### PR TITLE
Replace gossip infostore callback functions with a nonblocking channel-based interface

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -205,7 +205,7 @@ func (c *client) gossip(g *Gossip, stopper *stop.Stopper) error {
 	c.getGossip(g, addr, lAddr, done)
 
 	// Defer calling "undoer" callback returned from registration.
-	gossipC, unregister := g.is.registerUpdateChannel(".*")
+	gossipC, unregister := g.RegisterUpdateChannel(".*")
 	defer unregister()
 
 	// Loop until stopper is signalled, or until either the gossip or

--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -49,7 +49,7 @@ func startGossip(t *testing.T) (local, remote *Gossip, stopper *stop.Stopper) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	local = New(lRPCContext, TestBootstrap)
+	local = New(lRPCContext, TestBootstrap, stopper)
 	local.SetNodeID(1)
 	if err := local.SetNodeDescriptor(&roachpb.NodeDescriptor{
 		NodeID:  1,
@@ -71,7 +71,7 @@ func startGossip(t *testing.T) (local, remote *Gossip, stopper *stop.Stopper) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	remote = New(rRPCContext, TestBootstrap)
+	remote = New(rRPCContext, TestBootstrap, stopper)
 	remote.SetNodeID(2)
 	if err := remote.SetNodeDescriptor(&roachpb.NodeDescriptor{
 		NodeID:  2,
@@ -79,8 +79,8 @@ func startGossip(t *testing.T) (local, remote *Gossip, stopper *stop.Stopper) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	local.start(lserver, lln.Addr(), stopper)
-	remote.start(rserver, rln.Addr(), stopper)
+	local.start(lserver, lln.Addr())
+	remote.start(rserver, rln.Addr())
 	time.Sleep(time.Millisecond)
 	return
 }
@@ -132,8 +132,8 @@ func startFakeServerGossip(t *testing.T) (local *Gossip, remote *fakeGossipServe
 	if err != nil {
 		t.Fatal(err)
 	}
-	local = New(lRPCContext, TestBootstrap)
-	local.start(lserver, lln.Addr(), stopper)
+	local = New(lRPCContext, TestBootstrap, stopper)
+	local.start(lserver, lln.Addr())
 
 	rclock := hlc.NewClock(hlc.UnixNano)
 	rRPCContext := rpc.NewContext(&base.Context{Insecure: true}, rclock, stopper)

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -159,7 +159,7 @@ func New(rpcContext *rpc.Context, resolvers []resolver.Resolver, stopper *stop.S
 	}
 
 	// Add ourselves as a SystemConfig watcher.
-	updateC, _ := g.RegisterUpdateChannel(KeySystemConfig)
+	updateC, unregister := g.RegisterUpdateChannel(KeySystemConfig)
 	g.stopper.RunWorker(func() {
 		for {
 			select {
@@ -167,6 +167,7 @@ func New(rpcContext *rpc.Context, resolvers []resolver.Resolver, stopper *stop.S
 				g.updateSystemConfig(n)
 				updateC <- n
 			case <-g.stopper.ShouldStop():
+				unregister()
 				return
 			}
 		}

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -359,7 +359,7 @@ type Notification struct {
 // A function to unregister the notification channel is also returned.
 func (g *Gossip) RegisterUpdateChannel(pattern string) (chan Notification, func()) {
 	if pattern == KeySystemConfig {
-		log.Warningf("raw gossip callback registered on %s, consider using RegisterSystemConfigCallback",
+		log.Warningf("raw gossip callback registered on %s, consider using RegisterSystemConfigChannel",
 			KeySystemConfig)
 	}
 
@@ -380,8 +380,6 @@ func (g *Gossip) GetSystemConfig() *config.SystemConfig {
 	defer g.systemConfigMu.RUnlock()
 	return g.systemConfig
 }
-
-type systemConfigCallback func(*config.SystemConfig)
 
 // RegisterSystemConfigChannel registers a channel to signify updates for the
 // system config. It is notified after registration, and whenever a new

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -117,6 +117,7 @@ type Gossip struct {
 	clients       []*client           // Slice of clients
 	disconnected  chan *client        // Channel of disconnected clients
 	stalled       chan struct{}       // Channel to wakeup stalled bootstrap
+	stopper       *stop.Stopper       // Stopper to stop gossip notifications
 
 	// The system config is treated unlike other info objects.
 	// It is used so often that we keep an unmarshalled version of it
@@ -135,10 +136,10 @@ type Gossip struct {
 }
 
 // New creates an instance of a gossip node.
-func New(rpcContext *rpc.Context, resolvers []resolver.Resolver) *Gossip {
+func New(rpcContext *rpc.Context, resolvers []resolver.Resolver, stopper *stop.Stopper) *Gossip {
 	g := &Gossip{
 		Connected:     make(chan struct{}),
-		server:        newServer(),
+		server:        newServer(stopper),
 		outgoing:      makeNodeSet(1),
 		bootstrapping: map[string]struct{}{},
 		clients:       []*client{},
@@ -146,6 +147,7 @@ func New(rpcContext *rpc.Context, resolvers []resolver.Resolver) *Gossip {
 		stalled:       make(chan struct{}, 1),
 		resolverIdx:   len(resolvers) - 1,
 		resolvers:     resolvers,
+		stopper:       stopper,
 	}
 	// The gossip RPC context doesn't measure clock offsets, isn't
 	// shared with the other RPC clients which the node may be using,
@@ -159,7 +161,19 @@ func New(rpcContext *rpc.Context, resolvers []resolver.Resolver) *Gossip {
 	}
 
 	// Add ourselves as a SystemConfig watcher.
-	g.is.registerCallback(KeySystemConfig, g.updateSystemConfig)
+	updateC, _ := g.is.registerUpdateChannel(KeySystemConfig)
+	stopper.RunWorker(func() {
+		for {
+			select {
+			case n := <-updateC:
+				g.updateSystemConfig(n)
+				updateC <- n
+			case <-stopper.ShouldStop():
+				return
+			}
+		}
+	})
+
 	return g
 }
 
@@ -332,24 +346,29 @@ func (g *Gossip) GetInfosAsJSON() ([]byte, error) {
 	return json.MarshalIndent(g.is, "", "  ")
 }
 
-// Callback is a callback method to be invoked on gossip update
-// of info denoted by key.
-type Callback func(string, roachpb.Value)
+// Notification contains gossip update information for the specified
+// key.
+type Notification struct {
+	Key     string
+	Content roachpb.Value
+}
 
-// RegisterCallback registers a callback for a key pattern to be
-// invoked whenever new info for a gossip key matching pattern is
-// received. The callback method is invoked with the info key which
-// matched pattern. Returns a function to unregister the callback.
-func (g *Gossip) RegisterCallback(pattern string, method Callback) func() {
+// RegisterUpdateChannel registers a key pattern and returns a channel
+// that will be sent a gossip notification whenever new info for a
+// gossip key matching the pattern is received. The notification contains
+// the info key which matched the pattern along with the updated content,
+// and should be returned on the channel when its use is complete.
+// A function to unregister the notification channel is also returned.
+func (g *Gossip) RegisterUpdateChannel(pattern string) (chan Notification, func()) {
 	if pattern == KeySystemConfig {
-		log.Warning("raw gossip callback registered on %s, consider using RegisterSystemConfigCallback",
+		log.Warningf("raw gossip callback registered on %s, consider using RegisterSystemConfigCallback",
 			KeySystemConfig)
 	}
 
 	g.mu.Lock()
-	unregister := g.is.registerCallback(pattern, method)
+	c, unregister := g.is.registerUpdateChannel(pattern)
 	g.mu.Unlock()
-	return func() {
+	return c, func() {
 		g.mu.Lock()
 		unregister()
 		g.mu.Unlock()
@@ -386,17 +405,16 @@ func (g *Gossip) RegisterSystemConfigChannel() <-chan struct{} {
 	return c
 }
 
-// updateSystemConfig is the raw gossip info callback.
-// Unmarshal the system config, and if successfully, update out
-// copy and run the callbacks.
-func (g *Gossip) updateSystemConfig(key string, content roachpb.Value) {
-	if key != KeySystemConfig {
-		log.Fatalf("wrong key received on SystemConfig callback: %s", key)
+// updateSystemConfig unmarshals the system config from a gossip notification,
+// and if successful, updates our copy and notifies listeners.
+func (g *Gossip) updateSystemConfig(n Notification) {
+	if n.Key != KeySystemConfig {
+		log.Fatalf("wrong key received on SystemConfig channel: %s", n.Key)
 		return
 	}
 	cfg := &config.SystemConfig{}
-	if err := content.GetProto(cfg); err != nil {
-		log.Errorf("could not unmarshal system config on callback: %s", err)
+	if err := n.Content.GetProto(cfg); err != nil {
+		log.Errorf("could not unmarshal system config from channel: %s", err)
 		return
 	}
 
@@ -440,11 +458,11 @@ func (g *Gossip) Outgoing() []roachpb.NodeID {
 //
 // This method starts bootstrap loop, gossip server, and client
 // management in separate goroutines and returns.
-func (g *Gossip) Start(rpcServer *rpc.Server, addr net.Addr, stopper *stop.Stopper) {
-	g.server.start(rpcServer, addr, stopper) // serve gossip protocol
-	g.bootstrap(stopper)                     // bootstrap gossip client
-	g.manage(stopper)                        // manage gossip clients
-	g.maybeWarnAboutInit(stopper)
+func (g *Gossip) Start(rpcServer *rpc.Server, addr net.Addr) {
+	g.server.start(rpcServer, addr) // serve gossip protocol
+	g.bootstrap(g.stopper)          // bootstrap gossip client
+	g.manage(g.stopper)             // manage gossip clients
+	g.maybeWarnAboutInit(g.stopper)
 }
 
 // hasIncoming returns whether the server has an incoming gossip

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -230,8 +230,9 @@ func (s *server) start(rpcServer *rpc.Server, addr net.Addr) {
 	rpcServer.AddOpenCallback(s.onOpen)
 	rpcServer.AddCloseCallback(s.onClose)
 
-	// Defer calling "undoer" callback returned from registration.
+	s.mu.Lock()
 	gossipC, unregister := s.is.registerUpdateChannel(".*")
+	s.mu.Unlock()
 	s.stopper.RunWorker(func() {
 		for {
 			select {

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -52,17 +52,19 @@ type server struct {
 	sent     int                       // Count of infos sent from this server to clients
 	received int                       // Count of infos received from clients
 	ready    *sync.Cond                // Broadcasts wakeup to waiting gossip requests
+	stopper  *stop.Stopper             // Stopper to stop gossip notifications
 
 	simulationCycler *sync.Cond // Used when simulating the network to signal next cycle
 }
 
 // newServer creates and returns a server struct.
-func newServer() *server {
+func newServer(stopper *stop.Stopper) *server {
 	s := &server{
-		is:       newInfoStore(0, util.UnresolvedAddr{}),
+		is:       newInfoStore(0, util.UnresolvedAddr{}, stopper),
 		incoming: makeNodeSet(1),
 		lAddrMap: map[string]clientInfo{},
 		nodeMap:  map[roachpb.NodeID]string{},
+		stopper:  stopper,
 	}
 	s.ready = sync.NewCond(&s.mu)
 	return s
@@ -220,7 +222,7 @@ func (s *server) maxPeers() int {
 // then begins processing connecting clients in an infinite select
 // loop via goroutine. Periodically, clients connected and awaiting
 // the next round of gossip are awoken via the conditional variable.
-func (s *server) start(rpcServer *rpc.Server, addr net.Addr, stopper *stop.Stopper) {
+func (s *server) start(rpcServer *rpc.Server, addr net.Addr) {
 	s.is.NodeAddr = util.MakeUnresolvedAddr(addr.Network(), addr.String())
 	if err := rpcServer.Register("Gossip.Gossip", s.Gossip, &Request{}); err != nil {
 		log.Fatalf("unable to register gossip service with RPC server: %s", err)
@@ -228,17 +230,19 @@ func (s *server) start(rpcServer *rpc.Server, addr net.Addr, stopper *stop.Stopp
 	rpcServer.AddOpenCallback(s.onOpen)
 	rpcServer.AddCloseCallback(s.onClose)
 
-	updateCallback := func(_ string, _ roachpb.Value) {
-		// Wakeup all pending clients.
-		s.ready.Broadcast()
-	}
-	unregister := s.is.registerCallback(".*", updateCallback)
-
-	stopper.RunWorker(func() {
-		select {
-		case <-stopper.ShouldStop():
-			s.stop(unregister)
-			return
+	// Defer calling "undoer" callback returned from registration.
+	gossipC, unregister := s.is.registerUpdateChannel(".*")
+	s.stopper.RunWorker(func() {
+		for {
+			select {
+			case n := <-gossipC:
+				// Wakeup all pending clients.
+				s.ready.Broadcast()
+				gossipC <- n
+			case <-s.stopper.ShouldStop():
+				s.stop(unregister)
+				return
+			}
 		}
 	})
 }

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -80,7 +80,7 @@ func NewNetwork(nodeCount int, networkType string) *Network {
 		// Build new resolvers for each instance or we'll get data races.
 		resolvers := []resolver.Resolver{resolver.NewResolverFromAddress(nodes[0].Addr)}
 
-		gossipNode := gossip.New(rpcContext, resolvers)
+		gossipNode := gossip.New(rpcContext, resolvers, stopper)
 		addr := leftNode.Addr
 		gossipNode.SetNodeID(roachpb.NodeID(i + 1))
 		if err := gossipNode.SetNodeDescriptor(&roachpb.NodeDescriptor{
@@ -92,7 +92,7 @@ func NewNetwork(nodeCount int, networkType string) *Network {
 		if err := gossipNode.AddInfo(addr.String(), encoding.EncodeUint64(nil, 0), time.Hour); err != nil {
 			log.Fatal(err)
 		}
-		gossipNode.Start(leftNode.Server, addr, stopper)
+		gossipNode.Start(leftNode.Server, addr)
 		gossipNode.EnableSimulationCycler(true)
 
 		leftNode.Gossip = gossipNode

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -75,7 +75,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano)
 	ltc.Stopper = stop.NewStopper()
 	rpcContext := rpc.NewContext(testutils.NewNodeTestBaseContext(), ltc.Clock, ltc.Stopper)
-	ltc.Gossip = gossip.New(rpcContext, gossip.TestBootstrap)
+	ltc.Gossip = gossip.New(rpcContext, gossip.TestBootstrap, ltc.Stopper)
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20, ltc.Stopper)
 
 	ltc.stores = storage.NewStores()

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -64,14 +64,14 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	if err != nil {
 		t.Fatal(err)
 	}
-	g := gossip.New(nodeRPCContext, testContext.GossipBootstrapResolvers)
+	g := gossip.New(nodeRPCContext, testContext.GossipBootstrapResolvers, stopper)
 	if gossipBS != nil {
 		// Handle possibility of a :0 port specification.
 		if gossipBS == addr {
 			gossipBS = ln.Addr()
 		}
 		g.SetResolvers([]resolver.Resolver{resolver.NewResolverFromAddress(gossipBS)})
-		g.Start(rpcServer, ln.Addr(), stopper)
+		g.Start(rpcServer, ln.Addr())
 	}
 	ctx.Gossip = g
 	sender := kv.NewDistSender(&kv.DistSenderContext{Clock: ctx.Clock, RPCContext: nodeRPCContext}, g)

--- a/server/raft_transport_test.go
+++ b/server/raft_transport_test.go
@@ -61,7 +61,7 @@ func TestSendAndReceive(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	nodeRPCContext := rpc.NewContext(nodeTestBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
-	g := gossip.New(nodeRPCContext, gossip.TestBootstrap)
+	g := gossip.New(nodeRPCContext, gossip.TestBootstrap, stopper)
 	g.SetNodeID(roachpb.NodeID(1))
 
 	// Create several servers, each of which has two stores (A multiraft
@@ -236,7 +236,7 @@ func TestInOrderDelivery(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	nodeRPCContext := rpc.NewContext(nodeTestBaseContext, hlc.NewClock(hlc.UnixNano), stopper)
-	g := gossip.New(nodeRPCContext, gossip.TestBootstrap)
+	g := gossip.New(nodeRPCContext, gossip.TestBootstrap, stopper)
 	g.SetNodeID(roachpb.NodeID(1))
 
 	server := rpc.NewServer(nodeRPCContext)

--- a/server/server.go
+++ b/server/server.go
@@ -120,7 +120,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 
 	s.rpc = crpc.NewServer(s.rpcContext)
 
-	s.gossip = gossip.New(s.rpcContext, s.ctx.GossipBootstrapResolvers)
+	s.gossip = gossip.New(s.rpcContext, s.ctx.GossipBootstrapResolvers, stopper)
 	s.storePool = storage.NewStorePool(s.gossip, s.clock, ctx.TimeUntilStoreDead, stopper)
 
 	feed := util.NewFeed(stopper)
@@ -208,7 +208,7 @@ func (s *Server) Start(selfBootstrap bool) error {
 		}
 		s.gossip.SetResolvers([]resolver.Resolver{selfResolver})
 	}
-	s.gossip.Start(s.rpc, addr, s.stopper)
+	s.gossip.Start(s.rpc, addr)
 
 	if err := s.node.start(s.rpc, addr, s.ctx.Engines, s.ctx.NodeAttributes, s.stopper); err != nil {
 		return err

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -85,11 +85,11 @@ func newExecutor(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, st
 	}
 	exec.systemConfigCond = sync.NewCond(&exec.systemConfigMu)
 
-	gossipUpdateC := gossip.RegisterSystemConfigChannel()
+	configUpdateC := gossip.RegisterSystemConfigChannel()
 	stopper.RunWorker(func() {
 		for {
 			select {
-			case <-gossipUpdateC:
+			case <-configUpdateC:
 				cfg := gossip.GetSystemConfig()
 				exec.updateSystemConfig(cfg)
 			case <-stopper.ShouldStop():

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -612,10 +612,10 @@ func (m *LeaseManager) getSystemConfig() config.SystemConfig {
 func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gossip.Gossip) {
 	s.RunWorker(func() {
 		descKeyPrefix := keys.MakeTablePrefix(uint32(DescriptorTable.ID))
-		gossipUpdateC := gossip.RegisterSystemConfigChannel()
+		configUpdateC := gossip.RegisterSystemConfigChannel()
 		for {
 			select {
-			case <-gossipUpdateC:
+			case <-configUpdateC:
 				cfg := *gossip.GetSystemConfig()
 				m.updateSystemConfig(cfg)
 

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -115,15 +115,25 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 	}
 
 	successChan := make(chan struct{}, 1)
-	store.Gossip().RegisterCallback(gossip.KeySystemConfig, func(_ string, content roachpb.Value) {
-		contentBytes, err := content.GetBytes()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if bytes.Contains(contentBytes, descBytes) {
+	gossipC, unregister := store.Gossip().RegisterUpdateChannel(gossip.KeySystemConfig)
+	stopper.RunWorker(func() {
+		for {
 			select {
-			case successChan <- struct{}{}:
-			default:
+			case n := <-gossipC:
+				contentBytes, err := n.Content.GetBytes()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if bytes.Contains(contentBytes, descBytes) {
+					select {
+					case successChan <- struct{}{}:
+					default:
+					}
+				}
+				gossipC <- n
+			case <-stopper.ShouldStop():
+				unregister()
+				return
 			}
 		}
 	})

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -90,7 +90,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 		sCtx = &ctx
 	}
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
-	sCtx.Gossip = gossip.New(rpcContext, gossip.TestBootstrap)
+	sCtx.Gossip = gossip.New(rpcContext, gossip.TestBootstrap, stopper)
 	sCtx.Gossip.SetNodeID(nodeDesc.NodeID)
 	localSender := storage.NewStores()
 	rpcSend := func(_ rpc.Options, _ string, _ []net.Addr,
@@ -198,16 +198,16 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	if m.clock == nil {
 		m.clock = hlc.NewClock(m.manualClock.UnixNano)
 	}
-	if m.gossip == nil {
-		rpcContext := rpc.NewContext(&base.Context{}, m.clock, nil)
-		m.gossip = gossip.New(rpcContext, gossip.TestBootstrap)
-		m.gossip.SetNodeID(math.MaxInt32)
-	}
 	if m.scannerStopper == nil {
 		m.scannerStopper = stop.NewStopper()
 	}
 	if m.clientStopper == nil {
 		m.clientStopper = stop.NewStopper()
+	}
+	if m.gossip == nil {
+		rpcContext := rpc.NewContext(&base.Context{}, m.clock, nil)
+		m.gossip = gossip.New(rpcContext, gossip.TestBootstrap, m.clientStopper)
+		m.gossip.SetNodeID(math.MaxInt32)
 	}
 	if m.transport == nil {
 		m.transport = multiraft.NewLocalRPCTransport(m.clientStopper)

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -43,7 +43,7 @@ func gossipForTest(t *testing.T) (*gossip.Gossip, *stop.Stopper) {
 	config.TestingSetupZoneConfigHook(stopper)
 
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
-	g := gossip.New(rpcContext, gossip.TestBootstrap)
+	g := gossip.New(rpcContext, gossip.TestBootstrap, stopper)
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	// Put an empty system config into gossip.

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -109,7 +109,7 @@ func (tc *testContext) Start(t testing.TB) {
 	config.TestingSetupZoneConfigHook(tc.stopper)
 	if tc.gossip == nil {
 		rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), tc.stopper)
-		tc.gossip = gossip.New(rpcContext, gossip.TestBootstrap)
+		tc.gossip = gossip.New(rpcContext, gossip.TestBootstrap, tc.stopper)
 		tc.gossip.SetNodeID(1)
 	}
 	if tc.manualClock == nil {

--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -62,7 +62,7 @@ type Cluster struct {
 func createCluster(stopper *stop.Stopper, nodeCount int, epochWriter, actionWriter io.Writer, script Script, rand *rand.Rand) *Cluster {
 	clock := hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(&base.Context{}, clock, stopper)
-	g := gossip.New(rpcContext, gossip.TestBootstrap)
+	g := gossip.New(rpcContext, gossip.TestBootstrap, stopper)
 	storePool := storage.NewStorePool(g, clock, storage.TestTimeUntilStoreDeadOff, stopper)
 	c := &Cluster{
 		stopper:   stopper,
@@ -74,7 +74,7 @@ func createCluster(stopper *stop.Stopper, nodeCount int, epochWriter, actionWrit
 			AllowRebalance: true,
 			Deterministic:  true,
 		}),
-		storeGossiper:   gossiputil.NewStoreGossiper(g),
+		storeGossiper:   gossiputil.NewStoreGossiper(g, stopper),
 		nodes:           make(map[roachpb.NodeID]*Node),
 		stores:          make(map[roachpb.StoreID]*Store),
 		ranges:          make(map[roachpb.RangeID]*Range),

--- a/storage/store.go
+++ b/storage/store.go
@@ -518,11 +518,11 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 		// Register update channel for any changes to the system config.
 		// This may trigger splits along structured boundaries,
 		// and update max range bytes.
-		gossipUpdateC := s.ctx.Gossip.RegisterSystemConfigChannel()
+		configUpdateC := s.ctx.Gossip.RegisterSystemConfigChannel()
 		s.stopper.RunWorker(func() {
 			for {
 				select {
-				case <-gossipUpdateC:
+				case <-configUpdateC:
 					cfg := s.ctx.Gossip.GetSystemConfig()
 					s.systemGossipUpdate(cfg)
 				case <-s.stopper.ShouldStop():

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -131,7 +131,7 @@ func createTestStoreWithoutStart(t *testing.T) (*Store, *hlc.ManualClock, *stop.
 	config.TestingSetupZoneConfigHook(stopper)
 	rpcContext := rpc.NewContext(&base.Context{}, hlc.NewClock(hlc.UnixNano), stopper)
 	ctx := TestStoreContext
-	ctx.Gossip = gossip.New(rpcContext, gossip.TestBootstrap)
+	ctx.Gossip = gossip.New(rpcContext, gossip.TestBootstrap, stopper)
 	ctx.Gossip.SetNodeID(1)
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)


### PR DESCRIPTION
See #2978.

This ended up being a little more tricky than expected because the implementation had to fit all of the following constraints to work as expected and pass all existing unit tests:
1. The update channels **_cannot block**_ `gossip`/`infostore`. This immediately removed the opportunity for any direct synchronization with registered components.
2. Notifications must be guaranteed to be propagated to a given registered channel **_in order**_. This is currently **_not**_ enforced. However, when enforced, it removes the option to toss code in a goroutine as a quick asynchronous fix for constraint 1.
3. Update channels will be sent notifications for the **_same gossip update**_ in **_order of channel registration**_ time (currently enforced, but I believe coincidentally). This is needed for certain unit tests, where an update channel will be registered to determine when a previously registered component (ie. `StorePool`) had already received the same notification.
4. Update channels will respond when their processing of gossip notifications is complete synchronously, and only then will the next update be sent out. This is needed to avoid a number of race conditions, where a notification could have been delivered over a channel, but not yet processed when expected.

The primary component responsible for fitting all four of these constraints is the `BufferedNotifier` in `infostore.go`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3522)

<!-- Reviewable:end -->
