### PR TITLE
sql: prevent panic if client sends too many fmt codes

### DIFF
--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -455,6 +455,9 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 		return err
 	}
 	numParams := len(stmt.inTypes)
+	if int(numParamFormatCodes) > numParams {
+		return c.sendError(fmt.Sprintf("too many format codes specified: %d for %d paramaters", numParamFormatCodes, numParams))
+	}
 	paramFormatCodes := make([]formatCode, numParams)
 	for i := range paramFormatCodes[:numParamFormatCodes] {
 		c, err := buf.getInt16()


### PR DESCRIPTION
This is theoretical and difficult to test since it involves breaking
a client, but it's probably safer to try to prevent a panic here. The
panic would occur a few lines down when indexing into paramFormatCodes. If
the client sends 2 format codes, but the statement only has 1 parameter,
it would panic.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4636)

<!-- Reviewable:end -->
