### PR TITLE
Parallelize normal and race tests.

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -41,7 +41,6 @@ if [ -t 0 ]; then
   tty="--tty"
 fi
 
-buildcache_dir="buildcache"
 uicache_dir="uicache"
 
 # Absolute path to the toplevel cockroach directory.
@@ -70,11 +69,11 @@ docker run -i ${tty-} ${rm} \
   --volume="${gopath0}/pkg/linux_amd64_netgo:/usr/src/go/pkg/linux_amd64_netgo" \
   --volume="${gopath0}/pkg/linux_amd64_race:/usr/src/go/pkg/linux_amd64_race" \
   --volume="${gopath0}/bin/linux_amd64:/go/bin" \
-  --volume="${HOME}/${buildcache_dir}:/${buildcache_dir}" \
   --volume="${HOME}/${uicache_dir}:/${uicache_dir}" \
   --volume="${cockroach_toplevel}:/go/src/github.com/cockroachdb/cockroach" \
   --workdir="/go/src/github.com/cockroachdb/cockroach" \
-  --env="CACHE=/${buildcache_dir}" \
   --env="PAGER=cat" \
   --env="TSD_GITHUB_TOKEN=${TSD_GITHUB_TOKEN-}" \
+  --env="CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX}" \
+  --env="CIRCLE_NODE_TOTAL=${CIRCLE_NODE_TOTAL}" \
   "${image}" "$@"

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -2,6 +2,10 @@
 
 set -eux
 
+function is_shard() {
+  test $(($1 % $CIRCLE_NODE_TOTAL)) -eq $CIRCLE_NODE_INDEX
+}
+
 # This is mildly tricky: This script runs itself recursively. The
 # first time it is run it does not take the if-branch below and
 # executes on the host computer. As a final step it uses the
@@ -9,56 +13,62 @@ set -eux
 # the argument causing the commands in the if-branch to be executed
 # within the docker container.
 if [ "${1-}" = "docker" ]; then
-  cmds=$(grep '^cmd' GLOCKFILE | grep -v glock | awk '{print $2}')
+  # Be careful to keep the dependencies built for each shard in sync
+  # with the dependencies used by each shard in circle-test.sh.
 
-  # Symlink the cache into the source tree if they don't exist.
-  # In circleci they never do, but this script can also be run
-  # locally where they might.
-  for i in bower_components node_modules typings; do
-    if ! [ -e ui/$i ]; then
-      # Create the cache directory to avoid errors on `ln` below.
-      # `/uicache` is `~/uicache` on the host computer, which is cached
-      # by circle-ci.
-      mkdir -p /uicache/$i
-      ln -s /uicache/$i ui/$i
-    fi
-  done
+  if is_shard 0; then
+    # Symlink the cache into the source tree if they don't exist.
+    # In circleci they never do, but this script can also be run
+    # locally where they might.
+    for i in bower_components node_modules typings; do
+      if ! [ -e ui/$i ]; then
+        # Create the cache directory to avoid errors on `ln` below.
+        # `/uicache` is `~/uicache` on the host computer, which is cached
+        # by circle-ci.
+        mkdir -p /uicache/$i
+        ln -s /uicache/$i ui/$i
+      fi
+    done
 
