### PR TITLE
fix MVCCStats age computations

### DIFF
--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -815,8 +815,6 @@ func AsIntents(spans []Span, txn *Transaction) []Intent {
 }
 
 // Equal compares for equality.
-// TODO(tschottdorf): chance for code rot here. Adding a test like we did for
-// transactions (TestTransactionUpdate) can't hurt.
 func (s Span) Equal(o Span) bool {
 	return s.Key.Equal(o.Key) && s.EndKey.Equal(o.EndKey)
 }

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -18,13 +18,12 @@ package roachpb
 
 import (
 	"bytes"
-	"fmt"
 	"math"
 	"math/rand"
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
 
@@ -438,28 +437,15 @@ var nonZeroTxn = Transaction{
 }
 
 func TestTransactionUpdate(t *testing.T) {
-	noZeroField := func(txn Transaction) error {
-		ele := reflect.ValueOf(&txn).Elem()
-		eleT := ele.Type()
-		for i := 0; i < ele.NumField(); i++ {
-			f := ele.Field(i)
-			zero := reflect.Zero(f.Type())
-			if reflect.DeepEqual(f.Interface(), zero.Interface()) {
-				return fmt.Errorf("expected %s field to be non-zero", eleT.Field(i).Name)
-			}
-		}
-		return nil
-	}
 	txn := nonZeroTxn
-
-	if err := noZeroField(txn); err != nil {
+	if err := util.NoZeroField(txn); err != nil {
 		t.Fatal(err)
 	}
 
 	var txn2 Transaction
 	txn2.Update(&txn)
 
-	if err := noZeroField(txn2); err != nil {
+	if err := util.NoZeroField(txn2); err != nil {
 		t.Fatal(err)
 	}
 
@@ -469,7 +455,7 @@ func TestTransactionUpdate(t *testing.T) {
 	txn3.Isolation = SNAPSHOT
 	txn3.Update(&txn)
 
-	if err := noZeroField(txn3); err != nil {
+	if err := util.NoZeroField(txn3); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/status/monitor.go
+++ b/server/status/monitor.go
@@ -290,7 +290,7 @@ func NewStoreStatusMonitor(id roachpb.StoreID, metaRegistry *metric.Registry) *S
 func (ssm *StoreStatusMonitor) registerRange(event *storage.RegisterRangeEvent) {
 	ssm.Lock()
 	defer ssm.Unlock()
-	ssm.stats.Add(&event.Stats)
+	ssm.stats.Add(event.Stats)
 	ssm.rangeCount.Inc(1)
 	ssm.updateStorageGaugesLocked()
 }
@@ -298,16 +298,16 @@ func (ssm *StoreStatusMonitor) registerRange(event *storage.RegisterRangeEvent) 
 func (ssm *StoreStatusMonitor) updateRange(event *storage.UpdateRangeEvent) {
 	ssm.Lock()
 	defer ssm.Unlock()
-	ssm.stats.Add(&event.Delta)
+	ssm.stats.Add(event.Delta)
 	ssm.updateStorageGaugesLocked()
 }
 
 func (ssm *StoreStatusMonitor) removeRange(event *storage.RemoveRangeEvent) {
 	ssm.Lock()
 	defer ssm.Unlock()
-	ssm.stats.Subtract(&event.Stats)
-	ssm.updateStorageGaugesLocked()
+	ssm.stats.Subtract(event.Stats)
 	ssm.rangeCount.Dec(1)
+	ssm.updateStorageGaugesLocked()
 }
 
 func (ssm *StoreStatusMonitor) splitRange(event *storage.SplitRangeEvent) {

--- a/server/status/recorder.go
+++ b/server/status/recorder.go
@@ -150,7 +150,7 @@ func (nsr *NodeStatusRecorder) GetStatusSummaries() (*NodeStatus, []storage.Stor
 		// TODO(mrtracy): A number of the fields on the protocol buffer are
 		// Int32s when they would be more easily represented as Int64.
 		nodeStat.StoreIDs = append(nodeStat.StoreIDs, ssm.ID)
-		nodeStat.Stats.Add(&ssm.stats)
+		nodeStat.Stats.Add(ssm.stats)
 		nodeStat.RangeCount += int32(ssm.rangeCount.Count())
 		nodeStat.LeaderRangeCount += int32(ssm.leaderRangeCount.Value())
 		nodeStat.ReplicatedRangeCount += int32(ssm.replicatedRangeCount.Value())

--- a/server/status/recorder_test.go
+++ b/server/status/recorder_test.go
@@ -349,11 +349,11 @@ func TestNodeStatusRecorder(t *testing.T) {
 	}
 	// Use base stats to generate expected summary stat values.
 	for i := 0; i < 3; i++ {
-		expectedStoreSummaries[0].Stats.Add(&stats)
+		expectedStoreSummaries[0].Stats.Add(stats)
 	}
-	expectedStoreSummaries[1].Stats.Add(&stats)
+	expectedStoreSummaries[1].Stats.Add(stats)
 	for _, ss := range expectedStoreSummaries {
-		expectedNodeSummary.Stats.Add(&ss.Stats)
+		expectedNodeSummary.Stats.Add(ss.Stats)
 	}
 
 	nodeSummary, storeSummaries := recorder.GetStatusSummaries()

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -68,11 +68,10 @@ type Iterator interface {
 	// computes stats counters based on the values. This method is used after a
 	// range is split to recompute stats for each subrange. The start key is
 	// always adjusted to avoid counting local keys in the event stats are being
-	// recomputed for the first range (i.e. the one with start key ==
-	// KeyMin). The nowNanos arg specifies the wall time in nanoseconds since the
-	// epoch and is used to compute the total age of all intents. The computed
-	// stats are accumulated (not assigned) to the ms parameter.
-	ComputeStats(ms *MVCCStats, start, end MVCCKey, nowNanos int64) error
+	// recomputed for the first range (i.e. the one with start key == KeyMin).
+	// The nowNanos arg specifies the wall time in nanoseconds since the
+	// epoch and is used to compute the total age of all intents.
+	ComputeStats(start, end MVCCKey, nowNanos int64) (MVCCStats, error)
 }
 
 // Engine is the interface that wraps the core operations of a

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -141,6 +141,8 @@ func (ms *MVCCStats) Delta(oms *MVCCStats) MVCCStats {
 }
 
 // Add adds values from oms to ms.
+// TODO(tschottdorf): age computations here are broken when
+// LastUpdateNanos isn't the same.
 func (ms *MVCCStats) Add(oms *MVCCStats) {
 	ms.LiveBytes += oms.LiveBytes
 	ms.KeyBytes += oms.KeyBytes
@@ -160,6 +162,8 @@ func (ms *MVCCStats) Add(oms *MVCCStats) {
 }
 
 // Subtract subtracts the values of oms from ms.
+// TODO(tschottdorf): age computations here are broken when
+// LastUpdateNanos isn't the same.
 func (ms *MVCCStats) Subtract(oms *MVCCStats) {
 	ms.LiveBytes -= oms.LiveBytes
 	ms.KeyBytes -= oms.KeyBytes

--- a/storage/engine/mvcc.pb.go
+++ b/storage/engine/mvcc.pb.go
@@ -59,10 +59,10 @@ func (m *MVCCMetadata) String() string { return proto.CompactTextString(m) }
 func (*MVCCMetadata) ProtoMessage()    {}
 
 // MVCCStats tracks byte and instance counts for various groups of keys,
-// values or key-value pairs; see the field comments for details.
+// values, or key-value pairs; see the field comments for details.
 //
 // It also tracks two cumulative ages, namely that of intents and non-live
-// (i.e. GCable) bytes. This computation is intrinsically linked to
+// (i.e. GC-able) bytes. This computation is intrinsically linked to
 // last_update_nanos and is easy to get wrong. Updates happen only once every
 // full second, as measured by last_update_nanos/1e9. That is, forward updates
 // don't change last_update_nanos until an update at a timestamp which,

--- a/storage/engine/mvcc.pb.go
+++ b/storage/engine/mvcc.pb.go
@@ -58,30 +58,69 @@ func (m *MVCCMetadata) Reset()         { *m = MVCCMetadata{} }
 func (m *MVCCMetadata) String() string { return proto.CompactTextString(m) }
 func (*MVCCMetadata) ProtoMessage()    {}
 
-// MVCCStats tracks byte and instance counts for:
-//  - Live key/values (i.e. what a scan at current time will reveal;
-//    note that this includes intent keys and values, but not keys and
-//    values with most recent value deleted)
-//  - Key bytes (includes all keys, even those with most recent value deleted)
-//  - Value bytes (includes all versions)
-//  - Key count (count of all keys, including keys with deleted tombstones)
-//  - Value count (all versions, including deleted tombstones)
-//  - Intents (provisional values written during txns)
-//  - System-local key counts and byte totals
+// MVCCStats tracks byte and instance counts for various groups of keys,
+// values or key-value pairs; see the field comments for details.
+//
+// It also tracks two cumulative ages, namely that of intents and non-live
+// (i.e. GCable) bytes. This computation is intrinsically linked to
+// last_update_nanos and is easy to get wrong. Updates happen only once every
+// full second, as measured by last_update_nanos/1e9. That is, forward updates
+// don't change last_update_nanos until an update at a timestamp which,
+// truncated to the second, is ahead of last_update_nanos/1e9. Then, that
+// difference in seconds times the base quantity (excluding the currently
+// running update) is added to the age. It gets more complicated when data is
+// accounted for with a timestamp behind last_update_nanos. In this case, if
+// more than a second has passed (computed via truncation above), the ages have
+// to be adjusted to account for this late addition. This isn't hard: add the
+// new data's base quantity times the (truncated) number of seconds behind.
+// Important to keep in mind with those computations is that (x/1e9 - y/1e9)
+// does not equal (x-y)/1e9 in most cases.
 type MVCCStats struct {
-	LiveBytes       int64 `protobuf:"varint,1,opt,name=live_bytes" json:"live_bytes"`
-	KeyBytes        int64 `protobuf:"varint,2,opt,name=key_bytes" json:"key_bytes"`
-	ValBytes        int64 `protobuf:"varint,3,opt,name=val_bytes" json:"val_bytes"`
-	IntentBytes     int64 `protobuf:"varint,4,opt,name=intent_bytes" json:"intent_bytes"`
-	LiveCount       int64 `protobuf:"varint,5,opt,name=live_count" json:"live_count"`
-	KeyCount        int64 `protobuf:"varint,6,opt,name=key_count" json:"key_count"`
-	ValCount        int64 `protobuf:"varint,7,opt,name=val_count" json:"val_count"`
-	IntentCount     int64 `protobuf:"varint,8,opt,name=intent_count" json:"intent_count"`
-	IntentAge       int64 `protobuf:"varint,9,opt,name=intent_age" json:"intent_age"`
-	GCBytesAge      int64 `protobuf:"varint,10,opt,name=gc_bytes_age" json:"gc_bytes_age"`
-	SysBytes        int64 `protobuf:"varint,12,opt,name=sys_bytes" json:"sys_bytes"`
-	SysCount        int64 `protobuf:"varint,13,opt,name=sys_count" json:"sys_count"`
-	LastUpdateNanos int64 `protobuf:"varint,30,opt,name=last_update_nanos" json:"last_update_nanos"`
+	// last_update_nanos is a timestamp at which the ages were last
+	// updated. See the comment on MVCCStats.
+	LastUpdateNanos int64 `protobuf:"varint,1,opt,name=last_update_nanos" json:"last_update_nanos"`
+	// intent_age is the cumulative age of the tracked intents.
+	// See the comment on MVCCStats.
+	IntentAge int64 `protobuf:"varint,2,opt,name=intent_age" json:"intent_age"`
+	// gc_bytes_age is the cumulative age of the non-live data (i.e.
+	// data included in key_bytes and val_bytes, but not live_bytes).
+	// See the comment on MVCCStats.
+	GCBytesAge int64 `protobuf:"varint,3,opt,name=gc_bytes_age" json:"gc_bytes_age"`
+	// live_bytes is the number of bytes stored in keys and values which can in
+	// principle be read by means of a Scan or Get, including intents but not
+	// deletion tombstones (or their intents). Note that the size of the meta kv
+	// pair (which could be explicit or implicit) is included in this.
+	// Only the meta kv pair counts for the actual length of the encoded key
+	// (regular pairs only count the timestamp suffix).
+	LiveBytes int64 `protobuf:"varint,4,opt,name=live_bytes" json:"live_bytes"`
+	// live_count is the number of meta keys tracked under live_bytes.
+	LiveCount int64 `protobuf:"varint,5,opt,name=live_count" json:"live_count"`
+	// key_bytes is the number of bytes stored in all non-system
+	// keys, including live, meta, old, and deleted keys.
+	// Only meta keys really account for the "full" key; value
+	// keys only for the timestamp suffix.
+	KeyBytes int64 `protobuf:"varint,6,opt,name=key_bytes" json:"key_bytes"`
+	// key_count is the number of meta keys tracked under key_bytes.
+	KeyCount int64 `protobuf:"varint,7,opt,name=key_count" json:"key_count"`
+	// value_bytes is the number of bytes in all non-system version
+	// values, including meta values.
+	ValBytes int64 `protobuf:"varint,8,opt,name=val_bytes" json:"val_bytes"`
+	// val_count is the number of meta values tracked under val_bytes.
+	ValCount int64 `protobuf:"varint,9,opt,name=val_count" json:"val_count"`
+	// intent_bytes is the number of bytes in intent key-value
+	// pairs (without their meta keys).
+	IntentBytes int64 `protobuf:"varint,10,opt,name=intent_bytes" json:"intent_bytes"`
+	// intent_count is the number of keys tracked under intent_bytes.
+	// It is equal to the number of meta keys in the system with
+	// a non-empty Transaction proto.
+	IntentCount int64 `protobuf:"varint,11,opt,name=intent_count" json:"intent_count"`
+	// sys_bytes is the number of bytes stored in system-local  kv-pairs.
+	// This tracks the same quantity as (key_bytes + val_bytes), but
+	// for system-local keys (which aren't counted in either key_bytes
+	// or val_bytes).
+	SysBytes int64 `protobuf:"varint,12,opt,name=sys_bytes" json:"sys_bytes"`
+	// sys_count is the number of meta keys tracked under sys_bytes.
+	SysCount int64 `protobuf:"varint,13,opt,name=sys_count" json:"sys_count"`
 }
 
 func (m *MVCCStats) Reset()         { *m = MVCCStats{} }
@@ -175,45 +214,43 @@ func (m *MVCCStats) MarshalTo(data []byte) (int, error) {
 	_ = l
 	data[i] = 0x8
 	i++
-	i = encodeVarintMvcc(data, i, uint64(m.LiveBytes))
+	i = encodeVarintMvcc(data, i, uint64(m.LastUpdateNanos))
 	data[i] = 0x10
 	i++
-	i = encodeVarintMvcc(data, i, uint64(m.KeyBytes))
+	i = encodeVarintMvcc(data, i, uint64(m.IntentAge))
 	data[i] = 0x18
 	i++
-	i = encodeVarintMvcc(data, i, uint64(m.ValBytes))
+	i = encodeVarintMvcc(data, i, uint64(m.GCBytesAge))
 	data[i] = 0x20
 	i++
-	i = encodeVarintMvcc(data, i, uint64(m.IntentBytes))
+	i = encodeVarintMvcc(data, i, uint64(m.LiveBytes))
 	data[i] = 0x28
 	i++
 	i = encodeVarintMvcc(data, i, uint64(m.LiveCount))
 	data[i] = 0x30
 	i++
-	i = encodeVarintMvcc(data, i, uint64(m.KeyCount))
+	i = encodeVarintMvcc(data, i, uint64(m.KeyBytes))
 	data[i] = 0x38
 	i++
-	i = encodeVarintMvcc(data, i, uint64(m.ValCount))
+	i = encodeVarintMvcc(data, i, uint64(m.KeyCount))
 	data[i] = 0x40
 	i++
-	i = encodeVarintMvcc(data, i, uint64(m.IntentCount))
+	i = encodeVarintMvcc(data, i, uint64(m.ValBytes))
 	data[i] = 0x48
 	i++
-	i = encodeVarintMvcc(data, i, uint64(m.IntentAge))
+	i = encodeVarintMvcc(data, i, uint64(m.ValCount))
 	data[i] = 0x50
 	i++
-	i = encodeVarintMvcc(data, i, uint64(m.GCBytesAge))
+	i = encodeVarintMvcc(data, i, uint64(m.IntentBytes))
+	data[i] = 0x58
+	i++
+	i = encodeVarintMvcc(data, i, uint64(m.IntentCount))
 	data[i] = 0x60
 	i++
 	i = encodeVarintMvcc(data, i, uint64(m.SysBytes))
 	data[i] = 0x68
 	i++
 	i = encodeVarintMvcc(data, i, uint64(m.SysCount))
-	data[i] = 0xf0
-	i++
-	data[i] = 0x1
-	i++
-	i = encodeVarintMvcc(data, i, uint64(m.LastUpdateNanos))
 	return i, nil
 }
 
@@ -270,19 +307,19 @@ func (m *MVCCMetadata) Size() (n int) {
 func (m *MVCCStats) Size() (n int) {
 	var l int
 	_ = l
-	n += 1 + sovMvcc(uint64(m.LiveBytes))
-	n += 1 + sovMvcc(uint64(m.KeyBytes))
-	n += 1 + sovMvcc(uint64(m.ValBytes))
-	n += 1 + sovMvcc(uint64(m.IntentBytes))
-	n += 1 + sovMvcc(uint64(m.LiveCount))
-	n += 1 + sovMvcc(uint64(m.KeyCount))
-	n += 1 + sovMvcc(uint64(m.ValCount))
-	n += 1 + sovMvcc(uint64(m.IntentCount))
+	n += 1 + sovMvcc(uint64(m.LastUpdateNanos))
 	n += 1 + sovMvcc(uint64(m.IntentAge))
 	n += 1 + sovMvcc(uint64(m.GCBytesAge))
+	n += 1 + sovMvcc(uint64(m.LiveBytes))
+	n += 1 + sovMvcc(uint64(m.LiveCount))
+	n += 1 + sovMvcc(uint64(m.KeyBytes))
+	n += 1 + sovMvcc(uint64(m.KeyCount))
+	n += 1 + sovMvcc(uint64(m.ValBytes))
+	n += 1 + sovMvcc(uint64(m.ValCount))
+	n += 1 + sovMvcc(uint64(m.IntentBytes))
+	n += 1 + sovMvcc(uint64(m.IntentCount))
 	n += 1 + sovMvcc(uint64(m.SysBytes))
 	n += 1 + sovMvcc(uint64(m.SysCount))
-	n += 2 + sovMvcc(uint64(m.LastUpdateNanos))
 	return n
 }
 
@@ -562,6 +599,63 @@ func (m *MVCCStats) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastUpdateNanos", wireType)
+			}
+			m.LastUpdateNanos = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMvcc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.LastUpdateNanos |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IntentAge", wireType)
+			}
+			m.IntentAge = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMvcc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.IntentAge |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GCBytesAge", wireType)
+			}
+			m.GCBytesAge = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMvcc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.GCBytesAge |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field LiveBytes", wireType)
 			}
 			m.LiveBytes = 0
@@ -575,63 +669,6 @@ func (m *MVCCStats) Unmarshal(data []byte) error {
 				b := data[iNdEx]
 				iNdEx++
 				m.LiveBytes |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 2:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field KeyBytes", wireType)
-			}
-			m.KeyBytes = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowMvcc
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.KeyBytes |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ValBytes", wireType)
-			}
-			m.ValBytes = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowMvcc
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.ValBytes |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 4:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IntentBytes", wireType)
-			}
-			m.IntentBytes = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowMvcc
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.IntentBytes |= (int64(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -657,6 +694,25 @@ func (m *MVCCStats) Unmarshal(data []byte) error {
 			}
 		case 6:
 			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KeyBytes", wireType)
+			}
+			m.KeyBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMvcc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.KeyBytes |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field KeyCount", wireType)
 			}
 			m.KeyCount = 0
@@ -674,7 +730,26 @@ func (m *MVCCStats) Unmarshal(data []byte) error {
 					break
 				}
 			}
-		case 7:
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValBytes", wireType)
+			}
+			m.ValBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMvcc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.ValBytes |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 9:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ValCount", wireType)
 			}
@@ -693,7 +768,26 @@ func (m *MVCCStats) Unmarshal(data []byte) error {
 					break
 				}
 			}
-		case 8:
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IntentBytes", wireType)
+			}
+			m.IntentBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMvcc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.IntentBytes |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 11:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field IntentCount", wireType)
 			}
