### PR TITLE
Remove explicit "init" step to start a cluster

### DIFF
--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -233,17 +233,10 @@ func (l *LocalCluster) initCluster() {
 		}
 	}
 	create := func() (*Container, error) {
-		var entrypoint []string
-		if *cockroachImage == builderImage {
-			entrypoint = append(entrypoint, "/"+filepath.Base(*cockroachBinary))
-		} else if *cockroachEntry != "" {
-			entrypoint = append(entrypoint, *cockroachEntry)
-		}
 		return createContainer(l, dockerclient.ContainerConfig{
 			Image:      *cockroachImage,
 			Volumes:    vols,
-			Entrypoint: entrypoint,
-			Cmd:        []string{"init", "--stores=ssd=" + dataStr(0, 0)},
+			Entrypoint: []string{"/bin/true"},
 		})
 	}
 	c, err := create()
@@ -351,11 +344,6 @@ func (l *LocalCluster) createNodeCerts() {
 }
 
 func (l *LocalCluster) startNode(i int) *Container {
-	gossipNodes := []string{}
-	for j := 0; j < l.numLocal; j++ {
-		gossipNodes = append(gossipNodes, fmt.Sprintf("%s:%d", nodeStr(j), cockroachPort))
-	}
-
 	var stores = "ssd=" + dataStr(i, 0)
 	for j := 1; j < l.numStores; j++ {
 		stores += ",ssd=" + dataStr(i, j)
@@ -367,9 +355,13 @@ func (l *LocalCluster) startNode(i int) *Container {
 		"--certs=/certs",
 		"--host=" + nodeStr(i),
 		"--port=" + fmt.Sprintf("%d", cockroachPort),
-		"--gossip=" + strings.Join(gossipNodes, ","),
 		"--scan-max-idle-time=200ms", // set low to speed up tests
 	}
+	// Append --join flag for all nodes except first.
+	if i > 0 {
+		cmd = append(cmd, fmt.Sprintf("--join=%s:%d", nodeStr(0), cockroachPort))
+	}
+
 	var locallogDir string
 	if len(l.logDir) > 0 {
 		dockerlogDir := "/logs/" + nodeStr(i)

--- a/cli/cert.go
+++ b/cli/cert.go
@@ -17,8 +17,9 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/security"
-	"github.com/cockroachdb/cockroach/util"
 
 	"github.com/spf13/cobra"
 )
@@ -44,7 +45,7 @@ individual files in the directory specified by --certs (required).
 // to their corresponding files.
 func runCreateCACert(cmd *cobra.Command, args []string) error {
 	if err := security.RunCreateCACert(context.Certs, keySize); err != nil {
-		return util.Errorf("failed to generate CA certificate: %s", err)
+		return fmt.Errorf("failed to generate CA certificate: %s", err)
 	}
 	return nil
 }
@@ -68,7 +69,7 @@ At least one host should be passed in (either IP address of dns name).
 // to their corresponding files.
 func runCreateNodeCert(cmd *cobra.Command, args []string) error {
 	if err := security.RunCreateNodeCert(context.Certs, keySize, args); err != nil {
-		return util.Errorf("failed to generate node certificate: %s", err)
+		return fmt.Errorf("failed to generate node certificate: %s", err)
 	}
 	return nil
 }
@@ -95,7 +96,7 @@ func runCreateClientCert(cmd *cobra.Command, args []string) error {
 		return errMissingParams
 	}
 	if err := security.RunCreateClientCert(context.Certs, keySize, args[0]); err != nil {
-		return util.Errorf("failed to generate clent certificate: %s", err)
+		return fmt.Errorf("failed to generate clent certificate: %s", err)
 	}
 	return nil
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -57,7 +57,6 @@ var cockroachCmd = &cobra.Command{
 
 func init() {
 	cockroachCmd.AddCommand(
-		initCmd,
 		startCmd,
 		certCmd,
 		exterminateCmd,

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -654,8 +654,7 @@ func TestFlagUsage(t *testing.T) {
   cockroach [command]
 
 Available Commands:
-  init        init new Cockroach cluster
-  start       start a node by joining the gossip network
+  start       start a node
   cert        create ca, node, and client certs
   exterminate destroy all data held by the node
   quit        drain and shutdown node

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -84,19 +84,16 @@ error occurs in any statement, the command exits with a
 non-zero status code and further statements are not
 executed. Only the results of the first SQL statement in each
 positional argument are printed on the standard output.`),
-	"gossip": wrapText(`
-A comma-separated list of gossip addresses or resolvers for gossip
-bootstrap. Each item in the list has an optional type:
-[type=]<address>. An unspecified type means ip address or dns.
-Type is one of:`) + `
+	"join": wrapText(`
+A comma-separated list of addresses to use when a new node is joining
+an existing cluster. For the first node in a cluster, --join should
+NOT be specified. Each address in the list has an optional type:
+[type=]<address>. An unspecified type means ip address or dns.  Type
+is one of:
 - tcp: (default if type is omitted): plain ip address or hostname.
-- unix: unix socket
-- lb: RPC load balancer forwarding to an arbitrary node
 - http-lb: HTTP load balancer: we query
-  http(s)://<address>/_status/details/local
-- self: for single node systems, specify --gossip=self (the
-  <address> is omitted).
-`,
+           http(s)://<address>/_status/details/local
+`),
 	"host": wrapText(`
 Database server host.`),
 	"insecure": wrapText(`
@@ -194,14 +191,6 @@ func initFlags(ctx *Context) {
 	})
 
 	{
-		f := initCmd.Flags()
-		f.StringVar(&ctx.Stores, "stores", ctx.Stores, usage("stores"))
-		if err := initCmd.MarkFlagRequired("stores"); err != nil {
-			panic(err)
-		}
-	}
-
-	{
 		f := startCmd.Flags()
 		f.BoolVar(&ctx.EphemeralSingleNode, "dev", ctx.EphemeralSingleNode, usage("dev"))
 
@@ -219,8 +208,8 @@ func initFlags(ctx *Context) {
 		f.StringVar(&ctx.Certs, "certs", ctx.Certs, usage("certs"))
 		f.BoolVar(&ctx.Insecure, "insecure", ctx.Insecure, usage("insecure"))
 
-		// Gossip flags.
-		f.StringVar(&ctx.GossipBootstrap, "gossip", ctx.GossipBootstrap, usage("gossip"))
+		// Cluster joining flags.
+		f.StringVar(&ctx.JoinUsing, "join", ctx.JoinUsing, usage("join"))
 
 		// KV flags.
 		f.BoolVar(&ctx.Linearizable, "linearizable", ctx.Linearizable, usage("linearizable"))
@@ -232,9 +221,6 @@ func initFlags(ctx *Context) {
 		f.DurationVar(&ctx.ScanMaxIdleTime, "scan-max-idle-time", ctx.ScanMaxIdleTime, usage("scan-max-idle-time"))
 		f.DurationVar(&ctx.TimeUntilStoreDead, "time-until-store-dead", ctx.TimeUntilStoreDead, usage("time-until-store-dead"))
 
-		if err := startCmd.MarkFlagRequired("gossip"); err != nil {
-			panic(err)
-		}
 		if err := startCmd.MarkFlagRequired("stores"); err != nil {
 			panic(err)
 		}

--- a/cli/start.go
+++ b/cli/start.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
-	"github.com/cockroachdb/cockroach/util/uuid"
 
 	"github.com/spf13/cobra"
 )
@@ -77,77 +76,29 @@ func getJSON(hostport, path string, v interface{}) error {
 	return util.GetJSON(httpClient, context.HTTPRequestScheme(), hostport, path, v)
 }
 
-// initCmd command initializes a new Cockroach cluster.
-var initCmd = &cobra.Command{
-	Use:   "init --stores=...",
-	Short: "init new Cockroach cluster",
-	Long: `
-Initialize a new Cockroach cluster using the --stores flag to specify one or
-more storage locations. The first of these storage locations is used to
-bootstrap the first replica of the first range. If any of the storage locations
-are already part of a pre-existing cluster, the bootstrap will fail.
-`,
-	Example:      `  cockroach init --stores=ssd=/mnt/ssd1,ssd=/mnt/ssd2`,
-	SilenceUsage: true,
-	RunE:         runInit,
-}
-
-// runInit initializes the engine based on the first
-// store. The bootstrap engine may not be an in-memory type.
-func runInit(_ *cobra.Command, _ []string) error {
-	stopper := stop.NewStopper()
-	defer stopper.Stop()
-
-	// Default user for servers.
-	context.User = security.NodeUser
-
-	if err := context.InitStores(stopper); err != nil {
-		return util.Errorf("failed to initialize stores: %s", err)
-	}
-	if len(context.Engines) > 1 {
-		return util.Errorf("cannot bootstrap to more than one store")
-	}
-
-	return initCluster(stopper)
-}
-
-func initCluster(stopper *stop.Stopper) error {
-	// Generate a new UUID for cluster ID and bootstrap the cluster.
-	clusterID := uuid.NewUUID4().String()
-	if _, err := server.BootstrapCluster(clusterID, context.Engines, stopper); err != nil {
-		return util.Errorf("unable to bootstrap cluster: %s", err)
-	}
-
-	log.Infof("cockroach cluster %s has been initialized", clusterID)
-	return nil
-}
-
-// startCmd command starts nodes by joining the gossip network.
+// startCmd starts a node by initializing the stores and joining
+// the cluster.
 var startCmd = &cobra.Command{
 	Use:   "start",
-	Short: "start a node by joining the gossip network",
+	Short: "start a node",
 	Long: `
-Start a Cockroach node by joining the gossip network and exporting key ranges
-stored on physical device(s). The gossip network is joined by contacting one or
-more well-known hosts specified by the --gossip flag. Every node should be run
-with the same list of bootstrap hosts to guarantee a connected network. An
-alternate approach is to use a single host for --gossip and round-robin DNS.
+Start a CockroachDB node, which will export data from one or more
+storage devices, specified via the --stores flag.
 
-Each node exports data from one or more physical devices. These devices are
-specified via the --stores flag. This is a comma-separated list of paths to
-storage directories or for in-memory stores, the number of bytes. Although the
-paths should be specified to correspond uniquely to physical devices, this
-requirement isn't strictly enforced. See the --stores flag help description for
-additional details.`,
-	Example:      `  cockroach start --certs=<dir> --gossip=host1:port1[,...] --stores=ssd=/mnt/ssd1,...`,
+If no cluster exists yet and this is the first node, no additional
+flags are required. If the cluster already exists, and this node is
+uninitialized, specify the --join flag to point to any healthy node
+(or list of nodes) already part of the cluster.
+`,
+	Example:      `  cockroach start --certs=<dir> --stores=ssd=/mnt/ssd1,... [--join=host:port,[host:port]]`,
 	SilenceUsage: true,
 	RunE:         runStart,
 }
 
 // runStart starts the cockroach node using --stores as the list of
-// storage devices ("stores") on this machine and --gossip as the list
-// of "well-known" hosts used to join this node to the cockroach
-// cluster via the gossip network.
+// storage devices ("stores") on this machine and --join as the list
+// of other active nodes used to join this node to the cockroach
+// cluster, if this is its first time connecting.
 func runStart(_ *cobra.Command, _ []string) error {
 	info := util.GetBuildInfo()
 	log.Infof("[build] %s @ %s (%s)", info.Tag, info.Time, info.Vers)
@@ -160,36 +111,25 @@ func runStart(_ *cobra.Command, _ []string) error {
 		// for the default cluster-wide zone config.
 		config.DefaultZoneConfig.ReplicaAttrs = []roachpb.Attributes{{}}
 		context.Stores = "mem=1073741824"
-		context.GossipBootstrap = server.SelfGossipAddr
 	}
 
 	stopper := stop.NewStopper()
 	if err := context.InitStores(stopper); err != nil {
-		return util.Errorf("failed to initialize stores: %s", err)
-	}
-
-	if context.EphemeralSingleNode {
-		// A separate stopper for bootstrapping so that we can properly shutdown
-		// all of the stores.
-		initStopper := stop.NewStopper()
-		if err := initCluster(initStopper); err != nil {
-			return err
-		}
-		initStopper.Stop()
+		return fmt.Errorf("failed to initialize stores: %s", err)
 	}
 
 	if err := context.InitNode(); err != nil {
-		return util.Errorf("failed to initialize node: %s", err)
+		return fmt.Errorf("failed to initialize node: %s", err)
 	}
 
 	log.Info("starting cockroach node")
 	s, err := server.NewServer(&context.Context, stopper)
 	if err != nil {
-		return util.Errorf("failed to start Cockroach server: %s", err)
+		return fmt.Errorf("failed to start Cockroach server: %s", err)
 	}
 
-	if err := s.Start(false); err != nil {
-		return util.Errorf("cockroach server exited with error: %s", err)
+	if err := s.Start(); err != nil {
+		return fmt.Errorf("cockroach server exited with error: %s", err)
 	}
 
 	signalCh := make(chan os.Signal, 1)

--- a/gossip/client.go
+++ b/gossip/client.go
@@ -188,7 +188,7 @@ func (c *client) handleGossip(g *Gossip, call *netrpc.Call) error {
 		return util.Errorf("received forward from node %d to %d (%s)", reply.NodeID, reply.AlternateNodeID, reply.AlternateAddr)
 	}
 
-	// If we have the sentinel gossip, we're considered connected.
+	// If we have the sentinel gossip we're considered connected.
 	g.checkHasConnected()
 
 	// Check whether this outgoing client is duplicating work already

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -262,12 +262,11 @@ func (g *Gossip) SetStorage(storage Storage) error {
 	var storedBI BootstrapInfo
 	err := storage.ReadBootstrapInfo(&storedBI)
 	if err != nil {
-		log.Warningf("failed to read bootstrap info: %s", err)
+		log.Warningf("failed to read gossip bootstrap info: %s", err)
 	}
-	log.Infof("read %d gossip host(s) for bootstrapping from persistent storage", len(storedBI.Addresses))
 
 	// Merge the stored bootstrap info addresses with any we've become
-	// aware of through the --gossip bootstrap hosts we've connected to.
+	// aware of through the --join bootstrap hosts we've connected to.
 	if len(g.bootstrapInfo.Addresses) > 0 {
 		existing := map[string]struct{}{}
 		makeKey := func(a util.UnresolvedAddr) string { return fmt.Sprintf("%s,%s", a.Network(), a.String()) }
@@ -283,8 +282,6 @@ func (g *Gossip) SetStorage(storage Storage) error {
 		if numAddrs := len(g.bootstrapInfo.Addresses); numAddrs > len(storedBI.Addresses) {
 			if err := g.storage.WriteBootstrapInfo(&g.bootstrapInfo); err != nil {
 				log.Error(err)
-			} else {
-				log.Infof("wrote %d merged gossip host(s) to persistent storage", numAddrs)
 			}
 		}
 	} else {
@@ -297,7 +294,7 @@ func (g *Gossip) SetStorage(storage Storage) error {
 	for _, addr := range g.bootstrapInfo.Addresses {
 		r, err := resolver.NewResolverFromUnresolvedAddr(addr)
 		if err != nil {
-			log.Warningf("bad bootstrap address %s: %s", addr, err)
+			log.Warningf("bad node address %s: %s", addr, err)
 			continue
 		}
 		if g.haveResolver(r) {
@@ -312,9 +309,10 @@ func (g *Gossip) SetStorage(storage Storage) error {
 		g.resolvers = append(g.resolvers, r)
 	}
 
-	// If there are no resolvers after persistent storage has been queried, fatal error.
+	// If there are no resolvers even after merging known nodes from
+	// persistent storage, we need to error out.
 	if len(g.resolvers) == 0 {
-		return fmt.Errorf("no resolvers specified for gossip network: try adding peers via --gossip")
+		return fmt.Errorf("no nodes were found to connect to cluster; use --join")
 	}
 
 	// If a new resolver was found, immediately signal bootstrap.
@@ -336,6 +334,13 @@ func (g *Gossip) SetResolvers(resolvers []resolver.Resolver) {
 	g.resolverIdx = len(resolvers) - 1
 	g.resolvers = resolvers
 	g.resolversTried = map[int]struct{}{}
+}
+
+// GetResolvers returns a copy of the resolvers slice.
+func (g *Gossip) GetResolvers() []resolver.Resolver {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return append([]resolver.Resolver(nil), g.resolvers...)
 }
 
 // GetNodeIDAddress looks up the address of the node by ID.
@@ -381,9 +386,23 @@ func (g *Gossip) SimulationCycle() {
 // haveResolver returns whether the specified resolver is already in
 // the gossip node's list of resolvers. The caller must hold the
 // gossip mutex.
+// TODO(spencer): sort and binary search.
 func (g *Gossip) haveResolver(r resolver.Resolver) bool {
 	for _, ex := range g.resolvers {
 		if ex.Type() == r.Type() && ex.Addr() == r.Addr() {
+			return true
+		}
+	}
+	return false
+}
+
+// haveBootstrapAddress returns whether there is already a bootstrap
+// address matching the specified address. The caller must hold the
+// gossip mutex.
+// TODO(spencer): sort and binary search.
+func (g *Gossip) haveBootstrapAddress(addr util.UnresolvedAddr) bool {
+	for _, ex := range g.bootstrapInfo.Addresses {
+		if ex == addr {
 			return true
 		}
 	}
@@ -442,17 +461,18 @@ func (g *Gossip) updateNodeAddress(_ string, content roachpb.Value) {
 		log.Warningf("bad address from gossip node %s: %s", desc, err)
 		return
 	}
-	if g.haveResolver(r) {
-		return
+	if !g.haveResolver(r) {
+		g.resolvers = append(g.resolvers, r)
 	}
-	g.resolvers = append(g.resolvers, r)
 	// Add new address to bootstrap info and persist if possible.
-	g.bootstrapInfo.Addresses = append(g.bootstrapInfo.Addresses, desc.Address)
-	if g.storage != nil {
-		// TODO(spencer): need to clean up ancient gossip nodes, which
-		//   will otherwise stick around in the bootstrap info forever.
-		if err := g.storage.WriteBootstrapInfo(&g.bootstrapInfo); err != nil {
-			log.Error(err)
+	if !g.haveBootstrapAddress(desc.Address) {
+		g.bootstrapInfo.Addresses = append(g.bootstrapInfo.Addresses, desc.Address)
+		if g.storage != nil {
+			// TODO(spencer): need to clean up ancient gossip nodes, which
+			//   will otherwise stick around in the bootstrap info forever.
+			if err := g.storage.WriteBootstrapInfo(&g.bootstrapInfo); err != nil {
+				log.Error(err)
+			}
 		}
 	}
 }
@@ -653,8 +673,9 @@ func (g *Gossip) MaxHops() uint32 {
 }
 
 // Start launches the gossip instance, which commences joining the
-// gossip network using the supplied rpc server and the gossip
-// bootstrap addresses specified via command-line flag: --gossip.
+// gossip network using the supplied rpc server and previously known
+// peer addresses in addition to any bootstrap addresses specified via
+// --join.
 //
 // The supplied address is used to identify the gossip instance in the
 // gossip network; it will be used by other instances to connect to
@@ -880,13 +901,13 @@ func (g *Gossip) signalStalled() {
 // not being connected to the sentinel. This could happen in a network
 // partition, or because of misconfiguration. It's impossible to tell,
 // but we can warn appropriately. If there are no incoming or outgoing
-// connections, we warn about the --gossip flag being set. If we've
+// connections, we warn about the --join flag being set. If we've
 // connected, and all resolvers have been tried, we warn about either
 // the first range not being available or else possible the cluster
 // never having been initialized.
 func (g *Gossip) warnAboutStall() {
 	if g.outgoing.len()+g.incoming.len() == 0 {
-		log.Warningf("not connected to gossip; check that gossip flag is set appropriately")
+		log.Warningf("not connected to cluster; check --join specifies another active node")
 	} else if len(g.resolversTried) == len(g.resolvers) {
 		log.Warningf("first range unavailable or cluster not initialized")
 	} else {

--- a/gossip/resolver/node_lookup.go
+++ b/gossip/resolver/node_lookup.go
@@ -30,10 +30,9 @@ import (
 // address. This is useful for http load balancers which will not forward RPC.
 // It is never exhausted.
 type nodeLookupResolver struct {
-	context   *base.Context
-	typ       string
-	addr      string
-	exhausted bool
+	context *base.Context
+	typ     string
+	addr    string
 	// We need our own client so that we may specify timeouts.
 	httpClient *http.Client
 }
@@ -45,20 +44,7 @@ func (nl *nodeLookupResolver) Type() string { return nl.typ }
 func (nl *nodeLookupResolver) Addr() string { return nl.addr }
 
 // GetAddress returns a net.Addr or error.
-// Upon errors, we set exhausted=true, then flip it back when called again.
 func (nl *nodeLookupResolver) GetAddress() (net.Addr, error) {
-	// TODO(marc): this is a bit of a hack to allow the server to start.
-	// In single-node setups, this resolver will never return anything since
-	// the status handlers are not serving yet. Instead, we specify multiple
-	// gossip addresses (--gossip=localhost,http-lb=lb). We need this one to
-	// be exhausted from time to time so that we have a chance to hit the fixed address.
-	// Remove once the status pages are served before we've established a connection to
-	// the gossip network.
-	if nl.exhausted {
-		nl.exhausted = false
-		return nil, util.Errorf("skipping temporarily-exhausted resolver")
-	}
-
 	if nl.httpClient == nil {
 		tlsConfig, err := nl.context.GetClientTLSConfig()
 		if err != nil {
@@ -69,8 +55,6 @@ func (nl *nodeLookupResolver) GetAddress() (net.Addr, error) {
 			Timeout:   base.NetworkTimeout,
 		}
 	}
-
-	nl.exhausted = true
 
 	local := struct {
 		Address util.UnresolvedAddr `json:"address"`
@@ -87,8 +71,6 @@ func (nl *nodeLookupResolver) GetAddress() (net.Addr, error) {
 	if err != nil {
 		return nil, err
 	}
-	nl.exhausted = false
-	log.Infof("found gossip node: %+v", addr)
 	return addr, nil
 }
 
@@ -103,6 +85,6 @@ func resolveAddress(network, address string) (net.Addr, error) {
 	return nil, util.Errorf("unknown address type: %q", network)
 }
 
-// IsExhausted returns whether the resolver can yield further
-// addresses.
-func (nl *nodeLookupResolver) IsExhausted() bool { return nl.exhausted }
+// IsExhausted always returns false, as there's no way to know how many
+// nodes are behind a load balancer.
+func (nl *nodeLookupResolver) IsExhausted() bool { return false }

--- a/gossip/resolver/resolver.go
+++ b/gossip/resolver/resolver.go
@@ -35,7 +35,6 @@ type Resolver interface {
 
 var validTypes = map[string]struct{}{
 	"tcp":     {},
-	"lb":      {},
 	"unix":    {},
 	"http-lb": {},
 }
@@ -44,7 +43,6 @@ var validTypes = map[string]struct{}{
 // A specification is of the form: [<network type>=]<address>
 // Network type can be one of:
 // - tcp: plain hostname of ip address
-// - lb: load balancer host name or ip: points to an unknown number of backends
 // - unix: unix sockets
 // - http-lb: http load balancer: queries http(s)://<lb>/_status/details/local
 //   for node addresses

--- a/gossip/resolver/resolver_test.go
+++ b/gossip/resolver/resolver_test.go
@@ -39,7 +39,6 @@ func TestParseResolverSpec(t *testing.T) {
 		{"127.0.0.1", true, "tcp", "127.0.0.1:26257"},
 		{"tcp=127.0.0.1", true, "tcp", "127.0.0.1:26257"},
 		{"tcp=127.0.0.1:23456", true, "tcp", "127.0.0.1:23456"},
-		{"lb=127.0.0.1", true, "lb", "127.0.0.1:26257"},
 		{"unix=/tmp/unix-socket12345", true, "unix", "/tmp/unix-socket12345"},
 		{"http-lb=localhost:26257", true, "http-lb", "localhost:26257"},
 		{"http-lb=newhost:1234", true, "http-lb", "newhost:1234"},
@@ -47,7 +46,6 @@ func TestParseResolverSpec(t *testing.T) {
 		{"http-lb=:", true, "http-lb", def},
 		{"", false, "", ""},
 		{"foo=127.0.0.1", false, "", ""},
-		{"lb=", false, "", ""},
 		{"", false, "tcp", ""},
 		{":", true, "tcp", def},
 		{"tcp=", false, "tcp", ""},
@@ -83,9 +81,6 @@ func TestGetAddress(t *testing.T) {
 		{"tcp=127.0.0.1", true, true, "tcp", "127.0.0.1:26257"},
 		{"tcp=localhost:80", true, true, "tcp", "localhost:80"},
 		// We should test unresolvable dns too, but this would be fragile.
-		{"lb=localhost:80", true, false, "tcp", "localhost:80"},
-		{"lb=127.0.0.1:80", true, false, "tcp", "127.0.0.1:80"},
-		{"lb=127.0.0.1", true, false, "tcp", "127.0.0.1:26257"},
 		{"unix=/tmp/foo", true, true, "unix", "/tmp/foo"},
 	}
 

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 		os.Args = append(os.Args, "help")
 	}
 	if err := cli.Run(os.Args[1:]); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed running command %q: %v\n", os.Args[1:], err)
+		fmt.Fprintf(os.Stderr, "Failed running %q\n", os.Args[1])
 		os.Exit(1)
 	}
 }

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -30,7 +30,6 @@ func TestParseNodeAttributes(t *testing.T) {
 	ctx := NewContext()
 	ctx.Attrs = "attr1=val1::attr2=val2"
 	ctx.Stores = "mem=1"
-	ctx.GossipBootstrap = SelfGossipAddr
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	if err := ctx.InitStores(stopper); err != nil {
@@ -45,12 +44,12 @@ func TestParseNodeAttributes(t *testing.T) {
 	}
 }
 
-// TestParseGossipBootstrapAddrs verifies that GossipBootstrap is
-// parsed correctly.
-func TestParseGossipBootstrapAddrs(t *testing.T) {
+// TestParseJoinUsingAddrs verifies that JoinUsing is parsed
+// correctly.
+func TestParseJoinUsingAddrs(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	ctx := NewContext()
-	ctx.GossipBootstrap = "localhost:12345,,localhost:23456"
+	ctx.JoinUsing = "localhost:12345,,localhost:23456"
 	ctx.Stores = "mem=1"
 	stopper := stop.NewStopper()
 	defer stopper.Stop()

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -127,17 +127,16 @@ func (s keySlice) Less(i, j int) bool { return bytes.Compare(s[i], s[j]) < 0 }
 func TestBootstrapCluster(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	stopper := stop.NewStopper()
+	defer stopper.Stop()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper)
-	localDB, err := BootstrapCluster("cluster-1", []engine.Engine{e}, stopper)
-	if err != nil {
+	if _, err := bootstrapCluster([]engine.Engine{e}); err != nil {
 		t.Fatal(err)
 	}
-	defer stopper.Stop()
 
-	// Scan the complete contents of the local database.
-	rows, pErr := localDB.Scan(keys.LocalMax, roachpb.KeyMax, 0)
-	if pErr != nil {
-		t.Fatal(pErr)
+	// Scan the complete contents of the local database directly from the engine.
+	rows, _, err := engine.MVCCScan(e, keys.LocalMax, roachpb.KeyMax, 0, roachpb.MaxTimestamp, true, nil)
+	if err != nil {
+		t.Fatal(err)
 	}
 	var foundKeys keySlice
 	for _, kv := range rows {
@@ -172,11 +171,9 @@ func TestBootstrapNewStore(t *testing.T) {
 	engineStopper := stop.NewStopper()
 	defer engineStopper.Stop()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)
-	eagerStopper := stop.NewStopper()
-	if _, err := BootstrapCluster("cluster-1", []engine.Engine{e}, eagerStopper); err != nil {
+	if _, err := bootstrapCluster([]engine.Engine{e}); err != nil {
 		t.Fatal(err)
 	}
-	eagerStopper.Stop()
 
 	// Start a new node with two new stores which will require bootstrapping.
 	engines := []engine.Engine{
@@ -216,12 +213,9 @@ func TestNodeJoin(t *testing.T) {
 	engineStopper := stop.NewStopper()
 	defer engineStopper.Stop()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)
-	stopper := stop.NewStopper()
-	_, err := BootstrapCluster("cluster-1", []engine.Engine{e}, stopper)
-	if err != nil {
+	if _, err := bootstrapCluster([]engine.Engine{e}); err != nil {
 		t.Fatal(err)
 	}
-	stopper.Stop()
 
 	// Start the bootstrap node.
 	engines1 := []engine.Engine{e}
@@ -270,12 +264,9 @@ func TestCorruptedClusterID(t *testing.T) {
 	engineStopper := stop.NewStopper()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)
 	defer engineStopper.Stop()
-	eagerStopper := stop.NewStopper()
-	_, err := BootstrapCluster("cluster-1", []engine.Engine{e}, eagerStopper)
-	if err != nil {
+	if _, err := bootstrapCluster([]engine.Engine{e}); err != nil {
 		t.Fatal(err)
 	}
-	eagerStopper.Stop()
 
 	// Set the cluster ID to an empty string.
 	sIdent := roachpb.StoreIdent{
@@ -283,7 +274,7 @@ func TestCorruptedClusterID(t *testing.T) {
 		NodeID:    1,
 		StoreID:   1,
 	}
-	if err = engine.MVCCPutProto(e, nil, keys.StoreIdentKey(), roachpb.ZeroTimestamp, nil, &sIdent); err != nil {
+	if err := engine.MVCCPutProto(e, nil, keys.StoreIdentKey(), roachpb.ZeroTimestamp, nil, &sIdent); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,6 @@ import (
 	snappy "github.com/cockroachdb/c-snappy"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
-	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
 	crpc "github.com/cockroachdb/cockroach/rpc"
@@ -206,10 +205,9 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	return s, nil
 }
 
-// Start runs the RPC and HTTP servers, starts the gossip instance (if
-// selfBootstrap is true, uses the rpc server's address as the gossip
-// bootstrap), and starts the node using the supplied engines slice.
-func (s *Server) Start(selfBootstrap bool) error {
+// Start starts the server on the specified port, starts gossip and
+// initializes the node using the engines from the server's context.
+func (s *Server) Start() error {
 	tlsConfig, err := s.ctx.GetServerTLSConfig()
 	if err != nil {
 		return err
@@ -220,21 +218,11 @@ func (s *Server) Start(selfBootstrap bool) error {
 	if err != nil {
 		return err
 	}
-
 	s.listener = ln
-
 	addr := ln.Addr()
-	addrStr := addr.String()
-	s.rpcContext.SetLocalServer(s.rpc, addrStr)
 
-	// Handle self-bootstrapping case for a single node.
-	if selfBootstrap {
-		selfResolver, err := resolver.NewResolver(&s.ctx.Context, addrStr)
-		if err != nil {
-			return err
-		}
-		s.gossip.SetResolvers([]resolver.Resolver{selfResolver})
-	}
+	s.rpcContext.SetLocalServer(s.rpc, addr.String())
+
 	s.gossip.Start(s.rpc, addr)
 
 	if err := s.node.start(s.rpc, addr, s.ctx.Engines, s.ctx.NodeAttributes); err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -77,7 +77,7 @@ func TestInitEngine(t *testing.T) {
 	}
 	for _, spec := range testCases {
 		ctx := NewContext()
-		ctx.Stores, ctx.GossipBootstrap = spec.key, SelfGossipAddr
+		ctx.Stores = spec.key
 		if err := ctx.InitStores(stopper); err == nil {
 			engines := ctx.Engines
 			if spec.wantError {
@@ -109,7 +109,6 @@ func TestInitEngines(t *testing.T) {
 
 	ctx := NewContext()
 	ctx.Stores = fmt.Sprintf("mem=1000,mem:ddr3=1000,ssd=%s,hdd:7200rpm=%s", tmp[0], tmp[1])
-	ctx.GossipBootstrap = SelfGossipAddr
 	expEngines := []struct {
 		attrs roachpb.Attributes
 		isMem bool

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -261,7 +261,7 @@ func startServer(t *testing.T) TestServer {
 	ts.Ctx = NewTestContext()
 	ts.StoresPerNode = 3
 	if err := ts.Start(); err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to start test server: %s", err)
 	}
 
 	// Make sure the range is spun up with an arbitrary read command. We do not

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -98,8 +98,7 @@ func NewTestContext() *Context {
 //
 type TestServer struct {
 	// Ctx is the context used by this server.
-	Ctx           *Context
-	SkipBootstrap bool
+	Ctx *Context
 	// server is the embedded Cockroach server struct.
 	*Server
 	StoresPerNode int
@@ -195,24 +194,15 @@ func (ts *TestServer) StartWithStopper(stopper *stop.Stopper) error {
 		return err
 	}
 
-	// Ensure we have the correct number of engines. Add in in-memory ones where
-	// needed.  There must be at least one store/engine.
+	// Ensure we have the correct number of engines. Add in-memory ones where
+	// needed. There must be at least one store/engine.
 	if ts.StoresPerNode < 1 {
 		ts.StoresPerNode = 1
 	}
 	for i := len(ts.Ctx.Engines); i < ts.StoresPerNode; i++ {
 		ts.Ctx.Engines = append(ts.Ctx.Engines, engine.NewInMem(roachpb.Attributes{}, 100<<20, ts.Server.stopper))
 	}
-
-	if !ts.SkipBootstrap {
-		stopper := stop.NewStopper()
-		_, err := BootstrapCluster("cluster-1", ts.Ctx.Engines, stopper)
-		if err != nil {
-			return util.Errorf("could not bootstrap cluster: %s", err)
-		}
-		stopper.Stop()
-	}
-	if err := ts.Server.Start(true); err != nil {
+	if err := ts.Server.Start(); err != nil {
 		return err
 	}
 

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -117,7 +117,7 @@ func (r *RocksDB) Open() error {
 		return util.Errorf("could not open rocksdb instance: %s", err)
 	}
 
-	// Start a gorountine that will finish when the underlying handle
+	// Start a goroutine that will finish when the underlying handle
 	// is deallocated. This is used to check a leak in tests.
 	go func() {
 		<-r.deallocated


### PR DESCRIPTION
Previously, you had to create a cluster by init'ing and starting first node:

./cockroach init --stores=...
./cockroach start --stores=... --gossip=self=

  and add new nodes with:

./cockroach start --stores=... --gossip=<node[,node,...]>

Now, a cluster is created just by running start:

./cockroach start --stores=...

  and add new nodes with:

./cockroach start --stores=... --join=<node[,node,...]>

Also cleaned up the gossip address storage code. It had gotten out of
whack somehow and wasn't storing addresses in the event that a node
had no bootstrapped stores on start.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4027)

<!-- Reviewable:end -->
