### PR TITLE
util/interval: Introduce Sub, Encloses, ForEach, and String methods for RangeGroup

### DIFF
--- a/util/interval/interval.go
+++ b/util/interval/interval.go
@@ -9,6 +9,7 @@ package interval
 import (
 	"bytes"
 	"errors"
+	"fmt"
 
 	"github.com/biogo/store/llrb"
 )
@@ -63,6 +64,16 @@ func (r Range) OverlapExclusive(other Range) bool {
 	return r.End.Compare(other.Start) > 0 && r.Start.Compare(other.End) < 0
 }
 
+// Equal returns whether the two ranges are equal.
+func (r Range) Equal(other Range) bool {
+	return r.End.Equal(other.Start) && r.Start.Equal(other.End)
+}
+
+// String implements the Stringer interface.
+func (r Range) String() string {
+	return fmt.Sprintf("[%x-%x)", r.Start, r.End)
+}
+
 // An Interface is a type that can be inserted into a Tree.
 type Interface interface {
 	Range() Range
@@ -84,6 +95,13 @@ type Comparable []byte
 //
 func (c Comparable) Compare(o Comparable) int {
 	return bytes.Compare(c, o)
+}
+
+// Equal returns a boolean indicating if the given comparables are equal to
+// each other. Note that this has measurably better performance than
+// Compare() == 0, so it should be used when only equality state is needed.
+func (c Comparable) Equal(o Comparable) bool {
+	return bytes.Equal(c, o)
 }
 
 // A Node represents a node in a Tree.

--- a/util/interval/range_group.go
+++ b/util/interval/range_group.go
@@ -17,32 +17,56 @@
 package interval
 
 import (
+	"bytes"
 	"container/list"
 	"fmt"
 )
 
 // RangeGroup represents a set of possibly disjointed Ranges. The
-// primary use case of the interface is to add ranges to the group
-// and observe whether the addition increases the size of the group
-// or not, indicating whether the new range's interval is redundant,
-// or if it is needed for the full composition of the group. Because
+// interface exposes methods to manipulate the group by adding and
+// subtracting Ranges. All methods requiring a Range will panic
+// if the provided range is inverted or empty.
+//
+// One use case of the interface is to add ranges to the group and
+// observe whether the addition increases the size of the group or
+// not, indicating whether the new range's interval is redundant, or
+// if it is needed for the full composition of the group. Because
 // the RangeGroup builds as more ranges are added, insertion order of
 // the ranges is critical. For instance, if two identical ranges are
 // added, only the first to be added with Add will return true, as it
 // will be the only one to expand the group.
+//
+// Another use case of the interface is to add and subtract ranges as
+// needed to the group, allowing the internals of the implementation
+// to coalesce and split ranges when needed to factor the group to
+// its minimum number of disjoint ranges.
 type RangeGroup interface {
 	// Add will attempt to add the provided Range to the RangeGroup,
 	// returning whether the addition increased the range of the group
-	// or not. The method will panic if the provided range is inverted
-	// or empty.
+	// or not.
 	Add(Range) bool
+	// Sub will attempt to remove the provided Range from the RangeGroup,
+	// returning whether the subtraction reduced the range of the group
+	// or not.
+	Sub(Range) bool
+	// Clear clears all ranges from the RangeGroup, resetting it to be
+	// used again.
+	Clear()
+	// Encloses returns whether the provided Range is fully contained
+	// within the group of Ranges in the RangeGroup.
+	Encloses(Range) bool
+	// ForEach calls the provided function with each Range stored in
+	// the group. An error is returned indicating whether the callback
+	// function saw an error, whereupon the Range iteration will halt
+	// (potentially prematurely) and the error will be returned from ForEach
+	// itself. If no error is returned from the callback, the method
+	// will visit all Ranges in the group before returning a nil error.
+	ForEach(func(Range) error) error
 	// Len returns the number of Ranges currently within the RangeGroup.
 	// This will always be equal to or less than the number of ranges added,
 	// as ranges that overlap will merge to produce a single larger range.
 	Len() int
-	// Clear clears all ranges from the RangeGroup, resetting it to be
-	// used again.
-	Clear()
+	fmt.Stringer
 }
 
 // rangeList is an implementation of a RangeGroup using a linked
@@ -107,16 +131,113 @@ func (rg *rangeList) Add(r Range) bool {
 	return true
 }
 
-// Len implements RangeGroup. It returns the number of ranges in
-// the rangeList.
-func (rg *rangeList) Len() int {
-	return rg.ll.Len()
+// Sub implements RangeGroup. It iterates over the current ranges in the
+// rangeList to find which overlap with the range to subtract. For all
+// ranges that overlap with the provided range, the overlapping segment of
+// the range is removed. If the provided range fully contains a range in
+// the rangeList, the range in the rangeList will be removed. The method
+// returns whether the subtraction resulted in any decrease to the size
+// of the RangeGroup.
+func (rg *rangeList) Sub(r Range) bool {
+	if err := rangeError(r); err != nil {
+		panic(err)
+	}
+	dec := false
+	for e := rg.ll.Front(); e != nil; {
+		er := e.Value.(Range)
+		switch {
+		case er.OverlapExclusive(r):
+			sCmp := er.Start.Compare(r.Start)
+			eCmp := er.End.Compare(r.End)
+
+			delStart := sCmp >= 0
+			delEnd := eCmp <= 0
+			cont := eCmp < 0
+
+			switch {
+			case delStart && delEnd:
+				// Remove the entire range.
+				nextE := e.Next()
+				rg.ll.Remove(e)
+				e = nextE
+			case delStart:
+				// Remove the start of the range by truncating.
+				er.Start = r.End
+				e.Value = er
+				e = e.Next()
+			case delEnd:
+				// Remove the end of the range by truncating.
+				er.End = r.Start
+				e.Value = er
+				e = e.Next()
+			default:
+				// Remove the middle of the range by splitting and truncating.
+				oldEnd := er.End
+				er.End = r.Start
+				e.Value = er
+
+				rSplit := Range{Start: r.End, End: oldEnd}
+				newE := rg.ll.InsertAfter(rSplit, e)
+				e = newE.Next()
+			}
+
+			dec = true
+			if !cont {
+				return dec
+			}
+		case r.End.Compare(er.Start) <= 0:
+			// Past where overlapping ranges would be.
+			return dec
+		default:
+			e = e.Next()
+		}
+	}
+	return dec
 }
 
 // Clear implements RangeGroup. It clears all ranges from the
 // rangeList.
 func (rg *rangeList) Clear() {
 	rg.ll.Init()
+}
+
+// Encloses implements RangeGroup. It returns whether the provided
+// Range is fully contained within the group of Ranges in the rangeList.
+func (rg *rangeList) Encloses(r Range) bool {
+	if err := rangeError(r); err != nil {
+		panic(err)
+	}
+	for e := rg.ll.Front(); e != nil; e = e.Next() {
+		er := e.Value.(Range)
+		switch {
+		case contains(er, r):
+			return true
+		case r.End.Compare(er.Start) <= 0:
+			return false
+		}
+	}
+	return false
+}
+
+// ForEach implements RangeGroup. It calls the provided function f
+// with each Range stored in the rangeList.
+func (rg *rangeList) ForEach(f func(Range) error) error {
+	for e := rg.ll.Front(); e != nil; e = e.Next() {
+		if err := f(e.Value.(Range)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Len implements RangeGroup. It returns the number of ranges in
+// the rangeList.
+func (rg *rangeList) Len() int {
+	return rg.ll.Len()
+}
+
+func (rg *rangeList) String() string {
+	return rgString(rg)
 }
 
 // rangeTree is an implementation of a RangeGroup using an interval
@@ -183,10 +304,10 @@ func (rt *rangeTree) Add(r Range) bool {
 	if err := rangeError(r); err != nil {
 		panic(err)
 	}
-	key := rt.makeKey(r)
-	overlaps := rt.t.Get(key.r)
+	overlaps := rt.t.Get(r)
 	if len(overlaps) == 0 {
-		if err := rt.insertKey(key); err != nil {
+		key := rt.makeKey(r)
+		if err := rt.t.Insert(&key, false /* !fast */); err != nil {
 			panic(err)
 		}
 		return true
@@ -195,7 +316,7 @@ func (rt *rangeTree) Add(r Range) bool {
 
 	// If a current range fully contains the new range, no
 	// need to add it.
-	if first.Contains(key) {
+	if contains(first.r, r) {
 		return false
 	}
 
@@ -212,11 +333,86 @@ func (rt *rangeTree) Add(r Range) bool {
 	return true
 }
 
-// insertKey inserts the rangeKey into the rangeTree's interval tree.
-// This is split into a helper method so that key will only escape to
-// the heap when the insertion case is needed and Insert is called.
-func (rt *rangeTree) insertKey(key rangeKey) error {
-	return rt.t.Insert(&key, false /* !fast */)
+// Sub implements RangeGroup. It first uses the interval tree to lookup
+// the current ranges which overlap with the range to subtract. For all
+// ranges that overlap with the provided range, the overlapping segment of
+// the range is removed. If the provided range fully contains a range in
+// the rangeTree, the range in the rangeTree will be removed. The method
+// returns whether the subtraction resulted in any decrease to the size
+// of the RangeGroup.
+func (rt *rangeTree) Sub(r Range) bool {
+	if err := rangeError(r); err != nil {
+		panic(err)
+	}
+	overlaps := rt.t.Get(r)
+	if len(overlaps) == 0 {
+		return false
+	}
+
+	for _, o := range overlaps {
+		rk := o.(*rangeKey)
+		sCmp := rk.r.Start.Compare(r.Start)
+		eCmp := rk.r.End.Compare(r.End)
+
+		delStart := sCmp >= 0
+		delEnd := eCmp <= 0
+
+		switch {
+		case delStart && delEnd:
+			// Remove the entire range.
+			if err := rt.t.Delete(o, true /* fast */); err != nil {
+				panic(err)
+			}
+		case delStart:
+			// Remove the start of the range by truncating.
+			rk.r.Start = r.End
+		case delEnd:
+			// Remove the end of the range by truncating.
+			rk.r.End = r.Start
+		default:
+			// Remove the middle of the range by splitting.
+			oldEnd := rk.r.End
+			rk.r.End = r.Start
+
+			rSplit := Range{Start: r.End, End: oldEnd}
+			rKey := rt.makeKey(rSplit)
+			if err := rt.t.Insert(&rKey, true /* fast */); err != nil {
+				panic(err)
+			}
+		}
+	}
+	rt.t.AdjustRanges()
+	return true
+}
+
+// Clear implements RangeGroup. It clears all rangeKeys from the rangeTree.
+func (rt *rangeTree) Clear() {
+	rt.t = Tree{Overlapper: Range.OverlapInclusive}
+}
+
+// Encloses implements RangeGroup. It returns whether the provided
+// Range is fully contained within the group of Ranges in the rangeTree.
+func (rt *rangeTree) Encloses(r Range) bool {
+	if err := rangeError(r); err != nil {
+		panic(err)
+	}
+	overlaps := rt.t.Get(r)
+	if len(overlaps) != 1 {
+		return false
+	}
+	first := overlaps[0].(*rangeKey)
+	return contains(first.r, r)
+}
+
+// ForEach implements RangeGroup. It calls the provided function f
+// with each Range stored in the rangeTree.
+func (rt *rangeTree) ForEach(f func(Range) error) error {
+	var err error
+	rt.t.Do(func(i Interface) bool {
+		err = f(i.Range())
+		return err != nil
+	})
+	return err
 }
 
 // Len implements RangeGroup. It returns the number of rangeKeys in
@@ -225,9 +421,8 @@ func (rt *rangeTree) Len() int {
 	return rt.t.Len()
 }
 
-// Clear implements RangeGroup. It clears all rangeKeys from the rangeTree.
-func (rt *rangeTree) Clear() {
-	rt.t = Tree{Overlapper: Range.OverlapInclusive}
+func (rt *rangeTree) String() string {
+	return rgString(rt)
 }
 
 // contains returns if the range in the out range fully contains the
@@ -248,4 +443,23 @@ func merge(l, r Range) Range {
 		end = r.End
 	}
 	return Range{Start: start, End: end}
+}
+
+// rgString returns a string representation of the ranges in a RangeGroup.
+func rgString(rg RangeGroup) string {
+	var buffer bytes.Buffer
+	buffer.WriteRune('[')
+	space := false
+	if err := rg.ForEach(func(r Range) error {
+		if space {
+			buffer.WriteRune(' ')
+		}
+		buffer.WriteString(r.String())
+		space = true
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+	buffer.WriteRune(']')
+	return buffer.String()
 }

--- a/util/interval/range_group_test.go
+++ b/util/interval/range_group_test.go
@@ -19,20 +19,21 @@ package interval
 import (
 	"bytes"
 	"crypto/rand"
+	"reflect"
 	"testing"
 
 	_ "github.com/cockroachdb/cockroach/util/log" // for flags
 )
 
-func TestRangeListSingleRangeAndClear(t *testing.T) {
-	testRangeGroupSingleRangeAndClear(t, NewRangeList())
+func TestRangeListAddSingleRangeAndClear(t *testing.T) {
+	testRangeGroupAddSingleRangeAndClear(t, NewRangeList())
 }
 
-func TestRangeTreeSingleRangeAndClear(t *testing.T) {
-	testRangeGroupSingleRangeAndClear(t, NewRangeTree())
+func TestRangeTreeAddSingleRangeAndClear(t *testing.T) {
+	testRangeGroupAddSingleRangeAndClear(t, NewRangeTree())
 }
 
-func testRangeGroupSingleRangeAndClear(t *testing.T, rg RangeGroup) {
+func testRangeGroupAddSingleRangeAndClear(t *testing.T, rg RangeGroup) {
 	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
 		t.Errorf("added new range to range group, wanted true added flag; got false")
 	}
@@ -47,15 +48,15 @@ func testRangeGroupSingleRangeAndClear(t *testing.T, rg RangeGroup) {
 	}
 }
 
-func TestRangeListTwoRangesBefore(t *testing.T) {
-	testRangeGroupTwoRangesBefore(t, NewRangeList())
+func TestRangeListAddTwoRangesBefore(t *testing.T) {
+	testRangeGroupAddTwoRangesBefore(t, NewRangeList())
 }
 
-func TestRangeTreeTwoRangesBefore(t *testing.T) {
-	testRangeGroupTwoRangesBefore(t, NewRangeTree())
+func TestRangeTreeAddTwoRangesBefore(t *testing.T) {
+	testRangeGroupAddTwoRangesBefore(t, NewRangeTree())
 }
 
-func testRangeGroupTwoRangesBefore(t *testing.T, rg RangeGroup) {
+func testRangeGroupAddTwoRangesBefore(t *testing.T, rg RangeGroup) {
 	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
 		t.Errorf("added new range to range group, wanted true added flag; got false")
 	}
@@ -68,15 +69,15 @@ func testRangeGroupTwoRangesBefore(t *testing.T, rg RangeGroup) {
 	}
 }
 
-func TestRangeListTwoRangesAfter(t *testing.T) {
-	testRangeGroupTwoRangesAfter(t, NewRangeList())
+func TestRangeListAddTwoRangesAfter(t *testing.T) {
+	testRangeGroupAddTwoRangesAfter(t, NewRangeList())
 }
 
-func TestRangeTreeTwoRangesAfter(t *testing.T) {
-	testRangeGroupTwoRangesAfter(t, NewRangeTree())
+func TestRangeTreeAddTwoRangesAfter(t *testing.T) {
+	testRangeGroupAddTwoRangesAfter(t, NewRangeTree())
 }
 
-func testRangeGroupTwoRangesAfter(t *testing.T, rg RangeGroup) {
+func testRangeGroupAddTwoRangesAfter(t *testing.T, rg RangeGroup) {
 	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
 		t.Errorf("added new range to range group, wanted true added flag; got false")
 	}
@@ -89,15 +90,15 @@ func testRangeGroupTwoRangesAfter(t *testing.T, rg RangeGroup) {
 	}
 }
 
-func TestRangeListTwoRangesMergeForward(t *testing.T) {
-	testRangeGroupTwoRangesMergeForward(t, NewRangeList())
+func TestRangeListAddTwoRangesMergeForward(t *testing.T) {
+	testRangeGroupAddTwoRangesMergeForward(t, NewRangeList())
 }
 
-func TestRangeTreeTwoRangesMergeForward(t *testing.T) {
-	testRangeGroupTwoRangesMergeForward(t, NewRangeTree())
+func TestRangeTreeAddTwoRangesMergeForward(t *testing.T) {
+	testRangeGroupAddTwoRangesMergeForward(t, NewRangeTree())
 }
 
-func testRangeGroupTwoRangesMergeForward(t *testing.T, rg RangeGroup) {
+func testRangeGroupAddTwoRangesMergeForward(t *testing.T, rg RangeGroup) {
 	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
 		t.Errorf("added new range to range group, wanted true added flag; got false")
 	}
@@ -110,15 +111,15 @@ func testRangeGroupTwoRangesMergeForward(t *testing.T, rg RangeGroup) {
 	}
 }
 
-func TestRangeListTwoRangesMergeBackwards(t *testing.T) {
-	testRangeGroupTwoRangesMergeBackwards(t, NewRangeList())
+func TestRangeListAddTwoRangesMergeBackwards(t *testing.T) {
+	testRangeGroupAddTwoRangesMergeBackwards(t, NewRangeList())
 }
 
-func TestRangeTreeTwoRangesMergeBackwards(t *testing.T) {
-	testRangeGroupTwoRangesMergeBackwards(t, NewRangeTree())
+func TestRangeTreeAddTwoRangesMergeBackwards(t *testing.T) {
+	testRangeGroupAddTwoRangesMergeBackwards(t, NewRangeTree())
 }
 
-func testRangeGroupTwoRangesMergeBackwards(t *testing.T, rg RangeGroup) {
+func testRangeGroupAddTwoRangesMergeBackwards(t *testing.T, rg RangeGroup) {
 	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
 		t.Errorf("added new range to range group, wanted true added flag; got false")
 	}
@@ -131,15 +132,15 @@ func testRangeGroupTwoRangesMergeBackwards(t *testing.T, rg RangeGroup) {
 	}
 }
 
-func TestRangeListTwoRangesWithin(t *testing.T) {
-	testRangeGroupTwoRangesWithin(t, NewRangeList())
+func TestRangeListAddTwoRangesWithin(t *testing.T) {
+	testRangeGroupAddTwoRangesWithin(t, NewRangeList())
 }
 
-func TestRangeTreeTwoRangesWithin(t *testing.T) {
-	testRangeGroupTwoRangesWithin(t, NewRangeTree())
+func TestRangeTreeAddTwoRangesWithin(t *testing.T) {
+	testRangeGroupAddTwoRangesWithin(t, NewRangeTree())
 }
 
-func testRangeGroupTwoRangesWithin(t *testing.T, rg RangeGroup) {
+func testRangeGroupAddTwoRangesWithin(t *testing.T, rg RangeGroup) {
 	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x04}}); !added {
 		t.Errorf("added new range to range group, wanted true added flag; got false")
 	}
@@ -152,15 +153,15 @@ func testRangeGroupTwoRangesWithin(t *testing.T, rg RangeGroup) {
 	}
 }
 
-func TestRangeListTwoRangesSurround(t *testing.T) {
-	testRangeGroupTwoRangesSurround(t, NewRangeList())
+func TestRangeListAddTwoRangesSurround(t *testing.T) {
+	testRangeGroupAddTwoRangesSurround(t, NewRangeList())
 }
 
-func TestRangeTreeTwoRangesSurround(t *testing.T) {
-	testRangeGroupTwoRangesSurround(t, NewRangeTree())
+func TestRangeTreeAddTwoRangesSurround(t *testing.T) {
+	testRangeGroupAddTwoRangesSurround(t, NewRangeTree())
 }
 
-func testRangeGroupTwoRangesSurround(t *testing.T, rg RangeGroup) {
+func testRangeGroupAddTwoRangesSurround(t *testing.T, rg RangeGroup) {
 	if added := rg.Add(Range{Start: []byte{0x02}, End: []byte{0x03}}); !added {
 		t.Errorf("added new range to range group, wanted true added flag; got false")
 	}
@@ -173,15 +174,15 @@ func testRangeGroupTwoRangesSurround(t *testing.T, rg RangeGroup) {
 	}
 }
 
-func TestRangeListThreeRangesMergeInOrder(t *testing.T) {
-	testRangeGroupThreeRangesMergeInOrder(t, NewRangeList())
+func TestRangeListAddThreeRangesMergeInOrder(t *testing.T) {
+	testRangeGroupAddThreeRangesMergeInOrder(t, NewRangeList())
 }
 
-func TestRangeTreeThreeRangesMergeInOrder(t *testing.T) {
-	testRangeGroupThreeRangesMergeInOrder(t, NewRangeTree())
+func TestRangeTreeAddThreeRangesMergeInOrder(t *testing.T) {
+	testRangeGroupAddThreeRangesMergeInOrder(t, NewRangeTree())
 }
 
-func testRangeGroupThreeRangesMergeInOrder(t *testing.T, rg RangeGroup) {
+func testRangeGroupAddThreeRangesMergeInOrder(t *testing.T, rg RangeGroup) {
 	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
 		t.Errorf("added new range to range group, wanted true added flag; got false")
 	}
@@ -197,15 +198,15 @@ func testRangeGroupThreeRangesMergeInOrder(t *testing.T, rg RangeGroup) {
 	}
 }
 
-func TestRangeListThreeRangesMergeOutOfOrder(t *testing.T) {
-	testRangeGroupThreeRangesMergeOutOfOrder(t, NewRangeList())
+func TestRangeListAddThreeRangesMergeOutOfOrder(t *testing.T) {
+	testRangeGroupAddThreeRangesMergeOutOfOrder(t, NewRangeList())
 }
 
-func TestRangeTreeThreeRangesMergeOutOfOrder(t *testing.T) {
-	testRangeGroupThreeRangesMergeOutOfOrder(t, NewRangeTree())
+func TestRangeTreeAddThreeRangesMergeOutOfOrder(t *testing.T) {
+	testRangeGroupAddThreeRangesMergeOutOfOrder(t, NewRangeTree())
 }
 
-func testRangeGroupThreeRangesMergeOutOfOrder(t *testing.T, rg RangeGroup) {
+func testRangeGroupAddThreeRangesMergeOutOfOrder(t *testing.T, rg RangeGroup) {
 	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
 		t.Errorf("added new range to range group, wanted true added flag; got false")
 	}
@@ -221,15 +222,15 @@ func testRangeGroupThreeRangesMergeOutOfOrder(t *testing.T, rg RangeGroup) {
 	}
 }
 
-func TestRangeListThreeRangesMergeReverseOrder(t *testing.T) {
-	testRangeGroupThreeRangesMergeReverseOrder(t, NewRangeList())
+func TestRangeListAddThreeRangesMergeReverseOrder(t *testing.T) {
+	testRangeGroupAddThreeRangesMergeReverseOrder(t, NewRangeList())
 }
 
-func TestRangeTreeThreeRangesMergeReverseOrder(t *testing.T) {
-	testRangeGroupThreeRangesMergeReverseOrder(t, NewRangeTree())
+func TestRangeTreeAddThreeRangesMergeReverseOrder(t *testing.T) {
+	testRangeGroupAddThreeRangesMergeReverseOrder(t, NewRangeTree())
 }
 
-func testRangeGroupThreeRangesMergeReverseOrder(t *testing.T, rg RangeGroup) {
+func testRangeGroupAddThreeRangesMergeReverseOrder(t *testing.T, rg RangeGroup) {
 	if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
 		t.Errorf("added new range to range group, wanted true added flag; got false")
 	}
@@ -245,15 +246,15 @@ func testRangeGroupThreeRangesMergeReverseOrder(t *testing.T, rg RangeGroup) {
 	}
 }
 
-func TestRangeListThreeRangesSuperset(t *testing.T) {
-	testRangeGroupThreeRangesSuperset(t, NewRangeList())
+func TestRangeListAddThreeRangesSuperset(t *testing.T) {
+	testRangeGroupAddThreeRangesSuperset(t, NewRangeList())
 }
 
-func TestRangeTreeThreeRangesSuperset(t *testing.T) {
-	testRangeGroupThreeRangesSuperset(t, NewRangeTree())
+func TestRangeTreeAddThreeRangesSuperset(t *testing.T) {
+	testRangeGroupAddThreeRangesSuperset(t, NewRangeTree())
 }
 
-func testRangeGroupThreeRangesSuperset(t *testing.T, rg RangeGroup) {
+func testRangeGroupAddThreeRangesSuperset(t *testing.T, rg RangeGroup) {
 	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
 		t.Errorf("added new range to range group, wanted true added flag; got false")
 	}
@@ -269,6 +270,245 @@ func testRangeGroupThreeRangesSuperset(t *testing.T, rg RangeGroup) {
 	}
 }
 
+func TestRangeListSubRanges(t *testing.T) {
+	testRangeGroupSubRanges(t, NewRangeList())
+}
+
+func TestRangeTreeSubRanges(t *testing.T) {
+	testRangeGroupSubRanges(t, NewRangeTree())
+}
+
+func testRangeGroupSubRanges(t *testing.T, rg RangeGroup) {
+	oneRange := []Range{{Start: []byte{0x01}, End: []byte{0x05}}}
+	twoRanges := []Range{
+		{Start: []byte{0x01}, End: []byte{0x05}},
+		{Start: []byte{0x07}, End: []byte{0x0f}},
+	}
+
+	tests := []struct {
+		add []Range
+		sub Range
+		rem bool
+		res []Range
+	}{
+		{
+			add: oneRange,
+			sub: Range{Start: []byte{0x10}, End: []byte{0x11}},
+			rem: false,
+			res: []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+		},
+		{
+			add: oneRange,
+			sub: Range{Start: []byte{0x01}, End: []byte{0x05}},
+			rem: true,
+			res: []Range{},
+		},
+		{
+			add: oneRange,
+			sub: Range{Start: []byte{0x00}, End: []byte{0x06}},
+			rem: true,
+			res: []Range{},
+		},
+		{
+			add: oneRange,
+			sub: Range{Start: []byte{0x04}, End: []byte{0x06}},
+			rem: true,
+			res: []Range{{Start: []byte{0x01}, End: []byte{0x04}}},
+		},
+		{
+			add: oneRange,
+			sub: Range{Start: []byte{0x01}, End: []byte{0x03}},
+			rem: true,
+			res: []Range{{Start: []byte{0x03}, End: []byte{0x05}}},
+		},
+		{
+			add: oneRange,
+			sub: Range{Start: []byte{0x02}, End: []byte{0x04}},
+			rem: true,
+			res: []Range{
+				{Start: []byte{0x01}, End: []byte{0x02}},
+				{Start: []byte{0x04}, End: []byte{0x05}},
+			},
+		},
+		{
+			add: twoRanges,
+			sub: Range{Start: []byte{0x10}, End: []byte{0x11}},
+			rem: false,
+			res: []Range{
+				{Start: []byte{0x01}, End: []byte{0x05}},
+				{Start: []byte{0x07}, End: []byte{0x0f}},
+			},
+		},
+		{
+			add: twoRanges,
+			sub: Range{Start: []byte{0x01}, End: []byte{0x04}},
+			rem: true,
+			res: []Range{
+				{Start: []byte{0x04}, End: []byte{0x05}},
+				{Start: []byte{0x07}, End: []byte{0x0f}},
+			},
+		},
+		{
+			add: twoRanges,
+			sub: Range{Start: []byte{0x01}, End: []byte{0x05}},
+			rem: true,
+			res: []Range{{Start: []byte{0x07}, End: []byte{0x0f}}},
+		},
+		{
+			add: twoRanges,
+			sub: Range{Start: []byte{0x03}, End: []byte{0x09}},
+			rem: true,
+			res: []Range{
+				{Start: []byte{0x01}, End: []byte{0x03}},
+				{Start: []byte{0x09}, End: []byte{0x0f}},
+			},
+		},
+		{
+			add: twoRanges,
+			sub: Range{Start: []byte{0x03}, End: []byte{0xff}},
+			rem: true,
+			res: []Range{
+				{Start: []byte{0x01}, End: []byte{0x03}},
+			},
+		},
+		{
+			add: twoRanges,
+			sub: Range{Start: []byte{0x00}, End: []byte{0x09}},
+			rem: true,
+			res: []Range{
+				{Start: []byte{0x09}, End: []byte{0x0f}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		rg.Clear()
+
+		for _, r := range test.add {
+			if added := rg.Add(r); !added {
+				t.Errorf("added new range %v to empty range group, wanted true added flag; got false", r)
+			}
+		}
+		str := rg.String()
+
+		if rem := rg.Sub(test.sub); rem != test.rem {
+			t.Errorf("subtracted %v from range group %s, wanted %t removed flag; got %t", test.sub, str, test.rem, rem)
+		}
+
+		if l, el := rg.Len(), len(test.res); l != el {
+			t.Errorf("subtracted %v from range group %s, wanted %b remaining ranges; got %b", test.sub, str, el, l)
+		} else {
+			ranges := make([]Range, 0, l)
+			if err := rg.ForEach(func(r Range) error {
+				ranges = append(ranges, r)
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(ranges, test.res) {
+				t.Errorf("subtracted %v from range group %s, wanted the remaining ranges %v; got %v", test.sub, str, test.res, ranges)
+			}
+		}
+	}
+}
+
+func TestRangeListEnclosesRange(t *testing.T) {
+	testRangeGroupEnclosesRange(t, NewRangeList())
+}
+
+func TestRangeTreeEnclosesRange(t *testing.T) {
+	testRangeGroupEnclosesRange(t, NewRangeTree())
+}
+
+func testRangeGroupEnclosesRange(t *testing.T, rg RangeGroup) {
+	twoRanges := []Range{
+		{Start: []byte{0x01}, End: []byte{0x05}},
+		{Start: []byte{0x07}, End: []byte{0x0f}},
+	}
+
+	tests := []struct {
+		r    Range
+		want bool
+	}{
+		{
+			r:    Range{Start: []byte{0x10}, End: []byte{0x11}},
+			want: false,
+		},
+		{
+			r:    Range{Start: []byte{0x01}, End: []byte{0x04}},
+			want: true,
+		},
+		{
+			r:    Range{Start: []byte{0x01}, End: []byte{0x05}},
+			want: true,
+		},
+		{
+			r:    Range{Start: []byte{0x01}, End: []byte{0x0f}},
+			want: false,
+		},
+		{
+			r:    Range{Start: []byte{0x07}, End: []byte{0x0f}},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		rg.Clear()
+
+		for _, r := range twoRanges {
+			if added := rg.Add(r); !added {
+				t.Errorf("added new range %v to empty range group, wanted true added flag; got false", r)
+			}
+		}
+
+		if enc := rg.Encloses(test.r); enc != test.want {
+			t.Errorf("testing if range group %v encloses range %v, wanted %t; got %t", rg, test.r, test.want, enc)
+		}
+	}
+}
+
+func TestRangeListStringer(t *testing.T) {
+	testRangeGroupStringer(t, NewRangeList())
+}
+
+func TestRangeTreeStringer(t *testing.T) {
+	testRangeGroupStringer(t, NewRangeTree())
+}
+
+func testRangeGroupStringer(t *testing.T, rg RangeGroup) {
+	tests := []struct {
+		rngs []Range
+		str  string
+	}{
+		{
+			rngs: []Range{},
+			str:  "[]",
+		},
+		{
+			rngs: []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+			str:  "[[01-05)]",
+		},
+		{
+			rngs: []Range{
+				{Start: []byte{0x01}, End: []byte{0x05}},
+				{Start: []byte{0x09}, End: []byte{0xff}},
+			},
+			str: "[[01-05) [09-ff)]",
+		},
+	}
+
+	for _, test := range tests {
+		rg.Clear()
+		for _, r := range test.rngs {
+			rg.Add(r)
+		}
+		if str := rg.String(); str != test.str {
+			t.Errorf("added new ranges %v to range group, wanted string value %s; got %s", test.rngs, test.str, str)
+		}
+	}
+}
+
 func TestRangeListAndRangeGroupIdentical(t *testing.T) {
 	const trials = 5
 	for tr := 0; tr < trials; tr++ {
@@ -276,18 +516,58 @@ func TestRangeListAndRangeGroupIdentical(t *testing.T) {
 		rt := NewRangeTree()
 
 		const iters = 20
+		const nBytes = 3
 		for i := 0; i < iters; i++ {
-			r := getRandomRange(t, 3)
-			listAdded := rl.Add(r)
-			treeAdded := rt.Add(r)
+			lStr := rl.String()
+			tStr := rt.String()
+			if lStr != tStr {
+				t.Errorf("expected string value for RangeList and RangeTree to be the same; got %s for RangeList and %s for RangeTree", lStr, tStr)
+			}
+
+			ar := getRandomRange(t, nBytes)
+			listAdded := rl.Add(ar)
+			treeAdded := rt.Add(ar)
 			if listAdded != treeAdded {
-				t.Errorf("expected adding %s to RangeList and RangeTree to produce the same result; got %t from RangeList and %t from RangeTree", r, listAdded, treeAdded)
+				t.Errorf("expected adding %s to RangeList %v and RangeTree %v to produce the same result; got %t from RangeList and %t from RangeTree", ar, rl, rt, listAdded, treeAdded)
+			}
+
+			sr := getRandomRange(t, nBytes)
+			listSubtracted := rl.Sub(sr)
+			treeSubtracted := rt.Sub(sr)
+			if listSubtracted != treeSubtracted {
+				t.Errorf("expected subtracting %s from RangeList %v and RangeTree %v to produce the same result; got %t from RangeList and %t from RangeTree", sr, rl, rt, listSubtracted, treeSubtracted)
+			}
+
+			er := getRandomRange(t, nBytes)
+			listEncloses := rl.Encloses(er)
+			treeEncloses := rt.Encloses(er)
+			if listEncloses != treeEncloses {
+				t.Errorf("expected RangeList %v and RangeTree %v to return the same enclosing state for %v; got %t from RangeList and %t from RangeTree", rl, rt, er, listEncloses, treeEncloses)
 			}
 
 			listLen := rl.Len()
 			treeLen := rt.Len()
 			if listLen != treeLen {
 				t.Errorf("expected RangeList and RangeTree to have the same length; got %d from RangeList and %d from RangeTree", listLen, treeLen)
+			}
+
+			listRngs := make([]Range, 0, rl.Len())
+			treeRngs := make([]Range, 0, rt.Len())
+			if err := rl.ForEach(func(r Range) error {
+				listRngs = append(listRngs, r)
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := rt.ForEach(func(r Range) error {
+				treeRngs = append(treeRngs, r)
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(listRngs, treeRngs) {
+				t.Fatalf(`expected RangeList and RangeTree to contain the same ranges; started with %s, added %v, and subtracted %v to get %v for RangeList and %v for RangeTree`, lStr, ar, sr, rl, rt)
 			}
 		}
 	}


### PR DESCRIPTION
These methods will be used in a few places to help optimize our usage
of interval trees throughout the storage package.
- Sub removes a range from the group and returns if the group shrunk
- Encloses returns whether a provided range is fully enclosed in the
  group
- ForEach applies a function to each of the group's ranges
- String helps with debugging

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4715)

<!-- Reviewable:end -->