@@ -708,44 +802,6 @@ func (m *MVCCStats) Unmarshal(data []byte) error {
 				b := data[iNdEx]
 				iNdEx++
 				m.IntentCount |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 9:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IntentAge", wireType)
-			}
-			m.IntentAge = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowMvcc
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.IntentAge |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 10:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field GCBytesAge", wireType)
-			}
-			m.GCBytesAge = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowMvcc
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.GCBytesAge |= (int64(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -784,25 +840,6 @@ func (m *MVCCStats) Unmarshal(data []byte) error {
 				b := data[iNdEx]
 				iNdEx++
 				m.SysCount |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 30:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field LastUpdateNanos", wireType)
-			}
-			m.LastUpdateNanos = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowMvcc
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.LastUpdateNanos |= (int64(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/storage/engine/mvcc.proto
+++ b/storage/engine/mvcc.proto
@@ -47,28 +47,69 @@ message MVCCMetadata {
   optional roachpb.Timestamp merge_timestamp = 7;
 }
 
-// MVCCStats tracks byte and instance counts for:
-//  - Live key/values (i.e. what a scan at current time will reveal;
-//    note that this includes intent keys and values, but not keys and
-//    values with most recent value deleted)
-//  - Key bytes (includes all keys, even those with most recent value deleted)
-//  - Value bytes (includes all versions)
-//  - Key count (count of all keys, including keys with deleted tombstones)
-//  - Value count (all versions, including deleted tombstones)
-//  - Intents (provisional values written during txns)
-//  - System-local key counts and byte totals
+// MVCCStats tracks byte and instance counts for various groups of keys,
+// values or key-value pairs; see the field comments for details.
+//
+// It also tracks two cumulative ages, namely that of intents and non-live
+// (i.e. GCable) bytes. This computation is intrinsically linked to
+// last_update_nanos and is easy to get wrong. Updates happen only once every
+// full second, as measured by last_update_nanos/1e9. That is, forward updates
+// don't change last_update_nanos until an update at a timestamp which,
+// truncated to the second, is ahead of last_update_nanos/1e9. Then, that
+// difference in seconds times the base quantity (excluding the currently
+// running update) is added to the age. It gets more complicated when data is
+// accounted for with a timestamp behind last_update_nanos. In this case, if
+// more than a second has passed (computed via truncation above), the ages have
+// to be adjusted to account for this late addition. This isn't hard: add the
+// new data's base quantity times the (truncated) number of seconds behind.
+// Important to keep in mind with those computations is that (x/1e9 - y/1e9)
+// does not equal (x-y)/1e9 in most cases.
 message MVCCStats {
-  optional int64 live_bytes = 1 [(gogoproto.nullable) = false];
-  optional int64 key_bytes = 2 [(gogoproto.nullable) = false];
-  optional int64 val_bytes = 3 [(gogoproto.nullable) = false];
-  optional int64 intent_bytes = 4 [(gogoproto.nullable) = false];
+  // last_update_nanos is a timestamp at which the ages were last
+  // updated. See the comment on MVCCStats.
+  optional int64 last_update_nanos = 1 [(gogoproto.nullable) = false];
+  // intent_age is the cumulative age of the tracked intents.
+  // See the comment on MVCCStats.
+  optional int64 intent_age = 2 [(gogoproto.nullable) = false];
+  // gc_bytes_age is the cumulative age of the non-live data (i.e.
+  // data included in key_bytes and val_bytes, but not live_bytes).
+  // See the comment on MVCCStats.
+  optional int64 gc_bytes_age = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "GCBytesAge" ];
+
+  // live_bytes is the number of bytes stored in keys and values which can in
+  // principle be read by means of a Scan or Get, including intents but not
+  // deletion tombstones (or their intents). Note that the size of the meta kv
+  // pair (which could be explicit or implicit) is included in this.
+  // Only the meta kv pair counts for the actual length of the encoded key
+  // (regular pairs only count the timestamp suffix).
+  optional int64 live_bytes = 4 [(gogoproto.nullable) = false];
+  // live_count is the number of meta keys tracked under live_bytes.
   optional int64 live_count = 5 [(gogoproto.nullable) = false];
-  optional int64 key_count = 6 [(gogoproto.nullable) = false];
-  optional int64 val_count = 7 [(gogoproto.nullable) = false];
-  optional int64 intent_count = 8 [(gogoproto.nullable) = false];
-  optional int64 intent_age = 9 [(gogoproto.nullable) = false];
-  optional int64 gc_bytes_age = 10 [(gogoproto.nullable) = false, (gogoproto.customname) = "GCBytesAge" ];
+  // key_bytes is the number of bytes stored in all non-system
+  // keys, including live, meta, old, and deleted keys.
+  // Only meta keys really account for the "full" key; value
+  // keys only for the timestamp suffix.
+  optional int64 key_bytes = 6 [(gogoproto.nullable) = false];
+  // key_count is the number of meta keys tracked under key_bytes.
+  optional int64 key_count = 7 [(gogoproto.nullable) = false];
+  // value_bytes is the number of bytes in all non-system version
+  // values, including meta values.
+  optional int64 val_bytes = 8 [(gogoproto.nullable) = false];
+  // val_count is the number of meta values tracked under val_bytes.
+  optional int64 val_count = 9 [(gogoproto.nullable) = false];
+  // intent_bytes is the number of bytes in intent key-value
+  // pairs (without their meta keys).
+  optional int64 intent_bytes = 10 [(gogoproto.nullable) = false];
+  // intent_count is the number of keys tracked under intent_bytes.
+  // It is equal to the number of meta keys in the system with
+  // a non-empty Transaction proto.
+  optional int64 intent_count = 11 [(gogoproto.nullable) = false];
+
+  // sys_bytes is the number of bytes stored in system-local  kv-pairs.
+  // This tracks the same quantity as (key_bytes + val_bytes), but
+  // for system-local keys (which aren't counted in either key_bytes
+  // or val_bytes).
   optional int64 sys_bytes = 12 [(gogoproto.nullable) = false];
+  // sys_count is the number of meta keys tracked under sys_bytes.
   optional int64 sys_count = 13 [(gogoproto.nullable) = false];
-  optional int64 last_update_nanos = 30 [(gogoproto.nullable) = false];
 }

--- a/storage/engine/mvcc.proto
+++ b/storage/engine/mvcc.proto
@@ -48,10 +48,10 @@ message MVCCMetadata {
 }
 
 // MVCCStats tracks byte and instance counts for various groups of keys,
-// values or key-value pairs; see the field comments for details.
+// values, or key-value pairs; see the field comments for details.
 //
 // It also tracks two cumulative ages, namely that of intents and non-live
-// (i.e. GCable) bytes. This computation is intrinsically linked to
+// (i.e. GC-able) bytes. This computation is intrinsically linked to
 // last_update_nanos and is easy to get wrong. Updates happen only once every
 // full second, as measured by last_update_nanos/1e9. That is, forward updates
 // don't change last_update_nanos until an update at a timestamp which,

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -108,8 +108,9 @@ func TestMVCCStatsAddSubAgeTo(t *testing.T) {
 		SysCount:        1,
 		LastUpdateNanos: 1,
 	}
-	ms := goldMS
-	zeroWithLU := MVCCStats{LastUpdateNanos: ms.LastUpdateNanos}
+	if err := util.NoZeroField(&goldMS); err != nil {
+		t.Fatal(err) // prevent rot as fields are added
+	}
 
 	cmp := func(act, exp MVCCStats) {
 		f, l, _ := caller.Lookup(1)
@@ -118,9 +119,8 @@ func TestMVCCStatsAddSubAgeTo(t *testing.T) {
 		}
 	}
 
-	if err := util.NoZeroField(&ms); err != nil {
-		t.Fatal(err) // prevent rot as fields are added
-	}
+	ms := goldMS
+	zeroWithLU := MVCCStats{LastUpdateNanos: ms.LastUpdateNanos}
 
 	ms.Subtract(goldMS)
 	cmp(ms, zeroWithLU)
@@ -148,11 +148,12 @@ func TestMVCCStatsAddSubAgeTo(t *testing.T) {
 		oldDelta := delta
 		delta.AgeTo(ns)
 		if delta.LastUpdateNanos < ns {
-			t.Fatalf("%d: should always update LastUpdateNanos", i)
+			t.Fatalf("%d: expected LastUpdateNanos < %d, got %d", i, ns, delta.LastUpdateNanos)
 		}
-		shouldAge := ns/1E9 > oldDelta.LastUpdateNanos/1E9
-		if shouldAge != (delta.IntentAge != oldDelta.IntentAge &&
-			delta.GCBytesAge != oldDelta.GCBytesAge) {
+		shouldAge := ns/1E9-oldDelta.LastUpdateNanos/1E9 > 0
+		didAge := delta.IntentAge != oldDelta.IntentAge &&
+			delta.GCBytesAge != oldDelta.GCBytesAge
+		if shouldAge != didAge {
 			t.Fatalf("%d: should age: %t, but had\n%+v\nand now\n%+v", i, shouldAge, oldDelta, delta)
 		}
 	}
@@ -257,7 +258,7 @@ func TestMVCCEmptyKey(t *testing.T) {
 	if _, _, err := MVCCScan(engine, testKey1, roachpb.Key{}, 0, makeTS(0, 1), true, nil); err == nil {
 		t.Error("expected empty key error")
 	}
-	if err := MVCCResolveWriteIntent(engine, nil, roachpb.Key{}, makeTS(0, 1), txn1); err == nil {
+	if err := MVCCResolveWriteIntent(engine, nil, roachpb.Key{}, txn1); err == nil {
 		t.Error("expected empty key error")
 	}
 }
@@ -1494,7 +1495,7 @@ func TestMVCCResolveTxn(t *testing.T) {
 	}
 
 	// Resolve will write with txn1's timestamp which is 0,1.
-	if err := MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(0, 1), txn1Commit); err != nil {
+	if err := MVCCResolveWriteIntent(engine, nil, testKey1, txn1Commit); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1554,8 +1555,11 @@ func TestMVCCAbortTxn(t *testing.T) {
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
 
+	txn1Abort := txn1Abort.Clone()
+	txn1Abort.Timestamp = makeTS(0, 1)
+
 	err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1)
-	err = MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(0, 1), txn1Abort)
+	err = MVCCResolveWriteIntent(engine, nil, testKey1, txn1Abort)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1582,10 +1586,13 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
 
+	txn1Abort := txn1Abort.Clone()
+	txn1Abort.Timestamp = makeTS(2, 0)
+
 	err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, nil)
 	err = MVCCPut(engine, nil, testKey1, makeTS(1, 0), value2, nil)
 	err = MVCCPut(engine, nil, testKey1, makeTS(2, 0), value3, txn1)
-	err = MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(2, 0), txn1Abort)
+	err = MVCCResolveWriteIntent(engine, nil, testKey1, txn1Abort)
 	if err := engine.Commit(); err != nil {
 		t.Fatal(err)
 	}
@@ -1638,7 +1645,7 @@ func TestMVCCWriteWithDiffTimestampsAndEpochs(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Resolve the intent.
-	if err := MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(1, 0), makeTxn(txn1e2Commit, makeTS(1, 0))); err != nil {
+	if err := MVCCResolveWriteIntent(engine, nil, testKey1, makeTxn(txn1e2Commit, makeTS(1, 0))); err != nil {
 		t.Fatal(err)
 	}
 	// Now try writing an earlier intent--should get WriteTooOldError.
@@ -1748,7 +1755,7 @@ func TestMVCCReadWithPushedTimestamp(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Resolve the intent, pushing its timestamp forward.
-	if err := MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(0, 1), makeTxn(txn1, makeTS(1, 0))); err != nil {
+	if err := MVCCResolveWriteIntent(engine, nil, testKey1, makeTxn(txn1, makeTS(1, 0))); err != nil {
 		t.Fatal(err)
 	}
 	// Attempt to read using naive txn's previous timestamp.
@@ -1770,7 +1777,7 @@ func TestMVCCResolveWithDiffEpochs(t *testing.T) {
 	if err := MVCCPut(engine, nil, testKey2, makeTS(0, 1), value2, txn1e2); err != nil {
 		t.Fatal(err)
 	}
-	num, err := MVCCResolveWriteIntentRange(engine, nil, testKey1, testKey2.Next(), 2, makeTS(0, 1), txn1e2Commit)
+	num, err := MVCCResolveWriteIntentRange(engine, nil, testKey1, testKey2.Next(), 2, txn1e2Commit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1816,7 +1823,7 @@ func TestMVCCResolveWithUpdatedTimestamp(t *testing.T) {
 
 	// Resolve with a higher commit timestamp -- this should rewrite the
 	// intent when making it permanent.
-	if err = MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(1, 0), makeTxn(txn1Commit, makeTS(1, 0))); err != nil {
+	if err = MVCCResolveWriteIntent(engine, nil, testKey1, makeTxn(txn1Commit, makeTS(1, 0))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1857,7 +1864,7 @@ func TestMVCCResolveWithPushedTimestamp(t *testing.T) {
 
 	// Resolve with a higher commit timestamp, but with still-pending transaction.
 	// This represents a straightforward push (i.e. from a read/write conflict).
-	if err = MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(1, 0), makeTxn(txn1, makeTS(1, 0))); err != nil {
+	if err = MVCCResolveWriteIntent(engine, nil, testKey1, makeTxn(txn1, makeTS(1, 0))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1886,21 +1893,23 @@ func TestMVCCResolveTxnNoOps(t *testing.T) {
 	engine := createTestEngine(stopper)
 
 	// Resolve a non existent key; noop.
-	err := MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(0, 1), txn1Commit)
+	err := MVCCResolveWriteIntent(engine, nil, testKey1, txn1Commit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Add key and resolve despite there being no intent.
 	err = MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, nil)
-	err = MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(0, 1), txn2Commit)
+	err = MVCCResolveWriteIntent(engine, nil, testKey1, txn2Commit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Write intent and resolve with different txn.
 	err = MVCCPut(engine, nil, testKey1, makeTS(1, 0), value2, txn1)
-	err = MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(1, 0), txn2Commit)
+	txn2Commit := txn2Commit.Clone()
+	txn2Commit.Timestamp = makeTS(1, 0)
+	err = MVCCResolveWriteIntent(engine, nil, testKey1, txn2Commit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1925,7 +1934,7 @@ func TestMVCCResolveTxnRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	num, err := MVCCResolveWriteIntentRange(engine, nil, testKey1, testKey4.Next(), 0, makeTS(0, 1), txn1Commit)
+	num, err := MVCCResolveWriteIntentRange(engine, nil, testKey1, testKey4.Next(), 0, txn1Commit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2278,6 +2287,9 @@ func verifyStats(debug string, ms *MVCCStats, expMS *MVCCStats, t *testing.T) {
 	if ms.IntentCount != expMS.IntentCount {
 		t.Errorf("%s: mvcc intentCount %d; expected %d", debug, ms.IntentCount, expMS.IntentCount)
 	}
+	if ms.LastUpdateNanos != expMS.LastUpdateNanos {
+		t.Fatalf("%s: mvcc lastUpdateNanos %d; expected %d", debug, ms.LastUpdateNanos, expMS.LastUpdateNanos)
+	}
 	if ms.IntentAge != expMS.IntentAge {
 		t.Errorf("%s: mvcc intentAge %d; expected %d", debug, ms.IntentAge, expMS.IntentAge)
 	}
@@ -2321,14 +2333,18 @@ func TestMVCCStatsBasic(t *testing.T) {
 	vValSize := int64(len(value.RawBytes))
 
 	expMS := MVCCStats{
-		LiveBytes: mKeySize + vKeySize + vValSize,
-		LiveCount: 1,
-		KeyBytes:  mKeySize + vKeySize,
-		KeyCount:  1,
-		ValBytes:  vValSize,
-		ValCount:  1,
+		LiveBytes:       mKeySize + vKeySize + vValSize,
+		LiveCount:       1,
+		KeyBytes:        mKeySize + vKeySize,
+		KeyCount:        1,
+		ValBytes:        vValSize,
+		ValCount:        1,
+		LastUpdateNanos: 1E9,
 	}
 	verifyStats("after put", ms, &expMS, t)
+	if e, a := int64(0), ms.GCBytes(); e != a {
+		t.Fatalf("GCBytes: expected %d, got %d", e, a)
+	}
 
 	// Delete the value using a transaction.
 	txn := &roachpb.Transaction{ID: []byte("txn1"), Timestamp: makeTS(1*1E9, 0)}
@@ -2339,37 +2355,51 @@ func TestMVCCStatsBasic(t *testing.T) {
 	m2ValSize := encodedSize(&MVCCMetadata{Timestamp: ts2, Deleted: true, Txn: txn}, t)
 	v2KeySize := mvccVersionTimestampSize
 	v2ValSize := int64(0)
+
 	expMS2 := MVCCStats{
-		KeyBytes:    mKeySize + vKeySize + v2KeySize,
-		KeyCount:    1,
-		ValBytes:    m2ValSize + vValSize + v2ValSize,
-		ValCount:    2,
-		IntentBytes: v2KeySize + v2ValSize,
-		IntentCount: 1,
-		IntentAge:   0,
-		GCBytesAge:  vValSize + vKeySize, // immediately recognizes GC'able bytes from old value
+		KeyBytes:        mKeySize + vKeySize + v2KeySize,
+		KeyCount:        1,
+		ValBytes:        m2ValSize + vValSize + v2ValSize,
+		ValCount:        2,
+		IntentBytes:     v2KeySize + v2ValSize,
+		IntentCount:     1,
+		IntentAge:       0,
+		GCBytesAge:      vValSize + vKeySize, // immediately recognizes GC'able bytes from old value at 1E9
+		LastUpdateNanos: 2E9,
 	}
 	verifyStats("after delete", ms, &expMS2, t)
+	// This is expMS2.KeyBytes + expMS2.ValBytes - expMS2.LiveBytes
+	expGC2 := mKeySize + vKeySize + v2KeySize + m2ValSize + vValSize + v2ValSize
+	if a := ms.GCBytes(); expGC2 != a {
+		t.Fatalf("GCBytes: expected %d, got %d", expGC2, a)
+	}
 
 	// Resolve the deletion by aborting it.
 	txn.Status = roachpb.ABORTED
-	if err := MVCCResolveWriteIntent(engine, ms, key, ts2, txn); err != nil {
+	txn.Timestamp.Forward(ts2)
+	if err := MVCCResolveWriteIntent(engine, ms, key, txn); err != nil {
 		t.Fatal(err)
 	}
 	// Stats should equal same as before the deletion after aborting the intent.
+	expMS.LastUpdateNanos = 2E9
 	verifyStats("after abort", ms, &expMS, t)
 
 	// Re-delete, but this time, we're going to commit it.
 	txn.Status = roachpb.PENDING
 	ts3 := makeTS(3*1E9, 0)
+	txn.Timestamp.Forward(ts3)
 	if err := MVCCDelete(engine, ms, key, ts3, txn); err != nil {
 		t.Fatal(err)
 	}
-	// GCBytesAge will be x2 seconds now.
+	// GCBytesAge will now count the deleted value from ts=1E9 to ts=3E9.
 	expMS2.GCBytesAge = (vValSize + vKeySize) * 2
+	expMS2.LastUpdateNanos = 3E9
 	verifyStats("after 2nd delete", ms, &expMS2, t) // should be same as before.
+	if a := ms.GCBytes(); expGC2 != a {
+		t.Fatalf("GCBytes: expected %d, got %d", expGC2, a)
+	}
 
-	// Put another intent, which should age deleted intent.
+	// Write a second transactional value (i.e. an intent).
 	ts4 := makeTS(4*1E9, 0)
 	txn.Timestamp = ts4
 	key2 := roachpb.Key("b")
@@ -2390,29 +2420,73 @@ func TestMVCCStatsBasic(t *testing.T) {
 		LiveCount:   1,
 		IntentBytes: v2KeySize + v2ValSize + vKey2Size + vVal2Size,
 		IntentCount: 2,
-		GCBytesAge:  (vValSize + vKeySize) * 2,
+		IntentAge:   1,
+		// It gets interesting: The first term is the contribution from the
+		// deletion of the first put (written at 1s, deleted at 3s). From 3s
+		// to 4s, on top of that we age the intent's meta entry plus deletion
+		// tombstone on top of that (expGC2).
+		GCBytesAge:      (vValSize+vKeySize)*2 + expGC2,
+		LastUpdateNanos: 4E9,
 	}
+
+	expGC3 := expGC2 // no change, didn't delete anything
 	verifyStats("after 2nd put", ms, &expMS3, t)
+	if a := ms.GCBytes(); expGC3 != a {
+		t.Fatalf("GCBytes: expected %d, got %d", expGC3, a)
+	}
 
 	// Now commit both values.
 	txn.Status = roachpb.COMMITTED
-	if err := MVCCResolveWriteIntent(engine, ms, key, ts4, txn); err != nil {
-		t.Fatal(err)
-	}
-	if err := MVCCResolveWriteIntent(engine, ms, key2, ts4, txn); err != nil {
+	if err := MVCCResolveWriteIntent(engine, ms, key, txn); err != nil {
 		t.Fatal(err)
 	}
 	expMS4 := MVCCStats{
-		KeyBytes:   mKeySize + vKeySize + v2KeySize + mKey2Size + vKey2Size,
-		KeyCount:   2,
-		ValBytes:   vValSize + v2ValSize + vVal2Size,
-		ValCount:   3,
-		LiveBytes:  mKey2Size + vKey2Size + vVal2Size,
-		LiveCount:  1,
-		IntentAge:  -1,
-		GCBytesAge: (vValSize + vKeySize) * 2,
+		KeyBytes:    mKeySize + vKeySize + v2KeySize + mKey2Size + vKey2Size,
+		KeyCount:    2,
+		ValBytes:    vValSize + v2ValSize + mVal2Size + vVal2Size,
+		ValCount:    3,
+		LiveBytes:   mKey2Size + vKey2Size + mVal2Size + vVal2Size,
+		LiveCount:   1,
+		IntentBytes: vKey2Size + vVal2Size,
+		IntentCount: 1,
+		// The commit turned the explicit deletion intent meta back into an
+		// implicit one; so we see the originally written value which is now 3s
+		// old, plus the implicit meta key contribution (basically the key
+		// prefix) along with the deletion tombstone kv pair.
+		// You could also write this as
+		//	(vValSize+vKeySize)*2 + (expGC3 - m2ValSize)
+		// as we do in the second commit.
+		GCBytesAge:      (vValSize+vKeySize)*3 + (mKeySize + v2ValSize + v2KeySize),
+		LastUpdateNanos: 4E9,
 	}
-	verifyStats("after commit", ms, &expMS4, t)
+	verifyStats("after first commit", ms, &expMS4, t)
+
+	// With commit of the deletion intent, what really happens is that the
+	// explicit meta (carrying the intent) becomes implicit (so its key
+	// gets counted in the same way by convention, but its value is now empty).
+	expGC4 := expGC3 - m2ValSize
+	if a := ms.GCBytes(); expGC4 != a {
+		t.Fatalf("GCBytes: expected %d, got %d", expGC4, a)
+	}
+
+	if err := MVCCResolveWriteIntent(engine, ms, key2, txn); err != nil {
+		t.Fatal(err)
+	}
+	expMS4 = MVCCStats{
+		KeyBytes:        mKeySize + vKeySize + v2KeySize + mKey2Size + vKey2Size,
+		KeyCount:        2,
+		ValBytes:        vValSize + v2ValSize + vVal2Size,
+		ValCount:        3,
+		LiveBytes:       mKey2Size + vKey2Size + vVal2Size,
+		LiveCount:       1,
+		IntentAge:       0,
+		GCBytesAge:      (vValSize+vKeySize)*2 + (expGC3 - m2ValSize),
+		LastUpdateNanos: 4E9,
+	}
+	verifyStats("after second commit", ms, &expMS4, t)
+	if a := ms.GCBytes(); expGC4 != a { // no change here
+		t.Fatalf("GCBytes: expected %d, got %d", expGC4, a)
+	}
 
 	// Write over existing value to create GC'able bytes.
 	ts5 := makeTS(10*1E9, 0) // skip ahead 6s
@@ -2423,7 +2497,9 @@ func TestMVCCStatsBasic(t *testing.T) {
 	expMS5.KeyBytes += vKey2Size
 	expMS5.ValBytes += vVal2Size
 	expMS5.ValCount = 4
-	expMS5.GCBytesAge += (vKey2Size + vVal2Size) * 6 // since we skipped ahead 6s
+	// The age increases: 6 seconds for each key2 and key.
+	expMS5.GCBytesAge += (vKey2Size+vVal2Size)*6 + expGC4*6
+	expMS5.LastUpdateNanos = 10E9
 	verifyStats("after overwrite", ms, &expMS5, t)
 
 	// Write a transaction record which is a system-local key.
@@ -2463,15 +2539,14 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 			log.Infof("*** cycle %d", i)
 		}
 		// Manually advance aggregate intent age based on one extra second of simulation.
-		ms.IntentAge += ms.IntentCount
 		// Same for aggregate gc'able bytes age.
-		ms.GCBytesAge += ms.KeyBytes + ms.ValBytes - ms.LiveBytes
 
 		key := []byte(fmt.Sprintf("%s-%d", randutil.RandBytes(rng, int(rng.Int31n(32))), i))
 		keys[i] = key
+		ts := makeTS(int64(i+1)*1E9, 0)
 		var txn *roachpb.Transaction
 		if rng.Int31n(2) == 0 { // create a txn with 50% prob
-			txn = &roachpb.Transaction{ID: []byte(fmt.Sprintf("txn-%d", i)), Timestamp: makeTS(int64(i+1)*1E9, 0)}
+			txn = &roachpb.Transaction{ID: []byte(fmt.Sprintf("txn-%d", i)), Timestamp: ts}
 		}
 		// With 25% probability, put a new value; otherwise, delete an earlier
 		// key. Because an earlier step in this process may have itself been
@@ -2483,21 +2558,26 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 			if log.V(1) {
 				log.Infof("*** DELETE index %d", idx)
 			}
-			if err := MVCCDelete(engine, ms, keys[idx], makeTS(int64(i+1)*1E9, 0), txn); err != nil {
+			if err := MVCCDelete(engine, ms, keys[idx], ts, txn); err != nil {
 				// Abort any write intent on an earlier, unresolved txn.
 				if wiErr, ok := err.(*roachpb.WriteIntentError); ok {
 					wiErr.Intents[0].Txn.Status = roachpb.ABORTED
 					if log.V(1) {
 						log.Infof("*** ABORT index %d", idx)
 					}
-					if err := MVCCResolveWriteIntent(engine, ms, keys[idx], makeTS(int64(i+1)*1E9, 0), &wiErr.Intents[0].Txn); err != nil {
+					// Note that this already incorporates committing an intent
+					// at a later time (since we use a potentially later ts here
+					// for the resolution).
+					intentTxn := wiErr.Intents[0].Txn.Clone()
+					intentTxn.Timestamp = ts
+					if err := MVCCResolveWriteIntent(engine, ms, keys[idx], intentTxn); err != nil {
 						t.Fatal(err)
 					}
 					// Now, re-delete.
 					if log.V(1) {
 						log.Infof("*** RE-DELETE index %d", idx)
 					}
-					if err := MVCCDelete(engine, ms, keys[idx], makeTS(int64(i+1)*1E9, 0), txn); err != nil {
+					if err := MVCCDelete(engine, ms, keys[idx], ts, txn); err != nil {
 						t.Fatal(err)
 					}
 				} else {
@@ -2509,7 +2589,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 			if log.V(1) {
 				log.Infof("*** PUT index %d; TXN=%t", i, txn != nil)
 			}
-			if err := MVCCPut(engine, ms, key, makeTS(int64(i+1)*1E9, 0), rngVal, txn); err != nil {
+			if err := MVCCPut(engine, ms, key, ts, rngVal, txn); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -2521,11 +2601,12 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 			if log.V(1) {
 				log.Infof("*** RESOLVE index %d; COMMIT=%t", i, txn.Status == roachpb.COMMITTED)
 			}
-			if err := MVCCResolveWriteIntent(engine, ms, key, makeTS(int64(i+1)*1E9, 0), txn); err != nil {
+			if err := MVCCResolveWriteIntent(engine, ms, key, txn); err != nil {
 				t.Fatal(err)
 			}
 		}
 
+		ms.AgeTo(ts.WallTime) // a noop may not have updated the stats
 		// Every 10th step, verify the stats via manual engine scan.
 		if i%10 == 0 {
 			// Compute the stats manually.
@@ -2572,9 +2653,6 @@ func TestMVCCGarbageCollect(t *testing.T) {
 	}
 
 	for i := 0; i < 3; i++ {
-		// Manually advance aggregate gc'able bytes age based on one extra second of simulation.
-		ms.GCBytesAge += ms.KeyBytes + ms.ValBytes - ms.LiveBytes
-
 		for _, test := range testData {
 			if i >= len(test.vals) {
 				continue
@@ -2738,7 +2816,7 @@ func TestResolveIntentWithLowerEpoch(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Resolve the intent with a low epoch.
-	if err := MVCCResolveWriteIntent(engine, nil, testKey1, makeTS(0, 1), txn1); err != nil {
+	if err := MVCCResolveWriteIntent(engine, nil, testKey1, txn1); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -2611,10 +2611,10 @@ func TestMVCCGarbageCollectIntent(t *testing.T) {
 	}
 }
 
-// TestResovleIntentWithLowerEpoch verifies that trying to resolve
+// TestResolveIntentWithLowerEpoch verifies that trying to resolve
 // an intent at an epoch that is lower than the epoch of the intent
 // leaves the intent untouched.
-func TestResovleIntentWithLowerEpoch(t *testing.T) {
+func TestResolveIntentWithLowerEpoch(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	stopper := stop.NewStopper()
 	defer stopper.Stop()

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -2414,8 +2414,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		if i%10 == 0 {
 			// Compute the stats manually.
 			iter := engine.NewIterator(false)
-			var expMS MVCCStats
-			err := iter.ComputeStats(&expMS, mvccKey(roachpb.KeyMin),
+			expMS, err := iter.ComputeStats(mvccKey(roachpb.KeyMin),
 				mvccKey(roachpb.KeyMax), int64(i+1)*1E9)
 			iter.Close()
 			if err != nil {
@@ -2520,8 +2519,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 
 	// Verify aggregated stats match computed stats after GC.
 	iter := engine.NewIterator(false)
-	var expMS MVCCStats
-	err = iter.ComputeStats(&expMS, mvccKey(roachpb.KeyMin),
+	expMS, err := iter.ComputeStats(mvccKey(roachpb.KeyMin),
 		mvccKey(roachpb.KeyMax), ts3.WallTime)
 	iter.Close()
 	if err != nil {
@@ -2542,9 +2540,8 @@ func TestMVCCComputeStatsError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var ms MVCCStats
 	iter := engine.NewIterator(false)
-	err := iter.ComputeStats(&ms, mvccKey(roachpb.KeyMin),
+	_, err := iter.ComputeStats(mvccKey(roachpb.KeyMin),
 		mvccKey(roachpb.KeyMax), 100)
 	iter.Close()
 	if e := "unable to decode MVCCMetadata"; !testutils.IsError(err, e) {

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -588,22 +588,18 @@ func (r *rocksDBIterator) ComputeStats(start, end MVCCKey, nowNanos int64) (MVCC
 	if err := statusToError(result.status); err != nil {
 		return ms, err
 	}
-	ms.LiveBytes += int64(result.live_bytes)
-	ms.KeyBytes += int64(result.key_bytes)
-	ms.ValBytes += int64(result.val_bytes)
-	ms.IntentBytes += int64(result.intent_bytes)
-	ms.LiveCount += int64(result.live_count)
-	ms.KeyCount += int64(result.key_count)
-	ms.ValCount += int64(result.val_count)
-	ms.IntentCount += int64(result.intent_count)
-	// TODO(tschottdorf): this isn't legal since it messes up the age
-	// computations. Need to take into account the old LastUpdateNanos
-	// and besides, there's already MVCCStats.Add which should be
-	// used here.
-	ms.IntentAge += int64(result.intent_age)
-	ms.GCBytesAge += int64(result.gc_bytes_age)
-	ms.SysBytes += int64(result.sys_bytes)
-	ms.SysCount += int64(result.sys_count)
+	ms.LiveBytes = int64(result.live_bytes)
+	ms.KeyBytes = int64(result.key_bytes)
+	ms.ValBytes = int64(result.val_bytes)
+	ms.IntentBytes = int64(result.intent_bytes)
+	ms.LiveCount = int64(result.live_count)
+	ms.KeyCount = int64(result.key_count)
+	ms.ValCount = int64(result.val_count)
+	ms.IntentCount = int64(result.intent_count)
+	ms.IntentAge = int64(result.intent_age)
+	ms.GCBytesAge = int64(result.gc_bytes_age)
+	ms.SysBytes = int64(result.sys_bytes)
+	ms.SysCount = int64(result.sys_count)
 	ms.LastUpdateNanos = nowNanos
 	return ms, nil
 }

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -582,10 +582,11 @@ func (r *rocksDBIterator) setState(state C.DBIterState) {
 	r.value = state.value
 }
 
-func (r *rocksDBIterator) ComputeStats(ms *MVCCStats, start, end MVCCKey, nowNanos int64) error {
+func (r *rocksDBIterator) ComputeStats(start, end MVCCKey, nowNanos int64) (MVCCStats, error) {
 	result := C.MVCCComputeStats(r.iter, goToCKey(start), goToCKey(end), C.int64_t(nowNanos))
+	ms := MVCCStats{}
 	if err := statusToError(result.status); err != nil {
-		return err
+		return ms, err
 	}
 	ms.LiveBytes += int64(result.live_bytes)
 	ms.KeyBytes += int64(result.key_bytes)
@@ -595,12 +596,16 @@ func (r *rocksDBIterator) ComputeStats(ms *MVCCStats, start, end MVCCKey, nowNan
 	ms.KeyCount += int64(result.key_count)
 	ms.ValCount += int64(result.val_count)
 	ms.IntentCount += int64(result.intent_count)
+	// TODO(tschottdorf): this isn't legal since it messes up the age
+	// computations. Need to take into account the old LastUpdateNanos
+	// and besides, there's already MVCCStats.Add which should be
+	// used here.
 	ms.IntentAge += int64(result.intent_age)
 	ms.GCBytesAge += int64(result.gc_bytes_age)
 	ms.SysBytes += int64(result.sys_bytes)
 	ms.SysCount += int64(result.sys_count)
 	ms.LastUpdateNanos = nowNanos
-	return nil
+	return ms, nil
 }
 
 // goToCSlice converts a go byte slice to a DBSlice. Note that this is

--- a/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.cc
+++ b/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.cc
@@ -62,19 +62,19 @@ void protobuf_AssignDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto() {
       -1);
   MVCCStats_descriptor_ = file->message_type(1);
   static const int MVCCStats_offsets_[13] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, live_bytes_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, key_bytes_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, val_bytes_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, intent_bytes_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, live_count_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, key_count_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, val_count_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, intent_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, last_update_nanos_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, intent_age_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, gc_bytes_age_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, live_bytes_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, live_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, key_bytes_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, key_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, val_bytes_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, val_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, intent_bytes_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, intent_count_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, sys_bytes_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, sys_count_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MVCCStats, last_update_nanos_),
   };
   MVCCStats_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -132,16 +132,16 @@ void protobuf_AddDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto() {
     "ted\030\003 \001(\010B\004\310\336\037\000\022\027\n\tkey_bytes\030\004 \001(\003B\004\310\336\037\000"
     "\022\027\n\tval_bytes\030\005 \001(\003B\004\310\336\037\000\022\021\n\traw_bytes\030\006"
     " \001(\014\0225\n\017merge_timestamp\030\007 \001(\0132\034.cockroac"
-    "h.roachpb.Timestamp\"\362\002\n\tMVCCStats\022\030\n\nliv"
-    "e_bytes\030\001 \001(\003B\004\310\336\037\000\022\027\n\tkey_bytes\030\002 \001(\003B\004"
-    "\310\336\037\000\022\027\n\tval_bytes\030\003 \001(\003B\004\310\336\037\000\022\032\n\014intent_"
-    "bytes\030\004 \001(\003B\004\310\336\037\000\022\030\n\nlive_count\030\005 \001(\003B\004\310"
-    "\336\037\000\022\027\n\tkey_count\030\006 \001(\003B\004\310\336\037\000\022\027\n\tval_coun"
-    "t\030\007 \001(\003B\004\310\336\037\000\022\032\n\014intent_count\030\010 \001(\003B\004\310\336\037"
-    "\000\022\030\n\nintent_age\030\t \001(\003B\004\310\336\037\000\022(\n\014gc_bytes_"
-    "age\030\n \001(\003B\022\310\336\037\000\342\336\037\nGCBytesAge\022\027\n\tsys_byt"
-    "es\030\014 \001(\003B\004\310\336\037\000\022\027\n\tsys_count\030\r \001(\003B\004\310\336\037\000\022"
-    "\037\n\021last_update_nanos\030\036 \001(\003B\004\310\336\037\000B\010Z\006engi"
+    "h.roachpb.Timestamp\"\362\002\n\tMVCCStats\022\037\n\021las"
+    "t_update_nanos\030\001 \001(\003B\004\310\336\037\000\022\030\n\nintent_age"
+    "\030\002 \001(\003B\004\310\336\037\000\022(\n\014gc_bytes_age\030\003 \001(\003B\022\310\336\037\000"
+    "\342\336\037\nGCBytesAge\022\030\n\nlive_bytes\030\004 \001(\003B\004\310\336\037\000"
+    "\022\030\n\nlive_count\030\005 \001(\003B\004\310\336\037\000\022\027\n\tkey_bytes\030"
+    "\006 \001(\003B\004\310\336\037\000\022\027\n\tkey_count\030\007 \001(\003B\004\310\336\037\000\022\027\n\t"
+    "val_bytes\030\010 \001(\003B\004\310\336\037\000\022\027\n\tval_count\030\t \001(\003"
+    "B\004\310\336\037\000\022\032\n\014intent_bytes\030\n \001(\003B\004\310\336\037\000\022\032\n\014in"
+    "tent_count\030\013 \001(\003B\004\310\336\037\000\022\027\n\tsys_bytes\030\014 \001("
+    "\003B\004\310\336\037\000\022\027\n\tsys_count\030\r \001(\003B\004\310\336\037\000B\010Z\006engi"
     "neX\001", 764);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/storage/engine/mvcc.proto", &protobuf_RegisterTypes);
@@ -929,19 +929,19 @@ void MVCCMetadata::set_allocated_merge_timestamp(::cockroach::roachpb::Timestamp
 // ===================================================================
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int MVCCStats::kLiveBytesFieldNumber;
-const int MVCCStats::kKeyBytesFieldNumber;
-const int MVCCStats::kValBytesFieldNumber;
-const int MVCCStats::kIntentBytesFieldNumber;
-const int MVCCStats::kLiveCountFieldNumber;
-const int MVCCStats::kKeyCountFieldNumber;
-const int MVCCStats::kValCountFieldNumber;
-const int MVCCStats::kIntentCountFieldNumber;
+const int MVCCStats::kLastUpdateNanosFieldNumber;
 const int MVCCStats::kIntentAgeFieldNumber;
 const int MVCCStats::kGcBytesAgeFieldNumber;
+const int MVCCStats::kLiveBytesFieldNumber;
+const int MVCCStats::kLiveCountFieldNumber;
+const int MVCCStats::kKeyBytesFieldNumber;
+const int MVCCStats::kKeyCountFieldNumber;
+const int MVCCStats::kValBytesFieldNumber;
+const int MVCCStats::kValCountFieldNumber;
+const int MVCCStats::kIntentBytesFieldNumber;
+const int MVCCStats::kIntentCountFieldNumber;
 const int MVCCStats::kSysBytesFieldNumber;
 const int MVCCStats::kSysCountFieldNumber;
-const int MVCCStats::kLastUpdateNanosFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 MVCCStats::MVCCStats()
@@ -963,19 +963,19 @@ MVCCStats::MVCCStats(const MVCCStats& from)
 
 void MVCCStats::SharedCtor() {
   _cached_size_ = 0;
-  live_bytes_ = GOOGLE_LONGLONG(0);
-  key_bytes_ = GOOGLE_LONGLONG(0);
-  val_bytes_ = GOOGLE_LONGLONG(0);
-  intent_bytes_ = GOOGLE_LONGLONG(0);
-  live_count_ = GOOGLE_LONGLONG(0);
-  key_count_ = GOOGLE_LONGLONG(0);
-  val_count_ = GOOGLE_LONGLONG(0);
-  intent_count_ = GOOGLE_LONGLONG(0);
+  last_update_nanos_ = GOOGLE_LONGLONG(0);
   intent_age_ = GOOGLE_LONGLONG(0);
   gc_bytes_age_ = GOOGLE_LONGLONG(0);
+  live_bytes_ = GOOGLE_LONGLONG(0);
+  live_count_ = GOOGLE_LONGLONG(0);
+  key_bytes_ = GOOGLE_LONGLONG(0);
+  key_count_ = GOOGLE_LONGLONG(0);
+  val_bytes_ = GOOGLE_LONGLONG(0);
+  val_count_ = GOOGLE_LONGLONG(0);
+  intent_bytes_ = GOOGLE_LONGLONG(0);
+  intent_count_ = GOOGLE_LONGLONG(0);
   sys_bytes_ = GOOGLE_LONGLONG(0);
   sys_count_ = GOOGLE_LONGLONG(0);
-  last_update_nanos_ = GOOGLE_LONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -1024,10 +1024,10 @@ void MVCCStats::Clear() {
 } while (0)
 
   if (_has_bits_[0 / 32] & 255u) {
-    ZR_(live_bytes_, intent_count_);
+    ZR_(last_update_nanos_, val_bytes_);
   }
   if (_has_bits_[8 / 32] & 7936u) {
-    ZR_(intent_age_, last_update_nanos_);
+    ZR_(val_count_, sys_count_);
   }
 
 #undef ZR_HELPER_
@@ -1045,62 +1045,62 @@ bool MVCCStats::MergePartialFromCodedStream(
   ::google::protobuf::uint32 tag;
   // @@protoc_insertion_point(parse_start:cockroach.storage.engine.MVCCStats)
   for (;;) {
-    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(16383);
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional int64 live_bytes = 1;
+      // optional int64 last_update_nanos = 1;
       case 1: {
         if (tag == 8) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &live_bytes_)));
-          set_has_live_bytes();
+                 input, &last_update_nanos_)));
+          set_has_last_update_nanos();
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(16)) goto parse_key_bytes;
+        if (input->ExpectTag(16)) goto parse_intent_age;
         break;
       }
 
-      // optional int64 key_bytes = 2;
+      // optional int64 intent_age = 2;
       case 2: {
         if (tag == 16) {
-         parse_key_bytes:
+         parse_intent_age:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &key_bytes_)));
-          set_has_key_bytes();
+                 input, &intent_age_)));
+          set_has_intent_age();
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(24)) goto parse_val_bytes;
+        if (input->ExpectTag(24)) goto parse_gc_bytes_age;
         break;
       }
 
-      // optional int64 val_bytes = 3;
+      // optional int64 gc_bytes_age = 3;
       case 3: {
         if (tag == 24) {
-         parse_val_bytes:
+         parse_gc_bytes_age:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &val_bytes_)));
-          set_has_val_bytes();
+                 input, &gc_bytes_age_)));
+          set_has_gc_bytes_age();
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(32)) goto parse_intent_bytes;
+        if (input->ExpectTag(32)) goto parse_live_bytes;
         break;
       }
 
-      // optional int64 intent_bytes = 4;
+      // optional int64 live_bytes = 4;
       case 4: {
         if (tag == 32) {
-         parse_intent_bytes:
+         parse_live_bytes:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &intent_bytes_)));
-          set_has_intent_bytes();
+                 input, &live_bytes_)));
+          set_has_live_bytes();
         } else {
           goto handle_unusual;
         }
@@ -1119,13 +1119,28 @@ bool MVCCStats::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(48)) goto parse_key_count;
+        if (input->ExpectTag(48)) goto parse_key_bytes;
         break;
       }
 
-      // optional int64 key_count = 6;
+      // optional int64 key_bytes = 6;
       case 6: {
         if (tag == 48) {
+         parse_key_bytes:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &key_bytes_)));
+          set_has_key_bytes();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(56)) goto parse_key_count;
+        break;
+      }
+
+      // optional int64 key_count = 7;
+      case 7: {
+        if (tag == 56) {
          parse_key_count:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
@@ -1134,13 +1149,28 @@ bool MVCCStats::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(56)) goto parse_val_count;
+        if (input->ExpectTag(64)) goto parse_val_bytes;
         break;
       }
 
-      // optional int64 val_count = 7;
-      case 7: {
-        if (tag == 56) {
+      // optional int64 val_bytes = 8;
+      case 8: {
+        if (tag == 64) {
+         parse_val_bytes:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &val_bytes_)));
+          set_has_val_bytes();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(72)) goto parse_val_count;
+        break;
+      }
+
+      // optional int64 val_count = 9;
+      case 9: {
+        if (tag == 72) {
          parse_val_count:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
@@ -1149,48 +1179,33 @@ bool MVCCStats::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(64)) goto parse_intent_count;
+        if (input->ExpectTag(80)) goto parse_intent_bytes;
         break;
       }
 
-      // optional int64 intent_count = 8;
-      case 8: {
-        if (tag == 64) {
+      // optional int64 intent_bytes = 10;
+      case 10: {
+        if (tag == 80) {
+         parse_intent_bytes:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &intent_bytes_)));
+          set_has_intent_bytes();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(88)) goto parse_intent_count;
+        break;
+      }
+
+      // optional int64 intent_count = 11;
+      case 11: {
+        if (tag == 88) {
          parse_intent_count:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
                  input, &intent_count_)));
           set_has_intent_count();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(72)) goto parse_intent_age;
-        break;
-      }
-
-      // optional int64 intent_age = 9;
-      case 9: {
-        if (tag == 72) {
-         parse_intent_age:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &intent_age_)));
-          set_has_intent_age();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(80)) goto parse_gc_bytes_age;
-        break;
-      }
-
-      // optional int64 gc_bytes_age = 10;
-      case 10: {
-        if (tag == 80) {
-         parse_gc_bytes_age:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &gc_bytes_age_)));
-          set_has_gc_bytes_age();
         } else {
           goto handle_unusual;
         }
@@ -1224,21 +1239,6 @@ bool MVCCStats::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(240)) goto parse_last_update_nanos;
-        break;
-      }
-
-      // optional int64 last_update_nanos = 30;
-      case 30: {
-        if (tag == 240) {
-         parse_last_update_nanos:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &last_update_nanos_)));
-          set_has_last_update_nanos();
-        } else {
-          goto handle_unusual;
-        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -1268,24 +1268,24 @@ failure:
 void MVCCStats::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.storage.engine.MVCCStats)
