### PR TITLE
Decimal and Float decoding routines dont panic on absent terminator

### DIFF
--- a/util/encoding/decimal.go
+++ b/util/encoding/decimal.go
@@ -165,7 +165,10 @@ func decodeDecimal(buf []byte, tmp []byte, invert bool) ([]byte, *inf.Dec, error
 		return buf[1:], inf.NewDec(0, 0), nil
 	}
 	tmp = tmp[len(tmp):cap(tmp)]
-	idx := bytes.Index(buf, []byte{floatTerminator})
+	idx := bytes.IndexByte(buf, floatTerminator)
+	if idx == -1 {
+		return nil, nil, util.Errorf("did not find terminator %#x in buffer %#x", floatTerminator, buf)
+	}
 	switch {
 	case buf[0] == floatNegLarge:
 		// Negative large.

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -439,17 +439,17 @@ func DecodeBytesDescending(b []byte, r []byte) ([]byte, []byte, error) {
 
 func decodeBytesInternal(b []byte, r []byte, e escapes) ([]byte, []byte, error) {
 	if len(b) == 0 || b[0] != e.marker {
-		return nil, nil, util.Errorf("did not find marker")
+		return nil, nil, util.Errorf("did not find marker %#x in buffer %#x", e.marker, b)
 	}
 	b = b[1:]
 
 	for {
 		i := bytes.IndexByte(b, e.escape)
 		if i == -1 {
-			return nil, nil, util.Errorf("did not find terminator")
+			return nil, nil, util.Errorf("did not find terminator %#x in buffer %#x", e.escape, b)
 		}
 		if i+1 >= len(b) {
-			return nil, nil, util.Errorf("malformed escape")
+			return nil, nil, util.Errorf("malformed escape in buffer %#x", b)
 		}
 
 		v := b[i+1]

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -367,6 +367,30 @@ func TestDecodeInvalid(t *testing.T) {
 			pattern: "unknown escape",
 			decode:  func(b []byte) error { _, _, err := DecodeBytesDescending(b, nil); return err },
 		},
+		{
+			name:    "Float, no terminator",
+			buf:     []byte{floatPosLarge},
+			pattern: "did not find terminator",
+			decode:  func(b []byte) error { _, _, err := DecodeFloatAscending(b, nil); return err },
+		},
+		{
+			name:    "FloatDecreasing, no terminator",
+			buf:     []byte{floatPosLarge},
+			pattern: "did not find terminator",
+			decode:  func(b []byte) error { _, _, err := DecodeFloatDescending(b, nil); return err },
+		},
+		{
+			name:    "Decimal, no terminator",
+			buf:     []byte{floatPosLarge},
+			pattern: "did not find terminator",
+			decode:  func(b []byte) error { _, _, err := DecodeDecimalAscending(b, nil); return err },
+		},
+		{
+			name:    "DecimalDecreasing, no terminator",
+			buf:     []byte{floatPosLarge},
+			pattern: "did not find terminator",
+			decode:  func(b []byte) error { _, _, err := DecodeDecimalDescending(b, nil); return err },
+		},
 	}
 	for _, test := range tests {
 		err := test.decode(test.buf)

--- a/util/encoding/float.go
+++ b/util/encoding/float.go
@@ -88,7 +88,10 @@ func DecodeFloatAscending(buf []byte, tmp []byte) ([]byte, float64, error) {
 		return buf[1:], 0, nil
 	}
 	tmp = tmp[len(tmp):cap(tmp)]
-	idx := bytes.Index(buf, []byte{floatTerminator})
+	idx := bytes.IndexByte(buf, floatTerminator)
+	if idx == -1 {
+		return nil, 0, util.Errorf("did not find terminator %#x in buffer %#x", floatTerminator, buf)
+	}
 	switch {
 	case buf[0] == floatNegLarge:
 		// Negative large.


### PR DESCRIPTION
Instead of panicking, these functions now return an error in a similar
way to `decodeBytesInternal`.

This was important because there are times when the encoding of a
decimal can be brought out of bounds and lose its terminator when
constructing span constraints. If this span was then pretty printed
(for instance in an `EXPLAIN` statement), it would have previously caused
a panic.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4310)

<!-- Reviewable:end -->
