### PR TITLE
sql: fix ordering bug in selectIndex optimization

### DIFF
--- a/sql/select.go
+++ b/sql/select.go
@@ -688,7 +688,7 @@ func (p *planner) selectIndex(sel *selectNode, s *scanNode, ordering columnOrder
 		// If grouping has a desired order and there is a single span for which the
 		// filter is true, check to see if the ordering matches the desired
 		// ordering. If it does we can limit the scan to a single key.
-		existingOrdering := plan.Ordering()
+		existingOrdering := sel.computeOrdering(plan.Ordering())
 		match := computeOrderingMatch(ordering, existingOrdering, false)
 		if match == 1 {
 			s.spans[0].count = 1

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -533,3 +533,9 @@ query R
 SELECT STDDEV(x) FROM xyz WHERE x = 1;
 ----
 NULL
+
+# Verify we only look at one row for MIN when we have an index on that column.
+query ITTB
+EXPLAIN (DEBUG) SELECT MIN(z) FROM xyz
+----
+0 /xyz/zyx/3.0/2/1 NULL true 


### PR DESCRIPTION
Recent refactoring introduced a bug in a special case in selectIndex.
When a grouping function like MIN is used and the index provides the
correct ordering, we only need to read one row. When checking for this
condition, we are incorrectly comparing the desired ordering on select
render columns against an ordering of the table columns. Fixing this and
adding a test (verified it fails without the fix).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4122)

<!-- Reviewable:end -->
