### PR TITLE
Move Store test helpers to a _test.go file.

### DIFF
--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -14,15 +14,12 @@
 //
 // Author: Tamir Duberstein (tamird@gmail.com)
 
-package storage
+// This file includes test-only helper methods added to types in
+// package storage. These methods are only linked in to tests in this
+// directory (but may be used from tests in both package storage and
+// package storage_test).
 
-// WaitForInit waits for any asynchronous processes begun in Start()
-// to complete their initialization. In particular, this includes
-// gossiping. In some cases this may block until the range GC queue
-// has completed its scan. Only for testing.
-func (s *Store) WaitForInit() {
-	s.initComplete.Wait()
-}
+package storage
 
 // ForceReplicationScan iterates over all ranges and enqueues any that
 // need to be replicated. Exposed only for testing.

--- a/storage/store.go
+++ b/storage/store.go
@@ -593,6 +593,14 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 	return nil
 }
 
+// WaitForInit waits for any asynchronous processes begun in Start()
+// to complete their initialization. In particular, this includes
+// gossiping. In some cases this may block until the range GC queue
+// has completed its scan. Only for testing.
+func (s *Store) WaitForInit() {
+	s.initComplete.Wait()
+}
+
 // startGossip runs an infinite loop in a goroutine which regularly checks
 // whether the store has a first range or config replica and asks those ranges
 // to gossip accordingly.


### PR DESCRIPTION
This ensures that they are only linked in for tests, and only for
tests in the storage directory (which includes both storage and
storage_test packages).

Move WaitForInit back to store.go, since it is used for tests
in the server package.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3718)

<!-- Reviewable:end -->
