### PR TITLE
cli: add support for multiple results to SQL statements

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -25,6 +25,7 @@ github.com/cockroachdb/c-lz4 c40aaae2fc50293eb8750b34632bc3efe813e23f
 github.com/cockroachdb/c-protobuf 4feb192131ea08dfbd7253a00868ad69cbb61b81
 github.com/cockroachdb/c-rocksdb c0124c907c74b579d9d3d48eb96471bef270bc25
 github.com/cockroachdb/c-snappy 5c6d0932e0adaffce4bfca7bdf2ac37f79952ccf
+github.com/cockroachdb/pq 77893094b774b29f293681e6ac0a9322fbf3ce25
 github.com/cockroachdb/stress aa7690c22fd0abd6168ed0e6c361e4f4c5f7ab25
 github.com/codahale/hdrhistogram e88be87d51429689cef99043a54150d733265cd7
 github.com/coreos/etcd 410d32a9b14f6052a834a966a02950cde518d7ce

--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -25,7 +25,7 @@ github.com/cockroachdb/c-lz4 c40aaae2fc50293eb8750b34632bc3efe813e23f
 github.com/cockroachdb/c-protobuf 4feb192131ea08dfbd7253a00868ad69cbb61b81
 github.com/cockroachdb/c-rocksdb c0124c907c74b579d9d3d48eb96471bef270bc25
 github.com/cockroachdb/c-snappy 5c6d0932e0adaffce4bfca7bdf2ac37f79952ccf
