### PR TITLE
sql: Decouple sql executor and pgwire from sql/driver

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -31,7 +31,7 @@ func makeColIDtoRowIndex(row planNode, desc *TableDescriptor) (map[ColumnID]int,
 	columns := row.Columns()
 	colIDtoRowIndex := make(map[ColumnID]int, len(columns))
 	for i, column := range columns {
-		col, pErr := desc.FindActiveColumnByName(column.name)
+		col, pErr := desc.FindActiveColumnByName(column.Name)
 		if pErr != nil {
 			return nil, pErr
 		}

--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -142,7 +142,7 @@ func (n *distinctNode) ExplainPlan() (string, string, []planNode) {
 		strs := make([]string, 0, len(columns))
 		for i, column := range columns {
 			if n.columnsInOrder[i] {
-				strs = append(strs, column.name)
+				strs = append(strs, column.Name)
 			}
 		}
 		description = strings.Join(strs, ",")

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -62,6 +62,60 @@ var plannerPool = sync.Pool{
 	},
 }
 
+// Request is an SQL request to cockroach. A transaction can consist of multiple
+// requests.
+type Request struct {
+	// User is the originating user.
+	User string
+	// Session settings that were returned in the last response that
+	// contained them, being reflected back to the server.
+	Session []byte
+	// SQL statement(s) to be serially executed by the server. Multiple
+	// statements are passed as a single string separated by semicolons.
+	SQL string
+	// Parameters referred to in the above SQL statement(s) using "?".
+	Params []parser.Datum
+}
+
+// Response is the reply to an SQL request to cockroach.
+type Response struct {
+	// Setting that should be reflected back in all subsequent requests.
+	// When not set, future requests should continue to use existing settings.
+	Session []byte
+	// The list of results. There is one result object per SQL statement in the
+	// request.
+	Results []Result
+}
+
+// Result corresponds to the execution of a single SQL statement.
+type Result struct {
+	Err error
+	// The type of statement that the result is for.
+	Type parser.StatementType
+	// RowsAffected will be populated if the statement type is "RowsAffected".
+	RowsAffected int
+	// Columns will be populated if the statement type is "Rows". It will contain
+	// the names and types of the columns returned in the result set in the order
+	// specified in the SQL statement. The number of columns will equal the number
+	// of values in each Row.
+	Columns []ResultColumn
+	// Rows will be populated if the statement type is "Rows". It will contain
+	// the result set of the result.
+	// TODO(nvanbenschoten): Can this be streamed from the planNode?
+	Rows []ResultRow
+}
+
+// ResultColumn contains the name and type of a SQL "cell".
+type ResultColumn struct {
+	Name string
+	Typ  parser.Datum
+}
+
+// ResultRow is a collection of values representing a row in a result.
+type ResultRow struct {
+	Values []parser.Datum
+}
+
 // An Executor executes SQL statements.
 type Executor struct {
 	db       client.DB
@@ -130,7 +184,7 @@ func (e *Executor) getSystemConfig() config.SystemConfig {
 }
 
 // StatementResult returns the result types of the given statement(s).
-func (e *Executor) StatementResult(user string, stmt parser.Statement, args parser.MapArgs) ([]*driver.Response_Result_Rows_Column, *roachpb.Error) {
+func (e *Executor) StatementResult(user string, stmt parser.Statement, args parser.MapArgs) ([]ResultColumn, *roachpb.Error) {
 	planMaker := plannerPool.Get().(*planner)
 	defer plannerPool.Put(planMaker)
 
@@ -153,15 +207,10 @@ func (e *Executor) StatementResult(user string, stmt parser.Statement, args pars
 	if err != nil {
 		return nil, err
 	}
-	cols := make([]*driver.Response_Result_Rows_Column, len(plan.Columns()))
-	for i, c := range plan.Columns() {
-		d, err := makeDriverDatum(c.typ)
-		if err != nil {
+	cols := plan.Columns()
+	for _, c := range cols {
+		if err := checkResultDatum(c.Typ); err != nil {
 			return nil, err
-		}
-		cols[i] = &driver.Response_Result_Rows_Column{
-			Name: c.name,
-			Typ:  d,
 		}
 	}
 	return cols, nil
@@ -169,7 +218,7 @@ func (e *Executor) StatementResult(user string, stmt parser.Statement, args pars
 
 // ExecuteStatements executes the given statement(s) and returns a response.
 // On error, the returned integer is an HTTP error code.
-func (e *Executor) ExecuteStatements(user string, session Session, stmts string, params []driver.Datum) (driver.Response, int, error) {
+func (e *Executor) ExecuteStatements(user string, session Session, stmts string, params []parser.Datum) (Response, int, error) {
 	planMaker := plannerPool.Get().(*planner)
 	defer plannerPool.Put(planMaker)
 
@@ -219,7 +268,7 @@ func (e *Executor) ExecuteStatements(user string, session Session, stmts string,
 	}
 	bytes, err := proto.Marshal(&planMaker.session)
 	if err != nil {
-		return driver.Response{}, http.StatusInternalServerError, err
+		return Response{}, http.StatusInternalServerError, err
 	}
 	reply.Session = bytes
 
@@ -228,21 +277,21 @@ func (e *Executor) ExecuteStatements(user string, session Session, stmts string,
 
 // Execute the statement(s) in the given request and returns a response.
 // On error, the returned integer is an HTTP error code.
-func (e *Executor) Execute(args driver.Request) (driver.Response, int, error) {
+func (e *Executor) Execute(args Request) (Response, int, error) {
 	defer func(start time.Time) {
 		e.latency.RecordValue(time.Now().Sub(start).Nanoseconds())
 	}(time.Now())
 	var session Session
 	if err := proto.Unmarshal(args.Session, &session); err != nil {
-		return driver.Response{}, http.StatusBadRequest, err
+		return Response{}, http.StatusBadRequest, err
 	}
-	return e.ExecuteStatements(args.GetUser(), session, args.Sql, args.Params)
+	return e.ExecuteStatements(args.User, session, args.SQL, args.Params)
 }
 
 // exec executes the request. Any error encountered is returned; it is
 // the caller's responsibility to update the response.
-func (e *Executor) execStmts(sql string, planMaker *planner) driver.Response {
-	var resp driver.Response
+func (e *Executor) execStmts(sql string, planMaker *planner) Response {
+	var resp Response
 	stmts, err := planMaker.parser.Parse(sql, parser.Syntax(planMaker.session.Syntax))
 	if err != nil {
 		// A parse error occurred: we can't determine if there were multiple
@@ -294,8 +343,8 @@ func (e *Executor) execStmts(sql string, planMaker *planner) driver.Response {
 	return resp
 }
 
-func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (driver.Response_Result, *roachpb.Error) {
-	var result driver.Response_Result
+func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (Result, *roachpb.Error) {
+	var result Result
 	switch stmt.(type) {
 	case *parser.BeginTransaction:
 		if planMaker.txn != nil {
@@ -341,44 +390,31 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (driver.R
 			return pErr
 		}
 
-		switch stmt.StatementType() {
-		case parser.DDL:
-			result.Union = &driver.Response_Result_DDL_{DDL: &driver.Response_Result_DDL{}}
+		switch result.Type = stmt.StatementType(); result.Type {
 		case parser.RowsAffected:
-			resultRowsAffected := driver.Response_Result_RowsAffected{}
-			result.Union = &resultRowsAffected
 			for plan.Next() {
-				resultRowsAffected.RowsAffected++
+				result.RowsAffected++
 			}
 
 		case parser.Rows:
-			var resultRows driver.Response_Result_Rows
-			for _, column := range plan.Columns() {
-				datum, pErr := makeDriverDatum(column.typ)
-				if pErr != nil {
-					return pErr
+			result.Columns = plan.Columns()
+			for _, c := range result.Columns {
+				if err := checkResultDatum(c.Typ); err != nil {
+					return err
 				}
-
-				resultRows.Columns = append(resultRows.Columns, &driver.Response_Result_Rows_Column{
-					Name: column.name,
-					Typ:  datum,
-				})
 			}
 
-			result.Union = &driver.Response_Result_Rows_{
-				Rows: &resultRows,
-			}
 			for plan.Next() {
+				// The plan.Values DTuple needs to be copied on each iteration.
 				values := plan.Values()
-				row := driver.Response_Result_Rows_Row{Values: make([]driver.Datum, 0, len(values))}
+				row := ResultRow{Values: make([]parser.Datum, 0, len(values))}
 				for _, val := range values {
-					datum, pErr := makeDriverDatum(val)
-					if pErr != nil {
-						return pErr
+					if err := checkResultDatum(val); err != nil {
+						return err
 					}
-					row.Values = append(row.Values, datum)
+					row.Values = append(row.Values, val)
 				}
-				resultRows.Rows = append(resultRows.Rows, row)
+				result.Rows = append(result.Rows, row)
 			}
 		}
 
@@ -445,19 +481,18 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (driver.R
 // If we hit an error and there is a pending transaction, rollback
 // the transaction before returning. The client does not have to
 // deal with cleaning up transaction state.
-func makeResultFromError(planMaker *planner, pErr *roachpb.Error) driver.Response_Result {
+func makeResultFromError(planMaker *planner, pErr *roachpb.Error) Result {
 	if planMaker.txn != nil {
 		if _, ok := pErr.GoError().(*roachpb.SqlTransactionAbortedError); !ok {
 			planMaker.txn.Cleanup(pErr)
 		}
 	}
-	errString := pErr.String()
-	return driver.Response_Result{Error: &errString}
+	return Result{Err: pErr.GoError()}
 }
 
 var _ parser.Args = parameters{}
 
-type parameters []driver.Datum
+type parameters []parser.Datum
 
 var errNamedArgument = errors.New("named arguments are not supported")
 
@@ -488,30 +523,7 @@ func (p parameters) Arg(name string) (parser.Datum, bool) {
 	if i < 1 || int(i) > len(p) {
 		return nil, false
 	}
-	arg := p[i-1].Payload
-	if arg == nil {
-		return parser.DNull, true
-	}
-	switch t := arg.(type) {
-	case *driver.Datum_BoolVal:
-		return parser.DBool(t.BoolVal), true
-	case *driver.Datum_IntVal:
-		return parser.DInt(t.IntVal), true
-	case *driver.Datum_FloatVal:
-		return parser.DFloat(t.FloatVal), true
-	case *driver.Datum_BytesVal:
-		return parser.DBytes(t.BytesVal), true
-	case *driver.Datum_StringVal:
-		return parser.DString(t.StringVal), true
-	case *driver.Datum_DateVal:
-		return parser.DDate(t.DateVal), true
-	case *driver.Datum_TimeVal:
-		return parser.DTimestamp{Time: t.TimeVal.GoTime()}, true
-	case *driver.Datum_IntervalVal:
-		return parser.DInterval{Duration: time.Duration(t.IntervalVal)}, true
-	default:
-		panic(fmt.Sprintf("unexpected type %T", t))
-	}
+	return p[i-1], true
 }
 
 var _ parser.Args = golangParameters{}
@@ -574,48 +586,22 @@ func (gp golangParameters) Arg(name string) (parser.Datum, bool) {
 	panic(fmt.Sprintf("unexpected type %T", arg))
 }
 
-func makeDriverDatum(datum parser.Datum) (driver.Datum, *roachpb.Error) {
+func checkResultDatum(datum parser.Datum) *roachpb.Error {
 	if datum == parser.DNull {
-		return driver.Datum{}, nil
+		return nil
 	}
 
-	switch vt := datum.(type) {
+	switch datum.(type) {
 	case parser.DBool:
-		return driver.Datum{
-			Payload: &driver.Datum_BoolVal{BoolVal: bool(vt)},
-		}, nil
 	case parser.DInt:
-		return driver.Datum{
-			Payload: &driver.Datum_IntVal{IntVal: int64(vt)},
-		}, nil
 	case parser.DFloat:
-		return driver.Datum{
-			Payload: &driver.Datum_FloatVal{FloatVal: float64(vt)},
-		}, nil
 	case parser.DBytes:
-		return driver.Datum{
-			Payload: &driver.Datum_BytesVal{BytesVal: []byte(vt)},
-		}, nil
 	case parser.DString:
-		return driver.Datum{
-			Payload: &driver.Datum_StringVal{StringVal: string(vt)},
-		}, nil
 	case parser.DDate:
-		return driver.Datum{
-			Payload: &driver.Datum_DateVal{DateVal: int64(vt)},
-		}, nil
 	case parser.DTimestamp:
-		wireTimestamp := driver.Timestamp(vt.Time)
-		return driver.Datum{
-			Payload: &driver.Datum_TimeVal{
-				TimeVal: &wireTimestamp,
-			},
-		}, nil
 	case parser.DInterval:
-		return driver.Datum{
-			Payload: &driver.Datum_IntervalVal{IntervalVal: vt.Nanoseconds()},
-		}, nil
 	default:
-		return driver.Datum{}, roachpb.NewUErrorf("unsupported result type: %s", datum.Type())
+		return roachpb.NewUErrorf("unsupported result type: %s", datum.Type())
 	}
+	return nil
 }

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -59,10 +59,10 @@ func (p *planner) Explain(n *parser.Explain) (planNode, *roachpb.Error) {
 		return plan, nil
 	case explainPlan:
 		v := &valuesNode{}
-		v.columns = []resultColumn{
-			{name: "Level", typ: parser.DummyInt},
-			{name: "Type", typ: parser.DummyString},
-			{name: "Description", typ: parser.DummyString},
+		v.columns = []ResultColumn{
+			{Name: "Level", Typ: parser.DummyInt},
+			{Name: "Type", Typ: parser.DummyString},
+			{Name: "Description", Typ: parser.DummyString},
 		}
 		populateExplain(v, plan, 0)
 		plan = v
@@ -79,11 +79,11 @@ func markDebug(plan planNode, mode explainMode) (planNode, *roachpb.Error) {
 
 	case *scanNode:
 		// Mark the node as being explained.
-		t.columns = []resultColumn{
-			{name: "RowIdx", typ: parser.DummyInt},
-			{name: "Key", typ: parser.DummyString},
-			{name: "Value", typ: parser.DummyString},
-			{name: "Output", typ: parser.DummyBool},
+		t.columns = []ResultColumn{
+			{Name: "RowIdx", Typ: parser.DummyInt},
+			{Name: "Key", Typ: parser.DummyString},
+			{Name: "Value", Typ: parser.DummyString},
+			{Name: "Output", Typ: parser.DummyBool},
 		}
 		t.explain = mode
 		return t, nil

--- a/sql/group.go
+++ b/sql/group.go
@@ -205,7 +205,7 @@ type groupNode struct {
 	pErr            *roachpb.Error
 }
 
-func (n *groupNode) Columns() []resultColumn {
+func (n *groupNode) Columns() []ResultColumn {
 	return n.values.Columns()
 }
 

--- a/sql/join.go
+++ b/sql/join.go
@@ -107,7 +107,7 @@ func makeIndexJoin(indexScan *scanNode, exactPrefix int) (*indexJoinNode, *roach
 	}, nil
 }
 
-func (n *indexJoinNode) Columns() []resultColumn {
+func (n *indexJoinNode) Columns() []ResultColumn {
 	return n.table.Columns()
 }
 

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql"
-	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -81,7 +80,7 @@ const (
 type preparedStatement struct {
 	query       string
 	inTypes     []oid.Oid
-	columns     []*driver.Response_Result_Rows_Column
+	columns     []sql.ResultColumn
 	portalNames map[string]struct{}
 }
 
@@ -89,7 +88,7 @@ type preparedStatement struct {
 type preparedPortal struct {
 	stmt       preparedStatement
 	stmtName   string
-	params     []driver.Datum
+	params     []parser.Datum
 	outFormats []formatCode
 }
 
@@ -469,7 +468,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 	if int(numValues) != numParams {
 		return c.sendError(fmt.Sprintf("expected %d parameters, got %d", numParams, numValues))
 	}
-	params := make([]driver.Datum, numParams)
+	params := make([]parser.Datum, numParams)
 	for i, t := range stmt.inTypes {
 		plen, err := buf.getInt32()
 		if err != nil {
@@ -542,7 +541,7 @@ func (c *v3Conn) handleExecute(buf *readBuffer) error {
 	return c.executeStatements(portal.stmt.query, portal.params, portal.outFormats, false)
 }
 
-func (c *v3Conn) executeStatements(stmts string, params []driver.Datum, formatCodes []formatCode, sendDescription bool) error {
+func (c *v3Conn) executeStatements(stmts string, params []parser.Datum, formatCodes []formatCode, sendDescription bool) error {
 	c.session.Database = c.opts.database
 
 	// TODO(dt): this is a clumsy check better left to the actual parser. #3852
@@ -607,20 +606,20 @@ func (c *v3Conn) sendError(errToSend string) error {
 	return c.writeBuf.finishMsg(c.wr)
 }
 
-func (c *v3Conn) sendResponse(resp driver.Response, formatCodes []formatCode, sendDescription bool) error {
+func (c *v3Conn) sendResponse(resp sql.Response, formatCodes []formatCode, sendDescription bool) error {
 	if len(resp.Results) == 0 {
 		return c.sendCommandComplete(nil)
 	}
 	for _, result := range resp.Results {
-		if result.Error != nil {
-			if err := c.sendError(*result.Error); err != nil {
+		if result.Err != nil {
+			if err := c.sendError(result.Err.Error()); err != nil {
 				return err
 			}
 			continue
 		}
 
-		switch result := result.GetUnion().(type) {
-		case *driver.Response_Result_RowsAffected:
+		switch result.Type {
+		case parser.RowsAffected:
 			// Send CommandComplete.
 			// TODO(bdarnell): tags for other types of commands.
 			tag := append(c.tagBuf[:0], "SELECT "...)
@@ -629,17 +628,15 @@ func (c *v3Conn) sendResponse(resp driver.Response, formatCodes []formatCode, se
 				return err
 			}
 
-		case *driver.Response_Result_Rows_:
-			resultRows := result.Rows
-
+		case parser.Rows:
 			if sendDescription {
-				if err := c.sendRowDescription(resultRows.Columns, formatCodes); err != nil {
+				if err := c.sendRowDescription(result.Columns, formatCodes); err != nil {
 					return err
 				}
 			}
 
 			// Send DataRows.
-			for _, row := range resultRows.Rows {
+			for _, row := range result.Rows {
 				c.writeBuf.initMsg(serverMsgDataRow)
 				c.writeBuf.putInt16(int16(len(row.Values)))
 				for i, col := range row.Values {
@@ -668,7 +665,7 @@ func (c *v3Conn) sendResponse(resp driver.Response, formatCodes []formatCode, se
 			// Send CommandComplete.
 			// TODO(bdarnell): tags for other types of commands.
 			tag := append(c.tagBuf[:0], "SELECT "...)
-			tag = appendUint(tag, uint(len(resultRows.Rows)))
+			tag = appendUint(tag, uint(len(result.Rows)))
 			if err := c.sendCommandComplete(tag); err != nil {
 				return err
 			}
@@ -687,12 +684,12 @@ func (c *v3Conn) sendResponse(resp driver.Response, formatCodes []formatCode, se
 	return nil
 }
 
-func (c *v3Conn) sendRowDescription(columns []*driver.Response_Result_Rows_Column, formatCodes []formatCode) error {
+func (c *v3Conn) sendRowDescription(columns []sql.ResultColumn, formatCodes []formatCode) error {
 	c.writeBuf.initMsg(serverMsgRowDescription)
 	c.writeBuf.putInt16(int16(len(columns)))
 	for i, column := range columns {
 		if log.V(2) {
-			log.Infof("pgwire writing column %s of type: %T", column.Name, column.Typ.Payload)
+			log.Infof("pgwire writing column %s of type: %T", column.Name, column.Typ)
 		}
 		if err := c.writeBuf.writeString(column.Name); err != nil {
 			return err

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -238,17 +238,12 @@ func (p *planner) releaseLeases(db client.DB) {
 	}
 }
 
-type resultColumn struct {
-	name string
-	typ  parser.Datum
-}
-
 // planNode defines the interface for executing a query or portion of a query.
 type planNode interface {
 	// Columns returns the column names and types . The length of the
 	// returned slice is guaranteed to be equal to the length of the
 	// tuple returned by Values().
-	Columns() []resultColumn
+	Columns() []ResultColumn
 	// The indexes of the columns the output is ordered by.
 	Ordering() orderingInfo
 	// Values returns the values at the current row. The result is only valid

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -134,8 +134,8 @@ type scanNode struct {
 	visibleCols      []ColumnDescriptor
 	isSecondaryIndex bool
 	reverse          bool
-	columns          []resultColumn
-	originalCols     []resultColumn // copy of `columns` before additions (e.g. by sort or group)
+	columns          []ResultColumn
+	originalCols     []ResultColumn // copy of `columns` before additions (e.g. by sort or group)
 	columnIDs        []ColumnID
 	// The direction with which the corresponding column was encoded.
 	columnDirs       []encoding.Direction
@@ -159,7 +159,7 @@ type scanNode struct {
 	explainValue     parser.Datum
 }
 
-func (n *scanNode) Columns() []resultColumn {
+func (n *scanNode) Columns() []ResultColumn {
 	return n.columns
 }
 
@@ -535,13 +535,13 @@ func (n *scanNode) addRender(target parser.SelectExpr) *roachpb.Error {
 						return n.pErr
 					}
 					qval := n.getQVal(*col)
-					n.columns = append(n.columns, resultColumn{name: col.Name, typ: qval.datum})
+					n.columns = append(n.columns, ResultColumn{Name: col.Name, Typ: qval.datum})
 					n.render = append(n.render, qval)
 				}
 			} else {
 				for _, col := range n.desc.VisibleColumns() {
 					qval := n.getQVal(col)
-					n.columns = append(n.columns, resultColumn{name: col.Name, typ: qval.datum})
+					n.columns = append(n.columns, ResultColumn{Name: col.Name, Typ: qval.datum})
 					n.render = append(n.render, qval)
 				}
 			}
@@ -581,7 +581,7 @@ func (n *scanNode) addRender(target parser.SelectExpr) *roachpb.Error {
 			outputName = t.Column()
 		}
 	}
-	n.columns = append(n.columns, resultColumn{name: outputName, typ: typ})
+	n.columns = append(n.columns, ResultColumn{Name: outputName, Typ: typ})
 	return nil
 }
 

--- a/sql/select.go
+++ b/sql/select.go
@@ -42,7 +42,7 @@ type selectNode struct {
 // For now scanNode implements all the logic and selectNode just proxies the
 // calls.
 
-func (s *selectNode) Columns() []resultColumn {
+func (s *selectNode) Columns() []ResultColumn {
 	return s.from.Columns()
 }
 

--- a/sql/show.go
+++ b/sql/show.go
@@ -30,7 +30,7 @@ import (
 func (p *planner) Show(n *parser.Show) (planNode, *roachpb.Error) {
 	name := strings.ToUpper(n.Name)
 
-	v := &valuesNode{columns: []resultColumn{{name: name, typ: parser.DummyString}}}
+	v := &valuesNode{columns: []ResultColumn{{Name: name, Typ: parser.DummyString}}}
 
 	switch name {
 	case `DATABASE`:
@@ -62,11 +62,11 @@ func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, *roachpb.Error) 
 		return nil, pErr
 	}
 	v := &valuesNode{
-		columns: []resultColumn{
-			{name: "Field", typ: parser.DummyString},
-			{name: "Type", typ: parser.DummyString},
-			{name: "Null", typ: parser.DummyBool},
-			{name: "Default", typ: parser.DummyString},
+		columns: []ResultColumn{
+			{Name: "Field", Typ: parser.DummyString},
+			{Name: "Type", Typ: parser.DummyString},
+			{Name: "Null", Typ: parser.DummyBool},
+			{Name: "Default", Typ: parser.DummyString},
 		},
 	}
 	for i, col := range desc.Columns {
@@ -98,7 +98,7 @@ func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, *roachpb.Err
 	if pErr != nil {
 		return nil, pErr
 	}
-	v := &valuesNode{columns: []resultColumn{{name: "Database", typ: parser.DummyString}}}
+	v := &valuesNode{columns: []ResultColumn{{Name: "Database", Typ: parser.DummyString}}}
 	for _, row := range sr {
 		_, name, err := encoding.DecodeStringAscending(
 			bytes.TrimPrefix(row.Key, prefix), nil)
@@ -130,10 +130,10 @@ func (p *planner) ShowGrants(n *parser.ShowGrants) (planNode, *roachpb.Error) {
 	}
 
 	v := &valuesNode{
-		columns: []resultColumn{
-			{name: objectType, typ: parser.DummyString},
-			{name: "User", typ: parser.DummyString},
-			{name: "Privileges", typ: parser.DummyString},
+		columns: []ResultColumn{
+			{Name: objectType, Typ: parser.DummyString},
+			{Name: "User", Typ: parser.DummyString},
+			{Name: "Privileges", Typ: parser.DummyString},
 		},
 	}
 	var wantedUsers map[string]struct{}
@@ -171,14 +171,14 @@ func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, *roachpb.Error) {
 	}
 
 	v := &valuesNode{
-		columns: []resultColumn{
-			{name: "Table", typ: parser.DummyString},
-			{name: "Name", typ: parser.DummyString},
-			{name: "Unique", typ: parser.DummyBool},
-			{name: "Seq", typ: parser.DummyInt},
-			{name: "Column", typ: parser.DummyString},
-			{name: "Direction", typ: parser.DummyString},
-			{name: "Storing", typ: parser.DummyBool},
+		columns: []ResultColumn{
+			{Name: "Table", Typ: parser.DummyString},
+			{Name: "Name", Typ: parser.DummyString},
+			{Name: "Unique", Typ: parser.DummyBool},
+			{Name: "Seq", Typ: parser.DummyInt},
+			{Name: "Column", Typ: parser.DummyString},
+			{Name: "Direction", Typ: parser.DummyString},
+			{Name: "Storing", Typ: parser.DummyBool},
 		},
 	}
 
@@ -234,7 +234,7 @@ func (p *planner) ShowTables(n *parser.ShowTables) (planNode, *roachpb.Error) {
 	if pErr != nil {
 		return nil, pErr
 	}
-	v := &valuesNode{columns: []resultColumn{{name: "Table", typ: parser.DummyString}}}
+	v := &valuesNode{columns: []ResultColumn{{Name: "Table", Typ: parser.DummyString}}}
 	for _, name := range tableNames {
 		v.rows = append(v.rows, []parser.Datum{parser.DString(name.Table())})
 	}

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -58,7 +58,7 @@ func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, *roachpb.Er
 				//   SELECT a AS b FROM t ORDER BY b
 				target := string(qname.Base)
 				for j, col := range columns {
-					if equalName(target, col.name) {
+					if equalName(target, col.Name) {
 						index = j
 						break
 					}
@@ -118,13 +118,13 @@ func (p *planner) orderBy(n *parser.Select, s *scanNode) (*sortNode, *roachpb.Er
 
 type sortNode struct {
 	plan     planNode
-	columns  []resultColumn
+	columns  []ResultColumn
 	ordering columnOrdering
 	needSort bool
 	pErr     *roachpb.Error
 }
 
-func (n *sortNode) Columns() []resultColumn {
+func (n *sortNode) Columns() []ResultColumn {
 	return n.columns
 }
 
@@ -170,7 +170,7 @@ func (n *sortNode) ExplainPlan() (name, description string, children []planNode)
 		if o.direction == encoding.Descending {
 			prefix = '-'
 		}
-		strs[i] = fmt.Sprintf("%c%s", prefix, columns[o.colIdx].name)
+		strs[i] = fmt.Sprintf("%c%s", prefix, columns[o.colIdx].Name)
 	}
 	description = strings.Join(strs, ",")
 

--- a/sql/values.go
+++ b/sql/values.go
@@ -33,7 +33,7 @@ func (p *planner) Values(n parser.Values) (planNode, *roachpb.Error) {
 
 	for num, tuple := range n {
 		if num == 0 {
-			v.columns = make([]resultColumn, 0, len(tuple))
+			v.columns = make([]ResultColumn, 0, len(tuple))
 		} else if a, e := len(tuple), len(v.columns); a != e {
 			return nil, roachpb.NewUErrorf("VALUES lists must all be the same length, %d for %d", a, e)
 		}
@@ -54,11 +54,11 @@ func (p *planner) Values(n parser.Values) (planNode, *roachpb.Error) {
 				return nil, roachpb.NewError(err)
 			}
 			if num == 0 {
-				v.columns = append(v.columns, resultColumn{name: "column" + strconv.Itoa(i+1), typ: typ})
-			} else if v.columns[i].typ == parser.DNull {
-				v.columns[i].typ = typ
-			} else if typ != parser.DNull && typ != v.columns[i].typ {
-				return nil, roachpb.NewUErrorf("VALUES list type mismatch, %s for %s", typ.Type(), v.columns[i].typ.Type())
+				v.columns = append(v.columns, ResultColumn{Name: "column" + strconv.Itoa(i+1), Typ: typ})
+			} else if v.columns[i].Typ == parser.DNull {
+				v.columns[i].Typ = typ
+			} else if typ != parser.DNull && typ != v.columns[i].Typ {
+				return nil, roachpb.NewUErrorf("VALUES list type mismatch, %s for %s", typ.Type(), v.columns[i].Typ.Type())
 			}
 		}
 		data, err := tuple.Eval(p.evalCtx)
@@ -76,13 +76,13 @@ func (p *planner) Values(n parser.Values) (planNode, *roachpb.Error) {
 }
 
 type valuesNode struct {
-	columns  []resultColumn
+	columns  []ResultColumn
 	ordering columnOrdering
 	rows     []parser.DTuple
 	nextRow  int // The index of the next row.
 }
 
-func (n *valuesNode) Columns() []resultColumn {
+func (n *valuesNode) Columns() []ResultColumn {
 	return n.columns
 }
 


### PR DESCRIPTION
This is the first step in phasing out the internal dependence on the Cockroach `sql/driver` package. It moves a number of protobuf structs to classic Go structs, and moves them into the `sql.Executor`. This had the result of removing a couple of allocation paths.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3987)

<!-- Reviewable:end -->
