### PR TITLE
Add a stopper to DistSender

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -676,10 +676,10 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 				continue
 			case *roachpb.NotLeaderError:
 				newLeader := tErr.Leader
-				// Verify that leader is a known replica according to the
-				// descriptor. If not, we've got a stale replica; evict cache.
-				// Next, cache the new leader.
 				if newLeader != nil {
+					// Verify that leader is a known replica according to the
+					// descriptor. If not, we've got a stale range descriptor;
+					// evict cache.
 					if i, _ := desc.FindReplica(newLeader.StoreID); i == -1 {
 						if log.V(1) {
 							log.Infof("error indicates unknown leader %s, expunging descriptor %s", newLeader, desc)
@@ -687,8 +687,20 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 						evictDesc()
 					}
 				} else {
+					// If the new leader is unknown, we were talking to a
+					// replica that is partitioned away from the majority. Our
+					// range descriptor may be stale, so clear the cache.
+					//
+					// TODO(bdarnell): An unknown-leader error doesn't
+					// necessarily mean our descriptor is stale. Ideally we
+					// would treat these errors more like SendError: retry on
+					// another node (at a lower level), and then if it reaches
+					// this level then we know we've exhausted our options and
+					// must clear the cache.
+					evictDesc()
 					newLeader = &roachpb.ReplicaDescriptor{}
 				}
+				// Next, cache the new leader.
 				ds.updateLeaderCache(roachpb.RangeID(desc.RangeID), *newLeader)
 				if log.V(1) {
 					log.Warning(tErr)

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -553,6 +553,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 		var desc *roachpb.RangeDescriptor
 		var needAnother bool
 		var pErr *roachpb.Error
+		var finished bool
 		for r := retry.Start(ds.rpcRetryOptions); r.Next(); {
 			// Get range descriptor (or, when spanning range, descriptors). Our
 			// error handling below may clear them on certain errors, so we
@@ -627,6 +628,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			}()
 			// If sending succeeded, break this loop.
 			if pErr == nil {
+				finished = true
 				break
 			}
 
@@ -707,6 +709,13 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 		// Immediately return if querying a range failed non-retryably.
 		if pErr != nil {
 			return nil, pErr, false
+		} else if !finished {
+			select {
+			case <-ds.rpcRetryOptions.Closer:
+				return nil, roachpb.NewError(&roachpb.NodeUnavailableError{}), false
+			default:
+				log.Fatal("exited retry loop with nil error but finished=false")
+			}
 		}
 
 		ba.Txn.Update(curReply.Txn)

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -95,12 +95,14 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 		br.Error = pErr
 		return []proto.Message{br}, nil
 	}
+	retryOpts := GetDefaultDistSenderRetryOptions()
+	retryOpts.Closer = ltc.Stopper.ShouldDrain()
 	ltc.distSender = NewDistSender(&DistSenderContext{
 		Clock: ltc.Clock,
 		RangeDescriptorCacheSize: defaultRangeDescriptorCacheSize,
 		RangeLookupMaxRanges:     defaultRangeLookupMaxRanges,
 		LeaderCacheSize:          defaultLeaderCacheSize,
-		RPCRetryOptions:          &defaultRPCRetryOptions,
+		RPCRetryOptions:          &retryOpts,
 		nodeDescriptor:           nodeDesc,
 		RPCSend:                  rpcSend,    // defined above
 		RangeDescriptorDB:        ltc.stores, // for descriptor lookup

--- a/rpc/send.go
+++ b/rpc/send.go
@@ -83,7 +83,9 @@ func (r rpcError) CanRetry() bool { return true }
 // sendOneFn is overwritten in tests to mock sendOne.
 var sendOneFn = sendOne
 
-// NewSendError creates a SendError.
+// NewSendError creates a SendError. canRetry should be true in most
+// cases; the only non-retryable SendErrors are for things like
+// malformed (and not merely unresolvable) addresses.
 func NewSendError(msg string, canRetry bool) *roachpb.SendError {
 	return &roachpb.SendError{Message: msg, Retryable: canRetry}
 }

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -78,7 +78,13 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		g.Start(rpcServer, ln.Addr(), stopper)
 	}
 	ctx.Gossip = g
-	sender := kv.NewDistSender(&kv.DistSenderContext{Clock: ctx.Clock, RPCContext: nodeRPCContext}, g)
+	retryOpts := kv.GetDefaultDistSenderRetryOptions()
+	retryOpts.Closer = stopper.ShouldDrain()
+	sender := kv.NewDistSender(&kv.DistSenderContext{
+		Clock:           ctx.Clock,
+		RPCContext:      nodeRPCContext,
+		RPCRetryOptions: &retryOpts,
+	}, g)
 	ctx.DB = client.NewDB(sender)
 	// TODO(bdarnell): arrange to have the transport closed.
 	// (or attach LocalRPCTransport.Close to the stopper)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -299,7 +299,13 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	s := StartTestServer(t)
 	defer s.Stop()
-	ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock(), RPCContext: s.RPCContext()}, s.Gossip())
+	retryOpts := kv.GetDefaultDistSenderRetryOptions()
+	retryOpts.Closer = s.stopper.ShouldDrain()
+	ds := kv.NewDistSender(&kv.DistSenderContext{
+		Clock:           s.Clock(),
+		RPCContext:      s.RPCContext(),
+		RPCRetryOptions: &retryOpts,
+	}, s.Gossip())
 	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, nil, s.stopper)
 
 	if err := s.node.ctx.DB.AdminSplit("m"); err != nil {
@@ -391,7 +397,13 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 	for i, tc := range testCases {
 		s := StartTestServer(t)
 		defer s.Stop()
-		ds := kv.NewDistSender(&kv.DistSenderContext{Clock: s.Clock(), RPCContext: s.RPCContext()}, s.Gossip())
+		retryOpts := kv.GetDefaultDistSenderRetryOptions()
+		retryOpts.Closer = s.stopper.ShouldDrain()
+		ds := kv.NewDistSender(&kv.DistSenderContext{
+			Clock:           s.Clock(),
+			RPCContext:      s.RPCContext(),
+			RPCRetryOptions: &retryOpts,
+		}, s.Gossip())
 		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, nil, s.stopper)
 
 		for _, sk := range tc.splitKeys {

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -816,7 +816,6 @@ func TestSplitSnapshotRace_SplitWins(t *testing.T) {
 // so it still has a conflicting range.
 func TestSplitSnapshotRace_SnapshotWins(t *testing.T) {
 	defer leaktest.AfterTest(t)
-	t.Skip("TODO(bdarnell): https://github.com/cockroachdb/cockroach/issues/3121")
 	mtc, leftKey, rightKey := setupSplitSnapshotRace(t)
 	defer mtc.Stop()
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -329,7 +329,7 @@ func (m *multiTestContext) rpcSend(_ rpc.Options, _ string, addrs []net.Addr,
 			br, pErr = sender.Send(context.Background(), ba)
 		}) {
 			pErr = &roachpb.Error{}
-			pErr.SetGoError(rpc.NewSendError("store is stopped", false))
+			pErr.SetGoError(rpc.NewSendError("store is stopped", true))
 			m.expireLeaderLeases()
 			continue
 		}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -119,10 +119,13 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	if err := gossipNodeDesc(sCtx.Gossip, nodeDesc.NodeID); err != nil {
 		t.Fatal(err)
 	}
+	retryOpts := kv.GetDefaultDistSenderRetryOptions()
+	retryOpts.Closer = stopper.ShouldDrain()
 	distSender := kv.NewDistSender(&kv.DistSenderContext{
 		Clock:             clock,
 		RPCSend:           rpcSend, // defined above
-		RangeDescriptorDB: stores,  // for descriptor lookup
+		RPCRetryOptions:   &retryOpts,
+		RangeDescriptorDB: stores, // for descriptor lookup
 	}, sCtx.Gossip)
 
 	sender := kv.NewTxnCoordSender(distSender, clock, false, nil, stopper)
@@ -222,10 +225,13 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	}
 
 	if m.db == nil {
+		retryOpts := kv.GetDefaultDistSenderRetryOptions()
+		retryOpts.Closer = m.clientStopper.ShouldDrain()
 		m.distSender = kv.NewDistSender(&kv.DistSenderContext{
 			Clock:             m.clock,
 			RangeDescriptorDB: m,
 			RPCSend:           m.rpcSend,
+			RPCRetryOptions:   &retryOpts,
 		}, m.gossip)
 		sender := kv.NewTxnCoordSender(m.distSender, m.clock, false, nil, m.clientStopper)
 		m.db = client.NewDB(sender)


### PR DESCRIPTION
This is primarily to prevent endless retries of asynchronous operations
like intent resolution if a retryable error occurs during shutdown.

Make multiTestContext's "store is stopped" errors retryable.
This fixes flakiness in TestSplitSnapshotRace_SnapshotWins.

Fixes #3121

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3898)

<!-- Reviewable:end -->
