### PR TITLE
Custom code Transaction.Clone.

### DIFF
--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -88,7 +88,7 @@ func newTestSender(pre, post func(roachpb.BatchRequest) (*roachpb.BatchResponse,
 				status = roachpb.ABORTED
 			}
 		}
-		br.Txn = proto.Clone(ba.Txn).(*roachpb.Transaction)
+		br.Txn = ba.Txn.Clone()
 		if br.Txn != nil && pErr == nil {
 			br.Txn.Writing = writing
 			br.Txn.Status = status
@@ -157,8 +157,7 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 func TestTxnResetTxnOnAbort(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	db := newDB(newTestSender(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		return nil, roachpb.NewErrorWithTxn(&roachpb.TransactionAbortedError{},
-			proto.Clone(ba.Txn).(*roachpb.Transaction))
+		return nil, roachpb.NewErrorWithTxn(&roachpb.TransactionAbortedError{}, ba.Txn)
 	}, nil))
 
 	txn := NewTxn(*db)

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -583,9 +583,46 @@ func NewTransaction(name string, baseKey Key, userPriority UserPriority,
 	}
 }
 
-// Clone creates a deep copy of the given transaction.
+func (t *Transaction) cloneValue() Transaction {
+	// We explicitly list the fields we're cloning so that addition of a new
+	// field will cause TestTransactionClone to fail and require this method to
+	// be fixed. Note that we're not performing a deep-copy of Key and ID as
+	// these fields are immutable for the lifetime of a transaction.
+	v := Transaction{
+		Name:          t.Name,
+		Key:           t.Key,
+		ID:            t.ID,
+		Priority:      t.Priority,
+		Isolation:     t.Isolation,
+		Status:        t.Status,
+		Epoch:         t.Epoch,
+		Timestamp:     t.Timestamp,
+		OrigTimestamp: t.OrigTimestamp,
+		MaxTimestamp:  t.MaxTimestamp,
+		Writing:       t.Writing,
+		Sequence:      t.Sequence,
+	}
+	if t.LastHeartbeat != nil {
+		h := *t.LastHeartbeat
+		v.LastHeartbeat = &h
+	}
+	v.CertainNodes.Nodes = append([]NodeID(nil), t.CertainNodes.Nodes...)
+	// Note that we're not cloning the span keys under the assumption that the
+	// keys themselves are not mutable.
+	v.Intents = append([]Span(nil), t.Intents...)
+	return v
+}
+
+// Clone creates a copy of the given transaction. The copy is "mostly" deep,
+// but does share pieces of memory with the original such as Key, ID and the
+// keys with the intent spans.
 func (t *Transaction) Clone() *Transaction {
-	return proto.Clone(t).(*Transaction)
+	if t == nil {
+		return nil
+	}
+	r := &Transaction{}
+	*r = t.cloneValue()
+	return r
 }
 
 // Equal tests two transactions for equality. They are equal if they are
