### PR TITLE
rpc opt: if sends to the local, call the function directly.

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -95,6 +95,8 @@ type Client struct {
 	remoteOffset      RemoteOffset
 	heartbeatInterval time.Duration
 	heartbeatTimeout  time.Duration
+
+	localServer *Server // holds the local RPC server handle
 }
 
 // NewClient returns a client RPC stub for the specified address
@@ -152,6 +154,10 @@ func NewClient(addr net.Addr, context *Context) *Client {
 
 	if !context.DisableCache {
 		clients[key] = c
+	}
+
+	if context.localServer != nil && context.localAddr == c.RemoteAddr().String() {
+		c.localServer = context.localServer
 	}
 
 	retryOpts := clientRetryOptions

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -22,6 +22,9 @@ type Context struct {
 
 	heartbeatInterval time.Duration
 	heartbeatTimeout  time.Duration
+
+	localServer *Server // Holds the local RPC server handle
+	localAddr   string
 }
 
 // NewContext creates an rpc Context with the supplied values.
@@ -42,4 +45,10 @@ func (c *Context) Copy() *Context {
 	copy := *c
 	copy.RemoteClocks = newRemoteClockMonitor(c.localClock)
 	return &copy
+}
+
+// SetLocalServer sets the local RPC server handle to the context.
+func (c *Context) SetLocalServer(s *Server, addr string) {
+	c.localServer = s
+	c.localAddr = addr
 }

--- a/server/server.go
+++ b/server/server.go
@@ -225,6 +225,7 @@ func (s *Server) Start(selfBootstrap bool) error {
 
 	addr := ln.Addr()
 	addrStr := addr.String()
+	s.rpcContext.SetLocalServer(s.rpc, addrStr)
 
 	// Handle self-bootstrapping case for a single node.
 	if selfBootstrap {

--- a/sql/system.go
+++ b/sql/system.go
@@ -124,7 +124,7 @@ func createTableDescriptor(id, parentID ID, schema string, privileges *Privilege
 
 	desc, pErr := makeTableDesc(stmt.(*parser.CreateTable), parentID)
 	if pErr != nil {
-		log.Fatal(err)
+		log.Fatal(pErr)
 	}
 
 	desc.Privileges = privileges

--- a/storage/log.go
+++ b/storage/log.go
@@ -48,7 +48,8 @@ CREATE TABLE system.rangelog (
   eventType     STRING     NOT NULL,
   otherRangeID  INT,
   info          STRING,
-  PRIMARY KEY (timestamp, rangeID)
+  uniqueID      INT        DEFAULT experimental_unique_int(),
+  PRIMARY KEY (timestamp, rangeID, uniqueID)
 );`
 
 type rangeLogEvent struct {


### PR DESCRIPTION
Disabled by default. Enable by setting the environment variable
`ENABLE_LOCAL_CALLS` to `1`.

```
name                   old time/op  new time/op  delta
Insert1_Cockroach-8     473µs ± 2%   392µs ± 2%  -17.16%  (p=0.000 n=10+10)
Insert10_Cockroach-8    860µs ± 1%   769µs ± 1%  -10.53%  (p=0.000 n=10+10)
Insert100_Cockroach-8  4.52ms ± 1%  4.07ms ± 2%  -10.00%  (p=0.000 n=10+10)
Update1_Cockroach-8    1.13ms ± 0%  0.87ms ± 1%  -22.48%   (p=0.000 n=9+10)
Update10_Cockroach-8   6.35ms ± 1%  4.77ms ± 1%  -24.99%  (p=0.000 n=10+10)
Update100_Cockroach-8  60.2ms ± 0%  42.2ms ± 1%  -29.99%   (p=0.000 n=9+10)
Delete1_Cockroach-8    1.46ms ± 1%  1.19ms ± 1%  -18.43%  (p=0.000 n=10+10)
Delete10_Cockroach-8   2.36ms ± 1%  1.90ms ± 1%  -19.61%   (p=0.000 n=9+10)
Delete100_Cockroach-8  11.8ms ± 0%  10.6ms ± 1%   -9.88%    (p=0.000 n=9+9)
Scan1_Cockroach-8       278µs ± 1%   201µs ± 1%  -27.50%  (p=0.000 n=10+10)
Scan10_Cockroach-8      331µs ± 1%   244µs ± 1%  -26.32%  (p=0.000 n=10+10)
Scan100_Cockroach-8     774µs ± 0%   613µs ± 3%  -20.77%   (p=0.000 n=8+10)
```

Closes #3209.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4046)

<!-- Reviewable:end -->
