### PR TITLE
acceptance: introduce partition nemesis in acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ dupl:
 .PHONY: check
 check:
 	@echo "checking for time.Now calls (use timeutil.Now() instead)"
-	@! git grep -lF 'time\.Now' -- '*.go' | grep -vE '^util/(log|timeutil)/\w+\.go$$'
+	@! git grep -lF 'time.Now' -- '*.go' | grep -vE '^util/(log|timeutil)/\w+\.go$$'
 	@echo "checking for os.Getenv calls (use envutil.EnvOrDefault*() instead)"
 	@! git grep -lF 'os.Getenv' -- '*.go' | grep -vE '^((util/(log|envutil))|acceptance(/.*)?)/\w+\.go$$'
 	@echo "checking for proto.Clone calls (use protoutil.Clone instead)"

--- a/Makefile
+++ b/Makefile
@@ -186,15 +186,15 @@ dupl:
 .PHONY: check
 check:
 	@echo "checking for time.Now calls (use timeutil.Now() instead)"
-	@! git grep -E 'time\.Now' -- '*.go' | grep -vE '^util/(log|timeutil)/\w+\.go:'
+	@! git grep -lF 'time\.Now' -- '*.go' | grep -vE '^util/(log|timeutil)/\w+\.go$$'
 	@echo "checking for os.Getenv calls (use envutil.EnvOrDefault*() instead)"
-	@! git grep -e 'os\.Getenv' -- '*.go' | grep -vE '^(util/(log|envutil)|acceptance/.*)/\w+\.go:'
+	@! git grep -lF 'os.Getenv' -- '*.go' | grep -vE '^((util/(log|envutil))|acceptance(/.*)?)/\w+\.go$$'
 	@echo "checking for proto.Clone calls (use protoutil.Clone instead)"
 	@! git grep -E '\.Clone\([^)]+\)' -- '*.go' | grep -vF 'protoutil.Clone' | grep -vE '^util/protoutil/clone(_test)?\.go:'
 	@echo "checking for proto.Marshal calls (use protoutil.Marshal instead)"
 	@! git grep -E '\.Marshal\([^)]+\)' -- '*.go' | grep -vE '(json|yaml|protoutil)\.Marshal' | grep -vE '^util/protoutil/marshal(_test)?\.go:'
 	@echo "checking for grpc.NewServer calls (use rpc.NewServer instead)"
-	@! git grep -E 'grpc\.NewServer\(\)' -- '*.go' | grep -vE '^rpc/context(_test)?\.go:'
+	@! git grep -lF 'grpc.NewServer()' -- '*.go' | grep -vE '^rpc/context(_test)?\.go$$'
 	@echo "checking for missing defer leaktest.AfterTest"
 	@util/leaktest/check-leaktest.sh
 	@echo "misspell"

