### PR TITLE
Replace pErr.GoError().Error() with pErr.String()

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -154,7 +154,7 @@ type Result struct {
 
 func (r Result) String() string {
 	if r.PErr != nil {
-		return r.PErr.GoError().Error()
+		return r.PErr.String()
 	}
 	var buf bytes.Buffer
 	for i, row := range r.Rows {

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -488,7 +488,7 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 	ds := NewDistSender(ctx, g)
 	put := roachpb.NewPut(roachpb.Key("a"), roachpb.MakeValueFromString("value"))
 	// Fatal error on descriptor lookup, propagated to reply.
-	if _, pErr := client.SendWrapped(ds, nil, put); pErr.GoError().Error() != "fatal boom" {
+	if _, pErr := client.SendWrapped(ds, nil, put); pErr.String() != "fatal boom" {
 		t.Errorf("unexpected error: %s", pErr)
 	}
 	// Retryable error on descriptor lookup, second attempt successful.

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -128,7 +128,7 @@ func (db *testDescriptorDB) assertLookupCount(t *testing.T, expected int, key st
 func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) *roachpb.RangeDescriptor {
 	r, pErr := rc.LookupRangeDescriptor(roachpb.RKey(key), false /* considerIntents */, false /* useReverseScan */)
 	if pErr != nil {
-		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", pErr.GoError().Error())
+		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", pErr)
 	}
 	if !r.ContainsKey(keys.Addr(roachpb.Key(key))) {
 		t.Fatalf("Returned range did not contain key: %s-%s, %s", r.StartKey, r.EndKey, key)

--- a/server/status.go
+++ b/server/status.go
@@ -516,7 +516,7 @@ func (s *statusServer) handleNodesStatus(w http.ResponseWriter, r *http.Request,
 	rows, pErr := s.db.Scan(startKey, endKey, 0)
 	if pErr != nil {
 		log.Error(pErr)
-		http.Error(w, pErr.GoError().Error(), http.StatusInternalServerError)
+		http.Error(w, pErr.String(), http.StatusInternalServerError)
 		return
 	}
 
@@ -545,7 +545,7 @@ func (s *statusServer) handleNodeStatus(w http.ResponseWriter, r *http.Request, 
 	nodeStatus := &status.NodeStatus{}
 	if pErr := s.db.GetProto(key, nodeStatus); pErr != nil {
 		log.Error(pErr)
-		http.Error(w, pErr.GoError().Error(), http.StatusInternalServerError)
+		http.Error(w, pErr.String(), http.StatusInternalServerError)
 		return
 	}
 
@@ -560,7 +560,7 @@ func (s *statusServer) handleStoresStatus(w http.ResponseWriter, r *http.Request
 	rows, pErr := s.db.Scan(startKey, endKey, 0)
 	if pErr != nil {
 		log.Error(pErr)
-		http.Error(w, pErr.GoError().Error(), http.StatusInternalServerError)
+		http.Error(w, pErr.String(), http.StatusInternalServerError)
 		return
 	}
 
@@ -592,7 +592,7 @@ func (s *statusServer) handleStoreStatus(w http.ResponseWriter, r *http.Request,
 	storeStatus := &storage.StoreStatus{}
 	if pErr := s.db.GetProto(key, storeStatus); pErr != nil {
 		log.Error(pErr)
-		http.Error(w, pErr.GoError().Error(), http.StatusInternalServerError)
+		http.Error(w, pErr.String(), http.StatusInternalServerError)
 		return
 	}
 	respondAsJSON(w, r, storeStatus)

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -451,7 +451,7 @@ func makeResultFromError(planMaker *planner, pErr *roachpb.Error) driver.Respons
 			planMaker.txn.Cleanup(pErr)
 		}
 	}
-	errString := pErr.GoError().Error()
+	errString := pErr.String()
 	return driver.Response_Result{Error: &errString}
 }
 

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -344,7 +344,7 @@ func (c *v3Conn) handleParse(buf *readBuffer) error {
 	}
 	cols, pErr := c.executor.StatementResult(c.opts.user, stmt, args)
 	if pErr != nil {
-		return c.sendError(pErr.GoError().Error())
+		return c.sendError(pErr.String())
 	}
 	pq.columns = cols
 	c.preparedStatements[name] = pq

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2771,7 +2771,7 @@ func TestMerge(t *testing.T) {
 		mergeArgs := internalMergeArgs(key, roachpb.MakeValueFromString(str))
 
 		if _, pErr := client.SendWrapped(tc.Sender(), tc.rng.context(), &mergeArgs); pErr != nil {
-			t.Fatalf("unexpected error from Merge: %s", pErr.GoError().Error())
+			t.Fatalf("unexpected error from Merge: %s", pErr)
 		}
 	}
 

--- a/storage/stores_test.go
+++ b/storage/stores_test.go
@@ -118,7 +118,7 @@ func TestStoresGetStore(t *testing.T) {
 		t.Errorf("expected storeID to be %d but was %d",
 			s.Ident.StoreID, store.Ident.StoreID)
 	} else if pErr != nil {
-		t.Errorf("expected no error, instead had err=%s", pErr.GoError().Error())
+		t.Errorf("expected no error, instead had err=%s", pErr)
 	}
 }
 


### PR DESCRIPTION
This is to eliminate the use of `GoError()`. Also, `pErr.Message` includes txn information that `GoError().Error()` doesn't have (for `TransactionRetryError`, etc.).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3970)

<!-- Reviewable:end -->
