### PR TITLE
sql: First step in decoupling select from scan

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -158,7 +158,7 @@ func (p *planner) backfillBatch(b *client.Batch, oldTableDesc, newTableDesc *Tab
 			desc:    oldTableDesc,
 		}
 		scan.initDescDefaults()
-		rows, err := p.selectWithScan(scan, &parser.Select{Exprs: oldTableDesc.allColumnsSelector()})
+		rows, err := p.initScanNode(scan, &parser.Select{Exprs: oldTableDesc.allColumnsSelector()})
 		if err != nil {
 			return err
 		}

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -75,6 +75,9 @@ func (p *planner) Explain(n *parser.Explain) (planNode, error) {
 
 func markDebug(plan planNode, mode explainMode) (planNode, error) {
 	switch t := plan.(type) {
+	case *selectNode:
+		return markDebug(t.from, mode)
+
 	case *scanNode:
 		// Mark the node as being explained.
 		t.columns = []column{

--- a/sql/group.go
+++ b/sql/group.go
@@ -156,9 +156,13 @@ func (p *planner) groupBy(n *parser.Select, s *scanNode) (*groupNode, error) {
 	return group, nil
 }
 
+// A groupNode implements the planNode interface and handles the grouping logic.
+// It "wraps" a planNode which is used to retrieve the ungrouped results.
 type groupNode struct {
 	planner *planner
-	plan    planNode
+
+	// The "wrapped" node (which returns ungrouped results).
+	plan planNode
 
 	render []parser.Expr
 	having parser.Expr

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -276,3 +276,4 @@ var _ planNode = &limitNode{}
 var _ planNode = &scanNode{}
 var _ planNode = &sortNode{}
 var _ planNode = &valuesNode{}
+var _ planNode = &selectNode{}


### PR DESCRIPTION
This is the first in a sequence of changes to decouple the select code from the 
scan code (see issue #3707). 

We define selectNode (which has an internal reference to scanNode) and we
refactor the init path. The generic select logic will gradually be moved from
scanNode to selectNode. 

TestLogic passed with the default dataset, it's now running with the -bigtest set. Let me know what else I should run.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3753)

<!-- Reviewable:end -->
