### PR TITLE
storage: Use RangeGroup to remove superseded timestamp intervals in TimestampCache

### DIFF
--- a/storage/timestamp_cache_test.go
+++ b/storage/timestamp_cache_test.go
@@ -436,3 +436,26 @@ func TestTimestampCacheReadVsWrite(t *testing.T) {
 		t.Errorf("expected %s %s; got %s %s", ts2, tc.lowWater, rTS, wTS)
 	}
 }
+
+func BenchmarkTimestampCacheInsertion(b *testing.B) {
+	manual := hlc.NewManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	tc := NewTimestampCache(clock)
+
+	for i := 0; i < b.N; i++ {
+		tc.Clear(clock)
+		manual.Increment(1)
+
+		cdTS := clock.Now()
+		tc.Add(roachpb.Key("c"), roachpb.Key("d"), cdTS, nil, true)
+
+		beTS := clock.Now()
+		tc.Add(roachpb.Key("b"), roachpb.Key("e"), beTS, nil, true)
+
+		adTS := clock.Now()
+		tc.Add(roachpb.Key("a"), roachpb.Key("d"), adTS, nil, true)
+
+		cfTS := clock.Now()
+		tc.Add(roachpb.Key("c"), roachpb.Key("f"), cfTS, nil, true)
+	}
+}

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -366,11 +366,10 @@ type IntervalCache struct {
 
 	// The fields below are used to avoid allocations during get, del and
 	// GetOverlaps.
-	getID      uintptr
-	getEntry   *Entry
-	tmpEntry   Entry
-	overlapKey IntervalKey
-	overlaps   []Overlap
+	getID    uintptr
+	getEntry *Entry
+	tmpEntry Entry
+	overlaps []Overlap
 }
 
 // IntervalKey provides uniqueness as well as key interval.
@@ -474,11 +473,8 @@ type Overlap struct {
 // GetOverlaps returns a slice of values which overlap the specified
 // interval. The slice is only valid until the next call to GetOverlaps.
 func (ic *IntervalCache) GetOverlaps(start, end []byte) []Overlap {
-	ic.overlapKey.Range = interval.Range{
-		Start: interval.Comparable(start),
-		End:   interval.Comparable(end),
-	}
-	ic.tree.DoMatching(ic.doOverlaps, ic.overlapKey.Range)
+	r := interval.Range{Start: start, End: end}
+	ic.tree.DoMatching(ic.doOverlaps, r)
 	overlaps := ic.overlaps
 	ic.overlaps = ic.overlaps[:0]
 	return overlaps

--- a/util/interval/interval.go
+++ b/util/interval/interval.go
@@ -63,6 +63,11 @@ func (r Range) OverlapExclusive(other Range) bool {
 	return r.End.Compare(other.Start) > 0 && r.Start.Compare(other.End) < 0
 }
 
+// Equal returns whether the two ranges are equal.
+func (r Range) Equal(other Range) bool {
+	return r.End.Equal(other.Start) && r.Start.Equal(other.End)
+}
+
 // An Interface is a type that can be inserted into a Tree.
 type Interface interface {
 	Range() Range
@@ -84,6 +89,13 @@ type Comparable []byte
 //
 func (c Comparable) Compare(o Comparable) int {
 	return bytes.Compare(c, o)
+}
+
+// Equal returns a boolean indicating if the given comparables are equal to
+// each other. Note that this has measurably better performance than
+// Compare() == 0, so it should be used when only equality state is needed.
+func (c Comparable) Equal(o Comparable) bool {
+	return bytes.Equal(c, o)
 }
 
 // A Node represents a node in a Tree.

--- a/util/interval/range_group_test.go
+++ b/util/interval/range_group_test.go
@@ -315,3 +315,23 @@ func getRandomByteSlice(t *testing.T, n int) []byte {
 	}
 	return s
 }
+
+func BenchmarkRangeList(b *testing.B) {
+	benchmarkRangeGroup(b, NewRangeList())
+}
+
+func BenchmarkRangeTree(b *testing.B) {
+	benchmarkRangeGroup(b, NewRangeTree())
+}
+
+func benchmarkRangeGroup(b *testing.B, rg RangeGroup) {
+	for i := 0; i < b.N; i++ {
+		rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}})
+		rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}})
+		rg.Add(Range{Start: []byte{0x00}, End: []byte{0x02}})
+		rg.Add(Range{Start: []byte{0x01}, End: []byte{0x06}})
+		rg.Add(Range{Start: []byte{0x05}, End: []byte{0x15}})
+		rg.Add(Range{Start: []byte{0x25}, End: []byte{0x30}})
+		rg.Clear()
+	}
+}


### PR DESCRIPTION
Fixes #4616.

Previously, we only removed timestamp intervals from the `TimestampCache`
during addition when a newer timestamp interval itself fully superseded
the earlier timestamp interval. This failed to take into account that groups
of newer timestamp intervals could combine to supersede an older timestamp
together, which could then be removed. By using a `RangeGroup` in
a similar way to how the `CommandQueue` uses one during insertion, we are
able to more precisely determine when a timestamp interval is still contributing
to the cache's maximum timestamp for some segment of the keyspace, and if it's
not, remove it on the spot instead of waiting for the `MinTSCacheWindow` (currently
set to 10 seconds) before evicting the interval.

