### PR TITLE
Enable persistence for gossip bootstrap information.

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -490,7 +490,7 @@ Flags:
       --log-dir                 if non-empty, write log files in this directory
       --logtostderr             log to standard error instead of files (default true)
       --verbosity               log level for V logs
-      --vmodule                 comma-separated list of file=N settings for file-filtered logging
+      --vmodule                 comma-separated list of pattern=N settings for file-filtered logging
 
 Use "cockroach [command] --help" for more information about a command.
 `

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -59,7 +59,7 @@ var flagUsage = map[string]string{
         attributes should be specified first and in the same order for all
         nodes. For example:
 
-          --attrs=us-west-1b,gpu.
+          --attrs=us-west-1b,gpu
 `,
 	"cache-size": `
         Total size in bytes for caches, shared evenly if there are multiple
@@ -137,7 +137,7 @@ var flagUsage = map[string]string{
         attributes might also include speeds and other specs (7200rpm,
         200kiops, etc.). For example:
 
-          --stores=hdd:7200rpm=/mnt/hda1,ssd=/mnt/ssd01,ssd=/mnt/ssd02,mem=1073741824.
+          --stores=hdd:7200rpm=/mnt/hda1,ssd=/mnt/ssd01,ssd=/mnt/ssd02,mem=1073741824
 `,
 	"max-results": `
         Define the maximum number of results that will be retrieved.

--- a/cli/start.go
+++ b/cli/start.go
@@ -173,7 +173,7 @@ func runStart(_ *cobra.Command, _ []string) error {
 		return util.Errorf("failed to initialize node: %s", err)
 	}
 
-	log.Info("starting cockroach cluster")
+	log.Info("starting cockroach node")
 	s, err := server.NewServer(context, stopper)
 	if err != nil {
 		return util.Errorf("failed to start Cockroach server: %s", err)

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -66,7 +66,6 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/gogo/protobuf/proto"
 )
@@ -85,28 +84,41 @@ const (
 	// ttlNodeDescriptorGossip is time-to-live for node ID -> address.
 	ttlNodeDescriptorGossip = 0 * time.Second
 
-	// stallInterval is the default interval for checking whether the
-	// incoming and outgoing connections to the gossip network are
+	// defaultStallInterval is the default interval for checking whether
+	// the incoming and outgoing connections to the gossip network are
 	// insufficient to keep the network connected.
-	stallInterval = 1 * time.Second
+	defaultStallInterval = 1 * time.Second
 
-	// bootstrapInterval is the minimum time between successive
-	// bootstrapping attempts to avoid busy-looping trying to find
-	// the sentinel gossip info.
-	bootstrapInterval = 1 * time.Second
+	// defaultBootstrapInterval is the minimum time between successive
+	// bootstrapping attempts to avoid busy-looping trying to find the
+	// sentinel gossip info.
+	defaultBootstrapInterval = 1 * time.Second
+
+	// defaultCullInterval is the default interval for culling the least
+	// "useful" outgoing gossip connection to free up space for a more
+	// efficiently targeted connection to the most distant node.
+	//
+	// Note: this value is a var instead of const for testing.
+	defaultCullInterval = 60 * time.Second
 )
 
 var (
-	// cullInterval is the default interval for culling the least
-	// "useful" outgoing gossip connection to free up space for a
-	// more efficiently targeted connection to the most distant node.
-	//
-	// Note: this value is a var instead of const for testing.
-	cullInterval = 60 * time.Second
-
 	// TestBootstrap is the default gossip bootstrap used for running tests.
 	TestBootstrap = []resolver.Resolver{}
 )
+
+// Persistence is an interface which allows the gossip instance
+// to read and write bootstrapping data to persistent storage
+// between instantiations.
+type Persistence interface {
+	// ReadBootstrapInfo fetches the bootstrap data from the persistent
+	// store into the provided bootstrap protobuf. Returns nil or an
+	// error on failure.
+	ReadBootstrapInfo(*BootstrapInfo) error
+	// WriteBootstrapInfo stores the provided bootstrap data to the
+	// persistent store. Returns nil or an error on failure.
+	WriteBootstrapInfo(BootstrapInfo) error
+}
 
 // Gossip is an instance of a gossip node. It embeds a gossip server.
 // During bootstrapping, the bootstrap list contains candidates for
@@ -117,11 +129,17 @@ type Gossip struct {
 	rpcContext    *rpc.Context        // The context required for RPC
 	*server                           // Embedded gossip RPC server
 	outgoing      nodeSet             // Set of outgoing client node IDs
+	persist       Persistence         // Persistent storage interface
+	bootstrapInfo BootstrapInfo       // BootstrapInfo proto for persistent storage
 	bootstrapping map[string]struct{} // Set of active bootstrap clients
 	clientsMu     sync.Mutex          // Mutex protects the clients slice
 	clients       []*client           // Slice of clients
 	disconnected  chan *client        // Channel of disconnected clients
 	stalled       chan struct{}       // Channel to wakeup stalled bootstrap
+
+	stallInterval     time.Duration
+	bootstrapInterval time.Duration
+	cullInterval      time.Duration
 
 	// The system config is treated unlike other info objects.
 	// It is used so often that we keep an unmarshalled version of it
@@ -134,24 +152,28 @@ type Gossip struct {
 
 	// resolvers is a list of resolvers used to determine
 	// bootstrap hosts for connecting to the gossip network.
-	resolverIdx int
-	resolvers   []resolver.Resolver
-	triedAll    bool // True when all resolvers have been tried once
+	resolverIdx    int
+	resolvers      []resolver.Resolver
+	resolversTried map[int]struct{}            // Set of attempted resolver indexes
+	nodesSeen      map[roachpb.NodeID]struct{} // Set of nodes encountered via gossiping
 }
 
 // New creates an instance of a gossip node.
 func New(rpcContext *rpc.Context, resolvers []resolver.Resolver) *Gossip {
 	g := &Gossip{
-		Connected:     make(chan struct{}),
-		server:        newServer(),
-		outgoing:      makeNodeSet(1),
-		bootstrapping: map[string]struct{}{},
-		clients:       []*client{},
-		disconnected:  make(chan *client, 10),
-		stalled:       make(chan struct{}, 1),
-		resolverIdx:   len(resolvers) - 1,
-		resolvers:     resolvers,
+		Connected:         make(chan struct{}),
+		server:            newServer(),
+		outgoing:          makeNodeSet(1),
+		bootstrapping:     map[string]struct{}{},
+		clients:           []*client{},
+		disconnected:      make(chan *client, 10),
+		stalled:           make(chan struct{}, 1),
+		stallInterval:     defaultStallInterval,
+		bootstrapInterval: defaultBootstrapInterval,
+		cullInterval:      defaultCullInterval,
+		nodesSeen:         map[roachpb.NodeID]struct{}{},
 	}
+	g.SetResolvers(resolvers)
 	// The gossip RPC context doesn't measure clock offsets, isn't
 	// shared with the other RPC clients which the node may be using,
 	// and disables reconnects to make it possible to know for certain
@@ -165,6 +187,9 @@ func New(rpcContext *rpc.Context, resolvers []resolver.Resolver) *Gossip {
 
 	// Add ourselves as a SystemConfig watcher.
 	g.is.registerCallback(KeySystemConfig, g.updateSystemConfig)
+	// Add ourselves as a node descriptor watcher.
+	g.is.registerCallback(MakePrefixPattern(KeyNodeIDPrefix), g.updateNodeAddress)
+
 	return g
 }
 
@@ -197,6 +222,99 @@ func (g *Gossip) SetNodeDescriptor(desc *roachpb.NodeDescriptor) error {
 	return nil
 }
 
+// SetStallInterval sets the interval between periodic checks to
+// determine whether the node is not fully connected to the gossip
+// network.
+func (g *Gossip) SetStallInterval(interval time.Duration) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.stallInterval = interval
+}
+
+// SetBootstrapInterval sets a minimum interval between successive
+// attempts to connect to new hosts in order to join the gossip
+// network.
+func (g *Gossip) SetBootstrapInterval(interval time.Duration) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.bootstrapInterval = interval
+}
+
+// SetCullInterval sets the interval between periodic shutdown of
+// outgoing gossip client connections in an effort to improve the
+// fitness of the network.
+func (g *Gossip) SetCullInterval(interval time.Duration) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.cullInterval = interval
+}
+
+// SetPersistence provides an instance of the Persistence interface
+// for reading and writing gossip bootstrap data from persistent
+// storage. This should be invoked as early in the lifecycle of a
+// gossip instance as possible, but can be called at any time.
+func (g *Gossip) SetPersistence(persist Persistence) error {
+	// Read the bootstrap info from the persistent store.
+	var storedBI BootstrapInfo
+	err := persist.ReadBootstrapInfo(&storedBI)
+	if err != nil {
+		return err
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.persist = persist
+
+	// If the bootstrap info is empty, store any addresses we've become
+	// aware of through the --gossip bootstrap hosts we've managed to
+	// connect to.
+	if len(storedBI.Addresses) == 0 {
+		// And also no resolvers, fatal error.
+		if len(g.resolvers) == 0 {
+			log.Fatalf("no resolvers specified for gossip network")
+		}
+		// Otherwise, persist any addresses we've already accumulated through gossip.
+		if numAddrs := len(g.bootstrapInfo.Addresses); numAddrs > 0 {
+			if err := g.persist.WriteBootstrapInfo(g.bootstrapInfo); err != nil {
+				log.Error(err)
+			}
+			log.Infof("wrote %d initial gossip host(s) to persistent storage", numAddrs)
+		}
+		return nil
+	}
+	log.Infof("read %d gossip host(s) for bootstrapping from persistent storage", len(storedBI.Addresses))
+	g.bootstrapInfo = storedBI
+
+	// Cycle through all persisted bootstrap hosts and add resolvers for
+	// any which haven't already been added.
+	newResolverFound := false
+	for _, addr := range g.bootstrapInfo.Addresses {
+		r, err := resolver.NewResolverFromUnresolvedAddr(addr)
+		if err != nil {
+			log.Warningf("bad bootstrap address %s: %s", addr, err)
+			continue
+		}
+		if g.haveResolver(r) {
+			continue
+		}
+		// If we find a new resolver, reset the resolver index so that the
+		// next resolver we try is the first of the new resolvers.
+		if !newResolverFound {
+			newResolverFound = true
+			g.resolverIdx = len(g.resolvers) - 1
+		}
+		g.resolvers = append(g.resolvers, r)
+	}
+	// If a new resolver was found, immediately signal bootstrap.
+	if newResolverFound {
+		if log.V(1) {
+			log.Infof("found new resolvers from persistence; signalling bootstrap")
+		}
+		g.signalStalled()
+	}
+	return nil
+}
+
 // SetResolvers initializes the set of gossip resolvers used to
 // find nodes to bootstrap the gossip network.
 func (g *Gossip) SetResolvers(resolvers []resolver.Resolver) {
@@ -205,7 +323,12 @@ func (g *Gossip) SetResolvers(resolvers []resolver.Resolver) {
 	// Start index at end because get next address loop logic increments as first step.
 	g.resolverIdx = len(resolvers) - 1
 	g.resolvers = resolvers
-	g.triedAll = false
+	g.resolversTried = map[int]struct{}{}
+	// Initialize the bootstrap info with addresses of specified resolvers.
+	for _, r := range resolvers {
+		addr := util.MakeUnresolvedAddr(r.Type(), r.Addr())
+		g.bootstrapInfo.Addresses = append(g.bootstrapInfo.Addresses, addr)
+	}
 }
 
 // GetNodeIDAddress looks up the address of the node by ID.
@@ -240,12 +363,61 @@ func (g *Gossip) EnableSimulationCycler(enable bool) {
 	}
 }
 
+// haveResolver returns whether the specified resolver is already in
+// the gossip node's list of resolvers. The caller must hold the
+// gossip mutex.
+func (g *Gossip) haveResolver(r resolver.Resolver) bool {
+	for _, ex := range g.resolvers {
+		if ex.Type() == r.Type() && ex.Addr() == r.Addr() {
+			return true
+		}
+	}
+	return false
+}
+
 // SimulationCycle cycles this gossip node's server by allowing all
 // connected clients to proceed one step.
 func (g *Gossip) SimulationCycle() {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.simulationCycler.Broadcast()
+}
+
+// updateNodeAddress The gossip callback used to keep the StorePool up to date.
+func (g *Gossip) updateNodeAddress(_ string, content roachpb.Value) {
+	var desc roachpb.NodeDescriptor
+	if err := content.GetProto(&desc); err != nil {
+		log.Error(err)
+		return
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	// Does this node exist yet in the bootstrap addresses list?
+	if _, ok := g.nodesSeen[desc.NodeID]; !ok {
+		g.nodesSeen[desc.NodeID] = struct{}{} // add it!
+
+		// Add this new node to our list of resolvers so we can keep
+		// connecting to gossip if the original resolvers go offline.
+		r, err := resolver.NewResolverFromUnresolvedAddr(desc.Address)
+		if err != nil {
+			log.Warningf("bad address from gossip node %s: %s", desc, err)
+			return
+		}
+		if g.haveResolver(r) {
+			return
+		}
+		g.resolvers = append(g.resolvers, r)
+		// Add new address to bootstrap info and persist if possible.
+		g.bootstrapInfo.Addresses = append(g.bootstrapInfo.Addresses, desc.Address)
+		if g.persist != nil {
+			// TODO(spencer): need to clean up ancient gossip nodes, which
+			//   will otherwise stick around in the bootstrap info forever.
+			if err := g.persist.WriteBootstrapInfo(g.bootstrapInfo); err != nil {
+				log.Error(err)
+			}
+		}
+	}
 }
 
 // getNodeDescriptorLocked looks up the descriptor of the node by ID. The mutex
@@ -459,7 +631,6 @@ func (g *Gossip) Start(rpcServer *rpc.Server, addr net.Addr, stopper *stop.Stopp
 	g.server.start(rpcServer, addr, stopper) // serve gossip protocol
 	g.bootstrap(stopper)                     // bootstrap gossip client
 	g.manage(stopper)                        // manage gossip clients
-	g.maybeWarnAboutInit(stopper)
 }
 
 // hasIncoming returns whether the server has an incoming gossip
@@ -492,16 +663,10 @@ func (g *Gossip) filterExtant(nodes nodeSet) nodeSet {
 // slice supplied to the constructor or set using setBootstrap().
 // The lock is assumed held.
 func (g *Gossip) getNextBootstrapAddress() net.Addr {
-	if len(g.resolvers) == 0 {
-		log.Fatalf("no resolvers specified for gossip network")
-	}
-
 	// Run through resolvers round robin starting at last resolved index.
 	for i := 0; i < len(g.resolvers); i++ {
 		g.resolverIdx = (g.resolverIdx + 1) % len(g.resolvers)
-		if g.resolverIdx == len(g.resolvers)-1 {
-			g.triedAll = true
-		}
+		g.resolversTried[g.resolverIdx] = struct{}{}
 		resolver := g.resolvers[g.resolverIdx]
 		addr, err := resolver.GetAddress()
 		if err != nil {
@@ -547,7 +712,7 @@ func (g *Gossip) bootstrap(stopper *stop.Stopper) {
 
 			// Pause an interval before next possible bootstrap.
 			select {
-			case <-time.After(bootstrapInterval):
+			case <-time.After(g.bootstrapInterval):
 				// continue
 			case <-stopper.ShouldStop():
 				return
@@ -575,8 +740,8 @@ func (g *Gossip) bootstrap(stopper *stop.Stopper) {
 // is notified via the stalled conditional variable.
 func (g *Gossip) manage(stopper *stop.Stopper) {
 	stopper.RunWorker(func() {
-		cullTicker := time.NewTicker(g.jitteredInterval(cullInterval))
-		stallTicker := time.NewTicker(g.jitteredInterval(stallInterval))
+		cullTicker := time.NewTicker(g.jitteredInterval(g.cullInterval))
+		stallTicker := time.NewTicker(g.jitteredInterval(g.stallInterval))
 		defer cullTicker.Stop()
 		defer stallTicker.Stop()
 		for {
@@ -638,7 +803,9 @@ func (g *Gossip) cullNetwork() {
 		}
 		return
 	}
-	log.Infof("closing least useful client to node %d to tighten network graph", leastUsefulID)
+	if log.V(1) {
+		log.Infof("closing least useful client to node %d to tighten network graph", leastUsefulID)
+	}
 	g.closeClient(leastUsefulID)
 }
 
@@ -661,7 +828,7 @@ func (g *Gossip) maybeSignalStalledLocked() {
 	if g.outgoing.len()+g.incoming.len() == 0 {
 		g.signalStalled()
 	} else if g.is.getInfo(KeySentinel) == nil {
-		log.Warningf("missing sentinel gossip; assuming partition in gossip network")
+		g.warnAboutStall()
 		g.signalStalled()
 	}
 }
@@ -673,48 +840,22 @@ func (g *Gossip) signalStalled() {
 	}
 }
 
-// maybeWarnAboutInit looks for signs indicating a cluster which
-// hasn't been initialized and warns. There's no absolutely sure way
-// to determine whether the current node is simply waiting to be
-// bootstrapped to an existing cluster vs. the operator having failed
-// to initialize the cluster via the "cockroach init" command, so
-// we can only warn.
-//
-// This method checks whether all gossip bootstrap hosts are
-// connected, and whether the node itself is a bootstrap host, but
-// there is still no sentinel gossip.
-func (g *Gossip) maybeWarnAboutInit(stopper *stop.Stopper) {
-	stopper.RunWorker(func() {
-		// Wait 5s before first check.
-		select {
-		case <-stopper.ShouldStop():
-			return
-		case <-time.After(5 * time.Second):
-		}
-		retryOptions := retry.Options{
-			InitialBackoff: 5 * time.Second,      // first backoff at 5s
-			MaxBackoff:     60 * time.Second,     // max backoff is 60s
-			Multiplier:     2,                    // doubles
-			Closer:         stopper.ShouldStop(), // stop no matter what on stopper
-		}
-		// This will never error because of infinite retries.
-		for r := retry.Start(retryOptions); r.Next(); {
-			g.mu.Lock()
-			hasConnections := g.outgoing.len()+g.incoming.len() > 0
-			hasSentinel := g.is.getInfo(KeySentinel) != nil
-			triedAll := g.triedAll
-			g.mu.Unlock()
-			// If we have the sentinel, exit the retry loop.
-			if hasSentinel {
-				break
-			}
-			if !hasConnections {
-				log.Warningf("not connected to gossip; check that gossip flag is set appropriately")
-			} else if triedAll {
-				log.Warningf("missing gossip sentinel; first range unavailable or cluster not initialized")
-			}
-		}
-	})
+// warnAboutStall attempts to diagnose the cause of a gossip network
+// not being connected to the sentinel. This could happen in a network
+// partition, or because of misconfiguration. It's impossible to tell,
+// but we can warn appropriately. If there are no incoming or outgoing
+// connections, we warn about the --gossip flag being set. If we've
+// connected, and all resolvers have been tried, we warn about either
+// the first range not being available or else possible the cluster
+// never having been initialized.
+func (g *Gossip) warnAboutStall() {
+	if g.outgoing.len()+g.incoming.len() == 0 {
+		log.Warningf("not connected to gossip; check that gossip flag is set appropriately")
+	} else if len(g.resolversTried) == len(g.resolvers) {
+		log.Warningf("first range unavailable or cluster not initialized")
+	} else {
+		log.Warningf("partition in gossip network and attempting new connection")
+	}
 }
 
 // checkHasConnected checks whether this gossip instance is connected

--- a/gossip/gossip.pb.go
+++ b/gossip/gossip.pb.go
@@ -9,6 +9,7 @@
 		cockroach/gossip/gossip.proto
 
 	It has these top-level messages:
+		BootstrapInfo
 		Node
 		Request
 		Response
@@ -35,6 +36,17 @@ import io "io"
 var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
+
+// BootstrapInfo contains information necessary to bootstrapping the
+// gossip network from a cold start.
+type BootstrapInfo struct {
+	// A map from node ID to address.
+	Addresses []cockroach_util.UnresolvedAddr `protobuf:"bytes,1,rep,name=addresses" json:"addresses"`
+}
+
+func (m *BootstrapInfo) Reset()         { *m = BootstrapInfo{} }
+func (m *BootstrapInfo) String() string { return proto.CompactTextString(m) }
+func (*BootstrapInfo) ProtoMessage()    {}
 
 // Node contains information about a gossip node.
 type Node struct {
@@ -110,11 +122,42 @@ func (m *Info) String() string { return proto.CompactTextString(m) }
 func (*Info) ProtoMessage()    {}
 
 func init() {
+	proto.RegisterType((*BootstrapInfo)(nil), "cockroach.gossip.BootstrapInfo")
 	proto.RegisterType((*Node)(nil), "cockroach.gossip.Node")
 	proto.RegisterType((*Request)(nil), "cockroach.gossip.Request")
 	proto.RegisterType((*Response)(nil), "cockroach.gossip.Response")
 	proto.RegisterType((*Info)(nil), "cockroach.gossip.Info")
 }
+func (m *BootstrapInfo) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *BootstrapInfo) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Addresses) > 0 {
+		for _, msg := range m.Addresses {
+			data[i] = 0xa
+			i++
+			i = encodeVarintGossip(data, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(data[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	return i, nil
+}
+
 func (m *Node) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -404,6 +447,18 @@ func encodeVarintGossip(data []byte, offset int, v uint64) int {
 	data[offset] = uint8(v)
 	return offset + 1
 }
+func (m *BootstrapInfo) Size() (n int) {
+	var l int
+	_ = l
+	if len(m.Addresses) > 0 {
+		for _, e := range m.Addresses {
+			l = e.Size()
+			n += 1 + l + sovGossip(uint64(l))
+		}
+	}
+	return n
+}
+
 func (m *Node) Size() (n int) {
 	var l int
 	_ = l
@@ -530,6 +585,87 @@ func sovGossip(x uint64) (n int) {
 }
 func sozGossip(x uint64) (n int) {
 	return sovGossip(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *BootstrapInfo) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGossip
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BootstrapInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BootstrapInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Addresses", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGossip
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGossip
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Addresses = append(m.Addresses, cockroach_util.UnresolvedAddr{})
+			if err := m.Addresses[len(m.Addresses)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGossip(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGossip
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *Node) Unmarshal(data []byte) error {
 	l := len(data)

--- a/gossip/gossip.pb.go
+++ b/gossip/gossip.pb.go
@@ -42,6 +42,8 @@ var _ = math.Inf
 type BootstrapInfo struct {
 	// A map from node ID to address.
 	Addresses []cockroach_util.UnresolvedAddr `protobuf:"bytes,1,rep,name=addresses" json:"addresses"`
+	// Timestamp at which the bootstrap info was written.
+	Timestamp cockroach_roachpb1.Timestamp `protobuf:"bytes,2,opt,name=timestamp" json:"timestamp"`
 }
 
 func (m *BootstrapInfo) Reset()         { *m = BootstrapInfo{} }
@@ -155,6 +157,14 @@ func (m *BootstrapInfo) MarshalTo(data []byte) (int, error) {
 			i += n
 		}
 	}
+	data[i] = 0x12
+	i++
+	i = encodeVarintGossip(data, i, uint64(m.Timestamp.Size()))
+	n1, err := m.Timestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n1
 	return i, nil
 }
 
@@ -209,19 +219,19 @@ func (m *Request) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintGossip(data, i, uint64(m.Addr.Size()))
-	n1, err := m.Addr.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	data[i] = 0x1a
-	i++
-	i = encodeVarintGossip(data, i, uint64(m.LAddr.Size()))
-	n2, err := m.LAddr.MarshalTo(data[i:])
+	n2, err := m.Addr.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n2
+	data[i] = 0x1a
+	i++
+	i = encodeVarintGossip(data, i, uint64(m.LAddr.Size()))
+	n3, err := m.LAddr.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n3
 	if len(m.Nodes) > 0 {
 		for k := range m.Nodes {
 			data[i] = 0x22
@@ -239,11 +249,11 @@ func (m *Request) MarshalTo(data []byte) (int, error) {
 			data[i] = 0x12
 			i++
 			i = encodeVarintGossip(data, i, uint64(v.Size()))
-			n3, err := v.MarshalTo(data[i:])
+			n4, err := v.MarshalTo(data[i:])
 			if err != nil {
 				return 0, err
 			}
-			i += n3
+			i += n4
 		}
 	}
 	if len(m.Delta) > 0 {
@@ -264,11 +274,11 @@ func (m *Request) MarshalTo(data []byte) (int, error) {
 			data[i] = 0x12
 			i++
 			i = encodeVarintGossip(data, i, uint64(v.Size()))
-			n4, err := v.MarshalTo(data[i:])
+			n5, err := v.MarshalTo(data[i:])
 			if err != nil {
 				return 0, err
 			}
-			i += n4
+			i += n5
 		}
 	}
 	return i, nil
@@ -297,20 +307,20 @@ func (m *Response) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintGossip(data, i, uint64(m.Addr.Size()))
-	n5, err := m.Addr.MarshalTo(data[i:])
+	n6, err := m.Addr.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n5
+	i += n6
 	if m.AlternateAddr != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintGossip(data, i, uint64(m.AlternateAddr.Size()))
-		n6, err := m.AlternateAddr.MarshalTo(data[i:])
+		n7, err := m.AlternateAddr.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n6
+		i += n7
 	}
 	if m.AlternateNodeID != 0 {
 		data[i] = 0x20
@@ -335,11 +345,11 @@ func (m *Response) MarshalTo(data []byte) (int, error) {
 			data[i] = 0x12
 			i++
 			i = encodeVarintGossip(data, i, uint64(v.Size()))
-			n7, err := v.MarshalTo(data[i:])
+			n8, err := v.MarshalTo(data[i:])
 			if err != nil {
 				return 0, err
 			}
-			i += n7
+			i += n8
 		}
 	}
 	if len(m.Nodes) > 0 {
@@ -359,11 +369,11 @@ func (m *Response) MarshalTo(data []byte) (int, error) {
 			data[i] = 0x12
 			i++
 			i = encodeVarintGossip(data, i, uint64(v.Size()))
-			n8, err := v.MarshalTo(data[i:])
+			n9, err := v.MarshalTo(data[i:])
 			if err != nil {
 				return 0, err
 			}
-			i += n8
+			i += n9
 		}
 	}
 	return i, nil
@@ -387,11 +397,11 @@ func (m *Info) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGossip(data, i, uint64(m.Value.Size()))
-	n9, err := m.Value.MarshalTo(data[i:])
+	n10, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n9
+	i += n10
 	if m.OrigStamp != 0 {
 		data[i] = 0x10
 		i++
@@ -456,6 +466,8 @@ func (m *BootstrapInfo) Size() (n int) {
 			n += 1 + l + sovGossip(uint64(l))
 		}
 	}
+	l = m.Timestamp.Size()
+	n += 1 + l + sovGossip(uint64(l))
 	return n
 }
 
@@ -643,6 +655,36 @@ func (m *BootstrapInfo) Unmarshal(data []byte) error {
 			}
 			m.Addresses = append(m.Addresses, cockroach_util.UnresolvedAddr{})
 			if err := m.Addresses[len(m.Addresses)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGossip
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGossip
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Timestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/gossip/gossip.proto
+++ b/gossip/gossip.proto
@@ -23,6 +23,13 @@ import "cockroach/roachpb/metadata.proto";
 import "cockroach/util/unresolved_addr.proto";
 import weak "gogoproto/gogo.proto";
 
+// BootstrapInfo contains information necessary to bootstrapping the
+// gossip network from a cold start.
+message BootstrapInfo {
+  // A map from node ID to address.
+  repeated util.UnresolvedAddr addresses = 1 [(gogoproto.nullable) = false];
+}
+
 // Node contains information about a gossip node.
 message Node {
   // The most recent timestamp of any info which originated at this node.

--- a/gossip/gossip.proto
+++ b/gossip/gossip.proto
@@ -28,6 +28,8 @@ import weak "gogoproto/gogo.proto";
 message BootstrapInfo {
   // A map from node ID to address.
   repeated util.UnresolvedAddr addresses = 1 [(gogoproto.nullable) = false];
+  // Timestamp at which the bootstrap info was written.
+  roachpb.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
 }
 
 // Node contains information about a gossip node.

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -106,7 +106,6 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 // the network periodically (at cullInterval duration intervals).
 func TestGossipCullNetwork(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("#3620")
 
 	// Create the local gossip and minPeers peers.
 	stopper := stop.NewStopper()

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -108,17 +108,11 @@ func TestGossipCullNetwork(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	t.Skip("#3620")
 
-	// Set the cullInterval to a low value to guarantee it kicks in quickly.
-	origCullInterval := cullInterval
-	cullInterval = 5 * time.Millisecond
-	defer func() {
-		cullInterval = origCullInterval
-	}()
-
 	// Create the local gossip and minPeers peers.
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	local := startGossip(1, stopper, t)
+	local.SetCullInterval(5 * time.Millisecond)
 	peers := []*Gossip{}
 	for i := 0; i < minPeers; i++ {
 		peers = append(peers, startGossip(roachpb.NodeID(i+2), stopper, t))

--- a/gossip/info.go
+++ b/gossip/info.go
@@ -16,22 +16,16 @@
 
 package gossip
 
-import "github.com/cockroachdb/cockroach/roachpb"
-
 // expired returns true if the node's time to live (TTL) has expired.
 func (i *Info) expired(now int64) bool {
 	return i.TTLStamp <= now
 }
 
-// isFresh returns false if the info originated at this node, or if
-// the info has an originating timestamp earlier than the latest seen
-// by this node, or if the timestamps are equal but the hops the info
-// has taken to arrive at this node is greater than the minimum seen
-// from the originating node.
-func (i *Info) isFresh(thisNodeID roachpb.NodeID, n *Node) bool {
-	if thisNodeID != 0 && thisNodeID == i.NodeID {
-		return false
-	}
+// isFresh returns false if the info has an originating timestamp
+// earlier than the latest seen by this node, or if the timestamps are
+// equal but the hops the info has taken to arrive at this node is
+// greater than the minimum seen from the originating node.
+func (i *Info) isFresh(n *Node) bool {
 	if n == nil || (i.OrigStamp > n.HighWaterStamp ||
 		(i.OrigStamp == n.HighWaterStamp && i.Hops+1 < n.MinHops)) {
 		return true

--- a/gossip/info_test.go
+++ b/gossip/info_test.go
@@ -52,50 +52,40 @@ func TestExpired(t *testing.T) {
 func TestIsFresh(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
-	node1 := roachpb.NodeID(1)
-	node2 := roachpb.NodeID(2)
-	node3 := roachpb.NodeID(3)
 	i := newInfo(float64(1))
-	i.NodeID = node1
 	i.Hops = 3
-	if !i.isFresh(node3, nil) {
+	if !i.isFresh(nil) {
 		t.Error("info should be fresh:", i)
 	}
-	if i.isFresh(node1, nil) {
+	if !i.isFresh(&Node{i.OrigStamp - 1, 2}) {
+		t.Error("info should be fresh:", i)
+	}
+	if !i.isFresh(&Node{i.OrigStamp - 1, 3}) {
+		t.Error("info should be fresh:", i)
+	}
+	if !i.isFresh(&Node{i.OrigStamp - 1, 4}) {
+		t.Error("info should be fresh:", i)
+	}
+	if i.isFresh(&Node{i.OrigStamp, 3}) {
 		t.Error("info should not be fresh:", i)
 	}
-	if !i.isFresh(node3, &Node{i.OrigStamp - 1, 3}) {
-		t.Error("info should be fresh:", i)
-	}
-	if !i.isFresh(node3, &Node{i.OrigStamp - 1, 4}) {
-		t.Error("info should be fresh:", i)
-	}
-	if i.isFresh(node3, &Node{i.OrigStamp, 3}) {
+	if i.isFresh(&Node{i.OrigStamp, 4}) {
 		t.Error("info should not be fresh:", i)
 	}
-	if i.isFresh(node3, &Node{i.OrigStamp, 4}) {
-		t.Error("info should not be fresh:", i)
-	}
-	if !i.isFresh(node3, &Node{i.OrigStamp, 5}) {
+	if !i.isFresh(&Node{i.OrigStamp, 5}) {
 		t.Error("info should be fresh:", i)
 	}
-	if i.isFresh(node3, &Node{i.OrigStamp, 2}) {
+	if i.isFresh(&Node{i.OrigStamp, 2}) {
 		t.Error("info should not be fresh (hops + 1 will not be better):", i)
 	}
-	if i.isFresh(node3, &Node{i.OrigStamp + 1, 3}) {
+	if i.isFresh(&Node{i.OrigStamp + 1, 3}) {
 		t.Error("info should not be fresh:", i)
 	}
-	if i.isFresh(node3, &Node{i.OrigStamp + 1, 2}) {
+	if i.isFresh(&Node{i.OrigStamp + 1, 2}) {
 		t.Error("info should not be fresh:", i)
-	}
-	if i.isFresh(node1, &Node{i.OrigStamp - 1, 2}) {
-		t.Error("info should not be fresh:", i)
-	}
-	if !i.isFresh(node2, &Node{i.OrigStamp - 1, 3}) {
-		t.Error("info should be fresh:", i)
 	}
 	// Using node 0 will always yield fresh data.
-	if !i.isFresh(0, &Node{0, 0}) {
+	if !i.isFresh(&Node{0, 0}) {
 		t.Error("info should be fresh from node0:", i)
 	}
 }

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -299,7 +299,7 @@ func (is *infoStore) delta(nodeID roachpb.NodeID, nodes map[int32]*Node) map[str
 	infos := make(map[string]*Info)
 	// Compute delta of infos.
 	if err := is.visitInfos(func(key string, i *Info) error {
-		if i.isFresh(nodeID, nodes[int32(i.NodeID)]) {
+		if i.isFresh(nodes[int32(i.NodeID)]) {
 			infos[key] = i
 		}
 		return nil

--- a/gossip/persistence_test.go
+++ b/gossip/persistence_test.go
@@ -1,0 +1,127 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package gossip_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/gossip/resolver"
+	"github.com/cockroachdb/cockroach/gossip/simulation"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+type testPersistence struct {
+	read, write bool
+	info        gossip.BootstrapInfo
+}
+
+// Read implements the gossip.Persistence interface.
+func (tp *testPersistence) ReadBootstrapInfo(info *gossip.BootstrapInfo) error {
+	tp.read = true
+	*info = tp.info
+	return nil
+}
+
+// Write implements the gossip.Persistence interface.
+func (tp *testPersistence) WriteBootstrapInfo(info gossip.BootstrapInfo) error {
+	tp.write = true
+	tp.info = info
+	return nil
+}
+
+// TestGossipPersistence
+func TestGossipPersistence(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	const numNodes = 3
+	network := simulation.NewNetwork(3)
+	defer network.Stop()
+
+	// Set persistence for each of the nodes.
+	persists := []*testPersistence{}
+	for _, n := range network.Nodes {
+		tp := &testPersistence{}
+		persists = append(persists, tp)
+		if err := n.Gossip.SetPersistence(tp); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Wait for the gossip network to connect.
+	network.RunUntilFullyConnected()
+
+	for i, p := range persists {
+		if !p.read {
+			t.Errorf("%d: expected read from persistence", i)
+		}
+		if !p.write {
+			t.Errorf("%d: expected write from persistence", i)
+		}
+		// Verify all gossip addresses are written to each persistent store.
+		if len(p.info.Addresses) != 3 {
+			t.Errorf("%d: expected 3 addresses, have: %s", i, p.info.Addresses)
+		}
+	}
+
+	// Create an unaffiliated gossip node with only itself as a resolver,
+	// leaving it no way to reach the gossip network.
+	node, err := network.CreateNode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	node.Gossip.SetBootstrapInterval(1 * time.Millisecond)
+
+	r, err := resolver.NewResolverFromAddress(node.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	node.Gossip.SetResolvers([]resolver.Resolver{r})
+	if err := network.StartNode(node); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for a bit to ensure no connection.
+	select {
+	case <-time.After(10 * time.Millisecond):
+		// expected outcome...
+	case <-node.Gossip.Connected:
+		t.Fatal("unexpectedly connected to gossip")
+	}
+
+	// Give the new node persistence with info established from a node
+	// in the established network.
+	tp := &testPersistence{
+		info: persists[0].info,
+	}
+	if err := node.Gossip.SetPersistence(tp); err != nil {
+		t.Fatal(err)
+	}
+
+	network.SimulateNetwork(func(cycle int, network *simulation.Network) bool {
+		if cycle > 100 {
+			t.Fatal("failed to connect to gossip")
+		}
+		select {
+		case <-node.Gossip.Connected:
+			return false
+		default:
+			return true
+		}
+	})
+}

--- a/gossip/resolver/resolver.go
+++ b/gossip/resolver/resolver.go
@@ -99,10 +99,5 @@ func NewResolverFromAddress(addr net.Addr) (Resolver, error) {
 
 // NewResolverFromUnresolvedAddr takes a util.UnresolvedAddr and constructs a resolver.
 func NewResolverFromUnresolvedAddr(addr util.UnresolvedAddr) (Resolver, error) {
-	switch addr.Network() {
-	case "tcp", "unix":
-		return &socketResolver{typ: addr.Network(), addr: addr.String()}, nil
-	default:
-		return nil, util.Errorf("unknown address network %q for %v", addr.Network(), addr)
-	}
+	return NewResolverFromAddress(&addr)
 }

--- a/gossip/resolver/resolver.go
+++ b/gossip/resolver/resolver.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/log"
 )
 
 // Resolver is an interface which provides an abstract factory for
@@ -89,12 +88,21 @@ func NewResolver(context *base.Context, spec string) (Resolver, error) {
 }
 
 // NewResolverFromAddress takes a net.Addr and constructs a resolver.
-func NewResolverFromAddress(addr net.Addr) Resolver {
+func NewResolverFromAddress(addr net.Addr) (Resolver, error) {
 	switch addr.Network() {
 	case "tcp", "unix":
-		return &socketResolver{typ: addr.Network(), addr: addr.String()}
+		return &socketResolver{typ: addr.Network(), addr: addr.String()}, nil
 	default:
-		log.Fatalf("unknown address network %q for %v", addr.Network(), addr)
-		return nil
+		return nil, util.Errorf("unknown address network %q for %v", addr.Network(), addr)
+	}
+}
+
+// NewResolverFromUnresolvedAddr takes a util.UnresolvedAddr and constructs a resolver.
+func NewResolverFromUnresolvedAddr(addr util.UnresolvedAddr) (Resolver, error) {
+	switch addr.Network() {
+	case "tcp", "unix":
+		return &socketResolver{typ: addr.Network(), addr: addr.String()}, nil
+	default:
+		return nil, util.Errorf("unknown address network %q for %v", addr.Network(), addr)
 	}
 }

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -46,7 +46,7 @@ type Node struct {
 type Network struct {
 	Nodes           []*Node
 	Stopper         *stop.Stopper
-	nodeIDAllocator roachpb.NodeID
+	nodeIDAllocator roachpb.NodeID // provides unique node IDs
 	rpcContext      *rpc.Context
 	tlsConfig       *tls.Config
 }

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -17,6 +17,7 @@
 package simulation
 
 import (
+	"crypto/tls"
 	"net"
 	"time"
 
@@ -43,8 +44,11 @@ type Node struct {
 
 // Network provides access to a test gossip network of nodes.
 type Network struct {
-	Nodes   []*Node
-	Stopper *stop.Stopper
+	Nodes           []*Node
+	Stopper         *stop.Stopper
+	nodeIDAllocator roachpb.NodeID
+	rpcContext      *rpc.Context
+	tlsConfig       *tls.Config
 }
 
 // NewNetwork creates nodeCount gossip nodes.
@@ -53,53 +57,66 @@ func NewNetwork(nodeCount int) *Network {
 
 	log.Infof("simulating gossip network with %d nodes", nodeCount)
 
-	stopper := stop.NewStopper()
-
-	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, clock, stopper)
-	tlsConfig, err := rpcContext.GetServerTLSConfig()
+	n := &Network{
+		Nodes:   []*Node{},
+		Stopper: stop.NewStopper(),
+	}
+	n.rpcContext = rpc.NewContext(&base.Context{Insecure: true}, clock, n.Stopper)
+	var err error
+	n.tlsConfig, err = n.rpcContext.GetServerTLSConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	nodes := make([]*Node, nodeCount)
-	for i := range nodes {
-		server := rpc.NewServer(rpcContext)
-
-		testAddr := util.CreateTestAddr("tcp")
-		ln, err := util.ListenAndServe(stopper, server, testAddr, tlsConfig)
+	for i := 0; i < nodeCount; i++ {
+		node, err := n.CreateNode()
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		nodes[i] = &Node{Server: server, Addr: ln.Addr()}
-	}
-
-	for i, leftNode := range nodes {
-		// Build new resolvers for each instance or we'll get data races.
-		resolvers := []resolver.Resolver{resolver.NewResolverFromAddress(nodes[0].Addr)}
-
-		gossipNode := gossip.New(rpcContext, resolvers)
-		addr := leftNode.Addr
-		gossipNode.SetNodeID(roachpb.NodeID(i + 1))
-		if err := gossipNode.SetNodeDescriptor(&roachpb.NodeDescriptor{
-			NodeID:  roachpb.NodeID(i + 1),
-			Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),
-		}); err != nil {
+		// Build a resolver for each instance or we'll get data races.
+		r, err := resolver.NewResolverFromAddress(n.Nodes[0].Addr)
+		if err != nil {
+			log.Fatalf("bad gossip address %s: %s", n.Nodes[0].Addr, err)
+		}
+		node.Gossip.SetResolvers([]resolver.Resolver{r})
+		if err := n.StartNode(node); err != nil {
 			log.Fatal(err)
 		}
-		if err := gossipNode.AddInfo(addr.String(), encoding.EncodeUint64(nil, 0), time.Hour); err != nil {
-			log.Fatal(err)
-		}
-		gossipNode.Start(leftNode.Server, addr, stopper)
-		gossipNode.EnableSimulationCycler(true)
-
-		leftNode.Gossip = gossipNode
 	}
+	return n
+}
 
-	return &Network{
-		Nodes:   nodes,
-		Stopper: stopper,
+// CreateNode creates a simulation node and starts an RPC server for it.
+func (n *Network) CreateNode() (*Node, error) {
+	server := rpc.NewServer(n.rpcContext)
+	testAddr := util.CreateTestAddr("tcp")
+	ln, err := util.ListenAndServe(n.Stopper, server, testAddr, n.tlsConfig)
+	if err != nil {
+		return nil, err
 	}
+	node := &Node{Server: server, Addr: ln.Addr()}
+	node.Gossip = gossip.New(n.rpcContext, nil)
+	n.Nodes = append(n.Nodes, node)
+	return node, nil
+}
+
+// StartNode initializes a gossip instance for the simulation node and
+// starts it.
+func (n *Network) StartNode(node *Node) error {
+	n.nodeIDAllocator++
+	node.Gossip.SetNodeID(n.nodeIDAllocator)
+	if err := node.Gossip.SetNodeDescriptor(&roachpb.NodeDescriptor{
+		NodeID:  node.Gossip.GetNodeID(),
+		Address: util.MakeUnresolvedAddr(node.Addr.Network(), node.Addr.String()),
+	}); err != nil {
+		return err
+	}
+	if err := node.Gossip.AddInfo(node.Addr.String(), encoding.EncodeUint64(nil, 0), time.Hour); err != nil {
+		return err
+	}
+	node.Gossip.Start(node.Server, node.Addr, n.Stopper)
+	node.Gossip.EnableSimulationCycler(true)
+	return nil
 }
 
 // GetNodeFromAddr returns the simulation node associated with
@@ -137,8 +154,11 @@ func (n *Network) GetNodeFromID(nodeID roachpb.NodeID) (*Node, bool) {
 func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) bool) {
 	nodes := n.Nodes
 	for cycle := 1; simCallback(cycle, n); cycle++ {
-		// Node 0 gossips sentinel every cycle.
+		// Node 0 gossips sentinel & cluster ID every cycle.
 		if err := nodes[0].Gossip.AddInfo(gossip.KeySentinel, encoding.EncodeUint64(nil, uint64(cycle)), time.Hour); err != nil {
+			log.Fatal(err)
+		}
+		if err := nodes[0].Gossip.AddInfo(gossip.KeyClusterID, encoding.EncodeUint64(nil, uint64(cycle)), 0*time.Second); err != nil {
 			log.Fatal(err)
 		}
 		// Every node gossips cycle.

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -62,9 +62,8 @@ var (
 	// localStoreIdentSuffix stores an immutable identifier for this
 	// store, created when the store is first bootstrapped.
 	localStoreIdentSuffix = []byte("iden")
-	// localStoreGossipSuffix stores gossip bootstrap metadata which
-	// for this store which is updated any time new gossip hosts are
-	// encountered.
+	// localStoreGossipSuffix stores gossip bootstrap metadata for this
+	// store, updated any time new gossip hosts are encountered.
 	localStoreGossipSuffix = []byte("goss")
 
 	// LocalRangeIDPrefix is the prefix identifying per-range data

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -62,6 +62,10 @@ var (
 	// localStoreIdentSuffix stores an immutable identifier for this
 	// store, created when the store is first bootstrapped.
 	localStoreIdentSuffix = []byte("iden")
+	// localStoreGossipSuffix stores gossip bootstrap metadata which
+	// for this store which is updated any time new gossip hosts are
+	// encountered.
+	localStoreGossipSuffix = []byte("goss")
 
 	// LocalRangeIDPrefix is the prefix identifying per-range data
 	// indexed by Range ID. The Range ID is appended to this prefix,

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -44,6 +44,11 @@ func StoreIdentKey() roachpb.Key {
 	return MakeStoreKey(localStoreIdentSuffix, roachpb.RKey{})
 }
 
+// StoreGossipKey returns a store-local key for the gossip bootstrap metadata.
+func StoreGossipKey() roachpb.Key {
+	return MakeStoreKey(localStoreGossipSuffix, roachpb.RKey{})
+}
+
 // StoreStatusKey returns the key for accessing the store status for the
 // specified store ID.
 func StoreStatusKey(storeID int32) roachpb.Key {

--- a/keys/printer.go
+++ b/keys/printer.go
@@ -90,6 +90,8 @@ var (
 func localStoreKeyPrint(key roachpb.Key) string {
 	if bytes.HasPrefix(key, localStoreIdentSuffix) {
 		return "/storeIdent"
+	} else if bytes.HasPrefix(key, localStoreGossipSuffix) {
+		return "/gossipBootstrap"
 	}
 
 	return fmt.Sprintf("%q", []byte(key))

--- a/keys/printer_test.go
+++ b/keys/printer_test.go
@@ -36,6 +36,7 @@ func TestPrettyPrint(t *testing.T) {
 	}{
 		// local
 		{StoreIdentKey(), "/Local/Store/storeIdent"},
+		{StoreGossipKey(), "/Local/Store/gossipBootstrap"},
 		{SequenceCacheKeyPrefix(roachpb.RangeID(1000001), []byte("test0")), `/Local/RangeID/1000001/SequenceCache/"test0"`},
 		{SequenceCacheKey(roachpb.RangeID(1000001), []byte("test0"), uint32(111), uint32(222)), `/Local/RangeID/1000001/SequenceCache/"test0"/epoch:111/seq:222`},
 		{RaftLeaderLeaseKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/RaftLeaderLease"},

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -77,7 +77,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ltc.Gossip = gossip.New(rpcContext, gossip.TestBootstrap)
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20, ltc.Stopper)
 
-	ltc.stores = storage.NewStores()
+	ltc.stores = storage.NewStores(ltc.Clock)
 	var rpcSend rpcSendFn = func(_ rpc.Options, _ string, _ []net.Addr,
 		getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message,
 		_ *rpc.Context) ([]proto.Message, error) {

--- a/server/context.go
+++ b/server/context.go
@@ -183,11 +183,9 @@ func (ctx *Context) InitStores(stopper *stop.Stopper) error {
 		}
 		ctx.Engines = append(ctx.Engines, engine)
 	}
-	log.Infof("initialized %d storage engine(s)", len(ctx.Engines))
+	log.Infof("%d storage engine(s) specified", len(ctx.Engines))
 	return nil
 }
-
-var errNoGossipAddresses = errors.New("no gossip addresses found, did you specify --gossip?")
 
 // InitNode parses node attributes and initializes the gossip bootstrap
 // resolvers.
@@ -200,10 +198,9 @@ func (ctx *Context) InitNode() error {
 	if err != nil {
 		return err
 	}
-	if len(resolvers) == 0 {
-		return errNoGossipAddresses
+	if len(resolvers) > 0 {
+		ctx.GossipBootstrapResolvers = resolvers
 	}
-	ctx.GossipBootstrapResolvers = resolvers
 
 	return nil
 }

--- a/server/node.go
+++ b/server/node.go
@@ -299,9 +299,10 @@ func (n *Node) initStores(engines []engine.Engine, stopper *stop.Stopper) error 
 		return err
 	}
 
-	// Set the stores map as the gossip persistence, so that gossip can
-	// bootstrap using the most recently persisted set of node addresses.
-	if err := n.ctx.Gossip.SetPersistence(n.stores); err != nil {
+	// Set the stores map as the gossip persistent storage, so that
+	// gossip can bootstrap using the most recently persisted set of
+	// node addresses.
+	if err := n.ctx.Gossip.SetStorage(n.stores); err != nil {
 		log.Warningf("failed to set gossip persistence: %s; relying on --gossip bootstrap flag", err)
 	}
 
@@ -365,7 +366,6 @@ func (n *Node) bootstrapStores(bootstraps *list.List, stopper *stop.Stopper) {
 	}
 	for e := bootstraps.Front(); e != nil; e = e.Next() {
 		s := e.Value.(*storage.Store)
-		log.Infof("bootstrapping new store at %s...", s.Engine())
 		if err := s.Bootstrap(sIdent, stopper); err != nil {
 			log.Fatal(err)
 		}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -70,7 +70,11 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		if gossipBS == addr {
 			gossipBS = ln.Addr()
 		}
-		g.SetResolvers([]resolver.Resolver{resolver.NewResolverFromAddress(gossipBS)})
+		r, err := resolver.NewResolverFromAddress(gossipBS)
+		if err != nil {
+			t.Fatalf("bad gossip address %s: %s", gossipBS, err)
+		}
+		g.SetResolvers([]resolver.Resolver{r})
 		g.Start(rpcServer, ln.Addr(), stopper)
 	}
 	ctx.Gossip = g
@@ -171,7 +175,7 @@ func TestBootstrapNewStore(t *testing.T) {
 		engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper),
 		engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper),
 	}
-	_, _, node, stopper := createAndStartTestNode(util.CreateTestAddr("tcp"), engines, nil, t)
+	_, _, node, stopper := createAndStartTestNode(util.CreateTestAddr("tcp"), engines, util.CreateTestAddr("tcp"), t)
 	defer stopper.Stop()
 
 	// Non-initialized stores (in this case the new in-memory-based

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -93,7 +93,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	sCtx.Gossip = gossip.New(rpcContext, gossip.TestBootstrap)
 	sCtx.Gossip.SetNodeID(nodeDesc.NodeID)
 	sCtx.Tracer = tracer.NewTracer(nil, "testing")
-	localSender := storage.NewStores()
+	localSender := storage.NewStores(clock)
 	rpcSend := func(_ rpc.Options, _ string, _ []net.Addr,
 		getArgs func(addr net.Addr) proto.Message, _ func() proto.Message,
 		_ *rpc.Context) ([]proto.Message, error) {
@@ -215,7 +215,7 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	}
 
 	// Always create the first sender.
-	m.senders = append(m.senders, storage.NewStores())
+	m.senders = append(m.senders, storage.NewStores(m.clock))
 
 	if m.db == nil {
 		m.distSender = kv.NewDistSender(&kv.DistSenderContext{
@@ -417,7 +417,7 @@ func (m *multiTestContext) addStore() {
 	store.WaitForInit()
 	m.stores = append(m.stores, store)
 	if len(m.senders) == idx {
-		m.senders = append(m.senders, storage.NewStores())
+		m.senders = append(m.senders, storage.NewStores(clock))
 	}
 	m.senders[idx].AddStore(store)
 	if err := gossipNodeDesc(m.gossip, nodeID); err != nil {

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -551,9 +551,9 @@ func mvccGetMetadata(iter Iterator, metaKey MVCCKey,
 	}
 
 	meta.Reset()
-	// For values, the size of keys is always account for as
-	// mvccVersionTimestampSize. The size of the metadata key is accounted for
-	// separately.
+	// For values, the size of keys is always accounted for as
+	// mvccVersionTimestampSize. The size of the metadata key is
+	// accounted for separately.
 	meta.KeyBytes = mvccVersionTimestampSize
 	meta.ValBytes = int64(len(iter.unsafeValue()))
 	meta.Deleted = len(iter.unsafeValue()) == 0

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -485,7 +485,7 @@ class DBPrefixExtractor : public rocksdb::SliceTransform {
   // MVCC keys are encoded as <user-key>/<timestamp>. Extract the <user-key>
   // prefix which will allow for more efficient iteration over the keys
   // matching a particular <user-key>. Specifically, the <user-key> will be
-  // added to the per table bloom filters and will this be able to skip tables
+  // added to the per table bloom filters and will be used to skip tables
   // which do not contain the <user-key>.
   virtual rocksdb::Slice Transform(const rocksdb::Slice& src) const {
     rocksdb::Slice key;

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -55,16 +55,15 @@ const (
 	// it may be aborted by conflicting txns.
 	DefaultHeartbeatInterval = 5 * time.Second
 
-	// clusterIDGossipTTL is time-to-live for cluster ID. The cluster ID
-	// serves as the sentinel gossip key which informs a node whether or
-	// not it's connected to the primary gossip network and not just a
-	// partition. As such it must expire on a reasonable basis and be
-	// continually re-gossiped. The replica which is the raft leader of
-	// the first range gossips it.
-	clusterIDGossipTTL = 2 * time.Minute
-	// clusterIDGossipInterval is the approximate interval at which the
+	// sentinelGossipTTL is time-to-live for the gossip sentinel. The
+	// sentinel informs a node whether or not it's connected to the
+	// primary gossip network and not just a partition. As such it must
+	// expire on a reasonable basis and be continually re-gossiped. The
+	// replica which is the raft leader of the first range gossips it.
+	sentinelGossipTTL = 2 * time.Minute
+	// sentinalGossipInterval is the approximate interval at which the
 	// sentinel info is gossiped.
-	clusterIDGossipInterval = clusterIDGossipTTL / 2
+	sentinelGossipInterval = sentinelGossipTTL / 2
 
 	// configGossipTTL is the time-to-live for configuration maps.
 	configGossipTTL = 0 // does not expire
@@ -1548,17 +1547,18 @@ func (r *Replica) maybeGossipFirstRange() error {
 	if err == nil && bytes != nil {
 		gossipClusterID := string(bytes)
 		if gossipClusterID != r.store.ClusterID() {
-			log.Fatalc(ctx, "store %d belongs to cluster %s, but attemp to join cluster %s via gossip",
+			log.Fatalc(ctx, "store %d belongs to cluster %s, but attempted to join cluster %s via gossip",
 				r.store.StoreID(), r.store.ClusterID(), gossipClusterID)
 		}
 	}
 
-	// Gossip the cluster ID from all replicas of the first range.
+	// Gossip the cluster ID from all replicas of the first range; there
+	// is no expiration on the cluster ID.
 	if log.V(1) {
 		log.Infoc(ctx, "gossiping cluster id %s from store %d, range %d", r.store.ClusterID(),
 			r.store.StoreID(), r.Desc().RangeID)
 	}
-	if err := r.store.Gossip().AddInfo(gossip.KeyClusterID, []byte(r.store.ClusterID()), clusterIDGossipTTL); err != nil {
+	if err := r.store.Gossip().AddInfo(gossip.KeyClusterID, []byte(r.store.ClusterID()), 0*time.Second); err != nil {
 		log.Errorc(ctx, "failed to gossip cluster ID: %s", err)
 	}
 	if ok, err := r.getLeaseForGossip(ctx); !ok || err != nil {
@@ -1567,7 +1567,7 @@ func (r *Replica) maybeGossipFirstRange() error {
 	if log.V(1) {
 		log.Infoc(ctx, "gossiping sentinel from store %d, range %d", r.store.StoreID(), desc.RangeID)
 	}
-	if err := r.store.Gossip().AddInfo(gossip.KeySentinel, []byte(r.store.ClusterID()), clusterIDGossipTTL); err != nil {
+	if err := r.store.Gossip().AddInfo(gossip.KeySentinel, []byte(r.store.ClusterID()), sentinelGossipTTL); err != nil {
 		log.Errorc(ctx, "failed to gossip sentinel: %s", err)
 	}
 	if log.V(1) {

--- a/storage/store.go
+++ b/storage/store.go
@@ -615,7 +615,7 @@ func (s *Store) startGossip() {
 			log.Warningc(ctx, "error gossiping first range data: %s", err)
 		}
 		s.initComplete.Done()
-		ticker := time.NewTicker(clusterIDGossipInterval)
+		ticker := time.NewTicker(sentinelGossipInterval)
 		defer ticker.Stop()
 		for {
 			select {
@@ -655,7 +655,7 @@ func (s *Store) startGossip() {
 // loop in the event that the returned error indicates that the state
 // of the leader lease is not known. This can happen on lease command
 // timeouts. The retry loop makes sure we try hard to keep asking for
-// the lease instead of waiting for the next clusterIDGossipInterval
+// the lease instead of waiting for the next sentinelGossipInterval
 // to transpire.
 func (s *Store) maybeGossipFirstRange() error {
 	retryOptions := retry.Options{
@@ -790,7 +790,7 @@ func (s *Store) Bootstrap(ident roachpb.StoreIdent, stopper *stop.Stopper) error
 	s.Ident = ident
 	kvs, err := engine.Scan(s.engine,
 		engine.MakeMVCCMetadataKey(roachpb.Key(roachpb.RKeyMin)),
-		engine.MakeMVCCMetadataKey(roachpb.Key(roachpb.RKeyMax)), 1)
+		engine.MakeMVCCMetadataKey(roachpb.Key(roachpb.RKeyMax)), 10)
 	if err != nil {
 		return util.Errorf("store %s: unable to access: %s", s.engine, err)
 	} else if len(kvs) > 0 {
@@ -802,7 +802,11 @@ func (s *Store) Bootstrap(ident roachpb.StoreIdent, stopper *stop.Stopper) error
 		if ok {
 			return util.Errorf("store %s already belongs to cockroach cluster %s", s.engine, s.Ident.ClusterID)
 		}
-		return util.Errorf("store %s is not-empty and has invalid contents (first key: %q)", s.engine, kvs[0].Key)
+		keyVals := []string{}
+		for _, kv := range kvs {
+			keyVals = append(keyVals, fmt.Sprintf("%s: %q", kv.Key, kv.Value))
+		}
+		return util.Errorf("store %s is non-empty but does not contain store metadata (first %d key/values: %s)", s.engine, len(keyVals), keyVals)
 	}
 	err = engine.MVCCPutProto(s.engine, nil, keys.StoreIdentKey(), roachpb.ZeroTimestamp, nil, &s.Ident)
 	return err

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -23,25 +23,39 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/tracer"
 )
 
-// A Stores provides methods to access a collection of local stores.
+// A Stores provides methods to access a collection of stores. There's
+// a visitor pattern and also an implementation of the client.Sender
+// interface which directs a call to the appropriate store based on
+// the call's key range. Stores also implements the gossip.Persistence
+// interface, which allows gossip bootstrap information to be
+// persisted consistently to every store and the most recent bootstrap
+// information to be read at node startup.
 type Stores struct {
-	mu       sync.RWMutex               // Protects storeMap and addrs
-	storeMap map[roachpb.StoreID]*Store // Map from StoreID to Store
+	clock      *hlc.Clock
+	mu         sync.RWMutex               // Protects storeMap and addrs
+	storeMap   map[roachpb.StoreID]*Store // Map from StoreID to Store
+	gossipBI   gossip.BootstrapInfo       // The latest gossip bootstrap info
+	biLatestTS roachpb.Timestamp          // Timestamp of gossip bootstrap info
 }
 
-var _ client.Sender = &Stores{}
+var _ client.Sender = &Stores{}      // Stores implements the client.Sender interface
+var _ gossip.Persistence = &Stores{} // Stores implements the gossip.Persistence interface
 
 // NewStores returns a local-only sender which directly accesses
 // a collection of stores.
-func NewStores() *Stores {
+func NewStores(clock *hlc.Clock) *Stores {
 	return &Stores{
+		clock:    clock,
 		storeMap: map[roachpb.StoreID]*Store{},
 	}
 }
@@ -78,9 +92,16 @@ func (ls *Stores) AddStore(s *Store) {
 	ls.mu.Lock()
 	defer ls.mu.Unlock()
 	if _, ok := ls.storeMap[s.Ident.StoreID]; ok {
-		panic(fmt.Sprintf("cannot add store twice to local db: %+v", s.Ident))
+		panic(fmt.Sprintf("cannot add store twice: %+v", s.Ident))
 	}
 	ls.storeMap[s.Ident.StoreID] = s
+	// If we've already read the gossip bootstrap info, ensure that
+	// all stores have the most recent values.
+	if !ls.biLatestTS.Equal(roachpb.ZeroTimestamp) {
+		if err := ls.updateAllBootstrapInfos(); err != nil {
+			log.Errorf("failed to update bootstrap info on stores: %s", err)
+		}
+	}
 }
 
 // RemoveStore removes the specified store from the store map.
@@ -224,4 +245,76 @@ func (ls *Stores) RangeLookup(key roachpb.RKey, _ *roachpb.RangeDescriptor, cons
 		return nil, pErr.GoError()
 	}
 	return br.Responses[0].GetInner().(*roachpb.RangeLookupResponse).Ranges, nil
+}
+
+// ReadBootstrapInfo implements the gossip.Persistence interface. Read
+// attempts to read gossip bootstrap info from every known store and
+// finds the most recent from all stores to initialize the bootstrap
+// info argument. Returns nil if no stores contain gossip bootstrap
+// metadata or an error on any issues reading data from the stores.
+func (ls *Stores) ReadBootstrapInfo(bi *gossip.BootstrapInfo) error {
+	ls.biLatestTS = roachpb.ZeroTimestamp
+	for _, s := range ls.storeMap {
+		value, _, err := engine.MVCCGet(s.engine, keys.StoreGossipKey(), ls.clock.Now(), true, nil)
+		if err != nil {
+			return err
+		}
+		if value != nil && ls.biLatestTS.Less(value.Timestamp) {
+			var storeBI gossip.BootstrapInfo
+			if err := value.GetProto(&storeBI); err != nil {
+				return err
+			}
+			ls.biLatestTS = value.Timestamp
+			ls.gossipBI = storeBI
+		}
+	}
+	*bi = copyBootstrapInfo(ls.gossipBI)
+	return ls.updateAllBootstrapInfos()
+}
+
+// WriteBootstrapInfo implements the gossip.Persistence
+// interface. Write persists the supplied bootstrap info to every
+// known store. Returns nil on success; otherwise returns first error
+// encountered writing to the stores.
+func (ls *Stores) WriteBootstrapInfo(bi gossip.BootstrapInfo) error {
+	ls.biLatestTS = ls.clock.Now()
+	ls.gossipBI = copyBootstrapInfo(bi)
+	for _, s := range ls.storeMap {
+		if err := engine.MVCCPutProto(s.engine, nil, keys.StoreGossipKey(), ls.biLatestTS, nil, &ls.gossipBI); err != nil {
+			return err
+		}
+		log.Infof("wrote gossip bootstrap info to %s", s)
+	}
+	return nil
+}
+
+// updateAllBootstrapInfos cycles through all stores and ensures that
+// the most recent gossip bootstrap information is written to each.
+func (ls *Stores) updateAllBootstrapInfos() error {
+	if ls.biLatestTS.Equal(roachpb.ZeroTimestamp) {
+		return nil
+	}
+	now := ls.clock.Now()
+	for _, s := range ls.storeMap {
+		value, _, err := engine.MVCCGet(s.engine, keys.StoreGossipKey(), now, true, nil)
+		if err != nil {
+			return err
+		}
+		if value == nil || value.Timestamp.Less(ls.biLatestTS) {
+			if err := engine.MVCCPutProto(s.engine, nil, keys.StoreGossipKey(), ls.biLatestTS, nil, &ls.gossipBI); err != nil {
+				return err
+			}
+			log.Infof("wrote gossip bootstrap info to %s", s)
+		}
+	}
+	return nil
+}
+
+// copyBootstrapInfo creates a new instance of bootstrap info, with a
+// duplicate slice for the addresses.
+func copyBootstrapInfo(bi gossip.BootstrapInfo) gossip.BootstrapInfo {
+	var copyBI gossip.BootstrapInfo
+	copyBI.Addresses = make([]util.UnresolvedAddr, len(bi.Addresses), len(bi.Addresses))
+	copy(copyBI.Addresses, bi.Addresses)
+	return copyBI
 }

--- a/storage/stores_test.go
+++ b/storage/stores_test.go
@@ -210,8 +210,8 @@ func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores,
 	return manualClock, stores, ls, stopper
 }
 
-// TestStoresPersistence verifies reading and writing of bootstrap info.
-func TestStoresPersistence(t *testing.T) {
+// TestStoresGossipStorage verifies reading and writing of bootstrap info.
+func TestStoresGossipStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	manual, stores, ls, stopper := createStores(2, t)
 	defer stopper.Stop()
@@ -231,7 +231,7 @@ func TestStoresPersistence(t *testing.T) {
 	// Add a fake address and write.
 	manual.Increment(1)
 	bi.Addresses = append(bi.Addresses, util.MakeUnresolvedAddr("tcp", "127.0.0.1:8001"))
-	if err := ls.WriteBootstrapInfo(bi); err != nil {
+	if err := ls.WriteBootstrapInfo(&bi); err != nil {
 		t.Fatal(err)
 	}
 
@@ -260,9 +260,9 @@ func TestStoresPersistence(t *testing.T) {
 	}
 }
 
-// TestStoresPersistenceReadLatest verifies that the latest bootstrap
-// info from multiple stores is returned on Read.
-func TestStoresBootstrapInfoReadLatest(t *testing.T) {
+// TestStoresGossipStorageReadLatest verifies that the latest
+// bootstrap info from multiple stores is returned on Read.
+func TestStoresGossipStorageReadLatest(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	manual, stores, ls, stopper := createStores(2, t)
 	defer stopper.Stop()
@@ -274,7 +274,7 @@ func TestStoresBootstrapInfoReadLatest(t *testing.T) {
 	// Add a fake address and write.
 	var bi gossip.BootstrapInfo
 	bi.Addresses = append(bi.Addresses, util.MakeUnresolvedAddr("tcp", "127.0.0.1:8001"))
-	if err := ls.WriteBootstrapInfo(bi); err != nil {
+	if err := ls.WriteBootstrapInfo(&bi); err != nil {
 		t.Fatal(err)
 	}
 
@@ -285,7 +285,7 @@ func TestStoresBootstrapInfoReadLatest(t *testing.T) {
 	// Increment clock, add another address and write.
 	manual.Increment(1)
 	bi.Addresses = append(bi.Addresses, util.MakeUnresolvedAddr("tcp", "127.0.0.1:8002"))
-	if err := ls.WriteBootstrapInfo(bi); err != nil {
+	if err := ls.WriteBootstrapInfo(&bi); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/stores_test.go
+++ b/storage/stores_test.go
@@ -21,8 +21,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -30,7 +32,7 @@ import (
 
 func TestStoresAddStore(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	ls := NewStores()
+	ls := NewStores(hlc.NewClock(hlc.UnixNano))
 	store := Store{}
 	ls.AddStore(&store)
 	if !ls.HasStore(store.Ident.StoreID) {
@@ -43,7 +45,7 @@ func TestStoresAddStore(t *testing.T) {
 
 func TestStoresRemoveStore(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	ls := NewStores()
+	ls := NewStores(hlc.NewClock(hlc.UnixNano))
 
 	storeID := roachpb.StoreID(89)
 
@@ -58,7 +60,7 @@ func TestStoresRemoveStore(t *testing.T) {
 
 func TestStoresGetStoreCount(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	ls := NewStores()
+	ls := NewStores(hlc.NewClock(hlc.UnixNano))
 	if ls.GetStoreCount() != 0 {
 		t.Errorf("expected 0 stores in new local sender")
 	}
@@ -74,7 +76,7 @@ func TestStoresGetStoreCount(t *testing.T) {
 
 func TestStoresVisitStores(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	ls := NewStores()
+	ls := NewStores(hlc.NewClock(hlc.UnixNano))
 	numStores := 10
 	for i := 0; i < numStores; i++ {
 		ls.AddStore(&Store{Ident: roachpb.StoreIdent{StoreID: roachpb.StoreID(i)}})
@@ -100,7 +102,7 @@ func TestStoresVisitStores(t *testing.T) {
 
 func TestStoresGetStore(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	ls := NewStores()
+	ls := NewStores(hlc.NewClock(hlc.UnixNano))
 	store := Store{}
 	replica := roachpb.ReplicaDescriptor{StoreID: store.Ident.StoreID}
 	s, err := ls.GetStore(replica.StoreID)
@@ -127,7 +129,7 @@ func TestStoresLookupReplica(t *testing.T) {
 	ctx := TestStoreContext
 	manualClock := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manualClock.UnixNano)
-	ls := NewStores()
+	ls := NewStores(ctx.Clock)
 
 	// Create two new stores with ranges we care about.
 	var e [2]engine.Engine
@@ -181,5 +183,135 @@ func TestStoresLookupReplica(t *testing.T) {
 
 	if desc, err := ls.FirstRange(); err != nil || !reflect.DeepEqual(desc, d[0]) {
 		t.Fatalf("first range not as expected: error=%v, desc=%+v", err, desc)
+	}
+}
+
+var storeIDAlloc roachpb.StoreID
+
+// createStores creates a slice of count stores.
+func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores, *stop.Stopper) {
+	stopper := stop.NewStopper()
+	ctx := TestStoreContext
+	manualClock := hlc.NewManualClock(0)
+	ctx.Clock = hlc.NewClock(manualClock.UnixNano)
+	ls := NewStores(ctx.Clock)
+
+	// Create two stores with ranges we care about.
+	stores := []*Store{}
+	for i := 0; i < 2; i++ {
+		ctx.Transport = NewLocalRPCTransport(stopper)
+		defer ctx.Transport.Close()
+		s := NewStore(ctx, engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper), &roachpb.NodeDescriptor{NodeID: 1})
+		storeIDAlloc++
+		s.Ident.StoreID = storeIDAlloc
+		stores = append(stores, s)
+	}
+
+	return manualClock, stores, ls, stopper
+}
+
+// TestStoresPersistence verifies reading and writing of bootstrap info.
+func TestStoresPersistence(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	manual, stores, ls, stopper := createStores(2, t)
+	defer stopper.Stop()
+	ls.AddStore(stores[0])
+
+	manual.Set(1)
+
+	// Verify initial read is empty.
+	var bi gossip.BootstrapInfo
+	if err := ls.ReadBootstrapInfo(&bi); err != nil {
+		t.Fatal(err)
+	}
+	if len(bi.Addresses) != 0 {
+		t.Errorf("expected empty bootstrap info: %+v", bi)
+	}
+
+	// Add a fake address and write.
+	manual.Increment(1)
+	bi.Addresses = append(bi.Addresses, util.MakeUnresolvedAddr("tcp", "127.0.0.1:8001"))
+	if err := ls.WriteBootstrapInfo(bi); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify on read.
+	manual.Increment(1)
+	var newBI gossip.BootstrapInfo
+	if err := ls.ReadBootstrapInfo(&newBI); err != nil {
+		t.Fatal(err)
+	}
+	if len(newBI.Addresses) != 1 {
+		t.Errorf("expected single bootstrap info address: %+v", newBI)
+	}
+
+	// Add another store and verify it has bootstrap info written.
+	ls.AddStore(stores[1])
+
+	// Create a new stores object to verify read.
+	ls2 := NewStores(ls.clock)
+	ls2.AddStore(stores[1])
+	var verifyBI gossip.BootstrapInfo
+	if err := ls2.ReadBootstrapInfo(&verifyBI); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(bi, verifyBI) {
+		t.Errorf("bootstrap info %+v not equal to expected %+v", verifyBI, bi)
+	}
+}
+
+// TestStoresPersistenceReadLatest verifies that the latest bootstrap
+// info from multiple stores is returned on Read.
+func TestStoresBootstrapInfoReadLatest(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	manual, stores, ls, stopper := createStores(2, t)
+	defer stopper.Stop()
+	ls.AddStore(stores[0])
+
+	// Set clock to 1.
+	manual.Set(1)
+
+	// Add a fake address and write.
+	var bi gossip.BootstrapInfo
+	bi.Addresses = append(bi.Addresses, util.MakeUnresolvedAddr("tcp", "127.0.0.1:8001"))
+	if err := ls.WriteBootstrapInfo(bi); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now remove store 0 and add store 1.
+	ls.RemoveStore(stores[0])
+	ls.AddStore(stores[1])
+
+	// Increment clock, add another address and write.
+	manual.Increment(1)
+	bi.Addresses = append(bi.Addresses, util.MakeUnresolvedAddr("tcp", "127.0.0.1:8002"))
+	if err := ls.WriteBootstrapInfo(bi); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new stores object to freshly read. Should get latest
+	// version from store 1.
+	manual.Increment(1)
+	ls2 := NewStores(ls.clock)
+	ls2.AddStore(stores[0])
+	ls2.AddStore(stores[1])
+	var verifyBI gossip.BootstrapInfo
+	if err := ls2.ReadBootstrapInfo(&verifyBI); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(bi, verifyBI) {
+		t.Errorf("bootstrap info %+v not equal to expected %+v", verifyBI, bi)
+	}
+
+	// Verify that stores[0], which had old info, was updated with
+	// latest bootstrap info during the read.
+	ls3 := NewStores(ls.clock)
+	ls3.AddStore(stores[0])
+	verifyBI.Reset()
+	if err := ls2.ReadBootstrapInfo(&verifyBI); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(bi, verifyBI) {
+		t.Errorf("bootstrap info %+v not equal to expected %+v", verifyBI, bi)
 	}
 }

--- a/util/log/logflags/logflags.go
+++ b/util/log/logflags/logflags.go
@@ -65,7 +65,7 @@ func InitFlags(mu sync.Locker, toStderr *bool, alsoToStderr *bool, logDir, color
 	flag.Var(verbosity, "verbosity", "log level for V logs")
 	// TODO(tschottdorf): decide if we need this.
 	// pf.Var(&logging.stderrThreshold, "log-threshold", "logs at or above this threshold go to stderr")
-	flag.Var(vmodule, "vmodule", "comma-separated list of file=N settings for file-filtered logging")
+	flag.Var(vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
 	flag.Var(traceLocation, "log-backtrace-at", "when logging hits line file:N, emit a stack trace")
 	flag.StringVar(logDir, "log-dir", "", "if non-empty, write log files in this directory") // in util/log/file.go
 


### PR DESCRIPTION
This change stores gossip hosts in a new BootstrapInfo protobuf
message persistently on every store managed by a node. This allows
a node to be brought up without specifying the --gossip flag,
assuming of course that there are still extant nodes in the cluster
from the last time the node was active.

Miscellaneous logging fixes for clarity.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3711)

<!-- Reviewable:end -->
