### PR TITLE
Make Error.GoError return errors.New(e.Message)

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -187,7 +187,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 						} else {
 							pErr = db.Put(key, "value")
 						}
-						if _, ok := pErr.GoError().(*roachpb.WriteIntentError); !ok {
+						if _, ok := pErr.GetDetail().(*roachpb.WriteIntentError); !ok {
 							break
 						}
 					}

--- a/client/txn.go
+++ b/client/txn.go
@@ -63,7 +63,7 @@ func (ts *txnSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachp
 	if pErr == nil {
 		ts.Proto.Update(br.Txn)
 		return br, nil
-	} else if _, ok := pErr.GoError().(*roachpb.TransactionAbortedError); ok {
+	} else if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); ok {
 		// On Abort, reset the transaction so we start anew on restart.
 		ts.Proto = roachpb.Transaction{
 			Name:      ts.Proto.Name,

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -163,7 +163,7 @@ func TestTxnResetTxnOnAbort(t *testing.T) {
 
 	txn := NewTxn(*db)
 	_, pErr := txn.db.sender.Send(context.Background(), testPut())
-	if _, ok := pErr.GoError().(*roachpb.TransactionAbortedError); !ok {
+	if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
 		t.Fatalf("expected TransactionAbortedError, got %v", pErr)
 	}
 
@@ -456,7 +456,7 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 			if count != 1 {
 				t.Errorf("%d: expected no retries; got %d", i, count)
 			}
-			if reflect.TypeOf(pErr.GoError()) != reflect.TypeOf(test.err) {
+			if reflect.TypeOf(pErr.GetDetail()) != reflect.TypeOf(test.err) {
 				t.Errorf("%d: expected error of type %T; got %T", i, test.err, pErr)
 			}
 		}

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -639,13 +639,13 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			if log.V(1) {
 				log.Warningf("failed to invoke %s: %s", ba, pErr)
 			}
-			trace.Event(fmt.Sprintf("reply error: %T", pErr.GoError()))
+			trace.Event(fmt.Sprintf("reply error: %T", pErr.GetDetail()))
 
 			// Error handling below.
 			// If retryable, allow retry. For range not found or range
 			// key mismatch errors, we don't backoff on the retry,
 			// but reset the backoff loop so we can retry immediately.
-			switch tErr := pErr.GoError().(type) {
+			switch tErr := pErr.GetDetail().(type) {
 			case *roachpb.SendError:
 				// For an RPC error to occur, we must've been unable to contact
 				// any replicas. In this case, likely all nodes are down (or

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -522,7 +522,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 		b.CPut(targetKey, "new_val", origVal)
 		pErr := txn.CommitInBatch(b)
 		if epoch == 1 {
-			if _, ok := pErr.GoError().(*roachpb.ReadWithinUncertaintyIntervalError); ok {
+			if _, ok := pErr.GetDetail().(*roachpb.ReadWithinUncertaintyIntervalError); ok {
 				if !pErr.GetTxn().Writing {
 					t.Errorf("unexpected non-writing txn on error")
 				}
@@ -605,7 +605,7 @@ func TestPropagateTxnOnPushError(t *testing.T) {
 		// TransactionPushError.Transaction() returns nil.
 		pErr := txn.CommitInBatch(b)
 		if epoch == 1 {
-			if tErr, ok := pErr.GoError().(*roachpb.TransactionPushError); ok {
+			if tErr, ok := pErr.GetDetail().(*roachpb.TransactionPushError); ok {
 				if len(tErr.Txn.ID) == 0 {
 					t.Errorf("txn ID is not set unexpectedly: %s", tErr)
 				}

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -396,7 +396,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 		var pErr *roachpb.Error
 		br, pErr = tc.wrapped.Send(ctx, ba)
 
-		if _, ok := pErr.GoError().(*roachpb.OpRequiresTxnError); ok {
+		if _, ok := pErr.GetDetail().(*roachpb.OpRequiresTxnError); ok {
 			br, pErr = tc.resendWithTxn(ba)
 		}
 
@@ -647,7 +647,7 @@ func (tc *TxnCoordSender) updateState(ctx context.Context, ba roachpb.BatchReque
 	pErr = proto.Clone(pErr).(*roachpb.Error)
 	// TODO(bdarnell): We're writing to errors here (and where using ErrorWithIndex);
 	// since there's no concept of ownership copy-on-write is always preferable.
-	switch t := pErr.GoError().(type) {
+	switch t := pErr.GetDetail().(type) {
 	case nil:
 		newTxn.Update(br.Txn)
 		// Move txn timestamp forward to response timestamp if applicable.

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -358,7 +358,7 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 				}
 			case 1:
 				// Past deadline.
-				if _, ok := pErr.GoError().(*roachpb.TransactionAbortedError); !ok {
+				if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
 					t.Errorf("expected TransactionAbortedError but got %T: %s", pErr, pErr)
 				}
 			case 2:
@@ -391,7 +391,7 @@ func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 	if err := txn.Put("x", "y"); err != nil {
 		t.Fatal(err)
 	}
-	err, ok := txn.CPut(key, []byte("x"), []byte("born to fail")).GoError().(*roachpb.ConditionFailedError)
+	err, ok := txn.CPut(key, []byte("x"), []byte("born to fail")).GetDetail().(*roachpb.ConditionFailedError)
 	if !ok {
 		t.Fatal(err)
 	}
@@ -433,7 +433,7 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 	// Now end the transaction and verify we've cleanup up, even though
 	// end transaction failed.
 	pErr := txn1.Commit()
-	switch pErr.GoError().(type) {
+	switch pErr.GetDetail().(type) {
 	case *roachpb.TransactionAbortedError:
 		// Expected
 	default:

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -210,10 +210,10 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 				// Read within the transaction.
 				gr, pErr := txn.Get(key)
 				if pErr != nil {
-					if _, ok := pErr.GoError().(*roachpb.ReadWithinUncertaintyIntervalError); ok {
+					if _, ok := pErr.GetDetail().(*roachpb.ReadWithinUncertaintyIntervalError); ok {
 						return pErr
 					}
-					return roachpb.NewErrorf("unexpected read error of type %s: %s", reflect.TypeOf(pErr.GoError()), pErr)
+					return roachpb.NewErrorf("unexpected read error of type %s: %s", reflect.TypeOf(pErr.GetDetail()), pErr)
 				}
 				if !gr.Exists() {
 					return roachpb.NewErrorf("no value read")

--- a/roachpb/api_test.go
+++ b/roachpb/api_test.go
@@ -19,16 +19,15 @@ package roachpb
 import (
 	"reflect"
 	"testing"
-
-	"github.com/cockroachdb/cockroach/util/retry"
 )
 
 type testError struct{}
 
-func (t *testError) Error() string             { return "test" }
-func (t *testError) CanRetry() bool            { return true }
-func (t *testError) ErrorIndex() (int32, bool) { return 99, true }
-func (t *testError) SetErrorIndex(_ int32)     { panic("unsupported") }
+func (t *testError) Error() string              { return "test" }
+func (t *testError) message(pErr *Error) string { return "test" }
+func (t *testError) CanRetry() bool             { return true }
+func (t *testError) ErrorIndex() (int32, bool)  { return 99, true }
+func (t *testError) SetErrorIndex(_ int32)      { panic("unsupported") }
 
 // TestSetGoError verifies that a test error that
 // implements retryable or indexed is converted properly into a generic error.
@@ -41,9 +40,6 @@ func TestSetGoErrorGeneric(t *testing.T) {
 	}
 	if !br.Error.Retryable {
 		t.Error("expected generic error to be retryable")
-	}
-	if rErr, ok := br.Error.GoError().(retry.Retryable); !ok || !rErr.CanRetry() {
-		t.Error("generated GoError is not retryable")
 	}
 }
 

--- a/server/node.go
+++ b/server/node.go
@@ -485,7 +485,7 @@ func (n *Node) executeCmd(argsI proto.Message) (proto.Message, error) {
 		br, pErr = n.stores.Send(ctx, *ba)
 		if pErr != nil {
 			br = &roachpb.BatchResponse{}
-			trace.Event(fmt.Sprintf("error: %T", pErr.GoError()))
+			trace.Event(fmt.Sprintf("error: %T", pErr.GetDetail()))
 		}
 		if br.Error != nil {
 			panic(roachpb.ErrorUnexpectedlySet(n.stores, br))

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -52,7 +52,7 @@ func convertBatchError(tableDesc *TableDescriptor, b client.Batch, origPErr *roa
 		panic(fmt.Sprintf("index %d outside of results: %+v", index, b.Results))
 	}
 	result := b.Results[index]
-	if _, ok := origPErr.GoError().(*roachpb.ConditionFailedError); ok {
+	if _, ok := origPErr.GetDetail().(*roachpb.ConditionFailedError); ok {
 		for _, row := range result.Rows {
 			indexID, key, pErr := decodeIndexKeyPrefix(tableDesc, row.Key)
 			if pErr != nil {

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -347,7 +347,7 @@ func (e *Executor) execStmts(sql string, planMaker *planner) Response {
 							break
 						}
 						if pErr := sc.exec(); pErr != nil {
-							if _, ok := pErr.GoError().(*roachpb.ExistingSchemaChangeLeaseError); ok {
+							if _, ok := pErr.GetDetail().(*roachpb.ExistingSchemaChangeLeaseError); ok {
 								// Try again.
 								continue
 							}
@@ -507,7 +507,7 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (Result, 
 // deal with cleaning up transaction state.
 func makeResultFromError(planMaker *planner, pErr *roachpb.Error) Result {
 	if planMaker.txn != nil {
-		if _, ok := pErr.GoError().(*roachpb.SqlTransactionAbortedError); !ok {
+		if _, ok := pErr.GetDetail().(*roachpb.SqlTransactionAbortedError); !ok {
 			planMaker.txn.Cleanup(pErr)
 		}
 	}

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -272,8 +272,8 @@ func (s LeaseStore) Publish(tableID ID, update func(*TableDescriptor) error) *ro
 			return txn.CommitInBatch(b)
 		})
 
-		if _, ok := pErr.GoError().(*roachpb.LeaseVersionChangedError); !ok {
-			if _, ok := pErr.GoError().(*roachpb.DidntUpdateDescriptorError); ok {
+		if _, ok := pErr.GetDetail().(*roachpb.LeaseVersionChangedError); !ok {
+			if _, ok := pErr.GetDetail().(*roachpb.DidntUpdateDescriptorError); ok {
 				return nil
 			}
 			return pErr

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -75,7 +75,7 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, *roachpb.E
 	b.Del(oldKey)
 
 	if pErr := p.txn.Run(&b); pErr != nil {
-		if _, ok := pErr.GoError().(*roachpb.ConditionFailedError); ok {
+		if _, ok := pErr.GetDetail().(*roachpb.ConditionFailedError); ok {
 			return nil, roachpb.NewUErrorf("the new database name %q already exists", string(n.NewName))
 		}
 		return nil, pErr
@@ -175,7 +175,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, *roachpb.Error) 
 	b.Del(tbKey)
 
 	if pErr := p.txn.Run(&b); pErr != nil {
-		if _, ok := pErr.GoError().(*roachpb.ConditionFailedError); ok {
+		if _, ok := pErr.GetDetail().(*roachpb.ConditionFailedError); ok {
 			return nil, roachpb.NewUErrorf("table name %q already exists", n.NewName.Table())
 		}
 		return nil, pErr

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -570,7 +570,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 				for _, sc := range s.schemaChangers {
 					if time.Since(sc.execAfter) > 0 {
 						pErr := sc.exec()
-						if _, ok := pErr.GoError().(*roachpb.ExistingSchemaChangeLeaseError); !ok && pErr != nil {
+						if _, ok := pErr.GetDetail().(*roachpb.ExistingSchemaChangeLeaseError); !ok && pErr != nil {
 							log.Info(pErr)
 						}
 						// Advance the execAfter time so that this schema changer

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -322,7 +322,7 @@ func TestRestoreReplicas(t *testing.T) {
 	incArgs = incrementArgs([]byte("a"), 11)
 	{
 		_, pErr := client.SendWrapped(rg1(mtc.stores[1]), nil, &incArgs)
-		if _, ok := pErr.GoError().(*roachpb.NotLeaderError); !ok {
+		if _, ok := pErr.GetDetail().(*roachpb.NotLeaderError); !ok {
 			t.Fatalf("expected not leader error; got %s", pErr)
 		}
 	}
@@ -1408,7 +1408,7 @@ func TestLeaderRemoveSelf(t *testing.T) {
 
 	// Expect get a RangeNotFoundError.
 	_, pErr := client.SendWrappedWith(rg1(mtc.stores[0]), nil, header, &getArgs)
-	if _, ok := pErr.GoError().(*roachpb.RangeNotFoundError); !ok {
+	if _, ok := pErr.GetDetail().(*roachpb.RangeNotFoundError); !ok {
 		t.Fatalf("expect get RangeNotFoundError, actual get %v ", pErr)
 	}
 }

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -356,7 +356,7 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 	_, pErr := client.SendWrappedWith(rg1(store), nil, roachpb.Header{
 		Txn: txn,
 	}, &lIncArgs)
-	if _, ok := pErr.GoError().(*roachpb.TransactionRetryError); !ok {
+	if _, ok := pErr.GetDetail().(*roachpb.TransactionRetryError); !ok {
 		t.Fatalf("unexpected sequence cache miss: %v", pErr)
 	}
 
@@ -366,7 +366,7 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 		RangeID: newRng.RangeID,
 		Txn:     txn,
 	}, &rIncArgs)
-	if _, ok := pErr.GoError().(*roachpb.TransactionRetryError); !ok {
+	if _, ok := pErr.GetDetail().(*roachpb.TransactionRetryError); !ok {
 		t.Fatalf("unexpected sequence cache miss: %v", pErr)
 	}
 
@@ -501,7 +501,7 @@ func fillRange(store *storage.Store, rangeID roachpb.RangeID, prefix roachpb.Key
 		}, &pArgs)
 		// When the split occurs in the background, our writes may start failing.
 		// We know we can stop writing when this happens.
-		if _, ok := pErr.GoError().(*roachpb.RangeKeyMismatchError); ok {
+		if _, ok := pErr.GetDetail().(*roachpb.RangeKeyMismatchError); ok {
 			return
 		} else if pErr != nil {
 			t.Fatal(pErr)

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -335,7 +335,7 @@ func (m *multiTestContext) rpcSend(_ kv.SendOptions, _ string, addrs []net.Addr,
 		if pErr == nil {
 			return br, nil
 		}
-		switch tErr := pErr.GoError().(type) {
+		switch tErr := pErr.GetDetail().(type) {
 		case *roachpb.RangeKeyMismatchError:
 		case *roachpb.NotLeaderError:
 			if tErr.Leader == nil {
@@ -349,7 +349,7 @@ func (m *multiTestContext) rpcSend(_ kv.SendOptions, _ string, addrs []net.Addr,
 				m.expireLeaderLeases()
 			}
 		default:
-			if testutils.IsError(tErr, `store \d+ not found`) {
+			if testutils.IsPError(pErr, `store \d+ not found`) {
 				break
 			}
 			// If any store fails with an error that doesn't indicate we simply

--- a/storage/range_tree.go
+++ b/storage/range_tree.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/util"
 )
 
 // cachedNode is an in memory cache for use during range tree manipulations.
@@ -59,7 +58,7 @@ func SetupRangeTree(batch engine.Engine, ms *engine.MVCCStats, timestamp roachpb
 }
 
 // flush writes all dirty nodes and the tree to the transaction.
-func (tc *treeContext) flush(b *client.Batch) error {
+func (tc *treeContext) flush(b *client.Batch) {
 	if tc.dirty {
 		b.Put(keys.RangeTreeRoot, tc.tree)
 	}
@@ -72,14 +71,13 @@ func (tc *treeContext) flush(b *client.Batch) error {
 			}
 		}
 	}
-	return nil
 }
 
 // GetRangeTree fetches the RangeTree proto and sets up the range tree context.
-func getRangeTree(txn *client.Txn) (*treeContext, error) {
+func getRangeTree(txn *client.Txn) (*treeContext, *roachpb.Error) {
 	tree := new(roachpb.RangeTree)
 	if pErr := txn.GetProto(keys.RangeTreeRoot, tree); pErr != nil {
-		return nil, pErr.GoError()
+		return nil, pErr
 	}
 	return &treeContext{
 		txn:   txn,
@@ -116,7 +114,7 @@ func (tc *treeContext) dropNode(key roachpb.RKey) {
 
 // getNode returns the RangeTreeNode for the given key. If the key is nil, nil
 // is returned.
-func (tc *treeContext) getNode(key roachpb.RKey) (*roachpb.RangeTreeNode, error) {
+func (tc *treeContext) getNode(key roachpb.RKey) (*roachpb.RangeTreeNode, *roachpb.Error) {
 	if key == nil {
 		return nil, nil
 	}
@@ -131,7 +129,7 @@ func (tc *treeContext) getNode(key roachpb.RKey) (*roachpb.RangeTreeNode, error)
 	// We don't have it cached so fetch it and add it to the cache.
 	node := new(roachpb.RangeTreeNode)
 	if pErr := tc.txn.GetProto(keys.RangeTreeNodeKey(key), node); pErr != nil {
-		return nil, pErr.GoError()
+		return nil, pErr
 	}
 	tc.nodes[keyString] = cachedNode{
 		node:  node,
@@ -150,13 +148,13 @@ func isRed(node *roachpb.RangeTreeNode) bool {
 
 // getSibling returns the other child of the node's parent. Returns nil if the node
 // has no parent or its parent has only one child.
-func (tc *treeContext) getSibling(node *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, error) {
+func (tc *treeContext) getSibling(node *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, *roachpb.Error) {
 	if node == nil || node.ParentKey == nil {
 		return nil, nil
 	}
-	parent, err := tc.getNode(node.ParentKey)
-	if err != nil {
-		return nil, err
+	parent, pErr := tc.getNode(node.ParentKey)
+	if pErr != nil {
+		return nil, pErr
 	}
 	if parent.LeftKey == nil || parent.RightKey == nil {
 		return nil, nil
@@ -169,13 +167,13 @@ func (tc *treeContext) getSibling(node *roachpb.RangeTreeNode) (*roachpb.RangeTr
 
 // getUncle returns the node's parent's sibling. Or nil if the node doesn't have a
 // grandparent or their parent has no sibling.
-func (tc *treeContext) getUncle(node *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, error) {
+func (tc *treeContext) getUncle(node *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, *roachpb.Error) {
 	if node == nil || node.ParentKey == nil {
 		return nil, nil
 	}
-	parent, err := tc.getNode(node.ParentKey)
-	if err != nil {
-		return nil, err
+	parent, pErr := tc.getNode(node.ParentKey)
+	if pErr != nil {
+		return nil, pErr
 	}
 	return tc.getSibling(parent)
 }
@@ -183,17 +181,17 @@ func (tc *treeContext) getUncle(node *roachpb.RangeTreeNode) (*roachpb.RangeTree
 // replaceNode cuts a node away form its parent, substituting a new node or
 // nil. The updated new node is returned. Note that this does not in fact alter
 // the old node in any way, but only the old node's parent and the new node.
-func (tc *treeContext) replaceNode(oldNode, newNode *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, error) {
+func (tc *treeContext) replaceNode(oldNode, newNode *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, *roachpb.Error) {
 	if oldNode.ParentKey == nil {
 		if newNode == nil {
-			return nil, util.Errorf("cannot replace the root node with nil")
+			return nil, roachpb.NewErrorf("cannot replace the root node with nil")
 		}
 		// Update the root key if this was the root.
 		tc.setRootKey(newNode.Key)
 	} else {
-		oldParent, err := tc.getNode(oldNode.ParentKey)
-		if err != nil {
-			return nil, err
+		oldParent, pErr := tc.getNode(oldNode.ParentKey)
+		if pErr != nil {
+			return nil, pErr
 		}
 		if oldParent.LeftKey != nil && oldNode.Key.Equal(oldParent.LeftKey) {
 			if newNode == nil {
@@ -218,20 +216,20 @@ func (tc *treeContext) replaceNode(oldNode, newNode *roachpb.RangeTreeNode) (*ro
 }
 
 // rotateLeft performs a left rotation around the node.
-func (tc *treeContext) rotateLeft(node *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, error) {
-	right, err := tc.getNode(node.RightKey)
-	if err != nil {
-		return nil, err
+func (tc *treeContext) rotateLeft(node *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, *roachpb.Error) {
+	right, pErr := tc.getNode(node.RightKey)
+	if pErr != nil {
+		return nil, pErr
 	}
-	right, err = tc.replaceNode(node, right)
-	if err != nil {
-		return nil, err
+	right, pErr = tc.replaceNode(node, right)
+	if pErr != nil {
+		return nil, pErr
 	}
 	node.RightKey = right.LeftKey
 	if right.LeftKey != nil {
-		rightLeft, err := tc.getNode(right.LeftKey)
-		if err != nil {
-			return nil, err
+		rightLeft, pErr := tc.getNode(right.LeftKey)
+		if pErr != nil {
+			return nil, pErr
 		}
 		rightLeft.ParentKey = node.Key
 		tc.setNode(rightLeft)
@@ -244,20 +242,20 @@ func (tc *treeContext) rotateLeft(node *roachpb.RangeTreeNode) (*roachpb.RangeTr
 }
 
 // rotateRight performs a right rotation around the node.
-func (tc *treeContext) rotateRight(node *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, error) {
-	left, err := tc.getNode(node.LeftKey)
-	if err != nil {
-		return nil, err
+func (tc *treeContext) rotateRight(node *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, *roachpb.Error) {
+	left, pErr := tc.getNode(node.LeftKey)
+	if pErr != nil {
+		return nil, pErr
 	}
-	left, err = tc.replaceNode(node, left)
-	if err != nil {
-		return nil, err
+	left, pErr = tc.replaceNode(node, left)
+	if pErr != nil {
+		return nil, pErr
 	}
 	node.LeftKey = left.RightKey
 	if left.RightKey != nil {
-		leftRight, err := tc.getNode(left.RightKey)
-		if err != nil {
-			return nil, err
+		leftRight, pErr := tc.getNode(left.RightKey)
+		if pErr != nil {
+			return nil, pErr
 		}
 		leftRight.ParentKey = node.Key
 		tc.setNode(leftRight)
@@ -271,37 +269,38 @@ func (tc *treeContext) rotateRight(node *roachpb.RangeTreeNode) (*roachpb.RangeT
 
 // InsertRange adds a new range to the RangeTree. This should only be called
 // from operations that create new ranges, such as AdminSplit.
-func InsertRange(txn *client.Txn, b *client.Batch, key roachpb.RKey) error {
-	tc, err := getRangeTree(txn)
-	if err != nil {
-		return err
+func InsertRange(txn *client.Txn, b *client.Batch, key roachpb.RKey) *roachpb.Error {
+	tc, pErr := getRangeTree(txn)
+	if pErr != nil {
+		return pErr
 	}
 	newNode := &roachpb.RangeTreeNode{
 		Key: key,
 	}
-	if err := tc.insert(newNode); err != nil {
-		return err
+	if pErr := tc.insert(newNode); pErr != nil {
+		return pErr
 	}
-	return tc.flush(b)
+	tc.flush(b)
+	return nil
 }
 
 // insert performs the insertion of a new node into the tree. It walks the tree
 // until it finds the correct location. It will fail if the node already exists
 // as that case should not occur. After inserting the node, it checks all insert
 // cases to ensure the tree is balanced and adjusts it if needed.
-func (tc *treeContext) insert(node *roachpb.RangeTreeNode) error {
+func (tc *treeContext) insert(node *roachpb.RangeTreeNode) *roachpb.Error {
 	if tc.tree.RootKey == nil {
 		tc.setRootKey(node.Key)
 	} else {
 		// Walk the tree to find the right place to insert the new node.
 		currentKey := tc.tree.RootKey
 		for {
-			currentNode, err := tc.getNode(currentKey)
-			if err != nil {
-				return err
+			currentNode, pErr := tc.getNode(currentKey)
+			if pErr != nil {
+				return pErr
 			}
 			if node.Key.Equal(currentNode.Key) {
-				return util.Errorf("key %s already exists in the range tree", node.Key)
+				return roachpb.NewErrorf("key %s already exists in the range tree", node.Key)
 			}
 			if node.Key.Less(currentNode.Key) {
 				if currentNode.LeftKey == nil {
@@ -328,7 +327,7 @@ func (tc *treeContext) insert(node *roachpb.RangeTreeNode) error {
 }
 
 // insertCase1 handles the case when the inserted node is the root node.
-func (tc *treeContext) insertCase1(node *roachpb.RangeTreeNode) error {
+func (tc *treeContext) insertCase1(node *roachpb.RangeTreeNode) *roachpb.Error {
 	if node.ParentKey == nil {
 		node.Black = true
 		tc.setNode(node)
@@ -339,10 +338,10 @@ func (tc *treeContext) insertCase1(node *roachpb.RangeTreeNode) error {
 
 // insertCase2 handles the case when the inserted node has a black parent.
 // In this is the case, no work need to be done, the tree is already correct.
-func (tc *treeContext) insertCase2(node *roachpb.RangeTreeNode) error {
-	parent, err := tc.getNode(node.ParentKey)
-	if err != nil {
-		return err
+func (tc *treeContext) insertCase2(node *roachpb.RangeTreeNode) *roachpb.Error {
+	parent, pErr := tc.getNode(node.ParentKey)
+	if pErr != nil {
+		return pErr
 	}
 	if !isRed(parent) {
 		return nil
@@ -352,23 +351,23 @@ func (tc *treeContext) insertCase2(node *roachpb.RangeTreeNode) error {
 
 // insertCase3 handles the case in which the uncle node is red. If so, the uncle
 // and parent become black and the grandparent becomes red.
-func (tc *treeContext) insertCase3(node *roachpb.RangeTreeNode) error {
-	uncle, err := tc.getUncle(node)
-	if err != nil {
-		return err
+func (tc *treeContext) insertCase3(node *roachpb.RangeTreeNode) *roachpb.Error {
+	uncle, pErr := tc.getUncle(node)
+	if pErr != nil {
+		return pErr
 	}
 	if isRed(uncle) {
-		parent, err := tc.getNode(node.ParentKey)
-		if err != nil {
-			return err
+		parent, pErr := tc.getNode(node.ParentKey)
+		if pErr != nil {
+			return pErr
 		}
 		parent.Black = true
 		tc.setNode(parent)
 		uncle.Black = true
 		tc.setNode(uncle)
-		grandparent, err := tc.getNode(parent.ParentKey)
-		if err != nil {
-			return err
+		grandparent, pErr := tc.getNode(parent.ParentKey)
+		if pErr != nil {
+			return pErr
 		}
 		grandparent.Black = false
 		tc.setNode(grandparent)
@@ -382,39 +381,39 @@ func (tc *treeContext) insertCase3(node *roachpb.RangeTreeNode) error {
 // parent is required. Similarly, if the node is the left child of its parent
 // who is the right child of the grandparent, a right rotation around the parent
 // is required. This only prepares the tree for insertCase5.
-func (tc *treeContext) insertCase4(node *roachpb.RangeTreeNode) error {
-	parent, err := tc.getNode(node.ParentKey)
-	if err != nil {
-		return err
+func (tc *treeContext) insertCase4(node *roachpb.RangeTreeNode) *roachpb.Error {
+	parent, pErr := tc.getNode(node.ParentKey)
+	if pErr != nil {
+		return pErr
 	}
-	grandparent, err := tc.getNode(parent.ParentKey)
-	if err != nil {
-		return err
+	grandparent, pErr := tc.getNode(parent.ParentKey)
+	if pErr != nil {
+		return pErr
 	}
 	if parent.RightKey != nil && grandparent.LeftKey != nil && node.Key.Equal(parent.RightKey) && parent.Key.Equal(grandparent.LeftKey) {
-		if _, err := tc.rotateLeft(parent); err != nil {
-			return err
+		if _, pErr := tc.rotateLeft(parent); pErr != nil {
+			return pErr
 		}
-		node, err = tc.getNode(node.Key)
-		if err != nil {
-			return err
+		node, pErr = tc.getNode(node.Key)
+		if pErr != nil {
+			return pErr
 		}
-		node, err = tc.getNode(node.LeftKey)
-		if err != nil {
-			return err
+		node, pErr = tc.getNode(node.LeftKey)
+		if pErr != nil {
+			return pErr
 		}
 	} else if parent.LeftKey != nil && grandparent.RightKey != nil && node.Key.Equal(parent.LeftKey) && parent.Key.Equal(grandparent.RightKey) {
-		node, err = tc.rotateRight(parent)
-		if err != nil {
-			return err
+		node, pErr = tc.rotateRight(parent)
+		if pErr != nil {
+			return pErr
 		}
-		node, err = tc.getNode(node.Key)
-		if err != nil {
-			return err
+		node, pErr = tc.getNode(node.Key)
+		if pErr != nil {
+			return pErr
 		}
-		node, err = tc.getNode(node.RightKey)
-		if err != nil {
-			return err
+		node, pErr = tc.getNode(node.RightKey)
+		if pErr != nil {
+			return pErr
 		}
 	}
 	return tc.insertCase5(node)
@@ -425,26 +424,26 @@ func (tc *treeContext) insertCase4(node *roachpb.RangeTreeNode) error {
 // grandparent is required. Similarly, if the node is the left child of its
 // parent who is the left child of the grandparent, a left rotation around the
 // grandparent is required.
-func (tc *treeContext) insertCase5(node *roachpb.RangeTreeNode) error {
-	parent, err := tc.getNode(node.ParentKey)
-	if err != nil {
-		return err
+func (tc *treeContext) insertCase5(node *roachpb.RangeTreeNode) *roachpb.Error {
+	parent, pErr := tc.getNode(node.ParentKey)
+	if pErr != nil {
+		return pErr
 	}
 	parent.Black = true
 	tc.setNode(parent)
-	grandparent, err := tc.getNode(parent.ParentKey)
-	if err != nil {
-		return err
+	grandparent, pErr := tc.getNode(parent.ParentKey)
+	if pErr != nil {
+		return pErr
 	}
 	grandparent.Black = false
 	tc.setNode(grandparent)
 	if parent.LeftKey != nil && node.Key.Equal(parent.LeftKey) {
-		if _, err := tc.rotateRight(grandparent); err != nil {
-			return err
+		if _, pErr := tc.rotateRight(grandparent); pErr != nil {
+			return pErr
 		}
 	} else {
-		if _, err := tc.rotateLeft(grandparent); err != nil {
-			return err
+		if _, pErr := tc.rotateLeft(grandparent); pErr != nil {
+			return pErr
 		}
 	}
 	return nil
@@ -452,27 +451,28 @@ func (tc *treeContext) insertCase5(node *roachpb.RangeTreeNode) error {
 
 // DeleteRange removes a range from the RangeTree. This should only be called
 // from operations that remove ranges, such as AdminMerge.
-func DeleteRange(txn *client.Txn, b *client.Batch, key roachpb.RKey) error {
-	tc, err := getRangeTree(txn)
-	if err != nil {
-		return err
+func DeleteRange(txn *client.Txn, b *client.Batch, key roachpb.RKey) *roachpb.Error {
+	tc, pErr := getRangeTree(txn)
+	if pErr != nil {
+		return pErr
 	}
-	node, err := tc.getNode(key)
-	if err != nil {
-		return err
+	node, pErr := tc.getNode(key)
+	if pErr != nil {
+		return pErr
 	}
 	if node == nil {
-		return util.Errorf("could not find range tree node with the key %s", key)
+		return roachpb.NewErrorf("could not find range tree node with the key %s", key)
 	}
-	if err := tc.delete(node); err != nil {
-		return err
+	if pErr := tc.delete(node); pErr != nil {
+		return pErr
 	}
-	return tc.flush(b)
+	tc.flush(b)
+	return nil
 }
 
 // swapNodes swaps all aspects of nodes a and b except their keys. This function
 // is needed in order to accommodate the in-place style delete.
-func (tc *treeContext) swapNodes(a, b *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, *roachpb.RangeTreeNode, error) {
+func (tc *treeContext) swapNodes(a, b *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, *roachpb.RangeTreeNode, *roachpb.Error) {
 	newA := &roachpb.RangeTreeNode{
 		Key:       a.Key,
 		Black:     b.Black,
@@ -491,9 +491,9 @@ func (tc *treeContext) swapNodes(a, b *roachpb.RangeTreeNode) (*roachpb.RangeTre
 	if a.ParentKey != nil {
 		// Only change a's parent's child key if the parent is not b.
 		if !a.ParentKey.Equal(b.Key) {
-			parent, err := tc.getNode(a.ParentKey)
-			if err != nil {
-				return nil, nil, err
+			parent, pErr := tc.getNode(a.ParentKey)
+			if pErr != nil {
+				return nil, nil, pErr
 			}
 			if parent.LeftKey.Equal(a.Key) {
 				parent.LeftKey = b.Key
@@ -510,9 +510,9 @@ func (tc *treeContext) swapNodes(a, b *roachpb.RangeTreeNode) (*roachpb.RangeTre
 
 	if a.LeftKey != nil {
 		if !a.LeftKey.Equal(b.Key) {
-			left, err := tc.getNode(a.LeftKey)
-			if err != nil {
-				return nil, nil, err
+			left, pErr := tc.getNode(a.LeftKey)
+			if pErr != nil {
+				return nil, nil, pErr
 			}
 			left.ParentKey = b.Key
 			tc.setNode(left)
@@ -522,9 +522,9 @@ func (tc *treeContext) swapNodes(a, b *roachpb.RangeTreeNode) (*roachpb.RangeTre
 	}
 	if a.RightKey != nil {
 		if !a.RightKey.Equal(b.Key) {
-			right, err := tc.getNode(a.RightKey)
-			if err != nil {
-				return nil, nil, err
+			right, pErr := tc.getNode(a.RightKey)
+			if pErr != nil {
+				return nil, nil, pErr
 			}
 			right.ParentKey = b.Key
 			tc.setNode(right)
@@ -536,9 +536,9 @@ func (tc *treeContext) swapNodes(a, b *roachpb.RangeTreeNode) (*roachpb.RangeTre
 	if b.ParentKey != nil {
 		// Only change b's parent's child key if the parent is not a.
 		if !b.ParentKey.Equal(a.Key) {
-			parent, err := tc.getNode(b.ParentKey)
-			if err != nil {
-				return nil, nil, err
+			parent, pErr := tc.getNode(b.ParentKey)
+			if pErr != nil {
+				return nil, nil, pErr
 			}
 			if parent.LeftKey.Equal(b.Key) {
 				parent.LeftKey = a.Key
@@ -554,9 +554,9 @@ func (tc *treeContext) swapNodes(a, b *roachpb.RangeTreeNode) (*roachpb.RangeTre
 	}
 	if b.LeftKey != nil {
 		if !b.LeftKey.Equal(a.Key) {
-			left, err := tc.getNode(b.LeftKey)
-			if err != nil {
-				return nil, nil, err
+			left, pErr := tc.getNode(b.LeftKey)
+			if pErr != nil {
+				return nil, nil, pErr
 			}
 			left.ParentKey = a.Key
 			tc.setNode(left)
@@ -566,9 +566,9 @@ func (tc *treeContext) swapNodes(a, b *roachpb.RangeTreeNode) (*roachpb.RangeTre
 	}
 	if b.RightKey != nil {
 		if !b.RightKey.Equal(a.Key) {
-			right, err := tc.getNode(b.RightKey)
-			if err != nil {
-				return nil, nil, err
+			right, pErr := tc.getNode(b.RightKey)
+			if pErr != nil {
+				return nil, nil, pErr
 			}
 			right.ParentKey = a.Key
 			tc.setNode(right)
@@ -586,54 +586,54 @@ func (tc *treeContext) swapNodes(a, b *roachpb.RangeTreeNode) (*roachpb.RangeTre
 // Since this tree is not stored in memory but persisted through the ranges, in
 // place deletion is not possible. Instead, we use the helper function
 // swapNodes above.
-func (tc *treeContext) delete(node *roachpb.RangeTreeNode) error {
+func (tc *treeContext) delete(node *roachpb.RangeTreeNode) *roachpb.Error {
 	key := node.Key
 	if node.LeftKey != nil && node.RightKey != nil {
-		left, err := tc.getNode(node.LeftKey)
-		if err != nil {
-			return err
+		left, pErr := tc.getNode(node.LeftKey)
+		if pErr != nil {
+			return pErr
 		}
-		predecessor, err := tc.getMaxNode(left)
-		if err != nil {
-			return err
+		predecessor, pErr := tc.getMaxNode(left)
+		if pErr != nil {
+			return pErr
 		}
-		node, _, err = tc.swapNodes(node, predecessor)
-		if err != nil {
-			return err
+		node, _, pErr = tc.swapNodes(node, predecessor)
+		if pErr != nil {
+			return pErr
 		}
 	}
 
 	// Node will always have at most one child.
 	var child *roachpb.RangeTreeNode
-	var err error
+	var pErr *roachpb.Error
 	if node.LeftKey != nil {
-		if child, err = tc.getNode(node.LeftKey); err != nil {
-			return err
+		if child, pErr = tc.getNode(node.LeftKey); pErr != nil {
+			return pErr
 		}
 	} else if node.RightKey != nil {
-		if child, err = tc.getNode(node.RightKey); err != nil {
-			return err
+		if child, pErr = tc.getNode(node.RightKey); pErr != nil {
+			return pErr
 		}
 	}
 	if !isRed(node) {
 		// Paint the node to the color of the child node.
 		node.Black = !isRed(child)
 		tc.setNode(node)
-		if err := tc.deleteCase1(node); err != nil {
-			return err
+		if pErr := tc.deleteCase1(node); pErr != nil {
+			return pErr
 		}
 	}
-	if _, err := tc.replaceNode(node, child); err != nil {
-		return err
+	if _, pErr := tc.replaceNode(node, child); pErr != nil {
+		return pErr
 	}
 
 	// Always set the root back to black
-	if node, err = tc.getNode(node.Key); err != nil {
-		return err
+	if node, pErr = tc.getNode(node.Key); pErr != nil {
+		return pErr
 	}
 	if child != nil && node.ParentKey == nil {
-		if child, err = tc.getNode(child.Key); err != nil {
-			return err
+		if child, pErr = tc.getNode(child.Key); pErr != nil {
+			return pErr
 		}
 		child.Black = true
 		tc.setNode(child)
@@ -645,20 +645,20 @@ func (tc *treeContext) delete(node *roachpb.RangeTreeNode) error {
 
 // getMaxNode walks the tree to the right until it gets to a node without a
 // right child and returns that node.
-func (tc *treeContext) getMaxNode(node *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, error) {
+func (tc *treeContext) getMaxNode(node *roachpb.RangeTreeNode) (*roachpb.RangeTreeNode, *roachpb.Error) {
 	if node.RightKey == nil {
 		return node, nil
 	}
-	right, err := tc.getNode(node.RightKey)
-	if err != nil {
-		return nil, err
+	right, pErr := tc.getNode(node.RightKey)
+	if pErr != nil {
+		return nil, pErr
 	}
 	return tc.getMaxNode(right)
 }
 
 // deleteCase1 handles the case when node is the new root. If so, there is
 // nothing to do.
-func (tc *treeContext) deleteCase1(node *roachpb.RangeTreeNode) error {
+func (tc *treeContext) deleteCase1(node *roachpb.RangeTreeNode) *roachpb.Error {
 	if node.ParentKey == nil {
 		return nil
 	}
@@ -666,27 +666,27 @@ func (tc *treeContext) deleteCase1(node *roachpb.RangeTreeNode) error {
 }
 
 // deleteCase2 handles the case when node has a red sibling.
-func (tc *treeContext) deleteCase2(node *roachpb.RangeTreeNode) error {
-	sibling, err := tc.getSibling(node)
-	if err != nil {
-		return err
+func (tc *treeContext) deleteCase2(node *roachpb.RangeTreeNode) *roachpb.Error {
+	sibling, pErr := tc.getSibling(node)
+	if pErr != nil {
+		return pErr
 	}
 	if isRed(sibling) {
-		parent, err := tc.getNode(node.ParentKey)
-		if err != nil {
-			return err
+		parent, pErr := tc.getNode(node.ParentKey)
+		if pErr != nil {
+			return pErr
 		}
 		parent.Black = false
 		sibling.Black = true
 		tc.setNode(parent)
 		tc.setNode(sibling)
 		if parent.LeftKey.Equal(node.Key) {
-			if _, err := tc.rotateLeft(parent); err != nil {
-				return err
+			if _, pErr := tc.rotateLeft(parent); pErr != nil {
+				return pErr
 			}
 		} else {
-			if _, err := tc.rotateRight(parent); err != nil {
-				return err
+			if _, pErr := tc.rotateRight(parent); pErr != nil {
+				return pErr
 			}
 		}
 	}
@@ -695,26 +695,26 @@ func (tc *treeContext) deleteCase2(node *roachpb.RangeTreeNode) error {
 
 // deleteCase3 handles the case when node's parent, sibling and sibling's
 // children are all black.
-func (tc *treeContext) deleteCase3(node *roachpb.RangeTreeNode) error {
+func (tc *treeContext) deleteCase3(node *roachpb.RangeTreeNode) *roachpb.Error {
 	// This check uses cascading ifs to limit the number of db reads.
-	parent, err := tc.getNode(node.ParentKey)
-	if err != nil {
-		return err
+	parent, pErr := tc.getNode(node.ParentKey)
+	if pErr != nil {
+		return pErr
 	}
 	if !isRed(parent) {
-		sibling, err := tc.getSibling(node)
-		if err != nil {
-			return err
+		sibling, pErr := tc.getSibling(node)
+		if pErr != nil {
+			return pErr
 		}
 		if !isRed(sibling) {
-			siblingLeft, err := tc.getNode(sibling.LeftKey)
-			if err != nil {
-				return err
+			siblingLeft, pErr := tc.getNode(sibling.LeftKey)
+			if pErr != nil {
+				return pErr
 			}
 			if !isRed(siblingLeft) {
-				siblingRight, err := tc.getNode(sibling.RightKey)
-				if err != nil {
-					return err
+				siblingRight, pErr := tc.getNode(sibling.RightKey)
+				if pErr != nil {
+					return pErr
 				}
 				if !isRed(siblingRight) {
 					sibling.Black = false
@@ -729,26 +729,26 @@ func (tc *treeContext) deleteCase3(node *roachpb.RangeTreeNode) error {
 
 // deleteCase4 handles the case when node's sibling and siblings children are
 // black, but parent is red.
-func (tc *treeContext) deleteCase4(node *roachpb.RangeTreeNode) error {
+func (tc *treeContext) deleteCase4(node *roachpb.RangeTreeNode) *roachpb.Error {
 	// This check uses cascading ifs to limit the number of db reads.
-	parent, err := tc.getNode(node.ParentKey)
-	if err != nil {
-		return err
+	parent, pErr := tc.getNode(node.ParentKey)
+	if pErr != nil {
+		return pErr
 	}
 	if isRed(parent) {
-		sibling, err := tc.getSibling(node)
-		if err != nil {
-			return err
+		sibling, pErr := tc.getSibling(node)
+		if pErr != nil {
+			return pErr
 		}
 		if !isRed(sibling) {
-			siblingLeft, err := tc.getNode(sibling.LeftKey)
-			if err != nil {
-				return err
+			siblingLeft, pErr := tc.getNode(sibling.LeftKey)
+			if pErr != nil {
+				return pErr
 			}
 			if !isRed(siblingLeft) {
-				siblingRight, err := tc.getNode(sibling.RightKey)
-				if err != nil {
-					return err
+				siblingRight, pErr := tc.getNode(sibling.RightKey)
+				if pErr != nil {
+					return pErr
 				}
 				if !isRed(siblingRight) {
 					sibling.Black = false
@@ -770,22 +770,22 @@ func (tc *treeContext) deleteCase4(node *roachpb.RangeTreeNode) error {
 // its parent, node's sibling is black, node's sibling's left child is black but
 // right child is red. The operations here actually only prepare the tree for
 // deleteCase6.
-func (tc *treeContext) deleteCase5(node *roachpb.RangeTreeNode) error {
-	parent, err := tc.getNode(node.ParentKey)
-	if err != nil {
-		return err
+func (tc *treeContext) deleteCase5(node *roachpb.RangeTreeNode) *roachpb.Error {
+	parent, pErr := tc.getNode(node.ParentKey)
+	if pErr != nil {
+		return pErr
 	}
-	sibling, err := tc.getSibling(node)
-	if err != nil {
-		return err
+	sibling, pErr := tc.getSibling(node)
+	if pErr != nil {
+		return pErr
 	}
-	siblingLeft, err := tc.getNode(sibling.LeftKey)
-	if err != nil {
-		return err
+	siblingLeft, pErr := tc.getNode(sibling.LeftKey)
+	if pErr != nil {
+		return pErr
 	}
-	siblingRight, err := tc.getNode(sibling.RightKey)
-	if err != nil {
-		return err
+	siblingRight, pErr := tc.getNode(sibling.RightKey)
+	if pErr != nil {
+		return pErr
 	}
 	if parent.LeftKey.Equal(node.Key) &&
 		!isRed(sibling) &&
@@ -795,8 +795,8 @@ func (tc *treeContext) deleteCase5(node *roachpb.RangeTreeNode) error {
 		tc.setNode(sibling)
 		siblingLeft.Black = true
 		tc.setNode(siblingLeft)
-		if _, err := tc.rotateRight(sibling); err != nil {
-			return err
+		if _, pErr := tc.rotateRight(sibling); pErr != nil {
+			return pErr
 		}
 	} else if parent.RightKey.Equal(node.Key) &&
 		!isRed(sibling) &&
@@ -806,8 +806,8 @@ func (tc *treeContext) deleteCase5(node *roachpb.RangeTreeNode) error {
 		tc.setNode(sibling)
 		siblingRight.Black = true
 		tc.setNode(siblingRight)
-		if _, err := tc.rotateLeft(sibling); err != nil {
-			return err
+		if _, pErr := tc.rotateLeft(sibling); pErr != nil {
+			return pErr
 		}
 	}
 	return tc.deleteCase6(node)
@@ -818,38 +818,38 @@ func (tc *treeContext) deleteCase5(node *roachpb.RangeTreeNode) error {
 // is red. Or similarly, when node is the right child of its parent, node's
 // sibling is black  and node's sibling's left child is red. No checks are
 // needed here since we have already been forced into this case by deleteCase5.
-func (tc *treeContext) deleteCase6(node *roachpb.RangeTreeNode) error {
-	parent, err := tc.getNode(node.ParentKey)
-	if err != nil {
-		return err
+func (tc *treeContext) deleteCase6(node *roachpb.RangeTreeNode) *roachpb.Error {
+	parent, pErr := tc.getNode(node.ParentKey)
+	if pErr != nil {
+		return pErr
 	}
-	sibling, err := tc.getSibling(node)
-	if err != nil {
-		return err
+	sibling, pErr := tc.getSibling(node)
+	if pErr != nil {
+		return pErr
 	}
 	sibling.Black = parent.Black
 	tc.setNode(sibling)
 	parent.Black = true
 	tc.setNode(parent)
 	if node.Key.Equal(parent.LeftKey) {
-		siblingRight, err := tc.getNode(sibling.RightKey)
-		if err != nil {
-			return err
+		siblingRight, pErr := tc.getNode(sibling.RightKey)
+		if pErr != nil {
+			return pErr
 		}
 		siblingRight.Black = true
 		tc.setNode(siblingRight)
-		if _, err := tc.rotateLeft(parent); err != nil {
-			return err
+		if _, pErr := tc.rotateLeft(parent); pErr != nil {
+			return pErr
 		}
 	} else {
-		siblingLeft, err := tc.getNode(sibling.LeftKey)
-		if err != nil {
-			return err
+		siblingLeft, pErr := tc.getNode(sibling.LeftKey)
+		if pErr != nil {
+			return pErr
 		}
 		siblingLeft.Black = true
 		tc.setNode(siblingLeft)
-		if _, err := tc.rotateRight(parent); err != nil {
-			return err
+		if _, pErr := tc.rotateRight(parent); pErr != nil {
+			return pErr
 		}
 	}
 	return nil

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1310,8 +1310,8 @@ func (r *Replica) AdminSplit(args roachpb.AdminSplitRequest, desc *roachpb.Range
 		}
 		// Update the RangeTree.
 		b = &client.Batch{}
-		if err := InsertRange(txn, b, newDesc.StartKey); err != nil {
-			return roachpb.NewError(err)
+		if pErr := InsertRange(txn, b, newDesc.StartKey); pErr != nil {
+			return pErr
 		}
 		// Log the split into the range event log.
 		if err := r.store.logSplit(txn, updatedDesc, *newDesc); err != nil {
@@ -1548,8 +1548,8 @@ func (r *Replica) AdminMerge(args roachpb.AdminMergeRequest, origLeftDesc *roach
 		}
 
 		// Update the RangeTree.
-		if err := DeleteRange(txn, b, rightDesc.StartKey); err != nil {
-			return roachpb.NewError(err)
+		if pErr := DeleteRange(txn, b, rightDesc.StartKey); pErr != nil {
+			return pErr
 		}
 
 		// End the transaction manually instead of letting RunTransaction

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -145,7 +145,7 @@ func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ *config.
 		// This range is a current member of the raft group. Acquire the lease
 		// to avoid processing this range again before the next inactivity threshold.
 		if pErr := rng.requestLeaderLease(now); pErr != nil {
-			if _, ok := pErr.GoError().(*roachpb.LeaseRejectedError); !ok {
+			if _, ok := pErr.GetDetail().(*roachpb.LeaseRejectedError); !ok {
 				if log.V(1) {
 					log.Infof("unable to acquire lease from valid range %s: %s", rng, pErr)
 				}

--- a/storage/sequence_cache.go
+++ b/storage/sequence_cache.go
@@ -199,7 +199,7 @@ func (sc *SequenceCache) Put(e engine.Engine, id []byte, epoch, seq uint32, txnK
 // are retried on the server, and so are not recorded in the sequence
 // cache in the hopes of retrying to a successful outcome.
 func (sc *SequenceCache) shouldCacheError(pErr *roachpb.Error) bool {
-	switch pErr.GoError().(type) {
+	switch pErr.GetDetail().(type) {
 	case *roachpb.WriteTooOldError, *roachpb.WriteIntentError, *roachpb.NotLeaderError, *roachpb.RangeKeyMismatchError:
 		return false
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -904,7 +904,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 				t.Errorf("expected pushee to be aborted; got %s", txn.Status)
 			}
 		} else {
-			if rErr, ok := pErr.GoError().(*roachpb.TransactionPushError); !ok {
+			if rErr, ok := pErr.GetDetail().(*roachpb.TransactionPushError); !ok {
 				t.Errorf("expected txn push error; got %s", pErr)
 			} else if !bytes.Equal(rErr.PusheeTxn.ID, pushee.ID) {
 				t.Errorf("expected txn to match pushee %q; got %s", pushee.ID, rErr)
@@ -1044,7 +1044,7 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 						expTimestamp, etReply.Txn)
 				}
 			} else {
-				if _, ok := cErr.GoError().(*roachpb.TransactionRetryError); !ok {
+				if _, ok := cErr.GetDetail().(*roachpb.TransactionRetryError); !ok {
 					t.Errorf("expected transaction retry error; got %s", cErr)
 				}
 			}
@@ -1064,7 +1064,7 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 				if pErr == nil {
 					t.Errorf("expected read to fail")
 				}
-				if _, ok := pErr.GoError().(*roachpb.TransactionRetryError); !ok {
+				if _, ok := pErr.GetDetail().(*roachpb.TransactionRetryError); !ok {
 					t.Errorf("expected transaction retry error; got %T", pErr)
 				}
 			}
@@ -1220,7 +1220,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	if pErr == nil {
 		t.Errorf("unexpected success committing transaction")
 	}
-	if _, ok := pErr.GoError().(*roachpb.TransactionAbortedError); !ok {
+	if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
 		t.Errorf("expected transaction aborted error; got %s", pErr)
 	}
 }


### PR DESCRIPTION
`GoError()` used to convert Error to a corresponding error detail type, but we no longer do. To get an error detail, new method `GetDetail()` must be used.

The commit has the following changes:
- Make all error details implement `StructuredError`.
- Add `Error.GetDetail`. The method is used instead of `GoError()` when a structured error is needed (e.g., type check).
- Use `roachpb.Error` in `range_tree.go`. `InsertRange` and `DeleteRange` need to return `roachpb.Error` since they are called from `Txn` in `Admin{Merge,Split}`.

Each error detail still implements the error interface.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4058)

<!-- Reviewable:end -->
