### PR TITLE
Make `multiTestContext.{un,}replicateRange` more robust.

### DIFF
--- a/storage/client_event_test.go
+++ b/storage/client_event_test.go
@@ -224,7 +224,7 @@ func TestMultiStoreEventFeed(t *testing.T) {
 
 	// Replicate the default range.
 	rangeID := roachpb.RangeID(1)
-	mtc.replicateRange(rangeID, 0, 1, 2)
+	mtc.replicateRange(rangeID, 1, 2)
 
 	// Add some data in a transaction
 	pErr := mtc.db.Txn(func(txn *client.Txn) *roachpb.Error {

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -343,9 +343,9 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 
 	// Replicate the ranges to different sets of stores. Ranges A and C
 	// are collocated, but B is different.
-	mtc.replicateRange(rangeA.RangeID, 0, 1, 2)
-	mtc.replicateRange(rangeB.RangeID, 0, 1, 3)
-	mtc.replicateRange(rangeC.RangeID, 0, 1, 2)
+	mtc.replicateRange(rangeA.RangeID, 1, 2)
+	mtc.replicateRange(rangeB.RangeID, 1, 3)
+	mtc.replicateRange(rangeC.RangeID, 1, 2)
 
 	// Attempt to merge.
 	rangeADesc = rangeA.Desc()

--- a/storage/client_replica_gc_test.go
+++ b/storage/client_replica_gc_test.go
@@ -70,8 +70,8 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 	mtc.Start(t, numStores)
 	defer mtc.Stop()
 
-	mtc.replicateRange(rangeID, 0, 1, 2)
-	mtc.unreplicateRange(rangeID, 0, 1)
+	mtc.replicateRange(rangeID, 1, 2)
+	mtc.unreplicateRange(rangeID, 1)
 
 	// Make sure the range is removed from the store.
 	util.SucceedsWithin(t, time.Second, func() error {
@@ -93,8 +93,8 @@ func TestReplicaGCQueueDropReplicaGCOnScan(t *testing.T) {
 	mtc.stores[1].DisableReplicaGCQueue(true)
 
 	rangeID := roachpb.RangeID(1)
-	mtc.replicateRange(rangeID, 0, 1, 2)
-	mtc.unreplicateRange(rangeID, 0, 1)
+	mtc.replicateRange(rangeID, 1, 2)
+	mtc.unreplicateRange(rangeID, 1)
 
 	// Wait long enough for the direct replica GC to have had a chance and been
 	// discarded because the queue is disabled.

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -55,7 +55,7 @@ func TestRangeCommandClockUpdate(t *testing.T) {
 	}
 	mtc.Start(t, numNodes)
 	defer mtc.Stop()
-	mtc.replicateRange(1, 0, 1, 2)
+	mtc.replicateRange(1, 1, 2)
 
 	// Advance the leader's clock ahead of the followers (by more than
 	// MaxOffset but less than the leader lease) and execute a command.

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
@@ -535,6 +536,38 @@ func (m *multiTestContext) restartStore(i int) {
 	m.senders[i].AddStore(m.stores[i])
 }
 
+// findStartKeyLocked returns the start key of the given range.
+func (m *multiTestContext) findStartKeyLocked(rangeID roachpb.RangeID) roachpb.RKey {
+	// We can use the first store that returns results because the start
+	// key never changes.
+	for _, s := range m.stores {
+		rep, err := s.GetReplica(rangeID)
+		if err == nil && rep.IsInitialized() {
+			return rep.Desc().StartKey
+		}
+	}
+	m.t.Fatalf("couldn't find range %s on any store", rangeID)
+	return nil // unreached, but the compiler can't tell.
+}
+
+// findMemberStoreLocked finds a non-stopped Store which is a member
+// of the given range.
+func (m *multiTestContext) findMemberStoreLocked(desc roachpb.RangeDescriptor) *storage.Store {
+	for _, s := range m.stores {
+		if s == nil {
+			// Store is stopped.
+			continue
+		}
+		for _, r := range desc.Replicas {
+			if s.StoreID() == r.StoreID {
+				return s
+			}
+		}
+	}
+	m.t.Fatalf("couldn't find a live member of %s", desc)
+	return nil // unreached, but the compiler can't tell.
+}
+
 // restart stops and restarts all stores but leaves the engines intact,
 // so the stores should contain the same persistent storage as before.
 func (m *multiTestContext) restart() {
@@ -547,20 +580,32 @@ func (m *multiTestContext) restart() {
 }
 
 // replicateRange replicates the given range onto the given stores.
-func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, sourceStoreIndex int, dests ...int) {
+func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, dests ...int) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	rng, err := m.stores[sourceStoreIndex].GetReplica(rangeID)
-	if err != nil {
-		m.t.Fatal(err)
-	}
+
+	startKey := m.findStartKeyLocked(rangeID)
 
 	for _, dest := range dests {
-		err = rng.ChangeReplicas(roachpb.ADD_REPLICA,
+		// Perform a consistent read to get the range descriptor, to make
+		// sure we have the effects of the previous ChangeReplicas call.
+		// By the time ChangeReplicas returns the raft leader is
+		// guaranteed to have the updated version, but followers are not.
+		var desc roachpb.RangeDescriptor
+		if err := m.db.GetProto(keys.RangeDescriptorKey(startKey), &desc); err != nil {
+			m.t.Fatal(err)
+		}
+
+		rep, err := m.findMemberStoreLocked(desc).GetReplica(rangeID)
+		if err != nil {
+			m.t.Fatal(err)
+		}
+
+		err = rep.ChangeReplicas(roachpb.ADD_REPLICA,
 			roachpb.ReplicaDescriptor{
 				NodeID:  m.stores[dest].Ident.NodeID,
 				StoreID: m.stores[dest].Ident.StoreID,
-			}, rng.Desc())
+			}, &desc)
 		if err != nil {
 			m.t.Fatal(err)
 		}
@@ -571,7 +616,7 @@ func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, sourceStoreIn
 		for _, dest := range dests {
 			// Use LookupRange(keys) instead of GetRange(rangeID) to ensure that the
 			// snapshot has been transferred and the descriptor initialized.
-			if m.stores[dest].LookupReplica(rng.Desc().StartKey, nil) == nil {
+			if m.stores[dest].LookupReplica(startKey, nil) == nil {
 				return util.Errorf("range not found on store %d", dest)
 			}
 		}
@@ -579,38 +624,31 @@ func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, sourceStoreIn
 	})
 }
 
-// unreplicateRange removes a replica of the range in the source store
-// from the dest store.
-func (m *multiTestContext) unreplicateRange(rangeID roachpb.RangeID, source, dest int) {
+// unreplicateRange removes a replica of the range from the dest store.
+func (m *multiTestContext) unreplicateRange(rangeID roachpb.RangeID, dest int) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	rng, err := m.stores[source].GetReplica(rangeID)
+
+	startKey := m.findStartKeyLocked(rangeID)
+
+	var desc roachpb.RangeDescriptor
+	if err := m.db.GetProto(keys.RangeDescriptorKey(startKey), &desc); err != nil {
+		m.t.Fatal(err)
+	}
+
+	rep, err := m.findMemberStoreLocked(desc).GetReplica(rangeID)
 	if err != nil {
 		m.t.Fatal(err)
 	}
 
-	err = rng.ChangeReplicas(roachpb.REMOVE_REPLICA,
+	err = rep.ChangeReplicas(roachpb.REMOVE_REPLICA,
 		roachpb.ReplicaDescriptor{
 			NodeID:  m.idents[dest].NodeID,
 			StoreID: m.idents[dest].StoreID,
-		}, rng.Desc())
+		}, &desc)
 	if err != nil {
 		m.t.Fatal(err)
 	}
-
-	// Wait for the source node's ReplicaDescriptor to update.
-	util.SucceedsWithin(m.t, replicationTimeout, func() error {
-		rngDesc := m.stores[source].LookupReplica(rng.Desc().StartKey, nil)
-		if rngDesc == nil {
-			return util.Errorf("range not found on store %d", source)
-		}
-		for _, replDesc := range rngDesc.Desc().Replicas {
-			if replDesc.StoreID == m.idents[dest].StoreID {
-				return util.Errorf("store %d not yet removed", source)
-			}
-		}
-		return nil
-	})
 }
 
 // readIntFromEngines reads the current integer value at the given key

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -504,11 +504,11 @@ func (r *Replica) redirectOnOrAcquireLeaderLease(trace *tracer.Trace) *roachpb.E
 	return pErr
 }
 
-// isInitialized is true if we know the metadata of this range, either
+// IsInitialized is true if we know the metadata of this range, either
 // because we created it or we have received an initial snapshot from
 // another node. It is false when a range has been created in response
 // to an incoming message but we are waiting for our initial snapshot.
-func (r *Replica) isInitialized() bool {
+func (r *Replica) IsInitialized() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.isInitializedLocked()
@@ -1563,7 +1563,7 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba roa
 // should gossip; the bool returned indicates whether it's us.
 func (r *Replica) getLeaseForGossip(ctx context.Context) (bool, *roachpb.Error) {
 	// If no Gossip available (some tests) or range too fresh, noop.
-	if r.store.Gossip() == nil || !r.isInitialized() {
+	if r.store.Gossip() == nil || !r.IsInitialized() {
 		return false, roachpb.NewErrorf("no gossip or range not initialized")
 	}
 	var hasLease bool
@@ -1654,7 +1654,7 @@ func (r *Replica) maybeGossipFirstRange() *roachpb.Error {
 // need to avoid deadlocking in redirectOnOrAcquireLeaderLease.
 // TODO(tschottdorf): Can possibly simplify.
 func (r *Replica) maybeGossipSystemConfig() {
-	if r.store.Gossip() == nil || !r.isInitialized() {
+	if r.store.Gossip() == nil || !r.IsInitialized() {
 		return
 	}
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -1061,7 +1061,7 @@ func (s *Store) AddReplicaTest(rng *Replica) error {
 // the same Range ID has already been added to this store.
 // addReplicaInternalLocked requires that the store lock is held.
 func (s *Store) addReplicaInternalLocked(rng *Replica) error {
-	if !rng.isInitialized() {
+	if !rng.IsInitialized() {
 		return util.Errorf("attempted to add uninitialized range %s", rng)
 	}
 
@@ -1149,7 +1149,7 @@ func (s *Store) processRangeDescriptorUpdate(rng *Replica) error {
 
 // processRangeDescriptorUpdateLocked requires that the store lock is held.
 func (s *Store) processRangeDescriptorUpdateLocked(rng *Replica) error {
-	if !rng.isInitialized() {
+	if !rng.IsInitialized() {
 		return util.Errorf("attempted to process uninitialized range %s", rng)
 	}
 
@@ -1706,7 +1706,7 @@ func (s *Store) cacheReplicaDescriptorLocked(groupID roachpb.RangeID, replica ro
 // the replica).
 // canApplySnapshot requires that the store lock is held.
 func (s *Store) canApplySnapshotLocked(rangeID roachpb.RangeID, snap raftpb.Snapshot) bool {
-	if r, ok := s.mu.replicas[rangeID]; ok && r.isInitialized() {
+	if r, ok := s.mu.replicas[rangeID]; ok && r.IsInitialized() {
 		// We have the range and it's initialized, so let the snapshot
 		// through.
 		return true


### PR DESCRIPTION
`Replica.ChangeReplicas` may be called from any member of the range,
but by the time it returns the change is only guaranteed to have been
applied on the leader. Reading the range descriptor from a selected
"source" replica would sometimes fail if that replica is not the leader.
(this most commonly affects the `SplitSnapshotRace` tests because they
perform multiple replication operations when leadership is uncertain,
but it could affect any multi-store tests).

Replace the `source` argument to `{un,}replicateRange` with consistent
lookups of the range descriptors, which are guaranteed to see the
effects of any committed `ChangeReplicas` transactions.

Fixes #3648
Fixes #3864

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3865)

<!-- Reviewable:end -->
