### PR TITLE
sql: Remove error from a return value of PrivilegeDescriptor.Show

### DIFF
--- a/sql/privilege.go
+++ b/sql/privilege.go
@@ -227,7 +227,7 @@ type UserPrivilegeString struct {
 
 // Show returns the list of {username, privileges} sorted by username.
 // 'privileges' is a string of comma-separated sorted privilege names.
-func (p *PrivilegeDescriptor) Show() ([]UserPrivilegeString, error) {
+func (p *PrivilegeDescriptor) Show() []UserPrivilegeString {
 	ret := []UserPrivilegeString{}
 	for _, userPriv := range p.Users {
 		ret = append(ret, UserPrivilegeString{
@@ -235,7 +235,7 @@ func (p *PrivilegeDescriptor) Show() ([]UserPrivilegeString, error) {
 			Privileges: privilege.ListFromBitField(userPriv.Privileges).SortedString(),
 		})
 	}
-	return ret, nil
+	return ret
 }
 
 // CheckPrivilege returns true if 'user' has 'privilege' on this descriptor.

--- a/sql/privilege_test.go
+++ b/sql/privilege_test.go
@@ -74,10 +74,7 @@ func TestPrivilege(t *testing.T) {
 				descriptor.Revoke(tc.grantee, tc.revoke)
 			}
 		}
-		show, err := descriptor.Show()
-		if err != nil {
-			t.Fatal(err)
-		}
+		show := descriptor.Show()
 		if len(show) != len(tc.show) {
 			t.Fatalf("#%d: show output for descriptor %+v differs, got: %+v, expected %+v",
 				tcNum, descriptor, show, tc.show)

--- a/sql/show.go
+++ b/sql/show.go
@@ -144,10 +144,7 @@ func (p *planner) ShowGrants(n *parser.ShowGrants) (planNode, error) {
 		wantedUsers[u] = struct{}{}
 	}
 
-	userPrivileges, err := descriptor.GetPrivileges().Show()
-	if err != nil {
-		return nil, err
-	}
+	userPrivileges := descriptor.GetPrivileges().Show()
 	for _, userPriv := range userPrivileges {
 		if wantedUsers != nil {
 			if _, ok := wantedUsers[userPriv.User]; !ok {


### PR DESCRIPTION
Tiny fix. The return error value was always nil.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3600)

<!-- Reviewable:end -->
