### PR TITLE
cli: fix --{,also}logtostderr (without a value).

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -720,14 +720,14 @@ Available Commands:
   debug       debugging commands
 
 Flags:
-      --alsologtostderr         log to standard error as well as files
-      --color                   colorize standard error output according to severity (default "auto")
-      --log-backtrace-at        when logging hits line file:N, emit a stack trace (default :0)
-      --log-dir                 if non-empty, write log files in this directory (default "` + os.TempDir() + `")
-      --log-threshold           logs at or above this threshold go to stderr (default ERROR)
-      --logtostderr             log to standard error instead of files
-      --verbosity               log level for V logs
-      --vmodule                 comma-separated list of pattern=N settings for file-filtered logging
+      --alsologtostderr value[=true]   log to standard error as well as files
+      --color value                    colorize standard error output according to severity (default "auto")
+      --log-backtrace-at value         when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir value                  if non-empty, write log files in this directory (default "` + os.TempDir() + `")
+      --log-threshold value            logs at or above this threshold go to stderr (default ERROR)
+      --logtostderr value[=true]       log to standard error instead of files
+      --verbosity value                log level for V logs
+      --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
 
 Use "cockroach [command] --help" for more information about a command.
 `

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -33,9 +33,8 @@ func TestStdFlagToPflag(t *testing.T) {
 		if strings.HasPrefix(f.Name, "test.") {
 			return
 		}
-		n := normalizeStdFlagName(f.Name)
-		if pf := cf.Lookup(n); pf == nil {
-			t.Errorf("unable to find \"%s\"", n)
+		if pf := cf.Lookup(f.Name); pf == nil {
+			t.Errorf("unable to find \"%s\"", f.Name)
 		}
 	})
 }


### PR DESCRIPTION
Do an incorrect bridge of stdlib flag to pflag, --logtostderr and
--alsologtostderr required a value (i.e. --logtostderr=true). Use the
bridging facility provided by pflag which gets this right by setting
pflag.Flag.NoOptDefVal.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4495)

<!-- Reviewable:end -->
