### PR TITLE
More transient stats

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -50,7 +50,6 @@ github.com/lib/pq 69552e54d2a9d4c6a2438926a774930f7bc398ec
 github.com/mattn/go-isatty 56b76bdf51f7708750eac80fa38b952bb9f32639
 github.com/mattn/go-runewidth d037b52ae5c0338c2bb18da01fb7ddf0e8be9aa1
 github.com/mibk/dupl c450df04426c2f8c35d91fb588feb88fbe328915
-github.com/montanaflynn/stats 2c10aa99e7ec8c4607d4427ec7a1a60fcdfce85f
 github.com/olekukonko/tablewriter cca8bbc0798408af109aaaa239cbd2634846b340
 github.com/opencontainers/runc 5204301d1be4ce3f73d4b0a19feb67f3d2adaa6c
 github.com/opennota/check 2647c7f78677e5af42e988a36343bc83194b7109

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/gogo/protobuf/proto"
@@ -114,7 +115,8 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 		RangeDescriptorDB:        ltc.stores, // for descriptor lookup
 	}, ltc.Gossip)
 
-	ltc.Sender = NewTxnCoordSender(ltc.distSender, ltc.Clock, false /* !linearizable */, tracer, ltc.Stopper)
+	ltc.Sender = NewTxnCoordSender(ltc.distSender, ltc.Clock, false /* !linearizable */, tracer,
+		ltc.Stopper, NewTxnMetrics(metric.NewRegistry()))
 	ltc.DB = client.NewDB(ltc.Sender)
 	transport := storage.NewLocalRPCTransport(ltc.Stopper)
 	ltc.Stopper.AddCloser(transport)

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/tracing"
 )
@@ -48,7 +49,7 @@ func (f senderFn) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 
 // teardownHeartbeats goes through the coordinator's active transactions and
 // has the associated heartbeat tasks quit. This is useful for tests which
-// don't finish transactions.
+// don't finish transactions. This is safe to call multiple times.
 func teardownHeartbeats(tc *TxnCoordSender) {
 	if r := recover(); r != nil {
 		panic(r)
@@ -57,6 +58,7 @@ func teardownHeartbeats(tc *TxnCoordSender) {
 	for _, tm := range tc.txns {
 		if tm.txnEnd != nil {
 			close(tm.txnEnd)
+			tm.txnEnd = nil
 		}
 	}
 	defer tc.Unlock()
@@ -564,7 +566,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 				reply = ba.CreateReply()
 			}
 			return reply, test.pErr
-		}), clock, false, tracing.NewTracer(), stopper)
+		}), clock, false, tracing.NewTracer(), stopper, NewTxnMetrics(metric.NewRegistry()))
 		db := client.NewDB(ts)
 		txn := client.NewTxn(*db)
 		txn.InternalSetPriority(1)
@@ -667,7 +669,7 @@ func TestTxnCoordSenderSingleRoundtripTxn(t *testing.T) {
 		br.Txn = &txnClone
 		br.Txn.Writing = true
 		return br, nil
-	}), clock, false, tracing.NewTracer(), stopper)
+	}), clock, false, tracing.NewTracer(), stopper, NewTxnMetrics(metric.NewRegistry()))
 
 	// Stop the stopper manually, prior to trying the transaction. This has the
 	// effect of returning a NodeUnavailableError for any attempts at launching
@@ -702,7 +704,7 @@ func TestTxnCoordSenderErrorWithIntent(t *testing.T) {
 		pErr := roachpb.NewError(roachpb.NewTransactionRetryError())
 		pErr.SetTxn(&txn)
 		return nil, pErr
-	}), clock, false, tracing.NewTracer(), stopper)
+	}), clock, false, tracing.NewTracer(), stopper, NewTxnMetrics(metric.NewRegistry()))
 	defer stopper.Stop()
 
 	var ba roachpb.BatchRequest
