### PR TITLE
Fix one annoying and one serious concurrency bug

### DIFF
--- a/sql/testdata/snapshot_certain_read
+++ b/sql/testdata/snapshot_certain_read
@@ -1,0 +1,58 @@
+# This test verifies that when a SNAPSHOT transaction reads without
+# uncertainty, it actually does that. We had a performance bug which caused the
+# MaxTimestamp to be set to the Timestamp instead of OrigTimestamp on such
+# reads, which always left the interval (OrigTimestamp, Timestamp) open to
+# read uncertainty errors.
+
+statement ok
+CREATE TABLE t (a INT)
+
+statement ok
+GRANT ALL on t TO testuser
+
+# UserA starts the first transaction.
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SNAPSHOT
+
+# The SELECT forces the timestamp to be chosen.
+query I
+SELECT * FROM t
+----
+
+# UserB starts a transaction and inserts into the table.
+# TransactionB operates at a timestamp higher than TransactionA since we're
+# single-node and TransactionA has already picked its timestamp.
+user testuser
+
+# Insert a write that will show up in the future of TransactionA when it
+# tries to read.
+statement ok
+INSERT INTO t VALUES (1)
+
+# Touch all keys with a timestamp ahead of TransactionA. This means
+# the next write by TransactionA will push it into the future, and
+# in particular, into the future of the INSERT just above.
+query I
+SELECT * FROM t
+----
+1
+
+user root
+
+# This insert forces TransactionA's timestamp ahead, so that we have
+# OrigTimestamp < InsertTS < Timestamp < MaxTimestamp
+statement ok
+INSERT INTO t VALUES (2)
+
+# We (always) read at OrigTimestamp, and since this is a single node system
+# the read will always be certain. With the bug, we would still be uncertain
+# on (OrigTimestamp, Timestamp) and since we're running with a sizable
+# clock offset in these tests, the below would catch an uncertainty error.
+query I
+SELECT * FROM t
+----
+2
+
+# Cleanup.
+statement ok
+COMMIT

--- a/sql/testdata/snapshot_timestamp_drift
+++ b/sql/testdata/snapshot_timestamp_drift
@@ -1,0 +1,52 @@
+# Prevents regression of #4293: We used the commit timestamp candidate instead
+# of the original timestamp for reads, which means that transactions were
+# changing their snapshot while they were active, which is wildly inconsistent.
+
+statement ok
+CREATE TABLE t (a INT)
+
+statement ok
+GRANT ALL on t TO testuser
+
+# UserA starts the first transaction.
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SNAPSHOT
+
+# The SELECT forces the timestamp to be chosen.
+query I
+SELECT * FROM t
+----
+
+# UserB starts a transaction and inserts into the table.
+# TransactionB operates at a timestamp higher than TransactionA since we're
+# single-node and TransactionA has already picked its timestamp.
+user testuser
+
+# This insert will never become visible to TransactionA since it isn't present
+# in its snapshot.
+statement ok
+INSERT INTO t VALUES (1)
+
+# Touch all (relevant) keys with a timestamp ahead of TransactionA. This means
+# that future attempts of TransactionA to write with its original timestamp
+# must push TransactionA in the future.
+query I
+SELECT * FROM t
+----
+1
+
+user root
+
+# This insert forces TransactionA's timestamp ahead of that of TransactionB.
+statement ok
+INSERT INTO t VALUES (2)
+
+# The read is carried out at the original timestamp, not the pushed one;
+# consequently, we see only our own write.
+query I
+SELECT * FROM t
+----
+2
+
+statement ok
+COMMIT

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -161,14 +161,20 @@ func (ls *Stores) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 	// For calls that read data within a txn, we can avoid uncertainty
 	// related retries in certain situations. If the node is in
 	// "CertainNodes", we need not worry about uncertain reads any
-	// more. Setting MaxTimestamp=Timestamp for the operation
+	// more. Setting MaxTimestamp=OrigTimestamp for the operation
 	// accomplishes that. See roachpb.Transaction.CertainNodes for details.
 	if ba.Txn != nil && ba.Txn.CertainNodes.Contains(ba.Replica.NodeID) {
 		// MaxTimestamp = Timestamp corresponds to no clock uncertainty.
 		sp.LogEvent("read has no clock uncertainty")
 		// Copy-on-write to protect others we might be sharing the Txn with.
 		shallowTxn := *ba.Txn
-		shallowTxn.MaxTimestamp = ba.Txn.Timestamp
+		// We set to OrigTimestamp because that works for both SNAPSHOT and
+		// SERIALIZABLE: If we used Timestamp instead, we could run into
+		// unnecessary retries at SNAPSHOT. For example, a SNAPSHOT txn at
+		// OrigTimestamp = 1000.0, Timestamp = 2000.0, MaxTimestamp = 3000.0
+		// will always read at 1000, so a MaxTimestamp of 2000 will still let
+		// it restart with uncertainty when it finds a value in (1000, 2000).
+		shallowTxn.MaxTimestamp = ba.Txn.OrigTimestamp
 		ba.Txn = &shallowTxn
 	}
 	br, pErr = store.Send(ctx, ba)


### PR DESCRIPTION
Annoying:
We had a performance bug which caused the MaxTimestamp to be set to the
Timestamp instead of OrigTimestamp on txn reads, which always left the
interval (OrigTimestamp, Timestamp) open to read uncertainty errors.

Serious:
On txn reads (which must always be carried out with the original timestamp
of the transaction, OrigTimestamp), an old bit of code left over from a
larger refactor forwarded the timestamp to the transaction's current commit
timestamp. Perplexingly, this was only caught recently in a manual shell
session. The fix was trivial and a test has been added. Fixes #4293.

The two items are in a single commit because the first phenomenon happens
only after you fix the second, and writing the test for the second needs the fix
for the first.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4332)

<!-- Reviewable:end -->
