### PR TITLE
sql: fix subqueries with prepare panic

### DIFF
--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -370,6 +370,9 @@ func TestPGPreparedQuery(t *testing.T) {
 			base.Params(3).Results(3, 4),
 		},
 		*/
+		"SELECT a FROM d.T WHERE a = $1 AND (SELECT a >= $2 FROM d.T WHERE a = $1)": {
+			base.Params(10, 5).Results(10),
+		},
 	}
 
 	s := server.StartTestServer(t)
@@ -420,7 +423,8 @@ func TestPGPreparedQuery(t *testing.T) {
 		}
 	}
 
-	if _, err := db.Exec(`CREATE DATABASE d; CREATE TABLE d.t (a INT)`); err != nil {
+	initStmt := `CREATE DATABASE d; CREATE TABLE d.t (a INT); INSERT INTO d.t VALUES (10),(11)`
+	if _, err := db.Exec(initStmt); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Fixing a failure I noticed in the bank benchmark: don't call splitFilter in
prepareOnly mode - subqueries don't get expanded in this case which doesn't work
with splitFilter.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4765)

<!-- Reviewable:end -->
