### PR TITLE
Always set an error index when an error comes from an individual command

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -521,7 +521,7 @@ func (txn *Txn) send(reqs ...roachpb.Request) (*roachpb.BatchResponse, *roachpb.
 			idx := pErr.Index.Index
 			if idx == int32(firstWriteIndex) {
 				// An error was encountered on begin txn; disallow the indexing.
-				pErr = roachpb.NewErrorf("error on begin transaction: %s", pErr)
+				pErr.Index = nil
 			} else if idx > int32(firstWriteIndex) {
 				// An error was encountered after begin txn; decrement index.
 				pErr.SetErrorIndex(idx - 1)

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1510,14 +1510,7 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba roa
 
 		if pErr != nil {
 			// Initialize the error index.
-			// TODO(kaneda): Always set the index when the
-			// error stems from an individual command.
-			if _, ok := pErr.GetDetail().(*roachpb.WriteIntentError); ok {
-				pErr.SetErrorIndex(int32(index))
-			}
-			if _, ok := pErr.GetDetail().(*roachpb.ConditionFailedError); ok {
-				pErr.SetErrorIndex(int32(index))
-			}
+			pErr.SetErrorIndex(int32(index))
 			return nil, intents, pErr
 		}
 


### PR DESCRIPTION
Change `Txn.send()` to set `Index` to `nil` instead of creating a new `Error`. Otherwise, we will lose ErrorDetail and an error is not handled correctly.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4514)

<!-- Reviewable:end -->
