### PR TITLE
Move ts.keyDataPrefix to keys.TimeseriesPrefix.

### DIFF
--- a/keys/constants.go
+++ b/keys/constants.go
@@ -165,6 +165,9 @@ var (
 	// StatusNodePrefix stores all status info for nodes.
 	StatusNodePrefix = roachpb.Key(makeKey(StatusPrefix, roachpb.RKey("node-")))
 
+	// TimeseriesPrefix is the key prefix for all timeseries data.
+	TimeseriesPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("tsd")))
+
 	// TableDataMin is the start of the range of table data keys.
 	TableDataMin = roachpb.Key(encoding.EncodeVarintAscending(nil, math.MinInt64))
 	// TableDataMin is the end of the range of table data keys.

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -76,7 +77,7 @@ func (tm *testModel) Start() {
 // underlying engine. Data is returned as a map of strings to roachpb.Values.
 func (tm *testModel) getActualData() map[string]roachpb.Value {
 	// Scan over all TS Keys stored in the engine
-	startKey := keyDataPrefix
+	startKey := keys.TimeseriesPrefix
 	endKey := startKey.PrefixEnd()
 	keyValues, _, err := engine.MVCCScan(tm.Eng, startKey, endKey, 0, tm.Clock.Now(), true, nil)
 	if err != nil {

--- a/ts/keys_test.go
+++ b/ts/keys_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -58,7 +59,7 @@ func TestDataKeys(t *testing.T) {
 
 	for i, tc := range testCases {
 		encoded := MakeDataKey(tc.name, tc.source, tc.resolution, tc.timestamp)
-		if !bytes.HasPrefix(encoded, keyDataPrefix) {
+		if !bytes.HasPrefix(encoded, keys.TimeseriesPrefix) {
 			t.Errorf("case %d, encoded key %v did not have time series data prefix", i, encoded)
 		}
 		if a, e := len(encoded), tc.expectedLen; a != e {


### PR DESCRIPTION
Simplify rangeAddressing.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4186)

<!-- Reviewable:end -->
