### PR TITLE
reduce timer object creation to reduce gc overhead

### DIFF
--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -159,11 +159,13 @@ func (t *rpcTransport) processQueue(nodeID roachpb.NodeID, storeID roachpb.Store
 	done := make(chan *gorpc.Call, cap(ch))
 	var req *storage.RaftMessageRequest
 	protoResp := &storage.RaftMessageResponse{}
+	raftIdleTimer := time.NewTimer(raftIdleTimeout)
 	for {
+		raftIdleTimer.Reset(raftIdleTimeout)
 		select {
 		case <-t.rpcContext.Stopper.ShouldStop():
 			return
-		case <-time.After(raftIdleTimeout):
+		case <-raftIdleTimer.C:
 			if log.V(1) {
 				log.Infof("closing Raft transport to %d due to inactivity", nodeID)
 			}


### PR DESCRIPTION
by start 3 nodes with GODEBUG=memprofilerate=1, and using 

```
http://host:port/debug/pprof/heap?debug=1
```

will found heavy timer object creation

```
1604: 102656 [4251: 272064] @ 0x9cb15c 0x9cb451 0xa0b681 0x94dcd1
#   0x9cb15c    time.NewTimer+0x6c                              /usr/local/go/src/time/sleep.go:74
#   0x9cb451    time.After+0x21                                 /usr/local/go/src/time/sleep.go:110
#   0xa0b681    github.com/cockroachdb/cockroach/server.(*rpcTransport).processQueue+0x781  /cockroach/src/github.com/cockroachdb/cockroach/server/raft_transport.go:166
```

This creation can be done only once.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4175)

<!-- Reviewable:end -->
