### PR TITLE
Fix the main cause of flakiness in TestReplicaRogueRemoveNode.

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -705,7 +705,7 @@ func TestStoreRangeDownReplicate(t *testing.T) {
 			kickedOffReplicationQueue := false
 			for _, store := range mtc.stores {
 				if _, ok := idSet[store.StoreID()]; !ok {
-					store.ForceReplicaGCScan(t)
+					store.ForceReplicaGCScanAndProcess(t)
 				} else if !kickedOffReplicationQueue {
 					store.ForceReplicationScan(t)
 					kickedOffReplicationQueue = true
@@ -905,7 +905,7 @@ func TestReplicateAddAndRemove(t *testing.T) {
 
 		// Wait out the leader lease and the unleased duration to make the replica GC'able.
 		mtc.manualClock.Increment(int64(storage.ReplicaGCQueueInactivityThreshold+storage.DefaultLeaderLeaseDuration) + 1)
-		mtc.stores[1].ForceReplicaGCScan(t)
+		mtc.stores[1].ForceReplicaGCScanAndProcess(t)
 
 		// The removed store no longer has any of the data from the range.
 		verify([]int64{39, 0, 39, 39})
@@ -1322,12 +1322,23 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 	}
 
 	// Wait for the replica to be GC'd on node 1.
-	mtc.manualClock.Increment(int64(storage.DefaultLeaderLeaseDuration+
-		storage.ReplicaGCQueueInactivityThreshold) + 1)
-	mtc.stores[1].ForceReplicaGCScan(t)
-
 	// Store 0 has two writes, 1 has erased everything, and 2 still has the first write.
-	mtc.waitForValues(roachpb.Key("a"), time.Second, []int64{16, 0, 5})
+	// A single pass of ForceReplicaGCScanAndProcess is not enough, since the replica
+	// may be recreated by a stray raft message, so we run the GC scan inside the loop.
+	// TODO(bdarnell): if the call to RemoveReplica in replicaGCQueue.process can be
+	// moved under the lock, then the GC scan can be moved out of this loop.
+	util.SucceedsWithin(t, time.Second, func() error {
+		mtc.manualClock.Increment(int64(storage.DefaultLeaderLeaseDuration+
+			storage.ReplicaGCQueueInactivityThreshold) + 1)
+		mtc.stores[1].ForceReplicaGCScanAndProcess(t)
+
+		actual := mtc.readIntFromEngines(roachpb.Key("a"))
+		expected := []int64{16, 0, 5}
+		if !reflect.DeepEqual(expected, actual) {
+			return util.Errorf("expected %v, got %v", expected, actual)
+		}
+		return nil
+	})
 
 	// Bring node 2 back up.
 	mtc.restartStore(2)
@@ -1365,7 +1376,7 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 	// lease will cause GC to do a consistent range lookup, where it
 	// will see that the range has been moved and delete the old
 	// replica.
-	mtc.stores[2].ForceReplicaGCScan(t)
+	mtc.stores[2].ForceReplicaGCScanAndProcess(t)
 	mtc.waitForValues(roachpb.Key("a"), 3*time.Second, []int64{16, 0, 0})
 
 	// Now that the group has been GC'd, the goroutine that was

--- a/storage/client_replica_gc_test.go
+++ b/storage/client_replica_gc_test.go
@@ -113,7 +113,7 @@ func TestReplicaGCQueueDropReplicaGCOnScan(t *testing.T) {
 	// Make sure the range is removed from the store.
 	util.SucceedsWithin(t, time.Second, func() error {
 		store := mtc.stores[1]
-		store.ForceReplicaGCScan(t)
+		store.ForceReplicaGCScanAndProcess(t)
 		if _, err := store.GetReplica(rangeID); !testutils.IsError(err, "range .* was not found") {
 			return util.Errorf("expected range removal: %s", err)
 		}

--- a/storage/store.go
+++ b/storage/store.go
@@ -739,15 +739,17 @@ func (s *Store) ForceReplicationScan(t util.Tester) {
 	}
 }
 
-// ForceReplicaGCScan iterates over all ranges and enqueues any that
+// ForceReplicaGCScanAndProcess iterates over all ranges and enqueues any that
 // may need to be GC'd. Exposed only for testing.
-func (s *Store) ForceReplicaGCScan(t util.Tester) {
+func (s *Store) ForceReplicaGCScanAndProcess(t util.Tester) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	for _, r := range s.replicas {
 		s.replicaGCQueue.MaybeAdd(r, s.ctx.Clock.Now())
 	}
+	s.mu.Unlock()
+
+	s.replicaGCQueue.DrainQueue(s.ctx.Clock)
 }
 
 // DisableRaftLogQueue disables or enables the raft log queue.


### PR DESCRIPTION
The major issue is that a raft group could be reawakened during the GC
processing, so a single GC queue pass was not enough.

Fixes #3538.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3593)

<!-- Reviewable:end -->
