### PR TITLE
cli: humanize input and display of bytes values.

### DIFF
--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -59,3 +59,23 @@ func TestNoLinkForbidden(t *testing.T) {
 		}
 	}
 }
+
+func TestByteFlagValue(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	f := startCmd.Flags()
+	args := []string{"--cache-size", "100MB", "--memtable-budget", "42GiB"}
+	if err := f.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := cliContext
+	const expectedCacheSize = 100 * 1000 * 1000
+	if expectedCacheSize != ctx.CacheSize {
+		t.Errorf("expected %d, but got %d", expectedCacheSize, ctx.CacheSize)
+	}
+	const expectedMemtableBudget = 42 * 1024 * 1024 * 1024
+	if expectedMemtableBudget != ctx.MemtableBudget {
+		t.Errorf("expected %d, but got %d", expectedMemtableBudget, ctx.MemtableBudget)
+	}
+}


### PR DESCRIPTION
This allows: `cockroach start --cache-size 1GB`

Fixes #4348.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4637)

<!-- Reviewable:end -->
