### PR TITLE
acceptance: use a stable version of docker-spy

### DIFF
--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	builderImage   = "cockroachdb/builder"
-	dockerspyImage = "cockroachdb/docker-spy"
+	dockerspyImage = "cockroachdb/docker-spy:20160209-142834"
 	domain         = "local"
 )
 


### PR DESCRIPTION
This will allow us to push a new version of this image without the risk
of breaking CI.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4263)

<!-- Reviewable:end -->
