### PR TITLE
pick up cmux reader bug fix

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -61,7 +61,7 @@ github.com/robfig/glock cb3c3ec56de988289cab7bbd284eddc04dfee6c9
 github.com/russross/blackfriday 006144af03eeeff1037240a71865a9fd61f1c25f
 github.com/satori/go.uuid e673fdd4dea8a7334adbbe7f57b7e4b00bdc5502
 github.com/shurcooL/sanitized_anchor_name 10ef21a441db47d8b13ebcc5fd2310f636973c77
-github.com/soheilhy/cmux d8cc6481fa0dc82bbdc5f6c8db91a06f6024987c
+github.com/soheilhy/cmux d710784914b3024cacf5d915b5cafbd9b6a8f0fe
 github.com/spf13/cobra 65a708cee0a4424f4e353d031ce440643e312f92
 github.com/spf13/pflag 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7
 github.com/tebeka/go2xunit 304a3dad367b395460778a969d87101b778b322f


### PR DESCRIPTION
The fix was submitted in https://github.com/soheilhy/cmux/pull/20.

I'm not sure this fixes any of the (many) test failures we've been
seeing, but it might. I'm still able to reproduce some failures, so
this is not the end.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4693)

<!-- Reviewable:end -->
