### PR TITLE
Increase duration for SucceedsWithin test.

### DIFF
--- a/util/testing_test.go
+++ b/util/testing_test.go
@@ -82,7 +82,7 @@ func TestSucceedsWithin(t *testing.T) {
 
 	// Try a method which succeeds after a known duration.
 	start := time.Now()
-	duration := time.Millisecond
+	duration := time.Millisecond * 10
 	SucceedsWithin(t, 100*duration, func() error {
 		elapsed := time.Since(start)
 		if elapsed > duration {


### PR DESCRIPTION
This was frequently failing on stress tests (even worse on my machine
than AWS). Giving it a bit more leeway seems to help.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4325)

<!-- Reviewable:end -->
