### PR TITLE
sql: Primary Key constrained columns cannot be nullable

### DIFF
--- a/cli/sql_util_test.go
+++ b/cli/sql_util_test.go
@@ -75,8 +75,8 @@ OK
 	}
 
 	expectedRows := [][]string{
-		{`parentID`, `INT`, `true`, `NULL`},
-		{`name`, `STRING`, `true`, `NULL`},
+		{`parentID`, `INT`, `false`, `NULL`},
+		{`name`, `STRING`, `false`, `NULL`},
 		{`id`, `INT`, `true`, `NULL`},
 	}
 	if !reflect.DeepEqual(expectedRows, rows) {
@@ -88,13 +88,13 @@ OK
 	}
 
 	expected = `
-+----------+--------+------+---------+
-|  Field   |  Type  | Null | Default |
-+----------+--------+------+---------+
-| parentID | INT    | true | NULL    |
-| name     | STRING | true | NULL    |
-| id       | INT    | true | NULL    |
-+----------+--------+------+---------+
++----------+--------+-------+---------+
+|  Field   |  Type  | Null  | Default |
++----------+--------+-------+---------+
+| parentID | INT    | false | NULL    |
+| name     | STRING | false | NULL    |
+| id       | INT    | true  | NULL    |
++----------+--------+-------+---------+
 `
 
 	if a, e := b.String(), expected[1:]; a != e {

--- a/sql/create.go
+++ b/sql/create.go
@@ -134,6 +134,7 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, *roachpb.Error) 
 			},
 			DefaultExpr: &s,
 			Hidden:      true,
+			Nullable:    false,
 		}
 		desc.AddColumn(col)
 		idx := IndexDescriptor{

--- a/sql/descriptor_mutation_test.go
+++ b/sql/descriptor_mutation_test.go
@@ -691,5 +691,5 @@ CREATE TABLE t.test (a CHAR PRIMARY KEY, b CHAR, c CHAR, INDEX foo (c));
 	// Make column "e" live.
 	mt.makeMutationsActive()
 	// Column b changed to d.
-	_ = mt.checkQueryResponse("SHOW COLUMNS FROM t.test", [][]string{{"a", "STRING", "true", "NULL"}, {"d", "STRING", "true", "NULL"}, {"e", "STRING", "true", "NULL"}})
+	_ = mt.checkQueryResponse("SHOW COLUMNS FROM t.test", [][]string{{"a", "STRING", "false", "NULL"}, {"d", "STRING", "true", "NULL"}, {"e", "STRING", "true", "NULL"}})
 }

--- a/sql/table_test.go
+++ b/sql/table_test.go
@@ -101,7 +101,7 @@ func TestMakeTableDescColumns(t *testing.T) {
 	}
 	for i, d := range testData {
 		stmt, err := parser.ParseOneTraditional(
-			"CREATE TABLE foo.test (a " + d.sqlType + " PRIMARY KEY)")
+			"CREATE TABLE foo.test (a " + d.sqlType + " PRIMARY KEY, b " + d.sqlType + ")")
 		if err != nil {
 			t.Fatalf("%d: %v", i, err)
 		}
@@ -116,8 +116,14 @@ func TestMakeTableDescColumns(t *testing.T) {
 		if !reflect.DeepEqual(d.colType, schema.Columns[0].Type) {
 			t.Fatalf("%d: expected %+v, but got %+v", i, d.colType, schema.Columns[0])
 		}
-		if d.nullable != schema.Columns[0].Nullable {
-			t.Fatalf("%d: expected %+v, but got %+v", i, d.nullable, schema.Columns[0].Nullable)
+		if schema.Columns[0].Nullable {
+			t.Fatalf("%d: expected non-nullable primary key, but got %+v", i, schema.Columns[0].Nullable)
+		}
+		if !reflect.DeepEqual(d.colType, schema.Columns[1].Type) {
+			t.Fatalf("%d: expected %+v, but got %+v", i, d.colType, schema.Columns[1])
+		}
+		if d.nullable != schema.Columns[1].Nullable {
+			t.Fatalf("%d: expected %+v, but got %+v", i, d.nullable, schema.Columns[1].Nullable)
 		}
 	}
 }

