### PR TITLE
Bump rocksdb pointer.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -17,7 +17,7 @@ github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store 3b4c041f52c224ee4a44f5c8b150d003a40643a0
 github.com/cockroachdb/c-lz4 c40aaae2fc50293eb8750b34632bc3efe813e23f
 github.com/cockroachdb/c-protobuf 06ebfe7beffe6099e93edbc340051eb047ea91f3
-github.com/cockroachdb/c-rocksdb 238968fe404909024125e5d20372db140c624cff
+github.com/cockroachdb/c-rocksdb 6f3b30efeadd0ec50e378ea81f76c07b76470117
 github.com/cockroachdb/c-snappy 5c6d0932e0adaffce4bfca7bdf2ac37f79952ccf
 github.com/cockroachdb/yacc 443154b1852a8702b07d675da6cd97cd9177a316
 github.com/codahale/hdrhistogram 954f16e8b9ef0e5d5189456aa4c1202758e04f17

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -194,6 +194,16 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 		t.Errorf("error bootstrapping store: %s", err)
 	}
 
+	// Verify we can read the store ident after a flush.
+	if err := eng.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if value, _, err := engine.MVCCGet(eng, keys.StoreIdentKey(), roachpb.ZeroTimestamp, true, nil); err != nil {
+		t.Fatal(err)
+	} else if value == nil {
+		t.Fatalf("unable to read store ident")
+	}
+
 	// Try to get 1st range--non-existent.
 	if _, err := store.GetReplica(1); err == nil {
 		t.Error("expected error fetching non-existent range")


### PR DESCRIPTION
Add a check that the store ident can be read after bootstrapping.

Fixes #3624.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3655)

<!-- Reviewable:end -->
