### PR TITLE
[Tiny fix] Remove calling GoError() from Server.writeSummaries and Store.GetStatus()

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -685,8 +685,8 @@ func Example_node() {
 	defer c.stop()
 
 	// Refresh time series data, which is required to retrieve stats.
-	if err := c.TestServer.WriteSummaries(); err != nil {
-		log.Fatalf("Couldn't write stats summaries: %s", err)
+	if pErr := c.TestServer.WriteSummaries(); pErr != nil {
+		log.Fatalf("Couldn't write stats summaries: %s", pErr)
 	}
 
 	c.Run("node ls")
@@ -711,8 +711,8 @@ func TestNodeStatus(t *testing.T) {
 	defer c.stop()
 
 	// Refresh time series data, which is required to retrieve stats.
-	if err := c.TestServer.WriteSummaries(); err != nil {
-		t.Fatalf("couldn't write stats summaries: %s", err)
+	if pErr := c.TestServer.WriteSummaries(); pErr != nil {
+		t.Fatalf("couldn't write stats summaries: %s", pErr)
 	}
 
 	out, err := c.RunWithCapture("node status 1")

--- a/server/server.go
+++ b/server/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
+	"github.com/cockroachdb/cockroach/roachpb"
 	crpc "github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/server/status"
 	"github.com/cockroachdb/cockroach/sql"
@@ -309,12 +310,12 @@ func (s *Server) startWriteSummaries() {
 
 // writeSummaries retrieves status summaries from the supplied
 // NodeStatusRecorder and persists them to the cockroach data store.
-func (s *Server) writeSummaries() error {
+func (s *Server) writeSummaries() *roachpb.Error {
 	nodeStatus, storeStatuses := s.recorder.GetStatusSummaries()
 	if nodeStatus != nil {
 		key := keys.NodeStatusKey(int32(nodeStatus.Desc.NodeID))
 		if pErr := s.db.Put(key, nodeStatus); pErr != nil {
-			return pErr.GoError()
+			return pErr
 		}
 		if log.V(1) {
 			statusJSON, err := json.Marshal(nodeStatus)
@@ -328,7 +329,7 @@ func (s *Server) writeSummaries() error {
 	for _, ss := range storeStatuses {
 		key := keys.StoreStatusKey(int32(ss.Desc.StoreID))
 		if pErr := s.db.Put(key, &ss); pErr != nil {
-			return pErr.GoError()
+			return pErr
 		}
 		if log.V(1) {
 			statusJSON, err := json.Marshal(&ss)

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -318,6 +318,6 @@ func (ts *TestServer) SetRangeRetryOptions(ro retry.Options) {
 
 // WriteSummaries records summaries of time-series data, which is required for any tests
 // that query server stats.
-func (ts *TestServer) WriteSummaries() error {
+func (ts *TestServer) WriteSummaries() *roachpb.Error {
 	return ts.Server.writeSummaries()
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -1753,7 +1753,7 @@ func raftEntryFormatter(data []byte) string {
 // GetStatus fetches the latest store status from the stored value on the cluster.
 // Returns nil if the scanner has not yet run. The scanner runs once every
 // ctx.ScanInterval.
-func (s *Store) GetStatus() (*StoreStatus, error) {
+func (s *Store) GetStatus() (*StoreStatus, *roachpb.Error) {
 	if s.scanner.Count() == 0 {
 		// The scanner hasn't completed a first run yet.
 		return nil, nil
@@ -1761,7 +1761,7 @@ func (s *Store) GetStatus() (*StoreStatus, error) {
 	key := keys.StoreStatusKey(int32(s.Ident.StoreID))
 	status := &StoreStatus{}
 	if pErr := s.db.GetProto(key, status); pErr != nil {
-		return nil, pErr.GoError()
+		return nil, pErr
 	}
 	return status, nil
 }


### PR DESCRIPTION
Some more cleanup for avoiding `GoError()` when possible.. (It seems `Store.GetStatus()` is not used anywhere.)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4047)

<!-- Reviewable:end -->
