### PR TITLE
Refactor sql/executor to support retries of batches of statements.

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -459,11 +459,14 @@ func (db *DB) RunWithResponse(b *Batch) (*roachpb.BatchResponse, *roachpb.Error)
 // otherwise. The retryable function should have no side effects which could
 // cause problems in the event it must be run more than once.
 //
-// TODO(pmattis): Allow transaction options to be specified.
+// If you need more control over how the txn is executed, check out txn.Exec().
 func (db *DB) Txn(retryable func(txn *Txn) *roachpb.Error) *roachpb.Error {
 	txn := NewTxn(*db)
 	txn.SetDebugName("", 1)
-	return txn.exec(retryable)
+	return txn.Exec(TxnExecOptions{AutoRetry: true, AutoCommit: true},
+		func(txn *Txn, _ *TxnExecOptions) *roachpb.Error {
+			return retryable(txn)
+		})
 }
 
 // send runs the specified calls synchronously in a single batch and returns

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -364,6 +364,7 @@ func TestCommonMethods(t *testing.T) {
 		key{txnType, "DebugName"}:                 {},
 		key{txnType, "InternalSetPriority"}:       {},
 		key{txnType, "NewBatch"}:                  {},
+		key{txnType, "Exec"}:                      {},
 		key{txnType, "Run"}:                       {},
 		key{txnType, "RunWithResponse"}:           {},
 		key{txnType, "SetDebugName"}:              {},

--- a/client/txn.go
+++ b/client/txn.go
@@ -416,45 +416,88 @@ func endTxnReq(commit bool, deadline *roachpb.Timestamp, hasTrigger bool) roachp
 	return req
 }
 
