### PR TITLE
Fix and re-enable TestStoreRangeRebalance

### DIFF
--- a/storage/balancer.go
+++ b/storage/balancer.go
@@ -16,11 +16,7 @@
 
 package storage
 
-import (
-	"math/rand"
-
-	"github.com/cockroachdb/cockroach/roachpb"
-)
+import "github.com/cockroachdb/cockroach/roachpb"
 
 type nodeIDSet map[roachpb.NodeID]struct{}
 
@@ -55,7 +51,7 @@ type balancer interface {
 // rangeCountBalancer attempts to balance ranges across the cluster while
 // considering only the number of ranges being serviced each store.
 type rangeCountBalancer struct {
-	rand *rand.Rand
+	rand allocatorRand
 }
 
 func (rcb rangeCountBalancer) selectGood(sl StoreList, excluded nodeIDSet) *roachpb.StoreDescriptor {
@@ -112,7 +108,7 @@ func (rcb rangeCountBalancer) improve(store *roachpb.StoreDescriptor, sl StoreLi
 // usedCapacityBalancer attempts to balance ranges by considering the used
 // disk capacity of each store.
 type usedCapacityBalancer struct {
-	rand *rand.Rand
+	rand allocatorRand
 }
 
 func (ucb usedCapacityBalancer) selectGood(sl StoreList, excluded nodeIDSet) *roachpb.StoreDescriptor {
@@ -172,7 +168,7 @@ func (ucb usedCapacityBalancer) improve(store *roachpb.StoreDescriptor, sl Store
 // latter but using rangeCountBalancer on clusters with very low average disk
 // usage.
 type usageBalancer struct {
-	rand *rand.Rand
+	rand allocatorRand
 }
 
 func (db usageBalancer) selectGood(sl StoreList, excluded nodeIDSet) *roachpb.StoreDescriptor {
@@ -204,10 +200,12 @@ func (db usageBalancer) improve(store *roachpb.StoreDescriptor, sl StoreList, ex
 
 // selectRandom chooses up to count random store descriptors from the given
 // store list.
-func selectRandom(randGen *rand.Rand, count int, sl StoreList,
+func selectRandom(randGen allocatorRand, count int, sl StoreList,
 	excluded nodeIDSet) []*roachpb.StoreDescriptor {
 	var descs []*roachpb.StoreDescriptor
 	// Randomly permute available stores matching the required attributes.
+	randGen.Lock()
+	defer randGen.Unlock()
 	for _, idx := range randGen.Perm(len(sl.stores)) {
 		desc := sl.stores[idx]
 		// Skip if store is in excluded set.

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1163,7 +1163,6 @@ func TestStoreRangeRemoveDead(t *testing.T) {
 // rebalancing opportunities and add a new replica on another store.
 func TestStoreRangeRebalance(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skipf("TODO(pmattis): #4378, #3092")
 
 	// Start multiTestContext with replica rebalancing enabled.
 	mtc := &multiTestContext{


### PR DESCRIPTION
Fixes two issues with TestStoreRangeRebalance:
- A very rare race condition was occassionally causing TestStoreRangeRebalance
  to hang during shutdown (in `multiTestContext.Stop()`), evidently waiting for
  a raft command to be proposed while attempting to resolve intents.
  
  After discussion with @tamird and @tschottdorf, we are simply always proposing that particular raft command with a context that has a timeout; this was already the case in "handleSkippedIntents", but now all intent resolutions are best-effort and will cease after five seconds.
- A race condition was present involving the random source used by the
  rebalance queue's Allocator.
  
  This commit places the Allocator's random behind a mutex, preventing this race
  condition.

Fixes #3092
Fixes #4378

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4782)

<!-- Reviewable:end -->
