### PR TITLE
Fix an anomaly caused by command queue

### DIFF
--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -129,12 +129,21 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 		// the new commands overlapped range. Following this strategy, the other dependencies
 		// will be implicitly enforced, which reduces memory utilization and synchronization
 		// costs.
+		// The exception are existing reads: since reads don't wait for each other, an incoming
+		// write must wait for reads even when they are covered by a "later" read (since that
+		// "later" read won't wait for the earlier read to complete).
+		//
+		// TODO(nvanbeschoten): some (likely minimal) gains are possible: The writer does not
+		// have to blindly wait for all reads; only those which aren't already covered directly
+		// by writes are relevant.
 		sort.Sort(overlapSorter(overlaps))
 		for i := len(overlaps) - 1; i >= 0; i-- {
-			c := overlaps[i]
-			if cq.rg.Add(c.Key.Range) {
-				c := c.Value.(*cmd)
-				c.pending = append(c.pending, wg)
+			keyRange, cmd := overlaps[i].Key.Range, overlaps[i].Value.(*cmd)
+			// If we're a write and the current overlap is a read, we always wait
+			// as discussed above. There's some flexibility about adding to the
+			// RangeGroup in that case (currently we do).
+			if cq.rg.Add(keyRange) || (!readOnly && cmd.readOnly) {
+				cmd.pending = append(cmd.pending, wg)
 				wg.Add(1)
 			}
 		}


### PR DESCRIPTION
Fixes #4607, Fixes #4560.

A recent change the command queue came with an innocuous-looking optimization:
If a new read entered the command queue, it would not wait for previous reads
to overlapping key ranges.

Unfortunately, this introduced the anomaly explained below. Three transactions
A, B and C overlap on a single range, with increasing timestamps. Reads touch
all keys. A only reads; B and C try to read a maximum `m` and then write `m+1`
to their own keys.
The anomaly is that sometimes, B and C can commit with the same new maximum,
which is clearly not linearizable, with the history explained below. The
crux is (***): when B goes in for its write, it doesn't wait for C's read,
which sees the same maximum B read, and should get a chance to update the
timestamp cache. The reason C doesn't wait for B's read is that A went in for
its read after C started, but did not incur a dependency on A (due to the
read-read optimization).

```
+--------------+-----------------------------+
|      A       |       B      |       C      |
---------------+-----------------------------+
|              | enter CQ (r) |              |
|              | read max = 1 |              |
|              | leave CQ (r) |              |
|              |              | enter CQ(r)  |
|              |              | read max = 1 |
| enter CQ (r) |              |              |
|              | enter CQ (w) |              |
|              | wait: A ***  |              |
| read         |              |              |
| leave CQ (r) |              |              |
|              | write 2      |              |
|              | commit       |              |
|              | leave CQ (w) |              |
|              |              | leave CQ (r) |
|              |              | enter CQ (w) |
|              |              | write 2      |
|              |              | commit       |
|              |              | leave CQ (w) |
+--------------+--------------+--------------+
```

The fix is easy: Have write commands wait for all underlying reads, even when
they are already covered.

`Benchmark(Insert|Update|Delete|Scan).*Cockroach` are identical. Ditto for the
Pgbench suite, which had a tiny amount more allocs:

```
name                              old alloc/op   new alloc/op
PgbenchExec_Cockroach-8              152kB ± 0%     153kB ± 0%
PgbenchQuery_Cockroach-8             197kB ± 0%     197kB ± 0%
ParallelPgbenchQuery_Cockroach-8     659kB ± 0%     752kB ± 0%

name                              old allocs/op  new allocs/op
PgbenchExec_Cockroach-8              2.87k ± 0%     2.89k ± 0%
PgbenchQuery_Cockroach-8             3.58k ± 0%     3.57k ± 0%
ParallelPgbenchQuery_Cockroach-8     9.79k ± 0%    10.79k ± 0%
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4651)

<!-- Reviewable:end -->