@@ -743,5 +745,232 @@ func TestTxnCoordSenderReleaseTxnMeta(t *testing.T) {
 
 	if _, ok := s.Sender.txns[txnID]; ok {
 		t.Fatal("expected TxnCoordSender has released the txn")
+	}
+}
+
+// checkTxnMetrics verifies that the provided Sender's transaction metrics match the expected
+// values. This is done through a series of retries with increasing backoffs, to work around
+// the TxnCoordSender's asynchronous updating of metrics after a transaction ends.
+func checkTxnMetrics(t *testing.T, sender *TxnCoordSender, name string, commits, abandons, aborts, restarts int64) {
+	metrics := sender.metrics
+
+	util.SucceedsWithin(t, 5*time.Second, func() error {
+		testcases := []struct {
+			name string
+			a, e int64
+		}{
+			{"commits", metrics.Commits.Count(), commits},
+			{"abandons", metrics.Abandons.Count(), abandons},
+			{"aborts", metrics.Aborts.Count(), aborts},
+			{"durations", metrics.Durations[metric.Scale1M].Current().TotalCount(),
+				commits + abandons + aborts},
+		}
+
+		for _, tc := range testcases {
+			if tc.a != tc.e {
+				return util.Errorf("%s: actual %s %d != expected %d", name, tc.name, tc.a, tc.e)
+			}
+		}
+
+		// Handle restarts separately, because that's a histogram. Though the histogram is approximate,
+		// we're recording so few distinct values that we should be okay.
+		dist := metrics.Restarts.Merge().Distribution()
+		var actualRestarts int64
+		for _, b := range dist {
+			if b.From == b.To {
+				actualRestarts += b.From * b.Count
+			} else {
+				t.Fatalf("unexpected value in histogram: %d-%d", b.From, b.To)
+			}
+		}
+		if a, e := actualRestarts, restarts; a != e {
+			return util.Errorf("%s: actual restarts %d != expected %d", name, a, e)
+		}
+
+		return nil
+	})
+}
+
+// setupMetricsTest returns a TxnCoordSender and ManualClock pointing to a newly created
+// LocalTestCluster. Also returns a cleanup function to be executed at the end of the
+// test.
+func setupMetricsTest(t *testing.T) (*hlc.ManualClock, *TxnCoordSender, func()) {
+	s := createTestDB(t)
+	reg := metric.NewRegistry()
+	txnMetrics := NewTxnMetrics(reg)
+	manual := hlc.NewManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	sender := NewTxnCoordSender(s.distSender, clock, false, tracing.NewTracer(), s.Stopper, txnMetrics)
+
+	return manual, sender, func() {
+		teardownHeartbeats(sender)
+		s.Stop()
+	}
+}
+
+// Test a normal transaction. This and the other metrics tests below use real KV operations,
+// because it took far too much mucking with TxnCoordSender internals to mock out the sender
+// function as other tests do.
+func TestTxnCommit(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	_, sender, cleanupFn := setupMetricsTest(t)
+	defer cleanupFn()
+	value := []byte("value")
+	db := client.NewDB(sender)
+
+	// Test normal commit.
+	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+		key := []byte("key-commit")
+
+		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+			return roachpb.NewError(err)
+		}
+
+		if pErr := txn.Put(key, value); pErr != nil {
+			return pErr
+		}
+
+		if pErr := txn.Commit(); pErr != nil {
+			return pErr
+		}
+
+		return nil
+	}); pErr != nil {
+		t.Fatal(pErr)
+	}
+	teardownHeartbeats(sender)
+	checkTxnMetrics(t, sender, "commit txn", 1, 0, 0, 0)
+}
+
+func TestTxnAbandonCount(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	manual, sender, cleanupFn := setupMetricsTest(t)
+	defer cleanupFn()
+	value := []byte("value")
+	db := client.NewDB(sender)
+
+	// Test abandoned transaction by making the client timeout ridiculously short. We also set
+	// the sender to heartbeat very frequently, because the heartbeat detects and tears down
+	// abandoned transactions.
+	sender.heartbeatInterval = 2 * time.Millisecond
+	sender.clientTimeout = 1 * time.Millisecond
+	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+		key := []byte("key-abandon")
+
+		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+			return roachpb.NewError(err)
+		}
+
+		if pErr := txn.Put(key, value); pErr != nil {
+			return pErr
+		}
+
+		manual.Increment(int64(sender.clientTimeout + sender.heartbeatInterval*2))
+
+		checkTxnMetrics(t, sender, "abandon txn", 0, 1, 0, 0)
+
+		return nil
+	}); !testutils.IsPError(pErr, "already committed or aborted") {
+		t.Fatalf("unexpected error: %s", pErr)
+	}
+}
+
+func TestTxnAbortCount(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	_, sender, cleanupFn := setupMetricsTest(t)
+	defer cleanupFn()
+
+	value := []byte("value")
+	db := client.NewDB(sender)
+
+	intentionalErrText := "intentional error to cause abort"
+	// Test aborted transaction.
+	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+		key := []byte("key-abort")
+
+		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+			return roachpb.NewError(err)
+		}
+
+		if pErr := txn.Put(key, value); pErr != nil {
+			t.Fatal(pErr)
+		}
+
+		return roachpb.NewErrorf(intentionalErrText)
+	}); !testutils.IsPError(pErr, intentionalErrText) {
+		t.Fatalf("unexpected error: %s", pErr)
+	}
+	teardownHeartbeats(sender)
+	checkTxnMetrics(t, sender, "abort txn", 0, 0, 1, 0)
+}
+
+func TestTxnRestartCount(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	_, sender, cleanupFn := setupMetricsTest(t)
+	defer cleanupFn()
+
+	key := []byte("key-restart")
+	value := []byte("value")
+	db := client.NewDB(sender)
+
+	// Start a transaction and do a GET. This forces a timestamp to be chosen for the transaction.
+	txn := client.NewTxn(*db)
+	if _, err := txn.Get(key); err != nil {
+		t.Fatal(err)
+	}
+
+	// Outside of the transaction, read the same key as was read within the transaction. This
+	// means that future attempts to write will increase the timestamp.
+	if _, err := db.Get(key); err != nil {
+		t.Fatal(err)
+	}
+
+	// This put increases the candidate timestamp, which causes an immediate restart.
+	if err := txn.Put(key, value); err == nil {
+		t.Fatalf("unexpected success")
+	}
+	teardownHeartbeats(sender)
+	checkTxnMetrics(t, sender, "restart txn", 0, 1, 0, 1)
+}
+
+func TestTxnDurations(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	manual, sender, cleanupFn := setupMetricsTest(t)
+	defer cleanupFn()
+
+	db := client.NewDB(sender)
+	const puts = 10
+
+	const incr int64 = 1000
+	for i := 0; i < puts; i++ {
+		key := roachpb.Key(fmt.Sprintf("key-txn-durations-%d", i))
+		if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
+				return roachpb.NewError(err)
+			}
+			if err := txn.Put(key, []byte("val")); err != nil {
+				return err
+			}
+			manual.Increment(incr)
+			return nil
+		}); pErr != nil {
+			t.Fatal(pErr)
+		}
+	}
+
+	teardownHeartbeats(sender)
+	checkTxnMetrics(t, sender, "txn durations", puts, 0, 0, 0)
+
+	hist := sender.metrics.Durations[metric.Scale1M].Current()
+
+	// The clock is a bit odd in these tests, so I can't test the mean without introducing
+	// spurious errors or being overly lax.
+	// TODO(cdo): look into cause of variance.
+	if a, e := hist.TotalCount(), int64(puts); a != e {
+		t.Fatalf("durations %d != expected %d", a, e)
+	}
+
+	if min := hist.Min(); min < incr {
+		t.Fatalf("min %d < %d", min, incr)
 	}
 }

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/tracing"
 )
 
