### PR TITLE
cli: make sure log dir exists

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -113,20 +113,22 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// --log-dir=$TMPDIR and this will override their request. This can be fixed
 	// by changing the log-dir flag to keep track of whether it has been set or
 	// not. Doesn't seem urgent to do (yet).
-	if f := flag.Lookup("log-dir"); f.Value.String() == os.TempDir() {
+	f := flag.Lookup("log-dir")
+	if f.Value.String() == os.TempDir() {
 		for _, spec := range storeSpecs {
 			if spec.Attrs == "mem" {
 				continue
 			}
-			dir := filepath.Join(spec.Path, "logs")
-			if err := os.MkdirAll(dir, 0755); err != nil {
-				return err
-			}
-			if err := f.Value.Set(dir); err != nil {
+			if err := f.Value.Set(filepath.Join(spec.Path, "logs")); err != nil {
 				return err
 			}
 			break
 		}
+	}
+
+	// Make sure the path exists
+	if err := os.MkdirAll(f.Value.String(), 0755); err != nil {
+		return err
 	}
 
 	info := util.GetBuildInfo()


### PR DESCRIPTION
This fixes the following error:

I0225 10:52:45.498857 5256 cli/start.go:133  [build] alpha.v1-384-gcad048f @ 2016/02/25 02:45:59 (go1.6)
log: exiting because of error: log: cannot create log: open logs/cockroach.vagrant-ubuntu-trusty-64.vagrant.log.INFO.2016-02-25T10_52_45+08_00.5256: no such file or directory

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4632)

<!-- Reviewable:end -->
