### PR TITLE
Acceptance: Update test flags

### DIFF
--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -47,7 +47,7 @@ func TestChaos(t *testing.T) {
 	// One error sent by each client. A successful client sends a nil error.
 	errs := make(chan error, num)
 	start := time.Now()
-	deadline := start.Add(*duration)
+	deadline := start.Add(*flagDuration)
 	// The number of successful writes (puts) to the database.
 	var count int64
 	// The number of times chaos monkey has run.
@@ -179,7 +179,7 @@ func TestChaos(t *testing.T) {
 	}()
 
 	prevRound := atomic.LoadInt64(&round)
-	stallTime := time.Now().Add(*stall)
+	stallTime := time.Now().Add(*flagStall)
 	var prevOutput string
 	// Spin until all clients are shut.
 	for numShutClients := 0; numShutClients < num; {
@@ -201,11 +201,11 @@ func TestChaos(t *testing.T) {
 				if curRound == prevRound {
 					if time.Now().After(stallTime) {
 						atomic.StoreInt32(&stalled, 1)
-						t.Fatalf("Stall detected at round %d, no forward progress for %s", curRound, *stall)
+						t.Fatalf("Stall detected at round %d, no forward progress for %s", curRound, *flagStall)
 					}
 				} else {
 					prevRound = curRound
-					stallTime = time.Now().Add(*stall)
+					stallTime = time.Now().Add(*flagStall)
 				}
 				// Periodically print out progress so that we know the test is
 				// still running and making progress.

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -107,10 +107,10 @@ func TestGossipPeerings(t *testing.T) {
 	defer c.AssertAndStop(t)
 	num := c.NumNodes()
 
-	deadline := time.Now().Add(*duration)
+	deadline := time.Now().Add(*flagDuration)
 
 	waitTime := longWaitTime
-	if *duration < waitTime {
+	if *flagDuration < waitTime {
 		waitTime = shortWaitTime
 	}
 
@@ -151,10 +151,10 @@ func TestGossipRestart(t *testing.T) {
 	defer c.AssertAndStop(t)
 	num := c.NumNodes()
 
-	deadline := time.Now().Add(*duration)
+	deadline := time.Now().Add(*flagDuration)
 
 	waitTime := longWaitTime
-	if *duration < waitTime {
+	if *flagDuration < waitTime {
 		waitTime = shortWaitTime
 	}
 

--- a/acceptance/put_test.go
+++ b/acceptance/put_test.go
@@ -39,7 +39,7 @@ func TestPut(t *testing.T) {
 
 	errs := make(chan error, c.NumNodes())
 	start := time.Now()
-	deadline := start.Add(*duration)
+	deadline := start.Add(*flagDuration)
 	var count int64
 	for i := 0; i < c.NumNodes(); i++ {
 		go func() {

--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -6,4 +6,4 @@ source $(dirname $0)/../build/init-docker.sh
 $(dirname $0)/../build/builder.sh make install
 
 set -x
-go test -tags acceptance ./acceptance ${GOFLAGS-} -run "${TESTS-.}" -timeout ${TESTTIMEOUT-5m} ${TESTFLAGS--v -num-local 3}
+go test -tags acceptance ./acceptance ${GOFLAGS-} -run "${TESTS-.}" -timeout ${TESTTIMEOUT-5m} ${TESTFLAGS--v -nodes 3}

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -51,7 +51,7 @@ func TestSingleKey(t *testing.T) {
 	}
 
 	resultCh := make(chan result, num)
-	deadline := time.Now().Add(*duration)
+	deadline := time.Now().Add(*flagDuration)
 	var expected int64
 
 	// Start up num workers each reading and writing the same

--- a/acceptance/terraform_test.go
+++ b/acceptance/terraform_test.go
@@ -42,7 +42,7 @@ func TestBuildBabyCluster(t *testing.T) {
 // The test runs until SIGINT is received or the specified duration
 // has passed.
 func TestFiveNodesAndWriters(t *testing.T) {
-	deadline := time.After(*duration)
+	deadline := time.After(*flagDuration)
 	f := farmer(t)
 	defer f.MustDestroy()
 	const size = 5

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -154,7 +154,7 @@ if is_shard 0; then
     # Note that this test requires 2>&1 but the others don't because
     # this one runs outside the builder container (and inside the
     # container, something is already combining stdout and stderr).
-    time $(dirname $0)/../acceptance.test -num-local 3 -l ${outdir}/acceptance \
+    time $(dirname $0)/../acceptance.test -nodes 3 -l ${outdir}/acceptance \
       -test.v -test.timeout 5m \
       --verbosity=1 --vmodule=monitor=2 2>&1 | \
       tr -d '\r' | tee "${outdir}/acceptance.log" | \

--- a/build/push-docker-deploy.sh
+++ b/build/push-docker-deploy.sh
@@ -6,7 +6,7 @@ $(dirname $0)/build-docker-deploy.sh
 
 cd $(dirname $0)/../acceptance
 if [ -f ./acceptance.test ]; then
-  time ./acceptance.test -i cockroachdb/cockroach -b /cockroach/cockroach -num-local 3 \
+  time ./acceptance.test -i cockroachdb/cockroach -b /cockroach/cockroach -nodes 3 \
     -test.v -test.timeout -5m
 fi
 

--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ deployment:
       - build/build-static-binaries.sh
       - mkdir -p "${CIRCLE_ARTIFACTS}/acceptance_deploy"
       - time acceptance/acceptance.test -test.v -test.timeout 5m
-          -i cockroachdb/cockroach -num-local 3
+          -i cockroachdb/cockroach -nodes 3
           -l "${CIRCLE_ARTIFACTS}"/acceptance_deploy 2>&1 >
           "${CIRCLE_ARTIFACTS}/acceptance_deploy.log"
       - build/push-aws.sh


### PR DESCRIPTION
This changes the flags from the acceptance tests.  This PR is in preparation of adding in more complex configurations relating to #4015.
- added `-remote` flag to specify that you want to use a terraform instead of docker
- `-num-local` and `-num-remote` has been combined and renamed to `-nodes`
- `-num-stores` has been renamed to `-stores`
- and I also prefixed all the flags with "flag" which is similar to what you see in some of the golang tools code.  I found this to be useful since we're actually using those flags in the tests themselves and it can be confusing trying to isolate where the variable came from without it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4119)

<!-- Reviewable:end -->
