### PR TITLE
build: avoid gossip/simulation code rot

### DIFF
--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -91,6 +91,7 @@ if [ "${1-}" = "docker" ]; then
     time go test -v -c -tags acceptance ./acceptance
     # Avoid code rot.
     time go build ./gossip/simulation/...
+    time go test ./gossip/simulation/gossip.go
   fi
 
   exit 0


### PR DESCRIPTION
go build <path>/... apparently doesn't bother with package main.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4528)

<!-- Reviewable:end -->
