### PR TITLE
sql/parser: Convert from DDecimal implementing Datum to *DDecimal

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -631,7 +631,7 @@ func (gp golangParameters) Arg(name string) (parser.Datum, bool) {
 	case time.Duration:
 		return parser.DInterval{Duration: t}, true
 	case *inf.Dec:
-		dd := parser.DDecimal{}
+		dd := &parser.DDecimal{}
 		dd.Set(t)
 		return dd, true
 	}
@@ -672,7 +672,7 @@ func checkResultDatum(datum parser.Datum) *roachpb.Error {
 	case parser.DBool:
 	case parser.DInt:
 	case parser.DFloat:
-	case parser.DDecimal:
+	case *parser.DDecimal:
 	case parser.DBytes:
 	case parser.DString:
 	case parser.DDate:

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -38,7 +38,7 @@ var (
 	// DummyFloat is a placeholder DFloat value.
 	DummyFloat Datum = DFloat(0)
 	// DummyDecimal is a placeholder DDecimal value.
-	DummyDecimal Datum = DDecimal{}
+	DummyDecimal Datum = &DDecimal{}
 	// DummyString is a placeholder DString value.
 	DummyString Datum = DString("")
 	// DummyBytes is a placeholder DBytes value.
@@ -69,6 +69,12 @@ var (
 )
 
 // A Datum holds either a bool, int64, float64, string or []Datum.
+//
+// TODO(nvanbenschoten) It might be worth it in the future to make all
+// Datum implementations receive on pointer types to provide more control
+// over memory allocations when packaging and unpackaging concrete types
+// to and from their Datum interface. This would allow us to make
+// optimizations in terms of shared buffer preallocations.
 type Datum interface {
 	Expr
 	Type() string
@@ -338,23 +344,23 @@ type DDecimal struct {
 }
 
 // Type implements the Datum interface.
-func (d DDecimal) Type() string {
+func (d *DDecimal) Type() string {
 	return "decimal"
 }
 
 // TypeEqual implements the Datum interface.
-func (d DDecimal) TypeEqual(other Datum) bool {
-	_, ok := other.(DDecimal)
+func (d *DDecimal) TypeEqual(other Datum) bool {
+	_, ok := other.(*DDecimal)
 	return ok
 }
 
 // Compare implements the Datum interface.
-func (d DDecimal) Compare(other Datum) int {
+func (d *DDecimal) Compare(other Datum) int {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(DDecimal)
+	v, ok := other.(*DDecimal)
 	if !ok {
 		panic(fmt.Sprintf("unsupported comparison: %s to %s", d.Type(), other.Type()))
 	}
@@ -362,36 +368,36 @@ func (d DDecimal) Compare(other Datum) int {
 }
 
 // HasPrev implements the Datum interface.
-func (d DDecimal) HasPrev() bool {
+func (d *DDecimal) HasPrev() bool {
 	return false
 }
 
 // Prev implements the Datum interface.
-func (d DDecimal) Prev() Datum {
+func (d *DDecimal) Prev() Datum {
 	panic(d.Type() + ".Prev() not supported")
 }
 
 // HasNext implements the Datum interface.
-func (d DDecimal) HasNext() bool {
+func (d *DDecimal) HasNext() bool {
 	return false
 }
 
 // Next implements the Datum interface.
-func (d DDecimal) Next() Datum {
+func (d *DDecimal) Next() Datum {
 	panic(d.Type() + ".Next() not supported")
 }
 
 // IsMax implements the Datum interface.
-func (d DDecimal) IsMax() bool {
+func (d *DDecimal) IsMax() bool {
 	return false
 }
 
 // IsMin implements the Datum interface.
-func (d DDecimal) IsMin() bool {
+func (d *DDecimal) IsMin() bool {
 	return false
 }
 
-func (d DDecimal) String() string {
+func (d *DDecimal) String() string {
 	return d.Dec.String()
 }
 

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -92,9 +92,9 @@ var unaryOps = map[unaryArgs]unaryOp{
 	unaryArgs{UnaryMinus, decimalType}: {
 		returnType: DummyDecimal,
 		fn: func(_ EvalContext, d Datum) (Datum, error) {
-			dec := d.(DDecimal).Dec
-			dd := DDecimal{}
-			dd.Neg(&dec)
+			dec := d.(*DDecimal)
+			dd := &DDecimal{}
+			dd.Neg(&dec.Dec)
 			return dd, nil
 		},
 	},
@@ -159,9 +159,9 @@ var binOps = map[binArgs]binOp{
 	binArgs{Plus, decimalType, decimalType}: {
 		returnType: DummyDecimal,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			l := left.(DDecimal).Dec
-			r := right.(DDecimal).Dec
-			dd := DDecimal{}
+			l := left.(*DDecimal).Dec
+			r := right.(*DDecimal).Dec
+			dd := &DDecimal{}
 			dd.Add(&l, &r)
 			return dd, nil
 		},
@@ -211,9 +211,9 @@ var binOps = map[binArgs]binOp{
 	binArgs{Minus, decimalType, decimalType}: {
 		returnType: DummyDecimal,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			l := left.(DDecimal).Dec
-			r := right.(DDecimal).Dec
-			dd := DDecimal{}
+			l := left.(*DDecimal).Dec
+			r := right.(*DDecimal).Dec
+			dd := &DDecimal{}
 			dd.Sub(&l, &r)
 			return dd, nil
 		},
@@ -264,9 +264,9 @@ var binOps = map[binArgs]binOp{
 	binArgs{Mult, decimalType, decimalType}: {
 		returnType: DummyDecimal,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			l := left.(DDecimal).Dec
-			r := right.(DDecimal).Dec
-			dd := DDecimal{}
+			l := left.(*DDecimal).Dec
+			r := right.(*DDecimal).Dec
+			dd := &DDecimal{}
 			dd.Mul(&l, &r)
 			return dd, nil
 		},
@@ -303,12 +303,12 @@ var binOps = map[binArgs]binOp{
 	binArgs{Div, decimalType, decimalType}: {
 		returnType: DummyDecimal,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			l := left.(DDecimal).Dec
-			r := right.(DDecimal).Dec
+			l := left.(*DDecimal).Dec
+			r := right.(*DDecimal).Dec
 			if r.Sign() == 0 {
 				return nil, errDivByZero
 			}
-			dd := DDecimal{}
+			dd := &DDecimal{}
 			dd.QuoRound(&l, &r, decimal.Precision, inf.RoundHalfUp)
 			return dd, nil
 		},
@@ -343,12 +343,12 @@ var binOps = map[binArgs]binOp{
 	binArgs{Mod, decimalType, decimalType}: {
 		returnType: DummyDecimal,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			l := left.(DDecimal).Dec
-			r := right.(DDecimal).Dec
+			l := left.(*DDecimal).Dec
+			r := right.(*DDecimal).Dec
 			if r.Sign() == 0 {
 				return nil, errZeroModulus
 			}
-			dd := DDecimal{}
+			dd := &DDecimal{}
 			decimal.Mod(&dd.Dec, &l, &r)
 			return dd, nil
 		},
@@ -424,8 +424,8 @@ var cmpOps = map[cmpArgs]cmpOp{
 	},
 	cmpArgs{EQ, decimalType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := left.(DDecimal).Dec
-			r := right.(DDecimal).Dec
+			l := left.(*DDecimal).Dec
+			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) == 0), nil
 		},
 	},
@@ -441,7 +441,7 @@ var cmpOps = map[cmpArgs]cmpOp{
 	},
 	cmpArgs{EQ, decimalType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := left.(DDecimal).Dec
+			l := left.(*DDecimal).Dec
 			r := inf.NewDec(int64(right.(DInt)), 0)
 			return DBool(l.Cmp(r) == 0), nil
 		},
@@ -449,13 +449,13 @@ var cmpOps = map[cmpArgs]cmpOp{
 	cmpArgs{EQ, intType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := inf.NewDec(int64(left.(DInt)), 0)
-			r := right.(DDecimal).Dec
+			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) == 0), nil
 		},
 	},
 	cmpArgs{EQ, decimalType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := left.(DDecimal).Dec
+			l := left.(*DDecimal).Dec
 			r := decimal.NewDecFromFloat(float64(right.(DFloat)))
 			return DBool(l.Cmp(r) == 0), nil
 		},
@@ -463,7 +463,7 @@ var cmpOps = map[cmpArgs]cmpOp{
 	cmpArgs{EQ, floatType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := decimal.NewDecFromFloat(float64(left.(DFloat)))
-			r := right.(DDecimal).Dec
+			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) == 0), nil
 		},
 	},
@@ -510,8 +510,8 @@ var cmpOps = map[cmpArgs]cmpOp{
 	},
 	cmpArgs{LT, decimalType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := left.(DDecimal).Dec
-			r := right.(DDecimal).Dec
+			l := left.(*DDecimal).Dec
+			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) < 0), nil
 		},
 	},
@@ -527,7 +527,7 @@ var cmpOps = map[cmpArgs]cmpOp{
 	},
 	cmpArgs{LT, decimalType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := left.(DDecimal).Dec
+			l := left.(*DDecimal).Dec
 			r := inf.NewDec(int64(right.(DInt)), 0)
 			return DBool(l.Cmp(r) < 0), nil
 		},
@@ -535,13 +535,13 @@ var cmpOps = map[cmpArgs]cmpOp{
 	cmpArgs{LT, intType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := inf.NewDec(int64(left.(DInt)), 0)
-			r := right.(DDecimal).Dec
+			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) < 0), nil
 		},
 	},
 	cmpArgs{LT, decimalType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := left.(DDecimal).Dec
+			l := left.(*DDecimal).Dec
 			r := decimal.NewDecFromFloat(float64(right.(DFloat)))
 			return DBool(l.Cmp(r) < 0), nil
 		},
@@ -549,7 +549,7 @@ var cmpOps = map[cmpArgs]cmpOp{
 	cmpArgs{LT, floatType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := decimal.NewDecFromFloat(float64(left.(DFloat)))
-			r := right.(DDecimal).Dec
+			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) < 0), nil
 		},
 	},
@@ -596,8 +596,8 @@ var cmpOps = map[cmpArgs]cmpOp{
 	},
 	cmpArgs{LE, decimalType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := left.(DDecimal).Dec
-			r := right.(DDecimal).Dec
+			l := left.(*DDecimal).Dec
+			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) <= 0), nil
 		},
 	},
@@ -613,7 +613,7 @@ var cmpOps = map[cmpArgs]cmpOp{
 	},
 	cmpArgs{LE, decimalType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := left.(DDecimal).Dec
+			l := left.(*DDecimal).Dec
 			r := inf.NewDec(int64(right.(DInt)), 0)
 			return DBool(l.Cmp(r) <= 0), nil
 		},
@@ -621,13 +621,13 @@ var cmpOps = map[cmpArgs]cmpOp{
 	cmpArgs{LE, intType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := inf.NewDec(int64(left.(DInt)), 0)
-			r := right.(DDecimal).Dec
+			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) <= 0), nil
 		},
 	},
 	cmpArgs{LE, decimalType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := left.(DDecimal).Dec
+			l := left.(*DDecimal).Dec
 			r := decimal.NewDecFromFloat(float64(right.(DFloat)))
 			return DBool(l.Cmp(r) <= 0), nil
 		},
@@ -635,7 +635,7 @@ var cmpOps = map[cmpArgs]cmpOp{
 	cmpArgs{LE, floatType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := decimal.NewDecFromFloat(float64(left.(DFloat)))
-			r := right.(DDecimal).Dec
+			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) <= 0), nil
 		},
 	},
