### PR TITLE
roachpb: Transaction.Clone by value

### DIFF
--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -88,10 +88,13 @@ func newTestSender(pre, post func(roachpb.BatchRequest) (*roachpb.BatchResponse,
 				status = roachpb.ABORTED
 			}
 		}
-		br.Txn = ba.Txn.Clone()
-		if br.Txn != nil && pErr == nil {
-			br.Txn.Writing = writing
-			br.Txn.Status = status
+		if ba.Txn != nil {
+			txnClone := ba.Txn.Clone()
+			br.Txn = &txnClone
+			if pErr == nil {
+				br.Txn.Writing = writing
+				br.Txn.Status = status
+			}
 		}
 
 		if post != nil {

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -615,7 +615,8 @@ func (tc *TxnCoordSender) heartbeat(id string, trace opentracing.Span, ctx conte
 	hb.Key = txn.Key
 	ba := roachpb.BatchRequest{}
 	ba.Timestamp = tc.clock.Now()
-	ba.Txn = txn.Clone()
+	txnClone := txn.Clone()
+	ba.Txn = &txnClone
 	ba.Add(hb)
 
 	trace.LogEvent("heartbeat")

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -656,7 +656,8 @@ func TestTxnCoordSenderSingleRoundtripTxn(t *testing.T) {
 
 	ts := NewTxnCoordSender(senderFn(func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 		br := ba.CreateReply()
-		br.Txn = ba.Txn.Clone()
+		txnClone := ba.Txn.Clone()
+		br.Txn = &txnClone
 		br.Txn.Writing = true
 		return br, nil
 	}), clock, false, nil, stopper)
@@ -692,7 +693,7 @@ func TestTxnCoordSenderErrorWithIntent(t *testing.T) {
 		txn := ba.Txn.Clone()
 		txn.Writing = true
 		pErr := roachpb.NewError(roachpb.NewTransactionRetryError())
-		pErr.SetTxn(txn)
+		pErr.SetTxn(&txn)
 		return nil, pErr
 	}), clock, false, nil, stopper)
 	defer stopper.Stop()

--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -177,7 +177,11 @@ func (e *Error) setGoError(err error) {
 // SetTxn sets the txn and resets the error message.
 // TODO(kaneda): Unexpose this method and make callers use NewErrorWithTxn.
 func (e *Error) SetTxn(txn *Transaction) {
-	e.UnexposedTxn = txn.Clone()
+	e.UnexposedTxn = txn
+	if txn != nil {
+		txnClone := txn.Clone()
+		e.UnexposedTxn = &txnClone
+	}
 	if e.Detail != nil {
 		if sErr, ok := e.Detail.GetValue().(ErrorDetailInterface); ok {
 			// Refresh the message as the txn is updated.
@@ -341,12 +345,13 @@ func NewTransactionAbortedError() *TransactionAbortedError {
 // Txn is the transaction which will be retried. Both arguments are copied.
 // Transactions.
 func NewTransactionPushError(txn, pusheeTxn Transaction) *TransactionPushError {
-	err := &TransactionPushError{PusheeTxn: *pusheeTxn.Clone()}
+	err := &TransactionPushError{PusheeTxn: pusheeTxn.Clone()}
 	if len(txn.ID) != 0 {
 		// When the pusher is non-transactional, txn will be
 		// empty but for the priority. In that case, ignore it
 		// here.
-		err.Txn = txn.Clone()
+		txnClone := txn.Clone()
+		err.Txn = &txnClone
 	}
 	return err
 }

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -284,8 +284,7 @@ func TestMVCCPutWithTxn(t *testing.T) {
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
 
-	err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -332,14 +331,12 @@ func TestMVCCPutOutOfOrder(t *testing.T) {
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
 
-	err := MVCCPut(engine, nil, testKey1, makeTS(2, 1), value1, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(2, 1), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
 	// Put operation with earlier walltime. Will NOT be ignored.
-	err = MVCCPut(engine, nil, testKey1, makeTS(1, 0), value2, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value2, txn1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -509,13 +506,11 @@ func TestMVCCUpdateExistingKeyInTxn(t *testing.T) {
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
 
-	err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
-	err = MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -526,13 +521,11 @@ func TestMVCCUpdateExistingKeyDiffTxn(t *testing.T) {
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
 
-	err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
-	err = MVCCPut(engine, nil, testKey1, makeTS(1, 0), value2, txn2)
-	if err == nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value2, txn2); err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
 }
@@ -698,34 +691,33 @@ func TestMVCCGetAndDeleteInTxn(t *testing.T) {
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
 
-	err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, txn1)
-	value, _, err := MVCCGet(engine, testKey1, makeTS(2, 0), true, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
-	if value == nil {
+
+	if value, _, err := MVCCGet(engine, testKey1, makeTS(2, 0), true, txn1); err != nil {
+		t.Fatal(err)
+	} else if value == nil {
 		t.Fatal("the value should not be empty")
 	}
 
-	err = MVCCDelete(engine, nil, testKey1, makeTS(3, 0), txn1)
-	if err != nil {
+	if err := MVCCDelete(engine, nil, testKey1, makeTS(3, 0), txn1); err != nil {
 		t.Fatal(err)
 	}
 
 	// Read the latest version which should be deleted.
-	value, _, err = MVCCGet(engine, testKey1, makeTS(4, 0), true, txn1)
-	if err != nil {
+	if value, _, err := MVCCGet(engine, testKey1, makeTS(4, 0), true, txn1); err != nil {
 		t.Fatal(err)
-	}
-	if value != nil {
+	} else if value != nil {
 		t.Fatal("the value should be empty")
 	}
 
 	// Read the old version which shouldn't exist, as within a
 	// transaction, we delete previous values.
-	value, _, err = MVCCGet(engine, testKey1, makeTS(2, 0), true, nil)
-	if value != nil || err != nil {
-		t.Fatalf("expected value and err to be nil: %+v, %v", value, err)
+	if value, _, err := MVCCGet(engine, testKey1, makeTS(2, 0), true, nil); err != nil {
+		t.Fatal(err)
+	} else if value != nil {
+		t.Fatalf("expected value nil, got: %s", value)
 	}
 }
 
@@ -735,18 +727,15 @@ func TestMVCCGetWriteIntentError(t *testing.T) {
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
 
-	err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(0, 1), value1, txn1); err != nil {
 		t.Fatal(err)
 	}
 
-	_, _, err = MVCCGet(engine, testKey1, makeTS(1, 0), true, nil)
-	if err == nil {
+	if _, _, err := MVCCGet(engine, testKey1, makeTS(1, 0), true, nil); err == nil {
 		t.Fatal("cannot read the value of a write intent without TxnID")
 	}
 
-	_, _, err = MVCCGet(engine, testKey1, makeTS(1, 0), true, txn2)
-	if err == nil {
+	if _, _, err := MVCCGet(engine, testKey1, makeTS(1, 0), true, txn2); err == nil {
 		t.Fatal("cannot read the value of a write intent from a different TxnID")
 	}
 }
@@ -782,8 +771,7 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 		}
 		v := *proto.Clone(&kv.Value).(*roachpb.Value)
 		v.Timestamp = roachpb.ZeroTimestamp
-		err := MVCCPut(engine, nil, kv.Key, kv.Value.Timestamp, v, txn)
-		if err != nil {
+		if err := MVCCPut(engine, nil, kv.Key, kv.Value.Timestamp, v, txn); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -877,12 +865,10 @@ func TestMVCCGetInconsistent(t *testing.T) {
 	engine := createTestEngine(stopper)
 
 	// Put two values to key 1, the latest with a txn.
-	err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, nil)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	err = MVCCPut(engine, nil, testKey1, makeTS(2, 0), value2, txn1)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey1, makeTS(2, 0), value2, txn1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -909,8 +895,7 @@ func TestMVCCGetInconsistent(t *testing.T) {
 	}
 
 	// Write a single intent for key 2 and verify get returns empty.
-	err = MVCCPut(engine, nil, testKey2, makeTS(2, 0), value1, txn2)
-	if err != nil {
+	if err := MVCCPut(engine, nil, testKey2, makeTS(2, 0), value1, txn2); err != nil {
 		t.Fatal(err)
 	}
 	val, intents, err := MVCCGet(engine, testKey2, makeTS(2, 0), false, nil)

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1429,7 +1429,7 @@ func (r *Replica) checkSequenceCache(b engine.Engine, txn roachpb.Transaction) *
 		// aborted and learns about that right now.
 		newTxn := txn.Clone()
 		newTxn.Timestamp.Forward(entry.Timestamp)
-		return roachpb.NewErrorWithTxn(roachpb.NewTransactionAbortedError(), newTxn)
+		return roachpb.NewErrorWithTxn(roachpb.NewTransactionAbortedError(), &newTxn)
 	} else if sequence >= txn.Sequence || epoch > txn.Epoch {
 		// We hit the cache, so let the transaction restart.
 		// This is also the path taken by roachpb.SequencePoisonRestart.
@@ -1438,7 +1438,7 @@ func (r *Replica) checkSequenceCache(b engine.Engine, txn roachpb.Transaction) *
 		}
 		newTxn := txn.Clone()
 		newTxn.Timestamp.Forward(entry.Timestamp)
-		return roachpb.NewErrorWithTxn(roachpb.NewTransactionRetryError(), newTxn)
+		return roachpb.NewErrorWithTxn(roachpb.NewTransactionRetryError(), &newTxn)
 	}
 	return nil
 }

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -912,7 +912,7 @@ func (r *Replica) PushTxn(batch engine.Engine, ms *engine.MVCCStats, h roachpb.H
 	// has open intents (which is likely if someone pushes it).
 	if ok {
 		// Start with the persisted transaction record as final transaction.
-		reply.PusheeTxn = *existTxn.Clone()
+		reply.PusheeTxn = existTxn.Clone()
 		// Upgrade the epoch, timestamp and priority as necessary.
 		if reply.PusheeTxn.Epoch < args.PusheeTxn.Epoch {
 			reply.PusheeTxn.Epoch = args.PusheeTxn.Epoch
@@ -927,7 +927,7 @@ func (r *Replica) PushTxn(batch engine.Engine, ms *engine.MVCCStats, h roachpb.H
 		// something to win here by not aborting, but instead pushing the
 		// timestamp. For SERIALIZABLE it's less important, but still better
 		// to have them restart than abort. See #3344.
-		reply.PusheeTxn = *args.PusheeTxn.Clone()
+		reply.PusheeTxn = args.PusheeTxn.Clone()
 		reply.PusheeTxn.Status = roachpb.ABORTED
 		return reply, engine.MVCCPutProto(batch, ms, key, roachpb.ZeroTimestamp, nil, &reply.PusheeTxn)
 	}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2266,7 +2266,7 @@ func TestSequenceCacheError(t *testing.T) {
 	if _, ok := pErr.GetDetail().(*roachpb.TransactionRetryError); ok {
 		expected := txn.Clone()
 		expected.Timestamp = ts
-		if pErr.GetTxn() == nil || !reflect.DeepEqual(pErr.GetTxn(), expected) {
+		if pErr.GetTxn() == nil || !reflect.DeepEqual(pErr.GetTxn(), &expected) {
 			t.Errorf("txn does not match: %s v.s. %s", pErr.GetTxn(), expected)
 		}
 	} else {
@@ -2282,7 +2282,7 @@ func TestSequenceCacheError(t *testing.T) {
 	if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); ok {
 		expected := txn.Clone()
 		expected.Timestamp = ts
-		if pErr.GetTxn() == nil || !reflect.DeepEqual(pErr.GetTxn(), expected) {
+		if pErr.GetTxn() == nil || !reflect.DeepEqual(pErr.GetTxn(), &expected) {
 			t.Errorf("txn does not match: %s v.s. %s", pErr.GetTxn(), expected)
 		}
 	} else {
@@ -2417,7 +2417,7 @@ func TestPushTxnUpgradeExistingTxn(t *testing.T) {
 		expTxn.Status = roachpb.ABORTED
 		expTxn.LastHeartbeat = &test.startTS
 
-		if !reflect.DeepEqual(expTxn, &reply.PusheeTxn) {
+		if !reflect.DeepEqual(expTxn, reply.PusheeTxn) {
 			t.Errorf("unexpected push txn in trial %d; expected %+v, got %+v", i, expTxn, reply.PusheeTxn)
 		}
 	}


### PR DESCRIPTION
second commit includes random cleanup I ran into while fixing fallout.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4193)

<!-- Reviewable:end -->
