### PR TITLE
build: make sure parent directory exists before mv

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ checkout:
     # run or the subsequent `mv` will fail. We put our checkout in the correct
     # location for the OSX build step.
     - rm -rf "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach"
+    - mkdir -p "${GOPATH%%:*}/src/github.com/cockroachdb/"
     - mv ~/cockroach "${GOPATH%%:*}/src/github.com/cockroachdb/"
     - ln -s ${GOPATH%%:*}/src/github.com/cockroachdb/cockroach ~/cockroach
 


### PR DESCRIPTION
This fixes a bug when "rebuild without cache" is used. See
https://circleci.com/gh/petermattis/cockroach/363.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4585)

<!-- Reviewable:end -->
