### PR TITLE
Reimplement MakePriority

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -94,7 +94,7 @@ func createTestClientForUser(t *testing.T, stopper *stop.Stopper, addr, user str
 
 // createTestNotifyClient creates a new client which connects using an HTTP
 // sender to the server at addr. It contains a waitgroup to allow waiting.
-func createTestNotifyClient(stopper *stop.Stopper, addr string, priority int32) (*client.DB, *notifyingSender) {
+func createTestNotifyClient(stopper *stop.Stopper, addr string, priority float64) (*client.DB, *notifyingSender) {
 	db, err := client.Open(stopper, fmt.Sprintf("rpcs://%s@%s?certs=%s",
 		security.NodeUser,
 		addr,
@@ -145,7 +145,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 	for i, test := range testCases {
 		key := roachpb.Key(fmt.Sprintf("key-%d", i))
 		var txnPri int32 = 1
-		var clientPri int32 = 1
+		var clientPri float64 = 1
 		if test.canPush {
 			clientPri = 2
 		} else {

--- a/client/db.go
+++ b/client/db.go
@@ -33,6 +33,11 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
+// defaultUserPriority is set to 1, meaning ops run through the database
+// are all given equal weight when a random priority is chosen. This can
+// be set specifically via NewDBWithPriority().
+const defaultUserPriority = 1
+
 // KeyValue represents a single key/value pair and corresponding
 // timestamp. This is similar to roachpb.KeyValue except that the value may be
 // nil.
@@ -167,9 +172,9 @@ type DB struct {
 	sender Sender
 
 	// userPriority is the default user priority to set on API calls. If
-	// userPriority is set non-zero in call arguments, this value is
-	// ignored.
-	userPriority    int32
+	// userPriority is set to any value except 1 in call arguments, this
+	// value is ignored.
+	userPriority    float64
 	txnRetryOptions retry.Options
 }
 
@@ -182,12 +187,13 @@ func (db *DB) GetSender() Sender {
 func NewDB(sender Sender) *DB {
 	return &DB{
 		sender:          sender,
+		userPriority:    defaultUserPriority,
 		txnRetryOptions: DefaultTxnRetryOptions,
 	}
 }
 
 // NewDBWithPriority returns a new DB.
-func NewDBWithPriority(sender Sender, userPriority int32) *DB {
+func NewDBWithPriority(sender Sender, userPriority float64) *DB {
 	db := NewDB(sender)
 	db.userPriority = userPriority
 	return db
@@ -243,15 +249,16 @@ func Open(stopper *stop.Stopper, addr string) (*DB, error) {
 
 	db := &DB{
 		sender:          sender,
+		userPriority:    defaultUserPriority,
 		txnRetryOptions: DefaultTxnRetryOptions,
 	}
 
 	if priority := q["priority"]; len(priority) > 0 {
-		p, err := strconv.Atoi(priority[0])
+		p, err := strconv.ParseFloat(priority[0], 64)
 		if err != nil {
 			return nil, err
 		}
-		db.userPriority = int32(p)
+		db.userPriority = p
 	}
 
 	return db, nil
@@ -469,8 +476,8 @@ func (db *DB) send(reqs ...roachpb.Request) (*roachpb.BatchResponse, *roachpb.Er
 	ba := roachpb.BatchRequest{}
 	ba.Add(reqs...)
 
-	if ba.UserPriority == nil && db.userPriority != 0 {
-		ba.UserPriority = proto.Int32(db.userPriority)
+	if ba.UserPriority == 0 && db.userPriority != 1 {
+		ba.UserPriority = db.userPriority
 	}
 	br, pErr := db.sender.Send(context.TODO(), ba)
 	if pErr != nil {

--- a/client/txn.go
+++ b/client/txn.go
@@ -136,7 +136,7 @@ func (txn *Txn) SetIsolation(isolation roachpb.IsolationType) error {
 func (txn *Txn) InternalSetPriority(priority int32) {
 	// The negative user priority is translated on the server into a positive,
 	// non-randomized, priority for the transaction.
-	txn.db.userPriority = -priority
+	txn.db.userPriority = float64(-priority)
 }
 
 // SetSystemDBTrigger sets the system db trigger to true on this transaction.

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -51,7 +51,7 @@ func newTestSender(pre, post func(roachpb.BatchRequest) (*roachpb.BatchResponse,
 	txnID := []byte(uuid.NewUUID4())
 
 	return func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		ba.UserPriority = proto.Int32(-1)
+		ba.UserPriority = 1
 		if ba.Txn != nil && len(ba.Txn.ID) == 0 {
 			ba.Txn.Key = txnKey
 			ba.Txn.ID = txnID
@@ -184,7 +184,7 @@ func TestTransactionConfig(t *testing.T) {
 	db.userPriority = 101
 	if err := db.Txn(func(txn *Txn) error {
 		if txn.db.userPriority != db.userPriority {
-			t.Errorf("expected txn user priority %d; got %d", db.userPriority, txn.db.userPriority)
+			t.Errorf("expected txn user priority %f; got %f", db.userPriority, txn.db.userPriority)
 		}
 		return nil
 	}); err != nil {

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -570,9 +570,6 @@ message ResponseUnion {
 // A Header is attached to a BatchRequest, encapsulating routing and auxiliary
 // information required for executing it.
 message Header {
-  // Getters are required for default values.
-  option (gogoproto.goproto_getters) = true;
-
   // timestamp specifies time at which read or writes should be
   // performed. If the timestamp is set to zero value, its value
   // is initialized to the wall time of the receiving node.
@@ -584,16 +581,16 @@ message Header {
   // request to the correct range.
   optional int64 range_id = 3 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "RangeID", (gogoproto.casttype) = "RangeID"];
-  // user_priority specifies priority multiple for non-transactional
-  // commands. This value should be a positive integer [1, 2^31-1).
-  // It's properly viewed as a multiple for how likely this
-  // transaction will be to prevail if a write conflict occurs.
-  // Commands with user_priority=100 will be 100x less likely to be
-  // aborted as conflicting transactions or non-transactional commands
-  // with user_priority=1. This value is ignored if Txn is
-  // specified. If neither this value nor txn is specified, the value
-  // defaults to 1.
-  optional int32 user_priority = 4 [default = 1];
+  // user_priority allows any command's priority to be biased from the
+  // default random priority. It specifies a multiple. If set to 0.5,
+  // the chosen priority will be 1/2x as likely to beat any default
+  // random priority. If set to 1, a default random priority is
+  // chosen. If set to 2, the chosen priority will be 2x as likely to
+  // beat any default random priority, and so on. As a special case, 0
+  // priority is treated the same as 1. This value is ignored if txn
+  // is specified. The min and max user priorities are set via
+  // MinUserPriority and MaxUserPriority in data.go.
+  optional double user_priority = 4 [(gogoproto.nullable) = false];
   // txn is set non-nil if a transaction is underway. To start a txn,
   // the first request should set this field to non-nil with name and
   // isolation level set as desired. The response will contain the

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -285,14 +285,14 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	// priority to trigger the txn restart.
 	manualClock.Increment(100)
 
-	priority := int32(math.MaxInt32)
+	priority := float64(-math.MaxInt32)
 	requestHeader := roachpb.Span{
 		Key: roachpb.Key(key),
 	}
 	ts := clock.Now()
 	if _, err := client.SendWrappedWith(rg1(store), nil, roachpb.Header{
 		Timestamp:    ts,
-		UserPriority: &priority,
+		UserPriority: priority,
 	}, &roachpb.GetRequest{Span: requestHeader}); err != nil {
 		t.Fatalf("failed to get: %s", err)
 	}
@@ -310,7 +310,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	ts = clock.Now()
 	if _, err := client.SendWrappedWith(rg1(store), nil, roachpb.Header{
 		Timestamp:    ts,
-		UserPriority: &priority,
+		UserPriority: priority,
 	}, &roachpb.GetRequest{Span: requestHeader}); err == nil {
 		t.Fatal("unexpected success of get")
 	}

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -1498,30 +1498,30 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "LeaseResponse\022<\n\014reverse_scan\030\025 \001(\0132&.co"
     "ckroach.roachpb.ReverseScanResponse\022-\n\004n"
     "oop\030\026 \001(\0132\037.cockroach.roachpb.NoopRespon"
-    "se:\004\310\240\037\001\"\277\002\n\006Header\0225\n\ttimestamp\030\001 \001(\0132\034"
+    "se:\004\310\240\037\001\"\274\002\n\006Header\0225\n\ttimestamp\030\001 \001(\0132\034"
     ".cockroach.roachpb.TimestampB\004\310\336\037\000\022;\n\007re"
     "plica\030\002 \001(\0132$.cockroach.roachpb.ReplicaD"
     "escriptorB\004\310\336\037\000\022,\n\010range_id\030\003 \001(\003B\032\310\336\037\000\342"
-    "\336\037\007RangeID\372\336\037\007RangeID\022\030\n\ruser_priority\030\004"
-    " \001(\005:\0011\022+\n\003txn\030\005 \001(\0132\036.cockroach.roachpb"
-    ".Transaction\022F\n\020read_consistency\030\006 \001(\0162&"
-    ".cockroach.roachpb.ReadConsistencyTypeB\004"
-    "\310\336\037\000:\004\210\240\037\001\"\202\001\n\014BatchRequest\0223\n\006header\030\001 "
-    "\001(\0132\031.cockroach.roachpb.HeaderB\010\310\336\037\000\320\336\037\001"
-    "\0227\n\010requests\030\002 \003(\0132\037.cockroach.roachpb.R"
-    "equestUnionB\004\310\336\037\000:\004\230\240\037\000\"\253\002\n\rBatchRespons"
-    "e\022A\n\006header\030\001 \001(\0132\'.cockroach.roachpb.Ba"
-    "tchResponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponse"
-    "s\030\002 \003(\0132 .cockroach.roachpb.ResponseUnio"
-    "nB\004\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cock"
-    "roach.roachpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034"
-    ".cockroach.roachpb.TimestampB\004\310\336\037\000\022+\n\003tx"
-    "n\030\003 \001(\0132\036.cockroach.roachpb.Transaction:"
-    "\004\230\240\037\000*L\n\023ReadConsistencyType\022\016\n\nCONSISTE"
-    "NT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210"
-    "\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\016"
-    "\n\nPUSH_ABORT\020\001\022\016\n\nPUSH_TOUCH\020\002\032\004\210\243\036\000B\tZ\007"
-    "roachpbX\003", 8849);
+    "\336\037\007RangeID\372\336\037\007RangeID\022\033\n\ruser_priority\030\004"
+    " \001(\001B\004\310\336\037\000\022+\n\003txn\030\005 \001(\0132\036.cockroach.roac"
+    "hpb.Transaction\022F\n\020read_consistency\030\006 \001("
+    "\0162&.cockroach.roachpb.ReadConsistencyTyp"
+    "eB\004\310\336\037\000\"\202\001\n\014BatchRequest\0223\n\006header\030\001 \001(\013"
+    "2\031.cockroach.roachpb.HeaderB\010\310\336\037\000\320\336\037\001\0227\n"
+    "\010requests\030\002 \003(\0132\037.cockroach.roachpb.Requ"
+    "estUnionB\004\310\336\037\000:\004\230\240\037\000\"\253\002\n\rBatchResponse\022A"
+    "\n\006header\030\001 \001(\0132\'.cockroach.roachpb.Batch"
+    "Response.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002"
+    " \003(\0132 .cockroach.roachpb.ResponseUnionB\004"
+    "\310\336\037\000\032\225\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockroa"
+    "ch.roachpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034.co"
+    "ckroach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003"
+    " \001(\0132\036.cockroach.roachpb.Transaction:\004\230\240"
+    "\037\000*L\n\023ReadConsistencyType\022\016\n\nCONSISTENT\020"
+    "\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000"
+    "*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\016\n\nP"
+    "USH_ABORT\020\001\022\016\n\nPUSH_TOUCH\020\002\032\004\210\243\036\000B\tZ\007roa"
+    "chpbX\003", 8846);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ResponseHeader::default_instance_ = new ResponseHeader();
@@ -22138,7 +22138,7 @@ void Header::SharedCtor() {
   timestamp_ = NULL;
   replica_ = NULL;
   range_id_ = GOOGLE_LONGLONG(0);
-  user_priority_ = 1;
+  user_priority_ = 0;
   txn_ = NULL;
   read_consistency_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -22183,20 +22183,31 @@ Header* Header::New(::google::protobuf::Arena* arena) const {
 }
 
 void Header::Clear() {
+#define ZR_HELPER_(f) reinterpret_cast<char*>(\
+  &reinterpret_cast<Header*>(16)->f)
+
+#define ZR_(first, last) do {\
+  ::memset(&first, 0,\
+           ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
+} while (0)
+
   if (_has_bits_[0 / 32] & 63u) {
+    ZR_(range_id_, user_priority_);
     if (has_timestamp()) {
       if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
     if (has_replica()) {
       if (replica_ != NULL) replica_->::cockroach::roachpb::ReplicaDescriptor::Clear();
     }
-    range_id_ = GOOGLE_LONGLONG(0);
-    user_priority_ = 1;
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
     }
     read_consistency_ = 0;
   }
+
+#undef ZR_HELPER_
+#undef ZR_
+
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -22249,16 +22260,16 @@ bool Header::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(32)) goto parse_user_priority;
+        if (input->ExpectTag(33)) goto parse_user_priority;
         break;
       }
 
-      // optional int32 user_priority = 4 [default = 1];
+      // optional double user_priority = 4;
       case 4: {
-        if (tag == 32) {
+        if (tag == 33) {
          parse_user_priority:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
                  input, &user_priority_)));
           set_has_user_priority();
         } else {
@@ -22343,9 +22354,9 @@ void Header::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt64(3, this->range_id(), output);
   }
 
-  // optional int32 user_priority = 4 [default = 1];
+  // optional double user_priority = 4;
   if (has_user_priority()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt32(4, this->user_priority(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteDouble(4, this->user_priority(), output);
   }
 
   // optional .cockroach.roachpb.Transaction txn = 5;
@@ -22389,9 +22400,9 @@ void Header::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(3, this->range_id(), target);
   }
 
-  // optional int32 user_priority = 4 [default = 1];
+  // optional double user_priority = 4;
   if (has_user_priority()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(4, this->user_priority(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteDoubleToArray(4, this->user_priority(), target);
   }
 
   // optional .cockroach.roachpb.Transaction txn = 5;
@@ -22440,11 +22451,9 @@ int Header::ByteSize() const {
           this->range_id());
     }
 
-    // optional int32 user_priority = 4 [default = 1];
+    // optional double user_priority = 4;
     if (has_user_priority()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int32Size(
-          this->user_priority());
+      total_size += 1 + 8;
     }
 
     // optional .cockroach.roachpb.Transaction txn = 5;
@@ -22665,7 +22674,7 @@ void Header::clear_range_id() {
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Header.range_id)
 }
 
-// optional int32 user_priority = 4 [default = 1];
+// optional double user_priority = 4;
 bool Header::has_user_priority() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
@@ -22676,14 +22685,14 @@ void Header::clear_has_user_priority() {
   _has_bits_[0] &= ~0x00000008u;
 }
 void Header::clear_user_priority() {
-  user_priority_ = 1;
+  user_priority_ = 0;
   clear_has_user_priority();
 }
- ::google::protobuf::int32 Header::user_priority() const {
+ double Header::user_priority() const {
   // @@protoc_insertion_point(field_get:cockroach.roachpb.Header.user_priority)
   return user_priority_;
 }
- void Header::set_user_priority(::google::protobuf::int32 value) {
+ void Header::set_user_priority(double value) {
   set_has_user_priority();
   user_priority_ = value;
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Header.user_priority)

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -5564,12 +5564,12 @@ class Header : public ::google::protobuf::Message {
   ::google::protobuf::int64 range_id() const;
   void set_range_id(::google::protobuf::int64 value);
 
-  // optional int32 user_priority = 4 [default = 1];
+  // optional double user_priority = 4;
   bool has_user_priority() const;
   void clear_user_priority();
   static const int kUserPriorityFieldNumber = 4;
-  ::google::protobuf::int32 user_priority() const;
-  void set_user_priority(::google::protobuf::int32 value);
+  double user_priority() const;
+  void set_user_priority(double value);
 
   // optional .cockroach.roachpb.Transaction txn = 5;
   bool has_txn() const;
@@ -5608,8 +5608,8 @@ class Header : public ::google::protobuf::Message {
   ::cockroach::roachpb::Timestamp* timestamp_;
   ::cockroach::roachpb::ReplicaDescriptor* replica_;
   ::google::protobuf::int64 range_id_;
+  double user_priority_;
   ::cockroach::roachpb::Transaction* txn_;
-  ::google::protobuf::int32 user_priority_;
   int read_consistency_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
@@ -11506,7 +11506,7 @@ inline void Header::set_range_id(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Header.range_id)
 }
 
-// optional int32 user_priority = 4 [default = 1];
+// optional double user_priority = 4;
 inline bool Header::has_user_priority() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
@@ -11517,14 +11517,14 @@ inline void Header::clear_has_user_priority() {
   _has_bits_[0] &= ~0x00000008u;
 }
 inline void Header::clear_user_priority() {
-  user_priority_ = 1;
+  user_priority_ = 0;
   clear_has_user_priority();
 }
-inline ::google::protobuf::int32 Header::user_priority() const {
+inline double Header::user_priority() const {
   // @@protoc_insertion_point(field_get:cockroach.roachpb.Header.user_priority)
   return user_priority_;
 }
-inline void Header::set_user_priority(::google::protobuf::int32 value) {
+inline void Header::set_user_priority(double value) {
   set_has_user_priority();
   user_priority_ = value;
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Header.user_priority)

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -454,7 +454,7 @@ func pushTxn(repl *Replica, now roachpb.Timestamp, txn *roachpb.Transaction,
 			Key: txn.Key,
 		},
 		Now:       now,
-		PusherTxn: roachpb.Transaction{Priority: roachpb.MaxPriority},
+		PusherTxn: roachpb.Transaction{Priority: roachpb.MaxUserPriority},
 		PusheeTxn: *txn,
 		PushType:  typ,
 	}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -215,7 +215,7 @@ func (tc *testContext) initConfigs(realRange bool) error {
 	return nil
 }
 
-func newTransaction(name string, baseKey roachpb.Key, userPriority int32,
+func newTransaction(name string, baseKey roachpb.Key, userPriority float64,
 	isolation roachpb.IsolationType, clock *hlc.Clock) *roachpb.Transaction {
 	var offset int64
 	var now roachpb.Timestamp
@@ -223,8 +223,7 @@ func newTransaction(name string, baseKey roachpb.Key, userPriority int32,
 		offset = clock.MaxOffset().Nanoseconds()
 		now = clock.Now()
 	}
-	return roachpb.NewTransaction(name, baseKey, userPriority,
-		isolation, now, offset)
+	return roachpb.NewTransaction(name, baseKey, userPriority, isolation, now, offset)
 }
 
 // CreateReplicaSets creates new roachpb.ReplicaDescriptor protos based on an array of
@@ -1104,7 +1103,7 @@ func TestRangeCommandQueue(t *testing.T) {
 	blockingDone := make(chan struct{})
 	defer func() { TestingCommandFilter = nil }()
 	TestingCommandFilter = func(_ roachpb.StoreID, _ roachpb.Request, h roachpb.Header) error {
-		if h.GetUserPriority() == 42 {
+		if h.UserPriority == 42 {
 			blockingStart <- struct{}{}
 			<-blockingDone
 		}
@@ -1140,7 +1139,7 @@ func TestRangeCommandQueue(t *testing.T) {
 			args := readOrWriteArgs(key1, test.cmd1Read)
 
 			_, err := client.SendWrappedWith(tc.Sender(), tc.rng.context(), roachpb.Header{
-				UserPriority: proto.Int32(42),
+				UserPriority: 42,
 			}, args)
 
 			if err != nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -1451,7 +1451,7 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.Writ
 	// txn with only the priority set.
 	if pusherTxn == nil {
 		pusherTxn = &roachpb.Transaction{
-			Priority: roachpb.MakePriority(h.GetUserPriority()),
+			Priority: roachpb.MakePriority(h.UserPriority),
 		}
 	}
 	var pushReqs []roachpb.Request

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1168,7 +1168,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 		gArgs := getArgs(key)
 		if reply, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
 			Timestamp:    getTS,
-			UserPriority: proto.Int32(math.MaxInt32),
+			UserPriority: -math.MaxInt32,
 		}, &gArgs); err != nil {
 			t.Errorf("expected read to succeed: %s", err)
 		} else if gReply := reply.(*roachpb.GetResponse); gReply.Value != nil {
@@ -1182,7 +1182,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 		args.Value.SetBytes([]byte("value2"))
 		if _, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
 			Timestamp:    putTS,
-			UserPriority: proto.Int32(math.MaxInt32),
+			UserPriority: -math.MaxInt32,
 		}, &args); err != nil {
 			t.Errorf("expected success aborting pushee's txn; got %s", err)
 		}
@@ -1258,7 +1258,7 @@ func TestStoreReadInconsistent(t *testing.T) {
 		// Next, write intents for keyA and keyB. Note that the
 		// transactions have unpushable priorities if canPush is true and
 		// very pushable ones otherwise.
-		priority := int32(-roachpb.MaxPriority)
+		priority := float64(-math.MaxInt32)
 		if canPush {
 			priority = -1
 		}
@@ -1396,9 +1396,9 @@ func TestStoreScanIntents(t *testing.T) {
 			key := roachpb.Key(fmt.Sprintf("key%d-%02d", i, j))
 			keys = append(keys, key)
 			if txn == nil {
-				priority := int32(-1)
+				priority := float64(-1)
 				if !test.canPush {
-					priority = -roachpb.MaxPriority
+					priority = -math.MaxInt32
 				}
 				txn = newTransaction(fmt.Sprintf("test-%d", i), key, priority, roachpb.SERIALIZABLE, store.ctx.Clock)
 				bt, btH := beginTxnArgs(txn.Key, txn)


### PR DESCRIPTION
This is more sensical than the previous approach and allows smaller
priorities to be set when you want to, for example, de-prioritize
transactions, such as for batch processing jobs.

Fixes issue #3643.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3659)

<!-- Reviewable:end -->
