### PR TITLE
storage: avoid seeking iterators already at target

### DIFF
--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -511,6 +511,10 @@ func (r *rocksDBIterator) Seek(key MVCCKey) {
 		// to access start[0] in an explicit seek.
 		r.setState(C.DBIterSeekToFirst(r.iter))
 	} else {
+		// We can avoid seeking if we're already at the key we seek.
+		if r.valid && key.Equal(r.unsafeKey()) {
+			return
+		}
 		r.setState(C.DBIterSeek(r.iter, goToCKey(key)))
 	}
 }


### PR DESCRIPTION
```
name                              old time/op    new time/op    delta
MVCCConditionalPutCreate10-8        5.35µs ± 9%    5.13µs ± 2%  -4.04%        (p=0.002 n=10+10)
MVCCConditionalPutCreate100-8       5.34µs ± 1%    5.28µs ± 1%  -1.13%        (p=0.011 n=10+10)
MVCCConditionalPutCreate1000-8      7.22µs ± 2%    7.20µs ± 2%    ~             (p=0.546 n=9+9)
MVCCConditionalPutCreate10000-8     30.5µs ± 5%    28.9µs ± 1%  -5.04%        (p=0.001 n=10+10)
MVCCConditionalPutReplace10-8       7.01µs ± 3%    6.87µs ± 1%    ~            (p=0.053 n=9+10)
MVCCConditionalPutReplace100-8      7.71µs ± 7%    7.14µs ± 2%  -7.49%        (p=0.000 n=10+10)
MVCCConditionalPutReplace1000-8     14.1µs ± 8%    12.9µs ± 0%  -8.73%         (p=0.000 n=10+8)
MVCCConditionalPutReplace10000-8    56.0µs ± 5%    53.8µs ± 1%  -3.85%        (p=0.005 n=10+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4328)

<!-- Reviewable:end -->