-github.com/cockroachdb/pq 77893094b774b29f293681e6ac0a9322fbf3ce25
+github.com/cockroachdb/pq dd29f9a2c333350480bf658e7f99c4ffdc145830
 github.com/cockroachdb/stress aa7690c22fd0abd6168ed0e6c361e4f4c5f7ab25
 github.com/codahale/hdrhistogram e88be87d51429689cef99043a54150d733265cd7
 github.com/coreos/etcd 410d32a9b14f6052a834a966a02950cde518d7ce

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -538,6 +538,7 @@ func Example_sql() {
 	c.RunWithArgs([]string{"sql", "-e", "select * from t.f"})
 	c.RunWithArgs([]string{"sql", "-e", "show databases"})
 	c.RunWithArgs([]string{"sql", "-e", "explain select 3"})
+	c.RunWithArgs([]string{"sql", "-e", "select 1; select 2"})
 
 	// Output:
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
@@ -568,6 +569,13 @@ func Example_sql() {
 	// 1 row
 	// Level	Type	Description
 	// 0	empty	-
+	// sql -e select 1; select 2
+	// 1 row
+	// 1
+	// 1
+	// 1 row
+	// 2
+	// 2
 }
 
 func Example_sql_escape() {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -501,7 +501,7 @@ range_max_bytes: 67108864
 	// range_min_bytes: 8388608
 	// range_max_bytes: 67108864
 	//
-	// OK
+	// INSERT 1
 	// zone ls
 	// Object 100:
 	// replicas:
@@ -524,7 +524,7 @@ range_max_bytes: 67108864
 	//   ttlseconds: 0
 	//
 	// zone rm 100
-	// OK
+	// DELETE 1
 	// zone ls
 }
 
@@ -542,7 +542,7 @@ func Example_sql() {
 
 	// Output:
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
-	// OK
+	// INSERT 1
 	// sql -e select 3 select * from t.f
 	// 1 row
 	// 3
@@ -551,11 +551,11 @@ func Example_sql() {
 	// x	y
 	// 42	69
 	// sql -e begin select 3 commit
-	// OK
+	// BEGIN
 	// 1 row
 	// 3
 	// 3
-	// OK
+	// COMMIT
 	// sql -e select * from t.f
 	// 1 row
 	// x	y
@@ -594,21 +594,21 @@ func Example_sql_escape() {
 
 	// Output:
 	// sql -e create database t; create table t.t (s string, d string);
-	// OK
+	// CREATE TABLE
 	// sql -e insert into t.t values (e'foo', 'printable ASCII')
-	// OK
+	// INSERT 1
 	// sql -e insert into t.t values (e'foo\x0a', 'non-printable ASCII')
-	// OK
+	// INSERT 1
 	// sql -e insert into t.t values ('κόσμε', 'printable UTF8')
-	// OK
+	// INSERT 1
 	// sql -e insert into t.t values (e'\xc3\xb1', 'printable UTF8 using escapes')
-	// OK
+	// INSERT 1
 	// sql -e insert into t.t values (e'\x01', 'non-printable UTF8 string')
-	// OK
+	// INSERT 1
 	// sql -e insert into t.t values (e'\xdc\x88\x38\x35', 'UTF8 string with RTL char')
-	// OK
+	// INSERT 1
 	// sql -e insert into t.t values (e'\xc3\x28', 'non-UTF8 string')
-	// OK
+	// INSERT 1
 	// sql -e select * from t.t
 	// 7 rows
 	// s	d
@@ -640,7 +640,7 @@ func Example_user() {
 	// +----------+
 	// +----------+
 	// user set foo --password=bar
-	// OK
+	// INSERT 1
 	// user ls
 	// +----------+
 	// | username |
@@ -648,7 +648,7 @@ func Example_user() {
 	// | foo      |
 	// +----------+
 	// user rm foo
-	// OK
+	// DELETE 1
 	// user ls
 	// +----------+
 	// | username |

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -69,9 +69,8 @@ subsequent positional argument on the command line may contain
 one or more SQL statements, separated by semicolons. If an
 error occurs in any statement, the command exits with a
 non-zero status code and further statements are not
-executed. Only the results of the first SQL statement in each
-positional argument are printed on the standard output.`),
-
+executed. The results of each SQL statement are printed on
+the standard output.`),
 	"join": wrapText(`
 A comma-separated list of addresses to use when a new node is joining
 an existing cluster. For the first node in a cluster, --join should

--- a/cli/node.go
+++ b/cli/node.go
@@ -66,7 +66,7 @@ func runLsNodes(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	printQueryOutput(os.Stdout, lsNodesColumnHeaders, rows)
+	printQueryOutput(os.Stdout, lsNodesColumnHeaders, rows, "")
 	return nil
 }
 
@@ -128,7 +128,7 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 		return util.Errorf("expected no arguments or a single node ID")
 	}
 
-	printQueryOutput(os.Stdout, nodesColumnHeaders, nodeStatusesToRows(nodeStatuses))
+	printQueryOutput(os.Stdout, nodesColumnHeaders, nodeStatusesToRows(nodeStatuses), "")
 	return nil
 }
 

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -29,6 +29,8 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
+
+	"github.com/cockroachdb/pq"
 )
 
 const (
@@ -210,7 +212,7 @@ func runInteractive(conn *sqlConn) (exitErr error) {
 			readline.SetHistoryPath("")
 		}
 
-		if exitErr = runPrettyQuery(conn, os.Stdout, fullStmt); exitErr != nil {
+		if exitErr = runPrettyQuery(conn, os.Stdout, makeQuery(fullStmt)); exitErr != nil {
 			fmt.Fprintln(osStderr, exitErr)
 		}
 
@@ -225,30 +227,36 @@ func runInteractive(conn *sqlConn) (exitErr error) {
 // on error.
 func runStatements(conn *sqlConn, stmts []string) error {
 	for _, stmt := range stmts {
-		fullStmt := stmt + "\n"
-		cols, allRows, err := runQuery(conn, fullStmt)
-		if err != nil {
-			fmt.Fprintln(osStderr, err)
-			return err
-		}
-
-		if len(cols) == 0 {
-			// No result selected, inform the user.
-			fmt.Fprintln(os.Stdout, "OK")
-		} else {
-			// Some results selected, inform the user about how much data to expect.
-			noun := "rows"
-			if len(allRows) == 1 {
-				noun = "row"
+		q := makeQuery(stmt)
+		for {
+			cols, allRows, err := runQuery(conn, q)
+			if err != nil {
+				if err == pq.ErrNoMoreResults {
+					break
+				}
+				fmt.Fprintln(osStderr, err)
+				os.Exit(1)
 			}
 
-			fmt.Fprintf(os.Stdout, "%d %s\n", len(allRows), noun)
+			if len(cols) == 0 {
+				// No result selected, inform the user.
+				fmt.Fprintln(os.Stdout, "OK")
+			} else {
+				// Some results selected, inform the user about how much data to expect.
+				noun := "rows"
+				if len(allRows) == 1 {
+					noun = "row"
+				}
 
-			// Then print the results themselves.
-			fmt.Fprintln(os.Stdout, strings.Join(cols, "\t"))
-			for _, row := range allRows {
-				fmt.Fprintln(os.Stdout, strings.Join(row, "\t"))
+				fmt.Fprintf(os.Stdout, "%d %s\n", len(allRows), noun)
+
+				// Then print the results themselves.
+				fmt.Fprintln(os.Stdout, strings.Join(cols, "\t"))
+				for _, row := range allRows {
+					fmt.Fprintln(os.Stdout, strings.Join(row, "\t"))
+				}
 			}
+			q = nextResult
 		}
 	}
 	return nil

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -229,7 +229,7 @@ func runStatements(conn *sqlConn, stmts []string) error {
 	for _, stmt := range stmts {
 		q := makeQuery(stmt)
 		for {
-			cols, allRows, err := runQuery(conn, q)
+			cols, allRows, tag, err := runQuery(conn, q)
 			if err != nil {
 				if err == pq.ErrNoMoreResults {
 					break
@@ -240,15 +240,10 @@ func runStatements(conn *sqlConn, stmts []string) error {
 
 			if len(cols) == 0 {
 				// No result selected, inform the user.
-				fmt.Fprintln(os.Stdout, "OK")
+				fmt.Fprintln(os.Stdout, tag)
 			} else {
 				// Some results selected, inform the user about how much data to expect.
-				noun := "rows"
-				if len(allRows) == 1 {
-					noun = "row"
-				}
-
-				fmt.Fprintf(os.Stdout, "%d %s\n", len(allRows), noun)
+				fmt.Fprintf(os.Stdout, "%d row%s\n", len(allRows), pluralize(int64(len(allRows))))
 
 				// Then print the results themselves.
 				fmt.Fprintln(os.Stdout, strings.Join(cols, "\t"))

--- a/cli/sql_util.go
+++ b/cli/sql_util.go
@@ -61,7 +61,7 @@ func (c *sqlConn) Query(query string, args []driver.Value) (*sqlRows, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &sqlRows{Rows: rows, conn: c}, nil
+	return &sqlRows{rows: rows.(sqlRowsI), conn: c}, nil
 }
 
 func (c *sqlConn) Next() (*sqlRows, error) {
@@ -75,7 +75,7 @@ func (c *sqlConn) Next() (*sqlRows, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &sqlRows{Rows: rows, conn: c}, nil
+	return &sqlRows{rows: rows.(sqlRowsI), conn: c}, nil
 }
 
 func (c *sqlConn) Close() {
@@ -88,13 +88,31 @@ func (c *sqlConn) Close() {
 	}
 }
 
-type sqlRows struct {
+type sqlRowsI interface {
 	driver.Rows
+	Result() driver.Result
+	Tag() string
+}
+
+type sqlRows struct {
+	rows sqlRowsI
 	conn *sqlConn
 }
 
+func (r *sqlRows) Columns() []string {
+	return r.rows.Columns()
+}
+
+func (r *sqlRows) Result() driver.Result {
+	return r.rows.Result()
+}
+
+func (r *sqlRows) Tag() string {
+	return r.rows.Tag()
+}
+
 func (r *sqlRows) Close() error {
-	err := r.Rows.Close()
+	err := r.rows.Close()
 	if err == driver.ErrBadConn {
 		r.conn.Close()
 	}
@@ -102,7 +120,7 @@ func (r *sqlRows) Close() error {
 }
 
 func (r *sqlRows) Next(values []driver.Value) error {
-	err := r.Rows.Next(values)
+	err := r.rows.Next(values)
 	if err == driver.ErrBadConn {
 		r.conn.Close()
 	}
@@ -154,7 +172,7 @@ func makeQuery(query string, parameters ...driver.Value) queryFunc {
 
 // runQuery takes a 'query' with optional 'parameters'.
 // It runs the sql query and returns a list of columns names and a list of rows.
-func runQuery(conn *sqlConn, fn queryFunc) ([]string, [][]string, error) {
+func runQuery(conn *sqlConn, fn queryFunc) ([]string, [][]string, string, error) {
 	return runQueryWithFormat(conn, nil, fn)
 }
 
@@ -163,10 +181,10 @@ func runQuery(conn *sqlConn, fn queryFunc) ([]string, [][]string, error) {
 // If 'format' is not nil, the values with column name
 // found in the map are run through the corresponding callback.
 func runQueryWithFormat(conn *sqlConn, format fmtMap, fn queryFunc) (
-	[]string, [][]string, error) {
+	[]string, [][]string, string, error) {
 	rows, err := fn(conn)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 
 	defer func() { _ = rows.Close() }()
@@ -177,14 +195,14 @@ func runQueryWithFormat(conn *sqlConn, format fmtMap, fn queryFunc) (
 // It runs the sql query and writes pretty output to 'w'.
 func runPrettyQuery(conn *sqlConn, w io.Writer, fn queryFunc) error {
 	for {
-		cols, allRows, err := runQuery(conn, fn)
+		cols, allRows, result, err := runQuery(conn, fn)
 		if err != nil {
 			if err == pq.ErrNoMoreResults {
 				return nil
 			}
 			return err
 		}
-		printQueryOutput(w, cols, allRows)
+		printQueryOutput(w, cols, allRows, result)
 		fn = nextResult
 	}
 }
@@ -197,15 +215,14 @@ func runPrettyQuery(conn *sqlConn, w io.Writer, fn queryFunc) error {
 // It returns the header row followed by all data rows.
 // If both the header row and list of rows are empty, it means no row
 // information was returned (eg: statement was not a query).
-func sqlRowsToStrings(rows *sqlRows, format fmtMap) ([]string, [][]string, error) {
+func sqlRowsToStrings(rows *sqlRows, format fmtMap) ([]string, [][]string, string, error) {
 	cols := rows.Columns()
 
-	if len(cols) == 0 {
-		return nil, nil, nil
+	var allRows [][]string
+	var vals []driver.Value
+	if len(cols) > 0 {
+		vals = make([]driver.Value, len(cols))
 	}
-
-	vals := make([]driver.Value, len(cols))
-	allRows := [][]string{}
 
 	for {
 		err := rows.Next(vals)
@@ -213,7 +230,7 @@ func sqlRowsToStrings(rows *sqlRows, format fmtMap) ([]string, [][]string, error
 			break
 		}
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, "", err
 		}
 		rowStrings := make([]string, len(cols))
 		for i, v := range vals {
@@ -226,15 +243,33 @@ func sqlRowsToStrings(rows *sqlRows, format fmtMap) ([]string, [][]string, error
 		allRows = append(allRows, rowStrings)
 	}
 
-	return cols, allRows, nil
+	result := rows.Result()
+	tag := rows.Tag()
+	switch tag {
+	case "":
+		tag = "OK"
+	case "DELETE", "INSERT", "UPDATE":
+		if n, err := result.RowsAffected(); err == nil {
+			tag = fmt.Sprintf("%s %d", tag, n)
+		}
+	}
+
+	return cols, allRows, tag, nil
+}
+
+func pluralize(n int64) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 // printQueryOutput takes a list of column names and a list of row contents
 // writes a pretty table to 'w', or "OK" if empty.
-func printQueryOutput(w io.Writer, cols []string, allRows [][]string) {
+func printQueryOutput(w io.Writer, cols []string, allRows [][]string, tag string) {
 	if len(cols) == 0 {
-		// This operation did not return rows, just show success.
-		fmt.Fprintln(w, "OK")
+		// This operation did not return rows, just show the tag.
+		fmt.Fprintln(w, tag)
 		return
 	}
 

--- a/cli/sql_util.go
+++ b/cli/sql_util.go
@@ -22,16 +22,16 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/lib/pq"
-
 	"github.com/olekukonko/tablewriter"
 
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/pq"
 )
 
 type sqlConnI interface {
 	driver.Conn
 	driver.Queryer
+	Next() (driver.Rows, error)
 }
 
 type sqlConn struct {
@@ -55,6 +55,20 @@ func (c *sqlConn) Query(query string, args []driver.Value) (*sqlRows, error) {
 		return nil, err
 	}
 	rows, err := c.conn.Query(query, args)
+	if err == driver.ErrBadConn {
+		c.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &sqlRows{Rows: rows, conn: c}, nil
+}
+
+func (c *sqlConn) Next() (*sqlRows, error) {
+	if c.conn == nil {
+		return nil, driver.ErrBadConn
+	}
+	rows, err := c.conn.Next()
 	if err == driver.ErrBadConn {
 		c.Close()
 	}
@@ -113,51 +127,66 @@ func makeSQLClient() *sqlConn {
 // and outputs the string to be displayed.
 type fmtMap map[string]func(driver.Value) string
 
-// runQuery takes a 'query' with optional 'parameters'.
-// It runs the sql query and returns a list of columns names and a list of rows.
-func runQuery(db *sqlConn, query string, parameters ...driver.Value) (
-	[]string, [][]string, error) {
-	return runQueryWithFormat(db, nil, query, parameters...)
+type queryFunc func(conn *sqlConn) (*sqlRows, error)
+
+func nextResult(conn *sqlConn) (*sqlRows, error) {
+	return conn.Next()
+}
+
+func makeQuery(query string, parameters ...driver.Value) queryFunc {
+	return func(conn *sqlConn) (*sqlRows, error) {
+		// driver.Value is an alias for interface{}, but must adhere to a restricted
+		// set of types when being passed to driver.Queryer.Query (see
+		// driver.IsValue). We use driver.DefaultParameterConverter to perform the
+		// necessary conversion. This is usually taken care of by the sql package,
+		// but we have to do so manually because we're talking directly to the
+		// driver.
+		for i := range parameters {
+			var err error
+			parameters[i], err = driver.DefaultParameterConverter.ConvertValue(parameters[i])
+			if err != nil {
+				return nil, err
+			}
+		}
+		return conn.Query(query, parameters)
+	}
 }
 
 // runQuery takes a 'query' with optional 'parameters'.
 // It runs the sql query and returns a list of columns names and a list of rows.
+func runQuery(conn *sqlConn, fn queryFunc) ([]string, [][]string, error) {
+	return runQueryWithFormat(conn, nil, fn)
+}
+
+// runQueryWithFormat takes a 'query' with optional 'parameters'.
+// It runs the sql query and returns a list of columns names and a list of rows.
 // If 'format' is not nil, the values with column name
 // found in the map are run through the corresponding callback.
-func runQueryWithFormat(db *sqlConn, format fmtMap, query string, parameters ...driver.Value) (
+func runQueryWithFormat(conn *sqlConn, format fmtMap, fn queryFunc) (
 	[]string, [][]string, error) {
-	// driver.Value is an alias for interface{}, but must adhere to a restricted
-	// set of types when being passed to driver.Queryer.Query (see
-	// driver.IsValue). We use driver.DefaultParameterConverter to perform the
-	// necessary conversion. This is usually taken care of by the sql package,
-	// but we have to do so manually because we're talking directly to the
-	// driver.
-	for i := range parameters {
-		var err error
-		parameters[i], err = driver.DefaultParameterConverter.ConvertValue(parameters[i])
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	rows, err := db.Query(query, parameters)
+	rows, err := fn(conn)
 	if err != nil {
-		return nil, nil, fmt.Errorf("query error: %s", err)
+		return nil, nil, err
 	}
 
 	defer func() { _ = rows.Close() }()
 	return sqlRowsToStrings(rows, format)
 }
 
-// runPrettyQueryWithFormat takes a 'query' with optional 'parameters'.
+// runPrettyQuery takes a 'query' with optional 'parameters'.
 // It runs the sql query and writes pretty output to 'w'.
-func runPrettyQuery(db *sqlConn, w io.Writer, query string, parameters ...driver.Value) error {
-	cols, allRows, err := runQuery(db, query, parameters...)
-	if err != nil {
-		return err
+func runPrettyQuery(conn *sqlConn, w io.Writer, fn queryFunc) error {
+	for {
+		cols, allRows, err := runQuery(conn, fn)
+		if err != nil {
+			if err == pq.ErrNoMoreResults {
+				return nil
+			}
+			return err
+		}
+		printQueryOutput(w, cols, allRows)
+		fn = nextResult
 	}
-	printQueryOutput(w, cols, allRows)
-	return nil
 }
 
 // sqlRowsToStrings turns 'rows' into a list of rows, each of which

--- a/cli/sql_util_test.go
+++ b/cli/sql_util_test.go
@@ -49,7 +49,7 @@ func TestRunQuery(t *testing.T) {
 	}
 
 	expected := `
-OK
+SET
 `
 	if a, e := b.String(), expected[1:]; a != e {
 		t.Fatalf("expected output:\n%s\ngot:\n%s", e, a)
@@ -57,7 +57,7 @@ OK
 	b.Reset()
 
 	// Use system database for sample query/output as they are fairly fixed.
-	cols, rows, err := runQuery(conn, makeQuery(`SHOW COLUMNS FROM system.namespace`))
+	cols, rows, _, err := runQuery(conn, makeQuery(`SHOW COLUMNS FROM system.namespace`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ OK
 		return fmt.Sprintf("--> %s <--", val)
 	}
 
-	_, rows, err = runQueryWithFormat(conn, fmtMap{"name": newFormat},
+	_, rows, _, err = runQueryWithFormat(conn, fmtMap{"name": newFormat},
 		makeQuery(`SELECT * FROM system.namespace WHERE name=$1`, "descriptor"))
 	if err != nil {
 		t.Fatal(err)

--- a/cli/user.go
+++ b/cli/user.go
@@ -46,7 +46,7 @@ func runGetUser(cmd *cobra.Command, args []string) {
 	conn := makeSQLClient()
 	defer conn.Close()
 	err := runPrettyQuery(conn, os.Stdout,
-		`SELECT * FROM system.users WHERE username=$1`, args[0])
+		makeQuery(`SELECT * FROM system.users WHERE username=$1`, args[0]))
 	if err != nil {
 		panic(err)
 	}
@@ -70,7 +70,8 @@ func runLsUsers(cmd *cobra.Command, args []string) {
 	}
 	conn := makeSQLClient()
 	defer conn.Close()
-	err := runPrettyQuery(conn, os.Stdout, `SELECT username FROM system.users`)
+	err := runPrettyQuery(conn, os.Stdout,
+		makeQuery(`SELECT username FROM system.users`))
 	if err != nil {
 		panic(err)
 	}
@@ -95,7 +96,7 @@ func runRmUser(cmd *cobra.Command, args []string) {
 	conn := makeSQLClient()
 	defer conn.Close()
 	err := runPrettyQuery(conn, os.Stdout,
-		`DELETE FROM system.users WHERE username=$1`, args[0])
+		makeQuery(`DELETE FROM system.users WHERE username=$1`, args[0]))
 	if err != nil {
 		panic(err)
 	}
@@ -164,7 +165,7 @@ func runSetUser(cmd *cobra.Command, args []string) {
 	defer conn.Close()
 	// TODO(marc): switch to UPSERT.
 	err = runPrettyQuery(conn, os.Stdout,
-		`INSERT INTO system.users VALUES ($1, $2)`, args[0], hashed)
+		makeQuery(`INSERT INTO system.users VALUES ($1, $2)`, args[0], hashed))
 	if err != nil {
 		panic(err)
 	}

--- a/cli/zone.go
+++ b/cli/zone.go
@@ -85,7 +85,7 @@ func runGetZone(cmd *cobra.Command, args []string) {
 	conn := makeSQLClient()
 	defer conn.Close()
 	_, rows, err := runQueryWithFormat(conn, fmtMap{"config": formatZone},
-		`SELECT * FROM system.zones WHERE id=$1`, id)
+		makeQuery(`SELECT * FROM system.zones WHERE id=$1`, id))
 	if err != nil {
 		log.Error(err)
 		return
@@ -117,7 +117,8 @@ func runLsZones(cmd *cobra.Command, args []string) {
 	}
 	conn := makeSQLClient()
 	defer conn.Close()
-	_, rows, err := runQueryWithFormat(conn, fmtMap{"config": formatZone}, `SELECT * FROM system.zones`)
+	_, rows, err := runQueryWithFormat(conn, fmtMap{"config": formatZone},
+		makeQuery(`SELECT * FROM system.zones`))
 	if err != nil {
 		log.Error(err)
 		return
@@ -159,7 +160,7 @@ func runRmZone(cmd *cobra.Command, args []string) {
 	conn := makeSQLClient()
 	defer conn.Close()
 	err = runPrettyQuery(conn, os.Stdout,
-		`DELETE FROM system.zones WHERE id=$1`, id)
+		makeQuery(`DELETE FROM system.zones WHERE id=$1`, id))
 	if err != nil {
 		log.Error(err)
 		return
@@ -232,7 +233,7 @@ func runSetZone(cmd *cobra.Command, args []string) {
 	defer conn.Close()
 	// TODO(marc): switch to UPSERT.
 	err = runPrettyQuery(conn, os.Stdout,
-		`INSERT INTO system.zones VALUES ($1, $2)`, id, buf)
+		makeQuery(`INSERT INTO system.zones VALUES ($1, $2)`, id, buf))
 	if err != nil {
 		log.Error(err)
 		return

--- a/cli/zone.go
+++ b/cli/zone.go
@@ -84,7 +84,7 @@ func runGetZone(cmd *cobra.Command, args []string) {
 
 	conn := makeSQLClient()
 	defer conn.Close()
-	_, rows, err := runQueryWithFormat(conn, fmtMap{"config": formatZone},
+	_, rows, _, err := runQueryWithFormat(conn, fmtMap{"config": formatZone},
 		makeQuery(`SELECT * FROM system.zones WHERE id=$1`, id))
 	if err != nil {
 		log.Error(err)
@@ -117,7 +117,7 @@ func runLsZones(cmd *cobra.Command, args []string) {
 	}
 	conn := makeSQLClient()
 	defer conn.Close()
-	_, rows, err := runQueryWithFormat(conn, fmtMap{"config": formatZone},
+	_, rows, _, err := runQueryWithFormat(conn, fmtMap{"config": formatZone},
 		makeQuery(`SELECT * FROM system.zones`))
 	if err != nil {
 		log.Error(err)

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -24,12 +24,12 @@ import (
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
 
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/util/tracing"
+	_ "github.com/cockroachdb/pq"
 )
 
 func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *sql.DB)) {

--- a/sql/driver/wire.go
+++ b/sql/driver/wire.go
@@ -96,7 +96,7 @@ func (d Datum) Value() (driver.Value, error) {
 		val = t.FloatVal
 	case *Datum_DecimalVal:
 		// For now, we just return the decimal string, to be consistent
-		// with lib/pq's driver.
+		// with cockroachdb/pq's driver.
 		val = t.DecimalVal
 	case *Datum_BytesVal:
 		val = t.BytesVal

--- a/sql/pgwire/types.go
+++ b/sql/pgwire/types.go
@@ -25,11 +25,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/lib/pq/oid"
-
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/pq/oid"
 )
 
 //go:generate stringer -type=formatCode
@@ -201,8 +200,8 @@ func (b *writeBuffer) writeBinaryDatum(d parser.Datum) error {
 
 const pgTimeStampFormat = "2006-01-02 15:04:05.999999999-07:00"
 
-// formatTs formats t into a format lib/pq understands.
-// Mostly cribbed from github.com/lib/pq.
+// formatTs formats t into a format cockroachdb/pq understands.
+// Mostly cribbed from github.com/cockroachdb/pq.
 func formatTs(t time.Time) (b []byte) {
 	// Need to send dates before 0001 A.D. with " BC" suffix, instead of the
 	// minus sign preferred by Go.

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -24,14 +24,13 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/lib/pq/oid"
-
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/tracing"
+	"github.com/cockroachdb/pq/oid"
 )
 
 //go:generate stringer -type=clientMessageType

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -27,8 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lib/pq"
-
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/security/securitytest"
 	"github.com/cockroachdb/cockroach/server"
@@ -37,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/pq"
 )
 
 func trivialQuery(pgURL url.URL) error {
@@ -594,7 +593,7 @@ func TestCmdCompleteVsEmptyStatements(t *testing.T) {
 	}
 	defer db.Close()
 
-	// lib/pq handles the empty query response by returning a nil driver.Result.
+	// cockroachdb/pq handles the empty query response by returning a nil driver.Result.
 	// Unfortunately sql.Exec wraps that, nil or not, in a sql.Result which doesn't
 	// expose the underlying driver.Result.
 	// sql.Result does however have methods which attempt to dereference the underlying
@@ -606,7 +605,7 @@ func TestCmdCompleteVsEmptyStatements(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _ = nonempty.RowsAffected() // should not panic if lib/pq returned a non-nil result.
+	_, _ = nonempty.RowsAffected() // should not panic if cockroachdb/pq returned a non-nil result.
 
 	empty, err := db.Exec(" ; ; ;")
 	if err != nil {
@@ -615,11 +614,11 @@ func TestCmdCompleteVsEmptyStatements(t *testing.T) {
 	defer func() {
 		_ = recover()
 	}()
-	_, _ = empty.RowsAffected() // should panic if lib/pq returned a nil result as expected.
+	_, _ = empty.RowsAffected() // should panic if cockroachdb/pq returned a nil result as expected.
 	t.Fatal("should not get here -- empty result from empty query should panic first")
 }
 
-// Unfortunately lib/pq doesn't expose returned command tags directly, but we can test
+// Unfortunately cockroachdb/pq doesn't expose returned command tags directly, but we can test
 // the methods where it depends on their values (Begin, Commit, RowsAffected for INSERTs).
 func TestPGCommandTags(t *testing.T) {
 	defer leaktest.AfterTest(t)
@@ -652,7 +651,7 @@ func TestPGCommandTags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// lib/pq has a special-case for INSERT (due to oids), so test insert and update statements.
+	// cockroachdb/pq has a special-case for INSERT (due to oids), so test insert and update statements.
 	res, err := db.Exec("INSERT INTO testing.tags VALUES (1, 1), (2, 2)")
 	if err != nil {
 		t.Fatal(err)

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"testing"
 
-	_ "github.com/lib/pq"
-
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -32,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	_ "github.com/cockroachdb/pq"
 )
 
 func TestLogSplits(t *testing.T) {


### PR DESCRIPTION
Use the new functionality in lib/pq to select the next set of results
when multiple statements were executed.

Switch to using the "postgres" SQL driver in the cli tests.

Remove runPrettyQueryWithFormat. It was only used in tests.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4081)

<!-- Reviewable:end -->
