### PR TITLE
Implement raft consistency checker

### DIFF
--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -414,4 +415,9 @@ func testNodeRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfi
 	elapsed := time.Since(start)
 	count := atomic.LoadUint64(&client.count)
 	log.Infof("%d %.1f/sec", count, float64(count)/elapsed.Seconds())
+	kvClient, kvStopper := c.NewClient(t, num-1)
+	defer kvStopper.Stop()
+	if pErr := kvClient.CheckConsistency(keys.TableDataMin, keys.TableDataMax); pErr != nil {
+		t.Fatal(pErr.GoError())
+	}
 }

--- a/client/batch.go
+++ b/client/batch.go
@@ -171,6 +171,7 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 			case *roachpb.MergeRequest:
 			case *roachpb.TruncateLogRequest:
 			case *roachpb.LeaderLeaseRequest:
+			case *roachpb.CheckConsistencyRequest:
 				// Nothing to do for these methods as they do not generate any
 				// rows.
 
@@ -336,6 +337,23 @@ func (b *Batch) Scan(s, e interface{}, maxRows int64) {
 // key can be either a byte slice or a string.
 func (b *Batch) ReverseScan(s, e interface{}, maxRows int64) {
 	b.scan(s, e, maxRows, true)
+}
+
+// CheckConsistency creates a batch request to check the consistency of the
+// ranges holding the span of keys from s to e.
+func (b *Batch) CheckConsistency(s, e interface{}) {
+	begin, err := marshalKey(s)
+	if err != nil {
+		b.initResult(0, 0, err)
+		return
+	}
+	end, err := marshalKey(e)
+	if err != nil {
+		b.initResult(0, 0, err)
+		return
+	}
+	b.reqs = append(b.reqs, roachpb.NewCheckConsistency(roachpb.Key(begin), roachpb.Key(end)))
+	b.initResult(1, 0, nil)
 }
 
 // Del deletes one or more keys.

--- a/client/db.go
+++ b/client/db.go
@@ -322,6 +322,15 @@ func (db *DB) AdminSplit(splitKey interface{}) *roachpb.Error {
 	return pErr
 }
 
+// CheckConsistency runs a consistency check on all the ranges containing
+// the key span.
+func (db *DB) CheckConsistency(begin, end interface{}) *roachpb.Error {
+	b := db.NewBatch()
+	b.CheckConsistency(begin, end)
+	_, pErr := runOneResult(db, b)
+	return pErr
+}
+
 // sendAndFill is a helper which sends the given batch and fills its results,
 // returning the appropriate error which is either from the first failing call,
 // or an "internal" error.

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -317,12 +317,13 @@ func TestCommonMethods(t *testing.T) {
 		// request with the information that this particular Get must be
 		// unmarshaled, which didn't seem worth doing as we're not using
 		// Batch.GetProto at the moment.
-		key{dbType, "GetProto"}:  {},
-		key{txnType, "GetProto"}: {},
-
+		key{dbType, "GetProto"}:                   {},
+		key{txnType, "GetProto"}:                  {},
+		key{batchType, "CheckConsistency"}:        {},
 		key{batchType, "InternalAddRequest"}:      {},
 		key{dbType, "AdminMerge"}:                 {},
 		key{dbType, "AdminSplit"}:                 {},
+		key{dbType, "CheckConsistency"}:           {},
 		key{dbType, "NewBatch"}:                   {},
 		key{dbType, "Run"}:                        {},
 		key{dbType, "RunWithResponse"}:            {},

--- a/kv/db.go
+++ b/kv/db.go
@@ -42,6 +42,7 @@ var allExternalMethods = [...]roachpb.Request{
 	roachpb.EndTransaction:   &roachpb.EndTransactionRequest{},
 	roachpb.AdminSplit:       &roachpb.AdminSplitRequest{},
 	roachpb.AdminMerge:       &roachpb.AdminMergeRequest{},
+	roachpb.CheckConsistency: &roachpb.CheckConsistencyRequest{},
 }
 
 // A DBServer provides an HTTP server endpoint serving the key-value API.

--- a/roachpb/api.go
+++ b/roachpb/api.go
@@ -189,6 +189,17 @@ func (rr *ResolveIntentRangeResponse) combine(c combinable) error {
 	return nil
 }
 
+// Combine implements the combinable interface.
+func (cc *CheckConsistencyResponse) combine(c combinable) error {
+	if cc != nil {
+		otherCC := c.(*CheckConsistencyResponse)
+		if err := cc.Header().combine(otherCC.Header()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Header implements the Request interface for RequestHeader.
 func (rh *Span) Header() *Span {
 	return rh
@@ -312,6 +323,9 @@ func (*ScanRequest) Method() Method { return Scan }
 func (*ReverseScanRequest) Method() Method { return ReverseScan }
 
 // Method implements the Request interface.
+func (*CheckConsistencyRequest) Method() Method { return CheckConsistency }
+
+// Method implements the Request interface.
 func (*BeginTransactionRequest) Method() Method { return BeginTransaction }
 
 // Method implements the Request interface.
@@ -353,6 +367,12 @@ func (*TruncateLogRequest) Method() Method { return TruncateLog }
 // Method implements the Request interface.
 func (*LeaderLeaseRequest) Method() Method { return LeaderLease }
 
+// Method implements the Request interface.
+func (*ComputeChecksumRequest) Method() Method { return ComputeChecksum }
+
+// Method implements the Request interface.
+func (*VerifyChecksumRequest) Method() Method { return VerifyChecksum }
+
 func (*GetRequest) createReply() Response                { return &GetResponse{} }
 func (*PutRequest) createReply() Response                { return &PutResponse{} }
 func (*ConditionalPutRequest) createReply() Response     { return &ConditionalPutResponse{} }
@@ -361,6 +381,7 @@ func (*DeleteRequest) createReply() Response             { return &DeleteRespons
 func (*DeleteRangeRequest) createReply() Response        { return &DeleteRangeResponse{} }
 func (*ScanRequest) createReply() Response               { return &ScanResponse{} }
 func (*ReverseScanRequest) createReply() Response        { return &ReverseScanResponse{} }
+func (*CheckConsistencyRequest) createReply() Response   { return &CheckConsistencyResponse{} }
 func (*BeginTransactionRequest) createReply() Response   { return &BeginTransactionResponse{} }
 func (*EndTransactionRequest) createReply() Response     { return &EndTransactionResponse{} }
 func (*AdminSplitRequest) createReply() Response         { return &AdminSplitResponse{} }
@@ -375,6 +396,8 @@ func (*NoopRequest) createReply() Response               { return &NoopResponse{
 func (*MergeRequest) createReply() Response              { return &MergeResponse{} }
 func (*TruncateLogRequest) createReply() Response        { return &TruncateLogResponse{} }
 func (*LeaderLeaseRequest) createReply() Response        { return &LeaderLeaseResponse{} }
+func (*ComputeChecksumRequest) createReply() Response    { return &ComputeChecksumResponse{} }
+func (*VerifyChecksumRequest) createReply() Response     { return &VerifyChecksumResponse{} }
 
 // NewGet returns a Request initialized to get the value at key.
 func NewGet(key Key) Request {
@@ -458,6 +481,16 @@ func NewScan(key, endKey Key, maxResults int64) Request {
 	}
 }
 
+// NewCheckConsistency returns a Request initialized to scan from start to end keys.
+func NewCheckConsistency(key, endKey Key) Request {
+	return &CheckConsistencyRequest{
+		Span: Span{
+			Key:    key,
+			EndKey: endKey,
+		},
+	}
+}
+
 // NewReverseScan returns a Request initialized to reverse scan from end to
 // start keys with max results.
 func NewReverseScan(key, endKey Key, maxResults int64) Request {
@@ -492,3 +525,6 @@ func (*NoopRequest) flags() int               { return isRead } // slightly spec
 func (*MergeRequest) flags() int              { return isWrite }
 func (*TruncateLogRequest) flags() int        { return isWrite }
 func (*LeaderLeaseRequest) flags() int        { return isWrite }
+func (*ComputeChecksumRequest) flags() int    { return isWrite }
+func (*VerifyChecksumRequest) flags() int     { return isWrite }
+func (*CheckConsistencyRequest) flags() int   { return isAdmin | isRange }

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -31,6 +31,8 @@
 		ScanResponse
 		ReverseScanRequest
 		ReverseScanResponse
+		CheckConsistencyRequest
+		CheckConsistencyResponse
 		BeginTransactionRequest
 		BeginTransactionResponse
 		EndTransactionRequest
@@ -59,6 +61,10 @@
 		TruncateLogResponse
 		LeaderLeaseRequest
 		LeaderLeaseResponse
+		ComputeChecksumRequest
+		ComputeChecksumResponse
+		VerifyChecksumRequest
+		VerifyChecksumResponse
 		RequestUnion
 		ResponseUnion
 		Header
@@ -126,6 +132,8 @@ import math "math"
 import cockroach_util_tracing "github.com/cockroachdb/cockroach/util/tracing"
 
 // skipping weak import gogoproto "github.com/cockroachdb/gogoproto"
+
+import github_com_cockroachdb_cockroach_util_uuid "github.com/cockroachdb/cockroach/util/uuid"
 
 import (
 	context "golang.org/x/net/context"
@@ -434,6 +442,28 @@ type ReverseScanResponse struct {
 func (m *ReverseScanResponse) Reset()         { *m = ReverseScanResponse{} }
 func (m *ReverseScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanResponse) ProtoMessage()    {}
+
+// A CheckConsistencyRequest is the argument to the CheckConsistency() method.
+// It specifies the start and end keys for a span of ranges to which a consistency
+// check should be applied. A consistency check on a range involves running a
+// ComputeChecksum on the range followed by a VerifyChecksum.
+type CheckConsistencyRequest struct {
+	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+}
+
+func (m *CheckConsistencyRequest) Reset()         { *m = CheckConsistencyRequest{} }
+func (m *CheckConsistencyRequest) String() string { return proto.CompactTextString(m) }
+func (*CheckConsistencyRequest) ProtoMessage()    {}
+
+// A CheckConsistencyResponse is the return value from the CheckConsistency() method.
+// If a replica finds itself to be inconsistent with its leader it will panic.
+type CheckConsistencyResponse struct {
+	ResponseHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+}
+
+func (m *CheckConsistencyResponse) Reset()         { *m = CheckConsistencyResponse{} }
+func (m *CheckConsistencyResponse) String() string { return proto.CompactTextString(m) }
+func (*CheckConsistencyResponse) ProtoMessage()    {}
 
 // A BeginTransactionRequest is the argument to the BeginTransaction() method.
 type BeginTransactionRequest struct {
@@ -870,6 +900,58 @@ func (m *LeaderLeaseResponse) Reset()         { *m = LeaderLeaseResponse{} }
 func (m *LeaderLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*LeaderLeaseResponse) ProtoMessage()    {}
 
+// A ComputeChecksumRequest is arguments to the ComputeChecksum() method, to
+// start computing the checksum for the specified range at the snapshot for
+// this request command. A response is returned without the checksum.
+// The computed checksum is later compared to the one supplied
+// through a VerifyChecksumRequest.
+type ComputeChecksumRequest struct {
+	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	// The version used to pick the checksum method. It allows us to use a
+	// consistent checksumming method across replicas.
+	Version uint32 `protobuf:"varint,2,opt,name=version" json:"version"`
+	// A unique identifier to match a future VerifyChecksumRequest with this request.
+	ChecksumID github_com_cockroachdb_cockroach_util_uuid.UUID `protobuf:"bytes,3,opt,name=checksum_id,customtype=github.com/cockroachdb/cockroach/util/uuid.UUID" json:"checksum_id"`
+}
+
+func (m *ComputeChecksumRequest) Reset()         { *m = ComputeChecksumRequest{} }
+func (m *ComputeChecksumRequest) String() string { return proto.CompactTextString(m) }
+func (*ComputeChecksumRequest) ProtoMessage()    {}
+
+// A ComputeChecksumResponse is the response to a ComputeChecksum() operation.
+type ComputeChecksumResponse struct {
+	ResponseHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+}
+
+func (m *ComputeChecksumResponse) Reset()         { *m = ComputeChecksumResponse{} }
+func (m *ComputeChecksumResponse) String() string { return proto.CompactTextString(m) }
+func (*ComputeChecksumResponse) ProtoMessage()    {}
+
+// A VerifyChecksumRequest is arguments to the VerifyChecksum() method, to
+// verify the checksum computed on the leader against the one requested
+// earlier through a ComputeChecksumRequest with the same checksum_id.
+type VerifyChecksumRequest struct {
+	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	// The version used to pick the checksum method. It allows us to use a
+	// consistent checksumming method across replicas.
+	Version    uint32                                          `protobuf:"varint,2,opt,name=version" json:"version"`
+	ChecksumID github_com_cockroachdb_cockroach_util_uuid.UUID `protobuf:"bytes,3,opt,name=checksum_id,customtype=github.com/cockroachdb/cockroach/util/uuid.UUID" json:"checksum_id"`
+	Checksum   []byte                                          `protobuf:"bytes,4,opt,name=checksum" json:"checksum,omitempty"`
+}
+
+func (m *VerifyChecksumRequest) Reset()         { *m = VerifyChecksumRequest{} }
+func (m *VerifyChecksumRequest) String() string { return proto.CompactTextString(m) }
+func (*VerifyChecksumRequest) ProtoMessage()    {}
+
+// A VerifyChecksumResponse is the response to a VerifyChecksum() operation.
+type VerifyChecksumResponse struct {
+	ResponseHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+}
+
+func (m *VerifyChecksumResponse) Reset()         { *m = VerifyChecksumResponse{} }
+func (m *VerifyChecksumResponse) String() string { return proto.CompactTextString(m) }
+func (*VerifyChecksumResponse) ProtoMessage()    {}
+
 // A RequestUnion contains exactly one of the optional requests.
 // The values added here must match those in ResponseUnion.
 type RequestUnion struct {
@@ -894,7 +976,10 @@ type RequestUnion struct {
 	TruncateLog        *TruncateLogRequest        `protobuf:"bytes,19,opt,name=truncate_log" json:"truncate_log,omitempty"`
 	LeaderLease        *LeaderLeaseRequest        `protobuf:"bytes,20,opt,name=leader_lease" json:"leader_lease,omitempty"`
 	ReverseScan        *ReverseScanRequest        `protobuf:"bytes,21,opt,name=reverse_scan" json:"reverse_scan,omitempty"`
-	Noop               *NoopRequest               `protobuf:"bytes,22,opt,name=noop" json:"noop,omitempty"`
+	ComputeChecksum    *ComputeChecksumRequest    `protobuf:"bytes,22,opt,name=compute_checksum" json:"compute_checksum,omitempty"`
+	VerifyChecksum     *VerifyChecksumRequest     `protobuf:"bytes,23,opt,name=verify_checksum" json:"verify_checksum,omitempty"`
+	CheckConsistency   *CheckConsistencyRequest   `protobuf:"bytes,24,opt,name=check_consistency" json:"check_consistency,omitempty"`
+	Noop               *NoopRequest               `protobuf:"bytes,25,opt,name=noop" json:"noop,omitempty"`
 }
 
 func (m *RequestUnion) Reset()         { *m = RequestUnion{} }
@@ -925,7 +1010,10 @@ type ResponseUnion struct {
 	TruncateLog        *TruncateLogResponse        `protobuf:"bytes,19,opt,name=truncate_log" json:"truncate_log,omitempty"`
 	LeaderLease        *LeaderLeaseResponse        `protobuf:"bytes,20,opt,name=leader_lease" json:"leader_lease,omitempty"`
 	ReverseScan        *ReverseScanResponse        `protobuf:"bytes,21,opt,name=reverse_scan" json:"reverse_scan,omitempty"`
-	Noop               *NoopResponse               `protobuf:"bytes,22,opt,name=noop" json:"noop,omitempty"`
+	ComputeChecksum    *ComputeChecksumResponse    `protobuf:"bytes,22,opt,name=compute_checksum" json:"compute_checksum,omitempty"`
+	VerifyChecksum     *VerifyChecksumResponse     `protobuf:"bytes,23,opt,name=verify_checksum" json:"verify_checksum,omitempty"`
+	CheckConsistency   *CheckConsistencyResponse   `protobuf:"bytes,24,opt,name=check_consistency" json:"check_consistency,omitempty"`
+	Noop               *NoopResponse               `protobuf:"bytes,25,opt,name=noop" json:"noop,omitempty"`
 }
 
 func (m *ResponseUnion) Reset()         { *m = ResponseUnion{} }
@@ -1030,6 +1118,8 @@ func init() {
 	proto.RegisterType((*ScanResponse)(nil), "cockroach.roachpb.ScanResponse")
 	proto.RegisterType((*ReverseScanRequest)(nil), "cockroach.roachpb.ReverseScanRequest")
 	proto.RegisterType((*ReverseScanResponse)(nil), "cockroach.roachpb.ReverseScanResponse")
+	proto.RegisterType((*CheckConsistencyRequest)(nil), "cockroach.roachpb.CheckConsistencyRequest")
+	proto.RegisterType((*CheckConsistencyResponse)(nil), "cockroach.roachpb.CheckConsistencyResponse")
 	proto.RegisterType((*BeginTransactionRequest)(nil), "cockroach.roachpb.BeginTransactionRequest")
 	proto.RegisterType((*BeginTransactionResponse)(nil), "cockroach.roachpb.BeginTransactionResponse")
 	proto.RegisterType((*EndTransactionRequest)(nil), "cockroach.roachpb.EndTransactionRequest")
@@ -1059,6 +1149,10 @@ func init() {
 	proto.RegisterType((*TruncateLogResponse)(nil), "cockroach.roachpb.TruncateLogResponse")
 	proto.RegisterType((*LeaderLeaseRequest)(nil), "cockroach.roachpb.LeaderLeaseRequest")
 	proto.RegisterType((*LeaderLeaseResponse)(nil), "cockroach.roachpb.LeaderLeaseResponse")
+	proto.RegisterType((*ComputeChecksumRequest)(nil), "cockroach.roachpb.ComputeChecksumRequest")
+	proto.RegisterType((*ComputeChecksumResponse)(nil), "cockroach.roachpb.ComputeChecksumResponse")
+	proto.RegisterType((*VerifyChecksumRequest)(nil), "cockroach.roachpb.VerifyChecksumRequest")
+	proto.RegisterType((*VerifyChecksumResponse)(nil), "cockroach.roachpb.VerifyChecksumResponse")
 	proto.RegisterType((*RequestUnion)(nil), "cockroach.roachpb.RequestUnion")
 	proto.RegisterType((*ResponseUnion)(nil), "cockroach.roachpb.ResponseUnion")
 	proto.RegisterType((*Header)(nil), "cockroach.roachpb.Header")
@@ -1730,6 +1824,58 @@ func (m *ReverseScanResponse) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
+func (m *CheckConsistencyRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *CheckConsistencyRequest) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
+	n23, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n23
+	return i, nil
+}
+
+func (m *CheckConsistencyResponse) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *CheckConsistencyResponse) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
+	n24, err := m.ResponseHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n24
+	return i, nil
+}
+
 func (m *BeginTransactionRequest) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -1748,11 +1894,11 @@ func (m *BeginTransactionRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n23, err := m.Span.MarshalTo(data[i:])
+	n25, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n25
 	return i, nil
 }
 
@@ -1774,11 +1920,11 @@ func (m *BeginTransactionResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n24, err := m.ResponseHeader.MarshalTo(data[i:])
+	n26, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n24
+	i += n26
 	return i, nil
 }
 
@@ -1800,11 +1946,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n25, err := m.Span.MarshalTo(data[i:])
+	n27, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n25
+	i += n27
 	data[i] = 0x10
 	i++
 	if m.Commit {
@@ -1817,21 +1963,21 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Deadline.Size()))
-		n26, err := m.Deadline.MarshalTo(data[i:])
+		n28, err := m.Deadline.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n26
+		i += n28
 	}
 	if m.InternalCommitTrigger != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.InternalCommitTrigger.Size()))
-		n27, err := m.InternalCommitTrigger.MarshalTo(data[i:])
+		n29, err := m.InternalCommitTrigger.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n27
+		i += n29
 	}
 	if len(m.IntentSpans) > 0 {
 		for _, msg := range m.IntentSpans {
@@ -1866,11 +2012,11 @@ func (m *EndTransactionResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n28, err := m.ResponseHeader.MarshalTo(data[i:])
+	n30, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n28
+	i += n30
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.CommitWait))
@@ -1903,11 +2049,11 @@ func (m *AdminSplitRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n29, err := m.Span.MarshalTo(data[i:])
+	n31, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n29
+	i += n31
 	if m.SplitKey != nil {
 		data[i] = 0x12
 		i++
@@ -1935,11 +2081,11 @@ func (m *AdminSplitResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n30, err := m.ResponseHeader.MarshalTo(data[i:])
+	n32, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n30
+	i += n32
 	return i, nil
 }
 
@@ -1961,11 +2107,11 @@ func (m *AdminMergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n31, err := m.Span.MarshalTo(data[i:])
+	n33, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n31
+	i += n33
 	return i, nil
 }
 
@@ -1987,11 +2133,11 @@ func (m *AdminMergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n32, err := m.ResponseHeader.MarshalTo(data[i:])
+	n34, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n32
+	i += n34
 	return i, nil
 }
 
@@ -2013,11 +2159,11 @@ func (m *RangeLookupRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n33, err := m.Span.MarshalTo(data[i:])
+	n35, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n33
+	i += n35
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxRanges))
@@ -2058,11 +2204,11 @@ func (m *RangeLookupResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n34, err := m.ResponseHeader.MarshalTo(data[i:])
+	n36, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n34
+	i += n36
 	if len(m.Ranges) > 0 {
 		for _, msg := range m.Ranges {
 			data[i] = 0x12
@@ -2096,19 +2242,19 @@ func (m *HeartbeatTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n35, err := m.Span.MarshalTo(data[i:])
+	n37, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n35
+	i += n37
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n36, err := m.Now.MarshalTo(data[i:])
+	n38, err := m.Now.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n36
+	i += n38
 	return i, nil
 }
 
@@ -2130,11 +2276,11 @@ func (m *HeartbeatTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n37, err := m.ResponseHeader.MarshalTo(data[i:])
+	n39, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n37
+	i += n39
 	return i, nil
 }
 
@@ -2156,11 +2302,11 @@ func (m *GCRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n38, err := m.Span.MarshalTo(data[i:])
+	n40, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n38
+	i += n40
 	if len(m.Keys) > 0 {
 		for _, msg := range m.Keys {
 			data[i] = 0x1a
@@ -2200,11 +2346,11 @@ func (m *GCRequest_GCKey) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n39, err := m.Timestamp.MarshalTo(data[i:])
+	n41, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n39
+	i += n41
 	return i, nil
 }
 
@@ -2226,11 +2372,11 @@ func (m *GCResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n40, err := m.ResponseHeader.MarshalTo(data[i:])
+	n42, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n40
+	i += n42
 	return i, nil
 }
 
@@ -2252,43 +2398,43 @@ func (m *PushTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n41, err := m.Span.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n41
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
-	n42, err := m.PusherTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n42
-	data[i] = 0x1a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-	n43, err := m.PusheeTxn.MarshalTo(data[i:])
+	n43, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n43
-	data[i] = 0x22
+	data[i] = 0x12
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
-	n44, err := m.PushTo.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
+	n44, err := m.PusherTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n44
-	data[i] = 0x2a
+	data[i] = 0x1a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n45, err := m.Now.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
+	n45, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n45
+	data[i] = 0x22
+	i++
+	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
+	n46, err := m.PushTo.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n46
+	data[i] = 0x2a
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
+	n47, err := m.Now.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n47
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.PushType))
@@ -2313,19 +2459,19 @@ func (m *PushTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n46, err := m.ResponseHeader.MarshalTo(data[i:])
+	n48, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n46
+	i += n48
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-	n47, err := m.PusheeTxn.MarshalTo(data[i:])
+	n49, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n47
+	i += n49
 	return i, nil
 }
 
@@ -2347,19 +2493,19 @@ func (m *ResolveIntentRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n48, err := m.Span.MarshalTo(data[i:])
+	n50, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n48
+	i += n50
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n49, err := m.IntentTxn.MarshalTo(data[i:])
+	n51, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n49
+	i += n51
 	data[i] = 0x18
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Status))
@@ -2392,11 +2538,11 @@ func (m *ResolveIntentResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n50, err := m.ResponseHeader.MarshalTo(data[i:])
+	n52, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n50
+	i += n52
 	return i, nil
 }
 
@@ -2418,19 +2564,19 @@ func (m *ResolveIntentRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n51, err := m.Span.MarshalTo(data[i:])
+	n53, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n51
+	i += n53
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n52, err := m.IntentTxn.MarshalTo(data[i:])
+	n54, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n52
+	i += n54
 	data[i] = 0x18
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Status))
@@ -2463,11 +2609,11 @@ func (m *NoopResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n53, err := m.ResponseHeader.MarshalTo(data[i:])
+	n55, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n53
+	i += n55
 	return i, nil
 }
 
@@ -2489,11 +2635,11 @@ func (m *NoopRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n54, err := m.Span.MarshalTo(data[i:])
+	n56, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n54
+	i += n56
 	return i, nil
 }
 
@@ -2515,11 +2661,11 @@ func (m *ResolveIntentRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n55, err := m.ResponseHeader.MarshalTo(data[i:])
+	n57, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n55
+	i += n57
 	return i, nil
 }
 
@@ -2541,19 +2687,19 @@ func (m *MergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n56, err := m.Span.MarshalTo(data[i:])
+	n58, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n56
+	i += n58
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n57, err := m.Value.MarshalTo(data[i:])
+	n59, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n57
+	i += n59
 	return i, nil
 }
 
@@ -2575,11 +2721,11 @@ func (m *MergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n58, err := m.ResponseHeader.MarshalTo(data[i:])
+	n60, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n58
+	i += n60
 	return i, nil
 }
 
@@ -2601,11 +2747,11 @@ func (m *TruncateLogRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n59, err := m.Span.MarshalTo(data[i:])
+	n61, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n59
+	i += n61
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Index))
@@ -2633,11 +2779,11 @@ func (m *TruncateLogResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n60, err := m.ResponseHeader.MarshalTo(data[i:])
+	n62, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n60
+	i += n62
 	return i, nil
 }
 
@@ -2659,19 +2805,19 @@ func (m *LeaderLeaseRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n61, err := m.Span.MarshalTo(data[i:])
+	n63, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n61
+	i += n63
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
-	n62, err := m.Lease.MarshalTo(data[i:])
+	n64, err := m.Lease.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n62
+	i += n64
 	return i, nil
 }
 
@@ -2693,11 +2839,143 @@ func (m *LeaderLeaseResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n63, err := m.ResponseHeader.MarshalTo(data[i:])
+	n65, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n63
+	i += n65
+	return i, nil
+}
+
+func (m *ComputeChecksumRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ComputeChecksumRequest) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
+	n66, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n66
+	data[i] = 0x10
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Version))
+	data[i] = 0x1a
+	i++
+	i = encodeVarintApi(data, i, uint64(m.ChecksumID.Size()))
+	n67, err := m.ChecksumID.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n67
+	return i, nil
+}
+
+func (m *ComputeChecksumResponse) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ComputeChecksumResponse) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
+	n68, err := m.ResponseHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n68
+	return i, nil
+}
+
+func (m *VerifyChecksumRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *VerifyChecksumRequest) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
+	n69, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n69
+	data[i] = 0x10
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Version))
+	data[i] = 0x1a
+	i++
+	i = encodeVarintApi(data, i, uint64(m.ChecksumID.Size()))
+	n70, err := m.ChecksumID.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n70
+	if m.Checksum != nil {
+		data[i] = 0x22
+		i++
+		i = encodeVarintApi(data, i, uint64(len(m.Checksum)))
+		i += copy(data[i:], m.Checksum)
+	}
+	return i, nil
+}
+
+func (m *VerifyChecksumResponse) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *VerifyChecksumResponse) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
+	n71, err := m.ResponseHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n71
 	return i, nil
 }
 
@@ -2720,151 +2998,151 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n64, err := m.Get.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n64
-	}
-	if m.Put != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n65, err := m.Put.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n65
-	}
-	if m.ConditionalPut != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n66, err := m.ConditionalPut.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n66
-	}
-	if m.Increment != nil {
-		data[i] = 0x22
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n67, err := m.Increment.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n67
-	}
-	if m.Delete != nil {
-		data[i] = 0x2a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n68, err := m.Delete.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n68
-	}
-	if m.DeleteRange != nil {
-		data[i] = 0x32
-		i++
-		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n69, err := m.DeleteRange.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n69
-	}
-	if m.Scan != nil {
-		data[i] = 0x3a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n70, err := m.Scan.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n70
-	}
-	if m.BeginTransaction != nil {
-		data[i] = 0x42
-		i++
-		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
-		n71, err := m.BeginTransaction.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n71
-	}
-	if m.EndTransaction != nil {
-		data[i] = 0x4a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n72, err := m.EndTransaction.MarshalTo(data[i:])
+		n72, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n72
 	}
-	if m.AdminSplit != nil {
-		data[i] = 0x52
+	if m.Put != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n73, err := m.AdminSplit.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
+		n73, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n73
 	}
-	if m.AdminMerge != nil {
-		data[i] = 0x5a
+	if m.ConditionalPut != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n74, err := m.AdminMerge.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
+		n74, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n74
 	}
-	if m.HeartbeatTxn != nil {
-		data[i] = 0x62
+	if m.Increment != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n75, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
+		n75, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n75
 	}
