### PR TITLE
sql: don't modify select expressions in place

### DIFF
--- a/sql/parser/deep_copy.go
+++ b/sql/parser/deep_copy.go
@@ -16,8 +16,6 @@
 
 package parser
 
-import "fmt"
-
 // Helper function to deep copy a list of expressions.
 func deepCopyExprs(exprs []Expr) Exprs {
 	if len(exprs) == 0 {
@@ -150,7 +148,9 @@ func (expr *RangeCond) DeepCopy() Expr {
 
 // DeepCopy is part of the Expr interface.
 func (expr *Subquery) DeepCopy() Expr {
-	panic(fmt.Sprintf("deep copy not implemented for %T", expr))
+	// TODO(radu): the code currently does not modify in-place any part of a subquery. We should
+	// however implement this properly at some point.
+	return expr
 }
 
 // DeepCopy is part of the Expr interface.

--- a/sql/select_qvalue.go
+++ b/sql/select_qvalue.go
@@ -154,17 +154,12 @@ func (v *qnameVisitor) Visit(expr parser.Expr, pre bool) (parser.Visitor, parser
 
 	switch t := expr.(type) {
 	case *qvalue:
-		// We will encounter a qvalue in the expression during retry of an
-		// auto-transaction. When that happens, we've already gone through
-		// qualified name normalization and lookup, we just need to hook the qvalue
-		// up to the scanNode.
-		//
-		// TODO(pmattis): Should we be more careful about ensuring that the various
-		// statement implementations do not modify the AST nodes they are passed?
-		colRef := t.colRef
-		// TODO(radu): this is pretty hacky and won't work with multiple FROMs..
-		colRef.table = v.qt.table
-		return v, v.qt.qvals.getQVal(colRef)
+		// We allow resolving qvalues on expressions that have already been resolved by this
+		// resolver. This is used in some cases when adding render targets for grouping or sorting.
+		if v.qt.qvals[t.colRef] != t {
+			panic(fmt.Sprintf("qvalue already resolved with different resolver (name: %s)", t))
+		}
+		return v, expr
 
 	case *parser.QualifiedName:
 		var colRef columnRef
@@ -226,6 +221,12 @@ func resolveQNames(table *tableInfo, qvals qvalMap, expr parser.Expr) (parser.Ex
 			qvals: qvals,
 		},
 	}
+	// We make a copy of the expression first. This is necessary if the expression is reused, e.g.
+	// for retrying transactions.
+	// TODO(radu): ideally the visitor would make copies only of those nodes that needed it,
+	// allowing the old and new expression to share nodes for constant expressions.
+	expr = expr.DeepCopy()
+
 	expr = parser.WalkExpr(&v, expr)
 	return expr, v.err
 }


### PR DESCRIPTION
We currently resolve qnames in expressions, modifying them in-place. This leads
to some hacky code to correctly handle auto-transaction retries, and this scheme
won't work at all when we will split filtering expressions.

We change this by making a deep-copy of the expression before qname resolution.
If needed, in the future we could improve the visitor model to allow us to make
copies only of the nodes that change.

Changing prepared update code to look at the selectNode render target
expressions instead of relying on the in-place modification (it's actually
easier this way). @mjibson

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4418)

<!-- Reviewable:end -->
