### PR TITLE
storage: Use snapshots when verifying recomputations of a replica's stats in tests

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -914,9 +914,8 @@ func verifyRangeStats(eng engine.Engine, rangeID roachpb.RangeID, expMS engine.M
 	return nil
 }
 
-func verifyRecomputedStats(store *storage.Store, d *roachpb.RangeDescriptor, expMS engine.MVCCStats) error {
-	now := store.Clock().Timestamp()
-	if ms, err := storage.ComputeStatsForRange(d, store.Engine(), now.WallTime); err != nil {
+func verifyRecomputedStats(eng engine.Engine, d *roachpb.RangeDescriptor, expMS engine.MVCCStats) error {
+	if ms, err := storage.ComputeStatsForRange(d, eng, 0); err != nil {
 		return err
 	} else if expMS != ms {
 		return fmt.Errorf("expected range's stats to agree with recomputation: got\n%+v\nrecomputed\n%+v", expMS, ms)


### PR DESCRIPTION
Fixes #4740.

The issue was that we had introduced a race condition by not using an
engine snapshot between getting a replica's stats and recomputing a
replica's stats. This issue was present in `TestStoreRangeSplitStats`
and `TestStoreRangeMergeStats`. Now both will stand up to being
stressed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4746)

<!-- Reviewable:end -->
