### PR TITLE
sql: better output and indexJoin support for EXPLAIN DEBUG

### DIFF
--- a/sql/join.go
+++ b/sql/join.go
@@ -37,6 +37,8 @@ type indexJoinNode struct {
 	primaryKeyPrefix roachpb.Key
 	colIDtoRowIndex  map[ColumnID]int
 	pErr             *roachpb.Error
+	explain          explainMode
+	debugVals        debugValues
 }
 
 func makeIndexJoin(indexScan *scanNode, exactPrefix int) *indexJoinNode {
@@ -99,9 +101,11 @@ func (n *indexJoinNode) Values() parser.DTuple {
 	return n.table.Values()
 }
 
-func (*indexJoinNode) DebugValues() debugValues {
-	// TODO(radu)
-	panic("debug mode not implemented in indexJoinNode")
+func (n *indexJoinNode) DebugValues() debugValues {
+	if n.explain != explainDebug {
+		panic(fmt.Sprintf("node not in debug mode (mode %d)", n.explain))
+	}
+	return n.debugVals
 }
 
 func (n *indexJoinNode) Next() bool {
@@ -110,9 +114,12 @@ func (n *indexJoinNode) Next() bool {
 	// the index we perform another iteration of the loop looking for rows in the
 	// table. This outer loop is necessary because a batch of rows from the index
 	// might all be filtered when the resulting rows are read from the table.
-	for tableLookup := (n.table.kvs != nil); true; tableLookup = true {
+	for tableLookup := (len(n.table.spans) > 0); true; tableLookup = true {
 		// First, try to pull a row from the table.
 		if tableLookup && n.table.Next() {
+			if n.explain == explainDebug {
+				n.debugVals = n.table.DebugValues()
+			}
 			return true
 		}
 		if n.pErr = n.table.PErr(); n.pErr != nil {
@@ -137,6 +144,13 @@ func (n *indexJoinNode) Next() bool {
 				break
 			}
 
+			if n.explain == explainDebug {
+				n.debugVals = n.index.DebugValues()
+				if n.debugVals.output != debugValueRow {
+					return true
+				}
+			}
+
 			vals := n.index.Values()
 			primaryIndexKey, _, err := encodeIndexKey(
 				n.table.index, n.colIDtoRowIndex, vals, n.primaryKeyPrefix)
@@ -149,6 +163,12 @@ func (n *indexJoinNode) Next() bool {
 				start: key,
 				end:   key.PrefixEnd(),
 			})
+
+			if n.explain == explainDebug {
+				// In debug mode, return the index information as a "partial" row.
+				n.debugVals.output = debugValuePartial
+				return true
+			}
 		}
 
 		if log.V(3) {

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -153,7 +153,7 @@ func (n *scanNode) Values() parser.DTuple {
 
 func (n *scanNode) DebugValues() debugValues {
 	if n.explain != explainDebug {
-		panic("DebugValues called, node not in debug mode.")
+		panic(fmt.Sprintf("node not in debug mode (mode %d)", n.explain))
 	}
 	return n.debugVals
 }

--- a/sql/select.go
+++ b/sql/select.go
@@ -95,7 +95,7 @@ func (s *selectNode) Values() parser.DTuple {
 
 func (s *selectNode) DebugValues() debugValues {
 	if s.explain != explainDebug {
-		panic("DebugValues called, node not in debug mode.")
+		panic(fmt.Sprintf("node not in debug mode (mode %d)", s.explain))
 	}
 	return s.debugVals
 }

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -544,7 +544,7 @@ SELECT STDDEV(x) FROM xyz WHERE x = 1;
 NULL
 
 # Verify we only look at one row for MIN when we have an index on that column.
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT MIN(z) FROM xyz
 ----
-0 /xyz/zyx/3.0/2/1 NULL true 
+0 /xyz/zyx/3.0/2/1 NULL ROW 

--- a/sql/testdata/alter_table
+++ b/sql/testdata/alter_table
@@ -4,11 +4,11 @@ CREATE TABLE t (a INT PRIMARY KEY)
 statement ok
 INSERT INTO t VALUES (1)
 
-query ITTB colnames
+query ITTT colnames
 EXPLAIN (DEBUG) SELECT * FROM t
 ----
-RowIdx Key          Value Output
-0      /t/primary/1 NULL  true
+RowIdx Key          Value Disposition
+0      /t/primary/1 NULL  ROW
 
 user testuser
 
@@ -23,17 +23,17 @@ ALTER TABLE t ADD b INT
 query TTBT colnames
 SHOW COLUMNS FROM t
 ----
-Field Type Null Default
+Field Type Null  Default
 a     INT  false NULL
-b     INT  true NULL
+b     INT  true  NULL
 
 statement ok
 ALTER TABLE t ADD CONSTRAINT foo UNIQUE (b)
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@foo
 ----
-0 /t/foo/NULL /1 true
+0 /t/foo/NULL /1 ROW
 
 statement error duplicate index name: "foo"
 ALTER TABLE t ADD CONSTRAINT foo UNIQUE (b)
@@ -97,28 +97,28 @@ SHOW INDEX FROM t
 Table  Name     Unique  Seq  Column  Direction  Storing
 t      primary  true    1    a       ASC        false
 
-query ITTB colnames
+query ITTT colnames
 EXPLAIN (DEBUG) SELECT * FROM t
 ----
-RowIdx  Key             Value  Output
-0       /t/primary/1    NULL   true
-1       /t/primary/2    NULL   NULL
-1       /t/primary/2/b  1      NULL
-1       /t/primary/2/c  1      true
-2       /t/primary/3    NULL   NULL
-2       /t/primary/3/b  2      NULL
-2       /t/primary/3/c  1      true
+RowIdx  Key             Value  Disposition
+0       /t/primary/1    NULL   ROW
+1       /t/primary/2    NULL   PARTIAL
+1       /t/primary/2/b  1      PARTIAL
+1       /t/primary/2/c  1      ROW
+2       /t/primary/3    NULL   PARTIAL
+2       /t/primary/3/b  2      PARTIAL
+2       /t/primary/3/c  1      ROW
 
 statement ok
 ALTER TABLE t DROP b, DROP c
 
-query ITTB colnames
+query ITTT colnames
 EXPLAIN (DEBUG) SELECT * FROM t
 ----
-RowIdx  Key             Value  Output
-0       /t/primary/1    NULL   true
-1       /t/primary/2    NULL   true
-2       /t/primary/3    NULL   true
+RowIdx  Key             Value  Disposition
+0       /t/primary/1    NULL   ROW
+1       /t/primary/2    NULL   ROW
+2       /t/primary/3    NULL   ROW
 
 statement ok
 ALTER TABLE t ADD d INT UNIQUE

--- a/sql/testdata/create_index
+++ b/sql/testdata/create_index
@@ -7,11 +7,11 @@ CREATE TABLE t (
 statement ok
 INSERT INTO t VALUES (1,1)
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t
 ----
-0  /t/primary/1    NULL  NULL
-0  /t/primary/1/b  1     true
+0  /t/primary/1    NULL  PARTIAL
+0  /t/primary/1/b  1     ROW
 
 user testuser
 
@@ -36,19 +36,19 @@ Table Name    Unique Seq Column Direction Storing
 t     primary true   1   a      ASC       false
 t     foo     false  1   b      ASC       false
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@foo
 ----
-0  /t/foo/1/1  NULL  true
+0  /t/foo/1/1  NULL  ROW
 
 statement ok
 INSERT INTO t VALUES (2,1)
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@foo
 ----
-0  /t/foo/1/1  NULL  true
-1  /t/foo/1/2  NULL  true
+0  /t/foo/1/1  NULL  ROW
+1  /t/foo/1/2  NULL  ROW
 
 statement error duplicate key value \(b\)=\(1\) violates unique constraint "bar"
 CREATE UNIQUE INDEX bar ON t (b)
@@ -60,11 +60,11 @@ Table Name    Unique Seq Column Direction Storing
 t     primary true   1   a      ASC       false
 t     foo     false  1   b      ASC       false
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@foo
 ----
-0  /t/foo/1/1  NULL  true
-1  /t/foo/1/2  NULL  true
+0  /t/foo/1/1  NULL  ROW
+1  /t/foo/1/2  NULL  ROW
 
 # test for DESC index
 

--- a/sql/testdata/datetime
+++ b/sql/testdata/datetime
@@ -19,23 +19,23 @@ SELECT * FROM t WHERE a = '2015-08-25 05:45:45.53453+01:00'::timestamp
 ----
 2015-08-25 04:45:45.53453 +0000 +0000   2015-08-25 00:00:00 +0000 +0000   2h45m2.234s
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a = '2015-08-25 06:45:45.53453+02:00'::timestamp
 ----
-0 /t/primary/2015-08-25 04:45:45.53453+00:00   NULL        NULL
-0 /t/primary/2015-08-25 04:45:45.53453+00:00/b 2015-08-25  NULL
-0 /t/primary/2015-08-25 04:45:45.53453+00:00/c 2h45m2.234s true
+0 /t/primary/2015-08-25 04:45:45.53453+00:00   NULL        PARTIAL
+0 /t/primary/2015-08-25 04:45:45.53453+00:00/b 2015-08-25  PARTIAL
+0 /t/primary/2015-08-25 04:45:45.53453+00:00/c 2h45m2.234s ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT b FROM t WHERE b < '2015-08-29'::date
 ----
-0 /t/t_b_key/2015-08-25 /2015-08-25 04:45:45.53453+00:00 true
+0 /t/t_b_key/2015-08-25 /2015-08-25 04:45:45.53453+00:00 ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT c FROM t WHERE c < '234h45m2s234ms'::interval
 ----
-0 /t/t_c_key/2h45m2.234s /2015-08-25 04:45:45.53453+00:00 true
-1 /t/t_c_key/34h0m2s     /2015-08-30 03:34:45.34567+00:00 true
+0 /t/t_c_key/2h45m2.234s /2015-08-25 04:45:45.53453+00:00 ROW
+1 /t/t_c_key/34h0m2s     /2015-08-30 03:34:45.34567+00:00 ROW
 
 # insert duplicate value with different time zone offset
 statement error duplicate key value \(a\)=\(2015-08-30 03:34:45\.34567\+00:00\) violates unique constraint "primary"

--- a/sql/testdata/explain_debug
+++ b/sql/testdata/explain_debug
@@ -8,76 +8,76 @@ CREATE TABLE abc (
   INDEX bar (a)
 )
 
-query ITTB colnames
+query ITTT colnames
 EXPLAIN (DEBUG) SELECT * FROM abc
 ----
-RowIdx  Key  Value  Output
+RowIdx  Key  Value  Disposition
 
 statement ok
 INSERT INTO abc VALUES (1, 'one', 1.1), (2, 'two', NULL), (3, 'three', NULL)
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM abc
 ----
-0  /abc/primary/1/'one'    NULL  NULL
-0  /abc/primary/1/'one'/c  1.1   true
-1  /abc/primary/2/'two'    NULL  true
-2  /abc/primary/3/'three'  NULL  true
+0  /abc/primary/1/'one'    NULL  PARTIAL
+0  /abc/primary/1/'one'/c  1.1   ROW
+1  /abc/primary/2/'two'    NULL  ROW
+2  /abc/primary/3/'three'  NULL  ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM abc WHERE a = 2
 ----
-0  /abc/primary/2/'two'  NULL  true
+0  /abc/primary/2/'two'  NULL  ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM abc@foo
 ----
-0  /abc/foo/'one'    /1  true
-1  /abc/foo/'three'  /3  true
-2  /abc/foo/'two'    /2  true
+0  /abc/foo/'one'    /1  ROW
+1  /abc/foo/'three'  /3  ROW
+2  /abc/foo/'two'    /2  ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM abc@bar
 ----
-0  /abc/bar/1/'one'    NULL  true
-1  /abc/bar/2/'two'    NULL  true
-2  /abc/bar/3/'three'  NULL  true
+0  /abc/bar/1/'one'    NULL  ROW
+1  /abc/bar/2/'two'    NULL  ROW
+2  /abc/bar/3/'three'  NULL  ROW
 
 statement ok
 UPDATE abc SET c = NULL WHERE a = 1
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM abc
 ----
-0  /abc/primary/1/'one'    NULL  true
-1  /abc/primary/2/'two'    NULL  true
-2  /abc/primary/3/'three'  NULL  true
+0  /abc/primary/1/'one'    NULL  ROW
+1  /abc/primary/2/'two'    NULL  ROW
+2  /abc/primary/3/'three'  NULL  ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT 3
 ----
-0 NULL NULL true
+0 NULL NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) VALUES (1, 2, 3), (4, 5, 6)
 ----
-0 0 (1, 2, 3) true
-1 1 (4, 5, 6) true
+0 0 (1, 2, 3) ROW
+1 1 (4, 5, 6) ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS a;
 ----
-0 0 (1, 2, 3) true
-1 1 (4, 5, 6) true
+0 0 (1, 2, 3) ROW
+1 1 (4, 5, 6) ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM (SELECT * FROM abc) AS sub WHERE a = 2;
 ----
-0  /abc/primary/1/'one'    NULL  false
-1  /abc/primary/2/'two'    NULL  true
-2  /abc/primary/3/'three'  NULL  false
+0  /abc/primary/1/'one'    NULL  FILTERED
+1  /abc/primary/2/'two'    NULL  ROW
+2  /abc/primary/3/'three'  NULL  FILTERED
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM (SELECT * FROM abc WHERE a = 2) AS sub;
 ----
-0  /abc/primary/2/'two'    NULL  true
+0  /abc/primary/2/'two'    NULL  ROW

--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -36,140 +36,140 @@ INSERT INTO kv (k,v) VALUES ('a', 'b'), ('c', 'd')
 statement ok
 INSERT INTO kv VALUES ('e', 'f'), ('g', '')
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv
 ----
-0  /kv/primary/'A'     NULL  true
-1  /kv/primary/'a'     NULL  NULL
-1  /kv/primary/'a'/v   'b'   true
-2  /kv/primary/'c'     NULL  NULL
-2  /kv/primary/'c'/v   'd'   true
-3  /kv/primary/'e'     NULL  NULL
-3  /kv/primary/'e'/v   'f'   true
-4  /kv/primary/'g'     NULL  NULL
-4  /kv/primary/'g'/v   ''    true
-5  /kv/primary/'nil1'  NULL  true
-6  /kv/primary/'nil2'  NULL  true
-7  /kv/primary/'nil3'  NULL  true
-8  /kv/primary/'nil4'  NULL  true
+0  /kv/primary/'A'     NULL  ROW
+1  /kv/primary/'a'     NULL  PARTIAL
+1  /kv/primary/'a'/v   'b'   ROW
+2  /kv/primary/'c'     NULL  PARTIAL
+2  /kv/primary/'c'/v   'd'   ROW
+3  /kv/primary/'e'     NULL  PARTIAL
+3  /kv/primary/'e'/v   'f'   ROW
+4  /kv/primary/'g'     NULL  PARTIAL
+4  /kv/primary/'g'/v   ''    ROW
+5  /kv/primary/'nil1'  NULL  ROW
+6  /kv/primary/'nil2'  NULL  ROW
+7  /kv/primary/'nil3'  NULL  ROW
+8  /kv/primary/'nil4'  NULL  ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv@a
 ----
-0  /kv/a/NULL /'A'     true
-1  /kv/a/NULL /'nil1'  true
-2  /kv/a/NULL /'nil2'  true
-3  /kv/a/NULL /'nil3'  true
-4  /kv/a/NULL /'nil4'  true
-5  /kv/a/''   /'g'     true
-6  /kv/a/'b'  /'a'     true
-7  /kv/a/'d'  /'c'     true
-8  /kv/a/'f'  /'e'     true
+0  /kv/a/NULL /'A'     ROW
+1  /kv/a/NULL /'nil1'  ROW
+2  /kv/a/NULL /'nil2'  ROW
+3  /kv/a/NULL /'nil3'  ROW
+4  /kv/a/NULL /'nil4'  ROW
+5  /kv/a/''   /'g'     ROW
+6  /kv/a/'b'  /'a'     ROW
+7  /kv/a/'d'  /'c'     ROW
+8  /kv/a/'f'  /'e'     ROW
 
 statement error duplicate key value \(v\)=\('f'\) violates unique constraint "a"
 INSERT INTO kv VALUES ('e', 'f')
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv
 ----
-0  /kv/primary/'A'     NULL  true
-1  /kv/primary/'a'     NULL  NULL
-1  /kv/primary/'a'/v   'b'   true
-2  /kv/primary/'c'     NULL  NULL
-2  /kv/primary/'c'/v   'd'   true
-3  /kv/primary/'e'     NULL  NULL
-3  /kv/primary/'e'/v   'f'   true
-4  /kv/primary/'g'     NULL  NULL
-4  /kv/primary/'g'/v   ''    true
-5  /kv/primary/'nil1'  NULL  true
-6  /kv/primary/'nil2'  NULL  true
-7  /kv/primary/'nil3'  NULL  true
-8  /kv/primary/'nil4'  NULL  true
+0  /kv/primary/'A'     NULL  ROW
+1  /kv/primary/'a'     NULL  PARTIAL
+1  /kv/primary/'a'/v   'b'   ROW
+2  /kv/primary/'c'     NULL  PARTIAL
+2  /kv/primary/'c'/v   'd'   ROW
+3  /kv/primary/'e'     NULL  PARTIAL
+3  /kv/primary/'e'/v   'f'   ROW
+4  /kv/primary/'g'     NULL  PARTIAL
+4  /kv/primary/'g'/v   ''    ROW
+5  /kv/primary/'nil1'  NULL  ROW
+6  /kv/primary/'nil2'  NULL  ROW
+7  /kv/primary/'nil3'  NULL  ROW
+8  /kv/primary/'nil4'  NULL  ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv@a
 ----
-0  /kv/a/NULL /'A'     true
-1  /kv/a/NULL /'nil1'  true
-2  /kv/a/NULL /'nil2'  true
-3  /kv/a/NULL /'nil3'  true
-4  /kv/a/NULL /'nil4'  true
-5  /kv/a/''   /'g'     true
-6  /kv/a/'b'  /'a'     true
-7  /kv/a/'d'  /'c'     true
-8  /kv/a/'f'  /'e'     true
+0  /kv/a/NULL /'A'     ROW
+1  /kv/a/NULL /'nil1'  ROW
+2  /kv/a/NULL /'nil2'  ROW
+3  /kv/a/NULL /'nil3'  ROW
+4  /kv/a/NULL /'nil4'  ROW
+5  /kv/a/''   /'g'     ROW
+6  /kv/a/'b'  /'a'     ROW
+7  /kv/a/'d'  /'c'     ROW
+8  /kv/a/'f'  /'e'     ROW
 
 statement ok
 INSERT INTO kv VALUES ('f', 'g')
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv
 ----
-0  /kv/primary/'A'     NULL  true
-1  /kv/primary/'a'     NULL  NULL
-1  /kv/primary/'a'/v   'b'   true
-2  /kv/primary/'c'     NULL  NULL
-2  /kv/primary/'c'/v   'd'   true
-3  /kv/primary/'e'     NULL  NULL
-3  /kv/primary/'e'/v   'f'   true
-4  /kv/primary/'f'     NULL  NULL
-4  /kv/primary/'f'/v   'g'   true
-5  /kv/primary/'g'     NULL  NULL
-5  /kv/primary/'g'/v   ''    true
-6  /kv/primary/'nil1'  NULL  true
-7  /kv/primary/'nil2'  NULL  true
-8  /kv/primary/'nil3'  NULL  true
-9  /kv/primary/'nil4'  NULL  true
+0  /kv/primary/'A'     NULL  ROW
+1  /kv/primary/'a'     NULL  PARTIAL
+1  /kv/primary/'a'/v   'b'   ROW
+2  /kv/primary/'c'     NULL  PARTIAL
+2  /kv/primary/'c'/v   'd'   ROW
+3  /kv/primary/'e'     NULL  PARTIAL
+3  /kv/primary/'e'/v   'f'   ROW
+4  /kv/primary/'f'     NULL  PARTIAL
+4  /kv/primary/'f'/v   'g'   ROW
+5  /kv/primary/'g'     NULL  PARTIAL
+5  /kv/primary/'g'/v   ''    ROW
+6  /kv/primary/'nil1'  NULL  ROW
+7  /kv/primary/'nil2'  NULL  ROW
+8  /kv/primary/'nil3'  NULL  ROW
+9  /kv/primary/'nil4'  NULL  ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv@a
 ----
-0  /kv/a/NULL /'A'     true
-1  /kv/a/NULL /'nil1'  true
-2  /kv/a/NULL /'nil2'  true
-3  /kv/a/NULL /'nil3'  true
-4  /kv/a/NULL /'nil4'  true
-5  /kv/a/''   /'g'     true
-6  /kv/a/'b'  /'a'     true
-7  /kv/a/'d'  /'c'     true
-8  /kv/a/'f'  /'e'     true
-9  /kv/a/'g'  /'f'     true
+0  /kv/a/NULL /'A'     ROW
+1  /kv/a/NULL /'nil1'  ROW
+2  /kv/a/NULL /'nil2'  ROW
+3  /kv/a/NULL /'nil3'  ROW
+4  /kv/a/NULL /'nil4'  ROW
+5  /kv/a/''   /'g'     ROW
+6  /kv/a/'b'  /'a'     ROW
+7  /kv/a/'d'  /'c'     ROW
+8  /kv/a/'f'  /'e'     ROW
+9  /kv/a/'g'  /'f'     ROW
 
 statement error duplicate key value \(v\)=\('g'\) violates unique constraint "a"
 INSERT INTO kv VALUES ('h', 'g')
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv
 ----
-0  /kv/primary/'A'     NULL  true
-1  /kv/primary/'a'     NULL  NULL
-1  /kv/primary/'a'/v   'b'   true
-2  /kv/primary/'c'     NULL  NULL
-2  /kv/primary/'c'/v   'd'   true
-3  /kv/primary/'e'     NULL  NULL
-3  /kv/primary/'e'/v   'f'   true
-4  /kv/primary/'f'     NULL  NULL
-4  /kv/primary/'f'/v   'g'   true
-5  /kv/primary/'g'     NULL  NULL
-5  /kv/primary/'g'/v   ''    true
-6  /kv/primary/'nil1'  NULL  true
-7  /kv/primary/'nil2'  NULL  true
-8  /kv/primary/'nil3'  NULL  true
-9  /kv/primary/'nil4'  NULL  true
+0  /kv/primary/'A'     NULL  ROW
+1  /kv/primary/'a'     NULL  PARTIAL
+1  /kv/primary/'a'/v   'b'   ROW
+2  /kv/primary/'c'     NULL  PARTIAL
+2  /kv/primary/'c'/v   'd'   ROW
+3  /kv/primary/'e'     NULL  PARTIAL
+3  /kv/primary/'e'/v   'f'   ROW
+4  /kv/primary/'f'     NULL  PARTIAL
+4  /kv/primary/'f'/v   'g'   ROW
+5  /kv/primary/'g'     NULL  PARTIAL
+5  /kv/primary/'g'/v   ''    ROW
+6  /kv/primary/'nil1'  NULL  ROW
+7  /kv/primary/'nil2'  NULL  ROW
+8  /kv/primary/'nil3'  NULL  ROW
+9  /kv/primary/'nil4'  NULL  ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv@a
 ----
-0  /kv/a/NULL /'A'     true
-1  /kv/a/NULL /'nil1'  true
-2  /kv/a/NULL /'nil2'  true
-3  /kv/a/NULL /'nil3'  true
-4  /kv/a/NULL /'nil4'  true
-5  /kv/a/''   /'g'     true
-6  /kv/a/'b'  /'a'     true
-7  /kv/a/'d'  /'c'     true
-8  /kv/a/'f'  /'e'     true
-9  /kv/a/'g'  /'f'     true
+0  /kv/a/NULL /'A'     ROW
+1  /kv/a/NULL /'nil1'  ROW
+2  /kv/a/NULL /'nil2'  ROW
+3  /kv/a/NULL /'nil3'  ROW
+4  /kv/a/NULL /'nil4'  ROW
+5  /kv/a/''   /'g'     ROW
+6  /kv/a/'b'  /'a'     ROW
+7  /kv/a/'d'  /'c'     ROW
+8  /kv/a/'f'  /'e'     ROW
+9  /kv/a/'g'  /'f'     ROW
 
 query TT
 SELECT * FROM kv
@@ -281,10 +281,10 @@ CREATE TABLE kv5 (
 statement ok
 INSERT INTO kv5 VALUES('a', NULL)
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv5@a
 ----
-0 /kv5/a/NULL/'a' true
+0 /kv5/a/NULL/'a' ROW
 
 query TT
 SELECT * FROM kv5@a

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -168,49 +168,49 @@ SELECT d FROM abc ORDER BY LOWER(d)
 one
 Two
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM abc ORDER BY a
 ----
-0 /abc/primary/1/2/3   NULL  NULL
-0 /abc/primary/1/2/3/d 'one' true
-1 /abc/primary/4/5/6   NULL  NULL
-1 /abc/primary/4/5/6/d 'Two' true
+0 /abc/primary/1/2/3   NULL  PARTIAL
+0 /abc/primary/1/2/3/d 'one' ROW
+1 /abc/primary/4/5/6   NULL  PARTIAL
+1 /abc/primary/4/5/6/d 'Two' ROW
 
 query ITT
 EXPLAIN SELECT * FROM abc ORDER BY a
 ----
 0 scan abc@primary -
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT a, b FROM abc ORDER BY b, a
 ----
-0 /abc/ba/2/1/3 NULL true
-1 /abc/ba/5/4/6 NULL true
+0 /abc/ba/2/1/3 NULL ROW
+1 /abc/ba/5/4/6 NULL ROW
 
 query ITT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, a
 ----
 0 scan abc@ba -
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT b, c FROM abc ORDER BY b, c
 ----
-0 /abc/bc/2/3 /1 true
-1 /abc/bc/5/6 /4 true
+0 /abc/bc/2/3 /1 ROW
+1 /abc/bc/5/6 /4 ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT a, b, c FROM abc ORDER BY b
 ----
-0 /abc/bc/2/3 /1 true
-1 /abc/bc/5/6 /4 true
+0 /abc/bc/2/3 /1 ROW
+1 /abc/bc/5/6 /4 ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT a FROM abc ORDER BY a DESC
 ----
-0 /abc/primary/4/5/6/d 'Two' NULL
-0 /abc/primary/4/5/6   NULL  true
-1 /abc/primary/1/2/3/d 'one' NULL
-1 /abc/primary/1/2/3   NULL  true
+0 /abc/primary/4/5/6/d 'Two' PARTIAL
+0 /abc/primary/4/5/6   NULL  ROW
+1 /abc/primary/1/2/3/d 'one' PARTIAL
+1 /abc/primary/1/2/3   NULL  ROW
 
 query ITT
 EXPLAIN SELECT a FROM abc ORDER BY a DESC

--- a/sql/testdata/select_index
+++ b/sql/testdata/select_index
@@ -16,93 +16,93 @@ INSERT INTO t VALUES
   (2, 'two', 22, 'bar'),
   (3, 'three', 33, 'blah')
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a = 2
 ----
-0 /t/primary/2/'two'   NULL  NULL
-0 /t/primary/2/'two'/c 22    NULL
-0 /t/primary/2/'two'/d 'bar' true
+0 /t/primary/2/'two'   NULL  PARTIAL
+0 /t/primary/2/'two'/c 22    PARTIAL
+0 /t/primary/2/'two'/d 'bar' ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a IN (1, 3)
 ----
-0 /t/primary/1/'one'     NULL   NULL
-0 /t/primary/1/'one'/c   11     NULL
-0 /t/primary/1/'one'/d   'foo'  true
-1 /t/primary/3/'three'   NULL   NULL
-1 /t/primary/3/'three'/c 33     NULL
-1 /t/primary/3/'three'/d 'blah' true
+0 /t/primary/1/'one'     NULL   PARTIAL
+0 /t/primary/1/'one'/c   11     PARTIAL
+0 /t/primary/1/'one'/d   'foo'  ROW
+1 /t/primary/3/'three'   NULL   PARTIAL
+1 /t/primary/3/'three'/c 33     PARTIAL
+1 /t/primary/3/'three'/d 'blah' ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE d = 'foo' OR d = 'bar'
 ----
-0 /t/dc/'bar'/22/2/'two' NULL true
-1 /t/dc/'foo'/11/1/'one' NULL true
+0 /t/dc/'bar'/22/2/'two' NULL ROW
+1 /t/dc/'foo'/11/1/'one' NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE (d, c) IN (('foo', 11), ('bar', 22))
 ----
-0 /t/dc/'bar'/22/2/'two' NULL true
-1 /t/dc/'foo'/11/1/'one' NULL true
+0 /t/dc/'bar'/22/2/'two' NULL ROW
+1 /t/dc/'foo'/11/1/'one' NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE (d, c) = ('foo', 11)
 ----
-0 /t/dc/'foo'/11/1/'one' NULL true
+0 /t/dc/'foo'/11/1/'one' NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a < 2
 ----
-0 /t/primary/1/'one'   NULL  NULL
-0 /t/primary/1/'one'/c 11    NULL
-0 /t/primary/1/'one'/d 'foo' true
+0 /t/primary/1/'one'   NULL  PARTIAL
+0 /t/primary/1/'one'/c 11    PARTIAL
+0 /t/primary/1/'one'/d 'foo' ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a <= (1 + 1)
 ----
-0 /t/primary/1/'one'   NULL  NULL
-0 /t/primary/1/'one'/c 11    NULL
-0 /t/primary/1/'one'/d 'foo' true
-1 /t/primary/2/'two'   NULL  NULL
-1 /t/primary/2/'two'/c 22    NULL
-1 /t/primary/2/'two'/d 'bar' true
+0 /t/primary/1/'one'   NULL  PARTIAL
+0 /t/primary/1/'one'/c 11    PARTIAL
+0 /t/primary/1/'one'/d 'foo' ROW
+1 /t/primary/2/'two'   NULL  PARTIAL
+1 /t/primary/2/'two'/c 22    PARTIAL
+1 /t/primary/2/'two'/d 'bar' ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT a, b FROM t WHERE b > 't'
 ----
-0 /t/bc/'three'/33/3 NULL true
-1 /t/bc/'two'/22/2   NULL true
+0 /t/bc/'three'/33/3 NULL ROW
+1 /t/bc/'two'/22/2   NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE d < ('b' || 'l')
 ----
-0 /t/dc/'bar'/22/2/'two' NULL true
+0 /t/dc/'bar'/22/2/'two' NULL ROW
 
 # The where-clause does not contain columns matching a prefix of any
 # index. Note that the index "dc" was chosen because it contains fewer
 # keys per row than the primary key index while still containing all
 # of the needed columns.
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE c = 22
 ----
-0 /t/dc/'bar'/22/2/'two'    NULL true
-1 /t/dc/'blah'/33/3/'three' NULL false
-2 /t/dc/'foo'/11/1/'one'    NULL false
+0 /t/dc/'bar'/22/2/'two'    NULL ROW
+1 /t/dc/'blah'/33/3/'three' NULL FILTERED
+2 /t/dc/'foo'/11/1/'one'    NULL FILTERED
 
 # Use the descending index
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT a FROM t ORDER BY a DESC
 ----
-0  /t/a_desc/3/'three'  NULL  true
-1  /t/a_desc/2/'two'    NULL  true
-2  /t/a_desc/1/'one'    NULL  true
+0  /t/a_desc/3/'three'  NULL  ROW
+1  /t/a_desc/2/'two'    NULL  ROW
+2  /t/a_desc/1/'one'    NULL  ROW
 
 # Use the descending index with multiple spans.
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT a FROM t WHERE a in (2, 3) ORDER BY a DESC
 ----
-0  /t/a_desc/3/'three'  NULL  true
-1  /t/a_desc/2/'two'    NULL  true
+0  /t/a_desc/3/'three'  NULL  ROW
+1  /t/a_desc/2/'two'    NULL  ROW
 
 statement ok
 TRUNCATE TABLE t
@@ -113,17 +113,17 @@ INSERT INTO t VALUES
   (1, 'b', NULL, NULL),
   (1, 'c', NULL, NULL)
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a = 1 AND b > 'b'
 ----
-0 /t/primary/1/'c' NULL true
+0 /t/primary/1/'c' NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a > 0 AND b > 'b'
 ----
-0 /t/primary/1/'c' NULL true
+0 /t/primary/1/'c' NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a > 1 AND b > 'b'
 ----
 
@@ -132,10 +132,10 @@ EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
 0 empty -
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b
 ----
-0 /t/primary/1/'b' NULL true
+0 /t/primary/1/'b' NULL ROW
 
 statement ok
 DROP TABLE t
@@ -150,69 +150,69 @@ CREATE TABLE t (
 statement ok
 INSERT INTO t VALUES (1, 2), (3, 4), (5, 6)
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a >= 3 AND a < 5
 ----
-0 /t/ab/3/4 NULL true
+0 /t/ab/3/4 NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a BETWEEN 3 AND 4
 ----
-0 /t/ab/3/4 NULL true
+0 /t/ab/3/4 NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a BETWEEN 3 AND 5
 ----
-0 /t/ab/3/4 NULL true
-1 /t/ab/5/6 NULL true
+0 /t/ab/3/4 NULL ROW
+1 /t/ab/5/6 NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a < 2 OR a < 4
 ----
-0 /t/ab/1/2 NULL true
-1 /t/ab/3/4 NULL true
+0 /t/ab/1/2 NULL ROW
+1 /t/ab/3/4 NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a < 3 OR a <= 3
 ----
-0 /t/ab/1/2 NULL true
-1 /t/ab/3/4 NULL true
+0 /t/ab/1/2 NULL ROW
+1 /t/ab/3/4 NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a <= 3 OR a < 3
 ----
-0 /t/ab/1/2 NULL true
-1 /t/ab/3/4 NULL true
+0 /t/ab/1/2 NULL ROW
+1 /t/ab/3/4 NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a > 3 OR a >= 3
 ----
-0 /t/ab/3/4 NULL true
-1 /t/ab/5/6 NULL true
+0 /t/ab/3/4 NULL ROW
+1 /t/ab/5/6 NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a >= 3 OR a > 3
 ----
-0 /t/ab/3/4 NULL true
-1 /t/ab/5/6 NULL true
+0 /t/ab/3/4 NULL ROW
+1 /t/ab/5/6 NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a = 3 OR a = 5
 ----
-0 /t/ab/3/4 NULL true
-1 /t/ab/5/6 NULL true
+0 /t/ab/3/4 NULL ROW
+1 /t/ab/5/6 NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a < 3 OR a > 3
 ----
-0 /t/ab/1/2 NULL true
-1 /t/ab/3/4 NULL false
-2 /t/ab/5/6 NULL true
+0 /t/ab/1/2 NULL ROW
+1 /t/ab/3/4 NULL FILTERED
+2 /t/ab/5/6 NULL ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@ab WHERE a + 1 = 4
 ----
-0 /t/ab/3/4 NULL true
+0 /t/ab/3/4 NULL ROW
 
 query ITT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false

--- a/sql/testdata/select_non_covering_index
+++ b/sql/testdata/select_non_covering_index
@@ -18,10 +18,14 @@ EXPLAIN SELECT * FROM t WHERE b = 2
 1 scan       t@b /2-/3
 1 scan       t@primary
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE b = 2
 ----
-0 /t/b/2/1 NULL true
+0 /t/b/2/1       NULL PARTIAL
+0 /t/primary/1   NULL PARTIAL
+0 /t/primary/1/b 2    PARTIAL
+0 /t/primary/1/c 3    PARTIAL
+0 /t/primary/1/d 4    ROW
 
 query IIII
 SELECT * FROM t WHERE b = 2
@@ -35,10 +39,14 @@ EXPLAIN SELECT * FROM t WHERE c = 6
 1 scan       t@c /6-/7
 1 scan       t@primary
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t WHERE c = 7
 ----
-0 /t/c/7 /5 true
+0 /t/c/7         /5   PARTIAL
+0 /t/primary/5   NULL PARTIAL
+0 /t/primary/5/b 6    PARTIAL
+0 /t/primary/5/c 7    PARTIAL
+0 /t/primary/5/d 8    ROW
 
 query IIII
 SELECT * FROM t WHERE c = 7

--- a/sql/testdata/storing
+++ b/sql/testdata/storing
@@ -24,20 +24,20 @@ t     c_idx   true   4   d      N/A       true
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4)
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@b_idx
 ----
-0 /t/b_idx/2/1/3/4 NULL true
+0 /t/b_idx/2/1/3/4 NULL ROW
 
 query IIII
 SELECT a, b, c, d FROM t@b_idx
 ----
 1 2 3 4
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@c_idx
 ----
-0 /t/c_idx/3 /1/2/4 true
+0 /t/c_idx/3 /1/2/4 ROW
 
 query IIII
 SELECT a, b, c, d FROM t@c_idx
@@ -47,10 +47,10 @@ SELECT a, b, c, d FROM t@c_idx
 statement ok
 CREATE INDEX d_idx ON t (d) STORING (a, b)
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM t@d_idx
 ----
-0 /t/d_idx/4/1/2 NULL true
+0 /t/d_idx/4/1/2 NULL ROW
 
 query III
 SELECT a, b, d FROM t@d_idx

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -15,18 +15,18 @@ rangelog
 users
 zones
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM system.namespace
 ----
-0 /namespace/primary/0/'system'/id     1    true
-1 /namespace/primary/0/'test'/id       50   true
-2 /namespace/primary/1/'descriptor'/id 3    true
-3 /namespace/primary/1/'eventlog'/id   12   true
-4 /namespace/primary/1/'lease'/id      11   true
-5 /namespace/primary/1/'namespace'/id  2    true
-6 /namespace/primary/1/'rangelog'/id   13   true
-7 /namespace/primary/1/'users'/id      4    true
-8 /namespace/primary/1/'zones'/id      5    true
+0 /namespace/primary/0/'system'/id     1    ROW
+1 /namespace/primary/0/'test'/id       50   ROW
+2 /namespace/primary/1/'descriptor'/id 3    ROW
+3 /namespace/primary/1/'eventlog'/id   12   ROW
+4 /namespace/primary/1/'lease'/id      11   ROW
+5 /namespace/primary/1/'namespace'/id  2    ROW
+6 /namespace/primary/1/'rangelog'/id   13   ROW
+7 /namespace/primary/1/'users'/id      4    ROW
+8 /namespace/primary/1/'zones'/id      5    ROW
 
 query ITI
 SELECT * FROM system.namespace

--- a/sql/testdata/update
+++ b/sql/testdata/update
@@ -53,49 +53,49 @@ c   d
 e   f
 f   g
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv2
 ----
-0  /kv2/primary/'a'    NULL  NULL
-0  /kv2/primary/'a'/v  'b'   true
-1  /kv2/primary/'c'    NULL  NULL
-1  /kv2/primary/'c'/v  'd'   true
-2  /kv2/primary/'e'    NULL  NULL
-2  /kv2/primary/'e'/v  'f'   true
-3  /kv2/primary/'f'    NULL  NULL
-3  /kv2/primary/'f'/v  'g'   true
+0  /kv2/primary/'a'    NULL  PARTIAL
+0  /kv2/primary/'a'/v  'b'   ROW
+1  /kv2/primary/'c'    NULL  PARTIAL
+1  /kv2/primary/'c'/v  'd'   ROW
+2  /kv2/primary/'e'    NULL  PARTIAL
+2  /kv2/primary/'e'/v  'f'   ROW
+3  /kv2/primary/'f'    NULL  PARTIAL
+3  /kv2/primary/'f'/v  'g'   ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv2@a
 ----
-0  /kv2/a/'b'  /'a'  true
-1  /kv2/a/'d'  /'c'  true
-2  /kv2/a/'f'  /'e'  true
-3  /kv2/a/'g'  /'f'  true
+0  /kv2/a/'b'  /'a'  ROW
+1  /kv2/a/'d'  /'c'  ROW
+2  /kv2/a/'f'  /'e'  ROW
+3  /kv2/a/'g'  /'f'  ROW
 
 
 statement error duplicate key value \(v\)=\('g'\) violates unique constraint "a"
 UPDATE kv2 SET v = 'g' WHERE k IN ('a')
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv2
 ----
-0  /kv2/primary/'a'    NULL  NULL
-0  /kv2/primary/'a'/v  'b'   true
-1  /kv2/primary/'c'    NULL  NULL
-1  /kv2/primary/'c'/v  'd'   true
-2  /kv2/primary/'e'    NULL  NULL
-2  /kv2/primary/'e'/v  'f'   true
-3  /kv2/primary/'f'    NULL  NULL
-3  /kv2/primary/'f'/v  'g'   true
+0  /kv2/primary/'a'    NULL  PARTIAL
+0  /kv2/primary/'a'/v  'b'   ROW
+1  /kv2/primary/'c'    NULL  PARTIAL
+1  /kv2/primary/'c'/v  'd'   ROW
+2  /kv2/primary/'e'    NULL  PARTIAL
+2  /kv2/primary/'e'/v  'f'   ROW
+3  /kv2/primary/'f'    NULL  PARTIAL
+3  /kv2/primary/'f'/v  'g'   ROW
 
-query ITTB
+query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv2@a
 ----
-0  /kv2/a/'b'  /'a'  true
-1  /kv2/a/'d'  /'c'  true
-2  /kv2/a/'f'  /'e'  true
-3  /kv2/a/'g'  /'f'  true
+0  /kv2/a/'b'  /'a'  ROW
+1  /kv2/a/'d'  /'c'  ROW
+2  /kv2/a/'f'  /'e'  ROW
+3  /kv2/a/'g'  /'f'  ROW
 
 statement ok
 UPDATE kv2 SET v = 'i' WHERE k IN ('a')


### PR DESCRIPTION
Implementing support for EXPLAIN (DEBUG) in the index node: we return any debug
information we encounter from both the index and the table. Issue #4110.

Also replacing the cryptic `NULL`/`true`/`false` output value with a string
(`PARTIAL`, `FILTERED`, `ROW`). In the future we can augment the string with
more data, e.g. to show the layer where we filter something out
(`FITLERED@scan`, `FILTERED@indexJoin`, etc).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4350)

<!-- Reviewable:end -->