@@ -204,7 +205,8 @@ func verifyUncertainty(concurrency int, maxOffset time.Duration, t *testing.T) {
 			// higher values require roughly offset/5 restarts.
 			txnClock.SetMaxOffset(maxOffset)
 
-			sender := NewTxnCoordSender(s.distSender, txnClock, false, tracing.NewTracer(), s.Stopper)
+			sender := NewTxnCoordSender(s.distSender, txnClock, false, tracing.NewTracer(), s.Stopper,
+				NewTxnMetrics(metric.NewRegistry()))
 			txnDB := client.NewDB(sender)
 
 			if pErr := txnDB.Txn(func(txn *client.Txn) *roachpb.Error {

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -94,14 +94,15 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		RPCRetryOptions: &retryOpts,
 	}, g)
 	tracer := tracing.NewTracer()
-	sender := kv.NewTxnCoordSender(distSender, ctx.Clock, false, tracer, stopper)
+	sender := kv.NewTxnCoordSender(distSender, ctx.Clock, false, tracer, stopper,
+		kv.NewTxnMetrics(metric.NewRegistry()))
 	ctx.DB = client.NewDB(sender)
 	// TODO(bdarnell): arrange to have the transport closed.
 	// (or attach LocalRPCTransport.Close to the stopper)
 	ctx.Transport = storage.NewLocalRPCTransport(stopper)
 	ctx.EventFeed = util.NewFeed(stopper)
 	ctx.Tracer = tracer
-	node := NewNode(ctx, metric.NewRegistry(), stopper, nil)
+	node := NewNode(ctx, metric.NewRegistry(), stopper, nil, kv.NewTxnMetrics(metric.NewRegistry()))
 	return rpcServer, ln.Addr(), ctx.Clock, node, stopper
 }
 
