### PR TITLE
Support non-interactive user creation

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -421,6 +421,43 @@ range_max_bytes: 67108864
 	// node drained and shutdown: ok
 }
 
+func Example_user() {
+	c := newCLITest()
+
+	c.Run("user ls")
+	c.Run("user set foo --password=bar")
+	// Don't use get, since the output of hashedPassword is random.
+	// c.Run("user get foo")
+	c.Run("user ls")
+	c.Run("user rm foo")
+	c.Run("user ls")
+	c.Run("quit")
+
+	// Output:
+	// user ls
+	// +----------+
+	// | username |
+	// +----------+
+	// +----------+
+	// user set foo --password=bar
+	// OK
+	// user ls
+	// +----------+
+	// | username |
+	// +----------+
+	// | foo      |
+	// +----------+
+	// user rm foo
+	// OK
+	// user ls
+	// +----------+
+	// | username |
+	// +----------+
+	// +----------+
+	// quit
+	// node drained and shutdown: ok
+}
+
 // TestFlagUsage is a basic test to make sure the fragile
 // help template does not break.
 func TestFlagUsage(t *testing.T) {

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -146,6 +146,10 @@ var flagUsage = map[string]string{
 		Determines the criteria used by nodes to make balanced allocation
 		decisions.  Valid options are "usage" (default) or "rangecount".
 `,
+	"password": `
+        The created user's password. If provided, disables prompting. Pass '-' to provide
+	the password on standard input.
+`,
 }
 
 func normalizeStdFlagName(s string) string {
@@ -228,6 +232,8 @@ func initFlags(ctx *server.Context) {
 			panic(err)
 		}
 	}
+
+	setUserCmd.Flags().StringVar(&password, "password", "", flagUsage["password"])
 
 	clientCmds := []*cobra.Command{
 		sqlShellCmd, kvCmd, rangeCmd,

--- a/security/password.go
+++ b/security/password.go
@@ -63,8 +63,8 @@ func promptForPassword() ([]byte, error) {
 	return []byte(one), nil
 }
 
-// hashPassword takes a raw password and returns a bcrypt hashed password.
-func hashPassword(raw []byte) ([]byte, error) {
+// HashPassword takes a raw password and returns a bcrypt hashed password.
+func HashPassword(raw []byte) ([]byte, error) {
 	return bcrypt.GenerateFromPassword(raw, bcryptCost)
 }
 
@@ -79,5 +79,5 @@ func PromptForPasswordAndHash() ([]byte, error) {
 	if len(password) == 0 {
 		return nil, util.Errorf("password cannot be empty")
 	}
-	return hashPassword(password)
+	return HashPassword(password)
 }


### PR DESCRIPTION
This supports --password option for user creation of CLI and stops prompting for the password.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3603)

<!-- Reviewable:end -->
