### PR TITLE
Minor portability fix: bash may not be in /bin.

### DIFF
--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/build/deplicense.sh
+++ b/build/deplicense.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Output the license info for the current directory's dependencies.
 #

--- a/build/depvers.sh
+++ b/build/depvers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Output the revision control version information (git/hg SHA) for the
 # current directory's dependencies. If multiple packages are contained


### PR DESCRIPTION
This patch leaves the docker scripts and ui Makefile out, as these are
only run from "conventional Linux" at this time.
- acceptance/run.sh,
- build/deplicense.sh,
- build/depvers.sh: Use `/usr/bin/env' to find bash. At least some
  Linux distros, Android and BSD may have it in`/usr/bin' or elsewhere.
  
  (This is what the git hooks do anyways.)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3744)

<!-- Reviewable:end -->
