### PR TITLE
storage: Create benchmark for TimestampCache insertion

### DIFF
--- a/storage/timestamp_cache_test.go
+++ b/storage/timestamp_cache_test.go
@@ -436,3 +436,25 @@ func TestTimestampCacheReadVsWrite(t *testing.T) {
 		t.Errorf("expected %s %s; got %s %s", ts2, tc.lowWater, rTS, wTS)
 	}
 }
+
+func BenchmarkTimestampCacheInsertion(b *testing.B) {
+	manual := hlc.NewManualClock(0)
+	clock := hlc.NewClock(manual.UnixNano)
+	tc := NewTimestampCache(clock)
+
+	for i := 0; i < b.N; i++ {
+		tc.Clear(clock)
+
+		cdTS := clock.Now()
+		tc.Add(roachpb.Key("c"), roachpb.Key("d"), cdTS, nil, true)
+
+		beTS := clock.Now()
+		tc.Add(roachpb.Key("b"), roachpb.Key("e"), beTS, nil, true)
+
+		adTS := clock.Now()
+		tc.Add(roachpb.Key("a"), roachpb.Key("d"), adTS, nil, true)
+
+		cfTS := clock.Now()
+		tc.Add(roachpb.Key("c"), roachpb.Key("f"), cfTS, nil, true)
+	}
+}


### PR DESCRIPTION
This was moved from #4699. Note that this is using an HLC, so the logical clock is sufficient for ordering.

Initial results:

```
name                       time/op
TimestampCacheInsertion-4  4.78µs ± 2%

name                       alloc/op
TimestampCacheInsertion-4  1.15kB ± 0%

name                       allocs/op
TimestampCacheInsertion-4    20.0 ± 0%
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4717)

<!-- Reviewable:end -->