@@ -735,7 +772,7 @@ func (t *Transaction) Update(o *Transaction) {
 		return
 	}
 	if len(t.ID) == 0 {
-		*t = *proto.Clone(o).(*Transaction)
+		*t = o.cloneValue()
 		return
 	}
 	if len(t.Key) == 0 {

--- a/roachpb/data.pb.go
+++ b/roachpb/data.pb.go
@@ -382,6 +382,10 @@ func (*NodeList) ProtoMessage()    {}
 // transaction is assigned a random priority. This priority will be
 // used to decide whether a transaction will be aborted during
 // contention.
+//
+// If you add fields to Transaction you'll need to update
+// Transaction.Clone. Failure to do so will result in test failures.
+//
 // TODO(vivek): Remove parts of Transaction that expose internals.
 type Transaction struct {
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name"`

--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -212,6 +212,10 @@ message NodeList {
 // transaction is assigned a random priority. This priority will be
 // used to decide whether a transaction will be aborted during
 // contention.
+//
+// If you add fields to Transaction you'll need to update
+// Transaction.Clone. Failure to do so will result in test failures.
+//
 // TODO(vivek): Remove parts of Transaction that expose internals.
 message Transaction {
   option (gogoproto.goproto_stringer) = false;

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -454,7 +454,7 @@ var nonZeroTxn = Transaction{
 	},
 	Writing:  true,
 	Sequence: 123,
-	Intents:  []Span{{Key: []byte("a")}},
+	Intents:  []Span{{Key: []byte("a"), EndKey: []byte("b")}},
 }
 
 func TestTransactionUpdate(t *testing.T) {
@@ -479,7 +479,29 @@ func TestTransactionUpdate(t *testing.T) {
 	if err := util.NoZeroField(txn3); err != nil {
 		t.Fatal(err)
 	}
+}
 
+func TestTransactionClone(t *testing.T) {
+	txn := nonZeroTxn.Clone()
+	if &txn.Key[0] != &nonZeroTxn.Key[0] {
+		t.Fatalf("Key should be shared between clone and original")
+	}
+	if &txn.ID[0] != &nonZeroTxn.ID[0] {
+		t.Fatalf("ID should be shared between clone and original")
+	}
+	if txn.LastHeartbeat == nonZeroTxn.LastHeartbeat {
+		t.Fatalf("LastHeartbeat shared between clone and original")
+	}
+	if &txn.CertainNodes.Nodes[0] == &nonZeroTxn.CertainNodes.Nodes[0] {
+		t.Fatalf("CertainNodes.Nodes shared between clone and original")
+	}
+	if &txn.Intents[0] == &nonZeroTxn.Intents[0] {
+		t.Fatalf("Intents shared between clone and original")
+	}
+	if &txn.Intents[0].Key[0] != &nonZeroTxn.Intents[0].Key[0] ||
+		&txn.Intents[0].EndKey[0] != &nonZeroTxn.Intents[0].EndKey[0] {
+		t.Fatalf("Span keys should be shared between clone and original")
+	}
 }
 
 // checkVal verifies if a value is close to an expected value, within a fraction (e.g. if

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -72,7 +72,7 @@ func createTestEngine(stopper *stop.Stopper) Engine {
 // makeTxn creates a new transaction using the specified base
 // txn and timestamp.
 func makeTxn(baseTxn *roachpb.Transaction, ts roachpb.Timestamp) *roachpb.Transaction {
-	txn := proto.Clone(baseTxn).(*roachpb.Transaction)
+	txn := baseTxn.Clone()
 	txn.Timestamp = ts
 	return txn
 }

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2411,7 +2411,7 @@ func TestPushTxnUpgradeExistingTxn(t *testing.T) {
 			t.Fatal(pErr)
 		}
 		reply := resp.(*roachpb.PushTxnResponse)
-		expTxn := proto.Clone(pushee).(*roachpb.Transaction)
+		expTxn := pushee.Clone()
 		expTxn.Epoch = test.expEpoch
 		expTxn.Timestamp = test.expTS
 		expTxn.Status = roachpb.ABORTED


### PR DESCRIPTION
Avoid reflection and only clone pointer fields that need cloning.

TL;DR? `proto.Clone` is convenient but expensive.

```
name                   old time/op    new time/op    delta
Insert1_Cockroach-8       367µs ± 1%     349µs ± 1%   -4.99%   (p=0.000 n=10+9)
Insert10_Cockroach-8      750µs ± 3%     728µs ± 2%   -2.97%  (p=0.000 n=10+10)
Insert100_Cockroach-8    4.07ms ± 1%    4.02ms ± 1%   -1.40%   (p=0.000 n=10+9)
Update1_Cockroach-8       841µs ± 1%     807µs ± 0%   -4.07%   (p=0.000 n=10+9)
Update10_Cockroach-8     4.59ms ± 1%    4.33ms ± 1%   -5.67%  (p=0.000 n=10+10)
Update100_Cockroach-8    41.0ms ± 1%    38.7ms ± 0%   -5.78%   (p=0.000 n=10+8)
Delete1_Cockroach-8      1.18ms ± 1%    1.14ms ± 1%   -3.72%  (p=0.000 n=10+10)
Delete10_Cockroach-8     1.92ms ± 1%    1.86ms ± 1%   -3.13%  (p=0.000 n=10+10)
Delete100_Cockroach-8    10.6ms ± 1%    10.7ms ± 3%     ~      (p=0.720 n=9+10)
Scan1_Cockroach-8         182µs ± 1%     167µs ± 1%   -8.04%  (p=0.000 n=10+10)
Scan10_Cockroach-8        221µs ± 1%     206µs ± 1%   -6.90%  (p=0.000 n=10+10)
Scan100_Cockroach-8       600µs ± 3%     571µs ± 5%   -4.75%   (p=0.000 n=9+10)

name                   old allocs/op  new allocs/op  delta
Insert1_Cockroach-8         436 ± 0%       384 ± 0%  -12.04%  (p=0.000 n=10+10)
Insert10_Cockroach-8      1.08k ± 0%     1.03k ± 0%   -4.88%  (p=0.000 n=10+10)
Insert100_Cockroach-8     7.27k ± 0%     7.21k ± 0%   -0.78%  (p=0.000 n=10+10)
Update1_Cockroach-8         992 ± 0%       886 ± 0%  -10.69%  (p=0.000 n=10+10)
Update10_Cockroach-8      6.76k ± 0%     6.15k ± 0%   -9.02%  (p=0.000 n=10+10)
Update100_Cockroach-8     64.3k ± 0%     58.7k ± 0%   -8.71%   (p=0.000 n=9+10)
Delete1_Cockroach-8         949 ± 0%       843 ± 0%  -11.16%  (p=0.000 n=10+10)
Delete10_Cockroach-8      2.42k ± 0%     2.32k ± 0%   -4.39%   (p=0.000 n=10+9)
Delete100_Cockroach-8     16.5k ± 0%     16.4k ± 0%   -0.63%   (p=0.000 n=9+10)
Scan1_Cockroach-8           278 ± 0%       228 ± 0%  -18.00%  (p=0.000 n=10+10)
Scan10_Cockroach-8          368 ± 0%       318 ± 0%  -13.55%  (p=0.000 n=10+10)
Scan100_Cockroach-8       1.10k ± 0%     1.05k ± 0%   -4.53%    (p=0.001 n=8+9)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4179)

<!-- Reviewable:end -->
