### PR TITLE
more time for initial splits

### DIFF
--- a/server/testserver.go
+++ b/server/testserver.go
@@ -44,7 +44,8 @@ const (
 	TestUser = "testuser"
 	// initialSplitsTimeout is the amount of time to wait for initial splits to
 	// occur on a freshly started server.
-	initialSplitsTimeout = time.Second
+	// Note: this needs to be fairly high or tests become flaky.
+	initialSplitsTimeout = 10 * time.Second
 )
 
 // StartTestServer starts a in-memory test server.

--- a/sql/driver/driver_test.go
+++ b/sql/driver/driver_test.go
@@ -386,7 +386,6 @@ func TestConnectionSettings(t *testing.T) {
 
 func TestProtocols(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("TODO(tschottdorf): #3610")
 
 	// Test that all of the network protocols work.
 	for _, scheme := range []string{"http", "https", "rpc", "rpcs"} {


### PR DESCRIPTION
locally gets `TestProtocols` stable (>4k attempts),
so hopefully this eases the redness of master a bit.

Related to #3605.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3621)

<!-- Reviewable:end -->
