### PR TITLE
roachpb: Un-expose Error.SetGoError

### DIFF
--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -333,5 +333,5 @@ func (br *BatchResponse) SetGoError(err error) {
 		return
 	}
 	br.Error = &Error{}
-	br.Error.SetGoError(err)
+	br.Error.setGoError(err)
 }

--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -60,7 +60,7 @@ func NewError(err error) *Error {
 	if intErr, ok := err.(*internalError); ok {
 		*e = *(*Error)(intErr)
 	} else {
-		e.SetGoError(err)
+		e.setGoError(err)
 	}
 	return e
 }
@@ -145,8 +145,8 @@ func (e *Error) GoError() error {
 	return err
 }
 
-// SetGoError sets Error using err.
-func (e *Error) SetGoError(err error) {
+// setGoError sets Error using err.
+func (e *Error) setGoError(err error) {
 	if e.Message != "" {
 		panic("cannot re-use roachpb.Error")
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -328,8 +328,7 @@ func (m *multiTestContext) rpcSend(_ rpc.Options, _ string, addrs []net.Addr,
 			sender := m.senders[nodeIndex]
 			br, pErr = sender.Send(context.Background(), ba)
 		}) {
-			pErr = &roachpb.Error{}
-			pErr.SetGoError(rpc.NewSendError("store is stopped", true))
+			pErr = roachpb.NewError(rpc.NewSendError("store is stopped", true))
 			m.expireLeaderLeases()
 			continue
 		}


### PR DESCRIPTION
Use `NewError()` instead of `SetGoError()` when possible.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3983)

<!-- Reviewable:end -->