@@ -884,7 +884,7 @@ func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
 			return DBool(v != 0), nil
 		case DFloat:
 			return DBool(v != 0), nil
-		case DDecimal:
+		case *DDecimal:
 			return DBool(v.Sign() != 0), nil
 		case DString:
 			// TODO(pmattis): strconv.ParseBool is more permissive than the SQL
@@ -911,7 +911,7 @@ func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
 				panic(fmt.Sprintf("round should never fail with digits hardcoded to 0: %s", err))
 			}
 			return DInt(f.(DFloat)), nil
-		case DDecimal:
+		case *DDecimal:
 			dec := new(inf.Dec)
 			dec.Round(&v.Dec, 0, inf.RoundHalfUp)
 			i, ok := dec.Unscaled()
@@ -938,7 +938,7 @@ func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
 			return DFloat(v), nil
 		case DFloat:
 			return d, nil
-		case DDecimal:
+		case *DDecimal:
 			f, err := decimal.Float64FromDec(&v.Dec)
 			if err != nil {
 				return nil, errFloatOutOfRange
@@ -953,7 +953,7 @@ func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
 		}
 
 	case *DecimalType:
-		dd := DDecimal{}
+		dd := &DDecimal{}
 		switch v := d.(type) {
 		case DBool:
 			if v {
@@ -966,7 +966,7 @@ func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
 		case DFloat:
 			decimal.SetFromFloat(&dd.Dec, float64(v))
 			return dd, nil
-		case DDecimal:
+		case *DDecimal:
 			return d, nil
 		case DString:
 			if _, ok := dd.SetString(string(v)); !ok {
@@ -978,7 +978,7 @@ func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
 	case *StringType:
 		var s DString
 		switch t := d.(type) {
-		case DBool, DInt, DFloat, DDecimal, dNull:
+		case DBool, DInt, DFloat, *DDecimal, dNull:
 			s = DString(d.String())
 		case DString:
 			s = t
@@ -1192,7 +1192,7 @@ func (expr *IsOfTypeExpr) Eval(ctx EvalContext) (Datum, error) {
 			}
 		}
 
-	case DDecimal:
+	case *DDecimal:
 		for _, t := range expr.Types {
 			if _, ok := t.(*DecimalType); ok {
 				return result, nil
@@ -1423,7 +1423,7 @@ func (t DFloat) Eval(_ EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (t DDecimal) Eval(_ EvalContext) (Datum, error) {
+func (t *DDecimal) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -182,7 +182,7 @@ func (DDate) Walk(_ Visitor) {}
 func (DFloat) Walk(_ Visitor) {}
 
 // Walk implements the Expr interface.
-func (DDecimal) Walk(_ Visitor) {}
+func (*DDecimal) Walk(_ Visitor) {}
 
 // Walk implements the Expr interface.
 func (DInt) Walk(_ Visitor) {}

--- a/sql/pgwire/types.go
+++ b/sql/pgwire/types.go
@@ -68,7 +68,7 @@ func typeForDatum(d parser.Datum) pgType {
 	case parser.DFloat:
 		return pgType{oid.T_float8, 8}
 
-	case parser.DDecimal:
+	case *parser.DDecimal:
 		return pgType{oid.T_numeric, -1}
 
 	case parser.DBytes, parser.DString:
@@ -122,7 +122,7 @@ func (b *writeBuffer) writeTextDatum(d parser.Datum) error {
 		_, err := b.Write(s)
 		return err
 
-	case parser.DDecimal:
+	case *parser.DDecimal:
 		vs := v.Dec.String()
 		b.putInt32(int32(len(vs)))
 		_, err := b.WriteString(vs)
@@ -357,7 +357,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 	case oid.T_numeric:
 		switch code {
 		case formatText:
-			dd := parser.DDecimal{}
+			dd := &parser.DDecimal{}
 			if _, ok := dd.SetString(string(b)); !ok {
 				return nil, fmt.Errorf("could not parse string %q as decimal", b)
 			}

--- a/sql/server.go
+++ b/sql/server.go
@@ -209,7 +209,7 @@ func datumFromProto(d driver.Datum) parser.Datum {
 	case *driver.Datum_FloatVal:
 		return parser.DFloat(t.FloatVal)
 	case *driver.Datum_DecimalVal:
-		dd := parser.DDecimal{}
+		dd := &parser.DDecimal{}
 		if _, ok := dd.SetString(t.DecimalVal); !ok {
 			panic(fmt.Sprintf("could not parse string %q as decimal", t.DecimalVal))
 		}
@@ -247,7 +247,7 @@ func protoFromDatum(datum parser.Datum) driver.Datum {
 		return driver.Datum{
 			Payload: &driver.Datum_FloatVal{FloatVal: float64(vt)},
 		}
-	case parser.DDecimal:
+	case *parser.DDecimal:
 		return driver.Datum{
 			Payload: &driver.Datum_DecimalVal{DecimalVal: vt.Dec.String()},
 		}

--- a/sql/set.go
+++ b/sql/set.go
@@ -109,7 +109,7 @@ func (p *planner) SetTimeZone(n *parser.SetTimeZone) (planNode, *roachpb.Error) 
 	case parser.DFloat:
 		offset = int64(float64(v) * 60.0 * 60.0)
 
-	case parser.DDecimal:
+	case *parser.DDecimal:
 		sixty := inf.NewDec(60, 0)
 		sixty.Mul(sixty, sixty).Mul(sixty, &v.Dec)
 		var ok bool

--- a/sql/table.go
+++ b/sql/table.go
@@ -427,7 +427,7 @@ func encodeTableKey(b []byte, val parser.Datum, dir encoding.Direction) ([]byte,
 			return encoding.EncodeFloatAscending(b, float64(t)), nil
 		}
 		return encoding.EncodeFloatDescending(b, float64(t)), nil
-	case parser.DDecimal:
+	case *parser.DDecimal:
 		if dir == encoding.Ascending {
 			return encoding.EncodeDecimalAscending(b, &t.Dec), nil
 		}
@@ -592,14 +592,14 @@ func decodeTableKey(valType parser.Datum, key []byte, dir encoding.Direction) (
 			rkey, f, err = encoding.DecodeFloatDescending(key, nil)
 		}
 		return parser.DFloat(f), rkey, err
-	case parser.DDecimal:
+	case *parser.DDecimal:
 		var d *inf.Dec
 		if dir == encoding.Ascending {
 			rkey, d, err = encoding.DecodeDecimalAscending(key, nil)
 		} else {
 			rkey, d, err = encoding.DecodeDecimalDescending(key, nil)
 		}
-		dd := parser.DDecimal{}
+		dd := &parser.DDecimal{}
 		dd.Set(d)
 		return dd, rkey, err
 	case parser.DString:
@@ -739,7 +739,7 @@ func marshalColumnValue(col ColumnDescriptor, val parser.Datum, args parser.MapA
 			return nil, nil
 		}
 	case ColumnType_DECIMAL:
-		if v, ok := val.(parser.DDecimal); ok {
+		if v, ok := val.(*parser.DDecimal); ok {
 			return v.Dec, nil
 		}
 		if set, err := args.SetInferredType(val, parser.DummyDecimal); err != nil {
@@ -834,7 +834,7 @@ func unmarshalColumnValue(kind ColumnType_Kind, value *roachpb.Value) (parser.Da
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
-		dd := parser.DDecimal{}
+		dd := &parser.DDecimal{}
 		dd.Set(v)
 		return dd, nil
 	case ColumnType_STRING:


### PR DESCRIPTION
This should prevent allocations in cases whenever a pointer to an
embedded `inf.Dec` is needed directly from a `DDecimal` by replacing:

```
fn: func(_ EvalContext, args DTuple) (Datum, error) {
    dec := args[0].(DDecimal)
    dd := DDecimal{}
    dd.Round(&dec.Dec, ...) // Taking address of embedded dec.Dec
    return dd, nil
}
```

with

```
fn: func(_ EvalContext, args DTuple) (Datum, error) {
   dec := args[0].(*DDecimal)
   dd := &DDecimal{}
   dd.Round(&dec.Dec, ...) // Taking address of embedded dec.Dec
   return dd, nil
}
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4116)

<!-- Reviewable:end -->
