### PR TITLE
sql: minor select cleanup

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -45,7 +45,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 	if !gr.Exists() {
 		if n.IfExists {
 			// Noop.
-			return &valuesNode{}, nil
+			return &emptyNode{}, nil
 		}
 		// Key does not exist, but we want it to: error out.
 		return nil, roachpb.NewUErrorf("table %q does not exist", n.Table.Table())
@@ -177,7 +177,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 	// this line, but tests that run redundant operations like dropping
 	// a column when it's already dropped will hit this condition and exit.
 	if numMutations == len(tableDesc.Mutations) {
-		return &valuesNode{}, nil
+		return &emptyNode{}, nil
 	}
 	tableDesc.UpVersion = true
 	mutationID := tableDesc.NextMutationID
@@ -192,5 +192,5 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 	}
 	p.notifySchemaChange(tableDesc.ID, mutationID)
 
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }

--- a/sql/create.go
+++ b/sql/create.go
@@ -41,7 +41,7 @@ func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, *roachpb.E
 	if err := p.createDescriptor(databaseKey{string(n.Name)}, &desc, n.IfNotExists); err != nil {
 		return nil, err
 	}
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }
 
 // CreateIndex creates an index.
@@ -67,7 +67,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) 
 		}
 		if n.IfNotExists {
 			// Noop.
-			return &valuesNode{}, nil
+			return &emptyNode{}, nil
 		}
 	}
 
@@ -97,7 +97,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) 
 	}
 	p.notifySchemaChange(tableDesc.ID, mutationID)
 
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }
 
 // CreateTable creates a table.
@@ -153,5 +153,5 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, *roachpb.Error) 
 	if pErr := p.createDescriptor(tableKey{dbDesc.ID, n.Table.Table()}, &desc, n.IfNotExists); pErr != nil {
 		return nil, pErr
 	}
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -46,7 +46,7 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, *roachpb.Error
 	if !gr.Exists() {
 		if n.IfExists {
 			// Noop.
-			return &valuesNode{}, nil
+			return &emptyNode{}, nil
 		}
 		return nil, roachpb.NewUErrorf("database %q does not exist", n.Name)
 	}
@@ -97,7 +97,7 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, *roachpb.Error
 	if pErr := p.txn.Run(b); pErr != nil {
 		return nil, pErr
 	}
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }
 
 // DropIndex drops an index.
@@ -123,7 +123,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, *roachpb.Error) {
 		if pErr != nil {
 			if n.IfExists {
 				// Noop.
-				return &valuesNode{}, nil
+				return &emptyNode{}, nil
 			}
 			// Index does not exist, but we want it to: error out.
 			return nil, pErr
@@ -139,7 +139,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, *roachpb.Error) {
 				return nil, roachpb.NewUErrorf("index %q in the middle of being added, try again later", idxName)
 
 			case DescriptorMutation_DROP:
-				return &valuesNode{}, nil
+				return &emptyNode{}, nil
 			}
 		}
 		tableDesc.UpVersion = true
@@ -154,7 +154,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, *roachpb.Error) {
 		}
 		p.notifySchemaChange(tableDesc.ID, mutationID)
 	}
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }
 
 // DropTable drops a table.
@@ -233,5 +233,5 @@ func (p *planner) DropTable(n *parser.DropTable) (planNode, *roachpb.Error) {
 			return nil, pErr
 		}
 	}
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }

--- a/sql/grant.go
+++ b/sql/grant.go
@@ -56,7 +56,7 @@ func (p *planner) changePrivileges(targets parser.TargetList, grantees parser.Na
 	if ok {
 		p.notifySchemaChange(tableDesc.ID, invalidMutationID)
 	}
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }
 
 // Grant adds privileges to users.

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -281,12 +281,35 @@ type planNode interface {
 }
 
 var _ planNode = &distinctNode{}
-
 var _ planNode = &groupNode{}
-
 var _ planNode = &indexJoinNode{}
 var _ planNode = &limitNode{}
 var _ planNode = &scanNode{}
 var _ planNode = &sortNode{}
 var _ planNode = &valuesNode{}
 var _ planNode = &selectNode{}
