### PR TITLE
Introduce RangeGroup to topologically sort Replica command dependencies

### DIFF
--- a/util/interval/range_group.go
+++ b/util/interval/range_group.go
@@ -1,0 +1,254 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package interval
+
+import (
+	"container/list"
+	"fmt"
+)
+
+// RangeGroup represents a set of possibly disjointed Ranges. The
+// primary use case of the interface is to add ranges to the group
+// and observe whether the addition increases the size of the group
+// or not, indicating whether the new range's interval is redundant,
+// or if it is needed for the full composition of the group. Because
+// the RangeGroup builds as more ranges are added, insertion order of
+// the ranges is critical. For instance, if two identical ranges are
+// added, only the first to be added with Add will return true, as it
+// will be the only one to expand the group.
+type RangeGroup interface {
+	// Add will attempt to add the provided Range to the RangeGroup,
+	// returning whether the addition increased the range of the group
+	// or not. The method will panic if the provided range is inverted
+	// or empty.
+	Add(Range) bool
+	// Len returns the number of Ranges currently within the RangeGroup.
+	// This will always be equal to or less than the number of ranges added,
+	// as ranges that overlap will merge to produce a single larger range.
+	Len() int
+	// Clear clears all ranges from the RangeGroup, resetting it to be
+	// used again.
+	Clear()
+}
+
+// rangeList is an implementation of a RangeGroup using a linked
+// list to sequentially order non-overlapping ranges.
+//
+// rangeList is not safe for concurrent use by multiple goroutines.
+type rangeList struct {
+	ll list.List
+}
+
+// NewRangeList constructs a linked-list backed RangeGroup.
+func NewRangeList() RangeGroup {
+	var r rangeList
+	r.ll.Init()
+	return &r
+}
+
+// Add implements RangeGroup. It iterates over the current ranges in the
+// rangeList to find which overlap with the new range. If there is no
+// overlap, the new range will be added and the function will return true.
+// If there is some overlap, the function will return true if the new
+// range increases the range of the rangeList, in which case it will be
+// added to the list, and false if it does not increase the range, in which
+// case it won't be added. If the range is added, the function will also attempt
+// to merge any ranges within the list that now overlap.
+func (rg *rangeList) Add(r Range) bool {
+	if err := rangeError(r); err != nil {
+		panic(err)
+	}
+	for e := rg.ll.Front(); e != nil; e = e.Next() {
+		er := e.Value.(Range)
+		switch {
+		case overlap(er, r):
+			// If a current range fully contains the new range, no
+			// need to add it.
+			if contains(er, r) {
+				return false
+			}
+
+			// Merge as many ranges as possible, and replace old range.
+			newR := merge(er, r)
+			for p := e.Next(); p != nil; {
+				pr := p.Value.(Range)
+				if overlap(newR, pr) {
+					newR = merge(newR, pr)
+
+					nextP := p.Next()
+					rg.ll.Remove(p)
+					p = nextP
+				} else {
+					break
+				}
+			}
+			e.Value = newR
+			return true
+		case r.End.Compare(er.Start) < 0:
+			rg.ll.InsertBefore(r, e)
+			return true
+		}
+	}
+	rg.ll.PushBack(r)
+	return true
+}
+
+// Len implements RangeGroup. It returns the number of ranges in
+// the rangeList.
+func (rg *rangeList) Len() int {
+	return rg.ll.Len()
+}
+
+// Clear implements RangeGroup. It clears all ranges from the
+// rangeList.
+func (rg *rangeList) Clear() {
+	rg.ll.Init()
+}
+
+// rangeTree is an implementation of a RangeGroup using an interval
+// tree to efficiently store and search for non-overlapping ranges.
+//
+// rangeTree is not safe for concurrent use by multiple goroutines.
+type rangeTree struct {
+	t       Tree
+	idCount uintptr
+}
+
+// NewRangeTree constructs an interval tree backed RangeGroup.
+func NewRangeTree() RangeGroup {
+	return &rangeTree{}
+}
+
+// rangeKey implements Interface and can be inserted into a Tree. It
+// provides uniqueness as well as a key interval.
+type rangeKey struct {
+	r  Range
+	id uintptr
+}
+
+var _ Interface = rangeKey{}
+
+// makeKey creates a new rangeKey defined by the provided range.
+func (rt *rangeTree) makeKey(r Range) rangeKey {
+	rt.idCount++
+	return rangeKey{
+		r:  r,
+		id: rt.idCount,
+	}
+}
+
+// Overlap implements Interface.
+func (rk rangeKey) Overlap(r Range) bool {
+	return overlap(rk.r, r)
+}
+
+func (rk rangeKey) Contains(lk rangeKey) bool {
+	return contains(rk.r, lk.r)
+}
+
+// Range implements Interface.
+func (rk rangeKey) Range() Range {
+	return rk.r
+}
+
+// ID implements Interface.
+func (rk rangeKey) ID() uintptr {
+	return rk.id
+}
+
+func (rk rangeKey) String() string {
+	return fmt.Sprintf("%d: %q-%q", rk.id, rk.r.Start, rk.r.End)
+}
+
+// Add implements RangeGroup. It first uses the interval tree to lookup
+// the current ranges which overlap with the new range. If there is no
+// overlap, the new range will be added and the function will return true.
+// If there is some overlap, the function will return true if the new
+// range increases the range of the rangeTree, in which case it will be
+// added to the tree, and false if it does not increase the range, in which
+// case it won't be added. If the range is added, the function will also attempt
+// to merge any ranges within the tree that now overlap.
+func (rt *rangeTree) Add(r Range) bool {
+	if err := rangeError(r); err != nil {
+		panic(err)
+	}
+	key := rt.makeKey(r)
+	overlaps := rt.t.Get(key)
+	if len(overlaps) == 0 {
+		if err := rt.t.Insert(&key, false /* !fast */); err != nil {
+			panic(err)
+		}
+		return true
+	}
+	first := overlaps[0].(*rangeKey)
+
+	// If a current range fully contains the new range, no
+	// need to add it.
+	if first.Contains(key) {
+		return false
+	}
+
+	// Merge as many ranges as possible, and replace old range.
+	first.r = merge(first.r, r)
+	for _, o := range overlaps[1:] {
+		other := o.(*rangeKey)
+		first.r = merge(first.r, other.r)
+		if err := rt.t.Delete(o, true /* fast */); err != nil {
+			panic(err)
+		}
+	}
+	rt.t.AdjustRanges()
+	return true
+}
+
+// Len implements RangeGroup. It returns the number of rangeKeys in
+// the rangeTree.
+func (rt *rangeTree) Len() int {
+	return rt.t.Len()
+}
+
+// Clear implements RangeGroup. It clears all rangeKeys from the rangeTree.
+func (rt *rangeTree) Clear() {
+	rt.t = Tree{}
+}
+
+// overlap returns whether the two provided ranges overlap. It defines
+// overlapping as a pair of ranges that either share a segment of the
+// keyspace, or share an inclusive/exclusive boundary.
+func overlap(l, r Range) bool {
+	return l.End.Compare(r.Start) >= 0 && l.Start.Compare(r.End) <= 0
+}
+
+// contains returns if the range in the out range fully contains the
+// in range.
+func contains(out, in Range) bool {
+	return in.Start.Compare(out.Start) >= 0 && out.End.Compare(in.End) >= 0
+}
+
+// merge merges the provided ranges together into their union range. The
+// ranges must overlap or the function will not produce the correct output.
+func merge(l, r Range) Range {
+	start := l.Start
+	if r.Start.Compare(start) < 0 {
+		start = r.Start
+	}
+	end := l.End
+	if r.End.Compare(end) > 0 {
+		end = r.End
+	}
+	return Range{Start: start, End: end}
+}

