### PR TITLE
grpc: put a reasonable timeout on dialing

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -21,8 +21,6 @@ import (
 	"net"
 
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
@@ -70,19 +68,7 @@ func (c *client) start(g *Gossip, disconnected chan *client, ctx *rpc.Context, s
 			disconnected <- c
 		}()
 
-		var dialOpt grpc.DialOption
-		if ctx.Insecure {
-			dialOpt = grpc.WithInsecure()
-		} else {
-			tlsConfig, err := ctx.GetClientTLSConfig()
-			if err != nil {
-				log.Error(err)
-				return
-			}
-			dialOpt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
-		}
-
-		conn, err := grpc.Dial(c.addr.String(), dialOpt, grpc.WithBlock())
+		conn, err := ctx.GRPCDial(c.addr.String())
 		if err != nil {
 			log.Errorf("failed to dial: %v", err)
 			return

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -136,19 +135,7 @@ func (t *rpcTransport) processQueue(nodeID roachpb.NodeID, storeID roachpb.Store
 		return
 	}
 
-	var dialOpt grpc.DialOption
-	if t.rpcContext.Insecure {
-		dialOpt = grpc.WithInsecure()
-	} else {
-		tlsConfig, err := t.rpcContext.GetClientTLSConfig()
-		if err != nil {
-			log.Error(err)
-			return
-		}
-		dialOpt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
-	}
-
-	conn, err := grpc.Dial(addr.String(), dialOpt)
+	conn, err := t.rpcContext.GRPCDial(addr.String())
 	if err != nil {
 		log.Errorf("failed to dial: %v", err)
 		return


### PR DESCRIPTION
Wrap this functionality into rpc.Context while I'm here.

Fixes #4470. In that issue, a blocking grpc.Dial() had backed off to
the point of timing out the test. The maximum backoff in grpc is an incredible 120s[0].

[0] https://github.com/grpc/grpc-go/blob/178b68e/rpc_util.go#L404

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4485)

<!-- Reviewable:end -->
