### PR TITLE
Remove the txn field from TransactionRetyError

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -698,9 +698,8 @@ func (tc *TxnCoordSender) updateState(ctx context.Context, ba roachpb.BatchReque
 		t.Txn = newTxn
 		pErr.Txn = newTxn
 	case *roachpb.TransactionRetryError:
-		newTxn.Update(&t.Txn)
-		newTxn.Restart(ba.UserPriority, t.Txn.Priority, newTxn.Timestamp)
-		t.Txn = *newTxn
+		newTxn.Update(pErr.Txn)
+		newTxn.Restart(ba.UserPriority, pErr.Txn.Priority, newTxn.Timestamp)
 		pErr.Txn = newTxn
 	default:
 		trace.SetError()

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -535,10 +535,9 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 		},
 		{
 			// On retry, restart with new epoch, timestamp and priority.
-			pErr: roachpb.NewError(&roachpb.TransactionRetryError{
-				Txn: roachpb.Transaction{
-					Timestamp: origTS.Add(10, 10), Priority: int32(10)},
-			}),
+			pErr: roachpb.NewErrorWithTxn(&roachpb.TransactionRetryError{},
+				&roachpb.Transaction{
+					Timestamp: origTS.Add(10, 10), Priority: int32(10)}),
 			expEpoch:  1,
 			expPri:    10,
 			expTS:     origTS.Add(10, 10),
@@ -693,7 +692,9 @@ func TestTxnCoordSenderErrorWithIntent(t *testing.T) {
 	ts := NewTxnCoordSender(senderFn(func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 		txn := ba.Txn.Clone()
 		txn.Writing = true
-		return nil, roachpb.NewError(roachpb.NewTransactionRetryError(txn))
+		pErr := roachpb.NewError(roachpb.NewTransactionRetryError())
+		pErr.Txn = txn
+		return nil, pErr
 	}), clock, false, nil, stopper)
 	defer stopper.Stop()
 

--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -65,6 +65,13 @@ func NewError(err error) *Error {
 	return e
 }
 
+// NewErrorWithTxn creates an Error from the given error and a transaction.
+func NewErrorWithTxn(err error, txn *Transaction) *Error {
+	e := NewError(err)
+	e.Txn = txn
+	return e
+}
+
 // NewUErrorf creates an Error from the given error message. Used
 // for user-facing errors.
 func NewUErrorf(format string, a ...interface{}) *Error {
@@ -103,6 +110,12 @@ func (e *internalError) canRestartTransaction() TransactionRestart {
 	return e.TransactionRestart
 }
 
+// structuredError is an interface for each error detail.
+type structuredError interface {
+	// message returns an error message.
+	message(pErr *Error) string
+}
+
 // CanRetry implements the retry.Retryable interface.
 func (e *Error) CanRetry() bool {
 	return e.Retryable
@@ -137,7 +150,11 @@ func (e *Error) SetGoError(err error) {
 	if e.Message != "" {
 		panic("cannot re-use roachpb.Error")
 	}
-	e.Message = err.Error()
+	if sErr, ok := err.(structuredError); ok {
+		e.Message = sErr.message(e)
+	} else {
+		e.Message = err.Error()
+	}
 	if r, ok := err.(retry.Retryable); ok {
 		e.Retryable = r.CanRetry()
 	}
@@ -278,15 +295,23 @@ func (*TransactionPushError) canRestartTransaction() TransactionRestart {
 
 // NewTransactionRetryError initializes a new TransactionRetryError.
 // Txn is the transaction which will be retried (a copy is taken).
-func NewTransactionRetryError(txn *Transaction) *TransactionRetryError {
-	return &TransactionRetryError{Txn: *txn.Clone()}
+func NewTransactionRetryError() *TransactionRetryError {
+	return &TransactionRetryError{}
 }
 
 // Error formats error.
+// TODO(kaneda): Delete this method once we fully unimplement error for every
+// error detail.
 func (e *TransactionRetryError) Error() string {
-	return fmt.Sprintf("retry txn %s", e.Txn)
+	return fmt.Sprintf("retry txn")
 }
 
+// message returns an error message.
+func (e *TransactionRetryError) message(pErr *Error) string {
+	return fmt.Sprintf("retry txn %s", pErr.Txn)
+}
+
+var _ structuredError = &TransactionRetryError{}
 var _ transactionRestartError = &TransactionRetryError{}
 
 // canRestartTransaction implements the transactionRestartError interface.

--- a/roachpb/errors.pb.go
+++ b/roachpb/errors.pb.go
@@ -145,10 +145,8 @@ func (m *TransactionPushError) String() string { return proto.CompactTextString(
 func (*TransactionPushError) ProtoMessage()    {}
 
 // A TransactionRetryError indicates that the transaction must be
-// retried, usually with an increased transaction timestamp. The
-// transaction struct to use is returned with the error.
+// retried, usually with an increased transaction timestamp.
 type TransactionRetryError struct {
-	Txn Transaction `protobuf:"bytes,1,opt,name=txn" json:"txn"`
 }
 
 func (m *TransactionRetryError) Reset()         { *m = TransactionRetryError{} }
@@ -635,14 +633,6 @@ func (m *TransactionRetryError) MarshalTo(data []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	data[i] = 0xa
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-	n10, err := m.Txn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n10
 	return i, nil
 }
 
@@ -664,11 +654,11 @@ func (m *TransactionStatusError) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-	n11, err := m.Txn.MarshalTo(data[i:])
+	n10, err := m.Txn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n11
+	i += n10
 	data[i] = 0x12
 	i++
 	i = encodeVarintErrors(data, i, uint64(len(m.Msg)))
@@ -732,19 +722,19 @@ func (m *WriteTooOldError) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Timestamp.Size()))
-	n12, err := m.Timestamp.MarshalTo(data[i:])
+	n11, err := m.Timestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n11
+	data[i] = 0x12
+	i++
+	i = encodeVarintErrors(data, i, uint64(m.ExistingTimestamp.Size()))
+	n12, err := m.ExistingTimestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n12
-	data[i] = 0x12
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.ExistingTimestamp.Size()))
-	n13, err := m.ExistingTimestamp.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n13
 	return i, nil
 }
 
@@ -785,11 +775,11 @@ func (m *ConditionFailedError) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ActualValue.Size()))
-		n14, err := m.ActualValue.MarshalTo(data[i:])
+		n13, err := m.ActualValue.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n14
+		i += n13
 	}
 	return i, nil
 }