-	if m.Gc != nil {
-		data[i] = 0x6a
+	if m.Delete != nil {
+		data[i] = 0x2a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n76, err := m.Gc.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
+		n76, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n76
 	}
-	if m.PushTxn != nil {
-		data[i] = 0x72
+	if m.DeleteRange != nil {
+		data[i] = 0x32
 		i++
-		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n77, err := m.PushTxn.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
+		n77, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n77
 	}
-	if m.RangeLookup != nil {
-		data[i] = 0x7a
+	if m.Scan != nil {
+		data[i] = 0x3a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n78, err := m.RangeLookup.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
+		n78, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n78
+	}
+	if m.BeginTransaction != nil {
+		data[i] = 0x42
+		i++
+		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
+		n79, err := m.BeginTransaction.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n79
+	}
+	if m.EndTransaction != nil {
+		data[i] = 0x4a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
+		n80, err := m.EndTransaction.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n80
+	}
+	if m.AdminSplit != nil {
+		data[i] = 0x52
+		i++
+		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
+		n81, err := m.AdminSplit.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n81
+	}
+	if m.AdminMerge != nil {
+		data[i] = 0x5a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
+		n82, err := m.AdminMerge.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n82
+	}
+	if m.HeartbeatTxn != nil {
+		data[i] = 0x62
+		i++
+		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
+		n83, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n83
+	}
+	if m.Gc != nil {
+		data[i] = 0x6a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
+		n84, err := m.Gc.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n84
+	}
+	if m.PushTxn != nil {
+		data[i] = 0x72
+		i++
+		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
+		n85, err := m.PushTxn.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n85
+	}
+	if m.RangeLookup != nil {
+		data[i] = 0x7a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
+		n86, err := m.RangeLookup.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n86
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x82
@@ -2872,11 +3150,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n79, err := m.ResolveIntent.MarshalTo(data[i:])
+		n87, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n79
+		i += n87
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x8a
@@ -2884,11 +3162,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n80, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n88, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n80
+		i += n88
 	}
 	if m.Merge != nil {
 		data[i] = 0x92
@@ -2896,11 +3174,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n81, err := m.Merge.MarshalTo(data[i:])
+		n89, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n81
+		i += n89
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x9a
@@ -2908,11 +3186,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n82, err := m.TruncateLog.MarshalTo(data[i:])
+		n90, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n82
+		i += n90
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0xa2
@@ -2920,11 +3198,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n83, err := m.LeaderLease.MarshalTo(data[i:])
+		n91, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n83
+		i += n91
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xaa
@@ -2932,23 +3210,59 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n84, err := m.ReverseScan.MarshalTo(data[i:])
+		n92, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n84
+		i += n92
 	}
-	if m.Noop != nil {
+	if m.ComputeChecksum != nil {
 		data[i] = 0xb2
 		i++
 		data[i] = 0x1
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n85, err := m.Noop.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ComputeChecksum.Size()))
+		n93, err := m.ComputeChecksum.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n85
+		i += n93
+	}
+	if m.VerifyChecksum != nil {
+		data[i] = 0xba
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.VerifyChecksum.Size()))
+		n94, err := m.VerifyChecksum.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n94
+	}
+	if m.CheckConsistency != nil {
+		data[i] = 0xc2
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.CheckConsistency.Size()))
+		n95, err := m.CheckConsistency.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n95
+	}
+	if m.Noop != nil {
+		data[i] = 0xca
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
+		n96, err := m.Noop.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n96
 	}
 	return i, nil
 }
@@ -2972,151 +3286,151 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n86, err := m.Get.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n86
-	}
-	if m.Put != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n87, err := m.Put.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n87
-	}
-	if m.ConditionalPut != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n88, err := m.ConditionalPut.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n88
-	}
-	if m.Increment != nil {
-		data[i] = 0x22
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n89, err := m.Increment.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n89
-	}
-	if m.Delete != nil {
-		data[i] = 0x2a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n90, err := m.Delete.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n90
-	}
-	if m.DeleteRange != nil {
-		data[i] = 0x32
-		i++
-		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n91, err := m.DeleteRange.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n91
-	}
-	if m.Scan != nil {
-		data[i] = 0x3a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n92, err := m.Scan.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n92
-	}
-	if m.BeginTransaction != nil {
-		data[i] = 0x42
-		i++
-		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
-		n93, err := m.BeginTransaction.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n93
-	}
-	if m.EndTransaction != nil {
-		data[i] = 0x4a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n94, err := m.EndTransaction.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n94
-	}
-	if m.AdminSplit != nil {
-		data[i] = 0x52
-		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n95, err := m.AdminSplit.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n95
-	}
-	if m.AdminMerge != nil {
-		data[i] = 0x5a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n96, err := m.AdminMerge.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n96
-	}
-	if m.HeartbeatTxn != nil {
-		data[i] = 0x62
-		i++
-		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n97, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		n97, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n97
 	}
-	if m.Gc != nil {
-		data[i] = 0x6a
+	if m.Put != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n98, err := m.Gc.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
+		n98, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n98
 	}
-	if m.PushTxn != nil {
-		data[i] = 0x72
+	if m.ConditionalPut != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n99, err := m.PushTxn.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
+		n99, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n99
 	}
-	if m.RangeLookup != nil {
-		data[i] = 0x7a
+	if m.Increment != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n100, err := m.RangeLookup.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
+		n100, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n100
+	}
+	if m.Delete != nil {
+		data[i] = 0x2a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
+		n101, err := m.Delete.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n101
+	}
+	if m.DeleteRange != nil {
+		data[i] = 0x32
+		i++
+		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
+		n102, err := m.DeleteRange.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n102
+	}
+	if m.Scan != nil {
+		data[i] = 0x3a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
+		n103, err := m.Scan.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n103
+	}
+	if m.BeginTransaction != nil {
+		data[i] = 0x42
+		i++
+		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
+		n104, err := m.BeginTransaction.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n104
+	}
+	if m.EndTransaction != nil {
+		data[i] = 0x4a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
+		n105, err := m.EndTransaction.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n105
+	}
+	if m.AdminSplit != nil {
+		data[i] = 0x52
+		i++
+		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
+		n106, err := m.AdminSplit.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n106
+	}
+	if m.AdminMerge != nil {
+		data[i] = 0x5a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
+		n107, err := m.AdminMerge.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n107
+	}
+	if m.HeartbeatTxn != nil {
+		data[i] = 0x62
+		i++
+		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
+		n108, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n108
+	}
+	if m.Gc != nil {
+		data[i] = 0x6a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
+		n109, err := m.Gc.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n109
+	}
+	if m.PushTxn != nil {
+		data[i] = 0x72
+		i++
+		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
+		n110, err := m.PushTxn.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n110
+	}
+	if m.RangeLookup != nil {
+		data[i] = 0x7a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
+		n111, err := m.RangeLookup.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n111
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x82
@@ -3124,11 +3438,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n101, err := m.ResolveIntent.MarshalTo(data[i:])
+		n112, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n101
+		i += n112
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x8a
@@ -3136,11 +3450,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n102, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n113, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n102
+		i += n113
 	}
 	if m.Merge != nil {
 		data[i] = 0x92
@@ -3148,11 +3462,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n103, err := m.Merge.MarshalTo(data[i:])
+		n114, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n103
+		i += n114
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x9a
@@ -3160,11 +3474,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n104, err := m.TruncateLog.MarshalTo(data[i:])
+		n115, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n104
+		i += n115
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0xa2
@@ -3172,11 +3486,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n105, err := m.LeaderLease.MarshalTo(data[i:])
+		n116, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n105
+		i += n116
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xaa
@@ -3184,23 +3498,59 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n106, err := m.ReverseScan.MarshalTo(data[i:])
+		n117, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n106
+		i += n117
 	}
-	if m.Noop != nil {
+	if m.ComputeChecksum != nil {
 		data[i] = 0xb2
 		i++
 		data[i] = 0x1
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n107, err := m.Noop.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ComputeChecksum.Size()))
+		n118, err := m.ComputeChecksum.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n107
+		i += n118
+	}
+	if m.VerifyChecksum != nil {
+		data[i] = 0xba
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.VerifyChecksum.Size()))
+		n119, err := m.VerifyChecksum.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n119
+	}
+	if m.CheckConsistency != nil {
+		data[i] = 0xc2
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.CheckConsistency.Size()))
+		n120, err := m.CheckConsistency.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n120
+	}
+	if m.Noop != nil {
+		data[i] = 0xca
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
+		n121, err := m.Noop.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n121
 	}
 	return i, nil
 }
@@ -3223,19 +3573,19 @@ func (m *Header) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n108, err := m.Timestamp.MarshalTo(data[i:])
+	n122, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n108
+	i += n122
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
-	n109, err := m.Replica.MarshalTo(data[i:])
+	n123, err := m.Replica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n109
+	i += n123
 	data[i] = 0x18
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RangeID))
@@ -3246,11 +3596,11 @@ func (m *Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n110, err := m.Txn.MarshalTo(data[i:])
+		n124, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n110
+		i += n124
 	}
 	data[i] = 0x30
 	i++
@@ -3259,11 +3609,11 @@ func (m *Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Trace.Size()))
-		n111, err := m.Trace.MarshalTo(data[i:])
+		n125, err := m.Trace.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n111
+		i += n125
 	}
 	return i, nil
 }
@@ -3286,11 +3636,11 @@ func (m *BatchRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Header.Size()))
-	n112, err := m.Header.MarshalTo(data[i:])
+	n126, err := m.Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n112
+	i += n126
 	if len(m.Requests) > 0 {
 		for _, msg := range m.Requests {
 			data[i] = 0x12
@@ -3324,11 +3674,11 @@ func (m *BatchResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchResponse_Header.Size()))
-	n113, err := m.BatchResponse_Header.MarshalTo(data[i:])
+	n127, err := m.BatchResponse_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n113
+	i += n127
 	if len(m.Responses) > 0 {
 		for _, msg := range m.Responses {
 			data[i] = 0x12
@@ -3363,21 +3713,21 @@ func (m *BatchResponse_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Error.Size()))
-		n114, err := m.Error.MarshalTo(data[i:])
+		n128, err := m.Error.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n114
+		i += n128
 	}
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n115, err := m.Txn.MarshalTo(data[i:])
+		n129, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n115
+		i += n129
 	}
 	if len(m.CollectedSpans) > 0 {
 		for _, b := range m.CollectedSpans {
@@ -3590,6 +3940,22 @@ func (m *ReverseScanResponse) Size() (n int) {
 			n += 1 + l + sovApi(uint64(l))
 		}
 	}
+	return n
+}
+
+func (m *CheckConsistencyRequest) Size() (n int) {
+	var l int
+	_ = l
+	l = m.Span.Size()
+	n += 1 + l + sovApi(uint64(l))
+	return n
+}
+
+func (m *CheckConsistencyResponse) Size() (n int) {
+	var l int
+	_ = l
+	l = m.ResponseHeader.Size()
+	n += 1 + l + sovApi(uint64(l))
 	return n
 }
 
@@ -3897,6 +4263,48 @@ func (m *LeaderLeaseResponse) Size() (n int) {
 	return n
 }
 
+func (m *ComputeChecksumRequest) Size() (n int) {
+	var l int
+	_ = l
+	l = m.Span.Size()
+	n += 1 + l + sovApi(uint64(l))
+	n += 1 + sovApi(uint64(m.Version))
+	l = m.ChecksumID.Size()
+	n += 1 + l + sovApi(uint64(l))
+	return n
+}
+
+func (m *ComputeChecksumResponse) Size() (n int) {
+	var l int
+	_ = l
+	l = m.ResponseHeader.Size()
+	n += 1 + l + sovApi(uint64(l))
+	return n
+}
+
+func (m *VerifyChecksumRequest) Size() (n int) {
+	var l int
+	_ = l
+	l = m.Span.Size()
+	n += 1 + l + sovApi(uint64(l))
+	n += 1 + sovApi(uint64(m.Version))
+	l = m.ChecksumID.Size()
+	n += 1 + l + sovApi(uint64(l))
+	if m.Checksum != nil {
+		l = len(m.Checksum)
+		n += 1 + l + sovApi(uint64(l))
+	}
+	return n
+}
+
+func (m *VerifyChecksumResponse) Size() (n int) {
+	var l int
+	_ = l
+	l = m.ResponseHeader.Size()
+	n += 1 + l + sovApi(uint64(l))
+	return n
+}
+
 func (m *RequestUnion) Size() (n int) {
 	var l int
 	_ = l
@@ -3982,6 +4390,18 @@ func (m *RequestUnion) Size() (n int) {
 	}
 	if m.ReverseScan != nil {
 		l = m.ReverseScan.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	if m.ComputeChecksum != nil {
+		l = m.ComputeChecksum.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	if m.VerifyChecksum != nil {
+		l = m.VerifyChecksum.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	if m.CheckConsistency != nil {
+		l = m.CheckConsistency.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
 	if m.Noop != nil {
@@ -4076,6 +4496,18 @@ func (m *ResponseUnion) Size() (n int) {
 	}
 	if m.ReverseScan != nil {
 		l = m.ReverseScan.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	if m.ComputeChecksum != nil {
+		l = m.ComputeChecksum.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	if m.VerifyChecksum != nil {
+		l = m.VerifyChecksum.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	if m.CheckConsistency != nil {
+		l = m.CheckConsistency.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
 	if m.Noop != nil {
@@ -4231,6 +4663,15 @@ func (this *RequestUnion) GetValue() interface{} {
 	if this.ReverseScan != nil {
 		return this.ReverseScan
 	}
+	if this.ComputeChecksum != nil {
+		return this.ComputeChecksum
+	}
+	if this.VerifyChecksum != nil {
+		return this.VerifyChecksum
+	}
+	if this.CheckConsistency != nil {
+		return this.CheckConsistency
+	}
 	if this.Noop != nil {
 		return this.Noop
 	}
@@ -4281,6 +4722,12 @@ func (this *RequestUnion) SetValue(value interface{}) bool {
 		this.LeaderLease = vt
 	case *ReverseScanRequest:
 		this.ReverseScan = vt
+	case *ComputeChecksumRequest:
+		this.ComputeChecksum = vt
+	case *VerifyChecksumRequest:
+		this.VerifyChecksum = vt
+	case *CheckConsistencyRequest:
+		this.CheckConsistency = vt
 	case *NoopRequest:
 		this.Noop = vt
 	default:
@@ -4352,6 +4799,15 @@ func (this *ResponseUnion) GetValue() interface{} {
 	if this.ReverseScan != nil {
 		return this.ReverseScan
 	}
+	if this.ComputeChecksum != nil {
+		return this.ComputeChecksum
+	}
+	if this.VerifyChecksum != nil {
+		return this.VerifyChecksum
+	}
+	if this.CheckConsistency != nil {
+		return this.CheckConsistency
+	}
 	if this.Noop != nil {
 		return this.Noop
 	}
@@ -4402,6 +4858,12 @@ func (this *ResponseUnion) SetValue(value interface{}) bool {
 		this.LeaderLease = vt
 	case *ReverseScanResponse:
 		this.ReverseScan = vt
+	case *ComputeChecksumResponse:
+		this.ComputeChecksum = vt
+	case *VerifyChecksumResponse:
+		this.VerifyChecksum = vt
+	case *CheckConsistencyResponse:
+		this.CheckConsistency = vt
 	case *NoopResponse:
 		this.Noop = vt
 	default:
@@ -6110,6 +6572,166 @@ func (m *ReverseScanResponse) Unmarshal(data []byte) error {
 			}
 			m.Rows = append(m.Rows, KeyValue{})
 			if err := m.Rows[len(m.Rows)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipApi(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthApi
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CheckConsistencyRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowApi
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CheckConsistencyRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CheckConsistencyRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Span", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Span.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipApi(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthApi
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CheckConsistencyResponse) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowApi
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CheckConsistencyResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CheckConsistencyResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ResponseHeader.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -9237,6 +9859,455 @@ func (m *LeaderLeaseResponse) Unmarshal(data []byte) error {
 	}
 	return nil
 }
+func (m *ComputeChecksumRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowApi
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ComputeChecksumRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ComputeChecksumRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Span", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Span.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			m.Version = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.Version |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ChecksumID", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ChecksumID.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipApi(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthApi
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ComputeChecksumResponse) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowApi
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ComputeChecksumResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ComputeChecksumResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ResponseHeader.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipApi(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthApi
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *VerifyChecksumRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowApi
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VerifyChecksumRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VerifyChecksumRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Span", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Span.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			m.Version = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.Version |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ChecksumID", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ChecksumID.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Checksum", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Checksum = append(m.Checksum[:0], data[iNdEx:postIndex]...)
+			if m.Checksum == nil {
+				m.Checksum = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipApi(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthApi
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *VerifyChecksumResponse) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowApi
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VerifyChecksumResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VerifyChecksumResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ResponseHeader.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipApi(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthApi
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *RequestUnion) Unmarshal(data []byte) error {
 	l := len(data)
 	iNdEx := 0
@@ -9960,6 +11031,105 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 			}
 			iNdEx = postIndex
 		case 22:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ComputeChecksum", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ComputeChecksum == nil {
+				m.ComputeChecksum = &ComputeChecksumRequest{}
+			}
+			if err := m.ComputeChecksum.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 23:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VerifyChecksum", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.VerifyChecksum == nil {
+				m.VerifyChecksum = &VerifyChecksumRequest{}
+			}
+			if err := m.VerifyChecksum.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 24:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CheckConsistency", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CheckConsistency == nil {
+				m.CheckConsistency = &CheckConsistencyRequest{}
+			}
+			if err := m.CheckConsistency.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 25:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Noop", wireType)
 			}
@@ -10736,6 +11906,105 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 			}
 			iNdEx = postIndex
 		case 22:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ComputeChecksum", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ComputeChecksum == nil {
+				m.ComputeChecksum = &ComputeChecksumResponse{}
+			}
+			if err := m.ComputeChecksum.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 23:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VerifyChecksum", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.VerifyChecksum == nil {
+				m.VerifyChecksum = &VerifyChecksumResponse{}
+			}
+			if err := m.VerifyChecksum.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 24:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CheckConsistency", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CheckConsistency == nil {
+				m.CheckConsistency = &CheckConsistencyResponse{}
+			}
+			if err := m.CheckConsistency.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 25:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Noop", wireType)
 			}

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -183,6 +183,20 @@ message ReverseScanResponse {
   repeated KeyValue rows = 2 [(gogoproto.nullable) = false];
 }
 
+// A CheckConsistencyRequest is the argument to the CheckConsistency() method.
+// It specifies the start and end keys for a span of ranges to which a consistency
+// check should be applied. A consistency check on a range involves running a
+// ComputeChecksum on the range followed by a VerifyChecksum.
+message CheckConsistencyRequest {
+  optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
+// A CheckConsistencyResponse is the return value from the CheckConsistency() method.
+// If a replica finds itself to be inconsistent with its leader it will panic.
+message CheckConsistencyResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
 // A BeginTransactionRequest is the argument to the BeginTransaction() method.
 message BeginTransactionRequest {
   optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
@@ -518,6 +532,46 @@ message LeaderLeaseResponse{
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
+// A ComputeChecksumRequest is arguments to the ComputeChecksum() method, to
+// start computing the checksum for the specified range at the snapshot for
+// this request command. A response is returned without the checksum.
+// The computed checksum is later compared to the one supplied
+// through a VerifyChecksumRequest.
+message ComputeChecksumRequest {
+  optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // The version used to pick the checksum method. It allows us to use a
+  // consistent checksumming method across replicas.
+  optional uint32 version = 2 [(gogoproto.nullable) = false];
+  // A unique identifier to match a future VerifyChecksumRequest with this request.
+  optional bytes checksum_id = 3 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "ChecksumID",
+      (gogoproto.customtype) = "github.com/cockroachdb/cockroach/util/uuid.UUID"];
+} 
+
+// A ComputeChecksumResponse is the response to a ComputeChecksum() operation.
+message ComputeChecksumResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
+// A VerifyChecksumRequest is arguments to the VerifyChecksum() method, to
+// verify the checksum computed on the leader against the one requested
+// earlier through a ComputeChecksumRequest with the same checksum_id.
+message VerifyChecksumRequest {
+  optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // The version used to pick the checksum method. It allows us to use a
+  // consistent checksumming method across replicas.
+  optional uint32 version = 2 [(gogoproto.nullable) = false];
+  optional bytes checksum_id = 3 [(gogoproto.nullable) = false,
+      (gogoproto.customname) = "ChecksumID",
+      (gogoproto.customtype) = "github.com/cockroachdb/cockroach/util/uuid.UUID"];
+  optional bytes checksum = 4;
+} 
+
+// A VerifyChecksumResponse is the response to a VerifyChecksum() operation.
+message VerifyChecksumResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
 // A RequestUnion contains exactly one of the optional requests.
 // The values added here must match those in ResponseUnion.
 message RequestUnion {
@@ -544,7 +598,10 @@ message RequestUnion {
   optional TruncateLogRequest truncate_log = 19;
   optional LeaderLeaseRequest leader_lease = 20;
   optional ReverseScanRequest reverse_scan = 21;
-  optional NoopRequest noop = 22;
+  optional ComputeChecksumRequest compute_checksum = 22;
+  optional VerifyChecksumRequest verify_checksum = 23;
+  optional CheckConsistencyRequest check_consistency = 24;
+  optional NoopRequest noop = 25;
 }
 
 // A ResponseUnion contains exactly one of the optional responses.
@@ -573,7 +630,10 @@ message ResponseUnion {
   optional TruncateLogResponse truncate_log = 19;
   optional LeaderLeaseResponse leader_lease = 20;
   optional ReverseScanResponse reverse_scan = 21;
-  optional NoopResponse noop = 22;
+  optional ComputeChecksumResponse compute_checksum = 22;
+  optional VerifyChecksumResponse verify_checksum = 23;
+  optional CheckConsistencyResponse check_consistency = 24;
+  optional NoopResponse noop = 25;
 }
 
 // A Header is attached to a BatchRequest, encapsulating routing and auxiliary

--- a/roachpb/method.go
+++ b/roachpb/method.go
@@ -103,4 +103,12 @@ const (
 	TruncateLog
 	// LeaderLease requests a leader lease for a replica.
 	LeaderLease
+	// ComputeChecksum starts a checksum computation over a replica snapshot.
+	ComputeChecksum
+	// VerifyChecksum verifies the checksum computed through an earlier
+	// ComputeChecksum.
+	VerifyChecksum
+	// CheckConsistency verifies the consistency of all ranges falling within a
+	// key span.
+	CheckConsistency
 )

--- a/roachpb/method_string.go
+++ b/roachpb/method_string.go
@@ -4,9 +4,9 @@ package roachpb
 
 import "fmt"
 
-const _Method_name = "GetPutConditionalPutIncrementDeleteDeleteRangeScanReverseScanBeginTransactionEndTransactionAdminSplitAdminMergeHeartbeatTxnGCPushTxnRangeLookupResolveIntentResolveIntentRangeNoopMergeTruncateLogLeaderLease"
+const _Method_name = "GetPutConditionalPutIncrementDeleteDeleteRangeScanReverseScanBeginTransactionEndTransactionAdminSplitAdminMergeHeartbeatTxnGCPushTxnRangeLookupResolveIntentResolveIntentRangeNoopMergeTruncateLogLeaderLeaseComputeChecksumVerifyChecksumCheckConsistency"
 
-var _Method_index = [...]uint8{0, 3, 6, 20, 29, 35, 46, 50, 61, 77, 91, 101, 111, 123, 125, 132, 143, 156, 174, 178, 183, 194, 205}
+var _Method_index = [...]uint8{0, 3, 6, 20, 29, 35, 46, 50, 61, 77, 91, 101, 111, 123, 125, 132, 143, 156, 174, 178, 183, 194, 205, 220, 234, 250}
 
 func (i Method) String() string {
 	if i < 0 || i >= Method(len(_Method_index)-1) {

--- a/server/context.go
+++ b/server/context.go
@@ -43,16 +43,17 @@ import (
 
 // Context defaults.
 const (
-	defaultCGroupMemPath      = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
-	defaultAddr               = ":" + base.DefaultPort
-	defaultHTTPAddr           = ":" + base.DefaultHTTPPort
-	defaultMaxOffset          = 250 * time.Millisecond
-	defaultCacheSize          = 512 << 20 // 512 MB
-	defaultMemtableBudget     = 512 << 20 // 512 MB
-	defaultScanInterval       = 10 * time.Minute
-	defaultScanMaxIdleTime    = 5 * time.Second
-	defaultMetricsFrequency   = 10 * time.Second
-	defaultTimeUntilStoreDead = 5 * time.Minute
+	defaultCGroupMemPath            = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	defaultAddr                     = ":" + base.DefaultPort
+	defaultHTTPAddr                 = ":" + base.DefaultHTTPPort
+	defaultMaxOffset                = 250 * time.Millisecond
+	defaultCacheSize                = 512 << 20 // 512 MB
+	defaultMemtableBudget           = 512 << 20 // 512 MB
+	defaultScanInterval             = 10 * time.Minute
+	defaultConsistencyCheckInterval = 24 * time.Hour
+	defaultScanMaxIdleTime          = 5 * time.Second
+	defaultMetricsFrequency         = 10 * time.Second
+	defaultTimeUntilStoreDead       = 5 * time.Minute
 )
 
 // Context holds parameters needed to setup a server.
@@ -132,6 +133,9 @@ type Context struct {
 	// Environment Variable: COCKROACH_SCAN_MAX_IDLE_TIME
 	ScanMaxIdleTime time.Duration
 
+	// ConsistencyCheckInterval
+	ConsistencyCheckInterval time.Duration
+
 	// TimeUntilStoreDead is the time after which if there is no new gossiped
 	// information about a store, it is considered dead.
 	// Environment Variable: COCKROACH_TIME_UNTIL_STORE_DEAD
@@ -200,6 +204,7 @@ func (ctx *Context) InitDefaults() {
 	ctx.MemtableBudget = defaultMemtableBudget
 	ctx.ScanInterval = defaultScanInterval
 	ctx.ScanMaxIdleTime = defaultScanMaxIdleTime
+	ctx.ConsistencyCheckInterval = defaultConsistencyCheckInterval
 	ctx.MetricsFrequency = defaultMetricsFrequency
 	ctx.TimeUntilStoreDead = defaultTimeUntilStoreDead
 	ctx.Stores.Specs = append(ctx.Stores.Specs, StoreSpec{Path: "cockroach-data"})

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -73,6 +73,12 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* ReverseScanResponse_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ReverseScanResponse_reflection_ = NULL;
+const ::google::protobuf::Descriptor* CheckConsistencyRequest_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  CheckConsistencyRequest_reflection_ = NULL;
+const ::google::protobuf::Descriptor* CheckConsistencyResponse_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  CheckConsistencyResponse_reflection_ = NULL;
 const ::google::protobuf::Descriptor* BeginTransactionRequest_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   BeginTransactionRequest_reflection_ = NULL;
@@ -160,6 +166,18 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* LeaderLeaseResponse_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   LeaderLeaseResponse_reflection_ = NULL;
+const ::google::protobuf::Descriptor* ComputeChecksumRequest_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  ComputeChecksumRequest_reflection_ = NULL;
+const ::google::protobuf::Descriptor* ComputeChecksumResponse_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  ComputeChecksumResponse_reflection_ = NULL;
+const ::google::protobuf::Descriptor* VerifyChecksumRequest_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  VerifyChecksumRequest_reflection_ = NULL;
+const ::google::protobuf::Descriptor* VerifyChecksumResponse_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  VerifyChecksumResponse_reflection_ = NULL;
 const ::google::protobuf::Descriptor* RequestUnion_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   RequestUnion_reflection_ = NULL;
@@ -459,7 +477,37 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ReverseScanResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReverseScanResponse, _internal_metadata_),
       -1);
-  BeginTransactionRequest_descriptor_ = file->message_type(17);
+  CheckConsistencyRequest_descriptor_ = file->message_type(17);
+  static const int CheckConsistencyRequest_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CheckConsistencyRequest, header_),
+  };
+  CheckConsistencyRequest_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      CheckConsistencyRequest_descriptor_,
+      CheckConsistencyRequest::default_instance_,
+      CheckConsistencyRequest_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CheckConsistencyRequest, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(CheckConsistencyRequest),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CheckConsistencyRequest, _internal_metadata_),
+      -1);
+  CheckConsistencyResponse_descriptor_ = file->message_type(18);
+  static const int CheckConsistencyResponse_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CheckConsistencyResponse, header_),
+  };
+  CheckConsistencyResponse_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      CheckConsistencyResponse_descriptor_,
+      CheckConsistencyResponse::default_instance_,
+      CheckConsistencyResponse_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CheckConsistencyResponse, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(CheckConsistencyResponse),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CheckConsistencyResponse, _internal_metadata_),
+      -1);
+  BeginTransactionRequest_descriptor_ = file->message_type(19);
   static const int BeginTransactionRequest_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BeginTransactionRequest, header_),
   };
@@ -474,7 +522,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(BeginTransactionRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BeginTransactionRequest, _internal_metadata_),
       -1);
-  BeginTransactionResponse_descriptor_ = file->message_type(18);
+  BeginTransactionResponse_descriptor_ = file->message_type(20);
   static const int BeginTransactionResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BeginTransactionResponse, header_),
   };
@@ -489,7 +537,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(BeginTransactionResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BeginTransactionResponse, _internal_metadata_),
       -1);
-  EndTransactionRequest_descriptor_ = file->message_type(19);
+  EndTransactionRequest_descriptor_ = file->message_type(21);
   static const int EndTransactionRequest_offsets_[5] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, commit_),
@@ -508,7 +556,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(EndTransactionRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionRequest, _internal_metadata_),
       -1);
-  EndTransactionResponse_descriptor_ = file->message_type(20);
+  EndTransactionResponse_descriptor_ = file->message_type(22);
   static const int EndTransactionResponse_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, commit_wait_),
@@ -525,7 +573,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(EndTransactionResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EndTransactionResponse, _internal_metadata_),
       -1);
-  AdminSplitRequest_descriptor_ = file->message_type(21);
+  AdminSplitRequest_descriptor_ = file->message_type(23);
   static const int AdminSplitRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitRequest, split_key_),
@@ -541,7 +589,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(AdminSplitRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitRequest, _internal_metadata_),
       -1);
-  AdminSplitResponse_descriptor_ = file->message_type(22);
+  AdminSplitResponse_descriptor_ = file->message_type(24);
   static const int AdminSplitResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitResponse, header_),
   };
@@ -556,7 +604,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(AdminSplitResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminSplitResponse, _internal_metadata_),
       -1);
-  AdminMergeRequest_descriptor_ = file->message_type(23);
+  AdminMergeRequest_descriptor_ = file->message_type(25);
   static const int AdminMergeRequest_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeRequest, header_),
   };
@@ -571,7 +619,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(AdminMergeRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeRequest, _internal_metadata_),
       -1);
-  AdminMergeResponse_descriptor_ = file->message_type(24);
+  AdminMergeResponse_descriptor_ = file->message_type(26);
   static const int AdminMergeResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeResponse, header_),
   };
@@ -586,7 +634,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(AdminMergeResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AdminMergeResponse, _internal_metadata_),
       -1);
-  RangeLookupRequest_descriptor_ = file->message_type(25);
+  RangeLookupRequest_descriptor_ = file->message_type(27);
   static const int RangeLookupRequest_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupRequest, max_ranges_),
