### PR TITLE
sql: Improve LIKE regexp compilation error handling

### DIFF
--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -663,7 +663,7 @@ var cmpOps = map[cmpArgs]cmpOp{
 				key := likeKey(pattern)
 				re, err := ctx.ReCache.GetRegexp(key)
 				if err != nil {
-					panic(fmt.Sprintf("LIKE regexp compilations should not fail: %v", err))
+					return DBool(false), fmt.Errorf("LIKE regexp compilation failed: %v", err)
 				}
 				like = re.MatchString
 			}


### PR DESCRIPTION
Fixes #4276.

It was pretty tricky getting this test case working...

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4281)

<!-- Reviewable:end -->
