### PR TITLE
Simplify TestStoreRangeDownReplicate and make it robust

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -56,7 +56,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-const replicationTimeout = 3 * time.Second
+const replicationTimeout = 5 * time.Second
 
 // Check that Stores implements the RangeDescriptorDB interface.
 var _ kv.RangeDescriptorDB = &storage.Stores{}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -276,7 +276,20 @@ func (m *multiTestContext) Stop() {
 		m.reenableTableSplits()
 	}()
 
-	<-done
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		// If we've already failed, just attach another failure to the
+		// test, since a timeout during shutdown after a failure is
+		// probably not interesting, and will prevent the display of any
+		// pending t.Error. If we're timing out but the test was otherwise
+		// a success, panic so we see stack traces from other goroutines.
+		if m.t.Failed() {
+			m.t.Error("timed out during shutdown")
+		} else {
+			panic("timed out during shutdown")
+		}
+	}
 }
 
 // rpcSend implements the client.rpcSender interface. This implementation of "rpcSend" is

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -21,14 +21,16 @@
 
 package storage
 
-// ForceReplicationScan iterates over all ranges and enqueues any that
-// need to be replicated. Exposed only for testing.
-func (s *Store) ForceReplicationScan() {
+// ForceReplicationScanAndProcess iterates over all ranges and
+// enqueues any that need to be replicated. Exposed only for testing.
+func (s *Store) ForceReplicationScanAndProcess() {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	for _, r := range s.mu.replicas {
 		s.replicateQueue.MaybeAdd(r, s.ctx.Clock.Now())
 	}
+	s.mu.Unlock()
+
+	s.replicateQueue.DrainQueue(s.ctx.Clock)
 }
 
 // DisableReplicaGCQueue disables or enables the replica GC queue.

--- a/storage/store.go
+++ b/storage/store.go
@@ -1307,9 +1307,11 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 				resolveIntents, pErr = s.resolveWriteIntentError(ctx, wiErr, rng, args, ba.Header, pushType)
 				if len(resolveIntents) > 0 {
 					if resErr := rng.resolveIntents(ctx, resolveIntents, false /* !wait */, true /* poison */); resErr != nil {
-						// When resolving asynchronously, should never get an error
-						// back here.
-						panic(resErr)
+						// When resolving asynchronously, errors should not
+						// usually be returned here, although there are some cases
+						// when they may be (especially when a test cluster is in
+						// the process of shutting down).
+						log.Warningf("asynchronous resolveIntents failed: %s", resErr)
 					}
 				}
 				// Make sure that if an index is carried in the error, it


### PR DESCRIPTION
This test was previously testing the behavior of both replicateQueue and
replicaGCQueue, but its test of the latter was flaky because it did not
advance the clock enough to pass the ReplicaGCQueueInactivityThreshold
(and if it did, the transactions in replicateQueue would often be unable
to commit fast enough to pass the test).

This commit removes the parts of the test related to replica GC and only
verifies that the replication queue will detect over-replicated ranges
and remove replicas from them.

Fixes #3777.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3823)

<!-- Reviewable:end -->
