### PR TITLE
Always reset global state after a test failure

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -198,6 +198,16 @@ func startMultiTestContext(t *testing.T, numStores int) *multiTestContext {
 func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	m.t = t
 	m.reenableTableSplits = config.TestingDisableTableSplits()
+
+	var ranSuccessfully bool
+	defer func() {
+		// t.Fatal calls runtime.Goexit(), so recover() is nil, but we
+		// still need to know whether we ran to completion.
+		if !ranSuccessfully {
+			m.reenableTableSplits()
+		}
+	}()
+
 	if m.manualClock == nil {
 		m.manualClock = hlc.NewManualClock(0)
 	}
@@ -250,6 +260,7 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 		}
 		return nil
 	})
+	ranSuccessfully = true
 }
 
 func (m *multiTestContext) Stop() {


### PR DESCRIPTION
Prior to this change, if multiTextContext.Start() failed, it
would possibly not undo its call to disable the table splits,
which would fail the next test trying to use the same mechanism.

See https://circleci.com/gh/cockroachdb/cockroach/12862 for one
of these failures.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4406)

<!-- Reviewable:end -->
