### PR TITLE
Remove the txn field from TransactionAbortedError

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -66,11 +66,11 @@ func (ts *txnSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachp
 			Isolation: ts.Proto.Isolation,
 		}
 		// Acts as a minimum priority on restart.
-		if pErr.Txn != nil {
-			ts.Proto.Priority = pErr.Txn.Priority
+		if pErr.GetTxn() != nil {
+			ts.Proto.Priority = pErr.GetTxn().Priority
 		}
 	} else if pErr.TransactionRestart != roachpb.TransactionRestart_ABORT {
-		ts.Proto.Update(pErr.Txn)
+		ts.Proto.Update(pErr.GetTxn())
 	}
 	return nil, pErr
 }

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -157,9 +157,8 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 func TestTxnResetTxnOnAbort(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	db := newDB(newTestSender(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		return nil, roachpb.NewError(&roachpb.TransactionAbortedError{
-			Txn: *proto.Clone(ba.Txn).(*roachpb.Transaction),
-		})
+		return nil, roachpb.NewErrorWithTxn(&roachpb.TransactionAbortedError{},
+			proto.Clone(ba.Txn).(*roachpb.Transaction))
 	}, nil))
 
 	txn := NewTxn(*db)

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -513,11 +513,10 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 		{
 			// On abort, nothing changes but we get a new priority to use for
 			// the next attempt.
-			pErr: roachpb.NewError(&roachpb.TransactionAbortedError{
-				Txn: roachpb.Transaction{
+			pErr: roachpb.NewErrorWithTxn(&roachpb.TransactionAbortedError{},
+				&roachpb.Transaction{
 					Timestamp: origTS.Add(20, 10), Priority: 10,
-				},
-			}),
+				}),
 			expPri: 10,
 		},
 		{
@@ -693,7 +692,7 @@ func TestTxnCoordSenderErrorWithIntent(t *testing.T) {
 		txn := ba.Txn.Clone()
 		txn.Writing = true
 		pErr := roachpb.NewError(roachpb.NewTransactionRetryError())
-		pErr.Txn = txn
+		pErr.SetTxn(txn)
 		return nil, pErr
 	}), clock, false, nil, stopper)
 	defer stopper.Stop()

--- a/roachpb/errors.pb.go
+++ b/roachpb/errors.pb.go
@@ -123,7 +123,6 @@ func (*ReadWithinUncertaintyIntervalError) ProtoMessage()    {}
 // A TransactionAbortedError indicates that the transaction was
 // aborted by another concurrent transaction.
 type TransactionAbortedError struct {
-	Txn Transaction `protobuf:"bytes,1,opt,name=txn" json:"txn"`
 }
 
 func (m *TransactionAbortedError) Reset()         { *m = TransactionAbortedError{} }
@@ -352,7 +351,7 @@ type Error struct {
 	// restarting the transaction (with or without a backoff).
 	TransactionRestart TransactionRestart `protobuf:"varint,3,opt,name=transaction_restart,enum=cockroach.roachpb.TransactionRestart" json:"transaction_restart"`
 	// Transaction where the error is generated.
-	Txn *Transaction `protobuf:"bytes,4,opt,name=txn" json:"txn,omitempty"`
+	UnexposedTxn *Transaction `protobuf:"bytes,4,opt,name=txn" json:"txn,omitempty"`
 	// If an ErrorDetail is present, it may contain additional structured data
 	// about the error.
 	Detail *ErrorDetail `protobuf:"bytes,5,opt,name=detail" json:"detail,omitempty"`
@@ -571,14 +570,6 @@ func (m *TransactionAbortedError) MarshalTo(data []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	data[i] = 0xa
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-	n7, err := m.Txn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n7
 	return i, nil
 }
 
@@ -601,20 +592,20 @@ func (m *TransactionPushError) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-		n8, err := m.Txn.MarshalTo(data[i:])
+		n7, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n8
+		i += n7
 	}
 	data[i] = 0x12
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.PusheeTxn.Size()))
-	n9, err := m.PusheeTxn.MarshalTo(data[i:])
+	n8, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n9
+	i += n8
 	return i, nil
 }
 
@@ -654,11 +645,11 @@ func (m *TransactionStatusError) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-	n10, err := m.Txn.MarshalTo(data[i:])
+	n9, err := m.Txn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n10
+	i += n9
 	data[i] = 0x12
 	i++
 	i = encodeVarintErrors(data, i, uint64(len(m.Msg)))
@@ -722,19 +713,19 @@ func (m *WriteTooOldError) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Timestamp.Size()))
-	n11, err := m.Timestamp.MarshalTo(data[i:])
+	n10, err := m.Timestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n10
+	data[i] = 0x12
+	i++
+	i = encodeVarintErrors(data, i, uint64(m.ExistingTimestamp.Size()))
+	n11, err := m.ExistingTimestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n11
-	data[i] = 0x12
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.ExistingTimestamp.Size()))
-	n12, err := m.ExistingTimestamp.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n12
 	return i, nil
 }
 
