### PR TITLE
build: check the go version on every make invocation

### DIFF
--- a/.go-version
+++ b/.go-version
@@ -1,0 +1,1 @@
+GOVERS = go1.6

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,15 @@ clean:
 protobuf:
 	$(MAKE) -C .. -f cockroach/build/protobuf.mk
 
+# The .go-version target is phony so that it is rebuilt every time.
+.PHONY: .go-version
+.go-version:
+	@actual=$$($(GO) version); \
+	echo "$${actual}" | grep -q $(GOVERS) || \
+	  (echo "$(GOVERS) required (see CONTRIBUTING.md): $${actual}" && false)
+
+include .go-version
+
 ifneq ($(SKIP_BOOTSTRAP),1)
 
 GITHOOKS := $(subst githooks/,.git/hooks/,$(wildcard githooks/*))


### PR DESCRIPTION
~ make GO=~/Development/go-1.5/bin/go
go1.6 required: go version go1.5.2 darwin/amd64
make: **\* [.go-version-check] Error 1

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4598)

<!-- Reviewable:end -->
