### PR TITLE
Clean up after liner when SQL shell terminates with an error

### DIFF
--- a/cli/sql.go
+++ b/cli/sql.go
@@ -128,6 +128,10 @@ func runInteractive(db *sql.DB, dbURL string) {
 	}
 
 	if exitCode != 0 {
+		// Though we have a defer block that calls liner.Close() above, that defer block is never
+		// executed after we call os.Exit(). So, call it explicitly here to prevent us from leaving
+		// the terminal in a messed up state.
+		_ = liner.Close()
 		os.Exit(exitCode)
 	}
 }


### PR DESCRIPTION
Close the Liner instance (and restore terminal settings) when we exit from the SQL shell with an error code. The liner cleanup wasn't happening, because os.Exit() skips the deferred function that calls liner.Close().

When the SQL shell exited after some commands and Control-C was pressed, the terminal was left in a bad state that didn't output typed in characters.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4125)

<!-- Reviewable:end -->
