### PR TITLE
Improve acceptance test happiness

### DIFF
--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -121,16 +121,24 @@ func getConfigs() []cluster.TestConfig {
 func runTestOnConfigs(t *testing.T, testFunc func(*testing.T, cluster.Cluster, cluster.TestConfig)) {
 	cfgs := getConfigs()
 	for _, cfg := range cfgs {
-		cluster := StartCluster(t, cfg)
-		testFunc(t, cluster, cfg)
-		cluster.AssertAndStop(t)
+		func() {
+			cluster := StartCluster(t, cfg)
+			defer cluster.AssertAndStop(t)
+			testFunc(t, cluster, cfg)
+		}()
 	}
 }
 
 // StartCluster starts a cluster from the relevant flags. All test clusters
 // should be created through this command since it sets up the logging in a
 // unified way.
-func StartCluster(t *testing.T, cfg cluster.TestConfig) cluster.Cluster {
+func StartCluster(t *testing.T, cfg cluster.TestConfig) (c cluster.Cluster) {
+	var completed bool
+	defer func() {
+		if !completed && c != nil {
+			c.AssertAndStop(t)
+		}
+	}()
 	if !*flagRemote {
 		logDir := *flagLogDir
 		if logDir != "" {
@@ -140,10 +148,13 @@ func StartCluster(t *testing.T, cfg cluster.TestConfig) cluster.Cluster {
 		}
 		l := cluster.CreateLocal(cfg, logDir, stopper)
 		l.Start()
+		c = l
 		checkRangeReplication(t, l, 20*time.Second)
+		completed = true
 		return l
 	}
 	f := farmer(t)
+	c = f
 	if err := f.Resize(*flagNodes, 0); err != nil {
 		t.Fatal(err)
 	}
@@ -152,6 +163,7 @@ func StartCluster(t *testing.T, cfg cluster.TestConfig) cluster.Cluster {
 		t.Fatalf("cluster not ready in time: %v", err)
 	}
 	checkRangeReplication(t, f, 20*time.Second)
+	completed = true
 	return f
 }
 

--- a/util/testing.go
+++ b/util/testing.go
@@ -37,6 +37,25 @@ type Tester interface {
 	Fatalf(format string, args ...interface{})
 }
 
+type panicTesterImpl struct{}
+
+// PanicTester is a Tester which panics.
+var PanicTester Tester
+
+func (panicTesterImpl) Failed() bool { return false }
+
+func (panicTesterImpl) Error(args ...interface{}) {
+	panic(fmt.Sprint(args...))
+}
+
+func (pt panicTesterImpl) Fatal(args ...interface{}) {
+	pt.Error(args...)
+}
+
+func (panicTesterImpl) Fatalf(format string, args ...interface{}) {
+	panic(fmt.Sprintf(format, args...))
+}
+
 // tempUnixFile creates a temporary file for use with a unix domain socket.
 // TODO(bdarnell): use TempDir instead to make this atomic.
 func tempUnixFile() string {


### PR DESCRIPTION
- Clean up nodes even on failure
- Set a log level that actually prints things
- Create error log when container fails, even if no LogDir set

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4698)

<!-- Reviewable:end -->
