### PR TITLE
sql: wrap selectNode instead of scanNode + some cleanup

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -164,7 +164,11 @@ func (p *planner) backfillBatch(b *client.Batch, oldTableDesc *TableDescriptor, 
 			desc:    oldTableDesc,
 		}
 		scan.initDescDefaults()
-		rows, pErr := p.initScanNode(scan, &parser.Select{Exprs: oldTableDesc.allColumnsSelector()})
+		pErr := scan.init(&parser.Select{Exprs: oldTableDesc.allColumnsSelector()})
+		if pErr != nil {
+			return pErr
+		}
+		rows, pErr := p.selectIndex(scan, nil, false)
 		if pErr != nil {
 			return pErr
 		}

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -50,7 +50,7 @@ import (
 var (
 	resultsRE = regexp.MustCompile(`^(\d+)\s+values?\s+hashing\s+to\s+([0-9A-Fa-f]+)$`)
 	errorRE   = regexp.MustCompile(`^(?:statement|query)\s+error\s+(.*)$`)
-	testdata  = flag.String("d", "testdata/*", "test data glob")
+	testdata  = flag.String("d", "testdata/[^.]*", "test data glob")
 	bigtest   = flag.Bool("bigtest", false, "use the big set of logic test files (overrides testdata)")
 )
 

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -348,6 +348,14 @@ func (n *scanNode) initScan() bool {
 	return true
 }
 
+func (n *scanNode) init(sel *parser.Select) *roachpb.Error {
+	// TODO(radu): the where/targets logic will move into selectNode
+	if pErr := n.initWhere(sel.Where); pErr != nil {
+		return pErr
+	}
+	return n.initTargets(sel.Exprs)
+}
+
 func (n *scanNode) initWhere(where *parser.Where) *roachpb.Error {
 	if where == nil {
 		return nil
@@ -872,9 +880,9 @@ func (v *qnameVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser
 		return nil, expr
 
 	case *parser.FuncExpr:
-		// Special case handling for COUNT(*) and COUNT(foo.*), expanding the star
-		// into a tuple containing the columns in the primary key of the referenced
-		// table.
+		// Special case handling for COUNT(*). This is a special construct to
+		// count the number of rows; in this case * does NOT refer to a set of
+		// columns.
 		if len(t.Name.Indirect) > 0 || !strings.EqualFold(string(t.Name.Base), "count") {
 			break
 		}
@@ -896,20 +904,8 @@ func (v *qnameVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser
 			// will perform normal qualified name resolution.
 			break
 		}
-		// We've got either COUNT(*) or COUNT(foo.*). Retrieve the descriptor.
-		desc := v.getDesc(qname)
-		if desc == nil {
-			break
-		}
-		// Replace the function argument with a non-NULL column. We currently use
-		// the first column of the primary index since that column will be a
-		// candidate for index selection, but any non-NULL column would do for
-		// correctness of the aggregate.
-		var col *ColumnDescriptor
-		if col, v.pErr = desc.FindColumnByID(desc.PrimaryIndex.ColumnIDs[0]); v.pErr != nil {
-			return nil, expr
-		}
-		t.Exprs[0] = v.getQVal(*col)
+		// Replace the function argument with a special non-NULL VariableExpr.
+		t.Exprs[0] = starDatumInstance
 		return v, expr
 
 	case *parser.Subquery:
@@ -941,4 +937,32 @@ func (n *scanNode) resolveQNames(expr parser.Expr) (parser.Expr, *roachpb.Error)
 	v := qnameVisitor{scanNode: n}
 	expr = parser.WalkExpr(&v, expr)
 	return expr, v.pErr
+}
+
+// A VariableExpr used as a dummy argument for the special case COUNT(*).  This
+// ends up being processed correctly by the count aggregator since it is not
+// parser.DNull.
+//
+// We need to implement enough functionality to satisfy the type checker and to
+// allow the the intermediate rendering of the row (before the group
+// aggregation).
+type starDatum struct{}
+
+var starDatumInstance = &starDatum{}
+var _ parser.VariableExpr = starDatumInstance
+
+func (*starDatum) Variable() {}
+
+func (*starDatum) String() string {
+	return "*"
+}
+
+func (*starDatum) Walk(v parser.Visitor) {}
+
+func (*starDatum) TypeCheck(args parser.MapArgs) (parser.Datum, error) {
+	return parser.DummyInt.TypeCheck(args)
+}
+
+func (*starDatum) Eval(ctx parser.EvalContext) (parser.Datum, error) {
+	return parser.DummyInt.Eval(ctx)
 }


### PR DESCRIPTION
This change consists of a few refactoring changes:
- we change the wrapping logic for limit, filters etc to wrap the selectNode
  instead of scanNode
- we simplify the `COUNT(*)` handling: we don't need to resolve the star to the
  primary key column (which won't work if FROM isn't a table); we can just
  resolve to a special non-null variable.
- we clean up the initSelect interface a bit to not rely on sort and group
  nodes directly

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3811)

<!-- Reviewable:end -->
