### PR TITLE
fix glock failing to 'go get' inside githooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ $(GLOCK):
 # Update the git hooks and run the bootstrap script whenever any
 # of them (or their dependencies) change.
 .bootstrap: $(GITHOOKS) $(GLOCK) GLOCKFILE
-	@$(GLOCK) sync github.com/cockroachdb/cockroach
+	@env -u GIT_WORK_TREE $(GLOCK) sync github.com/cockroachdb/cockroach
 	touch $@
 
 include .bootstrap


### PR DESCRIPTION
When glock is run in a git hook and tries to `go get` a new dependency,
the `git clone` operation fails with a message like this:

```
fatal: working tree '.' already exists.
```

This is because the git hook is executed with `GIT_WORK_TREE` and `GIT_DIR`
env vars set, which interfere with git operations on other repos.
Using `env` to execute glock with these specifically unset should avoid the issue.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4402)

<!-- Reviewable:end -->
