### PR TITLE
Delete/unexport TransactionRestartError and IndexedError

### DIFF
--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -78,7 +78,8 @@ func TestChaos(t *testing.T) {
 			for time.Now().Before(deadline) && atomic.LoadInt32(&stalled) == 0 {
 				clients[i].RLock()
 				v := value[:r.Intn(len(value))]
-				if err := clients[i].db.Put(fmt.Sprintf("%08d", k), v); err != nil {
+				if pErr := clients[i].db.Put(fmt.Sprintf("%08d", k), v); pErr != nil {
+					err := pErr.GoError()
 					if _, ok := err.(*roachpb.SendError); ok || testutils.IsError(err, rpc.ErrShutdown.Error()) || testutils.IsError(err, "client is unhealthy") {
 						// Common errors we can ignore. Also suppress the
 						// log messages so they don't get spammy.

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -190,12 +191,12 @@ func TestGossipRestart(t *testing.T) {
 				}
 			}
 			var kv client.KeyValue
-			if err := db.Txn(func(txn *client.Txn) error {
-				var err error
-				kv, err = txn.Inc("count", 1)
-				return err
-			}); err != nil {
-				t.Fatal(err)
+			if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+				var pErr *roachpb.Error
+				kv, pErr = txn.Inc("count", 1)
+				return pErr
+			}); pErr != nil {
+				t.Fatal(pErr)
 			} else if v := kv.ValueInt(); v != int64(i+1) {
 				t.Fatalf("unexpected value %d for write #%d (expected %d)", v, i, i+1)
 			}

--- a/acceptance/put_test.go
+++ b/acceptance/put_test.go
@@ -49,8 +49,8 @@ func TestPut(t *testing.T) {
 			for time.Now().Before(deadline) {
 				k := atomic.AddInt64(&count, 1)
 				v := value[:r.Intn(len(value))]
-				if err := db.Put(fmt.Sprintf("%08d", k), v); err != nil {
-					errs <- err
+				if pErr := db.Put(fmt.Sprintf("%08d", k), v); pErr != nil {
+					errs <- pErr.GoError()
 					return
 				}
 			}

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -33,8 +33,8 @@ import (
 
 func countRangeReplicas(db *client.DB) (int, error) {
 	desc := &roachpb.RangeDescriptor{}
-	if err := db.GetProto(keys.RangeDescriptorKey(roachpb.RKeyMin), desc); err != nil {
-		return 0, err
+	if pErr := db.GetProto(keys.RangeDescriptorKey(roachpb.RKeyMin), desc); pErr != nil {
+		return 0, pErr.GoError()
 	}
 	return len(desc.Replicas), nil
 }

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -150,15 +150,15 @@ func runCPut(cmd *cobra.Command, args []string) {
 
 	key := unquoteArg(args[0], true /* disallow system keys */)
 	value := unquoteArg(args[1], false)
-	var err error
+	var pErr *roachpb.Error
 	if len(args) == 3 {
-		err = kvDB.CPut(key, value, unquoteArg(args[2], false))
+		pErr = kvDB.CPut(key, value, unquoteArg(args[2], false))
 	} else {
-		err = kvDB.CPut(key, value, nil)
+		pErr = kvDB.CPut(key, value, nil)
 	}
 
-	if err != nil {
-		panicf("conditional put failed: %s", err)
+	if pErr != nil {
+		panicf("conditional put failed: %s", pErr)
 	}
 }
 

--- a/client/batch.go
+++ b/client/batch.go
@@ -17,8 +17,6 @@
 package client
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/roachpb"
 )
 
@@ -52,10 +50,10 @@ type Batch struct {
 	rowsIdx    int
 }
 
-func (b *Batch) prepare() error {
+func (b *Batch) prepare() *roachpb.Error {
 	for _, r := range b.Results {
-		if err := r.Err; err != nil {
-			return err
+		if pErr := r.PErr; pErr != nil {
+			return pErr
 		}
 	}
 	return nil
@@ -63,7 +61,7 @@ func (b *Batch) prepare() error {
 
 func (b *Batch) initResult(calls, numRows int, err error) {
 	// TODO(tschottdorf): assert that calls is 0 or 1?
-	r := Result{calls: calls, Err: err}
+	r := Result{calls: calls, PErr: roachpb.NewError(err)}
 	if numRows > 0 {
 		if b.rowsIdx+numRows <= len(b.rowsBuf) {
 			r.Rows = b.rowsBuf[b.rowsIdx : b.rowsIdx+numRows]
@@ -78,7 +76,7 @@ func (b *Batch) initResult(calls, numRows int, err error) {
 	b.Results = append(b.Results, r)
 }
 
-func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) error {
+func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roachpb.Error {
 	offset := 0
 	for i := range b.Results {
 		result := &b.Results[i]
@@ -87,9 +85,9 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) erro
 			args := b.reqs[offset+k]
 
 			var reply roachpb.Response
-			if result.Err == nil {
-				result.Err = pErr.GoError()
-				if result.Err == nil {
+			if result.PErr == nil {
+				result.PErr = pErr
+				if result.PErr == nil {
 					if br != nil && offset+k < len(br.Responses) {
 						reply = br.Responses[offset+k].GetInner()
 					} else if args.Method() != roachpb.EndTransaction {
@@ -106,34 +104,34 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) erro
 			case *roachpb.GetRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.Err == nil {
+				if result.PErr == nil {
 					row.Value = reply.(*roachpb.GetResponse).Value
 				}
 			case *roachpb.PutRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.Err == nil {
+				if result.PErr == nil {
 					row.Value = &req.Value
 					row.setTimestamp(reply.(*roachpb.PutResponse).Timestamp)
 				}
 			case *roachpb.ConditionalPutRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.Err == nil {
+				if result.PErr == nil {
 					row.Value = &req.Value
 					row.setTimestamp(reply.(*roachpb.ConditionalPutResponse).Timestamp)
 				}
 			case *roachpb.IncrementRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.Err == nil {
+				if result.PErr == nil {
 					t := reply.(*roachpb.IncrementResponse)
 					row.Value = &roachpb.Value{}
 					row.Value.SetInt(t.NewValue)
 					row.setTimestamp(t.Timestamp)
 				}
 			case *roachpb.ScanRequest:
-				if result.Err == nil {
+				if result.PErr == nil {
 					t := reply.(*roachpb.ScanResponse)
 					result.Rows = make([]KeyValue, len(t.Rows))
 					for j := range t.Rows {
@@ -144,7 +142,7 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) erro
 					}
 				}
 			case *roachpb.ReverseScanRequest:
-				if result.Err == nil {
+				if result.PErr == nil {
 					t := reply.(*roachpb.ReverseScanResponse)
 					result.Rows = make([]KeyValue, len(t.Rows))
 					for j := range t.Rows {
@@ -176,8 +174,8 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) erro
 				// rows.
 
 			default:
-				if result.Err == nil {
-					result.Err = fmt.Errorf("unsupported reply: %T", reply)
+				if result.PErr == nil {
+					result.PErr = roachpb.NewErrorf("unsupported reply: %T", reply)
 				}
 			}
 		}
@@ -186,8 +184,8 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) erro
 
 	for i := range b.Results {
 		result := &b.Results[i]
-		if result.Err != nil {
-			return result.Err
+		if result.PErr != nil {
+			return result.PErr
 		}
 	}
 	return nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -21,7 +21,6 @@ package client_test
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -37,7 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -157,18 +156,18 @@ func TestClientRetryNonTxn(t *testing.T) {
 		// doneCall signals when the non-txn read or write has completed.
 		doneCall := make(chan struct{})
 		count := 0 // keeps track of retries
-		err := db.Txn(func(txn *client.Txn) error {
+		pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 			if test.isolation == roachpb.SNAPSHOT {
-				if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-					return err
+				if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
+					return pErr
 				}
 			}
 			txn.InternalSetPriority(int32(txnPri))
 
 			count++
 			// Lay down the intent.
-			if err := txn.Put(key, "txn-value"); err != nil {
-				return err
+			if pErr := txn.Put(key, "txn-value"); pErr != nil {
+				return pErr
 			}
 			// The wait group lets us pause txn until after the non-txn method has run once.
 			wg := sync.WaitGroup{}
@@ -181,37 +180,37 @@ func TestClientRetryNonTxn(t *testing.T) {
 				// it might have to retry and will only succeed immediately in
 				// the event we can push.
 				go func() {
-					var err error
+					var pErr *roachpb.Error
 					for i := 0; ; i++ {
 						if _, ok := test.args.(*roachpb.GetRequest); ok {
-							_, err = db.Get(key)
+							_, pErr = db.Get(key)
 						} else {
-							err = db.Put(key, "value")
+							pErr = db.Put(key, "value")
 						}
-						if _, ok := err.(*roachpb.WriteIntentError); !ok {
+						if _, ok := pErr.GoError().(*roachpb.WriteIntentError); !ok {
 							break
 						}
 					}
 					close(doneCall)
-					if err != nil {
-						t.Fatalf("%d: expected success on non-txn call to %s; got %s", i, test.args.Method(), err)
+					if pErr != nil {
+						t.Fatalf("%d: expected success on non-txn call to %s; got %s", i, test.args.Method(), pErr)
 					}
 				}()
 				sender.wait()
 			}
 			return nil
 		})
-		if err != nil {
-			t.Fatalf("%d: expected success writing transactionally; got %s", i, err)
+		if pErr != nil {
+			t.Fatalf("%d: expected success writing transactionally; got %s", i, pErr)
 		}
 
 		// Make sure non-txn put or get has finished.
 		<-doneCall
 
 		// Get the current value to verify whether the txn happened first.
-		gr, err := db.Get(key)
-		if err != nil {
-			t.Fatalf("%d: expected success getting %q: %s", i, key, err)
+		gr, pErr := db.Get(key)
+		if pErr != nil {
+			t.Fatalf("%d: expected success getting %q: %s", i, key, pErr)
 		}
 
 		if _, isGet := test.args.(*roachpb.GetRequest); isGet || test.canPush {
@@ -251,48 +250,48 @@ func TestClientRunTransaction(t *testing.T) {
 		key := []byte(fmt.Sprintf("%s/key-%t", testUser, commit))
 
 		// Use snapshot isolation so non-transactional read can always push.
-		err := db.Txn(func(txn *client.Txn) error {
-			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-				return err
+		pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+			if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
+				return pErr
 			}
 
 			// Put transactional value.
-			if err := txn.Put(key, value); err != nil {
-				return err
+			if pErr := txn.Put(key, value); pErr != nil {
+				return pErr
 			}
 			// Attempt to read outside of txn.
-			if gr, err := db.Get(key); err != nil {
-				return err
+			if gr, pErr := db.Get(key); pErr != nil {
+				return pErr
 			} else if gr.Value != nil {
-				return util.Errorf("expected nil value; got %+v", gr.Value)
+				return roachpb.NewErrorf("expected nil value; got %+v", gr.Value)
 			}
 			// Read within the transaction.
-			if gr, err := txn.Get(key); err != nil {
-				return err
+			if gr, pErr := txn.Get(key); pErr != nil {
+				return pErr
 			} else if gr.Value == nil || !bytes.Equal(gr.ValueBytes(), value) {
-				return util.Errorf("expected value %q; got %q", value, gr.ValueBytes())
+				return roachpb.NewErrorf("expected value %q; got %q", value, gr.ValueBytes())
 			}
 			if !commit {
-				return errors.New("purposefully failing transaction")
+				return roachpb.NewErrorf("purposefully failing transaction")
 			}
 			return nil
 		})
 
-		if commit != (err == nil) {
-			t.Errorf("expected success? %t; got %s", commit, err)
-		} else if !commit && err.Error() != "purposefully failing transaction" {
-			t.Errorf("unexpected failure with !commit: %s", err)
+		if commit != (pErr == nil) {
+			t.Errorf("expected success? %t; got %s", commit, pErr)
+		} else if !commit && !testutils.IsError(pErr.GoError(), "purposefully failing transaction") {
+			t.Errorf("unexpected failure with !commit: %s", pErr)
 		}
 
 		// Verify the value is now visible on commit == true, and not visible otherwise.
-		gr, err := db.Get(key)
+		gr, pErr := db.Get(key)
 		if commit {
-			if err != nil || gr.Value == nil || !bytes.Equal(gr.ValueBytes(), value) {
-				t.Errorf("expected success reading value: %+v, %s", gr.Value, err)
+			if pErr != nil || gr.Value == nil || !bytes.Equal(gr.ValueBytes(), value) {
+				t.Errorf("expected success reading value: %+v, %s", gr.Value, pErr)
 			}
 		} else {
-			if err != nil || gr.Value != nil {
-				t.Errorf("expected success and nil value: %+v, %s", gr.Value, err)
+			if pErr != nil || gr.Value != nil {
+				t.Errorf("expected success and nil value: %+v, %s", gr.Value, pErr)
 			}
 		}
 	}
@@ -316,13 +315,13 @@ func TestClientGetAndPutProto(t *testing.T) {
 	}
 
 	key := roachpb.Key(testUser + "/zone-config")
-	if err := db.Put(key, zoneConfig); err != nil {
-		t.Fatalf("unable to put proto: %s", err)
+	if pErr := db.Put(key, zoneConfig); pErr != nil {
+		t.Fatalf("unable to put proto: %s", pErr)
 	}
 
 	readZoneConfig := &config.ZoneConfig{}
-	if err := db.GetProto(key, readZoneConfig); err != nil {
-		t.Fatalf("unable to get proto: %v", err)
+	if pErr := db.GetProto(key, readZoneConfig); pErr != nil {
+		t.Fatalf("unable to get proto: %v", pErr)
 	}
 	if !proto.Equal(zoneConfig, readZoneConfig) {
 		t.Errorf("expected %+v, but found %+v", zoneConfig, readZoneConfig)
@@ -338,12 +337,12 @@ func TestClientGetAndPut(t *testing.T) {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
 	value := []byte("value")
-	if err := db.Put(testUser+"/key", value); err != nil {
-		t.Fatalf("unable to put value: %s", err)
+	if pErr := db.Put(testUser+"/key", value); pErr != nil {
+		t.Fatalf("unable to put value: %s", pErr)
 	}
-	gr, err := db.Get(testUser + "/key")
-	if err != nil {
-		t.Fatalf("unable to get value: %v", err)
+	gr, pErr := db.Get(testUser + "/key")
+	if pErr != nil {
+		t.Fatalf("unable to get value: %v", pErr)
 	}
 	if gr.Timestamp().IsZero() {
 		t.Error("expected non-zero timestamp")
@@ -364,20 +363,20 @@ func TestClientEmptyValues(t *testing.T) {
 	defer s.Stop()
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
-	if err := db.Put(testUser+"/a", []byte{}); err != nil {
-		t.Error(err)
+	if pErr := db.Put(testUser+"/a", []byte{}); pErr != nil {
+		t.Error(pErr)
 	}
-	if gr, err := db.Get(testUser + "/a"); err != nil {
-		t.Error(err)
+	if gr, pErr := db.Get(testUser + "/a"); pErr != nil {
+		t.Error(pErr)
 	} else if bytes := gr.ValueBytes(); bytes == nil || len(bytes) != 0 {
 		t.Errorf("expected non-nil empty byte slice; got %q", bytes)
 	}
 
-	if _, err := db.Inc(testUser+"/b", 0); err != nil {
-		t.Error(err)
+	if _, pErr := db.Inc(testUser+"/b", 0); pErr != nil {
+		t.Error(pErr)
 	}
-	if gr, err := db.Get(testUser + "/b"); err != nil {
-		t.Error(err)
+	if gr, pErr := db.Get(testUser + "/b"); pErr != nil {
+		t.Error(pErr)
 	} else if gr.Value == nil {
 		t.Errorf("expected non-nil integer")
 	} else if gr.ValueInt() != 0 {
@@ -405,8 +404,8 @@ func TestClientBatch(t *testing.T) {
 			b.Inc(key, int64(i))
 		}
 
-		if err := db.Run(b); err != nil {
-			t.Error(err)
+		if pErr := db.Run(b); pErr != nil {
+			t.Error(pErr)
 		}
 
 		for i, result := range b.Results {
@@ -421,8 +420,8 @@ func TestClientBatch(t *testing.T) {
 		b := &client.Batch{}
 		b.Scan(testUser+"/key 00", testUser+"/key 05", 0)
 		b.Scan(testUser+"/key 05", testUser+"/key 10", 0)
-		if err := db.Run(b); err != nil {
-			t.Error(err)
+		if pErr := db.Run(b); pErr != nil {
+			t.Error(pErr)
 		}
 
 		scan1 := b.Results[0].Rows
@@ -452,8 +451,8 @@ func TestClientBatch(t *testing.T) {
 		b := &client.Batch{}
 		b.ReverseScan(testUser+"/key 00", testUser+"/key 05", 0)
 		b.ReverseScan(testUser+"/key 05", testUser+"/key 10", 0)
-		if err := db.Run(b); err != nil {
-			t.Error(err)
+		if pErr := db.Run(b); pErr != nil {
+			t.Error(pErr)
 		}
 
 		revScan1 := b.Results[0].Rows
@@ -484,18 +483,18 @@ func TestClientBatch(t *testing.T) {
 	// Induce a non-transactional failure.
 	{
 		key := roachpb.Key("conditionalPut")
-		if err := db.Put(key, "hello"); err != nil {
-			t.Fatal(err)
+		if pErr := db.Put(key, "hello"); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		b := &client.Batch{}
 		b.CPut(key, "goodbyte", nil) // should fail
-		if err := db.Run(b); err == nil {
+		if pErr := db.Run(b); pErr == nil {
 			t.Error("unexpected success")
 		} else {
 			var foundError bool
 			for _, result := range b.Results {
-				if result.Err != nil {
+				if result.PErr != nil {
 					foundError = true
 					break
 				}
@@ -509,20 +508,20 @@ func TestClientBatch(t *testing.T) {
 	// Induce a transactional failure.
 	{
 		key := roachpb.Key("conditionalPut")
-		if err := db.Put(key, "hello"); err != nil {
-			t.Fatal(err)
+		if pErr := db.Put(key, "hello"); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		b := &client.Batch{}
 		b.CPut(key, "goodbyte", nil) // should fail
-		if err := db.Txn(func(txn *client.Txn) error {
+		if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 			return txn.Run(b)
-		}); err == nil {
+		}); pErr == nil {
 			t.Error("unexpected success")
 		} else {
 			var foundError bool
 			for _, result := range b.Results {
-				if result.Err != nil {
+				if result.PErr != nil {
 					foundError = true
 					break
 				}
@@ -555,13 +554,13 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 			// Wait until the other goroutines are running.
 			wgStart.Wait()
 
-			if err := db.Txn(func(txn *client.Txn) error {
+			if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 				txn.SetDebugName(fmt.Sprintf("test-%d", i), 0)
 
 				// Retrieve the other key.
-				gr, err := txn.Get(readKey)
-				if err != nil {
-					return err
+				gr, pErr := txn.Get(readKey)
+				if pErr != nil {
+					return pErr
 				}
 
 				otherValue := int64(0)
@@ -569,10 +568,10 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 					otherValue = gr.ValueInt()
 				}
 
-				_, err = txn.Inc(writeKey, 1+otherValue)
-				return err
-			}); err != nil {
-				t.Error(err)
+				_, pErr = txn.Inc(writeKey, 1+otherValue)
+				return pErr
+			}); pErr != nil {
+				t.Error(pErr)
 			}
 		}(i)
 	}
@@ -588,9 +587,9 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 	results := []int64(nil)
 	for i := 0; i < 2; i++ {
 		readKey := []byte(fmt.Sprintf(testUser+"/value-%d", i))
-		gr, err := db.Get(readKey)
-		if err != nil {
-			t.Fatal(err)
+		gr, pErr := db.Get(readKey)
+		if pErr != nil {
+			t.Fatal(pErr)
 		}
 		if gr.Value == nil {
 			t.Fatalf("unexpected empty key: %s=%v", readKey, gr.Value)
@@ -617,8 +616,8 @@ func TestConcurrentIncrements(t *testing.T) {
 	// Convenience loop: Crank up this number for testing this
 	// more often. It'll increase test duration though.
 	for k := 0; k < 5; k++ {
-		if err := db.DelRange(testUser+"/value-0", testUser+"/value-1x"); err != nil {
-			t.Fatalf("%d: unable to clean up: %v", k, err)
+		if pErr := db.DelRange(testUser+"/value-0", testUser+"/value-1x"); pErr != nil {
+			t.Fatalf("%d: unable to clean up: %v", k, pErr)
 		}
 		concurrentIncrements(db, t)
 	}
@@ -658,13 +657,13 @@ func TestClientPermissions(t *testing.T) {
 
 	value := []byte("value")
 	for tcNum, tc := range testCases {
-		err := tc.client.Put(tc.path, value)
-		if err == nil != tc.success {
-			t.Errorf("#%d: expected success=%t, got err=%s", tcNum, tc.success, err)
+		pErr := tc.client.Put(tc.path, value)
+		if pErr == nil != tc.success {
+			t.Errorf("#%d: expected success=%t, got err=%s", tcNum, tc.success, pErr)
 		}
-		_, err = tc.client.Get(tc.path)
-		if err == nil != tc.success {
-			t.Errorf("#%d: expected success=%t, got err=%s", tcNum, tc.success, err)
+		_, pErr = tc.client.Get(tc.path)
+		if pErr == nil != tc.success {
+			t.Errorf("#%d: expected success=%t, got err=%s", tcNum, tc.success, pErr)
 		}
 	}
 }
@@ -723,15 +722,15 @@ func setupClientBenchData(useSSL bool, numVersions, numKeys int, b *testing.B) (
 				batch.Put(roachpb.Key(keys[i]), randutil.RandBytes(rng, valueSize))
 			}
 			if (i+1)%1000 == 0 {
-				if err := db.Run(batch); err != nil {
-					b.Fatal(err)
+				if pErr := db.Run(batch); pErr != nil {
+					b.Fatal(pErr)
 				}
 				batch = &client.Batch{}
 			}
 		}
 		if len(batch.Results) != 0 {
-			if err := db.Run(batch); err != nil {
-				b.Fatal(err)
+			if pErr := db.Run(batch); pErr != nil {
+				b.Fatal(pErr)
 			}
 		}
 	}
@@ -764,9 +763,9 @@ func runClientScan(useSSL bool, numRows, numVersions int, b *testing.B) {
 			keyIdx := rand.Int31n(int32(numKeys - numRows))
 			startKey := roachpb.Key(encoding.EncodeUvarint(startKeyBuf, uint64(keyIdx)))
 			endKey := roachpb.Key(encoding.EncodeUvarint(endKeyBuf, uint64(keyIdx)+uint64(numRows)))
-			rows, err := db.Scan(startKey, endKey, int64(numRows))
-			if err != nil {
-				b.Fatalf("failed scan: %s", err)
+			rows, pErr := db.Scan(startKey, endKey, int64(numRows))
+			if pErr != nil {
+				b.Fatalf("failed scan: %s", pErr)
 			}
 			if len(rows) != numRows {
 				b.Fatalf("failed to scan: %d != %d", len(rows), numRows)

--- a/client/db_internal_test.go
+++ b/client/db_internal_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -33,20 +32,20 @@ func TestClientTxnSequenceNumber(t *testing.T) {
 	db := NewDB(newTestSender(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 		count++
 		if ba.Txn.Sequence <= curSeq {
-			return nil, roachpb.NewError(util.Errorf("sequence number %d did not increase", curSeq))
+			return nil, roachpb.NewErrorf("sequence number %d did not increase", curSeq)
 		}
 		curSeq = ba.Txn.Sequence
 		return ba.CreateReply(), nil
 	}, nil))
-	if err := db.Txn(func(txn *Txn) error {
+	if pErr := db.Txn(func(txn *Txn) *roachpb.Error {
 		for range []int{1, 2, 3} {
-			if err := txn.Put("a", "b"); err != nil {
-				return err
+			if pErr := txn.Put("a", "b"); pErr != nil {
+				return pErr
 			}
 		}
 		return nil
-	}); err != nil {
-		t.Fatal(err)
+	}); pErr != nil {
+		t.Fatal(pErr)
 	}
 	if count != 4 {
 		t.Errorf("expected test sender to be invoked four times; got %d", count)

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/util/caller"
@@ -46,9 +47,9 @@ func ExampleDB_Get() {
 	s, db := setup()
 	defer s.Stop()
 
-	result, err := db.Get("aa")
-	if err != nil {
-		panic(err)
+	result, pErr := db.Get("aa")
+	if pErr != nil {
+		panic(pErr)
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
@@ -60,12 +61,12 @@ func ExampleDB_Put() {
 	s, db := setup()
 	defer s.Stop()
 
-	if err := db.Put("aa", "1"); err != nil {
-		panic(err)
+	if pErr := db.Put("aa", "1"); pErr != nil {
+		panic(pErr)
 	}
-	result, err := db.Get("aa")
-	if err != nil {
-		panic(err)
+	result, pErr := db.Get("aa")
+	if pErr != nil {
+		panic(pErr)
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
@@ -77,41 +78,41 @@ func ExampleDB_CPut() {
 	s, db := setup()
 	defer s.Stop()
 
-	if err := db.Put("aa", "1"); err != nil {
-		panic(err)
+	if pErr := db.Put("aa", "1"); pErr != nil {
+		panic(pErr)
 	}
-	if err := db.CPut("aa", "2", "1"); err != nil {
-		panic(err)
+	if pErr := db.CPut("aa", "2", "1"); pErr != nil {
+		panic(pErr)
 	}
-	result, err := db.Get("aa")
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("aa=%s\n", result.ValueBytes())
-
-	if err = db.CPut("aa", "3", "1"); err == nil {
-		panic("expected error from conditional put")
-	}
-	result, err = db.Get("aa")
-	if err != nil {
-		panic(err)
+	result, pErr := db.Get("aa")
+	if pErr != nil {
+		panic(pErr)
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
-	if err = db.CPut("bb", "4", "1"); err == nil {
+	if pErr = db.CPut("aa", "3", "1"); pErr == nil {
+		panic("expected pError from conditional put")
+	}
+	result, pErr = db.Get("aa")
+	if pErr != nil {
+		panic(pErr)
+	}
+	fmt.Printf("aa=%s\n", result.ValueBytes())
+
+	if pErr = db.CPut("bb", "4", "1"); pErr == nil {
 		panic("expected error from conditional put")
 	}
-	result, err = db.Get("bb")
-	if err != nil {
-		panic(err)
+	result, pErr = db.Get("bb")
+	if pErr != nil {
+		panic(pErr)
 	}
 	fmt.Printf("bb=%s\n", result.ValueBytes())
-	if err = db.CPut("bb", "4", nil); err != nil {
-		panic(err)
+	if pErr = db.CPut("bb", "4", nil); pErr != nil {
+		panic(pErr)
 	}
-	result, err = db.Get("bb")
-	if err != nil {
-		panic(err)
+	result, pErr = db.Get("bb")
+	if pErr != nil {
+		panic(pErr)
 	}
 	fmt.Printf("bb=%s\n", result.ValueBytes())
 
@@ -126,12 +127,12 @@ func ExampleDB_Inc() {
 	s, db := setup()
 	defer s.Stop()
 
-	if _, err := db.Inc("aa", 100); err != nil {
-		panic(err)
+	if _, pErr := db.Inc("aa", 100); pErr != nil {
+		panic(pErr)
 	}
-	result, err := db.Get("aa")
-	if err != nil {
-		panic(err)
+	result, pErr := db.Get("aa")
+	if pErr != nil {
+		panic(pErr)
 	}
 	fmt.Printf("aa=%d\n", result.ValueInt())
 
@@ -146,8 +147,8 @@ func ExampleBatch() {
 	b := &client.Batch{}
 	b.Get("aa")
 	b.Put("bb", "2")
-	if err := db.Run(b); err != nil {
-		panic(err)
+	if pErr := db.Run(b); pErr != nil {
+		panic(pErr)
 	}
 	for _, result := range b.Results {
 		for _, row := range result.Rows {
@@ -168,12 +169,12 @@ func ExampleDB_Scan() {
 	b.Put("aa", "1")
 	b.Put("ab", "2")
 	b.Put("bb", "3")
-	if err := db.Run(b); err != nil {
-		panic(err)
+	if pErr := db.Run(b); pErr != nil {
+		panic(pErr)
 	}
-	rows, err := db.Scan("a", "b", 100)
-	if err != nil {
-		panic(err)
+	rows, pErr := db.Scan("a", "b", 100)
+	if pErr != nil {
+		panic(pErr)
 	}
 	for i, row := range rows {
 		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())
@@ -192,12 +193,12 @@ func ExampleDB_ReverseScan() {
 	b.Put("aa", "1")
 	b.Put("ab", "2")
 	b.Put("bb", "3")
-	if err := db.Run(b); err != nil {
-		panic(err)
+	if pErr := db.Run(b); pErr != nil {
+		panic(pErr)
 	}
-	rows, err := db.ReverseScan("ab", "c", 100)
-	if err != nil {
-		panic(err)
+	rows, pErr := db.ReverseScan("ab", "c", 100)
+	if pErr != nil {
+		panic(pErr)
 	}
 	for i, row := range rows {
 		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())
@@ -216,15 +217,15 @@ func ExampleDB_Del() {
 	b.Put("aa", "1")
 	b.Put("ab", "2")
 	b.Put("ac", "3")
-	if err := db.Run(b); err != nil {
-		panic(err)
+	if pErr := db.Run(b); pErr != nil {
+		panic(pErr)
 	}
-	if err := db.Del("ab"); err != nil {
-		panic(err)
+	if pErr := db.Del("ab"); pErr != nil {
+		panic(pErr)
 	}
-	rows, err := db.Scan("a", "b", 100)
-	if err != nil {
-		panic(err)
+	rows, pErr := db.Scan("a", "b", 100)
+	if pErr != nil {
+		panic(pErr)
 	}
 	for i, row := range rows {
 		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())
@@ -239,21 +240,21 @@ func ExampleTxn_Commit() {
 	s, db := setup()
 	defer s.Stop()
 
-	err := db.Txn(func(txn *client.Txn) error {
+	pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		b := txn.NewBatch()
 		b.Put("aa", "1")
 		b.Put("ab", "2")
 		return txn.CommitInBatch(b)
 	})
-	if err != nil {
-		panic(err)
+	if pErr != nil {
+		panic(pErr)
 	}
 
 	b := &client.Batch{}
 	b.Get("aa")
 	b.Get("ab")
-	if err := db.Run(b); err != nil {
-		panic(err)
+	if pErr := db.Run(b); pErr != nil {
+		panic(pErr)
 	}
 	for i, result := range b.Results {
 		for j, row := range result.Rows {
@@ -270,8 +271,8 @@ func ExampleDB_Put_insecure() {
 	s := &server.TestServer{}
 	s.Ctx = server.NewTestContext()
 	s.Ctx.Insecure = true
-	if err := s.Start(); err != nil {
-		log.Fatalf("Could not start server: %v", err)
+	if pErr := s.Start(); pErr != nil {
+		log.Fatalf("Could not start server: %v", pErr)
 	}
 	defer s.Stop()
 
@@ -280,12 +281,12 @@ func ExampleDB_Put_insecure() {
 		log.Fatal(err)
 	}
 
-	if err := db.Put("aa", "1"); err != nil {
-		panic(err)
+	if pErr := db.Put("aa", "1"); pErr != nil {
+		panic(pErr)
 	}
-	result, err := db.Get("aa")
-	if err != nil {
-		panic(err)
+	result, pErr := db.Get("aa")
+	if pErr != nil {
+		panic(pErr)
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
@@ -324,7 +325,7 @@ func TestDebugName(t *testing.T) {
 	defer s.Stop()
 
 	file, _, _ := caller.Lookup(0)
-	_ = db.Txn(func(txn *client.Txn) error {
+	_ = db.Txn(func(txn *client.Txn) *roachpb.Error {
 		if !strings.HasPrefix(txn.DebugName(), file+":") {
 			t.Fatalf("expected \"%s\" to have the prefix \"%s:\"", txn.DebugName(), file)
 		}

--- a/client/rpc_sender.go
+++ b/client/rpc_sender.go
@@ -17,7 +17,6 @@
 package client
 
 import (
-	"fmt"
 	"net"
 	"net/url"
 
@@ -81,8 +80,7 @@ func newRPCSender(server string, context *base.Context, stopper *stop.Stopper) (
 // the same client command ID and be given the cached response.
 func (s *rpcSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 	if !s.client.WaitHealthy() {
-		return nil, roachpb.NewError(
-			fmt.Errorf("failed to send RPC request %s: client is unhealthy", method))
+		return nil, roachpb.NewErrorf("failed to send RPC request %s: client is unhealthy", method)
 	}
 
 	br := &roachpb.BatchResponse{}

--- a/client/sender.go
+++ b/client/sender.go
@@ -80,7 +80,7 @@ func newSender(u *url.URL, ctx *base.Context, stopper *stop.Stopper) (Sender, er
 // and sends it via the provided Sender at the given timestamp. It returns the
 // unwrapped response or an error. It's valid to pass a `nil` context;
 // context.Background() is used in that case.
-func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.Header, args roachpb.Request) (roachpb.Response, error) {
+func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.Header, args roachpb.Request) (roachpb.Response, *roachpb.Error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -89,8 +89,8 @@ func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.Header, args 
 	ba.Add(args)
 
 	br, pErr := sender.Send(ctx, ba)
-	if err := pErr.GoError(); err != nil {
-		return nil, err
+	if pErr != nil {
+		return nil, pErr
 	}
 	unwrappedReply := br.Responses[0].GetInner()
 	unwrappedReply.Header().Txn = br.Txn
@@ -98,7 +98,7 @@ func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.Header, args 
 }
 
 // SendWrapped is identical to SendWrappedAt with a zero header.
-func SendWrapped(sender Sender, ctx context.Context, args roachpb.Request) (roachpb.Response, error) {
+func SendWrapped(sender Sender, ctx context.Context, args roachpb.Request) (roachpb.Response, *roachpb.Error) {
 	return SendWrappedWith(sender, ctx, roachpb.Header{}, args)
 }
 

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -57,42 +57,42 @@ func TestKVDBCoverage(t *testing.T) {
 	value3 := []byte("value3")
 
 	// Put first value at key.
-	if err := db.Put(key, value1); err != nil {
-		t.Fatal(err)
+	if pErr := db.Put(key, value1); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Verify put.
-	if gr, err := db.Get(key); err != nil {
-		t.Fatal(err)
+	if gr, pErr := db.Get(key); pErr != nil {
+		t.Fatal(pErr)
 	} else if !gr.Exists() {
 		t.Error("expected key to exist")
 	}
 
 	// Conditional put should succeed, changing value1 to value2.
-	if err := db.CPut(key, value2, value1); err != nil {
-		t.Fatal(err)
+	if pErr := db.CPut(key, value2, value1); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Verify get by looking up conditional put value.
-	if gr, err := db.Get(key); err != nil {
-		t.Fatal(err)
+	if gr, pErr := db.Get(key); pErr != nil {
+		t.Fatal(pErr)
 	} else if !bytes.Equal(gr.ValueBytes(), value2) {
 		t.Errorf("expected get to return %q; got %q", value2, gr.ValueBytes())
 	}
 
 	// Increment.
-	if ir, err := db.Inc("i", 10); err != nil {
-		t.Fatal(err)
+	if ir, pErr := db.Inc("i", 10); pErr != nil {
+		t.Fatal(pErr)
 	} else if ir.ValueInt() != 10 {
 		t.Errorf("expected increment new value of %d; got %d", 10, ir.ValueInt())
 	}
 
 	// Delete conditional put value.
-	if err := db.Del(key); err != nil {
-		t.Fatal(err)
+	if pErr := db.Del(key); pErr != nil {
+		t.Fatal(pErr)
 	}
-	if gr, err := db.Get(key); err != nil {
-		t.Fatal(err)
+	if gr, pErr := db.Get(key); pErr != nil {
+		t.Fatal(pErr)
 	} else if gr.Exists() {
 		t.Error("expected key to not exist after delete")
 	}
@@ -104,23 +104,23 @@ func TestKVDBCoverage(t *testing.T) {
 		{Key: roachpb.Key("c"), Value: roachpb.MakeValueFromBytes(value3)},
 	}
 	for _, kv := range keyValues {
-		valueBytes, err := kv.Value.GetBytes()
-		if err != nil {
-			t.Fatal(err)
+		valueBytes, pErr := kv.Value.GetBytes()
+		if pErr != nil {
+			t.Fatal(pErr)
 		}
-		if err := db.Put(kv.Key, valueBytes); err != nil {
-			t.Fatal(err)
+		if pErr := db.Put(kv.Key, valueBytes); pErr != nil {
+			t.Fatal(pErr)
 		}
 	}
-	if rows, err := db.Scan("a", "d", 0); err != nil {
-		t.Fatal(err)
+	if rows, pErr := db.Scan("a", "d", 0); pErr != nil {
+		t.Fatal(pErr)
 	} else if len(rows) != len(keyValues) {
 		t.Fatalf("expected %d rows in scan; got %d", len(keyValues), len(rows))
 	} else {
 		for i, kv := range keyValues {
-			valueBytes, err := kv.Value.GetBytes()
-			if err != nil {
-				t.Fatal(err)
+			valueBytes, pErr := kv.Value.GetBytes()
+			if pErr != nil {
+				t.Fatal(pErr)
 			}
 			if !bytes.Equal(rows[i].ValueBytes(), valueBytes) {
 				t.Errorf("%d: key %q, values %q != %q", i, kv.Key, rows[i].ValueBytes(), valueBytes)
@@ -129,15 +129,15 @@ func TestKVDBCoverage(t *testing.T) {
 	}
 
 	// Test reverse scan.
-	if rows, err := db.ReverseScan("a", "d", 0); err != nil {
-		t.Fatal(err)
+	if rows, pErr := db.ReverseScan("a", "d", 0); pErr != nil {
+		t.Fatal(pErr)
 	} else if len(rows) != len(keyValues) {
 		t.Fatalf("expected %d rows in scan; got %d", len(keyValues), len(rows))
 	} else {
 		for i, kv := range keyValues {
-			valueBytes, err := kv.Value.GetBytes()
-			if err != nil {
-				t.Fatal(err)
+			valueBytes, pErr := kv.Value.GetBytes()
+			if pErr != nil {
+				t.Fatal(pErr)
 			}
 			if !bytes.Equal(rows[len(keyValues)-1-i].ValueBytes(), valueBytes) {
 				t.Errorf("%d: key %q, values %q != %q", i, kv.Key, rows[len(keyValues)-i].ValueBytes(), valueBytes)
@@ -145,8 +145,8 @@ func TestKVDBCoverage(t *testing.T) {
 		}
 	}
 
-	if err := db.DelRange("a", "c"); err != nil {
-		t.Fatal(err)
+	if pErr := db.DelRange("a", "c"); pErr != nil {
+		t.Fatal(pErr)
 	}
 }
 
@@ -179,11 +179,11 @@ func TestKVDBInternalMethods(t *testing.T) {
 		}
 		b := &client.Batch{}
 		b.InternalAddRequest(args)
-		err := db.Run(b)
-		if err == nil {
+		pErr := db.Run(b)
+		if pErr == nil {
 			t.Errorf("%d: unexpected success calling %s", i, args.Method())
-		} else if !testutils.IsError(err, "contains an internal request|contains commit trigger") {
-			t.Errorf("%d: unexpected error for %s: %s", i, args.Method(), err)
+		} else if !testutils.IsError(pErr.GoError(), "contains an internal request|contains commit trigger") {
+			t.Errorf("%d: unexpected error for %s: %s", i, args.Method(), pErr)
 		}
 	}
 }
@@ -199,38 +199,38 @@ func TestKVDBTransaction(t *testing.T) {
 
 	key := roachpb.Key("db-txn-test")
 	value := []byte("value")
-	err := db.Txn(func(txn *client.Txn) error {
+	pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		// Use snapshot isolation so non-transactional read can always push.
-		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-			return err
+		if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
+			return pErr
 		}
 
-		if err := txn.Put(key, value); err != nil {
-			t.Fatal(err)
+		if pErr := txn.Put(key, value); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		// Attempt to read outside of txn.
-		if gr, err := db.Get(key); err != nil {
-			t.Fatal(err)
+		if gr, pErr := db.Get(key); pErr != nil {
+			t.Fatal(pErr)
 		} else if gr.Exists() {
 			t.Errorf("expected nil value; got %+v", gr.Value)
 		}
 
 		// Read within the transaction.
-		if gr, err := txn.Get(key); err != nil {
-			t.Fatal(err)
+		if gr, pErr := txn.Get(key); pErr != nil {
+			t.Fatal(pErr)
 		} else if !gr.Exists() || !bytes.Equal(gr.ValueBytes(), value) {
 			t.Errorf("expected value %q; got %q", value, gr.ValueBytes())
 		}
 		return nil
 	})
-	if err != nil {
-		t.Errorf("expected success on commit; got %s", err)
+	if pErr != nil {
+		t.Errorf("expected success on commit; got %s", pErr)
 	}
 
 	// Verify the value is now visible after commit.
-	if gr, err := db.Get(key); err != nil {
-		t.Errorf("expected success reading value; got %s", err)
+	if gr, pErr := db.Get(key); pErr != nil {
+		t.Errorf("expected success reading value; got %s", pErr)
 	} else if !gr.Exists() || !bytes.Equal(gr.ValueBytes(), value) {
 		t.Errorf("expected value %q; got %q", value, gr.ValueBytes())
 	}
@@ -250,14 +250,14 @@ func TestAuthentication(t *testing.T) {
 	// Create a "node" client and call Run() on it which lets us build
 	// our own request, specifying the user.
 	db1 := createTestClientForUser(t, s.Stopper(), s.ServingAddr(), security.NodeUser)
-	if err := db1.Run(b); err != nil {
-		t.Fatal(err)
+	if pErr := db1.Run(b); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Try again, but this time with certs for a non-node user (even the root
 	// user has no KV permissions).
 	db2 := createTestClientForUser(t, s.Stopper(), s.ServingAddr(), security.RootUser)
-	if err := db2.Run(b); err == nil {
+	if pErr := db2.Run(b); pErr == nil {
 		t.Fatal("Expected error!")
 	}
 }

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -142,13 +142,13 @@ func TestMultiRangeEmptyAfterTruncate(t *testing.T) {
 
 	// Delete the keys within a transaction. The range [c,d) doesn't have
 	// any active requests.
-	if err := db.Txn(func(txn *client.Txn) error {
+	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		b := txn.NewBatch()
 		b.DelRange("a", "b")
 		b.DelRange("e", "f")
 		return txn.CommitInBatch(b)
-	}); err != nil {
-		t.Fatalf("unexpected error on transactional DeleteRange: %s", err)
+	}); pErr != nil {
+		t.Fatalf("unexpected error on transactional DeleteRange: %s", pErr)
 	}
 }
 
@@ -162,44 +162,44 @@ func TestMultiRangeScanReverseScanDeleteResolve(t *testing.T) {
 
 	// Write keys before, at, and after the split key.
 	for _, key := range []string{"a", "b", "c"} {
-		if err := db.Put(key, "value"); err != nil {
-			t.Fatal(err)
+		if pErr := db.Put(key, "value"); pErr != nil {
+			t.Fatal(pErr)
 		}
 	}
 	// Scan to retrieve the keys just written.
-	if rows, err := db.Scan("a", "q", 0); err != nil {
-		t.Fatalf("unexpected error on Scan: %s", err)
+	if rows, pErr := db.Scan("a", "q", 0); pErr != nil {
+		t.Fatalf("unexpected pError on Scan: %s", pErr)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
 	}
 
 	// Scan in reverse order to retrieve the keys just written.
-	if rows, err := db.ReverseScan("a", "q", 0); err != nil {
-		t.Fatalf("unexpected error on ReverseScan: %s", err)
+	if rows, pErr := db.ReverseScan("a", "q", 0); pErr != nil {
+		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
 	}
 
 	// Delete the keys within a transaction. Implicitly, the intents are
 	// resolved via ResolveIntentRange upon completion.
-	if err := db.Txn(func(txn *client.Txn) error {
+	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		b := txn.NewBatch()
 		b.DelRange("a", "d")
 		return txn.CommitInBatch(b)
-	}); err != nil {
-		t.Fatalf("unexpected error on transactional DeleteRange: %s", err)
+	}); pErr != nil {
+		t.Fatalf("unexpected error on transactional DeleteRange: %s", pErr)
 	}
 
 	// Scan consistently to make sure the intents are gone.
-	if rows, err := db.Scan("a", "q", 0); err != nil {
-		t.Fatalf("unexpected error on Scan: %s", err)
+	if rows, pErr := db.Scan("a", "q", 0); pErr != nil {
+		t.Fatalf("unexpected error on Scan: %s", pErr)
 	} else if l := len(rows); l != 0 {
 		t.Errorf("expected 0 rows; got %d", l)
 	}
 
 	// ReverseScan consistently to make sure the intents are gone.
-	if rows, err := db.ReverseScan("a", "q", 0); err != nil {
-		t.Fatalf("unexpected error on ReverseScan: %s", err)
+	if rows, pErr := db.ReverseScan("a", "q", 0); pErr != nil {
+		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 0 {
 		t.Errorf("expected 0 rows; got %d", l)
 	}
@@ -222,8 +222,8 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	for i, key := range keys {
 		b := &client.Batch{}
 		b.Put(key, "value")
-		if err := db.Run(b); err != nil {
-			t.Fatal(err)
+		if pErr := db.Run(b); pErr != nil {
+			t.Fatal(pErr)
 		}
 		ts[i] = b.Results[0].Rows[0].Timestamp()
 		log.Infof("%d: %d.%d", i, ts[i].Unix(), ts[i].Nanosecond())
@@ -251,11 +251,11 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 
 	// Scan.
 	sa := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("c"), 0).(*roachpb.ScanRequest)
-	reply, err := client.SendWrappedWith(ds, nil, roachpb.Header{
+	reply, pErr := client.SendWrappedWith(ds, nil, roachpb.Header{
 		ReadConsistency: roachpb.INCONSISTENT,
 	}, sa)
-	if err != nil {
-		t.Fatal(err)
+	if pErr != nil {
+		t.Fatal(pErr)
 	}
 	sr := reply.(*roachpb.ScanResponse)
 
@@ -268,11 +268,11 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 
 	// ReverseScan.
 	rsa := roachpb.NewReverseScan(roachpb.Key("a"), roachpb.Key("c"), 0).(*roachpb.ReverseScanRequest)
-	reply, err = client.SendWrappedWith(ds, nil, roachpb.Header{
+	reply, pErr = client.SendWrappedWith(ds, nil, roachpb.Header{
 		ReadConsistency: roachpb.INCONSISTENT,
 	}, rsa)
-	if err != nil {
-		t.Fatal(err)
+	if pErr != nil {
+		t.Fatal(pErr)
 	}
 	rsr := reply.(*roachpb.ReverseScanResponse)
 	if l := len(rsr.Rows); l != 1 {
@@ -290,14 +290,14 @@ func initReverseScanTestEnv(s *server.TestServer, t *testing.T) *client.DB {
 	// ["", "b"),["b", "e") ,["e", "g") and ["g", "\xff\xff").
 	for _, key := range []string{"b", "e", "g"} {
 		// Split the keyspace at the given key.
-		if err := db.AdminSplit(key); err != nil {
-			t.Fatal(err)
+		if pErr := db.AdminSplit(key); pErr != nil {
+			t.Fatal(pErr)
 		}
 	}
 	// Write keys before, at, and after the split key.
 	for _, key := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
-		if err := db.Put(key, "value"); err != nil {
-			t.Fatal(err)
+		if pErr := db.Put(key, "value"); pErr != nil {
+			t.Fatal(pErr)
 		}
 	}
 	return db
@@ -312,22 +312,22 @@ func TestSingleRangeReverseScan(t *testing.T) {
 	db := initReverseScanTestEnv(s, t)
 
 	// Case 1: Request.EndKey is in the middle of the range.
-	if rows, err := db.ReverseScan("b", "d", 0); err != nil {
-		t.Fatalf("unexpected error on ReverseScan: %s", err)
+	if rows, pErr := db.ReverseScan("b", "d", 0); pErr != nil {
+		t.Fatalf("unexpected pError on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 2 {
 		t.Errorf("expected 2 rows; got %d", l)
 	}
 	// Case 2: Request.EndKey is equal to the EndKey of the range.
-	if rows, err := db.ReverseScan("e", "g", 0); err != nil {
-		t.Fatalf("unexpected error on ReverseScan: %s", err)
+	if rows, pErr := db.ReverseScan("e", "g", 0); pErr != nil {
+		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 2 {
 		t.Errorf("expected 2 rows; got %d", l)
 	}
 	// Case 3: Test roachpb.KeyMax
 	// This span covers the system DB keys.
 	wanted := 1 + len(server.GetBootstrapSchema().GetInitialValues())
-	if rows, err := db.ReverseScan("g", roachpb.KeyMax, 0); err != nil {
-		t.Fatalf("unexpected error on ReverseScan: %s", err)
+	if rows, pErr := db.ReverseScan("g", roachpb.KeyMax, 0); pErr != nil {
+		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != wanted {
 		t.Errorf("expected %d rows; got %d", wanted, l)
 	}
@@ -335,8 +335,8 @@ func TestSingleRangeReverseScan(t *testing.T) {
 	// This span covers the system DB keys. Note sql.GetInitialSystemValues
 	// returns one key before keys.SystemMax, but our scan is including one key
 	// (\xffa) created for the test.
-	if rows, err := db.ReverseScan(keys.SystemMax, "b", 0); err != nil {
-		t.Fatalf("unexpected error on ReverseScan: %s", err)
+	if rows, pErr := db.ReverseScan(keys.SystemMax, "b", 0); pErr != nil {
+		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 1 {
 		t.Errorf("expected 1 row; got %d", l)
 	}
@@ -351,14 +351,14 @@ func TestMultiRangeReverseScan(t *testing.T) {
 	db := initReverseScanTestEnv(s, t)
 
 	// Case 1: Request.EndKey is in the middle of the range.
-	if rows, err := db.ReverseScan("a", "d", 0); err != nil {
-		t.Fatalf("unexpected error on ReverseScan: %s", err)
+	if rows, pErr := db.ReverseScan("a", "d", 0); pErr != nil {
+		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
 	}
 	// Case 2: Request.EndKey is equal to the EndKey of the range.
-	if rows, err := db.ReverseScan("d", "g", 0); err != nil {
-		t.Fatalf("unexpected error on ReverseScan: %s", err)
+	if rows, pErr := db.ReverseScan("d", "g", 0); pErr != nil {
+		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
 	}
@@ -374,24 +374,24 @@ func TestReverseScanWithSplitAndMerge(t *testing.T) {
 
 	// Case 1: An encounter with a range split.
 	// Split the range ["b", "e") at "c".
-	if err := db.AdminSplit("c"); err != nil {
-		t.Fatal(err)
+	if pErr := db.AdminSplit("c"); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// The ReverseScan will run into a stale descriptor.
-	if rows, err := db.ReverseScan("a", "d", 0); err != nil {
-		t.Fatalf("unexpected error on ReverseScan: %s", err)
+	if rows, pErr := db.ReverseScan("a", "d", 0); pErr != nil {
+		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
 	}
 
 	// Case 2: encounter with range merge .
 	// Merge the range ["e", "g") and ["g", "\xff\xff") .
-	if err := db.AdminMerge("e"); err != nil {
-		t.Fatal(err)
+	if pErr := db.AdminMerge("e"); pErr != nil {
+		t.Fatal(pErr)
 	}
-	if rows, err := db.ReverseScan("d", "g", 0); err != nil {
-		t.Fatalf("unexpected error on ReverseScan: %s", err)
+	if rows, pErr := db.ReverseScan("d", "g", 0); pErr != nil {
+		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != 3 {
 		t.Errorf("expected 3 rows; got %d", l)
 	}
@@ -404,24 +404,24 @@ func TestBadRequest(t *testing.T) {
 	defer s.Stop()
 
 	// Write key "a".
-	if err := db.Put("a", "value"); err != nil {
-		t.Fatal(err)
+	if pErr := db.Put("a", "value"); pErr != nil {
+		t.Fatal(pErr)
 	}
 
-	if _, err := db.Scan("a", "a", 0); !testutils.IsError(err, "truncation resulted in empty batch") {
-		t.Fatalf("unexpected error on scan with startkey == endkey: %v", err)
+	if _, pErr := db.Scan("a", "a", 0); !testutils.IsError(pErr.GoError(), "truncation resulted in empty batch") {
+		t.Fatalf("unexpected error on scan with startkey == endkey: %v", pErr)
 	}
 
-	if _, err := db.ReverseScan("a", "a", 0); !testutils.IsError(err, "truncation resulted in empty batch") {
-		t.Fatalf("unexpected error on reverse scan with startkey == endkey: %v", err)
+	if _, pErr := db.ReverseScan("a", "a", 0); !testutils.IsError(pErr.GoError(), "truncation resulted in empty batch") {
+		t.Fatalf("unexpected pError on reverse scan with startkey == endkey: %v", pErr)
 	}
 
-	if err := db.DelRange("x", "a"); !testutils.IsError(err, "truncation resulted in empty batch") {
-		t.Fatalf("unexpected error on deletion on [x, a): %v", err)
+	if pErr := db.DelRange("x", "a"); !testutils.IsError(pErr.GoError(), "truncation resulted in empty batch") {
+		t.Fatalf("unexpected error on deletion on [x, a): %v", pErr)
 	}
 
-	if err := db.DelRange("", "z"); !testutils.IsError(err, "must be greater than LocalMax") {
-		t.Fatalf("unexpected error on deletion on [KeyMin, z): %v", err)
+	if pErr := db.DelRange("", "z"); !testutils.IsError(pErr.GoError(), "must be greater than LocalMax") {
+		t.Fatalf("unexpected error on deletion on [KeyMin, z): %v", pErr)
 	}
 }
 
@@ -447,15 +447,15 @@ func TestNoSequenceCachePutOnRangeMismatchError(t *testing.T) {
 	//    same replica.
 	// 5) The command succeeds since the sequence cache has not yet been updated.
 	epoch := 0
-	if err := db.Txn(func(txn *client.Txn) error {
+	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		epoch++
 		b := txn.NewBatch()
 		b.Put("a", "val")
 		b.Put("b", "val")
 		b.Put("c", "val")
 		return txn.CommitInBatch(b)
-	}); err != nil {
-		t.Errorf("unexpected error on transactional Puts: %s", err)
+	}); pErr != nil {
+		t.Errorf("unexpected error on transactional Puts: %s", pErr)
 	}
 
 	if epoch != 1 {
@@ -495,8 +495,8 @@ func TestPropagateTxnOnError(t *testing.T) {
 
 	// Set the initial value on the target key "b".
 	origVal := "val"
-	if err := db.Put(targetKey, origVal); err != nil {
-		t.Fatal(err)
+	if pErr := db.Put(targetKey, origVal); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// The following txn creates a batch request that is split
@@ -504,7 +504,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 	// get a ReadWithinUncertaintyIntervalError and the txn will be
 	// retried.
 	epoch := 0
-	if err := db.Txn(func(txn *client.Txn) error {
+	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		epoch++
 		if epoch >= 2 {
 			// Writing must be true since we ran the BeginTransaction command.
@@ -521,19 +521,19 @@ func TestPropagateTxnOnError(t *testing.T) {
 		b := txn.NewBatch()
 		b.Put("a", "val")
 		b.CPut(targetKey, "new_val", origVal)
-		err := txn.CommitInBatch(b)
+		pErr := txn.CommitInBatch(b)
 		if epoch == 1 {
-			if tErr, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); ok {
+			if tErr, ok := pErr.GoError().(*roachpb.ReadWithinUncertaintyIntervalError); ok {
 				if !tErr.Txn.Writing {
 					t.Errorf("unexpected non-writing txn on error")
 				}
 			} else {
-				t.Errorf("expected ReadWithinUncertaintyIntervalError, but got: %s", err)
+				t.Errorf("expected ReadWithinUncertaintyIntervalError, but got: %s", pErr)
 			}
 		}
-		return err
-	}); err != nil {
-		t.Errorf("unexpected error on transactional Puts: %s", err)
+		return pErr
+	}); pErr != nil {
+		t.Errorf("unexpected error on transactional Puts: %s", pErr)
 	}
 
 	if epoch != 2 {
@@ -556,17 +556,17 @@ func TestPropagateTxnOnPushError(t *testing.T) {
 	// Create a goroutine that creates a write intent and waits until
 	// another txn created in this test is restarted.
 	go func() {
-		if err := db.Txn(func(txn *client.Txn) error {
-			if err := txn.Put("b", "val"); err != nil {
-				return err
+		if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+			if pErr := txn.Put("b", "val"); pErr != nil {
+				return pErr
 			}
 			close(waitForWriteIntent)
 			// Wait until another txn in this test is
 			// restarted by a push txn error.
 			<-waitForTxnRestart
 			return txn.CommitInBatch(txn.NewBatch())
-		}); err != nil {
-			t.Errorf("unexpected error on transactional Puts: %s", err)
+		}); pErr != nil {
+			t.Errorf("unexpected error on transactional Puts: %s", pErr)
 		}
 		close(waitForTxnCommit)
 	}()
@@ -582,7 +582,7 @@ func TestPropagateTxnOnPushError(t *testing.T) {
 	//   is treated as a write made by some different txn.
 	epoch := 0
 	var txnID []byte
-	if err := db.Txn(func(txn *client.Txn) error {
+	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		// Set low priority so that the intent will not be pushed.
 		txn.InternalSetPriority(1)
 
@@ -604,20 +604,20 @@ func TestPropagateTxnOnPushError(t *testing.T) {
 		// passed to the next iteration. txnSender.Send() does
 		// not update the txn data since
 		// TransactionPushError.Transaction() returns nil.
-		err := txn.CommitInBatch(b)
+		pErr := txn.CommitInBatch(b)
 		if epoch == 1 {
-			if tErr, ok := err.(*roachpb.TransactionPushError); ok {
+			if tErr, ok := pErr.GoError().(*roachpb.TransactionPushError); ok {
 				if len(tErr.Txn.ID) == 0 {
 					t.Errorf("txn ID is not set unexpectedly: %s", tErr)
 				}
 				txnID = tErr.Txn.ID
 			} else {
-				t.Errorf("expected TransactionRetryError, but got: %s", err)
+				t.Errorf("expected TransactionRetryError, but got: %s", pErr)
 			}
 		}
-		return err
-	}); err != nil {
-		t.Errorf("unexpected error on transactional Puts: %s", err)
+		return pErr
+	}); pErr != nil {
+		t.Errorf("unexpected error on transactional Puts: %s", pErr)
 	}
 
 	if e := 2; epoch != e {

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -53,10 +53,10 @@ type RangeDescriptorDB interface {
 	// rangeLookup takes a meta key to look up descriptors for,
 	// for example \x00\x00meta1aa or \x00\x00meta2f.
 	// The two booleans are considerIntents and useReverseScan respectively.
-	RangeLookup(roachpb.RKey, *roachpb.RangeDescriptor, bool, bool) ([]roachpb.RangeDescriptor, error)
+	RangeLookup(roachpb.RKey, *roachpb.RangeDescriptor, bool, bool) ([]roachpb.RangeDescriptor, *roachpb.Error)
 	// FirstRange returns the descriptor for the first Range. This is the
 	// Range containing all \x00\x00meta1 entries.
-	FirstRange() (*roachpb.RangeDescriptor, error)
+	FirstRange() (*roachpb.RangeDescriptor, *roachpb.Error)
 }
 
 // rangeDescriptorCache is used to retrieve range descriptors for
@@ -117,7 +117,7 @@ func (rdc *rangeDescriptorCache) stringLocked() string {
 // This method returns the RangeDescriptor for the range containing
 // the key's data, or an error if any occurred.
 func (rdc *rangeDescriptorCache) LookupRangeDescriptor(key roachpb.RKey,
-	considerIntents, useReverseScan bool) (*roachpb.RangeDescriptor, error) {
+	considerIntents, useReverseScan bool) (*roachpb.RangeDescriptor, *roachpb.Error) {
 	if _, r := rdc.getCachedRangeDescriptor(key, useReverseScan); r != nil {
 		return r, nil
 	}
@@ -127,7 +127,7 @@ func (rdc *rangeDescriptorCache) LookupRangeDescriptor(key roachpb.RKey,
 	} else if log.V(1) {
 		log.Infof("lookup range descriptor: key=%s", key)
 	}
-	rs, err := func(key roachpb.RKey, considerIntents, useReverseScan bool) ([]roachpb.RangeDescriptor, error) {
+	rs, pErr := func(key roachpb.RKey, considerIntents, useReverseScan bool) ([]roachpb.RangeDescriptor, *roachpb.Error) {
 		var (
 			// metadataKey is sent to rangeLookup to find the
 			// RangeDescriptor which contains key.
@@ -135,35 +135,35 @@ func (rdc *rangeDescriptorCache) LookupRangeDescriptor(key roachpb.RKey,
 			// desc is the RangeDescriptor for the range which contains
 			// metadataKey.
 			desc *roachpb.RangeDescriptor
-			err  error
+			pErr *roachpb.Error
 		)
 		if bytes.Equal(metadataKey, roachpb.RKeyMin) {
 			// In this case, the requested key is stored in the cluster's first
 			// range. Return the first range, which is always gossiped and not
 			// queried from the datastore.
-			rd, err := rdc.db.FirstRange()
-			if err != nil {
-				return nil, err
+			desc, pErr = rdc.db.FirstRange()
+			if pErr != nil {
+				return nil, pErr
 			}
-			return []roachpb.RangeDescriptor{*rd}, nil
+			return []roachpb.RangeDescriptor{*desc}, nil
 		}
 		if bytes.HasPrefix(metadataKey, keys.Meta1Prefix) {
 			// In this case, desc is the cluster's first range.
-			if desc, err = rdc.db.FirstRange(); err != nil {
-				return nil, err
+			if desc, pErr = rdc.db.FirstRange(); pErr != nil {
+				return nil, pErr
 			}
 		} else {
 			// Look up desc from the cache, which will recursively call into
 			// this function if it is not cached.
-			desc, err = rdc.LookupRangeDescriptor(metadataKey, considerIntents, useReverseScan)
-			if err != nil {
-				return nil, err
+			desc, pErr = rdc.LookupRangeDescriptor(metadataKey, considerIntents, useReverseScan)
+			if pErr != nil {
+				return nil, pErr
 			}
 		}
 		return rdc.db.RangeLookup(metadataKey, desc, considerIntents, useReverseScan)
 	}(key, considerIntents, useReverseScan)
-	if err != nil {
-		return nil, err
+	if pErr != nil {
+		return nil, pErr
 	}
 	if len(rs) == 0 {
 		panic(fmt.Sprintf("no range descriptors returned for %s", key))

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -66,11 +66,11 @@ func (db *testDescriptorDB) getDescriptor(key roachpb.RKey) []roachpb.RangeDescr
 	return response
 }
 
-func (db *testDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, error) {
+func (db *testDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, *roachpb.Error) {
 	return nil, nil
 }
 
-func (db *testDescriptorDB) RangeLookup(key roachpb.RKey, _ *roachpb.RangeDescriptor, _, _ bool) ([]roachpb.RangeDescriptor, error) {
+func (db *testDescriptorDB) RangeLookup(key roachpb.RKey, _ *roachpb.RangeDescriptor, _, _ bool) ([]roachpb.RangeDescriptor, *roachpb.Error) {
 	db.lookupCount++
 	if bytes.HasPrefix(key, keys.Meta2Prefix) {
 		return db.getDescriptor(key[len(keys.Meta2Prefix):]), nil
@@ -126,9 +126,9 @@ func (db *testDescriptorDB) assertLookupCount(t *testing.T, expected int, key st
 }
 
 func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) *roachpb.RangeDescriptor {
-	r, err := rc.LookupRangeDescriptor(roachpb.RKey(key), false /* considerIntents */, false /* useReverseScan */)
-	if err != nil {
-		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", err.Error())
+	r, pErr := rc.LookupRangeDescriptor(roachpb.RKey(key), false /* considerIntents */, false /* useReverseScan */)
+	if pErr != nil {
+		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", pErr.GoError().Error())
 	}
 	if !r.ContainsKey(keys.Addr(roachpb.Key(key))) {
 		t.Fatalf("Returned range did not contain key: %s-%s, %s", r.StartKey, r.EndKey, key)

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -287,11 +287,11 @@ func getTxn(coord *TxnCoordSender, txn *roachpb.Transaction) (bool, *roachpb.Tra
 			Key: txn.Key,
 		},
 	}
-	reply, err := client.SendWrappedWith(coord, nil, roachpb.Header{
+	reply, pErr := client.SendWrappedWith(coord, nil, roachpb.Header{
 		Txn: txn,
 	}, hb)
-	if err != nil {
-		return false, nil, err
+	if pErr != nil {
+		return false, nil, pErr.GoError()
 	}
 	return true, reply.(*roachpb.HeartbeatTxnResponse).Txn, nil
 }
@@ -329,47 +329,47 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 		key := roachpb.Key("key: " + strconv.Itoa(i))
 		txn := client.NewTxn(*s.DB)
 		// Initialize the transaction
-		if err := txn.Put(key, []byte("value")); err != nil {
-			t.Fatal(err)
+		if pErr := txn.Put(key, []byte("value")); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		{
-			var err error
+			var pErr *roachpb.Error
 			switch i {
 			case 0:
 				// No deadline.
-				err = txn.Commit()
+				pErr = txn.Commit()
 			case 1:
 				// Past deadline.
-				err = txn.CommitBy(txn.Proto.Timestamp.Prev())
+				pErr = txn.CommitBy(txn.Proto.Timestamp.Prev())
 			case 2:
 				// Equal deadline.
-				err = txn.CommitBy(txn.Proto.Timestamp)
+				pErr = txn.CommitBy(txn.Proto.Timestamp)
 			case 3:
 				// Future deadline.
-				err = txn.CommitBy(txn.Proto.Timestamp.Next())
+				pErr = txn.CommitBy(txn.Proto.Timestamp.Next())
 			}
 
 			switch i {
 			case 0:
 				// No deadline.
-				if err != nil {
-					t.Error(err)
+				if pErr != nil {
+					t.Error(pErr)
 				}
 			case 1:
 				// Past deadline.
-				if _, ok := err.(*roachpb.TransactionAbortedError); !ok {
-					t.Errorf("expected TransactionAbortedError but got %T: %s", err, err)
+				if _, ok := pErr.GoError().(*roachpb.TransactionAbortedError); !ok {
+					t.Errorf("expected TransactionAbortedError but got %T: %s", pErr, pErr)
 				}
 			case 2:
 				// Equal deadline.
-				if err != nil {
-					t.Error(err)
+				if pErr != nil {
+					t.Error(pErr)
 				}
 			case 3:
 				// Future deadline.
-				if err != nil {
-					t.Error(err)
+				if pErr != nil {
+					t.Error(pErr)
 				}
 			}
 		}
@@ -391,9 +391,9 @@ func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 	if err := txn.Put("x", "y"); err != nil {
 		t.Fatal(err)
 	}
-	err, ok := txn.CPut(key, []byte("x"), []byte("born to fail")).(*roachpb.ConditionFailedError)
+	pErr, ok := txn.CPut(key, []byte("x"), []byte("born to fail")).GoError().(*roachpb.ConditionFailedError)
 	if !ok {
-		t.Fatal(err)
+		t.Fatal(pErr)
 	}
 	s.Sender.Lock()
 	intentSpans := s.Sender.txns[string(txn.Proto.ID)].intentSpans()
@@ -417,28 +417,28 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 	key := roachpb.Key("a")
 	txn1 := client.NewTxn(*s.DB)
 	txn1.InternalSetPriority(1)
-	if err := txn1.Put(key, []byte("value")); err != nil {
-		t.Fatal(err)
+	if pErr := txn1.Put(key, []byte("value")); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Push the transaction (by writing key "a" with higher priority) to abort it.
 	txn2 := client.NewTxn(*s.DB)
 	txn2.InternalSetPriority(2)
-	if err := txn2.Put(key, []byte("value2")); err != nil {
-		t.Fatal(err)
+	if pErr := txn2.Put(key, []byte("value2")); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Now end the transaction and verify we've cleanup up, even though
 	// end transaction failed.
-	err := txn1.Commit()
-	switch err.(type) {
+	pErr := txn1.Commit()
+	switch pErr.GoError().(type) {
 	case *roachpb.TransactionAbortedError:
 		// Expected
 	default:
-		t.Fatalf("expected transaction aborted error; got %s", err)
+		t.Fatalf("expected transaction aborted error; got %s", pErr)
 	}
-	if err := txn2.Commit(); err != nil {
-		t.Fatal(err)
+	if pErr := txn2.Commit(); pErr != nil {
+		t.Fatal(pErr)
 	}
 	verifyCleanup(key, s.Sender, s.Eng, t)
 }
@@ -454,8 +454,8 @@ func TestTxnCoordSenderGC(t *testing.T) {
 	s.Sender.heartbeatInterval = 1 * time.Millisecond
 
 	txn := client.NewTxn(*s.DB)
-	if err := txn.Put(roachpb.Key("a"), []byte("value")); err != nil {
-		t.Fatal(err)
+	if pErr := txn.Put(roachpb.Key("a"), []byte("value")); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Now, advance clock past the default client timeout.
@@ -481,7 +481,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	origTS := makeTS(123, 0)
 	testCases := []struct {
-		err              error
+		pErr             *roachpb.Error
 		expEpoch         uint32
 		expPri           int32
 		expTS, expOrigTS roachpb.Timestamp
@@ -489,7 +489,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 	}{
 		{
 			// No error, so nothing interesting either.
-			err:       nil,
+			pErr:      nil,
 			expEpoch:  0,
 			expPri:    1,
 			expTS:     origTS,
@@ -498,10 +498,10 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 		{
 			// On uncertainty error, new epoch begins and node is seen.
 			// Timestamp moves ahead of the existing write.
-			err: &roachpb.ReadWithinUncertaintyIntervalError{
+			pErr: roachpb.NewError(&roachpb.ReadWithinUncertaintyIntervalError{
 				NodeID:            1,
 				ExistingTimestamp: origTS.Add(10, 10),
-			},
+			}),
 			expEpoch:  1,
 			expPri:    1,
 			expTS:     origTS.Add(10, 11),
@@ -511,21 +511,21 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 		{
 			// On abort, nothing changes but we get a new priority to use for
 			// the next attempt.
-			err: &roachpb.TransactionAbortedError{
+			pErr: roachpb.NewError(&roachpb.TransactionAbortedError{
 				Txn: roachpb.Transaction{
 					Timestamp: origTS.Add(20, 10), Priority: 10,
 				},
-			},
+			}),
 			expPri: 10,
 		},
 		{
 			// On failed push, new epoch begins just past the pushed timestamp.
 			// Additionally, priority ratchets up to just below the pusher's.
-			err: &roachpb.TransactionPushError{
+			pErr: roachpb.NewError(&roachpb.TransactionPushError{
 				PusheeTxn: roachpb.Transaction{
 					Timestamp: origTS.Add(10, 10),
 					Priority:  int32(10)},
-			},
+			}),
 			expEpoch:  1,
 			expPri:    9,
 			expTS:     origTS.Add(10, 11),
@@ -533,10 +533,10 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 		},
 		{
 			// On retry, restart with new epoch, timestamp and priority.
-			err: &roachpb.TransactionRetryError{
+			pErr: roachpb.NewError(&roachpb.TransactionRetryError{
 				Txn: roachpb.Transaction{
 					Timestamp: origTS.Add(10, 10), Priority: int32(10)},
-			},
+			}),
 			expEpoch:  1,
 			expPri:    10,
 			expTS:     origTS.Add(10, 10),
@@ -553,22 +553,22 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 
 		ts := NewTxnCoordSender(senderFn(func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 			var reply *roachpb.BatchResponse
-			if test.err == nil {
+			if test.pErr == nil {
 				reply = ba.CreateReply()
 			}
-			return reply, roachpb.NewError(test.err)
+			return reply, test.pErr
 		}), clock, false, nil, stopper)
 		db := client.NewDB(ts)
 		txn := client.NewTxn(*db)
 		txn.InternalSetPriority(1)
 		txn.Proto.Name = "test txn"
 		key := roachpb.Key("test-key")
-		_, err := txn.Get(key)
+		_, pErr := txn.Get(key)
 		teardownHeartbeats(ts)
 		stopper.Stop()
 
-		if reflect.TypeOf(test.err) != reflect.TypeOf(err) {
-			t.Fatalf("%d: expected %T; got %T: %v", i, test.err, err, err)
+		if reflect.TypeOf(test.pErr) != reflect.TypeOf(pErr) {
+			t.Fatalf("%d: expected %T; got %T: %v", i, test.pErr, pErr, pErr)
 		}
 		if txn.Proto.Epoch != test.expEpoch {
 			t.Errorf("%d: expected epoch = %d; got %d",
@@ -612,14 +612,14 @@ func TestTxnMultipleCoord(t *testing.T) {
 	} {
 		txn := roachpb.NewTransaction("test", roachpb.Key("a"), 1, roachpb.SERIALIZABLE, s.Clock.Now(), s.Clock.MaxOffset().Nanoseconds())
 		txn.Writing = tc.writing
-		reply, err := client.SendWrappedWith(s.Sender, nil, roachpb.Header{
+		reply, pErr := client.SendWrappedWith(s.Sender, nil, roachpb.Header{
 			Txn: txn,
 		}, tc.args)
-		if err == nil != tc.ok {
+		if pErr == nil != tc.ok {
 			t.Errorf("%d: %T (writing=%t): success_expected=%t, but got: %v",
-				i, tc.args, tc.writing, tc.ok, err)
+				i, tc.args, tc.writing, tc.ok, pErr)
 		}
-		if err != nil {
+		if pErr != nil {
 			continue
 		}
 
@@ -634,12 +634,12 @@ func TestTxnMultipleCoord(t *testing.T) {
 			continue
 		}
 		// Abort for clean shutdown.
-		if _, err := client.SendWrappedWith(s.Sender, nil, roachpb.Header{
+		if _, pErr := client.SendWrappedWith(s.Sender, nil, roachpb.Header{
 			Txn: txn,
 		}, &roachpb.EndTransactionRequest{
 			Commit: false,
-		}); err != nil {
-			t.Fatal(err)
+		}); pErr != nil {
+			t.Fatal(pErr)
 		}
 	}
 }

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -79,7 +79,7 @@ type cmd struct {
 	txnIdx      int    // transaction index in the history
 	historyIdx  int    // this suffixes key so tests get unique keys
 	fn          func(
-		c *cmd, txn *client.Txn, t *testing.T) error // execution function
+		c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error // execution function
 	ch   chan struct{}    // channel for other commands to wait
 	prev <-chan struct{}  // channel this command must wait on before executing
 	env  map[string]int64 // contains all previously read values
@@ -95,24 +95,24 @@ func (c *cmd) init(prevCmd *cmd) {
 	c.debug = ""
 }
 
-func (c *cmd) execute(txn *client.Txn, t *testing.T) (string, error) {
+func (c *cmd) execute(txn *client.Txn, t *testing.T) (string, *roachpb.Error) {
 	if c.prev != nil {
 		<-c.prev
 	}
 	if log.V(1) {
 		log.Infof("executing %s", c)
 	}
-	err := c.fn(c, txn, t)
+	pErr := c.fn(c, txn, t)
 	if c.ch != nil {
 		c.ch <- struct{}{}
 	}
 	if len(c.key) > 0 && len(c.endKey) > 0 {
-		return fmt.Sprintf("%s%%d.%%d(%s-%s)%s", c.name, c.key, c.endKey, c.debug), err
+		return fmt.Sprintf("%s%%d.%%d(%s-%s)%s", c.name, c.key, c.endKey, c.debug), pErr
 	}
 	if len(c.key) > 0 {
-		return fmt.Sprintf("%s%%d.%%d(%s)%s", c.name, c.key, c.debug), err
+		return fmt.Sprintf("%s%%d.%%d(%s)%s", c.name, c.key, c.debug), pErr
 	}
-	return fmt.Sprintf("%s%%d.%%d%s", c.name, c.debug), err
+	return fmt.Sprintf("%s%%d.%%d%s", c.name, c.debug), pErr
 }
 
 func (c *cmd) done() {
@@ -144,10 +144,10 @@ func (c *cmd) String() string {
 }
 
 // readCmd reads a value from the db and stores it in the env.
-func readCmd(c *cmd, txn *client.Txn, t *testing.T) error {
-	r, err := txn.Get(c.getKey())
-	if err != nil {
-		return err
+func readCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
+	r, pErr := txn.Get(c.getKey())
+	if pErr != nil {
+		return pErr
 	}
 	if r.Value != nil {
 		c.env[c.key] = r.ValueInt()
@@ -157,15 +157,15 @@ func readCmd(c *cmd, txn *client.Txn, t *testing.T) error {
 }
 
 // deleteRngCmd deletes the range of values from the db from [key, endKey).
-func deleteRngCmd(c *cmd, txn *client.Txn, t *testing.T) error {
+func deleteRngCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 	return txn.DelRange(c.getKey(), c.getEndKey())
 }
 
 // scanCmd reads the values from the db from [key, endKey).
-func scanCmd(c *cmd, txn *client.Txn, t *testing.T) error {
-	rows, err := txn.Scan(c.getKey(), c.getEndKey(), 0)
-	if err != nil {
-		return err
+func scanCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
+	rows, pErr := txn.Scan(c.getKey(), c.getEndKey(), 0)
+	if pErr != nil {
+		return pErr
 	}
 	var vals []string
 	keyPrefix := []byte(fmt.Sprintf("%d.", c.historyIdx))
@@ -180,10 +180,10 @@ func scanCmd(c *cmd, txn *client.Txn, t *testing.T) error {
 
 // incCmd adds one to the value of c.key in the env and writes
 // it to the db. If c.key isn't in the db, writes 1.
-func incCmd(c *cmd, txn *client.Txn, t *testing.T) error {
-	r, err := txn.Inc(c.getKey(), 1)
-	if err != nil {
-		return err
+func incCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
+	r, pErr := txn.Inc(c.getKey(), 1)
+	if pErr != nil {
+		return pErr
 	}
 	c.env[c.key] = r.ValueInt()
 	c.debug = fmt.Sprintf("[%d]", r.ValueInt())
@@ -192,26 +192,26 @@ func incCmd(c *cmd, txn *client.Txn, t *testing.T) error {
 
 // sumCmd sums the values of all keys != c.key read during the transaction and
 // writes the result to the db.
-func sumCmd(c *cmd, txn *client.Txn, t *testing.T) error {
+func sumCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 	sum := int64(0)
 	for k, v := range c.env {
 		if k != c.key {
 			sum += v
 		}
 	}
-	r, err := txn.Inc(c.getKey(), sum)
+	r, pErr := txn.Inc(c.getKey(), sum)
 	c.debug = fmt.Sprintf("[%d ts=%d]", sum, r.Timestamp())
-	return err
+	return pErr
 }
 
 // commitCmd commits the transaction.
-func commitCmd(c *cmd, txn *client.Txn, t *testing.T) error {
+func commitCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 	return txn.CommitNoCleanup()
 }
 
 // cmdDict maps from command name to function implementing the command.
 // Use only upper case letters for commands. More than one letter is OK.
-var cmdDict = map[string]func(c *cmd, txn *client.Txn, t *testing.T) error{
+var cmdDict = map[string]func(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error{
 	"R":   readCmd,
 	"I":   incCmd,
 	"DR":  deleteRngCmd,
@@ -534,18 +534,18 @@ func (hv *historyVerifier) runHistory(historyIdx int, priorities []int32,
 		c.historyIdx = historyIdx
 		c.env = verifyEnv
 		c.init(nil)
-		err := db.Txn(func(txn *client.Txn) error {
-			fmtStr, err := c.execute(txn, t)
-			if err != nil {
-				return err
+		pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+			fmtStr, pErr := c.execute(txn, t)
+			if pErr != nil {
+				return pErr
 			}
 			cmdStr := fmt.Sprintf(fmtStr, 0, 0)
 			verifyStrs = append(verifyStrs, cmdStr)
 			return nil
 		})
-		if err != nil {
-			t.Errorf("failed on execution of verification cmd %s: %s", c, err)
-			return err
+		if pErr != nil {
+			t.Errorf("failed on execution of verification cmd %s: %s", c, pErr)
+			return pErr.GoError()
 		}
 	}
 
@@ -567,11 +567,11 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 	isolation roachpb.IsolationType, cmds []*cmd, db *client.DB, t *testing.T) error {
 	var retry int
 	txnName := fmt.Sprintf("txn%d", txnIdx)
-	err := db.Txn(func(txn *client.Txn) error {
+	pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		txn.SetDebugName(txnName, 0)
 		if isolation == roachpb.SNAPSHOT {
-			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-				return err
+			if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
+				return pErr
 			}
 		}
 		txn.InternalSetPriority(priority)
@@ -594,20 +594,20 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 		}
 		for i := range cmds {
 			cmds[i].env = env
-			if err := hv.runCmd(txn, txnIdx, retry, i, cmds, t); err != nil {
-				return err
+			if pErr := hv.runCmd(txn, txnIdx, retry, i, cmds, t); pErr != nil {
+				return pErr
 			}
 		}
 		return nil
 	})
 	hv.wg.Done()
-	return err
+	return pErr.GoError()
 }
 
-func (hv *historyVerifier) runCmd(txn *client.Txn, txnIdx, retry, cmdIdx int, cmds []*cmd, t *testing.T) error {
-	fmtStr, err := cmds[cmdIdx].execute(txn, t)
-	if err != nil {
-		return err
+func (hv *historyVerifier) runCmd(txn *client.Txn, txnIdx, retry, cmdIdx int, cmds []*cmd, t *testing.T) *roachpb.Error {
+	fmtStr, pErr := cmds[cmdIdx].execute(txn, t)
+	if pErr != nil {
+		return pErr
 	}
 	hv.Lock()
 	cmdStr := fmt.Sprintf(fmtStr, txnIdx, retry)

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -19,7 +19,6 @@ package kv
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -31,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -50,52 +50,52 @@ func TestTxnDBBasics(t *testing.T) {
 	for _, commit := range []bool{true, false} {
 		key := []byte(fmt.Sprintf("key-%t", commit))
 
-		err := s.DB.Txn(func(txn *client.Txn) error {
+		pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 			// Use snapshot isolation so non-transactional read can always push.
-			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-				return err
+			if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
+				return pErr
 			}
 
 			// Put transactional value.
-			if err := txn.Put(key, value); err != nil {
-				return err
+			if pErr := txn.Put(key, value); pErr != nil {
+				return pErr
 			}
 
 			// Attempt to read outside of txn.
-			if gr, err := s.DB.Get(key); err != nil {
-				return err
+			if gr, pErr := s.DB.Get(key); pErr != nil {
+				return pErr
 			} else if gr.Exists() {
-				return util.Errorf("expected nil value; got %v", gr.Value)
+				return roachpb.NewErrorf("expected nil value; got %v", gr.Value)
 			}
 
 			// Read within the transaction.
-			if gr, err := txn.Get(key); err != nil {
-				return err
+			if gr, pErr := txn.Get(key); pErr != nil {
+				return pErr
 			} else if !gr.Exists() || !bytes.Equal(gr.ValueBytes(), value) {
-				return util.Errorf("expected value %q; got %q", value, gr.Value)
+				return roachpb.NewErrorf("expected value %q; got %q", value, gr.Value)
 			}
 
 			if !commit {
-				return errors.New("purposefully failing transaction")
+				return roachpb.NewErrorf("purposefully failing transaction")
 			}
 			return nil
 		})
 
-		if commit != (err == nil) {
-			t.Errorf("expected success? %t; got %s", commit, err)
-		} else if !commit && err.Error() != "purposefully failing transaction" {
-			t.Errorf("unexpected failure with !commit: %s", err)
+		if commit != (pErr == nil) {
+			t.Errorf("expected success? %t; got %s", commit, pErr)
+		} else if !commit && !testutils.IsError(pErr.GoError(), "purposefully failing transaction") {
+			t.Errorf("unexpected failure with !commit: %s", pErr)
 		}
 
 		// Verify the value is now visible on commit == true, and not visible otherwise.
-		gr, err := s.DB.Get(key)
+		gr, pErr := s.DB.Get(key)
 		if commit {
-			if err != nil || !gr.Exists() || !bytes.Equal(gr.ValueBytes(), value) {
-				t.Errorf("expected success reading value: %+v, %s", gr.ValueBytes(), err)
+			if pErr != nil || !gr.Exists() || !bytes.Equal(gr.ValueBytes(), value) {
+				t.Errorf("expected success reading value: %+v, %s", gr.ValueBytes(), pErr)
 			}
 		} else {
-			if err != nil || gr.Exists() {
-				t.Errorf("expected success and nil value: %s, %s", gr, err)
+			if pErr != nil || gr.Exists() {
+				t.Errorf("expected success and nil value: %s, %s", gr, pErr)
 			}
 		}
 	}
@@ -113,7 +113,7 @@ func benchmarkSingleRoundtripWithLatency(b *testing.B, latency time.Duration) {
 	key := roachpb.Key("key")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if tErr := s.DB.Txn(func(txn *client.Txn) error {
+		if tErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 			b := txn.NewBatch()
 			b.Put(key, fmt.Sprintf("value-%d", i))
 			return txn.CommitInBatch(b)
@@ -206,25 +206,25 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 			sender := NewTxnCoordSender(s.distSender, txnClock, false, nil, s.Stopper)
 			txnDB := client.NewDB(sender)
 
-			if err := txnDB.Txn(func(txn *client.Txn) error {
+			if pErr := txnDB.Txn(func(txn *client.Txn) *roachpb.Error {
 				// Read within the transaction.
-				gr, err := txn.Get(key)
-				if err != nil {
-					if _, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); ok {
-						return err
+				gr, pErr := txn.Get(key)
+				if pErr != nil {
+					if _, ok := pErr.GoError().(*roachpb.ReadWithinUncertaintyIntervalError); ok {
+						return pErr
 					}
-					return util.Errorf("unexpected read error of type %s: %s", reflect.TypeOf(err), err)
+					return roachpb.NewErrorf("unexpected read error of type %s: %s", reflect.TypeOf(pErr.GoError()), pErr)
 				}
 				if !gr.Exists() {
-					return util.Errorf("no value read")
+					return roachpb.NewErrorf("no value read")
 				}
 				if !bytes.Equal(gr.ValueBytes(), readValue) {
-					return util.Errorf("%d: read wrong value %v at %s, wanted %q",
+					return roachpb.NewErrorf("%d: read wrong value %v at %s, wanted %q",
 						i, gr.Value, futureTS, readValue)
 				}
 				return nil
-			}); err != nil {
-				t.Error(err)
+			}); pErr != nil {
+				t.Error(pErr)
 			}
 		}(i)
 	}
@@ -295,7 +295,7 @@ func TestUncertaintyRestarts(t *testing.T) {
 	wantedBytes := []byte("value-0")
 
 	i := -1
-	tErr := s.DB.Txn(func(txn *client.Txn) error {
+	tErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 		i++
 		s.Manual.Increment(1)
 		futureTS := s.Clock.Now()
@@ -304,9 +304,9 @@ func TestUncertaintyRestarts(t *testing.T) {
 		if err := engine.MVCCPut(s.Eng, nil, key, futureTS, value, nil); err != nil {
 			t.Fatal(err)
 		}
-		gr, err := txn.Get(key)
-		if err != nil {
-			return err
+		gr, pErr := txn.Get(key)
+		if pErr != nil {
+			return pErr
 		}
 		if !gr.Exists() || !bytes.Equal(gr.ValueBytes(), wantedBytes) {
 			t.Fatalf("%d: read wrong value: %v, wanted %q", i, gr.Value, wantedBytes)
@@ -360,12 +360,12 @@ func TestUncertaintyMaxTimestampForwarding(t *testing.T) {
 	}
 
 	i := 0
-	if tErr := s.DB.Txn(func(txn *client.Txn) error {
+	if tErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 		i++
 		// The first command serves to start a Txn, fixing the timestamps.
 		// There will be a restart, but this is idempotent.
-		if _, err := txn.Scan("t", roachpb.Key("t").Next(), 0); err != nil {
-			t.Fatal(err)
+		if _, pErr := txn.Scan("t", roachpb.Key("t").Next(), 0); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		// The server's clock suddenly jumps ahead of keyFast's timestamp.
@@ -376,19 +376,19 @@ func TestUncertaintyMaxTimestampForwarding(t *testing.T) {
 		// node clock (which is ahead of keyFast as well). If the last part does
 		// not happen, the read of keyFast should fail (i.e. read nothing).
 		// There will be exactly one restart here.
-		if gr, err := txn.Get(keySlow); err != nil {
+		if gr, pErr := txn.Get(keySlow); pErr != nil {
 			if i != 1 {
-				t.Errorf("unexpected transaction error: %s", err)
+				t.Errorf("unexpected transaction error: %s", pErr)
 			}
-			return err
+			return pErr
 		} else if !gr.Exists() || !bytes.Equal(gr.ValueBytes(), valSlow) {
 			t.Errorf("read of %q returned %v, wanted value %q", keySlow, gr.Value, valSlow)
 		}
 
 		// The node should already be certain, so we expect no restart here
 		// and to read the correct key.
-		if gr, err := txn.Get(keyFast); err != nil {
-			t.Errorf("second Get failed with %s", err)
+		if gr, pErr := txn.Get(keyFast); pErr != nil {
+			t.Errorf("second Get failed with %s", pErr)
 		} else if !gr.Exists() || !bytes.Equal(gr.ValueBytes(), valFast) {
 			t.Errorf("read of %q returned %v, wanted value %q", keyFast, gr.Value, valFast)
 		}
@@ -409,34 +409,34 @@ func TestTxnTimestampRegression(t *testing.T) {
 
 	keyA := "a"
 	keyB := "b"
-	err := s.DB.Txn(func(txn *client.Txn) error {
+	pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 		// Use snapshot isolation so non-transactional read can always push.
-		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-			return err
+		if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
+			return pErr
 		}
 		// Put transactional value.
-		if err := txn.Put(keyA, "value1"); err != nil {
-			return err
+		if pErr := txn.Put(keyA, "value1"); pErr != nil {
+			return pErr
 		}
 
 		// Attempt to read outside of txn (this will push timestamp of transaction).
-		if _, err := s.DB.Get(keyA); err != nil {
-			return err
+		if _, pErr := s.DB.Get(keyA); pErr != nil {
+			return pErr
 		}
 
 		// Now, read again outside of txn to warmup timestamp cache with higher timestamp.
-		if _, err := s.DB.Get(keyB); err != nil {
-			return err
+		if _, pErr := s.DB.Get(keyB); pErr != nil {
+			return pErr
 		}
 
 		// Write now to keyB, which will get a higher timestamp than keyB was written at.
-		if err := txn.Put(keyB, "value2"); err != nil {
-			return err
+		if pErr := txn.Put(keyB, "value2"); pErr != nil {
+			return pErr
 		}
 		return nil
 	})
-	if err != nil {
-		t.Fatal(err)
+	if pErr != nil {
+		t.Fatal(pErr)
 	}
 }
 
@@ -453,27 +453,27 @@ func TestTxnLongDelayBetweenWritesWithConcurrentRead(t *testing.T) {
 	keyB := roachpb.Key("b")
 	ch := make(chan struct{})
 	go func() {
-		err := s.DB.Txn(func(txn *client.Txn) error {
+		pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 			// Use snapshot isolation.
-			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-				return err
+			if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
+				return pErr
 			}
 			// Put transactional value.
-			if err := txn.Put(keyA, "value1"); err != nil {
-				return err
+			if pErr := txn.Put(keyA, "value1"); pErr != nil {
+				return pErr
 			}
 			// Notify txnB do 1st get(b).
 			ch <- struct{}{}
 			// Wait for txnB notify us to put(b).
 			<-ch
 			// Write now to keyB.
-			if err := txn.Put(keyB, "value2"); err != nil {
-				return err
+			if pErr := txn.Put(keyB, "value2"); pErr != nil {
+				return pErr
 			}
 			return nil
 		})
-		if err != nil {
-			t.Fatal(err)
+		if pErr != nil {
+			t.Fatal(pErr)
 		}
 		// Notify txnB do 2nd get(b).
 		ch <- struct{}{}
@@ -483,25 +483,25 @@ func TestTxnLongDelayBetweenWritesWithConcurrentRead(t *testing.T) {
 	<-ch
 	// Delay for longer than the cache window.
 	s.Manual.Set((storage.MinTSCacheWindow + time.Second).Nanoseconds())
-	err := s.DB.Txn(func(txn *client.Txn) error {
+	pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 		// Use snapshot isolation.
-		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-			return err
+		if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
+			return pErr
 		}
 
 		// Attempt to get first keyB.
-		gr1, err := txn.Get(keyB)
-		if err != nil {
-			return err
+		gr1, pErr := txn.Get(keyB)
+		if pErr != nil {
+			return pErr
 		}
 		// Notify txnA put(b).
 		ch <- struct{}{}
 		// Wait for txnA finish commit.
 		<-ch
 		// get(b) again.
-		gr2, err := txn.Get(keyB)
-		if err != nil {
-			return err
+		gr2, pErr := txn.Get(keyB)
+		if pErr != nil {
+			return pErr
 		}
 
 		if gr1.Exists() || gr2.Exists() {
@@ -509,8 +509,8 @@ func TestTxnLongDelayBetweenWritesWithConcurrentRead(t *testing.T) {
 		}
 		return nil
 	})
-	if err != nil {
-		t.Fatal(err)
+	if pErr != nil {
+		t.Fatal(pErr)
 	}
 }
 
@@ -529,27 +529,27 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 	splitKey := roachpb.Key("b")
 	ch := make(chan struct{})
 	go func() {
-		err := s.DB.Txn(func(txn *client.Txn) error {
+		pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 			// Use snapshot isolation.
-			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-				return err
+			if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
+				return pErr
 			}
 			// Put transactional value.
-			if err := txn.Put(keyA, "value1"); err != nil {
-				return err
+			if pErr := txn.Put(keyA, "value1"); pErr != nil {
+				return pErr
 			}
 			// Notify txnB do 1st get(c).
 			ch <- struct{}{}
 			// Wait for txnB notify us to put(c).
 			<-ch
 			// Write now to keyC, which will keep timestamp.
-			if err := txn.Put(keyC, "value2"); err != nil {
-				return err
+			if pErr := txn.Put(keyC, "value2"); pErr != nil {
+				return pErr
 			}
 			return nil
 		})
-		if err != nil {
-			t.Fatal(err)
+		if pErr != nil {
+			t.Fatal(pErr)
 		}
 		// Notify txnB do 2nd get(c).
 		ch <- struct{}{}
@@ -558,29 +558,29 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 	// Wait till txnA finish put(a).
 	<-ch
 
-	err := s.DB.Txn(func(txn *client.Txn) error {
+	pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 		// Use snapshot isolation.
-		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-			return err
+		if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
+			return pErr
 		}
 
 		// First get keyC, value will be nil.
-		gr1, err := txn.Get(keyC)
-		if err != nil {
-			return err
+		gr1, pErr := txn.Get(keyC)
+		if pErr != nil {
+			return pErr
 		}
 		s.Manual.Set(time.Second.Nanoseconds())
 		// Split range by keyB.
-		if err := s.DB.AdminSplit(splitKey); err != nil {
-			t.Fatal(err)
+		if pErr := s.DB.AdminSplit(splitKey); pErr != nil {
+			t.Fatal(pErr)
 		}
 		// Wait till split complete.
 		// Check that we split 1 times in allotted time.
 		if err := util.IsTrueWithin(func() bool {
 			// Scan the meta records.
-			rows, err := s.DB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
-			if err != nil {
-				t.Fatalf("failed to scan meta2 keys: %s", err)
+			rows, spErr := s.DB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+			if spErr != nil {
+				t.Fatalf("failed to scan meta2 keys: %s", spErr)
 			}
 			return len(rows) >= 2
 		}, 6*time.Second); err != nil {
@@ -591,9 +591,9 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 		// Wait for txnA finish commit.
 		<-ch
 		// Get(c) again.
-		gr2, err := txn.Get(keyC)
-		if err != nil {
-			return err
+		gr2, pErr := txn.Get(keyC)
+		if pErr != nil {
+			return pErr
 		}
 
 		if !gr1.Exists() && gr2.Exists() {
@@ -601,8 +601,8 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 		}
 		return nil
 	})
-	if err != nil {
-		t.Fatal(err)
+	if pErr != nil {
+		t.Fatal(pErr)
 	}
 }
 
@@ -619,14 +619,14 @@ func TestTxnRestartedSerializableTimestampRegression(t *testing.T) {
 	ch := make(chan struct{})
 	var count int
 	go func() {
-		err := s.DB.Txn(func(txn *client.Txn) error {
+		pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 			count++
 			// Use a low priority for the transaction so that it can be pushed.
 			txn.InternalSetPriority(1)
 
 			// Put transactional value.
-			if err := txn.Put(keyA, "value1"); err != nil {
-				return err
+			if pErr := txn.Put(keyA, "value1"); pErr != nil {
+				return pErr
 			}
 			if count <= 2 {
 				// Notify txnB to push txnA on get(a).
@@ -635,27 +635,27 @@ func TestTxnRestartedSerializableTimestampRegression(t *testing.T) {
 				<-ch
 			}
 			// Do a write to keyB, which will forward txn timestamp.
-			if err := txn.Put(keyB, "value2"); err != nil {
-				return err
+			if pErr := txn.Put(keyB, "value2"); pErr != nil {
+				return pErr
 			}
 			// Now commit...
 			return nil
 		})
 		close(ch)
-		if err != nil {
-			t.Fatal(err)
+		if pErr != nil {
+			t.Fatal(pErr)
 		}
 	}()
 
 	// Wait until txnA finishes put(a).
 	<-ch
 	// Attempt to get keyA, which will push txnA.
-	if _, err := s.DB.Get(keyA); err != nil {
-		t.Fatal(err)
+	if _, pErr := s.DB.Get(keyA); pErr != nil {
+		t.Fatal(pErr)
 	}
 	// Do a read at keyB to cause txnA to forward timestamp.
-	if _, err := s.DB.Get(keyB); err != nil {
-		t.Fatal(err)
+	if _, pErr := s.DB.Get(keyB); pErr != nil {
+		t.Fatal(pErr)
 	}
 	// Notify txnA to commit.
 	ch <- struct{}{}

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -93,6 +93,12 @@
 		ConditionFailedError
 		LeaseRejectedError
 		SendError
+		RaftGroupDeletedError
+		ReplicaCorruptionError
+		LeaseVersionChangedError
+		DidntUpdateDescriptorError
+		SqlTransactionAbortedError
+		ExistingSchemaChangeLeaseError
 		ErrorDetail
 		ErrPosition
 		Error

--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -19,6 +19,7 @@ package roachpb
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/util/caller"
 	"github.com/cockroachdb/cockroach/util/retry"
 )
 
@@ -28,7 +29,7 @@ import (
 // another error in addition to this one).
 type ResponseWithError struct {
 	Reply *BatchResponse
-	Err   error
+	Err   *Error
 }
 
 // ErrorUnexpectedlySet creates a string to panic with when a response (typically
@@ -37,36 +38,10 @@ func ErrorUnexpectedlySet(culprit, response interface{}) string {
 	return fmt.Sprintf("error is unexpectedly set, culprit is %T:\n%+v", culprit, response)
 }
 
-// TransactionRestartError is an interface implemented by errors that cause
+// transactionRestartError is an interface implemented by errors that cause
 // a transaction to be restarted.
-type TransactionRestartError interface {
-	CanRestartTransaction() TransactionRestart
-	// Optionally, a transaction that should be used
-	// for an update before retrying.
-	Transaction() *Transaction
-}
-
-// IndexedError is an interface implemented by errors which can be associated
-// with a failed request in a Batch.
-type IndexedError interface {
-	ErrorIndex() (int32, bool) // bool is false iff no index associated
-	SetErrorIndex(int32)
-}
-
-var _ IndexedError = &WriteIntentError{}
-var _ IndexedError = &ConditionFailedError{}
-
-// ErrorIndex implements IndexedError.
-func (e *ConditionFailedError) ErrorIndex() (int32, bool) {
-	if e.Index != nil {
-		return e.Index.Index, true
-	}
-	return 0, false
-}
-
-// SetErrorIndex implements IndexedError.
-func (e *ConditionFailedError) SetErrorIndex(index int32) {
-	e.Index = &ErrPosition{Index: index}
+type transactionRestartError interface {
+	canRestartTransaction() TransactionRestart
 }
 
 func (e Error) getDetail() error {
@@ -90,6 +65,22 @@ func NewError(err error) *Error {
 	return e
 }
 
+// NewUErrorf creates an Error from the given error message. Used
+// for user-facing errors.
+func NewUErrorf(format string, a ...interface{}) *Error {
+	return NewError(fmt.Errorf(format, a...))
+}
+
+// NewErrorf creates an Error from the given error message. It is a
+// passthrough to fmt.Errorf, with an additional prefix containing the
+// filename and line number.
+func NewErrorf(format string, a ...interface{}) *Error {
+	// Cannot use util.Errorf here due to cyclic dependency.
+	file, line, _ := caller.Lookup(1)
+	s := fmt.Sprintf("%s:%d: ", file, line)
+	return NewError(fmt.Errorf(s+format, a...))
+}
+
 // String implements fmt.Stringer.
 func (e *Error) String() string {
 	return e.Message
@@ -107,16 +98,14 @@ func (e *internalError) CanRetry() bool {
 	return e.Retryable
 }
 
-// CanRestartTransaction implements the TransactionRestartError interface.
-func (e *internalError) CanRestartTransaction() TransactionRestart {
+// canRestartTransaction implements the transactionRestartError interface.
+func (e *internalError) canRestartTransaction() TransactionRestart {
 	return e.TransactionRestart
 }
 
-// Transaction implements the TransactionRestartError interface by returning
-// nil. The idea is that an error which isn't an ErrorDetail can't hold a
-// transaction (this is asserted by SetGoError()).
-func (*internalError) Transaction() *Transaction {
-	return nil
+// CanRetry implements the retry.Retryable interface.
+func (e *Error) CanRetry() bool {
+	return e.Retryable
 }
 
 // GoError returns the non-nil error from the roachpb.Error union.
@@ -139,17 +128,7 @@ func (e *Error) GoError() error {
 			panic(fmt.Sprintf("inconsistent error proto; expected %T to be retryable", err))
 		}
 	}
-	if r, ok := err.(TransactionRestartError); ok {
-		if r.CanRestartTransaction() != e.TransactionRestart {
-			panic(fmt.Sprintf("inconsistent error proto; expected %T to have restart mode %v",
-				err, e.TransactionRestart))
-		}
-	} else {
-		// Error type doesn't implement TransactionRestartError, so expect it to have the default.
-		if e.TransactionRestart != TransactionRestart_ABORT {
-			panic(fmt.Sprintf("inconsistent error proto; expected %T to have restart mode ABORT", err))
-		}
-	}
+
 	return err
 }
 
@@ -163,17 +142,22 @@ func (e *Error) SetGoError(err error) {
 		e.Retryable = r.CanRetry()
 	}
 	var isTxnError bool
-	if r, ok := err.(TransactionRestartError); ok {
+	if r, ok := err.(transactionRestartError); ok {
 		isTxnError = true
-		e.TransactionRestart = r.CanRestartTransaction()
+		e.TransactionRestart = r.canRestartTransaction()
 	}
 	// If the specific error type exists in the detail union, set it.
 	detail := &ErrorDetail{}
 	if detail.SetValue(err) {
 		e.Detail = detail
 	} else if _, isInternalError := err.(*internalError); !isInternalError && isTxnError {
-		panic(fmt.Sprintf("TransactionRestartError %T must be an ErrorDetail", err))
+		panic(fmt.Sprintf("transactionRestartError %T must be an ErrorDetail", err))
 	}
+}
+
+// SetErrorIndex sets the index of the error.
+func (e *Error) SetErrorIndex(index int32) {
+	e.Index = &ErrPosition{Index: index}
 }
 
 // Error formats error.
@@ -245,27 +229,22 @@ func (*RangeKeyMismatchError) CanRetry() bool {
 	return true
 }
 
-// NewTransactionAbortedError initializes a new TransactionAbortedError. It
-// creates a copy of the given Transaction.
-func NewTransactionAbortedError(txn *Transaction) *TransactionAbortedError {
-	return &TransactionAbortedError{Txn: *txn.Clone()}
-}
-
 // Error formats error.
 func (e *TransactionAbortedError) Error() string {
 	return fmt.Sprintf("txn aborted %s", e.Txn)
 }
 
-var _ TransactionRestartError = &TransactionAbortedError{}
+var _ transactionRestartError = &TransactionAbortedError{}
 
-// CanRestartTransaction implements the TransactionRestartError interface.
-func (*TransactionAbortedError) CanRestartTransaction() TransactionRestart {
+// canRestartTransaction implements the transactionRestartError interface.
+func (*TransactionAbortedError) canRestartTransaction() TransactionRestart {
 	return TransactionRestart_BACKOFF
 }
 
-// Transaction implements TransactionRestartError.
-func (e *TransactionAbortedError) Transaction() *Transaction {
-	return &e.Txn
+// NewTransactionAbortedError initializes a new TransactionAbortedError. It
+// creates a copy of the given Transaction.
+func NewTransactionAbortedError(txn *Transaction) *TransactionAbortedError {
+	return &TransactionAbortedError{Txn: *txn.Clone()}
 }
 
 // NewTransactionPushError initializes a new TransactionPushError.
@@ -290,16 +269,11 @@ func (e *TransactionPushError) Error() string {
 	return fmt.Sprintf("txn %s failed to push %s", e.Txn, e.PusheeTxn)
 }
 
-var _ TransactionRestartError = &TransactionPushError{}
+var _ transactionRestartError = &TransactionPushError{}
 
-// CanRestartTransaction implements the TransactionRestartError interface.
-func (*TransactionPushError) CanRestartTransaction() TransactionRestart {
+// canRestartTransaction implements the transactionRestartError interface.
+func (*TransactionPushError) canRestartTransaction() TransactionRestart {
 	return TransactionRestart_BACKOFF
-}
-
-// Transaction implements the TransactionRestartError interface.
-func (e *TransactionPushError) Transaction() *Transaction {
-	return e.Txn
 }
 
 // NewTransactionRetryError initializes a new TransactionRetryError.
@@ -313,16 +287,11 @@ func (e *TransactionRetryError) Error() string {
 	return fmt.Sprintf("retry txn %s", e.Txn)
 }
 
-var _ TransactionRestartError = &TransactionRetryError{}
+var _ transactionRestartError = &TransactionRetryError{}
 
-// CanRestartTransaction implements the TransactionRestartError interface.
-func (*TransactionRetryError) CanRestartTransaction() TransactionRestart {
+// canRestartTransaction implements the transactionRestartError interface.
+func (*TransactionRetryError) canRestartTransaction() TransactionRestart {
 	return TransactionRestart_IMMEDIATE
-}
-
-// Transaction implements the TransactionRestartError interface.
-func (e *TransactionRetryError) Transaction() *Transaction {
-	return &e.Txn
 }
 
 // NewTransactionStatusError initializes a new TransactionStatusError from
@@ -345,19 +314,6 @@ func (e *WriteIntentError) Error() string {
 	return fmt.Sprintf("conflicting intents on %v: resolved? %t", keys, e.Resolved)
 }
 
-// ErrorIndex implements IndexedError.
-func (e *WriteIntentError) ErrorIndex() (int32, bool) {
-	if e.Index != nil {
-		return e.Index.Index, true
-	}
-	return 0, false
-}
-
-// SetErrorIndex implements IndexedError.
-func (e *WriteIntentError) SetErrorIndex(index int32) {
-	e.Index = &ErrPosition{Index: index}
-}
-
 // Error formats error.
 func (e *WriteTooOldError) Error() string {
 	return fmt.Sprintf("write too old: timestamp %s <= %s", e.Timestamp, e.ExistingTimestamp)
@@ -368,16 +324,11 @@ func (e *ReadWithinUncertaintyIntervalError) Error() string {
 	return fmt.Sprintf("read at time %s encountered previous write with future timestamp %s within uncertainty interval", e.Timestamp, e.ExistingTimestamp)
 }
 
-var _ TransactionRestartError = &ReadWithinUncertaintyIntervalError{}
+var _ transactionRestartError = &ReadWithinUncertaintyIntervalError{}
 
-// CanRestartTransaction implements the TransactionRestartError interface.
-func (*ReadWithinUncertaintyIntervalError) CanRestartTransaction() TransactionRestart {
+// canRestartTransaction implements the transactionRestartError interface.
+func (*ReadWithinUncertaintyIntervalError) canRestartTransaction() TransactionRestart {
 	return TransactionRestart_IMMEDIATE
-}
-
-// Transaction implements the TransactionRestartError interface.
-func (e *ReadWithinUncertaintyIntervalError) Transaction() *Transaction {
-	return &e.Txn
 }
 
 // Error formats error.
@@ -388,4 +339,34 @@ func (*OpRequiresTxnError) Error() string {
 // Error formats error.
 func (e *ConditionFailedError) Error() string {
 	return fmt.Sprintf("unexpected value: %s", e.ActualValue)
+}
+
+// Error formats error.
+func (*RaftGroupDeletedError) Error() string {
+	return "raft group deleted"
+}
+
+// Error formats error.
+func (e *ReplicaCorruptionError) Error() string {
+	return fmt.Sprintf("replica corruption (processed=%t): %s", e.Processed, e.ErrorMsg)
+}
+
+// Error formats error.
+func (*LeaseVersionChangedError) Error() string {
+	return "lease version changed"
+}
+
+// Error formats error.
+func (*DidntUpdateDescriptorError) Error() string {
+	return "didn't update the table descriptor"
+}
+
+// Error formats error.
+func (*SqlTransactionAbortedError) Error() string {
+	return "current transaction is aborted, commands ignored until end of transaction block"
+}
+
+// Error formats error.
+func (*ExistingSchemaChangeLeaseError) Error() string {
+	return "an outstanding schema change lease exists"
 }

--- a/roachpb/errors.pb.go
+++ b/roachpb/errors.pb.go
@@ -181,9 +181,6 @@ func (*TransactionStatusError) ProtoMessage()    {}
 type WriteIntentError struct {
 	Intents  []Intent `protobuf:"bytes,1,rep,name=intents" json:"intents"`
 	Resolved bool     `protobuf:"varint,2,opt,name=resolved" json:"resolved"`
-	// The index, if given, contains the index of the request (in the batch)
-	// whose execution caused the error.
-	Index *ErrPosition `protobuf:"bytes,3,opt,name=index" json:"index,omitempty"`
 }
 
 func (m *WriteIntentError) Reset()         { *m = WriteIntentError{} }
@@ -218,8 +215,7 @@ func (*OpRequiresTxnError) ProtoMessage()    {}
 // because it was missing or was not equal. The error will
 // contain the actual value found.
 type ConditionFailedError struct {
-	ActualValue *Value       `protobuf:"bytes,1,opt,name=actual_value" json:"actual_value,omitempty"`
-	Index       *ErrPosition `protobuf:"bytes,2,opt,name=index" json:"index,omitempty"`
+	ActualValue *Value `protobuf:"bytes,1,opt,name=actual_value" json:"actual_value,omitempty"`
 }
 
 func (m *ConditionFailedError) Reset()         { *m = ConditionFailedError{} }
@@ -249,6 +245,61 @@ func (m *SendError) Reset()         { *m = SendError{} }
 func (m *SendError) String() string { return proto.CompactTextString(m) }
 func (*SendError) ProtoMessage()    {}
 
+// A RaftGroupDeletedError indicates a raft group has been deleted for
+// the replica.
+type RaftGroupDeletedError struct {
+}
+
+func (m *RaftGroupDeletedError) Reset()         { *m = RaftGroupDeletedError{} }
+func (m *RaftGroupDeletedError) String() string { return proto.CompactTextString(m) }
+func (*RaftGroupDeletedError) ProtoMessage()    {}
+
+// A ReplicaCorruptionError indicates that the replica has experienced
+// an error which puts its integrity at risk.
+type ReplicaCorruptionError struct {
+	ErrorMsg string `protobuf:"bytes,1,opt,name=error_msg" json:"error_msg"`
+	// processed indicates that the error has been taken into account and
+	// necessary steps will be taken. For now, required for testing.
+	Processed bool `protobuf:"varint,2,opt,name=processed" json:"processed"`
+}
+
+func (m *ReplicaCorruptionError) Reset()         { *m = ReplicaCorruptionError{} }
+func (m *ReplicaCorruptionError) String() string { return proto.CompactTextString(m) }
+func (*ReplicaCorruptionError) ProtoMessage()    {}
+
+// A LeaseVersionChangedError indicates that the lease version has changed.
+type LeaseVersionChangedError struct {
+}
+
+func (m *LeaseVersionChangedError) Reset()         { *m = LeaseVersionChangedError{} }
+func (m *LeaseVersionChangedError) String() string { return proto.CompactTextString(m) }
+func (*LeaseVersionChangedError) ProtoMessage()    {}
+
+// A DidntUpdateDescriptorError indicates that a table descriptor was not updated.
+type DidntUpdateDescriptorError struct {
+}
+
+func (m *DidntUpdateDescriptorError) Reset()         { *m = DidntUpdateDescriptorError{} }
+func (m *DidntUpdateDescriptorError) String() string { return proto.CompactTextString(m) }
+func (*DidntUpdateDescriptorError) ProtoMessage()    {}
+
+// An SqlTransactionAbortedError indicates that a current transaction is aborted.
+type SqlTransactionAbortedError struct {
+}
+
+func (m *SqlTransactionAbortedError) Reset()         { *m = SqlTransactionAbortedError{} }
+func (m *SqlTransactionAbortedError) String() string { return proto.CompactTextString(m) }
+func (*SqlTransactionAbortedError) ProtoMessage()    {}
+
+// An ExistingSchemaChangeLeaseError indicates that an outstanding
+// schema change lease exists.
+type ExistingSchemaChangeLeaseError struct {
+}
+
+func (m *ExistingSchemaChangeLeaseError) Reset()         { *m = ExistingSchemaChangeLeaseError{} }
+func (m *ExistingSchemaChangeLeaseError) String() string { return proto.CompactTextString(m) }
+func (*ExistingSchemaChangeLeaseError) ProtoMessage()    {}
+
 // ErrorDetail is a union type containing all available errors.
 type ErrorDetail struct {
 	NotLeader                     *NotLeaderError                     `protobuf:"bytes,1,opt,name=not_leader" json:"not_leader,omitempty"`
@@ -266,6 +317,14 @@ type ErrorDetail struct {
 	LeaseRejected                 *LeaseRejectedError                 `protobuf:"bytes,13,opt,name=lease_rejected" json:"lease_rejected,omitempty"`
 	NodeUnavailable               *NodeUnavailableError               `protobuf:"bytes,14,opt,name=node_unavailable" json:"node_unavailable,omitempty"`
 	Send                          *SendError                          `protobuf:"bytes,15,opt,name=send" json:"send,omitempty"`
+	// TODO(kaneda): Following are added to preserve the type when
+	// converting Go errors from/to proto Errors. Revisit this design.
+	RaftGroupDeleted          *RaftGroupDeletedError          `protobuf:"bytes,16,opt,name=raft_group_deleted" json:"raft_group_deleted,omitempty"`
+	ReplicaCorruption         *ReplicaCorruptionError         `protobuf:"bytes,17,opt,name=replica_corruption" json:"replica_corruption,omitempty"`
+	LeaseVersionChanged       *LeaseVersionChangedError       `protobuf:"bytes,18,opt,name=lease_version_changed" json:"lease_version_changed,omitempty"`
+	DidntUpdateDescriptor     *DidntUpdateDescriptorError     `protobuf:"bytes,19,opt,name=didnt_update_descriptor" json:"didnt_update_descriptor,omitempty"`
+	SqlTranasctionAborted     *SqlTransactionAbortedError     `protobuf:"bytes,20,opt,name=sql_tranasction_aborted" json:"sql_tranasction_aborted,omitempty"`
+	ExistingSchemeChangeLease *ExistingSchemaChangeLeaseError `protobuf:"bytes,21,opt,name=existing_scheme_change_lease" json:"existing_scheme_change_lease,omitempty"`
 }
 
 func (m *ErrorDetail) Reset()         { *m = ErrorDetail{} }
@@ -294,9 +353,14 @@ type Error struct {
 	// If transaction_restart is not ABORT, the error condition may be handled by
 	// restarting the transaction (with or without a backoff).
 	TransactionRestart TransactionRestart `protobuf:"varint,3,opt,name=transaction_restart,enum=cockroach.roachpb.TransactionRestart" json:"transaction_restart"`
+	// Transaction where the error is generated.
+	Txn *Transaction `protobuf:"bytes,4,opt,name=txn" json:"txn,omitempty"`
 	// If an ErrorDetail is present, it may contain additional structured data
 	// about the error.
-	Detail *ErrorDetail `protobuf:"bytes,4,opt,name=detail" json:"detail,omitempty"`
+	Detail *ErrorDetail `protobuf:"bytes,5,opt,name=detail" json:"detail,omitempty"`
+	// The index, if given, contains the index of the request (in the batch)
+	// whose execution caused the error.
+	Index *ErrPosition `protobuf:"bytes,6,opt,name=index" json:"index,omitempty"`
 }
 
 func (m *Error) Reset()      { *m = Error{} }
@@ -318,6 +382,12 @@ func init() {
 	proto.RegisterType((*ConditionFailedError)(nil), "cockroach.roachpb.ConditionFailedError")
 	proto.RegisterType((*LeaseRejectedError)(nil), "cockroach.roachpb.LeaseRejectedError")
 	proto.RegisterType((*SendError)(nil), "cockroach.roachpb.SendError")
+	proto.RegisterType((*RaftGroupDeletedError)(nil), "cockroach.roachpb.RaftGroupDeletedError")
+	proto.RegisterType((*ReplicaCorruptionError)(nil), "cockroach.roachpb.ReplicaCorruptionError")
+	proto.RegisterType((*LeaseVersionChangedError)(nil), "cockroach.roachpb.LeaseVersionChangedError")
+	proto.RegisterType((*DidntUpdateDescriptorError)(nil), "cockroach.roachpb.DidntUpdateDescriptorError")
+	proto.RegisterType((*SqlTransactionAbortedError)(nil), "cockroach.roachpb.SqlTransactionAbortedError")
+	proto.RegisterType((*ExistingSchemaChangeLeaseError)(nil), "cockroach.roachpb.ExistingSchemaChangeLeaseError")
 	proto.RegisterType((*ErrorDetail)(nil), "cockroach.roachpb.ErrorDetail")
 	proto.RegisterType((*ErrPosition)(nil), "cockroach.roachpb.ErrPosition")
 	proto.RegisterType((*Error)(nil), "cockroach.roachpb.Error")
@@ -641,16 +711,6 @@ func (m *WriteIntentError) MarshalTo(data []byte) (int, error) {
 		data[i] = 0
 	}
 	i++
-	if m.Index != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintErrors(data, i, uint64(m.Index.Size()))
-		n12, err := m.Index.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n12
-	}
 	return i, nil
 }
 
@@ -672,19 +732,19 @@ func (m *WriteTooOldError) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Timestamp.Size()))
-	n13, err := m.Timestamp.MarshalTo(data[i:])
+	n12, err := m.Timestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n12
+	data[i] = 0x12
+	i++
+	i = encodeVarintErrors(data, i, uint64(m.ExistingTimestamp.Size()))
+	n13, err := m.ExistingTimestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n13
-	data[i] = 0x12
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.ExistingTimestamp.Size()))
-	n14, err := m.ExistingTimestamp.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n14
 	return i, nil
 }
 
@@ -725,21 +785,11 @@ func (m *ConditionFailedError) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ActualValue.Size()))
-		n15, err := m.ActualValue.MarshalTo(data[i:])
+		n14, err := m.ActualValue.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n15
-	}
-	if m.Index != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintErrors(data, i, uint64(m.Index.Size()))
-		n16, err := m.Index.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n16
+		i += n14
 	}
 	return i, nil
 }
@@ -766,19 +816,19 @@ func (m *LeaseRejectedError) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Requested.Size()))
-	n17, err := m.Requested.MarshalTo(data[i:])
+	n15, err := m.Requested.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n17
+	i += n15
 	data[i] = 0x1a
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Existing.Size()))
-	n18, err := m.Existing.MarshalTo(data[i:])
+	n16, err := m.Existing.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n18
+	i += n16
 	return i, nil
 }
 
@@ -812,6 +862,126 @@ func (m *SendError) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
+func (m *RaftGroupDeletedError) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *RaftGroupDeletedError) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *ReplicaCorruptionError) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ReplicaCorruptionError) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintErrors(data, i, uint64(len(m.ErrorMsg)))
+	i += copy(data[i:], m.ErrorMsg)
+	data[i] = 0x10
+	i++
+	if m.Processed {
+		data[i] = 1
+	} else {
+		data[i] = 0
+	}
+	i++
+	return i, nil
+}
+
+func (m *LeaseVersionChangedError) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *LeaseVersionChangedError) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *DidntUpdateDescriptorError) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *DidntUpdateDescriptorError) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *SqlTransactionAbortedError) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *SqlTransactionAbortedError) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *ExistingSchemaChangeLeaseError) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ExistingSchemaChangeLeaseError) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
 func (m *ErrorDetail) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -831,151 +1001,223 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.NotLeader.Size()))
-		n19, err := m.NotLeader.MarshalTo(data[i:])
+		n17, err := m.NotLeader.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n19
+		i += n17
 	}
 	if m.RangeNotFound != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.RangeNotFound.Size()))
-		n20, err := m.RangeNotFound.MarshalTo(data[i:])
+		n18, err := m.RangeNotFound.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n20
+		i += n18
 	}
 	if m.RangeKeyMismatch != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.RangeKeyMismatch.Size()))
-		n21, err := m.RangeKeyMismatch.MarshalTo(data[i:])
+		n19, err := m.RangeKeyMismatch.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n21
+		i += n19
 	}
 	if m.ReadWithinUncertaintyInterval != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ReadWithinUncertaintyInterval.Size()))
-		n22, err := m.ReadWithinUncertaintyInterval.MarshalTo(data[i:])
+		n20, err := m.ReadWithinUncertaintyInterval.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n22
+		i += n20
 	}
 	if m.TransactionAborted != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionAborted.Size()))
-		n23, err := m.TransactionAborted.MarshalTo(data[i:])
+		n21, err := m.TransactionAborted.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n23
+		i += n21
 	}
 	if m.TransactionPush != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionPush.Size()))
-		n24, err := m.TransactionPush.MarshalTo(data[i:])
+		n22, err := m.TransactionPush.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n24
+		i += n22
 	}
 	if m.TransactionRetry != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionRetry.Size()))
-		n25, err := m.TransactionRetry.MarshalTo(data[i:])
+		n23, err := m.TransactionRetry.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n25
+		i += n23
 	}
 	if m.TransactionStatus != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionStatus.Size()))
-		n26, err := m.TransactionStatus.MarshalTo(data[i:])
+		n24, err := m.TransactionStatus.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n26
+		i += n24
 	}
 	if m.WriteIntent != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.WriteIntent.Size()))
-		n27, err := m.WriteIntent.MarshalTo(data[i:])
+		n25, err := m.WriteIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n27
+		i += n25
 	}
 	if m.WriteTooOld != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.WriteTooOld.Size()))
-		n28, err := m.WriteTooOld.MarshalTo(data[i:])
+		n26, err := m.WriteTooOld.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n28
+		i += n26
 	}
 	if m.OpRequiresTxn != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.OpRequiresTxn.Size()))
-		n29, err := m.OpRequiresTxn.MarshalTo(data[i:])
+		n27, err := m.OpRequiresTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n29
+		i += n27
 	}
 	if m.ConditionFailed != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ConditionFailed.Size()))
-		n30, err := m.ConditionFailed.MarshalTo(data[i:])
+		n28, err := m.ConditionFailed.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n30
+		i += n28
 	}
 	if m.LeaseRejected != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.LeaseRejected.Size()))
-		n31, err := m.LeaseRejected.MarshalTo(data[i:])
+		n29, err := m.LeaseRejected.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n31
+		i += n29
 	}
 	if m.NodeUnavailable != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.NodeUnavailable.Size()))
-		n32, err := m.NodeUnavailable.MarshalTo(data[i:])
+		n30, err := m.NodeUnavailable.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n32
+		i += n30
 	}
 	if m.Send != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Send.Size()))
-		n33, err := m.Send.MarshalTo(data[i:])
+		n31, err := m.Send.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n31
+	}
+	if m.RaftGroupDeleted != nil {
+		data[i] = 0x82
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.RaftGroupDeleted.Size()))
+		n32, err := m.RaftGroupDeleted.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n32
+	}
+	if m.ReplicaCorruption != nil {
+		data[i] = 0x8a
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.ReplicaCorruption.Size()))
+		n33, err := m.ReplicaCorruption.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n33
+	}
+	if m.LeaseVersionChanged != nil {
+		data[i] = 0x92
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.LeaseVersionChanged.Size()))
+		n34, err := m.LeaseVersionChanged.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n34
+	}
+	if m.DidntUpdateDescriptor != nil {
+		data[i] = 0x9a
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.DidntUpdateDescriptor.Size()))
+		n35, err := m.DidntUpdateDescriptor.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n35
+	}
+	if m.SqlTranasctionAborted != nil {
+		data[i] = 0xa2
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.SqlTranasctionAborted.Size()))
+		n36, err := m.SqlTranasctionAborted.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n36
+	}
+	if m.ExistingSchemeChangeLease != nil {
+		data[i] = 0xaa
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.ExistingSchemeChangeLease.Size()))
+		n37, err := m.ExistingSchemeChangeLease.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n37
 	}
 	return i, nil
 }
@@ -1031,15 +1273,35 @@ func (m *Error) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x18
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.TransactionRestart))
-	if m.Detail != nil {
+	if m.Txn != nil {
 		data[i] = 0x22
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.Detail.Size()))
-		n34, err := m.Detail.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
+		n38, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n34
+		i += n38
+	}
+	if m.Detail != nil {
+		data[i] = 0x2a
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.Detail.Size()))
+		n39, err := m.Detail.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n39
+	}
+	if m.Index != nil {
+		data[i] = 0x32
+		i++
+		i = encodeVarintErrors(data, i, uint64(m.Index.Size()))
+		n40, err := m.Index.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n40
 	}
 	return i, nil
 }
@@ -1178,10 +1440,6 @@ func (m *WriteIntentError) Size() (n int) {
 		}
 	}
 	n += 2
-	if m.Index != nil {
-		l = m.Index.Size()
-		n += 1 + l + sovErrors(uint64(l))
-	}
 	return n
 }
 
@@ -1208,10 +1466,6 @@ func (m *ConditionFailedError) Size() (n int) {
 		l = m.ActualValue.Size()
 		n += 1 + l + sovErrors(uint64(l))
 	}
-	if m.Index != nil {
-		l = m.Index.Size()
-		n += 1 + l + sovErrors(uint64(l))
-	}
 	return n
 }
 
@@ -1233,6 +1487,45 @@ func (m *SendError) Size() (n int) {
 	l = len(m.Message)
 	n += 1 + l + sovErrors(uint64(l))
 	n += 2
+	return n
+}
+
+func (m *RaftGroupDeletedError) Size() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *ReplicaCorruptionError) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.ErrorMsg)
+	n += 1 + l + sovErrors(uint64(l))
+	n += 2
+	return n
+}
+
+func (m *LeaseVersionChangedError) Size() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *DidntUpdateDescriptorError) Size() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *SqlTransactionAbortedError) Size() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *ExistingSchemaChangeLeaseError) Size() (n int) {
+	var l int
+	_ = l
 	return n
 }
 
@@ -1299,6 +1592,30 @@ func (m *ErrorDetail) Size() (n int) {
 		l = m.Send.Size()
 		n += 1 + l + sovErrors(uint64(l))
 	}
+	if m.RaftGroupDeleted != nil {
+		l = m.RaftGroupDeleted.Size()
+		n += 2 + l + sovErrors(uint64(l))
+	}
+	if m.ReplicaCorruption != nil {
+		l = m.ReplicaCorruption.Size()
+		n += 2 + l + sovErrors(uint64(l))
+	}
+	if m.LeaseVersionChanged != nil {
+		l = m.LeaseVersionChanged.Size()
+		n += 2 + l + sovErrors(uint64(l))
+	}
+	if m.DidntUpdateDescriptor != nil {
+		l = m.DidntUpdateDescriptor.Size()
+		n += 2 + l + sovErrors(uint64(l))
+	}
+	if m.SqlTranasctionAborted != nil {
+		l = m.SqlTranasctionAborted.Size()
+		n += 2 + l + sovErrors(uint64(l))
+	}
+	if m.ExistingSchemeChangeLease != nil {
+		l = m.ExistingSchemeChangeLease.Size()
+		n += 2 + l + sovErrors(uint64(l))
+	}
 	return n
 }
 
@@ -1316,8 +1633,16 @@ func (m *Error) Size() (n int) {
 	n += 1 + l + sovErrors(uint64(l))
 	n += 2
 	n += 1 + sovErrors(uint64(m.TransactionRestart))
+	if m.Txn != nil {
+		l = m.Txn.Size()
+		n += 1 + l + sovErrors(uint64(l))
+	}
 	if m.Detail != nil {
 		l = m.Detail.Size()
+		n += 1 + l + sovErrors(uint64(l))
+	}
+	if m.Index != nil {
+		l = m.Index.Size()
 		n += 1 + l + sovErrors(uint64(l))
 	}
 	return n
@@ -1382,6 +1707,24 @@ func (this *ErrorDetail) GetValue() interface{} {
 	if this.Send != nil {
 		return this.Send
 	}
+	if this.RaftGroupDeleted != nil {
+		return this.RaftGroupDeleted
+	}
+	if this.ReplicaCorruption != nil {
+		return this.ReplicaCorruption
+	}
+	if this.LeaseVersionChanged != nil {
+		return this.LeaseVersionChanged
+	}
+	if this.DidntUpdateDescriptor != nil {
+		return this.DidntUpdateDescriptor
+	}
+	if this.SqlTranasctionAborted != nil {
+		return this.SqlTranasctionAborted
+	}
+	if this.ExistingSchemeChangeLease != nil {
+		return this.ExistingSchemeChangeLease
+	}
 	return nil
 }
 
@@ -1417,6 +1760,18 @@ func (this *ErrorDetail) SetValue(value interface{}) bool {
 		this.NodeUnavailable = vt
 	case *SendError:
 		this.Send = vt
+	case *RaftGroupDeletedError:
+		this.RaftGroupDeleted = vt
+	case *ReplicaCorruptionError:
+		this.ReplicaCorruption = vt
+	case *LeaseVersionChangedError:
+		this.LeaseVersionChanged = vt
+	case *DidntUpdateDescriptorError:
+		this.DidntUpdateDescriptor = vt
+	case *SqlTransactionAbortedError:
+		this.SqlTranasctionAborted = vt
+	case *ExistingSchemaChangeLeaseError:
+		this.ExistingSchemeChangeLease = vt
 	default:
 		return false
 	}
@@ -2436,39 +2791,6 @@ func (m *WriteIntentError) Unmarshal(data []byte) error {
 				}
 			}
 			m.Resolved = bool(v != 0)
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Index", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowErrors
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthErrors
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.Index == nil {
-				m.Index = &ErrPosition{}
-			}
-			if err := m.Index.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipErrors(data[iNdEx:])
@@ -2712,39 +3034,6 @@ func (m *ConditionFailedError) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Index", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowErrors
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthErrors
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.Index == nil {
-				m.Index = &ErrPosition{}
-			}
-			if err := m.Index.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipErrors(data[iNdEx:])
@@ -2983,6 +3272,355 @@ func (m *SendError) Unmarshal(data []byte) error {
 				}
 			}
 			m.Retryable = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := skipErrors(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthErrors
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RaftGroupDeletedError) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowErrors
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RaftGroupDeletedError: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RaftGroupDeletedError: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipErrors(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthErrors
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ReplicaCorruptionError) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowErrors
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ReplicaCorruptionError: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ReplicaCorruptionError: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ErrorMsg", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowErrors
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthErrors
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ErrorMsg = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Processed", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowErrors
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Processed = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := skipErrors(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthErrors
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *LeaseVersionChangedError) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowErrors
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: LeaseVersionChangedError: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: LeaseVersionChangedError: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipErrors(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthErrors
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DidntUpdateDescriptorError) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowErrors
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DidntUpdateDescriptorError: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DidntUpdateDescriptorError: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipErrors(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthErrors
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SqlTransactionAbortedError) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowErrors
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SqlTransactionAbortedError: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SqlTransactionAbortedError: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipErrors(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthErrors
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ExistingSchemaChangeLeaseError) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowErrors
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ExistingSchemaChangeLeaseError: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ExistingSchemaChangeLeaseError: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
 		default:
 			iNdEx = preIndex
 			skippy, err := skipErrors(data[iNdEx:])
@@ -3528,6 +4166,204 @@ func (m *ErrorDetail) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 16:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RaftGroupDeleted", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowErrors
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthErrors
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RaftGroupDeleted == nil {
+				m.RaftGroupDeleted = &RaftGroupDeletedError{}
+			}
+			if err := m.RaftGroupDeleted.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 17:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReplicaCorruption", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowErrors
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthErrors
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ReplicaCorruption == nil {
+				m.ReplicaCorruption = &ReplicaCorruptionError{}
+			}
+			if err := m.ReplicaCorruption.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 18:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LeaseVersionChanged", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowErrors
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthErrors
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LeaseVersionChanged == nil {
+				m.LeaseVersionChanged = &LeaseVersionChangedError{}
+			}
+			if err := m.LeaseVersionChanged.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 19:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DidntUpdateDescriptor", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowErrors
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthErrors
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DidntUpdateDescriptor == nil {
+				m.DidntUpdateDescriptor = &DidntUpdateDescriptorError{}
+			}
+			if err := m.DidntUpdateDescriptor.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 20:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SqlTranasctionAborted", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowErrors
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthErrors
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.SqlTranasctionAborted == nil {
+				m.SqlTranasctionAborted = &SqlTransactionAbortedError{}
+			}
+			if err := m.SqlTranasctionAborted.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 21:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExistingSchemeChangeLease", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowErrors
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthErrors
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ExistingSchemeChangeLease == nil {
+				m.ExistingSchemeChangeLease = &ExistingSchemaChangeLeaseError{}
+			}
+			if err := m.ExistingSchemeChangeLease.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipErrors(data[iNdEx:])
@@ -3717,6 +4553,39 @@ func (m *Error) Unmarshal(data []byte) error {
 			}
 		case 4:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Txn", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowErrors
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthErrors
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Txn == nil {
+				m.Txn = &Transaction{}
+			}
+			if err := m.Txn.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Detail", wireType)
 			}
 			var msglen int
@@ -3745,6 +4614,39 @@ func (m *Error) Unmarshal(data []byte) error {
 				m.Detail = &ErrorDetail{}
 			}
 			if err := m.Detail.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Index", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowErrors
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthErrors
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Index == nil {
+				m.Index = &ErrPosition{}
+			}
+			if err := m.Index.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/roachpb/errors.proto
+++ b/roachpb/errors.proto
@@ -114,9 +114,6 @@ message TransactionStatusError {
 message WriteIntentError {
   repeated Intent intents = 1 [(gogoproto.nullable) = false];
   optional bool resolved = 2 [(gogoproto.nullable) = false];
-  // The index, if given, contains the index of the request (in the batch)
-  // whose execution caused the error.
-  optional ErrPosition index = 3;
 }
 
 // A WriteTooOldError indicates that a write encountered a versioned
@@ -140,7 +137,6 @@ message OpRequiresTxnError {
 // contain the actual value found.
 message ConditionFailedError {
   optional Value actual_value = 1;
-  optional ErrPosition index = 2;
 }
 
 // A LeaseRejectedError indicates that the requested replica could
@@ -156,6 +152,37 @@ message LeaseRejectedError {
 message SendError {
   optional string message = 1 [(gogoproto.nullable) = false];
   optional bool retryable = 2 [(gogoproto.nullable) = false];
+}
+
+// A RaftGroupDeletedError indicates a raft group has been deleted for
+// the replica.
+message RaftGroupDeletedError {
+}
+
+// A ReplicaCorruptionError indicates that the replica has experienced
+// an error which puts its integrity at risk.
+message ReplicaCorruptionError {
+  optional string error_msg = 1 [(gogoproto.nullable) = false];;
+  // processed indicates that the error has been taken into account and
+  // necessary steps will be taken. For now, required for testing.
+  optional bool processed = 2 [(gogoproto.nullable) = false];;
+}
+
+// A LeaseVersionChangedError indicates that the lease version has changed.
+message LeaseVersionChangedError {
+}
+
+// A DidntUpdateDescriptorError indicates that a table descriptor was not updated.
+message DidntUpdateDescriptorError {
+}
+
+// An SqlTransactionAbortedError indicates that a current transaction is aborted.
+message SqlTransactionAbortedError {
+}
+
+// An ExistingSchemaChangeLeaseError indicates that an outstanding
+// schema change lease exists.
+message ExistingSchemaChangeLeaseError {
 }
 
 // ErrorDetail is a union type containing all available errors.
@@ -177,6 +204,15 @@ message ErrorDetail {
   optional LeaseRejectedError lease_rejected = 13;
   optional NodeUnavailableError node_unavailable = 14;
   optional SendError send = 15;
+
+  // TODO(kaneda): Following are added to preserve the type when
+  // converting Go errors from/to proto Errors. Revisit this design.
+  optional RaftGroupDeletedError raft_group_deleted = 16;
+  optional ReplicaCorruptionError replica_corruption = 17;
+  optional LeaseVersionChangedError lease_version_changed = 18;
+  optional DidntUpdateDescriptorError didnt_update_descriptor = 19;
+  optional SqlTransactionAbortedError sql_tranasction_aborted = 20;
+  optional ExistingSchemaChangeLeaseError existing_scheme_change_lease = 21;
 }
 
 // TransactionRestart indicates how an error should be handled in a
@@ -218,7 +254,14 @@ message Error {
   // restarting the transaction (with or without a backoff).
   optional TransactionRestart transaction_restart = 3 [(gogoproto.nullable) = false];
 
+  // Transaction where the error is generated.
+  optional Transaction txn = 4;
+
   // If an ErrorDetail is present, it may contain additional structured data
   // about the error.
-  optional ErrorDetail detail = 4;
+  optional ErrorDetail detail = 5;
+
+  // The index, if given, contains the index of the request (in the batch)
+  // whose execution caused the error.
+  optional ErrPosition index = 6;
 }

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -113,7 +113,7 @@ func TestIntentResolution(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := s.db.Txn(func(txn *client.Txn) error {
+			if pErr := s.db.Txn(func(txn *client.Txn) *roachpb.Error {
 				b := txn.NewBatch()
 				for _, key := range tc.keys {
 					b.Put(key, "test")
@@ -122,8 +122,8 @@ func TestIntentResolution(t *testing.T) {
 					b.DelRange(kr[0], kr[1])
 				}
 				return txn.CommitInBatch(b)
-			}); err != nil {
-				t.Fatalf("%d: %s", i, err)
+			}); pErr != nil {
+				t.Fatalf("%d: %s", i, pErr)
 			}
 			<-closer // wait for async intents
 		}()

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -126,9 +126,9 @@ func TestBootstrapCluster(t *testing.T) {
 	defer stopper.Stop()
 
 	// Scan the complete contents of the local database.
-	rows, err := localDB.Scan(keys.LocalMax, roachpb.KeyMax, 0)
-	if err != nil {
-		t.Fatal(err)
+	rows, pErr := localDB.Scan(keys.LocalMax, roachpb.KeyMax, 0)
+	if pErr != nil {
+		t.Fatal(pErr.GoError())
 	}
 	var foundKeys keySlice
 	for _, kv := range rows {
@@ -439,9 +439,9 @@ func TestStatusSummaries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	storeDesc, err := s.Descriptor()
-	if err != nil {
-		t.Fatal(err)
+	storeDesc, pErr := s.Descriptor()
+	if pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Wait for full replication of initial ranges.

--- a/server/server.go
+++ b/server/server.go
@@ -309,8 +309,8 @@ func (s *Server) writeSummaries() error {
 	nodeStatus, storeStatuses := s.recorder.GetStatusSummaries()
 	if nodeStatus != nil {
 		key := keys.NodeStatusKey(int32(nodeStatus.Desc.NodeID))
-		if err := s.db.Put(key, nodeStatus); err != nil {
-			return err
+		if pErr := s.db.Put(key, nodeStatus); pErr != nil {
+			return pErr.GoError()
 		}
 		if log.V(1) {
 			statusJSON, err := json.Marshal(nodeStatus)
@@ -323,8 +323,8 @@ func (s *Server) writeSummaries() error {
 
 	for _, ss := range storeStatuses {
 		key := keys.StoreStatusKey(int32(ss.Desc.StoreID))
-		if err := s.db.Put(key, &ss); err != nil {
-			return err
+		if pErr := s.db.Put(key, &ss); pErr != nil {
+			return pErr.GoError()
 		}
 		if log.V(1) {
 			statusJSON, err := json.Marshal(&ss)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -520,18 +520,18 @@ func TestSystemConfigGossip(t *testing.T) {
 	}
 
 	// Now do it as part of a transaction, but without the trigger set.
-	if err := db.Txn(func(txn *client.Txn) error {
+	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		return txn.Put(key, valAt(1))
-	}); err != nil {
-		t.Fatal(err)
+	}); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// This time mark the transaction as having a Gossip trigger.
-	if err := db.Txn(func(txn *client.Txn) error {
+	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		txn.SetSystemConfigTrigger()
 		return txn.Put(key, valAt(2))
-	}); err != nil {
-		t.Fatal(err)
+	}); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Wait for the callback.

--- a/server/status.go
+++ b/server/status.go
@@ -513,19 +513,19 @@ func (s *statusServer) handleNodesStatus(w http.ResponseWriter, r *http.Request,
 	startKey := keys.StatusNodePrefix
 	endKey := startKey.PrefixEnd()
 
-	rows, err := s.db.Scan(startKey, endKey, 0)
-	if err != nil {
-		log.Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	rows, pErr := s.db.Scan(startKey, endKey, 0)
+	if pErr != nil {
+		log.Error(pErr)
+		http.Error(w, pErr.GoError().Error(), http.StatusInternalServerError)
 		return
 	}
 
 	nodeStatuses := []status.NodeStatus{}
 	for _, row := range rows {
 		nodeStatus := &status.NodeStatus{}
-		if err := row.ValueProto(nodeStatus); err != nil {
-			log.Error(err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		if pErr := row.ValueProto(nodeStatus); pErr != nil {
+			log.Error(pErr)
+			http.Error(w, pErr.Error(), http.StatusInternalServerError)
 			return
 		}
 		nodeStatuses = append(nodeStatuses, *nodeStatus)
@@ -543,9 +543,9 @@ func (s *statusServer) handleNodeStatus(w http.ResponseWriter, r *http.Request, 
 
 	key := keys.NodeStatusKey(int32(nodeID))
 	nodeStatus := &status.NodeStatus{}
-	if err = s.db.GetProto(key, nodeStatus); err != nil {
-		log.Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	if pErr := s.db.GetProto(key, nodeStatus); pErr != nil {
+		log.Error(pErr)
+		http.Error(w, pErr.GoError().Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -557,10 +557,10 @@ func (s *statusServer) handleStoresStatus(w http.ResponseWriter, r *http.Request
 	startKey := keys.StatusStorePrefix
 	endKey := startKey.PrefixEnd()
 
-	rows, err := s.db.Scan(startKey, endKey, 0)
-	if err != nil {
-		log.Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	rows, pErr := s.db.Scan(startKey, endKey, 0)
+	if pErr != nil {
+		log.Error(pErr)
+		http.Error(w, pErr.GoError().Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -590,9 +590,9 @@ func (s *statusServer) handleStoreStatus(w http.ResponseWriter, r *http.Request,
 
 	key := keys.StoreStatusKey(int32(id))
 	storeStatus := &storage.StoreStatus{}
-	if err := s.db.GetProto(key, storeStatus); err != nil {
-		log.Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	if pErr := s.db.GetProto(key, storeStatus); pErr != nil {
+		log.Error(pErr)
+		http.Error(w, pErr.GoError().Error(), http.StatusInternalServerError)
 		return
 	}
 	respondAsJSON(w, r, storeStatus)

--- a/server/status/feed.go
+++ b/server/status/feed.go
@@ -92,10 +92,8 @@ func (nef NodeEventFeed) StartNode(desc roachpb.NodeDescriptor, startedAt int64)
 func (nef NodeEventFeed) CallComplete(ba roachpb.BatchRequest, d time.Duration, pErr *roachpb.Error) {
 	if pErr != nil && pErr.TransactionRestart == roachpb.TransactionRestart_ABORT {
 		method := roachpb.Batch
-		if iErr, ok := pErr.GoError().(roachpb.IndexedError); ok {
-			if index, ok := iErr.ErrorIndex(); ok {
-				method = ba.Requests[index].GetInner().Method()
-			}
+		if pErr.Index != nil {
+			method = ba.Requests[pErr.Index.Index].GetInner().Method()
 		}
 		nef.f.Publish(&CallErrorEvent{
 			NodeID:   nef.id,

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -520,9 +520,9 @@ func TestStoreStatusResponse(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		desc, err := store.Descriptor()
-		if err != nil {
-			t.Fatal(err)
+		desc, pErr := store.Descriptor()
+		if pErr != nil {
+			t.Fatal(pErr)
 		}
 		// The capacities fluctuate a lot, so drop them for the deep equal.
 		desc.Capacity = roachpb.StoreCapacity{}
@@ -559,7 +559,7 @@ func TestMetricsRecording(t *testing.T) {
 	checkTimeSeriesKey := func(now int64, keyName string) error {
 		key := ts.MakeDataKey(keyName, "", ts.Resolution10s, now)
 		data := roachpb.InternalTimeSeriesData{}
-		return tsrv.db.GetProto(key, &data)
+		return tsrv.db.GetProto(key, &data).GoError()
 	}
 
 	// Verify that metrics for the current timestamp are recorded. This should

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -243,9 +243,9 @@ func (ts *TestServer) WaitForInitialSplits() error {
 	expectedRanges := ExpectedInitialRangeCount()
 	return util.RetryForDuration(initialSplitsTimeout, func() error {
 		// Scan all keys in the Meta2Prefix; we only need a count.
-		rows, err := kvDB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
-		if err != nil {
-			return err
+		rows, pErr := kvDB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+		if pErr != nil {
+			return pErr.GoError()
 		}
 		if a, e := len(rows), expectedRanges; a != e {
 			return util.Errorf("had %d ranges at startup, expected %d", a, e)

--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -68,9 +68,9 @@ func parseAndNormalizeExpr(t *testing.T, sql string) (parser.Expr, qvalMap) {
 		t.Fatal(err)
 	}
 
-	expr, err = s.resolveQNames(expr)
-	if err != nil {
-		t.Fatalf("%s: %v", sql, err)
+	expr, nErr := s.resolveQNames(expr)
+	if nErr != nil {
+		t.Fatalf("%s: %v", sql, nErr)
 	}
 	if _, err := expr.TypeCheck(nil); err != nil {
 		t.Fatalf("%s: %v", sql, err)

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -27,13 +27,13 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-func makeColIDtoRowIndex(row planNode, desc *TableDescriptor) (map[ColumnID]int, error) {
+func makeColIDtoRowIndex(row planNode, desc *TableDescriptor) (map[ColumnID]int, *roachpb.Error) {
 	columns := row.Columns()
 	colIDtoRowIndex := make(map[ColumnID]int, len(columns))
 	for i, column := range columns {
-		col, err := desc.FindActiveColumnByName(column.name)
-		if err != nil {
-			return nil, err
+		col, pErr := desc.FindActiveColumnByName(column.name)
+		if pErr != nil {
+			return nil, pErr
 		}
 		colIDtoRowIndex[col.ID] = i
 	}
@@ -67,7 +67,7 @@ func (ids indexesByID) Swap(i, j int) {
 	ids[i], ids[j] = ids[j], ids[i]
 }
 
-func (p *planner) backfillBatch(b *client.Batch, oldTableDesc *TableDescriptor, mutationID MutationID) error {
+func (p *planner) backfillBatch(b *client.Batch, oldTableDesc *TableDescriptor, mutationID MutationID) *roachpb.Error {
 	var droppedColumnDescs []ColumnDescriptor
 	var droppedIndexDescs []IndexDescriptor
 	var newIndexDescs []IndexDescriptor
@@ -114,8 +114,8 @@ func (p *planner) backfillBatch(b *client.Batch, oldTableDesc *TableDescriptor, 
 		// Use a different batch to perform the scan.
 		batch := &client.Batch{}
 		batch.Scan(start, start.PrefixEnd(), 0)
-		if err := p.txn.Run(batch); err != nil {
-			return err
+		if pErr := p.txn.Run(batch); pErr != nil {
+			return pErr
 		}
 		for _, result := range batch.Results {
 			var sentinelKey roachpb.Key
@@ -164,26 +164,26 @@ func (p *planner) backfillBatch(b *client.Batch, oldTableDesc *TableDescriptor, 
 			desc:    oldTableDesc,
 		}
 		scan.initDescDefaults()
-		rows, err := p.initScanNode(scan, &parser.Select{Exprs: oldTableDesc.allColumnsSelector()})
-		if err != nil {
-			return err
+		rows, pErr := p.initScanNode(scan, &parser.Select{Exprs: oldTableDesc.allColumnsSelector()})
+		if pErr != nil {
+			return pErr
 		}
 
 		// Construct a map from column ID to the index the value appears at within a
 		// row.
-		colIDtoRowIndex, err := makeColIDtoRowIndex(rows, oldTableDesc)
-		if err != nil {
-			return err
+		colIDtoRowIndex, pErr := makeColIDtoRowIndex(rows, oldTableDesc)
+		if pErr != nil {
+			return pErr
 		}
 
 		for rows.Next() {
 			rowVals := rows.Values()
 
 			for _, newIndexDesc := range newIndexDescs {
-				secondaryIndexEntries, err := encodeSecondaryIndexes(
+				secondaryIndexEntries, pErr := encodeSecondaryIndexes(
 					oldTableDesc.ID, []IndexDescriptor{newIndexDesc}, colIDtoRowIndex, rowVals)
-				if err != nil {
-					return err
+				if pErr != nil {
+					return pErr
 				}
 
 				for _, secondaryIndexEntry := range secondaryIndexEntries {
@@ -196,7 +196,7 @@ func (p *planner) backfillBatch(b *client.Batch, oldTableDesc *TableDescriptor, 
 			}
 		}
 
-		return rows.Err()
+		return rows.PErr()
 	}
 
 	return nil

--- a/sql/config_test.go
+++ b/sql/config_test.go
@@ -51,11 +51,11 @@ func forceNewConfig(t *testing.T, s *server.TestServer) (*config.SystemConfig, e
 	}
 
 	// This needs to be done in a transaction with the system trigger set.
-	if err := s.DB().Txn(func(txn *client.Txn) error {
+	if pErr := s.DB().Txn(func(txn *client.Txn) *roachpb.Error {
 		txn.SetSystemConfigTrigger()
 		return txn.Put(configDescKey, configDesc)
-	}); err != nil {
-		t.Fatal(err)
+	}); pErr != nil {
+		t.Fatal(pErr)
 	}
 	return waitForConfigChange(t, s)
 }

--- a/sql/create.go
+++ b/sql/create.go
@@ -17,8 +17,7 @@
 package sql
 
 import (
-	"fmt"
-
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
@@ -28,13 +27,13 @@ import (
 // Privileges: "root" user.
 //   Notes: postgres requires superuser or "CREATEDB".
 //          mysql uses the mysqladmin command.
-func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, error) {
+func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, *roachpb.Error) {
 	if n.Name == "" {
-		return nil, errEmptyDatabaseName
+		return nil, roachpb.NewError(errEmptyDatabaseName)
 	}
 
 	if p.user != security.RootUser {
-		return nil, fmt.Errorf("only %s is allowed to create databases", security.RootUser)
+		return nil, roachpb.NewUErrorf("only %s is allowed to create databases", security.RootUser)
 	}
 
 	desc := makeDatabaseDesc(n)
@@ -49,10 +48,10 @@ func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, error) {
 // Privileges: CREATE on table.
 //   notes: postgres requires CREATE on the table.
 //          mysql requires INDEX on the table.
-func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
-	tableDesc, err := p.getTableDesc(n.Table)
-	if err != nil {
-		return nil, err
+func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) {
+	tableDesc, pErr := p.getTableDesc(n.Table)
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	status, i, err := tableDesc.FindIndexByName(string(n.Name))
@@ -60,7 +59,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
 		if status == DescriptorIncomplete {
 			switch tableDesc.Mutations[i].Direction {
 			case DescriptorMutation_DROP:
-				return nil, fmt.Errorf("index %q being dropped, try again later", string(n.Name))
+				return nil, roachpb.NewUErrorf("index %q being dropped, try again later", string(n.Name))
 
 			case DescriptorMutation_ADD:
 				// Noop, will fail in AllocateIDs below.
@@ -72,8 +71,8 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
 		}
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
-		return nil, err
+	if pErr := p.checkPrivilege(tableDesc, privilege.CREATE); pErr != nil {
+		return nil, pErr
 	}
 
 	indexDesc := IndexDescriptor{
@@ -81,20 +80,20 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
 		Unique:           n.Unique,
 		StoreColumnNames: n.Storing,
 	}
-	if err := indexDesc.fillColumns(n.Columns); err != nil {
-		return nil, err
+	if pErr := indexDesc.fillColumns(n.Columns); pErr != nil {
+		return nil, pErr
 	}
 
 	tableDesc.addIndexMutation(indexDesc, DescriptorMutation_ADD)
 	tableDesc.UpVersion = true
 	mutationID := tableDesc.NextMutationID
 	tableDesc.NextMutationID++
-	if err := tableDesc.AllocateIDs(); err != nil {
-		return nil, err
+	if pErr := tableDesc.AllocateIDs(); pErr != nil {
+		return nil, pErr
 	}
 
-	if err := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc)); err != nil {
-		return nil, err
+	if pErr := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc)); pErr != nil {
+		return nil, pErr
 	}
 	p.notifySchemaChange(tableDesc.ID, mutationID)
 
@@ -104,23 +103,23 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
 // CreateTable creates a table.
 // Privileges: CREATE on database.
 //   Notes: postgres/mysql require CREATE on database.
-func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
+func (p *planner) CreateTable(n *parser.CreateTable) (planNode, *roachpb.Error) {
 	if err := n.Table.NormalizeTableName(p.session.Database); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 
-	dbDesc, err := p.getDatabaseDesc(n.Table.Database())
-	if err != nil {
-		return nil, err
+	dbDesc, pErr := p.getDatabaseDesc(n.Table.Database())
+	if pErr != nil {
+		return nil, pErr
 	}
 
-	if err := p.checkPrivilege(dbDesc, privilege.CREATE); err != nil {
-		return nil, err
+	if pErr := p.checkPrivilege(dbDesc, privilege.CREATE); pErr != nil {
+		return nil, pErr
 	}
 
-	desc, err := makeTableDesc(n, dbDesc.ID)
-	if err != nil {
-		return nil, err
+	desc, pErr := makeTableDesc(n, dbDesc.ID)
+	if pErr != nil {
+		return nil, pErr
 	}
 	// Inherit permissions from the database descriptor.
 	desc.Privileges = dbDesc.GetPrivileges()
@@ -142,17 +141,17 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 			ColumnNames:      []string{col.Name},
 			ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 		}
-		if err := desc.AddIndex(idx, true); err != nil {
-			return nil, err
+		if pErr := desc.AddIndex(idx, true); pErr != nil {
+			return nil, pErr
 		}
 	}
 
-	if err := desc.AllocateIDs(); err != nil {
-		return nil, err
+	if pErr := desc.AllocateIDs(); pErr != nil {
+		return nil, pErr
 	}
 
-	if err := p.createDescriptor(tableKey{dbDesc.ID, n.Table.Table()}, &desc, n.IfNotExists); err != nil {
-		return nil, err
+	if pErr := p.createDescriptor(tableKey{dbDesc.ID, n.Table.Table()}, &desc, n.IfNotExists); pErr != nil {
+		return nil, pErr
 	}
 	return &valuesNode{}, nil
 }

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -28,32 +28,32 @@ import (
 // Privileges: DELETE and SELECT on table. We currently always use a SELECT statement.
 //   Notes: postgres requires DELETE. Also requires SELECT for "USING" and "WHERE" with tables.
 //          mysql requires DELETE. Also requires SELECT if a table is used in the "WHERE" clause.
-func (p *planner) Delete(n *parser.Delete) (planNode, error) {
-	tableDesc, err := p.getAliasedTableLease(n.Table)
-	if err != nil {
-		return nil, err
+func (p *planner) Delete(n *parser.Delete) (planNode, *roachpb.Error) {
+	tableDesc, pErr := p.getAliasedTableLease(n.Table)
+	if pErr != nil {
+		return nil, pErr
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.DELETE); err != nil {
-		return nil, err
+	if pErr := p.checkPrivilege(tableDesc, privilege.DELETE); pErr != nil {
+		return nil, pErr
 	}
 
 	// TODO(tamird,pmattis): avoid going through Select to avoid encoding
 	// and decoding keys.
-	rows, err := p.Select(&parser.Select{
+	rows, pErr := p.Select(&parser.Select{
 		Exprs: tableDesc.allColumnsSelector(),
 		From:  parser.TableExprs{n.Table},
 		Where: n.Where,
 	})
-	if err != nil {
-		return nil, err
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	// Construct a map from column ID to the index the value appears at within a
 	// row.
-	colIDtoRowIndex, err := makeColIDtoRowIndex(rows, tableDesc)
-	if err != nil {
-		return nil, err
+	colIDtoRowIndex, pErr := makeColIDtoRowIndex(rows, tableDesc)
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	primaryIndex := tableDesc.PrimaryIndex
@@ -65,10 +65,10 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 		rowVals := rows.Values()
 		result.rows = append(result.rows, parser.DTuple(nil))
 
-		primaryIndexKey, _, err := encodeIndexKey(
+		primaryIndexKey, _, pErr := encodeIndexKey(
 			primaryIndex.ColumnIDs, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
-		if err != nil {
-			return nil, err
+		if pErr != nil {
+			return nil, pErr
 		}
 
 		// Delete the secondary indexes.
@@ -80,10 +80,10 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 				indexes = append(indexes, *index)
 			}
 		}
-		secondaryIndexEntries, err := encodeSecondaryIndexes(
+		secondaryIndexEntries, pErr := encodeSecondaryIndexes(
 			tableDesc.ID, indexes, colIDtoRowIndex, rowVals)
-		if err != nil {
-			return nil, err
+		if pErr != nil {
+			return nil, pErr
 		}
 
 		for _, secondaryIndexEntry := range secondaryIndexEntries {
@@ -102,16 +102,16 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 		b.DelRange(rowStartKey, rowEndKey)
 	}
 
-	if err := rows.Err(); err != nil {
-		return nil, err
+	if pErr := rows.PErr(); pErr != nil {
+		return nil, pErr
 	}
 
 	if isSystemConfigID(tableDesc.GetID()) {
 		// Mark transaction as operating on the system DB.
 		p.txn.SetSystemConfigTrigger()
 	}
-	if err := p.txn.Run(&b); err != nil {
-		return nil, err
+	if pErr := p.txn.Run(&b); pErr != nil {
+		return nil, pErr
 	}
 
 	return result, nil

--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -41,31 +41,31 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	}
 
 	dbNameKey := sql.MakeNameMetadataKey(keys.RootNamespaceID, "t")
-	r, err := kvDB.Get(dbNameKey)
-	if err != nil {
-		t.Fatal(err)
+	r, pErr := kvDB.Get(dbNameKey)
+	if pErr != nil {
+		t.Fatal(pErr.GoError())
 	}
 	if !r.Exists() {
 		t.Fatalf(`database "t" does not exist`)
 	}
 	dbDescKey := sql.MakeDescMetadataKey(sql.ID(r.ValueInt()))
 	desc := &sql.Descriptor{}
-	if err := kvDB.GetProto(dbDescKey, desc); err != nil {
-		t.Fatal(err)
+	if pErr := kvDB.GetProto(dbDescKey, desc); pErr != nil {
+		t.Fatal(pErr.GoError())
 	}
 	dbDesc := desc.GetDatabase()
 
 	tbNameKey := sql.MakeNameMetadataKey(dbDesc.ID, "kv")
-	gr, err := kvDB.Get(tbNameKey)
-	if err != nil {
-		t.Fatal(err)
+	gr, pErr := kvDB.Get(tbNameKey)
+	if pErr != nil {
+		t.Fatal(pErr.GoError())
 	}
 	if !gr.Exists() {
 		t.Fatalf(`table "kv" does not exist`)
 	}
 	tbDescKey := sql.MakeDescMetadataKey(sql.ID(gr.ValueInt()))
-	if err := kvDB.GetProto(tbDescKey, desc); err != nil {
-		t.Fatal(err)
+	if pErr := kvDB.GetProto(tbDescKey, desc); pErr != nil {
+		t.Fatal(pErr)
 	}
 	tbDesc := desc.GetTable()
 
@@ -165,9 +165,9 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	}
 
 	nameKey := sql.MakeNameMetadataKey(keys.MaxReservedDescID+1, "kv")
-	gr, err := kvDB.Get(nameKey)
-	if err != nil {
-		t.Fatal(err)
+	gr, pErr := kvDB.Get(nameKey)
+	if pErr != nil {
+		t.Fatal(pErr.GoError())
 	}
 
 	if !gr.Exists() {
@@ -176,8 +176,8 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 
 	descKey := sql.MakeDescMetadataKey(sql.ID(gr.ValueInt()))
 	desc := &sql.Descriptor{}
-	if err := kvDB.GetProto(descKey, desc); err != nil {
-		t.Fatal(err)
+	if pErr := kvDB.GetProto(descKey, desc); pErr != nil {
+		t.Fatal(pErr.GoError())
 	}
 	tableDesc := desc.GetTable()
 
@@ -231,9 +231,9 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	}
 
 	nameKey := sql.MakeNameMetadataKey(keys.MaxReservedDescID+1, "kv")
-	gr, err := kvDB.Get(nameKey)
-	if err != nil {
-		t.Fatal(err)
+	gr, pErr := kvDB.Get(nameKey)
+	if pErr != nil {
+		t.Fatal(pErr.GoError())
 	}
 
 	if !gr.Exists() {
@@ -242,8 +242,8 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 
 	descKey := sql.MakeDescMetadataKey(sql.ID(gr.ValueInt()))
 	desc := &sql.Descriptor{}
-	if err := kvDB.GetProto(descKey, desc); err != nil {
-		t.Fatal(err)
+	if pErr := kvDB.GetProto(descKey, desc); pErr != nil {
+		t.Fatal(pErr.GoError())
 	}
 	tableDesc := desc.GetTable()
 

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -42,40 +42,36 @@ func (e errUniquenessConstraintViolation) Error() string {
 		e.index.Name)
 }
 
-func convertBatchError(tableDesc *TableDescriptor, b client.Batch, err error) error {
-	iErr, ok := err.(roachpb.IndexedError)
-	if !ok {
-		return err
+func convertBatchError(tableDesc *TableDescriptor, b client.Batch, origPErr *roachpb.Error) *roachpb.Error {
+	if origPErr.Index == nil {
+		return origPErr
 	}
-	index, ok := iErr.ErrorIndex()
-	if !ok {
-		return err
-	}
+	index := origPErr.Index.Index
 	if index >= int32(len(b.Results)) {
 		panic(fmt.Sprintf("index %d outside of results: %+v", index, b.Results))
 	}
 	result := b.Results[index]
-	if _, ok := err.(*roachpb.ConditionFailedError); ok {
+	if _, ok := origPErr.GoError().(*roachpb.ConditionFailedError); ok {
 		for _, row := range result.Rows {
-			indexID, key, err := decodeIndexKeyPrefix(tableDesc, row.Key)
-			if err != nil {
-				return err
+			indexID, key, pErr := decodeIndexKeyPrefix(tableDesc, row.Key)
+			if pErr != nil {
+				return pErr
 			}
-			index, err := tableDesc.FindIndexByID(indexID)
-			if err != nil {
-				return err
+			index, pErr := tableDesc.FindIndexByID(indexID)
+			if pErr != nil {
+				return pErr
 			}
-			valTypes, err := makeKeyVals(tableDesc, index.ColumnIDs)
-			if err != nil {
-				return err
+			valTypes, pErr := makeKeyVals(tableDesc, index.ColumnIDs)
+			if pErr != nil {
+				return pErr
 			}
 			vals := make([]parser.Datum, len(valTypes))
-			if _, err := decodeKeyVals(valTypes, vals, key); err != nil {
-				return err
+			if _, pErr := decodeKeyVals(valTypes, vals, key); pErr != nil {
+				return pErr
 			}
 
-			return errUniquenessConstraintViolation{index: index, vals: vals}
+			return roachpb.NewError(errUniquenessConstraintViolation{index: index, vals: vals})
 		}
 	}
-	return err
+	return origPErr
 }

--- a/sql/grant.go
+++ b/sql/grant.go
@@ -17,11 +17,12 @@
 package sql
 
 import (
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 )
 
-func (p *planner) changePrivileges(targets parser.TargetList, grantees parser.NameList, changePrivilege func(*PrivilegeDescriptor, string)) (planNode, error) {
+func (p *planner) changePrivileges(targets parser.TargetList, grantees parser.NameList, changePrivilege func(*PrivilegeDescriptor, string)) (planNode, *roachpb.Error) {
 	descriptor, err := p.getDescriptorFromTargetList(targets)
 	if err != nil {
 		return nil, err
@@ -37,7 +38,7 @@ func (p *planner) changePrivileges(targets parser.TargetList, grantees parser.Na
 	}
 
 	if err := descriptor.Validate(); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 
 	tableDesc, ok := descriptor.(*TableDescriptor)
@@ -67,7 +68,7 @@ func (p *planner) changePrivileges(targets parser.TargetList, grantees parser.Na
 // Privileges: GRANT on database/table.
 //   Notes: postgres requires the object owner.
 //          mysql requires the "grant option" and the same privileges, and sometimes superuser.
-func (p *planner) Grant(n *parser.Grant) (planNode, error) {
+func (p *planner) Grant(n *parser.Grant) (planNode, *roachpb.Error) {
 	return p.changePrivileges(n.Targets, n.Grantees, func(privDesc *PrivilegeDescriptor, grantee string) {
 		privDesc.Grant(grantee, n.Privileges)
 	})
@@ -82,7 +83,7 @@ func (p *planner) Grant(n *parser.Grant) (planNode, error) {
 // Privileges: GRANT on database/table.
 //   Notes: postgres requires the object owner.
 //          mysql requires the "grant option" and the same privileges, and sometimes superuser.
-func (p *planner) Revoke(n *parser.Revoke) (planNode, error) {
+func (p *planner) Revoke(n *parser.Revoke) (planNode, *roachpb.Error) {
 	return p.changePrivileges(n.Targets, n.Grantees, func(privDesc *PrivilegeDescriptor, grantee string) {
 		privDesc.Revoke(grantee, n.Privileges)
 	})

--- a/sql/group.go
+++ b/sql/group.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -32,7 +33,7 @@ var aggregates = map[string]func() aggregateImpl{
 	"sum":   newSumAggregate,
 }
 
-func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, error) {
+func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, *roachpb.Error) {
 	// Determine if aggregation is being performed. This check is done on the raw
 	// Select expressions as simplification might have removed aggregation
 	// functions (e.g. `SELECT MIN(1)` -> `SELECT 1`).
@@ -46,20 +47,20 @@ func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, error) {
 	// that determination is made during validation, which will require matching
 	// expressions.
 	for i := range n.GroupBy {
-		resolved, err := s.resolveQNames(n.GroupBy[i])
-		if err != nil {
-			return nil, err
+		resolved, pErr := s.resolveQNames(n.GroupBy[i])
+		if pErr != nil {
+			return nil, pErr
 		}
 
 		// We could potentially skip this, since it will be checked in addRender,
 		// but checking now allows early err return.
 		if _, err := resolved.TypeCheck(p.evalCtx.Args); err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
 
 		norm, err := p.parser.NormalizeExpr(p.evalCtx, resolved)
 		if err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
 
 		// If a col index is specified, replace it with that expression first.
@@ -67,7 +68,7 @@ func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, error) {
 		// on s.render, the GroupBy expressions can contain wrapped qvalues.
 		// aggregateFunc's Eval() method handles being called during grouping.
 		if col, err := s.colIndex(norm); err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		} else if col >= 0 {
 			n.GroupBy[i] = s.render[col]
 		} else {
@@ -78,22 +79,22 @@ func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, error) {
 
 	// Normalize and check the HAVING expression too if it exists.
 	if n.Having != nil {
-		having, err := s.resolveQNames(n.Having.Expr)
-		if err != nil {
-			return nil, err
+		having, pErr := s.resolveQNames(n.Having.Expr)
+		if pErr != nil {
+			return nil, pErr
 		}
 
-		having, err = p.parser.NormalizeExpr(p.evalCtx, having)
+		having, err := p.parser.NormalizeExpr(p.evalCtx, having)
 		if err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
 
 		havingType, err := having.TypeCheck(p.evalCtx.Args)
 		if err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
 		if !(havingType == parser.DummyBool || havingType == parser.DNull) {
-			return nil, fmt.Errorf("argument of HAVING must be type %s, not type %s", parser.DummyBool.Type(), havingType.Type())
+			return nil, roachpb.NewUErrorf("argument of HAVING must be type %s, not type %s", parser.DummyBool.Type(), havingType.Type())
 		}
 		n.Having.Expr = having
 	}
@@ -128,7 +129,7 @@ func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, error) {
 	for i := range group.render {
 		expr, err := visitor.extract(group.render[i])
 		if err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
 		group.render[i] = expr
 	}
@@ -136,7 +137,7 @@ func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, error) {
 	if n.Having != nil {
 		having, err := visitor.extract(n.Having.Expr)
 		if err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
 		group.having = having
 	}
@@ -196,7 +197,7 @@ type groupNode struct {
 	currentBucket string
 
 	desiredOrdering []int
-	err             error
+	pErr            *roachpb.Error
 }
 
 func (n *groupNode) Columns() []column {
@@ -213,10 +214,10 @@ func (n *groupNode) Values() parser.DTuple {
 }
 
 func (n *groupNode) Next() bool {
-	if !n.populated && n.err == nil {
+	if !n.populated && n.pErr == nil {
 		n.computeAggregates()
 	}
-	if n.err != nil {
+	if n.pErr != nil {
 		return false
 	}
 	return n.values.Next()
@@ -234,8 +235,10 @@ func (n *groupNode) computeAggregates() {
 		// TODO(dt): optimization: skip buckets when underlying plan is ordered by grouped values.
 
 		var encoded []byte
-		encoded, n.err = encodeDTuple(scratch, groupedValues)
-		if n.err != nil {
+		var err error
+		encoded, err = encodeDTuple(scratch, groupedValues)
+		n.pErr = roachpb.NewError(err)
+		if n.pErr != nil {
 			return
 		}
 
@@ -243,15 +246,15 @@ func (n *groupNode) computeAggregates() {
 
 		// Feed the aggregateFuncs for this bucket the non-grouped values.
 		for i, value := range aggregatedValues {
-			if n.err = n.funcs[i].add(encoded, value); n.err != nil {
+			if n.pErr = n.funcs[i].add(encoded, value); n.pErr != nil {
 				return
 			}
 		}
 		scratch = encoded[:0]
 	}
 
-	n.err = n.plan.Err()
-	if n.err != nil {
+	n.pErr = n.plan.PErr()
+	if n.pErr != nil {
 		return
 	}
 
@@ -270,11 +273,11 @@ func (n *groupNode) computeAggregates() {
 		if n.having != nil {
 			res, err := n.having.Eval(n.planner.evalCtx)
 			if err != nil {
-				n.err = err
+				n.pErr = roachpb.NewError(err)
 				return
 			}
 			if res, err := parser.GetBool(res); err != nil {
-				n.err = err
+				n.pErr = roachpb.NewError(err)
 				return
 			} else if !res {
 				continue
@@ -285,7 +288,7 @@ func (n *groupNode) computeAggregates() {
 		for _, r := range n.render {
 			res, err := r.Eval(n.planner.evalCtx)
 			if err != nil {
-				n.err = err
+				n.pErr = roachpb.NewError(err)
 				return
 			}
 			row = append(row, res)
@@ -296,8 +299,8 @@ func (n *groupNode) computeAggregates() {
 
 }
 
-func (n *groupNode) Err() error {
-	return n.err
+func (n *groupNode) PErr() *roachpb.Error {
+	return n.pErr
 }
 
 func (n *groupNode) ExplainPlan() (name, description string, children []planNode) {
@@ -516,14 +519,14 @@ type aggregateFunc struct {
 	seen    map[string]struct{}
 }
 
-func (a *aggregateFunc) add(bucket []byte, d parser.Datum) error {
+func (a *aggregateFunc) add(bucket []byte, d parser.Datum) *roachpb.Error {
 	// NB: the compiler *should* optimize `myMap[string(myBytes)]`. See:
 	// https://github.com/golang/go/commit/f5f5a8b6209f84961687d993b93ea0d397f5d5bf
 
 	if a.seen != nil {
-		encoded, err := encodeDatum(bucket, d)
-		if err != nil {
-			return err
+		encoded, pErr := encodeDatum(bucket, d)
+		if pErr != nil {
+			return pErr
 		}
 		if _, ok := a.seen[string(encoded)]; ok {
 			// skip
@@ -538,7 +541,7 @@ func (a *aggregateFunc) add(bucket []byte, d parser.Datum) error {
 		a.buckets[string(bucket)] = impl
 	}
 
-	return impl.add(d)
+	return roachpb.NewError(impl.add(d))
 }
 
 func (*aggregateFunc) Variable() {}
@@ -576,19 +579,20 @@ func (a *aggregateFunc) Eval(ctx parser.EvalContext) (parser.Datum, error) {
 	return datum.Eval(ctx)
 }
 
-func encodeDatum(b []byte, d parser.Datum) ([]byte, error) {
+func encodeDatum(b []byte, d parser.Datum) ([]byte, *roachpb.Error) {
 	if values, ok := d.(parser.DTuple); ok {
-		return encodeDTuple(b, values)
+		dt, err := encodeDTuple(b, values)
+		return dt, roachpb.NewError(err)
 	}
 	return encodeTableKey(b, d)
 }
 
 func encodeDTuple(b []byte, d parser.DTuple) ([]byte, error) {
 	for _, val := range d {
-		var err error
-		b, err = encodeDatum(b, val)
-		if err != nil {
-			return nil, err
+		var pErr *roachpb.Error
+		b, pErr = encodeDatum(b, val)
+		if pErr != nil {
+			return nil, pErr.GoError()
 		}
 	}
 	return b, nil

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -17,13 +17,10 @@
 package sql
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -31,25 +28,25 @@ import (
 // Privileges: INSERT on table
 //   Notes: postgres requires INSERT. No "on duplicate key update" option.
 //          mysql requires INSERT. Also requires UPDATE on "ON DUPLICATE KEY UPDATE".
-func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, error) {
+func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.Error) {
 	// TODO(marcb): We can't use the cached descriptor here because a recent
 	// update of the schema (e.g. the addition of an index) might not be
 	// reflected in the cached version (yet). Perhaps schema modification
 	// routines such as CREATE INDEX should not return until the schema change
 	// has been pushed everywhere.
-	tableDesc, err := p.getTableLease(n.Table)
-	if err != nil {
-		return nil, err
+	tableDesc, pErr := p.getTableLease(n.Table)
+	if pErr != nil {
+		return nil, pErr
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.INSERT); err != nil {
-		return nil, err
+	if pErr := p.checkPrivilege(tableDesc, privilege.INSERT); pErr != nil {
+		return nil, pErr
 	}
 
 	// Determine which columns we're inserting into.
-	cols, err := p.processColumns(tableDesc, n.Columns)
-	if err != nil {
-		return nil, err
+	cols, pErr := p.processColumns(tableDesc, n.Columns)
+	if pErr != nil {
+		return nil, pErr
 	}
 	// Number of columns expecting an input. This doesn't include the
 	// columns receiving a default value.
@@ -91,32 +88,32 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, error) {
 	primaryKeyCols := map[ColumnID]struct{}{}
 	for i, id := range tableDesc.PrimaryIndex.ColumnIDs {
 		if _, ok := colIDtoRowIndex[id]; !ok {
-			return nil, fmt.Errorf("missing %q primary key column", tableDesc.PrimaryIndex.ColumnNames[i])
+			return nil, roachpb.NewUErrorf("missing %q primary key column", tableDesc.PrimaryIndex.ColumnNames[i])
 		}
 		primaryKeyCols[id] = struct{}{}
 	}
 
 	// Construct the default expressions. The returned slice will be nil if no
 	// column in the table has a default expression.
-	defaultExprs, err := p.makeDefaultExprs(cols)
-	if err != nil {
-		return nil, err
+	defaultExprs, pErr := p.makeDefaultExprs(cols)
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	// Replace any DEFAULT markers with the corresponding default expressions.
-	if n.Rows, err = p.fillDefaults(defaultExprs, cols, n.Rows); err != nil {
-		return nil, err
+	if n.Rows, pErr = p.fillDefaults(defaultExprs, cols, n.Rows); pErr != nil {
+		return nil, pErr
 	}
 
 	// Transform the values into a rows object. This expands SELECT statements or
 	// generates rows from the values contained within the query.
-	rows, err := p.makePlan(n.Rows, false)
-	if err != nil {
-		return nil, err
+	rows, pErr := p.makePlan(n.Rows, false)
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	if expressions := len(rows.Columns()); expressions > numInputColumns {
-		return nil, fmt.Errorf("INSERT has more expressions than target columns: %d/%d", expressions, numInputColumns)
+		return nil, roachpb.NewUErrorf("INSERT has more expressions than target columns: %d/%d", expressions, numInputColumns)
 	}
 
 	primaryIndex := tableDesc.PrimaryIndex
@@ -140,7 +137,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, error) {
 			}
 			d, err := defaultExprs[i].Eval(p.evalCtx)
 			if err != nil {
-				return nil, err
+				return nil, roachpb.NewError(err)
 			}
 			rowVals = append(rowVals, d)
 		}
@@ -149,7 +146,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, error) {
 		for _, col := range tableDesc.Columns {
 			if !col.Nullable {
 				if i, ok := colIDtoRowIndex[col.ID]; !ok || rowVals[i] == parser.DNull {
-					return nil, fmt.Errorf("null value in column %q violates not-null constraint", col.Name)
+					return nil, roachpb.NewUErrorf("null value in column %q violates not-null constraint", col.Name)
 				}
 			}
 		}
@@ -159,16 +156,16 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, error) {
 		// cannot be used as index values.
 		for i, val := range rowVals {
 			// Make sure the value can be written to the column before proceeding.
-			var err error
-			if marshalled[i], err = marshalColumnValue(cols[i], val); err != nil {
-				return nil, err
+			var mpErr *roachpb.Error
+			if marshalled[i], mpErr = marshalColumnValue(cols[i], val); mpErr != nil {
+				return nil, mpErr
 			}
 		}
 
-		primaryIndexKey, _, err := encodeIndexKey(
+		primaryIndexKey, _, epErr := encodeIndexKey(
 			primaryIndex.ColumnIDs, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
-		if err != nil {
-			return nil, err
+		if epErr != nil {
+			return nil, epErr
 		}
 
 		// Write the secondary indexes.
@@ -181,10 +178,10 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, error) {
 				}
 			}
 		}
-		secondaryIndexEntries, err := encodeSecondaryIndexes(
+		secondaryIndexEntries, epErr := encodeSecondaryIndexes(
 			tableDesc.ID, indexes, colIDtoRowIndex, rowVals)
-		if err != nil {
-			return nil, err
+		if epErr != nil {
+			return nil, epErr
 		}
 
 		for _, secondaryIndexEntry := range secondaryIndexEntries {
@@ -228,8 +225,8 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, error) {
 			}
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
+	if pErr := rows.PErr(); pErr != nil {
+		return nil, pErr
 	}
 
 	if isSystemConfigID(tableDesc.GetID()) {
@@ -241,18 +238,18 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, error) {
 		// An auto-txn can commit the transaction with the batch. This is an
 		// optimization to avoid an extra round-trip to the transaction
 		// coordinator.
-		err = p.txn.CommitInBatch(b)
+		pErr = p.txn.CommitInBatch(b)
 	} else {
-		err = p.txn.Run(b)
+		pErr = p.txn.Run(b)
 	}
-	if err != nil {
-		return nil, convertBatchError(tableDesc, *b, err)
+	if pErr != nil {
+		return nil, convertBatchError(tableDesc, *b, pErr)
 	}
 	return result, nil
 }
 
 func (p *planner) processColumns(tableDesc *TableDescriptor,
-	node parser.QualifiedNames) ([]ColumnDescriptor, error) {
+	node parser.QualifiedNames) ([]ColumnDescriptor, *roachpb.Error) {
 	if node == nil {
 		return tableDesc.VisibleColumns(), nil
 	}
@@ -263,14 +260,14 @@ func (p *planner) processColumns(tableDesc *TableDescriptor,
 		// TODO(pmattis): If the name is qualified, verify the table name matches
 		// tableDesc.Name.
 		if err := n.NormalizeColumnName(); err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
-		col, err := tableDesc.FindActiveColumnByName(n.Column())
-		if err != nil {
-			return nil, err
+		col, pErr := tableDesc.FindActiveColumnByName(n.Column())
+		if pErr != nil {
+			return nil, pErr
 		}
 		if _, ok := colIDSet[col.ID]; ok {
-			return nil, fmt.Errorf("multiple assignments to same column \"%s\"", n.Column())
+			return nil, roachpb.NewUErrorf("multiple assignments to same column \"%s\"", n.Column())
 		}
 		colIDSet[col.ID] = struct{}{}
 		cols[i] = col
@@ -280,7 +277,7 @@ func (p *planner) processColumns(tableDesc *TableDescriptor,
 }
 
 func (p *planner) fillDefaults(defaultExprs []parser.Expr,
-	cols []ColumnDescriptor, rows parser.SelectStatement) (parser.SelectStatement, error) {
+	cols []ColumnDescriptor, rows parser.SelectStatement) (parser.SelectStatement, *roachpb.Error) {
 	switch values := rows.(type) {
 	case nil:
 		// This indicates a DEFAULT VALUES expression.
@@ -311,7 +308,7 @@ func (p *planner) fillDefaults(defaultExprs []parser.Expr,
 	return rows, nil
 }
 
-func (p *planner) makeDefaultExprs(cols []ColumnDescriptor) ([]parser.Expr, error) {
+func (p *planner) makeDefaultExprs(cols []ColumnDescriptor) ([]parser.Expr, *roachpb.Error) {
 	// Check to see if any of the columns have DEFAULT expressions. If there are
 	// no DEFAULT expressions, we don't bother with constructing the defaults map
 	// as the defaults are all NULL.
@@ -335,14 +332,14 @@ func (p *planner) makeDefaultExprs(cols []ColumnDescriptor) ([]parser.Expr, erro
 		}
 		expr, err := parser.ParseExprTraditional(*col.DefaultExpr)
 		if err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
 		expr, err = p.parser.NormalizeExpr(p.evalCtx, expr)
 		if err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
 		if parser.ContainsVars(expr) {
-			return nil, util.Errorf("default expression contains variables")
+			return nil, roachpb.NewErrorf("default expression contains variables")
 		}
 		defaultExprs = append(defaultExprs, expr)
 	}

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -21,11 +21,12 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 )
 
 // limit constructs a limitNode based on the LIMIT and OFFSET clauses.
-func (p *planner) limit(n *parser.Select, plan planNode) (planNode, error) {
+func (p *planner) limit(n *parser.Select, plan planNode) (planNode, *roachpb.Error) {
 	if n.Limit == nil {
 		return plan, nil
 	}
@@ -47,16 +48,16 @@ func (p *planner) limit(n *parser.Select, plan planNode) (planNode, error) {
 			*datum.dst = datum.defaultVal
 		} else {
 			if parser.ContainsVars(datum.src) {
-				return nil, fmt.Errorf("argument of %s must not contain variables", datum.name)
+				return nil, roachpb.NewUErrorf("argument of %s must not contain variables", datum.name)
 			}
 
 			normalized, err := p.parser.NormalizeExpr(p.evalCtx, datum.src)
 			if err != nil {
-				return nil, err
+				return nil, roachpb.NewError(err)
 			}
 			dstDatum, err := normalized.Eval(p.evalCtx)
 			if err != nil {
-				return nil, err
+				return nil, roachpb.NewError(err)
 			}
 
 			if dstDatum == parser.DNull {
@@ -69,7 +70,7 @@ func (p *planner) limit(n *parser.Select, plan planNode) (planNode, error) {
 				continue
 			}
 
-			return nil, fmt.Errorf("argument of %s must be type %s, not type %s", datum.name, parser.DummyInt.Type(), dstDatum.Type())
+			return nil, roachpb.NewUErrorf("argument of %s must be type %s, not type %s", datum.name, parser.DummyInt.Type(), dstDatum.Type())
 		}
 	}
 

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -318,9 +318,9 @@ func (c *v3Conn) handleParse(buf *readBuffer) error {
 		}
 		pq.inTypes[i-1] = id
 	}
-	cols, err := c.executor.StatementResult(c.opts.user, stmt, args)
-	if err != nil {
-		return c.sendError(err.Error())
+	cols, pErr := c.executor.StatementResult(c.opts.user, stmt, args)
+	if pErr != nil {
+		return c.sendError(pErr.GoError().Error())
 	}
 	pq.columns = cols
 	c.preparedStatements[name] = pq

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -67,7 +67,7 @@ func (p *planner) resetTxn() {
 //
 // Note: The autoCommit parameter enables operations to enable the 1PC
 // optimization. This is a bit hackish/preliminary at present.
-func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, error) {
+func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, *roachpb.Error) {
 	// This will set the system DB trigger for transactions containing
 	// DDL statements that have no effect, such as
 	// `BEGIN; INSERT INTO ...; CREATE TABLE IF NOT EXISTS ...; COMMIT;`
@@ -145,68 +145,68 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, er
 	case parser.Values:
 		return p.Values(n)
 	default:
-		return nil, util.Errorf("unknown statement type: %T", stmt)
+		return nil, roachpb.NewErrorf("unknown statement type: %T", stmt)
 	}
 }
 
-func (p *planner) query(sql string, args ...interface{}) (planNode, error) {
+func (p *planner) query(sql string, args ...interface{}) (planNode, *roachpb.Error) {
 	stmt, err := parser.ParseOneTraditional(sql)
 	if err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 	if err := parser.FillArgs(stmt, golangParameters(args)); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 	return p.makePlan(stmt, false)
 }
 
-func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, error) {
+func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, *roachpb.Error) {
 	plan, err := p.query(sql, args...)
 	if err != nil {
 		return nil, err
 	}
 	if !plan.Next() {
-		if err := plan.Err(); err != nil {
-			return nil, err
+		if pErr := plan.PErr(); pErr != nil {
+			return nil, pErr
 		}
 		return nil, nil
 	}
 	values := plan.Values()
 	if plan.Next() {
-		return nil, util.Errorf("%s: unexpected multiple results", sql)
+		return nil, roachpb.NewErrorf("%s: unexpected multiple results", sql)
 	}
-	if err := plan.Err(); err != nil {
-		return nil, err
+	if pErr := plan.PErr(); pErr != nil {
+		return nil, pErr
 	}
 	return values, nil
 }
 
-func (p *planner) exec(sql string, args ...interface{}) (int, error) {
-	plan, err := p.query(sql, args...)
-	if err != nil {
-		return 0, err
+func (p *planner) exec(sql string, args ...interface{}) (int, *roachpb.Error) {
+	plan, pErr := p.query(sql, args...)
+	if pErr != nil {
+		return 0, pErr
 	}
 	count := 0
 	for plan.Next() {
 		count++
 	}
-	return count, plan.Err()
+	return count, plan.PErr()
 }
 
 // getAliasedTableLease looks up the table descriptor for an alias table
 // expression.
-func (p *planner) getAliasedTableLease(n parser.TableExpr) (*TableDescriptor, error) {
+func (p *planner) getAliasedTableLease(n parser.TableExpr) (*TableDescriptor, *roachpb.Error) {
 	ate, ok := n.(*parser.AliasedTableExpr)
 	if !ok {
-		return nil, util.Errorf("TODO(pmattis): unsupported FROM: %s", n)
+		return nil, roachpb.NewErrorf("TODO(pmattis): unsupported FROM: %s", n)
 	}
 	table, ok := ate.Expr.(*parser.QualifiedName)
 	if !ok {
-		return nil, util.Errorf("TODO(pmattis): unsupported FROM: %s", n)
+		return nil, roachpb.NewErrorf("TODO(pmattis): unsupported FROM: %s", n)
 	}
-	desc, err := p.getTableLease(table)
-	if err != nil {
-		return nil, err
+	desc, pErr := p.getTableLease(table)
+	if pErr != nil {
+		return nil, pErr
 	}
 	if ate.As != "" {
 		desc.Alias = string(ate.As)
@@ -230,8 +230,8 @@ func (p *planner) notifySchemaChange(id ID, mutationID MutationID) {
 func (p *planner) releaseLeases(db client.DB) {
 	if p.leases != nil {
 		for _, lease := range p.leases {
-			if err := p.leaseMgr.Release(lease); err != nil {
-				log.Warning(err)
+			if pErr := p.leaseMgr.Release(lease); pErr != nil {
+				log.Warning(pErr)
 			}
 		}
 		p.leases = nil
@@ -262,8 +262,8 @@ type planNode interface {
 	// Next advances to the next row, returning false if an error is encountered
 	// or if there is no next row.
 	Next() bool
-	// Err returns the error, if any, encountered during iteration.
-	Err() error
+	// PErr returns the error, if any, encountered during iteration.
+	PErr() *roachpb.Error
 	// ExplainPlan returns a name and description and a list of child nodes.
 	ExplainPlan() (name, description string, children []planNode)
 }

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -18,7 +18,6 @@ package sql
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
@@ -38,18 +37,18 @@ var (
 // Privileges: "root" user.
 //   Notes: postgres requires superuser, db owner, or "CREATEDB".
 //          mysql >= 5.1.23 does not allow database renames.
-func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
+func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, *roachpb.Error) {
 	if n.Name == "" || n.NewName == "" {
-		return nil, errEmptyDatabaseName
+		return nil, roachpb.NewError(errEmptyDatabaseName)
 	}
 
 	if p.user != security.RootUser {
-		return nil, fmt.Errorf("only %s is allowed to rename databases", security.RootUser)
+		return nil, roachpb.NewUErrorf("only %s is allowed to rename databases", security.RootUser)
 	}
 
-	dbDesc, err := p.getDatabaseDesc(string(n.Name))
-	if err != nil {
-		return nil, err
+	dbDesc, pErr := p.getDatabaseDesc(string(n.Name))
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	if n.Name == n.NewName {
@@ -62,7 +61,7 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
 	dbDesc.SetName(string(n.NewName))
 
 	if err := dbDesc.Validate(); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 
 	newKey := databaseKey{string(n.NewName)}.Key()
@@ -75,11 +74,11 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
 	b.Put(descKey, descDesc)
 	b.Del(oldKey)
 
-	if err := p.txn.Run(&b); err != nil {
-		if _, ok := err.(*roachpb.ConditionFailedError); ok {
-			return nil, fmt.Errorf("the new database name %q already exists", string(n.NewName))
+	if pErr := p.txn.Run(&b); pErr != nil {
+		if _, ok := pErr.GoError().(*roachpb.ConditionFailedError); ok {
+			return nil, roachpb.NewUErrorf("the new database name %q already exists", string(n.NewName))
 		}
-		return nil, err
+		return nil, pErr
 	}
 
 	p.testingVerifyMetadata = func(systemConfig config.SystemConfig) error {
@@ -100,30 +99,30 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
 //   Notes: postgres requires the table owner.
 //          mysql requires ALTER, DROP on the original table, and CREATE, INSERT
 //          on the new table (and does not copy privileges over).
-func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
+func (p *planner) RenameTable(n *parser.RenameTable) (planNode, *roachpb.Error) {
 	if err := n.NewName.NormalizeTableName(p.session.Database); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 
 	if n.NewName.Table() == "" {
-		return nil, errEmptyTableName
+		return nil, roachpb.NewError(errEmptyTableName)
 	}
 
 	if err := n.Name.NormalizeTableName(p.session.Database); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 
-	dbDesc, err := p.getDatabaseDesc(n.Name.Database())
-	if err != nil {
-		return nil, err
+	dbDesc, pErr := p.getDatabaseDesc(n.Name.Database())
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	tbKey := tableKey{dbDesc.ID, n.Name.Table()}.Key()
 
 	// Check if table exists.
-	gr, err := p.txn.Get(tbKey)
-	if err != nil {
-		return nil, err
+	gr, pErr := p.txn.Get(tbKey)
+	if pErr != nil {
+		return nil, pErr
 	}
 	if !gr.Exists() {
 		if n.IfExists {
@@ -131,16 +130,16 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 			return &valuesNode{}, nil
 		}
 		// Key does not exist, but we want it to: error out.
-		return nil, fmt.Errorf("table %q does not exist", n.Name.Table())
+		return nil, roachpb.NewUErrorf("table %q does not exist", n.Name.Table())
 	}
 
-	targetDbDesc, err := p.getDatabaseDesc(n.NewName.Database())
-	if err != nil {
-		return nil, err
+	targetDbDesc, pErr := p.getDatabaseDesc(n.NewName.Database())
+	if pErr != nil {
+		return nil, pErr
 	}
 
-	if err := p.checkPrivilege(targetDbDesc, privilege.CREATE); err != nil {
-		return nil, err
+	if pErr := p.checkPrivilege(targetDbDesc, privilege.CREATE); pErr != nil {
+		return nil, pErr
 	}
 
 	if n.Name.Database() == n.NewName.Database() && n.Name.Table() == n.NewName.Table() {
@@ -148,13 +147,13 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		return &valuesNode{}, nil
 	}
 
-	tableDesc, err := p.getTableDesc(n.Name)
-	if err != nil {
-		return nil, err
+	tableDesc, pErr := p.getTableDesc(n.Name)
+	if pErr != nil {
+		return nil, pErr
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
-		return nil, err
+	if pErr := p.checkPrivilege(tableDesc, privilege.DROP); pErr != nil {
+		return nil, pErr
 	}
 
 	tableDesc.SetName(n.NewName.Table())
@@ -164,7 +163,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 	newTbKey := tableKey{targetDbDesc.ID, n.NewName.Table()}.Key()
 
 	if err := tableDesc.Validate(); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 
 	descID := tableDesc.GetID()
@@ -175,11 +174,11 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 	b.CPut(newTbKey, descID, nil)
 	b.Del(tbKey)
 
-	if err := p.txn.Run(&b); err != nil {
-		if _, ok := err.(*roachpb.ConditionFailedError); ok {
-			return nil, fmt.Errorf("table name %q already exists", n.NewName.Table())
+	if pErr := p.txn.Run(&b); pErr != nil {
+		if _, ok := pErr.GoError().(*roachpb.ConditionFailedError); ok {
+			return nil, roachpb.NewUErrorf("table name %q already exists", n.NewName.Table())
 		}
-		return nil, err
+		return nil, pErr
 	}
 
 	p.testingVerifyMetadata = func(systemConfig config.SystemConfig) error {
@@ -199,34 +198,34 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 // Privileges: CREATE on table.
 //   notes: postgres requires CREATE on the table.
 //          mysql requires ALTER, CREATE, INSERT on the table.
-func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, error) {
+func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, *roachpb.Error) {
 	newIdxName := string(n.NewName)
 	if newIdxName == "" {
-		return nil, errEmptyIndexName
+		return nil, roachpb.NewError(errEmptyIndexName)
 	}
 
 	if err := n.Name.NormalizeTableName(p.session.Database); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 
-	tableDesc, err := p.getTableDesc(n.Name)
-	if err != nil {
-		return nil, err
+	tableDesc, pErr := p.getTableDesc(n.Name)
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	idxName := n.Name.Index()
-	status, i, err := tableDesc.FindIndexByName(idxName)
-	if err != nil {
+	status, i, pErr := tableDesc.FindIndexByName(idxName)
+	if pErr != nil {
 		if n.IfExists {
 			// Noop.
 			return &valuesNode{}, nil
 		}
 		// Index does not exist, but we want it to: error out.
-		return nil, err
+		return nil, pErr
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
-		return nil, err
+	if pErr := p.checkPrivilege(tableDesc, privilege.CREATE); pErr != nil {
+		return nil, pErr
 	}
 
 	if equalName(idxName, newIdxName) {
@@ -235,7 +234,7 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, error) {
 	}
 
 	if _, _, err := tableDesc.FindIndexByName(newIdxName); err == nil {
-		return nil, fmt.Errorf("index name %q already exists", n.NewName)
+		return nil, roachpb.NewUErrorf("index name %q already exists", n.NewName)
 	}
 
 	if status == DescriptorActive {
@@ -247,10 +246,10 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, error) {
 	tableDesc.UpVersion = true
 	descKey := MakeDescMetadataKey(tableDesc.GetID())
 	if err := tableDesc.Validate(); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
-	if err := p.txn.Put(descKey, wrapDescriptor(tableDesc)); err != nil {
-		return nil, err
+	if pErr := p.txn.Put(descKey, wrapDescriptor(tableDesc)); pErr != nil {
+		return nil, pErr
 	}
 	p.notifySchemaChange(tableDesc.ID, invalidMutationID)
 	return &valuesNode{}, nil
@@ -260,26 +259,26 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, error) {
 // Privileges: CREATE on table.
 //   notes: postgres requires CREATE on the table.
 //          mysql requires ALTER, CREATE, INSERT on the table.
-func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
+func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, *roachpb.Error) {
 	newColName := string(n.NewName)
 	if newColName == "" {
-		return nil, errEmptyColumnName
+		return nil, roachpb.NewError(errEmptyColumnName)
 	}
 
 	if err := n.Table.NormalizeTableName(p.session.Database); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 
-	dbDesc, err := p.getDatabaseDesc(n.Table.Database())
-	if err != nil {
-		return nil, err
+	dbDesc, pErr := p.getDatabaseDesc(n.Table.Database())
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	// Check if table exists.
 	tbKey := tableKey{dbDesc.ID, n.Table.Table()}.Key()
-	gr, err := p.txn.Get(tbKey)
-	if err != nil {
-		return nil, err
+	gr, pErr := p.txn.Get(tbKey)
+	if pErr != nil {
+		return nil, pErr
 	}
 	if !gr.Exists() {
 		if n.IfExists {
@@ -287,19 +286,19 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 			return &valuesNode{}, nil
 		}
 		// Key does not exist, but we want it to: error out.
-		return nil, fmt.Errorf("table %q does not exist", n.Table.Table())
+		return nil, roachpb.NewUErrorf("table %q does not exist", n.Table.Table())
 	}
 
-	tableDesc, err := p.getTableDesc(n.Table)
-	if err != nil {
-		return nil, err
+	tableDesc, pErr := p.getTableDesc(n.Table)
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	colName := string(n.Name)
-	status, i, err := tableDesc.FindColumnByName(colName)
+	status, i, pErr := tableDesc.FindColumnByName(colName)
 	// n.IfExists only applies to table, no need to check here.
-	if err != nil {
-		return nil, err
+	if pErr != nil {
+		return nil, pErr
 	}
 	var column *ColumnDescriptor
 	if status == DescriptorActive {
@@ -308,8 +307,8 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 		column = tableDesc.Mutations[i].GetColumn()
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
-		return nil, err
+	if pErr := p.checkPrivilege(tableDesc, privilege.CREATE); pErr != nil {
+		return nil, pErr
 	}
 
 	if equalName(colName, newColName) {
@@ -318,7 +317,7 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 	}
 
 	if _, _, err := tableDesc.FindColumnByName(newColName); err == nil {
-		return nil, fmt.Errorf("column name %q already exists", newColName)
+		return nil, roachpb.NewUErrorf("column name %q already exists", newColName)
 	}
 
 	// Rename the column in the indexes.
@@ -342,10 +341,10 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 
 	descKey := MakeDescMetadataKey(tableDesc.GetID())
 	if err := tableDesc.Validate(); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
-	if err := p.txn.Put(descKey, wrapDescriptor(tableDesc)); err != nil {
-		return nil, err
+	if pErr := p.txn.Put(descKey, wrapDescriptor(tableDesc)); pErr != nil {
+		return nil, pErr
 	}
 	p.notifySchemaChange(tableDesc.ID, invalidMutationID)
 	return &valuesNode{}, nil

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -132,7 +132,7 @@ type scanNode struct {
 	columnIDs        []ColumnID
 	ordering         []int
 	exactPrefix      int
-	err              error
+	pErr             *roachpb.Error
 	indexKey         []byte            // the index key of the current row
 	kvs              []client.KeyValue // the raw key/value pairs
 	kvIndex          int               // current index into the key/value pairs
@@ -164,7 +164,7 @@ func (n *scanNode) Values() parser.DTuple {
 }
 
 func (n *scanNode) Next() bool {
-	if n.err != nil {
+	if n.pErr != nil {
 		return false
 	}
 
@@ -182,7 +182,7 @@ func (n *scanNode) Next() bool {
 	// current values.
 	for {
 		if n.maybeOutputRow() {
-			return n.err == nil
+			return n.pErr == nil
 		}
 		if n.kvIndex == len(n.kvs) {
 			return false
@@ -194,8 +194,8 @@ func (n *scanNode) Next() bool {
 	}
 }
 
-func (n *scanNode) Err() error {
-	return n.err
+func (n *scanNode) PErr() *roachpb.Error {
+	return n.pErr
 }
 
 func (n *scanNode) ExplainPlan() (name, description string, children []planNode) {
@@ -214,13 +214,13 @@ func (n *scanNode) ExplainPlan() (name, description string, children []planNode)
 }
 
 // Initializes a scanNode from an AliasedTableExpr
-func (n *scanNode) initTableExpr(p *planner, ate *parser.AliasedTableExpr) error {
-	if n.desc, n.err = p.getAliasedTableLease(ate); n.err != nil {
-		return n.err
+func (n *scanNode) initTableExpr(p *planner, ate *parser.AliasedTableExpr) *roachpb.Error {
+	if n.desc, n.pErr = p.getAliasedTableLease(ate); n.pErr != nil {
+		return n.pErr
 	}
 
-	if err := p.checkPrivilege(n.desc, privilege.SELECT); err != nil {
-		return err
+	if pErr := p.checkPrivilege(n.desc, privilege.SELECT); pErr != nil {
+		return pErr
 	}
 
 	qname := ate.Expr.(*parser.QualifiedName)
@@ -235,8 +235,8 @@ func (n *scanNode) initTableExpr(p *planner, ate *parser.AliasedTableExpr) error
 			}
 		}
 		if n.index == nil {
-			n.err = fmt.Errorf("index \"%s\" not found", indexName)
-			return n.err
+			n.pErr = roachpb.NewUErrorf("index \"%s\" not found", indexName)
+			return n.pErr
 		}
 		// If the table was not aliased, use the index name instead of the table
 		// name for fully-qualified columns in the expression.
@@ -307,7 +307,7 @@ func (n *scanNode) initScan() bool {
 			b.Scan(n.spans[i].start, n.spans[i].end, n.spans[i].count)
 		}
 	}
-	if n.err = n.txn.Run(b); n.err != nil {
+	if n.pErr = n.txn.Run(b); n.pErr != nil {
 		return false
 	}
 
@@ -321,7 +321,7 @@ func (n *scanNode) initScan() bool {
 
 	if n.valTypes == nil {
 		// Prepare our index key vals slice.
-		if n.valTypes, n.err = makeKeyVals(n.desc, n.columnIDs); n.err != nil {
+		if n.valTypes, n.pErr = makeKeyVals(n.desc, n.columnIDs); n.pErr != nil {
 			return false
 		}
 		n.vals = make([]parser.Datum, len(n.valTypes))
@@ -329,7 +329,7 @@ func (n *scanNode) initScan() bool {
 		if n.isSecondaryIndex && n.index.Unique {
 			// Unique secondary indexes have a value that is the primary index
 			// key. Prepare implicitVals for use in decoding this value.
-			if n.implicitValTypes, n.err = makeKeyVals(n.desc, n.index.ImplicitColumnIDs); n.err != nil {
+			if n.implicitValTypes, n.pErr = makeKeyVals(n.desc, n.index.ImplicitColumnIDs); n.pErr != nil {
 				return false
 			}
 			n.implicitVals = make([]parser.Datum, len(n.implicitValTypes))
@@ -344,38 +344,42 @@ func (n *scanNode) initScan() bool {
 	return true
 }
 
-func (n *scanNode) initWhere(where *parser.Where) error {
+func (n *scanNode) initWhere(where *parser.Where) *roachpb.Error {
 	if where == nil {
 		return nil
 	}
-	n.filter, n.err = n.resolveQNames(where.Expr)
-	if n.err == nil {
+	n.filter, n.pErr = n.resolveQNames(where.Expr)
+	if n.pErr == nil {
 		var whereType parser.Datum
-		whereType, n.err = n.filter.TypeCheck(n.planner.evalCtx.Args)
-		if n.err == nil {
+		var err error
+		whereType, err = n.filter.TypeCheck(n.planner.evalCtx.Args)
+		n.pErr = roachpb.NewError(err)
+		if n.pErr == nil {
 			if !(whereType == parser.DummyBool || whereType == parser.DNull) {
-				n.err = fmt.Errorf("argument of WHERE must be type %s, not type %s", parser.DummyBool.Type(), whereType.Type())
+				n.pErr = roachpb.NewUErrorf("argument of WHERE must be type %s, not type %s", parser.DummyBool.Type(), whereType.Type())
 			}
 		}
 	}
-	if n.err == nil {
+	if n.pErr == nil {
 		// Normalize the expression (this will also evaluate any branches that are
 		// constant).
-		n.filter, n.err = n.planner.parser.NormalizeExpr(n.planner.evalCtx, n.filter)
+		var err error
+		n.filter, err = n.planner.parser.NormalizeExpr(n.planner.evalCtx, n.filter)
+		n.pErr = roachpb.NewError(err)
 	}
-	if n.err == nil {
-		n.filter, n.err = n.planner.expandSubqueries(n.filter, 1)
+	if n.pErr == nil {
+		n.filter, n.pErr = n.planner.expandSubqueries(n.filter, 1)
 	}
-	return n.err
+	return n.pErr
 }
 
-func (n *scanNode) initTargets(targets parser.SelectExprs) error {
+func (n *scanNode) initTargets(targets parser.SelectExprs) *roachpb.Error {
 	// Loop over the select expressions and expand them into the expressions
 	// we're going to use to generate the returned column set and the names for
 	// those columns.
 	for _, target := range targets {
-		if n.err = n.addRender(target); n.err != nil {
-			return n.err
+		if n.pErr = n.addRender(target); n.pErr != nil {
+			return n.pErr
 		}
 	}
 	// `groupBy` or `orderBy` may internally add additional columns which we
@@ -425,7 +429,7 @@ func (n *scanNode) computeOrdering(columnIDs []ColumnID) []int {
 	return ordering
 }
 
-func (n *scanNode) addRender(target parser.SelectExpr) error {
+func (n *scanNode) addRender(target parser.SelectExpr) *roachpb.Error {
 	// When generating an output column name it should exactly match the original
 	// expression, so determine the output column name before we perform any
 	// manipulations to the expression (such as star expansion).
@@ -440,26 +444,26 @@ func (n *scanNode) addRender(target parser.SelectExpr) error {
 	// prefix of the qualified name to one of the tables in the query and
 	// then expand the "*" into a list of columns.
 	if qname, ok := target.Expr.(*parser.QualifiedName); ok {
-		if n.err = qname.NormalizeColumnName(); n.err != nil {
-			return n.err
+		if n.pErr = roachpb.NewError(qname.NormalizeColumnName()); n.pErr != nil {
+			return n.pErr
 		}
 		if qname.IsStar() {
 			if n.desc == nil {
-				return fmt.Errorf("\"%s\" with no tables specified is not valid", qname)
+				return roachpb.NewUErrorf("\"%s\" with no tables specified is not valid", qname)
 			}
 			if target.As != "" {
-				return fmt.Errorf("\"%s\" cannot be aliased", qname)
+				return roachpb.NewUErrorf("\"%s\" cannot be aliased", qname)
 			}
 			tableName := qname.Table()
 			if tableName != "" && !equalName(n.desc.Alias, tableName) {
-				return fmt.Errorf("table \"%s\" not found", tableName)
+				return roachpb.NewUErrorf("table \"%s\" not found", tableName)
 			}
 
 			if n.isSecondaryIndex {
 				for _, id := range n.index.ColumnIDs {
 					var col *ColumnDescriptor
-					if col, n.err = n.desc.FindColumnByID(id); n.err != nil {
-						return n.err
+					if col, n.pErr = n.desc.FindColumnByID(id); n.pErr != nil {
+						return n.pErr
 					}
 					qval := n.getQVal(*col)
 					n.columns = append(n.columns, column{name: col.Name, typ: qval.datum})
@@ -479,20 +483,24 @@ func (n *scanNode) addRender(target parser.SelectExpr) error {
 	// Resolve qualified names. This has the side-effect of normalizing any
 	// qualified name found.
 	var resolved parser.Expr
-	if resolved, n.err = n.resolveQNames(target.Expr); n.err != nil {
-		return n.err
+	if resolved, n.pErr = n.resolveQNames(target.Expr); n.pErr != nil {
+		return n.pErr
 	}
-	if resolved, n.err = n.planner.expandSubqueries(resolved, 1); n.err != nil {
-		return n.err
+	if resolved, n.pErr = n.planner.expandSubqueries(resolved, 1); n.pErr != nil {
+		return n.pErr
 	}
 	var typ parser.Datum
-	if typ, n.err = resolved.TypeCheck(n.planner.evalCtx.Args); n.err != nil {
-		return n.err
+	var err error
+	typ, err = resolved.TypeCheck(n.planner.evalCtx.Args)
+	n.pErr = roachpb.NewError(err)
+	if n.pErr != nil {
+		return n.pErr
 	}
 	var normalized parser.Expr
-	normalized, n.err = n.planner.parser.NormalizeExpr(n.planner.evalCtx, resolved)
-	if n.err != nil {
-		return n.err
+	normalized, err = n.planner.parser.NormalizeExpr(n.planner.evalCtx, resolved)
+	n.pErr = roachpb.NewError(err)
+	if n.pErr != nil {
+		return n.pErr
 	}
 	n.render = append(n.render, normalized)
 
@@ -536,8 +544,7 @@ func (n *scanNode) processKV(kv client.KeyValue) bool {
 	}
 
 	var remaining []byte
-	remaining, n.err = decodeIndexKey(n.desc, *n.index, n.valTypes, n.vals, kv.Key)
-	if n.err != nil {
+	if remaining, n.pErr = decodeIndexKey(n.desc, *n.index, n.valTypes, n.vals, kv.Key); n.pErr != nil {
 		return false
 	}
 
@@ -558,8 +565,10 @@ func (n *scanNode) processKV(kv client.KeyValue) bool {
 
 	if !n.isSecondaryIndex && len(remaining) > 0 {
 		var v uint64
-		_, v, n.err = encoding.DecodeUvarint(remaining)
-		if n.err != nil {
+		var err error
+		_, v, err = encoding.DecodeUvarint(remaining)
+		n.pErr = roachpb.NewError(err)
+		if n.pErr != nil {
 			return false
 		}
 		n.colID = ColumnID(v)
@@ -582,7 +591,7 @@ func (n *scanNode) processKV(kv client.KeyValue) bool {
 		}
 	} else {
 		if n.implicitVals != nil {
-			if _, n.err = decodeKeyVals(n.implicitValTypes, n.implicitVals, kv.ValueBytes()); n.err != nil {
+			if _, n.pErr = decodeKeyVals(n.implicitValTypes, n.implicitVals, kv.ValueBytes()); n.pErr != nil {
 				return false
 			}
 			for i, id := range n.index.ImplicitColumnIDs {
@@ -642,7 +651,7 @@ func (n *scanNode) maybeOutputRow() bool {
 		// The current key belongs to a new row. Output the current row.
 		n.indexKey = nil
 		output := n.filterRow()
-		if n.err != nil {
+		if n.pErr != nil {
 			return true
 		}
 		if output {
@@ -660,7 +669,7 @@ func (n *scanNode) maybeOutputRow() bool {
 }
 
 // filterRow checks to see if the current row matches the filter (i.e. the
-// where-clause). May set n.err if an error occurs during expression
+// where-clause). May set n.pErr if an error occurs during expression
 // evaluation.
 func (n *scanNode) filterRow() bool {
 	if n.desc != nil {
@@ -680,8 +689,10 @@ func (n *scanNode) filterRow() bool {
 	}
 
 	var d parser.Datum
-	d, n.err = n.filter.Eval(n.planner.evalCtx)
-	if n.err != nil {
+	var err error
+	d, err = n.filter.Eval(n.planner.evalCtx)
+	n.pErr = roachpb.NewError(err)
+	if n.pErr != nil {
 		return false
 	}
 
@@ -689,7 +700,7 @@ func (n *scanNode) filterRow() bool {
 }
 
 // renderRow renders the row by evaluating the render expressions. May set
-// n.err if an error occurs during expression evaluation.
+// n.pErr if an error occurs during expression evaluation.
 func (n *scanNode) renderRow() {
 	if n.explain == explainDebug {
 		n.explainDebug(true, true)
@@ -700,8 +711,10 @@ func (n *scanNode) renderRow() {
 		n.row = make([]parser.Datum, len(n.render))
 	}
 	for i, e := range n.render {
-		n.row[i], n.err = e.Eval(n.planner.evalCtx)
-		if n.err != nil {
+		var err error
+		n.row[i], err = e.Eval(n.planner.evalCtx)
+		n.pErr = roachpb.NewError(err)
+		if n.pErr != nil {
 			return
 		}
 	}
@@ -754,12 +767,12 @@ func (n *scanNode) prettyKey() string {
 func (n *scanNode) unmarshalValue(kv client.KeyValue) (parser.Datum, bool) {
 	kind, ok := n.colKind[n.colID]
 	if !ok {
-		n.err = fmt.Errorf("column-id \"%d\" does not exist", n.colID)
+		n.pErr = roachpb.NewUErrorf("column-id \"%d\" does not exist", n.colID)
 		return nil, false
 	}
 	var d parser.Datum
-	d, n.err = unmarshalColumnValue(kind, kv.Value)
-	return d, n.err == nil
+	d, n.pErr = unmarshalColumnValue(kind, kv.Value)
+	return d, n.pErr == nil
 }
 
 func (n *scanNode) getQVal(col ColumnDescriptor) *qvalue {
@@ -802,13 +815,13 @@ func (n *scanNode) getQVal(col ColumnDescriptor) *qvalue {
 
 type qnameVisitor struct {
 	*scanNode
-	err error
+	pErr *roachpb.Error
 }
 
 var _ parser.Visitor = &qnameVisitor{}
 
 func (v *qnameVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser.Expr) {
-	if !pre || v.err != nil {
+	if !pre || v.pErr != nil {
 		return nil, expr
 	}
 
@@ -826,12 +839,12 @@ func (v *qnameVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser
 	case *parser.QualifiedName:
 		qname := t
 
-		v.err = qname.NormalizeColumnName()
-		if v.err != nil {
+		v.pErr = roachpb.NewError(qname.NormalizeColumnName())
+		if v.pErr != nil {
 			return nil, expr
 		}
 		if qname.IsStar() {
-			v.err = fmt.Errorf("qualified name \"%s\" not found", qname)
+			v.pErr = roachpb.NewUErrorf("qualified name \"%s\" not found", qname)
 			return nil, expr
 		}
 
@@ -845,7 +858,7 @@ func (v *qnameVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser
 			}
 		}
 
-		v.err = fmt.Errorf("qualified name \"%s\" not found", qname)
+		v.pErr = roachpb.NewUErrorf("qualified name \"%s\" not found", qname)
 		return nil, expr
 
 	case *parser.FuncExpr:
@@ -864,8 +877,8 @@ func (v *qnameVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser
 		if !ok {
 			break
 		}
-		v.err = qname.NormalizeColumnName()
-		if v.err != nil {
+		v.pErr = roachpb.NewError(qname.NormalizeColumnName())
+		if v.pErr != nil {
 			return nil, expr
 		}
 		if !qname.IsStar() {
@@ -883,7 +896,7 @@ func (v *qnameVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser
 		// candidate for index selection, but any non-NULL column would do for
 		// correctness of the aggregate.
 		var col *ColumnDescriptor
-		if col, v.err = desc.FindColumnByID(desc.PrimaryIndex.ColumnIDs[0]); v.err != nil {
+		if col, v.pErr = desc.FindColumnByID(desc.PrimaryIndex.ColumnIDs[0]); v.pErr != nil {
 			return nil, expr
 		}
 		t.Exprs[0] = v.getQVal(*col)
@@ -911,11 +924,11 @@ func (v *qnameVisitor) getDesc(qname *parser.QualifiedName) *TableDescriptor {
 	return nil
 }
 
-func (n *scanNode) resolveQNames(expr parser.Expr) (parser.Expr, error) {
+func (n *scanNode) resolveQNames(expr parser.Expr) (parser.Expr, *roachpb.Error) {
 	if expr == nil {
 		return expr, nil
 	}
 	v := qnameVisitor{scanNode: n}
 	expr = parser.WalkExpr(&v, expr)
-	return expr, v.err
+	return expr, v.pErr
 }

--- a/sql/scan_test.go
+++ b/sql/scan_test.go
@@ -41,9 +41,9 @@ func TestRetryResolveQNames(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = s.resolveQNames(expr)
-		if err != nil {
-			t.Fatal(err)
+		_, pErr := s.resolveQNames(expr)
+		if pErr != nil {
+			t.Fatal(pErr)
 		}
 		if len(s.qvals) != 1 {
 			t.Fatalf("%d: expected 1 qvalue, but found %d", i, len(s.qvals))

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -18,7 +18,6 @@ package sql
 
 import (
 	"bytes"
-	"errors"
 	"math"
 	"sync"
 	"time"
@@ -29,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -50,20 +48,20 @@ type SchemaChanger struct {
 
 // applyMutations runs the backfill for the mutations.
 // TODO(vivek): Merge this with backfill by moving backfill into this file.
-func (sc *SchemaChanger) applyMutations(lease *TableDescriptor_SchemaChangeLease) error {
-	l, err := sc.ExtendLease(*lease)
-	if err != nil {
-		return err
+func (sc *SchemaChanger) applyMutations(lease *TableDescriptor_SchemaChangeLease) *roachpb.Error {
+	l, pErr := sc.ExtendLease(*lease)
+	if pErr != nil {
+		return pErr
 	}
 	*lease = l
-	return sc.db.Txn(func(txn *client.Txn) error {
+	return sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		// TODO(vivek): Use the original users privileges.
 		p := planner{user: security.RootUser, systemConfig: sc.cfg, leaseMgr: sc.leaseMgr}
 		p.setTxn(txn, time.Now())
 
-		tableDesc, err := getTableDescFromID(txn, sc.tableID)
-		if err != nil {
-			return err
+		tableDesc, pErr := getTableDescFromID(txn, sc.tableID)
+		if pErr != nil {
+			return pErr
 		}
 
 		if len(tableDesc.Mutations) == 0 || tableDesc.Mutations[0].MutationID != sc.mutationID {
@@ -72,10 +70,10 @@ func (sc *SchemaChanger) applyMutations(lease *TableDescriptor_SchemaChangeLease
 		}
 
 		b := client.Batch{}
-		if err := p.backfillBatch(&b, tableDesc, sc.mutationID); err != nil {
-			return err
+		if pErr := p.backfillBatch(&b, tableDesc, sc.mutationID); pErr != nil {
+			return pErr
 		}
-		if err := p.txn.Run(&b); err != nil {
+		if pErr := p.txn.Run(&b); pErr != nil {
 			// Locally apply mutations belonging to the same mutationID
 			// for use by convertBatchError().
 			for _, mutation := range tableDesc.Mutations {
@@ -86,7 +84,7 @@ func (sc *SchemaChanger) applyMutations(lease *TableDescriptor_SchemaChangeLease
 				}
 				tableDesc.makeMutationComplete(mutation)
 			}
-			return convertBatchError(tableDesc, b, err)
+			return convertBatchError(tableDesc, b, pErr)
 		}
 		return nil
 	})
@@ -97,17 +95,15 @@ func NewSchemaChangerForTesting(tableID ID, mutationID MutationID, nodeID roachp
 	return SchemaChanger{tableID: tableID, mutationID: mutationID, nodeID: nodeID, db: db, leaseMgr: leaseMgr}
 }
 
-var errExistingSchemaChangeLease = errors.New("an outstanding schema change lease exists")
-
 func (sc *SchemaChanger) createSchemaChangeLease() TableDescriptor_SchemaChangeLease {
 	return TableDescriptor_SchemaChangeLease{NodeID: sc.nodeID, ExpirationTime: time.Now().Add(jitteredLeaseDuration()).UnixNano()}
 }
 
 // AcquireLease acquires a schema change lease on the table if
 // an unexpired lease doesn't exist. It returns the lease.
-func (sc *SchemaChanger) AcquireLease() (TableDescriptor_SchemaChangeLease, error) {
+func (sc *SchemaChanger) AcquireLease() (TableDescriptor_SchemaChangeLease, *roachpb.Error) {
 	var lease TableDescriptor_SchemaChangeLease
-	err := sc.db.Txn(func(txn *client.Txn) error {
+	err := sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		txn.SetSystemConfigTrigger()
 		tableDesc, err := getTableDescFromID(txn, sc.tableID)
 		if err != nil {
@@ -123,7 +119,7 @@ func (sc *SchemaChanger) AcquireLease() (TableDescriptor_SchemaChangeLease, erro
 
 		if tableDesc.Lease != nil {
 			if time.Unix(0, tableDesc.Lease.ExpirationTime).Add(expirationTimeUncertainty).After(time.Now()) {
-				return errExistingSchemaChangeLease
+				return roachpb.NewError(&roachpb.ExistingSchemaChangeLeaseError{})
 			}
 			log.Infof("Overriding existing expired lease %v", tableDesc.Lease)
 		}
@@ -134,24 +130,24 @@ func (sc *SchemaChanger) AcquireLease() (TableDescriptor_SchemaChangeLease, erro
 	return lease, err
 }
 
-func (sc *SchemaChanger) findTableWithLease(txn *client.Txn, lease TableDescriptor_SchemaChangeLease) (*TableDescriptor, error) {
+func (sc *SchemaChanger) findTableWithLease(txn *client.Txn, lease TableDescriptor_SchemaChangeLease) (*TableDescriptor, *roachpb.Error) {
 	tableDesc, err := getTableDescFromID(txn, sc.tableID)
 	if err != nil {
 		return nil, err
 	}
 	if tableDesc.Lease == nil {
-		return nil, util.Errorf("no lease present for tableID: %d", sc.tableID)
+		return nil, roachpb.NewErrorf("no lease present for tableID: %d", sc.tableID)
 	}
 	if *tableDesc.Lease != lease {
-		return nil, util.Errorf("table: %d has lease: %v, expected: %v", sc.tableID, tableDesc.Lease, lease)
+		return nil, roachpb.NewErrorf("table: %d has lease: %v, expected: %v", sc.tableID, tableDesc.Lease, lease)
 	}
 	return tableDesc, nil
 }
 
 // ReleaseLease the table lease if it is the one registered with
 // the table descriptor.
-func (sc *SchemaChanger) ReleaseLease(lease TableDescriptor_SchemaChangeLease) error {
-	return sc.db.Txn(func(txn *client.Txn) error {
+func (sc *SchemaChanger) ReleaseLease(lease TableDescriptor_SchemaChangeLease) *roachpb.Error {
+	return sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		tableDesc, err := sc.findTableWithLease(txn, lease)
 		if err != nil {
 			return err
@@ -163,8 +159,8 @@ func (sc *SchemaChanger) ReleaseLease(lease TableDescriptor_SchemaChangeLease) e
 }
 
 // ExtendLease for the current leaser.
-func (sc *SchemaChanger) ExtendLease(lease TableDescriptor_SchemaChangeLease) (TableDescriptor_SchemaChangeLease, error) {
-	err := sc.db.Txn(func(txn *client.Txn) error {
+func (sc *SchemaChanger) ExtendLease(lease TableDescriptor_SchemaChangeLease) (TableDescriptor_SchemaChangeLease, *roachpb.Error) {
+	err := sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		tableDesc, err := sc.findTableWithLease(txn, lease)
 		if err != nil {
 			return err
@@ -178,30 +174,30 @@ func (sc *SchemaChanger) ExtendLease(lease TableDescriptor_SchemaChangeLease) (T
 }
 
 // Execute the entire schema change in steps.
-func (sc SchemaChanger) exec() error {
+func (sc SchemaChanger) exec() *roachpb.Error {
 	// Acquire lease.
-	lease, err := sc.AcquireLease()
-	if err != nil {
-		return err
+	lease, pErr := sc.AcquireLease()
+	if pErr != nil {
+		return pErr
 	}
 	// Always try to release lease.
 	defer func(l *TableDescriptor_SchemaChangeLease) {
-		if err := sc.ReleaseLease(*l); err != nil {
-			log.Warning(err)
+		if pErr := sc.ReleaseLease(*l); pErr != nil {
+			log.Warning(pErr)
 		}
 	}(&lease)
 
 	// Increment the version and unset tableDescriptor.UpVersion.
-	if err := sc.MaybeIncrementVersion(); err != nil {
-		return err
+	if pErr := sc.MaybeIncrementVersion(); pErr != nil {
+		return pErr
 	}
 
 	// Wait for the schema change to propagate to all nodes after this function
 	// returns, so that the new schema is live everywhere. This is not needed for
 	// correctness but is done to make the UI experience/tests predictable.
 	defer func() {
-		if err := sc.waitToUpdateLeases(); err != nil {
-			log.Warning(err)
+		if pErr := sc.waitToUpdateLeases(); pErr != nil {
+			log.Warning(pErr)
 		}
 	}()
 
@@ -214,17 +210,17 @@ func (sc SchemaChanger) exec() error {
 	// but we're no longer responsible for taking care of that.
 
 	// Run through mutation state machine before backfill.
-	if err := sc.RunStateMachineBeforeBackfill(); err != nil {
-		return err
+	if pErr := sc.RunStateMachineBeforeBackfill(); pErr != nil {
+		return pErr
 	}
 
 	// Apply backfill.
-	if err := sc.applyMutations(&lease); err != nil {
+	if pErr := sc.applyMutations(&lease); pErr != nil {
 		// Purge the mutations if the application of the mutations fail.
 		if errPurge := sc.purgeMutations(&lease); errPurge != nil {
-			return util.Errorf("error purging mutation: %s, after error: %s", errPurge, err)
+			return roachpb.NewErrorf("error purging mutation: %s, after error: %s", errPurge, pErr)
 		}
-		return err
+		return pErr
 	}
 
 	// Mark the mutations as completed.
@@ -232,11 +228,11 @@ func (sc SchemaChanger) exec() error {
 }
 
 // MaybeIncrementVersion increments the version if needed.
-func (sc *SchemaChanger) MaybeIncrementVersion() error {
+func (sc *SchemaChanger) MaybeIncrementVersion() *roachpb.Error {
 	return sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
 		if !desc.UpVersion {
 			// Return error so that Publish() doesn't increment the version.
-			return errDidntUpdateDescriptor
+			return &roachpb.DidntUpdateDescriptorError{}
 		}
 		desc.UpVersion = false
 		// Publish() will increment the version.
@@ -247,8 +243,8 @@ func (sc *SchemaChanger) MaybeIncrementVersion() error {
 // RunStateMachineBeforeBackfill moves the state machine forward
 // and wait to ensure that all nodes are seeing the latest version
 // of the table.
-func (sc *SchemaChanger) RunStateMachineBeforeBackfill() error {
-	if err := sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
+func (sc *SchemaChanger) RunStateMachineBeforeBackfill() *roachpb.Error {
+	if pErr := sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
 		var modified bool
 		// Apply mutations belonging to the same version.
 		for i, mutation := range desc.Mutations {
@@ -287,11 +283,11 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill() error {
 		}
 		if !modified {
 			// Return error so that Publish() doesn't increment the version.
-			return errDidntUpdateDescriptor
+			return &roachpb.DidntUpdateDescriptorError{}
 		}
 		return nil
-	}); err != nil {
-		return err
+	}); pErr != nil {
+		return pErr
 	}
 	// wait for the state change to propagate to all leases.
 	return sc.waitToUpdateLeases()
@@ -299,7 +295,7 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill() error {
 
 // Wait until the entire cluster has been updated to the latest version
 // of the table descriptor.
-func (sc *SchemaChanger) waitToUpdateLeases() error {
+func (sc *SchemaChanger) waitToUpdateLeases() *roachpb.Error {
 	// Aggressively retry because there might be a user waiting for the
 	// schema change to complete.
 	retryOpts := retry.Options{
@@ -307,11 +303,11 @@ func (sc *SchemaChanger) waitToUpdateLeases() error {
 		MaxBackoff:     200 * time.Millisecond,
 		Multiplier:     2,
 	}
-	_, err := sc.leaseMgr.waitForOneVersion(sc.tableID, retryOpts)
-	return err
+	_, pErr := sc.leaseMgr.waitForOneVersion(sc.tableID, retryOpts)
+	return pErr
 }
 
-func (sc *SchemaChanger) done() error {
+func (sc *SchemaChanger) done() *roachpb.Error {
 	return sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
 		i := 0
 		for _, mutation := range desc.Mutations {
@@ -326,7 +322,7 @@ func (sc *SchemaChanger) done() error {
 		if i == 0 {
 			// The table descriptor is unchanged. Don't let Publish() increment
 			// the version.
-			return errDidntUpdateDescriptor
+			return &roachpb.DidntUpdateDescriptorError{}
 		}
 		desc.Mutations = desc.Mutations[i:]
 		return nil
@@ -336,9 +332,9 @@ func (sc *SchemaChanger) done() error {
 // Purge all mutations with the mutationID. This is called after
 // hitting an irrecoverable error. Reverse the direction of the mutations
 // and run through the state machine until the mutations are deleted.
-func (sc *SchemaChanger) purgeMutations(lease *TableDescriptor_SchemaChangeLease) error {
+func (sc *SchemaChanger) purgeMutations(lease *TableDescriptor_SchemaChangeLease) *roachpb.Error {
 	// Reverse the flow of the state machine.
-	if err := sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
+	if pErr := sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
 		for i, mutation := range desc.Mutations {
 			if mutation.MutationID != sc.mutationID {
 				// Mutations are applied in a FIFO order. Only apply the first set of
@@ -355,13 +351,13 @@ func (sc *SchemaChanger) purgeMutations(lease *TableDescriptor_SchemaChangeLease
 		}
 		// Publish() will increment the version.
 		return nil
-	}); err != nil {
-		return err
+	}); pErr != nil {
+		return pErr
 	}
 
 	// Run through mutation state machine before backfill.
-	if err := sc.RunStateMachineBeforeBackfill(); err != nil {
-		return err
+	if pErr := sc.RunStateMachineBeforeBackfill(); pErr != nil {
+		return pErr
 	}
 
 	// Apply backfill and don't run purge on hitting an error.
@@ -369,8 +365,8 @@ func (sc *SchemaChanger) purgeMutations(lease *TableDescriptor_SchemaChangeLease
 	// failure with some mutations, where subsequent schema
 	// changers keep attempting to apply and purge mutations.
 	// This is a theoretical problem at this stage (2015/12).
-	if err := sc.applyMutations(lease); err != nil {
-		return err
+	if pErr := sc.applyMutations(lease); pErr != nil {
+		return pErr
 	}
 
 	// Mark the mutations as completed.
@@ -379,13 +375,13 @@ func (sc *SchemaChanger) purgeMutations(lease *TableDescriptor_SchemaChangeLease
 
 // IsDone returns true if the work scheduled for the schema changer
 // is complete.
-func (sc *SchemaChanger) IsDone() (bool, error) {
+func (sc *SchemaChanger) IsDone() (bool, *roachpb.Error) {
 	var done bool
-	err := sc.db.Txn(func(txn *client.Txn) error {
+	pErr := sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		done = true
-		tableDesc, err := getTableDescFromID(txn, sc.tableID)
-		if err != nil {
-			return err
+		tableDesc, pErr := getTableDescFromID(txn, sc.tableID)
+		if pErr != nil {
+			return pErr
 		}
 		if sc.mutationID == invalidMutationID {
 			if tableDesc.UpVersion {
@@ -401,7 +397,7 @@ func (sc *SchemaChanger) IsDone() (bool, error) {
 		}
 		return nil
 	})
-	return done && err == nil, err
+	return done && pErr == nil, pErr
 }
 
 // SchemaChangeManager processes pending schema changes seen in gossip
@@ -590,8 +586,9 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 			case <-timer.C:
 				for _, sc := range s.schemaChangers {
 					if time.Since(sc.execAfter) > 0 {
-						if err := sc.exec(); err != nil && err != errExistingSchemaChangeLease {
-							log.Info(err)
+						pErr := sc.exec()
+						if _, ok := pErr.GoError().(*roachpb.ExistingSchemaChangeLeaseError); !ok && pErr != nil {
+							log.Info(pErr)
 						}
 						// Advance the execAfter time so that this schema changer
 						// doesn't get called again for a while.

--- a/sql/show.go
+++ b/sql/show.go
@@ -18,17 +18,16 @@ package sql
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 )
 
 // Show a session-local variable name.
-func (p *planner) Show(n *parser.Show) (planNode, error) {
+func (p *planner) Show(n *parser.Show) (planNode, *roachpb.Error) {
 	name := strings.ToUpper(n.Name)
 
 	v := &valuesNode{columns: []column{{name: name, typ: parser.DummyString}}}
@@ -39,7 +38,7 @@ func (p *planner) Show(n *parser.Show) (planNode, error) {
 	case `TIME ZONE`:
 		loc, err := p.evalCtx.GetLocation()
 		if err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
 		v.rows = append(v.rows, []parser.Datum{parser.DString(loc.String())})
 	case `SYNTAX`:
@@ -47,7 +46,7 @@ func (p *planner) Show(n *parser.Show) (planNode, error) {
 	case `TRANSACTION ISOLATION LEVEL`:
 		v.rows = append(v.rows, []parser.Datum{parser.DString(p.txn.Proto.Isolation.String())})
 	default:
-		return nil, fmt.Errorf("unknown variable: %q", name)
+		return nil, roachpb.NewUErrorf("unknown variable: %q", name)
 	}
 
 	return v, nil
@@ -57,10 +56,10 @@ func (p *planner) Show(n *parser.Show) (planNode, error) {
 // Privileges: None.
 //   Notes: postgres does not have a SHOW COLUMNS statement.
 //          mysql only returns columns you have privileges on.
-func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, error) {
-	desc, err := p.getTableDesc(n.Table)
-	if err != nil {
-		return nil, err
+func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, *roachpb.Error) {
+	desc, pErr := p.getTableDesc(n.Table)
+	if pErr != nil {
+		return nil, pErr
 	}
 	v := &valuesNode{
 		columns: []column{
@@ -89,21 +88,21 @@ func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, error) {
 // Privileges: None.
 //   Notes: postgres does not have a "show databases"
 //          mysql has a "SHOW DATABASES" permission, but we have no system-level permissions.
-func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, error) {
+func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, *roachpb.Error) {
 	// TODO(pmattis): This could be implemented as:
 	//
 	//   SELECT id FROM system.namespace WHERE parentID = 0
 
 	prefix := MakeNameMetadataKey(keys.RootNamespaceID, "")
-	sr, err := p.txn.Scan(prefix, prefix.PrefixEnd(), 0)
-	if err != nil {
-		return nil, err
+	sr, pErr := p.txn.Scan(prefix, prefix.PrefixEnd(), 0)
+	if pErr != nil {
+		return nil, pErr
 	}
 	v := &valuesNode{columns: []column{{name: "Database", typ: parser.DummyString}}}
 	for _, row := range sr {
 		_, name, err := encoding.DecodeString(bytes.TrimPrefix(row.Key, prefix), nil)
 		if err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
 		v.rows = append(v.rows, []parser.Datum{parser.DString(name)})
 	}
@@ -115,13 +114,13 @@ func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, error) {
 // Privileges: None.
 //   Notes: postgres does not have a SHOW GRANTS statement.
 //          mysql only returns the user's privileges.
-func (p *planner) ShowGrants(n *parser.ShowGrants) (planNode, error) {
+func (p *planner) ShowGrants(n *parser.ShowGrants) (planNode, *roachpb.Error) {
 	if n.Targets == nil {
-		return nil, util.Errorf("TODO(marc): implement SHOW GRANT with no targets")
+		return nil, roachpb.NewErrorf("TODO(marc): implement SHOW GRANT with no targets")
 	}
-	descriptor, err := p.getDescriptorFromTargetList(*n.Targets)
-	if err != nil {
-		return nil, err
+	descriptor, pErr := p.getDescriptorFromTargetList(*n.Targets)
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	objectType := "Database"
@@ -164,10 +163,10 @@ func (p *planner) ShowGrants(n *parser.ShowGrants) (planNode, error) {
 // Privileges: None.
 //   Notes: postgres does not have a SHOW INDEX statement.
 //          mysql requires some privilege for any column.
-func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, error) {
-	desc, err := p.getTableDesc(n.Table)
-	if err != nil {
-		return nil, err
+func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, *roachpb.Error) {
+	desc, pErr := p.getTableDesc(n.Table)
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	v := &valuesNode{
@@ -212,7 +211,7 @@ func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, error) {
 // Privileges: None.
 //   Notes: postgres does not have a SHOW TABLES statement.
 //          mysql only returns tables you have privileges on.
-func (p *planner) ShowTables(n *parser.ShowTables) (planNode, error) {
+func (p *planner) ShowTables(n *parser.ShowTables) (planNode, *roachpb.Error) {
 	// TODO(pmattis): This could be implemented as:
 	//
 	//   SELECT name FROM system.namespace
@@ -221,18 +220,18 @@ func (p *planner) ShowTables(n *parser.ShowTables) (planNode, error) {
 
 	if n.Name == nil {
 		if p.session.Database == "" {
-			return nil, errNoDatabase
+			return nil, roachpb.NewError(errNoDatabase)
 		}
 		n.Name = &parser.QualifiedName{Base: parser.Name(p.session.Database)}
 	}
-	dbDesc, err := p.getDatabaseDesc(string(n.Name.Base))
-	if err != nil {
-		return nil, err
+	dbDesc, pErr := p.getDatabaseDesc(string(n.Name.Base))
+	if pErr != nil {
+		return nil, pErr
 	}
 
-	tableNames, err := p.getTableNames(dbDesc)
-	if err != nil {
-		return nil, err
+	tableNames, pErr := p.getTableNames(dbDesc)
+	if pErr != nil {
+		return nil, pErr
 	}
 	v := &valuesNode{columns: []column{{name: "Table", typ: parser.DummyString}}}
 	for _, name := range tableNames {

--- a/sql/split_test.go
+++ b/sql/split_test.go
@@ -41,9 +41,9 @@ func getFastScanContext() *server.Context {
 
 // getRangeKeys returns the end keys of all ranges.
 func getRangeKeys(db *client.DB) ([]roachpb.Key, error) {
-	rows, err := db.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
-	if err != nil {
-		return nil, err
+	rows, pErr := db.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+	if pErr != nil {
+		return nil, pErr.GoError()
 	}
 	ret := make([]roachpb.Key, len(rows), len(rows))
 	for i := 0; i < len(rows); i++ {

--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -17,28 +17,27 @@
 package sql
 
 import (
-	"fmt"
-
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 )
 
-func (p *planner) expandSubqueries(expr parser.Expr, columns int) (parser.Expr, error) {
+func (p *planner) expandSubqueries(expr parser.Expr, columns int) (parser.Expr, *roachpb.Error) {
 	p.subqueryVisitor = subqueryVisitor{planner: p, columns: columns}
 	expr = parser.WalkExpr(&p.subqueryVisitor, expr)
-	return expr, p.subqueryVisitor.err
+	return expr, p.subqueryVisitor.pErr
 }
 
 type subqueryVisitor struct {
 	*planner
 	columns int
 	path    []parser.Expr // parent expressions
-	err     error
+	pErr    *roachpb.Error
 }
 
 var _ parser.Visitor = &subqueryVisitor{}
 
 func (v *subqueryVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser.Expr) {
-	if v.err != nil {
+	if v.pErr != nil {
 		return nil, expr
 	}
 	if !pre {
@@ -64,7 +63,7 @@ func (v *subqueryVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, par
 	// copy of the planner in order for there to have a separate subqueryVisitor.
 	planMaker := *v.planner
 	var plan planNode
-	if plan, v.err = planMaker.makePlan(subquery.Select, false); v.err != nil {
+	if plan, v.pErr = planMaker.makePlan(subquery.Select, false); v.pErr != nil {
 		return nil, expr
 	}
 
@@ -74,8 +73,8 @@ func (v *subqueryVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, par
 		if plan.Next() {
 			return v, parser.DBool(true)
 		}
-		v.err = plan.Err()
-		if v.err != nil {
+		v.pErr = plan.PErr()
+		if v.pErr != nil {
 			return nil, expr
 		}
 		return v, parser.DBool(false)
@@ -85,9 +84,9 @@ func (v *subqueryVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, par
 	if n := len(plan.Columns()); columns != n {
 		switch columns {
 		case 1:
-			v.err = fmt.Errorf("subquery must return only one column, found %d", n)
+			v.pErr = roachpb.NewUErrorf("subquery must return only one column, found %d", n)
 		default:
-			v.err = fmt.Errorf("subquery must return %d columns, found %d", columns, n)
+			v.pErr = roachpb.NewUErrorf("subquery must return %d columns, found %d", columns, n)
 		}
 		return nil, expr
 	}
@@ -127,14 +126,14 @@ func (v *subqueryVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, par
 				result = valuesCopy
 			}
 			if plan.Next() {
-				v.err = fmt.Errorf("more than one row returned by a subquery used as an expression")
+				v.pErr = roachpb.NewUErrorf("more than one row returned by a subquery used as an expression")
 				return nil, expr
 			}
 		}
 	}
 
-	v.err = plan.Err()
-	if v.err != nil {
+	v.pErr = plan.PErr()
+	if v.pErr != nil {
 		return nil, expr
 	}
 	return v, result

--- a/sql/system.go
+++ b/sql/system.go
@@ -120,8 +120,8 @@ func createTableDescriptor(id, parentID ID, schema string, privileges *Privilege
 		log.Fatal(err)
 	}
 
-	desc, err := makeTableDesc(stmt.(*parser.CreateTable), parentID)
-	if err != nil {
+	desc, pErr := makeTableDesc(stmt.(*parser.CreateTable), parentID)
+	if pErr != nil {
 		log.Fatal(err)
 	}
 

--- a/sql/table_test.go
+++ b/sql/table_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -108,9 +109,9 @@ func TestMakeTableDescColumns(t *testing.T) {
 		if err := create.Table.NormalizeTableName(""); err != nil {
 			t.Fatalf("%d: %v", i, err)
 		}
-		schema, err := makeTableDesc(create, 1)
-		if err != nil {
-			t.Fatalf("%d: %v", i, err)
+		schema, pErr := makeTableDesc(create, 1)
+		if pErr != nil {
+			t.Fatalf("%d: %v", i, pErr)
 		}
 		if !reflect.DeepEqual(d.colType, schema.Columns[0].Type) {
 			t.Fatalf("%d: expected %+v, but got %+v", i, d.colType, schema.Columns[0])
@@ -203,9 +204,9 @@ func TestMakeTableDescIndexes(t *testing.T) {
 		if err := create.Table.NormalizeTableName(""); err != nil {
 			t.Fatalf("%d: %v", i, err)
 		}
-		schema, err := makeTableDesc(create, 1)
+		schema, pErr := makeTableDesc(create, 1)
 		if err != nil {
-			t.Fatalf("%d: %v", i, err)
+			t.Fatalf("%d: %v", i, pErr)
 		}
 		if !reflect.DeepEqual(d.primary, schema.PrimaryIndex) {
 			t.Fatalf("%d: expected %+v, but got %+v", i, d.primary, schema.PrimaryIndex)
@@ -228,11 +229,12 @@ func TestPrimaryKeyUnspecified(t *testing.T) {
 	if err := create.Table.NormalizeTableName(""); err != nil {
 		t.Fatal(err)
 	}
-	desc, err := makeTableDesc(create, 1)
-	if err != nil {
-		t.Fatal(err)
+	desc, pErr := makeTableDesc(create, 1)
+	if pErr != nil {
+		t.Fatal(pErr)
 	}
-	if err := desc.AllocateIDs(); err != errMissingPrimaryKey {
-		t.Fatal(err)
+	pErr = desc.AllocateIDs()
+	if !testutils.IsError(pErr.GoError(), errMissingPrimaryKey.Error()) {
+		t.Fatalf("unexpected error: %s", pErr)
 	}
 }

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -89,16 +89,16 @@ func TestValues(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		plan, err := func() (_ planNode, err error) {
+		plan, pErr := func() (_ planNode, pErr *roachpb.Error) {
 			defer func() {
 				if r := recover(); r != nil {
-					err = fmt.Errorf("%v", r)
+					pErr = roachpb.NewErrorf("%v", r)
 				}
 			}()
 			return p.Values(tc.stmt)
 		}()
-		if err == nil != tc.ok {
-			t.Errorf("%d: error_expected=%t, but got error %v", i, tc.ok, err)
+		if pErr == nil != tc.ok {
+			t.Errorf("%d: error_expected=%t, but got error %v", i, tc.ok, pErr)
 		}
 		if plan != nil {
 			var rows []parser.DTuple

--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -227,35 +227,35 @@ func TestMultiStoreEventFeed(t *testing.T) {
 	mtc.replicateRange(rangeID, 0, 1, 2)
 
 	// Add some data in a transaction
-	err := mtc.db.Txn(func(txn *client.Txn) error {
+	pErr := mtc.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		b := txn.NewBatch()
 		b.Put("a", "asdf")
 		b.Put("c", "jkl;")
 		return txn.CommitInBatch(b)
 	})
-	if err != nil {
-		t.Fatalf("error putting data to db: %s", err)
+	if pErr != nil {
+		t.Fatalf("error putting data to db: %s", pErr)
 	}
 
 	// AdminSplit in between the two ranges.
-	if err := mtc.db.AdminSplit("b"); err != nil {
-		t.Fatalf("error splitting initial: %s", err)
+	if pErr := mtc.db.AdminSplit("b"); pErr != nil {
+		t.Fatalf("error splitting initial: %s", pErr)
 	}
 
 	// AdminSplit an empty range at the end of the second range.
-	if err := mtc.db.AdminSplit("z"); err != nil {
-		t.Fatalf("error splitting second range: %s", err)
+	if pErr := mtc.db.AdminSplit("z"); pErr != nil {
+		t.Fatalf("error splitting second range: %s", pErr)
 	}
 
 	// AdminMerge the empty range back into the second range.
-	if err := mtc.db.AdminMerge("c"); err != nil {
-		t.Fatalf("error merging final range: %s", err)
+	if pErr := mtc.db.AdminMerge("c"); pErr != nil {
+		t.Fatalf("error merging final range: %s", pErr)
 	}
 
 	// Add an additional put through the system and wait for all
 	// replicas to receive it.
-	if _, err := mtc.db.Inc("aa", 5); err != nil {
-		t.Fatalf("error putting data to db: %s", err)
+	if _, pErr := mtc.db.Inc("aa", 5); pErr != nil {
+		t.Fatalf("error putting data to db: %s", pErr)
 	}
 	util.SucceedsWithin(t, time.Second, func() error {
 		for _, eng := range mtc.engines {

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -42,7 +42,7 @@ func adminMergeArgs(key roachpb.Key) roachpb.AdminMergeRequest {
 	}
 }
 
-func createSplitRanges(store *storage.Store) (*roachpb.RangeDescriptor, *roachpb.RangeDescriptor, error) {
+func createSplitRanges(store *storage.Store) (*roachpb.RangeDescriptor, *roachpb.RangeDescriptor, *roachpb.Error) {
 	args := adminSplitArgs(roachpb.KeyMin, []byte("b"))
 	if _, err := client.SendWrapped(rg1(store), nil, &args); err != nil {
 		return nil, nil, err
@@ -300,8 +300,8 @@ func TestStoreRangeMergeLastRange(t *testing.T) {
 
 	// Merge last range.
 	args := adminMergeArgs(roachpb.KeyMin)
-	if _, err := client.SendWrapped(rg1(store), nil, &args); !testutils.IsError(err, "cannot merge final range") {
-		t.Fatalf("expected 'cannot merge final range' error; got %s", err)
+	if _, pErr := client.SendWrapped(rg1(store), nil, &args); !testutils.IsError(pErr.GoError(), "cannot merge final range") {
+		t.Fatalf("expected 'cannot merge final range' error; got %s", pErr)
 	}
 }
 
@@ -316,12 +316,12 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 
 	// Split into 3 ranges
 	argsSplit := adminSplitArgs(roachpb.KeyMin, []byte("d"))
-	if _, err := client.SendWrapped(rg1(store), nil, &argsSplit); err != nil {
-		t.Fatalf("Can't split range %s", err)
+	if _, pErr := client.SendWrapped(rg1(store), nil, &argsSplit); pErr != nil {
+		t.Fatalf("Can't split range %s", pErr)
 	}
 	argsSplit = adminSplitArgs(roachpb.KeyMin, []byte("b"))
-	if _, err := client.SendWrapped(rg1(store), nil, &argsSplit); err != nil {
-		t.Fatalf("Can't split range %s", err)
+	if _, pErr := client.SendWrapped(rg1(store), nil, &argsSplit); pErr != nil {
+		t.Fatalf("Can't split range %s", pErr)
 	}
 
 	rangeA := store.LookupReplica([]byte("a"), nil)
@@ -350,7 +350,7 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 	// Attempt to merge.
 	rangeADesc = rangeA.Desc()
 	argsMerge := adminMergeArgs(roachpb.Key(rangeADesc.StartKey))
-	if _, err := rangeA.AdminMerge(argsMerge, rangeADesc); !testutils.IsError(err, "ranges not collocated") {
-		t.Fatalf("did not got expected error; got %s", err)
+	if _, pErr := rangeA.AdminMerge(argsMerge, rangeADesc); !testutils.IsError(pErr.GoError(), "ranges not collocated") {
+		t.Fatalf("did not got expected error; got %s", pErr)
 	}
 }

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -100,7 +100,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 		defer stopper.Stop()
 		store := createTestStoreWithEngine(t, eng, clock, true, nil, stopper)
 
-		increment := func(rangeID roachpb.RangeID, key roachpb.Key, value int64) (*roachpb.IncrementResponse, error) {
+		increment := func(rangeID roachpb.RangeID, key roachpb.Key, value int64) (*roachpb.IncrementResponse, *roachpb.Error) {
 			args := incrementArgs(key, value)
 			resp, err := client.SendWrappedWith(rg1(store), nil, roachpb.Header{
 				RangeID: rangeID,
@@ -322,22 +322,22 @@ func TestRestoreReplicas(t *testing.T) {
 	// should be forwarded to the leader.
 	incArgs = incrementArgs([]byte("a"), 11)
 	{
-		_, err := client.SendWrapped(rg1(mtc.stores[1]), nil, &incArgs)
-		if _, ok := err.(*roachpb.NotLeaderError); !ok {
-			t.Fatalf("expected not leader error; got %s", err)
+		_, pErr := client.SendWrapped(rg1(mtc.stores[1]), nil, &incArgs)
+		if _, ok := pErr.GoError().(*roachpb.NotLeaderError); !ok {
+			t.Fatalf("expected not leader error; got %s", pErr)
 		}
 	}
 	// Send again, this time to first store.
-	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	if err := util.IsTrueWithin(func() bool {
 		getArgs := getArgs([]byte("a"))
-		reply, err := client.SendWrappedWith(rg1(mtc.stores[1]), nil, roachpb.Header{
+		reply, pErr := client.SendWrappedWith(rg1(mtc.stores[1]), nil, roachpb.Header{
 			ReadConsistency: roachpb.INCONSISTENT,
 		}, &getArgs)
-		if err != nil {
+		if pErr != nil {
 			return false
 		}
 		return mustGetInt(reply.(*roachpb.GetResponse).Value) == 39
@@ -1437,7 +1437,7 @@ func TestReplicateReAddAfterDown(t *testing.T) {
 
 // TestLeaderRemoveSelf verifies that a leader can remove itself
 // without panicking and future access to the range returns a
-// RangeNotFoundError (not errRaftGroupDeleted, and even before
+// RangeNotFoundError (not RaftGroupDeletedError, and even before
 // the ReplicaGCQueue has run).
 func TestLeaderRemoveSelf(t *testing.T) {
 	defer leaktest.AfterTest(t)
@@ -1460,8 +1460,8 @@ func TestLeaderRemoveSelf(t *testing.T) {
 	header.Timestamp = clock.Update(clock.Now().Add(int64(storage.DefaultLeaderLeaseDuration), 0))
 
 	// Expect get a RangeNotFoundError.
-	_, err := client.SendWrappedWith(rg1(mtc.stores[0]), nil, header, &getArgs)
-	if _, ok := err.(*roachpb.RangeNotFoundError); !ok {
-		t.Fatalf("expect get RangeNotFoundError, actual get %v ", err)
+	_, pErr := client.SendWrappedWith(rg1(mtc.stores[0]), nil, header, &getArgs)
+	if _, ok := pErr.GoError().(*roachpb.RangeNotFoundError); !ok {
+		t.Fatalf("expect get RangeNotFoundError, actual get %v ", pErr)
 	}
 }

--- a/storage/engine/rocksdb/cockroach/roachpb/errors.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/errors.pb.cc
@@ -67,6 +67,24 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* SendError_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   SendError_reflection_ = NULL;
+const ::google::protobuf::Descriptor* RaftGroupDeletedError_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  RaftGroupDeletedError_reflection_ = NULL;
+const ::google::protobuf::Descriptor* ReplicaCorruptionError_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  ReplicaCorruptionError_reflection_ = NULL;
+const ::google::protobuf::Descriptor* LeaseVersionChangedError_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  LeaseVersionChangedError_reflection_ = NULL;
+const ::google::protobuf::Descriptor* DidntUpdateDescriptorError_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  DidntUpdateDescriptorError_reflection_ = NULL;
+const ::google::protobuf::Descriptor* SqlTransactionAbortedError_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  SqlTransactionAbortedError_reflection_ = NULL;
+const ::google::protobuf::Descriptor* ExistingSchemaChangeLeaseError_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  ExistingSchemaChangeLeaseError_reflection_ = NULL;
 const ::google::protobuf::Descriptor* ErrorDetail_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ErrorDetail_reflection_ = NULL;
@@ -231,10 +249,9 @@ void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TransactionStatusError, _internal_metadata_),
       -1);
   WriteIntentError_descriptor_ = file->message_type(9);
-  static const int WriteIntentError_offsets_[3] = {
+  static const int WriteIntentError_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteIntentError, intents_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteIntentError, resolved_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WriteIntentError, index_),
   };
   WriteIntentError_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -278,9 +295,8 @@ void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(OpRequiresTxnError, _internal_metadata_),
       -1);
   ConditionFailedError_descriptor_ = file->message_type(12);
-  static const int ConditionFailedError_offsets_[2] = {
+  static const int ConditionFailedError_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConditionFailedError, actual_value_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConditionFailedError, index_),
   };
   ConditionFailedError_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -326,8 +342,94 @@ void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto() {
       sizeof(SendError),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SendError, _internal_metadata_),
       -1);
-  ErrorDetail_descriptor_ = file->message_type(15);
-  static const int ErrorDetail_offsets_[15] = {
+  RaftGroupDeletedError_descriptor_ = file->message_type(15);
+  static const int RaftGroupDeletedError_offsets_[1] = {
+  };
+  RaftGroupDeletedError_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      RaftGroupDeletedError_descriptor_,
+      RaftGroupDeletedError::default_instance_,
+      RaftGroupDeletedError_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftGroupDeletedError, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(RaftGroupDeletedError),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RaftGroupDeletedError, _internal_metadata_),
+      -1);
+  ReplicaCorruptionError_descriptor_ = file->message_type(16);
+  static const int ReplicaCorruptionError_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReplicaCorruptionError, error_msg_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReplicaCorruptionError, processed_),
+  };
+  ReplicaCorruptionError_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      ReplicaCorruptionError_descriptor_,
+      ReplicaCorruptionError::default_instance_,
+      ReplicaCorruptionError_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReplicaCorruptionError, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(ReplicaCorruptionError),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReplicaCorruptionError, _internal_metadata_),
+      -1);
+  LeaseVersionChangedError_descriptor_ = file->message_type(17);
+  static const int LeaseVersionChangedError_offsets_[1] = {
+  };
+  LeaseVersionChangedError_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      LeaseVersionChangedError_descriptor_,
+      LeaseVersionChangedError::default_instance_,
+      LeaseVersionChangedError_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaseVersionChangedError, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(LeaseVersionChangedError),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaseVersionChangedError, _internal_metadata_),
+      -1);
+  DidntUpdateDescriptorError_descriptor_ = file->message_type(18);
+  static const int DidntUpdateDescriptorError_offsets_[1] = {
+  };
+  DidntUpdateDescriptorError_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      DidntUpdateDescriptorError_descriptor_,
+      DidntUpdateDescriptorError::default_instance_,
+      DidntUpdateDescriptorError_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DidntUpdateDescriptorError, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(DidntUpdateDescriptorError),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DidntUpdateDescriptorError, _internal_metadata_),
+      -1);
+  SqlTransactionAbortedError_descriptor_ = file->message_type(19);
+  static const int SqlTransactionAbortedError_offsets_[1] = {
+  };
+  SqlTransactionAbortedError_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      SqlTransactionAbortedError_descriptor_,
+      SqlTransactionAbortedError::default_instance_,
+      SqlTransactionAbortedError_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SqlTransactionAbortedError, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(SqlTransactionAbortedError),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SqlTransactionAbortedError, _internal_metadata_),
+      -1);
+  ExistingSchemaChangeLeaseError_descriptor_ = file->message_type(20);
+  static const int ExistingSchemaChangeLeaseError_offsets_[1] = {
+  };
+  ExistingSchemaChangeLeaseError_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      ExistingSchemaChangeLeaseError_descriptor_,
+      ExistingSchemaChangeLeaseError::default_instance_,
+      ExistingSchemaChangeLeaseError_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ExistingSchemaChangeLeaseError, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(ExistingSchemaChangeLeaseError),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ExistingSchemaChangeLeaseError, _internal_metadata_),
+      -1);
+  ErrorDetail_descriptor_ = file->message_type(21);
+  static const int ErrorDetail_offsets_[21] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, not_leader_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, range_not_found_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, range_key_mismatch_),
@@ -343,6 +445,12 @@ void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, lease_rejected_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, node_unavailable_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, send_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, raft_group_deleted_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, replica_corruption_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, lease_version_changed_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, didnt_update_descriptor_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, sql_tranasction_aborted_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, existing_scheme_change_lease_),
   };
   ErrorDetail_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -355,7 +463,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto() {
       sizeof(ErrorDetail),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrorDetail, _internal_metadata_),
       -1);
-  ErrPosition_descriptor_ = file->message_type(16);
+  ErrPosition_descriptor_ = file->message_type(22);
   static const int ErrPosition_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrPosition, index_),
   };
@@ -370,12 +478,14 @@ void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto() {
       sizeof(ErrPosition),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrPosition, _internal_metadata_),
       -1);
-  Error_descriptor_ = file->message_type(17);
-  static const int Error_offsets_[4] = {
+  Error_descriptor_ = file->message_type(23);
+  static const int Error_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, message_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, retryable_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, transaction_restart_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, txn_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, detail_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, index_),
   };
   Error_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -432,6 +542,18 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       SendError_descriptor_, &SendError::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      RaftGroupDeletedError_descriptor_, &RaftGroupDeletedError::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      ReplicaCorruptionError_descriptor_, &ReplicaCorruptionError::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      LeaseVersionChangedError_descriptor_, &LeaseVersionChangedError::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      DidntUpdateDescriptorError_descriptor_, &DidntUpdateDescriptorError::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      SqlTransactionAbortedError_descriptor_, &SqlTransactionAbortedError::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      ExistingSchemaChangeLeaseError_descriptor_, &ExistingSchemaChangeLeaseError::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       ErrorDetail_descriptor_, &ErrorDetail::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       ErrPosition_descriptor_, &ErrPosition::default_instance());
@@ -472,6 +594,18 @@ void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto() {
   delete LeaseRejectedError_reflection_;
   delete SendError::default_instance_;
   delete SendError_reflection_;
+  delete RaftGroupDeletedError::default_instance_;
+  delete RaftGroupDeletedError_reflection_;
+  delete ReplicaCorruptionError::default_instance_;
+  delete ReplicaCorruptionError_reflection_;
+  delete LeaseVersionChangedError::default_instance_;
+  delete LeaseVersionChangedError_reflection_;
+  delete DidntUpdateDescriptorError::default_instance_;
+  delete DidntUpdateDescriptorError_reflection_;
+  delete SqlTransactionAbortedError::default_instance_;
+  delete SqlTransactionAbortedError_reflection_;
+  delete ExistingSchemaChangeLeaseError::default_instance_;
+  delete ExistingSchemaChangeLeaseError_reflection_;
   delete ErrorDetail::default_instance_;
   delete ErrorDetail_reflection_;
   delete ErrPosition::default_instance_;
@@ -519,55 +653,73 @@ void protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto() {
     "\001 \001(\0132\036.cockroach.roachpb.TransactionB\004\310"
     "\336\037\000\"^\n\026TransactionStatusError\0221\n\003txn\030\001 \001"
     "(\0132\036.cockroach.roachpb.TransactionB\004\310\336\037\000"
-    "\022\021\n\003msg\030\002 \001(\tB\004\310\336\037\000\"\213\001\n\020WriteIntentError"
-    "\0220\n\007intents\030\001 \003(\0132\031.cockroach.roachpb.In"
-    "tentB\004\310\336\037\000\022\026\n\010resolved\030\002 \001(\010B\004\310\336\037\000\022-\n\005in"
-    "dex\030\003 \001(\0132\036.cockroach.roachpb.ErrPositio"
-    "n\"\211\001\n\020WriteTooOldError\0225\n\ttimestamp\030\001 \001("
-    "\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022>\n"
-    "\022existing_timestamp\030\002 \001(\0132\034.cockroach.ro"
-    "achpb.TimestampB\004\310\336\037\000\"\024\n\022OpRequiresTxnEr"
-    "ror\"u\n\024ConditionFailedError\022.\n\014actual_va"
-    "lue\030\001 \001(\0132\030.cockroach.roachpb.Value\022-\n\005i"
-    "ndex\030\002 \001(\0132\036.cockroach.roachpb.ErrPositi"
-    "on\"\220\001\n\022LeaseRejectedError\022\025\n\007message\030\001 \001"
-    "(\tB\004\310\336\037\000\0221\n\trequested\030\002 \001(\0132\030.cockroach."
-    "roachpb.LeaseB\004\310\336\037\000\0220\n\010existing\030\003 \001(\0132\030."
-    "cockroach.roachpb.LeaseB\004\310\336\037\000\";\n\tSendErr"
-    "or\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryable\030\002"
-    " \001(\010B\004\310\336\037\000\"\361\007\n\013ErrorDetail\0225\n\nnot_leader"
-    "\030\001 \001(\0132!.cockroach.roachpb.NotLeaderErro"
-    "r\022>\n\017range_not_found\030\002 \001(\0132%.cockroach.r"
-    "oachpb.RangeNotFoundError\022D\n\022range_key_m"
-    "ismatch\030\003 \001(\0132(.cockroach.roachpb.RangeK"
-    "eyMismatchError\022_\n read_within_uncertain"
-    "ty_interval\030\004 \001(\01325.cockroach.roachpb.Re"
-    "adWithinUncertaintyIntervalError\022G\n\023tran"
-    "saction_aborted\030\005 \001(\0132*.cockroach.roachp"
-    "b.TransactionAbortedError\022A\n\020transaction"
-    "_push\030\006 \001(\0132\'.cockroach.roachpb.Transact"
-    "ionPushError\022C\n\021transaction_retry\030\007 \001(\0132"
-    "(.cockroach.roachpb.TransactionRetryErro"
-    "r\022E\n\022transaction_status\030\010 \001(\0132).cockroac"
-    "h.roachpb.TransactionStatusError\0229\n\014writ"
-    "e_intent\030\t \001(\0132#.cockroach.roachpb.Write"
-    "IntentError\022:\n\rwrite_too_old\030\n \001(\0132#.coc"
-    "kroach.roachpb.WriteTooOldError\022>\n\017op_re"
-    "quires_txn\030\013 \001(\0132%.cockroach.roachpb.OpR"
-    "equiresTxnError\022A\n\020condition_failed\030\014 \001("
-    "\0132\'.cockroach.roachpb.ConditionFailedErr"
-    "or\022=\n\016lease_rejected\030\r \001(\0132%.cockroach.r"
-    "oachpb.LeaseRejectedError\022A\n\020node_unavai"
-    "lable\030\016 \001(\0132\'.cockroach.roachpb.NodeUnav"
-    "ailableError\022*\n\004send\030\017 \001(\0132\034.cockroach.r"
-    "oachpb.SendError:\004\310\240\037\001\"\"\n\013ErrPosition\022\023\n"
-    "\005index\030\001 \001(\005B\004\310\336\037\000\"\267\001\n\005Error\022\025\n\007message\030"
-    "\001 \001(\tB\004\310\336\037\000\022\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\022H\n\023"
-    "transaction_restart\030\003 \001(\0162%.cockroach.ro"
-    "achpb.TransactionRestartB\004\310\336\037\000\022.\n\006detail"
-    "\030\004 \001(\0132\036.cockroach.roachpb.ErrorDetail:\004"
-    "\230\240\037\000*;\n\022TransactionRestart\022\t\n\005ABORT\020\000\022\013\n"
-    "\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\tZ\007roachpbX\002", 3118);
+    "\022\021\n\003msg\030\002 \001(\tB\004\310\336\037\000\"\\\n\020WriteIntentError\022"
+    "0\n\007intents\030\001 \003(\0132\031.cockroach.roachpb.Int"
+    "entB\004\310\336\037\000\022\026\n\010resolved\030\002 \001(\010B\004\310\336\037\000\"\211\001\n\020Wr"
+    "iteTooOldError\0225\n\ttimestamp\030\001 \001(\0132\034.cock"
+    "roach.roachpb.TimestampB\004\310\336\037\000\022>\n\022existin"
+    "g_timestamp\030\002 \001(\0132\034.cockroach.roachpb.Ti"
+    "mestampB\004\310\336\037\000\"\024\n\022OpRequiresTxnError\"F\n\024C"
+    "onditionFailedError\022.\n\014actual_value\030\001 \001("
+    "\0132\030.cockroach.roachpb.Value\"\220\001\n\022LeaseRej"
+    "ectedError\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\0221\n\treq"
+    "uested\030\002 \001(\0132\030.cockroach.roachpb.LeaseB\004"
+    "\310\336\037\000\0220\n\010existing\030\003 \001(\0132\030.cockroach.roach"
+    "pb.LeaseB\004\310\336\037\000\";\n\tSendError\022\025\n\007message\030\001"
+    " \001(\tB\004\310\336\037\000\022\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\"\027\n\025R"
+    "aftGroupDeletedError\"J\n\026ReplicaCorruptio"
+    "nError\022\027\n\terror_msg\030\001 \001(\tB\004\310\336\037\000\022\027\n\tproce"
+    "ssed\030\002 \001(\010B\004\310\336\037\000\"\032\n\030LeaseVersionChangedE"
+    "rror\"\034\n\032DidntUpdateDescriptorError\"\034\n\032Sq"
+    "lTransactionAbortedError\" \n\036ExistingSche"
+    "maChangeLeaseError\"\303\013\n\013ErrorDetail\0225\n\nno"
+    "t_leader\030\001 \001(\0132!.cockroach.roachpb.NotLe"
+    "aderError\022>\n\017range_not_found\030\002 \001(\0132%.coc"
+    "kroach.roachpb.RangeNotFoundError\022D\n\022ran"
+    "ge_key_mismatch\030\003 \001(\0132(.cockroach.roachp"
+    "b.RangeKeyMismatchError\022_\n read_within_u"
+    "ncertainty_interval\030\004 \001(\01325.cockroach.ro"
+    "achpb.ReadWithinUncertaintyIntervalError"
+    "\022G\n\023transaction_aborted\030\005 \001(\0132*.cockroac"
+    "h.roachpb.TransactionAbortedError\022A\n\020tra"
+    "nsaction_push\030\006 \001(\0132\'.cockroach.roachpb."
+    "TransactionPushError\022C\n\021transaction_retr"
+    "y\030\007 \001(\0132(.cockroach.roachpb.TransactionR"
+    "etryError\022E\n\022transaction_status\030\010 \001(\0132)."
+    "cockroach.roachpb.TransactionStatusError"
+    "\0229\n\014write_intent\030\t \001(\0132#.cockroach.roach"
+    "pb.WriteIntentError\022:\n\rwrite_too_old\030\n \001"
+    "(\0132#.cockroach.roachpb.WriteTooOldError\022"
+    ">\n\017op_requires_txn\030\013 \001(\0132%.cockroach.roa"
+    "chpb.OpRequiresTxnError\022A\n\020condition_fai"
+    "led\030\014 \001(\0132\'.cockroach.roachpb.ConditionF"
+    "ailedError\022=\n\016lease_rejected\030\r \001(\0132%.coc"
+    "kroach.roachpb.LeaseRejectedError\022A\n\020nod"
+    "e_unavailable\030\016 \001(\0132\'.cockroach.roachpb."
+    "NodeUnavailableError\022*\n\004send\030\017 \001(\0132\034.coc"
+    "kroach.roachpb.SendError\022D\n\022raft_group_d"
+    "eleted\030\020 \001(\0132(.cockroach.roachpb.RaftGro"
+    "upDeletedError\022E\n\022replica_corruption\030\021 \001"
+    "(\0132).cockroach.roachpb.ReplicaCorruption"
+    "Error\022J\n\025lease_version_changed\030\022 \001(\0132+.c"
+    "ockroach.roachpb.LeaseVersionChangedErro"
+    "r\022N\n\027didnt_update_descriptor\030\023 \001(\0132-.coc"
+    "kroach.roachpb.DidntUpdateDescriptorErro"
+    "r\022N\n\027sql_tranasction_aborted\030\024 \001(\0132-.coc"
+    "kroach.roachpb.SqlTransactionAbortedErro"
+    "r\022W\n\034existing_scheme_change_lease\030\025 \001(\0132"
+    "1.cockroach.roachpb.ExistingSchemaChange"
+    "LeaseError:\004\310\240\037\001\"\"\n\013ErrPosition\022\023\n\005index"
+    "\030\001 \001(\005B\004\310\336\037\000\"\223\002\n\005Error\022\025\n\007message\030\001 \001(\tB"
+    "\004\310\336\037\000\022\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\022H\n\023transa"
+    "ction_restart\030\003 \001(\0162%.cockroach.roachpb."
+    "TransactionRestartB\004\310\336\037\000\022+\n\003txn\030\004 \001(\0132\036."
+    "cockroach.roachpb.Transaction\022.\n\006detail\030"
+    "\005 \001(\0132\036.cockroach.roachpb.ErrorDetail\022-\n"
+    "\005index\030\006 \001(\0132\036.cockroach.roachpb.ErrPosi"
+    "tion:\004\230\240\037\000*;\n\022TransactionRestart\022\t\n\005ABOR"
+    "T\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\tZ\007roach"
+    "pbX\002", 3804);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/errors.proto", &protobuf_RegisterTypes);
   NotLeaderError::default_instance_ = new NotLeaderError();
@@ -585,6 +737,12 @@ void protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto() {
   ConditionFailedError::default_instance_ = new ConditionFailedError();
   LeaseRejectedError::default_instance_ = new LeaseRejectedError();
   SendError::default_instance_ = new SendError();
+  RaftGroupDeletedError::default_instance_ = new RaftGroupDeletedError();
+  ReplicaCorruptionError::default_instance_ = new ReplicaCorruptionError();
+  LeaseVersionChangedError::default_instance_ = new LeaseVersionChangedError();
+  DidntUpdateDescriptorError::default_instance_ = new DidntUpdateDescriptorError();
+  SqlTransactionAbortedError::default_instance_ = new SqlTransactionAbortedError();
+  ExistingSchemaChangeLeaseError::default_instance_ = new ExistingSchemaChangeLeaseError();
   ErrorDetail::default_instance_ = new ErrorDetail();
   ErrPosition::default_instance_ = new ErrPosition();
   Error::default_instance_ = new Error();
@@ -603,6 +761,12 @@ void protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto() {
   ConditionFailedError::default_instance_->InitAsDefaultInstance();
   LeaseRejectedError::default_instance_->InitAsDefaultInstance();
   SendError::default_instance_->InitAsDefaultInstance();
+  RaftGroupDeletedError::default_instance_->InitAsDefaultInstance();
+  ReplicaCorruptionError::default_instance_->InitAsDefaultInstance();
+  LeaseVersionChangedError::default_instance_->InitAsDefaultInstance();
+  DidntUpdateDescriptorError::default_instance_->InitAsDefaultInstance();
+  SqlTransactionAbortedError::default_instance_->InitAsDefaultInstance();
+  ExistingSchemaChangeLeaseError::default_instance_->InitAsDefaultInstance();
   ErrorDetail::default_instance_->InitAsDefaultInstance();
   ErrPosition::default_instance_->InitAsDefaultInstance();
   Error::default_instance_->InitAsDefaultInstance();
@@ -3874,7 +4038,6 @@ void TransactionStatusError::clear_msg() {
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int WriteIntentError::kIntentsFieldNumber;
 const int WriteIntentError::kResolvedFieldNumber;
-const int WriteIntentError::kIndexFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 WriteIntentError::WriteIntentError()
@@ -3884,7 +4047,6 @@ WriteIntentError::WriteIntentError()
 }
 
 void WriteIntentError::InitAsDefaultInstance() {
-  index_ = const_cast< ::cockroach::roachpb::ErrPosition*>(&::cockroach::roachpb::ErrPosition::default_instance());
 }
 
 WriteIntentError::WriteIntentError(const WriteIntentError& from)
@@ -3898,7 +4060,6 @@ WriteIntentError::WriteIntentError(const WriteIntentError& from)
 void WriteIntentError::SharedCtor() {
   _cached_size_ = 0;
   resolved_ = false;
-  index_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -3909,7 +4070,6 @@ WriteIntentError::~WriteIntentError() {
 
 void WriteIntentError::SharedDtor() {
   if (this != default_instance_) {
-    delete index_;
   }
 }
 
@@ -3939,12 +4099,7 @@ WriteIntentError* WriteIntentError::New(::google::protobuf::Arena* arena) const 
 }
 
 void WriteIntentError::Clear() {
-  if (_has_bits_[0 / 32] & 6u) {
-    resolved_ = false;
-    if (has_index()) {
-      if (index_ != NULL) index_->::cockroach::roachpb::ErrPosition::Clear();
-    }
-  }
+  resolved_ = false;
   intents_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3989,19 +4144,6 @@ bool WriteIntentError::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(26)) goto parse_index;
-        break;
-      }
-
-      // optional .cockroach.roachpb.ErrPosition index = 3;
-      case 3: {
-        if (tag == 26) {
-         parse_index:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_index()));
-        } else {
-          goto handle_unusual;
-        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -4042,12 +4184,6 @@ void WriteIntentError::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteBool(2, this->resolved(), output);
   }
 
-  // optional .cockroach.roachpb.ErrPosition index = 3;
-  if (has_index()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      3, *this->index_, output);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -4070,13 +4206,6 @@ void WriteIntentError::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(2, this->resolved(), target);
   }
 
-  // optional .cockroach.roachpb.ErrPosition index = 3;
-  if (has_index()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        3, *this->index_, target);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -4088,20 +4217,11 @@ void WriteIntentError::SerializeWithCachedSizes(
 int WriteIntentError::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[1 / 32] & 6u) {
-    // optional bool resolved = 2;
-    if (has_resolved()) {
-      total_size += 1 + 1;
-    }
-
-    // optional .cockroach.roachpb.ErrPosition index = 3;
-    if (has_index()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->index_);
-    }
-
+  // optional bool resolved = 2;
+  if (has_resolved()) {
+    total_size += 1 + 1;
   }
+
   // repeated .cockroach.roachpb.Intent intents = 1;
   total_size += 1 * this->intents_size();
   for (int i = 0; i < this->intents_size(); i++) {
@@ -4140,9 +4260,6 @@ void WriteIntentError::MergeFrom(const WriteIntentError& from) {
     if (from.has_resolved()) {
       set_resolved(from.resolved());
     }
-    if (from.has_index()) {
-      mutable_index()->::cockroach::roachpb::ErrPosition::MergeFrom(from.index());
-    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -4173,7 +4290,6 @@ void WriteIntentError::Swap(WriteIntentError* other) {
 void WriteIntentError::InternalSwap(WriteIntentError* other) {
   intents_.UnsafeArenaSwap(&other->intents_);
   std::swap(resolved_, other->resolved_);
-  std::swap(index_, other->index_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -4242,49 +4358,6 @@ void WriteIntentError::clear_resolved() {
   set_has_resolved();
   resolved_ = value;
   // @@protoc_insertion_point(field_set:cockroach.roachpb.WriteIntentError.resolved)
-}
-
-// optional .cockroach.roachpb.ErrPosition index = 3;
-bool WriteIntentError::has_index() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-void WriteIntentError::set_has_index() {
-  _has_bits_[0] |= 0x00000004u;
-}
-void WriteIntentError::clear_has_index() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-void WriteIntentError::clear_index() {
-  if (index_ != NULL) index_->::cockroach::roachpb::ErrPosition::Clear();
-  clear_has_index();
-}
-const ::cockroach::roachpb::ErrPosition& WriteIntentError::index() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.WriteIntentError.index)
-  return index_ != NULL ? *index_ : *default_instance_->index_;
-}
-::cockroach::roachpb::ErrPosition* WriteIntentError::mutable_index() {
-  set_has_index();
-  if (index_ == NULL) {
-    index_ = new ::cockroach::roachpb::ErrPosition;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.WriteIntentError.index)
-  return index_;
-}
-::cockroach::roachpb::ErrPosition* WriteIntentError::release_index() {
-  clear_has_index();
-  ::cockroach::roachpb::ErrPosition* temp = index_;
-  index_ = NULL;
-  return temp;
-}
-void WriteIntentError::set_allocated_index(::cockroach::roachpb::ErrPosition* index) {
-  delete index_;
-  index_ = index;
-  if (index) {
-    set_has_index();
-  } else {
-    clear_has_index();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.WriteIntentError.index)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -4856,7 +4929,6 @@ void OpRequiresTxnError::InternalSwap(OpRequiresTxnError* other) {
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int ConditionFailedError::kActualValueFieldNumber;
-const int ConditionFailedError::kIndexFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ConditionFailedError::ConditionFailedError()
@@ -4867,7 +4939,6 @@ ConditionFailedError::ConditionFailedError()
 
 void ConditionFailedError::InitAsDefaultInstance() {
   actual_value_ = const_cast< ::cockroach::roachpb::Value*>(&::cockroach::roachpb::Value::default_instance());
-  index_ = const_cast< ::cockroach::roachpb::ErrPosition*>(&::cockroach::roachpb::ErrPosition::default_instance());
 }
 
 ConditionFailedError::ConditionFailedError(const ConditionFailedError& from)
@@ -4881,7 +4952,6 @@ ConditionFailedError::ConditionFailedError(const ConditionFailedError& from)
 void ConditionFailedError::SharedCtor() {
   _cached_size_ = 0;
   actual_value_ = NULL;
-  index_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -4893,7 +4963,6 @@ ConditionFailedError::~ConditionFailedError() {
 void ConditionFailedError::SharedDtor() {
   if (this != default_instance_) {
     delete actual_value_;
-    delete index_;
   }
 }
 
@@ -4923,13 +4992,8 @@ ConditionFailedError* ConditionFailedError::New(::google::protobuf::Arena* arena
 }
 
 void ConditionFailedError::Clear() {
-  if (_has_bits_[0 / 32] & 3u) {
-    if (has_actual_value()) {
-      if (actual_value_ != NULL) actual_value_->::cockroach::roachpb::Value::Clear();
-    }
-    if (has_index()) {
-      if (index_ != NULL) index_->::cockroach::roachpb::ErrPosition::Clear();
-    }
+  if (has_actual_value()) {
+    if (actual_value_ != NULL) actual_value_->::cockroach::roachpb::Value::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -4952,19 +5016,6 @@ bool ConditionFailedError::MergePartialFromCodedStream(
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_actual_value()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(18)) goto parse_index;
-        break;
-      }
-
-      // optional .cockroach.roachpb.ErrPosition index = 2;
-      case 2: {
-        if (tag == 18) {
-         parse_index:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_index()));
         } else {
           goto handle_unusual;
         }
@@ -5003,12 +5054,6 @@ void ConditionFailedError::SerializeWithCachedSizes(
       1, *this->actual_value_, output);
   }
 
-  // optional .cockroach.roachpb.ErrPosition index = 2;
-  if (has_index()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      2, *this->index_, output);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -5026,13 +5071,6 @@ void ConditionFailedError::SerializeWithCachedSizes(
         1, *this->actual_value_, target);
   }
 
-  // optional .cockroach.roachpb.ErrPosition index = 2;
-  if (has_index()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        2, *this->index_, target);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -5044,22 +5082,13 @@ void ConditionFailedError::SerializeWithCachedSizes(
 int ConditionFailedError::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 3u) {
-    // optional .cockroach.roachpb.Value actual_value = 1;
-    if (has_actual_value()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->actual_value_);
-    }
-
-    // optional .cockroach.roachpb.ErrPosition index = 2;
-    if (has_index()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->index_);
-    }
-
+  // optional .cockroach.roachpb.Value actual_value = 1;
+  if (has_actual_value()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->actual_value_);
   }
+
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -5088,9 +5117,6 @@ void ConditionFailedError::MergeFrom(const ConditionFailedError& from) {
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_actual_value()) {
       mutable_actual_value()->::cockroach::roachpb::Value::MergeFrom(from.actual_value());
-    }
-    if (from.has_index()) {
-      mutable_index()->::cockroach::roachpb::ErrPosition::MergeFrom(from.index());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -5121,7 +5147,6 @@ void ConditionFailedError::Swap(ConditionFailedError* other) {
 }
 void ConditionFailedError::InternalSwap(ConditionFailedError* other) {
   std::swap(actual_value_, other->actual_value_);
-  std::swap(index_, other->index_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -5179,49 +5204,6 @@ void ConditionFailedError::set_allocated_actual_value(::cockroach::roachpb::Valu
     clear_has_actual_value();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ConditionFailedError.actual_value)
-}
-
-// optional .cockroach.roachpb.ErrPosition index = 2;
-bool ConditionFailedError::has_index() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
-}
-void ConditionFailedError::set_has_index() {
-  _has_bits_[0] |= 0x00000002u;
-}
-void ConditionFailedError::clear_has_index() {
-  _has_bits_[0] &= ~0x00000002u;
-}
-void ConditionFailedError::clear_index() {
-  if (index_ != NULL) index_->::cockroach::roachpb::ErrPosition::Clear();
-  clear_has_index();
-}
-const ::cockroach::roachpb::ErrPosition& ConditionFailedError::index() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.ConditionFailedError.index)
-  return index_ != NULL ? *index_ : *default_instance_->index_;
-}
-::cockroach::roachpb::ErrPosition* ConditionFailedError::mutable_index() {
-  set_has_index();
-  if (index_ == NULL) {
-    index_ = new ::cockroach::roachpb::ErrPosition;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ConditionFailedError.index)
-  return index_;
-}
-::cockroach::roachpb::ErrPosition* ConditionFailedError::release_index() {
-  clear_has_index();
-  ::cockroach::roachpb::ErrPosition* temp = index_;
-  index_ = NULL;
-  return temp;
-}
-void ConditionFailedError::set_allocated_index(::cockroach::roachpb::ErrPosition* index) {
-  delete index_;
-  index_ = index;
-  if (index) {
-    set_has_index();
-  } else {
-    clear_has_index();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ConditionFailedError.index)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -6084,6 +6066,1322 @@ void SendError::clear_retryable() {
 // ===================================================================
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+RaftGroupDeletedError::RaftGroupDeletedError()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.RaftGroupDeletedError)
+}
+
+void RaftGroupDeletedError::InitAsDefaultInstance() {
+}
+
+RaftGroupDeletedError::RaftGroupDeletedError(const RaftGroupDeletedError& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.RaftGroupDeletedError)
+}
+
+void RaftGroupDeletedError::SharedCtor() {
+  _cached_size_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+RaftGroupDeletedError::~RaftGroupDeletedError() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.RaftGroupDeletedError)
+  SharedDtor();
+}
+
+void RaftGroupDeletedError::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void RaftGroupDeletedError::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* RaftGroupDeletedError::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return RaftGroupDeletedError_descriptor_;
+}
+
+const RaftGroupDeletedError& RaftGroupDeletedError::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  return *default_instance_;
+}
+
+RaftGroupDeletedError* RaftGroupDeletedError::default_instance_ = NULL;
+
+RaftGroupDeletedError* RaftGroupDeletedError::New(::google::protobuf::Arena* arena) const {
+  RaftGroupDeletedError* n = new RaftGroupDeletedError;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void RaftGroupDeletedError::Clear() {
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool RaftGroupDeletedError::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.RaftGroupDeletedError)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+  handle_unusual:
+    if (tag == 0 ||
+        ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+        ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+      goto success;
+    }
+    DO_(::google::protobuf::internal::WireFormat::SkipField(
+          input, tag, mutable_unknown_fields()));
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.RaftGroupDeletedError)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.RaftGroupDeletedError)
+  return false;
+#undef DO_
+}
+
+void RaftGroupDeletedError::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.RaftGroupDeletedError)
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.RaftGroupDeletedError)
+}
+
+::google::protobuf::uint8* RaftGroupDeletedError::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.RaftGroupDeletedError)
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.RaftGroupDeletedError)
+  return target;
+}
+
+int RaftGroupDeletedError::ByteSize() const {
+  int total_size = 0;
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void RaftGroupDeletedError::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const RaftGroupDeletedError* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const RaftGroupDeletedError>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void RaftGroupDeletedError::MergeFrom(const RaftGroupDeletedError& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void RaftGroupDeletedError::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RaftGroupDeletedError::CopyFrom(const RaftGroupDeletedError& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RaftGroupDeletedError::IsInitialized() const {
+
+  return true;
+}
+
+void RaftGroupDeletedError::Swap(RaftGroupDeletedError* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void RaftGroupDeletedError::InternalSwap(RaftGroupDeletedError* other) {
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata RaftGroupDeletedError::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = RaftGroupDeletedError_descriptor_;
+  metadata.reflection = RaftGroupDeletedError_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// RaftGroupDeletedError
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ReplicaCorruptionError::kErrorMsgFieldNumber;
+const int ReplicaCorruptionError::kProcessedFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ReplicaCorruptionError::ReplicaCorruptionError()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.ReplicaCorruptionError)
+}
+
+void ReplicaCorruptionError::InitAsDefaultInstance() {
+}
+
+ReplicaCorruptionError::ReplicaCorruptionError(const ReplicaCorruptionError& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.ReplicaCorruptionError)
+}
+
+void ReplicaCorruptionError::SharedCtor() {
+  ::google::protobuf::internal::GetEmptyString();
+  _cached_size_ = 0;
+  error_msg_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  processed_ = false;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+ReplicaCorruptionError::~ReplicaCorruptionError() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.ReplicaCorruptionError)
+  SharedDtor();
+}
+
+void ReplicaCorruptionError::SharedDtor() {
+  error_msg_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (this != default_instance_) {
+  }
+}
+
+void ReplicaCorruptionError::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* ReplicaCorruptionError::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return ReplicaCorruptionError_descriptor_;
+}
+
+const ReplicaCorruptionError& ReplicaCorruptionError::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  return *default_instance_;
+}
+
+ReplicaCorruptionError* ReplicaCorruptionError::default_instance_ = NULL;
+
+ReplicaCorruptionError* ReplicaCorruptionError::New(::google::protobuf::Arena* arena) const {
+  ReplicaCorruptionError* n = new ReplicaCorruptionError;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void ReplicaCorruptionError::Clear() {
+  if (_has_bits_[0 / 32] & 3u) {
+    if (has_error_msg()) {
+      error_msg_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    }
+    processed_ = false;
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool ReplicaCorruptionError::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.ReplicaCorruptionError)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional string error_msg = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_error_msg()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+            this->error_msg().data(), this->error_msg().length(),
+            ::google::protobuf::internal::WireFormat::PARSE,
+            "cockroach.roachpb.ReplicaCorruptionError.error_msg");
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(16)) goto parse_processed;
+        break;
+      }
+
+      // optional bool processed = 2;
+      case 2: {
+        if (tag == 16) {
+         parse_processed:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &processed_)));
+          set_has_processed();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.ReplicaCorruptionError)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.ReplicaCorruptionError)
+  return false;
+#undef DO_
+}
+
+void ReplicaCorruptionError::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.ReplicaCorruptionError)
+  // optional string error_msg = 1;
+  if (has_error_msg()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->error_msg().data(), this->error_msg().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE,
+      "cockroach.roachpb.ReplicaCorruptionError.error_msg");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->error_msg(), output);
+  }
+
+  // optional bool processed = 2;
+  if (has_processed()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(2, this->processed(), output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.ReplicaCorruptionError)
+}
+
+::google::protobuf::uint8* ReplicaCorruptionError::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.ReplicaCorruptionError)
+  // optional string error_msg = 1;
+  if (has_error_msg()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->error_msg().data(), this->error_msg().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE,
+      "cockroach.roachpb.ReplicaCorruptionError.error_msg");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->error_msg(), target);
+  }
+
+  // optional bool processed = 2;
+  if (has_processed()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(2, this->processed(), target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.ReplicaCorruptionError)
+  return target;
+}
+
+int ReplicaCorruptionError::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & 3u) {
+    // optional string error_msg = 1;
+    if (has_error_msg()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::StringSize(
+          this->error_msg());
+    }
+
+    // optional bool processed = 2;
+    if (has_processed()) {
+      total_size += 1 + 1;
+    }
+
+  }
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void ReplicaCorruptionError::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const ReplicaCorruptionError* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const ReplicaCorruptionError>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void ReplicaCorruptionError::MergeFrom(const ReplicaCorruptionError& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_error_msg()) {
+      set_has_error_msg();
+      error_msg_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.error_msg_);
+    }
+    if (from.has_processed()) {
+      set_processed(from.processed());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void ReplicaCorruptionError::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ReplicaCorruptionError::CopyFrom(const ReplicaCorruptionError& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ReplicaCorruptionError::IsInitialized() const {
+
+  return true;
+}
+
+void ReplicaCorruptionError::Swap(ReplicaCorruptionError* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ReplicaCorruptionError::InternalSwap(ReplicaCorruptionError* other) {
+  error_msg_.Swap(&other->error_msg_);
+  std::swap(processed_, other->processed_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata ReplicaCorruptionError::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = ReplicaCorruptionError_descriptor_;
+  metadata.reflection = ReplicaCorruptionError_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// ReplicaCorruptionError
+
+// optional string error_msg = 1;
+bool ReplicaCorruptionError::has_error_msg() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void ReplicaCorruptionError::set_has_error_msg() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void ReplicaCorruptionError::clear_has_error_msg() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void ReplicaCorruptionError::clear_error_msg() {
+  error_msg_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_error_msg();
+}
+ const ::std::string& ReplicaCorruptionError::error_msg() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+  return error_msg_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void ReplicaCorruptionError::set_error_msg(const ::std::string& value) {
+  set_has_error_msg();
+  error_msg_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+}
+ void ReplicaCorruptionError::set_error_msg(const char* value) {
+  set_has_error_msg();
+  error_msg_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+}
+ void ReplicaCorruptionError::set_error_msg(const char* value, size_t size) {
+  set_has_error_msg();
+  error_msg_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+}
+ ::std::string* ReplicaCorruptionError::mutable_error_msg() {
+  set_has_error_msg();
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+  return error_msg_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ ::std::string* ReplicaCorruptionError::release_error_msg() {
+  clear_has_error_msg();
+  return error_msg_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void ReplicaCorruptionError::set_allocated_error_msg(::std::string* error_msg) {
+  if (error_msg != NULL) {
+    set_has_error_msg();
+  } else {
+    clear_has_error_msg();
+  }
+  error_msg_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), error_msg);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+}
+
+// optional bool processed = 2;
+bool ReplicaCorruptionError::has_processed() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+void ReplicaCorruptionError::set_has_processed() {
+  _has_bits_[0] |= 0x00000002u;
+}
+void ReplicaCorruptionError::clear_has_processed() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+void ReplicaCorruptionError::clear_processed() {
+  processed_ = false;
+  clear_has_processed();
+}
+ bool ReplicaCorruptionError::processed() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ReplicaCorruptionError.processed)
+  return processed_;
+}
+ void ReplicaCorruptionError::set_processed(bool value) {
+  set_has_processed();
+  processed_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ReplicaCorruptionError.processed)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+LeaseVersionChangedError::LeaseVersionChangedError()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.LeaseVersionChangedError)
+}
+
+void LeaseVersionChangedError::InitAsDefaultInstance() {
+}
+
+LeaseVersionChangedError::LeaseVersionChangedError(const LeaseVersionChangedError& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.LeaseVersionChangedError)
+}
+
+void LeaseVersionChangedError::SharedCtor() {
+  _cached_size_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+LeaseVersionChangedError::~LeaseVersionChangedError() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.LeaseVersionChangedError)
+  SharedDtor();
+}
+
+void LeaseVersionChangedError::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void LeaseVersionChangedError::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* LeaseVersionChangedError::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return LeaseVersionChangedError_descriptor_;
+}
+
+const LeaseVersionChangedError& LeaseVersionChangedError::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  return *default_instance_;
+}
+
+LeaseVersionChangedError* LeaseVersionChangedError::default_instance_ = NULL;
+
+LeaseVersionChangedError* LeaseVersionChangedError::New(::google::protobuf::Arena* arena) const {
+  LeaseVersionChangedError* n = new LeaseVersionChangedError;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void LeaseVersionChangedError::Clear() {
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool LeaseVersionChangedError::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.LeaseVersionChangedError)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+  handle_unusual:
+    if (tag == 0 ||
+        ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+        ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+      goto success;
+    }
+    DO_(::google::protobuf::internal::WireFormat::SkipField(
+          input, tag, mutable_unknown_fields()));
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.LeaseVersionChangedError)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.LeaseVersionChangedError)
+  return false;
+#undef DO_
+}
+
+void LeaseVersionChangedError::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.LeaseVersionChangedError)
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.LeaseVersionChangedError)
+}
+
+::google::protobuf::uint8* LeaseVersionChangedError::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.LeaseVersionChangedError)
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.LeaseVersionChangedError)
+  return target;
+}
+
+int LeaseVersionChangedError::ByteSize() const {
+  int total_size = 0;
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void LeaseVersionChangedError::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const LeaseVersionChangedError* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const LeaseVersionChangedError>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void LeaseVersionChangedError::MergeFrom(const LeaseVersionChangedError& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void LeaseVersionChangedError::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void LeaseVersionChangedError::CopyFrom(const LeaseVersionChangedError& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool LeaseVersionChangedError::IsInitialized() const {
+
+  return true;
+}
+
+void LeaseVersionChangedError::Swap(LeaseVersionChangedError* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void LeaseVersionChangedError::InternalSwap(LeaseVersionChangedError* other) {
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata LeaseVersionChangedError::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = LeaseVersionChangedError_descriptor_;
+  metadata.reflection = LeaseVersionChangedError_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// LeaseVersionChangedError
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+DidntUpdateDescriptorError::DidntUpdateDescriptorError()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.DidntUpdateDescriptorError)
+}
+
+void DidntUpdateDescriptorError::InitAsDefaultInstance() {
+}
+
+DidntUpdateDescriptorError::DidntUpdateDescriptorError(const DidntUpdateDescriptorError& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.DidntUpdateDescriptorError)
+}
+
+void DidntUpdateDescriptorError::SharedCtor() {
+  _cached_size_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+DidntUpdateDescriptorError::~DidntUpdateDescriptorError() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.DidntUpdateDescriptorError)
+  SharedDtor();
+}
+
+void DidntUpdateDescriptorError::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void DidntUpdateDescriptorError::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* DidntUpdateDescriptorError::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return DidntUpdateDescriptorError_descriptor_;
+}
+
+const DidntUpdateDescriptorError& DidntUpdateDescriptorError::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  return *default_instance_;
+}
+
+DidntUpdateDescriptorError* DidntUpdateDescriptorError::default_instance_ = NULL;
+
+DidntUpdateDescriptorError* DidntUpdateDescriptorError::New(::google::protobuf::Arena* arena) const {
+  DidntUpdateDescriptorError* n = new DidntUpdateDescriptorError;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void DidntUpdateDescriptorError::Clear() {
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool DidntUpdateDescriptorError::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.DidntUpdateDescriptorError)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+  handle_unusual:
+    if (tag == 0 ||
+        ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+        ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+      goto success;
+    }
+    DO_(::google::protobuf::internal::WireFormat::SkipField(
+          input, tag, mutable_unknown_fields()));
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.DidntUpdateDescriptorError)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.DidntUpdateDescriptorError)
+  return false;
+#undef DO_
+}
+
+void DidntUpdateDescriptorError::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.DidntUpdateDescriptorError)
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.DidntUpdateDescriptorError)
+}
+
+::google::protobuf::uint8* DidntUpdateDescriptorError::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.DidntUpdateDescriptorError)
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.DidntUpdateDescriptorError)
+  return target;
+}
+
+int DidntUpdateDescriptorError::ByteSize() const {
+  int total_size = 0;
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void DidntUpdateDescriptorError::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const DidntUpdateDescriptorError* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const DidntUpdateDescriptorError>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void DidntUpdateDescriptorError::MergeFrom(const DidntUpdateDescriptorError& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void DidntUpdateDescriptorError::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void DidntUpdateDescriptorError::CopyFrom(const DidntUpdateDescriptorError& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool DidntUpdateDescriptorError::IsInitialized() const {
+
+  return true;
+}
+
+void DidntUpdateDescriptorError::Swap(DidntUpdateDescriptorError* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void DidntUpdateDescriptorError::InternalSwap(DidntUpdateDescriptorError* other) {
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata DidntUpdateDescriptorError::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = DidntUpdateDescriptorError_descriptor_;
+  metadata.reflection = DidntUpdateDescriptorError_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// DidntUpdateDescriptorError
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+SqlTransactionAbortedError::SqlTransactionAbortedError()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.SqlTransactionAbortedError)
+}
+
+void SqlTransactionAbortedError::InitAsDefaultInstance() {
+}
+
+SqlTransactionAbortedError::SqlTransactionAbortedError(const SqlTransactionAbortedError& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.SqlTransactionAbortedError)
+}
+
+void SqlTransactionAbortedError::SharedCtor() {
+  _cached_size_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+SqlTransactionAbortedError::~SqlTransactionAbortedError() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.SqlTransactionAbortedError)
+  SharedDtor();
+}
+
+void SqlTransactionAbortedError::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void SqlTransactionAbortedError::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* SqlTransactionAbortedError::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return SqlTransactionAbortedError_descriptor_;
+}
+
+const SqlTransactionAbortedError& SqlTransactionAbortedError::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  return *default_instance_;
+}
+
+SqlTransactionAbortedError* SqlTransactionAbortedError::default_instance_ = NULL;
+
+SqlTransactionAbortedError* SqlTransactionAbortedError::New(::google::protobuf::Arena* arena) const {
+  SqlTransactionAbortedError* n = new SqlTransactionAbortedError;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void SqlTransactionAbortedError::Clear() {
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool SqlTransactionAbortedError::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.SqlTransactionAbortedError)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+  handle_unusual:
+    if (tag == 0 ||
+        ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+        ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+      goto success;
+    }
+    DO_(::google::protobuf::internal::WireFormat::SkipField(
+          input, tag, mutable_unknown_fields()));
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.SqlTransactionAbortedError)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.SqlTransactionAbortedError)
+  return false;
+#undef DO_
+}
+
+void SqlTransactionAbortedError::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.SqlTransactionAbortedError)
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.SqlTransactionAbortedError)
+}
+
+::google::protobuf::uint8* SqlTransactionAbortedError::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.SqlTransactionAbortedError)
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.SqlTransactionAbortedError)
+  return target;
+}
+
+int SqlTransactionAbortedError::ByteSize() const {
+  int total_size = 0;
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void SqlTransactionAbortedError::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const SqlTransactionAbortedError* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const SqlTransactionAbortedError>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void SqlTransactionAbortedError::MergeFrom(const SqlTransactionAbortedError& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void SqlTransactionAbortedError::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SqlTransactionAbortedError::CopyFrom(const SqlTransactionAbortedError& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SqlTransactionAbortedError::IsInitialized() const {
+
+  return true;
+}
+
+void SqlTransactionAbortedError::Swap(SqlTransactionAbortedError* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void SqlTransactionAbortedError::InternalSwap(SqlTransactionAbortedError* other) {
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata SqlTransactionAbortedError::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = SqlTransactionAbortedError_descriptor_;
+  metadata.reflection = SqlTransactionAbortedError_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// SqlTransactionAbortedError
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ExistingSchemaChangeLeaseError::ExistingSchemaChangeLeaseError()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.ExistingSchemaChangeLeaseError)
+}
+
+void ExistingSchemaChangeLeaseError::InitAsDefaultInstance() {
+}
+
+ExistingSchemaChangeLeaseError::ExistingSchemaChangeLeaseError(const ExistingSchemaChangeLeaseError& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.ExistingSchemaChangeLeaseError)
+}
+
+void ExistingSchemaChangeLeaseError::SharedCtor() {
+  _cached_size_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+ExistingSchemaChangeLeaseError::~ExistingSchemaChangeLeaseError() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.ExistingSchemaChangeLeaseError)
+  SharedDtor();
+}
+
+void ExistingSchemaChangeLeaseError::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void ExistingSchemaChangeLeaseError::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* ExistingSchemaChangeLeaseError::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return ExistingSchemaChangeLeaseError_descriptor_;
+}
+
+const ExistingSchemaChangeLeaseError& ExistingSchemaChangeLeaseError::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  return *default_instance_;
+}
+
+ExistingSchemaChangeLeaseError* ExistingSchemaChangeLeaseError::default_instance_ = NULL;
+
+ExistingSchemaChangeLeaseError* ExistingSchemaChangeLeaseError::New(::google::protobuf::Arena* arena) const {
+  ExistingSchemaChangeLeaseError* n = new ExistingSchemaChangeLeaseError;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void ExistingSchemaChangeLeaseError::Clear() {
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool ExistingSchemaChangeLeaseError::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.ExistingSchemaChangeLeaseError)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+  handle_unusual:
+    if (tag == 0 ||
+        ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+        ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+      goto success;
+    }
+    DO_(::google::protobuf::internal::WireFormat::SkipField(
+          input, tag, mutable_unknown_fields()));
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.ExistingSchemaChangeLeaseError)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.ExistingSchemaChangeLeaseError)
+  return false;
+#undef DO_
+}
+
+void ExistingSchemaChangeLeaseError::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.ExistingSchemaChangeLeaseError)
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.ExistingSchemaChangeLeaseError)
+}
+
+::google::protobuf::uint8* ExistingSchemaChangeLeaseError::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.ExistingSchemaChangeLeaseError)
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.ExistingSchemaChangeLeaseError)
+  return target;
+}
+
+int ExistingSchemaChangeLeaseError::ByteSize() const {
+  int total_size = 0;
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void ExistingSchemaChangeLeaseError::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const ExistingSchemaChangeLeaseError* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const ExistingSchemaChangeLeaseError>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void ExistingSchemaChangeLeaseError::MergeFrom(const ExistingSchemaChangeLeaseError& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void ExistingSchemaChangeLeaseError::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ExistingSchemaChangeLeaseError::CopyFrom(const ExistingSchemaChangeLeaseError& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ExistingSchemaChangeLeaseError::IsInitialized() const {
+
+  return true;
+}
+
+void ExistingSchemaChangeLeaseError::Swap(ExistingSchemaChangeLeaseError* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ExistingSchemaChangeLeaseError::InternalSwap(ExistingSchemaChangeLeaseError* other) {
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata ExistingSchemaChangeLeaseError::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = ExistingSchemaChangeLeaseError_descriptor_;
+  metadata.reflection = ExistingSchemaChangeLeaseError_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// ExistingSchemaChangeLeaseError
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int ErrorDetail::kNotLeaderFieldNumber;
 const int ErrorDetail::kRangeNotFoundFieldNumber;
 const int ErrorDetail::kRangeKeyMismatchFieldNumber;
@@ -6099,6 +7397,12 @@ const int ErrorDetail::kConditionFailedFieldNumber;
 const int ErrorDetail::kLeaseRejectedFieldNumber;
 const int ErrorDetail::kNodeUnavailableFieldNumber;
 const int ErrorDetail::kSendFieldNumber;
+const int ErrorDetail::kRaftGroupDeletedFieldNumber;
+const int ErrorDetail::kReplicaCorruptionFieldNumber;
+const int ErrorDetail::kLeaseVersionChangedFieldNumber;
+const int ErrorDetail::kDidntUpdateDescriptorFieldNumber;
+const int ErrorDetail::kSqlTranasctionAbortedFieldNumber;
+const int ErrorDetail::kExistingSchemeChangeLeaseFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ErrorDetail::ErrorDetail()
@@ -6123,6 +7427,12 @@ void ErrorDetail::InitAsDefaultInstance() {
   lease_rejected_ = const_cast< ::cockroach::roachpb::LeaseRejectedError*>(&::cockroach::roachpb::LeaseRejectedError::default_instance());
   node_unavailable_ = const_cast< ::cockroach::roachpb::NodeUnavailableError*>(&::cockroach::roachpb::NodeUnavailableError::default_instance());
   send_ = const_cast< ::cockroach::roachpb::SendError*>(&::cockroach::roachpb::SendError::default_instance());
+  raft_group_deleted_ = const_cast< ::cockroach::roachpb::RaftGroupDeletedError*>(&::cockroach::roachpb::RaftGroupDeletedError::default_instance());
+  replica_corruption_ = const_cast< ::cockroach::roachpb::ReplicaCorruptionError*>(&::cockroach::roachpb::ReplicaCorruptionError::default_instance());
+  lease_version_changed_ = const_cast< ::cockroach::roachpb::LeaseVersionChangedError*>(&::cockroach::roachpb::LeaseVersionChangedError::default_instance());
+  didnt_update_descriptor_ = const_cast< ::cockroach::roachpb::DidntUpdateDescriptorError*>(&::cockroach::roachpb::DidntUpdateDescriptorError::default_instance());
+  sql_tranasction_aborted_ = const_cast< ::cockroach::roachpb::SqlTransactionAbortedError*>(&::cockroach::roachpb::SqlTransactionAbortedError::default_instance());
+  existing_scheme_change_lease_ = const_cast< ::cockroach::roachpb::ExistingSchemaChangeLeaseError*>(&::cockroach::roachpb::ExistingSchemaChangeLeaseError::default_instance());
 }
 
 ErrorDetail::ErrorDetail(const ErrorDetail& from)
@@ -6150,6 +7460,12 @@ void ErrorDetail::SharedCtor() {
   lease_rejected_ = NULL;
   node_unavailable_ = NULL;
   send_ = NULL;
+  raft_group_deleted_ = NULL;
+  replica_corruption_ = NULL;
+  lease_version_changed_ = NULL;
+  didnt_update_descriptor_ = NULL;
+  sql_tranasction_aborted_ = NULL;
+  existing_scheme_change_lease_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -6175,6 +7491,12 @@ void ErrorDetail::SharedDtor() {
     delete lease_rejected_;
     delete node_unavailable_;
     delete send_;
+    delete raft_group_deleted_;
+    delete replica_corruption_;
+    delete lease_version_changed_;
+    delete didnt_update_descriptor_;
+    delete sql_tranasction_aborted_;
+    delete existing_scheme_change_lease_;
   }
 }
 
@@ -6230,7 +7552,7 @@ void ErrorDetail::Clear() {
       if (transaction_status_ != NULL) transaction_status_->::cockroach::roachpb::TransactionStatusError::Clear();
     }
   }
-  if (_has_bits_[8 / 32] & 32512u) {
+  if (_has_bits_[8 / 32] & 65280u) {
     if (has_write_intent()) {
       if (write_intent_ != NULL) write_intent_->::cockroach::roachpb::WriteIntentError::Clear();
     }
@@ -6252,6 +7574,26 @@ void ErrorDetail::Clear() {
     if (has_send()) {
       if (send_ != NULL) send_->::cockroach::roachpb::SendError::Clear();
     }
+    if (has_raft_group_deleted()) {
+      if (raft_group_deleted_ != NULL) raft_group_deleted_->::cockroach::roachpb::RaftGroupDeletedError::Clear();
+    }
+  }
+  if (_has_bits_[16 / 32] & 2031616u) {
+    if (has_replica_corruption()) {
+      if (replica_corruption_ != NULL) replica_corruption_->::cockroach::roachpb::ReplicaCorruptionError::Clear();
+    }
+    if (has_lease_version_changed()) {
+      if (lease_version_changed_ != NULL) lease_version_changed_->::cockroach::roachpb::LeaseVersionChangedError::Clear();
+    }
+    if (has_didnt_update_descriptor()) {
+      if (didnt_update_descriptor_ != NULL) didnt_update_descriptor_->::cockroach::roachpb::DidntUpdateDescriptorError::Clear();
+    }
+    if (has_sql_tranasction_aborted()) {
+      if (sql_tranasction_aborted_ != NULL) sql_tranasction_aborted_->::cockroach::roachpb::SqlTransactionAbortedError::Clear();
+    }
+    if (has_existing_scheme_change_lease()) {
+      if (existing_scheme_change_lease_ != NULL) existing_scheme_change_lease_->::cockroach::roachpb::ExistingSchemaChangeLeaseError::Clear();
+    }
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -6265,7 +7607,7 @@ bool ErrorDetail::MergePartialFromCodedStream(
   ::google::protobuf::uint32 tag;
   // @@protoc_insertion_point(parse_start:cockroach.roachpb.ErrorDetail)
   for (;;) {
-    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(16383);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
@@ -6459,6 +7801,84 @@ bool ErrorDetail::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(130)) goto parse_raft_group_deleted;
+        break;
+      }
+
+      // optional .cockroach.roachpb.RaftGroupDeletedError raft_group_deleted = 16;
+      case 16: {
+        if (tag == 130) {
+         parse_raft_group_deleted:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_raft_group_deleted()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(138)) goto parse_replica_corruption;
+        break;
+      }
+
+      // optional .cockroach.roachpb.ReplicaCorruptionError replica_corruption = 17;
+      case 17: {
+        if (tag == 138) {
+         parse_replica_corruption:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_replica_corruption()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(146)) goto parse_lease_version_changed;
+        break;
+      }
+
+      // optional .cockroach.roachpb.LeaseVersionChangedError lease_version_changed = 18;
+      case 18: {
+        if (tag == 146) {
+         parse_lease_version_changed:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_lease_version_changed()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(154)) goto parse_didnt_update_descriptor;
+        break;
+      }
+
+      // optional .cockroach.roachpb.DidntUpdateDescriptorError didnt_update_descriptor = 19;
+      case 19: {
+        if (tag == 154) {
+         parse_didnt_update_descriptor:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_didnt_update_descriptor()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(162)) goto parse_sql_tranasction_aborted;
+        break;
+      }
+
+      // optional .cockroach.roachpb.SqlTransactionAbortedError sql_tranasction_aborted = 20;
+      case 20: {
+        if (tag == 162) {
+         parse_sql_tranasction_aborted:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_sql_tranasction_aborted()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(170)) goto parse_existing_scheme_change_lease;
+        break;
+      }
+
+      // optional .cockroach.roachpb.ExistingSchemaChangeLeaseError existing_scheme_change_lease = 21;
+      case 21: {
+        if (tag == 170) {
+         parse_existing_scheme_change_lease:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_existing_scheme_change_lease()));
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -6578,6 +7998,42 @@ void ErrorDetail::SerializeWithCachedSizes(
       15, *this->send_, output);
   }
 
+  // optional .cockroach.roachpb.RaftGroupDeletedError raft_group_deleted = 16;
+  if (has_raft_group_deleted()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      16, *this->raft_group_deleted_, output);
+  }
+
+  // optional .cockroach.roachpb.ReplicaCorruptionError replica_corruption = 17;
+  if (has_replica_corruption()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      17, *this->replica_corruption_, output);
+  }
+
+  // optional .cockroach.roachpb.LeaseVersionChangedError lease_version_changed = 18;
+  if (has_lease_version_changed()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      18, *this->lease_version_changed_, output);
+  }
+
+  // optional .cockroach.roachpb.DidntUpdateDescriptorError didnt_update_descriptor = 19;
+  if (has_didnt_update_descriptor()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      19, *this->didnt_update_descriptor_, output);
+  }
+
+  // optional .cockroach.roachpb.SqlTransactionAbortedError sql_tranasction_aborted = 20;
+  if (has_sql_tranasction_aborted()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      20, *this->sql_tranasction_aborted_, output);
+  }
+
+  // optional .cockroach.roachpb.ExistingSchemaChangeLeaseError existing_scheme_change_lease = 21;
+  if (has_existing_scheme_change_lease()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      21, *this->existing_scheme_change_lease_, output);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -6693,6 +8149,48 @@ void ErrorDetail::SerializeWithCachedSizes(
         15, *this->send_, target);
   }
 
+  // optional .cockroach.roachpb.RaftGroupDeletedError raft_group_deleted = 16;
+  if (has_raft_group_deleted()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        16, *this->raft_group_deleted_, target);
+  }
+
+  // optional .cockroach.roachpb.ReplicaCorruptionError replica_corruption = 17;
+  if (has_replica_corruption()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        17, *this->replica_corruption_, target);
+  }
+
+  // optional .cockroach.roachpb.LeaseVersionChangedError lease_version_changed = 18;
+  if (has_lease_version_changed()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        18, *this->lease_version_changed_, target);
+  }
+
+  // optional .cockroach.roachpb.DidntUpdateDescriptorError didnt_update_descriptor = 19;
+  if (has_didnt_update_descriptor()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        19, *this->didnt_update_descriptor_, target);
+  }
+
+  // optional .cockroach.roachpb.SqlTransactionAbortedError sql_tranasction_aborted = 20;
+  if (has_sql_tranasction_aborted()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        20, *this->sql_tranasction_aborted_, target);
+  }
+
+  // optional .cockroach.roachpb.ExistingSchemaChangeLeaseError existing_scheme_change_lease = 21;
+  if (has_existing_scheme_change_lease()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        21, *this->existing_scheme_change_lease_, target);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -6762,7 +8260,7 @@ int ErrorDetail::ByteSize() const {
     }
 
   }
-  if (_has_bits_[8 / 32] & 32512u) {
+  if (_has_bits_[8 / 32] & 65280u) {
     // optional .cockroach.roachpb.WriteIntentError write_intent = 9;
     if (has_write_intent()) {
       total_size += 1 +
@@ -6810,6 +8308,50 @@ int ErrorDetail::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->send_);
+    }
+
+    // optional .cockroach.roachpb.RaftGroupDeletedError raft_group_deleted = 16;
+    if (has_raft_group_deleted()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->raft_group_deleted_);
+    }
+
+  }
+  if (_has_bits_[16 / 32] & 2031616u) {
+    // optional .cockroach.roachpb.ReplicaCorruptionError replica_corruption = 17;
+    if (has_replica_corruption()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->replica_corruption_);
+    }
+
+    // optional .cockroach.roachpb.LeaseVersionChangedError lease_version_changed = 18;
+    if (has_lease_version_changed()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->lease_version_changed_);
+    }
+
+    // optional .cockroach.roachpb.DidntUpdateDescriptorError didnt_update_descriptor = 19;
+    if (has_didnt_update_descriptor()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->didnt_update_descriptor_);
+    }
+
+    // optional .cockroach.roachpb.SqlTransactionAbortedError sql_tranasction_aborted = 20;
+    if (has_sql_tranasction_aborted()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->sql_tranasction_aborted_);
+    }
+
+    // optional .cockroach.roachpb.ExistingSchemaChangeLeaseError existing_scheme_change_lease = 21;
+    if (has_existing_scheme_change_lease()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->existing_scheme_change_lease_);
     }
 
   }
@@ -6886,6 +8428,26 @@ void ErrorDetail::MergeFrom(const ErrorDetail& from) {
     if (from.has_send()) {
       mutable_send()->::cockroach::roachpb::SendError::MergeFrom(from.send());
     }
+    if (from.has_raft_group_deleted()) {
+      mutable_raft_group_deleted()->::cockroach::roachpb::RaftGroupDeletedError::MergeFrom(from.raft_group_deleted());
+    }
+  }
+  if (from._has_bits_[16 / 32] & (0xffu << (16 % 32))) {
+    if (from.has_replica_corruption()) {
+      mutable_replica_corruption()->::cockroach::roachpb::ReplicaCorruptionError::MergeFrom(from.replica_corruption());
+    }
+    if (from.has_lease_version_changed()) {
+      mutable_lease_version_changed()->::cockroach::roachpb::LeaseVersionChangedError::MergeFrom(from.lease_version_changed());
+    }
+    if (from.has_didnt_update_descriptor()) {
+      mutable_didnt_update_descriptor()->::cockroach::roachpb::DidntUpdateDescriptorError::MergeFrom(from.didnt_update_descriptor());
+    }
+    if (from.has_sql_tranasction_aborted()) {
+      mutable_sql_tranasction_aborted()->::cockroach::roachpb::SqlTransactionAbortedError::MergeFrom(from.sql_tranasction_aborted());
+    }
+    if (from.has_existing_scheme_change_lease()) {
+      mutable_existing_scheme_change_lease()->::cockroach::roachpb::ExistingSchemaChangeLeaseError::MergeFrom(from.existing_scheme_change_lease());
+    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -6929,6 +8491,12 @@ void ErrorDetail::InternalSwap(ErrorDetail* other) {
   std::swap(lease_rejected_, other->lease_rejected_);
   std::swap(node_unavailable_, other->node_unavailable_);
   std::swap(send_, other->send_);
+  std::swap(raft_group_deleted_, other->raft_group_deleted_);
+  std::swap(replica_corruption_, other->replica_corruption_);
+  std::swap(lease_version_changed_, other->lease_version_changed_);
+  std::swap(didnt_update_descriptor_, other->didnt_update_descriptor_);
+  std::swap(sql_tranasction_aborted_, other->sql_tranasction_aborted_);
+  std::swap(existing_scheme_change_lease_, other->existing_scheme_change_lease_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -7590,6 +9158,264 @@ void ErrorDetail::set_allocated_send(::cockroach::roachpb::SendError* send) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.send)
 }
 
+// optional .cockroach.roachpb.RaftGroupDeletedError raft_group_deleted = 16;
+bool ErrorDetail::has_raft_group_deleted() const {
+  return (_has_bits_[0] & 0x00008000u) != 0;
+}
+void ErrorDetail::set_has_raft_group_deleted() {
+  _has_bits_[0] |= 0x00008000u;
+}
+void ErrorDetail::clear_has_raft_group_deleted() {
+  _has_bits_[0] &= ~0x00008000u;
+}
+void ErrorDetail::clear_raft_group_deleted() {
+  if (raft_group_deleted_ != NULL) raft_group_deleted_->::cockroach::roachpb::RaftGroupDeletedError::Clear();
+  clear_has_raft_group_deleted();
+}
+const ::cockroach::roachpb::RaftGroupDeletedError& ErrorDetail::raft_group_deleted() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.raft_group_deleted)
+  return raft_group_deleted_ != NULL ? *raft_group_deleted_ : *default_instance_->raft_group_deleted_;
+}
+::cockroach::roachpb::RaftGroupDeletedError* ErrorDetail::mutable_raft_group_deleted() {
+  set_has_raft_group_deleted();
+  if (raft_group_deleted_ == NULL) {
+    raft_group_deleted_ = new ::cockroach::roachpb::RaftGroupDeletedError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.raft_group_deleted)
+  return raft_group_deleted_;
+}
+::cockroach::roachpb::RaftGroupDeletedError* ErrorDetail::release_raft_group_deleted() {
+  clear_has_raft_group_deleted();
+  ::cockroach::roachpb::RaftGroupDeletedError* temp = raft_group_deleted_;
+  raft_group_deleted_ = NULL;
+  return temp;
+}
+void ErrorDetail::set_allocated_raft_group_deleted(::cockroach::roachpb::RaftGroupDeletedError* raft_group_deleted) {
+  delete raft_group_deleted_;
+  raft_group_deleted_ = raft_group_deleted;
+  if (raft_group_deleted) {
+    set_has_raft_group_deleted();
+  } else {
+    clear_has_raft_group_deleted();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.raft_group_deleted)
+}
+
+// optional .cockroach.roachpb.ReplicaCorruptionError replica_corruption = 17;
+bool ErrorDetail::has_replica_corruption() const {
+  return (_has_bits_[0] & 0x00010000u) != 0;
+}
+void ErrorDetail::set_has_replica_corruption() {
+  _has_bits_[0] |= 0x00010000u;
+}
+void ErrorDetail::clear_has_replica_corruption() {
+  _has_bits_[0] &= ~0x00010000u;
+}
+void ErrorDetail::clear_replica_corruption() {
+  if (replica_corruption_ != NULL) replica_corruption_->::cockroach::roachpb::ReplicaCorruptionError::Clear();
+  clear_has_replica_corruption();
+}
+const ::cockroach::roachpb::ReplicaCorruptionError& ErrorDetail::replica_corruption() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.replica_corruption)
+  return replica_corruption_ != NULL ? *replica_corruption_ : *default_instance_->replica_corruption_;
+}
+::cockroach::roachpb::ReplicaCorruptionError* ErrorDetail::mutable_replica_corruption() {
+  set_has_replica_corruption();
+  if (replica_corruption_ == NULL) {
+    replica_corruption_ = new ::cockroach::roachpb::ReplicaCorruptionError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.replica_corruption)
+  return replica_corruption_;
+}
+::cockroach::roachpb::ReplicaCorruptionError* ErrorDetail::release_replica_corruption() {
+  clear_has_replica_corruption();
+  ::cockroach::roachpb::ReplicaCorruptionError* temp = replica_corruption_;
+  replica_corruption_ = NULL;
+  return temp;
+}
+void ErrorDetail::set_allocated_replica_corruption(::cockroach::roachpb::ReplicaCorruptionError* replica_corruption) {
+  delete replica_corruption_;
+  replica_corruption_ = replica_corruption;
+  if (replica_corruption) {
+    set_has_replica_corruption();
+  } else {
+    clear_has_replica_corruption();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.replica_corruption)
+}
+
+// optional .cockroach.roachpb.LeaseVersionChangedError lease_version_changed = 18;
+bool ErrorDetail::has_lease_version_changed() const {
+  return (_has_bits_[0] & 0x00020000u) != 0;
+}
+void ErrorDetail::set_has_lease_version_changed() {
+  _has_bits_[0] |= 0x00020000u;
+}
+void ErrorDetail::clear_has_lease_version_changed() {
+  _has_bits_[0] &= ~0x00020000u;
+}
+void ErrorDetail::clear_lease_version_changed() {
+  if (lease_version_changed_ != NULL) lease_version_changed_->::cockroach::roachpb::LeaseVersionChangedError::Clear();
+  clear_has_lease_version_changed();
+}
+const ::cockroach::roachpb::LeaseVersionChangedError& ErrorDetail::lease_version_changed() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.lease_version_changed)
+  return lease_version_changed_ != NULL ? *lease_version_changed_ : *default_instance_->lease_version_changed_;
+}
+::cockroach::roachpb::LeaseVersionChangedError* ErrorDetail::mutable_lease_version_changed() {
+  set_has_lease_version_changed();
+  if (lease_version_changed_ == NULL) {
+    lease_version_changed_ = new ::cockroach::roachpb::LeaseVersionChangedError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.lease_version_changed)
+  return lease_version_changed_;
+}
+::cockroach::roachpb::LeaseVersionChangedError* ErrorDetail::release_lease_version_changed() {
+  clear_has_lease_version_changed();
+  ::cockroach::roachpb::LeaseVersionChangedError* temp = lease_version_changed_;
+  lease_version_changed_ = NULL;
+  return temp;
+}
+void ErrorDetail::set_allocated_lease_version_changed(::cockroach::roachpb::LeaseVersionChangedError* lease_version_changed) {
+  delete lease_version_changed_;
+  lease_version_changed_ = lease_version_changed;
+  if (lease_version_changed) {
+    set_has_lease_version_changed();
+  } else {
+    clear_has_lease_version_changed();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.lease_version_changed)
+}
+
+// optional .cockroach.roachpb.DidntUpdateDescriptorError didnt_update_descriptor = 19;
+bool ErrorDetail::has_didnt_update_descriptor() const {
+  return (_has_bits_[0] & 0x00040000u) != 0;
+}
+void ErrorDetail::set_has_didnt_update_descriptor() {
+  _has_bits_[0] |= 0x00040000u;
+}
+void ErrorDetail::clear_has_didnt_update_descriptor() {
+  _has_bits_[0] &= ~0x00040000u;
+}
+void ErrorDetail::clear_didnt_update_descriptor() {
+  if (didnt_update_descriptor_ != NULL) didnt_update_descriptor_->::cockroach::roachpb::DidntUpdateDescriptorError::Clear();
+  clear_has_didnt_update_descriptor();
+}
+const ::cockroach::roachpb::DidntUpdateDescriptorError& ErrorDetail::didnt_update_descriptor() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.didnt_update_descriptor)
+  return didnt_update_descriptor_ != NULL ? *didnt_update_descriptor_ : *default_instance_->didnt_update_descriptor_;
+}
+::cockroach::roachpb::DidntUpdateDescriptorError* ErrorDetail::mutable_didnt_update_descriptor() {
+  set_has_didnt_update_descriptor();
+  if (didnt_update_descriptor_ == NULL) {
+    didnt_update_descriptor_ = new ::cockroach::roachpb::DidntUpdateDescriptorError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.didnt_update_descriptor)
+  return didnt_update_descriptor_;
+}
+::cockroach::roachpb::DidntUpdateDescriptorError* ErrorDetail::release_didnt_update_descriptor() {
+  clear_has_didnt_update_descriptor();
+  ::cockroach::roachpb::DidntUpdateDescriptorError* temp = didnt_update_descriptor_;
+  didnt_update_descriptor_ = NULL;
+  return temp;
+}
+void ErrorDetail::set_allocated_didnt_update_descriptor(::cockroach::roachpb::DidntUpdateDescriptorError* didnt_update_descriptor) {
+  delete didnt_update_descriptor_;
+  didnt_update_descriptor_ = didnt_update_descriptor;
+  if (didnt_update_descriptor) {
+    set_has_didnt_update_descriptor();
+  } else {
+    clear_has_didnt_update_descriptor();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.didnt_update_descriptor)
+}
+
+// optional .cockroach.roachpb.SqlTransactionAbortedError sql_tranasction_aborted = 20;
+bool ErrorDetail::has_sql_tranasction_aborted() const {
+  return (_has_bits_[0] & 0x00080000u) != 0;
+}
+void ErrorDetail::set_has_sql_tranasction_aborted() {
+  _has_bits_[0] |= 0x00080000u;
+}
+void ErrorDetail::clear_has_sql_tranasction_aborted() {
+  _has_bits_[0] &= ~0x00080000u;
+}
+void ErrorDetail::clear_sql_tranasction_aborted() {
+  if (sql_tranasction_aborted_ != NULL) sql_tranasction_aborted_->::cockroach::roachpb::SqlTransactionAbortedError::Clear();
+  clear_has_sql_tranasction_aborted();
+}
+const ::cockroach::roachpb::SqlTransactionAbortedError& ErrorDetail::sql_tranasction_aborted() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.sql_tranasction_aborted)
+  return sql_tranasction_aborted_ != NULL ? *sql_tranasction_aborted_ : *default_instance_->sql_tranasction_aborted_;
+}
+::cockroach::roachpb::SqlTransactionAbortedError* ErrorDetail::mutable_sql_tranasction_aborted() {
+  set_has_sql_tranasction_aborted();
+  if (sql_tranasction_aborted_ == NULL) {
+    sql_tranasction_aborted_ = new ::cockroach::roachpb::SqlTransactionAbortedError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.sql_tranasction_aborted)
+  return sql_tranasction_aborted_;
+}
+::cockroach::roachpb::SqlTransactionAbortedError* ErrorDetail::release_sql_tranasction_aborted() {
+  clear_has_sql_tranasction_aborted();
+  ::cockroach::roachpb::SqlTransactionAbortedError* temp = sql_tranasction_aborted_;
+  sql_tranasction_aborted_ = NULL;
+  return temp;
+}
+void ErrorDetail::set_allocated_sql_tranasction_aborted(::cockroach::roachpb::SqlTransactionAbortedError* sql_tranasction_aborted) {
+  delete sql_tranasction_aborted_;
+  sql_tranasction_aborted_ = sql_tranasction_aborted;
+  if (sql_tranasction_aborted) {
+    set_has_sql_tranasction_aborted();
+  } else {
+    clear_has_sql_tranasction_aborted();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.sql_tranasction_aborted)
+}
+
+// optional .cockroach.roachpb.ExistingSchemaChangeLeaseError existing_scheme_change_lease = 21;
+bool ErrorDetail::has_existing_scheme_change_lease() const {
+  return (_has_bits_[0] & 0x00100000u) != 0;
+}
+void ErrorDetail::set_has_existing_scheme_change_lease() {
+  _has_bits_[0] |= 0x00100000u;
+}
+void ErrorDetail::clear_has_existing_scheme_change_lease() {
+  _has_bits_[0] &= ~0x00100000u;
+}
+void ErrorDetail::clear_existing_scheme_change_lease() {
+  if (existing_scheme_change_lease_ != NULL) existing_scheme_change_lease_->::cockroach::roachpb::ExistingSchemaChangeLeaseError::Clear();
+  clear_has_existing_scheme_change_lease();
+}
+const ::cockroach::roachpb::ExistingSchemaChangeLeaseError& ErrorDetail::existing_scheme_change_lease() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.existing_scheme_change_lease)
+  return existing_scheme_change_lease_ != NULL ? *existing_scheme_change_lease_ : *default_instance_->existing_scheme_change_lease_;
+}
+::cockroach::roachpb::ExistingSchemaChangeLeaseError* ErrorDetail::mutable_existing_scheme_change_lease() {
+  set_has_existing_scheme_change_lease();
+  if (existing_scheme_change_lease_ == NULL) {
+    existing_scheme_change_lease_ = new ::cockroach::roachpb::ExistingSchemaChangeLeaseError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.existing_scheme_change_lease)
+  return existing_scheme_change_lease_;
+}
+::cockroach::roachpb::ExistingSchemaChangeLeaseError* ErrorDetail::release_existing_scheme_change_lease() {
+  clear_has_existing_scheme_change_lease();
+  ::cockroach::roachpb::ExistingSchemaChangeLeaseError* temp = existing_scheme_change_lease_;
+  existing_scheme_change_lease_ = NULL;
+  return temp;
+}
+void ErrorDetail::set_allocated_existing_scheme_change_lease(::cockroach::roachpb::ExistingSchemaChangeLeaseError* existing_scheme_change_lease) {
+  delete existing_scheme_change_lease_;
+  existing_scheme_change_lease_ = existing_scheme_change_lease;
+  if (existing_scheme_change_lease) {
+    set_has_existing_scheme_change_lease();
+  } else {
+    clear_has_existing_scheme_change_lease();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.existing_scheme_change_lease)
+}
+
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -7857,7 +9683,9 @@ void ErrPosition::clear_index() {
 const int Error::kMessageFieldNumber;
 const int Error::kRetryableFieldNumber;
 const int Error::kTransactionRestartFieldNumber;
+const int Error::kTxnFieldNumber;
 const int Error::kDetailFieldNumber;
+const int Error::kIndexFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Error::Error()
@@ -7867,7 +9695,9 @@ Error::Error()
 }
 
 void Error::InitAsDefaultInstance() {
+  txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
   detail_ = const_cast< ::cockroach::roachpb::ErrorDetail*>(&::cockroach::roachpb::ErrorDetail::default_instance());
+  index_ = const_cast< ::cockroach::roachpb::ErrPosition*>(&::cockroach::roachpb::ErrPosition::default_instance());
 }
 
 Error::Error(const Error& from)
@@ -7884,7 +9714,9 @@ void Error::SharedCtor() {
   message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   retryable_ = false;
   transaction_restart_ = 0;
+  txn_ = NULL;
   detail_ = NULL;
+  index_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -7896,7 +9728,9 @@ Error::~Error() {
 void Error::SharedDtor() {
   message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
+    delete txn_;
     delete detail_;
+    delete index_;
   }
 }
 
@@ -7934,13 +9768,19 @@ void Error::Clear() {
            ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
 } while (0)
 
-  if (_has_bits_[0 / 32] & 15u) {
+  if (_has_bits_[0 / 32] & 63u) {
     ZR_(retryable_, transaction_restart_);
     if (has_message()) {
       message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
+    if (has_txn()) {
+      if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
+    }
     if (has_detail()) {
       if (detail_ != NULL) detail_->::cockroach::roachpb::ErrorDetail::Clear();
+    }
+    if (has_index()) {
+      if (index_ != NULL) index_->::cockroach::roachpb::ErrPosition::Clear();
     }
   }
 
@@ -8010,16 +9850,42 @@ bool Error::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(34)) goto parse_detail;
+        if (input->ExpectTag(34)) goto parse_txn;
         break;
       }
 
-      // optional .cockroach.roachpb.ErrorDetail detail = 4;
+      // optional .cockroach.roachpb.Transaction txn = 4;
       case 4: {
         if (tag == 34) {
+         parse_txn:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_txn()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(42)) goto parse_detail;
+        break;
+      }
+
+      // optional .cockroach.roachpb.ErrorDetail detail = 5;
+      case 5: {
+        if (tag == 42) {
          parse_detail:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_detail()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(50)) goto parse_index;
+        break;
+      }
+
+      // optional .cockroach.roachpb.ErrPosition index = 6;
+      case 6: {
+        if (tag == 50) {
+         parse_index:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_index()));
         } else {
           goto handle_unusual;
         }
@@ -8073,10 +9939,22 @@ void Error::SerializeWithCachedSizes(
       3, this->transaction_restart(), output);
   }
 
-  // optional .cockroach.roachpb.ErrorDetail detail = 4;
+  // optional .cockroach.roachpb.Transaction txn = 4;
+  if (has_txn()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      4, *this->txn_, output);
+  }
+
+  // optional .cockroach.roachpb.ErrorDetail detail = 5;
   if (has_detail()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      4, *this->detail_, output);
+      5, *this->detail_, output);
+  }
+
+  // optional .cockroach.roachpb.ErrPosition index = 6;
+  if (has_index()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      6, *this->index_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -8111,11 +9989,25 @@ void Error::SerializeWithCachedSizes(
       3, this->transaction_restart(), target);
   }
 
-  // optional .cockroach.roachpb.ErrorDetail detail = 4;
+  // optional .cockroach.roachpb.Transaction txn = 4;
+  if (has_txn()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        4, *this->txn_, target);
+  }
+
+  // optional .cockroach.roachpb.ErrorDetail detail = 5;
   if (has_detail()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        4, *this->detail_, target);
+        5, *this->detail_, target);
+  }
+
+  // optional .cockroach.roachpb.ErrPosition index = 6;
+  if (has_index()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        6, *this->index_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -8129,7 +10021,7 @@ void Error::SerializeWithCachedSizes(
 int Error::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 15u) {
+  if (_has_bits_[0 / 32] & 63u) {
     // optional string message = 1;
     if (has_message()) {
       total_size += 1 +
@@ -8148,11 +10040,25 @@ int Error::ByteSize() const {
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->transaction_restart());
     }
 
-    // optional .cockroach.roachpb.ErrorDetail detail = 4;
+    // optional .cockroach.roachpb.Transaction txn = 4;
+    if (has_txn()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->txn_);
+    }
+
+    // optional .cockroach.roachpb.ErrorDetail detail = 5;
     if (has_detail()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->detail_);
+    }
+
+    // optional .cockroach.roachpb.ErrPosition index = 6;
+    if (has_index()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->index_);
     }
 
   }
@@ -8192,8 +10098,14 @@ void Error::MergeFrom(const Error& from) {
     if (from.has_transaction_restart()) {
       set_transaction_restart(from.transaction_restart());
     }
+    if (from.has_txn()) {
+      mutable_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.txn());
+    }
     if (from.has_detail()) {
       mutable_detail()->::cockroach::roachpb::ErrorDetail::MergeFrom(from.detail());
+    }
+    if (from.has_index()) {
+      mutable_index()->::cockroach::roachpb::ErrPosition::MergeFrom(from.index());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -8226,7 +10138,9 @@ void Error::InternalSwap(Error* other) {
   message_.Swap(&other->message_);
   std::swap(retryable_, other->retryable_);
   std::swap(transaction_restart_, other->transaction_restart_);
+  std::swap(txn_, other->txn_);
   std::swap(detail_, other->detail_);
+  std::swap(index_, other->index_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -8345,15 +10259,58 @@ void Error::clear_transaction_restart() {
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Error.transaction_restart)
 }
 
-// optional .cockroach.roachpb.ErrorDetail detail = 4;
-bool Error::has_detail() const {
+// optional .cockroach.roachpb.Transaction txn = 4;
+bool Error::has_txn() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
-void Error::set_has_detail() {
+void Error::set_has_txn() {
   _has_bits_[0] |= 0x00000008u;
 }
-void Error::clear_has_detail() {
+void Error::clear_has_txn() {
   _has_bits_[0] &= ~0x00000008u;
+}
+void Error::clear_txn() {
+  if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
+  clear_has_txn();
+}
+const ::cockroach::roachpb::Transaction& Error::txn() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Error.txn)
+  return txn_ != NULL ? *txn_ : *default_instance_->txn_;
+}
+::cockroach::roachpb::Transaction* Error::mutable_txn() {
+  set_has_txn();
+  if (txn_ == NULL) {
+    txn_ = new ::cockroach::roachpb::Transaction;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Error.txn)
+  return txn_;
+}
+::cockroach::roachpb::Transaction* Error::release_txn() {
+  clear_has_txn();
+  ::cockroach::roachpb::Transaction* temp = txn_;
+  txn_ = NULL;
+  return temp;
+}
+void Error::set_allocated_txn(::cockroach::roachpb::Transaction* txn) {
+  delete txn_;
+  txn_ = txn;
+  if (txn) {
+    set_has_txn();
+  } else {
+    clear_has_txn();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.txn)
+}
+
+// optional .cockroach.roachpb.ErrorDetail detail = 5;
+bool Error::has_detail() const {
+  return (_has_bits_[0] & 0x00000010u) != 0;
+}
+void Error::set_has_detail() {
+  _has_bits_[0] |= 0x00000010u;
+}
+void Error::clear_has_detail() {
+  _has_bits_[0] &= ~0x00000010u;
 }
 void Error::clear_detail() {
   if (detail_ != NULL) detail_->::cockroach::roachpb::ErrorDetail::Clear();
@@ -8386,6 +10343,49 @@ void Error::set_allocated_detail(::cockroach::roachpb::ErrorDetail* detail) {
     clear_has_detail();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.detail)
+}
+
+// optional .cockroach.roachpb.ErrPosition index = 6;
+bool Error::has_index() const {
+  return (_has_bits_[0] & 0x00000020u) != 0;
+}
+void Error::set_has_index() {
+  _has_bits_[0] |= 0x00000020u;
+}
+void Error::clear_has_index() {
+  _has_bits_[0] &= ~0x00000020u;
+}
+void Error::clear_index() {
+  if (index_ != NULL) index_->::cockroach::roachpb::ErrPosition::Clear();
+  clear_has_index();
+}
+const ::cockroach::roachpb::ErrPosition& Error::index() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Error.index)
+  return index_ != NULL ? *index_ : *default_instance_->index_;
+}
+::cockroach::roachpb::ErrPosition* Error::mutable_index() {
+  set_has_index();
+  if (index_ == NULL) {
+    index_ = new ::cockroach::roachpb::ErrPosition;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Error.index)
+  return index_;
+}
+::cockroach::roachpb::ErrPosition* Error::release_index() {
+  clear_has_index();
+  ::cockroach::roachpb::ErrPosition* temp = index_;
+  index_ = NULL;
+  return temp;
+}
+void Error::set_allocated_index(::cockroach::roachpb::ErrPosition* index) {
+  delete index_;
+  index_ = index;
+  if (index) {
+    set_has_index();
+  } else {
+    clear_has_index();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.index)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/roachpb/errors.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/errors.pb.h
@@ -42,17 +42,23 @@ void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
 void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
 
 class ConditionFailedError;
+class DidntUpdateDescriptorError;
 class ErrPosition;
 class Error;
 class ErrorDetail;
+class ExistingSchemaChangeLeaseError;
 class LeaseRejectedError;
+class LeaseVersionChangedError;
 class NodeUnavailableError;
 class NotLeaderError;
 class OpRequiresTxnError;
+class RaftGroupDeletedError;
 class RangeKeyMismatchError;
 class RangeNotFoundError;
 class ReadWithinUncertaintyIntervalError;
+class ReplicaCorruptionError;
 class SendError;
+class SqlTransactionAbortedError;
 class TransactionAbortedError;
 class TransactionPushError;
 class TransactionRetryError;
@@ -1083,27 +1089,15 @@ class WriteIntentError : public ::google::protobuf::Message {
   bool resolved() const;
   void set_resolved(bool value);
 
-  // optional .cockroach.roachpb.ErrPosition index = 3;
-  bool has_index() const;
-  void clear_index();
-  static const int kIndexFieldNumber = 3;
-  const ::cockroach::roachpb::ErrPosition& index() const;
-  ::cockroach::roachpb::ErrPosition* mutable_index();
-  ::cockroach::roachpb::ErrPosition* release_index();
-  void set_allocated_index(::cockroach::roachpb::ErrPosition* index);
-
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.WriteIntentError)
  private:
   inline void set_has_resolved();
   inline void clear_has_resolved();
-  inline void set_has_index();
-  inline void clear_has_index();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::Intent > intents_;
-  ::cockroach::roachpb::ErrPosition* index_;
   bool resolved_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
@@ -1369,27 +1363,15 @@ class ConditionFailedError : public ::google::protobuf::Message {
   ::cockroach::roachpb::Value* release_actual_value();
   void set_allocated_actual_value(::cockroach::roachpb::Value* actual_value);
 
-  // optional .cockroach.roachpb.ErrPosition index = 2;
-  bool has_index() const;
-  void clear_index();
-  static const int kIndexFieldNumber = 2;
-  const ::cockroach::roachpb::ErrPosition& index() const;
-  ::cockroach::roachpb::ErrPosition* mutable_index();
-  ::cockroach::roachpb::ErrPosition* release_index();
-  void set_allocated_index(::cockroach::roachpb::ErrPosition* index);
-
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.ConditionFailedError)
  private:
   inline void set_has_actual_value();
   inline void clear_has_actual_value();
-  inline void set_has_index();
-  inline void clear_has_index();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::cockroach::roachpb::Value* actual_value_;
-  ::cockroach::roachpb::ErrPosition* index_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
@@ -1621,6 +1603,505 @@ class SendError : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
+class RaftGroupDeletedError : public ::google::protobuf::Message {
+ public:
+  RaftGroupDeletedError();
+  virtual ~RaftGroupDeletedError();
+
+  RaftGroupDeletedError(const RaftGroupDeletedError& from);
+
+  inline RaftGroupDeletedError& operator=(const RaftGroupDeletedError& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const RaftGroupDeletedError& default_instance();
+
+  void Swap(RaftGroupDeletedError* other);
+
+  // implements Message ----------------------------------------------
+
+  inline RaftGroupDeletedError* New() const { return New(NULL); }
+
+  RaftGroupDeletedError* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const RaftGroupDeletedError& from);
+  void MergeFrom(const RaftGroupDeletedError& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(RaftGroupDeletedError* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.RaftGroupDeletedError)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
+
+  void InitAsDefaultInstance();
+  static RaftGroupDeletedError* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class ReplicaCorruptionError : public ::google::protobuf::Message {
+ public:
+  ReplicaCorruptionError();
+  virtual ~ReplicaCorruptionError();
+
+  ReplicaCorruptionError(const ReplicaCorruptionError& from);
+
+  inline ReplicaCorruptionError& operator=(const ReplicaCorruptionError& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ReplicaCorruptionError& default_instance();
+
+  void Swap(ReplicaCorruptionError* other);
+
+  // implements Message ----------------------------------------------
+
+  inline ReplicaCorruptionError* New() const { return New(NULL); }
+
+  ReplicaCorruptionError* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const ReplicaCorruptionError& from);
+  void MergeFrom(const ReplicaCorruptionError& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(ReplicaCorruptionError* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional string error_msg = 1;
+  bool has_error_msg() const;
+  void clear_error_msg();
+  static const int kErrorMsgFieldNumber = 1;
+  const ::std::string& error_msg() const;
+  void set_error_msg(const ::std::string& value);
+  void set_error_msg(const char* value);
+  void set_error_msg(const char* value, size_t size);
+  ::std::string* mutable_error_msg();
+  ::std::string* release_error_msg();
+  void set_allocated_error_msg(::std::string* error_msg);
+
+  // optional bool processed = 2;
+  bool has_processed() const;
+  void clear_processed();
+  static const int kProcessedFieldNumber = 2;
+  bool processed() const;
+  void set_processed(bool value);
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.ReplicaCorruptionError)
+ private:
+  inline void set_has_error_msg();
+  inline void clear_has_error_msg();
+  inline void set_has_processed();
+  inline void clear_has_processed();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::google::protobuf::internal::ArenaStringPtr error_msg_;
+  bool processed_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
+
+  void InitAsDefaultInstance();
+  static ReplicaCorruptionError* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class LeaseVersionChangedError : public ::google::protobuf::Message {
+ public:
+  LeaseVersionChangedError();
+  virtual ~LeaseVersionChangedError();
+
+  LeaseVersionChangedError(const LeaseVersionChangedError& from);
+
+  inline LeaseVersionChangedError& operator=(const LeaseVersionChangedError& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const LeaseVersionChangedError& default_instance();
+
+  void Swap(LeaseVersionChangedError* other);
+
+  // implements Message ----------------------------------------------
+
+  inline LeaseVersionChangedError* New() const { return New(NULL); }
+
+  LeaseVersionChangedError* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const LeaseVersionChangedError& from);
+  void MergeFrom(const LeaseVersionChangedError& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(LeaseVersionChangedError* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.LeaseVersionChangedError)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
+
+  void InitAsDefaultInstance();
+  static LeaseVersionChangedError* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class DidntUpdateDescriptorError : public ::google::protobuf::Message {
+ public:
+  DidntUpdateDescriptorError();
+  virtual ~DidntUpdateDescriptorError();
+
+  DidntUpdateDescriptorError(const DidntUpdateDescriptorError& from);
+
+  inline DidntUpdateDescriptorError& operator=(const DidntUpdateDescriptorError& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const DidntUpdateDescriptorError& default_instance();
+
+  void Swap(DidntUpdateDescriptorError* other);
+
+  // implements Message ----------------------------------------------
+
+  inline DidntUpdateDescriptorError* New() const { return New(NULL); }
+
+  DidntUpdateDescriptorError* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const DidntUpdateDescriptorError& from);
+  void MergeFrom(const DidntUpdateDescriptorError& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(DidntUpdateDescriptorError* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.DidntUpdateDescriptorError)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
+
+  void InitAsDefaultInstance();
+  static DidntUpdateDescriptorError* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class SqlTransactionAbortedError : public ::google::protobuf::Message {
+ public:
+  SqlTransactionAbortedError();
+  virtual ~SqlTransactionAbortedError();
+
+  SqlTransactionAbortedError(const SqlTransactionAbortedError& from);
+
+  inline SqlTransactionAbortedError& operator=(const SqlTransactionAbortedError& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const SqlTransactionAbortedError& default_instance();
+
+  void Swap(SqlTransactionAbortedError* other);
+
+  // implements Message ----------------------------------------------
+
+  inline SqlTransactionAbortedError* New() const { return New(NULL); }
+
+  SqlTransactionAbortedError* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const SqlTransactionAbortedError& from);
+  void MergeFrom(const SqlTransactionAbortedError& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(SqlTransactionAbortedError* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.SqlTransactionAbortedError)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
+
+  void InitAsDefaultInstance();
+  static SqlTransactionAbortedError* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class ExistingSchemaChangeLeaseError : public ::google::protobuf::Message {
+ public:
+  ExistingSchemaChangeLeaseError();
+  virtual ~ExistingSchemaChangeLeaseError();
+
+  ExistingSchemaChangeLeaseError(const ExistingSchemaChangeLeaseError& from);
+
+  inline ExistingSchemaChangeLeaseError& operator=(const ExistingSchemaChangeLeaseError& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ExistingSchemaChangeLeaseError& default_instance();
+
+  void Swap(ExistingSchemaChangeLeaseError* other);
+
+  // implements Message ----------------------------------------------
+
+  inline ExistingSchemaChangeLeaseError* New() const { return New(NULL); }
+
+  ExistingSchemaChangeLeaseError* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const ExistingSchemaChangeLeaseError& from);
+  void MergeFrom(const ExistingSchemaChangeLeaseError& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(ExistingSchemaChangeLeaseError* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.ExistingSchemaChangeLeaseError)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
+
+  void InitAsDefaultInstance();
+  static ExistingSchemaChangeLeaseError* default_instance_;
+};
+// -------------------------------------------------------------------
+
 class ErrorDetail : public ::google::protobuf::Message {
  public:
   ErrorDetail();
@@ -1820,6 +2301,60 @@ class ErrorDetail : public ::google::protobuf::Message {
   ::cockroach::roachpb::SendError* release_send();
   void set_allocated_send(::cockroach::roachpb::SendError* send);
 
+  // optional .cockroach.roachpb.RaftGroupDeletedError raft_group_deleted = 16;
+  bool has_raft_group_deleted() const;
+  void clear_raft_group_deleted();
+  static const int kRaftGroupDeletedFieldNumber = 16;
+  const ::cockroach::roachpb::RaftGroupDeletedError& raft_group_deleted() const;
+  ::cockroach::roachpb::RaftGroupDeletedError* mutable_raft_group_deleted();
+  ::cockroach::roachpb::RaftGroupDeletedError* release_raft_group_deleted();
+  void set_allocated_raft_group_deleted(::cockroach::roachpb::RaftGroupDeletedError* raft_group_deleted);
+
+  // optional .cockroach.roachpb.ReplicaCorruptionError replica_corruption = 17;
+  bool has_replica_corruption() const;
+  void clear_replica_corruption();
+  static const int kReplicaCorruptionFieldNumber = 17;
+  const ::cockroach::roachpb::ReplicaCorruptionError& replica_corruption() const;
+  ::cockroach::roachpb::ReplicaCorruptionError* mutable_replica_corruption();
+  ::cockroach::roachpb::ReplicaCorruptionError* release_replica_corruption();
+  void set_allocated_replica_corruption(::cockroach::roachpb::ReplicaCorruptionError* replica_corruption);
+
+  // optional .cockroach.roachpb.LeaseVersionChangedError lease_version_changed = 18;
+  bool has_lease_version_changed() const;
+  void clear_lease_version_changed();
+  static const int kLeaseVersionChangedFieldNumber = 18;
+  const ::cockroach::roachpb::LeaseVersionChangedError& lease_version_changed() const;
+  ::cockroach::roachpb::LeaseVersionChangedError* mutable_lease_version_changed();
+  ::cockroach::roachpb::LeaseVersionChangedError* release_lease_version_changed();
+  void set_allocated_lease_version_changed(::cockroach::roachpb::LeaseVersionChangedError* lease_version_changed);
+
+  // optional .cockroach.roachpb.DidntUpdateDescriptorError didnt_update_descriptor = 19;
+  bool has_didnt_update_descriptor() const;
+  void clear_didnt_update_descriptor();
+  static const int kDidntUpdateDescriptorFieldNumber = 19;
+  const ::cockroach::roachpb::DidntUpdateDescriptorError& didnt_update_descriptor() const;
+  ::cockroach::roachpb::DidntUpdateDescriptorError* mutable_didnt_update_descriptor();
+  ::cockroach::roachpb::DidntUpdateDescriptorError* release_didnt_update_descriptor();
+  void set_allocated_didnt_update_descriptor(::cockroach::roachpb::DidntUpdateDescriptorError* didnt_update_descriptor);
+
+  // optional .cockroach.roachpb.SqlTransactionAbortedError sql_tranasction_aborted = 20;
+  bool has_sql_tranasction_aborted() const;
+  void clear_sql_tranasction_aborted();
+  static const int kSqlTranasctionAbortedFieldNumber = 20;
+  const ::cockroach::roachpb::SqlTransactionAbortedError& sql_tranasction_aborted() const;
+  ::cockroach::roachpb::SqlTransactionAbortedError* mutable_sql_tranasction_aborted();
+  ::cockroach::roachpb::SqlTransactionAbortedError* release_sql_tranasction_aborted();
+  void set_allocated_sql_tranasction_aborted(::cockroach::roachpb::SqlTransactionAbortedError* sql_tranasction_aborted);
+
+  // optional .cockroach.roachpb.ExistingSchemaChangeLeaseError existing_scheme_change_lease = 21;
+  bool has_existing_scheme_change_lease() const;
+  void clear_existing_scheme_change_lease();
+  static const int kExistingSchemeChangeLeaseFieldNumber = 21;
+  const ::cockroach::roachpb::ExistingSchemaChangeLeaseError& existing_scheme_change_lease() const;
+  ::cockroach::roachpb::ExistingSchemaChangeLeaseError* mutable_existing_scheme_change_lease();
+  ::cockroach::roachpb::ExistingSchemaChangeLeaseError* release_existing_scheme_change_lease();
+  void set_allocated_existing_scheme_change_lease(::cockroach::roachpb::ExistingSchemaChangeLeaseError* existing_scheme_change_lease);
+
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.ErrorDetail)
  private:
   inline void set_has_not_leader();
@@ -1852,6 +2387,18 @@ class ErrorDetail : public ::google::protobuf::Message {
   inline void clear_has_node_unavailable();
   inline void set_has_send();
   inline void clear_has_send();
+  inline void set_has_raft_group_deleted();
+  inline void clear_has_raft_group_deleted();
+  inline void set_has_replica_corruption();
+  inline void clear_has_replica_corruption();
+  inline void set_has_lease_version_changed();
+  inline void clear_has_lease_version_changed();
+  inline void set_has_didnt_update_descriptor();
+  inline void clear_has_didnt_update_descriptor();
+  inline void set_has_sql_tranasction_aborted();
+  inline void clear_has_sql_tranasction_aborted();
+  inline void set_has_existing_scheme_change_lease();
+  inline void clear_has_existing_scheme_change_lease();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
@@ -1871,6 +2418,12 @@ class ErrorDetail : public ::google::protobuf::Message {
   ::cockroach::roachpb::LeaseRejectedError* lease_rejected_;
   ::cockroach::roachpb::NodeUnavailableError* node_unavailable_;
   ::cockroach::roachpb::SendError* send_;
+  ::cockroach::roachpb::RaftGroupDeletedError* raft_group_deleted_;
+  ::cockroach::roachpb::ReplicaCorruptionError* replica_corruption_;
+  ::cockroach::roachpb::LeaseVersionChangedError* lease_version_changed_;
+  ::cockroach::roachpb::DidntUpdateDescriptorError* didnt_update_descriptor_;
+  ::cockroach::roachpb::SqlTransactionAbortedError* sql_tranasction_aborted_;
+  ::cockroach::roachpb::ExistingSchemaChangeLeaseError* existing_scheme_change_lease_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
@@ -2059,14 +2612,32 @@ class Error : public ::google::protobuf::Message {
   ::cockroach::roachpb::TransactionRestart transaction_restart() const;
   void set_transaction_restart(::cockroach::roachpb::TransactionRestart value);
 
-  // optional .cockroach.roachpb.ErrorDetail detail = 4;
+  // optional .cockroach.roachpb.Transaction txn = 4;
+  bool has_txn() const;
+  void clear_txn();
+  static const int kTxnFieldNumber = 4;
+  const ::cockroach::roachpb::Transaction& txn() const;
+  ::cockroach::roachpb::Transaction* mutable_txn();
+  ::cockroach::roachpb::Transaction* release_txn();
+  void set_allocated_txn(::cockroach::roachpb::Transaction* txn);
+
+  // optional .cockroach.roachpb.ErrorDetail detail = 5;
   bool has_detail() const;
   void clear_detail();
-  static const int kDetailFieldNumber = 4;
+  static const int kDetailFieldNumber = 5;
   const ::cockroach::roachpb::ErrorDetail& detail() const;
   ::cockroach::roachpb::ErrorDetail* mutable_detail();
   ::cockroach::roachpb::ErrorDetail* release_detail();
   void set_allocated_detail(::cockroach::roachpb::ErrorDetail* detail);
+
+  // optional .cockroach.roachpb.ErrPosition index = 6;
+  bool has_index() const;
+  void clear_index();
+  static const int kIndexFieldNumber = 6;
+  const ::cockroach::roachpb::ErrPosition& index() const;
+  ::cockroach::roachpb::ErrPosition* mutable_index();
+  ::cockroach::roachpb::ErrPosition* release_index();
+  void set_allocated_index(::cockroach::roachpb::ErrPosition* index);
 
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.Error)
  private:
@@ -2076,8 +2647,12 @@ class Error : public ::google::protobuf::Message {
   inline void clear_has_retryable();
   inline void set_has_transaction_restart();
   inline void clear_has_transaction_restart();
+  inline void set_has_txn();
+  inline void clear_has_txn();
   inline void set_has_detail();
   inline void clear_has_detail();
+  inline void set_has_index();
+  inline void clear_has_index();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
@@ -2085,7 +2660,9 @@ class Error : public ::google::protobuf::Message {
   ::google::protobuf::internal::ArenaStringPtr message_;
   bool retryable_;
   int transaction_restart_;
+  ::cockroach::roachpb::Transaction* txn_;
   ::cockroach::roachpb::ErrorDetail* detail_;
+  ::cockroach::roachpb::ErrPosition* index_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
@@ -2895,49 +3472,6 @@ inline void WriteIntentError::set_resolved(bool value) {
   // @@protoc_insertion_point(field_set:cockroach.roachpb.WriteIntentError.resolved)
 }
 
-// optional .cockroach.roachpb.ErrPosition index = 3;
-inline bool WriteIntentError::has_index() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-inline void WriteIntentError::set_has_index() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void WriteIntentError::clear_has_index() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-inline void WriteIntentError::clear_index() {
-  if (index_ != NULL) index_->::cockroach::roachpb::ErrPosition::Clear();
-  clear_has_index();
-}
-inline const ::cockroach::roachpb::ErrPosition& WriteIntentError::index() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.WriteIntentError.index)
-  return index_ != NULL ? *index_ : *default_instance_->index_;
-}
-inline ::cockroach::roachpb::ErrPosition* WriteIntentError::mutable_index() {
-  set_has_index();
-  if (index_ == NULL) {
-    index_ = new ::cockroach::roachpb::ErrPosition;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.WriteIntentError.index)
-  return index_;
-}
-inline ::cockroach::roachpb::ErrPosition* WriteIntentError::release_index() {
-  clear_has_index();
-  ::cockroach::roachpb::ErrPosition* temp = index_;
-  index_ = NULL;
-  return temp;
-}
-inline void WriteIntentError::set_allocated_index(::cockroach::roachpb::ErrPosition* index) {
-  delete index_;
-  index_ = index;
-  if (index) {
-    set_has_index();
-  } else {
-    clear_has_index();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.WriteIntentError.index)
-}
-
 // -------------------------------------------------------------------
 
 // WriteTooOldError
@@ -3077,49 +3611,6 @@ inline void ConditionFailedError::set_allocated_actual_value(::cockroach::roachp
     clear_has_actual_value();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ConditionFailedError.actual_value)
-}
-
-// optional .cockroach.roachpb.ErrPosition index = 2;
-inline bool ConditionFailedError::has_index() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
-}
-inline void ConditionFailedError::set_has_index() {
-  _has_bits_[0] |= 0x00000002u;
-}
-inline void ConditionFailedError::clear_has_index() {
-  _has_bits_[0] &= ~0x00000002u;
-}
-inline void ConditionFailedError::clear_index() {
-  if (index_ != NULL) index_->::cockroach::roachpb::ErrPosition::Clear();
-  clear_has_index();
-}
-inline const ::cockroach::roachpb::ErrPosition& ConditionFailedError::index() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.ConditionFailedError.index)
-  return index_ != NULL ? *index_ : *default_instance_->index_;
-}
-inline ::cockroach::roachpb::ErrPosition* ConditionFailedError::mutable_index() {
-  set_has_index();
-  if (index_ == NULL) {
-    index_ = new ::cockroach::roachpb::ErrPosition;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ConditionFailedError.index)
-  return index_;
-}
-inline ::cockroach::roachpb::ErrPosition* ConditionFailedError::release_index() {
-  clear_has_index();
-  ::cockroach::roachpb::ErrPosition* temp = index_;
-  index_ = NULL;
-  return temp;
-}
-inline void ConditionFailedError::set_allocated_index(::cockroach::roachpb::ErrPosition* index) {
-  delete index_;
-  index_ = index;
-  if (index) {
-    set_has_index();
-  } else {
-    clear_has_index();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ConditionFailedError.index)
 }
 
 // -------------------------------------------------------------------
@@ -3345,6 +3836,107 @@ inline void SendError::set_retryable(bool value) {
   retryable_ = value;
   // @@protoc_insertion_point(field_set:cockroach.roachpb.SendError.retryable)
 }
+
+// -------------------------------------------------------------------
+
+// RaftGroupDeletedError
+
+// -------------------------------------------------------------------
+
+// ReplicaCorruptionError
+
+// optional string error_msg = 1;
+inline bool ReplicaCorruptionError::has_error_msg() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void ReplicaCorruptionError::set_has_error_msg() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void ReplicaCorruptionError::clear_has_error_msg() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void ReplicaCorruptionError::clear_error_msg() {
+  error_msg_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_error_msg();
+}
+inline const ::std::string& ReplicaCorruptionError::error_msg() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+  return error_msg_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ReplicaCorruptionError::set_error_msg(const ::std::string& value) {
+  set_has_error_msg();
+  error_msg_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+}
+inline void ReplicaCorruptionError::set_error_msg(const char* value) {
+  set_has_error_msg();
+  error_msg_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+}
+inline void ReplicaCorruptionError::set_error_msg(const char* value, size_t size) {
+  set_has_error_msg();
+  error_msg_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+}
+inline ::std::string* ReplicaCorruptionError::mutable_error_msg() {
+  set_has_error_msg();
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+  return error_msg_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ReplicaCorruptionError::release_error_msg() {
+  clear_has_error_msg();
+  return error_msg_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ReplicaCorruptionError::set_allocated_error_msg(::std::string* error_msg) {
+  if (error_msg != NULL) {
+    set_has_error_msg();
+  } else {
+    clear_has_error_msg();
+  }
+  error_msg_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), error_msg);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ReplicaCorruptionError.error_msg)
+}
+
+// optional bool processed = 2;
+inline bool ReplicaCorruptionError::has_processed() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void ReplicaCorruptionError::set_has_processed() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void ReplicaCorruptionError::clear_has_processed() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void ReplicaCorruptionError::clear_processed() {
+  processed_ = false;
+  clear_has_processed();
+}
+inline bool ReplicaCorruptionError::processed() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ReplicaCorruptionError.processed)
+  return processed_;
+}
+inline void ReplicaCorruptionError::set_processed(bool value) {
+  set_has_processed();
+  processed_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ReplicaCorruptionError.processed)
+}
+
+// -------------------------------------------------------------------
+
+// LeaseVersionChangedError
+
+// -------------------------------------------------------------------
+
+// DidntUpdateDescriptorError
+
+// -------------------------------------------------------------------
+
+// SqlTransactionAbortedError
+
+// -------------------------------------------------------------------
+
+// ExistingSchemaChangeLeaseError
 
 // -------------------------------------------------------------------
 
@@ -3995,6 +4587,264 @@ inline void ErrorDetail::set_allocated_send(::cockroach::roachpb::SendError* sen
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.send)
 }
 
+// optional .cockroach.roachpb.RaftGroupDeletedError raft_group_deleted = 16;
+inline bool ErrorDetail::has_raft_group_deleted() const {
+  return (_has_bits_[0] & 0x00008000u) != 0;
+}
+inline void ErrorDetail::set_has_raft_group_deleted() {
+  _has_bits_[0] |= 0x00008000u;
+}
+inline void ErrorDetail::clear_has_raft_group_deleted() {
+  _has_bits_[0] &= ~0x00008000u;
+}
+inline void ErrorDetail::clear_raft_group_deleted() {
+  if (raft_group_deleted_ != NULL) raft_group_deleted_->::cockroach::roachpb::RaftGroupDeletedError::Clear();
+  clear_has_raft_group_deleted();
+}
+inline const ::cockroach::roachpb::RaftGroupDeletedError& ErrorDetail::raft_group_deleted() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.raft_group_deleted)
+  return raft_group_deleted_ != NULL ? *raft_group_deleted_ : *default_instance_->raft_group_deleted_;
+}
+inline ::cockroach::roachpb::RaftGroupDeletedError* ErrorDetail::mutable_raft_group_deleted() {
+  set_has_raft_group_deleted();
+  if (raft_group_deleted_ == NULL) {
+    raft_group_deleted_ = new ::cockroach::roachpb::RaftGroupDeletedError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.raft_group_deleted)
+  return raft_group_deleted_;
+}
+inline ::cockroach::roachpb::RaftGroupDeletedError* ErrorDetail::release_raft_group_deleted() {
+  clear_has_raft_group_deleted();
+  ::cockroach::roachpb::RaftGroupDeletedError* temp = raft_group_deleted_;
+  raft_group_deleted_ = NULL;
+  return temp;
+}
+inline void ErrorDetail::set_allocated_raft_group_deleted(::cockroach::roachpb::RaftGroupDeletedError* raft_group_deleted) {
+  delete raft_group_deleted_;
+  raft_group_deleted_ = raft_group_deleted;
+  if (raft_group_deleted) {
+    set_has_raft_group_deleted();
+  } else {
+    clear_has_raft_group_deleted();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.raft_group_deleted)
+}
+
+// optional .cockroach.roachpb.ReplicaCorruptionError replica_corruption = 17;
+inline bool ErrorDetail::has_replica_corruption() const {
+  return (_has_bits_[0] & 0x00010000u) != 0;
+}
+inline void ErrorDetail::set_has_replica_corruption() {
+  _has_bits_[0] |= 0x00010000u;
+}
+inline void ErrorDetail::clear_has_replica_corruption() {
+  _has_bits_[0] &= ~0x00010000u;
+}
+inline void ErrorDetail::clear_replica_corruption() {
+  if (replica_corruption_ != NULL) replica_corruption_->::cockroach::roachpb::ReplicaCorruptionError::Clear();
+  clear_has_replica_corruption();
+}
+inline const ::cockroach::roachpb::ReplicaCorruptionError& ErrorDetail::replica_corruption() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.replica_corruption)
+  return replica_corruption_ != NULL ? *replica_corruption_ : *default_instance_->replica_corruption_;
+}
+inline ::cockroach::roachpb::ReplicaCorruptionError* ErrorDetail::mutable_replica_corruption() {
+  set_has_replica_corruption();
+  if (replica_corruption_ == NULL) {
+    replica_corruption_ = new ::cockroach::roachpb::ReplicaCorruptionError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.replica_corruption)
+  return replica_corruption_;
+}
+inline ::cockroach::roachpb::ReplicaCorruptionError* ErrorDetail::release_replica_corruption() {
+  clear_has_replica_corruption();
+  ::cockroach::roachpb::ReplicaCorruptionError* temp = replica_corruption_;
+  replica_corruption_ = NULL;
+  return temp;
+}
+inline void ErrorDetail::set_allocated_replica_corruption(::cockroach::roachpb::ReplicaCorruptionError* replica_corruption) {
+  delete replica_corruption_;
+  replica_corruption_ = replica_corruption;
+  if (replica_corruption) {
+    set_has_replica_corruption();
+  } else {
+    clear_has_replica_corruption();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.replica_corruption)
+}
+
+// optional .cockroach.roachpb.LeaseVersionChangedError lease_version_changed = 18;
+inline bool ErrorDetail::has_lease_version_changed() const {
+  return (_has_bits_[0] & 0x00020000u) != 0;
+}
+inline void ErrorDetail::set_has_lease_version_changed() {
+  _has_bits_[0] |= 0x00020000u;
+}
+inline void ErrorDetail::clear_has_lease_version_changed() {
+  _has_bits_[0] &= ~0x00020000u;
+}
+inline void ErrorDetail::clear_lease_version_changed() {
+  if (lease_version_changed_ != NULL) lease_version_changed_->::cockroach::roachpb::LeaseVersionChangedError::Clear();
+  clear_has_lease_version_changed();
+}
+inline const ::cockroach::roachpb::LeaseVersionChangedError& ErrorDetail::lease_version_changed() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.lease_version_changed)
+  return lease_version_changed_ != NULL ? *lease_version_changed_ : *default_instance_->lease_version_changed_;
+}
+inline ::cockroach::roachpb::LeaseVersionChangedError* ErrorDetail::mutable_lease_version_changed() {
+  set_has_lease_version_changed();
+  if (lease_version_changed_ == NULL) {
+    lease_version_changed_ = new ::cockroach::roachpb::LeaseVersionChangedError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.lease_version_changed)
+  return lease_version_changed_;
+}
+inline ::cockroach::roachpb::LeaseVersionChangedError* ErrorDetail::release_lease_version_changed() {
+  clear_has_lease_version_changed();
+  ::cockroach::roachpb::LeaseVersionChangedError* temp = lease_version_changed_;
+  lease_version_changed_ = NULL;
+  return temp;
+}
+inline void ErrorDetail::set_allocated_lease_version_changed(::cockroach::roachpb::LeaseVersionChangedError* lease_version_changed) {
+  delete lease_version_changed_;
+  lease_version_changed_ = lease_version_changed;
+  if (lease_version_changed) {
+    set_has_lease_version_changed();
+  } else {
+    clear_has_lease_version_changed();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.lease_version_changed)
+}
+
+// optional .cockroach.roachpb.DidntUpdateDescriptorError didnt_update_descriptor = 19;
+inline bool ErrorDetail::has_didnt_update_descriptor() const {
+  return (_has_bits_[0] & 0x00040000u) != 0;
+}
+inline void ErrorDetail::set_has_didnt_update_descriptor() {
+  _has_bits_[0] |= 0x00040000u;
+}
+inline void ErrorDetail::clear_has_didnt_update_descriptor() {
+  _has_bits_[0] &= ~0x00040000u;
+}
+inline void ErrorDetail::clear_didnt_update_descriptor() {
+  if (didnt_update_descriptor_ != NULL) didnt_update_descriptor_->::cockroach::roachpb::DidntUpdateDescriptorError::Clear();
+  clear_has_didnt_update_descriptor();
+}
+inline const ::cockroach::roachpb::DidntUpdateDescriptorError& ErrorDetail::didnt_update_descriptor() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.didnt_update_descriptor)
+  return didnt_update_descriptor_ != NULL ? *didnt_update_descriptor_ : *default_instance_->didnt_update_descriptor_;
+}
+inline ::cockroach::roachpb::DidntUpdateDescriptorError* ErrorDetail::mutable_didnt_update_descriptor() {
+  set_has_didnt_update_descriptor();
+  if (didnt_update_descriptor_ == NULL) {
+    didnt_update_descriptor_ = new ::cockroach::roachpb::DidntUpdateDescriptorError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.didnt_update_descriptor)
+  return didnt_update_descriptor_;
+}
+inline ::cockroach::roachpb::DidntUpdateDescriptorError* ErrorDetail::release_didnt_update_descriptor() {
+  clear_has_didnt_update_descriptor();
+  ::cockroach::roachpb::DidntUpdateDescriptorError* temp = didnt_update_descriptor_;
+  didnt_update_descriptor_ = NULL;
+  return temp;
+}
+inline void ErrorDetail::set_allocated_didnt_update_descriptor(::cockroach::roachpb::DidntUpdateDescriptorError* didnt_update_descriptor) {
+  delete didnt_update_descriptor_;
+  didnt_update_descriptor_ = didnt_update_descriptor;
+  if (didnt_update_descriptor) {
+    set_has_didnt_update_descriptor();
+  } else {
+    clear_has_didnt_update_descriptor();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.didnt_update_descriptor)
+}
+
+// optional .cockroach.roachpb.SqlTransactionAbortedError sql_tranasction_aborted = 20;
+inline bool ErrorDetail::has_sql_tranasction_aborted() const {
+  return (_has_bits_[0] & 0x00080000u) != 0;
+}
+inline void ErrorDetail::set_has_sql_tranasction_aborted() {
+  _has_bits_[0] |= 0x00080000u;
+}
+inline void ErrorDetail::clear_has_sql_tranasction_aborted() {
+  _has_bits_[0] &= ~0x00080000u;
+}
+inline void ErrorDetail::clear_sql_tranasction_aborted() {
+  if (sql_tranasction_aborted_ != NULL) sql_tranasction_aborted_->::cockroach::roachpb::SqlTransactionAbortedError::Clear();
+  clear_has_sql_tranasction_aborted();
+}
+inline const ::cockroach::roachpb::SqlTransactionAbortedError& ErrorDetail::sql_tranasction_aborted() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.sql_tranasction_aborted)
+  return sql_tranasction_aborted_ != NULL ? *sql_tranasction_aborted_ : *default_instance_->sql_tranasction_aborted_;
+}
+inline ::cockroach::roachpb::SqlTransactionAbortedError* ErrorDetail::mutable_sql_tranasction_aborted() {
+  set_has_sql_tranasction_aborted();
+  if (sql_tranasction_aborted_ == NULL) {
+    sql_tranasction_aborted_ = new ::cockroach::roachpb::SqlTransactionAbortedError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.sql_tranasction_aborted)
+  return sql_tranasction_aborted_;
+}
+inline ::cockroach::roachpb::SqlTransactionAbortedError* ErrorDetail::release_sql_tranasction_aborted() {
+  clear_has_sql_tranasction_aborted();
+  ::cockroach::roachpb::SqlTransactionAbortedError* temp = sql_tranasction_aborted_;
+  sql_tranasction_aborted_ = NULL;
+  return temp;
+}
+inline void ErrorDetail::set_allocated_sql_tranasction_aborted(::cockroach::roachpb::SqlTransactionAbortedError* sql_tranasction_aborted) {
+  delete sql_tranasction_aborted_;
+  sql_tranasction_aborted_ = sql_tranasction_aborted;
+  if (sql_tranasction_aborted) {
+    set_has_sql_tranasction_aborted();
+  } else {
+    clear_has_sql_tranasction_aborted();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.sql_tranasction_aborted)
+}
+
+// optional .cockroach.roachpb.ExistingSchemaChangeLeaseError existing_scheme_change_lease = 21;
+inline bool ErrorDetail::has_existing_scheme_change_lease() const {
+  return (_has_bits_[0] & 0x00100000u) != 0;
+}
+inline void ErrorDetail::set_has_existing_scheme_change_lease() {
+  _has_bits_[0] |= 0x00100000u;
+}
+inline void ErrorDetail::clear_has_existing_scheme_change_lease() {
+  _has_bits_[0] &= ~0x00100000u;
+}
+inline void ErrorDetail::clear_existing_scheme_change_lease() {
+  if (existing_scheme_change_lease_ != NULL) existing_scheme_change_lease_->::cockroach::roachpb::ExistingSchemaChangeLeaseError::Clear();
+  clear_has_existing_scheme_change_lease();
+}
+inline const ::cockroach::roachpb::ExistingSchemaChangeLeaseError& ErrorDetail::existing_scheme_change_lease() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ErrorDetail.existing_scheme_change_lease)
+  return existing_scheme_change_lease_ != NULL ? *existing_scheme_change_lease_ : *default_instance_->existing_scheme_change_lease_;
+}
+inline ::cockroach::roachpb::ExistingSchemaChangeLeaseError* ErrorDetail::mutable_existing_scheme_change_lease() {
+  set_has_existing_scheme_change_lease();
+  if (existing_scheme_change_lease_ == NULL) {
+    existing_scheme_change_lease_ = new ::cockroach::roachpb::ExistingSchemaChangeLeaseError;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ErrorDetail.existing_scheme_change_lease)
+  return existing_scheme_change_lease_;
+}
+inline ::cockroach::roachpb::ExistingSchemaChangeLeaseError* ErrorDetail::release_existing_scheme_change_lease() {
+  clear_has_existing_scheme_change_lease();
+  ::cockroach::roachpb::ExistingSchemaChangeLeaseError* temp = existing_scheme_change_lease_;
+  existing_scheme_change_lease_ = NULL;
+  return temp;
+}
+inline void ErrorDetail::set_allocated_existing_scheme_change_lease(::cockroach::roachpb::ExistingSchemaChangeLeaseError* existing_scheme_change_lease) {
+  delete existing_scheme_change_lease_;
+  existing_scheme_change_lease_ = existing_scheme_change_lease;
+  if (existing_scheme_change_lease) {
+    set_has_existing_scheme_change_lease();
+  } else {
+    clear_has_existing_scheme_change_lease();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ErrorDetail.existing_scheme_change_lease)
+}
+
 // -------------------------------------------------------------------
 
 // ErrPosition
@@ -4129,15 +4979,58 @@ inline void Error::set_transaction_restart(::cockroach::roachpb::TransactionRest
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Error.transaction_restart)
 }
 
-// optional .cockroach.roachpb.ErrorDetail detail = 4;
-inline bool Error::has_detail() const {
+// optional .cockroach.roachpb.Transaction txn = 4;
+inline bool Error::has_txn() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
-inline void Error::set_has_detail() {
+inline void Error::set_has_txn() {
   _has_bits_[0] |= 0x00000008u;
 }
-inline void Error::clear_has_detail() {
+inline void Error::clear_has_txn() {
   _has_bits_[0] &= ~0x00000008u;
+}
+inline void Error::clear_txn() {
+  if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
+  clear_has_txn();
+}
+inline const ::cockroach::roachpb::Transaction& Error::txn() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Error.txn)
+  return txn_ != NULL ? *txn_ : *default_instance_->txn_;
+}
+inline ::cockroach::roachpb::Transaction* Error::mutable_txn() {
+  set_has_txn();
+  if (txn_ == NULL) {
+    txn_ = new ::cockroach::roachpb::Transaction;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Error.txn)
+  return txn_;
+}
+inline ::cockroach::roachpb::Transaction* Error::release_txn() {
+  clear_has_txn();
+  ::cockroach::roachpb::Transaction* temp = txn_;
+  txn_ = NULL;
+  return temp;
+}
+inline void Error::set_allocated_txn(::cockroach::roachpb::Transaction* txn) {
+  delete txn_;
+  txn_ = txn;
+  if (txn) {
+    set_has_txn();
+  } else {
+    clear_has_txn();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.txn)
+}
+
+// optional .cockroach.roachpb.ErrorDetail detail = 5;
+inline bool Error::has_detail() const {
+  return (_has_bits_[0] & 0x00000010u) != 0;
+}
+inline void Error::set_has_detail() {
+  _has_bits_[0] |= 0x00000010u;
+}
+inline void Error::clear_has_detail() {
+  _has_bits_[0] &= ~0x00000010u;
 }
 inline void Error::clear_detail() {
   if (detail_ != NULL) detail_->::cockroach::roachpb::ErrorDetail::Clear();
@@ -4172,7 +5065,62 @@ inline void Error::set_allocated_detail(::cockroach::roachpb::ErrorDetail* detai
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.detail)
 }
 
+// optional .cockroach.roachpb.ErrPosition index = 6;
+inline bool Error::has_index() const {
+  return (_has_bits_[0] & 0x00000020u) != 0;
+}
+inline void Error::set_has_index() {
+  _has_bits_[0] |= 0x00000020u;
+}
+inline void Error::clear_has_index() {
+  _has_bits_[0] &= ~0x00000020u;
+}
+inline void Error::clear_index() {
+  if (index_ != NULL) index_->::cockroach::roachpb::ErrPosition::Clear();
+  clear_has_index();
+}
+inline const ::cockroach::roachpb::ErrPosition& Error::index() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Error.index)
+  return index_ != NULL ? *index_ : *default_instance_->index_;
+}
+inline ::cockroach::roachpb::ErrPosition* Error::mutable_index() {
+  set_has_index();
+  if (index_ == NULL) {
+    index_ = new ::cockroach::roachpb::ErrPosition;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Error.index)
+  return index_;
+}
+inline ::cockroach::roachpb::ErrPosition* Error::release_index() {
+  clear_has_index();
+  ::cockroach::roachpb::ErrPosition* temp = index_;
+  index_ = NULL;
+  return temp;
+}
+inline void Error::set_allocated_index(::cockroach::roachpb::ErrPosition* index) {
+  delete index_;
+  index_ = index;
+  if (index) {
+    set_has_index();
+  } else {
+    clear_has_index();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.index)
+}
+
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -280,8 +280,8 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 		}
 	}
 
-	if err := repl.resolveIntents(repl.context(), intents, true /* wait */, false /* !poison */); err != nil {
-		return err
+	if pErr := repl.resolveIntents(repl.context(), intents, true /* wait */, false /* !poison */); pErr != nil {
+		return pErr.GoError()
 	}
 
 	// Deal with any leftover sequence cache keys. There shouldn't be many of

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -140,7 +140,7 @@ func (rlq *raftLogQueue) process(now roachpb.Timestamp, r *Replica, _ *config.Sy
 			Index:   oldestIndex,
 			RangeID: r.RangeID,
 		})
-		return rlq.db.Run(b)
+		return rlq.db.Run(b).GoError()
 	}
 	return nil
 }

--- a/storage/range_tree.go
+++ b/storage/range_tree.go
@@ -78,8 +78,8 @@ func (tc *treeContext) flush(b *client.Batch) error {
 // GetRangeTree fetches the RangeTree proto and sets up the range tree context.
 func getRangeTree(txn *client.Txn) (*treeContext, error) {
 	tree := new(roachpb.RangeTree)
-	if err := txn.GetProto(keys.RangeTreeRoot, tree); err != nil {
-		return nil, err
+	if pErr := txn.GetProto(keys.RangeTreeRoot, tree); pErr != nil {
+		return nil, pErr.GoError()
 	}
 	return &treeContext{
 		txn:   txn,
@@ -130,8 +130,8 @@ func (tc *treeContext) getNode(key roachpb.RKey) (*roachpb.RangeTreeNode, error)
 
 	// We don't have it cached so fetch it and add it to the cache.
 	node := new(roachpb.RangeTreeNode)
-	if err := tc.txn.GetProto(keys.RangeTreeNodeKey(key), node); err != nil {
-		return nil, err
+	if pErr := tc.txn.GetProto(keys.RangeTreeNodeKey(key), node); pErr != nil {
+		return nil, pErr.GoError()
 	}
 	tc.nodes[keyString] = cachedNode{
 		node:  node,

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -99,9 +99,9 @@ func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.
 		},
 		MaxRanges: 1,
 	})
-	br, err := q.db.RunWithResponse(b)
-	if err != nil {
-		return err
+	br, pErr := q.db.RunWithResponse(b)
+	if pErr != nil {
+		return pErr.GoError()
 	}
 	reply := br.Responses[0].GetInner().(*roachpb.RangeLookupResponse)
 
@@ -144,10 +144,10 @@ func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.
 	} else {
 		// This range is a current member of the raft group. Acquire the lease
 		// to avoid processing this range again before the next inactivity threshold.
-		if err := rng.requestLeaderLease(now); err != nil {
-			if _, ok := err.(*roachpb.LeaseRejectedError); !ok {
+		if pErr := rng.requestLeaderLease(now); pErr != nil {
+			if _, ok := pErr.GoError().(*roachpb.LeaseRejectedError); !ok {
 				if log.V(1) {
-					log.Infof("unable to acquire lease from valid range %s: %s", rng, err)
+					log.Infof("unable to acquire lease from valid range %s: %s", rng, pErr)
 				}
 			}
 		}

--- a/storage/sequence_cache.go
+++ b/storage/sequence_cache.go
@@ -181,11 +181,11 @@ func (sc *SequenceCache) CopyFrom(e engine.Engine, originRangeID roachpb.RangeID
 }
 
 // Put writes a sequence number for the specified transaction ID.
-func (sc *SequenceCache) Put(e engine.Engine, id []byte, epoch, seq uint32, txnKey roachpb.Key, txnTS roachpb.Timestamp, err error) error {
+func (sc *SequenceCache) Put(e engine.Engine, id []byte, epoch, seq uint32, txnKey roachpb.Key, txnTS roachpb.Timestamp, pErr *roachpb.Error) error {
 	if seq <= 0 || len(id) == 0 {
 		return errEmptyTxnID
 	}
-	if !sc.shouldCacheError(err) {
+	if !sc.shouldCacheError(pErr) {
 		return nil
 	}
 
@@ -198,8 +198,8 @@ func (sc *SequenceCache) Put(e engine.Engine, id []byte, epoch, seq uint32, txnK
 // Responses with write-too-old, write-intent and not leader errors
 // are retried on the server, and so are not recorded in the sequence
 // cache in the hopes of retrying to a successful outcome.
-func (sc *SequenceCache) shouldCacheError(err error) bool {
-	switch err.(type) {
+func (sc *SequenceCache) shouldCacheError(pErr *roachpb.Error) bool {
+	switch pErr.GoError().(type) {
 	case *roachpb.WriteTooOldError, *roachpb.WriteIntentError, *roachpb.NotLeaderError, *roachpb.RangeKeyMismatchError:
 		return false
 	}

--- a/storage/sequence_cache_test.go
+++ b/storage/sequence_cache_test.go
@@ -242,7 +242,7 @@ func TestSequenceCacheShouldCache(t *testing.T) {
 	for i, test := range testCases {
 		br := &roachpb.BatchResponse{}
 		br.Add(&reply)
-		if shouldCache := sc.shouldCacheError(test.err); shouldCache != test.shouldCache {
+		if shouldCache := sc.shouldCacheError(roachpb.NewError(test.err)); shouldCache != test.shouldCache {
 			t.Errorf("%d: expected cache? %t; got %t", i, test.shouldCache, shouldCache)
 		}
 	}

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -111,10 +111,10 @@ func (sq *splitQueue) process(now roachpb.Timestamp, rng *Replica,
 	// FIXME: why is this implementation not the same as the one above?
 	if float64(rng.stats.GetSize())/float64(zone.RangeMaxBytes) > 1 {
 		log.Infof("splitting %s size=%d max=%d", rng, rng.stats.GetSize(), zone.RangeMaxBytes)
-		if _, err = client.SendWrapped(rng, rng.context(), &roachpb.AdminSplitRequest{
+		if _, pErr := client.SendWrapped(rng, rng.context(), &roachpb.AdminSplitRequest{
 			Span: roachpb.Span{Key: desc.StartKey.AsRawKey()},
-		}); err != nil {
-			return err
+		}); pErr != nil {
+			return pErr.GoError()
 		}
 	}
 	return nil

--- a/storage/store.go
+++ b/storage/store.go
@@ -18,7 +18,6 @@ package storage
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -88,10 +87,6 @@ var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeTy
 	roachpb.ADD_REPLICA:    raftpb.ConfChangeAddNode,
 	roachpb.REMOVE_REPLICA: raftpb.ConfChangeRemoveNode,
 }
-
-// errRaftGroupDeleted is returned for commands which are pending
-// while their group is deleted.
-var errRaftGroupDeleted = errors.New("raft group deleted")
 
 // verifyKeys verifies keys. If checkEndKey is true, then the end key
 // is verified to be non-nil and greater than start key. If
@@ -652,7 +647,7 @@ func (s *Store) startGossip() {
 // timeouts. The retry loop makes sure we try hard to keep asking for
 // the lease instead of waiting for the next sentinelGossipInterval
 // to transpire.
-func (s *Store) maybeGossipFirstRange() error {
+func (s *Store) maybeGossipFirstRange() *roachpb.Error {
 	retryOptions := retry.Options{
 		InitialBackoff: 100 * time.Millisecond, // first backoff at 100ms
 		MaxBackoff:     1 * time.Second,        // max backoff is 1s
@@ -662,9 +657,9 @@ func (s *Store) maybeGossipFirstRange() error {
 	for loop := retry.Start(retryOptions); loop.Next(); {
 		rng := s.LookupReplica(roachpb.RKeyMin, nil)
 		if rng != nil {
-			err := rng.maybeGossipFirstRange()
-			if nlErr, ok := err.(*roachpb.NotLeaderError); !ok || nlErr.Leader != nil {
-				return err
+			pErr := rng.maybeGossipFirstRange()
+			if nlErr, ok := pErr.GoError().(*roachpb.NotLeaderError); !ok || nlErr.Leader != nil {
+				return pErr
 			}
 		} else {
 			return nil
@@ -675,7 +670,7 @@ func (s *Store) maybeGossipFirstRange() error {
 
 // maybeGossipSystemConfig looks for the range containing SystemConfig keys and
 // lets that range gossip them.
-func (s *Store) maybeGossipSystemConfig() error {
+func (s *Store) maybeGossipSystemConfig() *roachpb.Error {
 	rng := s.LookupReplica(roachpb.RKey(keys.SystemConfigSpan.Key), nil)
 	if rng == nil {
 		// This store has no range with this configuration.
@@ -685,8 +680,8 @@ func (s *Store) maybeGossipSystemConfig() error {
 	// gossip. If an unexpected error occurs (i.e. nobody else seems to
 	// have an active lease but we still failed to obtain it), return
 	// that error.
-	_, err := rng.getLeaseForGossip(s.Context(nil))
-	return err
+	_, pErr := rng.getLeaseForGossip(s.Context(nil))
+	return pErr
 }
 
 // systemGossipUpdate is a callback for gossip updates to
@@ -1224,8 +1219,8 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 			// before we reach that point.
 			offset := time.Duration(ba.Timestamp.WallTime - s.Clock().PhysicalNow())
 			if offset > s.Clock().MaxOffset() {
-				return nil, roachpb.NewError(util.Errorf("Rejecting command with timestamp in the future: %d (%s ahead)",
-					ba.Timestamp.WallTime, offset))
+				return nil, roachpb.NewErrorf("Rejecting command with timestamp in the future: %d (%s ahead)",
+					ba.Timestamp.WallTime, offset)
 			}
 		}
 		// Update our clock with the incoming request timestamp. This
@@ -1260,24 +1255,21 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 		return r.Next()
 	}
 	var rng *Replica
-	var err error
+	var pErr *roachpb.Error
 
 	// Add the command to the range for execution; exit retry loop on success.
 	for r := retry.Start(s.ctx.RangeRetryOptions); next(&r); {
 		// Get range and add command to the range for execution.
+		var err error
 		rng, err = s.GetReplica(ba.RangeID)
 		if err != nil {
-			return nil, roachpb.NewError(err)
+			pErr = roachpb.NewError(err)
+			return nil, pErr
 		}
 
 		var br *roachpb.BatchResponse
-		{
-			var pErr *roachpb.Error
-			br, pErr = rng.Send(ctx, ba)
-			err = pErr.GoError()
-		}
-
-		if err == nil {
+		br, pErr = rng.Send(ctx, ba)
+		if pErr == nil {
 			return br, nil
 		}
 
@@ -1285,7 +1277,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 		// because this is the code path with the requesting client
 		// waiting. We don't want every replica to attempt to resolve the
 		// intent independently, so we can't do it there.
-		if wiErr, ok := err.(*roachpb.WriteIntentError); ok {
+		if wiErr, ok := pErr.GoError().(*roachpb.WriteIntentError); ok {
 			var pushType roachpb.PushTxnType
 			if ba.IsWrite() {
 				pushType = roachpb.PUSH_ABORT
@@ -1293,12 +1285,12 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 				pushType = roachpb.PUSH_TIMESTAMP
 			}
 
-			index, ok := wiErr.ErrorIndex()
-			if ok {
-				args := ba.Requests[index].GetInner()
+			index := pErr.Index
+			if index != nil {
+				args := ba.Requests[index.Index].GetInner()
 				// TODO(tschottdorf): implications of using the batch ts here?
 				var resolveIntents []roachpb.Intent
-				resolveIntents, err = s.resolveWriteIntentError(ctx, wiErr, rng, args, ba.Header, pushType)
+				resolveIntents, pErr = s.resolveWriteIntentError(ctx, wiErr, rng, args, ba.Header, pushType)
 				if len(resolveIntents) > 0 {
 					if resErr := rng.resolveIntents(ctx, resolveIntents, false /* !wait */, true /* poison */); resErr != nil {
 						// When resolving asynchronously, should never get an error
@@ -1308,34 +1300,32 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 				}
 				// Make sure that if an index is carried in the error, it
 				// remains the one corresponding to the batch here.
-				if iErr, ok := err.(roachpb.IndexedError); ok {
-					if _, ok := iErr.ErrorIndex(); ok {
-						iErr.SetErrorIndex(index)
-					}
+				if pErr.Index != nil {
+					pErr.SetErrorIndex(index.Index)
 				}
 			}
 		}
 
-		switch t := err.(type) {
+		switch t := pErr.GoError().(type) {
 		case *roachpb.ReadWithinUncertaintyIntervalError:
 			t.NodeID = ba.Replica.NodeID
 		case *roachpb.WriteTooOldError:
-			trace.Event(fmt.Sprintf("error: %T", err))
+			trace.Event(fmt.Sprintf("error: %T", pErr.GoError()))
 			// Update request timestamp and retry immediately.
 			ba.Timestamp = t.ExistingTimestamp.Next()
 			r.Reset()
 			if log.V(1) {
-				log.Warning(err)
+				log.Warning(pErr)
 			}
 			continue
 		case *roachpb.WriteIntentError:
-			trace.Event(fmt.Sprintf("error: %T", err))
+			trace.Event(fmt.Sprintf("error: %T", pErr.GoError()))
 			// If write intent error is resolved, exit retry/backoff loop to
 			// immediately retry.
 			if t.Resolved {
 				r.Reset()
 				if log.V(1) {
-					log.Warning(err)
+					log.Warning(pErr)
 				}
 				continue
 			}
@@ -1347,11 +1337,11 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 				}
 			}
 			if log.V(1) {
-				log.Warning(err)
+				log.Warning(pErr)
 			}
 			continue
 		}
-		return nil, roachpb.NewError(err)
+		return nil, pErr
 	}
 
 	// By default, retries are indefinite. However, some unittests set a
@@ -1359,9 +1349,11 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 	// and the original error otherwise.
 	trace.Event("store retry limit exceeded") // good to check for if tests fail
 	if ba.Txn != nil {
-		return nil, roachpb.NewError(roachpb.NewTransactionRetryError(ba.Txn))
+		pErr := roachpb.NewError(roachpb.NewTransactionRetryError(ba.Txn))
+		pErr.Txn = ba.Txn
+		return nil, pErr
 	}
-	return nil, roachpb.NewError(err)
+	return nil, pErr
 }
 
 // resolveWriteIntentError tries to push the conflicting transaction (if
@@ -1381,7 +1373,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 // c) resolving intents upon EndTransaction which are not local to the given
 //    range. This is the only path in which the transaction is going to be
 //    in non-pending state and doesn't require a push.
-func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.WriteIntentError, rng *Replica, args roachpb.Request, h roachpb.Header, pushType roachpb.PushTxnType) ([]roachpb.Intent, error) {
+func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.WriteIntentError, rng *Replica, args roachpb.Request, h roachpb.Header, pushType roachpb.PushTxnType) ([]roachpb.Intent, *roachpb.Error) {
 	method := args.Method()
 	pusherTxn := h.Txn
 	readOnly := roachpb.IsReadOnly(args) // TODO(tschottdorf): pass as param
@@ -1436,6 +1428,8 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.Writ
 			PushType: pushType,
 		})
 	}
+	// TODO(kaneda): Set the transaction in the header so that the
+	// txn is correctly propagated in an error response.
 	b := &client.Batch{}
 	b.InternalAddRequest(pushReqs...)
 	br, pushErr := s.db.RunWithResponse(b)
@@ -1454,7 +1448,7 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.Writ
 		// For read/write conflicts, return the write intent error which
 		// engages backoff/retry (with !Resolved). We don't need to
 		// restart the txn, only resend the read with a backoff.
-		return nil, wiErr
+		return nil, roachpb.NewError(wiErr)
 	}
 	wiErr.Resolved = true // success!
 
@@ -1462,7 +1456,7 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.Writ
 		intent.Txn = br.Responses[i].GetInner().(*roachpb.PushTxnResponse).PusheeTxn
 		resolveIntents = append(resolveIntents, intent)
 	}
-	return resolveIntents, wiErr
+	return resolveIntents, roachpb.NewError(wiErr)
 }
 
 // TODO(bdarnell): is this buffering necessary? sufficient?
@@ -1624,7 +1618,7 @@ func (s *Store) getOrCreateReplicaLocked(groupID roachpb.RangeID, replicaID roac
 		return nil, err
 	} else if ok {
 		if replicaID != 0 && replicaID < tombstone.NextReplicaID {
-			return nil, errRaftGroupDeleted
+			return nil, &roachpb.RaftGroupDeletedError{}
 		}
 	}
 
@@ -1745,8 +1739,8 @@ func (s *Store) GetStatus() (*StoreStatus, error) {
 	}
 	key := keys.StoreStatusKey(int32(s.Ident.StoreID))
 	status := &StoreStatus{}
-	if err := s.db.GetProto(key, status); err != nil {
-		return nil, err
+	if pErr := s.db.GetProto(key, status); pErr != nil {
+		return nil, pErr.GoError()
 	}
 	return status, nil
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -96,7 +96,7 @@ func (s *Store) testSender() client.Sender {
 // TODO(tschottdorf): {kv->storage}.LocalSender
 func (db *testSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 	if et, ok := ba.GetArg(roachpb.EndTransaction); ok {
-		return nil, roachpb.NewError(util.Errorf("%s method not supported", et.Method()))
+		return nil, roachpb.NewErrorf("%s method not supported", et.Method())
 	}
 	// Lookup range and direct request.
 	rs := keys.Range(ba)
@@ -107,7 +107,7 @@ func (db *testSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 	ba.RangeID = rng.RangeID
 	replica := rng.GetReplica()
 	if replica == nil {
-		return nil, roachpb.NewError(util.Errorf("own replica missing in range"))
+		return nil, roachpb.NewErrorf("own replica missing in range")
 	}
 	ba.Replica = *replica
 	br, pErr := db.store.Send(ctx, ba)
@@ -534,12 +534,12 @@ func TestStoreSend(t *testing.T) {
 	gArgs := getArgs([]byte("a"))
 
 	// Try a successful get request.
-	if _, err := client.SendWrapped(store.testSender(), nil, &gArgs); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &gArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
 	pArgs := putArgs([]byte("a"), []byte("aaa"))
-	if _, err := client.SendWrapped(store.testSender(), nil, &pArgs); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &pArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
 }
 
@@ -571,54 +571,54 @@ func TestStoreVerifyKeys(t *testing.T) {
 	defer stopper.Stop()
 	// Try a start key == KeyMax.
 	gArgs := getArgs(roachpb.KeyMax)
-	if _, err := client.SendWrapped(store.testSender(), nil, &gArgs); !testutils.IsError(err, "must be less than KeyMax") {
-		t.Fatalf("expected error for start key == KeyMax: %v", err)
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &gArgs); !testutils.IsError(pErr.GoError(), "must be less than KeyMax") {
+		t.Fatalf("expected error for start key == KeyMax: %v", pErr)
 	}
 	// Try a get with an end key specified (get requires only a start key and should fail).
 	gArgs.EndKey = roachpb.KeyMax
-	if _, err := client.SendWrapped(store.testSender(), nil, &gArgs); !testutils.IsError(err, "must be less than KeyMax") {
-		t.Fatalf("unexpected error for end key specified on a non-range-based operation: %v", err)
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &gArgs); !testutils.IsError(pErr.GoError(), "must be less than KeyMax") {
+		t.Fatalf("unexpected error for end key specified on a non-range-based operation: %v", pErr)
 	}
 	// Try a scan with end key < start key.
 	sArgs := scanArgs([]byte("b"), []byte("a"))
-	if _, err := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsError(err, "must be greater than") {
-		t.Fatalf("unexpected error for end key < start: %v", err)
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsError(pErr.GoError(), "must be greater than") {
+		t.Fatalf("unexpected error for end key < start: %v", pErr)
 	}
 	// Try a scan with start key == end key.
 	sArgs.Key = []byte("a")
 	sArgs.EndKey = sArgs.Key
-	if _, err := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsError(err, "must be greater than") {
-		t.Fatalf("unexpected error for start == end key: %v", err)
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsError(pErr.GoError(), "must be greater than") {
+		t.Fatalf("unexpected error for start == end key: %v", pErr)
 	}
 	// Try a scan with range-local start key, but "regular" end key.
 	sArgs.Key = keys.MakeRangeKey([]byte("test"), []byte("sffx"), nil)
 	sArgs.EndKey = []byte("z")
-	if _, err := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsError(err, "range-local") {
-		t.Fatalf("unexpected error for local start, non-local end key: %v", err)
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsError(pErr.GoError(), "range-local") {
+		t.Fatalf("unexpected error for local start, non-local end key: %v", pErr)
 	}
 
 	// Try a put to meta2 key which would otherwise exceed maximum key
 	// length, but is accepted because of the meta prefix.
 	meta2KeyMax := keys.MakeKey(keys.Meta2Prefix, roachpb.RKeyMax)
 	pArgs := putArgs(meta2KeyMax, []byte("value"))
-	if _, err := client.SendWrapped(store.testSender(), nil, &pArgs); err != nil {
-		t.Fatalf("unexpected error on put to meta2 value: %s", err)
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &pArgs); pErr != nil {
+		t.Fatalf("unexpected error on put to meta2 value: %s", pErr)
 	}
 	// Try to put a range descriptor record for a start key which is
 	// maximum length.
 	key := append([]byte{}, roachpb.RKeyMax...)
 	key[len(key)-1] = 0x01
 	pArgs = putArgs(keys.RangeDescriptorKey(key), []byte("value"))
-	if _, err := client.SendWrapped(store.testSender(), nil, &pArgs); err != nil {
-		t.Fatalf("unexpected error on put to range descriptor for KeyMax value: %s", err)
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &pArgs); pErr != nil {
+		t.Fatalf("unexpected error on put to range descriptor for KeyMax value: %s", pErr)
 	}
 	// Try a put to txn record for a meta2 key (note that this doesn't
 	// actually happen in practice, as txn records are not put directly,
 	// but are instead manipulated only through txn methods).
 	pArgs = putArgs(keys.TransactionKey(meta2KeyMax, []byte(uuid.NewUUID4())),
 		[]byte("value"))
-	if _, err := client.SendWrapped(store.testSender(), nil, &pArgs); err != nil {
-		t.Fatalf("unexpected error on put to txn meta2 value: %s", err)
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &pArgs); pErr != nil {
+		t.Fatalf("unexpected error on put to txn meta2 value: %s", pErr)
 	}
 }
 
@@ -630,9 +630,9 @@ func TestStoreSendUpdateTime(t *testing.T) {
 	args := getArgs([]byte("a"))
 	reqTS := store.ctx.Clock.Now()
 	reqTS.WallTime += (100 * time.Millisecond).Nanoseconds()
-	_, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Timestamp: reqTS}, &args)
-	if err != nil {
-		t.Fatal(err)
+	_, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Timestamp: reqTS}, &args)
+	if pErr != nil {
+		t.Fatal(pErr)
 	}
 	ts := store.ctx.Clock.Timestamp()
 	if ts.WallTime != reqTS.WallTime || ts.Logical <= reqTS.Logical {
@@ -650,9 +650,9 @@ func TestStoreSendWithZeroTime(t *testing.T) {
 
 	// Set clock to time 1.
 	mc.Set(1)
-	resp, err := client.SendWrapped(store.testSender(), nil, &args)
-	if err != nil {
-		t.Fatal(err)
+	resp, pErr := client.SendWrapped(store.testSender(), nil, &args)
+	if pErr != nil {
+		t.Fatal(pErr)
 	}
 	reply := resp.(*roachpb.GetResponse)
 	// The Logical time will increase over the course of the command
@@ -679,7 +679,7 @@ func TestStoreSendWithClockOffset(t *testing.T) {
 	store.ctx.Clock.SetMaxOffset(maxOffset)
 	// Set args timestamp to exceed max offset.
 	ts := store.ctx.Clock.Now().Add(maxOffset.Nanoseconds()+1, 0)
-	if _, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Timestamp: ts}, &args); err == nil {
+	if _, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Timestamp: ts}, &args); pErr == nil {
 		t.Error("expected max offset clock error")
 	}
 }
@@ -690,9 +690,9 @@ func TestStoreSendBadRange(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 	args := getArgs([]byte("0"))
-	if _, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
+	if _, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
 		RangeID: 2, // no such range
-	}, &args); err == nil {
+	}, &args); pErr == nil {
 		t.Error("expected invalid range")
 	}
 }
@@ -889,10 +889,10 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 
 		// Now, try a put using the pusher's txn.
 		h.Txn = pusher
-		_, err := client.SendWrappedWith(store.testSender(), nil, h, &pArgs)
+		_, pErr := client.SendWrappedWith(store.testSender(), nil, h, &pArgs)
 		if resolvable {
-			if err != nil {
-				t.Errorf("expected intent resolved; got unexpected error: %s", err)
+			if pErr != nil {
+				t.Errorf("expected intent resolved; got unexpected error: %s", pErr)
 			}
 			txnKey := keys.TransactionKey(pushee.Key, pushee.ID)
 			var txn roachpb.Transaction
@@ -904,14 +904,14 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 				t.Errorf("expected pushee to be aborted; got %s", txn.Status)
 			}
 		} else {
-			if rErr, ok := err.(*roachpb.TransactionPushError); !ok {
-				t.Errorf("expected txn push error; got %s", err)
+			if rErr, ok := pErr.GoError().(*roachpb.TransactionPushError); !ok {
+				t.Errorf("expected txn push error; got %s", pErr)
 			} else if !bytes.Equal(rErr.PusheeTxn.ID, pushee.ID) {
 				t.Errorf("expected txn to match pushee %q; got %s", pushee.ID, rErr)
 			}
 			// Trying again should fail again.
 			h.Txn.Sequence++
-			if _, err := client.SendWrappedWith(store.testSender(), nil, h, &pArgs); err == nil {
+			if _, pErr := client.SendWrappedWith(store.testSender(), nil, h, &pArgs); pErr == nil {
 				t.Errorf("expected another error on latent write intent but succeeded")
 			}
 		}
@@ -933,23 +933,23 @@ func TestStoreResolveWriteIntentRollback(t *testing.T) {
 
 	// Begin pushee's transaction.
 	bt, btH := beginTxnArgs(key, pushee)
-	if _, err := client.SendWrappedWith(store.testSender(), nil, btH, &bt); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrappedWith(store.testSender(), nil, btH, &bt); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// First lay down intent using the pushee's txn.
 	args := incrementArgs(key, 1)
 	h := roachpb.Header{Txn: pushee}
 	pushee.Sequence++
-	if _, err := client.SendWrappedWith(store.testSender(), nil, h, &args); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrappedWith(store.testSender(), nil, h, &args); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Now, try a put using the pusher's txn.
 	h.Txn = pusher
 	args.Increment = 2
-	if resp, err := client.SendWrappedWith(store.testSender(), nil, h, &args); err != nil {
-		t.Errorf("expected increment to succeed: %s", err)
+	if resp, pErr := client.SendWrappedWith(store.testSender(), nil, h, &args); pErr != nil {
+		t.Errorf("expected increment to succeed: %s", pErr)
 	} else if reply := resp.(*roachpb.IncrementResponse); reply.NewValue != 2 {
 		t.Errorf("expected rollback of earlier increment to yield increment value of 2; got %d", reply.NewValue)
 	}
@@ -991,22 +991,22 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 
 		// Begin pushee's transaction.
 		bt, btH := beginTxnArgs(key, pushee)
-		if _, err := client.SendWrappedWith(store.testSender(), nil, btH, &bt); err != nil {
-			t.Fatal(err)
+		if _, pErr := client.SendWrappedWith(store.testSender(), nil, btH, &bt); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		// First, write original value.
 		args := putArgs(key, []byte("value1"))
-		if _, err := client.SendWrapped(store.testSender(), nil, &args); err != nil {
-			t.Fatal(err)
+		if _, pErr := client.SendWrapped(store.testSender(), nil, &args); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		// Second, lay down intent using the pushee's txn.
 		h := roachpb.Header{Txn: pushee}
 		pushee.Sequence++
 		args.Value.SetBytes([]byte("value2"))
-		if _, err := client.SendWrappedWith(store.testSender(), nil, h, &args); err != nil {
-			t.Fatal(err)
+		if _, pErr := client.SendWrappedWith(store.testSender(), nil, h, &args); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		// Now, try to read value using the pusher's txn.
@@ -1014,10 +1014,10 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 		gArgs := getArgs(key)
 		h.Txn = pusher
 		h.Timestamp = ts
-		firstReply, err := client.SendWrappedWith(store.testSender(), nil, h, &gArgs)
+		firstReply, pErr := client.SendWrappedWith(store.testSender(), nil, h, &gArgs)
 		if test.resolvable {
-			if err != nil {
-				t.Errorf("%d: expected read to succeed: %s", i, err)
+			if pErr != nil {
+				t.Errorf("%d: expected read to succeed: %s", i, pErr)
 			} else if replyBytes, err := firstReply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 				t.Fatal(err)
 			} else if !bytes.Equal(replyBytes, []byte("value1")) {
@@ -1044,7 +1044,7 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 						expTimestamp, etReply.Txn)
 				}
 			} else {
-				if _, ok := cErr.(*roachpb.TransactionRetryError); !ok {
+				if _, ok := cErr.GoError().(*roachpb.TransactionRetryError); !ok {
 					t.Errorf("expected transaction retry error; got %s", cErr)
 				}
 			}
@@ -1053,19 +1053,19 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 			// even a non-resolvable read will succeed. Otherwise, verify we
 			// receive a transaction retry error (because we max out retries).
 			if test.pusheeIso == roachpb.SNAPSHOT {
-				if err != nil {
-					t.Errorf("expected read to succeed: %s", err)
+				if pErr != nil {
+					t.Errorf("expected read to succeed: %s", pErr)
 				} else if replyBytes, err := firstReply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 					t.Fatal(err)
 				} else if !bytes.Equal(replyBytes, []byte("value1")) {
 					t.Errorf("expected bytes to be %q, got %q", "value1", replyBytes)
 				}
 			} else {
-				if err == nil {
+				if pErr == nil {
 					t.Errorf("expected read to fail")
 				}
-				if _, ok := err.(*roachpb.TransactionRetryError); !ok {
-					t.Errorf("expected transaction retry error; got %T", err)
+				if _, ok := pErr.GoError().(*roachpb.TransactionRetryError); !ok {
+					t.Errorf("expected transaction retry error; got %T", pErr)
 				}
 			}
 		}
@@ -1087,15 +1087,15 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 
 	// Begin pushee's transaction.
 	bt, btH := beginTxnArgs(key, pushee)
-	if _, err := client.SendWrappedWith(store.testSender(), nil, btH, &bt); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrappedWith(store.testSender(), nil, btH, &bt); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// First, write original value.
 	args := putArgs(key, []byte("value1"))
 	ts := store.ctx.Clock.Now()
-	if _, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Timestamp: ts}, &args); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Timestamp: ts}, &args); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Lay down intent using the pushee's txn.
@@ -1103,8 +1103,8 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	h.Txn.Sequence++
 	h.Timestamp = store.ctx.Clock.Now()
 	args.Value.SetBytes([]byte("value2"))
-	if _, err := client.SendWrappedWith(store.testSender(), nil, h, &args); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrappedWith(store.testSender(), nil, h, &args); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Now, try to read value using the pusher's txn.
@@ -1112,8 +1112,8 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	gTS := store.ctx.Clock.Now()
 	h.Txn = pusher
 	h.Timestamp = gTS
-	if reply, err := client.SendWrappedWith(store.testSender(), nil, h, &gArgs); err != nil {
-		t.Errorf("expected read to succeed: %s", err)
+	if reply, pErr := client.SendWrappedWith(store.testSender(), nil, h, &gArgs); pErr != nil {
+		t.Errorf("expected read to succeed: %s", pErr)
 	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 		t.Fatal(err)
 	} else if !bytes.Equal(replyBytes, []byte("value1")) {
@@ -1126,9 +1126,9 @@ func TestStoreResolveWriteIntentSnapshotIsolation(t *testing.T) {
 	etArgs, h := endTxnArgs(pushee, true)
 	h.Timestamp = pushee.Timestamp
 	h.Txn.Sequence++
-	reply, err := client.SendWrappedWith(store.testSender(), nil, h, &etArgs)
-	if err != nil {
-		t.Fatal(err)
+	reply, pErr := client.SendWrappedWith(store.testSender(), nil, h, &etArgs)
+	if pErr != nil {
+		t.Fatal(pErr)
 	}
 	etReply := reply.(*roachpb.EndTransactionResponse)
 	expTimestamp := gTS
@@ -1152,26 +1152,26 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 
 	// Begin pushee's transaction.
 	bt, btH := beginTxnArgs(key, pushee)
-	if _, err := client.SendWrappedWith(store.testSender(), nil, btH, &bt); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrappedWith(store.testSender(), nil, btH, &bt); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// First, lay down intent from pushee.
 	pushee.Sequence++
 	args := putArgs(key, []byte("value1"))
-	if _, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Txn: pushee}, &args); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Txn: pushee}, &args); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Now, try to read outside a transaction.
 	getTS := store.ctx.Clock.Now() // accessed later
 	{
 		gArgs := getArgs(key)
-		if reply, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
+		if reply, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
 			Timestamp:    getTS,
 			UserPriority: -math.MaxInt32,
-		}, &gArgs); err != nil {
-			t.Errorf("expected read to succeed: %s", err)
+		}, &gArgs); pErr != nil {
+			t.Errorf("expected read to succeed: %s", pErr)
 		} else if gReply := reply.(*roachpb.GetResponse); gReply.Value != nil {
 			t.Errorf("expected value to be nil, got %+v", gReply.Value)
 		}
@@ -1181,11 +1181,11 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 		// Next, try to write outside of a transaction. We will succeed in pushing txn.
 		putTS := store.ctx.Clock.Now()
 		args.Value.SetBytes([]byte("value2"))
-		if _, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
+		if _, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
 			Timestamp:    putTS,
 			UserPriority: -math.MaxInt32,
-		}, &args); err != nil {
-			t.Errorf("expected success aborting pushee's txn; got %s", err)
+		}, &args); pErr != nil {
+			t.Errorf("expected success aborting pushee's txn; got %s", pErr)
 		}
 	}
 
@@ -1216,12 +1216,12 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	// been aborted.
 	etArgs, h := endTxnArgs(pushee, true)
 	pushee.Sequence++
-	_, err := client.SendWrappedWith(store.testSender(), nil, h, &etArgs)
-	if err == nil {
+	_, pErr := client.SendWrappedWith(store.testSender(), nil, h, &etArgs)
+	if pErr == nil {
 		t.Errorf("unexpected success committing transaction")
 	}
-	if _, ok := err.(*roachpb.TransactionAbortedError); !ok {
-		t.Errorf("expected transaction aborted error; got %s", err)
+	if _, ok := pErr.GoError().(*roachpb.TransactionAbortedError); !ok {
+		t.Errorf("expected transaction aborted error; got %s", pErr)
 	}
 }
 
@@ -1252,8 +1252,8 @@ func TestStoreReadInconsistent(t *testing.T) {
 
 		// First, write keyA.
 		args := putArgs(keyA, []byte("value1"))
-		if _, err := client.SendWrapped(store.testSender(), nil, &args); err != nil {
-			t.Fatal(err)
+		if _, pErr := client.SendWrapped(store.testSender(), nil, &args); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		// Next, write intents for keyA and keyB. Note that the
@@ -1268,30 +1268,30 @@ func TestStoreReadInconsistent(t *testing.T) {
 		txnB := newTransaction("testB", keyB, priority, roachpb.SERIALIZABLE, store.ctx.Clock)
 		for _, txn := range []*roachpb.Transaction{txnA, txnB} {
 			bt, btH := beginTxnArgs(txn.Key, txn)
-			if _, err := client.SendWrappedWith(store.testSender(), nil, btH, &bt); err != nil {
-				t.Fatal(err)
+			if _, pErr := client.SendWrappedWith(store.testSender(), nil, btH, &bt); pErr != nil {
+				t.Fatal(pErr)
 			}
 			args.Key = txn.Key
 			txn.Sequence++
-			if _, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Txn: txn}, &args); err != nil {
-				t.Fatal(err)
+			if _, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Txn: txn}, &args); pErr != nil {
+				t.Fatal(pErr)
 			}
 		}
 		// End txn B, but without resolving the intent.
 		etArgs, h := endTxnArgs(txnB, true)
 		txnB.Sequence++
-		if _, err := client.SendWrappedWith(store.testSender(), nil, h, &etArgs); err != nil {
-			t.Fatal(err)
+		if _, pErr := client.SendWrappedWith(store.testSender(), nil, h, &etArgs); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		// Now, get from both keys and verify. Whether we can push or not, we
 		// will be able to read with INCONSISTENT.
 		gArgs := getArgs(keyA)
 
-		if reply, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
+		if reply, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
 			ReadConsistency: roachpb.INCONSISTENT,
-		}, &gArgs); err != nil {
-			t.Errorf("expected read to succeed: %s", err)
+		}, &gArgs); pErr != nil {
+			t.Errorf("expected read to succeed: %s", pErr)
 		} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 			t.Fatal(err)
 		} else if !bytes.Equal(replyBytes, []byte("value1")) {
@@ -1299,10 +1299,10 @@ func TestStoreReadInconsistent(t *testing.T) {
 		}
 		gArgs.Key = keyB
 
-		if reply, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
+		if reply, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
 			ReadConsistency: roachpb.INCONSISTENT,
-		}, &gArgs); err != nil {
-			t.Errorf("expected read to succeed: %s", err)
+		}, &gArgs); pErr != nil {
+			t.Errorf("expected read to succeed: %s", pErr)
 		} else if gReply := reply.(*roachpb.GetResponse); gReply.Value != nil {
 			// The new value of B will not be read at first.
 			t.Errorf("expected value nil, got %+v", gReply.Value)
@@ -1310,10 +1310,10 @@ func TestStoreReadInconsistent(t *testing.T) {
 		// However, it will be read eventually, as B's intent can be
 		// resolved asynchronously as txn B is committed.
 		util.SucceedsWithin(t, 500*time.Millisecond, func() error {
-			if reply, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
+			if reply, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
 				ReadConsistency: roachpb.INCONSISTENT,
-			}, &gArgs); err != nil {
-				return util.Errorf("expected read to succeed: %s", err)
+			}, &gArgs); pErr != nil {
+				return util.Errorf("expected read to succeed: %s", pErr)
 			} else if gReply := reply.(*roachpb.GetResponse).Value; gReply == nil {
 				return util.Errorf("value is nil")
 			} else if replyBytes, err := gReply.GetBytes(); err != nil {
@@ -1326,11 +1326,11 @@ func TestStoreReadInconsistent(t *testing.T) {
 
 		// Scan keys and verify results.
 		sArgs := scanArgs(keyA, keyB.Next())
-		reply, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
+		reply, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
 			ReadConsistency: roachpb.INCONSISTENT,
 		}, &sArgs)
-		if err != nil {
-			t.Errorf("expected scan to succeed: %s", err)
+		if pErr != nil {
+			t.Errorf("expected scan to succeed: %s", pErr)
 		}
 		sReply := reply.(*roachpb.ScanResponse)
 		if l := len(sReply.Rows); l != 2 {
@@ -1403,14 +1403,14 @@ func TestStoreScanIntents(t *testing.T) {
 				}
 				txn = newTransaction(fmt.Sprintf("test-%d", i), key, priority, roachpb.SERIALIZABLE, store.ctx.Clock)
 				bt, btH := beginTxnArgs(txn.Key, txn)
-				if _, err := client.SendWrappedWith(store.testSender(), nil, btH, &bt); err != nil {
-					t.Fatal(err)
+				if _, pErr := client.SendWrappedWith(store.testSender(), nil, btH, &bt); pErr != nil {
+					t.Fatal(pErr)
 				}
 			}
 			args := putArgs(key, []byte(fmt.Sprintf("value%02d", j)))
 			txn.Sequence++
-			if _, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Txn: txn}, &args); err != nil {
-				t.Fatal(err)
+			if _, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Txn: txn}, &args); pErr != nil {
+				t.Fatal(pErr)
 			}
 		}
 
@@ -1425,11 +1425,11 @@ func TestStoreScanIntents(t *testing.T) {
 		}
 		done := make(chan struct{})
 		go func() {
-			if reply, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
+			if reply, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
 				Timestamp:       ts,
 				ReadConsistency: consistency,
-			}, &sArgs); err != nil {
-				t.Fatal(err)
+			}, &sArgs); pErr != nil {
+				t.Fatal(pErr)
 			} else {
 				sReply = reply.(*roachpb.ScanResponse)
 			}
@@ -1458,8 +1458,8 @@ func TestStoreScanIntents(t *testing.T) {
 				for _, key := range keys {
 					etArgs.IntentSpans = append(etArgs.IntentSpans, roachpb.Span{Key: key})
 				}
-				if _, err := client.SendWrappedWith(store.testSender(), nil, h, &etArgs); err != nil {
-					t.Fatal(err)
+				if _, pErr := client.SendWrappedWith(store.testSender(), nil, h, &etArgs); pErr != nil {
+					t.Fatal(pErr)
 				}
 				<-done
 			}
@@ -1492,8 +1492,8 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	// Lay down 10 intents to scan over.
 	txn := newTransaction("test", roachpb.Key("foo"), 1, roachpb.SERIALIZABLE, store.ctx.Clock)
 	bt, btH := beginTxnArgs(txn.Key, txn)
-	if _, err := client.SendWrappedWith(store.testSender(), nil, btH, &bt); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrappedWith(store.testSender(), nil, btH, &bt); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	keys := []roachpb.Key{}
@@ -1502,8 +1502,8 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 		keys = append(keys, key)
 		args := putArgs(key, []byte(fmt.Sprintf("value%02d", j)))
 		txn.Sequence++
-		if _, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Txn: txn}, &args); err != nil {
-			t.Fatal(err)
+		if _, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{Txn: txn}, &args); pErr != nil {
+			t.Fatal(pErr)
 		}
 	}
 
@@ -1512,8 +1512,8 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	// attempts to resolve the intents would fail.
 	etArgs, h := endTxnArgs(txn, true)
 	txn.Sequence++
-	if _, err := client.SendWrappedWith(store.testSender(), nil, h, &etArgs); err != nil {
-		t.Fatal(err)
+	if _, pErr := client.SendWrappedWith(store.testSender(), nil, h, &etArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	intercept.Store(false) // allow async intent resolution
@@ -1521,10 +1521,10 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	// Scan the range repeatedly until we've verified count.
 	sArgs := scanArgs(keys[0], keys[9].Next())
 	util.SucceedsWithin(t, time.Second, func() error {
-		if reply, err := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
+		if reply, pErr := client.SendWrappedWith(store.testSender(), nil, roachpb.Header{
 			ReadConsistency: roachpb.INCONSISTENT,
-		}, &sArgs); err != nil {
-			return err
+		}, &sArgs); pErr != nil {
+			return pErr.GoError()
 		} else if sReply := reply.(*roachpb.ScanResponse); len(sReply.Rows) != 10 {
 			return util.Errorf("could not read rows as expected")
 		}
@@ -1596,8 +1596,8 @@ func TestStoreBadRequests(t *testing.T) {
 		if test.header.Txn != nil {
 			test.header.Txn.Sequence++
 		}
-		if _, err := client.SendWrappedWith(store.testSender(), nil, *test.header, test.args); err == nil || test.err == "" || !testutils.IsError(err, test.err) {
-			t.Errorf("%d unexpected result: %s", i, err)
+		if _, pErr := client.SendWrappedWith(store.testSender(), nil, *test.header, test.args); pErr == nil || test.err == "" || !testutils.IsError(pErr.GoError(), test.err) {
+			t.Errorf("%d unexpected result: %s", i, pErr)
 		}
 	}
 }

--- a/storage/stores_test.go
+++ b/storage/stores_test.go
@@ -105,20 +105,20 @@ func TestStoresGetStore(t *testing.T) {
 	ls := NewStores(hlc.NewClock(hlc.UnixNano))
 	store := Store{}
 	replica := roachpb.ReplicaDescriptor{StoreID: store.Ident.StoreID}
-	s, err := ls.GetStore(replica.StoreID)
-	if s != nil || err == nil {
+	s, pErr := ls.GetStore(replica.StoreID)
+	if s != nil || pErr == nil {
 		t.Errorf("expected no stores in new local sender")
 	}
 
 	ls.AddStore(&store)
-	s, err = ls.GetStore(replica.StoreID)
+	s, pErr = ls.GetStore(replica.StoreID)
 	if s == nil {
 		t.Errorf("expected store")
 	} else if s.Ident.StoreID != store.Ident.StoreID {
 		t.Errorf("expected storeID to be %d but was %d",
 			s.Ident.StoreID, store.Ident.StoreID)
-	} else if err != nil {
-		t.Errorf("expected no error, instead had err=%s", err.Error())
+	} else if pErr != nil {
+		t.Errorf("expected no error, instead had err=%s", pErr.GoError().Error())
 	}
 }
 

--- a/ts/db.go
+++ b/ts/db.go
@@ -133,5 +133,5 @@ func (db *DB) StoreData(r Resolution, data []TimeSeriesData) error {
 		})
 	}
 
-	return db.db.Run(&b)
+	return db.db.Run(&b).GoError()
 }

--- a/ts/query.go
+++ b/ts/query.go
@@ -407,10 +407,10 @@ func (db *DB) Query(query TimeSeriesQueryRequest_Query, r Resolution,
 		// query.
 		startKey := MakeDataKey(query.Name, "" /* source */, r, startNanos)
 		endKey := MakeDataKey(query.Name, "" /* source */, r, endNanos).PrefixEnd()
-		var err error
-		rows, err = db.db.Scan(startKey, endKey, 0)
-		if err != nil {
-			return nil, nil, err
+		var pErr *roachpb.Error
+		rows, pErr = db.db.Scan(startKey, endKey, 0)
+		if pErr != nil {
+			return nil, nil, pErr.GoError()
 		}
 	} else {
 		b := db.db.NewBatch()
@@ -422,9 +422,9 @@ func (db *DB) Query(query TimeSeriesQueryRequest_Query, r Resolution,
 				b.Get(key)
 			}
 		}
-		err := db.db.Run(b)
-		if err != nil {
-			return nil, nil, err
+		pErr := db.db.Run(b)
+		if pErr != nil {
+			return nil, nil, pErr.GoError()
 		}
 		for _, result := range b.Results {
 			row := result.Rows[0]


### PR DESCRIPTION
This is the first step for #2809 and #3303. There are several cleanup I still have to make, but I wanted to make sure the overall direction is good.

This commit contains the following changes:
- Add txn and index to Error. Use them whenever possible (e.g., `txnSender.Send`).
- Remove `index` from `WriteIntentError` and `ConditionFailedError`.
- Change `Replica.executeCommand` to return `roachpb.Error`. Change transitively affected code to use `roachpb.Error` and avoid calling `GoError()` as much as possible.

Note that `roachpb.Error` has _NOT_ yet implemented the `Error` interface. This is necessary (at least during transition) to avoid mixing `roachpb.Error` and other Go errors.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3661)

<!-- Reviewable:end -->
