### PR TITLE
Fixed bug in MergeInto function in storage/timestamp_cache

### DIFF
--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -158,12 +158,8 @@ func (tc *TimestampCache) MergeInto(dest *TimestampCache, clear bool) {
 		dest.lowWater = tc.lowWater
 		dest.latest = tc.latest
 	} else {
-		if dest.lowWater.Less(tc.lowWater) {
-			dest.lowWater = tc.lowWater
-		}
-		if dest.latest.Less(tc.latest) {
-			tc.latest = dest.latest
-		}
+		dest.lowWater.Forward(tc.lowWater)
+		dest.latest.Forward(tc.latest)
 	}
 	tc.cache.Do(func(k, v interface{}) {
 		dest.cache.Add(k, v)

--- a/storage/timestamp_cache_test.go
+++ b/storage/timestamp_cache_test.go
@@ -231,6 +231,13 @@ func TestTimestampCacheMergeInto(t *testing.T) {
 			if rTS, _ := tc2.GetMax(roachpb.Key("a"), roachpb.Key("c"), nil); !rTS.Equal(aaTS) {
 				t.Error("expected \"a\"-\"c\" to have aaTS timestamp")
 			}
+
+			if !tc2.latest.Equal(cTS) {
+				t.Error("expected \"aa\" to have cTS timestamp")
+			}
+			if !tc1.latest.Equal(cTS) {
+				t.Error("expected \"a\"-\"c\" to have cTS timestamp")
+			}
 		}
 	}
 }

--- a/storage/timestamp_cache_test.go
+++ b/storage/timestamp_cache_test.go
@@ -231,14 +231,13 @@ func TestTimestampCacheMergeInto(t *testing.T) {
 			if rTS, _ := tc2.GetMax(roachpb.Key("a"), roachpb.Key("c"), nil); !rTS.Equal(aaTS) {
 				t.Error("expected \"a\"-\"c\" to have aaTS timestamp")
 			}
-			//Proposed new test by AbhishekSaha
-			//Tests PR #3797
-			if !tc2.latest.Equal(cTS) { //Thrown if dest timestamp cache doesn't have origin's latest timestamp
+
+			if !tc2.latest.Equal(cTS) {
 				t.Error("expected \"aa\" to have cTS timestamp")
 			}
-			if !tc1.latest.Equal(cTS) {//Thrown if origin's timestamp is replaced; tests for bug that triggered PR
+			if !tc1.latest.Equal(cTS) {
 				t.Error("expected \"a\"-\"c\" to have cTS timestamp")
-		}
+			}
 		}
 	}
 }

--- a/storage/timestamp_cache_test.go
+++ b/storage/timestamp_cache_test.go
@@ -231,6 +231,14 @@ func TestTimestampCacheMergeInto(t *testing.T) {
 			if rTS, _ := tc2.GetMax(roachpb.Key("a"), roachpb.Key("c"), nil); !rTS.Equal(aaTS) {
 				t.Error("expected \"a\"-\"c\" to have aaTS timestamp")
 			}
+			//Proposed new test by AbhishekSaha
+			//Tests PR #3797
+			if !tc2.latest.Equal(cTS) { //Thrown if dest timestamp cache doesn't have origin's latest timestamp
+				t.Error("expected \"aa\" to have cTS timestamp")
+			}
+			if !tc1.latest.Equal(cTS) {//Thrown if origin's timestamp is replaced; tests for bug that triggered PR
+				t.Error("expected \"a\"-\"c\" to have cTS timestamp")
+		}
 		}
 	}
 }


### PR DESCRIPTION
I saw this bug: https://github.com/cockroachdb/cockroach/issues/3554 and fixed the bug. I'm new to Cockroach and Open Source, so I'm still learning the ropes but I'm hoping this pull request is OK

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3797)

<!-- Reviewable:end -->
