### PR TITLE
cli: default the log directory to the "logs" subdirectory of the first store

### DIFF
--- a/cli/context.go
+++ b/cli/context.go
@@ -41,5 +41,5 @@ func NewContext() *Context {
 func (ctx *Context) InitDefaults() {
 	ctx.Context.InitDefaults()
 	ctx.OneShotSQL = false
-	ctx.Stores = "./cockroach-data"
+	ctx.Stores = "cockroach-data"
 }


### PR DESCRIPTION
Tweak the info that is output at startup.

Fixes #4492.

```
~ ./cockroach start --insecure
build:     alpha.v1-226-gefd2c41 @ 2016/02/19 02:43:06 (go1.6)
admin:     http://Peters-MacBook-Pro-2.local:26257
sql:       postgresql://root@Peters-MacBook-Pro-2.local:15432?sslmode=disable
logs:      cockroach-data/logs
store[0]:  cockroach-data
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4505)

<!-- Reviewable:end -->
