### PR TITLE
Create a disabled state for the RPC server to return 503 instead of 404

### DIFF
--- a/server/node_test.go
+++ b/server/node_test.go
@@ -257,6 +257,23 @@ func TestNodeJoin(t *testing.T) {
 	}
 }
 
+// TestNodeJoinSelf verifies that an uninitialized node trying to join
+// itself will fail.
+func TestNodeJoinSelf(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	engineStopper := stop.NewStopper()
+	defer engineStopper.Stop()
+	engines := []engine.Engine{engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)}
+	addr := util.CreateTestAddr("tcp")
+	rpcServer, addr, _, node, stopper := createTestNode(addr, engines, addr, t)
+	defer stopper.Stop()
+	err := node.start(rpcServer, addr, engines, roachpb.Attributes{})
+	if err != errCannotJoinSelf {
+		t.Fatalf("expected err %s; got %s", errCannotJoinSelf, err)
+	}
+}
+
 // TestCorruptedClusterID verifies that a node fails to start when a
 // store's cluster ID is empty.
 func TestCorruptedClusterID(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -64,6 +64,7 @@ type Server struct {
 	listener net.Listener // Only used in tests.
 
 	mux                 *http.ServeMux
+	httpReady           chan struct{}
 	clock               *hlc.Clock
 	rpcContext          *crpc.Context
 	rpc                 *crpc.Server
@@ -111,6 +112,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	s := &Server{
 		ctx:          ctx,
 		mux:          http.NewServeMux(),
+		httpReady:    make(chan struct{}),
 		clock:        hlc.NewClock(hlc.UnixNano),
 		metaRegistry: metric.NewRegistry(),
 		stopper:      stopper,
@@ -273,6 +275,8 @@ func (s *Server) initHTTP() {
 	// The SQL endpoints handles its own authentication, verifying user
 	// credentials against the requested user.
 	s.mux.Handle(driver.Endpoint, s.sqlServer)
+
+	close(s.httpReady)
 }
 
 // startWriteSummaries begins periodically persisting status summaries for the
@@ -340,6 +344,14 @@ func (s *Server) Stop() {
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Check if we're draining; if so return 503, service unavailable.
 	if !s.stopper.RunTask(func() {
+		// If server is not available, return 503 http response code.
+		select {
+		case <-s.httpReady:
+			// Proceed.
+		default:
+			http.Error(w, "node not yet available", http.StatusServiceUnavailable)
+			return
+		}
 		// Disable caching of responses.
 		w.Header().Set("Cache-control", "no-cache")
 


### PR DESCRIPTION
This addresses a very confusing aspect of startup in some cases, where the
--join flag specified a host which was also not bootstrapped. In those
cases, we'd simply show "404 not found". Now we register the RPC handler,
but leave it disabled until after the node has properly bootstrapped. In
the meantime, if a node connects, it will receive a more reasonable HTTP
error code.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4111)

<!-- Reviewable:end -->
