### PR TITLE
sql: send ROLLBACK command tag even when txn already aborted

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -457,6 +457,8 @@ func (e *Executor) execStmt(stmt parser.Statement, planMaker *planner) (Result, 
 		} else if planMaker.txn.Proto.Status == roachpb.ABORTED {
 			// Reset to allow starting a new transaction.
 			planMaker.resetTxn()
+			// NB: postgres replies to COMMIT of failed txn with "ROLLBACK" too.
+			result.PGTag = (*parser.RollbackTransaction)(nil).StatementTag()
 			return result, nil
 		}
 	case *parser.SetTransaction:

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -704,6 +704,31 @@ func TestPGCommandTags(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	tx, err = db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec("INSERT INTO testing.tags VALUES (4, 1)"); err != nil {
+		t.Fatal(err)
+	}
+	// Rollback also checks the correct tag is returned.
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err = db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// An error will abort the server's transaction.
+	if _, err := tx.Exec("INSERT INTO testing.tags VALUES (4, 1), (4, 1)"); err == nil {
+		t.Fatal("expected an error on duplicate k")
+	}
+	// Rollback, even of an aborted txn, should also return the correct tag.
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+
 	// cockroachdb/pq has a special-case for INSERT (due to oids), so test insert and update statements.
 	res, err := db.Exec("INSERT INTO testing.tags VALUES (1, 1), (2, 2)")
 	if err != nil {


### PR DESCRIPTION
drivers (inc `lib/pq`) will assume a rollback failed if we do not reply with `ROLLBACK`, even if the server txn was already aborted.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4736)

<!-- Reviewable:end -->
