### PR TITLE
Output the admin and sql URLs and log dir on startup.

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -723,8 +723,9 @@ Flags:
       --alsologtostderr         log to standard error as well as files
       --color                   colorize standard error output according to severity (default "auto")
       --log-backtrace-at        when logging hits line file:N, emit a stack trace (default :0)
-      --log-dir                 if non-empty, write log files in this directory
-      --logtostderr             log to standard error instead of files (default true)
+      --log-dir                 if non-empty, write log files in this directory (default "` + os.TempDir() + `")
+      --log-threshold           logs at or above this threshold go to stderr (default ERROR)
+      --logtostderr             log to standard error instead of files
       --verbosity               log level for V logs
       --vmodule                 comma-separated list of pattern=N settings for file-filtered logging
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -225,6 +225,14 @@ func normalizeStdFlagName(s string) string {
 // Keep in sync with "server/context.go". Values in Context should be
 // settable here.
 func initFlags(ctx *Context) {
+	// Change the logging defaults for the main cockroach binary.
+	if err := flag.Lookup("log-dir").Value.Set(os.TempDir()); err != nil {
+		panic(err)
+	}
+	if err := flag.Lookup("logtostderr").Value.Set("false"); err != nil {
+		panic(err)
+	}
+
 	// Map any flags registered in the standard "flag" package into the
 	// top-level cockroach command.
 	pf := cockroachCmd.PersistentFlags()

--- a/cli/start.go
+++ b/cli/start.go
@@ -19,6 +19,7 @@ package cli
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -131,6 +132,11 @@ func runStart(_ *cobra.Command, _ []string) error {
 	if err := s.Start(); err != nil {
 		return fmt.Errorf("cockroach server exited with error: %s", err)
 	}
+
+	fmt.Printf("admin:  %s\n", cliContext.AdminURL())
+	fmt.Printf("sql:    %s\n", cliContext.PGURL(connUser))
+	fmt.Printf("logs:   %s\n", flag.Lookup("log-dir").Value)
+	fmt.Printf("stores: %s\n", cliContext.Stores)
 
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt, os.Kill)

--- a/server/server.go
+++ b/server/server.go
@@ -236,6 +236,7 @@ func (s *Server) Start() error {
 	if err := officializeAddr(unresolvedAddr, ln.Addr()); err != nil {
 		return err
 	}
+	s.ctx.Addr = unresolvedAddr.String()
 
 	s.rpcContext.SetLocalServer(s.rpc, unresolvedAddr.String())
 
@@ -267,7 +268,16 @@ func (s *Server) Start() error {
 	log.Infof("starting %s server at %s", s.ctx.HTTPRequestScheme(), unresolvedAddr)
 	s.initHTTP()
 
-	return s.pgServer.Start(util.NewUnresolvedAddr("tcp", s.ctx.PGAddr))
+	pgAddr := util.NewUnresolvedAddr("tcp", s.ctx.PGAddr)
+	if err := s.pgServer.Start(pgAddr); err != nil {
+		return err
+	}
+	if err := officializeAddr(pgAddr, s.pgServer.Addr()); err != nil {
+		return err
+	}
+	s.ctx.PGAddr = pgAddr.String()
+
+	return nil
 }
 
 // initHTTP registers http prefixes.

--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -80,6 +80,9 @@ func (s *Severity) set(val Severity) {
 
 // String is part of the flag.Value interface.
 func (s *Severity) String() string {
+	if i := int(*s); i >= 0 && i < len(severityName) {
+		return severityName[i]
+	}
 	return strconv.FormatInt(int64(*s), 10)
 }
 
@@ -597,8 +600,8 @@ func formatLogEntry(entry *LogEntry, colors *colorProfile) []byte {
 }
 
 func init() {
-	// Default stderrThreshold is so high that nothing gets through.
-	logging.stderrThreshold = NumSeverity
+	// Default stderrThreshold to errors and above.
+	logging.stderrThreshold = ErrorLog
 	{
 		tmpStr := ""
 		logDir = &tmpStr

--- a/util/log/flags.go
+++ b/util/log/flags.go
@@ -16,8 +16,16 @@
 
 package log
 
-import "github.com/cockroachdb/cockroach/util/log/logflags"
+import (
+	"flag"
+
+	"github.com/cockroachdb/cockroach/util/log/logflags"
+)
 
 func init() {
-	logflags.InitFlags(&logging.mu, &logging.toStderr, &logging.alsoToStderr, logDir, &logging.color, &logging.verbosity, &logging.vmodule, &logging.traceLocation)
+	logflags.InitFlags(&logging.mu, &logging.toStderr, &logging.alsoToStderr,
+		logDir, &logging.color, &logging.verbosity, &logging.vmodule, &logging.traceLocation)
+	// We define this flag here because stderrThreshold has the non-exported type
+	// "severity".
+	flag.Var(&logging.stderrThreshold, "log-threshold", "logs at or above this threshold go to stderr")
 }

--- a/util/log/logflags/logflags.go
+++ b/util/log/logflags/logflags.go
@@ -63,10 +63,7 @@ func InitFlags(mu sync.Locker, toStderr *bool, alsoToStderr *bool, logDir, color
 	flag.Var(&atomicBool{Locker: mu, b: alsoToStderr}, "alsologtostderr", "log to standard error as well as files")
 	flag.StringVar(color, "color", "auto", "colorize standard error output according to severity")
 	flag.Var(verbosity, "verbosity", "log level for V logs")
-	// TODO(tschottdorf): decide if we need this.
-	// pf.Var(&logging.stderrThreshold, "log-threshold", "logs at or above this threshold go to stderr")
 	flag.Var(vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
 	flag.Var(traceLocation, "log-backtrace-at", "when logging hits line file:N, emit a stack trace")
 	flag.StringVar(logDir, "log-dir", "", "if non-empty, write log files in this directory") // in util/log/file.go
-
 }


### PR DESCRIPTION
Now when starting cockroach:

  ~ cockroach start --dev --host=localhost
 ...
 admin: http://localhost:26257
 sql:   postgres://localhost:15432
 logs:  /var/folders/qc/fpqpgdqd167c70dtc6840xxh0000gn/T/

Fixes #4337.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4448)

<!-- Reviewable:end -->