-  time make -C ui npm.installed   || rm -rf ui/node_modules/*     && make -C ui npm.installed
-  time make -C ui bower.installed || rm -rf ui/bower_components/* && make -C ui bower.installed
-  time make -C ui tsd.installed   || rm -rf ui/typings/*          && make -C ui tsd.installed
+    time make -C ui npm.installed   || rm -rf ui/node_modules/*     && make -C ui npm.installed
+    time make -C ui bower.installed || rm -rf ui/bower_components/* && make -C ui bower.installed
+    time make -C ui tsd.installed   || rm -rf ui/typings/*          && make -C ui tsd.installed
 
-  # Restore previously cached build artifacts.
-  time go install github.com/cockroachdb/build-cache
-  time build-cache restore . .:race,test ${cmds}
-  # Build everything needed by circle-test.sh.
-  time go test -race -v -i ./...
-  time go install -v ${cmds}
-  time make install
-  time go test -v -c -tags acceptance ./acceptance
-  # Cache the current build artifacts for future builds.
-  time build-cache save . .:race,test ${cmds}
+    cmds=$(grep '^cmd' GLOCKFILE | grep -v glock | awk '{print $2}')
+    time go install -v ${cmds}
+  fi
+
+  if is_shard 1; then
+    time make install GOFLAGS=-v
+    time go test -v -i ./...
+    time go test -v -c -tags acceptance ./acceptance
+    # Avoid code rot.
+    time go build ./gossip/simulation/...
+  fi
+
+  if is_shard 2; then
+    time go test -race -v -i ./...
+  fi
 
   exit 0
 fi
 
-# `~/buildcache` is cached by circle-ci.
-buildcache_dir=~/buildcache
+# `~/builder` is cached by circle-ci.
+builder_dir=~/builder
+mkdir -p "${builder_dir}"
+du -sh "${builder_dir}"
+ls -lah "${builder_dir}"
 
 # The tag for the cockroachdb/builder image. If the image is changed
 # (for example, adding "npm"), a new image should be pushed using
 # "build/builder.sh push" and the new tag value placed here.
 tag="20151210-134003"
 
-mkdir -p "${buildcache_dir}"
-du -sh "${buildcache_dir}"
-ls -lh "${buildcache_dir}"
-
 if ! docker images | grep -q "${tag}"; then
   # If there's a base image cached, load it. A click on CircleCI's "Clear
   # Cache" will make sure we start with a clean slate.
-  rm -f "$(ls ${buildcache_dir}/builder*.tar 2>/dev/null | grep -v ${tag})"
-  builder="${buildcache_dir}/builder.${tag}.tar"
+  builder="${builder_dir}/builder.${tag}.tar"
+  find "${builder_dir}" -not -path "${builder}" -type f -delete  
   if [[ ! -e "${builder}" ]]; then
     time docker pull "cockroachdb/builder:${tag}"
     docker tag -f "cockroachdb/builder:${tag}" "cockroachdb/builder:latest"
@@ -69,17 +79,9 @@ if ! docker images | grep -q "${tag}"; then
   fi
 fi
 
-HOME="" go get -d -u github.com/cockroachdb/build-cache
 HOME="" go get -u github.com/robfig/glock
 grep -v '^cmd' GLOCKFILE | glock sync -n
 
 # Recursively invoke this script inside the builder docker container,
 # passing "docker" as the first argument.
 $(dirname $0)/builder.sh $0 docker
-
-# Clear the cache of any files that haven't been modified in more than
-# 12 hours. Note that the "build-cache restore" call above will
-# "touch" any cache files that are used by the current run.
-find "${buildcache_dir}" -type f -mmin +720 -ls -delete
-du -sh "${buildcache_dir}"
-ls -lh "${buildcache_dir}"

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -110,51 +110,57 @@ prepare_artifacts() {
 
 trap prepare_artifacts EXIT
 
-# 1. Run "make check" to verify coding guidelines.
-echo "make check"
-time ${builder} make check | tee "${outdir}/check.log"
+function is_shard() {
+  test $(($1 % $CIRCLE_NODE_TOTAL)) -eq $CIRCLE_NODE_INDEX
+}
 
-# 2.1 Verify that "go generate" was run.
-echo "verifying generated files"
-time ${builder} /bin/bash -c "go generate ./..."
-time ${builder} /bin/bash -c "(git ls-files --modified --deleted --others --exclude-standard | diff /dev/null -) || (git add -A && git diff -u HEAD && false)" | tee "${outdir}/generate.log"
-# 2.2 Avoid code rot.
-echo "building gossip simulation"
-time ${builder} /bin/bash -c "go build ./gossip/simulation/..."
+if is_shard 0; then
+  # Run "make check" to verify coding guidelines.
+  echo "make check"
+  time ${builder} make check | tee "${outdir}/check.log"
 
-# 3. Run "make test".
-echo "make test"
-time ${builder} make test \
-  TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2,tracer=2' | \
-  tr -d '\r' | tee "${outdir}/test.log" | \
-  grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
-  awk '{print "test:", $0}'
-
-# 4. Run the acceptance tests (only on Linux). We can run the
-# acceptance tests on the Mac's, but circle-deps.sh only built the
-# acceptance tests for Linux.
-if [ "$(uname)" = "Linux" ]; then
-  # Make a place for the containers to write their logs.
-  mkdir -p ${outdir}/acceptance
-
-  # Note that this test requires 2>&1 but the others don't because
-  # this one runs outside the builder container (and inside the
-  # container, something is already combining stdout and stderr).
-  time $(dirname $0)/../acceptance.test -num-local 3 -l ${outdir}/acceptance \
-    -test.v -test.timeout 5m \
-    --verbosity=1 --vmodule=monitor=2 2>&1 | \
-    tr -d '\r' | tee "${outdir}/acceptance.log" | \
-    grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
-    awk '{print "acceptance:", $0}'
-else
-  echo "skipping acceptance tests on $(uname): use 'make acceptance' instead"
+  # Verify that "go generate" was run.
+  echo "verifying generated files"
+  time ${builder} /bin/bash -c "go generate ./..."
+  time ${builder} /bin/bash -c "(git ls-files --modified --deleted --others --exclude-standard | diff /dev/null -) || (git add -A && git diff -u HEAD && false)" | tee "${outdir}/generate.log"
 fi
 
-# 5. Run "make testrace". This takes a long time and fails mostly for flaky
-# tests, so it's last to give the "real" failures a chance first.
-echo "make testrace"
-time ${builder} make testrace \
-  TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
-  tr -d '\r' | tee "${outdir}/testrace.log" | \
-  grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
-  awk '{print "race:", $0}'
+if is_shard 1; then
+  # Run "make test".
+  echo "make test"
+  time ${builder} make test \
+    TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2,tracer=2' | \
+    tr -d '\r' | tee "${outdir}/test.log" | \
+    grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
+    awk '{print "test:", $0}'
+
+  # Run the acceptance tests (only on Linux). We can run the
+  # acceptance tests on the Mac's, but circle-deps.sh only built the
+  # acceptance tests for Linux.
+  if [ "$(uname)" = "Linux" ]; then
+    # Make a place for the containers to write their logs.
+    mkdir -p ${outdir}/acceptance
+
+    # Note that this test requires 2>&1 but the others don't because
+    # this one runs outside the builder container (and inside the
+    # container, something is already combining stdout and stderr).
+    time $(dirname $0)/../acceptance.test -num-local 3 -l ${outdir}/acceptance \
+      -test.v -test.timeout 5m \
+      --verbosity=1 --vmodule=monitor=2 2>&1 | \
+      tr -d '\r' | tee "${outdir}/acceptance.log" | \
+      grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
+      awk '{print "acceptance:", $0}'
+  else
+    echo "skipping acceptance tests on $(uname): use 'make acceptance' instead"
+  fi
+fi
+
+if is_shard 2; then
+  # Run "make testrace".
+  echo "make testrace"
+  time ${builder} make testrace \
+    TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
+    tr -d '\r' | tee "${outdir}/testrace.log" | \
+    grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
+    awk '{print "race:", $0}'
+fi

--- a/circle.yml
+++ b/circle.yml
@@ -9,14 +9,16 @@ checkout:
 
 dependencies:
   override:
-    - build/circle-deps.sh
+    - build/circle-deps.sh:
+        parallel: true
   cache_directories:
-    - ~/buildcache
+    - ~/builder
     - ~/uicache
 
 test:
   override:
-    - build/circle-test.sh
+    - build/circle-test.sh:
+        parallel: true
 
 deployment:
   docker:


### PR DESCRIPTION
We now can utilize 3 build machines:
  0 - make check and make acceptance
  1 - make test
  2 - make testrace

This brings CircleCI build times down to around 10-11 min (for
non-master builds).

Apparently CircleCI improved their automatic caching of Go output. The
buildcache stuff is no longer necessary.

Fixes #3758.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3807)

<!-- Reviewable:end -->
