### PR TITLE
Fix test two race conditions: one with locking, the other with timing.

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -267,7 +267,7 @@ func (g *Gossip) SetStorage(storage Storage) error {
 	}
 
 	// Merge the stored bootstrap info addresses with any we've become
-	// aware of through the --join bootstrap hosts we've connected to.
+	// aware of through gossip.
 	if len(g.bootstrapInfo.Addresses) > 0 {
 		existing := map[string]struct{}{}
 		makeKey := func(a util.UnresolvedAddr) string { return fmt.Sprintf("%s,%s", a.Network(), a.String()) }

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -105,6 +105,8 @@ func (n *Network) CreateNode() (*Node, error) {
 // StartNode initializes a gossip instance for the simulation node and
 // starts it.
 func (n *Network) StartNode(node *Node) error {
+	node.Gossip.Start(node.Server, node.Addr)
+	node.Gossip.EnableSimulationCycler(true)
 	n.nodeIDAllocator++
 	node.Gossip.SetNodeID(n.nodeIDAllocator)
 	if err := node.Gossip.SetNodeDescriptor(&roachpb.NodeDescriptor{
@@ -117,8 +119,6 @@ func (n *Network) StartNode(node *Node) error {
 		encoding.EncodeUint64Ascending(nil, 0), time.Hour); err != nil {
 		return err
 	}
-	node.Gossip.Start(node.Server, node.Addr)
-	node.Gossip.EnableSimulationCycler(true)
 	return nil
 }
 


### PR DESCRIPTION
Also did some refactoring for clarity in the tests.

The timing issue was caused by the simulated gossip network code gossiping a node's address before it was properly initialized with its own address. This would sometimes cause the node to store its own address in the bootstrap info.

Fixes #4482
Fixes #4484

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4498)

<!-- Reviewable:end -->
