### PR TITLE
Bump Go to 1.6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 1.  Install the following prerequisites, as necessary:
     - A C++ compiler that supports C++11 (GCC 4.9+ and clang 3.6+ are known to work). On Mac OS X, Xcode should suffice.
-    - A [Go environment](http://golang.org/doc/code.html) with a 64-bit version of Go 1.5. You can download the [Go binary](https://golang.org/dl/) directly from the official site. On OS X, you can also use [homebrew](http://brew.sh): `brew install go`. Be sure to set the `$GOPATH` and `$PATH` environment variables as described [here](https://golang.org/doc/code.html#GOPATH).
+    - A [Go environment](http://golang.org/doc/code.html) with a 64-bit version of Go 1.6. You can download the [Go binary](https://golang.org/dl/) directly from the official site. On OS X, you can also use [homebrew](http://brew.sh): `brew install go`. Be sure to set the `$GOPATH` and `$PATH` environment variables as described [here](https://golang.org/doc/code.html#GOPATH).
     - Git 1.8+
 
 2.  Get the CockroachDB code:

--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -2,7 +2,6 @@ cmd github.com/client9/misspell/cmd/misspell
 cmd github.com/cockroachdb/c-protobuf/cmd/protoc
 cmd github.com/cockroachdb/cockroach/cmd/protoc-gen-gogoroach
 cmd github.com/cockroachdb/stress
-cmd github.com/cockroachdb/yacc
 cmd github.com/golang/lint/golint
 cmd github.com/gordonklaus/ineffassign
 cmd github.com/jteeuwen/go-bindata/go-bindata
@@ -26,7 +25,6 @@ github.com/cockroachdb/c-protobuf 4feb192131ea08dfbd7253a00868ad69cbb61b81
 github.com/cockroachdb/c-rocksdb c0124c907c74b579d9d3d48eb96471bef270bc25
 github.com/cockroachdb/c-snappy 5c6d0932e0adaffce4bfca7bdf2ac37f79952ccf
 github.com/cockroachdb/stress aa7690c22fd0abd6168ed0e6c361e4f4c5f7ab25
-github.com/cockroachdb/yacc 443154b1852a8702b07d675da6cd97cd9177a316
 github.com/codahale/hdrhistogram 2da969979c0dd5cda296463b05293e775bc3b5be
 github.com/coreos/etcd c15b2a5077396c0f5aa0659d3cd0ed9f0f97cc1a
 github.com/cpuguy83/go-md2man 2724a9c9051aa62e9cca11304e7dd518e9e41599

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,13 +1,18 @@
-FROM golang:1.5.2
+FROM golang:1.6
 
 MAINTAINER Peter Mattis <peter@cockroachlabs.com>
 
-RUN curl --silent --location https://deb.nodesource.com/setup_5.x | bash - && \
+RUN \
+ curl --silent --location https://deb.nodesource.com/setup_5.x | bash - && \
  apt-get dist-upgrade -y && \
- apt-get install --no-install-recommends --auto-remove -y git build-essential file nodejs && \
+ apt-get install --no-install-recommends --auto-remove -y nodejs && \
  apt-get clean autoclean && \
  apt-get autoremove -y && \
+ git clone --depth 1 https://chromium.googlesource.com/chromium/src/tools/clang && \
+ clang/scripts/update.py && \
  rm -rf /tmp/*
+
+ENV PATH=/third_party/llvm-build/Release+Asserts/bin:$PATH
 
 ENV SKIP_BOOTSTRAP=1
 

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -130,7 +130,7 @@ ls -lah "${builder_dir}"
 # The tag for the cockroachdb/builder image. If the image is changed
 # (for example, adding "npm"), a new image should be pushed using
 # "build/builder.sh push" and the new tag value placed here.
-fetch_docker "builder" "20151210-134003"
+fetch_docker "builder" "20160218-125307"
 
 fetch_docker "docker-spy" "20160209-143235"
 

--- a/gossip/convergence_test.go
+++ b/gossip/convergence_test.go
@@ -45,5 +45,5 @@ func verifyConvergence(numNodes, maxCycles int, t *testing.T) {
 // actual production gossip code than seems worthwhile for a unittest.
 func TestConvergence(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	verifyConvergence(10, 60, t)
+	verifyConvergence(10, 100, t)
 }

--- a/sql/parser/sql_union.sh
+++ b/sql/parser/sql_union.sh
@@ -2,8 +2,6 @@
 
 set -eu
 
-YACC="../../../../../../bin/yacc"
-
 # This step runs sql.y through the YACC compiler directly without
 # performing any type/token declaration modifications, throwing out
 # the result on a successful compilation. This allows the YACC compiler
@@ -12,11 +10,11 @@ YACC="../../../../../../bin/yacc"
 # to union type accessors in the Go code within rules, as the YACC
 # compiler does not type check Go code.
 function type_check() {
-    $YACC -o /dev/null -p sql sql.y
+    go tool yacc -o /dev/null -p sql sql.y
 }
 
 # This step performs the actual compilation from the sql.y syntax to
-# the sql.go parser implementation. It first translates the syntax 
+# the sql.go parser implementation. It first translates the syntax
 # file to use the union type for any type declaration whose type was
 # given a union accessor on sqlSymUnion. Next, it performs the YACC
 # compilation.
@@ -44,7 +42,7 @@ function compile() {
 
     # Compile this new "unionized" syntax file through YACC, this time writing
     # the output to sql.go.
-    $YACC -o sql.go -p sql sql.y
+    go tool yacc -o sql.go -p sql sql.y
 
     # Overwrite the migrated syntax file with the original syntax file.
     mv sql.y.tmp sql.y

--- a/util/net.go
+++ b/util/net.go
@@ -66,8 +66,6 @@ func (ml *replayableConnListener) Accept() (net.Conn, error) {
 }
 
 // Listen delegates to `net.Listen` and, if tlsConfig is not nil, to `tls.NewListener`.
-// The returned listener's Addr() method will return an address with the hostname unresovled,
-// which means it can be used to initiate TLS connections.
 func Listen(addr net.Addr, tlsConfig *tls.Config) (net.Listener, error) {
 	ln, err := net.Listen(addr.Network(), addr.String())
 	if err == nil {

--- a/util/net.go
+++ b/util/net.go
@@ -31,26 +31,80 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
+const eol = "\r\n"
+const hostHeader = "Host: CRDB" + eol
+
+var headerInsertionIndex = int64(strings.Index(http2.ClientPreface, eol) + len(eol))
+
 type replayableConn struct {
 	net.Conn
 	buf    bytes.Buffer
 	reader io.Reader
 }
 
-// Do not call `replay` more than once, bad things will happen.
-func (bc *replayableConn) replay() *replayableConn {
-	bc.reader = io.MultiReader(&bc.buf, bc.Conn)
-	return bc
+func newReplayableConn(conn net.Conn) *replayableConn {
+	rc := replayableConn{Conn: conn}
+	rc.reader = io.LimitReader(io.TeeReader(conn, &rc.buf), headerInsertionIndex)
+	return &rc
 }
 
-func (bc *replayableConn) Read(b []byte) (int, error) {
-	return bc.reader.Read(b)
+func (rc *replayableConn) replay() *replayableConn {
+	rc.reader = io.MultiReader(&rc.buf, rc.Conn)
+	return rc
 }
 
-func newBufferedConn(conn net.Conn) *replayableConn {
-	bc := replayableConn{Conn: conn}
-	bc.reader = io.TeeReader(conn, &bc.buf)
-	return &bc
+func (rc *replayableConn) Read(p []byte) (int, error) {
+	if limitReader, ok := rc.reader.(*io.LimitedReader); ok {
+		// rc.reader is a LimitedReader wrapping a TeeReader.
+		off := headerInsertionIndex - limitReader.N
+		n, err := rc.reader.Read(p)
+		if !strings.HasPrefix(http2.ClientPreface[off:], string(p[:n])) {
+			// The incoming request is not an HTTP2 request, so buffering is no
+			// longer required; send all reads directly to the underlying net.Conn.
+			rc.reader = rc.Conn
+			rc.buf = bytes.Buffer{} // Release the memory.
+		} else if err == io.EOF {
+			// We've exhausted our LimitedReader, which means he incoming request is
+			// an HTTP2 request. Remember, that we are in this code path means that
+			// TLS is not in use, which means the caller (net/http machinery) won't
+			// be able to parse anything after http2.ClientPreface. However, Go 1.6
+			// introduced strict Host header checking for HTTP >= 1.1 requests (see
+			// https://github.com/golang/go/commit/6e11f45), and http2.ClientPreface
+			// contains enough information for the caller to identify this first
+			// request as an HTTP 2 request, but not enough for the caller to
+			// determine the value of the Host header. On the next line, we're going
+			// to help the caller out by providing a bogus HTTP 1.x-style Host
+			// header. This will get us past Host header verification.
+			//
+			// Note that this bogus header won't reappear after replay is called.
+			rc.reader = io.MultiReader(strings.NewReader(hostHeader), limitReader.R)
+		} else {
+			// The LimitedReader isn't exhausted yet, or we hit an error.
+			return n, err
+		}
+
+		// Cribbed from io.Multireader.
+		if n > 0 || err != io.EOF {
+			if err == io.EOF {
+				// Don't return EOF yet. We've replaced our LimitedReader with rc.Conn or
+				// a new MultiReader and there may be more bytes in there.
+				err = nil
+			}
+			return n, err
+		}
+	}
+
+	// Pseudocode:
+	// if rc.IsHTTP2() {
+	// 	if rc.replayCalled {
+	// 		rc.reader == io.MultiReader(&rc.buf, rc.Conn)
+	// 	} else {
+	// 		rc.reader == io.TeeReader(conn, &rc.buf)
+	// 	}
+	// } else {
+	// 	rc.reader == rc.Conn
+	// }
+	return rc.reader.Read(p)
 }
 
 type replayableConnListener struct {
@@ -60,7 +114,7 @@ type replayableConnListener struct {
 func (ml *replayableConnListener) Accept() (net.Conn, error) {
 	conn, err := ml.Listener.Accept()
 	if err == nil {
-		conn = newBufferedConn(conn)
+		conn = newReplayableConn(conn)
 	}
 	return conn, err
 }

--- a/util/net_test.go
+++ b/util/net_test.go
@@ -1,0 +1,111 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tamir Duberstein (tamird@gmail.com)
+
+package util
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	"golang.org/x/net/http2"
+)
+
+func TestReplayableConn(t *testing.T) {
+	const chunkSize = 2
+
+	for _, tc := range []struct {
+		input          string
+		expectedOutput string
+	}{
+		{"\x12\x34", "\x12\x34"},
+		{"GET /index.html HTTP1.1\r\n", "GET /index.html HTTP1.1\r\n"},
+		{"PRI x HTTP/2.0\r\n\r\nSM\r\n\r\n", "PRI x HTTP/2.0\r\n\r\nSM\r\n\r\n"},
+		{http2.ClientPreface, http2.ClientPreface[:headerInsertionIndex] + hostHeader + http2.ClientPreface[headerInsertionIndex:]},
+	} {
+		c1, c2 := net.Pipe()
+		errCh := make(chan error, 100) // prevent deadlocks
+		go func() {
+			inputSlice := []byte(tc.input)
+			// Write the input chunkSize bytes at a time, so that many Read calls are
+			// needed.
+			for i := 0; i < len(inputSlice); i += chunkSize {
+				j := i + chunkSize
+				if j > len(inputSlice) {
+					j = len(inputSlice)
+				}
+				writeSlice := inputSlice[i:j]
+				if n, err := c1.Write(writeSlice); err != nil {
+					errCh <- err
+				} else if n != len(writeSlice) {
+					errCh <- fmt.Errorf("%q: expected to write %d bytes, but wrote %d bytes", tc.input, len(writeSlice), n)
+				}
+			}
+			errCh <- c1.Close()
+			close(errCh)
+		}()
+
+		rc := newReplayableConn(c2)
+
+		// This construction reads from rc chunkSize bytes at a time to ensure that
+		// rc.Read makes no unwise assumptions about the capacity of the passed
+		// slice.
+		numReads := 1 // declared outside readAll because we only check it once.
+		readAll := func() []byte {
+			var output []byte
+			var readBuf [chunkSize]byte
+
+			for ; ; numReads++ {
+				n, err := rc.Read(readBuf[:])
+				output = append(output, readBuf[:n]...)
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					t.Fatal(err)
+				}
+			}
+
+			return output
+		}
+
+		if output := readAll(); string(output) != tc.expectedOutput {
+			t.Errorf("%q: expected output:\n%q\nactual output:\n%q", tc.input, tc.expectedOutput, output)
+		} else if e := ((len(output) + chunkSize - 1) / chunkSize) + 1; numReads != e {
+			t.Errorf("%q: expected read to complete in %d calls, but took %d", tc.input, e, numReads)
+		}
+
+		for err := range errCh {
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		rc.replay()
+
+		var expectedOutput string
+		// If the expected output equals the input, then the test case is not an
+		// HTTP2 request, the buffer has been released, so no playback occurs after
+		// the call to replay.
+		if tc.expectedOutput != tc.input {
+			expectedOutput = tc.input
+		}
+		if output := readAll(); string(output) != expectedOutput {
+			t.Errorf("%q: expected output:\n%q\nactual output:\n%q", tc.input, expectedOutput, output)
+		}
+	}
+}


### PR DESCRIPTION
- Remove dependency on cockroachdb/yacc
- Use Chromium's bleeding-edge clang; it is needed because of a bug in
  MemorySanitizer (https://llvm.org/bugs/show_bug.cgi?id=24155)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3563)

<!-- Reviewable:end -->
