### PR TITLE
sql: change checkResultDatum to use a separate error for DValArg

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/retry"
@@ -678,8 +679,10 @@ func checkResultDatum(datum parser.Datum) error {
 	case parser.DDate:
 	case parser.DTimestamp:
 	case parser.DInterval:
+	case parser.DValArg:
+		return fmt.Errorf("could not determine data type of parameter %s", datum)
 	default:
-		return fmt.Errorf("unsupported result type: %s", datum.Type())
+		return util.Errorf("unsupported result type: %s", datum.Type())
 	}
 	return nil
 }

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -680,7 +680,7 @@ func checkResultDatum(datum parser.Datum) error {
 	case parser.DTimestamp:
 	case parser.DInterval:
 	case parser.DValArg:
-		return fmt.Errorf("could not determine data type of parameter %s", datum)
+		return fmt.Errorf("could not determine data type of %s %s", datum.Type(), datum)
 	default:
 		return util.Errorf("unsupported result type: %s", datum.Type())
 	}

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -77,6 +77,7 @@ var (
 // optimizations in terms of shared buffer preallocations.
 type Datum interface {
 	Expr
+	// Type returns the (user-friendly) name of the type.
 	Type() string
 	// TypeEqual determines if the receiver and the other Datum have the same
 	// type or not. This method should be used for asserting the type of all
@@ -968,7 +969,7 @@ func (DValArg) Variable() {}
 
 // Type implements the Datum interface.
 func (DValArg) Type() string {
-	return "valarg"
+	return "parameter"
 }
 
 // TypeEqual implements the Datum interface.

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -179,13 +179,12 @@ func TestPGPrepareFail(t *testing.T) {
 	testFailures := map[string]string{
 		"SELECT $1 = $1":                           "pq: unsupported comparison operator: <valarg> = <valarg>",
 		"SELECT $1 > 0 AND NOT $1":                 "pq: incompatible NOT argument type: int",
-		"SELECT $1":                                "pq: unsupported result type: valarg",
+		"SELECT $1":                                "pq: could not determine data type of parameter $1",
 		"SELECT $1 + $1":                           "pq: unsupported binary operator: <valarg> + <valarg>",
 		"SELECT now() + $1":                        "pq: unsupported binary operator: <timestamp> + <valarg>",
 		"SELECT CASE $1 WHEN 1 THEN 1 END":         "pq: unsupported case expression type: valarg",
 		"SELECT CASE 1 WHEN 2 THEN 1 ELSE $1 END":  "pq: incompatible value types valarg, int",
-		"SELECT CASE 1 WHEN 2 THEN $2 ELSE $1 END": "pq: unsupported result type: valarg",
-
+		"SELECT CASE 1 WHEN 2 THEN $2 ELSE $1 END": "pq: could not determine data type of parameter $1",
 		"CREATE TABLE $1 (id INT)":  "pq: syntax error at or near \"1\"\nCREATE TABLE $1 (id INT)\n             ^\n",
 		"DROP TABLE t":              "pq: prepare statement not supported: DROP TABLE",
 		"UPDATE d.t SET s = i + $1": "pq: value type int doesn't match type STRING of column \"s\"",

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -177,17 +177,17 @@ func TestPGPrepareFail(t *testing.T) {
 	defer db.Close()
 
 	testFailures := map[string]string{
-		"SELECT $1 = $1":                           "pq: unsupported comparison operator: <valarg> = <valarg>",
+		"SELECT $1 = $1":                           "pq: unsupported comparison operator: <parameter> = <parameter>",
 		"SELECT $1 > 0 AND NOT $1":                 "pq: incompatible NOT argument type: int",
 		"SELECT $1":                                "pq: could not determine data type of parameter $1",
-		"SELECT $1 + $1":                           "pq: unsupported binary operator: <valarg> + <valarg>",
-		"SELECT now() + $1":                        "pq: unsupported binary operator: <timestamp> + <valarg>",
-		"SELECT CASE $1 WHEN 1 THEN 1 END":         "pq: unsupported case expression type: valarg",
-		"SELECT CASE 1 WHEN 2 THEN 1 ELSE $1 END":  "pq: incompatible value types valarg, int",
+		"SELECT $1 + $1":                           "pq: unsupported binary operator: <parameter> + <parameter>",
+		"SELECT now() + $1":                        "pq: unsupported binary operator: <timestamp> + <parameter>",
+		"SELECT CASE $1 WHEN 1 THEN 1 END":         "pq: unsupported case expression type: parameter",
+		"SELECT CASE 1 WHEN 2 THEN 1 ELSE $1 END":  "pq: incompatible value types parameter, int",
 		"SELECT CASE 1 WHEN 2 THEN $2 ELSE $1 END": "pq: could not determine data type of parameter $1",
-		"CREATE TABLE $1 (id INT)":  "pq: syntax error at or near \"1\"\nCREATE TABLE $1 (id INT)\n             ^\n",
-		"DROP TABLE t":              "pq: prepare statement not supported: DROP TABLE",
-		"UPDATE d.t SET s = i + $1": "pq: value type int doesn't match type STRING of column \"s\"",
+		"CREATE TABLE $1 (id INT)":                 "pq: syntax error at or near \"1\"\nCREATE TABLE $1 (id INT)\n             ^\n",
+		"DROP TABLE t":                             "pq: prepare statement not supported: DROP TABLE",
+		"UPDATE d.t SET s = i + $1":                "pq: value type int doesn't match type STRING of column \"s\"",
 	}
 
 	if _, err := db.Exec(`CREATE DATABASE d; CREATE TABLE d.t (i INT, s STRING, d INT)`); err != nil {


### PR DESCRIPTION
Change other cases to return `util.Errorf()`. 

@tamird , does this look good?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4162)

<!-- Reviewable:end -->
