### PR TITLE
Bump opentracing pointer.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -46,7 +46,7 @@ github.com/mibk/dupl 47b66d6a523fb992d21bc375c1a2fef7320ccaa1
 github.com/montanaflynn/stats 2c10aa99e7ec8c4607d4427ec7a1a60fcdfce85f
 github.com/olekukonko/tablewriter cca8bbc0798408af109aaaa239cbd2634846b340
 github.com/opennota/check 2647c7f78677e5af42e988a36343bc83194b7109
-github.com/opentracing/opentracing-go a33c13ce61bf7d67fb342d044d5d899e8a9da77a
+github.com/opentracing/opentracing-go bc83a422bc08c8d1b72f0f548faab0145e35bb54
 github.com/peterh/liner d5e5aeeb67ca5aeeddeb0b6c3af05421ff63a0b6
 github.com/rcrowley/go-metrics 51425a2415d21afadfd55cd93432c0bc69e9598d
 github.com/robfig/glock cb3c3ec56de988289cab7bbd284eddc04dfee6c9


### PR DESCRIPTION
Grabs fix for unnecessary allocation in `opentracing.SpanFromContext`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4226)

<!-- Reviewable:end -->
