### PR TITLE
sql: Use prefix as name of db to connect to in testing helper

### DIFF
--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -290,7 +290,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			base.Params(true, 0).Error(`pq: param $1: strconv.ParseInt: parsing "true": invalid syntax`),
 		},
 		"SHOW database": {
-			base.Results(""),
+			base.Results("TestPGPreparedQuery"),
 		},
 		"SELECT descriptor FROM system.descriptor WHERE descriptor != $1": {
 			base.Params([]byte("abc")).Results([]byte("\x12\x16\n\x06system\x10\x01\x1a\n\n\b\n\x04root\x100")),

--- a/testutils/sqlutils/pg_url.go
+++ b/testutils/sqlutils/pg_url.go
@@ -65,6 +65,7 @@ func PGUrl(t testing.TB, ts *server.TestServer, user, prefix string) (url.URL, f
 			Scheme:   "postgres",
 			User:     url.User(user),
 			Host:     net.JoinHostPort(host, port),
+			Path:     prefix,
 			RawQuery: options.Encode(),
 		}, func() {
 			if err := os.RemoveAll(tempDir); err != nil {


### PR DESCRIPTION
Rather than always relying on prefixing table names with db names.
Still may need to do the connect-create-reconnect dance in a few places to actually use this though.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4605)

<!-- Reviewable:end -->
