### PR TITLE
acceptance logs: MkdirAll instead of Mkdir

### DIFF
--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -365,7 +365,7 @@ func (l *LocalCluster) startNode(i int) *Container {
 		dockerlogDir := "/logs/" + nodeStr(i)
 		locallogDir = filepath.Join(l.logDir, nodeStr(i))
 		if !exists(locallogDir) {
-			if err := os.Mkdir(locallogDir, 0777); err != nil {
+			if err := os.MkdirAll(locallogDir, 0777); err != nil {
 				log.Fatal(err)
 			}
 		}

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -274,6 +274,12 @@ func (l *LocalCluster) initCluster() {
 			l.logDir = filepath.Join(pwd, l.logDir)
 		}
 		binds = append(binds, l.logDir+":/logs")
+		// If we don't make sure the directory exists, Docker will and then we
+		// may run into ownership issues (think Docker running as root, but us
+		// running as a regular Joe as it happens on CircleCI).
+		if err := os.MkdirAll(l.logDir, 0777); err != nil {
+			log.Fatal(err)
+		}
 	} else if l.ForceLogging {
 		l.logDir, err = ioutil.TempDir(pwd, ".localcluster.logs.")
 		if err != nil {

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -370,10 +370,8 @@ func (l *LocalCluster) startNode(i int) *Container {
 	if len(l.logDir) > 0 {
 		dockerlogDir := "/logs/" + nodeStr(i)
 		locallogDir = filepath.Join(l.logDir, nodeStr(i))
-		if !exists(locallogDir) {
-			if err := os.MkdirAll(locallogDir, 0777); err != nil {
-				log.Fatal(err)
-			}
+		if err := os.MkdirAll(locallogDir, 0777); err != nil {
+			log.Fatal(err)
 		}
 		cmd = append(
 			cmd,

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -15,8 +15,8 @@ match='^F\d+|^panic|^[Gg]oroutine \d+|(read|write) by.*goroutine|DATA RACE|Too m
 
 prepare_artifacts() {
   ret=$?
-
-  set +e
+  # Show each action taken so we can trace if things go awry here.
+  set -x
 
   # Translate the log output to xml to integrate with CircleCI
   # better.

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -14,6 +14,7 @@ builder=$(dirname $0)/builder.sh
 match='^F[0-9]+|^panic|^[Gg]oroutine [0-9]+|(read|write) by.*goroutine|DATA RACE|Too many goroutines running after tests'
 
 prepare_artifacts() {
+  # Friendly but stern reminder: Never ever move this or put anything above it.
   ret=$?
   # Show each action taken so we can trace if things go awry here.
   set -x

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -11,7 +11,7 @@ else
 fi
 
 builder=$(dirname $0)/builder.sh
-match='^F\d+|^panic|^[Gg]oroutine \d+|(read|write) by.*goroutine|DATA RACE|Too many goroutines running after tests'
+match='^F[0-9]+|^panic|^[Gg]oroutine [0-9]+|(read|write) by.*goroutine|DATA RACE|Too many goroutines running after tests'
 
 prepare_artifacts() {
   ret=$?

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -76,7 +76,7 @@ prepare_artifacts() {
      [ "${CIRCLE_BRANCH-}" = "master" -o -n "${NIGHTLY-}" ]
   then
       function post() {
-        curl -v -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \
+        curl -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \
         "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/$1" \
         -d "${2}"
       }

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -132,15 +132,7 @@ time ${builder} make test \
   grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
   awk '{print "test:", $0}'
 
-# 4. Run "make testrace".
-echo "make testrace"
-time ${builder} make testrace \
-  TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
-  tr -d '\r' | tee "${outdir}/testrace.log" | \
-  grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
-  awk '{print "race:", $0}'
-
-# 5. Run the acceptance tests (only on Linux). We can run the
+# 4. Run the acceptance tests (only on Linux). We can run the
 # acceptance tests on the Mac's, but circle-deps.sh only built the
 # acceptance tests for Linux.
 if [ "$(uname)" = "Linux" ]; then
@@ -157,3 +149,12 @@ if [ "$(uname)" = "Linux" ]; then
 else
   echo "skipping acceptance tests on $(uname): use 'make acceptance' instead"
 fi
+
+# 5. Run "make testrace". This takes a long time and fails mostly for flaky
+# tests, so it's last to give the "real" failures a chance first.
+echo "make testrace"
+time ${builder} make testrace \
+  TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
+  tr -d '\r' | tee "${outdir}/testrace.log" | \
+  grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
+  awk '{print "race:", $0}'


### PR DESCRIPTION
I think this is responsible for

```
F0105 17:26:51.483286 18569 acceptance/cluster/localcluster.go:369  mkdir /tmp/circle-artifacts.Z4vWa88/acceptance/TestChaos/roach0.local: permission denied
```

though there could be other issues (on OSX, `-l /tmp/something` fails, likely related to it not being mounted into the host vm).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3625)

<!-- Reviewable:end -->
