### PR TITLE
Add databaseCache for caching database IDs.

### DIFF
--- a/sql/plan.go
+++ b/sql/plan.go
@@ -30,13 +30,14 @@ import (
 // planner is the centerpiece of SQL statement execution combining session
 // state and database state with the logic for SQL execution.
 type planner struct {
-	txn          *client.Txn
-	session      Session
-	user         string
-	evalCtx      parser.EvalContext
-	leases       map[ID]*LeaseState
-	leaseMgr     *LeaseManager
-	systemConfig config.SystemConfig
+	txn           *client.Txn
+	session       Session
+	user          string
+	evalCtx       parser.EvalContext
+	leases        []*LeaseState
+	leaseMgr      *LeaseManager
+	systemConfig  config.SystemConfig
+	databaseCache *databaseCache
 	// List of schema changers (one for each outstanding
 	// schema change) created by commands in a transaction.
 	// The executor commits the transaction and then calls exec()


### PR DESCRIPTION
This avoids unmarshalling the database descriptor in order to retrieve
the database ID whenever a table lease is retrieved.

Change the planner leases cache from a map to a slice. This cache is
expected to be small (1 element in most cases, a few elements in extreme
cases). A slice is both faster and more memory efficient.

Minor perf gains. Chipping away, but the low-hanging fruit is fast
disappearing.

```
name                   old time/op    new time/op    delta
Insert1_Cockroach-8       332µs ± 1%     328µs ± 1%  -1.17%    (p=0.004 n=9+9)
Insert10_Cockroach-8      669µs ± 3%     658µs ± 3%  -1.77%  (p=0.043 n=10+10)
Insert100_Cockroach-8    3.62ms ± 2%    3.55ms ± 1%  -1.95%  (p=0.000 n=10+10)
Update1_Cockroach-8       734µs ± 2%     731µs ± 1%    ~      (p=0.083 n=10+8)
Update10_Cockroach-8     3.75ms ± 0%    3.70ms ± 1%  -1.41%   (p=0.000 n=9+10)
Update100_Cockroach-8    32.8ms ± 0%    32.3ms ± 1%  -1.55%   (p=0.000 n=7+10)
Delete1_Cockroach-8      1.06ms ± 1%    1.05ms ± 1%    ~       (p=0.605 n=9+9)
Delete10_Cockroach-8     1.57ms ± 1%    1.54ms ± 2%  -1.94%   (p=0.000 n=9+10)
Delete100_Cockroach-8    7.52ms ± 1%    7.46ms ± 1%  -0.82%  (p=0.015 n=10+10)
Scan1_Cockroach-8         146µs ± 1%     142µs ± 1%  -2.63%   (p=0.000 n=9+10)
Scan10_Cockroach-8        178µs ± 1%     175µs ± 2%  -1.57%  (p=0.001 n=10+10)
Scan100_Cockroach-8       453µs ± 3%     452µs ± 3%    ~     (p=0.971 n=10+10)

name                   old allocs/op  new allocs/op  delta
Insert1_Cockroach-8         299 ± 0%       285 ± 0%  -4.68%  (p=0.000 n=10+10)
Insert10_Cockroach-8        749 ± 0%       735 ± 0%  -1.87%   (p=0.000 n=9+10)
Insert100_Cockroach-8     5.03k ± 0%     5.01k ± 0%  -0.27%  (p=0.000 n=10+10)
Update1_Cockroach-8         679 ± 0%       652 ± 0%  -3.98%  (p=0.000 n=10+10)
Update10_Cockroach-8      4.78k ± 0%     4.51k ± 0%  -5.47%    (p=0.000 n=8+8)
Update100_Cockroach-8     45.6k ± 0%     43.0k ± 0%  -5.70%  (p=0.000 n=10+10)
Delete1_Cockroach-8         621 ± 0%       594 ± 0%  -4.35%  (p=0.000 n=10+10)
Delete10_Cockroach-8      1.38k ± 0%     1.36k ± 0%  -1.97%   (p=0.000 n=9+10)
Delete100_Cockroach-8     8.47k ± 0%     8.44k ± 0%  -0.32%   (p=0.000 n=10+8)
Scan1_Cockroach-8           169 ± 0%       155 ± 0%  -8.45%   (p=0.000 n=10+9)
Scan10_Cockroach-8          249 ± 0%       235 ± 0%  -5.50%   (p=0.000 n=8+10)
Scan100_Cockroach-8         975 ± 0%       962 ± 0%  -1.40%  (p=0.000 n=10+10)

```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4245)

<!-- Reviewable:end -->
