### PR TITLE
Actively abort abandoned Txns in (*TxnCoordSender).heartbeat

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -592,6 +592,7 @@ func (tc *TxnCoordSender) heartbeat(txnID uuid.UUID, trace opentracing.Span, ctx
 	tc.Lock()
 	proceed := true
 	txnMeta := tc.txns[txnID]
+	var intentSpans []roachpb.Span
 	// Before we send a heartbeat, determine whether this transaction
 	// should be considered abandoned. If so, exit heartbeat.
 	if txnMeta.hasClientAbandonedCoord(tc.clock.PhysicalNow()) {
@@ -605,21 +606,43 @@ func (tc *TxnCoordSender) heartbeat(txnID uuid.UUID, trace opentracing.Span, ctx
 				txnMeta.txn)
 		}
 		proceed = false
+		// Grab the intents here to avoid potential race.
+		intentSpans = txnMeta.intentSpans()
+		txnMeta.keys.Clear()
 	}
 	// txnMeta.txn is possibly replaced concurrently,
 	// so grab a copy before unlocking.
-	txn := txnMeta.txn
+	txn := txnMeta.txn.Clone()
 	tc.Unlock()
+
+	ba := roachpb.BatchRequest{}
+	ba.Timestamp = tc.clock.Now()
+	ba.Txn = &txn
+
 	if !proceed {
+		// Actively abort the transaction and its intents since we assume it's abandoned.
+		et := &roachpb.EndTransactionRequest{
+			Span: roachpb.Span{
+				Key: txn.Key,
+			},
+			Commit:      false,
+			IntentSpans: intentSpans,
+		}
+		ba.Add(et)
+		tc.stopper.RunAsyncTask(func() {
+			// Use the wrapped sender since the normal Sender
+			// does not allow clients to specify intents.
+			if _, pErr := tc.wrapped.Send(ctx, ba); pErr != nil {
+				if log.V(1) {
+					log.Warningf("abort due to inactivity failed for %s: %s ", txn, pErr)
+				}
+			}
+		})
 		return false
 	}
 
 	hb := &roachpb.HeartbeatTxnRequest{}
 	hb.Key = txn.Key
-	ba := roachpb.BatchRequest{}
-	ba.Timestamp = tc.clock.Now()
-	txnClone := txn.Clone()
-	ba.Txn = &txnClone
 	ba.Add(hb)
 
 	trace.LogEvent("heartbeat")

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -453,7 +453,7 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 }
 
 // TestTxnCoordSenderGC verifies that the coordinator cleans up extant
-// transactions after the lastUpdateNanos exceeds the timeout.
+// transactions and intents after the lastUpdateNanos exceeds the timeout.
 func TestTxnCoordSenderGC(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	s := createTestDB(t)
@@ -463,7 +463,8 @@ func TestTxnCoordSenderGC(t *testing.T) {
 	s.Sender.heartbeatInterval = 1 * time.Millisecond
 
 	txn := client.NewTxn(*s.DB)
-	if pErr := txn.Put(roachpb.Key("a"), []byte("value")); pErr != nil {
+	key := roachpb.Key("a")
+	if pErr := txn.Put(key, []byte("value")); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -484,6 +485,8 @@ func TestTxnCoordSenderGC(t *testing.T) {
 	}, 50*time.Millisecond); err != nil {
 		t.Error("expected garbage collection")
 	}
+
+	verifyCleanup(key, s.Sender, s.Eng, t)
 }
 
 // TestTxnCoordSenderTxnUpdatedOnError verifies that errors adjust the


### PR DESCRIPTION
This is from #3035 (didn't know a good way to update the PR).

Diff from bg451's last commit is following:
- Address some of the remaining comments from @tschottdorf .
- Set `Span.Key` in `EndTransactionRequest`
- Add a simple test

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4614)

<!-- Reviewable:end -->
