### PR TITLE
Ensure gossip callbacks are run in order.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"fmt"
 	"sort"
 
@@ -115,6 +116,18 @@ func ObjectIDForKey(key roachpb.RKey) (uint32, bool) {
 	// Consume first encoded int.
 	_, id64, err := encoding.DecodeUvarint(key)
 	return uint32(id64), err == nil
+}
+
+// Hash returns a SHA1 hash of the SystemConfig contents.
+func (s SystemConfig) Hash() []byte {
+	sha := sha1.New()
+	for _, kv := range s.Values {
+		_, _ = sha.Write(kv.Key)
+		// There are all kinds of different types here, so we can't use the typed
+		// getters.
+		_, _ = sha.Write(kv.Value.RawBytes)
+	}
+	return sha.Sum(nil)
 }
 
 // GetValue searches the kv list for 'key' and returns its

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -52,6 +52,10 @@ type infoStore struct {
 	NodeAddr  util.UnresolvedAddr `json:"-"`               // Address of node owning this info store: "host:port"
 	nodes     map[int32]*Node     // Per-node information for gossip peers
 	callbacks []*callback
+
+	callbackMu     sync.Mutex // Serializes callbacks
+	callbackWorkMu sync.Mutex // Protects callbackWork
+	callbackWork   []func()
 }
 
 var monoTime struct {
@@ -101,8 +105,8 @@ func (is *infoStore) String() string {
 }
 
 // newInfoStore allocates and returns a new infoStore.
-func newInfoStore(nodeID roachpb.NodeID, nodeAddr util.UnresolvedAddr) infoStore {
-	return infoStore{
+func newInfoStore(nodeID roachpb.NodeID, nodeAddr util.UnresolvedAddr) *infoStore {
+	return &infoStore{
 		Infos:    make(infoMap),
 		NodeID:   nodeID,
 		NodeAddr: nodeAddr,
@@ -237,10 +241,33 @@ func (is *infoStore) processCallbacks(key string, content roachpb.Value) {
 		}
 	}
 
-	// Run callbacks in a goroutine to avoid mutex reentry.
-	go func() {
+	// Add the matching callbacks to the callback work list.
+	f := func() {
 		for _, method := range matches {
 			method(key, content)
+		}
+	}
+	is.callbackWorkMu.Lock()
+	is.callbackWork = append(is.callbackWork, f)
+	is.callbackWorkMu.Unlock()
+
+	// Run callbacks in a goroutine to avoid mutex reentry. We also guarantee
+	// callbacks are run in order such that if a key is updated twice in
+	// succession, the second callback will never be run before the first.
+	go func() {
+		// Grab the callback mutex to prevent another goroutine from invoking
+		// callbacks.
+		is.callbackMu.Lock()
+		defer is.callbackMu.Unlock()
+
+		// Grab and execute the list of work.
+		is.callbackWorkMu.Lock()
+		work := is.callbackWork
+		is.callbackWork = nil
+		is.callbackWorkMu.Unlock()
+
+		for _, w := range work {
+			w()
 		}
 	}()
 }

--- a/gossip/infostore_test.go
+++ b/gossip/infostore_test.go
@@ -168,7 +168,7 @@ func TestAddInfoSameKeyDifferentHops(t *testing.T) {
 }
 
 // Helper method creates an infostore with 10 infos.
-func createTestInfoStore(t *testing.T) infoStore {
+func createTestInfoStore(t *testing.T) *infoStore {
 	is := newInfoStore(1, emptyAddr)
 
 	for i := 0; i < 10; i++ {

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -44,7 +44,7 @@ type clientInfo struct {
 // newly arrived information on a periodic basis.
 type server struct {
 	mu       sync.Mutex                // Protects the fields below
-	is       infoStore                 // The backing infostore
+	is       *infoStore                // The backing infostore
 	closed   bool                      // True if server was closed
 	incoming nodeSet                   // Incoming client node IDs
 	lAddrMap map[string]clientInfo     // Incoming client's local address -> client's node info


### PR DESCRIPTION
This showed up in TestGetZoneConfig where back-to-back callbacks for the
system config were reordered causing the newer config to be called back
first and then for the older config to overwrite it. We could have fixed
the problem for system configs by changing `Gossip.updateSystemConfig`
to retrieve the most recent info from the `infoStore`. Enforcing
callback ordering seems like a safer solution for other users of the
gossip callbacks as well.

Fixes #3697.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3727)

<!-- Reviewable:end -->
