### PR TITLE
storage: port raft to gRPC

### DIFF
--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -176,7 +176,7 @@ func (t *rpcTransport) processQueue(nodeID roachpb.NodeID, storeID roachpb.Store
 	for {
 		raftIdleTimer.Reset(raftIdleTimeout)
 		select {
-		case <-t.rpcContext.Stopper.ShouldStop():
+		case <-ctx.Done():
 			return
 		case <-raftIdleTimer.C:
 			raftIdleTimer.Read = true

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -21,21 +21,21 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/grpcutil"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/gogo/protobuf/proto"
-
-	gorpc "net/rpc"
 )
 
 const (
-	// TODO(bdarnell): consider changing raftServiceName/raftMessageName
-	raftServiceName = "MultiRaft"
-	raftMessageName = raftServiceName + ".RaftMessage"
 	// Outgoing messages are queued on a per-node basis on a channel of
 	// this size.
 	raftSendBufferSize = 500
@@ -47,55 +47,48 @@ const (
 // rpcTransport handles the rpc messages for raft.
 type rpcTransport struct {
 	gossip     *gossip.Gossip
-	rpcServer  *rpc.Server
 	rpcContext *rpc.Context
 	mu         sync.Mutex
 	handlers   map[roachpb.StoreID]storage.RaftMessageHandler
 	queues     map[roachpb.StoreID]chan *storage.RaftMessageRequest
 }
 
-// newRPCTransport creates a new rpcTransport with specified gossip and rpc server.
-func newRPCTransport(gossip *gossip.Gossip, rpcServer *rpc.Server, rpcContext *rpc.Context) (
-	storage.RaftTransport, error) {
+// newRPCTransport creates a new rpcTransport with specified gossip and grpc server.
+func newRPCTransport(gossip *gossip.Gossip, grpcServer *grpc.Server, rpcContext *rpc.Context) storage.RaftTransport {
 	t := &rpcTransport{
 		gossip:     gossip,
-		rpcServer:  rpcServer,
 		rpcContext: rpcContext,
 		handlers:   make(map[roachpb.StoreID]storage.RaftMessageHandler),
 		queues:     make(map[roachpb.StoreID]chan *storage.RaftMessageRequest),
 	}
 
-	if t.rpcServer != nil {
-		if err := t.rpcServer.RegisterAsync(raftMessageName, false, /*not public*/
-			t.RaftMessage, &storage.RaftMessageRequest{}); err != nil {
-			return nil, err
-		}
+	if grpcServer != nil {
+		storage.RegisterMultiRaftServer(grpcServer, t)
 	}
 
-	return t, nil
+	return t
 }
 
 // RaftMessage proxies the incoming request to the listening server interface.
-func (t *rpcTransport) RaftMessage(args proto.Message, callback func(proto.Message, error)) {
-	req := args.(*storage.RaftMessageRequest)
+func (t *rpcTransport) RaftMessage(stream storage.MultiRaft_RaftMessageServer) error {
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			return err
+		}
 
-	t.mu.Lock()
-	handler, ok := t.handlers[req.ToReplica.StoreID]
-	t.mu.Unlock()
+		t.mu.Lock()
+		handler, ok := t.handlers[req.ToReplica.StoreID]
+		t.mu.Unlock()
 
-	if !ok {
-		callback(nil, util.Errorf("Unable to proxy message to node: %d", req.Message.To))
-		return
+		if !ok {
+			return util.Errorf("Unable to proxy message to node: %d", req.Message.To)
+		}
+
+		if err := handler(req); err != nil {
+			return err
+		}
 	}
-
-	// Raft responses are empty so we don't actually need to get a
-	// response from the handler. In fact, we don't even need to wait
-	// for the message to be processed to invoke the callback. We are
-	// just (ab)using the async handler mechanism to get this
-	// (synchronous) handler called in the RPC server's goroutine so we
-	// can preserve order of incoming messages.
-	err := handler(req)
-	callback(&storage.RaftMessageResponse{}, err)
 }
 
 // Listen implements the storage.RaftTransport interface by
@@ -142,23 +135,42 @@ func (t *rpcTransport) processQueue(nodeID roachpb.NodeID, storeID roachpb.Store
 		}
 		return
 	}
-	client := rpc.NewClient(addr, t.rpcContext)
-	select {
-	case <-t.rpcContext.Stopper.ShouldStop():
-		return
-	case <-client.Closed:
-		log.Warningf("raft client for node %d was closed", nodeID)
-		return
-	case <-time.After(raftIdleTimeout):
-		// Should never happen.
-		log.Errorf("raft client for node %d stuck connecting", nodeID)
-		return
-	case <-client.Healthy():
+
+	var dialOpt grpc.DialOption
+	if t.rpcContext.Insecure {
+		dialOpt = grpc.WithInsecure()
+	} else {
+		tlsConfig, err := t.rpcContext.GetClientTLSConfig()
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		dialOpt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 
-	done := make(chan *gorpc.Call, cap(ch))
-	var req *storage.RaftMessageRequest
-	protoResp := &storage.RaftMessageResponse{}
+	conn, err := grpc.Dial(addr.String(), dialOpt)
+	if err != nil {
+		log.Errorf("failed to dial: %v", err)
+		return
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			log.Error(err)
+		}
+	}()
+	client := storage.NewMultiRaftClient(conn)
+	ctx := grpcutil.NewContextWithStopper(context.Background(), t.rpcContext.Stopper)
+	stream, err := client.RaftMessage(ctx)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	defer func() {
+		if err := stream.CloseSend(); err != nil {
+			log.Error(err)
+		}
+	}()
+
 	var raftIdleTimer util.Timer
 	defer raftIdleTimer.Stop()
 	for {
@@ -172,21 +184,12 @@ func (t *rpcTransport) processQueue(nodeID roachpb.NodeID, storeID roachpb.Store
 				log.Infof("closing Raft transport to %d due to inactivity", nodeID)
 			}
 			return
-		case <-client.Closed:
-			log.Warningf("raft client for node %d closed", nodeID)
-			return
-		case call := <-done:
-			if call.Error != nil {
-				log.Errorf("raft message to node %d failed: %s", nodeID, call.Error)
+		case req := <-ch:
+			if err := stream.Send(req); err != nil {
+				log.Error(err)
+				return
 			}
-			continue
-		case req = <-ch:
 		}
-		if req == nil {
-			return
-		}
-
-		client.Go(raftMessageName, req, protoResp, done)
 	}
 }
 

--- a/storage/client_replica_gc_test.go
+++ b/storage/client_replica_gc_test.go
@@ -74,7 +74,7 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 	mtc.unreplicateRange(rangeID, 1)
 
 	// Make sure the range is removed from the store.
-	util.SucceedsWithin(t, time.Second, func() error {
+	util.SucceedsWithin(t, 10*time.Second, func() error {
 		if _, err := mtc.stores[1].GetReplica(rangeID); !testutils.IsError(err, "range .* was not found") {
 			return util.Errorf("expected range removal")
 		}

--- a/storage/raft.proto
+++ b/storage/raft.proto
@@ -52,3 +52,7 @@ message ConfChangeContext {
   // Replica contains full details about the replica being added or removed.
   optional roachpb.ReplicaDescriptor replica = 3 [(gogoproto.nullable) = false];
 }
+
+service MultiRaft {
+  rpc RaftMessage (stream RaftMessageRequest) returns (RaftMessageResponse) {}
+}


### PR DESCRIPTION
Note that this makes Raft not use our RPC package, which means heartbeats will no longer take place on those connections. I'd like to restore that functionality in a follow-up PR in which the global client cache is replaced with something more explicit which is handed down to raft/gossip/kv from server/server.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4365)

<!-- Reviewable:end -->
