### PR TITLE
error on zero timestamp in raft proposals

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -986,6 +986,10 @@ func (r *Replica) proposePendingCmdLocked(idKey cmdIDKey, p *pendingCmd) error {
 		return r.proposeRaftCommandFn(idKey, p.raftCmd)
 	}
 
+	if p.raftCmd.Cmd.Timestamp == roachpb.ZeroTimestamp {
+		return util.Errorf("can't propose Raft command with zero timestamp")
+	}
+
 	data, err := proto.Marshal(&p.raftCmd)
 	if err != nil {
 		return err

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -280,6 +280,7 @@ func TestRangeContains(t *testing.T) {
 
 func setLeaderLease(t *testing.T, r *Replica, l *roachpb.Lease) {
 	ba := roachpb.BatchRequest{}
+	ba.Timestamp = r.store.Clock().Now()
 	ba.Add(&roachpb.LeaderLeaseRequest{Lease: *l})
 	pendingCmd, err := r.proposeRaftCommand(r.context(), ba)
 	if err == nil {
@@ -726,6 +727,7 @@ func TestRangeLeaderLeaseRejectUnknownRaftNodeID(t *testing.T) {
 		},
 	}
 	ba := roachpb.BatchRequest{}
+	ba.Timestamp = tc.rng.store.Clock().Now()
 	ba.Add(&roachpb.LeaderLeaseRequest{Lease: *lease})
 	pendingCmd, err := tc.rng.proposeRaftCommand(tc.rng.context(), ba)
 	if err == nil {
@@ -2415,6 +2417,7 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 			pushee.LastHeartbeat = &test.heartbeat
 		}
 		bt, btH := beginTxnArgs(key, pushee)
+		btH.Timestamp = tc.rng.store.Clock().Now()
 		if _, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
prevents regression of bugs such as #3573.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3580)

<!-- Reviewable:end -->