--- a/sql/testdata/alter_table
+++ b/sql/testdata/alter_table
@@ -24,7 +24,7 @@ query TTBT colnames
 SHOW COLUMNS FROM t
 ----
 Field Type Null Default
-a     INT  true NULL
+a     INT  false NULL
 b     INT  true NULL
 
 statement ok

--- a/sql/testdata/default
+++ b/sql/testdata/default
@@ -12,7 +12,7 @@ query TTBT colnames
 SHOW COLUMNS FROM t
 ----
 Field Type      Null Default
-a     INT       true 42
+a     INT       false 42
 b     TIMESTAMP true now()
 c     FLOAT     true random()
 

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -60,26 +60,34 @@ SELECT length(descriptor) * (id - 1) FROM system.descriptor WHERE id = 1
 query TTBT
 SHOW COLUMNS FROM system.namespace;
 ----
-parentID INT    true NULL
-name     STRING true NULL
+parentID INT    false NULL
+name     STRING false NULL
 id       INT    true NULL
 
 query TTBT
 SHOW COLUMNS FROM system.descriptor;
 ----
-id         INT   true NULL
+id         INT   false NULL
 descriptor BYTES true NULL
+
+query TTBT
+SHOW COLUMNS FROM system.lease;
+----
+descID     INT       false NULL
+version    INT       false NULL
+nodeID     INT       false NULL
+expiration TIMESTAMP false NULL
 
 query TTBT
 SHOW COLUMNS FROM system.users;
 ----
-username       STRING true NULL
+username       STRING false NULL
 hashedPassword BYTES  true NULL
 
 query TTBT
 SHOW COLUMNS FROM system.zones;
 ----
-id     INT   true NULL
+id     INT   false NULL
 config BYTES true NULL
 
 # Verify default privileges on system tables.

--- a/sql/testdata/table
+++ b/sql/testdata/table
@@ -62,12 +62,55 @@ c     c_foo_bar_idx  false  1   foo    ASC        false
 c     c_foo_bar_idx  false  2   bar    DESC       false
 c     c_bar_key      true   1   bar    ASC        false
 
+# primary keys can never be null 
+
+statement ok
+CREATE TABLE d (
+  id    INT PRIMARY KEY NULL
+)
+
+query TTBT colnames
+SHOW COLUMNS FROM d
+----
+Field Type   Null  Default
+id    INT    false  NULL
+
+statement ok
+CREATE TABLE e (
+  id    INT NULL PRIMARY KEY
+)
+
+query TTBT colnames
+SHOW COLUMNS FROM e
+----
+Field Type   Null  Default
+id    INT    false  NULL
+
+statement ok
+CREATE TABLE f (
+  a INT,
+  b INT,
+  c INT,
+  PRIMARY KEY (a, b, c)
+)
+
+query TTBT colnames
+SHOW COLUMNS FROM f
+----
+Field Type   Null  Default
+a     INT   false  NULL
+b     INT   false  NULL
+c     INT   false  NULL
+
 query T
 SHOW TABLES FROM test
 ----
 a
 b
 c
+d
+e
+f
 
 statement ok
 SET DATABASE = ""
@@ -103,7 +146,7 @@ query TTBT colnames
 SHOW COLUMNS FROM test.users
 ----
 Field Type   Null  Default
-id    INT    true  NULL
+id    INT    false  NULL
 name  STRING false NULL
 title STRING true  NULL
 


### PR DESCRIPTION
Fixes #4112.

There are three cases that needed to be handled here:
- A table has an explicit single primary key column, which should be set to non-null regardless of declared nullable state
- A table has a set of primary key columns, which all need to be set to non-null (again, regardless of declared nullable state)
- A table was not given a primary key explicitly, so the default primary key should be set to non-nullable

At the moment, discrepancies between declared nullability and declared primary keys are ignored and the declared NULL is ignored silently. This is the same behavior as Postgres, but it is worthy of a discussion. Should `CREATE TABLE t (id INT PRIMARY KEY NULL)` silently throw away the NULL and make a single non-null column (again, what Postgres does), or should the discrepancy throw an error? @dt mentioned offline that if we did throw an error, we might risk compatibility with tools built for Postgres that by default set all columns to NULL without taking into account PRIMARY KEY state.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4120)

<!-- Reviewable:end -->