@@ -604,7 +652,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(RangeLookupRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupRequest, _internal_metadata_),
       -1);
-  RangeLookupResponse_descriptor_ = file->message_type(26);
+  RangeLookupResponse_descriptor_ = file->message_type(28);
   static const int RangeLookupResponse_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupResponse, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupResponse, ranges_),
@@ -620,7 +668,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(RangeLookupResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeLookupResponse, _internal_metadata_),
       -1);
-  HeartbeatTxnRequest_descriptor_ = file->message_type(27);
+  HeartbeatTxnRequest_descriptor_ = file->message_type(29);
   static const int HeartbeatTxnRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(HeartbeatTxnRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(HeartbeatTxnRequest, now_),
@@ -636,7 +684,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(HeartbeatTxnRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(HeartbeatTxnRequest, _internal_metadata_),
       -1);
-  HeartbeatTxnResponse_descriptor_ = file->message_type(28);
+  HeartbeatTxnResponse_descriptor_ = file->message_type(30);
   static const int HeartbeatTxnResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(HeartbeatTxnResponse, header_),
   };
@@ -651,7 +699,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(HeartbeatTxnResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(HeartbeatTxnResponse, _internal_metadata_),
       -1);
-  GCRequest_descriptor_ = file->message_type(29);
+  GCRequest_descriptor_ = file->message_type(31);
   static const int GCRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCRequest, keys_),
@@ -683,7 +731,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(GCRequest_GCKey),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCRequest_GCKey, _internal_metadata_),
       -1);
-  GCResponse_descriptor_ = file->message_type(30);
+  GCResponse_descriptor_ = file->message_type(32);
   static const int GCResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCResponse, header_),
   };
@@ -698,7 +746,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(GCResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GCResponse, _internal_metadata_),
       -1);
-  PushTxnRequest_descriptor_ = file->message_type(31);
+  PushTxnRequest_descriptor_ = file->message_type(33);
   static const int PushTxnRequest_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnRequest, pusher_txn_),
@@ -718,7 +766,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(PushTxnRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnRequest, _internal_metadata_),
       -1);
-  PushTxnResponse_descriptor_ = file->message_type(32);
+  PushTxnResponse_descriptor_ = file->message_type(34);
   static const int PushTxnResponse_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnResponse, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnResponse, pushee_txn_),
@@ -734,7 +782,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(PushTxnResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PushTxnResponse, _internal_metadata_),
       -1);
-  ResolveIntentRequest_descriptor_ = file->message_type(33);
+  ResolveIntentRequest_descriptor_ = file->message_type(35);
   static const int ResolveIntentRequest_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRequest, intent_txn_),
@@ -752,7 +800,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ResolveIntentRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRequest, _internal_metadata_),
       -1);
-  ResolveIntentResponse_descriptor_ = file->message_type(34);
+  ResolveIntentResponse_descriptor_ = file->message_type(36);
   static const int ResolveIntentResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentResponse, header_),
   };
@@ -767,7 +815,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ResolveIntentResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentResponse, _internal_metadata_),
       -1);
-  ResolveIntentRangeRequest_descriptor_ = file->message_type(35);
+  ResolveIntentRangeRequest_descriptor_ = file->message_type(37);
   static const int ResolveIntentRangeRequest_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeRequest, intent_txn_),
@@ -785,7 +833,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ResolveIntentRangeRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeRequest, _internal_metadata_),
       -1);
-  NoopResponse_descriptor_ = file->message_type(36);
+  NoopResponse_descriptor_ = file->message_type(38);
   static const int NoopResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NoopResponse, header_),
   };
@@ -800,7 +848,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(NoopResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NoopResponse, _internal_metadata_),
       -1);
-  NoopRequest_descriptor_ = file->message_type(37);
+  NoopRequest_descriptor_ = file->message_type(39);
   static const int NoopRequest_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NoopRequest, header_),
   };
@@ -815,7 +863,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(NoopRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NoopRequest, _internal_metadata_),
       -1);
-  ResolveIntentRangeResponse_descriptor_ = file->message_type(38);
+  ResolveIntentRangeResponse_descriptor_ = file->message_type(40);
   static const int ResolveIntentRangeResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeResponse, header_),
   };
@@ -830,7 +878,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ResolveIntentRangeResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResolveIntentRangeResponse, _internal_metadata_),
       -1);
-  MergeRequest_descriptor_ = file->message_type(39);
+  MergeRequest_descriptor_ = file->message_type(41);
   static const int MergeRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeRequest, value_),
@@ -846,7 +894,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(MergeRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeRequest, _internal_metadata_),
       -1);
-  MergeResponse_descriptor_ = file->message_type(40);
+  MergeResponse_descriptor_ = file->message_type(42);
   static const int MergeResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeResponse, header_),
   };
@@ -861,7 +909,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(MergeResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeResponse, _internal_metadata_),
       -1);
-  TruncateLogRequest_descriptor_ = file->message_type(41);
+  TruncateLogRequest_descriptor_ = file->message_type(43);
   static const int TruncateLogRequest_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TruncateLogRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TruncateLogRequest, index_),
@@ -878,7 +926,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(TruncateLogRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TruncateLogRequest, _internal_metadata_),
       -1);
-  TruncateLogResponse_descriptor_ = file->message_type(42);
+  TruncateLogResponse_descriptor_ = file->message_type(44);
   static const int TruncateLogResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TruncateLogResponse, header_),
   };
@@ -893,7 +941,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(TruncateLogResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TruncateLogResponse, _internal_metadata_),
       -1);
-  LeaderLeaseRequest_descriptor_ = file->message_type(43);
+  LeaderLeaseRequest_descriptor_ = file->message_type(45);
   static const int LeaderLeaseRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaderLeaseRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaderLeaseRequest, lease_),
@@ -909,7 +957,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(LeaderLeaseRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaderLeaseRequest, _internal_metadata_),
       -1);
-  LeaderLeaseResponse_descriptor_ = file->message_type(44);
+  LeaderLeaseResponse_descriptor_ = file->message_type(46);
   static const int LeaderLeaseResponse_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaderLeaseResponse, header_),
   };
@@ -924,8 +972,73 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(LeaderLeaseResponse),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LeaderLeaseResponse, _internal_metadata_),
       -1);
-  RequestUnion_descriptor_ = file->message_type(45);
-  static const int RequestUnion_offsets_[22] = {
+  ComputeChecksumRequest_descriptor_ = file->message_type(47);
+  static const int ComputeChecksumRequest_offsets_[3] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ComputeChecksumRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ComputeChecksumRequest, version_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ComputeChecksumRequest, checksum_id_),
+  };
+  ComputeChecksumRequest_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      ComputeChecksumRequest_descriptor_,
+      ComputeChecksumRequest::default_instance_,
+      ComputeChecksumRequest_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ComputeChecksumRequest, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(ComputeChecksumRequest),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ComputeChecksumRequest, _internal_metadata_),
+      -1);
+  ComputeChecksumResponse_descriptor_ = file->message_type(48);
+  static const int ComputeChecksumResponse_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ComputeChecksumResponse, header_),
+  };
+  ComputeChecksumResponse_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      ComputeChecksumResponse_descriptor_,
+      ComputeChecksumResponse::default_instance_,
+      ComputeChecksumResponse_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ComputeChecksumResponse, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(ComputeChecksumResponse),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ComputeChecksumResponse, _internal_metadata_),
+      -1);
+  VerifyChecksumRequest_descriptor_ = file->message_type(49);
+  static const int VerifyChecksumRequest_offsets_[4] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VerifyChecksumRequest, header_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VerifyChecksumRequest, version_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VerifyChecksumRequest, checksum_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VerifyChecksumRequest, checksum_),
+  };
+  VerifyChecksumRequest_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      VerifyChecksumRequest_descriptor_,
+      VerifyChecksumRequest::default_instance_,
+      VerifyChecksumRequest_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VerifyChecksumRequest, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(VerifyChecksumRequest),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VerifyChecksumRequest, _internal_metadata_),
+      -1);
+  VerifyChecksumResponse_descriptor_ = file->message_type(50);
+  static const int VerifyChecksumResponse_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VerifyChecksumResponse, header_),
+  };
+  VerifyChecksumResponse_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      VerifyChecksumResponse_descriptor_,
+      VerifyChecksumResponse::default_instance_,
+      VerifyChecksumResponse_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VerifyChecksumResponse, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(VerifyChecksumResponse),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VerifyChecksumResponse, _internal_metadata_),
+      -1);
+  RequestUnion_descriptor_ = file->message_type(51);
+  static const int RequestUnion_offsets_[25] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, get_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, put_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, conditional_put_),
@@ -947,6 +1060,9 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, truncate_log_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, leader_lease_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, reverse_scan_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, compute_checksum_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, verify_checksum_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, check_consistency_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, noop_),
   };
   RequestUnion_reflection_ =
@@ -960,8 +1076,8 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(RequestUnion),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RequestUnion, _internal_metadata_),
       -1);
-  ResponseUnion_descriptor_ = file->message_type(46);
-  static const int ResponseUnion_offsets_[22] = {
+  ResponseUnion_descriptor_ = file->message_type(52);
+  static const int ResponseUnion_offsets_[25] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, get_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, put_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, conditional_put_),
@@ -983,6 +1099,9 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, truncate_log_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, leader_lease_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, reverse_scan_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, compute_checksum_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, verify_checksum_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, check_consistency_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, noop_),
   };
   ResponseUnion_reflection_ =
@@ -996,7 +1115,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(ResponseUnion),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, _internal_metadata_),
       -1);
-  Header_descriptor_ = file->message_type(47);
+  Header_descriptor_ = file->message_type(53);
   static const int Header_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, replica_),
@@ -1017,7 +1136,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(Header),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, _internal_metadata_),
       -1);
-  BatchRequest_descriptor_ = file->message_type(48);
+  BatchRequest_descriptor_ = file->message_type(54);
   static const int BatchRequest_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest, requests_),
@@ -1033,7 +1152,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       sizeof(BatchRequest),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchRequest, _internal_metadata_),
       -1);
-  BatchResponse_descriptor_ = file->message_type(49);
+  BatchResponse_descriptor_ = file->message_type(55);
   static const int BatchResponse_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse, header_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse, responses_),
@@ -1115,6 +1234,10 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       ReverseScanResponse_descriptor_, &ReverseScanResponse::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      CheckConsistencyRequest_descriptor_, &CheckConsistencyRequest::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      CheckConsistencyResponse_descriptor_, &CheckConsistencyResponse::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       BeginTransactionRequest_descriptor_, &BeginTransactionRequest::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       BeginTransactionResponse_descriptor_, &BeginTransactionResponse::default_instance());
@@ -1173,6 +1296,14 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       LeaderLeaseResponse_descriptor_, &LeaderLeaseResponse::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      ComputeChecksumRequest_descriptor_, &ComputeChecksumRequest::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      ComputeChecksumResponse_descriptor_, &ComputeChecksumResponse::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      VerifyChecksumRequest_descriptor_, &VerifyChecksumRequest::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      VerifyChecksumResponse_descriptor_, &VerifyChecksumResponse::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       RequestUnion_descriptor_, &RequestUnion::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       ResponseUnion_descriptor_, &ResponseUnion::default_instance());
@@ -1223,6 +1354,10 @@ void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto() {
   delete ReverseScanRequest_reflection_;
   delete ReverseScanResponse::default_instance_;
   delete ReverseScanResponse_reflection_;
+  delete CheckConsistencyRequest::default_instance_;
+  delete CheckConsistencyRequest_reflection_;
+  delete CheckConsistencyResponse::default_instance_;
+  delete CheckConsistencyResponse_reflection_;
   delete BeginTransactionRequest::default_instance_;
   delete BeginTransactionRequest_reflection_;
   delete BeginTransactionResponse::default_instance_;
@@ -1281,6 +1416,14 @@ void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto() {
   delete LeaderLeaseRequest_reflection_;
   delete LeaderLeaseResponse::default_instance_;
   delete LeaderLeaseResponse_reflection_;
+  delete ComputeChecksumRequest::default_instance_;
+  delete ComputeChecksumRequest_reflection_;
+  delete ComputeChecksumResponse::default_instance_;
+  delete ComputeChecksumResponse_reflection_;
+  delete VerifyChecksumRequest::default_instance_;
+  delete VerifyChecksumRequest_reflection_;
+  delete VerifyChecksumResponse::default_instance_;
+  delete VerifyChecksumResponse_reflection_;
   delete RequestUnion::default_instance_;
   delete RequestUnion_reflection_;
   delete ResponseUnion::default_instance_;
@@ -1356,189 +1499,218 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "results\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023ReverseScanRespo"
     "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
     "ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033"
-    ".cockroach.roachpb.KeyValueB\004\310\336\037\000\"L\n\027Beg"
-    "inTransactionRequest\0221\n\006header\030\001 \001(\0132\027.c"
-    "ockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\"W\n\030Begin"
-    "TransactionResponse\022;\n\006header\030\001 \001(\0132!.co"
+    ".cockroach.roachpb.KeyValueB\004\310\336\037\000\"L\n\027Che"
+    "ckConsistencyRequest\0221\n\006header\030\001 \001(\0132\027.c"
+    "ockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\"W\n\030Check"
+    "ConsistencyResponse\022;\n\006header\030\001 \001(\0132!.co"
     "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"\220\002\n\025EndTransactionRequest\0221\n\006header\030\001 \001"
-    "(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\024\n"
-    "\006commit\030\002 \001(\010B\004\310\336\037\000\022.\n\010deadline\030\003 \001(\0132\034."
-    "cockroach.roachpb.Timestamp\022I\n\027internal_"
-    "commit_trigger\030\004 \001(\0132(.cockroach.roachpb"
-    ".InternalCommitTrigger\0223\n\014intent_spans\030\005"
-    " \003(\0132\027.cockroach.roachpb.SpanB\004\310\336\037\000\"\213\001\n\026"
-    "EndTransactionResponse\022;\n\006header\030\001 \001(\0132!"
-    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
-    "\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolv"
-    "ed\030\003 \003(\014B\007\372\336\037\003Key\"b\n\021AdminSplitRequest\0221"
-    "\n\006header\030\001 \001(\0132\027.cockroach.roachpb.SpanB"
-    "\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n"
-    "\022AdminSplitResponse\022;\n\006header\030\001 \001(\0132!.co"
-    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"F\n\021AdminMergeRequest\0221\n\006header\030\001 \001(\0132\027."
-    "cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\"Q\n\022Admi"
-    "nMergeResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
-    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\230\001\n\022"
-    "RangeLookupRequest\0221\n\006header\030\001 \001(\0132\027.coc"
-    "kroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ran"
-    "ges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_intents\030\003 \001("
-    "\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023Range"
-    "LookupResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
-    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0228\n\006r"
-    "anges\030\002 \003(\0132\".cockroach.roachpb.RangeDes"
-    "criptorB\004\310\336\037\000\"y\n\023HeartbeatTxnRequest\0221\n\006"
-    "header\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310"
-    "\336\037\000\320\336\037\001\022/\n\003now\030\002 \001(\0132\034.cockroach.roachpb"
-    ".TimestampB\004\310\336\037\000\"S\n\024HeartbeatTxnResponse"
-    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
-    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"\314\001\n\tGCRequest\0221\n\006h"
-    "eader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336"
-    "\037\000\320\336\037\001\0226\n\004keys\030\003 \003(\0132\".cockroach.roachpb"
-    ".GCRequest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001"
-    " \001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockr"
-    "oach.roachpb.TimestampB\004\310\336\037\000\"I\n\nGCRespon"
-    "se\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.R"
-    "esponseHeaderB\010\310\336\037\000\320\336\037\001\"\322\002\n\016PushTxnReque"
+    "\"L\n\027BeginTransactionRequest\0221\n\006header\030\001 "
+    "\001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\"W"
+    "\n\030BeginTransactionResponse\022;\n\006header\030\001 \001"
+    "(\0132!.cockroach.roachpb.ResponseHeaderB\010\310"
+    "\336\037\000\320\336\037\001\"\220\002\n\025EndTransactionRequest\0221\n\006hea"
+    "der\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000"
+    "\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022.\n\010deadline\030\003"
+    " \001(\0132\034.cockroach.roachpb.Timestamp\022I\n\027in"
+    "ternal_commit_trigger\030\004 \001(\0132(.cockroach."
+    "roachpb.InternalCommitTrigger\0223\n\014intent_"
+    "spans\030\005 \003(\0132\027.cockroach.roachpb.SpanB\004\310\336"
+    "\037\000\"\213\001\n\026EndTransactionResponse\022;\n\006header\030"
+    "\001 \001(\0132!.cockroach.roachpb.ResponseHeader"
+    "B\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n"
+    "\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"b\n\021AdminSplitRe"
+    "quest\0221\n\006header\030\001 \001(\0132\027.cockroach.roachp"
+    "b.SpanB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037"
+    "\003Key\"Q\n\022AdminSplitResponse\022;\n\006header\030\001 \001"
+    "(\0132!.cockroach.roachpb.ResponseHeaderB\010\310"
+    "\336\037\000\320\336\037\001\"F\n\021AdminMergeRequest\0221\n\006header\030\001"
+    " \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\""
+    "Q\n\022AdminMergeResponse\022;\n\006header\030\001 \001(\0132!."
+    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\"\230\001\n\022RangeLookupRequest\0221\n\006header\030\001 \001("
+    "\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\030\n\n"
+    "max_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_inten"
+    "ts\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001"
+    "\n\023RangeLookupResponse\022;\n\006header\030\001 \001(\0132!."
+    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
+    "\037\001\0228\n\006ranges\030\002 \003(\0132\".cockroach.roachpb.R"
+    "angeDescriptorB\004\310\336\037\000\"y\n\023HeartbeatTxnRequ"
+    "est\0221\n\006header\030\001 \001(\0132\027.cockroach.roachpb."
+    "SpanB\010\310\336\037\000\320\336\037\001\022/\n\003now\030\002 \001(\0132\034.cockroach."
+    "roachpb.TimestampB\004\310\336\037\000\"S\n\024HeartbeatTxnR"
+    "esponse\022;\n\006header\030\001 \001(\0132!.cockroach.roac"
+    "hpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\314\001\n\tGCReque"
     "st\0221\n\006header\030\001 \001(\0132\027.cockroach.roachpb.S"
-    "panB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\0132\036.cock"
-    "roach.roachpb.TransactionB\004\310\336\037\000\0224\n\npushe"
-    "e_txn\030\003 \001(\0132\032.cockroach.roachpb.TxnMetaB"
-    "\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cockroach.roach"
-    "pb.TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034.cockro"
-    "ach.roachpb.TimestampB\004\310\336\037\000\0227\n\tpush_type"
-    "\030\006 \001(\0162\036.cockroach.roachpb.PushTxnTypeB\004"
-    "\310\336\037\000\"\210\001\n\017PushTxnResponse\022;\n\006header\030\001 \001(\013"
-    "2!.cockroach.roachpb.ResponseHeaderB\010\310\336\037"
-    "\000\320\336\037\001\0228\n\npushee_txn\030\002 \001(\0132\036.cockroach.ro"
-    "achpb.TransactionB\004\310\336\037\000\"\321\001\n\024ResolveInten"
-    "tRequest\0221\n\006header\030\001 \001(\0132\027.cockroach.roa"
-    "chpb.SpanB\010\310\336\037\000\320\336\037\001\0224\n\nintent_txn\030\002 \001(\0132"
-    "\032.cockroach.roachpb.TxnMetaB\004\310\336\037\000\022:\n\006sta"
-    "tus\030\003 \001(\0162$.cockroach.roachpb.Transactio"
-    "nStatusB\004\310\336\037\000\022\024\n\006poison\030\004 \001(\010B\004\310\336\037\000\"T\n\025R"
-    "esolveIntentResponse\022;\n\006header\030\001 \001(\0132!.c"
-    "ockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037"
-    "\001\"\326\001\n\031ResolveIntentRangeRequest\0221\n\006heade"
-    "r\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336"
-    "\037\001\0224\n\nintent_txn\030\002 \001(\0132\032.cockroach.roach"
-    "pb.TxnMetaB\004\310\336\037\000\022:\n\006status\030\003 \001(\0162$.cockr"
-    "oach.roachpb.TransactionStatusB\004\310\336\037\000\022\024\n\006"
-    "poison\030\004 \001(\010B\004\310\336\037\000\"K\n\014NoopResponse\022;\n\006he"
-    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
-    "eaderB\010\310\336\037\000\320\336\037\001\"@\n\013NoopRequest\0221\n\006header"
-    "\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037"
-    "\001\"Y\n\032ResolveIntentRangeResponse\022;\n\006heade"
+    "panB\010\310\336\037\000\320\336\037\001\0226\n\004keys\030\003 \003(\0132\".cockroach."
+    "roachpb.GCRequest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024"
+    "\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132"
+    "\034.cockroach.roachpb.TimestampB\004\310\336\037\000\"I\n\nG"
+    "CResponse\022;\n\006header\030\001 \001(\0132!.cockroach.ro"
+    "achpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\322\002\n\016PushT"
+    "xnRequest\0221\n\006header\030\001 \001(\0132\027.cockroach.ro"
+    "achpb.SpanB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\013"
+    "2\036.cockroach.roachpb.TransactionB\004\310\336\037\000\0224"
+    "\n\npushee_txn\030\003 \001(\0132\032.cockroach.roachpb.T"
+    "xnMetaB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cockroac"
+    "h.roachpb.TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034"
+    ".cockroach.roachpb.TimestampB\004\310\336\037\000\0227\n\tpu"
+    "sh_type\030\006 \001(\0162\036.cockroach.roachpb.PushTx"
+    "nTypeB\004\310\336\037\000\"\210\001\n\017PushTxnResponse\022;\n\006heade"
     "r\030\001 \001(\0132!.cockroach.roachpb.ResponseHead"
-    "erB\010\310\336\037\000\320\336\037\001\"p\n\014MergeRequest\0221\n\006header\030\001"
-    " \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022"
-    "-\n\005value\030\002 \001(\0132\030.cockroach.roachpb.Value"
-    "B\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006header\030\001 \001(\0132"
-    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
-    "\320\336\037\001\"\212\001\n\022TruncateLogRequest\0221\n\006header\030\001 "
-    "\001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\023"
-    "\n\005index\030\002 \001(\004B\004\310\336\037\000\022,\n\010range_id\030\003 \001(\003B\032\310"
-    "\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\"R\n\023TruncateLog"
-    "Response\022;\n\006header\030\001 \001(\0132!.cockroach.roa"
-    "chpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"v\n\022LeaderL"
-    "easeRequest\0221\n\006header\030\001 \001(\0132\027.cockroach."
-    "roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002 \001(\0132\030."
-    "cockroach.roachpb.LeaseB\004\310\336\037\000\"R\n\023LeaderL"
-    "easeResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
-    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\201\n\n\014Re"
-    "questUnion\022*\n\003get\030\001 \001(\0132\035.cockroach.roac"
-    "hpb.GetRequest\022*\n\003put\030\002 \001(\0132\035.cockroach."
-    "roachpb.PutRequest\022A\n\017conditional_put\030\003 "
-    "\001(\0132(.cockroach.roachpb.ConditionalPutRe"
-    "quest\0226\n\tincrement\030\004 \001(\0132#.cockroach.roa"
-    "chpb.IncrementRequest\0220\n\006delete\030\005 \001(\0132 ."
-    "cockroach.roachpb.DeleteRequest\022;\n\014delet"
-    "e_range\030\006 \001(\0132%.cockroach.roachpb.Delete"
-    "RangeRequest\022,\n\004scan\030\007 \001(\0132\036.cockroach.r"
-    "oachpb.ScanRequest\022E\n\021begin_transaction\030"
-    "\010 \001(\0132*.cockroach.roachpb.BeginTransacti"
-    "onRequest\022A\n\017end_transaction\030\t \001(\0132(.coc"
-    "kroach.roachpb.EndTransactionRequest\0229\n\013"
-    "admin_split\030\n \001(\0132$.cockroach.roachpb.Ad"
-    "minSplitRequest\0229\n\013admin_merge\030\013 \001(\0132$.c"
-    "ockroach.roachpb.AdminMergeRequest\022=\n\rhe"
-    "artbeat_txn\030\014 \001(\0132&.cockroach.roachpb.He"
-    "artbeatTxnRequest\022(\n\002gc\030\r \001(\0132\034.cockroac"
-    "h.roachpb.GCRequest\0223\n\010push_txn\030\016 \001(\0132!."
-    "cockroach.roachpb.PushTxnRequest\022;\n\014rang"
-    "e_lookup\030\017 \001(\0132%.cockroach.roachpb.Range"
-    "LookupRequest\022\?\n\016resolve_intent\030\020 \001(\0132\'."
-    "cockroach.roachpb.ResolveIntentRequest\022J"
-    "\n\024resolve_intent_range\030\021 \001(\0132,.cockroach"
-    ".roachpb.ResolveIntentRangeRequest\022.\n\005me"
-    "rge\030\022 \001(\0132\037.cockroach.roachpb.MergeReque"
-    "st\022;\n\014truncate_log\030\023 \001(\0132%.cockroach.roa"
-    "chpb.TruncateLogRequest\022;\n\014leader_lease\030"
-    "\024 \001(\0132%.cockroach.roachpb.LeaderLeaseReq"
-    "uest\022;\n\014reverse_scan\030\025 \001(\0132%.cockroach.r"
-    "oachpb.ReverseScanRequest\022,\n\004noop\030\026 \001(\0132"
-    "\036.cockroach.roachpb.NoopRequest:\004\310\240\037\001\"\230\n"
-    "\n\rResponseUnion\022+\n\003get\030\001 \001(\0132\036.cockroach"
-    ".roachpb.GetResponse\022+\n\003put\030\002 \001(\0132\036.cock"
-    "roach.roachpb.PutResponse\022B\n\017conditional"
-    "_put\030\003 \001(\0132).cockroach.roachpb.Condition"
-    "alPutResponse\0227\n\tincrement\030\004 \001(\0132$.cockr"
-    "oach.roachpb.IncrementResponse\0221\n\006delete"
-    "\030\005 \001(\0132!.cockroach.roachpb.DeleteRespons"
-    "e\022<\n\014delete_range\030\006 \001(\0132&.cockroach.roac"
-    "hpb.DeleteRangeResponse\022-\n\004scan\030\007 \001(\0132\037."
-    "cockroach.roachpb.ScanResponse\022F\n\021begin_"
-    "transaction\030\010 \001(\0132+.cockroach.roachpb.Be"
-    "ginTransactionResponse\022B\n\017end_transactio"
-    "n\030\t \001(\0132).cockroach.roachpb.EndTransacti"
-    "onResponse\022:\n\013admin_split\030\n \001(\0132%.cockro"
-    "ach.roachpb.AdminSplitResponse\022:\n\013admin_"
-    "merge\030\013 \001(\0132%.cockroach.roachpb.AdminMer"
-    "geResponse\022>\n\rheartbeat_txn\030\014 \001(\0132\'.cock"
-    "roach.roachpb.HeartbeatTxnResponse\022)\n\002gc"
-    "\030\r \001(\0132\035.cockroach.roachpb.GCResponse\0224\n"
-    "\010push_txn\030\016 \001(\0132\".cockroach.roachpb.Push"
-    "TxnResponse\022<\n\014range_lookup\030\017 \001(\0132&.cock"
-    "roach.roachpb.RangeLookupResponse\022@\n\016res"
-    "olve_intent\030\020 \001(\0132(.cockroach.roachpb.Re"
-    "solveIntentResponse\022K\n\024resolve_intent_ra"
-    "nge\030\021 \001(\0132-.cockroach.roachpb.ResolveInt"
-    "entRangeResponse\022/\n\005merge\030\022 \001(\0132 .cockro"
-    "ach.roachpb.MergeResponse\022<\n\014truncate_lo"
-    "g\030\023 \001(\0132&.cockroach.roachpb.TruncateLogR"
-    "esponse\022<\n\014leader_lease\030\024 \001(\0132&.cockroac"
-    "h.roachpb.LeaderLeaseResponse\022<\n\014reverse"
-    "_scan\030\025 \001(\0132&.cockroach.roachpb.ReverseS"
-    "canResponse\022-\n\004noop\030\026 \001(\0132\037.cockroach.ro"
-    "achpb.NoopResponse:\004\310\240\037\001\"\371\002\n\006Header\0225\n\tt"
-    "imestamp\030\001 \001(\0132\034.cockroach.roachpb.Times"
-    "tampB\004\310\336\037\000\022;\n\007replica\030\002 \001(\0132$.cockroach."
-    "roachpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010range"
-    "_id\030\003 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022+\n"
-    "\ruser_priority\030\004 \001(\001B\024\310\336\037\000\372\336\037\014UserPriori"
-    "ty\022+\n\003txn\030\005 \001(\0132\036.cockroach.roachpb.Tran"
-    "saction\022F\n\020read_consistency\030\006 \001(\0162&.cock"
-    "roach.roachpb.ReadConsistencyTypeB\004\310\336\037\000\022"
-    "+\n\005trace\030\007 \001(\0132\034.cockroach.util.tracing."
-    "Span\"\202\001\n\014BatchRequest\0223\n\006header\030\001 \001(\0132\031."
-    "cockroach.roachpb.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010re"
-    "quests\030\002 \003(\0132\037.cockroach.roachpb.Request"
-    "UnionB\004\310\336\037\000:\004\230\240\037\000\"\214\002\n\rBatchResponse\022A\n\006h"
-    "eader\030\001 \001(\0132\'.cockroach.roachpb.BatchRes"
-    "ponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003("
-    "\0132 .cockroach.roachpb.ResponseUnionB\004\310\336\037"
-    "\000\032w\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockroach.r"
-    "oachpb.Error\022+\n\003txn\030\003 \001(\0132\036.cockroach.ro"
-    "achpb.Transaction\022\027\n\017collected_spans\030\004 \003"
-    "(\014:\004\230\240\037\000*L\n\023ReadConsistencyType\022\016\n\nCONSI"
-    "STENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002"
-    "\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020"
-    "\000\022\016\n\nPUSH_ABORT\020\001\022\016\n\nPUSH_TOUCH\020\002\032\004\210\243\036\0002"
-    "X\n\010Internal\022L\n\005Batch\022\037.cockroach.roachpb"
-    ".BatchRequest\032 .cockroach.roachpb.BatchR"
-    "esponse\"\0002X\n\010External\022L\n\005Batch\022\037.cockroa"
-    "ch.roachpb.BatchRequest\032 .cockroach.roac"
-    "hpb.BatchResponse\"\000B\tZ\007roachpbX\004", 9272);
+    "erB\010\310\336\037\000\320\336\037\001\0228\n\npushee_txn\030\002 \001(\0132\036.cockr"
+    "oach.roachpb.TransactionB\004\310\336\037\000\"\321\001\n\024Resol"
+    "veIntentRequest\0221\n\006header\030\001 \001(\0132\027.cockro"
+    "ach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\0224\n\nintent_txn"
+    "\030\002 \001(\0132\032.cockroach.roachpb.TxnMetaB\004\310\336\037\000"
+    "\022:\n\006status\030\003 \001(\0162$.cockroach.roachpb.Tra"
+    "nsactionStatusB\004\310\336\037\000\022\024\n\006poison\030\004 \001(\010B\004\310\336"
+    "\037\000\"T\n\025ResolveIntentResponse\022;\n\006header\030\001 "
+    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
+    "\310\336\037\000\320\336\037\001\"\326\001\n\031ResolveIntentRangeRequest\0221"
+    "\n\006header\030\001 \001(\0132\027.cockroach.roachpb.SpanB"
+    "\010\310\336\037\000\320\336\037\001\0224\n\nintent_txn\030\002 \001(\0132\032.cockroac"
+    "h.roachpb.TxnMetaB\004\310\336\037\000\022:\n\006status\030\003 \001(\0162"
+    "$.cockroach.roachpb.TransactionStatusB\004\310"
+    "\336\037\000\022\024\n\006poison\030\004 \001(\010B\004\310\336\037\000\"K\n\014NoopRespons"
+    "e\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Re"
+    "sponseHeaderB\010\310\336\037\000\320\336\037\001\"@\n\013NoopRequest\0221\n"
+    "\006header\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010"
+    "\310\336\037\000\320\336\037\001\"Y\n\032ResolveIntentRangeResponse\022;"
+    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
+    "nseHeaderB\010\310\336\037\000\320\336\037\001\"p\n\014MergeRequest\0221\n\006h"
+    "eader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336"
+    "\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachp"
+    "b.ValueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006header"
+    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
+    "rB\010\310\336\037\000\320\336\037\001\"\212\001\n\022TruncateLogRequest\0221\n\006he"
+    "ader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037"
+    "\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\022,\n\010range_id\030\003"
+    " \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\"R\n\023Trun"
+    "cateLogResponse\022;\n\006header\030\001 \001(\0132!.cockro"
+    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"v\n\022"
+    "LeaderLeaseRequest\0221\n\006header\030\001 \001(\0132\027.coc"
+    "kroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002"
+    " \001(\0132\030.cockroach.roachpb.LeaseB\004\310\336\037\000\"R\n\023"
+    "LeaderLeaseResponse\022;\n\006header\030\001 \001(\0132!.co"
+    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
+    "\"\276\001\n\026ComputeChecksumRequest\0221\n\006header\030\001 "
+    "\001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\025"
+    "\n\007version\030\002 \001(\rB\004\310\336\037\000\022Z\n\013checksum_id\030\003 \001"
+    "(\014BE\310\336\037\000\342\336\037\nChecksumID\332\336\037/github.com/coc"
+    "kroachdb/cockroach/util/uuid.UUID\"V\n\027Com"
+    "puteChecksumResponse\022;\n\006header\030\001 \001(\0132!.c"
+    "ockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037"
+    "\001\"\317\001\n\025VerifyChecksumRequest\0221\n\006header\030\001 "
+    "\001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\025"
+    "\n\007version\030\002 \001(\rB\004\310\336\037\000\022Z\n\013checksum_id\030\003 \001"
+    "(\014BE\310\336\037\000\342\336\037\nChecksumID\332\336\037/github.com/coc"
+    "kroachdb/cockroach/util/uuid.UUID\022\020\n\010che"
+    "cksum\030\004 \001(\014\"U\n\026VerifyChecksumResponse\022;\n"
+    "\006header\030\001 \001(\0132!.cockroach.roachpb.Respon"
+    "seHeaderB\010\310\336\037\000\320\336\037\001\"\320\013\n\014RequestUnion\022*\n\003g"
+    "et\030\001 \001(\0132\035.cockroach.roachpb.GetRequest\022"
+    "*\n\003put\030\002 \001(\0132\035.cockroach.roachpb.PutRequ"
+    "est\022A\n\017conditional_put\030\003 \001(\0132(.cockroach"
+    ".roachpb.ConditionalPutRequest\0226\n\tincrem"
+    "ent\030\004 \001(\0132#.cockroach.roachpb.IncrementR"
+    "equest\0220\n\006delete\030\005 \001(\0132 .cockroach.roach"
+    "pb.DeleteRequest\022;\n\014delete_range\030\006 \001(\0132%"
+    ".cockroach.roachpb.DeleteRangeRequest\022,\n"
+    "\004scan\030\007 \001(\0132\036.cockroach.roachpb.ScanRequ"
+    "est\022E\n\021begin_transaction\030\010 \001(\0132*.cockroa"
+    "ch.roachpb.BeginTransactionRequest\022A\n\017en"
+    "d_transaction\030\t \001(\0132(.cockroach.roachpb."
+    "EndTransactionRequest\0229\n\013admin_split\030\n \001"
+    "(\0132$.cockroach.roachpb.AdminSplitRequest"
+    "\0229\n\013admin_merge\030\013 \001(\0132$.cockroach.roachp"
+    "b.AdminMergeRequest\022=\n\rheartbeat_txn\030\014 \001"
+    "(\0132&.cockroach.roachpb.HeartbeatTxnReque"
+    "st\022(\n\002gc\030\r \001(\0132\034.cockroach.roachpb.GCReq"
+    "uest\0223\n\010push_txn\030\016 \001(\0132!.cockroach.roach"
+    "pb.PushTxnRequest\022;\n\014range_lookup\030\017 \001(\0132"
+    "%.cockroach.roachpb.RangeLookupRequest\022\?"
+    "\n\016resolve_intent\030\020 \001(\0132\'.cockroach.roach"
+    "pb.ResolveIntentRequest\022J\n\024resolve_inten"
+    "t_range\030\021 \001(\0132,.cockroach.roachpb.Resolv"
+    "eIntentRangeRequest\022.\n\005merge\030\022 \001(\0132\037.coc"
+    "kroach.roachpb.MergeRequest\022;\n\014truncate_"
+    "log\030\023 \001(\0132%.cockroach.roachpb.TruncateLo"
+    "gRequest\022;\n\014leader_lease\030\024 \001(\0132%.cockroa"
+    "ch.roachpb.LeaderLeaseRequest\022;\n\014reverse"
+    "_scan\030\025 \001(\0132%.cockroach.roachpb.ReverseS"
+    "canRequest\022C\n\020compute_checksum\030\026 \001(\0132).c"
+    "ockroach.roachpb.ComputeChecksumRequest\022"
+    "A\n\017verify_checksum\030\027 \001(\0132(.cockroach.roa"
+    "chpb.VerifyChecksumRequest\022E\n\021check_cons"
+    "istency\030\030 \001(\0132*.cockroach.roachpb.CheckC"
+    "onsistencyRequest\022,\n\004noop\030\031 \001(\0132\036.cockro"
+    "ach.roachpb.NoopRequest:\004\310\240\037\001\"\352\013\n\rRespon"
+    "seUnion\022+\n\003get\030\001 \001(\0132\036.cockroach.roachpb"
+    ".GetResponse\022+\n\003put\030\002 \001(\0132\036.cockroach.ro"
+    "achpb.PutResponse\022B\n\017conditional_put\030\003 \001"
+    "(\0132).cockroach.roachpb.ConditionalPutRes"
+    "ponse\0227\n\tincrement\030\004 \001(\0132$.cockroach.roa"
+    "chpb.IncrementResponse\0221\n\006delete\030\005 \001(\0132!"
+    ".cockroach.roachpb.DeleteResponse\022<\n\014del"
+    "ete_range\030\006 \001(\0132&.cockroach.roachpb.Dele"
+    "teRangeResponse\022-\n\004scan\030\007 \001(\0132\037.cockroac"
+    "h.roachpb.ScanResponse\022F\n\021begin_transact"
+    "ion\030\010 \001(\0132+.cockroach.roachpb.BeginTrans"
+    "actionResponse\022B\n\017end_transaction\030\t \001(\0132"
+    ").cockroach.roachpb.EndTransactionRespon"
+    "se\022:\n\013admin_split\030\n \001(\0132%.cockroach.roac"
+    "hpb.AdminSplitResponse\022:\n\013admin_merge\030\013 "
+    "\001(\0132%.cockroach.roachpb.AdminMergeRespon"
+    "se\022>\n\rheartbeat_txn\030\014 \001(\0132\'.cockroach.ro"
+    "achpb.HeartbeatTxnResponse\022)\n\002gc\030\r \001(\0132\035"
+    ".cockroach.roachpb.GCResponse\0224\n\010push_tx"
+    "n\030\016 \001(\0132\".cockroach.roachpb.PushTxnRespo"
+    "nse\022<\n\014range_lookup\030\017 \001(\0132&.cockroach.ro"
+    "achpb.RangeLookupResponse\022@\n\016resolve_int"
+    "ent\030\020 \001(\0132(.cockroach.roachpb.ResolveInt"
+    "entResponse\022K\n\024resolve_intent_range\030\021 \001("
+    "\0132-.cockroach.roachpb.ResolveIntentRange"
+    "Response\022/\n\005merge\030\022 \001(\0132 .cockroach.roac"
+    "hpb.MergeResponse\022<\n\014truncate_log\030\023 \001(\0132"
+    "&.cockroach.roachpb.TruncateLogResponse\022"
+    "<\n\014leader_lease\030\024 \001(\0132&.cockroach.roachp"
+    "b.LeaderLeaseResponse\022<\n\014reverse_scan\030\025 "
+    "\001(\0132&.cockroach.roachpb.ReverseScanRespo"
+    "nse\022D\n\020compute_checksum\030\026 \001(\0132*.cockroac"
+    "h.roachpb.ComputeChecksumResponse\022B\n\017ver"
+    "ify_checksum\030\027 \001(\0132).cockroach.roachpb.V"
+    "erifyChecksumResponse\022F\n\021check_consisten"
+    "cy\030\030 \001(\0132+.cockroach.roachpb.CheckConsis"
+    "tencyResponse\022-\n\004noop\030\031 \001(\0132\037.cockroach."
+    "roachpb.NoopResponse:\004\310\240\037\001\"\371\002\n\006Header\0225\n"
+    "\ttimestamp\030\001 \001(\0132\034.cockroach.roachpb.Tim"
+    "estampB\004\310\336\037\000\022;\n\007replica\030\002 \001(\0132$.cockroac"
+    "h.roachpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010ran"
+    "ge_id\030\003 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022"
+    "+\n\ruser_priority\030\004 \001(\001B\024\310\336\037\000\372\336\037\014UserPrio"
+    "rity\022+\n\003txn\030\005 \001(\0132\036.cockroach.roachpb.Tr"
+    "ansaction\022F\n\020read_consistency\030\006 \001(\0162&.co"
+    "ckroach.roachpb.ReadConsistencyTypeB\004\310\336\037"
+    "\000\022+\n\005trace\030\007 \001(\0132\034.cockroach.util.tracin"
+    "g.Span\"\202\001\n\014BatchRequest\0223\n\006header\030\001 \001(\0132"
+    "\031.cockroach.roachpb.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010"
+    "requests\030\002 \003(\0132\037.cockroach.roachpb.Reque"
+    "stUnionB\004\310\336\037\000:\004\230\240\037\000\"\214\002\n\rBatchResponse\022A\n"
+    "\006header\030\001 \001(\0132\'.cockroach.roachpb.BatchR"
+    "esponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 "
+    "\003(\0132 .cockroach.roachpb.ResponseUnionB\004\310"
+    "\336\037\000\032w\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockroach"
+    ".roachpb.Error\022+\n\003txn\030\003 \001(\0132\036.cockroach."
+    "roachpb.Transaction\022\027\n\017collected_spans\030\004"
+    " \003(\014:\004\230\240\037\000*L\n\023ReadConsistencyType\022\016\n\nCON"
+    "SISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT"
+    "\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAM"
+    "P\020\000\022\016\n\nPUSH_ABORT\020\001\022\016\n\nPUSH_TOUCH\020\002\032\004\210\243\036"
+    "\0002X\n\010Internal\022L\n\005Batch\022\037.cockroach.roach"
+    "pb.BatchRequest\032 .cockroach.roachpb.Batc"
+    "hResponse\"\0002X\n\010External\022L\n\005Batch\022\037.cockr"
+    "oach.roachpb.BatchRequest\032 .cockroach.ro"
+    "achpb.BatchResponse\"\000B\tZ\007roachpbX\004", 10434);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ResponseHeader::default_instance_ = new ResponseHeader();
@@ -1558,6 +1730,8 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
   ScanResponse::default_instance_ = new ScanResponse();
   ReverseScanRequest::default_instance_ = new ReverseScanRequest();
   ReverseScanResponse::default_instance_ = new ReverseScanResponse();
