### PR TITLE
disable flaky TestProtocols

### DIFF
--- a/sql/driver/driver_test.go
+++ b/sql/driver/driver_test.go
@@ -386,6 +386,7 @@ func TestConnectionSettings(t *testing.T) {
 
 func TestProtocols(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	t.Skip("TODO(tschottdorf): #3610")
 
 	// Test that all of the network protocols work.
 	for _, scheme := range []string{"http", "https", "rpc", "rpcs"} {


### PR DESCRIPTION
I'll look at a fix. Looks like the initial splits get stuck.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3613)

<!-- Reviewable:end -->
