### PR TITLE
Remove trailing equal sign from --gossip=self usage.

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -79,7 +79,7 @@ var flagUsage = map[string]string{
         - lb: RPC load balancer forwarding to an arbitrary node
         - http-lb: HTTP load balancer: we query
           http(s)://<address>/_status/details/local
-        - self: for single node systems, specify --gossip=self= (the
+        - self: for single node systems, specify --gossip=self (the
           <address> is omitted).
 `,
 	"key-size": `

--- a/server/context.go
+++ b/server/context.go
@@ -228,7 +228,7 @@ func (ctx *Context) initEngine(attrsStr, path string, stopper *stop.Stopper) (en
 // SelfGossipAddr is a special flag that configures a node to gossip
 // only with itself. This avoids having to specify the port twice for
 // single-node clusters (i.e. once in --addr, and again in --gossip).
-const SelfGossipAddr = "self="
+const SelfGossipAddr = "self"
 
 // parseGossipBootstrapResolvers parses a comma-separated list of
 // gossip bootstrap resolvers.
@@ -239,7 +239,7 @@ func (ctx *Context) parseGossipBootstrapResolvers() ([]resolver.Resolver, error)
 		if len(address) == 0 {
 			continue
 		}
-		if strings.HasPrefix(address, SelfGossipAddr) {
+		if address == SelfGossipAddr {
 			address = ctx.Addr
 		}
 		resolver, err := resolver.NewResolver(&ctx.Context, address)


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3892)

<!-- Reviewable:end -->
