### PR TITLE
Avoid sequence cache growth

### DIFF
--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -412,6 +412,9 @@ func processSequenceCache(r *Replica, now, cutoff roachpb.Timestamp, prevTxns ma
 
 	var wg sync.WaitGroup
 	wg.Add(len(txns))
+	// TODO(tschottdorf): a lot of these transactions will be on our local range,
+	// so we should simply read those from a snapshot, and only push those which
+	// are PENDING.
 	for _, txn := range txns {
 		// Check if the Txn is still alive. If this indicates that the Txn is
 		// aborted and old enough to guarantee that any running coordinator

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -380,7 +380,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 		}
 		seqTS := txn.Timestamp
 		seqTS.Forward(*txn.LastHeartbeat)
-		if err := tc.rng.sequence.Put(tc.engine, txn.ID, epo, 2*epo, txn.Key, seqTS, nil /* err */); err != nil {
+		if err := tc.rng.sequence.Put(tc.engine, nil, txn.ID, epo, 2*epo, txn.Key, seqTS, nil /* err */); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1476,6 +1476,15 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba roa
 	// accumulate updates to it.
 	isTxn := ba.Txn != nil
 
+	if ba.Requests[0].GetInner().Method() == roachpb.BeginTransaction &&
+		(len(ba.Requests) < 2 || !roachpb.IsTransactionWrite(ba.Requests[1].GetInner())) {
+		// We rely on this fact for cleaning out sequence cache entries as
+		// early as possible. See the implementation of EndTransaction for
+		// details.
+		return nil, nil, roachpb.NewError(util.Errorf("BeginTransaction must be followed by a transactional write: %s", ba))
+
+	}
+
 	// Ensure that timestamps on individual requests are offset by an incremental
 	// amount of logical ticks from the base timestamp of the batch request (if
 	// that is non-zero and the batch is not in a Txn). This has the effect of

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -519,7 +519,19 @@ func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h ro
 		}
 	}
 
-	return reply, externalIntents, nil
+	// If the transaction just ended (via a successful EndTransaction call),
+	// we can purge the local sequence cache state. Why? We are on the range to
+	// which the transaction is anchored, and replay protection isn't needed
+	// any more. When a transactional write gets replayed over its own resolved
+	// intent, the write will fail (WriteTooOldError), so the case which
+	// requires our attention is that of a yet unresolved intent. We're ok on
+	// this range; after all, we are resolving all local intents in this same
+	// batch. The only interesting replay here could be another lonely
+	// EndTransaction, which is fine either way (if we auto-gced our entry,
+	// that will fail due to missing BeginTransaction; otherwise, there's a
+	// non-pending entry here). BeginTransaction itself can't replay; it always
+	// comes in a batch with a write and will thus fail.
+	return reply, externalIntents, r.clearSequenceCache(batch, ms, false /* !poison */, reply.Txn.TxnMeta, reply.Txn.Status)
 }
 
 // intersectSpan takes an intent and a descriptor. It then splits the
@@ -1012,18 +1024,31 @@ func (r *Replica) PushTxn(batch engine.Engine, ms *engine.MVCCStats, h roachpb.H
 	return reply, nil
 }
 
