### PR TITLE
Stop-gap for RPC flakiness

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -424,14 +424,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// This is our base handler, so catch all panics and make sure they stick.
 		defer log.FatalOnPanic()
 
+		// Wait for the http server to be ready. This is temporary code; the
+		// old comment stated:
 		// If server is not available, return 503 http response code.
-		select {
-		case <-s.httpReady:
-			// Proceed.
-		default:
-			http.Error(w, "node not yet available", http.StatusServiceUnavailable)
-			return
-		}
+		// TODO(spencerkimball): reintroduce the logic described above, but
+		// without reintroducing #4723.
+		<-s.httpReady
+
 		// Disable caching of responses.
 		w.Header().Set("Cache-control", "no-cache")
 


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/4723.

Related to #4723.

I verified this locally by inserting a `Sleep` before the channel was closed, at least for `TestKVDBCoverage`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4726)

<!-- Reviewable:end -->
