### PR TITLE
Reduce allocations in IntervalCache and its usage.

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -101,17 +101,20 @@ func (tm *txnMetadata) addKeyRange(start, end roachpb.Key) {
 		end = start.Next()
 		start = end[:len(start)]
 	}
-	key := tm.keys.NewKey(start, end)
-	for _, o := range tm.keys.GetOverlaps(start, end) {
+	key := tm.keys.MakeKey(start, end)
+	for _, o := range tm.keys.GetOverlaps(key.Start(), key.End()) {
 		if o.Key.Contains(key) {
 			return
-		} else if key.Contains(o.Key) {
+		} else if key.Contains(*o.Key) {
 			tm.keys.Del(o.Key)
 		}
 	}
 
-	// Since no existing key range fully covered this range, add it now.
-	tm.keys.Add(key, nil)
+	// Since no existing key range fully covered this range, add it now. The
+	// strange assignment to pkey makes sure we delay the heap allocation until
+	// we know it is necessary.
+	pkey := key
+	tm.keys.Add(&pkey, nil)
 }
 
 // setLastUpdate updates the wall time (in nanoseconds) since the most

--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -106,7 +106,7 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 // Add should be invoked after waiting on already-executing, overlapping
 // commands via the WaitGroup initialized through GetWait().
 func (cq *CommandQueue) Add(readOnly bool, spans ...roachpb.Span) []interface{} {
-	var r []interface{}
+	r := make([]interface{}, 0, len(spans))
 	for _, span := range spans {
 		start, end := span.Key, span.EndKey
 		if len(end) == 0 {

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -101,20 +101,30 @@ func (tc *TimestampCache) Add(start, end roachpb.Key, timestamp roachpb.Timestam
 	if tc.lowWater.Less(timestamp) {
 		// Check existing, overlapping entries. Remove superseded
 		// entries or return without adding this entry if necessary.
-		key := tc.cache.NewKey(start, end)
-		for _, o := range tc.cache.GetOverlaps(start, end) {
-			ce := o.Value.(cacheEntry)
+		key := tc.cache.MakeKey(start, end)
+		for _, o := range tc.cache.GetOverlaps(key.Start(), key.End()) {
+			ce := o.Value.(*cacheEntry)
 			if ce.readOnly != readOnly {
 				continue
 			}
-			if o.Key.Contains(key) && !ce.timestamp.Less(timestamp) {
-				return // don't add this key; there's already a cache entry with >= timestamp.
-			} else if key.Contains(o.Key) && !timestamp.Less(ce.timestamp) {
+			if o.Key.Contains(key) {
+				if !ce.timestamp.Less(timestamp) {
+					return // don't add this key; there's already a cache entry with >= timestamp.
+				}
+				if key.Contains(*o.Key) {
+					// The keys are equal, update the existing cache entry.
+					*ce = cacheEntry{timestamp: timestamp, txnID: txnID, readOnly: readOnly}
+					return
+				}
+			} else if key.Contains(*o.Key) && !timestamp.Less(ce.timestamp) {
 				tc.cache.Del(o.Key) // delete existing key; this cache entry supersedes.
 			}
 		}
-		ce := cacheEntry{timestamp: timestamp, txnID: txnID, readOnly: readOnly}
-		tc.cache.Add(key, ce)
+		alloc := struct {
+			key   cache.IntervalKey
+			entry cacheEntry
+		}{key, cacheEntry{timestamp: timestamp, txnID: txnID, readOnly: readOnly}}
+		tc.cache.Add(&alloc.key, &alloc.entry)
 	}
 }
 
@@ -136,7 +146,7 @@ func (tc *TimestampCache) GetMax(start, end roachpb.Key, txnID []byte) (roachpb.
 	maxR := tc.lowWater
 	maxW := tc.lowWater
 	for _, o := range tc.cache.GetOverlaps(start, end) {
-		ce := o.Value.(cacheEntry)
+		ce := o.Value.(*cacheEntry)
 		if ce.txnID == nil || txnID == nil || !roachpb.TxnIDEqual(txnID, ce.txnID) {
 			if ce.readOnly && maxR.Less(ce.timestamp) {
 				maxR = ce.timestamp
@@ -162,14 +172,17 @@ func (tc *TimestampCache) MergeInto(dest *TimestampCache, clear bool) {
 		dest.latest.Forward(tc.latest)
 	}
 	tc.cache.Do(func(k, v interface{}) {
-		dest.cache.Add(k, v)
+		// Cache entries are mutable (see Add), so we give each cache its own
+		// unique copy.
+		ce := *v.(*cacheEntry)
+		dest.cache.Add(k, &ce)
 	})
 }
 
 // shouldEvict returns true if the cache entry's timestamp is no
 // longer within the MinTSCacheWindow.
 func (tc *TimestampCache) shouldEvict(size int, key, value interface{}) bool {
-	ce := value.(cacheEntry)
+	ce := value.(*cacheEntry)
 	// In case low water mark was set higher, evict any entries
 	// which occurred before it.
 	if ce.timestamp.Less(tc.lowWater) {


### PR DESCRIPTION
IntervalCache is the data structure backing TimestampCache, the
transaction coordinator's key cache and the storage layer's
CommandQueue. Reducing allocations here has an outsized impact.

There is further work to be done here. All uses of IntervalCache are
using roachpb.{Key,RKey} as the key. But storing those keys in an
interval.Comparable interface requires an allocation (a []byte is
essentially a struct with 3 fields). Given how frequently used
IntervalCache is, we may want to fork the underlying
biogo/store/interval.Tree and specialize it for []byte.

```
name                   old time/op    new time/op    delta
Insert1_Cockroach-8       353µs ± 1%     349µs ± 1%   -1.00%  (p=0.000 n=10+10)
Insert10_Cockroach-8      731µs ± 3%     715µs ± 2%   -2.15%  (p=0.002 n=10+10)
Insert100_Cockroach-8    4.04ms ± 2%    3.95ms ± 1%   -2.36%  (p=0.000 n=10+10)
Update1_Cockroach-8       811µs ± 1%     785µs ± 1%   -3.24%    (p=0.000 n=9+9)
Update10_Cockroach-8     4.38ms ± 1%    4.12ms ± 2%   -5.95%  (p=0.000 n=10+10)
Update100_Cockroach-8    39.6ms ± 1%    36.7ms ± 1%   -7.10%  (p=0.000 n=10+10)
Delete1_Cockroach-8      1.14ms ± 1%    1.11ms ± 1%   -2.56%    (p=0.000 n=9+9)
Delete10_Cockroach-8     1.86ms ± 1%    1.67ms ± 1%  -10.29%   (p=0.000 n=10+8)
Delete100_Cockroach-8    10.7ms ± 2%     8.2ms ± 1%  -23.41%   (p=0.000 n=10+9)
Scan1_Cockroach-8         169µs ± 1%     159µs ± 1%   -5.81%   (p=0.000 n=10+9)
Scan10_Cockroach-8        208µs ± 1%     191µs ± 1%   -8.40%    (p=0.000 n=9+8)
Scan100_Cockroach-8       573µs ± 4%     501µs ± 5%  -12.62%  (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
Insert1_Cockroach-8         382 ± 0%       361 ± 0%   -5.42%  (p=0.000 n=10+10)
Insert10_Cockroach-8      1.02k ± 0%     0.94k ± 0%   -8.44%  (p=0.000 n=10+10)
Insert100_Cockroach-8     7.21k ± 0%     6.48k ± 0%  -10.17%   (p=0.000 n=10+9)
Update1_Cockroach-8         882 ± 0%       831 ± 0%   -5.78%  (p=0.000 n=10+10)
Update10_Cockroach-8      6.13k ± 0%     5.72k ± 0%   -6.65%   (p=0.000 n=7+10)
Update100_Cockroach-8     58.5k ± 0%     54.5k ± 0%   -6.84%    (p=0.000 n=9+9)
Delete1_Cockroach-8         838 ± 0%       772 ± 0%   -7.95%  (p=0.000 n=10+10)
Delete10_Cockroach-8      2.31k ± 0%     1.75k ± 0%  -24.36%   (p=0.000 n=8+10)
Delete100_Cockroach-8     16.4k ± 0%     11.0k ± 0%  -33.07%    (p=0.000 n=9+9)
Scan1_Cockroach-8           227 ± 0%       208 ± 0%   -8.34%  (p=0.000 n=10+10)
Scan10_Cockroach-8          317 ± 0%       287 ± 0%   -9.25%  (p=0.000 n=10+10)
Scan100_Cockroach-8       1.05k ± 0%     1.01k ± 0%   -3.61%  (p=0.000 n=10+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4206)

<!-- Reviewable:end -->
