### PR TITLE
sql: Replace shopspring/decimal library with inf.v0 decimal library

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -20,7 +20,6 @@ github.com/cockroachdb/c-lz4 c40aaae2fc50293eb8750b34632bc3efe813e23f
 github.com/cockroachdb/c-protobuf 4feb192131ea08dfbd7253a00868ad69cbb61b81
 github.com/cockroachdb/c-rocksdb b7fb7bddcb55be35eacdf67e9e2c931083ce02c4
 github.com/cockroachdb/c-snappy 5c6d0932e0adaffce4bfca7bdf2ac37f79952ccf
-github.com/cockroachdb/decimal 5c4ecc7240b4ae5f60895cb8a5c5bc948a39bbba
 github.com/cockroachdb/stress 59f39ff87026147c876ea51e59ba2f052ec0c228
 github.com/cockroachdb/yacc 443154b1852a8702b07d675da6cd97cd9177a316
 github.com/codahale/hdrhistogram 954f16e8b9ef0e5d5189456aa4c1202758e04f17
@@ -57,4 +56,5 @@ golang.org/x/crypto 3760e016850398b85094c4c99e955b8c3dea5711
 golang.org/x/net c92cdcb05f66ce5b61460e23498d2dc5fcf69aaf
 golang.org/x/text cf4986612c83df6c55578ba198316d1684a9a287
 golang.org/x/tools ae18226edd6df820ca562ef374e4441e6f8f5145
+gopkg.in/inf.v0 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 gopkg.in/yaml.v1 9f9df34309c04878acc86042b16630b0f696e1de

--- a/client/util.go
+++ b/client/util.go
@@ -21,8 +21,9 @@ import (
 	"reflect"
 	"time"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/decimal"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -66,7 +67,7 @@ func marshalValue(v interface{}) (roachpb.Value, error) {
 		r.SetBytes(t)
 		return r, nil
 
-	case decimal.Decimal:
+	case *inf.Dec:
 		err := r.SetDecimal(t)
 		return r, err
 

--- a/client/util.go
+++ b/client/util.go
@@ -67,8 +67,8 @@ func marshalValue(v interface{}) (roachpb.Value, error) {
 		r.SetBytes(t)
 		return r, nil
 
-	case *inf.Dec:
-		err := r.SetDecimal(t)
+	case inf.Dec:
+		err := r.SetDecimal(&t)
 		return r, err
 
 	case roachpb.Key:

--- a/keys/printer_test.go
+++ b/keys/printer_test.go
@@ -21,10 +21,11 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/leaktest"
-	"github.com/cockroachdb/decimal"
 )
 
 func TestPrettyPrint(t *testing.T) {
@@ -119,10 +120,10 @@ func TestPrettyPrint(t *testing.T) {
 			roachpb.RKey(encoding.EncodeTimeDescending(nil, tm))),
 			"/Table/42/Sat Mar  7 11:06:39 UTC 2015"},
 		{MakeKey(MakeTablePrefix(42),
-			roachpb.RKey(encoding.EncodeDecimalAscending(nil, decimal.New(1234, -2)))),
+			roachpb.RKey(encoding.EncodeDecimalAscending(nil, inf.NewDec(1234, 2)))),
 			"/Table/42/12.34"},
 		{MakeKey(MakeTablePrefix(42),
-			roachpb.RKey(encoding.EncodeDecimalDescending(nil, decimal.New(1234, -2)))),
+			roachpb.RKey(encoding.EncodeDecimalDescending(nil, inf.NewDec(1234, 2)))),
 			"/Table/42/-12.34"},
 
 		// others

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -23,9 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/uuid"
-	"github.com/cockroachdb/decimal"
 )
 
 // TestKeyNext tests that the method for creating lexicographic
@@ -314,14 +315,14 @@ func TestSetGetChecked(t *testing.T) {
 		t.Errorf("set %d on a value and extracted it, expected %d back, but got %d", i, i, r)
 	}
 
