### PR TITLE
sql: Convert roachpb.Error back to error

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -51,13 +51,13 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 		return nil, roachpb.NewUErrorf("table %q does not exist", n.Table.Table())
 	}
 
-	tableDesc, err := p.getTableDesc(n.Table)
-	if err != nil {
-		return nil, err
+	tableDesc, pErr := p.getTableDesc(n.Table)
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 
 	numMutations := len(tableDesc.Mutations)
@@ -68,7 +68,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 			d := t.ColumnDef
 			col, idx, err := makeColumnDefDescs(d)
 			if err != nil {
-				return nil, err
+				return nil, roachpb.NewError(err)
 			}
 			status, i, err := tableDesc.FindColumnByName(col.Name)
 			if err == nil {
@@ -115,7 +115,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 					// Noop.
 					continue
 				}
-				return nil, err
+				return nil, roachpb.NewError(err)
 			}
 			switch status {
 			case DescriptorActive:
@@ -148,7 +148,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 					// Noop.
 					continue
 				}
-				return nil, err
+				return nil, roachpb.NewError(err)
 			}
 			switch status {
 			case DescriptorActive:

--- a/sql/create.go
+++ b/sql/create.go
@@ -71,8 +71,8 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) 
 		}
 	}
 
-	if pErr := p.checkPrivilege(tableDesc, privilege.CREATE); pErr != nil {
-		return nil, pErr
+	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	indexDesc := IndexDescriptor{
@@ -113,8 +113,8 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, *roachpb.Error) 
 		return nil, pErr
 	}
 
-	if pErr := p.checkPrivilege(dbDesc, privilege.CREATE); pErr != nil {
-		return nil, pErr
+	if err := p.checkPrivilege(dbDesc, privilege.CREATE); err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	desc, pErr := makeTableDesc(n, dbDesc.ID)
@@ -142,8 +142,8 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, *roachpb.Error) 
 			ColumnNames:      []string{col.Name},
 			ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 		}
-		if pErr := desc.AddIndex(idx, true); pErr != nil {
-			return nil, pErr
+		if err := desc.AddIndex(idx, true); err != nil {
+			return nil, roachpb.NewError(err)
 		}
 	}
 

--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -121,12 +121,16 @@ func (n *distinctNode) encodeValues(values parser.DTuple) ([]byte, []byte) {
 			if prefix == nil {
 				prefix = make([]byte, 0, 100)
 			}
-			prefix, n.pErr = encodeDatum(prefix, val)
+			var err error
+			prefix, err = encodeDatum(prefix, val)
+			n.pErr = roachpb.NewError(err)
 		} else {
 			if suffix == nil {
 				suffix = make([]byte, 0, 100)
 			}
-			suffix, n.pErr = encodeDatum(suffix, val)
+			var err error
+			suffix, err = encodeDatum(suffix, val)
+			n.pErr = roachpb.NewError(err)
 		}
 		if n.pErr != nil {
 			break

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -64,8 +64,8 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, *roachpb.Error
 		return nil, roachpb.NewError(err)
 	}
 
-	if pErr := p.checkPrivilege(dbDesc, privilege.DROP); pErr != nil {
-		return nil, pErr
+	if err := p.checkPrivilege(dbDesc, privilege.DROP); err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	tbNames, pErr := p.getTableNames(dbDesc)
@@ -115,18 +115,18 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, *roachpb.Error) {
 			return nil, pErr
 		}
 
-		if pErr := p.checkPrivilege(tableDesc, privilege.CREATE); pErr != nil {
-			return nil, pErr
+		if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
+			return nil, roachpb.NewError(err)
 		}
 		idxName := indexQualifiedName.Index()
