### PR TITLE
sql: Return error in lease.go and scheme_changer.go when possible

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -498,6 +498,9 @@ RetryLoop:
 		// Let the sql executor do it.
 		txn.Cleanup(pErr)
 	}
+	if pErr != nil {
+		pErr.StripErrorTransaction()
+	}
 	return pErr
 }
 

--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -203,6 +203,12 @@ func (e *Error) SetErrorIndex(index int32) {
 	e.Index = &ErrPosition{Index: index}
 }
 
+// StripErrorTransaction strips the txn information in the error.
+func (e *Error) StripErrorTransaction() {
+	// Do not call SetTxn() as we do not want to update e.Message with nil txn.
+	e.UnexposedTxn = nil
+}
+
 // Error formats error.
 func (e *NodeUnavailableError) Error() string {
 	return e.message(nil)

--- a/roachpb/errors_test.go
+++ b/roachpb/errors_test.go
@@ -72,3 +72,25 @@ func TestErrorTxn(t *testing.T) {
 		t.Fatalf("wanted name %s, unexpected: %+v", name, txn)
 	}
 }
+
+// TestStripErrorTransaction verifies that StripErrorTransaction
+// strips the transaction information on an error, but it does not
+// update the error message.
+func TestStripErrorTransaction(t *testing.T) {
+	txn := NewTransaction("test", Key("a"), 1, SERIALIZABLE, Timestamp{}, 0)
+	pErr := NewErrorWithTxn(NewTransactionAbortedError(), txn)
+	if pErr.GetTxn() == nil {
+		t.Errorf("no txn on error: %s", pErr)
+	}
+	if !strings.HasPrefix(pErr.Message, "txn aborted \"test\"") {
+		t.Errorf("unexpected message: %s", pErr.Message)
+	}
+
+	pErr.StripErrorTransaction()
+	if pErr.GetTxn() != nil {
+		t.Errorf("txn must be stripped: %s", pErr)
+	}
+	if !strings.HasPrefix(pErr.Message, "txn aborted \"test\"") {
+		t.Errorf("unexpected message: %s", pErr.Message)
+	}
+}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -349,7 +349,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 		panic("trying to execute schema changes while still in a transaction")
 	}
 	// Release the leases once a transaction is complete.
