### PR TITLE
Update the help text for cockroach sql -e.

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -82,7 +82,7 @@ subsequent positional argument on the command line may contain
 one or more SQL statements, separated by semicolons. If an
 error occurs in any statement, the command exits with a
 non-zero status code and further statements are not
-executed. The results of the last SQL statement in each
+executed. Only the results of the first SQL statement in each
 positional argument are printed on the standard output.`),
 	"gossip": wrapText(`
 A comma-separated list of gossip addresses or resolvers for gossip


### PR DESCRIPTION
Following up on 1f90651acf1da864608f9629fb1faf5b04343385 and 382e440e86dd40d7bb64a8e1f2bb68ede813a53c.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4061)

<!-- Reviewable:end -->
