### PR TITLE
Trim spacing before parsing cgroups configuration data.

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -155,7 +155,7 @@ func getDefaultCacheSize() uint64 {
 			return halfSysMem
 		}
 
-		cgAvlMem, err := strconv.ParseUint(string(buf), 10, 64)
+		cgAvlMem, err := strconv.ParseUint(strings.TrimSpace(string(buf)), 10, 64)
 		if err != nil {
 			log.Infof("can't parse available memory from cgroups (%s), setting default rocksdb cache size to %dMB (half of system memory)", err, halfSysMem>>20)
 			return halfSysMem


### PR DESCRIPTION
Fixes #4201.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4202)

<!-- Reviewable:end -->