-  // optional int64 live_bytes = 1;
+  // optional int64 last_update_nanos = 1;
+  if (has_last_update_nanos()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->last_update_nanos(), output);
+  }
+
+  // optional int64 intent_age = 2;
+  if (has_intent_age()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->intent_age(), output);
+  }
+
+  // optional int64 gc_bytes_age = 3;
+  if (has_gc_bytes_age()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(3, this->gc_bytes_age(), output);
+  }
+
+  // optional int64 live_bytes = 4;
   if (has_live_bytes()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->live_bytes(), output);
-  }
-
-  // optional int64 key_bytes = 2;
-  if (has_key_bytes()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->key_bytes(), output);
-  }
-
-  // optional int64 val_bytes = 3;
-  if (has_val_bytes()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(3, this->val_bytes(), output);
-  }
-
-  // optional int64 intent_bytes = 4;
-  if (has_intent_bytes()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(4, this->intent_bytes(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(4, this->live_bytes(), output);
   }
 
   // optional int64 live_count = 5;
@@ -1293,29 +1293,34 @@ void MVCCStats::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt64(5, this->live_count(), output);
   }
 
-  // optional int64 key_count = 6;
+  // optional int64 key_bytes = 6;
+  if (has_key_bytes()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(6, this->key_bytes(), output);
+  }
+
+  // optional int64 key_count = 7;
   if (has_key_count()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(6, this->key_count(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(7, this->key_count(), output);
   }
 
-  // optional int64 val_count = 7;
+  // optional int64 val_bytes = 8;
+  if (has_val_bytes()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(8, this->val_bytes(), output);
+  }
+
+  // optional int64 val_count = 9;
   if (has_val_count()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(7, this->val_count(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(9, this->val_count(), output);
   }
 
-  // optional int64 intent_count = 8;
+  // optional int64 intent_bytes = 10;
+  if (has_intent_bytes()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(10, this->intent_bytes(), output);
+  }
+
+  // optional int64 intent_count = 11;
   if (has_intent_count()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(8, this->intent_count(), output);
-  }
-
-  // optional int64 intent_age = 9;
-  if (has_intent_age()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(9, this->intent_age(), output);
-  }
-
-  // optional int64 gc_bytes_age = 10;
-  if (has_gc_bytes_age()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(10, this->gc_bytes_age(), output);
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(11, this->intent_count(), output);
   }
 
   // optional int64 sys_bytes = 12;
@@ -1328,11 +1333,6 @@ void MVCCStats::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt64(13, this->sys_count(), output);
   }
 
-  // optional int64 last_update_nanos = 30;
-  if (has_last_update_nanos()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(30, this->last_update_nanos(), output);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -1343,24 +1343,24 @@ void MVCCStats::SerializeWithCachedSizes(
 ::google::protobuf::uint8* MVCCStats::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.storage.engine.MVCCStats)
-  // optional int64 live_bytes = 1;
+  // optional int64 last_update_nanos = 1;
+  if (has_last_update_nanos()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->last_update_nanos(), target);
+  }
+
+  // optional int64 intent_age = 2;
+  if (has_intent_age()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->intent_age(), target);
+  }
+
+  // optional int64 gc_bytes_age = 3;
+  if (has_gc_bytes_age()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(3, this->gc_bytes_age(), target);
+  }
+
+  // optional int64 live_bytes = 4;
   if (has_live_bytes()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->live_bytes(), target);
-  }
-
-  // optional int64 key_bytes = 2;
-  if (has_key_bytes()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->key_bytes(), target);
-  }
-
-  // optional int64 val_bytes = 3;
-  if (has_val_bytes()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(3, this->val_bytes(), target);
-  }
-
-  // optional int64 intent_bytes = 4;
-  if (has_intent_bytes()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(4, this->intent_bytes(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(4, this->live_bytes(), target);
   }
 
   // optional int64 live_count = 5;
@@ -1368,29 +1368,34 @@ void MVCCStats::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(5, this->live_count(), target);
   }
 
-  // optional int64 key_count = 6;
+  // optional int64 key_bytes = 6;
+  if (has_key_bytes()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(6, this->key_bytes(), target);
+  }
+
+  // optional int64 key_count = 7;
   if (has_key_count()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(6, this->key_count(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(7, this->key_count(), target);
   }
 
-  // optional int64 val_count = 7;
+  // optional int64 val_bytes = 8;
+  if (has_val_bytes()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(8, this->val_bytes(), target);
+  }
+
+  // optional int64 val_count = 9;
   if (has_val_count()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(7, this->val_count(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(9, this->val_count(), target);
   }
 
-  // optional int64 intent_count = 8;
+  // optional int64 intent_bytes = 10;
+  if (has_intent_bytes()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(10, this->intent_bytes(), target);
+  }
+
+  // optional int64 intent_count = 11;
   if (has_intent_count()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(8, this->intent_count(), target);
-  }
-
-  // optional int64 intent_age = 9;
-  if (has_intent_age()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(9, this->intent_age(), target);
-  }
-
-  // optional int64 gc_bytes_age = 10;
-  if (has_gc_bytes_age()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(10, this->gc_bytes_age(), target);
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(11, this->intent_count(), target);
   }
 
   // optional int64 sys_bytes = 12;
@@ -1401,11 +1406,6 @@ void MVCCStats::SerializeWithCachedSizes(
   // optional int64 sys_count = 13;
   if (has_sys_count()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(13, this->sys_count(), target);
-  }
-
-  // optional int64 last_update_nanos = 30;
-  if (has_last_update_nanos()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(30, this->last_update_nanos(), target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -1420,32 +1420,32 @@ int MVCCStats::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & 255u) {
-    // optional int64 live_bytes = 1;
+    // optional int64 last_update_nanos = 1;
+    if (has_last_update_nanos()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->last_update_nanos());
+    }
+
+    // optional int64 intent_age = 2;
+    if (has_intent_age()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->intent_age());
+    }
+
+    // optional int64 gc_bytes_age = 3;
+    if (has_gc_bytes_age()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->gc_bytes_age());
+    }
+
+    // optional int64 live_bytes = 4;
     if (has_live_bytes()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int64Size(
           this->live_bytes());
-    }
-
-    // optional int64 key_bytes = 2;
-    if (has_key_bytes()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->key_bytes());
-    }
-
-    // optional int64 val_bytes = 3;
-    if (has_val_bytes()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->val_bytes());
-    }
-
-    // optional int64 intent_bytes = 4;
-    if (has_intent_bytes()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->intent_bytes());
     }
 
     // optional int64 live_count = 5;
@@ -1455,41 +1455,48 @@ int MVCCStats::ByteSize() const {
           this->live_count());
     }
 
-    // optional int64 key_count = 6;
+    // optional int64 key_bytes = 6;
+    if (has_key_bytes()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->key_bytes());
+    }
+
+    // optional int64 key_count = 7;
     if (has_key_count()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int64Size(
           this->key_count());
     }
 
-    // optional int64 val_count = 7;
+    // optional int64 val_bytes = 8;
+    if (has_val_bytes()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->val_bytes());
+    }
+
+  }
+  if (_has_bits_[8 / 32] & 7936u) {
+    // optional int64 val_count = 9;
     if (has_val_count()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int64Size(
           this->val_count());
     }
 
-    // optional int64 intent_count = 8;
+    // optional int64 intent_bytes = 10;
+    if (has_intent_bytes()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->intent_bytes());
+    }
+
+    // optional int64 intent_count = 11;
     if (has_intent_count()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int64Size(
           this->intent_count());
-    }
-
-  }
-  if (_has_bits_[8 / 32] & 7936u) {
-    // optional int64 intent_age = 9;
-    if (has_intent_age()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->intent_age());
-    }
-
-    // optional int64 gc_bytes_age = 10;
-    if (has_gc_bytes_age()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->gc_bytes_age());
     }
 
     // optional int64 sys_bytes = 12;
