### PR TITLE
sql: limit hint to reduce the first scan chunk

### DIFF
--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -153,3 +153,5 @@ func (n *distinctNode) ExplainPlan() (string, string, []planNode) {
 	}
 	return "distinct", description, []planNode{n.planNode}
 }
+
+func (*distinctNode) SetLimitHint(_ int64) {}

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -281,3 +281,5 @@ func (n *explainDebugNode) Values() parser.DTuple {
 func (*explainDebugNode) DebugValues() debugValues {
 	panic("debug mode not implemented in explainDebugNode")
 }
+
+func (*explainDebugNode) SetLimitHint(_ int64) {}

--- a/sql/group.go
+++ b/sql/group.go
@@ -327,6 +327,8 @@ func (n *groupNode) ExplainPlan() (name, description string, children []planNode
 	return name, description, []planNode{n.plan}
 }
 
+func (*groupNode) SetLimitHint(_ int64) {}
+
 // wrap the supplied planNode with the groupNode if grouping/aggregation is required.
 func (n *groupNode) wrap(plan planNode) planNode {
 	if n == nil {

--- a/sql/join.go
+++ b/sql/join.go
@@ -202,3 +202,10 @@ func (n *indexJoinNode) PErr() *roachpb.Error {
 func (n *indexJoinNode) ExplainPlan() (name, description string, children []planNode) {
 	return "index-join", "", []planNode{n.index, n.table}
 }
+
+func (n *indexJoinNode) SetLimitHint(numRows int64) {
+	if numRows < joinBatchSize {
+		numRows = joinBatchSize
+	}
+	n.index.SetLimitHint(numRows)
+}

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -74,6 +74,10 @@ func (p *planner) limit(n *parser.Select, plan planNode) (planNode, error) {
 		}
 	}
 
+	if count != math.MaxInt64 {
+		plan.SetLimitHint(offset + count)
+	}
+
 	return &limitNode{planNode: plan, count: count, offset: offset}, nil
 }
 
@@ -108,3 +112,5 @@ func (n *limitNode) ExplainPlan() (string, string, []planNode) {
 
 	return "limit", fmt.Sprintf("count: %s, offset: %d", count, n.offset), []planNode{n.planNode}
 }
+
+func (*limitNode) SetLimitHint(_ int64) {}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -307,6 +307,10 @@ type planNode interface {
 	PErr() *roachpb.Error
 	// ExplainPlan returns a name and description and a list of child nodes.
 	ExplainPlan() (name, description string, children []planNode)
+	// SetLimitHint tells this node to optimize things under the assumption that we will only need
+	// the first `numRows` rows. This is only a hint; the node must still be able to produce all
+	// results if requested.
+	SetLimitHint(numRows int64)
 }
 
 var _ planNode = &distinctNode{}
@@ -353,3 +357,5 @@ func (e *emptyNode) Next() bool {
 	e.results = false
 	return r
 }
+
+func (*emptyNode) SetLimitHint(_ int64) {}

--- a/sql/select.go
+++ b/sql/select.go
@@ -145,6 +145,10 @@ func (s *selectNode) ExplainPlan() (name, description string, children []planNod
 	return s.table.node.ExplainPlan()
 }
 
+func (s *selectNode) SetLimitHint(numRows int64) {
+	s.table.node.SetLimitHint(numRows)
+}
+
 // Select selects rows from a single table. Select is the workhorse of the SQL
 // statements. In the slowest and most general case, select must perform full
 // table scans across multiple tables and sort and join the resulting rows on

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -182,6 +182,13 @@ func (n *sortNode) ExplainPlan() (name, description string, children []planNode)
 	return name, description, []planNode{n.plan}
 }
 
+func (n *sortNode) SetLimitHint(numRows int64) {
+	// The limit is only useful to the wrapped node if we don't need to sort.
+	if !n.needSort {
+		n.plan.SetLimitHint(numRows)
+	}
+}
+
 // wrap the supplied planNode with the sortNode if sorting is required.
 func (n *sortNode) wrap(plan planNode) planNode {
 	if n != nil {

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -119,3 +119,5 @@ func (n *explainTraceNode) Values() parser.DTuple {
 func (*explainTraceNode) DebugValues() debugValues {
 	panic("debug mode not implemented in explainTraceNode")
 }
+
+func (*explainTraceNode) SetLimitHint(_ int64) {}

--- a/sql/values.go
+++ b/sql/values.go
@@ -167,3 +167,5 @@ func (n *valuesNode) ExplainPlan() (name, description string, children []planNod
 		len(n.rows), pluralize(len(n.rows)))
 	return name, description, nil
 }
+
+func (*valuesNode) SetLimitHint(_ int64) {}


### PR DESCRIPTION
We plumb a "limit hint" down to the scanNode which will set a batch size in the
kvFetcher. The strategy here is to calculate the first batch according to the
limit in an optimistic fashion (assume any filters will pass), and if that is
not sufficient resume using the regular batch size for any subsequent batches.
Addresses #4299.

```
name                          old time/op  new time/op  delta
Scan1000Limit1_Cockroach-4    2.91ms ±43%  0.40ms ±33%  -86.23%  (p=0.000 n=10+10)
Scan1000Limit10_Cockroach-4   2.61ms ±11%  0.40ms ± 5%  -84.60%  (p=0.000 n=9+8)
Scan1000Limit100_Cockroach-4  2.87ms ±29%  0.73ms ± 7%  -74.52%  (p=0.000 n=9+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4778)

<!-- Reviewable:end -->