@@ -816,19 +806,19 @@ func (m *LeaseRejectedError) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Requested.Size()))
-	n15, err := m.Requested.MarshalTo(data[i:])
+	n14, err := m.Requested.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n14
+	data[i] = 0x1a
+	i++
+	i = encodeVarintErrors(data, i, uint64(m.Existing.Size()))
+	n15, err := m.Existing.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n15
-	data[i] = 0x1a
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.Existing.Size()))
-	n16, err := m.Existing.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n16
 	return i, nil
 }
 
@@ -1001,151 +991,151 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.NotLeader.Size()))
-		n17, err := m.NotLeader.MarshalTo(data[i:])
+		n16, err := m.NotLeader.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n17
+		i += n16
 	}
 	if m.RangeNotFound != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.RangeNotFound.Size()))
-		n18, err := m.RangeNotFound.MarshalTo(data[i:])
+		n17, err := m.RangeNotFound.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n18
+		i += n17
 	}
 	if m.RangeKeyMismatch != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.RangeKeyMismatch.Size()))
-		n19, err := m.RangeKeyMismatch.MarshalTo(data[i:])
+		n18, err := m.RangeKeyMismatch.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n19
+		i += n18
 	}
 	if m.ReadWithinUncertaintyInterval != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ReadWithinUncertaintyInterval.Size()))
-		n20, err := m.ReadWithinUncertaintyInterval.MarshalTo(data[i:])
+		n19, err := m.ReadWithinUncertaintyInterval.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n20
+		i += n19
 	}
 	if m.TransactionAborted != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionAborted.Size()))
-		n21, err := m.TransactionAborted.MarshalTo(data[i:])
+		n20, err := m.TransactionAborted.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n21
+		i += n20
 	}
 	if m.TransactionPush != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionPush.Size()))
-		n22, err := m.TransactionPush.MarshalTo(data[i:])
+		n21, err := m.TransactionPush.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n22
+		i += n21
 	}
 	if m.TransactionRetry != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionRetry.Size()))
-		n23, err := m.TransactionRetry.MarshalTo(data[i:])
+		n22, err := m.TransactionRetry.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n23
+		i += n22
 	}
 	if m.TransactionStatus != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionStatus.Size()))
-		n24, err := m.TransactionStatus.MarshalTo(data[i:])
+		n23, err := m.TransactionStatus.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n24
+		i += n23
 	}
 	if m.WriteIntent != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.WriteIntent.Size()))
-		n25, err := m.WriteIntent.MarshalTo(data[i:])
+		n24, err := m.WriteIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n25
+		i += n24
 	}
 	if m.WriteTooOld != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.WriteTooOld.Size()))
-		n26, err := m.WriteTooOld.MarshalTo(data[i:])
+		n25, err := m.WriteTooOld.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n26
+		i += n25
 	}
 	if m.OpRequiresTxn != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.OpRequiresTxn.Size()))
