### PR TITLE
roachpb: [Tiny fix] Kill BatchResponse.SetGoError

### DIFF
--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -423,7 +423,7 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 		args roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
 		if first {
 			reply := &roachpb.BatchResponse{}
-			reply.SetGoError(
+			reply.Error = roachpb.NewError(
 				&roachpb.NotLeaderError{Leader: &leader, Replica: &roachpb.ReplicaDescriptor{}})
 			first = false
 			return reply, nil
@@ -535,7 +535,7 @@ func TestEvictCacheOnError(t *testing.T) {
 				err = errors.New("boom")
 			}
 			reply := &roachpb.BatchResponse{}
-			reply.SetGoError(err)
+			reply.Error = roachpb.NewError(err)
 			return reply, nil
 		}
 

--- a/roachpb/api_test.go
+++ b/roachpb/api_test.go
@@ -21,37 +21,6 @@ import (
 	"testing"
 )
 
-type testError struct{}
-
-func (t *testError) Error() string              { return "test" }
-func (t *testError) message(pErr *Error) string { return "test" }
-func (t *testError) CanRetry() bool             { return true }
-func (t *testError) ErrorIndex() (int32, bool)  { return 99, true }
-func (t *testError) SetErrorIndex(_ int32)      { panic("unsupported") }
-
-// TestSetGoError verifies that a test error that
-// implements retryable or indexed is converted properly into a generic error.
-func TestSetGoErrorGeneric(t *testing.T) {
-	br := &BatchResponse{}
-	br.SetGoError(&testError{})
-	if br.Error.GoError().Error() != "test" {
-		t.Errorf("unexpected error: %s", br.Error)
-	}
-	if !br.Error.Retryable {
-		t.Error("expected generic error to be retryable")
-	}
-}
-
-// TestResponseHeaderNilError verifies that a nil error can be set
-// and retrieved from a response header.
-func TestSetGoErrorNil(t *testing.T) {
-	br := &BatchResponse{}
-	br.SetGoError(nil)
-	if br.Error != nil {
-		t.Errorf("expected nil error; got %s", br.Error)
-	}
-}
-
 // TestCombinable tests the correct behaviour of some types that implement
 // the Combinable interface, notably {Scan,DeleteRange}Response and
 // ResponseHeader.
@@ -124,15 +93,5 @@ func TestCombinable(t *testing.T) {
 
 	if !reflect.DeepEqual(dr1, wantedDR) {
 		t.Errorf("wanted %v, got %v", wantedDR, dr1)
-	}
-}
-
-func TestSetGoErrorCopy(t *testing.T) {
-	br := &BatchResponse{}
-	oErr := &Error{Message: "test123"}
-	br.Error = oErr
-	br.SetGoError(&testError{})
-	if oErr.Message != "test123" {
-		t.Fatalf("SetGoError did not create a new error")
 	}
 }

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -295,14 +295,3 @@ func (ba *BatchRequest) SetNewRequest() {
 	}
 	ba.Txn.Sequence++
 }
-
-// SetGoError converts the specified type into either one of the proto-
-// defined error types or into an Error for all other Go errors.
-func (br *BatchResponse) SetGoError(err error) {
-	if err == nil {
-		br.Error = nil
-		return
-	}
-	br.Error = &Error{}
-	br.Error.setGoError(err)
-}


### PR DESCRIPTION
This method is used only from tests. Some of the test cases are moved
from api_test.go to errors_test.go.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4532)

<!-- Reviewable:end -->
