### PR TITLE
Tiny fix: Remove unnecessary call of GoError()

### DIFF
--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -954,9 +954,8 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 	ba.Add(roachpb.NewPut(keys.RangeTreeNodeKey(roachpb.RKey("a")), val).(*roachpb.PutRequest))
 	ba.Add(roachpb.NewPut(keys.RangeTreeNodeKey(roachpb.RKey("b")), val).(*roachpb.PutRequest))
 
-	_, pErr := ds.Send(context.Background(), ba)
-	if err := pErr.GoError(); err != nil {
-		t.Fatal(err)
+	if _, pErr := ds.Send(context.Background(), ba); pErr != nil {
+		t.Fatal(pErr)
 	}
 }
 
@@ -1062,9 +1061,8 @@ func TestSequenceUpdateOnMultiRangeQueryLoop(t *testing.T) {
 	ba.Add(roachpb.NewPut(roachpb.Key("a"), val).(*roachpb.PutRequest))
 	ba.Add(roachpb.NewPut(roachpb.Key("b"), val).(*roachpb.PutRequest))
 
-	_, pErr := ds.Send(context.Background(), ba)
-	if err := pErr.GoError(); err != nil {
-		t.Fatal(err)
+	if _, pErr := ds.Send(context.Background(), ba); pErr != nil {
+		t.Fatal(pErr)
 	}
 }
 
@@ -1174,9 +1172,8 @@ func TestMultiRangeSplitEndTransaction(t *testing.T) {
 		ba.Add(roachpb.NewPut(roachpb.Key(test.put2), val).(*roachpb.PutRequest))
 		ba.Add(&roachpb.EndTransactionRequest{Span: roachpb.Span{Key: test.et}})
 
-		_, pErr := ds.Send(context.Background(), ba)
-		if err := pErr.GoError(); err != nil {
-			t.Fatal(err)
+		if _, pErr := ds.Send(context.Background(), ba); pErr != nil {
+			t.Fatal(pErr)
 		}
 
 		if !reflect.DeepEqual(test.exp, act) {

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -134,7 +134,7 @@ func TestBootstrapCluster(t *testing.T) {
 	// Scan the complete contents of the local database.
 	rows, pErr := localDB.Scan(keys.LocalMax, roachpb.KeyMax, 0)
 	if pErr != nil {
-		t.Fatal(pErr.GoError())
+		t.Fatal(pErr)
 	}
 	var foundKeys keySlice
 	for _, kv := range rows {

--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -43,7 +43,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	dbNameKey := sql.MakeNameMetadataKey(keys.RootNamespaceID, "t")
 	r, pErr := kvDB.Get(dbNameKey)
 	if pErr != nil {
-		t.Fatal(pErr.GoError())
+		t.Fatal(pErr)
 	}
 	if !r.Exists() {
 		t.Fatalf(`database "t" does not exist`)
@@ -51,14 +51,14 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	dbDescKey := sql.MakeDescMetadataKey(sql.ID(r.ValueInt()))
 	desc := &sql.Descriptor{}
 	if pErr := kvDB.GetProto(dbDescKey, desc); pErr != nil {
-		t.Fatal(pErr.GoError())
+		t.Fatal(pErr)
 	}
 	dbDesc := desc.GetDatabase()
 
 	tbNameKey := sql.MakeNameMetadataKey(dbDesc.ID, "kv")
 	gr, pErr := kvDB.Get(tbNameKey)
 	if pErr != nil {
-		t.Fatal(pErr.GoError())
+		t.Fatal(pErr)
 	}
 	if !gr.Exists() {
 		t.Fatalf(`table "kv" does not exist`)
@@ -167,7 +167,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	nameKey := sql.MakeNameMetadataKey(keys.MaxReservedDescID+1, "kv")
 	gr, pErr := kvDB.Get(nameKey)
 	if pErr != nil {
-		t.Fatal(pErr.GoError())
+		t.Fatal(pErr)
 	}
 
 	if !gr.Exists() {
@@ -177,7 +177,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	descKey := sql.MakeDescMetadataKey(sql.ID(gr.ValueInt()))
 	desc := &sql.Descriptor{}
 	if pErr := kvDB.GetProto(descKey, desc); pErr != nil {
-		t.Fatal(pErr.GoError())
+		t.Fatal(pErr)
 	}
 	tableDesc := desc.GetTable()
 
@@ -233,7 +233,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	nameKey := sql.MakeNameMetadataKey(keys.MaxReservedDescID+1, "kv")
 	gr, pErr := kvDB.Get(nameKey)
 	if pErr != nil {
-		t.Fatal(pErr.GoError())
+		t.Fatal(pErr)
 	}
 
 	if !gr.Exists() {
@@ -243,7 +243,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	descKey := sql.MakeDescMetadataKey(sql.ID(gr.ValueInt()))
 	desc := &sql.Descriptor{}
 	if pErr := kvDB.GetProto(descKey, desc); pErr != nil {
-		t.Fatal(pErr.GoError())
+		t.Fatal(pErr)
 	}
 	tableDesc := desc.GetTable()
 


### PR DESCRIPTION
Change `t.Fatal(pErr.GoError())` to `t.Fatal(pErr)`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3982)

<!-- Reviewable:end -->
