### PR TITLE
Avoid panic on (*Error)(nil).GetTxn()

### DIFF
--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -192,6 +192,9 @@ func (e *Error) SetTxn(txn *Transaction) {
 
 // GetTxn returns the txn.
 func (e *Error) GetTxn() *Transaction {
+	if e == nil {
+		return nil
+	}
 	return e.UnexposedTxn
 }
 

--- a/roachpb/errors_test.go
+++ b/roachpb/errors_test.go
@@ -30,3 +30,16 @@ func TestSetTxn(t *testing.T) {
 		t.Errorf("unexpected message: %s", e.Message)
 	}
 }
+
+func TestErrorTxn(t *testing.T) {
+	var pErr *Error
+	if txn := pErr.GetTxn(); txn != nil {
+		t.Fatalf("wanted nil, unexpected: %+v", txn)
+	}
+	pErr = &Error{}
+	const name = "X"
+	pErr.SetTxn(&Transaction{Name: name})
+	if txn := pErr.GetTxn(); txn == nil || txn.Name != name {
+		t.Fatalf("wanted name %s, unexpected: %+v", name, txn)
+	}
+}


### PR DESCRIPTION
spotted in CircleCI output in a panicking Printf call.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4405)

<!-- Reviewable:end -->
