### PR TITLE
testutils: depend on testing

### DIFF
--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/acceptance/terrafarm"
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/caller"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/randutil"
@@ -143,7 +142,7 @@ func SkipUnlessLocal(t *testing.T) {
 	}
 }
 
-func makeClient(t util.Tester, str string) (*client.DB, *stop.Stopper) {
+func makeClient(t *testing.T, str string) (*client.DB, *stop.Stopper) {
 	stopper := stop.NewStopper()
 	db, err := client.Open(stopper, str)
 	if err != nil {
@@ -152,7 +151,7 @@ func makeClient(t util.Tester, str string) (*client.DB, *stop.Stopper) {
 	return db, stopper
 }
 
-func makePGClient(t util.Tester, dest string) *sql.DB {
+func makePGClient(t *testing.T, dest string) *sql.DB {
 	db, err := sql.Open("postgres", dest)
 	if err != nil {
 		t.Fatal(err)

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -20,6 +20,7 @@ package acceptance
 
 import (
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
@@ -38,7 +39,7 @@ func countRangeReplicas(db *client.DB) (int, error) {
 	return len(desc.Replicas), nil
 }
 
-func checkRangeReplication(t util.Tester, c cluster.Cluster, d time.Duration) {
+func checkRangeReplication(t *testing.T, c cluster.Cluster, d time.Duration) {
 	// Always talk to node 0.
 	client, dbStopper := makeClient(t, c.ConnString(0))
 	defer dbStopper.Stop()

--- a/security/securitytest/securitytest.go
+++ b/security/securitytest/securitytest.go
@@ -18,6 +18,8 @@
 package securitytest
 
 import (
+	"testing"
+
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -33,7 +35,7 @@ import (
 // The file will have restrictive file permissions (0600), making it
 // appropriate for usage by libraries that require security assets to have such
 // restrictive permissions.
-func RestrictedCopy(t util.Tester, path, tempdir, name string) string {
+func RestrictedCopy(t testing.TB, path, tempdir, name string) string {
 	contents, err := Asset(path)
 	if err != nil {
 		if t == nil {

--- a/ts/server_test.go
+++ b/ts/server_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/server"
-	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/ts"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -138,7 +137,7 @@ func TestHttpQuery(t *testing.T) {
 	}
 
 	response := &ts.TimeSeriesQueryResponse{}
-	session := testutils.NewTestHTTPSession(t, &base.Context{}, tsrv.ServingAddr())
+	session := newTestHTTPSession(t, &base.Context{}, tsrv.ServingAddr())
 	session.PostProto(ts.URLQuery, &ts.TimeSeriesQueryRequest{
 		StartNanos: 500 * 1e9,
 		EndNanos:   526 * 1e9,


### PR DESCRIPTION
This establishes testutils as a package that is not linked into
non-test code.

This is implicitly assumed in #4173.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4174)

<!-- Reviewable:end -->
