### PR TITLE
Ensure that table splits are reenabled before another test can start.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,9 @@ var (
 // that re-enables this splitting.
 func TestingDisableTableSplits() func() {
 	testingLock.Lock()
+	if testingDisableTableSplits {
+		log.Fatal("TestingDisableTableSplits called twice without cleaning up")
+	}
 	testingDisableTableSplits = true
 	testingLock.Unlock()
 	return func() {

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -791,9 +791,7 @@ func TestProgressWithDownNode(t *testing.T) {
 func TestReplicateAddAndRemove(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
-	// Run the test twice, once adding the replacement before removing
-	// the downed node, and once removing the downed node first.
-	for _, addFirst := range []bool{true, false} {
+	testFunc := func(addFirst bool) {
 		mtc := startMultiTestContext(t, 4)
 		defer mtc.Stop()
 
@@ -872,6 +870,10 @@ func TestReplicateAddAndRemove(t *testing.T) {
 			t.Fatalf("expected replica IDs to be %v but got %v", expected, replicaIDsByStore)
 		}
 	}
+	// Run the test twice, once adding the replacement before removing
+	// the downed node, and once removing the downed node first.
+	testFunc(true)
+	testFunc(false)
 }
 
 // TestRaftHeartbeats verifies that coalesced heartbeats are correctly

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -276,8 +276,8 @@ func (m *multiTestContext) Stop() {
 		for _, s := range m.engineStoppers {
 			s.Stop()
 		}
-		close(done)
 		m.reenableTableSplits()
+		close(done)
 	}()
 
 	select {


### PR DESCRIPTION
This is the only potential cause I could find of #3803, in which a table
split occurred in a test that should have disabled them (although I was
never able to reproduce the failure).

Fixes #3803

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3974)

<!-- Reviewable:end -->
