### PR TITLE
tracing: defer Finish for all started spans

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -233,9 +233,11 @@ func (ds *DistSender) RangeLookup(key roachpb.RKey, desc *roachpb.RangeDescripto
 		Reverse:         useReverseScan,
 	})
 	replicas := newReplicaSlice(ds.gossip, desc)
-	// TODO(tschottdorf) consider a Trace here, potentially that of the request
-	// that had the cache miss and waits for the result.
-	br, err := ds.sendRPC(ds.Tracer.StartSpan("range lookup"), desc.RangeID, replicas, orderRandom, ba)
+	trace := ds.Tracer.StartSpan("range lookup")
+	defer trace.Finish()
+	// TODO(tschottdorf): Ideally we would use the trace of the request which
+	// caused this lookup instead of a new one.
+	br, err := ds.sendRPC(trace, desc.RangeID, replicas, orderRandom, ba)
 	if err != nil {
 		return nil, err
 	}
@@ -524,7 +526,8 @@ func (ds *DistSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error, bool) {
 	isReverse := ba.IsReverse()
 
-	sp := tracing.SpanFromContext(opDistSender, ds.Tracer, ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opDistSender, ds.Tracer, ctx)
+	defer cleanupSp()
 
 	// The minimal key range encompassing all requests contained within.
 	// Local addressing has already been resolved.

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -309,7 +309,8 @@ func (tc *TxnCoordSender) startStats() {
 // write intents; they're tagged to an outgoing EndTransaction request, with
 // the receiving replica in charge of resolving them.
 func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-	sp := tracing.SpanFromContext(opTxnCoordSender, tc.tracer, ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opTxnCoordSender, tc.tracer, ctx)
+	defer cleanupSp()
 	// TODO(tschottdorf): real tracing should still propagate here, but the
 	// serialization is currently pretty slow and that sucks for benchmarks.
 	if sp.BaggageItem(tracing.Snowball) != "" {
@@ -695,7 +696,8 @@ func (tc *TxnCoordSender) heartbeat(txnID uuid.UUID, trace opentracing.Span, ctx
 // object when adequate. It also updates certain errors with the
 // updated transaction for use by client restarts.
 func (tc *TxnCoordSender) updateState(ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse, pErr *roachpb.Error) *roachpb.Error {
-	sp := tracing.SpanFromContext(opTxnCoordSender, tc.tracer, ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opTxnCoordSender, tc.tracer, ctx)
+	defer cleanupSp()
 	newTxn := &roachpb.Transaction{}
 	newTxn.Update(ba.Txn)
 	// If the request was successful but we're in a transaction which needs to

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -410,8 +410,10 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 	// order to be processed, check whether this replica has leader lease
 	// and renew or acquire if necessary.
 	if bq.impl.needsLeaderLease() {
+		span := repl.store.Tracer().StartSpan("queue")
+		defer span.Finish()
 		// Create a "fake" get request in order to invoke redirectOnOrAcquireLease.
-		if err := repl.redirectOnOrAcquireLeaderLease(repl.store.Tracer().StartSpan("queue")); err != nil {
+		if err := repl.redirectOnOrAcquireLeaderLease(span); err != nil {
 			bq.eventLog.Infof(log.V(3), "%s: could not acquire leader lease; skipping", repl)
 			return nil
 		}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -644,7 +644,8 @@ func (r *Replica) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 		return nil, roachpb.NewError(err)
 	}
 
-	sp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	defer cleanupSp()
 	// Differentiate between admin, read-only and write.
 	var pErr *roachpb.Error
 	if ba.IsAdmin() {
@@ -786,7 +787,9 @@ func (r *Replica) addAdminCmd(ctx context.Context, ba roachpb.BatchRequest) (*ro
 		return nil, pErr
 	}
 
-	sp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	defer cleanupSp()
+
 	sp.SetOperationName(reflect.TypeOf(args).String())
 
 	// Admin commands always require the leader lease.
@@ -823,7 +826,8 @@ func (r *Replica) addAdminCmd(ctx context.Context, ba roachpb.BatchRequest) (*ro
 // overlapping writes currently processing through Raft ahead of us to
 // clear via the read queue.
 func (r *Replica) addReadOnlyCmd(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-	sp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	defer cleanupSp()
 
 	// Add the read to the command queue to gate subsequent
 	// overlapping commands until this command completes.
@@ -884,7 +888,8 @@ func (r *Replica) addWriteCmd(ctx context.Context, ba roachpb.BatchRequest, wg *
 	// early returns do not skip this.
 	defer signal()
 
-	sp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	defer cleanupSp()
 
 	// Add the write to the command queue to gate subsequent overlapping
 	// commands until this command completes. Note that this must be
@@ -1255,7 +1260,9 @@ func (r *Replica) processRaftCommand(idKey cmdIDKey, index uint64, raftCmd roach
 		ctx = r.context()
 	}
 
-	sp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	defer cleanupSp()
+
 	sp.LogEvent("applying batch")
 	// applyRaftCommand will return "expected" errors, but may also indicate
 	// replica corruption (as of now, signaled by a replicaCorruptionError).
@@ -1582,7 +1589,9 @@ func (r *Replica) getLeaseForGossip(ctx context.Context) (bool, *roachpb.Error) 
 	var pErr *roachpb.Error
 	if !r.store.Stopper().RunTask(func() {
 		// Check for or obtain the lease, if none active.
-		pErr = r.redirectOnOrAcquireLeaderLease(tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx))
+		sp, cleanupSp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+		defer cleanupSp()
+		pErr = r.redirectOnOrAcquireLeaderLease(sp)
 		hasLease = pErr == nil
 		if pErr != nil {
 			switch e := pErr.GetDetail().(type) {
@@ -1824,7 +1833,9 @@ func (r *Replica) maybeSetCorrupt(pErr *roachpb.Error) *roachpb.Error {
 // waiting client retries immediately after calling this function, it will not
 // hit the same intents again.
 func (r *Replica) resolveIntents(ctx context.Context, intents []roachpb.Intent, wait bool, poison bool) *roachpb.Error {
-	sp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	defer cleanupSp()
+
 	ctx, _ = opentracing.ContextWithSpan(ctx, nil) // we're doing async stuff below; those need new traces
 	sp.LogEvent(fmt.Sprintf("resolving intents [wait=%t]", wait))
 

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1290,7 +1290,8 @@ func (r *Replica) LeaderLease(batch engine.Engine, ms *engine.MVCCStats, h roach
 // TODO(tschottdorf): should assert that split key is not a local key.
 func (r *Replica) AdminSplit(ctx context.Context, args roachpb.AdminSplitRequest, desc *roachpb.RangeDescriptor) (roachpb.AdminSplitResponse, *roachpb.Error) {
 	var reply roachpb.AdminSplitResponse
-	sp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	defer cleanupSp()
 
 	// Determine split key if not provided with args. This scan is
 	// allowed to be relatively slow because admin commands don't block
@@ -1550,7 +1551,8 @@ func (r *Replica) splitTrigger(batch engine.Engine, ms *engine.MVCCStats, split 
 // comment of "AdminSplit" for more information on this pattern.
 func (r *Replica) AdminMerge(ctx context.Context, args roachpb.AdminMergeRequest, origLeftDesc *roachpb.RangeDescriptor) (roachpb.AdminMergeResponse, *roachpb.Error) {
 	var reply roachpb.AdminMergeResponse
-	sp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
+	defer cleanupSp()
 
 	if origLeftDesc.EndKey.Equal(roachpb.RKeyMax) {
 		// Merging the final range doesn't make sense.

--- a/storage/store.go
+++ b/storage/store.go
@@ -1377,7 +1377,8 @@ func (s *Store) ReplicaCount() int {
 // command using the fetched range.
 func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 	ctx = s.Context(ctx)
-	sp := tracing.SpanFromContext(opStore, s.Tracer(), ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opStore, s.Tracer(), ctx)
+	defer cleanupSp()
 
 	for _, union := range ba.Requests {
 		arg := union.GetInner()
@@ -1560,7 +1561,8 @@ func (s *Store) resolveWriteIntentError(ctx context.Context, wiErr *roachpb.Writ
 	if log.V(6) {
 		log.Infoc(ctx, "resolving write intent %s", wiErr)
 	}
-	sp := tracing.SpanFromContext(opStore, s.Tracer(), ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opStore, s.Tracer(), ctx)
+	defer cleanupSp()
 	sp.LogEvent("intent resolution")
 
 	// Split intents into those we need to push and those which are good to

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -159,7 +159,8 @@ func (ls *Stores) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 		return nil, roachpb.NewError(err)
 	}
 
-	sp := tracing.SpanFromContext(opStores, store.Tracer(), ctx)
+	sp, cleanupSp := tracing.SpanFromContext(opStores, store.Tracer(), ctx)
+	defer cleanupSp()
 	// For calls that read data within a txn, we can avoid uncertainty
 	// related retries in certain situations. If the node is in
 	// "CertainNodes", we need not worry about uncertain reads any


### PR DESCRIPTION
Also refactor SpanFromContext to return a cleanup func that finishes the span iff it creates a new one.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4748)

<!-- Reviewable:end -->
