### PR TITLE
Do not pass `-a` to `go build` for release builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,8 @@ endif
 .PHONY: all
 all: build test check
 
-# On a release build, rebuild everything to make sure that the
-# 'release' build tag is taken into account.
 .PHONY: release
 release: TAGS += release
-release: GOFLAGS += -a
 release: build
 
 .PHONY: build


### PR DESCRIPTION
In Go-1.5 and above, the build-id mechanism will ensure proper rebuilds
if a tag changes the files that are part of a package. Passing `-a`
causes a full rebuild for the docker deploy image which is quite slow.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3850)

<!-- Reviewable:end -->
