### PR TITLE
CI: Unify `master` branch deployment sections

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -45,9 +45,6 @@ deployment:
           -l "${CIRCLE_ARTIFACTS}"/acceptance_deploy 2>&1 >
           "${CIRCLE_ARTIFACTS}/acceptance_deploy.log"
       - build/push-aws.sh
-  osx:
-    branch: master
-    commands:
       - |
           if [ -n "${BUILD_OSX-}" ]; then
             set -eux


### PR DESCRIPTION
When multiple sections match the same branch (as in the previous
version), only the first section runs.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4396)

<!-- Reviewable:end -->
