### PR TITLE
Execute BatchRequest RPCs within stopper tasks.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -156,7 +156,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	}
 	s.stopper.AddCloser(s.raftTransport)
 
-	s.kvDB = kv.NewDBServer(&s.ctx.Context, sender)
+	s.kvDB = kv.NewDBServer(&s.ctx.Context, sender, stopper)
 	if err := s.kvDB.RegisterRPC(s.rpc); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes rare test failures where an RPC arrives after the stopper has
been stopped and tries to utilize resources (e.g. the rocksdb engine)
that have been closed.

Fixes #3639.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3683)

<!-- Reviewable:end -->
