### PR TITLE
sql: support prepare for CASE statements

### DIFF
--- a/sql/bank_test.go
+++ b/sql/bank_test.go
@@ -75,7 +75,7 @@ CREATE TABLE IF NOT EXISTS bench.bank (
 			amount := rand.Intn(*maxTransfer)
 
 			// TODO(mjibson): We can't use query parameters with this query because
-			// it fails type checking on the CASE expression.
+			// of the subquery.
 			update := fmt.Sprintf(`
 UPDATE bench.bank
   SET balance = CASE id WHEN %[1]d THEN balance-%[3]d WHEN %[2]d THEN balance+%[3]d END

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -85,12 +85,14 @@ func (expr *BinaryExpr) TypeCheck(args MapArgs) (Datum, error) {
 func (expr *CaseExpr) TypeCheck(args MapArgs) (Datum, error) {
 	var dummyCond, dummyVal Datum
 
+	valArgType := DummyBool
 	if expr.Expr != nil {
 		var err error
 		dummyCond, err = expr.Expr.TypeCheck(args)
 		if err != nil {
 			return nil, err
 		}
+		valArgType = dummyCond
 	}
 
 	if expr.Else != nil {
@@ -106,6 +108,11 @@ func (expr *CaseExpr) TypeCheck(args MapArgs) (Datum, error) {
 		if err != nil {
 			return nil, err
 		}
+		if set, err := args.SetInferredType(nextDummyCond, valArgType); err != nil {
+			return nil, err
+		} else if set != nil {
+			nextDummyCond = set
+		}
 		if dummyCond == nil || dummyCond == DNull {
 			dummyCond = nextDummyCond
 		} else if !(nextDummyCond == DNull || nextDummyCond.TypeEqual(dummyCond)) {
@@ -115,6 +122,11 @@ func (expr *CaseExpr) TypeCheck(args MapArgs) (Datum, error) {
 		nextDummyVal, err := when.Val.TypeCheck(args)
 		if err != nil {
 			return nil, err
+		}
+		if set, err := args.SetInferredType(nextDummyVal, dummyVal); err != nil {
+			return nil, err
+		} else if set != nil {
+			nextDummyVal = set
 		}
 		if dummyVal == nil || dummyVal == DNull {
 			dummyVal = nextDummyVal


### PR DESCRIPTION
Also add protecting against other statements where valargs are not fully
supported. Say that $2 gets inferred but $1 does not. The previous code
would panic because the slice isn't long enough (expected to be of length
2 when it indexed into pq.inTypes[1]) because it only made pq.inTypes
length 1 since that's how many valargs it inferred.

Fixes #4024

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4142)

<!-- Reviewable:end -->
