### PR TITLE
storage: Arithmetically compute stats in splitTrigger and mergeTrigger

### DIFF
--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -125,12 +125,17 @@ message SplitTrigger {
 
 // A MergeTrigger is run after a successful commit of an AdminMerge
 // command. It provides the updated range descriptor that now encompasses
-// what was originally both ranges. This information allows the final bookkeeping
-// for the merge to be completed and put into operation.
+// what was originally both ranges and the soon to be invalid range
+// descriptor that used to cover the subsumed half of the merge. This
+// information allows the final bookkeeping for the merge to be completed
+// and put into operation.
 message MergeTrigger {
+  // The updated range descriptor that now encompasses what was originally
+  // both ranges.
   optional RangeDescriptor updated_desc = 1 [(gogoproto.nullable) = false];
-  optional int64 subsumed_range_id = 2 [(gogoproto.nullable) = false,
-      (gogoproto.customname) = "SubsumedRangeID", (gogoproto.casttype) = "RangeID"];
+  // The soon to be invalid range descriptor that used to cover the subsumed
+  // half of the merge.
+  optional RangeDescriptor subsumed_desc = 2 [(gogoproto.nullable) = false];
 }
 
 // ReplicaChangeType is a parameter of ChangeReplicasTrigger.

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -902,3 +902,26 @@ func TestSortRangeDescByAge(t *testing.T) {
 		t.Fatalf("RangeDescriptor sort by age was not correct. Diff: %s", pretty.Diff(sortedRangeDescs, rangeDescs))
 	}
 }
