### PR TITLE
sql: cleaner explainDebug implementation

### DIFF
--- a/sql/explain.go
+++ b/sql/explain.go
@@ -56,7 +56,9 @@ func (p *planner) Explain(n *parser.Explain) (planNode, *roachpb.Error) {
 		if err != nil {
 			return nil, roachpb.NewUErrorf("%v: %s", err, n)
 		}
-		return plan, nil
+		// Wrap the plan in an explainDebugNode.
+		return &explainDebugNode{plan}, nil
+
 	case explainPlan:
 		v := &valuesNode{}
 		v.columns = []ResultColumn{
@@ -65,11 +67,11 @@ func (p *planner) Explain(n *parser.Explain) (planNode, *roachpb.Error) {
 			{Name: "Description", Typ: parser.DummyString},
 		}
 		populateExplain(v, plan, 0)
-		plan = v
+		return v, nil
+
 	default:
 		return nil, roachpb.NewUErrorf("unsupported EXPLAIN mode: %d", mode)
 	}
-	return plan, nil
 }
 
 func markDebug(plan planNode, mode explainMode) (planNode, *roachpb.Error) {
@@ -79,8 +81,12 @@ func markDebug(plan planNode, mode explainMode) (planNode, *roachpb.Error) {
 
 		if _, ok := t.table.node.(*indexJoinNode); ok {
 			// We will replace the indexJoinNode with the index node; we cannot
-			// process filters anymore (we don't have all the values).
+			// process filter or render expressions (we don't have all the values).
+			// TODO(radu): this should go away once indexJoinNode properly
+			// implements explainDebug.
 			t.filter = nil
+			t.render = nil
+			t.qvals = nil
 		} else if _, ok := t.table.node.(*scanNode); !ok {
 			// TODO(radu): We don't support debug mode for selects with no table or with a
 			// virtual table (subquery).
@@ -125,4 +131,63 @@ func populateExplain(v *valuesNode, plan planNode, level int) {
 	for _, child := range children {
 		populateExplain(v, child, level+1)
 	}
+}
+
+// debugValues is a set of values used to implement EXPLAIN (DEBUG).
+type debugValues struct {
+	rowIdx int
+	key    string
+	value  parser.Datum
+	output debugValueType
+}
+
+// explainDebugNode is a planNode that wraps another node and converts DebugValues() results to a
+// row of Values(). It is used as the top-level node for EXPLAIN (DEBUG) statements.
+type explainDebugNode struct {
+	plan planNode
+}
+
+// Columns for explainDebug mode.
+var debugColumns = []ResultColumn{
+	{Name: "RowIdx", Typ: parser.DummyInt},
+	{Name: "Key", Typ: parser.DummyString},
+	{Name: "Value", Typ: parser.DummyString},
+	{Name: "Output", Typ: parser.DummyBool},
+}
+
+func (*explainDebugNode) Columns() []ResultColumn { return debugColumns }
+func (*explainDebugNode) Ordering() orderingInfo  { return orderingInfo{} }
+
+func (n *explainDebugNode) PErr() *roachpb.Error { return n.plan.PErr() }
+func (n *explainDebugNode) Next() bool           { return n.plan.Next() }
+
+func (n *explainDebugNode) ExplainPlan() (name, description string, children []planNode) {
+	return n.plan.ExplainPlan()
+}
+
+func (n *explainDebugNode) Values() parser.DTuple {
+	vals := n.plan.DebugValues()
+
+	// The "output" value is NULL for partial rows, or a DBool indicating if the row passed the
+	// filtering.
+	outputVal := parser.DNull
+
+	switch vals.output {
+	case debugValueFiltered:
+		outputVal = parser.DBool(false)
+
+	case debugValueRow:
+		outputVal = parser.DBool(true)
+	}
+
+	return parser.DTuple{
+		parser.DInt(vals.rowIdx),
+		parser.DString(vals.key),
+		vals.value,
+		outputVal,
+	}
+}
+
+func (*explainDebugNode) DebugValues() debugValues {
+	panic("debug mode not implemented in explainDebugNode")
 }

--- a/sql/group.go
+++ b/sql/group.go
@@ -223,6 +223,11 @@ func (n *groupNode) Values() parser.DTuple {
 	return n.values.Values()
 }
 
+func (*groupNode) DebugValues() debugValues {
+	// TODO(radu)
+	panic("debug mode not implemented in groupNode")
+}
+
 func (n *groupNode) Next() bool {
 	if !n.populated && n.pErr == nil {
 		n.computeAggregates()

--- a/sql/join.go
+++ b/sql/join.go
@@ -99,6 +99,11 @@ func (n *indexJoinNode) Values() parser.DTuple {
 	return n.table.Values()
 }
 
+func (*indexJoinNode) DebugValues() debugValues {
+	// TODO(radu)
+	panic("debug mode not implemented in indexJoinNode")
+}
+
 func (n *indexJoinNode) Next() bool {
 	// Loop looking up the next row. We either are going to pull a row from the
 	// table or a batch of rows from the index. If we pull a batch of rows from

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -259,6 +259,19 @@ func (p *planner) releaseLeases(db client.DB) {
 	}
 }
 
+type debugValueType int
+
+const (
+	// The debug values do not refer to a full result row.
+	debugValuePartial debugValueType = iota
+
+	// The debug values refer to a full result row but the row was filtered out.
+	debugValueFiltered
+
+	// The debug values refer to a full result row.
+	debugValueRow
+)
+
 // planNode defines the interface for executing a query or portion of a query.
 type planNode interface {
 	// Columns returns the column names and types . The length of the
@@ -270,6 +283,10 @@ type planNode interface {
 	// Values returns the values at the current row. The result is only valid
 	// until the next call to Next().
 	Values() parser.DTuple
+	// DebugValues returns a set of debug values, valid until the next call to Next(). This is only
+	// available for nodes that have been put in a special "explainDebug" mode. When the output
+	// field in the results is debugValueRow, a set of values is also available through Values().
+	DebugValues() debugValues
 	// Next advances to the next row, returning false if an error is encountered
 	// or if there is no next row.
 	Next() bool
@@ -288,6 +305,7 @@ var _ planNode = &sortNode{}
 var _ planNode = &valuesNode{}
 var _ planNode = &selectNode{}
 var _ planNode = &emptyNode{}
+var _ planNode = &explainDebugNode{}
 
 // emptyNode is a planNode with no columns and either no rows (default) or a single row with empty
 // results (if results is initializer to true). The former is used for nodes that have no results
@@ -298,10 +316,11 @@ type emptyNode struct {
 	results bool
 }
 
-func (*emptyNode) Columns() []ResultColumn { return nil }
-func (*emptyNode) Ordering() orderingInfo  { return orderingInfo{} }
-func (*emptyNode) Values() parser.DTuple   { return nil }
-func (*emptyNode) PErr() *roachpb.Error    { return nil }
+func (*emptyNode) Columns() []ResultColumn  { return nil }
+func (*emptyNode) Ordering() orderingInfo   { return orderingInfo{} }
+func (*emptyNode) Values() parser.DTuple    { return nil }
+func (*emptyNode) DebugValues() debugValues { return debugValues{} }
+func (*emptyNode) PErr() *roachpb.Error     { return nil }
 
 func (*emptyNode) ExplainPlan() (name, description string, children []planNode) {
 	return "empty", "-", nil

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -142,6 +142,11 @@ func (n *sortNode) Values() parser.DTuple {
 	return v[:len(n.columns)]
 }
 
+func (*sortNode) DebugValues() debugValues {
+	// TODO(radu)
+	panic("debug mode not implemented in sortNode")
+}
+
 func (n *sortNode) Next() bool {
 	if n.needSort {
 		n.needSort = false

--- a/sql/values.go
+++ b/sql/values.go
@@ -94,6 +94,15 @@ func (n *valuesNode) Values() parser.DTuple {
 	return n.rows[n.nextRow-1]
 }
 
+func (n *valuesNode) DebugValues() debugValues {
+	return debugValues{
+		rowIdx: n.nextRow - 1,
+		key:    fmt.Sprintf("%d", n.nextRow-1),
+		value:  n.rows[n.nextRow-1],
+		output: debugValueRow,
+	}
+}
+
 func (n *valuesNode) Next() bool {
 	if n.nextRow >= len(n.rows) {
 		return false


### PR DESCRIPTION
Following up on Andrei's suggestion to separate the debug values in a different
interface. The new interface has much cleaner semantics and allows each layer to
make use of the regular values even in explainDebug mode.
@andreimatei

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4098)

<!-- Reviewable:end -->
