### PR TITLE
Introduce retry loop into client/rpc_sender.go:Send

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -627,6 +627,12 @@ func TestClientPermissions(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
+	oldHealthyTimeout := client.HealthyTimeout
+	client.HealthyTimeout = 250 * time.Millisecond
+	defer func() {
+		client.HealthyTimeout = oldHealthyTimeout
+	}()
+
 	// NodeUser certs are required for all KV operations.
 	// RootUser has no KV privileges whatsoever.
 	nodeClient := createTestClientForUser(t, s.Stopper(), s.ServingAddr(), security.NodeUser)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -21,7 +21,6 @@ type Context struct {
 	RemoteClocks      *RemoteClockMonitor
 	DisableCache      bool // Disable client cache when calling NewClient()
 	DisableReconnects bool // Disable client reconnects
-	HealthWait        time.Duration
 
 	HeartbeatInterval time.Duration
 	HeartbeatTimeout  time.Duration
@@ -37,7 +36,6 @@ func NewContext(context *base.Context, clock *hlc.Clock, stopper *stop.Stopper) 
 		localClock:   clock,
 		Stopper:      stopper,
 		RemoteClocks: newRemoteClockMonitor(clock),
-		HealthWait:   5 * time.Second,
 	}
 	return ctx
 }


### PR DESCRIPTION
This code is almost dead, but it causes issues with KV unittests
which still use it when testing the DBServer which is the old HTTP
RPC gateway to the server. The retry loop is a better stopgap than
the previous change to remove code which returned 503 errors on
requests arriving before the HTTP server is ready, as that fix
(#4726) disabled better error messages when trying to join a still-
bootstrapping node.

Fixes #4723

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4741)

<!-- Reviewable:end -->
