### PR TITLE
sql: retry par pgbench query with backoff

### DIFF
--- a/sql/pgbench_test.go
+++ b/sql/pgbench_test.go
@@ -22,11 +22,13 @@ import (
 	"math/rand"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/sql/pgbench"
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/tracing"
 )
 
@@ -53,13 +55,27 @@ func runPgbenchQueryParallel(b *testing.B, db *sql.DB) {
 		b.Fatal(err)
 	}
 
+	retryOpts := retry.Options{
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     200 * time.Millisecond,
+		Multiplier:     2,
+	}
+
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		src := rand.New(rand.NewSource(5432))
+		r := retry.Start(retryOpts)
+		var err error
 		for pb.Next() {
-			if err := pgbench.RunOne(db, src, 20000); err != nil {
-				// TODO(dt): handle retry/aborted correctly
-				// b.Fatal(err)
+			r.Reset()
+			for r.Next() {
+				err = pgbench.RunOne(db, src, 20000)
+				if err == nil {
+					break
+				}
+			}
+			if err != nil {
+				b.Fatal(err)
 			}
 		}
 	})


### PR DESCRIPTION
ignoring retry/abort txn was massively inflating perf numbers:

```
name                              old time/op    new time/op    delta
ParallelPgbenchQuery_Cockroach-8    2.41ms ±12%    5.93ms ±23%  +146.17%  (p=0.000 n=10+10)
ParallelPgbenchQuery_Postgres-8      198µs ± 9%     196µs ± 7%      ~     (p=1.000 n=10+10)

name                              old alloc/op   new alloc/op   delta
ParallelPgbenchQuery_Cockroach-8     243kB ± 7%     607kB ±13%  +150.35%  (p=0.000 n=10+10)
ParallelPgbenchQuery_Postgres-8     1.74kB ± 4%    1.72kB ± 6%      ~      (p=0.435 n=9+10)

name                              old allocs/op  new allocs/op  delta
ParallelPgbenchQuery_Cockroach-8     3.86k ± 6%     9.57k ±16%  +148.10%  (p=0.000 n=10+10)
ParallelPgbenchQuery_Postgres-8       39.8 ± 3%      39.4 ± 4%      ~      (p=0.313 n=9+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4629)

<!-- Reviewable:end -->