+  CheckConsistencyRequest::default_instance_ = new CheckConsistencyRequest();
+  CheckConsistencyResponse::default_instance_ = new CheckConsistencyResponse();
   BeginTransactionRequest::default_instance_ = new BeginTransactionRequest();
   BeginTransactionResponse::default_instance_ = new BeginTransactionResponse();
   EndTransactionRequest::default_instance_ = new EndTransactionRequest();
@@ -1587,6 +1761,10 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
   TruncateLogResponse::default_instance_ = new TruncateLogResponse();
   LeaderLeaseRequest::default_instance_ = new LeaderLeaseRequest();
   LeaderLeaseResponse::default_instance_ = new LeaderLeaseResponse();
+  ComputeChecksumRequest::default_instance_ = new ComputeChecksumRequest();
+  ComputeChecksumResponse::default_instance_ = new ComputeChecksumResponse();
+  VerifyChecksumRequest::default_instance_ = new VerifyChecksumRequest();
+  VerifyChecksumResponse::default_instance_ = new VerifyChecksumResponse();
   RequestUnion::default_instance_ = new RequestUnion();
   ResponseUnion::default_instance_ = new ResponseUnion();
   Header::default_instance_ = new Header();
@@ -1610,6 +1788,8 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
   ScanResponse::default_instance_->InitAsDefaultInstance();
   ReverseScanRequest::default_instance_->InitAsDefaultInstance();
   ReverseScanResponse::default_instance_->InitAsDefaultInstance();
+  CheckConsistencyRequest::default_instance_->InitAsDefaultInstance();
+  CheckConsistencyResponse::default_instance_->InitAsDefaultInstance();
   BeginTransactionRequest::default_instance_->InitAsDefaultInstance();
   BeginTransactionResponse::default_instance_->InitAsDefaultInstance();
   EndTransactionRequest::default_instance_->InitAsDefaultInstance();
@@ -1639,6 +1819,10 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
   TruncateLogResponse::default_instance_->InitAsDefaultInstance();
   LeaderLeaseRequest::default_instance_->InitAsDefaultInstance();
   LeaderLeaseResponse::default_instance_->InitAsDefaultInstance();
+  ComputeChecksumRequest::default_instance_->InitAsDefaultInstance();
+  ComputeChecksumResponse::default_instance_->InitAsDefaultInstance();
+  VerifyChecksumRequest::default_instance_->InitAsDefaultInstance();
+  VerifyChecksumResponse::default_instance_->InitAsDefaultInstance();
   RequestUnion::default_instance_->InitAsDefaultInstance();
   ResponseUnion::default_instance_->InitAsDefaultInstance();
   Header::default_instance_->InitAsDefaultInstance();