@@ -775,11 +766,11 @@ func (m *ConditionFailedError) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ActualValue.Size()))
-		n13, err := m.ActualValue.MarshalTo(data[i:])
+		n12, err := m.ActualValue.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n13
+		i += n12
 	}
 	return i, nil
 }
@@ -806,19 +797,19 @@ func (m *LeaseRejectedError) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.Requested.Size()))
-	n14, err := m.Requested.MarshalTo(data[i:])
+	n13, err := m.Requested.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n13
+	data[i] = 0x1a
+	i++
+	i = encodeVarintErrors(data, i, uint64(m.Existing.Size()))
+	n14, err := m.Existing.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n14
-	data[i] = 0x1a
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.Existing.Size()))
-	n15, err := m.Existing.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n15
 	return i, nil
 }
 
@@ -991,151 +982,151 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.NotLeader.Size()))
-		n16, err := m.NotLeader.MarshalTo(data[i:])
+		n15, err := m.NotLeader.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n16
+		i += n15
 	}
 	if m.RangeNotFound != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.RangeNotFound.Size()))
-		n17, err := m.RangeNotFound.MarshalTo(data[i:])
+		n16, err := m.RangeNotFound.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n17
+		i += n16
 	}
 	if m.RangeKeyMismatch != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.RangeKeyMismatch.Size()))
-		n18, err := m.RangeKeyMismatch.MarshalTo(data[i:])
+		n17, err := m.RangeKeyMismatch.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n18
+		i += n17
 	}
 	if m.ReadWithinUncertaintyInterval != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ReadWithinUncertaintyInterval.Size()))
-		n19, err := m.ReadWithinUncertaintyInterval.MarshalTo(data[i:])
+		n18, err := m.ReadWithinUncertaintyInterval.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n19
+		i += n18
 	}
 	if m.TransactionAborted != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionAborted.Size()))
-		n20, err := m.TransactionAborted.MarshalTo(data[i:])
+		n19, err := m.TransactionAborted.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n20
+		i += n19
 	}
 	if m.TransactionPush != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionPush.Size()))
-		n21, err := m.TransactionPush.MarshalTo(data[i:])
+		n20, err := m.TransactionPush.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n21
+		i += n20
 	}
 	if m.TransactionRetry != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionRetry.Size()))
-		n22, err := m.TransactionRetry.MarshalTo(data[i:])
+		n21, err := m.TransactionRetry.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n22
+		i += n21
 	}
 	if m.TransactionStatus != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.TransactionStatus.Size()))
-		n23, err := m.TransactionStatus.MarshalTo(data[i:])
+		n22, err := m.TransactionStatus.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n23
+		i += n22
 	}
 	if m.WriteIntent != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.WriteIntent.Size()))
-		n24, err := m.WriteIntent.MarshalTo(data[i:])
+		n23, err := m.WriteIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n24
+		i += n23
 	}
 	if m.WriteTooOld != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.WriteTooOld.Size()))
-		n25, err := m.WriteTooOld.MarshalTo(data[i:])
+		n24, err := m.WriteTooOld.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n25
+		i += n24
 	}
 	if m.OpRequiresTxn != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.OpRequiresTxn.Size()))
-		n26, err := m.OpRequiresTxn.MarshalTo(data[i:])
+		n25, err := m.OpRequiresTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n26
+		i += n25
 	}
 	if m.ConditionFailed != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ConditionFailed.Size()))
-		n27, err := m.ConditionFailed.MarshalTo(data[i:])
+		n26, err := m.ConditionFailed.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n27
+		i += n26
 	}
 	if m.LeaseRejected != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.LeaseRejected.Size()))
-		n28, err := m.LeaseRejected.MarshalTo(data[i:])
+		n27, err := m.LeaseRejected.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n28
+		i += n27
 	}
 	if m.NodeUnavailable != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.NodeUnavailable.Size()))
-		n29, err := m.NodeUnavailable.MarshalTo(data[i:])
+		n28, err := m.NodeUnavailable.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n29
+		i += n28
 	}
 	if m.Send != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Send.Size()))
