### PR TITLE
sql: select from subqueries

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -110,6 +110,9 @@ type Result struct {
 type ResultColumn struct {
 	Name string
 	Typ  parser.Datum
+
+	// If set, this is an implicit column; used internally.
+	hidden bool
 }
 
 // ResultRow is a collection of values representing a row in a result.

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -84,7 +84,7 @@ func markDebug(plan planNode, mode explainMode) (planNode, *roachpb.Error) {
 		}
 		// Mark the from node as debug (and potentially replace it).
 		newNode, err := markDebug(t.from.node, mode)
-		t.from.node = newNode.(fromNode)
+		t.from.node = newNode
 		return t, err
 
 	case *scanNode:

--- a/sql/join.go
+++ b/sql/join.go
@@ -91,10 +91,6 @@ func (n *indexJoinNode) Columns() []ResultColumn {
 	return n.table.Columns()
 }
 
-func (n *indexJoinNode) isColumnHidden(idx int) bool {
-	return n.table.isColumnHidden(idx)
-}
-
 func (n *indexJoinNode) Ordering() orderingInfo {
 	return n.index.Ordering()
 }

--- a/sql/testdata/subquery
+++ b/sql/testdata/subquery
@@ -1,3 +1,5 @@
+# Tests for subqueries (SELECT statements which are part of a bigger statement).
+
 query I
 SELECT (SELECT 1)
 ----
@@ -145,3 +147,128 @@ query B
 SELECT EXISTS(SELECT 1 FROM kv WHERE k = 2)
 ----
 false
+
+
+# Tests for subquery in the FROM part of a SELECT
+
+query II colnames
+SELECT * FROM (VALUES (1, 2)) AS foo
+----
+column1 column2
+1 2
+
+query error subquery in FROM must have an alias
+SELECT * FROM (VALUES (1, 2))
+
+query IT colnames
+SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS foo
+----
+column1 column2
+1 one
+2 two
+3 three
+
+query III colnames
+SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS foo
+----
+column1 column2 column3
+1       2       3
+4       5       6
+
+query III colnames
+SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS foo (foo1, foo2, foo3)
+----
+foo1 foo2 foo3
+1    2    3
+4    5    6
+
+query III colnames
+SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS foo (foo1, foo2)
+----
+foo1 foo2 column3
+1    2    3
+4    5    6
+
+query III colnames
+SELECT * FROM (SELECT * FROM xyz) AS foo
+----
+x y  z
+1 2  3
+4 5  6
+7 11 12
+
+query III colnames
+SELECT * FROM (SELECT * FROM xyz) AS foo (foo1)
+----
+foo1 y  z
+1    2  3
+4    5  6
+7    11 12
+
+query III colnames
+SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3)) as foo (foo1)
+----
+foo1 moo2 moo3
+1    2    3
+4    5    6
+7    11   12
+
+query III colnames
+SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3) ORDER BY moo1) as foo (foo1)
+----
+foo1 moo2 moo3
+1    2    3
+4    5    6
+7    11   12
+
+query III colnames
+SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3) ORDER BY moo1) as foo (foo1) ORDER BY moo2 DESC
+----
+foo1 moo2 moo3
+7    11   12
+4    5    6
+1    2    3
+
+query III colnames
+SELECT * FROM (SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS moo (moo1, moo2, moo3) WHERE moo1 = 4) as foo (foo1)
+----
+foo1 moo2 moo3
+4    5    6
+
+query III colnames
+SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
+----
+foo1 moo2 moo3
+1    8    8
+2    4    4
+3    1    1
+
+query ITT
+EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
+----
+0 sort   +foo1
+1 sort   +moo2
+2 values 3 columns, 3 rows
+
+query II colnames
+SELECT a, b FROM (VALUES (1, 2, 3), (3, 4, 7), (5, 6, 10)) AS foo (a, b, c) WHERE a + b = c
+----
+a b
+1 2
+3 4
+
+query I colnames
+SELECT foo.a FROM (VALUES (1), (2), (3)) AS foo (a)
+----
+a
+1
+2
+3
+
+query IITT colnames
+SELECT foo.a, a, column2, foo.column2 FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS foo (a)
+----
+a a column2 column2
+1 1 one     one
+2 2 two     two
+3 3 three   three


### PR DESCRIPTION
In this change we add support for subqueries in the FROM part of SELECT
statements. This includes SELECT FROM (VALUES..).

We do away with the fromNode interface since it makes things unnecessarily
difficult. We instead add a "hidden" field to ResultColumn. SetNeededColumns was
also a candidate for that interface but it's actually something that can only be
used with scanNode, and in a very specific way (before index selection and
potential creation of an indexJoinNode).

Fixes #3707 and #2692.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4049)

<!-- Reviewable:end -->
