### PR TITLE
remove ForceLogging flag, always use StartCluster

### DIFF
--- a/acceptance/build_info_test.go
+++ b/acceptance/build_info_test.go
@@ -22,28 +22,26 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/util"
 )
 
 func TestBuildInfo(t *testing.T) {
-	SkipUnlessLocal(t)
-	l := StartCluster(t).(*cluster.LocalCluster)
-	defer l.AssertAndStop(t)
+	c := StartCluster(t)
+	defer c.AssertAndStop(t)
 
-	checkGossip(t, l, 20*time.Second, hasPeers(l.NumNodes()))
+	checkGossip(t, c, 20*time.Second, hasPeers(c.NumNodes()))
 
 	util.SucceedsWithin(t, 10*time.Second, func() error {
 		select {
 		case <-stopper:
 			t.Fatalf("interrupted")
 			return nil
-		case <-time.After(200 * time.Millisecond):
+		default:
 		}
 		var r struct {
 			BuildInfo map[string]string
 		}
-		if err := l.Nodes[0].GetJSON("", "/_status/details/local", &r); err != nil {
+		if err := getJSON(c.URL(0), "/_status/details/local", &r); err != nil {
 			return err
 		}
 		for _, key := range []string{"goVersion", "tag", "time", "dependencies"} {

--- a/acceptance/build_info_test.go
+++ b/acceptance/build_info_test.go
@@ -27,11 +27,8 @@ import (
 )
 
 func TestBuildInfo(t *testing.T) {
-	if *numLocal == 0 {
-		t.Skip("skipping since not run against local cluster")
-	}
-	l := cluster.CreateLocal(1, 1, *logDir, stopper) // intentionally using a local cluster
-	l.Start()
+	SkipUnlessLocal(t)
+	l := StartCluster(t).(*cluster.LocalCluster)
 	defer l.AssertAndStop(t)
 
 	checkGossip(t, l, 20*time.Second, hasPeers(l.NumNodes()))

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -118,7 +118,6 @@ type LocalCluster struct {
 	monitorStopper chan struct{}
 	logDir         string
 	keepLogs       bool
-	ForceLogging   bool // Forces logging to disk on a per test basis
 }
 
 // CreateLocal creates a new local cockroach cluster. The stopper is used to
@@ -287,12 +286,6 @@ func (l *LocalCluster) initCluster() {
 		if err := os.MkdirAll(l.logDir, 0777); err != nil {
 			log.Fatal(err)
 		}
-	} else if l.ForceLogging {
-		l.logDir, err = ioutil.TempDir(pwd, ".localcluster.logs.")
-		if err != nil {
-			panic(err)
-		}
-		binds = append(binds, l.logDir+":/logs")
 	}
 	if *cockroachImage == builderImage {
 		path, err := filepath.Abs(*cockroachBinary)

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -118,6 +118,7 @@ func StartCluster(t *testing.T) cluster.Cluster {
 		_ = f.Destroy()
 		t.Fatalf("cluster not ready in time: %v", err)
 	}
+	checkRangeReplication(t, f, 20*time.Second)
 	return f
 }
 
@@ -138,7 +139,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// SkipUnlessLocal skips if not running against a local cluster.
+// SkipUnlessLocal calls t.Skip if not running against a local cluster.
 func SkipUnlessLocal(t *testing.T) {
 	if *numLocal == 0 {
 		t.Skip("skipping since not run against local cluster")

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -73,7 +73,8 @@ func checkRangeReplication(t util.Tester, c *cluster.LocalCluster, d time.Durati
 }
 
 func TestRangeReplication(t *testing.T) {
-	l := MustStartLocal(t)
+	SkipUnlessLocal(t)
+	l := StartCluster(t).(*cluster.LocalCluster)
 	defer l.AssertAndStop(t)
 
 	checkRangeReplication(t, l, 20*time.Second)

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -20,7 +20,6 @@ package acceptance
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
@@ -39,14 +38,14 @@ func countRangeReplicas(db *client.DB) (int, error) {
 	return len(desc.Replicas), nil
 }
 
-func checkRangeReplication(t util.Tester, c *cluster.LocalCluster, d time.Duration) {
+func checkRangeReplication(t util.Tester, c cluster.Cluster, d time.Duration) {
 	// Always talk to node 0.
 	client, dbStopper := makeClient(t, c.ConnString(0))
 	defer dbStopper.Stop()
 
 	wantedReplicas := 3
-	if len(c.Nodes) < 3 {
-		wantedReplicas = len(c.Nodes)
+	if c.NumNodes() < 3 {
+		wantedReplicas = c.NumNodes()
 	}
 
 	log.Infof("waiting for first range to have %d replicas", wantedReplicas)
@@ -70,12 +69,4 @@ func checkRangeReplication(t util.Tester, c *cluster.LocalCluster, d time.Durati
 		}
 		return fmt.Errorf("expected %d replicas, only found %d", wantedReplicas, foundReplicas)
 	})
-}
-
-func TestRangeReplication(t *testing.T) {
-	SkipUnlessLocal(t)
-	l := StartCluster(t).(*cluster.LocalCluster)
-	defer l.AssertAndStop(t)
-
-	checkRangeReplication(t, l, 20*time.Second)
 }

--- a/acceptance/status_server_test.go
+++ b/acceptance/status_server_test.go
@@ -93,13 +93,9 @@ func checkNode(t *testing.T, node *cluster.Container, nodeID, otherNodeID, expec
 // TestStatusServer starts up an N node cluster and tests the status server on
 // each node.
 func TestStatusServer(t *testing.T) {
-	if *numLocal == 0 {
-		t.Skip("skipping since not run against local cluster")
-	}
+	SkipUnlessLocal(t)
 
-	l := cluster.CreateLocal(*numLocal, *numStores, *logDir, stopper) // intentionally using local cluster
-	l.ForceLogging = true
-	l.Start()
+	l := StartCluster(t).(*cluster.LocalCluster)
 	defer l.AssertAndStop(t)
 
 	checkRangeReplication(t, l, 20*time.Second)

--- a/acceptance/status_server_test.go
+++ b/acceptance/status_server_test.go
@@ -19,7 +19,6 @@
 package acceptance
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -44,9 +43,9 @@ var retryOptions = retry.Options{
 }
 
 // get performs an HTTPS GET to the specified path for a specific node.
-func get(t *testing.T, node *cluster.Container, path string) []byte {
-	url := fmt.Sprintf("https://%s%s", node.Addr(""), path)
+func get(t *testing.T, base, rel string) []byte {
 	// TODO(bram) #2059: Remove retry logic.
+	url := fmt.Sprintf("%s/%s", base, rel)
 	for r := retry.Start(retryOptions); r.Next(); {
 		resp, err := cluster.HTTPClient.Get(url)
 		if err != nil {
@@ -73,61 +72,55 @@ func get(t *testing.T, node *cluster.Container, path string) []byte {
 // checkNode checks all the endpoints of the status server hosted by node and
 // requests info for the node with otherNodeID. That node could be the same
 // other node, the same node or "local".
-func checkNode(t *testing.T, node *cluster.Container, nodeID, otherNodeID, expectedNodeID string) {
-	body := get(t, node, "/_status/details/"+otherNodeID)
+func checkNode(t *testing.T, c cluster.Cluster, i int, nodeID, otherNodeID, expectedNodeID string) {
 	var detail details
-	if err := json.Unmarshal(body, &detail); err != nil {
+	if err := getJSON(c.URL(i), "/_status/details/"+otherNodeID, &detail); err != nil {
 		t.Fatal(util.ErrorfSkipFrames(1, "unable to parse details - %s", err))
 	}
 	if actualNodeID := detail.NodeID.String(); actualNodeID != expectedNodeID {
 		t.Fatal(util.ErrorfSkipFrames(1, "%s calling %s: node ids don't match - expected %s, actual %s", nodeID, otherNodeID, expectedNodeID, actualNodeID))
 	}
 
-	get(t, node, fmt.Sprintf("/_status/gossip/%s", otherNodeID))
-	get(t, node, fmt.Sprintf("/_status/logfiles/%s", otherNodeID))
-	get(t, node, fmt.Sprintf("/_status/logs/%s", otherNodeID))
-	get(t, node, fmt.Sprintf("/_status/stacks/%s", otherNodeID))
-	get(t, node, fmt.Sprintf("/_status/nodes/%s", otherNodeID))
+	get(t, c.URL(i), fmt.Sprintf("/_status/gossip/%s", otherNodeID))
+	get(t, c.URL(i), fmt.Sprintf("/_status/logfiles/%s", otherNodeID))
+	get(t, c.URL(i), fmt.Sprintf("/_status/logs/%s", otherNodeID))
+	get(t, c.URL(i), fmt.Sprintf("/_status/stacks/%s", otherNodeID))
+	get(t, c.URL(i), fmt.Sprintf("/_status/nodes/%s", otherNodeID))
 }
 
 // TestStatusServer starts up an N node cluster and tests the status server on
 // each node.
 func TestStatusServer(t *testing.T) {
-	SkipUnlessLocal(t)
-
-	l := StartCluster(t).(*cluster.LocalCluster)
-	defer l.AssertAndStop(t)
-
-	checkRangeReplication(t, l, 20*time.Second)
+	c := StartCluster(t)
+	defer c.AssertAndStop(t)
 
 	// Get the ids for each node.
-	idMap := make(map[string]string)
-	for _, node := range l.Nodes {
-		body := get(t, node, "/_status/details/local")
+	idMap := make(map[int]string)
+	for i := 0; i < c.NumNodes(); i++ {
 		var detail details
-		if err := json.Unmarshal(body, &detail); err != nil {
-			t.Fatalf("unable to parse details - %s", err)
+		if err := getJSON(c.URL(i), "/_status/details/local", &detail); err != nil {
+			t.Fatal(err)
 		}
-		idMap[node.ID] = detail.NodeID.String()
+		idMap[i] = detail.NodeID.String()
 	}
 
 	// Check local response for the every node.
-	for _, node := range l.Nodes {
-		checkNode(t, node, idMap[node.ID], "local", idMap[node.ID])
-		get(t, node, "/_status/nodes")
-		get(t, node, "/_status/stores")
+	for i := 0; i < c.NumNodes(); i++ {
+		checkNode(t, c, i, idMap[i], "local", idMap[i])
+		get(t, c.URL(i), "/_status/nodes")
+		get(t, c.URL(i), "/_status/stores")
 	}
 
 	// Proxy from the first node to the last node.
-	firstNode := l.Nodes[0]
-	lastNode := l.Nodes[len(l.Nodes)-1]
-	firstID := idMap[firstNode.ID]
-	lastID := idMap[lastNode.ID]
-	checkNode(t, firstNode, firstID, lastID, lastID)
+	firstNode := 0
+	lastNode := c.NumNodes() - 1
+	firstID := idMap[firstNode]
+	lastID := idMap[lastNode]
+	checkNode(t, c, firstNode, firstID, lastID, lastID)
 
 	// And from the last node to the first node.
-	checkNode(t, lastNode, lastID, firstID, firstID)
+	checkNode(t, c, lastNode, lastID, firstID, firstID)
 
 	// And from the last node to the last node.
-	checkNode(t, lastNode, lastID, lastID, lastID)
+	checkNode(t, c, lastNode, lastID, lastID, lastID)
 }

--- a/util/log/file.go
+++ b/util/log/file.go
@@ -220,6 +220,9 @@ type FileInfo struct {
 // on the local node, in any of the configured log directories.
 func ListLogFiles() ([]FileInfo, error) {
 	var results []FileInfo
+	if *logDir == "" {
+		return nil, nil
+	}
 	infos, err := ioutil.ReadDir(*logDir)
 	if err != nil {
 		return results, err


### PR DESCRIPTION
only StartCluster sets up the logging directory for
per-test usage.
ForceLogging was made obsolete by changing `util/log`
to return an empty result instead of an error when
no log dirs were defined.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3924)

<!-- Reviewable:end -->