--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -309,9 +309,6 @@ func TestClusterRecovery(t *testing.T) {
 
 func testClusterRecoveryInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
 	num := c.NumNodes()
-	if num <= 0 {
-		t.Fatalf("%d nodes in cluster", num)
-	}
 
 	// One client for each node.
 	initBank(t, c.PGUrl(0))
@@ -369,8 +366,8 @@ func TestNodeRestart(t *testing.T) {
 
 func testNodeRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
 	num := c.NumNodes()
-	if num <= 0 {
-		t.Fatalf("%d nodes in cluster", num)
+	if minNum := 3; num < minNum {
+		t.Skipf("need at least %d nodes, got %d", minNum, num)
 	}
 
 	// One client for each node.

--- a/acceptance/cluster/cluster.go
+++ b/acceptance/cluster/cluster.go
@@ -17,6 +17,7 @@
 package cluster
 
 import (
+	"net"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -34,6 +35,8 @@ type Cluster interface {
 	NewClient(*testing.T, int) (*client.DB, *stop.Stopper)
 	// PGUrl returns a URL string for the given node postgres server.
 	PGUrl(int) string
+	// InternalIP returns the address used for inter-node communication.
+	InternalIP(i int) net.IP
 	// Assert verifies that the cluster state is as expected (i.e. no unexpected
 	// restarts or node deaths occurred). Tests can call this periodically to
 	// ascertain cluster health.
@@ -41,6 +44,8 @@ type Cluster interface {
 	// AssertAndStop performs the same test as Assert but then proceeds to
 	// dismantle the cluster.
 	AssertAndStop(*testing.T)
+	// ExecRoot executes the given command with super-user privileges.
+	ExecRoot(i int, cmd []string) error
 	// Kill terminates the cockroach process running on the given node number.
 	// The given integer must be in the range [0,NumNodes()-1].
 	Kill(int) error

--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -389,14 +389,15 @@ type retryingDockerClient struct {
 //
 // For example, retrying a container removal could fail on the second attempt
 // if the first request timed out (but still executed).
-func (cli retryingDockerClient) retry(
+func retry(
 	ctx context.Context,
+	attempts int,
 	timeout time.Duration,
 	name string,
 	retryErrorsRE string,
 	f func(ctx context.Context) error,
 ) error {
-	for i := 0; i < cli.attempts; i++ {
+	for i := 0; i < attempts; i++ {
 		timeoutCtx, _ := context.WithTimeout(ctx, timeout)
 		err := f(timeoutCtx)
 		if err != nil {
@@ -417,7 +418,7 @@ func (cli retryingDockerClient) retry(
 		}
 		return err
 	}
-	return fmt.Errorf("%s: exceeded %d tries with a %s timeout", name, cli.attempts, cli.timeout)
+	return fmt.Errorf("%s: exceeded %d tries with a %s timeout", name, attempts, timeout)
 }
 
 func (cli retryingDockerClient) ContainerCreate(
@@ -428,7 +429,7 @@ func (cli retryingDockerClient) ContainerCreate(
 	containerName string,
 ) (types.ContainerCreateResponse, error) {
 	var ret types.ContainerCreateResponse
-	err := cli.retry(ctx, cli.timeout,
+	err := retry(ctx, cli.attempts, cli.timeout,
 		"ContainerCreate", matchNone,
 		func(timeoutCtx context.Context) error {
 			var err error
@@ -440,21 +441,21 @@ func (cli retryingDockerClient) ContainerCreate(
 }
 
 func (cli retryingDockerClient) ContainerStart(ctx context.Context, containerID string) error {
-	return cli.retry(ctx, cli.timeout, "ContainerStart", matchNone,
+	return retry(ctx, cli.attempts, cli.timeout, "ContainerStart", matchNone,
 		func(timeoutCtx context.Context) error {
 			return cli.resilientDockerClient.ContainerStart(timeoutCtx, containerID)
 		})
 }
 
 func (cli retryingDockerClient) ContainerRemove(ctx context.Context, options types.ContainerRemoveOptions) error {
-	return cli.retry(ctx, cli.timeout, "ContainerRemove", "No such container",
+	return retry(ctx, cli.attempts, cli.timeout, "ContainerRemove", "No such container",
 		func(timeoutCtx context.Context) error {
 			return cli.resilientDockerClient.ContainerRemove(timeoutCtx, options)
 		})
 }
 
 func (cli retryingDockerClient) ContainerKill(ctx context.Context, containerID, signal string) error {
-	return cli.retry(ctx, cli.timeout, "ContainerKill",
+	return retry(ctx, cli.attempts, cli.timeout, "ContainerKill",
 		"Container .* is not running",
 		func(timeoutCtx context.Context) error {
 			return cli.resilientDockerClient.ContainerKill(timeoutCtx, containerID, signal)
@@ -463,7 +464,7 @@ func (cli retryingDockerClient) ContainerKill(ctx context.Context, containerID, 
 
 func (cli retryingDockerClient) ContainerWait(ctx context.Context, containerID string) (int, error) {
 	var ret int
-	return ret, cli.retry(ctx, cli.timeout, "ContainerWait", matchNone,
+	return ret, retry(ctx, cli.attempts, cli.timeout, "ContainerWait", matchNone,
 		func(timeoutCtx context.Context) error {
 			var err error
 			ret, err = cli.resilientDockerClient.ContainerWait(timeoutCtx, containerID)
@@ -476,7 +477,7 @@ func (cli retryingDockerClient) ImageList(
 	ctx context.Context, options types.ImageListOptions,
 ) ([]types.Image, error) {
 	var ret []types.Image
-	return ret, cli.retry(ctx, cli.timeout, "ImageList", matchNone,
+	return ret, retry(ctx, cli.attempts, cli.timeout, "ImageList", matchNone,
 		func(timeoutCtx context.Context) error {
 			var err error
 			ret, err = cli.resilientDockerClient.ImageList(timeoutCtx, options)
@@ -494,7 +495,7 @@ func (cli retryingDockerClient) ImagePull(
 		timeout = minTimeout
 	}
 	var ret io.ReadCloser
-	return ret, cli.retry(ctx, timeout, "ImagePull", matchNone,
+	return ret, retry(ctx, cli.attempts, timeout, "ImagePull", matchNone,
 		func(timeoutCtx context.Context) error {
 			var err error
 			ret, err = cli.resilientDockerClient.ImagePull(timeoutCtx, options, privilegeFunc)

--- a/acceptance/cluster/stdcopy.go
+++ b/acceptance/cluster/stdcopy.go
@@ -1,0 +1,181 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Source: github.com/docker/docker/pkg/stdcopy
+
+package cluster
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// StdType is the type of standard stream
+// a writer can multiplex to.
+type StdType byte
+
+const (
+	// Stdin represents standard input stream type.
+	Stdin StdType = iota
+	// Stdout represents standard output stream type.
+	Stdout
+	// Stderr represents standard error steam type.
+	Stderr
+
+	stdWriterPrefixLen = 8
+	stdWriterFdIndex   = 0
+	stdWriterSizeIndex = 4
+
+	startingBufLen = 32*1024 + stdWriterPrefixLen + 1
+)
+
+// stdWriter is wrapper of io.Writer with extra customized info.
+type stdWriter struct {
+	io.Writer
+	prefix byte
+}
+
+// Write sends the buffer to the underneath writer.
+// It insert the prefix header before the buffer,
+// so stdcopy.StdCopy knows where to multiplex the output.
+// It makes stdWriter to implement io.Writer.
+func (w *stdWriter) Write(buf []byte) (n int, err error) {
+	if w == nil || w.Writer == nil {
+		return 0, errors.New("Writer not instantiated")
+	}
+	if buf == nil {
+		return 0, nil
+	}
+
+	header := [stdWriterPrefixLen]byte{stdWriterFdIndex: w.prefix}
+	binary.BigEndian.PutUint32(header[stdWriterSizeIndex:], uint32(len(buf)))
+
+	line := append(header[:], buf...)
+
+	n, err = w.Writer.Write(line)
+	n -= stdWriterPrefixLen
+
+	if n < 0 {
+		n = 0
+	}
+	return
+}
+
+// NewStdWriter instantiates a new Writer.
+// Everything written to it will be encapsulated using a custom format,
+// and written to the underlying `w` stream.
+// This allows multiple write streams (e.g. stdout and stderr) to be muxed into a single connection.
+// `t` indicates the id of the stream to encapsulate.
+// It can be stdcopy.Stdin, stdcopy.Stdout, stdcopy.Stderr.
+func NewStdWriter(w io.Writer, t StdType) io.Writer {
+	return &stdWriter{
+		Writer: w,
+		prefix: byte(t),
+	}
+}
+
+// StdCopy is a modified version of io.Copy.
+//
+// StdCopy will demultiplex `src`, assuming that it contains two streams,
+// previously multiplexed together using a StdWriter instance.
+// As it reads from `src`, StdCopy will write to `dstout` and `dsterr`.
+//
+// StdCopy will read until it hits EOF on `src`. It will then return a nil error.
+// In other words: if `err` is non nil, it indicates a real underlying error.
+//
+// `written` will hold the total number of bytes written to `dstout` and `dsterr`.
+func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
+	var (
+		buf       = make([]byte, startingBufLen)
+		bufLen    = len(buf)
+		nr, nw    int
+		er, ew    error
+		out       io.Writer
+		frameSize int
+	)
+
+	for {
+		// Make sure we have at least a full header
+		for nr < stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		// Check the first byte to know where to write
+		switch StdType(buf[stdWriterFdIndex]) {
+		case Stdin:
+			fallthrough
+		case Stdout:
+			// Write on stdout
+			out = dstout
+		case Stderr:
+			// Write on stderr
+			out = dsterr
+		default:
+			return 0, fmt.Errorf("Unrecognized input header: %d", buf[stdWriterFdIndex])
+		}
+
+		// Retrieve the size of the frame
+		frameSize = int(binary.BigEndian.Uint32(buf[stdWriterSizeIndex : stdWriterSizeIndex+4]))
+
+		// Check if the buffer is big enough to read the frame.
+		// Extend it if necessary.
+		if frameSize+stdWriterPrefixLen > bufLen {
+			buf = append(buf, make([]byte, frameSize+stdWriterPrefixLen-bufLen+1)...)
+			bufLen = len(buf)
+		}
+
+		// While the amount of bytes read is less than the size of the frame + header, we keep reading
+		for nr < frameSize+stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < frameSize+stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		// Write the retrieved frame (without header)
+		nw, ew = out.Write(buf[stdWriterPrefixLen : frameSize+stdWriterPrefixLen])
+		if ew != nil {
+			return 0, ew
+		}
+		// If the frame has not been fully written: error
+		if nw != frameSize {
+			return 0, io.ErrShortWrite
+		}
+		written += int64(nw)
+
+		// Move the rest of the buffer to the beginning
+		copy(buf, buf[frameSize+stdWriterPrefixLen:])
+		// Move the index
+		nr -= frameSize + stdWriterPrefixLen
+	}
+}

--- a/acceptance/cluster/stdcopy_test.go
+++ b/acceptance/cluster/stdcopy_test.go
@@ -1,0 +1,278 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Source: github.com/docker/docker/pkg/stdcopy
+
+package cluster
+
+// TODO(tamird): all of this can be removed if a dependency on docker/docker
+// is deemed acceptable or https://github.com/docker/engine-api/issues/204
+// closes.
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestNewStdWriter(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	if writer == nil {
+		t.Fatalf("NewStdWriter with an invalid StdType should not return nil.")
+	}
+}
+
+func TestWriteWithUnitializedStdWriter(t *testing.T) {
+	writer := stdWriter{
+		Writer: nil,
+		prefix: byte(Stdout),
+	}
+	n, err := writer.Write([]byte("Something here"))
+	if n != 0 || err == nil {
+		t.Fatalf("Should fail when given an uncomplete or uninitialized StdWriter")
+	}
+}
+
+func TestWriteWithNilBytes(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	n, err := writer.Write(nil)
+	if err != nil {
+		t.Fatalf("Shouldn't have fail when given no data")
+	}
+	if n > 0 {
+		t.Fatalf("Write should have written 0 byte, but has written %d", n)
+	}
+}
+
+func TestWrite(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	data := []byte("Test StdWrite.Write")
+	n, err := writer.Write(data)
+	if err != nil {
+		t.Fatalf("Error while writing with StdWrite")
+	}
+	if n != len(data) {
+		t.Fatalf("Write should have written %d byte but wrote %d.", len(data), n)
+	}
+}
+
+type errWriter struct {
+	n   int
+	err error
+}
+
+func (f *errWriter) Write(buf []byte) (int, error) {
+	return f.n, f.err
+}
+
+func TestWriteWithWriterError(t *testing.T) {
+	expectedError := errors.New("expected")
+	expectedReturnedBytes := 10
+	writer := NewStdWriter(&errWriter{
+		n:   stdWriterPrefixLen + expectedReturnedBytes,
+		err: expectedError}, Stdout)
+	data := []byte("This won't get written, sigh")
+	n, err := writer.Write(data)
+	if err != expectedError {
+		t.Fatalf("Didn't get expected error.")
+	}
+	if n != expectedReturnedBytes {
+		t.Fatalf("Didn't get expected written bytes %d, got %d.",
+			expectedReturnedBytes, n)
+	}
+}
+
+func TestWriteDoesNotReturnNegativeWrittenBytes(t *testing.T) {
+	writer := NewStdWriter(&errWriter{n: -1}, Stdout)
+	data := []byte("This won't get written, sigh")
+	actual, _ := writer.Write(data)
+	if actual != 0 {
+		t.Fatalf("Expected returned written bytes equal to 0, got %d", actual)
+	}
+}
+
+func getSrcBuffer(stdOutBytes, stdErrBytes []byte) (buffer *bytes.Buffer, err error) {
+	buffer = new(bytes.Buffer)
+	dstOut := NewStdWriter(buffer, Stdout)
+	_, err = dstOut.Write(stdOutBytes)
+	if err != nil {
+		return
+	}
+	dstErr := NewStdWriter(buffer, Stderr)
+	_, err = dstErr.Write(stdErrBytes)
+	return
+}
+
+func TestStdCopyWriteAndRead(t *testing.T) {
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	written, err := StdCopy(ioutil.Discard, ioutil.Discard, buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedTotalWritten := len(stdOutBytes) + len(stdErrBytes)
+	if written != int64(expectedTotalWritten) {
+		t.Fatalf("Expected to have total of %d bytes written, got %d", expectedTotalWritten, written)
+	}
+}
+
+type customReader struct {
+	n            int
+	err          error
+	totalCalls   int
+	correctCalls int
+	src          *bytes.Buffer
+}
+
+func (f *customReader) Read(buf []byte) (int, error) {
+	f.totalCalls++
+	if f.totalCalls <= f.correctCalls {
+		return f.src.Read(buf)
+	}
+	return f.n, f.err
+}
+
+func TestStdCopyReturnsErrorReadingHeader(t *testing.T) {
+	expectedError := errors.New("error")
+	reader := &customReader{
+		err: expectedError}
+	written, err := StdCopy(ioutil.Discard, ioutil.Discard, reader)
+	if written != 0 {
+		t.Fatalf("Expected 0 bytes read, got %d", written)
+	}
+	if err != expectedError {
+		t.Fatalf("Didn't get expected error")
+	}
+}
+
+func TestStdCopyReturnsErrorReadingFrame(t *testing.T) {
+	expectedError := errors.New("error")
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := &customReader{
+		correctCalls: 1,
+		n:            stdWriterPrefixLen + 1,
+		err:          expectedError,
+		src:          buffer}
+	written, err := StdCopy(ioutil.Discard, ioutil.Discard, reader)
+	if written != 0 {
+		t.Fatalf("Expected 0 bytes read, got %d", written)
+	}
+	if err != expectedError {
+		t.Fatalf("Didn't get expected error")
+	}
+}
+
+func TestStdCopyDetectsCorruptedFrame(t *testing.T) {
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := &customReader{
+		correctCalls: 1,
+		n:            stdWriterPrefixLen + 1,
+		err:          io.EOF,
+		src:          buffer}
+	written, err := StdCopy(ioutil.Discard, ioutil.Discard, reader)
+	if written != startingBufLen {
+		t.Fatalf("Expected %d bytes read, got %d", startingBufLen, written)
+	}
+	if err != nil {
+		t.Fatal("Didn't get nil error")
+	}
+}
+
+func TestStdCopyWithInvalidInputHeader(t *testing.T) {
+	dstOut := NewStdWriter(ioutil.Discard, Stdout)
+	dstErr := NewStdWriter(ioutil.Discard, Stderr)
+	src := strings.NewReader("Invalid input")
+	_, err := StdCopy(dstOut, dstErr, src)
+	if err == nil {
+		t.Fatal("StdCopy with invalid input header should fail.")
+	}
+}
+
+func TestStdCopyWithCorruptedPrefix(t *testing.T) {
+	data := []byte{0x01, 0x02, 0x03}
+	src := bytes.NewReader(data)
+	written, err := StdCopy(nil, nil, src)
+	if err != nil {
+		t.Fatalf("StdCopy should not return an error with corrupted prefix.")
+	}
+	if written != 0 {
+		t.Fatalf("StdCopy should have written 0, but has written %d", written)
+	}
+}
+
+func TestStdCopyReturnsWriteErrors(t *testing.T) {
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedError := errors.New("expected")
+
+	dstOut := &errWriter{err: expectedError}
+
+	written, err := StdCopy(dstOut, ioutil.Discard, buffer)
+	if written != 0 {
+		t.Fatalf("StdCopy should have written 0, but has written %d", written)
+	}
+	if err != expectedError {
+		t.Fatalf("Didn't get expected error, got %v", err)
+	}
+}
+
+func TestStdCopyDetectsNotFullyWrittenFrames(t *testing.T) {
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dstOut := &errWriter{n: startingBufLen - 10}
+
+	written, err := StdCopy(dstOut, ioutil.Discard, buffer)
+	if written != 0 {
+		t.Fatalf("StdCopy should have return 0 written bytes, but returned %d", written)
+	}
+	if err != io.ErrShortWrite {
+		t.Fatalf("Didn't get expected io.ErrShortWrite error")
+	}
+}
+
+func BenchmarkWrite(b *testing.B) {
+	w := NewStdWriter(ioutil.Discard, Stdout)
+	data := []byte("Test line for testing stdwriter performance\n")
+	data = bytes.Repeat(data, 100)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := w.Write(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/acceptance/iptables/iptables.go
+++ b/acceptance/iptables/iptables.go
@@ -1,0 +1,110 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package iptables
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/base"
+)
+
+const chain = "partition_nemesis"
+
+// An IP is an IP address.
+type IP string
+
+// Bidirectional takes groups of nodes and creates rules which isolate them
+// from one another. For example, with arguments ([ip1], [ip2, ip3]), ip1 would
+// not be able to talk to ip2 and ip3, and vice versa.
+func Bidirectional(partitions ...[]IP) map[IP][]IP {
+	blacklist := make(map[IP][]IP)
+	for i, srcPart := range partitions {
+		for _, srcAddr := range srcPart {
+			var blockedDests []IP
+			for j, destPart := range partitions {
+				if j == i {
+					continue
+				}
+				blockedDests = append(blockedDests, destPart...)
+			}
+			blacklist[srcAddr] = blockedDests
+		}
+	}
+	return blacklist
+}
+
+// Cmd is a naive command without proper support for whitespace.
+type Cmd []string
+
+// String formats the Cmd for shell copy&paste.
+func (c Cmd) String() string {
+	return strings.Join(c, " ")
+}
+
+// Cmds is a slice of commands.
+type Cmds []Cmd
+
+// String formats the Cmds for shell copy&paste.
+func (c Cmds) String() string {
+	s := make([]string, len(c))
+	for i := range c {
+		s[i] = c[i].String()
+	}
+	return strings.Join(s, " && \\\n")
+}
+
+func cmd(s string, args ...interface{}) Cmd {
+	return append([]string{"iptables"}, strings.Split(fmt.Sprintf(s, args...), " ")...)
+}
+
+// Rules translates a blacklist into a map of invocations of `iptables`, keyed
+// by the node on which they need to be run. A blacklist is keyed by origin,
+// the values being the nodes which will be blocked from receiving inbound
+// connections from the origin. For example, {ip1: [ip2, ip3]} means that rules
+// will be created at ip2 and ip3 which drop incoming connections from ip1. In
+// particular, asymmetry is supported: ip2 and ip3 would continue to be able to
+// connect to ip1.
+// The commands don't stack; before applying new rules, run Reset() to clear up
+// a previous partition.
+func Rules(blacklist map[IP][]IP) map[IP]Cmds {
+	cmds := make(map[IP]Cmds)
+	for src, dests := range blacklist {
+		r := Cmds{
+			cmd("-N %s", chain),          // create chain
+			cmd("-I INPUT -j %s", chain), // jump to chain on incoming traffic
+		}
+		for _, dest := range dests {
+			// Drop all incoming connection attempts which originate at the
+			// blacklisted destination. Blocking outgoing packets isn't silent;
+			// the client will get a permission error - but we want silent.
+			r = append(r, cmd("-I %s -s %s -p tcp --dport %s -j DROP", chain, dest, base.DefaultPort))
+		}
+		cmds[src] = r
+	}
+	return cmds
+}
+
+// Reset creates commands which, when executed, undo the effects of a previous
+// execution of Rules().
+func Reset() Cmds {
+	return Cmds{
+		cmd("-D INPUT -j %s", chain), // remove from active rules
+		cmd("-F %s", chain),          // remove all contained rules
+		cmd("-X %s", chain),          // remove chain
+	}
+}

--- a/acceptance/iptables/iptables_test.go
+++ b/acceptance/iptables/iptables_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package iptables
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRules(t *testing.T) {
+	blacklist := map[IP][]IP{
+		"192.168.0.1": {"192.168.0.2"},
+		"192.168.0.2": {"192.168.0.3", "192.168.0.1"},
+	}
+	exp := map[IP]string{
+		"192.168.0.1": `iptables -N partition_nemesis && \` + "\n" +
+			`iptables -I INPUT -j partition_nemesis && \` + "\n" +
+			`iptables -I partition_nemesis -s 192.168.0.2 -p tcp --dport 26257 -j DROP`,
+		"192.168.0.2": `iptables -N partition_nemesis && \` + "\n" +
+			`iptables -I INPUT -j partition_nemesis && \` + "\n" +
+			`iptables -I partition_nemesis -s 192.168.0.3 -p tcp --dport 26257 -j DROP && \` + "\n" +
+			`iptables -I partition_nemesis -s 192.168.0.1 -p tcp --dport 26257 -j DROP`,
+	}
+	act := make(map[IP]string)
+	for addr, rules := range Rules(blacklist) {
+		act[addr] = rules.String()
+	}
+
+	if !reflect.DeepEqual(act, exp) {
+		t.Fatalf("expected:\n%v\ngot:\n%v", exp, act)
+	}
+}
+
+func TestBidirectional(t *testing.T) {
+	partition1 := []IP{"192.168.0.1"}
+	partition2 := []IP{"192.168.0.2", "192.168.0.3"}
+	partition3 := []IP{"192.168.0.4", "192.168.0.5"}
+
+	exp := map[IP][]IP{
+		"192.168.0.1": {"192.168.0.2", "192.168.0.3", "192.168.0.4", "192.168.0.5"},
+		"192.168.0.2": {"192.168.0.1", "192.168.0.4", "192.168.0.5"},
+		"192.168.0.3": {"192.168.0.1", "192.168.0.4", "192.168.0.5"},
+		"192.168.0.4": {"192.168.0.1", "192.168.0.2", "192.168.0.3"},
+		"192.168.0.5": {"192.168.0.1", "192.168.0.2", "192.168.0.3"},
+	}
+	act := Bidirectional(partition1, partition2, partition3)
+	if !reflect.DeepEqual(act, exp) {
+		t.Fatalf("expected:\n%v\ngot:\n%v", exp, act)
+	}
+}

--- a/acceptance/partition.go
+++ b/acceptance/partition.go
@@ -1,0 +1,107 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package acceptance
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/acceptance/iptables"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+func mustGetHosts(t *testing.T, c cluster.Cluster) (
+	[]iptables.IP, map[iptables.IP]int,
+) {
+	var addrs []iptables.IP
+	addrsToNode := make(map[iptables.IP]int)
+	for i := 0; i < c.NumNodes(); i++ {
+		addr := iptables.IP(c.InternalIP(i).String())
+		addrsToNode[addr] = i
+		addrs = append(addrs, addr)
+	}
+	return addrs, addrsToNode
+}
+
+func randomBidirectionalPartition(numNodes int) [][]int {
+	if numNodes <= 1 {
+		return ([][]int{{0}})[:numNodes]
+	}
+	all := rand.Perm(numNodes)
+	r := 1 + rand.Intn(numNodes-1)
+	return [][]int{all[:r], all[r:]}
+}
+
+// A NemesisFn runs a nemesis on the given cluster, shutting down in a timely
+// manner when the stop channel is closed.
+type NemesisFn func(t *testing.T, stop <-chan struct{}, c cluster.Cluster)
+
+// BidirectionalPartitionNemesis is a nemesis which randomly severs the network
+// symmetrically between two random groups of nodes. Partitioned and connected
+// mode take alternating turns, with random durations of up to 15s.
+func BidirectionalPartitionNemesis(t *testing.T, stop <-chan struct{}, c cluster.Cluster) {
+	randSec := func() time.Duration { return time.Duration(rand.Int63n(15 * int64(time.Second))) }
+	for {
+		ch := make(chan struct{})
+		go func() {
+			select {
+			case <-time.After(randSec()):
+			case <-stop:
+			}
+			close(ch)
+		}()
+		cutNetwork(t, c, ch, randomBidirectionalPartition(c.NumNodes())...)
+		select {
+		case <-stop:
+			return
+		case <-time.After(randSec()):
+		}
+	}
+}
+
+var _ NemesisFn = BidirectionalPartitionNemesis
+
+func cutNetwork(t *testing.T, c cluster.Cluster, closer <-chan struct{}, partitions ...[]int) {
+	addrs, addrsToNode := mustGetHosts(t, c)
+	ipPartitions := make([][]iptables.IP, 0, len(partitions))
+	for _, partition := range partitions {
+		ipPartition := make([]iptables.IP, 0, len(partition))
+		for _, nodeIndex := range partition {
+			ipPartition = append(ipPartition, addrs[nodeIndex])
+		}
+		ipPartitions = append(ipPartitions, ipPartition)
+	}
+	log.Warningf("partitioning: %v (%v)", partitions, ipPartitions)
+	for host, cmds := range iptables.Rules(iptables.Bidirectional(ipPartitions...)) {
+		for _, cmd := range cmds {
+			if err := c.ExecRoot(addrsToNode[host], cmd); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	<-closer
+	for i := 0; i < c.NumNodes(); i++ {
+		for _, cmd := range iptables.Reset() {
+			if err := c.ExecRoot(i, cmd); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	log.Warningf("resolved all partitions")
+}

--- a/acceptance/partition_test.go
+++ b/acceptance/partition_test.go
@@ -1,0 +1,198 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package acceptance
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
+)
+
+func TestPartitionNemesis(t *testing.T) {
+	t.Skip("only enabled for manually playing with the partitioning agent")
+	SkipUnlessLocal(t)
+	runTestOnConfigs(t, func(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
+		s := stop.NewStopper()
+		defer s.Stop()
+		s.RunWorker(func() {
+			BidirectionalPartitionNemesis(t, s.ShouldDrain(), c)
+		})
+		select {
+		case <-time.After(*flagDuration):
+		case <-stopper:
+		}
+	})
+}
+
+func TestPartitionBank(t *testing.T) {
+	SkipUnlessPrivileged(t)
+	runTestOnConfigs(t, testBankWithNemesis(BidirectionalPartitionNemesis))
+}
+
+type Bank struct {
+	cluster.Cluster
+	*testing.T
+	accounts, initialBalance int
+}
+
+func (b *Bank) must(err error) {
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+// NewBank creates a Bank.
+// TODO(tamird,tschottdorf): share this code with other bank test(s).
+func NewBank(t *testing.T, c cluster.Cluster) *Bank {
+	return &Bank{Cluster: c, T: t}
+}
+
+func (b *Bank) exec(query string, vars ...interface{}) error {
+	db := makePGClient(b.T, b.PGUrl(0))
+	defer db.Close()
+	_, err := db.Exec(query, vars...)
+	return err
+}
+
+// Init sets up the bank for the given number of accounts, each of which
+// receiving a deposit of the given amount.
+// This should be called before any nemeses are active; it will fail the test
+// if unsuccessful.
+func (b *Bank) Init(numAccounts, initialBalance int) {
+	b.accounts = numAccounts
+	b.initialBalance = initialBalance
+
+	b.must(b.exec(`CREATE DATABASE IF NOT EXISTS bank`))
+	b.must(b.exec(`DROP TABLE IF EXISTS bank.accounts`))
+	const schema = `CREATE TABLE bank.accounts (id INT PRIMARY KEY, balance INT NOT NULL)`
+	b.must(b.exec(schema))
+	for i := 0; i < numAccounts; i++ {
+		b.must(b.exec(`INSERT INTO bank.accounts (id, balance) VALUES ($1, $2)`,
+			i, initialBalance))
+	}
+}
+
+// Verify makes sure that the total amount of money in the system has not
+// changed.
+func (b *Bank) Verify() {
+	exp := b.accounts * b.initialBalance
+	db := makePGClient(b.T, b.PGUrl(0))
+	defer db.Close()
+	r := db.QueryRow(`SELECT SUM(balance) FROM bank.accounts`)
+	var act int
+	b.must(r.Scan(&act))
+	if act != exp {
+		b.Fatalf("bank is worth $%d, should be $%d", act, exp)
+	}
+}
+
+func (b *Bank) logFailed(i int, v interface{}) {
+	log.Warningf("%d: %v", i, v)
+}
+func (b *Bank) logBegin(i int, from, to, amount int) {
+	log.Warningf("%d: %d trying to give $%d to %d", i, from, amount, to)
+}
+func (b *Bank) logSuccess(i int, from, to, amount int) {
+	log.Warningf("%d: %d gave $%d to %d", i, from, amount, to)
+}
+
+// Invoke transfers a random amount of money between random accounts.
+func (b *Bank) Invoke(i int) {
+	handle := func(err error) {
+		if err != nil {
+			panic(err)
+		}
+	}
+	var from, to int
+	{
+		p := rand.Perm(b.accounts)
+		from, to = p[0], p[1]
+	}
+	amount := rand.Intn(b.initialBalance)
+	b.logBegin(i, from, to, amount)
+	defer func() {
+		if r := recover(); r != nil {
+			b.logFailed(i, r)
+		} else {
+			b.logSuccess(i, from, to, amount)
+		}
+	}()
+
+	db := makePGClient(b.T, b.PGUrl(i%b.NumNodes()))
+	defer db.Close()
+	txn, err := db.Begin()
+	handle(err)
+	// The following SQL queries are intentionally unoptimized.
+	var bFrom, bTo int
+	{
+		rFrom := txn.QueryRow(`SELECT balance FROM bank.accounts WHERE id = $1`, from)
+		handle(rFrom.Scan(&bFrom))
+		rTo := txn.QueryRow(`SELECT balance FROM bank.accounts WHERE id = $1`, to)
+		handle(rTo.Scan(&bTo))
+	}
+	if diff := bFrom - amount; diff < 0 {
+		handle(fmt.Errorf("%d is %d short to pay $%d", bFrom, -diff, amount))
+	}
+	_, err = txn.Exec(`UPDATE bank.accounts SET balance = $1 WHERE id = $2`, bFrom-amount, from)
+	handle(err)
+	_, err = txn.Exec(`UPDATE bank.accounts SET balance = $1 WHERE id = $2`, bTo+amount, to)
+	handle(err)
+}
+
+func testBankWithNemesis(nemeses ...NemesisFn) configTestRunner {
+	return func(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
+		const (
+			concurrency = 5
+			accounts    = 10
+		)
+		deadline := timeutil.Now().Add(cfg.Duration)
+		s := stop.NewStopper()
+		defer s.Stop()
+		b := NewBank(t, c)
+		b.Init(accounts, 10)
+		for _, nemesis := range nemeses {
+			s.RunWorker(func() {
+				nemesis(t, s.ShouldDrain(), c)
+			})
+		}
+		for i := 0; i < concurrency; i++ {
+			localI := i
+			s.RunAsyncTask(func() {
+				for timeutil.Now().Before(deadline) {
+					select {
+					case <-s.ShouldDrain():
+						return
+					default:
+					}
+					b.Invoke(localI)
+				}
+			})
+		}
+		select {
+		case <-stopper:
+		case <-time.After(cfg.Duration):
+		}
+		log.Warningf("finishing test")
+		b.Verify()
+	}
+}

--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -173,6 +173,11 @@ func (f *Farmer) PGUrl(i int) string {
 	panic("unimplemented")
 }
 
+// InternalIP returns the address used for inter-node communication.
+func (f *Farmer) InternalIP(i int) net.IP {
+	panic("unimplemented")
+}
+
 // WaitReady waits until the infrastructure is in a state that *should* allow
 // for a healthy cluster. Currently, this means waiting for the load balancer
 // to resolve from all nodes.
@@ -231,6 +236,13 @@ func (f *Farmer) AssertAndStop(t *testing.T) {
 	if err := f.Destroy(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// ExecRoot executes the given command with super-user privileges.
+func (f *Farmer) ExecRoot(i int, cmd []string) error {
+	// We have `f.Exec(i, strings.Join(" ", cmd))`, so this should be
+	// easy to implement once we need it.
+	panic("unimplemented")
 }
 
 // Kill terminates the cockroach process running on the given node number.


### PR DESCRIPTION
```
This nemesis allows node partitions to be set up during tests. Partitions can
be bidirectional, but also one-way (i.e. one node can initiate connections to
another, but not the other way around). The latter likely isn't too
interesting with the change to streaming RPCs, but it should be possible to
introduce interesting phenomena nevertheless.

Wrote a bank test with the nemesis. I found the existing bank test too
complicated for its own sake, so I re-wrote it. The plan is to make it
the more advanced bank example with constraints which would fail under
SNAPSHOT isolation (i.e. transferring money from A and B to C and D under
the constraint that A+B >= 0).
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4712)

<!-- Reviewable:end -->
