### PR TITLE
Set the BatchRequest.Timestamp for LeaderLease requests.

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -341,6 +341,7 @@ func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) error {
 		},
 	}
 	ba := roachpb.BatchRequest{}
+	ba.Timestamp = r.store.Clock().Now()
 	ba.RangeID = desc.RangeID
 	ba.Add(args)
 


### PR DESCRIPTION
Failure to set the Timestamp was causing these requests to foul up the
GCBytesAge computation.

See #3234.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3573)

<!-- Reviewable:end -->
