### PR TITLE
Fix incorrect intent count metric

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -845,11 +845,11 @@ func checkNodeStatus(t *testing.T, c cliTest, output string, start time.Time) {
 		idx    int
 		maxval int64
 	}{
-		{"live_bytes", 4, 20000},
-		{"key_bytes", 5, 20000},
-		{"value_bytes", 6, 20000},
-		{"intent_bytes", 7, 20000},
-		{"system_bytes", 8, 20000},
+		{"live_bytes", 4, 30000},
+		{"key_bytes", 5, 30000},
+		{"value_bytes", 6, 30000},
+		{"intent_bytes", 7, 30000},
+		{"system_bytes", 8, 30000},
 		{"leader_ranges", 9, 3},
 		{"repl_ranges", 10, 3},
 		{"avail_ranges", 11, 3},

--- a/storage/client_metrics_test.go
+++ b/storage/client_metrics_test.go
@@ -1,0 +1,102 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package storage_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func getGauge(t *testing.T, s *storage.Store, key string) int64 {
+	gauge := s.Registry().GetGauge(key)
+	if gauge == nil {
+		t.Fatal(util.ErrorfSkipFrames(1, "store did not contain gauge %s", key))
+	}
+	return gauge.Value()
+}
+
+func getCounter(t *testing.T, s *storage.Store, key string) int64 {
+	counter := s.Registry().GetCounter(key)
+	if counter == nil {
+		t.Fatal(util.ErrorfSkipFrames(1, "store did not contain counter %s", key))
+	}
+	return counter.Count()
+}
+
+func checkGauge(t *testing.T, s *storage.Store, key string, e int64) {
+	if a := getGauge(t, s, key); a != e {
+		t.Error(util.ErrorfSkipFrames(1, "%s for store: actual %d != expected %d", key, a, e))
+	}
+}
+
+func checkCounter(t *testing.T, s *storage.Store, key string, e int64) {
+	if a := getCounter(t, s, key); a != e {
+		t.Error(util.ErrorfSkipFrames(1, "%s for store: actual %d != expected %d", key, a, e))
+	}
+}
+
+func TestStoreStatsSplit(t *testing.T) {
+	defer leaktest.AfterTest(t)
+	mtc := startMultiTestContext(t, 3)
+	defer mtc.Stop()
+
+	store0 := mtc.stores[0]
+
+	// Perform a split, which has special metrics handling.
+	splitArgs := adminSplitArgs(roachpb.KeyMin, roachpb.Key("m"))
+	if _, err := client.SendWrapped(rg1(store0), nil, &splitArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify range count is as expected
+	checkCounter(t, store0, "ranges", 2)
+
+	// Compute real total MVCC statistics from store.
+	realStats, err := store0.ComputeMVCCStatsTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity regression check for bug #4624: ensure intent count is zero.
+	if a := realStats.IntentCount; a != 0 {
+		t.Fatalf("Expected intent count to be zero, was %d", a)
+	}
+
+	// Sanity check: LiveBytes is not zero (ensures we don't have
+	// zeroed out structures.)
+	if liveBytes := getGauge(t, store0, "livebytes"); liveBytes == 0 {
+		t.Fatal("Expected livebytes to be non-nero, was zero")
+	}
+
+	// Ensure that real MVCC stats match computed stats.
+	checkGauge(t, store0, "livebytes", realStats.LiveBytes)
+	checkGauge(t, store0, "keybytes", realStats.KeyBytes)
+	checkGauge(t, store0, "valbytes", realStats.ValBytes)
+	checkGauge(t, store0, "intentbytes", realStats.IntentBytes)
+	checkGauge(t, store0, "livecount", realStats.LiveCount)
+	checkGauge(t, store0, "keycount", realStats.KeyCount)
+	checkGauge(t, store0, "valcount", realStats.ValCount)
+	checkGauge(t, store0, "intentcount", realStats.IntentCount)
+	checkGauge(t, store0, "intentage", realStats.IntentAge)
+	checkGauge(t, store0, "gcbytesage", realStats.GCBytesAge)
+	checkGauge(t, store0, "lastupdatenanos", realStats.LastUpdateNanos)
+}

--- a/storage/store.go
+++ b/storage/store.go
@@ -2010,6 +2010,27 @@ func (s *Store) ComputeMetrics() error {
 	return nil
 }
 
+// ComputeMVCCStatsTest immediately computes correct total MVCC usage statistics
+// for the store, returning the computed values (but without modifying the
+// store). This is intended for use only by unit tests.
+func (s *Store) ComputeMVCCStatsTest() (engine.MVCCStats, error) {
+	var totalStats engine.MVCCStats
+	var err error
+
+	visitor := newStoreRangeSet(s)
+	now := s.Clock().PhysicalNow()
+	visitor.Visit(func(r *Replica) bool {
+		var stats engine.MVCCStats
+		stats, err = r.computeStats(r.Desc(), s.Engine(), now)
+		if err != nil {
+			return false
+		}
+		totalStats.Add(stats)
+		return true
+	})
+	return totalStats, err
+}
+
 // SetRangeRetryOptions sets the retry options used for this store.
 // For unittests only.
 // TODO(bdarnell): have the affected tests pass retry options in through


### PR DESCRIPTION
The displayed metric for "intent count" on a store was being computed
incorrectly in the event of a split.

The issue was that the normal incremental stats computed during command
execution are zeroed out when an EndTransactionRequest has a splitTrigger - the
expectation is that the MVCC stats will be explicitly recomputed for both
ranges, and thus the incremental update is not needed. However, the splitTrigger
is thus responsible for updating the store metrics, and it was not doing this.

Fixes #2952

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4624)

<!-- Reviewable:end -->
