### PR TITLE
Change Txn.Set{Priority,Isolation} to return error instead of roachpb.Error

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -153,8 +153,8 @@ func TestClientRetryNonTxn(t *testing.T) {
 		count := 0 // keeps track of retries
 		pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 			if test.isolation == roachpb.SNAPSHOT {
-				if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
-					return pErr
+				if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+					return roachpb.NewError(err)
 				}
 			}
 			txn.InternalSetPriority(txnPri)
@@ -246,8 +246,8 @@ func TestClientRunTransaction(t *testing.T) {
 
 		// Use snapshot isolation so non-transactional read can always push.
 		pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
-			if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
-				return pErr
+			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+				return roachpb.NewError(err)
 			}
 
 			// Put transactional value.

--- a/client/txn.go
+++ b/client/txn.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/caller"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
@@ -121,10 +122,10 @@ func (txn *Txn) DebugName() string {
 // SetIsolation sets the transaction's isolation type. Transactions default to
 // serializable isolation. The isolation must be set before any operations are
 // performed on the transaction.
-func (txn *Txn) SetIsolation(isolation roachpb.IsolationType) *roachpb.Error {
+func (txn *Txn) SetIsolation(isolation roachpb.IsolationType) error {
 	if txn.Proto.Isolation != isolation {
 		if txn.Proto.IsInitialized() {
-			return roachpb.NewErrorf("cannot change the isolation level of a running transaction")
+			return util.Errorf("cannot change the isolation level of a running transaction")
 		}
 		txn.Proto.Isolation = isolation
 	}
@@ -134,13 +135,13 @@ func (txn *Txn) SetIsolation(isolation roachpb.IsolationType) *roachpb.Error {
 // SetUserPriority sets the transaction's user priority. Transactions default to
 // normal user priority. The user priority must be set before any operations are
 // performed on the transaction.
-func (txn *Txn) SetUserPriority(userPriority roachpb.UserPriority) *roachpb.Error {
+func (txn *Txn) SetUserPriority(userPriority roachpb.UserPriority) error {
 	if txn.UserPriority != userPriority {
 		if txn.Proto.IsInitialized() {
-			return roachpb.NewErrorf("cannot change the user priority of a running transaction")
+			return util.Errorf("cannot change the user priority of a running transaction")
 		}
 		if userPriority < roachpb.MinUserPriority || userPriority > roachpb.MaxUserPriority {
-			return roachpb.NewErrorf("the given user priority %f is out of the allowed range [%f, %f]", userPriority, roachpb.MinUserPriority, roachpb.MaxUserPriority)
+			return util.Errorf("the given user priority %f is out of the allowed range [%f, %d]", userPriority, roachpb.MinUserPriority, roachpb.MaxUserPriority)
 		}
 		txn.UserPriority = userPriority
 	}

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -201,8 +201,8 @@ func TestKVDBTransaction(t *testing.T) {
 	value := []byte("value")
 	pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		// Use snapshot isolation so non-transactional read can always push.
-		if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
-			return pErr
+		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+			return roachpb.NewError(err)
 		}
 
 		if pErr := txn.Put(key, value); pErr != nil {

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -570,8 +570,8 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 	pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 		txn.SetDebugName(txnName, 0)
 		if isolation == roachpb.SNAPSHOT {
-			if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
-				return pErr
+			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+				return roachpb.NewError(err)
 			}
 		}
 		txn.InternalSetPriority(priority)

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -53,8 +53,8 @@ func TestTxnDBBasics(t *testing.T) {
 
 		pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 			// Use snapshot isolation so non-transactional read can always push.
-			if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
-				return pErr
+			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+				return roachpb.NewError(err)
 			}
 
 			// Put transactional value.
@@ -413,8 +413,8 @@ func TestTxnTimestampRegression(t *testing.T) {
 	keyB := "b"
 	pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 		// Use snapshot isolation so non-transactional read can always push.
-		if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
-			return pErr
+		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+			return roachpb.NewError(err)
 		}
 		// Put transactional value.
 		if pErr := txn.Put(keyA, "value1"); pErr != nil {
@@ -457,8 +457,8 @@ func TestTxnLongDelayBetweenWritesWithConcurrentRead(t *testing.T) {
 	go func() {
 		pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 			// Use snapshot isolation.
-			if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
-				return pErr
+			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+				return roachpb.NewError(err)
 			}
 			// Put transactional value.
 			if pErr := txn.Put(keyA, "value1"); pErr != nil {
@@ -487,8 +487,8 @@ func TestTxnLongDelayBetweenWritesWithConcurrentRead(t *testing.T) {
 	s.Manual.Set((storage.MinTSCacheWindow + time.Second).Nanoseconds())
 	pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 		// Use snapshot isolation.
-		if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
-			return pErr
+		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+			return roachpb.NewError(err)
 		}
 
 		// Attempt to get first keyB.
@@ -533,8 +533,8 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 	go func() {
 		pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 			// Use snapshot isolation.
-			if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
-				return pErr
+			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+				return roachpb.NewError(err)
 			}
 			// Put transactional value.
 			if pErr := txn.Put(keyA, "value1"); pErr != nil {
@@ -562,8 +562,8 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 
 	pErr := s.DB.Txn(func(txn *client.Txn) *roachpb.Error {
 		// Use snapshot isolation.
-		if pErr := txn.SetIsolation(roachpb.SNAPSHOT); pErr != nil {
-			return pErr
+		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+			return roachpb.NewError(err)
 		}
 
 		// First get keyC, value will be nil.

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -89,7 +89,8 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, *r
 	case *parser.AlterTable:
 		return p.AlterTable(n)
 	case *parser.BeginTransaction:
-		return p.BeginTransaction(n)
+		pNode, err := p.BeginTransaction(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.CommitTransaction:
 		return p.CommitTransaction(n)
 	case *parser.CreateDatabase:
@@ -133,7 +134,8 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, *r
 	case *parser.SetTimeZone:
 		return p.SetTimeZone(n)
 	case *parser.SetTransaction:
-		return p.SetTransaction(n)
+		pNode, err := p.SetTransaction(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.Show:
 		return p.Show(n)
 	case *parser.ShowColumns:


### PR DESCRIPTION
Also change the following methods to return error.
- planner.BeginTransaction
- planner.SetTransaction
- planner.setIsolationLevel
- planner.setUserPriority

These methods call `Txn.Set{Priority,Isolation}` directly or indirectly.

Fix a tiny format error found by "go vet": Use `"%d"` for `roachpb.MaxUserPriority (= 1000)`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4283)

<!-- Reviewable:end -->
