### PR TITLE
Empty lines at the CLI prompt should not invite a continuation prompt.

### DIFF
--- a/cli/sql.go
+++ b/cli/sql.go
@@ -100,11 +100,23 @@ func runInteractive(db *sql.DB, dbURL string) {
 			break
 		}
 
+		tl := strings.TrimSpace(l)
+		if len(stmt) == 0 && len(tl) == 0 {
+			// Empty line at beginning, simply continue.
+			// However, we don't simply continue after the first line since
+			// we may be in the middle of a string literal where empty lines
+			// may be significant.
+			continue
+		}
+
+		// We append the newly read line to the previous line(s), if
+		// any. We add the non-trimmed line here since we may be in the
+		// middle of a string literal.
 		stmt = append(stmt, l)
 
 		// See if we have a semicolon at the end of the line (ignoring
 		// trailing whitespace).
-		if !strings.HasSuffix(strings.TrimSpace(l), ";") {
+		if !strings.HasSuffix(tl, ";") {
 			// No semicolon: read some more.
 			continue
 		}


### PR DESCRIPTION
Partially fixes #4134.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4210)

<!-- Reviewable:end -->
