### PR TITLE
sql: fatal on bank test query error

### DIFF
--- a/sql/bank_test.go
+++ b/sql/bank_test.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-
-	"github.com/cockroachdb/cockroach/util/log"
 )
 
 var maxTransfer = flag.Int("max-transfer", 999, "Maximum amount to transfer in one transaction.")
@@ -82,10 +80,7 @@ UPDATE bench.bank
   WHERE id IN (%[1]d, %[2]d) AND (SELECT balance >= %[3]d FROM bench.bank WHERE id = %[1]d)
 `, from, to, amount)
 			if _, err := db.Exec(update); err != nil {
-				if log.V(1) {
-					log.Warning(err)
-				}
-				continue
+				b.Fatal(err)
 			}
 		}
 	})


### PR DESCRIPTION
In 394548915d02f4bc92d0b6dd5976eaaffc8012e6 a Fatal was removed and the
Log added. However, the structure has changed a lot since then and now
we aren't running in a transaction, so there's nothing to abort. The
server will retry the transaction if needed. Fatal'ing here is now
correct because it's a genuine, unexpected error.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4157)

<!-- Reviewable:end -->
