### PR TITLE
acceptance: allow docker tests to run

### DIFF
--- a/acceptance/c_test.go
+++ b/acceptance/c_test.go
@@ -23,9 +23,7 @@ import (
 	"testing"
 )
 
-// TestC connects to a cluster with C.
-func TestC(t *testing.T) {
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/3826")
+func TestDockerC(t *testing.T) {
 	testDockerSuccess(t, "c", []string{"/bin/sh", "-c", strings.Replace(c, "%v", "3", 1)})
 	testDockerFail(t, "c", []string{"/bin/sh", "-c", strings.Replace(c, "%v", "a", 1)})
 }

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -121,6 +121,7 @@ type LocalCluster struct {
 	Nodes                []*Container
 	events               chan Event
 	expectedEvents       chan Event
+	oneshot              *Container
 	CertsDir             string
 	monitorCtx           context.Context
 	monitorCtxCancelFunc func()
@@ -168,6 +169,31 @@ func (l *LocalCluster) expectEvent(c *Container, msgs ...string) {
 		}
 		break
 	}
+}
+
+// OneShot runs a container, expecting it to successfully run to completion
+// and die, after which it is removed. Not goroutine safe: only one OneShot
+// can be running at once.
+func (l *LocalCluster) OneShot(ipo types.ImagePullOptions, containerConfig container.Config, hostConfig container.HostConfig, name string) error {
+	if err := pullImage(l, ipo); err != nil {
+		return err
+	}
+	container, err := createContainer(l, containerConfig, hostConfig, name)
+	if err != nil {
+		return err
+	}
+	l.oneshot = container
+	defer func() {
+		if err := l.oneshot.Remove(); err != nil {
+			log.Errorf("ContainerRemove: %s", err)
+		}
+		l.oneshot = nil
+	}()
+
+	if err := l.oneshot.Start(); err != nil {
+		return err
+	}
+	return l.oneshot.Wait()
 }
 
 // stopOnPanic is invoked as a deferred function in Start in order to attempt