-	planMaker.releaseLeases(e.db)
+	planMaker.releaseLeases()
 	if len(scc.schemaChangers) == 0 ||
 		// Disable execution in some tests.
 		disableSyncSchemaChangeExec {
@@ -485,7 +485,7 @@ func (e *Executor) ExecuteStatements(
 	if curTxnState.txn != nil {
 		// TODO(pmattis): Need to associate the leases used by a transaction with
 		// the session state.
-		planMaker.releaseLeases(e.db)
+		planMaker.releaseLeases()
 		session.Txn = Session_Transaction{
 			Txn:          &curTxnState.txn.Proto,
 			TxnTimestamp: Timestamp(curTxnState.txnTimestamp),
@@ -628,7 +628,7 @@ func (e *Executor) execRequest(
 		// If the txn is in a final state (committed, rolled back or aborted), exec
 		// the schema changes.
 		if txnState.state() != openTransaction {
-			planMaker.releaseLeases(e.db)
+			planMaker.releaseLeases()
 			// Exec the schema changers (if the txn rolled back, the schema changers
 			// will short-circuit because the corresponding descriptor mutation is not
 			// found).

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
@@ -155,8 +156,8 @@ func (s LeaseStore) Acquire(txn *client.Txn, tableID ID, minVersion DescriptorVe
 }
 
 // Release a previously acquired table descriptor lease.
-func (s LeaseStore) Release(lease *LeaseState) *roachpb.Error {
-	return s.db.Txn(func(txn *client.Txn) *roachpb.Error {
+func (s LeaseStore) Release(lease *LeaseState) error {
+	pErr := s.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		p := makePlanner()
 		p.txn = txn
 		p.user = security.RootUser
@@ -172,6 +173,7 @@ func (s LeaseStore) Release(lease *LeaseState) *roachpb.Error {
 		}
 		return nil
 	})
+	return pErr.GoError()
 }
 
 // waitForOneVersion returns once there are no unexpired leases on the
@@ -180,7 +182,7 @@ func (s LeaseStore) Release(lease *LeaseState) *roachpb.Error {
 // returned verson. Lease acquisition (see acquire()) maintains the
 // invariant that no new leases for desc.Version-1 will be granted once
 // desc.Version exists.
-func (s LeaseStore) waitForOneVersion(tableID ID, retryOpts retry.Options) (DescriptorVersion, *roachpb.Error) {
+func (s LeaseStore) waitForOneVersion(tableID ID, retryOpts retry.Options) (DescriptorVersion, error) {
 	desc := &Descriptor{}
 	descKey := MakeDescMetadataKey(tableID)
 	var tableDesc *TableDescriptor
@@ -189,18 +191,18 @@ func (s LeaseStore) waitForOneVersion(tableID ID, retryOpts retry.Options) (Desc
 		//
 		// TODO(pmattis): Do an inconsistent read here?
 		if pErr := s.db.GetProto(descKey, desc); pErr != nil {
-			return 0, pErr
+			return 0, pErr.GoError()
 		}
 		tableDesc = desc.GetTable()
 		if tableDesc == nil {
-			return 0, roachpb.NewErrorf("ID %d is not a table", tableID)
+			return 0, util.Errorf("ID %d is not a table", tableID)
 		}
 		// Check to see if there are any leases that still exist on the previous
 		// version of the descriptor.
 		now := s.clock.Now()
-		count, pErr := s.countLeases(tableDesc.ID, tableDesc.Version-1, now.GoTime())
-		if pErr != nil {
-			return 0, pErr
+		count, err := s.countLeases(tableDesc.ID, tableDesc.Version-1, now.GoTime())
+		if err != nil {
+			return 0, err
 		}
 		if count == 0 {
 			break
@@ -224,14 +226,14 @@ func (s LeaseStore) Publish(tableID ID, update func(*TableDescriptor) error) *ro
 	for r := retry.Start(retryOpts); r.Next(); {
 		// Wait until there are no unexpired leases on the previous version
 		// of the table.
-		expectedVersion, pErr := s.waitForOneVersion(tableID, retryOpts)
-		if pErr != nil {
-			return pErr
+		expectedVersion, err := s.waitForOneVersion(tableID, retryOpts)
+		if err != nil {
+			return roachpb.NewError(err)
 		}
 
 		// There should be only one version of the descriptor, but it's
 		// a race now to update to the next version.
-		pErr = s.db.Txn(func(txn *client.Txn) *roachpb.Error {
+		pErr := s.db.Txn(func(txn *client.Txn) *roachpb.Error {
 			desc := &Descriptor{}
 			descKey := MakeDescMetadataKey(tableID)
 
@@ -291,7 +293,7 @@ func (s LeaseStore) Publish(tableID ID, update func(*TableDescriptor) error) *ro
 
 // countLeases returns the number of unexpired leases for a particular version
 // of a descriptor.
-func (s LeaseStore) countLeases(descID ID, version DescriptorVersion, expiration time.Time) (int, *roachpb.Error) {
+func (s LeaseStore) countLeases(descID ID, version DescriptorVersion, expiration time.Time) (int, error) {
 	var count int
 	pErr := s.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		p := makePlanner()
@@ -307,7 +309,7 @@ func (s LeaseStore) countLeases(descID ID, version DescriptorVersion, expiration
 		count = int(values[0].(parser.DInt))
 		return nil
 	})
-	return count, pErr
+	return count, pErr.GoError()
 }
 
 // leaseSet maintains an ordered set of LeaseState objects. It supports
@@ -461,11 +463,11 @@ func (t *tableState) acquire(txn *client.Txn, version DescriptorVersion, store L
 			// There is no active lease acquisition so we'll go ahead and perform
 			// one.
 			t.acquiring = make(chan struct{})
-			s, err := t.acquireNodeLease(txn, version, store)
+			s, pErr := t.acquireNodeLease(txn, version, store)
 			close(t.acquiring)
 			t.acquiring = nil
-			if err != nil {
-				return nil, err
+			if pErr != nil {
+				return nil, pErr
 			}
 			t.active.insert(s)
 			if err := t.releaseNonLatest(store); err != nil {
@@ -478,14 +480,14 @@ func (t *tableState) acquire(txn *client.Txn, version DescriptorVersion, store L
 }
 
 // releaseNonLatest releases all unused non-latest leases.
-func (t *tableState) releaseNonLatest(store LeaseStore) *roachpb.Error {
+func (t *tableState) releaseNonLatest(store LeaseStore) error {
 	// Skip the last lease.
 	for i := 0; i < len(t.active.data)-1; {
 		s := t.active.data[i]
 		if s.Refcount() == 0 {
 			t.active.remove(s)
-			if pErr := t.releaseNodeLease(s, store); pErr != nil {
-				return pErr
+			if err := t.releaseNodeLease(s, store); err != nil {
+				return err
 			}
 		} else {
 			i++
@@ -511,13 +513,13 @@ func (t *tableState) acquireNodeLease(txn *client.Txn, minVersion DescriptorVers
 	return store.Acquire(txn, t.id, minVersion)
 }
 
-func (t *tableState) release(lease *LeaseState, store LeaseStore) *roachpb.Error {
+func (t *tableState) release(lease *LeaseState, store LeaseStore) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	s := t.active.find(lease.Version, lease.expiration)
 	if s == nil {
-		return roachpb.NewErrorf("table %d version %d not found", lease.ID, lease.Version)
+		return util.Errorf("table %d version %d not found", lease.ID, lease.Version)
 	}
 	s.refcount--
 	if log.V(3) {
@@ -540,7 +542,7 @@ func (t *tableState) release(lease *LeaseState, store LeaseStore) *roachpb.Error
 	return nil
 }
 
-func (t *tableState) releaseNodeLease(lease *LeaseState, store LeaseStore) *roachpb.Error {
+func (t *tableState) releaseNodeLease(lease *LeaseState, store LeaseStore) error {
 	// We're called with mu locked, but need to unlock it while releasing the
 	// lease.
 	t.mu.Unlock()
@@ -578,10 +580,10 @@ func (m *LeaseManager) Acquire(txn *client.Txn, tableID ID, version DescriptorVe
 }
 
 // Release releases a previously acquired read lease.
-func (m *LeaseManager) Release(lease *LeaseState) *roachpb.Error {
+func (m *LeaseManager) Release(lease *LeaseState) error {
 	t := m.findTableState(lease.ID, false)
 	if t == nil {
-		return roachpb.NewErrorf("table %d not found", lease.ID)
+		return util.Errorf("table %d not found", lease.ID)
 	}
 	// TODO(pmattis): Can/should we delete from LeaseManager.tables if the
 	// tableState becomes empty?
@@ -654,7 +656,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gos
 }
 
 // refreshLease tries to refresh the node's table lease.
-func (m *LeaseManager) refreshLease(db *client.DB, id ID, minVersion DescriptorVersion) *roachpb.Error {
+func (m *LeaseManager) refreshLease(db *client.DB, id ID, minVersion DescriptorVersion) error {
 	// Only attempt to update a lease for a table that is already leased.
 	if t := m.findTableState(id, false); t == nil {
 		return nil
@@ -672,7 +674,7 @@ func (m *LeaseManager) refreshLease(db *client.DB, id ID, minVersion DescriptorV
 		lease, pErr = m.Acquire(txn, id, minVersion)
 		return pErr
 	}); pErr != nil {
-		return pErr
+		return pErr.GoError()
 	}
 	return m.Release(lease)
 }

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -105,7 +105,7 @@ func (t *leaseTest) mustAcquire(nodeID uint32, descID csql.ID, version csql.Desc
 	return lease
 }
 
-func (t *leaseTest) release(nodeID uint32, lease *csql.LeaseState) *roachpb.Error {
+func (t *leaseTest) release(nodeID uint32, lease *csql.LeaseState) error {
 	return t.node(nodeID).Release(lease)
 }
 

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -278,11 +278,11 @@ func (p *planner) notifySchemaChange(id ID, mutationID MutationID) {
 	p.schemaChangeCallback(sc)
 }
 
-func (p *planner) releaseLeases(db client.DB) {
+func (p *planner) releaseLeases() {
 	if p.leases != nil {
 		for _, lease := range p.leases {
-			if pErr := p.leaseMgr.Release(lease); pErr != nil {
-				log.Warning(pErr)
+			if err := p.leaseMgr.Release(lease); err != nil {
+				log.Warning(err)
 			}
 		}
 		p.leases = nil

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -148,16 +148,17 @@ func (sc *SchemaChanger) findTableWithLease(txn *client.Txn, lease TableDescript
 
 // ReleaseLease the table lease if it is the one registered with
 // the table descriptor.
-func (sc *SchemaChanger) ReleaseLease(lease TableDescriptor_SchemaChangeLease) *roachpb.Error {
-	return sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
-		tableDesc, err := sc.findTableWithLease(txn, lease)
-		if err != nil {
-			return err
+func (sc *SchemaChanger) ReleaseLease(lease TableDescriptor_SchemaChangeLease) error {
+	pErr := sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
+		tableDesc, pErr := sc.findTableWithLease(txn, lease)
+		if pErr != nil {
+			return pErr
 		}
 		tableDesc.Lease = nil
 		txn.SetSystemConfigTrigger()
 		return txn.Put(MakeDescMetadataKey(tableDesc.ID), wrapDescriptor(tableDesc))
 	})
+	return pErr.GoError()
 }
 
 // ExtendLease for the current leaser.
@@ -185,8 +186,8 @@ func (sc SchemaChanger) exec() *roachpb.Error {
 	}
 	// Always try to release lease.
 	defer func(l *TableDescriptor_SchemaChangeLease) {
-		if pErr := sc.ReleaseLease(*l); pErr != nil {
-			log.Warning(pErr)
+		if err := sc.ReleaseLease(*l); err != nil {
+			log.Warning(err)
 		}
 	}(&lease)
 
@@ -199,8 +200,8 @@ func (sc SchemaChanger) exec() *roachpb.Error {
 	// returns, so that the new schema is live everywhere. This is not needed for
 	// correctness but is done to make the UI experience/tests predictable.
 	defer func() {
-		if pErr := sc.waitToUpdateLeases(); pErr != nil {
-			log.Warning(pErr)
+		if err := sc.waitToUpdateLeases(); err != nil {
+			log.Warning(err)
 		}
 	}()
 
@@ -213,8 +214,8 @@ func (sc SchemaChanger) exec() *roachpb.Error {
 	// but we're no longer responsible for taking care of that.
 
 	// Run through mutation state machine before backfill.
-	if pErr := sc.RunStateMachineBeforeBackfill(); pErr != nil {
-		return pErr
+	if err := sc.RunStateMachineBeforeBackfill(); err != nil {
+		return roachpb.NewError(err)
 	}
 
 	// Apply backfill.
@@ -246,7 +247,7 @@ func (sc *SchemaChanger) MaybeIncrementVersion() *roachpb.Error {
 // RunStateMachineBeforeBackfill moves the state machine forward
 // and wait to ensure that all nodes are seeing the latest version
 // of the table.
-func (sc *SchemaChanger) RunStateMachineBeforeBackfill() *roachpb.Error {
+func (sc *SchemaChanger) RunStateMachineBeforeBackfill() error {
 	if pErr := sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
 		var modified bool
 		// Apply mutations belonging to the same version.
@@ -290,7 +291,7 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill() *roachpb.Error {
 		}
 		return nil
 	}); pErr != nil {
-		return pErr
+		return pErr.GoError()
 	}
 	// wait for the state change to propagate to all leases.
 	return sc.waitToUpdateLeases()
@@ -298,7 +299,7 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill() *roachpb.Error {
 
 // Wait until the entire cluster has been updated to the latest version
 // of the table descriptor.
-func (sc *SchemaChanger) waitToUpdateLeases() *roachpb.Error {
+func (sc *SchemaChanger) waitToUpdateLeases() error {
 	// Aggressively retry because there might be a user waiting for the
 	// schema change to complete.
 	retryOpts := retry.Options{
@@ -306,8 +307,8 @@ func (sc *SchemaChanger) waitToUpdateLeases() *roachpb.Error {
 		MaxBackoff:     200 * time.Millisecond,
 		Multiplier:     2,
 	}
-	_, pErr := sc.leaseMgr.waitForOneVersion(sc.tableID, retryOpts)
-	return pErr
+	_, err := sc.leaseMgr.waitForOneVersion(sc.tableID, retryOpts)
+	return err
 }
 
 func (sc *SchemaChanger) done() *roachpb.Error {
@@ -335,7 +336,7 @@ func (sc *SchemaChanger) done() *roachpb.Error {
 // Purge all mutations with the mutationID. This is called after
 // hitting an irrecoverable error. Reverse the direction of the mutations
 // and run through the state machine until the mutations are deleted.
-func (sc *SchemaChanger) purgeMutations(lease *TableDescriptor_SchemaChangeLease) *roachpb.Error {
+func (sc *SchemaChanger) purgeMutations(lease *TableDescriptor_SchemaChangeLease) error {
 	// Reverse the flow of the state machine.
 	if pErr := sc.leaseMgr.Publish(sc.tableID, func(desc *TableDescriptor) error {
 		for i, mutation := range desc.Mutations {
@@ -356,12 +357,12 @@ func (sc *SchemaChanger) purgeMutations(lease *TableDescriptor_SchemaChangeLease
 		// Publish() will increment the version.
 		return nil
 	}); pErr != nil {
-		return pErr
+		return pErr.GoError()
 	}
 
 	// Run through mutation state machine before backfill.
-	if pErr := sc.RunStateMachineBeforeBackfill(); pErr != nil {
-		return pErr
+	if err := sc.RunStateMachineBeforeBackfill(); err != nil {
+		return err
 	}
 
 	// Apply backfill and don't run purge on hitting an error.
@@ -370,16 +371,16 @@ func (sc *SchemaChanger) purgeMutations(lease *TableDescriptor_SchemaChangeLease
 	// changers keep attempting to apply and purge mutations.
 	// This is a theoretical problem at this stage (2015/12).
 	if pErr := sc.applyMutations(lease); pErr != nil {
-		return pErr
+		return pErr.GoError()
 	}
 
 	// Mark the mutations as completed.
-	return sc.done()
+	return sc.done().GoError()
 }
 
 // IsDone returns true if the work scheduled for the schema changer
 // is complete.
-func (sc *SchemaChanger) IsDone() (bool, *roachpb.Error) {
+func (sc *SchemaChanger) IsDone() (bool, error) {
 	var done bool
 	pErr := sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		done = true
@@ -401,7 +402,7 @@ func (sc *SchemaChanger) IsDone() (bool, *roachpb.Error) {
 		}
 		return nil
 	})
-	return done && pErr == nil, pErr
+	return done && pErr == nil, pErr.GoError()
 }
 
 // SchemaChangeManager processes pending schema changes seen in gossip


### PR DESCRIPTION
Change the following methods to return error instead of roachpb.Error.
- LeaseStore.Release
- LeaseStore.waitForOneVersion
- LeaseStore.countLeases
- tableState.releaseNonLatest
- tableState.release
- tableState.releaseNodeLease
- LeaseManager.Release(leas
- LeaseManager.refreshLease
- leaseTest.release
- SchemaChanger.ReleaseLease
- SchemaChanger.RunStateMachineBeforeBackfill
- SchemaChanger.waitToUpdateLeases
- SchemaChanger.purgeMutations

Rename err to pErr when I forgot to do.

(I'm not totally sure this change is a good direction. The code might be fragile as people can accidentally call this methods inside a txn in future.)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4513)

<!-- Reviewable:end -->
