### PR TITLE
Add 'clean' target to ui Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ clean:
 	$(GO) clean $(GOFLAGS) -i github.com/cockroachdb/...
 	find . -name '*.test' -type f -exec rm -f {} \;
 	rm -f .bootstrap
+	make -C ui clean
 
 .PHONY: protobuf
 protobuf:

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -81,16 +81,16 @@ GOGOPROTO_FOLDER  := $(GOPATH)/src/github.com/gogo/protobuf
 GOGOPROTO         := $(GOGOPROTO_FOLDER)/gogoproto/gogo.proto
 PROTO_JSON_TARGET := $(GENERATED_ROOT)/wireproto.json
 
-.PHONY:
+.PHONY: all
 all: lint $(GOBINDATA_TARGET) $(TEST_TARGET) $(PROTO_JSON_TARGET)
 	rm -f $(GOBINDATA_DEBUG_TARGET)
 
-.PHONY:
+.PHONY: lint
 lint: npm.installed
 	stylint -c .stylintrc $(STYL_ROOT)
 	tslint -c $(TS_ROOT)/tslint.json $(shell find $(TS_ROOT) -name '*.ts')
 
-.PHONY:
+.PHONY: debug
 debug: $(GOBINDATA_DEBUG_TARGET) $(TEST_TARGET) $(PROTO_JSON_TARGET)
 	rm -f $(GOBINDATA_TARGET)
 
@@ -143,3 +143,8 @@ $(GOBINDATA_DEBUG_TARGET): $(GOBINDATA_DEBUG_DEPS) bower.installed debug/$(INDEX
 
 watch: debug
 	gulp watch
+
+.PHONY: clean
+clean:
+	rm -f $(REMOTE_DEPS) $(INDEX)
+	rm -rf $(NODE_MODULES) $(BOWER_COMPONENTS) build generated typings


### PR DESCRIPTION
I was running into issues where an interrupted make on the UI left behind a corrupted mess of generated / npm installed files in my ui directory. This 'clean' target fixes that kind of situation.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4038)

<!-- Reviewable:end -->
