### PR TITLE
Simplify build info logged at startup.

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -150,10 +150,7 @@ additional details.`,
 // cluster via the gossip network.
 func runStart(_ *cobra.Command, _ []string) error {
 	info := util.GetBuildInfo()
-	log.Infof("build Vers: %s", info.Vers)
-	log.Infof("build Tag:  %s", info.Tag)
-	log.Infof("build Time: %s", info.Time)
-	log.Infof("build Deps: %s", info.Deps)
+	log.Infof("[build] %s @ %s (%s)", info.Tag, info.Time, info.Vers)
 
 	// Default user for servers.
 	context.User = security.NodeUser


### PR DESCRIPTION
Omit logging the build deps. These are still available via `cockroach
version`.

Miscellaneous makefile changes.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3916)

<!-- Reviewable:end -->
