### PR TITLE
Set cache size to half of the total memory.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -15,6 +15,7 @@ cmd golang.org/x/tools/cmd/stringer
 github.com/VividCortex/ewma c34099b489e4ac33ca8d8c5f9d29d6eeaf69f2ed
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store 3b4c041f52c224ee4a44f5c8b150d003a40643a0
+github.com/cloudfoundry/gosigar 3ed7c74352dae6dc00bdc8c74045375352e3ec05
 github.com/cockroachdb/c-lz4 c40aaae2fc50293eb8750b34632bc3efe813e23f
 github.com/cockroachdb/c-protobuf 4feb192131ea08dfbd7253a00868ad69cbb61b81
 github.com/cockroachdb/c-rocksdb b7fb7bddcb55be35eacdf67e9e2c931083ce02c4


### PR DESCRIPTION
PTAL.

What's a good place to print the cache size info message? Currently the message appears too early. It it the very first message that is printed when running the `server` and `sql` commands. The message is also printed before the usage information (with `./cockroach -h` or when a flag is missing).

The total memory is the minium of the system memory (determined by gosigar) and the cgroup memory limit (from `/sys/fs/cgroup/memory/memory.limit_in_bytes`).

Fixes #2965.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3919)

<!-- Reviewable:end -->
