### PR TITLE
Remove {BatchRequest,Transaction}.Trace{ID,Name}.

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -310,9 +310,8 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 
 	// This is the earliest point at which the request has an ID (if
 	// applicable). Begin a Trace which follows this request.
-	sp := tc.tracer.StartTrace(ba.TraceID())
+	sp := tc.tracer.StartTrace("sending batch")
 	defer sp.Finish()
-	sp.LogEvent("sending batch")
 	ctx, _ = opentracing.ContextWithSpan(ctx, sp)
 
 	var id string // optional transaction ID
@@ -561,7 +560,7 @@ func (tc *TxnCoordSender) heartbeatLoop(id string) {
 		tc.Lock()
 		txnMeta := tc.txns[id] // do not leak to outer scope
 		closer = txnMeta.txnEnd
-		sp = tc.tracer.StartTrace(txnMeta.txn.TraceID())
+		sp = tc.tracer.StartTrace("heartbeat loop")
 		defer sp.Finish()
 		tc.Unlock()
 	}

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -274,30 +274,6 @@ func (ba BatchRequest) String() string {
 	return strings.Join(str, ", ")
 }
 
-// Short gives gives a short version of the batch, printing the flags and
-// timestamp only.
-func (ba BatchRequest) Short() string {
-	return flagsToStr(ba.flags()) + "@" + ba.Timestamp.String()
-}
-
-// TraceID implements tracer.Traceable by returning the TraceID of the Transaction or,
-// if not transactional, a digest of the batch.
-func (ba BatchRequest) TraceID() string {
-	if r := ba.Txn.TraceID(); r != "" {
-		return r
-	}
-	return "c" + ba.Short()
-}
-
-// TraceName implements tracer.Traceable and behaves like TraceID, but using
-// the TraceName of the object delegated to.
-func (ba BatchRequest) TraceName() string {
-	if r := ba.Txn.TraceID(); r != "" {
-		return ba.Txn.TraceName()
-	}
-	return ba.Short()
-}
-
 // TODO(marc): we should assert
 // var _ security.RequestWithUser = &BatchRequest{}
 // here, but we need to break cycles first.

--- a/roachpb/batch_test.go
+++ b/roachpb/batch_test.go
@@ -18,9 +18,7 @@
 package roachpb
 
 import (
-	"encoding/hex"
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -87,30 +85,6 @@ func TestFlagsToStr(t *testing.T) {
 	exp := "AdWrAl"
 	if act := flagsToStr(ba.flags()); act != exp {
 		t.Fatalf("expected %s, got %s", exp, act)
-	}
-}
-
-func TestBatchTraceID(t *testing.T) {
-	var ba BatchRequest
-	ba.Add(&ReverseScanRequest{})
-	ba.Add(&IncrementRequest{})
-
-	expID := "cRdWrRgRv@0.000000000,0"
-	expName := expID[1:]
-	if actID, actName := ba.TraceID(), ba.TraceName(); expID != actID || expName != actName {
-		t.Fatalf("expected (%s,%s), got (%s, %s)", expID, expName, actID, actName)
-	}
-
-	uuidStr := "a53eef22-35f3-4c69-8e98-c563100e028c"
-	bytes, err := hex.DecodeString(strings.Replace(uuidStr, "-", "", -1))
-	if err != nil {
-		t.Fatal(err)
-	}
-	ba.Txn = &Transaction{ID: bytes}
-	expID = "t" + uuidStr
-	expName = expID[:9]
-	if actID, actName := ba.TraceID(), ba.TraceName(); expID != actID || expName != actName {
-		t.Fatalf("expected (%s,%s), got (%s, %s)", expID, expName, actID, actName)
 	}
 }
 

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -610,26 +610,6 @@ func (t *Transaction) Equal(s *Transaction) bool {
 	return TxnIDEqual(t.ID, s.ID)
 }
 
-// TraceID implements tracer.Traceable. For a nontrivial Transaction, it
-// returns 't', followed by the transaction ID. Otherwise, the empty string is
-// returned.
-func (t *Transaction) TraceID() string {
-	if t == nil || len(t.ID) == 0 {
-		return ""
-	}
-	s := uuid.UUID(t.ID).String()
-	return "t" + s
-}
-
-// TraceName implements tracer.Traceable. It returns TraceID, but using the
-// short version of the UUID.
-func (t *Transaction) TraceName() string {
-	if t == nil || len(t.ID) == 0 {
-		return "(none)"
-	}
-	return "t" + t.Short()
-}
-
 // IsInitialized returns true if the transaction has been initialized.
 func (t *Transaction) IsInitialized() bool {
 	return len(t.ID) > 0

--- a/server/node.go
+++ b/server/node.go
@@ -533,9 +533,8 @@ func (n *Node) executeCmd(argsI proto.Message) (proto.Message, error) {
 	f := func() {
 		// TODO(tschottdorf) get a hold of the client's ID, add it to the
 		// context before dispatching, and create an ID for tracing the request.
-		sp := n.ctx.Tracer.StartTrace(ba.TraceID())
+		sp := n.ctx.Tracer.StartTrace("node")
 		defer sp.Finish()
-		sp.LogEvent("node")
 		ctx, _ := opentracing.ContextWithSpan((*Node)(n).context(), sp)
 
 		tStart := time.Now()

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -103,7 +103,7 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 	stores := storage.NewStores(clock)
 	rpcSend := func(_ kv.SendOptions, _ kv.ReplicaSlice,
 		ba roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
-		sp := sCtx.Tracer.StartTrace(ba.TraceID())
+		sp := sCtx.Tracer.StartTrace("rpc send")
 		defer sp.Finish()
 		ctx, _ := opentracing.ContextWithSpan(context.Background(), sp)
 		br, pErr := stores.Send(ctx, ba)

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1842,7 +1842,7 @@ func (r *Replica) resolveIntents(ctx context.Context, intents []roachpb.Intent, 
 	if len(baLocal.Requests) > 0 {
 		action := func() *roachpb.Error {
 			// Trace this under the ID of the intent owner.
-			sp := r.store.Tracer().StartTrace(baLocal.TraceID())
+			sp := r.store.Tracer().StartTrace("resolve intents")
 			defer sp.Finish()
 			ctx, _ = opentracing.ContextWithSpan(ctx, sp)
 			_, pErr := r.addWriteCmd(ctx, baLocal, &wg)


### PR DESCRIPTION
TraceName wasn't being used. TraceID was only being used when starting
traces, but using it in this way should no longer be necessary as
opentracing internally has a trace ID. Additionally, TraceID was showing
up on profiles, even when tracing was disabled. If we want to log the
transaction ID in traces we'll have to find a more efficient
way (e.g. `opentracing.Span.LogEventWithPayload`).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4223)

<!-- Reviewable:end -->