-		n27, err := m.OpRequiresTxn.MarshalTo(data[i:])
+		n26, err := m.OpRequiresTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n27
+		i += n26
 	}
 	if m.ConditionFailed != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ConditionFailed.Size()))
-		n28, err := m.ConditionFailed.MarshalTo(data[i:])
+		n27, err := m.ConditionFailed.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n28
+		i += n27
 	}
 	if m.LeaseRejected != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.LeaseRejected.Size()))
-		n29, err := m.LeaseRejected.MarshalTo(data[i:])
+		n28, err := m.LeaseRejected.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n29
+		i += n28
 	}
 	if m.NodeUnavailable != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.NodeUnavailable.Size()))
-		n30, err := m.NodeUnavailable.MarshalTo(data[i:])
+		n29, err := m.NodeUnavailable.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n30
+		i += n29
 	}
 	if m.Send != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Send.Size()))
-		n31, err := m.Send.MarshalTo(data[i:])
+		n30, err := m.Send.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n31
+		i += n30
 	}
 	if m.RaftGroupDeleted != nil {
 		data[i] = 0x82
@@ -1153,11 +1143,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.RaftGroupDeleted.Size()))
-		n32, err := m.RaftGroupDeleted.MarshalTo(data[i:])
+		n31, err := m.RaftGroupDeleted.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n32
+		i += n31
 	}
 	if m.ReplicaCorruption != nil {
 		data[i] = 0x8a
@@ -1165,11 +1155,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ReplicaCorruption.Size()))
-		n33, err := m.ReplicaCorruption.MarshalTo(data[i:])
+		n32, err := m.ReplicaCorruption.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n33
+		i += n32
 	}
 	if m.LeaseVersionChanged != nil {
 		data[i] = 0x92
@@ -1177,11 +1167,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.LeaseVersionChanged.Size()))
-		n34, err := m.LeaseVersionChanged.MarshalTo(data[i:])
+		n33, err := m.LeaseVersionChanged.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n34
+		i += n33
 	}
 	if m.DidntUpdateDescriptor != nil {
 		data[i] = 0x9a
@@ -1189,11 +1179,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.DidntUpdateDescriptor.Size()))
-		n35, err := m.DidntUpdateDescriptor.MarshalTo(data[i:])
+		n34, err := m.DidntUpdateDescriptor.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n35
+		i += n34
 	}
 	if m.SqlTranasctionAborted != nil {
 		data[i] = 0xa2
@@ -1201,11 +1191,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.SqlTranasctionAborted.Size()))
-		n36, err := m.SqlTranasctionAborted.MarshalTo(data[i:])
+		n35, err := m.SqlTranasctionAborted.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n36
+		i += n35
 	}
 	if m.ExistingSchemeChangeLease != nil {
 		data[i] = 0xaa
@@ -1213,11 +1203,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ExistingSchemeChangeLease.Size()))
-		n37, err := m.ExistingSchemeChangeLease.MarshalTo(data[i:])
+		n36, err := m.ExistingSchemeChangeLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n37
+		i += n36
 	}
 	return i, nil
 }
@@ -1277,31 +1267,31 @@ func (m *Error) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x22
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-		n38, err := m.Txn.MarshalTo(data[i:])
+		n37, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n38
+		i += n37
 	}
 	if m.Detail != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Detail.Size()))
-		n39, err := m.Detail.MarshalTo(data[i:])
+		n38, err := m.Detail.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n39
+		i += n38
 	}
 	if m.Index != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Index.Size()))
-		n40, err := m.Index.MarshalTo(data[i:])
+		n39, err := m.Index.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n40
+		i += n39
 	}
 	return i, nil
 }
