### PR TITLE
sql: store TableDescriptor by value in scanNode, instead of reference

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -56,7 +56,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 		return nil, pErr
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
+	if err := p.checkPrivilege(&tableDesc, privilege.CREATE); err != nil {
 		return nil, roachpb.NewError(err)
 	}
 
@@ -187,7 +187,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 		return nil, err
 	}
 
-	if pErr := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc)); err != nil {
+	if pErr := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(&tableDesc)); err != nil {
 		return nil, pErr
 	}
 	p.notifySchemaChange(tableDesc.ID, mutationID)

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -160,7 +160,7 @@ func (p *planner) backfillBatch(b *client.Batch, oldTableDesc *TableDescriptor, 
 		scan := &scanNode{
 			planner: p,
 			txn:     p.txn,
-			desc:    oldTableDesc,
+			desc:    *oldTableDesc,
 		}
 		scan.initDescDefaults()
 		rows := p.selectIndex(&selectNode{}, scan, nil, false)

--- a/sql/create.go
+++ b/sql/create.go
@@ -71,7 +71,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) 
 		}
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
+	if err := p.checkPrivilege(&tableDesc, privilege.CREATE); err != nil {
 		return nil, roachpb.NewError(err)
 	}
 
@@ -92,7 +92,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) 
 		return nil, pErr
 	}
 
-	if pErr := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc)); pErr != nil {
+	if pErr := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(&tableDesc)); pErr != nil {
 		return nil, pErr
 	}
 	p.notifySchemaChange(tableDesc.ID, mutationID)

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -193,7 +193,7 @@ func (p *planner) getDescriptorsFromTargetList(targets parser.TargetList) (
 			if err != nil {
 				return nil, err
 			}
-			descs = append(descs, descriptor)
+			descs = append(descs, &descriptor)
 		}
 	}
 	return descs, nil

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -115,7 +115,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, *roachpb.Error) {
 			return nil, pErr
 		}
 
-		if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
+		if err := p.checkPrivilege(&tableDesc, privilege.CREATE); err != nil {
 			return nil, roachpb.NewError(err)
 		}
 		idxName := indexQualifiedName.Index()
@@ -149,7 +149,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, *roachpb.Error) {
 			return nil, roachpb.NewError(err)
 		}
 
-		if pErr := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc)); pErr != nil {
+		if pErr := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(&tableDesc)); pErr != nil {
 			return nil, pErr
 		}
 		p.notifySchemaChange(tableDesc.ID, mutationID)

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -42,7 +42,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 		return nil, pErr
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.INSERT); err != nil {
+	if err := p.checkPrivilege(&tableDesc, privilege.INSERT); err != nil {
 		return nil, roachpb.NewError(err)
 	}
 
@@ -52,7 +52,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 		cols = tableDesc.Columns
 	} else {
 		var err error
-		if cols, err = p.processColumns(tableDesc, n.Columns); err != nil {
+		if cols, err = p.processColumns(&tableDesc, n.Columns); err != nil {
 			return nil, roachpb.NewError(err)
 		}
 	}
@@ -257,7 +257,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 		pErr = p.txn.Run(b)
 	}
 	if pErr != nil {
-		return nil, convertBatchError(tableDesc, *b, pErr)
+		return nil, convertBatchError(&tableDesc, *b, pErr)
 	}
 	return result, nil
 }

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -246,7 +246,7 @@ func (p *planner) getAliasedTableLease(n parser.TableExpr) (*TableDescriptor, *r
 	if pErr != nil {
 		return nil, pErr
 	}
-	return desc, nil
+	return &desc, nil
 }
 
 // notify that an outstanding schema change exists for the table.

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -152,7 +152,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, *roachpb.Error) 
 		return nil, pErr
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
+	if err := p.checkPrivilege(&tableDesc, privilege.DROP); err != nil {
 		return nil, roachpb.NewError(err)
 	}
 
@@ -167,7 +167,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, *roachpb.Error) 
 	}
 
 	descID := tableDesc.GetID()
-	descDesc := wrapDescriptor(tableDesc)
+	descDesc := wrapDescriptor(&tableDesc)
 
 	b := client.Batch{}
 	b.Put(descKey, descDesc)
@@ -224,7 +224,7 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, *roachpb.Error) 
 		return nil, roachpb.NewError(err)
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
+	if err := p.checkPrivilege(&tableDesc, privilege.CREATE); err != nil {
 		return nil, roachpb.NewError(err)
 	}
 
@@ -248,7 +248,7 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, *roachpb.Error) 
 	if err := tableDesc.Validate(); err != nil {
 		return nil, roachpb.NewError(err)
 	}
