### PR TITLE
Add EventLog, log Create Table events

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -340,13 +340,15 @@ func Example_ranges() {
 	// range ls
 	// /Min-"c" [1]
 	// 	0: node-id=1 store-id=1
-	// "c"-/Table/11 [4]
+	// "c"-/Table/11 [5]
 	// 	0: node-id=1 store-id=1
 	// /Table/11-/Table/12 [2]
 	// 	0: node-id=1 store-id=1
-	// /Table/12-/Max [3]
+	// /Table/12-/Table/13 [3]
 	// 	0: node-id=1 store-id=1
-	// 4 result(s)
+	// /Table/13-/Max [4]
+	// 	0: node-id=1 store-id=1
+	// 5 result(s)
 	// kv scan
 	// "a"	"1"
 	// "b"	"2"
@@ -365,9 +367,11 @@ func Example_ranges() {
 	// 	0: node-id=1 store-id=1
 	// /Table/11-/Table/12 [2]
 	// 	0: node-id=1 store-id=1
-	// /Table/12-/Max [3]
+	// /Table/12-/Table/13 [3]
 	// 	0: node-id=1 store-id=1
-	// 3 result(s)
+	// /Table/13-/Max [4]
+	// 	0: node-id=1 store-id=1
+	// 4 result(s)
 	// kv scan
 	// "a"	"1"
 	// "b"	"2"
@@ -469,7 +473,7 @@ func Example_max_results() {
 	// range ls --max-results=2
 	// /Min-"c" [1]
 	// 	0: node-id=1 store-id=1
-	// "c"-"d" [4]
+	// "c"-"d" [5]
 	// 	0: node-id=1 store-id=1
 	// 2 result(s)
 }

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -213,5 +213,6 @@ const (
 	// Reserved IDs for other system tables.
 	// NOTE: IDs must be <= MaxReservedDescID.
 	LeaseTableID      = 11
-	RangeEventTableID = 12
+	EventLogTableID   = 12
+	RangeEventTableID = 13
 )

--- a/server/node.go
+++ b/server/node.go
@@ -110,6 +110,7 @@ func allocateStoreIDs(nodeID roachpb.NodeID, inc int64, db *client.DB) (roachpb.
 func GetBootstrapSchema() sql.MetadataSchema {
 	schema := sql.MakeMetadataSchema()
 	storage.AddEventLogToMetadataSchema(&schema)
+	sql.AddEventLogToMetadataSchema(&schema)
 	return schema
 }
 

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Cockroach Authors.
+// Copyright 2016 The Cockroach Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,30 +71,31 @@ func (p *planner) checkPrivilege(descriptor descriptorProto, privilege privilege
 		p.user, privilege, descriptor.TypeName(), descriptor.GetName())
 }
 
-// createDescriptor takes a Table or Database descriptor and creates it
-// if needed, incrementing the descriptor counter.
-func (p *planner) createDescriptor(plainKey descriptorKey, descriptor descriptorProto, ifNotExists bool) *roachpb.Error {
+// createDescriptor takes a Table or Database descriptor and creates it if
+// needed, incrementing the descriptor counter. Returns true if the descriptor
+// is actually created, false if it already existed.
+func (p *planner) createDescriptor(plainKey descriptorKey, descriptor descriptorProto, ifNotExists bool) (bool, *roachpb.Error) {
 	idKey := plainKey.Key()
 	// Check whether idKey exists.
 	gr, err := p.txn.Get(idKey)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if gr.Exists() {
 		if ifNotExists {
 			// Noop.
-			return nil
+			return false, nil
 		}
 		// Key exists, but we don't want it to: error out.
-		return roachpb.NewUErrorf("%s %q already exists", descriptor.TypeName(), plainKey.Name())
+		return false, roachpb.NewUErrorf("%s %q already exists", descriptor.TypeName(), plainKey.Name())
 	}
 
 	// Increment unique descriptor counter.
 	if ir, err := p.txn.Inc(keys.DescIDGenerator, 1); err == nil {
 		descriptor.SetID(ID(ir.ValueInt() - 1))
 	} else {
-		return err
+		return false, err
 	}
 
 	// TODO(pmattis): The error currently returned below is likely going to be
@@ -121,7 +122,7 @@ func (p *planner) createDescriptor(plainKey descriptorKey, descriptor descriptor
 		return expectDescriptor(systemConfig, descKey, descDesc)
 	}
 
-	return p.txn.Run(&b)
+	return true, p.txn.Run(&b)
 }
 
 // getDescriptor looks up the descriptor for `plainKey`, validates it,

--- a/sql/event_log.go
+++ b/sql/event_log.go
@@ -1,0 +1,118 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package sql
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/sql/privilege"
+)
+
+// EventLogType represents an event type that can be recorded in the event log.
+type EventLogType string
+
+const (
+	// EventLogCreateTable is recorded when a table is created.
+	EventLogCreateTable EventLogType = "create_table"
+)
+
+// eventTableSchema describes the schema of the event log table.
+const eventTableSchema = `
+CREATE TABLE system.eventlog (
+  timestamp    TIMESTAMP  NOT NULL,
+  eventType    STRING     NOT NULL,
+  targetID     INT        NOT NULL,
+  reportingID  INT        NOT NULL,
+  info         STRING,
+  uniqueID     BYTES      DEFAULT experimental_unique_bytes(),
+  PRIMARY KEY (timestamp, uniqueID)
+);`
+
+// AddEventLogToMetadataSchema adds the event log table to the supplied
+// MetadataSchema.
+func AddEventLogToMetadataSchema(schema *MetadataSchema) {
+	schema.AddTable(keys.EventLogTableID, eventTableSchema, privilege.List{privilege.ALL})
+}
+
+// An EventLogger exposes methods used to record events to the event table.
+type EventLogger struct {
+	InternalExecutor
+}
+
+// MakeEventLogger constructs a new EventLogger. A LeaseManager is required in
+// order to correctly execute SQL statements.
+func MakeEventLogger(leaseMgr *LeaseManager) EventLogger {
+	return EventLogger{InternalExecutor{
+		LeaseManager: leaseMgr,
+	}}
+}
+
+// insertEventRecord inserts a single event into the event log as part of the
+// provided transaction.
+func (ev EventLogger) insertEventRecord(txn *client.Txn, eventType EventLogType, targetID, reportingID int32, info interface{}) *roachpb.Error {
+	const insertEventTableStmt = `
+INSERT INTO system.eventlog (
+  timestamp, eventType, targetID, reportingID, info
+)
+VALUES(
+  $1, $2, $3, $4, $5
+)
+`
+	args := []interface{}{
+		ev.selectEventTimestamp(txn.Proto.Timestamp),
+		eventType,
+		targetID,
+		reportingID,
+		nil, // info
+	}
+	if info != nil {
+		infoBytes, err := json.Marshal(info)
+		if err != nil {
+			return roachpb.NewError(err)
+		}
+		args[4] = string(infoBytes)
+	}
+
+	rows, err := ev.ExecuteStatementInTransaction(txn, insertEventTableStmt, args...)
+	if err != nil {
+		return err
+	}
+	if rows != 1 {
+		return roachpb.NewErrorf("%d rows affected by log insertion; expected exactly one row affected.", rows)
+	}
+	return nil
+}
+
+// selectEventTimestamp selects a timestamp for this log message. If the
+// transaction this event is being written in has a non-zero timestamp, then that
+// timestamp should be used; otherwise, the store's physical clock is used.
+// This helps with testing; in normal usage, the logging of an event will never
+// be the first action in the transaction, and thus the transaction will have an
+// assigned database timestamp. However, in the case of our tests log events
+// *are* the first action in a transaction, and we must elect to use the store's
+// physical time instead.
+func (ev EventLogger) selectEventTimestamp(input roachpb.Timestamp) time.Time {
+	if input == roachpb.ZeroTimestamp {
+		return ev.LeaseManager.clock.PhysicalTime()
+	}
+	return input.GoTime()
+}

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -68,7 +68,16 @@ func checkEndTransactionTrigger(_ roachpb.StoreID, req roachpb.Request, _ roachp
 			break
 		}
 	}
