### PR TITLE
Don't close http.Request.Body

### DIFF
--- a/rpc/codec/rpc_test.go
+++ b/rpc/codec/rpc_test.go
@@ -416,7 +416,6 @@ func benchmarkEchoProtoHTTP(b *testing.B, size int) {
 	go func() {
 		if err := http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reqBody, err := ioutil.ReadAll(r.Body)
-			defer r.Body.Close()
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return

--- a/server/authentication_test.go
+++ b/server/authentication_test.go
@@ -131,9 +131,8 @@ func TestSSLEnforcement(t *testing.T) {
 			nodeCertsContext, true, http.StatusOK},
 		{"POST", driver.Endpoint + driver.Execute.String(), sqlForUser(testCertsContext),
 			testCertsContext, true, http.StatusOK},
-		// TODO(bdarnell): https://github.com/cockroachdb/cockroach/issues/4718
-		//{"POST", driver.Endpoint + driver.Execute.String(), sqlForUser(noCertsContext),
-		//	noCertsContext, true, http.StatusUnauthorized},
+		{"POST", driver.Endpoint + driver.Execute.String(), sqlForUser(noCertsContext),
+			noCertsContext, true, http.StatusUnauthorized},
 		{"POST", driver.Endpoint + driver.Execute.String(), sqlForUser(insecureContext),
 			insecureContext, false, -1},
 	}

--- a/sql/server.go
+++ b/sql/server.go
@@ -56,7 +56,6 @@ func MakeServer(ctx *base.Context, executor *Executor) Server {
 // present, in the same format as the request's incoming Content-Type
 // header.
 func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
 	method := r.URL.Path
 	if !strings.HasPrefix(method, driver.Endpoint) {
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)

--- a/ts/server.go
+++ b/ts/server.go
@@ -63,7 +63,6 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request, _ httproute
 
 	// Unmarshal query request.
 	reqBody, err := ioutil.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
The HTTP server is responsible for closing the request body. Doing so
was apparently harmless in HTTP/1, but makes things racy with HTTP/2 (at
least when the body has not been read before closing).

Fixes #4718 

@tschottdorf: `git blame` says you touched this last. Do you remember seeing actual problems that required closing the request body?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4738)

<!-- Reviewable:end -->