-func (txn *Txn) exec(retryable func(txn *Txn) *roachpb.Error) *roachpb.Error {
-	// Run retryable in a retry loop until we encounter a success or
+// TxnExecOptions controls how Exec() runs a transaction and the corresponding
+// closure.
+type TxnExecOptions struct {
+	// If set, the transaction is automatically aborted if the closure returns any
+	// error aside from recoverable internal errors, in which case the closure is
+	// retried. The retryable function should have no side effects which could
+	// cause problems in the event it must be run more than once.
+	// If not set, all errors cause the txn to be aborted.
+	AutoRetry bool
+	// If set, then the txn is automatically committed if no errors are
+	// encountered. If not set, committing or leaving open the txn is the
+	// responsibility of the client.
+	AutoCommit bool
+}
+
+// Exec executes fn in the context of a distributed transaction.
+// Execution is controlled by opt (see comments in TxnExecOptions).
+//
+// opt is passed to fn, and it's valid for fn to modify opt as it sees
+// fit during each execution attempt.
+//
+// It's valid for txn to be nil (meaning the txn has already aborted) if fn
+// can handle that. This is useful for continuing transactions that have been
+// aborted because of an error in a previous batch of statements in the hope
+// that a ROLLBACK will reset the state. Neither opt.AutoRetry not opt.AutoCommit
+// can be set in this case.
+//
+// If an error is returned, the txn has been aborted.
+func (txn *Txn) Exec(
+	opt TxnExecOptions,
+	fn func(txn *Txn, opt *TxnExecOptions) *roachpb.Error) *roachpb.Error {
+	// Run fn in a retry loop until we encounter a success or
 	// error condition this loop isn't capable of handling.
 	var pErr *roachpb.Error
-	for r := retry.Start(txn.db.txnRetryOptions); r.Next(); {
-		pErr = retryable(txn)
-		if pErr == nil && txn.Proto.Status == roachpb.PENDING {
-			// retryable succeeded, but didn't commit.
+	var retryOptions retry.Options
+	if txn == nil && (opt.AutoRetry || opt.AutoCommit) {
+		panic("asked to retry  or commit a txn that is already aborted")
+	}
+	if opt.AutoRetry {
+		retryOptions = txn.db.txnRetryOptions
+	}
+RetryLoop:
+	for r := retry.Start(retryOptions); r.Next(); {
+		pErr = fn(txn, &opt)
+		if (pErr == nil) && opt.AutoCommit && (txn.Proto.Status == roachpb.PENDING) {
+			// fn succeeded, but didn't commit.
 			pErr = txn.commit(nil)
 		}
 
-		if pErr != nil {
-			// Make sure the txn record that pErr carries is for this txn.
-			// We check only when txn.Proto.ID has been initialized after an initial successful send.
-			if pErr.GetTxn() != nil && txn.Proto.ID != nil {
-				if errTxn := pErr.GetTxn(); !errTxn.Equal(&txn.Proto) {
-					return roachpb.NewErrorf("mismatching transaction record in the error:\n%s\nv.s.\n%s",
-						errTxn, txn.Proto)
-				}
-			}
-
-			switch pErr.TransactionRestart {
-			case roachpb.TransactionRestart_IMMEDIATE:
-				if log.V(2) {
-					log.Warning(pErr)
-				}
-				r.Reset()
-				continue
-			case roachpb.TransactionRestart_BACKOFF:
-				if log.V(2) {
-					log.Warning(pErr)
-				}
-				continue
-			}
-			// By default, fall through and break.
+		if pErr == nil {
+			break
 		}
-		break
+
+		// Make sure the txn record that pErr carries is for this txn.
+		// We check only when txn.Proto.ID has been initialized after an initial successful send.
+		if pErr.GetTxn() != nil && txn.Proto.ID != nil {
+			if errTxn := pErr.GetTxn(); !errTxn.Equal(&txn.Proto) {
+				return roachpb.NewErrorf("mismatching transaction record in the error:\n%s\nv.s.\n%s",
+					errTxn, txn.Proto)
+			}
+		}
+
+		if !opt.AutoRetry {
+			break RetryLoop
+		}
+		switch pErr.TransactionRestart {
+		case roachpb.TransactionRestart_IMMEDIATE:
+			r.Reset()
+		case roachpb.TransactionRestart_BACKOFF:
+		default:
+			break RetryLoop
+		}
+		if log.V(2) {
+			log.Infof("automatically retrying transaction: %s because of error: %s",
+				txn.DebugName(), pErr)
+		}
 	}
-	txn.Cleanup(pErr)
+	if txn != nil {
+		// TODO(andrei): don't do Cleanup() on retriable errors here.
+		// Let the sql executor do it.
+		txn.Cleanup(pErr)
+	}
 	return pErr
 }
 

--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -347,6 +347,8 @@ func NewTransactionAbortedError() *TransactionAbortedError {
 // NewTransactionPushError initializes a new TransactionPushError.
 // The argument is copied.
 func NewTransactionPushError(pusheeTxn Transaction) *TransactionPushError {
+	// Note: this error will cause a txn restart. The error that the client
+	// receives contains a txn that might have a modified priority.
 	return &TransactionPushError{PusheeTxn: pusheeTxn.Clone()}
 }
 

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -143,8 +143,9 @@ func TestAdminAPIDatabases(t *testing.T) {
 	const testdb = "test"
 	var session sql.Session
 	query := "CREATE DATABASE " + testdb
-	if _, _, err := s.sqlExecutor.ExecuteStatements("root", session, query, nil); err != nil {
-		t.Fatal(err)
+	createRes := s.sqlExecutor.ExecuteStatements("root", &session, query, nil)
+	if createRes.ResultList[0].PErr != nil {
+		t.Fatal(createRes.ResultList[0].PErr)
 	}
 
 	type databasesResult struct {
@@ -172,8 +173,9 @@ func TestAdminAPIDatabases(t *testing.T) {
 	privileges := []string{"SELECT", "UPDATE"}
 	testuser := "testuser"
 	grantQuery := "GRANT " + strings.Join(privileges, ", ") + " ON DATABASE " + testdb + " TO " + testuser
-	if _, _, err := s.sqlExecutor.ExecuteStatements("root", session, grantQuery, nil); err != nil {
-		t.Fatal(err)
+	grantRes := s.sqlExecutor.ExecuteStatements("root", &session, grantQuery, nil)
+	if grantRes.ResultList[0].PErr != nil {
+		t.Fatal(grantRes.ResultList[0].PErr)
 	}
 
 	type databaseDetailsResult struct {

--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -181,9 +181,12 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	}
 	tableDesc := desc.GetTable()
 
-	_, i, err := tableDesc.FindIndexByName("foo")
+	status, i, err := tableDesc.FindIndexByName("foo")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if status != sql.DescriptorActive {
+		t.Fatal("Index 'foo' is not active.")
 	}
 	indexPrefix := sql.MakeIndexKeyPrefix(tableDesc.ID, tableDesc.Indexes[i].ID)
 

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -13,6 +13,7 @@
 // permissions and limitations under the License.
 //
 // Author: Tamir Duberstein (tamird@gmail.com)
+// Author: Andrei Matei (andreimatei1@gmail.com)
 
 package sql
 
@@ -42,14 +43,14 @@ import (
 // TODO(radu): perhaps we should turn this on only for tests.
 const checkStmtStringChange = true
 
-var testingWaitForMetadata bool
+var testingWaitForGossipUpdate bool
 
-// TestingWaitForMetadata causes metadata-mutating operations to wait
+// TestingWaitForGossipUpdate causes metadata-mutating operations to wait
 // for the new metadata to back-propagate through gossip.
-func TestingWaitForMetadata() func() {
-	testingWaitForMetadata = true
+func TestingWaitForGossipUpdate() func() {
+	testingWaitForGossipUpdate = true
 	return func() {
-		testingWaitForMetadata = false
+		testingWaitForGossipUpdate = false
 	}
 }
 
@@ -57,12 +58,23 @@ var errNoTransactionInProgress = errors.New("there is no transaction in progress
 var errStaleMetadata = errors.New("metadata is still stale")
 var errTransactionInProgress = errors.New("there is already a transaction in progress")
 
+var defaultRetryOpt = retry.Options{
+	InitialBackoff: 20 * time.Millisecond,
+	MaxBackoff:     200 * time.Millisecond,
+	Multiplier:     2,
+}
+
+// Release through releasePlanner().
 var plannerPool = sync.Pool{
 	New: func() interface{} {
-		p := &planner{}
-		p.evalCtx.GetLocation = p.session.getLocation
-		return p
+		return makePlanner()
 	},
+}
+
+func releasePlanner(p *planner) {
+	// Ensure future users don't clobber the session just used.
+	p.session = nil
+	plannerPool.Put(p)
 }
 
 // Request is an SQL request to cockroach. A transaction can consist of multiple
@@ -72,7 +84,8 @@ type Request struct {
 	User string
 	// Session settings that were returned in the last response that
 	// contained them, being reflected back to the server.
-	Session Session
+	// This Session will be updated as part of executing this request.
+	Session *Session
 	// SQL statement(s) to be serially executed by the server. Multiple
 	// statements are passed as a single string separated by semicolons.
 	SQL string
@@ -82,13 +95,20 @@ type Request struct {
 
 // Response is the reply to an SQL request to cockroach.
 type Response struct {
-	// Setting that should be reflected back in all subsequent requests.
-	// When not set, future requests should continue to use existing settings.
-	Session Session
-	// The list of results. There is one result object per SQL statement in the
-	// request.
-	Results []Result
+	// Settings that should be reflected back in all subsequent requests.
+	// Immutable.
+	Session *Session
+	Results StatementResults
+}
 
+// ResultList represents a list of results for a list of SQL statements.
+// There is one result object per SQL statement in the request.
+type ResultList []Result
+
+// StatementResults represents a list of results from running a batch of
+// SQL statements, plus some meta info about the batch.
+type StatementResults struct {
+	ResultList
 	// Indicates that after parsing, the request contained 0 non-empty statements.
 	Empty bool
 }
@@ -128,6 +148,7 @@ type ResultRow struct {
 }
 
 // An Executor executes SQL statements.
+// Executor is thread-safe.
 type Executor struct {
 	db       client.DB
 	nodeID   roachpb.NodeID
@@ -152,9 +173,12 @@ type Executor struct {
 	miscCount        *metric.Counter
 
 	// System Config and mutex.
-	systemConfig     config.SystemConfig
-	databaseCache    *databaseCache
-	systemConfigMu   sync.RWMutex
+	systemConfig   config.SystemConfig
+	databaseCache  *databaseCache
+	systemConfigMu sync.RWMutex
+	// This uses systemConfigMu in RLocker mode to not block
+	// execution of statements. So don't go on changing state after you've
+	// Wait()ed on it.
 	systemConfigCond *sync.Cond
 }
 
@@ -180,7 +204,7 @@ func NewExecutor(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, st
 		ddlCount:         registry.Counter("ddl.count"),
 		miscCount:        registry.Counter("misc.count"),
 	}
-	exec.systemConfigCond = sync.NewCond(&exec.systemConfigMu)
+	exec.systemConfigCond = sync.NewCond(exec.systemConfigMu.RLocker())
 
 	gossipUpdateC := gossip.RegisterSystemConfigChannel()
 	stopper.RunWorker(func() {
@@ -227,12 +251,12 @@ func (e *Executor) getSystemConfig() (config.SystemConfig, *databaseCache) {
 }
 
 // initializeTxn initialize a Txn using the session defaults.
-func (e *Executor) initializeTxn(txn *client.Txn, s Session) {
+func (e *Executor) initializeTxn(txn *client.Txn, s *Session) {
 	txn.Proto.Isolation = s.DefaultIsolationLevel
 }
 
 // newTxn creates a new Txn and initializes it using the session defaults.
-func (e *Executor) newTxn(s Session) *client.Txn {
+func (e *Executor) newTxn(s *Session) *client.Txn {
 	txn := client.NewTxn(e.db)
 	e.initializeTxn(txn, s)
 	return txn
@@ -241,23 +265,22 @@ func (e *Executor) newTxn(s Session) *client.Txn {
 // Prepare returns the result types of the given statement. Args may be a
 // partially populated val args map. Prepare will populate the missing val
 // args. The column result types are returned (or nil if there are no results).
-func (e *Executor) Prepare(user string, query string, session Session, args parser.MapArgs) ([]ResultColumn, *roachpb.Error) {
+func (e *Executor) Prepare(user string, query string, session *Session, args parser.MapArgs) (
+	[]ResultColumn, *roachpb.Error) {
 	stmt, err := parser.ParseOne(query, parser.Syntax(session.Syntax))
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}
 	planMaker := plannerPool.Get().(*planner)
-	defer plannerPool.Put(planMaker)
+	defer releasePlanner(planMaker)
 
 	cfg, cache := e.getSystemConfig()
 	*planMaker = planner{
 		user: user,
 		evalCtx: parser.EvalContext{
-			NodeID:  e.nodeID,
-			ReCache: e.reCache,
-			// Copy existing GetLocation closure. See plannerPool.New() for the
-			// initial setting.
-			GetLocation: planMaker.evalCtx.GetLocation,
+			NodeID:      e.nodeID,
+			ReCache:     e.reCache,
+			GetLocation: session.getLocation,
 			Args:        args,
 		},
 		leaseMgr:      e.leaseMgr,
@@ -286,21 +309,145 @@ func (e *Executor) Prepare(user string, query string, session Session, args pars
 	return cols, nil
 }
 
+type schemaChangerCollection struct {
+	// The index of the current statement, relative to its group. For statements
+	// statements that have been received from the client in the same batch, the
+	// group consists of all statements in the same transaction.
+	curStatementIdx int
+	// schema change callbacks together with the index of the statement
+	// that enqueued it (within its group of statements).
+	// TODO(andrei): Schema changers enqueued in a txn are not restored
+	// if the txn is not COMMITTED in the same group of statements (#4428).
+	schemaChangers []struct {
+		idx int
+		sc  SchemaChanger
+	}
+}
+
+func (scc *schemaChangerCollection) queueSchemaChanger(
+	schemaChanger SchemaChanger) {
+	scc.schemaChangers = append(
+		scc.schemaChangers,
+		struct {
+			idx int
+			sc  SchemaChanger
+		}{scc.curStatementIdx, schemaChanger})
+}
+
+// execSchemaChanges releases schema leases and runs the queued
+// schema changers. This needs to be run after the transaction
+// scheduling the schema change has finished.
+//
+// The list of closures is cleared after (attempting) execution.
+//
+// Args:
+//  results: The results from all statements in the group that scheduled the
+//    schema changes we're about to execute. Results corresponding to the
+//    schema change statements will be changed in case an error occurs.
+func (scc *schemaChangerCollection) execSchemaChanges(
+	e *Executor, planMaker *planner, results ResultList) {
+	if planMaker.txn != nil {
+		panic("trying to execute schema changes while still in a transaction")
+	}
+	// Release the leases once a transaction is complete.
+	planMaker.releaseLeases(e.db)
+	if len(scc.schemaChangers) == 0 ||
+		// Disable execution in some tests.
+		disableSyncSchemaChangeExec {
+		return
+	}
+	// Execute any schema changes that were scheduled, in the order of the
+	// statements that scheduled them.
+	retryOpt := defaultRetryOpt
+	for _, scEntry := range scc.schemaChangers {
+		sc := &scEntry.sc
+		sc.db = e.db
+		for r := retry.Start(retryOpt); r.Next(); {
+			if done, err := sc.IsDone(); err != nil {
+				log.Warning(err)
+				break
+			} else if done {
+				break
+			}
+			if pErr := sc.exec(); pErr != nil {
+				if _, ok := pErr.GetDetail().(*roachpb.ExistingSchemaChangeLeaseError); ok {
+					// Try again.
+					continue
+				}
+				// All other errors can be reported; we report it as the result
+				// corresponding to the statement that enqueued this changer.
+				// There's some sketchiness here: we assume there's a single result
+				// per statement and we clobber the result/error of the corresponding
+				// statement.
+				results[scEntry.idx] = Result{PErr: pErr}
+			}
+			break
+		}
+	}
+	scc.schemaChangers = scc.schemaChangers[:0]
+}
+
+// txnState contains state associated with an ongoing SQL txn.
+// There may or may not be an open KV txn associated with the SQL txn.
+// For interactive transactions (open across batches of SQL commands sent by a
+// user, txnState is intended to be serialized/deserialized as part of a user
+// Session.
+// The state is as follows:
+// - if aborted is set, the sql txn is in a mode where it rejects every
+// statement until a COMMIT/ROLLBACK, after which there will be no more
+// transaction to speak of.
+// In the future there might be a difference between txn being nil or not,
+// signaling whether the user can retry the transaction.
+// - if aborted is not set and txn is nil, it means that the SQL transaction is
+// done (COMMIT/ROLLBACK).
+// - if aborted is not set and txn != nil, the SQL transaction is open, as is
+// the KV txn.
+type txnState struct {
+	txn *client.Txn
+	// true if we were inside a txn at some point and that txn was aborted. We
+	// need to reject every subsequent statement.
+	aborted bool
+	// Timestamp to be used by SQL (transaction_timestamp()) in the above
+	// transaction.
+	txnTimestamp time.Time
+	// The schema change closures to run when this txn is done.
+	schemaChangers schemaChangerCollection
+}
+
+type transactionState int
+
+const (
+	noTransaction transactionState = iota
+	openTransaction
+	abortedTransaction // waiting for COMMIT/ROLLBACK
+)
+
+func (s *txnState) state() transactionState {
+	if s.aborted {
+		return abortedTransaction
+	}
+	if s.txn == nil {
+		return noTransaction
+	}
+	return openTransaction
+}
+
 // ExecuteStatements executes the given statement(s) and returns a response.
 // On error, the returned integer is an HTTP error code.
-func (e *Executor) ExecuteStatements(user string, session Session, stmts string, params []parser.Datum) (Response, int, error) {
+func (e *Executor) ExecuteStatements(
+	user string, session *Session, stmts string,
+	params []parser.Datum) StatementResults {
+
 	planMaker := plannerPool.Get().(*planner)
-	defer plannerPool.Put(planMaker)
+	defer releasePlanner(planMaker)
 
 	cfg, cache := e.getSystemConfig()
 	*planMaker = planner{
 		user: user,
 		evalCtx: parser.EvalContext{
-			NodeID:  e.nodeID,
-			ReCache: e.reCache,
-			// Copy existing GetLocation closure. See plannerPool.New() for the
-			// initial setting.
-			GetLocation: planMaker.evalCtx.GetLocation,
+			NodeID:      e.nodeID,
+			ReCache:     e.reCache,
+			GetLocation: session.getLocation,
 		},
 		leaseMgr:      e.leaseMgr,
 		systemConfig:  cfg,
@@ -308,41 +455,52 @@ func (e *Executor) ExecuteStatements(user string, session Session, stmts string,
 		session:       session,
 	}
 
-	// Resume a pending transaction if present.
-	if planMaker.session.Txn != nil {
-		txn := e.newTxn(session)
-		txn.Proto = planMaker.session.Txn.Txn
-		txn.UserPriority = planMaker.session.Txn.UserPriority
-		if planMaker.session.MutatesSystemConfig {
-			txn.SetSystemConfigTrigger()
-		}
-		planMaker.setTxn(txn, planMaker.session.Txn.Timestamp.GoTime())
+	// Move the transaction state from the session to curTxnState, a struct
+	// that only lives for the duration of this request.
+	// If a pending transaction is present, it will be resumed.
+	curTxnState := txnState{
+		txn:          nil,
+		aborted:      false,
+		txnTimestamp: time.Time{},
 	}
+	txnProto := session.Txn.Txn
+	curTxnState.aborted = session.Txn.TxnAborted
+	if txnProto != nil {
+		curTxnState.txn = e.newTxn(session)
+		curTxnState.txn.Proto = *txnProto
+		curTxnState.txn.UserPriority = session.Txn.UserPriority
+		if session.Txn.MutatesSystemConfig {
+			curTxnState.txn.SetSystemConfigTrigger()
+		}
+		curTxnState.txnTimestamp = session.Txn.TxnTimestamp.GoTime()
+	}
+	session.Txn = Session_Transaction{}
 
 	// Send the Request for SQL execution and set the application-level error
 	// for each result in the reply.
 	planMaker.params = parameters(params)
-	reply := e.execStmts(stmts, planMaker)
+	res := e.execRequest(&curTxnState, stmts, planMaker)
 
 	// Send back the session state even if there were application-level errors.
 	// Add transaction to session state.
-	if planMaker.txn != nil {
-		// TODO(pmattis): Need to record the leases used by a transaction within
-		// the transaction state and restore it when the transaction is restored.
+	if curTxnState.txn != nil {
+		// TODO(pmattis): Need to associate the leases used by a transaction with
+		// the session state.
 		planMaker.releaseLeases(e.db)
-		planMaker.session.Txn = &Session_Transaction{
-			Txn:          planMaker.txn.Proto,
-			Timestamp:    driver.Timestamp(planMaker.evalCtx.TxnTimestamp.Time),
-			UserPriority: planMaker.txn.UserPriority,
+		session.Txn = Session_Transaction{
+			Txn:          &curTxnState.txn.Proto,
+			TxnTimestamp: driver.Timestamp(curTxnState.txnTimestamp),
+			UserPriority: curTxnState.txn.UserPriority,
 		}
-		planMaker.session.MutatesSystemConfig = planMaker.txn.SystemConfigTrigger()
+		session.Txn.MutatesSystemConfig = curTxnState.txn.SystemConfigTrigger()
+		session.Txn.TxnAborted = curTxnState.aborted
 	} else {
-		planMaker.session.Txn = nil
-		planMaker.session.MutatesSystemConfig = false
+		session.Txn.Txn = nil
+		session.Txn.TxnAborted = curTxnState.aborted
+		session.Txn.MutatesSystemConfig = false
 	}
-	reply.Session = planMaker.session
 
-	return reply, 0, nil
+	return res
 }
 
 // Execute the statement(s) in the given request and returns a response.
@@ -351,78 +509,167 @@ func (e *Executor) Execute(args Request) (Response, int, error) {
 	defer func(start time.Time) {
 		e.latency.RecordValue(time.Now().Sub(start).Nanoseconds())
 	}(time.Now())
-	return e.ExecuteStatements(args.User, args.Session, args.SQL, args.Params)
+	results := e.ExecuteStatements(
+		args.User, args.Session, args.SQL, args.Params)
+	return Response{Results: results, Session: args.Session}, 0, nil
 }
 
-// exec executes the request. Any error encountered is returned; it is
-// the caller's responsibility to update the response.
-func (e *Executor) execStmts(sql string, planMaker *planner) Response {
-	var resp Response
+// execRequest executes the request using the provided planner.
+// It parses the sql into statements, iterates through the statements, creates
+// KV transactions and automatically retries them when possible, executes the
+// (synchronous attempt of) schema changes.
+// It will accumulate a result in Response for each statement.
+// It will resume a SQL transaction, if one was previously open for this client.
+//
+// execRequest handles the mismatch between the SQL interface that the Executor
+// provides, based on statements being streamed from the client in the context
+// of a session, and the KV client.Txn interface, based on (possibly-retriable)
+// callbacks passed to be executed in the context of a transaction. Actual
+// execution of statements in the context of a KV txn is delegated to
+// runTxnAttempt().
+//
+// Args:
+//  txnState: State about about ongoing transaction (if any). The state will be
+//   updated.
+func (e *Executor) execRequest(
+	txnState *txnState, sql string, planMaker *planner) StatementResults {
+	var res StatementResults
 	stmts, err := planMaker.parser.Parse(sql, parser.Syntax(planMaker.session.Syntax))
 	if err != nil {
+		pErr := roachpb.NewError(err)
 		// A parse error occurred: we can't determine if there were multiple
 		// statements or only one, so just pretend there was one.
-		resp.Results = append(resp.Results, makeResultFromError(planMaker, roachpb.NewError(err)))
-		return resp
+		if txnState.txn != nil {
+			// Rollback the txn.
+			txnState.txn.Cleanup(pErr)
+			txnState.aborted = true
+			txnState.txn = nil
+		}
+		res.ResultList = append(res.ResultList, Result{PErr: pErr})
+		return res
 	}
 	if len(stmts) == 0 {
-		resp.Empty = true
-		return resp
+		res.Empty = true
+		return res
 	}
 
-	for _, stmt := range stmts {
-		var stmtStrBefore string
-		if checkStmtStringChange {
-			stmtStrBefore = stmt.String()
-		}
-		result, err := e.execStmt(stmt, planMaker)
-		if checkStmtStringChange {
-			after := stmt.String()
-			if after != stmtStrBefore {
-				panic(fmt.Sprintf("statement changed after exec; before:\n    %s\nafter:\n    %s",
-					stmtStrBefore, after))
-			}
-		}
-		if err != nil {
-			result = makeResultFromError(planMaker, err)
-		}
-		// Release the leases once a transaction is complete.
-		if planMaker.txn == nil {
-			planMaker.releaseLeases(e.db)
-			// Execute any schema changes that were scheduled.
-			if len(planMaker.schemaChangers) > 0 &&
-				// Disable execution in some tests.
-				!disableSyncSchemaChangeExec {
-				retryOpts := retry.Options{
-					InitialBackoff: 20 * time.Millisecond,
-					MaxBackoff:     200 * time.Millisecond,
-					Multiplier:     2,
-				}
-				for _, sc := range planMaker.schemaChangers {
-					sc.db = e.db
-					for r := retry.Start(retryOpts); r.Next(); {
-						if done, err := sc.IsDone(); err != nil {
-							log.Warning(err)
-							break
-						} else if done {
-							break
-						}
-						if pErr := sc.exec(); pErr != nil {
-							if _, ok := pErr.GetDetail().(*roachpb.ExistingSchemaChangeLeaseError); ok {
-								// Try again.
-								continue
-							}
-							// All other errors can be reported.
-							result = makeResultFromError(planMaker, pErr)
-						}
-						break
-					}
-				}
-			}
-		}
-		resp.Results = append(resp.Results, result)
+	if testingWaitForGossipUpdate {
+		// We might need to verify metadata. Lock the system config so that no
+		// gossip updates sneak in under us. The point is to be able to assert
+		// that the verify callback only succeeds after a gossip update.
+		//
+		// This lock does not change semantics. Even outside of tests, the
+		// planner is initialized with a static systemConfig, so locking
+		// the Executor's systemConfig cannot change the semantics of the
+		// SQL operation being performed under lock.
+		//
+		// The case of a multi-request transaction is not handled here,
+		// because those transactions outlive the verification callback.
+		// TODO(andrei): consider putting this callback on the Session, not
+		// on the executor, after Session is not a proto any more. Also, #4646.
+		e.systemConfigCond.L.Lock()
+		defer func() {
+			e.systemConfigCond.L.Unlock()
+		}()
 	}
-	return resp
+
+	for len(stmts) > 0 {
+		// Each iteration consumes a transaction's worth of statements.
+
+		inTxn := txnState.state() != noTransaction
+		var execOpt client.TxnExecOptions
+		// Figure out the statements out of which we're going to try to consume
+		// this iteration. If we need to create an implicit txn, only one statement
+		// can be consumed.
+		stmtsToExec := stmts
+		// We can AutoRetry the next batch of statements if we're in a clean state
+		// (i.e. the next statements we're going to see are the first statements in
+		// a transaction).
+		if !inTxn {
+			// Detect implicit transactions.
+			if _, isBegin := stmts[0].(*parser.BeginTransaction); !isBegin {
+				execOpt.AutoCommit = true
+				stmtsToExec = stmtsToExec[0:1]
+			}
+			txnState.txn = e.newTxn(planMaker.session)
+			execOpt.AutoRetry = true
+			txnState.txnTimestamp = time.Now()
+			txnState.txn.SetDebugName(fmt.Sprintf("sql implicit: %t", execOpt.AutoCommit), 0)
+		}
+		if txnState.state() == noTransaction {
+			panic("we failed to initialize a txn")
+		}
+		// Now actually run some statements.
+		var remainingStmts parser.StatementList
+		var results []Result
+		origAborted := txnState.state() == abortedTransaction
+
+		txnClosure := func(txn *client.Txn, opt *client.TxnExecOptions) *roachpb.Error {
+			return runTxnAttempt(e, planMaker, origAborted, txnState, txn, opt, stmtsToExec,
+				&results, &remainingStmts)
+		}
+		// This is where the magic happens - we ask db to run a KV txn and possibly retry it.
+		pErr := txnState.txn.Exec(execOpt, txnClosure)
+		res.ResultList = append(res.ResultList, results...)
+		// Now make sense of the state we got into and update txnState.
+		if pErr != nil {
+			// If we got an error, the txn has been aborted (or it might be already
+			// done if the error was encountered when executing the COMMIT/ROLLBACK.
+			// There's nothing we can use it for any more.
+			// TODO(andrei): once txn.Exec() doesn't abort retriable txns any more,
+			// we need to be more nuanced here.
+			txnState.txn = nil
+			e.txnAbortCount.Inc(1)
+		}
+		if execOpt.AutoCommit {
+			// If execOpt.AutoCommit was set, then the txn no longer exists at this point.
+			txnState.txn = nil
+			txnState.aborted = false
+		}
+		// If the txn is in a final state (committed, rolled back or aborted), exec
+		// the schema changes.
+		if txnState.state() != openTransaction {
+			planMaker.releaseLeases(e.db)
+			// Exec the schema changers (if the txn rolled back, the schema changers
+			// will short-circuit because the corresponding descriptor mutation is not
+			// found).
+			txnState.schemaChangers.execSchemaChanges(e, planMaker, res.ResultList)
+			stmtsExecuted := stmts[0 : len(stmtsToExec)-len(remainingStmts)]
+			e.checkTestingWaitForGossipUpdateOrDie(planMaker, stmtsExecuted)
+		}
+
+		// Figure out what statements to run on the next iteration.
+		if pErr != nil {
+			// Don't execute anything further.
+			stmts = nil
+		} else if execOpt.AutoCommit {
+			stmts = stmts[1:]
+		} else {
+			stmts = remainingStmts
+		}
+	}
+
+	return res
+}
+
+func (e *Executor) checkTestingWaitForGossipUpdateOrDie(
+	planMaker *planner, stmts parser.StatementList) {
+	if testingWaitForGossipUpdate {
+		if verify := planMaker.testingVerifyMetadata; verify != nil {
+			// In the case of a multi-statement request, avoid reusing this
+			// callback.
+			planMaker.testingVerifyMetadata = nil
+			first := true
+			for verify(e.systemConfig) != nil {
+				first = false
+				e.systemConfigCond.Wait()
+			}
+			if first {
+				panic(fmt.Sprintf(
+					"expected %q to require a gossip update, but it did not", stmts))
+			}
+		}
+	}
 }
 
 // If the plan is a returningNode we can just use the `rowCount`,
@@ -438,150 +685,244 @@ func countRowsAffected(p planNode) int {
 	return count
 }
 
-func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (Result, *roachpb.Error) {
-	var result Result
+// runTxnAttempt is the closure we pass to txn.Exec(). It will be called
+// possibly multiple times (if opt.AutoRetry is set).
+// It sets up a planner and delegates execution of statements to
+// execStmtsInCurrentTxn().
+func runTxnAttempt(
+	e *Executor, planMaker *planner, origAborted bool, txnState *txnState,
+	txn *client.Txn, opt *client.TxnExecOptions,
+	stmts parser.StatementList,
+	// return values
+	results *[]Result, remainingStmts *parser.StatementList) *roachpb.Error {
 
+	if txnState.txn != txn {
+		panic("runTxnAttempt wasn't called in the txn we set up for it")
+	}
+	// Ignore the abort status that might have been set by a previous try
+	// of this closure.
+	txnState.aborted = origAborted
+	*results = nil
+	// (re)init the schemaChangers.
+	// TODO(andrei): figure out how to persist schema changers across
+	// different batches of statements in the same txn.
+	txnState.schemaChangers = schemaChangerCollection{}
+	planMaker.schemaChangeCallback = txnState.schemaChangers.queueSchemaChanger
+
+	planMaker.setTxn(txn, txnState.txnTimestamp)
+	var pErr *roachpb.Error
+	*results, *remainingStmts, pErr = e.execStmtsInCurrentTxn(
+		stmts, planMaker, txnState,
+		opt.AutoCommit /* implicitTxn */, opt.AutoRetry /* txnBeginning */)
+	if opt.AutoCommit && len(*remainingStmts) > 0 {
+		panic("implicit txn failed to execute all stmts")
+	}
+	planMaker.resetTxn()
+	return pErr
+}
+
+// execStmtsInCurrentTransaction consumes a prefix of stmts, namely the
+// statements belonging to a single SQL transaction. It executes in the
+// planner's transaction, which is assumed to exist.
+//
+// COMMIT/ROLLBACK statements can end the current transaction. If that happens,
+// this method returns, and the remaining statements are returned.
+//
+// If an error occurs while executing a statement, the SQL txn will be
+// considered aborted and subsequent statements will be discarded (they will
+// not be executed, they will not be returned for future execution, they will
+// not generate results). Note that this also includes COMMIT/ROLLBACK
+// statements. Further note that SqlTransactionAbortedError is no exception -
+// encountering it will discard subsequent statements. This means that, to
+// recover from an aborted txn, a COMMIT/ROLLBACK statement needs to be the
+// first one in stmts.
+//
+// Args:
+//  txnState: Specifies whether we're executing inside a txn, or inside an aborted txn.
+//    The state is updated.
+//  implicitTxn: set if the current transaction was implicitly
+//    created by the system (i.e. the client sent the statement outside of
+//    a transaction).
+// Returns:
+//  - the list of results (one per executed statement).
+//  - the statements that haven't been executed because the transaction has
+//    been committed or rolled back. In returning an error, this will be nil.
+//  - the error encountered while executing statements, if any. If an error
+//    occurred, it is also the last result returned. Subsequent statements
+//    have not been executed.
+func (e *Executor) execStmtsInCurrentTxn(
+	stmts parser.StatementList, planMaker *planner,
+	txnState *txnState,
+	implicitTxn bool, txnBeginning bool) (
+	[]Result, parser.StatementList, *roachpb.Error) {
+	var results []Result
+	if planMaker.txn == nil && txnState.state() != abortedTransaction {
+		panic("execStmtsInCurrentTransaction called outside of a txn")
+	}
+	for i, stmt := range stmts {
+		if log.V(2) {
+			log.Infof("about to execute sql statement (%d/%d): %s", i+1, len(stmts), stmt)
+		}
+		txnState.schemaChangers.curStatementIdx = i
+		// For implicit transactions, the transaction timestamp is also
+		// used as the statement_transaction() too.
+		stmtTimestamp := planMaker.evalCtx.TxnTimestamp
+		if !implicitTxn {
+			stmtTimestamp = parser.DTimestamp{Time: time.Now()}
+		}
+		var stmtStrBefore string
+		if checkStmtStringChange {
+			stmtStrBefore = stmt.String()
+		}
+		res, pErr, txnDone := e.execStmtInCurrentTransaction(
+			stmt, planMaker,
+			txnState.aborted, implicitTxn,
+			txnBeginning && (i == 0), /* firstInTxn */
+			stmtTimestamp)
+		if checkStmtStringChange {
+			after := stmt.String()
+			if after != stmtStrBefore {
+				panic(fmt.Sprintf("statement changed after exec; before:\n    %s\nafter:\n    %s",
+					stmtStrBefore, after))
+			}
+		}
+		if pErr != nil {
+			results = append(results, Result{PErr: pErr})
+			txnState.aborted = true
+			return results, nil, pErr
+		}
+		results = append(results, res)
+		if txnDone {
+			// If the transaction is done, return the remaining statements to
+			// be executed as a different group.
+			txnState.aborted = false
+			txnState.txn = nil
+			return results, stmts[i+1:], nil
+		}
+	}
+	return results, nil, nil
+}
+
+// execStmtInCurrentTransaction executes one statement in the context
+// of the planner's transaction (which is assumed to exist).
+// It handles statements that affect the transaction state (BEGIN, COMMIT)
+// and delegates everything else to `execStmt`.
+// It binds placeholders.
+// It also handles the Executor's "aborted mode", where it short-circuits execution if
+// the current transaction has been aborted.
+//
+// The current transaction might be committed/rolled back when this returns.
+//
+// Args:
+// abortedMode: if set, we're in a transaction that has encountered errors, so we
+//  must reject the statement unless it's a COMMIT/ROLLBACK.
+// implicitTxn: set if the current transaction was implicitly
+//  created by the system (i.e. the client sent the statement outside of
+//  a transaction).
+//  COMMIT/ROLLBACK statements are rejected if set. Also, the transaction
+//  might be auto-committed in this function.
+// firstInTxn: set for the first statement in a transaction. Used
+//  so that nested BEGIN statements are caught.
+// stmtTimestamp: Used as the statement_timestamp().
+//
+// Returns:
+// - a Result
+// - an error, if any
+// - a bool indicating whether the SQL txn is done (set) or not.
+func (e *Executor) execStmtInCurrentTransaction(
+	stmt parser.Statement, planMaker *planner,
+	abortedMode bool,
+	implicitTxn bool,
+	firstInTxn bool,
+	stmtTimestamp parser.DTimestamp) (Result, *roachpb.Error, bool) {
+	// Short-circuit if we're in aborted mode.
+	if abortedMode {
+		switch stmt.(type) {
+		case *parser.CommitTransaction, *parser.RollbackTransaction:
+			// Reset the state to allow new transactions to start.
+			// Note: postgres replies to COMMIT of failed txn with "ROLLBACK" too.
+			result := Result{PGTag: (*parser.RollbackTransaction)(nil).StatementTag()}
+			return result, nil, true
+		default:
+			return Result{}, roachpb.NewError(&roachpb.SqlTransactionAbortedError{}), false
+		}
+	}
+
+	if planMaker.txn == nil {
+		panic("running execStmtInCurrentTransaction outside of a transaction")
+	}
+
+	planMaker.evalCtx.StmtTimestamp = stmtTimestamp
+
+	// TODO(cdo): Figure out how to not double count on retries.
 	e.updateStmtCounts(stmt)
 	switch stmt.(type) {
 	case *parser.BeginTransaction:
-		if planMaker.txn != nil {
-			return result, roachpb.NewError(errTransactionInProgress)
+		if !firstInTxn {
+			return Result{}, roachpb.NewError(errTransactionInProgress), false
 		}
-		// Start a transaction here and not in planMaker to prevent begin
-		// transaction from being called within an auto-transaction below.
-		planMaker.setTxn(e.newTxn(planMaker.session), time.Now())
-		planMaker.txn.SetDebugName("sql", 0)
 	case *parser.CommitTransaction, *parser.RollbackTransaction:
-		if planMaker.txn == nil {
-			return result, roachpb.NewError(errNoTransactionInProgress)
-		} else if planMaker.txn.Proto.Status == roachpb.ABORTED {
-			// Reset to allow starting a new transaction.
-			planMaker.resetTxn()
-			// NB: postgres replies to COMMIT of failed txn with "ROLLBACK" too.
-			result.PGTag = (*parser.RollbackTransaction)(nil).StatementTag()
-			return result, nil
+		if implicitTxn {
+			return Result{}, roachpb.NewError(errNoTransactionInProgress), false
 		}
 	case *parser.SetTransaction:
-		if planMaker.txn == nil {
-			return result, roachpb.NewError(errNoTransactionInProgress)
-		}
-	default:
-		if planMaker.txn != nil && planMaker.txn.Proto.Status == roachpb.ABORTED {
-			return result, roachpb.NewError(&roachpb.SqlTransactionAbortedError{})
+		if implicitTxn {
+			return Result{}, roachpb.NewError(errNoTransactionInProgress), false
 		}
 	}
 
 	// Bind all the placeholder variables in the stmt to actual values.
 	stmt, err := parser.FillArgs(stmt, &planMaker.params)
 	if err != nil {
-		return result, roachpb.NewError(err)
+		return Result{}, roachpb.NewError(err), false
 	}
 
-	// Create a function which both makes and executes the plan, populating
-	// result.
-	//
-	// TODO(pmattis): Should this be a separate function? Perhaps we should move
-	// some of the common code back out into execStmts and have execStmt contain
-	// only the body of this closure.
-	f := func(timestamp time.Time, autoCommit bool) *roachpb.Error {
-		planMaker.evalCtx.StmtTimestamp = parser.DTimestamp{Time: timestamp}
-		plan, pErr := planMaker.makePlan(stmt, autoCommit)
-		if pErr != nil {
-			return pErr
-		}
+	result, pErr := e.execStmt(stmt, planMaker, time.Now(),
+		implicitTxn /* autoCommit */)
+	txnDone := planMaker.txn == nil
+	return result, pErr, txnDone
+}
 
-		result.PGTag = stmt.StatementTag()
-		result.Type = stmt.StatementType()
-
-		switch result.Type {
-		case parser.RowsAffected:
-			result.RowsAffected += countRowsAffected(plan)
-
-		case parser.Rows:
-			result.Columns = plan.Columns()
-			for _, c := range result.Columns {
-				if err := checkResultDatum(c.Typ); err != nil {
-					return roachpb.NewError(err)
-				}
-			}
-
-			for plan.Next() {
-				// The plan.Values DTuple needs to be copied on each iteration.
-				values := plan.Values()
-				row := ResultRow{Values: make([]parser.Datum, 0, len(values))}
-				for _, val := range values {
-					if err := checkResultDatum(val); err != nil {
-						return roachpb.NewError(err)
-					}
-					row.Values = append(row.Values, val)
-				}
-				result.Rows = append(result.Rows, row)
-			}
-		}
-
-		return plan.PErr()
-	}
-
-	// If there is a pending transaction.
-	if planMaker.txn != nil {
-		pErr := f(time.Now(), false)
-		if pErr != nil {
-			e.txnAbortCount.Inc(1)
-		}
+// the current transaction might have been committed/rolled back when this returns.
+func (e *Executor) execStmt(
+	stmt parser.Statement, planMaker *planner,
+	timestamp time.Time, autoCommit bool) (Result, *roachpb.Error) {
+	var result Result
+	plan, pErr := planMaker.makePlan(stmt, autoCommit)
+	if pErr != nil {
 		return result, pErr
 	}
 
-	if testingWaitForMetadata {
-		// We might need to verify metadata. Lock the system config so that
-		// no gossip updates sneak in under us.
-		// This lock does not change semantics. Even outside of tests, the
-		// planner is initialized with a static systemConfig, so locking
-		// the Executor's systemConfig cannot change the semantics of the
-		// SQL operation being performed under lock.
-		//
-		// The case of a multi-request transaction is not handled here,
-		// because those transactions outlive the verification callback.
-		// This can be addressed when we move to a connection-oriented
-		// protocol and server-side transactions.
-		e.systemConfigCond.L.Lock()
-		defer e.systemConfigCond.L.Unlock()
-	}
+	result.PGTag = stmt.StatementTag()
+	result.Type = stmt.StatementType()
 
-	// No transaction. Run the command as a retryable block in an
-	// auto-transaction.
-	if pErr := e.db.Txn(func(txn *client.Txn) *roachpb.Error {
-		e.initializeTxn(txn, planMaker.session)
-		// For transient stats, we do not report implicit transactions as part of txnCount.
-		timestamp := time.Now()
-		planMaker.setTxn(txn, timestamp)
-		pErr := f(timestamp, true)
-		planMaker.resetTxn()
-		return pErr
-	}); pErr != nil {
-		return result, pErr
-	}
+	switch result.Type {
+	case parser.RowsAffected:
+		result.RowsAffected += countRowsAffected(plan)
 
-	if testingWaitForMetadata {
-		if verify := planMaker.testingVerifyMetadata; verify != nil {
-			// In the case of a multi-statement request, avoid reusing this
-			// callback.
-			planMaker.testingVerifyMetadata = nil
-			for i := 0; ; i++ {
-				if verify(e.systemConfig) != nil {
-					e.systemConfigCond.Wait()
-				} else {
-					if i == 0 {
-						return result, roachpb.NewErrorf("expected %q to require a gossip update, but it did not", stmt)
-					} else if i > 1 {
-						log.Infof("%q unexpectedly required %d gossip updates", stmt, i)
-					}
-					break
-				}
+	case parser.Rows:
+		result.Columns = plan.Columns()
+		for _, c := range result.Columns {
+			if err := checkResultDatum(c.Typ); err != nil {
+				return result, roachpb.NewError(err)
 			}
+		}
+
+		for plan.Next() {
+			// The plan.Values DTuple needs to be copied on each iteration.
+			values := plan.Values()
+			row := ResultRow{Values: make([]parser.Datum, 0, len(values))}
+			for _, val := range values {
+				if err := checkResultDatum(val); err != nil {
+					return result, roachpb.NewError(err)
+				}
+				row.Values = append(row.Values, val)
+			}
+			result.Rows = append(result.Rows, row)
 		}
 	}
 
-	return result, nil
+	return result, plan.PErr()
 }
 
 // updateStmtCounts updates metrics for the number of times the different types of SQL
@@ -615,18 +956,6 @@ func (e *Executor) updateStmtCounts(stmt parser.Statement) {
 // access its stats or be added to another registry.
 func (e *Executor) Registry() *metric.Registry {
 	return e.registry
-}
-
-// If we hit an error and there is a pending transaction, rollback
-// the transaction before returning. The client does not have to
-// deal with cleaning up transaction state.
-func makeResultFromError(planMaker *planner, pErr *roachpb.Error) Result {
-	if planMaker.txn != nil {
-		if _, ok := pErr.GetDetail().(*roachpb.SqlTransactionAbortedError); !ok {
-			planMaker.txn.Cleanup(pErr)
-		}
-	}
-	return Result{PErr: pErr}
 }
 
 var _ parser.Args = parameters{}

--- a/sql/internal.go
+++ b/sql/internal.go
@@ -33,7 +33,9 @@ type InternalExecutor struct {
 // ExecuteStatementInTransaction executes the supplied SQL statement as part of
 // the supplied transaction. Statements are currently executed as the root user.
 func (ie InternalExecutor) ExecuteStatementInTransaction(txn *client.Txn, statement string, params ...interface{}) (int, *roachpb.Error) {
-	p := planner{user: security.RootUser, leaseMgr: ie.LeaseManager}
+	p := makePlanner()
 	p.setTxn(txn, txn.Proto.Timestamp.GoTime())
+	p.user = security.RootUser
+	p.leaseMgr = ie.LeaseManager
 	return p.exec(statement, params...)
 }

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -693,7 +693,7 @@ func (t *logicTest) traceStop() {
 
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer csql.TestingWaitForMetadata()()
+	defer csql.TestingWaitForGossipUpdate()()
 
 	// TODO(marc): splitting ranges at table boundaries causes
 	// a blocked task and won't drain. Investigate and fix.
@@ -750,6 +750,9 @@ func TestLogic(t *testing.T) {
 
 	total := 0
 	for _, p := range paths {
+		if testing.Verbose() || log.V(1) {
+			fmt.Printf("Running logic test on file: %s\n", p)
+		}
 		l := logicTest{T: t}
 		l.run(p)
 		total += l.progress

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -24,7 +24,6 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
@@ -194,17 +193,18 @@ func (c *v3Conn) serve(authenticationHook func(string, bool) error) error {
 	for {
 		if !c.doingExtendedQueryMessage {
 			c.writeBuf.initMsg(serverMsgReady)
-			var txnStatus byte = 'I'
-			if sessionTxn := c.session.Txn; sessionTxn != nil {
-				switch sessionTxn.Txn.Status {
-				case roachpb.PENDING:
-					txnStatus = 'T'
-				case roachpb.COMMITTED:
-					txnStatus = 'I'
-				case roachpb.ABORTED:
-					txnStatus = 'E'
-				}
+			var txnStatus byte
+			switch {
+			case c.session.Txn.TxnAborted:
+				txnStatus = 'E'
+			case c.session.Txn.Txn != nil:
+				// We're in a PENDING txn.
+				txnStatus = 'T'
+			case c.session.Txn.Txn == nil:
+				// We're not in a txn (i.e. the last txn was committed).
+				txnStatus = 'I'
 			}
+
 			if log.V(2) {
 				log.Infof("pgwire: %s: %q", serverMsgReady, txnStatus)
 			}
@@ -323,7 +323,7 @@ func (c *v3Conn) handleParse(buf *readBuffer) error {
 		}
 		args[fmt.Sprint(i+1)] = v
 	}
-	cols, pErr := c.executor.Prepare(c.opts.user, query, c.session, args)
+	cols, pErr := c.executor.Prepare(c.opts.user, query, &c.session, args)
 	if pErr != nil {
 		return c.sendError(pErr.String())
 	}
@@ -552,21 +552,16 @@ func (c *v3Conn) handleExecute(buf *readBuffer) error {
 
 func (c *v3Conn) executeStatements(stmts string, params []parser.Datum, formatCodes []formatCode, sendDescription bool, limit int32) error {
 	tracing.AnnotateTrace()
-	resp, _, err := c.executor.ExecuteStatements(c.opts.user, c.session, stmts, params)
-	if err != nil {
-		return c.sendError(err.Error())
-	}
-
-	c.session.Reset()
-	c.session = resp.Session
+	results := c.executor.ExecuteStatements(c.opts.user, &c.session, stmts, params)
+	response := sql.Response{Results: results, Session: &c.session}
 
 	tracing.AnnotateTrace()
-	if resp.Empty {
+	if results.Empty {
 		// Skip executor and just send EmptyQueryResponse.
 		c.writeBuf.initMsg(serverMsgEmptyQuery)
 		return c.writeBuf.finishMsg(c.wr)
 	}
-	return c.sendResponse(resp, formatCodes, sendDescription, limit)
+	return c.sendResponse(response, formatCodes, sendDescription, limit)
 }
 
 func (c *v3Conn) sendCommandComplete(tag []byte) error {
@@ -611,10 +606,10 @@ func (c *v3Conn) sendError(errToSend string) error {
 }
 
 func (c *v3Conn) sendResponse(resp sql.Response, formatCodes []formatCode, sendDescription bool, limit int32) error {
-	if len(resp.Results) == 0 {
+	if len(resp.Results.ResultList) == 0 {
 		return c.sendCommandComplete(nil)
 	}
-	for _, result := range resp.Results {
+	for _, result := range resp.Results.ResultList {
 		if result.PErr != nil {
 			if err := c.sendError(result.PErr.String()); err != nil {
 				return err

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -55,7 +55,10 @@ func (sc *SchemaChanger) applyMutations(lease *TableDescriptor_SchemaChangeLease
 	*lease = l
 	return sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		// TODO(vivek): Use the original users privileges.
-		p := planner{user: security.RootUser, systemConfig: sc.cfg, leaseMgr: sc.leaseMgr}
+		p := makePlanner()
+		p.user = security.RootUser
+		p.systemConfig = sc.cfg
+		p.leaseMgr = sc.leaseMgr
 		p.setTxn(txn, time.Now())
 
 		tableDesc, pErr := getTableDescFromID(txn, sc.tableID)

--- a/sql/server.go
+++ b/sql/server.go
@@ -147,7 +147,7 @@ func requestFromProto(dr driver.Request) (Request, error) {
 
 	r := Request{
 		User:    dr.User,
-		Session: session,
+		Session: &session,
 		SQL:     dr.Sql,
 		Params:  make([]parser.Datum, 0, len(dr.Params)),
 	}
@@ -158,16 +158,16 @@ func requestFromProto(dr driver.Request) (Request, error) {
 }
 
 func protoFromResponse(r Response) (*driver.Response, error) {
-	bytes, err := proto.Marshal(&r.Session)
+	bytes, err := proto.Marshal(r.Session)
 	if err != nil {
 		return nil, err
 	}
 
 	dr := &driver.Response{
 		Session: bytes,
-		Results: make([]driver.Response_Result, 0, len(r.Results)),
+		Results: make([]driver.Response_Result, 0, len(r.Results.ResultList)),
 	}
-	for _, rr := range r.Results {
+	for _, rr := range r.Results.ResultList {
 		dr.Results = append(dr.Results, protoFromResult(rr))
 	}
 	return dr, nil

--- a/sql/session.pb.go
+++ b/sql/session.pb.go
@@ -24,11 +24,8 @@ var _ = math.Inf
 type Session struct {
 	Database string `protobuf:"bytes,1,opt,name=database" json:"database"`
 	Syntax   int32  `protobuf:"varint,2,opt,name=syntax" json:"syntax"`
-	// Open transaction.
-	Txn *Session_Transaction `protobuf:"bytes,3,opt,name=txn" json:"txn,omitempty"`
-	// Indicates that the above transaction is mutating keys in the
-	// SystemConfig span.
-	MutatesSystemConfig bool `protobuf:"varint,4,opt,name=mutates_system_config" json:"mutates_system_config"`
+	// Info about the open transaction (if any).
+	Txn Session_Transaction `protobuf:"bytes,3,opt,name=txn" json:"txn"`
 	// Types that are valid to be assigned to Timezone:
 	//	*Session_Location
 	//	*Session_Offset
@@ -125,11 +122,20 @@ func _Session_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer
 }
 
 type Session_Transaction struct {
-	Txn cockroach_roachpb1.Transaction `protobuf:"bytes,1,opt,name=txn" json:"txn"`
-	// Timestamp to be used by SQL in the above transaction. Note: this is not the
-	// transaction timestamp in roachpb.Transaction above.
-	Timestamp    cockroach_sql_driver.Datum_Timestamp                  `protobuf:"bytes,2,opt,name=timestamp" json:"timestamp"`
-	UserPriority github_com_cockroachdb_cockroach_roachpb.UserPriority `protobuf:"fixed64,3,opt,name=user_priority,casttype=github.com/cockroachdb/cockroach/roachpb.UserPriority" json:"user_priority"`
+	// If missing, it means we're not inside a (KV) txn.
+	Txn *cockroach_roachpb1.Transaction `protobuf:"bytes,1,opt,name=txn" json:"txn,omitempty"`
+	// txnAborted is set once executing a statement returned an error from KV.
+	// While in this state, every subsequent statement must be rejected until
+	// a COMMIT/ROLLBACK is seen.
+	TxnAborted bool `protobuf:"varint,2,opt,name=txnAborted" json:"txnAborted"`
+	// Timestamp to be used by SQL (transaction_timestamp()) in the above
+	// transaction. Note: this is not the transaction timestamp in
+	// roachpb.Transaction above, although it probably should be (#4393).
+	TxnTimestamp cockroach_sql_driver.Datum_Timestamp                  `protobuf:"bytes,3,opt,name=txn_timestamp" json:"txn_timestamp"`
+	UserPriority github_com_cockroachdb_cockroach_roachpb.UserPriority `protobuf:"fixed64,4,opt,name=user_priority,casttype=github.com/cockroachdb/cockroach/roachpb.UserPriority" json:"user_priority"`
+	// Indicates that the transaction is mutating keys in the
+	// SystemConfig span.
+	MutatesSystemConfig bool `protobuf:"varint,5,opt,name=mutates_system_config" json:"mutates_system_config"`
 }
 
 func (m *Session_Transaction) Reset()         { *m = Session_Transaction{} }
@@ -162,24 +168,14 @@ func (m *Session) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x10
 	i++
 	i = encodeVarintSession(data, i, uint64(m.Syntax))
-	if m.Txn != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintSession(data, i, uint64(m.Txn.Size()))
-		n1, err := m.Txn.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n1
-	}
-	data[i] = 0x20
+	data[i] = 0x1a
 	i++
-	if m.MutatesSystemConfig {
-		data[i] = 1
-	} else {
-		data[i] = 0
+	i = encodeVarintSession(data, i, uint64(m.Txn.Size()))
+	n1, err := m.Txn.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
 	}
-	i++
+	i += n1
 	if m.Timezone != nil {
 		nn2, err := m.Timezone.MarshalTo(data[i:])
 		if err != nil {
@@ -223,25 +219,43 @@ func (m *Session_Transaction) MarshalTo(data []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	data[i] = 0xa
-	i++
-	i = encodeVarintSession(data, i, uint64(m.Txn.Size()))
-	n3, err := m.Txn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
+	if m.Txn != nil {
+		data[i] = 0xa
+		i++
+		i = encodeVarintSession(data, i, uint64(m.Txn.Size()))
+		n3, err := m.Txn.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n3
 	}
-	i += n3
-	data[i] = 0x12
+	data[i] = 0x10
 	i++
-	i = encodeVarintSession(data, i, uint64(m.Timestamp.Size()))
-	n4, err := m.Timestamp.MarshalTo(data[i:])
+	if m.TxnAborted {
+		data[i] = 1
+	} else {
+		data[i] = 0
+	}
+	i++
+	data[i] = 0x1a
+	i++
+	i = encodeVarintSession(data, i, uint64(m.TxnTimestamp.Size()))
+	n4, err := m.TxnTimestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n4
-	data[i] = 0x19
+	data[i] = 0x21
 	i++
 	i = encodeFixed64Session(data, i, uint64(math.Float64bits(float64(m.UserPriority))))
+	data[i] = 0x28
+	i++
+	if m.MutatesSystemConfig {
+		data[i] = 1
+	} else {
+		data[i] = 0
+	}
+	i++
 	return i, nil
 }
 
@@ -278,11 +292,8 @@ func (m *Session) Size() (n int) {
 	l = len(m.Database)
 	n += 1 + l + sovSession(uint64(l))
 	n += 1 + sovSession(uint64(m.Syntax))
-	if m.Txn != nil {
-		l = m.Txn.Size()
-		n += 1 + l + sovSession(uint64(l))
-	}
-	n += 2
+	l = m.Txn.Size()
+	n += 1 + l + sovSession(uint64(l))
 	if m.Timezone != nil {
 		n += m.Timezone.Size()
 	}
@@ -306,11 +317,15 @@ func (m *Session_Offset) Size() (n int) {
 func (m *Session_Transaction) Size() (n int) {
 	var l int
 	_ = l
-	l = m.Txn.Size()
-	n += 1 + l + sovSession(uint64(l))
-	l = m.Timestamp.Size()
+	if m.Txn != nil {
+		l = m.Txn.Size()
+		n += 1 + l + sovSession(uint64(l))
+	}
+	n += 2
+	l = m.TxnTimestamp.Size()
 	n += 1 + l + sovSession(uint64(l))
 	n += 9
+	n += 2
 	return n
 }
 
@@ -430,33 +445,10 @@ func (m *Session) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Txn == nil {
-				m.Txn = &Session_Transaction{}
-			}
 			if err := m.Txn.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
-		case 4:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field MutatesSystemConfig", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowSession
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				v |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.MutatesSystemConfig = bool(v != 0)
 		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Location", wireType)
@@ -601,13 +593,36 @@ func (m *Session_Transaction) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
+			if m.Txn == nil {
+				m.Txn = &cockroach_roachpb1.Transaction{}
+			}
 			if err := m.Txn.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
 		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TxnAborted", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSession
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.TxnAborted = bool(v != 0)
+		case 3:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field TxnTimestamp", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -631,11 +646,11 @@ func (m *Session_Transaction) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.Timestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
+			if err := m.TxnTimestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
-		case 3:
+		case 4:
 			if wireType != 1 {
 				return fmt.Errorf("proto: wrong wireType = %d for field UserPriority", wireType)
 			}
@@ -653,6 +668,26 @@ func (m *Session_Transaction) Unmarshal(data []byte) error {
 			v |= uint64(data[iNdEx-2]) << 48
 			v |= uint64(data[iNdEx-1]) << 56
 			m.UserPriority = github_com_cockroachdb_cockroach_roachpb.UserPriority(math.Float64frombits(v))
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MutatesSystemConfig", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSession
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.MutatesSystemConfig = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipSession(data[iNdEx:])

--- a/sql/session.proto
+++ b/sql/session.proto
@@ -26,18 +26,24 @@ message Session {
   optional string database = 1 [(gogoproto.nullable) = false];
   optional int32 syntax = 2 [(gogoproto.nullable) = false];
   message Transaction {
-    optional roachpb.Transaction txn = 1 [(gogoproto.nullable) = false];
-    // Timestamp to be used by SQL in the above transaction. Note: this is not the
-    // transaction timestamp in roachpb.Transaction above.
-    optional driver.Datum.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
-    optional double user_priority = 3 [(gogoproto.nullable) = false,
+    // If missing, it means we're not inside a (KV) txn.
+    optional roachpb.Transaction txn = 1;
+    // txnAborted is set once executing a statement returned an error from KV.
+    // While in this state, every subsequent statement must be rejected until
+    // a COMMIT/ROLLBACK is seen.
+    optional bool txnAborted = 2 [(gogoproto.nullable) = false];
+    // Timestamp to be used by SQL (transaction_timestamp()) in the above
+    // transaction. Note: this is not the transaction timestamp in
+    // roachpb.Transaction above, although it probably should be (#4393).
+    optional driver.Datum.Timestamp txn_timestamp = 3 [(gogoproto.nullable) = false];
+    optional double user_priority = 4 [(gogoproto.nullable) = false,
         (gogoproto.casttype) = "github.com/cockroachdb/cockroach/roachpb.UserPriority"];
+    // Indicates that the transaction is mutating keys in the
+    // SystemConfig span.
+    optional bool mutates_system_config = 5 [(gogoproto.nullable) = false];
   }
-  // Open transaction.
-  optional Transaction txn = 3;
-  // Indicates that the above transaction is mutating keys in the
-  // SystemConfig span.
-  optional bool mutates_system_config = 4 [(gogoproto.nullable) = false];
+  // Info about the open transaction (if any).
+  optional Transaction txn = 3 [(gogoproto.nullable) = false];
   oneof timezone {
     // A time zone; LOCAL or DEFAULT imply UTC.
     string location = 5;

--- a/sql/testdata/datetime
+++ b/sql/testdata/datetime
@@ -130,6 +130,8 @@ SELECT clock_timestamp() - statement_timestamp() < interval '10s'
 ----
 true
 
+# Test that implicit transactions use the transaction_timestamp() as
+# the statement_timestamp.
 query B
 SELECT now() - transaction_timestamp() = interval '0s'
 ----
@@ -181,6 +183,33 @@ query I
 SELECT COUNT(DISTINCT v) FROM kv
 ----
 4
+
+# Test that transaction_timestamp() is consistent in transaction
+# spanning multiple batches of statements.
+statement ok
+DELETE FROM kv
+
+statement ok
+BEGIN;
+INSERT INTO kv (k,v) VALUES ('a', transaction_timestamp());
+SELECT * FROM kv;
+
+statement ok
+INSERT INTO kv (k,v) VALUES ('b', transaction_timestamp());
+SELECT * FROM kv;
+COMMIT;
+
+statement ok
+BEGIN;
+SELECT * FROM KV;
+INSERT INTO kv (k,v) VALUES ('c', transaction_timestamp());
+COMMIT;
+
+query I
+SELECT COUNT(DISTINCT v) FROM kv
+----
+2
+
 
 query I
 SELECT extract(year from timestamp '2001-04-10 12:04:59')

--- a/sql/testdata/multi_statement
+++ b/sql/testdata/multi_statement
@@ -18,7 +18,7 @@ a b
 c d
 
 # error if either statement returns an error
-# first statement returns an error
+# first statement returns an error. Second stmt shouldn't execute.
 statement error duplicate key value \(k\)=\('a'\) violates unique constraint "primary"
 INSERT INTO kv (k,v) VALUES ('a', 'b'); INSERT INTO kv (k,v) VALUES ('e', 'f')
 
@@ -27,7 +27,6 @@ SELECT * FROM kv
 ----
 a b
 c d
-e f
 
 # second statement returns an error
 statement error duplicate key value \(k\)=\('a'\) violates unique constraint "primary"
@@ -38,7 +37,6 @@ SELECT * FROM kv
 ----
 a b
 c d
-e f
 g h
 
 # parse error runs nothing
@@ -50,11 +48,16 @@ SELECT * FROM kv
 ----
 a b
 c d
-e f
 g h
 
 statement error pq: database "x" does not exist
 BEGIN; INSERT INTO x.y(a) VALUES (1); END;
+
+statement error pq: current transaction is aborted, commands ignored until end of transaction block
+SELECT * from kv; ROLLBACK;
+
+statement ok
+ROLLBACK
 
 statement error pq: table "t" does not exist
 BEGIN TRANSACTION; SELECT * FROM system.t; INSERT INTO t(a) VALUES (1);

--- a/sql/testdata/txn
+++ b/sql/testdata/txn
@@ -105,24 +105,37 @@ SELECT * FROM kv
 ----
 a c
 
-# Abort transaction with a problematic statement, and ignore statements until the end of the transaction block
+# Abort transaction with a problematic statement, and ignore statements until
+# the end of the transaction block (a COMMIT/ROLLBACK statement as the first
+# statement in a batch).
 
 statement ok
 BEGIN
 
 statement error duplicate key value \(k\)=\('a'\) violates unique constraint "primary"
-INSERT INTO kv VALUES('a', 'c')
+INSERT INTO kv VALUES('unique_key', 'some value');
+INSERT INTO kv VALUES('a', 'c');
+INSERT INTO kv VALUES('unique_key2', 'some value');
+COMMIT;
 
+# Txn is still aborted.
 statement error current transaction is aborted, commands ignored until end of transaction block
 UPDATE kv SET v = 'b' WHERE k in ('a')
 
+# Txn is still aborted.
+statement error current transaction is aborted, commands ignored until end of transaction block
+UPDATE kv SET v = 'b' WHERE k in ('a')
+
+# Now the transaction will be ended. After that, statements execute.
 statement ok
-COMMIT
+COMMIT;
+INSERT INTO kv VALUES('x', 'y');
 
 query TT
 SELECT * FROM kv
 ----
 a c
+x y
 
 # BEGIN in the middle of a transaction is an error.
 

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -1,0 +1,136 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Andrei Matei (andreimatei1@gmail.com)
+
+package sql_test
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+	_ "github.com/cockroachdb/pq"
+)
+
+func injectRetriableErrors(
+	_ roachpb.StoreID, req roachpb.Request, hdr roachpb.Header,
+	magicVals []string, restarts map[string]int) error {
+	cput, ok := req.(*roachpb.ConditionalPutRequest)
+	if !ok {
+		return nil
+	}
+	for _, val := range magicVals {
+		if restarts[val] < 2 && bytes.Contains(cput.Value.RawBytes, []byte(val)) {
+			restarts[val]++
+			return &roachpb.ReadWithinUncertaintyIntervalError{
+				Timestamp:         hdr.Timestamp,
+				ExistingTimestamp: hdr.Timestamp,
+			}
+		}
+	}
+	return nil
+}
+
+// TestTxnRestart tests the logic in the sql executor for automatically retrying
+// txns in case of retriable errors.
+func TestTxnRestart(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer func() { storage.TestingCommandFilter = nil }()
+	server, sqlDB, _ := setup(t)
+	defer cleanup(server, sqlDB)
+
+	// Set up error injection useful later in the test.
+	var magicValsLock sync.Mutex
+	magicValsLock.Lock()
+	restarts := make(map[string]int)
+	magicVals := []string{"boulanger", "dromedary", "fajita", "hooly", "josephine", "laureal"}
+	magicValsLock.Unlock()
+	storage.TestingCommandFilter =
+		func(sid roachpb.StoreID, req roachpb.Request, hdr roachpb.Header) error {
+			magicValsLock.Lock()
+			defer magicValsLock.Unlock()
+			return injectRetriableErrors(sid, req, hdr, magicVals, restarts)
+		}
+
+	// Make sure all the commands we send in this test are sent over the same connection.
+	// This is a bit of a hack; in Go you're not supposed to have connection state
+	// outside of using a db.Tx. But we can't use a db.Tx here, because we want
+	// to control the batching of BEGIN/COMMIT statements.
+	// This SetMaxOpenConns is pretty shady, it doesn't guarantee that you'll be using
+	// the *same* one connection across calls. A proper solution would be to use a
+	// lib/pq connection directly. As of Feb 2016, there's code in cli/sql_util.go to
+	// do that.
+	sqlDB.SetMaxOpenConns(1)
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k CHAR PRIMARY KEY, v TEXT);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test that implicit txns, txns for which we see all the statements and prefixes
+	// of txns (statements batched together with the BEGIN stmt) are retried.
+	if _, err := sqlDB.Exec(`
+INSERT INTO t.test (k, v) VALUES ('a', 'boulanger');
+BEGIN;
+INSERT INTO t.test (k, v) VALUES ('c', 'dromedary');
+INSERT INTO t.test (k, v) VALUES ('e', 'fajita');
+END;
+INSERT INTO t.test (k, v) VALUES ('g', 'hooly');
+BEGIN;
+INSERT INTO t.test (k, v) VALUES ('i', 'josephine');
+INSERT INTO t.test (k, v) VALUES ('k', 'laureal');
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	{
+		magicValsLock.Lock()
+		for _, val := range magicVals {
+			if restarts[val] != 2 {
+				t.Errorf("INSERT for %s has been retried %d times, instead of 2",
+					val, restarts[val])
+			}
+		}
+
+		// Now test that we don't retry what we shouldn't: insert an error into a txn
+		// we can't automatically retry (because it spans requests).
+
+		magicVals = []string{"hooly"}
+		restarts = make(map[string]int)
+		magicValsLock.Unlock()
+	}
+
+	// Start a txn.
+	if _, err := sqlDB.Exec(`
+END;
+DELETE FROM t.test WHERE true;
+BEGIN;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Continue the txn in a new request, which is not retriable.
+	_, err := sqlDB.Exec("INSERT INTO t.test (k, v) VALUES ('g', 'hooly')")
+	if err == nil || !strings.Contains(
+		err.Error(), "encountered previous write with future timestamp") {
+		t.Errorf("didn't get expected injected error. Got: %s", err)
+	}
+}

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -32,7 +32,7 @@ import (
 func TestValues(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	p := planner{}
+	p := makePlanner()
 
 	vInt := int64(5)
 	vNum := 3.14159

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -82,8 +82,7 @@ const (
 // with regular processing or non-nil to terminate processing with the
 // returned error. Note that in a multi-replica test this filter will
 // be run once for each replica and must produce consistent results
-// each time. Should only be used in tests in the storage and
-// storage_test packages.
+// each time.
 var TestingCommandFilter func(roachpb.StoreID, roachpb.Request, roachpb.Header) error
 
 // This flag controls whether Transaction entries are automatically gc'ed

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -58,7 +58,9 @@ func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, h roachp
 	// If a unittest filter was installed, check for an injected error; otherwise, continue.
 	if TestingCommandFilter != nil {
 		if err := TestingCommandFilter(r.store.StoreID(), args, h); err != nil {
-			return nil, nil, roachpb.NewErrorWithTxn(err, h.Txn)
+			pErr := roachpb.NewErrorWithTxn(err, h.Txn)
+			log.Infof("test injecting error: %s", pErr)
+			return nil, nil, pErr
 		}
 	}
 

--- a/testutils/sqlutils/pg_url.go
+++ b/testutils/sqlutils/pg_url.go
@@ -35,6 +35,11 @@ import (
 // In order to connect securely using postgres, this method will create temporary on-disk copies of
 // certain embedded security certificates. The certificates will be created in a new temporary
 // directory. The returned cleanup function will delete this temporary directory.
+// Note that two calls to this function for the same `user` will generate different
+// copies of the certificates, so the cleanup function must always be called.
+//
+// Args:
+//  prefix: A prefix to be prepended to the temp file names generated, for debugging.
 func PGUrl(t testing.TB, ts *server.TestServer, user, prefix string) (url.URL, func()) {
 	host, port, err := net.SplitHostPort(ts.ServingAddr())
 	if err != nil {

--- a/util/metric/doc.go
+++ b/util/metric/doc.go
@@ -60,9 +60,10 @@ a hierarchy of Registry instances underneath that to make your metrics more mana
 
 Testing
 
-After your test does something to trigger your new metric update, you'll probably want to call
-methods in TestServer such as MustGetCounter() to verify that the metric was updated correctly. See
-"sql/metric_test.go" for an example.
+After your test does something to trigger your new metric update, you'll
+probably want to call methods in TestServer such as MustGetSQLCounter() to
+verify that the metric was updated correctly. See "sql/metric_test.go" for an
+example.
 
 Additionally, you can manually verify that your metric is updating by using the metrics
 endpoint.  For example, if you're running the Cockroach DB server with the "--insecure"


### PR DESCRIPTION
Previously the only SQL txns that we automatically retry were implicit
txns (single-statements outside of a user txn). With this change, we're
retrying batches of statements.

In a future change, we'll bubble up retriable errors for txns that we
don't auto-retry to the user, and allow her to manually retry.
- unify the handling of implicit and explicit sql txns
- automatically retry the batch of statements that contain BEGIN (the
  prefix of a txn sent as one batch)
- made the executor and pgwire not look inside the kv txn proto any more
  to determine txn state. This was ugly. Instead, the executor and
  planner cooperate to maintain their own view of the sql txn status
- made schema change errors from async processing insert errors into the
  Results at the appropriate position (the position of the statement
  that queued up the schema change)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4576)

<!-- Reviewable:end -->