--- a/util/interval/range_group_test.go
+++ b/util/interval/range_group_test.go
@@ -1,0 +1,317 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package interval
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	_ "github.com/cockroachdb/cockroach/util/log" // for flags
+)
+
+func TestRangeListSingleRangeAndClear(t *testing.T) {
+	testRangeGroupSingleRangeAndClear(t, NewRangeList())
+}
+
+func TestRangeTreeSingleRangeAndClear(t *testing.T) {
+	testRangeGroupSingleRangeAndClear(t, NewRangeTree())
+}
+
+func testRangeGroupSingleRangeAndClear(t *testing.T, rg RangeGroup) {
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+
+	if l := rg.Len(); l != 1 {
+		t.Errorf("added 1 range to range group, wanted len = 1; got len = %d", l)
+	}
+
+	rg.Clear()
+	if l := rg.Len(); l != 0 {
+		t.Errorf("cleared range group, wanted len = 0; got len = %d", l)
+	}
+}
+
+func TestRangeListTwoRangesBefore(t *testing.T) {
+	testRangeGroupTwoRangesBefore(t, NewRangeList())
+}
+
+func TestRangeTreeTwoRangesBefore(t *testing.T) {
+	testRangeGroupTwoRangesBefore(t, NewRangeTree())
+}
+
+func testRangeGroupTwoRangesBefore(t *testing.T, rg RangeGroup) {
+	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+
+	if l := rg.Len(); l != 2 {
+		t.Errorf("added 2 disjoint ranges to range group, wanted len = 2; got len = %d", l)
+	}
+}
+
+func TestRangeListTwoRangesAfter(t *testing.T) {
+	testRangeGroupTwoRangesAfter(t, NewRangeList())
+}
+
+func TestRangeTreeTwoRangesAfter(t *testing.T) {
+	testRangeGroupTwoRangesAfter(t, NewRangeTree())
+}
+
+func testRangeGroupTwoRangesAfter(t *testing.T, rg RangeGroup) {
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+
+	if l := rg.Len(); l != 2 {
+		t.Errorf("added 2 disjoint ranges to range group, wanted len = 2; got len = %d", l)
+	}
+}
+
+func TestRangeListTwoRangesMergeForward(t *testing.T) {
+	testRangeGroupTwoRangesMergeForward(t, NewRangeList())
+}
+
+func TestRangeTreeTwoRangesMergeForward(t *testing.T) {
+	testRangeGroupTwoRangesMergeForward(t, NewRangeTree())
+}
+
+func testRangeGroupTwoRangesMergeForward(t *testing.T, rg RangeGroup) {
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+
+	if l := rg.Len(); l != 1 {
+		t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
+	}
+}
+
+func TestRangeListTwoRangesMergeBackwards(t *testing.T) {
+	testRangeGroupTwoRangesMergeBackwards(t, NewRangeList())
+}
+
+func TestRangeTreeTwoRangesMergeBackwards(t *testing.T) {
+	testRangeGroupTwoRangesMergeBackwards(t, NewRangeTree())
+}
+
+func testRangeGroupTwoRangesMergeBackwards(t *testing.T, rg RangeGroup) {
+	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+
+	if l := rg.Len(); l != 1 {
+		t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
+	}
+}
+
+func TestRangeListTwoRangesWithin(t *testing.T) {
+	testRangeGroupTwoRangesWithin(t, NewRangeList())
+}
+
+func TestRangeTreeTwoRangesWithin(t *testing.T) {
+	testRangeGroupTwoRangesWithin(t, NewRangeTree())
+}
+
+func testRangeGroupTwoRangesWithin(t *testing.T, rg RangeGroup) {
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x04}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x02}, End: []byte{0x03}}); added {
+		t.Errorf("added fully contained range to range group, wanted false added flag; got true")
+	}
+
+	if l := rg.Len(); l != 1 {
+		t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
+	}
+}
+
+func TestRangeListTwoRangesSurround(t *testing.T) {
+	testRangeGroupTwoRangesSurround(t, NewRangeList())
+}
+
+func TestRangeTreeTwoRangesSurround(t *testing.T) {
+	testRangeGroupTwoRangesSurround(t, NewRangeTree())
+}
+
+func testRangeGroupTwoRangesSurround(t *testing.T, rg RangeGroup) {
+	if added := rg.Add(Range{Start: []byte{0x02}, End: []byte{0x03}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x04}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+
+	if l := rg.Len(); l != 1 {
+		t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
+	}
+}
+
+func TestRangeListThreeRangesMergeInOrder(t *testing.T) {
+	testRangeGroupThreeRangesMergeInOrder(t, NewRangeList())
+}
+
+func TestRangeTreeThreeRangesMergeInOrder(t *testing.T) {
+	testRangeGroupThreeRangesMergeInOrder(t, NewRangeTree())
+}
+
+func testRangeGroupThreeRangesMergeInOrder(t *testing.T, rg RangeGroup) {
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+
+	if l := rg.Len(); l != 1 {
+		t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
+	}
+}
+
+func TestRangeListThreeRangesMergeOutOfOrder(t *testing.T) {
+	testRangeGroupThreeRangesMergeOutOfOrder(t, NewRangeList())
+}
+
+func TestRangeTreeThreeRangesMergeOutOfOrder(t *testing.T) {
+	testRangeGroupThreeRangesMergeOutOfOrder(t, NewRangeTree())
+}
+
+func testRangeGroupThreeRangesMergeOutOfOrder(t *testing.T, rg RangeGroup) {
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+
+	if l := rg.Len(); l != 1 {
+		t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
+	}
+}
+
+func TestRangeListThreeRangesMergeReverseOrder(t *testing.T) {
+	testRangeGroupThreeRangesMergeReverseOrder(t, NewRangeList())
+}
+
+func TestRangeTreeThreeRangesMergeReverseOrder(t *testing.T) {
+	testRangeGroupThreeRangesMergeReverseOrder(t, NewRangeTree())
+}
+
+func testRangeGroupThreeRangesMergeReverseOrder(t *testing.T, rg RangeGroup) {
+	if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+
+	if l := rg.Len(); l != 1 {
+		t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
+	}
+}
+
+func TestRangeListThreeRangesSuperset(t *testing.T) {
+	testRangeGroupThreeRangesSuperset(t, NewRangeList())
+}
+
+func TestRangeTreeThreeRangesSuperset(t *testing.T) {
+	testRangeGroupThreeRangesSuperset(t, NewRangeTree())
+}
+
+func testRangeGroupThreeRangesSuperset(t *testing.T, rg RangeGroup) {
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x06}}); !added {
+		t.Errorf("added new range to range group, wanted true added flag; got false")
+	}
+
+	if l := rg.Len(); l != 1 {
+		t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
+	}
+}
+
+func TestRangeListAndRangeGroupIdentical(t *testing.T) {
+	const trials = 5
+	for tr := 0; tr < trials; tr++ {
+		rl := NewRangeList()
+		rt := NewRangeTree()
+
+		const iters = 20
+		for i := 0; i < iters; i++ {
+			r := getRandomRange(t, 3)
+			listAdded := rl.Add(r)
+			treeAdded := rt.Add(r)
+			if listAdded != treeAdded {
+				t.Errorf("expected adding %s to RangeList and RangeTree to produce the same result; got %t from RangeList and %t from RangeTree", r, listAdded, treeAdded)
+			}
+
+			listLen := rl.Len()
+			treeLen := rt.Len()
+			if listLen != treeLen {
+				t.Errorf("expected RangeList and RangeTree to have the same length; got %d from RangeList and %d from RangeTree", listLen, treeLen)
+			}
+		}
+	}
+}
+
+func getRandomRange(t *testing.T, n int) Range {
+	s1 := getRandomByteSlice(t, n)
+	s2 := getRandomByteSlice(t, n)
+	cmp := bytes.Compare(s1, s2)
+	for cmp == 0 {
+		s2 = getRandomByteSlice(t, n)
+		cmp = bytes.Compare(s1, s2)
+	}
+	if cmp < 0 {
+		return Range{Start: s1, End: s2}
+	}
+	return Range{Start: s2, End: s1}
+}
+
+func getRandomByteSlice(t *testing.T, n int) []byte {
+	s := make([]byte, n)
+	_, err := rand.Read(s)
+	if err != nil {
+		t.Fatalf("could not create random byte slice: %v", err)
+	}
+	return s
+}


