### PR TITLE
Make *UnresolvedAddr implement net.Addr, not UnresolvedAddr.

### DIFF
--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -141,7 +141,7 @@ func TestClientGossip(t *testing.T) {
 	local := startGossip(1, stopper, t)
 	remote := startGossip(2, stopper, t)
 	disconnected := make(chan *client, 1)
-	client := newClient(remote.is.NodeAddr)
+	client := newClient(&remote.is.NodeAddr)
 
 	defer func() {
 		stopper.Stop()
@@ -185,7 +185,7 @@ func TestClientNodeID(t *testing.T) {
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, lclock, stopper)
 
 	// Start a gossip client.
-	c := newClient(remote.nodeAddr)
+	c := newClient(&remote.nodeAddr)
 	defer func() {
 		stopper.Stop()
 		if c != <-disconnected {
@@ -229,7 +229,7 @@ func TestClientDisconnectLoopback(t *testing.T) {
 	// startClient requires locks are held, so acquire here.
 	local.mu.Lock()
 	lAddr := local.is.NodeAddr
-	local.startClient(lAddr, stopper)
+	local.startClient(&lAddr, stopper)
 	local.mu.Unlock()
 	local.manage()
 	util.SucceedsWithin(t, 10*time.Second, func() error {
@@ -256,8 +256,8 @@ func TestClientDisconnectRedundant(t *testing.T) {
 
 	rAddr := remote.is.NodeAddr
 	lAddr := local.is.NodeAddr
-	local.startClient(rAddr, stopper)
-	remote.startClient(lAddr, stopper)
+	local.startClient(&rAddr, stopper)
+	remote.startClient(&lAddr, stopper)
 	local.mu.Unlock()
 	remote.mu.Unlock()
 	local.manage()
@@ -295,8 +295,8 @@ func TestClientDisallowMultipleConns(t *testing.T) {
 	// Start two clients from local to remote. RPC client cache is
 	// disabled via the context, so we'll start two different outgoing
 	// connections.
-	local.startClient(rAddr, stopper)
-	local.startClient(rAddr, stopper)
+	local.startClient(&rAddr, stopper)
+	local.startClient(&rAddr, stopper)
 	local.mu.Unlock()
 	remote.mu.Unlock()
 	local.manage()

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -344,7 +344,7 @@ func (g *Gossip) GetResolvers() []resolver.Resolver {
 }
 
 // GetNodeIDAddress looks up the address of the node by ID.
-func (g *Gossip) GetNodeIDAddress(nodeID roachpb.NodeID) (net.Addr, error) {
+func (g *Gossip) GetNodeIDAddress(nodeID roachpb.NodeID) (*util.UnresolvedAddr, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.getNodeIDAddressLocked(nodeID)
@@ -502,12 +502,12 @@ func (g *Gossip) getNodeDescriptorLocked(nodeID roachpb.NodeID) (*roachpb.NodeDe
 // assumed held by the caller. This method is called externally via
 // GetNodeIDAddress or internally when looking up a "distant" node address to
 // connect directly to.
-func (g *Gossip) getNodeIDAddressLocked(nodeID roachpb.NodeID) (net.Addr, error) {
+func (g *Gossip) getNodeIDAddressLocked(nodeID roachpb.NodeID) (*util.UnresolvedAddr, error) {
 	nd, err := g.getNodeDescriptorLocked(nodeID)
 	if err != nil {
 		return nil, err
 	}
-	return nd.Address, nil
+	return &nd.Address, nil
 }
 
 // AddInfo adds or updates an info object. Returns an error if info

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -130,7 +130,7 @@ func TestGossipCullNetwork(t *testing.T) {
 	local.mu.Lock()
 	for _, p := range peers {
 		pAddr := p.is.NodeAddr
-		local.startClient(pAddr, stopper)
+		local.startClient(&pAddr, stopper)
 	}
 	local.mu.Unlock()
 	local.manage()

--- a/gossip/resolver/node_lookup.go
+++ b/gossip/resolver/node_lookup.go
@@ -80,7 +80,7 @@ func resolveAddress(network, address string) (net.Addr, error) {
 		if err != nil {
 			return nil, err
 		}
-		return util.MakeUnresolvedAddr("tcp", address), nil
+		return util.NewUnresolvedAddr("tcp", address), nil
 	}
 	return nil, util.Errorf("unknown address type: %q", network)
 }

--- a/gossip/resolver/socket.go
+++ b/gossip/resolver/socket.go
@@ -56,7 +56,7 @@ func (sr *socketResolver) GetAddress() (net.Addr, error) {
 			// "tcp" resolvers point to a single host. "lb" have an unknown of number of backends.
 			sr.exhausted = true
 		}
-		return util.MakeUnresolvedAddr("tcp", sr.addr), nil
+		return util.NewUnresolvedAddr("tcp", sr.addr), nil
 	}
 	return nil, util.Errorf("unknown address type: %q", sr.typ)
 }

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -321,7 +321,7 @@ func (ds *DistSender) sendRPC(trace opentracing.Span, rangeID roachpb.RangeID, r
 	addrs := make([]net.Addr, 0, len(replicas))
 	replicaMap := make(map[string]*roachpb.ReplicaDescriptor, len(replicas))
 	for i := range replicas {
-		addr := replicas[i].NodeDesc.Address
+		addr := &replicas[i].NodeDesc.Address
 		addrs = append(addrs, addr)
 		replicaMap[addr.String()] = &replicas[i].ReplicaDescriptor
 	}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -52,7 +52,7 @@ var testRangeDescriptor = roachpb.RangeDescriptor{
 	},
 }
 
-var testAddress = util.MakeUnresolvedAddr("tcp", "node1:26257")
+var testAddress = util.NewUnresolvedAddr("tcp", "node1:26257")
 
 func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
 	n := simulation.NewNetwork(1)
@@ -67,7 +67,7 @@ func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
 	nodeIDKey := gossip.MakeNodeIDKey(1)
 	if err := g.AddInfoProto(nodeIDKey, &roachpb.NodeDescriptor{
 		NodeID:  1,
-		Address: util.MakeUnresolvedAddr(testAddress.Network(), testAddress.String()),
+		Address: *testAddress,
 		Attrs:   roachpb.Attributes{Attrs: []string{"attr1", "attr2"}},
 	}, time.Hour); err != nil {
 		t.Fatal(err)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -357,7 +357,7 @@ func (c *Client) LocalAddr() net.Addr {
 
 // RemoteAddr returns remote address of the client.
 func (c *Client) RemoteAddr() net.Addr {
-	return c.addr
+	return &c.addr
 }
 
 // heartbeat sends a single heartbeat RPC. As part of the heartbeat protocol,

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -107,7 +107,7 @@ func TestClientCloseBeforeConnect(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
 	c := NewClient(
-		util.MakeUnresolvedAddr("tcp", ":1337"),
+		util.NewUnresolvedAddr("tcp", ":1337"),
 		&Context{Stopper: stop.NewStopper()},
 	)
 

--- a/server/node.go
+++ b/server/node.go
@@ -343,8 +343,10 @@ func (n *Node) initStores(engines []engine.Engine, stopper *stop.Stopper) error 
 		case 0:
 			return errNeedsBootstrap
 		case 1:
-			if addr, err := resolvers[0].GetAddress(); err == nil && addr == n.Descriptor.Address {
-				return errCannotJoinSelf
+			if addr, err := resolvers[0].GetAddress(); err == nil {
+				if uaddr, ok := addr.(*util.UnresolvedAddr); ok && *uaddr == n.Descriptor.Address {
+					return errCannotJoinSelf
+				}
 			}
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -215,7 +215,7 @@ func (s *Server) Start() error {
 		return err
 	}
 
-	unresolvedAddr := util.MakeUnresolvedAddr("tcp", s.ctx.Addr)
+	unresolvedAddr := util.NewUnresolvedAddr("tcp", s.ctx.Addr)
 	ln, err := util.ListenAndServe(s.stopper, s, unresolvedAddr, tlsConfig)
 	if err != nil {
 		return err
@@ -253,7 +253,7 @@ func (s *Server) Start() error {
 	log.Infof("starting %s server at %s", s.ctx.HTTPRequestScheme(), addr)
 	s.initHTTP()
 
-	return s.pgServer.Start(util.MakeUnresolvedAddr("tcp", s.ctx.PGAddr))
+	return s.pgServer.Start(util.NewUnresolvedAddr("tcp", s.ctx.PGAddr))
 }
 
 // initHTTP registers http prefixes.

--- a/server/status.go
+++ b/server/status.go
@@ -254,7 +254,7 @@ func (s *statusServer) handleDetailsLocal(w http.ResponseWriter, r *http.Request
 		BuildInfo: util.GetBuildInfo(),
 	}
 	if addr, err := s.gossip.GetNodeIDAddress(s.gossip.GetNodeID()); err == nil {
-		local.Address = addr.(util.UnresolvedAddr)
+		local.Address = *addr
 	}
 	respondAsJSON(w, r, local)
 }

--- a/util/net.go
+++ b/util/net.go
@@ -129,7 +129,7 @@ func updatedAddr(oldAddr, newAddr net.Addr) (net.Addr, error) {
 			return nil, fmt.Errorf("asked for port %s, got %s", oldPort, newPort)
 		}
 
-		return MakeUnresolvedAddr(network, net.JoinHostPort(host, newPort)), nil
+		return NewUnresolvedAddr(network, net.JoinHostPort(host, newPort)), nil
 
 	case "unix":
 		if oldAddrStr != newAddrStr {

--- a/util/net_test.go
+++ b/util/net_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 func checkUpdateMatches(t *testing.T, network, oldAddrString, newAddrString, expAddrString string) {
-	oldAddr := MakeUnresolvedAddr(network, oldAddrString)
-	newAddr := MakeUnresolvedAddr(network, newAddrString)
-	expAddr := MakeUnresolvedAddr(network, expAddrString)
+	oldAddr := NewUnresolvedAddr(network, oldAddrString)
+	newAddr := NewUnresolvedAddr(network, newAddrString)
+	expAddr := NewUnresolvedAddr(network, expAddrString)
 
 	retAddr, err := updatedAddr(oldAddr, newAddr)
 	if err != nil {
@@ -38,8 +38,8 @@ func checkUpdateMatches(t *testing.T, network, oldAddrString, newAddrString, exp
 }
 
 func checkUpdateFails(t *testing.T, network, oldAddrString, newAddrString string) {
-	oldAddr := MakeUnresolvedAddr(network, oldAddrString)
-	newAddr := MakeUnresolvedAddr(network, newAddrString)
+	oldAddr := NewUnresolvedAddr(network, oldAddrString)
+	newAddr := NewUnresolvedAddr(network, newAddrString)
 
 	retAddr, err := updatedAddr(oldAddr, newAddr)
 	if err == nil {

--- a/util/unresolved_addr.go
+++ b/util/unresolved_addr.go
@@ -21,22 +21,39 @@ import (
 	"net"
 )
 
-// MakeUnresolvedAddr creates a new UnresolvedAddr from a network
-// and raw address string.
-func MakeUnresolvedAddr(network string, str string) UnresolvedAddr {
+// MakeUnresolvedAddr populates an UnresolvedAddr from a network and raw
+// address string.
+func MakeUnresolvedAddr(network, addr string) UnresolvedAddr {
 	return UnresolvedAddr{
 		NetworkField: network,
-		AddressField: str,
+		AddressField: addr,
 	}
 }
 
+// NewUnresolvedAddr creates a new UnresolvedAddr from a network and raw
+// address string.
+func NewUnresolvedAddr(network, addr string) *UnresolvedAddr {
+	return &UnresolvedAddr{
+		NetworkField: network,
+		AddressField: addr,
+	}
+}
+
+// Note that we make *UnresolvedAddr implement the net.Addr interface, not
+// UnresolvedAddr. This is done because assigning a non-empty struct to an
+// interface requires an allocation, while assigning a pointer to an interface
+// is allocation free. Using an *UnresolvedAddr makes it both clear that an
+// allocation is occurring and allows us to avoid an allocation when an
+// UnresolvedAddr is a field of a struct (e.g. NodeDescriptor.Address).
+var _ net.Addr = &UnresolvedAddr{}
+
 // Network returns the address's network name.
-func (a UnresolvedAddr) Network() string {
+func (a *UnresolvedAddr) Network() string {
 	return a.NetworkField
 }
 
 // String returns the address's string form.
-func (a UnresolvedAddr) String() string {
+func (a *UnresolvedAddr) String() string {
 	return a.AddressField
 }
 


### PR DESCRIPTION
This is done because assigning a non-empty struct to an interface requires an
allocation, while assigning a pointer to an interface is allocation free. Using
an *UnresolvedAddr makes it both clear that an allocation is occurring and
allows us to avoid an allocation when an UnresolvedAddr is a field of a
struct (e.g. NodeDescriptor.Address). This saves a few allocations on every
DistSender RPC.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4131)

<!-- Reviewable:end -->
