### PR TITLE
Fix caching of parallel builds.

### DIFF
--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -16,7 +16,11 @@ if [ "${1-}" = "docker" ]; then
   # Be careful to keep the dependencies built for each shard in sync
   # with the dependencies used by each shard in circle-test.sh.
 
-  if is_shard 0; then
+  # Note the ordering here and later in this script of the shard tests
+  # is a bit odd. We perform the tests in this order to maintain the
+  # same build order as the pre-parallel deps script.
+
+  if is_shard 2; then
     # Symlink the cache into the source tree if they don't exist.
     # In circleci they never do, but this script can also be run
     # locally where they might.
@@ -30,15 +34,24 @@ if [ "${1-}" = "docker" ]; then
       fi
     done
 
-    time make -C ui npm.installed   || rm -rf ui/node_modules/*     && make -C ui npm.installed
-    time make -C ui bower.installed || rm -rf ui/bower_components/* && make -C ui bower.installed
-    time make -C ui tsd.installed   || rm -rf ui/typings/*          && make -C ui tsd.installed
+    time make -C ui npm.installed   || rm -rf ui/node_modules/{*,.bin} && make -C ui npm.installed
+    time make -C ui bower.installed || rm -rf ui/bower_components/*    && make -C ui bower.installed
+    time make -C ui tsd.installed   || rm -rf ui/typings/*             && make -C ui tsd.installed
+
+    # Fix permissions on the ui/typings directory and subdirectories
+    # (they lack the execute permission for group/other).
+    find /uicache/typings -type d | xargs chmod 0755
 
     cmds=$(grep '^cmd' GLOCKFILE | grep -v glock | awk '{print $2}')
     time go install -v ${cmds}
   fi
 
   if is_shard 1; then
+    time go test -race -v -i ./...
+    time go install -v github.com/tebeka/go2xunit
+  fi
+
+  if is_shard 0; then
     time make install GOFLAGS=-v
     time go test -v -i ./...
     time go test -v -c -tags acceptance ./acceptance
@@ -46,12 +59,25 @@ if [ "${1-}" = "docker" ]; then
     time go build ./gossip/simulation/...
   fi
 
-  if is_shard 2; then
-    time go test -race -v -i ./...
-  fi
-
   exit 0
 fi
+
+shard1_done="${HOME}/shard1"
+shard2_done="${HOME}/shard2"
+
+function notify() {
+  if is_shard 2; then
+    time ssh node0 touch "${shard2_done}"
+  fi
+
+  if is_shard 1; then
+    time ssh node0 touch "${shard1_done}"
+  fi
+}
+
+# Notify shard 0 that shard's 1 and 2 are done if they exit for any
+# reason. This prevents shard 0 from spinning forever.
+trap "notify" EXIT
 
 # `~/builder` is cached by circle-ci.
 builder_dir=~/builder
@@ -85,3 +111,50 @@ grep -v '^cmd' GLOCKFILE | glock sync -n
 # Recursively invoke this script inside the builder docker container,
 # passing "docker" as the first argument.
 $(dirname $0)/builder.sh $0 docker
+
+# According to
+# https://discuss.circleci.com/t/cache-save-restore-algorithm/759, the
+# cache is only collected from container (shard) 0. We work around
+# this limitation by copying the build output from shards 1 and 2 over
+# to shard 0. On shard 0 we wait for this remote data to be copied.
+
+gopath0="${GOPATH%%:*}"
+
+if is_shard 2; then
+  # We might already be on shard 0 if we're running without
+  # parallelism. Avoid deleting our build output in that case.
+  if ! is_shard 0; then
+    dir="${HOME}/uicache"
+    time rsync -av --delete "${dir}/" node0:"${dir}"
+
+    cmds=$(grep '^cmd' GLOCKFILE | grep -v glock | awk '{print $2}' | awk -F/ '{print $NF}')
+    time ssh node0 mkdir -p "${gopath0}/bin/linux_amd64"
+    for cmd in ${cmds}; do
+      path="${gopath0}/bin/linux_amd64/${cmd}"
+      time rsync -v "${path}" node0:"${path}"
+    done
+  fi
+  notify
+fi
+
+if is_shard 1; then
+  # We might already be on shard 0 if we're running without
+  # parallelism. Avoid deleting our build output in that case.
+  if ! is_shard 0; then
+    dir="${gopath0}/pkg/linux_amd64_race"
+    time rsync -av --delete "${dir}/" node0:"${dir}"
+  fi
+  notify
+fi
+
+if is_shard 0; then
+  set +x
+  start=$(date +%s)
+  while :; do
+    if [ -e "${shard1_done}" -a -e "${shard2_done}" ]; then
+      break
+    fi
+    sleep 1
+  done
+  echo "waited $(($(date +%s) - ${start})) secs"
+fi

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -114,7 +114,14 @@ function is_shard() {
   test $(($1 % $CIRCLE_NODE_TOTAL)) -eq $CIRCLE_NODE_INDEX
 }
 
-if is_shard 0; then
+# Note that the order of the is_shard tests is a bit odd. It would be
+# more natural to check shard 0, then 1, and then 2. The odd ordering
+# is done so that the tests are performed in the pre-parallel order
+# when parallelism is disabled. That is, we get a good ordering when
+# only a single container is running the tests (CIRCLE_NODE_INDEX ==
+# 1).
+
+if is_shard 2; then
   # Run "make check" to verify coding guidelines.
   echo "make check"
   time ${builder} make check | tee "${outdir}/check.log"
@@ -125,7 +132,7 @@ if is_shard 0; then
   time ${builder} /bin/bash -c "(git ls-files --modified --deleted --others --exclude-standard | diff /dev/null -) || (git add -A && git diff -u HEAD && false)" | tee "${outdir}/generate.log"
 fi
 
-if is_shard 1; then
+if is_shard 0; then
   # Run "make test".
   echo "make test"
   time ${builder} make test \
@@ -155,7 +162,7 @@ if is_shard 1; then
   fi
 fi
 
-if is_shard 2; then
+if is_shard 1; then
   # Run "make testrace".
   echo "make testrace"
   time ${builder} make testrace \

--- a/build/stale.sh
+++ b/build/stale.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+pkgs=$(go list -f '{{printf "%s\n" .ImportPath}}{{range .Deps}}{{printf "%s\n" .}}{{end}}' "$@")
+for pkg in ${pkgs}; do
+  stale=$(go list -f '{{ .Stale }}' "${pkg}")
+  if [ "${stale}" = "true" ]; then
+    target=$(go list -f '{{ .Target }}' "${pkg}")
+    dir=$(go list -f '{{ .Dir }}' "${pkg}")
+    if [ ! -e "${target}" ]; then
+      echo "${target}: does not exist"
+      continue
+    fi
+
+    echo "${target}"
+    files=$(go list -f '{{range .GoFiles}}{{printf "%s\n" .}}{{end}}{{range .CgoFiles}}{{printf "%s\n" .}}{{end}}{{range .CXXFiles}}{{printf "%s\n" .}}{{end}}{{range .CFiles}}{{printf "%s\n" .}}{{end}}{{range .HFiles}}{{printf "%s\n" .}}{{end}}{{range .SFiles}}{{printf "%s\n" .}}{{end}}{{range .MFiles}}{{printf "%s\n" .}}{{end}}{{range .SwigFiles}}{{printf "%s\n" .}}{{end}}{{range .SwigCXXFiles}}{{printf "%s\n" .}}{{end}}{{range .SysoFiles}}{{printf "%s\n" .}}{{end}}' "${pkg}")
+    for file in ${files}; do
+      path="${dir}/${file}"
+      if [ "${path}" -nt "${target}" ]; then
+        echo "    ${file}"
+      fi
+    done
+  fi
+done


### PR DESCRIPTION
CircleCI only collects the cache from container (shard) 0. We workaround
this limitation by syncing the contents of the builds from shard 1 and
shard 2 to shard 0.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3858)

<!-- Reviewable:end -->
