### PR TITLE
sql: explain debug on selects with no table and subselects

### DIFF
--- a/sql/explain.go
+++ b/sql/explain.go
@@ -87,10 +87,6 @@ func markDebug(plan planNode, mode explainMode) (planNode, *roachpb.Error) {
 			t.filter = nil
 			t.render = nil
 			t.qvals = nil
-		} else if _, ok := t.table.node.(*scanNode); !ok {
-			// TODO(radu): We don't support debug mode for selects with no table or with a
-			// virtual table (subquery).
-			return t, nil
 		}
 		// Mark the from node as debug (and potentially replace it).
 		newNode, err := markDebug(t.table.node, mode)
@@ -113,6 +109,14 @@ func markDebug(plan planNode, mode explainMode) (planNode, *roachpb.Error) {
 		// Replace the group node with the node it wraps.
 		return markDebug(t.plan, mode)
 
+	case *emptyNode:
+		// emptyNode supports DebugValues without any explicit enablement.
+		return t, nil
+
+	case *valuesNode:
+		// valuesNode supports DebugValues without any explicit enablement.
+		return t, nil
+
 	default:
 		return nil, roachpb.NewErrorf("TODO(pmattis): unimplemented %T", plan)
 	}
@@ -133,11 +137,24 @@ func populateExplain(v *valuesNode, plan planNode, level int) {
 	}
 }
 
+type debugValueType int
+
+const (
+	// The debug values do not refer to a full result row.
+	debugValuePartial debugValueType = iota
+
+	// The debug values refer to a full result row but the row was filtered out.
+	debugValueFiltered
+
+	// The debug values refer to a full result row.
+	debugValueRow
+)
+
 // debugValues is a set of values used to implement EXPLAIN (DEBUG).
 type debugValues struct {
 	rowIdx int
 	key    string
-	value  parser.Datum
+	value  string
 	output debugValueType
 }
 
@@ -168,6 +185,11 @@ func (n *explainDebugNode) ExplainPlan() (name, description string, children []p
 func (n *explainDebugNode) Values() parser.DTuple {
 	vals := n.plan.DebugValues()
 
+	keyVal := parser.DNull
+	if vals.key != "" {
+		keyVal = parser.DString(vals.key)
+	}
+
 	// The "output" value is NULL for partial rows, or a DBool indicating if the row passed the
 	// filtering.
 	outputVal := parser.DNull
@@ -182,8 +204,8 @@ func (n *explainDebugNode) Values() parser.DTuple {
 
 	return parser.DTuple{
 		parser.DInt(vals.rowIdx),
-		parser.DString(vals.key),
-		vals.value,
+		keyVal,
+		parser.DString(vals.value),
 		outputVal,
 	}
 }

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -259,19 +259,6 @@ func (p *planner) releaseLeases(db client.DB) {
 	}
 }
 
-type debugValueType int
-
-const (
-	// The debug values do not refer to a full result row.
-	debugValuePartial debugValueType = iota
-
-	// The debug values refer to a full result row but the row was filtered out.
-	debugValueFiltered
-
-	// The debug values refer to a full result row.
-	debugValueRow
-)
-
 // planNode defines the interface for executing a query or portion of a query.
 type planNode interface {
 	// Columns returns the column names and types . The length of the
@@ -316,14 +303,22 @@ type emptyNode struct {
 	results bool
 }
 
-func (*emptyNode) Columns() []ResultColumn  { return nil }
-func (*emptyNode) Ordering() orderingInfo   { return orderingInfo{} }
-func (*emptyNode) Values() parser.DTuple    { return nil }
-func (*emptyNode) DebugValues() debugValues { return debugValues{} }
-func (*emptyNode) PErr() *roachpb.Error     { return nil }
+func (*emptyNode) Columns() []ResultColumn { return nil }
+func (*emptyNode) Ordering() orderingInfo  { return orderingInfo{} }
+func (*emptyNode) Values() parser.DTuple   { return nil }
+func (*emptyNode) PErr() *roachpb.Error    { return nil }
 
 func (*emptyNode) ExplainPlan() (name, description string, children []planNode) {
 	return "empty", "-", nil
+}
+
+func (*emptyNode) DebugValues() debugValues {
+	return debugValues{
+		rowIdx: 0,
+		key:    "",
+		value:  parser.DNull.String(),
+		output: debugValueRow,
+	}
 }
 
 func (e *emptyNode) Next() bool {

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -577,15 +577,15 @@ func (n *scanNode) explainDebug(endOfRow bool) {
 	n.debugVals.key = n.prettyKey()
 
 	if n.implicitVals != nil {
-		n.debugVals.value = parser.DString(prettyDatums(n.implicitVals))
+		n.debugVals.value = prettyDatums(n.implicitVals)
 	} else {
-		// This conversion to DString is odd. `n.explainValue` is already a
-		// `Datum`, but logic_test currently expects EXPLAIN DEBUG output
-		// to come out formatted using `encodeSQLString`. This is not
-		// consistent across all printing of strings in logic_test, though.
+		// We convert any datum to string, which will eventually be returned as a DString.
+		// This conversion to DString is odd. `n.explainValue` is already a `Datum`, but logic_test
+		// currently expects EXPLAIN DEBUG output to come out formatted using `encodeSQLString`.
+		// This is not consistent across all printing of strings in logic_test, though.
 		// TODO(tamird/pmattis): figure out a consistent story for string
 		// printing in logic_test.
-		n.debugVals.value = parser.DString(n.explainValue.String())
+		n.debugVals.value = n.explainValue.String()
 	}
 	if endOfRow {
 		n.debugVals.output = debugValueRow

--- a/sql/testdata/explain_debug
+++ b/sql/testdata/explain_debug
@@ -52,3 +52,32 @@ EXPLAIN (DEBUG) SELECT * FROM abc
 0  /abc/primary/1/'one'    NULL  true
 1  /abc/primary/2/'two'    NULL  true
 2  /abc/primary/3/'three'  NULL  true
+
+query ITTB
+EXPLAIN (DEBUG) SELECT 3
+----
+0 NULL NULL true
+
+query ITTB
+EXPLAIN (DEBUG) VALUES (1, 2, 3), (4, 5, 6)
+----
+0 0 (1, 2, 3) true
+1 1 (4, 5, 6) true
+
+query ITTB
+EXPLAIN (DEBUG) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS a;
+----
+0 0 (1, 2, 3) true
+1 1 (4, 5, 6) true
+
+query ITTB
+EXPLAIN (DEBUG) SELECT * FROM (SELECT * FROM abc) AS sub WHERE a = 2;
+----
+0  /abc/primary/1/'one'    NULL  false
+1  /abc/primary/2/'two'    NULL  true
+2  /abc/primary/3/'three'  NULL  false
+
+query ITTB
+EXPLAIN (DEBUG) SELECT * FROM (SELECT * FROM abc WHERE a = 2) AS sub;
+----
+0  /abc/primary/2/'two'    NULL  true

--- a/sql/values.go
+++ b/sql/values.go
@@ -98,7 +98,7 @@ func (n *valuesNode) DebugValues() debugValues {
 	return debugValues{
 		rowIdx: n.nextRow - 1,
 		key:    fmt.Sprintf("%d", n.nextRow-1),
-		value:  n.rows[n.nextRow-1],
+		value:  n.rows[n.nextRow-1].String(),
 		output: debugValueRow,
 	}
 }


### PR DESCRIPTION
This change adds support for EXPLAIN (DEBUG) for select statements with
no table and for subqueries in the from claue.

Fixes #4060

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4114)

<!-- Reviewable:end -->