@@ -1504,13 +1511,6 @@ int MVCCStats::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::Int64Size(
           this->sys_count());
-    }
-
-    // optional int64 last_update_nanos = 30;
-    if (has_last_update_nanos()) {
-      total_size += 2 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->last_update_nanos());
     }
 
   }
@@ -1540,46 +1540,46 @@ void MVCCStats::MergeFrom(const ::google::protobuf::Message& from) {
 void MVCCStats::MergeFrom(const MVCCStats& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_live_bytes()) {
-      set_live_bytes(from.live_bytes());
+    if (from.has_last_update_nanos()) {
+      set_last_update_nanos(from.last_update_nanos());
     }
-    if (from.has_key_bytes()) {
-      set_key_bytes(from.key_bytes());
-    }
-    if (from.has_val_bytes()) {
-      set_val_bytes(from.val_bytes());
-    }
-    if (from.has_intent_bytes()) {
-      set_intent_bytes(from.intent_bytes());
-    }
-    if (from.has_live_count()) {
-      set_live_count(from.live_count());
-    }
-    if (from.has_key_count()) {
-      set_key_count(from.key_count());
-    }
-    if (from.has_val_count()) {
-      set_val_count(from.val_count());
-    }
-    if (from.has_intent_count()) {
-      set_intent_count(from.intent_count());
-    }
-  }
-  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
     if (from.has_intent_age()) {
       set_intent_age(from.intent_age());
     }
     if (from.has_gc_bytes_age()) {
       set_gc_bytes_age(from.gc_bytes_age());
     }
+    if (from.has_live_bytes()) {
+      set_live_bytes(from.live_bytes());
+    }
+    if (from.has_live_count()) {
+      set_live_count(from.live_count());
+    }
+    if (from.has_key_bytes()) {
+      set_key_bytes(from.key_bytes());
+    }
+    if (from.has_key_count()) {
+      set_key_count(from.key_count());
+    }
+    if (from.has_val_bytes()) {
+      set_val_bytes(from.val_bytes());
+    }
+  }
+  if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
+    if (from.has_val_count()) {
+      set_val_count(from.val_count());
+    }
+    if (from.has_intent_bytes()) {
+      set_intent_bytes(from.intent_bytes());
+    }
+    if (from.has_intent_count()) {
+      set_intent_count(from.intent_count());
+    }
     if (from.has_sys_bytes()) {
       set_sys_bytes(from.sys_bytes());
     }
     if (from.has_sys_count()) {
       set_sys_count(from.sys_count());
-    }
-    if (from.has_last_update_nanos()) {
-      set_last_update_nanos(from.last_update_nanos());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -1609,19 +1609,19 @@ void MVCCStats::Swap(MVCCStats* other) {
   InternalSwap(other);
 }
 void MVCCStats::InternalSwap(MVCCStats* other) {
-  std::swap(live_bytes_, other->live_bytes_);
-  std::swap(key_bytes_, other->key_bytes_);
-  std::swap(val_bytes_, other->val_bytes_);
-  std::swap(intent_bytes_, other->intent_bytes_);
-  std::swap(live_count_, other->live_count_);
-  std::swap(key_count_, other->key_count_);
-  std::swap(val_count_, other->val_count_);
-  std::swap(intent_count_, other->intent_count_);
+  std::swap(last_update_nanos_, other->last_update_nanos_);
   std::swap(intent_age_, other->intent_age_);
   std::swap(gc_bytes_age_, other->gc_bytes_age_);
+  std::swap(live_bytes_, other->live_bytes_);
+  std::swap(live_count_, other->live_count_);
+  std::swap(key_bytes_, other->key_bytes_);
+  std::swap(key_count_, other->key_count_);
+  std::swap(val_bytes_, other->val_bytes_);
+  std::swap(val_count_, other->val_count_);
+  std::swap(intent_bytes_, other->intent_bytes_);
+  std::swap(intent_count_, other->intent_count_);
   std::swap(sys_bytes_, other->sys_bytes_);
   std::swap(sys_count_, other->sys_count_);
-  std::swap(last_update_nanos_, other->last_update_nanos_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -1638,15 +1638,87 @@ void MVCCStats::InternalSwap(MVCCStats* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // MVCCStats
 
-// optional int64 live_bytes = 1;
-bool MVCCStats::has_live_bytes() const {
+// optional int64 last_update_nanos = 1;
+bool MVCCStats::has_last_update_nanos() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void MVCCStats::set_has_live_bytes() {
+void MVCCStats::set_has_last_update_nanos() {
   _has_bits_[0] |= 0x00000001u;
 }
-void MVCCStats::clear_has_live_bytes() {
+void MVCCStats::clear_has_last_update_nanos() {
   _has_bits_[0] &= ~0x00000001u;
+}
+void MVCCStats::clear_last_update_nanos() {
+  last_update_nanos_ = GOOGLE_LONGLONG(0);
+  clear_has_last_update_nanos();
+}
+ ::google::protobuf::int64 MVCCStats::last_update_nanos() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.last_update_nanos)
+  return last_update_nanos_;
+}
+ void MVCCStats::set_last_update_nanos(::google::protobuf::int64 value) {
+  set_has_last_update_nanos();
+  last_update_nanos_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.last_update_nanos)
+}
+
+// optional int64 intent_age = 2;
+bool MVCCStats::has_intent_age() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+void MVCCStats::set_has_intent_age() {
+  _has_bits_[0] |= 0x00000002u;
+}
+void MVCCStats::clear_has_intent_age() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+void MVCCStats::clear_intent_age() {
+  intent_age_ = GOOGLE_LONGLONG(0);
+  clear_has_intent_age();
+}
+ ::google::protobuf::int64 MVCCStats::intent_age() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.intent_age)
+  return intent_age_;
+}
+ void MVCCStats::set_intent_age(::google::protobuf::int64 value) {
+  set_has_intent_age();
+  intent_age_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.intent_age)
+}
+
+// optional int64 gc_bytes_age = 3;
+bool MVCCStats::has_gc_bytes_age() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+void MVCCStats::set_has_gc_bytes_age() {
+  _has_bits_[0] |= 0x00000004u;
+}
+void MVCCStats::clear_has_gc_bytes_age() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+void MVCCStats::clear_gc_bytes_age() {
+  gc_bytes_age_ = GOOGLE_LONGLONG(0);
+  clear_has_gc_bytes_age();
+}
+ ::google::protobuf::int64 MVCCStats::gc_bytes_age() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.gc_bytes_age)
+  return gc_bytes_age_;
+}
+ void MVCCStats::set_gc_bytes_age(::google::protobuf::int64 value) {
+  set_has_gc_bytes_age();
+  gc_bytes_age_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.gc_bytes_age)
+}
+
+// optional int64 live_bytes = 4;
+bool MVCCStats::has_live_bytes() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+void MVCCStats::set_has_live_bytes() {
+  _has_bits_[0] |= 0x00000008u;
+}
+void MVCCStats::clear_has_live_bytes() {
+  _has_bits_[0] &= ~0x00000008u;
 }
 void MVCCStats::clear_live_bytes() {
   live_bytes_ = GOOGLE_LONGLONG(0);
@@ -1660,78 +1732,6 @@ void MVCCStats::clear_live_bytes() {
   set_has_live_bytes();
   live_bytes_ = value;
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.live_bytes)
-}
-
-// optional int64 key_bytes = 2;
-bool MVCCStats::has_key_bytes() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
-}
-void MVCCStats::set_has_key_bytes() {
-  _has_bits_[0] |= 0x00000002u;
-}
-void MVCCStats::clear_has_key_bytes() {
-  _has_bits_[0] &= ~0x00000002u;
-}
-void MVCCStats::clear_key_bytes() {
-  key_bytes_ = GOOGLE_LONGLONG(0);
-  clear_has_key_bytes();
-}
- ::google::protobuf::int64 MVCCStats::key_bytes() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.key_bytes)
-  return key_bytes_;
-}
- void MVCCStats::set_key_bytes(::google::protobuf::int64 value) {
-  set_has_key_bytes();
-  key_bytes_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.key_bytes)
-}
-
-// optional int64 val_bytes = 3;
-bool MVCCStats::has_val_bytes() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-void MVCCStats::set_has_val_bytes() {
-  _has_bits_[0] |= 0x00000004u;
-}
-void MVCCStats::clear_has_val_bytes() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-void MVCCStats::clear_val_bytes() {
-  val_bytes_ = GOOGLE_LONGLONG(0);
-  clear_has_val_bytes();
-}
- ::google::protobuf::int64 MVCCStats::val_bytes() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.val_bytes)
-  return val_bytes_;
-}
- void MVCCStats::set_val_bytes(::google::protobuf::int64 value) {
-  set_has_val_bytes();
-  val_bytes_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.val_bytes)
-}
-
-// optional int64 intent_bytes = 4;
-bool MVCCStats::has_intent_bytes() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-void MVCCStats::set_has_intent_bytes() {
-  _has_bits_[0] |= 0x00000008u;
-}
-void MVCCStats::clear_has_intent_bytes() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-void MVCCStats::clear_intent_bytes() {
-  intent_bytes_ = GOOGLE_LONGLONG(0);
-  clear_has_intent_bytes();
-}
- ::google::protobuf::int64 MVCCStats::intent_bytes() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.intent_bytes)
-  return intent_bytes_;
-}
- void MVCCStats::set_intent_bytes(::google::protobuf::int64 value) {
-  set_has_intent_bytes();
-  intent_bytes_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.intent_bytes)
 }
 
 // optional int64 live_count = 5;
