### PR TITLE
util: set http.Server.ErrorLog

### DIFF
--- a/sql/driver/link_test.go
+++ b/sql/driver/link_test.go
@@ -40,7 +40,6 @@ func TestNoLinkForbidden(t *testing.T) {
 	for _, forbidden := range []string{
 		"C",       // cross compilation
 		"testing", // defines flags
-		"github.com/cockroachdb/cockroach/util/log", // defines flags
 	} {
 		if _, ok := imports[forbidden]; ok {
 			t.Errorf("sql/driver includes %s, which is forbidden", forbidden)

--- a/util/log/clog_test.go
+++ b/util/log/clog_test.go
@@ -122,19 +122,15 @@ func TestInfo(t *testing.T) {
 	}
 }
 
-func init() {
-	CopyStandardLogTo("INFO")
-}
-
-// Test that CopyStandardLogTo panics on bad input.
-func TestCopyStandardLogToPanic(t *testing.T) {
+// Test that copyStandardLogTo panics on bad input.
+func TestcopyStandardLogToPanic(t *testing.T) {
 	setFlags()
 	defer func() {
 		if s, ok := recover().(string); !ok || !strings.Contains(s, "LOG") {
-			t.Errorf(`CopyStandardLogTo("LOG") should have panicked: %v`, s)
+			t.Errorf(`copyStandardLogTo("LOG") should have panicked: %v`, s)
 		}
 	}()
-	CopyStandardLogTo("LOG")
+	copyStandardLogTo("LOG")
 }
 
 // Test that using the standard log package logs to INFO.

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -19,9 +19,7 @@ package log
 import "golang.org/x/net/context"
 
 func init() {
-	// TODO(tschottdorf) this should go to our logger. Currently this will log
-	// with clog (=glog) format.
-	CopyStandardLogTo("INFO")
+	copyStandardLogTo("INFO")
 }
 
 // FatalOnPanic recovers from a panic and exits the process with a

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -33,8 +33,8 @@ import (
 func AddStructured(ctx context.Context, s Severity, depth int, format string, args []interface{}) {
 	file, line, _ := caller.Lookup(depth + 1)
 	entry := LogEntry{}
-	entry.set(ctx, format, args)
-	logging.outputLogEntry(s, file, line, false, &entry)
+	entry.Set(ctx, format, args)
+	logging.outputLogEntry(s, file, line, &entry)
 }
 
 // getJSON returns a JSON representation of the specified argument.
@@ -61,7 +61,9 @@ func getJSON(arg interface{}) []byte {
 	return jsonBytes
 }
 
-func (entry *LogEntry) set(ctx context.Context, format string, args []interface{}) {
+// Set sets the contents of an entry from a context, format string and
+// arguments.
+func (entry *LogEntry) Set(ctx context.Context, format string, args []interface{}) {
 	entry.Format, entry.Args = parseFormatWithArgs(format, args)
 
 	if ctx != nil {

--- a/util/testing.go
+++ b/util/testing.go
@@ -19,12 +19,13 @@ package util
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
 	"reflect"
 	"time"
+
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 // Tester is a proxy for e.g. testing.T which does not introduce a dependency


### PR DESCRIPTION
Bridge log messages written to http.Server.ErrorLog to the util/log
infrastructure at the ERROR level.

Change util/log.logBridge to send log messages to their normal
destination instead of forcing them to also be written to stderr.

Now that `util` depends on `util/log` I had to lift the restriction on
which imports are allowed in `sql/driver`. This is fine because this
package will be going away some time soon.

Fixes #4374.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4525)

<!-- Reviewable:end -->