-		status, i, pErr := tableDesc.FindIndexByName(idxName)
-		if pErr != nil {
+		status, i, err := tableDesc.FindIndexByName(idxName)
+		if err != nil {
 			if n.IfExists {
 				// Noop.
 				return &emptyNode{}, nil
 			}
 			// Index does not exist, but we want it to: error out.
-			return nil, pErr
+			return nil, roachpb.NewError(err)
 		}
 		switch status {
 		case DescriptorActive:
@@ -203,8 +203,8 @@ func (p *planner) DropTable(n *parser.DropTable) (planNode, *roachpb.Error) {
 			return nil, roachpb.NewError(err)
 		}
 
-		if pErr := p.checkPrivilege(tableDesc, privilege.DROP); pErr != nil {
-			return nil, pErr
+		if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
+			return nil, roachpb.NewError(err)
 		}
 
 		if _, pErr := p.Truncate(&parser.Truncate{Tables: n.Names[i : i+1]}); pErr != nil {

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -247,7 +247,7 @@ func (e *Executor) Prepare(user string, query string, args parser.MapArgs) ([]Re
 	cols := plan.Columns()
 	for _, c := range cols {
 		if err := checkResultDatum(c.Typ); err != nil {
-			return nil, err
+			return nil, roachpb.NewError(err)
 		}
 	}
 	return cols, nil
@@ -445,7 +445,7 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (Result, 
 			result.Columns = plan.Columns()
 			for _, c := range result.Columns {
 				if err := checkResultDatum(c.Typ); err != nil {
-					return err
+					return roachpb.NewError(err)
 				}
 			}
 
@@ -455,7 +455,7 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (Result, 
 				row := ResultRow{Values: make([]parser.Datum, 0, len(values))}
 				for _, val := range values {
 					if err := checkResultDatum(val); err != nil {
-						return err
+						return roachpb.NewError(err)
 					}
 					row.Values = append(row.Values, val)
 				}
@@ -663,7 +663,7 @@ func (gp golangParameters) Arg(name string) (parser.Datum, bool) {
 	panic(fmt.Sprintf("unexpected type %T", arg))
 }
 
-func checkResultDatum(datum parser.Datum) *roachpb.Error {
+func checkResultDatum(datum parser.Datum) error {
 	if datum == parser.DNull {
 		return nil
 	}
@@ -679,7 +679,7 @@ func checkResultDatum(datum parser.Datum) *roachpb.Error {
 	case parser.DTimestamp:
 	case parser.DInterval:
 	default:
-		return roachpb.NewUErrorf("unsupported result type: %s", datum.Type())
+		return fmt.Errorf("unsupported result type: %s", datum.Type())
 	}
 	return nil
 }

--- a/sql/grant.go
+++ b/sql/grant.go
@@ -23,13 +23,13 @@ import (
 )
 
 func (p *planner) changePrivileges(targets parser.TargetList, grantees parser.NameList, changePrivilege func(*PrivilegeDescriptor, string)) (planNode, *roachpb.Error) {
-	descriptor, err := p.getDescriptorFromTargetList(targets)
-	if err != nil {
-		return nil, err
+	descriptor, pErr := p.getDescriptorFromTargetList(targets)
+	if pErr != nil {
+		return nil, pErr
 	}
 
 	if err := p.checkPrivilege(descriptor, privilege.GRANT); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 
 	privileges := descriptor.GetPrivileges()

--- a/sql/join.go
+++ b/sql/join.go
@@ -39,7 +39,7 @@ type indexJoinNode struct {
 	pErr             *roachpb.Error
 }
 
-func makeIndexJoin(indexScan *scanNode, exactPrefix int) (*indexJoinNode, *roachpb.Error) {
+func makeIndexJoin(indexScan *scanNode, exactPrefix int) *indexJoinNode {
 	// Create a new table scan node with the primary index.
 	table := &scanNode{planner: indexScan.planner, txn: indexScan.txn}
 	table.desc = indexScan.desc
@@ -84,7 +84,7 @@ func makeIndexJoin(indexScan *scanNode, exactPrefix int) (*indexJoinNode, *roach
 		table:            table,
 		primaryKeyPrefix: primaryKeyPrefix,
 		colIDtoRowIndex:  colIDtoRowIndex,
-	}, nil
+	}
 }
 
 func (n *indexJoinNode) Columns() []ResultColumn {
@@ -138,9 +138,9 @@ func (n *indexJoinNode) Next() bool {
 			}
 
 			vals := n.index.Values()
-			var primaryIndexKey []byte
-			primaryIndexKey, _, n.pErr = encodeIndexKey(
+			primaryIndexKey, _, err := encodeIndexKey(
 				n.table.index, n.colIDtoRowIndex, vals, n.primaryKeyPrefix)
+			n.pErr = roachpb.NewError(err)
 			if n.pErr != nil {
 				return false
 			}

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -138,8 +138,8 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, *roachpb.Error) 
 		return nil, pErr
 	}
 
-	if pErr := p.checkPrivilege(targetDbDesc, privilege.CREATE); pErr != nil {
-		return nil, pErr
+	if err := p.checkPrivilege(targetDbDesc, privilege.CREATE); err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	if n.Name.Database() == n.NewName.Database() && n.Name.Table() == n.NewName.Table() {
@@ -152,8 +152,8 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, *roachpb.Error) 
 		return nil, pErr
 	}
 
-	if pErr := p.checkPrivilege(tableDesc, privilege.DROP); pErr != nil {
-		return nil, pErr
+	if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	tableDesc.SetName(n.NewName.Table())
@@ -214,18 +214,18 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, *roachpb.Error) 
 	}
 
 	idxName := n.Name.Index()
-	status, i, pErr := tableDesc.FindIndexByName(idxName)
-	if pErr != nil {
+	status, i, err := tableDesc.FindIndexByName(idxName)
+	if err != nil {
 		if n.IfExists {
 			// Noop.
 			return &emptyNode{}, nil
 		}
 		// Index does not exist, but we want it to: error out.
-		return nil, pErr
+		return nil, roachpb.NewError(err)
 	}
 
-	if pErr := p.checkPrivilege(tableDesc, privilege.CREATE); pErr != nil {
-		return nil, pErr
+	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	if equalName(idxName, newIdxName) {
@@ -295,10 +295,10 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, *roachpb.Error
 	}
 
 	colName := string(n.Name)
-	status, i, pErr := tableDesc.FindColumnByName(colName)
+	status, i, err := tableDesc.FindColumnByName(colName)
 	// n.IfExists only applies to table, no need to check here.
-	if pErr != nil {
-		return nil, pErr
+	if err != nil {
+		return nil, roachpb.NewError(err)
 	}
 	var column *ColumnDescriptor
 	if status == DescriptorActive {
@@ -307,8 +307,8 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, *roachpb.Error
 		column = tableDesc.Mutations[i].GetColumn()
 	}
 
-	if pErr := p.checkPrivilege(tableDesc, privilege.CREATE); pErr != nil {
-		return nil, pErr
+	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	if equalName(colName, newColName) {

--- a/sql/truncate.go
+++ b/sql/truncate.go
@@ -37,8 +37,8 @@ func (p *planner) Truncate(n *parser.Truncate) (planNode, *roachpb.Error) {
 			return nil, pErr
 		}
 
-		if pErr := p.checkPrivilege(tableDesc, privilege.DROP); pErr != nil {
-			return nil, pErr
+		if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
+			return nil, roachpb.NewError(err)
 		}
 
 		tablePrefix := keys.MakeTablePrefix(uint32(tableDesc.ID))


### PR DESCRIPTION
This change partially reverts the previous change that introduced `roachpb.Error` in the sql package. This initial change is conservative, and I'll send follow-up PRs for more changes.

One concrete example that we cannot use error is when an error is used inside `Txn`. For example, `planner.exec` needs to return `roachpb.Error` as the method is called inside `db.Txn()` in `LeaseStore.Acquire()`.

Some other changes:
- Rename `err` to `pErr` at several places where `roachpb.Error` is actually passed.
- Change `makeIndexJoin()` to not return an error since it always return `nil`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4126)

<!-- Reviewable:end -->
