### PR TITLE
sql: benchmark via exec of 'pgbench'

### DIFF
--- a/server/testserver.go
+++ b/server/testserver.go
@@ -63,6 +63,22 @@ func StartTestServer(t util.Tester) *TestServer {
 	return s
 }
 
+// StartInsecureTestServer starts an insecure in-memory test server.
+func StartInsecureTestServer(t util.Tester) *TestServer {
+	s := &TestServer{Ctx: NewTestContext()}
+	s.Ctx.Insecure = true
+	s.Ctx.Certs = ""
+
+	if err := s.Start(); err != nil {
+		if t != nil {
+			t.Fatalf("Could not start server: %v", err)
+		} else {
+			log.Fatalf("Could not start server: %v", err)
+		}
+	}
+	return s
+}
+
 // NewTestContext returns a context for testing. It overrides the
 // Certs with the test certs directory.
 // We need to override the certs loader.

--- a/sql/pgbench/query.go
+++ b/sql/pgbench/query.go
@@ -20,6 +20,9 @@ import (
 	"database/sql"
 	"fmt"
 	"math/rand"
+	"net"
+	"net/url"
+	"os/exec"
 )
 
 // This is the TPC-B(ish) query that pgbench runs.
@@ -43,4 +46,30 @@ func RunOne(db *sql.DB, r *rand.Rand, accounts int) error {
 	q := fmt.Sprintf(tpcbQuery, delta, account, teller, branch)
 	_, err := db.Exec(q)
 	return err
+}
+
+// ExecPgbench returns a ready-to-run pgbench Cmd, that will run
+// against the db specified by `pgURL`.
+func ExecPgbench(pgURL url.URL, dbname string, count int) (*exec.Cmd, error) {
+	host, port, err := net.SplitHostPort(pgURL.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{
+		"-n", // disable (pg-specific) vacuum
+		"-r", // print stats
+		fmt.Sprintf("--transactions=%d", count),
+		"-h", host,
+		"-p", port,
+	}
+
+	if pgURL.User != nil {
+		if user := pgURL.User.Username(); user != "" {
+			args = append(args, "-U", user)
+		}
+	}
+	args = append(args, dbname)
+
+	return exec.Command("pgbench", args...), nil
 }


### PR DESCRIPTION
We'll only get the top-level timing from go but it'll still be useful
and we can run `pgbench` by hand to dig into that number as needed.

```
name                     time/op
PgbenchExec_Cockroach-8  3.04ms ± 3%
PgbenchExec_Postgres-8   1.16ms ±25%

name                     alloc/op
PgbenchExec_Cockroach-8   168kB ± 8%

name                     allocs/op
PgbenchExec_Cockroach-8   2.69k ± 8%
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4619)

<!-- Reviewable:end -->