### PR DESCRIPTION
Introduces a `RangeGroup` type that represents a set of disjointed
Ranges. The primary use-case of the interface is to add ranges to the
group and observe whether the addition increases the size of the group
or not, indicating whether the RangeGroup is dependent upon some
or all of the new range's interval. This PR also introduces two
implementations of the `RangeGroup`, `RangeList` based on a linked-list,
and `RangeTree` based on an interval tree.

This new construct is then used in a `Replica`'s `CommandQueue` to
prevent decencies between commands with contentious spans from
exponentially exploding, which was causing visible [performance issues](https://github.com/cockroachdb/cockroach/issues/4346#issuecomment-183752564)
due to large memory allocations and high synchronization costs. The 
observed explosion occurred because as new contentious commands came into
the queue, every overlapping command would have to mark it as a
dependent command, and then synchronize with this new command when it
was done. As more overlapping commands came in, the process slowed down,
and the queue built up, which meant more commands had to be marked as
dependent, and so on... 

With this change, the number of commands that have to update their dependency
lists given a new command is near-constant instead of linear with respect to the
size of the `CommandQueue` (in a worst-case contentious situation). This in turn
means that the synchronization cost of alerting all dependent `WaitGroup`s when
command processing is complete is also near-constant instead of linear. Furthermore,
while the `RangeGroup` does add some compute complexity to determining 
dependencies, using the `RangeTree` should run this analysis in logarithmic time, 
and there are a few optimizations that could be added to stop this analysis short once
the `RangeGroup` fully encompasses the new command's range.
## Effects of Change:
### Steps:
- Start up a three node cluster
- Hit each node with a 50-user photo example instance
- Wait about a minute
- Memory profile each node using `--inuse-space` or `--inuse-objects`
### Results before change:

The `CommandQueue`'s `GetWait` method would quickly become the dominant
memory allocator for all 3 nodes, especially one of them (lease
leader?).
#### Memory:

After a minute:

```
587.94MB 80.26% 80.26% 587.94MB 80.26% github.com/cockroachdb/cockroach/storage.(*CommandQueue).GetWait
```

After 5 mintues

```
982.96MB 85.49% 85.49% 983.67MB 85.56% github.com/cockroachdb/cockroach/storage.(*CommandQueue).GetWait
```
#### Blocking:

`storage.(*Replica).beginCmds` resposible for **1.12%** of all blocking
and 100% of `WaitGroup` block after a minute, and this grew steadily.
**1.49%** after 2 minutes
**2.74%** after 3 minutes
**4.00%** after 5 minutes
etc.
### Results after change:
- `RangeGroup` is not visible while profiling after 10+ minutes
- `(*CommandQueue).GetWait` is not visible while profiling
- Blocking on `WaitGroup`s back to normal (< 1% of all blocking)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4375)

<!-- Reviewable:end -->
