### PR TITLE
Add a separate heartbeatTimeout configuration.

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -45,9 +45,8 @@ const (
 )
 
 var (
-	clientMu          sync.Mutex         // Protects access to the client cache.
-	clients           map[string]*Client // Cache of RPC clients.
-	heartbeatInterval = defaultHeartbeatInterval
+	clientMu sync.Mutex         // Protects access to the client cache.
+	clients  map[string]*Client // Cache of RPC clients.
 	// TODO(tschottdorf) err{Closed,Unstarted} are candidates for NodeUnavailableError.
 	errClosed    = errors.New("client is closed")
 	errUnstarted = errors.New("not started yet")
@@ -91,6 +90,8 @@ type Client struct {
 	clock             *hlc.Clock
 	remoteClocks      *RemoteClockMonitor
 	remoteOffset      RemoteOffset
+	heartbeatInterval time.Duration
+	heartbeatTimeout  time.Duration
 }
 
 // NewClient returns a client RPC stub for the specified address
@@ -131,6 +132,15 @@ func NewClient(addr net.Addr, context *Context) *Client {
 		disableReconnects: context.DisableReconnects,
 		clock:             context.localClock,
 		remoteClocks:      context.RemoteClocks,
+		heartbeatInterval: context.heartbeatInterval,
+		heartbeatTimeout:  context.heartbeatTimeout,
+	}
+
+	if c.heartbeatInterval == 0 {
+		c.heartbeatInterval = defaultHeartbeatInterval
+	}
+	if c.heartbeatTimeout == 0 {
+		c.heartbeatTimeout = 2 * c.heartbeatInterval
 	}
 
 	c.healthy.Store(make(chan struct{}))
@@ -248,6 +258,18 @@ func (c *Client) close() {
 	}
 }
 
+func (c *Client) maybeClose(extCloser <-chan struct{}) bool {
+	select {
+	case <-c.closer:
+		return true
+	case <-extCloser:
+		c.close()
+		return true
+	default:
+		return false
+	}
+}
+
 // runHeartbeat sends periodic heartbeats to client, marking the client healthy
 // or unhealthy and reconnecting appropriately until either the Client or the
 // supplied channel is closed.
@@ -280,13 +302,8 @@ func (c *Client) runHeartbeat(retryOpts retry.Options) {
 	var err = errUnstarted // initial condition
 	for {
 		for r := retry.Start(retryOpts); r.Next(); {
-			select {
-			case <-c.closer:
+			if c.maybeClose(retryOpts.Closer) {
 				return
-			case <-retryOpts.Closer:
-				c.close()
-				return
-			default:
 			}
 
 			// Reconnect on failure.
@@ -306,6 +323,9 @@ func (c *Client) runHeartbeat(retryOpts retry.Options) {
 			if err = c.heartbeat(retryOpts.Closer); err != nil {
 				setUnhealthy()
 				log.Warning(err)
+				if c.maybeClose(retryOpts.Closer) {
+					return
+				}
 				continue
 			}
 
@@ -321,7 +341,7 @@ func (c *Client) runHeartbeat(retryOpts retry.Options) {
 		case <-retryOpts.Closer:
 			c.close()
 			return
-		case <-time.After(heartbeatInterval):
+		case <-time.After(c.heartbeatInterval):
 			// TODO(tamird): Perhaps retry more aggressively when the client is unhealthy.
 		}
 	}
@@ -357,8 +377,8 @@ func (c *Client) heartbeat(closer <-chan struct{}) error {
 		if err := call.Error; err != nil {
 			return err
 		}
-	case <-time.After(2 * heartbeatInterval):
-		return util.Errorf("heartbeat timed out after %s", 2*heartbeatInterval)
+	case <-time.After(c.heartbeatTimeout):
+		return util.Errorf("heartbeat timed out after %s", c.heartbeatTimeout)
 	}
 
 	receiveTime := c.clock.PhysicalNow()

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -34,7 +34,7 @@ var (
 )
 
 func init() {
-	monitorInterval = heartbeatInterval * 10
+	monitorInterval = defaultHeartbeatInterval * 10
 }
 
 // RemoteClockMonitor keeps track of the most recent measurements of remote

--- a/rpc/main_test.go
+++ b/rpc/main_test.go
@@ -38,12 +38,10 @@ func init() {
 //go:generate ../util/leaktest/add-leaktest.sh *_test.go
 
 func TestMain(m *testing.M) {
-	defer func(hbInterval time.Duration, retryOpts retry.Options) {
-		heartbeatInterval = hbInterval
+	defer func(retryOpts retry.Options) {
 		clientRetryOptions = retryOpts
-	}(heartbeatInterval, clientRetryOptions)
+	}(clientRetryOptions)
 
-	heartbeatInterval = 10 * time.Millisecond
 	clientRetryOptions = retry.Options{
 		InitialBackoff: 1 * time.Millisecond,
 		MaxBackoff:     1 * time.Millisecond,
@@ -58,7 +56,10 @@ func newNodeTestContext(clock *hlc.Clock, stopper *stop.Stopper) *Context {
 	if clock == nil {
 		clock = hlc.NewClock(hlc.UnixNano)
 	}
-	return NewContext(testutils.NewNodeTestBaseContext(), clock, stopper)
+	ctx := NewContext(testutils.NewNodeTestBaseContext(), clock, stopper)
+	ctx.heartbeatInterval = 10 * time.Millisecond
+	ctx.heartbeatTimeout = 2 * defaultHeartbeatInterval
+	return ctx
 }
 
 func newTestServer(t *testing.T, ctx *Context, manual bool) (*Server, net.Listener) {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -19,6 +19,9 @@ type Context struct {
 	DisableCache      bool // Disable client cache when calling NewClient()
 	DisableReconnects bool // Disable client reconnects
 	HealthWait        time.Duration
+
+	heartbeatInterval time.Duration
+	heartbeatTimeout  time.Duration
 }
 
 // NewContext creates an rpc Context with the supplied values.


### PR DESCRIPTION
Tests were previously computing heartbeat timeouts of 20ms which would
sometimes expire on very slow/overloaded machines. With a separate
heartbeatTimeout configuration, only tests which need a low
heartbeatTimeout bother to change it.

De-flake a few other tests by increasing timeouts or removing them
entirely on relying on the test timeout.

Fixes #3734.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3790)

<!-- Reviewable:end -->