-	if pErr := p.txn.Put(descKey, wrapDescriptor(tableDesc)); pErr != nil {
+	if pErr := p.txn.Put(descKey, wrapDescriptor(&tableDesc)); pErr != nil {
 		return nil, pErr
 	}
 	p.notifySchemaChange(tableDesc.ID, invalidMutationID)
@@ -307,7 +307,7 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, *roachpb.Error
 		column = tableDesc.Mutations[i].GetColumn()
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
+	if err := p.checkPrivilege(&tableDesc, privilege.CREATE); err != nil {
 		return nil, roachpb.NewError(err)
 	}
 
@@ -343,7 +343,7 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, *roachpb.Error
 	if err := tableDesc.Validate(); err != nil {
 		return nil, roachpb.NewError(err)
 	}
-	if pErr := p.txn.Put(descKey, wrapDescriptor(tableDesc)); pErr != nil {
+	if pErr := p.txn.Put(descKey, wrapDescriptor(&tableDesc)); pErr != nil {
 		return nil, pErr
 	}
 	p.notifySchemaChange(tableDesc.ID, invalidMutationID)

--- a/sql/select.go
+++ b/sql/select.go
@@ -566,7 +566,7 @@ func (s *selectNode) computeOrdering(fromOrder orderingInfo) orderingInfo {
 //
 // If grouping is true, the ordering is the desired ordering for grouping.
 func (p *planner) selectIndex(sel *selectNode, s *scanNode, ordering columnOrdering, grouping bool) planNode {
-	if s.desc == nil || (sel.filter == nil && ordering == nil) {
+	if s.desc.isEmpty() || (sel.filter == nil && ordering == nil) {
 		// No table or no where-clause and no ordering.
 		s.initOrdering(0)
 		return s
@@ -577,17 +577,17 @@ func (p *planner) selectIndex(sel *selectNode, s *scanNode, ordering columnOrder
 		// An explicit secondary index was requested. Only add it to the candidate
 		// indexes list.
 		candidates = append(candidates, &indexInfo{
-			desc:  s.desc,
+			desc:  &s.desc,
 			index: s.index,
 		})
 	} else {
 		candidates = append(candidates, &indexInfo{
-			desc:  s.desc,
+			desc:  &s.desc,
 			index: &s.desc.PrimaryIndex,
 		})
 		for i := range s.desc.Indexes {
 			candidates = append(candidates, &indexInfo{
-				desc:  s.desc,
+				desc:  &s.desc,
 				index: &s.desc.Indexes[i],
 			})
 		}

--- a/sql/select_qvalue_test.go
+++ b/sql/select_qvalue_test.go
@@ -25,7 +25,7 @@ import (
 
 func testInitDummySelectNode(desc *TableDescriptor) *selectNode {
 	scan := &scanNode{}
-	scan.desc = desc
+	scan.desc = *desc
 	scan.initDescDefaults()
 
 	sel := &selectNode{}

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -631,6 +631,11 @@ func (desc *TableDescriptor) allColumnsSelector() parser.SelectExprs {
 	return exprs
 }
 
+func (desc *TableDescriptor) isEmpty() bool {
+	// Valid tables cannot have an ID of 0.
+	return desc.ID == 0
+}
+
 // SQLString returns the SQL string corresponding to the type.
 func (c *ColumnType) SQLString() string {
 	switch c.Kind {

--- a/sql/truncate.go
+++ b/sql/truncate.go
@@ -37,7 +37,7 @@ func (p *planner) Truncate(n *parser.Truncate) (planNode, *roachpb.Error) {
 			return nil, pErr
 		}
 
-		if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
+		if err := p.checkPrivilege(&tableDesc, privilege.DROP); err != nil {
 			return nil, roachpb.NewError(err)
 		}
 


### PR DESCRIPTION
This saves an entire allocation!

```
name                   old time/op    new time/op    delta
Bank_Cockroach-4          486µs ± 9%     459µs ± 4%  -5.39% (p=0.007 n=10+10)
Select1_Cockroach-4      61.2µs ± 5%    61.6µs ± 5%    ~    (p=0.905 n=9+10)
Insert1_Cockroach-4       474µs ± 1%     468µs ± 1%  -1.19% (p=0.001 n=10+8)
Insert10_Cockroach-4      850µs ± 1%     849µs ± 2%    ~    (p=0.853 n=10+10)
Insert100_Cockroach-4    4.29ms ± 3%    4.26ms ± 1%    ~    (p=0.400 n=9+10)
Update1_Cockroach-4      1.21ms ± 1%    1.21ms ± 2%    ~    (p=0.460 n=10+8)
Update10_Cockroach-4     6.09ms ± 1%    6.09ms ± 1%    ~    (p=0.897 n=8+10)
Update100_Cockroach-4    56.1ms ± 0%    56.0ms ± 2%    ~    (p=0.278 n=9+10)
Delete1_Cockroach-4      1.82ms ± 1%    1.86ms ± 1%  +2.37% (p=0.000 n=9+8)
Delete10_Cockroach-4     2.26ms ± 3%    2.29ms ± 2%    ~    (p=0.063 n=10+10)
Delete100_Cockroach-4    8.92ms ± 2%    8.94ms ± 2%    ~    (p=0.968 n=9+10)
Scan1_Cockroach-4         261µs ± 2%     259µs ± 2%    ~    (p=0.315 n=10+10)
Scan10_Cockroach-4        311µs ± 1%     313µs ± 3%    ~    (p=0.143 n=10+10)
Scan100_Cockroach-4       720µs ± 2%     720µs ± 1%    ~    (p=0.842 n=10+9)

name                   old alloc/op   new alloc/op   delta
Bank_Cockroach-4          165kB ± 1%     165kB ± 0%    ~    (p=0.529 n=10+10)
Select1_Cockroach-4      2.13kB ± 1%    2.13kB ± 1%    ~    (p=0.956 n=10+10)
Insert1_Cockroach-4      25.5kB ± 0%    25.5kB ± 0%    ~    (p=0.434 n=10+9)
Insert10_Cockroach-4     82.1kB ± 0%    82.1kB ± 0%    ~    (p=0.446 n=9+10)
Insert100_Cockroach-4     646kB ± 0%     646kB ± 0%    ~    (p=0.542 n=10+10)
Update1_Cockroach-4      43.4kB ± 0%    43.4kB ± 0%  +0.05% (p=0.036 n=8+10)
Update10_Cockroach-4      282kB ± 0%     283kB ± 0%    ~    (p=0.353 n=10+10)
Update100_Cockroach-4    2.65MB ± 0%    2.66MB ± 0%    ~    (p=0.190 n=10+10)
Delete1_Cockroach-4      41.1kB ± 0%    41.1kB ± 0%    ~    (p=0.393 n=10+10)
Delete10_Cockroach-4      140kB ± 0%     140kB ± 0%    ~    (p=0.356 n=9+10)
Delete100_Cockroach-4    1.04MB ± 0%    1.04MB ± 0%    ~    (p=0.089 n=10+10)
Scan1_Cockroach-4        11.1kB ± 1%    11.1kB ± 1%    ~    (p=0.739 n=10+10)
Scan10_Cockroach-4       17.4kB ± 0%    17.4kB ± 0%    ~    (p=0.492 n=10+10)
Scan100_Cockroach-4      69.3kB ± 0%    69.3kB ± 0%    ~    (p=0.853 n=10+10)

name                   old allocs/op  new allocs/op  delta
Bank_Cockroach-4            984 ± 0%       979 ± 0%  -0.47% (p=0.000 n=8+8)
Select1_Cockroach-4        49.0 ± 0%      49.0 ± 0%    ~    (all samples are equal)
Insert1_Cockroach-4         372 ± 0%       372 ± 0%    ~    (all samples are equal)
Insert10_Cockroach-4        874 ± 0%       874 ± 0%    ~    (all samples are equal)
Insert100_Cockroach-4     5.63k ± 0%     5.63k ± 0%    ~    (p=0.568 n=6+10)
Update1_Cockroach-4         825 ± 0%       824 ± 0%  -0.12% (p=0.000 n=10+10)
Update10_Cockroach-4      5.67k ± 0%     5.66k ± 0%  -0.17% (p=0.000 n=10+10)
Update100_Cockroach-4     54.0k ± 0%     53.9k ± 0%  -0.17% (p=0.000 n=9+10)
Delete1_Cockroach-4         766 ± 0%       765 ± 0%  -0.13% (p=0.000 n=7+10)
Delete10_Cockroach-4      1.66k ± 0%     1.66k ± 0%  -0.06% (p=0.006 n=7+9)
Delete100_Cockroach-4     9.94k ± 0%     9.94k ± 0%  -0.02% (p=0.001 n=10+10)
Scan1_Cockroach-4           224 ± 0%       223 ± 0%  -0.45% (p=0.000 n=8+7)
Scan10_Cockroach-4          326 ± 0%       325 ± 0%  -0.18% (p=0.006 n=9+10)
Scan100_Cockroach-4       1.24k ± 0%     1.23k ± 0%  -0.11% (p=0.000 n=8+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4278)

<!-- Reviewable:end -->
