### PR TITLE
Fix shell expansion.

### DIFF
--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -89,7 +89,7 @@ prepare_artifacts() {
         # If we generated XML reports and the simple grep didn't find
         # anything (which happens for timeouts and panics), parse the
         # XML for more robust results.
-        FAILEDTESTS=$(python3 -c 'import sys, xml.etree.ElementTree as ET; [print(t.attrib["name"]) for filename in sys.argv[1:] for t in ET.parse(filename).findall(".//failure/..")]' "$(find "${CIRCLE_TEST_REPORTS}" -type f -iname '*.xml')")
+        FAILEDTESTS=$(python3 -c 'import sys, xml.etree.ElementTree as ET; [print(t.attrib["name"]) for filename in sys.argv[1:] for t in ET.parse(filename).findall(".//failure/..")]' $(find "${CIRCLE_TEST_REPORTS}" -type f -iname '*.xml'))
       fi
       # Generate string for JSON labels below:
       # '"test-failure", "TestRaftRemoveRace", "TestChaos", "TestHoneyBooBoo"'


### PR DESCRIPTION
"$@" is a special-case and does not generalize to other variable
expansions. This change will break if we ever see CIRCLE_TEST_REPORTS
paths with spaces but fixing that is a pain and I trust circleci not
to do something so obnoxious.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3820)

<!-- Reviewable:end -->
