### PR TITLE
sql: support prepared for SHOW

### DIFF
--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -279,6 +279,27 @@ func TestPGPreparedQuery(t *testing.T) {
 			base.Params(2, 3).Results(2),
 			base.Params(true, 0).Error(`pq: param $1: strconv.ParseInt: parsing "true": invalid syntax`),
 		},
+		"SHOW database": {
+			base.Results(""),
+		},
+		"SHOW COLUMNS FROM system.users": {
+			base.Results("username", "STRING", false, sql.NullBool{}),
+		},
+		"SHOW DATABASES": {
+			base.Results("system"),
+		},
+		"SHOW GRANTS ON system.users": {
+			base.Results("users", "root", "DELETE,GRANT,INSERT,SELECT,UPDATE"),
+		},
+		"SHOW INDEX FROM system.users": {
+			base.Results("users", "primary", true, 1, "username", "ASC", false),
+		},
+		"SHOW TABLES FROM system": {
+			base.Results("descriptor"),
+		},
+		"SHOW TIME ZONE": {
+			base.Results("UTC"),
+		},
 		// TODO(mjibson): test date/time types
 	}
 

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -165,6 +165,18 @@ func (p *planner) prepare(stmt parser.Statement) (planNode, *roachpb.Error) {
 		return p.Insert(n, false)
 	case *parser.Select:
 		return p.Select(n)
+	case *parser.Show:
+		return p.Show(n)
+	case *parser.ShowColumns:
+		return p.ShowColumns(n)
+	case *parser.ShowDatabases:
+		return p.ShowDatabases(n)
+	case *parser.ShowGrants:
+		return p.ShowGrants(n)
+	case *parser.ShowIndex:
+		return p.ShowIndex(n)
+	case *parser.ShowTables:
+		return p.ShowTables(n)
 	case *parser.Update:
 		return p.Update(n)
 	default:


### PR DESCRIPTION
Although psql errors on `prepare a as SHOW TIME ZONE`, postgres does
indeed support prepared SHOW statements. The psql client doesn't support
the extended prepare protocol, so it passes on the parsing of those
to the server, which errors. This was why I thought we didn't need to
support prepared SHOW. However using a better driver indicates we need
to support this.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4150)

<!-- Reviewable:end -->
