### PR TITLE
client: [Tiny fix] Check returned roachpb.Errors in {db,txn}_test.go

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -418,6 +418,7 @@ func sendAndFill(send func(...roachpb.Request) (*roachpb.BatchResponse, *roachpb
 	// result gets initialized with an error from the corresponding call.
 	br, pErr := send(b.reqs...)
 	if pErr != nil {
+		// Discard errors from fillResults.
 		_ = b.fillResults(nil, pErr)
 		return nil, pErr
 	}

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -325,12 +325,14 @@ func TestDebugName(t *testing.T) {
 	defer s.Stop()
 
 	file, _, _ := caller.Lookup(0)
-	_ = db.Txn(func(txn *client.Txn) *roachpb.Error {
+	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		if !strings.HasPrefix(txn.DebugName(), file+":") {
 			t.Fatalf("expected \"%s\" to have the prefix \"%s:\"", txn.DebugName(), file)
 		}
 		return nil
-	})
+	}); pErr != nil {
+		t.Errorf("txn failed: %s", pErr)
+	}
 }
 
 func TestCommonMethods(t *testing.T) {

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -498,8 +498,12 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 		}, nil))
 
 		txn := NewTxn(*db)
-		_ = txn.Put("a", "b")
-		_ = txn.Commit()
+		if pErr := txn.Put("a", "b"); pErr != nil {
+			t.Fatalf("put failed: %s", pErr)
+		}
+		if pErr := txn.Commit(); pErr == nil {
+			t.Fatalf("unexpected commit success")
+		}
 
 		if !commit {
 			t.Errorf("%T: failed to find commit", test.err)


### PR DESCRIPTION
Also add a tiny comment to sendAndFill() to clarify that an error from fillResults() is ignored.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3935)

<!-- Reviewable:end -->
