### PR TITLE
remove the double quote around the databases and tables in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,19 +88,22 @@ Now let's talk to this node. The easiest way to do that is to use the `cockroach
 +----------+
 | Database |
 +----------+
-| "system" |
+| system   |
 +----------+
 192.168.99.100:26257> SET database = system;
 OK
 192.168.99.100:26257> show tables;
-+--------------+
-|    Table     |
-+--------------+
-| "descriptor" |
-| "namespace"  |
-| "users"      |
-| "zones"      |
-+--------------+
++------------+
+|   Table    |
++------------+
+| descriptor |
+| eventlog   |
+| lease      |
+| namespace  |
+| rangelog   |
+| users      |
+| zones      |
++------------+
 ```
 
 Check out `./cockroach help` to see all available commands.


### PR DESCRIPTION
remove the double quotes and update to the latest default tables.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4404)

<!-- Reviewable:end -->
