### PR TITLE
change typings paths

### DIFF
--- a/ui/ts/components/metrics.ts
+++ b/ui/ts/components/metrics.ts
@@ -1,7 +1,6 @@
 // source: components/metrics.ts
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../typings/d3/d3.d.ts" />
-/// <reference path="../../typings/nvd3/nvd3.d.ts" />
+/// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../util/types.ts" />
 /// <reference path="../util/querycache.ts" />
 /// <reference path="../models/metrics.ts" />

--- a/ui/ts/components/navbar.ts
+++ b/ui/ts/components/navbar.ts
@@ -1,6 +1,6 @@
 // source: pages/nodes.ts
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../typings/lodash/lodash.d.ts" />
+/// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../util/property.ts" />
 
 // Author: Matt Tracy (matt@cockroachlabs.com)

--- a/ui/ts/components/table.ts
+++ b/ui/ts/components/table.ts
@@ -1,6 +1,6 @@
 // source: components/table.ts
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../typings/lodash/lodash.d.ts" />
+/// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../util/property.ts" />
 /// <reference path="../util/format.ts" />
 // Author: Matt Tracy (matt@cockroachlabs.com)

--- a/ui/ts/components/visualizations/bar.ts
+++ b/ui/ts/components/visualizations/bar.ts
@@ -1,5 +1,5 @@
 /// <reference path="../../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../../typings/d3/d3.d.ts" />
+/// <reference path="../../../typings/browser.d.ts" />
 
 // Author: Max Lang (max@cockroachlabs.com)
 

--- a/ui/ts/components/visualizations/bullet.ts
+++ b/ui/ts/components/visualizations/bullet.ts
@@ -1,5 +1,5 @@
 /// <reference path="../../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../../typings/d3/d3.d.ts" />
+/// <reference path="../../../typings/browser.d.ts" />
 
 // Author: Max Lang (max@cockroachlabs.com)
 

--- a/ui/ts/components/visualizations/line.ts
+++ b/ui/ts/components/visualizations/line.ts
@@ -1,5 +1,5 @@
 /// <reference path="../../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../../typings/d3/d3.d.ts" />
+/// <reference path="../../../typings/browser.d.ts" />
 
 // Author: Max Lang (max@cockroachlabs.com)
 

--- a/ui/ts/components/visualizations/number.ts
+++ b/ui/ts/components/visualizations/number.ts
@@ -1,5 +1,5 @@
 /// <reference path="../../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../../typings/d3/d3.d.ts" />
+/// <reference path="../../../typings/browser.d.ts" />
 
 // Author: Max Lang (max@cockroachlabs.com)
 

--- a/ui/ts/components/visualizations/pie.ts
+++ b/ui/ts/components/visualizations/pie.ts
@@ -1,5 +1,5 @@
 /// <reference path="../../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../../typings/d3/d3.d.ts" />
+/// <reference path="../../../typings/browser.d.ts" />
 
 // Author: Max Lang (max@cockroachlabs.com)
 

--- a/ui/ts/models/log.ts
+++ b/ui/ts/models/log.ts
@@ -1,6 +1,6 @@
 // source: models/log.ts
 /// <reference path="../models/proto.ts" />
-/// <reference path="../../typings/d3/d3.d.ts" />
+/// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
 /// <reference path="../util/chainprop.ts" />
 /// <reference path="../util/format.ts" />

--- a/ui/ts/models/status.ts
+++ b/ui/ts/models/status.ts
@@ -1,6 +1,5 @@
 // source: models/status.ts
-/// <reference path="../../typings/lodash/lodash.d.ts" />
-/// <reference path="../../typings/moment/moment.d.ts" />
+/// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
 /// <reference path="../util/http.ts" />
 /// <reference path="../util/querycache.ts" />

--- a/ui/ts/pages/cluster.ts
+++ b/ui/ts/pages/cluster.ts
@@ -1,6 +1,6 @@
 // source: pages/nodes.ts
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../typings/lodash/lodash.d.ts"/>
+/// <reference path="../../typings/browser.d.ts"/>
 /// <reference path="../models/status.ts" />
 /// <reference path="../components/metrics.ts" />
 /// <reference path="../components/table.ts" />

--- a/ui/ts/pages/graph.ts
+++ b/ui/ts/pages/graph.ts
@@ -1,6 +1,6 @@
 // source: pages/graph.ts
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../typings/d3/d3.d.ts" />
+/// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../util/querycache.ts" />
 /// <reference path="../components/metrics.ts" />
 

--- a/ui/ts/pages/nodes.ts
+++ b/ui/ts/pages/nodes.ts
@@ -1,6 +1,6 @@
 // source: pages/nodes.ts
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../typings/lodash/lodash.d.ts"/>
+/// <reference path="../../typings/browser.d.ts"/>
 /// <reference path="../models/status.ts" />
 /// <reference path="../components/metrics.ts" />
 /// <reference path="../components/table.ts" />

--- a/ui/ts/pages/sql.ts
+++ b/ui/ts/pages/sql.ts
@@ -1,7 +1,6 @@
 // source: pages/sql.ts
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../typings/moment/moment.d.ts" />
-/// <reference path="../../typings/moment-timezone/moment-timezone.d.ts"/>
+/// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../models/sqlquery.ts" />
 /// <reference path="../models/proto.ts" />
 /// <reference path="../util/property.ts" />

--- a/ui/ts/pages/stores.ts
+++ b/ui/ts/pages/stores.ts
@@ -1,6 +1,6 @@
 // source: pages/stores.ts
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../typings/lodash/lodash.d.ts"/>
+/// <reference path="../../typings/browser.d.ts"/>
 /// <reference path="../models/status.ts" />
 /// <reference path="../components/metrics.ts" />
 /// <reference path="../components/table.ts" />

--- a/ui/ts/test/components.ts
+++ b/ui/ts/test/components.ts
@@ -1,7 +1,5 @@
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../typings/lodash/lodash.d.ts" />
-/// <reference path="../../typings/mocha/mocha.d.ts" />
-/// <reference path="../../typings/chai/chai.d.ts" />
+/// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../components/table.ts" />
 /// <reference path="../util/property.ts" />
 

--- a/ui/ts/test/util.ts
+++ b/ui/ts/test/util.ts
@@ -1,6 +1,5 @@
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
-/// <reference path="../../typings/mocha/mocha.d.ts" />
-/// <reference path="../../typings/chai/chai.d.ts" />
+/// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../util/property.ts" />
 /// <reference path="../util/querycache.ts" />
 

--- a/ui/ts/util/convert.ts
+++ b/ui/ts/util/convert.ts
@@ -1,5 +1,4 @@
-/// <reference path="../../typings/moment/moment.d.ts" />
-/// <reference path="../../typings/moment-timezone/moment-timezone.d.ts"/>
+/// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../models/proto.ts" />
 
 // source: util/convert.ts

--- a/ui/ts/util/format.ts
+++ b/ui/ts/util/format.ts
@@ -1,5 +1,5 @@
 // source: util/format.ts
-/// <reference path="../../typings/d3/d3.d.ts" />
+/// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../models/proto.ts" />
 /// <reference path="../util/convert.ts" />
 // Author: Bram Gruneir (bram+code@cockroachlabs.com)


### PR DESCRIPTION
Typings has caused more issues than bower/npm combined and pulls in way fewer files.

The latest issue is that the typings file structure has changed to accommodate browser vs non-browser type files and master no longer builds.

I propose we should stop relying on it as part of our builds and just check in the type files.

(EDIT: This was scaled back to keep typings and just fix the paths)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4275)

<!-- Reviewable:end -->