+var _ planNode = &emptyNode{}
+
+// emptyNode is a planNode with no columns and either no rows (default) or a single row with empty
+// results (if results is initializer to true). The former is used for nodes that have no results
+// (e.g. a table for which the filtering condition has a contradiction), the latter is used by
+// select statements that have no table or where we detect the filtering condition throws away all
+// results.
+type emptyNode struct {
+	results bool
+}
+
+func (*emptyNode) Columns() []ResultColumn { return nil }
+func (*emptyNode) Ordering() orderingInfo  { return orderingInfo{} }
+func (*emptyNode) Values() parser.DTuple   { return nil }
+func (*emptyNode) PErr() *roachpb.Error    { return nil }
+
+func (*emptyNode) ExplainPlan() (name, description string, children []planNode) {
+	return "empty", "-", nil
+}
+
+func (e *emptyNode) Next() bool {
+	r := e.results
+	e.results = false
+	return r
+}

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -53,7 +53,7 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, *roachpb.E
 
 	if n.Name == n.NewName {
 		// Noop.
-		return &valuesNode{}, nil
+		return &emptyNode{}, nil
 	}
 
 	// Now update the nameMetadataKey and the descriptor.
@@ -91,7 +91,7 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, *roachpb.E
 		return expectDeleted(systemConfig, oldKey)
 	}
 
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }
 
 // RenameTable renames the table.
@@ -127,7 +127,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, *roachpb.Error) 
 	if !gr.Exists() {
 		if n.IfExists {
 			// Noop.
-			return &valuesNode{}, nil
+			return &emptyNode{}, nil
 		}
 		// Key does not exist, but we want it to: error out.
 		return nil, roachpb.NewUErrorf("table %q does not exist", n.Name.Table())
@@ -144,7 +144,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, *roachpb.Error) 
 
 	if n.Name.Database() == n.NewName.Database() && n.Name.Table() == n.NewName.Table() {
 		// Noop.
-		return &valuesNode{}, nil
+		return &emptyNode{}, nil
 	}
 
 	tableDesc, pErr := p.getTableDesc(n.Name)
@@ -191,7 +191,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, *roachpb.Error) 
 		return expectDeleted(systemConfig, tbKey)
 	}
 
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }
 
 // RenameIndex renames the index.
@@ -218,7 +218,7 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, *roachpb.Error) 
 	if pErr != nil {
 		if n.IfExists {
 			// Noop.
-			return &valuesNode{}, nil
+			return &emptyNode{}, nil
 		}
 		// Index does not exist, but we want it to: error out.
 		return nil, pErr
@@ -230,7 +230,7 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, *roachpb.Error) 
 
 	if equalName(idxName, newIdxName) {
 		// Noop.
-		return &valuesNode{}, nil
+		return &emptyNode{}, nil
 	}
 
 	if _, _, err := tableDesc.FindIndexByName(newIdxName); err == nil {
@@ -252,7 +252,7 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, *roachpb.Error) 
 		return nil, pErr
 	}
 	p.notifySchemaChange(tableDesc.ID, invalidMutationID)
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }
 
 // RenameColumn renames the column.
@@ -283,7 +283,7 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, *roachpb.Error
 	if !gr.Exists() {
 		if n.IfExists {
 			// Noop.
-			return &valuesNode{}, nil
+			return &emptyNode{}, nil
 		}
 		// Key does not exist, but we want it to: error out.
 		return nil, roachpb.NewUErrorf("table %q does not exist", n.Table.Table())
@@ -313,7 +313,7 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, *roachpb.Error
 
 	if equalName(colName, newColName) {
 		// Noop.
-		return &valuesNode{}, nil
+		return &emptyNode{}, nil
 	}
 
 	if _, _, err := tableDesc.FindColumnByName(newColName); err == nil {
@@ -347,5 +347,5 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, *roachpb.Error
 		return nil, pErr
 	}
 	p.notifySchemaChange(tableDesc.ID, invalidMutationID)
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -193,12 +193,7 @@ func (n *scanNode) ExplainPlan() (name, description string, children []planNode)
 	} else {
 		name = "scan"
 	}
