### PR TITLE
sql: support for RETURNING *

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -49,7 +49,7 @@ func (p *planner) Delete(n *parser.Delete, autoCommit bool) (planNode, *roachpb.
 	if pErr != nil {
 		return nil, pErr
 	}
-	rh, err := newReturningHelper(p, n.Returning, tableDesc.Name, tableDesc.Columns)
+	rh, err := makeReturningHelper(p, n.Returning, tableDesc.Name, tableDesc.Columns)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -128,7 +128,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 	marshalled := make([]interface{}, len(cols))
 
 	b := p.txn.NewBatch()
-	rh, err := newReturningHelper(p, n.Returning, tableDesc.Name, cols)
+	rh, err := makeReturningHelper(p, n.Returning, tableDesc.Name, cols)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -548,7 +548,12 @@ func (t *logicTest) execQuery(query logicQuery) {
 
 	var results []string
 	if query.colNames {
-		results = append(results, cols...)
+		for _, col := range cols {
+			// We split column names on whitespace and append a separate "result"
+			// for each string. A bit unusual, but otherwise we can't match strings
+			// containing whitespace.
+			results = append(results, strings.Fields(col)...)
+		}
 	}
 	for rows.Next() {
 		if err := rows.Scan(vals...); err != nil {

--- a/sql/testdata/delete
+++ b/sql/testdata/delete
@@ -78,3 +78,20 @@ DELETE FROM unindexed RETURNING k, v
 query II
 SELECT * FROM unindexed
 ----
+
+statement ok
+INSERT INTO unindexed VALUES (1, 2), (3, 4), (5, 6), (7, 8)
+
+query II colnames
+DELETE FROM unindexed WHERE k=3 or v=6 RETURNING *
+----
+k v
+3 4
+5 6
+
+query II colnames
+DELETE FROM unindexed RETURNING unindexed.*
+----
+k v
+1 2
+7 8

--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -339,6 +339,40 @@ INSERT INTO return VALUES (default) RETURNING rowid != unique_rowid()
 statement error pq: qualified name "b" not found
 INSERT INTO return (a) VALUES (default) RETURNING b
 
-# TODO(mjibson): support *
-statement error pq: qualified name "\*" not found
+query II colnames
 INSERT INTO return VALUES (default) RETURNING *
+----
+a b
+3 NULL
+
+query II colnames
+INSERT INTO return VALUES (1, 2), (3, 4) RETURNING return.a, b
+----
+a b
+1 2
+3 4
+
+query II colnames
+INSERT INTO return VALUES (1, 2), (3, 4) RETURNING *
+----
+a b
+1 2
+3 4
+
+# Verify we return all columns even if we don't provide a value for all of them.
+query II colnames
+INSERT INTO return VALUES (1) RETURNING *
+----
+a b
+1 NULL
+
+
+statement error pq: "return.*" cannot be aliased
+INSERT INTO return VALUES (1, 2), (3, 4) RETURNING return.* as x
+
+query III colnames
+INSERT INTO return VALUES (1, 2), (3, 4) RETURNING return.*, a + b
+----
+a b a + b
+1 2 3
+3 4 7

--- a/sql/testdata/update
+++ b/sql/testdata/update
@@ -171,10 +171,38 @@ SELECT * FROM abc
 ----
 1 6 7
 
-query III
-UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING b, c, 4
+query III colnames
+UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING abc.b, c, 4
 ----
+b c 4
 8 9 4
+
+query III colnames
+UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING b as col1, c as col2, 4 as col3
+----
+col1 col2 col3
+8    9    4
+
+# Issue #4368: we should be able to return other columns.
+query error pq: qualified name "a" not found
+UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING a
+
+# Issue #4368: this should return all columns in the table.
+query II colnames
+UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING *
+----
+b c
+8 9
+
+# Issue #4368: this should return all columns in the table.
+query II colnames
+UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING abc.*
+----
+b c
+8 9
+
+statement error pq: "abc.*" cannot be aliased
+UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING abc.* as x
 
 query III
 SELECT * FROM abc

--- a/sql/update.go
+++ b/sql/update.go
@@ -142,7 +142,7 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 		return nil, pErr
 	}
 
-	rh, err := newReturningHelper(p, n.Returning, tableDesc.Name, cols)
+	rh, err := makeReturningHelper(p, n.Returning, tableDesc.Name, cols)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}


### PR DESCRIPTION
This change adds support for RETURNING \* in inserts and deletes. For updates we
currently only expand the updated columns; this is related to an existing
problem (we can't return other columns even explicitly; filed #4645).

Fixes #4593.

@knz @mjibson

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4647)

<!-- Reviewable:end -->
