### PR TITLE
sql/parser: benchmark parsing a pgbench-like query

### DIFF
--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -852,3 +852,23 @@ func TestParsePrecedence(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkParse(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		st, pErr := parse(`
+			BEGIN;
+			UPDATE pgbench_accounts SET abalance = abalance + 77 WHERE aid = 5;
+			SELECT abalance FROM pgbench_accounts WHERE aid = 5;
+			INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES (1, 2, 5, 77, CURRENT_TIMESTAMP);
+			END`, Traditional)
+		if pErr != nil {
+			b.Fatal(pErr)
+		}
+		if len(st) != 5 {
+			b.Fatal("parsed wrong number of statements: ", len(st))
+		}
+		if _, ok := st[1].(*Update); !ok {
+			b.Fatalf("unexpected statement type: %T", st[1])
+		}
+	}
+}


### PR DESCRIPTION
name     time/op
Parse-8  42.1µs ± 1%

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3978)

<!-- Reviewable:end -->
