### PR TITLE
sql: support valargs for bin ops

### DIFF
--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -60,6 +60,7 @@ var (
 	intervalType  = reflect.TypeOf(DummyInterval)
 	tupleType     = reflect.TypeOf(dummyTuple)
 	nullType      = reflect.TypeOf(DNull)
+	valargType    = reflect.TypeOf(DValArg{})
 )
 
 // A Datum holds either a bool, int64, float64, string or []Datum.

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -59,6 +59,18 @@ func (expr *BinaryExpr) TypeCheck(args MapArgs) (Datum, error) {
 	expr.ltype = reflect.TypeOf(dummyLeft)
 	expr.rtype = reflect.TypeOf(dummyRight)
 
+	if expr.ltype == valargType {
+		if _, err := args.setInferredType(dummyLeft, dummyRight); err != nil {
+			return nil, err
+		}
+		expr.ltype = expr.rtype
+	} else if expr.rtype == valargType {
+		if _, err := args.setInferredType(dummyRight, dummyLeft); err != nil {
+			return nil, err
+		}
+		expr.rtype = expr.ltype
+	}
+
 	var ok bool
 	if expr.fn, ok = binOps[binArgs{expr.Operator, expr.ltype, expr.rtype}]; ok {
 		return expr.fn.returnType, nil


### PR DESCRIPTION
This adds support for any binary operation where both sides can be the
same type (like numbers). It doesn't work for dates, since date addition
doesn't make sense.

Fixes #3628

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3724)

<!-- Reviewable:end -->
