### PR TITLE
sql: return 'tags' identifying SQL commands that are executed

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -92,6 +92,8 @@ type Result struct {
 	Err error
 	// The type of statement that the result is for.
 	Type parser.StatementType
+	// The tag of the statement that the result is for.
+	PGTag string
 	// RowsAffected will be populated if the statement type is "RowsAffected".
 	RowsAffected int
 	// Columns will be populated if the statement type is "Rows". It will contain
@@ -390,7 +392,10 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (Result, 
 			return pErr
 		}
 
-		switch result.Type = stmt.StatementType(); result.Type {
+		result.PGTag = stmt.StatementTag()
+		result.Type = stmt.StatementType()
+
+		switch result.Type {
 		case parser.RowsAffected:
 			for plan.Next() {
 				result.RowsAffected++

--- a/sql/parser/stmt.go
+++ b/sql/parser/stmt.go
@@ -55,106 +55,214 @@ const (
 type Statement interface {
 	fmt.Stringer
 	StatementType() StatementType
+	// StatementTag is a short string identifying the type of statement
+	// (usually a single verb). This is different than the Stringer output,
+	// which is the actual statement (including args).
+	// TODO(dt): Currently tags are always pg-compatible in the future it
+	// might make sense to pass a tag format specifier.
+	StatementTag() string
 }
 
 // StatementType implements the Statement interface.
 func (*AlterTable) StatementType() StatementType { return DDL }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*AlterTable) StatementTag() string { return "ALTER TABLE" }
+
 // StatementType implements the Statement interface.
 func (*BeginTransaction) StatementType() StatementType { return Ack }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*BeginTransaction) StatementTag() string { return "BEGIN" }
 
 // StatementType implements the Statement interface.
 func (*CommitTransaction) StatementType() StatementType { return Ack }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*CommitTransaction) StatementTag() string { return "COMMIT" }
+
 // StatementType implements the Statement interface.
 func (*CreateDatabase) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*CreateDatabase) StatementTag() string { return "CREATE DATABASE" }
 
 // StatementType implements the Statement interface.
 func (*CreateIndex) StatementType() StatementType { return DDL }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*CreateIndex) StatementTag() string { return "CREATE INDEX" }
+
 // StatementType implements the Statement interface.
 func (*CreateTable) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*CreateTable) StatementTag() string { return "CREATE TABLE" }
 
 // StatementType implements the Statement interface.
 func (*Delete) StatementType() StatementType { return RowsAffected }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*Delete) StatementTag() string { return "DELETE" }
+
 // StatementType implements the Statement interface.
 func (*DropDatabase) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*DropDatabase) StatementTag() string { return "DROP DATABASE" }
 
 // StatementType implements the Statement interface.
 func (*DropIndex) StatementType() StatementType { return DDL }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*DropIndex) StatementTag() string { return "DROP INDEX" }
+
 // StatementType implements the Statement interface.
 func (*DropTable) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*DropTable) StatementTag() string { return "DROP TABLE" }
 
 // StatementType implements the Statement interface.
 func (*Explain) StatementType() StatementType { return Rows }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*Explain) StatementTag() string { return "EXPLAIN" }
+
 // StatementType implements the Statement interface.
 func (*Grant) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*Grant) StatementTag() string { return "GRANT" }
 
 // StatementType implements the Statement interface.
 func (*Insert) StatementType() StatementType { return RowsAffected }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*Insert) StatementTag() string { return "INSERT" }
+
 // StatementType implements the Statement interface.
 func (*ParenSelect) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ParenSelect) StatementTag() string { return "SELECT" }
 
 // StatementType implements the Statement interface.
 func (*RenameColumn) StatementType() StatementType { return DDL }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*RenameColumn) StatementTag() string { return "RENAME COLUMN" }
+
 // StatementType implements the Statement interface.
 func (*RenameDatabase) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*RenameDatabase) StatementTag() string { return "RENAME DATABASE" }
 
 // StatementType implements the Statement interface.
 func (*RenameIndex) StatementType() StatementType { return DDL }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*RenameIndex) StatementTag() string { return "RENAME INDEX" }
+
 // StatementType implements the Statement interface.
 func (*RenameTable) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*RenameTable) StatementTag() string { return "RENAME TABLE" }
 
 // StatementType implements the Statement interface.
 func (*Revoke) StatementType() StatementType { return DDL }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*Revoke) StatementTag() string { return "REVOKE" }
