### PR TITLE
fix age computations on GC and a bug in C++

### DIFF
--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1482,8 +1482,13 @@ DBStatus DBMergeOne(DBSlice existing, DBSlice update, DBString* new_value) {
   return MergeResult(&meta, new_value);
 }
 
+const int64_t kNanosecondPerSecond = 1e9;
+
 inline int64_t age_factor(int64_t fromNS, int64_t toNS) {
-  return toNS/1e9 - fromNS/1e9; // not the same as (toNS-fromNS)/1e9!
+  // Careful about implicit conversions here.
+  // toNS/1e9 - fromNS/1e9 is not the same since
+  // "1e9" is a double.
+  return toNS/kNanosecondPerSecond - fromNS/kNanosecondPerSecond;
 }
 
 // TODO(tschottdorf): it's unfortunate that this method duplicates the logic


### PR DESCRIPTION
updated `updateStatsOnGC` to correctly use `AgeTo`.
Updated `TestMVCCStatsWithRandomRuns` to not use full second timestamps.
This is the first test which does so, and it gives new (semantic) coverage
which caught a bug in the C++ code which led to incorrect age increments.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3905)

<!-- Reviewable:end -->
