### PR TITLE
Enable 1PC optimization for inserts.

### DIFF
--- a/sql/explain.go
+++ b/sql/explain.go
@@ -47,7 +47,7 @@ func (p *planner) Explain(n *parser.Explain) (planNode, error) {
 		return nil, fmt.Errorf("unsupported EXPLAIN options: %s", n)
 	}
 
-	plan, err := p.makePlan(n.Statement)
+	plan, err := p.makePlan(n.Statement, false)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -64,7 +64,7 @@ func (v *subqueryVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, par
 	// copy of the planner in order for there to have a separate subqueryVisitor.
 	planMaker := *v.planner
 	var plan planNode
-	if plan, v.err = planMaker.makePlan(subquery.Select); v.err != nil {
+	if plan, v.err = planMaker.makePlan(subquery.Select, false); v.err != nil {
 		return nil, expr
 	}
 


### PR DESCRIPTION
```
name                   old time/op  new time/op  delta
Insert1_Cockroach-8     876µs ± 1%   542µs ± 2%  -38.20%  (p=0.000 n=8+10)
Insert10_Cockroach-8   1.26ms ± 2%  0.94ms ± 0%  -25.69%  (p=0.000 n=10+7)
Insert100_Cockroach-8  4.77ms ± 1%  4.45ms ± 1%   -6.65%  (p=0.000 n=10+9)
```

See #3417.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3616)

<!-- Reviewable:end -->
