### PR TITLE
Remove the rpc.Options.N field.

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -128,7 +128,7 @@ var _ client.Sender = &DistSender{}
 // rpcSendFn is the function type used to dispatch RPC calls.
 type rpcSendFn func(rpc.Options, string, []net.Addr,
 	func(addr net.Addr) proto.Message, func() proto.Message,
-	*rpc.Context) ([]proto.Message, error)
+	*rpc.Context) (proto.Message, error)
 
 // DistSenderContext holds auxiliary objects that can be passed to
 // NewDistSender.
@@ -332,7 +332,6 @@ func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID roachpb.RangeID, repl
 
 	// Set RPC opts with stipulation that one of N RPCs must succeed.
 	rpcOpts := rpc.Options{
-		N:               1,
 		Ordering:        order,
 		SendNextTimeout: defaultSendNextTimeout,
 		Timeout:         rpc.DefaultRPCTimeout,
@@ -371,11 +370,11 @@ func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID roachpb.RangeID, repl
 	defer tracer.AnnotateTrace()
 
 	const method = "Node.Batch"
-	replies, err := ds.rpcSend(rpcOpts, method, addrs, getArgs, getReply, ds.rpcContext)
+	reply, err := ds.rpcSend(rpcOpts, method, addrs, getArgs, getReply, ds.rpcContext)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}
-	return replies[0].(*roachpb.BatchResponse), nil
+	return reply.(*roachpb.BatchResponse), nil
 }
 
 // getDescriptors looks up the range descriptor to use for a query over the

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -80,7 +80,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ltc.stores = storage.NewStores(ltc.Clock)
 	var rpcSend rpcSendFn = func(_ rpc.Options, _ string, _ []net.Addr,
 		getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message,
-		_ *rpc.Context) ([]proto.Message, error) {
+		_ *rpc.Context) (proto.Message, error) {
 		// TODO(tschottdorf): remove getReply().
 		if ltc.Latency > 0 {
 			time.Sleep(ltc.Latency)
@@ -93,7 +93,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 			panic(roachpb.ErrorUnexpectedlySet(ltc.stores, br))
 		}
 		br.Error = pErr
-		return []proto.Message{br}, nil
+		return br, nil
 	}
 	retryOpts := GetDefaultDistSenderRetryOptions()
 	retryOpts.Closer = ltc.Stopper.ShouldDrain()

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -50,12 +50,9 @@ func TestUnregisteredMethod(t *testing.T) {
 
 	_, ln := newTestServer(t, nodeContext, false)
 
-	opts := Options{
-		N: 1,
-	}
-
 	// Sending an invalid method fails cleanly, but leaves the connection
 	// in a valid state.
+	opts := Options{}
 	_, err := sendRPC(opts, []net.Addr{ln.Addr()}, nodeContext, "Foo.Bar",
 		&PingRequest{}, &PingResponse{})
 	if !testutils.IsError(err, ".*rpc: couldn't find method: Foo.Bar") {


### PR DESCRIPTION
It never had a value other than 1 in non-test code. This allowed
simplification of the rpc.Send() signature to only return a single
response.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4034)

<!-- Reviewable:end -->
