### PR TITLE
keys: Rename RaftLeaderLeaseKey to RangeLeaderLeaseKey

### DIFF
--- a/keys/constants.go
+++ b/keys/constants.go
@@ -79,8 +79,6 @@ var (
 	// LocalSequenceCacheSuffix is the suffix used for the replay protection
 	// mechanism.
 	LocalSequenceCacheSuffix = []byte("res-")
-	// localRaftLeaderLeaseSuffix is the suffix for the raft leader lease.
-	localRaftLeaderLeaseSuffix = []byte("rfll")
 	// localRaftTombstoneSuffix is the suffix for the raft tombstone.
 	localRaftTombstoneSuffix = []byte("rftb")
 	// localRaftHardStateSuffix is the Suffix for the raft HardState.
@@ -93,6 +91,8 @@ var (
 	localRaftTruncatedStateSuffix = []byte("rftt")
 	// localRaftLastIndexSuffix is the suffix for raft's last index.
 	localRaftLastIndexSuffix = []byte("rfti")
+	// localRangeLeaderLeaseSuffix is the suffix for a range leader lease.
+	localRangeLeaderLeaseSuffix = []byte("rll-")
 	// localRangeLastVerificationTimestampSuffix is the suffix for a range's
 	// last verification timestamp (for checking integrity of on-disk data).
 	localRangeLastVerificationTimestampSuffix = []byte("rlvt")

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -120,11 +120,6 @@ func RaftAppliedIndexKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDKey(rangeID, localRaftAppliedIndexSuffix, nil)
 }
 
-// RaftLeaderLeaseKey returns a system-local key for a raft leader lease.
-func RaftLeaderLeaseKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDKey(rangeID, localRaftLeaderLeaseSuffix, nil)
-}
-
 // RaftTombstoneKey returns a system-local key for a raft tombstone.
 func RaftTombstoneKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDKey(rangeID, localRaftTombstoneSuffix, nil)
@@ -157,6 +152,11 @@ func SequenceCacheKeyPrefix(rangeID roachpb.RangeID, txnID *uuid.UUID) roachpb.K
 	key := MakeRangeIDKey(rangeID, LocalSequenceCacheSuffix, nil)
 	key = encoding.EncodeBytesAscending(key, txnID.Bytes())
 	return key
+}
+
+// RangeLeaderLeaseKey returns a system-local key for a range leader lease.
+func RangeLeaderLeaseKey(rangeID roachpb.RangeID) roachpb.Key {
+	return MakeRangeIDKey(rangeID, localRangeLeaderLeaseSuffix, nil)
 }
 
 // MakeRangeKey creates a range-local key based on the range

--- a/keys/printer.go
+++ b/keys/printer.go
@@ -87,7 +87,6 @@ var (
 		ppFunc func(key roachpb.Key) string
 	}{
 		{name: "SequenceCache", suffix: LocalSequenceCacheSuffix, ppFunc: sequenceCacheKeyPrint},
-		{name: "RaftLeaderLease", suffix: localRaftLeaderLeaseSuffix},
 		{name: "RaftTombstone", suffix: localRaftTombstoneSuffix},
 		{name: "RaftHardState", suffix: localRaftHardStateSuffix},
 		{name: "RaftAppliedIndex", suffix: localRaftAppliedIndexSuffix},
@@ -95,6 +94,7 @@ var (
 		{name: "RaftTruncatedState", suffix: localRaftTruncatedStateSuffix},
 		{name: "RaftLastIndex", suffix: localRaftLastIndexSuffix},
 		{name: "RangeLastVerificationTimestamp", suffix: localRangeLastVerificationTimestampSuffix},
+		{name: "RangeLeaderLease", suffix: localRangeLeaderLeaseSuffix},
 		{name: "RangeStats", suffix: localRangeStatsSuffix},
 	}
 

--- a/keys/printer_test.go
+++ b/keys/printer_test.go
@@ -45,7 +45,6 @@ func TestPrettyPrint(t *testing.T) {
 		{StoreGossipKey(), "/Local/Store/gossipBootstrap"},
 		{SequenceCacheKeyPrefix(roachpb.RangeID(1000001), txnID), fmt.Sprintf(`/Local/RangeID/1000001/SequenceCache/%q`, txnID)},
 		{SequenceCacheKey(roachpb.RangeID(1000001), txnID, uint32(111), uint32(222)), fmt.Sprintf(`/Local/RangeID/1000001/SequenceCache/%q/epoch:111/seq:222`, txnID)},
-		{RaftLeaderLeaseKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/RaftLeaderLease"},
 		{RaftTombstoneKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/RaftTombstone"},
 		{RaftHardStateKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/RaftHardState"},
 		{RaftAppliedIndexKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/RaftAppliedIndex"},
@@ -53,6 +52,7 @@ func TestPrettyPrint(t *testing.T) {
 		{RaftTruncatedStateKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/RaftTruncatedState"},
 		{RaftLastIndexKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/RaftLastIndex"},
 		{RangeLastVerificationTimestampKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/RangeLastVerificationTimestamp"},
+		{RangeLeaderLeaseKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/RangeLeaderLease"},
 		{RangeStatsKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/RangeStats"},
 
 		{MakeRangeKeyPrefix(roachpb.RKey("ok")), `/Local/Range/"ok"`},

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -352,7 +352,7 @@ func (r *Replica) IsFirstRange() bool {
 
 func loadLeaderLease(eng engine.Engine, rangeID roachpb.RangeID) (*roachpb.Lease, error) {
 	lease := &roachpb.Lease{}
-	if _, err := engine.MVCCGetProto(eng, keys.RaftLeaderLeaseKey(rangeID), roachpb.ZeroTimestamp, true, nil, lease); err != nil {
+	if _, err := engine.MVCCGetProto(eng, keys.RangeLeaderLeaseKey(rangeID), roachpb.ZeroTimestamp, true, nil, lease); err != nil {
 		return nil, err
 	}
 	return lease, nil

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1243,7 +1243,7 @@ func (r *Replica) LeaderLease(batch engine.Engine, ms *engine.MVCCStats, h roach
 	args.Lease.Start = effectiveStart
 
 	// Store the lease to disk & in-memory.
-	if err := engine.MVCCPutProto(batch, ms, keys.RaftLeaderLeaseKey(r.RangeID), roachpb.ZeroTimestamp, nil, &args.Lease); err != nil {
+	if err := engine.MVCCPutProto(batch, ms, keys.RangeLeaderLeaseKey(r.RangeID), roachpb.ZeroTimestamp, nil, &args.Lease); err != nil {
 		return reply, err
 	}
 	r.mu.leaderLease = &args.Lease


### PR DESCRIPTION
A range's leader lease is explicitly not part of Raft, so the previous
key name was misleading.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4574)

<!-- Reviewable:end -->
