### PR TITLE
sql: typecheck GROUP BY expressions early

### DIFF
--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -39,6 +39,9 @@ SELECT 3 FROM kv HAVING TRUE;
 query error column "k" must appear in the GROUP BY clause or be used in an aggregate function
 SELECT COUNT(*), k FROM kv
 
+query error unsupported comparison operator: <string> < <int>
+SELECT COUNT(*) FROM kv GROUP BY s < 5
+
 query II rowsort
 SELECT COUNT(*), k FROM kv GROUP BY k
 ----


### PR DESCRIPTION
not strictly needed, since they will be checked when they are added to `s.render`, but checking early allows early rejection of bad queries.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3681)

<!-- Reviewable:end -->
