### PR TITLE
cli: use lib/pq directly

### DIFF
--- a/cli/user.go
+++ b/cli/user.go
@@ -43,9 +43,9 @@ func runGetUser(cmd *cobra.Command, args []string) {
 		mustUsage(cmd)
 		return
 	}
-	db, _ := makeSQLClient()
-	defer func() { _ = db.Close() }()
-	err := runPrettyQuery(db, os.Stdout,
+	conn := makeSQLClient()
+	defer conn.Close()
+	err := runPrettyQuery(conn, os.Stdout,
 		`SELECT * FROM system.users WHERE username=$1`, args[0])
 	if err != nil {
 		panic(err)
@@ -68,9 +68,9 @@ func runLsUsers(cmd *cobra.Command, args []string) {
 		mustUsage(cmd)
 		return
 	}
-	db, _ := makeSQLClient()
-	defer func() { _ = db.Close() }()
-	err := runPrettyQuery(db, os.Stdout, `SELECT username FROM system.users`)
+	conn := makeSQLClient()
+	defer conn.Close()
+	err := runPrettyQuery(conn, os.Stdout, `SELECT username FROM system.users`)
 	if err != nil {
 		panic(err)
 	}
@@ -92,9 +92,9 @@ func runRmUser(cmd *cobra.Command, args []string) {
 		mustUsage(cmd)
 		return
 	}
-	db, _ := makeSQLClient()
-	defer func() { _ = db.Close() }()
-	err := runPrettyQuery(db, os.Stdout,
+	conn := makeSQLClient()
+	defer conn.Close()
+	err := runPrettyQuery(conn, os.Stdout,
 		`DELETE FROM system.users WHERE username=$1`, args[0])
 	if err != nil {
 		panic(err)
@@ -160,10 +160,10 @@ func runSetUser(cmd *cobra.Command, args []string) {
 			panic(err)
 		}
 	}
-	db, _ := makeSQLClient()
-	defer func() { _ = db.Close() }()
+	conn := makeSQLClient()
+	defer conn.Close()
 	// TODO(marc): switch to UPSERT.
-	err = runPrettyQuery(db, os.Stdout,
+	err = runPrettyQuery(conn, os.Stdout,
 		`INSERT INTO system.users VALUES ($1, $2)`, args[0], hashed)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Manually create connections using lib/pq instead of going through the
sql package. This ensures we have a single connection to the database
and paves the way for exposing more functionality in lib/pq to our sql
shell. The downside is the loss of some of the functionality in the
standard sql package.

See #4081.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4567)

<!-- Reviewable:end -->
