### PR TITLE
sql: Avoid calling GoError() by storing roachpb.Error in Result

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -90,7 +90,7 @@ type Response struct {
 
 // Result corresponds to the execution of a single SQL statement.
 type Result struct {
-	Err error
+	PErr *roachpb.Error
 	// The type of statement that the result is for.
 	Type parser.StatementType
 	// RowsAffected will be populated if the statement type is "RowsAffected".
@@ -490,7 +490,7 @@ func makeResultFromError(planMaker *planner, pErr *roachpb.Error) Result {
 			planMaker.txn.Cleanup(pErr)
 		}
 	}
-	return Result{Err: pErr.GoError()}
+	return Result{PErr: pErr}
 }
 
 var _ parser.Args = parameters{}

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -614,8 +614,8 @@ func (c *v3Conn) sendResponse(resp sql.Response, formatCodes []formatCode, sendD
 		return c.sendCommandComplete(nil)
 	}
 	for _, result := range resp.Results {
-		if result.Err != nil {
-			if err := c.sendError(result.Err.Error()); err != nil {
+		if result.PErr != nil {
+			if err := c.sendError(result.PErr.String()); err != nil {
 				return err
 			}
 			continue

--- a/sql/server.go
+++ b/sql/server.go
@@ -150,8 +150,8 @@ func protoFromResponse(r Response) *driver.Response {
 
 func protoFromResult(r Result) driver.Response_Result {
 	drr := driver.Response_Result{}
-	if r.Err != nil {
-		drr.Error = proto.String(r.Err.Error())
+	if r.PErr != nil {
+		drr.Error = proto.String(r.PErr.String())
 	}
 	switch r.Type {
 	case parser.DDL:


### PR DESCRIPTION
This is yet another small fix to avoid calling `GoError()` at random places.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4033)

<!-- Reviewable:end -->
