### PR TITLE
sql: allow Java acceptance tests to work

### DIFF
--- a/acceptance/java_test.go
+++ b/acceptance/java_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestDockerJava(t *testing.T) {
-	t.Skip("blocked by #4411")
 	testDockerSuccess(t, "java", []string{"/bin/sh", "-c", strings.Replace(java, "%v", "Int(2, 3)", 1)})
 	testDockerFail(t, "java", []string{"/bin/sh", "-c", strings.Replace(java, "%v", `String(2, "a")`, 1)})
 }

--- a/sql/pgwire/types.go
+++ b/sql/pgwire/types.go
@@ -250,6 +250,7 @@ var (
 		oid.T_numeric:   parser.DummyDecimal,
 		oid.T_text:      parser.DummyString,
 		oid.T_timestamp: parser.DummyTimestamp,
+		oid.T_varchar:   parser.DummyString,
 	}
 	// Using reflection to support unhashable types.
 	datumToOid = map[reflect.Type]oid.Oid{
@@ -382,7 +383,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 		default:
 			return d, fmt.Errorf("unsupported numeric format code: %d", code)
 		}
-	case oid.T_text:
+	case oid.T_text, oid.T_varchar:
 		switch code {
 		case formatText:
 			d = parser.DString(b)

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -282,7 +282,7 @@ func (c *v3Conn) handleSimpleQuery(buf *readBuffer) error {
 		return err
 	}
 
-	return c.executeStatements(query, nil, nil, true)
+	return c.executeStatements(query, nil, nil, true, 0)
 }
 
 func (c *v3Conn) handleParse(buf *readBuffer) error {
@@ -544,14 +544,11 @@ func (c *v3Conn) handleExecute(buf *readBuffer) error {
 	if err != nil {
 		return err
 	}
-	if limit != 0 {
-		return c.sendError("execute row count limits not supported")
-	}
 
-	return c.executeStatements(portal.stmt.query, portal.params, portal.outFormats, false)
+	return c.executeStatements(portal.stmt.query, portal.params, portal.outFormats, false, limit)
 }
 
-func (c *v3Conn) executeStatements(stmts string, params []parser.Datum, formatCodes []formatCode, sendDescription bool) error {
+func (c *v3Conn) executeStatements(stmts string, params []parser.Datum, formatCodes []formatCode, sendDescription bool, limit int32) error {
 	tracing.AnnotateTrace()
 
 	c.session.Database = c.opts.database
@@ -573,7 +570,7 @@ func (c *v3Conn) executeStatements(stmts string, params []parser.Datum, formatCo
 
 	c.opts.database = c.session.Database
 	tracing.AnnotateTrace()
-	return c.sendResponse(resp, formatCodes, sendDescription)
+	return c.sendResponse(resp, formatCodes, sendDescription, int(limit))
 }
 
 func (c *v3Conn) sendCommandComplete(tag []byte) error {
@@ -617,13 +614,19 @@ func (c *v3Conn) sendError(errToSend string) error {
 	return c.writeBuf.finishMsg(c.wr)
 }
 
-func (c *v3Conn) sendResponse(resp sql.Response, formatCodes []formatCode, sendDescription bool) error {
+func (c *v3Conn) sendResponse(resp sql.Response, formatCodes []formatCode, sendDescription bool, limit int) error {
 	if len(resp.Results) == 0 {
 		return c.sendCommandComplete(nil)
 	}
 	for _, result := range resp.Results {
 		if result.PErr != nil {
 			if err := c.sendError(result.PErr.String()); err != nil {
+				return err
+			}
+			break
+		}
+		if limit != 0 && len(result.Rows) > limit {
+			if err := c.sendError(fmt.Sprintf("execute row count limits not supported: %d of %d", limit, len(result.Rows))); err != nil {
 				return err
 			}
 			break

--- a/sql/set.go
+++ b/sql/set.go
@@ -61,6 +61,9 @@ func (p *planner) Set(n *parser.Set) (planNode, *roachpb.Error) {
 			return nil, roachpb.NewUErrorf("%s: \"%s\" is not in (%q, %q)", name, s, parser.Modern, parser.Traditional)
 		}
 
+	case `EXTRA_FLOAT_DIGITS`:
+		// These settings are sent by the JDBC driver but we silently ignore them.
+
 	default:
 		return nil, roachpb.NewUErrorf("unknown variable: %q", name)
 	}


### PR DESCRIPTION
Three changes make this possible.
1. Accept the VARCHAR OID and treat it like TEXT.
2. Support the limit field in execute commands as long as there aren't
   any leftover rows. If we find a driver or test case where this assumption
   doesn't hold (i.e., we will need to page through the results), we will
   add support for it later.
3. Silently ignore the EXTRA_FLOAT_DIGITS setting, which is sent by the
   JDBC driver during connection start.

Fixes #4035

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4496)

<!-- Reviewable:end -->
