### PR TITLE
storage: relax TestAcquireLeaderLease requirements

### DIFF
--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -225,7 +225,7 @@ func (t Timestamp) Add(wallTime int64, logical int32) Timestamp {
 }
 
 // Next returns the timestamp with the next later timestamp.
-func (t *Timestamp) Next() Timestamp {
+func (t Timestamp) Next() Timestamp {
 	if t.Logical == math.MaxInt32 {
 		if t.WallTime == math.MaxInt64 {
 			panic("cannot take the next value to a max timestamp")
@@ -241,7 +241,7 @@ func (t *Timestamp) Next() Timestamp {
 }
 
 // Prev returns the next earliest timestamp.
-func (t *Timestamp) Prev() Timestamp {
+func (t Timestamp) Prev() Timestamp {
 	if t.Logical > 0 {
 		return Timestamp{
 			WallTime: t.WallTime,

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -114,7 +114,7 @@ type queueLog struct {
 
 func (l queueLog) Infof(logv bool, format string, a ...interface{}) {
 	if logv {
-		log.Infof(l.prefix+format, a...)
+		log.InfofDepth(1, l.prefix+format, a...)
 	}
 	l.traceLog.Printf(format, a...)
 }

--- a/storage/raft.go
+++ b/storage/raft.go
@@ -48,80 +48,73 @@ type raftLogger struct {
 	group uint64
 }
 
-func (r *raftLogger) prependContext(format string, v []interface{}) string {
-	var s string
+// logPrefix returns a string that will prefix logs emitted by
+// raftLogger. Bad things will happen if this method returns a string
+// containing unescaped '%' characters.
+func (r *raftLogger) logPrefix() string {
 	if r.group != 0 {
-		v2 := append([]interface{}{r.group}, v...)
-		s = fmt.Sprintf("[group %d] "+format, v2...)
-	} else {
-		s = fmt.Sprintf(format, v...)
+		return fmt.Sprintf("[group %d] ", r.group)
 	}
-	return s
+	return ""
 }
 
-func (*raftLogger) Debug(v ...interface{}) {
+func (r *raftLogger) Debug(v ...interface{}) {
 	if log.V(2) {
-		log.InfoDepth(1, v...)
+		log.InfofDepth(1, r.logPrefix(), v...)
 	}
 }
 
 func (r *raftLogger) Debugf(format string, v ...interface{}) {
 	if log.V(2) {
-		s := r.prependContext(format, v)
-		log.InfoDepth(1, s)
+		log.InfofDepth(1, r.logPrefix()+format, v...)
 	}
 }
 
-func (*raftLogger) Info(v ...interface{}) {
+func (r *raftLogger) Info(v ...interface{}) {
 	if log.V(1) {
-		log.InfoDepth(1, v...)
+		log.InfofDepth(1, r.logPrefix(), v...)
 	}
 }
 
 func (r *raftLogger) Infof(format string, v ...interface{}) {
 	if log.V(1) {
-		s := r.prependContext(format, v)
-		log.InfoDepth(1, s)
+		log.InfofDepth(1, r.logPrefix()+format, v...)
 	}
 }
 
-func (*raftLogger) Warning(v ...interface{}) {
-	log.WarningDepth(1, v...)
+func (r *raftLogger) Warning(v ...interface{}) {
+	log.WarningfDepth(1, r.logPrefix(), v...)
 }
 
 func (r *raftLogger) Warningf(format string, v ...interface{}) {
-	s := r.prependContext(format, v)
-	log.WarningDepth(1, s)
+	log.WarningfDepth(1, r.logPrefix()+format, v...)
 }
 
-func (*raftLogger) Error(v ...interface{}) {
-	log.ErrorDepth(1, v...)
+func (r *raftLogger) Error(v ...interface{}) {
+	log.ErrorfDepth(1, r.logPrefix(), v...)
 }
 
 func (r *raftLogger) Errorf(format string, v ...interface{}) {
-	s := r.prependContext(format, v)
-	log.ErrorDepth(1, s)
+	log.ErrorfDepth(1, r.logPrefix()+format, v...)
 }
 
-func (*raftLogger) Fatal(v ...interface{}) {
-	log.FatalDepth(1, v...)
+func (r *raftLogger) Fatal(v ...interface{}) {
+	log.FatalfDepth(1, r.logPrefix(), v...)
 }
 
 func (r *raftLogger) Fatalf(format string, v ...interface{}) {
-	s := r.prependContext(format, v)
-	log.FatalDepth(1, s)
+	log.FatalfDepth(1, r.logPrefix()+format, v...)
 }
 
-func (*raftLogger) Panic(v ...interface{}) {
+func (r *raftLogger) Panic(v ...interface{}) {
 	s := fmt.Sprint(v...)
-	log.ErrorDepth(1, s)
+	log.ErrorfDepth(1, s)
 	panic(s)
 }
 
 func (r *raftLogger) Panicf(format string, v ...interface{}) {
-	s := r.prependContext(format, v)
-	log.ErrorDepth(1, s)
-	panic(s)
+	log.ErrorfDepth(1, r.logPrefix()+format, v...)
+	panic(fmt.Sprintf(r.logPrefix()+format, v...))
 }
 
 var logRaftReadyMu sync.Mutex

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -84,10 +84,11 @@ func Infof(format string, args ...interface{}) {
 	logDepth(nil, 1, InfoLog, format, args)
 }
 
-// InfoDepth logs to the INFO log, offsetting the caller's stack frame by
-// 'depth'.
-func InfoDepth(depth int, args ...interface{}) {
-	logDepth(nil, depth+1, InfoLog, "", args)
+// InfofDepth logs to the INFO log, offsetting the caller's stack frame by
+// 'depth'. Passing an empty string for `format` causes this method to
+// naturally format `args`.
+func InfofDepth(depth int, format string, args ...interface{}) {
+	logDepth(nil, depth+1, InfoLog, format, args)
 }
 
 // Warningc logs to the WARNING and INFO logs. It extracts values from the
@@ -112,10 +113,11 @@ func Warningf(format string, args ...interface{}) {
 	logDepth(nil, 1, WarningLog, format, args)
 }
 
-// WarningDepth logs to the WARNING and INFO logs, offsetting the caller's
-// stack frame by 'depth'.
-func WarningDepth(depth int, args ...interface{}) {
-	logDepth(nil, depth+1, WarningLog, "", args)
+// WarningfDepth logs to the WARNING and INFO logs, offsetting the caller's
+// stack frame by 'depth'. Passing an empty string for `format` causes this
+// method to naturally format `args`.
+func WarningfDepth(depth int, format string, args ...interface{}) {
+	logDepth(nil, depth+1, WarningLog, format, args)
 }
 
 // Errorc logs to the ERROR, WARNING, and INFO logs. It extracts values from
@@ -138,10 +140,11 @@ func Errorf(format string, args ...interface{}) {
 	logDepth(nil, 1, ErrorLog, format, args)
 }
 
-// ErrorDepth logs to the ERROR, WARNING, and INFO logs, offsetting the
-// caller's stack frame by 'depth'.
-func ErrorDepth(depth int, args ...interface{}) {
-	logDepth(nil, depth+1, ErrorLog, "", args)
+// ErrorfDepth logs to the ERROR, WARNING, and INFO logs, offsetting the
+// caller's stack frame by 'depth'. Passing an empty string for `format` causes
+// this method to naturally format `args`.
+func ErrorfDepth(depth int, format string, args ...interface{}) {
+	logDepth(nil, depth+1, ErrorLog, format, args)
 }
 
 // Fatalc logs to the INFO, WARNING, ERROR, and FATAL logs, including a stack
@@ -167,11 +170,12 @@ func Fatalf(format string, args ...interface{}) {
 	logDepth(nil, 1, FatalLog, format, args)
 }
 
-// FatalDepth logs to the INFO, WARNING, ERROR, and FATAL logs,
+// FatalfDepth logs to the INFO, WARNING, ERROR, and FATAL logs,
 // including a stack trace of all running goroutines, then calls os.Exit(255),
-// offsetting the caller's stack frame by 'depth'.
-func FatalDepth(depth int, args ...interface{}) {
-	logDepth(nil, depth+1, FatalLog, "", args)
+// offsetting the caller's stack frame by 'depth'. Passing an empty string for
+// `format` causes this method to naturally format `args`.
+func FatalfDepth(depth int, format string, args ...interface{}) {
+	logDepth(nil, depth+1, FatalLog, format, args)
 }
 
 // V returns true if the logging verbosity is set to the specified level or

--- a/util/tracer/tracer.go
+++ b/util/tracer/tracer.go
@@ -187,9 +187,10 @@ func (t *Trace) Fork() *Trace {
 // Trace.
 func (t Trace) String() string {
 	const tab = "\t"
-	buf := bytes.NewBuffer(nil)
-	w := tabwriter.NewWriter(buf, 1, 1, 0, ' ', 0)
-	fmt.Fprintln(w, "Name", tab, "Origin", tab, "Ts", tab, "Dur", tab, "Desc", tab, "File")
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 1, 1, 0, ' ', 0)
+	fmt.Fprintln(w, "Trace", t.Name)
+	fmt.Fprintln(w, "Origin", tab, "Ts", tab, "Dur", tab, "Desc", tab, "File")
 
 	const traceTimeFormat = "15:04:05.000000"
 	for _, c := range t.Content {
@@ -197,9 +198,9 @@ func (t Trace) String() string {
 		if c.depth > 1 {
 			namePrefix = strings.Repeat("·", int(c.depth-1))
 		}
-		fmt.Fprintln(w, t.Name, tab, c.Origin, tab,
-			c.Timestamp.Format(traceTimeFormat), tab, c.Duration, tab,
-			namePrefix+c.Name, tab, c.File+":"+strconv.Itoa(c.Line))
+		fmt.Fprintln(w, c.Origin, tab, c.Timestamp.Format(traceTimeFormat),
+			tab, c.Duration, tab, namePrefix+c.Name, tab,
+			c.File+":"+strconv.Itoa(c.Line))
 	}
 
 	_ = w.Flush()


### PR DESCRIPTION
Some random logging improvements here, too.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3754)

<!-- Reviewable:end -->
