### PR TITLE
sql: Make more trivial conversion from roachpb.Error to errror

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -94,7 +94,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 					StoreColumnNames: d.Storing,
 				}
 				if err := idx.fillColumns(d.Columns); err != nil {
-					return nil, err
+					return nil, roachpb.NewError(err)
 				}
 				status, i, err := tableDesc.FindIndexByName(name)
 				if err == nil {
@@ -184,7 +184,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 	tableDesc.NextMutationID++
 
 	if err := tableDesc.AllocateIDs(); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 
 	if pErr := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc)); err != nil {

--- a/sql/create.go
+++ b/sql/create.go
@@ -96,16 +96,16 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) 
 		Unique:           n.Unique,
 		StoreColumnNames: n.Storing,
 	}
-	if pErr := indexDesc.fillColumns(n.Columns); pErr != nil {
-		return nil, pErr
+	if err := indexDesc.fillColumns(n.Columns); err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	tableDesc.addIndexMutation(indexDesc, DescriptorMutation_ADD)
 	tableDesc.UpVersion = true
 	mutationID := tableDesc.NextMutationID
 	tableDesc.NextMutationID++
-	if pErr := tableDesc.AllocateIDs(); pErr != nil {
-		return nil, pErr
+	if err := tableDesc.AllocateIDs(); err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	if pErr := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc)); pErr != nil {
@@ -133,9 +133,9 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, *roachpb.Error) 
 		return nil, roachpb.NewError(err)
 	}
 
-	desc, pErr := makeTableDesc(n, dbDesc.ID)
-	if pErr != nil {
-		return nil, pErr
+	desc, err := makeTableDesc(n, dbDesc.ID)
+	if err != nil {
+		return nil, roachpb.NewError(err)
 	}
 	// Inherit permissions from the database descriptor.
 	desc.Privileges = dbDesc.GetPrivileges()
@@ -163,8 +163,8 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, *roachpb.Error) 
 		}
 	}
 
-	if pErr := desc.AllocateIDs(); pErr != nil {
-		return nil, pErr
+	if err := desc.AllocateIDs(); err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	created, pErr := p.createDescriptor(tableKey{dbDesc.ID, n.Table.Table()}, &desc, n.IfNotExists)

--- a/sql/table_test.go
+++ b/sql/table_test.go
@@ -239,8 +239,8 @@ func TestPrimaryKeyUnspecified(t *testing.T) {
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
-	pErr = desc.AllocateIDs()
-	if !testutils.IsPError(pErr, errMissingPrimaryKey.Error()) {
-		t.Fatalf("unexpected error: %s", pErr)
+	err = desc.AllocateIDs()
+	if !testutils.IsError(err, errMissingPrimaryKey.Error()) {
+		t.Fatalf("unexpected error: %s", err)
 	}
 }


### PR DESCRIPTION
Change the following methods to return error:
- selectNode.findColumn
- IndexDescriptor.fillColumns
- TableDescriptor.AllocateIDs
- makeTableDesc

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4195)

<!-- Reviewable:end -->
