### PR TITLE
Add 1PC optimization to delete/update.

### DIFF
--- a/sql/plan.go
+++ b/sql/plan.go
@@ -100,7 +100,7 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, *r
 	case *parser.CreateTable:
 		return p.CreateTable(n)
 	case *parser.Delete:
-		return p.Delete(n)
+		return p.Delete(n, autoCommit)
 	case *parser.DropDatabase:
 		return p.DropDatabase(n)
 	case *parser.DropIndex:
@@ -151,7 +151,7 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, *r
 	case *parser.Truncate:
 		return p.Truncate(n)
 	case *parser.Update:
-		return p.Update(n)
+		return p.Update(n, autoCommit)
 	case parser.Values:
 		return p.Values(n)
 	default:
@@ -163,7 +163,7 @@ func (p *planner) prepare(stmt parser.Statement) (planNode, *roachpb.Error) {
 	p.prepareOnly = true
 	switch n := stmt.(type) {
 	case *parser.Delete:
-		return p.Delete(n)
+		return p.Delete(n, false)
 	case *parser.Insert:
 		return p.Insert(n, false)
 	case *parser.Select:
@@ -181,7 +181,7 @@ func (p *planner) prepare(stmt parser.Statement) (planNode, *roachpb.Error) {
 	case *parser.ShowTables:
 		return p.ShowTables(n)
 	case *parser.Update:
-		return p.Update(n)
+		return p.Update(n, false)
 	default:
 		return nil, roachpb.NewUErrorf("prepare statement not supported: %s", stmt.StatementTag())
 


### PR DESCRIPTION
The changes in the Update10 and Update100 benchmarks are just noise as
they aren't able to take advantage of the optimization due to using an
explicit transaction. This does highlight that allowing users to specify
that they want the operations within a transaction to be batched could
give a significant speedup.

I need to figure out why Delete100 got slower. That result is
repeatable, but confusing.

```
name                   old time/op    new time/op    delta
Update1_Cockroach-8       626µs ± 2%     462µs ± 1%  -26.20%        (p=0.000 n=10+10)
Update10_Cockroach-8     3.70ms ± 1%    3.63ms ± 1%   -1.81%         (p=0.000 n=9+10)
Update100_Cockroach-8    32.9ms ± 1%    32.3ms ± 1%   -1.89%        (p=0.000 n=10+10)
Delete1_Cockroach-8       619µs ± 1%     466µs ± 1%  -24.76%        (p=0.000 n=10+10)
Delete10_Cockroach-8     1.26ms ± 2%    1.16ms ± 1%   -8.19%         (p=0.000 n=10+9)
Delete100_Cockroach-8    7.08ms ± 1%    7.50ms ± 1%   +5.89%        (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
Update1_Cockroach-8         651 ± 0%       488 ± 0%  -25.04%         (p=0.000 n=10+9)
Update10_Cockroach-8      4.47k ± 0%     4.47k ± 0%     ~     (all samples are equal)
Update100_Cockroach-8     42.5k ± 0%     42.5k ± 0%     ~           (p=0.669 n=10+10)
Delete1_Cockroach-8         597 ± 0%       452 ± 0%  -24.29%        (p=0.000 n=10+10)
Delete10_Cockroach-8      1.37k ± 0%     1.20k ± 0%  -12.33%        (p=0.000 n=10+10)
Delete100_Cockroach-8     8.54k ± 0%     8.19k ± 0%   -4.09%         (p=0.000 n=7+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4384)

<!-- Reviewable:end -->
