### PR TITLE
Remove `TestServer.OpenDBClient`.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -696,12 +696,7 @@ func setupClientBenchData(useSSL bool, numVersions, numKeys int, b *testing.B) (
 		b.Fatal(err)
 	}
 
-	db, err := client.Open(s.Stopper(), fmt.Sprintf("%s://%s@%s?certs=%s",
-		s.Ctx.RPCRequestScheme(), security.NodeUser, s.ServingAddr(), s.Ctx.Certs))
-	if err != nil {
-		b.Fatal(err)
-	}
-
+	db := s.DB()
 	if exists {
 		return s, db
 	}

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -33,14 +33,7 @@ import (
 
 func setup() (*server.TestServer, *client.DB) {
 	s := server.StartTestServer(nil)
-	db, err := client.Open(s.Stopper(), fmt.Sprintf("rpcs://%s@%s?certs=%s",
-		security.NodeUser,
-		s.ServingAddr(),
-		security.EmbeddedCertsDir))
-	if err != nil {
-		log.Fatal(err)
-	}
-	return s, db
+	return s, s.DB()
 }
 
 func ExampleDB_Get() {
@@ -276,11 +269,7 @@ func ExampleDB_Put_insecure() {
 	}
 	defer s.Stop()
 
-	db, err := client.Open(s.Stopper(), "rpc://foo@"+s.ServingAddr())
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	db := s.DB()
 	if pErr := db.Put("aa", "1"); pErr != nil {
 		panic(pErr)
 	}

--- a/server/status/feed_test.go
+++ b/server/status/feed_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/server/status"
 	"github.com/cockroachdb/cockroach/testutils"
@@ -205,13 +204,7 @@ func TestServerNodeEventFeed(t *testing.T) {
 	ner := nodeEventReader{}
 	ner.readEvents(feed)
 
-	db, err := client.Open(s.Stopper(), fmt.Sprintf("rpcs://%s@%s?certs=%s",
-		security.NodeUser,
-		s.ServingAddr(),
-		security.EmbeddedCertsDir))
-	if err != nil {
-		t.Fatal(err)
-	}
+	db := s.DB()
 
 	// Add some data in a transaction. It could restart, but we return nil
 	// intentionally (i.e. we're giving up if we don't succeed immediately,

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -17,7 +17,6 @@
 package server
 
 import (
-	"fmt"
 	"net"
 	"time"
 
@@ -239,27 +238,14 @@ func ExpectedInitialRangeCount() int {
 	return GetBootstrapSchema().DescriptorCount() - sql.NumSystemDescriptors + 1
 }
 
-// OpenDBClient opens a KVDB Client connecting to the server with the supplied
-// user.
-func (ts *TestServer) OpenDBClient(user string) (*client.DB, error) {
-	connString := fmt.Sprintf("%s://%s@%s?certs=%s",
-		ts.Ctx.RPCRequestScheme(), user, ts.ServingAddr(), ts.Ctx.Certs)
-	return client.Open(ts.Stopper(), connString)
-}
-
 // WaitForInitialSplits waits for the server to complete its expected initial
 // splits at startup. If the expected range count is not reached within a
 // configured timeout, an error is returned.
 func (ts *TestServer) WaitForInitialSplits() error {
-	kvDB, err := ts.OpenDBClient(security.NodeUser)
-	if err != nil {
-		return err
-	}
-
 	expectedRanges := ExpectedInitialRangeCount()
 	return util.RetryForDuration(initialSplitsTimeout, func() error {
 		// Scan all keys in the Meta2Prefix; we only need a count.
-		rows, pErr := kvDB.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+		rows, pErr := ts.DB().Scan(keys.Meta2Prefix, keys.MetaMax, 0)
 		if pErr != nil {
 			return pErr.GoError()
 		}

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -101,14 +101,8 @@ func setupWithContext(t *testing.T, ctx *server.Context) (*server.TestServer, *s
 	if err != nil {
 		t.Fatal(err)
 	}
-	// All KV requests need "node" certs.
-	kvDB, err := client.Open(s.Stopper(), fmt.Sprintf("rpcs://%s@%s?certs=%s",
-		security.NodeUser, s.ServingAddr(), security.EmbeddedCertsDir))
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	return s, sqlDB, kvDB
+	return s, sqlDB, s.DB()
 }
 
 func cleanupTestServer(s *server.TestServer) {

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -65,10 +65,7 @@ func TestLogSplits(t *testing.T) {
 	}
 
 	// Generate an explicit split event.
-	kvDB, err := s.OpenDBClient(security.NodeUser)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kvDB := s.DB()
 	if err := kvDB.AdminSplit("splitkey"); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Replace usage of `TestServer.OpenDBClient` with `TestServer.DB`. Replace
a few unnecessary calls to `client.Open` with `TestServer.DB`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4099)

<!-- Reviewable:end -->
