### PR TITLE
sql: test + enable ruby

### DIFF
--- a/acceptance/cluster/cluster.go
+++ b/acceptance/cluster/cluster.go
@@ -16,7 +16,11 @@
 
 package cluster
 
-import "github.com/cockroachdb/cockroach/util"
+import (
+	"net"
+
+	"github.com/cockroachdb/cockroach/util"
+)
 
 // A Cluster is an abstraction away from a concrete cluster deployment (i.e.
 // a local docker cluster, or an AWS-provisioned one). It exposes a shared
@@ -26,6 +30,8 @@ type Cluster interface {
 	NumNodes() int
 	// ConnString returns a connection string for the given node.
 	ConnString(int) string
+	// PGAddr returns the Postgres address for the given node.
+	PGAddr(i int) *net.TCPAddr
 	// Assert verifies that the cluster state is as expected (i.e. no unexpected
 	// restarts or node deaths occurred). Tests can call this periodically to
 	// ascertain cluster health.

--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -66,7 +66,7 @@ func getTLSConfig() *tls.Config {
 // method. If DOCKER_HOST is set, initialize the client using DOCKER_TLS_VERIFY
 // and DOCKER_CERT_PATH. If DOCKER_HOST is not set, look for the unix domain
 // socket in /run/docker.sock and /var/run/docker.sock.
-func newDockerClient() dockerclient.Client {
+func NewDockerClient() dockerclient.Client {
 	if host := os.Getenv("DOCKER_HOST"); host != "" {
 		if os.Getenv("DOCKER_TLS_VERIFY") == "" {
 			c, err := dockerclient.NewDockerClient(host, nil)
@@ -296,12 +296,7 @@ func (c *Container) Addr(name string) *net.TCPAddr {
 		return nil
 	}
 	if name == "" {
-		// No port specified, pick a random one (random because iteration
-		// over maps is randomized).
-		for port := range containerInfo.NetworkSettings.Ports {
-			name = port
-			break
-		}
+		name = cockroachTCP
 	}
 	bindings, ok := containerInfo.NetworkSettings.Ports[name]
 	if !ok || len(bindings) == 0 {
@@ -312,6 +307,11 @@ func (c *Container) Addr(name string) *net.TCPAddr {
 		IP:   dockerIP(),
 		Port: port,
 	}
+}
+
+// PGAddr returns the address to connect to the Postgres port.
+func (c *Container) PGAddr() *net.TCPAddr {
+	return c.Addr(pgTCP)
 }
 
 // GetJSON retrieves the URL specified by https://Addr(<port>)<path>

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,6 +40,12 @@ const (
 	dockerspyImage = "cockroachdb/docker-spy"
 	domain         = "local"
 	cockroachPort  = 26257
+	pgPort         = 15432
+)
+
+var (
+	cockroachTCP = fmt.Sprintf("%d/tcp", cockroachPort)
+	pgTCP        = fmt.Sprintf("%d/tcp", pgPort)
 )
 
 var cockroachImage = flag.String("i", builderImage, "the docker image to run")
@@ -130,7 +137,7 @@ func CreateLocal(numLocal, numStores int, logDir string, stopper chan struct{}) 
 	}
 
 	return &LocalCluster{
-		client:    newDockerClient(),
+		client:    NewDockerClient(),
 		stopper:   stopper,
 		numLocal:  numLocal,
 		numStores: numStores,
@@ -309,12 +316,15 @@ func (l *LocalCluster) createRoach(i int, cmd ...string) *Container {
 		entrypoint = append(entrypoint, *cockroachEntry)
 	}
 	c, err := createContainer(l, dockerclient.ContainerConfig{
-		Hostname:     hostname,
-		Domainname:   domain,
-		Image:        *cockroachImage,
-		ExposedPorts: map[string]struct{}{fmt.Sprintf("%d/tcp", cockroachPort): {}},
-		Entrypoint:   entrypoint,
-		Cmd:          cmd,
+		Hostname:   hostname,
+		Domainname: domain,
+		Image:      *cockroachImage,
+		ExposedPorts: map[string]struct{}{
+			cockroachTCP: {},
+			pgTCP:        {},
+		},
+		Entrypoint: entrypoint,
+		Cmd:        cmd,
 		Labels: map[string]string{
 			// Allow for `docker ps --filter label=Hostname=roach0` or `--filter label=Roach`.
 			"Hostname": hostname,
@@ -590,6 +600,11 @@ func (l *LocalCluster) ConnString(i int) string {
 	return "rpcs://" + security.NodeUser + "@" +
 		l.Nodes[i].Addr("").String() +
 		"?certs=" + l.CertsDir
+}
+
+// PGAddr returns the Postgres address for the given node.
+func (l *LocalCluster) PGAddr(i int) *net.TCPAddr {
+	return l.Nodes[i].PGAddr()
 }
 
 // NumNodes returns the number of nodes in the cluster.

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -126,6 +126,16 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// MustStartLocal skips tests not running against a local cluster.
+func MustStartLocal(t *testing.T) *cluster.LocalCluster {
+	if *numLocal == 0 {
+		t.Skip("skipping since not run against local cluster")
+	}
+	l := cluster.CreateLocal(*numLocal, *numStores, *logDir, stopper)
+	l.Start()
+	return l
+}
+
 func makeClient(t util.Tester, str string) (*client.DB, *stop.Stopper) {
 	stopper := stop.NewStopper()
 

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -73,11 +73,7 @@ func checkRangeReplication(t util.Tester, c *cluster.LocalCluster, d time.Durati
 }
 
 func TestRangeReplication(t *testing.T) {
-	if *numLocal == 0 {
-		t.Skip("skipping since not run against local cluster")
-	}
-	l := cluster.CreateLocal(*numLocal, *numStores, *logDir, stopper) // intentionally using local cluster
-	l.Start()
+	l := MustStartLocal(t)
 	defer l.AssertAndStop(t)
 
 	checkRangeReplication(t, l, 20*time.Second)

--- a/acceptance/ruby_test.go
+++ b/acceptance/ruby_test.go
@@ -1,0 +1,93 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Jibson (mjibson@cockroachlabs.com)
+
+// +build acceptance
+
+package acceptance
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/acceptance/cluster"
+	"github.com/samalba/dockerclient"
+)
+
+// TestRuby connects to a cluster with ruby.
+func TestRuby(t *testing.T) {
+	l := MustStartLocal(t)
+	defer l.AssertAndStop(t)
+
+	addr := l.Nodes[0].PGAddr()
+
+	client := cluster.NewDockerClient()
+	containerConfig := dockerclient.ContainerConfig{
+		Image: "cockroachdb/postgres-test:ruby",
+		Env: []string{
+			fmt.Sprintf("PGHOST=%s", addr.IP),
+			fmt.Sprintf("PGPORT=%d", addr.Port),
+			"PGSSLCERT=/certs/node.client.crt",
+			"PGSSLKEY=/certs/node.client.key",
+		},
+		Cmd: []string{"ruby", "-e", ruby},
+	}
+	if err := client.PullImage(containerConfig.Image, nil); err != nil {
+		t.Fatal(err)
+	}
+	id, err := client.CreateContainer(&containerConfig, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.RemoveContainer(id, false, false)
+
+	hostConfig := dockerclient.HostConfig{
+		Binds:       []string{fmt.Sprintf("%s:%s", l.CertsDir, "/certs")},
+		NetworkMode: "host",
+	}
+	if err := client.StartContainer(id, &hostConfig); err != nil {
+		t.Fatal(err)
+	}
+	wr := <-client.Wait(id)
+	if wr.Error != nil {
+		t.Fatal(wr.Error)
+	}
+	if wr.ExitCode != 0 {
+		rc, err := client.ContainerLogs(id, &dockerclient.LogOptions{
+			Stdout: true,
+			Stderr: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := ioutil.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Log(err)
+		} else {
+			t.Log(string(b))
+		}
+		t.Fatalf("exit code: %d", wr.ExitCode)
+	}
+}
+
+const ruby = `
+require 'pg'
+
+conn = PG.connect(host: ENV['PGHOST'], port: ENV['PGPORT'])
+res = conn.exec_params('SELECT 1, 2 > $1, $1', [3])
+raise 'Unexpected: ' + res.values.to_s unless res.values == [["1", "f", "3"]]
+`

--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -173,6 +173,11 @@ func (f *Farmer) ConnString(i int) string {
 		"?certs=" + "certswhocares"
 }
 
+// PGAddr returns the Postgres address for the given node.
+func (f *Farmer) PGAddr(i int) *net.TCPAddr {
+	panic("unimplemented")
+}
+
 // WaitReady waits until the infrastructure is in a state that *should* allow
 // for a healthy cluster. Currently, this means waiting for the load balancer
 // to resolve from all nodes.

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -111,6 +111,9 @@ var flagUsage = map[string]string{
 	"metrics-frequency": `
         Adjust the frequency at which the server records its own internal metrics.
 `,
+	"pgaddr": `
+        The host:port to bind for Postgres traffic.
+`,
 	"scan-interval": `
         Adjusts the target for the duration of a single scan through a store's
         ranges. The scan is slowed as necessary to approximately achieve this
@@ -174,6 +177,7 @@ func initFlags(ctx *server.Context) {
 
 		// Server flags.
 		f.StringVar(&ctx.Addr, "addr", ctx.Addr, flagUsage["addr"])
+		f.StringVar(&ctx.PGAddr, "pgaddr", ctx.PGAddr, flagUsage["pgaddr"])
 		f.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, flagUsage["attrs"])
 		f.StringVar(&ctx.Stores, "stores", ctx.Stores, flagUsage["stores"])
 		f.DurationVar(&ctx.MaxOffset, "max-offset", ctx.MaxOffset, flagUsage["max-offset"])

--- a/server/context.go
+++ b/server/context.go
@@ -37,6 +37,7 @@ import (
 // Context defaults.
 const (
 	defaultAddr               = ":26257"
+	defaultPGAddr             = ":15432"
 	defaultMaxOffset          = 250 * time.Millisecond
 	defaultCacheSize          = 512 << 20 // 512 MB
 	defaultMemtableBudget     = 512 << 20 // 512 MB
@@ -56,6 +57,9 @@ type Context struct {
 
 	// Addr is the host:port to bind for HTTP/RPC traffic.
 	Addr string
+
+	// PGAddr is the host:port to bind for Postgres traffic.
+	PGAddr string
 
 	// Stores is specified to enable durable key-value storage.
 	// Memory-backed key value stores may be optionally specified
@@ -142,6 +146,7 @@ func NewContext() *Context {
 func (ctx *Context) InitDefaults() {
 	ctx.Context.InitDefaults()
 	ctx.Addr = defaultAddr
+	ctx.PGAddr = defaultPGAddr
 	ctx.MaxOffset = defaultMaxOffset
 	ctx.CacheSize = defaultCacheSize
 	ctx.MemtableBudget = defaultMemtableBudget

--- a/server/server.go
+++ b/server/server.go
@@ -250,13 +250,7 @@ func (s *Server) Start(selfBootstrap bool) error {
 	log.Infof("starting %s server at %s", s.ctx.HTTPRequestScheme(), addr)
 	s.initHTTP()
 
-	// TODO(tamird): pick a port here
-	host, _, err := net.SplitHostPort(addrStr)
-	if err != nil {
-		return err
-	}
-
-	return s.pgServer.Start(util.MakeUnresolvedAddr("tcp", net.JoinHostPort(host, "0")))
+	return s.pgServer.Start(util.MakeUnresolvedAddr("tcp", s.ctx.PGAddr))
 }
 
 // initHTTP registers http prefixes.

--- a/sql/pgwire/server.go
+++ b/sql/pgwire/server.go
@@ -73,6 +73,7 @@ func (s *Server) Start(addr net.Addr) error {
 		<-s.context.Stopper.ShouldStop()
 		s.close()
 	})
+	log.Infof("starting postgres server at %s", ln.Addr())
 	return nil
 }
 

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -290,6 +290,9 @@ func (c *v3Conn) handleParse(buf *readBuffer) error {
 	}
 	args := make(parser.MapArgs)
 	for i, t := range inTypeHints {
+		if t == 0 {
+			continue
+		}
 		v, ok := oidToDatum[t]
 		if !ok {
 			return c.sendError(fmt.Sprintf("unknown oid type: %v", t))


### PR DESCRIPTION
The change in v3.go allows types of '0', which the spec says to treat
as unspecified.

The changes to server hardcode a postgres port of 15432. We can add options
to change it later, but it is currently the same logic as the cockroach port.

The acceptance tests spawn a docker container running ruby with the pg
gem installed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3602)

<!-- Reviewable:end -->
