### PR TITLE
sql: add support for default zone config storage

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -494,6 +494,14 @@ range_max_bytes: 67108864
 
 	// Output:
 	// zone ls
+	// Object 0:
+	// replicas:
+	// - attrs: []
+	// range_min_bytes: 1048576
+	// range_max_bytes: 67108864
+	// gc:
+	//   ttlseconds: 86400
+	//
 	// zone set 100 replicas:
 	// - attrs: [us-east-1a,ssd]
 	// - attrs: [us-east-1b,ssd]
@@ -503,6 +511,14 @@ range_max_bytes: 67108864
 	//
 	// INSERT 1
 	// zone ls
+	// Object 0:
+	// replicas:
+	// - attrs: []
+	// range_min_bytes: 1048576
+	// range_max_bytes: 67108864
+	// gc:
+	//   ttlseconds: 86400
+	//
 	// Object 100:
 	// replicas:
 	// - attrs: [us-east-1a, ssd]
@@ -526,6 +542,14 @@ range_max_bytes: 67108864
 	// zone rm 100
 	// DELETE 1
 	// zone ls
+	// Object 0:
+	// replicas:
+	// - attrs: []
+	// range_min_bytes: 1048576
+	// range_max_bytes: 67108864
+	// gc:
+	//   ttlseconds: 86400
+	//
 }
 
 func Example_sql() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,7 @@ package config_test
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -233,6 +234,7 @@ func TestComputeSplits(t *testing.T) {
 	// Real SQL system with reserved non-system and user database.
 	allSql := append(schema.GetInitialValues(),
 		descriptor(start), descriptor(start+1), descriptor(start+5))
+	sort.Sort(roachpb.KeyValueByKey(allSql))
 
 	allUserSplits := []uint32{start, start + 1, start + 2, start + 3, start + 4, start + 5}
 	allReservedSplits := []uint32{reservedStart, reservedStart + 1, reservedStart + 2}

--- a/config/testutil.go
+++ b/config/testutil.go
@@ -86,5 +86,5 @@ func testingZoneConfigHook(_ SystemConfig, id uint32) (*ZoneConfig, error) {
 	if zone, ok := testingZoneConfig[id]; ok {
 		return zone, nil
 	}
-	return DefaultZoneConfig, nil
+	return &defaultZoneConfig, nil
 }

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -175,9 +175,9 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 func TestRangeSplitsWithWritePressure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Override default zone config.
-	previousMaxBytes := config.DefaultZoneConfig.RangeMaxBytes
-	config.DefaultZoneConfig.RangeMaxBytes = 1 << 18
-	defer func() { config.DefaultZoneConfig.RangeMaxBytes = previousMaxBytes }()
+	cfg := config.DefaultZoneConfig()
+	cfg.RangeMaxBytes = 1 << 18
+	defer config.TestingSetDefaultZoneConfig(cfg)()
 
 	s := createTestDB(t)
 	// This is purely to silence log spam.

--- a/server/store_spec.go
+++ b/server/store_spec.go
@@ -29,7 +29,7 @@ import (
 	"github.com/dustin/go-humanize"
 )
 
-var minimumStoreSize = 10 * uint64(config.DefaultZoneConfig.RangeMaxBytes)
+var minimumStoreSize = 10 * uint64(config.DefaultZoneConfig().RangeMaxBytes)
 
 // StoreSpec contains the details that can be specified in the cli pertaining
 // to the --store flag.

--- a/sql/config.go
+++ b/sql/config.go
@@ -16,7 +16,10 @@
 
 package sql
 
-import "github.com/cockroachdb/cockroach/config"
+import (
+	"github.com/cockroachdb/cockroach/config"
+	"github.com/cockroachdb/cockroach/keys"
+)
 
 func init() {
 	// TODO(marc): we use a hook to avoid a dependency on the sql package. We
@@ -50,7 +53,12 @@ func GetZoneConfig(cfg config.SystemConfig, id uint32) (*config.ZoneConfig, erro
 		}
 	}
 
-	// No descriptor or not a table. This table/db could have been deleted, just
-	// return the default config.
-	return config.DefaultZoneConfig, nil
+	// Retrieve the default zone config, but only as long as that wasn't the ID
+	// we were trying to retrieve (avoid infinite recursion).
+	if id != keys.RootNamespaceID {
+		return GetZoneConfig(cfg, keys.RootNamespaceID)
+	}
+
+	// No descriptor or not a table.
+	return nil, nil
 }

--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -70,7 +70,8 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	tbDesc := desc.GetTable()
 
 	// Add a zone config for both the table and database.
