### PR TITLE
keys: Fix pretty printing local range keys

### DIFF
--- a/keys/printer.go
+++ b/keys/printer.go
@@ -177,7 +177,7 @@ func localRangeKeyPrint(key roachpb.Key) string {
 		if s.atEnd {
 			if bytes.HasSuffix(key, s.suffix) {
 				key = key[:len(key)-len(s.suffix)]
-				fmt.Fprintf(&buf, "/%s%s", s.name, decodeKeyPrint(key))
+				fmt.Fprintf(&buf, "%s/%s", decodeKeyPrint(key), s.name)
 				return buf.String()
 			}
 		} else {
@@ -188,7 +188,7 @@ func localRangeKeyPrint(key roachpb.Key) string {
 				if err != nil {
 					return fmt.Sprintf("/%q/err:%v", key, err)
 				}
-				fmt.Fprintf(&buf, "/%s/addrKey:%s/id:%q", s.name, decodeKeyPrint(addrKey), txnID)
+				fmt.Fprintf(&buf, "%s/%s/addrKey:/id:%q", decodeKeyPrint(addrKey), s.name, txnID)
 				return buf.String()
 			}
 		}

--- a/keys/printer_test.go
+++ b/keys/printer_test.go
@@ -56,9 +56,9 @@ func TestPrettyPrint(t *testing.T) {
 		{RangeStatsKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/RangeStats"},
 
 		{MakeRangeKeyPrefix(roachpb.RKey("ok")), `/Local/Range/"ok"`},
-		{RangeDescriptorKey(roachpb.RKey("111")), `/Local/Range/RangeDescriptor/"111"`},
-		{RangeTreeNodeKey(roachpb.RKey("111")), `/Local/Range/RangeTreeNode/"111"`},
-		{TransactionKey(roachpb.Key("111"), txnID), fmt.Sprintf(`/Local/Range/Transaction/addrKey:/"111"/id:%q`, txnID)},
+		{RangeDescriptorKey(roachpb.RKey("111")), `/Local/Range/"111"/RangeDescriptor`},
+		{RangeTreeNodeKey(roachpb.RKey("111")), `/Local/Range/"111"/RangeTreeNode`},
+		{TransactionKey(roachpb.Key("111"), txnID), fmt.Sprintf(`/Local/Range/"111"/Transaction/addrKey:/id:%q`, txnID)},
 
 		{LocalMax, `/Meta1/""`}, // LocalMax == Meta1Prefix
 


### PR DESCRIPTION
Previously, local range keys were pretty printed such that their suffix
(Descriptor, TreeNode, Transaction) would be formatted before their key.
This was incorrect, and misrepresented the sorting or local range keys.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4497)

<!-- Reviewable:end -->