@@ -1415,8 +1405,6 @@ func (m *TransactionPushError) Size() (n int) {
 func (m *TransactionRetryError) Size() (n int) {
 	var l int
 	_ = l
-	l = m.Txn.Size()
-	n += 1 + l + sovErrors(uint64(l))
 	return n
 }
 
@@ -2557,36 +2545,6 @@ func (m *TransactionRetryError) Unmarshal(data []byte) error {
 			return fmt.Errorf("proto: TransactionRetryError: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Txn", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowErrors
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthErrors
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.Txn.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipErrors(data[iNdEx:])

--- a/roachpb/errors.proto
+++ b/roachpb/errors.proto
@@ -86,10 +86,8 @@ message TransactionPushError {
 }
 
 // A TransactionRetryError indicates that the transaction must be
-// retried, usually with an increased transaction timestamp. The
-// transaction struct to use is returned with the error.
+// retried, usually with an increased transaction timestamp.
 message TransactionRetryError {
-  optional Transaction txn = 1 [(gogoproto.nullable) = false];
 }
 
 // A TransactionStatusError indicates that the transaction status is

--- a/storage/engine/rocksdb/cockroach/roachpb/errors.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/errors.pb.cc
@@ -219,7 +219,6 @@ void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto() {
       -1);
   TransactionRetryError_descriptor_ = file->message_type(7);
   static const int TransactionRetryError_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TransactionRetryError, txn_),
   };
   TransactionRetryError_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -649,77 +648,75 @@ void protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto() {
     "\"}\n\024TransactionPushError\022+\n\003txn\030\001 \001(\0132\036."
     "cockroach.roachpb.Transaction\0228\n\npushee_"
     "txn\030\002 \001(\0132\036.cockroach.roachpb.Transactio"
-    "nB\004\310\336\037\000\"J\n\025TransactionRetryError\0221\n\003txn\030"
-    "\001 \001(\0132\036.cockroach.roachpb.TransactionB\004\310"
-    "\336\037\000\"^\n\026TransactionStatusError\0221\n\003txn\030\001 \001"
-    "(\0132\036.cockroach.roachpb.TransactionB\004\310\336\037\000"
-    "\022\021\n\003msg\030\002 \001(\tB\004\310\336\037\000\"\\\n\020WriteIntentError\022"
-    "0\n\007intents\030\001 \003(\0132\031.cockroach.roachpb.Int"
-    "entB\004\310\336\037\000\022\026\n\010resolved\030\002 \001(\010B\004\310\336\037\000\"\211\001\n\020Wr"
-    "iteTooOldError\0225\n\ttimestamp\030\001 \001(\0132\034.cock"
-    "roach.roachpb.TimestampB\004\310\336\037\000\022>\n\022existin"
-    "g_timestamp\030\002 \001(\0132\034.cockroach.roachpb.Ti"
-    "mestampB\004\310\336\037\000\"\024\n\022OpRequiresTxnError\"F\n\024C"
-    "onditionFailedError\022.\n\014actual_value\030\001 \001("
-    "\0132\030.cockroach.roachpb.Value\"\220\001\n\022LeaseRej"
-    "ectedError\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\0221\n\treq"
-    "uested\030\002 \001(\0132\030.cockroach.roachpb.LeaseB\004"
-    "\310\336\037\000\0220\n\010existing\030\003 \001(\0132\030.cockroach.roach"
-    "pb.LeaseB\004\310\336\037\000\";\n\tSendError\022\025\n\007message\030\001"
-    " \001(\tB\004\310\336\037\000\022\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\"\027\n\025R"
-    "aftGroupDeletedError\"J\n\026ReplicaCorruptio"
-    "nError\022\027\n\terror_msg\030\001 \001(\tB\004\310\336\037\000\022\027\n\tproce"
-    "ssed\030\002 \001(\010B\004\310\336\037\000\"\032\n\030LeaseVersionChangedE"
-    "rror\"\034\n\032DidntUpdateDescriptorError\"\034\n\032Sq"
-    "lTransactionAbortedError\" \n\036ExistingSche"
-    "maChangeLeaseError\"\303\013\n\013ErrorDetail\0225\n\nno"
-    "t_leader\030\001 \001(\0132!.cockroach.roachpb.NotLe"
-    "aderError\022>\n\017range_not_found\030\002 \001(\0132%.coc"
-    "kroach.roachpb.RangeNotFoundError\022D\n\022ran"
-    "ge_key_mismatch\030\003 \001(\0132(.cockroach.roachp"
-    "b.RangeKeyMismatchError\022_\n read_within_u"
-    "ncertainty_interval\030\004 \001(\01325.cockroach.ro"
-    "achpb.ReadWithinUncertaintyIntervalError"
-    "\022G\n\023transaction_aborted\030\005 \001(\0132*.cockroac"
-    "h.roachpb.TransactionAbortedError\022A\n\020tra"
-    "nsaction_push\030\006 \001(\0132\'.cockroach.roachpb."
-    "TransactionPushError\022C\n\021transaction_retr"
-    "y\030\007 \001(\0132(.cockroach.roachpb.TransactionR"
-    "etryError\022E\n\022transaction_status\030\010 \001(\0132)."
-    "cockroach.roachpb.TransactionStatusError"
-    "\0229\n\014write_intent\030\t \001(\0132#.cockroach.roach"
-    "pb.WriteIntentError\022:\n\rwrite_too_old\030\n \001"
-    "(\0132#.cockroach.roachpb.WriteTooOldError\022"
-    ">\n\017op_requires_txn\030\013 \001(\0132%.cockroach.roa"
-    "chpb.OpRequiresTxnError\022A\n\020condition_fai"
-    "led\030\014 \001(\0132\'.cockroach.roachpb.ConditionF"
-    "ailedError\022=\n\016lease_rejected\030\r \001(\0132%.coc"
-    "kroach.roachpb.LeaseRejectedError\022A\n\020nod"
-    "e_unavailable\030\016 \001(\0132\'.cockroach.roachpb."
-    "NodeUnavailableError\022*\n\004send\030\017 \001(\0132\034.coc"
-    "kroach.roachpb.SendError\022D\n\022raft_group_d"
-    "eleted\030\020 \001(\0132(.cockroach.roachpb.RaftGro"
-    "upDeletedError\022E\n\022replica_corruption\030\021 \001"
-    "(\0132).cockroach.roachpb.ReplicaCorruption"
-    "Error\022J\n\025lease_version_changed\030\022 \001(\0132+.c"
-    "ockroach.roachpb.LeaseVersionChangedErro"
-    "r\022N\n\027didnt_update_descriptor\030\023 \001(\0132-.coc"
-    "kroach.roachpb.DidntUpdateDescriptorErro"
-    "r\022N\n\027sql_tranasction_aborted\030\024 \001(\0132-.coc"
-    "kroach.roachpb.SqlTransactionAbortedErro"
-    "r\022W\n\034existing_scheme_change_lease\030\025 \001(\0132"
-    "1.cockroach.roachpb.ExistingSchemaChange"
-    "LeaseError:\004\310\240\037\001\"\"\n\013ErrPosition\022\023\n\005index"
-    "\030\001 \001(\005B\004\310\336\037\000\"\223\002\n\005Error\022\025\n\007message\030\001 \001(\tB"
-    "\004\310\336\037\000\022\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\022H\n\023transa"
-    "ction_restart\030\003 \001(\0162%.cockroach.roachpb."
-    "TransactionRestartB\004\310\336\037\000\022+\n\003txn\030\004 \001(\0132\036."
-    "cockroach.roachpb.Transaction\022.\n\006detail\030"
-    "\005 \001(\0132\036.cockroach.roachpb.ErrorDetail\022-\n"
-    "\005index\030\006 \001(\0132\036.cockroach.roachpb.ErrPosi"
-    "tion:\004\230\240\037\000*;\n\022TransactionRestart\022\t\n\005ABOR"
-    "T\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\tZ\007roach"
-    "pbX\002", 3804);
+    "nB\004\310\336\037\000\"\027\n\025TransactionRetryError\"^\n\026Tran"
+    "sactionStatusError\0221\n\003txn\030\001 \001(\0132\036.cockro"
+    "ach.roachpb.TransactionB\004\310\336\037\000\022\021\n\003msg\030\002 \001"
+    "(\tB\004\310\336\037\000\"\\\n\020WriteIntentError\0220\n\007intents\030"
+    "\001 \003(\0132\031.cockroach.roachpb.IntentB\004\310\336\037\000\022\026"
+    "\n\010resolved\030\002 \001(\010B\004\310\336\037\000\"\211\001\n\020WriteTooOldEr"
+    "ror\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach.roach"
+    "pb.TimestampB\004\310\336\037\000\022>\n\022existing_timestamp"
+    "\030\002 \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336"
+    "\037\000\"\024\n\022OpRequiresTxnError\"F\n\024ConditionFai"
+    "ledError\022.\n\014actual_value\030\001 \001(\0132\030.cockroa"
+    "ch.roachpb.Value\"\220\001\n\022LeaseRejectedError\022"
+    "\025\n\007message\030\001 \001(\tB\004\310\336\037\000\0221\n\trequested\030\002 \001("
+    "\0132\030.cockroach.roachpb.LeaseB\004\310\336\037\000\0220\n\010exi"
+    "sting\030\003 \001(\0132\030.cockroach.roachpb.LeaseB\004\310"
+    "\336\037\000\";\n\tSendError\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022"
+    "\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\"\027\n\025RaftGroupDel"
+    "etedError\"J\n\026ReplicaCorruptionError\022\027\n\te"
+    "rror_msg\030\001 \001(\tB\004\310\336\037\000\022\027\n\tprocessed\030\002 \001(\010B"
+    "\004\310\336\037\000\"\032\n\030LeaseVersionChangedError\"\034\n\032Did"
+    "ntUpdateDescriptorError\"\034\n\032SqlTransactio"
+    "nAbortedError\" \n\036ExistingSchemaChangeLea"
+    "seError\"\303\013\n\013ErrorDetail\0225\n\nnot_leader\030\001 "
+    "\001(\0132!.cockroach.roachpb.NotLeaderError\022>"
+    "\n\017range_not_found\030\002 \001(\0132%.cockroach.roac"
+    "hpb.RangeNotFoundError\022D\n\022range_key_mism"
+    "atch\030\003 \001(\0132(.cockroach.roachpb.RangeKeyM"
+    "ismatchError\022_\n read_within_uncertainty_"
+    "interval\030\004 \001(\01325.cockroach.roachpb.ReadW"
+    "ithinUncertaintyIntervalError\022G\n\023transac"
+    "tion_aborted\030\005 \001(\0132*.cockroach.roachpb.T"
+    "ransactionAbortedError\022A\n\020transaction_pu"
+    "sh\030\006 \001(\0132\'.cockroach.roachpb.Transaction"
+    "PushError\022C\n\021transaction_retry\030\007 \001(\0132(.c"
+    "ockroach.roachpb.TransactionRetryError\022E"
+    "\n\022transaction_status\030\010 \001(\0132).cockroach.r"
+    "oachpb.TransactionStatusError\0229\n\014write_i"
+    "ntent\030\t \001(\0132#.cockroach.roachpb.WriteInt"
+    "entError\022:\n\rwrite_too_old\030\n \001(\0132#.cockro"
+    "ach.roachpb.WriteTooOldError\022>\n\017op_requi"
+    "res_txn\030\013 \001(\0132%.cockroach.roachpb.OpRequ"
+    "iresTxnError\022A\n\020condition_failed\030\014 \001(\0132\'"
+    ".cockroach.roachpb.ConditionFailedError\022"
+    "=\n\016lease_rejected\030\r \001(\0132%.cockroach.roac"
+    "hpb.LeaseRejectedError\022A\n\020node_unavailab"
+    "le\030\016 \001(\0132\'.cockroach.roachpb.NodeUnavail"
+    "ableError\022*\n\004send\030\017 \001(\0132\034.cockroach.roac"
+    "hpb.SendError\022D\n\022raft_group_deleted\030\020 \001("
+    "\0132(.cockroach.roachpb.RaftGroupDeletedEr"
+    "ror\022E\n\022replica_corruption\030\021 \001(\0132).cockro"
+    "ach.roachpb.ReplicaCorruptionError\022J\n\025le"
+    "ase_version_changed\030\022 \001(\0132+.cockroach.ro"
+    "achpb.LeaseVersionChangedError\022N\n\027didnt_"
+    "update_descriptor\030\023 \001(\0132-.cockroach.roac"
+    "hpb.DidntUpdateDescriptorError\022N\n\027sql_tr"
+    "anasction_aborted\030\024 \001(\0132-.cockroach.roac"
+    "hpb.SqlTransactionAbortedError\022W\n\034existi"
+    "ng_scheme_change_lease\030\025 \001(\01321.cockroach"
+    ".roachpb.ExistingSchemaChangeLeaseError:"
+    "\004\310\240\037\001\"\"\n\013ErrPosition\022\023\n\005index\030\001 \001(\005B\004\310\336\037"
+    "\000\"\223\002\n\005Error\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tre"
+    "tryable\030\002 \001(\010B\004\310\336\037\000\022H\n\023transaction_resta"
+    "rt\030\003 \001(\0162%.cockroach.roachpb.Transaction"
+    "RestartB\004\310\336\037\000\022+\n\003txn\030\004 \001(\0132\036.cockroach.r"
+    "oachpb.Transaction\022.\n\006detail\030\005 \001(\0132\036.coc"
+    "kroach.roachpb.ErrorDetail\022-\n\005index\030\006 \001("
+    "\0132\036.cockroach.roachpb.ErrPosition:\004\230\240\037\000*"
+    ";\n\022TransactionRestart\022\t\n\005ABORT\020\000\022\013\n\007BACK"
+    "OFF\020\001\022\r\n\tIMMEDIATE\020\002B\tZ\007roachpbX\002", 3753);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/errors.proto", &protobuf_RegisterTypes);
   NotLeaderError::default_instance_ = new NotLeaderError();