-	buf, err := proto.Marshal(config.DefaultZoneConfig)
+	cfg := config.DefaultZoneConfig()
+	buf, err := proto.Marshal(&cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +252,8 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	tableDesc := desc.GetTable()
 
 	// Add a zone config for the table.
-	buf, err := proto.Marshal(config.DefaultZoneConfig)
+	cfg := config.DefaultZoneConfig()
+	buf, err := proto.Marshal(&cfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/metadata.go
+++ b/sql/metadata.go
@@ -32,8 +32,9 @@ import (
 // installed on the underlying persistent storage before a cockroach store can
 // start running correctly, thus requiring this special initialization.
 type MetadataSchema struct {
-	descs  []metadataDescriptor
-	tables []metadataTable
+	descs   []metadataDescriptor
+	tables  []metadataTable
+	otherKV []roachpb.KeyValue
 }
 
 type metadataDescriptor struct {
@@ -130,6 +131,10 @@ func (ms MetadataSchema) GetInitialValues() []roachpb.KeyValue {
 		desc := createTableDescriptor(tbl.id, dbID, tbl.definition, tbl.privileges)
 		addDescriptor(dbID, &desc)
 	}
+
+	// Other key/value generation that doesn't fit into databases and
+	// tables. This can be used to add initial entries to a table.
+	ret = append(ret, ms.otherKV...)
 
 	// Sort returned key values; this is valuable because it matches the way the
 	// objects would be sorted if read from the engine.

--- a/sql/system_test.go
+++ b/sql/system_test.go
@@ -29,10 +29,14 @@ import (
 func TestInitialKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	const nonSystemDesc = 1
+	const keysPerDesc = 2
+	const nonDescKeys = 2
+
 	ms := sql.MakeMetadataSchema()
-	// IDGenerator + 2 for each system object in the default schema.
 	kv := ms.GetInitialValues()
-	if actual, expected := len(kv), 3+2*sql.NumSystemDescriptors; actual != expected {
+	expected := nonDescKeys + keysPerDesc*(nonSystemDesc+sql.NumSystemDescriptors)
+	if actual := len(kv); actual != expected {
 		t.Fatalf("Wrong number of initial sql kv pairs: %d, wanted %d", actual, expected)
 	}
 
@@ -41,8 +45,8 @@ func TestInitialKeys(t *testing.T) {
 		"CREATE TABLE testdb.x (val INTEGER PRIMARY KEY)",
 		privilege.List{privilege.ALL})
 	kv = ms.GetInitialValues()
-	// IDGenerator + 2 for each descriptor in the schema.
-	if actual, expected := len(kv), 1+2*ms.DescriptorCount(); actual != expected {
+	expected = nonDescKeys + keysPerDesc*ms.DescriptorCount()
+	if actual := len(kv); actual != expected {
 		t.Fatalf("Wrong number of initial sql kv pairs: %d, wanted %d", actual, expected)
 	}
 

--- a/sql/update.go
+++ b/sql/update.go
@@ -321,6 +321,11 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 		return nil, pErr
 	}
 
+	if isSystemConfigID(tableDesc.GetID()) {
+		// Mark transaction as operating on the system DB.
+		p.txn.SetSystemConfigTrigger()
+	}
+
 	if autoCommit {
 		// An auto-txn can commit the transaction with the batch. This is an
 		// optimization to avoid an extra round-trip to the transaction

--- a/storage/simulation/range.go
+++ b/storage/simulation/range.go
@@ -50,7 +50,7 @@ func newRange(rangeID roachpb.RangeID, allocator storage.Allocator) *Range {
 		desc: roachpb.RangeDescriptor{
 			RangeID: rangeID,
 		},
-		zone:      *config.DefaultZoneConfig,
+		zone:      config.DefaultZoneConfig(),
 		replicas:  make(map[roachpb.StoreID]replica),
 		allocator: allocator,
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -835,11 +835,11 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 		expMaxBytes int64
 	}{
 		{store.LookupReplica(roachpb.RKeyMin, nil),
-			config.DefaultZoneConfig.RangeMaxBytes},
+			config.DefaultZoneConfig().RangeMaxBytes},
 		{splitTestRange(store, roachpb.RKeyMin, keys.MakeTablePrefix(baseID), t),
 			1 << 20},
 		{splitTestRange(store, keys.MakeTablePrefix(baseID), keys.MakeTablePrefix(baseID+1), t),
-			config.DefaultZoneConfig.RangeMaxBytes},
+			config.DefaultZoneConfig().RangeMaxBytes},
 		{splitTestRange(store, keys.MakeTablePrefix(baseID+1), keys.MakeTablePrefix(baseID+2), t),
 			2 << 20},
 	}


### PR DESCRIPTION
A default zone config for all tables and ranges that do not have an
explicit zone config is now stored under object ID 0. This default is
initialized during bootstrap. And can be updated using the normal
command line zone operations.

Changed config.DefaultZoneConfig from a variable to a function. Added
config.TestingSetDefaultZoneConfig to ease changing the default zone
config during testing. It would be nice if the default zone config could
be specified during cluster creation (i.e. for tests), but there is no
easy way to plumb that down through the various levels of
initialization.

Fixes #4353.
Fixes #2506.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4783)

<!-- Reviewable:end -->
