### PR TITLE
Fix rocksdb prefix Seek performance.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -21,7 +21,7 @@ github.com/biogo/store 3b4c041f52c224ee4a44f5c8b150d003a40643a0
 github.com/cloudfoundry/gosigar 3ed7c74352dae6dc00bdc8c74045375352e3ec05
 github.com/cockroachdb/c-lz4 c40aaae2fc50293eb8750b34632bc3efe813e23f
 github.com/cockroachdb/c-protobuf 4feb192131ea08dfbd7253a00868ad69cbb61b81
-github.com/cockroachdb/c-rocksdb b7fb7bddcb55be35eacdf67e9e2c931083ce02c4
+github.com/cockroachdb/c-rocksdb c0124c907c74b579d9d3d48eb96471bef270bc25
 github.com/cockroachdb/c-snappy 5c6d0932e0adaffce4bfca7bdf2ac37f79952ccf
 github.com/cockroachdb/stress aa7690c22fd0abd6168ed0e6c361e4f4c5f7ab25
 github.com/cockroachdb/yacc 443154b1852a8702b07d675da6cd97cd9177a316

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -125,12 +125,12 @@ type Engine interface {
 	// immediately.
 	Flush() error
 	// NewIterator returns a new instance of an Iterator over this engine. When
-	// prefix is true, Seek will use the user-key prefix of the supplied MVCC key
-	// to restrict which sstables are searched, but iteration (using Next) over
-	// keys without the same user-key prefix will not work correctly (keys may be
-	// skipped). The caller must invoke Iterator.Close() when finished with the
-	// iterator to free resources.
-	NewIterator(prefix bool) Iterator
+	// prefix is non-nil, Seek will use the user-key prefix of the supplied MVCC
+	// key to restrict which sstables are searched, but iteration (using Next)
+	// over keys without the same user-key prefix will not work correctly (keys
+	// may be skipped). The caller must invoke Iterator.Close() when finished
+	// with the iterator to free resources.
+	NewIterator(prefix roachpb.Key) Iterator
 	// NewSnapshot returns a new instance of a read-only snapshot
 	// engine. Snapshots are instantaneous and, as long as they're
 	// released relatively quickly, inexpensive. Snapshots are released

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -215,7 +215,7 @@ func TestEngineBatch(t *testing.T) {
 				t.Errorf("%d: expected %s, but got %s", i, expectedValue, actualValue)
 			}
 			// Try using an iterator to get the value from the batch.
-			iter := b.NewIterator(false)
+			iter := b.NewIterator(nil)
 			iter.Seek(key)
 			if !iter.Valid() {
 				if currentBatch[len(currentBatch)-1].value != nil {
@@ -694,7 +694,7 @@ func TestSnapshotMethods(t *testing.T) {
 		}
 
 		// Verify NewIterator still iterates over original snapshot.
-		iter := snap.NewIterator(false)
+		iter := snap.NewIterator(nil)
 		iter.Seek(newKey)
 		if iter.Valid() {
 			t.Error("expected invalid iterator when seeking to element which shouldn't be visible to snapshot")

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -2609,7 +2609,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		// Every 10th step, verify the stats via manual engine scan.
 		if i%10 == 0 {
 			// Compute the stats manually.
-			iter := engine.NewIterator(false)
+			iter := engine.NewIterator(nil)
 			expMS, err := iter.ComputeStats(mvccKey(roachpb.KeyMin),
 				mvccKey(roachpb.KeyMax), ts.WallTime)
 			iter.Close()
@@ -2714,7 +2714,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 	}
 
 	// Verify aggregated stats match computed stats after GC.
-	iter := engine.NewIterator(false)
+	iter := engine.NewIterator(nil)
 	expMS, err := iter.ComputeStats(mvccKey(roachpb.KeyMin),
 		mvccKey(roachpb.KeyMax), ts3.WallTime)
 	iter.Close()
@@ -2736,7 +2736,7 @@ func TestMVCCComputeStatsError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	iter := engine.NewIterator(false)
+	iter := engine.NewIterator(nil)
 	_, err := iter.ComputeStats(mvccKey(roachpb.KeyMin),
 		mvccKey(roachpb.KeyMax), 100)
 	iter.Close()

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -253,7 +253,7 @@ func (r *RocksDB) Flush() error {
 }
 
 // NewIterator returns an iterator over this rocksdb engine.
-func (r *RocksDB) NewIterator(prefix bool) Iterator {
+func (r *RocksDB) NewIterator(prefix roachpb.Key) Iterator {
 	return newRocksDBIterator(r.rdb, prefix)
 }
 
@@ -355,7 +355,7 @@ func (r *rocksDBSnapshot) Flush() error {
 
 // NewIterator returns a new instance of an Iterator over the
 // engine using the snapshot handle.
-func (r *rocksDBSnapshot) NewIterator(prefix bool) Iterator {
+func (r *rocksDBSnapshot) NewIterator(prefix roachpb.Key) Iterator {
 	return newRocksDBIterator(r.handle, prefix)
 }
 
@@ -444,7 +444,7 @@ func (r *rocksDBBatch) Flush() error {
 	return util.Errorf("cannot flush a batch")
 }
 
-func (r *rocksDBBatch) NewIterator(prefix bool) Iterator {
+func (r *rocksDBBatch) NewIterator(prefix roachpb.Key) Iterator {
 	return newRocksDBIterator(r.batch, prefix)
 }
 
@@ -490,13 +490,13 @@ type rocksDBIterator struct {
 // instance. If snapshotHandle is not nil, uses the indicated snapshot.
 // The caller must call rocksDBIterator.Close() when finished with the
 // iterator to free up resources.
-func newRocksDBIterator(rdb *C.DBEngine, prefix bool) *rocksDBIterator {
+func newRocksDBIterator(rdb *C.DBEngine, prefix roachpb.Key) *rocksDBIterator {
 	// In order to prevent content displacement, caching is disabled
 	// when performing scans. Any options set within the shared read
 	// options field that should be carried over needs to be set here
 	// as well.
 	return &rocksDBIterator{
-		iter: C.DBNewIter(rdb, C.bool(prefix)),
+		iter: C.DBNewIter(rdb, goToCSlice(prefix)),
 	}
 }
 
@@ -786,7 +786,7 @@ func dbIterate(rdb *C.DBEngine, start, end MVCCKey,
 	if !start.Less(end) {
 		return nil
 	}
-	it := newRocksDBIterator(rdb, false)
+	it := newRocksDBIterator(rdb, nil)
 	defer it.Close()
 
 	it.Seek(start)

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -109,21 +109,22 @@ DBStatus DBDelete(DBEngine* db, DBKey key);
 DBStatus DBWriteBatch(DBEngine* db);
 
 // Creates a new snapshot of the database for use in DBGet() and
-// DBNewIter(). It is the callers responsibility to call DBClose().
+// DBNewIter(). It is the caller's responsibility to call DBClose().
 DBEngine* DBNewSnapshot(DBEngine* db);
 
 // Creates a new batch for performing a series of operations
 // atomically. Use DBWriteBatch() on the returned engine to apply the
-// batch to the database. It is the callers responsibility to call
+// batch to the database. It is the caller's responsibility to call
 // DBClose().
 DBEngine* DBNewBatch(DBEngine *db);
 
-// Creates a new database iterator. When prefix is true, Seek will use the
-// user-key prefix of the supplied MVCC key to restrict which sstables are
-// searched, but iteration (using Next) over keys without the same user-key
-// prefix will not work correctly (keys may be skipped). It is the callers
-// responsibility to call DBIterDestroy().
-DBIterator* DBNewIter(DBEngine* db, bool prefix);
+// Creates a new database iterator. When prefix is not empty, Seek
+// will use the user-key prefix of the supplied MVCC key to restrict
+// which sstables are searched, but iteration (using Next) over keys
+// without the same user-key prefix will not work correctly (keys may
+// be skipped). It is the caller's responsibility to call
+// DBIterDestroy().
+DBIterator* DBNewIter(DBEngine* db, DBSlice prefix);
 
 // Destroys an iterator, freeing up any associated memory.
 void DBIterDestroy(DBIterator* iter);

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1354,7 +1354,7 @@ func (r *Replica) AdminSplit(args roachpb.AdminSplitRequest, desc *roachpb.Range
 }
 
 func (r *Replica) computeStats(d *roachpb.RangeDescriptor, e engine.Engine, nowNanos int64) (engine.MVCCStats, error) {
-	iter := e.NewIterator(false)
+	iter := e.NewIterator(nil)
 	defer iter.Close()
 
 	ms := &engine.MVCCStats{}

--- a/storage/replica_data_iter.go
+++ b/storage/replica_data_iter.go
@@ -67,7 +67,7 @@ func makeReplicaKeyRanges(d *roachpb.RangeDescriptor) []keyRange {
 func newReplicaDataIterator(d *roachpb.RangeDescriptor, e engine.Engine) *replicaDataIterator {
 	ri := &replicaDataIterator{
 		ranges:   makeReplicaKeyRanges(d),
-		Iterator: e.NewIterator(false),
+		Iterator: e.NewIterator(nil),
 	}
 	ri.Seek(ri.ranges[ri.curIndex].start)
 	return ri


### PR DESCRIPTION
Set ReadOptions.iterate_upper_bound when creating "prefix"
iterators. This avoids pathological performance when seeking into a
rocksdb MemTable which contains large expanses of deletion tombstones.

Added a benchmark which demonstrates the pathological performance of the
old code.

```
name             old time/op  new time/op  delta
MVCCPutDelete-8   185µs ± 8%    11µs ± 3%  -94.11%  (p=0.000 n=10+10)
```

Fixes #4196.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4319)

<!-- Reviewable:end -->
