### PR TITLE
storage: don't bother setting members to nil

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1165,7 +1165,6 @@ func TestStoreRangeRemoveDead(t *testing.T) {
 			mtc.stores[1].ForceReplicationScanAndProcess()
 		}
 	}
-	ticker.Stop()
 }
 
 // TestStoreRangeRebalance verifies that the replication queue will take

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -382,11 +382,6 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 
 			// Exit on stopper.
 			case <-stopper.ShouldStop():
-				bq.mu.Lock()
-				bq.mu.replicas = nil
-				bq.mu.priorityQ = nil
-				bq.mu.purgatory = nil
-				bq.mu.Unlock()
 				return
 			}
 		}


### PR DESCRIPTION
The stopper having stopped is not a guarantee that no more calls to the
queue will occur. It buys us nothing to set these members to nil, so
just leave them be.

Fixes #4220.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4221)

<!-- Reviewable:end -->
