### PR TITLE
Log Splits to Range Event Table

### DIFF
--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -323,10 +323,9 @@ func TestSingleRangeReverseScan(t *testing.T) {
 	} else if l := len(rows); l != 2 {
 		t.Errorf("expected 2 rows; got %d", l)
 	}
-	// Case 3: Test roachpb.KeyMax
-	// This span covers the system DB keys.
-	wanted := 1 + len(server.GetBootstrapSchema().GetInitialValues())
-	if rows, pErr := db.ReverseScan("g", roachpb.KeyMax, 0); pErr != nil {
+	// Case 3: Test roachpb.TableDataMin. Expected to return "g" and "h".
+	wanted := 2
+	if rows, pErr := db.ReverseScan("g", keys.TableDataMin, 0); pErr != nil {
 		t.Fatalf("unexpected error on ReverseScan: %s", pErr)
 	} else if l := len(rows); l != wanted {
 		t.Errorf("expected %d rows; got %d", wanted, l)

--- a/security/securitytest/securitytest.go
+++ b/security/securitytest/securitytest.go
@@ -17,6 +17,25 @@
 // Package securitytest embeds the TLS test certificates.
 package securitytest
 
+import "github.com/cockroachdb/cockroach/util"
+
 //go:generate go-bindata -pkg securitytest -mode 0644 -modtime 1400000000 -o ./embedded.go -ignore README.md -prefix ../../resource ../../resource/test_certs/...
 //go:generate gofmt -s -w embedded.go
 //go:generate goimports -w embedded.go
+
+// TempRestrictedCopy creates a temporary on-disk copy of the embedded security asset
+// with the provided path. The copy will be created as a temporary file in the
+// provided directory; its filename will have the provided prefix. Returns the
+// path of the temporary file and a cleanup function that will delete the
+// temporary file.
+//
+// The temporary file will have restrictive file permissions (0600), making it
+// appropriate for usage by libraries that require security assets to have such
+// restrictive permissions.
+func TempRestrictedCopy(t util.Tester, path, tempdir, prefix string) (string, func()) {
+	contents, err := Asset(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return util.CreateTempRestrictedFile(t, contents, tempdir, prefix)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -189,6 +189,10 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		EventFeed:       feed,
 		Tracer:          tracer,
 		StorePool:       s.storePool,
+		SQLExecutor: sql.InternalExecutor{
+			LeaseManager: s.leaseMgr,
+		},
+		LogRangeEvents: true,
 		AllocatorOptions: storage.AllocatorOptions{
 			AllowRebalance: true,
 			Mode:           s.ctx.BalanceMode,

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -230,12 +230,19 @@ func ExpectedInitialRangeCount() int {
 	return GetBootstrapSchema().DescriptorCount() - sql.NumSystemDescriptors + 1
 }
 
+// OpenDBClient opens a KVDB Client connecting to the server with the supplied
+// user.
+func (ts *TestServer) OpenDBClient(user string) (*client.DB, error) {
+	connString := fmt.Sprintf("%s://%s@%s?certs=%s",
+		ts.Ctx.RPCRequestScheme(), user, ts.ServingAddr(), ts.Ctx.Certs)
+	return client.Open(ts.Stopper(), connString)
+}
+
 // WaitForInitialSplits waits for the server to complete its expected initial
 // splits at startup. If the expected range count is not reached within a
 // configured timeout, an error is returned.
 func (ts *TestServer) WaitForInitialSplits() error {
-	kvDB, err := client.Open(ts.Stopper(), fmt.Sprintf("%s://%s@%s?certs=%s",
-		ts.Ctx.RPCRequestScheme(), security.NodeUser, ts.ServingAddr(), ts.Ctx.Certs))
+	kvDB, err := ts.OpenDBClient(security.NodeUser)
 	if err != nil {
 		return err
 	}

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -35,7 +35,7 @@ func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *sql.DB)) {
 	s := server.StartTestServer(b)
 	defer s.Stop()
 
-	pgUrl, cleanupFn := sqlutils.PGUrl(s, b, security.RootUser, os.TempDir(), "benchmarkCockroach")
+	pgUrl, cleanupFn := sqlutils.PGUrl(b, s, security.RootUser, os.TempDir(), "benchmarkCockroach")
 	defer cleanupFn()
 
 	db, err := sql.Open("postgres", pgUrl.String())

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -28,13 +28,14 @@ import (
 
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 )
 
 func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *sql.DB)) {
 	s := server.StartTestServer(b)
 	defer s.Stop()
 
-	pgUrl, cleanupFn := pgURL(b, s, security.RootUser, os.TempDir(), "benchmarkCockroach")
+	pgUrl, cleanupFn := sqlutils.PGUrl(s, b, security.RootUser, os.TempDir(), "benchmarkCockroach")
 	defer cleanupFn()
 
 	db, err := sql.Open("postgres", pgUrl.String())

--- a/sql/internal.go
+++ b/sql/internal.go
@@ -1,0 +1,38 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package sql
+
+import (
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/security"
+)
+
+// InternalExecutor can be used internally by cockroach to execute SQL
+// statements without needing to open a SQL connection. InternalExecutor assumes
+// that the caller has access to a cockroach KV client to handle connection and
+// transaction management.
+type InternalExecutor struct {
+	LeaseManager *LeaseManager
+}
+
+// ExecuteStatementInTransaction executes the supplied SQL statement as part of
+// the supplied transaction. Statements are currently executed as the root user.
+func (ie InternalExecutor) ExecuteStatementInTransaction(txn *client.Txn, statement string, params ...interface{}) (int, *roachpb.Error) {
+	p := planner{txn: txn, user: security.RootUser, leaseMgr: ie.LeaseManager}
+	return p.exec(statement, params...)
+}

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -203,7 +203,7 @@ func (t *logicTest) setUser(tempDir, user string) {
 
 	// The entire tempDir will be deleted later, so the cleanup function can be
 	// ignored.
-	pgUrl, _ := sqlutils.PGUrl(t.srv, t.T, user, tempDir, "TestLogic")
+	pgUrl, _ := sqlutils.PGUrl(t.T, t.srv, user, tempDir, "TestLogic")
 	db, err := sql.Open("postgres", pgUrl.String())
 	if err != nil {
 		t.Fatal(err)

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/server"
 	csql "github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -200,7 +201,9 @@ func (t *logicTest) setUser(tempDir, user string) {
 		return
 	}
 
-	pgUrl, _ := pgURL(t.T, t.srv, user, tempDir, "TestLogic")
+	// The entire tempDir will be deleted later, so the cleanup function can be
+	// ignored.
+	pgUrl, _ := sqlutils.PGUrl(t.srv, t.T, user, tempDir, "TestLogic")
 	db, err := sql.Open("postgres", pgUrl.String())
 	if err != nil {
 		t.Fatal(err)

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -20,11 +20,6 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
-	"net"
-	"net/url"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -124,66 +119,4 @@ func cleanupTestServer(s *server.TestServer) {
 func cleanup(s *server.TestServer, db *sql.DB) {
 	_ = db.Close()
 	cleanupTestServer(s)
-}
-
-func tempRestrictedCopy(tb testing.TB, tempdir, path, prefix string) (string, func()) {
-	contents, err := securitytest.Asset(path)
-	if err != nil {
-		tb.Fatal(err)
-	}
-
-	tempFile, err := ioutil.TempFile(tempdir, prefix)
-	if err != nil {
-		tb.Fatal(err)
-	}
-	if err := tempFile.Close(); err != nil {
-		tb.Fatal(err)
-	}
-	tempPath := tempFile.Name()
-	if err := os.Remove(tempPath); err != nil {
-		tb.Fatal(err)
-	}
-	// `github.com/lib/pq` requires that private key file permissions are
-	// "u=rw (0600) or less".
-	if err := ioutil.WriteFile(tempPath, contents, 0600); err != nil {
-		tb.Fatal(err)
-	}
-	return tempPath, func() {
-		if err := os.Remove(tempPath); err != nil {
-			// Not Fatal() because we might already be panicking.
-			tb.Error(err)
-		}
-	}
-}
-
-func pgURL(tb testing.TB, s *server.TestServer, user, tempDir, prefix string) (url.URL, func()) {
-	host, port, err := net.SplitHostPort(s.PGAddr())
-	if err != nil {
-		tb.Fatal(err)
-	}
-
-	caPath := filepath.Join(security.EmbeddedCertsDir, "ca.crt")
-	certPath := security.ClientCertPath(security.EmbeddedCertsDir, user)
-	keyPath := security.ClientKeyPath(security.EmbeddedCertsDir, user)
-
-	// Copy these assets to disk from embedded strings, so this test can
-	// run from a standalone binary.
-	tempCAPath, tempCACleanup := tempRestrictedCopy(tb, tempDir, caPath, "TestLogic_ca")
-	tempCertPath, tempCertCleanup := tempRestrictedCopy(tb, tempDir, certPath, "TestLogic_cert")
-	tempKeyPath, tempKeyCleanup := tempRestrictedCopy(tb, tempDir, keyPath, "TestLogic_key")
-
-	return url.URL{
-			Scheme: "postgres",
-			User:   url.User(user),
-			Host:   net.JoinHostPort(host, port),
-			RawQuery: fmt.Sprintf("sslmode=verify-full&sslrootcert=%s&sslcert=%s&sslkey=%s",
-				url.QueryEscape(tempCAPath),
-				url.QueryEscape(tempCertPath),
-				url.QueryEscape(tempKeyPath),
-			),
-		}, func() {
-			tempCACleanup()
-			tempCertCleanup()
-			tempKeyCleanup()
-		}
 }

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -236,7 +236,7 @@ func TestPGPrepared(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgUrl, cleanupFn := sqlutils.PGUrl(s, t, security.RootUser, os.TempDir(), "TestPGPrepared")
+	pgUrl, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, os.TempDir(), "TestPGPrepared")
 	defer cleanupFn()
 
 	db, err := sql.Open("postgres", pgUrl.String())

--- a/storage/log.go
+++ b/storage/log.go
@@ -18,24 +18,95 @@
 package storage
 
 import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 )
 
-// TODO(mrtracy) rangeEventTableSchema defines the schema for the range event
-// schema.  Currently there is no useful information in this table; this is a
-// work in progress.
+// RangeEventLogType describes a specific event type recorded in the range log
+// table.
+type RangeEventLogType string
+
+const (
+	// RangeEventLogSplit is the event type recorded when a range splits.
+	RangeEventLogSplit RangeEventLogType = "split"
+)
+
+// rangeEventTableSchema defines the schema of the event log table. It is
+// currently envisioned as a wide table; many different event types can be
+// recorded to the table.
 const rangeEventTableSchema = `
 CREATE TABLE system.rangelog (
   timestamp     TIMESTAMP  NOT NULL,
   rangeID       INT        NOT NULL,
+  eventType     STRING     NOT NULL,
+  storeID       INT        NOT NULL,
+  otherRangeID  INT,
   PRIMARY KEY (timestamp, rangeID)
 );`
+
+type rangeLogEvent struct {
+	timestamp    time.Time
+	rangeID      roachpb.RangeID
+	eventType    RangeEventLogType
+	storeID      roachpb.StoreID
+	otherRangeID *roachpb.RangeID
+	info         string
+}
+
+func (s *Store) insertRangeLogEvent(txn *client.Txn, event rangeLogEvent) *roachpb.Error {
+	const insertEventTableStmt = `
+INSERT INTO system.rangelog (
+  timestamp, rangeID, eventType, storeID, otherRangeID
+)
+VALUES(
+  $1, $2, $3, $4, $5
+)
+`
+	args := []interface{}{
+		event.timestamp,
+		event.rangeID,
+		event.eventType,
+		event.storeID,
+		nil, //otherRangeID
+	}
+	if event.otherRangeID != nil {
+		args[4] = *event.otherRangeID
+	}
+
+	rows, err := s.ctx.SQLExecutor.ExecuteStatementInTransaction(txn, insertEventTableStmt, args...)
+	if err != nil {
+		return err
+	}
+	if rows != 1 {
+		return roachpb.NewErrorf("%d rows affected by log insertion; expected exactly one row affected.", rows)
+	}
+	return nil
+}
 
 // AddEventLogToMetadataSchema adds the range event log table to the supplied
 // MetadataSchema.
 func AddEventLogToMetadataSchema(schema *sql.MetadataSchema) {
 	allPrivileges := sql.NewPrivilegeDescriptor(security.RootUser, privilege.List{privilege.ALL})
 	schema.AddTable(rangeEventTableSchema, allPrivileges)
+}
+
+// logSplit logs a range split event into the event table. The affected range is
+// the range which previously existed and is being split in half; the "other"
+// range is the new range which is being created.
+func (s *Store) logSplit(txn *client.Txn, updated, new roachpb.RangeDescriptor) *roachpb.Error {
+	if !s.ctx.LogRangeEvents {
+		return nil
+	}
+	return s.insertRangeLogEvent(txn, rangeLogEvent{
+		timestamp:    txn.Proto.Timestamp.GoTime(),
+		rangeID:      updated.RangeID,
+		eventType:    RangeEventLogSplit,
+		storeID:      s.StoreID(),
+		otherRangeID: &new.RangeID,
+	})
 }

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -1,0 +1,103 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package storage_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	_ "github.com/lib/pq"
+
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func TestLogSplits(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s := server.StartTestServer(t)
+	defer s.Stop()
+
+	pgUrl, cleanupFn := sqlutils.PGUrl(s, t, security.RootUser, os.TempDir(), "TestLogSplits")
+	defer cleanupFn()
+
+	db, err := sql.Open("postgres", pgUrl.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	countSplits := func() int {
+		var count int
+		// TODO(mrtracy): this should be a parameterized query, but due to #3660
+		// it does not work. This should be changed when #3660 is fixed.
+		err := db.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM system.rangelog WHERE eventType = '%s'`, string(storage.RangeEventLogSplit))).Scan(&count)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return count
+	}
+
+	// Count the number of split events.
+	initialSplits := server.ExpectedInitialRangeCount() - 1
+	if a, e := countSplits(), initialSplits; a != e {
+		t.Fatalf("expected %d initial splits, found %d", e, a)
+	}
+
+	// Generate an explicit split event.
+	kvDB, err := s.OpenDBClient(security.NodeUser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := kvDB.AdminSplit("splitkey"); err != nil {
+		t.Fatal(err)
+	}
+
+	// verify that every the count has increased by one.
+	if a, e := countSplits(), initialSplits+1; a != e {
+		t.Fatalf("expected %d splits, found %d", e, a)
+	}
+
+	// verify that RangeID always increases (a good way to see that the splits
+	// are logged correctly)
+	// TODO(mrtracy): Change to parameterized query when #3660 is fixed.
+	rows, err := db.Query(fmt.Sprintf(`SELECT rangeID, otherRangeID FROM system.rangelog WHERE eventType = '%s'`, string(storage.RangeEventLogSplit)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for rows.Next() {
+		var rangeID int64
+		var otherRangeID sql.NullInt64
+		if err := rows.Scan(&rangeID, &otherRangeID); err != nil {
+			t.Fatal(err)
+		}
+
+		if !otherRangeID.Valid {
+			t.Fatalf("otherRangeID not recorded for split of range %d", rangeID)
+		}
+		if otherRangeID.Int64 <= rangeID {
+			t.Fatalf("otherRangeID %d is not greater than rangeID %d", otherRangeID.Int64, rangeID)
+		}
+	}
+	if rows.Err() != nil {
+		t.Fatal(rows.Err())
+	}
+}

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -36,7 +36,7 @@ func TestLogSplits(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgUrl, cleanupFn := sqlutils.PGUrl(s, t, security.RootUser, os.TempDir(), "TestLogSplits")
+	pgUrl, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, os.TempDir(), "TestLogSplits")
 	defer cleanupFn()
 
 	db, err := sql.Open("postgres", pgUrl.String())

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1314,6 +1314,10 @@ func (r *Replica) AdminSplit(args roachpb.AdminSplitRequest, desc *roachpb.Range
 		if err := InsertRange(txn, b, newDesc.StartKey); err != nil {
 			return roachpb.NewError(err)
 		}
+		// Log the split into the range event log.
+		if err := r.store.logSplit(txn, updatedDesc, *newDesc); err != nil {
+			return err
+		}
 		// End the transaction manually, instead of letting RunTransaction
 		// loop do it, in order to provide a split trigger.
 		b.InternalAddRequest(&roachpb.EndTransactionRequest{

--- a/storage/store.go
+++ b/storage/store.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/cache"
@@ -297,6 +298,10 @@ type StoreContext struct {
 	StorePool *StorePool
 	Transport RaftTransport
 
+	// SQLExecutor is used by the store to execute SQL statements in a way that
+	// is more direct than using a sql.Executor.
+	SQLExecutor sql.InternalExecutor
+
 	// RangeRetryOptions are the retry options when retryable errors are
 	// encountered sending commands to ranges.
 	RangeRetryOptions retry.Options
@@ -335,6 +340,10 @@ type StoreContext struct {
 
 	// Tracer is a request tracer.
 	Tracer *tracer.Tracer
+
+	// If LogRangeEvents is true, major changes to ranges will be logged into
+	// the range event log.
+	LogRangeEvents bool
 }
 
 // Valid returns true if the StoreContext is populated correctly.

--- a/testutils/sqlutils/conn.go
+++ b/testutils/sqlutils/conn.go
@@ -37,7 +37,7 @@ import (
 // certificates will be created as temporary files in the provided directory,
 // and their filenames will have the provided prefix. The returned cleanup
 // function will delete these temporary files.
-func PGUrl(ts *server.TestServer, t util.Tester, user, tempDir, prefix string) (url.URL, func()) {
+func PGUrl(t util.Tester, ts *server.TestServer, user, tempDir, prefix string) (url.URL, func()) {
 	host, port, err := net.SplitHostPort(ts.PGAddr())
 	if err != nil {
 		t.Fatal(err)

--- a/testutils/sqlutils/conn.go
+++ b/testutils/sqlutils/conn.go
@@ -1,0 +1,70 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package sqlutils
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"path/filepath"
+
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/security/securitytest"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/util"
+)
+
+// PGUrl returns a postgres connection url which connects to this server with
+// the given user. Returns a connection string and a cleanup function which must
+// be called after any connection created using the string has been closed.
+//
+// In order to connect securely using postgres, this method will create
+// temporary on-disk copies of certain embedded security certificates. The
+// certificates will be created as temporary files in the provided directory,
+// and their filenames will have the provided prefix. The returned cleanup
+// function will delete these temporary files.
+func PGUrl(ts *server.TestServer, t util.Tester, user, tempDir, prefix string) (url.URL, func()) {
+	host, port, err := net.SplitHostPort(ts.PGAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caPath := filepath.Join(security.EmbeddedCertsDir, "ca.crt")
+	certPath := security.ClientCertPath(security.EmbeddedCertsDir, user)
+	keyPath := security.ClientKeyPath(security.EmbeddedCertsDir, user)
+
+	// Copy these assets to disk from embedded strings, so this test can
+	// run from a standalone binary.
+	tempCAPath, tempCACleanup := securitytest.TempRestrictedCopy(t, caPath, tempDir, "TestLogic_ca")
+	tempCertPath, tempCertCleanup := securitytest.TempRestrictedCopy(t, certPath, tempDir, "TestLogic_cert")
+	tempKeyPath, tempKeyCleanup := securitytest.TempRestrictedCopy(t, keyPath, tempDir, "TestLogic_key")
+
+	return url.URL{
+			Scheme: "postgres",
+			User:   url.User(user),
+			Host:   net.JoinHostPort(host, port),
+			RawQuery: fmt.Sprintf("sslmode=verify-full&sslrootcert=%s&sslcert=%s&sslkey=%s",
+				url.QueryEscape(tempCAPath),
+				url.QueryEscape(tempCertPath),
+				url.QueryEscape(tempKeyPath),
+			),
+		}, func() {
+			tempCACleanup()
+			tempCertCleanup()
+			tempKeyCleanup()
+		}
+}

--- a/util/testing.go
+++ b/util/testing.go
@@ -27,6 +27,7 @@ import (
 // Tester is a proxy for e.g. testing.T which does not introduce a dependency
 // on "testing".
 type Tester interface {
+	Error(args ...interface{})
 	Failed() bool
 	Fatal(args ...interface{})
 	Fatalf(format string, args ...interface{})
@@ -60,6 +61,36 @@ func CreateTempDir(t Tester, prefix string) string {
 		t.Fatal(err)
 	}
 	return dir
+}
+
+// CreateTempRestrictedFile creates a temporary file on disk which contains the
+// supplied byte string as its content. The resulting file will have restrictive
+// permissions; specifically, u=rw (0600). Returns the path of the created file
+// along with a function that will delete the created file.
+//
+// This is needed for some Go libraries (e.g. postgres SQL driver) which will
+// refuse to open certificate files that have overly permissive permissions.
+func CreateTempRestrictedFile(t Tester, contents []byte, tempdir, prefix string) (string, func()) {
+	tempFile, err := ioutil.TempFile(tempdir, prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tempFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	tempPath := tempFile.Name()
+	if err := os.Remove(tempPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(tempPath, contents, 0600); err != nil {
+		t.Fatal(err)
+	}
+	return tempPath, func() {
+		if err := os.Remove(tempPath); err != nil {
+			// Not Fatal() because we might already be panicking.
+			t.Error(err)
+		}
+	}
 }
 
 // CreateNTempDirs creates N temporary directories and returns a slice


### PR DESCRIPTION
First commit:  _Refactor TestServer client helpers_
Refactor a few helper functions for connecting to a TestServer instance through
a client. This primarily extracts the Postgres URL generation function from the
SQL package and places it into a new TestUtils package for more broad usage.
This method is somewhat complicated, as making a secure postgres driver
connection involves the creation of temporary on-disk certificates.

Commit also adds a small convenience method to open a KVDB connection to the
TestServer, which is somewhat less complex than opening a Postgres connection.

Second Commit: _Begin logging splits to Range Event Log_
This commit begins the logging of split events in the recently added range event
log. This is the first event being logged, and thus some additional
infrastructure was also added.

Creates a new "InternalExecutor" object in the SQL package, which can be used by
other cockroach packages to execute SQL without needing to open a SQL
connection. This needs to be a persistent object because a LeaseManager is
required. The InternalExecutor used by each store currently shares a
LeaseManager with the Executor used by that store.

Commit also extends the rangelog.event schema to hold information relevant to
splits. This information should not necessarily be considered complete;
additional information may be captured in subsequent commits.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3687)

<!-- Reviewable:end -->