@@ -7596,6 +7780,572 @@ const ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::KeyValue >&
 ReverseScanResponse::rows() const {
   // @@protoc_insertion_point(field_list:cockroach.roachpb.ReverseScanResponse.rows)
   return rows_;
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int CheckConsistencyRequest::kHeaderFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+CheckConsistencyRequest::CheckConsistencyRequest()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.CheckConsistencyRequest)
+}
+
+void CheckConsistencyRequest::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::roachpb::Span*>(&::cockroach::roachpb::Span::default_instance());
+}
+
+CheckConsistencyRequest::CheckConsistencyRequest(const CheckConsistencyRequest& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.CheckConsistencyRequest)
+}
+
+void CheckConsistencyRequest::SharedCtor() {
+  _cached_size_ = 0;
+  header_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+CheckConsistencyRequest::~CheckConsistencyRequest() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.CheckConsistencyRequest)
+  SharedDtor();
+}
+
+void CheckConsistencyRequest::SharedDtor() {
+  if (this != default_instance_) {
+    delete header_;
+  }
+}
+
+void CheckConsistencyRequest::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* CheckConsistencyRequest::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return CheckConsistencyRequest_descriptor_;
+}
+
+const CheckConsistencyRequest& CheckConsistencyRequest::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  return *default_instance_;
+}
+
+CheckConsistencyRequest* CheckConsistencyRequest::default_instance_ = NULL;
+
+CheckConsistencyRequest* CheckConsistencyRequest::New(::google::protobuf::Arena* arena) const {
+  CheckConsistencyRequest* n = new CheckConsistencyRequest;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void CheckConsistencyRequest::Clear() {
+  if (has_header()) {
+    if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool CheckConsistencyRequest::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.CheckConsistencyRequest)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.roachpb.Span header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.CheckConsistencyRequest)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.CheckConsistencyRequest)
+  return false;
+#undef DO_
+}
+
+void CheckConsistencyRequest::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.CheckConsistencyRequest)
+  // optional .cockroach.roachpb.Span header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->header_, output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.CheckConsistencyRequest)
+}
+
+::google::protobuf::uint8* CheckConsistencyRequest::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.CheckConsistencyRequest)
+  // optional .cockroach.roachpb.Span header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, *this->header_, target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.CheckConsistencyRequest)
+  return target;
+}
+
+int CheckConsistencyRequest::ByteSize() const {
+  int total_size = 0;
+
+  // optional .cockroach.roachpb.Span header = 1;
+  if (has_header()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->header_);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void CheckConsistencyRequest::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const CheckConsistencyRequest* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const CheckConsistencyRequest>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void CheckConsistencyRequest::MergeFrom(const CheckConsistencyRequest& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::roachpb::Span::MergeFrom(from.header());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void CheckConsistencyRequest::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void CheckConsistencyRequest::CopyFrom(const CheckConsistencyRequest& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool CheckConsistencyRequest::IsInitialized() const {
+
+  return true;
+}
+
+void CheckConsistencyRequest::Swap(CheckConsistencyRequest* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void CheckConsistencyRequest::InternalSwap(CheckConsistencyRequest* other) {
+  std::swap(header_, other->header_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata CheckConsistencyRequest::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = CheckConsistencyRequest_descriptor_;
+  metadata.reflection = CheckConsistencyRequest_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// CheckConsistencyRequest
+
+// optional .cockroach.roachpb.Span header = 1;
+bool CheckConsistencyRequest::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void CheckConsistencyRequest::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void CheckConsistencyRequest::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void CheckConsistencyRequest::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+  clear_has_header();
+}
+const ::cockroach::roachpb::Span& CheckConsistencyRequest::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.CheckConsistencyRequest.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+::cockroach::roachpb::Span* CheckConsistencyRequest::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::Span;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.CheckConsistencyRequest.header)
+  return header_;
+}
+::cockroach::roachpb::Span* CheckConsistencyRequest::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::Span* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+void CheckConsistencyRequest::set_allocated_header(::cockroach::roachpb::Span* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.CheckConsistencyRequest.header)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int CheckConsistencyResponse::kHeaderFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+CheckConsistencyResponse::CheckConsistencyResponse()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.CheckConsistencyResponse)
+}
+
+void CheckConsistencyResponse::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::roachpb::ResponseHeader*>(&::cockroach::roachpb::ResponseHeader::default_instance());
+}
+
+CheckConsistencyResponse::CheckConsistencyResponse(const CheckConsistencyResponse& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.CheckConsistencyResponse)
+}
+
+void CheckConsistencyResponse::SharedCtor() {
+  _cached_size_ = 0;
+  header_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+CheckConsistencyResponse::~CheckConsistencyResponse() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.CheckConsistencyResponse)
+  SharedDtor();
+}
+
+void CheckConsistencyResponse::SharedDtor() {
+  if (this != default_instance_) {
+    delete header_;
+  }
+}
+
+void CheckConsistencyResponse::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* CheckConsistencyResponse::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return CheckConsistencyResponse_descriptor_;
+}
+
+const CheckConsistencyResponse& CheckConsistencyResponse::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  return *default_instance_;
+}
+
+CheckConsistencyResponse* CheckConsistencyResponse::default_instance_ = NULL;
+
+CheckConsistencyResponse* CheckConsistencyResponse::New(::google::protobuf::Arena* arena) const {
+  CheckConsistencyResponse* n = new CheckConsistencyResponse;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void CheckConsistencyResponse::Clear() {
+  if (has_header()) {
+    if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool CheckConsistencyResponse::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.CheckConsistencyResponse)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.roachpb.ResponseHeader header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.CheckConsistencyResponse)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.CheckConsistencyResponse)
+  return false;
+#undef DO_
+}
+
+void CheckConsistencyResponse::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.CheckConsistencyResponse)
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->header_, output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.CheckConsistencyResponse)
+}
+
+::google::protobuf::uint8* CheckConsistencyResponse::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.CheckConsistencyResponse)
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, *this->header_, target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.CheckConsistencyResponse)
+  return target;
+}
+
+int CheckConsistencyResponse::ByteSize() const {
+  int total_size = 0;
+
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->header_);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void CheckConsistencyResponse::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const CheckConsistencyResponse* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const CheckConsistencyResponse>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void CheckConsistencyResponse::MergeFrom(const CheckConsistencyResponse& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::roachpb::ResponseHeader::MergeFrom(from.header());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void CheckConsistencyResponse::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void CheckConsistencyResponse::CopyFrom(const CheckConsistencyResponse& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool CheckConsistencyResponse::IsInitialized() const {
+
+  return true;
+}
+
+void CheckConsistencyResponse::Swap(CheckConsistencyResponse* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void CheckConsistencyResponse::InternalSwap(CheckConsistencyResponse* other) {
+  std::swap(header_, other->header_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata CheckConsistencyResponse::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = CheckConsistencyResponse_descriptor_;
+  metadata.reflection = CheckConsistencyResponse_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// CheckConsistencyResponse
+
+// optional .cockroach.roachpb.ResponseHeader header = 1;
+bool CheckConsistencyResponse::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void CheckConsistencyResponse::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void CheckConsistencyResponse::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void CheckConsistencyResponse::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  clear_has_header();
+}
+const ::cockroach::roachpb::ResponseHeader& CheckConsistencyResponse::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.CheckConsistencyResponse.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+::cockroach::roachpb::ResponseHeader* CheckConsistencyResponse::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::ResponseHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.CheckConsistencyResponse.header)
+  return header_;
+}
+::cockroach::roachpb::ResponseHeader* CheckConsistencyResponse::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::ResponseHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+void CheckConsistencyResponse::set_allocated_header(::cockroach::roachpb::ResponseHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.CheckConsistencyResponse.header)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -18220,6 +18970,1565 @@ void LeaderLeaseResponse::set_allocated_header(::cockroach::roachpb::ResponseHea
 // ===================================================================
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ComputeChecksumRequest::kHeaderFieldNumber;
+const int ComputeChecksumRequest::kVersionFieldNumber;
+const int ComputeChecksumRequest::kChecksumIdFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ComputeChecksumRequest::ComputeChecksumRequest()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.ComputeChecksumRequest)
+}
+
+void ComputeChecksumRequest::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::roachpb::Span*>(&::cockroach::roachpb::Span::default_instance());
+}
+
+ComputeChecksumRequest::ComputeChecksumRequest(const ComputeChecksumRequest& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.ComputeChecksumRequest)
+}
+
+void ComputeChecksumRequest::SharedCtor() {
+  ::google::protobuf::internal::GetEmptyString();
+  _cached_size_ = 0;
+  header_ = NULL;
+  version_ = 0u;
+  checksum_id_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+ComputeChecksumRequest::~ComputeChecksumRequest() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.ComputeChecksumRequest)
+  SharedDtor();
+}
+
+void ComputeChecksumRequest::SharedDtor() {
+  checksum_id_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (this != default_instance_) {
+    delete header_;
+  }
+}
+
+void ComputeChecksumRequest::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* ComputeChecksumRequest::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return ComputeChecksumRequest_descriptor_;
+}
+
+const ComputeChecksumRequest& ComputeChecksumRequest::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  return *default_instance_;
+}
+
+ComputeChecksumRequest* ComputeChecksumRequest::default_instance_ = NULL;
+
+ComputeChecksumRequest* ComputeChecksumRequest::New(::google::protobuf::Arena* arena) const {
+  ComputeChecksumRequest* n = new ComputeChecksumRequest;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void ComputeChecksumRequest::Clear() {
+  if (_has_bits_[0 / 32] & 7u) {
+    if (has_header()) {
+      if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+    }
+    version_ = 0u;
+    if (has_checksum_id()) {
+      checksum_id_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    }
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool ComputeChecksumRequest::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.ComputeChecksumRequest)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.roachpb.Span header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(16)) goto parse_version;
+        break;
+      }
+
+      // optional uint32 version = 2;
+      case 2: {
+        if (tag == 16) {
+         parse_version:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
+                 input, &version_)));
+          set_has_version();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(26)) goto parse_checksum_id;
+        break;
+      }
+
+      // optional bytes checksum_id = 3;
+      case 3: {
+        if (tag == 26) {
+         parse_checksum_id:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->mutable_checksum_id()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.ComputeChecksumRequest)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.ComputeChecksumRequest)
+  return false;
+#undef DO_
+}
+
+void ComputeChecksumRequest::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.ComputeChecksumRequest)
+  // optional .cockroach.roachpb.Span header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->header_, output);
+  }
+
+  // optional uint32 version = 2;
+  if (has_version()) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt32(2, this->version(), output);
+  }
+
+  // optional bytes checksum_id = 3;
+  if (has_checksum_id()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      3, this->checksum_id(), output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.ComputeChecksumRequest)
+}
+
+::google::protobuf::uint8* ComputeChecksumRequest::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.ComputeChecksumRequest)
+  // optional .cockroach.roachpb.Span header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, *this->header_, target);
+  }
+
+  // optional uint32 version = 2;
+  if (has_version()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteUInt32ToArray(2, this->version(), target);
+  }
+
+  // optional bytes checksum_id = 3;
+  if (has_checksum_id()) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        3, this->checksum_id(), target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.ComputeChecksumRequest)
+  return target;
+}
+
+int ComputeChecksumRequest::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & 7u) {
+    // optional .cockroach.roachpb.Span header = 1;
+    if (has_header()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->header_);
+    }
+
+    // optional uint32 version = 2;
+    if (has_version()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::UInt32Size(
+          this->version());
+    }
+
+    // optional bytes checksum_id = 3;
+    if (has_checksum_id()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->checksum_id());
+    }
+
+  }
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void ComputeChecksumRequest::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const ComputeChecksumRequest* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const ComputeChecksumRequest>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void ComputeChecksumRequest::MergeFrom(const ComputeChecksumRequest& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::roachpb::Span::MergeFrom(from.header());
+    }
+    if (from.has_version()) {
+      set_version(from.version());
+    }
+    if (from.has_checksum_id()) {
+      set_has_checksum_id();
+      checksum_id_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.checksum_id_);
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void ComputeChecksumRequest::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ComputeChecksumRequest::CopyFrom(const ComputeChecksumRequest& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ComputeChecksumRequest::IsInitialized() const {
+
+  return true;
+}
+
+void ComputeChecksumRequest::Swap(ComputeChecksumRequest* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ComputeChecksumRequest::InternalSwap(ComputeChecksumRequest* other) {
+  std::swap(header_, other->header_);
+  std::swap(version_, other->version_);
+  checksum_id_.Swap(&other->checksum_id_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata ComputeChecksumRequest::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = ComputeChecksumRequest_descriptor_;
+  metadata.reflection = ComputeChecksumRequest_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// ComputeChecksumRequest
+
+// optional .cockroach.roachpb.Span header = 1;
+bool ComputeChecksumRequest::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void ComputeChecksumRequest::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void ComputeChecksumRequest::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void ComputeChecksumRequest::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+  clear_has_header();
+}
+const ::cockroach::roachpb::Span& ComputeChecksumRequest::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ComputeChecksumRequest.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+::cockroach::roachpb::Span* ComputeChecksumRequest::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::Span;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ComputeChecksumRequest.header)
+  return header_;
+}
+::cockroach::roachpb::Span* ComputeChecksumRequest::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::Span* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+void ComputeChecksumRequest::set_allocated_header(::cockroach::roachpb::Span* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ComputeChecksumRequest.header)
+}
+
+// optional uint32 version = 2;
+bool ComputeChecksumRequest::has_version() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+void ComputeChecksumRequest::set_has_version() {
+  _has_bits_[0] |= 0x00000002u;
+}
+void ComputeChecksumRequest::clear_has_version() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+void ComputeChecksumRequest::clear_version() {
+  version_ = 0u;
+  clear_has_version();
+}
+ ::google::protobuf::uint32 ComputeChecksumRequest::version() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ComputeChecksumRequest.version)
+  return version_;
+}
+ void ComputeChecksumRequest::set_version(::google::protobuf::uint32 value) {
+  set_has_version();
+  version_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ComputeChecksumRequest.version)
+}
+
+// optional bytes checksum_id = 3;
+bool ComputeChecksumRequest::has_checksum_id() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+void ComputeChecksumRequest::set_has_checksum_id() {
+  _has_bits_[0] |= 0x00000004u;
+}
+void ComputeChecksumRequest::clear_has_checksum_id() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+void ComputeChecksumRequest::clear_checksum_id() {
+  checksum_id_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_checksum_id();
+}
+ const ::std::string& ComputeChecksumRequest::checksum_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+  return checksum_id_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void ComputeChecksumRequest::set_checksum_id(const ::std::string& value) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+}
+ void ComputeChecksumRequest::set_checksum_id(const char* value) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+}
+ void ComputeChecksumRequest::set_checksum_id(const void* value, size_t size) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+}
+ ::std::string* ComputeChecksumRequest::mutable_checksum_id() {
+  set_has_checksum_id();
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+  return checksum_id_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ ::std::string* ComputeChecksumRequest::release_checksum_id() {
+  clear_has_checksum_id();
+  return checksum_id_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void ComputeChecksumRequest::set_allocated_checksum_id(::std::string* checksum_id) {
+  if (checksum_id != NULL) {
+    set_has_checksum_id();
+  } else {
+    clear_has_checksum_id();
+  }
+  checksum_id_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), checksum_id);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ComputeChecksumResponse::kHeaderFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ComputeChecksumResponse::ComputeChecksumResponse()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.ComputeChecksumResponse)
+}
+
+void ComputeChecksumResponse::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::roachpb::ResponseHeader*>(&::cockroach::roachpb::ResponseHeader::default_instance());
+}
+
+ComputeChecksumResponse::ComputeChecksumResponse(const ComputeChecksumResponse& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.ComputeChecksumResponse)
+}
+
+void ComputeChecksumResponse::SharedCtor() {
+  _cached_size_ = 0;
+  header_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+ComputeChecksumResponse::~ComputeChecksumResponse() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.ComputeChecksumResponse)
+  SharedDtor();
+}
+
+void ComputeChecksumResponse::SharedDtor() {
+  if (this != default_instance_) {
+    delete header_;
+  }
+}
+
+void ComputeChecksumResponse::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* ComputeChecksumResponse::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return ComputeChecksumResponse_descriptor_;
+}
+
+const ComputeChecksumResponse& ComputeChecksumResponse::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  return *default_instance_;
+}
+
+ComputeChecksumResponse* ComputeChecksumResponse::default_instance_ = NULL;
+
+ComputeChecksumResponse* ComputeChecksumResponse::New(::google::protobuf::Arena* arena) const {
+  ComputeChecksumResponse* n = new ComputeChecksumResponse;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void ComputeChecksumResponse::Clear() {
+  if (has_header()) {
+    if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool ComputeChecksumResponse::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.ComputeChecksumResponse)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.roachpb.ResponseHeader header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.ComputeChecksumResponse)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.ComputeChecksumResponse)
+  return false;
+#undef DO_
+}
+
+void ComputeChecksumResponse::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.ComputeChecksumResponse)
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->header_, output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.ComputeChecksumResponse)
+}
+
+::google::protobuf::uint8* ComputeChecksumResponse::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.ComputeChecksumResponse)
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, *this->header_, target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.ComputeChecksumResponse)
+  return target;
+}
+
+int ComputeChecksumResponse::ByteSize() const {
+  int total_size = 0;
+
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->header_);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void ComputeChecksumResponse::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const ComputeChecksumResponse* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const ComputeChecksumResponse>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void ComputeChecksumResponse::MergeFrom(const ComputeChecksumResponse& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::roachpb::ResponseHeader::MergeFrom(from.header());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void ComputeChecksumResponse::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ComputeChecksumResponse::CopyFrom(const ComputeChecksumResponse& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ComputeChecksumResponse::IsInitialized() const {
+
+  return true;
+}
+
+void ComputeChecksumResponse::Swap(ComputeChecksumResponse* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ComputeChecksumResponse::InternalSwap(ComputeChecksumResponse* other) {
+  std::swap(header_, other->header_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata ComputeChecksumResponse::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = ComputeChecksumResponse_descriptor_;
+  metadata.reflection = ComputeChecksumResponse_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// ComputeChecksumResponse
+
+// optional .cockroach.roachpb.ResponseHeader header = 1;
+bool ComputeChecksumResponse::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void ComputeChecksumResponse::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void ComputeChecksumResponse::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void ComputeChecksumResponse::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  clear_has_header();
+}
+const ::cockroach::roachpb::ResponseHeader& ComputeChecksumResponse::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ComputeChecksumResponse.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+::cockroach::roachpb::ResponseHeader* ComputeChecksumResponse::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::ResponseHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ComputeChecksumResponse.header)
+  return header_;
+}
+::cockroach::roachpb::ResponseHeader* ComputeChecksumResponse::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::ResponseHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+void ComputeChecksumResponse::set_allocated_header(::cockroach::roachpb::ResponseHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ComputeChecksumResponse.header)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int VerifyChecksumRequest::kHeaderFieldNumber;
+const int VerifyChecksumRequest::kVersionFieldNumber;
+const int VerifyChecksumRequest::kChecksumIdFieldNumber;
+const int VerifyChecksumRequest::kChecksumFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+VerifyChecksumRequest::VerifyChecksumRequest()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.VerifyChecksumRequest)
+}
+
+void VerifyChecksumRequest::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::roachpb::Span*>(&::cockroach::roachpb::Span::default_instance());
+}
+
+VerifyChecksumRequest::VerifyChecksumRequest(const VerifyChecksumRequest& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.VerifyChecksumRequest)
+}
+
+void VerifyChecksumRequest::SharedCtor() {
+  ::google::protobuf::internal::GetEmptyString();
+  _cached_size_ = 0;
+  header_ = NULL;
+  version_ = 0u;
+  checksum_id_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  checksum_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+VerifyChecksumRequest::~VerifyChecksumRequest() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.VerifyChecksumRequest)
+  SharedDtor();
+}
+
+void VerifyChecksumRequest::SharedDtor() {
+  checksum_id_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  checksum_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (this != default_instance_) {
+    delete header_;
+  }
+}
+
+void VerifyChecksumRequest::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* VerifyChecksumRequest::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return VerifyChecksumRequest_descriptor_;
+}
+
+const VerifyChecksumRequest& VerifyChecksumRequest::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  return *default_instance_;
+}
+
+VerifyChecksumRequest* VerifyChecksumRequest::default_instance_ = NULL;
+
+VerifyChecksumRequest* VerifyChecksumRequest::New(::google::protobuf::Arena* arena) const {
+  VerifyChecksumRequest* n = new VerifyChecksumRequest;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void VerifyChecksumRequest::Clear() {
+  if (_has_bits_[0 / 32] & 15u) {
+    if (has_header()) {
+      if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+    }
+    version_ = 0u;
+    if (has_checksum_id()) {
+      checksum_id_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    }
+    if (has_checksum()) {
+      checksum_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    }
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool VerifyChecksumRequest::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.VerifyChecksumRequest)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.roachpb.Span header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(16)) goto parse_version;
+        break;
+      }
+
+      // optional uint32 version = 2;
+      case 2: {
+        if (tag == 16) {
+         parse_version:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
+                 input, &version_)));
+          set_has_version();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(26)) goto parse_checksum_id;
+        break;
+      }
+
+      // optional bytes checksum_id = 3;
+      case 3: {
+        if (tag == 26) {
+         parse_checksum_id:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->mutable_checksum_id()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(34)) goto parse_checksum;
+        break;
+      }
+
+      // optional bytes checksum = 4;
+      case 4: {
+        if (tag == 34) {
+         parse_checksum:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
+                input, this->mutable_checksum()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.VerifyChecksumRequest)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.VerifyChecksumRequest)
+  return false;
+#undef DO_
+}
+
+void VerifyChecksumRequest::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.VerifyChecksumRequest)
+  // optional .cockroach.roachpb.Span header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->header_, output);
+  }
+
+  // optional uint32 version = 2;
+  if (has_version()) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt32(2, this->version(), output);
+  }
+
+  // optional bytes checksum_id = 3;
+  if (has_checksum_id()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      3, this->checksum_id(), output);
+  }
+
+  // optional bytes checksum = 4;
+  if (has_checksum()) {
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
+      4, this->checksum(), output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.VerifyChecksumRequest)
+}
+
+::google::protobuf::uint8* VerifyChecksumRequest::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.VerifyChecksumRequest)
+  // optional .cockroach.roachpb.Span header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, *this->header_, target);
+  }
+
+  // optional uint32 version = 2;
+  if (has_version()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteUInt32ToArray(2, this->version(), target);
+  }
+
+  // optional bytes checksum_id = 3;
+  if (has_checksum_id()) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        3, this->checksum_id(), target);
+  }
+
+  // optional bytes checksum = 4;
+  if (has_checksum()) {
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
+        4, this->checksum(), target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.VerifyChecksumRequest)
+  return target;
+}
+
+int VerifyChecksumRequest::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & 15u) {
+    // optional .cockroach.roachpb.Span header = 1;
+    if (has_header()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->header_);
+    }
+
+    // optional uint32 version = 2;
+    if (has_version()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::UInt32Size(
+          this->version());
+    }
+
+    // optional bytes checksum_id = 3;
+    if (has_checksum_id()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->checksum_id());
+    }
+
+    // optional bytes checksum = 4;
+    if (has_checksum()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::BytesSize(
+          this->checksum());
+    }
+
+  }
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void VerifyChecksumRequest::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const VerifyChecksumRequest* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const VerifyChecksumRequest>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void VerifyChecksumRequest::MergeFrom(const VerifyChecksumRequest& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::roachpb::Span::MergeFrom(from.header());
+    }
+    if (from.has_version()) {
+      set_version(from.version());
+    }
+    if (from.has_checksum_id()) {
+      set_has_checksum_id();
+      checksum_id_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.checksum_id_);
+    }
+    if (from.has_checksum()) {
+      set_has_checksum();
+      checksum_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.checksum_);
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void VerifyChecksumRequest::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void VerifyChecksumRequest::CopyFrom(const VerifyChecksumRequest& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool VerifyChecksumRequest::IsInitialized() const {
+
+  return true;
+}
+
+void VerifyChecksumRequest::Swap(VerifyChecksumRequest* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void VerifyChecksumRequest::InternalSwap(VerifyChecksumRequest* other) {
+  std::swap(header_, other->header_);
+  std::swap(version_, other->version_);
+  checksum_id_.Swap(&other->checksum_id_);
+  checksum_.Swap(&other->checksum_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata VerifyChecksumRequest::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = VerifyChecksumRequest_descriptor_;
+  metadata.reflection = VerifyChecksumRequest_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// VerifyChecksumRequest
+
+// optional .cockroach.roachpb.Span header = 1;
+bool VerifyChecksumRequest::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void VerifyChecksumRequest::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void VerifyChecksumRequest::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void VerifyChecksumRequest::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+  clear_has_header();
+}
+const ::cockroach::roachpb::Span& VerifyChecksumRequest::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.VerifyChecksumRequest.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+::cockroach::roachpb::Span* VerifyChecksumRequest::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::Span;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.VerifyChecksumRequest.header)
+  return header_;
+}
+::cockroach::roachpb::Span* VerifyChecksumRequest::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::Span* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+void VerifyChecksumRequest::set_allocated_header(::cockroach::roachpb::Span* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.VerifyChecksumRequest.header)
+}
+
+// optional uint32 version = 2;
+bool VerifyChecksumRequest::has_version() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+void VerifyChecksumRequest::set_has_version() {
+  _has_bits_[0] |= 0x00000002u;
+}
+void VerifyChecksumRequest::clear_has_version() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+void VerifyChecksumRequest::clear_version() {
+  version_ = 0u;
+  clear_has_version();
+}
+ ::google::protobuf::uint32 VerifyChecksumRequest::version() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.VerifyChecksumRequest.version)
+  return version_;
+}
+ void VerifyChecksumRequest::set_version(::google::protobuf::uint32 value) {
+  set_has_version();
+  version_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.VerifyChecksumRequest.version)
+}
+
+// optional bytes checksum_id = 3;
+bool VerifyChecksumRequest::has_checksum_id() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+void VerifyChecksumRequest::set_has_checksum_id() {
+  _has_bits_[0] |= 0x00000004u;
+}
+void VerifyChecksumRequest::clear_has_checksum_id() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+void VerifyChecksumRequest::clear_checksum_id() {
+  checksum_id_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_checksum_id();
+}
+ const ::std::string& VerifyChecksumRequest::checksum_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+  return checksum_id_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void VerifyChecksumRequest::set_checksum_id(const ::std::string& value) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+}
+ void VerifyChecksumRequest::set_checksum_id(const char* value) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+}
+ void VerifyChecksumRequest::set_checksum_id(const void* value, size_t size) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+}
+ ::std::string* VerifyChecksumRequest::mutable_checksum_id() {
+  set_has_checksum_id();
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+  return checksum_id_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ ::std::string* VerifyChecksumRequest::release_checksum_id() {
+  clear_has_checksum_id();
+  return checksum_id_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void VerifyChecksumRequest::set_allocated_checksum_id(::std::string* checksum_id) {
+  if (checksum_id != NULL) {
+    set_has_checksum_id();
+  } else {
+    clear_has_checksum_id();
+  }
+  checksum_id_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), checksum_id);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+}
+
+// optional bytes checksum = 4;
+bool VerifyChecksumRequest::has_checksum() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+void VerifyChecksumRequest::set_has_checksum() {
+  _has_bits_[0] |= 0x00000008u;
+}
+void VerifyChecksumRequest::clear_has_checksum() {
+  _has_bits_[0] &= ~0x00000008u;
+}
+void VerifyChecksumRequest::clear_checksum() {
+  checksum_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_checksum();
+}
+ const ::std::string& VerifyChecksumRequest::checksum() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.VerifyChecksumRequest.checksum)
+  return checksum_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void VerifyChecksumRequest::set_checksum(const ::std::string& value) {
+  set_has_checksum();
+  checksum_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.VerifyChecksumRequest.checksum)
+}
+ void VerifyChecksumRequest::set_checksum(const char* value) {
+  set_has_checksum();
+  checksum_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.VerifyChecksumRequest.checksum)
+}
+ void VerifyChecksumRequest::set_checksum(const void* value, size_t size) {
+  set_has_checksum();
+  checksum_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.VerifyChecksumRequest.checksum)
+}
+ ::std::string* VerifyChecksumRequest::mutable_checksum() {
+  set_has_checksum();
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.VerifyChecksumRequest.checksum)
+  return checksum_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ ::std::string* VerifyChecksumRequest::release_checksum() {
+  clear_has_checksum();
+  return checksum_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+ void VerifyChecksumRequest::set_allocated_checksum(::std::string* checksum) {
+  if (checksum != NULL) {
+    set_has_checksum();
+  } else {
+    clear_has_checksum();
+  }
+  checksum_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), checksum);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.VerifyChecksumRequest.checksum)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int VerifyChecksumResponse::kHeaderFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+VerifyChecksumResponse::VerifyChecksumResponse()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.VerifyChecksumResponse)
+}
+
+void VerifyChecksumResponse::InitAsDefaultInstance() {
+  header_ = const_cast< ::cockroach::roachpb::ResponseHeader*>(&::cockroach::roachpb::ResponseHeader::default_instance());
+}
+
+VerifyChecksumResponse::VerifyChecksumResponse(const VerifyChecksumResponse& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.VerifyChecksumResponse)
+}
+
+void VerifyChecksumResponse::SharedCtor() {
+  _cached_size_ = 0;
+  header_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+VerifyChecksumResponse::~VerifyChecksumResponse() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.VerifyChecksumResponse)
+  SharedDtor();
+}
+
+void VerifyChecksumResponse::SharedDtor() {
+  if (this != default_instance_) {
+    delete header_;
+  }
+}
+
+void VerifyChecksumResponse::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* VerifyChecksumResponse::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return VerifyChecksumResponse_descriptor_;
+}
+
+const VerifyChecksumResponse& VerifyChecksumResponse::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  return *default_instance_;
+}
+
+VerifyChecksumResponse* VerifyChecksumResponse::default_instance_ = NULL;
+
+VerifyChecksumResponse* VerifyChecksumResponse::New(::google::protobuf::Arena* arena) const {
+  VerifyChecksumResponse* n = new VerifyChecksumResponse;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void VerifyChecksumResponse::Clear() {
+  if (has_header()) {
+    if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool VerifyChecksumResponse::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.VerifyChecksumResponse)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .cockroach.roachpb.ResponseHeader header = 1;
+      case 1: {
+        if (tag == 10) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_header()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.VerifyChecksumResponse)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.VerifyChecksumResponse)
+  return false;
+#undef DO_
+}
+
+void VerifyChecksumResponse::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.VerifyChecksumResponse)
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->header_, output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.VerifyChecksumResponse)
+}
+
+::google::protobuf::uint8* VerifyChecksumResponse::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.VerifyChecksumResponse)
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, *this->header_, target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.VerifyChecksumResponse)
+  return target;
+}
+
+int VerifyChecksumResponse::ByteSize() const {
+  int total_size = 0;
+
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  if (has_header()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->header_);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void VerifyChecksumResponse::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const VerifyChecksumResponse* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const VerifyChecksumResponse>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void VerifyChecksumResponse::MergeFrom(const VerifyChecksumResponse& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_header()) {
+      mutable_header()->::cockroach::roachpb::ResponseHeader::MergeFrom(from.header());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void VerifyChecksumResponse::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void VerifyChecksumResponse::CopyFrom(const VerifyChecksumResponse& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool VerifyChecksumResponse::IsInitialized() const {
+
+  return true;
+}
+
+void VerifyChecksumResponse::Swap(VerifyChecksumResponse* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void VerifyChecksumResponse::InternalSwap(VerifyChecksumResponse* other) {
+  std::swap(header_, other->header_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata VerifyChecksumResponse::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = VerifyChecksumResponse_descriptor_;
+  metadata.reflection = VerifyChecksumResponse_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// VerifyChecksumResponse
+
+// optional .cockroach.roachpb.ResponseHeader header = 1;
+bool VerifyChecksumResponse::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void VerifyChecksumResponse::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void VerifyChecksumResponse::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void VerifyChecksumResponse::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  clear_has_header();
+}
+const ::cockroach::roachpb::ResponseHeader& VerifyChecksumResponse::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.VerifyChecksumResponse.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+::cockroach::roachpb::ResponseHeader* VerifyChecksumResponse::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::ResponseHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.VerifyChecksumResponse.header)
+  return header_;
+}
+::cockroach::roachpb::ResponseHeader* VerifyChecksumResponse::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::ResponseHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+void VerifyChecksumResponse::set_allocated_header(::cockroach::roachpb::ResponseHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.VerifyChecksumResponse.header)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int RequestUnion::kGetFieldNumber;
 const int RequestUnion::kPutFieldNumber;
 const int RequestUnion::kConditionalPutFieldNumber;
@@ -18241,6 +20550,9 @@ const int RequestUnion::kMergeFieldNumber;
 const int RequestUnion::kTruncateLogFieldNumber;
 const int RequestUnion::kLeaderLeaseFieldNumber;
 const int RequestUnion::kReverseScanFieldNumber;
+const int RequestUnion::kComputeChecksumFieldNumber;
+const int RequestUnion::kVerifyChecksumFieldNumber;
+const int RequestUnion::kCheckConsistencyFieldNumber;
 const int RequestUnion::kNoopFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
@@ -18272,6 +20584,9 @@ void RequestUnion::InitAsDefaultInstance() {
   truncate_log_ = const_cast< ::cockroach::roachpb::TruncateLogRequest*>(&::cockroach::roachpb::TruncateLogRequest::default_instance());
   leader_lease_ = const_cast< ::cockroach::roachpb::LeaderLeaseRequest*>(&::cockroach::roachpb::LeaderLeaseRequest::default_instance());
   reverse_scan_ = const_cast< ::cockroach::roachpb::ReverseScanRequest*>(&::cockroach::roachpb::ReverseScanRequest::default_instance());
+  compute_checksum_ = const_cast< ::cockroach::roachpb::ComputeChecksumRequest*>(&::cockroach::roachpb::ComputeChecksumRequest::default_instance());
+  verify_checksum_ = const_cast< ::cockroach::roachpb::VerifyChecksumRequest*>(&::cockroach::roachpb::VerifyChecksumRequest::default_instance());
+  check_consistency_ = const_cast< ::cockroach::roachpb::CheckConsistencyRequest*>(&::cockroach::roachpb::CheckConsistencyRequest::default_instance());
   noop_ = const_cast< ::cockroach::roachpb::NoopRequest*>(&::cockroach::roachpb::NoopRequest::default_instance());
 }
 
@@ -18306,6 +20621,9 @@ void RequestUnion::SharedCtor() {
   truncate_log_ = NULL;
   leader_lease_ = NULL;
   reverse_scan_ = NULL;
+  compute_checksum_ = NULL;
+  verify_checksum_ = NULL;
+  check_consistency_ = NULL;
   noop_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -18338,6 +20656,9 @@ void RequestUnion::SharedDtor() {
     delete truncate_log_;
     delete leader_lease_;
     delete reverse_scan_;
+    delete compute_checksum_;
+    delete verify_checksum_;
+    delete check_consistency_;
     delete noop_;
   }
 }
@@ -18420,7 +20741,7 @@ void RequestUnion::Clear() {
       if (resolve_intent_ != NULL) resolve_intent_->::cockroach::roachpb::ResolveIntentRequest::Clear();
     }
   }
-  if (_has_bits_[16 / 32] & 4128768u) {
+  if (_has_bits_[16 / 32] & 16711680u) {
     if (has_resolve_intent_range()) {
       if (resolve_intent_range_ != NULL) resolve_intent_range_->::cockroach::roachpb::ResolveIntentRangeRequest::Clear();
     }
@@ -18436,9 +20757,18 @@ void RequestUnion::Clear() {
     if (has_reverse_scan()) {
       if (reverse_scan_ != NULL) reverse_scan_->::cockroach::roachpb::ReverseScanRequest::Clear();
     }
-    if (has_noop()) {
-      if (noop_ != NULL) noop_->::cockroach::roachpb::NoopRequest::Clear();
+    if (has_compute_checksum()) {
+      if (compute_checksum_ != NULL) compute_checksum_->::cockroach::roachpb::ComputeChecksumRequest::Clear();
     }
+    if (has_verify_checksum()) {
+      if (verify_checksum_ != NULL) verify_checksum_->::cockroach::roachpb::VerifyChecksumRequest::Clear();
+    }
+    if (has_check_consistency()) {
+      if (check_consistency_ != NULL) check_consistency_->::cockroach::roachpb::CheckConsistencyRequest::Clear();
+    }
+  }
+  if (has_noop()) {
+    if (noop_ != NULL) noop_->::cockroach::roachpb::NoopRequest::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -18724,13 +21054,52 @@ bool RequestUnion::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(178)) goto parse_noop;
+        if (input->ExpectTag(178)) goto parse_compute_checksum;
         break;
       }
 
-      // optional .cockroach.roachpb.NoopRequest noop = 22;
+      // optional .cockroach.roachpb.ComputeChecksumRequest compute_checksum = 22;
       case 22: {
         if (tag == 178) {
+         parse_compute_checksum:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_compute_checksum()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(186)) goto parse_verify_checksum;
+        break;
+      }
+
+      // optional .cockroach.roachpb.VerifyChecksumRequest verify_checksum = 23;
+      case 23: {
+        if (tag == 186) {
+         parse_verify_checksum:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_verify_checksum()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(194)) goto parse_check_consistency;
+        break;
+      }
+
+      // optional .cockroach.roachpb.CheckConsistencyRequest check_consistency = 24;
+      case 24: {
+        if (tag == 194) {
+         parse_check_consistency:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_check_consistency()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(202)) goto parse_noop;
+        break;
+      }
+
+      // optional .cockroach.roachpb.NoopRequest noop = 25;
+      case 25: {
+        if (tag == 202) {
          parse_noop:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_noop()));
@@ -18892,10 +21261,28 @@ void RequestUnion::SerializeWithCachedSizes(
       21, *this->reverse_scan_, output);
   }
 
-  // optional .cockroach.roachpb.NoopRequest noop = 22;
+  // optional .cockroach.roachpb.ComputeChecksumRequest compute_checksum = 22;
+  if (has_compute_checksum()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      22, *this->compute_checksum_, output);
+  }
+
+  // optional .cockroach.roachpb.VerifyChecksumRequest verify_checksum = 23;
+  if (has_verify_checksum()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      23, *this->verify_checksum_, output);
+  }
+
+  // optional .cockroach.roachpb.CheckConsistencyRequest check_consistency = 24;
+  if (has_check_consistency()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      24, *this->check_consistency_, output);
+  }
+
+  // optional .cockroach.roachpb.NoopRequest noop = 25;
   if (has_noop()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      22, *this->noop_, output);
+      25, *this->noop_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -19055,11 +21442,32 @@ void RequestUnion::SerializeWithCachedSizes(
         21, *this->reverse_scan_, target);
   }
 
-  // optional .cockroach.roachpb.NoopRequest noop = 22;
+  // optional .cockroach.roachpb.ComputeChecksumRequest compute_checksum = 22;
+  if (has_compute_checksum()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        22, *this->compute_checksum_, target);
+  }
+
+  // optional .cockroach.roachpb.VerifyChecksumRequest verify_checksum = 23;
+  if (has_verify_checksum()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        23, *this->verify_checksum_, target);
+  }
+
+  // optional .cockroach.roachpb.CheckConsistencyRequest check_consistency = 24;
+  if (has_check_consistency()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        24, *this->check_consistency_, target);
+  }
+
+  // optional .cockroach.roachpb.NoopRequest noop = 25;
   if (has_noop()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        22, *this->noop_, target);
+        25, *this->noop_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -19189,7 +21597,7 @@ int RequestUnion::ByteSize() const {
     }
 
   }
-  if (_has_bits_[16 / 32] & 4128768u) {
+  if (_has_bits_[16 / 32] & 16711680u) {
     // optional .cockroach.roachpb.ResolveIntentRangeRequest resolve_intent_range = 17;
     if (has_resolve_intent_range()) {
       total_size += 2 +
@@ -19225,14 +21633,35 @@ int RequestUnion::ByteSize() const {
           *this->reverse_scan_);
     }
 
-    // optional .cockroach.roachpb.NoopRequest noop = 22;
-    if (has_noop()) {
+    // optional .cockroach.roachpb.ComputeChecksumRequest compute_checksum = 22;
+    if (has_compute_checksum()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->noop_);
+          *this->compute_checksum_);
+    }
+
+    // optional .cockroach.roachpb.VerifyChecksumRequest verify_checksum = 23;
+    if (has_verify_checksum()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->verify_checksum_);
+    }
+
+    // optional .cockroach.roachpb.CheckConsistencyRequest check_consistency = 24;
+    if (has_check_consistency()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->check_consistency_);
     }
 
   }
