### PR TITLE
cli: default --stores to "./cockroach-data".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ _testmain.go
 .DS_Store
 
 /cockroach
+/cockroach-data
 *.swp
 
 .bootstrap

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Note: If you’re using Docker as described above, run all the commands describe
 Setting up Cockroach is easy, but starting a test node is even easier. All it takes is running:
 
 ```bash
-./cockroach start --dev &
+./cockroach start --insecure &
 ```
 
 Verify that you're up and running by visiting the cluster UI. If you're running
@@ -80,7 +80,7 @@ the correct address (but the port is the same).
 Now let's talk to this node. The easiest way to do that is to use the `cockroach` binary - it comes with a built-in sql client:
 
 ```bash
-./cockroach sql --dev
+./cockroach sql --insecure
 # Welcome to the cockroach SQL interface.
 # All statements must be terminated by a semicolon.
 # To exit: CTRL + D.

--- a/cli/context.go
+++ b/cli/context.go
@@ -41,4 +41,5 @@ func NewContext() *Context {
 func (ctx *Context) InitDefaults() {
 	ctx.Context.InitDefaults()
 	ctx.OneShotSQL = false
+	ctx.Stores = "./cockroach-data"
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/security"
-	"github.com/cockroachdb/cockroach/util/log"
 )
 
 var maxResults int64
@@ -242,7 +241,6 @@ func initFlags(ctx *Context) {
 
 	{
 		f := startCmd.Flags()
-		f.BoolVar(&ctx.EphemeralSingleNode, "dev", ctx.EphemeralSingleNode, usage("dev"))
 
 		// Server flags.
 		f.StringVar(&connHost, "host", "", usage("host"))
@@ -305,7 +303,6 @@ func initFlags(ctx *Context) {
 	}
 	for _, cmd := range clientCmds {
 		f := cmd.PersistentFlags()
-		f.BoolVar(&cliContext.EphemeralSingleNode, "dev", cliContext.EphemeralSingleNode, usage("dev"))
 		f.BoolVar(&ctx.Insecure, "insecure", ctx.Insecure, usage("insecure"))
 		f.StringVar(&ctx.Certs, "certs", ctx.Certs, usage("certs"))
 		f.StringVar(&connHost, "host", "", usage("host"))
@@ -345,23 +342,6 @@ func init() {
 	initFlags(cliContext)
 
 	cobra.OnInitialize(func() {
-		if cliContext.EphemeralSingleNode {
-			cliContext.Insecure = true
-			if len(cliContext.JoinUsing) != 0 {
-				log.Errorf("--join cannot be specified when running a node in dev mode (--dev)")
-				os.Exit(1)
-			}
-			fmt.Printf(`
-****
-**
-** This node is being run in DEVELOPMENT mode.
-**
-** All data is ephemeral, and there is no security.
-**
-****
-
-`)
-		}
 		cliContext.Addr = net.JoinHostPort(connHost, connPort)
 		cliContext.PGAddr = net.JoinHostPort(connHost, connPGPort)
 	})

--- a/cli/start.go
+++ b/cli/start.go
@@ -27,8 +27,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/config"
-	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -106,13 +104,6 @@ func runStart(_ *cobra.Command, _ []string) error {
 
 	// Default user for servers.
 	cliContext.User = security.NodeUser
-
-	if cliContext.EphemeralSingleNode {
-		// TODO(marc): set this in the zones table when we have an entry
-		// for the default cluster-wide zone config.
-		config.DefaultZoneConfig.ReplicaAttrs = []roachpb.Attributes{{}}
-		cliContext.Stores = "mem=1073741824" // 1024MB
-	}
 
 	stopper := stop.NewStopper()
 	if err := cliContext.InitStores(stopper); err != nil {

--- a/server/context.go
+++ b/server/context.go
@@ -93,9 +93,6 @@ type Context struct {
 	// act as bootstrap hosts for connecting to the gossip network.
 	JoinUsing string
 
-	// Enables running the node as a single-node in-memory cluster.
-	EphemeralSingleNode bool
-
 	// Enables linearizable behaviour of operations on this node by making sure
 	// that no commit timestamp is reported back to the client until all other
 	// node clocks have necessarily passed it.
@@ -235,11 +232,6 @@ func (ctx *Context) InitStores(stopper *stop.Stopper) error {
 func (ctx *Context) InitNode() error {
 	// Initialize attributes.
 	ctx.NodeAttributes = parseAttributes(ctx.Attrs)
-
-	// Skip gossip bootstrap if we're running as an ephemeral single node.
-	if ctx.EphemeralSingleNode {
-		return nil
-	}
 
 	// Get the gossip bootstrap resolvers.
 	resolvers, err := ctx.parseGossipBootstrapResolvers()

--- a/util/metric/doc.go
+++ b/util/metric/doc.go
@@ -64,9 +64,9 @@ After your test does something to trigger your new metric update, you'll probabl
 methods in TestServer such as MustGetCounter() to verify that the metric was updated correctly. See
 "sql/metric_test.go" for an example.
 
-Additionally, you can manually verify that your metric is updating by using the metrics endpoint.
-For example, if you're running the Cockroach DB server with the "--dev" flag, you can use access the
-endpoint as follows:
+Additionally, you can manually verify that your metric is updating by using the metrics
+endpoint.  For example, if you're running the Cockroach DB server with the "--insecure"
+flag, you can use access the endpoint as follows:
 
 	$ curl http://localhost:26257/_status/metrics/1
 


### PR DESCRIPTION
Remove --dev as it was not providing any benefit over
--insecure. Adjusting the default zone config in dev mode is no longer
important now that the queues have a purgatory state.

Fixes #4335.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4453)

<!-- Reviewable:end -->
