### PR TITLE
Storage: Convert replica's and store's RWMutexes to Mutex

### DIFF
--- a/storage/client_raft_log_queue_test.go
+++ b/storage/client_raft_log_queue_test.go
@@ -56,9 +56,9 @@ func TestRaftLogQueue(t *testing.T) {
 	if raftLeaderRepl == nil {
 		t.Fatalf("could not find raft leader replica for range %d", rangeID)
 	}
-	raftLeaderRepl.RLock()
+	raftLeaderRepl.Lock()
 	originalIndex, err := raftLeaderRepl.FirstIndex()
-	raftLeaderRepl.RUnlock()
+	raftLeaderRepl.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,9 +83,9 @@ func TestRaftLogQueue(t *testing.T) {
 		// Ensure that firstIndex has increased indicating that the log
 		// truncation has occurred.
 		var err error
-		raftLeaderRepl.RLock()
+		raftLeaderRepl.Lock()
 		afterTruncationIndex, err = raftLeaderRepl.FirstIndex()
-		raftLeaderRepl.RUnlock()
+		raftLeaderRepl.Unlock()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -102,9 +102,9 @@ func TestRaftLogQueue(t *testing.T) {
 		store.ForceRaftLogScanAndProcess()
 	}
 
-	raftLeaderRepl.RLock()
+	raftLeaderRepl.Lock()
 	after2ndTruncationIndex, err := raftLeaderRepl.FirstIndex()
-	raftLeaderRepl.RUnlock()
+	raftLeaderRepl.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/client_raft_log_queue_test.go
+++ b/storage/client_raft_log_queue_test.go
@@ -56,9 +56,7 @@ func TestRaftLogQueue(t *testing.T) {
 	if raftLeaderRepl == nil {
 		t.Fatalf("could not find raft leader replica for range %d", rangeID)
 	}
-	raftLeaderRepl.Lock()
-	originalIndex, err := raftLeaderRepl.FirstIndex()
-	raftLeaderRepl.Unlock()
+	originalIndex, err := raftLeaderRepl.GetFirstIndex()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,9 +81,7 @@ func TestRaftLogQueue(t *testing.T) {
 		// Ensure that firstIndex has increased indicating that the log
 		// truncation has occurred.
 		var err error
-		raftLeaderRepl.Lock()
-		afterTruncationIndex, err = raftLeaderRepl.FirstIndex()
-		raftLeaderRepl.Unlock()
+		afterTruncationIndex, err = raftLeaderRepl.GetFirstIndex()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -102,9 +98,7 @@ func TestRaftLogQueue(t *testing.T) {
 		store.ForceRaftLogScanAndProcess()
 	}
 
-	raftLeaderRepl.Lock()
-	after2ndTruncationIndex, err := raftLeaderRepl.FirstIndex()
-	raftLeaderRepl.Unlock()
+	after2ndTruncationIndex, err := raftLeaderRepl.GetFirstIndex()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1027,9 +1027,9 @@ func TestRangeDescriptorSnapshotRace(t *testing.T) {
 				if rng == nil {
 					t.Fatal("failed to look up min range")
 				}
-				rng.RLock()
+				rng.Lock()
 				_, err := rng.Snapshot()
-				rng.RUnlock()
+				rng.Unlock()
 				if err != nil {
 					t.Fatalf("failed to snapshot min range: %s", err)
 				}
@@ -1038,9 +1038,9 @@ func TestRangeDescriptorSnapshotRace(t *testing.T) {
 				if rng == nil {
 					t.Fatal("failed to look up max range")
 				}
-				rng.RLock()
+				rng.Lock()
 				_, err = rng.Snapshot()
-				rng.RUnlock()
+				rng.Unlock()
 				if err != nil {
 					t.Fatalf("failed to snapshot max range: %s", err)
 				}

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1027,9 +1027,7 @@ func TestRangeDescriptorSnapshotRace(t *testing.T) {
 				if rng == nil {
 					t.Fatal("failed to look up min range")
 				}
-				rng.Lock()
-				_, err := rng.Snapshot()
-				rng.Unlock()
+				_, err := rng.GetSnapshot()
 				if err != nil {
 					t.Fatalf("failed to snapshot min range: %s", err)
 				}
@@ -1038,9 +1036,7 @@ func TestRangeDescriptorSnapshotRace(t *testing.T) {
 				if rng == nil {
 					t.Fatal("failed to look up max range")
 				}
-				rng.Lock()
-				_, err = rng.Snapshot()
-				rng.Unlock()
+				_, err = rng.GetSnapshot()
 				if err != nil {
 					t.Fatalf("failed to snapshot max range: %s", err)
 				}

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -24,9 +24,9 @@ package storage
 // ForceReplicationScan iterates over all ranges and enqueues any that
 // need to be replicated. Exposed only for testing.
 func (s *Store) ForceReplicationScan() {
-	s.Lock()
-	defer s.Unlock()
-	for _, r := range s.replicas {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, r := range s.mu.replicas {
 		s.replicateQueue.MaybeAdd(r, s.ctx.Clock.Now())
 	}
 }
@@ -40,11 +40,11 @@ func (s *Store) DisableReplicaGCQueue(disabled bool) {
 // ForceReplicaGCScanAndProcess iterates over all ranges and enqueues any that
 // may need to be GC'd. Exposed only for testing.
 func (s *Store) ForceReplicaGCScanAndProcess() {
-	s.Lock()
-	for _, r := range s.replicas {
+	s.mu.Lock()
+	for _, r := range s.mu.replicas {
 		s.replicaGCQueue.MaybeAdd(r, s.ctx.Clock.Now())
 	}
-	s.Unlock()
+	s.mu.Unlock()
 
 	s.replicaGCQueue.DrainQueue(s.ctx.Clock)
 }
@@ -59,32 +59,16 @@ func (s *Store) DisableRaftLogQueue(disabled bool) {
 // need their raft logs truncated and then process each of them.
 // Exposed only for testing.
 func (s *Store) ForceRaftLogScanAndProcess() {
-	// NB: This copy allows calling s.Unlock() before calling MaybeAdd, which
-	// is necessary to avoid deadlocks. Without it, a concurrent call to
-	// (*Store).Lock() will deadlock the system:
-	//
-	// (*Store).Lock()
-	//
-	// Start of (*Store).Lock() danger zone
-	//
-	// raftLogQueue.MaybeAdd
-	// raftLogQueue.shouldQueue
-	// getTruncatableIndexes
-	// (*Store).RaftStatus
-	//
-	// End of (*Store).Lock() danger zone
-	//
-	// (*Store).RLock()
-	//
-	// See http://play.golang.org/p/xTJiAiRfYf
-	replicas := make([]*Replica, 0, len(s.replicas))
-	s.Lock()
-	for _, r := range s.replicas {
+	// Gather the list of replicas to call MaybeAdd on to avoid locking the
+	// Mutex twice.
+	s.mu.Lock()
+	replicas := make([]*Replica, 0, len(s.mu.replicas))
+	for _, r := range s.mu.replicas {
 		replicas = append(replicas, r)
 	}
-	s.Unlock()
+	s.mu.Unlock()
 
-	// Add each range to the queue.
+	// Add each replica to the queue.
 	for _, r := range replicas {
 		s.raftLogQueue.MaybeAdd(r, s.ctx.Clock.Now())
 	}

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -89,8 +89,8 @@ func getTruncatableIndexes(r *Replica) (uint64, uint64, error) {
 		}
 	}
 
-	r.RLock()
-	defer r.RUnlock()
+	r.Lock()
+	defer r.Unlock()
 	firstIndex, err := r.FirstIndex()
 	if err != nil {
 		return 0, 0, util.Errorf("error retrieving first index for range %d: %s", rangeID, err)

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -89,8 +89,8 @@ func getTruncatableIndexes(r *Replica) (uint64, uint64, error) {
 		}
 	}
 
-	r.Lock()
-	defer r.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	firstIndex, err := r.FirstIndex()
 	if err != nil {
 		return 0, 0, util.Errorf("error retrieving first index for range %d: %s", rangeID, err)

--- a/storage/raft_log_queue_test.go
+++ b/storage/raft_log_queue_test.go
@@ -57,9 +57,9 @@ func TestGetTruncatableIndexes(t *testing.T) {
 		t.Error(err)
 	}
 
-	r.RLock()
+	r.Lock()
 	firstIndex, err := r.FirstIndex()
-	r.RUnlock()
+	r.Unlock()
 	if err != nil {
 		t.Error(err)
 	}
@@ -92,9 +92,9 @@ func TestGetTruncatableIndexes(t *testing.T) {
 	// before ForceRaftLogScanAndProcess but is still working on it.
 	stopper.Quiesce()
 
-	r.RLock()
+	r.Lock()
 	newFirstIndex, err := r.FirstIndex()
-	r.RUnlock()
+	r.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/raft_log_queue_test.go
+++ b/storage/raft_log_queue_test.go
@@ -57,9 +57,9 @@ func TestGetTruncatableIndexes(t *testing.T) {
 		t.Error(err)
 	}
 
-	r.Lock()
+	r.mu.Lock()
 	firstIndex, err := r.FirstIndex()
-	r.Unlock()
+	r.mu.Unlock()
 	if err != nil {
 		t.Error(err)
 	}
@@ -92,9 +92,9 @@ func TestGetTruncatableIndexes(t *testing.T) {
 	// before ForceRaftLogScanAndProcess but is still working on it.
 	stopper.Quiesce()
 
-	r.Lock()
+	r.mu.Lock()
 	newFirstIndex, err := r.FirstIndex()
-	r.Unlock()
+	r.mu.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/tracer"
 	"github.com/coreos/etcd/raft"
@@ -166,17 +167,18 @@ type Replica struct {
 	// RWMutex
 	readOnlyCmdMu sync.RWMutex
 
-	sync.Mutex                  // Protects the following fields:
-	cmdQ        *CommandQueue   // Enforce at most one command is running per key(s)
-	tsCache     *TimestampCache // Most recent timestamps for keys / key ranges
-	pendingSeq  uint64          // atomic sequence counter for cmdIDKey generation
-	pendingCmds map[cmdIDKey]*pendingCmd
-	desc        *roachpb.RangeDescriptor
-
 	truncatedState unsafe.Pointer // *roachpb.RaftTruncatedState
 
-	replicaID roachpb.ReplicaID
-	raftGroup *raft.RawNode
+	mu struct {
+		sync.Mutex                  // Protects all fields in the mu struct.
+		cmdQ        *CommandQueue   // Enforce at most one command is running per key(s)
+		tsCache     *TimestampCache // Most recent timestamps for keys / key ranges
+		pendingSeq  uint64          // atomic sequence counter for cmdIDKey generation
+		pendingCmds map[cmdIDKey]*pendingCmd
+		desc        *roachpb.RangeDescriptor
+		replicaID   roachpb.ReplicaID
+		raftGroup   *raft.RawNode
+	}
 }
 
 var _ client.Sender = &Replica{}
@@ -184,15 +186,12 @@ var _ client.Sender = &Replica{}
 // NewReplica initializes the replica using the given metadata.
 func NewReplica(desc *roachpb.RangeDescriptor, store *Store) (*Replica, error) {
 	r := &Replica{
-		store:       store,
-		cmdQ:        NewCommandQueue(),
-		tsCache:     NewTimestampCache(store.Clock()),
-		sequence:    NewSequenceCache(desc.RangeID),
-		pendingCmds: map[cmdIDKey]*pendingCmd{},
-		RangeID:     desc.RangeID,
+		store:    store,
+		sequence: NewSequenceCache(desc.RangeID),
+		RangeID:  desc.RangeID,
 	}
 
-	if err := r.newReplicaInner(desc); err != nil {
+	if err := r.newReplicaInner(desc, store.Clock()); err != nil {
 		return nil, err
 	}
 
@@ -208,9 +207,14 @@ func NewReplica(desc *roachpb.RangeDescriptor, store *Store) (*Replica, error) {
 	return r, nil
 }
 
-func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor) error {
-	r.Lock()
-	defer r.Unlock()
+func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor, clock *hlc.Clock) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.mu.cmdQ = NewCommandQueue()
+	r.mu.tsCache = NewTimestampCache(clock)
+	r.mu.pendingCmds = map[cmdIDKey]*pendingCmd{}
+
 	r.setDescWithoutProcessUpdateLocked(desc)
 
 	lastIndex, err := r.loadLastIndexLocked()
@@ -276,18 +280,18 @@ func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor) error {
 }
 
 func (r *Replica) setReplicaID(replicaID roachpb.ReplicaID) error {
-	r.Lock()
-	defer r.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.setReplicaIDLocked(replicaID)
 }
 
 // setReplicaIDLocked requires that the replica lock is held.
 func (r *Replica) setReplicaIDLocked(replicaID roachpb.ReplicaID) error {
-	if r.replicaID == replicaID {
+	if r.mu.replicaID == replicaID {
 		return nil
-	} else if r.replicaID > replicaID {
+	} else if r.mu.replicaID > replicaID {
 		return util.Errorf("replicaID cannot move backwards")
-	} else if r.replicaID != 0 {
+	} else if r.mu.replicaID != 0 {
 		// TODO(bdarnell): clean up previous raftGroup (cancel pending commands,
 		// update peers)
 	}
@@ -307,8 +311,8 @@ func (r *Replica) setReplicaIDLocked(replicaID roachpb.ReplicaID) error {
 	if err != nil {
 		return err
 	}
-	r.replicaID = replicaID
-	r.raftGroup = raftGroup
+	r.mu.replicaID = replicaID
+	r.mu.raftGroup = raftGroup
 
 	// Automatically campaign and elect a leader for this group if there's
 	// exactly one known node for this group.
@@ -326,7 +330,7 @@ func (r *Replica) setReplicaIDLocked(replicaID roachpb.ReplicaID) error {
 	// could happen is both nodes ending up in candidate state, timing
 	// out and then voting again. This is expected to be an extremely
 	// rare event.
-	if len(r.desc.Replicas) == 1 && r.desc.Replicas[0].StoreID == r.store.StoreID() {
+	if len(r.mu.desc.Replicas) == 1 && r.mu.desc.Replicas[0].StoreID == r.store.StoreID() {
 		if err := raftGroup.Campaign(); err != nil {
 			return err
 		}
@@ -506,8 +510,8 @@ func (r *Replica) redirectOnOrAcquireLeaderLease(trace *tracer.Trace) *roachpb.E
 // another node. It is false when a range has been created in response
 // to an incoming message but we are waiting for our initial snapshot.
 func (r *Replica) isInitialized() bool {
-	r.Lock()
-	defer r.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.isInitializedLocked()
 }
 
@@ -517,14 +521,14 @@ func (r *Replica) isInitialized() bool {
 // to an incoming message but we are waiting for our initial snapshot.
 // isInitializedLocked requires that the replica lock is held.
 func (r *Replica) isInitializedLocked() bool {
-	return len(r.desc.EndKey) > 0
+	return len(r.mu.desc.EndKey) > 0
 }
 
 // Desc returns the range's descriptor.
 func (r *Replica) Desc() *roachpb.RangeDescriptor {
-	r.Lock()
-	defer r.Unlock()
-	return r.desc
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.desc
 }
 
 // setDesc atomically sets the range's descriptor. This method calls
@@ -542,8 +546,8 @@ func (r *Replica) setDesc(desc *roachpb.RangeDescriptor) error {
 // setDescWithoutProcessUpdate updates the range descriptor without calling
 // processRangeDescriptorUpdate.
 func (r *Replica) setDescWithoutProcessUpdate(desc *roachpb.RangeDescriptor) {
-	r.Lock()
-	defer r.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.setDescWithoutProcessUpdateLocked(desc)
 }
 
@@ -555,7 +559,7 @@ func (r *Replica) setDescWithoutProcessUpdateLocked(desc *roachpb.RangeDescripto
 		panic(fmt.Sprintf("range descriptor ID (%d) does not match replica's range ID (%d)",
 			desc.RangeID, r.RangeID))
 	}
-	r.desc = desc
+	r.mu.desc = desc
 }
 
 // getCachedTruncatedState atomically returns the range's cached truncated
@@ -579,10 +583,10 @@ func (r *Replica) GetReplica() *roachpb.ReplicaDescriptor {
 // ReplicaDescriptor returns information about the given member of
 // this replica's range.
 func (r *Replica) ReplicaDescriptor(replicaID roachpb.ReplicaID) (roachpb.ReplicaDescriptor, error) {
-	r.Lock()
-	defer r.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	desc := r.desc
+	desc := r.mu.desc
 	for _, repAddress := range desc.Replicas {
 		if repAddress.ReplicaID == replicaID {
 			return repAddress, nil
@@ -637,9 +641,9 @@ func (r *Replica) SetLastVerificationTimestamp(timestamp roachpb.Timestamp) erro
 
 // RaftStatus returns the current raft status of the replica.
 func (r *Replica) RaftStatus() *raft.Status {
-	r.Lock()
-	defer r.Unlock()
-	return r.raftGroup.Status()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.raftGroup.Status()
 }
 
 // Send adds a command for execution on this range. The command's
@@ -732,7 +736,7 @@ func (r *Replica) beginCmds(ba *roachpb.BatchRequest) []interface{} {
 	var cmdKeys []interface{}
 	// Don't use the command queue for inconsistent reads.
 	if ba.ReadConsistency != roachpb.INCONSISTENT {
-		r.Lock()
+		r.mu.Lock()
 		var wg sync.WaitGroup
 		var spans []roachpb.Span
 		readOnly := ba.IsReadOnly()
@@ -740,9 +744,9 @@ func (r *Replica) beginCmds(ba *roachpb.BatchRequest) []interface{} {
 			h := union.GetInner().Header()
 			spans = append(spans, roachpb.Span{Key: h.Key, EndKey: h.EndKey})
 		}
-		r.cmdQ.GetWait(readOnly, &wg, spans...)
-		cmdKeys = append(cmdKeys, r.cmdQ.Add(readOnly, spans...)...)
-		r.Unlock()
+		r.mu.cmdQ.GetWait(readOnly, &wg, spans...)
+		cmdKeys = append(cmdKeys, r.mu.cmdQ.Add(readOnly, spans...)...)
+		r.mu.Unlock()
 		wg.Wait()
 	}
 
@@ -765,7 +769,7 @@ func (r *Replica) beginCmds(ba *roachpb.BatchRequest) []interface{} {
 // endCmds removes pending commands from the command queue and updates
 // the timestamp cache using the final timestamp of each command.
 func (r *Replica) endCmds(cmdKeys []interface{}, ba roachpb.BatchRequest, pErr *roachpb.Error) {
-	r.Lock()
+	r.mu.Lock()
 	// Only update the timestamp cache if the command succeeded and we're not
 	// doing inconsistent ops (in which case the ops are always read-only).
 	if pErr == nil && ba.ReadConsistency != roachpb.INCONSISTENT {
@@ -777,12 +781,12 @@ func (r *Replica) endCmds(cmdKeys []interface{}, ba roachpb.BatchRequest, pErr *
 				if ba.Txn != nil {
 					txnID = ba.Txn.ID
 				}
-				r.tsCache.Add(header.Key, header.EndKey, ba.Timestamp, txnID, roachpb.IsReadOnly(args))
+				r.mu.tsCache.Add(header.Key, header.EndKey, ba.Timestamp, txnID, roachpb.IsReadOnly(args))
 			}
 		}
 	}
-	r.cmdQ.Remove(cmdKeys)
-	r.Unlock()
+	r.mu.cmdQ.Remove(cmdKeys)
+	r.mu.Unlock()
 }
 
 // addAdminCmd executes the command directly. There is no interaction
@@ -924,7 +928,7 @@ func (r *Replica) addWriteCmd(ctx context.Context, ba roachpb.BatchRequest, wg *
 	//
 	// Find the maximum timestamp required to satisfy all requests in
 	// the batch and then apply that to all requests.
-	r.Lock()
+	r.mu.Lock()
 	for _, union := range ba.Requests {
 		args := union.GetInner()
 		if usesTimestampCache(args) {
@@ -933,7 +937,7 @@ func (r *Replica) addWriteCmd(ctx context.Context, ba roachpb.BatchRequest, wg *
 			if ba.Txn != nil {
 				txnID = ba.Txn.ID
 			}
-			rTS, wTS := r.tsCache.GetMax(header.Key, header.EndKey, txnID)
+			rTS, wTS := r.mu.tsCache.GetMax(header.Key, header.EndKey, txnID)
 
 			// Always push the timestamp forward if there's been a read which
 			// occurred after our txn timestamp.
@@ -954,7 +958,7 @@ func (r *Replica) addWriteCmd(ctx context.Context, ba roachpb.BatchRequest, wg *
 		}
 	}
 
-	r.Unlock()
+	r.mu.Unlock()
 
 	defer trace.Epoch("raft")()
 
@@ -980,9 +984,9 @@ func (r *Replica) addWriteCmd(ctx context.Context, ba roachpb.BatchRequest, wg *
 // proposes the command to Raft and returns the error channel and
 // pending command struct for receiving.
 func (r *Replica) proposeRaftCommand(ctx context.Context, ba roachpb.BatchRequest) (*pendingCmd, error) {
-	r.Lock()
-	defer r.Unlock()
-	_, replica := r.desc.FindReplica(r.store.StoreID())
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, replica := r.mu.desc.FindReplica(r.store.StoreID())
 	if replica == nil {
 		return nil, roachpb.NewRangeNotFoundError(r.RangeID)
 	}
@@ -999,19 +1003,19 @@ func (r *Replica) proposeRaftCommand(ctx context.Context, ba roachpb.BatchReques
 		},
 	}
 
-	if _, ok := r.pendingCmds[idKey]; ok {
+	if _, ok := r.mu.pendingCmds[idKey]; ok {
 		log.Fatalf("pending command already exists for %s", idKey)
 	}
-	r.pendingCmds[idKey] = pendingCmd
+	r.mu.pendingCmds[idKey] = pendingCmd
 
 	if err := r.proposePendingCmdLocked(idKey, pendingCmd); err != nil {
-		delete(r.pendingCmds, idKey)
+		delete(r.mu.pendingCmds, idKey)
 		return nil, err
 	}
 	return pendingCmd, nil
 }
 
-// proposePendingCmdLocked proposes or re-proposes a command in r.pendingCmds.
+// proposePendingCmdLocked proposes or re-proposes a command in r.mu.pendingCmds.
 // The replica lock must be held.
 func (r *Replica) proposePendingCmdLocked(idKey cmdIDKey, p *pendingCmd) error {
 	if r.proposeRaftCommandFn != nil {
@@ -1048,7 +1052,7 @@ func (r *Replica) proposePendingCmdLocked(idKey cmdIDKey, p *pendingCmd) error {
 				return err
 			}
 
-			return r.raftGroup.ProposeConfChange(
+			return r.mu.raftGroup.ProposeConfChange(
 				raftpb.ConfChange{
 					Type:    changeTypeInternalToRaft[crt.ChangeType],
 					NodeID:  uint64(crt.Replica.ReplicaID),
@@ -1056,17 +1060,17 @@ func (r *Replica) proposePendingCmdLocked(idKey cmdIDKey, p *pendingCmd) error {
 				})
 		}
 	}
-	return r.raftGroup.Propose(encodeRaftCommand(string(idKey), data))
+	return r.mu.raftGroup.Propose(encodeRaftCommand(string(idKey), data))
 }
 
 func (r *Replica) handleRaftReady() error {
-	r.Lock()
-	if !r.raftGroup.HasReady() {
-		r.Unlock()
+	r.mu.Lock()
+	if !r.mu.raftGroup.HasReady() {
+		r.mu.Unlock()
 		return nil
 	}
-	rd := r.raftGroup.Ready()
-	r.Unlock()
+	rd := r.mu.raftGroup.Ready()
+	r.mu.Unlock()
 	logRaftReady(r.store.StoreID(), r.RangeID, rd)
 
 	batch := r.store.Engine().NewBatch()
@@ -1139,40 +1143,40 @@ func (r *Replica) handleRaftReady() error {
 			}
 			if err := r.processRaftCommand(cmdIDKey(ctx.CommandID), e.Index, command); err == nil {
 				// TODO(bdarnell): update coalesced heartbeat mapping
-				r.Lock()
-				r.raftGroup.ApplyConfChange(cc)
-				r.Unlock()
+				r.mu.Lock()
+				r.mu.raftGroup.ApplyConfChange(cc)
+				r.mu.Unlock()
 			} else {
 				// If processRaftCommand failed, tell raft that the config change was aborted.
-				r.Lock()
-				r.raftGroup.ApplyConfChange(raftpb.ConfChange{})
-				r.Unlock()
+				r.mu.Lock()
+				r.mu.raftGroup.ApplyConfChange(raftpb.ConfChange{})
+				r.mu.Unlock()
 			}
 
 		}
 
 	}
 	if hasEmptyEntry {
-		r.Lock()
-		if len(r.pendingCmds) > 0 {
+		r.mu.Lock()
+		if len(r.mu.pendingCmds) > 0 {
 			if log.V(1) {
-				log.Infof("reproposing %d commands after empty entry", len(r.pendingCmds))
+				log.Infof("reproposing %d commands after empty entry", len(r.mu.pendingCmds))
 			}
-			for idKey, p := range r.pendingCmds {
+			for idKey, p := range r.mu.pendingCmds {
 				if err := r.proposePendingCmdLocked(idKey, p); err != nil {
-					r.Unlock()
+					r.mu.Unlock()
 					return err
 				}
 			}
 		}
-		r.Unlock()
+		r.mu.Unlock()
 	}
 	// TODO(bdarnell): need to check replica id and not Advance if it
 	// has changed. Or do we need more locking to guarantee that replica
 	// ID cannot change during handleRaftReady?
-	r.Lock()
-	r.raftGroup.Advance(rd)
-	r.Unlock()
+	r.mu.Lock()
+	r.mu.raftGroup.Advance(rd)
+	r.mu.Unlock()
 	return nil
 }
 
@@ -1202,17 +1206,17 @@ func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 	if err != nil {
 		log.Warningf("group %s on store %s failed to send message to %s: %s", groupID,
 			r.store.StoreID(), toReplica.StoreID, err)
-		r.Lock()
-		r.raftGroup.ReportUnreachable(msg.To)
-		r.Unlock()
+		r.mu.Lock()
+		r.mu.raftGroup.ReportUnreachable(msg.To)
+		r.mu.Unlock()
 		snapStatus = raft.SnapshotFailure
 	}
 	if msg.Type == raftpb.MsgSnap {
 		// TODO(bdarnell): add an ack for snapshots and don't report status until
 		// ack, error, or timeout.
-		r.Lock()
-		r.raftGroup.ReportSnapshot(msg.To, snapStatus)
-		r.Unlock()
+		r.mu.Lock()
+		r.mu.raftGroup.ReportSnapshot(msg.To, snapStatus)
+		r.mu.Unlock()
 	}
 }
 
@@ -1225,10 +1229,10 @@ func (r *Replica) processRaftCommand(idKey cmdIDKey, index uint64, raftCmd roach
 		log.Fatalc(r.context(), "processRaftCommand requires a non-zero index")
 	}
 
-	r.Lock()
-	cmd := r.pendingCmds[idKey]
-	delete(r.pendingCmds, idKey)
-	r.Unlock()
+	r.mu.Lock()
+	cmd := r.mu.pendingCmds[idKey]
+	delete(r.mu.pendingCmds, idKey)
+	r.mu.Unlock()
 
 	var ctx context.Context
 	if cmd != nil {
@@ -1406,8 +1410,8 @@ func (r *Replica) applyRaftCommandInBatch(ctx context.Context, index uint64, ori
 // or transaction abort error is returned, respectively.
 // checkSequenceCache locks the replica.
 func (r *Replica) checkSequenceCache(b engine.Engine, txn roachpb.Transaction) *roachpb.Error {
-	r.Lock()
-	defer r.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	var entry roachpb.SequenceCacheEntry
 	if epoch, sequence, readErr := r.sequence.Get(b, txn.ID, &entry); readErr != nil {

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1178,20 +1178,20 @@ func (r *Replica) handleRaftReady() error {
 
 func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 	groupID := r.RangeID
-	r.store.mu.RLock()
+	r.store.Lock()
 	toReplica, err := r.store.replicaDescriptorLocked(groupID, roachpb.ReplicaID(msg.To))
 	if err != nil {
 		log.Warningf("failed to lookup recipient replica %d in group %s: %s", msg.To, groupID, err)
-		r.store.mu.RUnlock()
+		r.store.Unlock()
 		return
 	}
 	fromReplica, err := r.store.replicaDescriptorLocked(groupID, roachpb.ReplicaID(msg.From))
 	if err != nil {
 		log.Warningf("failed to lookup sender replica %d in group %s: %s", msg.From, groupID, err)
-		r.store.mu.RUnlock()
+		r.store.Unlock()
 		return
 	}
-	r.store.mu.RUnlock()
+	r.store.Unlock()
 	err = r.store.ctx.Transport.Send(&RaftMessageRequest{
 		GroupID:     groupID,
 		ToReplica:   toReplica,

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1182,20 +1182,20 @@ func (r *Replica) handleRaftReady() error {
 
 func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 	groupID := r.RangeID
-	r.store.Lock()
+	r.store.mu.Lock()
 	toReplica, err := r.store.replicaDescriptorLocked(groupID, roachpb.ReplicaID(msg.To))
 	if err != nil {
 		log.Warningf("failed to lookup recipient replica %d in group %s: %s", msg.To, groupID, err)
-		r.store.Unlock()
+		r.store.mu.Unlock()
 		return
 	}
 	fromReplica, err := r.store.replicaDescriptorLocked(groupID, roachpb.ReplicaID(msg.From))
 	if err != nil {
 		log.Warningf("failed to lookup sender replica %d in group %s: %s", msg.From, groupID, err)
-		r.store.Unlock()
+		r.store.mu.Unlock()
 		return
 	}
-	r.store.Unlock()
+	r.store.mu.Unlock()
 	err = r.store.ctx.Transport.Send(&RaftMessageRequest{
 		GroupID:     groupID,
 		ToReplica:   toReplica,

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1407,11 +1407,7 @@ func (r *Replica) splitTrigger(batch engine.Engine, split *roachpb.SplitTrigger)
 		return util.Errorf("unable to write MVCC stats: %s", err)
 	}
 
-	// Copy the timestamp cache into the new range. Commit triggers already
-	// acquire the read lock since concurrent reads could add updates that
-	// never make it to the new Range (see #3148), so all we grab here is
-	// the actual lock (at time of writing, this isn't necessary but for
-	// convention).
+	// Copy the timestamp cache into the new range.
 	r.mu.Lock()
 	newRng.mu.Lock()
 	r.mu.tsCache.MergeInto(newRng.mu.tsCache, true /* clear */)

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1079,8 +1079,8 @@ func (r *Replica) Merge(batch engine.Engine, ms *engine.MVCCStats, h roachpb.Hea
 // has already been truncated has no effect. If this range is not the one
 // specified within the request body, the request will also be ignored.
 func (r *Replica) TruncateLog(batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.TruncateLogRequest) (roachpb.TruncateLogResponse, error) {
-	r.Lock()
-	defer r.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	var reply roachpb.TruncateLogResponse
 
 	// After a merge, it's possible that this request was sent to the wrong
@@ -1206,7 +1206,9 @@ func (r *Replica) LeaderLease(batch engine.Engine, ms *engine.MVCCStats, h roach
 	// node.
 	if r.getLease().Replica.StoreID == r.store.StoreID() &&
 		prevLease.Replica.StoreID != r.getLease().Replica.StoreID {
-		r.tsCache.SetLowWater(prevLease.Expiration.Add(int64(r.store.Clock().MaxOffset()), 0))
+		r.mu.Lock()
+		r.mu.tsCache.SetLowWater(prevLease.Expiration.Add(int64(r.store.Clock().MaxOffset()), 0))
+		r.mu.Unlock()
 		log.Infof("range %d: new leader lease %s", r.RangeID, args.Lease)
 	}
 
@@ -1410,9 +1412,11 @@ func (r *Replica) splitTrigger(batch engine.Engine, split *roachpb.SplitTrigger)
 	// never make it to the new Range (see #3148), so all we grab here is
 	// the actual lock (at time of writing, this isn't necessary but for
 	// convention).
-	r.Lock()
-	r.tsCache.MergeInto(newRng.tsCache, true /* clear */)
-	r.Unlock()
+	r.mu.Lock()
+	newRng.mu.Lock()
+	r.mu.tsCache.MergeInto(newRng.mu.tsCache, true /* clear */)
+	newRng.mu.Unlock()
+	r.mu.Unlock()
 
 	batch.Defer(func() {
 		if err := r.store.SplitRange(r, newRng); err != nil {
@@ -1451,9 +1455,9 @@ func (r *Replica) splitTrigger(batch engine.Engine, split *roachpb.SplitTrigger)
 			r.store.stopper.RunAsyncTask(func() {
 				time.Sleep(10 * time.Millisecond)
 				// TODO(bdarnell): make sure newRng hasn't been removed
-				newRng.Lock()
-				_ = newRng.raftGroup.Campaign()
-				newRng.Unlock()
+				newRng.mu.Lock()
+				_ = newRng.mu.raftGroup.Campaign()
+				newRng.mu.Unlock()
 			})
 		}
 	})
@@ -1610,9 +1614,9 @@ func (r *Replica) mergeTrigger(batch engine.Engine, merge *roachpb.MergeTrigger)
 	// subsumed replica each held their respective leader leases, we
 	// could merge the timestamp caches for efficiency. But it's unlikely
 	// and not worth the extra logic and potential for error.
-	r.Lock()
-	r.tsCache.Clear(r.store.Clock())
-	r.Unlock()
+	r.mu.Lock()
+	r.mu.tsCache.Clear(r.store.Clock())
+	r.mu.Unlock()
 
 	batch.Defer(func() {
 		if err := r.store.MergeRange(r, merge.UpdatedDesc.EndKey, merge.SubsumedRangeID); err != nil {
@@ -1659,8 +1663,8 @@ func (r *Replica) ChangeReplicas(changeType roachpb.ReplicaChangeType, replica r
 	updatedDesc := *desc
 	updatedDesc.Replicas = append([]roachpb.ReplicaDescriptor(nil), desc.Replicas...)
 	err := func() error {
-		r.Lock()
-		defer r.Unlock()
+		r.mu.Lock()
+		defer r.mu.Unlock()
 
 		found := -1       // tracks NodeID && StoreID
 		nodeUsed := false // tracks NodeID only

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2774,9 +2774,9 @@ func TestTruncateLog(t *testing.T) {
 	}
 
 	// FirstIndex has changed.
-	tc.rng.RLock()
+	tc.rng.Lock()
 	firstIndex, err := tc.rng.FirstIndex()
-	tc.rng.RUnlock()
+	tc.rng.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2785,9 +2785,9 @@ func TestTruncateLog(t *testing.T) {
 	}
 
 	// We can still get what remains of the log.
-	tc.rng.RLock()
+	tc.rng.Lock()
 	entries, err := tc.rng.Entries(indexes[5], indexes[9], math.MaxUint64)
-	tc.rng.RUnlock()
+	tc.rng.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2796,17 +2796,17 @@ func TestTruncateLog(t *testing.T) {
 	}
 
 	// But any range that includes the truncated entries returns an error.
-	tc.rng.RLock()
+	tc.rng.Lock()
 	_, err = tc.rng.Entries(indexes[4], indexes[9], math.MaxUint64)
-	tc.rng.RUnlock()
+	tc.rng.Unlock()
 	if err != raft.ErrCompacted {
 		t.Errorf("expected ErrCompacted, got %s", err)
 	}
 
 	// The term of the last truncated entry is still available.
-	tc.rng.RLock()
+	tc.rng.Lock()
 	term, err := tc.rng.Term(indexes[4])
-	tc.rng.RUnlock()
+	tc.rng.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2815,9 +2815,9 @@ func TestTruncateLog(t *testing.T) {
 	}
 
 	// The terms of older entries are gone.
-	tc.rng.RLock()
+	tc.rng.Lock()
 	_, err = tc.rng.Term(indexes[3])
-	tc.rng.RUnlock()
+	tc.rng.Unlock()
 	if err != raft.ErrCompacted {
 		t.Errorf("expected ErrCompacted, got %s", err)
 	}
@@ -2836,10 +2836,10 @@ func TestTruncateLog(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	tc.rng.RLock()
+	tc.rng.Lock()
 	// The term of the last truncated entry is still available.
 	term, err = tc.rng.Term(indexes[4])
-	tc.rng.RUnlock()
+	tc.rng.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3629,9 +3629,9 @@ func TestEntries(t *testing.T) {
 		// Case 14: lo is available, hi is not, but it was cut off by maxBytes.
 		{lo: indexes[5], hi: indexes[9] + 1000, maxBytes: 1, expResultCount: 1},
 	} {
-		rng.RLock()
+		rng.Lock()
 		ents, err := rng.Entries(tc.lo, tc.hi, tc.maxBytes)
-		rng.RUnlock()
+		rng.Unlock()
 		if tc.expError == nil && err != nil {
 			t.Errorf("%d: expected no error, got %s", i, err)
 			continue
@@ -3645,11 +3645,11 @@ func TestEntries(t *testing.T) {
 	}
 
 	// Case 15: Lo must be less than or equal to hi.
-	rng.RLock()
+	rng.Lock()
 	if _, err := rng.Entries(indexes[9], indexes[5], 0); err == nil {
 		t.Errorf("15: error expected, got none")
 	}
-	rng.RUnlock()
+	rng.Unlock()
 
 	// Case 16: add a gap to the indexes.
 	if err := engine.MVCCDelete(tc.store.Engine(), nil, keys.RaftLogKey(rangeID, indexes[6]), roachpb.ZeroTimestamp,
@@ -3657,8 +3657,8 @@ func TestEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rng.RLock()
-	defer rng.RUnlock()
+	rng.Lock()
+	defer rng.Unlock()
 	if _, err := rng.Entries(indexes[5], indexes[9], 0); err == nil {
 		t.Errorf("16: error expected, got none")
 	}
@@ -3709,8 +3709,8 @@ func TestTerm(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	rng.RLock()
-	defer rng.RUnlock()
+	rng.Lock()
+	defer rng.Unlock()
 
 	firstIndex, err := rng.FirstIndex()
 	if err != nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -1511,9 +1511,9 @@ func (s *Store) handleRaftMessage(req *RaftMessageRequest) error {
 	if err != nil {
 		return err
 	}
-	r.Lock()
-	err = r.raftGroup.Step(req.Message)
-	r.Unlock()
+	r.mu.Lock()
+	err = r.mu.raftGroup.Step(req.Message)
+	r.mu.Unlock()
 	if err != nil {
 		return err
 	}
@@ -1584,9 +1584,9 @@ func (s *Store) processRaft() {
 				// TODO(bdarnell): rework raft ticker.
 				s.Lock()
 				for rangeID, r := range s.replicas {
-					r.Lock()
-					r.raftGroup.Tick()
-					r.Unlock()
+					r.mu.Lock()
+					r.mu.raftGroup.Tick()
+					r.mu.Unlock()
 					s.pendingRaftGroups[rangeID] = struct{}{}
 				}
 				s.Unlock()

--- a/storage/store.go
+++ b/storage/store.go
@@ -200,22 +200,22 @@ func (rs *storeRangeSet) Visit(visitor func(*Replica) bool) {
 	// Copy the  range IDs to a slice and iterate over the slice so
 	// that we can safely (e.g., no race, no range skip) iterate
 	// over ranges regardless of how BTree is implemented.
-	rs.store.Lock()
-	rs.rangeIDs = make([]roachpb.RangeID, rs.store.replicasByKey.Len())
+	rs.store.mu.Lock()
+	rs.rangeIDs = make([]roachpb.RangeID, rs.store.mu.replicasByKey.Len())
 	i := 0
-	rs.store.replicasByKey.Ascend(func(item btree.Item) bool {
+	rs.store.mu.replicasByKey.Ascend(func(item btree.Item) bool {
 		rs.rangeIDs[i] = item.(*Replica).RangeID
 		i++
 		return true
 	})
-	rs.store.Unlock()
+	rs.store.mu.Unlock()
 
 	rs.visited = 0
 	for _, rangeID := range rs.rangeIDs {
 		rs.visited++
-		rs.store.Lock()
-		rng, ok := rs.store.replicas[rangeID]
-		rs.store.Unlock()
+		rs.store.mu.Lock()
+		rng, ok := rs.store.mu.replicas[rangeID]
+		rs.store.mu.Unlock()
 		if ok {
 			if !visitor(rng) {
 				break
@@ -226,10 +226,10 @@ func (rs *storeRangeSet) Visit(visitor func(*Replica) bool) {
 }
 
 func (rs *storeRangeSet) EstimatedCount() int {
-	rs.store.Lock()
-	defer rs.store.Unlock()
+	rs.store.mu.Lock()
+	defer rs.store.mu.Unlock()
 	if rs.visited <= 0 {
-		return rs.store.replicasByKey.Len()
+		return rs.store.mu.replicasByKey.Len()
 	}
 	return len(rs.rangeIDs) - rs.visited
 }
@@ -263,23 +263,25 @@ type Store struct {
 	startedAt         int64
 	nodeDesc          *roachpb.NodeDescriptor
 	initComplete      sync.WaitGroup // Signaled by async init tasks
+	raftRequestChan   chan *RaftMessageRequest
 
 	// Lock ordering notes: The processRaft goroutine acts as a kind of
 	// mutex. To avoid deadlocks, the following lock order must be
-	// obeyed: processRaft goroutine < Store.Mutex < Replica.Mutex. (i.e.
+	// obeyed: processRaft goroutine < Store.mu.Mutex < Replica.mu.Mutex. (i.e.
 	// methods like removeReplica which depend on the processRaft
-	// goroutine must not be called while holding Store.Mutex).
-	sync.Mutex                                  // Protects variables below...
-	replicas       map[roachpb.RangeID]*Replica // Map of replicas by Range ID
-	replicasByKey  *btree.BTree                 // btree keyed by ranges end keys.
-	uninitReplicas map[roachpb.RangeID]*Replica // Map of uninitialized replicas by Range ID
+	// goroutine must not be called while holding Store.mu.Mutex).
+	mu struct {
+		sync.Mutex                                  // Protects all variables in the mu struct.
+		replicas       map[roachpb.RangeID]*Replica // Map of replicas by Range ID
+		replicasByKey  *btree.BTree                 // btree keyed by ranges end keys.
+		uninitReplicas map[roachpb.RangeID]*Replica // Map of uninitialized replicas by Range ID
 
-	replicaDescCache *cache.UnorderedCache
-	// pendingRaftGroups contains the ranges that should be checked for
-	// updates. After updating this map, write to wakeRaftLoop to
-	// trigger the check.
-	pendingRaftGroups map[roachpb.RangeID]struct{}
-	raftRequestChan   chan *RaftMessageRequest
+		replicaDescCache *cache.UnorderedCache
+		// pendingRaftGroups contains the ranges that should be checked for
+		// updates. After updating this map, write to wakeRaftLoop to
+		// trigger the check.
+		pendingRaftGroups map[roachpb.RangeID]struct{}
+	}
 }
 
 var _ client.Sender = &Store{}
@@ -375,21 +377,25 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 		db:                ctx.DB, // TODO(tschottdorf) remove redundancy.
 		engine:            eng,
 		allocator:         MakeAllocator(ctx.StorePool, ctx.AllocatorOptions),
-		replicas:          map[roachpb.RangeID]*Replica{},
-		replicasByKey:     btree.New(64 /* degree */),
-		uninitReplicas:    map[roachpb.RangeID]*Replica{},
 		nodeDesc:          nodeDesc,
 		removeReplicaChan: make(chan removeReplicaOp),
-		replicaDescCache: cache.NewUnorderedCache(cache.Config{
-			Policy: cache.CacheLRU,
-			ShouldEvict: func(size int, key, value interface{}) bool {
-				return size > maxReplicaDescCacheSize
-			},
-		}),
 		wakeRaftLoop:      make(chan struct{}, 1),
-		pendingRaftGroups: map[roachpb.RangeID]struct{}{},
 		raftRequestChan:   make(chan *RaftMessageRequest, raftReqBufferSize),
 	}
+
+	s.mu.Lock()
+	s.mu.replicas = map[roachpb.RangeID]*Replica{}
+	s.mu.replicasByKey = btree.New(64 /* degree */)
+	s.mu.uninitReplicas = map[roachpb.RangeID]*Replica{}
+	s.mu.replicaDescCache = cache.NewUnorderedCache(cache.Config{
+		Policy: cache.CacheLRU,
+		ShouldEvict: func(size int, key, value interface{}) bool {
+			return size > maxReplicaDescCacheSize
+		},
+	})
+	s.mu.pendingRaftGroups = map[roachpb.RangeID]struct{}{}
+
+	s.mu.Unlock()
 
 	// Add range scanner and configure with queues.
 	s.scanner = newReplicaScanner(ctx.ScanInterval, ctx.ScanMaxIdleTime, newStoreRangeSet(s))
@@ -397,7 +403,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 	s.splitQueue = newSplitQueue(s.db, s.ctx.Gossip)
 	s.verifyQueue = newVerifyQueue(s.ctx.Gossip, s.ReplicaCount)
 	s.replicateQueue = newReplicateQueue(s.ctx.Gossip, s.allocator, s.ctx.Clock, s.ctx.AllocatorOptions)
-	s.replicaGCQueue = newReplicaGCQueue(s.db, s.ctx.Gossip, &s.Mutex)
+	s.replicaGCQueue = newReplicaGCQueue(s.db, s.ctx.Gossip, &s.mu.Mutex)
 	s.raftLogQueue = newRaftLogQueue(s.db, s.ctx.Gossip)
 	s.scanner.AddQueues(s.gcQueue, s.splitQueue, s.verifyQueue, s.replicateQueue, s.replicaGCQueue, s.raftLogQueue)
 
@@ -493,7 +499,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 	// (consistent=false). Uncommitted intents which have been abandoned
 	// due to a split crashing halfway will simply be resolved on the
 	// next split attempt. They can otherwise be ignored.
-	s.Lock()
+	s.mu.Lock()
 	s.feed.beginScanRanges()
 	_, err = engine.MVCCIterate(s.engine, start, end, now, false /* !consistent */, nil, /* txn */
 		false /* !reverse */, func(kv roachpb.KeyValue) (bool, error) {
@@ -513,7 +519,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 			if err != nil {
 				return false, err
 			}
-			if err = s.addReplicaInternal(rng); err != nil {
+			if err = s.addReplicaInternalLocked(rng); err != nil {
 				return false, err
 			}
 			s.feed.registerRange(rng, true /* scan */)
@@ -527,7 +533,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 			// and initialize those groups.
 			return false, nil
 		})
-	s.Unlock()
+	s.mu.Unlock()
 	s.feed.endScanRanges()
 	if err != nil {
 		return err
@@ -687,10 +693,10 @@ func (s *Store) maybeGossipSystemConfig() *roachpb.Error {
 // systemGossipUpdate is a callback for gossip updates to
 // the system config which affect range split boundaries.
 func (s *Store) systemGossipUpdate(cfg *config.SystemConfig) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	// For every range, update its MaxBytes and check if it needs to be split.
-	for _, rng := range s.replicas {
+	for _, rng := range s.mu.replicas {
 		if zone, err := cfg.GetZoneConfigForKey(rng.Desc().StartKey); err == nil {
 			rng.SetMaxBytes(zone.RangeMaxBytes)
 		}
@@ -754,15 +760,15 @@ func (s *Store) Bootstrap(ident roachpb.StoreIdent, stopper *stop.Stopper) error
 
 // GetReplica fetches a replica by Range ID. Returns an error if no replica is found.
 func (s *Store) GetReplica(rangeID roachpb.RangeID) (*Replica, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.getReplicaLocked(rangeID)
 }
 
 // getReplicaLocked fetches a replica by RangeID. The store's lock must be held
 // in read or read/write mode.
 func (s *Store) getReplicaLocked(rangeID roachpb.RangeID) (*Replica, error) {
-	if rng, ok := s.replicas[rangeID]; ok {
+	if rng, ok := s.mu.replicas[rangeID]; ok {
 		return rng, nil
 	}
 	return nil, roachpb.NewRangeNotFoundError(rangeID)
@@ -774,11 +780,11 @@ func (s *Store) getReplicaLocked(rangeID roachpb.RangeID) (*Replica, error) {
 // using Key.Address() to ensure we lookup replicas correctly for local
 // keys. When end is nil, a replica that contains start is looked up.
 func (s *Store) LookupReplica(start, end roachpb.RKey) *Replica {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	var rng *Replica
-	s.replicasByKey.AscendGreaterOrEqual((rangeBTreeKey)(start.Next()), func(i btree.Item) bool {
+	s.mu.replicasByKey.AscendGreaterOrEqual((rangeBTreeKey)(start.Next()), func(i btree.Item) bool {
 		rng = i.(*Replica)
 		return false
 	})
@@ -792,7 +798,7 @@ func (s *Store) LookupReplica(start, end roachpb.RKey) *Replica {
 // descriptor is present on the Store.
 func (s *Store) hasOverlappingReplicaLocked(rngDesc *roachpb.RangeDescriptor) bool {
 	var rng *Replica
-	s.replicasByKey.AscendGreaterOrEqual((rangeBTreeKey)(rngDesc.StartKey.Next()), func(i btree.Item) bool {
+	s.mu.replicasByKey.AscendGreaterOrEqual((rangeBTreeKey)(rngDesc.StartKey.Next()), func(i btree.Item) bool {
 		rng = i.(*Replica)
 		return false
 	})
@@ -807,9 +813,9 @@ func (s *Store) hasOverlappingReplicaLocked(rngDesc *roachpb.RangeDescriptor) bo
 // RaftStatus returns the current raft status of the local replica of
 // the given range.
 func (s *Store) RaftStatus(rangeID roachpb.RangeID) *raft.Status {
-	s.Lock()
-	defer s.Unlock()
-	if r, ok := s.replicas[rangeID]; ok {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if r, ok := s.mu.replicas[rangeID]; ok {
 		return r.RaftStatus()
 	}
 	return nil
@@ -949,22 +955,22 @@ func (s *Store) SplitRange(origRng, newRng *Replica) error {
 		return util.Errorf("orig range is not splittable by new range: %+v, %+v", origDesc, newDesc)
 	}
 
-	s.Lock()
-	defer s.Unlock()
-	if _, ok := s.uninitReplicas[newDesc.RangeID]; ok {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.mu.uninitReplicas[newDesc.RangeID]; ok {
 		// If we have an uninitialized replica of the new range, delete it
 		// to make way for the complete one created by the split. A live
 		// uninitialized raft group cannot be converted to an
 		// initialized one (because of the tricks we do to change
 		// FirstIndex from 0 to raftInitialLogIndex), so the group must be
 		// removed before we install the new range into s.replicas.
-		delete(s.uninitReplicas, newDesc.RangeID)
-		delete(s.replicas, newDesc.RangeID)
+		delete(s.mu.uninitReplicas, newDesc.RangeID)
+		delete(s.mu.replicas, newDesc.RangeID)
 	}
 
 	// Replace the end key of the original range with the start key of
 	// the new range. Reinsert the range since the btree is keyed by range end keys.
-	if s.replicasByKey.Delete(origRng) == nil {
+	if s.mu.replicasByKey.Delete(origRng) == nil {
 		return util.Errorf("couldn't find range %s in rangesByKey btree", origRng)
 	}
 
@@ -972,11 +978,11 @@ func (s *Store) SplitRange(origRng, newRng *Replica) error {
 	copyDesc.EndKey = append([]byte(nil), newDesc.StartKey...)
 	origRng.setDescWithoutProcessUpdate(&copyDesc)
 
-	if s.replicasByKey.ReplaceOrInsert(origRng) != nil {
+	if s.mu.replicasByKey.ReplaceOrInsert(origRng) != nil {
 		return util.Errorf("couldn't insert range %v in rangesByKey btree", origRng)
 	}
 
-	if err := s.addReplicaInternal(newRng); err != nil {
+	if err := s.addReplicaInternalLocked(newRng); err != nil {
 		return util.Errorf("couldn't insert range %v in rangesByKey btree: %s", newRng, err)
 	}
 
@@ -1034,47 +1040,47 @@ func (s *Store) MergeRange(subsumingRng *Replica, updatedEndKey roachpb.RKey, su
 // AddReplicaTest adds the replica to the store's replica map and to the sorted
 // replicasByKey slice. To be used only by unittests.
 func (s *Store) AddReplicaTest(rng *Replica) error {
-	s.Lock()
-	defer s.Unlock()
-	if err := s.addReplicaInternal(rng); err != nil {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.addReplicaInternalLocked(rng); err != nil {
 		return err
 	}
 	s.feed.registerRange(rng, false /* scan */)
 	return nil
 }
 
-// addReplicaInternal adds the replica to the replicas map and the replicasByKey btree.
-// This method presupposes the store's lock is held. Returns a rangeAlreadyExists
-// error if a replica with the same Range ID has already been added to this store.
-func (s *Store) addReplicaInternal(rng *Replica) error {
+// addReplicaInternalLocked adds the replica to the replicas map and the
+// replicasByKey btree. Returns a rangeAlreadyExists error if a replica with
+// the same Range ID has already been added to this store.
+// addReplicaInternalLocked requires that the store lock is held.
+func (s *Store) addReplicaInternalLocked(rng *Replica) error {
 	if !rng.isInitialized() {
 		return util.Errorf("attempted to add uninitialized range %s", rng)
 	}
 
 	// TODO(spencer); will need to determine which range is
 	// newer, and keep that one.
-	if err := s.addReplicaToRangeMap(rng); err != nil {
+	if err := s.addReplicaToRangeMapLocked(rng); err != nil {
 		return err
 	}
 
 	if s.hasOverlappingReplicaLocked(rng.Desc()) {
 		return rangeAlreadyExists{rng}
 	}
-	if exRngItem := s.replicasByKey.ReplaceOrInsert(rng); exRngItem != nil {
+	if exRngItem := s.mu.replicasByKey.ReplaceOrInsert(rng); exRngItem != nil {
 		return util.Errorf("range for key %v already exists in rangesByKey btree",
 			(exRngItem.(*Replica)).getKey())
 	}
 	return nil
 }
 
-// addReplicaToRangeMap adds the replica to the replicas map.
-func (s *Store) addReplicaToRangeMap(rng *Replica) error {
-	rangeID := rng.RangeID
-
-	if exRng, ok := s.replicas[rangeID]; ok {
+// addReplicaToRangeMapLocked adds the replica to the replicas map.
+// addReplicaToRangeMapLocked requires that the store lock is held.
+func (s *Store) addReplicaToRangeMapLocked(rng *Replica) error {
+	if exRng, ok := s.mu.replicas[rng.RangeID]; ok {
 		return rangeAlreadyExists{exRng}
 	}
-	s.replicas[rangeID] = rng
+	s.mu.replicas[rng.RangeID] = rng
 	return nil
 }
 
@@ -1106,11 +1112,11 @@ func (s *Store) removeReplicaImpl(rep *Replica, origDesc roachpb.RangeDescriptor
 		return util.Errorf("cannot remove replica %s; replica ID has changed (%s >= %s)",
 			rep, rd.ReplicaID, origDesc.NextReplicaID)
 	}
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	delete(s.replicas, rep.RangeID)
-	if s.replicasByKey.Delete(rep) == nil {
+	delete(s.mu.replicas, rep.RangeID)
+	if s.mu.replicasByKey.Delete(rep) == nil {
 		return util.Errorf("couldn't find range in replicasByKey btree")
 	}
 	s.scanner.RemoveReplica(rep)
@@ -1129,11 +1135,12 @@ func (s *Store) removeReplicaImpl(rep *Replica, origDesc roachpb.RangeDescriptor
 // processRangeDescriptorUpdate is called whenever a range's
 // descriptor is updated.
 func (s *Store) processRangeDescriptorUpdate(rng *Replica) error {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.processRangeDescriptorUpdateLocked(rng)
 }
 
+// processRangeDescriptorUpdateLocked requires that the store lock is held.
 func (s *Store) processRangeDescriptorUpdateLocked(rng *Replica) error {
 	if !rng.isInitialized() {
 		return util.Errorf("attempted to process uninitialized range %s", rng)
@@ -1141,17 +1148,17 @@ func (s *Store) processRangeDescriptorUpdateLocked(rng *Replica) error {
 
 	rangeID := rng.RangeID
 
-	if _, ok := s.uninitReplicas[rangeID]; !ok {
+	if _, ok := s.mu.uninitReplicas[rangeID]; !ok {
 		// Do nothing if the range has already been initialized.
 		return nil
 	}
-	delete(s.uninitReplicas, rangeID)
+	delete(s.mu.uninitReplicas, rangeID)
 	s.feed.registerRange(rng, false /* scan */)
 
-	if s.replicasByKey.Has(rng) {
+	if s.mu.replicasByKey.Has(rng) {
 		return rangeAlreadyExists{rng}
 	}
-	if exRngItem := s.replicasByKey.ReplaceOrInsert(rng); exRngItem != nil {
+	if exRngItem := s.mu.replicasByKey.ReplaceOrInsert(rng); exRngItem != nil {
 		return util.Errorf("range for key %v already exists in rangesByKey btree",
 			(exRngItem.(*Replica)).getKey())
 	}
@@ -1192,9 +1199,9 @@ func (s *Store) Descriptor() (*roachpb.StoreDescriptor, error) {
 
 // ReplicaCount returns the number of replicas contained by this store.
 func (s *Store) ReplicaCount() int {
-	s.Lock()
-	defer s.Unlock()
-	return len(s.replicas)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.mu.replicas)
 }
 
 // Send fetches a range based on the header's replica, assembles
@@ -1468,9 +1475,9 @@ func (s *Store) enqueueRaftMessage(req *RaftMessageRequest) error {
 func (s *Store) handleRaftMessage(req *RaftMessageRequest) error {
 	switch req.Message.Type {
 	case raftpb.MsgSnap:
-		s.Lock()
-		canApply := s.canApplySnapshot(req.GroupID, req.Message.Snapshot)
-		s.Unlock()
+		s.mu.Lock()
+		canApply := s.canApplySnapshotLocked(req.GroupID, req.Message.Snapshot)
+		s.mu.Unlock()
 		if !canApply {
 			// If the storage cannot accept the snapshot, drop it before
 			// passing it to RawNode.Step, since our error handling
@@ -1483,9 +1490,9 @@ func (s *Store) handleRaftMessage(req *RaftMessageRequest) error {
 		// A subset of coalesced heartbeats: drop heartbeats (but not
 		// other messages!) that come from a node that we don't believe to
 		// be a current member of the group.
-		s.Lock()
-		r, ok := s.replicas[req.GroupID]
-		s.Unlock()
+		s.mu.Lock()
+		r, ok := s.mu.replicas[req.GroupID]
+		s.mu.Unlock()
 		if ok {
 			found := false
 			for _, rep := range r.Desc().Replicas {
@@ -1500,14 +1507,14 @@ func (s *Store) handleRaftMessage(req *RaftMessageRequest) error {
 		}
 	}
 
-	s.Lock()
+	s.mu.Lock()
 	s.cacheReplicaDescriptorLocked(req.GroupID, req.FromReplica)
 	s.cacheReplicaDescriptorLocked(req.GroupID, req.ToReplica)
 	// Lazily create the group.
 	r, err := s.getOrCreateReplicaLocked(req.GroupID, req.ToReplica.ReplicaID)
 	// TODO(bdarnell): is it safe to release the store lock here?
 	// It deadlocks to hold s.Mutex while calling raftGroup.Step.
-	s.Unlock()
+	s.mu.Unlock()
 	if err != nil {
 		return err
 	}
@@ -1529,9 +1536,9 @@ func (s *Store) enqueueRaftUpdateCheck(rangeID roachpb.RangeID) {
 	// simply acquire s.Mutex; this violates lock ordering and may
 	// deadlock.
 	go func() {
-		s.Lock()
-		s.pendingRaftGroups[rangeID] = struct{}{}
-		s.Unlock()
+		s.mu.Lock()
+		s.mu.pendingRaftGroups[rangeID] = struct{}{}
+		s.mu.Unlock()
 		select {
 		case s.wakeRaftLoop <- struct{}{}:
 		default:
@@ -1550,19 +1557,19 @@ func (s *Store) processRaft() {
 		defer ticker.Stop()
 		for {
 			var replicas []*Replica
-			s.Lock()
-			for rangeID := range s.pendingRaftGroups {
-				r, ok := s.replicas[rangeID]
+			s.mu.Lock()
+			for rangeID := range s.mu.pendingRaftGroups {
+				r, ok := s.mu.replicas[rangeID]
 				if !ok {
 					continue
 				}
 				replicas = append(replicas, r)
 
 			}
-			if len(s.pendingRaftGroups) > 0 {
-				s.pendingRaftGroups = map[roachpb.RangeID]struct{}{}
+			if len(s.mu.pendingRaftGroups) > 0 {
+				s.mu.pendingRaftGroups = map[roachpb.RangeID]struct{}{}
 			}
-			s.Unlock()
+			s.mu.Unlock()
 			for _, r := range replicas {
 				if err := r.handleRaftReady(); err != nil {
 					panic(err) // TODO(bdarnell)
@@ -1582,14 +1589,14 @@ func (s *Store) processRaft() {
 
 			case <-ticker.C:
 				// TODO(bdarnell): rework raft ticker.
-				s.Lock()
-				for rangeID, r := range s.replicas {
+				s.mu.Lock()
+				for rangeID, r := range s.mu.replicas {
 					r.mu.Lock()
 					r.mu.raftGroup.Tick()
 					r.mu.Unlock()
-					s.pendingRaftGroups[rangeID] = struct{}{}
+					s.mu.pendingRaftGroups[rangeID] = struct{}{}
 				}
-				s.Unlock()
+				s.mu.Unlock()
 
 			case <-s.stopper.ShouldStop():
 				return
@@ -1602,7 +1609,7 @@ func (s *Store) processRaft() {
 // creating an uninitialized replica if necessary. The caller must
 // hold the store's lock.
 func (s *Store) getOrCreateReplicaLocked(groupID roachpb.RangeID, replicaID roachpb.ReplicaID) (*Replica, error) {
-	r, ok := s.replicas[groupID]
+	r, ok := s.mu.replicas[groupID]
 	if ok {
 		if err := r.setReplicaID(replicaID); err != nil {
 			return nil, err
@@ -1637,10 +1644,10 @@ func (s *Store) getOrCreateReplicaLocked(groupID roachpb.RangeID, replicaID roac
 	// Add the range to range map, but not rangesByKey since
 	// the range's start key is unknown. The range will be
 	// added to rangesByKey later when a snapshot is applied.
-	if err = s.addReplicaToRangeMap(r); err != nil {
+	if err = s.addReplicaToRangeMapLocked(r); err != nil {
 		return nil, err
 	}
-	s.uninitReplicas[r.RangeID] = r
+	s.mu.uninitReplicas[r.RangeID] = r
 
 	return r, nil
 }
@@ -1648,15 +1655,15 @@ func (s *Store) getOrCreateReplicaLocked(groupID roachpb.RangeID, replicaID roac
 // ReplicaDescriptor returns the replica descriptor for the given
 // range and replica, if known.
 func (s *Store) ReplicaDescriptor(groupID roachpb.RangeID, replicaID roachpb.ReplicaID) (roachpb.ReplicaDescriptor, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.replicaDescriptorLocked(groupID, replicaID)
 }
 
 // replicaDescriptorLocked returns the replica descriptor for the given
 // range and replica, if known.
 func (s *Store) replicaDescriptorLocked(groupID roachpb.RangeID, replicaID roachpb.ReplicaID) (roachpb.ReplicaDescriptor, error) {
-	if rep, ok := s.replicaDescCache.Get(replicaDescCacheKey{groupID, replicaID}); ok {
+	if rep, ok := s.mu.replicaDescCache.Get(replicaDescCacheKey{groupID, replicaID}); ok {
 		return rep.(roachpb.ReplicaDescriptor), nil
 	}
 	rep, err := s.getReplicaLocked(groupID)
@@ -1674,21 +1681,23 @@ func (s *Store) replicaDescriptorLocked(groupID roachpb.RangeID, replicaID roach
 
 // cacheReplicaDescriptorLocked adds the given replica descriptor to a cache
 // to be used by replicaDescriptorLocked.
+// cacheReplicaDescriptorLocked requires that the store lock is held.
 func (s *Store) cacheReplicaDescriptorLocked(groupID roachpb.RangeID, replica roachpb.ReplicaDescriptor) {
-	if old, ok := s.replicaDescCache.Get(replicaDescCacheKey{groupID, replica.ReplicaID}); ok {
+	if old, ok := s.mu.replicaDescCache.Get(replicaDescCacheKey{groupID, replica.ReplicaID}); ok {
 		if old != replica {
 			log.Fatalf("%s replicaDescCache: clobbering %s with %s", s, old, replica)
 		}
 		return
 	}
-	s.replicaDescCache.Add(replicaDescCacheKey{groupID, replica.ReplicaID}, replica)
+	s.mu.replicaDescCache.Add(replicaDescCacheKey{groupID, replica.ReplicaID}, replica)
 }
 
 // canApplySnapshot returns true if the snapshot can be applied to
 // this store's replica (i.e. it is not from an older incarnation of
-// the replica). The caller must hold the store's lock.
-func (s *Store) canApplySnapshot(rangeID roachpb.RangeID, snap raftpb.Snapshot) bool {
-	if r, ok := s.replicas[rangeID]; ok && r.isInitialized() {
+// the replica).
+// canApplySnapshot requires that the store lock is held.
+func (s *Store) canApplySnapshotLocked(rangeID roachpb.RangeID, snap raftpb.Snapshot) bool {
+	if r, ok := s.mu.replicas[rangeID]; ok && r.isInitialized() {
 		// We have the range and it's initialized, so let the snapshot
 		// through.
 		return true
@@ -1760,9 +1769,9 @@ func (s *Store) computeReplicationStatus(now int64) (
 	}
 
 	timestamp := roachpb.Timestamp{WallTime: now}
-	s.Lock()
-	defer s.Unlock()
-	for _, rng := range s.replicas {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, rng := range s.mu.replicas {
 		zoneConfig, err := cfg.GetZoneConfigForKey(rng.Desc().StartKey)
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
Fixes #3722 

commit 1) convert replica's sync.RWMutex to a sync.Mutex
commit 2) convert store's  sync.RWMutex to a sync.Mutex and embed it instead of using the mu variable
commit 3) turn replica's sync.Mutex into an anonymous struct
commit 4) turn store's sync.Mutex into an anonymous struct

I think I caught the comments about holding a read lock as well.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3747)

<!-- Reviewable:end -->
