### PR TITLE
Allow for cockroach to be used as a vendored go module.

### DIFF
--- a/util/caller/resolver.go
+++ b/util/caller/resolver.go
@@ -74,7 +74,7 @@ var defaultRE = func() *regexp.Regexp {
 		// creates packages inside of a "src" directory within their GOPATH.
 		return regexp.MustCompile(".*" + qSep + "src" + pkgStrip)
 	}
-	if !strings.HasSuffix(path, sep+"src") {
+	if !strings.HasSuffix(path, sep+"src") && !strings.HasSuffix(path, sep+"vendor") {
 		panic("unable to find base path for default call resolver, got " + path)
 	}
 	return regexp.MustCompile(regexp.QuoteMeta(path) + pkgStrip)


### PR DESCRIPTION
If you use cockroach as a "vendored" go module (see https://golang.org/s/go15vendor), and then `make build`, then then the built `cockroach` binary doesnt work properly because it panics unless it is inside of a directory named `src`. This patch fixes the problem by allowing both `src` and `vendor` paths.

Example usage of vendoring:

```
brew install glide
mkdir $GOPATH/src/vendor-test
cd $GOPATH/src/vendor-test
glide init
glide get github.com/cockroachdb/cockroach
cd $GOPATH/src/vendor-test/vendor/github.com/cockroachdb/cockroach
make build
./cockroach start --dev # this works now, but previously failed
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4053)

<!-- Reviewable:end -->