@@ -1758,15 +1758,39 @@ void MVCCStats::clear_live_count() {
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.live_count)
 }
 
-// optional int64 key_count = 6;
-bool MVCCStats::has_key_count() const {
+// optional int64 key_bytes = 6;
+bool MVCCStats::has_key_bytes() const {
   return (_has_bits_[0] & 0x00000020u) != 0;
 }
-void MVCCStats::set_has_key_count() {
+void MVCCStats::set_has_key_bytes() {
   _has_bits_[0] |= 0x00000020u;
 }
-void MVCCStats::clear_has_key_count() {
+void MVCCStats::clear_has_key_bytes() {
   _has_bits_[0] &= ~0x00000020u;
+}
+void MVCCStats::clear_key_bytes() {
+  key_bytes_ = GOOGLE_LONGLONG(0);
+  clear_has_key_bytes();
+}
+ ::google::protobuf::int64 MVCCStats::key_bytes() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.key_bytes)
+  return key_bytes_;
+}
+ void MVCCStats::set_key_bytes(::google::protobuf::int64 value) {
+  set_has_key_bytes();
+  key_bytes_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.key_bytes)
+}
+
+// optional int64 key_count = 7;
+bool MVCCStats::has_key_count() const {
+  return (_has_bits_[0] & 0x00000040u) != 0;
+}
+void MVCCStats::set_has_key_count() {
+  _has_bits_[0] |= 0x00000040u;
+}
+void MVCCStats::clear_has_key_count() {
+  _has_bits_[0] &= ~0x00000040u;
 }
 void MVCCStats::clear_key_count() {
   key_count_ = GOOGLE_LONGLONG(0);
@@ -1782,15 +1806,39 @@ void MVCCStats::clear_key_count() {
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.key_count)
 }
 
