### PR TITLE
rpc: log.Error instead of log.Warning on connection errors

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -325,7 +325,7 @@ func (c *Client) runHeartbeat(retryOpts retry.Options) {
 				}
 				if err = c.connect(); err != nil {
 					setUnhealthy()
-					log.Warning(err)
+					log.Error(err)
 					continue
 				}
 			}


### PR DESCRIPTION
And log errors instead of warnings on all other connection errors.

See #4466.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4477)

<!-- Reviewable:end -->
