### PR TITLE
Makefile check if GOPATH is correctly set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,10 @@ TESTFLAGS    :=
 STRESSFLAGS  :=
 DUPLFLAGS    := -t 100
 BUILDMODE    := install
+export GOPATH := $(realpath ../../../..)
+export PATH := $(GOPATH)/bin:$(PATH)
 
-# Note: We pass `-v` go `go build` and `go test -i` so that warnings
+# Note: We pass `-v` to `go build` and `go test -i` so that warnings
 # from the linker aren't suppressed. The usage of `-v` also shows when
 # dependencies are rebuilt which is useful when switching between
 # normal and race test builds.
@@ -65,6 +67,8 @@ install: LDFLAGS += -X "github.com/cockroachdb/cockroach/util.buildTag=$(shell g
 install: LDFLAGS += -X "github.com/cockroachdb/cockroach/util.buildTime=$(shell date -u '+%Y/%m/%d %H:%M:%S')"
 install: LDFLAGS += -X "github.com/cockroachdb/cockroach/util.buildDeps=$(shell GOPATH=${GOPATH} build/depvers.sh)"
 install:
+	@echo "GOPATH set to $$GOPATH"
+	@echo "$$GOPATH/bin added to PATH"
 	@echo $(GO) $(BUILDMODE) -v $(GOFLAGS)
 	@$(GO) $(BUILDMODE) -v $(GOFLAGS) -ldflags '$(LDFLAGS)'
 


### PR DESCRIPTION
The change adds a bit of logic in Makefile to check that GOPATH resolves to a
prefix of the cockroach directory. This is useful when using multiple GOPATHs.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4141)

<!-- Reviewable:end -->
