### PR TITLE
Introduce a few optimized LIKE matching paths that avoid Regexp compilation

### DIFF
--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -430,3 +430,26 @@ func TestSimilarEscape(t *testing.T) {
 		}
 	}
 }
+
+var optimizedLikePatterns = []string{
+	`test%`,
+	`%test%`,
+	`%test`,
+}
+
+func benchmarkLike(b *testing.B, ctx EvalContext) {
+	likeFn := cmpOps[cmpArgs{Like, stringType, stringType}].fn
+	for n := 0; n < b.N; n++ {
+		for _, p := range optimizedLikePatterns {
+			likeFn(ctx, DString("test"), DString(p))
+		}
+	}
+}
+
+func BenchmarkLikeWithCache(b *testing.B) {
+	benchmarkLike(b, EvalContext{ReCache: NewRegexpCache(len(optimizedLikePatterns))})
+}
+
+func BenchmarkLikeWithoutCache(b *testing.B) {
+	benchmarkLike(b, EvalContext{})
+}


### PR DESCRIPTION
Inspired by [Spark SQL](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala#L379).

Typical workload (6 of 9 patterns optimizable)

```
name                old time/op  new time/op  delta
LikeWithCache-4     5.33µs ± 2%  3.09µs ± 3%  -42.01%  (p=0.000 n=8+10)
LikeWithoutCache-4   123µs ± 5%    33µs ± 8%  -73.49%  (p=0.000 n=8+10)
```

Optimal workload (all 6 patterns optimizable)

```
name                old time/op  new time/op  delta
LikeWithCache-4     4.82µs ±47%  1.52µs ± 9%  -68.44%  (p=0.000 n=10+9)
LikeWithoutCache-4   119µs ±18%     1µs ±11%  -98.76%  (p=0.000 n=9+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3756)

<!-- Reviewable:end -->
