### PR TITLE
storage: MVCCDeleteRange with iterator

### DIFF
--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -353,7 +353,7 @@ func runBenchmarkDelete(b *testing.B, db *sql.DB, rows int) {
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.delete`); err != nil {
 		b.Fatal(err)
 	}
-	if _, err := db.Exec(`CREATE TABLE bench.delete (k INT PRIMARY KEY)`); err != nil {
+	if _, err := db.Exec(`CREATE TABLE bench.delete (k INT PRIMARY KEY, v1 INT, v2 INT, v3 INT)`); err != nil {
 		b.Fatal(err)
 	}
 	defer func() {
@@ -372,7 +372,7 @@ func runBenchmarkDelete(b *testing.B, db *sql.DB, rows int) {
 			if j > 0 {
 				buf.WriteString(", ")
 			}
-			fmt.Fprintf(&buf, "(%d)", j)
+			fmt.Fprintf(&buf, "(%d, %d, %d, %d)", j, j, j, j)
 		}
 		if _, err := db.Exec(buf.String()); err != nil {
 			b.Fatal(err)


### PR DESCRIPTION
Fixes #4489.

```
name                               old time/op    new time/op    delta
MVCCDeleteRange1Version8Bytes-8       122ms ±10%      93ms ± 1%  -24.02%  (p=0.000 n=10+10)
MVCCDeleteRange1Version32Bytes-8     92.2ms ± 4%    84.9ms ± 6%   -7.95%  (p=0.000 n=10+10)
MVCCDeleteRange1Version256Bytes-8    25.3ms ± 4%    23.0ms ± 3%   -9.10%  (p=0.000 n=10+10)

name                               old speed      new speed      delta
MVCCDeleteRange1Version8Bytes-8    4.30MB/s ±11%  5.64MB/s ± 1%  +31.11%  (p=0.000 n=10+10)
MVCCDeleteRange1Version32Bytes-8   5.69MB/s ± 5%  6.18MB/s ± 7%   +8.66%  (p=0.000 n=10+10)
MVCCDeleteRange1Version256Bytes-8  20.7MB/s ± 4%  22.8MB/s ± 3%   +9.99%  (p=0.000 n=10+10)

name                               old alloc/op   new alloc/op   delta
MVCCDeleteRange1Version8Bytes-8      4.15MB ± 0%    0.30MB ± 0%  -92.76%    (p=0.000 n=9+8)
MVCCDeleteRange1Version32Bytes-8     2.81MB ± 0%    0.42MB ± 0%  -85.03%  (p=0.000 n=10+10)
MVCCDeleteRange1Version256Bytes-8    1.10MB ± 0%    0.53MB ± 0%  -52.04%   (p=0.000 n=10+7)

name                               old allocs/op  new allocs/op  delta
MVCCDeleteRange1Version8Bytes-8       37.5k ± 0%     28.1k ± 0%  -25.12%  (p=0.000 n=10+10)
MVCCDeleteRange1Version32Bytes-8      26.3k ± 0%     19.7k ± 0%  -25.13%   (p=0.000 n=10+9)
MVCCDeleteRange1Version256Bytes-8     6.93k ± 0%     5.18k ± 0%  -25.17%   (p=0.000 n=8+10)
```

And in SQL:

```
name                   old time/op    new time/op    delta
Delete1_Cockroach-8       787µs ± 4%     773µs ± 5%    ~     (p=0.143 n=10+10)
Delete10_Cockroach-8     2.47ms ± 2%    2.46ms ± 3%    ~      (p=0.780 n=9+10)
Delete100_Cockroach-8    17.5ms ± 3%    16.8ms ± 2%  -4.22%   (p=0.000 n=9+10)

name                   old alloc/op   new alloc/op   delta
Delete1_Cockroach-8      35.3kB ± 0%    34.7kB ± 0%  -1.81%  (p=0.000 n=10+10)
Delete10_Cockroach-8      141kB ± 0%     135kB ± 0%  -4.52%  (p=0.000 n=10+10)
Delete100_Cockroach-8    1.15MB ± 0%    1.09MB ± 0%  -5.60%    (p=0.000 n=8+9)

name                   old allocs/op  new allocs/op  delta
Delete1_Cockroach-8         586 ± 0%       580 ± 0%  -1.02%  (p=0.000 n=10+10)
Delete10_Cockroach-8      1.82k ± 0%     1.76k ± 0%  -3.30%  (p=0.000 n=10+10)
Delete100_Cockroach-8     13.5k ± 0%     12.9k ± 0%  -4.45%   (p=0.000 n=8+10)
```

I'll expect bigger % gains on SQL side if/when we make simple deletes skip scans.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4521)

<!-- Reviewable:end -->
