### PR TITLE
Move rangelog.event to system.rangelog.

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -226,11 +226,11 @@ func Example_ranges() {
 	// range ls
 	// /Min-"c" [1]
 	// 	0: node-id=1 store-id=1
-	// "c"-/Table/501 [4]
+	// "c"-/Table/11 [4]
 	// 	0: node-id=1 store-id=1
-	// /Table/501-/Table/502 [2]
+	// /Table/11-/Table/12 [2]
 	// 	0: node-id=1 store-id=1
-	// /Table/502-/Max [3]
+	// /Table/12-/Max [3]
 	// 	0: node-id=1 store-id=1
 	// 4 result(s)
 	// kv scan
@@ -247,11 +247,11 @@ func Example_ranges() {
 	// 4 result(s)
 	// range merge b
 	// range ls
-	// /Min-/Table/501 [1]
+	// /Min-/Table/11 [1]
 	// 	0: node-id=1 store-id=1
-	// /Table/501-/Table/502 [2]
+	// /Table/11-/Table/12 [2]
 	// 	0: node-id=1 store-id=1
-	// /Table/502-/Max [3]
+	// /Table/12-/Max [3]
 	// 	0: node-id=1 store-id=1
 	// 3 result(s)
 	// kv scan

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -374,8 +374,8 @@ func TestCommonMethods(t *testing.T) {
 		key{txnType, "RunWithResponse"}:           {},
 		key{txnType, "SetDebugName"}:              {},
 		key{txnType, "SetIsolation"}:              {},
-		key{txnType, "SetSystemDBTrigger"}:        {},
-		key{txnType, "SystemDBTrigger"}:           {},
+		key{txnType, "SetSystemConfigTrigger"}:    {},
+		key{txnType, "SystemConfigTrigger"}:       {},
 	}
 
 	for b := range blacklist {

--- a/config/config.go
+++ b/config/config.go
@@ -296,20 +296,20 @@ func (s SystemConfig) ComputeSplitKeys(startKey, endKey roachpb.RKey) []roachpb.
 		return nil
 	}
 
-	tableStart := roachpb.RKey(keys.ReservedTableDataMin)
+	tableStart := roachpb.RKey(keys.SystemConfigTableDataMax)
 	if !tableStart.Less(endKey) {
 		// This range is before the user tables span: no required splits.
 		return nil
 	}
 
 	startID, ok := ObjectIDForKey(startKey)
-	if !ok || startID <= keys.MaxSystemDescID {
+	if !ok || startID <= keys.MaxSystemConfigDescID {
 		// The start key is either:
 		// - not part of the structured data span
 		// - part of the system span
 		// In either case, start looking for splits at the first ID usable
 		// by the user data span.
-		startID = keys.MaxSystemDescID + 1
+		startID = keys.MaxSystemConfigDescID + 1
 	} else {
 		// The start key is either already a split key, or after the split
 		// key for its ID. We can skip straight to the next one.

--- a/docs/RFCS/schema_gossip.md
+++ b/docs/RFCS/schema_gossip.md
@@ -14,7 +14,7 @@ In order to support performant SQL queries, each gateway node must be able to ad
 
 # Detailed design
 
-The entire `keys.SystemDBSpan` span will have its writes bifurcated into gossip (with a TTL TBD) in the same way that `storage.(*Replica).maybeGossipConfigs()` works today. The gossip system will provide atomicity in propagating these modifications through the usual sequence number mechanism.
+The entire `keys.SystemConfigSpan` span will have its writes bifurcated into gossip (with a TTL TBD) in the same way that `storage.(*Replica).maybeGossipConfigs()` works today. The gossip system will provide atomicity in propagating these modifications through the usual sequence number mechanism.
 
 Complete propagation of new metadata will take at most `numHops * gossipInterval` where `numHops` is the maximum number of hops between any node and the publishing node, and `gossipInterval` is the maximum interval between sequential writes to the gossip network on a given node.
 

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -167,9 +167,8 @@ var (
 	// TableDataMin is the end of the range of table data keys.
 	TableDataMax = roachpb.Key(encoding.EncodeVarint(nil, math.MaxInt64))
 
-	// ReservedTableDataMin is the start key of reserved structured data
-	// (excluding SystemDB).
-	ReservedTableDataMin = roachpb.Key(MakeTablePrefix(MaxSystemDescID + 1))
+	// SystemConfigTableDataMax is the end key of system config structured data.
+	SystemConfigTableDataMax = roachpb.Key(MakeTablePrefix(MaxSystemConfigDescID + 1))
 
 	// UserTableDataMin is the start key of user structured data.
 	UserTableDataMin = roachpb.Key(MakeTablePrefix(MaxReservedDescID + 1))
@@ -183,34 +182,25 @@ var (
 // Various IDs used by the structured data layer.
 // NOTE: these must not change during the lifetime of a cluster.
 const (
-	// MaxSystemDescID is the maximum value of the system IDs under
-	// 'TableDataPrefix'. Reserved objects with IDs in this range are considered
-	// "system" objects and have considerable special semantics.
-	//
-	// TODO: There is quite a bit of disagreement over the best way to handle
-	// the special semantics needed by these tables; in particular, there is
-	// considerable hesitance to use multiple reserved ranges to hold tables
-	// which require different levels of special support. For the immediate
-	// moment we are using multiple reserved ranges, but that may not be the
-	// case in the near future. Active discussion on github issue #3444:
-	// https://github.com/cockroachdb/cockroach/issues/3444
-	MaxSystemDescID = 500
+	// MaxSystemConfigDescID is the maximum system descriptor ID that will be
+	// gossiped as part of the SystemConfig. Be careful adding new descriptors to
+	// this ID range.
+	MaxSystemConfigDescID = 10
 
-	// MaxReservedDescID is the maximum value of reserved descriptor IDs
-	// under 'TableDataPrefix'. Reserved IDs are used by namespaces and tables
-	// used internally by cockroach.
-	MaxReservedDescID = 999
+	// MaxReservedDescID is the maximum value of reserved descriptor
+	// IDs. Reserved IDs are used by namespaces and tables used internally by
+	// cockroach.
+	MaxReservedDescID = 49
 
 	// RootNamespaceID is the ID of the root namespace.
 	RootNamespaceID = 0
 
 	// SystemDatabaseID and following are the database/table IDs for objects
 	// in the system span.
-	// NOTE: IDs should remain <= MaxSystemDescID.
+	// NOTE: IDs should remain <= MaxSystemConfigDescID.
 	SystemDatabaseID  = 1
 	NamespaceTableID  = 2
 	DescriptorTableID = 3
-	LeaseTableID      = 4
-	UsersTableID      = 5
-	ZonesTableID      = 6
+	UsersTableID      = 4
+	ZonesTableID      = 5
 )

--- a/keys/printer_test.go
+++ b/keys/printer_test.go
@@ -65,7 +65,7 @@ func TestPrettyPrint(t *testing.T) {
 		{SystemMax, "/System/Max"},
 
 		// table
-		{UserTableDataMin, "/Table/1000"},
+		{UserTableDataMin, "/Table/50"},
 		{MakeTablePrefix(111), "/Table/111"},
 		{MakeKey(MakeTablePrefix(42), roachpb.RKey("foo")), `/Table/42/"foo"`},
 		{MakeKey(MakeTablePrefix(42), roachpb.RKey(encoding.EncodeFloat(nil, float64(233.221112)))), "/Table/42/233.221112"},

--- a/keys/spans.go
+++ b/keys/spans.go
@@ -25,11 +25,11 @@ var (
 	// UserDataSpan is the non-meta and non-structured portion of the key space.
 	UserDataSpan = roachpb.Span{Key: SystemMax, EndKey: TableDataMin}
 
-	// SystemDBSpan is the range of system objects for structured data.
-	SystemDBSpan = roachpb.Span{Key: TableDataMin, EndKey: ReservedTableDataMin}
+	// SystemConfigSpan is the range of system objects which will be gossiped.
+	SystemConfigSpan = roachpb.Span{Key: TableDataMin, EndKey: SystemConfigTableDataMax}
 
 	// NoSplitSpans describes the ranges that should never be split.
 	// Meta1Span: needed to find other ranges.
-	// SystemDBSpan: system objects have interdepencies.
-	NoSplitSpans = []roachpb.Span{Meta1Span, SystemDBSpan}
+	// SystemConfigSpan: system objects which will be gossiped.
+	NoSplitSpans = []roachpb.Span{Meta1Span, SystemConfigSpan}
 )

--- a/roachpb/data.pb.go
+++ b/roachpb/data.pb.go
@@ -315,7 +315,7 @@ func (*ChangeReplicasTrigger) ProtoMessage()    {}
 // ModifiedSpanTrigger indicates that a specific span has been modified.
 // This can be used to trigger scan-and-gossip for the given span.
 type ModifiedSpanTrigger struct {
-	SystemDBSpan bool `protobuf:"varint,1,opt,name=system_db_span" json:"system_db_span"`
+	SystemConfigSpan bool `protobuf:"varint,1,opt,name=system_config_span" json:"system_config_span"`
 }
 
 func (m *ModifiedSpanTrigger) Reset()         { *m = ModifiedSpanTrigger{} }
@@ -775,7 +775,7 @@ func (m *ModifiedSpanTrigger) MarshalTo(data []byte) (int, error) {
 	_ = l
 	data[i] = 0x8
 	i++
-	if m.SystemDBSpan {
+	if m.SystemConfigSpan {
 		data[i] = 1
 	} else {
 		data[i] = 0
@@ -2280,7 +2280,7 @@ func (m *ModifiedSpanTrigger) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field SystemDBSpan", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field SystemConfigSpan", wireType)
 			}
 			var v int
 			for shift := uint(0); ; shift += 7 {
@@ -2297,7 +2297,7 @@ func (m *ModifiedSpanTrigger) Unmarshal(data []byte) error {
 					break
 				}
 			}
-			m.SystemDBSpan = bool(v != 0)
+			m.SystemConfigSpan = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipData(data[iNdEx:])

--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -151,7 +151,7 @@ message ChangeReplicasTrigger {
 // ModifiedSpanTrigger indicates that a specific span has been modified.
 // This can be used to trigger scan-and-gossip for the given span.
 message ModifiedSpanTrigger {
-  optional bool system_db_span = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "SystemDBSpan"];
+  optional bool system_config_span = 1 [(gogoproto.nullable) = false];
 }
 
 // InternalCommitTrigger encapsulates all of the internal-only commit triggers.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -486,7 +486,7 @@ func TestSQLServer(t *testing.T) {
 	}
 }
 
-func TestSystemDBGossip(t *testing.T) {
+func TestSystemConfigGossip(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	s := StartTestServer(t)
 	defer s.Stop()
@@ -526,9 +526,9 @@ func TestSystemDBGossip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// This time mark the transaction as having a SystemDB trigger.
+	// This time mark the transaction as having a Gossip trigger.
 	if err := db.Txn(func(txn *client.Txn) error {
-		txn.SetSystemDBTrigger()
+		txn.SetSystemConfigTrigger()
 		return txn.Put(key, valAt(2))
 	}); err != nil {
 		t.Fatal(err)

--- a/sql/config_test.go
+++ b/sql/config_test.go
@@ -52,7 +52,7 @@ func forceNewConfig(t *testing.T, s *server.TestServer) (*config.SystemConfig, e
 
 	// This needs to be done in a transaction with the system trigger set.
 	if err := s.DB().Txn(func(txn *client.Txn) error {
-		txn.SetSystemDBTrigger()
+		txn.SetSystemConfigTrigger()
 		return txn.Put(configDescKey, configDesc)
 	}); err != nil {
 		t.Fatal(err)

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -106,9 +106,9 @@ func (p *planner) Delete(n *parser.Delete) (planNode, error) {
 		return nil, err
 	}
 
-	if IsSystemID(tableDesc.GetID()) {
+	if isSystemConfigID(tableDesc.GetID()) {
 		// Mark transaction as operating on the system DB.
-		p.txn.SetSystemDBTrigger()
+		p.txn.SetSystemConfigTrigger()
 	}
 	if err := p.txn.Run(&b); err != nil {
 		return nil, err

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -193,8 +193,8 @@ func (e *Executor) ExecuteStatements(user string, session Session, stmts string,
 	if planMaker.session.Txn != nil {
 		txn := client.NewTxn(e.db)
 		txn.Proto = planMaker.session.Txn.Txn
-		if planMaker.session.MutatesSystemDB {
-			txn.SetSystemDBTrigger()
+		if planMaker.session.MutatesSystemConfig {
+			txn.SetSystemConfigTrigger()
 		}
 		planMaker.setTxn(txn, planMaker.session.Txn.Timestamp.GoTime())
 	}
@@ -214,10 +214,10 @@ func (e *Executor) ExecuteStatements(user string, session Session, stmts string,
 			Txn:       planMaker.txn.Proto,
 			Timestamp: driver.Timestamp(planMaker.evalCtx.TxnTimestamp.Time),
 		}
-		planMaker.session.MutatesSystemDB = planMaker.txn.SystemDBTrigger()
+		planMaker.session.MutatesSystemConfig = planMaker.txn.SystemConfigTrigger()
 	} else {
 		planMaker.session.Txn = nil
-		planMaker.session.MutatesSystemDB = false
+		planMaker.session.MutatesSystemConfig = false
 	}
 	bytes, err := proto.Marshal(&planMaker.session)
 	if err != nil {

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -232,9 +232,9 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, error) {
 		return nil, err
 	}
 
-	if IsSystemID(tableDesc.GetID()) {
+	if isSystemConfigID(tableDesc.GetID()) {
 		// Mark transaction as operating on the system DB.
-		p.txn.SetSystemDBTrigger()
+		p.txn.SetSystemConfigTrigger()
 	}
 
 	if autoCommit {

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -268,7 +268,7 @@ func (s LeaseStore) Publish(tableID ID, update func(*TableDescriptor) error) err
 			// Write the updated descriptor.
 			b := txn.NewBatch()
 			b.Put(descKey, desc)
-			txn.SetSystemDBTrigger()
+			txn.SetSystemConfigTrigger()
 			return txn.CommitInBatch(b)
 		})
 

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -32,6 +32,13 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
+const (
+	// TODO(peter): This is ugly. All system tables should have static IDs. There
+	// isn't much point in dynamically allocating IDs for system tables and it
+	// makes tests either more complex or more fragile.
+	leaseTableID = keys.MaxSystemConfigDescID + 1
+)
+
 type leaseTest struct {
 	*testing.T
 	server *server.TestServer
@@ -142,7 +149,7 @@ func TestLeaseManager(testingT *testing.T) {
 	t := newLeaseTest(testingT)
 	defer t.cleanup()
 
-	const descID = keys.LeaseTableID
+	const descID = leaseTableID
 
 	// We can't acquire a lease on a non-existent table.
 	expected := "table ID 10000 not found"
@@ -235,7 +242,7 @@ func TestLeaseManagerReacquire(testingT *testing.T) {
 	t := newLeaseTest(testingT)
 	defer t.cleanup()
 
-	const descID = keys.LeaseTableID
+	const descID = leaseTableID
 
 	// Acquire 2 leases from the same node. They should point to the same lease
 	// structure.
@@ -282,7 +289,7 @@ func TestLeaseManagerPublishVersionChanged(testingT *testing.T) {
 	t := newLeaseTest(testingT)
 	defer t.cleanup()
 
-	const descID = keys.LeaseTableID
+	const descID = leaseTableID
 
 	// Start two goroutines that are concurrently trying to publish a new version
 	// of the descriptor. The first goroutine progresses to the update function

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -62,19 +62,20 @@ func checkEndTransactionTrigger(_ roachpb.StoreID, req roachpb.Request, _ roachp
 	}
 
 	modifiedSpanTrigger := args.InternalCommitTrigger.GetModifiedSpanTrigger()
-	modifiedSystemSpan := modifiedSpanTrigger != nil && modifiedSpanTrigger.SystemDBSpan
+	modifiedSystemConfigSpan := modifiedSpanTrigger != nil && modifiedSpanTrigger.SystemConfigSpan
 
 	var hasSystemKey bool
 	for _, span := range args.IntentSpans {
 		addr := keys.Addr(span.Key)
-		if bytes.Compare(addr, keys.SystemDBSpan.Key) >= 0 && bytes.Compare(addr, keys.SystemDBSpan.EndKey) < 0 {
+		if bytes.Compare(addr, keys.SystemConfigSpan.Key) >= 0 &&
+			bytes.Compare(addr, keys.SystemConfigSpan.EndKey) < 0 {
 			hasSystemKey = true
 			break
 		}
 	}
-	if hasSystemKey != modifiedSystemSpan {
-		return util.Errorf("EndTransaction hasSystemKey=%t, but hasSystemDBTrigger=%t",
-			hasSystemKey, modifiedSystemSpan)
+	if hasSystemKey != modifiedSystemConfigSpan {
+		return util.Errorf("EndTransaction hasSystemKey=%t, but hasSystemConfigTrigger=%t",
+			hasSystemKey, modifiedSystemConfigSpan)
 	}
 
 	return nil

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -81,7 +81,7 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, er
 	// where the table already exists. This will generate some false
 	// refreshes, but that's expected to be quite rare in practice.
 	if stmt.StatementType() == parser.DDL {
-		p.txn.SetSystemDBTrigger()
+		p.txn.SetSystemConfigTrigger()
 	}
 
 	switch n := stmt.(type) {

--- a/sql/privilege.go
+++ b/sql/privilege.go
@@ -189,7 +189,7 @@ func (p *PrivilegeDescriptor) Validate(id ID) error {
 	if !ok {
 		return fmt.Errorf("user %s does not have privileges", security.RootUser)
 	}
-	if IsSystemID(id) {
+	if isSystemConfigID(id) {
 		// System databases and tables have custom maximum allowed privileges.
 		objectPrivileges, ok := SystemAllowedPrivileges[id]
 		if !ok {

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -90,7 +90,7 @@ func (sc *SchemaChanger) createSchemaChangeLease() TableDescriptor_SchemaChangeL
 func (sc *SchemaChanger) AcquireLease() (TableDescriptor_SchemaChangeLease, error) {
 	var lease TableDescriptor_SchemaChangeLease
 	err := sc.db.Txn(func(txn *client.Txn) error {
-		txn.SetSystemDBTrigger()
+		txn.SetSystemConfigTrigger()
 		tableDesc, err := getTableDescFromID(txn, sc.tableID)
 		if err != nil {
 			return err
@@ -136,7 +136,7 @@ func (sc *SchemaChanger) ReleaseLease(lease TableDescriptor_SchemaChangeLease) e
 			return err
 		}
 		tableDesc.Lease = nil
-		txn.SetSystemDBTrigger()
+		txn.SetSystemConfigTrigger()
 		return txn.Put(MakeDescMetadataKey(tableDesc.ID), wrapDescriptor(tableDesc))
 	})
 }
@@ -150,7 +150,7 @@ func (sc *SchemaChanger) ExtendLease(lease TableDescriptor_SchemaChangeLease) (T
 		}
 		lease = sc.createSchemaChangeLease()
 		tableDesc.Lease = &lease
-		txn.SetSystemDBTrigger()
+		txn.SetSystemConfigTrigger()
 		return txn.Put(MakeDescMetadataKey(tableDesc.ID), wrapDescriptor(tableDesc))
 	})
 	return lease, err

--- a/sql/session.pb.go
+++ b/sql/session.pb.go
@@ -25,8 +25,8 @@ type Session struct {
 	// Open transaction.
 	Txn *Session_Transaction `protobuf:"bytes,3,opt,name=txn" json:"txn,omitempty"`
 	// Indicates that the above transaction is mutating keys in the
-	// SystemDB span.
-	MutatesSystemDB bool `protobuf:"varint,4,opt,name=mutates_system_db" json:"mutates_system_db"`
+	// SystemConfig span.
+	MutatesSystemConfig bool `protobuf:"varint,4,opt,name=mutates_system_config" json:"mutates_system_config"`
 	// Types that are valid to be assigned to Timezone:
 	//	*Session_Location
 	//	*Session_Offset
@@ -170,7 +170,7 @@ func (m *Session) MarshalTo(data []byte) (int, error) {
 	}
 	data[i] = 0x20
 	i++
-	if m.MutatesSystemDB {
+	if m.MutatesSystemConfig {
 		data[i] = 1
 	} else {
 		data[i] = 0
@@ -427,7 +427,7 @@ func (m *Session) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 4:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field MutatesSystemDB", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field MutatesSystemConfig", wireType)
 			}
 			var v int
 			for shift := uint(0); ; shift += 7 {
@@ -444,7 +444,7 @@ func (m *Session) Unmarshal(data []byte) error {
 					break
 				}
 			}
-			m.MutatesSystemDB = bool(v != 0)
+			m.MutatesSystemConfig = bool(v != 0)
 		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Location", wireType)

--- a/sql/session.proto
+++ b/sql/session.proto
@@ -34,8 +34,8 @@ message Session {
   // Open transaction.
   optional Transaction txn = 3;
   // Indicates that the above transaction is mutating keys in the
-  // SystemDB span.
-  optional bool mutates_system_db = 4 [(gogoproto.nullable) = false, (gogoproto.customname) = "MutatesSystemDB"];
+  // SystemConfig span.
+  optional bool mutates_system_config = 4 [(gogoproto.nullable) = false];
   oneof timezone {
     // A time zone; LOCAL or DEFAULT imply UTC.
     string location = 5;

--- a/sql/system.go
+++ b/sql/system.go
@@ -79,9 +79,6 @@ var (
 	// DescriptorTable is the descriptor for the descriptor table.
 	DescriptorTable = createSystemTable(keys.DescriptorTableID, descriptorTableSchema)
 
-	// LeaseTable is the descriptor for the lease table.
-	LeaseTable = createSystemTable(keys.LeaseTableID, leaseTableSchema)
-
 	// UsersTable is the descriptor for the users table.
 	UsersTable = createSystemTable(keys.UsersTableID, usersTableSchema)
 
@@ -96,7 +93,6 @@ var (
 		keys.SystemDatabaseID:  privilege.ReadData,
 		keys.NamespaceTableID:  privilege.ReadData,
 		keys.DescriptorTableID: privilege.ReadData,
-		keys.LeaseTableID:      privilege.ReadWriteData,
 		keys.UsersTableID:      privilege.ReadWriteData,
 		keys.ZonesTableID:      privilege.ReadWriteData,
 	}
@@ -147,15 +143,18 @@ func addSystemDatabaseToSchema(target *MetadataSchema) {
 	// Add system database.
 	target.AddSystemDescriptor(keys.RootNamespaceID, &SystemDB)
 
-	// Add system tables.
+	// Add system config tables.
 	target.AddSystemDescriptor(keys.SystemDatabaseID, &NamespaceTable)
 	target.AddSystemDescriptor(keys.SystemDatabaseID, &DescriptorTable)
-	target.AddSystemDescriptor(keys.SystemDatabaseID, &LeaseTable)
 	target.AddSystemDescriptor(keys.SystemDatabaseID, &UsersTable)
 	target.AddSystemDescriptor(keys.SystemDatabaseID, &ZonesTable)
+
+	// Add other system tables.
+	target.AddTable(leaseTableSchema,
+		NewPrivilegeDescriptor(security.RootUser, privilege.List{privilege.ALL}))
 }
 
-// IsSystemID returns true if this ID is reserved for system objects.
-func IsSystemID(id ID) bool {
-	return id > 0 && id <= keys.MaxSystemDescID
+// isSystemConfigID returns true if this ID is reserved for system objects.
+func isSystemConfigID(id ID) bool {
+	return id > 0 && id <= keys.MaxSystemConfigDescID
 }

--- a/sql/system_test.go
+++ b/sql/system_test.go
@@ -33,14 +33,13 @@ func TestInitialKeys(t *testing.T) {
 	ms := sql.MakeMetadataSchema()
 	// IDGenerator + 2 for each system object in the default schema.
 	kv := ms.GetInitialValues()
-	if actual, expected := len(kv), 1+2*sql.NumSystemDescriptors; actual != expected {
+	if actual, expected := len(kv), 3+2*sql.NumSystemDescriptors; actual != expected {
 		t.Fatalf("Wrong number of initial sql kv pairs: %d, wanted %d", actual, expected)
 	}
 
-	// Add a non-system database and table.
-	db := sql.MakeMetadataDatabase("testdb", sql.NewPrivilegeDescriptor(security.RootUser, privilege.List{privilege.ALL}))
-	db.AddTable("CREATE TABLE testdb.x (val INTEGER PRIMARY KEY)", sql.NewPrivilegeDescriptor(security.RootUser, privilege.List{privilege.ALL}))
-	ms.AddDatabase(db)
+	// Add an additional table.
+	ms.AddTable("CREATE TABLE testdb.x (val INTEGER PRIMARY KEY)",
+		sql.NewPrivilegeDescriptor(security.RootUser, privilege.List{privilege.ALL}))
 	kv = ms.GetInitialValues()
 	// IDGenerator + 2 for each descriptor in the schema.
 	if actual, expected := len(kv), 1+2*ms.DescriptorCount(); actual != expected {

--- a/sql/testdata/database
+++ b/sql/testdata/database
@@ -15,7 +15,6 @@ SHOW DATABASES
 ----
 Database
 a
-rangelog
 system
 test
 
@@ -31,7 +30,6 @@ SHOW DATABASES
 a
 b
 c
-rangelog
 system
 test
 
@@ -69,7 +67,6 @@ SHOW DATABASES
 Database
 a
 c
-rangelog
 system
 test
 

--- a/sql/testdata/rename_database
+++ b/sql/testdata/rename_database
@@ -1,7 +1,6 @@
 query T
 SHOW DATABASES
 ----
-rangelog
 system
 test
 
@@ -40,7 +39,6 @@ SHOW GRANTS ON DATABASE test
 query T
 SHOW DATABASES
 ----
-rangelog
 system
 u
 
@@ -87,7 +85,6 @@ ALTER DATABASE t RENAME TO v
 query T
 SHOW DATABASES
 ----
-rangelog
 system
 t
 u

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -1,7 +1,6 @@
 query T
 SHOW DATABASES
 ----
-rangelog
 system
 test
 
@@ -11,34 +10,33 @@ SHOW TABLES FROM system
 descriptor
 lease
 namespace
+rangelog
 users
 zones
 
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM system.namespace
 ----
-0 /namespace/primary/0/'rangelog'/id   501  true
-1 /namespace/primary/0/'system'/id     1    true
-2 /namespace/primary/0/'test'/id       1000 true
-3 /namespace/primary/1/'descriptor'/id 3    true
-4 /namespace/primary/1/'lease'/id      4    true
-5 /namespace/primary/1/'namespace'/id  2    true
-6 /namespace/primary/1/'users'/id      5    true
-7 /namespace/primary/1/'zones'/id      6    true
-8 /namespace/primary/501/'event'/id    502  true
+0 /namespace/primary/0/'system'/id     1    true
+1 /namespace/primary/0/'test'/id       50   true
+2 /namespace/primary/1/'descriptor'/id 3    true
+3 /namespace/primary/1/'lease'/id      11   true
+4 /namespace/primary/1/'namespace'/id  2    true
+5 /namespace/primary/1/'rangelog'/id   12   true
+6 /namespace/primary/1/'users'/id      4    true
+7 /namespace/primary/1/'zones'/id      5    true
 
 query ITI
 SELECT * FROM system.namespace
 ----
-0 rangelog   501
 0 system     1
-0 test       1000
+0 test       50
 1 descriptor 3
-1 lease      4
+1 lease      11
 1 namespace  2
-1 users      5
-1 zones      6
-501 event    502
+1 rangelog   12
+1 users      4
+1 zones      5
 
 query I
 SELECT id FROM system.descriptor
@@ -48,10 +46,9 @@ SELECT id FROM system.descriptor
 3
 4
 5
-6
-501
-502
-1000
+11
+12
+50
 
 # Verify we can read "protobuf" columns.
 query I

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
@@ -61,6 +62,7 @@ func createSplitRanges(store *storage.Store) (*roachpb.RangeDescriptor, *roachpb
 // together.
 func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	defer config.TestingDisableTableSplits()()
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
 
@@ -88,6 +90,7 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 // subsumed range is cleaned up on merge.
 func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	defer config.TestingDisableTableSplits()()
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
 
@@ -165,10 +168,11 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 // each containing data.
 func TestStoreRangeMergeWithData(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	content := roachpb.Key("testing!")
-
+	defer config.TestingDisableTableSplits()()
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
+
+	content := roachpb.Key("testing!")
 
 	aDesc, bDesc, err := createSplitRanges(store)
 	if err != nil {

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -60,6 +61,7 @@ func mustGetInt(v *roachpb.Value) int64 {
 // after being stopped and recreated.
 func TestStoreRecoverFromEngine(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	defer config.TestingDisableTableSplits()()
 	rangeID := roachpb.RangeID(1)
 	splitKey := roachpb.Key("m")
 	key1 := roachpb.Key("a")

--- a/storage/client_range_tree_test.go
+++ b/storage/client_range_tree_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -193,6 +194,7 @@ func TestSetupRangeTree(t *testing.T) {
 // performs actual splits and merges.
 func TestTree(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	defer config.TestingDisableTableSplits()()
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
 	db := store.DB()

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
@@ -323,6 +324,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 // are correct when scanning in reverse order.
 func TestRangeLookupUseReverse(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	defer config.TestingDisableTableSplits()()
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
 

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1880,8 +1880,8 @@ func TestValidSplitKeys(t *testing.T) {
 		{roachpb.Key("a"), true},
 		{roachpb.Key("\xff"), true},
 		{roachpb.Key("\xff\x01"), true},
-		{roachpb.Key(keys.MakeTablePrefix(keys.MaxSystemDescID)), false},
-		{roachpb.Key(keys.MakeTablePrefix(keys.MaxSystemDescID + 1)), true},
+		{roachpb.Key(keys.MakeTablePrefix(keys.MaxSystemConfigDescID)), false},
+		{roachpb.Key(keys.MakeTablePrefix(keys.MaxSystemConfigDescID + 1)), true},
 	}
 
 	for i, test := range testCases {
@@ -1955,7 +1955,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 		{
 			keys: []roachpb.Key{
 				roachpb.Key(keys.MakeTablePrefix(1)),
-				roachpb.Key(keys.MakeTablePrefix(keys.MaxSystemDescID)),
+				roachpb.Key(keys.MakeTablePrefix(keys.MaxSystemConfigDescID)),
 			},
 			expSplit: nil,
 			expError: true,

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
@@ -215,7 +215,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
       -1);
   ModifiedSpanTrigger_descriptor_ = file->message_type(8);
   static const int ModifiedSpanTrigger_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ModifiedSpanTrigger, system_db_span_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ModifiedSpanTrigger, system_config_span_),
   };
   ModifiedSpanTrigger_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -460,50 +460,49 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
     "B\004\310\336\037\000\022D\n\020updated_replicas\030\003 \003(\0132$.cockr"
     "oach.roachpb.ReplicaDescriptorB\004\310\336\037\000\022;\n\017"
     "next_replica_id\030\004 \001(\005B\"\310\336\037\000\342\336\037\rNextRepli"
-    "caID\372\336\037\tReplicaID\"C\n\023ModifiedSpanTrigger"
-    "\022,\n\016system_db_span\030\001 \001(\010B\024\310\336\037\000\342\336\037\014System"
-    "DBSpan\"\237\002\n\025InternalCommitTrigger\0226\n\rspli"
-    "t_trigger\030\001 \001(\0132\037.cockroach.roachpb.Spli"
-    "tTrigger\0226\n\rmerge_trigger\030\002 \001(\0132\037.cockro"
-    "ach.roachpb.MergeTrigger\022I\n\027change_repli"
-    "cas_trigger\030\003 \001(\0132(.cockroach.roachpb.Ch"
-    "angeReplicasTrigger\022E\n\025modified_span_tri"
-    "gger\030\004 \001(\0132&.cockroach.roachpb.ModifiedS"
-    "panTrigger:\004\210\240\037\001\"\'\n\010NodeList\022\033\n\005nodes\030\001 "
-    "\003(\005B\014\020\001\372\336\037\006NodeID\"\362\004\n\013Transaction\022\022\n\004nam"
-    "e\030\001 \001(\tB\004\310\336\037\000\022\024\n\003key\030\002 \001(\014B\007\372\336\037\003Key\022\022\n\002i"
-    "d\030\003 \001(\014B\006\342\336\037\002ID\022\026\n\010priority\030\004 \001(\005B\004\310\336\037\000\022"
-    "9\n\tisolation\030\005 \001(\0162 .cockroach.roachpb.I"
-    "solationTypeB\004\310\336\037\000\022:\n\006status\030\006 \001(\0162$.coc"
-    "kroach.roachpb.TransactionStatusB\004\310\336\037\000\022\023"
-    "\n\005epoch\030\007 \001(\rB\004\310\336\037\000\0224\n\016last_heartbeat\030\010 "
-    "\001(\0132\034.cockroach.roachpb.Timestamp\0225\n\ttim"
-    "estamp\030\t \001(\0132\034.cockroach.roachpb.Timesta"
-    "mpB\004\310\336\037\000\022:\n\016orig_timestamp\030\n \001(\0132\034.cockr"
-    "oach.roachpb.TimestampB\004\310\336\037\000\0229\n\rmax_time"
-    "stamp\030\013 \001(\0132\034.cockroach.roachpb.Timestam"
-    "pB\004\310\336\037\000\0228\n\rcertain_nodes\030\014 \001(\0132\033.cockroa"
-    "ch.roachpb.NodeListB\004\310\336\037\000\022\025\n\007Writing\030\r \001"
-    "(\010B\004\310\336\037\000\022\026\n\010Sequence\030\016 \001(\rB\004\310\336\037\000\022.\n\007Inte"
-    "nts\030\017 \003(\0132\027.cockroach.roachpb.SpanB\004\310\336\037\000"
-    ":\004\230\240\037\000\"l\n\006Intent\022/\n\004span\030\001 \001(\0132\027.cockroa"
-    "ch.roachpb.SpanB\010\310\336\037\000\320\336\037\001\0221\n\003txn\030\002 \001(\0132\036"
-    ".cockroach.roachpb.TransactionB\004\310\336\037\000\"\265\001\n"
-    "\005Lease\0221\n\005start\030\001 \001(\0132\034.cockroach.roachp"
-    "b.TimestampB\004\310\336\037\000\0226\n\nexpiration\030\002 \001(\0132\034."
-    "cockroach.roachpb.TimestampB\004\310\336\037\000\022;\n\007rep"
-    "lica\030\003 \001(\0132$.cockroach.roachpb.ReplicaDe"
-    "scriptorB\004\310\336\037\000:\004\230\240\037\000\"a\n\022SequenceCacheEnt"
-    "ry\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 "
-    "\001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000*"
-    "Q\n\tValueType\022\013\n\007UNKNOWN\020\000\022\007\n\003INT\020\001\022\t\n\005FL"
-    "OAT\020\002\022\t\n\005BYTES\020\003\022\010\n\004TIME\020\004\022\016\n\nTIMESERIES"
-    "\020d*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000"
-    "\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationT"
-    "ype\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036"
-    "\000*B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tC"
-    "OMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\tZ\007roachpb"
-    "X\001", 2882);
+    "caID\372\336\037\tReplicaID\"7\n\023ModifiedSpanTrigger"
+    "\022 \n\022system_config_span\030\001 \001(\010B\004\310\336\037\000\"\237\002\n\025I"
+    "nternalCommitTrigger\0226\n\rsplit_trigger\030\001 "
+    "\001(\0132\037.cockroach.roachpb.SplitTrigger\0226\n\r"
+    "merge_trigger\030\002 \001(\0132\037.cockroach.roachpb."
+    "MergeTrigger\022I\n\027change_replicas_trigger\030"
+    "\003 \001(\0132(.cockroach.roachpb.ChangeReplicas"
+    "Trigger\022E\n\025modified_span_trigger\030\004 \001(\0132&"
+    ".cockroach.roachpb.ModifiedSpanTrigger:\004"
+    "\210\240\037\001\"\'\n\010NodeList\022\033\n\005nodes\030\001 \003(\005B\014\020\001\372\336\037\006N"
+    "odeID\"\362\004\n\013Transaction\022\022\n\004name\030\001 \001(\tB\004\310\336\037"
+    "\000\022\024\n\003key\030\002 \001(\014B\007\372\336\037\003Key\022\022\n\002id\030\003 \001(\014B\006\342\336\037"
+    "\002ID\022\026\n\010priority\030\004 \001(\005B\004\310\336\037\000\0229\n\tisolation"
+    "\030\005 \001(\0162 .cockroach.roachpb.IsolationType"
+    "B\004\310\336\037\000\022:\n\006status\030\006 \001(\0162$.cockroach.roach"
+    "pb.TransactionStatusB\004\310\336\037\000\022\023\n\005epoch\030\007 \001("
+    "\rB\004\310\336\037\000\0224\n\016last_heartbeat\030\010 \001(\0132\034.cockro"
+    "ach.roachpb.Timestamp\0225\n\ttimestamp\030\t \001(\013"
+    "2\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022:\n\016"
+    "orig_timestamp\030\n \001(\0132\034.cockroach.roachpb"
+    ".TimestampB\004\310\336\037\000\0229\n\rmax_timestamp\030\013 \001(\0132"
+    "\034.cockroach.roachpb.TimestampB\004\310\336\037\000\0228\n\rc"
+    "ertain_nodes\030\014 \001(\0132\033.cockroach.roachpb.N"
+    "odeListB\004\310\336\037\000\022\025\n\007Writing\030\r \001(\010B\004\310\336\037\000\022\026\n\010"
+    "Sequence\030\016 \001(\rB\004\310\336\037\000\022.\n\007Intents\030\017 \003(\0132\027."
+    "cockroach.roachpb.SpanB\004\310\336\037\000:\004\230\240\037\000\"l\n\006In"
+    "tent\022/\n\004span\030\001 \001(\0132\027.cockroach.roachpb.S"
+    "panB\010\310\336\037\000\320\336\037\001\0221\n\003txn\030\002 \001(\0132\036.cockroach.r"
+    "oachpb.TransactionB\004\310\336\037\000\"\265\001\n\005Lease\0221\n\005st"
+    "art\030\001 \001(\0132\034.cockroach.roachpb.TimestampB"
+    "\004\310\336\037\000\0226\n\nexpiration\030\002 \001(\0132\034.cockroach.ro"
+    "achpb.TimestampB\004\310\336\037\000\022;\n\007replica\030\003 \001(\0132$"
+    ".cockroach.roachpb.ReplicaDescriptorB\004\310\336"
+    "\037\000:\004\230\240\037\000\"a\n\022SequenceCacheEntry\022\024\n\003key\030\001 "
+    "\001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockro"
+    "ach.roachpb.TimestampB\004\310\336\037\000*Q\n\tValueType"
+    "\022\013\n\007UNKNOWN\020\000\022\007\n\003INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BYT"
+    "ES\020\003\022\010\n\004TIME\020\004\022\016\n\nTIMESERIES\020d*>\n\021Replic"
+    "aChangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_R"
+    "EPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERIA"
+    "LIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021Transac"
+    "tionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013"
+    "\n\007ABORTED\020\002\032\004\210\243\036\000B\tZ\007roachpbX\001", 2870);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/data.proto", &protobuf_RegisterTypes);
   Span::default_instance_ = new Span();
@@ -3857,7 +3856,7 @@ void ChangeReplicasTrigger::clear_next_replica_id() {
 // ===================================================================
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int ModifiedSpanTrigger::kSystemDbSpanFieldNumber;
+const int ModifiedSpanTrigger::kSystemConfigSpanFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ModifiedSpanTrigger::ModifiedSpanTrigger()
@@ -3879,7 +3878,7 @@ ModifiedSpanTrigger::ModifiedSpanTrigger(const ModifiedSpanTrigger& from)
 
 void ModifiedSpanTrigger::SharedCtor() {
   _cached_size_ = 0;
-  system_db_span_ = false;
+  system_config_span_ = false;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -3919,7 +3918,7 @@ ModifiedSpanTrigger* ModifiedSpanTrigger::New(::google::protobuf::Arena* arena) 
 }
 
 void ModifiedSpanTrigger::Clear() {
-  system_db_span_ = false;
+  system_config_span_ = false;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -3936,13 +3935,13 @@ bool ModifiedSpanTrigger::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional bool system_db_span = 1;
+      // optional bool system_config_span = 1;
       case 1: {
         if (tag == 8) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
-                 input, &system_db_span_)));
-          set_has_system_db_span();
+                 input, &system_config_span_)));
+          set_has_system_config_span();
         } else {
           goto handle_unusual;
         }
@@ -3975,9 +3974,9 @@ failure:
 void ModifiedSpanTrigger::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.roachpb.ModifiedSpanTrigger)
-  // optional bool system_db_span = 1;
-  if (has_system_db_span()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->system_db_span(), output);
+  // optional bool system_config_span = 1;
+  if (has_system_config_span()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->system_config_span(), output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3990,9 +3989,9 @@ void ModifiedSpanTrigger::SerializeWithCachedSizes(
 ::google::protobuf::uint8* ModifiedSpanTrigger::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.ModifiedSpanTrigger)
-  // optional bool system_db_span = 1;
-  if (has_system_db_span()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->system_db_span(), target);
+  // optional bool system_config_span = 1;
+  if (has_system_config_span()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->system_config_span(), target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -4006,8 +4005,8 @@ void ModifiedSpanTrigger::SerializeWithCachedSizes(
 int ModifiedSpanTrigger::ByteSize() const {
   int total_size = 0;
 
-  // optional bool system_db_span = 1;
-  if (has_system_db_span()) {
+  // optional bool system_config_span = 1;
+  if (has_system_config_span()) {
     total_size += 1 + 1;
   }
 
@@ -4037,8 +4036,8 @@ void ModifiedSpanTrigger::MergeFrom(const ::google::protobuf::Message& from) {
 void ModifiedSpanTrigger::MergeFrom(const ModifiedSpanTrigger& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_system_db_span()) {
-      set_system_db_span(from.system_db_span());
+    if (from.has_system_config_span()) {
+      set_system_config_span(from.system_config_span());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -4068,7 +4067,7 @@ void ModifiedSpanTrigger::Swap(ModifiedSpanTrigger* other) {
   InternalSwap(other);
 }
 void ModifiedSpanTrigger::InternalSwap(ModifiedSpanTrigger* other) {
-  std::swap(system_db_span_, other->system_db_span_);
+  std::swap(system_config_span_, other->system_config_span_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -4085,28 +4084,28 @@ void ModifiedSpanTrigger::InternalSwap(ModifiedSpanTrigger* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // ModifiedSpanTrigger
 
-// optional bool system_db_span = 1;
-bool ModifiedSpanTrigger::has_system_db_span() const {
+// optional bool system_config_span = 1;
+bool ModifiedSpanTrigger::has_system_config_span() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void ModifiedSpanTrigger::set_has_system_db_span() {
+void ModifiedSpanTrigger::set_has_system_config_span() {
   _has_bits_[0] |= 0x00000001u;
 }
-void ModifiedSpanTrigger::clear_has_system_db_span() {
+void ModifiedSpanTrigger::clear_has_system_config_span() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void ModifiedSpanTrigger::clear_system_db_span() {
-  system_db_span_ = false;
-  clear_has_system_db_span();
+void ModifiedSpanTrigger::clear_system_config_span() {
+  system_config_span_ = false;
+  clear_has_system_config_span();
 }
- bool ModifiedSpanTrigger::system_db_span() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.ModifiedSpanTrigger.system_db_span)
-  return system_db_span_;
+ bool ModifiedSpanTrigger::system_config_span() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ModifiedSpanTrigger.system_config_span)
+  return system_config_span_;
 }
- void ModifiedSpanTrigger::set_system_db_span(bool value) {
-  set_has_system_db_span();
-  system_db_span_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.ModifiedSpanTrigger.system_db_span)
+ void ModifiedSpanTrigger::set_system_config_span(bool value) {
+  set_has_system_config_span();
+  system_config_span_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ModifiedSpanTrigger.system_config_span)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
@@ -1075,22 +1075,22 @@ class ModifiedSpanTrigger : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional bool system_db_span = 1;
-  bool has_system_db_span() const;
-  void clear_system_db_span();
-  static const int kSystemDbSpanFieldNumber = 1;
-  bool system_db_span() const;
-  void set_system_db_span(bool value);
+  // optional bool system_config_span = 1;
+  bool has_system_config_span() const;
+  void clear_system_config_span();
+  static const int kSystemConfigSpanFieldNumber = 1;
+  bool system_config_span() const;
+  void set_system_config_span(bool value);
 
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.ModifiedSpanTrigger)
  private:
-  inline void set_has_system_db_span();
-  inline void clear_has_system_db_span();
+  inline void set_has_system_config_span();
+  inline void clear_has_system_config_span();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  bool system_db_span_;
+  bool system_config_span_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2fdata_2eproto();
@@ -2685,28 +2685,28 @@ inline void ChangeReplicasTrigger::set_next_replica_id(::google::protobuf::int32
 
 // ModifiedSpanTrigger
 
-// optional bool system_db_span = 1;
-inline bool ModifiedSpanTrigger::has_system_db_span() const {
+// optional bool system_config_span = 1;
+inline bool ModifiedSpanTrigger::has_system_config_span() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void ModifiedSpanTrigger::set_has_system_db_span() {
+inline void ModifiedSpanTrigger::set_has_system_config_span() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void ModifiedSpanTrigger::clear_has_system_db_span() {
+inline void ModifiedSpanTrigger::clear_has_system_config_span() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void ModifiedSpanTrigger::clear_system_db_span() {
-  system_db_span_ = false;
-  clear_has_system_db_span();
+inline void ModifiedSpanTrigger::clear_system_config_span() {
+  system_config_span_ = false;
+  clear_has_system_config_span();
 }
-inline bool ModifiedSpanTrigger::system_db_span() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.ModifiedSpanTrigger.system_db_span)
-  return system_db_span_;
+inline bool ModifiedSpanTrigger::system_config_span() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ModifiedSpanTrigger.system_config_span)
+  return system_config_span_;
 }
-inline void ModifiedSpanTrigger::set_system_db_span(bool value) {
-  set_has_system_db_span();
-  system_db_span_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.ModifiedSpanTrigger.system_db_span)
+inline void ModifiedSpanTrigger::set_system_config_span(bool value) {
+  set_has_system_config_span();
+  system_config_span_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ModifiedSpanTrigger.system_config_span)
 }
 
 // -------------------------------------------------------------------

--- a/storage/log.go
+++ b/storage/log.go
@@ -27,7 +27,7 @@ import (
 // schema.  Currently there is no useful information in this table; this is a
 // work in progress.
 const rangeEventTableSchema = `
-CREATE TABLE rangelog.event (
+CREATE TABLE system.rangelog (
   timestamp     TIMESTAMP  NOT NULL,
   rangeID       INT        NOT NULL,
   PRIMARY KEY (timestamp, rangeID)
@@ -37,7 +37,5 @@ CREATE TABLE rangelog.event (
 // MetadataSchema.
 func AddEventLogToMetadataSchema(schema *sql.MetadataSchema) {
 	allPrivileges := sql.NewPrivilegeDescriptor(security.RootUser, privilege.List{privilege.ALL})
-	db := sql.MakeMetadataDatabase("rangelog", allPrivileges)
-	db.AddTable(rangeEventTableSchema, allPrivileges)
-	schema.AddDatabase(db)
+	schema.AddTable(rangeEventTableSchema, allPrivileges)
 }

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -351,7 +351,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	if err := neverSplits.setDesc(&roachpb.RangeDescriptor{
 		RangeID:  1,
 		StartKey: roachpb.RKeyMin,
-		EndKey:   keys.Addr(keys.ReservedTableDataMin),
+		EndKey:   keys.Addr(keys.SystemConfigTableDataMax),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -360,7 +360,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	willSplit := &Replica{RangeID: 2}
 	if err := willSplit.setDesc(&roachpb.RangeDescriptor{
 		RangeID:  2,
-		StartKey: keys.Addr(keys.ReservedTableDataMin),
+		StartKey: keys.Addr(keys.SystemConfigTableDataMax),
 		EndKey:   roachpb.RKeyMax,
 	}); err != nil {
 		t.Fatal(err)

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -492,7 +492,7 @@ func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h ro
 				}
 			}
 			if ct.GetModifiedSpanTrigger() != nil {
-				if ct.ModifiedSpanTrigger.SystemDBSpan {
+				if ct.ModifiedSpanTrigger.SystemConfigSpan {
 					// Check if we need to gossip the system config.
 					batch.Defer(r.maybeGossipSystemConfig)
 				}
@@ -1193,7 +1193,7 @@ func (r *Replica) LeaderLease(batch engine.Engine, ms *engine.MVCCStats, h roach
 	}
 
 	// Gossip system config if this range includes the system span.
-	if r.ContainsKey(keys.SystemDBSpan.Key) {
+	if r.ContainsKey(keys.SystemConfigSpan.Key) {
 		r.maybeGossipSystemConfig()
 	}
 	return reply, nil

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -579,8 +579,8 @@ func TestRangeGossipConfigsOnLease(t *testing.T) {
 	rngDesc.Replicas = append(rngDesc.Replicas, secondReplica)
 	tc.rng.setDescWithoutProcessUpdate(rngDesc)
 
-	// Write some arbitrary data in the system span (up to, but not including MaxReservedID+1)
-	key := keys.MakeTablePrefix(keys.MaxSystemDescID)
+	// Write some arbitrary data in the system config span.
+	key := keys.MakeTablePrefix(keys.MaxSystemConfigDescID)
 	var val roachpb.Value
 	val.SetInt(42)
 	if err := engine.MVCCPut(tc.engine, nil, key, roachpb.MinTimestamp, val, nil); err != nil {
@@ -3480,27 +3480,27 @@ func TestBatchErrorWithIndex(t *testing.T) {
 
 }
 
-// TestReplicaLoadSystemDBSpanIntent verifies that intents on the SystemDBSpan
+// TestReplicaLoadSystemConfigSpanIntent verifies that intents on the SystemConfigSpan
 // cause an error, but trigger asynchronous cleanup.
-func TestReplicaLoadSystemDBSpanIntent(t *testing.T) {
+func TestReplicaLoadSystemConfigSpanIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()
-	rng := tc.store.LookupReplica(keys.Addr(keys.SystemDBSpan.Key), nil)
+	rng := tc.store.LookupReplica(keys.Addr(keys.SystemConfigSpan.Key), nil)
 	if rng == nil {
-		t.Fatalf("no replica contains the SystemDB span")
+		t.Fatalf("no replica contains the SystemConfig span")
 	}
 	v := roachpb.MakeValueFromString("foo")
 	// Create a transaction. We don't write a txn record, so pushing this will
 	// succeed and abort the intent we write here.
 	txn := newTransaction("test", []byte("a"), 1, roachpb.SERIALIZABLE, rng.store.Clock())
 	if err := engine.MVCCPut(rng.store.Engine(), &engine.MVCCStats{},
-		keys.SystemDBSpan.Key, rng.store.Clock().Now(), v, txn); err != nil {
+		keys.SystemConfigSpan.Key, rng.store.Clock().Now(), v, txn); err != nil {
 		t.Fatal(err)
 	}
-	// Verify that this trips up loading the SystemDB data.
-	if _, _, err := rng.loadSystemDBSpan(); err != errSystemDBIntent {
+	// Verify that this trips up loading the SystemConfig data.
+	if _, _, err := rng.loadSystemConfigSpan(); err != errSystemConfigIntent {
 		t.Fatal(err)
 	}
 
@@ -3508,17 +3508,17 @@ func TestReplicaLoadSystemDBSpanIntent(t *testing.T) {
 	// there and verify that we can now load the data as expected.
 	util.SucceedsWithin(t, time.Second, func() error {
 		if err := engine.MVCCPut(rng.store.Engine(), &engine.MVCCStats{},
-			keys.SystemDBSpan.Key, rng.store.Clock().Now(), v, nil); err != nil {
+			keys.SystemConfigSpan.Key, rng.store.Clock().Now(), v, nil); err != nil {
 			return err
 		}
 
-		kvs, _, err := rng.loadSystemDBSpan()
+		kvs, _, err := rng.loadSystemConfigSpan()
 		if err != nil {
 			return err
 		}
 
-		if len(kvs) != 1 || !bytes.Equal(kvs[0].Key, keys.SystemDBSpan.Key) {
-			return util.Errorf("expected only key %q in SystemDB map: %+v", keys.SystemDBSpan.Key, kvs)
+		if len(kvs) != 1 || !bytes.Equal(kvs[0].Key, keys.SystemConfigSpan.Key) {
+			return util.Errorf("expected only key %s in SystemConfigSpan map: %+v", keys.SystemConfigSpan.Key, kvs)
 		}
 		return nil
 	})

--- a/storage/store.go
+++ b/storage/store.go
@@ -678,10 +678,10 @@ func (s *Store) maybeGossipFirstRange() error {
 	return nil
 }
 
-// maybeGossipSystemConfig looks for the range containing SystemDB keys and
+// maybeGossipSystemConfig looks for the range containing SystemConfig keys and
 // lets that range gossip them.
 func (s *Store) maybeGossipSystemConfig() error {
-	rng := s.LookupReplica(roachpb.RKey(keys.SystemDBSpan.Key), nil)
+	rng := s.LookupReplica(roachpb.RKey(keys.SystemConfigSpan.Key), nil)
 	if rng == nil {
 		// This store has no range with this configuration.
 		return nil


### PR DESCRIPTION
Removed MetadataDatabase abstraction. Now all system tables are added to
the "system" database. The "system" database is just a namespace for
tables and does not connote whether the table contents are gossiped or
not. Gossiped tables are part of the "SystemConfig" span which is not
split. Replaced "SystemDB" with "SystemConfig" in various names to make
the distinction between "system" tables and "SystemConfig" tables
clearer.

Reworked the system table ID space. The first 10 IDs are reserved for
gossiped tables, of which there are now 5: systemDB, namespace,
descriptor, users and zones. The lease table is no longer gossiped. Took
the opportunity to shrink the reserved ID space to `[1-49]`.

A side-effect of moving the lease table out of the "SystemConfig" span
is that a new cluster now wants to split on the lease table at
startup. Sprinkled calls to `config.TestingDisableTableSplits()`
throughout the `storage` package which was not expecting such splits to
occur.

I apologize for the size of this commit. I did not have the time to make
it smaller.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3737)

<!-- Reviewable:end -->
