### PR TITLE
gossip/raft: gracefully drain gRPC connections

### DIFF
--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -291,10 +291,11 @@ CREATE TABLE bank.accounts (
 	// chaos monkey.
 	var sum int
 	clients[0].RLock()
-	if err := clients[0].db.QueryRow("SELECT SUM(balance) FROM bank.accounts").Scan(&sum); err != nil {
+	err := clients[0].db.QueryRow("SELECT SUM(balance) FROM bank.accounts").Scan(&sum)
+	clients[0].RUnlock()
+	if err != nil {
 		t.Fatal(err)
 	}
-	clients[0].RUnlock()
 	if sum != 0 {
 		t.Fatalf("The bank is not in good order. Total value: %d", sum)
 	}

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/grpcutil"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
@@ -41,111 +40,72 @@ type server struct {
 	tighten  chan roachpb.NodeID                    // Channel of too-distant node IDs
 	sent     int                                    // Count of infos sent from this server to clients
 	received int                                    // Count of infos received from clients
-	ready    *sync.Cond                             // Broadcasts wakeup to waiting gossip requests
+	ready    chan struct{}                          // Broadcasts wakeup to waiting gossip requests
 
 	simulationCycler *sync.Cond // Used when simulating the network to signal next cycle
 }
 
 // newServer creates and returns a server struct.
 func newServer(stopper *stop.Stopper) *server {
-	s := &server{
+	return &server{
 		stopper:  stopper,
 		is:       newInfoStore(0, util.UnresolvedAddr{}, stopper),
 		incoming: makeNodeSet(minPeers),
 		nodeMap:  make(map[util.UnresolvedAddr]roachpb.NodeID),
 		tighten:  make(chan roachpb.NodeID, 1),
+		ready:    make(chan struct{}),
 	}
-	s.ready = sync.NewCond(&s.mu)
-	return s
 }
 
-func (s *server) gossipSender(argsPtr **Request, senderFn func(*Response) error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
+func (s *server) gossipSender(argsPtr **Request, senderFn func(*Response) error) error {
 	reply := new(Response)
 
 	for {
-		if !s.stopper.RunTask(func() {
-			args := *argsPtr
-			delta := s.is.delta(args.Nodes)
-			if infoCount := len(delta); infoCount > 0 {
-				if log.V(1) {
-					log.Infof("node %d returned %d info(s) to node %d", s.is.NodeID, infoCount, args.NodeID)
-				}
+		s.mu.Lock()
 
-				*reply = Response{
-					NodeID: s.is.NodeID,
-					Nodes:  s.is.getNodes(),
-					Delta:  delta,
-				}
+		args := *argsPtr
+		delta := s.is.delta(args.Nodes)
 
-				s.mu.Unlock()
-				err := senderFn(reply)
-				s.mu.Lock()
-				if err != nil {
-					if !grpcutil.IsClosedConnection(err) {
-						log.Error(err)
-					}
-					return
-				}
-				s.sent += infoCount
+		if infoCount := len(delta); infoCount > 0 {
+			if log.V(1) {
+				log.Infof("node %d returned %d info(s) to node %d", s.is.NodeID, infoCount, args.NodeID)
 			}
-		}) {
-			return
+
+			*reply = Response{
+				NodeID: s.is.NodeID,
+				Nodes:  s.is.getNodes(),
+				Delta:  delta,
+			}
+
+			s.mu.Unlock()
+			if err := senderFn(reply); err != nil {
+				return err
+			}
+			s.mu.Lock()
+			s.sent += infoCount
 		}
 
-		s.ready.Wait()
+		ready := s.ready
+		s.mu.Unlock()
+
+		select {
+		case <-ready:
+		case <-s.stopper.ShouldDrain():
+			return nil
+		}
 	}
 }
 
-// Gossip receives gossiped information from a peer node.
-// The received delta is combined with the infostore, and this
-// node's own gossip is returned to requesting client.
-func (s *server) Gossip(stream Gossip_GossipServer) error {
-	args, err := stream.Recv()
-	if err != nil {
-		return err
-	}
-
-	ctx := stream.Context()
-	syncChan := make(chan struct{}, 1)
-	send := func(reply *Response) error {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case syncChan <- struct{}{}:
-			defer func() { <-syncChan }()
-			return stream.Send(reply)
-		}
-	}
-
-	defer func() { syncChan <- struct{}{} }()
-
+func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) error, receiverFn func() (*Request, error)) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	// Verify that there aren't multiple incoming connections from the same
-	// node. This can happen when bootstrap connections are initiated through
-	// a load balancer.
-	if _, ok := s.nodeMap[args.Addr]; ok {
-		return util.Errorf("duplicate connection from node at %s", args.Addr)
-	}
-
-	// Starting the worker in a task prevents data races during shutdown.
-	if !s.stopper.RunTask(func() {
-		s.stopper.RunWorker(func() {
-			s.gossipSender(&args, send)
-		})
-	}) {
-		return nil
-	}
 
 	reply := new(Response)
 
 	// This loop receives gossip from the client. It does not attempt to send the
 	// server's gossip to the client.
 	for {
+		args := *argsPtr
 		if args.NodeID != 0 {
 			// Decide whether or not we can accept the incoming connection
 			// as a permanent peer.
@@ -178,7 +138,7 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 				}
 
 				s.mu.Unlock()
-				err := send(reply)
+				err := senderFn(reply)
 				s.mu.Lock()
 				return err
 			}
@@ -200,7 +160,7 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 		}
 
 		s.mu.Unlock()
-		err = send(reply)
+		err = senderFn(reply)
 		s.mu.Lock()
 		if err != nil {
 			return err
@@ -211,7 +171,7 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 		}
 
 		s.mu.Unlock()
-		recvArgs, err := stream.Recv()
+		recvArgs, err := receiverFn()
 		s.mu.Lock()
 		if err != nil {
 			return err
@@ -220,7 +180,60 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 		// args holds the remote peer state; we need to update it whenever we receive a new non-nil
 		// request. We avoid assigning to args directly because the gossip sender worker above has
 		// closed over args and may NPE if args were set to nil.
-		args = recvArgs
+		*argsPtr = recvArgs
+	}
+}
+
+// Gossip receives gossiped information from a peer node.
+// The received delta is combined with the infostore, and this
+// node's own gossip is returned to requesting client.
+func (s *server) Gossip(stream Gossip_GossipServer) error {
+	args, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+
+	ctx := stream.Context()
+	syncChan := make(chan struct{}, 1)
+	send := func(reply *Response) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case syncChan <- struct{}{}:
+			defer func() { <-syncChan }()
+			return stream.Send(reply)
+		}
+	}
+
+	defer func() { syncChan <- struct{}{} }()
+
+	// Verify that there aren't multiple incoming connections from the same
+	// node. This can happen when bootstrap connections are initiated through
+	// a load balancer.
+	s.mu.Lock()
+	_, ok := s.nodeMap[args.Addr]
+	s.mu.Unlock()
+	if ok {
+		return util.Errorf("duplicate connection from node at %s", args.Addr)
+	}
+
+	errCh := make(chan error, 2)
+
+	// Starting workers in a task prevents data races during shutdown.
+	s.stopper.RunTask(func() {
+		s.stopper.RunWorker(func() {
+			errCh <- s.gossipSender(&args, send)
+		})
+		s.stopper.RunWorker(func() {
+			errCh <- s.gossipReceiver(&args, send, stream.Recv)
+		})
+	})
+
+	select {
+	case <-s.stopper.ShouldDrain():
+		return nil
+	case err := <-errCh:
+		return err
 	}
 }
 
