### PR TITLE
Change IntervalCache to only support []byte keys.

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -102,7 +102,7 @@ func (tm *txnMetadata) addKeyRange(start, end roachpb.Key) {
 		start = end[:len(start)]
 	}
 	key := tm.keys.MakeKey(start, end)
-	for _, o := range tm.keys.GetOverlaps(key.Start(), key.End()) {
+	for _, o := range tm.keys.GetOverlaps(key.Start, key.End) {
 		if o.Key.Contains(key) {
 			return
 		} else if key.Contains(*o.Key) {
@@ -144,9 +144,9 @@ func (tm *txnMetadata) intentSpans() []roachpb.Span {
 	intents := make([]roachpb.Span, 0, tm.keys.Len())
 	for _, o := range tm.keys.GetOverlaps(roachpb.KeyMin, roachpb.KeyMax) {
 		intent := roachpb.Span{
-			Key: o.Key.Start().(roachpb.Key),
+			Key: roachpb.Key(o.Key.Start),
 		}
-		if endKey := o.Key.End().(roachpb.Key); !intent.Key.IsPrev(endKey) {
+		if endKey := roachpb.Key(o.Key.End); !intent.Key.IsPrev(endKey) {
 			intent.EndKey = endKey
 		}
 		intents = append(intents, intent)

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -113,8 +113,12 @@ func (tm *txnMetadata) addKeyRange(start, end roachpb.Key) {
 	// Since no existing key range fully covered this range, add it now. The
 	// strange assignment to pkey makes sure we delay the heap allocation until
 	// we know it is necessary.
-	pkey := key
-	tm.keys.Add(&pkey, nil)
+	alloc := struct {
+		key   cache.IntervalKey
+		entry cache.Entry
+	}{key: key}
+	alloc.entry.Key = &alloc.key
+	tm.keys.AddEntry(&alloc.entry)
 }
 
 // setLastUpdate updates the wall time (in nanoseconds) since the most

--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -114,9 +114,15 @@ func (cq *CommandQueue) Add(readOnly bool, spans ...roachpb.Span) []interface{} 
 		}
 		alloc := struct {
 			key   cache.IntervalKey
-			entry cmd
-		}{cq.cache.MakeKey(start, end), cmd{readOnly: readOnly}}
-		cq.cache.Add(&alloc.key, &alloc.entry)
+			value cmd
+			entry cache.Entry
+		}{
+			key:   cq.cache.MakeKey(start, end),
+			value: cmd{readOnly: readOnly},
+		}
+		alloc.entry.Key = &alloc.key
+		alloc.entry.Value = &alloc.value
+		cq.cache.AddEntry(&alloc.entry)
 		r = append(r, &alloc.key)
 	}
 	return r

--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -112,9 +112,12 @@ func (cq *CommandQueue) Add(readOnly bool, spans ...roachpb.Span) []interface{} 
 		if len(end) == 0 {
 			end = start.Next()
 		}
-		key := cq.cache.NewKey(start, end)
-		cq.cache.Add(key, &cmd{readOnly: readOnly})
-		r = append(r, key)
+		alloc := struct {
+			key   cache.IntervalKey
+			entry cmd
+		}{cq.cache.MakeKey(start, end), cmd{readOnly: readOnly}}
+		cq.cache.Add(&alloc.key, &alloc.entry)
+		r = append(r, &alloc.key)
 	}
 	return r
 }

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -102,7 +102,7 @@ func (tc *TimestampCache) Add(start, end roachpb.Key, timestamp roachpb.Timestam
 		// Check existing, overlapping entries. Remove superseded
 		// entries or return without adding this entry if necessary.
 		key := tc.cache.MakeKey(start, end)
-		for _, o := range tc.cache.GetOverlaps(key.Start(), key.End()) {
+		for _, o := range tc.cache.GetOverlaps(key.Start, key.End) {
 			ce := o.Value.(*cacheEntry)
 			if ce.readOnly != readOnly {
 				continue

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -48,11 +48,25 @@ type TimestampCache struct {
 	lowWater, latest roachpb.Timestamp
 }
 
-// A cacheEntry combines the timestamp with an optional txn ID.
-type cacheEntry struct {
+// A cacheValue combines the timestamp with an optional txn ID.
+type cacheValue struct {
 	timestamp roachpb.Timestamp
 	txnID     []byte // Nil for no transaction
 	readOnly  bool   // Command is read-only
+}
+
+func makeCacheEntry(key cache.IntervalKey, value cacheValue) *cache.Entry {
+	alloc := struct {
+		key   cache.IntervalKey
+		value cacheValue
+		entry cache.Entry
+	}{
+		key:   key,
+		value: value,
+	}
+	alloc.entry.Key = &alloc.key
+	alloc.entry.Value = &alloc.value
+	return &alloc.entry
 }
 
 // NewTimestampCache returns a new timestamp cache with supplied
@@ -103,7 +117,7 @@ func (tc *TimestampCache) Add(start, end roachpb.Key, timestamp roachpb.Timestam
 		// entries or return without adding this entry if necessary.
 		key := tc.cache.MakeKey(start, end)
 		for _, o := range tc.cache.GetOverlaps(key.Start, key.End) {
-			ce := o.Value.(*cacheEntry)
+			ce := o.Value.(*cacheValue)
 			if ce.readOnly != readOnly {
 				continue
 			}
@@ -113,18 +127,16 @@ func (tc *TimestampCache) Add(start, end roachpb.Key, timestamp roachpb.Timestam
 				}
 				if key.Contains(*o.Key) {
 					// The keys are equal, update the existing cache entry.
-					*ce = cacheEntry{timestamp: timestamp, txnID: txnID, readOnly: readOnly}
+					*ce = cacheValue{timestamp: timestamp, txnID: txnID, readOnly: readOnly}
 					return
 				}
 			} else if key.Contains(*o.Key) && !timestamp.Less(ce.timestamp) {
 				tc.cache.Del(o.Key) // delete existing key; this cache entry supersedes.
 			}
 		}
-		alloc := struct {
-			key   cache.IntervalKey
-			entry cacheEntry
-		}{key, cacheEntry{timestamp: timestamp, txnID: txnID, readOnly: readOnly}}
-		tc.cache.Add(&alloc.key, &alloc.entry)
+		entry := makeCacheEntry(
+			key, cacheValue{timestamp: timestamp, txnID: txnID, readOnly: readOnly})
+		tc.cache.AddEntry(entry)
 	}
 }
 
@@ -146,7 +158,7 @@ func (tc *TimestampCache) GetMax(start, end roachpb.Key, txnID []byte) (roachpb.
 	maxR := tc.lowWater
 	maxW := tc.lowWater
 	for _, o := range tc.cache.GetOverlaps(start, end) {
-		ce := o.Value.(*cacheEntry)
+		ce := o.Value.(*cacheValue)
 		if ce.txnID == nil || txnID == nil || !roachpb.TxnIDEqual(txnID, ce.txnID) {
 			if ce.readOnly && maxR.Less(ce.timestamp) {
 				maxR = ce.timestamp
@@ -174,15 +186,15 @@ func (tc *TimestampCache) MergeInto(dest *TimestampCache, clear bool) {
 	tc.cache.Do(func(k, v interface{}) {
 		// Cache entries are mutable (see Add), so we give each cache its own
 		// unique copy.
-		ce := *v.(*cacheEntry)
-		dest.cache.Add(k, &ce)
+		entry := makeCacheEntry(*k.(*cache.IntervalKey), *v.(*cacheValue))
+		dest.cache.AddEntry(entry)
 	})
 }
 
 // shouldEvict returns true if the cache entry's timestamp is no
 // longer within the MinTSCacheWindow.
 func (tc *TimestampCache) shouldEvict(size int, key, value interface{}) bool {
-	ce := value.(*cacheEntry)
+	ce := value.(*cacheValue)
 	// In case low water mark was set higher, evict any entries
 	// which occurred before it.
 	if ce.timestamp.Less(tc.lowWater) {

--- a/util/interval/bu23.go
+++ b/util/interval/bu23.go
@@ -1,0 +1,9 @@
+// Copyright ©2014 The bíogo Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !td234
+
+package interval
+
+const Mode = BU23

--- a/util/interval/bu23.go
+++ b/util/interval/bu23.go
@@ -6,4 +6,5 @@
 
 package interval
 
+// Mode .
 const Mode = BU23

--- a/util/interval/interval.go
+++ b/util/interval/interval.go
@@ -1,0 +1,666 @@
+// Copyright ©2012 The bíogo Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package interval implements an interval tree based on an augmented
+// Left-Leaning Red Black tree.
+package interval
+
+import (
+	"errors"
+
+	"github.com/biogo/store/llrb"
+)
+
+// Operation mode of the underlying LLRB tree.
+const (
+	TD234 = iota
+	BU23
+)
+
+func init() {
+	if Mode != TD234 && Mode != BU23 {
+		panic("interval: unknown mode")
+	}
+}
+
+// ErrInvertedRange is returned if an interval is used where the start value is greater
+// than the end value.
+var ErrInvertedRange = errors.New("interval: inverted range")
+
+// An Overlapper can determine whether it overlaps a range.
+type Overlapper interface {
+	// Overlap returns a boolean indicating whether the receiver overlaps the parameter.
+	Overlap(Range) bool
+}
+
+// A Range is a type that describes the basic characteristics of an interval.
+type Range interface {
+	// Return a Comparable equal to the start value of the Overlapper.
+	Start() Comparable
+	// Return a Comparable equal to the end value of the Overlapper.
+	End() Comparable
+}
+
+// An Interface is a type that can be inserted into a Tree.
+type Interface interface {
+	Overlapper
+	Range
+	ID() uintptr         // Returns a unique ID for the element.
+	NewMutable() Mutable // Returns an mutable copy of the Interface's range.
+}
+
+// A Mutable is a Range that can have its range altered.
+type Mutable interface {
+	Range
+	SetStart(Comparable) // Set the start value.
+	SetEnd(Comparable)   // Set the end value.
+}
+
+// A Comparable is a type that describes the ends of an Overlapper.
+type Comparable interface {
+	// Compare returns a value indicating the sort order relationship between the
+	// receiver and the parameter.
+	//
+	// Given c = a.Compare(b):
+	//  c < 0 if a < b;
+	//  c == 0 if a == b; and
+	//  c > 0 if a > b.
+	//
+	Compare(Comparable) int
+}
+
+// A Node represents a node in a Tree.
+type Node struct {
+	Elem        Interface
+	Range       Mutable
+	Left, Right *Node
+	Color       llrb.Color
+}
+
+// A Tree manages the root node of an interval tree. Public methods are exposed through this type.
+type Tree struct {
+	Root  *Node // Root node of the tree.
+	Count int   // Number of elements stored.
+}
+
+// Helper methods
+
+// color returns the effect color of a Node. A nil node returns black.
+func (n *Node) color() llrb.Color {
+	if n == nil {
+		return llrb.Black
+	}
+	return n.Color
+}
+
+// maxRange returns the furthest right position held by the subtree
+// rooted at root, assuming that the left and right nodes have correct
+// range extents.
+func maxRange(root, left, right *Node) Comparable {
+	end := root.Elem.End()
+	if left != nil && left.Range.End().Compare(end) > 0 {
+		end = left.Range.End()
+	}
+	if right != nil && right.Range.End().Compare(end) > 0 {
+		end = right.Range.End()
+	}
+	return end
+}
+
+// (a,c)b -rotL-> ((a,)b,)c
+func (n *Node) rotateLeft() (root *Node) {
+	// Assumes: n has a right child.
+	root = n.Right
+	n.Right = root.Left
+	root.Left = n
+	root.Color = n.Color
+	n.Color = llrb.Red
+
+	root.Left.Range.SetEnd(maxRange(root.Left, root.Left.Left, root.Left.Right))
+	if root.Left == nil {
+		root.Range.SetStart(root.Elem.Start())
+	} else {
+		root.Range.SetStart(root.Left.Range.Start())
+	}
+	root.Range.SetEnd(maxRange(root, root.Left, root.Right))
+
+	return
+}
+
+// (a,c)b -rotR-> (,(,c)b)a
+func (n *Node) rotateRight() (root *Node) {
+	// Assumes: n has a left child.
+	root = n.Left
+	n.Left = root.Right
+	root.Right = n
+	root.Color = n.Color
+	n.Color = llrb.Red
+
+	if root.Right.Left == nil {
+		root.Right.Range.SetStart(root.Right.Elem.Start())
+	} else {
+		root.Right.Range.SetStart(root.Right.Left.Range.Start())
+	}
+	root.Right.Range.SetEnd(maxRange(root.Right, root.Right.Left, root.Right.Right))
+	root.Range.SetEnd(maxRange(root, root.Left, root.Right))
+
+	return
+}
+
+// (aR,cR)bB -flipC-> (aB,cB)bR | (aB,cB)bR -flipC-> (aR,cR)bB
+func (n *Node) flipColors() {
+	// Assumes: n has two children.
+	n.Color = !n.Color
+	n.Left.Color = !n.Left.Color
+	n.Right.Color = !n.Right.Color
+}
+
+// fixUp ensures that black link balance is correct, that red nodes lean left,
+// and that 4 nodes are split in the case of BU23 and properly balanced in TD234.
+func (n *Node) fixUp(fast bool) *Node {
+	if !fast {
+		n.adjustRange()
+	}
+	if n.Right.color() == llrb.Red {
+		if Mode == TD234 && n.Right.Left.color() == llrb.Red {
+			n.Right = n.Right.rotateRight()
+		}
+		n = n.rotateLeft()
+	}
+	if n.Left.color() == llrb.Red && n.Left.Left.color() == llrb.Red {
+		n = n.rotateRight()
+	}
+	if Mode == BU23 && n.Left.color() == llrb.Red && n.Right.color() == llrb.Red {
+		n.flipColors()
+	}
+
+	return n
+}
+
+// adjustRange sets the Range to the maximum extent of the childrens' Range
+// spans and the node's Elem span.
+func (n *Node) adjustRange() {
+	if n.Left == nil {
+		n.Range.SetStart(n.Elem.Start())
+	} else {
+		n.Range.SetStart(n.Left.Range.Start())
+	}
+	n.Range.SetEnd(maxRange(n, n.Left, n.Right))
+}
+
+func (n *Node) moveRedLeft() *Node {
+	n.flipColors()
+	if n.Right.Left.color() == llrb.Red {
+		n.Right = n.Right.rotateRight()
+		n = n.rotateLeft()
+		n.flipColors()
+		if Mode == TD234 && n.Right.Right.color() == llrb.Red {
+			n.Right = n.Right.rotateLeft()
+		}
+	}
+	return n
+}
+
+func (n *Node) moveRedRight() *Node {
+	n.flipColors()
+	if n.Left.Left.color() == llrb.Red {
+		n = n.rotateRight()
+		n.flipColors()
+	}
+	return n
+}
+
+// Len returns the number of intervals stored in the Tree.
+func (t *Tree) Len() int {
+	return t.Count
+}
+
+// Get returns a slice of Interfaces that overlap q in the Tree according
+// to q.Overlap().
+func (t *Tree) Get(q Overlapper) (o []Interface) {
+	if t.Root != nil && q.Overlap(t.Root.Range) {
+		t.Root.doMatch(func(e Interface) (done bool) { o = append(o, e); return }, q)
+	}
+	return
+}
+
+// AdjustRanges fixes range fields for all Nodes in the Tree. This must be called
+// before Get or DoMatching* is used if fast insertion or deletion has been performed.
+func (t *Tree) AdjustRanges() {
+	if t.Root == nil {
+		return
+	}
+	t.Root.adjustRanges()
+}
+
+func (n *Node) adjustRanges() {
+	if n.Left != nil {
+		n.Left.adjustRanges()
+	}
+	if n.Right != nil {
+		n.Right.adjustRanges()
+	}
+	n.adjustRange()
+}
+
+// Insert inserts the Interface e into the Tree. Insertions may replace
+// existing stored intervals.
+func (t *Tree) Insert(e Interface, fast bool) (err error) {
+	if e.Start().Compare(e.End()) > 0 {
+		return ErrInvertedRange
+	}
+	var d int
+	t.Root, d = t.Root.insert(e, e.Start(), e.ID(), fast)
+	t.Count += d
+	t.Root.Color = llrb.Black
+	return
+}
+
+func (n *Node) insert(e Interface, min Comparable, id uintptr, fast bool) (root *Node, d int) {
+	if n == nil {
+		return &Node{Elem: e, Range: e.NewMutable()}, 1
+	} else if n.Elem == nil {
+		n.Elem = e
+		if !fast {
+			n.adjustRange()
+		}
+		return n, 1
+	}
+
+	if Mode == TD234 {
+		if n.Left.color() == llrb.Red && n.Right.color() == llrb.Red {
+			n.flipColors()
+		}
+	}
+
+	switch c := min.Compare(n.Elem.Start()); {
+	case c == 0:
+		switch cid := id - n.Elem.ID(); {
+		case cid == 0:
+			n.Elem = e
+			if !fast {
+				n.Range.SetEnd(e.End())
+			}
+		case cid < 0:
+			n.Left, d = n.Left.insert(e, min, id, fast)
+		default:
+			n.Right, d = n.Right.insert(e, min, id, fast)
+		}
+	case c < 0:
+		n.Left, d = n.Left.insert(e, min, id, fast)
+	default:
+		n.Right, d = n.Right.insert(e, min, id, fast)
+	}
+
+	if n.Right.color() == llrb.Red && n.Left.color() == llrb.Black {
+		n = n.rotateLeft()
+	}
+	if n.Left.color() == llrb.Red && n.Left.Left.color() == llrb.Red {
+		n = n.rotateRight()
+	}
+
+	if Mode == BU23 {
+		if n.Left.color() == llrb.Red && n.Right.color() == llrb.Red {
+			n.flipColors()
+		}
+	}
+
+	if !fast {
+		n.adjustRange()
+	}
+	root = n
+
+	return
+}
+
+// DeleteMin deletes the left-most interval.
+func (t *Tree) DeleteMin(fast bool) {
+	if t.Root == nil {
+		return
+	}
+	var d int
+	t.Root, d = t.Root.deleteMin(fast)
+	t.Count += d
+	if t.Root == nil {
+		return
+	}
+	t.Root.Color = llrb.Black
+}
+
+func (n *Node) deleteMin(fast bool) (root *Node, d int) {
+	if n.Left == nil {
+		return nil, -1
+	}
+	if n.Left.color() == llrb.Black && n.Left.Left.color() == llrb.Black {
+		n = n.moveRedLeft()
+	}
+	n.Left, d = n.Left.deleteMin(fast)
+	if n.Left == nil {
+		n.Range.SetStart(n.Elem.Start())
+	}
+
+	root = n.fixUp(fast)
+
+	return
+}
+
+// DeleteMax deletes the right-most interval.
+func (t *Tree) DeleteMax(fast bool) {
+	if t.Root == nil {
+		return
+	}
+	var d int
+	t.Root, d = t.Root.deleteMax(fast)
+	t.Count += d
+	if t.Root == nil {
+		return
+	}
+	t.Root.Color = llrb.Black
+}
+
+func (n *Node) deleteMax(fast bool) (root *Node, d int) {
+	if n.Left != nil && n.Left.color() == llrb.Red {
+		n = n.rotateRight()
+	}
+	if n.Right == nil {
+		return nil, -1
+	}
+	if n.Right.color() == llrb.Black && n.Right.Left.color() == llrb.Black {
+		n = n.moveRedRight()
+	}
+	n.Right, d = n.Right.deleteMax(fast)
+	if n.Right == nil {
+		n.Range.SetEnd(n.Elem.End())
+	}
+
+	root = n.fixUp(fast)
+
+	return
+}
+
+// Delete deletes the element e if it exists in the Tree.
+func (t *Tree) Delete(e Interface, fast bool) (err error) {
+	if e.Start().Compare(e.End()) > 0 {
+		return ErrInvertedRange
+	}
+	if t.Root == nil || !e.Overlap(t.Root.Range) {
+		return
+	}
+	var d int
+	t.Root, d = t.Root.delete(e.Start(), e.ID(), fast)
+	t.Count += d
+	if t.Root == nil {
+		return
+	}
+	t.Root.Color = llrb.Black
+	return
+}
+
+func (n *Node) delete(min Comparable, id uintptr, fast bool) (root *Node, d int) {
+	if p := min.Compare(n.Elem.Start()); p < 0 || (p == 0 && id < n.Elem.ID()) {
+		if n.Left != nil {
+			if n.Left.color() == llrb.Black && n.Left.Left.color() == llrb.Black {
+				n = n.moveRedLeft()
+			}
+			n.Left, d = n.Left.delete(min, id, fast)
+			if n.Left == nil {
+				n.Range.SetStart(n.Elem.Start())
+			}
+		}
+	} else {
+		if n.Left.color() == llrb.Red {
+			n = n.rotateRight()
+		}
+		if n.Right == nil && id == n.Elem.ID() {
+			return nil, -1
+		}
+		if n.Right != nil {
+			if n.Right.color() == llrb.Black && n.Right.Left.color() == llrb.Black {
+				n = n.moveRedRight()
+			}
+			if id == n.Elem.ID() {
+				n.Elem = n.Right.min().Elem
+				n.Right, d = n.Right.deleteMin(fast)
+			} else {
+				n.Right, d = n.Right.delete(min, id, fast)
+			}
+			if n.Right == nil {
+				n.Range.SetEnd(n.Elem.End())
+			}
+		}
+	}
+
+	root = n.fixUp(fast)
+
+	return
+}
+
+// Return the left-most interval stored in the tree.
+func (t *Tree) Min() Interface {
+	if t.Root == nil {
+		return nil
+	}
+	return t.Root.min().Elem
+}
+
+func (n *Node) min() *Node {
+	for ; n.Left != nil; n = n.Left {
+	}
+	return n
+}
+
+// Return the right-most interval stored in the tree.
+func (t *Tree) Max() Interface {
+	if t.Root == nil {
+		return nil
+	}
+	return t.Root.max().Elem
+}
+
+func (n *Node) max() *Node {
+	for ; n.Right != nil; n = n.Right {
+	}
+	return n
+}
+
+// Floor returns the largest value equal to or less than the query q according to
+// q.Start().Compare(), with ties broken by comparison of ID() values.
+func (t *Tree) Floor(q Interface) (o Interface, err error) {
+	if t.Root == nil {
+		return
+	}
+	n := t.Root.floor(q.Start(), q.ID())
+	if n == nil {
+		return
+	}
+	return n.Elem, nil
+}
+
+func (n *Node) floor(m Comparable, id uintptr) *Node {
+	if n == nil {
+		return nil
+	}
+	switch c := m.Compare(n.Elem.Start()); {
+	case c == 0:
+		switch cid := id - n.Elem.ID(); {
+		case cid == 0:
+			return n
+		case cid < 0:
+			return n.Left.floor(m, id)
+		default:
+			if r := n.Right.floor(m, id); r != nil {
+				return r
+			}
+		}
+	case c < 0:
+		return n.Left.floor(m, id)
+	default:
+		if r := n.Right.floor(m, id); r != nil {
+			return r
+		}
+	}
+	return n
+}
+
+// Ceil returns the smallest value equal to or greater than the query q according to
+// q.Start().Compare(), with ties broken by comparison of ID() values.
+func (t *Tree) Ceil(q Interface) (o Interface, err error) {
+	if t.Root == nil {
+		return
+	}
+	n := t.Root.ceil(q.Start(), q.ID())
+	if n == nil {
+		return
+	}
+	return n.Elem, nil
+}
+
+func (n *Node) ceil(m Comparable, id uintptr) *Node {
+	if n == nil {
+		return nil
+	}
+	switch c := m.Compare(n.Elem.Start()); {
+	case c == 0:
+		switch cid := id - n.Elem.ID(); {
+		case cid == 0:
+			return n
+		case cid > 0:
+			return n.Right.ceil(m, id)
+		default:
+			if l := n.Left.ceil(m, id); l != nil {
+				return l
+			}
+		}
+	case c > 0:
+		return n.Right.ceil(m, id)
+	default:
+		if l := n.Left.ceil(m, id); l != nil {
+			return l
+		}
+	}
+	return n
+}
+
+// An Operation is a function that operates on an Interface. If done is returned true, the
+// Operation is indicating that no further work needs to be done and so the Do function should
+// traverse no further.
+type Operation func(Interface) (done bool)
+
+// Do performs fn on all intervals stored in the tree. A boolean is returned indicating whether the
+// Do traversal was interrupted by an Operation returning true. If fn alters stored intervals' sort
+// relationships, future tree operation behaviors are undefined.
+func (t *Tree) Do(fn Operation) bool {
+	if t.Root == nil {
+		return false
+	}
+	return t.Root.do(fn)
+}
+
+func (n *Node) do(fn Operation) (done bool) {
+	if n.Left != nil {
+		done = n.Left.do(fn)
+		if done {
+			return
+		}
+	}
+	done = fn(n.Elem)
+	if done {
+		return
+	}
+	if n.Right != nil {
+		done = n.Right.do(fn)
+	}
+	return
+}
+
+// DoReverse performs fn on all intervals stored in the tree, but in reverse of sort order. A boolean
+// is returned indicating whether the Do traversal was interrupted by an Operation returning true.
+// If fn alters stored intervals' sort relationships, future tree operation behaviors are undefined.
+func (t *Tree) DoReverse(fn Operation) bool {
+	if t.Root == nil {
+		return false
+	}
+	return t.Root.doReverse(fn)
+}
+
+func (n *Node) doReverse(fn Operation) (done bool) {
+	if n.Right != nil {
+		done = n.Right.doReverse(fn)
+		if done {
+			return
+		}
+	}
+	done = fn(n.Elem)
+	if done {
+		return
+	}
+	if n.Left != nil {
+		done = n.Left.doReverse(fn)
+	}
+	return
+}
+
+// DoMatch performs fn on all intervals stored in the tree that match q according to Overlap, with
+// q.Overlap() used to guide tree traversal, so DoMatching() will out perform Do() with a called
+// conditional function if the condition is based on sort order, but can not be reliably used if
+// the condition is independent of sort order. A boolean is returned indicating whether the Do
+// traversal was interrupted by an Operation returning true. If fn alters stored intervals' sort
+// relationships, future tree operation behaviors are undefined.
+func (t *Tree) DoMatching(fn Operation, q Overlapper) bool {
+	if t.Root != nil && q.Overlap(t.Root.Range) {
+		return t.Root.doMatch(fn, q)
+	}
+	return false
+}
+
+func (n *Node) doMatch(fn Operation, q Overlapper) (done bool) {
+	if n.Left != nil && q.Overlap(n.Left.Range) {
+		done = n.Left.doMatch(fn, q)
+		if done {
+			return
+		}
+	}
+	if q.Overlap(n.Elem) {
+		done = fn(n.Elem)
+		if done {
+			return
+		}
+	}
+	if n.Right != nil && q.Overlap(n.Right.Range) {
+		done = n.Right.doMatch(fn, q)
+	}
+	return
+}
+
+// DoMatchReverse performs fn on all intervals stored in the tree that match q according to Overlap,
+// with q.Overlap() used to guide tree traversal, so DoMatching() will out perform Do() with a called
+// conditional function if the condition is based on sort order, but can not be reliably used if
+// the condition is independent of sort order. A boolean is returned indicating whether the Do
+// traversal was interrupted by an Operation returning true. If fn alters stored intervals' sort
+// relationships, future tree operation behaviors are undefined.
+func (t *Tree) DoMatchingReverse(fn Operation, q Overlapper) bool {
+	if t.Root != nil && q.Overlap(t.Root.Range) {
+		return t.Root.doMatch(fn, q)
+	}
+	return false
+}
+
+func (n *Node) doMatchReverse(fn Operation, q Overlapper) (done bool) {
+	if n.Right != nil && q.Overlap(n.Right.Range) {
+		done = n.Right.doMatchReverse(fn, q)
+		if done {
+			return
+		}
+	}
+	if q.Overlap(n.Elem) {
+		done = fn(n.Elem)
+		if done {
+			return
+		}
+	}
+	if n.Left != nil && q.Overlap(n.Left.Range) {
+		done = n.Left.doMatchReverse(fn, q)
+	}
+	return
+}

--- a/util/interval/interval.go
+++ b/util/interval/interval.go
@@ -7,6 +7,7 @@
 package interval
 
 import (
+	"bytes"
 	"errors"
 
 	"github.com/biogo/store/llrb"
@@ -35,45 +36,36 @@ type Overlapper interface {
 }
 
 // A Range is a type that describes the basic characteristics of an interval.
-type Range interface {
-	// Return a Comparable equal to the start value of the Overlapper.
-	Start() Comparable
-	// Return a Comparable equal to the end value of the Overlapper.
-	End() Comparable
+type Range struct {
+	Start, End Comparable
 }
 
 // An Interface is a type that can be inserted into a Tree.
 type Interface interface {
 	Overlapper
-	Range
-	ID() uintptr         // Returns a unique ID for the element.
-	NewMutable() Mutable // Returns an mutable copy of the Interface's range.
-}
-
-// A Mutable is a Range that can have its range altered.
-type Mutable interface {
-	Range
-	SetStart(Comparable) // Set the start value.
-	SetEnd(Comparable)   // Set the end value.
+	Range() Range
+	ID() uintptr // Returns a unique ID for the element.
 }
 
 // A Comparable is a type that describes the ends of an Overlapper.
-type Comparable interface {
-	// Compare returns a value indicating the sort order relationship between the
-	// receiver and the parameter.
-	//
-	// Given c = a.Compare(b):
-	//  c < 0 if a < b;
-	//  c == 0 if a == b; and
-	//  c > 0 if a > b.
-	//
-	Compare(Comparable) int
+type Comparable []byte
+
+// Compare returns a value indicating the sort order relationship between the
+// receiver and the parameter.
+//
+// Given c = a.Compare(b):
+//  c < 0 if a < b;
+//  c == 0 if a == b; and
+//  c > 0 if a > b.
+//
+func (c Comparable) Compare(o Comparable) int {
+	return bytes.Compare(c, o)
 }
 
 // A Node represents a node in a Tree.
 type Node struct {
 	Elem        Interface
-	Range       Mutable
+	Range       Range
 	Left, Right *Node
 	Color       llrb.Color
 }
@@ -98,12 +90,12 @@ func (n *Node) color() llrb.Color {
 // rooted at root, assuming that the left and right nodes have correct
 // range extents.
 func maxRange(root, left, right *Node) Comparable {
-	end := root.Elem.End()
-	if left != nil && left.Range.End().Compare(end) > 0 {
-		end = left.Range.End()
+	end := root.Elem.Range().End
+	if left != nil && left.Range.End.Compare(end) > 0 {
+		end = left.Range.End
 	}
-	if right != nil && right.Range.End().Compare(end) > 0 {
-		end = right.Range.End()
+	if right != nil && right.Range.End.Compare(end) > 0 {
+		end = right.Range.End
 	}
 	return end
 }
@@ -117,13 +109,13 @@ func (n *Node) rotateLeft() (root *Node) {
 	root.Color = n.Color
 	n.Color = llrb.Red
 
-	root.Left.Range.SetEnd(maxRange(root.Left, root.Left.Left, root.Left.Right))
+	root.Left.Range.End = maxRange(root.Left, root.Left.Left, root.Left.Right)
 	if root.Left == nil {
-		root.Range.SetStart(root.Elem.Start())
+		root.Range.Start = root.Elem.Range().Start
 	} else {
-		root.Range.SetStart(root.Left.Range.Start())
+		root.Range.Start = root.Left.Range.Start
 	}
-	root.Range.SetEnd(maxRange(root, root.Left, root.Right))
+	root.Range.End = maxRange(root, root.Left, root.Right)
 
 	return
 }
@@ -138,12 +130,12 @@ func (n *Node) rotateRight() (root *Node) {
 	n.Color = llrb.Red
 
 	if root.Right.Left == nil {
-		root.Right.Range.SetStart(root.Right.Elem.Start())
+		root.Right.Range.Start = root.Right.Elem.Range().Start
 	} else {
-		root.Right.Range.SetStart(root.Right.Left.Range.Start())
+		root.Right.Range.Start = root.Right.Left.Range.Start
 	}
-	root.Right.Range.SetEnd(maxRange(root.Right, root.Right.Left, root.Right.Right))
-	root.Range.SetEnd(maxRange(root, root.Left, root.Right))
+	root.Right.Range.End = maxRange(root.Right, root.Right.Left, root.Right.Right)
+	root.Range.End = maxRange(root, root.Left, root.Right)
 
 	return
 }
@@ -182,11 +174,11 @@ func (n *Node) fixUp(fast bool) *Node {
 // spans and the node's Elem span.
 func (n *Node) adjustRange() {
 	if n.Left == nil {
-		n.Range.SetStart(n.Elem.Start())
+		n.Range.Start = n.Elem.Range().Start
 	} else {
-		n.Range.SetStart(n.Left.Range.Start())
+		n.Range.Start = n.Left.Range.Start
 	}
-	n.Range.SetEnd(maxRange(n, n.Left, n.Right))
+	n.Range.End = maxRange(n, n.Left, n.Right)
 }
 
 func (n *Node) moveRedLeft() *Node {
@@ -247,11 +239,12 @@ func (n *Node) adjustRanges() {
 // Insert inserts the Interface e into the Tree. Insertions may replace
 // existing stored intervals.
 func (t *Tree) Insert(e Interface, fast bool) (err error) {
-	if e.Start().Compare(e.End()) > 0 {
+	r := e.Range()
+	if r.Start.Compare(r.End) > 0 {
 		return ErrInvertedRange
 	}
 	var d int
-	t.Root, d = t.Root.insert(e, e.Start(), e.ID(), fast)
+	t.Root, d = t.Root.insert(e, r.Start, e.ID(), fast)
 	t.Count += d
 	t.Root.Color = llrb.Black
 	return
@@ -259,7 +252,7 @@ func (t *Tree) Insert(e Interface, fast bool) (err error) {
 
 func (n *Node) insert(e Interface, min Comparable, id uintptr, fast bool) (root *Node, d int) {
 	if n == nil {
-		return &Node{Elem: e, Range: e.NewMutable()}, 1
+		return &Node{Elem: e, Range: e.Range()}, 1
 	} else if n.Elem == nil {
 		n.Elem = e
 		if !fast {
@@ -274,13 +267,13 @@ func (n *Node) insert(e Interface, min Comparable, id uintptr, fast bool) (root 
 		}
 	}
 
-	switch c := min.Compare(n.Elem.Start()); {
+	switch c := min.Compare(n.Elem.Range().Start); {
 	case c == 0:
 		switch cid := id - n.Elem.ID(); {
 		case cid == 0:
 			n.Elem = e
 			if !fast {
-				n.Range.SetEnd(e.End())
+				n.Range.End = e.Range().End
 			}
 		case cid < 0:
 			n.Left, d = n.Left.insert(e, min, id, fast)
@@ -337,7 +330,7 @@ func (n *Node) deleteMin(fast bool) (root *Node, d int) {
 	}
 	n.Left, d = n.Left.deleteMin(fast)
 	if n.Left == nil {
-		n.Range.SetStart(n.Elem.Start())
+		n.Range.Start = n.Elem.Range().Start
 	}
 
 	root = n.fixUp(fast)
@@ -371,7 +364,7 @@ func (n *Node) deleteMax(fast bool) (root *Node, d int) {
 	}
 	n.Right, d = n.Right.deleteMax(fast)
 	if n.Right == nil {
-		n.Range.SetEnd(n.Elem.End())
+		n.Range.End = n.Elem.Range().End
 	}
 
 	root = n.fixUp(fast)
@@ -381,14 +374,15 @@ func (n *Node) deleteMax(fast bool) (root *Node, d int) {
 
 // Delete deletes the element e if it exists in the Tree.
 func (t *Tree) Delete(e Interface, fast bool) (err error) {
-	if e.Start().Compare(e.End()) > 0 {
+	r := e.Range()
+	if r.Start.Compare(r.End) > 0 {
 		return ErrInvertedRange
 	}
 	if t.Root == nil || !e.Overlap(t.Root.Range) {
 		return
 	}
 	var d int
-	t.Root, d = t.Root.delete(e.Start(), e.ID(), fast)
+	t.Root, d = t.Root.delete(r.Start, e.ID(), fast)
 	t.Count += d
 	if t.Root == nil {
 		return
@@ -398,14 +392,14 @@ func (t *Tree) Delete(e Interface, fast bool) (err error) {
 }
 
 func (n *Node) delete(min Comparable, id uintptr, fast bool) (root *Node, d int) {
-	if p := min.Compare(n.Elem.Start()); p < 0 || (p == 0 && id < n.Elem.ID()) {
+	if p := min.Compare(n.Elem.Range().Start); p < 0 || (p == 0 && id < n.Elem.ID()) {
 		if n.Left != nil {
 			if n.Left.color() == llrb.Black && n.Left.Left.color() == llrb.Black {
 				n = n.moveRedLeft()
 			}
 			n.Left, d = n.Left.delete(min, id, fast)
 			if n.Left == nil {
-				n.Range.SetStart(n.Elem.Start())
+				n.Range.Start = n.Elem.Range().Start
 			}
 		}
 	} else {
@@ -426,7 +420,7 @@ func (n *Node) delete(min Comparable, id uintptr, fast bool) (root *Node, d int)
 				n.Right, d = n.Right.delete(min, id, fast)
 			}
 			if n.Right == nil {
-				n.Range.SetEnd(n.Elem.End())
+				n.Range.End = n.Elem.Range().End
 			}
 		}
 	}
@@ -436,7 +430,7 @@ func (n *Node) delete(min Comparable, id uintptr, fast bool) (root *Node, d int)
 	return
 }
 
-// Return the left-most interval stored in the tree.
+// Min returns the left-most interval stored in the tree.
 func (t *Tree) Min() Interface {
 	if t.Root == nil {
 		return nil
@@ -450,7 +444,7 @@ func (n *Node) min() *Node {
 	return n
 }
 
-// Return the right-most interval stored in the tree.
+// Max returns the right-most interval stored in the tree.
 func (t *Tree) Max() Interface {
 	if t.Root == nil {
 		return nil
@@ -465,12 +459,12 @@ func (n *Node) max() *Node {
 }
 
 // Floor returns the largest value equal to or less than the query q according to
-// q.Start().Compare(), with ties broken by comparison of ID() values.
+// q.Start.Compare(), with ties broken by comparison of ID() values.
 func (t *Tree) Floor(q Interface) (o Interface, err error) {
 	if t.Root == nil {
 		return
 	}
-	n := t.Root.floor(q.Start(), q.ID())
+	n := t.Root.floor(q.Range().Start, q.ID())
 	if n == nil {
 		return
 	}
@@ -481,7 +475,7 @@ func (n *Node) floor(m Comparable, id uintptr) *Node {
 	if n == nil {
 		return nil
 	}
-	switch c := m.Compare(n.Elem.Start()); {
+	switch c := m.Compare(n.Elem.Range().Start); {
 	case c == 0:
 		switch cid := id - n.Elem.ID(); {
 		case cid == 0:
@@ -504,12 +498,12 @@ func (n *Node) floor(m Comparable, id uintptr) *Node {
 }
 
 // Ceil returns the smallest value equal to or greater than the query q according to
-// q.Start().Compare(), with ties broken by comparison of ID() values.
+// q.Start.Compare(), with ties broken by comparison of ID() values.
 func (t *Tree) Ceil(q Interface) (o Interface, err error) {
 	if t.Root == nil {
 		return
 	}
-	n := t.Root.ceil(q.Start(), q.ID())
+	n := t.Root.ceil(q.Range().Start, q.ID())
 	if n == nil {
 		return
 	}
@@ -520,7 +514,7 @@ func (n *Node) ceil(m Comparable, id uintptr) *Node {
 	if n == nil {
 		return nil
 	}
-	switch c := m.Compare(n.Elem.Start()); {
+	switch c := m.Compare(n.Elem.Range().Start); {
 	case c == 0:
 		switch cid := id - n.Elem.ID(); {
 		case cid == 0:
@@ -601,7 +595,7 @@ func (n *Node) doReverse(fn Operation) (done bool) {
 	return
 }
 
-// DoMatch performs fn on all intervals stored in the tree that match q according to Overlap, with
+// DoMatching performs fn on all intervals stored in the tree that match q according to Overlap, with
 // q.Overlap() used to guide tree traversal, so DoMatching() will out perform Do() with a called
 // conditional function if the condition is based on sort order, but can not be reliably used if
 // the condition is independent of sort order. A boolean is returned indicating whether the Do
@@ -621,7 +615,7 @@ func (n *Node) doMatch(fn Operation, q Overlapper) (done bool) {
 			return
 		}
 	}
-	if q.Overlap(n.Elem) {
+	if q.Overlap(n.Elem.Range()) {
 		done = fn(n.Elem)
 		if done {
 			return
@@ -633,7 +627,7 @@ func (n *Node) doMatch(fn Operation, q Overlapper) (done bool) {
 	return
 }
 
-// DoMatchReverse performs fn on all intervals stored in the tree that match q according to Overlap,
+// DoMatchingReverse performs fn on all intervals stored in the tree that match q according to Overlap,
 // with q.Overlap() used to guide tree traversal, so DoMatching() will out perform Do() with a called
 // conditional function if the condition is based on sort order, but can not be reliably used if
 // the condition is independent of sort order. A boolean is returned indicating whether the Do
@@ -653,7 +647,7 @@ func (n *Node) doMatchReverse(fn Operation, q Overlapper) (done bool) {
 			return
 		}
 	}
-	if q.Overlap(n.Elem) {
+	if q.Overlap(n.Elem.Range()) {
 		done = fn(n.Elem)
 		if done {
 			return

--- a/util/interval/td234.go
+++ b/util/interval/td234.go
@@ -1,0 +1,9 @@
+// Copyright ©2014 The bíogo Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build td234
+
+package interval
+
+const Mode = TD234


### PR DESCRIPTION
The reduction in allocations was in line with what I was expecting, but
the perf benefits were smaller. I think it is still worthwhile to do
this, though.

Note the first commit is a fork of the biogo/store/interval code and the
second specializes it to only support []byte keys. I'll port the
biogo/store/interval tests as well if we decide this is worth keeping.

Fixes #4208.

```
name                   old time/op    new time/op    delta
Insert1_Cockroach-8       349µs ± 1%     348µs ± 1%     ~     (p=0.190 n=10+10)
Insert10_Cockroach-8      715µs ± 2%     695µs ± 3%   -2.78%  (p=0.000 n=10+10)
Insert100_Cockroach-8    3.95ms ± 1%    3.67ms ± 1%   -7.04%  (p=0.000 n=10+10)
Update1_Cockroach-8       785µs ± 1%     785µs ± 1%     ~       (p=1.000 n=9+9)
Update10_Cockroach-8     4.12ms ± 2%    4.06ms ± 2%   -1.43%  (p=0.011 n=10+10)
Update100_Cockroach-8    36.7ms ± 1%    35.9ms ± 1%   -2.28%  (p=0.000 n=10+10)
Delete1_Cockroach-8      1.11ms ± 1%    1.12ms ± 2%   +1.17%   (p=0.028 n=9+10)
Delete10_Cockroach-8     1.67ms ± 1%    1.60ms ± 2%   -4.11%   (p=0.000 n=8+10)
Delete100_Cockroach-8    8.16ms ± 1%    7.63ms ± 3%   -6.54%   (p=0.000 n=9+10)
Scan1_Cockroach-8         159µs ± 1%     159µs ± 1%     ~      (p=0.968 n=9+10)
Scan10_Cockroach-8        191µs ± 1%     190µs ± 1%     ~       (p=0.167 n=8+9)
Scan100_Cockroach-8       501µs ± 5%     491µs ± 2%     ~      (p=0.193 n=10+7)

name                   old allocs/op  new allocs/op  delta
Insert1_Cockroach-8         361 ± 0%       339 ± 0%   -5.98%  (p=0.000 n=10+10)
Insert10_Cockroach-8        937 ± 0%       790 ± 0%  -15.68%   (p=0.000 n=10+6)
Insert100_Cockroach-8     6.48k ± 0%     5.07k ± 0%  -21.74%    (p=0.000 n=9+8)
Update1_Cockroach-8         831 ± 0%       809 ± 0%   -2.65%  (p=0.000 n=10+10)
Update10_Cockroach-8      5.72k ± 0%     5.59k ± 0%   -2.30%  (p=0.000 n=10+10)
Update100_Cockroach-8     54.5k ± 0%     53.3k ± 0%   -2.25%   (p=0.000 n=9+10)
Delete1_Cockroach-8         772 ± 0%       752 ± 0%   -2.54%   (p=0.000 n=10+9)
Delete10_Cockroach-8      1.75k ± 0%     1.51k ± 0%  -13.48%   (p=0.000 n=10+8)
Delete100_Cockroach-8     11.0k ± 0%      8.6k ± 0%  -21.79%   (p=0.000 n=9+10)
Scan1_Cockroach-8           208 ± 0%       205 ± 1%   -1.16%  (p=0.000 n=10+10)
Scan10_Cockroach-8          287 ± 0%       285 ± 0%   -0.84%   (p=0.000 n=10+9)
Scan100_Cockroach-8       1.01k ± 0%     1.01k ± 0%   -0.16%   (p=0.000 n=10+8)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4215)

<!-- Reviewable:end -->
