### PR TITLE
Add simple event logs for the storage queues.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -50,7 +50,7 @@ github.com/spf13/pflag 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7
 github.com/tebeka/go2xunit 1dc98d1bb46ddc80cede27ce57b0376948005a31
 github.com/termie/go-shutil bcacb06fecaeec8dc42af03c87c6949f4a05c74c
 golang.org/x/crypto f18420efc3b4f8e9f3d51f6bd2476e92c46260e9
-golang.org/x/net 0cb26f788dd4625d1956c6fd97ffc4c90669d129
+golang.org/x/net 0ab009005dc16437045369e823a35d1af6232b69
 golang.org/x/text cf4986612c83df6c55578ba198316d1684a9a287
 golang.org/x/tools 6e2f52e572ea836c54886d4856872cf239800498
 gopkg.in/yaml.v1 9f9df34309c04878acc86042b16630b0f696e1de

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -163,12 +163,6 @@ type multiTestContext struct {
 	// test individually. clientStopper is for 'db', transportStopper is
 	// for 'transport', and the 'stoppers' slice corresponds to the
 	// 'stores'.
-	// TODO(bdarnell): scannerStopper is a hack. The scanner is the one
-	// source of asynchronous operations that the test has no direct
-	// control over, and it is prone to an infinite retry loop during
-	// shutdown. When we have fixed our retry configurations (#2500),
-	// we should be able to remove scannerStopper.
-	scannerStopper     *stop.Stopper
 	clientStopper      *stop.Stopper
 	transportStopper   *stop.Stopper
 	engineStoppers     []*stop.Stopper
@@ -201,9 +195,6 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 		rpcContext := rpc.NewContext(&base.Context{}, m.clock, nil)
 		m.gossip = gossip.New(rpcContext, gossip.TestBootstrap)
 		m.gossip.SetNodeID(math.MaxInt32)
-	}
-	if m.scannerStopper == nil {
-		m.scannerStopper = stop.NewStopper()
 	}
 	if m.clientStopper == nil {
 		m.clientStopper = stop.NewStopper()
@@ -253,7 +244,7 @@ func (m *multiTestContext) Stop() {
 	go func() {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
-		stoppers := append([]*stop.Stopper{m.scannerStopper, m.clientStopper, m.transportStopper},
+		stoppers := append([]*stop.Stopper{m.clientStopper, m.transportStopper},
 			m.stoppers...)
 		// Quiesce all the stoppers so that we can stop all stoppers in unison.
 		for _, s := range stoppers {
@@ -370,7 +361,6 @@ func (m *multiTestContext) makeContext(i int) storage.StoreContext {
 	ctx.StorePool = m.storePool
 	ctx.Transport = m.transport
 	ctx.EventFeed = m.feed
-	ctx.ScannerStopper = m.scannerStopper
 	return ctx
 }
 

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"container/heap"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -106,6 +107,27 @@ type queueImpl interface {
 	timer() time.Duration
 }
 
+type queueLog struct {
+	traceLog trace.EventLog
+	prefix   string
+}
+
+func (l queueLog) Infof(logv bool, format string, a ...interface{}) {
+	if logv {
+		log.Infof(l.prefix+format, a...)
+	}
+	l.traceLog.Printf(format, a...)
+}
+
+func (l queueLog) Errorf(format string, a ...interface{}) {
+	log.Errorf(l.prefix+format, a...)
+	l.traceLog.Errorf(format, a...)
+}
+
+func (l queueLog) Finish() {
+	l.traceLog.Finish()
+}
+
 // baseQueue is the base implementation of the replicaQueue interface.
 // Queue implementations should embed a baseQueue and implement queueImpl.
 //
@@ -129,7 +151,7 @@ type baseQueue struct {
 	// Some tests in this package disable queues.
 	disabled int32 // updated atomically
 
-	eventLog trace.EventLog
+	eventLog queueLog
 }
 
 // makeBaseQueue returns a new instance of baseQueue with the
@@ -147,7 +169,10 @@ func makeBaseQueue(name string, impl queueImpl, gossip *gossip.Gossip, maxSize i
 		incoming: make(chan struct{}, 1),
 		Locker:   new(sync.Mutex),
 		replicas: map[roachpb.RangeID]*replicaItem{},
-		eventLog: trace.NewEventLog("queue", name),
+		eventLog: queueLog{
+			traceLog: trace.NewEventLog("queue", name),
+			prefix:   fmt.Sprintf("[%s] ", name),
+		},
 	}
 }
 
@@ -197,10 +222,7 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now roachpb.Timestamp) {
 	// Load the system config.
 	cfg := bq.gossip.GetSystemConfig()
 	if cfg == nil {
-		if log.V(1) {
-			log.Infof("no system config available. skipping")
-		}
-		bq.eventLog.Printf("no system config available. skipping")
+		bq.eventLog.Infof(log.V(1), "no system config available. skipping")
 		return
 	}
 
@@ -208,10 +230,7 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now roachpb.Timestamp) {
 	if !bq.impl.acceptsUnsplitRanges() && cfg.NeedsSplit(desc.StartKey, desc.EndKey) {
 		// Range needs to be split due to zone configs, but queue does
 		// not accept unsplit ranges.
-		if log.V(3) {
-			log.Infof("%s needs to be split; not adding", repl)
-		}
-		bq.eventLog.Printf("%s: split needed; not adding", repl)
+		bq.eventLog.Infof(log.V(1), "%s: split needed; not adding", repl)
 		return
 	}
 
@@ -220,7 +239,7 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now roachpb.Timestamp) {
 	should, priority := bq.impl.shouldQueue(now, repl, cfg)
 	if err := bq.addInternal(repl, should, priority); err != nil {
 		if log.V(3) {
-			log.Infof("unable to add %s to queue %s: %s", repl, bq.name, err)
+			log.Infof("[%s] unable to add %s: %s", bq.name, repl, err)
 		}
 	}
 }
@@ -231,7 +250,7 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now roachpb.Timestamp) {
 // added.
 func (bq *baseQueue) addInternal(repl *Replica, should bool, priority float64) error {
 	if atomic.LoadInt32(&bq.disabled) == 1 {
-		bq.eventLog.Printf("queue disabled")
+		bq.eventLog.Infof(false, "queue disabled")
 		return errQueueDisabled
 	}
 
@@ -240,23 +259,21 @@ func (bq *baseQueue) addInternal(repl *Replica, should bool, priority float64) e
 	item, ok := bq.replicas[rangeID]
 	if !should {
 		if ok {
-			bq.eventLog.Printf("%s: removing", item.value)
+			bq.eventLog.Infof(false, "%s: removing", item.value)
 			bq.remove(item.index)
 		}
 		return errReplicaNotAddable
 	} else if ok {
 		if item.priority != priority {
-			bq.eventLog.Printf("%s: updating priority: %0.3f -> %0.3f", repl, item.priority, priority)
+			bq.eventLog.Infof(false, "%s: updating priority: %0.3f -> %0.3f",
+				repl, item.priority, priority)
 		}
 		// Replica has already been added; update priority.
 		bq.priorityQ.update(item, priority)
 		return nil
 	}
 
-	if log.V(3) {
-		log.Infof("adding %s to %s queue", repl, bq.name)
-	}
-	bq.eventLog.Printf("%s: adding: priority=%0.3f", repl, priority)
+	bq.eventLog.Infof(log.V(3), "%s: adding: priority=%0.3f", repl, priority)
 	item = &replicaItem{value: repl, priority: priority}
 	heap.Push(&bq.priorityQ, item)
 	bq.replicas[rangeID] = item
@@ -280,10 +297,7 @@ func (bq *baseQueue) MaybeRemove(repl *Replica) {
 	bq.Lock()
 	defer bq.Unlock()
 	if item, ok := bq.replicas[repl.Desc().RangeID]; ok {
-		if log.V(3) {
-			log.Infof("removing %s from %s queue", item.value, bq.name)
-		}
-		bq.eventLog.Printf("%s: removing", item.value)
+		bq.eventLog.Infof(log.V(3), "%s: removing", item.value)
 		bq.remove(item.index)
 	}
 }
@@ -367,10 +381,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) {
 	if !bq.impl.acceptsUnsplitRanges() && cfg.NeedsSplit(desc.StartKey, desc.EndKey) {
 		// Range needs to be split due to zone configs, but queue does
 		// not accept unsplit ranges.
-		if log.V(3) {
-			log.Infof("%s needs to be split; skipping", repl)
-		}
-		bq.eventLog.Printf("%s: split needed; skipping", repl)
+		bq.eventLog.Infof(log.V(3), "%s: split needed; skipping", repl)
 		return
 	}
 
@@ -380,27 +391,18 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) {
 	if bq.impl.needsLeaderLease() {
 		// Create a "fake" get request in order to invoke redirectOnOrAcquireLease.
 		if err := repl.redirectOnOrAcquireLeaderLease(nil /* Trace */, now); err != nil {
-			if log.V(3) {
-				log.Infof("this replica of %s could not acquire leader lease; skipping", repl)
-			}
-			bq.eventLog.Printf("%s: could not acquire leader lease; skipping", repl)
+			bq.eventLog.Infof(log.V(3), "%s: could not acquire leader lease; skipping", repl)
 			return
 		}
 	}
 
-	if log.V(3) {
-		log.Infof("processing replica %s from %s queue...", repl, bq.name)
-	}
-	bq.eventLog.Printf("%s: processing", repl)
+	bq.eventLog.Infof(log.V(3), "%s: processing", repl)
 
 	if err := bq.impl.process(now, repl, cfg); err != nil {
-		log.Errorf("while processing %s from %s queue: %s", repl, bq.name, err)
-		bq.eventLog.Printf("%s: error: %v", repl, err)
+		bq.eventLog.Errorf("%s: error: %v", repl, err)
 	} else {
-		if log.V(2) {
-			log.Infof("processed %s from %s queue in %s", repl, bq.name, time.Now().Sub(start))
-		}
-		bq.eventLog.Printf("%s: done", repl)
+		bq.eventLog.Infof(log.V(2), "%s: done: %0.2fms", repl,
+			time.Since(start).Seconds()*1000)
 	}
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -439,6 +439,17 @@ func (s *Store) StartedAt() int64 {
 func (s *Store) Start(stopper *stop.Stopper) error {
 	s.stopper = stopper
 
+	// Add a closer for the various scanner queues, needed to properly clean up
+	// the event logs.
+	s.stopper.AddCloser(stop.CloserFn(func() {
+		s.gcQueue.Close()
+		s.splitQueue.Close()
+		s.verifyQueue.Close()
+		s.replicateQueue.Close()
+		s.replicaGCQueue.Close()
+		s.raftLogQueue.Close()
+	}))
+
 	if s.Ident.NodeID == 0 {
 		// Open engine (i.e. initialize RocksDB database). "NodeID != 0"
 		// implies the engine has already been opened.


### PR DESCRIPTION
The queue event logs are visible at the /debug/events endpoint. Properly
"stop" the store used for bootstrapping during "cockroach start --dev".

Removed StoreContext.ScannerStopper. It doesn't seem to be used anymore
and creates headaches for code trying to atomically cleanup in scanner
queues as there is no easy way to guarantee that both the normal and
scanner stopper are both stopped.

Don't compress responses for the /debug/ pages.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3577)

<!-- Reviewable:end -->