-		n30, err := m.Send.MarshalTo(data[i:])
+		n29, err := m.Send.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n30
+		i += n29
 	}
 	if m.RaftGroupDeleted != nil {
 		data[i] = 0x82
@@ -1143,11 +1134,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.RaftGroupDeleted.Size()))
-		n31, err := m.RaftGroupDeleted.MarshalTo(data[i:])
+		n30, err := m.RaftGroupDeleted.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n31
+		i += n30
 	}
 	if m.ReplicaCorruption != nil {
 		data[i] = 0x8a
@@ -1155,11 +1146,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ReplicaCorruption.Size()))
-		n32, err := m.ReplicaCorruption.MarshalTo(data[i:])
+		n31, err := m.ReplicaCorruption.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n32
+		i += n31
 	}
 	if m.LeaseVersionChanged != nil {
 		data[i] = 0x92
@@ -1167,11 +1158,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.LeaseVersionChanged.Size()))
-		n33, err := m.LeaseVersionChanged.MarshalTo(data[i:])
+		n32, err := m.LeaseVersionChanged.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n33
+		i += n32
 	}
 	if m.DidntUpdateDescriptor != nil {
 		data[i] = 0x9a
@@ -1179,11 +1170,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.DidntUpdateDescriptor.Size()))
-		n34, err := m.DidntUpdateDescriptor.MarshalTo(data[i:])
+		n33, err := m.DidntUpdateDescriptor.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n34
+		i += n33
 	}
 	if m.SqlTranasctionAborted != nil {
 		data[i] = 0xa2
@@ -1191,11 +1182,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.SqlTranasctionAborted.Size()))
-		n35, err := m.SqlTranasctionAborted.MarshalTo(data[i:])
+		n34, err := m.SqlTranasctionAborted.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n35
+		i += n34
 	}
 	if m.ExistingSchemeChangeLease != nil {
 		data[i] = 0xaa
@@ -1203,11 +1194,11 @@ func (m *ErrorDetail) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.ExistingSchemeChangeLease.Size()))
-		n36, err := m.ExistingSchemeChangeLease.MarshalTo(data[i:])
+		n35, err := m.ExistingSchemeChangeLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n36
+		i += n35
 	}
 	return i, nil
 }
@@ -1263,35 +1254,35 @@ func (m *Error) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x18
 	i++
 	i = encodeVarintErrors(data, i, uint64(m.TransactionRestart))
-	if m.Txn != nil {
+	if m.UnexposedTxn != nil {
 		data[i] = 0x22
 		i++
-		i = encodeVarintErrors(data, i, uint64(m.Txn.Size()))
-		n37, err := m.Txn.MarshalTo(data[i:])
+		i = encodeVarintErrors(data, i, uint64(m.UnexposedTxn.Size()))
+		n36, err := m.UnexposedTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n37
+		i += n36
 	}
 	if m.Detail != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Detail.Size()))
-		n38, err := m.Detail.MarshalTo(data[i:])
+		n37, err := m.Detail.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n38
+		i += n37
 	}
 	if m.Index != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Index.Size()))
-		n39, err := m.Index.MarshalTo(data[i:])
+		n38, err := m.Index.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n39
+		i += n38
 	}
 	return i, nil
 }