-// maybePoison inspects the given transaction and, if it's either been aborted
-// or pushed despite being serializable, poisons the sequence cache entry
-// accordingly so that the transaction will be forced to abort or restart,
-// respectively, upon returning to this Range.
-func (r *Replica) maybePoison(batch engine.Engine, shouldPoison bool, txn roachpb.TxnMeta, status roachpb.TransactionStatus) error {
+// clearSequenceCache clears out the sequence cache and optionally poisons it
+// (creating a new special entry). shouldPoison should be set when the
+// transaction in question may still be in use, and causes the sequence cache
+// to be "poisoned": the transaction will not be able to access the range again
+// (preventing anomalies as in #2231).
+//
+// Clearing out the sequence cache reduces the work the GC queue and range
+// splits/merges (which need to copy the whole sequence cache) have to carry
+// out.
+// TODO(tschottdorf): early restarts are currently disabled, see TODO within.
+func (r *Replica) clearSequenceCache(batch engine.Engine, ms *engine.MVCCStats, shouldPoison bool, txn roachpb.TxnMeta, status roachpb.TransactionStatus) (err error) {
+	// Clear out before (maybe) poisoning unless it's PENDING. No need for old
+	// stuff to accumulate.
+	if status != roachpb.PENDING {
+		if err := r.sequence.Del(batch, ms, txn.ID); err != nil {
+			return err
+		}
+	}
+
 	if !shouldPoison {
 		return nil
 	}
+
 	var poison uint32
 	switch status {
-	case roachpb.ABORTED:
-		poison = roachpb.SequencePoisonAbort
 	case roachpb.PENDING:
 		poison = roachpb.SequencePoisonRestart
 		// TODO(tschottdorf): Previous code here poisoned unless the
@@ -1034,13 +1059,17 @@ func (r *Replica) maybePoison(batch engine.Engine, shouldPoison bool, txn roachp
 		// elbow grease, it should be possible to thread the necessary
 		// information through ResolveIntent{,Range} to here, at least in cases
 		// where the performance matters (short-circuiting a Transaction helps
-		// avoid redundant work).
+		// avoid redundant work). Early-return for now; we don't want to mess
+		// with SNAPSHOT transactions.
 		return nil
 	default:
-		return nil
+		// When committing or aborting, we don't want the transaction (or accidental
+		// replays) to come back.
+		poison = roachpb.SequencePoisonAbort
 	}
 
-	return r.sequence.Put(batch, txn.ID, txn.Epoch, poison,
+	// The snake bites.
+	return r.sequence.Put(batch, ms, txn.ID, txn.Epoch, poison,
 		txn.Key, txn.Timestamp, nil)
 }
 
@@ -1057,7 +1086,7 @@ func (r *Replica) ResolveIntent(batch engine.Engine, ms *engine.MVCCStats, h roa
 	if err := engine.MVCCResolveWriteIntent(batch, ms, intent); err != nil {
 		return reply, err
 	}
-	return reply, r.maybePoison(batch, args.Poison, args.IntentTxn, intent.Status)
+	return reply, r.clearSequenceCache(batch, ms, args.Poison, args.IntentTxn, intent.Status)
 }
 
 // ResolveIntentRange resolves write intents in the specified
@@ -1075,7 +1104,7 @@ func (r *Replica) ResolveIntentRange(batch engine.Engine, ms *engine.MVCCStats,
 	if _, err := engine.MVCCResolveWriteIntentRange(batch, ms, intent, 0); err != nil {
 		return reply, err
 	}
-	return reply, r.maybePoison(batch, args.Poison, args.IntentTxn, intent.Status)
+	return reply, r.clearSequenceCache(batch, ms, args.Poison, args.IntentTxn, intent.Status)
 }
 
 // Merge is used to merge a value into an existing key. Merge is an
@@ -1404,22 +1433,23 @@ func (r *Replica) splitTrigger(batch engine.Engine, split *roachpb.SplitTrigger)
 	}
 
 	// Compute stats for updated range.
-	sp.LogEvent("computing stats for old range")
 	now := r.store.Clock().Timestamp()
 	ms, err := r.computeStats(&split.UpdatedDesc, batch, now.WallTime)
 	if err != nil {
 		return util.Errorf("unable to compute stats for updated range after split: %s", err)
 	}
+	sp.LogEvent("computed stats for old range")
 	if err := r.stats.SetMVCCStats(batch, ms); err != nil {
 		return util.Errorf("unable to write MVCC stats: %s", err)
 	}
 
-	sp.LogEvent("copying sequence cache")
 	// Initialize the new range's sequence cache by copying the original's.
-	if err = r.sequence.CopyInto(batch, split.NewDesc.RangeID); err != nil {
+	seqCount, err := r.sequence.CopyInto(batch, nil /* TODO(nvanbeschoten) */, split.NewDesc.RangeID)
+	if err != nil {
 		// TODO(tschottdorf): ReplicaCorruptionError.
 		return util.Errorf("unable to copy sequence cache to new split range: %s", err)
 	}
+	sp.LogEvent(fmt.Sprintf("copied sequence cache (%d entries)", seqCount))
 
 	// Add the new split replica to the store. This step atomically
 	// updates the EndKey of the updated replica and also adds the
@@ -1430,7 +1460,6 @@ func (r *Replica) splitTrigger(batch engine.Engine, split *roachpb.SplitTrigger)
 	}
 
 	// Compute stats for new range.
-	sp.LogEvent("computing stats for new range")
 	ms, err = r.computeStats(&split.NewDesc, batch, now.WallTime)
 	if err != nil {
 		return util.Errorf("unable to compute stats for new range after split: %s", err)
@@ -1438,17 +1467,18 @@ func (r *Replica) splitTrigger(batch engine.Engine, split *roachpb.SplitTrigger)
 	if err = newRng.stats.SetMVCCStats(batch, ms); err != nil {
 		return util.Errorf("unable to write MVCC stats: %s", err)
 	}
+	sp.LogEvent("computed stats for new range")
 
-	sp.LogEvent("copy timestamp cache")
 	// Copy the timestamp cache into the new range.
 	r.mu.Lock()
 	newRng.mu.Lock()
 	r.mu.tsCache.MergeInto(newRng.mu.tsCache, true /* clear */)
 	newRng.mu.Unlock()
 	r.mu.Unlock()
+	sp.LogEvent("copied timestamp cache")
 
-	sp.LogEvent("returning to EndTransaction")
-
+	// Note: you must not use the trace inside of this defer since it may
+	// run after the trace has already completed.
 	batch.Defer(func() {
 		if err := r.store.SplitRange(r, newRng); err != nil {
 			// Our in-memory state has diverged from the on-disk state.
@@ -1625,7 +1655,8 @@ func (r *Replica) mergeTrigger(batch engine.Engine, merge *roachpb.MergeTrigger)
 	}
 
 	// Copy the subsumed range's sequence cache to the subsuming one.
-	if err := r.sequence.CopyFrom(batch, merge.SubsumedRangeID); err != nil {
+	_, err := r.sequence.CopyFrom(batch, nil /* TODO(nvanbenschoten) */, merge.SubsumedRangeID)
+	if err != nil {
 		return util.Errorf("unable to copy sequence cache to new split range: %s", err)
 	}
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/coreos/etcd/raft"
 	"github.com/gogo/protobuf/proto"
 
@@ -1523,7 +1525,7 @@ func TestRangeSequenceCacheStoredTxnRetryError(t *testing.T) {
 	for i, pastError := range []error{errors.New("boom"), nil} {
 		txn := newTransaction("test", key, 10, roachpb.SERIALIZABLE, tc.clock)
 		txn.Sequence = uint32(1 + i)
-		_ = tc.rng.sequence.Put(tc.engine, txn.ID, uint32(txn.Epoch), txn.Sequence, txn.Key, txn.Timestamp, roachpb.NewError(pastError))
+		_ = tc.rng.sequence.Put(tc.engine, nil, txn.ID, uint32(txn.Epoch), txn.Sequence, txn.Key, txn.Timestamp, roachpb.NewError(pastError))
 
 		args := incrementArgs(key, 1)
 		_, pErr := client.SendWrappedWith(tc.Sender(), tc.rng.context(), roachpb.Header{
@@ -1708,6 +1710,7 @@ func TestEndTransactionBeforeHeartbeat(t *testing.T) {
 
 		// Try a heartbeat to the already-committed transaction; should get
 		// committed txn back, but without last heartbeat timestamp set.
+		txn.Epoch++ // need to fake a higher epoch to sneak past sequence cache
 		txn.Sequence++
 		hBA, h := heartbeatArgs(txn)
 
@@ -1998,6 +2001,10 @@ func setupResolutionTest(t *testing.T, tc testContext, key roachpb.Key, splitKey
 	newRng := splitTestRange(tc.store, splitKey, splitKey, t)
 
 	txn := newTransaction("test", key, 1, roachpb.SERIALIZABLE, tc.clock)
+	// These increments are not required, but testing feels safer when zero
+	// values are unexpected.
+	txn.Sequence++
+	txn.Epoch++
 	bt, btH := beginTxnArgs(key, txn)
 	if _, pErr := client.SendWrappedWith(tc.Sender(), tc.rng.context(), btH, &bt); pErr != nil {
 		t.Fatal(pErr)
@@ -2067,7 +2074,7 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 
 // TestEndTransactionDirectGC verifies that after successfully resolving the
 // external intents of a transaction after EndTransaction, the transaction and
-// sequence cache records are purged.
+// sequence cache records are purged on the local range (and only there).
 func TestEndTransactionDirectGC(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	tc := testContext{}
@@ -2076,7 +2083,7 @@ func TestEndTransactionDirectGC(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	_, txn := setupResolutionTest(t, tc, key, splitKey)
+	rightRng, txn := setupResolutionTest(t, tc, key, splitKey)
 
 	util.SucceedsWithin(t, 5*time.Second, func() error {
 		if gr, _, err := tc.rng.Get(tc.engine, roachpb.Header{}, roachpb.GetRequest{Span: roachpb.Span{Key: keys.TransactionKey(txn.Key, txn.ID)}}); err != nil {
@@ -2086,10 +2093,15 @@ func TestEndTransactionDirectGC(t *testing.T) {
 		}
 
 		var entry roachpb.SequenceCacheEntry
-		if seq, _, err := tc.rng.sequence.Get(tc.engine, txn.ID, &entry); err != nil {
-			return err
+		if _, seq, err := tc.rng.sequence.Get(tc.engine, txn.ID, &entry); err != nil {
+			t.Fatal(err)
 		} else if seq > 0 {
 			return util.Errorf("sequence cache still populated: %v", entry)
+		}
+		if _, seq, err := rightRng.sequence.Get(tc.engine, txn.ID, &entry); err != nil {
+			t.Fatal(err)
+		} else if seq == 0 {
+			t.Fatalf("right-hand side with external intent had its sequence cache cleared")
 		}
 
 		return nil
@@ -2132,6 +2144,40 @@ func TestEndTransactionDirectGCFailure(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestEndTransactionDirectGC_1PC runs a test similar to TestEndTransactionDirectGC
+// for the case of a transaction which is contained in a single batch.
+func TestEndTransactionDirectGC_1PC(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	for _, commit := range []bool{true, false} {
+		func() {
+			tc := testContext{}
+			tc.Start(t)
+			defer tc.Stop()
+
+			key := roachpb.Key("a")
+			txn := newTransaction("test", key, 1, roachpb.SERIALIZABLE, tc.clock)
+			bt, _ := beginTxnArgs(key, txn)
+			put := putArgs(key, []byte("value"))
+			et, etH := endTxnArgs(txn, commit)
+			et.IntentSpans = []roachpb.Span{{Key: key}}
+
+			var ba roachpb.BatchRequest
+			ba.Header = etH
+			ba.Add(&bt, &put, &et)
+			if _, err := tc.rng.Send(context.Background(), ba); err != nil {
+				t.Fatalf("commit=%t: %s", commit, err)
+			}
+
+			var entry roachpb.SequenceCacheEntry
+			if seq, _, err := tc.rng.sequence.Get(tc.engine, txn.ID, &entry); err != nil {
+				t.Fatal(err)
+			} else if seq > 0 {
+				t.Fatalf("commit=%t: sequence cache still populated: %v", commit, entry)
+			}
+		}()
+	}
 }
 
 // TestSequenceCachePoisonOnResolve verifies that when an intent is pushed into
@@ -2267,7 +2313,7 @@ func TestSequenceCacheError(t *testing.T) {
 	// to trigger TransactionRetryError.
 	key := roachpb.Key("k")
 	ts := txn.Timestamp.Next()
-	if err := tc.rng.sequence.Put(tc.engine, txn.ID, txn.Epoch, txn.Sequence+1, key, ts, nil); err != nil {
+	if err := tc.rng.sequence.Put(tc.engine, nil, txn.ID, txn.Epoch, txn.Sequence+1, key, ts, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2283,7 +2329,7 @@ func TestSequenceCacheError(t *testing.T) {
 	}
 
 	// Poison the sequence cache to trigger TransactionAbortedError.
-	if err := tc.rng.sequence.Put(tc.engine, txn.ID, txn.Epoch, roachpb.SequencePoisonAbort, key, ts, nil); err != nil {
+	if err := tc.rng.sequence.Put(tc.engine, nil, txn.ID, txn.Epoch, roachpb.SequencePoisonAbort, key, ts, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/sequence_cache.go
+++ b/storage/sequence_cache.go
@@ -143,9 +143,12 @@ func (sc *SequenceCache) Iterate(e engine.Engine, f func([]byte, *uuid.UUID, roa
 		})
 }
 
-func copySeqCache(e engine.Engine, srcID, dstID roachpb.RangeID, keyMin, keyMax engine.MVCCKey) error {
+// TODO(nvanbenschoten): We pass MVCCStats in, but the actual key handling is
+// too low level to update it.
+func copySeqCache(e engine.Engine, ms *engine.MVCCStats, srcID, dstID roachpb.RangeID, keyMin, keyMax engine.MVCCKey) (int, error) {
 	var scratch [64]byte
-	return e.Iterate(keyMin, keyMax,
+	var count int
+	err := e.Iterate(keyMin, keyMax,
 		func(kv engine.MVCCKeyValue) (bool, error) {
 			// Decode the key into a cmd, skipping on error. Otherwise,
 			// write it to the corresponding key in the new cache.
@@ -167,14 +170,17 @@ func copySeqCache(e engine.Engine, srcID, dstID roachpb.RangeID, keyMin, keyMax 
 			value.InitChecksum(key)
 			meta.RawBytes = value.RawBytes
 			_, _, err = engine.PutProto(e, encKey, meta)
+			count++
 			return false, err
 		})
+	return count, err
 }
 
 // CopyInto copies all the results from this sequence cache into the destRangeID
 // sequence cache. Failures decoding individual cache entries return an error.
-func (sc *SequenceCache) CopyInto(e engine.Engine, destRangeID roachpb.RangeID) error {
-	return copySeqCache(e, sc.rangeID, destRangeID,
+// On success, returns the number of entries (key-value pairs) copied.
+func (sc *SequenceCache) CopyInto(e engine.Engine, ms *engine.MVCCStats, destRangeID roachpb.RangeID) (int, error) {
+	return copySeqCache(e, ms, sc.rangeID, destRangeID,
 		engine.MakeMVCCMetadataKey(sc.min), engine.MakeMVCCMetadataKey(sc.max))
 }
 
@@ -183,16 +189,24 @@ func (sc *SequenceCache) CopyInto(e engine.Engine, destRangeID roachpb.RangeID) 
 // locked while copying is in progress. Failures decoding individual
 // entries return an error. The copy is done directly using the engine
 // instead of interpreting values through MVCC for efficiency.
-func (sc *SequenceCache) CopyFrom(e engine.Engine, originRangeID roachpb.RangeID) error {
+// On success, returns the number of entries (key-value pairs) copied.
+func (sc *SequenceCache) CopyFrom(e engine.Engine, ms *engine.MVCCStats, originRangeID roachpb.RangeID) (int, error) {
 	originMin := engine.MakeMVCCMetadataKey(
 		keys.SequenceCacheKey(originRangeID, txnIDMin, math.MaxUint32, math.MaxUint32))
 	originMax := engine.MakeMVCCMetadataKey(
 		keys.SequenceCacheKey(originRangeID, txnIDMax, 0, 0))
-	return copySeqCache(e, originRangeID, sc.rangeID, originMin, originMax)
+	return copySeqCache(e, ms, originRangeID, sc.rangeID, originMin, originMax)
+}
+
+// Del removes all sequence cache entries for the given transaction.
+func (sc *SequenceCache) Del(e engine.Engine, ms *engine.MVCCStats, txnID *uuid.UUID) error {
+	startKey := keys.SequenceCacheKeyPrefix(sc.rangeID, txnID)
+	_, err := engine.MVCCDeleteRange(e, nil /* ms */, startKey, startKey.PrefixEnd(), 0 /* max */, roachpb.ZeroTimestamp, nil /* txn */)
+	return err
 }
 
 // Put writes a sequence number for the specified transaction ID.
-func (sc *SequenceCache) Put(e engine.Engine, txnID *uuid.UUID, epoch, seq uint32, txnKey roachpb.Key, txnTS roachpb.Timestamp, pErr *roachpb.Error) error {
+func (sc *SequenceCache) Put(e engine.Engine, ms *engine.MVCCStats, txnID *uuid.UUID, epoch, seq uint32, txnKey roachpb.Key, txnTS roachpb.Timestamp, pErr *roachpb.Error) error {
 	if seq <= 0 || txnID == nil {
 		return errEmptyTxnID
 	}
@@ -203,7 +217,7 @@ func (sc *SequenceCache) Put(e engine.Engine, txnID *uuid.UUID, epoch, seq uint3
 	// Write the response value to the engine.
 	key := keys.SequenceCacheKey(sc.rangeID, txnID, epoch, seq)
 	sc.scratchEntry = roachpb.SequenceCacheEntry{Key: txnKey, Timestamp: txnTS}
-	return engine.MVCCPutProto(e, nil /* ms */, key, roachpb.ZeroTimestamp, nil /* txn */, &sc.scratchEntry)
+	return engine.MVCCPutProto(e, ms, key, roachpb.ZeroTimestamp, nil /* txn */, &sc.scratchEntry)
 }
 
 // Responses with write-too-old, write-intent and not leader errors

--- a/storage/sequence_cache.go
+++ b/storage/sequence_cache.go
@@ -201,7 +201,7 @@ func (sc *SequenceCache) CopyFrom(e engine.Engine, ms *engine.MVCCStats, originR
 // Del removes all sequence cache entries for the given transaction.
 func (sc *SequenceCache) Del(e engine.Engine, ms *engine.MVCCStats, txnID *uuid.UUID) error {
 	startKey := keys.SequenceCacheKeyPrefix(sc.rangeID, txnID)
-	_, err := engine.MVCCDeleteRange(e, nil /* ms */, startKey, startKey.PrefixEnd(), 0 /* max */, roachpb.ZeroTimestamp, nil /* txn */)
+	_, err := engine.MVCCDeleteRange(e, nil /* TODO(nvanbenschoten) */, startKey, startKey.PrefixEnd(), 0 /* max */, roachpb.ZeroTimestamp, nil /* txn */)
 	return err
 }
 

--- a/storage/sequence_cache_test.go
+++ b/storage/sequence_cache_test.go
@@ -93,7 +93,7 @@ func TestSequenceCachePutGetClearData(t *testing.T) {
 	}
 	// Cache the test response.
 	const seq = 123
-	if err := sc.Put(e, testTxnID, testTxnEpoch, seq, testTxnKey, testTxnTimestamp, nil); err != nil {
+	if err := sc.Put(e, nil, testTxnID, testTxnEpoch, seq, testTxnKey, testTxnTimestamp, nil); err != nil {
 		t.Errorf("unexpected error putting response: %s", err)
 	}
 
@@ -119,18 +119,18 @@ func TestSequenceCachePutGetClearData(t *testing.T) {
 	}
 	tryHit(0, 0)
 
-	if err := sc.Put(e, testTxnID, testTxnEpoch, 2*seq, testTxnKey, testTxnTimestamp, nil); err != nil {
+	if err := sc.Put(e, nil, testTxnID, testTxnEpoch, 2*seq, testTxnKey, testTxnTimestamp, nil); err != nil {
 		t.Errorf("unexpected error putting response: %s", err)
 	}
 	tryHit(2*seq, testTxnEpoch)
 
-	if err := sc.Put(e, testTxnID, 2*testTxnEpoch, 2*seq, testTxnKey, testTxnTimestamp, nil); err != nil {
+	if err := sc.Put(e, nil, testTxnID, 2*testTxnEpoch, 2*seq, testTxnKey, testTxnTimestamp, nil); err != nil {
 		t.Errorf("unexpected error putting response: %s", err)
 	}
 
 	tryHit(2*seq, 2*testTxnEpoch)
 
-	if err := sc.Put(e, testTxnID, testTxnEpoch-1, 2*seq, testTxnKey, testTxnTimestamp, nil); err != nil {
+	if err := sc.Put(e, nil, testTxnID, testTxnEpoch-1, 2*seq, testTxnKey, testTxnTimestamp, nil); err != nil {
 		t.Errorf("unexpected error putting response: %s", err)
 	}
 
@@ -144,10 +144,10 @@ func TestSequenceCacheEmptyParams(t *testing.T) {
 	defer stopper.Stop()
 	sc, e := createTestSequenceCache(t, 1, stopper)
 	// Put value for test response.
-	if err := sc.Put(e, testTxnID, testTxnEpoch, 0, testTxnKey, testTxnTimestamp, nil); err != errEmptyTxnID {
+	if err := sc.Put(e, nil, testTxnID, testTxnEpoch, 0, testTxnKey, testTxnTimestamp, nil); err != errEmptyTxnID {
 		t.Errorf("unexpected error putting response: %v", err)
 	}
-	if err := sc.Put(e, nil, testTxnEpoch, 10, testTxnKey, testTxnTimestamp, nil); err != errEmptyTxnID {
+	if err := sc.Put(e, nil, nil, testTxnEpoch, 10, testTxnKey, testTxnTimestamp, nil); err != errEmptyTxnID {
 		t.Errorf("unexpected error putting response: %v", err)
 	}
 	if _, _, readErr := sc.Get(e, nil, nil); readErr != errEmptyTxnID {
@@ -165,12 +165,14 @@ func TestSequenceCacheCopyInto(t *testing.T) {
 	rc2, _ := createTestSequenceCache(t, 2, stopper)
 	const seq = 123
 	// Store an increment with new value one in the first cache.
-	if err := rc1.Put(e, testTxnID, testTxnEpoch, seq, testTxnKey, testTxnTimestamp, nil); err != nil {
+	if err := rc1.Put(e, nil, testTxnID, testTxnEpoch, seq, testTxnKey, testTxnTimestamp, nil); err != nil {
 		t.Errorf("unexpected error putting response: %s", err)
 	}
 	// Copy the first cache into the second.
-	if err := rc1.CopyInto(e, rc2.rangeID); err != nil {
-		t.Errorf("unexpected error while copying sequence cache: %s", err)
+	if count, err := rc1.CopyInto(e, nil, rc2.rangeID); err != nil {
+		t.Fatal(err)
+	} else if expCount := 1; count != expCount {
+		t.Errorf("unexpected number of copied entries: %d", count)
 	}
 	for _, cache := range []*SequenceCache{rc1, rc2} {
 		var entry roachpb.SequenceCacheEntry
@@ -195,13 +197,15 @@ func TestSequenceCacheCopyFrom(t *testing.T) {
 	rc2, _ := createTestSequenceCache(t, 2, stopper)
 	const seq = 321
 	// Store an increment with new value one in the first cache.
-	if err := rc1.Put(e, testTxnID, testTxnEpoch, seq, testTxnKey, testTxnTimestamp, nil); err != nil {
+	if err := rc1.Put(e, nil, testTxnID, testTxnEpoch, seq, testTxnKey, testTxnTimestamp, nil); err != nil {
 		t.Errorf("unexpected error putting response: %s", err)
 	}
 
 	// Copy the first cache into the second.
-	if err := rc2.CopyFrom(e, rc1.rangeID); err != nil {
-		t.Errorf("unexpected error while copying sequence cache: %s", err)
+	if count, err := rc2.CopyFrom(e, nil, rc1.rangeID); err != nil {
+		t.Fatal(err)
+	} else if expCount := 1; count != expCount {
+		t.Errorf("unexpected number of copied entries: %d", count)
 	}
 
 	// Get should hit both caches.


### PR DESCRIPTION
While we already had a mechanism in place to eagerly garbage collect sequence
cache entries, this only affected external intents (i.e. those not colocated
with the transaction entry). On that range itself, we now clear out the
sequence cache entries on EndTransaction.

Replay behavior is somewhat affected by this: A batch which contains the whole
transaction could now replay and would execute successfully. There is an "easy"
fix: Allow invalidation of individual transactions on the read timestamp cache.
Currently, each timestamp cache entry also holds a transaction ID. The reason
for this is that a transaction should always be able to write over its own
intent, but that is normally forbidden (a WriteTooOldError). Clearing out this
memorized transaction ID would prevent those replays as well.

Fixes #4413.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4469)

<!-- Reviewable:end -->
