### PR TITLE
testutils: Define IsPError to eliminate IsError(perr.GoError())

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -279,7 +279,7 @@ func TestClientRunTransaction(t *testing.T) {
 
 		if commit != (pErr == nil) {
 			t.Errorf("expected success? %t; got %s", commit, pErr)
-		} else if !commit && !testutils.IsError(pErr.GoError(), "purposefully failing transaction") {
+		} else if !commit && !testutils.IsPError(pErr, "purposefully failing transaction") {
 			t.Errorf("unexpected failure with !commit: %s", pErr)
 		}
 

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -182,7 +182,7 @@ func TestKVDBInternalMethods(t *testing.T) {
 		pErr := db.Run(b)
 		if pErr == nil {
 			t.Errorf("%d: unexpected success calling %s", i, args.Method())
-		} else if !testutils.IsError(pErr.GoError(), "contains an internal request|contains commit trigger") {
+		} else if !testutils.IsPError(pErr, "contains an internal request|contains commit trigger") {
 			t.Errorf("%d: unexpected error for %s: %s", i, args.Method(), pErr)
 		}
 	}

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -407,19 +407,19 @@ func TestBadRequest(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	if _, pErr := db.Scan("a", "a", 0); !testutils.IsError(pErr.GoError(), "truncation resulted in empty batch") {
+	if _, pErr := db.Scan("a", "a", 0); !testutils.IsPError(pErr, "truncation resulted in empty batch") {
 		t.Fatalf("unexpected error on scan with startkey == endkey: %v", pErr)
 	}
 
-	if _, pErr := db.ReverseScan("a", "a", 0); !testutils.IsError(pErr.GoError(), "truncation resulted in empty batch") {
+	if _, pErr := db.ReverseScan("a", "a", 0); !testutils.IsPError(pErr, "truncation resulted in empty batch") {
 		t.Fatalf("unexpected pError on reverse scan with startkey == endkey: %v", pErr)
 	}
 
-	if pErr := db.DelRange("x", "a"); !testutils.IsError(pErr.GoError(), "truncation resulted in empty batch") {
+	if pErr := db.DelRange("x", "a"); !testutils.IsPError(pErr, "truncation resulted in empty batch") {
 		t.Fatalf("unexpected error on deletion on [x, a): %v", pErr)
 	}
 
-	if pErr := db.DelRange("", "z"); !testutils.IsError(pErr.GoError(), "must be greater than LocalMax") {
+	if pErr := db.DelRange("", "z"); !testutils.IsPError(pErr, "must be greater than LocalMax") {
 		t.Fatalf("unexpected error on deletion on [KeyMin, z): %v", pErr)
 	}
 }

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -550,7 +550,7 @@ func TestEvictCacheOnError(t *testing.T) {
 		ds.updateLeaderCache(1, leader)
 		put := roachpb.NewPut(roachpb.Key("a"), roachpb.MakeValueFromString("value")).(*roachpb.PutRequest)
 
-		if _, pErr := client.SendWrapped(ds, nil, put); pErr != nil && !testutils.IsError(pErr.GoError(), "boom") {
+		if _, pErr := client.SendWrapped(ds, nil, put); pErr != nil && !testutils.IsPError(pErr, "boom") {
 			t.Errorf("put encountered unexpected error: %s", pErr)
 		}
 		if cur := ds.leaderCache.Lookup(1); reflect.DeepEqual(cur, &roachpb.ReplicaDescriptor{}) && !tc.shouldClearLeader {

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -704,7 +704,7 @@ func TestTxnCoordSenderErrorWithIntent(t *testing.T) {
 	ba.Add(&roachpb.PutRequest{Span: roachpb.Span{Key: key}})
 	ba.Add(&roachpb.EndTransactionRequest{})
 	ba.Txn = &roachpb.Transaction{Name: "test"}
-	if _, pErr := ts.Send(context.Background(), ba); !testutils.IsError(pErr.GoError(), "retry txn") {
+	if _, pErr := ts.Send(context.Background(), ba); !testutils.IsPError(pErr, "retry txn") {
 		t.Fatalf("unexpected error: %v", pErr)
 	}
 

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -83,7 +83,7 @@ func TestTxnDBBasics(t *testing.T) {
 
 		if commit != (pErr == nil) {
 			t.Errorf("expected success? %t; got %s", commit, pErr)
-		} else if !commit && !testutils.IsError(pErr.GoError(), "purposefully failing transaction") {
+		} else if !commit && !testutils.IsPError(pErr, "purposefully failing transaction") {
 			t.Errorf("unexpected failure with !commit: %s", pErr)
 		}
 

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -236,11 +236,11 @@ func TestServerNodeEventFeed(t *testing.T) {
 
 	// Scan, which should fail (before it makes it to server, so this won't
 	// be tracked)
-	if _, pErr := db.Scan("b", "a", 0); !testutils.IsError(pErr.GoError(), "empty batch") {
+	if _, pErr := db.Scan("b", "a", 0); !testutils.IsPError(pErr, "empty batch") {
 		t.Fatalf("unexpected Scan error: %v", pErr)
 	}
 
-	if pErr := db.CPut("test", "will", "fail"); !testutils.IsError(pErr.GoError(), "unexpected value") {
+	if pErr := db.CPut("test", "will", "fail"); !testutils.IsPError(pErr, "unexpected value") {
 		t.Fatalf("unexpected CPut error: %v", pErr)
 	}
 

--- a/sql/table_test.go
+++ b/sql/table_test.go
@@ -234,7 +234,7 @@ func TestPrimaryKeyUnspecified(t *testing.T) {
 		t.Fatal(pErr)
 	}
 	pErr = desc.AllocateIDs()
-	if !testutils.IsError(pErr.GoError(), errMissingPrimaryKey.Error()) {
+	if !testutils.IsPError(pErr, errMissingPrimaryKey.Error()) {
 		t.Fatalf("unexpected error: %s", pErr)
 	}
 }

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -300,7 +300,7 @@ func TestStoreRangeMergeLastRange(t *testing.T) {
 
 	// Merge last range.
 	args := adminMergeArgs(roachpb.KeyMin)
-	if _, pErr := client.SendWrapped(rg1(store), nil, &args); !testutils.IsError(pErr.GoError(), "cannot merge final range") {
+	if _, pErr := client.SendWrapped(rg1(store), nil, &args); !testutils.IsPError(pErr, "cannot merge final range") {
 		t.Fatalf("expected 'cannot merge final range' error; got %s", pErr)
 	}
 }
@@ -350,7 +350,7 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 	// Attempt to merge.
 	rangeADesc = rangeA.Desc()
 	argsMerge := adminMergeArgs(roachpb.Key(rangeADesc.StartKey))
-	if _, pErr := rangeA.AdminMerge(argsMerge, rangeADesc); !testutils.IsError(pErr.GoError(), "ranges not collocated") {
+	if _, pErr := rangeA.AdminMerge(argsMerge, rangeADesc); !testutils.IsPError(pErr, "ranges not collocated") {
 		t.Fatalf("did not got expected error; got %s", pErr)
 	}
 }

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1497,7 +1497,7 @@ func TestRangeSequenceCacheReadError(t *testing.T) {
 	_, pErr := client.SendWrappedWith(tc.Sender(), tc.rng.context(), roachpb.Header{
 		Txn: txn,
 	}, &args)
-	if !testutils.IsError(pErr.GoError(), "replica corruption") {
+	if !testutils.IsPError(pErr, "replica corruption") {
 		t.Fatal(pErr)
 	}
 }
@@ -1658,7 +1658,7 @@ func TestEndTransactionWithMalformedSplitTrigger(t *testing.T) {
 	}
 
 	txn.Sequence++
-	if _, pErr := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &args); !testutils.IsError(pErr.GoError(), "range does not match splits") {
+	if _, pErr := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &args); !testutils.IsPError(pErr, "range does not match splits") {
 		t.Errorf("expected range does not match splits error; got %s", pErr)
 	}
 }
@@ -1918,7 +1918,7 @@ func TestEndTransactionWithErrors(t *testing.T) {
 		args, h := endTxnArgs(txn, true)
 		txn.Sequence++
 
-		if _, pErr := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &args); !testutils.IsError(pErr.GoError(), test.expErrRegexp) {
+		if _, pErr := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &args); !testutils.IsPError(pErr, test.expErrRegexp) {
 			t.Errorf("expected error:\n%s\nto match:\n%s", pErr, test.expErrRegexp)
 		}
 	}
@@ -2300,7 +2300,7 @@ func TestPushTxnBadKey(t *testing.T) {
 	args := pushTxnArgs(pusher, pushee, roachpb.PUSH_ABORT)
 	args.Key = pusher.Key
 
-	if _, pErr := client.SendWrapped(tc.Sender(), tc.rng.context(), &args); !testutils.IsError(pErr.GoError(), ".*should match pushee.*") {
+	if _, pErr := client.SendWrapped(tc.Sender(), tc.rng.context(), &args); !testutils.IsPError(pErr, ".*should match pushee.*") {
 		t.Errorf("unexpected error %s", pErr)
 	}
 }
@@ -3022,7 +3022,7 @@ func TestReplicaCorruption(t *testing.T) {
 	// maybeSetCorrupt should have been called.
 	args = putArgs(roachpb.Key("boom"), []byte("value"))
 	_, pErr := client.SendWrapped(tc.Sender(), tc.rng.context(), &args)
-	if !testutils.IsError(pErr.GoError(), "replica corruption \\(processed=true\\)") {
+	if !testutils.IsPError(pErr, "replica corruption \\(processed=true\\)") {
 		t.Fatalf("unexpected error: %s", pErr)
 	}
 
@@ -3144,7 +3144,7 @@ func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 	// First, try this consistently, which should not be allowed.
 	rlArgs.ConsiderIntents = true
 	_, pErr = client.SendWrapped(tc.Sender(), tc.rng.context(), rlArgs)
-	if !testutils.IsError(pErr.GoError(), "can not read consistently and special-case intents") {
+	if !testutils.IsPError(pErr, "can not read consistently and special-case intents") {
 		t.Fatalf("wanted specific error, not %s", pErr)
 	}
 	// After changing back to inconsistent lookups, should be good to go.
@@ -3529,7 +3529,7 @@ func TestBatchErrorWithIndex(t *testing.T) {
 
 	if _, pErr := tc.Sender().Send(tc.rng.context(), ba); pErr == nil {
 		t.Fatal("expected an error")
-	} else if pErr.Index == nil || pErr.Index.Index != 1 || !testutils.IsError(pErr.GoError(), "unexpected value") {
+	} else if pErr.Index == nil || pErr.Index.Index != 1 || !testutils.IsPError(pErr, "unexpected value") {
 		t.Fatalf("invalid index or error type: %s", pErr)
 	}
 

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -571,29 +571,29 @@ func TestStoreVerifyKeys(t *testing.T) {
 	defer stopper.Stop()
 	// Try a start key == KeyMax.
 	gArgs := getArgs(roachpb.KeyMax)
-	if _, pErr := client.SendWrapped(store.testSender(), nil, &gArgs); !testutils.IsError(pErr.GoError(), "must be less than KeyMax") {
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &gArgs); !testutils.IsPError(pErr, "must be less than KeyMax") {
 		t.Fatalf("expected error for start key == KeyMax: %v", pErr)
 	}
 	// Try a get with an end key specified (get requires only a start key and should fail).
 	gArgs.EndKey = roachpb.KeyMax
-	if _, pErr := client.SendWrapped(store.testSender(), nil, &gArgs); !testutils.IsError(pErr.GoError(), "must be less than KeyMax") {
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &gArgs); !testutils.IsPError(pErr, "must be less than KeyMax") {
 		t.Fatalf("unexpected error for end key specified on a non-range-based operation: %v", pErr)
 	}
 	// Try a scan with end key < start key.
 	sArgs := scanArgs([]byte("b"), []byte("a"))
-	if _, pErr := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsError(pErr.GoError(), "must be greater than") {
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsPError(pErr, "must be greater than") {
 		t.Fatalf("unexpected error for end key < start: %v", pErr)
 	}
 	// Try a scan with start key == end key.
 	sArgs.Key = []byte("a")
 	sArgs.EndKey = sArgs.Key
-	if _, pErr := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsError(pErr.GoError(), "must be greater than") {
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsPError(pErr, "must be greater than") {
 		t.Fatalf("unexpected error for start == end key: %v", pErr)
 	}
 	// Try a scan with range-local start key, but "regular" end key.
 	sArgs.Key = keys.MakeRangeKey([]byte("test"), []byte("sffx"), nil)
 	sArgs.EndKey = []byte("z")
-	if _, pErr := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsError(pErr.GoError(), "range-local") {
+	if _, pErr := client.SendWrapped(store.testSender(), nil, &sArgs); !testutils.IsPError(pErr, "range-local") {
 		t.Fatalf("unexpected error for local start, non-local end key: %v", pErr)
 	}
 
@@ -1596,7 +1596,7 @@ func TestStoreBadRequests(t *testing.T) {
 		if test.header.Txn != nil {
 			test.header.Txn.Sequence++
 		}
-		if _, pErr := client.SendWrappedWith(store.testSender(), nil, *test.header, test.args); pErr == nil || test.err == "" || !testutils.IsError(pErr.GoError(), test.err) {
+		if _, pErr := client.SendWrappedWith(store.testSender(), nil, *test.header, test.args); pErr == nil || test.err == "" || !testutils.IsPError(pErr, test.err) {
 			t.Errorf("%d unexpected result: %s", i, pErr)
 		}
 	}

--- a/testutils/error.go
+++ b/testutils/error.go
@@ -16,7 +16,11 @@
 
 package testutils
 
-import "regexp"
+import (
+	"regexp"
+
+	"github.com/cockroachdb/cockroach/roachpb"
+)
 
 // IsError returns true if err is non-nil and the error string matches the
 // supplied regexp.
@@ -25,6 +29,19 @@ func IsError(err error, re string) bool {
 		return false
 	}
 	matched, merr := regexp.MatchString(re, err.Error())
+	if merr != nil {
+		return false
+	}
+	return matched
+}
+
+// IsPError returns true if pErr is non-nil and the error message matches the
+// supplied regexp.
+func IsPError(pErr *roachpb.Error, re string) bool {
+	if pErr == nil {
+		return false
+	}
+	matched, merr := regexp.MatchString(re, pErr.Message)
 	if merr != nil {
 		return false
 	}


### PR DESCRIPTION
This is a cleanup for eliminating unnecessary use of `GoError()`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3949)

<!-- Reviewable:end -->
