### PR TITLE
Fix data races in metrics

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -256,8 +256,8 @@ func (tc *TxnCoordSender) startStats() {
 			// Take a snapshot of metrics. There's some chance of skew, since the snapshots are
 			// not done atomically, but that should be fine for these debug stats.
 			metrics := tc.metrics
-			durations := metrics.Durations[scale].Merge()
-			restarts := metrics.Restarts.Merge()
+			durations := metrics.Durations[scale].Current()
+			restarts := metrics.Restarts.Current()
 			commitRate := metrics.Commits.Rates[scale].Value()
 			abortRate := metrics.Aborts.Rates[scale].Value()
 			abandonRate := metrics.Abandons.Rates[scale].Value()

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -774,7 +774,7 @@ func checkTxnMetrics(t *testing.T, sender *TxnCoordSender, name string, commits,
 
 		// Handle restarts separately, because that's a histogram. Though the histogram is approximate,
 		// we're recording so few distinct values that we should be okay.
-		dist := metrics.Restarts.Merge().Distribution()
+		dist := metrics.Restarts.Current().Distribution()
 		var actualRestarts int64
 		for _, b := range dist {
 			if b.From == b.To {


### PR DESCRIPTION
Also, I removed (_Histogram).Merge(), since (_Histogram).Current() does the same thing I was
intending to do but better. However, Current() still had a further issue, where
(*hdrhistogram.Histogram).Export() was doing a shallow copy of one of the histogram's fields,
leading to a data race. So, I'm working around that for now and will submit a PR.

cc @tamird since this should fix the data race you saw in your CircleCI run

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4611)

<!-- Reviewable:end -->
