### PR TITLE
Add map NodeID->ObservedTimestamp to Txn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ check:
            test ! -s forbidden.log
 	@rm -f forbidden.log
 	@echo "ineffassign"
-	@! ineffassign . | grep -vF gossip/gossip.pb.go
+	@! ineffassign . | grep -vE 'roachpb/data.pb.go|gossip/gossip.pb.go' # gogo/protobuf#152
 	@echo "errcheck"
 	@errcheck -ignore 'bytes:Write.*,io:Close,net:Close,net/http:Close,net/rpc:Close,os:Close,database/sql:Close' $(PKG)
 	@echo "returncheck"

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -378,10 +378,12 @@ func TestOwnNodeCertain(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var act []roachpb.NodeWithTimestamp
+	act := make(map[roachpb.NodeID]roachpb.Timestamp)
 	var testFn rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
 		ba roachpb.BatchRequest, _ *rpc.Context) (proto.Message, error) {
-		act = append([]roachpb.NodeWithTimestamp(nil), ba.Txn.MaxTimestamps...)
+		for k, v := range ba.Txn.ObservedTimestamps {
+			act[k] = v
+		}
 		return ba.CreateReply(), nil
 	}
 
@@ -396,12 +398,17 @@ func TestOwnNodeCertain(t *testing.T) {
 	v := roachpb.MakeValueFromString("value")
 	put := roachpb.NewPut(roachpb.Key("a"), v)
 	if _, err := client.SendWrappedWith(ds, nil, roachpb.Header{
-		Txn: &roachpb.Transaction{OrigTimestamp: expTS},
+		// ObservedTimestamp is set very high so that all uncertainty updates have
+		// effect.
+		Txn: &roachpb.Transaction{OrigTimestamp: expTS, ObservedTimestamp: roachpb.MaxTimestamp},
 	}, put); err != nil {
 		t.Fatalf("put encountered error: %s", err)
 	}
-	if len(act) != 1 || act[0].NodeID != expNodeID || !act[0].MaxTimestamp.Equal(expTS) {
-		t.Fatalf("got %v, expected only entry for %d with timestamp %s", act, expNodeID, expTS)
+	exp := map[roachpb.NodeID]roachpb.Timestamp{
+		expNodeID: expTS,
+	}
+	if !reflect.DeepEqual(exp, act) {
+		t.Fatalf("wanted %v, got %v", exp, act)
 	}
 
 }

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -732,7 +732,8 @@ func (tc *TxnCoordSender) updateState(ctx context.Context, ba roachpb.BatchReque
 			panic("no replica set in header on uncertainty restart")
 		}
 		newTxn.Update(pErr.GetTxn())
-		newTxn.CertainNodes.Add(t.NodeID)
+		// No more restarts for this node for anything after ExistingTimestamp.
+		newTxn.UpdateUncertainty(t.NodeID, t.ExistingTimestamp)
 		// If the reader encountered a newer write within the uncertainty
 		// interval, move the timestamp forward, just past that write or
 		// up to MaxTimestamp, whichever comes first.

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -733,11 +733,11 @@ func (tc *TxnCoordSender) updateState(ctx context.Context, ba roachpb.BatchReque
 		}
 		newTxn.Update(pErr.GetTxn())
 		// No more restarts for this node for anything after ExistingTimestamp.
-		newTxn.UpdateUncertainty(t.NodeID, t.ExistingTimestamp)
+		newTxn.UpdateObservedTimestamp(t.NodeID, t.ExistingTimestamp)
 		// If the reader encountered a newer write within the uncertainty
 		// interval, move the timestamp forward, just past that write or
-		// up to MaxTimestamp, whichever comes first.
-		candidateTS := newTxn.MaxTimestamp
+		// up to ObservedTimestamp, whichever comes first.
+		candidateTS := newTxn.ObservedTimestamp
 		candidateTS.Backward(t.ExistingTimestamp.Add(0, 1))
 		newTxn.Timestamp.Forward(candidateTS)
 		newTxn.Restart(ba.UserPriority, newTxn.Priority, newTxn.Timestamp)

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -597,9 +597,9 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			t.Errorf("%d: expected orig timestamp to be %s + 1; got %s",
 				i, test.expOrigTS, txn.Proto.OrigTimestamp)
 		}
-		if nodes := txn.Proto.CertainNodes.Nodes; (len(nodes) != 0) != test.nodeSeen {
+		if ns := txn.Proto.MaxTimestamps; (len(ns) != 0) != test.nodeSeen {
 			t.Errorf("%d: expected nodeSeen=%t, but list of hosts is %v",
-				i, test.nodeSeen, nodes)
+				i, test.nodeSeen, ns)
 		}
 	}
 }

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -597,7 +597,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			t.Errorf("%d: expected orig timestamp to be %s + 1; got %s",
 				i, test.expOrigTS, txn.Proto.OrigTimestamp)
 		}
-		if ns := txn.Proto.MaxTimestamps; (len(ns) != 0) != test.nodeSeen {
+		if ns := txn.Proto.ObservedTimestamps; (len(ns) != 0) != test.nodeSeen {
 			t.Errorf("%d: expected nodeSeen=%t, but list of hosts is %v",
 				i, test.nodeSeen, ns)
 		}

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -324,7 +324,7 @@ func TestUncertaintyRestarts(t *testing.T) {
 	}
 }
 
-// TestUncertaintyMaxTimestampForwarding checks that we correctly read
+// TestUncertaintyObservedTimestampForwarding checks that we correctly read
 // from hosts for which we control the uncertainty by checking that
 // when a transaction restarts after an uncertain read, it will also
 // take into account the target node's clock at the time of the failed