+  // optional .cockroach.roachpb.NoopRequest noop = 25;
+  if (has_noop()) {
+    total_size += 2 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->noop_);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -19326,6 +21755,17 @@ void RequestUnion::MergeFrom(const RequestUnion& from) {
     if (from.has_reverse_scan()) {
       mutable_reverse_scan()->::cockroach::roachpb::ReverseScanRequest::MergeFrom(from.reverse_scan());
     }
+    if (from.has_compute_checksum()) {
+      mutable_compute_checksum()->::cockroach::roachpb::ComputeChecksumRequest::MergeFrom(from.compute_checksum());
+    }
+    if (from.has_verify_checksum()) {
+      mutable_verify_checksum()->::cockroach::roachpb::VerifyChecksumRequest::MergeFrom(from.verify_checksum());
+    }
+    if (from.has_check_consistency()) {
+      mutable_check_consistency()->::cockroach::roachpb::CheckConsistencyRequest::MergeFrom(from.check_consistency());
+    }
+  }
+  if (from._has_bits_[24 / 32] & (0xffu << (24 % 32))) {
     if (from.has_noop()) {
       mutable_noop()->::cockroach::roachpb::NoopRequest::MergeFrom(from.noop());
     }
@@ -19378,6 +21818,9 @@ void RequestUnion::InternalSwap(RequestUnion* other) {
   std::swap(truncate_log_, other->truncate_log_);
   std::swap(leader_lease_, other->leader_lease_);
   std::swap(reverse_scan_, other->reverse_scan_);
+  std::swap(compute_checksum_, other->compute_checksum_);
+  std::swap(verify_checksum_, other->verify_checksum_);
+  std::swap(check_consistency_, other->check_consistency_);
   std::swap(noop_, other->noop_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -20298,15 +22741,144 @@ void RequestUnion::set_allocated_reverse_scan(::cockroach::roachpb::ReverseScanR
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.reverse_scan)
 }
 
-// optional .cockroach.roachpb.NoopRequest noop = 22;
-bool RequestUnion::has_noop() const {
+// optional .cockroach.roachpb.ComputeChecksumRequest compute_checksum = 22;
+bool RequestUnion::has_compute_checksum() const {
   return (_has_bits_[0] & 0x00200000u) != 0;
 }
-void RequestUnion::set_has_noop() {
+void RequestUnion::set_has_compute_checksum() {
   _has_bits_[0] |= 0x00200000u;
 }
-void RequestUnion::clear_has_noop() {
+void RequestUnion::clear_has_compute_checksum() {
   _has_bits_[0] &= ~0x00200000u;
+}
+void RequestUnion::clear_compute_checksum() {
+  if (compute_checksum_ != NULL) compute_checksum_->::cockroach::roachpb::ComputeChecksumRequest::Clear();
+  clear_has_compute_checksum();
+}
+const ::cockroach::roachpb::ComputeChecksumRequest& RequestUnion::compute_checksum() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestUnion.compute_checksum)
+  return compute_checksum_ != NULL ? *compute_checksum_ : *default_instance_->compute_checksum_;
+}
+::cockroach::roachpb::ComputeChecksumRequest* RequestUnion::mutable_compute_checksum() {
+  set_has_compute_checksum();
+  if (compute_checksum_ == NULL) {
+    compute_checksum_ = new ::cockroach::roachpb::ComputeChecksumRequest;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestUnion.compute_checksum)
+  return compute_checksum_;
+}
+::cockroach::roachpb::ComputeChecksumRequest* RequestUnion::release_compute_checksum() {
+  clear_has_compute_checksum();
+  ::cockroach::roachpb::ComputeChecksumRequest* temp = compute_checksum_;
+  compute_checksum_ = NULL;
+  return temp;
+}
+void RequestUnion::set_allocated_compute_checksum(::cockroach::roachpb::ComputeChecksumRequest* compute_checksum) {
+  delete compute_checksum_;
+  compute_checksum_ = compute_checksum;
+  if (compute_checksum) {
+    set_has_compute_checksum();
+  } else {
+    clear_has_compute_checksum();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.compute_checksum)
+}
+
+// optional .cockroach.roachpb.VerifyChecksumRequest verify_checksum = 23;
+bool RequestUnion::has_verify_checksum() const {
+  return (_has_bits_[0] & 0x00400000u) != 0;
+}
+void RequestUnion::set_has_verify_checksum() {
+  _has_bits_[0] |= 0x00400000u;
+}
+void RequestUnion::clear_has_verify_checksum() {
+  _has_bits_[0] &= ~0x00400000u;
+}
+void RequestUnion::clear_verify_checksum() {
+  if (verify_checksum_ != NULL) verify_checksum_->::cockroach::roachpb::VerifyChecksumRequest::Clear();
+  clear_has_verify_checksum();
+}
+const ::cockroach::roachpb::VerifyChecksumRequest& RequestUnion::verify_checksum() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestUnion.verify_checksum)
+  return verify_checksum_ != NULL ? *verify_checksum_ : *default_instance_->verify_checksum_;
+}
+::cockroach::roachpb::VerifyChecksumRequest* RequestUnion::mutable_verify_checksum() {
+  set_has_verify_checksum();
+  if (verify_checksum_ == NULL) {
+    verify_checksum_ = new ::cockroach::roachpb::VerifyChecksumRequest;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestUnion.verify_checksum)
+  return verify_checksum_;
+}
+::cockroach::roachpb::VerifyChecksumRequest* RequestUnion::release_verify_checksum() {
+  clear_has_verify_checksum();
+  ::cockroach::roachpb::VerifyChecksumRequest* temp = verify_checksum_;
+  verify_checksum_ = NULL;
+  return temp;
+}
+void RequestUnion::set_allocated_verify_checksum(::cockroach::roachpb::VerifyChecksumRequest* verify_checksum) {
+  delete verify_checksum_;
+  verify_checksum_ = verify_checksum;
+  if (verify_checksum) {
+    set_has_verify_checksum();
+  } else {
+    clear_has_verify_checksum();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.verify_checksum)
+}
+
+// optional .cockroach.roachpb.CheckConsistencyRequest check_consistency = 24;
+bool RequestUnion::has_check_consistency() const {
+  return (_has_bits_[0] & 0x00800000u) != 0;
+}
+void RequestUnion::set_has_check_consistency() {
+  _has_bits_[0] |= 0x00800000u;
+}
+void RequestUnion::clear_has_check_consistency() {
+  _has_bits_[0] &= ~0x00800000u;
+}
+void RequestUnion::clear_check_consistency() {
+  if (check_consistency_ != NULL) check_consistency_->::cockroach::roachpb::CheckConsistencyRequest::Clear();
+  clear_has_check_consistency();
+}
+const ::cockroach::roachpb::CheckConsistencyRequest& RequestUnion::check_consistency() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestUnion.check_consistency)
+  return check_consistency_ != NULL ? *check_consistency_ : *default_instance_->check_consistency_;
+}
+::cockroach::roachpb::CheckConsistencyRequest* RequestUnion::mutable_check_consistency() {
+  set_has_check_consistency();
+  if (check_consistency_ == NULL) {
+    check_consistency_ = new ::cockroach::roachpb::CheckConsistencyRequest;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestUnion.check_consistency)
+  return check_consistency_;
+}
+::cockroach::roachpb::CheckConsistencyRequest* RequestUnion::release_check_consistency() {
+  clear_has_check_consistency();
+  ::cockroach::roachpb::CheckConsistencyRequest* temp = check_consistency_;
+  check_consistency_ = NULL;
+  return temp;
+}
+void RequestUnion::set_allocated_check_consistency(::cockroach::roachpb::CheckConsistencyRequest* check_consistency) {
+  delete check_consistency_;
+  check_consistency_ = check_consistency;
+  if (check_consistency) {
+    set_has_check_consistency();
+  } else {
+    clear_has_check_consistency();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.check_consistency)
+}
+
+// optional .cockroach.roachpb.NoopRequest noop = 25;
+bool RequestUnion::has_noop() const {
+  return (_has_bits_[0] & 0x01000000u) != 0;
+}
+void RequestUnion::set_has_noop() {
+  _has_bits_[0] |= 0x01000000u;
+}
+void RequestUnion::clear_has_noop() {
+  _has_bits_[0] &= ~0x01000000u;
 }
 void RequestUnion::clear_noop() {
   if (noop_ != NULL) noop_->::cockroach::roachpb::NoopRequest::Clear();
@@ -20367,6 +22939,9 @@ const int ResponseUnion::kMergeFieldNumber;
 const int ResponseUnion::kTruncateLogFieldNumber;
 const int ResponseUnion::kLeaderLeaseFieldNumber;
 const int ResponseUnion::kReverseScanFieldNumber;
+const int ResponseUnion::kComputeChecksumFieldNumber;
+const int ResponseUnion::kVerifyChecksumFieldNumber;
+const int ResponseUnion::kCheckConsistencyFieldNumber;
 const int ResponseUnion::kNoopFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
@@ -20398,6 +22973,9 @@ void ResponseUnion::InitAsDefaultInstance() {
   truncate_log_ = const_cast< ::cockroach::roachpb::TruncateLogResponse*>(&::cockroach::roachpb::TruncateLogResponse::default_instance());
   leader_lease_ = const_cast< ::cockroach::roachpb::LeaderLeaseResponse*>(&::cockroach::roachpb::LeaderLeaseResponse::default_instance());
   reverse_scan_ = const_cast< ::cockroach::roachpb::ReverseScanResponse*>(&::cockroach::roachpb::ReverseScanResponse::default_instance());
+  compute_checksum_ = const_cast< ::cockroach::roachpb::ComputeChecksumResponse*>(&::cockroach::roachpb::ComputeChecksumResponse::default_instance());
+  verify_checksum_ = const_cast< ::cockroach::roachpb::VerifyChecksumResponse*>(&::cockroach::roachpb::VerifyChecksumResponse::default_instance());
+  check_consistency_ = const_cast< ::cockroach::roachpb::CheckConsistencyResponse*>(&::cockroach::roachpb::CheckConsistencyResponse::default_instance());
   noop_ = const_cast< ::cockroach::roachpb::NoopResponse*>(&::cockroach::roachpb::NoopResponse::default_instance());
 }
 
@@ -20432,6 +23010,9 @@ void ResponseUnion::SharedCtor() {
   truncate_log_ = NULL;
   leader_lease_ = NULL;
   reverse_scan_ = NULL;
+  compute_checksum_ = NULL;
+  verify_checksum_ = NULL;
+  check_consistency_ = NULL;
   noop_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -20464,6 +23045,9 @@ void ResponseUnion::SharedDtor() {
     delete truncate_log_;
     delete leader_lease_;
     delete reverse_scan_;
+    delete compute_checksum_;
+    delete verify_checksum_;
+    delete check_consistency_;
     delete noop_;
   }
 }
@@ -20546,7 +23130,7 @@ void ResponseUnion::Clear() {
       if (resolve_intent_ != NULL) resolve_intent_->::cockroach::roachpb::ResolveIntentResponse::Clear();
     }
   }
-  if (_has_bits_[16 / 32] & 4128768u) {
+  if (_has_bits_[16 / 32] & 16711680u) {
     if (has_resolve_intent_range()) {
       if (resolve_intent_range_ != NULL) resolve_intent_range_->::cockroach::roachpb::ResolveIntentRangeResponse::Clear();
     }
@@ -20562,9 +23146,18 @@ void ResponseUnion::Clear() {
     if (has_reverse_scan()) {
       if (reverse_scan_ != NULL) reverse_scan_->::cockroach::roachpb::ReverseScanResponse::Clear();
     }
-    if (has_noop()) {
-      if (noop_ != NULL) noop_->::cockroach::roachpb::NoopResponse::Clear();
+    if (has_compute_checksum()) {
+      if (compute_checksum_ != NULL) compute_checksum_->::cockroach::roachpb::ComputeChecksumResponse::Clear();
     }
+    if (has_verify_checksum()) {
+      if (verify_checksum_ != NULL) verify_checksum_->::cockroach::roachpb::VerifyChecksumResponse::Clear();
+    }
+    if (has_check_consistency()) {
+      if (check_consistency_ != NULL) check_consistency_->::cockroach::roachpb::CheckConsistencyResponse::Clear();
+    }
+  }
+  if (has_noop()) {
+    if (noop_ != NULL) noop_->::cockroach::roachpb::NoopResponse::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -20850,13 +23443,52 @@ bool ResponseUnion::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(178)) goto parse_noop;
+        if (input->ExpectTag(178)) goto parse_compute_checksum;
         break;
       }
 
-      // optional .cockroach.roachpb.NoopResponse noop = 22;
+      // optional .cockroach.roachpb.ComputeChecksumResponse compute_checksum = 22;
       case 22: {
         if (tag == 178) {
+         parse_compute_checksum:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_compute_checksum()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(186)) goto parse_verify_checksum;
+        break;
+      }
+
+      // optional .cockroach.roachpb.VerifyChecksumResponse verify_checksum = 23;
+      case 23: {
+        if (tag == 186) {
+         parse_verify_checksum:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_verify_checksum()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(194)) goto parse_check_consistency;
+        break;
+      }
+
+      // optional .cockroach.roachpb.CheckConsistencyResponse check_consistency = 24;
+      case 24: {
+        if (tag == 194) {
+         parse_check_consistency:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_check_consistency()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(202)) goto parse_noop;
+        break;
+      }
+
+      // optional .cockroach.roachpb.NoopResponse noop = 25;
+      case 25: {
+        if (tag == 202) {
          parse_noop:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_noop()));
@@ -21018,10 +23650,28 @@ void ResponseUnion::SerializeWithCachedSizes(
       21, *this->reverse_scan_, output);
   }
 
-  // optional .cockroach.roachpb.NoopResponse noop = 22;
+  // optional .cockroach.roachpb.ComputeChecksumResponse compute_checksum = 22;
+  if (has_compute_checksum()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      22, *this->compute_checksum_, output);
+  }
+
+  // optional .cockroach.roachpb.VerifyChecksumResponse verify_checksum = 23;
+  if (has_verify_checksum()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      23, *this->verify_checksum_, output);
+  }
+
+  // optional .cockroach.roachpb.CheckConsistencyResponse check_consistency = 24;
+  if (has_check_consistency()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      24, *this->check_consistency_, output);
+  }
+
+  // optional .cockroach.roachpb.NoopResponse noop = 25;
   if (has_noop()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      22, *this->noop_, output);
+      25, *this->noop_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -21181,11 +23831,32 @@ void ResponseUnion::SerializeWithCachedSizes(
         21, *this->reverse_scan_, target);
   }
 
-  // optional .cockroach.roachpb.NoopResponse noop = 22;
+  // optional .cockroach.roachpb.ComputeChecksumResponse compute_checksum = 22;
+  if (has_compute_checksum()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        22, *this->compute_checksum_, target);
+  }
+
+  // optional .cockroach.roachpb.VerifyChecksumResponse verify_checksum = 23;
+  if (has_verify_checksum()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        23, *this->verify_checksum_, target);
+  }
+
+  // optional .cockroach.roachpb.CheckConsistencyResponse check_consistency = 24;
+  if (has_check_consistency()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        24, *this->check_consistency_, target);
+  }
+
+  // optional .cockroach.roachpb.NoopResponse noop = 25;
   if (has_noop()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        22, *this->noop_, target);
+        25, *this->noop_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -21315,7 +23986,7 @@ int ResponseUnion::ByteSize() const {
     }
 
   }
-  if (_has_bits_[16 / 32] & 4128768u) {
+  if (_has_bits_[16 / 32] & 16711680u) {
     // optional .cockroach.roachpb.ResolveIntentRangeResponse resolve_intent_range = 17;
     if (has_resolve_intent_range()) {
       total_size += 2 +
@@ -21351,14 +24022,35 @@ int ResponseUnion::ByteSize() const {
           *this->reverse_scan_);
     }
 
-    // optional .cockroach.roachpb.NoopResponse noop = 22;
-    if (has_noop()) {
+    // optional .cockroach.roachpb.ComputeChecksumResponse compute_checksum = 22;
+    if (has_compute_checksum()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->noop_);
+          *this->compute_checksum_);
+    }
+
+    // optional .cockroach.roachpb.VerifyChecksumResponse verify_checksum = 23;
+    if (has_verify_checksum()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->verify_checksum_);
+    }
+
+    // optional .cockroach.roachpb.CheckConsistencyResponse check_consistency = 24;
+    if (has_check_consistency()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->check_consistency_);
     }
 
   }
