### PR TITLE
Set default cache size of RocksDB based on available memory

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -16,11 +16,12 @@ cmd golang.org/x/tools/cmd/stringer
 github.com/VividCortex/ewma c34099b489e4ac33ca8d8c5f9d29d6eeaf69f2ed
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store 3b4c041f52c224ee4a44f5c8b150d003a40643a0
+github.com/cloudfoundry/gosigar 3ed7c74352dae6dc00bdc8c74045375352e3ec05
 github.com/cockroachdb/c-lz4 c40aaae2fc50293eb8750b34632bc3efe813e23f
 github.com/cockroachdb/c-protobuf 4feb192131ea08dfbd7253a00868ad69cbb61b81
 github.com/cockroachdb/c-rocksdb b7fb7bddcb55be35eacdf67e9e2c931083ce02c4
 github.com/cockroachdb/c-snappy 5c6d0932e0adaffce4bfca7bdf2ac37f79952ccf
-github.com/cockroachdb/stress 574c7f17016a4db745b88f6643700995110bdd07 
+github.com/cockroachdb/stress 574c7f17016a4db745b88f6643700995110bdd07
 github.com/cockroachdb/yacc 443154b1852a8702b07d675da6cd97cd9177a316
 github.com/codahale/hdrhistogram 954f16e8b9ef0e5d5189456aa4c1202758e04f17
 github.com/coreos/etcd 8199147cf859882f625523446c28ae2e53b2432f

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -218,8 +218,8 @@ func initFlags(ctx *Context) {
 		f.BoolVar(&ctx.Linearizable, "linearizable", ctx.Linearizable, usage("linearizable"))
 
 		// Engine flags.
-		f.Int64Var(&ctx.CacheSize, "cache-size", ctx.CacheSize, usage("cache-size"))
-		f.Int64Var(&ctx.MemtableBudget, "memtable-budget", ctx.MemtableBudget, usage("memtable-budget"))
+		f.Uint64Var(&ctx.CacheSize, "cache-size", ctx.CacheSize, usage("cache-size"))
+		f.Uint64Var(&ctx.MemtableBudget, "memtable-budget", ctx.MemtableBudget, usage("memtable-budget"))
 		f.DurationVar(&ctx.ScanInterval, "scan-interval", ctx.ScanInterval, usage("scan-interval"))
 		f.DurationVar(&ctx.ScanMaxIdleTime, "scan-max-idle-time", ctx.ScanMaxIdleTime, usage("scan-max-idle-time"))
 		f.DurationVar(&ctx.TimeUntilStoreDead, "time-until-store-dead", ctx.TimeUntilStoreDead, usage("time-until-store-dead"))

--- a/cli/start.go
+++ b/cli/start.go
@@ -110,7 +110,7 @@ func runStart(_ *cobra.Command, _ []string) error {
 		// TODO(marc): set this in the zones table when we have an entry
 		// for the default cluster-wide zone config.
 		config.DefaultZoneConfig.ReplicaAttrs = []roachpb.Attributes{{}}
-		context.Stores = "mem=1073741824"
+		context.Stores = "mem=1073741824" // 1024MB
 	}
 
 	stopper := stop.NewStopper()

--- a/storage/engine/in_mem.go
+++ b/storage/engine/in_mem.go
@@ -27,7 +27,7 @@ type InMem struct {
 }
 
 // NewInMem allocates and returns a new, opened InMem engine.
-func NewInMem(attrs roachpb.Attributes, cacheSize int64, stopper *stop.Stopper) InMem {
+func NewInMem(attrs roachpb.Attributes, cacheSize uint64, stopper *stop.Stopper) InMem {
 	db := InMem{
 		RocksDB: newMemRocksDB(attrs, cacheSize, 512<<20 /* 512 MB */, stopper),
 	}

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -51,14 +51,14 @@ type RocksDB struct {
 	rdb            *C.DBEngine
 	attrs          roachpb.Attributes // Attributes for this engine
 	dir            string             // The data directory
-	cacheSize      int64              // Memory to use to cache values.
-	memtableBudget int64              // Memory to use for the memory table.
+	cacheSize      uint64             // Memory to use to cache values.
+	memtableBudget uint64             // Memory to use for the memory table.
 	stopper        *stop.Stopper
 	deallocated    chan struct{} // Closed when the underlying handle is deallocated.
 }
 
 // NewRocksDB allocates and returns a new RocksDB object.
-func NewRocksDB(attrs roachpb.Attributes, dir string, cacheSize, memtableBudget int64,
+func NewRocksDB(attrs roachpb.Attributes, dir string, cacheSize, memtableBudget uint64,
 	stopper *stop.Stopper) *RocksDB {
 	if dir == "" {
 		panic(util.Errorf("dir must be non-empty"))
@@ -73,7 +73,7 @@ func NewRocksDB(attrs roachpb.Attributes, dir string, cacheSize, memtableBudget 
 	}
 }
 
-func newMemRocksDB(attrs roachpb.Attributes, cacheSize, memtableBudget int64,
+func newMemRocksDB(attrs roachpb.Attributes, cacheSize, memtableBudget uint64,
 	stopper *stop.Stopper) *RocksDB {
 	return &RocksDB{
 		attrs: attrs,
@@ -107,8 +107,8 @@ func (r *RocksDB) Open() error {
 	}
 	status := C.DBOpen(&r.rdb, goToCSlice([]byte(r.dir)),
 		C.DBOptions{
-			cache_size:      C.int64_t(r.cacheSize),
-			memtable_budget: C.int64_t(r.memtableBudget),
+			cache_size:      C.uint64_t(r.cacheSize),
+			memtable_budget: C.uint64_t(r.memtableBudget),
 			allow_os_buffer: C.bool(true),
 			logging_enabled: C.bool(log.V(3)),
 		})

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -59,8 +59,8 @@ typedef struct DBIterator DBIterator;
 
 // DBOptions contains local database options.
 typedef struct {
-  int64_t cache_size;
-  int64_t memtable_budget;
+  uint64_t cache_size;
+  uint64_t memtable_budget;
   bool allow_os_buffer;
   bool logging_enabled;
 } DBOptions;


### PR DESCRIPTION
Make all the things unsigned, since negative memory is nonsense.

This is a fixup of #3514. Closes #3514.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4148)

<!-- Reviewable:end -->
