### PR TITLE
sql: rename params/bind vars/arguments to placeholders

### DIFF
--- a/sql/driver/conn.go
+++ b/sql/driver/conn.go
@@ -123,9 +123,9 @@ func (c *conn) internalQuery(stmt string, args []driver.Value) (*Response_Result
 // send sends the statement to the server.
 func (c *conn) send(stmt string, dArgs []Datum) (*Response_Result, error) {
 	args := Request{
-		Session: c.session,
-		Sql:     stmt,
-		Params:  dArgs,
+		Session:      c.session,
+		Sql:          stmt,
+		Placeholders: dArgs,
 	}
 	// Forget the session state, and use the one provided in the server
 	// response for the next request.

--- a/sql/driver/wire.pb.go
+++ b/sql/driver/wire.pb.go
@@ -296,8 +296,8 @@ type Request struct {
 	// SQL statement(s) to be serially executed by the server. Multiple
 	// statements are passed as a single string separated by semicolons.
 	Sql string `protobuf:"bytes,3,opt,name=sql" json:"sql"`
-	// Parameters referred to in the above SQL statement(s) using "?".
-	Params []Datum `protobuf:"bytes,4,rep,name=params" json:"params"`
+	// Placeholders referred to in the above SQL statement(s) using "?".
+	Placeholders []Datum `protobuf:"bytes,4,rep,name=placeholders" json:"placeholders"`
 }
 
 func (m *Request) Reset()         { *m = Request{} }
@@ -647,8 +647,8 @@ func (m *Request) MarshalTo(data []byte) (int, error) {
 	i++
 	i = encodeVarintWire(data, i, uint64(len(m.Sql)))
 	i += copy(data[i:], m.Sql)
-	if len(m.Params) > 0 {
-		for _, msg := range m.Params {
+	if len(m.Placeholders) > 0 {
+		for _, msg := range m.Placeholders {
 			data[i] = 0x22
 			i++
 			i = encodeVarintWire(data, i, uint64(msg.Size()))
@@ -994,8 +994,8 @@ func (m *Request) Size() (n int) {
 	}
 	l = len(m.Sql)
 	n += 1 + l + sovWire(uint64(l))
-	if len(m.Params) > 0 {
-		for _, e := range m.Params {
+	if len(m.Placeholders) > 0 {
+		for _, e := range m.Placeholders {
 			l = e.Size()
 			n += 1 + l + sovWire(uint64(l))
 		}
@@ -1560,7 +1560,7 @@ func (m *Request) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Params", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Placeholders", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1584,8 +1584,8 @@ func (m *Request) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Params = append(m.Params, Datum{})
-			if err := m.Params[len(m.Params)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+			m.Placeholders = append(m.Placeholders, Datum{})
+			if err := m.Placeholders[len(m.Placeholders)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/sql/driver/wire.proto
+++ b/sql/driver/wire.proto
@@ -60,8 +60,8 @@ message Request {
   // SQL statement(s) to be serially executed by the server. Multiple
   // statements are passed as a single string separated by semicolons.
   optional string sql = 3 [(gogoproto.nullable) = false];
-  // Parameters referred to in the above SQL statement(s) using "?".
-  repeated Datum params = 4 [(gogoproto.nullable) = false];
+  // Placeholders referred to in the above SQL statement(s) using "?".
+  repeated Datum placeholders = 4 [(gogoproto.nullable) = false];
 }
 
 message Response {

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -126,7 +126,7 @@ func (e *Executor) getSystemConfig() config.SystemConfig {
 }
 
 // StatementResult returns the result types of the given statement(s).
-func (e *Executor) StatementResult(user string, stmt parser.Statement, args parser.MapArgs) ([]*driver.Response_Result_Rows_Column, error) {
+func (e *Executor) StatementResult(user string, stmt parser.Statement, args parser.Placeholders) ([]*driver.Response_Result_Rows_Column, error) {
 	planMaker := plannerPool.Get().(*planner)
 	defer plannerPool.Put(planMaker)
 
@@ -165,7 +165,7 @@ func (e *Executor) StatementResult(user string, stmt parser.Statement, args pars
 
 // ExecuteStatements executes the given statement(s) and returns a response.
 // On error, the returned integer is an HTTP error code.
-func (e *Executor) ExecuteStatements(user string, session Session, stmts string, params []driver.Datum) (driver.Response, int, error) {
+func (e *Executor) ExecuteStatements(user string, session Session, stmts string, placeholders []driver.Datum) (driver.Response, int, error) {
 	planMaker := plannerPool.Get().(*planner)
 	defer plannerPool.Put(planMaker)
 
@@ -195,7 +195,7 @@ func (e *Executor) ExecuteStatements(user string, session Session, stmts string,
 
 	// Send the Request for SQL execution and set the application-level error
 	// for each result in the reply.
-	planMaker.params = parameters(params)
+	planMaker.params = parameters(placeholders)
 	reply := e.execStmts(stmts, planMaker)
 
 	// Send back the session state even if there were application-level errors.
@@ -229,7 +229,7 @@ func (e *Executor) Execute(args driver.Request) (driver.Response, int, error) {
 	if err := proto.Unmarshal(args.Session, &session); err != nil {
 		return driver.Response{}, http.StatusBadRequest, err
 	}
-	return e.ExecuteStatements(args.GetUser(), session, args.Sql, args.Params)
+	return e.ExecuteStatements(args.GetUser(), session, args.Sql, args.Placeholders)
 }
 
 // exec executes the request. Any error encountered is returned; it is

--- a/sql/group.go
+++ b/sql/group.go
@@ -329,7 +329,7 @@ func (av *aggregateValue) Walk(v parser.Visitor) {
 	// But it seems `av.datum` is sometimes nil.
 }
 
-func (av *aggregateValue) TypeCheck(args parser.MapArgs) (parser.Datum, error) {
+func (av *aggregateValue) TypeCheck(args parser.Placeholders) (parser.Datum, error) {
 	return av.expr.TypeCheck(args)
 }
 

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -86,7 +86,7 @@ func (v variadicType) match(types argTypes) bool {
 
 type builtin struct {
 	types      typeList
-	returnType func(MapArgs, DTuple) (Datum, error)
+	returnType func(Placeholders, DTuple) (Datum, error)
 	// Set to true when a function potentially returns a different value
 	// when called in the same statement with the same parameters.
 	// e.g.: random(), clock_timestamp(). Some functions like now()
@@ -994,7 +994,7 @@ func floatBuiltin2(f func(float64, float64) (Datum, error)) builtin {
 	}
 }
 
-func stringBuiltin1(f func(string) (Datum, error), returnType func(MapArgs, DTuple) (Datum, error)) builtin {
+func stringBuiltin1(f func(string) (Datum, error), returnType func(Placeholders, DTuple) (Datum, error)) builtin {
 	return builtin{
 		types:      argTypes{stringType},
 		returnType: returnType,
@@ -1004,7 +1004,7 @@ func stringBuiltin1(f func(string) (Datum, error), returnType func(MapArgs, DTup
 	}
 }
 
-func stringBuiltin2(f func(string, string) (Datum, error), returnType func(MapArgs, DTuple) (Datum, error)) builtin {
+func stringBuiltin2(f func(string, string) (Datum, error), returnType func(Placeholders, DTuple) (Datum, error)) builtin {
 	return builtin{
 		types:      argTypes{stringType, stringType},
 		returnType: returnType,
@@ -1014,7 +1014,7 @@ func stringBuiltin2(f func(string, string) (Datum, error), returnType func(MapAr
 	}
 }
 
-func stringBuiltin3(f func(string, string, string) (Datum, error), returnType func(MapArgs, DTuple) (Datum, error)) builtin {
+func stringBuiltin3(f func(string, string, string) (Datum, error), returnType func(Placeholders, DTuple) (Datum, error)) builtin {
 	return builtin{
 		types:      argTypes{stringType, stringType, stringType},
 		returnType: returnType,
@@ -1024,7 +1024,7 @@ func stringBuiltin3(f func(string, string, string) (Datum, error), returnType fu
 	}
 }
 
-func stringBuiltin4(f func(string, string, string, string) (Datum, error), returnType func(MapArgs, DTuple) (Datum, error)) builtin {
+func stringBuiltin4(f func(string, string, string, string) (Datum, error), returnType func(Placeholders, DTuple) (Datum, error)) builtin {
 	return builtin{
 		types:      argTypes{stringType, stringType, stringType, stringType},
 		returnType: returnType,
@@ -1034,7 +1034,7 @@ func stringBuiltin4(f func(string, string, string, string) (Datum, error), retur
 	}
 }
 
-func bytesBuiltin1(f func(string) (Datum, error), returnType func(MapArgs, DTuple) (Datum, error)) builtin {
+func bytesBuiltin1(f func(string) (Datum, error), returnType func(Placeholders, DTuple) (Datum, error)) builtin {
 	return builtin{
 		types:      argTypes{bytesType},
 		returnType: returnType,
@@ -1260,15 +1260,15 @@ func round(x float64, n int64) (Datum, error) {
 
 // typeTuple returns the Datum type that all arguments share, or an error
 // if they do not share types.
-func typeTuple(params MapArgs, args DTuple) (Datum, error) {
+func typeTuple(params Placeholders, args DTuple) (Datum, error) {
 	datum := DNull
-	hasValArgs := false
+	hasPlaceholders := false
 	for _, arg := range args {
 		if arg == DNull {
 			continue
 		}
-		if _, ok := arg.(DValArg); ok {
-			hasValArgs = true
+		if _, ok := arg.(DPlaceholder); ok {
+			hasPlaceholders = true
 			continue
 		}
 		// Find the first non-null argument.
@@ -1280,7 +1280,7 @@ func typeTuple(params MapArgs, args DTuple) (Datum, error) {
 			return nil, fmt.Errorf("incompatible argument types %s, %s", datum.Type(), arg.Type())
 		}
 	}
-	if hasValArgs {
+	if hasPlaceholders {
 		for _, arg := range args {
 			_, err := params.setInferredType(arg, datum)
 			if err != nil {

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -616,41 +616,41 @@ func (d dNull) String() string {
 	return "NULL"
 }
 
-var _ VariableExpr = DValArg{}
+var _ VariableExpr = DPlaceholder{}
 
-// DValArg is the named bind var argument Datum.
-type DValArg struct {
+// DPlaceholder is the named placeholder Datum.
+type DPlaceholder struct {
 	name string
 }
 
 // Variable implements the VariableExpr interface.
-func (DValArg) Variable() {}
+func (DPlaceholder) Variable() {}
 
 // Type implements the Datum interface.
-func (DValArg) Type() string {
-	return "valarg"
+func (DPlaceholder) Type() string {
+	return "placeholder"
 }
 
 // Compare implements the Datum interface.
-func (d DValArg) Compare(other Datum) int {
+func (d DPlaceholder) Compare(other Datum) int {
 	panic(d.Type() + ".Compare not supported")
 }
 
 // Next implements the Datum interface.
-func (d DValArg) Next() Datum {
+func (d DPlaceholder) Next() Datum {
 	panic(d.Type() + ".Next not supported")
 }
 
 // IsMax implements the Datum interface.
-func (DValArg) IsMax() bool {
+func (DPlaceholder) IsMax() bool {
 	return true
 }
 
 // IsMin implements the Datum interface.
-func (DValArg) IsMin() bool {
+func (DPlaceholder) IsMin() bool {
 	return true
 }
 
-func (d DValArg) String() string {
+func (d DPlaceholder) String() string {
 	return "$" + d.name
 }

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -557,7 +557,7 @@ type EvalContext struct {
 	TxnTimestamp  DTimestamp
 	ReCache       *RegexpCache
 	GetLocation   func() (*time.Location, error)
-	Args          MapArgs
+	Args          Placeholders
 }
 
 var defaultContext = EvalContext{
@@ -1149,7 +1149,7 @@ func (t Tuple) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (t ValArg) Eval(_ EvalContext) (Datum, error) {
+func (t Placeholder) Eval(_ EvalContext) (Datum, error) {
 	return nil, util.Errorf("unhandled type %T", t)
 }
 
@@ -1204,7 +1204,7 @@ func (t DTuple) Eval(_ EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (t DValArg) Eval(_ EvalContext) (Datum, error) {
+func (t DPlaceholder) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -30,17 +30,16 @@ type Expr interface {
 	// implementation is empty.
 	Walk(Visitor)
 	// TypeCheck returns the zero value of the expression's type, or an
-	// error if the expression doesn't type-check. args maps bind var argument
-	// names to types.
-	TypeCheck(args MapArgs) (Datum, error)
+	// error if the expression doesn't type-check.
+	TypeCheck(Placeholders) (Datum, error)
 	// Eval evaluates an SQL expression. Expression evaluation is a mostly
 	// straightforward walk over the parse tree. The only significant complexity is
 	// the handling of types and implicit conversions. See binOps and cmpOps for
 	// more details. Note that expression evaluation returns an error if certain
-	// node types are encountered: ValArg, QualifiedName or Subquery. These nodes
-	// should be replaced prior to expression evaluation by an appropriate
-	// WalkExpr. For example, ValArg should be replace by the argument passed from
-	// the client.
+	// node types are encountered: Placeholder, QualifiedName or Subquery. These
+	// nodes should be replaced prior to expression evaluation by an appropriate
+	// WalkExpr. For example, Placeholder should be replaced by the argument
+	// passed from the client.
 	Eval(EvalContext) (Datum, error)
 }
 
@@ -254,17 +253,17 @@ func (node DefaultVal) String() string {
 	return "DEFAULT"
 }
 
-var _ VariableExpr = ValArg{}
+var _ VariableExpr = Placeholder{}
 
-// ValArg represents a named bind var argument.
-type ValArg struct {
+// Placeholder represents a named placeholder.
+type Placeholder struct {
 	name string
 }
 
 // Variable implements the VariableExpr interface.
-func (ValArg) Variable() {}
+func (Placeholder) Variable() {}
 
-func (node ValArg) String() string {
+func (node Placeholder) String() string {
 	return fmt.Sprintf("$%s", node.name)
 }
 

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -88,7 +88,7 @@ func (expr *ComparisonExpr) normalize(v *normalizeVisitor) Expr {
 		for {
 			if v.isConst(expr.Left) {
 				switch expr.Right.(type) {
-				case *BinaryExpr, VariableExpr, *QualifiedName, ValArg:
+				case *BinaryExpr, VariableExpr, *QualifiedName, Placeholder:
 					break
 				default:
 					return expr

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -4306,7 +4306,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:849
 		{
-			sqlVAL.expr = ValArg{name: sqlDollar[1].str}
+			sqlVAL.expr = Placeholder{name: sqlDollar[1].str}
 		}
 	case 110:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
@@ -6568,7 +6568,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:2719
 		{
-			sqlVAL.expr = ValArg{name: sqlDollar[1].str}
+			sqlVAL.expr = Placeholder{name: sqlDollar[1].str}
 		}
 	case 516:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -847,7 +847,7 @@ var_value:
 | numeric_only
 | PARAM
   {
-    $$ = ValArg{name: $1}
+    $$ = Placeholder{name: $1}
   }
 
 iso_level:
@@ -2717,7 +2717,7 @@ c_expr:
 | a_expr_const
 | PARAM
   {
-    $$ = ValArg{name: $1}
+    $$ = Placeholder{name: $1}
   }
 | '(' a_expr ')'
   {

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -25,22 +25,22 @@ import (
 )
 
 var (
-	typeBytes     = func(MapArgs, DTuple) (Datum, error) { return DummyBytes, nil }
-	typeDate      = func(MapArgs, DTuple) (Datum, error) { return DummyDate, nil }
-	typeFloat     = func(MapArgs, DTuple) (Datum, error) { return DummyFloat, nil }
-	typeInt       = func(MapArgs, DTuple) (Datum, error) { return DummyInt, nil }
-	typeInterval  = func(MapArgs, DTuple) (Datum, error) { return DummyInterval, nil }
-	typeString    = func(MapArgs, DTuple) (Datum, error) { return DummyString, nil }
-	typeTimestamp = func(MapArgs, DTuple) (Datum, error) { return DummyTimestamp, nil }
+	typeBytes     = func(Placeholders, DTuple) (Datum, error) { return DummyBytes, nil }
+	typeDate      = func(Placeholders, DTuple) (Datum, error) { return DummyDate, nil }
+	typeFloat     = func(Placeholders, DTuple) (Datum, error) { return DummyFloat, nil }
+	typeInt       = func(Placeholders, DTuple) (Datum, error) { return DummyInt, nil }
+	typeInterval  = func(Placeholders, DTuple) (Datum, error) { return DummyInterval, nil }
+	typeString    = func(Placeholders, DTuple) (Datum, error) { return DummyString, nil }
+	typeTimestamp = func(Placeholders, DTuple) (Datum, error) { return DummyTimestamp, nil }
 )
 
 // TypeCheck implements the Expr interface.
-func (expr *AndExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *AndExpr) TypeCheck(args Placeholders) (Datum, error) {
 	return typeCheckBooleanExprs(args, "AND", expr.Left, expr.Right)
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *BinaryExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *BinaryExpr) TypeCheck(args Placeholders) (Datum, error) {
 	dummyLeft, err := expr.Left.TypeCheck(args)
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ func (expr *BinaryExpr) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *CaseExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *CaseExpr) TypeCheck(args Placeholders) (Datum, error) {
 	var dummyCond, dummyVal Datum
 
 	if expr.Expr != nil {
@@ -114,7 +114,7 @@ func (expr *CaseExpr) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *CastExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *CastExpr) TypeCheck(args Placeholders) (Datum, error) {
 	dummyExpr, err := expr.Expr.TypeCheck(args)
 	if err != nil {
 		return nil, err
@@ -183,7 +183,7 @@ func (expr *CastExpr) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *CoalesceExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *CoalesceExpr) TypeCheck(args Placeholders) (Datum, error) {
 	var dummyArg Datum
 	for _, e := range expr.Exprs {
 		arg, err := e.TypeCheck(args)
@@ -200,7 +200,7 @@ func (expr *CoalesceExpr) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *ComparisonExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *ComparisonExpr) TypeCheck(args Placeholders) (Datum, error) {
 	leftType, err := expr.Left.TypeCheck(args)
 	if err != nil {
 		return nil, err
@@ -215,7 +215,7 @@ func (expr *ComparisonExpr) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *ExistsExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *ExistsExpr) TypeCheck(args Placeholders) (Datum, error) {
 	_, err := expr.Subquery.TypeCheck(args)
 	if err != nil {
 		return nil, err
@@ -224,7 +224,7 @@ func (expr *ExistsExpr) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *FuncExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *FuncExpr) TypeCheck(args Placeholders) (Datum, error) {
 	dummyArgs := make(DTuple, 0, len(expr.Exprs))
 	types := make(argTypes, 0, len(expr.Exprs))
 	for _, e := range expr.Exprs {
@@ -295,7 +295,7 @@ func (expr *FuncExpr) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *IfExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *IfExpr) TypeCheck(args Placeholders) (Datum, error) {
 	cond, err := expr.Cond.TypeCheck(args)
 	if err != nil {
 		return nil, err
@@ -324,7 +324,7 @@ func (expr *IfExpr) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *IsOfTypeExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *IsOfTypeExpr) TypeCheck(args Placeholders) (Datum, error) {
 	if _, err := expr.Expr.TypeCheck(args); err != nil {
 		return nil, err
 	}
@@ -332,12 +332,12 @@ func (expr *IsOfTypeExpr) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *NotExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *NotExpr) TypeCheck(args Placeholders) (Datum, error) {
 	return typeCheckBooleanExprs(args, "NOT", expr.Expr)
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *NullIfExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *NullIfExpr) TypeCheck(args Placeholders) (Datum, error) {
 	expr1, err := expr.Expr1.TypeCheck(args)
 	if err != nil {
 		return nil, err
@@ -356,17 +356,17 @@ func (expr *NullIfExpr) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *OrExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *OrExpr) TypeCheck(args Placeholders) (Datum, error) {
 	return typeCheckBooleanExprs(args, "OR", expr.Left, expr.Right)
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *QualifiedName) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *QualifiedName) TypeCheck(args Placeholders) (Datum, error) {
 	return nil, fmt.Errorf("qualified name \"%s\" not found", expr)
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *RangeCond) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *RangeCond) TypeCheck(args Placeholders) (Datum, error) {
 	leftType, err := expr.Left.TypeCheck(args)
 	if err != nil {
 		return nil, err
@@ -391,14 +391,14 @@ func (expr *RangeCond) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *Subquery) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *Subquery) TypeCheck(args Placeholders) (Datum, error) {
 	// Avoid type checking subqueries. We need the subquery to be expanded in
 	// order to do so properly.
 	return DNull, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *UnaryExpr) TypeCheck(args MapArgs) (Datum, error) {
+func (expr *UnaryExpr) TypeCheck(args Placeholders) (Datum, error) {
 	dummyExpr, err := expr.Expr.TypeCheck(args)
 	if err != nil {
 		return nil, err
@@ -416,32 +416,32 @@ func (expr *UnaryExpr) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr Array) TypeCheck(args MapArgs) (Datum, error) {
+func (expr Array) TypeCheck(args Placeholders) (Datum, error) {
 	return nil, util.Errorf("unhandled type %T", expr)
 }
 
 // TypeCheck implements the Expr interface.
-func (expr DefaultVal) TypeCheck(args MapArgs) (Datum, error) {
+func (expr DefaultVal) TypeCheck(args Placeholders) (Datum, error) {
 	return nil, util.Errorf("unhandled type %T", expr)
 }
 
 // TypeCheck implements the Expr interface.
-func (expr IntVal) TypeCheck(args MapArgs) (Datum, error) {
+func (expr IntVal) TypeCheck(args Placeholders) (Datum, error) {
 	return DummyInt, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr NumVal) TypeCheck(args MapArgs) (Datum, error) {
+func (expr NumVal) TypeCheck(args Placeholders) (Datum, error) {
 	return DummyFloat, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr Row) TypeCheck(args MapArgs) (Datum, error) {
+func (expr Row) TypeCheck(args Placeholders) (Datum, error) {
 	return Tuple(expr).TypeCheck(args)
 }
 
 // TypeCheck implements the Expr interface.
-func (expr Tuple) TypeCheck(args MapArgs) (Datum, error) {
+func (expr Tuple) TypeCheck(args Placeholders) (Datum, error) {
 	tuple := make(DTuple, 0, len(expr))
 	for _, v := range expr {
 		d, err := v.TypeCheck(args)
@@ -454,65 +454,65 @@ func (expr Tuple) TypeCheck(args MapArgs) (Datum, error) {
 }
 
 // TypeCheck implements the Expr interface.
-func (expr ValArg) TypeCheck(args MapArgs) (Datum, error) {
+func (expr Placeholder) TypeCheck(args Placeholders) (Datum, error) {
 	if v, ok := args[expr.name]; ok {
 		return v, nil
 	}
-	return DValArg{name: expr.name}, nil
+	return DPlaceholder{name: expr.name}, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr DValArg) TypeCheck(args MapArgs) (Datum, error) {
+func (expr DPlaceholder) TypeCheck(args Placeholders) (Datum, error) {
 	return nil, util.Errorf("unhandled type %T", expr)
 }
 
 // TypeCheck implements the Expr interface.
-func (expr DBool) TypeCheck(args MapArgs) (Datum, error) {
+func (expr DBool) TypeCheck(args Placeholders) (Datum, error) {
 	return DummyBool, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr DBytes) TypeCheck(args MapArgs) (Datum, error) {
+func (expr DBytes) TypeCheck(args Placeholders) (Datum, error) {
 	return DummyBytes, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr DDate) TypeCheck(args MapArgs) (Datum, error) {
+func (expr DDate) TypeCheck(args Placeholders) (Datum, error) {
 	return DummyDate, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr DFloat) TypeCheck(args MapArgs) (Datum, error) {
+func (expr DFloat) TypeCheck(args Placeholders) (Datum, error) {
 	return DummyFloat, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr DInt) TypeCheck(args MapArgs) (Datum, error) {
+func (expr DInt) TypeCheck(args Placeholders) (Datum, error) {
 	return DummyInt, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr DInterval) TypeCheck(args MapArgs) (Datum, error) {
+func (expr DInterval) TypeCheck(args Placeholders) (Datum, error) {
 	return DummyInterval, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr dNull) TypeCheck(args MapArgs) (Datum, error) {
+func (expr dNull) TypeCheck(args Placeholders) (Datum, error) {
 	return DNull, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr DString) TypeCheck(args MapArgs) (Datum, error) {
+func (expr DString) TypeCheck(args Placeholders) (Datum, error) {
 	return DummyString, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr DTimestamp) TypeCheck(args MapArgs) (Datum, error) {
+func (expr DTimestamp) TypeCheck(args Placeholders) (Datum, error) {
 	return DummyTimestamp, nil
 }
 
 // TypeCheck implements the Expr interface.
-func (expr DTuple) TypeCheck(args MapArgs) (Datum, error) {
+func (expr DTuple) TypeCheck(args Placeholders) (Datum, error) {
 	tuple := make(DTuple, 0, len(expr))
 	for _, v := range expr {
 		d, err := v.TypeCheck(args)
@@ -524,7 +524,7 @@ func (expr DTuple) TypeCheck(args MapArgs) (Datum, error) {
 	return tuple, nil
 }
 
-func typeCheckBooleanExprs(args MapArgs, op string, exprs ...Expr) (Datum, error) {
+func typeCheckBooleanExprs(args Placeholders, op string, exprs ...Expr) (Datum, error) {
 	for _, expr := range exprs {
 		dummyExpr, err := expr.TypeCheck(args)
 		if err != nil {
@@ -545,7 +545,7 @@ func typeCheckBooleanExprs(args MapArgs, op string, exprs ...Expr) (Datum, error
 	return DummyBool, nil
 }
 
-func typeCheckComparisonOp(args MapArgs, op ComparisonOp, dummyLeft, dummyRight Datum) (Datum, cmpOp, error) {
+func typeCheckComparisonOp(args Placeholders, op ComparisonOp, dummyLeft, dummyRight Datum) (Datum, cmpOp, error) {
 	if set, err := args.setInferredType(dummyLeft, dummyRight); err != nil {
 		return nil, cmpOp{}, err
 	} else if set != nil {
@@ -589,7 +589,7 @@ func typeCheckComparisonOp(args MapArgs, op ComparisonOp, dummyLeft, dummyRight 
 		dummyLeft.Type(), op, dummyRight.Type())
 }
 
-func typeCheckTupleEQ(args MapArgs, lDummy, rDummy Datum) error {
+func typeCheckTupleEQ(args Placeholders, lDummy, rDummy Datum) error {
 	lTuple := lDummy.(DTuple)
 	rTuple := rDummy.(DTuple)
 	if len(lTuple) != len(rTuple) {
@@ -605,7 +605,7 @@ func typeCheckTupleEQ(args MapArgs, lDummy, rDummy Datum) error {
 	return nil
 }
 
-func typeCheckTupleIN(args MapArgs, arg, values Datum) error {
+func typeCheckTupleIN(args Placeholders, arg, values Datum) error {
 	if arg == DNull {
 		return nil
 	}

--- a/sql/parser/walk_test.go
+++ b/sql/parser/walk_test.go
@@ -27,53 +27,53 @@ func TestFillArgs(t *testing.T) {
 	testData := []struct {
 		expr     string
 		expected string
-		args     MapArgs
+		args     Placeholders
 	}{
-		{`$1`, `'a'`, MapArgs{`1`: DString(`a`)}},
-		{`($1, $1, $1)`, `('a', 'a', 'a')`, MapArgs{`1`: DString(`a`)}},
-		{`$1 & $2`, `1 & 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 | $2`, `1 | 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 ^ $2`, `1 ^ 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 + $2`, `1 + 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 - $2`, `1 - 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 * $2`, `1 * 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 % $2`, `1 % 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 / $2`, `1 / 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 / $2`, `1 / 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1`, `'a'`, Placeholders{`1`: DString(`a`)}},
+		{`($1, $1, $1)`, `('a', 'a', 'a')`, Placeholders{`1`: DString(`a`)}},
+		{`$1 & $2`, `1 & 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 | $2`, `1 | 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 ^ $2`, `1 ^ 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 + $2`, `1 + 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 - $2`, `1 - 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 * $2`, `1 * 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 % $2`, `1 % 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 / $2`, `1 / 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 / $2`, `1 / 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
 		{`$1 + $2 + ($3 * $4)`, `1 + 2 + (3 * 4)`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3), `4`: DInt(4)}},
-		{`$1 || $2`, `'a' || 'b'`, MapArgs{`1`: DString("a"), `2`: DString("b")}},
-		{`$1 OR $2`, `true OR false`, MapArgs{`1`: DBool(true), `2`: DBool(false)}},
-		{`$1 AND $2`, `true AND false`, MapArgs{`1`: DBool(true), `2`: DBool(false)}},
-		{`$1 = $2`, `1 = 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 != $2`, `1 != 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 <> $2`, `1 != 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 < $2`, `1 < 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 <= $2`, `1 <= 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 > $2`, `1 > 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 >= $2`, `1 >= 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 IS NULL`, `1 IS NULL`, MapArgs{`1`: DInt(1)}},
-		{`$1 IS NOT NULL`, `1 IS NOT NULL`, MapArgs{`1`: DInt(1)}},
-		{`$1 BETWEEN $2 AND $3`, `1 BETWEEN 2 AND 3`, MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
+			Placeholders{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3), `4`: DInt(4)}},
+		{`$1 || $2`, `'a' || 'b'`, Placeholders{`1`: DString("a"), `2`: DString("b")}},
+		{`$1 OR $2`, `true OR false`, Placeholders{`1`: DBool(true), `2`: DBool(false)}},
+		{`$1 AND $2`, `true AND false`, Placeholders{`1`: DBool(true), `2`: DBool(false)}},
+		{`$1 = $2`, `1 = 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 != $2`, `1 != 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 <> $2`, `1 != 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 < $2`, `1 < 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 <= $2`, `1 <= 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 > $2`, `1 > 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 >= $2`, `1 >= 2`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1 IS NULL`, `1 IS NULL`, Placeholders{`1`: DInt(1)}},
+		{`$1 IS NOT NULL`, `1 IS NOT NULL`, Placeholders{`1`: DInt(1)}},
+		{`$1 BETWEEN $2 AND $3`, `1 BETWEEN 2 AND 3`, Placeholders{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
 		{`$1 NOT BETWEEN $2 AND $3`, `1 NOT BETWEEN 2 AND 3`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
-		{`CASE WHEN $1 THEN $2 END`, `CASE WHEN 1 THEN 2 END`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
+			Placeholders{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
+		{`CASE WHEN $1 THEN $2 END`, `CASE WHEN 1 THEN 2 END`, Placeholders{`1`: DInt(1), `2`: DInt(2)}},
 		{`CASE WHEN $1 THEN $2 ELSE $3 END`, `CASE WHEN 1 THEN 2 ELSE 3 END`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
+			Placeholders{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
 		{`CASE $1 WHEN $2 THEN $3 ELSE $4 END`, `CASE 1 WHEN 2 THEN 3 ELSE 4 END`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3), `4`: DInt(4)}},
+			Placeholders{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3), `4`: DInt(4)}},
 		{`($1, $2) = ($3, $4)`, `(1, 2) = (3, 4)`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3), `4`: DInt(4)}},
+			Placeholders{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3), `4`: DInt(4)}},
 		{`$1 IN ($2, $3)`, `1 IN (2, 3)`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
+			Placeholders{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
 		{`$1 NOT IN ($2, $3)`, `1 NOT IN (2, 3)`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
-		{`length($1)`, `length('a')`, MapArgs{`1`: DString("a")}},
-		{`length($1, $2)`, `length('a', 'b')`, MapArgs{`1`: DString("a"), `2`: DString("b")}},
-		{`CAST($1 AS INT)`, `CAST(1.1 AS INT)`, MapArgs{`1`: DFloat(1.1)}},
-		{`ROW($1, $2, $3)`, `ROW(1, 2, '3')`, MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DString("3")}},
-		{`(SELECT $1)`, `(SELECT 'a')`, MapArgs{`1`: DString("a")}},
-		{`EXISTS (SELECT $1)`, `EXISTS (SELECT 'a')`, MapArgs{`1`: DString("a")}},
+			Placeholders{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
+		{`length($1)`, `length('a')`, Placeholders{`1`: DString("a")}},
+		{`length($1, $2)`, `length('a', 'b')`, Placeholders{`1`: DString("a"), `2`: DString("b")}},
+		{`CAST($1 AS INT)`, `CAST(1.1 AS INT)`, Placeholders{`1`: DFloat(1.1)}},
+		{`ROW($1, $2, $3)`, `ROW(1, 2, '3')`, Placeholders{`1`: DInt(1), `2`: DInt(2), `3`: DString("3")}},
+		{`(SELECT $1)`, `(SELECT 'a')`, Placeholders{`1`: DString("a")}},
+		{`EXISTS (SELECT $1)`, `EXISTS (SELECT 'a')`, Placeholders{`1`: DString("a")}},
 	}
 
 	for _, d := range testData {
@@ -94,10 +94,10 @@ func TestFillArgsError(t *testing.T) {
 	testData := []struct {
 		expr     string
 		expected string
-		args     MapArgs
+		args     Placeholders
 	}{
-		{`$1`, `arg $1 not found`, MapArgs{}},
-		{`$2 AND $1`, `arg $2 not found`, MapArgs{}},
+		{`$1`, `arg $1 not found`, Placeholders{}},
+		{`$2 AND $1`, `arg $2 not found`, Placeholders{}},
 	}
 	for _, d := range testData {
 		q, err := ParseOneTraditional("SELECT " + d.expr)
@@ -116,23 +116,23 @@ func TestWalkStmt(t *testing.T) {
 	testData := []struct {
 		sql      string
 		expected string
-		args     MapArgs
+		args     Placeholders
 	}{
 		{`DELETE FROM db.table WHERE k IN ($1, $2)`,
 			`DELETE FROM db.table WHERE k IN ('a', 'c')`,
-			MapArgs{`1`: DString(`a`), `2`: DString(`c`)}},
+			Placeholders{`1`: DString(`a`), `2`: DString(`c`)}},
 		{`INSERT INTO db.table (k, v) VALUES (1, 2), ($1, $2)`,
 			`INSERT INTO db.table (k, v) VALUES (1, 2), (3, 4)`,
-			MapArgs{`1`: DInt(3), `2`: DInt(4)}},
+			Placeholders{`1`: DInt(3), `2`: DInt(4)}},
 		{`SELECT $1, $2 FROM db.table ORDER BY $1 DESC LIMIT $3 OFFSET $4`,
 			`SELECT 'a', 'b' FROM db.table ORDER BY 'a' DESC LIMIT 5 OFFSET 2`,
-			MapArgs{`1`: DString(`a`), `2`: DString(`b`), `3`: DInt(5), `4`: DInt(2)}},
+			Placeholders{`1`: DString(`a`), `2`: DString(`b`), `3`: DInt(5), `4`: DInt(2)}},
 		{`SELECT $1, $2 FROM db.table WHERE c in ($3, 2 * $4) GROUP BY $1 HAVING COUNT($5) > $6`,
 			`SELECT 'a', 'b' FROM db.table WHERE c in (1.1, 2 * 6.5) GROUP BY 'a' HAVING COUNT('d') > 6`,
-			MapArgs{`1`: DString(`a`), `2`: DString(`b`), `3`: DFloat(1.1), `4`: DFloat(6.5), `5`: DString('d'), `6`: DInt(6)}},
+			Placeholders{`1`: DString(`a`), `2`: DString(`b`), `3`: DFloat(1.1), `4`: DFloat(6.5), `5`: DString('d'), `6`: DInt(6)}},
 		{`UPDATE db.table SET v = $3 WHERE k IN ($1, $2)`,
 			`UPDATE db.table SET v = 2 WHERE k IN ('a', 'b')`,
-			MapArgs{`1`: DString(`a`), `2`: DString(`b`), `3`: DInt(2)}},
+			Placeholders{`1`: DString(`a`), `2`: DString(`b`), `3`: DInt(2)}},
 	}
 	for _, d := range testData {
 		q, err := ParseOneTraditional(d.sql)

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -274,9 +274,9 @@ func TestPGPrepared(t *testing.T) {
 	}
 
 	testFailures := map[string]string{
-		"SELECT $1 = $1":           "pq: unsupported comparison operator: <valarg> = <valarg>",
+		"SELECT $1 = $1":           "pq: unsupported comparison operator: <placeholder> = <placeholder>",
 		"SELECT $1 > 0 AND NOT $1": "pq: incompatible NOT argument type: int",
-		"SELECT $1":                "pq: unsupported result type: valarg",
+		"SELECT $1":                "pq: unsupported result type: placeholder",
 	}
 
 	for query, reason := range testFailures {

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -51,7 +51,7 @@ func (q *qvalue) Walk(v parser.Visitor) {
 	q.datum = parser.WalkExpr(v, q.datum).(parser.Datum)
 }
 
-func (q *qvalue) TypeCheck(args parser.MapArgs) (parser.Datum, error) {
+func (q *qvalue) TypeCheck(args parser.Placeholders) (parser.Datum, error) {
 	return q.datum.TypeCheck(args)
 }
 


### PR DESCRIPTION
Placeholder is chosen because it appears in both the Go database/sql docs
about DB.Exec and the Postgres Extended Query docs.

https://golang.org/pkg/database/sql/#DB.Exec
http://www.postgresql.org/docs/9.4/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY

fixes #3507

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3545)

<!-- Reviewable:end -->