-	if n.desc == nil {
-		description = "-"
-	} else {
-		description = fmt.Sprintf("%s@%s %s", n.desc.Name, n.index.Name,
-			prettySpans(n.spans, 2))
-	}
+	description = fmt.Sprintf("%s@%s %s", n.desc.Name, n.index.Name, prettySpans(n.spans, 2))
 	return name, description, nil
 }
 
@@ -332,13 +327,6 @@ func (n *scanNode) initVisibleCols(visibleCols []ColumnDescriptor, numImplicit i
 // structure.
 func (n *scanNode) initScan() bool {
 	// Initialize our key/values.
-	if n.desc == nil {
-		// No table to read from, pretend there is a single empty row.
-		n.kvs = []client.KeyValue{}
-		n.indexKey = []byte{}
-		return true
-	}
-
 	if len(n.spans) == 0 {
 		// If no spans were specified retrieve all of the keys that start with our
 		// index key prefix.
@@ -609,9 +597,6 @@ func (n *scanNode) explainDebug(endOfRow bool) {
 }
 
 func (n *scanNode) prettyKey() string {
-	if n.desc == nil {
-		return ""
-	}
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "/%s/%s%s", n.desc.Name, n.index.Name, prettyDatums(n.vals))
 	if n.colID > 0 {

--- a/sql/select.go
+++ b/sql/select.go
@@ -28,8 +28,9 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-// fromInfo contains the information for a select "source" (FROM).
-type fromInfo struct {
+// tableInfo contains the information for table used by a select statement. It can be an actual
+// table, or a "virtual table" which is the result of a subquery.
+type tableInfo struct {
 	// node which can be used to retrieve the data (normally a scanNode). For performance purposes,
 	// this node can be aware of the filters, grouping etc.
 	node planNode
@@ -49,7 +50,7 @@ type fromInfo struct {
 type selectNode struct {
 	planner *planner
 
-	from fromInfo
+	table tableInfo
 
 	// Map of qvalues encountered in expressions.
 	qvals qvalMap
@@ -101,10 +102,10 @@ func (s *selectNode) Values() parser.DTuple {
 
 func (s *selectNode) Next() bool {
 	for {
-		if !s.from.node.Next() {
+		if !s.table.node.Next() {
 			return false
 		}
-		row := s.from.node.Values()
+		row := s.table.node.Values()
 
 		if s.explain == explainDebug {
 			if len(s.row) != 4 {
@@ -143,11 +144,11 @@ func (s *selectNode) PErr() *roachpb.Error {
 	if s.pErr != nil {
 		return s.pErr
 	}
-	return s.from.node.PErr()
+	return s.table.node.PErr()
 }
 
 func (s *selectNode) ExplainPlan() (name, description string, children []planNode) {
-	return s.from.node.ExplainPlan()
+	return s.table.node.ExplainPlan()
 }
 
 // Select selects rows from a single table. Select is the workhorse of the SQL
@@ -205,12 +206,12 @@ func (p *planner) initSelect(s *selectNode, parsed *parser.Select) (planNode, *r
 		ordering = sort.Ordering().ordering
 	}
 
-	if scan, ok := s.from.node.(*scanNode); ok {
+	if scan, ok := s.table.node.(*scanNode); ok {
 		// Find the set of columns that we actually need values for. This is an optimization to avoid
 		// unmarshaling unnecessary values and is also used for index selection.
-		neededCols := make([]bool, len(s.from.columns))
+		neededCols := make([]bool, len(s.table.columns))
 		for i := range neededCols {
-			_, ok := s.qvals[columnRef{&s.from, i}]
+			_, ok := s.qvals[columnRef{&s.table, i}]
 			neededCols[i] = ok
 		}
 		scan.setNeededColumns(neededCols)
@@ -220,11 +221,11 @@ func (p *planner) initSelect(s *selectNode, parsed *parser.Select) (planNode, *r
 			return nil, pErr
 		}
 
-		// Update s.from with the new plan.
-		s.from.node = plan
+		// Update s.table with the new plan.
+		s.table.node = plan
 	}
 
-	s.ordering = s.computeOrdering(s.from.node.Ordering())
+	s.ordering = s.computeOrdering(s.table.node.Ordering())
 
 	// Wrap this node as necessary.
 	limit, pErr := p.limit(parsed, p.distinct(parsed, sort.wrap(group.wrap(s))))
@@ -234,15 +235,13 @@ func (p *planner) initSelect(s *selectNode, parsed *parser.Select) (planNode, *r
 	return limit, nil
 }
 
-// Initializes the from node, given the parsed select expression
+// Initializes the table node, given the parsed select expression
 func (s *selectNode) initFrom(p *planner, parsed *parser.Select) *roachpb.Error {
 	from := parsed.From
 	var colAlias parser.NameList
 	switch len(from) {
 	case 0:
-		// Nothing to do
-		// TODO(radu): we shouldn't be using a scanNode in this case at all.
-		s.from.node = &scanNode{planner: p, txn: p.txn}
+		s.table.node = &emptyNode{results: true}
 
 	case 1:
 		ate, ok := from[0].(*parser.AliasedTableExpr)
@@ -254,11 +253,11 @@ func (s *selectNode) initFrom(p *planner, parsed *parser.Select) *roachpb.Error 
 		case *parser.QualifiedName:
 			// Usual case: a table.
 			scan := &scanNode{planner: p, txn: p.txn}
-			s.from.alias, s.pErr = scan.initTable(p, expr)
+			s.table.alias, s.pErr = scan.initTable(p, expr)
 			if s.pErr != nil {
 				return s.pErr
 			}
-			s.from.node = scan
+			s.table.node = scan
 
 		case *parser.Subquery:
 			// We have a subquery (this includes a simple "VALUES").
@@ -266,7 +265,7 @@ func (s *selectNode) initFrom(p *planner, parsed *parser.Select) *roachpb.Error 
 				return roachpb.NewErrorf("subquery in FROM must have an alias")
 			}
 
-			s.from.node, s.pErr = p.makePlan(expr.Select, false)
+			s.table.node, s.pErr = p.makePlan(expr.Select, false)
 			if s.pErr != nil {
 				return s.pErr
 			}
@@ -277,7 +276,7 @@ func (s *selectNode) initFrom(p *planner, parsed *parser.Select) *roachpb.Error 
 
 		if ate.As.Alias != "" {
 			// If an alias was specified, use that.
-			s.from.alias = string(ate.As.Alias)
+			s.table.alias = string(ate.As.Alias)
 		}
 		colAlias = ate.As.Cols
 	default:
@@ -285,22 +284,22 @@ func (s *selectNode) initFrom(p *planner, parsed *parser.Select) *roachpb.Error 
 		return s.pErr
 	}
 
-	s.from.columns = s.from.node.Columns()
+	s.table.columns = s.table.node.Columns()
 	if len(colAlias) > 0 {
 		// Make a copy of the slice since we are about to modify the contents.
-		s.from.columns = append([]ResultColumn(nil), s.from.columns...)
+		s.table.columns = append([]ResultColumn(nil), s.table.columns...)
 
 		// The column aliases can only refer to explicit columns.
 		for colIdx, aliasIdx := 0, 0; aliasIdx < len(colAlias); colIdx++ {
-			if colIdx >= len(s.from.columns) {
+			if colIdx >= len(s.table.columns) {
 				return roachpb.NewErrorf(
 					"table \"%s\" has %d columns available but %d columns specified",
-					s.from.alias, aliasIdx, len(colAlias))
+					s.table.alias, aliasIdx, len(colAlias))
 			}
-			if s.from.columns[colIdx].hidden {
+			if s.table.columns[colIdx].hidden {
 				continue
 			}
-			s.from.columns[colIdx].Name = string(colAlias[aliasIdx])
+			s.table.columns[colIdx].Name = string(colAlias[aliasIdx])
 			aliasIdx++
 		}
 	}
@@ -398,7 +397,7 @@ func (s *selectNode) addRender(target parser.SelectExpr) *roachpb.Error {
 			return s.pErr
 		}
 		if qname.IsStar() {
-			if s.from.alias == "" {
+			if s.table.alias == "" {
 				return roachpb.NewUErrorf("\"%s\" with no tables specified is not valid", qname)
 			}
 			if target.As != "" {
@@ -406,15 +405,15 @@ func (s *selectNode) addRender(target parser.SelectExpr) *roachpb.Error {
 			}
 			// TODO(radu): support multiple FROMs, consolidate with logic in findColumn
 			tableName := qname.Table()
-			if tableName != "" && !equalName(s.from.alias, tableName) {
+			if tableName != "" && !equalName(s.table.alias, tableName) {
 				return roachpb.NewUErrorf("table \"%s\" not found", tableName)
 			}
 
-			for idx, col := range s.from.columns {
+			for idx, col := range s.table.columns {
 				if col.hidden {
 					continue
 				}
-				qval := s.getQVal(columnRef{&s.from, idx})
+				qval := s.getQVal(columnRef{&s.table, idx})
 				s.columns = append(s.columns, ResultColumn{Name: col.Name, Typ: qval.datum})
 				s.render = append(s.render, qval)
 			}
@@ -537,7 +536,7 @@ func (s *selectNode) computeOrdering(fromOrder orderingInfo) orderingInfo {
 	// The rows from the index are ordered by k then by v, but since k is an exact match
 	// column the results are also ordered just by v.
 	for colIdx := range fromOrder.exactMatchCols {
-		colRef := columnRef{&s.from, colIdx}
+		colRef := columnRef{&s.table, colIdx}
 		if renderIdx, ok := s.findRenderIndexForCol(colRef); ok {
 			ordering.addExactMatchColumn(renderIdx)
 		}
@@ -552,7 +551,7 @@ func (s *selectNode) computeOrdering(fromOrder orderingInfo) orderingInfo {
 	// The rows from the index are ordered by k then by v. We cannot make any use of this
 	// ordering as an ordering on v.
 	for _, colOrder := range fromOrder.ordering {
-		colRef := columnRef{&s.from, colOrder.colIdx}
+		colRef := columnRef{&s.table, colOrder.colIdx}
 		renderIdx, ok := s.findRenderIndexForCol(colRef)
 		if !ok {
 			break
@@ -617,9 +616,7 @@ func (p *planner) selectIndex(sel *selectNode, s *scanNode, ordering columnOrder
 		if len(exprs) == 1 && len(exprs[0]) == 1 {
 			if d, ok := exprs[0][0].(parser.DBool); ok && bool(!d) {
 				// The expression simplified to false.
-				s.desc = nil
-				s.index = nil
-				return s, nil
+				return &emptyNode{}, nil
 			}
 		}
 
@@ -677,9 +674,7 @@ func (p *planner) selectIndex(sel *selectNode, s *scanNode, ordering columnOrder
 	s.spans = makeSpans(c.constraints, c.desc.ID, c.index)
 	if len(s.spans) == 0 {
 		// There are no spans to scan.
-		s.desc = nil
-		s.index = nil
-		return s, nil
+		return &emptyNode{}, nil
 	}
 	sel.filter = applyConstraints(sel.filter, c.constraints)
 	s.reverse = c.reverse

--- a/sql/select_qvalue_test.go
+++ b/sql/select_qvalue_test.go
@@ -30,9 +30,9 @@ func testInitDummySelectNode(desc *TableDescriptor) *selectNode {
 
 	sel := &selectNode{}
 	sel.qvals = make(qvalMap)
-	sel.from.node = scan
-	sel.from.alias = desc.Name
-	sel.from.columns = scan.Columns()
+	sel.table.node = scan
+	sel.table.alias = desc.Name
+	sel.table.columns = scan.Columns()
 
 	return sel
 }
@@ -61,7 +61,7 @@ func TestRetryResolveQNames(t *testing.T) {
 		if len(s.qvals) != 1 {
 			t.Fatalf("%d: expected 1 qvalue, but found %d", i, len(s.qvals))
 		}
-		if _, ok := s.qvals[columnRef{&s.from, 0}]; !ok {
+		if _, ok := s.qvals[columnRef{&s.table, 0}]; !ok {
 			t.Fatalf("%d: unable to find qvalue for column 0 (a)", i)
 		}
 	}

--- a/sql/set.go
+++ b/sql/set.go
@@ -63,7 +63,7 @@ func (p *planner) Set(n *parser.Set) (planNode, *roachpb.Error) {
 	default:
 		return nil, roachpb.NewUErrorf("unknown variable: %q", name)
 	}
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }
 
 func (p *planner) getStringVal(name string, values parser.Exprs) (string, *roachpb.Error) {
@@ -119,5 +119,5 @@ func (p *planner) SetTimeZone(n *parser.SetTimeZone) (planNode, *roachpb.Error) 
 		p.session.Timezone = &Session_Offset{Offset: offset}
 	}
 	p.evalCtx.GetLocation = p.session.getLocation
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -73,7 +73,7 @@ func (p *planner) orderBy(n *parser.Select, s *selectNode) (*sortNode, *roachpb.
 				if err := qname.NormalizeColumnName(); err != nil {
 					return nil, roachpb.NewError(err)
 				}
-				if qname.Table() == "" || equalName(s.from.alias, qname.Table()) {
+				if qname.Table() == "" || equalName(s.table.alias, qname.Table()) {
 					for j, r := range s.render {
 						if qval, ok := r.(*qvalue); ok {
 							if equalName(qval.colRef.get().Name, qname.Column()) {

--- a/sql/testdata/select_index
+++ b/sql/testdata/select_index
@@ -130,7 +130,7 @@ EXPLAIN (DEBUG) SELECT * FROM t WHERE a > 1 AND b > 'b'
 query ITT
 EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
-0 scan -
+0 empty -
 
 query ITTB
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b
@@ -217,4 +217,4 @@ EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a + 1 = 4
 query ITT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
-0 scan -
+0 empty -

--- a/sql/truncate.go
+++ b/sql/truncate.go
@@ -56,5 +56,5 @@ func (p *planner) Truncate(n *parser.Truncate) (planNode, *roachpb.Error) {
 		return nil, pErr
 	}
 
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }

--- a/sql/txn.go
+++ b/sql/txn.go
@@ -32,7 +32,7 @@ func (p *planner) BeginTransaction(n *parser.BeginTransaction) (planNode, *roach
 	if pErr := p.setUserPriority(n.UserPriority); pErr != nil {
 		return nil, pErr
 	}
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }
 
 // CommitTransaction commits a transaction.
@@ -40,7 +40,7 @@ func (p *planner) CommitTransaction(n *parser.CommitTransaction) (planNode, *roa
 	pErr := p.txn.Commit()
 	// Reset transaction.
 	p.resetTxn()
-	return &valuesNode{}, pErr
+	return &emptyNode{}, pErr
 }
 
 // RollbackTransaction rolls back a transaction.
@@ -48,7 +48,7 @@ func (p *planner) RollbackTransaction(n *parser.RollbackTransaction) (planNode, 
 	pErr := p.txn.Rollback()
 	// Reset transaction.
 	p.resetTxn()
-	return &valuesNode{}, pErr
+	return &emptyNode{}, pErr
 }
 
 // SetTransaction sets a transaction's isolation level
@@ -59,7 +59,7 @@ func (p *planner) SetTransaction(n *parser.SetTransaction) (planNode, *roachpb.E
 	if pErr := p.setUserPriority(n.UserPriority); pErr != nil {
 		return nil, pErr
 	}
-	return &valuesNode{}, nil
+	return &emptyNode{}, nil
 }
 
 func (p *planner) setIsolationLevel(level parser.IsolationLevel) *roachpb.Error {


### PR DESCRIPTION
Cleanup in select code:
- the from/fromInfo terminology is renamed to table/tableInfo (this is
  consistent with postgres docs and grammar).
- we no longer use a scanNode with a nil descriptor for SELECTs with no table
  or when we detect a contradiction in the filtering condition. We instead use
  a special emptyNode.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4066)

<!-- Reviewable:end -->
