### PR TITLE
cli: reenable Example_max_results

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -334,9 +334,6 @@ func Example_cput() {
 	// node drained and shutdown: ok
 }
 
-// TODO(tamird): reenable this? it sometimes leakes goroutines.
-// https://github.com/cockroachdb/cockroach/issues/3120
-/*
 func Example_max_results() {
 	c := newCLITest()
 
@@ -362,15 +359,14 @@ func Example_max_results() {
 	// range split c
 	// range split d
 	// range ls --max-results=2
-	// ""-"c" [1]
+	// /Min-"c" [1]
 	// 	0: node-id=1 store-id=1
-	// "c"-"d" [2]
+	// "c"-"d" [4]
 	// 	0: node-id=1 store-id=1
 	// 2 result(s)
 	// quit
 	// node drained and shutdown: ok
 }
-*/
 
 func Example_zone() {
 	c := newCLITest()


### PR DESCRIPTION
I can't reproduce the goroutine leak locally. Fixes #3120.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3644)

<!-- Reviewable:end -->
