### PR TITLE
sql: Throw error when nested aggregate functions used in SELECT or HAVING clauses

### DIFF
--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -184,6 +184,9 @@ SELECT COUNT(*), v/(k+v) FROM kv GROUP BY k+v
 query error aggregate functions are not allowed in WHERE
 SELECT k FROM kv WHERE AVG(k) > 1
 
+query error aggregate function calls cannot be nested under MAX
+SELECT MAX(AVG(k)) FROM kv
+
 # Test case from #2761.
 query II rowsort
 SELECT count(kv.k) AS count_1, kv.v + kv.w AS lx FROM kv GROUP BY kv.v + kv.w
@@ -206,13 +209,16 @@ SELECT UPPER(s), COUNT(DISTINCT s), COUNT(DISTINCT UPPER(s)) FROM kv GROUP BY UP
 A 2 1
 
 query II rowsort
-SELECT MAX(k), MIN(v) FROM kv HAVING MIN(v) > 2;
+SELECT MAX(k), MIN(v) FROM kv HAVING MIN(v) > 2
 ----
 
 query II rowsort
-SELECT MAX(k), MIN(v) FROM kv HAVING MAX(v) > 2;
+SELECT MAX(k), MIN(v) FROM kv HAVING MAX(v) > 2
 ----
 8 2
+
+query error aggregate function calls cannot be nested under MAX
+SELECT MAX(k), MIN(v) FROM kv HAVING MAX(MIN(v)) > 2
 
 query error argument of HAVING must be type bool, not type int
 SELECT MAX(k), MIN(v) FROM kv HAVING k;


### PR DESCRIPTION
Fixes #4140.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4153)

<!-- Reviewable:end -->