@@ -268,17 +281,25 @@ func (s *server) start(grpcServer *grpc.Server, addr net.Addr) {
 	s.mu.Unlock()
 	RegisterGossipServer(grpcServer, s)
 
-	updateCallback := func(_ string, _ roachpb.Value) {
-		// Wakeup all pending clients.
-		s.ready.Broadcast()
+	broadcast := func() {
+		ready := make(chan struct{})
+
+		s.mu.Lock()
+		close(s.ready)
+		s.ready = ready
+		s.mu.Unlock()
 	}
-	unregister := s.is.registerCallback(".*", updateCallback)
+	unregister := s.is.registerCallback(".*", func(_ string, _ roachpb.Value) {
+		broadcast()
+	})
 
 	s.stopper.RunWorker(func() {
-		<-s.stopper.ShouldStop()
+		<-s.stopper.ShouldDrain()
+
 		s.mu.Lock()
-		defer s.mu.Unlock()
 		unregister()
-		s.ready.Broadcast() // wake up clients
+		s.mu.Unlock()
+
+		broadcast()
 	})
 }


### PR DESCRIPTION
This regressed when I previously separated draining from shutdown in
util/net.go.

To achieve this, gossip.Server.ready has been replaced with a channel,
which composes with other channels more naturally than a Cond.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4423)

<!-- Reviewable:end -->
