### PR TITLE
sql: add 1k row benchmarks

### DIFF
--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -241,6 +241,10 @@ func runBenchmarkInsert100(b *testing.B, db *sql.DB) {
 	runBenchmarkInsert(b, db, 100)
 }
 
+func runBenchmarkInsert1000(b *testing.B, db *sql.DB) {
+	runBenchmarkInsert(b, db, 1000)
+}
+
 func BenchmarkInsert1_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkInsert1)
 }
@@ -263,6 +267,14 @@ func BenchmarkInsert100_Cockroach(b *testing.B) {
 
 func BenchmarkInsert100_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkInsert100)
+}
+
+func BenchmarkInsert1000_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkInsert1000)
+}
+
+func BenchmarkInsert1000_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkInsert1000)
 }
 
 // runBenchmarkUpdate benchmarks updating count random rows in a table.
@@ -325,6 +337,10 @@ func runBenchmarkUpdate100(b *testing.B, db *sql.DB) {
 	runBenchmarkUpdate(b, db, 100)
 }
 
+func runBenchmarkUpdate1000(b *testing.B, db *sql.DB) {
+	runBenchmarkUpdate(b, db, 1000)
+}
+
 func BenchmarkUpdate1_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkUpdate1)
 }
@@ -347,6 +363,14 @@ func BenchmarkUpdate100_Cockroach(b *testing.B) {
 
 func BenchmarkUpdate100_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkUpdate100)
+}
+
+func BenchmarkUpdate1000_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkUpdate1000)
+}
+
+func BenchmarkUpdate1000_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkUpdate1000)
 }
 
 // runBenchmarkDelete benchmarks deleting count rows from a table.
@@ -408,6 +432,10 @@ func runBenchmarkDelete100(b *testing.B, db *sql.DB) {
 	runBenchmarkDelete(b, db, 100)
 }
 
+func runBenchmarkDelete1000(b *testing.B, db *sql.DB) {
+	runBenchmarkDelete(b, db, 1000)
+}
+
 func BenchmarkDelete1_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkDelete1)
 }
@@ -430,6 +458,14 @@ func BenchmarkDelete100_Cockroach(b *testing.B) {
 
 func BenchmarkDelete100_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkDelete100)
+}
+
+func BenchmarkDelete1000_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkDelete1000)
+}
+
+func BenchmarkDelete1000_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkDelete1000)
 }
 
 // runBenchmarkScan benchmarks scanning a table containing count rows.
@@ -511,5 +547,13 @@ func BenchmarkScan100_Cockroach(b *testing.B) {
 }
 
 func BenchmarkScan100_Postgres(b *testing.B) {
+	benchmarkPostgres(b, runBenchmarkScan100)
+}
+
+func BenchmarkScan1000_Cockroach(b *testing.B) {
+	benchmarkCockroach(b, runBenchmarkScan100)
+}
+
+func BenchmarkScan1000_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkScan100)
 }


### PR DESCRIPTION
Some recent changes spculated that they'd have bigger or different impact on larger
numbers of rows, so adding 1k versions of our existing 1, 10, 100 benchmarks.

```
name                    time/op
Delete1000_Cockroach-8   136ms ±10%
Delete100_Cockroach-8   12.1ms ± 2%
Insert1000_Cockroach-8  31.2ms ± 3%
Insert100_Cockroach-8   3.22ms ± 0%
Scan1000_Cockroach-8     522µs ± 2%
Scan100_Cockroach-8      526µs ± 1%
Update1000_Cockroach-8  57.7ms ± 5%
Update100_Cockroach-8   6.08ms ± 1%

name                    alloc/op
Delete1000_Cockroach-8  4.36MB ± 0%
Delete100_Cockroach-8    488kB ± 0%
Insert1000_Cockroach-8  3.95MB ± 1%
Insert100_Cockroach-8    446kB ± 0%
Scan1000_Cockroach-8    41.6kB ± 0%
Scan100_Cockroach-8     41.6kB ± 0%
Update1000_Cockroach-8  6.04MB ± 1%
Update100_Cockroach-8    685kB ± 0%

name                    allocs/op
Delete1000_Cockroach-8   64.8k ± 0%
Delete100_Cockroach-8    6.80k ± 0%
Insert1000_Cockroach-8   44.7k ± 0%
Insert100_Cockroach-8    4.70k ± 0%
Scan1000_Cockroach-8       968 ± 0%
Scan100_Cockroach-8        968 ± 0%
Update1000_Cockroach-8   66.0k ± 1%
Update100_Cockroach-8    7.30k ± 0%
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4649)

<!-- Reviewable:end -->