@@ -137,7 +138,7 @@ func TestBootstrapCluster(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper)
-	if _, err := bootstrapCluster([]engine.Engine{e}); err != nil {
+	if _, err := bootstrapCluster([]engine.Engine{e}, kv.NewTxnMetrics(metric.NewRegistry())); err != nil {
 		t.Fatal(err)
 	}
 
@@ -179,7 +180,7 @@ func TestBootstrapNewStore(t *testing.T) {
 	engineStopper := stop.NewStopper()
 	defer engineStopper.Stop()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)
-	if _, err := bootstrapCluster([]engine.Engine{e}); err != nil {
+	if _, err := bootstrapCluster([]engine.Engine{e}, kv.NewTxnMetrics(metric.NewRegistry())); err != nil {
 		t.Fatal(err)
 	}
 
@@ -221,7 +222,7 @@ func TestNodeJoin(t *testing.T) {
 	engineStopper := stop.NewStopper()
 	defer engineStopper.Stop()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)
-	if _, err := bootstrapCluster([]engine.Engine{e}); err != nil {
+	if _, err := bootstrapCluster([]engine.Engine{e}, kv.NewTxnMetrics(metric.NewRegistry())); err != nil {
 		t.Fatal(err)
 	}
 
@@ -288,7 +289,7 @@ func TestCorruptedClusterID(t *testing.T) {
 	engineStopper := stop.NewStopper()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)
 	defer engineStopper.Stop()
-	if _, err := bootstrapCluster([]engine.Engine{e}); err != nil {
+	if _, err := bootstrapCluster([]engine.Engine{e}, kv.NewTxnMetrics(metric.NewRegistry())); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/gogo/protobuf/proto"
@@ -307,7 +308,8 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 		RPCContext:      s.RPCContext(),
 		RPCRetryOptions: &retryOpts,
 	}, s.Gossip())
-	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, tracing.NewTracer(), s.stopper)
+	tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, tracing.NewTracer(),
+		s.stopper, kv.NewTxnMetrics(metric.NewRegistry()))
 
 	if err := s.node.ctx.DB.AdminSplit("m"); err != nil {
 		t.Fatal(err)
@@ -405,7 +407,8 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 			RPCContext:      s.RPCContext(),
 			RPCRetryOptions: &retryOpts,
 		}, s.Gossip())
