### PR TITLE
sql: add parallel benchmarks for updates

### DIFF
--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
@@ -30,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/util/retry"
 )
 
 func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *sql.DB)) {
@@ -239,7 +241,7 @@ func BenchmarkInsert100_Postgres(b *testing.B) {
 }
 
 // runBenchmarkUpdate benchmarks updating count random rows in a table.
-func runBenchmarkUpdate(b *testing.B, db *sql.DB, count int) {
+func runBenchmarkUpdate(b *testing.B, db *sql.DB, parallel bool, count int) {
 	rows := 10000
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.update`); err != nil {
 		b.Fatal(err)
@@ -248,15 +250,15 @@ func runBenchmarkUpdate(b *testing.B, db *sql.DB, count int) {
 		b.Fatal(err)
 	}
 
-	var buf bytes.Buffer
-	buf.WriteString(`INSERT INTO bench.update VALUES `)
+	var insert bytes.Buffer
+	insert.WriteString(`INSERT INTO bench.update VALUES `)
 	for i := 0; i < rows; i++ {
 		if i > 0 {
-			buf.WriteString(", ")
+			insert.WriteString(", ")
 		}
-		fmt.Fprintf(&buf, "(%d, %d)", i, i)
+		fmt.Fprintf(&insert, "(%d, %d)", i, i)
 	}
-	if _, err := db.Exec(buf.String()); err != nil {
+	if _, err := db.Exec(insert.String()); err != nil {
 		b.Fatal(err)
 	}
 
@@ -266,33 +268,75 @@ func runBenchmarkUpdate(b *testing.B, db *sql.DB, count int) {
 		}
 	}()
 
-	s := rand.New(rand.NewSource(5432))
-
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		buf.Reset()
-		buf.WriteString(`BEGIN; `)
-		for j := 0; j < count; j++ {
-			fmt.Fprintf(&buf, `UPDATE bench.update SET v = v + 1 WHERE k = %d; `, s.Intn(rows))
-		}
-		buf.WriteString(`COMMIT;`)
-		if _, err := db.Exec(buf.String()); err != nil {
-			b.Fatal(err)
+	if parallel {
+		b.RunParallel(func(pb *testing.PB) {
+			s := rand.New(rand.NewSource(5432))
+			var buf bytes.Buffer
+			for pb.Next() {
+				buf.Reset()
+				buf.WriteString(`BEGIN; `)
+				for j := 0; j < count; j++ {
+					fmt.Fprintf(&buf, `UPDATE bench.update SET v = v + 1 WHERE k = %d; `, s.Intn(rows))
+				}
+				buf.WriteString(`COMMIT;`)
+				retryOpts := retry.Options{
+					InitialBackoff: 2 * time.Millisecond,
+					MaxBackoff:     20 * time.Millisecond,
+					Multiplier:     2,
+				}
+				var err error
+				for r := retry.Start(retryOpts); r.Next(); {
+					_, err = db.Exec(buf.String())
+					if err == nil {
+						break
+					}
+				}
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	} else {
+		s := rand.New(rand.NewSource(5432))
+		var buf bytes.Buffer
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			buf.WriteString(`BEGIN; `)
+			for j := 0; j < count; j++ {
+				fmt.Fprintf(&buf, `UPDATE bench.update SET v = v + 1 WHERE k = %d; `, s.Intn(rows))
+			}
+			buf.WriteString(`COMMIT;`)
+			if _, err := db.Exec(buf.String()); err != nil {
+				b.Fatal(err)
+			}
 		}
 	}
 	b.StopTimer()
 }
 
 func runBenchmarkUpdate1(b *testing.B, db *sql.DB) {
-	runBenchmarkUpdate(b, db, 1)
+	runBenchmarkUpdate(b, db, false, 1)
 }
 
 func runBenchmarkUpdate10(b *testing.B, db *sql.DB) {
-	runBenchmarkUpdate(b, db, 10)
+	runBenchmarkUpdate(b, db, false, 10)
 }
 
 func runBenchmarkUpdate100(b *testing.B, db *sql.DB) {
-	runBenchmarkUpdate(b, db, 100)
+	runBenchmarkUpdate(b, db, false, 100)
+}
+
+func runBenchmarkUpdate1Parallel(b *testing.B, db *sql.DB) {
+	runBenchmarkUpdate(b, db, true, 1)
+}
+
+func runBenchmarkUpdate10Parallel(b *testing.B, db *sql.DB) {
+	runBenchmarkUpdate(b, db, true, 10)
+}
+
+func runBenchmarkUpdate100Parallel(b *testing.B, db *sql.DB) {
+	runBenchmarkUpdate(b, db, true, 100)
 }
 
 func BenchmarkUpdate1_Cockroach(b *testing.B) {
@@ -317,6 +361,30 @@ func BenchmarkUpdate100_Cockroach(b *testing.B) {
 
 func BenchmarkUpdate100_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkUpdate100)
+}
+
+func BenchmarkUpdate1_Parallel_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkUpdate1Parallel)
+}
+
+func BenchmarkUpdate1_Parallel_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkUpdate1Parallel)
+}
+
+func BenchmarkUpdate10_Parallel_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkUpdate10Parallel)
+}
+
+func BenchmarkUpdate10_Parallel_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkUpdate10Parallel)
+}
+
+func BenchmarkUpdate100_Parallel_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkUpdate100Parallel)
+}
+
+func BenchmarkUpdate100_Parallel_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkUpdate100Parallel)
 }
 
 // runBenchmarkDelete benchmarks deleting count rows from a table.


### PR DESCRIPTION
I wanted to see how a lock change affected things with contention in the picture and realized our benchmarks were all serial.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4068)

<!-- Reviewable:end -->
