### PR TITLE
sql: [Tiny fix] Remove error from the return value of fillDefaults

### DIFF
--- a/sql/insert.go
+++ b/sql/insert.go
@@ -109,9 +109,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 	}
 
 	// Replace any DEFAULT markers with the corresponding default expressions.
-	if n.Rows, pErr = p.fillDefaults(defaultExprs, cols, n); pErr != nil {
-		return nil, pErr
-	}
+	n.Rows = p.fillDefaults(defaultExprs, cols, n)
 
 	// Transform the values into a rows object. This expands SELECT statements or
 	// generates rows from the values contained within the query.
@@ -297,7 +295,7 @@ func (p *planner) processColumns(tableDesc *TableDescriptor,
 }
 
 func (p *planner) fillDefaults(defaultExprs []parser.Expr,
-	cols []ColumnDescriptor, n *parser.Insert) (parser.SelectStatement, *roachpb.Error) {
+	cols []ColumnDescriptor, n *parser.Insert) parser.SelectStatement {
 	if n.DefaultValues() {
 		row := make(parser.Tuple, 0, len(cols))
 		for i := range cols {
@@ -307,7 +305,7 @@ func (p *planner) fillDefaults(defaultExprs []parser.Expr,
 			}
 			row = append(row, defaultExprs[i])
 		}
-		return parser.Values{row}, nil
+		return parser.Values{row}
 	}
 
 	switch values := n.Rows.(type) {
@@ -325,7 +323,7 @@ func (p *planner) fillDefaults(defaultExprs []parser.Expr,
 			}
 		}
 	}
-	return n.Rows, nil
+	return n.Rows
 }
 
 func (p *planner) makeDefaultExprs(cols []ColumnDescriptor) ([]parser.Expr, error) {


### PR DESCRIPTION
It was always nil.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4176)

<!-- Reviewable:end -->
