### PR TITLE
Mark generated sql/parser/sql.go as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+sql/parser/sql.go binary
+ui/embedded.go binary


### PR DESCRIPTION
'binary' is short for -diff -merge and -text.
-diff hides line-by-line change in output.
-merge disabled 3-way merge
-text disables line-ending normalization.

Disabling merging and hiding changes make sense for generated code since
re-generation is really the correct resolution after merging the source,
and hiding generated changes (by default) focuses attention on the real
change (when generated changes are low-information, i.e. streams of numbers).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3899)

<!-- Reviewable:end -->
