### PR TITLE
sql: match postgres behavior in handling of errors on COMMIT

### DIFF
--- a/sql/driver/driver_test.go
+++ b/sql/driver/driver_test.go
@@ -499,8 +499,9 @@ func concurrentIncrements(db *sql.DB, t *testing.T) {
 // test for the KV layer. This Belt and Suspenders test is mostly
 // documentation and adds another layer of confidence that transactions
 // are serializable and performant even at the SQL layer.
+// TODO(andrei): move this test over to use pgwire. Also make it do retries
+// on retriable errors.
 func TestConcurrentIncrements(t *testing.T) {
-	t.Skipf("TODO(andrei): #4752")
 	defer leaktest.AfterTest(t)()
 	s, db := setup(t, time.Local)
 	defer cleanup(s, db)

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -774,11 +774,15 @@ func (e *Executor) execStmtsInCurrentTxn(
 		if checkStmtStringChange {
 			stmtStrBefore = stmt.String()
 		}
-		res, pErr, txnDone := e.execStmtInCurrentTransaction(
-			stmt, planMaker,
-			txnState.aborted, implicitTxn,
-			txnBeginning && (i == 0), /* firstInTxn */
-			stmtTimestamp)
+		var res Result
+		var pErr *roachpb.Error
+		if txnState.state() == abortedTransaction {
+			res, pErr = e.execStmtInAbortedTxn(stmt, txnState)
+		} else {
+			res, pErr = e.execStmtInOpenTxn(
+				stmt, planMaker, implicitTxn, txnBeginning && (i == 0), /* firstInTxn */
+				stmtTimestamp, txnState)
+		}
 		if checkStmtStringChange {
 			after := stmt.String()
 			if after != stmtStrBefore {
@@ -786,30 +790,49 @@ func (e *Executor) execStmtsInCurrentTxn(
 					stmtStrBefore, after))
 			}
 		}
+		results = append(results, res)
 		if pErr != nil {
-			results = append(results, Result{PErr: pErr})
-			txnState.aborted = true
+			// After an error happened, skip executing all the remaining statements
+			// in this batch.  This is Postgres behavior, and it makes sense as the
+			// protocol doesn't let you return results after an error.
 			return results, nil, pErr
 		}
-		results = append(results, res)
-		if txnDone {
+		if txnState.state() == noTransaction {
 			// If the transaction is done, return the remaining statements to
 			// be executed as a different group.
-			txnState.aborted = false
-			txnState.txn = nil
 			return results, stmts[i+1:], nil
 		}
 	}
+	// If we got here, we've managed to consume all statements and we're still in a txn.
 	return results, nil, nil
 }
 
-// execStmtInCurrentTransaction executes one statement in the context
+// execStmtInAbortedMode executes a statement in a txn that's in aborted mode.
+// Everything but COMMIT/ROLLBACK causes errors.
+func (e *Executor) execStmtInAbortedTxn(
+	stmt parser.Statement, txnState *txnState) (Result, *roachpb.Error) {
+	if txnState.state() != abortedTransaction {
+		panic("execStmtInAbortedTxn called outside of an aborted txn")
+	}
+	switch stmt.(type) {
+	case *parser.CommitTransaction, *parser.RollbackTransaction:
+		// Reset the state to allow new transactions to start.
+		// Note: postgres replies to COMMIT of failed txn with "ROLLBACK" too.
+		result := Result{PGTag: (*parser.RollbackTransaction)(nil).StatementTag()}
+		txnState.aborted = false
+		txnState.txn = nil
+		return result, nil
+	default:
+		pErr := roachpb.NewError(&roachpb.SqlTransactionAbortedError{})
+		return Result{PErr: pErr}, pErr
+	}
+}
+
+// execStmtInOpenTxn executes one statement in the context
 // of the planner's transaction (which is assumed to exist).
 // It handles statements that affect the transaction state (BEGIN, COMMIT)
 // and delegates everything else to `execStmt`.
 // It binds placeholders.
-// It also handles the Executor's "aborted mode", where it short-circuits execution if
-// the current transaction has been aborted.
 //
 // The current transaction might be committed/rolled back when this returns.
 //
@@ -827,29 +850,18 @@ func (e *Executor) execStmtsInCurrentTxn(
 //
 // Returns:
 // - a Result
-// - an error, if any
-// - a bool indicating whether the SQL txn is done (set) or not.
-func (e *Executor) execStmtInCurrentTransaction(
+// - an error, if any. In case of error, the result returned also reflects this error.
+func (e *Executor) execStmtInOpenTxn(
 	stmt parser.Statement, planMaker *planner,
-	abortedMode bool,
 	implicitTxn bool,
 	firstInTxn bool,
-	stmtTimestamp parser.DTimestamp) (Result, *roachpb.Error, bool) {
-	// Short-circuit if we're in aborted mode.
-	if abortedMode {
-		switch stmt.(type) {
-		case *parser.CommitTransaction, *parser.RollbackTransaction:
-			// Reset the state to allow new transactions to start.
-			// Note: postgres replies to COMMIT of failed txn with "ROLLBACK" too.
-			result := Result{PGTag: (*parser.RollbackTransaction)(nil).StatementTag()}
-			return result, nil, true
-		default:
-			return Result{}, roachpb.NewError(&roachpb.SqlTransactionAbortedError{}), false
-		}
+	stmtTimestamp parser.DTimestamp,
+	txnState *txnState) (Result, *roachpb.Error) {
+	if txnState.state() != openTransaction {
+		panic("execStmtInOpenTxn called outside of an open txn")
 	}
-
 	if planMaker.txn == nil {
-		panic("running execStmtInCurrentTransaction outside of a transaction")
+		panic("execStmtInOpenTxn called with the a txn not set on the planner")
 	}
 
 	planMaker.evalCtx.StmtTimestamp = stmtTimestamp
@@ -859,28 +871,38 @@ func (e *Executor) execStmtInCurrentTransaction(
 	switch stmt.(type) {
 	case *parser.BeginTransaction:
 		if !firstInTxn {
-			return Result{}, roachpb.NewError(errTransactionInProgress), false
+			txnState.aborted = true
+			pErr := roachpb.NewError(errTransactionInProgress)
+			return Result{PErr: pErr}, pErr
 		}
-	case *parser.CommitTransaction, *parser.RollbackTransaction:
+	case *parser.CommitTransaction, *parser.RollbackTransaction, *parser.SetTransaction:
 		if implicitTxn {
-			return Result{}, roachpb.NewError(errNoTransactionInProgress), false
-		}
-	case *parser.SetTransaction:
-		if implicitTxn {
-			return Result{}, roachpb.NewError(errNoTransactionInProgress), false
+			txnState.aborted = true
+			pErr := roachpb.NewError(errNoTransactionInProgress)
+			return Result{PErr: pErr}, pErr
 		}
 	}
 
 	// Bind all the placeholder variables in the stmt to actual values.
 	stmt, err := parser.FillArgs(stmt, &planMaker.params)
 	if err != nil {
-		return Result{}, roachpb.NewError(err), false
+		txnState.aborted = true
+		pErr := roachpb.NewError(err)
+		return Result{PErr: pErr}, pErr
 	}
 
 	result, pErr := e.execStmt(stmt, planMaker, time.Now(),
 		implicitTxn /* autoCommit */)
 	txnDone := planMaker.txn == nil
-	return result, pErr, txnDone
+	if pErr != nil {
+		result = Result{PErr: pErr}
+		txnState.aborted = true
+	}
+	if txnDone {
+		txnState.aborted = false
+		txnState.txn = nil
+	}
+	return result, pErr
 }
 
 // the current transaction might have been committed/rolled back when this returns.


### PR DESCRIPTION
The txn needs to not remain in the aborted state, as there's no way for the client to recover (e.g. in
Go you can't use a Txn object after doing Txn.Commit()). However, an
error is still returned to the client.

Statements in the same batch coming after a failed COMMIT are still not
executed; that's in line with the principle of not running any
statements after an error since we can't return results for them.

The change pushes the responsability of updating txnState down from
execStmtsInCurrentTxn() to execStmtInCurrentTxn(). The actual change in
behavior comes from setting txnState.aborted = false in the `txnDone`
case. Before the error would take precedence and txnState.aborted would
be set to true.

Fixes #4752 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4779)

<!-- Reviewable:end -->