This missing optimization during `TimestampCache` insertion meant that the
`TimestampCache` grew to extreme sizes, often accounting for over **300 MB**
per-node, which meant that it accounted for about **88%** of all memory usage
for Cockroach nodes. With this new optimization now being diligent about removing
timestamp intervals from the timestamp cache as soon as they can be removed, we
are able to reduce the upper bound for the per-node `TimestampCache` size to
about **9 MB**, a **33 x** reduction in size. This means that we are able to
reduce the total Cockroach node memory usage from around **360 MB** to around
**70 MB**!

Because this optimization does more work during `TimestampCache` insertion, it
is expected that it will hurt performance slightly. That said, if benchmarks are
run as is, they will lead to misleading/incorrect results. This is because the
`MinTSCacheWindow` is currently set to 10 seconds, meaning that pre-optimization
benchmarks never had to perform costly timestamp cache deletions during eviction
because they always finished before this time. To work around this, I modified
all SQL benchmarks to clear the `TimestampCache` after each iteration to give a more
even comparison between the cost of evicting timestamp intervals during insertion
vs. evicting them after the `MinTSCacheWindow`. While this helps make the benchmarks
more accurate, it still doesn't make them fully representative of this changes impact
on real-world performance. Keep in mind while looking at them that after the 10 seconds,
this `MinTSCacheWindow` eviction was previously still happening synchronously during
timestamp insertion, it was just pushing the cost of deletion 10 seconds into the future.

Perf Impact:

