### PR TITLE
Expire leader leases at the end of TestRaftAfterRemoveRange

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -668,6 +668,7 @@ func TestStoreRangeDownReplicate(t *testing.T) {
 
 	// Expire leader leases one more time, so that any remaining resolutions can
 	// get a leader lease.
+	// TODO(bdarnell): understand why some tests need this.
 	mtc.expireLeaderLeases()
 }
 
@@ -1075,6 +1076,10 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 	// Execute another replica change to ensure that raft has processed
 	// the heartbeat just sent.
 	mtc.replicateRange(roachpb.RangeID(1), 1)
+
+	// Expire leases to ensure any remaining intent resolutions can complete.
+	// TODO(bdarnell): understand why some tests need this.
+	mtc.expireLeaderLeases()
 }
 
 // TestRaftRemoveRace adds and removes a replica repeatedly in an


### PR DESCRIPTION
Cargo-culted from TestStoreRangeDownReplicate.

Fixes #3930

Also move deadline setting earlier in handleSkippedIntents.

This extends the work begun in #3809 and makes the related deadlocks
even rarer, but does not completely solve the problem.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/3999)

<!-- Reviewable:end -->
