### PR TITLE
rpc: Minor rpc.Send optimization.

### DIFF
--- a/rpc/codec/conn.go
+++ b/rpc/codec/conn.go
@@ -32,7 +32,7 @@ import (
 // LZ4 benchmarks slightly faster than Snappy for pure-RPC benchmarks,
 // but slightly slower than Snappy on higher level benchmarks like the
 // ones for the Cockroach client.
-const compressionType = wire.CompressionType_SNAPPY
+const compressionType = wire.CompressionType_NONE
 
 type decompressFunc func(src []byte, uncompressedSize uint32, m proto.Message) error
 


### PR DESCRIPTION
Don't fire off a goroutine to check if the client is healthy before
sending an RPC in the common case where the client is already
healthy. This showed up traces of SELECT operations.

Disable snappy compression of RPCs. This is a minor perf win for small
RPCs and a minor loss for large ones. It also mirrors gRPC which
currently doesn't support compression in Go.

```
name                   old time/op  new time/op  delta
Insert1_Cockroach-8     582µs ± 1%   554µs ± 2%  -4.77%   (p=0.000 n=9+10)
Insert10_Cockroach-8    970µs ± 0%   950µs ± 1%  -2.06%   (p=0.000 n=9+10)
Insert100_Cockroach-8  4.62ms ± 1%  4.68ms ± 1%  +1.20%  (p=0.000 n=10+10)
Update1_Cockroach-8    1.37ms ± 1%  1.36ms ± 1%    ~      (p=0.243 n=10+9)
Update10_Cockroach-8   8.49ms ± 1%  7.96ms ± 1%  -6.32%   (p=0.000 n=9+10)
Update100_Cockroach-8  80.3ms ± 1%  74.8ms ± 1%  -6.81%  (p=0.000 n=10+10)
Delete1_Cockroach-8    1.51ms ± 1%  1.44ms ± 1%  -4.75%    (p=0.000 n=9+8)
Delete10_Cockroach-8   2.68ms ± 1%  2.62ms ± 1%  -2.08%  (p=0.000 n=10+10)
Delete100_Cockroach-8  11.9ms ± 1%  12.0ms ± 1%  +0.96%    (p=0.019 n=9+9)
Scan1_Cockroach-8       375µs ± 0%   350µs ± 1%  -6.80%   (p=0.000 n=9+10)
Scan10_Cockroach-8      432µs ± 0%   408µs ± 0%  -5.55%    (p=0.000 n=9+9)
Scan100_Cockroach-8     867µs ± 1%   869µs ± 1%    ~      (p=0.400 n=10+9)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4039)

<!-- Reviewable:end -->