@@ -3356,7 +3353,6 @@ void TransactionPushError::set_allocated_pushee_txn(::cockroach::roachpb::Transa
 // ===================================================================
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int TransactionRetryError::kTxnFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 TransactionRetryError::TransactionRetryError()
@@ -3366,7 +3362,6 @@ TransactionRetryError::TransactionRetryError()
 }
 
 void TransactionRetryError::InitAsDefaultInstance() {
-  txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
 }
 
 TransactionRetryError::TransactionRetryError(const TransactionRetryError& from)
@@ -3379,7 +3374,6 @@ TransactionRetryError::TransactionRetryError(const TransactionRetryError& from)
 
 void TransactionRetryError::SharedCtor() {
   _cached_size_ = 0;
-  txn_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -3390,7 +3384,6 @@ TransactionRetryError::~TransactionRetryError() {
 
 void TransactionRetryError::SharedDtor() {
   if (this != default_instance_) {
-    delete txn_;
   }
 }
 
@@ -3420,9 +3413,6 @@ TransactionRetryError* TransactionRetryError::New(::google::protobuf::Arena* are
 }
 
 void TransactionRetryError::Clear() {
-  if (has_txn()) {
-    if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
-  }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -3438,31 +3428,14 @@ bool TransactionRetryError::MergePartialFromCodedStream(
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
     tag = p.first;
     if (!p.second) goto handle_unusual;
-    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.roachpb.Transaction txn = 1;
-      case 1: {
-        if (tag == 10) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_txn()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectAtEnd()) goto success;
-        break;
-      }
-
-      default: {
-      handle_unusual:
-        if (tag == 0 ||
-            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
-            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
-          goto success;
-        }
-        DO_(::google::protobuf::internal::WireFormat::SkipField(
-              input, tag, mutable_unknown_fields()));
-        break;
-      }
+  handle_unusual:
+    if (tag == 0 ||
+        ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+        ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+      goto success;
     }
+    DO_(::google::protobuf::internal::WireFormat::SkipField(
+          input, tag, mutable_unknown_fields()));
   }
 success:
   // @@protoc_insertion_point(parse_success:cockroach.roachpb.TransactionRetryError)
@@ -3476,12 +3449,6 @@ failure:
 void TransactionRetryError::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.roachpb.TransactionRetryError)
-  // optional .cockroach.roachpb.Transaction txn = 1;
-  if (has_txn()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->txn_, output);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -3492,13 +3459,6 @@ void TransactionRetryError::SerializeWithCachedSizes(
 ::google::protobuf::uint8* TransactionRetryError::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.TransactionRetryError)
-  // optional .cockroach.roachpb.Transaction txn = 1;
-  if (has_txn()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        1, *this->txn_, target);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -3509,13 +3469,6 @@ void TransactionRetryError::SerializeWithCachedSizes(
 
 int TransactionRetryError::ByteSize() const {
   int total_size = 0;
-
-  // optional .cockroach.roachpb.Transaction txn = 1;
-  if (has_txn()) {
-    total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->txn_);
-  }
 
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
@@ -3542,11 +3495,6 @@ void TransactionRetryError::MergeFrom(const ::google::protobuf::Message& from) {
 
 void TransactionRetryError::MergeFrom(const TransactionRetryError& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_txn()) {
-      mutable_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.txn());
-    }
-  }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
   }
