### PR TITLE
all: remove "root" and "node" whenever possible

### DIFF
--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util/retry"
 )
 
@@ -165,7 +166,7 @@ func (f *Farmer) Exec(i int, cmd string) error {
 // ConnString returns a connection string to pass to client.Open().
 func (f *Farmer) ConnString(i int) string {
 	// TODO(tschottdorf,mberhault): TLS all the things!
-	return "rpc://" + "root" + "@" +
+	return "rpc://" + security.RootUser + "@" +
 		net.JoinHostPort(f.Nodes()[i], base.DefaultPort) +
 		"?certs=" + "certswhocares"
 }

--- a/base/context.go
+++ b/base/context.go
@@ -57,7 +57,7 @@ type Context struct {
 	Certs string
 
 	// User running this process. It could be the user under which
-	// the server is running ("node"), or the user passed in client calls.
+	// the server is running or the user passed in client calls.
 	User string
 
 	// Protects both clientTLSConfig and serverTLSConfig.

--- a/base/context_test.go
+++ b/base/context_test.go
@@ -39,12 +39,12 @@ func TestClientSSLSettings(t *testing.T) {
 		nilConfig     bool
 		noCAs         bool
 	}{
-		{true, "foobar", "node", "http", true, true, false},
+		{true, "foobar", security.NodeUser, "http", true, true, false},
 		{true, certsDir, "not-a-user", "http", true, true, false},
 		{false, certsDir, "not-a-user", "https", false, true, false},
-		{false, "", "node", "https", true, false, true},
-		{false, certsDir, "node", "https", true, false, false},
-		{false, "/dev/null", "node", "https", false, false, false},
+		{false, "", security.NodeUser, "https", true, false, true},
+		{false, certsDir, security.NodeUser, "https", true, false, false},
+		{false, "/dev/null", security.NodeUser, "https", false, false, false},
 	}
 
 	for tcNum, tc := range testCases {

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -247,8 +247,8 @@ func TestAuthentication(t *testing.T) {
 	b := &client.Batch{}
 	b.InternalAddRequest(arg)
 
-	// Create a "node" client and call Run() on it which lets us build
-	// our own request, specifying the user.
+	// Create a node user client and call Run() on it which lets us build our own
+	// request, specifying the user.
 	db1 := createTestClientForUser(t, s.Stopper(), s.ServingAddr(), security.NodeUser)
 	if pErr := db1.Run(b); pErr != nil {
 		t.Fatal(pErr)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -87,7 +87,7 @@ func NewServer(context *Context) *Server {
 // argument of the same type as `reqPrototype`. Both the argument and
 // return value of 'handler' should be a pointer to a protocol message
 // type. The handler function will be executed in a new goroutine.
-// Only the "node" system user is allowed to use these endpoints.
+// Only the security.NodeUser system user is allowed to use these endpoints.
 func (s *Server) Register(name string,
 	handler func(proto.Message) (proto.Message, error),
 	reqPrototype proto.Message) error {
@@ -110,7 +110,7 @@ func (s *Server) RegisterPublic(name string,
 // RPC server's goroutine guarantees that the order of requests as
 // they were read from the connection is preserved.
 // If 'public' is true, all users may call this method, otherwise
-// "node" users only.
+// only the security.NodeUser system user may.
 func (s *Server) RegisterAsync(name string, public bool,
 	handler func(proto.Message, func(proto.Message, error)),
 	reqPrototype proto.Message) error {

--- a/security/certs.go
+++ b/security/certs.go
@@ -141,7 +141,7 @@ func RunCreateCACert(certsDir string, keySize int) error {
 // RunCreateNodeCert is the entry-point from the command-line interface
 // to generate node certs and keys:
 // - node.server.{crt,key}: server cert with list of dns/ip addresses
-// - node.client.{crt,key}: client cert with "node" as the Common Name.
+// - node.client.{crt,key}: client cert with <NodeUser> as the Common Name.
 // We intentionally generate distinct keys for each cert.
 func RunCreateNodeCert(certsDir string, keySize int, hosts []string) error {
 	if certsDir == "" {

--- a/security/certs_test.go
+++ b/security/certs_test.go
@@ -92,7 +92,7 @@ func TestUseCerts(t *testing.T) {
 	}
 
 	// Load TLS Configs. This is what TestServer and HTTPClient do internally.
-	_, err = security.LoadServerTLSConfig(certsDir, "node")
+	_, err = security.LoadServerTLSConfig(certsDir, security.NodeUser)
 	if err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}

--- a/security/tls.go
+++ b/security/tls.go
@@ -54,7 +54,7 @@ func ResetReadFileFn() {
 // - node.server.crt -- the server certificate of this node; should be signed by the CA
 // - node.server.key -- the certificate key
 // If the path is prefixed with "embedded=", load the embedded certs.
-// We should never have username != "node", but this is a good way to
+// We should never have username != NodeUser, but this is a good way to
 // catch tests that use the wrong users.
 func LoadServerTLSConfig(certDir, username string) (*tls.Config, error) {
 	certPEM, err := readFileFn(filepath.Join(certDir, username+".server.crt"))

--- a/security/tls_test.go
+++ b/security/tls_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestLoadTLSConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	config, err := security.LoadServerTLSConfig(security.EmbeddedCertsDir, "node")
+	config, err := security.LoadServerTLSConfig(security.EmbeddedCertsDir, security.NodeUser)
 	if err != nil {
 		t.Fatalf("Failed to load TLS config: %v", err)
 	}

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
@@ -143,7 +144,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 	const testdb = "test"
 	var session sql.Session
 	query := "CREATE DATABASE " + testdb
-	createRes := s.sqlExecutor.ExecuteStatements("root", &session, query, nil)
+	createRes := s.sqlExecutor.ExecuteStatements(security.RootUser, &session, query, nil)
 	if createRes.ResultList[0].PErr != nil {
 		t.Fatal(createRes.ResultList[0].PErr)
 	}
@@ -173,7 +174,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 	privileges := []string{"SELECT", "UPDATE"}
 	testuser := "testuser"
 	grantQuery := "GRANT " + strings.Join(privileges, ", ") + " ON DATABASE " + testdb + " TO " + testuser
-	grantRes := s.sqlExecutor.ExecuteStatements("root", &session, grantQuery, nil)
+	grantRes := s.sqlExecutor.ExecuteStatements(security.RootUser, &session, grantQuery, nil)
 	if grantRes.ResultList[0].PErr != nil {
 		t.Fatal(grantRes.ResultList[0].PErr)
 	}
@@ -197,7 +198,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 
 	for _, grant := range details.Grants {
 		switch grant.User {
-		case "root":
+		case security.RootUser:
 			if !reflect.DeepEqual(grant.Privileges, []string{"ALL"}) {
 				t.Fatalf("privileges %v != expected %v", details.Grants[0].Privileges, privileges)
 			}

--- a/server/authentication_test.go
+++ b/server/authentication_test.go
@@ -66,11 +66,11 @@ func TestSSLEnforcement(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 
-	// HTTPS with client certs for "root".
+	// HTTPS with client certs for security.RootUser.
 	rootCertsContext := testutils.NewTestBaseContext(security.RootUser)
-	// HTTPS with client certs for "node".
+	// HTTPS with client certs for security.NodeUser.
 	nodeCertsContext := testutils.NewNodeTestBaseContext()
-	// HTTPS with client certs for testuser.
+	// HTTPS with client certs for TestUser.
 	testCertsContext := testutils.NewTestBaseContext(TestUser)
 	// HTTPS without client certs. The user does not matter.
 	noCertsContext := testutils.NewTestBaseContext(TestUser)

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -100,7 +100,7 @@ func NewTestContext() *Context {
 	// Start() to an available port.
 	// Call TestServer.ServingAddr() for the full address (including bound port).
 	ctx.Addr = "127.0.0.1:0"
-	// Set standard "node" user for intra-cluster traffic.
+	// Set standard user for intra-cluster traffic.
 	ctx.User = security.NodeUser
 
 	return ctx

--- a/sql/create.go
+++ b/sql/create.go
@@ -24,7 +24,7 @@ import (
 )
 
 // CreateDatabase creates a database.
-// Privileges: "root" user.
+// Privileges: security.RootUser user.
 //   Notes: postgres requires superuser or "CREATEDB".
 //          mysql uses the mysqladmin command.
 func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, *roachpb.Error) {

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -105,7 +105,7 @@ func setup(t *testing.T) (*testServer, *sql.DB, *client.DB) {
 func setupWithContext(t *testing.T, ctx *server.Context) (*testServer, *sql.DB, *client.DB) {
 	s := setupTestServer(t)
 
-	// SQL requests use "root" which has ALL permissions on everything.
+	// SQL requests use security.RootUser which has ALL permissions on everything.
 	url, cleanupFn := sqlutils.PGUrl(t, &s.TestServer, security.RootUser, "setupWithContext")
 	sqlDB, err := sql.Open("postgres", url.String())
 	if err != nil {

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -337,7 +337,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			base.Results("d"),
 		},
 		"SHOW GRANTS ON system.users": {
-			base.Results("users", "root", "DELETE,GRANT,INSERT,SELECT,UPDATE"),
+			base.Results("users", security.RootUser, "DELETE,GRANT,INSERT,SELECT,UPDATE"),
 		},
 		"SHOW INDEX FROM system.users": {
 			base.Results("users", "primary", true, 1, "username", "ASC", false),

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -34,7 +34,7 @@ var (
 )
 
 // RenameDatabase renames the database.
-// Privileges: "root" user.
+// Privileges: security.RootUser user.
 //   Notes: postgres requires superuser, db owner, or "CREATEDB".
 //          mysql >= 5.1.23 does not allow database renames.
 func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, *roachpb.Error) {

--- a/sql/testdata/privileges_database
+++ b/sql/testdata/privileges_database
@@ -1,5 +1,5 @@
 # Test default database-level permissions.
-# Default user is "root".
+# Default user is root.
 statement ok
 CREATE DATABASE a
 

--- a/sql/testdata/privileges_table
+++ b/sql/testdata/privileges_table
@@ -1,5 +1,5 @@
 # Test default table-level permissions.
-# Default user is "root".
+# Default user is root.
 statement ok
 CREATE DATABASE a
 

--- a/testutils/base.go
+++ b/testutils/base.go
@@ -21,9 +21,9 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 )
 
-// NewNodeTestBaseContext creates a base context for testing.
-// This uses embedded certs and the "node" user (default node user).
-// The "node" user has both server and client certificates.
+// NewNodeTestBaseContext creates a base context for testing. This uses
+// embedded certs and the default node user. The default node user has both
+// server and client certificates.
 func NewNodeTestBaseContext() *base.Context {
 	return NewTestBaseContext(security.NodeUser)
 }


### PR DESCRIPTION
This makes it easier to search for both places where these user
constants are used and places where they are explicitly not used.

@marc @petermattis

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4770)

<!-- Reviewable:end -->
