### PR TITLE
add support for nightly CI runs

### DIFF
--- a/build/circle-trigger-nightly.sh
+++ b/build/circle-trigger-nightly.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -eu
+
+REV=$(git describe --tags)
+
+if [ -z "${1-}" ]; then
+  cat <<EOF
+Trigger a CircleCI nightly build for the revision currently checked out (${REV}).
+
+  Usage: $0 <circle_api_token>
+EOF
+  exit 2
+fi
+
+curl -X POST --header 'Content-Type: application/json' \
+  -d ' { "build_parameters": { "NIGHTLY": "true" } }' \
+  "https://circleci.com/api/v1/project/cockroachdb/cockroach/tree/${REV}?circle-token=${1}"


### PR DESCRIPTION
This should be a fun way to get `master` less red over time.
The build now interprets the `NIGHTLY` env variable. If nonempty, we'll always create issues (just like a failing `master` build does); everything else works as before.

Added a helper script which is invoked like this

`./build/circle-trigger-nightly.sh <your_circle_api_token>`

and starts a build for `$(git describe --tags)` (which is something like `v0.1-alpha-61-g90e7acf`).
That will be the "branch" name for the build on CircleCI, so in particular you can run this on `master`
without triggering all of the deploy logic (which is tied to `branch == "master"`).

The plan is to have something like

`for i in $(seq 0 10) do; ./build/circle-trigger-nightly.sh <token>; done` at night and to wake up in the
mornings with stuff to do and a good feeling over time of what the flaky tests in the system are (in 
particular since failures are already grouped by [label](https://github.com/cockroachdb/cockroach/labels)).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3556)

<!-- Reviewable:end -->
