### PR TITLE
Fix apply constraints for tuples.

### DIFF
--- a/sql/select.go
+++ b/sql/select.go
@@ -829,6 +829,17 @@ func (v *applyConstraintsVisitor) Visit(expr parser.Expr, pre bool) (parser.Visi
 			if !isDatum(t.Right) || !isDatum(c.Right) {
 				return v, expr
 			}
+			if tuple, ok := c.Left.(parser.Tuple); ok {
+				// Do not apply a constraint on a tuple which does not use the entire
+				// tuple.
+				//
+				// TODO(peter): The current code is conservative. We could trim the
+				// tuple instead.
+				if len(tuple) != len(v.constraint.tupleMap) {
+					return v, expr
+				}
+			}
+
 			datum := t.Right.(parser.Datum)
 			cdatum := c.Right.(parser.Datum)
 

--- a/sql/select_test.go
+++ b/sql/select_test.go
@@ -241,6 +241,9 @@ func TestMakeSpans(t *testing.T) {
 		{`a IN (1) AND b <= 1`, []string{"a", "b"}, `/1/#-/1/2`},
 		{`a IN (1) AND b IS NULL`, []string{"a", "b"}, `/1-/1/#`},
 		{`a IN (1) AND b IS NOT NULL`, []string{"a", "b"}, `/1/#-/2`},
+
+		{`(a, b) = (1, 2)`, []string{"a"}, `/1-/2`},
+		{`(a, b) = (1, 2)`, []string{"a", "b"}, `/1/2-/1/3`},
 	}
 	for _, d := range testData {
 		desc, index := makeTestIndex(t, d.columns)
@@ -308,6 +311,7 @@ func TestApplyConstraints(t *testing.T) {
 		{`a IN (1, 2) AND b = 3`, []string{"a", "b"}, `b = 3`},
 		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, []string{"a", "b"}, `a <= 5 AND b >= 6`},
 		{`a IN (1) AND a = 1`, []string{"a"}, `<nil>`},
+		{`(a, b) = (1, 2)`, []string{"a"}, `(a, b) IN ((1, 2))`},
 		// Filters that are not trimmed as of Dec 2015, although they could be.
 		// Issue #3473.
 		// {`a > 1`, []string{"a"}, `<nil>`},

--- a/sql/testdata/tuple_issue3568
+++ b/sql/testdata/tuple_issue3568
@@ -1,0 +1,16 @@
+statement ok
+CREATE TABLE kv (
+  k INT PRIMARY KEY,
+  v INT
+)
+
+statement ok
+INSERT INTO kv VALUES (1, 2)
+
+query II
+SELECT k, v FROM kv WHERE (k, v) = (1, 100)
+----
+
+query II
+SELECT k, v FROM kv WHERE (k, v) IN ((1, 100))
+----


### PR DESCRIPTION
Do not apply tuple constraints when only a portion of the tuple was used
for the constraint. This is weaker than necessary, but also
correct. applyConstraints needs to be rewritten to be more general and
robust.

Fixes #3568.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3572)

<!-- Reviewable:end -->
