### PR TITLE
Restrict PGAddr to 127.0.0.1 in a few more tests.

### DIFF
--- a/security/certs_test.go
+++ b/security/certs_test.go
@@ -107,6 +107,7 @@ func TestUseCerts(t *testing.T) {
 	testCtx.Certs = certsDir
 	testCtx.User = security.NodeUser
 	testCtx.Addr = "127.0.0.1:0"
+	testCtx.PGAddr = "127.0.0.1:0"
 	s := &server.TestServer{Ctx: testCtx}
 	if err := s.Start(); err != nil {
 		t.Fatal(err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -182,6 +182,7 @@ func TestPlainHTTPServer(t *testing.T) {
 	// Create a custom context. The default one has a default --certs value.
 	ctx := NewContext()
 	ctx.Addr = "127.0.0.1:0"
+	ctx.PGAddr = "127.0.0.1:0"
 	ctx.Insecure = true
 	// TestServer.Start does not override the context if set.
 	s := &TestServer{Ctx: ctx}


### PR DESCRIPTION
Fixes recurring firewall prompts on the mac.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3688)

<!-- Reviewable:end -->