+
+func verifyRangeStats(eng engine.Engine, rangeID roachpb.RangeID, expMS engine.MVCCStats) error {
+	var ms engine.MVCCStats
+	if err := engine.MVCCGetRangeStats(eng, rangeID, &ms); err != nil {
+		return err
+	}
+	// Clear system counts as these are expected to vary.
+	ms.SysBytes, ms.SysCount = 0, 0
+	if expMS != ms {
+		return fmt.Errorf("expected stats %+v; got %+v", expMS, ms)
+	}
+	return nil
+}
+
+func verifyRecomputedStats(store *storage.Store, d *roachpb.RangeDescriptor, expMS engine.MVCCStats) error {
+	now := store.Clock().Timestamp()
+	if ms, err := storage.ComputeStatsForRange(d, store.Engine(), now.WallTime); err != nil {
+		return err
+	} else if expMS != ms {
+		return fmt.Errorf("expected range's stats to agree with recomputation: got\n%+v\nrecomputed\n%+v", expMS, ms)
+	}
+	return nil
+}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -80,7 +80,7 @@ func rg1(s *storage.Store) client.Sender {
 
 // createTestStore creates a test store using an in-memory
 // engine. The caller is responsible for stopping the stopper on exit.
-func createTestStore(t *testing.T) (*storage.Store, *stop.Stopper) {
+func createTestStore(t testing.TB) (*storage.Store, *stop.Stopper) {
 	stopper := stop.NewStopper()
 	store := createTestStoreWithEngine(t,
 		engine.NewInMem(roachpb.Attributes{}, 10<<20, stopper),
@@ -90,7 +90,7 @@ func createTestStore(t *testing.T) (*storage.Store, *stop.Stopper) {
 }
 
 // createTestStoreWithEngine creates a test store using the given engine and clock.
-func createTestStoreWithEngine(t *testing.T, eng engine.Engine, clock *hlc.Clock,
+func createTestStoreWithEngine(t testing.TB, eng engine.Engine, clock *hlc.Clock,
 	bootstrap bool, sCtx *storage.StoreContext, stopper *stop.Stopper) *storage.Store {
 	rpcContext := rpc.NewContext(&base.Context{}, clock, stopper)
 	if sCtx == nil {

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
@@ -185,7 +185,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
   MergeTrigger_descriptor_ = file->message_type(6);
   static const int MergeTrigger_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeTrigger, updated_desc_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeTrigger, subsumed_range_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeTrigger, subsumed_desc_),
   };
   MergeTrigger_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -474,64 +474,64 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
     "\002 \001(\0132\".cockroach.roachpb.RangeDescripto"
     "rB\004\310\336\037\000\022H\n\027initial_leader_store_id\030\003 \001(\005"
     "B\'\310\336\037\000\342\336\037\024InitialLeaderStoreID\372\336\037\007StoreI"
-    "D\"\215\001\n\014MergeTrigger\022>\n\014updated_desc\030\001 \001(\013"
+    "D\"\217\001\n\014MergeTrigger\022>\n\014updated_desc\030\001 \001(\013"
     "2\".cockroach.roachpb.RangeDescriptorB\004\310\336"
-    "\037\000\022=\n\021subsumed_range_id\030\002 \001(\003B\"\310\336\037\000\342\336\037\017S"
-    "ubsumedRangeID\372\336\037\007RangeID\"\230\002\n\025ChangeRepl"
-    "icasTrigger\022\?\n\013change_type\030\001 \001(\0162$.cockr"
-    "oach.roachpb.ReplicaChangeTypeB\004\310\336\037\000\022;\n\007"
-    "replica\030\002 \001(\0132$.cockroach.roachpb.Replic"
-    "aDescriptorB\004\310\336\037\000\022D\n\020updated_replicas\030\003 "
-    "\003(\0132$.cockroach.roachpb.ReplicaDescripto"
-    "rB\004\310\336\037\000\022;\n\017next_replica_id\030\004 \001(\005B\"\310\336\037\000\342\336"
-    "\037\rNextReplicaID\372\336\037\tReplicaID\"7\n\023Modified"
-    "SpanTrigger\022 \n\022system_config_span\030\001 \001(\010B"
-    "\004\310\336\037\000\"\237\002\n\025InternalCommitTrigger\0226\n\rsplit"
-    "_trigger\030\001 \001(\0132\037.cockroach.roachpb.Split"
-    "Trigger\0226\n\rmerge_trigger\030\002 \001(\0132\037.cockroa"
-    "ch.roachpb.MergeTrigger\022I\n\027change_replic"
-    "as_trigger\030\003 \001(\0132(.cockroach.roachpb.Cha"
-    "ngeReplicasTrigger\022E\n\025modified_span_trig"
-    "ger\030\004 \001(\0132&.cockroach.roachpb.ModifiedSp"
-    "anTrigger:\004\210\240\037\001\"\'\n\010NodeList\022\033\n\005nodes\030\001 \003"
-    "(\005B\014\020\001\372\336\037\006NodeID\"\355\001\n\007TxnMeta\022E\n\002id\030\001 \001(\014"
-    "B9\342\336\037\002ID\332\336\037/github.com/cockroachdb/cockr"
-    "oach/util/uuid.UUID\0229\n\tisolation\030\002 \001(\0162 "
-    ".cockroach.roachpb.IsolationTypeB\004\310\336\037\000\022\024"
-    "\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\023\n\005epoch\030\004 \001(\rB\004\310\336\037"
-    "\000\0225\n\ttimestamp\030\005 \001(\0132\034.cockroach.roachpb"
-    ".TimestampB\004\310\336\037\000\"\365\003\n\013Transaction\0222\n\004meta"
-    "\030\001 \001(\0132\032.cockroach.roachpb.TxnMetaB\010\310\336\037\000"
-    "\320\336\037\001\022\022\n\004name\030\002 \001(\tB\004\310\336\037\000\022\026\n\010priority\030\003 \001"
-    "(\005B\004\310\336\037\000\022:\n\006status\030\004 \001(\0162$.cockroach.roa"
-    "chpb.TransactionStatusB\004\310\336\037\000\0224\n\016last_hea"
-    "rtbeat\030\005 \001(\0132\034.cockroach.roachpb.Timesta"
-    "mp\022:\n\016orig_timestamp\030\006 \001(\0132\034.cockroach.r"
-    "oachpb.TimestampB\004\310\336\037\000\0229\n\rmax_timestamp\030"
-    "\007 \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037"
-    "\000\0228\n\rcertain_nodes\030\010 \001(\0132\033.cockroach.roa"
-    "chpb.NodeListB\004\310\336\037\000\022\025\n\007Writing\030\t \001(\010B\004\310\336"
-    "\037\000\022\026\n\010Sequence\030\n \001(\rB\004\310\336\037\000\022.\n\007Intents\030\013 "
-    "\003(\0132\027.cockroach.roachpb.SpanB\004\310\336\037\000:\004\230\240\037\000"
-    "\"\244\001\n\006Intent\022/\n\004span\030\001 \001(\0132\027.cockroach.ro"
-    "achpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\003txn\030\002 \001(\0132\032.cock"
-    "roach.roachpb.TxnMetaB\004\310\336\037\000\022:\n\006status\030\003 "
-    "\001(\0162$.cockroach.roachpb.TransactionStatu"
-    "sB\004\310\336\037\000\"\265\001\n\005Lease\0221\n\005start\030\001 \001(\0132\034.cockr"
-    "oach.roachpb.TimestampB\004\310\336\037\000\0226\n\nexpirati"
-    "on\030\002 \001(\0132\034.cockroach.roachpb.TimestampB\004"
-    "\310\336\037\000\022;\n\007replica\030\003 \001(\0132$.cockroach.roachp"
-    "b.ReplicaDescriptorB\004\310\336\037\000:\004\230\240\037\000\"a\n\022Seque"
-    "nceCacheEntry\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\tt"
-    "imestamp\030\002 \001(\0132\034.cockroach.roachpb.Times"
-    "tampB\004\310\336\037\000*^\n\tValueType\022\013\n\007UNKNOWN\020\000\022\007\n\003"
-    "INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BYTES\020\003\022\010\n\004TIME\020\004\022\013\n"
-    "\007DECIMAL\020\005\022\016\n\nTIMESERIES\020d*>\n\021ReplicaCha"
-    "ngeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_REPLI"
-    "CA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERIALIZA"
-    "BLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021Transaction"
-    "Status\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007AB"
-    "ORTED\020\002\032\004\210\243\036\000B\tZ\007roachpbX\001", 3106);
+    "\037\000\022\?\n\rsubsumed_desc\030\002 \001(\0132\".cockroach.ro"
+    "achpb.RangeDescriptorB\004\310\336\037\000\"\230\002\n\025ChangeRe"
+    "plicasTrigger\022\?\n\013change_type\030\001 \001(\0162$.coc"
+    "kroach.roachpb.ReplicaChangeTypeB\004\310\336\037\000\022;"
+    "\n\007replica\030\002 \001(\0132$.cockroach.roachpb.Repl"
+    "icaDescriptorB\004\310\336\037\000\022D\n\020updated_replicas\030"
+    "\003 \003(\0132$.cockroach.roachpb.ReplicaDescrip"
+    "torB\004\310\336\037\000\022;\n\017next_replica_id\030\004 \001(\005B\"\310\336\037\000"
+    "\342\336\037\rNextReplicaID\372\336\037\tReplicaID\"7\n\023Modifi"
+    "edSpanTrigger\022 \n\022system_config_span\030\001 \001("
+    "\010B\004\310\336\037\000\"\237\002\n\025InternalCommitTrigger\0226\n\rspl"
+    "it_trigger\030\001 \001(\0132\037.cockroach.roachpb.Spl"
+    "itTrigger\0226\n\rmerge_trigger\030\002 \001(\0132\037.cockr"
+    "oach.roachpb.MergeTrigger\022I\n\027change_repl"
+    "icas_trigger\030\003 \001(\0132(.cockroach.roachpb.C"
+    "hangeReplicasTrigger\022E\n\025modified_span_tr"
+    "igger\030\004 \001(\0132&.cockroach.roachpb.Modified"
+    "SpanTrigger:\004\210\240\037\001\"\'\n\010NodeList\022\033\n\005nodes\030\001"
+    " \003(\005B\014\020\001\372\336\037\006NodeID\"\355\001\n\007TxnMeta\022E\n\002id\030\001 \001"
+    "(\014B9\342\336\037\002ID\332\336\037/github.com/cockroachdb/coc"
+    "kroach/util/uuid.UUID\0229\n\tisolation\030\002 \001(\016"
+    "2 .cockroach.roachpb.IsolationTypeB\004\310\336\037\000"
+    "\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\023\n\005epoch\030\004 \001(\rB\004\310"
+    "\336\037\000\0225\n\ttimestamp\030\005 \001(\0132\034.cockroach.roach"
+    "pb.TimestampB\004\310\336\037\000\"\365\003\n\013Transaction\0222\n\004me"
+    "ta\030\001 \001(\0132\032.cockroach.roachpb.TxnMetaB\010\310\336"
+    "\037\000\320\336\037\001\022\022\n\004name\030\002 \001(\tB\004\310\336\037\000\022\026\n\010priority\030\003"
+    " \001(\005B\004\310\336\037\000\022:\n\006status\030\004 \001(\0162$.cockroach.r"
+    "oachpb.TransactionStatusB\004\310\336\037\000\0224\n\016last_h"
+    "eartbeat\030\005 \001(\0132\034.cockroach.roachpb.Times"
+    "tamp\022:\n\016orig_timestamp\030\006 \001(\0132\034.cockroach"
+    ".roachpb.TimestampB\004\310\336\037\000\0229\n\rmax_timestam"
+    "p\030\007 \001(\0132\034.cockroach.roachpb.TimestampB\004\310"
+    "\336\037\000\0228\n\rcertain_nodes\030\010 \001(\0132\033.cockroach.r"
+    "oachpb.NodeListB\004\310\336\037\000\022\025\n\007Writing\030\t \001(\010B\004"
+    "\310\336\037\000\022\026\n\010Sequence\030\n \001(\rB\004\310\336\037\000\022.\n\007Intents\030"
+    "\013 \003(\0132\027.cockroach.roachpb.SpanB\004\310\336\037\000:\004\230\240"
+    "\037\000\"\244\001\n\006Intent\022/\n\004span\030\001 \001(\0132\027.cockroach."
+    "roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\003txn\030\002 \001(\0132\032.co"
+    "ckroach.roachpb.TxnMetaB\004\310\336\037\000\022:\n\006status\030"
+    "\003 \001(\0162$.cockroach.roachpb.TransactionSta"
+    "tusB\004\310\336\037\000\"\265\001\n\005Lease\0221\n\005start\030\001 \001(\0132\034.coc"
+    "kroach.roachpb.TimestampB\004\310\336\037\000\0226\n\nexpira"
+    "tion\030\002 \001(\0132\034.cockroach.roachpb.Timestamp"
+    "B\004\310\336\037\000\022;\n\007replica\030\003 \001(\0132$.cockroach.roac"
+    "hpb.ReplicaDescriptorB\004\310\336\037\000:\004\230\240\037\000\"a\n\022Seq"
+    "uenceCacheEntry\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n"
+    "\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb.Tim"
+    "estampB\004\310\336\037\000*^\n\tValueType\022\013\n\007UNKNOWN\020\000\022\007"
+    "\n\003INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BYTES\020\003\022\010\n\004TIME\020\004\022"
+    "\013\n\007DECIMAL\020\005\022\016\n\nTIMESERIES\020d*>\n\021ReplicaC"
+    "hangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_REP"
+    "LICA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERIALI"
+    "ZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021Transacti"
+    "onStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007"
+    "ABORTED\020\002\032\004\210\243\036\000B\tZ\007roachpbX\001", 3108);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/data.proto", &protobuf_RegisterTypes);
   Span::default_instance_ = new Span();
@@ -3024,7 +3024,7 @@ void SplitTrigger::clear_initial_leader_store_id() {
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int MergeTrigger::kUpdatedDescFieldNumber;
-const int MergeTrigger::kSubsumedRangeIdFieldNumber;
+const int MergeTrigger::kSubsumedDescFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 MergeTrigger::MergeTrigger()
@@ -3035,6 +3035,7 @@ MergeTrigger::MergeTrigger()
 
 void MergeTrigger::InitAsDefaultInstance() {
   updated_desc_ = const_cast< ::cockroach::roachpb::RangeDescriptor*>(&::cockroach::roachpb::RangeDescriptor::default_instance());
+  subsumed_desc_ = const_cast< ::cockroach::roachpb::RangeDescriptor*>(&::cockroach::roachpb::RangeDescriptor::default_instance());
 }
 
 MergeTrigger::MergeTrigger(const MergeTrigger& from)
@@ -3048,7 +3049,7 @@ MergeTrigger::MergeTrigger(const MergeTrigger& from)
 void MergeTrigger::SharedCtor() {
   _cached_size_ = 0;
   updated_desc_ = NULL;
-  subsumed_range_id_ = GOOGLE_LONGLONG(0);
+  subsumed_desc_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -3060,6 +3061,7 @@ MergeTrigger::~MergeTrigger() {
 void MergeTrigger::SharedDtor() {
   if (this != default_instance_) {
     delete updated_desc_;
+    delete subsumed_desc_;
   }
 }
 
@@ -3093,7 +3095,9 @@ void MergeTrigger::Clear() {
     if (has_updated_desc()) {
       if (updated_desc_ != NULL) updated_desc_->::cockroach::roachpb::RangeDescriptor::Clear();
     }
-    subsumed_range_id_ = GOOGLE_LONGLONG(0);
+    if (has_subsumed_desc()) {
+      if (subsumed_desc_ != NULL) subsumed_desc_->::cockroach::roachpb::RangeDescriptor::Clear();
+    }
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3119,18 +3123,16 @@ bool MergeTrigger::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(16)) goto parse_subsumed_range_id;
+        if (input->ExpectTag(18)) goto parse_subsumed_desc;
         break;
       }
 
-      // optional int64 subsumed_range_id = 2;
+      // optional .cockroach.roachpb.RangeDescriptor subsumed_desc = 2;
       case 2: {
-        if (tag == 16) {
-         parse_subsumed_range_id:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
-                 input, &subsumed_range_id_)));
-          set_has_subsumed_range_id();
+        if (tag == 18) {
+         parse_subsumed_desc:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_subsumed_desc()));
         } else {
           goto handle_unusual;
         }
@@ -3169,9 +3171,10 @@ void MergeTrigger::SerializeWithCachedSizes(
       1, *this->updated_desc_, output);
   }
 
-  // optional int64 subsumed_range_id = 2;
-  if (has_subsumed_range_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->subsumed_range_id(), output);
+  // optional .cockroach.roachpb.RangeDescriptor subsumed_desc = 2;
+  if (has_subsumed_desc()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2, *this->subsumed_desc_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3191,9 +3194,11 @@ void MergeTrigger::SerializeWithCachedSizes(
         1, *this->updated_desc_, target);
   }
 
-  // optional int64 subsumed_range_id = 2;
-  if (has_subsumed_range_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->subsumed_range_id(), target);
+  // optional .cockroach.roachpb.RangeDescriptor subsumed_desc = 2;
+  if (has_subsumed_desc()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        2, *this->subsumed_desc_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -3215,11 +3220,11 @@ int MergeTrigger::ByteSize() const {
           *this->updated_desc_);
     }
 
-    // optional int64 subsumed_range_id = 2;
-    if (has_subsumed_range_id()) {
+    // optional .cockroach.roachpb.RangeDescriptor subsumed_desc = 2;
+    if (has_subsumed_desc()) {
       total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int64Size(
-          this->subsumed_range_id());
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->subsumed_desc_);
     }
 
   }
