### PR TITLE
storage: Clean up pendingRaftGroup processing code in Store.processRaft

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -1627,15 +1627,12 @@ func (s *Store) processRaft() {
 			var replicas []*Replica
 			s.processRaftMu.Lock()
 			s.mu.Lock()
-			for rangeID := range s.mu.pendingRaftGroups {
-				r, ok := s.mu.replicas[rangeID]
-				if !ok {
-					continue
-				}
-				replicas = append(replicas, r)
-
-			}
 			if len(s.mu.pendingRaftGroups) > 0 {
+				for rangeID := range s.mu.pendingRaftGroups {
+					if r, ok := s.mu.replicas[rangeID]; ok {
+						replicas = append(replicas, r)
+					}
+				}
 				s.mu.pendingRaftGroups = map[roachpb.RangeID]struct{}{}
 			}
 			s.mu.Unlock()


### PR DESCRIPTION
If we're already checking the length, might as well put the for-range loop inside the check because it makes the function easier to read. Also, the map lookup could be cleaned up a bit.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4580)

<!-- Reviewable:end -->
