### PR TITLE
storage: fail the test instead of logging

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -570,11 +571,11 @@ func TestSystemConfigGossip(t *testing.T) {
 	}
 
 	// Make sure the returned value is valAt(2).
-	var got sql.DatabaseDescriptor
-	if err := val.GetProto(&got); err != nil {
+	got := new(sql.DatabaseDescriptor)
+	if err := val.GetProto(got); err != nil {
 		t.Fatal(err)
 	}
-	if got.ID != 2 {
-		t.Fatalf("mismatch: expected %+v, got %+v", valAt(2), got)
+	if expected := valAt(2); !reflect.DeepEqual(got, expected) {
+		t.Fatalf("mismatch: expected %+v, got %+v", *expected, *got)
 	}
 }


### PR DESCRIPTION
Also clean up some usage of `IsTrueWithin` and remove spurious logs.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3961)

<!-- Reviewable:end -->