-// optional int64 val_count = 7;
+// optional int64 val_bytes = 8;
+bool MVCCStats::has_val_bytes() const {
+  return (_has_bits_[0] & 0x00000080u) != 0;
+}
+void MVCCStats::set_has_val_bytes() {
+  _has_bits_[0] |= 0x00000080u;
+}
+void MVCCStats::clear_has_val_bytes() {
+  _has_bits_[0] &= ~0x00000080u;
+}
+void MVCCStats::clear_val_bytes() {
+  val_bytes_ = GOOGLE_LONGLONG(0);
+  clear_has_val_bytes();
+}
+ ::google::protobuf::int64 MVCCStats::val_bytes() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.val_bytes)
+  return val_bytes_;
+}
+ void MVCCStats::set_val_bytes(::google::protobuf::int64 value) {
+  set_has_val_bytes();
+  val_bytes_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.val_bytes)
+}
+
+// optional int64 val_count = 9;
 bool MVCCStats::has_val_count() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000100u) != 0;
 }
 void MVCCStats::set_has_val_count() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000100u;
 }
 void MVCCStats::clear_has_val_count() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000100u;
 }
 void MVCCStats::clear_val_count() {
   val_count_ = GOOGLE_LONGLONG(0);
@@ -1806,15 +1854,39 @@ void MVCCStats::clear_val_count() {
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.val_count)
 }
 
-// optional int64 intent_count = 8;
+// optional int64 intent_bytes = 10;
+bool MVCCStats::has_intent_bytes() const {
+  return (_has_bits_[0] & 0x00000200u) != 0;
+}
+void MVCCStats::set_has_intent_bytes() {
+  _has_bits_[0] |= 0x00000200u;
+}
+void MVCCStats::clear_has_intent_bytes() {
+  _has_bits_[0] &= ~0x00000200u;
+}
+void MVCCStats::clear_intent_bytes() {
+  intent_bytes_ = GOOGLE_LONGLONG(0);
+  clear_has_intent_bytes();
+}
+ ::google::protobuf::int64 MVCCStats::intent_bytes() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.intent_bytes)
+  return intent_bytes_;
+}
+ void MVCCStats::set_intent_bytes(::google::protobuf::int64 value) {
+  set_has_intent_bytes();
+  intent_bytes_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.intent_bytes)
+}
+
+// optional int64 intent_count = 11;
 bool MVCCStats::has_intent_count() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000400u) != 0;
 }
 void MVCCStats::set_has_intent_count() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000400u;
 }
 void MVCCStats::clear_has_intent_count() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000400u;
 }
 void MVCCStats::clear_intent_count() {
   intent_count_ = GOOGLE_LONGLONG(0);
@@ -1830,63 +1902,15 @@ void MVCCStats::clear_intent_count() {
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.intent_count)
 }
 
-// optional int64 intent_age = 9;
-bool MVCCStats::has_intent_age() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
-}
-void MVCCStats::set_has_intent_age() {
-  _has_bits_[0] |= 0x00000100u;
-}
-void MVCCStats::clear_has_intent_age() {
-  _has_bits_[0] &= ~0x00000100u;
-}
-void MVCCStats::clear_intent_age() {
-  intent_age_ = GOOGLE_LONGLONG(0);
-  clear_has_intent_age();
-}
- ::google::protobuf::int64 MVCCStats::intent_age() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.intent_age)
-  return intent_age_;
-}
- void MVCCStats::set_intent_age(::google::protobuf::int64 value) {
-  set_has_intent_age();
-  intent_age_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.intent_age)
-}
-
-// optional int64 gc_bytes_age = 10;
-bool MVCCStats::has_gc_bytes_age() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
-}
-void MVCCStats::set_has_gc_bytes_age() {
-  _has_bits_[0] |= 0x00000200u;
-}
-void MVCCStats::clear_has_gc_bytes_age() {
-  _has_bits_[0] &= ~0x00000200u;
-}
-void MVCCStats::clear_gc_bytes_age() {
-  gc_bytes_age_ = GOOGLE_LONGLONG(0);
-  clear_has_gc_bytes_age();
-}
- ::google::protobuf::int64 MVCCStats::gc_bytes_age() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.gc_bytes_age)
-  return gc_bytes_age_;
-}
- void MVCCStats::set_gc_bytes_age(::google::protobuf::int64 value) {
-  set_has_gc_bytes_age();
-  gc_bytes_age_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.gc_bytes_age)
-}
-
 // optional int64 sys_bytes = 12;
 bool MVCCStats::has_sys_bytes() const {
-  return (_has_bits_[0] & 0x00000400u) != 0;
+  return (_has_bits_[0] & 0x00000800u) != 0;
 }
 void MVCCStats::set_has_sys_bytes() {
-  _has_bits_[0] |= 0x00000400u;
+  _has_bits_[0] |= 0x00000800u;
 }
 void MVCCStats::clear_has_sys_bytes() {
-  _has_bits_[0] &= ~0x00000400u;
+  _has_bits_[0] &= ~0x00000800u;
 }
 void MVCCStats::clear_sys_bytes() {
   sys_bytes_ = GOOGLE_LONGLONG(0);
@@ -1904,13 +1928,13 @@ void MVCCStats::clear_sys_bytes() {
 
 // optional int64 sys_count = 13;
 bool MVCCStats::has_sys_count() const {
-  return (_has_bits_[0] & 0x00000800u) != 0;
+  return (_has_bits_[0] & 0x00001000u) != 0;
 }
 void MVCCStats::set_has_sys_count() {
-  _has_bits_[0] |= 0x00000800u;
+  _has_bits_[0] |= 0x00001000u;
 }
 void MVCCStats::clear_has_sys_count() {
-  _has_bits_[0] &= ~0x00000800u;
+  _has_bits_[0] &= ~0x00001000u;
 }
 void MVCCStats::clear_sys_count() {
   sys_count_ = GOOGLE_LONGLONG(0);
@@ -1924,30 +1948,6 @@ void MVCCStats::clear_sys_count() {
   set_has_sys_count();
   sys_count_ = value;
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.sys_count)
-}
-
-// optional int64 last_update_nanos = 30;
-bool MVCCStats::has_last_update_nanos() const {
-  return (_has_bits_[0] & 0x00001000u) != 0;
-}
-void MVCCStats::set_has_last_update_nanos() {
-  _has_bits_[0] |= 0x00001000u;
-}
-void MVCCStats::clear_has_last_update_nanos() {
-  _has_bits_[0] &= ~0x00001000u;
-}
-void MVCCStats::clear_last_update_nanos() {
-  last_update_nanos_ = GOOGLE_LONGLONG(0);
-  clear_has_last_update_nanos();
-}
- ::google::protobuf::int64 MVCCStats::last_update_nanos() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.last_update_nanos)
-  return last_update_nanos_;
-}
- void MVCCStats::set_last_update_nanos(::google::protobuf::int64 value) {
-  set_has_last_update_nanos();
-  last_update_nanos_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.last_update_nanos)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.h
+++ b/storage/engine/rocksdb/cockroach/storage/engine/mvcc.pb.h
@@ -269,33 +269,33 @@ class MVCCStats : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional int64 live_bytes = 1;
+  // optional int64 last_update_nanos = 1;
+  bool has_last_update_nanos() const;
+  void clear_last_update_nanos();
+  static const int kLastUpdateNanosFieldNumber = 1;
+  ::google::protobuf::int64 last_update_nanos() const;
+  void set_last_update_nanos(::google::protobuf::int64 value);
+
+  // optional int64 intent_age = 2;
+  bool has_intent_age() const;
+  void clear_intent_age();
+  static const int kIntentAgeFieldNumber = 2;
+  ::google::protobuf::int64 intent_age() const;
+  void set_intent_age(::google::protobuf::int64 value);
+
+  // optional int64 gc_bytes_age = 3;
+  bool has_gc_bytes_age() const;
+  void clear_gc_bytes_age();
+  static const int kGcBytesAgeFieldNumber = 3;
+  ::google::protobuf::int64 gc_bytes_age() const;
+  void set_gc_bytes_age(::google::protobuf::int64 value);
+
+  // optional int64 live_bytes = 4;
   bool has_live_bytes() const;
   void clear_live_bytes();
-  static const int kLiveBytesFieldNumber = 1;
+  static const int kLiveBytesFieldNumber = 4;
   ::google::protobuf::int64 live_bytes() const;
   void set_live_bytes(::google::protobuf::int64 value);
-
-  // optional int64 key_bytes = 2;
-  bool has_key_bytes() const;
-  void clear_key_bytes();
-  static const int kKeyBytesFieldNumber = 2;
-  ::google::protobuf::int64 key_bytes() const;
-  void set_key_bytes(::google::protobuf::int64 value);
-
-  // optional int64 val_bytes = 3;
-  bool has_val_bytes() const;
-  void clear_val_bytes();
-  static const int kValBytesFieldNumber = 3;
-  ::google::protobuf::int64 val_bytes() const;
-  void set_val_bytes(::google::protobuf::int64 value);
-
-  // optional int64 intent_bytes = 4;
-  bool has_intent_bytes() const;
-  void clear_intent_bytes();
-  static const int kIntentBytesFieldNumber = 4;
-  ::google::protobuf::int64 intent_bytes() const;
-  void set_intent_bytes(::google::protobuf::int64 value);
 
   // optional int64 live_count = 5;
   bool has_live_count() const;