@@ -415,6 +441,12 @@ func (l *LocalCluster) startNode(i int) *Container {
 func (l *LocalCluster) processEvent(event events.Message) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+
+	// If there's currently a oneshot container, ignore any die messages from
+	// it because those are expected.
+	if l.oneshot != nil && event.ID == l.oneshot.id && event.Status == eventDie {
+		return true
+	}
 
 	for i, n := range l.Nodes {
 		if n != nil && n.id == event.ID {

--- a/acceptance/java_test.go
+++ b/acceptance/java_test.go
@@ -23,11 +23,10 @@ import (
 	"testing"
 )
 
-// TestJava connects to a cluster with Java.
-func TestJava(t *testing.T) {
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/3826")
-	testDockerSuccess(t, "java", []string{"/bin/sh", "-c", strings.Replace(java, "%v", "3", 1)})
-	testDockerFail(t, "java", []string{"/bin/sh", "-c", strings.Replace(java, "%v", `"a"`, 1)})
+func TestDockerJava(t *testing.T) {
+	t.Skip("blocked by #4411")
+	testDockerSuccess(t, "java", []string{"/bin/sh", "-c", strings.Replace(java, "%v", "Int(2, 3)", 1)})
+	testDockerFail(t, "java", []string{"/bin/sh", "-c", strings.Replace(java, "%v", `String(2, "a")`, 1)})
 }
 
 const java = `
@@ -50,7 +49,7 @@ public class main {
 
 		PreparedStatement stmt = conn.prepareStatement("SELECT 1, 2 > ?, ?::int, ?::string, ?::string, ?::string, ?::string, ?::string");
 		stmt.setInt(1, 3);
-		stmt.setInt(2, %v);
+		stmt.set%v;
 
 		stmt.setBoolean(3, true);
 		stmt.setLong(4, -4L);

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -34,13 +33,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/pkg/jsonmessage"
-	dockerclient "github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/strslice"
 	_ "github.com/lib/pq"
-	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/acceptance/terrafarm"
@@ -198,34 +194,28 @@ func getJSON(url, rel string, v interface{}) error {
 }
 
 // testDockerFail ensures the specified docker cmd fails.
-func testDockerFail(t *testing.T, tag string, cmd []string) {
-	if exitCode, logs := testDocker(t, tag, cmd); exitCode == 0 {
-		t.Log(logs)
-		t.Errorf("unexpected failure:\n%s", logs)
+func testDockerFail(t *testing.T, name string, cmd []string) {
+	if err := testDocker(t, name, cmd); err == nil {
+		t.Error("expected failure")
 	}
 }
 
 // testDockerSuccess ensures the specified docker cmd succeeds.
-func testDockerSuccess(t *testing.T, tag string, cmd []string) {
-	if exitCode, logs := testDocker(t, tag, cmd); exitCode != 0 {
-		t.Errorf("unexpected success:\n%s", logs)
+func testDockerSuccess(t *testing.T, name string, cmd []string) {
+	if err := testDocker(t, name, cmd); err != nil {
+		t.Errorf("expected success: %s", err)
 	}
 }
 
-func testDocker(t *testing.T, tag string, cmd []string) (exitCode int, logs string) {
+func testDocker(t *testing.T, name string, cmd []string) error {
+	const image = "cockroachdb/postgres-test"
+	const tag = "20160203-140220"
 	SkipUnlessLocal(t)
 	l := StartCluster(t).(*cluster.LocalCluster)
-
 	defer l.AssertAndStop(t)
-
-	cli, err := dockerclient.NewEnvClient()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	addr := l.Nodes[0].PGAddr()
 	containerConfig := container.Config{
-		Image: "cockroachdb/postgres-test:" + tag,
+		Image: fmt.Sprintf("%s:%s", image, tag),
 		Env: []string{
 			fmt.Sprintf("PGHOST=%s", addr.IP),
 			fmt.Sprintf("PGPORT=%d", addr.Port),
@@ -238,64 +228,9 @@ func testDocker(t *testing.T, tag string, cmd []string) (exitCode int, logs stri
 		Binds:       []string{fmt.Sprintf("%s:%s", l.CertsDir, "/certs")},
 		NetworkMode: "host",
 	}
-
-	rc, err := cli.ImagePull(context.Background(), types.ImagePullOptions{
-		ImageID: containerConfig.Image,
+	ipo := types.ImagePullOptions{
+		ImageID: image,
 		Tag:     tag,
-	}, nil)
-	if err != nil {
-		t.Fatal(err)
 	}
-	defer rc.Close()
-	dec := json.NewDecoder(rc)
-	for {
-		var message jsonmessage.JSONMessage
-		if err := dec.Decode(&message); err != nil {
-			if err == io.EOF {
-				break
-			}
-			t.Fatal(err)
-		}
-		log.Infof("ImagePull response: %s", message)
-	}
-
-	resp, err := cli.ContainerCreate(&containerConfig, &hostConfig, nil, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, warning := range resp.Warnings {
-		log.Warning(warning)
-	}
-	defer func() {
-		if err := cli.ContainerRemove(types.ContainerRemoveOptions{
-			ContainerID:   resp.ID,
-			RemoveVolumes: true,
-		}); err != nil {
-			t.Error(err)
-		}
-	}()
-	if err := cli.ContainerStart(resp.ID); err != nil {
-		t.Fatal(err)
-	}
-	exitCode, err = cli.ContainerWait(context.Background(), resp.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if exitCode != 0 {
-		rc, err := cli.ContainerLogs(context.Background(), types.ContainerLogsOptions{
-			ContainerID: resp.ID,
-			ShowStdout:  true,
-			ShowStderr:  true,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer rc.Close()
-		b, err := ioutil.ReadAll(rc)
-		if err != nil {
-			t.Fatal(err)
-		}
-		logs = string(b)
-	}
-	return
+	return l.OneShot(ipo, containerConfig, hostConfig, fmt.Sprintf("docker-%s", name))
 }

--- a/acceptance/php_test.go
+++ b/acceptance/php_test.go
@@ -23,11 +23,9 @@ import (
 	"testing"
 )
 
-// TestPHP connects to a cluster with PHP.
-func TestPHP(t *testing.T) {
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/3826")
-	testDockerSuccess(t, "php", []string{"-r", strings.Replace(php, "%v", "3", 1)})
-	testDockerFail(t, "php", []string{"-r", strings.Replace(php, "%v", `"a"`, 1)})
+func TestDockerPHP(t *testing.T) {
+	testDockerSuccess(t, "php", []string{"php", "-r", strings.Replace(php, "%v", "3", 1)})
+	testDockerFail(t, "php", []string{"php", "-r", strings.Replace(php, "%v", `"a"`, 1)})
 }
 
 const php = `

--- a/acceptance/python_test.go
+++ b/acceptance/python_test.go
@@ -23,11 +23,9 @@ import (
 	"testing"
 )
 
-// TestPython connects to a cluster with python.
-func TestPython(t *testing.T) {
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/3826")
-	testDockerSuccess(t, "python", []string{"-c", strings.Replace(python, "%v", "3", 1)})
-	testDockerFail(t, "python", []string{"-c", strings.Replace(python, "%v", `"a"`, 1)})
+func TestDockerPython(t *testing.T) {
+	testDockerSuccess(t, "python", []string{"python", "-c", strings.Replace(python, "%v", "3", 1)})
+	testDockerFail(t, "python", []string{"python", "-c", strings.Replace(python, "%v", `"a"`, 1)})
 }
 
 const python = `

--- a/acceptance/ruby_test.go
+++ b/acceptance/ruby_test.go
@@ -23,9 +23,7 @@ import (
 	"testing"
 )
 
-// TestRuby connects to a cluster with ruby.
-func TestRuby(t *testing.T) {
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/3826")
+func TestDockerRuby(t *testing.T) {
 	testDockerSuccess(t, "ruby", []string{"ruby", "-e", strings.Replace(ruby, "%v", "3", 1)})
 	testDockerFail(t, "ruby", []string{"ruby", "-e", strings.Replace(ruby, "%v", `"a"`, 1)})
 }

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -9,6 +9,26 @@ function is_shard() {
   test $(($1 % $CIRCLE_NODE_TOTAL)) -eq $CIRCLE_NODE_INDEX
 }
 
+function fetch_docker() {
+  local image=${1}
+  local tag=${2}
+  local name=${image}:${tag}
+  if ! docker images | grep -q "${name}"; then
+    # If there's a base image cached, load it. A click on CircleCI's "Clear
+    # Cache" will make sure we start with a clean slate.
+    imgcache="${builder_dir}/builder.${name}.tar"
+    find "${builder_dir}" -not -path "${imgcache}" -type f -delete
+    if [[ ! -e "${imgcache}" ]]; then
+      time docker pull "cockroachdb/${name}"
+      docker tag -f "cockroachdb/${name}" "cockroachdb/${image}:latest"
+      time docker save "cockroachdb/${name}" > "${imgcache}"
+    else
+      time docker load -i "${imgcache}"
+      docker tag -f "cockroachdb/${name}" "cockroachdb/${image}:latest"
+    fi
+  fi
+}
+
 # This is mildly tricky: This script runs itself recursively. The
 # first time it is run it does not take the if-branch below and
 # executes on the host computer. As a final step it uses the
@@ -110,22 +130,14 @@ ls -lah "${builder_dir}"
 # The tag for the cockroachdb/builder image. If the image is changed
 # (for example, adding "npm"), a new image should be pushed using
 # "build/builder.sh push" and the new tag value placed here.
-tag="20151210-134003"
+fetch_docker "builder" "20151210-134003"
 
-if ! docker images | grep -q "${tag}"; then
-  # If there's a base image cached, load it. A click on CircleCI's "Clear
-  # Cache" will make sure we start with a clean slate.
-  builder="${builder_dir}/builder.${tag}.tar"
-  find "${builder_dir}" -not -path "${builder}" -type f -delete
-  if [[ ! -e "${builder}" ]]; then
-    time docker pull "cockroachdb/builder:${tag}"
-    docker tag -f "cockroachdb/builder:${tag}" "cockroachdb/builder:latest"
-    time docker save "cockroachdb/builder:${tag}" > "${builder}"
-  else
-    time docker load -i "${builder}"
-    docker tag -f "cockroachdb/builder:${tag}" "cockroachdb/builder:latest"
-  fi
+if is_shard 0; then
+  # Dockerfile at: https://github.com/cockroachdb/postgres-test
+  fetch_docker "postgres-test" "20160203-140220"
 fi
+
+# TODO(mjibson): cache the docker-spy image
 
 HOME="" go get -u github.com/robfig/glock
 grep -v '^cmd' GLOCKFILE | glock sync -n


### PR DESCRIPTION
Cache the builder image, which is now just one image with all langs.

Continuation of #4113

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4301)

<!-- Reviewable:end -->
