### PR TITLE
make circle-trigger-nightly.sh standalone

### DIFF
--- a/build/circle-trigger-nightly.sh
+++ b/build/circle-trigger-nightly.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 
-REV=$(git describe --tags)
-
-if [ -z "${1-}" ]; then
+if [ $# -ne 2 ]; then
   cat <<EOF
-Trigger a CircleCI nightly build for the revision currently checked out (${REV}).
+Trigger a CircleCI nightly build for the given ref (for example "master").
 
-  Usage: $0 <circle_api_token>
+  Usage: $0 <circle_api_token> <ref>
 EOF
   exit 2
 fi
 
+REV=$(git ls-remote --exit-code git@github.com:cockroachdb/cockroach.git "${2}" | awk '{print $1}')
+echo "Triggering ${2} (${REV})"
 curl -X POST --header 'Content-Type: application/json' \
   -d ' { "build_parameters": { "NIGHTLY": "true" } }' \
   "https://circleci.com/api/v1/project/cockroachdb/cockroach/tree/${REV}?circle-token=${1}"


### PR DESCRIPTION
it now uses an ad-hoc call to our main repo to resolve the
given ref, and triggers that:

`./build/circle-trigger-nightly.sh <token> master`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3558)

<!-- Reviewable:end -->
