### PR TITLE
util/interval: Create benchmarks for RangeList and RangeTree

### DIFF
--- a/util/interval/range_group_test.go
+++ b/util/interval/range_group_test.go
@@ -315,3 +315,23 @@ func getRandomByteSlice(t *testing.T, n int) []byte {
 	}
 	return s
 }
+
+func BenchmarkRangeList(b *testing.B) {
+	benchmarkRangeGroup(b, NewRangeList())
+}
+
+func BenchmarkRangeTree(b *testing.B) {
+	benchmarkRangeGroup(b, NewRangeTree())
+}
+
+func benchmarkRangeGroup(b *testing.B, rg RangeGroup) {
+	for i := 0; i < b.N; i++ {
+		rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}})
+		rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}})
+		rg.Add(Range{Start: []byte{0x00}, End: []byte{0x02}})
+		rg.Add(Range{Start: []byte{0x01}, End: []byte{0x06}})
+		rg.Add(Range{Start: []byte{0x05}, End: []byte{0x15}})
+		rg.Add(Range{Start: []byte{0x25}, End: []byte{0x30}})
+		rg.Clear()
+	}
+}


### PR DESCRIPTION
This was moved from #4699.

Initial results:

```
name         time/op
RangeList-4  1.26µs ± 3%
RangeTree-4  2.30µs ± 1%

name         alloc/op
RangeList-4    444B ± 0%
RangeTree-4    572B ± 0%

name         allocs/op
RangeList-4    21.0 ± 0%
RangeTree-4    22.0 ± 0%
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4716)

<!-- Reviewable:end -->
