### PR TITLE
roachpb: Remove BatchRequest.GoError()

### DIFF
--- a/roachpb/api_test.go
+++ b/roachpb/api_test.go
@@ -34,9 +34,8 @@ func (t *testError) SetErrorIndex(_ int32)      { panic("unsupported") }
 func TestSetGoErrorGeneric(t *testing.T) {
 	br := &BatchResponse{}
 	br.SetGoError(&testError{})
-	err := br.GoError()
-	if err.Error() != "test" {
-		t.Fatalf("unexpected error: %s", err)
+	if br.Error.GoError().Error() != "test" {
+		t.Errorf("unexpected error: %s", br.Error)
 	}
 	if !br.Error.Retryable {
 		t.Error("expected generic error to be retryable")
@@ -48,8 +47,8 @@ func TestSetGoErrorGeneric(t *testing.T) {
 func TestSetGoErrorNil(t *testing.T) {
 	br := &BatchResponse{}
 	br.SetGoError(nil)
-	if err := br.GoError(); err != nil {
-		t.Errorf("expected nil error; got %s", err)
+	if br.Error != nil {
+		t.Errorf("expected nil error; got %s", br.Error)
 	}
 }
 

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -296,11 +296,6 @@ func (ba *BatchRequest) SetNewRequest() {
 	ba.Txn.Sequence++
 }
 
-// GoError returns the non-nil error from the proto.Error union.
-func (br *BatchResponse) GoError() error {
-	return br.Error.GoError()
-}
-
 // SetGoError converts the specified type into either one of the proto-
 // defined error types or into an Error for all other Go errors.
 func (br *BatchResponse) SetGoError(err error) {


### PR DESCRIPTION
The method was only used in api_test.go.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4400)

<!-- Reviewable:end -->
