### PR TITLE
Add "trace{on,off}" commands.

### DIFF
--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime/trace"
 	"sort"
 	"strconv"
 	"strings"
@@ -160,6 +161,7 @@ type logicTest struct {
 	db           *sql.DB
 	progress     int
 	lastProgress time.Time
+	traceFile    *os.File
 }
 
 func (t *logicTest) close() {
@@ -432,6 +434,18 @@ SET DATABASE = test;
 				t.Fatalf("unimplemented test statement: %s", s.Text())
 			}
 
+		case "traceon":
+			if len(fields) != 2 {
+				t.Fatalf("traceon requires a filename argument, found: %v", fields)
+			}
+			t.traceStart(fields[1])
+
+		case "traceoff":
+			if t.traceFile == nil {
+				t.Fatalf("no trace active")
+			}
+			t.traceStop()
+
 		default:
 			t.Fatalf("%s:%d: unknown command: %s", path, s.line, cmd)
 		}
@@ -440,6 +454,8 @@ SET DATABASE = test;
 	if err := s.Err(); err != nil {
 		t.Fatal(err)
 	}
+
+	t.traceStop()
 
 	fmt.Printf("%s: %d\n", path, t.progress)
 }
@@ -608,6 +624,28 @@ func (t *logicTest) success(file string) {
 	if now.Sub(t.lastProgress) >= 2*time.Second {
 		t.lastProgress = now
 		fmt.Printf("%s: %d\n", file, t.progress)
+	}
+}
+
+func (t *logicTest) traceStart(filename string) {
+	if t.traceFile != nil {
+		t.Fatalf("tracing already active")
+	}
+	var err error
+	t.traceFile, err = os.Create(filename)
+	if err != nil {
+		t.Fatalf("unable to open trace output file: %s", err)
+	}
+	if err := trace.Start(t.traceFile); err != nil {
+		t.Fatalf("unable to start tracing: %s", err)
+	}
+}
+
+func (t *logicTest) traceStop() {
+	if t.traceFile != nil {
+		trace.Stop()
+		t.traceFile.Close()
+		t.traceFile = nil
 	}
 }
 


### PR DESCRIPTION
This allows tracing to be enabled for individual SQL operations which is
useful for performance analysis. Use by creating a file containing an
operation to trace:

```
statement ok
CREATE TABLE t (k INT PRIMARY KEY)

statement ok
INSERT INTO t VALUES (1)

traceon trace.out

query I
SELECT * FROM t
----
1

traceoff
```

And then:

```
cd ./sql
go test -v -i -c
./sql.test -test.run TestLogic -d testfile
go tool trace ./sql.test trace.out
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4004)

<!-- Reviewable:end -->
