### PR TITLE
sql: avoid detour though []byte when passing Session to exec

### DIFF
--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -564,9 +564,7 @@ func (c *v3Conn) executeStatements(stmts string, params []parser.Datum, formatCo
 	}
 
 	c.session.Reset()
-	if err := c.session.Unmarshal(resp.Session); err != nil {
-		return err
-	}
+	c.session = resp.Session
 
 	c.opts.database = c.session.Database
 	tracing.AnnotateTrace()

--- a/sql/server.go
+++ b/sql/server.go
@@ -95,13 +95,22 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reply, code, err := s.Execute(requestFromProto(args))
+	req, err := requestFromProto(args)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	reply, code, err := s.Execute(req)
 	if err != nil {
 		http.Error(w, err.Error(), code)
 	}
 
+	resp, err := protoFromResponse(reply)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
 	// Marshal the response.
-	body, contentType, err := util.MarshalResponse(r, protoFromResponse(reply), allowedEncodings)
+	body, contentType, err := util.MarshalResponse(r, resp, allowedEncodings)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -119,32 +128,49 @@ func (s Server) RegisterRPC(rpcServer *rpc.Server) error {
 
 func (s Server) executeCmd(argsI proto.Message) (proto.Message, error) {
 	args := argsI.(*driver.Request)
-	reply, _, err := s.Execute(requestFromProto(*args))
-	return protoFromResponse(reply), err
+	req, err := requestFromProto(*args)
+	if err != nil {
+		return nil, err
+	}
+	reply, _, err := s.Execute(req)
+	if err != nil {
+		return nil, err
+	}
+	return protoFromResponse(reply)
 }
 
-func requestFromProto(dr driver.Request) Request {
+func requestFromProto(dr driver.Request) (Request, error) {
+	var session Session
+	if err := proto.Unmarshal(dr.Session, &session); err != nil {
+		return Request{}, err
+	}
+
 	r := Request{
 		User:    dr.User,
-		Session: dr.Session,
+		Session: session,
 		SQL:     dr.Sql,
 		Params:  make([]parser.Datum, 0, len(dr.Params)),
 	}
 	for _, d := range dr.Params {
 		r.Params = append(r.Params, datumFromProto(d))
 	}
-	return r
+	return r, nil
 }
 
-func protoFromResponse(r Response) *driver.Response {
+func protoFromResponse(r Response) (*driver.Response, error) {
+	bytes, err := proto.Marshal(&r.Session)
+	if err != nil {
+		return nil, err
+	}
+
 	dr := &driver.Response{
-		Session: r.Session,
+		Session: bytes,
 		Results: make([]driver.Response_Result, 0, len(r.Results)),
 	}
 	for _, rr := range r.Results {
 		dr.Results = append(dr.Results, protoFromResult(rr))
 	}
-	return dr
+	return dr, nil
 }
 
 func protoFromResult(r Result) driver.Response_Result {


### PR DESCRIPTION
```
name                 old time/op    new time/op    delta
Select1_Cockroach-8    65.7µs ± 4%    62.2µs ± 1%  -5.30%  (p=0.000 n=10+10)
Insert1_Cockroach-8     484µs ± 4%     466µs ± 1%  -3.79%   (p=0.000 n=10+9)
Update1_Cockroach-8    1.13ms ± 5%    1.11ms ± 1%  -2.38%  (p=0.035 n=10+10)
Delete1_Cockroach-8    1.53ms ± 2%    1.49ms ± 2%  -2.17%  (p=0.000 n=10+10)
Scan1_Cockroach-8       263µs ± 3%     256µs ± 1%  -2.72%  (p=0.000 n=10+10)

name                 old alloc/op   new alloc/op   delta
Select1_Cockroach-8    2.16kB ± 0%    2.14kB ± 0%  -0.72%   (p=0.000 n=10+9)
Insert1_Cockroach-8    25.1kB ± 0%    25.1kB ± 0%    ~      (p=0.315 n=9+10)
Update1_Cockroach-8    42.8kB ± 0%    42.8kB ± 0%    ~     (p=0.810 n=10+10)
Delete1_Cockroach-8    40.4kB ± 0%    40.3kB ± 0%  -0.15%   (p=0.003 n=9+10)
Scan1_Cockroach-8      10.7kB ± 0%    10.7kB ± 0%    ~     (p=0.280 n=10+10)

name                 old allocs/op  new allocs/op  delta
Select1_Cockroach-8      49.0 ± 0%      48.0 ± 0%  -2.04%  (p=0.000 n=10+10)
Insert1_Cockroach-8       358 ± 0%       357 ± 0%  -0.28%  (p=0.000 n=10+10)
Update1_Cockroach-8       798 ± 0%       797 ± 0%  -0.13%  (p=0.000 n=10+10)
Delete1_Cockroach-8       738 ± 0%       738 ± 0%  -0.11%  (p=0.009 n=10+10)
Scan1_Cockroach-8         210 ± 0%       209 ± 0%  -0.62%   (p=0.000 n=10+8)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4289)

<!-- Reviewable:end -->