-		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, tracing.NewTracer(), s.stopper)
+		tds := kv.NewTxnCoordSender(ds, s.Clock(), testContext.Linearizable, tracing.NewTracer(),
+			s.stopper, kv.NewTxnMetrics(metric.NewRegistry()))
 
 		for _, sk := range tc.splitKeys {
 			if err := s.node.ctx.DB.AdminSplit(sk); err != nil {

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -136,11 +136,17 @@ type Executor struct {
 	latency       metric.Histograms
 	selectCount   *metric.Counter
 	txnBeginCount *metric.Counter
-	updateCount   *metric.Counter
-	insertCount   *metric.Counter
-	deleteCount   *metric.Counter
-	ddlCount      *metric.Counter
-	miscCount     *metric.Counter
+
+	// txnCommitCount counts the number of times a COMMIT was attempted.
+	txnCommitCount *metric.Counter
+
+	txnAbortCount    *metric.Counter
+	txnRollbackCount *metric.Counter
+	updateCount      *metric.Counter
+	insertCount      *metric.Counter
+	deleteCount      *metric.Counter
+	ddlCount         *metric.Counter
+	miscCount        *metric.Counter
 
 	// System Config and mutex.
 	systemConfig     config.SystemConfig
@@ -158,15 +164,18 @@ func NewExecutor(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, st
 		reCache:  parser.NewRegexpCache(512),
 		leaseMgr: leaseMgr,
 
-		registry:      registry,
-		latency:       registry.Latency("latency"),
-		txnBeginCount: registry.Counter("transaction.begincount"),
-		selectCount:   registry.Counter("select.count"),
-		updateCount:   registry.Counter("update.count"),
-		insertCount:   registry.Counter("insert.count"),
-		deleteCount:   registry.Counter("delete.count"),
-		ddlCount:      registry.Counter("ddl.count"),
-		miscCount:     registry.Counter("misc.count"),
+		registry:         registry,
+		latency:          registry.Latency("latency"),
+		txnBeginCount:    registry.Counter("txn.begin.count"),
+		txnCommitCount:   registry.Counter("txn.commit.count"),
+		txnAbortCount:    registry.Counter("txn.abort.count"),
+		txnRollbackCount: registry.Counter("txn.rollback.count"),
+		selectCount:      registry.Counter("select.count"),
+		updateCount:      registry.Counter("update.count"),
+		insertCount:      registry.Counter("insert.count"),
+		deleteCount:      registry.Counter("delete.count"),
+		ddlCount:         registry.Counter("ddl.count"),
+		miscCount:        registry.Counter("misc.count"),
 	}
 	exec.systemConfigCond = sync.NewCond(&exec.systemConfigMu)
 
@@ -402,7 +411,6 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (Result, 
 		// transaction from being called within an auto-transaction below.
 		planMaker.setTxn(client.NewTxn(e.db), time.Now())
 		planMaker.txn.SetDebugName("sql", 0)
-		e.txnBeginCount.Inc(1)
 	case *parser.CommitTransaction, *parser.RollbackTransaction:
 		if planMaker.txn == nil {
 			return result, roachpb.NewError(errNoTransactionInProgress)
@@ -476,6 +484,9 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (Result, 
 	// If there is a pending transaction.
 	if planMaker.txn != nil {
 		pErr := f(time.Now(), false)
+		if pErr != nil {
+			e.txnAbortCount.Inc(1)
+		}
 		return result, pErr
 	}
 
@@ -535,6 +546,8 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (Result, 
 // statements have been received by this node.
 func (e *Executor) updateStmtCounts(stmt parser.Statement) {
 	switch stmt.(type) {
+	case *parser.BeginTransaction:
+		e.txnBeginCount.Inc(1)
 	case *parser.Select:
 		e.selectCount.Inc(1)
 	case *parser.Update:
@@ -543,6 +556,10 @@ func (e *Executor) updateStmtCounts(stmt parser.Statement) {
 		e.insertCount.Inc(1)
 	case *parser.Delete:
 		e.deleteCount.Inc(1)
+	case *parser.CommitTransaction:
+		e.txnCommitCount.Inc(1)
+	case *parser.RollbackTransaction:
+		e.txnRollbackCount.Inc(1)
 	default:
 		if stmt.StatementType() == parser.DDL {
 			e.ddlCount.Inc(1)

--- a/sql/metric_test.go
+++ b/sql/metric_test.go
@@ -1,8 +1,10 @@
 package sql_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -13,29 +15,31 @@ func TestQueryCounts(t *testing.T) {
 	nid := s.Gossip().GetNodeID().String()
 
 	var testcases = []struct {
-		query       string
-		txnCount    int64
-		selectCount int64
-		updateCount int64
-		insertCount int64
-		deleteCount int64
-		ddlCount    int64
-		miscCount   int64
+		query            string
+		txnBeginCount    int64
+		selectCount      int64
+		updateCount      int64
+		insertCount      int64
+		deleteCount      int64
+		ddlCount         int64
+		miscCount        int64
+		txnCommitCount   int64
+		txnRollbackCount int64
 	}{
-		{"", 0, 0, 0, 0, 0, 0, 0},
-		{"BEGIN; END", 1, 0, 0, 0, 0, 0, 2},
-		{"SELECT 1", 1, 1, 0, 0, 0, 0, 2},
-		{"CREATE DATABASE mt", 1, 1, 0, 0, 0, 1, 2},
-		{"CREATE TABLE mt.n (num INTEGER)", 1, 1, 0, 0, 0, 2, 2},
-		{"INSERT INTO mt.n VALUES (3)", 1, 1, 0, 1, 0, 2, 2},
-		{"UPDATE mt.n SET num = num + 1", 1, 1, 1, 1, 0, 2, 2},
-		{"DELETE FROM mt.n", 1, 1, 1, 1, 1, 2, 2},
-		{"ALTER TABLE mt.n ADD COLUMN num2 INTEGER", 1, 1, 1, 1, 1, 3, 2},
-		{"EXPLAIN SELECT * FROM mt.n", 1, 1, 1, 1, 1, 3, 3},
-		{"BEGIN; UPDATE mt.n SET num = num + 1; END", 2, 1, 2, 1, 1, 3, 5},
-		{"SELECT * FROM mt.n; SELECT * FROM mt.n; SELECT * FROM mt.n", 2, 4, 2, 1, 1, 3, 5},
-		{"DROP TABLE mt.n", 2, 4, 2, 1, 1, 4, 5},
-		{"SET database = system", 2, 4, 2, 1, 1, 4, 6},
+		{"", 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		{"BEGIN; END", 1, 0, 0, 0, 0, 0, 0, 1, 0},
+		{"SELECT 1", 1, 1, 0, 0, 0, 0, 0, 1, 0},
+		{"CREATE DATABASE mt", 1, 1, 0, 0, 0, 1, 0, 1, 0},
+		{"CREATE TABLE mt.n (num INTEGER)", 1, 1, 0, 0, 0, 2, 0, 1, 0},
+		{"INSERT INTO mt.n VALUES (3)", 1, 1, 0, 1, 0, 2, 0, 1, 0},
+		{"UPDATE mt.n SET num = num + 1", 1, 1, 1, 1, 0, 2, 0, 1, 0},
+		{"DELETE FROM mt.n", 1, 1, 1, 1, 1, 2, 0, 1, 0},
+		{"ALTER TABLE mt.n ADD COLUMN num2 INTEGER", 1, 1, 1, 1, 1, 3, 0, 1, 0},
+		{"EXPLAIN SELECT * FROM mt.n", 1, 1, 1, 1, 1, 3, 1, 1, 0},
+		{"BEGIN; UPDATE mt.n SET num = num + 1; END", 2, 1, 2, 1, 1, 3, 1, 2, 0},
+		{"SELECT * FROM mt.n; SELECT * FROM mt.n; SELECT * FROM mt.n", 2, 4, 2, 1, 1, 3, 1, 2, 0},
+		{"DROP TABLE mt.n", 2, 4, 2, 1, 1, 4, 1, 2, 0},
+		{"SET database = system", 2, 4, 2, 1, 1, 4, 2, 2, 0},
 	}
 
 	for _, tc := range testcases {
@@ -49,31 +53,100 @@ func TestQueryCounts(t *testing.T) {
 		if err := s.WriteSummaries(); err != nil {
 			t.Fatal(err)
 		}
-		if a, e := s.MustGetCounter("cr.node.sql.transaction.begincount."+nid), tc.txnCount; a != e {
-			t.Errorf("transaction count for '%s': actual %d != expected %d", tc.query, a, e)
+
+		checkCounter := func(key string, e int64) {
+			if a := s.MustGetCounter(fmt.Sprintf("cr.node.sql.%s.%s", key, nid)); a != e {
+				t.Errorf("%s for '%s': actual %d != expected %d", key, tc.query, a, e)
+			}
 		}
-		if a, e := s.MustGetCounter("cr.node.sql.select.count."+nid), tc.selectCount; a != e {
-			t.Errorf("select count for '%s': actual %d != expected %d", tc.query, a, e)
-		}
-		if a, e := s.MustGetCounter("cr.node.sql.update.count."+nid), tc.updateCount; a != e {
-			t.Errorf("update count for '%s': actual %d != expected %d", tc.query, a, e)
-		}
-		if a, e := s.MustGetCounter("cr.node.sql.insert.count."+nid), tc.insertCount; a != e {
-			t.Errorf("insert count for '%s': actual %d != expected %d", tc.query, a, e)
-		}
-		if a, e := s.MustGetCounter("cr.node.sql.delete.count."+nid), tc.deleteCount; a != e {
-			t.Errorf("delete count for '%s': actual %d != expected %d", tc.query, a, e)
-		}
-		if a, e := s.MustGetCounter("cr.node.sql.ddl.count."+nid), tc.ddlCount; a != e {
-			t.Errorf("DDL count for '%s': actual %d != expected %d", tc.query, a, e)
-		}
-		if a, e := s.MustGetCounter("cr.node.sql.misc.count."+nid), tc.miscCount; a != e {
-			t.Errorf("misc count for '%s': actual %d != expected %d", tc.query, a, e)
-		}
+		checkCounter("txn.begin.count", tc.txnBeginCount)
+		checkCounter("select.count", tc.selectCount)
+		checkCounter("update.count", tc.updateCount)
+		checkCounter("insert.count", tc.insertCount)
+		checkCounter("delete.count", tc.deleteCount)
+		checkCounter("ddl.count", tc.ddlCount)
+		checkCounter("misc.count", tc.miscCount)
+		checkCounter("txn.commit.count", tc.txnCommitCount)
+		checkCounter("txn.rollback.count", tc.txnRollbackCount)
+		checkCounter("txn.abort.count", 0)
 
 		// Everything after this query will also fail, so quit now to avoid deluge of errors.
 		if t.Failed() {
 			t.FailNow()
 		}
 	}
+}
+
+func TestAbortCountConflictingWrites(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, sqlDB, _ := setup(t)
+	defer cleanup(s, sqlDB)
+
+	if _, err := sqlDB.Exec("CREATE DATABASE db"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec("CREATE TABLE db.t (n INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Within a transaction, start an INSERT but don't COMMIT it.
+	txn, err := sqlDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := txn.Exec("INSERT INTO db.t VALUES (1)"); err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Outside the transaction, do a conflicting INSERT.
+	if _, err := sqlDB.Exec("INSERT INTO db.t VALUES (1)"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The earlier transaction loses.
+	// TODO(cdo): This is not exactly right and could take a while. Fix this when there's
+	// a better test to model this after.
+	if err := txn.Commit(); !testutils.IsError(err, "aborted") {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	nid := s.Gossip().GetNodeID().String()
+	checkCounter := func(key string, e int64) {
+		if a := s.MustGetCounter(fmt.Sprintf("cr.node.sql.%s.%s", key, nid)); a != e {
+			t.Errorf("stat %s: actual %d != expected %d", key, a, e)
+		}
+	}
+	checkCounter("txn.abort.count", 1)
+	checkCounter("txn.begin.count", 1)
+	checkCounter("txn.rollback.count", 0)
+	checkCounter("txn.commit.count", 1)
+	checkCounter("insert.count", 2)
+}
+
+// TestErrorDuringTransaction tests that the transaction abort count goes up when a query
+// results in an error during a txn.
+func TestAbortCountErrorDuringTransaction(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	s, sqlDB, _ := setup(t)
+	defer cleanup(s, sqlDB)
+
+	txn, err := sqlDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := txn.Query("SELECT * FROM i_do.not_exist"); err == nil {
+		t.Fatal("Expected an error but didn't get one")
+	}
+
+	nid := s.Gossip().GetNodeID().String()
+	checkCounter := func(key string, e int64) {
+		if a := s.MustGetCounter(fmt.Sprintf("cr.node.sql.%s.%s", key, nid)); a != e {
+			t.Errorf("stat %s: actual %d != expected %d", key, a, e)
+		}
+	}
+	checkCounter("txn.abort.count", 1)
+	checkCounter("txn.begin.count", 1)
+	checkCounter("select.count", 1)
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/tracing"
 )
@@ -126,7 +127,8 @@ func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock
 		RangeDescriptorDB: stores, // for descriptor lookup
 	}, sCtx.Gossip)
 
-	sender := kv.NewTxnCoordSender(distSender, clock, false, tracing.NewTracer(), stopper)
+	sender := kv.NewTxnCoordSender(distSender, clock, false, tracing.NewTracer(), stopper,
+		kv.NewTxnMetrics(metric.NewRegistry()))
 	sCtx.Clock = clock
 	sCtx.DB = client.NewDB(sender)
 	sCtx.StorePool = storage.NewStorePool(sCtx.Gossip, clock, storage.TestTimeUntilStoreDeadOff, stopper)
@@ -244,7 +246,8 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 			RPCSend:           m.rpcSend,
 			RPCRetryOptions:   &retryOpts,
 		}, m.gossip)
-		sender := kv.NewTxnCoordSender(m.distSender, m.clock, false, tracing.NewTracer(), m.clientStopper)
+		sender := kv.NewTxnCoordSender(m.distSender, m.clock, false, tracing.NewTracer(),
+			m.clientStopper, kv.NewTxnMetrics(metric.NewRegistry()))
 		m.db = client.NewDB(sender)
 	}
 

--- a/ui/styl/partials/layout.styl
+++ b/ui/styl/partials/layout.styl
@@ -132,3 +132,10 @@ a.toggle
     color $secondary-gold
   &.healthy
     color $main-green
+
+.charts h2
+  clear both
+  padding-top 15px
+
+.charts h2:first-child
+  padding-top 0

--- a/util/metric/registry.go
+++ b/util/metric/registry.go
@@ -28,7 +28,7 @@ const sep = "-"
 
 // DefaultTimeScales are the durations used for helpers which create windowed
 // metrics in bulk (such as Latency or Rates).
-var DefaultTimeScales = []TimeScale{scale1M, scale10M, scale1H}
+var DefaultTimeScales = []TimeScale{Scale1M, Scale10M, Scale1H}
 
 // A Registry bundles up various iterables (i.e. typically metrics or other
 // registries) to provide a single point of access to them.
@@ -67,7 +67,7 @@ func (r *Registry) Add(format string, item Iterable) error {
 // MustAdd calls Add and panics on error.
 func (r *Registry) MustAdd(format string, item Iterable) {
 	if err := r.Add(format, item); err != nil {
-		panic(err)
+		panic(fmt.Sprintf("error adding %s: %s", format, err))
 	}
 }
 
@@ -114,10 +114,9 @@ func (r *Registry) Histogram(name string, duration time.Duration, maxVal int64,
 // which) information flows between metrics and time series.
 func (r *Registry) Latency(prefix string) Histograms {
 	windows := DefaultTimeScales
-	hs := make([]*Histogram, 0, 3)
+	hs := make(Histograms)
 	for _, w := range windows {
-		h := r.Histogram(prefix+sep+w.name, w.d, int64(time.Minute), 2)
-		hs = append(hs, h)
+		hs[w] = r.Histogram(prefix+sep+w.name, w.d, int64(time.Minute), 2)
 	}
 	return hs
 }
@@ -144,13 +143,13 @@ func (r *Registry) Rate(name string, timescale time.Duration) *Rate {
 	return e
 }
 
-// Rates returns a slice of EWMAs prefixed with the given name and
-// various "standard" timescales.
+// Rates registers and returns a new Rates instance, which contains a set of EWMA-based rates
+// with generally useful time scales and a cumulative counter.
 func (r *Registry) Rates(prefix string) Rates {
 	scales := DefaultTimeScales
-	es := make([]*Rate, 0, len(scales))
+	es := make(map[TimeScale]*Rate)
 	for _, scale := range scales {
-		es = append(es, r.Rate(prefix+sep+scale.name, scale.d))
+		es[scale] = r.Rate(prefix+sep+scale.name, scale.d)
 	}
 	c := r.Counter(prefix + sep + "count")
 	return Rates{Counter: c, Rates: es}


### PR DESCRIPTION
Added the following counters:
- pgwire connection count
- SQL transaction commits, rollbacks, and aborts
- KV transaction commits, aborts, abandons, restarts, and durations

Also replaced existing, non-persistent KV stats with our standard, persistent stats.

cc @mrtracy for metrics in general, @maxlang for front-end code

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4507)

<!-- Reviewable:end -->
