### PR TITLE
Dynamic port binding for PGAddr in test context

### DIFF
--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -62,7 +62,7 @@ func getTLSConfig() *tls.Config {
 	}
 }
 
-// newDockerClient constructs a new docker client using the best available
+// NewDockerClient constructs a new docker client using the best available
 // method. If DOCKER_HOST is set, initialize the client using DOCKER_TLS_VERIFY
 // and DOCKER_CERT_PATH. If DOCKER_HOST is not set, look for the unix domain
 // socket in /run/docker.sock and /var/run/docker.sock.

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -82,6 +82,7 @@ func NewTestContext() *Context {
 	// Start() to an available port.
 	// Call TestServer.ServingAddr() for the full address (including bound port).
 	ctx.Addr = "127.0.0.1:0"
+	ctx.PGAddr = "127.0.0.1:0"
 	// Set standard "node" user for intra-cluster traffic.
 	ctx.User = security.NodeUser
 


### PR DESCRIPTION
Happening because PG now binds to 15432.

See https://circleci.com/gh/cockroachdb/cockroach/10758

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3679)

<!-- Reviewable:end -->
