### PR TITLE
util/interval: Remove Overlapper interface from IntervalTree

### DIFF
--- a/util/interval/range_group.go
+++ b/util/interval/range_group.go
@@ -186,7 +186,7 @@ func (rt *rangeTree) Add(r Range) bool {
 	key := rt.makeKey(r)
 	overlaps := rt.t.Get(key.r)
 	if len(overlaps) == 0 {
-		if err := rt.t.Insert(&key, false /* !fast */); err != nil {
+		if err := rt.insertKey(key); err != nil {
 			panic(err)
 		}
 		return true
@@ -210,6 +210,13 @@ func (rt *rangeTree) Add(r Range) bool {
 	}
 	rt.t.AdjustRanges()
 	return true
+}
+
+// insertKey inserts the rangeKey into the rangeTree's interval tree.
+// This is split into a helper method so that key will only escape to
+// the heap when the insertion case is needed and Insert is called.
+func (rt *rangeTree) insertKey(key rangeKey) error {
+	return rt.t.Insert(&key, false /* !fast */)
 }
 
 // Len implements RangeGroup. It returns the number of rangeKeys in

--- a/util/interval/range_group.go
+++ b/util/interval/range_group.go
@@ -75,7 +75,7 @@ func (rg *rangeList) Add(r Range) bool {
 	for e := rg.ll.Front(); e != nil; e = e.Next() {
 		er := e.Value.(Range)
 		switch {
-		case overlap(er, r):
+		case er.OverlapInclusive(r):
 			// If a current range fully contains the new range, no
 			// need to add it.
 			if contains(er, r) {
@@ -86,7 +86,7 @@ func (rg *rangeList) Add(r Range) bool {
 			newR := merge(er, r)
 			for p := e.Next(); p != nil; {
 				pr := p.Value.(Range)
-				if overlap(newR, pr) {
+				if newR.OverlapInclusive(pr) {
 					newR = merge(newR, pr)
 
 					nextP := p.Next()
@@ -130,7 +130,9 @@ type rangeTree struct {
 
 // NewRangeTree constructs an interval tree backed RangeGroup.
 func NewRangeTree() RangeGroup {
-	return &rangeTree{}
+	return &rangeTree{
+		t: Tree{Overlapper: Range.OverlapInclusive},
+	}
 }
 
 // rangeKey implements Interface and can be inserted into a Tree. It
@@ -149,11 +151,6 @@ func (rt *rangeTree) makeKey(r Range) rangeKey {
 		r:  r,
 		id: rt.idCount,
 	}
-}
-
-// Overlap implements Interface.
-func (rk rangeKey) Overlap(r Range) bool {
-	return overlap(rk.r, r)
 }
 
 func (rk rangeKey) Contains(lk rangeKey) bool {
@@ -187,7 +184,7 @@ func (rt *rangeTree) Add(r Range) bool {
 		panic(err)
 	}
 	key := rt.makeKey(r)
-	overlaps := rt.t.Get(key)
+	overlaps := rt.t.Get(key.r)
 	if len(overlaps) == 0 {
 		if err := rt.t.Insert(&key, false /* !fast */); err != nil {
 			panic(err)
@@ -223,14 +220,7 @@ func (rt *rangeTree) Len() int {
 
 // Clear implements RangeGroup. It clears all rangeKeys from the rangeTree.
 func (rt *rangeTree) Clear() {
-	rt.t = Tree{}
-}
-
-// overlap returns whether the two provided ranges overlap. It defines
-// overlapping as a pair of ranges that either share a segment of the
-// keyspace, or share an inclusive/exclusive boundary.
-func overlap(l, r Range) bool {
-	return l.End.Compare(r.Start) >= 0 && l.Start.Compare(r.End) <= 0
+	rt.t = Tree{Overlapper: Range.OverlapInclusive}
 }
 
 // contains returns if the range in the out range fully contains the


### PR DESCRIPTION
Related to #4616.

Remove the `Overlapper` interface and directly compare `Range`s when
testing for overlapping. This reduces the genericity of the `IntervalTree`,
but allows the interval tree to determine overlapping intervals without
having to allocate. This is critical for both the `TimestampCache` and the
`RangeGroup`.

To support the two current use cases for `IntervalTree`, this change adds
the notion of inclusive and exclusive overlapping. With inclusive
overlapping, ranges' start and end keys are considered inclusive. With
exclusive overlapping, ranges' start keys are considered inclusive, and
end keys are considered exclusive.

The PR also contains a secondary commit which makes sure RangeGroup's 
key variable in `RangeGroup.Add` only escapes when needed.
Previously, `RangeGroup.Add` would allow its rangeKey to escape to the
heap during every call, even though this was only needed during the
case where the key needed to be inserted into the tree. By using a
helper function to contain this insertion, we can avoid the variable
from escaping for the vast majority of cases. This change gave a modest
performance boost.

```
name                              old time/op    new time/op    delta
Bank_Cockroach-4                     267µs ± 6%     269µs ± 8%    ~    (p=0.661 n=10+9)
Select1_Cockroach-4                 40.9µs ± 3%    40.6µs ± 1%    ~    (p=0.218 n=10+10)
Select2_Cockroach-4                  755µs ± 3%     752µs ± 1%    ~    (p=0.780 n=10+9)
Insert1_Cockroach-4                  400µs ± 1%     400µs ± 2%    ~    (p=0.796 n=9+9)
Insert10_Cockroach-4                 688µs ± 1%     685µs ± 1%    ~    (p=0.077 n=9+9)
Insert100_Cockroach-4               3.44ms ± 0%    3.39ms ± 1%  -1.44% (p=0.000 n=9+10)
Update1_Cockroach-4                  661µs ± 1%     662µs ± 1%    ~    (p=0.739 n=10+10)
Update10_Cockroach-4                1.28ms ± 3%    1.28ms ± 1%    ~    (p=0.905 n=10+9)
Update100_Cockroach-4               6.83ms ± 0%    6.76ms ± 1%  -0.98% (p=0.000 n=8+8)
Delete1_Cockroach-4                  617µs ± 2%     621µs ± 1%    ~    (p=0.243 n=9+10)
Delete10_Cockroach-4                1.69ms ± 3%    1.69ms ± 3%    ~    (p=0.829 n=10+8)
Delete100_Cockroach-4               13.1ms ± 4%    12.6ms ± 2%  -3.37% (p=0.006 n=10+8)
Scan1_Cockroach-4                    213µs ± 2%     214µs ± 1%    ~    (p=0.079 n=10+9)
Scan10_Cockroach-4                   253µs ± 1%     255µs ± 3%    ~    (p=0.278 n=9+10)
Scan100_Cockroach-4                  563µs ± 2%     562µs ± 2%    ~    (p=1.000 n=9+10)
PgbenchExec_Cockroach-4             3.12ms ± 4%    3.06ms ± 3%    ~    (p=0.222 n=9+9)
PgbenchQuery_Cockroach-4            3.29ms ± 7%    3.22ms ± 5%    ~    (p=0.143 n=10+10)
ParallelPgbenchQuery_Cockroach-4    3.08ms ± 5%    3.18ms ± 6%    ~    (p=0.079 n=9+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4627)

<!-- Reviewable:end -->
