### PR TITLE
exit codes and no bootstrapping of >1 store

### DIFF
--- a/cli/cert.go
+++ b/cli/cert.go
@@ -17,9 +17,8 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/util"
 
 	"github.com/spf13/cobra"
 )
@@ -37,18 +36,17 @@ var createCACertCmd = &cobra.Command{
 Generates a new key pair and CA certificate, writing them to
 individual files in the directory specified by --certs (required).
 `,
-	Run: runCreateCACert,
+	SilenceUsage: true,
+	RunE:         runCreateCACert,
 }
 
 // runCreateCACert generates key pair and CA certificate and writes them
 // to their corresponding files.
-func runCreateCACert(cmd *cobra.Command, args []string) {
-	err := security.RunCreateCACert(context.Certs, keySize)
-	if err != nil {
-		fmt.Fprintf(osStderr, "failed to generate CA certificate: %s\n", err)
-		osExit(1)
-		return
+func runCreateCACert(cmd *cobra.Command, args []string) error {
+	if err := security.RunCreateCACert(context.Certs, keySize); err != nil {
+		return util.Errorf("failed to generate CA certificate: %s", err)
 	}
+	return nil
 }
 
 // A createNodeCert command generates a node certificate and stores it
@@ -62,18 +60,17 @@ individual files in the directory specified by --certs (required).
 The certs directory should contain a CA cert and key.
 At least one host should be passed in (either IP address of dns name).
 `,
-	Run: runCreateNodeCert,
+	SilenceUsage: true,
+	RunE:         runCreateNodeCert,
 }
 
 // runCreateNodeCert generates key pair and CA certificate and writes them
 // to their corresponding files.
