### PR TITLE
Revert "sql: Return error from Executor.Prepare"

### DIFF
--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -324,9 +324,9 @@ func (c *v3Conn) handleParse(buf *readBuffer) error {
 		}
 		args[fmt.Sprint(i+1)] = v
 	}
-	cols, err := c.executor.Prepare(c.opts.user, query, c.session, args)
-	if err != nil {
-		return c.sendError(err.Error())
+	cols, pErr := c.executor.Prepare(c.opts.user, query, c.session, args)
+	if pErr != nil {
+		return c.sendError(pErr.String())
 	}
 	pq := preparedStatement{
 		query:       query,


### PR DESCRIPTION
This reverts commit 571270f7f85a2f2bc2daf79365b20c8f1501d66b.

Discussed in #4480. We might want to pass roachpb.Error for #2625.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4508)

<!-- Reviewable:end -->
