### PR TITLE
sql: Return error from Executor.Prepare

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -214,10 +214,10 @@ func (e *Executor) getSystemConfig() (config.SystemConfig, *databaseCache) {
 // Prepare returns the result types of the given statement. Args may be a
 // partially populated val args map. Prepare will populate the missing val
 // args. The column result types are returned (or nil if there are no results).
-func (e *Executor) Prepare(user string, query string, session Session, args parser.MapArgs) ([]ResultColumn, *roachpb.Error) {
+func (e *Executor) Prepare(user string, query string, session Session, args parser.MapArgs) ([]ResultColumn, error) {
 	stmt, err := parser.ParseOne(query, parser.Syntax(session.Syntax))
 	if err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 	planMaker := plannerPool.Get().(*planner)
 	defer plannerPool.Put(planMaker)
@@ -244,7 +244,7 @@ func (e *Executor) Prepare(user string, query string, session Session, args pars
 	planMaker.evalCtx.StmtTimestamp = parser.DTimestamp{Time: timestamp}
 	plan, pErr := planMaker.prepare(stmt)
 	if pErr != nil {
-		return nil, pErr
+		return nil, pErr.GoError()
 	}
 	if plan == nil {
 		return nil, nil
@@ -252,7 +252,7 @@ func (e *Executor) Prepare(user string, query string, session Session, args pars
 	cols := plan.Columns()
 	for _, c := range cols {
 		if err := checkResultDatum(c.Typ); err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 	}
 	return cols, nil

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -324,9 +324,9 @@ func (c *v3Conn) handleParse(buf *readBuffer) error {
 		}
 		args[fmt.Sprint(i+1)] = v
 	}
-	cols, pErr := c.executor.Prepare(c.opts.user, query, c.session, args)
-	if pErr != nil {
-		return c.sendError(pErr.String())
+	cols, err := c.executor.Prepare(c.opts.user, query, c.session, args)
+	if err != nil {
+		return c.sendError(err.Error())
 	}
 	pq := preparedStatement{
 		query:       query,


### PR DESCRIPTION
The change is safe as `error` is just passed to `c.sendError` in `pgwire/v3.go`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4479)

<!-- Reviewable:end -->