```
name                      old time/op    new time/op    delta
Bank_Cockroach-4             366µs ±13%     344µs ± 7%   -6.06%        (p=0.019 n=10+10)
Select1_Cockroach-4         56.7µs ± 4%    56.9µs ± 4%     ~            (p=0.780 n=9+10)
Select2_Cockroach-4          801µs ± 1%     829µs ± 2%   +3.52%          (p=0.000 n=9+9)
Insert1_Cockroach-4          378µs ± 1%     380µs ± 1%     ~             (p=0.222 n=9+9)
Insert10_Cockroach-4         685µs ± 1%     698µs ± 1%   +1.87%          (p=0.001 n=8+9)
Insert100_Cockroach-4       3.56ms ± 1%    3.63ms ± 2%   +1.93%         (p=0.002 n=9+10)
Insert1000_Cockroach-4      35.3ms ± 1%    35.8ms ± 3%     ~            (p=0.079 n=10+9)
Update1_Cockroach-4          568µs ± 3%     583µs ± 6%     ~            (p=0.065 n=9+10)
Update10_Cockroach-4        1.09ms ± 1%    1.14ms ± 4%   +5.13%         (p=0.000 n=8+10)
Update100_Cockroach-4       6.47ms ± 3%    6.66ms ± 1%   +2.84%         (p=0.000 n=10+9)
Update1000_Cockroach-4      60.5ms ± 3%    67.6ms ± 2%  +11.77%         (p=0.000 n=9+10)
Delete1_Cockroach-4          633µs ±16%     624µs ± 3%     ~           (p=0.353 n=10+10)
Delete10_Cockroach-4        1.71ms ± 4%    1.77ms ± 4%   +3.47%        (p=0.003 n=10+10)
Delete100_Cockroach-4       13.7ms ± 3%    14.5ms ± 2%   +6.25%         (p=0.000 n=10+9)
Delete1000_Cockroach-4       129ms ± 6%     138ms ± 2%   +6.96%        (p=0.000 n=10+10)
Scan1_Cockroach-4            190µs ± 5%     196µs ± 2%   +3.12%        (p=0.003 n=10+10)
Scan10_Cockroach-4           223µs ± 1%     232µs ± 3%   +3.79%         (p=0.000 n=9+10)
Scan100_Cockroach-4          484µs ± 2%     511µs ± 3%   +5.64%        (p=0.000 n=10+10)
Scan1000_Cockroach-4        2.96ms ± 1%    3.16ms ± 2%   +6.51%        (p=0.000 n=10+10)
PgbenchExec_Cockroach-4     2.69ms ± 4%    2.85ms ± 4%   +5.98%        (p=0.000 n=10+10)
PgbenchQuery_Cockroach-4    3.09ms ± 3%    3.26ms ±10%   +5.34%        (p=0.009 n=10+10)

name                      old alloc/op   new alloc/op   delta
Bank_Cockroach-4            68.4kB ± 0%    68.7kB ± 1%     ~            (p=0.167 n=8+10)
Select1_Cockroach-4         3.68kB ± 0%    3.68kB ± 0%     ~             (p=0.247 n=8+9)
Select2_Cockroach-4         74.0kB ± 0%    74.2kB ± 0%   +0.26%        (p=0.000 n=10+10)
Insert1_Cockroach-4         21.4kB ± 0%    21.6kB ± 0%   +0.89%        (p=0.000 n=10+10)
Insert10_Cockroach-4        65.3kB ± 0%    67.2kB ± 0%   +2.92%        (p=0.000 n=10+10)
Insert100_Cockroach-4        503kB ± 0%     523kB ± 0%   +3.85%         (p=0.000 n=9+10)
Insert1000_Cockroach-4      4.52MB ± 1%    4.72MB ± 1%   +4.38%        (p=0.000 n=10+10)
Update1_Cockroach-4         34.6kB ± 0%    35.0kB ± 0%   +1.15%        (p=0.000 n=10+10)
Update10_Cockroach-4         102kB ± 0%     106kB ± 0%   +3.81%        (p=0.000 n=10+10)
Update100_Cockroach-4        748kB ± 0%     790kB ± 0%   +5.59%         (p=0.000 n=9+10)
Update1000_Cockroach-4      6.41MB ± 0%    7.03MB ± 1%   +9.69%         (p=0.000 n=8+10)
Delete1_Cockroach-4         27.9kB ± 0%    28.1kB ± 0%   +0.93%        (p=0.000 n=10+10)
Delete10_Cockroach-4        72.2kB ± 0%    76.1kB ± 0%   +5.44%        (p=0.000 n=10+10)
Delete100_Cockroach-4        513kB ± 0%     560kB ± 0%   +9.10%         (p=0.000 n=9+10)
Delete1000_Cockroach-4      4.62MB ± 1%    5.11MB ± 2%  +10.62%        (p=0.000 n=10+10)
Scan1_Cockroach-4           12.3kB ± 0%    12.5kB ± 0%   +1.66%          (p=0.000 n=9+9)
Scan10_Cockroach-4          15.9kB ± 0%    16.1kB ± 0%   +1.20%         (p=0.000 n=9+10)
Scan100_Cockroach-4         45.2kB ± 0%    45.3kB ± 0%   +0.41%         (p=0.000 n=9+10)
Scan1000_Cockroach-4         298kB ± 0%     298kB ± 0%   +0.07%         (p=0.000 n=10+9)
PgbenchExec_Cockroach-4      165kB ± 8%     170kB ± 7%     ~           (p=0.052 n=10+10)
PgbenchQuery_Cockroach-4     207kB ± 0%     212kB ± 0%   +2.49%          (p=0.000 n=9+9)

name                      old allocs/op  new allocs/op  delta
Bank_Cockroach-4             1.68k ± 0%     1.68k ± 0%   +0.27%         (p=0.006 n=8+10)
Select1_Cockroach-4           90.0 ± 0%      90.0 ± 0%     ~     (all samples are equal)
Select2_Cockroach-4          2.64k ± 0%     2.65k ± 0%   +0.10%         (p=0.000 n=10+8)
Insert1_Cockroach-4            338 ± 0%       341 ± 0%   +0.83%         (p=0.000 n=10+7)
Insert10_Cockroach-4           889 ± 0%       919 ± 0%   +3.37%          (p=0.001 n=7+7)
Insert100_Cockroach-4        6.16k ± 0%     6.46k ± 0%   +4.89%         (p=0.000 n=10+6)
Insert1000_Cockroach-4       58.8k ± 0%     61.9k ± 0%   +5.18%        (p=0.000 n=10+10)
Update1_Cockroach-4            689 ± 0%       696 ± 0%   +0.91%        (p=0.000 n=10+10)
Update10_Cockroach-4         1.42k ± 0%     1.49k ± 0%   +4.26%        (p=0.000 n=10+10)
Update100_Cockroach-4        8.35k ± 0%     9.00k ± 0%   +7.73%         (p=0.000 n=9+10)
Update1000_Cockroach-4       72.2k ± 0%     81.6k ± 0%  +12.95%         (p=0.000 n=8+10)
Delete1_Cockroach-4            540 ± 0%       547 ± 0%   +1.33%        (p=0.000 n=10+10)
Delete10_Cockroach-4         1.19k ± 0%     1.29k ± 0%   +7.61%        (p=0.000 n=10+10)
Delete100_Cockroach-4        7.44k ± 0%     8.42k ± 0%  +13.19%         (p=0.000 n=9+10)
Delete1000_Cockroach-4       69.6k ± 1%     79.7k ± 1%  +14.51%        (p=0.000 n=10+10)
Scan1_Cockroach-4              261 ± 0%       264 ± 0%   +1.30%         (p=0.000 n=7+10)
Scan10_Cockroach-4             342 ± 0%       344 ± 0%   +0.88%        (p=0.000 n=10+10)
Scan100_Cockroach-4          1.07k ± 0%     1.07k ± 0%   +0.25%         (p=0.000 n=8+10)
Scan1000_Cockroach-4         8.28k ± 0%     8.28k ± 0%   +0.04%         (p=0.000 n=9+10)
PgbenchExec_Cockroach-4      3.18k ± 7%     3.25k ± 7%     ~           (p=0.052 n=10+10)
PgbenchQuery_Cockroach-4     3.83k ± 0%     3.91k ± 0%   +2.09%          (p=0.000 n=8+9)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4699)

<!-- Reviewable:end -->
