### PR TITLE
Don't store initial resolver addresses in the bootstrap info.

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -334,11 +334,6 @@ func (g *Gossip) SetResolvers(resolvers []resolver.Resolver) {
 	g.resolverIdx = len(resolvers) - 1
 	g.resolvers = resolvers
 	g.resolversTried = map[int]struct{}{}
-	// Initialize the bootstrap info with addresses of specified resolvers.
-	for _, r := range resolvers {
-		addr := util.MakeUnresolvedAddr(r.Type(), r.Addr())
-		g.bootstrapInfo.Addresses = append(g.bootstrapInfo.Addresses, addr)
-	}
 }
 
 // GetNodeIDAddress looks up the address of the node by ID.


### PR DESCRIPTION
Instead, we only record addresses gossiped by nodes. The previous
code was using the resolver type for the address network type which
was brain dead. There's no reason to set this list with resolvers
in any case. That was a misguided notion and unnecessary.

Fixes #3883

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3887)

<!-- Reviewable:end -->