+  // optional .cockroach.roachpb.NoopResponse noop = 25;
+  if (has_noop()) {
+    total_size += 2 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->noop_);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -21452,6 +24144,17 @@ void ResponseUnion::MergeFrom(const ResponseUnion& from) {
     if (from.has_reverse_scan()) {
       mutable_reverse_scan()->::cockroach::roachpb::ReverseScanResponse::MergeFrom(from.reverse_scan());
     }
+    if (from.has_compute_checksum()) {
+      mutable_compute_checksum()->::cockroach::roachpb::ComputeChecksumResponse::MergeFrom(from.compute_checksum());
+    }
+    if (from.has_verify_checksum()) {
+      mutable_verify_checksum()->::cockroach::roachpb::VerifyChecksumResponse::MergeFrom(from.verify_checksum());
+    }
+    if (from.has_check_consistency()) {
+      mutable_check_consistency()->::cockroach::roachpb::CheckConsistencyResponse::MergeFrom(from.check_consistency());
+    }
+  }
+  if (from._has_bits_[24 / 32] & (0xffu << (24 % 32))) {
     if (from.has_noop()) {
       mutable_noop()->::cockroach::roachpb::NoopResponse::MergeFrom(from.noop());
     }
@@ -21504,6 +24207,9 @@ void ResponseUnion::InternalSwap(ResponseUnion* other) {
   std::swap(truncate_log_, other->truncate_log_);
   std::swap(leader_lease_, other->leader_lease_);
   std::swap(reverse_scan_, other->reverse_scan_);
+  std::swap(compute_checksum_, other->compute_checksum_);
+  std::swap(verify_checksum_, other->verify_checksum_);
+  std::swap(check_consistency_, other->check_consistency_);
   std::swap(noop_, other->noop_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -22424,15 +25130,144 @@ void ResponseUnion::set_allocated_reverse_scan(::cockroach::roachpb::ReverseScan
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.reverse_scan)
 }
 
-// optional .cockroach.roachpb.NoopResponse noop = 22;
-bool ResponseUnion::has_noop() const {
+// optional .cockroach.roachpb.ComputeChecksumResponse compute_checksum = 22;
+bool ResponseUnion::has_compute_checksum() const {
   return (_has_bits_[0] & 0x00200000u) != 0;
 }
-void ResponseUnion::set_has_noop() {
+void ResponseUnion::set_has_compute_checksum() {
   _has_bits_[0] |= 0x00200000u;
 }
-void ResponseUnion::clear_has_noop() {
+void ResponseUnion::clear_has_compute_checksum() {
   _has_bits_[0] &= ~0x00200000u;
+}
+void ResponseUnion::clear_compute_checksum() {
+  if (compute_checksum_ != NULL) compute_checksum_->::cockroach::roachpb::ComputeChecksumResponse::Clear();
+  clear_has_compute_checksum();
+}
+const ::cockroach::roachpb::ComputeChecksumResponse& ResponseUnion::compute_checksum() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResponseUnion.compute_checksum)
+  return compute_checksum_ != NULL ? *compute_checksum_ : *default_instance_->compute_checksum_;
+}
+::cockroach::roachpb::ComputeChecksumResponse* ResponseUnion::mutable_compute_checksum() {
+  set_has_compute_checksum();
+  if (compute_checksum_ == NULL) {
+    compute_checksum_ = new ::cockroach::roachpb::ComputeChecksumResponse;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ResponseUnion.compute_checksum)
+  return compute_checksum_;
+}
+::cockroach::roachpb::ComputeChecksumResponse* ResponseUnion::release_compute_checksum() {
+  clear_has_compute_checksum();
+  ::cockroach::roachpb::ComputeChecksumResponse* temp = compute_checksum_;
+  compute_checksum_ = NULL;
+  return temp;
+}
+void ResponseUnion::set_allocated_compute_checksum(::cockroach::roachpb::ComputeChecksumResponse* compute_checksum) {
+  delete compute_checksum_;
+  compute_checksum_ = compute_checksum;
+  if (compute_checksum) {
+    set_has_compute_checksum();
+  } else {
+    clear_has_compute_checksum();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.compute_checksum)
+}
+
+// optional .cockroach.roachpb.VerifyChecksumResponse verify_checksum = 23;
+bool ResponseUnion::has_verify_checksum() const {
+  return (_has_bits_[0] & 0x00400000u) != 0;
+}
+void ResponseUnion::set_has_verify_checksum() {
+  _has_bits_[0] |= 0x00400000u;
+}
+void ResponseUnion::clear_has_verify_checksum() {
+  _has_bits_[0] &= ~0x00400000u;
+}
+void ResponseUnion::clear_verify_checksum() {
+  if (verify_checksum_ != NULL) verify_checksum_->::cockroach::roachpb::VerifyChecksumResponse::Clear();
+  clear_has_verify_checksum();
+}
+const ::cockroach::roachpb::VerifyChecksumResponse& ResponseUnion::verify_checksum() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResponseUnion.verify_checksum)
+  return verify_checksum_ != NULL ? *verify_checksum_ : *default_instance_->verify_checksum_;
+}
+::cockroach::roachpb::VerifyChecksumResponse* ResponseUnion::mutable_verify_checksum() {
+  set_has_verify_checksum();
+  if (verify_checksum_ == NULL) {
+    verify_checksum_ = new ::cockroach::roachpb::VerifyChecksumResponse;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ResponseUnion.verify_checksum)
+  return verify_checksum_;
+}
+::cockroach::roachpb::VerifyChecksumResponse* ResponseUnion::release_verify_checksum() {
+  clear_has_verify_checksum();
+  ::cockroach::roachpb::VerifyChecksumResponse* temp = verify_checksum_;
+  verify_checksum_ = NULL;
+  return temp;
+}
+void ResponseUnion::set_allocated_verify_checksum(::cockroach::roachpb::VerifyChecksumResponse* verify_checksum) {
+  delete verify_checksum_;
+  verify_checksum_ = verify_checksum;
+  if (verify_checksum) {
+    set_has_verify_checksum();
+  } else {
+    clear_has_verify_checksum();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.verify_checksum)
+}
+
+// optional .cockroach.roachpb.CheckConsistencyResponse check_consistency = 24;
+bool ResponseUnion::has_check_consistency() const {
+  return (_has_bits_[0] & 0x00800000u) != 0;
+}
+void ResponseUnion::set_has_check_consistency() {
+  _has_bits_[0] |= 0x00800000u;
+}
+void ResponseUnion::clear_has_check_consistency() {
+  _has_bits_[0] &= ~0x00800000u;
+}
+void ResponseUnion::clear_check_consistency() {
+  if (check_consistency_ != NULL) check_consistency_->::cockroach::roachpb::CheckConsistencyResponse::Clear();
+  clear_has_check_consistency();
+}
+const ::cockroach::roachpb::CheckConsistencyResponse& ResponseUnion::check_consistency() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResponseUnion.check_consistency)
+  return check_consistency_ != NULL ? *check_consistency_ : *default_instance_->check_consistency_;
+}
+::cockroach::roachpb::CheckConsistencyResponse* ResponseUnion::mutable_check_consistency() {
+  set_has_check_consistency();
+  if (check_consistency_ == NULL) {
+    check_consistency_ = new ::cockroach::roachpb::CheckConsistencyResponse;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ResponseUnion.check_consistency)
+  return check_consistency_;
+}
+::cockroach::roachpb::CheckConsistencyResponse* ResponseUnion::release_check_consistency() {
+  clear_has_check_consistency();
+  ::cockroach::roachpb::CheckConsistencyResponse* temp = check_consistency_;
+  check_consistency_ = NULL;
+  return temp;
+}
+void ResponseUnion::set_allocated_check_consistency(::cockroach::roachpb::CheckConsistencyResponse* check_consistency) {
+  delete check_consistency_;
+  check_consistency_ = check_consistency;
+  if (check_consistency) {
+    set_has_check_consistency();
+  } else {
+    clear_has_check_consistency();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.check_consistency)
+}
+
+// optional .cockroach.roachpb.NoopResponse noop = 25;
+bool ResponseUnion::has_noop() const {
+  return (_has_bits_[0] & 0x01000000u) != 0;
+}
+void ResponseUnion::set_has_noop() {
+  _has_bits_[0] |= 0x01000000u;
+}
+void ResponseUnion::clear_has_noop() {
+  _has_bits_[0] &= ~0x01000000u;
 }
 void ResponseUnion::clear_noop() {
   if (noop_ != NULL) noop_->::cockroach::roachpb::NoopResponse::Clear();

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -52,6 +52,10 @@ class BatchResponse;
 class BatchResponse_Header;
 class BeginTransactionRequest;
 class BeginTransactionResponse;
+class CheckConsistencyRequest;
+class CheckConsistencyResponse;
+class ComputeChecksumRequest;
+class ComputeChecksumResponse;
 class ConditionalPutRequest;
 class ConditionalPutResponse;
 class DeleteRangeRequest;
@@ -95,6 +99,8 @@ class ScanRequest;
 class ScanResponse;
 class TruncateLogRequest;
 class TruncateLogResponse;
+class VerifyChecksumRequest;
+class VerifyChecksumResponse;
 
 enum ReadConsistencyType {
   CONSISTENT = 0,
@@ -1845,6 +1851,188 @@ class ReverseScanResponse : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static ReverseScanResponse* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class CheckConsistencyRequest : public ::google::protobuf::Message {
+ public:
+  CheckConsistencyRequest();
+  virtual ~CheckConsistencyRequest();
+
+  CheckConsistencyRequest(const CheckConsistencyRequest& from);
+
+  inline CheckConsistencyRequest& operator=(const CheckConsistencyRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const CheckConsistencyRequest& default_instance();
+
+  void Swap(CheckConsistencyRequest* other);
+
+  // implements Message ----------------------------------------------
+
+  inline CheckConsistencyRequest* New() const { return New(NULL); }
+
+  CheckConsistencyRequest* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const CheckConsistencyRequest& from);
+  void MergeFrom(const CheckConsistencyRequest& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(CheckConsistencyRequest* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.roachpb.Span header = 1;
+  bool has_header() const;
+  void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  const ::cockroach::roachpb::Span& header() const;
+  ::cockroach::roachpb::Span* mutable_header();
+  ::cockroach::roachpb::Span* release_header();
+  void set_allocated_header(::cockroach::roachpb::Span* header);
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.CheckConsistencyRequest)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::roachpb::Span* header_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
+
+  void InitAsDefaultInstance();
+  static CheckConsistencyRequest* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class CheckConsistencyResponse : public ::google::protobuf::Message {
+ public:
+  CheckConsistencyResponse();
+  virtual ~CheckConsistencyResponse();
+
+  CheckConsistencyResponse(const CheckConsistencyResponse& from);
+
+  inline CheckConsistencyResponse& operator=(const CheckConsistencyResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const CheckConsistencyResponse& default_instance();
+
+  void Swap(CheckConsistencyResponse* other);
+
+  // implements Message ----------------------------------------------
+
+  inline CheckConsistencyResponse* New() const { return New(NULL); }
+
+  CheckConsistencyResponse* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const CheckConsistencyResponse& from);
+  void MergeFrom(const CheckConsistencyResponse& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(CheckConsistencyResponse* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  bool has_header() const;
+  void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  const ::cockroach::roachpb::ResponseHeader& header() const;
+  ::cockroach::roachpb::ResponseHeader* mutable_header();
+  ::cockroach::roachpb::ResponseHeader* release_header();
+  void set_allocated_header(::cockroach::roachpb::ResponseHeader* header);
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.CheckConsistencyResponse)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::roachpb::ResponseHeader* header_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
+
+  void InitAsDefaultInstance();
+  static CheckConsistencyResponse* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -4839,6 +5027,435 @@ class LeaderLeaseResponse : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
+class ComputeChecksumRequest : public ::google::protobuf::Message {
+ public:
+  ComputeChecksumRequest();
+  virtual ~ComputeChecksumRequest();
+
+  ComputeChecksumRequest(const ComputeChecksumRequest& from);
+
+  inline ComputeChecksumRequest& operator=(const ComputeChecksumRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ComputeChecksumRequest& default_instance();
+
+  void Swap(ComputeChecksumRequest* other);
+
+  // implements Message ----------------------------------------------
+
+  inline ComputeChecksumRequest* New() const { return New(NULL); }
+
+  ComputeChecksumRequest* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const ComputeChecksumRequest& from);
+  void MergeFrom(const ComputeChecksumRequest& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(ComputeChecksumRequest* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.roachpb.Span header = 1;
+  bool has_header() const;
+  void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  const ::cockroach::roachpb::Span& header() const;
+  ::cockroach::roachpb::Span* mutable_header();
+  ::cockroach::roachpb::Span* release_header();
+  void set_allocated_header(::cockroach::roachpb::Span* header);
+
+  // optional uint32 version = 2;
+  bool has_version() const;
+  void clear_version();
+  static const int kVersionFieldNumber = 2;
+  ::google::protobuf::uint32 version() const;
+  void set_version(::google::protobuf::uint32 value);
+
+  // optional bytes checksum_id = 3;
+  bool has_checksum_id() const;
+  void clear_checksum_id();
+  static const int kChecksumIdFieldNumber = 3;
+  const ::std::string& checksum_id() const;
+  void set_checksum_id(const ::std::string& value);
+  void set_checksum_id(const char* value);
+  void set_checksum_id(const void* value, size_t size);
+  ::std::string* mutable_checksum_id();
+  ::std::string* release_checksum_id();
+  void set_allocated_checksum_id(::std::string* checksum_id);
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.ComputeChecksumRequest)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+  inline void set_has_version();
+  inline void clear_has_version();
+  inline void set_has_checksum_id();
+  inline void clear_has_checksum_id();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::roachpb::Span* header_;
+  ::google::protobuf::internal::ArenaStringPtr checksum_id_;
+  ::google::protobuf::uint32 version_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
+
+  void InitAsDefaultInstance();
+  static ComputeChecksumRequest* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class ComputeChecksumResponse : public ::google::protobuf::Message {
+ public:
+  ComputeChecksumResponse();
+  virtual ~ComputeChecksumResponse();
+
+  ComputeChecksumResponse(const ComputeChecksumResponse& from);
+
+  inline ComputeChecksumResponse& operator=(const ComputeChecksumResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ComputeChecksumResponse& default_instance();
+
+  void Swap(ComputeChecksumResponse* other);
+
+  // implements Message ----------------------------------------------
+
+  inline ComputeChecksumResponse* New() const { return New(NULL); }
+
+  ComputeChecksumResponse* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const ComputeChecksumResponse& from);
+  void MergeFrom(const ComputeChecksumResponse& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(ComputeChecksumResponse* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  bool has_header() const;
+  void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  const ::cockroach::roachpb::ResponseHeader& header() const;
+  ::cockroach::roachpb::ResponseHeader* mutable_header();
+  ::cockroach::roachpb::ResponseHeader* release_header();
+  void set_allocated_header(::cockroach::roachpb::ResponseHeader* header);
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.ComputeChecksumResponse)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::roachpb::ResponseHeader* header_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
+
+  void InitAsDefaultInstance();
+  static ComputeChecksumResponse* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class VerifyChecksumRequest : public ::google::protobuf::Message {
+ public:
+  VerifyChecksumRequest();
+  virtual ~VerifyChecksumRequest();
+
+  VerifyChecksumRequest(const VerifyChecksumRequest& from);
+
+  inline VerifyChecksumRequest& operator=(const VerifyChecksumRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const VerifyChecksumRequest& default_instance();
+
+  void Swap(VerifyChecksumRequest* other);
+
+  // implements Message ----------------------------------------------
+
+  inline VerifyChecksumRequest* New() const { return New(NULL); }
+
+  VerifyChecksumRequest* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const VerifyChecksumRequest& from);
+  void MergeFrom(const VerifyChecksumRequest& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(VerifyChecksumRequest* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.roachpb.Span header = 1;
+  bool has_header() const;
+  void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  const ::cockroach::roachpb::Span& header() const;
+  ::cockroach::roachpb::Span* mutable_header();
+  ::cockroach::roachpb::Span* release_header();
+  void set_allocated_header(::cockroach::roachpb::Span* header);
+
+  // optional uint32 version = 2;
+  bool has_version() const;
+  void clear_version();
+  static const int kVersionFieldNumber = 2;
+  ::google::protobuf::uint32 version() const;
+  void set_version(::google::protobuf::uint32 value);
+
+  // optional bytes checksum_id = 3;
+  bool has_checksum_id() const;
+  void clear_checksum_id();
+  static const int kChecksumIdFieldNumber = 3;
+  const ::std::string& checksum_id() const;
+  void set_checksum_id(const ::std::string& value);
+  void set_checksum_id(const char* value);
+  void set_checksum_id(const void* value, size_t size);
+  ::std::string* mutable_checksum_id();
+  ::std::string* release_checksum_id();
+  void set_allocated_checksum_id(::std::string* checksum_id);
+
+  // optional bytes checksum = 4;
+  bool has_checksum() const;
+  void clear_checksum();
+  static const int kChecksumFieldNumber = 4;
+  const ::std::string& checksum() const;
+  void set_checksum(const ::std::string& value);
+  void set_checksum(const char* value);
+  void set_checksum(const void* value, size_t size);
+  ::std::string* mutable_checksum();
+  ::std::string* release_checksum();
+  void set_allocated_checksum(::std::string* checksum);
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.VerifyChecksumRequest)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+  inline void set_has_version();
+  inline void clear_has_version();
+  inline void set_has_checksum_id();
+  inline void clear_has_checksum_id();
+  inline void set_has_checksum();
+  inline void clear_has_checksum();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::roachpb::Span* header_;
+  ::google::protobuf::internal::ArenaStringPtr checksum_id_;
+  ::google::protobuf::internal::ArenaStringPtr checksum_;
+  ::google::protobuf::uint32 version_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
+
+  void InitAsDefaultInstance();
+  static VerifyChecksumRequest* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class VerifyChecksumResponse : public ::google::protobuf::Message {
+ public:
+  VerifyChecksumResponse();
+  virtual ~VerifyChecksumResponse();
+
+  VerifyChecksumResponse(const VerifyChecksumResponse& from);
+
+  inline VerifyChecksumResponse& operator=(const VerifyChecksumResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const VerifyChecksumResponse& default_instance();
+
+  void Swap(VerifyChecksumResponse* other);
+
+  // implements Message ----------------------------------------------
+
+  inline VerifyChecksumResponse* New() const { return New(NULL); }
+
+  VerifyChecksumResponse* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const VerifyChecksumResponse& from);
+  void MergeFrom(const VerifyChecksumResponse& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(VerifyChecksumResponse* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .cockroach.roachpb.ResponseHeader header = 1;
+  bool has_header() const;
+  void clear_header();
+  static const int kHeaderFieldNumber = 1;
+  const ::cockroach::roachpb::ResponseHeader& header() const;
+  ::cockroach::roachpb::ResponseHeader* mutable_header();
+  ::cockroach::roachpb::ResponseHeader* release_header();
+  void set_allocated_header(::cockroach::roachpb::ResponseHeader* header);
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.VerifyChecksumResponse)
+ private:
+  inline void set_has_header();
+  inline void clear_has_header();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  ::cockroach::roachpb::ResponseHeader* header_;
+  friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
+  friend void protobuf_ShutdownFile_cockroach_2froachpb_2fapi_2eproto();
+
+  void InitAsDefaultInstance();
+  static VerifyChecksumResponse* default_instance_;
+};
+// -------------------------------------------------------------------
+
 class RequestUnion : public ::google::protobuf::Message {
  public:
   RequestUnion();
@@ -5092,10 +5709,37 @@ class RequestUnion : public ::google::protobuf::Message {
   ::cockroach::roachpb::ReverseScanRequest* release_reverse_scan();
   void set_allocated_reverse_scan(::cockroach::roachpb::ReverseScanRequest* reverse_scan);
 
-  // optional .cockroach.roachpb.NoopRequest noop = 22;
+  // optional .cockroach.roachpb.ComputeChecksumRequest compute_checksum = 22;
+  bool has_compute_checksum() const;
+  void clear_compute_checksum();
+  static const int kComputeChecksumFieldNumber = 22;
+  const ::cockroach::roachpb::ComputeChecksumRequest& compute_checksum() const;
+  ::cockroach::roachpb::ComputeChecksumRequest* mutable_compute_checksum();
+  ::cockroach::roachpb::ComputeChecksumRequest* release_compute_checksum();
+  void set_allocated_compute_checksum(::cockroach::roachpb::ComputeChecksumRequest* compute_checksum);
+
+  // optional .cockroach.roachpb.VerifyChecksumRequest verify_checksum = 23;
+  bool has_verify_checksum() const;
+  void clear_verify_checksum();
+  static const int kVerifyChecksumFieldNumber = 23;
+  const ::cockroach::roachpb::VerifyChecksumRequest& verify_checksum() const;
+  ::cockroach::roachpb::VerifyChecksumRequest* mutable_verify_checksum();
+  ::cockroach::roachpb::VerifyChecksumRequest* release_verify_checksum();
+  void set_allocated_verify_checksum(::cockroach::roachpb::VerifyChecksumRequest* verify_checksum);
+
+  // optional .cockroach.roachpb.CheckConsistencyRequest check_consistency = 24;
+  bool has_check_consistency() const;
+  void clear_check_consistency();
+  static const int kCheckConsistencyFieldNumber = 24;
+  const ::cockroach::roachpb::CheckConsistencyRequest& check_consistency() const;
+  ::cockroach::roachpb::CheckConsistencyRequest* mutable_check_consistency();
+  ::cockroach::roachpb::CheckConsistencyRequest* release_check_consistency();
+  void set_allocated_check_consistency(::cockroach::roachpb::CheckConsistencyRequest* check_consistency);
+
+  // optional .cockroach.roachpb.NoopRequest noop = 25;
   bool has_noop() const;
   void clear_noop();
-  static const int kNoopFieldNumber = 22;
+  static const int kNoopFieldNumber = 25;
   const ::cockroach::roachpb::NoopRequest& noop() const;
   ::cockroach::roachpb::NoopRequest* mutable_noop();
   ::cockroach::roachpb::NoopRequest* release_noop();
@@ -5145,6 +5789,12 @@ class RequestUnion : public ::google::protobuf::Message {
   inline void clear_has_leader_lease();
   inline void set_has_reverse_scan();
   inline void clear_has_reverse_scan();
+  inline void set_has_compute_checksum();
+  inline void clear_has_compute_checksum();
+  inline void set_has_verify_checksum();
+  inline void clear_has_verify_checksum();
+  inline void set_has_check_consistency();
+  inline void clear_has_check_consistency();
   inline void set_has_noop();
   inline void clear_has_noop();
 
@@ -5172,6 +5822,9 @@ class RequestUnion : public ::google::protobuf::Message {
   ::cockroach::roachpb::TruncateLogRequest* truncate_log_;
   ::cockroach::roachpb::LeaderLeaseRequest* leader_lease_;
   ::cockroach::roachpb::ReverseScanRequest* reverse_scan_;
+  ::cockroach::roachpb::ComputeChecksumRequest* compute_checksum_;
+  ::cockroach::roachpb::VerifyChecksumRequest* verify_checksum_;
+  ::cockroach::roachpb::CheckConsistencyRequest* check_consistency_;
   ::cockroach::roachpb::NoopRequest* noop_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
@@ -5435,10 +6088,37 @@ class ResponseUnion : public ::google::protobuf::Message {
   ::cockroach::roachpb::ReverseScanResponse* release_reverse_scan();
   void set_allocated_reverse_scan(::cockroach::roachpb::ReverseScanResponse* reverse_scan);
 
-  // optional .cockroach.roachpb.NoopResponse noop = 22;
+  // optional .cockroach.roachpb.ComputeChecksumResponse compute_checksum = 22;
+  bool has_compute_checksum() const;
+  void clear_compute_checksum();
+  static const int kComputeChecksumFieldNumber = 22;
+  const ::cockroach::roachpb::ComputeChecksumResponse& compute_checksum() const;
+  ::cockroach::roachpb::ComputeChecksumResponse* mutable_compute_checksum();
+  ::cockroach::roachpb::ComputeChecksumResponse* release_compute_checksum();
+  void set_allocated_compute_checksum(::cockroach::roachpb::ComputeChecksumResponse* compute_checksum);
+
+  // optional .cockroach.roachpb.VerifyChecksumResponse verify_checksum = 23;
+  bool has_verify_checksum() const;
+  void clear_verify_checksum();
+  static const int kVerifyChecksumFieldNumber = 23;
+  const ::cockroach::roachpb::VerifyChecksumResponse& verify_checksum() const;
+  ::cockroach::roachpb::VerifyChecksumResponse* mutable_verify_checksum();
+  ::cockroach::roachpb::VerifyChecksumResponse* release_verify_checksum();
+  void set_allocated_verify_checksum(::cockroach::roachpb::VerifyChecksumResponse* verify_checksum);
+
+  // optional .cockroach.roachpb.CheckConsistencyResponse check_consistency = 24;
+  bool has_check_consistency() const;
+  void clear_check_consistency();
+  static const int kCheckConsistencyFieldNumber = 24;
+  const ::cockroach::roachpb::CheckConsistencyResponse& check_consistency() const;
+  ::cockroach::roachpb::CheckConsistencyResponse* mutable_check_consistency();
+  ::cockroach::roachpb::CheckConsistencyResponse* release_check_consistency();
+  void set_allocated_check_consistency(::cockroach::roachpb::CheckConsistencyResponse* check_consistency);
+
+  // optional .cockroach.roachpb.NoopResponse noop = 25;
   bool has_noop() const;
   void clear_noop();
-  static const int kNoopFieldNumber = 22;
+  static const int kNoopFieldNumber = 25;
   const ::cockroach::roachpb::NoopResponse& noop() const;
   ::cockroach::roachpb::NoopResponse* mutable_noop();
   ::cockroach::roachpb::NoopResponse* release_noop();
@@ -5488,6 +6168,12 @@ class ResponseUnion : public ::google::protobuf::Message {
   inline void clear_has_leader_lease();
   inline void set_has_reverse_scan();
   inline void clear_has_reverse_scan();
+  inline void set_has_compute_checksum();
+  inline void clear_has_compute_checksum();
+  inline void set_has_verify_checksum();
+  inline void clear_has_verify_checksum();
+  inline void set_has_check_consistency();
+  inline void clear_has_check_consistency();
   inline void set_has_noop();
   inline void clear_has_noop();
 
@@ -5515,6 +6201,9 @@ class ResponseUnion : public ::google::protobuf::Message {
   ::cockroach::roachpb::TruncateLogResponse* truncate_log_;
   ::cockroach::roachpb::LeaderLeaseResponse* leader_lease_;
   ::cockroach::roachpb::ReverseScanResponse* reverse_scan_;
+  ::cockroach::roachpb::ComputeChecksumResponse* compute_checksum_;
+  ::cockroach::roachpb::VerifyChecksumResponse* verify_checksum_;
+  ::cockroach::roachpb::CheckConsistencyResponse* check_consistency_;
   ::cockroach::roachpb::NoopResponse* noop_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
@@ -7284,6 +7973,100 @@ inline const ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::KeyValu
 ReverseScanResponse::rows() const {
   // @@protoc_insertion_point(field_list:cockroach.roachpb.ReverseScanResponse.rows)
   return rows_;
+}
+
+// -------------------------------------------------------------------
+
+// CheckConsistencyRequest
+
+// optional .cockroach.roachpb.Span header = 1;
+inline bool CheckConsistencyRequest::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void CheckConsistencyRequest::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void CheckConsistencyRequest::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void CheckConsistencyRequest::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+  clear_has_header();
+}
+inline const ::cockroach::roachpb::Span& CheckConsistencyRequest::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.CheckConsistencyRequest.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+inline ::cockroach::roachpb::Span* CheckConsistencyRequest::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::Span;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.CheckConsistencyRequest.header)
+  return header_;
+}
+inline ::cockroach::roachpb::Span* CheckConsistencyRequest::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::Span* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+inline void CheckConsistencyRequest::set_allocated_header(::cockroach::roachpb::Span* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.CheckConsistencyRequest.header)
+}
+
+// -------------------------------------------------------------------
+
+// CheckConsistencyResponse
+
+// optional .cockroach.roachpb.ResponseHeader header = 1;
+inline bool CheckConsistencyResponse::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void CheckConsistencyResponse::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void CheckConsistencyResponse::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void CheckConsistencyResponse::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  clear_has_header();
+}
+inline const ::cockroach::roachpb::ResponseHeader& CheckConsistencyResponse::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.CheckConsistencyResponse.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+inline ::cockroach::roachpb::ResponseHeader* CheckConsistencyResponse::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::ResponseHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.CheckConsistencyResponse.header)
+  return header_;
+}
+inline ::cockroach::roachpb::ResponseHeader* CheckConsistencyResponse::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::ResponseHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+inline void CheckConsistencyResponse::set_allocated_header(::cockroach::roachpb::ResponseHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.CheckConsistencyResponse.header)
 }
 
 // -------------------------------------------------------------------
@@ -9708,6 +10491,401 @@ inline void LeaderLeaseResponse::set_allocated_header(::cockroach::roachpb::Resp
 
 // -------------------------------------------------------------------
 
+// ComputeChecksumRequest
+
+// optional .cockroach.roachpb.Span header = 1;
+inline bool ComputeChecksumRequest::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void ComputeChecksumRequest::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void ComputeChecksumRequest::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void ComputeChecksumRequest::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+  clear_has_header();
+}
+inline const ::cockroach::roachpb::Span& ComputeChecksumRequest::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ComputeChecksumRequest.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+inline ::cockroach::roachpb::Span* ComputeChecksumRequest::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::Span;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ComputeChecksumRequest.header)
+  return header_;
+}
+inline ::cockroach::roachpb::Span* ComputeChecksumRequest::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::Span* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+inline void ComputeChecksumRequest::set_allocated_header(::cockroach::roachpb::Span* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ComputeChecksumRequest.header)
+}
+
+// optional uint32 version = 2;
+inline bool ComputeChecksumRequest::has_version() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void ComputeChecksumRequest::set_has_version() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void ComputeChecksumRequest::clear_has_version() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void ComputeChecksumRequest::clear_version() {
+  version_ = 0u;
+  clear_has_version();
+}
+inline ::google::protobuf::uint32 ComputeChecksumRequest::version() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ComputeChecksumRequest.version)
+  return version_;
+}
+inline void ComputeChecksumRequest::set_version(::google::protobuf::uint32 value) {
+  set_has_version();
+  version_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ComputeChecksumRequest.version)
+}
+
+// optional bytes checksum_id = 3;
+inline bool ComputeChecksumRequest::has_checksum_id() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void ComputeChecksumRequest::set_has_checksum_id() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void ComputeChecksumRequest::clear_has_checksum_id() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void ComputeChecksumRequest::clear_checksum_id() {
+  checksum_id_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_checksum_id();
+}
+inline const ::std::string& ComputeChecksumRequest::checksum_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+  return checksum_id_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ComputeChecksumRequest::set_checksum_id(const ::std::string& value) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+}
+inline void ComputeChecksumRequest::set_checksum_id(const char* value) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+}
+inline void ComputeChecksumRequest::set_checksum_id(const void* value, size_t size) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+}
+inline ::std::string* ComputeChecksumRequest::mutable_checksum_id() {
+  set_has_checksum_id();
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+  return checksum_id_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ComputeChecksumRequest::release_checksum_id() {
+  clear_has_checksum_id();
+  return checksum_id_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ComputeChecksumRequest::set_allocated_checksum_id(::std::string* checksum_id) {
+  if (checksum_id != NULL) {
+    set_has_checksum_id();
+  } else {
+    clear_has_checksum_id();
+  }
+  checksum_id_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), checksum_id);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ComputeChecksumRequest.checksum_id)
+}
+
+// -------------------------------------------------------------------
+
+// ComputeChecksumResponse
+
+// optional .cockroach.roachpb.ResponseHeader header = 1;
+inline bool ComputeChecksumResponse::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void ComputeChecksumResponse::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void ComputeChecksumResponse::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void ComputeChecksumResponse::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  clear_has_header();
+}
+inline const ::cockroach::roachpb::ResponseHeader& ComputeChecksumResponse::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ComputeChecksumResponse.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+inline ::cockroach::roachpb::ResponseHeader* ComputeChecksumResponse::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::ResponseHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ComputeChecksumResponse.header)
+  return header_;
+}
+inline ::cockroach::roachpb::ResponseHeader* ComputeChecksumResponse::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::ResponseHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+inline void ComputeChecksumResponse::set_allocated_header(::cockroach::roachpb::ResponseHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ComputeChecksumResponse.header)
+}
+
+// -------------------------------------------------------------------
+
+// VerifyChecksumRequest
+
+// optional .cockroach.roachpb.Span header = 1;
+inline bool VerifyChecksumRequest::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void VerifyChecksumRequest::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void VerifyChecksumRequest::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void VerifyChecksumRequest::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::Span::Clear();
+  clear_has_header();
+}
+inline const ::cockroach::roachpb::Span& VerifyChecksumRequest::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.VerifyChecksumRequest.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+inline ::cockroach::roachpb::Span* VerifyChecksumRequest::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::Span;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.VerifyChecksumRequest.header)
+  return header_;
+}
+inline ::cockroach::roachpb::Span* VerifyChecksumRequest::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::Span* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+inline void VerifyChecksumRequest::set_allocated_header(::cockroach::roachpb::Span* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.VerifyChecksumRequest.header)
+}
+
+// optional uint32 version = 2;
+inline bool VerifyChecksumRequest::has_version() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void VerifyChecksumRequest::set_has_version() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void VerifyChecksumRequest::clear_has_version() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void VerifyChecksumRequest::clear_version() {
+  version_ = 0u;
+  clear_has_version();
+}
+inline ::google::protobuf::uint32 VerifyChecksumRequest::version() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.VerifyChecksumRequest.version)
+  return version_;
+}
+inline void VerifyChecksumRequest::set_version(::google::protobuf::uint32 value) {
+  set_has_version();
+  version_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.VerifyChecksumRequest.version)
+}
+
+// optional bytes checksum_id = 3;
+inline bool VerifyChecksumRequest::has_checksum_id() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void VerifyChecksumRequest::set_has_checksum_id() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void VerifyChecksumRequest::clear_has_checksum_id() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void VerifyChecksumRequest::clear_checksum_id() {
+  checksum_id_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_checksum_id();
+}
+inline const ::std::string& VerifyChecksumRequest::checksum_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+  return checksum_id_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void VerifyChecksumRequest::set_checksum_id(const ::std::string& value) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+}
+inline void VerifyChecksumRequest::set_checksum_id(const char* value) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+}
+inline void VerifyChecksumRequest::set_checksum_id(const void* value, size_t size) {
+  set_has_checksum_id();
+  checksum_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+}
+inline ::std::string* VerifyChecksumRequest::mutable_checksum_id() {
+  set_has_checksum_id();
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+  return checksum_id_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* VerifyChecksumRequest::release_checksum_id() {
+  clear_has_checksum_id();
+  return checksum_id_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void VerifyChecksumRequest::set_allocated_checksum_id(::std::string* checksum_id) {
+  if (checksum_id != NULL) {
+    set_has_checksum_id();
+  } else {
+    clear_has_checksum_id();
+  }
+  checksum_id_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), checksum_id);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.VerifyChecksumRequest.checksum_id)
+}
+
+// optional bytes checksum = 4;
+inline bool VerifyChecksumRequest::has_checksum() const {
+  return (_has_bits_[0] & 0x00000008u) != 0;
+}
+inline void VerifyChecksumRequest::set_has_checksum() {
+  _has_bits_[0] |= 0x00000008u;
+}
+inline void VerifyChecksumRequest::clear_has_checksum() {
+  _has_bits_[0] &= ~0x00000008u;
+}
+inline void VerifyChecksumRequest::clear_checksum() {
+  checksum_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  clear_has_checksum();
+}
+inline const ::std::string& VerifyChecksumRequest::checksum() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.VerifyChecksumRequest.checksum)
+  return checksum_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void VerifyChecksumRequest::set_checksum(const ::std::string& value) {
+  set_has_checksum();
+  checksum_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.VerifyChecksumRequest.checksum)
+}
+inline void VerifyChecksumRequest::set_checksum(const char* value) {
+  set_has_checksum();
+  checksum_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:cockroach.roachpb.VerifyChecksumRequest.checksum)
+}
+inline void VerifyChecksumRequest::set_checksum(const void* value, size_t size) {
+  set_has_checksum();
+  checksum_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:cockroach.roachpb.VerifyChecksumRequest.checksum)
+}
+inline ::std::string* VerifyChecksumRequest::mutable_checksum() {
+  set_has_checksum();
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.VerifyChecksumRequest.checksum)
+  return checksum_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* VerifyChecksumRequest::release_checksum() {
+  clear_has_checksum();
+  return checksum_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void VerifyChecksumRequest::set_allocated_checksum(::std::string* checksum) {
+  if (checksum != NULL) {
+    set_has_checksum();
+  } else {
+    clear_has_checksum();
+  }
+  checksum_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), checksum);
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.VerifyChecksumRequest.checksum)
+}
+
+// -------------------------------------------------------------------
+
+// VerifyChecksumResponse
+
+// optional .cockroach.roachpb.ResponseHeader header = 1;
+inline bool VerifyChecksumResponse::has_header() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void VerifyChecksumResponse::set_has_header() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void VerifyChecksumResponse::clear_has_header() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void VerifyChecksumResponse::clear_header() {
+  if (header_ != NULL) header_->::cockroach::roachpb::ResponseHeader::Clear();
+  clear_has_header();
+}
+inline const ::cockroach::roachpb::ResponseHeader& VerifyChecksumResponse::header() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.VerifyChecksumResponse.header)
+  return header_ != NULL ? *header_ : *default_instance_->header_;
+}
+inline ::cockroach::roachpb::ResponseHeader* VerifyChecksumResponse::mutable_header() {
+  set_has_header();
+  if (header_ == NULL) {
+    header_ = new ::cockroach::roachpb::ResponseHeader;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.VerifyChecksumResponse.header)
+  return header_;
+}
+inline ::cockroach::roachpb::ResponseHeader* VerifyChecksumResponse::release_header() {
+  clear_has_header();
+  ::cockroach::roachpb::ResponseHeader* temp = header_;
+  header_ = NULL;
+  return temp;
+}
+inline void VerifyChecksumResponse::set_allocated_header(::cockroach::roachpb::ResponseHeader* header) {
+  delete header_;
+  header_ = header;
+  if (header) {
+    set_has_header();
+  } else {
+    clear_has_header();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.VerifyChecksumResponse.header)
+}
+
+// -------------------------------------------------------------------
+
 // RequestUnion
 
 // optional .cockroach.roachpb.GetRequest get = 1;
@@ -10613,15 +11791,144 @@ inline void RequestUnion::set_allocated_reverse_scan(::cockroach::roachpb::Rever
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.reverse_scan)
 }
 
-// optional .cockroach.roachpb.NoopRequest noop = 22;
-inline bool RequestUnion::has_noop() const {
+// optional .cockroach.roachpb.ComputeChecksumRequest compute_checksum = 22;
+inline bool RequestUnion::has_compute_checksum() const {
   return (_has_bits_[0] & 0x00200000u) != 0;
 }
-inline void RequestUnion::set_has_noop() {
+inline void RequestUnion::set_has_compute_checksum() {
   _has_bits_[0] |= 0x00200000u;
 }
-inline void RequestUnion::clear_has_noop() {
+inline void RequestUnion::clear_has_compute_checksum() {
   _has_bits_[0] &= ~0x00200000u;
+}
+inline void RequestUnion::clear_compute_checksum() {
+  if (compute_checksum_ != NULL) compute_checksum_->::cockroach::roachpb::ComputeChecksumRequest::Clear();
+  clear_has_compute_checksum();
+}
+inline const ::cockroach::roachpb::ComputeChecksumRequest& RequestUnion::compute_checksum() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestUnion.compute_checksum)
+  return compute_checksum_ != NULL ? *compute_checksum_ : *default_instance_->compute_checksum_;
+}
+inline ::cockroach::roachpb::ComputeChecksumRequest* RequestUnion::mutable_compute_checksum() {
+  set_has_compute_checksum();
+  if (compute_checksum_ == NULL) {
+    compute_checksum_ = new ::cockroach::roachpb::ComputeChecksumRequest;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestUnion.compute_checksum)
+  return compute_checksum_;
+}
+inline ::cockroach::roachpb::ComputeChecksumRequest* RequestUnion::release_compute_checksum() {
+  clear_has_compute_checksum();
+  ::cockroach::roachpb::ComputeChecksumRequest* temp = compute_checksum_;
+  compute_checksum_ = NULL;
+  return temp;
+}
+inline void RequestUnion::set_allocated_compute_checksum(::cockroach::roachpb::ComputeChecksumRequest* compute_checksum) {
+  delete compute_checksum_;
+  compute_checksum_ = compute_checksum;
+  if (compute_checksum) {
+    set_has_compute_checksum();
+  } else {
+    clear_has_compute_checksum();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.compute_checksum)
+}
+
+// optional .cockroach.roachpb.VerifyChecksumRequest verify_checksum = 23;
+inline bool RequestUnion::has_verify_checksum() const {
+  return (_has_bits_[0] & 0x00400000u) != 0;
+}
+inline void RequestUnion::set_has_verify_checksum() {
+  _has_bits_[0] |= 0x00400000u;
+}
+inline void RequestUnion::clear_has_verify_checksum() {
+  _has_bits_[0] &= ~0x00400000u;
+}
+inline void RequestUnion::clear_verify_checksum() {
+  if (verify_checksum_ != NULL) verify_checksum_->::cockroach::roachpb::VerifyChecksumRequest::Clear();
+  clear_has_verify_checksum();
+}
+inline const ::cockroach::roachpb::VerifyChecksumRequest& RequestUnion::verify_checksum() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestUnion.verify_checksum)
+  return verify_checksum_ != NULL ? *verify_checksum_ : *default_instance_->verify_checksum_;
+}
+inline ::cockroach::roachpb::VerifyChecksumRequest* RequestUnion::mutable_verify_checksum() {
+  set_has_verify_checksum();
+  if (verify_checksum_ == NULL) {
+    verify_checksum_ = new ::cockroach::roachpb::VerifyChecksumRequest;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestUnion.verify_checksum)
+  return verify_checksum_;
+}
+inline ::cockroach::roachpb::VerifyChecksumRequest* RequestUnion::release_verify_checksum() {
+  clear_has_verify_checksum();
+  ::cockroach::roachpb::VerifyChecksumRequest* temp = verify_checksum_;
+  verify_checksum_ = NULL;
+  return temp;
+}
+inline void RequestUnion::set_allocated_verify_checksum(::cockroach::roachpb::VerifyChecksumRequest* verify_checksum) {
+  delete verify_checksum_;
+  verify_checksum_ = verify_checksum;
+  if (verify_checksum) {
+    set_has_verify_checksum();
+  } else {
+    clear_has_verify_checksum();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.verify_checksum)
+}
+
+// optional .cockroach.roachpb.CheckConsistencyRequest check_consistency = 24;
+inline bool RequestUnion::has_check_consistency() const {
+  return (_has_bits_[0] & 0x00800000u) != 0;
+}
+inline void RequestUnion::set_has_check_consistency() {
+  _has_bits_[0] |= 0x00800000u;
+}
+inline void RequestUnion::clear_has_check_consistency() {
+  _has_bits_[0] &= ~0x00800000u;
+}
+inline void RequestUnion::clear_check_consistency() {
+  if (check_consistency_ != NULL) check_consistency_->::cockroach::roachpb::CheckConsistencyRequest::Clear();
+  clear_has_check_consistency();
+}
+inline const ::cockroach::roachpb::CheckConsistencyRequest& RequestUnion::check_consistency() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.RequestUnion.check_consistency)
+  return check_consistency_ != NULL ? *check_consistency_ : *default_instance_->check_consistency_;
+}
+inline ::cockroach::roachpb::CheckConsistencyRequest* RequestUnion::mutable_check_consistency() {
+  set_has_check_consistency();
+  if (check_consistency_ == NULL) {
+    check_consistency_ = new ::cockroach::roachpb::CheckConsistencyRequest;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.RequestUnion.check_consistency)
+  return check_consistency_;
+}
+inline ::cockroach::roachpb::CheckConsistencyRequest* RequestUnion::release_check_consistency() {
+  clear_has_check_consistency();
+  ::cockroach::roachpb::CheckConsistencyRequest* temp = check_consistency_;
+  check_consistency_ = NULL;
+  return temp;
+}
+inline void RequestUnion::set_allocated_check_consistency(::cockroach::roachpb::CheckConsistencyRequest* check_consistency) {
+  delete check_consistency_;
+  check_consistency_ = check_consistency;
+  if (check_consistency) {
+    set_has_check_consistency();
+  } else {
+    clear_has_check_consistency();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.RequestUnion.check_consistency)
+}
+
+// optional .cockroach.roachpb.NoopRequest noop = 25;
+inline bool RequestUnion::has_noop() const {
+  return (_has_bits_[0] & 0x01000000u) != 0;
+}
+inline void RequestUnion::set_has_noop() {
+  _has_bits_[0] |= 0x01000000u;
+}
+inline void RequestUnion::clear_has_noop() {
+  _has_bits_[0] &= ~0x01000000u;
 }
 inline void RequestUnion::clear_noop() {
   if (noop_ != NULL) noop_->::cockroach::roachpb::NoopRequest::Clear();
@@ -11563,15 +12870,144 @@ inline void ResponseUnion::set_allocated_reverse_scan(::cockroach::roachpb::Reve
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.reverse_scan)
 }
 
