### PR TITLE
improve error message about under-replication

### DIFF
--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -251,9 +251,9 @@ func (a *Allocator) AllocateTarget(required roachpb.Attributes, existing []roach
 			return target, nil
 		}
 		if len(attrs) == 0 {
-			return nil, util.Errorf("unable to allocate a target store; no candidates available")
+			return nil, util.Errorf("no suitable replication target store found, are you running enough nodes?")
 		} else if !relaxConstraints {
-			return nil, util.Errorf("unable to allocate a target store; no candidates available with attributes %s", required)
+			return nil, util.Errorf("no target store with attributes %s available", required)
 		}
 	}
 }

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -370,7 +370,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) {
 		}
 	}
 	if err := bq.impl.process(now, repl, cfg); err != nil {
-		log.Errorf("failure processing replica %s from %s queue: %s", repl, bq.name, err)
+		log.Errorf("while processing replica %s from %s queue: %s", repl, bq.name, err)
 	} else if log.V(2) {
 		log.Infof("processed replica %s from %s queue in %s", repl, bq.name, time.Now().Sub(start))
 	}


### PR DESCRIPTION
see #3060

> E1230 18:02:54.035314 85177 storage/queue.go:373  while processing replica range=1 [/Min-/Max) from replicate queue: storage/allocator.go:254: no suitable replication target store found, are you running enough nodes?

it's still red and an error, but maybe that's ok. Gets people to read the thing.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3567)

<!-- Reviewable:end -->