@@ -304,40 +304,47 @@ class MVCCStats : public ::google::protobuf::Message {
   ::google::protobuf::int64 live_count() const;
   void set_live_count(::google::protobuf::int64 value);
 
-  // optional int64 key_count = 6;
+  // optional int64 key_bytes = 6;
+  bool has_key_bytes() const;
+  void clear_key_bytes();
+  static const int kKeyBytesFieldNumber = 6;
+  ::google::protobuf::int64 key_bytes() const;
+  void set_key_bytes(::google::protobuf::int64 value);
+
+  // optional int64 key_count = 7;
   bool has_key_count() const;
   void clear_key_count();
-  static const int kKeyCountFieldNumber = 6;
+  static const int kKeyCountFieldNumber = 7;
   ::google::protobuf::int64 key_count() const;
   void set_key_count(::google::protobuf::int64 value);
 
-  // optional int64 val_count = 7;
+  // optional int64 val_bytes = 8;
+  bool has_val_bytes() const;
+  void clear_val_bytes();
+  static const int kValBytesFieldNumber = 8;
+  ::google::protobuf::int64 val_bytes() const;
+  void set_val_bytes(::google::protobuf::int64 value);
+
+  // optional int64 val_count = 9;
   bool has_val_count() const;
   void clear_val_count();
-  static const int kValCountFieldNumber = 7;
+  static const int kValCountFieldNumber = 9;
   ::google::protobuf::int64 val_count() const;
   void set_val_count(::google::protobuf::int64 value);
 
-  // optional int64 intent_count = 8;
+  // optional int64 intent_bytes = 10;
+  bool has_intent_bytes() const;
+  void clear_intent_bytes();
+  static const int kIntentBytesFieldNumber = 10;
+  ::google::protobuf::int64 intent_bytes() const;
+  void set_intent_bytes(::google::protobuf::int64 value);
+
+  // optional int64 intent_count = 11;
   bool has_intent_count() const;
   void clear_intent_count();
-  static const int kIntentCountFieldNumber = 8;
+  static const int kIntentCountFieldNumber = 11;
   ::google::protobuf::int64 intent_count() const;
   void set_intent_count(::google::protobuf::int64 value);
-
-  // optional int64 intent_age = 9;
-  bool has_intent_age() const;
-  void clear_intent_age();
-  static const int kIntentAgeFieldNumber = 9;
-  ::google::protobuf::int64 intent_age() const;
-  void set_intent_age(::google::protobuf::int64 value);
-
-  // optional int64 gc_bytes_age = 10;
-  bool has_gc_bytes_age() const;
-  void clear_gc_bytes_age();
-  static const int kGcBytesAgeFieldNumber = 10;
-  ::google::protobuf::int64 gc_bytes_age() const;
-  void set_gc_bytes_age(::google::protobuf::int64 value);
 
   // optional int64 sys_bytes = 12;
   bool has_sys_bytes() const;
@@ -353,58 +360,51 @@ class MVCCStats : public ::google::protobuf::Message {
   ::google::protobuf::int64 sys_count() const;
   void set_sys_count(::google::protobuf::int64 value);
 
-  // optional int64 last_update_nanos = 30;
-  bool has_last_update_nanos() const;
-  void clear_last_update_nanos();
-  static const int kLastUpdateNanosFieldNumber = 30;
-  ::google::protobuf::int64 last_update_nanos() const;
-  void set_last_update_nanos(::google::protobuf::int64 value);
-
   // @@protoc_insertion_point(class_scope:cockroach.storage.engine.MVCCStats)
  private:
-  inline void set_has_live_bytes();
-  inline void clear_has_live_bytes();
-  inline void set_has_key_bytes();
-  inline void clear_has_key_bytes();
-  inline void set_has_val_bytes();
-  inline void clear_has_val_bytes();
-  inline void set_has_intent_bytes();
-  inline void clear_has_intent_bytes();
-  inline void set_has_live_count();
-  inline void clear_has_live_count();
-  inline void set_has_key_count();
-  inline void clear_has_key_count();
-  inline void set_has_val_count();
-  inline void clear_has_val_count();
-  inline void set_has_intent_count();
-  inline void clear_has_intent_count();
+  inline void set_has_last_update_nanos();
+  inline void clear_has_last_update_nanos();
   inline void set_has_intent_age();
   inline void clear_has_intent_age();
   inline void set_has_gc_bytes_age();
   inline void clear_has_gc_bytes_age();
+  inline void set_has_live_bytes();
+  inline void clear_has_live_bytes();
+  inline void set_has_live_count();
+  inline void clear_has_live_count();
+  inline void set_has_key_bytes();
+  inline void clear_has_key_bytes();
+  inline void set_has_key_count();
+  inline void clear_has_key_count();
+  inline void set_has_val_bytes();
+  inline void clear_has_val_bytes();
+  inline void set_has_val_count();
+  inline void clear_has_val_count();
+  inline void set_has_intent_bytes();
+  inline void clear_has_intent_bytes();
+  inline void set_has_intent_count();
+  inline void clear_has_intent_count();
   inline void set_has_sys_bytes();
   inline void clear_has_sys_bytes();
   inline void set_has_sys_count();
   inline void clear_has_sys_count();
-  inline void set_has_last_update_nanos();
-  inline void clear_has_last_update_nanos();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::google::protobuf::int64 live_bytes_;
-  ::google::protobuf::int64 key_bytes_;
-  ::google::protobuf::int64 val_bytes_;
-  ::google::protobuf::int64 intent_bytes_;
-  ::google::protobuf::int64 live_count_;
-  ::google::protobuf::int64 key_count_;
-  ::google::protobuf::int64 val_count_;
-  ::google::protobuf::int64 intent_count_;
+  ::google::protobuf::int64 last_update_nanos_;
   ::google::protobuf::int64 intent_age_;
   ::google::protobuf::int64 gc_bytes_age_;
+  ::google::protobuf::int64 live_bytes_;
+  ::google::protobuf::int64 live_count_;
+  ::google::protobuf::int64 key_bytes_;
+  ::google::protobuf::int64 key_count_;
+  ::google::protobuf::int64 val_bytes_;
+  ::google::protobuf::int64 val_count_;
+  ::google::protobuf::int64 intent_bytes_;
+  ::google::protobuf::int64 intent_count_;
   ::google::protobuf::int64 sys_bytes_;
   ::google::protobuf::int64 sys_count_;
-  ::google::protobuf::int64 last_update_nanos_;
   friend void  protobuf_AddDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
   friend void protobuf_AssignDesc_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2fstorage_2fengine_2fmvcc_2eproto();
@@ -678,15 +678,87 @@ inline void MVCCMetadata::set_allocated_merge_timestamp(::cockroach::roachpb::Ti
 
 // MVCCStats
 
-// optional int64 live_bytes = 1;
-inline bool MVCCStats::has_live_bytes() const {
+// optional int64 last_update_nanos = 1;
+inline bool MVCCStats::has_last_update_nanos() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void MVCCStats::set_has_live_bytes() {
+inline void MVCCStats::set_has_last_update_nanos() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void MVCCStats::clear_has_live_bytes() {
+inline void MVCCStats::clear_has_last_update_nanos() {
   _has_bits_[0] &= ~0x00000001u;
+}
+inline void MVCCStats::clear_last_update_nanos() {
+  last_update_nanos_ = GOOGLE_LONGLONG(0);
+  clear_has_last_update_nanos();
+}
+inline ::google::protobuf::int64 MVCCStats::last_update_nanos() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.last_update_nanos)
+  return last_update_nanos_;
+}
+inline void MVCCStats::set_last_update_nanos(::google::protobuf::int64 value) {
+  set_has_last_update_nanos();
+  last_update_nanos_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.last_update_nanos)
+}
+
+// optional int64 intent_age = 2;
+inline bool MVCCStats::has_intent_age() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void MVCCStats::set_has_intent_age() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void MVCCStats::clear_has_intent_age() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void MVCCStats::clear_intent_age() {
+  intent_age_ = GOOGLE_LONGLONG(0);
+  clear_has_intent_age();
+}
+inline ::google::protobuf::int64 MVCCStats::intent_age() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.intent_age)
+  return intent_age_;
+}
+inline void MVCCStats::set_intent_age(::google::protobuf::int64 value) {
+  set_has_intent_age();
+  intent_age_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.intent_age)
+}
+
+// optional int64 gc_bytes_age = 3;
+inline bool MVCCStats::has_gc_bytes_age() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void MVCCStats::set_has_gc_bytes_age() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void MVCCStats::clear_has_gc_bytes_age() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void MVCCStats::clear_gc_bytes_age() {
+  gc_bytes_age_ = GOOGLE_LONGLONG(0);
+  clear_has_gc_bytes_age();
+}
+inline ::google::protobuf::int64 MVCCStats::gc_bytes_age() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.gc_bytes_age)
+  return gc_bytes_age_;
+}
+inline void MVCCStats::set_gc_bytes_age(::google::protobuf::int64 value) {
+  set_has_gc_bytes_age();
+  gc_bytes_age_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.gc_bytes_age)
+}
+
+// optional int64 live_bytes = 4;
+inline bool MVCCStats::has_live_bytes() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+inline void MVCCStats::set_has_live_bytes() {
+  _has_bits_[0] |= 0x00000008u;
+}
+inline void MVCCStats::clear_has_live_bytes() {
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline void MVCCStats::clear_live_bytes() {
   live_bytes_ = GOOGLE_LONGLONG(0);
@@ -700,78 +772,6 @@ inline void MVCCStats::set_live_bytes(::google::protobuf::int64 value) {
   set_has_live_bytes();
   live_bytes_ = value;
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.live_bytes)
-}
-
-// optional int64 key_bytes = 2;
-inline bool MVCCStats::has_key_bytes() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
-}
-inline void MVCCStats::set_has_key_bytes() {
-  _has_bits_[0] |= 0x00000002u;
-}
-inline void MVCCStats::clear_has_key_bytes() {
-  _has_bits_[0] &= ~0x00000002u;
-}
-inline void MVCCStats::clear_key_bytes() {
-  key_bytes_ = GOOGLE_LONGLONG(0);
-  clear_has_key_bytes();
-}
-inline ::google::protobuf::int64 MVCCStats::key_bytes() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.key_bytes)
-  return key_bytes_;
-}
-inline void MVCCStats::set_key_bytes(::google::protobuf::int64 value) {
-  set_has_key_bytes();
-  key_bytes_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.key_bytes)
-}
-
-// optional int64 val_bytes = 3;
-inline bool MVCCStats::has_val_bytes() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-inline void MVCCStats::set_has_val_bytes() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void MVCCStats::clear_has_val_bytes() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-inline void MVCCStats::clear_val_bytes() {
-  val_bytes_ = GOOGLE_LONGLONG(0);
-  clear_has_val_bytes();
-}
-inline ::google::protobuf::int64 MVCCStats::val_bytes() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.val_bytes)
-  return val_bytes_;
-}
-inline void MVCCStats::set_val_bytes(::google::protobuf::int64 value) {
-  set_has_val_bytes();
-  val_bytes_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.val_bytes)
-}
-
-// optional int64 intent_bytes = 4;
-inline bool MVCCStats::has_intent_bytes() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
-}
-inline void MVCCStats::set_has_intent_bytes() {
-  _has_bits_[0] |= 0x00000008u;
-}
-inline void MVCCStats::clear_has_intent_bytes() {
-  _has_bits_[0] &= ~0x00000008u;
-}
-inline void MVCCStats::clear_intent_bytes() {
-  intent_bytes_ = GOOGLE_LONGLONG(0);
-  clear_has_intent_bytes();
-}
-inline ::google::protobuf::int64 MVCCStats::intent_bytes() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.intent_bytes)
-  return intent_bytes_;
-}
-inline void MVCCStats::set_intent_bytes(::google::protobuf::int64 value) {
-  set_has_intent_bytes();
-  intent_bytes_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.intent_bytes)
 }
 
 // optional int64 live_count = 5;
@@ -798,15 +798,39 @@ inline void MVCCStats::set_live_count(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.live_count)
 }
 
-// optional int64 key_count = 6;
-inline bool MVCCStats::has_key_count() const {
+// optional int64 key_bytes = 6;
+inline bool MVCCStats::has_key_bytes() const {
   return (_has_bits_[0] & 0x00000020u) != 0;
 }
-inline void MVCCStats::set_has_key_count() {
+inline void MVCCStats::set_has_key_bytes() {
   _has_bits_[0] |= 0x00000020u;
 }
-inline void MVCCStats::clear_has_key_count() {
+inline void MVCCStats::clear_has_key_bytes() {
   _has_bits_[0] &= ~0x00000020u;
+}
+inline void MVCCStats::clear_key_bytes() {
+  key_bytes_ = GOOGLE_LONGLONG(0);
+  clear_has_key_bytes();
+}
+inline ::google::protobuf::int64 MVCCStats::key_bytes() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.key_bytes)
+  return key_bytes_;
+}
+inline void MVCCStats::set_key_bytes(::google::protobuf::int64 value) {
+  set_has_key_bytes();
+  key_bytes_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.key_bytes)
+}
+
+// optional int64 key_count = 7;
+inline bool MVCCStats::has_key_count() const {
+  return (_has_bits_[0] & 0x00000040u) != 0;
+}
+inline void MVCCStats::set_has_key_count() {
+  _has_bits_[0] |= 0x00000040u;
+}
+inline void MVCCStats::clear_has_key_count() {
+  _has_bits_[0] &= ~0x00000040u;
 }
 inline void MVCCStats::clear_key_count() {
   key_count_ = GOOGLE_LONGLONG(0);
@@ -822,15 +846,39 @@ inline void MVCCStats::set_key_count(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.key_count)
 }
 
-// optional int64 val_count = 7;
+// optional int64 val_bytes = 8;
+inline bool MVCCStats::has_val_bytes() const {
+  return (_has_bits_[0] & 0x00000080u) != 0;
+}
+inline void MVCCStats::set_has_val_bytes() {
+  _has_bits_[0] |= 0x00000080u;
+}
+inline void MVCCStats::clear_has_val_bytes() {
+  _has_bits_[0] &= ~0x00000080u;
+}
+inline void MVCCStats::clear_val_bytes() {
+  val_bytes_ = GOOGLE_LONGLONG(0);
+  clear_has_val_bytes();
+}
+inline ::google::protobuf::int64 MVCCStats::val_bytes() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.val_bytes)
+  return val_bytes_;
+}
+inline void MVCCStats::set_val_bytes(::google::protobuf::int64 value) {
+  set_has_val_bytes();
+  val_bytes_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.val_bytes)
+}
+
+// optional int64 val_count = 9;
 inline bool MVCCStats::has_val_count() const {
-  return (_has_bits_[0] & 0x00000040u) != 0;
+  return (_has_bits_[0] & 0x00000100u) != 0;
 }
 inline void MVCCStats::set_has_val_count() {
-  _has_bits_[0] |= 0x00000040u;
+  _has_bits_[0] |= 0x00000100u;
 }
 inline void MVCCStats::clear_has_val_count() {
-  _has_bits_[0] &= ~0x00000040u;
+  _has_bits_[0] &= ~0x00000100u;
 }
 inline void MVCCStats::clear_val_count() {
   val_count_ = GOOGLE_LONGLONG(0);
@@ -846,15 +894,39 @@ inline void MVCCStats::set_val_count(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.val_count)
 }
 
-// optional int64 intent_count = 8;
+// optional int64 intent_bytes = 10;
+inline bool MVCCStats::has_intent_bytes() const {
+  return (_has_bits_[0] & 0x00000200u) != 0;
+}
+inline void MVCCStats::set_has_intent_bytes() {
+  _has_bits_[0] |= 0x00000200u;
+}
+inline void MVCCStats::clear_has_intent_bytes() {
+  _has_bits_[0] &= ~0x00000200u;
+}
+inline void MVCCStats::clear_intent_bytes() {
+  intent_bytes_ = GOOGLE_LONGLONG(0);
+  clear_has_intent_bytes();
+}
+inline ::google::protobuf::int64 MVCCStats::intent_bytes() const {
+  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.intent_bytes)
+  return intent_bytes_;
+}
+inline void MVCCStats::set_intent_bytes(::google::protobuf::int64 value) {
+  set_has_intent_bytes();
+  intent_bytes_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.intent_bytes)
+}
+
+// optional int64 intent_count = 11;
 inline bool MVCCStats::has_intent_count() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+  return (_has_bits_[0] & 0x00000400u) != 0;
 }
 inline void MVCCStats::set_has_intent_count() {
-  _has_bits_[0] |= 0x00000080u;
+  _has_bits_[0] |= 0x00000400u;
 }
 inline void MVCCStats::clear_has_intent_count() {
-  _has_bits_[0] &= ~0x00000080u;
+  _has_bits_[0] &= ~0x00000400u;
 }
 inline void MVCCStats::clear_intent_count() {
   intent_count_ = GOOGLE_LONGLONG(0);
@@ -870,63 +942,15 @@ inline void MVCCStats::set_intent_count(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.intent_count)
 }
 