@@ -1385,8 +1376,6 @@ func (m *ReadWithinUncertaintyIntervalError) Size() (n int) {
 func (m *TransactionAbortedError) Size() (n int) {
 	var l int
 	_ = l
-	l = m.Txn.Size()
-	n += 1 + l + sovErrors(uint64(l))
 	return n
 }
 
@@ -1621,8 +1610,8 @@ func (m *Error) Size() (n int) {
 	n += 1 + l + sovErrors(uint64(l))
 	n += 2
 	n += 1 + sovErrors(uint64(m.TransactionRestart))
-	if m.Txn != nil {
-		l = m.Txn.Size()
+	if m.UnexposedTxn != nil {
+		l = m.UnexposedTxn.Size()
 		n += 1 + l + sovErrors(uint64(l))
 	}
 	if m.Detail != nil {
@@ -2352,36 +2341,6 @@ func (m *TransactionAbortedError) Unmarshal(data []byte) error {
 			return fmt.Errorf("proto: TransactionAbortedError: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Txn", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowErrors
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthErrors
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.Txn.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipErrors(data[iNdEx:])
@@ -4517,7 +4476,7 @@ func (m *Error) Unmarshal(data []byte) error {
 			}
 		case 4:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Txn", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field UnexposedTxn", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -4541,10 +4500,10 @@ func (m *Error) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Txn == nil {
-				m.Txn = &Transaction{}
+			if m.UnexposedTxn == nil {
+				m.UnexposedTxn = &Transaction{}
 			}
-			if err := m.Txn.Unmarshal(data[iNdEx:postIndex]); err != nil {
+			if err := m.UnexposedTxn.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/roachpb/errors.proto
+++ b/roachpb/errors.proto
@@ -72,7 +72,6 @@ message ReadWithinUncertaintyIntervalError {
 // A TransactionAbortedError indicates that the transaction was
 // aborted by another concurrent transaction.
 message TransactionAbortedError {
-  optional Transaction txn = 1 [(gogoproto.nullable) = false];
 }
 
 // A TransactionPushError indicates that the transaction could not
@@ -253,7 +252,7 @@ message Error {
   optional TransactionRestart transaction_restart = 3 [(gogoproto.nullable) = false];
 
   // Transaction where the error is generated.
-  optional Transaction txn = 4;
+  optional Transaction txn = 4 [(gogoproto.customname) = "UnexposedTxn"];
 
   // If an ErrorDetail is present, it may contain additional structured data
   // about the error.

--- a/roachpb/errors_test.go
+++ b/roachpb/errors_test.go
@@ -1,0 +1,32 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Kenji Kaneda (kenji.kaneda@gmail.com)
+
+package roachpb
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSetTxn vefifies that SetTxn updates the error message.
+func TestSetTxn(t *testing.T) {
+	e := NewError(NewTransactionAbortedError())
+	txn := NewTransaction("test", Key("a"), 1, SERIALIZABLE, Timestamp{}, 0)
+	e.SetTxn(txn)
+	if !strings.HasPrefix(e.Message, "txn aborted \"test\"") {
+		t.Errorf("unexpected message: %s", e.Message)
+	}
+}

--- a/storage/engine/rocksdb/cockroach/roachpb/errors.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/errors.pb.cc
@@ -188,7 +188,6 @@ void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto() {
       -1);
   TransactionAbortedError_descriptor_ = file->message_type(5);
   static const int TransactionAbortedError_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TransactionAbortedError, txn_),
   };
   TransactionAbortedError_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -643,80 +642,79 @@ void protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto() {
     "oach.roachpb.TimestampB\004\310\336\037\000\022)\n\007node_id\030"
     "\003 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\372\336\037\006NodeID\0221\n\003txn\030\004"
     " \001(\0132\036.cockroach.roachpb.TransactionB\004\310\336"
-    "\037\000\"L\n\027TransactionAbortedError\0221\n\003txn\030\001 \001"
-    "(\0132\036.cockroach.roachpb.TransactionB\004\310\336\037\000"
-    "\"}\n\024TransactionPushError\022+\n\003txn\030\001 \001(\0132\036."
-    "cockroach.roachpb.Transaction\0228\n\npushee_"
-    "txn\030\002 \001(\0132\036.cockroach.roachpb.Transactio"
-    "nB\004\310\336\037\000\"\027\n\025TransactionRetryError\"^\n\026Tran"
-    "sactionStatusError\0221\n\003txn\030\001 \001(\0132\036.cockro"
-    "ach.roachpb.TransactionB\004\310\336\037\000\022\021\n\003msg\030\002 \001"
-    "(\tB\004\310\336\037\000\"\\\n\020WriteIntentError\0220\n\007intents\030"
-    "\001 \003(\0132\031.cockroach.roachpb.IntentB\004\310\336\037\000\022\026"
-    "\n\010resolved\030\002 \001(\010B\004\310\336\037\000\"\211\001\n\020WriteTooOldEr"
-    "ror\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach.roach"
-    "pb.TimestampB\004\310\336\037\000\022>\n\022existing_timestamp"
-    "\030\002 \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336"
-    "\037\000\"\024\n\022OpRequiresTxnError\"F\n\024ConditionFai"
-    "ledError\022.\n\014actual_value\030\001 \001(\0132\030.cockroa"
-    "ch.roachpb.Value\"\220\001\n\022LeaseRejectedError\022"
-    "\025\n\007message\030\001 \001(\tB\004\310\336\037\000\0221\n\trequested\030\002 \001("
-    "\0132\030.cockroach.roachpb.LeaseB\004\310\336\037\000\0220\n\010exi"
-    "sting\030\003 \001(\0132\030.cockroach.roachpb.LeaseB\004\310"
-    "\336\037\000\";\n\tSendError\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022"
-    "\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\"\027\n\025RaftGroupDel"
-    "etedError\"J\n\026ReplicaCorruptionError\022\027\n\te"
-    "rror_msg\030\001 \001(\tB\004\310\336\037\000\022\027\n\tprocessed\030\002 \001(\010B"
-    "\004\310\336\037\000\"\032\n\030LeaseVersionChangedError\"\034\n\032Did"
-    "ntUpdateDescriptorError\"\034\n\032SqlTransactio"
-    "nAbortedError\" \n\036ExistingSchemaChangeLea"
-    "seError\"\303\013\n\013ErrorDetail\0225\n\nnot_leader\030\001 "
-    "\001(\0132!.cockroach.roachpb.NotLeaderError\022>"
-    "\n\017range_not_found\030\002 \001(\0132%.cockroach.roac"
-    "hpb.RangeNotFoundError\022D\n\022range_key_mism"
-    "atch\030\003 \001(\0132(.cockroach.roachpb.RangeKeyM"
-    "ismatchError\022_\n read_within_uncertainty_"
-    "interval\030\004 \001(\01325.cockroach.roachpb.ReadW"
-    "ithinUncertaintyIntervalError\022G\n\023transac"
-    "tion_aborted\030\005 \001(\0132*.cockroach.roachpb.T"
-    "ransactionAbortedError\022A\n\020transaction_pu"
-    "sh\030\006 \001(\0132\'.cockroach.roachpb.Transaction"
-    "PushError\022C\n\021transaction_retry\030\007 \001(\0132(.c"
-    "ockroach.roachpb.TransactionRetryError\022E"
-    "\n\022transaction_status\030\010 \001(\0132).cockroach.r"
-    "oachpb.TransactionStatusError\0229\n\014write_i"
-    "ntent\030\t \001(\0132#.cockroach.roachpb.WriteInt"
-    "entError\022:\n\rwrite_too_old\030\n \001(\0132#.cockro"
-    "ach.roachpb.WriteTooOldError\022>\n\017op_requi"
-    "res_txn\030\013 \001(\0132%.cockroach.roachpb.OpRequ"
-    "iresTxnError\022A\n\020condition_failed\030\014 \001(\0132\'"
-    ".cockroach.roachpb.ConditionFailedError\022"
-    "=\n\016lease_rejected\030\r \001(\0132%.cockroach.roac"
-    "hpb.LeaseRejectedError\022A\n\020node_unavailab"
-    "le\030\016 \001(\0132\'.cockroach.roachpb.NodeUnavail"
-    "ableError\022*\n\004send\030\017 \001(\0132\034.cockroach.roac"
-    "hpb.SendError\022D\n\022raft_group_deleted\030\020 \001("
-    "\0132(.cockroach.roachpb.RaftGroupDeletedEr"
-    "ror\022E\n\022replica_corruption\030\021 \001(\0132).cockro"
-    "ach.roachpb.ReplicaCorruptionError\022J\n\025le"
-    "ase_version_changed\030\022 \001(\0132+.cockroach.ro"
-    "achpb.LeaseVersionChangedError\022N\n\027didnt_"
-    "update_descriptor\030\023 \001(\0132-.cockroach.roac"
-    "hpb.DidntUpdateDescriptorError\022N\n\027sql_tr"
-    "anasction_aborted\030\024 \001(\0132-.cockroach.roac"
-    "hpb.SqlTransactionAbortedError\022W\n\034existi"
-    "ng_scheme_change_lease\030\025 \001(\01321.cockroach"
-    ".roachpb.ExistingSchemaChangeLeaseError:"
-    "\004\310\240\037\001\"\"\n\013ErrPosition\022\023\n\005index\030\001 \001(\005B\004\310\336\037"
-    "\000\"\223\002\n\005Error\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tre"
-    "tryable\030\002 \001(\010B\004\310\336\037\000\022H\n\023transaction_resta"
-    "rt\030\003 \001(\0162%.cockroach.roachpb.Transaction"
-    "RestartB\004\310\336\037\000\022+\n\003txn\030\004 \001(\0132\036.cockroach.r"
-    "oachpb.Transaction\022.\n\006detail\030\005 \001(\0132\036.coc"
-    "kroach.roachpb.ErrorDetail\022-\n\005index\030\006 \001("
-    "\0132\036.cockroach.roachpb.ErrPosition:\004\230\240\037\000*"
-    ";\n\022TransactionRestart\022\t\n\005ABORT\020\000\022\013\n\007BACK"
-    "OFF\020\001\022\r\n\tIMMEDIATE\020\002B\tZ\007roachpbX\002", 3753);
+    "\037\000\"\031\n\027TransactionAbortedError\"}\n\024Transac"
+    "tionPushError\022+\n\003txn\030\001 \001(\0132\036.cockroach.r"
+    "oachpb.Transaction\0228\n\npushee_txn\030\002 \001(\0132\036"
+    ".cockroach.roachpb.TransactionB\004\310\336\037\000\"\027\n\025"
+    "TransactionRetryError\"^\n\026TransactionStat"
+    "usError\0221\n\003txn\030\001 \001(\0132\036.cockroach.roachpb"
+    ".TransactionB\004\310\336\037\000\022\021\n\003msg\030\002 \001(\tB\004\310\336\037\000\"\\\n"
+    "\020WriteIntentError\0220\n\007intents\030\001 \003(\0132\031.coc"
+    "kroach.roachpb.IntentB\004\310\336\037\000\022\026\n\010resolved\030"
+    "\002 \001(\010B\004\310\336\037\000\"\211\001\n\020WriteTooOldError\0225\n\ttime"
+    "stamp\030\001 \001(\0132\034.cockroach.roachpb.Timestam"
+    "pB\004\310\336\037\000\022>\n\022existing_timestamp\030\002 \001(\0132\034.co"
+    "ckroach.roachpb.TimestampB\004\310\336\037\000\"\024\n\022OpReq"
+    "uiresTxnError\"F\n\024ConditionFailedError\022.\n"
+    "\014actual_value\030\001 \001(\0132\030.cockroach.roachpb."
+    "Value\"\220\001\n\022LeaseRejectedError\022\025\n\007message\030"
+    "\001 \001(\tB\004\310\336\037\000\0221\n\trequested\030\002 \001(\0132\030.cockroa"
+    "ch.roachpb.LeaseB\004\310\336\037\000\0220\n\010existing\030\003 \001(\013"
+    "2\030.cockroach.roachpb.LeaseB\004\310\336\037\000\";\n\tSend"
+    "Error\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryabl"
+    "e\030\002 \001(\010B\004\310\336\037\000\"\027\n\025RaftGroupDeletedError\"J"
+    "\n\026ReplicaCorruptionError\022\027\n\terror_msg\030\001 "
+    "\001(\tB\004\310\336\037\000\022\027\n\tprocessed\030\002 \001(\010B\004\310\336\037\000\"\032\n\030Le"
+    "aseVersionChangedError\"\034\n\032DidntUpdateDes"
+    "criptorError\"\034\n\032SqlTransactionAbortedErr"
+    "or\" \n\036ExistingSchemaChangeLeaseError\"\303\013\n"
+    "\013ErrorDetail\0225\n\nnot_leader\030\001 \001(\0132!.cockr"
+    "oach.roachpb.NotLeaderError\022>\n\017range_not"
+    "_found\030\002 \001(\0132%.cockroach.roachpb.RangeNo"
+    "tFoundError\022D\n\022range_key_mismatch\030\003 \001(\0132"
+    "(.cockroach.roachpb.RangeKeyMismatchErro"
+    "r\022_\n read_within_uncertainty_interval\030\004 "
+    "\001(\01325.cockroach.roachpb.ReadWithinUncert"
+    "aintyIntervalError\022G\n\023transaction_aborte"
+    "d\030\005 \001(\0132*.cockroach.roachpb.TransactionA"
+    "bortedError\022A\n\020transaction_push\030\006 \001(\0132\'."
+    "cockroach.roachpb.TransactionPushError\022C"
+    "\n\021transaction_retry\030\007 \001(\0132(.cockroach.ro"
+    "achpb.TransactionRetryError\022E\n\022transacti"
+    "on_status\030\010 \001(\0132).cockroach.roachpb.Tran"
+    "sactionStatusError\0229\n\014write_intent\030\t \001(\013"
+    "2#.cockroach.roachpb.WriteIntentError\022:\n"
+    "\rwrite_too_old\030\n \001(\0132#.cockroach.roachpb"
+    ".WriteTooOldError\022>\n\017op_requires_txn\030\013 \001"
+    "(\0132%.cockroach.roachpb.OpRequiresTxnErro"
+    "r\022A\n\020condition_failed\030\014 \001(\0132\'.cockroach."
+    "roachpb.ConditionFailedError\022=\n\016lease_re"
+    "jected\030\r \001(\0132%.cockroach.roachpb.LeaseRe"
+    "jectedError\022A\n\020node_unavailable\030\016 \001(\0132\'."
+    "cockroach.roachpb.NodeUnavailableError\022*"
+    "\n\004send\030\017 \001(\0132\034.cockroach.roachpb.SendErr"
+    "or\022D\n\022raft_group_deleted\030\020 \001(\0132(.cockroa"
+    "ch.roachpb.RaftGroupDeletedError\022E\n\022repl"
+    "ica_corruption\030\021 \001(\0132).cockroach.roachpb"
+    ".ReplicaCorruptionError\022J\n\025lease_version"
+    "_changed\030\022 \001(\0132+.cockroach.roachpb.Lease"
+    "VersionChangedError\022N\n\027didnt_update_desc"
+    "riptor\030\023 \001(\0132-.cockroach.roachpb.DidntUp"
+    "dateDescriptorError\022N\n\027sql_tranasction_a"
+    "borted\030\024 \001(\0132-.cockroach.roachpb.SqlTran"
+    "sactionAbortedError\022W\n\034existing_scheme_c"
+    "hange_lease\030\025 \001(\01321.cockroach.roachpb.Ex"
+    "istingSchemaChangeLeaseError:\004\310\240\037\001\"\"\n\013Er"
+    "rPosition\022\023\n\005index\030\001 \001(\005B\004\310\336\037\000\"\245\002\n\005Error"
+    "\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\tretryable\030\002 \001"
+    "(\010B\004\310\336\037\000\022H\n\023transaction_restart\030\003 \001(\0162%."
+    "cockroach.roachpb.TransactionRestartB\004\310\336"
+    "\037\000\022=\n\003txn\030\004 \001(\0132\036.cockroach.roachpb.Tran"
+    "sactionB\020\342\336\037\014UnexposedTxn\022.\n\006detail\030\005 \001("
+    "\0132\036.cockroach.roachpb.ErrorDetail\022-\n\005ind"
+    "ex\030\006 \001(\0132\036.cockroach.roachpb.ErrPosition"
+    ":\004\230\240\037\000*;\n\022TransactionRestart\022\t\n\005ABORT\020\000\022"
+    "\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\tZ\007roachpbX\002", 3720);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/errors.proto", &protobuf_RegisterTypes);
   NotLeaderError::default_instance_ = new NotLeaderError();
@@ -2696,7 +2694,6 @@ void ReadWithinUncertaintyIntervalError::set_allocated_txn(::cockroach::roachpb:
 // ===================================================================
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int TransactionAbortedError::kTxnFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 TransactionAbortedError::TransactionAbortedError()
@@ -2706,7 +2703,6 @@ TransactionAbortedError::TransactionAbortedError()
 }
 
 void TransactionAbortedError::InitAsDefaultInstance() {
-  txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
 }
 
 TransactionAbortedError::TransactionAbortedError(const TransactionAbortedError& from)
@@ -2719,7 +2715,6 @@ TransactionAbortedError::TransactionAbortedError(const TransactionAbortedError& 
 
 void TransactionAbortedError::SharedCtor() {
   _cached_size_ = 0;
-  txn_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -2730,7 +2725,6 @@ TransactionAbortedError::~TransactionAbortedError() {
 
 void TransactionAbortedError::SharedDtor() {
   if (this != default_instance_) {
-    delete txn_;
   }
 }
 
@@ -2760,9 +2754,6 @@ TransactionAbortedError* TransactionAbortedError::New(::google::protobuf::Arena*
 }
 
 void TransactionAbortedError::Clear() {
-  if (has_txn()) {
-    if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
-  }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
@@ -2778,31 +2769,14 @@ bool TransactionAbortedError::MergePartialFromCodedStream(
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
     tag = p.first;
     if (!p.second) goto handle_unusual;
-    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.roachpb.Transaction txn = 1;
-      case 1: {
-        if (tag == 10) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_txn()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectAtEnd()) goto success;
-        break;
-      }
-
-      default: {
-      handle_unusual:
-        if (tag == 0 ||
-            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
-            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
-          goto success;
-        }
-        DO_(::google::protobuf::internal::WireFormat::SkipField(
-              input, tag, mutable_unknown_fields()));
-        break;
-      }
+  handle_unusual:
+    if (tag == 0 ||
+        ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+        ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+      goto success;
     }
+    DO_(::google::protobuf::internal::WireFormat::SkipField(
+          input, tag, mutable_unknown_fields()));
   }
 success:
   // @@protoc_insertion_point(parse_success:cockroach.roachpb.TransactionAbortedError)
@@ -2816,12 +2790,6 @@ failure:
 void TransactionAbortedError::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.roachpb.TransactionAbortedError)
-  // optional .cockroach.roachpb.Transaction txn = 1;
-  if (has_txn()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->txn_, output);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -2832,13 +2800,6 @@ void TransactionAbortedError::SerializeWithCachedSizes(
 ::google::protobuf::uint8* TransactionAbortedError::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.TransactionAbortedError)
-  // optional .cockroach.roachpb.Transaction txn = 1;
-  if (has_txn()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        1, *this->txn_, target);
-  }
-
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -2849,13 +2810,6 @@ void TransactionAbortedError::SerializeWithCachedSizes(
 
 int TransactionAbortedError::ByteSize() const {
   int total_size = 0;
-
-  // optional .cockroach.roachpb.Transaction txn = 1;
-  if (has_txn()) {
-    total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        *this->txn_);
-  }
 
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
@@ -2882,11 +2836,6 @@ void TransactionAbortedError::MergeFrom(const ::google::protobuf::Message& from)
 
 void TransactionAbortedError::MergeFrom(const TransactionAbortedError& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_txn()) {
-      mutable_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.txn());
-    }
-  }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
   }
@@ -2914,8 +2863,6 @@ void TransactionAbortedError::Swap(TransactionAbortedError* other) {
   InternalSwap(other);
 }
 void TransactionAbortedError::InternalSwap(TransactionAbortedError* other) {
-  std::swap(txn_, other->txn_);
-  std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
 }
@@ -2930,49 +2877,6 @@ void TransactionAbortedError::InternalSwap(TransactionAbortedError* other) {
 
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // TransactionAbortedError
-
-// optional .cockroach.roachpb.Transaction txn = 1;
-bool TransactionAbortedError::has_txn() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-void TransactionAbortedError::set_has_txn() {
-  _has_bits_[0] |= 0x00000001u;
-}
-void TransactionAbortedError::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-void TransactionAbortedError::clear_txn() {
-  if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
-  clear_has_txn();
-}
-const ::cockroach::roachpb::Transaction& TransactionAbortedError::txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.TransactionAbortedError.txn)
-  return txn_ != NULL ? *txn_ : *default_instance_->txn_;
-}
-::cockroach::roachpb::Transaction* TransactionAbortedError::mutable_txn() {
-  set_has_txn();
-  if (txn_ == NULL) {
-    txn_ = new ::cockroach::roachpb::Transaction;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.TransactionAbortedError.txn)
-  return txn_;
-}
-::cockroach::roachpb::Transaction* TransactionAbortedError::release_txn() {
-  clear_has_txn();
-  ::cockroach::roachpb::Transaction* temp = txn_;
-  txn_ = NULL;
-  return temp;
-}
-void TransactionAbortedError::set_allocated_txn(::cockroach::roachpb::Transaction* txn) {
-  delete txn_;
-  txn_ = txn;
-  if (txn) {
-    set_has_txn();
-  } else {
-    clear_has_txn();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.TransactionAbortedError.txn)
-}
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 

--- a/storage/engine/rocksdb/cockroach/roachpb/errors.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/errors.pb.h
@@ -679,24 +679,12 @@ class TransactionAbortedError : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.roachpb.Transaction txn = 1;
-  bool has_txn() const;
-  void clear_txn();
-  static const int kTxnFieldNumber = 1;
-  const ::cockroach::roachpb::Transaction& txn() const;
-  ::cockroach::roachpb::Transaction* mutable_txn();
-  ::cockroach::roachpb::Transaction* release_txn();
-  void set_allocated_txn(::cockroach::roachpb::Transaction* txn);
-
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.TransactionAbortedError)
  private:
-  inline void set_has_txn();
-  inline void clear_has_txn();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::roachpb::Transaction* txn_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
@@ -3121,49 +3109,6 @@ inline void ReadWithinUncertaintyIntervalError::set_allocated_txn(::cockroach::r
 // -------------------------------------------------------------------
 
 // TransactionAbortedError
-
-// optional .cockroach.roachpb.Transaction txn = 1;
-inline bool TransactionAbortedError::has_txn() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-inline void TransactionAbortedError::set_has_txn() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void TransactionAbortedError::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-inline void TransactionAbortedError::clear_txn() {
-  if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
-  clear_has_txn();
-}
-inline const ::cockroach::roachpb::Transaction& TransactionAbortedError::txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.TransactionAbortedError.txn)
-  return txn_ != NULL ? *txn_ : *default_instance_->txn_;
-}
-inline ::cockroach::roachpb::Transaction* TransactionAbortedError::mutable_txn() {
-  set_has_txn();
-  if (txn_ == NULL) {
-    txn_ = new ::cockroach::roachpb::Transaction;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.TransactionAbortedError.txn)
-  return txn_;
-}
-inline ::cockroach::roachpb::Transaction* TransactionAbortedError::release_txn() {
-  clear_has_txn();
-  ::cockroach::roachpb::Transaction* temp = txn_;
-  txn_ = NULL;
-  return temp;
-}
-inline void TransactionAbortedError::set_allocated_txn(::cockroach::roachpb::Transaction* txn) {
-  delete txn_;
-  txn_ = txn;
-  if (txn) {
-    set_has_txn();
-  } else {
-    clear_has_txn();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.TransactionAbortedError.txn)
-}
 
 // -------------------------------------------------------------------
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2265,8 +2265,8 @@ func TestSequenceCacheError(t *testing.T) {
 	if _, ok := pErr.GoError().(*roachpb.TransactionRetryError); ok {
 		expected := txn.Clone()
 		expected.Timestamp = ts
-		if pErr.Txn == nil || !reflect.DeepEqual(pErr.Txn, expected) {
-			t.Errorf("txn does not match: %s v.s. %s", pErr.Txn, expected)
+		if pErr.GetTxn() == nil || !reflect.DeepEqual(pErr.GetTxn(), expected) {
+			t.Errorf("txn does not match: %s v.s. %s", pErr.GetTxn(), expected)
 		}
 	} else {
 		t.Errorf("unexpected error: %s", pErr)
@@ -2278,9 +2278,11 @@ func TestSequenceCacheError(t *testing.T) {
 	}
 
 	pErr = tc.rng.checkSequenceCache(tc.engine, txn)
-	if err, ok := pErr.GoError().(*roachpb.TransactionAbortedError); ok {
-		if pErr.Txn == nil || !reflect.DeepEqual(pErr.Txn, &err.Txn) {
-			t.Errorf("txn does not match: %s v.s. %s", pErr.Txn, err.Txn)
+	if _, ok := pErr.GoError().(*roachpb.TransactionAbortedError); ok {
+		expected := txn.Clone()
+		expected.Timestamp = ts
+		if pErr.GetTxn() == nil || !reflect.DeepEqual(pErr.GetTxn(), expected) {
+			t.Errorf("txn does not match: %s v.s. %s", pErr.GetTxn(), expected)
 		}
 	} else {
 		t.Errorf("unexpected error: %s", pErr)

--- a/storage/store.go
+++ b/storage/store.go
@@ -1366,7 +1366,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 	trace.Event("store retry limit exceeded") // good to check for if tests fail
 	if ba.Txn != nil {
 		pErr := roachpb.NewError(roachpb.NewTransactionRetryError())
-		pErr.Txn = ba.Txn
+		pErr.SetTxn(ba.Txn)
 		return nil, pErr
 	}
 	return nil, pErr


### PR DESCRIPTION
Introduce `Error.SetTxn` as we have to reset `Error.Message` when the `Txn`
field is set. Other than that, the change is similar to what we did to `TransactionRetryError`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3952)

<!-- Reviewable:end -->