-// optional .cockroach.roachpb.NoopResponse noop = 22;
-inline bool ResponseUnion::has_noop() const {
+// optional .cockroach.roachpb.ComputeChecksumResponse compute_checksum = 22;
+inline bool ResponseUnion::has_compute_checksum() const {
   return (_has_bits_[0] & 0x00200000u) != 0;
 }
-inline void ResponseUnion::set_has_noop() {
+inline void ResponseUnion::set_has_compute_checksum() {
   _has_bits_[0] |= 0x00200000u;
 }
-inline void ResponseUnion::clear_has_noop() {
+inline void ResponseUnion::clear_has_compute_checksum() {
   _has_bits_[0] &= ~0x00200000u;
+}
+inline void ResponseUnion::clear_compute_checksum() {
+  if (compute_checksum_ != NULL) compute_checksum_->::cockroach::roachpb::ComputeChecksumResponse::Clear();
+  clear_has_compute_checksum();
+}
+inline const ::cockroach::roachpb::ComputeChecksumResponse& ResponseUnion::compute_checksum() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResponseUnion.compute_checksum)
+  return compute_checksum_ != NULL ? *compute_checksum_ : *default_instance_->compute_checksum_;
+}
+inline ::cockroach::roachpb::ComputeChecksumResponse* ResponseUnion::mutable_compute_checksum() {
+  set_has_compute_checksum();
+  if (compute_checksum_ == NULL) {
+    compute_checksum_ = new ::cockroach::roachpb::ComputeChecksumResponse;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ResponseUnion.compute_checksum)
+  return compute_checksum_;
+}
+inline ::cockroach::roachpb::ComputeChecksumResponse* ResponseUnion::release_compute_checksum() {
+  clear_has_compute_checksum();
+  ::cockroach::roachpb::ComputeChecksumResponse* temp = compute_checksum_;
+  compute_checksum_ = NULL;
+  return temp;
+}
+inline void ResponseUnion::set_allocated_compute_checksum(::cockroach::roachpb::ComputeChecksumResponse* compute_checksum) {
+  delete compute_checksum_;
+  compute_checksum_ = compute_checksum;
+  if (compute_checksum) {
+    set_has_compute_checksum();
+  } else {
+    clear_has_compute_checksum();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.compute_checksum)
+}
+
+// optional .cockroach.roachpb.VerifyChecksumResponse verify_checksum = 23;
+inline bool ResponseUnion::has_verify_checksum() const {
+  return (_has_bits_[0] & 0x00400000u) != 0;
+}
+inline void ResponseUnion::set_has_verify_checksum() {
+  _has_bits_[0] |= 0x00400000u;
+}
+inline void ResponseUnion::clear_has_verify_checksum() {
+  _has_bits_[0] &= ~0x00400000u;
+}
+inline void ResponseUnion::clear_verify_checksum() {
+  if (verify_checksum_ != NULL) verify_checksum_->::cockroach::roachpb::VerifyChecksumResponse::Clear();
+  clear_has_verify_checksum();
+}
+inline const ::cockroach::roachpb::VerifyChecksumResponse& ResponseUnion::verify_checksum() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResponseUnion.verify_checksum)
+  return verify_checksum_ != NULL ? *verify_checksum_ : *default_instance_->verify_checksum_;
+}
+inline ::cockroach::roachpb::VerifyChecksumResponse* ResponseUnion::mutable_verify_checksum() {
+  set_has_verify_checksum();
+  if (verify_checksum_ == NULL) {
+    verify_checksum_ = new ::cockroach::roachpb::VerifyChecksumResponse;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ResponseUnion.verify_checksum)
+  return verify_checksum_;
+}
+inline ::cockroach::roachpb::VerifyChecksumResponse* ResponseUnion::release_verify_checksum() {
+  clear_has_verify_checksum();
+  ::cockroach::roachpb::VerifyChecksumResponse* temp = verify_checksum_;
+  verify_checksum_ = NULL;
+  return temp;
+}
+inline void ResponseUnion::set_allocated_verify_checksum(::cockroach::roachpb::VerifyChecksumResponse* verify_checksum) {
+  delete verify_checksum_;
+  verify_checksum_ = verify_checksum;
+  if (verify_checksum) {
+    set_has_verify_checksum();
+  } else {
+    clear_has_verify_checksum();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.verify_checksum)
+}
+
+// optional .cockroach.roachpb.CheckConsistencyResponse check_consistency = 24;
+inline bool ResponseUnion::has_check_consistency() const {
+  return (_has_bits_[0] & 0x00800000u) != 0;
+}
+inline void ResponseUnion::set_has_check_consistency() {
+  _has_bits_[0] |= 0x00800000u;
+}
+inline void ResponseUnion::clear_has_check_consistency() {
+  _has_bits_[0] &= ~0x00800000u;
+}
+inline void ResponseUnion::clear_check_consistency() {
+  if (check_consistency_ != NULL) check_consistency_->::cockroach::roachpb::CheckConsistencyResponse::Clear();
+  clear_has_check_consistency();
+}
+inline const ::cockroach::roachpb::CheckConsistencyResponse& ResponseUnion::check_consistency() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResponseUnion.check_consistency)
+  return check_consistency_ != NULL ? *check_consistency_ : *default_instance_->check_consistency_;
+}
+inline ::cockroach::roachpb::CheckConsistencyResponse* ResponseUnion::mutable_check_consistency() {
+  set_has_check_consistency();
+  if (check_consistency_ == NULL) {
+    check_consistency_ = new ::cockroach::roachpb::CheckConsistencyResponse;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ResponseUnion.check_consistency)
+  return check_consistency_;
+}
+inline ::cockroach::roachpb::CheckConsistencyResponse* ResponseUnion::release_check_consistency() {
+  clear_has_check_consistency();
+  ::cockroach::roachpb::CheckConsistencyResponse* temp = check_consistency_;
+  check_consistency_ = NULL;
+  return temp;
+}
+inline void ResponseUnion::set_allocated_check_consistency(::cockroach::roachpb::CheckConsistencyResponse* check_consistency) {
+  delete check_consistency_;
+  check_consistency_ = check_consistency;
+  if (check_consistency) {
+    set_has_check_consistency();
+  } else {
+    clear_has_check_consistency();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseUnion.check_consistency)
+}
+
+// optional .cockroach.roachpb.NoopResponse noop = 25;
+inline bool ResponseUnion::has_noop() const {
+  return (_has_bits_[0] & 0x01000000u) != 0;
+}
+inline void ResponseUnion::set_has_noop() {
+  _has_bits_[0] |= 0x01000000u;
+}
+inline void ResponseUnion::clear_has_noop() {
+  _has_bits_[0] &= ~0x01000000u;
 }
 inline void ResponseUnion::clear_noop() {
   if (noop_ != NULL) noop_->::cockroach::roachpb::NoopResponse::Clear();
@@ -12154,6 +13590,18 @@ BatchResponse::responses() const {
 }
 
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -350,6 +350,10 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 
 		for {
 			select {
+			// Exit on stopper.
+			case <-stopper.ShouldStop():
+				return
+
 			// Incoming signal sets the next time to process if there were previously
 			// no replicas in the queue.
 			case <-bq.incoming:
@@ -379,10 +383,6 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 				} else {
 					nextTime = time.After(bq.impl.timer())
 				}
-
-			// Exit on stopper.
-			case <-stopper.ShouldStop():
-				return
 			}
 		}
 	})

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -141,6 +141,17 @@ type pendingCmd struct {
 
 type cmdIDKey string
 
+type replicaChecksum struct {
+	// Set to true when the checksum computation is ready. The checksum
+	// can be nil indicating an error.
+	ok bool
+	// Computed checksum. This is set to nil on error.
+	checksum []byte
+	// GC this checksum after this timestamp. The timestamp is set when
+	// ok is set to true.
+	gcTimestamp time.Time
+}
+
 // A Replica is a contiguous keyspace with writes managed via an
 // instance of the Raft consensus algorithm. Many ranges may exist
 // in a store and they are unlikely to be contiguous. Ranges are
@@ -163,19 +174,21 @@ type Replica struct {
 	mu struct {
 		sync.Mutex                   // Protects all fields in the mu struct.
 		appliedIndex   uint64        // Last index applied to the state machine.
-		cmdQ           *CommandQueue // Enforce at most one command is running per key(s)
+		cmdQ           *CommandQueue // Enforce at most one command is running per key(s).
 		desc           *roachpb.RangeDescriptor
 		lastIndex      uint64 // Last index persisted to the raft log (not necessarily committed).
 		leaderLease    *roachpb.Lease
 		maxBytes       int64 // Max bytes before split.
 		pendingCmds    map[cmdIDKey]*pendingCmd
-		pendingSeq     uint64 // atomic sequence counter for cmdIDKey generation
+		pendingSeq     uint64 // atomic sequence counter for cmdIDKey generation.
 		raftGroup      *raft.RawNode
 		replicaID      roachpb.ReplicaID
 		truncatedState *roachpb.RaftTruncatedState
 		tsCache        *TimestampCache // Most recent timestamps for keys / key ranges
 		// proposeRaftCommandFn can be set to mock out the propose operation.
 		proposeRaftCommandFn func(cmdIDKey, roachpb.RaftCommand) error
+		checksums            map[uuid.UUID]replicaChecksum // computed checksum at a snapshot UUID.
+		checksumNotify       map[uuid.UUID]chan []byte     // notify of computed checksum.
 	}
 }
 
@@ -213,7 +226,8 @@ func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor, clock *hlc.Cloc
 	r.mu.cmdQ = NewCommandQueue()
 	r.mu.tsCache = NewTimestampCache(clock)
 	r.mu.pendingCmds = map[cmdIDKey]*pendingCmd{}
-
+	r.mu.checksums = map[uuid.UUID]replicaChecksum{}
+	r.mu.checksumNotify = map[uuid.UUID]chan []byte{}
 	r.setDescWithoutProcessUpdateLocked(desc)
 
 	var err error
@@ -246,7 +260,7 @@ func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor, clock *hlc.Cloc
 	return r.setReplicaIDLocked(replicaID)
 }
 
-// String returns a string representation of the range.
+// String returns a string representation of the range. It acquires mu.Lock in the call to Desc().
 func (r *Replica) String() string {
 	desc := r.Desc()
 	return fmt.Sprintf("range=%d [%s-%s)", desc.RangeID, desc.StartKey, desc.EndKey)
@@ -731,7 +745,6 @@ func (r *Replica) beginCmds(ba *roachpb.BatchRequest) func(*roachpb.Error) {
 	var cmdKeys []interface{}
 	// Don't use the command queue for inconsistent reads.
 	if ba.ReadConsistency != roachpb.INCONSISTENT {
-		r.mu.Lock()
 		var spans []roachpb.Span
 		readOnly := ba.IsReadOnly()
 		for _, union := range ba.Requests {
@@ -739,6 +752,7 @@ func (r *Replica) beginCmds(ba *roachpb.BatchRequest) func(*roachpb.Error) {
 			spans = append(spans, roachpb.Span{Key: h.Key, EndKey: h.EndKey})
 		}
 		var wg sync.WaitGroup
+		r.mu.Lock()
 		r.mu.cmdQ.GetWait(readOnly, &wg, spans...)
 		cmdKeys = append(cmdKeys, r.mu.cmdQ.Add(readOnly, spans...)...)
 		r.mu.Unlock()
@@ -821,6 +835,10 @@ func (r *Replica) addAdminCmd(ctx context.Context, ba roachpb.BatchRequest) (*ro
 	case *roachpb.AdminMergeRequest:
 		var reply roachpb.AdminMergeResponse
 		reply, pErr = r.AdminMerge(ctx, *tArgs, r.Desc())
+		resp = &reply
+	case *roachpb.CheckConsistencyRequest:
+		var reply roachpb.CheckConsistencyResponse
+		reply, pErr = r.CheckConsistency(*tArgs, r.Desc())
 		resp = &reply
 	default:
 		return nil, roachpb.NewErrorf("unrecognized admin command: %T", args)
@@ -1222,12 +1240,12 @@ func (r *Replica) handleRaftReady() error {
 
 func (r *Replica) tick() error {
 	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.mu.raftGroup.Tick()
 	// TODO(tamird/bdarnell): Reproposals should occur less frequently than
 	// ticks, but this is acceptable for now.
 	// TODO(tamird/bdarnell): Add unit tests.
 	err := r.reproposePendingCmdsLocked()
-	r.mu.Unlock()
 	return err
 }
 

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -21,6 +21,8 @@ package storage
 
 import (
 	"bytes"
+	"crypto/sha512"
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"time"
@@ -34,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/tracing"
+	"github.com/cockroachdb/cockroach/util/uuid"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -147,6 +150,14 @@ func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, h roachp
 	case *roachpb.LeaderLeaseRequest:
 		var resp roachpb.LeaderLeaseResponse
 		resp, err = r.LeaderLease(batch, ms, h, *tArgs)
+		reply = &resp
+	case *roachpb.ComputeChecksumRequest:
+		var resp roachpb.ComputeChecksumResponse
+		resp, err = r.ComputeChecksum(batch, ms, h, *tArgs)
+		reply = &resp
+	case *roachpb.VerifyChecksumRequest:
+		var resp roachpb.VerifyChecksumResponse
+		resp, err = r.VerifyChecksum(batch, ms, h, *tArgs)
 		reply = &resp
 	default:
 		err = util.Errorf("unrecognized command %s", args.Method())
@@ -1250,6 +1261,246 @@ func (r *Replica) LeaderLease(batch engine.Engine, ms *engine.MVCCStats, h roach
 	}
 
 	return reply, nil
+}
+
+// CheckConsistency runs a consistency check on the range. It first applies
+// a ComputeChecksum command on the range. It then applies a VerifyChecksum
+// command passing along a locally computed checksum for the range.
+func (r *Replica) CheckConsistency(args roachpb.CheckConsistencyRequest, desc *roachpb.RangeDescriptor) (roachpb.CheckConsistencyResponse, *roachpb.Error) {
+	key := desc.StartKey.AsRawKey()
+	endKey := desc.EndKey.AsRawKey()
+	notifyChan := make(chan []byte, 1)
+	id := uuid.MakeV4()
+	r.setChecksumNotify(id, notifyChan)
+	// Send a ComputeChecksum to all the replicas of the range.
+	start := time.Now()
+	{
+		var ba roachpb.BatchRequest
+		ba.RangeID = r.Desc().RangeID
+		checkArgs := &roachpb.ComputeChecksumRequest{
+			Span: roachpb.Span{
+				Key:    key,
+				EndKey: endKey,
+			},
+			Version:    replicaChecksumVersion,
+			ChecksumID: id,
+		}
+		ba.Add(checkArgs)
+		_, pErr := r.Send(r.context(), ba)
+		if pErr != nil {
+			return roachpb.CheckConsistencyResponse{}, pErr
+		}
+	}
+	// wait for local checksum and collect it.
+	checksum := <-notifyChan
+
+	if checksum == nil {
+		// Don't bother verifying the checksum.
+		return roachpb.CheckConsistencyResponse{}, roachpb.NewErrorf("unable to compute checksum for range [%v, %v]", key, endKey)
+	}
+
+	// Wait for a bit to improve the probability that all
+	// the replicas have computed their checksum. We do this
+	// because VerifyChecksum blocks on every replica until the
+	// computed checksum is available.
+	computeChecksumDuration := time.Since(start)
+	time.Sleep(computeChecksumDuration)
+	// Send a VerifyChecksum to all the replicas of the range.
+	{
+		var ba roachpb.BatchRequest
+		ba.RangeID = r.Desc().RangeID
+		checkArgs := &roachpb.VerifyChecksumRequest{
+			Span: roachpb.Span{
+				Key:    key,
+				EndKey: endKey,
+			},
+			Version:    replicaChecksumVersion,
+			ChecksumID: id,
+			Checksum:   checksum,
+		}
+		ba.Add(checkArgs)
+		_, pErr := r.Send(r.context(), ba)
+		if pErr != nil {
+			return roachpb.CheckConsistencyResponse{}, pErr
+		}
+	}
+	return roachpb.CheckConsistencyResponse{}, nil
+}
+
+const (
+	replicaChecksumVersion    = 0
+	replicaChecksumGCInterval = time.Hour
+)
+
+// setChecksumNotify sets a notification channel on which the checksum
+// from the result of ComputeChecksum is sent.
+func (r *Replica) setChecksumNotify(id uuid.UUID, notify chan []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.mu.checksumNotify[id]; ok {
+		panic(fmt.Sprintf("id %v already exists", id))
+	}
+	r.mu.checksumNotify[id] = notify
+	return
+}
+
+// computeChecksumDone adds the computed checksum, sets a deadline for GCing the
+// checksum, and sends out a notification.
+func (r *Replica) computeChecksumDone(id uuid.UUID, sha []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if c, ok := r.mu.checksums[id]; ok {
+		c.ok = true
+		c.checksum = sha
+		c.gcTimestamp = time.Now().Add(replicaChecksumGCInterval)
+		r.mu.checksums[id] = c
+	} else {
+		panic("checksum has been GCed")
+	}
+	notify := r.mu.checksumNotify[id]
+	delete(r.mu.checksumNotify, id)
+	if notify != nil {
+		notify <- sha
+	}
+}
+
+// ComputeChecksum starts the process of computing a checksum on the
+// replica at a particular snapshot. The checksum is later verified
+// through the VerifyChecksum request.
+func (r *Replica) ComputeChecksum(batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.ComputeChecksumRequest) (roachpb.ComputeChecksumResponse, error) {
+	if args.Version != replicaChecksumVersion {
+		log.Errorf("Incompatible versions: e=%d, v=%d", replicaChecksumVersion, args.Version)
+		return roachpb.ComputeChecksumResponse{}, nil
+	}
+	stopper := r.store.Stopper()
+	id := args.ChecksumID
+	now := time.Now()
+	r.mu.Lock()
+	if _, ok := r.mu.checksums[id]; ok {
+		// A previous attempt was made to compute the checksum.
+		r.mu.Unlock()
+		return roachpb.ComputeChecksumResponse{}, nil
+	}
+
+	// GC old entries.
+	var oldEntries []uuid.UUID
+	for id, val := range r.mu.checksums {
+		// The timestamp is only valid when the checksum is set.
+		if val.checksum != nil && now.After(val.gcTimestamp) {
+			oldEntries = append(oldEntries, id)
+		}
+	}
+	for _, id := range oldEntries {
+		delete(r.mu.checksums, id)
+	}
+
+	// Create an entry with checksum == nil and gcTimestamp unset.
+	r.mu.checksums[id] = replicaChecksum{}
+	desc := *r.mu.desc
+	r.mu.Unlock()
+	snap := r.store.NewSnapshot()
+
+	// Compute SHA asynchronously and store it in a map by UUID.
+	if !stopper.RunAsyncTask(func() {
+		defer snap.Close()
+		sha, err := r.sha512(desc, snap)
+		if err != nil {
+			log.Error(err)
+			sha = nil
+		}
+		r.computeChecksumDone(id, sha)
+	}) {
+		defer snap.Close()
+		// Set checksum to nil.
+		r.computeChecksumDone(id, nil)
+	}
+	return roachpb.ComputeChecksumResponse{}, nil
+}
+
+// sha512 computes the SHA512 hash of all the replica data at the snapshot.
+func (r *Replica) sha512(desc roachpb.RangeDescriptor, snap engine.Engine) ([]byte, error) {
+	hasher := sha512.New()
+	// Iterate over all the data in the range.
+	iter := newReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		key := iter.Key()
+		value := iter.Value()
+		// Encode the length of the key and value.
+		if err := binary.Write(hasher, binary.LittleEndian, int64(len(key.Key))); err != nil {
+			return nil, err
+		}
+		if err := binary.Write(hasher, binary.LittleEndian, int64(len(value))); err != nil {
+			return nil, err
+		}
+		if _, err := hasher.Write(key.Key); err != nil {
+			return nil, err
+		}
+		timestamp, err := key.Timestamp.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := hasher.Write(timestamp); err != nil {
+			return nil, err
+		}
+		if _, err := hasher.Write(value); err != nil {
+			return nil, err
+		}
+	}
+	sha := make([]byte, 0, sha512.Size)
+	return hasher.Sum(sha), nil
+}
+
+// maybeSetChecksumNotify may set a channel to receive a checksum
+// notification if the checksum is unavailable.
+func (r *Replica) maybeSetChecksumNotify(id uuid.UUID) chan []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if c, ok := r.mu.checksums[id]; ok && !c.ok {
+		// Checksum hasn't been computed yet; set notification.
+		if r.mu.checksumNotify[id] != nil {
+			panic("existing notification exists")
+		}
+		notify := make(chan []byte, 1)
+		r.mu.checksumNotify[id] = notify
+		return notify
+	}
+	return nil
+}
+
+// VerifyChecksum verifies the checksum that was computed through a
+// ComputeChecksum request.
+func (r *Replica) VerifyChecksum(batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.VerifyChecksumRequest) (roachpb.VerifyChecksumResponse, error) {
+	if args.Version != replicaChecksumVersion {
+		log.Errorf("Incompatible versions: e=%d, v=%d", replicaChecksumVersion, args.Version)
+		return roachpb.VerifyChecksumResponse{}, nil
+	}
+	id := args.ChecksumID
+	notify := r.maybeSetChecksumNotify(id)
+	if notify != nil {
+		now := time.Now()
+		<-notify
+		if log.V(1) {
+			log.Info("waited for compute checksum for %s", time.Since(now))
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if c, ok := r.mu.checksums[id]; ok {
+		if c.ok {
+			if c.checksum != nil && !bytes.Equal(c.checksum, args.Checksum) {
+				if p := r.store.ctx.TestingMocker.BadChecksumPanic; p != nil {
+					p()
+				} else {
+					panic(fmt.Sprintf("checksums: e = %v, v = %v", args.Checksum, c.checksum))
+				}
+			}
+		} else {
+			panic("received checksum notification but no checksum")
+		}
+	}
+	return roachpb.VerifyChecksumResponse{}, nil
 }
 
 // AdminSplit divides the range into into two ranges, using either

--- a/storage/replica_consistency_queue.go
+++ b/storage/replica_consistency_queue.go
@@ -1,0 +1,74 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Vivek Menezes (vivek@cockroachlabs.com)
+
+package storage
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/config"
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+const (
+	replicaConsistencyQueueSize = 100
+)
+
+type replicaConsistencyQueue struct {
+	baseQueue
+}
+
+// newReplicaConsistencyQueue returns a new instance of replicaConsistencyQueue.
+func newReplicaConsistencyQueue(gossip *gossip.Gossip) *replicaConsistencyQueue {
+	rcq := &replicaConsistencyQueue{}
+	rcq.baseQueue = makeBaseQueue("replica consistency checker", rcq, gossip, replicaConsistencyQueueSize)
+	return rcq
+}
+
+func (*replicaConsistencyQueue) needsLeaderLease() bool {
+	return true
+}
+
+func (*replicaConsistencyQueue) acceptsUnsplitRanges() bool {
+	return true
+}
+
+func (*replicaConsistencyQueue) shouldQueue(now roachpb.Timestamp, rng *Replica,
+	_ *config.SystemConfig) (bool, float64) {
+	return true, 1.0
+}
+
+// process() is called on every range for which this node is a leader.
+func (q *replicaConsistencyQueue) process(_ roachpb.Timestamp, rng *Replica, _ *config.SystemConfig) error {
+	req := roachpb.CheckConsistencyRequest{}
+	_, pErr := rng.CheckConsistency(req, rng.Desc())
+	if pErr != nil {
+		log.Error(pErr.GoError())
+	}
+	return nil
+}
+
+func (*replicaConsistencyQueue) timer() time.Duration {
+	// Some interval between replicas.
+	return 10 * time.Second
+}
+
+// purgatoryChan returns nil.
+func (*replicaConsistencyQueue) purgatoryChan() <-chan struct{} {
+	return nil
+}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -4048,3 +4048,135 @@ func TestReplicaCancelRaft(t *testing.T) {
 		}()
 	}
 }
+
+// verify the checksum for the range and returrn it.
+func verifyChecksum(t *testing.T, rng *Replica) []byte {
+	id := uuid.MakeV4()
+	notify := make(chan []byte, 1)
+	rng.setChecksumNotify(id, notify)
+	args := roachpb.ComputeChecksumRequest{
+		ChecksumID: id,
+		Version:    replicaChecksumVersion,
+	}
+	_, err := rng.ComputeChecksum(nil, nil, roachpb.Header{}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case checksum := <-notify:
+		if checksum == nil {
+			t.Fatal("couldn't compute checksum")
+		}
+		verifyArgs := roachpb.VerifyChecksumRequest{
+			ChecksumID: id,
+			Version:    replicaChecksumVersion,
+			Checksum:   checksum,
+		}
+		_, err := rng.VerifyChecksum(nil, nil, roachpb.Header{}, verifyArgs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return checksum
+	}
+}
+
+func TestComputeVerifyChecksum(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+	rng := tc.rng
+
+	incArgs := incrementArgs([]byte("a"), 23)
+	if _, err := client.SendWrapped(tc.Sender(), rng.context(), &incArgs); err != nil {
+		t.Fatal(err)
+	}
+	initialChecksum := verifyChecksum(t, rng)
+
+	// Getting a value will not affect the snapshot checksum
+	gArgs := getArgs(roachpb.Key("a"))
+	if _, err := client.SendWrapped(tc.Sender(), rng.context(), &gArgs); err != nil {
+		t.Fatal(err)
+	}
+	checksum := verifyChecksum(t, rng)
+
+	if !bytes.Equal(initialChecksum, checksum) {
+		t.Fatalf("changed checksum: e = %v, c = %v", initialChecksum, checksum)
+	}
+
+	// Modifying the range will change the checksum.
+	incArgs = incrementArgs([]byte("a"), 5)
+	if _, err := client.SendWrapped(tc.Sender(), rng.context(), &incArgs); err != nil {
+		t.Fatal(err)
+	}
+	checksum = verifyChecksum(t, rng)
+	if bytes.Equal(initialChecksum, checksum) {
+		t.Fatalf("same checksum: e = %v, c = %v", initialChecksum, checksum)
+	}
+
+	// Verify that a bad version/checksum sent will result in an error.
+	id := uuid.MakeV4()
+	notify := make(chan []byte, 1)
+	rng.setChecksumNotify(id, notify)
+	args := roachpb.ComputeChecksumRequest{
+		ChecksumID: id,
+	}
+	_, err := rng.ComputeChecksum(nil, nil, roachpb.Header{}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Set a callback for checksum mismatch panics.
+	var panicked bool
+	rng.store.ctx.TestingMocker.BadChecksumPanic = func() { panicked = true }
+	select {
+	case <-notify:
+		// First test that sending a Verification request with a bad version and
+		// bad checksum will return without panicking because of a bad checksum.
+		verifyArgs := roachpb.VerifyChecksumRequest{
+			ChecksumID: id,
+			Version:    10000001,
+			Checksum:   []byte("bad checksum"),
+		}
+		_, err = rng.VerifyChecksum(nil, nil, roachpb.Header{}, verifyArgs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if panicked {
+			t.Fatal("VerifyChecksum panicked")
+		}
+		// Setting the correct version results in a panic.
+		verifyArgs.Version = replicaChecksumVersion
+		_, err = rng.VerifyChecksum(nil, nil, roachpb.Header{}, verifyArgs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !panicked {
+			t.Fatal("VerifyChecksum didn't panic")
+		}
+		panicked = false
+	}
+
+	id = uuid.MakeV4()
+	// send a ComputeChecksum with a bad version doesn't result in a
+	// computed checksum.
+	args = roachpb.ComputeChecksumRequest{
+		ChecksumID: id,
+		Version:    23343434,
+	}
+	_, err = rng.ComputeChecksum(nil, nil, roachpb.Header{}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sending a VerifyChecksum with a bad checksum is a noop.
+	verifyArgs := roachpb.VerifyChecksumRequest{
+		ChecksumID: id,
+		Checksum:   []byte("bad checksum"),
+	}
+	_, err = rng.VerifyChecksum(nil, nil, roachpb.Header{}, verifyArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if panicked {
+		t.Fatal("VerifyChecksum panicked")
+	}
+}

--- a/storage/store.go
+++ b/storage/store.go
@@ -94,6 +94,7 @@ func TestStoreContext() StoreContext {
 		RaftHeartbeatIntervalTicks: 1,
 		RaftElectionTimeoutTicks:   2,
 		ScanInterval:               10 * time.Minute,
+		ConsistencyCheckInterval:   10 * time.Minute,
 	}
 }
 
@@ -251,27 +252,29 @@ type replicaDescCacheKey struct {
 // A Store maintains a map of ranges by start key. A Store corresponds
 // to one physical device.
 type Store struct {
-	Ident           roachpb.StoreIdent
-	ctx             StoreContext
-	db              *client.DB
-	engine          engine.Engine   // The underlying key-value store
-	allocator       Allocator       // Makes allocation decisions
-	rangeIDAlloc    *idAllocator    // Range ID allocator
-	gcQueue         *gcQueue        // Garbage collection queue
-	splitQueue      *splitQueue     // Range splitting queue
-	verifyQueue     *verifyQueue    // Checksum verification queue
-	replicateQueue  *replicateQueue // Replication queue
-	replicaGCQueue  *replicaGCQueue // Replica GC queue
-	raftLogQueue    *raftLogQueue   // Raft Log Truncation queue
-	scanner         *replicaScanner // Replica scanner
-	metrics         *storeMetrics
-	wakeRaftLoop    chan struct{}
-	started         int32
-	stopper         *stop.Stopper
-	startedAt       int64
-	nodeDesc        *roachpb.NodeDescriptor
-	initComplete    sync.WaitGroup // Signaled by async init tasks
-	raftRequestChan chan *RaftMessageRequest
+	Ident                   roachpb.StoreIdent
+	ctx                     StoreContext
+	db                      *client.DB
+	engine                  engine.Engine            // The underlying key-value store
+	allocator               Allocator                // Makes allocation decisions
+	rangeIDAlloc            *idAllocator             // Range ID allocator
+	gcQueue                 *gcQueue                 // Garbage collection queue
+	splitQueue              *splitQueue              // Range splitting queue
+	verifyQueue             *verifyQueue             // Checksum verification queue
+	replicateQueue          *replicateQueue          // Replication queue
+	replicaGCQueue          *replicaGCQueue          // Replica GC queue
+	raftLogQueue            *raftLogQueue            // Raft Log Truncation queue
+	scanner                 *replicaScanner          // Replica scanner
+	replicaConsistencyQueue *replicaConsistencyQueue // Replica consistency check queue
+	consistencyScanner      *replicaScanner          // Consistency checker scanner
+	metrics                 *storeMetrics
+	wakeRaftLoop            chan struct{}
+	started                 int32
+	stopper                 *stop.Stopper
+	startedAt               int64
+	nodeDesc                *roachpb.NodeDescriptor
+	initComplete            sync.WaitGroup // Signaled by async init tasks
+	raftRequestChan         chan *RaftMessageRequest
 
 	// Locking notes: To avoid deadlocks, the following lock order
 	// must be obeyed: processRaftMu < Store.mu.Mutex <
@@ -344,6 +347,10 @@ type StoreContext struct {
 	// stores.
 	ScanMaxIdleTime time.Duration
 
+	// ConsistencyCheckInterval is the default time period in between consecutive
+	// consistency checks on a range.
+	ConsistencyCheckInterval time.Duration
+
 	// TimeUntilStoreDead is the time after which if there is no new gossiped
 	// information about a store, it can be considered dead.
 	TimeUntilStoreDead time.Duration
@@ -366,6 +373,9 @@ type StoreContext struct {
 type StoreTestingMocker struct {
 	// A callback to be called when executing every replica command.
 	TestingCommandFilter CommandFilter
+	// A callback to be called instead of panicking due to a
+	// checksum mismatch in VerifyChecksum()
+	BadChecksumPanic func()
 }
 
 type storeMetrics struct {
@@ -551,6 +561,11 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 	s.raftLogQueue = newRaftLogQueue(s.db, s.ctx.Gossip)
 	s.scanner.AddQueues(s.gcQueue, s.splitQueue, s.verifyQueue, s.replicateQueue, s.replicaGCQueue, s.raftLogQueue)
 
+	// Add consistency check scanner.
+	s.consistencyScanner = newReplicaScanner(ctx.ConsistencyCheckInterval, ctx.ScanMaxIdleTime, newStoreRangeSet(s))
+	s.replicaConsistencyQueue = newReplicaConsistencyQueue(s.ctx.Gossip)
+	s.consistencyScanner.AddQueues(s.replicaConsistencyQueue)
+
 	return s
 }
 
@@ -727,6 +742,17 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 				return
 			}
 		})
+
+		// Start the consistency scanner.
+		s.stopper.RunWorker(func() {
+			select {
+			case <-s.ctx.Gossip.Connected:
+				s.consistencyScanner.Start(s.ctx.Clock, s.stopper)
+			case <-s.stopper.ShouldStop():
+				return
+			}
+		})
+
 	}
 
 	// Set the started flag (for unittests).
@@ -1071,6 +1097,9 @@ func (s *Store) Stopper() *stop.Stopper { return s.stopper }
 // Tracer accessor.
 func (s *Store) Tracer() opentracing.Tracer { return s.ctx.Tracer }
 
+// TestingMocker accessor.
+func (s *Store) TestingMocker() *StoreTestingMocker { return &s.ctx.TestingMocker }
+
 // NewRangeDescriptor creates a new descriptor based on start and end
 // keys and the supplied roachpb.Replicas slice. It allocates new
 // replica IDs to fill out the supplied replicas.
@@ -1262,6 +1291,7 @@ func (s *Store) removeReplicaImpl(rep *Replica, origDesc roachpb.RangeDescriptor
 		return util.Errorf("couldn't find range in replicasByKey btree")
 	}
 	s.scanner.RemoveReplica(rep)
+	s.consistencyScanner.RemoveReplica(rep)
 
 	// Adjust stats before calling Destroy. This can be called before or after
 	// Destroy, but this configuration helps avoid races in stat verification


### PR DESCRIPTION
closes #837 

This PR implements two mechanisms for running consistency checks. The KV API exports a method
CheckConsistency() to be used in all acceptance/SQL tests. The production code runs a periodic (every 24 hours) consistency check on all ranges and logs an error whenever it sees a bad range.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4686)

<!-- Reviewable:end -->
