### PR TITLE
Fix cleanup properly

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -83,18 +83,16 @@ func newCLITest() cliTest {
 		security.ClientKeyPath(security.EmbeddedCertsDir, security.NodeUser),
 	}
 
-	cleanups := []func(){}
 	for _, a := range assets {
-		_, cleanupFn := securitytest.RestrictedCopy(nil, a, tempDir, filepath.Base(a))
-		cleanups = append(cleanups, cleanupFn)
+		securitytest.RestrictedCopy(nil, a, tempDir, filepath.Base(a))
 	}
 
 	return cliTest{
 		TestServer: s,
 		certsDir:   tempDir,
 		cleanupFunc: func() {
-			for _, f := range cleanups {
-				f()
+			if err := os.RemoveAll(tempDir); err != nil {
+				log.Fatal(err)
 			}
 		},
 	}

--- a/security/securitytest/securitytest.go
+++ b/security/securitytest/securitytest.go
@@ -33,7 +33,7 @@ import (
 // The file will have restrictive file permissions (0600), making it
 // appropriate for usage by libraries that require security assets to have such
 // restrictive permissions.
-func RestrictedCopy(t util.Tester, path, tempdir, name string) (string, func()) {
+func RestrictedCopy(t util.Tester, path, tempdir, name string) string {
 	contents, err := Asset(path)
 	if err != nil {
 		if t == nil {

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -21,7 +21,6 @@ import (
 	"database/sql"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -38,7 +37,7 @@ func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *sql.DB)) {
 	s := server.StartTestServer(b)
 	defer s.Stop()
 
-	pgUrl, cleanupFn := sqlutils.PGUrl(b, s, security.RootUser, os.TempDir(), "benchmarkCockroach")
+	pgUrl, cleanupFn := sqlutils.PGUrl(b, s, security.RootUser, "benchmarkCockroach")
 	defer cleanupFn()
 
 	db, err := sql.Open("postgres", pgUrl.String())

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -19,7 +19,6 @@ package sql_test
 import (
 	"bytes"
 	"database/sql"
-	"os"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -103,7 +102,7 @@ func setupWithContext(t *testing.T, ctx *server.Context) (*testServer, *sql.DB, 
 	s := setupTestServer(t)
 
 	// SQL requests use "root" which has ALL permissions on everything.
-	url, cleanupFn := sqlutils.PGUrl(t, &s.TestServer, security.RootUser, os.TempDir(), "setupWithContext")
+	url, cleanupFn := sqlutils.PGUrl(t, &s.TestServer, security.RootUser, "setupWithContext")
 	sqlDB, err := sql.Open("postgres", url.String())
 	if err != nil {
 		t.Fatal(err)

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -20,7 +20,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"os"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -40,7 +39,7 @@ func TestLogSplits(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgUrl, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, os.TempDir(), "TestLogSplits")
+	pgUrl, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestLogSplits")
 	defer cleanupFn()
 
 	db, err := sql.Open("postgres", pgUrl.String())
@@ -157,7 +156,7 @@ func TestLogRebalances(t *testing.T) {
 	logEvent(roachpb.REMOVE_REPLICA)
 
 	// Open a SQL connection to verify that the events have been logged.
-	pgUrl, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, os.TempDir(), "TestLogRebalances")
+	pgUrl, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestLogRebalances")
 	defer cleanupFn()
 
 	sqlDB, err := sql.Open("postgres", pgUrl.String())

--- a/util/testing.go
+++ b/util/testing.go
@@ -73,7 +73,7 @@ func CreateTempDir(t Tester, prefix string) string {
 //
 // This is needed for some Go libraries (e.g. postgres SQL driver) which will
 // refuse to open certificate files that have overly permissive permissions.
-func CreateRestrictedFile(t Tester, contents []byte, tempdir, name string) (string, func()) {
+func CreateRestrictedFile(t Tester, contents []byte, tempdir, name string) string {
 	tempPath := filepath.Join(tempdir, name)
 	if err := ioutil.WriteFile(tempPath, contents, 0600); err != nil {
 		if t == nil {
@@ -82,16 +82,7 @@ func CreateRestrictedFile(t Tester, contents []byte, tempdir, name string) (stri
 			t.Fatal(err)
 		}
 	}
-	return tempPath, func() {
-		if err := os.Remove(tempPath); err != nil {
-			// Not Fatal() because we might already be panicking.
-			if t == nil {
-				log.Print(err)
-			} else {
-				t.Error(err)
-			}
-		}
-	}
+	return tempPath
 }
 
 // CreateNTempDirs creates N temporary directories and returns a slice


### PR DESCRIPTION
@bdarnell pointed out that PGUrl reuses filenames, which looks like the result of an accumulation of code movement.

This should fix the races we've been seeing.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4166)

<!-- Reviewable:end -->