@@ -333,7 +333,7 @@ func TestUncertaintyRestarts(t *testing.T) {
 // This is a prerequisite for being able to prevent further uncertainty
 // restarts for that node and transaction without sacrificing correctness.
 // See roachpb.Transaction.CertainNodes for details.
-func TestUncertaintyMaxTimestampForwarding(t *testing.T) {
+func TestUncertaintyObservedTimestampForwarding(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := createTestDB(t)
 	disableOwnNodeCertain(s)

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -73,7 +73,6 @@
 		ChangeReplicasTrigger
 		ModifiedSpanTrigger
 		InternalCommitTrigger
-		NodeWithTimestamp
 		TxnMeta
 		Transaction
 		Intent

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -73,7 +73,7 @@
 		ChangeReplicasTrigger
 		ModifiedSpanTrigger
 		InternalCommitTrigger
-		NodeList
+		NodeWithTimestamp
 		TxnMeta
 		Transaction
 		Intent

--- a/roachpb/data.pb.go
+++ b/roachpb/data.pb.go
@@ -374,15 +374,6 @@ func (m *InternalCommitTrigger) GetModifiedSpanTrigger() *ModifiedSpanTrigger {
 	return nil
 }
 
-type NodeWithTimestamp struct {
-	NodeID       NodeID    `protobuf:"varint,1,opt,name=node_id,casttype=NodeID" json:"node_id"`
-	MaxTimestamp Timestamp `protobuf:"bytes,2,opt,name=max_timestamp" json:"max_timestamp"`
-}
-
-func (m *NodeWithTimestamp) Reset()         { *m = NodeWithTimestamp{} }
-func (m *NodeWithTimestamp) String() string { return proto.CompactTextString(m) }
-func (*NodeWithTimestamp) ProtoMessage()    {}
-
 // TxnMeta is the metadata of a Transaction record.
 type TxnMeta struct {
 	// id is a unique UUID value which identifies the transaction.
@@ -428,31 +419,21 @@ type Transaction struct {
 	// transaction will retry.
 	OrigTimestamp Timestamp `protobuf:"bytes,6,opt,name=orig_timestamp" json:"orig_timestamp"`
 	// Initial Timestamp + clock skew. Reads which encounter values with
-	// timestamps between timestamp and max_timestamp trigger a txn
+	// timestamps between timestamp and observed_timestamp trigger a txn
 	// retry error, unless the node being read is listed in certain_nodes
 	// (in which case no more read uncertainty can occur).
-	// The case max_timestamp < timestamp is possible for transactions which have
-	// been pushed; in this case, max_timestamp should be ignored.
-	MaxTimestamp Timestamp `protobuf:"bytes,7,opt,name=max_timestamp" json:"max_timestamp"`
-	// A sorted list of ids of nodes for which a ReadWithinUncertaintyIntervalError
-	// occurred during a prior read. The purpose of keeping this information is
-	// that as a reaction to this error, the transaction's timestamp is forwarded
-	// appropriately to reflect that node's clock uncertainty. Future reads to
-	// the same node are therefore freed from uncertainty restarts.
-	//
-	// The exact mechanism is that upon encountering the above error, the trans-
-	// action will have to retry with a higher timestamp. This higher timestamp
-	// is either the one of the encountered future write returned in the error
-	// or (if higher, which is in the majority of cases), the time of the node
-	// serving the key at the time of the failed read.
-	// Additionally storing the node, we make sure to set max_timestamp=timestamp
-	// at the time of the read for nodes whose clock we've taken into account,
-	// which amounts to reading without any uncertainty.
-	//
-	// Bits of this mechanism are found in the local sender, the range and the
-	// txn_coord_sender, with brief comments referring here.
-	// See https://github.com/cockroachdb/cockroach/pull/221.
-	MaxTimestamps []NodeWithTimestamp `protobuf:"bytes,8,rep,name=max_timestamps" json:"max_timestamps"`
+	// The case observed_timestamp < timestamp is possible for transactions which have
+	// been pushed; in this case, observed_timestamp should be ignored.
+	ObservedTimestamp Timestamp `protobuf:"bytes,7,opt,name=observed_timestamp" json:"observed_timestamp"`
+	// A map of NodeID to timestamps as observed from their local clock during
+	// this transaction. The purpose of this map is to avoid uncertainty related
+	// restarts which normally occur when reading a value in the near future as
+	// per the observed_timestamp field.
+	// When this map holds a corresponding entry for the node the current request
+	// is executing on, we can run the command with the map's timestamp as the
+	// top boundary of our uncertainty interval, limiting (and often avoiding)
+	// uncertainty restarts.
+	ObservedTimestamps map[NodeID]Timestamp `protobuf:"bytes,8,rep,name=observed_timestamps,castkey=NodeID" json:"observed_timestamps" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Writing is true if the transaction has previously executed a successful
 	// write request, i.e. a request that may have left intents (across retries).
 	Writing bool `protobuf:"varint,9,opt,name=Writing" json:"Writing"`
@@ -518,7 +499,6 @@ func init() {
 	proto.RegisterType((*ChangeReplicasTrigger)(nil), "cockroach.roachpb.ChangeReplicasTrigger")
 	proto.RegisterType((*ModifiedSpanTrigger)(nil), "cockroach.roachpb.ModifiedSpanTrigger")
 	proto.RegisterType((*InternalCommitTrigger)(nil), "cockroach.roachpb.InternalCommitTrigger")
-	proto.RegisterType((*NodeWithTimestamp)(nil), "cockroach.roachpb.NodeWithTimestamp")
 	proto.RegisterType((*TxnMeta)(nil), "cockroach.roachpb.TxnMeta")
 	proto.RegisterType((*Transaction)(nil), "cockroach.roachpb.Transaction")
 	proto.RegisterType((*Intent)(nil), "cockroach.roachpb.Intent")
@@ -878,35 +858,6 @@ func (m *InternalCommitTrigger) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
-func (m *NodeWithTimestamp) Marshal() (data []byte, err error) {
-	size := m.Size()
-	data = make([]byte, size)
-	n, err := m.MarshalTo(data)
-	if err != nil {
-		return nil, err
-	}
-	return data[:n], nil
-}
-
-func (m *NodeWithTimestamp) MarshalTo(data []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	data[i] = 0x8
-	i++
-	i = encodeVarintData(data, i, uint64(m.NodeID))
-	data[i] = 0x12
-	i++
-	i = encodeVarintData(data, i, uint64(m.MaxTimestamp.Size()))
-	n13, err := m.MaxTimestamp.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n13
-	return i, nil
-}
-
 func (m *TxnMeta) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -926,11 +877,11 @@ func (m *TxnMeta) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintData(data, i, uint64(m.ID.Size()))
-		n14, err := m.ID.MarshalTo(data[i:])
+		n13, err := m.ID.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n14
+		i += n13
 	}
 	data[i] = 0x10
 	i++
@@ -947,11 +898,11 @@ func (m *TxnMeta) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x2a
 	i++
 	i = encodeVarintData(data, i, uint64(m.Timestamp.Size()))
-	n15, err := m.Timestamp.MarshalTo(data[i:])
+	n14, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n15
+	i += n14
 	return i, nil
 }
 
@@ -973,11 +924,11 @@ func (m *Transaction) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintData(data, i, uint64(m.TxnMeta.Size()))
-	n16, err := m.TxnMeta.MarshalTo(data[i:])
+	n15, err := m.TxnMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n16
+	i += n15
 	data[i] = 0x12
 	i++
 	i = encodeVarintData(data, i, uint64(len(m.Name)))
@@ -992,38 +943,47 @@ func (m *Transaction) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintData(data, i, uint64(m.LastHeartbeat.Size()))
-		n17, err := m.LastHeartbeat.MarshalTo(data[i:])
+		n16, err := m.LastHeartbeat.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n17
+		i += n16
 	}
 	data[i] = 0x32
 	i++
 	i = encodeVarintData(data, i, uint64(m.OrigTimestamp.Size()))
-	n18, err := m.OrigTimestamp.MarshalTo(data[i:])
+	n17, err := m.OrigTimestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n17
+	data[i] = 0x3a
+	i++
+	i = encodeVarintData(data, i, uint64(m.ObservedTimestamp.Size()))
+	n18, err := m.ObservedTimestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n18
-	data[i] = 0x3a
-	i++
-	i = encodeVarintData(data, i, uint64(m.MaxTimestamp.Size()))
-	n19, err := m.MaxTimestamp.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n19
-	if len(m.MaxTimestamps) > 0 {
-		for _, msg := range m.MaxTimestamps {
+	if len(m.ObservedTimestamps) > 0 {
+		for k := range m.ObservedTimestamps {
 			data[i] = 0x42
 			i++
-			i = encodeVarintData(data, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(data[i:])
+			v := m.ObservedTimestamps[k]
+			msgSize := (&v).Size()
+			mapSize := 1 + sovData(uint64(k)) + 1 + msgSize + sovData(uint64(msgSize))
+			i = encodeVarintData(data, i, uint64(mapSize))
+			data[i] = 0x8
+			i++
+			i = encodeVarintData(data, i, uint64(k))
+			data[i] = 0x12
+			i++
+			i = encodeVarintData(data, i, uint64((&v).Size()))
+			n19, err := (&v).MarshalTo(data[i:])
 			if err != nil {
 				return 0, err
 			}
-			i += n
+			i += n19
 		}
 	}
 	data[i] = 0x48
@@ -1312,15 +1272,6 @@ func (m *InternalCommitTrigger) Size() (n int) {
 	return n
 }
 
-func (m *NodeWithTimestamp) Size() (n int) {
-	var l int
-	_ = l
-	n += 1 + sovData(uint64(m.NodeID))
-	l = m.MaxTimestamp.Size()
-	n += 1 + l + sovData(uint64(l))
-	return n
-}
-
 func (m *TxnMeta) Size() (n int) {
 	var l int
 	_ = l
@@ -1354,12 +1305,15 @@ func (m *Transaction) Size() (n int) {
 	}
 	l = m.OrigTimestamp.Size()
 	n += 1 + l + sovData(uint64(l))
-	l = m.MaxTimestamp.Size()
+	l = m.ObservedTimestamp.Size()
 	n += 1 + l + sovData(uint64(l))
-	if len(m.MaxTimestamps) > 0 {
-		for _, e := range m.MaxTimestamps {
-			l = e.Size()
-			n += 1 + l + sovData(uint64(l))
+	if len(m.ObservedTimestamps) > 0 {
+		for k, v := range m.ObservedTimestamps {
+			_ = k
+			_ = v
+			l = v.Size()
+			mapEntrySize := 1 + sovData(uint64(k)) + 1 + l + sovData(uint64(l))
+			n += mapEntrySize + 1 + sovData(uint64(mapEntrySize))
 		}
 	}
 	n += 2
@@ -2601,105 +2555,6 @@ func (m *InternalCommitTrigger) Unmarshal(data []byte) error {
 	}
 	return nil
 }
-func (m *NodeWithTimestamp) Unmarshal(data []byte) error {
-	l := len(data)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowData
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := data[iNdEx]
-			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: NodeWithTimestamp: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: NodeWithTimestamp: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field NodeID", wireType)
-			}
-			m.NodeID = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowData
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.NodeID |= (NodeID(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field MaxTimestamp", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowData
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthData
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.MaxTimestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipData(data[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthData
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
 func (m *TxnMeta) Unmarshal(data []byte) error {
 	l := len(data)
 	iNdEx := 0
@@ -3072,7 +2927,7 @@ func (m *Transaction) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 7:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field MaxTimestamp", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field ObservedTimestamp", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -3096,13 +2951,13 @@ func (m *Transaction) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.MaxTimestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
+			if err := m.ObservedTimestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
 		case 8:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field MaxTimestamps", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field ObservedTimestamps", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -3126,10 +2981,85 @@ func (m *Transaction) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.MaxTimestamps = append(m.MaxTimestamps, NodeWithTimestamp{})
-			if err := m.MaxTimestamps[len(m.MaxTimestamps)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+			var keykey uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowData
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				keykey |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			var mapkey int32
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowData
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				mapkey |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			var valuekey uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowData
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				valuekey |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			var mapmsglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowData
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				mapmsglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if mapmsglen < 0 {
+				return ErrInvalidLengthData
+			}
+			postmsgIndex := iNdEx + mapmsglen
+			if mapmsglen < 0 {
+				return ErrInvalidLengthData
+			}
+			if postmsgIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			mapvalue := &Timestamp{}
+			if err := mapvalue.Unmarshal(data[iNdEx:postmsgIndex]); err != nil {
 				return err
 			}
+			iNdEx = postmsgIndex
+			if m.ObservedTimestamps == nil {
+				m.ObservedTimestamps = make(map[NodeID]Timestamp)
+			}
+			m.ObservedTimestamps[NodeID(mapkey)] = *mapvalue
 			iNdEx = postIndex
 		case 9:
 			if wireType != 0 {

--- a/roachpb/data.pb.go
+++ b/roachpb/data.pb.go
@@ -374,15 +374,14 @@ func (m *InternalCommitTrigger) GetModifiedSpanTrigger() *ModifiedSpanTrigger {
 	return nil
 }
 
-// NodeList keeps a growing set of NodeIDs as a sorted slice, with Add()
-// adding to the set and Contains() verifying membership.
-type NodeList struct {
-	Nodes []NodeID `protobuf:"varint,1,rep,packed,name=nodes,casttype=NodeID" json:"nodes,omitempty"`
+type NodeWithTimestamp struct {
+	NodeID       NodeID    `protobuf:"varint,1,opt,name=node_id,casttype=NodeID" json:"node_id"`
+	MaxTimestamp Timestamp `protobuf:"bytes,2,opt,name=max_timestamp" json:"max_timestamp"`
 }
 
-func (m *NodeList) Reset()         { *m = NodeList{} }
-func (m *NodeList) String() string { return proto.CompactTextString(m) }
-func (*NodeList) ProtoMessage()    {}
+func (m *NodeWithTimestamp) Reset()         { *m = NodeWithTimestamp{} }
+func (m *NodeWithTimestamp) String() string { return proto.CompactTextString(m) }
+func (*NodeWithTimestamp) ProtoMessage()    {}
 
 // TxnMeta is the metadata of a Transaction record.
 type TxnMeta struct {
@@ -453,7 +452,7 @@ type Transaction struct {
 	// Bits of this mechanism are found in the local sender, the range and the
 	// txn_coord_sender, with brief comments referring here.
 	// See https://github.com/cockroachdb/cockroach/pull/221.
-	CertainNodes NodeList `protobuf:"bytes,8,opt,name=certain_nodes" json:"certain_nodes"`
+	MaxTimestamps []NodeWithTimestamp `protobuf:"bytes,8,rep,name=max_timestamps" json:"max_timestamps"`
 	// Writing is true if the transaction has previously executed a successful
 	// write request, i.e. a request that may have left intents (across retries).
 	Writing bool `protobuf:"varint,9,opt,name=Writing" json:"Writing"`
@@ -519,7 +518,7 @@ func init() {
 	proto.RegisterType((*ChangeReplicasTrigger)(nil), "cockroach.roachpb.ChangeReplicasTrigger")
 	proto.RegisterType((*ModifiedSpanTrigger)(nil), "cockroach.roachpb.ModifiedSpanTrigger")
 	proto.RegisterType((*InternalCommitTrigger)(nil), "cockroach.roachpb.InternalCommitTrigger")
-	proto.RegisterType((*NodeList)(nil), "cockroach.roachpb.NodeList")
+	proto.RegisterType((*NodeWithTimestamp)(nil), "cockroach.roachpb.NodeWithTimestamp")
 	proto.RegisterType((*TxnMeta)(nil), "cockroach.roachpb.TxnMeta")
 	proto.RegisterType((*Transaction)(nil), "cockroach.roachpb.Transaction")
 	proto.RegisterType((*Intent)(nil), "cockroach.roachpb.Intent")
@@ -879,7 +878,7 @@ func (m *InternalCommitTrigger) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
-func (m *NodeList) Marshal() (data []byte, err error) {
+func (m *NodeWithTimestamp) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
 	n, err := m.MarshalTo(data)
@@ -889,29 +888,22 @@ func (m *NodeList) Marshal() (data []byte, err error) {
 	return data[:n], nil
 }
 
-func (m *NodeList) MarshalTo(data []byte) (int, error) {
+func (m *NodeWithTimestamp) MarshalTo(data []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
 	_ = l
-	if len(m.Nodes) > 0 {
-		data14 := make([]byte, len(m.Nodes)*10)
-		var j13 int
-		for _, num1 := range m.Nodes {
-			num := uint64(num1)
-			for num >= 1<<7 {
-				data14[j13] = uint8(uint64(num)&0x7f | 0x80)
-				num >>= 7
-				j13++
-			}
-			data14[j13] = uint8(num)
-			j13++
-		}
-		data[i] = 0xa
-		i++
-		i = encodeVarintData(data, i, uint64(j13))
-		i += copy(data[i:], data14[:j13])
+	data[i] = 0x8
+	i++
+	i = encodeVarintData(data, i, uint64(m.NodeID))
+	data[i] = 0x12
+	i++
+	i = encodeVarintData(data, i, uint64(m.MaxTimestamp.Size()))
+	n13, err := m.MaxTimestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
 	}
+	i += n13
 	return i, nil
 }
 
@@ -934,11 +926,11 @@ func (m *TxnMeta) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintData(data, i, uint64(m.ID.Size()))
-		n15, err := m.ID.MarshalTo(data[i:])
+		n14, err := m.ID.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n15
+		i += n14
 	}
 	data[i] = 0x10
 	i++
@@ -955,11 +947,11 @@ func (m *TxnMeta) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x2a
 	i++
 	i = encodeVarintData(data, i, uint64(m.Timestamp.Size()))
-	n16, err := m.Timestamp.MarshalTo(data[i:])
+	n15, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n16
+	i += n15
 	return i, nil
 }
 
@@ -981,11 +973,11 @@ func (m *Transaction) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintData(data, i, uint64(m.TxnMeta.Size()))
-	n17, err := m.TxnMeta.MarshalTo(data[i:])
+	n16, err := m.TxnMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n17
+	i += n16
 	data[i] = 0x12
 	i++
 	i = encodeVarintData(data, i, uint64(len(m.Name)))
@@ -1000,36 +992,40 @@ func (m *Transaction) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintData(data, i, uint64(m.LastHeartbeat.Size()))
-		n18, err := m.LastHeartbeat.MarshalTo(data[i:])
+		n17, err := m.LastHeartbeat.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n18
+		i += n17
 	}
 	data[i] = 0x32
 	i++
 	i = encodeVarintData(data, i, uint64(m.OrigTimestamp.Size()))
-	n19, err := m.OrigTimestamp.MarshalTo(data[i:])
+	n18, err := m.OrigTimestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n18
+	data[i] = 0x3a
+	i++
+	i = encodeVarintData(data, i, uint64(m.MaxTimestamp.Size()))
+	n19, err := m.MaxTimestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n19
-	data[i] = 0x3a
-	i++
-	i = encodeVarintData(data, i, uint64(m.MaxTimestamp.Size()))
-	n20, err := m.MaxTimestamp.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
+	if len(m.MaxTimestamps) > 0 {
+		for _, msg := range m.MaxTimestamps {
+			data[i] = 0x42
+			i++
+			i = encodeVarintData(data, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(data[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
 	}
-	i += n20
-	data[i] = 0x42
-	i++
-	i = encodeVarintData(data, i, uint64(m.CertainNodes.Size()))
-	n21, err := m.CertainNodes.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n21
 	data[i] = 0x48
 	i++
 	if m.Writing {
@@ -1074,19 +1070,19 @@ func (m *Intent) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintData(data, i, uint64(m.Span.Size()))
-	n22, err := m.Span.MarshalTo(data[i:])
+	n20, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n22
+	i += n20
 	data[i] = 0x12
 	i++
 	i = encodeVarintData(data, i, uint64(m.Txn.Size()))
-	n23, err := m.Txn.MarshalTo(data[i:])
+	n21, err := m.Txn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n21
 	data[i] = 0x18
 	i++
 	i = encodeVarintData(data, i, uint64(m.Status))
@@ -1111,27 +1107,27 @@ func (m *Lease) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintData(data, i, uint64(m.Start.Size()))
-	n24, err := m.Start.MarshalTo(data[i:])
+	n22, err := m.Start.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n22
+	data[i] = 0x12
+	i++
+	i = encodeVarintData(data, i, uint64(m.Expiration.Size()))
+	n23, err := m.Expiration.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n23
+	data[i] = 0x1a
+	i++
+	i = encodeVarintData(data, i, uint64(m.Replica.Size()))
+	n24, err := m.Replica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n24
-	data[i] = 0x12
-	i++
-	i = encodeVarintData(data, i, uint64(m.Expiration.Size()))
-	n25, err := m.Expiration.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n25
-	data[i] = 0x1a
-	i++
-	i = encodeVarintData(data, i, uint64(m.Replica.Size()))
-	n26, err := m.Replica.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n26
 	return i, nil
 }
 
@@ -1159,11 +1155,11 @@ func (m *SequenceCacheEntry) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintData(data, i, uint64(m.Timestamp.Size()))
-	n27, err := m.Timestamp.MarshalTo(data[i:])
+	n25, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n27
+	i += n25
 	return i, nil
 }
 
@@ -1316,16 +1312,12 @@ func (m *InternalCommitTrigger) Size() (n int) {
 	return n
 }
 
-func (m *NodeList) Size() (n int) {
+func (m *NodeWithTimestamp) Size() (n int) {
 	var l int
 	_ = l
-	if len(m.Nodes) > 0 {
-		l = 0
-		for _, e := range m.Nodes {
-			l += sovData(uint64(e))
-		}
-		n += 1 + sovData(uint64(l)) + l
-	}
+	n += 1 + sovData(uint64(m.NodeID))
+	l = m.MaxTimestamp.Size()
+	n += 1 + l + sovData(uint64(l))
 	return n
 }
 
@@ -1364,8 +1356,12 @@ func (m *Transaction) Size() (n int) {
 	n += 1 + l + sovData(uint64(l))
 	l = m.MaxTimestamp.Size()
 	n += 1 + l + sovData(uint64(l))
-	l = m.CertainNodes.Size()
-	n += 1 + l + sovData(uint64(l))
+	if len(m.MaxTimestamps) > 0 {
+		for _, e := range m.MaxTimestamps {
+			l = e.Size()
+			n += 1 + l + sovData(uint64(l))
+		}
+	}
 	n += 2
 	n += 1 + sovData(uint64(m.Sequence))
 	if len(m.Intents) > 0 {
@@ -2605,7 +2601,7 @@ func (m *InternalCommitTrigger) Unmarshal(data []byte) error {
 	}
 	return nil
 }
-func (m *NodeList) Unmarshal(data []byte) error {
+func (m *NodeWithTimestamp) Unmarshal(data []byte) error {
 	l := len(data)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2628,74 +2624,61 @@ func (m *NodeList) Unmarshal(data []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: NodeList: wiretype end group for non-group")
+			return fmt.Errorf("proto: NodeWithTimestamp: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: NodeList: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: NodeWithTimestamp: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
-			if wireType == 2 {
-				var packedLen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowData
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := data[iNdEx]
-					iNdEx++
-					packedLen |= (int(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeID", wireType)
+			}
+			m.NodeID = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowData
 				}
-				if packedLen < 0 {
-					return ErrInvalidLengthData
-				}
-				postIndex := iNdEx + packedLen
-				if postIndex > l {
+				if iNdEx >= l {
 					return io.ErrUnexpectedEOF
 				}
-				for iNdEx < postIndex {
-					var v NodeID
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowData
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := data[iNdEx]
-						iNdEx++
-						v |= (NodeID(b) & 0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					m.Nodes = append(m.Nodes, v)
+				b := data[iNdEx]
+				iNdEx++
+				m.NodeID |= (NodeID(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
 				}
-			} else if wireType == 0 {
-				var v NodeID
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowData
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := data[iNdEx]
-					iNdEx++
-					v |= (NodeID(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				m.Nodes = append(m.Nodes, v)
-			} else {
-				return fmt.Errorf("proto: wrong wireType = %d for field Nodes", wireType)
 			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxTimestamp", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowData
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthData
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.MaxTimestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipData(data[iNdEx:])
@@ -3119,7 +3102,7 @@ func (m *Transaction) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 8:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field CertainNodes", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxTimestamps", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -3143,7 +3126,8 @@ func (m *Transaction) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.CertainNodes.Unmarshal(data[iNdEx:postIndex]); err != nil {
+			m.MaxTimestamps = append(m.MaxTimestamps, NodeWithTimestamp{})
+			if err := m.MaxTimestamps[len(m.MaxTimestamps)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -207,10 +207,9 @@ enum TransactionStatus {
   ABORTED = 2;
 }
 
-// NodeList keeps a growing set of NodeIDs as a sorted slice, with Add()
-// adding to the set and Contains() verifying membership.
-message NodeList {
-  repeated int32 nodes = 1 [packed = true, (gogoproto.casttype) = "NodeID"];
+message NodeWithTimestamp {
+  optional int32 node_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID", (gogoproto.casttype) = "NodeID"];
+  optional Timestamp max_timestamp = 2 [(gogoproto.nullable) = false];
 }
 
 // TxnMeta is the metadata of a Transaction record.
@@ -281,7 +280,7 @@ message Transaction {
   // Bits of this mechanism are found in the local sender, the range and the
   // txn_coord_sender, with brief comments referring here.
   // See https://github.com/cockroachdb/cockroach/pull/221.
-  optional NodeList certain_nodes = 8 [(gogoproto.nullable) = false];
+  repeated NodeWithTimestamp max_timestamps = 8 [(gogoproto.nullable) = false];
   // Writing is true if the transaction has previously executed a successful
   // write request, i.e. a request that may have left intents (across retries).
   optional bool Writing = 9 [(gogoproto.nullable) = false];

--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -207,11 +207,6 @@ enum TransactionStatus {
   ABORTED = 2;
 }
 
-message NodeWithTimestamp {
-  optional int32 node_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID", (gogoproto.casttype) = "NodeID"];
-  optional Timestamp max_timestamp = 2 [(gogoproto.nullable) = false];
-}
-
 // TxnMeta is the metadata of a Transaction record.
 message TxnMeta {
   // id is a unique UUID value which identifies the transaction.
@@ -256,31 +251,21 @@ message Transaction {
   // transaction will retry.
   optional Timestamp orig_timestamp = 6 [(gogoproto.nullable) = false];
   // Initial Timestamp + clock skew. Reads which encounter values with
-  // timestamps between timestamp and max_timestamp trigger a txn
+  // timestamps between timestamp and observed_timestamp trigger a txn
   // retry error, unless the node being read is listed in certain_nodes
   // (in which case no more read uncertainty can occur).
-  // The case max_timestamp < timestamp is possible for transactions which have
-  // been pushed; in this case, max_timestamp should be ignored.
-  optional Timestamp max_timestamp = 7 [(gogoproto.nullable) = false];
-  // A sorted list of ids of nodes for which a ReadWithinUncertaintyIntervalError
-  // occurred during a prior read. The purpose of keeping this information is
-  // that as a reaction to this error, the transaction's timestamp is forwarded
-  // appropriately to reflect that node's clock uncertainty. Future reads to
-  // the same node are therefore freed from uncertainty restarts.
-  //
-  // The exact mechanism is that upon encountering the above error, the trans-
-  // action will have to retry with a higher timestamp. This higher timestamp
-  // is either the one of the encountered future write returned in the error
-  // or (if higher, which is in the majority of cases), the time of the node
-  // serving the key at the time of the failed read.
-  // Additionally storing the node, we make sure to set max_timestamp=timestamp
-  // at the time of the read for nodes whose clock we've taken into account,
-  // which amounts to reading without any uncertainty.
-  //
-  // Bits of this mechanism are found in the local sender, the range and the
-  // txn_coord_sender, with brief comments referring here.
-  // See https://github.com/cockroachdb/cockroach/pull/221.
-  repeated NodeWithTimestamp max_timestamps = 8 [(gogoproto.nullable) = false];
+  // The case observed_timestamp < timestamp is possible for transactions which have
+  // been pushed; in this case, observed_timestamp should be ignored.
+  optional Timestamp observed_timestamp = 7 [(gogoproto.nullable) = false];
+  // A map of NodeID to timestamps as observed from their local clock during
+  // this transaction. The purpose of this map is to avoid uncertainty related
+  // restarts which normally occur when reading a value in the near future as
+  // per the observed_timestamp field.
+  // When this map holds a corresponding entry for the node the current request
+  // is executing on, we can run the command with the map's timestamp as the
+  // top boundary of our uncertainty interval, limiting (and often avoiding)
+  // uncertainty restarts.
+  map<int32, Timestamp> observed_timestamps = 8 [(gogoproto.nullable) = false, (gogoproto.castkey) = "NodeID"];
   // Writing is true if the transaction has previously executed a successful
   // write request, i.e. a request that may have left intents (across retries).
   optional bool Writing = 9 [(gogoproto.nullable) = false];

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -28,6 +28,7 @@ import (
 	"gopkg.in/inf.v0"
 
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/randutil"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
 
@@ -402,12 +403,12 @@ func TestTransactionString(t *testing.T) {
 			Epoch:     2,
 			Timestamp: makeTS(20, 21),
 		},
-		Name:          "name",
-		Priority:      957356782,
-		Status:        COMMITTED,
-		LastHeartbeat: &ts1,
-		OrigTimestamp: makeTS(30, 31),
-		MaxTimestamp:  makeTS(40, 41),
+		Name:              "name",
+		Priority:          957356782,
+		Status:            COMMITTED,
+		LastHeartbeat:     &ts1,
+		OrigTimestamp:     makeTS(30, 31),
+		ObservedTimestamp: makeTS(40, 41),
 	}
 	expStr := `"name" id=d7aa0f5e key="foo" rw=false pri=44.58039917 iso=SERIALIZABLE stat=COMMITTED ` +
 		`epo=2 ts=0.000000020,21 orig=0.000000030,31 max=0.000000040,41`
@@ -420,32 +421,33 @@ func TestTransactionString(t *testing.T) {
 	_ = txnEmpty.String() // prevent regression of NPE
 }
 
-// TestTransactionUncertainty verifies that txn.{Get,Update}Uncertainty work as
+// TestTransactionObservedTimestamp verifies that txn.{Get,Update}ObservedTimestamp work as
 // advertised.
-func TestTransactionUncertainty(t *testing.T) {
-	txn := Transaction{}
-	mkTS := func(nodeID NodeID) Timestamp {
-		return ZeroTimestamp.Add(rand.New(rand.NewSource(int64(nodeID))).Int63(), 0)
-	}
+func TestTransactionObservedTimestamp(t *testing.T) {
+	txn := Transaction{ObservedTimestamp: ZeroTimestamp.Add(12345678, 9)}
+	rng, seed := randutil.NewPseudoRand()
+	t.Logf("running with seed %d", seed)
 	ids := append([]int{109, 104, 102, 108, 1000}, rand.Perm(100)...)
+	timestamps := make(map[NodeID]Timestamp, len(ids))
+	for i := 0; i < len(ids); i++ {
+		timestamps[NodeID(i)] = ZeroTimestamp.Add(rng.Int63n(txn.ObservedTimestamp.WallTime), 0)
+	}
 	for i, n := range ids {
 		nodeID := NodeID(n)
-		if ts := txn.GetUncertainty(nodeID); ts != MaxTimestamp {
+		if ts := txn.GetObservedTimestamp(nodeID); ts != txn.ObservedTimestamp {
 			t.Fatalf("%d: false positive hit %s in %v", nodeID, ts, ids[:i+1])
 		}
-		txn.UpdateUncertainty(nodeID, mkTS(nodeID))
-		if exp, act := i+1, len(txn.MaxTimestamps); act != exp {
-			t.Fatalf("%d: expected %d entries, got %d: %v", nodeID, exp, act, txn.MaxTimestamps)
+		txn.UpdateObservedTimestamp(nodeID, timestamps[nodeID])
+		txn.UpdateObservedTimestamp(nodeID, MaxTimestamp) // should be noop
+		if exp, act := i+1, len(txn.ObservedTimestamps); act != exp {
+			t.Fatalf("%d: expected %d entries, got %d: %v", nodeID, exp, act, txn.ObservedTimestamps)
 		}
-		for j, m := range ids[:i+1] {
-			checkID := NodeID(m)
-			var exp Timestamp
-			if j <= i+1 {
-				exp = mkTS(checkID)
-			}
-			if act := txn.GetUncertainty(checkID); !act.Equal(exp) {
-				t.Fatalf("%d: expected %s, got %s", checkID, exp, act)
-			}
+	}
+	for _, m := range ids {
+		checkID := NodeID(m)
+		exp := timestamps[checkID]
+		if act := txn.GetObservedTimestamp(checkID); !act.Equal(exp) {
+			t.Fatalf("%d: expected %s, got %s", checkID, exp, act)
 		}
 	}
 }
@@ -459,16 +461,16 @@ var nonZeroTxn = Transaction{
 		Epoch:     2,
 		Timestamp: makeTS(20, 21),
 	},
-	Name:          "name",
-	Priority:      957356782,
-	Status:        COMMITTED,
-	LastHeartbeat: &Timestamp{1, 2},
-	OrigTimestamp: makeTS(30, 31),
-	MaxTimestamp:  makeTS(40, 41),
-	MaxTimestamps: []NodeWithTimestamp{{NodeID: 1, MaxTimestamp: makeTS(1, 2)}},
-	Writing:       true,
-	Sequence:      123,
-	Intents:       []Span{{Key: []byte("a"), EndKey: []byte("b")}},
+	Name:               "name",
+	Priority:           957356782,
+	Status:             COMMITTED,
+	LastHeartbeat:      &Timestamp{1, 2},
+	OrigTimestamp:      makeTS(30, 31),
+	ObservedTimestamp:  makeTS(40, 41),
+	ObservedTimestamps: map[NodeID]Timestamp{1: makeTS(1, 2)},
+	Writing:            true,
+	Sequence:           123,
+	Intents:            []Span{{Key: []byte("a"), EndKey: []byte("b")}},
 }
 
 func TestTransactionUpdate(t *testing.T) {

--- a/roachpb/metadata.go
+++ b/roachpb/metadata.go
@@ -29,6 +29,7 @@ import (
 type NodeID int32
 
 // NodeIDSlice implements sort.Interface.
+// TODO(tschottdorf): can remove/move to storage/simulation/cluster.go.
 type NodeIDSlice []NodeID
 
 func (n NodeIDSlice) Len() int           { return len(n) }

--- a/roachpb/metadata.go
+++ b/roachpb/metadata.go
@@ -28,14 +28,6 @@ import (
 // NodeID is a custom type for a cockroach node ID. (not a raft node ID)
 type NodeID int32
 
-// NodeIDSlice implements sort.Interface.
-// TODO(tschottdorf): can remove/move to storage/simulation/cluster.go.
-type NodeIDSlice []NodeID
-
-func (n NodeIDSlice) Len() int           { return len(n) }
-func (n NodeIDSlice) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
-func (n NodeIDSlice) Less(i, j int) bool { return n[i] < n[j] }
-
 // String implements the fmt.Stringer interface.
 // It is used to format the ID for use in Gossip keys.
 func (n NodeID) String() string {

--- a/sql/testdata/snapshot_certain_read
+++ b/sql/testdata/snapshot_certain_read
@@ -1,6 +1,6 @@
 # This test verifies that when a SNAPSHOT transaction reads without
 # uncertainty, it actually does that. We had a performance bug which caused the
-# MaxTimestamp to be set to the Timestamp instead of OrigTimestamp on such
+# ObservedTimestamp to be set to the Timestamp instead of OrigTimestamp on such
 # reads, which always left the interval (OrigTimestamp, Timestamp) open to
 # read uncertainty errors.
 
@@ -40,7 +40,7 @@ SELECT * FROM t
 user root
 
 # This insert forces TransactionA's timestamp ahead, so that we have
-# OrigTimestamp < InsertTS < Timestamp < MaxTimestamp
+# OrigTimestamp < InsertTS < Timestamp < ObservedTimestamp
 statement ok
 INSERT INTO t VALUES (2)
 

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -567,19 +567,19 @@ func TestMVCCGetNoMoreOldVersion(t *testing.T) {
 
 // TestMVCCGetUncertainty verifies that the appropriate error results when
 // a transaction reads a key at a timestamp that has versions newer than that
-// timestamp, but older than the transaction's MaxTimestamp.
+// timestamp, but older than the transaction's ObservedTimestamp.
 func TestMVCCGetUncertainty(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
 
-	txn := &roachpb.Transaction{TxnMeta: roachpb.TxnMeta{ID: uuid.NewV4(), Timestamp: makeTS(5, 0)}, MaxTimestamp: makeTS(10, 0)}
+	txn := &roachpb.Transaction{TxnMeta: roachpb.TxnMeta{ID: uuid.NewV4(), Timestamp: makeTS(5, 0)}, ObservedTimestamp: makeTS(10, 0)}
 	// Put a value from the past.
 	if err := MVCCPut(engine, nil, testKey1, makeTS(1, 0), value1, nil); err != nil {
 		t.Fatal(err)
 	}
-	// Put a value that is ahead of MaxTimestamp, it should not interfere.
+	// Put a value that is ahead of ObservedTimestamp, it should not interfere.
 	if err := MVCCPut(engine, nil, testKey1, makeTS(12, 0), value2, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +593,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 	}
 
 	// Now using testKey2.
-	// Put a value that conflicts with MaxTimestamp.
+	// Put a value that conflicts with ObservedTimestamp.
 	if err := MVCCPut(engine, nil, testKey2, makeTS(9, 0), value2, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -606,8 +606,8 @@ func TestMVCCGetUncertainty(t *testing.T) {
 	if _, _, err := MVCCScan(engine, testKey2, testKey2.PrefixEnd(), 10, makeTS(7, 0), true, txn); err == nil {
 		t.Fatal("wanted an error")
 	}
-	// Adjust MaxTimestamp and retry.
-	txn.MaxTimestamp = makeTS(7, 0)
+	// Adjust ObservedTimestamp and retry.
+	txn.ObservedTimestamp = makeTS(7, 0)
 	if _, _, err := MVCCGet(engine, testKey2, makeTS(7, 0), true, txn); err != nil {
 		t.Fatal(err)
 	}
@@ -615,9 +615,9 @@ func TestMVCCGetUncertainty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txn.MaxTimestamp = makeTS(10, 0)
+	txn.ObservedTimestamp = makeTS(10, 0)
 	// Now using testKey3.
-	// Put a value that conflicts with MaxTimestamp and another write further
+	// Put a value that conflicts with ObservedTimestamp and another write further
 	// ahead and not conflicting any longer. The first write should still ruin
 	// it.
 	if err := MVCCPut(engine, nil, testKey3, makeTS(9, 0), value2, nil); err != nil {

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
@@ -52,9 +52,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* InternalCommitTrigger_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   InternalCommitTrigger_reflection_ = NULL;
-const ::google::protobuf::Descriptor* NodeList_descriptor_ = NULL;
+const ::google::protobuf::Descriptor* NodeWithTimestamp_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
-  NodeList_reflection_ = NULL;
+  NodeWithTimestamp_reflection_ = NULL;
 const ::google::protobuf::Descriptor* TxnMeta_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   TxnMeta_reflection_ = NULL;
@@ -249,20 +249,21 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
       sizeof(InternalCommitTrigger),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, _internal_metadata_),
       -1);
-  NodeList_descriptor_ = file->message_type(10);
-  static const int NodeList_offsets_[1] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeList, nodes_),
+  NodeWithTimestamp_descriptor_ = file->message_type(10);
+  static const int NodeWithTimestamp_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeWithTimestamp, node_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeWithTimestamp, max_timestamp_),
   };
-  NodeList_reflection_ =
+  NodeWithTimestamp_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
-      NodeList_descriptor_,
-      NodeList::default_instance_,
-      NodeList_offsets_,
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeList, _has_bits_[0]),
+      NodeWithTimestamp_descriptor_,
+      NodeWithTimestamp::default_instance_,
+      NodeWithTimestamp_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeWithTimestamp, _has_bits_[0]),
       -1,
       -1,
-      sizeof(NodeList),
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeList, _internal_metadata_),
+      sizeof(NodeWithTimestamp),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeWithTimestamp, _internal_metadata_),
       -1);
   TxnMeta_descriptor_ = file->message_type(11);
   static const int TxnMeta_offsets_[5] = {
@@ -292,7 +293,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, last_heartbeat_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, orig_timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, max_timestamp_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, certain_nodes_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, max_timestamps_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, writing_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, sequence_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, intents_),
@@ -395,7 +396,7 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       InternalCommitTrigger_descriptor_, &InternalCommitTrigger::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
-      NodeList_descriptor_, &NodeList::default_instance());
+      NodeWithTimestamp_descriptor_, &NodeWithTimestamp::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       TxnMeta_descriptor_, &TxnMeta::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
@@ -431,8 +432,8 @@ void protobuf_ShutdownFile_cockroach_2froachpb_2fdata_2eproto() {
   delete ModifiedSpanTrigger_reflection_;
   delete InternalCommitTrigger::default_instance_;
   delete InternalCommitTrigger_reflection_;
-  delete NodeList::default_instance_;
-  delete NodeList_reflection_;
+  delete NodeWithTimestamp::default_instance_;
+  delete NodeWithTimestamp_reflection_;
   delete TxnMeta::default_instance_;
   delete TxnMeta_reflection_;
   delete Transaction::default_instance_;
@@ -493,45 +494,47 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
     "icas_trigger\030\003 \001(\0132(.cockroach.roachpb.C"
     "hangeReplicasTrigger\022E\n\025modified_span_tr"
     "igger\030\004 \001(\0132&.cockroach.roachpb.Modified"
-    "SpanTrigger:\004\210\240\037\001\"\'\n\010NodeList\022\033\n\005nodes\030\001"
-    " \003(\005B\014\020\001\372\336\037\006NodeID\"\355\001\n\007TxnMeta\022E\n\002id\030\001 \001"
-    "(\014B9\342\336\037\002ID\332\336\037/github.com/cockroachdb/coc"
-    "kroach/util/uuid.UUID\0229\n\tisolation\030\002 \001(\016"
-    "2 .cockroach.roachpb.IsolationTypeB\004\310\336\037\000"
-    "\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\023\n\005epoch\030\004 \001(\rB\004\310"
-    "\336\037\000\0225\n\ttimestamp\030\005 \001(\0132\034.cockroach.roach"
-    "pb.TimestampB\004\310\336\037\000\"\365\003\n\013Transaction\0222\n\004me"
-    "ta\030\001 \001(\0132\032.cockroach.roachpb.TxnMetaB\010\310\336"
-    "\037\000\320\336\037\001\022\022\n\004name\030\002 \001(\tB\004\310\336\037\000\022\026\n\010priority\030\003"
-    " \001(\005B\004\310\336\037\000\022:\n\006status\030\004 \001(\0162$.cockroach.r"
-    "oachpb.TransactionStatusB\004\310\336\037\000\0224\n\016last_h"
-    "eartbeat\030\005 \001(\0132\034.cockroach.roachpb.Times"
-    "tamp\022:\n\016orig_timestamp\030\006 \001(\0132\034.cockroach"
-    ".roachpb.TimestampB\004\310\336\037\000\0229\n\rmax_timestam"
-    "p\030\007 \001(\0132\034.cockroach.roachpb.TimestampB\004\310"
-    "\336\037\000\0228\n\rcertain_nodes\030\010 \001(\0132\033.cockroach.r"
-    "oachpb.NodeListB\004\310\336\037\000\022\025\n\007Writing\030\t \001(\010B\004"
-    "\310\336\037\000\022\026\n\010Sequence\030\n \001(\rB\004\310\336\037\000\022.\n\007Intents\030"
-    "\013 \003(\0132\027.cockroach.roachpb.SpanB\004\310\336\037\000:\004\230\240"
-    "\037\000\"\244\001\n\006Intent\022/\n\004span\030\001 \001(\0132\027.cockroach."
-    "roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\003txn\030\002 \001(\0132\032.co"
-    "ckroach.roachpb.TxnMetaB\004\310\336\037\000\022:\n\006status\030"
-    "\003 \001(\0162$.cockroach.roachpb.TransactionSta"
-    "tusB\004\310\336\037\000\"\265\001\n\005Lease\0221\n\005start\030\001 \001(\0132\034.coc"
-    "kroach.roachpb.TimestampB\004\310\336\037\000\0226\n\nexpira"
-    "tion\030\002 \001(\0132\034.cockroach.roachpb.Timestamp"
-    "B\004\310\336\037\000\022;\n\007replica\030\003 \001(\0132$.cockroach.roac"
-    "hpb.ReplicaDescriptorB\004\310\336\037\000:\004\230\240\037\000\"a\n\022Seq"
-    "uenceCacheEntry\022\024\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n"
-    "\ttimestamp\030\002 \001(\0132\034.cockroach.roachpb.Tim"
-    "estampB\004\310\336\037\000*^\n\tValueType\022\013\n\007UNKNOWN\020\000\022\007"
-    "\n\003INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BYTES\020\003\022\010\n\004TIME\020\004\022"
-    "\013\n\007DECIMAL\020\005\022\016\n\nTIMESERIES\020d*>\n\021ReplicaC"
-    "hangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n\016REMOVE_REP"
-    "LICA\020\001\032\004\210\243\036\000*5\n\rIsolationType\022\020\n\014SERIALI"
-    "ZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B\n\021Transacti"
-    "onStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMMITTED\020\001\022\013\n\007"
-    "ABORTED\020\002\032\004\210\243\036\000B\tZ\007roachpbX\001", 3108);
+    "SpanTrigger:\004\210\240\037\001\"y\n\021NodeWithTimestamp\022)"
+    "\n\007node_id\030\001 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\372\336\037\006NodeI"
+    "D\0229\n\rmax_timestamp\030\002 \001(\0132\034.cockroach.roa"
+    "chpb.TimestampB\004\310\336\037\000\"\355\001\n\007TxnMeta\022E\n\002id\030\001"
+    " \001(\014B9\342\336\037\002ID\332\336\037/github.com/cockroachdb/c"
+    "ockroach/util/uuid.UUID\0229\n\tisolation\030\002 \001"
+    "(\0162 .cockroach.roachpb.IsolationTypeB\004\310\336"
+    "\037\000\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\023\n\005epoch\030\004 \001(\rB"
+    "\004\310\336\037\000\0225\n\ttimestamp\030\005 \001(\0132\034.cockroach.roa"
+    "chpb.TimestampB\004\310\336\037\000\"\377\003\n\013Transaction\0222\n\004"
+    "meta\030\001 \001(\0132\032.cockroach.roachpb.TxnMetaB\010"
+    "\310\336\037\000\320\336\037\001\022\022\n\004name\030\002 \001(\tB\004\310\336\037\000\022\026\n\010priority"
+    "\030\003 \001(\005B\004\310\336\037\000\022:\n\006status\030\004 \001(\0162$.cockroach"
+    ".roachpb.TransactionStatusB\004\310\336\037\000\0224\n\016last"
+    "_heartbeat\030\005 \001(\0132\034.cockroach.roachpb.Tim"
+    "estamp\022:\n\016orig_timestamp\030\006 \001(\0132\034.cockroa"
+    "ch.roachpb.TimestampB\004\310\336\037\000\0229\n\rmax_timest"
+    "amp\030\007 \001(\0132\034.cockroach.roachpb.TimestampB"
+    "\004\310\336\037\000\022B\n\016max_timestamps\030\010 \003(\0132$.cockroac"
+    "h.roachpb.NodeWithTimestampB\004\310\336\037\000\022\025\n\007Wri"
+    "ting\030\t \001(\010B\004\310\336\037\000\022\026\n\010Sequence\030\n \001(\rB\004\310\336\037\000"
+    "\022.\n\007Intents\030\013 \003(\0132\027.cockroach.roachpb.Sp"
+    "anB\004\310\336\037\000:\004\230\240\037\000\"\244\001\n\006Intent\022/\n\004span\030\001 \001(\0132"
+    "\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\003tx"
+    "n\030\002 \001(\0132\032.cockroach.roachpb.TxnMetaB\004\310\336\037"
+    "\000\022:\n\006status\030\003 \001(\0162$.cockroach.roachpb.Tr"
+    "ansactionStatusB\004\310\336\037\000\"\265\001\n\005Lease\0221\n\005start"
+    "\030\001 \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336"
+    "\037\000\0226\n\nexpiration\030\002 \001(\0132\034.cockroach.roach"
+    "pb.TimestampB\004\310\336\037\000\022;\n\007replica\030\003 \001(\0132$.co"
+    "ckroach.roachpb.ReplicaDescriptorB\004\310\336\037\000:"
+    "\004\230\240\037\000\"a\n\022SequenceCacheEntry\022\024\n\003key\030\001 \001(\014"
+    "B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach"
+    ".roachpb.TimestampB\004\310\336\037\000*^\n\tValueType\022\013\n"
+    "\007UNKNOWN\020\000\022\007\n\003INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BYTES\020"
+    "\003\022\010\n\004TIME\020\004\022\013\n\007DECIMAL\020\005\022\016\n\nTIMESERIES\020d"
+    "*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000\022\022"
+    "\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationTyp"
+    "e\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*"
+    "B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOM"
+    "MITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\tZ\007roachpbX\001", 3200);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/data.proto", &protobuf_RegisterTypes);
   Span::default_instance_ = new Span();
@@ -544,7 +547,7 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
   ChangeReplicasTrigger::default_instance_ = new ChangeReplicasTrigger();
   ModifiedSpanTrigger::default_instance_ = new ModifiedSpanTrigger();
   InternalCommitTrigger::default_instance_ = new InternalCommitTrigger();
-  NodeList::default_instance_ = new NodeList();
+  NodeWithTimestamp::default_instance_ = new NodeWithTimestamp();
   TxnMeta::default_instance_ = new TxnMeta();
   Transaction::default_instance_ = new Transaction();
   Intent::default_instance_ = new Intent();
@@ -560,7 +563,7 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
   ChangeReplicasTrigger::default_instance_->InitAsDefaultInstance();
   ModifiedSpanTrigger::default_instance_->InitAsDefaultInstance();
   InternalCommitTrigger::default_instance_->InitAsDefaultInstance();
-  NodeList::default_instance_->InitAsDefaultInstance();
+  NodeWithTimestamp::default_instance_->InitAsDefaultInstance();
   TxnMeta::default_instance_->InitAsDefaultInstance();
   Transaction::default_instance_->InitAsDefaultInstance();
   Intent::default_instance_->InitAsDefaultInstance();
@@ -4705,94 +4708,114 @@ void InternalCommitTrigger::set_allocated_modified_span_trigger(::cockroach::roa
 // ===================================================================
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int NodeList::kNodesFieldNumber;
+const int NodeWithTimestamp::kNodeIdFieldNumber;
+const int NodeWithTimestamp::kMaxTimestampFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
-NodeList::NodeList()
+NodeWithTimestamp::NodeWithTimestamp()
   : ::google::protobuf::Message(), _internal_metadata_(NULL) {
   SharedCtor();
-  // @@protoc_insertion_point(constructor:cockroach.roachpb.NodeList)
+  // @@protoc_insertion_point(constructor:cockroach.roachpb.NodeWithTimestamp)
 }
 
-void NodeList::InitAsDefaultInstance() {
+void NodeWithTimestamp::InitAsDefaultInstance() {
+  max_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
 }
 
-NodeList::NodeList(const NodeList& from)
+NodeWithTimestamp::NodeWithTimestamp(const NodeWithTimestamp& from)
   : ::google::protobuf::Message(),
     _internal_metadata_(NULL) {
   SharedCtor();
   MergeFrom(from);
-  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.NodeList)
+  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.NodeWithTimestamp)
 }
 
-void NodeList::SharedCtor() {
+void NodeWithTimestamp::SharedCtor() {
   _cached_size_ = 0;
+  node_id_ = 0;
+  max_timestamp_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
-NodeList::~NodeList() {
-  // @@protoc_insertion_point(destructor:cockroach.roachpb.NodeList)
+NodeWithTimestamp::~NodeWithTimestamp() {
+  // @@protoc_insertion_point(destructor:cockroach.roachpb.NodeWithTimestamp)
   SharedDtor();
 }
 
-void NodeList::SharedDtor() {
+void NodeWithTimestamp::SharedDtor() {
   if (this != default_instance_) {
+    delete max_timestamp_;
   }
 }
 
-void NodeList::SetCachedSize(int size) const {
+void NodeWithTimestamp::SetCachedSize(int size) const {
   GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
   _cached_size_ = size;
   GOOGLE_SAFE_CONCURRENT_WRITES_END();
 }
-const ::google::protobuf::Descriptor* NodeList::descriptor() {
+const ::google::protobuf::Descriptor* NodeWithTimestamp::descriptor() {
   protobuf_AssignDescriptorsOnce();
-  return NodeList_descriptor_;
+  return NodeWithTimestamp_descriptor_;
 }
 
-const NodeList& NodeList::default_instance() {
+const NodeWithTimestamp& NodeWithTimestamp::default_instance() {
   if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto();
   return *default_instance_;
 }
 
-NodeList* NodeList::default_instance_ = NULL;
+NodeWithTimestamp* NodeWithTimestamp::default_instance_ = NULL;
 
-NodeList* NodeList::New(::google::protobuf::Arena* arena) const {
-  NodeList* n = new NodeList;
+NodeWithTimestamp* NodeWithTimestamp::New(::google::protobuf::Arena* arena) const {
+  NodeWithTimestamp* n = new NodeWithTimestamp;
   if (arena != NULL) {
     arena->Own(n);
   }
   return n;
 }
 
-void NodeList::Clear() {
-  nodes_.Clear();
+void NodeWithTimestamp::Clear() {
+  if (_has_bits_[0 / 32] & 3u) {
+    node_id_ = 0;
+    if (has_max_timestamp()) {
+      if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+    }
+  }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->Clear();
   }
 }
 
-bool NodeList::MergePartialFromCodedStream(
+bool NodeWithTimestamp::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:cockroach.roachpb.NodeList)
+  // @@protoc_insertion_point(parse_start:cockroach.roachpb.NodeWithTimestamp)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // repeated int32 nodes = 1 [packed = true];
+      // optional int32 node_id = 1;
       case 1: {
-        if (tag == 10) {
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
+        if (tag == 8) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 input, this->mutable_nodes())));
-        } else if (tag == 8) {
-          DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
-                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 1, 10, input, this->mutable_nodes())));
+                 input, &node_id_)));
+          set_has_node_id();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(18)) goto parse_max_timestamp;
+        break;
+      }
+
+      // optional .cockroach.roachpb.Timestamp max_timestamp = 2;
+      case 2: {
+        if (tag == 18) {
+         parse_max_timestamp:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_max_timestamp()));
         } else {
           goto handle_unusual;
         }
@@ -4814,79 +4837,77 @@ bool NodeList::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:cockroach.roachpb.NodeList)
+  // @@protoc_insertion_point(parse_success:cockroach.roachpb.NodeWithTimestamp)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.NodeList)
+  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.NodeWithTimestamp)
   return false;
 #undef DO_
 }
 
-void NodeList::SerializeWithCachedSizes(
+void NodeWithTimestamp::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.NodeList)
-  // repeated int32 nodes = 1 [packed = true];
-  if (this->nodes_size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteTag(1, ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED, output);
-    output->WriteVarint32(_nodes_cached_byte_size_);
+  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.NodeWithTimestamp)
+  // optional int32 node_id = 1;
+  if (has_node_id()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(1, this->node_id(), output);
   }
-  for (int i = 0; i < this->nodes_size(); i++) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt32NoTag(
-      this->nodes(i), output);
+
+  // optional .cockroach.roachpb.Timestamp max_timestamp = 2;
+  if (has_max_timestamp()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2, *this->max_timestamp_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
   }
-  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.NodeList)
+  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.NodeWithTimestamp)
 }
 
-::google::protobuf::uint8* NodeList::SerializeWithCachedSizesToArray(
+::google::protobuf::uint8* NodeWithTimestamp::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
-  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.NodeList)
-  // repeated int32 nodes = 1 [packed = true];
-  if (this->nodes_size() > 0) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteTagToArray(
-      1,
-      ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED,
-      target);
-    target = ::google::protobuf::io::CodedOutputStream::WriteVarint32ToArray(
-      _nodes_cached_byte_size_, target);
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.NodeWithTimestamp)
+  // optional int32 node_id = 1;
+  if (has_node_id()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(1, this->node_id(), target);
   }
-  for (int i = 0; i < this->nodes_size(); i++) {
+
+  // optional .cockroach.roachpb.Timestamp max_timestamp = 2;
+  if (has_max_timestamp()) {
     target = ::google::protobuf::internal::WireFormatLite::
-      WriteInt32NoTagToArray(this->nodes(i), target);
+      WriteMessageNoVirtualToArray(
+        2, *this->max_timestamp_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.NodeList)
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.NodeWithTimestamp)
   return target;
 }
 
-int NodeList::ByteSize() const {
+int NodeWithTimestamp::ByteSize() const {
   int total_size = 0;
 
-  // repeated int32 nodes = 1 [packed = true];
-  {
-    int data_size = 0;
-    for (int i = 0; i < this->nodes_size(); i++) {
-      data_size += ::google::protobuf::internal::WireFormatLite::
-        Int32Size(this->nodes(i));
-    }
-    if (data_size > 0) {
+  if (_has_bits_[0 / 32] & 3u) {
+    // optional int32 node_id = 1;
+    if (has_node_id()) {
       total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int32Size(data_size);
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->node_id());
     }
-    GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
-    _nodes_cached_byte_size_ = data_size;
-    GOOGLE_SAFE_CONCURRENT_WRITES_END();
-    total_size += data_size;
-  }
 
+    // optional .cockroach.roachpb.Timestamp max_timestamp = 2;
+    if (has_max_timestamp()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->max_timestamp_);
+    }
+
+  }
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -4898,10 +4919,10 @@ int NodeList::ByteSize() const {
   return total_size;
 }
 
-void NodeList::MergeFrom(const ::google::protobuf::Message& from) {
+void NodeWithTimestamp::MergeFrom(const ::google::protobuf::Message& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  const NodeList* source = 
-      ::google::protobuf::internal::DynamicCastToGenerated<const NodeList>(
+  const NodeWithTimestamp* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const NodeWithTimestamp>(
           &from);
   if (source == NULL) {
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
@@ -4910,81 +4931,126 @@ void NodeList::MergeFrom(const ::google::protobuf::Message& from) {
   }
 }
 
-void NodeList::MergeFrom(const NodeList& from) {
+void NodeWithTimestamp::MergeFrom(const NodeWithTimestamp& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  nodes_.MergeFrom(from.nodes_);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_node_id()) {
+      set_node_id(from.node_id());
+    }
+    if (from.has_max_timestamp()) {
+      mutable_max_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.max_timestamp());
+    }
+  }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
   }
 }
 
-void NodeList::CopyFrom(const ::google::protobuf::Message& from) {
+void NodeWithTimestamp::CopyFrom(const ::google::protobuf::Message& from) {
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void NodeList::CopyFrom(const NodeList& from) {
+void NodeWithTimestamp::CopyFrom(const NodeWithTimestamp& from) {
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool NodeList::IsInitialized() const {
+bool NodeWithTimestamp::IsInitialized() const {
 
   return true;
 }
 
-void NodeList::Swap(NodeList* other) {
+void NodeWithTimestamp::Swap(NodeWithTimestamp* other) {
   if (other == this) return;
   InternalSwap(other);
 }
-void NodeList::InternalSwap(NodeList* other) {
-  nodes_.UnsafeArenaSwap(&other->nodes_);
+void NodeWithTimestamp::InternalSwap(NodeWithTimestamp* other) {
+  std::swap(node_id_, other->node_id_);
+  std::swap(max_timestamp_, other->max_timestamp_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
 }
 
-::google::protobuf::Metadata NodeList::GetMetadata() const {
+::google::protobuf::Metadata NodeWithTimestamp::GetMetadata() const {
   protobuf_AssignDescriptorsOnce();
   ::google::protobuf::Metadata metadata;
-  metadata.descriptor = NodeList_descriptor_;
-  metadata.reflection = NodeList_reflection_;
+  metadata.descriptor = NodeWithTimestamp_descriptor_;
+  metadata.reflection = NodeWithTimestamp_reflection_;
   return metadata;
 }
 
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
-// NodeList
+// NodeWithTimestamp
 
-// repeated int32 nodes = 1 [packed = true];
-int NodeList::nodes_size() const {
-  return nodes_.size();
+// optional int32 node_id = 1;
+bool NodeWithTimestamp::has_node_id() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void NodeList::clear_nodes() {
-  nodes_.Clear();
+void NodeWithTimestamp::set_has_node_id() {
+  _has_bits_[0] |= 0x00000001u;
 }
- ::google::protobuf::int32 NodeList::nodes(int index) const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.NodeList.nodes)
-  return nodes_.Get(index);
+void NodeWithTimestamp::clear_has_node_id() {
+  _has_bits_[0] &= ~0x00000001u;
 }
- void NodeList::set_nodes(int index, ::google::protobuf::int32 value) {
-  nodes_.Set(index, value);
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.NodeList.nodes)
+void NodeWithTimestamp::clear_node_id() {
+  node_id_ = 0;
+  clear_has_node_id();
 }
- void NodeList::add_nodes(::google::protobuf::int32 value) {
-  nodes_.Add(value);
-  // @@protoc_insertion_point(field_add:cockroach.roachpb.NodeList.nodes)
+ ::google::protobuf::int32 NodeWithTimestamp::node_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.NodeWithTimestamp.node_id)
+  return node_id_;
 }
- const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
-NodeList::nodes() const {
-  // @@protoc_insertion_point(field_list:cockroach.roachpb.NodeList.nodes)
-  return nodes_;
+ void NodeWithTimestamp::set_node_id(::google::protobuf::int32 value) {
+  set_has_node_id();
+  node_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.NodeWithTimestamp.node_id)
 }
- ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-NodeList::mutable_nodes() {
-  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.NodeList.nodes)
-  return &nodes_;
+
+// optional .cockroach.roachpb.Timestamp max_timestamp = 2;
+bool NodeWithTimestamp::has_max_timestamp() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+void NodeWithTimestamp::set_has_max_timestamp() {
+  _has_bits_[0] |= 0x00000002u;
+}
+void NodeWithTimestamp::clear_has_max_timestamp() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+void NodeWithTimestamp::clear_max_timestamp() {
+  if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_max_timestamp();
+}
+const ::cockroach::roachpb::Timestamp& NodeWithTimestamp::max_timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
+  return max_timestamp_ != NULL ? *max_timestamp_ : *default_instance_->max_timestamp_;
+}
+::cockroach::roachpb::Timestamp* NodeWithTimestamp::mutable_max_timestamp() {
+  set_has_max_timestamp();
+  if (max_timestamp_ == NULL) {
+    max_timestamp_ = new ::cockroach::roachpb::Timestamp;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
+  return max_timestamp_;
+}
+::cockroach::roachpb::Timestamp* NodeWithTimestamp::release_max_timestamp() {
+  clear_has_max_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = max_timestamp_;
+  max_timestamp_ = NULL;
+  return temp;
+}
+void NodeWithTimestamp::set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp) {
+  delete max_timestamp_;
+  max_timestamp_ = max_timestamp;
+  if (max_timestamp) {
+    set_has_max_timestamp();
+  } else {
+    clear_has_max_timestamp();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -5625,7 +5691,7 @@ const int Transaction::kStatusFieldNumber;
 const int Transaction::kLastHeartbeatFieldNumber;
 const int Transaction::kOrigTimestampFieldNumber;
 const int Transaction::kMaxTimestampFieldNumber;
-const int Transaction::kCertainNodesFieldNumber;
+const int Transaction::kMaxTimestampsFieldNumber;
 const int Transaction::kWritingFieldNumber;
 const int Transaction::kSequenceFieldNumber;
 const int Transaction::kIntentsFieldNumber;
@@ -5642,7 +5708,6 @@ void Transaction::InitAsDefaultInstance() {
   last_heartbeat_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
   orig_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
   max_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
-  certain_nodes_ = const_cast< ::cockroach::roachpb::NodeList*>(&::cockroach::roachpb::NodeList::default_instance());
 }
 
 Transaction::Transaction(const Transaction& from)
@@ -5663,7 +5728,6 @@ void Transaction::SharedCtor() {
   last_heartbeat_ = NULL;
   orig_timestamp_ = NULL;
   max_timestamp_ = NULL;
-  certain_nodes_ = NULL;
   writing_ = false;
   sequence_ = 0u;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -5681,7 +5745,6 @@ void Transaction::SharedDtor() {
     delete last_heartbeat_;
     delete orig_timestamp_;
     delete max_timestamp_;
-    delete certain_nodes_;
   }
 }
 
@@ -5719,7 +5782,7 @@ void Transaction::Clear() {
            ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
 } while (0)
 
-  if (_has_bits_[0 / 32] & 255u) {
+  if (_has_bits_[0 / 32] & 127u) {
     ZR_(priority_, status_);
     if (has_meta()) {
       if (meta_ != NULL) meta_->::cockroach::roachpb::TxnMeta::Clear();
@@ -5736,15 +5799,13 @@ void Transaction::Clear() {
     if (has_max_timestamp()) {
       if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
-    if (has_certain_nodes()) {
-      if (certain_nodes_ != NULL) certain_nodes_->::cockroach::roachpb::NodeList::Clear();
-    }
   }
   ZR_(writing_, sequence_);
 
 #undef ZR_HELPER_
 #undef ZR_
 
+  max_timestamps_.Clear();
   intents_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5861,19 +5922,23 @@ bool Transaction::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(66)) goto parse_certain_nodes;
+        if (input->ExpectTag(66)) goto parse_max_timestamps;
         break;
       }
 
-      // optional .cockroach.roachpb.NodeList certain_nodes = 8;
+      // repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
       case 8: {
         if (tag == 66) {
-         parse_certain_nodes:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_certain_nodes()));
+         parse_max_timestamps:
+          DO_(input->IncrementRecursionDepth());
+         parse_loop_max_timestamps:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtualNoRecursionDepth(
+                input, add_max_timestamps()));
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(66)) goto parse_loop_max_timestamps;
+        input->UnsafeDecrementRecursionDepth();
         if (input->ExpectTag(72)) goto parse_Writing;
         break;
       }
@@ -5995,10 +6060,10 @@ void Transaction::SerializeWithCachedSizes(
       7, *this->max_timestamp_, output);
   }
 
-  // optional .cockroach.roachpb.NodeList certain_nodes = 8;
-  if (has_certain_nodes()) {
+  // repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
+  for (unsigned int i = 0, n = this->max_timestamps_size(); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      8, *this->certain_nodes_, output);
+      8, this->max_timestamps(i), output);
   }
 
   // optional bool Writing = 9;
@@ -6077,11 +6142,11 @@ void Transaction::SerializeWithCachedSizes(
         7, *this->max_timestamp_, target);
   }
 
-  // optional .cockroach.roachpb.NodeList certain_nodes = 8;
-  if (has_certain_nodes()) {
+  // repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
+  for (unsigned int i = 0, n = this->max_timestamps_size(); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        8, *this->certain_nodes_, target);
+        8, this->max_timestamps(i), target);
   }
 
   // optional bool Writing = 9;
@@ -6112,7 +6177,7 @@ void Transaction::SerializeWithCachedSizes(
 int Transaction::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 255u) {
+  if (_has_bits_[0 / 32] & 127u) {
     // optional .cockroach.roachpb.TxnMeta meta = 1;
     if (has_meta()) {
       total_size += 1 +
@@ -6161,13 +6226,6 @@ int Transaction::ByteSize() const {
           *this->max_timestamp_);
     }
 
-    // optional .cockroach.roachpb.NodeList certain_nodes = 8;
-    if (has_certain_nodes()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->certain_nodes_);
-    }
-
   }
   if (_has_bits_[8 / 32] & 768u) {
     // optional bool Writing = 9;
@@ -6183,6 +6241,14 @@ int Transaction::ByteSize() const {
     }
 
   }
+  // repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
+  total_size += 1 * this->max_timestamps_size();
+  for (int i = 0; i < this->max_timestamps_size(); i++) {
+    total_size +=
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        this->max_timestamps(i));
+  }
+
   // repeated .cockroach.roachpb.Span Intents = 11;
   total_size += 1 * this->intents_size();
   for (int i = 0; i < this->intents_size(); i++) {
@@ -6216,6 +6282,7 @@ void Transaction::MergeFrom(const ::google::protobuf::Message& from) {
 
 void Transaction::MergeFrom(const Transaction& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  max_timestamps_.MergeFrom(from.max_timestamps_);
   intents_.MergeFrom(from.intents_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_meta()) {
@@ -6239,9 +6306,6 @@ void Transaction::MergeFrom(const Transaction& from) {
     }
     if (from.has_max_timestamp()) {
       mutable_max_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.max_timestamp());
-    }
-    if (from.has_certain_nodes()) {
-      mutable_certain_nodes()->::cockroach::roachpb::NodeList::MergeFrom(from.certain_nodes());
     }
   }
   if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
@@ -6286,7 +6350,7 @@ void Transaction::InternalSwap(Transaction* other) {
   std::swap(last_heartbeat_, other->last_heartbeat_);
   std::swap(orig_timestamp_, other->orig_timestamp_);
   std::swap(max_timestamp_, other->max_timestamp_);
-  std::swap(certain_nodes_, other->certain_nodes_);
+  max_timestamps_.UnsafeArenaSwap(&other->max_timestamps_);
   std::swap(writing_, other->writing_);
   std::swap(sequence_, other->sequence_);
   intents_.UnsafeArenaSwap(&other->intents_);
@@ -6580,47 +6644,34 @@ void Transaction::set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* m
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.max_timestamp)
 }
 
-// optional .cockroach.roachpb.NodeList certain_nodes = 8;
-bool Transaction::has_certain_nodes() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+// repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
+int Transaction::max_timestamps_size() const {
+  return max_timestamps_.size();
 }
-void Transaction::set_has_certain_nodes() {
-  _has_bits_[0] |= 0x00000080u;
+void Transaction::clear_max_timestamps() {
+  max_timestamps_.Clear();
 }
-void Transaction::clear_has_certain_nodes() {
-  _has_bits_[0] &= ~0x00000080u;
+const ::cockroach::roachpb::NodeWithTimestamp& Transaction::max_timestamps(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.max_timestamps)
+  return max_timestamps_.Get(index);
 }
-void Transaction::clear_certain_nodes() {
-  if (certain_nodes_ != NULL) certain_nodes_->::cockroach::roachpb::NodeList::Clear();
-  clear_has_certain_nodes();
+::cockroach::roachpb::NodeWithTimestamp* Transaction::mutable_max_timestamps(int index) {
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.max_timestamps)
+  return max_timestamps_.Mutable(index);
 }
-const ::cockroach::roachpb::NodeList& Transaction::certain_nodes() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.certain_nodes)
-  return certain_nodes_ != NULL ? *certain_nodes_ : *default_instance_->certain_nodes_;
+::cockroach::roachpb::NodeWithTimestamp* Transaction::add_max_timestamps() {
+  // @@protoc_insertion_point(field_add:cockroach.roachpb.Transaction.max_timestamps)
+  return max_timestamps_.Add();
 }
-::cockroach::roachpb::NodeList* Transaction::mutable_certain_nodes() {
-  set_has_certain_nodes();
-  if (certain_nodes_ == NULL) {
-    certain_nodes_ = new ::cockroach::roachpb::NodeList;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.certain_nodes)
-  return certain_nodes_;
+::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >*
+Transaction::mutable_max_timestamps() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.Transaction.max_timestamps)
+  return &max_timestamps_;
 }
-::cockroach::roachpb::NodeList* Transaction::release_certain_nodes() {
-  clear_has_certain_nodes();
-  ::cockroach::roachpb::NodeList* temp = certain_nodes_;
-  certain_nodes_ = NULL;
-  return temp;
-}
-void Transaction::set_allocated_certain_nodes(::cockroach::roachpb::NodeList* certain_nodes) {
-  delete certain_nodes_;
-  certain_nodes_ = certain_nodes;
-  if (certain_nodes) {
-    set_has_certain_nodes();
-  } else {
-    clear_has_certain_nodes();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.certain_nodes)
+const ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >&
+Transaction::max_timestamps() const {
+  // @@protoc_insertion_point(field_list:cockroach.roachpb.Transaction.max_timestamps)
+  return max_timestamps_;
 }
 
 // optional bool Writing = 9;

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
@@ -52,15 +52,13 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* InternalCommitTrigger_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   InternalCommitTrigger_reflection_ = NULL;
-const ::google::protobuf::Descriptor* NodeWithTimestamp_descriptor_ = NULL;
-const ::google::protobuf::internal::GeneratedMessageReflection*
-  NodeWithTimestamp_reflection_ = NULL;
 const ::google::protobuf::Descriptor* TxnMeta_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   TxnMeta_reflection_ = NULL;
 const ::google::protobuf::Descriptor* Transaction_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   Transaction_reflection_ = NULL;
+const ::google::protobuf::Descriptor* Transaction_ObservedTimestampsEntry_descriptor_ = NULL;
 const ::google::protobuf::Descriptor* Intent_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   Intent_reflection_ = NULL;
@@ -249,23 +247,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
       sizeof(InternalCommitTrigger),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InternalCommitTrigger, _internal_metadata_),
       -1);
-  NodeWithTimestamp_descriptor_ = file->message_type(10);
-  static const int NodeWithTimestamp_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeWithTimestamp, node_id_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeWithTimestamp, max_timestamp_),
-  };
-  NodeWithTimestamp_reflection_ =
-    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
-      NodeWithTimestamp_descriptor_,
-      NodeWithTimestamp::default_instance_,
-      NodeWithTimestamp_offsets_,
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeWithTimestamp, _has_bits_[0]),
-      -1,
-      -1,
-      sizeof(NodeWithTimestamp),
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NodeWithTimestamp, _internal_metadata_),
-      -1);
-  TxnMeta_descriptor_ = file->message_type(11);
+  TxnMeta_descriptor_ = file->message_type(10);
   static const int TxnMeta_offsets_[5] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TxnMeta, id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TxnMeta, isolation_),
@@ -284,7 +266,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
       sizeof(TxnMeta),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TxnMeta, _internal_metadata_),
       -1);
-  Transaction_descriptor_ = file->message_type(12);
+  Transaction_descriptor_ = file->message_type(11);
   static const int Transaction_offsets_[11] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, meta_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, name_),
@@ -292,8 +274,8 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, status_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, last_heartbeat_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, orig_timestamp_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, max_timestamp_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, max_timestamps_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, observed_timestamp_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, observed_timestamps_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, writing_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, sequence_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, intents_),
@@ -309,7 +291,8 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
       sizeof(Transaction),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, _internal_metadata_),
       -1);
-  Intent_descriptor_ = file->message_type(13);
+  Transaction_ObservedTimestampsEntry_descriptor_ = Transaction_descriptor_->nested_type(0);
+  Intent_descriptor_ = file->message_type(12);
   static const int Intent_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Intent, span_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Intent, txn_),
@@ -326,7 +309,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
       sizeof(Intent),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Intent, _internal_metadata_),
       -1);
-  Lease_descriptor_ = file->message_type(14);
+  Lease_descriptor_ = file->message_type(13);
   static const int Lease_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, start_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, expiration_),
@@ -343,7 +326,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
       sizeof(Lease),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Lease, _internal_metadata_),
       -1);
-  SequenceCacheEntry_descriptor_ = file->message_type(15);
+  SequenceCacheEntry_descriptor_ = file->message_type(14);
   static const int SequenceCacheEntry_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SequenceCacheEntry, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SequenceCacheEntry, timestamp_),
@@ -396,11 +379,18 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       InternalCommitTrigger_descriptor_, &InternalCommitTrigger::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
-      NodeWithTimestamp_descriptor_, &NodeWithTimestamp::default_instance());
-  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       TxnMeta_descriptor_, &TxnMeta::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       Transaction_descriptor_, &Transaction::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+        Transaction_ObservedTimestampsEntry_descriptor_,
+        ::google::protobuf::internal::MapEntry<
+            ::google::protobuf::int32,
+            ::cockroach::roachpb::Timestamp,
+            ::google::protobuf::internal::WireFormatLite::TYPE_INT32,
+            ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
+            0>::CreateDefaultInstance(
+                Transaction_ObservedTimestampsEntry_descriptor_));
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       Intent_descriptor_, &Intent::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
@@ -432,8 +422,6 @@ void protobuf_ShutdownFile_cockroach_2froachpb_2fdata_2eproto() {
   delete ModifiedSpanTrigger_reflection_;
   delete InternalCommitTrigger::default_instance_;
   delete InternalCommitTrigger_reflection_;
-  delete NodeWithTimestamp::default_instance_;
-  delete NodeWithTimestamp_reflection_;
   delete TxnMeta::default_instance_;
   delete TxnMeta_reflection_;
   delete Transaction::default_instance_;
@@ -494,47 +482,48 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
     "icas_trigger\030\003 \001(\0132(.cockroach.roachpb.C"
     "hangeReplicasTrigger\022E\n\025modified_span_tr"
     "igger\030\004 \001(\0132&.cockroach.roachpb.Modified"
-    "SpanTrigger:\004\210\240\037\001\"y\n\021NodeWithTimestamp\022)"
-    "\n\007node_id\030\001 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\372\336\037\006NodeI"
-    "D\0229\n\rmax_timestamp\030\002 \001(\0132\034.cockroach.roa"
-    "chpb.TimestampB\004\310\336\037\000\"\355\001\n\007TxnMeta\022E\n\002id\030\001"
-    " \001(\014B9\342\336\037\002ID\332\336\037/github.com/cockroachdb/c"
-    "ockroach/util/uuid.UUID\0229\n\tisolation\030\002 \001"
-    "(\0162 .cockroach.roachpb.IsolationTypeB\004\310\336"
-    "\037\000\022\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\023\n\005epoch\030\004 \001(\rB"
-    "\004\310\336\037\000\0225\n\ttimestamp\030\005 \001(\0132\034.cockroach.roa"
-    "chpb.TimestampB\004\310\336\037\000\"\377\003\n\013Transaction\0222\n\004"
-    "meta\030\001 \001(\0132\032.cockroach.roachpb.TxnMetaB\010"
-    "\310\336\037\000\320\336\037\001\022\022\n\004name\030\002 \001(\tB\004\310\336\037\000\022\026\n\010priority"
-    "\030\003 \001(\005B\004\310\336\037\000\022:\n\006status\030\004 \001(\0162$.cockroach"
-    ".roachpb.TransactionStatusB\004\310\336\037\000\0224\n\016last"
-    "_heartbeat\030\005 \001(\0132\034.cockroach.roachpb.Tim"
-    "estamp\022:\n\016orig_timestamp\030\006 \001(\0132\034.cockroa"
-    "ch.roachpb.TimestampB\004\310\336\037\000\0229\n\rmax_timest"
-    "amp\030\007 \001(\0132\034.cockroach.roachpb.TimestampB"
-    "\004\310\336\037\000\022B\n\016max_timestamps\030\010 \003(\0132$.cockroac"
-    "h.roachpb.NodeWithTimestampB\004\310\336\037\000\022\025\n\007Wri"
-    "ting\030\t \001(\010B\004\310\336\037\000\022\026\n\010Sequence\030\n \001(\rB\004\310\336\037\000"
-    "\022.\n\007Intents\030\013 \003(\0132\027.cockroach.roachpb.Sp"
-    "anB\004\310\336\037\000:\004\230\240\037\000\"\244\001\n\006Intent\022/\n\004span\030\001 \001(\0132"
-    "\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\003tx"
-    "n\030\002 \001(\0132\032.cockroach.roachpb.TxnMetaB\004\310\336\037"
-    "\000\022:\n\006status\030\003 \001(\0162$.cockroach.roachpb.Tr"
-    "ansactionStatusB\004\310\336\037\000\"\265\001\n\005Lease\0221\n\005start"
-    "\030\001 \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336"
-    "\037\000\0226\n\nexpiration\030\002 \001(\0132\034.cockroach.roach"
-    "pb.TimestampB\004\310\336\037\000\022;\n\007replica\030\003 \001(\0132$.co"
-    "ckroach.roachpb.ReplicaDescriptorB\004\310\336\037\000:"
-    "\004\230\240\037\000\"a\n\022SequenceCacheEntry\022\024\n\003key\030\001 \001(\014"
-    "B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach"
-    ".roachpb.TimestampB\004\310\336\037\000*^\n\tValueType\022\013\n"
-    "\007UNKNOWN\020\000\022\007\n\003INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BYTES\020"
-    "\003\022\010\n\004TIME\020\004\022\013\n\007DECIMAL\020\005\022\016\n\nTIMESERIES\020d"
-    "*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000\022\022"
-    "\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationTyp"
-    "e\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*"
-    "B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOM"
-    "MITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\tZ\007roachpbX\001", 3200);
+    "SpanTrigger:\004\210\240\037\001\"\355\001\n\007TxnMeta\022E\n\002id\030\001 \001("
+    "\014B9\342\336\037\002ID\332\336\037/github.com/cockroachdb/cock"
+    "roach/util/uuid.UUID\0229\n\tisolation\030\002 \001(\0162"
+    " .cockroach.roachpb.IsolationTypeB\004\310\336\037\000\022"
+    "\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\023\n\005epoch\030\004 \001(\rB\004\310\336"
+    "\037\000\0225\n\ttimestamp\030\005 \001(\0132\034.cockroach.roachp"
+    "b.TimestampB\004\310\336\037\000\"\376\004\n\013Transaction\0222\n\004met"
+    "a\030\001 \001(\0132\032.cockroach.roachpb.TxnMetaB\010\310\336\037"
+    "\000\320\336\037\001\022\022\n\004name\030\002 \001(\tB\004\310\336\037\000\022\026\n\010priority\030\003 "
+    "\001(\005B\004\310\336\037\000\022:\n\006status\030\004 \001(\0162$.cockroach.ro"
+    "achpb.TransactionStatusB\004\310\336\037\000\0224\n\016last_he"
+    "artbeat\030\005 \001(\0132\034.cockroach.roachpb.Timest"
+    "amp\022:\n\016orig_timestamp\030\006 \001(\0132\034.cockroach."
+    "roachpb.TimestampB\004\310\336\037\000\022>\n\022observed_time"
+    "stamp\030\007 \001(\0132\034.cockroach.roachpb.Timestam"
+    "pB\004\310\336\037\000\022c\n\023observed_timestamps\030\010 \003(\01326.c"
+    "ockroach.roachpb.Transaction.ObservedTim"
+    "estampsEntryB\016\310\336\037\000\202\337\037\006NodeID\022\025\n\007Writing\030"
+    "\t \001(\010B\004\310\336\037\000\022\026\n\010Sequence\030\n \001(\rB\004\310\336\037\000\022.\n\007I"
+    "ntents\030\013 \003(\0132\027.cockroach.roachpb.SpanB\004\310"
+    "\336\037\000\032W\n\027ObservedTimestampsEntry\022\013\n\003key\030\001 "
+    "\001(\005\022+\n\005value\030\002 \001(\0132\034.cockroach.roachpb.T"
+    "imestamp:\0028\001:\004\230\240\037\000\"\244\001\n\006Intent\022/\n\004span\030\001 "
+    "\001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-"
+    "\n\003txn\030\002 \001(\0132\032.cockroach.roachpb.TxnMetaB"
+    "\004\310\336\037\000\022:\n\006status\030\003 \001(\0162$.cockroach.roachp"
+    "b.TransactionStatusB\004\310\336\037\000\"\265\001\n\005Lease\0221\n\005s"
+    "tart\030\001 \001(\0132\034.cockroach.roachpb.Timestamp"
+    "B\004\310\336\037\000\0226\n\nexpiration\030\002 \001(\0132\034.cockroach.r"
+    "oachpb.TimestampB\004\310\336\037\000\022;\n\007replica\030\003 \001(\0132"
+    "$.cockroach.roachpb.ReplicaDescriptorB\004\310"
+    "\336\037\000:\004\230\240\037\000\"a\n\022SequenceCacheEntry\022\024\n\003key\030\001"
+    " \001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockr"
+    "oach.roachpb.TimestampB\004\310\336\037\000*^\n\tValueTyp"
+    "e\022\013\n\007UNKNOWN\020\000\022\007\n\003INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BY"
+    "TES\020\003\022\010\n\004TIME\020\004\022\013\n\007DECIMAL\020\005\022\016\n\nTIMESERI"
+    "ES\020d*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLICA"
+    "\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolatio"
+    "nType\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210"
+    "\243\036\000*B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r\n"
+    "\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\tZ\007roach"
+    "pbX\001", 3204);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/data.proto", &protobuf_RegisterTypes);
   Span::default_instance_ = new Span();
@@ -547,7 +536,6 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
   ChangeReplicasTrigger::default_instance_ = new ChangeReplicasTrigger();
   ModifiedSpanTrigger::default_instance_ = new ModifiedSpanTrigger();
   InternalCommitTrigger::default_instance_ = new InternalCommitTrigger();
-  NodeWithTimestamp::default_instance_ = new NodeWithTimestamp();
   TxnMeta::default_instance_ = new TxnMeta();
   Transaction::default_instance_ = new Transaction();
   Intent::default_instance_ = new Intent();
@@ -563,7 +551,6 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
   ChangeReplicasTrigger::default_instance_->InitAsDefaultInstance();
   ModifiedSpanTrigger::default_instance_->InitAsDefaultInstance();
   InternalCommitTrigger::default_instance_->InitAsDefaultInstance();
-  NodeWithTimestamp::default_instance_->InitAsDefaultInstance();
   TxnMeta::default_instance_->InitAsDefaultInstance();
   Transaction::default_instance_->InitAsDefaultInstance();
   Intent::default_instance_->InitAsDefaultInstance();
@@ -4708,356 +4695,6 @@ void InternalCommitTrigger::set_allocated_modified_span_trigger(::cockroach::roa
 // ===================================================================
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int NodeWithTimestamp::kNodeIdFieldNumber;
-const int NodeWithTimestamp::kMaxTimestampFieldNumber;
-#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
-
-NodeWithTimestamp::NodeWithTimestamp()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:cockroach.roachpb.NodeWithTimestamp)
-}
-
-void NodeWithTimestamp::InitAsDefaultInstance() {
-  max_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
-}
-
-NodeWithTimestamp::NodeWithTimestamp(const NodeWithTimestamp& from)
-  : ::google::protobuf::Message(),
-    _internal_metadata_(NULL) {
-  SharedCtor();
-  MergeFrom(from);
-  // @@protoc_insertion_point(copy_constructor:cockroach.roachpb.NodeWithTimestamp)
-}
-
-void NodeWithTimestamp::SharedCtor() {
-  _cached_size_ = 0;
-  node_id_ = 0;
-  max_timestamp_ = NULL;
-  ::memset(_has_bits_, 0, sizeof(_has_bits_));
-}
-
-NodeWithTimestamp::~NodeWithTimestamp() {
-  // @@protoc_insertion_point(destructor:cockroach.roachpb.NodeWithTimestamp)
-  SharedDtor();
-}
-
-void NodeWithTimestamp::SharedDtor() {
-  if (this != default_instance_) {
-    delete max_timestamp_;
-  }
-}
-
-void NodeWithTimestamp::SetCachedSize(int size) const {
-  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
-  _cached_size_ = size;
-  GOOGLE_SAFE_CONCURRENT_WRITES_END();
-}
-const ::google::protobuf::Descriptor* NodeWithTimestamp::descriptor() {
-  protobuf_AssignDescriptorsOnce();
-  return NodeWithTimestamp_descriptor_;
-}
-
-const NodeWithTimestamp& NodeWithTimestamp::default_instance() {
-  if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto();
-  return *default_instance_;
-}
-
-NodeWithTimestamp* NodeWithTimestamp::default_instance_ = NULL;
-
-NodeWithTimestamp* NodeWithTimestamp::New(::google::protobuf::Arena* arena) const {
-  NodeWithTimestamp* n = new NodeWithTimestamp;
-  if (arena != NULL) {
-    arena->Own(n);
-  }
-  return n;
-}
-
-void NodeWithTimestamp::Clear() {
-  if (_has_bits_[0 / 32] & 3u) {
-    node_id_ = 0;
-    if (has_max_timestamp()) {
-      if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
-    }
-  }
-  ::memset(_has_bits_, 0, sizeof(_has_bits_));
-  if (_internal_metadata_.have_unknown_fields()) {
-    mutable_unknown_fields()->Clear();
-  }
-}
-
-bool NodeWithTimestamp::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:cockroach.roachpb.NodeWithTimestamp)
-  for (;;) {
-    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional int32 node_id = 1;
-      case 1: {
-        if (tag == 8) {
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 input, &node_id_)));
-          set_has_node_id();
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(18)) goto parse_max_timestamp;
-        break;
-      }
-
-      // optional .cockroach.roachpb.Timestamp max_timestamp = 2;
-      case 2: {
-        if (tag == 18) {
-         parse_max_timestamp:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_max_timestamp()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectAtEnd()) goto success;
-        break;
-      }
-
-      default: {
-      handle_unusual:
-        if (tag == 0 ||
-            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
-            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
-          goto success;
-        }
-        DO_(::google::protobuf::internal::WireFormat::SkipField(
-              input, tag, mutable_unknown_fields()));
-        break;
-      }
-    }
-  }
-success:
-  // @@protoc_insertion_point(parse_success:cockroach.roachpb.NodeWithTimestamp)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:cockroach.roachpb.NodeWithTimestamp)
-  return false;
-#undef DO_
-}
-
-void NodeWithTimestamp::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:cockroach.roachpb.NodeWithTimestamp)
-  // optional int32 node_id = 1;
-  if (has_node_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt32(1, this->node_id(), output);
-  }
-
-  // optional .cockroach.roachpb.Timestamp max_timestamp = 2;
-  if (has_max_timestamp()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      2, *this->max_timestamp_, output);
-  }
-
-  if (_internal_metadata_.have_unknown_fields()) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        unknown_fields(), output);
-  }
-  // @@protoc_insertion_point(serialize_end:cockroach.roachpb.NodeWithTimestamp)
-}
-
-::google::protobuf::uint8* NodeWithTimestamp::SerializeWithCachedSizesToArray(
-    ::google::protobuf::uint8* target) const {
-  // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.NodeWithTimestamp)
-  // optional int32 node_id = 1;
-  if (has_node_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(1, this->node_id(), target);
-  }
-
-  // optional .cockroach.roachpb.Timestamp max_timestamp = 2;
-  if (has_max_timestamp()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        2, *this->max_timestamp_, target);
-  }
-
-  if (_internal_metadata_.have_unknown_fields()) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        unknown_fields(), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:cockroach.roachpb.NodeWithTimestamp)
-  return target;
-}
-
-int NodeWithTimestamp::ByteSize() const {
-  int total_size = 0;
-
-  if (_has_bits_[0 / 32] & 3u) {
-    // optional int32 node_id = 1;
-    if (has_node_id()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int32Size(
-          this->node_id());
-    }
-
-    // optional .cockroach.roachpb.Timestamp max_timestamp = 2;
-    if (has_max_timestamp()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->max_timestamp_);
-    }
-
-  }
-  if (_internal_metadata_.have_unknown_fields()) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        unknown_fields());
-  }
-  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
-  _cached_size_ = total_size;
-  GOOGLE_SAFE_CONCURRENT_WRITES_END();
-  return total_size;
-}
-
-void NodeWithTimestamp::MergeFrom(const ::google::protobuf::Message& from) {
-  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  const NodeWithTimestamp* source = 
-      ::google::protobuf::internal::DynamicCastToGenerated<const NodeWithTimestamp>(
-          &from);
-  if (source == NULL) {
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-    MergeFrom(*source);
-  }
-}
-
-void NodeWithTimestamp::MergeFrom(const NodeWithTimestamp& from) {
-  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_node_id()) {
-      set_node_id(from.node_id());
-    }
-    if (from.has_max_timestamp()) {
-      mutable_max_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.max_timestamp());
-    }
-  }
-  if (from._internal_metadata_.have_unknown_fields()) {
-    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
-  }
-}
-
-void NodeWithTimestamp::CopyFrom(const ::google::protobuf::Message& from) {
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void NodeWithTimestamp::CopyFrom(const NodeWithTimestamp& from) {
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool NodeWithTimestamp::IsInitialized() const {
-
-  return true;
-}
-
-void NodeWithTimestamp::Swap(NodeWithTimestamp* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void NodeWithTimestamp::InternalSwap(NodeWithTimestamp* other) {
-  std::swap(node_id_, other->node_id_);
-  std::swap(max_timestamp_, other->max_timestamp_);
-  std::swap(_has_bits_[0], other->_has_bits_[0]);
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-  std::swap(_cached_size_, other->_cached_size_);
-}
-
-::google::protobuf::Metadata NodeWithTimestamp::GetMetadata() const {
-  protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::Metadata metadata;
-  metadata.descriptor = NodeWithTimestamp_descriptor_;
-  metadata.reflection = NodeWithTimestamp_reflection_;
-  return metadata;
-}
-
-#if PROTOBUF_INLINE_NOT_IN_HEADERS
-// NodeWithTimestamp
-
-// optional int32 node_id = 1;
-bool NodeWithTimestamp::has_node_id() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-void NodeWithTimestamp::set_has_node_id() {
-  _has_bits_[0] |= 0x00000001u;
-}
-void NodeWithTimestamp::clear_has_node_id() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-void NodeWithTimestamp::clear_node_id() {
-  node_id_ = 0;
-  clear_has_node_id();
-}
- ::google::protobuf::int32 NodeWithTimestamp::node_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.NodeWithTimestamp.node_id)
-  return node_id_;
-}
- void NodeWithTimestamp::set_node_id(::google::protobuf::int32 value) {
-  set_has_node_id();
-  node_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.NodeWithTimestamp.node_id)
-}
-
-// optional .cockroach.roachpb.Timestamp max_timestamp = 2;
-bool NodeWithTimestamp::has_max_timestamp() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
-}
-void NodeWithTimestamp::set_has_max_timestamp() {
-  _has_bits_[0] |= 0x00000002u;
-}
-void NodeWithTimestamp::clear_has_max_timestamp() {
-  _has_bits_[0] &= ~0x00000002u;
-}
-void NodeWithTimestamp::clear_max_timestamp() {
-  if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_max_timestamp();
-}
-const ::cockroach::roachpb::Timestamp& NodeWithTimestamp::max_timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
-  return max_timestamp_ != NULL ? *max_timestamp_ : *default_instance_->max_timestamp_;
-}
-::cockroach::roachpb::Timestamp* NodeWithTimestamp::mutable_max_timestamp() {
-  set_has_max_timestamp();
-  if (max_timestamp_ == NULL) {
-    max_timestamp_ = new ::cockroach::roachpb::Timestamp;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
-  return max_timestamp_;
-}
-::cockroach::roachpb::Timestamp* NodeWithTimestamp::release_max_timestamp() {
-  clear_has_max_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = max_timestamp_;
-  max_timestamp_ = NULL;
-  return temp;
-}
-void NodeWithTimestamp::set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp) {
-  delete max_timestamp_;
-  max_timestamp_ = max_timestamp;
-  if (max_timestamp) {
-    set_has_max_timestamp();
-  } else {
-    clear_has_max_timestamp();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
-}
-
-#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
-
-// ===================================================================
-
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int TxnMeta::kIdFieldNumber;
 const int TxnMeta::kIsolationFieldNumber;
 const int TxnMeta::kKeyFieldNumber;
@@ -5690,8 +5327,8 @@ const int Transaction::kPriorityFieldNumber;
 const int Transaction::kStatusFieldNumber;
 const int Transaction::kLastHeartbeatFieldNumber;
 const int Transaction::kOrigTimestampFieldNumber;
-const int Transaction::kMaxTimestampFieldNumber;
-const int Transaction::kMaxTimestampsFieldNumber;
+const int Transaction::kObservedTimestampFieldNumber;
+const int Transaction::kObservedTimestampsFieldNumber;
 const int Transaction::kWritingFieldNumber;
 const int Transaction::kSequenceFieldNumber;
 const int Transaction::kIntentsFieldNumber;
@@ -5707,7 +5344,7 @@ void Transaction::InitAsDefaultInstance() {
   meta_ = const_cast< ::cockroach::roachpb::TxnMeta*>(&::cockroach::roachpb::TxnMeta::default_instance());
   last_heartbeat_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
   orig_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
-  max_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
+  observed_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
 }
 
 Transaction::Transaction(const Transaction& from)
@@ -5727,7 +5364,11 @@ void Transaction::SharedCtor() {
   status_ = 0;
   last_heartbeat_ = NULL;
   orig_timestamp_ = NULL;
-  max_timestamp_ = NULL;
+  observed_timestamp_ = NULL;
+  observed_timestamps_.SetAssignDescriptorCallback(
+      protobuf_AssignDescriptorsOnce);
+  observed_timestamps_.SetEntryDescriptor(
+      &::cockroach::roachpb::Transaction_ObservedTimestampsEntry_descriptor_);
   writing_ = false;
   sequence_ = 0u;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -5744,7 +5385,7 @@ void Transaction::SharedDtor() {
     delete meta_;
     delete last_heartbeat_;
     delete orig_timestamp_;
-    delete max_timestamp_;
+    delete observed_timestamp_;
   }
 }
 
@@ -5796,8 +5437,8 @@ void Transaction::Clear() {
     if (has_orig_timestamp()) {
       if (orig_timestamp_ != NULL) orig_timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
-    if (has_max_timestamp()) {
-      if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+    if (has_observed_timestamp()) {
+      if (observed_timestamp_ != NULL) observed_timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
   }
   ZR_(writing_, sequence_);
@@ -5805,7 +5446,7 @@ void Transaction::Clear() {
 #undef ZR_HELPER_
 #undef ZR_
 
-  max_timestamps_.Clear();
+  observed_timestamps_.Clear();
   intents_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -5909,35 +5550,37 @@ bool Transaction::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(58)) goto parse_max_timestamp;
+        if (input->ExpectTag(58)) goto parse_observed_timestamp;
         break;
       }
 
-      // optional .cockroach.roachpb.Timestamp max_timestamp = 7;
+      // optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
       case 7: {
         if (tag == 58) {
-         parse_max_timestamp:
+         parse_observed_timestamp:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_max_timestamp()));
+               input, mutable_observed_timestamp()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(66)) goto parse_max_timestamps;
+        if (input->ExpectTag(66)) goto parse_observed_timestamps;
         break;
       }
 
-      // repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
+      // map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;
       case 8: {
         if (tag == 66) {
-         parse_max_timestamps:
+         parse_observed_timestamps:
           DO_(input->IncrementRecursionDepth());
-         parse_loop_max_timestamps:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtualNoRecursionDepth(
-                input, add_max_timestamps()));
+         parse_loop_observed_timestamps:
+          ::google::protobuf::scoped_ptr<Transaction_ObservedTimestampsEntry> entry(observed_timestamps_.NewEntry());
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, entry.get()));
+          (*mutable_observed_timestamps())[entry->key()].Swap(entry->mutable_value());
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(66)) goto parse_loop_max_timestamps;
+        if (input->ExpectTag(66)) goto parse_loop_observed_timestamps;
         input->UnsafeDecrementRecursionDepth();
         if (input->ExpectTag(72)) goto parse_Writing;
         break;
@@ -6054,16 +5697,22 @@ void Transaction::SerializeWithCachedSizes(
       6, *this->orig_timestamp_, output);
   }
 
-  // optional .cockroach.roachpb.Timestamp max_timestamp = 7;
-  if (has_max_timestamp()) {
+  // optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
+  if (has_observed_timestamp()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      7, *this->max_timestamp_, output);
+      7, *this->observed_timestamp_, output);
   }
 
-  // repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
-  for (unsigned int i = 0, n = this->max_timestamps_size(); i < n; i++) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      8, this->max_timestamps(i), output);
+  // map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;
+  {
+    ::google::protobuf::scoped_ptr<Transaction_ObservedTimestampsEntry> entry;
+    for (::google::protobuf::Map< ::google::protobuf::int32, ::cockroach::roachpb::Timestamp >::const_iterator
+        it = this->observed_timestamps().begin();
+        it != this->observed_timestamps().end(); ++it) {
+      entry.reset(observed_timestamps_.NewEntryWrapper(it->first, it->second));
+      ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+          8, *entry, output);
+    }
   }
 
   // optional bool Writing = 9;
@@ -6135,18 +5784,24 @@ void Transaction::SerializeWithCachedSizes(
         6, *this->orig_timestamp_, target);
   }
 
-  // optional .cockroach.roachpb.Timestamp max_timestamp = 7;
-  if (has_max_timestamp()) {
+  // optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
+  if (has_observed_timestamp()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        7, *this->max_timestamp_, target);
+        7, *this->observed_timestamp_, target);
   }
 
-  // repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
-  for (unsigned int i = 0, n = this->max_timestamps_size(); i < n; i++) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        8, this->max_timestamps(i), target);
+  // map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;
+  {
+    ::google::protobuf::scoped_ptr<Transaction_ObservedTimestampsEntry> entry;
+    for (::google::protobuf::Map< ::google::protobuf::int32, ::cockroach::roachpb::Timestamp >::const_iterator
+        it = this->observed_timestamps().begin();
+        it != this->observed_timestamps().end(); ++it) {
+      entry.reset(observed_timestamps_.NewEntryWrapper(it->first, it->second));
+      target = ::google::protobuf::internal::WireFormatLite::
+          WriteMessageNoVirtualToArray(
+              8, *entry, target);
+    }
   }
 
   // optional bool Writing = 9;
@@ -6219,11 +5874,11 @@ int Transaction::ByteSize() const {
           *this->orig_timestamp_);
     }
 
-    // optional .cockroach.roachpb.Timestamp max_timestamp = 7;
-    if (has_max_timestamp()) {
+    // optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
+    if (has_observed_timestamp()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->max_timestamp_);
+          *this->observed_timestamp_);
     }
 
   }
@@ -6241,12 +5896,17 @@ int Transaction::ByteSize() const {
     }
 
   }
-  // repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
-  total_size += 1 * this->max_timestamps_size();
-  for (int i = 0; i < this->max_timestamps_size(); i++) {
-    total_size +=
-      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-        this->max_timestamps(i));
+  // map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;
+  total_size += 1 * this->observed_timestamps_size();
+  {
+    ::google::protobuf::scoped_ptr<Transaction_ObservedTimestampsEntry> entry;
+    for (::google::protobuf::Map< ::google::protobuf::int32, ::cockroach::roachpb::Timestamp >::const_iterator
+        it = this->observed_timestamps().begin();
+        it != this->observed_timestamps().end(); ++it) {
+      entry.reset(observed_timestamps_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
   }
 
   // repeated .cockroach.roachpb.Span Intents = 11;
@@ -6282,7 +5942,7 @@ void Transaction::MergeFrom(const ::google::protobuf::Message& from) {
 
 void Transaction::MergeFrom(const Transaction& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  max_timestamps_.MergeFrom(from.max_timestamps_);
+  observed_timestamps_.MergeFrom(from.observed_timestamps_);
   intents_.MergeFrom(from.intents_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_meta()) {
@@ -6304,8 +5964,8 @@ void Transaction::MergeFrom(const Transaction& from) {
     if (from.has_orig_timestamp()) {
       mutable_orig_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.orig_timestamp());
     }
-    if (from.has_max_timestamp()) {
-      mutable_max_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.max_timestamp());
+    if (from.has_observed_timestamp()) {
+      mutable_observed_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.observed_timestamp());
     }
   }
   if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
@@ -6349,8 +6009,8 @@ void Transaction::InternalSwap(Transaction* other) {
   std::swap(status_, other->status_);
   std::swap(last_heartbeat_, other->last_heartbeat_);
   std::swap(orig_timestamp_, other->orig_timestamp_);
-  std::swap(max_timestamp_, other->max_timestamp_);
-  max_timestamps_.UnsafeArenaSwap(&other->max_timestamps_);
+  std::swap(observed_timestamp_, other->observed_timestamp_);
+  observed_timestamps_.Swap(&other->observed_timestamps_);
   std::swap(writing_, other->writing_);
   std::swap(sequence_, other->sequence_);
   intents_.UnsafeArenaSwap(&other->intents_);
@@ -6601,77 +6261,65 @@ void Transaction::set_allocated_orig_timestamp(::cockroach::roachpb::Timestamp* 
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.orig_timestamp)
 }
 
-// optional .cockroach.roachpb.Timestamp max_timestamp = 7;
-bool Transaction::has_max_timestamp() const {
+// optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
+bool Transaction::has_observed_timestamp() const {
   return (_has_bits_[0] & 0x00000040u) != 0;
 }
-void Transaction::set_has_max_timestamp() {
+void Transaction::set_has_observed_timestamp() {
   _has_bits_[0] |= 0x00000040u;
 }
-void Transaction::clear_has_max_timestamp() {
+void Transaction::clear_has_observed_timestamp() {
   _has_bits_[0] &= ~0x00000040u;
 }
-void Transaction::clear_max_timestamp() {
-  if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_max_timestamp();
+void Transaction::clear_observed_timestamp() {
+  if (observed_timestamp_ != NULL) observed_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_observed_timestamp();
 }
-const ::cockroach::roachpb::Timestamp& Transaction::max_timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.max_timestamp)
-  return max_timestamp_ != NULL ? *max_timestamp_ : *default_instance_->max_timestamp_;
+const ::cockroach::roachpb::Timestamp& Transaction::observed_timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.observed_timestamp)
+  return observed_timestamp_ != NULL ? *observed_timestamp_ : *default_instance_->observed_timestamp_;
 }
-::cockroach::roachpb::Timestamp* Transaction::mutable_max_timestamp() {
-  set_has_max_timestamp();
-  if (max_timestamp_ == NULL) {
-    max_timestamp_ = new ::cockroach::roachpb::Timestamp;
+::cockroach::roachpb::Timestamp* Transaction::mutable_observed_timestamp() {
+  set_has_observed_timestamp();
+  if (observed_timestamp_ == NULL) {
+    observed_timestamp_ = new ::cockroach::roachpb::Timestamp;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.max_timestamp)
-  return max_timestamp_;
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.observed_timestamp)
+  return observed_timestamp_;
 }
-::cockroach::roachpb::Timestamp* Transaction::release_max_timestamp() {
-  clear_has_max_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = max_timestamp_;
-  max_timestamp_ = NULL;
+::cockroach::roachpb::Timestamp* Transaction::release_observed_timestamp() {
+  clear_has_observed_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = observed_timestamp_;
+  observed_timestamp_ = NULL;
   return temp;
 }
-void Transaction::set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp) {
-  delete max_timestamp_;
-  max_timestamp_ = max_timestamp;
-  if (max_timestamp) {
-    set_has_max_timestamp();
+void Transaction::set_allocated_observed_timestamp(::cockroach::roachpb::Timestamp* observed_timestamp) {
+  delete observed_timestamp_;
+  observed_timestamp_ = observed_timestamp;
+  if (observed_timestamp) {
+    set_has_observed_timestamp();
   } else {
-    clear_has_max_timestamp();
+    clear_has_observed_timestamp();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.max_timestamp)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.observed_timestamp)
 }
 
-// repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
-int Transaction::max_timestamps_size() const {
-  return max_timestamps_.size();
+// map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;
+int Transaction::observed_timestamps_size() const {
+  return observed_timestamps_.size();
 }
-void Transaction::clear_max_timestamps() {
-  max_timestamps_.Clear();
+void Transaction::clear_observed_timestamps() {
+  observed_timestamps_.Clear();
 }
-const ::cockroach::roachpb::NodeWithTimestamp& Transaction::max_timestamps(int index) const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.max_timestamps)
-  return max_timestamps_.Get(index);
+ const ::google::protobuf::Map< ::google::protobuf::int32, ::cockroach::roachpb::Timestamp >&
+Transaction::observed_timestamps() const {
+  // @@protoc_insertion_point(field_map:cockroach.roachpb.Transaction.observed_timestamps)
+  return observed_timestamps_.GetMap();
 }
-::cockroach::roachpb::NodeWithTimestamp* Transaction::mutable_max_timestamps(int index) {
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.max_timestamps)
-  return max_timestamps_.Mutable(index);
-}
-::cockroach::roachpb::NodeWithTimestamp* Transaction::add_max_timestamps() {
-  // @@protoc_insertion_point(field_add:cockroach.roachpb.Transaction.max_timestamps)
-  return max_timestamps_.Add();
-}
-::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >*
-Transaction::mutable_max_timestamps() {
-  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.Transaction.max_timestamps)
-  return &max_timestamps_;
-}
-const ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >&
-Transaction::max_timestamps() const {
-  // @@protoc_insertion_point(field_list:cockroach.roachpb.Transaction.max_timestamps)
-  return max_timestamps_;
+ ::google::protobuf::Map< ::google::protobuf::int32, ::cockroach::roachpb::Timestamp >*
+Transaction::mutable_observed_timestamps() {
+  // @@protoc_insertion_point(field_mutable_map:cockroach.roachpb.Transaction.observed_timestamps)
+  return observed_timestamps_.MutableMap();
 }
 
 // optional bool Writing = 9;

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
@@ -26,6 +26,8 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/extension_set.h>
+#include <google/protobuf/map.h>
+#include <google/protobuf/map_field_inl.h>
 #include <google/protobuf/generated_enum_reflection.h>
 #include <google/protobuf/unknown_field_set.h>
 #include "cockroach/roachpb/metadata.pb.h"
@@ -47,7 +49,6 @@ class KeyValue;
 class Lease;
 class MergeTrigger;
 class ModifiedSpanTrigger;
-class NodeWithTimestamp;
 class SequenceCacheEntry;
 class Span;
 class SplitTrigger;
@@ -1231,107 +1232,6 @@ class InternalCommitTrigger : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
-class NodeWithTimestamp : public ::google::protobuf::Message {
- public:
-  NodeWithTimestamp();
-  virtual ~NodeWithTimestamp();
-
-  NodeWithTimestamp(const NodeWithTimestamp& from);
-
-  inline NodeWithTimestamp& operator=(const NodeWithTimestamp& from) {
-    CopyFrom(from);
-    return *this;
-  }
-
-  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
-    return _internal_metadata_.unknown_fields();
-  }
-
-  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
-    return _internal_metadata_.mutable_unknown_fields();
-  }
-
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const NodeWithTimestamp& default_instance();
-
-  void Swap(NodeWithTimestamp* other);
-
-  // implements Message ----------------------------------------------
-
-  inline NodeWithTimestamp* New() const { return New(NULL); }
-
-  NodeWithTimestamp* New(::google::protobuf::Arena* arena) const;
-  void CopyFrom(const ::google::protobuf::Message& from);
-  void MergeFrom(const ::google::protobuf::Message& from);
-  void CopyFrom(const NodeWithTimestamp& from);
-  void MergeFrom(const NodeWithTimestamp& from);
-  void Clear();
-  bool IsInitialized() const;
-
-  int ByteSize() const;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input);
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const;
-  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
-  int GetCachedSize() const { return _cached_size_; }
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const;
-  void InternalSwap(NodeWithTimestamp* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return _internal_metadata_.arena();
-  }
-  inline void* MaybeArenaPtr() const {
-    return _internal_metadata_.raw_arena_ptr();
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // optional int32 node_id = 1;
-  bool has_node_id() const;
-  void clear_node_id();
-  static const int kNodeIdFieldNumber = 1;
-  ::google::protobuf::int32 node_id() const;
-  void set_node_id(::google::protobuf::int32 value);
-
-  // optional .cockroach.roachpb.Timestamp max_timestamp = 2;
-  bool has_max_timestamp() const;
-  void clear_max_timestamp();
-  static const int kMaxTimestampFieldNumber = 2;
-  const ::cockroach::roachpb::Timestamp& max_timestamp() const;
-  ::cockroach::roachpb::Timestamp* mutable_max_timestamp();
-  ::cockroach::roachpb::Timestamp* release_max_timestamp();
-  void set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp);
-
-  // @@protoc_insertion_point(class_scope:cockroach.roachpb.NodeWithTimestamp)
- private:
-  inline void set_has_node_id();
-  inline void clear_has_node_id();
-  inline void set_has_max_timestamp();
-  inline void clear_has_max_timestamp();
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  ::google::protobuf::uint32 _has_bits_[1];
-  mutable int _cached_size_;
-  ::cockroach::roachpb::Timestamp* max_timestamp_;
-  ::google::protobuf::int32 node_id_;
-  friend void  protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto();
-  friend void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto();
-  friend void protobuf_ShutdownFile_cockroach_2froachpb_2fdata_2eproto();
-
-  void InitAsDefaultInstance();
-  static NodeWithTimestamp* default_instance_;
-};
-// -------------------------------------------------------------------
-
 class TxnMeta : public ::google::protobuf::Message {
  public:
   TxnMeta();
@@ -1535,6 +1435,7 @@ class Transaction : public ::google::protobuf::Message {
 
   // nested types ----------------------------------------------------
 
+
   // accessors -------------------------------------------------------
 
   // optional .cockroach.roachpb.TxnMeta meta = 1;
@@ -1590,26 +1491,23 @@ class Transaction : public ::google::protobuf::Message {
   ::cockroach::roachpb::Timestamp* release_orig_timestamp();
   void set_allocated_orig_timestamp(::cockroach::roachpb::Timestamp* orig_timestamp);
 
-  // optional .cockroach.roachpb.Timestamp max_timestamp = 7;
-  bool has_max_timestamp() const;
-  void clear_max_timestamp();
-  static const int kMaxTimestampFieldNumber = 7;
-  const ::cockroach::roachpb::Timestamp& max_timestamp() const;
-  ::cockroach::roachpb::Timestamp* mutable_max_timestamp();
-  ::cockroach::roachpb::Timestamp* release_max_timestamp();
-  void set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp);
+  // optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
+  bool has_observed_timestamp() const;
+  void clear_observed_timestamp();
+  static const int kObservedTimestampFieldNumber = 7;
+  const ::cockroach::roachpb::Timestamp& observed_timestamp() const;
+  ::cockroach::roachpb::Timestamp* mutable_observed_timestamp();
+  ::cockroach::roachpb::Timestamp* release_observed_timestamp();
+  void set_allocated_observed_timestamp(::cockroach::roachpb::Timestamp* observed_timestamp);
 
-  // repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
-  int max_timestamps_size() const;
-  void clear_max_timestamps();
-  static const int kMaxTimestampsFieldNumber = 8;
-  const ::cockroach::roachpb::NodeWithTimestamp& max_timestamps(int index) const;
-  ::cockroach::roachpb::NodeWithTimestamp* mutable_max_timestamps(int index);
-  ::cockroach::roachpb::NodeWithTimestamp* add_max_timestamps();
-  ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >*
-      mutable_max_timestamps();
-  const ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >&
-      max_timestamps() const;
+  // map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;
+  int observed_timestamps_size() const;
+  void clear_observed_timestamps();
+  static const int kObservedTimestampsFieldNumber = 8;
+  const ::google::protobuf::Map< ::google::protobuf::int32, ::cockroach::roachpb::Timestamp >&
+      observed_timestamps() const;
+  ::google::protobuf::Map< ::google::protobuf::int32, ::cockroach::roachpb::Timestamp >*
+      mutable_observed_timestamps();
 
   // optional bool Writing = 9;
   bool has_writing() const;
@@ -1651,8 +1549,8 @@ class Transaction : public ::google::protobuf::Message {
   inline void clear_has_last_heartbeat();
   inline void set_has_orig_timestamp();
   inline void clear_has_orig_timestamp();
-  inline void set_has_max_timestamp();
-  inline void clear_has_max_timestamp();
+  inline void set_has_observed_timestamp();
+  inline void clear_has_observed_timestamp();
   inline void set_has_writing();
   inline void clear_has_writing();
   inline void set_has_sequence();
@@ -1667,8 +1565,18 @@ class Transaction : public ::google::protobuf::Message {
   int status_;
   ::cockroach::roachpb::Timestamp* last_heartbeat_;
   ::cockroach::roachpb::Timestamp* orig_timestamp_;
-  ::cockroach::roachpb::Timestamp* max_timestamp_;
-  ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp > max_timestamps_;
+  ::cockroach::roachpb::Timestamp* observed_timestamp_;
+  typedef ::google::protobuf::internal::MapEntryLite<
+      ::google::protobuf::int32, ::cockroach::roachpb::Timestamp,
+      ::google::protobuf::internal::WireFormatLite::TYPE_INT32,
+      ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
+      0 >
+      Transaction_ObservedTimestampsEntry;
+  ::google::protobuf::internal::MapField<
+      ::google::protobuf::int32, ::cockroach::roachpb::Timestamp,
+      ::google::protobuf::internal::WireFormatLite::TYPE_INT32,
+      ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
+      0 > observed_timestamps_;
   bool writing_;
   ::google::protobuf::uint32 sequence_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::Span > intents_;
@@ -3020,77 +2928,6 @@ inline void InternalCommitTrigger::set_allocated_modified_span_trigger(::cockroa
 
 // -------------------------------------------------------------------
 
-// NodeWithTimestamp
-
-// optional int32 node_id = 1;
-inline bool NodeWithTimestamp::has_node_id() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-inline void NodeWithTimestamp::set_has_node_id() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void NodeWithTimestamp::clear_has_node_id() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-inline void NodeWithTimestamp::clear_node_id() {
-  node_id_ = 0;
-  clear_has_node_id();
-}
-inline ::google::protobuf::int32 NodeWithTimestamp::node_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.NodeWithTimestamp.node_id)
-  return node_id_;
-}
-inline void NodeWithTimestamp::set_node_id(::google::protobuf::int32 value) {
-  set_has_node_id();
-  node_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.NodeWithTimestamp.node_id)
-}
-
-// optional .cockroach.roachpb.Timestamp max_timestamp = 2;
-inline bool NodeWithTimestamp::has_max_timestamp() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
-}
-inline void NodeWithTimestamp::set_has_max_timestamp() {
-  _has_bits_[0] |= 0x00000002u;
-}
-inline void NodeWithTimestamp::clear_has_max_timestamp() {
-  _has_bits_[0] &= ~0x00000002u;
-}
-inline void NodeWithTimestamp::clear_max_timestamp() {
-  if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_max_timestamp();
-}
-inline const ::cockroach::roachpb::Timestamp& NodeWithTimestamp::max_timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
-  return max_timestamp_ != NULL ? *max_timestamp_ : *default_instance_->max_timestamp_;
-}
-inline ::cockroach::roachpb::Timestamp* NodeWithTimestamp::mutable_max_timestamp() {
-  set_has_max_timestamp();
-  if (max_timestamp_ == NULL) {
-    max_timestamp_ = new ::cockroach::roachpb::Timestamp;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
-  return max_timestamp_;
-}
-inline ::cockroach::roachpb::Timestamp* NodeWithTimestamp::release_max_timestamp() {
-  clear_has_max_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = max_timestamp_;
-  max_timestamp_ = NULL;
-  return temp;
-}
-inline void NodeWithTimestamp::set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp) {
-  delete max_timestamp_;
-  max_timestamp_ = max_timestamp;
-  if (max_timestamp) {
-    set_has_max_timestamp();
-  } else {
-    clear_has_max_timestamp();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
-}
-
-// -------------------------------------------------------------------
-
 // TxnMeta
 
 // optional bytes id = 1;
@@ -3526,77 +3363,65 @@ inline void Transaction::set_allocated_orig_timestamp(::cockroach::roachpb::Time
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.orig_timestamp)
 }
 
-// optional .cockroach.roachpb.Timestamp max_timestamp = 7;
-inline bool Transaction::has_max_timestamp() const {
+// optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
+inline bool Transaction::has_observed_timestamp() const {
   return (_has_bits_[0] & 0x00000040u) != 0;
 }
-inline void Transaction::set_has_max_timestamp() {
+inline void Transaction::set_has_observed_timestamp() {
   _has_bits_[0] |= 0x00000040u;
 }
-inline void Transaction::clear_has_max_timestamp() {
+inline void Transaction::clear_has_observed_timestamp() {
   _has_bits_[0] &= ~0x00000040u;
 }
-inline void Transaction::clear_max_timestamp() {
-  if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_max_timestamp();
+inline void Transaction::clear_observed_timestamp() {
+  if (observed_timestamp_ != NULL) observed_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_observed_timestamp();
 }
-inline const ::cockroach::roachpb::Timestamp& Transaction::max_timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.max_timestamp)
-  return max_timestamp_ != NULL ? *max_timestamp_ : *default_instance_->max_timestamp_;
+inline const ::cockroach::roachpb::Timestamp& Transaction::observed_timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.observed_timestamp)
+  return observed_timestamp_ != NULL ? *observed_timestamp_ : *default_instance_->observed_timestamp_;
 }
-inline ::cockroach::roachpb::Timestamp* Transaction::mutable_max_timestamp() {
-  set_has_max_timestamp();
-  if (max_timestamp_ == NULL) {
-    max_timestamp_ = new ::cockroach::roachpb::Timestamp;
+inline ::cockroach::roachpb::Timestamp* Transaction::mutable_observed_timestamp() {
+  set_has_observed_timestamp();
+  if (observed_timestamp_ == NULL) {
+    observed_timestamp_ = new ::cockroach::roachpb::Timestamp;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.max_timestamp)
-  return max_timestamp_;
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.observed_timestamp)
+  return observed_timestamp_;
 }
-inline ::cockroach::roachpb::Timestamp* Transaction::release_max_timestamp() {
-  clear_has_max_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = max_timestamp_;
-  max_timestamp_ = NULL;
+inline ::cockroach::roachpb::Timestamp* Transaction::release_observed_timestamp() {
+  clear_has_observed_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = observed_timestamp_;
+  observed_timestamp_ = NULL;
   return temp;
 }
-inline void Transaction::set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp) {
-  delete max_timestamp_;
-  max_timestamp_ = max_timestamp;
-  if (max_timestamp) {
-    set_has_max_timestamp();
+inline void Transaction::set_allocated_observed_timestamp(::cockroach::roachpb::Timestamp* observed_timestamp) {
+  delete observed_timestamp_;
+  observed_timestamp_ = observed_timestamp;
+  if (observed_timestamp) {
+    set_has_observed_timestamp();
   } else {
-    clear_has_max_timestamp();
+    clear_has_observed_timestamp();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.max_timestamp)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.observed_timestamp)
 }
 
-// repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
-inline int Transaction::max_timestamps_size() const {
-  return max_timestamps_.size();
+// map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;
+inline int Transaction::observed_timestamps_size() const {
+  return observed_timestamps_.size();
 }
-inline void Transaction::clear_max_timestamps() {
-  max_timestamps_.Clear();
+inline void Transaction::clear_observed_timestamps() {
+  observed_timestamps_.Clear();
 }
-inline const ::cockroach::roachpb::NodeWithTimestamp& Transaction::max_timestamps(int index) const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.max_timestamps)
-  return max_timestamps_.Get(index);
+inline const ::google::protobuf::Map< ::google::protobuf::int32, ::cockroach::roachpb::Timestamp >&
+Transaction::observed_timestamps() const {
+  // @@protoc_insertion_point(field_map:cockroach.roachpb.Transaction.observed_timestamps)
+  return observed_timestamps_.GetMap();
 }
-inline ::cockroach::roachpb::NodeWithTimestamp* Transaction::mutable_max_timestamps(int index) {
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.max_timestamps)
-  return max_timestamps_.Mutable(index);
-}
-inline ::cockroach::roachpb::NodeWithTimestamp* Transaction::add_max_timestamps() {
-  // @@protoc_insertion_point(field_add:cockroach.roachpb.Transaction.max_timestamps)
-  return max_timestamps_.Add();
-}
-inline ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >*
-Transaction::mutable_max_timestamps() {
-  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.Transaction.max_timestamps)
-  return &max_timestamps_;
-}
-inline const ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >&
-Transaction::max_timestamps() const {
-  // @@protoc_insertion_point(field_list:cockroach.roachpb.Transaction.max_timestamps)
-  return max_timestamps_;
+inline ::google::protobuf::Map< ::google::protobuf::int32, ::cockroach::roachpb::Timestamp >*
+Transaction::mutable_observed_timestamps() {
+  // @@protoc_insertion_point(field_mutable_map:cockroach.roachpb.Transaction.observed_timestamps)
+  return observed_timestamps_.MutableMap();
 }
 
 // optional bool Writing = 9;
@@ -4026,8 +3851,6 @@ inline void SequenceCacheEntry::set_allocated_timestamp(::cockroach::roachpb::Ti
 }
 
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
-// -------------------------------------------------------------------
-
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
@@ -47,7 +47,7 @@ class KeyValue;
 class Lease;
 class MergeTrigger;
 class ModifiedSpanTrigger;
-class NodeList;
+class NodeWithTimestamp;
 class SequenceCacheEntry;
 class Span;
 class SplitTrigger;
@@ -1231,14 +1231,14 @@ class InternalCommitTrigger : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
-class NodeList : public ::google::protobuf::Message {
+class NodeWithTimestamp : public ::google::protobuf::Message {
  public:
-  NodeList();
-  virtual ~NodeList();
+  NodeWithTimestamp();
+  virtual ~NodeWithTimestamp();
 
-  NodeList(const NodeList& from);
+  NodeWithTimestamp(const NodeWithTimestamp& from);
 
-  inline NodeList& operator=(const NodeList& from) {
+  inline NodeWithTimestamp& operator=(const NodeWithTimestamp& from) {
     CopyFrom(from);
     return *this;
   }
@@ -1252,19 +1252,19 @@ class NodeList : public ::google::protobuf::Message {
   }
 
   static const ::google::protobuf::Descriptor* descriptor();
-  static const NodeList& default_instance();
+  static const NodeWithTimestamp& default_instance();
 
-  void Swap(NodeList* other);
+  void Swap(NodeWithTimestamp* other);
 
   // implements Message ----------------------------------------------
 
-  inline NodeList* New() const { return New(NULL); }
+  inline NodeWithTimestamp* New() const { return New(NULL); }
 
-  NodeList* New(::google::protobuf::Arena* arena) const;
+  NodeWithTimestamp* New(::google::protobuf::Arena* arena) const;
   void CopyFrom(const ::google::protobuf::Message& from);
   void MergeFrom(const ::google::protobuf::Message& from);
-  void CopyFrom(const NodeList& from);
-  void MergeFrom(const NodeList& from);
+  void CopyFrom(const NodeWithTimestamp& from);
+  void MergeFrom(const NodeWithTimestamp& from);
   void Clear();
   bool IsInitialized() const;
 
@@ -1279,7 +1279,7 @@ class NodeList : public ::google::protobuf::Message {
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const;
-  void InternalSwap(NodeList* other);
+  void InternalSwap(NodeWithTimestamp* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
     return _internal_metadata_.arena();
@@ -1295,32 +1295,40 @@ class NodeList : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // repeated int32 nodes = 1 [packed = true];
-  int nodes_size() const;
-  void clear_nodes();
-  static const int kNodesFieldNumber = 1;
-  ::google::protobuf::int32 nodes(int index) const;
-  void set_nodes(int index, ::google::protobuf::int32 value);
-  void add_nodes(::google::protobuf::int32 value);
-  const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
-      nodes() const;
-  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-      mutable_nodes();
+  // optional int32 node_id = 1;
+  bool has_node_id() const;
+  void clear_node_id();
+  static const int kNodeIdFieldNumber = 1;
+  ::google::protobuf::int32 node_id() const;
+  void set_node_id(::google::protobuf::int32 value);
 
-  // @@protoc_insertion_point(class_scope:cockroach.roachpb.NodeList)
+  // optional .cockroach.roachpb.Timestamp max_timestamp = 2;
+  bool has_max_timestamp() const;
+  void clear_max_timestamp();
+  static const int kMaxTimestampFieldNumber = 2;
+  const ::cockroach::roachpb::Timestamp& max_timestamp() const;
+  ::cockroach::roachpb::Timestamp* mutable_max_timestamp();
+  ::cockroach::roachpb::Timestamp* release_max_timestamp();
+  void set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp);
+
+  // @@protoc_insertion_point(class_scope:cockroach.roachpb.NodeWithTimestamp)
  private:
+  inline void set_has_node_id();
+  inline void clear_has_node_id();
+  inline void set_has_max_timestamp();
+  inline void clear_has_max_timestamp();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::google::protobuf::RepeatedField< ::google::protobuf::int32 > nodes_;
-  mutable int _nodes_cached_byte_size_;
+  ::cockroach::roachpb::Timestamp* max_timestamp_;
+  ::google::protobuf::int32 node_id_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2fdata_2eproto();
 
   void InitAsDefaultInstance();
-  static NodeList* default_instance_;
+  static NodeWithTimestamp* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -1591,14 +1599,17 @@ class Transaction : public ::google::protobuf::Message {
   ::cockroach::roachpb::Timestamp* release_max_timestamp();
   void set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp);
 
-  // optional .cockroach.roachpb.NodeList certain_nodes = 8;
-  bool has_certain_nodes() const;
-  void clear_certain_nodes();
-  static const int kCertainNodesFieldNumber = 8;
-  const ::cockroach::roachpb::NodeList& certain_nodes() const;
-  ::cockroach::roachpb::NodeList* mutable_certain_nodes();
-  ::cockroach::roachpb::NodeList* release_certain_nodes();
-  void set_allocated_certain_nodes(::cockroach::roachpb::NodeList* certain_nodes);
+  // repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
+  int max_timestamps_size() const;
+  void clear_max_timestamps();
+  static const int kMaxTimestampsFieldNumber = 8;
+  const ::cockroach::roachpb::NodeWithTimestamp& max_timestamps(int index) const;
+  ::cockroach::roachpb::NodeWithTimestamp* mutable_max_timestamps(int index);
+  ::cockroach::roachpb::NodeWithTimestamp* add_max_timestamps();
+  ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >*
+      mutable_max_timestamps();
+  const ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >&
+      max_timestamps() const;
 
   // optional bool Writing = 9;
   bool has_writing() const;
@@ -1642,8 +1653,6 @@ class Transaction : public ::google::protobuf::Message {
   inline void clear_has_orig_timestamp();
   inline void set_has_max_timestamp();
   inline void clear_has_max_timestamp();
-  inline void set_has_certain_nodes();
-  inline void clear_has_certain_nodes();
   inline void set_has_writing();
   inline void clear_has_writing();
   inline void set_has_sequence();
@@ -1659,7 +1668,7 @@ class Transaction : public ::google::protobuf::Message {
   ::cockroach::roachpb::Timestamp* last_heartbeat_;
   ::cockroach::roachpb::Timestamp* orig_timestamp_;
   ::cockroach::roachpb::Timestamp* max_timestamp_;
-  ::cockroach::roachpb::NodeList* certain_nodes_;
+  ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp > max_timestamps_;
   bool writing_;
   ::google::protobuf::uint32 sequence_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::Span > intents_;
@@ -3011,36 +3020,73 @@ inline void InternalCommitTrigger::set_allocated_modified_span_trigger(::cockroa
 
 // -------------------------------------------------------------------
 
-// NodeList
+// NodeWithTimestamp
 
-// repeated int32 nodes = 1 [packed = true];
-inline int NodeList::nodes_size() const {
-  return nodes_.size();
+// optional int32 node_id = 1;
+inline bool NodeWithTimestamp::has_node_id() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void NodeList::clear_nodes() {
-  nodes_.Clear();
+inline void NodeWithTimestamp::set_has_node_id() {
+  _has_bits_[0] |= 0x00000001u;
 }
-inline ::google::protobuf::int32 NodeList::nodes(int index) const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.NodeList.nodes)
-  return nodes_.Get(index);
+inline void NodeWithTimestamp::clear_has_node_id() {
+  _has_bits_[0] &= ~0x00000001u;
 }
-inline void NodeList::set_nodes(int index, ::google::protobuf::int32 value) {
-  nodes_.Set(index, value);
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.NodeList.nodes)
+inline void NodeWithTimestamp::clear_node_id() {
+  node_id_ = 0;
+  clear_has_node_id();
 }
-inline void NodeList::add_nodes(::google::protobuf::int32 value) {
-  nodes_.Add(value);
-  // @@protoc_insertion_point(field_add:cockroach.roachpb.NodeList.nodes)
+inline ::google::protobuf::int32 NodeWithTimestamp::node_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.NodeWithTimestamp.node_id)
+  return node_id_;
 }
-inline const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
-NodeList::nodes() const {
-  // @@protoc_insertion_point(field_list:cockroach.roachpb.NodeList.nodes)
-  return nodes_;
+inline void NodeWithTimestamp::set_node_id(::google::protobuf::int32 value) {
+  set_has_node_id();
+  node_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.NodeWithTimestamp.node_id)
 }
-inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-NodeList::mutable_nodes() {
-  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.NodeList.nodes)
-  return &nodes_;
+
+// optional .cockroach.roachpb.Timestamp max_timestamp = 2;
+inline bool NodeWithTimestamp::has_max_timestamp() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void NodeWithTimestamp::set_has_max_timestamp() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void NodeWithTimestamp::clear_has_max_timestamp() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void NodeWithTimestamp::clear_max_timestamp() {
+  if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_max_timestamp();
+}
+inline const ::cockroach::roachpb::Timestamp& NodeWithTimestamp::max_timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
+  return max_timestamp_ != NULL ? *max_timestamp_ : *default_instance_->max_timestamp_;
+}
+inline ::cockroach::roachpb::Timestamp* NodeWithTimestamp::mutable_max_timestamp() {
+  set_has_max_timestamp();
+  if (max_timestamp_ == NULL) {
+    max_timestamp_ = new ::cockroach::roachpb::Timestamp;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
+  return max_timestamp_;
+}
+inline ::cockroach::roachpb::Timestamp* NodeWithTimestamp::release_max_timestamp() {
+  clear_has_max_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = max_timestamp_;
+  max_timestamp_ = NULL;
+  return temp;
+}
+inline void NodeWithTimestamp::set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp) {
+  delete max_timestamp_;
+  max_timestamp_ = max_timestamp;
+  if (max_timestamp) {
+    set_has_max_timestamp();
+  } else {
+    clear_has_max_timestamp();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.NodeWithTimestamp.max_timestamp)
 }
 
 // -------------------------------------------------------------------
@@ -3523,47 +3569,34 @@ inline void Transaction::set_allocated_max_timestamp(::cockroach::roachpb::Times
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.max_timestamp)
 }
 
-// optional .cockroach.roachpb.NodeList certain_nodes = 8;
-inline bool Transaction::has_certain_nodes() const {
-  return (_has_bits_[0] & 0x00000080u) != 0;
+// repeated .cockroach.roachpb.NodeWithTimestamp max_timestamps = 8;
+inline int Transaction::max_timestamps_size() const {
+  return max_timestamps_.size();
 }
-inline void Transaction::set_has_certain_nodes() {
-  _has_bits_[0] |= 0x00000080u;
+inline void Transaction::clear_max_timestamps() {
+  max_timestamps_.Clear();
 }
-inline void Transaction::clear_has_certain_nodes() {
-  _has_bits_[0] &= ~0x00000080u;
+inline const ::cockroach::roachpb::NodeWithTimestamp& Transaction::max_timestamps(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.max_timestamps)
+  return max_timestamps_.Get(index);
 }
-inline void Transaction::clear_certain_nodes() {
-  if (certain_nodes_ != NULL) certain_nodes_->::cockroach::roachpb::NodeList::Clear();
-  clear_has_certain_nodes();
+inline ::cockroach::roachpb::NodeWithTimestamp* Transaction::mutable_max_timestamps(int index) {
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.max_timestamps)
+  return max_timestamps_.Mutable(index);
 }
-inline const ::cockroach::roachpb::NodeList& Transaction::certain_nodes() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.certain_nodes)
-  return certain_nodes_ != NULL ? *certain_nodes_ : *default_instance_->certain_nodes_;
+inline ::cockroach::roachpb::NodeWithTimestamp* Transaction::add_max_timestamps() {
+  // @@protoc_insertion_point(field_add:cockroach.roachpb.Transaction.max_timestamps)
+  return max_timestamps_.Add();
 }
-inline ::cockroach::roachpb::NodeList* Transaction::mutable_certain_nodes() {
-  set_has_certain_nodes();
-  if (certain_nodes_ == NULL) {
-    certain_nodes_ = new ::cockroach::roachpb::NodeList;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.certain_nodes)
-  return certain_nodes_;
+inline ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >*
+Transaction::mutable_max_timestamps() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.Transaction.max_timestamps)
+  return &max_timestamps_;
 }
-inline ::cockroach::roachpb::NodeList* Transaction::release_certain_nodes() {
-  clear_has_certain_nodes();
-  ::cockroach::roachpb::NodeList* temp = certain_nodes_;
-  certain_nodes_ = NULL;
-  return temp;
-}
-inline void Transaction::set_allocated_certain_nodes(::cockroach::roachpb::NodeList* certain_nodes) {
-  delete certain_nodes_;
-  certain_nodes_ = certain_nodes;
-  if (certain_nodes) {
-    set_has_certain_nodes();
-  } else {
-    clear_has_certain_nodes();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.certain_nodes)
+inline const ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::NodeWithTimestamp >&
+Transaction::max_timestamps() const {
+  // @@protoc_insertion_point(field_list:cockroach.roachpb.Transaction.max_timestamps)
+  return max_timestamps_;
 }
 
 // optional bool Writing = 9;

--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -34,6 +34,13 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
+// nodeIDSlice implements sort.Interface.
+type nodeIDSlice []roachpb.NodeID
+
+func (n nodeIDSlice) Len() int           { return len(n) }
+func (n nodeIDSlice) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n nodeIDSlice) Less(i, j int) bool { return n[i] < n[j] }
+
 // Cluster maintains a list of all nodes, stores and ranges as well as any
 // shared resources.
 type Cluster struct {
@@ -389,7 +396,7 @@ func (c *Cluster) String() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "Cluster Info:\tEpoch - %d\n", c.epoch)
 
-	var nodeIDs roachpb.NodeIDSlice
+	var nodeIDs nodeIDSlice
 	for nodeID := range c.nodes {
 		nodeIDs = append(nodeIDs, nodeID)
 	}

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -164,19 +164,22 @@ func (ls *Stores) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 	if ba.Txn != nil {
 		// For calls that read data within a txn, we keep track of timestamps
 		// observed from the various participating nodes' HLC clocks. If we have
-		// a timestamp on file which is smaller then MaxTimestamp, we can lower
-		// MaxTimestamp accordingly. If MaxTimestamp drops below OrigTimestamp,
-		// we effectively can't see uncertainty restarts any more.
-		if maxTS := ba.Txn.GetUncertainty(ba.Replica.NodeID); maxTS.Less(ba.Txn.MaxTimestamp) {
+		// a timestamp on file for this Node which is smaller than ObservedTimestamp,
+		// we can lower ObservedTimestamp accordingly. If ObservedTimestamp drops below
+		// OrigTimestamp, we effectively can't see uncertainty restarts any
+		// more.
+		// Note that it's not an issue if ObservedTimestamp propagates back out to
+		// the client via a returned Transaction update - when updating a Txn
+		// from another, the larger ObservedTimestamp wins.
+		if maxTS := ba.Txn.GetObservedTimestamp(ba.Replica.NodeID); maxTS.Less(ba.Txn.ObservedTimestamp) {
 			// Copy-on-write to protect others we might be sharing the Txn with.
 			shallowTxn := *ba.Txn
-			log.Warningf("at %s, moving to %s (orig %s)", shallowTxn.MaxTimestamp, maxTS, shallowTxn.OrigTimestamp)
 			// The uncertainty window is [OrigTimestamp, maxTS), so if that window
 			// is empty, there won't be any uncertainty restarts.
 			if !ba.Txn.OrigTimestamp.Less(maxTS) {
 				sp.LogEvent("read has no clock uncertainty")
 			}
-			shallowTxn.MaxTimestamp.Backward(maxTS)
+			shallowTxn.ObservedTimestamp.Backward(maxTS)
 			ba.Txn = &shallowTxn
 		}
 	}

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -161,24 +161,24 @@ func (ls *Stores) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 
 	sp, cleanupSp := tracing.SpanFromContext(opStores, store.Tracer(), ctx)
 	defer cleanupSp()
-	// For calls that read data within a txn, we can avoid uncertainty
-	// related retries in certain situations. If the node is in
-	// "CertainNodes", we need not worry about uncertain reads any
-	// more. Setting MaxTimestamp=OrigTimestamp for the operation
-	// accomplishes that. See roachpb.Transaction.CertainNodes for details.
-	if ba.Txn != nil && ba.Txn.CertainNodes.Contains(ba.Replica.NodeID) {
-		// MaxTimestamp = Timestamp corresponds to no clock uncertainty.
-		sp.LogEvent("read has no clock uncertainty")
-		// Copy-on-write to protect others we might be sharing the Txn with.
-		shallowTxn := *ba.Txn
-		// We set to OrigTimestamp because that works for both SNAPSHOT and
-		// SERIALIZABLE: If we used Timestamp instead, we could run into
-		// unnecessary retries at SNAPSHOT. For example, a SNAPSHOT txn at
-		// OrigTimestamp = 1000.0, Timestamp = 2000.0, MaxTimestamp = 3000.0
-		// will always read at 1000, so a MaxTimestamp of 2000 will still let
-		// it restart with uncertainty when it finds a value in (1000, 2000).
-		shallowTxn.MaxTimestamp = ba.Txn.OrigTimestamp
-		ba.Txn = &shallowTxn
+	if ba.Txn != nil {
+		// For calls that read data within a txn, we keep track of timestamps
+		// observed from the various participating nodes' HLC clocks. If we have
+		// a timestamp on file which is smaller then MaxTimestamp, we can lower
+		// MaxTimestamp accordingly. If MaxTimestamp drops below OrigTimestamp,
+		// we effectively can't see uncertainty restarts any more.
+		if maxTS := ba.Txn.GetUncertainty(ba.Replica.NodeID); maxTS.Less(ba.Txn.MaxTimestamp) {
+			// Copy-on-write to protect others we might be sharing the Txn with.
+			shallowTxn := *ba.Txn
+			log.Warningf("at %s, moving to %s (orig %s)", shallowTxn.MaxTimestamp, maxTS, shallowTxn.OrigTimestamp)
+			// The uncertainty window is [OrigTimestamp, maxTS), so if that window
+			// is empty, there won't be any uncertainty restarts.
+			if !ba.Txn.OrigTimestamp.Less(maxTS) {
+				sp.LogEvent("read has no clock uncertainty")
+			}
+			shallowTxn.MaxTimestamp.Backward(maxTS)
+			ba.Txn = &shallowTxn
+		}
 	}
 	br, pErr := store.Send(ctx, ba)
 	if br != nil && br.Error != nil {


### PR DESCRIPTION
This is a lead-up to improving uncertainty-related restarts. We currently don't
do a very good job of reducing them; only when catching a
ReadWithinUncertaintyIntervalError we take action which prevents further such
restarts for a given node.
An upcoming change will populate this new map with timestamps on more
occasions, fixing issues such as #2861.

There will be related changes across the board in doing this, so I'm trying to put
up some smaller PRs.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4722)

<!-- Reviewable:end -->
