### PR TITLE
circleci: use a hard-coded length limit

### DIFF
--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -82,7 +82,7 @@ prepare_artifacts() {
       function post() {
         curl -X POST -H "Authorization: token ${GITHUB_API_TOKEN}" \
         "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/$1" \
-        -d "${2:0:$(getconf ARG_MAX)-1000}"
+        -d "${2:0:30000}"
       }
 
       echo "Posting an issue"


### PR DESCRIPTION
There are two limits in play here; `getconf ARG_MAX` applies to the sum
of all arguments, but there is a separate limit (not easily queryable)
for the length of a single argument.

30K ought to be enough for anybody (and well below the limits we'll
encounter in practice)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4439)

<!-- Reviewable:end -->
