### PR TITLE
More cleanup and simplification of the kv.send interface.

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -19,7 +19,6 @@ package kv
 import (
 	"errors"
 	"fmt"
-	"net"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -127,9 +126,8 @@ type DistSender struct {
 var _ client.Sender = &DistSender{}
 
 // rpcSendFn is the function type used to dispatch RPC calls.
-type rpcSendFn func(SendOptions, []net.Addr,
-	func(i int) *roachpb.BatchRequest,
-	*rpc.Context) (proto.Message, error)
+type rpcSendFn func(SendOptions, ReplicaSlice,
+	roachpb.BatchRequest, *rpc.Context) (proto.Message, error)
 
 // DistSenderContext holds auxiliary objects that can be passed to
 // NewDistSender.
@@ -251,7 +249,7 @@ func (ds *DistSender) FirstRange() (*roachpb.RangeDescriptor, *roachpb.Error) {
 	return rangeDesc, nil
 }
 
-func (ds *DistSender) optimizeReplicaOrder(replicas replicaSlice) orderingPolicy {
+func (ds *DistSender) optimizeReplicaOrder(replicas ReplicaSlice) orderingPolicy {
 	// Unless we know better, send the RPCs randomly.
 	order := orderingPolicy(orderRandom)
 	nodeDesc := ds.getNodeDescriptor()
@@ -311,17 +309,10 @@ func (ds *DistSender) getNodeDescriptor() *roachpb.NodeDescriptor {
 // must succeed. Returns an RPC error if the request could not be sent. Note
 // that the reply may contain a higher level error and must be checked in
 // addition to the RPC error.
-func (ds *DistSender) sendRPC(trace opentracing.Span, rangeID roachpb.RangeID, replicas replicaSlice, order orderingPolicy,
-	ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+func (ds *DistSender) sendRPC(trace opentracing.Span, rangeID roachpb.RangeID, replicas ReplicaSlice,
+	order orderingPolicy, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 	if len(replicas) == 0 {
 		return nil, roachpb.NewError(noNodeAddrsAvailError{})
-	}
-
-	// Build a slice of replica addresses.
-	addrs := make([]net.Addr, 0, len(replicas))
-	for i := range replicas {
-		addr := &replicas[i].NodeDesc.Address
-		addrs = append(addrs, addr)
 	}
 
 	// TODO(pmattis): This needs to be tested. If it isn't set we'll
@@ -336,20 +327,10 @@ func (ds *DistSender) sendRPC(trace opentracing.Span, rangeID roachpb.RangeID, r
 		Timeout:         rpc.DefaultRPCTimeout,
 		Trace:           trace,
 	}
-	getArgs := func(i int) *roachpb.BatchRequest {
-		// Make a shallow copy of our prototype request so that we can set the
-		// replica differently.
-		a := &roachpb.BatchRequest{}
-		*a = ba
-		if i >= 0 {
-			a.Replica = replicas[i].ReplicaDescriptor
-		}
-		return a
-	}
 	tracing.AnnotateTrace()
 	defer tracing.AnnotateTrace()
 
-	reply, err := ds.rpcSend(rpcOpts, addrs, getArgs, ds.rpcContext)
+	reply, err := ds.rpcSend(rpcOpts, replicas, ba, ds.rpcContext)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"net"
 	"reflect"
 	"testing"
 	"time"
@@ -80,21 +79,21 @@ func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
 func TestMoveLocalReplicaToFront(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	testCase := []struct {
-		slice         replicaSlice
+		slice         ReplicaSlice
 		localNodeDesc roachpb.NodeDescriptor
 	}{
 		{
 			// No attribute prefix
-			slice: replicaSlice{
-				replicaInfo{
+			slice: ReplicaSlice{
+				ReplicaInfo{
 					ReplicaDescriptor: roachpb.ReplicaDescriptor{NodeID: 2, StoreID: 2},
 					NodeDesc:          &roachpb.NodeDescriptor{NodeID: 2},
 				},
-				replicaInfo{
+				ReplicaInfo{
 					ReplicaDescriptor: roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3},
 					NodeDesc:          &roachpb.NodeDescriptor{NodeID: 3},
 				},
-				replicaInfo{
+				ReplicaInfo{
 					ReplicaDescriptor: roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 1},
 					NodeDesc:          &roachpb.NodeDescriptor{NodeID: 1},
 				},
@@ -103,16 +102,16 @@ func TestMoveLocalReplicaToFront(t *testing.T) {
 		},
 		{
 			// Sort replicas by attribute
-			slice: replicaSlice{
-				replicaInfo{
+			slice: ReplicaSlice{
+				ReplicaInfo{
 					ReplicaDescriptor: roachpb.ReplicaDescriptor{NodeID: 2, StoreID: 2},
 					NodeDesc:          &roachpb.NodeDescriptor{NodeID: 2, Attrs: roachpb.Attributes{Attrs: []string{"ad"}}},
 				},
-				replicaInfo{
+				ReplicaInfo{
 					ReplicaDescriptor: roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3},
 					NodeDesc:          &roachpb.NodeDescriptor{NodeID: 3, Attrs: roachpb.Attributes{Attrs: []string{"ab", "c"}}},
 				},
-				replicaInfo{
+				ReplicaInfo{
 					ReplicaDescriptor: roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 1},
 					NodeDesc:          &roachpb.NodeDescriptor{NodeID: 1, Attrs: roachpb.Attributes{Attrs: []string{"ab"}}},
 				},
@@ -151,21 +150,21 @@ func TestSendRPCOrder(t *testing.T) {
 	// Gets filled below to identify the replica by its address.
 	addrToNode := make(map[string]int32)
 	makeVerifier := func(expOrder orderingPolicy,
-		expAddrs []int32) func(SendOptions, []net.Addr) error {
-		return func(o SendOptions, addrs []net.Addr) error {
+		expAddrs []int32) func(SendOptions, ReplicaSlice) error {
+		return func(o SendOptions, replicas ReplicaSlice) error {
 			if o.Ordering != expOrder {
 				return util.Errorf("unexpected ordering, wanted %v, got %v",
 					expOrder, o.Ordering)
 			}
 			var actualAddrs []int32
-			for i, a := range addrs {
+			for i, r := range replicas {
 				if len(expAddrs) <= i {
-					return util.Errorf("got unexpected address: %s", a)
+					return util.Errorf("got unexpected address: %s", r.NodeDesc.Address)
 				}
 				if expAddrs[i] == 0 {
 					actualAddrs = append(actualAddrs, 0)
 				} else {
-					actualAddrs = append(actualAddrs, addrToNode[a.String()])
+					actualAddrs = append(actualAddrs, addrToNode[r.NodeDesc.Address.String()])
 				}
 			}
 			if !reflect.DeepEqual(expAddrs, actualAddrs) {
@@ -264,14 +263,14 @@ func TestSendRPCOrder(t *testing.T) {
 	}
 
 	// Stub to be changed in each test case.
-	var verifyCall func(SendOptions, []net.Addr) error
+	var verifyCall func(SendOptions, ReplicaSlice) error
 
-	var testFn rpcSendFn = func(opts SendOptions, addrs []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
-		if err := verifyCall(opts, addrs); err != nil {
+	var testFn rpcSendFn = func(opts SendOptions, replicas ReplicaSlice,
+		args roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+		if err := verifyCall(opts, replicas); err != nil {
 			return nil, err
 		}
-		return getArgs(0).CreateReply(), nil
+		return args.CreateReply(), nil
 	}
 
 	ctx := &DistSenderContext{
@@ -382,9 +381,8 @@ func TestOwnNodeCertain(t *testing.T) {
 	}
 
 	var act roachpb.NodeList
-	var testFn rpcSendFn = func(_ SendOptions, _ []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
-		ba := getArgs(-1)
+	var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+		ba roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
 		for _, nodeID := range ba.Txn.CertainNodes.Nodes {
 			act.Add(roachpb.NodeID(nodeID))
 		}
@@ -423,8 +421,8 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 	}
 	first := true
 
-	var testFn rpcSendFn = func(_ SendOptions, _ []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+	var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+		args roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
 		if first {
 			reply := &roachpb.BatchResponse{}
 			reply.SetGoError(
@@ -432,7 +430,7 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 			first = false
 			return reply, nil
 		}
-		return getArgs(-1).CreateReply(), nil
+		return args.CreateReply(), nil
 	}
 
 	ctx := &DistSenderContext{
@@ -463,9 +461,9 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 	g, s := makeTestGossip(t)
 	defer s()
 
-	var testFn rpcSendFn = func(_ SendOptions, _ []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
-		return getArgs(-1).CreateReply(), nil
+	var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+		args roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+		return args.CreateReply(), nil
 	}
 
 	pErrs := []*roachpb.Error{
@@ -523,10 +521,10 @@ func TestEvictCacheOnError(t *testing.T) {
 		}
 		first := true
 
-		var testFn rpcSendFn = func(_ SendOptions, _ []net.Addr,
-			getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+		var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+			args roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
 			if !first {
-				return getArgs(-1).CreateReply(), nil
+				return args.CreateReply(), nil
 			}
 			first = false
 			if tc.rpcError {
@@ -580,10 +578,9 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 	newRangeDescriptor.StartKey = badStartKey
 	descStale := true
 
-	var testFn rpcSendFn = func(_ SendOptions, _ []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
-		ba := getArgs(0)
-		rs := keys.Range(*ba)
+	var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+		ba roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+		rs := keys.Range(ba)
 		if _, ok := ba.GetArg(roachpb.RangeLookup); ok {
 			if !descStale && bytes.HasPrefix(rs.Key, keys.Meta2Prefix) {
 				t.Errorf("unexpected extra lookup for non-stale replica descriptor at %s",
@@ -692,8 +689,8 @@ func TestSendRPCRetry(t *testing.T) {
 			StoreID: roachpb.StoreID(i),
 		})
 	}
-	var testFn rpcSendFn = func(_ SendOptions, _ []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+	var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+		args roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
 		batchReply := &roachpb.BatchResponse{}
 		reply := &roachpb.ScanResponse{}
 		batchReply.Add(reply)
@@ -778,10 +775,9 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 		{Key: roachpb.Key("a"), Value: roachpb.MakeValueFromString("1")},
 		{Key: roachpb.Key("c"), Value: roachpb.MakeValueFromString("2")},
 	}
-	var testFn rpcSendFn = func(_ SendOptions, _ []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
-		ba := getArgs(0)
-		rs := keys.Range(*ba)
+	var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+		ba roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+		rs := keys.Range(ba)
 		batchReply := &roachpb.BatchResponse{}
 		reply := &roachpb.ScanResponse{}
 		batchReply.Add(reply)
@@ -827,9 +823,9 @@ func TestRangeLookupOptionOnReverseScan(t *testing.T) {
 	g, s := makeTestGossip(t)
 	defer s()
 
-	var testFn rpcSendFn = func(_ SendOptions, _ []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
-		return getArgs(-1).CreateReply(), nil
+	var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+		args roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+		return args.CreateReply(), nil
 	}
 
 	ctx := &DistSenderContext{
@@ -907,10 +903,9 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 	// requests. The first request should be the point request on
 	// "a". The second request should be on "b".
 	first := true
-	var testFn rpcSendFn = func(_ SendOptions, _ []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
-		ba := getArgs(0)
-		rs := keys.Range(*ba)
+	var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+		ba roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+		rs := keys.Range(ba)
 		if first {
 			if !(rs.Key.Equal(roachpb.RKey("a")) && rs.EndKey.Equal(roachpb.RKey("a").Next())) {
 				t.Errorf("Unexpected span [%s,%s)", rs.Key, rs.EndKey)
@@ -1018,10 +1013,9 @@ func TestSequenceUpdateOnMultiRangeQueryLoop(t *testing.T) {
 	// first request.
 	first := true
 	var firstSequence uint32
-	var testFn rpcSendFn = func(_ SendOptions, _ []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
-		ba := getArgs(0)
-		rs := keys.Range(*ba)
+	var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+		ba roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+		rs := keys.Range(ba)
 		if first {
 			if !(rs.Key.Equal(roachpb.RKey("a")) && rs.EndKey.Equal(roachpb.RKey("a").Next())) {
 				t.Errorf("unexpected span [%s,%s)", rs.Key, rs.EndKey)
@@ -1139,9 +1133,8 @@ func TestMultiRangeSplitEndTransaction(t *testing.T) {
 
 	for _, test := range testCases {
 		var act [][]roachpb.Method
-		var testFn rpcSendFn = func(_ SendOptions, _ []net.Addr,
-			ga func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
-			ba := ga(0)
+		var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+			ba roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
 			var cur []roachpb.Method
 			for _, union := range ba.Requests {
 				cur = append(cur, union.GetInner().Method())

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -79,12 +79,12 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 
 	ltc.stores = storage.NewStores(ltc.Clock)
 	var rpcSend rpcSendFn = func(_ SendOptions, _ []net.Addr,
-		getArgs func(addr net.Addr) *roachpb.BatchRequest,
+		getArgs func(i int) *roachpb.BatchRequest,
 		_ *rpc.Context) (proto.Message, error) {
 		if ltc.Latency > 0 {
 			time.Sleep(ltc.Latency)
 		}
-		br, pErr := ltc.stores.Send(context.Background(), *getArgs(nil))
+		br, pErr := ltc.stores.Send(context.Background(), *getArgs(-1))
 		if br == nil {
 			br = &roachpb.BatchResponse{}
 		}

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -17,7 +17,6 @@
 package kv
 
 import (
-	"net"
 	"time"
 
 	"golang.org/x/net/context"
@@ -78,13 +77,12 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20, ltc.Stopper)
 
 	ltc.stores = storage.NewStores(ltc.Clock)
-	var rpcSend rpcSendFn = func(_ SendOptions, _ []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest,
-		_ *rpc.Context) (proto.Message, error) {
+	var rpcSend rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+		args roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
 		if ltc.Latency > 0 {
 			time.Sleep(ltc.Latency)
 		}
-		br, pErr := ltc.stores.Send(context.Background(), *getArgs(-1))
+		br, pErr := ltc.stores.Send(context.Background(), args)
 		if br == nil {
 			br = &roachpb.BatchResponse{}
 		}

--- a/kv/replica_slice.go
+++ b/kv/replica_slice.go
@@ -25,28 +25,28 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-// replicaInfo extends the Replica structure with the associated node
+// ReplicaInfo extends the Replica structure with the associated node
 // descriptor.
-type replicaInfo struct {
+type ReplicaInfo struct {
 	roachpb.ReplicaDescriptor
 	NodeDesc *roachpb.NodeDescriptor
 }
 
-func (i replicaInfo) attrs() []string {
+func (i ReplicaInfo) attrs() []string {
 	return i.NodeDesc.Attrs.Attrs
 }
 
-// A replicaSlice is a slice of replicaInfo.
-type replicaSlice []replicaInfo
+// A ReplicaSlice is a slice of ReplicaInfo.
+type ReplicaSlice []ReplicaInfo
 
-// newReplicaSlice creates a replicaSlice from the replicas listed in the range
+// newReplicaSlice creates a ReplicaSlice from the replicas listed in the range
 // descriptor and using gossip to lookup node descriptors. Replicas on nodes
 // that are not gossipped are omitted from the result.
-func newReplicaSlice(gossip *gossip.Gossip, desc *roachpb.RangeDescriptor) replicaSlice {
+func newReplicaSlice(gossip *gossip.Gossip, desc *roachpb.RangeDescriptor) ReplicaSlice {
 	if gossip == nil {
 		return nil
 	}
-	replicas := make(replicaSlice, 0, len(desc.Replicas))
+	replicas := make(ReplicaSlice, 0, len(desc.Replicas))
 	for _, r := range desc.Replicas {
 		nd, err := gossip.GetNodeDescriptor(r.NodeID)
 		if err != nil {
@@ -55,7 +55,7 @@ func newReplicaSlice(gossip *gossip.Gossip, desc *roachpb.RangeDescriptor) repli
 			}
 			continue
 		}
-		replicas = append(replicas, replicaInfo{
+		replicas = append(replicas, ReplicaInfo{
 			ReplicaDescriptor: r,
 			NodeDesc:          nd,
 		})
@@ -64,13 +64,13 @@ func newReplicaSlice(gossip *gossip.Gossip, desc *roachpb.RangeDescriptor) repli
 }
 
 // Swap interchanges the replicas stored at the given indices.
-func (rs replicaSlice) Swap(i, j int) {
+func (rs ReplicaSlice) Swap(i, j int) {
 	rs[i], rs[j] = rs[j], rs[i]
 }
 
 // FindReplica returns the index of the replica which matches the specified store
 // ID. If no replica matches, -1 is returned.
-func (rs replicaSlice) FindReplica(storeID roachpb.StoreID) int {
+func (rs ReplicaSlice) FindReplica(storeID roachpb.StoreID) int {
 	for i := range rs {
 		if rs[i].StoreID == storeID {
 			return i
@@ -81,7 +81,7 @@ func (rs replicaSlice) FindReplica(storeID roachpb.StoreID) int {
 
 // FindReplicaByNodeID returns the index of the replica which matches the specified node
 // ID. If no replica matches, -1 is returned.
-func (rs replicaSlice) FindReplicaByNodeID(nodeID roachpb.NodeID) int {
+func (rs ReplicaSlice) FindReplicaByNodeID(nodeID roachpb.NodeID) int {
 	for i := range rs {
 		if rs[i].NodeID == nodeID {
 			return i
@@ -90,14 +90,14 @@ func (rs replicaSlice) FindReplicaByNodeID(nodeID roachpb.NodeID) int {
 	return -1
 }
 
-// SortByCommonAttributePrefix rearranges the replicaSlice by comparing the
+// SortByCommonAttributePrefix rearranges the ReplicaSlice by comparing the
 // attributes to the given reference attributes. The basis for the comparison
 // is that of the common prefix of replica attributes (i.e. the number of equal
 // attributes, starting at the first), with a longer prefix sorting first. The
 // number of attributes successfully matched to at least one replica is
-// returned (hence, if the return value equals the length of the replicaSlice,
+// returned (hence, if the return value equals the length of the ReplicaSlice,
 // at least one replica matched all attributes).
-func (rs replicaSlice) SortByCommonAttributePrefix(attrs []string) int {
+func (rs ReplicaSlice) SortByCommonAttributePrefix(attrs []string) int {
 	if len(rs) < 2 {
 		return 0
 	}
@@ -127,7 +127,7 @@ func (rs replicaSlice) SortByCommonAttributePrefix(attrs []string) int {
 // MoveToFront moves the replica at the given index to the front
 // of the slice, keeping the order of the remaining elements stable.
 // The function will panic when invoked with an invalid index.
-func (rs replicaSlice) MoveToFront(i int) {
+func (rs ReplicaSlice) MoveToFront(i int) {
 	if i >= len(rs) {
 		panic("out of bound index")
 	}
@@ -137,7 +137,7 @@ func (rs replicaSlice) MoveToFront(i int) {
 	rs[0] = front
 }
 
-func (rs replicaSlice) randPerm(startIndex int, topIndex int, intnFn func(int) int) {
+func (rs ReplicaSlice) randPerm(startIndex int, topIndex int, intnFn func(int) int) {
 	length := topIndex - startIndex + 1
 	for i := 1; i < length; i++ {
 		j := intnFn(i + 1)

--- a/kv/replica_slice_test.go
+++ b/kv/replica_slice_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
-func verifyOrdering(attrs []string, replicas replicaSlice, prefixLen int) bool {
+func verifyOrdering(attrs []string, replicas ReplicaSlice, prefixLen int) bool {
 	prevMatchIndex := len(attrs)
 	for i, replica := range replicas {
 		matchIndex := -1
@@ -66,9 +66,9 @@ func TestReplicaSetSortByCommonAttributePrefix(t *testing.T) {
 	}
 
 	for i, attr := range attrs {
-		rs := replicaSlice{}
+		rs := ReplicaSlice{}
 		for _, c := range replicaAttrs {
-			rs = append(rs, replicaInfo{
+			rs = append(rs, ReplicaInfo{
 				NodeDesc: &roachpb.NodeDescriptor{
 					Attrs: roachpb.Attributes{Attrs: c},
 				},
@@ -81,17 +81,17 @@ func TestReplicaSetSortByCommonAttributePrefix(t *testing.T) {
 	}
 }
 
-func getStores(rs replicaSlice) (r []roachpb.StoreID) {
+func getStores(rs ReplicaSlice) (r []roachpb.StoreID) {
 	for i := range rs {
 		r = append(r, rs[i].StoreID)
 	}
 	return
 }
 
-func createReplicaSlice() replicaSlice {
-	rs := replicaSlice(nil)
+func createReplicaSlice() ReplicaSlice {
+	rs := ReplicaSlice(nil)
 	for i := 0; i < 5; i++ {
-		rs = append(rs, replicaInfo{ReplicaDescriptor: roachpb.ReplicaDescriptor{StoreID: roachpb.StoreID(i + 1)}})
+		rs = append(rs, ReplicaInfo{ReplicaDescriptor: roachpb.ReplicaDescriptor{StoreID: roachpb.StoreID(i + 1)}})
 	}
 	return rs
 }

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -181,12 +181,12 @@ func TestUnretryableError(t *testing.T) {
 		SendNextTimeout: 1 * time.Second,
 		Timeout:         10 * time.Second,
 	}
-	getArgs := func(addr net.Addr) *roachpb.BatchRequest {
+	getArgs := func(i int) *roachpb.BatchRequest {
 		return &roachpb.BatchRequest{}
 	}
 
-	sendOneFn = func(client *rpc.Client, timeout time.Duration,
-		getArgs func(addr net.Addr) *roachpb.BatchRequest,
+	sendOneFn = func(client rpcClient, timeout time.Duration,
+		getArgs func(i int) *roachpb.BatchRequest,
 		context *rpc.Context, trace opentracing.Span, done chan *netrpc.Call) {
 		call := netrpc.Call{
 			Reply: &roachpb.BatchResponse{},
@@ -320,13 +320,13 @@ func TestComplexScenarios(t *testing.T) {
 			SendNextTimeout: 1 * time.Second,
 			Timeout:         10 * time.Second,
 		}
-		getArgs := func(addr net.Addr) *roachpb.BatchRequest {
+		getArgs := func(i int) *roachpb.BatchRequest {
 			return &roachpb.BatchRequest{}
 		}
 
 		// Mock sendOne.
-		sendOneFn = func(client *rpc.Client, timeout time.Duration,
-			getArgs func(addr net.Addr) *roachpb.BatchRequest,
+		sendOneFn = func(client rpcClient, timeout time.Duration,
+			getArgs func(i int) *roachpb.BatchRequest,
 			context *rpc.Context, trace opentracing.Span, done chan *netrpc.Call) {
 			addr := client.RemoteAddr()
 			addrID := -1
@@ -374,7 +374,7 @@ func sendBatch(opts SendOptions, addrs []net.Addr, rpcContext *rpc.Context) (pro
 
 func sendRPC(opts SendOptions, addrs []net.Addr, rpcContext *rpc.Context,
 	args *roachpb.BatchRequest) (proto.Message, error) {
-	getArgs := func(addr net.Addr) *roachpb.BatchRequest {
+	getArgs := func(i int) *roachpb.BatchRequest {
 		return args
 	}
 	return send(opts, addrs, getArgs, rpcContext)

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -182,7 +182,7 @@ func TestUnretryableError(t *testing.T) {
 		Timeout:         10 * time.Second,
 	}
 
-	sendOneFn = func(client rpcClient, args roachpb.BatchRequest, timeout time.Duration,
+	sendOneFn = func(client *batchClient, timeout time.Duration,
 		context *rpc.Context, trace opentracing.Span, done chan *netrpc.Call) {
 		call := netrpc.Call{
 			Reply: &roachpb.BatchResponse{},
@@ -318,7 +318,7 @@ func TestComplexScenarios(t *testing.T) {
 		}
 
 		// Mock sendOne.
-		sendOneFn = func(client rpcClient, args roachpb.BatchRequest, timeout time.Duration,
+		sendOneFn = func(client *batchClient, timeout time.Duration,
 			context *rpc.Context, trace opentracing.Span, done chan *netrpc.Call) {
 			addr := client.RemoteAddr()
 			addrID := -1

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -83,13 +83,13 @@ func (n Node) Batch(args proto.Message) (proto.Message, error) {
 func TestInvalidAddrLength(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
-	// The provided addrs is nil, so its length will be always
-	// less than the specified response number
-	ret, err := send(SendOptions{}, nil, nil, nil)
+	// The provided replicas is nil, so its length will be always less than the
+	// specified response number
+	ret, err := send(SendOptions{}, nil, roachpb.BatchRequest{}, nil)
 
 	// the expected return is nil and SendError
 	if _, ok := err.(*roachpb.SendError); !ok || ret != nil {
-		t.Fatalf("Shorter addrs should return nil and SendError.")
+		t.Fatalf("Shorter replicas should return nil and SendError.")
 	}
 }
 
@@ -181,12 +181,8 @@ func TestUnretryableError(t *testing.T) {
 		SendNextTimeout: 1 * time.Second,
 		Timeout:         10 * time.Second,
 	}
-	getArgs := func(i int) *roachpb.BatchRequest {
-		return &roachpb.BatchRequest{}
-	}
 
-	sendOneFn = func(client rpcClient, timeout time.Duration,
-		getArgs func(i int) *roachpb.BatchRequest,
+	sendOneFn = func(client rpcClient, args roachpb.BatchRequest, timeout time.Duration,
 		context *rpc.Context, trace opentracing.Span, done chan *netrpc.Call) {
 		call := netrpc.Call{
 			Reply: &roachpb.BatchResponse{},
@@ -196,7 +192,7 @@ func TestUnretryableError(t *testing.T) {
 	}
 	defer func() { sendOneFn = sendOne }()
 
-	_, err := send(opts, []net.Addr{ln.Addr()}, getArgs, nodeContext)
+	_, err := sendBatch(opts, []net.Addr{ln.Addr()}, nodeContext)
 	if err == nil {
 		t.Fatalf("Unexpected success")
 	}
@@ -320,13 +316,9 @@ func TestComplexScenarios(t *testing.T) {
 			SendNextTimeout: 1 * time.Second,
 			Timeout:         10 * time.Second,
 		}
-		getArgs := func(i int) *roachpb.BatchRequest {
-			return &roachpb.BatchRequest{}
-		}
 
 		// Mock sendOne.
-		sendOneFn = func(client rpcClient, timeout time.Duration,
-			getArgs func(i int) *roachpb.BatchRequest,
+		sendOneFn = func(client rpcClient, args roachpb.BatchRequest, timeout time.Duration,
 			context *rpc.Context, trace opentracing.Span, done chan *netrpc.Call) {
 			addr := client.RemoteAddr()
 			addrID := -1
@@ -349,7 +341,7 @@ func TestComplexScenarios(t *testing.T) {
 		}
 		defer func() { sendOneFn = sendOne }()
 
-		reply, err := send(opts, serverAddrs, getArgs, nodeContext)
+		reply, err := sendBatch(opts, serverAddrs, nodeContext)
 		if test.success {
 			if reply == nil {
 				t.Errorf("%d: expected reply", i)
@@ -367,15 +359,17 @@ func TestComplexScenarios(t *testing.T) {
 	}
 }
 
-// sendBatch sends Batch requests to specified addresses using send.
-func sendBatch(opts SendOptions, addrs []net.Addr, rpcContext *rpc.Context) (proto.Message, error) {
-	return sendRPC(opts, addrs, rpcContext, &roachpb.BatchRequest{})
+func makeReplicas(addrs ...net.Addr) ReplicaSlice {
+	replicas := make(ReplicaSlice, len(addrs))
+	for i, addr := range addrs {
+		replicas[i].NodeDesc = &roachpb.NodeDescriptor{
+			Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),
+		}
+	}
+	return replicas
 }
 
-func sendRPC(opts SendOptions, addrs []net.Addr, rpcContext *rpc.Context,
-	args *roachpb.BatchRequest) (proto.Message, error) {
-	getArgs := func(i int) *roachpb.BatchRequest {
-		return args
-	}
-	return send(opts, addrs, getArgs, rpcContext)
+// sendBatch sends Batch requests to specified addresses using send.
+func sendBatch(opts SendOptions, addrs []net.Addr, rpcContext *rpc.Context) (proto.Message, error) {
+	return send(opts, makeReplicas(addrs...), roachpb.BatchRequest{}, rpcContext)
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"net"
 	"reflect"
 	"sort"
 	"strconv"
@@ -102,14 +101,12 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	sCtx.ScanMaxIdleTime = splitTimeout / 10
 	sCtx.Tracer = tracing.NewTracer()
 	stores := storage.NewStores(clock)
-	rpcSend := func(_ kv.SendOptions, _ []net.Addr,
-		getArgs func(i int) *roachpb.BatchRequest,
-		_ *rpc.Context) (proto.Message, error) {
-		ba := getArgs(-1 /* index */)
+	rpcSend := func(_ kv.SendOptions, _ kv.ReplicaSlice,
+		ba roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
 		sp := sCtx.Tracer.StartTrace(ba.TraceID())
 		defer sp.Finish()
 		ctx, _ := opentracing.ContextWithSpan(context.Background(), sp)
-		br, pErr := stores.Send(ctx, *ba)
+		br, pErr := stores.Send(ctx, ba)
 		if br == nil {
 			br = &roachpb.BatchResponse{}
 		}
@@ -301,8 +298,8 @@ func (m *multiTestContext) Stop() {
 // used to multiplex calls between many local senders in a simple way; It sends
 // the request to multiTestContext's localSenders specified in addrs. The request is
 // sent in order until no error is returned.
-func (m *multiTestContext) rpcSend(_ kv.SendOptions, addrs []net.Addr,
-	getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+func (m *multiTestContext) rpcSend(_ kv.SendOptions, replicas kv.ReplicaSlice,
+	args roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	fail := func(pErr *roachpb.Error) (proto.Message, error) {
@@ -312,10 +309,10 @@ func (m *multiTestContext) rpcSend(_ kv.SendOptions, addrs []net.Addr,
 	}
 	var br *roachpb.BatchResponse
 	var pErr *roachpb.Error
-	for _, addr := range addrs {
-		ba := *getArgs(-1 /* index */)
+	for _, replica := range replicas {
+		ba := *proto.Clone(&args).(*roachpb.BatchRequest)
 		// Node ID is encoded in the address.
-		nodeID, stErr := strconv.Atoi(addr.String())
+		nodeID, stErr := strconv.Atoi(replica.NodeDesc.Address.String())
 		if stErr != nil {
 			m.t.Fatal(stErr)
 		}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -103,9 +103,9 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	sCtx.Tracer = tracing.NewTracer()
 	stores := storage.NewStores(clock)
 	rpcSend := func(_ kv.SendOptions, _ []net.Addr,
-		getArgs func(addr net.Addr) *roachpb.BatchRequest,
+		getArgs func(i int) *roachpb.BatchRequest,
 		_ *rpc.Context) (proto.Message, error) {
-		ba := getArgs(nil /* net.Addr */)
+		ba := getArgs(-1 /* index */)
 		sp := sCtx.Tracer.StartTrace(ba.TraceID())
 		defer sp.Finish()
 		ctx, _ := opentracing.ContextWithSpan(context.Background(), sp)
@@ -302,7 +302,7 @@ func (m *multiTestContext) Stop() {
 // the request to multiTestContext's localSenders specified in addrs. The request is
 // sent in order until no error is returned.
 func (m *multiTestContext) rpcSend(_ kv.SendOptions, addrs []net.Addr,
-	getArgs func(addr net.Addr) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
+	getArgs func(i int) *roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	fail := func(pErr *roachpb.Error) (proto.Message, error) {
@@ -313,7 +313,7 @@ func (m *multiTestContext) rpcSend(_ kv.SendOptions, addrs []net.Addr,
 	var br *roachpb.BatchResponse
 	var pErr *roachpb.Error
 	for _, addr := range addrs {
-		ba := *getArgs(nil /* net.Addr */)
+		ba := *getArgs(-1 /* index */)
 		// Node ID is encoded in the address.
 		nodeID, stErr := strconv.Atoi(addr.String())
 		if stErr != nil {


### PR DESCRIPTION
Besides the simplification, this is a (very) small performance win. I
Need to figure out what is causing the variation in the Bank benchmark
timings. It definitely didn't get slower due to this change. Perhaps
transaction restarts when operations collide.

```
name                   old time/op    new time/op    delta
Bank_Cockroach-8          166µs ±15%     177µs ±14%    ~      (p=0.079 n=10+9)
Insert1_Cockroach-8       382µs ± 1%     376µs ± 1%  -1.47%  (p=0.000 n=10+10)
Insert10_Cockroach-8      775µs ± 2%     760µs ± 2%  -1.90%  (p=0.003 n=10+10)
Insert100_Cockroach-8    4.11ms ± 1%    4.07ms ± 1%  -1.08%   (p=0.003 n=10+9)
Update1_Cockroach-8       870µs ± 1%     855µs ± 1%  -1.73%  (p=0.000 n=10+10)
Update10_Cockroach-8     4.75ms ± 1%    4.59ms ± 1%  -3.22%   (p=0.000 n=9+10)
Update100_Cockroach-8    42.8ms ± 1%    40.9ms ± 0%  -4.52%   (p=0.000 n=10+8)
Delete1_Cockroach-8      1.20ms ± 1%    1.18ms ± 1%  -2.15%  (p=0.000 n=10+10)
Delete10_Cockroach-8     1.93ms ± 1%    1.91ms ± 2%  -1.28%  (p=0.004 n=10+10)
Delete100_Cockroach-8    10.7ms ± 1%    10.7ms ± 2%    ~      (p=0.182 n=9+10)
Scan1_Cockroach-8         187µs ± 1%     183µs ± 1%  -2.14%  (p=0.000 n=10+10)
Scan10_Cockroach-8        228µs ± 1%     224µs ± 1%  -1.93%  (p=0.000 n=10+10)
Scan100_Cockroach-8       612µs ± 4%     598µs ± 2%  -2.28%  (p=0.002 n=10+10)

name                   old allocs/op  new allocs/op  delta
Bank_Cockroach-8            624 ± 1%       617 ± 1%  -1.17%   (p=0.000 n=9+10)
Insert1_Cockroach-8         486 ± 0%       481 ± 0%  -1.07%   (p=0.000 n=6+10)
Insert10_Cockroach-8      1.13k ± 0%     1.12k ± 0%  -0.49%  (p=0.000 n=10+10)
Insert100_Cockroach-8     7.32k ± 0%     7.32k ± 0%  -0.08%  (p=0.000 n=10+10)
Update1_Cockroach-8       1.10k ± 0%     1.08k ± 0%  -1.37%  (p=0.000 n=10+10)
Update10_Cockroach-8      7.36k ± 0%     7.26k ± 0%  -1.43%    (p=0.000 n=9+8)
Update100_Cockroach-8     69.9k ± 0%     68.9k ± 0%  -1.45%  (p=0.000 n=10+10)
Delete1_Cockroach-8       1.05k ± 0%     1.03k ± 0%  -1.37%   (p=0.000 n=7+10)
Delete10_Cockroach-8      2.53k ± 0%     2.51k ± 0%  -0.63%  (p=0.000 n=10+10)
Delete100_Cockroach-8     16.6k ± 0%     16.6k ± 0%  -0.08%   (p=0.000 n=10+8)
Scan1_Cockroach-8           297 ± 0%       292 ± 0%  -1.75%  (p=0.000 n=10+10)
Scan10_Cockroach-8          388 ± 0%       383 ± 0%  -1.24%  (p=0.000 n=10+10)
Scan100_Cockroach-8       1.12k ± 0%     1.12k ± 0%  -0.40%   (p=0.000 n=10+8)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4167)

<!-- Reviewable:end -->
