### PR TITLE
Use the correct lease when extending the schema change lease.

### DIFF
--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -280,7 +280,6 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 
 func TestAsyncSchemaChanger(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("#3764")
 	// Disable synchronous schema change execution so
 	// the asynchronous schema changer executes all
 	// schema changes.


### PR DESCRIPTION
Reenable TestAsyncSchemaChanger. Without this fix, if the
extend lease txn retried, it would use a recomputed lease that
was different from the one stored in the table, resulting in the
lease not getting extended and the schema change failing and
being purged. The test would block on schema change execution,
which would never happen because it was purged.

closes #3764

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3789)

<!-- Reviewable:end -->
