### PR TITLE
sql: just count affected rows if not returning

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -79,7 +79,7 @@ func (p *planner) Delete(n *parser.Delete, autoCommit bool) (planNode, *roachpb.
 	b := p.txn.NewBatch()
 	for rows.Next() {
 		rowVals := rows.Values()
-		result.rows = append(result.rows, parser.DTuple(nil))
+		result.rowCount++
 
 		primaryIndexKey, _, err := encodeIndexKey(
 			&primaryIndex, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -134,7 +134,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 	}
 	for rows.Next() {
 		rowVals := rows.Values()
-		result.rows = append(result.rows, parser.DTuple(nil))
+		result.rowCount++
 
 		// The values for the row may be shorter than the number of columns being
 		// inserted into. Generate default values for those columns using the

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -230,11 +230,7 @@ func (p *planner) exec(sql string, args ...interface{}) (int, *roachpb.Error) {
 	if pErr != nil {
 		return 0, pErr
 	}
-	count := 0
-	for plan.Next() {
-		count++
-	}
-	return count, plan.PErr()
+	return countRowsAffected(plan), plan.PErr()
 }
 
 // getAliasedTableLease looks up the table descriptor for an alias table

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -18,8 +18,13 @@ package sql
 
 import "github.com/cockroachdb/cockroach/sql/parser"
 
-func (p *planner) initReturning(r parser.ReturningExprs, alias string, tablecols []ColumnDescriptor) (*valuesNode, qvalMap, error) {
-	result := &valuesNode{}
+type returningNode struct {
+	valuesNode
+	rowCount int
+}
+
+func (p *planner) initReturning(r parser.ReturningExprs, alias string, tablecols []ColumnDescriptor) (*returningNode, qvalMap, error) {
+	result := &returningNode{valuesNode{}, 0}
 	if r == nil {
 		return result, nil, nil
 	}
@@ -52,7 +57,7 @@ func (p *planner) initReturning(r parser.ReturningExprs, alias string, tablecols
 	return result, qvals, nil
 }
 
-func (p *planner) populateReturning(r parser.ReturningExprs, result *valuesNode, qvals qvalMap, rowVals parser.DTuple) error {
+func (p *planner) populateReturning(r parser.ReturningExprs, result *returningNode, qvals qvalMap, rowVals parser.DTuple) error {
 	if r == nil {
 		return nil
 	}
@@ -65,6 +70,6 @@ func (p *planner) populateReturning(r parser.ReturningExprs, result *valuesNode,
 		}
 		resrow[i] = d
 	}
-	result.rows[len(result.rows)-1] = resrow
+	result.rows = append(result.rows, resrow)
 	return nil
 }

--- a/sql/update.go
+++ b/sql/update.go
@@ -219,7 +219,7 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 		tracing.AnnotateTrace()
 
 		rowVals := rows.Values()
-		result.rows = append(result.rows, parser.DTuple(nil))
+		result.rowCount++
 
 		primaryIndexKey, _, err := encodeIndexKey(
 			&primaryIndex, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)


### PR DESCRIPTION
The reduction in memory allocation probably matters most for extreme cases, like
inserting or deleting 100k rows, but is visible in the the 100 row benchmarks too.

```
name                   old time/op    new time/op    delta
Insert100_Cockroach-8    4.00ms ± 4%    3.99ms ± 2%    ~     (p=0.796 n=10+10)

name                   old alloc/op   new alloc/op   delta
Insert100_Cockroach-8     582kB ± 0%     575kB ± 0%  -1.11%   (p=0.000 n=10+9)

name                   old allocs/op  new allocs/op  delta
Insert100_Cockroach-8     5.37k ± 0%     5.36k ± 0%  -0.19%   (p=0.000 n=10+8)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4603)

<!-- Reviewable:end -->
