### PR TITLE
relax TestRaftLogQueue

### DIFF
--- a/storage/client_raft_log_queue_test.go
+++ b/storage/client_raft_log_queue_test.go
@@ -102,8 +102,8 @@ func TestRaftLogQueue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if afterTruncationIndex != after2ndTruncationIndex {
-		t.Fatalf("raft log was truncated again and it shouldn't have been, afterTruncationIndex:%d after2ndTruncationIndex:%d",
+	if afterTruncationIndex > after2ndTruncationIndex {
+		t.Fatalf("second truncation destroyed state: afterTruncationIndex:%d after2ndTruncationIndex:%d",
 			afterTruncationIndex, after2ndTruncationIndex)
 	}
 }


### PR DESCRIPTION
it previously tested that truncating again did not
change anything, but I do not see a reason for why
not (esp. in the face of Raft replays, which are probably
still happening despite the attempts at the beginning
of the test).
@BramGruneir, am I missing something?

Fixes #3666.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3673)

<!-- Reviewable:end -->
