### PR TITLE
MVCCResolveWriteIntent{,Range} optimizations.

### DIFF
--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -2377,7 +2377,6 @@ func TestMVCCStatsBasic(t *testing.T) {
 	// Resolve the deletion by aborting it.
 	txn.Status = roachpb.ABORTED
 	txn.Timestamp.Forward(ts2)
-	fmt.Printf("after delete: %+v\n", expMS2)
 	if err := MVCCResolveWriteIntent(engine, ms, roachpb.Intent{Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Reduce memory allocations. Reuse an iterator between
MVCCResolveWriteIntentRange and the calls to MVCCResolveWriteIntent
instead of creating an iterator on every call to MVCCResolveWriteIntent.

```
name                   old time/op    new time/op    delta
Insert1_Cockroach-8       327µs ± 1%     324µs ± 1%   -0.83%         (p=0.003 n=10+9)
Insert10_Cockroach-8      637µs ± 1%     630µs ± 1%   -1.17%        (p=0.000 n=10+10)
Insert100_Cockroach-8    3.34ms ± 0%    3.32ms ± 1%   -0.60%         (p=0.028 n=9+10)
Update1_Cockroach-8       468µs ± 1%     467µs ± 1%     ~           (p=0.315 n=10+10)
Update10_Cockroach-8     3.74ms ± 1%    3.71ms ± 2%     ~           (p=0.218 n=10+10)
Update100_Cockroach-8    32.9ms ± 0%    32.7ms ± 1%   -0.61%        (p=0.002 n=10+10)
Delete1_Cockroach-8       465µs ± 1%     458µs ± 1%   -1.63%         (p=0.000 n=9+10)
Delete10_Cockroach-8     1.18ms ± 1%    1.07ms ± 1%   -9.79%         (p=0.000 n=9+10)
Delete100_Cockroach-8    7.53ms ± 1%    6.53ms ± 2%  -13.26%         (p=0.000 n=10+9)
Scan1_Cockroach-8         139µs ± 1%     139µs ± 1%     ~            (p=0.497 n=10+9)
Scan10_Cockroach-8        170µs ± 1%     171µs ± 1%     ~           (p=0.190 n=10+10)
Scan100_Cockroach-8       473µs ± 2%     481µs ± 4%     ~           (p=0.063 n=10+10)

name                   old allocs/op  new allocs/op  delta
Insert1_Cockroach-8         287 ± 0%       284 ± 0%   -1.05%        (p=0.000 n=10+10)
Insert10_Cockroach-8        737 ± 0%       707 ± 0%   -4.07%         (p=0.000 n=9+10)
Insert100_Cockroach-8     5.01k ± 0%     4.71k ± 0%   -5.99%        (p=0.000 n=10+10)
Update1_Cockroach-8         479 ± 0%       475 ± 0%   -0.63%        (p=0.000 n=10+10)
Update10_Cockroach-8      4.38k ± 0%     4.35k ± 0%   -0.68%          (p=0.000 n=6+9)
Update100_Cockroach-8     41.7k ± 0%     41.4k ± 0%   -0.71%        (p=0.000 n=10+10)
Delete1_Cockroach-8         443 ± 0%       428 ± 0%   -3.39%        (p=0.000 n=10+10)
Delete10_Cockroach-8      1.18k ± 0%     1.01k ± 0%  -14.23%        (p=0.000 n=10+10)
Delete100_Cockroach-8     8.08k ± 0%     6.38k ± 0%  -21.02%         (p=0.000 n=10+9)
Scan1_Cockroach-8           161 ± 0%       161 ± 0%     ~     (all samples are equal)
Scan10_Cockroach-8          241 ± 0%       241 ± 0%     ~     (all samples are equal)
Scan100_Cockroach-8         967 ± 0%       968 ± 0%     ~           (p=0.656 n=10+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4391)

<!-- Reviewable:end -->