-	d := decimal.New(11, -1)
-	if err := v.SetDecimal(d); err != nil {
+	dec := inf.NewDec(11, 1)
+	if err := v.SetDecimal(dec); err != nil {
 		t.Fatal(err)
 	}
 	if r, err := v.GetDecimal(); err != nil {
 		t.Fatal(err)
-	} else if !d.Equals(r) {
-		t.Errorf("set %s on a value and extracted it, expected %s back, but got %s", d, d, r)
+	} else if dec.Cmp(r) != 0 {
+		t.Errorf("set %s on a value and extracted it, expected %s back, but got %s", dec, dec, r)
 	}
 
 	if err := v.SetProto(&Value{}); err != nil {

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -582,7 +582,9 @@ func (gp golangParameters) Arg(name string) (parser.Datum, bool) {
 	case time.Duration:
 		return parser.DInterval{Duration: t}, true
 	case *inf.Dec:
-		return parser.DDecimal{Dec: t}, true
+		dd := parser.DDecimal{}
+		dd.Set(t)
+		return dd, true
 	}
 
 	// Handle all types which have an underlying type that can be stored in the

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -37,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
-	"github.com/cockroachdb/decimal"
 )
 
 var testingWaitForMetadata bool
@@ -580,8 +581,8 @@ func (gp golangParameters) Arg(name string) (parser.Datum, bool) {
 		return parser.DTimestamp{Time: t}, true
 	case time.Duration:
 		return parser.DInterval{Duration: t}, true
-	case decimal.Decimal:
-		return parser.DDecimal{Decimal: t}, true
+	case *inf.Dec:
+		return parser.DDecimal{Dec: t}, true
 	}
 
 	// Handle all types which have an underlying type that can be stored in the

--- a/sql/group.go
+++ b/sql/group.go
@@ -21,12 +21,13 @@ import (
 	"math"
 	"strings"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/cockroachdb/decimal"
 )
 
 var aggregates = map[string]func() aggregateImpl{
@@ -657,7 +658,9 @@ func (a *avgAggregate) result() (parser.Datum, error) {
 	case parser.DFloat:
 		return t / parser.DFloat(a.count), nil
 	case parser.DDecimal:
-		return parser.DDecimal{Decimal: t.Div(decimal.New(int64(a.count), 0))}, nil
+		count := inf.NewDec(int64(a.count), 0)
+		t.Dec.QuoRound(t.Dec, count, util.DecimalPrecision, inf.RoundHalfUp)
+		return t, nil
 	default:
 		return parser.DNull, util.Errorf("unexpected SUM result type: %s", t.Type())
 	}
@@ -766,6 +769,12 @@ func (a *sumAggregate) add(datum parser.Datum) error {
 		return nil
 	}
 	if a.sum == nil {
+		switch t := datum.(type) {
+		case parser.DDecimal:
+			// Make copy of decimal to allow for modification later.
+			dec := new(inf.Dec)
+			datum = parser.DDecimal{Dec: dec.Set(t.Dec)}
+		}
 		a.sum = datum
 		return nil
 	}
@@ -785,7 +794,7 @@ func (a *sumAggregate) add(datum parser.Datum) error {
 
 	case parser.DDecimal:
 		if v, ok := a.sum.(parser.DDecimal); ok {
-			a.sum = parser.DDecimal{Decimal: v.Add(t.Decimal)}
+			v.Dec.Add(v.Dec, t.Dec)
 			return nil
 		}
 	}
@@ -797,7 +806,14 @@ func (a *sumAggregate) result() (parser.Datum, error) {
 	if a.sum == nil {
 		return parser.DNull, nil
 	}
-	return a.sum, nil
+	switch t := a.sum.(type) {
+	case parser.DDecimal:
+		// Allocate a new decimal, because this must be idempotent.
+		dec := new(inf.Dec)
+		return parser.DDecimal{Dec: dec.Set(t.Dec)}, nil
+	default:
+		return a.sum, nil
+	}
 }
 
 type varianceAggregate struct {

--- a/sql/group.go
+++ b/sql/group.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/decimal"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -597,6 +598,8 @@ var _ aggregateImpl = &minAggregate{}
 var _ aggregateImpl = &sumAggregate{}
 var _ aggregateImpl = &stddevAggregate{}
 var _ aggregateImpl = &varianceAggregate{}
+var _ aggregateImpl = &floatVarianceAggregate{}
+var _ aggregateImpl = &decimalVarianceAggregate{}
 var _ aggregateImpl = &identAggregate{}
 
 // In order to render the unaggregated (i.e. grouped) fields, during aggregation,
@@ -659,7 +662,7 @@ func (a *avgAggregate) result() (parser.Datum, error) {
 		return t / parser.DFloat(a.count), nil
 	case parser.DDecimal:
 		count := inf.NewDec(int64(a.count), 0)
-		t.Dec.QuoRound(t.Dec, count, util.DecimalPrecision, inf.RoundHalfUp)
+		t.QuoRound(&t.Dec, count, decimal.Precision, inf.RoundHalfUp)
 		return t, nil
 	default:
 		return parser.DNull, util.Errorf("unexpected SUM result type: %s", t.Type())
@@ -772,8 +775,9 @@ func (a *sumAggregate) add(datum parser.Datum) error {
 		switch t := datum.(type) {
 		case parser.DDecimal:
 			// Make copy of decimal to allow for modification later.
-			dec := new(inf.Dec)
-			datum = parser.DDecimal{Dec: dec.Set(t.Dec)}
+			dd := parser.DDecimal{}
+			dd.Set(&t.Dec)
+			datum = dd
 		}
 		a.sum = datum
 		return nil
@@ -794,7 +798,8 @@ func (a *sumAggregate) add(datum parser.Datum) error {
 
 	case parser.DDecimal:
 		if v, ok := a.sum.(parser.DDecimal); ok {
-			v.Dec.Add(v.Dec, t.Dec)
+			v.Add(&v.Dec, &t.Dec)
+			a.sum = v
 			return nil
 		}
 	}
@@ -808,18 +813,18 @@ func (a *sumAggregate) result() (parser.Datum, error) {
 	}
 	switch t := a.sum.(type) {
 	case parser.DDecimal:
-		// Allocate a new decimal, because this must be idempotent.
-		dec := new(inf.Dec)
-		return parser.DDecimal{Dec: dec.Set(t.Dec)}, nil
+		dd := parser.DDecimal{}
+		dd.Set(&t.Dec)
+		return dd, nil
 	default:
 		return a.sum, nil
 	}
 }
 
 type varianceAggregate struct {
-	count   int
-	mean    parser.DFloat
-	sqrDiff parser.DFloat
+	typedAggregate aggregateImpl
+	// Used for passing int64s as *inf.Dec values.
+	tmpDec parser.DDecimal
 }
 
 func newVarianceAggregate() aggregateImpl {
@@ -831,34 +836,128 @@ func (a *varianceAggregate) add(datum parser.Datum) error {
 		return nil
 	}
 
-	var d parser.DFloat
+	const unexpectedErrFormat = "unexpected VARIANCE argument type: %s"
 	switch t := datum.(type) {
-	case parser.DInt:
-		d = parser.DFloat(t)
 	case parser.DFloat:
-		d = t
-	// case parser.DDecimal:
-	// TODO(nvanbenschoten) add support for decimal variance and stddev
-	// aggregation functions. Will require adding decimal.Sqrt() to library.
+		if a.typedAggregate == nil {
+			a.typedAggregate = newFloatVarianceAggregate()
+		} else {
+			switch a.typedAggregate.(type) {
+			case *floatVarianceAggregate:
+			default:
+				return util.Errorf(unexpectedErrFormat, datum.Type())
+			}
+		}
+		return a.typedAggregate.add(t)
+	case parser.DInt:
+		if a.typedAggregate == nil {
+			a.typedAggregate = newDecimalVarianceAggregate()
+		} else {
+			switch a.typedAggregate.(type) {
+			case *decimalVarianceAggregate:
+			default:
+				return util.Errorf(unexpectedErrFormat, datum.Type())
+			}
+		}
+		a.tmpDec.SetUnscaled(int64(t))
+		return a.typedAggregate.add(a.tmpDec)
+	case parser.DDecimal:
+		if a.typedAggregate == nil {
+			a.typedAggregate = newDecimalVarianceAggregate()
+		} else {
+			switch a.typedAggregate.(type) {
+			case *decimalVarianceAggregate:
+			default:
+				return util.Errorf(unexpectedErrFormat, datum.Type())
+			}
+		}
+		return a.typedAggregate.add(t)
 	default:
-		return util.Errorf("unexpected VARIANCE argument type: %s", datum.Type())
+		return util.Errorf(unexpectedErrFormat, datum.Type())
 	}
+}
+
+func (a *varianceAggregate) result() (parser.Datum, error) {
+	if a.typedAggregate == nil {
+		return parser.DNull, nil
+	}
+	return a.typedAggregate.result()
+}
+
+type floatVarianceAggregate struct {
+	count   int
+	mean    float64
+	sqrDiff float64
+}
+
+func newFloatVarianceAggregate() aggregateImpl {
+	return &floatVarianceAggregate{}
+}
+
+func (a *floatVarianceAggregate) add(datum parser.Datum) error {
+	f := float64(datum.(parser.DFloat))
 
 	// Uses the Knuth/Welford method for accurately computing variance online in a
 	// single pass. See http://www.johndcook.com/blog/standard_deviation/ and
 	// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm.
 	a.count++
-	delta := d - a.mean
-	a.mean += delta / parser.DFloat(a.count)
-	a.sqrDiff += delta * (d - a.mean)
+	delta := f - a.mean
+	a.mean += delta / float64(a.count)
+	a.sqrDiff += delta * (f - a.mean)
 	return nil
 }
 
-func (a *varianceAggregate) result() (parser.Datum, error) {
+func (a *floatVarianceAggregate) result() (parser.Datum, error) {
 	if a.count < 2 {
 		return parser.DNull, nil
 	}
-	return a.sqrDiff / (parser.DFloat(a.count) - 1), nil
+	return parser.DFloat(a.sqrDiff / (float64(a.count) - 1)), nil
+}
+
+type decimalVarianceAggregate struct {
+	// Variables used across iterations.
+	count   inf.Dec
+	mean    inf.Dec
+	sqrDiff inf.Dec
+
+	// Variables used as scratch space within iterations.
+	delta inf.Dec
+	tmp   inf.Dec
+}
+
+func newDecimalVarianceAggregate() aggregateImpl {
+	return &decimalVarianceAggregate{}
+}
+
+// Read-only constants used for compuation.
+var (
+	decimalOne = inf.NewDec(1, 0)
+	decimalTwo = inf.NewDec(2, 0)
+)
+
+func (a *decimalVarianceAggregate) add(datum parser.Datum) error {
+	d := datum.(parser.DDecimal).Dec
+
+	// Uses the Knuth/Welford method for accurately computing variance online in a
+	// single pass. See http://www.johndcook.com/blog/standard_deviation/ and
+	// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm.
+	a.count.Add(&a.count, decimalOne)
+	a.delta.Sub(&d, &a.mean)
+	a.tmp.QuoRound(&a.delta, &a.count, decimal.Precision, inf.RoundHalfUp)
+	a.mean.Add(&a.mean, &a.tmp)
+	a.tmp.Sub(&d, &a.mean)
+	a.sqrDiff.Add(&a.sqrDiff, a.delta.Mul(&a.delta, &a.tmp))
+	return nil
+}
+
+func (a *decimalVarianceAggregate) result() (parser.Datum, error) {
+	if a.count.Cmp(decimalTwo) < 0 {
+		return parser.DNull, nil
+	}
+	a.tmp.Sub(&a.count, decimalOne)
+	dd := parser.DDecimal{}
+	dd.QuoRound(&a.sqrDiff, &a.tmp, decimal.Precision, inf.RoundHalfUp)
+	return dd, nil
 }
 
 type stddevAggregate struct {
@@ -866,7 +965,7 @@ type stddevAggregate struct {
 }
 
 func newStddevAggregate() aggregateImpl {
-	return &stddevAggregate{}
+	return &stddevAggregate{varianceAggregate: *newVarianceAggregate().(*varianceAggregate)}
 }
 
 func (a *stddevAggregate) result() (parser.Datum, error) {
@@ -877,6 +976,9 @@ func (a *stddevAggregate) result() (parser.Datum, error) {
 	switch t := variance.(type) {
 	case parser.DFloat:
 		return parser.DFloat(math.Sqrt(float64(t))), nil
+	case parser.DDecimal:
+		decimal.Sqrt(&t.Dec, &t.Dec, decimal.Precision)
+		return t, nil
 	}
 	return nil, util.Errorf("unexpected variance result type: %s", variance.Type())
 }

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -36,15 +36,18 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/uuid"
-	"github.com/cockroachdb/decimal"
 )
 
 var errEmptyInputString = errors.New("the input string must not be empty")
 var errAbsOfMinInt64 = errors.New("abs of min integer value (-9223372036854775808) not defined")
 var errRoundNumberDigits = errors.New("number of digits must be greater than 0")
+var errSqrtOfNegNumber = errors.New("cannot take square root of a negative number")
 
 type argTypes []reflect.Type
 
@@ -650,7 +653,11 @@ var builtins = map[string][]builtin{
 	"variance": {
 		builtin{
 			types:      argTypes{intType},
-			returnType: typeFloat,
+			returnType: typeDecimal,
+		},
+		builtin{
+			types:      argTypes{decimalType},
+			returnType: typeDecimal,
 		},
 		builtin{
 			types:      argTypes{floatType},
@@ -661,7 +668,11 @@ var builtins = map[string][]builtin{
 	"stddev": {
 		builtin{
 			types:      argTypes{intType},
-			returnType: typeFloat,
+			returnType: typeDecimal,
+		},
+		builtin{
+			types:      argTypes{decimalType},
+			returnType: typeDecimal,
 		},
 		builtin{
 			types:      argTypes{floatType},
@@ -683,7 +694,8 @@ var builtins = map[string][]builtin{
 			returnType: typeDecimal,
 			types:      argTypes{decimalType},
 			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				return DDecimal{Decimal: args[0].(DDecimal).Abs()}, nil
+				dec := new(inf.Dec)
+				return DDecimal{Dec: dec.Abs(args[0].(DDecimal).Dec)}, nil
 			},
 		},
 		builtin{
@@ -756,11 +768,12 @@ var builtins = map[string][]builtin{
 		floatBuiltin2(func(x, y float64) (Datum, error) {
 			return DFloat(math.Trunc(x / y)), nil
 		}),
-		decimalBuiltin2(func(x, y decimal.Decimal) (Datum, error) {
-			if y.Equals(decimal.Zero) {
+		decimalBuiltin2(func(x, y *inf.Dec) (Datum, error) {
+			if y.Sign() == 0 {
 				return nil, errDivByZero
 			}
-			return DDecimal{Decimal: x.Div(y).Truncate(0)}, nil
+			dec := new(inf.Dec)
+			return DDecimal{Dec: dec.QuoRound(x, y, 0, inf.RoundDown)}, nil
 		}),
 	},
 
@@ -773,8 +786,9 @@ var builtins = map[string][]builtin{
 		floatBuiltin1(func(x float64) (Datum, error) {
 			return DFloat(math.Floor(x)), nil
 		}),
-		decimalBuiltin1(func(x decimal.Decimal) (Datum, error) {
-			return DDecimal{Decimal: x.Floor()}, nil
+		decimalBuiltin1(func(x *inf.Dec) (Datum, error) {
+			dec := new(inf.Dec)
+			return DDecimal{Dec: dec.Round(x, 0, inf.RoundFloor)}, nil
 		}),
 	},
 
@@ -792,11 +806,12 @@ var builtins = map[string][]builtin{
 		floatBuiltin2(func(x, y float64) (Datum, error) {
 			return DFloat(math.Mod(x, y)), nil
 		}),
-		decimalBuiltin2(func(x, y decimal.Decimal) (Datum, error) {
-			if y.Equals(decimal.Zero) {
+		decimalBuiltin2(func(x, y *inf.Dec) (Datum, error) {
+			if y.Sign() == 0 {
 				return nil, errZeroModulus
 			}
-			return DDecimal{Decimal: x.Mod(y)}, nil
+			return nil, nil
+			// TODO
 		}),
 		builtin{
 			returnType: typeInt,
@@ -835,8 +850,9 @@ var builtins = map[string][]builtin{
 		floatBuiltin1(func(x float64) (Datum, error) {
 			return round(x, 0)
 		}),
-		decimalBuiltin1(func(x decimal.Decimal) (Datum, error) {
-			return DDecimal{Decimal: x.Round(0)}, nil
+		decimalBuiltin1(func(x *inf.Dec) (Datum, error) {
+			dec := new(inf.Dec)
+			return DDecimal{Dec: dec.Round(x, 0, inf.RoundHalfUp)}, nil
 		}),
 		builtin{
 			returnType: typeFloat,
@@ -849,7 +865,8 @@ var builtins = map[string][]builtin{
 			returnType: typeFloat,
 			types:      argTypes{decimalType, intType},
 			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				return DDecimal{Decimal: args[0].(DDecimal).Round(int32(args[1].(DInt)))}, nil
+				dec := new(inf.Dec)
+				return DDecimal{Dec: dec.Round(args[0].(DDecimal).Dec, inf.Scale(args[1].(DInt)), inf.RoundHalfUp)}, nil
 			},
 		},
 	},
@@ -870,8 +887,8 @@ var builtins = map[string][]builtin{
 			}
 			return DFloat(1), nil
 		}),
-		decimalBuiltin1(func(x decimal.Decimal) (Datum, error) {
-			return DFloat(x.Cmp(decimal.Zero)), nil
+		decimalBuiltin1(func(x *inf.Dec) (Datum, error) {
+			return DFloat(x.Sign()), nil
 		}),
 		builtin{
 			returnType: typeInt,
@@ -904,8 +921,9 @@ var builtins = map[string][]builtin{
 		floatBuiltin1(func(x float64) (Datum, error) {
 			return DFloat(math.Trunc(x)), nil
 		}),
-		decimalBuiltin1(func(x decimal.Decimal) (Datum, error) {
-			return DDecimal{Decimal: x.Truncate(0)}, nil
+		decimalBuiltin1(func(x *inf.Dec) (Datum, error) {
+			dec := new(inf.Dec)
+			return DDecimal{Dec: dec.Round(x, 0, inf.RoundDown)}, nil
 		}),
 	},
 }
@@ -1010,8 +1028,9 @@ var ceilImpl = []builtin{
 	floatBuiltin1(func(x float64) (Datum, error) {
 		return DFloat(math.Ceil(x)), nil
 	}),
-	decimalBuiltin1(func(x decimal.Decimal) (Datum, error) {
-		return DDecimal{Decimal: x.Ceil()}, nil
+	decimalBuiltin1(func(x *inf.Dec) (Datum, error) {
+		dec := new(inf.Dec)
+		return DDecimal{Dec: dec.Round(x, 0, inf.RoundCeil)}, nil
 	}),
 }
 
@@ -1049,23 +1068,23 @@ func floatBuiltin2(f func(float64, float64) (Datum, error)) builtin {
 	}
 }
 
-func decimalBuiltin1(f func(decimal.Decimal) (Datum, error)) builtin {
+func decimalBuiltin1(f func(*inf.Dec) (Datum, error)) builtin {
 	return builtin{
 		types:      argTypes{decimalType},
 		returnType: typeDecimal,
 		fn: func(_ EvalContext, args DTuple) (Datum, error) {
-			return f(args[0].(DDecimal).Decimal)
+			return f(args[0].(DDecimal).Dec)
 		},
 	}
 }
 
-func decimalBuiltin2(f func(decimal.Decimal, decimal.Decimal) (Datum, error)) builtin {
+func decimalBuiltin2(f func(*inf.Dec, *inf.Dec) (Datum, error)) builtin {
 	return builtin{
 		types:      argTypes{decimalType, decimalType},
 		returnType: typeDecimal,
 		fn: func(_ EvalContext, args DTuple) (Datum, error) {
-			return f(args[0].(DDecimal).Decimal,
-				args[1].(DDecimal).Decimal)
+			return f(args[0].(DDecimal).Dec,
+				args[1].(DDecimal).Dec)
 		},
 	}
 }
@@ -1082,7 +1101,10 @@ func floatOrDecimalBuiltin1(f func(float64) (Datum, error)) []builtin {
 			types:      argTypes{decimalType},
 			returnType: typeDecimal,
 			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				v, _ := args[0].(DDecimal).Float64()
+				v, err := util.Float64FromDec(args[0].(DDecimal).Dec)
+				if err != nil {
+					return nil, err
+				}
 				r, err := f(v)
 				if err != nil {
 					return r, err
@@ -1093,7 +1115,7 @@ func floatOrDecimalBuiltin1(f func(float64) (Datum, error)) []builtin {
 					// into the decimal library to support it here.
 					return nil, fmt.Errorf("decimal does not support NaN")
 				}
-				return DDecimal{Decimal: decimal.NewFromFloat(rf)}, nil
+				return DDecimal{Dec: util.NewDecFromFloat(rf)}, nil
 			},
 		},
 	}
@@ -1112,8 +1134,14 @@ func floatOrDecimalBuiltin2(f func(float64, float64) (Datum, error)) []builtin {
 			types:      argTypes{decimalType, decimalType},
 			returnType: typeDecimal,
 			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				v1, _ := args[0].(DDecimal).Float64()
-				v2, _ := args[1].(DDecimal).Float64()
+				v1, err := util.Float64FromDec(args[0].(DDecimal).Dec)
+				if err != nil {
+					return nil, err
+				}
+				v2, err := util.Float64FromDec(args[1].(DDecimal).Dec)
+				if err != nil {
+					return nil, err
+				}
 				r, err := f(v1, v2)
 				if err != nil {
 					return r, err
@@ -1124,7 +1152,7 @@ func floatOrDecimalBuiltin2(f func(float64, float64) (Datum, error)) []builtin {
 					// into the decimal library to support it here.
 					return nil, fmt.Errorf("decimal does not support NaN")
 				}
-				return DDecimal{Decimal: decimal.NewFromFloat(rf)}, nil
+				return DDecimal{Dec: util.NewDecFromFloat(rf)}, nil
 			},
 		},
 	}

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -810,8 +810,7 @@ var builtins = map[string][]builtin{
 			if y.Sign() == 0 {
 				return nil, errZeroModulus
 			}
-			return nil, nil
-			// TODO
+			return DDecimal{Dec: util.DecMod(nil, x, y)}, nil
 		}),
 		builtin{
 			returnType: typeInt,
@@ -906,10 +905,20 @@ var builtins = map[string][]builtin{
 		},
 	},
 
-	// TODO(nvanbenschoten) Add native support for decimal.
-	"sqrt": floatOrDecimalBuiltin1(func(x float64) (Datum, error) {
-		return DFloat(math.Sqrt(x)), nil
-	}),
+	"sqrt": {
+		floatBuiltin1(func(x float64) (Datum, error) {
+			if x < 0 {
+				return nil, errSqrtOfNegNumber
+			}
+			return DFloat(math.Sqrt(x)), nil
+		}),
+		decimalBuiltin1(func(x *inf.Dec) (Datum, error) {
+			if x.Sign() < 0 {
+				return nil, errSqrtOfNegNumber
+			}
+			return DDecimal{Dec: util.DecSqrt(nil, x, util.DecimalPrecision)}, nil
+		}),
+	},
 
 	"tan": {
 		floatBuiltin1(func(x float64) (Datum, error) {

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -25,8 +25,9 @@ import (
 	"strconv"
 	"time"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/decimal"
 )
 
 var (
@@ -333,7 +334,7 @@ func (d DFloat) String() string {
 
 // DDecimal is the decimal Datum.
 type DDecimal struct {
-	decimal.Decimal
+	*inf.Dec
 }
 
 // Type implements the Datum interface.
@@ -357,7 +358,7 @@ func (d DDecimal) Compare(other Datum) int {
 	if !ok {
 		panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
 	}
-	return d.Cmp(v.Decimal)
+	return d.Cmp(v.Dec)
 }
 
 // HasPrev implements the Datum interface.
@@ -391,7 +392,7 @@ func (d DDecimal) IsMin() bool {
 }
 
 func (d DDecimal) String() string {
-	return d.Decimal.String()
+	return d.Dec.String()
 }
 
 // DString is the string Datum.

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -334,7 +334,7 @@ func (d DFloat) String() string {
 
 // DDecimal is the decimal Datum.
 type DDecimal struct {
-	*inf.Dec
+	inf.Dec
 }
 
 // Type implements the Datum interface.
@@ -358,7 +358,7 @@ func (d DDecimal) Compare(other Datum) int {
 	if !ok {
 		panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
 	}
-	return d.Cmp(v.Dec)
+	return d.Cmp(&v.Dec)
 }
 
 // HasPrev implements the Datum interface.

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -331,8 +331,7 @@ var binOps = map[binArgs]binOp{
 			if right.(DDecimal).Sign() == 0 {
 				return nil, errZeroModulus
 			}
-			return nil, nil
-			// TODO
+			return DDecimal{Dec: util.DecMod(nil, left.(DDecimal).Dec, right.(DDecimal).Dec)}, nil
 		},
 	},
 

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -47,7 +47,7 @@ func TestEval(t *testing.T) {
 		{`4 / 5`, `0.8`},
 		{`1.0 / 0.0`, `+Inf`},
 		{`-1.0 * (1.0 / 0.0)`, `-Inf`},
-		{`1.1::decimal / 2.2::decimal`, `0.5`},
+		{`1.1::decimal / 2.2::decimal`, `0.5000000000000000`},
 		// Grouping
 		{`1 + 2 + (3 * 4)`, `15`},
 		// Unary operators.

--- a/sql/parser/type_check_test.go
+++ b/sql/parser/type_check_test.go
@@ -32,6 +32,7 @@ func TestTypeCheck(t *testing.T) {
 		`NULL + 'hello'`,
 		`NULL::int`,
 		`NULL + 'hello'::bytes`,
+		`(1.1::decimal)::decimal`,
 		`NULL = 1`,
 		`1 = NULL`,
 		`true AND NULL`,

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -334,7 +335,7 @@ func (c *v3Conn) handleParse(buf *readBuffer) error {
 		if pq.inTypes[i-1] != 0 {
 			continue
 		}
-		id, ok := datumToOid[v]
+		id, ok := datumToOid[reflect.TypeOf(v)]
 		if !ok {
 			return c.sendError(fmt.Sprintf("unknown datum type: %s", v.Type()))
 		}

--- a/sql/server.go
+++ b/sql/server.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/decimal"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -210,11 +211,11 @@ func datumFromProto(d driver.Datum) parser.Datum {
 	case *driver.Datum_FloatVal:
 		return parser.DFloat(t.FloatVal)
 	case *driver.Datum_DecimalVal:
-		dec, err := decimal.NewFromString(t.DecimalVal)
-		if err != nil {
-			panic(fmt.Sprintf("could not parse decimal: %v", err))
+		dec := new(inf.Dec)
+		if _, ok := dec.SetString(t.DecimalVal); !ok {
+			panic(fmt.Sprintf("could not parse string %q as decimal", t.DecimalVal))
 		}
-		return parser.DDecimal{Decimal: dec}
+		return parser.DDecimal{Dec: dec}
 	case *driver.Datum_BytesVal:
 		return parser.DBytes(t.BytesVal)
 	case *driver.Datum_StringVal:
@@ -250,7 +251,7 @@ func protoFromDatum(datum parser.Datum) driver.Datum {
 		}
 	case parser.DDecimal:
 		return driver.Datum{
-			Payload: &driver.Datum_DecimalVal{DecimalVal: vt.Decimal.String()},
+			Payload: &driver.Datum_DecimalVal{DecimalVal: vt.Dec.String()},
 		}
 	case parser.DBytes:
 		return driver.Datum{

--- a/sql/server.go
+++ b/sql/server.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/inf.v0"
-
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
@@ -211,11 +209,11 @@ func datumFromProto(d driver.Datum) parser.Datum {
 	case *driver.Datum_FloatVal:
 		return parser.DFloat(t.FloatVal)
 	case *driver.Datum_DecimalVal:
-		dec := new(inf.Dec)
-		if _, ok := dec.SetString(t.DecimalVal); !ok {
+		dd := parser.DDecimal{}
+		if _, ok := dd.SetString(t.DecimalVal); !ok {
 			panic(fmt.Sprintf("could not parse string %q as decimal", t.DecimalVal))
 		}
-		return parser.DDecimal{Dec: dec}
+		return dd
 	case *driver.Datum_BytesVal:
 		return parser.DBytes(t.BytesVal)
 	case *driver.Datum_StringVal:

--- a/sql/set.go
+++ b/sql/set.go
@@ -111,7 +111,7 @@ func (p *planner) SetTimeZone(n *parser.SetTimeZone) (planNode, *roachpb.Error) 
 
 	case parser.DDecimal:
 		sixty := inf.NewDec(60, 0)
-		sixty.Mul(sixty, sixty).Mul(sixty, v.Dec)
+		sixty.Mul(sixty, sixty).Mul(sixty, &v.Dec)
 		var ok bool
 		if offset, ok = sixty.Unscaled(); !ok {
 			return nil, roachpb.NewUErrorf("time zone value %s would overflow an int64", sixty)

--- a/sql/table.go
+++ b/sql/table.go
@@ -20,13 +20,14 @@ import (
 	"bytes"
 	"time"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
-	"github.com/cockroachdb/decimal"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -411,9 +412,9 @@ func encodeTableKey(b []byte, val parser.Datum, dir encoding.Direction) ([]byte,
 		return encoding.EncodeFloatDescending(b, float64(t)), nil
 	case parser.DDecimal:
 		if dir == encoding.Ascending {
-			return encoding.EncodeDecimalAscending(b, t.Decimal), nil
+			return encoding.EncodeDecimalAscending(b, t.Dec), nil
 		}
-		return encoding.EncodeDecimalDescending(b, t.Decimal), nil
+		return encoding.EncodeDecimalDescending(b, t.Dec), nil
 	case parser.DString:
 		if dir == encoding.Ascending {
 			return encoding.EncodeStringAscending(b, string(t)), nil
@@ -575,13 +576,13 @@ func decodeTableKey(valType parser.Datum, key []byte, dir encoding.Direction) (
 		}
 		return parser.DFloat(f), rkey, err
 	case parser.DDecimal:
-		var d decimal.Decimal
+		var d *inf.Dec
 		if dir == encoding.Ascending {
 			rkey, d, err = encoding.DecodeDecimalAscending(key, nil)
 		} else {
 			rkey, d, err = encoding.DecodeDecimalDescending(key, nil)
 		}
-		return parser.DDecimal{Decimal: d}, rkey, err
+		return parser.DDecimal{Dec: d}, rkey, err
 	case parser.DString:
 		var r string
 		if dir == encoding.Ascending {
@@ -720,7 +721,7 @@ func marshalColumnValue(col ColumnDescriptor, val parser.Datum, args parser.MapA
 		}
 	case ColumnType_DECIMAL:
 		if v, ok := val.(parser.DDecimal); ok {
-			return v.Decimal, nil
+			return v.Dec, nil
 		}
 		if set, err := args.SetInferredType(val, parser.DummyDecimal); err != nil {
 			return nil, roachpb.NewError(err)
@@ -814,7 +815,7 @@ func unmarshalColumnValue(kind ColumnType_Kind, value *roachpb.Value) (parser.Da
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
-		return parser.DDecimal{Decimal: v}, nil
+		return parser.DDecimal{Dec: v}, nil
 	case ColumnType_STRING:
 		v, err := value.GetBytes()
 		if err != nil {

--- a/sql/table.go
+++ b/sql/table.go
@@ -412,9 +412,9 @@ func encodeTableKey(b []byte, val parser.Datum, dir encoding.Direction) ([]byte,
 		return encoding.EncodeFloatDescending(b, float64(t)), nil
 	case parser.DDecimal:
 		if dir == encoding.Ascending {
-			return encoding.EncodeDecimalAscending(b, t.Dec), nil
+			return encoding.EncodeDecimalAscending(b, &t.Dec), nil
 		}
-		return encoding.EncodeDecimalDescending(b, t.Dec), nil
+		return encoding.EncodeDecimalDescending(b, &t.Dec), nil
 	case parser.DString:
 		if dir == encoding.Ascending {
 			return encoding.EncodeStringAscending(b, string(t)), nil
@@ -582,7 +582,9 @@ func decodeTableKey(valType parser.Datum, key []byte, dir encoding.Direction) (
 		} else {
 			rkey, d, err = encoding.DecodeDecimalDescending(key, nil)
 		}
-		return parser.DDecimal{Dec: d}, rkey, err
+		dd := parser.DDecimal{}
+		dd.Set(d)
+		return dd, rkey, err
 	case parser.DString:
 		var r string
 		if dir == encoding.Ascending {
@@ -815,7 +817,9 @@ func unmarshalColumnValue(kind ColumnType_Kind, value *roachpb.Value) (parser.Da
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
-		return parser.DDecimal{Dec: v}, nil
+		dd := parser.DDecimal{}
+		dd.Set(v)
+		return dd, nil
 	case ColumnType_STRING:
 		v, err := value.GetBytes()
 		if err != nil {

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -341,7 +341,7 @@ SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM kv
 query RRRR
 SELECT AVG(k::decimal), AVG(v::decimal), SUM(k::decimal), SUM(v::decimal) FROM kv
 ----
-5 2.8 30 14
+5.0000000000000000 2.8000000000000000 30 14
 
 query RRII
 SELECT AVG(DISTINCT k), AVG(DISTINCT v), SUM(DISTINCT k), SUM(DISTINCT v) FROM kv
@@ -383,7 +383,7 @@ two 2 true 5
 query RRRR
 SELECT AVG(b), SUM(b), AVG(d), SUM(d) FROM abc
 ----
-1.75 3.5 3.05 6.1
+1.75 3.5 3.0500000000000000 6.1
 
 query error unknown signature for AVG: AVG\(string\)
 SELECT AVG(a) FROM abc
@@ -407,13 +407,13 @@ statement ok
 CREATE TABLE xyz (
   x INT PRIMARY KEY,
   y INT,
-  z INT,
+  z FLOAT,
   INDEX xy (x, y),
   INDEX zyx (z, y, x)
 )
 
 statement ok
-INSERT INTO xyz VALUES (1, 2, 3), (4, 5, 6), (7, NULL, 8)
+INSERT INTO xyz VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0)
 
 query I
 SELECT MIN(x) FROM xyz
@@ -482,31 +482,31 @@ EXPLAIN SELECT MAX(y) FROM xyz WHERE x = 7
 1 revscan xyz@xy 1:/7/#-/8
 
 query I
-SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3)
+SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 1
 
 query ITT
-EXPLAIN SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3)
+EXPLAIN SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 0 group MIN(x)
 1 scan  xyz@zyx 1:/3/2/#-/3/3
 
 query I
-SELECT MAX(x) FROM xyz WHERE (z, y) = (3, 2)
+SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
 1
 
 query ITT
-EXPLAIN SELECT MAX(x) FROM xyz WHERE (z, y) = (3, 2)
+EXPLAIN SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
 0 group   MAX(x)
 1 revscan xyz@zyx 1:/3/2/#-/3/3
 
 query RRR
-SELECT VARIANCE(x), VARIANCE(y), VARIANCE(z) FROM xyz;
+SELECT VARIANCE(x), VARIANCE(y::decimal), VARIANCE(z) FROM xyz;
 ----
-9 4.5 6.333333333333333
+9.0000000000000000 4.5000000000000000 6.333333333333333
 
 query R
 SELECT VARIANCE(x) FROM xyz WHERE x = 10;
@@ -525,9 +525,9 @@ EXPLAIN SELECT VARIANCE(x) FROM xyz WHERE x = 1;
 1 scan xyz@xy /1-/2
 
 query RRR
-SELECT STDDEV(x), STDDEV(y), STDDEV(z) FROM xyz;
+SELECT STDDEV(x), STDDEV(y::decimal), STDDEV(z) FROM xyz;
 ----
-3 2.1213203435596424 2.516611478423583
+3.0000000000000000 2.1213203435596426 2.516611478423583
 
 query R
 SELECT STDDEV(x) FROM xyz WHERE x = 1;

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -633,10 +633,16 @@ SELECT sin(-1.0), sin(0.0), sin(1.0)
 ----
 -0.8414709848078965 0 0.8414709848078965
 
-query RRR
-SELECT sqrt(-1.0), sqrt(4.0), sqrt(9.0::decimal)
+query RR
+SELECT sqrt(4.0), sqrt(9.0::decimal)
 ----
-NaN 2 3
+2 3.0000000000000000
+
+query error cannot take square root of a negative number
+SELECT sqrt(-1.0)
+
+query error cannot take square root of a negative number
+SELECT sqrt(-1.0::decimal)
 
 query RRR
 SELECT tan(-5.0), tan(0.0), tan(5.0)

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -22,10 +22,11 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util/leaktest"
-	"github.com/cockroachdb/decimal"
 )
 
 func TestValues(t *testing.T) {
@@ -148,7 +149,7 @@ func TestGolangParams(t *testing.T) {
 		{float64(1.0), reflect.TypeOf(parser.DummyFloat)},
 
 		// Decimal type.
-		{decimal.New(55, -1), reflect.TypeOf(parser.DummyDecimal)},
+		{inf.NewDec(55, 1), reflect.TypeOf(parser.DummyDecimal)},
 
 		// String type.
 		{"test", reflect.TypeOf(parser.DummyString)},

--- a/util/decimal.go
+++ b/util/decimal.go
@@ -1,0 +1,90 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package util
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"gopkg.in/inf.v0"
+)
+
+// DecimalPrecision defines the minimum precision all inexact decimal
+// calculations should attempt to achieve.
+const DecimalPrecision = 16
+
+// Read-only constants used for compuation.
+var decimalHalf = inf.NewDec(5, 1)
+
+// NewDecFromFloat allocates and returns a new Dec set to the given
+// float64 value. The function will panic if the float is NaN or ±Inf.
+func NewDecFromFloat(f float64) *inf.Dec {
+	switch {
+	case math.IsInf(f, 0):
+		panic("cannot create a decimal from an infinte float")
+	case math.IsNaN(f):
+		panic("cannot create a decimal from an NaN float")
+	}
+
+	s := strconv.FormatFloat(f, 'e', -1, 64)
+
+	// Determine the decimal's exponent.
+	var e10 int64
+	e := strings.IndexByte(s, 'e')
+	for i := e + 2; i < len(s); i++ {
+		e10 = e10*10 + int64(s[i]-'0')
+	}
+	switch s[e+1] {
+	case '-':
+		e10 = -e10
+	case '+':
+	default:
+		panic(fmt.Sprintf("malformed float: %v -> %s", f, s))
+	}
+	e10++
+
+	// Determine the decimal's mantissa.
+	var mant int64
+	i := 0
+	neg := false
+	if s[0] == '-' {
+		i++
+		neg = true
+	}
+	for ; i < e; i++ {
+		if s[i] == '.' {
+			continue
+		}
+		mant = mant*10 + int64(s[i]-'0')
+		e10--
+	}
+	if neg {
+		mant = -mant
+	}
+
+	return inf.NewDec(mant, inf.Scale(-e10))
+}
+
+// Float64FromDec converts a decimal to a float64 value, returning
+// the value and any error that occured. This converson exposes a
+// possible loss of information.
+func Float64FromDec(dec *inf.Dec) (float64, error) {
+	return strconv.ParseFloat(dec.String(), 64)
+}
+

--- a/util/decimal/decimal.go
+++ b/util/decimal/decimal.go
@@ -14,7 +14,7 @@
 //
 // Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
 
-package util
+package decimal
 
 import (
 	"fmt"
@@ -25,9 +25,9 @@ import (
 	"gopkg.in/inf.v0"
 )
 
-// DecimalPrecision defines the minimum precision all inexact decimal
+// Precision defines the minimum precision all inexact decimal
 // calculations should attempt to achieve.
-const DecimalPrecision = 16
+const Precision = 16
 
 // Read-only constants used for compuation.
 var decimalHalf = inf.NewDec(5, 1)
@@ -35,6 +35,12 @@ var decimalHalf = inf.NewDec(5, 1)
 // NewDecFromFloat allocates and returns a new Dec set to the given
 // float64 value. The function will panic if the float is NaN or ±Inf.
 func NewDecFromFloat(f float64) *inf.Dec {
+	return SetFromFloat(new(inf.Dec), f)
+}
+
+// SetFromFloat sets z to the given float64 value and returns z. The
+// function will panic if the float is NaN or ±Inf.
+func SetFromFloat(z *inf.Dec, f float64) *inf.Dec {
 	switch {
 	case math.IsInf(f, 0):
 		panic("cannot create a decimal from an infinte float")
@@ -78,7 +84,7 @@ func NewDecFromFloat(f float64) *inf.Dec {
 		mant = -mant
 	}
 
-	return inf.NewDec(mant, inf.Scale(-e10))
+	return z.SetUnscaled(mant).SetScale(inf.Scale(-e10))
 }
 
 // Float64FromDec converts a decimal to a float64 value, returning
@@ -88,14 +94,14 @@ func Float64FromDec(dec *inf.Dec) (float64, error) {
 	return strconv.ParseFloat(dec.String(), 64)
 }
 
-// DecMod performs the modulo arithmatic x % y and stores the
+// Mod performs the modulo arithmatic x % y and stores the
 // result in z, which is also the return value. It is valid for z
 // to be nil, in which case it will be allocated internally.
-// DecMod will panic if the y is zero.
+// Mod will panic if the y is zero.
 //
 // The modulo calculation is implemented using the algorithm:
 //     x % y = x - (y * ⌊x / y⌋).
-func DecMod(z, x, y *inf.Dec) *inf.Dec {
+func Mod(z, x, y *inf.Dec) *inf.Dec {
 	switch z {
 	case nil:
 		z = new(inf.Dec)
@@ -110,14 +116,14 @@ func DecMod(z, x, y *inf.Dec) *inf.Dec {
 	return z.Sub(x, z.Mul(z, y))
 }
 
-// DecSqrt calculates the square root of x to the specified scale
+// Sqrt calculates the square root of x to the specified scale
 // and stores the result in z, which is also the return value.
 // The function will panic if x is a negative number.
 //
 // The square root calculation is implemented using Newton's Method.
 // We start with an initial estimate for sqrt(d), and then iterate:
 //     x_{n+1} = 1/2 * ( x_n + (d / x_n) ).
-func DecSqrt(z, x *inf.Dec, s inf.Scale) *inf.Dec {
+func Sqrt(z, x *inf.Dec, s inf.Scale) *inf.Dec {
 	switch z {
 	case nil:
 		z = new(inf.Dec)

--- a/util/decimal/decimal_test.go
+++ b/util/decimal/decimal_test.go
@@ -14,15 +14,16 @@
 //
 // Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
 
-package util
+package decimal
 
 import (
 	"math"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/util/randutil"
-
 	"gopkg.in/inf.v0"
+
+	_ "github.com/cockroachdb/cockroach/util/log" // for flags
+	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
 var floatDecimalEqualities = map[float64]*inf.Dec{
@@ -41,6 +42,11 @@ func TestNewDecFromFloat(t *testing.T) {
 	for tf, td := range floatDecimalEqualities {
 		if dec := NewDecFromFloat(tf); dec.Cmp(td) != 0 {
 			t.Errorf("NewDecFromFloat(%f) expected to give %s, but got %s", tf, td, dec)
+		}
+
+		var dec inf.Dec
+		if SetFromFloat(&dec, tf); dec.Cmp(td) != 0 {
+			t.Errorf("SetFromFloat(%f) expected to set decimal to %s, but got %s", tf, td, dec)
 		}
 	}
 }
@@ -77,20 +83,20 @@ func TestDecimalMod(t *testing.T) {
 		exp.SetString(tc.z)
 
 		// Test return value.
-		z := DecMod(nil, x, y)
+		z := Mod(nil, x, y)
 		if exp.Cmp(z) != 0 {
 			t.Errorf("%d: expected %s, got %s", i, exp, z)
 		}
 
 		// Test provided decimal mutation.
 		z.SetString("0.0")
-		DecMod(z, x, y)
+		Mod(z, x, y)
 		if exp.Cmp(z) != 0 {
 			t.Errorf("%d: expected %s, got %s", i, exp, z)
 		}
 
 		// Test same argument mutation.
-		DecMod(x, x, y)
+		Mod(x, x, y)
 		if exp.Cmp(x) != 0 {
 			t.Errorf("%d: expected %s, got %s", i, exp, x)
 		}
@@ -116,7 +122,7 @@ func BenchmarkDecimalMod(b *testing.B) {
 	z := new(inf.Dec)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		DecMod(z, dividends[i%len(dividends)], divisors[i%len(divisors)])
+		Mod(z, dividends[i%len(dividends)], divisors[i%len(divisors)])
 	}
 }
 
@@ -140,20 +146,20 @@ func TestDecimalSqrt(t *testing.T) {
 		exp.SetString(tc.expected)
 
 		// Test return value.
-		z := DecSqrt(nil, x, 16)
+		z := Sqrt(nil, x, 16)
 		if exp.Cmp(z) != 0 {
 			t.Errorf("%d: expected %s, got %s", i, exp, z)
 		}
 
 		// Test provided decimal mutation.
 		z.SetString("0.0")
-		DecSqrt(z, x, 16)
+		Sqrt(z, x, 16)
 		if exp.Cmp(z) != 0 {
 			t.Errorf("%d: expected %s, got %s", i, exp, z)
 		}
 
 		// Test same argument mutation.
-		DecSqrt(x, x, 16)
+		Sqrt(x, x, 16)
 		if exp.Cmp(x) != 0 {
 			t.Errorf("%d: expected %s, got %s", i, exp, x)
 		}
@@ -171,6 +177,6 @@ func BenchmarkDecimalSqrt(b *testing.B) {
 	z := new(inf.Dec)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		DecSqrt(z, vals[i%len(vals)], 16)
+		Sqrt(z, vals[i%len(vals)], 16)
 	}
 }

--- a/util/decimal_test.go
+++ b/util/decimal_test.go
@@ -57,3 +57,120 @@ func TestFloat64FromDec(t *testing.T) {
 	}
 }
 
+func TestDecimalMod(t *testing.T) {
+	tests := []struct {
+		x, y, z string
+	}{
+		{"3", "2", "1"},
+		{"3451204593", "2454495034", "996709559"},
+		{"24544.95034", ".3451204593", "0.3283950433"},
+		{".1", ".1", "0"},
+		{"0", "1.001", "0"},
+		{"-7.5", "2", "-1.5"},
+		{"7.5", "-2", "1.5"},
+		{"-7.5", "-2", "-1.5"},
+	}
+	for i, tc := range tests {
+		x, y, exp := new(inf.Dec), new(inf.Dec), new(inf.Dec)
+		x.SetString(tc.x)
+		y.SetString(tc.y)
+		exp.SetString(tc.z)
+
+		// Test return value.
+		z := DecMod(nil, x, y)
+		if exp.Cmp(z) != 0 {
+			t.Errorf("%d: expected %s, got %s", i, exp, z)
+		}
+
+		// Test provided decimal mutation.
+		z.SetString("0.0")
+		DecMod(z, x, y)
+		if exp.Cmp(z) != 0 {
+			t.Errorf("%d: expected %s, got %s", i, exp, z)
+		}
+
+		// Test same argument mutation.
+		DecMod(x, x, y)
+		if exp.Cmp(x) != 0 {
+			t.Errorf("%d: expected %s, got %s", i, exp, x)
+		}
+	}
+}
+
+func BenchmarkDecimalMod(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+	populate := func(vals []*inf.Dec) []*inf.Dec {
+		for i := range vals {
+			f := 0.0
+			for f == 0 {
+				f = rng.Float64()
+			}
+			vals[i] = NewDecFromFloat(f)
+		}
+		return vals
+	}
+
+	dividends := populate(make([]*inf.Dec, 10000))
+	divisors := populate(make([]*inf.Dec, 10000))
+
+	z := new(inf.Dec)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DecMod(z, dividends[i%len(dividends)], divisors[i%len(divisors)])
+	}
+}
+
+func TestDecimalSqrt(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"0", "0"},
+		{".12345678987654321122763812", "0.3513641841117891"},
+		{"4", "2"},
+		{"9", "3"},
+		{"100", "10"},
+		{"2454495034", "49542.8605754653613946"},
+		{"24544.95034", "156.6682812186308502"},
+		{"1234567898765432112.2763812", "1111111110.0000000055243715"},
+	}
+	for i, tc := range tests {
+		x, exp := new(inf.Dec), new(inf.Dec)
+		x.SetString(tc.input)
+		exp.SetString(tc.expected)
+
+		// Test return value.
+		z := DecSqrt(nil, x, 16)
+		if exp.Cmp(z) != 0 {
+			t.Errorf("%d: expected %s, got %s", i, exp, z)
+		}
+
+		// Test provided decimal mutation.
+		z.SetString("0.0")
+		DecSqrt(z, x, 16)
+		if exp.Cmp(z) != 0 {
+			t.Errorf("%d: expected %s, got %s", i, exp, z)
+		}
+
+		// Test same argument mutation.
+		DecSqrt(x, x, 16)
+		if exp.Cmp(x) != 0 {
+			t.Errorf("%d: expected %s, got %s", i, exp, x)
+		}
+	}
+}
+
+func BenchmarkDecimalSqrt(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+
+	vals := make([]*inf.Dec, 10000)
+	for i := range vals {
+		vals[i] = NewDecFromFloat(math.Abs(rng.Float64()))
+	}
+
+	z := new(inf.Dec)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DecSqrt(z, vals[i%len(vals)], 16)
+	}
+}

--- a/util/decimal_test.go
+++ b/util/decimal_test.go
@@ -1,0 +1,59 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package util
+
+import (
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util/randutil"
+
+	"gopkg.in/inf.v0"
+)
+
+var floatDecimalEqualities = map[float64]*inf.Dec{
+	-987650000: inf.NewDec(-98765, -4),
+	-123.2:     inf.NewDec(-1232, 1),
+	-1:         inf.NewDec(-1, 0),
+	-.00000121: inf.NewDec(-121, 8),
+	0:          inf.NewDec(0, 0),
+	.00000121:  inf.NewDec(121, 8),
+	1:          inf.NewDec(1, 0),
+	123.2:      inf.NewDec(1232, 1),
+	987650000:  inf.NewDec(98765, -4),
+}
+
+func TestNewDecFromFloat(t *testing.T) {
+	for tf, td := range floatDecimalEqualities {
+		if dec := NewDecFromFloat(tf); dec.Cmp(td) != 0 {
+			t.Errorf("NewDecFromFloat(%f) expected to give %s, but got %s", tf, td, dec)
+		}
+	}
+}
+
+func TestFloat64FromDec(t *testing.T) {
+	for tf, td := range floatDecimalEqualities {
+		f, err := Float64FromDec(td)
+		if err != nil {
+			t.Errorf("Float64FromDec(%s) expected to give %f, but returned error: %v", td, tf, err)
+		}
+		if f != tf {
+			t.Errorf("Float64FromDec(%s) expected to give %f, but got %f", td, tf, f)
+		}
+	}
+}
+

--- a/util/encoding/decimal_test.go
+++ b/util/encoding/decimal_test.go
@@ -25,7 +25,7 @@ import (
 
 	"gopkg.in/inf.v0"
 
-	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/decimal"
 	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
@@ -100,7 +100,7 @@ func TestEncodeDecimal(t *testing.T) {
 		Value    *inf.Dec
 		Encoding []byte
 	}{
-		{util.NewDecFromFloat(-math.MaxFloat64), []byte{0x04, 0x64, 0xfc, 0x60, 0x66, 0x44, 0xe4, 0x9e, 0x82, 0xc0, 0x8d, 0x0}},
+		{decimal.NewDecFromFloat(-math.MaxFloat64), []byte{0x04, 0x64, 0xfc, 0x60, 0x66, 0x44, 0xe4, 0x9e, 0x82, 0xc0, 0x8d, 0x0}},
 		{inf.NewDec(-1, -308), []byte{0x04, 0x64, 0xfd, 0x0}},
 		// Four duplicates to make sure -1*10^4 <= -10*10^3 <= -100*10^2 <= -1*10^4
 		{inf.NewDec(-1, -4), []byte{0x0c, 0xfd, 0x0}},
@@ -113,9 +113,9 @@ func TestEncodeDecimal(t *testing.T) {
 		{inf.NewDec(-1, 0), []byte{0x0e, 0xfd, 0x0}},
 		{inf.NewDec(-123, 5), []byte{0x10, 0x1, 0xe6, 0xc3, 0x0}},
 		{inf.NewDec(-1, 307), []byte{0x10, 0x99, 0xeb, 0x0}},
-		{util.NewDecFromFloat(-math.SmallestNonzeroFloat64), []byte{0x10, 0xa1, 0xf5, 0x0}},
+		{decimal.NewDecFromFloat(-math.SmallestNonzeroFloat64), []byte{0x10, 0xa1, 0xf5, 0x0}},
 		{inf.NewDec(0, 0), []byte{0x11}},
-		{util.NewDecFromFloat(math.SmallestNonzeroFloat64), []byte{0x12, 0x5e, 0xa, 0x0}},
+		{decimal.NewDecFromFloat(math.SmallestNonzeroFloat64), []byte{0x12, 0x5e, 0xa, 0x0}},
 		{inf.NewDec(1, 307), []byte{0x12, 0x66, 0x14, 0x0}},
 		{inf.NewDec(123, 5), []byte{0x12, 0xfe, 0x19, 0x3c, 0x0}},
 		{inf.NewDec(123, 4), []byte{0x13, 0x03, 0x2e, 0x0}},
@@ -146,7 +146,7 @@ func TestEncodeDecimal(t *testing.T) {
 		{inf.NewDec(12345, 0), []byte{0x16, 0x03, 0x2f, 0x5a, 0x0}},
 		{inf.NewDec(123450, 0), []byte{0x16, 0x19, 0x45, 0x64, 0x0}},
 		{inf.NewDec(1, -308), []byte{0x1e, 0x9b, 0x2, 0x0}},
-		{util.NewDecFromFloat(math.MaxFloat64), []byte{0x1e, 0x9b, 0x3, 0x9f, 0x99, 0xbb, 0x1b, 0x61, 0x7d, 0x3f, 0x72, 0x0}},
+		{decimal.NewDecFromFloat(math.MaxFloat64), []byte{0x1e, 0x9b, 0x3, 0x9f, 0x99, 0xbb, 0x1b, 0x61, 0x7d, 0x3f, 0x72, 0x0}},
 	}
 
 	var lastEncoded []byte
@@ -205,7 +205,7 @@ func BenchmarkEncodeDecimal(b *testing.B) {
 
 	vals := make([]*inf.Dec, 10000)
 	for i := range vals {
-		vals[i] = util.NewDecFromFloat(rng.Float64())
+		vals[i] = decimal.NewDecFromFloat(rng.Float64())
 	}
 
 	buf := make([]byte, 0, 100)
@@ -221,7 +221,7 @@ func BenchmarkDecodeDecimal(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		d := util.NewDecFromFloat(rng.Float64())
+		d := decimal.NewDecFromFloat(rng.Float64())
 		vals[i] = EncodeDecimalAscending(nil, d)
 	}
 

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -25,8 +25,9 @@ import (
 	"time"
 	"unsafe"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/decimal"
 )
 
 const (
@@ -732,7 +733,7 @@ func prettyPrintFirstValue(b []byte) ([]byte, string, error) {
 		}
 		// Decode both floats and decimals as decimals to avoid
 		// overflow.
-		var d decimal.Decimal
+		var d *inf.Dec
 		b, d, err = DecodeDecimalAscending(b, nil)
 		if err != nil {
 			return b, "", err

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -23,8 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/util/randutil"
-	"github.com/cockroachdb/decimal"
 )
 
 func testBasicEncodeDecode32(encFunc func([]byte, uint32) []byte,
@@ -704,8 +705,8 @@ func TestPeekType(t *testing.T) {
 		{EncodeUvarintDescending(nil, 0), Int},
 		{EncodeFloatAscending(nil, 0), Float},
 		{EncodeFloatDescending(nil, 0), Float},
-		{EncodeDecimalAscending(nil, decimal.Decimal{}), Float},
-		{EncodeDecimalDescending(nil, decimal.Decimal{}), Float},
+		{EncodeDecimalAscending(nil, inf.NewDec(0, 0)), Float},
+		{EncodeDecimalDescending(nil, inf.NewDec(0, 0)), Float},
 		{EncodeBytesAscending(nil, []byte("")), Bytes},
 		{EncodeBytesDescending(nil, []byte("")), BytesDesc},
 		{EncodeTimeAscending(nil, time.Now()), Time},


### PR DESCRIPTION
## Reasons for the change:
- It had become apparent that `shopspring/decimal.Decimal` did not
  provide the level of control over memory allocations that we needed,
  which was a result of their explicit emphasis on ease-of-use over
  performance and immutability. Unfortunately, we are at a point where
  this poor performance was unacceptable, and we needed better memory
  management control when dealing with Decimal calculations. Because
  `inf.Dec` provides pointer semantics in an identical way to the
  `math/big` library, it gives us much better control over when to
  allocate and when to avoid allocations. This is apparent in the
  performance improvements we have seen from switching libraries and
  being smarter about allocations. For example, a relatively naive
  implementation of `dec.Sqrt` using `inf.Dec` to avoid allocations
  resulted in over a 80x speed boost, and an identical implementation of
  `inf.Mod` that simply avoids extra allocations and uses the more
  performant `inf.QuoRound` method over `decimal.Div` resulted in over a
  100x speed boost (see below). It is expected that the speedup would have
  been even more pronounced in the Decimal aggregation routines (`sum`,
  `average`, `variance`, `stddev`), which were able to remove all
  iterative decimal allocations (O(n) space efficiency -> O(1) space
  efficiency).
- Better, more transparent, precision semantics with `inf.Scale`.
- Precision is a retained trait of each decimal. This is important when
  dealing with computation that expects significant digits to be
  preserved (ie. 12 \* 0.50 == 6.0 != 6).
- `inf.Dec` provides direct access to the underlying `big.Int` using
  `dec.Unscaled`, and exposes a constructor that takes a `big.Int`. Both
  features we need that I had been struggling to push upstream.
### Effect on Encoding/Decoding:

```
name             old time/op  new time/op  delta
EncodeDecimal-4   504ns ± 9%   443ns ± 1%  -12.02%  (p=0.008 n=5+5)
DecodeDecimal-4   575ns ±12%   621ns ± 8%     ~     (p=0.056 n=5+5)
```
### Computation Performance Comparison

With `decimal.Decimal`:

```
BenchmarkDecimalMod-4      30000             33416 ns/op
BenchmarkDecimalSqrt-4      2000           1169745 ns/op
```

With `inf.Dec`:

```
BenchmarkDecimalMod-4    2000000               829 ns/op
BenchmarkDecimalSqrt-4     20000             76165 ns/op
```

Comparison:

```
name           old time/op  new time/op  delta
DecimalMod-4    116µs ± 7%     1µs ± 2%  -99.34%  (p=0.008 n=5+5)
DecimalSqrt-4  4.02ms ±11%  0.05ms ± 1%  -98.70%  (p=0.008 n=5+5)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4045)

<!-- Reviewable:end -->
