### PR TITLE
Prevent NPE in Txn.String()

### DIFF
--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -26,6 +26,7 @@ import (
 	"math/rand"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -799,6 +800,9 @@ func (t Transaction) String() string {
 
 // Short returns the short form of the Transaction's UUID.
 func (t Transaction) Short() string {
+	if t.ID == nil {
+		return strings.Repeat("?", 8)
+	}
 	return t.ID.String()[:8]
 }
 

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -415,6 +415,9 @@ func TestTransactionString(t *testing.T) {
 	if str := txn.String(); str != expStr {
 		t.Errorf("expected txn %s; got %s", expStr, str)
 	}
+
+	var txnEmpty Transaction
+	_ = txnEmpty.String() // prevent regression of NPE
 }
 
 // TestNodeList verifies that its exported methods Add() and Contain()


### PR DESCRIPTION
We were calling Txn.Short() on a UUID which
was potentially nil. Fixed Short() to return
a dummy string in that case.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4371)

<!-- Reviewable:end -->
