### PR TITLE
Add an AnnotateTrace() utility.

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/tracer"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -480,6 +481,9 @@ func (db *DB) send(reqs ...roachpb.Request) (*roachpb.BatchResponse, *roachpb.Er
 	if ba.UserPriority == 0 && db.userPriority != 1 {
 		ba.UserPriority = db.userPriority
 	}
+
+	tracer.AnnotateTrace()
+
 	br, pErr := db.sender.Send(context.TODO(), ba)
 	if pErr != nil {
 		if log.V(1) {

--- a/client/txn.go
+++ b/client/txn.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/caller"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
+	"github.com/cockroachdb/cockroach/util/tracer"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -286,6 +287,9 @@ func (txn *Txn) Run(b *Batch) *roachpb.Error {
 
 // RunWithResponse is a version of Run that returns the BatchResponse.
 func (txn *Txn) RunWithResponse(b *Batch) (*roachpb.BatchResponse, *roachpb.Error) {
+	tracer.AnnotateTrace()
+	defer tracer.AnnotateTrace()
+
 	if pErr := b.prepare(); pErr != nil {
 		return nil, pErr
 	}

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -367,6 +367,9 @@ func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID roachpb.RangeID, repl
 		return &roachpb.BatchResponse{}
 	}
 
+	tracer.AnnotateTrace()
+	defer tracer.AnnotateTrace()
+
 	const method = "Node.Batch"
 	replies, err := ds.rpcSend(rpcOpts, method, addrs, getArgs, getReply, ds.rpcContext)
 	if err != nil {
@@ -468,6 +471,8 @@ func (ds *DistSender) sendSingleRange(trace *tracer.Trace, ba roachpb.BatchReque
 // of a transaction, but no entry. Pushing such a transaction will succeed, and
 // may lead to the transaction being aborted early.
 func (ds *DistSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+	tracer.AnnotateTrace()
+
 	// In the event that timestamp isn't set and read consistency isn't
 	// required, set the timestamp using the local clock.
 	if ba.ReadConsistency == roachpb.INCONSISTENT && ba.Timestamp.Equal(roachpb.ZeroTimestamp) {

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/tracer"
 )
 
 //go:generate stringer -type=clientMessageType
@@ -542,6 +543,8 @@ func (c *v3Conn) handleExecute(buf *readBuffer) error {
 }
 
 func (c *v3Conn) executeStatements(stmts string, params []parser.Datum, formatCodes []formatCode, sendDescription bool) error {
+	tracer.AnnotateTrace()
+
 	c.session.Database = c.opts.database
 
 	// TODO(dt): this is a clumsy check better left to the actual parser. #3852

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/tracer"
 )
 
 // planner is the centerpiece of SQL statement execution combining session
@@ -68,6 +69,8 @@ func (p *planner) resetTxn() {
 // Note: The autoCommit parameter enables operations to enable the 1PC
 // optimization. This is a bit hackish/preliminary at present.
 func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, *roachpb.Error) {
+	tracer.AnnotateTrace()
+
 	// This will set the system DB trigger for transactions containing
 	// DDL statements that have no effect, such as
 	// `BEGIN; INSERT INTO ...; CREATE TABLE IF NOT EXISTS ...; COMMIT;`

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/tracer"
 )
 
 // qvalue implements the parser.DRereference interface and is used as a
@@ -172,6 +173,8 @@ func (n *scanNode) Values() parser.DTuple {
 }
 
 func (n *scanNode) Next() bool {
+	tracer.AnnotateTrace()
+
 	if n.pErr != nil {
 		return false
 	}

--- a/util/tracer/annotate.go
+++ b/util/tracer/annotate.go
@@ -1,0 +1,32 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (petermattis@gmail.com)
+
+package tracer
+
+// static void annotateTrace() {
+// }
+import "C"
+import "os"
+
+var annotationEnabled = os.Getenv("ANNOTATE_TRACES") == "1"
+
+// AnnotateTrace adds an annotation to the golang executation tracer by calling
+// a no-op cgo function.
+func AnnotateTrace() {
+	if annotationEnabled {
+		C.annotateTrace()
+	}
+}


### PR DESCRIPTION
AnnotateTrace() adds an annotation trace to the golang execution tracer by
invoking a system call (i.e. a no-op cgo function). Annotations are only
enabled when the ANNOTATE_TRACES environment variable is set to 1.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4010)

<!-- Reviewable:end -->
