### PR TITLE
sql: fix UPDATE with multiple tuples of DEFAULT

### DIFF
--- a/sql/testdata/default
+++ b/sql/testdata/default
@@ -69,3 +69,9 @@ query IBB
 SELECT a, b <= now(), c >= 0.0 FROM t WHERE a = 2
 ----
 2 true true
+
+statement ok
+UPDATE t SET b = DEFAULT, c = DEFAULT
+
+statement ok
+UPDATE t SET (b) = (DEFAULT), (c) = (DEFAULT)

--- a/sql/update.go
+++ b/sql/update.go
@@ -99,22 +99,26 @@ func (p *planner) Update(n *parser.Update) (planNode, *roachpb.Error) {
 	// above. So "UPDATE t SET (a, b) = (1, 2)" translates into select targets of
 	// "*, 1, 2", not "*, (1, 2)".
 	targets := tableDesc.allColumnsSelector()
+	i := 0
 	for _, expr := range n.Exprs {
 		if expr.Tuple {
 			switch t := expr.Expr.(type) {
 			case parser.Tuple:
-				for i, e := range t {
+				for _, e := range t {
 					e = fillDefault(e, i, defaultExprs)
 					targets = append(targets, parser.SelectExpr{Expr: e})
+					i++
 				}
 			case parser.DTuple:
 				for _, e := range t {
 					targets = append(targets, parser.SelectExpr{Expr: e})
+					i++
 				}
 			}
 		} else {
-			e := fillDefault(expr.Expr, 0, defaultExprs)
+			e := fillDefault(expr.Expr, i, defaultExprs)
 			targets = append(targets, parser.SelectExpr{Expr: e})
+			i++
 		}
 	}
 


### PR DESCRIPTION
Without this, the new tests fail with:

pq: value type timestamp doesn't match type FLOAT of column "c"

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4023)

<!-- Reviewable:end -->