-func runCreateNodeCert(cmd *cobra.Command, args []string) {
-	err := security.RunCreateNodeCert(context.Certs, keySize, args)
-	if err != nil {
-		fmt.Fprintf(osStderr, "failed to generate node certificate: %s\n", err)
-		osExit(1)
-		return
+func runCreateNodeCert(cmd *cobra.Command, args []string) error {
+	if err := security.RunCreateNodeCert(context.Certs, keySize, args); err != nil {
+		return util.Errorf("failed to generate node certificate: %s", err)
 	}
+	return nil
 }
 
 // A createClientCert command generates a client certificate and stores it
@@ -86,22 +83,21 @@ Generates a new key pair and client certificate, writing them to
 individual files in the directory specified by --certs (required).
 The certs directory should contain a CA cert and key.
 `,
-	Run: runCreateClientCert,
+	SilenceUsage: true,
+	RunE:         runCreateClientCert,
 }
 
 // runCreateClientCert generates key pair and CA certificate and writes them
 // to their corresponding files.
-func runCreateClientCert(cmd *cobra.Command, args []string) {
+func runCreateClientCert(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		mustUsage(cmd)
-		return
+		return errMissingParams
 	}
-	err := security.RunCreateClientCert(context.Certs, keySize, args[0])
-	if err != nil {
-		fmt.Fprintf(osStderr, "failed to generate clent certificate: %s\n", err)
-		osExit(1)
-		return
+	if err := security.RunCreateClientCert(context.Certs, keySize, args[0]); err != nil {
+		return util.Errorf("failed to generate clent certificate: %s", err)
 	}
+	return nil
 }
 
 var certCmds = []*cobra.Command{

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -27,8 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 )
 
-// Proxies to allow overrides in tests.
-var osExit = os.Exit
+// Proxy to allow overrides in tests.
 var osStderr = os.Stderr
 
 var versionCmd = &cobra.Command{

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -41,7 +41,6 @@ func newCLITest() cliTest {
 	// overwrite the existing struct's values.
 	context.InitDefaults()
 
-	osExit = func(int) {}
 	osStderr = os.Stdout
 
 	s := &server.TestServer{}

--- a/cli/log.go
+++ b/cli/log.go
@@ -36,7 +36,8 @@ log command parses the specified log files and outputs the result to
 standard out. If the terminal supports colors, the output is colorized
 unless --color=off is specified.
 `,
-	Run: runLog,
+	SilenceUsage: true,
+	RunE:         panicGuard(runLog),
 }
 
 // runLog accesses creates a term log entry reader for each

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -40,7 +40,7 @@ var sqlShellCmd = &cobra.Command{
 	Long: `
 Open a sql shell running against the cockroach database at --addr.
 `,
-	Run: runTerm,
+	Run: runTerm, // TODO(tschottdorf): should be able to return err code when reading from stdin
 }
 
 func runTerm(cmd *cobra.Command, args []string) {

--- a/cli/sql_util.go
+++ b/cli/sql_util.go
@@ -36,8 +36,7 @@ func makeSQLClient() *sql.DB {
 			context.Addr,
 			context.Certs))
 	if err != nil {
-		fmt.Fprintf(osStderr, "failed to initialize SQL client: %s\n", err)
-		osExit(1)
+		panicf("failed to initialize SQL client: %s", err)
 	}
 	return db
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -18,6 +18,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -41,6 +42,29 @@ import (
 // Context is the CLI Context used for the server.
 var context = server.NewContext()
 
+var errMissingParams = errors.New("missing or invalid parameters")
+
+// panicGuard wraps an errorless command into one wrapping panics into errors.
+// This simplifies error handling for many commands for which more elaborate
+// error handling isn't needed and would otherwise bloat the code.
+func panicGuard(cmdFn func(*cobra.Command, []string)) func(*cobra.Command, []string) error {
+	return func(c *cobra.Command, args []string) (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("%v", r)
+			}
+		}()
+		cmdFn(c, args)
+		return nil
+	}
+}
+
+// panicf is only to be used when wrapped through panicGuard, since the
+// stack trace doesn't matter then.
+func panicf(format string, args ...interface{}) {
+	panic(fmt.Sprintf(format, args...))
+}
+
 // initCmd command initializes a new Cockroach cluster.
 var initCmd = &cobra.Command{
 	Use:   "init --stores=...",
@@ -51,36 +75,39 @@ more storage locations. The first of these storage locations is used to
 bootstrap the first replica of the first range. If any of the storage locations
 are already part of a pre-existing cluster, the bootstrap will fail.
 `,
-	Example: `  cockroach init --stores=ssd=/mnt/ssd1,ssd=/mnt/ssd2`,
-	Run:     runInit,
+	Example:      `  cockroach init --stores=ssd=/mnt/ssd1,ssd=/mnt/ssd2`,
+	SilenceUsage: true,
+	RunE:         runInit,
 }
 
 // runInit initializes the engine based on the first
 // store. The bootstrap engine may not be an in-memory type.
-func runInit(_ *cobra.Command, _ []string) {
+func runInit(_ *cobra.Command, _ []string) error {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 
-	initCluster(stopper)
+	return initCluster(stopper)
 }
 
-func initCluster(stopper *stop.Stopper) {
+func initCluster(stopper *stop.Stopper) error {
 	// Default user for servers.
 	context.User = security.NodeUser
 
 	if err := context.InitStores(stopper); err != nil {
-		log.Errorf("failed to initialize stores: %s", err)
-		return
+		return util.Errorf("failed to initialize stores: %s", err)
+	}
+	if len(context.Engines) > 1 {
+		return util.Errorf("cannot bootstrap to more than one store")
 	}
 
 	// Generate a new UUID for cluster ID and bootstrap the cluster.
 	clusterID := uuid.NewUUID4().String()
 	if _, err := server.BootstrapCluster(clusterID, context.Engines, stopper); err != nil {
-		log.Errorf("unable to bootstrap cluster: %s", err)
-		return
+		return util.Errorf("unable to bootstrap cluster: %s", err)
 	}
 
 	log.Infof("cockroach cluster %s has been initialized", clusterID)
+	return nil
 }
 
 // startCmd command starts nodes by joining the gossip network.
@@ -100,15 +127,16 @@ storage directories or for in-memory stores, the number of bytes. Although the
 paths should be specified to correspond uniquely to physical devices, this
 requirement isn't strictly enforced. See the --stores flag help description for
 additional details.`,
-	Example: `  cockroach start --certs=<dir> --gossip=host1:port1[,...] --stores=ssd=/mnt/ssd1,...`,
-	Run:     runStart,
+	Example:      `  cockroach start --certs=<dir> --gossip=host1:port1[,...] --stores=ssd=/mnt/ssd1,...`,
+	SilenceUsage: true,
+	RunE:         runStart,
 }
 
 // runStart starts the cockroach node using --stores as the list of
 // storage devices ("stores") on this machine and --gossip as the list
 // of "well-known" hosts used to join this node to the cockroach
 // cluster via the gossip network.