@@ -3574,8 +3522,6 @@ void TransactionRetryError::Swap(TransactionRetryError* other) {
   InternalSwap(other);
 }
 void TransactionRetryError::InternalSwap(TransactionRetryError* other) {
-  std::swap(txn_, other->txn_);
-  std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
 }
@@ -3590,49 +3536,6 @@ void TransactionRetryError::InternalSwap(TransactionRetryError* other) {
 
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // TransactionRetryError
-
-// optional .cockroach.roachpb.Transaction txn = 1;
-bool TransactionRetryError::has_txn() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-void TransactionRetryError::set_has_txn() {
-  _has_bits_[0] |= 0x00000001u;
-}
-void TransactionRetryError::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-void TransactionRetryError::clear_txn() {
-  if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
-  clear_has_txn();
-}
-const ::cockroach::roachpb::Transaction& TransactionRetryError::txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.TransactionRetryError.txn)
-  return txn_ != NULL ? *txn_ : *default_instance_->txn_;
-}
-::cockroach::roachpb::Transaction* TransactionRetryError::mutable_txn() {
-  set_has_txn();
-  if (txn_ == NULL) {
-    txn_ = new ::cockroach::roachpb::Transaction;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.TransactionRetryError.txn)
-  return txn_;
-}
-::cockroach::roachpb::Transaction* TransactionRetryError::release_txn() {
-  clear_has_txn();
-  ::cockroach::roachpb::Transaction* temp = txn_;
-  txn_ = NULL;
-  return temp;
-}
-void TransactionRetryError::set_allocated_txn(::cockroach::roachpb::Transaction* txn) {
-  delete txn_;
-  txn_ = txn;
-  if (txn) {
-    set_has_txn();
-  } else {
-    clear_has_txn();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.TransactionRetryError.txn)
-}
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 

