### PR TITLE
sql: convert NULL to false

### DIFF
--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -88,6 +88,9 @@ func getBool(d Datum) (DBool, error) {
 	if v, ok := d.(DBool); ok {
 		return v, nil
 	}
+	if d == DNull {
+		return DBool(false), nil
+	}
 	return false, fmt.Errorf("cannot convert %s to bool", d.Type())
 }
 

--- a/sql/testdata/select
+++ b/sql/testdata/select
@@ -231,3 +231,8 @@ query I
 SELECT value FROM boolean_table
 ----
 NULL
+
+query I
+SELECT CASE WHEN NULL THEN 1 ELSE 2 END
+----
+2


### PR DESCRIPTION
Matches behavior of postgres, which returns 2 for:

select case when null then 1 else 2 end;

Where previously we would exit with:

query error: cannot convert NULL to bool

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3544)

<!-- Reviewable:end -->
