### PR TITLE
server: restrict the server.Context.InitDefaults implementation

### DIFF
--- a/cli/context.go
+++ b/cli/context.go
@@ -16,7 +16,6 @@
 
 package cli
 
-// Context holds parameters needed to setup a server.
 import "github.com/cockroachdb/cockroach/server"
 
 // Context contains global settings for the command-line client.

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -36,6 +36,10 @@ var maxResults int64
 var connURL string
 var connUser, connHost, connPort, connDBName string
 
+// cliContext is the CLI Context used for the command-line client.
+var cliContext = NewContext()
+var cacheSize *bytesValue
+
 var flagUsage = map[string]string{
 	"attrs": wrapText(`
 An ordered, colon-separated list of node attributes. Attributes are
@@ -204,14 +208,22 @@ Database user name.`),
 const usageIndentation = 8
 const wrapWidth = 79 - usageIndentation
 
-type bytesValue uint64
+type bytesValue struct {
+	val   *uint64
+	isSet bool
+}
+
+func newBytesValue(val *uint64) *bytesValue {
+	return &bytesValue{val: val}
+}
 
 func (b *bytesValue) Set(s string) error {
 	v, err := humanize.ParseBytes(s)
 	if err != nil {
 		return err
 	}
-	*b = bytesValue(v)
+	*b.val = v
+	b.isSet = true
 	return nil
 }
 
@@ -223,7 +235,7 @@ func (b *bytesValue) String() string {
 	// This uses the MiB, GiB, etc suffixes. If we use humanize.Bytes() we get
 	// the MB, GB, etc suffixes, but the conversion is done in multiples of 1000
 	// vs 1024.
-	return humanize.IBytes(uint64(*b))
+	return humanize.IBytes(*b.val)
 }
 
 func wrapText(s string) string {
@@ -281,11 +293,16 @@ func initFlags(ctx *Context) {
 		f.BoolVar(&ctx.Linearizable, "linearizable", ctx.Linearizable, usage("linearizable"))
 
 		// Engine flags.
-		f.Var((*bytesValue)(&ctx.CacheSize), "cache-size", usage("cache-size"))
-		f.Var((*bytesValue)(&ctx.MemtableBudget), "memtable-budget", usage("memtable-budget"))
+		cacheSize = newBytesValue(&ctx.CacheSize)
+		f.Var(cacheSize, "cache-size", usage("cache-size"))
+		f.Var(newBytesValue(&ctx.MemtableBudget), "memtable-budget", usage("memtable-budget"))
 		f.DurationVar(&ctx.ScanInterval, "scan-interval", ctx.ScanInterval, usage("scan-interval"))
 		f.DurationVar(&ctx.ScanMaxIdleTime, "scan-max-idle-time", ctx.ScanMaxIdleTime, usage("scan-max-idle-time"))
 		f.DurationVar(&ctx.TimeUntilStoreDead, "time-until-store-dead", ctx.TimeUntilStoreDead, usage("time-until-store-dead"))
+
+		// Clear the cache-size default value. This flag does have a default, but
+		// it is set only when the "start" command is run.
+		f.Lookup("cache-size").DefValue = ""
 
 		if err := startCmd.MarkFlagRequired("store"); err != nil {
 			panic(err)

--- a/cli/start.go
+++ b/cli/start.go
@@ -39,9 +39,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// cliContext is the CLI Context used for the command-line client.
-var cliContext = NewContext()
-
 var errMissingParams = errors.New("missing or invalid parameters")
 
 // panicGuard wraps an errorless command into one wrapping panics into errors.
@@ -101,6 +98,12 @@ uninitialized, specify the --join flag to point to any healthy node
 // of other active nodes used to join this node to the cockroach
 // cluster, if this is its first time connecting.
 func runStart(_ *cobra.Command, _ []string) error {
+	if !cacheSize.isSet {
+		if size, err := server.GetTotalMemory(); err == nil {
+			cliContext.CacheSize = size / 2
+		}
+	}
+
 	// Default the log directory to the the "logs" subdirectory of the first
 	// non-memory store. We only do this for the "start" command which is why
 	// this work occurs here and not in an OnInitialize function.


### PR DESCRIPTION
Not create a `server.Context` until we know the `start` command has been
performed is doable, but awkward as we'd end up copying a lot of
fields. Instead we take the approach of requiring that
`Context.InitDefaults` is simple.

The default value of `server.Context.CacheSize` is now set only during
the `start` command.

Fixes #4203, #4217.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4745)

<!-- Reviewable:end -->
