### PR TITLE
sql/parser: Add support for Datum.HasNext type trait

### DIFF
--- a/sql/select.go
+++ b/sql/select.go
@@ -625,12 +625,14 @@ func (v *indexInfo) makeConstraints(exprs []parser.Exprs) error {
 							Left:     c.Left,
 							Right:    c.Right,
 						}
-					} else {
+					} else if c.Right.(parser.Datum).HasNext() {
 						*startExpr = &parser.ComparisonExpr{
 							Operator: parser.GE,
 							Left:     c.Left,
 							Right:    c.Right.(parser.Datum).Next(),
 						}
+					} else {
+						*startExpr = c
 					}
 				case parser.LT:
 					if *endDone || (*endExpr != nil) {
@@ -890,7 +892,7 @@ func encodeInclusiveEndValue(
 	needExclusiveKey := false
 	if isLastEndConstraint {
 		if dir == encoding.Ascending {
-			if datum.IsMax() {
+			if datum.IsMax() || !datum.HasNext() {
 				needExclusiveKey = true
 			} else {
 				datum = datum.Next()


### PR DESCRIPTION
In relation to Andrei's [comment](https://github.com/cockroachdb/cockroach/pull/3902#issuecomment-174689848), a `HasNext` method on Datum is needed for Datum that do not have a logical "next" value, much like the `HasPrev` method on Datum was needed for Datum that do not have a logical "previous" value.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3965)

<!-- Reviewable:end -->