-// optional int64 intent_age = 9;
-inline bool MVCCStats::has_intent_age() const {
-  return (_has_bits_[0] & 0x00000100u) != 0;
-}
-inline void MVCCStats::set_has_intent_age() {
-  _has_bits_[0] |= 0x00000100u;
-}
-inline void MVCCStats::clear_has_intent_age() {
-  _has_bits_[0] &= ~0x00000100u;
-}
-inline void MVCCStats::clear_intent_age() {
-  intent_age_ = GOOGLE_LONGLONG(0);
-  clear_has_intent_age();
-}
-inline ::google::protobuf::int64 MVCCStats::intent_age() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.intent_age)
-  return intent_age_;
-}
-inline void MVCCStats::set_intent_age(::google::protobuf::int64 value) {
-  set_has_intent_age();
-  intent_age_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.intent_age)
-}
-
-// optional int64 gc_bytes_age = 10;
-inline bool MVCCStats::has_gc_bytes_age() const {
-  return (_has_bits_[0] & 0x00000200u) != 0;
-}
-inline void MVCCStats::set_has_gc_bytes_age() {
-  _has_bits_[0] |= 0x00000200u;
-}
-inline void MVCCStats::clear_has_gc_bytes_age() {
-  _has_bits_[0] &= ~0x00000200u;
-}
-inline void MVCCStats::clear_gc_bytes_age() {
-  gc_bytes_age_ = GOOGLE_LONGLONG(0);
-  clear_has_gc_bytes_age();
-}
-inline ::google::protobuf::int64 MVCCStats::gc_bytes_age() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.gc_bytes_age)
-  return gc_bytes_age_;
-}
-inline void MVCCStats::set_gc_bytes_age(::google::protobuf::int64 value) {
-  set_has_gc_bytes_age();
-  gc_bytes_age_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.gc_bytes_age)
-}
-
 // optional int64 sys_bytes = 12;
 inline bool MVCCStats::has_sys_bytes() const {
-  return (_has_bits_[0] & 0x00000400u) != 0;
+  return (_has_bits_[0] & 0x00000800u) != 0;
 }
 inline void MVCCStats::set_has_sys_bytes() {
-  _has_bits_[0] |= 0x00000400u;
+  _has_bits_[0] |= 0x00000800u;
 }
 inline void MVCCStats::clear_has_sys_bytes() {
-  _has_bits_[0] &= ~0x00000400u;
+  _has_bits_[0] &= ~0x00000800u;
 }
 inline void MVCCStats::clear_sys_bytes() {
   sys_bytes_ = GOOGLE_LONGLONG(0);
@@ -944,13 +968,13 @@ inline void MVCCStats::set_sys_bytes(::google::protobuf::int64 value) {
 
 // optional int64 sys_count = 13;
 inline bool MVCCStats::has_sys_count() const {
-  return (_has_bits_[0] & 0x00000800u) != 0;
+  return (_has_bits_[0] & 0x00001000u) != 0;
 }
 inline void MVCCStats::set_has_sys_count() {
-  _has_bits_[0] |= 0x00000800u;
+  _has_bits_[0] |= 0x00001000u;
 }
 inline void MVCCStats::clear_has_sys_count() {
-  _has_bits_[0] &= ~0x00000800u;
+  _has_bits_[0] &= ~0x00001000u;
 }
 inline void MVCCStats::clear_sys_count() {
   sys_count_ = GOOGLE_LONGLONG(0);
@@ -964,30 +988,6 @@ inline void MVCCStats::set_sys_count(::google::protobuf::int64 value) {
   set_has_sys_count();
   sys_count_ = value;
   // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.sys_count)
-}
-
-// optional int64 last_update_nanos = 30;
-inline bool MVCCStats::has_last_update_nanos() const {
-  return (_has_bits_[0] & 0x00001000u) != 0;
-}
-inline void MVCCStats::set_has_last_update_nanos() {
-  _has_bits_[0] |= 0x00001000u;
-}
-inline void MVCCStats::clear_has_last_update_nanos() {
-  _has_bits_[0] &= ~0x00001000u;
-}
-inline void MVCCStats::clear_last_update_nanos() {
-  last_update_nanos_ = GOOGLE_LONGLONG(0);
-  clear_has_last_update_nanos();
-}
-inline ::google::protobuf::int64 MVCCStats::last_update_nanos() const {
-  // @@protoc_insertion_point(field_get:cockroach.storage.engine.MVCCStats.last_update_nanos)
-  return last_update_nanos_;
-}
-inline void MVCCStats::set_last_update_nanos(::google::protobuf::int64 value) {
-  set_has_last_update_nanos();
-  last_update_nanos_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.storage.engine.MVCCStats.last_update_nanos)
 }
 
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -558,10 +558,10 @@ func runMVCCComputeStats(valueBytes int, b *testing.B) {
 	b.ResetTimer()
 
 	var stats MVCCStats
+	var err error
 	for i := 0; i < b.N; i++ {
 		iter := rocksdb.NewIterator(false)
-		stats = MVCCStats{}
-		err := iter.ComputeStats(&stats, mvccKey(roachpb.KeyMin), mvccKey(roachpb.KeyMax), 0)
+		stats, err = iter.ComputeStats(mvccKey(roachpb.KeyMin), mvccKey(roachpb.KeyMax), 0)
 		iter.Close()
 		if err != nil {
 			b.Fatal(err)

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -461,7 +461,8 @@ func runMVCCMerge(value *roachpb.Value, numKeys int, b *testing.B) {
 		for pb.Next() {
 			ms := MVCCStats{}
 			ts.Logical++
-			if err := MVCCMerge(rocksdb, &ms, keys[rand.Intn(numKeys)], ts, *value); err != nil {
+			err := MVCCMerge(rocksdb, &ms, keys[rand.Intn(numKeys)], ts, *value)
+			if err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/storage/feed.go
+++ b/storage/feed.go
@@ -287,7 +287,7 @@ func makeSplitRangeEvent(id roachpb.StoreID, rngOrig, rngNew *Replica) *SplitRan
 	}
 	// Size delta of original range is the additive inverse of stats for
 	// the new range.
-	sre.Original.Delta.Subtract(&sre.New.Stats)
+	sre.Original.Delta.Subtract(sre.New.Stats)
 	return sre
 }
 

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -110,10 +110,10 @@ func (*gcQueue) shouldQueue(now roachpb.Timestamp, repl *Replica,
 	intentScore := repl.stats.GetAvgIntentAge(now.WallTime) / float64(intentAgeNormalization.Nanoseconds()/1E9)
 
 	// Compute priority.
-	if gcScore > 1 {
+	if gcScore >= 1 {
 		priority += gcScore
 	}
-	if intentScore > 1 {
+	if intentScore >= 1 {
 		priority += intentScore
 	}
 	shouldQ = priority > 0

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -59,7 +59,8 @@ func TestGCQueueShouldQueue(t *testing.T) {
 	desc := tc.rng.Desc()
 	zone, err := cfg.GetZoneConfigForKey(desc.StartKey)
 	if err != nil {
-		log.Errorf("could not find GC policy for range %s: %s", tc.rng, err)
+		log.Errorf("could not find GC policy for range %s: %s, got zone %+v",
+			tc.rng, err, zone)
 		return
 	}
 	policy := zone.GC

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -52,47 +52,73 @@ func TestGCQueueShouldQueue(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
+	cfg := tc.gossip.GetSystemConfig()
+	if cfg == nil {
+		t.Fatal("nil config")
+	}
+	desc := tc.rng.Desc()
+	zone, err := cfg.GetZoneConfigForKey(desc.StartKey)
+	if err != nil {
+		log.Errorf("could not find GC policy for range %s: %s", tc.rng, err)
+		return
+	}
+	policy := zone.GC
+
 	iaN := intentAgeNormalization.Nanoseconds()
 	ia := iaN / 1E9
 	bc := int64(gcByteCountNormalization)
-	ttl := int64(24 * 60 * 60)
+	ttl := int64(policy.TTLSeconds)
+
+	now := makeTS(iaN, 0) // at time of stats object
 
 	testCases := []struct {
 		gcBytes     int64
 		gcBytesAge  int64
 		intentCount int64
 		intentAge   int64
-		now         roachpb.Timestamp
+		now         roachpb.Timestamp // at time of shouldQueue
 		shouldQ     bool
 		priority    float64
 	}{
+		// First, test cases where shouldQueue is called with the same
+		// timestamp that the stats are at.
+
 		// No GC'able bytes, no time elapsed.
-		{0, 0, 0, 0, makeTS(0, 0), false, 0},
+		{0, 0, 0, 0, now, false, 0},
 		// No GC'able bytes, with intent age, 1/2 intent normalization period elapsed.
-		{0, 0, 1, ia / 2, makeTS(0, 0), false, 0},
+		{0, 0, 1, ia / 2, now, false, 0},
 		// No GC'able bytes, with intent age=1/2 period, and other 1/2 period elapsed.
-		{0, 0, 1, ia / 2, makeTS(iaN/2, 0), false, 0},
-		// No GC'able bytes, with intent age=2*intent normalization.
-		{0, 0, 1, 3 * ia / 2, makeTS(iaN/2, 0), true, 2},
-		// No GC'able bytes, 2 intents, with avg intent age=4x intent normalization.
-		{0, 0, 2, 7 * ia, makeTS(iaN, 0), true, 4.5},
+		{0, 0, 1, ia / 2, now, false, 0},
+		// No GC'able bytes, with (abs and avg) intent age=1.5*normalization.
+		{0, 0, 1, 3 * ia / 2, now, true, 1.5},
+		// No GC'able bytes, 2 intents, with avg intent age=3.5*normalization.
+		{0, 0, 2, 7 * ia, now, true, 3.5},
 		// GC'able bytes, no time elapsed.
-		{bc, 0, 0, 0, makeTS(0, 0), false, 0},
-		// GC'able bytes, avg age = TTLSeconds.
-		{bc, bc * ttl, 0, 0, makeTS(0, 0), false, 0},
+		{bc, 0, 0, 0, now, false, 0},
+		// GC'able bytes, avg age = just below TTLSeconds.
+		{bc, bc*ttl - 1, 0, 0, now, false, 0},
 		// GC'able bytes, avg age = 2*TTLSeconds.
-		{bc, 2 * bc * ttl, 0, 0, makeTS(0, 0), true, 2},
+		{bc, 2 * bc * ttl, 0, 0, now, true, 2},
 		// x2 GC'able bytes, avg age = TTLSeconds.
-		{2 * bc, 2 * bc * ttl, 0, 0, makeTS(0, 0), true, 2},
+		{2 * bc, 2 * bc * ttl, 0, 0, now, true, 2},
 		// GC'able bytes, intent bytes, and intent normalization * 2 elapsed.
-		{bc, bc * ttl, 1, 0, makeTS(iaN*2, 0), true, 5},
+		// Queues solely because of gc'able bytes.
+		{bc, 5 * bc * ttl, 10 * ia, 0, now, true, 5},
+		// A contribution of 1 from gc, 10/5 from intents.
+		{bc, bc * ttl, 5, 10 * ia, now, true, 1 + 2},
+
+		// Some tests where the ages increase since we call shouldNow with
+		// a later timestamp.
+
+		// One normalized unit of unaged gc'able bytes at time zero.
+		{ttl * bc, 0, 0, 0, roachpb.ZeroTimestamp, true, float64(now.WallTime) / 1E9},
+
+		// 2 intents aging from zero to now (which is exactly the intent age
+		// normalization).
+		{0, 0, 2, 0, roachpb.ZeroTimestamp, true, 1},
 	}
 
 	gcQ := newGCQueue(tc.gossip)
-	cfg := tc.gossip.GetSystemConfig()
-	if cfg == nil {
-		t.Fatal("nil config")
-	}
 
 	for i, test := range testCases {
 		// Write gc'able bytes as key bytes; since "live" bytes will be
@@ -100,15 +126,16 @@ func TestGCQueueShouldQueue(t *testing.T) {
 		// intent count. Note: the actual accounting on bytes is fictional
 		// in this test.
 		stats := engine.MVCCStats{
-			KeyBytes:    test.gcBytes,
-			IntentCount: test.intentCount,
-			IntentAge:   test.intentAge,
-			GCBytesAge:  test.gcBytesAge,
+			KeyBytes:        test.gcBytes,
+			IntentCount:     test.intentCount,
+			IntentAge:       test.intentAge,
+			GCBytesAge:      test.gcBytesAge,
+			LastUpdateNanos: test.now.WallTime,
 		}
 		if err := tc.rng.stats.SetMVCCStats(tc.rng.store.Engine(), stats); err != nil {
 			t.Fatal(err)
 		}
-		shouldQ, priority := gcQ.shouldQueue(test.now, tc.rng, cfg)
+		shouldQ, priority := gcQ.shouldQueue(now, tc.rng, cfg)
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
 		}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1385,7 +1385,8 @@ func (r *Replica) applyRaftCommandInBatch(ctx context.Context, index uint64, ori
 	if ba.IsWrite() {
 		if err == nil {
 			// If command was successful, flush the MVCC stats to the batch.
-			if err := r.stats.MergeMVCCStats(btch, ms, ba.Timestamp.WallTime); err != nil {
+			ms.AgeTo(ba.Timestamp.WallTime)
+			if err := r.stats.MergeMVCCStats(btch, *ms); err != nil {
 				// TODO(tschottdorf): ReplicaCorruptionError.
 				log.Fatalc(ctx, "setting mvcc stats in a batch should never fail: %s", err)
 			}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1385,7 +1385,6 @@ func (r *Replica) applyRaftCommandInBatch(ctx context.Context, index uint64, ori
 	if ba.IsWrite() {
 		if err == nil {
 			// If command was successful, flush the MVCC stats to the batch.
-			ms.AgeTo(ba.Timestamp.WallTime)
 			if err := r.stats.MergeMVCCStats(btch, *ms); err != nil {
 				// TODO(tschottdorf): ReplicaCorruptionError.
 				log.Fatalc(ctx, "setting mvcc stats in a batch should never fail: %s", err)

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1346,10 +1346,11 @@ func (r *Replica) computeStats(d *roachpb.RangeDescriptor, e engine.Engine, nowN
 
 	ms := &engine.MVCCStats{}
 	for _, r := range makeReplicaKeyRanges(d) {
-		err := iter.ComputeStats(ms, r.start, r.end, nowNanos)
+		msDelta, err := iter.ComputeStats(r.start, r.end, nowNanos)
 		if err != nil {
-			return *ms, err
+			return engine.MVCCStats{}, err
 		}
+		ms.Add(&msDelta)
 	}
 	return *ms, nil
 }

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1350,7 +1350,7 @@ func (r *Replica) computeStats(d *roachpb.RangeDescriptor, e engine.Engine, nowN
 		if err != nil {
 			return engine.MVCCStats{}, err
 		}
-		ms.Add(&msDelta)
+		ms.Add(msDelta)
 	}
 	return *ms, nil
 }

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -429,7 +429,7 @@ func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h ro
 					return nil
 				}
 				return engine.MVCCResolveWriteIntent(batch, ms,
-					span.Key, reply.Txn.Timestamp, reply.Txn)
+					span.Key, reply.Txn)
 			}
 			// For intent ranges, cut into parts inside and outside our key
 			// range. Resolve locally inside, delegate the rest. In particular,
@@ -440,7 +440,7 @@ func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h ro
 			}
 			if inSpan != nil {
 				_, err := engine.MVCCResolveWriteIntentRange(batch, ms,
-					inSpan.Key, inSpan.EndKey, 0, reply.Txn.Timestamp, reply.Txn)
+					inSpan.Key, inSpan.EndKey, 0, reply.Txn)
 				return err
 			}
 			return nil
@@ -1044,7 +1044,7 @@ func (r *Replica) maybePoison(batch engine.Engine, shouldPoison bool, txn roachp
 func (r *Replica) ResolveIntent(batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.ResolveIntentRequest) (roachpb.ResolveIntentResponse, error) {
 	var reply roachpb.ResolveIntentResponse
 
-	if err := engine.MVCCResolveWriteIntent(batch, ms, args.Key, h.Timestamp, &args.IntentTxn); err != nil {
+	if err := engine.MVCCResolveWriteIntent(batch, ms, args.Key, &args.IntentTxn); err != nil {
 		return reply, err
 	}
 	return reply, r.maybePoison(batch, args.Poison, args.IntentTxn)
@@ -1056,7 +1056,7 @@ func (r *Replica) ResolveIntentRange(batch engine.Engine, ms *engine.MVCCStats,
 	h roachpb.Header, args roachpb.ResolveIntentRangeRequest) (roachpb.ResolveIntentRangeResponse, error) {
 	var reply roachpb.ResolveIntentRangeResponse
 
-	if _, err := engine.MVCCResolveWriteIntentRange(batch, ms, args.Key, args.EndKey, 0, h.Timestamp, &args.IntentTxn); err != nil {
+	if _, err := engine.MVCCResolveWriteIntentRange(batch, ms, args.Key, args.EndKey, 0, &args.IntentTxn); err != nil {
 		return reply, err
 	}
 	return reply, r.maybePoison(batch, args.Poison, args.IntentTxn)

--- a/util/testing.go
+++ b/util/testing.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"reflect"
 	"time"
 )
 
@@ -204,4 +205,20 @@ func Panics(f func()) (panics bool) {
 	}()
 	f()
 	return
+}
+
+// NoZeroField returns nil if none of the fields of the struct underlying the
+// interface are equal to the zero value, and an error otherwise.
+// It will panic if the struct has unexported fields and for any non-struct.
+func NoZeroField(v interface{}) error {
+	ele := reflect.Indirect(reflect.ValueOf(v))
+	eleT := ele.Type()
+	for i := 0; i < ele.NumField(); i++ {
+		f := ele.Field(i)
+		zero := reflect.Zero(f.Type())
+		if reflect.DeepEqual(f.Interface(), zero.Interface()) {
+			return fmt.Errorf("expected %s field to be non-zero", eleT.Field(i).Name)
+		}
+	}
+	return nil
 }

--- a/util/testing_test.go
+++ b/util/testing_test.go
@@ -91,3 +91,20 @@ func TestSucceedsWithin(t *testing.T) {
 		return Errorf("%s elapsed, waiting until %s elapses", elapsed, duration)
 	})
 }
+
+func TestNoZeroField(t *testing.T) {
+	type foo struct {
+		X, Y int
+	}
+	testFoo := foo{1, 2}
+	if err := NoZeroField(&testFoo); err != nil {
+		t.Fatal(err)
+	}
+	if err := NoZeroField(interface{}(testFoo)); err != nil {
+		t.Fatal(err)
+	}
+	testFoo.Y = 0
+	if err := NoZeroField(&testFoo); err == nil {
+		t.Fatal("expected an error")
+	}
+}


### PR DESCRIPTION
Previously, stats objects were mostly treated as additive ad-hoc,
though the age components can only be added or subtracted
if they correspond to the same LastUpdateNanos. This wasn't
the case in various locations.
To mitigate this, added an `AgeTo` method which performs this,
and am now calling it in `Add` and `Subtract` appropriately.

Also fixed a bug in the C++ code (which unfortunately duplicates
much of the logic for a (slightly) special case). The code is
potentially still incorrect, though - I have to revisit the
assumptions. Basically, we need the guarantee that whichever
timestamp ComputeStats is called with is also larger than any
MVCC timestamp in the scanned range. I'll send a separate fix
for that when this one is done.

Converted the low-level MVCC operations to correctly compute MVCCStats.
Instead of the old strategy (compute ad-hoc ages everywhere and trust
that someone would update LastUpdateNanos in the right places), use
the AgeTo helper. For each type of update, identify the various time
intervals over which the contributions need to be accounted for, and
use AgeTo to adjust the GC and intent ages automatically. This is a
pleasant simplification, and also has the side effect that the existing
test coverage now has to deal with more realistic aging of values
(on top of having simplified as well).

For MVCCResolve{,Range}, don't use the batch request's timestamp.
All that matters is the timestamp of the transaction involved.
Previously, the batch timestamp was used for MVCCStats computations,
which is incorrect. Its absence also lends more clarity to the code
as such.

Commit-by-commit is recommended.

Fixes #3234.

@petermattis, assigning you since you've looked at #3234.
@spencerkimball, your eyeballs also appreciated. I don't want to have
to revisit this again for a while.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3867)

<!-- Reviewable:end -->
