### PR TITLE
storage_test: increase scanner frequency

### DIFF
--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -516,7 +516,6 @@ func fillRange(store *storage.Store, rangeID roachpb.RangeID, prefix roachpb.Key
 // exceeding zone's RangeMaxBytes.
 func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("#3762")
 	store, stopper := createTestStore(t)
 	config.TestingSetupZoneConfigHook(stopper)
 	defer stopper.Stop()
@@ -577,7 +576,6 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 // split.
 func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("#3749")
 	store, stopper := createTestStore(t)
 	config.TestingSetupZoneConfigHook(stopper)
 	defer stopper.Stop()
@@ -612,7 +610,6 @@ func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 // the SystemConfig span.
 func TestStoreRangeSystemSplits(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("#3698")
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -93,6 +93,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
 	sCtx.Gossip = gossip.New(rpcContext, gossip.TestBootstrap)
 	sCtx.Gossip.SetNodeID(nodeDesc.NodeID)
+	sCtx.ScanMaxIdleTime = splitTimeout / 10
 	sCtx.Tracer = tracer.NewTracer(nil, "testing")
 	stores := storage.NewStores(clock)
 	rpcSend := func(_ rpc.Options, _ string, _ []net.Addr,
@@ -122,6 +123,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	sender := kv.NewTxnCoordSender(distSender, clock, false, nil, stopper)
 	sCtx.Clock = clock
 	sCtx.DB = client.NewDB(sender)
+	sCtx.StorePool = storage.NewStorePool(sCtx.Gossip, clock, storage.TestTimeUntilStoreDeadOff, stopper)
 	sCtx.Transport = storage.NewLocalRPCTransport(stopper)
 	// TODO(bdarnell): arrange to have the transport closed.
 	store := storage.NewStore(*sCtx, eng, nodeDesc)

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -399,8 +399,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) {
 	if err := bq.impl.process(clock.Now(), repl, cfg); err != nil {
 		bq.eventLog.Errorf("%s: error: %v", repl, err)
 	} else {
-		bq.eventLog.Infof(log.V(2), "%s: done: %0.2fms", repl,
-			time.Since(start).Seconds()*1000)
+		bq.eventLog.Infof(log.V(2), "%s: done: %s", repl, time.Since(start))
 	}
 }
 


### PR DESCRIPTION
Fixes #3698.
Fixes #3749.
Fixes #3762.

Somewhat surprisingly, this doesn't adversely affect the storage tests' runtime.
Before: 13.024s
After: 12.432s

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3805)

<!-- Reviewable:end -->
