### PR TITLE
Write the different parts of raft.Ready in a single batch.

### DIFF
--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -39,7 +39,6 @@ import (
 // independent keys, while nodes are being killed and restarted continuously.
 // The test measures not write performance, but cluster recovery.
 func TestChaos(t *testing.T) {
-	t.Skip("#3640")
 	c := StartCluster(t)
 	defer c.AssertAndStop(t)
 

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -102,7 +102,6 @@ func hasClusterID(infos map[string]interface{}) error {
 }
 
 func TestGossipPeerings(t *testing.T) {
-	t.Skip("#3611")
 	c := StartCluster(t)
 	defer c.AssertAndStop(t)
 	num := c.NumNodes()
@@ -141,7 +140,6 @@ func TestGossipPeerings(t *testing.T) {
 // re-bootstrapped after a time when all nodes were down
 // simultaneously.
 func TestGossipRestart(t *testing.T) {
-	t.Skip("#3611")
 	// This already replicates the first range (in the local setup).
 	// The replication of the first range is important: as long as the
 	// first range only exists on one node, that node can trivially


### PR DESCRIPTION
If these writes are not atomic, then a crash in between them can leave
things in an inconsistent state resulting in panics on restart.

Fixes #3611
Fixes #3640

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3728)

<!-- Reviewable:end -->
