### PR TITLE
Better ordering data structure

### DIFF
--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -33,29 +33,25 @@ func (*planner) distinct(n *parser.Select, p planNode) planNode {
 		planNode:   p,
 		suffixSeen: make(map[string]struct{}),
 	}
-	ordering, prefix := p.Ordering()
-	if len(ordering) != 0 {
+	ordering := p.Ordering()
+	if !ordering.isEmpty() {
 		d.columnsInOrder = make([]bool, len(p.Columns()))
-	}
-	for _, p := range ordering {
-		if p == 0 {
-			if prefix > 0 {
-				prefix--
+		for colIdx := range ordering.exactMatchCols {
+			if colIdx >= len(d.columnsInOrder) {
+				// If the exact-match column is not part of the output, we can safely ignore it.
 				continue
 			}
-			break
+			d.columnsInOrder[colIdx] = true
 		}
-		if p < 0 {
-			p = -p
-		}
-		if p <= len(d.columnsInOrder) {
-			d.columnsInOrder[p-1] = true
-		} else {
-			// Cannot use sort order. This happens when the
-			// columns used for sorting are not part of the output.
-			// e.g. SELECT a FROM t ORDER BY c.
-			d.columnsInOrder = nil
-			break
+		for _, c := range ordering.ordering {
+			if c.colIdx >= len(d.columnsInOrder) {
+				// Cannot use sort order. This happens when the
+				// columns used for sorting are not part of the output.
+				// e.g. SELECT a FROM t ORDER BY c.
+				d.columnsInOrder = nil
+				break
+			}
+			d.columnsInOrder[c.colIdx] = true
 		}
 	}
 	return d

--- a/sql/group.go
+++ b/sql/group.go
@@ -201,7 +201,7 @@ type groupNode struct {
 	// During rendering, aggregateFuncs compute their result for group.currentBucket.
 	currentBucket string
 
-	desiredOrdering []int
+	desiredOrdering columnOrdering
 	pErr            *roachpb.Error
 }
 
@@ -209,9 +209,9 @@ func (n *groupNode) Columns() []resultColumn {
 	return n.values.Columns()
 }
 
-func (n *groupNode) Ordering() ([]int, int) {
+func (n *groupNode) Ordering() orderingInfo {
 	// TODO(dt): aggregate buckets are returned un-ordered for now.
-	return nil, 0
+	return orderingInfo{}
 }
 
 func (n *groupNode) Values() parser.DTuple {
@@ -335,11 +335,8 @@ func (n *groupNode) isNotNullFilter(expr parser.Expr) parser.Expr {
 	if len(n.desiredOrdering) != 1 {
 		return expr
 	}
-	i := n.desiredOrdering[0]
-	if i < 0 {
-		i = -i
-	}
-	f := n.funcs[i-1]
+	i := n.desiredOrdering[0].colIdx
+	f := n.funcs[i]
 	isNotNull := &parser.ComparisonExpr{
 		Operator: parser.IsNot,
 		Left:     f.arg,
@@ -359,20 +356,21 @@ func (n *groupNode) isNotNullFilter(expr parser.Expr) parser.Expr {
 // aggregation. If zero or multiple MIN/MAX aggregations are requested then no
 // ordering will be requested. A negative index indicates a MAX aggregation was
 // requested for the output column.
-func desiredAggregateOrdering(funcs []*aggregateFunc) []int {
-	var limit int
+func desiredAggregateOrdering(funcs []*aggregateFunc) columnOrdering {
+	limit := -1
+	direction := encoding.Ascending
 	for i, f := range funcs {
 		impl := f.create()
 		switch impl.(type) {
 		case *maxAggregate, *minAggregate:
-			if limit != 0 || f.arg == nil {
+			if limit != -1 || f.arg == nil {
 				return nil
 			}
 			switch f.arg.(type) {
 			case *qvalue:
-				limit = i + 1
+				limit = i
 				if _, ok := impl.(*maxAggregate); ok {
-					limit = -limit
+					direction = encoding.Descending
 				}
 			default:
 				return nil
@@ -382,10 +380,10 @@ func desiredAggregateOrdering(funcs []*aggregateFunc) []int {
 			return nil
 		}
 	}
-	if limit == 0 {
+	if limit == -1 {
 		return nil
 	}
-	return []int{limit}
+	return columnOrdering{{limit, direction}}
 }
 
 type extractAggregatesVisitor struct {

--- a/sql/group_test.go
+++ b/sql/group_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -28,11 +29,11 @@ func TestDesiredAggregateOrder(t *testing.T) {
 
 	testData := []struct {
 		expr     string
-		ordering []int
+		ordering columnOrdering
 	}{
 		{`a`, nil},
-		{`MIN(a)`, []int{1}},
-		{`MAX(a)`, []int{-1}},
+		{`MIN(a)`, columnOrdering{{0, encoding.Ascending}}},
+		{`MAX(a)`, columnOrdering{{0, encoding.Descending}}},
 		{`(MIN(a), MAX(a))`, nil},
 		{`(MIN(a), AVG(a))`, nil},
 		{`(MIN(a), COUNT(a))`, nil},
@@ -53,7 +54,7 @@ func TestDesiredAggregateOrder(t *testing.T) {
 		}
 		ordering := desiredAggregateOrdering(group.funcs)
 		if !reflect.DeepEqual(d.ordering, ordering) {
-			t.Fatalf("%s: expected %d, but found %d", d.expr, d.ordering, ordering)
+			t.Fatalf("%s: expected %v, but found %v", d.expr, d.ordering, ordering)
 		}
 	}
 }

--- a/sql/join.go
+++ b/sql/join.go
@@ -111,7 +111,7 @@ func (n *indexJoinNode) Columns() []resultColumn {
 	return n.table.Columns()
 }
 
-func (n *indexJoinNode) Ordering() ([]int, int) {
+func (n *indexJoinNode) Ordering() orderingInfo {
 	return n.index.Ordering()
 }
 

--- a/sql/ordering.go
+++ b/sql/ordering.go
@@ -1,0 +1,104 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sql
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/util/encoding"
+)
+
+// columnOrdering is used to describe a desired column ordering. For example,
+//     []columnOrderInfo{ {3, true}, {1, false} }
+// represents an ordering first by column 3 (descending), then by column 1 (ascending).
+type columnOrdering []columnOrderInfo
+
+type columnOrderInfo struct {
+	colIdx    int
+	direction encoding.Direction
+}
+
+// orderingInfo describes the column ordering on a set of results.
+//
+// If results are known to be restricted to a single value on some columns, we call these "exact
+// match" columns; these are inconsequential w.r.t ordering.
+//
+// For example, if an index was defined on columns (a, b, c, d) and the WHERE clause was
+// "(a, c) = (1, 2)" then a and c are exact-match columns and we have an ordering by b then d.
+// Such an ordering satisfies any of the following desired orderings (among many others):
+//    a, c
+//    c, a
+//    b, a, c
+//    b, c, a
+//    a, b, c
+//    c, b, a
+//    b, d, a
+//    a, b, c, d
+//    b, a, c, d
+//
+type orderingInfo struct {
+	// columns for which we know we have a single value.
+	exactMatchCols map[int]struct{}
+
+	// ordering of any other columns (the columns in exactMatchCols do not appear in this ordering).
+	ordering columnOrdering
+}
+
+func (ord orderingInfo) isEmpty() bool {
+	return len(ord.exactMatchCols) == 0 && len(ord.ordering) == 0
+}
+
+func (ord *orderingInfo) addExactMatchColumn(colIdx int) {
+	if ord.exactMatchCols == nil {
+		ord.exactMatchCols = make(map[int]struct{})
+	}
+	ord.exactMatchCols[colIdx] = struct{}{}
+}
+
+func (ord *orderingInfo) addColumn(colIdx int, dir encoding.Direction) {
+	if dir != encoding.Ascending && dir != encoding.Descending {
+		panic(fmt.Sprintf("Invalid direction %d", dir))
+	}
+	ord.ordering = append(ord.ordering, columnOrderInfo{colIdx, dir})
+}
+
+// Computes how long of a prefix of a desired columnOrdering is matched by an existing ordering. If
+// reverse is set, we assume the reverse of the existing ordering.
+//
+// Returns a value between 0 and len(desired).
+func computeOrderingMatch(desired columnOrdering, existing orderingInfo, reverse bool) int {
+	// position in existing.ordering
+	pos := 0
+	for i, col := range desired {
+		if pos < len(existing.ordering) {
+			ci := existing.ordering[pos]
+
+			// Check that the next column matches. Note: "!=" acts as logical XOR.
+			if ci.colIdx == col.colIdx && (ci.direction == col.direction) != reverse {
+				pos++
+				continue
+			}
+		}
+		// If the column did not match, check if it is one of the exact match columns.
+		if _, ok := existing.exactMatchCols[col.colIdx]; !ok {
+			// Everything matched up to this point.
+			return i
+		}
+	}
+	// Everything matched!
+	return len(desired)
+}

--- a/sql/ordering_test.go
+++ b/sql/ordering_test.go
@@ -1,0 +1,114 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sql
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+type desiredCase struct {
+	line            int
+	desired         columnOrdering
+	expected        int
+	expectedReverse int
+}
+
+type computeOrderCase struct {
+	existing orderingInfo
+	cases    []desiredCase
+}
+
+func defTestCase(expected, expectedReverse int, desired columnOrdering) desiredCase {
+	// The line number is used to identify testcases in error messages.
+	_, _, line, _ := runtime.Caller(1)
+	return desiredCase{
+		line:            line,
+		desired:         desired,
+		expected:        expected,
+		expectedReverse: expectedReverse,
+	}
+}
+
+func TestComputeOrderingMatch(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	e := struct{}{}
+	asc := encoding.Ascending
+	desc := encoding.Descending
+	testSets := []computeOrderCase{
+		{
+			// No existing ordering
+			existing: orderingInfo{
+				exactMatchCols: nil,
+				ordering:       nil,
+			},
+			cases: []desiredCase{
+				defTestCase(0, 0, columnOrdering{{1, desc}, {5, asc}}),
+			},
+		},
+		{
+			// Ordering with no exact-match columns
+			existing: orderingInfo{
+				exactMatchCols: nil,
+				ordering:       []columnOrderInfo{{1, desc}, {2, asc}},
+			},
+			cases: []desiredCase{
+				defTestCase(1, 0, columnOrdering{{1, desc}, {5, asc}}),
+				defTestCase(0, 1, columnOrdering{{1, asc}, {5, asc}, {2, asc}}),
+			},
+		},
+		{
+			// Ordering with only exact-match columns
+			existing: orderingInfo{
+				exactMatchCols: map[int]struct{}{1: e, 2: e},
+				ordering:       nil,
+			},
+			cases: []desiredCase{
+				defTestCase(1, 1, columnOrdering{{2, desc}, {5, asc}, {1, asc}}),
+				defTestCase(0, 0, columnOrdering{{5, asc}, {2, asc}}),
+			},
+		},
+		{
+			existing: orderingInfo{
+				exactMatchCols: map[int]struct{}{0: e, 5: e, 6: e},
+				ordering:       []columnOrderInfo{{1, desc}, {2, asc}},
+			},
+			cases: []desiredCase{
+				defTestCase(2, 0, columnOrdering{{1, desc}, {5, asc}}),
+				defTestCase(2, 2, columnOrdering{{0, desc}, {5, asc}}),
+				defTestCase(1, 0, columnOrdering{{1, desc}, {2, desc}}),
+				defTestCase(5, 2, columnOrdering{{0, asc}, {6, desc}, {1, desc}, {5, desc}, {2, asc}}),
+				defTestCase(2, 2, columnOrdering{{0, asc}, {6, desc}, {2, asc}, {5, desc}, {1, desc}}),
+			},
+		},
+	}
+
+	for _, ts := range testSets {
+		for _, tc := range ts.cases {
+			res := computeOrderingMatch(tc.desired, ts.existing, false)
+			resRev := computeOrderingMatch(tc.desired, ts.existing, true)
+			if res != tc.expected || resRev != tc.expectedReverse {
+				t.Errorf("Test defined on line %d failed: expected:%d/%d got:%d/%d",
+					tc.line, tc.expected, tc.expectedReverse, res, resRev)
+			}
+		}
+	}
+}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -249,13 +249,8 @@ type planNode interface {
 	// returned slice is guaranteed to be equal to the length of the
 	// tuple returned by Values().
 	Columns() []resultColumn
-	// The indexes of the columns the output is ordered by. Indexes are 1-based
-	// and negative indexes indicate descending ordering. The ordering return
-	// value may be nil if no ordering has been performed. The prefix return
-	// value indicates the prefix of the ordering for which an exact match has
-	// been performed via filtering. This prefix may safely be ignored for
-	// ordering considerations.
-	Ordering() (ordering []int, prefix int)
+	// The indexes of the columns the output is ordered by.
+	Ordering() orderingInfo
 	// Values returns the values at the current row. The result is only valid
 	// until the next call to Next().
 	Values() parser.DTuple

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -37,10 +38,10 @@ func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, *roachpb.Er
 	// We grab a copy of columns here because we might add new render targets
 	// below. This is the set of columns requested by the query.
 	columns := s.Columns()
-	var ordering []int
+	var ordering columnOrdering
 
 	for _, o := range n.OrderBy {
-		index := 0
+		index := -1
 
 		// Normalize the expression which has the side-effect of evaluating
 		// constant expressions and unwrapping expressions like "((a))" to "a".
@@ -58,13 +59,13 @@ func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, *roachpb.Er
 				target := string(qname.Base)
 				for j, col := range columns {
 					if equalName(target, col.name) {
-						index = j + 1
+						index = j
 						break
 					}
 				}
 			}
 
-			if index == 0 {
+			if index == -1 {
 				// No output column matched the qualified name, so look for an existing
 				// render target that matches the column name. This handles cases like:
 				//
@@ -76,7 +77,7 @@ func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, *roachpb.Er
 					for j, r := range s.render {
 						if qval, ok := r.(*qvalue); ok {
 							if equalName(qval.col.Name, qname.Column()) {
-								index = j + 1
+								index = j
 								break
 							}
 						}
@@ -85,13 +86,13 @@ func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, *roachpb.Er
 			}
 		}
 
-		if index == 0 {
+		if index == -1 {
 			// The order by expression matched neither an output column nor an
 			// existing render target.
 			if col, err := s.colIndex(expr); err != nil {
 				return nil, roachpb.NewError(err)
 			} else if col >= 0 {
-				index = col + 1
+				index = col
 			} else {
 				// Add a new render expression to use for ordering. This handles cases
 				// were the expression is either not a qualified name or is a qualified
@@ -102,14 +103,14 @@ func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, *roachpb.Er
 				if err := s.addRender(parser.SelectExpr{Expr: expr}); err != nil {
 					return nil, err
 				}
-				index = len(s.columns)
+				index = len(s.columns) - 1
 			}
 		}
-
+		direction := encoding.Ascending
 		if o.Direction == parser.Descending {
-			index = -index
+			direction = encoding.Descending
 		}
-		ordering = append(ordering, index)
+		ordering = append(ordering, columnOrderInfo{index, direction})
 	}
 
 	return &sortNode{columns: columns, ordering: ordering}, nil
@@ -118,7 +119,7 @@ func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, *roachpb.Er
 type sortNode struct {
 	plan     planNode
 	columns  []resultColumn
-	ordering []int
+	ordering columnOrdering
 	needSort bool
 	pErr     *roachpb.Error
 }
@@ -127,11 +128,11 @@ func (n *sortNode) Columns() []resultColumn {
 	return n.columns
 }
 
-func (n *sortNode) Ordering() ([]int, int) {
+func (n *sortNode) Ordering() orderingInfo {
 	if n == nil {
-		return nil, 0
+		return orderingInfo{}
 	}
-	return n.ordering, 0
+	return orderingInfo{exactMatchCols: nil, ordering: n.ordering}
 }
 
 func (n *sortNode) Values() parser.DTuple {
@@ -166,11 +167,10 @@ func (n *sortNode) ExplainPlan() (name, description string, children []planNode)
 	strs := make([]string, len(n.ordering))
 	for i, o := range n.ordering {
 		prefix := '+'
-		if o < 0 {
-			o = -o
+		if o.direction == encoding.Descending {
 			prefix = '-'
 		}
-		strs[i] = fmt.Sprintf("%c%s", prefix, columns[o-1].name)
+		strs[i] = fmt.Sprintf("%c%s", prefix, columns[o.colIdx].name)
 	}
 	description = strings.Join(strs, ",")
 
@@ -182,11 +182,11 @@ func (n *sortNode) wrap(plan planNode) planNode {
 	if n != nil {
 		// Check to see if the requested ordering is compatible with the existing
 		// ordering.
-		existingOrdering, prefix := plan.Ordering()
+		existingOrdering := plan.Ordering()
 		if log.V(2) {
-			log.Infof("Sort: existing=%d (%d) desired=%d", existingOrdering, prefix, n.ordering)
+			log.Infof("Sort: existing=%d desired=%d", existingOrdering, n.ordering)
 		}
-		match := computeOrderingMatch(n.ordering, existingOrdering, prefix, +1)
+		match := computeOrderingMatch(n.ordering, existingOrdering, false)
 		if match < len(n.ordering) {
 			n.plan = plan
 			n.needSort = true
@@ -233,25 +233,4 @@ func (n *sortNode) initValues() bool {
 	sort.Sort(v)
 	n.plan = v
 	return true
-}
-
-func computeOrderingMatch(desired, existing []int, prefix, reverse int) int {
-	match := 0
-	for match < len(desired) && match < len(existing) {
-		if desired[match] == reverse*existing[match] {
-			// The existing ordering matched the desired ordering.
-			prefix = 0
-			match++
-			continue
-		}
-		// The existing ordering did not match the desired ordering. Check if we're
-		// still considering a prefix of the existing ordering for which there was
-		// an exact match (and thus ordering is inconsequential).
-		if prefix == 0 {
-			break
-		}
-		prefix--
-		existing = existing[1:]
-	}
-	return match
 }

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -254,3 +254,36 @@ SELECT * FROM bar ORDER BY baz, id;
 ----
 0 NULL
 1 NULL
+
+statement ok
+CREATE TABLE abcd (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  INDEX abc (a, b, c)
+)
+
+statement ok
+INSERT INTO abcd VALUES (1, 4, 2, 3), (2, 3, 4, 1), (3, 2, 1, 2), (4, 4, 1, 1)
+
+# The following tests verify we recognize that sorting is not necessary
+query ITT
+EXPLAIN SELECT * FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
+----
+0 scan abcd@abc /1/4-/1/5
+
+query ITT
+EXPLAIN SELECT * FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
+----
+0 scan abcd@abc /1/4-/1/5
+
+query ITT
+EXPLAIN SELECT * FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
+----
+0 scan abcd@abc /1/4-/1/5
+
+query ITT
+EXPLAIN SELECT * FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
+----
+0 scan abcd@abc /1/4-/1/5

--- a/sql/values.go
+++ b/sql/values.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/encoding"
 )
 
 // Values constructs a valuesNode from a VALUES expression.
@@ -76,7 +77,7 @@ func (p *planner) Values(n parser.Values) (planNode, *roachpb.Error) {
 
 type valuesNode struct {
 	columns  []resultColumn
-	ordering []int
+	ordering columnOrdering
 	rows     []parser.DTuple
 	nextRow  int // The index of the next row.
 }
@@ -85,8 +86,8 @@ func (n *valuesNode) Columns() []resultColumn {
 	return n.columns
 }
 
-func (n *valuesNode) Ordering() ([]int, int) {
-	return nil, 0
+func (n *valuesNode) Ordering() orderingInfo {
+	return orderingInfo{}
 }
 
 func (n *valuesNode) Values() parser.DTuple {
@@ -114,14 +115,14 @@ func (n *valuesNode) Less(i, j int) bool {
 	// be to construct a sort-key per row using encodeTableKey(). Using a
 	// sort-key approach would likely fit better with a disk-based sort.
 	ra, rb := n.rows[i], n.rows[j]
-	for _, k := range n.ordering {
+	for _, c := range n.ordering {
 		var da, db parser.Datum
-		if k < 0 {
-			da = rb[-(k + 1)]
-			db = ra[-(k + 1)]
+		if c.direction == encoding.Ascending {
+			da = ra[c.colIdx]
+			db = rb[c.colIdx]
 		} else {
-			da = ra[k-1]
-			db = rb[k-1]
+			da = rb[c.colIdx]
+			db = ra[c.colIdx]
 		}
 		// TODO(pmattis): This is assuming that the datum types are compatible. I'm
 		// not sure this always holds as `CASE` expressions can return different

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -18,6 +18,7 @@ package encoding
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"reflect"
 	"time"
@@ -78,6 +79,18 @@ const (
 	Ascending
 	Descending
 )
+
+// Reverse returns the opposite direction.
+func (d Direction) Reverse() Direction {
+	switch d {
+	case Ascending:
+		return Descending
+	case Descending:
+		return Ascending
+	default:
+		panic(fmt.Sprintf("Invalid direction %d", d))
+	}
+}
 
 // EncodeUint32Ascending encodes the uint32 value using a big-endian 8 byte
 // representation. The bytes are appended to the supplied buffer and


### PR DESCRIPTION
The current ordering code is hard to understand (the logic of what the []int
actually represents is spread around the codebase) and there are some problems
with the representation, outlined in issue #3914.

In this change we introduce a better representation and abstraction for ordering
information and refactor the code accordingly.

@andreimatei @petermattis 
This should fix the example query in #3914 - I will add some tests like that to verify.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3918)

<!-- Reviewable:end -->
