### PR TITLE
Fix TestStoreRangeRebalance

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1181,7 +1181,6 @@ func TestStoreRangeRemoveDead(t *testing.T) {
 // rebalancing opportunities and add a new replica on another store.
 func TestStoreRangeRebalance(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("TODO(mrtracy): https://github.com/cockroachdb/cockroach/issues/3092")
 
 	// Start multiTestContext with replica rebalancing enabled.
 	mtc := &multiTestContext{


### PR DESCRIPTION
Fixes #3483
Fixes #3092

Two commits: 
1. fixes an issue which arises in multiTestContext when the stores[0] is _not_ the range leader for the first range.
2. Increase a timeout in replicateRange() which was causing 1/5000 failures on local stress test runs.

Unskips TestStoreRangeRebalance.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3814)

<!-- Reviewable:end -->