-	if hasSystemKey != modifiedSystemConfigSpan {
+	// If the transaction in question has intents in the system span, then
+	// modifiedSystemConfigSpan should always be true. However, it is possible
+	// for modifiedSystemConfigSpan to be set, even though no system keys are
+	// present. This can occur with certain conditional DDL statements (e.g.
+	// "CREATE TABLE IF NOT EXISTS"), which set the SystemConfigTrigger
+	// aggressively but may not actually end up changing the system DB depending
+	// on the current state.
+	// For more information, see the related comment at the beginning of
+	// planner.makePlan().
+	if hasSystemKey && !modifiedSystemConfigSpan {
 		return util.Errorf("EndTransaction hasSystemKey=%t, but hasSystemConfigTrigger=%t",
 			hasSystemKey, modifiedSystemConfigSpan)
 	}

--- a/sql/testdata/event_log
+++ b/sql/testdata/event_log
@@ -1,0 +1,34 @@
+statement ok
+CREATE TABLE test.a (id INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE IF NOT EXISTS test.b (id INT PRIMARY KEY)
+
+query II
+SELECT targetID, reportingID FROM system.eventlog WHERE eventType = 'create_table'
+----
+51 1
+52 1
+
+statement ok
+CREATE TABLE IF NOT EXISTS a (id INT PRIMARY KEY)
+
+query I
+SELECT COUNT(*) FROM system.eventlog WHERE eventType = 'create_table'
+----
+2
+
+query I
+SELECT COUNT(*) FROM system.eventlog WHERE info LIKE '%CREATE TABLE test.a%'
+----
+1
+
+query I
+SELECT COUNT(*) FROM system.eventlog WHERE info LIKE '%CREATE TABLE IF NOT EXISTS test.b%'
+----
+1
+
+query I
+SELECT COUNT(*) FROM system.eventlog WHERE info LIKE '%CREATE TABLE badtable%'
+----
+0

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -8,6 +8,7 @@ query T
 SHOW TABLES FROM system
 ----
 descriptor
+eventlog
 lease
 namespace
 rangelog
@@ -20,11 +21,12 @@ EXPLAIN (DEBUG) SELECT * FROM system.namespace
 0 /namespace/primary/0/'system'/id     1    true
 1 /namespace/primary/0/'test'/id       50   true
 2 /namespace/primary/1/'descriptor'/id 3    true
-3 /namespace/primary/1/'lease'/id      11   true
-4 /namespace/primary/1/'namespace'/id  2    true
-5 /namespace/primary/1/'rangelog'/id   12   true
-6 /namespace/primary/1/'users'/id      4    true
-7 /namespace/primary/1/'zones'/id      5    true
+3 /namespace/primary/1/'eventlog'/id   12   true
+4 /namespace/primary/1/'lease'/id      11   true
+5 /namespace/primary/1/'namespace'/id  2    true
+6 /namespace/primary/1/'rangelog'/id   13   true
+7 /namespace/primary/1/'users'/id      4    true
+8 /namespace/primary/1/'zones'/id      5    true
 
 query ITI
 SELECT * FROM system.namespace
@@ -32,9 +34,10 @@ SELECT * FROM system.namespace
 0 system     1
 0 test       50
 1 descriptor 3
+1 eventlog   12
 1 lease      11
 1 namespace  2
-1 rangelog   12
+1 rangelog   13
 1 users      4
 1 zones      5
 
@@ -48,6 +51,7 @@ SELECT id FROM system.descriptor
 5
 11
 12
+13
 50
 
 # Verify we can read "protobuf" columns.

--- a/storage/log.go
+++ b/storage/log.go
@@ -60,7 +60,7 @@ CREATE TABLE system.rangelog (
   otherRangeID  INT,
   info          STRING,
   uniqueID      INT        DEFAULT experimental_unique_int(),
-  PRIMARY KEY (timestamp, rangeID, uniqueID)
+  PRIMARY KEY (timestamp, uniqueID)
 );`
 
 type rangeLogEvent struct {


### PR DESCRIPTION
This commit adds the EventLog table, an additional log structured table which
will capture various events on the cluster. This is separate from the previously
created RangeLog table due to concerns about the volume and value of
range-related events.

The first event being logged to this table is "Create Table" - an event is
logged every time a table is successfully created on the server.

There is already an active TODO on the existing RangeLog code in the `storage`
package to move that code into the sql package; it should be appropriate for all
planned log messages to be recorded using code in the sql package.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4156)

<!-- Reviewable:end -->
