### PR TITLE
Avoid an allocation in storing and retrieving traces from contexts.

### DIFF
--- a/util/tracer/context.go
+++ b/util/tracer/context.go
@@ -18,18 +18,14 @@ package tracer
 
 import "golang.org/x/net/context"
 
-// contextKeyType is a dummy type to avoid naming collisions with other
+// contextKey is a dummy type to avoid naming collisions with other
 // package's context keys.
-type contextKeyType int
-
-// contextKey is the key claimed for storing and retrieving a Trace from
-// a context.Context.
-const contextKey contextKeyType = 0
+type contextKey struct{}
 
 // FromCtx is a helper to pass a Trace in a context.Context. It returns the
 // Trace stored at ContextKey or nil.
 func FromCtx(ctx context.Context) *Trace {
-	if t, ok := ctx.Value(contextKey).(*Trace); ok {
+	if t, ok := ctx.Value(contextKey{}).(*Trace); ok {
 		return t
 	}
 	return nil
@@ -37,5 +33,5 @@ func FromCtx(ctx context.Context) *Trace {
 
 // ToCtx is a helper to store a Trace in a context.Context under ContextKey.
 func ToCtx(ctx context.Context, trace *Trace) context.Context {
-	return context.WithValue(ctx, contextKey, trace)
+	return context.WithValue(ctx, contextKey{}, trace)
 }


### PR DESCRIPTION
Noticed this in passing. Doubt it is important, but the change is simple
enough.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4007)

<!-- Reviewable:end -->