+
 // StatementType implements the Statement interface.
 func (*RollbackTransaction) StatementType() StatementType { return Ack }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*RollbackTransaction) StatementTag() string { return "ROLLBACK" }
 
 // StatementType implements the Statement interface.
 func (*Select) StatementType() StatementType { return Rows }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*Select) StatementTag() string { return "SELECT" }
+
 // StatementType implements the Statement interface.
 func (*Set) StatementType() StatementType { return Ack }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*Set) StatementTag() string { return "SET" }
 
 // StatementType implements the Statement interface.
 func (*SetTransaction) StatementType() StatementType { return Ack }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*SetTransaction) StatementTag() string { return "SET TRANSACTION" }
+
 // StatementType implements the Statement interface.
 func (*SetTimeZone) StatementType() StatementType { return Ack }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*SetTimeZone) StatementTag() string { return "SET TIMEZONE" }
 
 // StatementType implements the Statement interface.
 func (*Show) StatementType() StatementType { return Rows }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*Show) StatementTag() string { return "SHOW" }
+
 // StatementType implements the Statement interface.
 func (*ShowColumns) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowColumns) StatementTag() string { return "SHOW COLUMNS" }
 
 // StatementType implements the Statement interface.
 func (*ShowDatabases) StatementType() StatementType { return Rows }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowDatabases) StatementTag() string { return "SHOW DATABASES" }
+
 // StatementType implements the Statement interface.
 func (*ShowGrants) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowGrants) StatementTag() string { return "SHOW GRANTS" }
 
 // StatementType implements the Statement interface.
 func (*ShowIndex) StatementType() StatementType { return Rows }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowIndex) StatementTag() string { return "SHOW INDEX" }
+
 // StatementType implements the Statement interface.
 func (*ShowTables) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowTables) StatementTag() string { return "SHOW TABLES" }
 
 // StatementType implements the Statement interface.
 func (*Truncate) StatementType() StatementType { return Ack }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*Truncate) StatementTag() string { return "TRUNCATE" }
+
 // StatementType implements the Statement interface.
 func (*Update) StatementType() StatementType { return RowsAffected }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*Update) StatementTag() string { return "UPDATE" }
 
 // StatementType implements the Statement interface.
 func (*Union) StatementType() StatementType { return Rows }
 
+// StatementTag returns a short string identifying the type of statement.
+func (*Union) StatementTag() string { return "UNION" }
+
 // StatementType implements the Statement interface.
 func (Values) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (Values) StatementTag() string { return "VALUES" }

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -366,3 +366,74 @@ func TestCmdCompleteVsEmptyStatements(t *testing.T) {
 	t.Fatal("should not get here -- empty result from empty query should panic first")
 	// TODO(dt): clean this up with testify/assert and add tests for less trivial empty queries.
 }
+
+// Unfortunately lib/pq doesn't expose returned command tags directly, but we can test
+// the methods where it depends on their values (Begin, Commit, RowsAffected for INSERTs).
+func TestPGCommandTags(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s := server.StartTestServer(t)
+	defer s.Stop()
+
+	pgUrl, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "", "TestPGCommandTags")
+	defer cleanupFn()
+
+	db, err := sql.Open("postgres", pgUrl.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS testing`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE testing.tags (k INT PRIMARY KEY, v INT)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Begin will error if the returned tag is not BEGIN.
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit also checks the correct tag is returned.
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// lib/pq has a special-case for INSERT (due to oids), so test insert and update statements.
+	res, err := db.Exec("INSERT INTO testing.tags VALUES (1, 1), (2, 2)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if affected != 2 {
+		t.Fatal("unexpected number of rows affected:", affected)
+	}
+
+	res, err = db.Exec("INSERT INTO testing.tags VALUES (3, 3)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	affected, err = res.RowsAffected()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if affected != 1 {
+		t.Fatal("unexpected number of rows affected:", affected)
+	}
+
+	res, err = db.Exec("UPDATE testing.tags SET v = 3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	affected, err = res.RowsAffected()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if affected != 3 {
+		t.Fatal("unexpected number of rows affected:", affected)
+	}
+}


### PR DESCRIPTION
Some clients inspect returned command tags eg lib/pq when starting a transaction,
and will fail if the expected tag is not sent.

Statements return their string tag along with their StatementType,
and Executor includes these its results so that pgwrire can return them to clients.

Fixes #3890

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3984)

<!-- Reviewable:end -->
