### PR TITLE
Enhance the implementation of EXTRACT.

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -581,20 +581,20 @@ var builtins = map[string][]builtin{
 				fromTime := args[1].(DTimestamp)
 				timeSpan := strings.ToLower(string(args[0].(DString)))
 				switch timeSpan {
-				case "year":
+				case "year", "years":
 					return DInt(fromTime.Year()), nil
 
 				case "quarter":
 					return DInt(fromTime.Month()/4 + 1), nil
 
-				case "month":
+				case "month", "months":
 					return DInt(fromTime.Month()), nil
 
-				case "week":
+				case "week", "weeks":
 					_, week := fromTime.ISOWeek()
 					return DInt(week), nil
 
-				case "day":
+				case "day", "days":
 					return DInt(fromTime.Day()), nil
 
 				case "dayofweek", "dow":
@@ -603,23 +603,29 @@ var builtins = map[string][]builtin{
 				case "dayofyear", "doy":
 					return DInt(fromTime.YearDay()), nil
 
-				case "hour":
+				case "hour", "hours":
 					return DInt(fromTime.Hour()), nil
 
-				case "minute":
+				case "minute", "minutes":
 					return DInt(fromTime.Minute()), nil
 
-				case "second":
+				case "second", "seconds":
 					return DInt(fromTime.Second()), nil
 
-				case "millisecond":
+				case "millisecond", "milliseconds":
+					// This a PG extension not supported in MySQL.
 					return DInt(fromTime.Nanosecond() / int(time.Millisecond)), nil
 
-				case "microsecond":
+				case "microsecond", "microseconds":
 					return DInt(fromTime.Nanosecond() / int(time.Microsecond)), nil
 
-				case "nanosecond":
+				case "nanosecond", "nanoseconds":
+					// This is a CockroachDB extension.
 					return DInt(fromTime.Nanosecond()), nil
+
+				case "epoch_nanosecond", "epoch_nanoseconds":
+					// This is a CockroachDB extension.
+					return DInt(fromTime.UnixNano()), nil
 
 				case "epoch":
 					return DInt(fromTime.Unix()), nil

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -763,6 +763,111 @@ foobarbaz
 query error regexp_replace: invalid regexp flag: 'z'
 SELECT regexp_replace(E'fooBar\nbaz', 'b(..)$', E'X\\&Y', 'z')
 
+query I
+SELECT extract(milliseconds FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+306
+
+query I
+SELECT extract(millisecond FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+306
+
+query I
+SELECT extract(microseconds FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+306157
+
+query I
+SELECT extract(microsecond FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+306157
+
+query I
+SELECT extract(nanoseconds FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+306157519
+
+query I
+SELECT extract(nanosecond FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+306157519
+
+query I
+SELECT extract(second FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+33
+
+query I
+SELECT extract(seconds FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+33
+
+query I
+SELECT extract(minute FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+46
+
+query I
+SELECT extract(minutes FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+46
+
+query I
+SELECT extract(hour FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+19
+
+query I
+SELECT extract(hours FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+19
+
+query I
+SELECT extract(day FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+10
+
+query I
+SELECT extract(days FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+10
+
+query I
+SELECT extract(month FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+2
+
+query I
+SELECT extract(months FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+2
+
+query I
+SELECT extract(year FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+2016
+
+query I
+SELECT extract(years FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+2016
+
+query I
+SELECT extract(epoch FROM '1970-01-02 00:00:01.000001'::timestamp)
+----
+86401
+
+query I
+SELECT extract(epoch_nanosecond FROM '1970-01-02 00:00:01.000001'::timestamp)
+----
+86401000001000
+
+query I
+SELECT extract(epoch_nanoseconds FROM '1970-01-02 00:00:01.000001'::timestamp)
+----
+86401000001000
+
 query BI
 SELECT experimental_unique_bytes() < experimental_unique_bytes(), length(experimental_unique_bytes())
 ----


### PR DESCRIPTION
Prior to this patch there was a deviation between CockroachDB,
PostgreSQL's code, PostgreSQL's documentation and MySQL about
`EXTRACT`.
- MySQL: `EXTRACT(MICROSECOND FROM '2016-02-10 22:00:01.000123')` gives
  123
- PostgreSQL's code: `EXTRACT(MICROSECOND FROM '2016-02-10
  22:00:01.000123')` gives 1000123 (Seconds included!)
- PostgreSQL's doc: `EXTRACT(MICROSECOND FROM ...)` _fails with a syntax
  error_ (the doc only mentions `MICROSECONDS`, plural).
- CockroachDB: `EXTRACT(MICROSECOND FROM ...)` _fails with a syntax
  error_ (does what PG's doc says)

Now what about the plurals:
- MySQL: `EXTRACT(MICROSECONDS FROM ...` _fails with a syntax error_
- PostgreSQL's code: `EXTRACT(MICROSECONDS FROM '2016-02-10
  22:00:01.000123')` gives 1000123
- PostgreSQL's doc: same as code
- CockroachDB: `EXTRACT(MICROSECONDS FROM '2016-02-10 22:00:01.000123')`
  gives 123 (same as MySQL)

So to summarize:
- MySQL knows only singular, pg knows both.
- CockroachDB only knew the syntax advertised by the
  PostgreSQL docs, but did the same as MySQL.

This was unfortunate, and this patch restores some sanity by:
- supporting both singular and plural forms to create overlap
  with MySQL and PostgreSQL;
- using the same behavior as MySQL for 'microsecond' (only the
  fractional part), since it seems to be the most commonly used;
- providing 'millisecond' and 'nanosecond' to complement 'microsecond',
  and their plural forms;
- adding a new part 'epoch_nanoseconds' which returns the number of
  nanoseconds since the epoch. This is a convenience extension that
  enables extracting the full time information, including the
  fractional part, as an integer, without a convoluted expression
  involving multiple `EXTRACT` calls.

Fixes #4291.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4300)

<!-- Reviewable:end -->
