### PR TITLE
Allow nightly builds of OSX binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,7 @@ build: BUILDMODE = build
 build: install
 
 .PHONY: install
-install: LDFLAGS += -X "github.com/cockroachdb/cockroach/util.buildTag=$(shell git describe --dirty --tags)"
-install: LDFLAGS += -X "github.com/cockroachdb/cockroach/util.buildTime=$(shell date -u '+%Y/%m/%d %H:%M:%S')"
-install: LDFLAGS += -X "github.com/cockroachdb/cockroach/util.buildDeps=$(shell GOPATH=${GOPATH} build/depvers.sh)"
+install: LDFLAGS += $(shell GOPATH=${GOPATH} build/ldflags.sh)
 install:
 	@echo "GOPATH set to $$GOPATH"
 	@echo "$$GOPATH/bin added to PATH"

--- a/build/build-osx.sh
+++ b/build/build-osx.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+set -eu
+
+go get github.com/karalabe/xgo
+# OSX 10.9 is the most recent version available at time of writing.
+xgo --targets=darwin-10.9/amd64 --go=1.6rc2 --ldflags="$($(dirname "${0}")/ldflags.sh)" ${GOPATH%%:*}/src/github.com/cockroachdb/cockroach

--- a/build/ldflags.sh
+++ b/build/ldflags.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+set -eu
+
+cd "$(dirname "${0}")/.."
+
+echo '-X "github.com/cockroachdb/cockroach/util.buildTag='$(git describe --dirty --tags)'"' \
+     '-X "github.com/cockroachdb/cockroach/util.buildTime='$(date -u '+%Y/%m/%d %H:%M:%S')'"' \
+     '-X "github.com/cockroachdb/cockroach/util.buildDeps='$(build/depvers.sh)'"'

--- a/build/push-aws.sh
+++ b/build/push-aws.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env sh
 # Push binaries to AWS.
 # This is run by circle-ci after successful docker push.
 #
-# Requisites:
+# Prerequisites:
 # - binaries must be statically linked by running build/build-static-binaries.sh
 # - circleci must have AWS credentials configured
 # - AWS credentials must have S3 write permissions on the bucket
@@ -14,30 +14,12 @@
 
 set -eux
 
-BUCKET_NAME="cockroach"
-LATEST_SUFFIX=".LATEST"
-REPO_NAME="cockroach"
+cd "$(dirname "${0}")"
+
+OSARCH="" # TODO(mberhault): should be "-linux-amd64"
 SHA="${CIRCLE_SHA1-$(git rev-parse HEAD)}"
 
-# push_one_binary takes the path to the binary inside the repo.
-# eg: push_one_binary sql/sql.test
-# The file will be pushed to: s3://BUCKET_NAME/REPO_NAME/sql.test.SHA
-# The S3 basename will be stored in s3://BUCKET_NAME/REPO_NAME/sql.test.LATEST
-function push_one_binary {
-  rel_path=$1
-  binary_name=$(basename $1)
-
-  cd $(dirname $0)/..
-  time aws s3 cp ${rel_path} s3://${BUCKET_NAME}/${REPO_NAME}/${binary_name}.${SHA}
-
-  # Upload LATEST file.
-  tmpfile=$(mktemp /tmp/cockroach-push.XXXXXX)
-  echo ${SHA} > ${tmpfile}
-  time aws s3 cp ${tmpfile} s3://${BUCKET_NAME}/${REPO_NAME}/${binary_name}${LATEST_SUFFIX}
-  rm -f ${tmpfile}
-}
-
-push_one_binary cockroach
-push_one_binary sql/sql.test
-push_one_binary acceptance/acceptance.test
-push_one_binary static-tests.tar.gz
+./push-one-binary.sh ${SHA} cockroach cockroach${OSARCH}
+./push-one-binary.sh ${SHA} sql/sql${OSARCH}.test
+./push-one-binary.sh ${SHA} acceptance/acceptance${OSARCH}.test
+./push-one-binary.sh ${SHA} static-tests${OSARCH}.tar.gz

--- a/build/push-one-binary.sh
+++ b/build/push-one-binary.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# This file uses `bash` and not `sh` due to the `time` builtin (the external
+# `time` is not available on CircleCI).
+
+set -eu
+
+BUCKET_NAME="cockroach"
+LATEST_SUFFIX=".LATEST"
+REPO_NAME="cockroach"
+
+# $0 takes the path to the binary inside the repo.
+# eg: $0 sql/sql.test sql/sql-foo.test
+# The file will be pushed to: s3://BUCKET_NAME/REPO_NAME/sql-foo.test.SHA
+# The S3 basename will be stored in s3://BUCKET_NAME/REPO_NAME/sql-foo.test.LATEST
+
+sha=$1
+rel_path=$2
+binary_name=${3-$(basename "${2}")}
+
+cd "$(dirname "${0}")/.."
+time aws s3 cp ${rel_path} s3://${BUCKET_NAME}/${REPO_NAME}/${binary_name}.${sha}
+
+# Upload LATEST file.
+tmpfile=$(mktemp /tmp/cockroach-push.XXXXXX)
+echo ${sha} > ${tmpfile}
+time aws s3 cp ${tmpfile} s3://${BUCKET_NAME}/${REPO_NAME}/${binary_name}${LATEST_SUFFIX}
+rm -f ${tmpfile}

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,12 @@ checkout:
   post:
     - git fetch --unshallow || true
     - git fetch --tags
+    # GOPATH is cached, so we need to clean out the version from the previous
+    # run or the subsequent `mv` will fail. We put our checkout in the correct
+    # location for the OSX build step.
+    - rm -rf "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach"
+    - mv ~/cockroach "${GOPATH%%:*}/src/github.com/cockroachdb/"
+    - ln -s ${GOPATH%%:*}/src/github.com/cockroachdb/cockroach ~/cockroach
 
 dependencies:
   override:
@@ -39,3 +45,14 @@ deployment:
           -l "${CIRCLE_ARTIFACTS}"/acceptance_deploy 2>&1 >
           "${CIRCLE_ARTIFACTS}/acceptance_deploy.log"
       - build/push-aws.sh
+  osx:
+    branch: master
+    commands:
+      - |
+          if [ -n "${BUILD_OSX-}" ]; then
+            set -eux
+            build/build-osx.sh
+            aws configure set region us-east-1
+            source build/build-common.sh
+            build/push-one-binary.sh $(git rev-parse HEAD) cockroach-darwin-10.9-amd64 cockroach-darwin-10.9-amd64
+          fi


### PR DESCRIPTION
Triggered via a master build with the `NIGHTLY` environment
variable. This ran in 10-15min, so no caching should be
necessary.

Still playing with this, but take a look if you like, especially
the Makefile.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4343)

<!-- Reviewable:end -->
