### PR TITLE
Log Replica Changes to Rangelog table

### DIFF
--- a/server/testserver.go
+++ b/server/testserver.go
@@ -246,6 +246,11 @@ func (ts *TestServer) WaitForInitialSplits() error {
 	})
 }
 
+// Stores returns the collection of stores from this TestServer's node.
+func (ts *TestServer) Stores() *storage.Stores {
+	return ts.node.stores
+}
+
 // ServingAddr returns the rpc server's address. Should be used by clients.
 func (ts *TestServer) ServingAddr() string {
 	return ts.listener.Addr().String()

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -21,6 +21,11 @@
 
 package storage
 
+import (
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/roachpb"
+)
+
 // ForceReplicationScanAndProcess iterates over all ranges and
 // enqueues any that need to be replicated. Exposed only for testing.
 func (s *Store) ForceReplicationScanAndProcess() {
@@ -76,4 +81,10 @@ func (s *Store) ForceRaftLogScanAndProcess() {
 	}
 
 	s.raftLogQueue.DrainQueue(s.ctx.Clock)
+}
+
+// LogReplicaChangeTest adds a fake replica change event to the log for the
+// range which contains the given key. This is intended for usage only in unit tests.
+func (s *Store) LogReplicaChangeTest(txn *client.Txn, changeType roachpb.ReplicaChangeType, replica roachpb.ReplicaDescriptor, desc roachpb.RangeDescriptor) *roachpb.Error {
+	return s.logChange(txn, changeType, replica, desc)
 }

--- a/storage/log.go
+++ b/storage/log.go
@@ -28,6 +28,11 @@ import (
 	"github.com/cockroachdb/cockroach/sql/privilege"
 )
 
+// TODO(mrtracy): All of this logic should probably be moved into the SQL
+// package; there are going to be additional event log tables which will not be
+// strongly associated with a store, and it would be better to keep event log
+// tables close together in the code.
+
 // RangeEventLogType describes a specific event type recorded in the range log
 // table.
 type RangeEventLogType string
@@ -35,6 +40,12 @@ type RangeEventLogType string
 const (
 	// RangeEventLogSplit is the event type recorded when a range splits.
 	RangeEventLogSplit RangeEventLogType = "split"
+	// RangeEventLogAdd is the event type recorded when a range adds a
+	// new replica.
+	RangeEventLogAdd RangeEventLogType = "add"
+	// RangeEventLogRemove is the event type recorded when a range removes a
+	// replica.
+	RangeEventLogRemove RangeEventLogType = "remove"
 )
 
 // rangeEventTableSchema defines the schema of the event log table. It is
@@ -104,6 +115,8 @@ func AddEventLogToMetadataSchema(schema *sql.MetadataSchema) {
 // logSplit logs a range split event into the event table. The affected range is
 // the range which previously existed and is being split in half; the "other"
 // range is the new range which is being created.
+// TODO(mrtracy): There are several different reasons that a replica split
+// could occur, and that information should be logged.
 func (s *Store) logSplit(txn *client.Txn, updatedDesc, newDesc roachpb.RangeDescriptor) *roachpb.Error {
 	if !s.ctx.LogRangeEvents {
 		return nil
@@ -118,11 +131,69 @@ func (s *Store) logSplit(txn *client.Txn, updatedDesc, newDesc roachpb.RangeDesc
 	}
 	infoStr := string(infoBytes)
 	return s.insertRangeLogEvent(txn, rangeLogEvent{
-		timestamp:    txn.Proto.Timestamp.GoTime(),
+		timestamp:    selectEventTimestamp(s, txn.Proto.Timestamp),
 		rangeID:      updatedDesc.RangeID,
 		eventType:    RangeEventLogSplit,
 		storeID:      s.StoreID(),
 		otherRangeID: &newDesc.RangeID,
 		info:         &infoStr,
 	})
+}
+
+// logChange logs a replica change event, which represents a replica being added
+// to or removed from a range.
+// TODO(mrtracy): There are several different reasons that a replica change
+// could occur, and that information should be logged.
+func (s *Store) logChange(txn *client.Txn, changeType roachpb.ReplicaChangeType, replica roachpb.ReplicaDescriptor,
+	desc roachpb.RangeDescriptor) *roachpb.Error {
+	if !s.ctx.LogRangeEvents {
+		return nil
+	}
+
+	var logType RangeEventLogType
+	var infoStruct interface{}
+	switch changeType {
+	case roachpb.ADD_REPLICA:
+		logType = RangeEventLogAdd
+		infoStruct = struct {
+			AddReplica  roachpb.ReplicaDescriptor
+			UpdatedDesc roachpb.RangeDescriptor
+		}{replica, desc}
+	case roachpb.REMOVE_REPLICA:
+		logType = RangeEventLogRemove
+		infoStruct = struct {
+			RemovedReplica roachpb.ReplicaDescriptor
+			UpdatedDesc    roachpb.RangeDescriptor
+		}{replica, desc}
+	default:
+		return roachpb.NewErrorf("unknown replica change type %s", changeType)
+	}
+
+	infoBytes, err := json.Marshal(infoStruct)
+	if err != nil {
+		return roachpb.NewError(err)
+	}
+	infoStr := string(infoBytes)
+	return s.insertRangeLogEvent(txn, rangeLogEvent{
+		timestamp: selectEventTimestamp(s, txn.Proto.Timestamp),
+		rangeID:   desc.RangeID,
+		eventType: logType,
+		storeID:   s.StoreID(),
+		info:      &infoStr,
+	})
+}
+
+// selectEventTimestamp selects a timestamp for this log message. If the
+// transaction this event is being written in has a non-zero timestamp, then that
+// timestamp should be used; otherwise, the store's physical clock is used.
+// This helps with testing; in normal usage, the logging of an event will never
+// be the first action in the transaction, and thus the transaction will have an
+// assigned database timestamp. However, in the case of our tests log events
+// *are* the first action in a transaction, and we must elect to use the store's
+// physical time instead.
+func selectEventTimestamp(s *Store, input roachpb.Timestamp) time.Time {
+	if input == roachpb.ZeroTimestamp {
+		return s.Clock().PhysicalTime()
+	}
+	return input.GoTime()
 }

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -25,6 +25,8 @@ import (
 
 	_ "github.com/lib/pq"
 
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
@@ -117,5 +119,140 @@ func TestLogSplits(t *testing.T) {
 	}
 	if rows.Err() != nil {
 		t.Fatal(rows.Err())
+	}
+}
+
+func TestLogRebalances(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s := server.StartTestServer(t)
+	defer s.Stop()
+
+	// Use a client to get the RangeDescriptor for the first range. We will use
+	// this range's information to log fake rebalance events.
+	db := s.DB()
+	desc := &roachpb.RangeDescriptor{}
+	if pErr := db.GetProto(keys.RangeDescriptorKey(roachpb.RKeyMin), desc); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	// This code assumes that there is only one TestServer, and thus that
+	// StoreID 1 is present on the testserver. If this assumption changes in the
+	// future, *any* store will work, but a new method will need to be added to
+	// Stores (or a creative usage of VisitStores could suffice).
+	store, pErr := s.Stores().GetStore(roachpb.StoreID(1))
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	// Log several fake events using the store.
+	logEvent := func(changeType roachpb.ReplicaChangeType) {
+		if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+			return store.LogReplicaChangeTest(txn, changeType, desc.Replicas[0], *desc)
+		}); pErr != nil {
+			t.Fatal(pErr)
+		}
+	}
+	logEvent(roachpb.ADD_REPLICA)
+	logEvent(roachpb.ADD_REPLICA)
+	logEvent(roachpb.REMOVE_REPLICA)
+
+	// Open a SQL connection to verify that the events have been logged.
+	pgUrl, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, os.TempDir(), "TestLogRebalances")
+	defer cleanupFn()
+
+	sqlDB, err := sql.Open("postgres", pgUrl.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqlDB.Close()
+
+	// verify that two add replica events have been logged.
+	// TODO(mrtracy): placeholders still appear to be broken, this query should
+	// be using a string placeholder for the eventType value.
+	rows, err := sqlDB.Query(`SELECT rangeID, info FROM system.rangelog WHERE eventType = 'add'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	for rows.Next() {
+		count++
+		var rangeID int64
+		var infoStr sql.NullString
+		if err := rows.Scan(&rangeID, &infoStr); err != nil {
+			t.Fatal(err)
+		}
+
+		if a, e := roachpb.RangeID(rangeID), desc.RangeID; a != e {
+			t.Errorf("wrong rangeID %d recorded for add event, expected %d", a, e)
+		}
+		// Verify that info returns a json struct.
+		if !infoStr.Valid {
+			t.Errorf("info not recorded for add replica of range %d", rangeID)
+		}
+		var info struct {
+			AddReplica  roachpb.ReplicaDescriptor
+			UpdatedDesc roachpb.RangeDescriptor
+		}
+		if err := json.Unmarshal([]byte(infoStr.String), &info); err != nil {
+			t.Errorf("error unmarshalling info string for add replica %d: %s", rangeID, err)
+			continue
+		}
+		if int64(info.UpdatedDesc.RangeID) != rangeID {
+			t.Errorf("recorded wrong updated descriptor %s for add replica of range %d", info.UpdatedDesc, rangeID)
+		}
+		if a, e := info.AddReplica, desc.Replicas[0]; a != e {
+			t.Errorf("recorded wrong updated replica %s for add replica of range %d, expected %s",
+				a, rangeID, e)
+		}
+	}
+	if rows.Err() != nil {
+		t.Fatal(rows.Err())
+	}
+	if a, e := count, 2; a != e {
+		t.Errorf("expected %d AddReplica events logged, found %d", e, a)
+	}
+
+	// verify that one remove replica event was logged.
+	rows, err = sqlDB.Query(`SELECT rangeID, info FROM system.rangelog WHERE eventType = 'remove'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count = 0
+	for rows.Next() {
+		count++
+		var rangeID int64
+		var infoStr sql.NullString
+		if err := rows.Scan(&rangeID, &infoStr); err != nil {
+			t.Fatal(err)
+		}
+
+		if a, e := roachpb.RangeID(rangeID), desc.RangeID; a != e {
+			t.Errorf("wrong rangeID %d recorded for remove event, expected %d", a, e)
+		}
+		// Verify that info returns a json struct.
+		if !infoStr.Valid {
+			t.Errorf("info not recorded for remove replica of range %d", rangeID)
+		}
+		var info struct {
+			RemovedReplica roachpb.ReplicaDescriptor
+			UpdatedDesc    roachpb.RangeDescriptor
+		}
+		if err := json.Unmarshal([]byte(infoStr.String), &info); err != nil {
+			t.Errorf("error unmarshalling info string for remove replica %d: %s", rangeID, err)
+			continue
+		}
+		if int64(info.UpdatedDesc.RangeID) != rangeID {
+			t.Errorf("recorded wrong updated descriptor %s for remove replica of range %d", info.UpdatedDesc, rangeID)
+		}
+		if a, e := info.RemovedReplica, desc.Replicas[0]; a != e {
+			t.Errorf("recorded wrong updated replica %s for remove replica of range %d, expected %s",
+				a, rangeID, e)
+		}
+	}
+	if rows.Err() != nil {
+		t.Fatal(rows.Err())
+	}
+	if a, e := count, 1; a != e {
+		t.Errorf("expected %d RemoveReplica events logged, found %d", e, a)
 	}
 }


### PR DESCRIPTION
"ChangeReplicas" events are now logged to the system.rangelog table. This will
allow tracking of rebalances and other replication changes.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4085)

<!-- Reviewable:end -->