-func runStart(_ *cobra.Command, _ []string) {
+func runStart(_ *cobra.Command, _ []string) error {
 	info := util.GetBuildInfo()
 	log.Infof("build Vers: %s", info.Vers)
 	log.Infof("build Tag:  %s", info.Tag)
@@ -129,29 +157,27 @@ func runStart(_ *cobra.Command, _ []string) {
 		context.Stores = "mem=1073741824"
 		context.GossipBootstrap = server.SelfGossipAddr
 
-		initCluster(stopper)
+		if err := initCluster(stopper); err != nil {
+			return err
+		}
 	} else {
 		if err := context.InitStores(stopper); err != nil {
-			log.Errorf("failed to initialize stores: %s", err)
-			return
+			return util.Errorf("failed to initialize stores: %s", err)
 		}
 	}
 
 	if err := context.InitNode(); err != nil {
-		log.Errorf("failed to initialize node: %s", err)
-		return
+		return util.Errorf("failed to initialize node: %s", err)
 	}
 
 	log.Info("starting cockroach cluster")
 	s, err := server.NewServer(context, stopper)
 	if err != nil {
-		log.Errorf("failed to start Cockroach server: %s", err)
-		return
+		return util.Errorf("failed to start Cockroach server: %s", err)
 	}
 
 	if err := s.Start(false); err != nil {
-		log.Errorf("cockroach server exited with error: %s", err)
-		return
+		return util.Errorf("cockroach server exited with error: %s", err)
 	}
 
 	signalCh := make(chan os.Signal, 1)
@@ -194,6 +220,7 @@ func runStart(_ *cobra.Command, _ []string) {
 		log.Infof("server drained and shutdown completed")
 	}
 	log.Flush()
+	return nil
 }
 
 // exterminateCmd command shuts down the node server and
@@ -205,7 +232,8 @@ var exterminateCmd = &cobra.Command{
 First shuts down the system and then destroys all data held by the
 node, cycling through each store specified by the --stores flag.
 `,
-	Run: runExterminate,
+	SilenceUsage: true,
+	RunE:         panicGuard(runExterminate),
 }
 
 // runExterminate destroys the data held in the specified stores.
@@ -213,27 +241,17 @@ func runExterminate(_ *cobra.Command, _ []string) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	if err := context.InitStores(stopper); err != nil {
-		log.Errorf("failed to initialize context: %s", err)
-		return
+		panicf("failed to initialize context: %s", err)
 	}
 
-	// First attempt to shutdown the server. Note that an error of EOF just
-	// means the HTTP server shutdown before the request to quit returned.
-	admin := client.NewAdminClient(&context.Context, context.Addr, client.Quit)
-	body, err := admin.Get()
-	if err != nil {
-		log.Infof("shutdown node %s: %s", context.Addr, err)
-	} else {
-		log.Infof("shutdown node in anticipation of data extermination: %s", body)
-	}
+	runQuit(nil, nil)
 
 	// Exterminate all data held in specified stores.
 	for _, e := range context.Engines {
 		if rocksdb, ok := e.(*engine.RocksDB); ok {
 			log.Infof("exterminating data from store %s", e)
 			if err := rocksdb.Destroy(); err != nil {
-				log.Errorf("unable to destroy store %s: %s", e, err)
-				osExit(1)
+				panicf("unable to destroy store %s: %s", e, err)
 			}
 		}
 	}
@@ -249,17 +267,18 @@ Shutdown the server. The first stage is drain, where any new requests
 will be ignored by the server. When all extant requests have been
 completed, the server exits.
 `,
-	Run: runQuit,
+	SilenceUsage: true,
+	RunE:         panicGuard(runQuit),
 }
 
 // runQuit accesses the quit shutdown path.
 func runQuit(_ *cobra.Command, _ []string) {
 	admin := client.NewAdminClient(&context.Context, context.Addr, client.Quit)
 	body, err := admin.Get()
+	// TODO(tschottdorf): needs cleanup. An error here can happen if the shutdown
+	// happened faster than the HTTP request made it back.
 	if err != nil {
-		fmt.Printf("shutdown node error: %s\n", err)
-		osExit(1)
-		return
+		panicf("shutdown node error: %s", err)
 	}
 	fmt.Printf("node drained and shutdown: %s\n", body)
 }

--- a/cli/user.go
+++ b/cli/user.go
@@ -32,7 +32,8 @@ var getUserCmd = &cobra.Command{
 	Long: `
 Fetches and displays the user configuration for <username>.
 `,
-	Run: runGetUser,
+	SilenceUsage: true,
+	RunE:         panicGuard(runGetUser),
 }
 
 func runGetUser(cmd *cobra.Command, args []string) {
@@ -56,7 +57,8 @@ var lsUsersCmd = &cobra.Command{
 	Long: `
 List all user configs.
 `,
-	Run: runLsUsers,
+	SilenceUsage: true,
+	RunE:         panicGuard(runLsUsers),
 }
 
 func runLsUsers(cmd *cobra.Command, args []string) {
@@ -80,7 +82,8 @@ var rmUserCmd = &cobra.Command{
 	Long: `
 Remove an existing user config by username.
 `,
-	Run: runRmUser,
+	SilenceUsage: true,
+	RunE:         panicGuard(runRmUser),
 }
 
 func runRmUser(cmd *cobra.Command, args []string) {
@@ -105,7 +108,8 @@ var setUserCmd = &cobra.Command{
 Create or update a user config for the specified username, prompting
 for the password.
 `,
-	Run: runSetUser,
+	SilenceUsage: true,
+	RunE:         panicGuard(runSetUser),
 }
 
 // runSetUser prompts for a password, then inserts the user and hash

--- a/cli/zone.go
+++ b/cli/zone.go
@@ -63,7 +63,8 @@ var getZoneCmd = &cobra.Command{
 	Long: `
 Fetches and displays the zone configuration for <object-id>.
 `,
-	Run: runGetZone,
+	SilenceUsage: true,
+	RunE:         panicGuard(runGetZone),
 }
 
 // runGetZone retrieves the zone config for a given object id,
@@ -103,7 +104,8 @@ var lsZonesCmd = &cobra.Command{
 	Long: `
 List zone configs.
 `,
-	Run: runLsZones,
+	SilenceUsage: true,
+	RunE:         panicGuard(runLsZones),
 }
 
 // TODO(marc): return db/table names rather than IDs.
@@ -137,7 +139,8 @@ var rmZoneCmd = &cobra.Command{
 Remove an existing zone config by object ID. No action is taken if no
 zone configuration exists for the specified object ID.
 `,
-	Run: runRmZone,
+	SilenceUsage: true,
+	RunE:         panicGuard(runRmZone),
 }
 
 // TODO(marc): accept db/table names rather than IDs.
@@ -185,7 +188,8 @@ cockroach zone set 100 "replicas:
 range_min_bytes: 8388608
 range_max_bytes: 67108864"
 `,
-	Run: runSetZone,
+	SilenceUsage: true,
+	RunE:         panicGuard(runSetZone),
 }
 
 // runSetZone parses the yaml input file, converts it to proto,

--- a/cli/zone.go
+++ b/cli/zone.go
@@ -121,7 +121,7 @@ func runLsZones(cmd *cobra.Command, args []string) {
 	}
 
 	if len(rows) == 0 {
-		log.Error("No zone configs founds")
+		log.Error("No zone configs found")
 		return
 	}
 	for _, r := range rows {

--- a/util/stop/stopper.go
+++ b/util/stop/stopper.go
@@ -194,7 +194,9 @@ func (s *Stopper) runningTasksLocked() TaskMap {
 // confirm it has stopped.
 func (s *Stopper) Stop() {
 	// Don't bother doing stuff cleanly if we're panicking, that would likely
-	// block. Instead, best effort only.
+	// block. Instead, best effort only. This cleans up the stack traces,
+	// avoids stalls and helps some tests in `./cli` finish cleanly (where
+	// panics happen on purpose).
 	if r := recover(); r != nil {
 		go s.Quiesce()
 		close(s.stopper)


### PR DESCRIPTION
this makes it a little more sane to work with the `cli`. In particular, a failed `init`, `start`, ... now returns an error. Also changed `./cockroach sql` so that it returns the error of the last failing command, which makes something like

`echo "SELECTTTT 1;" | ./cockroach sql`

return a nonzero exit code.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3581)

<!-- Reviewable:end -->
