### PR TITLE
sql: make column values in index keys be encoded with the correct direction

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -713,7 +713,7 @@ func setupClientBenchData(useSSL bool, numVersions, numKeys int, b *testing.B) (
 		batch := &client.Batch{}
 		for i := 0; i < numKeys; i++ {
 			if t == 1 {
-				keys[i] = roachpb.Key(encoding.EncodeUvarint([]byte("key-"), uint64(i)))
+				keys[i] = roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(i)))
 				nvs[i] = int(rand.Int31n(int32(numVersions)) + 1)
 			}
 			// Only write values if this iteration is less than the random
@@ -761,8 +761,10 @@ func runClientScan(useSSL bool, numRows, numVersions int, b *testing.B) {
 		for pb.Next() {
 			// Choose a random key to start scan.
 			keyIdx := rand.Int31n(int32(numKeys - numRows))
-			startKey := roachpb.Key(encoding.EncodeUvarint(startKeyBuf, uint64(keyIdx)))
-			endKey := roachpb.Key(encoding.EncodeUvarint(endKeyBuf, uint64(keyIdx)+uint64(numRows)))
+			startKey := roachpb.Key(encoding.EncodeUvarintAscending(
+				startKeyBuf, uint64(keyIdx)))
+			endKey := roachpb.Key(encoding.EncodeUvarintAscending(
+				endKeyBuf, uint64(keyIdx)+uint64(numRows)))
 			rows, pErr := db.Scan(startKey, endKey, int64(numRows))
 			if pErr != nil {
 				b.Fatalf("failed scan: %s", pErr)

--- a/config/config.go
+++ b/config/config.go
@@ -114,7 +114,7 @@ func ObjectIDForKey(key roachpb.RKey) (uint32, bool) {
 		return 0, false
 	}
 	// Consume first encoded int.
-	_, id64, err := encoding.DecodeUvarint(key)
+	_, id64, err := encoding.DecodeUvarintAscending(key)
 	return uint32(id64), err == nil
 }
 
@@ -174,12 +174,12 @@ func decodeDescMetadataID(key roachpb.Key) (uint64, error) {
 		return 0, util.Errorf("key is not a descriptor table entry: %v", key)
 	}
 	// DescriptorTable.PrimaryIndex.ID
-	remaining, _, err = encoding.DecodeUvarint(remaining)
+	remaining, _, err = encoding.DecodeUvarintAscending(remaining)
 	if err != nil {
 		return 0, err
 	}
 	// descID
-	_, id, err := encoding.DecodeUvarint(remaining)
+	_, id, err := encoding.DecodeUvarintAscending(remaining)
 	if err != nil {
 		return 0, err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,9 +38,9 @@ func plainKV(k, v string) roachpb.KeyValue {
 
 func sqlKV(tableID uint32, indexID, descriptorID uint64) roachpb.KeyValue {
 	k := keys.MakeTablePrefix(tableID)
-	k = encoding.EncodeUvarint(k, indexID)
-	k = encoding.EncodeUvarint(k, descriptorID)
-	k = encoding.EncodeUvarint(k, 12345) // Column ID, but could be anything.
+	k = encoding.EncodeUvarintAscending(k, indexID)
+	k = encoding.EncodeUvarintAscending(k, descriptorID)
+	k = encoding.EncodeUvarintAscending(k, 12345) // Column ID, but could be anything.
 	return kv(k, nil)
 }
 

--- a/gossip/simulation/gossip.go
+++ b/gossip/simulation/gossip.go
@@ -210,7 +210,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 				missing = append(missing, otherNode.Gossip.GetNodeID())
 				quiescent = false
 			} else {
-				_, val, err := encoding.DecodeUint64(info)
+				_, val, err := encoding.DecodeUint64Ascending(info)
 				if err != nil {
 					log.Fatalf("bad decode of node info cycle: %s", err)
 				}
@@ -224,7 +224,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 		if info, err := node.GetInfo(gossip.KeySentinel); err != nil {
 			log.Infof("error getting info for sentinel gossip key %q: %s", gossip.KeySentinel, err)
 		} else {
-			_, val, err := encoding.DecodeUint64(info)
+			_, val, err := encoding.DecodeUint64Ascending(info)
 			if err != nil {
 				log.Fatalf("bad decode of sentinel cycle: %s", err)
 			}

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -111,7 +111,8 @@ func (n *Network) StartNode(node *Node) error {
 	}); err != nil {
 		return err
 	}
-	if err := node.Gossip.AddInfo(node.Addr.String(), encoding.EncodeUint64(nil, 0), time.Hour); err != nil {
+	if err := node.Gossip.AddInfo(node.Addr.String(),
+		encoding.EncodeUint64Ascending(nil, 0), time.Hour); err != nil {
 		return err
 	}
 	node.Gossip.Start(node.Server, node.Addr, n.Stopper)
@@ -155,15 +156,22 @@ func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) 
 	nodes := n.Nodes
 	for cycle := 1; simCallback(cycle, n); cycle++ {
 		// Node 0 gossips sentinel & cluster ID every cycle.
-		if err := nodes[0].Gossip.AddInfo(gossip.KeySentinel, encoding.EncodeUint64(nil, uint64(cycle)), time.Hour); err != nil {
+		if err := nodes[0].Gossip.AddInfo(
+			gossip.KeySentinel,
+			encoding.EncodeUint64Ascending(nil, uint64(cycle)),
+			time.Hour); err != nil {
 			log.Fatal(err)
 		}
-		if err := nodes[0].Gossip.AddInfo(gossip.KeyClusterID, encoding.EncodeUint64(nil, uint64(cycle)), 0*time.Second); err != nil {
+		if err := nodes[0].Gossip.AddInfo(gossip.KeyClusterID,
+			encoding.EncodeUint64Ascending(nil, uint64(cycle)), 0*time.Second); err != nil {
 			log.Fatal(err)
 		}
 		// Every node gossips cycle.
 		for _, node := range nodes {
-			if err := node.Gossip.AddInfo(node.Addr.String(), encoding.EncodeUint64(nil, uint64(cycle)), time.Hour); err != nil {
+			if err := node.Gossip.AddInfo(
+				node.Addr.String(),
+				encoding.EncodeUint64Ascending(nil, uint64(cycle)),
+				time.Hour); err != nil {
 				log.Fatal(err)
 			}
 			node.Gossip.SimulationCycle()

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -166,9 +166,9 @@ var (
 	StatusNodePrefix = roachpb.Key(MakeKey(StatusPrefix, roachpb.RKey("node-")))
 
 	// TableDataMin is the start of the range of table data keys.
-	TableDataMin = roachpb.Key(encoding.EncodeVarint(nil, math.MinInt64))
+	TableDataMin = roachpb.Key(encoding.EncodeVarintAscending(nil, math.MinInt64))
 	// TableDataMin is the end of the range of table data keys.
-	TableDataMax = roachpb.Key(encoding.EncodeVarint(nil, math.MaxInt64))
+	TableDataMax = roachpb.Key(encoding.EncodeVarintAscending(nil, math.MaxInt64))
 
 	// SystemConfigTableDataMax is the end key of system config structured data.
 	SystemConfigTableDataMax = roachpb.Key(MakeTablePrefix(MaxSystemConfigDescID + 1))

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -52,19 +52,20 @@ func StoreGossipKey() roachpb.Key {
 // StoreStatusKey returns the key for accessing the store status for the
 // specified store ID.
 func StoreStatusKey(storeID int32) roachpb.Key {
-	return roachpb.Key(MakeKey(StatusStorePrefix, encoding.EncodeUvarint(nil, uint64(storeID))))
+	return roachpb.Key(
+		MakeKey(StatusStorePrefix, encoding.EncodeUvarintAscending(nil, uint64(storeID))))
 }
 
 // NodeStatusKey returns the key for accessing the node status for the
 // specified node ID.
 func NodeStatusKey(nodeID int32) roachpb.Key {
-	return MakeKey(StatusNodePrefix, encoding.EncodeUvarint(nil, uint64(nodeID)))
+	return MakeKey(StatusNodePrefix, encoding.EncodeUvarintAscending(nil, uint64(nodeID)))
 }
 
 // MakeRangeIDPrefix creates a range-local key prefix from
 // rangeID.
 func MakeRangeIDPrefix(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeKey(LocalRangeIDPrefix, encoding.EncodeUvarint(nil, uint64(rangeID)))
+	return MakeKey(LocalRangeIDPrefix, encoding.EncodeUvarintAscending(nil, uint64(rangeID)))
 }
 
 // MakeRangeIDKey creates a range-local key based on the range's
@@ -79,7 +80,7 @@ func MakeRangeIDKey(rangeID roachpb.RangeID, suffix, detail roachpb.RKey) roachp
 // RaftLogKey returns a system-local key for a Raft log entry.
 func RaftLogKey(rangeID roachpb.RangeID, logIndex uint64) roachpb.Key {
 	return MakeRangeIDKey(rangeID, localRaftLogSuffix,
-		encoding.EncodeUint64(nil, logIndex))
+		encoding.EncodeUint64Ascending(nil, logIndex))
 }
 
 // RaftLogPrefix returns the system-local prefix shared by all entries in a Raft log.
@@ -128,15 +129,18 @@ func RangeStatsKey(rangeID roachpb.RangeID) roachpb.Key {
 // supplied transaction ID, epoch and sequence number.
 func SequenceCacheKey(rangeID roachpb.RangeID, id []byte, epoch uint32, seq uint32) roachpb.Key {
 	return MakeRangeIDKey(rangeID, LocalSequenceCacheSuffix,
-		encoding.EncodeUint32Decreasing(
-			encoding.EncodeUint32Decreasing(
-				encoding.EncodeBytes(nil, id), epoch), seq))
+		encoding.EncodeUint32Descending(
+			encoding.EncodeUint32Descending(
+				encoding.EncodeBytesAscending(nil, id),
+				epoch),
+			seq))
 }
 
 // SequenceCacheKeyPrefix returns the prefix common to all sequence cache keys
 // for the given ID.
 func SequenceCacheKeyPrefix(rangeID roachpb.RangeID, id []byte) roachpb.Key {
-	return MakeRangeIDKey(rangeID, LocalSequenceCacheSuffix, encoding.EncodeBytes(nil, id))
+	return MakeRangeIDKey(rangeID, LocalSequenceCacheSuffix,
+		encoding.EncodeBytesAscending(nil, id))
 }
 
 // MakeRangeKey creates a range-local key based on the range
@@ -152,7 +156,7 @@ func MakeRangeKey(key, suffix, detail roachpb.RKey) roachpb.Key {
 // MakeRangeKeyPrefix creates a key prefix under which all range-local keys
 // can be found.
 func MakeRangeKeyPrefix(key roachpb.RKey) roachpb.Key {
-	return MakeKey(LocalRangePrefix, encoding.EncodeBytes(nil, key))
+	return MakeKey(LocalRangePrefix, encoding.EncodeBytesAscending(nil, key))
 }
 
 // DecodeRangeKey decodes the range key into range start key,
@@ -164,7 +168,7 @@ func DecodeRangeKey(key roachpb.Key) (startKey, suffix, detail roachpb.Key, err 
 	}
 	// Cut the prefix and the Range ID.
 	b := key[len(LocalRangePrefix):]
-	b, startKey, err = encoding.DecodeBytes(b, nil)
+	b, startKey, err = encoding.DecodeBytesAscending(b, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -228,7 +232,7 @@ func Addr(k roachpb.Key) roachpb.RKey {
 	}
 	if bytes.HasPrefix(k, LocalRangePrefix) {
 		k = k[len(LocalRangePrefix):]
-		_, k, err := encoding.DecodeBytes(k, nil)
+		_, k, err := encoding.DecodeBytesAscending(k, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -335,7 +339,7 @@ func MetaReverseScanBounds(key roachpb.RKey) (roachpb.Key, roachpb.Key, error) {
 
 // MakeTablePrefix returns the key prefix used for the table's data.
 func MakeTablePrefix(tableID uint32) []byte {
-	return encoding.EncodeUvarint(nil, uint64(tableID))
+	return encoding.EncodeUvarintAscending(nil, uint64(tableID))
 }
 
 // DecodeTablePrefix validates that the given key has a table prefix, returning
@@ -345,24 +349,24 @@ func DecodeTablePrefix(key roachpb.Key) ([]byte, uint64, error) {
 	if encoding.PeekType(key) != encoding.Int {
 		return key, 0, util.Errorf("invalid key prefix: %q", key)
 	}
-	return encoding.DecodeUvarint(key)
+	return encoding.DecodeUvarintAscending(key)
 }
 
 // MakeColumnKey returns the key for the column in the given row.
 func MakeColumnKey(rowKey []byte, colID uint32) []byte {
 	key := append([]byte(nil), rowKey...)
 	size := len(key)
-	key = encoding.EncodeUvarint(key, uint64(colID))
+	key = encoding.EncodeUvarintAscending(key, uint64(colID))
 	// Note that we assume that `len(key)-size` will always be encoded to a
 	// single byte by EncodeUvarint. This is currently always true because the
 	// varint encoding will encode 1-9 bytes.
-	return encoding.EncodeUvarint(key, uint64(len(key)-size))
+	return encoding.EncodeUvarintAscending(key, uint64(len(key)-size))
 }
 
 // MakeNonColumnKey creates a non-column key for a row by appending a 0 column
 // ID suffix size to rowKey.
 func MakeNonColumnKey(rowKey []byte) []byte {
-	return encoding.EncodeUvarint(rowKey, 0)
+	return encoding.EncodeUvarintAscending(rowKey, 0)
 }
 
 // MakeSplitKey transforms an SQL table key such that it is a valid split key
@@ -386,7 +390,7 @@ func MakeSplitKey(key roachpb.Key) (roachpb.Key, error) {
 	// Strip off the column ID suffix from the buf. The last byte of the buf
 	// contains the length of the column ID suffix (which might be 0 if the buf
 	// does not contain a column ID suffix).
-	_, colIDLen, err := encoding.DecodeUvarint(buf)
+	_, colIDLen, err := encoding.DecodeUvarintAscending(buf)
 	if err != nil {
 		return nil, err
 	}

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -365,7 +365,7 @@ func TestMakeSplitKey(t *testing.T) {
 	e := func(vals ...uint64) roachpb.Key {
 		var k roachpb.Key
 		for _, v := range vals {
-			k = encoding.EncodeUvarint(k, v)
+			k = encoding.EncodeUvarintAscending(k, v)
 		}
 		return k
 	}

--- a/keys/printer.go
+++ b/keys/printer.go
@@ -338,7 +338,7 @@ func init() {
 	roachpb.PrettyPrintKey = PrettyPrint
 }
 
-// Does some transformations on pretty-printed spans and keys:
+// MassagePrettyPrintedSpanForTest does some transformations on pretty-printed spans and keys:
 // - if dirs is not nil, replace all ints with their ones' complement for
 // descendingly-encoded columns.
 // - strips line numbers from error messages.
@@ -346,7 +346,7 @@ func MassagePrettyPrintedSpanForTest(span string, dirs []encoding.Direction) str
 	var r string
 	colIdx := -1
 	for i := 0; i < len(span); i++ {
-		var d int = -789
+		d := -789
 		fmt.Sscanf(span[i:], "%d", &d)
 		if (dirs != nil) && (d != -789) {
 			// We've managed to consume an int.

--- a/keys/printer.go
+++ b/keys/printer.go
@@ -19,6 +19,8 @@ package keys
 import (
 	"bytes"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -100,7 +102,7 @@ func localStoreKeyPrint(key roachpb.Key) string {
 func raftLogKeyPrint(key roachpb.Key) string {
 	var logIndex uint64
 	var err error
-	key, logIndex, err = encoding.DecodeUint64(key)
+	key, logIndex, err = encoding.DecodeUint64Ascending(key)
 	if err != nil {
 		return fmt.Sprintf("/err<%v:%q>", err, []byte(key))
 	}
@@ -115,7 +117,7 @@ func localRangeIDKeyPrint(key roachpb.Key) string {
 	}
 
 	// get range id
-	key, i, err := encoding.DecodeVarint(key)
+	key, i, err := encoding.DecodeVarintAscending(key)
 	if err != nil {
 		return fmt.Sprintf("/err<%v:%q>", err, []byte(key))
 	}
@@ -174,7 +176,7 @@ func localRangeKeyPrint(key roachpb.Key) string {
 }
 
 func sequenceCacheKeyPrint(key roachpb.Key) string {
-	b, id, err := encoding.DecodeBytes([]byte(key), nil)
+	b, id, err := encoding.DecodeBytesAscending([]byte(key), nil)
 	if err != nil {
 		return fmt.Sprintf("/%q/err:%v", key, err)
 	}
@@ -183,12 +185,12 @@ func sequenceCacheKeyPrint(key roachpb.Key) string {
 		return fmt.Sprintf("/%q", id)
 	}
 
-	b, epoch, err := encoding.DecodeUint32Decreasing(b)
+	b, epoch, err := encoding.DecodeUint32Descending(b)
 	if err != nil {
 		return fmt.Sprintf("/%q/err:%v", id, err)
 	}
 
-	_, seq, err := encoding.DecodeUint32Decreasing(b)
+	_, seq, err := encoding.DecodeUint32Descending(b)
 	if err != nil {
 		return fmt.Sprintf("/%q/epoch:%d/err:%v", id, epoch, err)
 	}
@@ -213,25 +215,37 @@ func decodeKeyPrint(key roachpb.Key) string {
 			fmt.Fprintf(&buf, "/#")
 		case encoding.Int:
 			var i int64
-			key, i, err = encoding.DecodeVarint(key)
+			key, i, err = encoding.DecodeVarintAscending(key)
 			if err == nil {
 				fmt.Fprintf(&buf, "/%d", i)
 			}
 		case encoding.Float:
 			var f float64
-			key, f, err = encoding.DecodeFloat(key, nil)
+			key, f, err = encoding.DecodeFloatAscending(key, nil)
 			if err == nil {
 				fmt.Fprintf(&buf, "/%f", f)
 			}
 		case encoding.Bytes:
 			var s string
-			key, s, err = encoding.DecodeString(key, nil)
+			key, s, err = encoding.DecodeStringAscending(key, nil)
+			if err == nil {
+				fmt.Fprintf(&buf, "/%q", s)
+			}
+		case encoding.BytesDesc:
+			var s string
+			key, s, err = encoding.DecodeStringDescending(key, nil)
 			if err == nil {
 				fmt.Fprintf(&buf, "/%q", s)
 			}
 		case encoding.Time:
 			var t time.Time
-			key, t, err = encoding.DecodeTime(key)
+			key, t, err = encoding.DecodeTimeAscending(key)
+			if err == nil {
+				fmt.Fprintf(&buf, "/%s", t.UTC().Format(time.UnixDate))
+			}
+		case encoding.TimeDesc:
+			var t time.Time
+			key, t, err = encoding.DecodeTimeDescending(key)
 			if err == nil {
 				fmt.Fprintf(&buf, "/%s", t.UTC().Format(time.UnixDate))
 			}
@@ -322,4 +336,54 @@ func PrettyPrint(key roachpb.Key) string {
 
 func init() {
 	roachpb.PrettyPrintKey = PrettyPrint
+}
+
+// Does some transformations on pretty-printed spans and keys:
+// - if dirs is not nil, replace all ints with their ones' complement for
+// descendingly-encoded columns.
+// - strips line numbers from error messages.
+func MassagePrettyPrintedSpanForTest(span string, dirs []encoding.Direction) string {
+	var r string
+	colIdx := -1
+	for i := 0; i < len(span); i++ {
+		var d int = -789
+		fmt.Sscanf(span[i:], "%d", &d)
+		if (dirs != nil) && (d != -789) {
+			// We've managed to consume an int.
+			dir := dirs[colIdx]
+			i += len(strconv.Itoa(d)) - 1
+			x := d
+			if dir == encoding.Descending {
+				x = ^x
+			}
+			r += strconv.Itoa(x)
+		} else {
+			r += string(span[i])
+			switch span[i] {
+			case '/':
+				colIdx++
+			case '-', ' ':
+				// We're switching from the start constraints to the end constraints,
+				// or starting another span.
+				colIdx = -1
+			case '<':
+				// This is an error message, like <util/encoding/encoding.go:256: ....>.
+				end := strings.Index(span[i:], ">")
+				if end == -1 {
+					panic("parse error")
+				}
+				errMsg := span[i+1 : i+end+1]
+				lineIdx := strings.Index(errMsg, ":")
+				if lineIdx != -1 {
+					var lineEnd int
+					for lineEnd = lineIdx + 1; errMsg[lineEnd] >= '0' && errMsg[lineEnd] <= '9'; lineEnd++ {
+					}
+					errMsg = errMsg[:lineIdx] + errMsg[lineIdx+(lineEnd-lineIdx):]
+				}
+				r += errMsg
+				i += end
+			}
+		}
+	}
+	return r
 }

--- a/keys/printer_test.go
+++ b/keys/printer_test.go
@@ -107,7 +107,7 @@ func TestPrettyPrint(t *testing.T) {
 
 		// others
 		{MakeKey([]byte("")), "/Min"},
-		{MakeKey(MakeTablePrefix(42), roachpb.RKey([]byte{0x21, 'a', 0x00, 0x02})), "/Table/42/<util/encoding/encoding.go:521: unknown escape>"},
+		{MakeKey(MakeTablePrefix(42), roachpb.RKey([]byte{0x21, 'a', 0x00, 0x02})), "/Table/42/<util/encoding/encoding.go:9999: unknown escape sequence: 0x0 0x2>"},
 	}
 	for i, test := range testCases {
 		keyInfo := MassagePrettyPrintedSpanForTest(PrettyPrint(test.key), nil)

--- a/keys/printer_test.go
+++ b/keys/printer_test.go
@@ -69,26 +69,55 @@ func TestPrettyPrint(t *testing.T) {
 		{UserTableDataMin, "/Table/50"},
 		{MakeTablePrefix(111), "/Table/111"},
 		{MakeKey(MakeTablePrefix(42), roachpb.RKey("foo")), `/Table/42/"foo"`},
-		{MakeKey(MakeTablePrefix(42), roachpb.RKey(encoding.EncodeFloat(nil, float64(233.221112)))), "/Table/42/233.221112"},
-		{MakeKey(MakeTablePrefix(42), roachpb.RKey(encoding.EncodeVarint(nil, 1222)), roachpb.RKey(encoding.EncodeString(nil, "handsome man"))), `/Table/42/1222/"handsome man"`},
-		{MakeKey(MakeTablePrefix(42), roachpb.RKey(encoding.EncodeBytes(nil, []byte{1, 2, 8, 255}))), `/Table/42/"\x01\x02\b\xff"`},
-		{MakeKey(MakeTablePrefix(42), roachpb.RKey(encoding.EncodeBytes(nil, []byte{1, 2, 8, 255})), roachpb.RKey("bar")), `/Table/42/"\x01\x02\b\xff"/"bar"`},
-		{MakeKey(MakeTablePrefix(42), roachpb.RKey(encoding.EncodeNull(nil))), "/Table/42/NULL"},
-		{MakeKey(MakeTablePrefix(42), roachpb.RKey(encoding.EncodeNotNull(nil))), "/Table/42/#"},
-		{MakeKey(MakeTablePrefix(42), roachpb.RKey(encoding.EncodeTime(nil, tm))), "/Table/42/Sat Mar  7 11:06:39 UTC 2015"},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeFloatAscending(nil, float64(233.221112)))),
+			"/Table/42/233.221112"},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeFloatDescending(nil, float64(-233.221112)))),
+			"/Table/42/233.221112"},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeVarintAscending(nil, 1222)),
+			roachpb.RKey(encoding.EncodeStringAscending(nil, "handsome man"))),
+			`/Table/42/1222/"handsome man"`},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeVarintAscending(nil, 1222))),
+			`/Table/42/1222`},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeVarintDescending(nil, 1222))),
+			`/Table/42/-1223`},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeBytesAscending(nil, []byte{1, 2, 8, 255}))),
+			`/Table/42/"\x01\x02\b\xff"`},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeBytesAscending(nil, []byte{1, 2, 8, 255})),
+			roachpb.RKey("bar")), `/Table/42/"\x01\x02\b\xff"/"bar"`},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeBytesDescending(nil, []byte{1, 2, 8, 255})),
+			roachpb.RKey("bar")), `/Table/42/"\x01\x02\b\xff"/"bar"`},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeNullAscending(nil))), "/Table/42/NULL"},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeNotNullAscending(nil))), "/Table/42/#"},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeTimeAscending(nil, tm))),
+			"/Table/42/Sat Mar  7 11:06:39 UTC 2015"},
+		{MakeKey(MakeTablePrefix(42),
+			roachpb.RKey(encoding.EncodeTimeDescending(nil, tm))),
+			"/Table/42/Sat Mar  7 11:06:39 UTC 2015"},
 
 		// others
 		{MakeKey([]byte("")), "/Min"},
