### PR TITLE
sql: Return roachpb.Error from expandTableGlob

### DIFF
--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
-	"github.com/cockroachdb/cockroach/util"
 )
 
 var (
@@ -184,9 +183,9 @@ func (p *planner) getDescriptorsFromTargetList(targets parser.TargetList) (
 	}
 	descs := make([]descriptorProto, 0, len(targets.Tables))
 	for _, tableGlob := range targets.Tables {
-		tables, err := p.expandTableGlob(tableGlob)
-		if err != nil {
-			return nil, roachpb.NewError(err)
+		tables, pErr := p.expandTableGlob(tableGlob)
+		if pErr != nil {
+			return nil, pErr
 		}
 		for _, table := range tables {
 			descriptor, err := p.getTableDesc(table)
@@ -207,17 +206,17 @@ func (p *planner) getDescriptorsFromTargetList(targets parser.TargetList) (
 // 		table
 // 		*
 func (p *planner) expandTableGlob(expr *parser.QualifiedName) (
-	parser.QualifiedNames, error) {
+	parser.QualifiedNames, *roachpb.Error) {
 	if len(expr.Indirect) == 0 {
 		return parser.QualifiedNames{expr}, nil
 	}
 
 	if err := expr.QualifyWithDatabase(p.session.Database); err != nil {
-		return nil, err
+		return nil, roachpb.NewError(err)
 	}
 	// We must have a single indirect: either .table or .*
 	if len(expr.Indirect) != 1 {
-		return nil, util.Errorf("invalid table glob: %s", expr)
+		return nil, roachpb.NewErrorf("invalid table glob: %s", expr)
 	}
 
 	switch expr.Indirect[0].(type) {
@@ -226,15 +225,15 @@ func (p *planner) expandTableGlob(expr *parser.QualifiedName) (
 	case parser.StarIndirection:
 		dbDesc, pErr := p.getDatabaseDesc(string(expr.Base))
 		if pErr != nil {
-			return nil, pErr.GoError()
+			return nil, pErr
 		}
 		tableNames, pErr := p.getTableNames(dbDesc)
 		if pErr != nil {
-			return nil, pErr.GoError()
+			return nil, pErr
 		}
 		return tableNames, nil
 	default:
-		return nil, util.Errorf("invalid table glob: %s", expr)
+		return nil, roachpb.NewErrorf("invalid table glob: %s", expr)
 	}
 }
 


### PR DESCRIPTION
The method used to return `error` and `getDescriptorsFromTargetList` converted `error` back to `roachpb.Error`. Technically we should avoid this since the error can be passed to `db.Txn` in the following way:

```
   planner.expandTableGlob
-> planner.getDescriptorsFromTargetList
-> planner.ShowGrants
-> planner.makePlan
-> Txn in Executor.execStmt
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4436)

<!-- Reviewable:end -->
