### PR TITLE
build: add --fail-on-race to go2xunit cmdline

### DIFF
--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -27,12 +27,12 @@ prepare_artifacts() {
   if [ -n "${CIRCLE_TEST_REPORTS-}" ]; then
     if [ -f "${outdir}/test.log" ]; then
       mkdir -p "${CIRCLE_TEST_REPORTS}/test"
-      ${builder} go2xunit < "${outdir}/test.log" \
+      ${builder} go2xunit --fail-on-race < "${outdir}/test.log" \
         > "${CIRCLE_TEST_REPORTS}/test/test.xml"
     fi
     if [ -f "${outdir}/testrace.log" ]; then
       mkdir -p "${CIRCLE_TEST_REPORTS}/race"
-      ${builder} go2xunit < "${outdir}/testrace.log" \
+      ${builder} go2xunit --fail-on-race < "${outdir}/testrace.log" \
         > "${CIRCLE_TEST_REPORTS}/race/testrace.xml"
     fi
     if [ -f "${outdir}/acceptance.log" ]; then
@@ -48,7 +48,7 @@ prepare_artifacts() {
       echo 'ok github.com/cockroachdb/cockroach/acceptance 1337s' \
         >> "${outdir}/acceptance.log"
 
-      ${builder} go2xunit < "${outdir}/acceptance.log" \
+      ${builder} go2xunit --fail-on-race < "${outdir}/acceptance.log" \
         > "${CIRCLE_TEST_REPORTS}/acceptance/acceptance.xml"
     fi
   fi


### PR DESCRIPTION
This gives us better failure output for data races.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4265)

<!-- Reviewable:end -->
