### PR TITLE
sql: Create a suite of benchmarks for aggregation functions

### DIFF
--- a/sql/group_test.go
+++ b/sql/group_test.go
@@ -20,8 +20,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/decimal"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
 func TestDesiredAggregateOrder(t *testing.T) {
@@ -57,4 +60,127 @@ func TestDesiredAggregateOrder(t *testing.T) {
 			t.Fatalf("%s: expected %v, but found %v", d.expr, d.ordering, ordering)
 		}
 	}
+}
+
+func makeIntTestDatum(count int) []parser.Datum {
+	rng, _ := randutil.NewPseudoRand()
+
+	vals := make([]parser.Datum, count)
+	for i := range vals {
+		vals[i] = parser.DInt(rng.Int63())
+	}
+	return vals
+}
+
+func makeFloatTestDatum(count int) []parser.Datum {
+	rng, _ := randutil.NewPseudoRand()
+
+	vals := make([]parser.Datum, count)
+	for i := range vals {
+		vals[i] = parser.DFloat(rng.Float64())
+	}
+	return vals
+}
+
+func makeDecimalTestDatum(count int) []parser.Datum {
+	rng, _ := randutil.NewPseudoRand()
+
+	vals := make([]parser.Datum, count)
+	for i := range vals {
+		dd := parser.DDecimal{}
+		decimal.SetFromFloat(&dd.Dec, rng.Float64())
+		vals[i] = dd
+	}
+	return vals
+}
+
+func runBenchmarkAggregate(b *testing.B, aggFunc func() aggregateImpl, vals []parser.Datum) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		aggImpl := aggFunc()
+		for i := range vals {
+			if err := aggImpl.add(vals[i]); err != nil {
+				b.Errorf("adding value to aggregate implementation %T failed: %v", aggImpl, err)
+			}
+		}
+		if _, err := aggImpl.result(); err != nil {
+			b.Errorf("taking result of aggregate implementation %T failed: %v", aggImpl, err)
+		}
+	}
+}
+
+func BenchmarkAvgAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newAvgAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkAvgAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newAvgAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkAvgAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newAvgAggregate, makeDecimalTestDatum(1000))
+}
+
+func BenchmarkCountAggregate1K(b *testing.B) {
+	runBenchmarkAggregate(b, newCountAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkSumAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newSumAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkSumAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newSumAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkSumAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newSumAggregate, makeDecimalTestDatum(1000))
+}
+
+func BenchmarkMaxAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMaxAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkMaxAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMaxAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkMaxAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMaxAggregate, makeDecimalTestDatum(1000))
+}
+
+func BenchmarkMinAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMinAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkMinAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMinAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkMinAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMinAggregate, makeDecimalTestDatum(1000))
+}
+
+func BenchmarkVarianceAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newVarianceAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkVarianceAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newVarianceAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkVarianceAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newVarianceAggregate, makeDecimalTestDatum(1000))
+}
+
+func BenchmarkStddevAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newStddevAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkStddevAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newStddevAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkStddevAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newStddevAggregate, makeDecimalTestDatum(1000))
 }


### PR DESCRIPTION
Current results are:

```
BenchmarkAvgAggregateInt-4             20000         68674 ns/op
BenchmarkAvgAggregateFloat-4           20000         70410 ns/op
BenchmarkAvgAggregateDecimal-4          3000        397697 ns/op
BenchmarkCountAggregate-4             200000          6874 ns/op
BenchmarkSumAggregateInt-4             20000         65337 ns/op
BenchmarkSumAggregateFloat-4           20000         68260 ns/op
BenchmarkSumAggregateDecimal-4          3000        390299 ns/op
BenchmarkMaxAggregateInt-4            100000         17648 ns/op
BenchmarkMaxAggregateFloat-4          100000         17894 ns/op
BenchmarkMaxAggregateDecimal-4         10000        157491 ns/op
BenchmarkMinAggregateInt-4            100000         17654 ns/op
BenchmarkMinAggregateFloat-4          100000         17517 ns/op
BenchmarkMinAggregateDecimal-4          5000        295761 ns/op
BenchmarkVarianceAggregateInt-4         1000       1762158 ns/op
BenchmarkVarianceAggregateFloat-4      20000         75138 ns/op
BenchmarkVarianceAggregateDecimal-4     1000       1650435 ns/op
BenchmarkStddevAggregateInt-4           1000       1963264 ns/op
BenchmarkStddevAggregateFloat-4        20000         77677 ns/op
BenchmarkStddevAggregateDecimal-4       1000       1667530 ns/op
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4139)

<!-- Reviewable:end -->
