### PR TITLE
support using ORDER BY with GROUP BY

### DIFF
--- a/sql/select.go
+++ b/sql/select.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -54,17 +53,12 @@ func (p *planner) selectWithScan(scan *scanNode, n *parser.Select) (planNode, er
 	if err := scan.initTargets(n.Exprs); err != nil {
 		return nil, err
 	}
-	group, err := p.groupBy(n, scan)
+	// NB: both orderBy and groupBy are passed and can modify `scan` but orderBy must do so first.
+	sort, err := p.orderBy(n, scan)
 	if err != nil {
 		return nil, err
 	}
-	if group != nil && n.OrderBy != nil {
-		// TODO(pmattis): orderBy currently uses deep knowledge of the
-		// scanNode. Need to lift that out or make orderBy compatible with
-		// groupNode as well.
-		return nil, util.Errorf("TODO(pmattis): unimplemented ORDER BY with GROUP BY/aggregation")
-	}
-	sort, err := p.orderBy(n, scan)
+	group, err := p.groupBy(n, scan)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -170,8 +170,47 @@ SELECT COUNT(*, 1) FROM kv
 query error unknown signature for COUNT: COUNT\(int, int\)
 SELECT COUNT(k, v) FROM kv
 
-query error unimplemented ORDER BY with GROUP BY/aggregation
-SELECT COUNT(k) FROM kv ORDER BY v
+query II
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v
+----
+NULL 1
+2 3
+4 2
+
+query II
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v DESC
+----
+4 2
+2 3
+NULL 1
+
+query II
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
+----
+NULL 1
+4 2
+2 3
+
+query II
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k) DESC
+----
+2 3
+4 2
+NULL 1
+
+query II
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v-COUNT(k)
+----
+NULL 1
+2 3
+4 2
+
+query II
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY 1 DESC
+----
+4 2
+2 3
+NULL 1
 
 query IIII colnames
 SELECT COUNT(*), COUNT(kv.*), COUNT(k), COUNT(kv.v) FROM kv


### PR DESCRIPTION
Closes #3542.

Unlike either approach (for nesting order of sortNode and groupNode) mentioned there, this PR just passes both `sortBy` and `orderBy` the original `scanNode`, letting them inspect and modify it directly, rather than having one delegate to the to the other and extracting some common interface for inspecting and modifying the render expressions.

Note that `sortBy`, despite wrapping _after_ `groupBy`, is given the first chance at the `scanNode`: this is important for two reasons: first, so that any aggregate expressions it adds will be properly transformed along with the rest of `render` by `groupBy` and second so that when looking for existing expressions that match, it does so before the their transformation into aggregatefuncs.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3564)

<!-- Reviewable:end -->