--- a/storage/engine/rocksdb/cockroach/roachpb/errors.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/errors.pb.h
@@ -873,24 +873,12 @@ class TransactionRetryError : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.roachpb.Transaction txn = 1;
-  bool has_txn() const;
-  void clear_txn();
-  static const int kTxnFieldNumber = 1;
-  const ::cockroach::roachpb::Transaction& txn() const;
-  ::cockroach::roachpb::Transaction* mutable_txn();
-  ::cockroach::roachpb::Transaction* release_txn();
-  void set_allocated_txn(::cockroach::roachpb::Transaction* txn);
-
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.TransactionRetryError)
  private:
-  inline void set_has_txn();
-  inline void clear_has_txn();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::roachpb::Transaction* txn_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
@@ -3270,49 +3258,6 @@ inline void TransactionPushError::set_allocated_pushee_txn(::cockroach::roachpb:
 // -------------------------------------------------------------------
 
 // TransactionRetryError
-
-// optional .cockroach.roachpb.Transaction txn = 1;
-inline bool TransactionRetryError::has_txn() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-inline void TransactionRetryError::set_has_txn() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void TransactionRetryError::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-inline void TransactionRetryError::clear_txn() {
-  if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
-  clear_has_txn();
-}
-inline const ::cockroach::roachpb::Transaction& TransactionRetryError::txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.TransactionRetryError.txn)
-  return txn_ != NULL ? *txn_ : *default_instance_->txn_;
-}
-inline ::cockroach::roachpb::Transaction* TransactionRetryError::mutable_txn() {
-  set_has_txn();
-  if (txn_ == NULL) {
-    txn_ = new ::cockroach::roachpb::Transaction;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.TransactionRetryError.txn)
-  return txn_;
-}
-inline ::cockroach::roachpb::Transaction* TransactionRetryError::release_txn() {
-  clear_has_txn();
-  ::cockroach::roachpb::Transaction* temp = txn_;
-  txn_ = NULL;
-  return temp;
-}
-inline void TransactionRetryError::set_allocated_txn(::cockroach::roachpb::Transaction* txn) {
-  delete txn_;
-  txn_ = txn;
-  if (txn) {
-    set_has_txn();
-  } else {
-    clear_has_txn();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.TransactionRetryError.txn)
-}
 
 // -------------------------------------------------------------------
 

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1439,11 +1439,9 @@ func (r *Replica) checkSequenceCache(b engine.Engine, txn roachpb.Transaction) *
 		if log.V(1) {
 			log.Infof("found sequence cache entry for %s@%d", txn.Short(), txn.Sequence)
 		}
