### PR TITLE
Move rpc.Send to kv.send.

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -116,7 +116,7 @@ type DistSender struct {
 	// leaderCache caches the last known leader replica for range
 	// consensus groups.
 	leaderCache *leaderCache
-	// RPCSend is used to send RPC calls and defaults to rpc.Send
+	// RPCSend is used to send RPC calls and defaults to send
 	// outside of tests.
 	rpcSend         rpcSendFn
 	rpcContext      *rpc.Context
@@ -126,7 +126,7 @@ type DistSender struct {
 var _ client.Sender = &DistSender{}
 
 // rpcSendFn is the function type used to dispatch RPC calls.
-type rpcSendFn func(rpc.Options, string, []net.Addr,
+type rpcSendFn func(SendOptions, string, []net.Addr,
 	func(addr net.Addr) proto.Message, func() proto.Message,
 	*rpc.Context) (proto.Message, error)
 
@@ -144,8 +144,8 @@ type DistSenderContext struct {
 	// lives on, for instance when deciding where to send RPCs.
 	// Usually it is filled in from the Gossip network on demand.
 	nodeDescriptor *roachpb.NodeDescriptor
-	// The RPC dispatcher. Defaults to rpc.Send but can be changed here
-	// for testing purposes.
+	// The RPC dispatcher. Defaults to send but can be changed here for testing
+	// purposes.
 	RPCSend           rpcSendFn
 	RPCContext        *rpc.Context
 	RangeDescriptorDB RangeDescriptorDB
@@ -187,7 +187,7 @@ func NewDistSender(ctx *DistSenderContext, gossip *gossip.Gossip) *DistSender {
 	if ctx.RangeLookupMaxRanges <= 0 {
 		ds.rangeLookupMaxRanges = defaultRangeLookupMaxRanges
 	}
-	ds.rpcSend = rpc.Send
+	ds.rpcSend = send
 	if ctx.RPCSend != nil {
 		ds.rpcSend = ctx.RPCSend
 	}
@@ -227,7 +227,7 @@ func (ds *DistSender) RangeLookup(key roachpb.RKey, desc *roachpb.RangeDescripto
 	replicas := newReplicaSlice(ds.gossip, desc)
 	// TODO(tschottdorf) consider a Trace here, potentially that of the request
 	// that had the cache miss and waits for the result.
-	br, err := ds.sendRPC(nil /* Trace */, desc.RangeID, replicas, rpc.OrderRandom, ba)
+	br, err := ds.sendRPC(nil /* Trace */, desc.RangeID, replicas, orderRandom, ba)
 	if err != nil {
 		return nil, err
 	}
@@ -250,9 +250,9 @@ func (ds *DistSender) FirstRange() (*roachpb.RangeDescriptor, *roachpb.Error) {
 	return rangeDesc, nil
 }
 
-func (ds *DistSender) optimizeReplicaOrder(replicas replicaSlice) rpc.OrderingPolicy {
+func (ds *DistSender) optimizeReplicaOrder(replicas replicaSlice) orderingPolicy {
 	// Unless we know better, send the RPCs randomly.
-	order := rpc.OrderingPolicy(rpc.OrderRandom)
+	order := orderingPolicy(orderRandom)
 	nodeDesc := ds.getNodeDescriptor()
 	// If we don't know which node we're on, don't optimize anything.
 	if nodeDesc == nil {
@@ -264,12 +264,12 @@ func (ds *DistSender) optimizeReplicaOrder(replicas replicaSlice) rpc.OrderingPo
 		// There's at least some attribute prefix, and we hope that the
 		// replicas that come early in the slice are now located close to
 		// us and hence better candidates.
-		order = rpc.OrderStable
+		order = orderStable
 	}
 	// If there is a replica in local node, move it to the front.
 	if i := replicas.FindReplicaByNodeID(nodeDesc.NodeID); i > 0 {
 		replicas.MoveToFront(i)
-		order = rpc.OrderStable
+		order = orderStable
 	}
 	return order
 }
@@ -306,11 +306,11 @@ func (ds *DistSender) getNodeDescriptor() *roachpb.NodeDescriptor {
 // sendRPC sends one or more RPCs to replicas from the supplied roachpb.Replica
 // slice. First, replicas which have gossiped addresses are corralled (and
 // rearranged depending on proximity and whether the request needs to go to a
-// leader) and then sent via rpc.Send, with requirement that one RPC to a
-// server must succeed. Returns an RPC error if the request could not be sent.
-// Note that the reply may contain a higher level error and must be checked in
+// leader) and then sent via Send, with requirement that one RPC to a server
+// must succeed. Returns an RPC error if the request could not be sent. Note
+// that the reply may contain a higher level error and must be checked in
 // addition to the RPC error.
-func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID roachpb.RangeID, replicas replicaSlice, order rpc.OrderingPolicy,
+func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID roachpb.RangeID, replicas replicaSlice, order orderingPolicy,
 	ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 	if len(replicas) == 0 {
 		return nil, roachpb.NewError(noNodeAddrsAvailError{})
@@ -331,7 +331,7 @@ func (ds *DistSender) sendRPC(trace *tracer.Trace, rangeID roachpb.RangeID, repl
 	ba.RangeID = rangeID
 
 	// Set RPC opts with stipulation that one of N RPCs must succeed.
-	rpcOpts := rpc.Options{
+	rpcOpts := SendOptions{
 		Ordering:        order,
 		SendNextTimeout: defaultSendNextTimeout,
 		Timeout:         rpc.DefaultRPCTimeout,
@@ -437,7 +437,7 @@ func (ds *DistSender) sendSingleRange(trace *tracer.Trace, ba roachpb.BatchReque
 		leader.StoreID > 0 {
 		if i := replicas.FindReplica(leader.StoreID); i >= 0 {
 			replicas.MoveToFront(i)
-			order = rpc.OrderStable
+			order = orderStable
 		}
 	}
 

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -150,9 +150,9 @@ func TestSendRPCOrder(t *testing.T) {
 
 	// Gets filled below to identify the replica by its address.
 	addrToNode := make(map[string]int32)
-	makeVerifier := func(expOrder rpc.OrderingPolicy,
-		expAddrs []int32) func(rpc.Options, []net.Addr) error {
-		return func(o rpc.Options, addrs []net.Addr) error {
+	makeVerifier := func(expOrder orderingPolicy,
+		expAddrs []int32) func(SendOptions, []net.Addr) error {
+		return func(o SendOptions, addrs []net.Addr) error {
 			if o.Ordering != expOrder {
 				return util.Errorf("unexpected ordering, wanted %v, got %v",
 					expOrder, o.Ordering)
@@ -178,7 +178,7 @@ func TestSendRPCOrder(t *testing.T) {
 	testCases := []struct {
 		args       roachpb.Request
 		attrs      []string
-		order      rpc.OrderingPolicy
+		order      orderingPolicy
 		expReplica []int32
 		leader     int32 // 0 for not caching a leader.
 		// Naming is somewhat off, as eventually consistent reads usually
@@ -192,7 +192,7 @@ func TestSendRPCOrder(t *testing.T) {
 		{
 			args:       &roachpb.ScanRequest{},
 			attrs:      []string{},
-			order:      rpc.OrderRandom,
+			order:      orderRandom,
 			expReplica: []int32{1, 2, 3, 4, 5},
 		},
 		// Inconsistent Scan with matching attributes.
@@ -201,7 +201,7 @@ func TestSendRPCOrder(t *testing.T) {
 		{
 			args:  &roachpb.ScanRequest{},
 			attrs: nodeAttrs[5],
-			order: rpc.OrderStable,
+			order: orderStable,
 			// Compare only the first two resulting addresses.
 			expReplica: []int32{5, 4, 0, 0, 0},
 		},
@@ -211,7 +211,7 @@ func TestSendRPCOrder(t *testing.T) {
 		{
 			args:       &roachpb.ScanRequest{},
 			attrs:      []string{},
-			order:      rpc.OrderRandom,
+			order:      orderRandom,
 			expReplica: []int32{1, 2, 3, 4, 5},
 			consistent: true,
 		},
@@ -220,7 +220,7 @@ func TestSendRPCOrder(t *testing.T) {
 		{
 			args:       &roachpb.PutRequest{},
 			attrs:      []string{"nomatch"},
-			order:      rpc.OrderRandom,
+			order:      orderRandom,
 			expReplica: []int32{1, 2, 3, 4, 5},
 		},
 		// Put with matching attributes but no leader.
@@ -230,7 +230,7 @@ func TestSendRPCOrder(t *testing.T) {
 			args:  &roachpb.PutRequest{},
 			attrs: append(nodeAttrs[5], "irrelevant"),
 			// Compare only the first two resulting addresses.
-			order:      rpc.OrderStable,
+			order:      orderStable,
 			expReplica: []int32{5, 4, 0, 0, 0},
 		},
 		// Put with matching attributes that finds the leader (node 3).
@@ -241,7 +241,7 @@ func TestSendRPCOrder(t *testing.T) {
 			attrs: append(nodeAttrs[5], "irrelevant"),
 			// Compare only the first resulting addresses as we have a leader
 			// and that means we're only trying to send there.
-			order:      rpc.OrderStable,
+			order:      orderStable,
 			expReplica: []int32{2, 5, 4, 0, 0},
 			leader:     2,
 		},
@@ -250,7 +250,7 @@ func TestSendRPCOrder(t *testing.T) {
 		{
 			args:       &roachpb.GetRequest{},
 			attrs:      []string{},
-			order:      rpc.OrderRandom,
+			order:      orderRandom,
 			expReplica: []int32{1, 2, 3, 4, 5},
 			leader:     2,
 		},
@@ -264,9 +264,9 @@ func TestSendRPCOrder(t *testing.T) {
 	}
 
 	// Stub to be changed in each test case.
-	var verifyCall func(rpc.Options, []net.Addr) error
+	var verifyCall func(SendOptions, []net.Addr) error
 
-	var testFn rpcSendFn = func(opts rpc.Options, method string,
+	var testFn rpcSendFn = func(opts SendOptions, method string,
 		addrs []net.Addr, getArgs func(addr net.Addr) proto.Message,
 		getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 		if err := verifyCall(opts, addrs); err != nil {
@@ -383,7 +383,7 @@ func TestOwnNodeCertain(t *testing.T) {
 	}
 
 	var act roachpb.NodeList
-	var testFn rpcSendFn = func(_ rpc.Options, _ string, _ []net.Addr, getArgs func(addr net.Addr) proto.Message, _ func() proto.Message, _ *rpc.Context) (proto.Message, error) {
+	var testFn rpcSendFn = func(_ SendOptions, _ string, _ []net.Addr, getArgs func(addr net.Addr) proto.Message, _ func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 		ba := getArgs(nil).(*roachpb.BatchRequest)
 		for _, nodeID := range ba.Txn.CertainNodes.Nodes {
 			act.Add(roachpb.NodeID(nodeID))
@@ -423,7 +423,7 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 	}
 	first := true
 
-	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
+	var testFn rpcSendFn = func(_ SendOptions, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 		if first {
 			reply := getReply()
 			reply.(*roachpb.BatchResponse).SetGoError(
@@ -462,7 +462,7 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 	g, s := makeTestGossip(t)
 	defer s()
 
-	var testFn rpcSendFn = func(_ rpc.Options, _ string, _ []net.Addr, getArgs func(addr net.Addr) proto.Message, _ func() proto.Message, _ *rpc.Context) (proto.Message, error) {
+	var testFn rpcSendFn = func(_ SendOptions, _ string, _ []net.Addr, getArgs func(addr net.Addr) proto.Message, _ func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 		return getArgs(nil).(*roachpb.BatchRequest).CreateReply(), nil
 	}
 
@@ -521,13 +521,13 @@ func TestEvictCacheOnError(t *testing.T) {
 		}
 		first := true
 
-		var testFn rpcSendFn = func(_ rpc.Options, _ string, _ []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
+		var testFn rpcSendFn = func(_ SendOptions, _ string, _ []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 			if !first {
 				return getArgs(nil).(*roachpb.BatchRequest).CreateReply(), nil
 			}
 			first = false
 			if tc.rpcError {
-				return nil, rpc.NewSendError("boom", tc.retryable)
+				return nil, roachpb.NewSendError("boom", tc.retryable)
 			}
 			var err error
 			if tc.retryable {
@@ -564,7 +564,7 @@ func TestEvictCacheOnError(t *testing.T) {
 }
 
 // TestRetryOnWrongReplicaError sets up a DistSender on a minimal gossip
-// network and a mock of rpc.Send, and verifies that the DistSender correctly
+// network and a mock of Send, and verifies that the DistSender correctly
 // retries upon encountering a stale entry in its range descriptor cache.
 func TestRetryOnWrongReplicaError(t *testing.T) {
 	defer leaktest.AfterTest(t)
@@ -577,7 +577,7 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 	newRangeDescriptor.StartKey = badStartKey
 	descStale := true
 
-	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
+	var testFn rpcSendFn = func(_ SendOptions, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 		ba := getArgs(testAddress).(*roachpb.BatchRequest)
 		rs := keys.Range(*ba)
 		if _, ok := ba.GetArg(roachpb.RangeLookup); ok {
@@ -689,7 +689,7 @@ func TestSendRPCRetry(t *testing.T) {
 		})
 	}
 	// Define our rpcSend stub which returns success on the second address.
-	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
+	var testFn rpcSendFn = func(_ SendOptions, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 		if method == "Node.Batch" {
 			// reply from first address failed
 			_ = getReply()
@@ -780,7 +780,7 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 		{Key: roachpb.Key("a"), Value: roachpb.MakeValueFromString("1")},
 		{Key: roachpb.Key("c"), Value: roachpb.MakeValueFromString("2")},
 	}
-	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
+	var testFn rpcSendFn = func(_ SendOptions, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 		if method != "Node.Batch" {
 			t.Fatalf("unexpected method:%s", method)
 		}
@@ -831,7 +831,7 @@ func TestRangeLookupOptionOnReverseScan(t *testing.T) {
 	g, s := makeTestGossip(t)
 	defer s()
 
-	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, _ func() proto.Message, _ *rpc.Context) (proto.Message, error) {
+	var testFn rpcSendFn = func(_ SendOptions, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, _ func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 		return getArgs(nil).(*roachpb.BatchRequest).CreateReply(), nil
 	}
 
@@ -910,7 +910,7 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 	// requests. The first request should be the point request on
 	// "a". The second request should be on "b".
 	first := true
-	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
+	var testFn rpcSendFn = func(_ SendOptions, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 		if method != "Node.Batch" {
 			return nil, util.Errorf("unexpected method %v", method)
 		}
@@ -1024,7 +1024,7 @@ func TestSequenceUpdateOnMultiRangeQueryLoop(t *testing.T) {
 	// first request.
 	first := true
 	var firstSequence uint32
-	var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
+	var testFn rpcSendFn = func(_ SendOptions, method string, addrs []net.Addr, getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 		if method != "Node.Batch" {
 			return nil, util.Errorf("unexpected method %v", method)
 		}
@@ -1148,7 +1148,7 @@ func TestMultiRangeSplitEndTransaction(t *testing.T) {
 
 	for _, test := range testCases {
 		var act [][]roachpb.Method
-		var testFn rpcSendFn = func(_ rpc.Options, method string, addrs []net.Addr, ga func(addr net.Addr) proto.Message, _ func() proto.Message, _ *rpc.Context) (proto.Message, error) {
+		var testFn rpcSendFn = func(_ SendOptions, method string, addrs []net.Addr, ga func(addr net.Addr) proto.Message, _ func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 			ba := ga(testAddress).(*roachpb.BatchRequest)
 			var cur []roachpb.Method
 			for _, union := range ba.Requests {

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -78,7 +78,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20, ltc.Stopper)
 
 	ltc.stores = storage.NewStores(ltc.Clock)
-	var rpcSend rpcSendFn = func(_ rpc.Options, _ string, _ []net.Addr,
+	var rpcSend rpcSendFn = func(_ SendOptions, _ string, _ []net.Addr,
 		getArgs func(addr net.Addr) proto.Message, getReply func() proto.Message,
 		_ *rpc.Context) (proto.Message, error) {
 		// TODO(tschottdorf): remove getReply().

--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -214,6 +214,13 @@ func (*LeaseRejectedError) CanRetry() bool {
 	return false
 }
 
+// NewSendError creates a SendError. canRetry should be true in most cases; the
+// only non-retryable SendErrors are for things like malformed (and not merely
+// unresolvable) addresses.
+func NewSendError(msg string, canRetry bool) *SendError {
+	return &SendError{Message: msg, Retryable: canRetry}
+}
+
 // Error formats error.
 func (s SendError) Error() string {
 	return "failed to send RPC: " + s.Message

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -95,8 +95,6 @@ type Client struct {
 	remoteOffset      RemoteOffset
 	heartbeatInterval time.Duration
 	heartbeatTimeout  time.Duration
-
-	localServer *Server // holds the local RPC server handle
 }
 
 // NewClient returns a client RPC stub for the specified address
@@ -137,8 +135,8 @@ func NewClient(addr net.Addr, context *Context) *Client {
 		disableReconnects: context.DisableReconnects,
 		clock:             context.localClock,
 		remoteClocks:      context.RemoteClocks,
-		heartbeatInterval: context.heartbeatInterval,
-		heartbeatTimeout:  context.heartbeatTimeout,
+		heartbeatInterval: context.HeartbeatInterval,
+		heartbeatTimeout:  context.HeartbeatTimeout,
 	}
 
 	if c.heartbeatInterval == 0 {
@@ -154,10 +152,6 @@ func NewClient(addr net.Addr, context *Context) *Client {
 
 	if !context.DisableCache {
 		clients[key] = c
-	}
-
-	if context.localServer != nil && context.localAddr == c.RemoteAddr().String() {
-		c.localServer = context.localServer
 	}
 
 	retryOpts := clientRetryOptions

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -227,7 +227,7 @@ func TestFailedOffsetMeasurement(t *testing.T) {
 	clientManual := hlc.NewManualClock(0)
 	clientClock := hlc.NewClock(clientManual.UnixNano)
 	context := newNodeTestContext(clientClock, stopper)
-	context.heartbeatTimeout = 20 * context.heartbeatInterval
+	context.HeartbeatTimeout = 20 * context.HeartbeatInterval
 	c := NewClient(ln.Addr(), context)
 	heartbeat.ready <- struct{}{} // Allow one heartbeat for initialization.
 	<-c.Healthy()
@@ -240,7 +240,7 @@ func TestFailedOffsetMeasurement(t *testing.T) {
 		default:
 			return true
 		}
-	}, context.heartbeatTimeout*10); err != nil {
+	}, context.HeartbeatTimeout*10); err != nil {
 		t.Fatal(err)
 	}
 	if !proto.Equal(&c.remoteOffset, &RemoteOffset{}) {

--- a/rpc/main_test.go
+++ b/rpc/main_test.go
@@ -57,8 +57,8 @@ func newNodeTestContext(clock *hlc.Clock, stopper *stop.Stopper) *Context {
 		clock = hlc.NewClock(hlc.UnixNano)
 	}
 	ctx := NewContext(testutils.NewNodeTestBaseContext(), clock, stopper)
-	ctx.heartbeatInterval = 10 * time.Millisecond
-	ctx.heartbeatTimeout = 2 * defaultHeartbeatInterval
+	ctx.HeartbeatInterval = 10 * time.Millisecond
+	ctx.HeartbeatTimeout = 2 * defaultHeartbeatInterval
 	return ctx
 }
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -20,11 +20,11 @@ type Context struct {
 	DisableReconnects bool // Disable client reconnects
 	HealthWait        time.Duration
 
-	heartbeatInterval time.Duration
-	heartbeatTimeout  time.Duration
+	HeartbeatInterval time.Duration
+	HeartbeatTimeout  time.Duration
 
-	localServer *Server // Holds the local RPC server handle
-	localAddr   string
+	LocalServer *Server // Holds the local RPC server handle
+	LocalAddr   string
 }
 
 // NewContext creates an rpc Context with the supplied values.
@@ -49,6 +49,6 @@ func (c *Context) Copy() *Context {
 
 // SetLocalServer sets the local RPC server handle to the context.
 func (c *Context) SetLocalServer(s *Server, addr string) {
-	c.localServer = s
-	c.localAddr = addr
+	c.LocalServer = s
+	c.LocalAddr = addr
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -67,11 +67,7 @@ type Server struct {
 
 // NewServer creates a new instance of Server.
 func NewServer(context *Context) *Server {
-	s := &Server{
-		insecure:    context.Insecure,
-		activeConns: make(map[net.Conn]struct{}),
-		methods:     map[string]method{},
-	}
+	s := NewManualServer(context)
 	heartbeat := &HeartbeatService{
 		clock:              context.localClock,
 		remoteClockMonitor: context.RemoteClocks,
@@ -80,6 +76,15 @@ func NewServer(context *Context) *Server {
 		log.Fatalf("unable to register heartbeat service with RPC server: %s", err)
 	}
 	return s
+}
+
+// NewManualServer creates a new instance of Server without a heartbeat service.
+func NewManualServer(context *Context) *Server {
+	return &Server{
+		insecure:    context.Insecure,
+		activeConns: make(map[net.Conn]struct{}),
+		methods:     map[string]method{},
+	}
 }
 
 // Register a new method handler. `name` is a qualified name of the
@@ -166,6 +171,42 @@ func (s *Server) runCloseCallbacks(conn net.Conn) {
 	}
 }
 
+// LocalCall invokes the specified method directly. Returns false if the method
+// is public and cannot be served with a local call. Local calls skip the
+// standard authorization checks, hence the restriction against calling public
+// methods which are accessible from end users.
+func (s *Server) LocalCall(method string, args proto.Message, done chan *rpc.Call) bool {
+	s.mu.RLock()
+	m := s.methods[method]
+	s.mu.RUnlock()
+
+	if m.handler == nil {
+		done <- &rpc.Call{
+			Error: util.Errorf("rpc: unable to find method: %s", method),
+		}
+		return true
+	}
+
+	if m.public {
+		return false
+	}
+
+	// TODO(pmattis): Note that we're passing the request directly through to the
+	// handler. This differs from an actual RPC which would encode the request
+	// and decode it on the remote side. The result is that the method handler
+	// might mutate the request which in turn might surprise the caller. We
+	// should add a check to guard against that.
+	m.handler(args, func(reply proto.Message, err error) {
+		done <- &rpc.Call{
+			ServiceMethod: method,
+			Error:         err,
+			Reply:         reply,
+			Args:          args,
+		}
+	})
+	return true
+}
+
 var _ http.Handler = &Server{}
 
 // ServeHTTP implements an http.Handler that answers RPC requests.
@@ -244,7 +285,7 @@ func (s *Server) readRequests(conn net.Conn, codec rpc.ServerCodec, authHook fun
 		if meth.handler == nil {
 			responses <- serverResponse{
 				req: req,
-				err: util.Errorf("rpc: couldn't find method: %s", req.ServiceMethod),
+				err: util.Errorf("rpc: unable to find method: %s", req.ServiceMethod),
 			}
 			continue
 		}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -101,7 +101,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	sCtx.ScanMaxIdleTime = splitTimeout / 10
 	sCtx.Tracer = tracer.NewTracer(nil, "testing")
 	stores := storage.NewStores(clock)
-	rpcSend := func(_ rpc.Options, _ string, _ []net.Addr,
+	rpcSend := func(_ kv.SendOptions, _ string, _ []net.Addr,
 		getArgs func(addr net.Addr) proto.Message, _ func() proto.Message,
 		_ *rpc.Context) (proto.Message, error) {
 		ba := getArgs(nil /* net.Addr */).(*roachpb.BatchRequest)
@@ -300,7 +300,7 @@ func (m *multiTestContext) Stop() {
 // used to multiplex calls between many local senders in a simple way; It sends
 // the request to multiTestContext's localSenders specified in addrs. The request is
 // sent in order until no error is returned.
-func (m *multiTestContext) rpcSend(_ rpc.Options, _ string, addrs []net.Addr,
+func (m *multiTestContext) rpcSend(_ kv.SendOptions, _ string, addrs []net.Addr,
 	getArgs func(addr net.Addr) proto.Message,
 	getReply func() proto.Message, _ *rpc.Context) (proto.Message, error) {
 	m.mu.RLock()
@@ -328,7 +328,7 @@ func (m *multiTestContext) rpcSend(_ rpc.Options, _ string, addrs []net.Addr,
 			sender := m.senders[nodeIndex]
 			br, pErr = sender.Send(context.Background(), ba)
 		}) {
-			pErr = roachpb.NewError(rpc.NewSendError("store is stopped", true))
+			pErr = roachpb.NewError(roachpb.NewSendError("store is stopped", true))
 			m.expireLeaderLeases()
 			continue
 		}


### PR DESCRIPTION
This is primarily code movement (e.g. `git mv rpc/send* kv`) but with a
moderate amount of fixups. The local call operation moved to
`rpc.Server.LocalCall` and various fields and types were either exported
or unexported as required/possible.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4064)

<!-- Reviewable:end -->