-		{MakeKey(MakeTablePrefix(42), roachpb.RKey([]byte{0x20, 'a', 0x00, 0x02})), "/Table/42/<util/encoding/encoding.go:407: unknown escape>"},
+		{MakeKey(MakeTablePrefix(42), roachpb.RKey([]byte{0x21, 'a', 0x00, 0x02})), "/Table/42/<util/encoding/encoding.go:521: unknown escape>"},
 	}
 	for i, test := range testCases {
-		keyInfo := PrettyPrint(test.key)
-		if test.exp != keyInfo {
-			t.Fatalf("%d: expected %s, got %s", i, test.exp, keyInfo)
+		keyInfo := MassagePrettyPrintedSpanForTest(PrettyPrint(test.key), nil)
+		exp := MassagePrettyPrintedSpanForTest(test.exp, nil)
+		if exp != keyInfo {
+			t.Fatalf("%d: expected %s, got %s", i, exp, keyInfo)
 		}
 
-		if test.exp != test.key.String() {
-			t.Fatalf("%d: expected %s, got %s", i, test.exp, keyInfo)
+		if exp != MassagePrettyPrintedSpanForTest(test.key.String(), nil) {
+			t.Fatalf("%d: expected %s, got %s", i, exp, test.key.String())
 		}
 	}
 }

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -288,7 +288,7 @@ func (v Value) checksum() uint32 {
 	if len(v.RawBytes) < checksumSize {
 		return 0
 	}
-	_, u, err := encoding.DecodeUint32(v.RawBytes[:checksumSize])
+	_, u, err := encoding.DecodeUint32Ascending(v.RawBytes[:checksumSize])
 	if err != nil {
 		panic(err)
 	}
@@ -297,7 +297,7 @@ func (v Value) checksum() uint32 {
 
 func (v *Value) setChecksum(cksum uint32) {
 	if len(v.RawBytes) >= checksumSize {
-		encoding.EncodeUint32(v.RawBytes[:0], cksum)
+		encoding.EncodeUint32Ascending(v.RawBytes[:0], cksum)
 	}
 }
 
@@ -388,7 +388,7 @@ func (v *Value) SetBytes(b []byte) {
 // receiver, sets the tag and clears the checksum.
 func (v *Value) SetFloat(f float64) {
 	v.RawBytes = make([]byte, headerSize+8)
-	encoding.EncodeUint64(v.RawBytes[headerSize:headerSize], math.Float64bits(f))
+	encoding.EncodeUint64Ascending(v.RawBytes[headerSize:headerSize], math.Float64bits(f))
 	v.setTag(ValueType_FLOAT)
 }
 
@@ -421,7 +421,7 @@ func (v *Value) SetProto(msg proto.Message) error {
 // receiver, sets the tag and clears the checksum.
 func (v *Value) SetTime(t time.Time) {
 	v.RawBytes = make([]byte, headerSize, 16)
-	v.RawBytes = encoding.EncodeTime(v.RawBytes[:headerSize], t)
+	v.RawBytes = encoding.EncodeTimeAscending(v.RawBytes[:headerSize], t)
 	v.setTag(ValueType_TIME)
 }
 
@@ -445,7 +445,7 @@ func (v Value) GetFloat() (float64, error) {
 	if len(dataBytes) != 8 {
 		return 0, fmt.Errorf("float64 value should be exactly 8 bytes: %d", len(dataBytes))
 	}
-	_, u, err := encoding.DecodeUint64(dataBytes)
+	_, u, err := encoding.DecodeUint64Ascending(dataBytes)
 	if err != nil {
 		return 0, err
 	}
@@ -488,7 +488,7 @@ func (v Value) GetTime() (time.Time, error) {
 	if tag := v.GetTag(); tag != ValueType_TIME {
 		return time.Time{}, fmt.Errorf("value type is not %s: %s", ValueType_TIME, tag)
 	}
-	_, t, err := encoding.DecodeTime(v.dataBytes())
+	_, t, err := encoding.DecodeTimeAscending(v.dataBytes())
 	if err != nil {
 		return t, err
 	}

--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -39,6 +39,7 @@ func testTableDesc() *TableDescriptor {
 			{Name: "g", Type: ColumnType{Kind: ColumnType_BOOL}},
 			{Name: "h", Type: ColumnType{Kind: ColumnType_FLOAT}},
 			{Name: "i", Type: ColumnType{Kind: ColumnType_STRING}},
+			{Name: "j", Type: ColumnType{Kind: ColumnType_INT}},
 		},
 		PrimaryIndex: IndexDescriptor{
 			Name: "primary", Unique: true, ColumnNames: []string{"a"},

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -66,7 +66,7 @@ func (p *planner) Delete(n *parser.Delete) (planNode, *roachpb.Error) {
 		result.rows = append(result.rows, parser.DTuple(nil))
 
 		primaryIndexKey, _, pErr := encodeIndexKey(
-			primaryIndex.ColumnIDs, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
+			&primaryIndex, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
 		if pErr != nil {
 			return nil, pErr
 		}

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/encoding"
 )
 
 type errUniquenessConstraintViolation struct {
@@ -65,8 +66,16 @@ func convertBatchError(tableDesc *TableDescriptor, b client.Batch, origPErr *roa
 			if pErr != nil {
 				return pErr
 			}
+			dirs := make([]encoding.Direction, 0, len(index.ColumnIDs))
+			for _, dir := range index.ColumnDirections {
+				convertedDir, err := dir.toEncodingDirection()
+				if err != nil {
+					return roachpb.NewError(err)
+				}
+				dirs = append(dirs, convertedDir)
+			}
 			vals := make([]parser.Datum, len(valTypes))
-			if _, pErr := decodeKeyVals(valTypes, vals, key); pErr != nil {
+			if _, pErr := decodeKeyVals(valTypes, vals, dirs, key); pErr != nil {
 				return pErr
 			}
 

--- a/sql/group.go
+++ b/sql/group.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -588,7 +589,7 @@ func encodeDatum(b []byte, d parser.Datum) ([]byte, *roachpb.Error) {
 		dt, err := encodeDTuple(b, values)
 		return dt, roachpb.NewError(err)
 	}
-	return encodeTableKey(b, d)
+	return encodeTableKey(b, d, encoding.Ascending)
 }
 
 func encodeDTuple(b []byte, d parser.DTuple) ([]byte, error) {

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -163,7 +163,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 		}
 
 		primaryIndexKey, _, epErr := encodeIndexKey(
-			primaryIndex.ColumnIDs, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
+			&primaryIndex, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
 		if epErr != nil {
 			return nil, epErr
 		}

--- a/sql/join.go
+++ b/sql/join.go
@@ -155,7 +155,7 @@ func (n *indexJoinNode) Next() bool {
 			vals := n.index.Values()
 			var primaryIndexKey []byte
 			primaryIndexKey, _, n.pErr = encodeIndexKey(
-				n.table.index.ColumnIDs, n.colIDtoRowIndex, vals, n.primaryKeyPrefix)
+				n.table.index, n.colIDtoRowIndex, vals, n.primaryKeyPrefix)
 			if n.pErr != nil {
 				return false
 			}

--- a/sql/keys.go
+++ b/sql/keys.go
@@ -71,10 +71,10 @@ func equalName(a, b string) bool {
 func MakeNameMetadataKey(parentID ID, name string) roachpb.Key {
 	name = normalizeName(name)
 	k := keys.MakeTablePrefix(uint32(namespaceTable.ID))
-	k = encoding.EncodeUvarint(k, uint64(namespaceTable.PrimaryIndex.ID))
-	k = encoding.EncodeUvarint(k, uint64(parentID))
+	k = encoding.EncodeUvarintAscending(k, uint64(namespaceTable.PrimaryIndex.ID))
+	k = encoding.EncodeUvarintAscending(k, uint64(parentID))
 	if name != "" {
-		k = encoding.EncodeBytes(k, []byte(name))
+		k = encoding.EncodeBytesAscending(k, []byte(name))
 		k = keys.MakeColumnKey(k, uint32(namespaceTable.Columns[2].ID))
 	}
 	return k
@@ -83,23 +83,23 @@ func MakeNameMetadataKey(parentID ID, name string) roachpb.Key {
 // MakeDescMetadataKey returns the key for the descriptor.
 func MakeDescMetadataKey(descID ID) roachpb.Key {
 	k := keys.MakeTablePrefix(uint32(descriptorTable.ID))
-	k = encoding.EncodeUvarint(k, uint64(descriptorTable.PrimaryIndex.ID))
-	k = encoding.EncodeUvarint(k, uint64(descID))
+	k = encoding.EncodeUvarintAscending(k, uint64(descriptorTable.PrimaryIndex.ID))
+	k = encoding.EncodeUvarintAscending(k, uint64(descID))
 	return keys.MakeColumnKey(k, uint32(descriptorTable.Columns[1].ID))
 }
 
 // MakeZoneKey returns the key for 'id's entry in the system.zones table.
 func MakeZoneKey(id ID) roachpb.Key {
 	k := keys.MakeTablePrefix(uint32(zonesTable.ID))
-	k = encoding.EncodeUvarint(k, uint64(zonesTable.PrimaryIndex.ID))
-	k = encoding.EncodeUvarint(k, uint64(id))
+	k = encoding.EncodeUvarintAscending(k, uint64(zonesTable.PrimaryIndex.ID))
+	k = encoding.EncodeUvarintAscending(k, uint64(id))
 	return keys.MakeColumnKey(k, uint32(zonesTable.Columns[1].ID))
 }
 
 // MakeIndexKeyPrefix returns the key prefix used for the index's data.
 func MakeIndexKeyPrefix(tableID ID, indexID IndexID) []byte {
 	key := keys.MakeTablePrefix(uint32(tableID))
-	key = encoding.EncodeUvarint(key, uint64(indexID))
+	key = encoding.EncodeUvarintAscending(key, uint64(indexID))
 	return key
 }
 

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -1343,7 +1343,7 @@ func generateUniqueBytes(nodeID roachpb.NodeID) DBytes {
 	uniqueBytesState.Unlock()
 
 	b := make([]byte, 0, 8+binary.MaxVarintLen32)
-	b = encoding.EncodeUint64(b, nanos)
+	b = encoding.EncodeUint64Ascending(b, nanos)
 	// We use binary.PutUvarint instead of encoding.EncodeUvarint because the
 	// former uses less space for values < 128 which is a common occurrence for
 	// node IDs.

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -70,9 +70,19 @@ type Datum interface {
 	// Compare returns -1 if the receiver is less than other, 0 if receiver is
 	// equal to other and +1 if receiver is greater than other.
 	Compare(other Datum) int
+	// HasPrev is a type trait specifying if Prev() can be used to compute a
+	// previous value for a datum. For example, DBytes doesn't support it
+	// (the previous for BB is BAZZZ..).
+	HasPrev() bool
+	// Prev returns the previous datum. If the receiver is "b" and the returned datum
+	// is "a", then "a < b" and no other datum will compare such that "a < c <
+	// b".
+	// The return value is undefined is `IsMin()`.
+	Prev() Datum
 	// Next returns the next datum. If the receiver is "a" and the returned datum
 	// is "b", then "a < b" and no other datum will compare such that "a < c <
 	// b".
+	// The return value is undefined is `IsMax()`.
 	Next() Datum
 	// IsMax returns true if the datum is equal to the maximum value the datum
 	// type can hold.
@@ -118,6 +128,16 @@ func (d DBool) Compare(other Datum) int {
 		return 1
 	}
 	return 0
+}
+
+// HasPrev implements the Datum interface.
+func (d DBool) HasPrev() bool {
+	return true
+}
+
+// Prev implements the Datum interface.
+func (d DBool) Prev() Datum {
+	return DBool(false)
 }
 
 // Next implements the Datum interface.
@@ -166,6 +186,16 @@ func (d DInt) Compare(other Datum) int {
 	return 0
 }
 
+// HasPrev implements the Datum interface.
+func (d DInt) HasPrev() bool {
+	return true
+}
+
+// Prev implements the Datum interface.
+func (d DInt) Prev() Datum {
+	return d - 1
+}
+
 // Next implements the Datum interface.
 func (d DInt) Next() Datum {
 	return d + 1
@@ -210,6 +240,16 @@ func (d DFloat) Compare(other Datum) int {
 		return 1
 	}
 	return 0
+}
+
+// HasPrev implements the Datum interface.
+func (d DFloat) HasPrev() bool {
+	return true
+}
+
+// Prev implements the Datum interface.
+func (d DFloat) Prev() Datum {
+	return DFloat(math.Nextafter(float64(d), math.Inf(-1)))
 }
 
 // Next implements the Datum interface.
@@ -274,6 +314,16 @@ func (d DString) Compare(other Datum) int {
 	return 0
 }
 
+// HasPrev implements the Datum interface.
+func (d DString) HasPrev() bool {
+	return false
+}
+
+// Prev implements the Datum interface.
+func (d DString) Prev() Datum {
+	panic(d.Type() + ".Prev() not supported")
+}
+
 // Next implements the Datum interface.
 func (d DString) Next() Datum {
 	return DString(roachpb.Key(d).Next())
@@ -319,6 +369,16 @@ func (d DBytes) Compare(other Datum) int {
 		return 1
 	}
 	return 0
+}
+
+// HasPrev implements the Datum interface.
+func (d DBytes) HasPrev() bool {
+	return false
+}
+
+// Prev implements the Datum interface.
+func (d DBytes) Prev() Datum {
+	panic(d.Type() + ".Prev() not supported")
 }
 
 // Next implements the Datum interface.
@@ -368,6 +428,16 @@ func (d DDate) Compare(other Datum) int {
 	return 0
 }
 
+// HasPrev implements the Datum interface.
+func (d DDate) HasPrev() bool {
+	return true
+}
+
+// Prev implements the Datum interface.
+func (d DDate) Prev() Datum {
+	return d - 1
+}
+
 // Next implements the Datum interface.
 func (d DDate) Next() Datum {
 	return d + 1
@@ -414,6 +484,16 @@ func (d DTimestamp) Compare(other Datum) int {
 		return 1
 	}
 	return 0
+}
+
+// HasPrev implements the Datum interface.
+func (d DTimestamp) HasPrev() bool {
+	return true
+}
+
+// Prev implements the Datum interface.
+func (d DTimestamp) Prev() Datum {
+	return DTimestamp{Time: d.Add(-1)}
 }
 
 // Next implements the Datum interface.
@@ -466,6 +546,16 @@ func (d DInterval) Compare(other Datum) int {
 	return 0
 }
 
+// HasPrev implements the Datum interface.
+func (d DInterval) HasPrev() bool {
+	return true
+}
+
+// Prev implements the Datum interface.
+func (d DInterval) Prev() Datum {
+	return DInterval{Duration: d.Duration - 1}
+}
+
 // Next implements the Datum interface.
 func (d DInterval) Next() Datum {
 	return DInterval{Duration: d.Duration + 1}
@@ -516,6 +606,18 @@ func (d DTuple) Compare(other Datum) int {
 		return 1
 	}
 	return 0
+}
+
+// HasPrev implements the Datum interface.
+func (d DTuple) HasPrev() bool {
+	return false
+}
+
+// Prev implements the Datum interface.
+func (d DTuple) Prev() Datum {
+	// We could implement it depending on the constituents of the tuple, but it's
+	// not needed.
+	panic(fmt.Errorf("can't compute Prev() on a tuple"))
 }
 
 // Next implements the Datum interface.
@@ -602,6 +704,16 @@ func (d dNull) Compare(other Datum) int {
 	return -1
 }
 
+// HasPrev implements the Datum interface.
+func (d dNull) HasPrev() bool {
+	return false
+}
+
+// Prev implements the Datum interface.
+func (d dNull) Prev() Datum {
+	panic(fmt.Errorf("cannot compute Prev() on Null"))
+}
+
 // Next implements the Datum interface.
 func (d dNull) Next() Datum {
 	panic("dNull.Next not supported")
@@ -639,6 +751,16 @@ func (DValArg) Type() string {
 // Compare implements the Datum interface.
 func (d DValArg) Compare(other Datum) int {
 	panic(d.Type() + ".Compare not supported")
+}
+
+// HasPrev implements the Datum interface.
+func (d DValArg) HasPrev() bool {
+	return false
+}
+
+// Prev implements the Datum interface.
+func (d DValArg) Prev() Datum {
+	panic(d.Type() + ".Prev not supported")
 }
 
 // Next implements the Datum interface.

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -332,7 +332,7 @@ func (n *scanNode) initScan() bool {
 			// Unique secondary indexes have a value that is the primary index
 			// key. Prepare implicitVals for use in decoding this value.
 			// Primary indexes only contain ascendingly-encoded values. If this
-			// even changes, we'll probably have to figure out the directions here too.
+			// ever changes, we'll probably have to figure out the directions here too.
 			if n.implicitValTypes, n.pErr = makeKeyVals(n.desc, n.index.ImplicitColumnIDs); n.pErr != nil {
 				return false
 			}

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -62,8 +62,8 @@ type qvalMap map[ColumnID]*qvalue
 type colKindMap map[ColumnID]ColumnType_Kind
 
 type span struct {
-	start roachpb.Key
-	end   roachpb.Key
+	start roachpb.Key // inclusive key
+	end   roachpb.Key // exclusive key
 	count int64
 }
 
@@ -130,6 +130,8 @@ type scanNode struct {
 	columns          []column
 	originalCols     []column // copy of `columns` before additions (e.g. by sort or group)
 	columnIDs        []ColumnID
+	// The direction with which the corresponding column was encoded.
+	columnDirs       []encoding.Direction
 	ordering         []int
 	exactPrefix      int
 	pErr             *roachpb.Error
@@ -329,6 +331,8 @@ func (n *scanNode) initScan() bool {
 		if n.isSecondaryIndex && n.index.Unique {
 			// Unique secondary indexes have a value that is the primary index
 			// key. Prepare implicitVals for use in decoding this value.
+			// Primary indexes only contain ascendingly-encoded values. If this
+			// even changes, we'll probably have to figure out the directions here too.
 			if n.implicitValTypes, n.pErr = makeKeyVals(n.desc, n.index.ImplicitColumnIDs); n.pErr != nil {
 				return false
 			}
@@ -395,7 +399,7 @@ func (n *scanNode) initOrdering(exactPrefix int) {
 		return
 	}
 	n.exactPrefix = exactPrefix
-	n.columnIDs = n.index.fullColumnIDs()
+	n.columnIDs, n.columnDirs = n.index.fullColumnIDs()
 	n.ordering = n.computeOrdering(n.columnIDs)
 	if n.reverse {
 		for i := range n.ordering {
@@ -544,7 +548,8 @@ func (n *scanNode) processKV(kv client.KeyValue) bool {
 	}
 
 	var remaining []byte
-	if remaining, n.pErr = decodeIndexKey(n.desc, *n.index, n.valTypes, n.vals, kv.Key); n.pErr != nil {
+	remaining, n.pErr = decodeIndexKey(n.desc, n.index.ID, n.valTypes, n.vals, n.columnDirs, kv.Key)
+	if n.pErr != nil {
 		return false
 	}
 
@@ -566,7 +571,7 @@ func (n *scanNode) processKV(kv client.KeyValue) bool {
 	if !n.isSecondaryIndex && len(remaining) > 0 {
 		var v uint64
 		var err error
-		_, v, err = encoding.DecodeUvarint(remaining)
+		_, v, err = encoding.DecodeUvarintAscending(remaining)
 		n.pErr = roachpb.NewError(err)
 		if n.pErr != nil {
 			return false
@@ -591,7 +596,12 @@ func (n *scanNode) processKV(kv client.KeyValue) bool {
 		}
 	} else {
 		if n.implicitVals != nil {
-			if _, n.pErr = decodeKeyVals(n.implicitValTypes, n.implicitVals, kv.ValueBytes()); n.pErr != nil {
+			implicitDirs := make([]encoding.Direction, 0, len(n.index.ImplicitColumnIDs))
+			for range n.index.ImplicitColumnIDs {
+				implicitDirs = append(implicitDirs, encoding.Ascending)
+			}
+			if _, n.pErr = decodeKeyVals(
+				n.implicitValTypes, n.implicitVals, implicitDirs, kv.ValueBytes()); n.pErr != nil {
 				return false
 			}
 			for i, id := range n.index.ImplicitColumnIDs {

--- a/sql/select.go
+++ b/sql/select.go
@@ -267,7 +267,7 @@ func (p *planner) selectIndex(s *scanNode, group *groupNode, sort *sortNode) (pl
 	c := candidates[0]
 	s.index = c.index
 	s.isSecondaryIndex = (c.index != &s.desc.PrimaryIndex)
-	s.spans = makeSpans(c.constraints, c.desc.ID, c.index.ID)
+	s.spans = makeSpans(c.constraints, c.desc.ID, c.index)
 	if len(s.spans) == 0 {
 		// There are no spans to scan.
 		s.desc = nil
@@ -337,6 +337,10 @@ func (c indexConstraint) String() string {
 	return buf.String()
 }
 
+// indexConstraints is a set of constraints on a prefix of the columns
+// in a single index. The constraints are ordered as the columns in the index.
+// A constraint referencing a tuple accounts for several columns (the size of
+// its .tupleMap).
 type indexConstraints []indexConstraint
 
 func (c indexConstraints) String() string {
@@ -407,7 +411,8 @@ func (v *indexInfo) analyzeOrdering(scan *scanNode, ordering []int) {
 	v.exactPrefix = exactPrefix(v.constraints)
 
 	// Compute the ordering provided by the index.
-	indexOrdering := scan.computeOrdering(v.index.fullColumnIDs())
+	colIds, _ := v.index.fullColumnIDs()
+	indexOrdering := scan.computeOrdering(colIds)
 
 	// Compute how much of the index ordering matches the requested ordering for
 	// both forward and reverse scans.
@@ -441,6 +446,9 @@ func (v *indexInfo) analyzeOrdering(scan *scanNode, ordering []int) {
 // have the constraints:
 //
 //   {a: {start: > 1}}
+//   !!! this is not true, and there's even a test about showing constraints for
+//   both a and b. Probably because this function never gets ">". Simplification
+//   turns it into ">=". The function could assert that?
 //
 // Why is there no constraint on "b"? Because the start constraint was > and
 // such a constraint does not allow us to consider further columns in the
@@ -451,6 +459,16 @@ func (v *indexInfo) analyzeOrdering(scan *scanNode, ordering []int) {
 // Start constraints look for comparison expressions with the operators >, >=,
 // = or IN. End constraints look for comparison expressions with the operators
 // <, <=, = or IN.
+//
+// Attention: The generated constraints do not take into consideration the
+// ordering of the encoding of the columns in the index.
+//
+// This method generates one indexConstraint for a prefix of the columns in
+// the index (except for tuple constraints which can account for more than
+// one column). A prefix of the generated constraints has a .start, and
+// similarly a prefix of the contraints has a .end); in other words,
+// once a constraint doesn't have a .start, no further constraints will
+// have one. This is because they wouldn't be useful when generating spans.
 func (v *indexInfo) makeConstraints(exprs []parser.Exprs) {
 	if len(exprs) != 1 {
 		return
@@ -596,6 +614,9 @@ func (v *indexInfo) makeConstraints(exprs []parser.Exprs) {
 			endDone = true
 		}
 		if startDone && endDone {
+			// The rest of the expressions don't matter; when we'll construct index spans
+			// based on these constraints we won't be able to accumulate more in either
+			// the start key prefix nor the end key prefix.
 			break
 		}
 	}
@@ -638,21 +659,30 @@ func (v indexInfoByCost) Sort() {
 }
 
 // makeSpans constructs the spans for an index given a set of constraints.
-func makeSpans(constraints indexConstraints, tableID ID, indexID IndexID) []span {
-	prefix := roachpb.Key(MakeIndexKeyPrefix(tableID, indexID))
+//
+// The spans will be constructed by iterating over the constraints (and implicitly
+// over the index columns) - each constraint contributes to a value to the column's
+// slot in each span.
+func makeSpans(constraints indexConstraints, tableID ID, index *IndexDescriptor) []span {
+	prefix := roachpb.Key(MakeIndexKeyPrefix(tableID, index.ID))
 	spans := []span{{
 		start: append(roachpb.Key(nil), prefix...),
 		end:   append(roachpb.Key(nil), prefix...),
 	}}
 	var buf [100]byte
 
+	colIdx := -1 // The column that the current constraint refers to.
 	for i, c := range constraints {
+		colIdx++
 		// Is this the last end constraint? We perform special processing on the
 		// last end constraint to account for the exclusive nature of the scan end
 		// key.
 		lastEnd := c.end != nil &&
 			(i+1 == len(constraints) || constraints[i+1].end == nil)
 
+		// Special handling of IN exprssions. Such expressions apply to both the
+		// start and end key, but also cause an explosion in the number of spans
+		// searched within an index.
 		if (c.start != nil && c.start.Operator == parser.In) ||
 			(c.end != nil && c.end.Operator == parser.In) {
 			var e *parser.ComparisonExpr
@@ -662,9 +692,6 @@ func makeSpans(constraints indexConstraints, tableID ID, indexID IndexID) []span
 				e = c.end
 			}
 
-			// Special handling of IN exprssions. Such expressions apply to both the
-			// start and end key, but also cause an explosion in the number of spans
-			// searched within an index.
 			tuple, ok := e.Right.(parser.DTuple)
 			if !ok {
 				break
@@ -680,38 +707,55 @@ func makeSpans(constraints indexConstraints, tableID ID, indexID IndexID) []span
 				switch t := datum.(type) {
 				case parser.DTuple:
 					start = buf[:0]
-					for _, i := range c.tupleMap {
+					for i, tupleIdx := range c.tupleMap {
+						var dir encoding.Direction
+						var err error
+						if dir, err = index.ColumnDirections[colIdx+i].toEncodingDirection(); err != nil {
+							panic(err)
+						}
 						var pErr *roachpb.Error
-						if start, pErr = encodeTableKey(start, t[i]); pErr != nil {
-							panic(pErr)
+						if start, pErr = encodeTableKey(start, t[tupleIdx], dir); pErr != nil {
+							panic(err)
 						}
 					}
 
+					// Even though the end key is exclusive, we can use start as part of
+					// the end key. We'll take care later to append something to make the
+					// exclusion work.
 					end = start
 					if lastEnd {
 						end = nil
-						for i := range c.tupleMap {
-							d := t[c.tupleMap[i]]
+						for i, tupleIdx := range c.tupleMap {
+							d := t[tupleIdx]
 							if i+1 == len(c.tupleMap) {
 								d = d.Next()
 							}
+							var dir encoding.Direction
+							var err error
+							if dir, err = index.ColumnDirections[colIdx+i].toEncodingDirection(); err != nil {
+								panic(err)
+							}
 							var pErr *roachpb.Error
-							if end, pErr = encodeTableKey(end, d); pErr != nil {
+							if end, pErr = encodeTableKey(end, d, dir); pErr != nil {
 								panic(pErr)
 							}
 						}
 					}
-
 				default:
+					var dir encoding.Direction
+					var err error
+					if dir, err = index.ColumnDirections[colIdx].toEncodingDirection(); err != nil {
+						panic(err)
+					}
 					var pErr *roachpb.Error
-					if start, pErr = encodeTableKey(buf[:0], datum); pErr != nil {
+					if start, pErr = encodeTableKey(buf[:0], datum, dir); pErr != nil {
 						panic(pErr)
 					}
 
 					end = start
 					if lastEnd {
 						var pErr *roachpb.Error
-						if end, pErr = encodeTableKey(nil, datum.Next()); pErr != nil {
+						if end, pErr = encodeTableKey(nil, datum.Next(), dir); pErr != nil {
 							panic(pErr)
 						}
 					}
@@ -728,7 +772,28 @@ func makeSpans(constraints indexConstraints, tableID ID, indexID IndexID) []span
 				}
 			}
 
+			// Skip over the columns covered by the tuple.
+			colIdx += len(c.tupleMap) - 1
 			continue
+		}
+
+		var dir encoding.Direction
+		var err error
+		if dir, err = index.ColumnDirections[colIdx].toEncodingDirection(); err != nil {
+			panic(err)
+		}
+
+		// If the column direction in the index is Descending, we need to invert
+		// the start and end constraints. But rather than switching the
+		// constraints, it's easier code-wise to just switch the start and end
+		// keys.
+		var startKey, endKey *roachpb.Key
+		if dir == encoding.Ascending {
+			startKey = &spans[i].start
+			endKey = &spans[i].end
+		} else {
+			startKey = &spans[i].end
+			endKey = &spans[i].start
 		}
 
 		if c.start != nil {
@@ -737,18 +802,22 @@ func makeSpans(constraints indexConstraints, tableID ID, indexID IndexID) []span
 			case parser.NE, parser.IsNot:
 				// A != or IS NOT NULL expression allows us to constrain the start of
 				// the range to not include NULL.
-				for i := range spans {
-					spans[i].start = encoding.EncodeNotNull(spans[i].start)
+				for range spans {
+					if dir == encoding.Ascending {
+						*startKey = encoding.EncodeNotNullAscending(*startKey)
+					} else {
+						*startKey = encoding.EncodeNotNullDescending(*startKey)
+					}
 				}
 			default:
 				if datum, ok := c.start.Right.(parser.Datum); ok {
-					key, pErr := encodeTableKey(buf[:0], datum)
+					key, pErr := encodeTableKey(buf[:0], datum, dir)
 					if pErr != nil {
-						panic(pErr)
+						panic(err)
 					}
 					// Append the constraint to all of the existing spans.
-					for i := range spans {
-						spans[i].start = append(spans[i].start, key...)
+					for range spans {
+						*startKey = append(*startKey, key...)
 					}
 				}
 			}
@@ -758,31 +827,41 @@ func makeSpans(constraints indexConstraints, tableID ID, indexID IndexID) []span
 			// We have an end constraint.
 			switch c.end.Operator {
 			case parser.Is:
-				// An IS NULL expressions allows us to constrain the end of the range
-				// to stop at NULL.
-				for i := range spans {
-					spans[i].end = encoding.EncodeNotNull(spans[i].end)
+				// makeConstraints() only passes along IS NULL expressions as end expressions.
+				// These allow us to constrain the end of the range to stop at NULL.
+				for range spans {
+					if dir == encoding.Ascending {
+						*endKey = encoding.EncodeNotNullAscending(*endKey)
+					} else {
+						*endKey = encoding.EncodeNotNullDescending(*endKey)
+					}
 				}
 			default:
 				if datum, ok := c.end.Right.(parser.Datum); ok {
 					if lastEnd && c.end.Operator != parser.LT {
 						datum = datum.Next()
 					}
-					key, pErr := encodeTableKey(buf[:0], datum)
+					key, pErr := encodeTableKey(buf[:0], datum, dir)
 					if pErr != nil {
-						panic(pErr)
+						panic(err)
 					}
 					// Append the constraint to all of the existing spans.
-					for i := range spans {
-						spans[i].end = append(spans[i].end, key...)
+					for range spans {
+						*endKey = append(*endKey, key...)
 					}
 				}
 
 				if c.start == nil && (i == 0 || constraints[i-1].start != nil) {
 					// This is the first constraint for which we don't have a start
-					// constraint. Add a not-NULL endpoint.
-					for i := range spans {
-						spans[i].start = encoding.EncodeNotNull(spans[i].start)
+					// constraint. Add a not-NULL start-point.
+					// TODO(andrei): add this start-point to all the subsequent columns
+					// with an end constraint.
+					for range spans {
+						if dir == encoding.Ascending {
+							*startKey = encoding.EncodeNotNullAscending(*startKey)
+						} else {
+							*startKey = encoding.EncodeNotNullDescending(*startKey)
+						}
 					}
 				}
 			}

--- a/sql/select.go
+++ b/sql/select.go
@@ -388,7 +388,9 @@ func (v *indexInfo) init(s *scanNode) {
 // analyzeExprs examines the range map to determine the cost of using the
 // index.
 func (v *indexInfo) analyzeExprs(exprs []parser.Exprs) {
-	v.makeConstraints(exprs)
+	if err := v.makeConstraints(exprs); err != nil {
+		panic(err)
+	}
 
 	// Count the number of elements used to limit the start and end keys. We then
 	// boost the cost by what fraction of the index keys are being used. The
@@ -441,46 +443,77 @@ func (v *indexInfo) analyzeOrdering(scan *scanNode, ordering []int) {
 
 // makeConstraints populates the indexInfo.constraints field based on the
 // analyzed expressions. The constraints are a start and end expressions for a
-// prefix of the columns that make up the index. For example, consider an index
-// on the columns (a, b, c). For the expressions "a > 1 AND b > 2" we would
-// have the constraints:
+// prefix of the columns that make up the index. For example, consider
+// the expression "a >= 1 AND b >= 2":
 //
-//   {a: {start: > 1}}
-//   !!! this is not true, and there's even a test about showing constraints for
-//   both a and b. Probably because this function never gets ">". Simplification
-//   turns it into ">=". The function could assert that?
-//
-// Why is there no constraint on "b"? Because the start constraint was > and
-// such a constraint does not allow us to consider further columns in the
-// index. What about the expression "a >= 1 AND b > 2":
-//
-//   {a: {start: >= 1}, b: {start: > 2}}
-//
-// Start constraints look for comparison expressions with the operators >, >=,
-// = or IN. End constraints look for comparison expressions with the operators
-// <, <=, = or IN.
-//
-// Attention: The generated constraints do not take into consideration the
-// ordering of the encoding of the columns in the index.
+//   {a: {start: >= 1}, b: {start: >= 2}}
 //
 // This method generates one indexConstraint for a prefix of the columns in
 // the index (except for tuple constraints which can account for more than
 // one column). A prefix of the generated constraints has a .start, and
-// similarly a prefix of the contraints has a .end); in other words,
+// similarly a prefix of the contraints has a .end (in other words,
 // once a constraint doesn't have a .start, no further constraints will
-// have one. This is because they wouldn't be useful when generating spans.
-func (v *indexInfo) makeConstraints(exprs []parser.Exprs) {
+// have one). This is because they wouldn't be useful when generating spans.
+//
+// makeConstraints takes into account the direction of the columns in the index.
+// For ascending cols, start constraints look for comparison expressions with the
+// operators >=, = or IN and end constraints look for comparison expressions
+// with the operators <, <=, = or IN. Vice versa for descending cols.
+//
+// Whenever possible, < and > are converted to <= and >=, respectively.
+// This is because we can use inclusive constraints better than exclusive ones;
+// with inclusive constraints we can continue accumulate constraints for
+// next columns. Not so with exclusive ones: Consider "a < 1 AND b < 2".
+// "a < 1" will be encoded as an exclusive span end; if we were to append
+// anything about "b" to it, that would be incorrect.
+// Note that it's not always possible to transform "<" to "<=", because some
+// types do not support the Prev() operation.
+// So, the resulting constraints will never contain ">". They might contain
+// "<", in which case that will be the last constraint with `.end` filled.
+//
+// TODO(pmattis): It would be more obvious to perform this transform in
+// simplifyComparisonExpr, but doing so there eliminates some of the other
+// simplifications. For example, "a < 1 OR a > 1" currently simplifies to "a !=
+// 1", but if we performed this transform in simpilfyComparisonExpr it would
+// simplify to "a < 1 OR a >= 2" which is also the same as "a != 1", but not so
+// obvious based on comparisons of the constants.
+func (v *indexInfo) makeConstraints(exprs []parser.Exprs) error {
 	if len(exprs) != 1 {
-		return
+		// TODO(andrei): what should we do with ORs?
+		return nil
 	}
 
 	andExprs := exprs[0]
-	startDone := false
-	endDone := false
+	trueStartDone := false
+	trueEndDone := false
 
 	for i := 0; i < len(v.index.ColumnIDs); i++ {
 		colID := v.index.ColumnIDs[i]
+		var colDir encoding.Direction
+		var err error
+		if colDir, err = v.index.ColumnDirections[i].toEncodingDirection(); err != nil {
+			return err
+		}
+
 		var constraint indexConstraint
+		// We're going to fill in that start and end of the constraint
+		// by indirection, which keeps in mind the direction of the
+		// column's encoding in the index.
+		// This allows us to produce direction-aware constraints, but
+		// still have the code below be intuitive (e.g. treat ">" always as
+		// a start constraint).
+		startExpr := &constraint.start
+		endExpr := &constraint.end
+		startDone := &trueStartDone
+		endDone := &trueEndDone
+		if colDir == encoding.Descending {
+			// For descending index cols, c.start is an end constraint
+			// and c.end is a start constraint.
+			startExpr = &constraint.end
+			endExpr = &constraint.start
+			startDone = &trueEndDone
+			endDone = &trueStartDone
+		}
 
 		for _, e := range andExprs {
 			if c, ok := e.(*parser.ComparisonExpr); ok {
@@ -512,6 +545,7 @@ func (v *indexInfo) makeConstraints(exprs []parser.Exprs) {
 						// This tuple does not contain the column we're looking for.
 						continue
 					}
+					// Skip all the next columns covered by this tuple.
 					i += (len(tupleMap) - 1)
 				}
 
@@ -525,18 +559,26 @@ func (v *indexInfo) makeConstraints(exprs []parser.Exprs) {
 
 				switch c.Operator {
 				case parser.EQ:
-					if !startDone {
-						constraint.start = c
+					// An equality constraint will overwrite any other type
+					// of constraint.
+					if !*startDone {
+						*startExpr = c
 					}
-					if !endDone {
-						constraint.end = c
+					if !*endDone {
+						*endExpr = c
 					}
 				case parser.NE:
-					// Note that makeSpans treats "a != x" the same as "a IS NOT
-					// NULL". We don't simplify "a != x" to "a IS NOT NULL" in
+					// We rewrite "a != x" to "a IS NOT NULL", since this is all that
+					// makeSpans() cares about.
+					// We don't simplify "a != x" to "a IS NOT NULL" in
 					// simplifyExpr because doing so affects other simplifications.
-					if !startDone {
-						constraint.start = c
+					if *startDone || *startExpr != nil {
+						continue
+					}
+					*startExpr = &parser.ComparisonExpr{
+						Operator: parser.IsNot,
+						Left:     c.Left,
+						Right:    parser.DNull,
 					}
 				case parser.In:
 					// Only allow the IN constraint if the previous constraints are all
@@ -545,81 +587,117 @@ func (v *indexInfo) makeConstraints(exprs []parser.Exprs) {
 					// 2)]. This would turn into the spans /1/1-/3/2 and /1/2-/3/3.
 					ok := true
 					for _, c := range v.constraints {
-						ok = c.start == c.end && c.start.Operator == parser.EQ
-						if !ok {
-							break
-						}
+						ok = ok && (c.start == c.end) && (c.start.Operator == parser.EQ)
 					}
 					if !ok {
 						continue
 					}
 
-					if !startDone && (constraint.start == nil || constraint.start.Operator != parser.EQ) {
-						constraint.start = c
+					if !*startDone && (*startExpr == nil || (*startExpr).Operator != parser.EQ) {
+						*startExpr = c
 						constraint.tupleMap = tupleMap
 					}
-					if !endDone && (constraint.end == nil || constraint.end.Operator != parser.EQ) {
-						constraint.end = c
+					if !*endDone && (*endExpr == nil || (*endExpr).Operator != parser.EQ) {
+						*endExpr = c
 						constraint.tupleMap = tupleMap
 					}
-				case parser.GT, parser.GE:
-					if !startDone && constraint.start == nil {
-						constraint.start = c
+				case parser.GE:
+					if !*startDone && *startExpr == nil {
+						*startExpr = c
 					}
-				case parser.LT, parser.LE:
-					if !endDone && constraint.end == nil {
-						constraint.end = c
+				case parser.GT:
+					// Transform ">" into ">=".
+					if *startDone || (*startExpr != nil) {
+						continue
+					}
+					if c.Right.(parser.Datum).IsMax() {
+						*startExpr = &parser.ComparisonExpr{
+							Operator: parser.EQ,
+							Left:     c.Left,
+							Right:    c.Right,
+						}
+					} else {
+						*startExpr = &parser.ComparisonExpr{
+							Operator: parser.GE,
+							Left:     c.Left,
+							Right:    c.Right.(parser.Datum).Next(),
+						}
+					}
+				case parser.LT:
+					if *endDone || (*endExpr != nil) {
+						continue
+					}
+					// Transform "<" into "<=".
+					if c.Right.(parser.Datum).IsMin() {
+						*endExpr = &parser.ComparisonExpr{
+							Operator: parser.EQ,
+							Left:     c.Left,
+							Right:    c.Right,
+						}
+					} else if c.Right.(parser.Datum).HasPrev() {
+						*endExpr = &parser.ComparisonExpr{
+							Operator: parser.LE,
+							Left:     c.Left,
+							Right:    c.Right.(parser.Datum).Prev(),
+						}
+					} else {
+						*endExpr = c
+					}
+				case parser.LE:
+					if !*endDone && *endExpr == nil {
+						*endExpr = c
 					}
 				case parser.Is:
-					if c.Right == parser.DNull && !endDone {
-						constraint.end = c
+					if c.Right == parser.DNull && !*endDone {
+						*endExpr = c
 					}
 				case parser.IsNot:
-					if c.Right == parser.DNull && !startDone {
-						constraint.start = c
+					if c.Right == parser.DNull && !*startDone && (*startExpr == nil) {
+						*startExpr = c
 					}
 				}
 			}
 		}
 
-		if constraint.start != nil && constraint.start.Operator == parser.GT {
-			// Transform a > constraint into a >= constraint so that we play
-			// nicer with the inclusive nature of the scan start key.
-			//
-			// TODO(pmattis): It would be more obvious to perform this
-			// transform in simplifyComparisonExpr, but doing so there
-			// eliminates some of the other simplifications. For example, "a <
-			// 1 OR a > 1" currently simplifies to "a != 1", but if we
-			// performed this transform in simpilfyComparisonExpr it would
-			// simplify to "a < 1 OR a >= 2" which is also the same as "a !=
-			// 1", but not so obvious based on comparisons of the constants.
-			constraint.start = &parser.ComparisonExpr{
-				Operator: parser.GE,
-				Left:     constraint.start.Left,
-				Right:    constraint.start.Right.(parser.Datum).Next(),
+		if *endExpr != nil && (*endExpr).Operator == parser.LT {
+			*endDone = true
+		}
+
+		if !*startDone && *startExpr == nil {
+			// Add an IS NOT NULL constraint if there's an end constraint.
+			if (*endExpr != nil) &&
+				!((*endExpr).Operator == parser.Is && (*endExpr).Right == parser.DNull) {
+				*startExpr = &parser.ComparisonExpr{
+					Operator: parser.IsNot,
+					Left:     (*endExpr).Left,
+					Right:    parser.DNull,
+				}
 			}
 		}
-		if constraint.end != nil && constraint.end.Operator == parser.LT {
-			endDone = true
+
+		if (*startExpr == nil) ||
+			(((*startExpr).Operator == parser.IsNot) && ((*startExpr).Right == parser.DNull)) {
+			// There's no point in allowing future start constraints after an IS NOT NULL
+			// one; since NOT NULL is not actually a value present in an index,
+			// values encoded after an NOT NULL don't matter.
+			*startDone = true
 		}
 
 		if constraint.start != nil || constraint.end != nil {
 			v.constraints = append(v.constraints, constraint)
 		}
 
-		if constraint.start == nil {
-			startDone = true
+		if *endExpr == nil {
+			*endDone = true
 		}
-		if constraint.end == nil {
-			endDone = true
-		}
-		if startDone && endDone {
-			// The rest of the expressions don't matter; when we'll construct index spans
+		if *startDone && *endDone {
+			// The rest of the expressions don't matter; when we construct index spans
 			// based on these constraints we won't be able to accumulate more in either
 			// the start key prefix nor the end key prefix.
 			break
 		}
 	}
+	return nil
 }
 
 // isCoveringIndex returns true if all of the columns referenced by the target
@@ -658,216 +736,308 @@ func (v indexInfoByCost) Sort() {
 	sort.Sort(v)
 }
 
-// makeSpans constructs the spans for an index given a set of constraints.
+func encodeStartConstraintAscending(spans []span, c *parser.ComparisonExpr) {
+	switch c.Operator {
+	case parser.IsNot:
+		// A IS NOT NULL expression allows us to constrain the start of
+		// the range to not include NULL.
+		for i := range spans {
+			spans[i].start = encoding.EncodeNotNullAscending(spans[i].start)
+		}
+	case parser.GT:
+		panic("'>' operators should have been transformed to '>='.")
+	case parser.NE:
+		panic("'!=' operators should have been transformed to 'IS NOT NULL'")
+	default:
+		if datum, ok := c.Right.(parser.Datum); ok {
+			key, err := encodeTableKey(nil, datum, encoding.Ascending)
+			if err != nil {
+				panic(err)
+			}
+			// Append the constraint to all of the existing spans.
+			for i := range spans {
+				spans[i].start = append(spans[i].start, key...)
+			}
+		}
+	}
+}
+
+func encodeEndConstraintAscending(spans []span, c *parser.ComparisonExpr,
+	isLastEndConstraint bool) {
+	switch c.Operator {
+	case parser.Is:
+		// An IS NULL expressions allows us to constrain the end of the range
+		// to stop at NULL.
+		if c.Right != parser.DNull {
+			panic("Expected NULL operand for IS operator.")
+		}
+		for i := range spans {
+			spans[i].end = encoding.EncodeNotNullAscending(spans[i].end)
+		}
+	default:
+		if datum, ok := c.Right.(parser.Datum); ok {
+			if c.Operator != parser.LT {
+				for i := range spans {
+					spans[i].end = encodeInclusiveEndValue(
+						spans[i].end, datum, encoding.Ascending, isLastEndConstraint)
+				}
+				break
+			}
+			if !isLastEndConstraint {
+				panic("Can't have other end constraints after a '<' constraint.")
+			}
+			key, err := encodeTableKey(nil, datum, encoding.Ascending)
+			if err != nil {
+				panic(err)
+			}
+			// Append the constraint to all of the existing spans.
+			for i := range spans {
+				spans[i].end = append(spans[i].end, key...)
+			}
+		}
+	}
+}
+
+func encodeStartConstraintDescending(
+	spans []span, c *parser.ComparisonExpr) {
+	switch c.Operator {
+	case parser.Is:
+		// An IS NULL expressions allows us to constrain the start of the range
+		// to begin at NULL.
+		if c.Right != parser.DNull {
+			panic("Expected NULL operand for IS operator.")
+		}
+		for i := range spans {
+			spans[i].start = encoding.EncodeNullDescending(spans[i].start)
+		}
+	case parser.LE, parser.EQ:
+		if datum, ok := c.Right.(parser.Datum); ok {
+			key, pErr := encodeTableKey(nil, datum, encoding.Descending)
+			if pErr != nil {
+				panic(pErr)
+			}
+			// Append the constraint to all of the existing spans.
+			for i := range spans {
+				spans[i].start = append(spans[i].start, key...)
+			}
+		}
+	case parser.LT:
+		// A "<" constraint is the last start constraint. Since the constraint
+		// is exclusive and the start key is inclusive, we're going to apply
+		// a .PrefixEnd().
+		if datum, ok := c.Right.(parser.Datum); ok {
+			key, pErr := encodeTableKey(nil, datum, encoding.Descending)
+			if pErr != nil {
+				panic(pErr)
+			}
+			// Append the constraint to all of the existing spans.
+			for i := range spans {
+				spans[i].start = append(spans[i].start, key...)
+				spans[i].start = spans[i].start.PrefixEnd()
+			}
+		}
+	default:
+		panic(fmt.Errorf("unexpected operator: %s", c.String()))
+	}
+}
+
+func encodeEndConstraintDescending(spans []span, c *parser.ComparisonExpr,
+	isLastEndConstraint bool) {
+	switch c.Operator {
+	case parser.IsNot:
+		// An IS NULL expressions allows us to constrain the end of the range
+		// to stop at NULL.
+		if c.Right != parser.DNull {
+			panic("Expected NULL operand for IS NOT operator.")
+		}
+		for i := range spans {
+			spans[i].end = encoding.EncodeNotNullDescending(spans[i].end)
+		}
+	case parser.GE, parser.EQ:
+		datum := c.Right.(parser.Datum)
+		for i := range spans {
+			spans[i].end = encodeInclusiveEndValue(
+				spans[i].end, datum, encoding.Descending, isLastEndConstraint)
+		}
+	case parser.GT:
+		panic("'>' operators should have been transformed to '>='.")
+	default:
+		panic(fmt.Errorf("unexpected operator: %s", c.String()))
+	}
+}
+
+// Encodes datum at the end of key, using direction `dir` for the encoding.
+// The key is a span end key, which is exclusive, but `val` needs to
+// be inclusive. So if datum is the last end constraint, we transform it accordingly.
+func encodeInclusiveEndValue(
+	key roachpb.Key, datum parser.Datum, dir encoding.Direction,
+	isLastEndConstraint bool) roachpb.Key {
+	// Since the end of a span is exclusive, if the last constraint is an
+	// inclusive one, we might need to make the key exclusive by applying a
+	// PrefixEnd().  We normally avoid doing this by transforming "a = x" to
+	// "a = x±1" for the last end constraint, depending on the encoding direction
+	// (since this keeps the key nice and pretty-printable).
+	// However, we might not be able to do the ±1.
+	needExclusiveKey := false
+	if isLastEndConstraint {
+		if dir == encoding.Ascending {
+			if datum.IsMax() {
+				needExclusiveKey = true
+			} else {
+				datum = datum.Next()
+			}
+		} else {
+			if datum.IsMin() || !datum.HasPrev() {
+				needExclusiveKey = true
+			} else {
+				datum = datum.Prev()
+			}
+		}
+	}
+	key, pErr := encodeTableKey(key, datum, dir)
+	if pErr != nil {
+		panic(pErr)
+	}
+	if needExclusiveKey {
+		key = key.PrefixEnd()
+	}
+	return key
+}
+
+// Splits spans according to a constraint like (...) in <tuple>.
+// If the constraint is (a,b) IN ((1,2),(3,4)), each input span
+// will be split into two: the first one will have "1/2" appended to
+// the start and/or end, the second one will have "3/4" appended to
+// the start and/or end.
 //
-// The spans will be constructed by iterating over the constraints (and implicitly
-// over the index columns) - each constraint contributes to a value to the column's
-// slot in each span.
-func makeSpans(constraints indexConstraints, tableID ID, index *IndexDescriptor) []span {
+// Returns the exploded spans and the number of index columns covered
+// by this constraint (i.e. 1, if the left side is a qvalue or
+// len(tupleMap) if it's a tuple).
+func applyInConstraint(spans []span, c indexConstraint, firstCol int,
+	index *IndexDescriptor, isLastEndConstraint bool) ([]span, int) {
+	var e *parser.ComparisonExpr
+	var coveredColumns int
+	// It might be that the IN constraint is a start constraint, an
+	// end constraint, or both, depending on how whether we had
+	// start and end constraints for all the previous index cols.
+	if c.start != nil && c.start.Operator == parser.In {
+		e = c.start
+	} else {
+		e = c.end
+	}
+	tuple := e.Right.(parser.DTuple)
+	existingSpans := spans
+	spans = make([]span, 0, len(existingSpans)*len(tuple))
+	for _, datum := range tuple {
+		// start and end will accumulate the end constraint for
+		// the current element of the tuple.
+		var start, end []byte
+
+		switch t := datum.(type) {
+		case parser.DTuple:
+			// The constraint is a tuple of tuples, meaning something like
+			// (...) IN ((1,2),(3,4)).
+			coveredColumns = len(c.tupleMap)
+			for j, tupleIdx := range c.tupleMap {
+				var err error
+				var colDir encoding.Direction
+				if colDir, err = index.ColumnDirections[firstCol+j].toEncodingDirection(); err != nil {
+					panic(err)
+				}
+
+				var pErr *roachpb.Error
+				if start, pErr = encodeTableKey(start, t[tupleIdx], colDir); pErr != nil {
+					panic(pErr)
+				}
+				end = encodeInclusiveEndValue(
+					end, t[tupleIdx], colDir, isLastEndConstraint && (j == len(c.tupleMap)-1))
+			}
+		default:
+			// The constraint is a tuple of values, meaning something like
+			// a IN (1,2).
+			var colDir encoding.Direction
+			var err error
+			if colDir, err = index.ColumnDirections[firstCol].toEncodingDirection(); err != nil {
+				panic(err)
+			}
+			coveredColumns = 1
+			var pErr *roachpb.Error
+			if start, pErr = encodeTableKey(nil, datum, colDir); pErr != nil {
+				panic(pErr)
+			}
+
+			end = encodeInclusiveEndValue(nil, datum, colDir, isLastEndConstraint)
+			// TODO(andrei): assert here that we end is not \xff\xff...
+			// encodeInclusiveEndValue sometimes calls key.PrefixEnd(),
+			// which doesn't work if the input is \xff\xff... However,
+			// that shouldn't happen: datum should not have that encoding.
+		}
+		for _, s := range existingSpans {
+			if c.start != nil {
+				s.start = append(append(roachpb.Key(nil), s.start...), start...)
+			}
+			if c.end != nil {
+				s.end = append(append(roachpb.Key(nil), s.end...), end...)
+			}
+			spans = append(spans, s)
+		}
+	}
+	return spans, coveredColumns
+}
+
+// makeSpans constructs the spans for an index given a set of constraints.
+func makeSpans(constraints indexConstraints,
+	tableID ID, index *IndexDescriptor) []span {
 	prefix := roachpb.Key(MakeIndexKeyPrefix(tableID, index.ID))
+	// We have one constraint per column, so each contributes something
+	// to the start and/or the end key of the span.
+	// But we also have (...) IN <tuple> constraints that span multiple columns.
+	// These constraints split each span, and that's how we can end up with
+	// multiple spans.
 	spans := []span{{
 		start: append(roachpb.Key(nil), prefix...),
 		end:   append(roachpb.Key(nil), prefix...),
 	}}
-	var buf [100]byte
 
-	colIdx := -1 // The column that the current constraint refers to.
+	colIdx := -1
 	for i, c := range constraints {
 		colIdx++
-		// Is this the last end constraint? We perform special processing on the
-		// last end constraint to account for the exclusive nature of the scan end
-		// key.
-		lastEnd := c.end != nil &&
+		// We perform special processing on the last end constraint to account for
+		// the exclusive nature of the scan end key.
+		lastEnd := (c.end != nil) &&
 			(i+1 == len(constraints) || constraints[i+1].end == nil)
 
-		// Special handling of IN exprssions. Such expressions apply to both the
-		// start and end key, but also cause an explosion in the number of spans
-		// searched within an index.
-		if (c.start != nil && c.start.Operator == parser.In) ||
-			(c.end != nil && c.end.Operator == parser.In) {
-			var e *parser.ComparisonExpr
-			if c.start != nil && c.start.Operator == parser.In {
-				e = c.start
-			} else {
-				e = c.end
-			}
-
-			tuple, ok := e.Right.(parser.DTuple)
-			if !ok {
-				break
-			}
-
-			// For each of the existing spans and for each value in the tuple, create
-			// a new span.
-			existingSpans := spans
-			spans = make([]span, 0, len(existingSpans)*len(tuple))
-			for _, datum := range tuple {
-				var start, end []byte
-
-				switch t := datum.(type) {
-				case parser.DTuple:
-					start = buf[:0]
-					for i, tupleIdx := range c.tupleMap {
-						var dir encoding.Direction
-						var err error
-						if dir, err = index.ColumnDirections[colIdx+i].toEncodingDirection(); err != nil {
-							panic(err)
-						}
-						var pErr *roachpb.Error
-						if start, pErr = encodeTableKey(start, t[tupleIdx], dir); pErr != nil {
-							panic(err)
-						}
-					}
-
-					// Even though the end key is exclusive, we can use start as part of
-					// the end key. We'll take care later to append something to make the
-					// exclusion work.
-					end = start
-					if lastEnd {
-						end = nil
-						for i, tupleIdx := range c.tupleMap {
-							d := t[tupleIdx]
-							if i+1 == len(c.tupleMap) {
-								d = d.Next()
-							}
-							var dir encoding.Direction
-							var err error
-							if dir, err = index.ColumnDirections[colIdx+i].toEncodingDirection(); err != nil {
-								panic(err)
-							}
-							var pErr *roachpb.Error
-							if end, pErr = encodeTableKey(end, d, dir); pErr != nil {
-								panic(pErr)
-							}
-						}
-					}
-				default:
-					var dir encoding.Direction
-					var err error
-					if dir, err = index.ColumnDirections[colIdx].toEncodingDirection(); err != nil {
-						panic(err)
-					}
-					var pErr *roachpb.Error
-					if start, pErr = encodeTableKey(buf[:0], datum, dir); pErr != nil {
-						panic(pErr)
-					}
-
-					end = start
-					if lastEnd {
-						var pErr *roachpb.Error
-						if end, pErr = encodeTableKey(nil, datum.Next(), dir); pErr != nil {
-							panic(pErr)
-						}
-					}
-				}
-
-				for _, s := range existingSpans {
-					if c.start != nil {
-						s.start = append(append(roachpb.Key(nil), s.start...), start...)
-					}
-					if c.end != nil {
-						s.end = append(append(roachpb.Key(nil), s.end...), end...)
-					}
-					spans = append(spans, s)
-				}
-			}
-
-			// Skip over the columns covered by the tuple.
-			colIdx += len(c.tupleMap) - 1
+		// IN is handled separately, since it can affect multiple columns.
+		if ((c.start != nil) && (c.start.Operator == parser.In)) ||
+			((c.end != nil) && (c.end.Operator == parser.IN)) {
+			var coveredCols int
+			spans, coveredCols = applyInConstraint(spans, c, colIdx, index, lastEnd)
+			// Skip over all the columns contained in the tuple.
+			colIdx += coveredCols - 1
 			continue
 		}
-
 		var dir encoding.Direction
 		var err error
 		if dir, err = index.ColumnDirections[colIdx].toEncodingDirection(); err != nil {
 			panic(err)
 		}
-
-		// If the column direction in the index is Descending, we need to invert
-		// the start and end constraints. But rather than switching the
-		// constraints, it's easier code-wise to just switch the start and end
-		// keys.
-		var startKey, endKey *roachpb.Key
-		if dir == encoding.Ascending {
-			startKey = &spans[i].start
-			endKey = &spans[i].end
-		} else {
-			startKey = &spans[i].end
-			endKey = &spans[i].start
-		}
-
 		if c.start != nil {
-			// We have a start constraint.
-			switch c.start.Operator {
-			case parser.NE, parser.IsNot:
-				// A != or IS NOT NULL expression allows us to constrain the start of
-				// the range to not include NULL.
-				for range spans {
-					if dir == encoding.Ascending {
-						*startKey = encoding.EncodeNotNullAscending(*startKey)
-					} else {
-						*startKey = encoding.EncodeNotNullDescending(*startKey)
-					}
-				}
-			default:
-				if datum, ok := c.start.Right.(parser.Datum); ok {
-					key, pErr := encodeTableKey(buf[:0], datum, dir)
-					if pErr != nil {
-						panic(err)
-					}
-					// Append the constraint to all of the existing spans.
-					for range spans {
-						*startKey = append(*startKey, key...)
-					}
-				}
+			if dir == encoding.Ascending {
+				encodeStartConstraintAscending(spans, c.start)
+			} else {
+				encodeStartConstraintDescending(spans, c.start)
 			}
 		}
-
 		if c.end != nil {
-			// We have an end constraint.
-			switch c.end.Operator {
-			case parser.Is:
-				// makeConstraints() only passes along IS NULL expressions as end expressions.
-				// These allow us to constrain the end of the range to stop at NULL.
-				for range spans {
-					if dir == encoding.Ascending {
-						*endKey = encoding.EncodeNotNullAscending(*endKey)
-					} else {
-						*endKey = encoding.EncodeNotNullDescending(*endKey)
-					}
-				}
-			default:
-				if datum, ok := c.end.Right.(parser.Datum); ok {
-					if lastEnd && c.end.Operator != parser.LT {
-						datum = datum.Next()
-					}
-					key, pErr := encodeTableKey(buf[:0], datum, dir)
-					if pErr != nil {
-						panic(err)
-					}
-					// Append the constraint to all of the existing spans.
-					for range spans {
-						*endKey = append(*endKey, key...)
-					}
-				}
-
-				if c.start == nil && (i == 0 || constraints[i-1].start != nil) {
-					// This is the first constraint for which we don't have a start
-					// constraint. Add a not-NULL start-point.
-					// TODO(andrei): add this start-point to all the subsequent columns
-					// with an end constraint.
-					for range spans {
-						if dir == encoding.Ascending {
-							*startKey = encoding.EncodeNotNullAscending(*startKey)
-						} else {
-							*startKey = encoding.EncodeNotNullDescending(*startKey)
-						}
-					}
-				}
+			if dir == encoding.Ascending {
+				encodeEndConstraintAscending(spans, c.end, lastEnd)
+			} else {
+				encodeEndConstraintDescending(spans, c.end, lastEnd)
 			}
 		}
 	}
 
+	// If we had no end constraints, make it so that we scan the whole index.
 	if len(constraints) == 0 || constraints[0].end == nil {
 		for i := range spans {
 			spans[i].end = spans[i].end.PrefixEnd()
@@ -885,7 +1055,6 @@ func makeSpans(constraints indexConstraints, tableID ID, index *IndexDescriptor)
 		}
 	}
 	spans = spans[:n]
-
 	return spans
 }
 

--- a/sql/select_test.go
+++ b/sql/select_test.go
@@ -247,8 +247,9 @@ func TestMakeSpans(t *testing.T) {
 	}
 	for _, d := range testData {
 		desc, index := makeTestIndex(t, d.columns)
+
 		constraints, _ := makeConstraints(t, d.expr, desc, index)
-		spans := makeSpans(constraints, desc.ID, index.ID)
+		spans := makeSpans(constraints, desc.ID, index)
 		if s := prettySpans(spans, 2); d.expected != s {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 		}

--- a/sql/select_test.go
+++ b/sql/select_test.go
@@ -18,13 +18,18 @@ package sql
 
 import (
 	"fmt"
+	"math"
+	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
-func makeTestIndex(t *testing.T, columns []string) (*TableDescriptor, *IndexDescriptor) {
+func makeTestIndex(t *testing.T, columns []string, dirs []encoding.Direction) (
+	*TableDescriptor, *IndexDescriptor) {
 	desc := testTableDesc()
 	desc.Indexes = append(desc.Indexes, IndexDescriptor{
 		Name:        "foo",
@@ -32,8 +37,14 @@ func makeTestIndex(t *testing.T, columns []string) (*TableDescriptor, *IndexDesc
 	})
 	idx := &desc.Indexes[len(desc.Indexes)-1]
 	// Fill in the directions for the columns.
-	for range columns {
-		idx.ColumnDirections = append(idx.ColumnDirections, IndexDescriptor_ASC)
+	for i := range columns {
+		var dir IndexDescriptor_Direction
+		if dirs[i] == encoding.Ascending {
+			dir = IndexDescriptor_ASC
+		} else {
+			dir = IndexDescriptor_DESC
+		}
+		idx.ColumnDirections = append(idx.ColumnDirections, dir)
 	}
 
 	if err := desc.AllocateIDs(); err != nil {
@@ -69,11 +80,11 @@ func TestMakeConstraints(t *testing.T) {
 	}{
 		{`a = 1`, []string{"b"}, `[]`},
 		{`a = 1`, []string{"a"}, `[a = 1]`},
-		{`a != 1`, []string{"a"}, `[a != 1]`},
+		{`a != 1`, []string{"a"}, `[a IS NOT NULL]`},
 		{`a > 1`, []string{"a"}, `[a >= 2]`},
 		{`a >= 1`, []string{"a"}, `[a >= 1]`},
-		{`a < 1`, []string{"a"}, `[a < 1]`},
-		{`a <= 1`, []string{"a"}, `[a <= 1]`},
+		{`a < 1`, []string{"a"}, `[a IS NOT NULL, a <= 0]`},
+		{`a <= 1`, []string{"a"}, `[a IS NOT NULL, a <= 1]`},
 
 		{`a IN (1,2,3)`, []string{"a"}, `[a IN (1, 2, 3)]`},
 		{`a IN (1,2,3) AND b = 1`, []string{"a", "b"}, `[a IN (1, 2, 3), b = 1]`},
@@ -87,53 +98,53 @@ func TestMakeConstraints(t *testing.T) {
 		{`(a, b) IN ((1, 2)) AND a = 1`, []string{"a", "b"}, `[a = 1]`},
 
 		{`a = 1 AND b = 1`, []string{"a", "b"}, `[a = 1, b = 1]`},
-		{`a = 1 AND b != 1`, []string{"a", "b"}, `[a = 1, b != 1]`},
+		{`a = 1 AND b != 1`, []string{"a", "b"}, `[a = 1, b IS NOT NULL]`},
 		{`a = 1 AND b > 1`, []string{"a", "b"}, `[a = 1, b >= 2]`},
 		{`a = 1 AND b >= 1`, []string{"a", "b"}, `[a = 1, b >= 1]`},
-		{`a = 1 AND b < 1`, []string{"a", "b"}, `[a = 1, b < 1]`},
-		{`a = 1 AND b <= 1`, []string{"a", "b"}, `[a = 1, b <= 1]`},
+		{`a = 1 AND b < 1`, []string{"a", "b"}, `[a = 1, b IS NOT NULL, b <= 0]`},
+		{`a = 1 AND b <= 1`, []string{"a", "b"}, `[a = 1, b IS NOT NULL, b <= 1]`},
 
-		{`a != 1 AND b = 1`, []string{"a", "b"}, `[a != 1, b = 1]`},
-		{`a != 1 AND b != 1`, []string{"a", "b"}, `[a != 1, b != 1]`},
-		{`a != 1 AND b > 1`, []string{"a", "b"}, `[a != 1, b >= 2]`},
-		{`a != 1 AND b >= 1`, []string{"a", "b"}, `[a != 1, b >= 1]`},
-		{`a != 1 AND b < 1`, []string{"a", "b"}, `[a != 1]`},
-		{`a != 1 AND b <= 1`, []string{"a", "b"}, `[a != 1]`},
+		{`a != 1 AND b = 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
+		{`a != 1 AND b != 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
+		{`a != 1 AND b > 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
+		{`a != 1 AND b >= 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
+		{`a != 1 AND b < 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
+		{`a != 1 AND b <= 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
 
 		{`a > 1 AND b = 1`, []string{"a", "b"}, `[a >= 2, b = 1]`},
-		{`a > 1 AND b != 1`, []string{"a", "b"}, `[a >= 2, b != 1]`},
+		{`a > 1 AND b != 1`, []string{"a", "b"}, `[a >= 2, b IS NOT NULL]`},
 		{`a > 1 AND b > 1`, []string{"a", "b"}, `[a >= 2, b >= 2]`},
 		{`a > 1 AND b >= 1`, []string{"a", "b"}, `[a >= 2, b >= 1]`},
 		{`a > 1 AND b < 1`, []string{"a", "b"}, `[a >= 2]`},
 		{`a > 1 AND b <= 1`, []string{"a", "b"}, `[a >= 2]`},
 
 		{`a >= 1 AND b = 1`, []string{"a", "b"}, `[a >= 1, b = 1]`},
-		{`a >= 1 AND b != 1`, []string{"a", "b"}, `[a >= 1, b != 1]`},
+		{`a >= 1 AND b != 1`, []string{"a", "b"}, `[a >= 1, b IS NOT NULL]`},
 		{`a >= 1 AND b > 1`, []string{"a", "b"}, `[a >= 1, b >= 2]`},
 		{`a >= 1 AND b >= 1`, []string{"a", "b"}, `[a >= 1, b >= 1]`},
 		{`a >= 1 AND b < 1`, []string{"a", "b"}, `[a >= 1]`},
 		{`a >= 1 AND b <= 1`, []string{"a", "b"}, `[a >= 1]`},
 
-		{`a < 1 AND b = 1`, []string{"a", "b"}, `[a < 1]`},
-		{`a < 1 AND b != 1`, []string{"a", "b"}, `[a < 1]`},
-		{`a < 1 AND b > 1`, []string{"a", "b"}, `[a < 1]`},
-		{`a < 1 AND b >= 1`, []string{"a", "b"}, `[a < 1]`},
-		{`a < 1 AND b < 1`, []string{"a", "b"}, `[a < 1]`},
-		{`a < 1 AND b <= 1`, []string{"a", "b"}, `[a < 1]`},
+		{`a < 1 AND b = 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0, b = 1]`},
+		{`a < 1 AND b != 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0]`},
+		{`a < 1 AND b > 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0]`},
+		{`a < 1 AND b >= 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0]`},
+		{`a < 1 AND b < 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0, b <= 0]`},
+		{`a < 1 AND b <= 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0, b <= 1]`},
 
-		{`a <= 1 AND b = 1`, []string{"a", "b"}, `[a <= 1, b = 1]`},
-		{`a <= 1 AND b != 1`, []string{"a", "b"}, `[a <= 1]`},
-		{`a <= 1 AND b > 1`, []string{"a", "b"}, `[a <= 1]`},
-		{`a <= 1 AND b >= 1`, []string{"a", "b"}, `[a <= 1]`},
-		{`a <= 1 AND b < 1`, []string{"a", "b"}, `[a <= 1, b < 1]`},
-		{`a <= 1 AND b <= 1`, []string{"a", "b"}, `[a <= 1, b <= 1]`},
+		{`a <= 1 AND b = 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1, b = 1]`},
+		{`a <= 1 AND b != 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1]`},
+		{`a <= 1 AND b > 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1]`},
+		{`a <= 1 AND b >= 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1]`},
+		{`a <= 1 AND b < 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1, b <= 0]`},
+		{`a <= 1 AND b <= 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1, b <= 1]`},
 
 		{`a IN (1) AND b = 1`, []string{"a", "b"}, `[a IN (1), b = 1]`},
-		{`a IN (1) AND b != 1`, []string{"a", "b"}, `[a IN (1), b != 1]`},
+		{`a IN (1) AND b != 1`, []string{"a", "b"}, `[a IN (1), b IS NOT NULL]`},
 		{`a IN (1) AND b > 1`, []string{"a", "b"}, `[a IN (1), b >= 2]`},
 		{`a IN (1) AND b >= 1`, []string{"a", "b"}, `[a IN (1), b >= 1]`},
-		{`a IN (1) AND b < 1`, []string{"a", "b"}, `[a IN (1), b < 1]`},
-		{`a IN (1) AND b <= 1`, []string{"a", "b"}, `[a IN (1), b <= 1]`},
+		{`a IN (1) AND b < 1`, []string{"a", "b"}, `[a IN (1), b IS NOT NULL, b <= 0]`},
+		{`a IN (1) AND b <= 1`, []string{"a", "b"}, `[a IN (1), b IS NOT NULL, b <= 1]`},
 
 		{`(a, b) IN ((1, 2))`, []string{"a", "b"}, `[(a, b) IN ((1, 2))]`},
 		{`(b, a) IN ((1, 2))`, []string{"a", "b"}, `[(b, a) IN ((1, 2))]`},
@@ -145,7 +156,11 @@ func TestMakeConstraints(t *testing.T) {
 		{`a IS NOT NULL`, []string{"a"}, `[a IS NOT NULL]`},
 	}
 	for _, d := range testData {
-		desc, index := makeTestIndex(t, d.columns)
+		dirs := make([]encoding.Direction, 0, len(d.columns))
+		for range d.columns {
+			dirs = append(dirs, encoding.Ascending)
+		}
+		desc, index := makeTestIndex(t, d.columns, dirs)
 		constraints, _ := makeConstraints(t, d.expr, desc, index)
 		if s := constraints.String(); d.expected != s {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
@@ -153,105 +168,211 @@ func TestMakeConstraints(t *testing.T) {
 	}
 }
 
+func indexToDirs(index *IndexDescriptor) []encoding.Direction {
+	var dirs []encoding.Direction
+	for _, dir := range index.ColumnDirections {
+		d, err := dir.toEncodingDirection()
+		if err != nil {
+			panic(err)
+		}
+		dirs = append(dirs, d)
+	}
+	return dirs
+}
+
 func TestMakeSpans(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
 	testData := []struct {
-		expr     string
-		columns  []string
-		expected string
+		expr         string
+		columns      []string
+		expectedAsc  string
+		expectedDesc string
 	}{
-		{`a = 1`, []string{"a"}, `/1-/2`},
-		{`a != 1`, []string{"a"}, `/#-`},
-		{`a > 1`, []string{"a"}, `/2-`},
-		{`a >= 1`, []string{"a"}, `/1-`},
-		{`a < 1`, []string{"a"}, `/#-/1`},
-		{`a <= 1`, []string{"a"}, `/#-/2`},
-		{`a IS NULL`, []string{"a"}, `-/#`},
-		{`a IS NOT NULL`, []string{"a"}, `/#-`},
+		{`a = 1`, []string{"a"}, `/1-/2`, `/1-/0`},
+		{`a != 1`, []string{"a"}, `/#-`, `-/#`},
+		{`a > 1`, []string{"a"}, `/2-`, `-/1`},
+		{`a >= 1`, []string{"a"}, `/1-`, `-/0`},
+		{`a < 1`, []string{"a"}, `/#-/1`, `/0-/#`},
+		{`a <= 1`, []string{"a"}, `/#-/2`, `/1-/#`},
+		{`a IS NULL`, []string{"a"}, `-/#`, `/NULL-`},
+		{`a IS NOT NULL`, []string{"a"}, `/#-`, `-/#`},
 
-		{`a IN (1,2,3)`, []string{"a"}, `/1-/2 /2-/3 /3-/4`},
-		{`a IN (1,2,3) AND b = 1`, []string{"a", "b"}, `/1/1-/1/2 /2/1-/2/2 /3/1-/3/2`},
-		{`a = 1 AND b IN (1,2,3)`, []string{"a", "b"}, `/1/1-/1/2 /1/2-/1/3 /1/3-/1/4`},
-		{`a >= 1 AND b IN (1,2,3)`, []string{"a", "b"}, `/1-`},
-		{`a <= 1 AND b IN (1,2,3)`, []string{"a", "b"}, `/#-/2`},
-		{`(a, b) IN ((1, 2), (3, 4))`, []string{"a", "b"}, `/1/2-/1/3 /3/4-/3/5`},
-		{`(b, a) IN ((1, 2), (3, 4))`, []string{"a", "b"}, `/2/1-/2/2 /4/3-/4/4`},
-		{`(a, b) IN ((1, 2), (3, 4))`, []string{"b"}, `/2-/3 /4-/5`},
+		{`a IN (1,2,3)`, []string{"a"}, `/1-/2 /2-/3 /3-/4`, `/1-/0 /2-/1 /3-/2`},
+		{`a IN (1,2,3) AND b = 1`, []string{"a", "b"},
+			`/1/1-/1/2 /2/1-/2/2 /3/1-/3/2`, `/1/1-/1/0 /2/1-/2/0 /3/1-/3/0`},
+		{`a = 1 AND b IN (1,2,3)`, []string{"a", "b"},
+			`/1/1-/1/2 /1/2-/1/3 /1/3-/1/4`, `/1/1-/1/0 /1/2-/1/1 /1/3-/1/2`},
+		{`a >= 1 AND b IN (1,2,3)`, []string{"a", "b"}, `/1-`, `-/0`},
+		{`a <= 1 AND b IN (1,2,3)`, []string{"a", "b"}, `/#-/2`, `/1-/#`},
+		{`(a, b) IN ((1, 2), (3, 4))`, []string{"a", "b"},
+			`/1/2-/1/3 /3/4-/3/5`, `/1/2-/1/1 /3/4-/3/3`},
+		{`(b, a) IN ((1, 2), (3, 4))`, []string{"a", "b"},
+			`/2/1-/2/2 /4/3-/4/4`, `/2/1-/2/0 /4/3-/4/2`},
+		{`(a, b) IN ((1, 2), (3, 4))`, []string{"b"}, `/2-/3 /4-/5`, `/2-/1 /4-/3`},
 
-		{`a = 1 AND b = 1`, []string{"a", "b"}, `/1/1-/1/2`},
-		{`a = 1 AND b != 1`, []string{"a", "b"}, `/1/#-/2`},
-		{`a = 1 AND b > 1`, []string{"a", "b"}, `/1/2-/2`},
-		{`a = 1 AND b >= 1`, []string{"a", "b"}, `/1/1-/2`},
-		{`a = 1 AND b < 1`, []string{"a", "b"}, `/1/#-/1/1`},
-		{`a = 1 AND b <= 1`, []string{"a", "b"}, `/1/#-/1/2`},
-		{`a = 1 AND b IS NULL`, []string{"a", "b"}, `/1-/1/#`},
-		{`a = 1 AND b IS NOT NULL`, []string{"a", "b"}, `/1/#-/2`},
+		{`a = 1 AND b = 1`, []string{"a", "b"}, `/1/1-/1/2`, `/1/1-/1/0`},
+		{`a = 1 AND b != 1`, []string{"a", "b"}, `/1/#-/2`, `/1-/1/#`},
+		{`a = 1 AND b > 1`, []string{"a", "b"}, `/1/2-/2`, `/1-/1/1`},
+		{`a = 1 AND b >= 1`, []string{"a", "b"}, `/1/1-/2`, `/1-/1/0`},
+		{`a = 1 AND b < 1`, []string{"a", "b"}, `/1/#-/1/1`, `/1/0-/1/#`},
+		{`a = 1 AND b <= 1`, []string{"a", "b"}, `/1/#-/1/2`, `/1/1-/1/#`},
+		{`a = 1 AND b IS NULL`, []string{"a", "b"}, `/1-/1/#`, `/1/NULL-/0`},
+		{`a = 1 AND b IS NOT NULL`, []string{"a", "b"}, `/1/#-/2`, `/1-/1/#`},
 
-		{`a != 1 AND b = 1`, []string{"a", "b"}, `/#/1-`},
-		{`a != 1 AND b != 1`, []string{"a", "b"}, `/#/#-`},
-		{`a != 1 AND b > 1`, []string{"a", "b"}, `/#/2-`},
-		{`a != 1 AND b >= 1`, []string{"a", "b"}, `/#/1-`},
-		{`a != 1 AND b < 1`, []string{"a", "b"}, `/#-`},
-		{`a != 1 AND b <= 1`, []string{"a", "b"}, `/#-`},
-		{`a != 1 AND b IS NULL`, []string{"a", "b"}, `/#-`},
-		{`a != 1 AND b IS NOT NULL`, []string{"a", "b"}, `/#/#-`},
+		{`a != 1 AND b = 1`, []string{"a", "b"}, `/#-`, `-/#`},
+		{`a != 1 AND b != 1`, []string{"a", "b"}, `/#-`, `-/#`},
+		{`a != 1 AND b > 1`, []string{"a", "b"}, `/#-`, `-/#`},
+		{`a != 1 AND b >= 1`, []string{"a", "b"}, `/#-`, `-/#`},
+		{`a != 1 AND b < 1`, []string{"a", "b"}, `/#-`, `-/#`},
+		{`a != 1 AND b <= 1`, []string{"a", "b"}, `/#-`, `-/#`},
+		{`a != 1 AND b IS NULL`, []string{"a", "b"}, `/#-`, `-/#`},
+		{`a != 1 AND b IS NOT NULL`, []string{"a", "b"}, `/#-`, `-/#`},
 
-		{`a > 1 AND b = 1`, []string{"a", "b"}, `/2/1-`},
-		{`a > 1 AND b != 1`, []string{"a", "b"}, `/2/#-`},
-		{`a > 1 AND b > 1`, []string{"a", "b"}, `/2/2-`},
-		{`a > 1 AND b >= 1`, []string{"a", "b"}, `/2/1-`},
-		{`a > 1 AND b < 1`, []string{"a", "b"}, `/2-`},
-		{`a > 1 AND b <= 1`, []string{"a", "b"}, `/2-`},
-		{`a > 1 AND b IS NULL`, []string{"a", "b"}, `/2-`},
-		{`a > 1 AND b IS NOT NULL`, []string{"a", "b"}, `/2/#-`},
+		{`a > 1 AND b = 1`, []string{"a", "b"}, `/2/1-`, `-/2/0`},
+		{`a > 1 AND b != 1`, []string{"a", "b"}, `/2/#-`, `-/2/#`},
+		{`a > 1 AND b > 1`, []string{"a", "b"}, `/2/2-`, `-/2/1`},
+		{`a > 1 AND b >= 1`, []string{"a", "b"}, `/2/1-`, `-/2/0`},
+		{`a > 1 AND b < 1`, []string{"a", "b"}, `/2-`, `-/1`},
+		{`a > 1 AND b <= 1`, []string{"a", "b"}, `/2-`, `-/1`},
+		{`a > 1 AND b IS NULL`, []string{"a", "b"}, `/2-`, `-/1`},
+		{`a > 1 AND b IS NOT NULL`, []string{"a", "b"}, `/2/#-`, `-/2/#`},
 
-		{`a >= 1 AND b = 1`, []string{"a", "b"}, `/1/1-`},
-		{`a >= 1 AND b != 1`, []string{"a", "b"}, `/1/#-`},
-		{`a >= 1 AND b > 1`, []string{"a", "b"}, `/1/2-`},
-		{`a >= 1 AND b >= 1`, []string{"a", "b"}, `/1/1-`},
-		{`a >= 1 AND b < 1`, []string{"a", "b"}, `/1-`},
-		{`a >= 1 AND b <= 1`, []string{"a", "b"}, `/1-`},
-		{`a >= 1 AND b IS NULL`, []string{"a", "b"}, `/1-`},
-		{`a >= 1 AND b IS NOT NULL`, []string{"a", "b"}, `/1/#-`},
+		{`a >= 1 AND b = 1`, []string{"a", "b"}, `/1/1-`, `-/1/0`},
+		{`a >= 1 AND b != 1`, []string{"a", "b"}, `/1/#-`, `-/1/#`},
+		{`a >= 1 AND b > 1`, []string{"a", "b"}, `/1/2-`, `-/1/1`},
+		{`a >= 1 AND b >= 1`, []string{"a", "b"}, `/1/1-`, `-/1/0`},
+		{`a >= 1 AND b < 1`, []string{"a", "b"}, `/1-`, `-/0`},
+		{`a >= 1 AND b <= 1`, []string{"a", "b"}, `/1-`, `-/0`},
+		{`a >= 1 AND b IS NULL`, []string{"a", "b"}, `/1-`, `-/0`},
+		{`a >= 1 AND b IS NOT NULL`, []string{"a", "b"}, `/1/#-`, `-/1/#`},
 
-		{`a < 1 AND b = 1`, []string{"a", "b"}, `/#-/1`},
-		{`a < 1 AND b != 1`, []string{"a", "b"}, `/#-/1`},
-		{`a < 1 AND b > 1`, []string{"a", "b"}, `/#-/1`},
-		{`a < 1 AND b >= 1`, []string{"a", "b"}, `/#-/1`},
-		{`a < 1 AND b < 1`, []string{"a", "b"}, `/#-/1`},
-		{`a < 1 AND b <= 1`, []string{"a", "b"}, `/#-/1`},
-		{`a < 1 AND b IS NULL`, []string{"a", "b"}, `/#-/1`},
-		{`a < 1 AND b IS NOT NULL`, []string{"a", "b"}, `/#-/1`},
+		{`a < 1 AND b = 1`, []string{"a", "b"}, `/#-/0/2`, `/0/1-/#`},
+		{`a < 1 AND b != 1`, []string{"a", "b"}, `/#-/1`, `/0-/#`},
+		{`a < 1 AND b > 1`, []string{"a", "b"}, `/#-/1`, `/0-/#`},
+		{`a < 1 AND b >= 1`, []string{"a", "b"}, `/#-/1`, `/0-/#`},
+		{`a < 1 AND b < 1`, []string{"a", "b"}, `/#-/0/1`, `/0/0-/#`},
+		{`a < 1 AND b <= 1`, []string{"a", "b"}, `/#-/0/2`, `/0/1-/#`},
+		{`a < 1 AND b IS NULL`, []string{"a", "b"}, `/#-/0/#`, `/0/NULL-/#`},
+		{`a < 1 AND b IS NOT NULL`, []string{"a", "b"}, `/#-/1`, `/0-/#`},
 
-		{`a <= 1 AND b = 1`, []string{"a", "b"}, `/#-/1/2`},
-		{`a <= 1 AND b != 1`, []string{"a", "b"}, `/#-/2`},
-		{`a <= 1 AND b > 1`, []string{"a", "b"}, `/#-/2`},
-		{`a <= 1 AND b >= 1`, []string{"a", "b"}, `/#-/2`},
-		{`a <= 1 AND b < 1`, []string{"a", "b"}, `/#-/1/1`},
-		{`a <= 1 AND b <= 1`, []string{"a", "b"}, `/#-/1/2`},
-		{`a <= 1 AND b IS NULL`, []string{"a", "b"}, `/#-/1/#`},
-		{`a <= 1 AND b IS NOT NULL`, []string{"a", "b"}, `/#-/2`},
+		{`a <= 1 AND b = 1`, []string{"a", "b"}, `/#-/1/2`, `/1/1-/#`},
+		{`a <= 1 AND b != 1`, []string{"a", "b"}, `/#-/2`, `/1-/#`},
+		{`a <= 1 AND b > 1`, []string{"a", "b"}, `/#-/2`, `/1-/#`},
+		{`a <= 1 AND b >= 1`, []string{"a", "b"}, `/#-/2`, `/1-/#`},
+		{`a <= 1 AND b < 1`, []string{"a", "b"}, `/#-/1/1`, `/1/0-/#`},
+		{`a <= 1 AND b <= 1`, []string{"a", "b"}, `/#-/1/2`, `/1/1-/#`},
+		{`a <= 1 AND b IS NULL`, []string{"a", "b"}, `/#-/1/#`, `/1/NULL-/#`},
+		{`a <= 1 AND b IS NOT NULL`, []string{"a", "b"}, `/#-/2`, `/1-/#`},
 
-		{`a IN (1) AND b = 1`, []string{"a", "b"}, `/1/1-/1/2`},
-		{`a IN (1) AND b != 1`, []string{"a", "b"}, `/1/#-/2`},
-		{`a IN (1) AND b > 1`, []string{"a", "b"}, `/1/2-/2`},
-		{`a IN (1) AND b >= 1`, []string{"a", "b"}, `/1/1-/2`},
-		{`a IN (1) AND b < 1`, []string{"a", "b"}, `/1/#-/1/1`},
-		{`a IN (1) AND b <= 1`, []string{"a", "b"}, `/1/#-/1/2`},
-		{`a IN (1) AND b IS NULL`, []string{"a", "b"}, `/1-/1/#`},
-		{`a IN (1) AND b IS NOT NULL`, []string{"a", "b"}, `/1/#-/2`},
+		{`a IN (1) AND b = 1`, []string{"a", "b"}, `/1/1-/1/2`, `/1/1-/1/0`},
+		{`a IN (1) AND b != 1`, []string{"a", "b"}, `/1/#-/2`, `/1-/1/#`},
+		{`a IN (1) AND b > 1`, []string{"a", "b"}, `/1/2-/2`, `/1-/1/1`},
+		{`a IN (1) AND b >= 1`, []string{"a", "b"}, `/1/1-/2`, `/1-/1/0`},
+		{`a IN (1) AND b < 1`, []string{"a", "b"}, `/1/#-/1/1`, `/1/0-/1/#`},
+		{`a IN (1) AND b <= 1`, []string{"a", "b"}, `/1/#-/1/2`, `/1/1-/1/#`},
+		{`a IN (1) AND b IS NULL`, []string{"a", "b"}, `/1-/1/#`, `/1/NULL-/0`},
+		{`a IN (1) AND b IS NOT NULL`, []string{"a", "b"}, `/1/#-/2`, `/1-/1/#`},
 
-		{`(a, b) = (1, 2)`, []string{"a"}, `/1-/2`},
-		{`(a, b) = (1, 2)`, []string{"a", "b"}, `/1/2-/1/3`},
+		{`(a, b) = (1, 2)`, []string{"a"}, `/1-/2`, `/1-/0`},
+		{`(a, b) = (1, 2)`, []string{"a", "b"}, `/1/2-/1/3`, `/1/2-/1/1`},
+
+		// When encoding an end constraint for a maximal datum, we use
+		// bytes.PrefixEnd() to go beyond the normal encodings of that datatype.
+		{fmt.Sprintf(`a = %d`, math.MaxInt64), []string{"a"},
+			`/9223372036854775807-/<util/encoding/encoding.go: ` +
+				`varint 9223372036854775808 overflows int64>`, `/9223372036854775807-/9223372036854775806`},
+		{fmt.Sprintf(`a = %d`, math.MinInt64), []string{"a"},
+			`/-9223372036854775808-/-9223372036854775807`,
+			`/-9223372036854775808-/<util/encoding/encoding.go: varint 9223372036854775808 overflows int64>`},
 	}
 	for _, d := range testData {
-		desc, index := makeTestIndex(t, d.columns)
+		for i := range []int{0, 1} {
+			dir := encoding.Ascending
+			if i == 1 {
+				dir = encoding.Descending
+			}
+			dirs := make([]encoding.Direction, 0, len(d.columns))
+			for range d.columns {
+				dirs = append(dirs, dir)
+			}
+			desc, index := makeTestIndex(t, d.columns, dirs)
+			constraints, _ := makeConstraints(t, d.expr, desc, index)
+			spans := makeSpans(constraints, desc.ID, index)
+			s := prettySpans(spans, 2)
+			var expected string
+			if dir == encoding.Ascending {
+				expected = d.expectedAsc
+			} else {
+				expected = d.expectedDesc
+			}
+			s = keys.MassagePrettyPrintedSpanForTest(s, indexToDirs(index))
+			if expected != s {
+				t.Errorf("[index direction: %d] %s: expected %s, but found %s", dir, d.expr, expected, s)
+			}
+		}
+	}
 
+	type Col struct {
+		col string
+		dir encoding.Direction
+	}
+
+	// Test indexes with mixed-directions (some cols Asc, some cols Desc) and other edge cases.
+	testData2 := []struct {
+		expr     string
+		columns  []Col
+		expected string
+	}{
+		{`a = 1 AND b = 5`,
+			[]Col{{"a", encoding.Ascending}, {"b", encoding.Descending}, {"c", encoding.Ascending}},
+			`/1/5-/1/4`},
+		{`a = 7 AND b IN (1,2,3) AND c = false`,
+			[]Col{{"a", encoding.Ascending}, {"b", encoding.Descending}, {"c", encoding.Ascending}},
+			`/7/1/0-/7/1/1 /7/2/0-/7/2/1 /7/3/0-/7/3/1`},
+		// Test different directions for te columns inside a tuple.
+		{`(a,b,j) IN ((1,2,3), (4,5,6))`,
+			[]Col{{"a", encoding.Descending}, {"b", encoding.Ascending}, {"j", encoding.Descending}},
+			`/1/2/3-/1/2/2 /4/5/6-/4/5/5`},
+		{`i = E'\xff'`,
+			[]Col{{"i", encoding.Ascending}},
+			`/"\xff"-/"\xff\x00"`},
+		// Test that limits on bytes work correctly: when encoding a descending limit for bytes,
+		// we need to go outside the bytes encoding.
+		// "\xaa" is encoded as [bytesDescMarker, ^0xaa, <term escape sequence>]
+		{`i = E'\xaa'`,
+			[]Col{{"i", encoding.Descending}},
+			fmt.Sprintf("raw:%c%c\xff\xfe-%c%c\xff\xff",
+				encoding.BytesDescMarker, ^byte(0xaa), encoding.BytesDescMarker, ^byte(0xaa))},
+	}
+	for _, d := range testData2 {
+		cols := make([]string, 0, len(d.columns))
+		dirs := make([]encoding.Direction, 0, len(d.columns))
+		for _, col := range d.columns {
+			cols = append(cols, col.col)
+			dirs = append(dirs, col.dir)
+		}
+		desc, index := makeTestIndex(t, cols, dirs)
 		constraints, _ := makeConstraints(t, d.expr, desc, index)
 		spans := makeSpans(constraints, desc.ID, index)
-		if s := prettySpans(spans, 2); d.expected != s {
-			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
+		var got string
+		raw := false
+		if strings.HasPrefix(d.expected, "raw:") {
+			raw = true
+			span := spans[0]
+			d.expected = d.expected[4:]
+			// Trim the index prefix from the span.
+			got = strings.TrimPrefix(string(span.start), string(MakeIndexKeyPrefix(desc.ID, index.ID))) +
+				"-" + strings.TrimPrefix(string(span.end), string(MakeIndexKeyPrefix(desc.ID, index.ID)))
+		} else {
+			got = keys.MassagePrettyPrintedSpanForTest(prettySpans(spans, 2), indexToDirs(index))
+		}
+		if d.expected != got {
+			if !raw {
+				t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, got)
+			} else {
+				t.Errorf("%s: expected %# x, but found %# x", d.expr, []byte(d.expected), got)
+			}
 		}
 	}
 }
@@ -275,7 +396,11 @@ func TestExactPrefix(t *testing.T) {
 		{`a = 1 AND (b, c) IN ((2, true))`, []string{"a", "b", "c"}, 3},
 	}
 	for _, d := range testData {
-		desc, index := makeTestIndex(t, d.columns)
+		dirs := make([]encoding.Direction, 0, len(d.columns))
+		for range d.columns {
+			dirs = append(dirs, encoding.Ascending)
+		}
+		desc, index := makeTestIndex(t, d.columns, dirs)
 		constraints, _ := makeConstraints(t, d.expr, desc, index)
 		prefix := exactPrefix(constraints)
 		if d.expected != prefix {
@@ -319,7 +444,11 @@ func TestApplyConstraints(t *testing.T) {
 		// {`a < 1`, []string{"a"}, `<nil>`},
 	}
 	for _, d := range testData {
-		desc, index := makeTestIndex(t, d.columns)
+		dirs := make([]encoding.Direction, 0, len(d.columns))
+		for range d.columns {
+			dirs = append(dirs, encoding.Ascending)
+		}
+		desc, index := makeTestIndex(t, d.columns, dirs)
 		constraints, expr := makeConstraints(t, d.expr, desc, index)
 		expr2 := applyConstraints(expr, constraints)
 		if s := fmt.Sprint(expr2); d.expected != s {

--- a/sql/show.go
+++ b/sql/show.go
@@ -100,7 +100,8 @@ func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, *roachpb.Err
 	}
 	v := &valuesNode{columns: []column{{name: "Database", typ: parser.DummyString}}}
 	for _, row := range sr {
-		_, name, err := encoding.DecodeString(bytes.TrimPrefix(row.Key, prefix), nil)
+		_, name, err := encoding.DecodeStringAscending(
+			bytes.TrimPrefix(row.Key, prefix), nil)
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/encoding"
 )
 
 // ID, ColumnID, and IndexID are all uint32, but are each given a
@@ -77,6 +78,18 @@ func validateName(name, typ string) error {
 	}
 	// TODO(pmattis): Do we want to be more restrictive than this?
 	return nil
+}
+
+// toEncodingDirection converts a direction from the proto to an encoding.Direction.
+func (dir IndexDescriptor_Direction) toEncodingDirection() (encoding.Direction, error) {
+	switch dir {
+	case IndexDescriptor_ASC:
+		return encoding.Ascending, nil
+	case IndexDescriptor_DESC:
+		return encoding.Descending, nil
+	default:
+		return encoding.Ascending, util.Errorf("invalid direction: %s", dir)
+	}
 }
 
 // allocateName sets desc.Name to a value that is not equalName to any
@@ -144,16 +157,29 @@ func (desc *IndexDescriptor) containsColumnID(colID ColumnID) bool {
 }
 
 // fullColumnIDs returns the index column IDs including any implicit column IDs
-// for non-unique indexes.
-func (desc *IndexDescriptor) fullColumnIDs() []ColumnID {
-	if desc.Unique {
-		return desc.ColumnIDs
+// for non-unique indexes. It also returns the direction with which each column
+// was encoded.
+func (desc *IndexDescriptor) fullColumnIDs() ([]ColumnID, []encoding.Direction) {
+	dirs := make([]encoding.Direction, 0, len(desc.ColumnIDs))
+	for _, dir := range desc.ColumnDirections {
+		convertedDir, err := dir.toEncodingDirection()
+		if err != nil {
+			panic(err)
+		}
+		dirs = append(dirs, convertedDir)
 	}
-	// Non-unique indexes have the some of the primary-key columns appended to
+	if desc.Unique {
+		return desc.ColumnIDs, dirs
+	}
+	// Non-unique indexes have some of the primary-key columns appended to
 	// their key.
 	columnIDs := append([]ColumnID(nil), desc.ColumnIDs...)
 	columnIDs = append(columnIDs, desc.ImplicitColumnIDs...)
-	return columnIDs
+	for range desc.ImplicitColumnIDs {
+		// Implicit columns are encoded ascendingly.
+		dirs = append(dirs, encoding.Ascending)
+	}
+	return columnIDs, dirs
 }
 
 // SetID implements the descriptorProto interface.

--- a/sql/structured.pb.go
+++ b/sql/structured.pb.go
@@ -261,6 +261,9 @@ type IndexDescriptor struct {
 	// indexes these columns will be stored in the value. The extra column IDs is
 	// computed as PrimaryIndex.column_ids - column_ids. For the primary index
 	// the list will be empty.
+	// The distinction about whether the columns are written in the key or the value
+	// comes because we want to always do writes using a single operation - this
+	// way for unique indexes we can do a conditional put on the key.
 	ImplicitColumnIDs []ColumnID `protobuf:"varint,7,rep,name=implicit_column_ids,casttype=ColumnID" json:"implicit_column_ids,omitempty"`
 }
 

--- a/sql/structured.proto
+++ b/sql/structured.proto
@@ -87,6 +87,9 @@ message IndexDescriptor {
   // indexes these columns will be stored in the value. The extra column IDs is
   // computed as PrimaryIndex.column_ids - column_ids. For the primary index
   // the list will be empty.
+  // The distinction about whether the columns are written in the key or the value
+  // comes because we want to always do writes using a single operation - this
+  // way for unique indexes we can do a conditional put on the key.
   repeated uint32 implicit_column_ids = 7 [(gogoproto.customname) = "ImplicitColumnIDs",
       (gogoproto.casttype) = "ColumnID"];
 }

--- a/sql/testdata/select
+++ b/sql/testdata/select
@@ -236,3 +236,16 @@ query I
 SELECT CASE WHEN NULL THEN 1 ELSE 2 END
 ----
 2
+
+# Doing an index lookup by MaxInt used to not work.
+# https://github.com/cockroachdb/cockroach/issues/3587
+statement ok
+CREATE TABLE MaxIntTest (a INT PRIMARY KEY)
+
+statement ok
+INSERT INTO MaxIntTest VALUES (9223372036854775807)
+
+query I
+SELECT a FROM MaxIntTest WHERE a = 9223372036854775807
+----
+9223372036854775807

--- a/sql/update.go
+++ b/sql/update.go
@@ -184,7 +184,7 @@ func (p *planner) Update(n *parser.Update) (planNode, *roachpb.Error) {
 		result.rows = append(result.rows, parser.DTuple(nil))
 
 		primaryIndexKey, _, pErr := encodeIndexKey(
-			primaryIndex.ColumnIDs, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
+			&primaryIndex, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
 		if pErr != nil {
 			return nil, pErr
 		}

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -150,8 +150,8 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 	//
 	//   CREATE TABLE t (id STRING PRIMARY KEY, col1 INT, col2 INT)
 	tableKey := keys.MakeTablePrefix(keys.MaxReservedDescID + 1)
-	rowKey := roachpb.Key(encoding.EncodeVarint(append([]byte(nil), tableKey...), 1))
-	rowKey = encoding.EncodeString(encoding.EncodeVarint(rowKey, 1), "a")
+	rowKey := roachpb.Key(encoding.EncodeVarintAscending(append([]byte(nil), tableKey...), 1))
+	rowKey = encoding.EncodeStringAscending(encoding.EncodeVarintAscending(rowKey, 1), "a")
 	col1Key := keys.MakeColumnKey(append([]byte(nil), rowKey...), 1)
 	col2Key := keys.MakeColumnKey(append([]byte(nil), rowKey...), 2)
 

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -99,7 +99,7 @@ func setupMVCCData(numVersions, numKeys, valueBytes int, b *testing.B) (*RocksDB
 	keys := make([]roachpb.Key, numKeys)
 	var order []int
 	for i := 0; i < numKeys; i++ {
-		keys[i] = roachpb.Key(encoding.EncodeUvarint([]byte("key-"), uint64(i)))
+		keys[i] = roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(i)))
 		keyVersions := rng.Intn(numVersions) + 1
 		for j := 0; j < keyVersions; j++ {
 			order = append(order, i)
@@ -173,7 +173,7 @@ func runMVCCScan(numRows, numVersions, valueSize int, b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// Choose a random key to start scan.
 		keyIdx := rand.Int31n(int32(numKeys - numRows))
-		startKey := roachpb.Key(encoding.EncodeUvarint(keyBuf[:4], uint64(keyIdx)))
+		startKey := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(keyIdx)))
 		walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 		ts := makeTS(walltime, 0)
 		kvs, _, err := MVCCScan(rocksdb, startKey, keyMax, int64(numRows), ts, true, nil)
@@ -319,7 +319,7 @@ func runMVCCGet(numVersions, valueSize int, b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// Choose a random key to retrieve.
 		keyIdx := rand.Int31n(int32(numKeys))
-		key := roachpb.Key(encoding.EncodeUvarint(keyBuf[:4], uint64(keyIdx)))
+		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(keyIdx)))
 		walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 		ts := makeTS(walltime, 0)
 		if v, _, err := MVCCGet(rocksdb, key, ts, true, nil); err != nil {
@@ -361,7 +361,7 @@ func runMVCCPut(valueSize int, b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		key := roachpb.Key(encoding.EncodeUvarint(keyBuf[:4], uint64(i)))
+		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
 		ts := makeTS(time.Now().UnixNano(), 0)
 		if err := MVCCPut(rocksdb, nil, key, ts, value, nil); err != nil {
 			b.Fatalf("failed put: %s", err)
@@ -408,7 +408,7 @@ func runMVCCBatchPut(valueSize, batchSize int, b *testing.B) {
 		batch := rocksdb.NewBatch()
 
 		for j := i; j < end; j++ {
-			key := roachpb.Key(encoding.EncodeUvarint(keyBuf[:4], uint64(j)))
+			key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(j)))
 			ts := makeTS(time.Now().UnixNano(), 0)
 			if err := MVCCPut(batch, nil, key, ts, value, nil); err != nil {
 				b.Fatalf("failed put: %s", err)

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -980,7 +980,7 @@ func (r *Replica) proposeRaftCommand(ctx context.Context, ba roachpb.BatchReques
 		return nil, roachpb.NewRangeNotFoundError(r.RangeID)
 	}
 	idKeyBuf := make([]byte, 0, raftCommandIDLen)
-	idKeyBuf = encoding.EncodeUint64(idKeyBuf, uint64(rand.Int63()))
+	idKeyBuf = encoding.EncodeUint64Ascending(idKeyBuf, uint64(rand.Int63()))
 	idKey := cmdIDKey(idKeyBuf)
 	pendingCmd := &pendingCmd{
 		ctx:  ctx,

--- a/storage/sequence_cache.go
+++ b/storage/sequence_cache.go
@@ -213,7 +213,7 @@ func decodeSequenceCacheKey(key roachpb.Key, dest []byte) ([]byte, uint32, uint3
 	}
 	// Cut the prefix and the Range ID.
 	b := key[len(keys.LocalRangeIDPrefix):]
-	b, _, err := encoding.DecodeUvarint(b)
+	b, _, err := encoding.DecodeUvarintAscending(b)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -224,17 +224,17 @@ func decodeSequenceCacheKey(key roachpb.Key, dest []byte) ([]byte, uint32, uint3
 	// Cut the sequence cache suffix.
 	b = b[len(keys.LocalSequenceCacheSuffix):]
 	// Decode the id.
-	b, id, err := encoding.DecodeBytes(b, dest)
+	b, id, err := encoding.DecodeBytesAscending(b, dest)
 	if err != nil {
 		return nil, 0, 0, err
 	}
 	// Decode the epoch.
-	b, epoch, err := encoding.DecodeUint32Decreasing(b)
+	b, epoch, err := encoding.DecodeUint32Descending(b)
 	if err != nil {
 		return nil, 0, 0, err
 	}
 	// Decode the sequence number.
-	b, seq, err := encoding.DecodeUint32Decreasing(b)
+	b, seq, err := encoding.DecodeUint32Descending(b)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/ts/keys.go
+++ b/ts/keys.go
@@ -69,9 +69,9 @@ func MakeDataKey(name string, source string, r Resolution, timestamp int64) roac
 	timeslot := timestamp / r.KeyDuration()
 
 	k := append(roachpb.Key(nil), keyDataPrefix...)
-	k = encoding.EncodeBytes(k, []byte(name))
-	k = encoding.EncodeVarint(k, int64(r))
-	k = encoding.EncodeVarint(k, timeslot)
+	k = encoding.EncodeBytesAscending(k, []byte(name))
+	k = encoding.EncodeVarintAscending(k, int64(r))
+	k = encoding.EncodeVarintAscending(k, timeslot)
 	k = append(k, source...)
 	return k
 }
@@ -86,18 +86,18 @@ func DecodeDataKey(key roachpb.Key) (string, string, Resolution, int64, error) {
 	remainder = remainder[len(keyDataPrefix):]
 
 	// Decode series name.
-	remainder, name, err := encoding.DecodeBytes(remainder, nil)
+	remainder, name, err := encoding.DecodeBytesAscending(remainder, nil)
 	if err != nil {
 		return "", "", 0, 0, err
 	}
 	// Decode resolution.
-	remainder, resolutionInt, err := encoding.DecodeVarint(remainder)
+	remainder, resolutionInt, err := encoding.DecodeVarintAscending(remainder)
 	if err != nil {
 		return "", "", 0, 0, err
 	}
 	resolution := Resolution(resolutionInt)
 	// Decode timestamp.
-	remainder, timeslot, err := encoding.DecodeVarint(remainder)
+	remainder, timeslot, err := encoding.DecodeVarintAscending(remainder)
 	if err != nil {
 		return "", "", 0, 0, err
 	}

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -450,7 +450,7 @@ func decodeBytesInternal(b []byte, r []byte, e escapes) ([]byte, []byte, error) 
 			r = append(r, b[:i]...)
 			r = append(r, e.escapedFF)
 		} else {
-			return nil, nil, util.Errorf("unknown escape")
+			return nil, nil, util.Errorf("unknown escape sequence: %#x %#x", e.escape, v)
 		}
 
 		b = b[i+2:]

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -27,7 +27,10 @@ import (
 )
 
 const (
-	encodedNull    = 0x00
+	encodedNull = 0x00
+	// A marker greater than NULL but lower than any other value.
+	// This value is not actually ever present in a stored key, but
+	// it's used in keys used as span boundaries for index scans.
 	encodedNotNull = 0x01
 
 	floatNaN              = encodedNotNull + 1
@@ -40,37 +43,59 @@ const (
 	floatPosMedium        = floatPosSmall + 1
 	floatPosLarge         = floatPosMedium + 11
 	floatInfinity         = floatPosLarge + 1
+	floatNaNDesc          = floatInfinity + 1 // NaN encoded descendingly
 	floatTerminator       = 0x00
 
-	bytesMarker byte = floatInfinity + 1
-	timeMarker  byte = bytesMarker + 1
+	bytesMarker     byte = floatNaNDesc + 1
+	timeMarker      byte = bytesMarker + 1
+	bytesDescMarker byte = timeMarker + 1
+	timeDescMarker  byte = bytesDescMarker + 1
 
 	// IntMin is chosen such that the range of int tags does not overlap the
 	// ascii character set that is frequently used in testing.
 	IntMin   = 0x80
 	intZero  = IntMin + 8
-	intSmall = IntMax - intZero - 8 // 111
+	intSmall = IntMax - intZero - 8 // 109
 	// IntMax is the maximum int tag value.
-	IntMax = 0xff
+	IntMax = 0xfd
+
+	// Nulls come last when encoded descendingly.
+	encodedNotNullDesc = 0xfe
+	encodedNullDesc    = 0xff
 )
 
-// EncodeUint32 encodes the uint32 value using a big-endian 8 byte
+const (
+	// BytesDescMarker is exported for testing.
+	BytesDescMarker = bytesDescMarker
+)
+
+// Direction for ordering results.
+type Direction int
+
+// Direction values.
+const (
+	_ Direction = iota
+	Ascending
+	Descending
+)
+
+// EncodeUint32Ascending encodes the uint32 value using a big-endian 8 byte
 // representation. The bytes are appended to the supplied buffer and
 // the final buffer is returned.
-func EncodeUint32(b []byte, v uint32) []byte {
+func EncodeUint32Ascending(b []byte, v uint32) []byte {
 	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 }
 
-// EncodeUint32Decreasing encodes the uint32 value so that it sorts in
+// EncodeUint32Descending encodes the uint32 value so that it sorts in
 // reverse order, from largest to smallest.
-func EncodeUint32Decreasing(b []byte, v uint32) []byte {
-	return EncodeUint32(b, ^v)
+func EncodeUint32Descending(b []byte, v uint32) []byte {
+	return EncodeUint32Ascending(b, ^v)
 }
 
-// DecodeUint32 decodes a uint32 from the input buffer, treating
+// DecodeUint32Ascending decodes a uint32 from the input buffer, treating
 // the input as a big-endian 4 byte uint32 representation. The remainder
 // of the input buffer and the decoded uint32 are returned.
-func DecodeUint32(b []byte) ([]byte, uint32, error) {
+func DecodeUint32Ascending(b []byte) ([]byte, uint32, error) {
 	if len(b) < 4 {
 		return nil, 0, util.Errorf("insufficient bytes to decode uint32 int value")
 	}
@@ -79,32 +104,32 @@ func DecodeUint32(b []byte) ([]byte, uint32, error) {
 	return b[4:], v, nil
 }
 
-// DecodeUint32Decreasing decodes a uint32 value which was encoded
-// using EncodeUint32Decreasing.
-func DecodeUint32Decreasing(b []byte) ([]byte, uint32, error) {
-	leftover, v, err := DecodeUint32(b)
+// DecodeUint32Descending decodes a uint32 value which was encoded
+// using EncodeUint32Descending.
+func DecodeUint32Descending(b []byte) ([]byte, uint32, error) {
+	leftover, v, err := DecodeUint32Ascending(b)
 	return leftover, ^v, err
 }
 
-// EncodeUint64 encodes the uint64 value using a big-endian 8 byte
+// EncodeUint64Ascending encodes the uint64 value using a big-endian 8 byte
 // representation. The bytes are appended to the supplied buffer and
 // the final buffer is returned.
-func EncodeUint64(b []byte, v uint64) []byte {
+func EncodeUint64Ascending(b []byte, v uint64) []byte {
 	return append(b,
 		byte(v>>56), byte(v>>48), byte(v>>40), byte(v>>32),
 		byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 }
 
-// EncodeUint64Decreasing encodes the uint64 value so that it sorts in
+// EncodeUint64Descending encodes the uint64 value so that it sorts in
 // reverse order, from largest to smallest.
-func EncodeUint64Decreasing(b []byte, v uint64) []byte {
-	return EncodeUint64(b, ^v)
+func EncodeUint64Descending(b []byte, v uint64) []byte {
+	return EncodeUint64Ascending(b, ^v)
 }
 
-// DecodeUint64 decodes a uint64 from the input buffer, treating
+// DecodeUint64Ascending decodes a uint64 from the input buffer, treating
 // the input as a big-endian 8 byte uint64 representation. The remainder
 // of the input buffer and the decoded uint64 are returned.
-func DecodeUint64(b []byte) ([]byte, uint64, error) {
+func DecodeUint64Ascending(b []byte) ([]byte, uint64, error) {
 	if len(b) < 8 {
 		return nil, 0, util.Errorf("insufficient bytes to decode uint64 int value")
 	}
@@ -115,20 +140,20 @@ func DecodeUint64(b []byte) ([]byte, uint64, error) {
 	return b[8:], v, nil
 }
 
-// DecodeUint64Decreasing decodes a uint64 value which was encoded
-// using EncodeUint64Decreasing.
-func DecodeUint64Decreasing(b []byte) ([]byte, uint64, error) {
-	leftover, v, err := DecodeUint64(b)
+// DecodeUint64Descending decodes a uint64 value which was encoded
+// using EncodeUint64Descending.
+func DecodeUint64Descending(b []byte) ([]byte, uint64, error) {
+	leftover, v, err := DecodeUint64Ascending(b)
 	return leftover, ^v, err
 }
 
-// EncodeVarint encodes the int64 value using a variable length
+// EncodeVarintAscending encodes the int64 value using a variable length
 // (length-prefixed) representation. The length is encoded as a single
 // byte. If the value to be encoded is negative the length is encoded
 // as 8-numBytes. If the value is positive it is encoded as
 // 8+numBytes. The encoded bytes are appended to the supplied buffer
 // and the final buffer is returned.
-func EncodeVarint(b []byte, v int64) []byte {
+func EncodeVarintAscending(b []byte, v int64) []byte {
 	if v < 0 {
 		switch {
 		case v >= -0xff:
@@ -153,20 +178,17 @@ func EncodeVarint(b []byte, v int64) []byte {
 				byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 		}
 	}
-
-	return EncodeUvarint(b, uint64(v))
+	return EncodeUvarintAscending(b, uint64(v))
 }
 
-// EncodeVarintDecreasing encodes the int64 value so that it sorts in reverse
+// EncodeVarintDescending encodes the int64 value so that it sorts in reverse
 // order, from largest to smallest.
-func EncodeVarintDecreasing(b []byte, v int64) []byte {
-	return EncodeVarint(b, ^v)
+func EncodeVarintDescending(b []byte, v int64) []byte {
+	return EncodeVarintAscending(b, ^v)
 }
 
-// DecodeVarint decodes a varint encoded int64 from the input
-// buffer. The remainder of the input buffer and the decoded int64
-// are returned.
-func DecodeVarint(b []byte) ([]byte, int64, error) {
+// DecodeVarintAscending decodes a value encode by EncodeVaringAscending.
+func DecodeVarintAscending(b []byte) ([]byte, int64, error) {
 	if len(b) == 0 {
 		return nil, 0, util.Errorf("insufficient bytes to decode uvarint value")
 	}
@@ -187,7 +209,7 @@ func DecodeVarint(b []byte) ([]byte, int64, error) {
 		return remB[length:], ^v, nil
 	}
 
-	remB, v, err := DecodeUvarint(b)
+	remB, v, err := DecodeUvarintAscending(b)
 	if err != nil {
 		return remB, 0, err
 	}
@@ -197,19 +219,19 @@ func DecodeVarint(b []byte) ([]byte, int64, error) {
 	return remB, int64(v), nil
 }
 
-// DecodeVarintDecreasing decodes a uint64 value which was encoded
-// using EncodeVarintDecreasing.
-func DecodeVarintDecreasing(b []byte) ([]byte, int64, error) {
-	leftover, v, err := DecodeVarint(b)
+// DecodeVarintDescending decodes a uint64 value which was encoded
+// using EncodeVarintDescending.
+func DecodeVarintDescending(b []byte) ([]byte, int64, error) {
+	leftover, v, err := DecodeVarintAscending(b)
 	return leftover, ^v, err
 }
 
-// EncodeUvarint encodes the uint64 value using a variable length
+// EncodeUvarintAscending encodes the uint64 value using a variable length
 // (length-prefixed) representation. The length is encoded as a single
 // byte indicating the number of encoded bytes (-8) to follow. See
-// EncodeVarint for rationale. The encoded bytes are appended to the
+// EncodeVarintAscending for rationale. The encoded bytes are appended to the
 // supplied buffer and the final buffer is returned.
-func EncodeUvarint(b []byte, v uint64) []byte {
+func EncodeUvarintAscending(b []byte, v uint64) []byte {
 	switch {
 	case v <= intSmall:
 		return append(b, intZero+byte(v))
@@ -236,9 +258,9 @@ func EncodeUvarint(b []byte, v uint64) []byte {
 	}
 }
 
-// EncodeUvarintDecreasing encodes the uint64 value so that it sorts in
+// EncodeUvarintDescending encodes the uint64 value so that it sorts in
 // reverse order, from largest to smallest.
-func EncodeUvarintDecreasing(b []byte, v uint64) []byte {
+func EncodeUvarintDescending(b []byte, v uint64) []byte {
 	switch {
 	case v == 0:
 		return append(b, IntMin+8)
@@ -273,10 +295,10 @@ func EncodeUvarintDecreasing(b []byte, v uint64) []byte {
 	}
 }
 
-// DecodeUvarint decodes a varint encoded uint64 from the input
+// DecodeUvarintAscending decodes a varint encoded uint64 from the input
 // buffer. The remainder of the input buffer and the decoded uint64
 // are returned.
-func DecodeUvarint(b []byte) ([]byte, uint64, error) {
+func DecodeUvarintAscending(b []byte) ([]byte, uint64, error) {
 	if len(b) == 0 {
 		return nil, 0, util.Errorf("insufficient bytes to decode uvarint value")
 	}
@@ -300,9 +322,9 @@ func DecodeUvarint(b []byte) ([]byte, uint64, error) {
 	return b[length:], v, nil
 }
 
-// DecodeUvarintDecreasing decodes a uint64 value which was encoded
-// using EncodeUvarintDecreasing.
-func DecodeUvarintDecreasing(b []byte) ([]byte, uint64, error) {
+// DecodeUvarintDescending decodes a uint64 value which was encoded
+// using EncodeUvarintDescending.
+func DecodeUvarintDescending(b []byte) ([]byte, uint64, error) {
 	if len(b) == 0 {
 		return nil, 0, util.Errorf("insufficient bytes to decode uvarint value")
 	}
@@ -339,15 +361,15 @@ type escapes struct {
 
 var (
 	ascendingEscapes  = escapes{escape, escapedTerm, escaped00, escapedFF, bytesMarker}
-	descendingEscapes = escapes{^escape, ^escapedTerm, ^escaped00, ^escapedFF, bytesMarker}
+	descendingEscapes = escapes{^escape, ^escapedTerm, ^escaped00, ^escapedFF, bytesDescMarker}
 )
 
-// EncodeBytes encodes the []byte value using an escape-based
+// EncodeBytesAscending encodes the []byte value using an escape-based
 // encoding. The encoded value is terminated with the sequence
 // "\x00\x01" which is guaranteed to not occur elsewhere in the
 // encoded value. The encoded bytes are append to the supplied buffer
 // and the resulting buffer is returned.
-func EncodeBytes(b []byte, data []byte) []byte {
+func EncodeBytesAscending(b []byte, data []byte) []byte {
 	b = append(b, bytesMarker)
 	for {
 		// IndexByte is implemented by the go runtime in assembly and is
@@ -364,18 +386,42 @@ func EncodeBytes(b []byte, data []byte) []byte {
 	return append(b, escape, escapedTerm)
 }
 
-// EncodeBytesDecreasing encodes the []byte value using an
+// EncodeBytesDescending encodes the []byte value using an
 // escape-based encoding and then inverts (ones complement) the result
 // so that it sorts in reverse order, from larger to smaller
 // lexicographically.
-func EncodeBytesDecreasing(b []byte, data []byte) []byte {
+func EncodeBytesDescending(b []byte, data []byte) []byte {
 	n := len(b)
-	b = EncodeBytes(b, data)
+	b = EncodeBytesAscending(b, data)
+	b[n] = bytesDescMarker
 	onesComplement(b[n+1:])
 	return b
 }
 
-func decodeBytes(b []byte, r []byte, e escapes) ([]byte, []byte, error) {
+// DecodeBytesAscending decodes a []byte value from the input buffer
+// which was encoded using EncodeBytesAscending. The decoded bytes
+// are appended to r. The remainder of the input buffer and the
+// decoded []byte are returned.
+func DecodeBytesAscending(b []byte, r []byte) ([]byte, []byte, error) {
+	return decodeBytesInternal(b, r, ascendingEscapes)
+}
+
+// DecodeBytesDescending decodes a []byte value from the input buffer
+// which was encoded using EncodeBytesDescending. The decoded bytes
+// are appended to r. The remainder of the input buffer and the
+// decoded []byte are returned.
+func DecodeBytesDescending(b []byte, r []byte) ([]byte, []byte, error) {
+	// Always pass an `r` to make sure we never get back a sub-slice of `b`,
+	// since we're going to modify the contents of the slice.
+	if r == nil {
+		r = []byte{}
+	}
+	b, r, err := decodeBytesInternal(b, r, descendingEscapes)
+	onesComplement(r)
+	return b, r, err
+}
+
+func decodeBytesInternal(b []byte, r []byte, e escapes) ([]byte, []byte, error) {
 	if len(b) == 0 || b[0] != e.marker {
 		return nil, nil, util.Errorf("did not find marker")
 	}
@@ -411,103 +457,84 @@ func decodeBytes(b []byte, r []byte, e escapes) ([]byte, []byte, error) {
 	}
 }
 
-// DecodeBytes decodes a []byte value from the input buffer which was
-// encoded using EncodeBytes. The decoded bytes are appended to r. The
-// remainder of the input buffer and the decoded []byte are returned.
-func DecodeBytes(b []byte, r []byte) ([]byte, []byte, error) {
-	return decodeBytes(b, r, ascendingEscapes)
-}
-
-// DecodeBytesDecreasing decodes a []byte value from the input buffer
-// which was encoded using EncodeBytesDecreasing. The decoded bytes
-// are appended to r. The remainder of the input buffer and the
-// decoded []byte are returned.
-func DecodeBytesDecreasing(b []byte, r []byte) ([]byte, []byte, error) {
-	if r == nil {
-		r = []byte{}
-	}
-	b, r, err := decodeBytes(b, r, descendingEscapes)
-	onesComplement(r)
-	return b, r, err
-}
-
-// EncodeString encodes the string value using an escape-based encoding. See
+// EncodeStringAscending encodes the string value using an escape-based encoding. See
 // EncodeBytes for details. The encoded bytes are append to the supplied buffer
 // and the resulting buffer is returned.
-func EncodeString(b []byte, s string) []byte {
+func EncodeStringAscending(b []byte, s string) []byte {
 	if len(s) == 0 {
-		return EncodeBytes(b, nil)
+		return EncodeBytesAscending(b, nil)
 	}
 	// We unsafely convert the string to a []byte to avoid the
 	// usual allocation when converting to a []byte. This is
-	// kosher because we know that EncodeBytes{,Decreasing} does
+	// kosher because we know that EncodeBytes{,Descending} does
 	// not keep a reference to the value it encodes. The first
 	// step is getting access to the string internals.
 	hdr := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	// Next we treat the string data as a maximally sized array which we
 	// slice. This usage is safe because the pointer value remains in the string.
 	arg := (*[0x7fffffff]byte)(unsafe.Pointer(hdr.Data))[:len(s):len(s)]
-	return EncodeBytes(b, arg)
+	return EncodeBytesAscending(b, arg)
 }
 
-// EncodeStringDecreasing encodes the string value using an escape-based
-// encoding. See EncodeBytesDecreasing for details. The encoded bytes are
-// append to the supplied buffer and the resulting buffer is returned.
-func EncodeStringDecreasing(b []byte, s string) []byte {
+// EncodeStringDescending is the descending version of EncodeStringAscending.
+func EncodeStringDescending(b []byte, s string) []byte {
 	if len(s) == 0 {
-		return EncodeBytesDecreasing(b, nil)
+		return EncodeBytesDescending(b, nil)
 	}
 	// We unsafely convert the string to a []byte to avoid the
 	// usual allocation when converting to a []byte. This is
-	// kosher because we know that EncodeBytes{,Decreasing} does
+	// kosher because we know that EncodeBytes{,Descending} does
 	// not keep a reference to the value it encodes. The first
 	// step is getting access to the string internals.
 	hdr := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	// Next we treat the string data as a maximally sized array which we
 	// slice. This usage is safe because the pointer value remains in the string.
 	arg := (*[0x7fffffff]byte)(unsafe.Pointer(hdr.Data))[:len(s):len(s)]
-	return EncodeBytesDecreasing(b, arg)
+	return EncodeBytesDescending(b, arg)
 }
 
-// DecodeString decodes a string value from the input buffer which was encoded
+// DecodeStringAscending decodes a string value from the input buffer which was encoded
 // using EncodeString or EncodeBytes. The r []byte is used as a temporary
 // buffer in order to avoid memory allocations. The remainder of the input
 // buffer and the decoded string are returned.
-func DecodeString(b []byte, r []byte) ([]byte, string, error) {
-	b, r, err := decodeBytes(b, r, ascendingEscapes)
+func DecodeStringAscending(b []byte, r []byte) ([]byte, string, error) {
+	b, r, err := DecodeBytesAscending(b, r)
 	return b, string(r), err
 }
 
-// DecodeStringDecreasing decodes a string value from the input buffer which
-// was encoded using EncodeStringDecreasing or EncodeBytesDecreasing. The r
+// DecodeStringDescending decodes a string value from the input buffer which
+// was encoded using EncodeStringDescending or EncodeBytesDescending. The r
 // []byte is used as a temporary buffer in order to avoid memory
 // allocations. The remainder of the input buffer and the decoded string are
 // returned.
-func DecodeStringDecreasing(b []byte, r []byte) ([]byte, string, error) {
-	// We need to pass in a non-nil "r" parameter here so that the output is
-	// always copied to a new string instead of just returning the input when
-	// when there are no embedded escapes.
-	if r == nil {
-		r = []byte{}
-	}
-	b, r, err := decodeBytes(b, r, descendingEscapes)
-	onesComplement(r)
+func DecodeStringDescending(b []byte, r []byte) ([]byte, string, error) {
+	b, r, err := DecodeBytesDescending(b, r)
 	return b, string(r), err
 }
 
-// EncodeNull encodes a NULL value. The encodes bytes are appended to the
+// EncodeNullAscending encodes a NULL value. The encodes bytes are appended to the
 // supplied buffer and the final buffer is returned. The encoded value for a
 // NULL is guaranteed to not be a prefix for the EncodeVarint, EncodeFloat,
 // EncodeBytes and EncodeString encodings.
-func EncodeNull(b []byte) []byte {
+func EncodeNullAscending(b []byte) []byte {
 	return append(b, encodedNull)
 }
 
-// EncodeNotNull encodes a value that is larger than the NULL marker encoded by
+// EncodeNullDescending is the descending equivalent of EncodeNullAscending.
+func EncodeNullDescending(b []byte) []byte {
+	return append(b, encodedNullDesc)
+}
+
+// EncodeNotNullAscending encodes a value that is larger than the NULL marker encoded by
 // EncodeNull but less than any encoded value returned by EncodeVarint,
 // EncodeFloat, EncodeBytes or EncodeString.
-func EncodeNotNull(b []byte) []byte {
+func EncodeNotNullAscending(b []byte) []byte {
 	return append(b, encodedNotNull)
+}
+
+// EncodeNotNullDescending is the descending equivalent of EncodeNotNullAscending.
+func EncodeNotNullDescending(b []byte) []byte {
+	return append(b, encodedNotNullDesc)
 }
 
 // DecodeIfNull decodes a NULL value from the input buffer. If the input buffer
@@ -517,6 +544,7 @@ func EncodeNotNull(b []byte) []byte {
 // NULL value encoding is guaranteed to never occur as the prefix for the
 // EncodeVarint, EncodeFloat, EncodeBytes and EncodeString encodings, it is
 // safe to call DecodeIfNull on their encoded values.
+// This function handles both ascendingly and descendingly encoded NULLs.
 func DecodeIfNull(b []byte) ([]byte, bool) {
 	if PeekType(b) == Null {
 		return b[1:], true
@@ -531,6 +559,7 @@ func DecodeIfNull(b []byte) ([]byte, bool) {
 // for the second result. Note that the not-NULL marker is identical to the
 // empty string encoding, so do not use this routine where it is necessary to
 // distinguish not-NULL from the empty string.
+// This function handles both ascendingly and descendingly encoded NULLs.
 func DecodeIfNotNull(b []byte) ([]byte, bool) {
 	if PeekType(b) == NotNull {
 		return b[1:], true
@@ -538,33 +567,60 @@ func DecodeIfNotNull(b []byte) ([]byte, bool) {
 	return b, false
 }
 
-// EncodeTime encodes a time value, appends it to the supplied buffer,
+// EncodeTimeAscending encodes a time value, appends it to the supplied buffer,
 // and returns the final buffer. The encoding is guaranteed to be ordered
 // Such that if t1.Before(t2) then after EncodeTime(b1, t1), and
 // EncodeTime(b2, t1), Compare(b1, b2) < 0. The time zone offset not
 // included in the encoding.
-func EncodeTime(b []byte, t time.Time) []byte {
+func EncodeTimeAscending(b []byte, t time.Time) []byte {
 	// Read the unix absolute time. This is the absolute time and is
 	// not time zone offset dependent.
 	b = append(b, timeMarker)
-	b = EncodeVarint(b, t.Unix())
-	b = EncodeVarint(b, int64(t.Nanosecond()))
+	b = EncodeVarintAscending(b, t.Unix())
+	b = EncodeVarintAscending(b, int64(t.Nanosecond()))
 	return b
 }
 
-// DecodeTime decodes a time.Time value which was encoded using
+// EncodeTimeDescending is the descending version of EncodeTimeAscending.
+func EncodeTimeDescending(b []byte, t time.Time) []byte {
+	// Read the unix absolute time. This is the absolute time and is
+	// not time zone offset dependent.
+	b = append(b, timeDescMarker)
+	b = EncodeVarintDescending(b, t.Unix())
+	b = EncodeVarintDescending(b, int64(t.Nanosecond()))
+	return b
+}
+
+// DecodeTimeAscending decodes a time.Time value which was encoded using
 // EncodeTime. The remainder of the input buffer and the decoded
 // time.Time are returned.
-func DecodeTime(b []byte) ([]byte, time.Time, error) {
+func DecodeTimeAscending(b []byte) ([]byte, time.Time, error) {
 	if PeekType(b) != Time {
 		return nil, time.Time{}, util.Errorf("did not find marker")
 	}
 	b = b[1:]
-	b, sec, err := DecodeVarint(b)
+	b, sec, err := DecodeVarintAscending(b)
 	if err != nil {
 		return b, time.Time{}, err
 	}
-	b, nsec, err := DecodeVarint(b)
+	b, nsec, err := DecodeVarintAscending(b)
+	if err != nil {
+		return b, time.Time{}, err
+	}
+	return b, time.Unix(sec, nsec), nil
+}
+
+// DecodeTimeDescending is the descending version of DecodeTimeAscending.
+func DecodeTimeDescending(b []byte) ([]byte, time.Time, error) {
+	if PeekType(b) != TimeDesc {
+		return nil, time.Time{}, util.Errorf("did not find marker")
+	}
+	b = b[1:]
+	b, sec, err := DecodeVarintDescending(b)
+	if err != nil {
+		return b, time.Time{}, err
+	}
+	b, nsec, err := DecodeVarintDescending(b)
 	if err != nil {
 		return b, time.Time{}, err
 	}
@@ -583,7 +639,9 @@ const (
 	Int
 	Float
 	Bytes
+	BytesDesc // Bytes encoded descendingly
 	Time
+	TimeDesc // Time encoded descendingly
 )
 
 // PeekType peeks at the type of the value encoded at the start of b.
@@ -591,17 +649,21 @@ func PeekType(b []byte) Type {
 	if len(b) >= 1 {
 		m := b[0]
 		switch {
-		case m == encodedNull:
+		case m == encodedNull || m == encodedNullDesc:
 			return Null
-		case m == encodedNotNull:
+		case m == encodedNotNull || m == encodedNotNullDesc:
 			return NotNull
 		case m == bytesMarker:
 			return Bytes
+		case m == bytesDescMarker:
+			return BytesDesc
 		case m == timeMarker:
 			return Time
+		case m == timeDescMarker:
+			return TimeDesc
 		case m >= IntMin && m <= IntMax:
 			return Int
-		case m >= floatNaN && m <= floatInfinity:
+		case m >= floatNaN && m <= floatNaNDesc:
 			return Float
 		}
 	}

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func testBasicEncodeDecode32(encFunc func([]byte, uint32) []byte,
-	dec func([]byte) ([]byte, uint32, error), decreasing bool, t *testing.T) {
+	decFunc func([]byte) ([]byte, uint32, error), decreasing bool, t *testing.T) {
 	testCases := []uint32{
 		0, 1,
 		1<<8 - 1, 1 << 8,
@@ -45,7 +45,7 @@ func testBasicEncodeDecode32(encFunc func([]byte, uint32) []byte,
 				t.Errorf("ordered constraint violated for %d: [% x] vs. [% x]", v, enc, lastEnc)
 			}
 		}
-		b, decode, err := dec(enc)
+		b, decode, err := decFunc(enc)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -76,29 +76,29 @@ func testCustomEncodeUint32(testCases []testCaseUint32,
 }
 
 func TestEncodeDecodeUint32(t *testing.T) {
-	testBasicEncodeDecode32(EncodeUint32, DecodeUint32, false, t)
+	testBasicEncodeDecode32(EncodeUint32Ascending, DecodeUint32Ascending, false, t)
 	testCases := []testCaseUint32{
 		{0, []byte{0x00, 0x00, 0x00, 0x00}},
 		{1, []byte{0x00, 0x00, 0x00, 0x01}},
 		{1 << 8, []byte{0x00, 0x00, 0x01, 0x00}},
 		{math.MaxUint32, []byte{0xff, 0xff, 0xff, 0xff}},
 	}
-	testCustomEncodeUint32(testCases, EncodeUint32, t)
+	testCustomEncodeUint32(testCases, EncodeUint32Ascending, t)
 }
 
-func TestEncodeDecodeUint32Decreasing(t *testing.T) {
-	testBasicEncodeDecode32(EncodeUint32Decreasing, DecodeUint32Decreasing, true, t)
+func TestEncodeDecodeUint32Descending(t *testing.T) {
+	testBasicEncodeDecode32(EncodeUint32Descending, DecodeUint32Descending, true, t)
 	testCases := []testCaseUint32{
 		{0, []byte{0xff, 0xff, 0xff, 0xff}},
 		{1, []byte{0xff, 0xff, 0xff, 0xfe}},
 		{1 << 8, []byte{0xff, 0xff, 0xfe, 0xff}},
 		{math.MaxUint32, []byte{0x00, 0x00, 0x00, 0x00}},
 	}
-	testCustomEncodeUint32(testCases, EncodeUint32Decreasing, t)
+	testCustomEncodeUint32(testCases, EncodeUint32Descending, t)
 }
 
 func testBasicEncodeDecodeUint64(encFunc func([]byte, uint64) []byte,
-	dec func([]byte) ([]byte, uint64, error), decreasing bool, t *testing.T) {
+	decFunc func([]byte) ([]byte, uint64, error), decreasing bool, t *testing.T) {
 	testCases := []uint64{
 		0, 1,
 		1<<8 - 1, 1 << 8,
@@ -120,7 +120,7 @@ func testBasicEncodeDecodeUint64(encFunc func([]byte, uint64) []byte,
 				t.Errorf("ordered constraint violated for %d: [% x] vs. [% x]", v, enc, lastEnc)
 			}
 		}
-		b, decode, err := dec(enc)
+		b, decode, err := decFunc(enc)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -136,7 +136,7 @@ func testBasicEncodeDecodeUint64(encFunc func([]byte, uint64) []byte,
 }
 
 func testBasicEncodeDecodeInt64(encFunc func([]byte, int64) []byte,
-	dec func([]byte) ([]byte, int64, error), decreasing bool, t *testing.T) {
+	decFunc func([]byte) ([]byte, int64, error), decreasing bool, t *testing.T) {
 	testCases := []int64{
 		math.MinInt64, math.MinInt64 + 1,
 		-1<<56 - 1, -1 << 56,
@@ -166,7 +166,7 @@ func testBasicEncodeDecodeInt64(encFunc func([]byte, int64) []byte,
 				t.Errorf("ordered constraint violated for %d: [% x] vs. [% x]", v, enc, lastEnc)
 			}
 		}
-		b, decode, err := dec(enc)
+		b, decode, err := decFunc(enc)
 		if err != nil {
 			t.Errorf("%v: %d [%x]", err, v, enc)
 			continue
@@ -191,7 +191,7 @@ func testCustomEncodeInt64(testCases []testCaseInt64,
 	for _, test := range testCases {
 		enc := encFunc(nil, test.value)
 		if bytes.Compare(enc, test.expEnc) != 0 {
-			t.Errorf("expected [% x]; got [% x]", test.expEnc, enc)
+			t.Errorf("expected [% x]; got [% x] (value: %d)", test.expEnc, enc, test.value)
 		}
 	}
 }
@@ -206,35 +206,35 @@ func testCustomEncodeUint64(testCases []testCaseUint64,
 	for _, test := range testCases {
 		enc := encFunc(nil, test.value)
 		if bytes.Compare(enc, test.expEnc) != 0 {
-			t.Errorf("expected [% x]; got [% x]", test.expEnc, enc)
+			t.Errorf("expected [% x]; got [% x] (value: %d)", test.expEnc, enc, test.value)
 		}
 	}
 }
 
 func TestEncodeDecodeUint64(t *testing.T) {
-	testBasicEncodeDecodeUint64(EncodeUint64, DecodeUint64, false, t)
+	testBasicEncodeDecodeUint64(EncodeUint64Ascending, DecodeUint64Ascending, false, t)
 	testCases := []testCaseUint64{
 		{0, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
 		{1, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}},
 		{1 << 8, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00}},
 		{math.MaxUint64, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
 	}
-	testCustomEncodeUint64(testCases, EncodeUint64, t)
+	testCustomEncodeUint64(testCases, EncodeUint64Ascending, t)
 }
 
 func TestEncodeDecodeUint64Decreasing(t *testing.T) {
-	testBasicEncodeDecodeUint64(EncodeUint64Decreasing, DecodeUint64Decreasing, true, t)
+	testBasicEncodeDecodeUint64(EncodeUint64Descending, DecodeUint64Descending, true, t)
 	testCases := []testCaseUint64{
 		{0, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
 		{1, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe}},
 		{1 << 8, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff}},
 		{math.MaxUint64, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
 	}
-	testCustomEncodeUint64(testCases, EncodeUint64Decreasing, t)
+	testCustomEncodeUint64(testCases, EncodeUint64Descending, t)
 }
 
 func TestEncodeDecodeVarint(t *testing.T) {
-	testBasicEncodeDecodeInt64(EncodeVarint, DecodeVarint, false, t)
+	testBasicEncodeDecodeInt64(EncodeVarintAscending, DecodeVarintAscending, false, t)
 	testCases := []testCaseInt64{
 		{math.MinInt64, []byte{0x80, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
 		{math.MinInt64 + 1, []byte{0x80, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}},
@@ -242,42 +242,53 @@ func TestEncodeDecodeVarint(t *testing.T) {
 		{-1, []byte{0x87, 0xff}},
 		{0, []byte{0x88}},
 		{1, []byte{0x89}},
-		{111, []byte{0xf7}},
-		{112, []byte{0xf8, 0x70}},
-		{1 << 8, []byte{0xf9, 0x01, 0x00}},
-		{math.MaxInt64, []byte{0xff, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
+		{109, []byte{0xf5}},
+		{112, []byte{0xf6, 0x70}},
+		{1 << 8, []byte{0xf7, 0x01, 0x00}},
+		{math.MaxInt64, []byte{0xfd, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
 	}
-	testCustomEncodeInt64(testCases, EncodeVarint, t)
+	testCustomEncodeInt64(testCases, EncodeVarintAscending, t)
 }
 
-func TestEncodeDecodeVarintDecreasing(t *testing.T) {
-	testBasicEncodeDecodeInt64(EncodeVarintDecreasing, DecodeVarintDecreasing, true, t)
+func TestEncodeDecodeVarintDescending(t *testing.T) {
+	testBasicEncodeDecodeInt64(EncodeVarintDescending, DecodeVarintDescending, true, t)
 	testCases := []testCaseInt64{
-		{math.MinInt64, []byte{0xff, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
-		{math.MinInt64 + 1, []byte{0xff, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe}},
-		{-1 << 8, []byte{0xf8, 0xff}},
-		{-112, []byte{0xf7}},
-		{-111, []byte{0xf6}},
+		{math.MinInt64, []byte{0xfd, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
+		{math.MinInt64 + 1, []byte{0xfd, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe}},
+		{-1 << 8, []byte{0xf6, 0xff}},
+		{-110, []byte{0xf5}},
 		{-1, []byte{0x88}},
 		{0, []byte{0x87, 0xff}},
 		{1, []byte{0x87, 0xfe}},
 		{1 << 8, []byte{0x86, 0xfe, 0xff}},
 		{math.MaxInt64, []byte{0x80, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
 	}
-	testCustomEncodeInt64(testCases, EncodeVarintDecreasing, t)
+	testCustomEncodeInt64(testCases, EncodeVarintDescending, t)
 }
 
 func TestEncodeDecodeUvarint(t *testing.T) {
-	testBasicEncodeDecodeUint64(EncodeUvarint, DecodeUvarint, false, t)
+	testBasicEncodeDecodeUint64(EncodeUvarintAscending, DecodeUvarintAscending, false, t)
 	testCases := []testCaseUint64{
 		{0, []byte{0x88}},
 		{1, []byte{0x89}},
-		{111, []byte{0xf7}},
-		{112, []byte{0xf8, 0x70}},
-		{1 << 8, []byte{0xf9, 0x01, 0x00}},
-		{math.MaxUint64, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
+		{109, []byte{0xf5}},
+		{110, []byte{0xf6, 0x6e}},
+		{1 << 8, []byte{0xf7, 0x01, 0x00}},
+		{math.MaxUint64, []byte{0xfd, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
 	}
-	testCustomEncodeUint64(testCases, EncodeUvarint, t)
+	testCustomEncodeUint64(testCases, EncodeUvarintAscending, t)
+}
+
+func TestEncodeDecodeUvarintDescending(t *testing.T) {
+	testBasicEncodeDecodeUint64(EncodeUvarintDescending, DecodeUvarintDescending, true, t)
+	testCases := []testCaseUint64{
+		{0, []byte{0x88}},
+		{1, []byte{0x87, 0xfe}},
+		{1 << 8, []byte{0x86, 0xfe, 0xff}},
+		{math.MaxUint64 - 1, []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}},
+		{math.MaxUint64, []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+	}
+	testCustomEncodeUint64(testCases, EncodeUvarintDescending, t)
 }
 
 // TestDecodeInvalid tests that decoding invalid bytes panics.
@@ -292,67 +303,67 @@ func TestDecodeInvalid(t *testing.T) {
 			name:    "DecodeVarint, overflows int64",
 			buf:     []byte{IntMax, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			pattern: "varint [0-9]+ overflows int64",
-			decode:  func(b []byte) error { _, _, err := DecodeVarint(b); return err },
+			decode:  func(b []byte) error { _, _, err := DecodeVarintAscending(b); return err },
 		},
 		{
 			name:    "Bytes, no marker",
 			buf:     []byte{'a'},
 			pattern: "did not find marker",
-			decode:  func(b []byte) error { _, _, err := DecodeBytes(b, nil); return err },
+			decode:  func(b []byte) error { _, _, err := DecodeBytesAscending(b, nil); return err },
 		},
 		{
 			name:    "Bytes, no terminator",
 			buf:     []byte{bytesMarker, 'a'},
 			pattern: "did not find terminator",
-			decode:  func(b []byte) error { _, _, err := DecodeBytes(b, nil); return err },
+			decode:  func(b []byte) error { _, _, err := DecodeBytesAscending(b, nil); return err },
 		},
 		{
 			name:    "Bytes, malformed escape",
 			buf:     []byte{bytesMarker, 'a', 0x00},
 			pattern: "malformed escape",
-			decode:  func(b []byte) error { _, _, err := DecodeBytes(b, nil); return err },
+			decode:  func(b []byte) error { _, _, err := DecodeBytesAscending(b, nil); return err },
 		},
 		{
 			name:    "Bytes, invalid escape 1",
 			buf:     []byte{bytesMarker, 'a', 0x00, 0x00},
 			pattern: "unknown escape",
-			decode:  func(b []byte) error { _, _, err := DecodeBytes(b, nil); return err },
+			decode:  func(b []byte) error { _, _, err := DecodeBytesAscending(b, nil); return err },
 		},
 		{
 			name:    "Bytes, invalid escape 2",
 			buf:     []byte{bytesMarker, 'a', 0x00, 0x02},
 			pattern: "unknown escape",
-			decode:  func(b []byte) error { _, _, err := DecodeBytes(b, nil); return err },
+			decode:  func(b []byte) error { _, _, err := DecodeBytesAscending(b, nil); return err },
 		},
 		{
 			name:    "BytesDecreasing, no marker",
 			buf:     []byte{'a'},
 			pattern: "did not find marker",
-			decode:  func(b []byte) error { _, _, err := DecodeBytes(b, nil); return err },
+			decode:  func(b []byte) error { _, _, err := DecodeBytesAscending(b, nil); return err },
 		},
 		{
 			name:    "BytesDecreasing, no terminator",
-			buf:     []byte{bytesMarker, ^byte('a')},
+			buf:     []byte{bytesDescMarker, ^byte('a')},
 			pattern: "did not find terminator",
-			decode:  func(b []byte) error { _, _, err := DecodeBytesDecreasing(b, nil); return err },
+			decode:  func(b []byte) error { _, _, err := DecodeBytesDescending(b, nil); return err },
 		},
 		{
 			name:    "BytesDecreasing, malformed escape",
-			buf:     []byte{bytesMarker, ^byte('a'), 0xff},
+			buf:     []byte{bytesDescMarker, ^byte('a'), 0xff},
 			pattern: "malformed escape",
-			decode:  func(b []byte) error { _, _, err := DecodeBytesDecreasing(b, nil); return err },
+			decode:  func(b []byte) error { _, _, err := DecodeBytesDescending(b, nil); return err },
 		},
 		{
 			name:    "BytesDecreasing, invalid escape 1",
-			buf:     []byte{bytesMarker, ^byte('a'), 0xff, 0xff},
+			buf:     []byte{bytesDescMarker, ^byte('a'), 0xff, 0xff},
 			pattern: "unknown escape",
-			decode:  func(b []byte) error { _, _, err := DecodeBytesDecreasing(b, nil); return err },
+			decode:  func(b []byte) error { _, _, err := DecodeBytesDescending(b, nil); return err },
 		},
 		{
 			name:    "BytesDecreasing, invalid escape 2",
-			buf:     []byte{bytesMarker, ^byte('a'), 0xff, 0xfd},
+			buf:     []byte{bytesDescMarker, ^byte('a'), 0xff, 0xfd},
 			pattern: "unknown escape",
-			decode:  func(b []byte) error { _, _, err := DecodeBytesDecreasing(b, nil); return err },
+			decode:  func(b []byte) error { _, _, err := DecodeBytesDescending(b, nil); return err },
 		},
 	}
 	for _, test := range tests {
@@ -363,36 +374,24 @@ func TestDecodeInvalid(t *testing.T) {
 	}
 }
 
-func TestEncodeDecodeUvarintDecreasing(t *testing.T) {
-	testBasicEncodeDecodeUint64(EncodeUvarintDecreasing, DecodeUvarintDecreasing, true, t)
-	testCases := []testCaseUint64{
-		{0, []byte{0x88}},
-		{1, []byte{0x87, 0xfe}},
-		{1 << 8, []byte{0x86, 0xfe, 0xff}},
-		{math.MaxUint64 - 1, []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}},
-		{math.MaxUint64, []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-	}
-	testCustomEncodeUint64(testCases, EncodeUvarintDecreasing, t)
-}
-
 func TestEncodeDecodeBytes(t *testing.T) {
 	testCases := []struct {
 		value   []byte
 		encoded []byte
 	}{
-		{[]byte{0, 1, 'a'}, []byte{0x20, 0x00, 0xff, 1, 'a', 0x00, 0x01}},
-		{[]byte{0, 'a'}, []byte{0x20, 0x00, 0xff, 'a', 0x00, 0x01}},
-		{[]byte{0, 0xff, 'a'}, []byte{0x20, 0x00, 0xff, 0xff, 'a', 0x00, 0x01}},
-		{[]byte{'a'}, []byte{0x20, 'a', 0x00, 0x01}},
-		{[]byte{'b'}, []byte{0x20, 'b', 0x00, 0x01}},
-		{[]byte{'b', 0}, []byte{0x20, 'b', 0x00, 0xff, 0x00, 0x01}},
-		{[]byte{'b', 0, 0}, []byte{0x20, 'b', 0x00, 0xff, 0x00, 0xff, 0x00, 0x01}},
-		{[]byte{'b', 0, 0, 'a'}, []byte{0x20, 'b', 0x00, 0xff, 0x00, 0xff, 'a', 0x00, 0x01}},
-		{[]byte{'b', 0xff}, []byte{0x20, 'b', 0xff, 0x00, 0x01}},
-		{[]byte("hello"), []byte{0x20, 'h', 'e', 'l', 'l', 'o', 0x00, 0x01}},
+		{[]byte{0, 1, 'a'}, []byte{0x21, 0x00, 0xff, 1, 'a', 0x00, 0x01}},
+		{[]byte{0, 'a'}, []byte{0x21, 0x00, 0xff, 'a', 0x00, 0x01}},
+		{[]byte{0, 0xff, 'a'}, []byte{0x21, 0x00, 0xff, 0xff, 'a', 0x00, 0x01}},
+		{[]byte{'a'}, []byte{0x21, 'a', 0x00, 0x01}},
+		{[]byte{'b'}, []byte{0x21, 'b', 0x00, 0x01}},
+		{[]byte{'b', 0}, []byte{0x21, 'b', 0x00, 0xff, 0x00, 0x01}},
+		{[]byte{'b', 0, 0}, []byte{0x21, 'b', 0x00, 0xff, 0x00, 0xff, 0x00, 0x01}},
+		{[]byte{'b', 0, 0, 'a'}, []byte{0x21, 'b', 0x00, 0xff, 0x00, 0xff, 'a', 0x00, 0x01}},
+		{[]byte{'b', 0xff}, []byte{0x21, 'b', 0xff, 0x00, 0x01}},
+		{[]byte("hello"), []byte{0x21, 'h', 'e', 'l', 'l', 'o', 0x00, 0x01}},
 	}
 	for i, c := range testCases {
-		enc := EncodeBytes(nil, c.value)
+		enc := EncodeBytesAscending(nil, c.value)
 		if !bytes.Equal(enc, c.encoded) {
 			t.Errorf("unexpected encoding mismatch for %v. expected [% x], got [% x]",
 				c.value, c.encoded, enc)
@@ -403,7 +402,7 @@ func TestEncodeDecodeBytes(t *testing.T) {
 					c.value, testCases[i-1].encoded, enc)
 			}
 		}
-		remainder, dec, err := DecodeBytes(enc, nil)
+		remainder, dec, err := DecodeBytesAscending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -416,7 +415,7 @@ func TestEncodeDecodeBytes(t *testing.T) {
 		}
 
 		enc = append(enc, []byte("remainder")...)
-		remainder, _, err = DecodeBytes(enc, nil)
+		remainder, _, err = DecodeBytesAscending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -427,27 +426,27 @@ func TestEncodeDecodeBytes(t *testing.T) {
 	}
 }
 
-func TestEncodeDecodeBytesDecreasing(t *testing.T) {
+func TestEncodeDecodeBytesDescending(t *testing.T) {
 	testCases := []struct {
 		value   []byte
 		encoded []byte
 	}{
-		{[]byte("hello"), []byte{0x20, ^byte('h'), ^byte('e'), ^byte('l'), ^byte('l'), ^byte('o'), 0xff, 0xfe}},
-		{[]byte{'b', 0xff}, []byte{0x20, ^byte('b'), 0x00, 0xff, 0xfe}},
-		{[]byte{'b', 0, 0, 'a'}, []byte{0x20, ^byte('b'), 0xff, 0x00, 0xff, 0x00, ^byte('a'), 0xff, 0xfe}},
-		{[]byte{'b', 0, 0}, []byte{0x20, ^byte('b'), 0xff, 0x00, 0xff, 0x00, 0xff, 0xfe}},
-		{[]byte{'b', 0}, []byte{0x20, ^byte('b'), 0xff, 0x00, 0xff, 0xfe}},
-		{[]byte{'b'}, []byte{0x20, ^byte('b'), 0xff, 0xfe}},
-		{[]byte{'a'}, []byte{0x20, ^byte('a'), 0xff, 0xfe}},
-		{[]byte{0, 0xff, 'a'}, []byte{0x20, 0xff, 0x00, 0x00, ^byte('a'), 0xff, 0xfe}},
-		{[]byte{0, 'a'}, []byte{0x20, 0xff, 0x00, ^byte('a'), 0xff, 0xfe}},
-		{[]byte{0, 1, 'a'}, []byte{0x20, 0xff, 0x00, 0xfe, ^byte('a'), 0xff, 0xfe}},
+		{[]byte("hello"), []byte{0x23, ^byte('h'), ^byte('e'), ^byte('l'), ^byte('l'), ^byte('o'), 0xff, 0xfe}},
+		{[]byte{'b', 0xff}, []byte{0x23, ^byte('b'), 0x00, 0xff, 0xfe}},
+		{[]byte{'b', 0, 0, 'a'}, []byte{0x23, ^byte('b'), 0xff, 0x00, 0xff, 0x00, ^byte('a'), 0xff, 0xfe}},
+		{[]byte{'b', 0, 0}, []byte{0x23, ^byte('b'), 0xff, 0x00, 0xff, 0x00, 0xff, 0xfe}},
+		{[]byte{'b', 0}, []byte{0x23, ^byte('b'), 0xff, 0x00, 0xff, 0xfe}},
+		{[]byte{'b'}, []byte{0x23, ^byte('b'), 0xff, 0xfe}},
+		{[]byte{'a'}, []byte{0x23, ^byte('a'), 0xff, 0xfe}},
+		{[]byte{0, 0xff, 'a'}, []byte{0x23, 0xff, 0x00, 0x00, ^byte('a'), 0xff, 0xfe}},
+		{[]byte{0, 'a'}, []byte{0x23, 0xff, 0x00, ^byte('a'), 0xff, 0xfe}},
+		{[]byte{0, 1, 'a'}, []byte{0x23, 0xff, 0x00, 0xfe, ^byte('a'), 0xff, 0xfe}},
 	}
 	for i, c := range testCases {
-		enc := EncodeBytesDecreasing(nil, c.value)
+		enc := EncodeBytesDescending(nil, c.value)
 		if !bytes.Equal(enc, c.encoded) {
-			t.Errorf("unexpected encoding mismatch for %v. expected [% x], got [% x]",
-				c.value, c.encoded, enc)
+			t.Errorf("%d: unexpected encoding mismatch for %v ([% x]). expected [% x], got [% x]",
+				i, c.value, c.value, c.encoded, enc)
 		}
 		if i > 0 {
 			if bytes.Compare(testCases[i-1].encoded, enc) >= 0 {
@@ -455,7 +454,7 @@ func TestEncodeDecodeBytesDecreasing(t *testing.T) {
 					c.value, testCases[i-1].encoded, enc)
 			}
 		}
-		remainder, dec, err := DecodeBytesDecreasing(enc, nil)
+		remainder, dec, err := DecodeBytesDescending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -468,7 +467,7 @@ func TestEncodeDecodeBytesDecreasing(t *testing.T) {
 		}
 
 		enc = append(enc, []byte("remainder")...)
-		remainder, _, err = DecodeBytesDecreasing(enc, nil)
+		remainder, _, err = DecodeBytesDescending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -484,19 +483,19 @@ func TestEncodeDecodeString(t *testing.T) {
 		value   string
 		encoded []byte
 	}{
-		{"\x00\x01a", []byte{0x20, 0x00, 0xff, 1, 'a', 0x00, 0x01}},
-		{"\x00a", []byte{0x20, 0x00, 0xff, 'a', 0x00, 0x01}},
-		{"\x00\xffa", []byte{0x20, 0x00, 0xff, 0xff, 'a', 0x00, 0x01}},
-		{"a", []byte{0x20, 'a', 0x00, 0x01}},
-		{"b", []byte{0x20, 'b', 0x00, 0x01}},
-		{"b\x00", []byte{0x20, 'b', 0x00, 0xff, 0x00, 0x01}},
-		{"b\x00\x00", []byte{0x20, 'b', 0x00, 0xff, 0x00, 0xff, 0x00, 0x01}},
-		{"b\x00\x00a", []byte{0x20, 'b', 0x00, 0xff, 0x00, 0xff, 'a', 0x00, 0x01}},
-		{"b\xff", []byte{0x20, 'b', 0xff, 0x00, 0x01}},
-		{"hello", []byte{0x20, 'h', 'e', 'l', 'l', 'o', 0x00, 0x01}},
+		{"\x00\x01a", []byte{0x21, 0x00, 0xff, 1, 'a', 0x00, 0x01}},
+		{"\x00a", []byte{0x21, 0x00, 0xff, 'a', 0x00, 0x01}},
+		{"\x00\xffa", []byte{0x21, 0x00, 0xff, 0xff, 'a', 0x00, 0x01}},
+		{"a", []byte{0x21, 'a', 0x00, 0x01}},
+		{"b", []byte{0x21, 'b', 0x00, 0x01}},
+		{"b\x00", []byte{0x21, 'b', 0x00, 0xff, 0x00, 0x01}},
+		{"b\x00\x00", []byte{0x21, 'b', 0x00, 0xff, 0x00, 0xff, 0x00, 0x01}},
+		{"b\x00\x00a", []byte{0x21, 'b', 0x00, 0xff, 0x00, 0xff, 'a', 0x00, 0x01}},
+		{"b\xff", []byte{0x21, 'b', 0xff, 0x00, 0x01}},
+		{"hello", []byte{0x21, 'h', 'e', 'l', 'l', 'o', 0x00, 0x01}},
 	}
 	for i, c := range testCases {
-		enc := EncodeString(nil, c.value)
+		enc := EncodeStringAscending(nil, c.value)
 		if !bytes.Equal(enc, c.encoded) {
 			t.Errorf("unexpected encoding mismatch for %v. expected [% x], got [% x]",
 				c.value, c.encoded, enc)
@@ -507,7 +506,7 @@ func TestEncodeDecodeString(t *testing.T) {
 					c.value, testCases[i-1].encoded, enc)
 			}
 		}
-		remainder, dec, err := DecodeString(enc, nil)
+		remainder, dec, err := DecodeStringAscending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -520,7 +519,7 @@ func TestEncodeDecodeString(t *testing.T) {
 		}
 
 		enc = append(enc, "remainder"...)
-		remainder, _, err = DecodeString(enc, nil)
+		remainder, _, err = DecodeStringAscending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -536,19 +535,19 @@ func TestEncodeDecodeStringDecreasing(t *testing.T) {
 		value   string
 		encoded []byte
 	}{
-		{"hello", []byte{0x20, ^byte('h'), ^byte('e'), ^byte('l'), ^byte('l'), ^byte('o'), 0xff, 0xfe}},
-		{"b\xff", []byte{0x20, ^byte('b'), 0x00, 0xff, 0xfe}},
-		{"b\x00\x00a", []byte{0x20, ^byte('b'), 0xff, 0x00, 0xff, 0x00, ^byte('a'), 0xff, 0xfe}},
-		{"b\x00\x00", []byte{0x20, ^byte('b'), 0xff, 0x00, 0xff, 0x00, 0xff, 0xfe}},
-		{"b\x00", []byte{0x20, ^byte('b'), 0xff, 0x00, 0xff, 0xfe}},
-		{"b", []byte{0x20, ^byte('b'), 0xff, 0xfe}},
-		{"a", []byte{0x20, ^byte('a'), 0xff, 0xfe}},
-		{"\x00\xffa", []byte{0x20, 0xff, 0x00, 0x00, ^byte('a'), 0xff, 0xfe}},
-		{"\x00a", []byte{0x20, 0xff, 0x00, ^byte('a'), 0xff, 0xfe}},
-		{"\x00\x01a", []byte{0x20, 0xff, 0x00, 0xfe, ^byte('a'), 0xff, 0xfe}},
+		{"hello", []byte{0x23, ^byte('h'), ^byte('e'), ^byte('l'), ^byte('l'), ^byte('o'), 0xff, 0xfe}},
+		{"b\xff", []byte{0x23, ^byte('b'), 0x00, 0xff, 0xfe}},
+		{"b\x00\x00a", []byte{0x23, ^byte('b'), 0xff, 0x00, 0xff, 0x00, ^byte('a'), 0xff, 0xfe}},
+		{"b\x00\x00", []byte{0x23, ^byte('b'), 0xff, 0x00, 0xff, 0x00, 0xff, 0xfe}},
+		{"b\x00", []byte{0x23, ^byte('b'), 0xff, 0x00, 0xff, 0xfe}},
+		{"b", []byte{0x23, ^byte('b'), 0xff, 0xfe}},
+		{"a", []byte{0x23, ^byte('a'), 0xff, 0xfe}},
+		{"\x00\xffa", []byte{0x23, 0xff, 0x00, 0x00, ^byte('a'), 0xff, 0xfe}},
+		{"\x00a", []byte{0x23, 0xff, 0x00, ^byte('a'), 0xff, 0xfe}},
+		{"\x00\x01a", []byte{0x23, 0xff, 0x00, 0xfe, ^byte('a'), 0xff, 0xfe}},
 	}
 	for i, c := range testCases {
-		enc := EncodeStringDecreasing(nil, c.value)
+		enc := EncodeStringDescending(nil, c.value)
 		if !bytes.Equal(enc, c.encoded) {
 			t.Errorf("unexpected encoding mismatch for %v. expected [% x], got [% x]",
 				c.value, c.encoded, enc)
@@ -559,20 +558,20 @@ func TestEncodeDecodeStringDecreasing(t *testing.T) {
 					c.value, testCases[i-1].encoded, enc)
 			}
 		}
-		remainder, dec, err := DecodeStringDecreasing(enc, nil)
+		remainder, dec, err := DecodeStringDescending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
 		}
 		if c.value != dec {
-			t.Errorf("unexpected decoding mismatch for %v. got %v", c.value, dec)
+			t.Errorf("unexpected decoding mismatch for %v. got [% x]", c.value, dec)
 		}
 		if len(remainder) != 0 {
 			t.Errorf("unexpected remaining bytes: %v", remainder)
 		}
 
 		enc = append(enc, "remainder"...)
-		remainder, _, err = DecodeStringDecreasing(enc, nil)
+		remainder, _, err = DecodeStringDescending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -586,7 +585,7 @@ func TestEncodeDecodeStringDecreasing(t *testing.T) {
 func TestEncodeDecodeNull(t *testing.T) {
 	const hello = "hello"
 
-	buf := EncodeNull([]byte(hello))
+	buf := EncodeNullAscending([]byte(hello))
 	expected := []byte(hello + "\x00")
 	if !bytes.Equal(expected, buf) {
 		t.Fatalf("expected %q, but found %q", expected, buf)
@@ -644,34 +643,48 @@ func TestEncodeDecodeTime(t *testing.T) {
 
 	var last time.Time
 	var lastEncoded []byte
-	for i := range testCases {
-		d, err := time.ParseDuration(testCases[i])
-		if err != nil {
-			t.Fatal(err)
-		}
-		current := zeroTime.Add(d)
-		var b []byte
-		if !last.IsZero() {
-			b = EncodeTime(b, current)
-			_, decodedCurrent, err := DecodeTime(b)
+	for _, dir := range []Direction{Ascending, Descending} {
+		for i := range testCases {
+			d, err := time.ParseDuration(testCases[i])
 			if err != nil {
-				t.Error(err)
-				continue
+				t.Fatal(err)
 			}
-			if !decodedCurrent.Equal(current) {
-				t.Fatalf("lossy transport: before (%v) vs after (%v)", current, decodedCurrent)
+			current := zeroTime.Add(d)
+			var b []byte
+			var decodedCurrent time.Time
+			if !last.IsZero() {
+				if dir == Ascending {
+					b = EncodeTimeAscending(b, current)
+					_, decodedCurrent, err = DecodeTimeAscending(b)
+				} else {
+					b = EncodeTimeDescending(b, current)
+					_, decodedCurrent, err = DecodeTimeDescending(b)
+				}
+				if err != nil {
+					t.Error(err)
+					continue
+				}
+				if !decodedCurrent.Equal(current) {
+					t.Fatalf("lossy transport: before (%v) vs after (%v)", current, decodedCurrent)
+				}
+				if i > 0 {
+					if (bytes.Compare(lastEncoded, b) >= 0 && dir == Ascending) ||
+						(bytes.Compare(lastEncoded, b) <= 0 && dir == Descending) {
+						t.Fatalf("encodings %s, %s not increasing", testCases[i-1], testCases[i])
+					}
+				}
 			}
-			if bytes.Compare(lastEncoded, b) >= 0 {
-				t.Fatalf("encodings %s, %s not increasing", testCases[i-1], testCases[i])
+			last = current
+			lastEncoded = b
+		}
+
+		// Check that the encoding hasn't changed.
+		if dir == Ascending {
+			a, e := lastEncoded, []byte("\x22\xfa\x01 \xbc\x0e\xae\xf9\r\xf2\x8e\x80")
+			if !bytes.Equal(a, e) {
+				t.Errorf("encoding has changed:\nexpected [% x]\nactual   [% x]", e, a)
 			}
 		}
-		last = current
-		lastEncoded = b
-	}
-
-	// Check that the encoding hasn't changed.
-	if a, e := lastEncoded, []byte("\x21\xfc\x01 \xbc\x0e\xae\xfb\r\xf2\x8e\x80"); !bytes.Equal(a, e) {
-		t.Errorf("encoding has changed:\nexpected %x\nactual   %x", e, a)
 	}
 }
 
@@ -680,13 +693,20 @@ func TestPeekType(t *testing.T) {
 		enc []byte
 		typ Type
 	}{
-		{EncodeNull(nil), Null},
-		{EncodeNotNull(nil), NotNull},
-		{EncodeVarint(nil, 0), Int},
-		{EncodeUvarint(nil, 0), Int},
-		{EncodeFloat(nil, 0), Float},
-		{EncodeBytes(nil, []byte("")), Bytes},
-		{EncodeTime(nil, time.Now()), Time},
+		{EncodeNullAscending(nil), Null},
+		{EncodeNotNullAscending(nil), NotNull},
+		{EncodeNullDescending(nil), Null},
+		{EncodeNotNullDescending(nil), NotNull},
+		{EncodeVarintAscending(nil, 0), Int},
+		{EncodeVarintDescending(nil, 0), Int},
+		{EncodeUvarintAscending(nil, 0), Int},
+		{EncodeUvarintDescending(nil, 0), Int},
+		{EncodeFloatAscending(nil, 0), Float},
+		{EncodeFloatDescending(nil, 0), Float},
+		{EncodeBytesAscending(nil, []byte("")), Bytes},
+		{EncodeBytesDescending(nil, []byte("")), BytesDesc},
+		{EncodeTimeAscending(nil, time.Now()), Time},
+		{EncodeTimeDescending(nil, time.Now()), TimeDesc},
 	}
 	for i, c := range testCases {
 		typ := PeekType(c.enc)
@@ -708,7 +728,7 @@ func BenchmarkEncodeUint32(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EncodeUint32(buf, vals[i%len(vals)])
+		_ = EncodeUint32Ascending(buf, vals[i%len(vals)])
 	}
 }
 
@@ -717,12 +737,12 @@ func BenchmarkDecodeUint32(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		vals[i] = EncodeUint32(nil, uint32(rng.Int31()))
+		vals[i] = EncodeUint32Ascending(nil, uint32(rng.Int31()))
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeUint32(vals[i%len(vals)])
+		_, _, _ = DecodeUint32Ascending(vals[i%len(vals)])
 	}
 }
 
@@ -738,7 +758,7 @@ func BenchmarkEncodeUint64(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EncodeUint64(buf, vals[i%len(vals)])
+		_ = EncodeUint64Ascending(buf, vals[i%len(vals)])
 	}
 }
 
@@ -747,12 +767,12 @@ func BenchmarkDecodeUint64(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		vals[i] = EncodeUint64(nil, uint64(rng.Int63()))
+		vals[i] = EncodeUint64Ascending(nil, uint64(rng.Int63()))
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeUint64(vals[i%len(vals)])
+		_, _, _ = DecodeUint64Ascending(vals[i%len(vals)])
 	}
 }
 
@@ -768,7 +788,7 @@ func BenchmarkEncodeVarint(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EncodeVarint(buf, vals[i%len(vals)])
+		_ = EncodeVarintAscending(buf, vals[i%len(vals)])
 	}
 }
 
@@ -777,12 +797,12 @@ func BenchmarkDecodeVarint(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		vals[i] = EncodeVarint(nil, rng.Int63())
+		vals[i] = EncodeVarintAscending(nil, rng.Int63())
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeVarint(vals[i%len(vals)])
+		_, _, _ = DecodeVarintAscending(vals[i%len(vals)])
 	}
 }
 
@@ -798,7 +818,7 @@ func BenchmarkEncodeUvarint(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EncodeUvarint(buf, vals[i%len(vals)])
+		_ = EncodeUvarintAscending(buf, vals[i%len(vals)])
 	}
 }
 
@@ -807,12 +827,12 @@ func BenchmarkDecodeUvarint(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		vals[i] = EncodeUvarint(nil, uint64(rng.Int63()))
+		vals[i] = EncodeUvarintAscending(nil, uint64(rng.Int63()))
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeUvarint(vals[i%len(vals)])
+		_, _, _ = DecodeUvarintAscending(vals[i%len(vals)])
 	}
 }
 
@@ -828,7 +848,7 @@ func BenchmarkEncodeBytes(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EncodeBytes(buf, vals[i%len(vals)])
+		_ = EncodeBytesAscending(buf, vals[i%len(vals)])
 	}
 }
 
@@ -844,7 +864,7 @@ func BenchmarkEncodeBytesDecreasing(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EncodeBytesDecreasing(buf, vals[i%len(vals)])
+		_ = EncodeBytesDescending(buf, vals[i%len(vals)])
 	}
 }
 
@@ -853,14 +873,14 @@ func BenchmarkDecodeBytes(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		vals[i] = EncodeBytes(nil, randutil.RandBytes(rng, 100))
+		vals[i] = EncodeBytesAscending(nil, randutil.RandBytes(rng, 100))
 	}
 
 	buf := make([]byte, 0, 1000)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeBytes(vals[i%len(vals)], buf)
+		_, _, _ = DecodeBytesAscending(vals[i%len(vals)], buf)
 	}
 }
 
@@ -869,14 +889,14 @@ func BenchmarkDecodeBytesDecreasing(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		vals[i] = EncodeBytesDecreasing(nil, randutil.RandBytes(rng, 100))
+		vals[i] = EncodeBytesDescending(nil, randutil.RandBytes(rng, 100))
 	}
 
 	buf := make([]byte, 0, 1000)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeBytesDecreasing(vals[i%len(vals)], buf)
+		_, _, _ = DecodeBytesDescending(vals[i%len(vals)], buf)
 	}
 }
 
@@ -892,11 +912,11 @@ func BenchmarkEncodeString(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EncodeString(buf, vals[i%len(vals)])
+		_ = EncodeStringAscending(buf, vals[i%len(vals)])
 	}
 }
 
-func BenchmarkEncodeStringDecreasing(b *testing.B) {
+func BenchmarkEncodeStringDescending(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 
 	vals := make([]string, 10000)
@@ -908,7 +928,7 @@ func BenchmarkEncodeStringDecreasing(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EncodeStringDecreasing(buf, vals[i%len(vals)])
+		_ = EncodeStringDescending(buf, vals[i%len(vals)])
 	}
 }
 
@@ -917,14 +937,14 @@ func BenchmarkDecodeString(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		vals[i] = EncodeString(nil, string(randutil.RandBytes(rng, 100)))
+		vals[i] = EncodeStringAscending(nil, string(randutil.RandBytes(rng, 100)))
 	}
 
 	buf := make([]byte, 0, 1000)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeString(vals[i%len(vals)], buf)
+		_, _, _ = DecodeStringAscending(vals[i%len(vals)], buf)
 	}
 }
 
@@ -933,13 +953,13 @@ func BenchmarkDecodeStringDecreasing(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		vals[i] = EncodeStringDecreasing(nil, string(randutil.RandBytes(rng, 100)))
+		vals[i] = EncodeStringDescending(nil, string(randutil.RandBytes(rng, 100)))
 	}
 
 	buf := make([]byte, 0, 1000)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeStringDecreasing(vals[i%len(vals)], buf)
+		_, _, _ = DecodeStringDescending(vals[i%len(vals)], buf)
 	}
 }

--- a/util/encoding/float.go
+++ b/util/encoding/float.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 )
 
-// EncodeFloat returns the resulting byte slice with the encoded float64
+// EncodeFloatAscending returns the resulting byte slice with the encoded float64
 // appended to b.
 //
 // Values are classified as large, medium, or small according to the value of
@@ -48,7 +48,7 @@ import (
 // as a byte 0x13-E followed by the ones-complement of M. Large negative values
 // consist of the single byte 0x08 followed by the ones-complement of the
 // varint encoding of E followed by the ones-complement of M.
-func EncodeFloat(b []byte, f float64) []byte {
+func EncodeFloatAscending(b []byte, f float64) []byte {
 	// Handle the simplistic cases first.
 	switch {
 	case math.IsNaN(f):
@@ -79,9 +79,17 @@ func EncodeFloat(b []byte, f float64) []byte {
 	return nil
 }
 
-// DecodeFloat returns the remaining byte slice after decoding and the decoded
+// EncodeFloatDescending is the descending version of EncodeFloatAscending.
+func EncodeFloatDescending(b []byte, f float64) []byte {
+	if math.IsNaN(f) {
+		return append(b, floatNaNDesc)
+	}
+	return EncodeFloatAscending(b, -f)
+}
+
+// DecodeFloatAscending returns the remaining byte slice after decoding and the decoded
 // float64 from buf.
-func DecodeFloat(buf []byte, tmp []byte) ([]byte, float64, error) {
+func DecodeFloatAscending(buf []byte, tmp []byte) ([]byte, float64, error) {
 	if buf[0] == floatZero {
 		return buf[1:], 0, nil
 	}
@@ -89,6 +97,8 @@ func DecodeFloat(buf []byte, tmp []byte) ([]byte, float64, error) {
 	idx := bytes.Index(buf, []byte{floatTerminator})
 	switch {
 	case buf[0] == floatNaN:
+		return buf[1:], math.NaN(), nil
+	case buf[0] == floatNaNDesc:
 		return buf[1:], math.NaN(), nil
 	case buf[0] == floatInfinity:
 		return buf[1:], math.Inf(1), nil
@@ -121,6 +131,12 @@ func DecodeFloat(buf []byte, tmp []byte) ([]byte, float64, error) {
 	default:
 		return nil, 0, util.Errorf("unknown prefix of the encoded byte slice: %q", buf)
 	}
+}
+
+// DecodeFloatDescending decodes floats encoded with EncodeFloatDescending.
+func DecodeFloatDescending(buf []byte, tmp []byte) ([]byte, float64, error) {
+	b, r, err := DecodeFloatAscending(buf, tmp)
+	return b, -r, err
 }
 
 // floatMandE computes and returns the mantissa M and exponent E for f.

--- a/util/encoding/float_test.go
+++ b/util/encoding/float_test.go
@@ -124,36 +124,57 @@ func TestEncodeFloat(t *testing.T) {
 		{math.Inf(1), []byte{0x1f}},
 	}
 
-	for i, c := range testCases {
-		enc := EncodeFloat(nil, c.Value)
-		if !bytes.Equal(enc, c.Encoding) {
-			t.Errorf("unexpected mismatch for %v. expected [% x], got [% x]",
-				c.Value, c.Encoding, enc)
-		}
-		if i > 0 {
-			if bytes.Compare(testCases[i-1].Encoding, enc) >= 0 {
-				t.Errorf("%v: expected [% x] to be less than [% x]",
-					c.Value, testCases[i-1].Encoding, enc)
+	var lastEncoded []byte
+	for _, dir := range []Direction{Ascending, Descending} {
+		for i, c := range testCases {
+			var enc []byte
+			var err error
+			var dec float64
+			if dir == Ascending {
+				enc = EncodeFloatAscending(nil, c.Value)
+				_, dec, err = DecodeFloatAscending(enc, nil)
+			} else {
+				enc = EncodeFloatDescending(nil, c.Value)
+				_, dec, err = DecodeFloatDescending(enc, nil)
 			}
-		}
-		_, dec, err := DecodeFloat(enc, nil)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-		if math.IsNaN(c.Value) {
-			if !math.IsNaN(dec) {
+			if dir == Ascending && !bytes.Equal(enc, c.Encoding) {
+				t.Errorf("unexpected mismatch for %v. expected [% x], got [% x]",
+					c.Value, c.Encoding, enc)
+			}
+			if i > 0 {
+				if (bytes.Compare(lastEncoded, enc) >= 0 && dir == Ascending) ||
+					(bytes.Compare(lastEncoded, enc) <= 0 && dir == Descending) {
+					t.Errorf("%v: expected [% x] to be less than [% x]",
+						c.Value, testCases[i-1].Encoding, enc)
+				}
+			}
+			if err != nil {
+				t.Error(err)
+				continue
+			}
+			if math.IsNaN(c.Value) {
+				if !math.IsNaN(dec) {
+					t.Errorf("unexpected mismatch for %v. got %v", c.Value, dec)
+				}
+			} else if dec != c.Value {
 				t.Errorf("unexpected mismatch for %v. got %v", c.Value, dec)
 			}
-		} else if dec != c.Value {
-			t.Errorf("unexpected mismatch for %v. got %v", c.Value, dec)
+			lastEncoded = enc
 		}
-	}
 
-	// Test that appending the float to an existing buffer works.
-	enc := EncodeFloat([]byte("hello"), 1.23)
-	if _, dec, _ := DecodeFloat(enc[5:], nil); dec != 1.23 {
-		t.Errorf("unexpected mismatch for %v. got %v", 1.23, dec)
+		// Test that appending the float to an existing buffer works.
+		var enc []byte
+		var dec float64
+		if dir == Ascending {
+			enc = EncodeFloatAscending([]byte("hello"), 1.23)
+			_, dec, _ = DecodeFloatAscending(enc[5:], nil)
+		} else {
+			enc = EncodeFloatDescending([]byte("hello"), 1.23)
+			_, dec, _ = DecodeFloatDescending(enc[5:], nil)
+		}
+		if dec != 1.23 {
+			t.Errorf("unexpected mismatch for %v. got %v", 1.23, dec)
+		}
 	}
 }
 
@@ -169,7 +190,7 @@ func BenchmarkEncodeFloat(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EncodeFloat(buf, vals[i%len(vals)])
+		_ = EncodeFloatAscending(buf, vals[i%len(vals)])
 	}
 }
 
@@ -178,13 +199,13 @@ func BenchmarkDecodeFloat(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		vals[i] = EncodeFloat(nil, rng.Float64())
+		vals[i] = EncodeFloatAscending(nil, rng.Float64())
 	}
 
 	buf := make([]byte, 0, 100)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeFloat(vals[i%len(vals)], buf)
+		_, _, _ = DecodeFloatAscending(vals[i%len(vals)], buf)
 	}
 }

--- a/util/encoding/main_test.go
+++ b/util/encoding/main_test.go
@@ -17,6 +17,7 @@
 package encoding_test
 
 import (
+	"os"
 	"testing"
 
 	_ "github.com/cockroachdb/cockroach/util/log" // for flags
@@ -25,5 +26,5 @@ import (
 
 func TestMain(m *testing.M) {
 	randutil.SeedForTests()
-	m.Run()
+	os.Exit(m.Run())
 }

--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -376,7 +376,7 @@ func (lr *EntryDecoder) Decode(entry *LogEntry) error {
 	if err != nil {
 		return err
 	}
-	_, sz, err := encoding.DecodeUint32(szBuf)
+	_, sz, err := encoding.DecodeUint32Ascending(szBuf)
 	if err != nil {
 		return err
 	}
@@ -808,7 +808,7 @@ func encodeLogEntry(entry *LogEntry) []byte {
 		panic(fmt.Sprintf("unable to marshal log entry: %s", err))
 	}
 	// Encode the length of the data first, followed by the encoded data.
-	data := encoding.EncodeUint32([]byte(nil), uint32(len(entryData)))
+	data := encoding.EncodeUint32Ascending([]byte(nil), uint32(len(entryData)))
 	return append(data, entryData...)
 }
 


### PR DESCRIPTION
- added some missing DESC encoding functions
- this changes the encoding for things and restricts the range of varints that fit in a byte a bit

I don't think this is sufficient for DESC indexes to be actually used in correctly in queries - I have yet to look in detail at how a matching index is chosen for a query and how the direction is used.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3553)

<!-- Reviewable:end -->
