### PR TITLE
kv: Do not clone a txn on TransactionStatusError

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -672,8 +672,7 @@ func (tc *TxnCoordSender) updateState(ctx context.Context, ba roachpb.BatchReque
 	case *roachpb.TransactionStatusError:
 		// Likely already committed or more obscure errors such as epoch or
 		// timestamp regressions; consider txn dead.
-		pErrTxn := pErr.GetTxn().Clone()
-		defer tc.cleanupTxn(sp, pErrTxn)
+		defer tc.cleanupTxn(sp, *pErr.GetTxn())
 	case *roachpb.OpRequiresTxnError:
 		panic("OpRequiresTxnError must not happen at this level")
 	case *roachpb.ReadWithinUncertaintyIntervalError:


### PR DESCRIPTION
We don't need to clone a txn since there is no write access in cleanupTxn. This is also consistent with what we do for TransactionAbortedError.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4553)

<!-- Reviewable:end -->
