### PR TITLE
util: Reduce allocations in ordered, unordered, and interval caches

### DIFF
--- a/util/cache/cache_test.go
+++ b/util/cache/cache_test.go
@@ -289,3 +289,49 @@ func TestIntervalCacheClear(t *testing.T) {
 		t.Error("expected reinsert to succeed")
 	}
 }
+
+func benchmarkCache(b *testing.B, c *baseCache, keys []interface{}) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < len(keys); j++ {
+			c.Add(keys[j], j)
+		}
+		c.Clear()
+	}
+}
+
+func BenchmarkUnorderedCache(b *testing.B) {
+	mc := NewUnorderedCache(Config{Policy: CacheLRU, ShouldEvict: noEviction})
+	testKeys := []interface{}{
+		testKey("a"),
+		testKey("b"),
+		testKey("c"),
+		testKey("d"),
+		testKey("e"),
+	}
+	benchmarkCache(b, &mc.baseCache, testKeys)
+}
+
+func BenchmarkOrderedCache(b *testing.B) {
+	oc := NewOrderedCache(Config{Policy: CacheLRU, ShouldEvict: noEviction})
+	testKeys := []interface{}{
+		testKey("a"),
+		testKey("b"),
+		testKey("c"),
+		testKey("d"),
+		testKey("e"),
+	}
+	benchmarkCache(b, &oc.baseCache, testKeys)
+}
+
+func BenchmarkIntervalCache(b *testing.B) {
+	ic := NewIntervalCache(Config{Policy: CacheLRU, ShouldEvict: noEviction})
+	testKeys := []interface{}{
+		ic.NewKey([]byte("a"), []byte("c")),
+		ic.NewKey([]byte("b"), []byte("d")),
+		ic.NewKey([]byte("c"), []byte("e")),
+		ic.NewKey([]byte("d"), []byte("f")),
+		ic.NewKey([]byte("e"), []byte("g")),
+	}
+	benchmarkCache(b, &ic.baseCache, testKeys)
+}


### PR DESCRIPTION
This change reduces the number of allocations during construction
for all three types of caches:
- Unordered Cache: from 4 to 2 allocations
- Ordered Cache:   from 3 to 1 allocation
- Interval Cache:  from 4 to 1 allocation

The gains are all during construction, so there is little to no
effect during the use of the caches, except perhaps due to reduced
GC pressue.

```
name              old time/op  new time/op  delta
UnorderedCache-4  1.91µs ± 3%  1.93µs ± 1%    ~      (p=0.097 n=10+8)
OrderedCache-4    4.25µs ± 0%  4.24µs ± 1%  -0.43%    (p=0.007 n=8+9)
IntervalCache-4   3.27µs ± 1%  3.27µs ± 1%    ~     (p=0.956 n=10+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4338)

<!-- Reviewable:end -->