-		retryErr := roachpb.NewTransactionRetryError(&txn)
-		retryErr.Txn.Timestamp.Forward(entry.Timestamp)
-		pErr := roachpb.NewError(retryErr)
-		pErr.Txn = &retryErr.Txn
-		return pErr
+		newTxn := txn.Clone()
+		newTxn.Timestamp.Forward(entry.Timestamp)
+		return roachpb.NewErrorWithTxn(roachpb.NewTransactionRetryError(), newTxn)
 	}
 	return nil
 }

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -400,7 +400,7 @@ func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h ro
 		// retry error if the commit timestamp isn't equal to the txn
 		// timestamp.
 		if h.Txn.Isolation == roachpb.SERIALIZABLE && !reply.Txn.Timestamp.Equal(h.Txn.OrigTimestamp) {
-			return reply, nil, roachpb.NewTransactionRetryError(reply.Txn)
+			return reply, nil, roachpb.NewTransactionRetryError()
 		}
 		reply.Txn.Status = roachpb.COMMITTED
 	} else {

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2262,9 +2262,11 @@ func TestSequenceCacheError(t *testing.T) {
 	}
 
 	pErr := tc.rng.checkSequenceCache(tc.engine, txn)
-	if err, ok := pErr.GoError().(*roachpb.TransactionRetryError); ok {
-		if pErr.Txn == nil || !reflect.DeepEqual(pErr.Txn, &err.Txn) {
-			t.Errorf("txn does not match: %s v.s. %s", pErr.Txn, err.Txn)
+	if _, ok := pErr.GoError().(*roachpb.TransactionRetryError); ok {
+		expected := txn.Clone()
+		expected.Timestamp = ts
+		if pErr.Txn == nil || !reflect.DeepEqual(pErr.Txn, expected) {
+			t.Errorf("txn does not match: %s v.s. %s", pErr.Txn, expected)
 		}
 	} else {
 		t.Errorf("unexpected error: %s", pErr)

--- a/storage/store.go
+++ b/storage/store.go
@@ -1365,7 +1365,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 	// and the original error otherwise.
 	trace.Event("store retry limit exceeded") // good to check for if tests fail
 	if ba.Txn != nil {
-		pErr := roachpb.NewError(roachpb.NewTransactionRetryError(ba.Txn))
+		pErr := roachpb.NewError(roachpb.NewTransactionRetryError())
 		pErr.Txn = ba.Txn
 		return nil, pErr
 	}


### PR DESCRIPTION
This is an initial step for unimplementing Error for error details (#3303).
- Use pErr.Txn instead of TransactionRetyError.Txn
- Define structuredError and make TransactionRetyError implement the interface
- Change Error.SetGoError to generate an error message for structuredErrors by calling message().

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3939)

<!-- Reviewable:end -->
