### PR TITLE
Move Replica.Destroy from replicaGCQueue to store.removeReplicaImpl

### DIFF
--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -281,7 +281,7 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 		t.Error(err)
 	}
 	// Remove range 1.
-	if err := store.RemoveReplica(rng1, *rng1.Desc()); err != nil {
+	if err := store.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
 		t.Error(err)
 	}
 	// Create a new range (id=2).
@@ -298,7 +298,7 @@ func TestStoreAddRemoveRanges(t *testing.T) {
 		t.Fatalf("expected rangeAlreadyExists error; got %s", err)
 	}
 	// Try to remove range 1 again.
-	if err := store.RemoveReplica(rng1, *rng1.Desc()); err == nil {
+	if err := store.RemoveReplica(rng1, *rng1.Desc(), true); err == nil {
 		t.Fatal("expected error re-removing same range")
 	}
 	// Try to add a range with previously-used (but now removed) ID.
@@ -354,12 +354,12 @@ func TestStoreRemoveReplicaOldDescriptor(t *testing.T) {
 	if err := rng1.setDesc(newDesc); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.RemoveReplica(rng1, *origDesc); !testutils.IsError(err, "replica ID has changed") {
+	if err := store.RemoveReplica(rng1, *origDesc, true); !testutils.IsError(err, "replica ID has changed") {
 		t.Fatalf("expected error 'replica ID has changed' but got %s", err)
 	}
 
 	// Now try the latest descriptor and succeed.
-	if err := store.RemoveReplica(rng1, *rng1.Desc()); err != nil {
+	if err := store.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -374,7 +374,7 @@ func TestStoreRangeSet(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if err := store.RemoveReplica(rng1, *rng1.Desc()); err != nil {
+	if err := store.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
 		t.Error(err)
 	}
 	// Add 10 new ranges.
@@ -457,7 +457,7 @@ func TestStoreRangeSet(t *testing.T) {
 	if rng.RangeID != 2 {
 		t.Errorf("expected fetch of rangeID=2; got %d", rng.RangeID)
 	}
-	if err := store.RemoveReplica(rng, *rng.Desc()); err != nil {
+	if err := store.RemoveReplica(rng, *rng.Desc(), true); err != nil {
 		t.Error(err)
 	}
 	if ec := ranges.EstimatedCount(); ec != 9 {
@@ -481,7 +481,7 @@ func TestHasOverlappingReplica(t *testing.T) {
 		t.Error(err)
 	}
 	// Remove range 1.
-	if err := store.RemoveReplica(rng1, *rng1.Desc()); err != nil {
+	if err := store.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
 		t.Error(err)
 	}
 
@@ -1641,7 +1641,7 @@ func TestMaybeRemove(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if err := store.RemoveReplica(rng, *rng.Desc()); err != nil {
+	if err := store.RemoveReplica(rng, *rng.Desc(), true); err != nil {
 		t.Error(err)
 	}
 	// MaybeRemove is called.


### PR DESCRIPTION
This removes the possibility of the "replica recreated during deletion"
scenario, and the chance for Store.getOrCreateReplicaLocked to create
a replica for which data already exists on disk.

Fixes #3447.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3709)

<!-- Reviewable:end -->
