### PR TITLE
Ensure that the planner knows about the session during prepare.

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -260,6 +260,7 @@ func (e *Executor) Prepare(user string, query string, session Session, args pars
 		leaseMgr:      e.leaseMgr,
 		systemConfig:  cfg,
 		databaseCache: cache,
+		session:       session,
 	}
 
 	timestamp := time.Now()


### PR DESCRIPTION
Prepare needs the current database name to resolve unqualified
names and globs. This is available from the session. This patch
ensure that the planner knows about the current session in
prepare, not only execute.

Fixes #4550.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4610)

<!-- Reviewable:end -->
