### PR TITLE
cli: correctly handle control characters

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -533,6 +533,22 @@ range_max_bytes: 67108864
 	// zone ls
 }
 
+// Send a query that returns control characters as a byte array. The byte
+// array is hex-encoded per the postgres docs, see:
+// http://www.postgresql.org/docs/current/static/datatype-binary.html
+func Example_sql_Hex() {
+	c := newCLITest()
+	defer c.stop()
+
+	c.RunWithArgs([]string{"sql", "-e", "select E'\\x097f'"})
+
+	// Output:
+	// sql -e select E'\x097f'
+	// 1 row
+	// e'\t7f'
+	// "\t7f"
+}
+
 func Example_sql() {
 	c := newCLITest()
 	defer c.stop()

--- a/cli/sql_util.go
+++ b/cli/sql_util.go
@@ -17,12 +17,13 @@
 package cli
 
 import (
+	"bytes"
 	"database/sql"
 	"fmt"
 	"io"
 	"net"
 	"net/url"
-	"unicode/utf8"
+	"unicode"
 
 	// Import postgres driver.
 	_ "github.com/lib/pq"
@@ -174,11 +175,11 @@ func formatVal(val interface{}) string {
 	case nil:
 		return "NULL"
 	case []byte:
-		if !utf8.Valid(t) {
-			// Ensure that protobufs containing non-UTF8 binary data print escaped.
-			return fmt.Sprintf("%q", t)
+		// All characters are IsPrint, so make a string.
+		if len(bytes.TrimLeftFunc(t, unicode.IsPrint)) == 0 {
+			return string(t)
 		}
-		return string(t)
+		return fmt.Sprintf("%q", t)
 	}
 	return fmt.Sprint(val)
 }


### PR DESCRIPTION
Before this fix, the test would fail like so:

```
--- FAIL: Example_sql_Hex (0.09s)
got:
sql -e select E'\x097f'
1 row
e'\t7f'
    7f
want:
sql -e select E'\x097f'
1 row
e'\t7f'
"\t7f"
```

Fixes #4315. /cc @bdarnell

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4359)

<!-- Reviewable:end -->
