### PR TITLE
Remove import aliases for versioned gopkg deps

### DIFF
--- a/cli/zone.go
+++ b/cli/zone.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v1"
 
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/util/log"

--- a/util/http.go
+++ b/util/http.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
-	yaml "gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v1"
 )
 
 const (


### PR DESCRIPTION
While playing around with using [gopkg.in/inf](https://godoc.org/gopkg.in/inf.v0), I realized the import aliases for gopkg dependencies with the version at the end aren't needed. This is supported by "Refer to it as yaml" here http://gopkg.in/yaml.v1.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4040)

<!-- Reviewable:end -->
