### PR TITLE
Clean up some gossip issues

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -212,7 +212,7 @@ func (c *client) gossip(g *Gossip, stopper *stop.Stopper) error {
 	// For un-bootstrapped node, g.is.NodeID is 0 when client start gossip,
 	// so it's better to get nodeID from g.is every time.
 	g.mu.Lock()
-	addr := util.MakeUnresolvedAddr(g.is.NodeAddr.Network(), g.is.NodeAddr.String())
+	addr := g.is.NodeAddr
 	g.mu.Unlock()
 
 	lAddr := util.MakeUnresolvedAddr(c.rpcClient.LocalAddr().Network(), c.rpcClient.LocalAddr().String())

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -243,7 +243,9 @@ func (s *server) maybeTighten() {
 // loop via goroutine. Periodically, clients connected and awaiting
 // the next round of gossip are awoken via the conditional variable.
 func (s *server) start(rpcServer *rpc.Server, addr net.Addr) {
+	s.mu.Lock()
 	s.is.NodeAddr = util.MakeUnresolvedAddr(addr.Network(), addr.String())
+	s.mu.Unlock()
 	if err := rpcServer.Register("Gossip.Gossip", s.Gossip, &Request{}); err != nil {
 		log.Fatalf("unable to register gossip service with RPC server: %s", err)
 	}

--- a/server/node.go
+++ b/server/node.go
@@ -473,6 +473,11 @@ func (n *Node) startGossip(stopper *stop.Stopper) {
 		for {
 			select {
 			case <-ticker.C:
+				// Node descriptor.
+				if err := n.ctx.Gossip.SetNodeDescriptor(&n.Descriptor); err != nil {
+					log.Warningf("couldn't gossip descriptor for node %d: %s", n.Descriptor.NodeID, err)
+				}
+				// Store capacities.
 				n.gossipStores()
 			case <-stopper.ShouldStop():
 				return


### PR DESCRIPTION
In particular:
- Set an expiration on the node descriptor gossip and periodically gossip it
- Never store own address in bootstrap info – this saves unnecessary
  confusion when changing port numbers on successive runs.
- Increase interval for checking for a stalled gossip network to 30s from 1s.
  1s was a temporary testing change which accidentally became permanent.
- No longer fail out with error in event there are no resolvers. Instead, we
  warn to use --join periodically if not connected. This keeps us from failing
  in degenerative single-node cases.
- Only signal bootstrapping in gossip if sentinel gossip is missing.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4200)

<!-- Reviewable:end -->
