### PR TITLE
storage: [Tiny fix] Call NewErrorWithTxn instead of SetTxn

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -1403,9 +1403,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.Bat
 	// and the original error otherwise.
 	sp.LogEvent("store retry limit exceeded") // good to check for if tests fail
 	if ba.Txn != nil {
-		pErr := roachpb.NewError(roachpb.NewTransactionRetryError())
-		pErr.SetTxn(ba.Txn)
-		return nil, pErr
+		return nil, roachpb.NewErrorWithTxn(roachpb.NewTransactionRetryError(), ba.Txn)
 	}
 	return nil, pErr
 }


### PR DESCRIPTION
At several places, we used to call `roachpb.NewError()` and then `SetTxn()`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4531)

<!-- Reviewable:end -->
