### PR TITLE
Limit amount of data in issues created by circle-test

### DIFF
--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -82,7 +82,7 @@ prepare_artifacts() {
       function post() {
         curl -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \
         "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/$1" \
-        -d "${2}"
+        -d "${2:0:$(getconf ARG_MAX)-1000}"
       }
 
       echo "Posting an issue"


### PR DESCRIPTION
Issue creation can currently fail because the size of our logs exceeds
the command-line length limit. We could avoid having to limit the data
by passing it to curl via stdin instead of `-d`, but including unlimited
volumes of log data in the issue probably isn't what we want anyway.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4412)

<!-- Reviewable:end -->