@@ -3252,8 +3257,8 @@ void MergeTrigger::MergeFrom(const MergeTrigger& from) {
     if (from.has_updated_desc()) {
       mutable_updated_desc()->::cockroach::roachpb::RangeDescriptor::MergeFrom(from.updated_desc());
     }
-    if (from.has_subsumed_range_id()) {
-      set_subsumed_range_id(from.subsumed_range_id());
+    if (from.has_subsumed_desc()) {
+      mutable_subsumed_desc()->::cockroach::roachpb::RangeDescriptor::MergeFrom(from.subsumed_desc());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -3284,7 +3289,7 @@ void MergeTrigger::Swap(MergeTrigger* other) {
 }
 void MergeTrigger::InternalSwap(MergeTrigger* other) {
   std::swap(updated_desc_, other->updated_desc_);
-  std::swap(subsumed_range_id_, other->subsumed_range_id_);
+  std::swap(subsumed_desc_, other->subsumed_desc_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -3344,28 +3349,47 @@ void MergeTrigger::set_allocated_updated_desc(::cockroach::roachpb::RangeDescrip
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.MergeTrigger.updated_desc)
 }
 
-// optional int64 subsumed_range_id = 2;
-bool MergeTrigger::has_subsumed_range_id() const {
+// optional .cockroach.roachpb.RangeDescriptor subsumed_desc = 2;
+bool MergeTrigger::has_subsumed_desc() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-void MergeTrigger::set_has_subsumed_range_id() {
+void MergeTrigger::set_has_subsumed_desc() {
   _has_bits_[0] |= 0x00000002u;
 }
-void MergeTrigger::clear_has_subsumed_range_id() {
+void MergeTrigger::clear_has_subsumed_desc() {
   _has_bits_[0] &= ~0x00000002u;
 }
-void MergeTrigger::clear_subsumed_range_id() {
-  subsumed_range_id_ = GOOGLE_LONGLONG(0);
-  clear_has_subsumed_range_id();
+void MergeTrigger::clear_subsumed_desc() {
+  if (subsumed_desc_ != NULL) subsumed_desc_->::cockroach::roachpb::RangeDescriptor::Clear();
+  clear_has_subsumed_desc();
 }
- ::google::protobuf::int64 MergeTrigger::subsumed_range_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.MergeTrigger.subsumed_range_id)
-  return subsumed_range_id_;
+const ::cockroach::roachpb::RangeDescriptor& MergeTrigger::subsumed_desc() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.MergeTrigger.subsumed_desc)
+  return subsumed_desc_ != NULL ? *subsumed_desc_ : *default_instance_->subsumed_desc_;
 }
- void MergeTrigger::set_subsumed_range_id(::google::protobuf::int64 value) {
-  set_has_subsumed_range_id();
-  subsumed_range_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.MergeTrigger.subsumed_range_id)
+::cockroach::roachpb::RangeDescriptor* MergeTrigger::mutable_subsumed_desc() {
+  set_has_subsumed_desc();
+  if (subsumed_desc_ == NULL) {
+    subsumed_desc_ = new ::cockroach::roachpb::RangeDescriptor;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.MergeTrigger.subsumed_desc)
+  return subsumed_desc_;
+}
+::cockroach::roachpb::RangeDescriptor* MergeTrigger::release_subsumed_desc() {
+  clear_has_subsumed_desc();
+  ::cockroach::roachpb::RangeDescriptor* temp = subsumed_desc_;
+  subsumed_desc_ = NULL;
+  return temp;
+}
+void MergeTrigger::set_allocated_subsumed_desc(::cockroach::roachpb::RangeDescriptor* subsumed_desc) {
+  delete subsumed_desc_;
+  subsumed_desc_ = subsumed_desc;
+  if (subsumed_desc) {
+    set_has_subsumed_desc();
+  } else {
+    clear_has_subsumed_desc();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.MergeTrigger.subsumed_desc)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
@@ -861,25 +861,27 @@ class MergeTrigger : public ::google::protobuf::Message {
   ::cockroach::roachpb::RangeDescriptor* release_updated_desc();
   void set_allocated_updated_desc(::cockroach::roachpb::RangeDescriptor* updated_desc);
 
-  // optional int64 subsumed_range_id = 2;
-  bool has_subsumed_range_id() const;
-  void clear_subsumed_range_id();
-  static const int kSubsumedRangeIdFieldNumber = 2;
-  ::google::protobuf::int64 subsumed_range_id() const;
-  void set_subsumed_range_id(::google::protobuf::int64 value);
+  // optional .cockroach.roachpb.RangeDescriptor subsumed_desc = 2;
+  bool has_subsumed_desc() const;
+  void clear_subsumed_desc();
+  static const int kSubsumedDescFieldNumber = 2;
+  const ::cockroach::roachpb::RangeDescriptor& subsumed_desc() const;
+  ::cockroach::roachpb::RangeDescriptor* mutable_subsumed_desc();
+  ::cockroach::roachpb::RangeDescriptor* release_subsumed_desc();
+  void set_allocated_subsumed_desc(::cockroach::roachpb::RangeDescriptor* subsumed_desc);
 
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.MergeTrigger)
  private:
   inline void set_has_updated_desc();
   inline void clear_has_updated_desc();
-  inline void set_has_subsumed_range_id();
-  inline void clear_has_subsumed_range_id();
+  inline void set_has_subsumed_desc();
+  inline void clear_has_subsumed_desc();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::cockroach::roachpb::RangeDescriptor* updated_desc_;
-  ::google::protobuf::int64 subsumed_range_id_;
+  ::cockroach::roachpb::RangeDescriptor* subsumed_desc_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2fdata_2eproto();
@@ -2634,28 +2636,47 @@ inline void MergeTrigger::set_allocated_updated_desc(::cockroach::roachpb::Range
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.MergeTrigger.updated_desc)
 }
 
-// optional int64 subsumed_range_id = 2;
-inline bool MergeTrigger::has_subsumed_range_id() const {
+// optional .cockroach.roachpb.RangeDescriptor subsumed_desc = 2;
+inline bool MergeTrigger::has_subsumed_desc() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void MergeTrigger::set_has_subsumed_range_id() {
+inline void MergeTrigger::set_has_subsumed_desc() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void MergeTrigger::clear_has_subsumed_range_id() {
+inline void MergeTrigger::clear_has_subsumed_desc() {
   _has_bits_[0] &= ~0x00000002u;
 }
-inline void MergeTrigger::clear_subsumed_range_id() {
-  subsumed_range_id_ = GOOGLE_LONGLONG(0);
-  clear_has_subsumed_range_id();
+inline void MergeTrigger::clear_subsumed_desc() {
+  if (subsumed_desc_ != NULL) subsumed_desc_->::cockroach::roachpb::RangeDescriptor::Clear();
+  clear_has_subsumed_desc();
 }
-inline ::google::protobuf::int64 MergeTrigger::subsumed_range_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.MergeTrigger.subsumed_range_id)
-  return subsumed_range_id_;
+inline const ::cockroach::roachpb::RangeDescriptor& MergeTrigger::subsumed_desc() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.MergeTrigger.subsumed_desc)
+  return subsumed_desc_ != NULL ? *subsumed_desc_ : *default_instance_->subsumed_desc_;
 }
-inline void MergeTrigger::set_subsumed_range_id(::google::protobuf::int64 value) {
-  set_has_subsumed_range_id();
-  subsumed_range_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.MergeTrigger.subsumed_range_id)
+inline ::cockroach::roachpb::RangeDescriptor* MergeTrigger::mutable_subsumed_desc() {
+  set_has_subsumed_desc();
+  if (subsumed_desc_ == NULL) {
+    subsumed_desc_ = new ::cockroach::roachpb::RangeDescriptor;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.MergeTrigger.subsumed_desc)
+  return subsumed_desc_;
+}
+inline ::cockroach::roachpb::RangeDescriptor* MergeTrigger::release_subsumed_desc() {
+  clear_has_subsumed_desc();
+  ::cockroach::roachpb::RangeDescriptor* temp = subsumed_desc_;
+  subsumed_desc_ = NULL;
+  return temp;
+}
+inline void MergeTrigger::set_allocated_subsumed_desc(::cockroach::roachpb::RangeDescriptor* subsumed_desc) {
+  delete subsumed_desc_;
+  subsumed_desc_ = subsumed_desc;
+  if (subsumed_desc) {
+    set_has_subsumed_desc();
+  } else {
+    clear_has_subsumed_desc();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.MergeTrigger.subsumed_desc)
 }
 
 // -------------------------------------------------------------------

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -403,12 +403,14 @@ func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h ro
 	// Resolve any explicit intents. All that are local to this range get
 	// resolved synchronously in the same batch. The remainder are collected
 	// and handed off to asynchronous processing.
-	desc := *r.Desc()
+	desc := r.Desc()
+	var preMergeDesc *roachpb.RangeDescriptor
 	if mergeTrigger := args.InternalCommitTrigger.GetMergeTrigger(); mergeTrigger != nil {
 		// If this is a merge, then use the post-merge descriptor to determine
 		// which intents are local (note that for a split, we want to use the
 		// pre-split one instead because it's larger).
-		desc = mergeTrigger.UpdatedDesc
+		preMergeDesc = desc
+		desc = &mergeTrigger.UpdatedDesc
 	}
 
 	var externalIntents []roachpb.Intent
@@ -418,16 +420,24 @@ func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h ro
 			if len(span.EndKey) == 0 {
 				// For single-key intents, do a KeyAddress-aware check of
 				// whether it's contained in our Range.
-				if !containsKey(desc, span.Key) {
+				if !containsKey(*desc, span.Key) {
 					externalIntents = append(externalIntents, intent)
 					return nil
 				}
-				return engine.MVCCResolveWriteIntent(batch, ms, intent)
+				resolveMs := ms
+				if preMergeDesc != nil && !containsKey(*preMergeDesc, span.Key) {
+					// If this transaction included a merge and the intents
+					// are from the subsumed range, ignore the intent resolution
+					// stats, as they will already be accounted for during the
+					// merge trigger.
+					resolveMs = nil
+				}
+				return engine.MVCCResolveWriteIntent(batch, resolveMs, intent)
 			}
 			// For intent ranges, cut into parts inside and outside our key
 			// range. Resolve locally inside, delegate the rest. In particular,
 			// an intent range for range-local data is correctly considered local.
-			inSpan, outSpans := intersectSpan(span, desc)
+			inSpan, outSpans := intersectSpan(span, *desc)
 			for _, span := range outSpans {
 				outIntent := intent
 				outIntent.Span = span
@@ -482,16 +492,16 @@ func (r *Replica) EndTransaction(batch engine.Engine, ms *engine.MVCCStats, h ro
 
 		if err := func() error {
 			if ct.GetSplitTrigger() != nil {
-				*ms = engine.MVCCStats{} // clear stats, as split will recompute from scratch.
-				if err := r.splitTrigger(batch, ct.SplitTrigger); err != nil {
+				if err := r.splitTrigger(batch, ms, ct.SplitTrigger); err != nil {
 					return err
 				}
+				*ms = engine.MVCCStats{} // clear stats, as split recomputed.
 			}
 			if ct.GetMergeTrigger() != nil {
-				*ms = engine.MVCCStats{} // clear stats, as merge will recompute from scratch.
-				if err := r.mergeTrigger(batch, ct.MergeTrigger); err != nil {
+				if err := r.mergeTrigger(batch, ms, ct.MergeTrigger); err != nil {
 					return err
 				}
+				*ms = engine.MVCCStats{} // clear stats, as merge recomputed.
 			}
 			if ct.GetChangeReplicasTrigger() != nil {
 				if err := r.changeReplicasTrigger(batch, ct.ChangeReplicasTrigger); err != nil {
@@ -1392,26 +1402,11 @@ func (r *Replica) AdminSplit(ctx context.Context, args roachpb.AdminSplitRequest
 	return reply, nil
 }
 
-func (r *Replica) computeStats(d *roachpb.RangeDescriptor, e engine.Engine, nowNanos int64) (engine.MVCCStats, error) {
-	iter := e.NewIterator(nil)
-	defer iter.Close()
-
-	ms := &engine.MVCCStats{}
-	for _, r := range makeReplicatedKeyRanges(d) {
-		msDelta, err := iter.ComputeStats(r.start, r.end, nowNanos)
-		if err != nil {
-			return engine.MVCCStats{}, err
-		}
-		ms.Add(msDelta)
-	}
-	return *ms, nil
-}
-
 // splitTrigger is called on a successful commit of an AdminSplit
 // transaction. It copies the sequence cache for the new range and
 // recomputes stats for both the existing, updated range and the new
 // range.
-func (r *Replica) splitTrigger(batch engine.Engine, split *roachpb.SplitTrigger) error {
+func (r *Replica) splitTrigger(batch engine.Engine, ms *engine.MVCCStats, split *roachpb.SplitTrigger) error {
 	// TODO(tschottdorf): should have an incoming context from the corresponding
 	// EndTransaction, but the plumbing has not been done yet.
 	sp := r.store.Tracer().StartSpan("split")
@@ -1424,32 +1419,40 @@ func (r *Replica) splitTrigger(batch engine.Engine, split *roachpb.SplitTrigger)
 			split.NewDesc.StartKey, split.NewDesc.EndKey, r)
 	}
 
-	// Snapshot original stats from updated range. Split recomputes stats, and
-	// we need to apply the difference to store metrics.
+	// Preserve stats for presplit range and begin computing stats delta
+	// for current transaction.
 	origStats := r.GetMVCCStats()
+	deltaMs := *ms
+
+	// Account for MVCCStats' own contribution to the new range's statistics.
+	if err := deltaMs.AccountForSelf(split.NewDesc.RangeID); err != nil {
+		return util.Errorf("unable to account for MVCCStats's own stats impact: %s", err)
+	}
+
+	// Compute stats for updated range.
+	now := r.store.Clock().Timestamp()
+	leftMs, err := ComputeStatsForRange(&split.UpdatedDesc, batch, now.WallTime)
+	if err != nil {
+		return util.Errorf("unable to compute stats for updated range after split: %s", err)
+	}
+	sp.LogEvent("computed stats for old range")
+	if err := r.stats.SetMVCCStats(batch, leftMs); err != nil {
+		return util.Errorf("unable to write MVCC stats: %s", err)
+	}
 
 	// Copy the last verification timestamp.
 	verifyTS, err := r.GetLastVerificationTimestamp()
 	if err != nil {
 		return util.Errorf("unable to fetch last verification timestamp: %s", err)
 	}
-	if err := engine.MVCCPutProto(batch, nil, keys.RangeLastVerificationTimestampKey(split.NewDesc.RangeID), roachpb.ZeroTimestamp, nil, &verifyTS); err != nil {
+	// TODO(nvanbenschoten) update stats again here when #4710 is resolved
+	// and the LastVerificationTimestampKey is replicated again.
+	if err := engine.MVCCPutProto(batch, nil /* &deltaMs */, keys.RangeLastVerificationTimestampKey(split.NewDesc.RangeID), roachpb.ZeroTimestamp, nil, &verifyTS); err != nil {
 		return util.Errorf("unable to copy last verification timestamp: %s", err)
 	}
 
-	// Compute stats for updated range.
-	now := r.store.Clock().Timestamp()
-	updatedStats, err := r.computeStats(&split.UpdatedDesc, batch, now.WallTime)
-	if err != nil {
-		return util.Errorf("unable to compute stats for updated range after split: %s", err)
-	}
-	sp.LogEvent("computed stats for old range")
-	if err := r.stats.SetMVCCStats(batch, updatedStats); err != nil {
-		return util.Errorf("unable to write MVCC stats: %s", err)
-	}
-
 	// Initialize the new range's sequence cache by copying the original's.
-	seqCount, err := r.sequence.CopyInto(batch, nil /* TODO(nvanbeschoten) */, split.NewDesc.RangeID)
+	seqCount, err := r.sequence.CopyInto(batch, &deltaMs, split.NewDesc.RangeID)
 	if err != nil {
 		// TODO(tschottdorf): ReplicaCorruptionError.
 		return util.Errorf("unable to copy sequence cache to new split range: %s", err)
@@ -1464,12 +1467,12 @@ func (r *Replica) splitTrigger(batch engine.Engine, split *roachpb.SplitTrigger)
 		return err
 	}
 
-	// Compute stats for new range.
-	newStats, err := r.computeStats(&split.NewDesc, batch, now.WallTime)
-	if err != nil {
-		return util.Errorf("unable to compute stats for new range after split: %s", err)
-	}
-	if err = newRng.stats.SetMVCCStats(batch, newStats); err != nil {
+	rightMs := deltaMs
+	// Add in the original range's stats.
+	rightMs.Add(origStats)
+	// Remove stats from the left side of the split.
+	rightMs.Subtract(leftMs)
+	if err = newRng.stats.SetMVCCStats(batch, rightMs); err != nil {
 		return util.Errorf("unable to write MVCC stats: %s", err)
 	}
 	sp.LogEvent("computed stats for new range")
@@ -1491,9 +1494,7 @@ func (r *Replica) splitTrigger(batch engine.Engine, split *roachpb.SplitTrigger)
 		}
 
 		// Update store stats with difference in stats before and after split.
-		newStats.Add(updatedStats)
-		newStats.Subtract(origStats)
-		r.store.metrics.addMVCCStats(newStats)
+		r.store.metrics.addMVCCStats(deltaMs)
 
 		// To avoid leaving the new range unavailable as it waits to elect
 		// its leader, one (and only one) of the nodes should start an
@@ -1632,8 +1633,8 @@ func (r *Replica) AdminMerge(ctx context.Context, args roachpb.AdminMergeRequest
 			Commit: true,
 			InternalCommitTrigger: &roachpb.InternalCommitTrigger{
 				MergeTrigger: &roachpb.MergeTrigger{
-					UpdatedDesc:     updatedLeftDesc,
-					SubsumedRangeID: rightDesc.RangeID,
+					UpdatedDesc:  updatedLeftDesc,
+					SubsumedDesc: rightDesc,
 				},
 			},
 		})
@@ -1648,7 +1649,7 @@ func (r *Replica) AdminMerge(ctx context.Context, args roachpb.AdminMergeRequest
 
 // mergeTrigger is called on a successful commit of an AdminMerge
 // transaction. It recomputes stats for the receiving range.
-func (r *Replica) mergeTrigger(batch engine.Engine, merge *roachpb.MergeTrigger) error {
+func (r *Replica) mergeTrigger(batch engine.Engine, ms *engine.MVCCStats, merge *roachpb.MergeTrigger) error {
 	desc := r.Desc()
 	if !bytes.Equal(desc.StartKey, merge.UpdatedDesc.StartKey) {
 		return util.Errorf("range and updated range start keys do not match: %s != %s",
@@ -1660,29 +1661,52 @@ func (r *Replica) mergeTrigger(batch engine.Engine, merge *roachpb.MergeTrigger)
 			desc.EndKey, merge.UpdatedDesc.EndKey)
 	}
 
-	if merge.SubsumedRangeID <= 0 {
-		return util.Errorf("subsumed  range ID must be provided: %d", merge.SubsumedRangeID)
+	subsumedRangeID := merge.SubsumedDesc.RangeID
+	if subsumedRangeID <= 0 {
+		return util.Errorf("subsumed range ID must be provided: %d", subsumedRangeID)
 	}
 
+	// Compute stats for premerged range, including current transaction.
+	var mergedMs = r.GetMVCCStats()
+	mergedMs.Add(*ms)
+
+	// Add in stats for right half of merge, excluding system-local stats, which
+	// will need to be recomputed.
+	var rightMs engine.MVCCStats
+	if err := engine.MVCCGetRangeStats(batch, subsumedRangeID, &rightMs); err != nil {
+		return err
+	}
+	rightMs.SysBytes, rightMs.SysCount = 0, 0
+	mergedMs.Add(rightMs)
+
 	// Copy the subsumed range's sequence cache to the subsuming one.
-	_, err := r.sequence.CopyFrom(batch, nil /* TODO(nvanbenschoten) */, merge.SubsumedRangeID)
+	_, err := r.sequence.CopyFrom(batch, &mergedMs, subsumedRangeID)
 	if err != nil {
 		return util.Errorf("unable to copy sequence cache to new split range: %s", err)
 	}
 
-	// Remove the subsumed range's metadata.
-	localRangeKeyPrefix := keys.MakeRangeIDPrefix(merge.SubsumedRangeID)
-	if _, err := engine.MVCCDeleteRange(batch, nil, localRangeKeyPrefix, localRangeKeyPrefix.PrefixEnd(), 0, roachpb.ZeroTimestamp, nil, false); err != nil {
+	// Remove the subsumed range's metadata. Note that we don't need to
+	// keep track of stats here, because we already set the right range's
+	// system-local stats contribution to 0.
+	localRangeIDKeyPrefix := keys.MakeRangeIDPrefix(subsumedRangeID)
+	if _, err := engine.MVCCDeleteRange(batch, nil, localRangeIDKeyPrefix, localRangeIDKeyPrefix.PrefixEnd(), 0, roachpb.ZeroTimestamp, nil, false); err != nil {
 		return util.Errorf("cannot remove range metadata %s", err)
 	}
 
-	// Compute stats for updated range.
+	// Add in the stats for the subsumed range's range keys.
+	iter := batch.NewIterator(nil)
+	defer iter.Close()
+	localRangeKeyStart := engine.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(merge.SubsumedDesc.StartKey))
+	localRangeKeyEnd := engine.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(merge.SubsumedDesc.EndKey))
 	now := r.store.Clock().Timestamp()
-	ms, err := r.computeStats(&merge.UpdatedDesc, batch, now.WallTime)
+	msRange, err := iter.ComputeStats(localRangeKeyStart, localRangeKeyEnd, now.WallTime)
 	if err != nil {
-		return util.Errorf("unable to compute stats for the range after merge: %s", err)
+		return util.Errorf("unable to compute subsumed range's local stats: %s", err)
 	}
-	if err = r.stats.SetMVCCStats(batch, ms); err != nil {
+	mergedMs.Add(msRange)
+
+	// Set stats for updated range.
+	if err = r.stats.SetMVCCStats(batch, mergedMs); err != nil {
 		return util.Errorf("unable to write MVCC stats: %s", err)
 	}
 
@@ -1695,7 +1719,7 @@ func (r *Replica) mergeTrigger(batch engine.Engine, merge *roachpb.MergeTrigger)
 	r.mu.Unlock()
 
 	batch.Defer(func() {
-		if err := r.store.MergeRange(r, merge.UpdatedDesc.EndKey, merge.SubsumedRangeID); err != nil {
+		if err := r.store.MergeRange(r, merge.UpdatedDesc.EndKey, subsumedRangeID); err != nil {
 			// Our in-memory state has diverged from the on-disk state.
 			log.Fatalf("failed to update store after merging range: %s", err)
 		}

--- a/storage/replica_data_iter.go
+++ b/storage/replica_data_iter.go
@@ -59,10 +59,11 @@ func makeReplicaKeyRanges(d *roachpb.RangeDescriptor, metaFunc func(roachpb.Rang
 	if d.StartKey.Equal(roachpb.RKeyMin) {
 		dataStartKey = keys.LocalMax
 	}
+	sysRangeIDKey := metaFunc(d.RangeID)
 	return []keyRange{
 		{
-			start: engine.MakeMVCCMetadataKey(metaFunc(d.RangeID)),
-			end:   engine.MakeMVCCMetadataKey(metaFunc(d.RangeID + 1)),
+			start: engine.MakeMVCCMetadataKey(sysRangeIDKey),
+			end:   engine.MakeMVCCMetadataKey(sysRangeIDKey.PrefixEnd()),
 		},
 		{
 			start: engine.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(d.StartKey)),

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -272,11 +272,11 @@ func (r *Replica) loadAppliedIndexLocked(eng engine.Engine) (uint64, error) {
 }
 
 // setAppliedIndex persists a new applied index.
-func setAppliedIndex(eng engine.Engine, rangeID roachpb.RangeID, appliedIndex uint64) error {
+func setAppliedIndex(eng engine.Engine, ms *engine.MVCCStats, rangeID roachpb.RangeID, appliedIndex uint64) error {
 	var value roachpb.Value
 	value.SetInt(int64(appliedIndex))
 
-	return engine.MVCCPut(eng, nil, /* stats */
+	return engine.MVCCPut(eng, ms,
 		keys.RaftAppliedIndexKey(rangeID),
 		roachpb.ZeroTimestamp,
 		value,

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2810,17 +2810,24 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, pErr := client.SendWrapped(tc.Sender(), tc.rng.context(), &pArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
-	expMS := engine.MVCCStats{LiveBytes: 25, KeyBytes: 14, ValBytes: 11, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 52, SysCount: 1, LastUpdateNanos: 0}
-	verifyRangeStats(tc.engine, tc.rng.RangeID, expMS, t)
+	expMS := engine.MVCCStats{LiveBytes: 25, KeyBytes: 14, ValBytes: 11, IntentBytes: 0, LiveCount: 1, KeyCount: 1, ValCount: 1, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 81, SysCount: 2, LastUpdateNanos: 0}
 
 	// Put a 2nd value transactionally.
 	pArgs = putArgs([]byte("b"), []byte("value2"))
-	txn := &roachpb.Transaction{TxnMeta: roachpb.TxnMeta{ID: uuid.NewV4(), Timestamp: tc.clock.Now()}, Sequence: 1}
+
+	// Consistent UUID needed for a deterministic SysBytes value. This is because
+	// a random UUID could have a 0x00 byte that would be escaped by the encoding,
+	// increasing the encoded size and throwing off statistics verification.
+	uuid, err := uuid.FromString("ea5b9590-a157-421b-8b93-a4caa2c41137")
+	if err != nil {
+		t.Fatal(err)
+	}
+	txn := &roachpb.Transaction{TxnMeta: roachpb.TxnMeta{ID: uuid, Timestamp: tc.clock.Now()}, Sequence: 1}
 
 	if _, pErr := client.SendWrappedWith(tc.Sender(), tc.rng.context(), roachpb.Header{Txn: txn}, &pArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 92, KeyBytes: 28, ValBytes: 64, IntentBytes: 23, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1, IntentAge: 0, GCBytesAge: 0, SysBytes: 52, SysCount: 1, LastUpdateNanos: 0}
+	expMS = engine.MVCCStats{LiveBytes: 92, KeyBytes: 28, ValBytes: 64, IntentBytes: 23, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 1, IntentAge: 0, GCBytesAge: 0, SysBytes: 142, SysCount: 3, LastUpdateNanos: 0}
 	verifyRangeStats(tc.engine, tc.rng.RangeID, expMS, t)
 
 	// Resolve the 2nd value.
@@ -2835,7 +2842,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, pErr := client.SendWrapped(tc.Sender(), tc.rng.context(), rArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 50, KeyBytes: 28, ValBytes: 22, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 52, SysCount: 1, LastUpdateNanos: 0}
+	expMS = engine.MVCCStats{LiveBytes: 50, KeyBytes: 28, ValBytes: 22, IntentBytes: 0, LiveCount: 2, KeyCount: 2, ValCount: 2, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 81, SysCount: 2, LastUpdateNanos: 0}
 	verifyRangeStats(tc.engine, tc.rng.RangeID, expMS, t)
 
 	// Delete the 1st value.
@@ -2844,7 +2851,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	if _, pErr := client.SendWrapped(tc.Sender(), tc.rng.context(), &dArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
-	expMS = engine.MVCCStats{LiveBytes: 25, KeyBytes: 40, ValBytes: 22, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 52, SysCount: 1, LastUpdateNanos: 0}
+	expMS = engine.MVCCStats{LiveBytes: 25, KeyBytes: 40, ValBytes: 22, IntentBytes: 0, LiveCount: 1, KeyCount: 2, ValCount: 3, IntentCount: 0, IntentAge: 0, GCBytesAge: 0, SysBytes: 81, SysCount: 2, LastUpdateNanos: 0}
 	verifyRangeStats(tc.engine, tc.rng.RangeID, expMS, t)
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -985,7 +985,9 @@ func (s *Store) BootstrapRange(initialValues []roachpb.KeyValue) error {
 		return err
 	}
 	// Verification timestamp.
-	if err := engine.MVCCPutProto(batch, ms, keys.RangeLastVerificationTimestampKey(desc.RangeID), roachpb.ZeroTimestamp, nil, &now); err != nil {
+	// TODO(nvanbenschoten) update stats again here when #4710 is resolved
+	// and the LastVerificationTimestampKey is replicated again.
+	if err := engine.MVCCPutProto(batch, nil /* ms */, keys.RangeLastVerificationTimestampKey(desc.RangeID), roachpb.ZeroTimestamp, nil, &now); err != nil {
 		return err
 	}
 	// Range addressing for meta2.
@@ -2021,7 +2023,7 @@ func (s *Store) ComputeMVCCStatsTest() (engine.MVCCStats, error) {
 	now := s.Clock().PhysicalNow()
 	visitor.Visit(func(r *Replica) bool {
 		var stats engine.MVCCStats
-		stats, err = r.computeStats(r.Desc(), s.Engine(), now)
+		stats, err = ComputeStatsForRange(r.Desc(), s.Engine(), now)
 		if err != nil {
 			return false
 		}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -225,7 +225,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 
 	// Stats should agree with a recomputation.
 	now := r.store.Clock().Timestamp()
-	if ms, err := r.computeStats(r.Desc(), eng, now.WallTime); err != nil {
+	if ms, err := ComputeStatsForRange(r.Desc(), eng, now.WallTime); err != nil {
 		t.Errorf("failure computing range's stats: %s", err)
 	} else if ms != rs {
 		t.Errorf("expected range's stats to agree with recomputation: got\n%+v\nrecomputed\n%+v", ms, rs)


### PR DESCRIPTION
Closes #4322. Fixes #4478 and #4454.

This change primarily focuses on arithmetically computing the new
`MVCCStats` in the `mergeTrigger` and `splitTrigger` for performance
reasons. Both of these optimizations allow for improved performance
because the entire statistics objects for all keys in new ranges no
longer need to be recomputed from scratch. The perf boost resulting from
this change is shown below.

In addition, the change includes a number of fixes to improve the
consistency of `MVCCStats` for ranges in general. This includes fixes
like updating stats on changes to the `SequenceCache` and the Raft applied
index. It also includes a number of new tests which should help enforce
this consistency.
#### Performance improvement:

```
name               old time/op  new time/op  delta
StoreRangeMerge-4  19.5ms ± 2%  15.4ms ± 2%  -21.01%    (p=0.000 n=8+9)
StoreRangeSplit-4  15.0ms ± 1%  13.9ms ± 2%   -7.58%  (p=0.000 n=10+10)
```

Note that memory stats are not provided because they seemed to depend
linearly on the operation running time (sleeping in the middle of
the benchmark loop to double the duration of each op doubled the
reported memory usage), so they were deemed misleading and inconclusive.
I believe the issue had something to do with client heartbeats but
briefly profiling the issue did not reveal any clear leads.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4697)

<!-- Reviewable:end -->
