### PR TITLE
sql/parser: prevent panic by switching missing CASE type to DNull

### DIFF
--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -105,6 +105,12 @@ func (expr *CaseExpr) TypeCheck(args MapArgs) (Datum, error) {
 			return nil, err
 		}
 	}
+	if dummyVal == nil {
+		// TODO(dt): This isn't ideal -- we'll probably end up with a
+		// type error elsewhere, but it prevents a panic in the call to
+		// SetInferredType below. See #4691.
+		dummyVal = DNull
+	}
 
 	for _, when := range expr.Whens {
 		nextDummyCond, err := when.Cond.TypeCheck(args)

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -516,12 +516,13 @@ func TestPGPreparedExec(t *testing.T) {
 				base.Params(1, 2, 3).RowsAffected(3),
 			},
 		},
-		{
-			`UPDATE d.t SET d = CASE i WHEN $1 THEN $3 WHEN $2 THEN $4 END WHERE i IN ($1, $2)`,
-			[]preparedExecTest{
-				base.Params(1, 2, 3, 4).RowsAffected(0),
-			},
-		},
+		// TODO(dt): #4691.
+		// {
+		// 	`UPDATE d.t SET d = CASE i WHEN $1 THEN $3 WHEN $2 THEN $4 END WHERE i IN ($1, $2)`,
+		// 	[]preparedExecTest{
+		// 		base.Params(1, 2, 3, 4).RowsAffected(0),
+		// 	},
+		// },
 		{
 			"DROP TABLE d.t",
 			[]preparedExecTest{

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -517,6 +517,12 @@ func TestPGPreparedExec(t *testing.T) {
 			},
 		},
 		{
+			`UPDATE d.t SET d = CASE i WHEN $1 THEN $3 WHEN $2 THEN $4 END WHERE i IN ($1, $2)`,
+			[]preparedExecTest{
+				base.Params(1, 2, 3, 4).RowsAffected(0),
+			},
+		},
+		{
 			"DROP TABLE d.t",
 			[]preparedExecTest{
 				base,


### PR DESCRIPTION
Workaround to avoid crash in #4691

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4695)

<!-- Reviewable:end -->
