### PR TITLE
sql: prepare support for INSERT, UPDATE, DELETE

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -49,6 +49,10 @@ func (p *planner) Delete(n *parser.Delete) (planNode, *roachpb.Error) {
 		return nil, pErr
 	}
 
+	if p.prepareOnly {
+		return nil, nil
+	}
+
 	// Construct a map from column ID to the index the value appears at within a
 	// row.
 	colIDtoRowIndex, pErr := makeColIDtoRowIndex(rows, tableDesc)

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -1421,7 +1421,7 @@ func typeTuple(params MapArgs, args DTuple) (Datum, error) {
 	}
 	if hasValArgs {
 		for _, arg := range args {
-			_, err := params.setInferredType(arg, datum)
+			_, err := params.SetInferredType(arg, datum)
 			if err != nil {
 				return nil, err
 			}

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -1374,7 +1374,7 @@ func (t Tuple) Eval(ctx EvalContext) (Datum, error) {
 
 // Eval implements the Expr interface.
 func (t ValArg) Eval(_ EvalContext) (Datum, error) {
-	return nil, util.Errorf("unhandled type %T", t)
+	return DValArg{name: t.name}, nil
 }
 
 // Eval implements the Expr interface.

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -61,12 +61,12 @@ func (expr *BinaryExpr) TypeCheck(args MapArgs) (Datum, error) {
 	expr.rtype = reflect.TypeOf(dummyRight)
 
 	if expr.ltype == valargType {
-		if _, err := args.setInferredType(dummyLeft, dummyRight); err != nil {
+		if _, err := args.SetInferredType(dummyLeft, dummyRight); err != nil {
 			return nil, err
 		}
 		expr.ltype = expr.rtype
 	} else if expr.rtype == valargType {
-		if _, err := args.setInferredType(dummyRight, dummyLeft); err != nil {
+		if _, err := args.SetInferredType(dummyRight, dummyLeft); err != nil {
 			return nil, err
 		}
 		expr.rtype = expr.ltype
@@ -133,7 +133,7 @@ func (expr *CastExpr) TypeCheck(args MapArgs) (Datum, error) {
 		return nil, err
 	}
 
-	if set, err := args.setInferredType(dummyExpr, DummyString); err != nil {
+	if set, err := args.SetInferredType(dummyExpr, DummyString); err != nil {
 		return nil, err
 	} else if set != nil {
 		dummyExpr = DummyString
@@ -555,7 +555,7 @@ func typeCheckBooleanExprs(args MapArgs, op string, exprs ...Expr) (Datum, error
 		if dummyExpr == DNull {
 			continue
 		}
-		if set, err := args.setInferredType(dummyExpr, DummyBool); err != nil {
+		if set, err := args.SetInferredType(dummyExpr, DummyBool); err != nil {
 			return nil, err
 		} else if set != nil {
 			continue
@@ -568,11 +568,11 @@ func typeCheckBooleanExprs(args MapArgs, op string, exprs ...Expr) (Datum, error
 }
 
 func typeCheckComparisonOp(args MapArgs, op ComparisonOp, dummyLeft, dummyRight Datum) (Datum, cmpOp, error) {
-	if set, err := args.setInferredType(dummyLeft, dummyRight); err != nil {
+	if set, err := args.SetInferredType(dummyLeft, dummyRight); err != nil {
 		return nil, cmpOp{}, err
 	} else if set != nil {
 		dummyLeft = set
-	} else if set, err := args.setInferredType(dummyRight, dummyLeft); err != nil {
+	} else if set, err := args.SetInferredType(dummyRight, dummyLeft); err != nil {
 		return nil, cmpOp{}, err
 	} else if set != nil {
 		dummyRight = set

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -237,11 +237,11 @@ func (m MapArgs) Arg(name string) (Datum, bool) {
 	return d, ok
 }
 
-// setValArg sets the bind var argument d to the type typ in m. If m is nil
-// or d is not a DValArg, nil is returned. If the bind var argument is set,
+// SetInferredType sets the bind var argument d to the type typ in m. If m is
+// nil or d is not a DValArg, nil is returned. If the bind var argument is set,
 // typ is returned. An error is returned if typ cannot be set because a
 // different type is already present.
-func (m MapArgs) setInferredType(d, typ Datum) (set Datum, err error) {
+func (m MapArgs) SetInferredType(d, typ Datum) (set Datum, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -366,25 +366,4 @@ func containsSubquery(expr Expr) bool {
 	v := containsSubqueryVisitor{containsSubquery: false}
 	_ = WalkExpr(&v, expr)
 	return v.containsSubquery
-}
-
-type checkVisitor struct {
-	args MapArgs
-	err  error
-}
-
-func (v *checkVisitor) Visit(expr Expr, pre bool) (Visitor, Expr) {
-	if !pre || v.err != nil {
-		return nil, expr
-	}
-	_, v.err = expr.TypeCheck(v.args)
-	// Return nil to stop recursion since TypeCheck above recurses.
-	return nil, expr
-}
-
-// InferArgs populates args with the inferred types of stmt's placeholders.
-func InferArgs(stmt Statement, args MapArgs) error {
-	v := checkVisitor{args: args}
-	WalkStmt(&v, stmt)
-	return v.err
 }

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -43,6 +43,10 @@ type planner struct {
 	// on these schema changers to roll out the new schema.
 	schemaChangers []SchemaChanger
 
+	// TODO(mjibson): remove prepareOnly in favor of a 2-step prepare-exec solution
+	// that is also able to save the plan to skip work during the exec step.
+	prepareOnly bool
+
 	testingVerifyMetadata func(config.SystemConfig) error
 
 	parser             parser.Parser
@@ -149,6 +153,26 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, *r
 		return p.Values(n)
 	default:
 		return nil, roachpb.NewErrorf("unknown statement type: %T", stmt)
+	}
+}
+
+func (p *planner) prepare(stmt parser.Statement) (planNode, *roachpb.Error) {
+	p.prepareOnly = true
+	switch n := stmt.(type) {
+	case *parser.Delete:
+		return p.Delete(n)
+	case *parser.Insert:
+		return p.Insert(n, false)
+	case *parser.Select:
+		return p.Select(n)
+	case *parser.Update:
+		return p.Update(n)
+	default:
+		// TODO(mjibson): use stmt.PGTag() instead of %T
+		return nil, roachpb.NewUErrorf("prepare statement not supported: %T", stmt)
+
+		// TODO(mjibson): add support for parser.Values.
+		// Broken because it conflicts with INSERT's use of VALUES.
 	}
 }
 

--- a/sql/table.go
+++ b/sql/table.go
@@ -667,7 +667,7 @@ func encodeSecondaryIndexes(tableID ID, indexes []IndexDescriptor,
 // marshalColumnValue returns a Go primitive value equivalent of val, of the
 // type expected by col. If val's type is incompatible with col, or if
 // col's type is not yet implemented, an error is returned.
-func marshalColumnValue(col ColumnDescriptor, val parser.Datum) (interface{}, *roachpb.Error) {
+func marshalColumnValue(col ColumnDescriptor, val parser.Datum, args parser.MapArgs) (interface{}, *roachpb.Error) {
 	if val == parser.DNull {
 		return nil, nil
 	}
@@ -677,37 +677,85 @@ func marshalColumnValue(col ColumnDescriptor, val parser.Datum) (interface{}, *r
 		if v, ok := val.(parser.DBool); ok {
 			return bool(v), nil
 		}
+		if set, err := args.SetInferredType(val, parser.DummyBool); err != nil {
+			return nil, roachpb.NewError(err)
+		} else if set != nil {
+			return nil, nil
+		}
 	case ColumnType_INT:
 		if v, ok := val.(parser.DInt); ok {
 			return int64(v), nil
+		}
+		if set, err := args.SetInferredType(val, parser.DummyInt); err != nil {
+			return nil, roachpb.NewError(err)
+		} else if set != nil {
+			return nil, nil
 		}
 	case ColumnType_FLOAT:
 		if v, ok := val.(parser.DFloat); ok {
 			return float64(v), nil
 		}
+		if set, err := args.SetInferredType(val, parser.DummyFloat); err != nil {
+			return nil, roachpb.NewError(err)
+		} else if set != nil {
+			return nil, nil
+		}
 	case ColumnType_DECIMAL:
 		if v, ok := val.(parser.DDecimal); ok {
 			return v.Decimal, nil
+		}
+		if set, err := args.SetInferredType(val, parser.DummyDecimal); err != nil {
+			return nil, roachpb.NewError(err)
+		} else if set != nil {
+			return nil, nil
 		}
 	case ColumnType_STRING:
 		if v, ok := val.(parser.DString); ok {
 			return string(v), nil
 		}
+		if set, err := args.SetInferredType(val, parser.DummyString); err != nil {
+			return nil, roachpb.NewError(err)
+		} else if set != nil {
+			return nil, nil
+		}
 	case ColumnType_BYTES:
 		if v, ok := val.(parser.DBytes); ok {
 			return string(v), nil
+		}
+		if v, ok := val.(parser.DString); ok {
+			return string(v), nil
+		}
+		if set, err := args.SetInferredType(val, parser.DummyBytes); err != nil {
+			return nil, roachpb.NewError(err)
+		} else if set != nil {
+			return nil, nil
 		}
 	case ColumnType_DATE:
 		if v, ok := val.(parser.DDate); ok {
 			return int64(v), nil
 		}
+		if set, err := args.SetInferredType(val, parser.DummyDate); err != nil {
+			return nil, roachpb.NewError(err)
+		} else if set != nil {
+			return nil, nil
+		}
 	case ColumnType_TIMESTAMP:
 		if v, ok := val.(parser.DTimestamp); ok {
 			return v.Time, nil
 		}
+		if set, err := args.SetInferredType(val, parser.DummyTimestamp); err != nil {
+			return nil, roachpb.NewError(err)
+		} else if set != nil {
+			return nil, nil
+		}
 	case ColumnType_INTERVAL:
 		if v, ok := val.(parser.DInterval); ok {
 			return v.Duration, nil
+		}
+		if set, err := args.SetInferredType(val, parser.DummyInterval); err != nil {
+			return nil, roachpb.NewError(err)
+		} else if set != nil {
+			return nil, nil
 		}
 	default:
 		return nil, roachpb.NewErrorf("unsupported column type: %s", col.Type.Kind)


### PR DESCRIPTION
Make sure prepare statements are run in a transaction.

Use a new boolean flag on the planner to indicate prepare. Statement
implementations will gain knowledge of work to omit during prepare. An
alternative implementation would split up the prepare and exec portions of
the work. However, this would require passing around significant amounts
of state and I think the best implementation is the one here.

Keep a whitelist of statement types that support preparation instead of
attempting to exec them during prepare.

This also functions as a refactor for prepare statements in
general. Previously, we called parser.InferArgs, which walked the statement
and ran TypeCheck on all expressions. It turns out this is not needed,
since Select (and others) do this themselves. Thus, we can invoke those
worker functions directly but teach them about prepareOnly so they can
omit work once the val args have been populated and the type checks done.

Fixes #3819

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4037)

<!-- Reviewable:end -->
