### PR TITLE
Mark cockroach/client as deprecated in its documentation.

### DIFF
--- a/client/doc.go
+++ b/client/doc.go
@@ -15,6 +15,10 @@
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 
 /*
+Package client and its KV API has been deprecated for external usage. Please use
+a postgres-compatible SQL driver (e.g. github.com/lib/pq). For more details, see
+http://www.cockroachlabs.com/blog/sql-in-cockroachdb-mapping-table-data-to-key-value-storage/.
+
 Package client provides clients for accessing the various externally-facing
 Cockroach database endpoints.
 


### PR DESCRIPTION
I was caught off guard today when I found out that the client package and its KV API is no longer supported. Hopefully this note will help others to realize the same thing but quicker than I did :)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4062)

<!-- Reviewable:end -->
