### PR TITLE
cli: fix log-dir flag processing logic

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -56,6 +57,10 @@ func newCLITest() cliTest {
 	// pointer (because they are tied into the flags), but instead
 	// overwrite the existing struct's values.
 	cliContext.InitDefaults()
+
+	if err := flag.Lookup("log-dir").Value.Set(os.TempDir()); err != nil {
+		panic(err)
+	}
 
 	osStderr = os.Stdout
 
@@ -718,7 +723,7 @@ Flags:
       --alsologtostderr value[=true]   log to standard error as well as files
       --color value                    colorize standard error output according to severity (default "auto")
       --log-backtrace-at value         when logging hits line file:N, emit a stack trace (default :0)
-      --log-dir value                  if non-empty, write log files in this directory (default "` + os.TempDir() + `")
+      --log-dir value                  if non-empty, write log files in this directory
       --log-threshold value            logs at or above this threshold go to stderr (default ERROR)
       --logtostderr value[=true]       log to standard error instead of files
       --verbosity value                log level for V logs

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"net"
-	"os"
 	"strings"
 
 	"github.com/kr/text"
@@ -197,7 +196,7 @@ func usage(name string) string {
 // settable here.
 func initFlags(ctx *Context) {
 	// Change the logging defaults for the main cockroach binary.
-	if err := flag.Lookup("log-dir").Value.Set(os.TempDir()); err != nil {
+	if err := flag.Lookup("log-dir").Value.Set(""); err != nil {
 		panic(err)
 	}
 	if err := flag.Lookup("logtostderr").Value.Set("false"); err != nil {


### PR DESCRIPTION
`log-dir` now defaults to:
- user specified path if this flag is set.
- store path + 'logs' if one non-memory store is given.
- TEMPDIR is only memory store is provided.

fixes #4527

Tested with following commands:
- ./cockroach start --log-dir=./logs
- ./cockroach start --stores=./data1
- ./cockroach start --stores=mem=1024000

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4615)

<!-- Reviewable:end -->
