### PR TITLE
storage: disable splits when testing merging last range

### DIFF
--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -295,6 +295,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 // fails.
 func TestStoreRangeMergeLastRange(t *testing.T) {
 	defer leaktest.AfterTest(t)
+	defer config.TestingDisableTableSplits()()
 	store, stopper := createTestStore(t)
 	defer stopper.Stop()
 


### PR DESCRIPTION
This previously pitted table splits against the attempt to merge the
last range in the system. Disabling table splits fixes #3928.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3955)

<!-- Reviewable:end -->
