### PR TITLE
Add support for chaining of TestingCommandFilter's.

### DIFF
--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/server"
-	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
@@ -473,20 +472,19 @@ func TestPropagateTxnOnError(t *testing.T) {
 	// get a ReadWithinUncertaintyIntervalError.
 	targetKey := roachpb.Key("b")
 	var numGets int32
-	storage.TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
-		if _, ok := args.(*roachpb.ConditionalPutRequest); ok && args.Header().Key.Equal(targetKey) {
-			if atomic.AddInt32(&numGets, 1) == 1 {
-				return roachpb.NewReadWithinUncertaintyIntervalError(roachpb.ZeroTimestamp, roachpb.ZeroTimestamp)
 
+	ctx := server.NewTestContext()
+	ctx.TestingMocker.StoreTestingMocker.TestingCommandFilter =
+		func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
+			if _, ok := args.(*roachpb.ConditionalPutRequest); ok && args.Header().Key.Equal(targetKey) {
+				if atomic.AddInt32(&numGets, 1) == 1 {
+					return roachpb.NewReadWithinUncertaintyIntervalError(
+						roachpb.ZeroTimestamp, roachpb.ZeroTimestamp)
+				}
 			}
+			return nil
 		}
-		return nil
-	}
-	defer func() {
-		storage.TestingCommandFilter = nil
-	}()
-
-	s := server.StartTestServer(t)
+	s := server.StartTestServerWithContext(t, ctx)
 	defer s.Stop()
 	db := setupMultipleRanges(t, s, "b")
 

--- a/server/context.go
+++ b/server/context.go
@@ -122,6 +122,14 @@ type Context struct {
 	// TimeUntilStoreDead is the time after which if there is no new gossiped
 	// information about a store, it is considered dead.
 	TimeUntilStoreDead time.Duration
+
+	TestingMocker TestingMocker
+}
+
+// TestingMocker is a struct containing facilities for mocking
+// or otherwise controlling various parts of the system.
+type TestingMocker struct {
+	StoreTestingMocker storage.StoreTestingMocker
 }
 
 // GetTotalMemory returns either the total system memory or if possible the

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -69,31 +68,33 @@ func TestIntentResolution(t *testing.T) {
 
 	splitKey := []byte("s")
 	results := map[string]struct{}{}
-	defer func() { storage.TestingCommandFilter = nil }()
 	for i, tc := range testCases {
 		var mu sync.Mutex
 		closer := make(chan struct{}, 2)
-		storage.TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
-			mu.Lock()
-			defer mu.Unlock()
-			header := args.Header()
-			// Ignore anything outside of the intent key range of "a" - "z"
-			if header.Key.Compare(roachpb.Key("a")) < 0 || header.Key.Compare(roachpb.Key("z")) > 0 {
+
+		ctx := NewTestContext()
+		ctx.TestingMocker.StoreTestingMocker.TestingCommandFilter =
+			func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
+				mu.Lock()
+				defer mu.Unlock()
+				header := args.Header()
+				// Ignore anything outside of the intent key range of "a" - "z"
+				if header.Key.Compare(roachpb.Key("a")) < 0 || header.Key.Compare(roachpb.Key("z")) > 0 {
+					return nil
+				}
+				switch args.(type) {
+				case *roachpb.ResolveIntentRequest:
+					results[string(header.Key)] = struct{}{}
+				case *roachpb.ResolveIntentRangeRequest:
+					results[fmt.Sprintf("%s-%s", header.Key, header.EndKey)] = struct{}{}
+				}
+				if len(results) == len(tc.exp) {
+					closer <- struct{}{}
+				}
 				return nil
 			}
-			switch args.(type) {
-			case *roachpb.ResolveIntentRequest:
-				results[string(header.Key)] = struct{}{}
-			case *roachpb.ResolveIntentRangeRequest:
-				results[fmt.Sprintf("%s-%s", header.Key, header.EndKey)] = struct{}{}
-			}
-			if len(results) == len(tc.exp) {
-				closer <- struct{}{}
-			}
-			return nil
-		}
 		func() {
-			s := StartTestServer(t)
+			s := StartTestServerWithContext(t, ctx)
 			defer s.Stop()
 
 			go func() {

--- a/server/server.go
+++ b/server/server.go
@@ -188,6 +188,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 			AllowRebalance: true,
 			Mode:           s.ctx.BalanceMode,
 		},
+		TestingMocker: ctx.TestingMocker.StoreTestingMocker,
 	}
 
 	s.recorder = status.NewMetricsRecorder(s.clock)

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -50,9 +50,10 @@ const (
 	initialSplitsTimeout = 10 * time.Second
 )
 
-// StartTestServer starts a in-memory test server.
-func StartTestServer(t util.Tester) *TestServer {
-	s := &TestServer{}
+// StartTestServerWithContext starts an in-memory test server.
+// ctx can be nil, in which case a default context will be created.
+func StartTestServerWithContext(t util.Tester, ctx *Context) *TestServer {
+	s := &TestServer{Ctx: ctx}
 	if err := s.Start(); err != nil {
 		if t != nil {
 			t.Fatalf("Could not start server: %v", err)
@@ -61,6 +62,11 @@ func StartTestServer(t util.Tester) *TestServer {
 		}
 	}
 	return s
+}
+
+// StartTestServer starts an in-memory test server.
+func StartTestServer(t util.Tester) *TestServer {
+	return StartTestServerWithContext(t, nil)
 }
 
 // StartTestServerJoining starts an in-memory test server that attempts to join `other`.

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -92,7 +92,7 @@ func setupTestServer(t *testing.T) *testServer {
 func setupTestServerWithContext(t *testing.T, ctx *server.Context) *testServer {
 	storage.GetTestingCommandFilters().AppendFilter(checkEndTransactionTrigger)
 	s := &testServer{TestServer: server.TestServer{Ctx: ctx}}
-	s.cleanupFns = append(s.cleanupFns, func() { storage.GetTestingCommandFilters().Reset() })
+	s.cleanupFns = append(s.cleanupFns, storage.GetTestingCommandFilters().Reset)
 	if err := s.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -19,6 +19,8 @@ package sql_test
 import (
 	"bytes"
 	"database/sql"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -34,6 +36,66 @@ import (
 
 func init() {
 	security.SetReadFileFn(securitytest.Asset)
+}
+
+// CommandFilters provides facilities for registering "TestingCommandFilters"
+// (i.e. functions to be run on every replica command).
+// CommandFilters is thread-safe.
+type CommandFilters struct {
+	sync.RWMutex
+	filters []struct {
+		id     int
+		filter storage.CommandFilter
+	}
+	nextID int
+}
+
+// runFilters executes the registered filters, stopping at the first one
+// that returns an error.
+func (c *CommandFilters) runFilters(
+	sid roachpb.StoreID, req roachpb.Request, hdr roachpb.Header) error {
+
+	c.RLock()
+	defer c.RUnlock()
+	for _, f := range c.filters {
+		if err := f.filter(sid, req, hdr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AppendFilter registers a filter function to run after all the previously
+// registered filters.
+// Returns a closure that the client must run for doing cleanup when the
+// filter should be deregistered.
+func (c *CommandFilters) AppendFilter(filter storage.CommandFilter) func() {
+	c.Lock()
+	defer c.Unlock()
+	id := c.nextID
+	c.nextID++
+	c.filters = append(c.filters, struct {
+		id     int
+		filter storage.CommandFilter
+	}{id, filter})
+
+	return func() {
+		c.removeFilter(id)
+	}
+}
+
+// removeFilter removes a filter previously registered. Meant to be used as the
+// closure returned by AppendFilter.
+func (c *CommandFilters) removeFilter(id int) {
+	c.Lock()
+	defer c.Unlock()
+	for i, f := range c.filters {
+		if f.id == id {
+			c.filters = append(c.filters[:i], c.filters[i+1:]...)
+			return
+		}
+	}
+	panic(fmt.Sprintf("failed to find filter with id: %d.", id))
 }
 
 //go:generate ../util/leaktest/add-leaktest.sh *_test.go
@@ -86,13 +148,21 @@ type testServer struct {
 }
 
 func setupTestServer(t *testing.T) *testServer {
-	return setupTestServerWithContext(t, server.NewTestContext())
+	ctx, _ := createTestServerContext()
+	return setupTestServerWithContext(t, ctx)
 }
 
+func createTestServerContext() (*server.Context, *CommandFilters) {
+	ctx := server.NewTestContext()
+	var cmdFilters CommandFilters
+	cmdFilters.AppendFilter(checkEndTransactionTrigger)
+	ctx.TestingMocker.StoreTestingMocker.TestingCommandFilter = cmdFilters.runFilters
+	return ctx, &cmdFilters
+}
+
+// The context used should probably come from createTestServerContext.
 func setupTestServerWithContext(t *testing.T, ctx *server.Context) *testServer {
-	storage.GetTestingCommandFilters().AppendFilter(checkEndTransactionTrigger)
 	s := &testServer{TestServer: server.TestServer{Ctx: ctx}}
-	s.cleanupFns = append(s.cleanupFns, storage.GetTestingCommandFilters().Reset)
 	if err := s.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +174,7 @@ func setup(t *testing.T) (*testServer, *sql.DB, *client.DB) {
 }
 
 func setupWithContext(t *testing.T, ctx *server.Context) (*testServer, *sql.DB, *client.DB) {
-	s := setupTestServer(t)
+	s := setupTestServerWithContext(t, ctx)
 
 	// SQL requests use security.RootUser which has ALL permissions on everything.
 	url, cleanupFn := sqlutils.PGUrl(t, &s.TestServer, security.RootUser, "setupWithContext")

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -74,7 +74,7 @@ func TestPGWire(t *testing.T) {
 	tempKeyPath := securitytest.RestrictedCopy(t, keyPath, tempDir, "key")
 
 	for _, insecure := range [...]bool{true, false} {
-		ctx := server.NewTestContext()
+		ctx, _ := createTestServerContext()
 		ctx.Insecure = insecure
 		s := setupTestServerWithContext(t, ctx)
 

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -19,25 +19,34 @@ package sql_test
 import (
 	"bytes"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	_ "github.com/cockroachdb/pq"
 )
 
+type filterVals struct {
+	sync.Mutex
+	vals          []string
+	restartCounts map[string]int
+}
+
 func injectRetriableErrors(
 	_ roachpb.StoreID, req roachpb.Request, hdr roachpb.Header,
-	magicVals []string, restarts map[string]int) error {
+	magicVals *filterVals) error {
+	magicVals.Lock()
+	defer magicVals.Unlock()
 	cput, ok := req.(*roachpb.ConditionalPutRequest)
 	if !ok {
 		return nil
 	}
-	for _, val := range magicVals {
-		if restarts[val] < 2 && bytes.Contains(cput.Value.RawBytes, []byte(val)) {
-			restarts[val]++
-			return roachpb.NewReadWithinUncertaintyIntervalError(roachpb.ZeroTimestamp, roachpb.ZeroTimestamp)
+	for _, val := range magicVals.vals {
+		if magicVals.restartCounts[val] < 2 && bytes.Contains(cput.Value.RawBytes, []byte(val)) {
+			magicVals.restartCounts[val]++
+			return roachpb.NewReadWithinUncertaintyIntervalError(
+				roachpb.ZeroTimestamp, roachpb.ZeroTimestamp)
 		}
 	}
 	return nil
@@ -48,16 +57,8 @@ func injectRetriableErrors(
 func TestTxnRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// Set up error injection that causes retries, to be used later in the test.
-	// This needs to be set up before the server is started.
-	restarts := make(map[string]int)
-	magicVals := []string{"boulanger", "dromedary", "fajita", "hooly", "josephine", "laureal"}
-	cleanupFilter := storage.GetTestingCommandFilters().AppendFilter(
-		func(sid roachpb.StoreID, req roachpb.Request, hdr roachpb.Header) error {
-			return injectRetriableErrors(sid, req, hdr, magicVals, restarts)
-		})
-
-	server, sqlDB, _ := setup(t)
+	ctx, cmdFilters := createTestServerContext()
+	server, sqlDB, _ := setupWithContext(t, ctx)
 	defer cleanup(server, sqlDB)
 
 	// Make sure all the commands we send in this test are sent over the same connection.
@@ -70,16 +71,26 @@ func TestTxnRestart(t *testing.T) {
 	// do that.
 	sqlDB.SetMaxOpenConns(1)
 
-	if _, err := sqlDB.Exec(`
+	// Set up error injection that causes retries.
+	magicVals := &filterVals{
+		restartCounts: make(map[string]int),
+		vals:          []string{"boulanger", "dromedary", "fajita", "hooly", "josephine", "laureal"},
+	}
+	cleanupFilter := cmdFilters.AppendFilter(
+		func(sid roachpb.StoreID, req roachpb.Request, hdr roachpb.Header) error {
+			return injectRetriableErrors(sid, req, hdr, magicVals)
+		})
+	func() {
+		if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
 CREATE TABLE t.test (k CHAR PRIMARY KEY, v TEXT);
 `); err != nil {
-		t.Fatal(err)
-	}
+			t.Fatal(err)
+		}
 
-	// Test that implicit txns - txns for which we see all the statements and prefixes
-	// of txns (statements batched together with the BEGIN stmt) - are retried.
-	if _, err := sqlDB.Exec(`
+		// Test that implicit txns - txns for which we see all the statements and prefixes
+		// of txns (statements batched together with the BEGIN stmt) - are retried.
+		if _, err := sqlDB.Exec(`
 INSERT INTO t.test (k, v) VALUES ('a', 'boulanger');
 BEGIN;
 INSERT INTO t.test (k, v) VALUES ('c', 'dromedary');
@@ -90,26 +101,29 @@ BEGIN;
 INSERT INTO t.test (k, v) VALUES ('i', 'josephine');
 INSERT INTO t.test (k, v) VALUES ('k', 'laureal');
 `); err != nil {
-		t.Fatal(err)
-	}
+			t.Fatal(err)
+		}
+	}()
 
 	cleanupFilter()
 
-	for _, val := range magicVals {
-		if restarts[val] != 2 {
+	for _, val := range magicVals.vals {
+		if magicVals.restartCounts[val] != 2 {
 			t.Errorf("INSERT for %s has been retried %d times, instead of 2",
-				val, restarts[val])
+				val, magicVals.restartCounts[val])
 		}
 	}
 
 	// Now test that we don't retry what we shouldn't: insert an error into a txn
 	// we can't automatically retry (because it spans requests).
 
-	magicVals = []string{"hooly"}
-	restarts = make(map[string]int)
-	cleanupFilter = storage.GetTestingCommandFilters().AppendFilter(
+	magicVals = &filterVals{
+		vals:          []string{"hooly"},
+		restartCounts: make(map[string]int),
+	}
+	cleanupFilter = cmdFilters.AppendFilter(
 		func(sid roachpb.StoreID, req roachpb.Request, hdr roachpb.Header) error {
-			return injectRetriableErrors(sid, req, hdr, magicVals, restarts)
+			return injectRetriableErrors(sid, req, hdr, magicVals)
 		})
 	defer cleanupFilter()
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -79,11 +79,18 @@ func rg1(s *storage.Store) client.Sender {
 // createTestStore creates a test store using an in-memory
 // engine. The caller is responsible for stopping the stopper on exit.
 func createTestStore(t testing.TB) (*storage.Store, *stop.Stopper) {
+	sCtx := storage.TestStoreContext()
+	return createTestStoreWithContext(t, &sCtx)
+}
+
+func createTestStoreWithContext(t testing.TB, sCtx *storage.StoreContext) (
+	*storage.Store, *stop.Stopper) {
+
 	stopper := stop.NewStopper()
 	store := createTestStoreWithEngine(t,
 		engine.NewInMem(roachpb.Attributes{}, 10<<20, stopper),
 		hlc.NewClock(hlc.NewManualClock(0).UnixNano),
-		true, nil, stopper)
+		true, sCtx, stopper)
 	return store, stopper
 }
 

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -77,108 +77,12 @@ const (
 	opReplica = "replica"
 )
 
-// CommandFilter is the type of function to use with CommandFilters.
+// CommandFilter may be used in tests through the StorageTestingMocker to
+// intercept the handling of commands and artificially generate errors. Return
+// nil to continue with regular processing or non-nil to terminate processing
+// with the returned error. Note that in a multi-replica test this filter will
+// be run once for each replica and must produce consistent results each time.
 type CommandFilter func(roachpb.StoreID, roachpb.Request, roachpb.Header) error
-
-// TestingCommandFilter may be set in tests to intercept the handling
-// of commands and artificially generate errors. Return nil to continue
-// with regular processing or non-nil to terminate processing with the
-// returned error. Note that in a multi-replica test this filter will
-// be run once for each replica and must produce consistent results
-// each time.
-//
-// DEPRECATED: writing to this directly is deprecated. Use CommandFilters
-// for registering filter functions.
-var TestingCommandFilter CommandFilter
-
-// CommandFilters provides facilities for registering "TestingCommandFilters"
-// (i.e. functions to be run on every replica command).
-// This should be used as a singleton, through GetTestingCommandFilters().
-// CommandFilters is thread-safe.
-type CommandFilters struct {
-	sync.RWMutex
-	filters []struct {
-		id     int
-		filter CommandFilter
-	}
-	nextID int
-}
-
-// Singleton CommandFilters.
-var commandFiltersSingleton CommandFilters
-var commandFilterInit sync.Once
-
-// GetTestingCommandFilters returns a CommandFilters singleton.
-//
-// Note that this overrides TestingCommandFilters, so it shouldn't be
-// used with modules that write TestingCommandFilter directly.
-// Also note that, in order to avoid data races, this should be called for the
-// first time before executing any KV commands, since Replica reads
-// TestingCommandFilter unsynchronized. Before server startup would be a good
-// time to call this.  But once you've ensured this is called once before the
-// server starts, subsequent calls can be done at any time as they no longer
-// race with anyone.
-func GetTestingCommandFilters() *CommandFilters {
-	commandFilterInit.Do(func() {
-		TestingCommandFilter = commandFiltersSingleton.runFilters
-	})
-	return &commandFiltersSingleton
-}
-
-// runFilters executes the registered filters, stopping at the first one
-// that returns an error.
-func (c *CommandFilters) runFilters(
-	sid roachpb.StoreID, req roachpb.Request, hdr roachpb.Header) error {
-
-	c.RLock()
-	defer c.RUnlock()
-	for _, f := range c.filters {
-		if err := f.filter(sid, req, hdr); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// AppendFilter registers a filter function to run after all the previously
-// registered filters.
-// Returns a closure that the client must run for doing cleanup when the
-// filter should be deregistered.
-func (c *CommandFilters) AppendFilter(filter CommandFilter) func() {
-	c.Lock()
-	defer c.Unlock()
-	id := c.nextID
-	c.nextID++
-	c.filters = append(c.filters, struct {
-		id     int
-		filter CommandFilter
-	}{id, filter})
-
-	return func() {
-		c.removeFilter(id)
-	}
-}
-
-// removeFilter removes a filter previously registered. Meant to be used as the
-// closure returned by AppendFilter.
-func (c *CommandFilters) removeFilter(id int) {
-	c.Lock()
-	defer c.Unlock()
-	for i, f := range c.filters {
-		if f.id == id {
-			c.filters = append(c.filters[:i], c.filters[i+1:]...)
-			return
-		}
-	}
-	panic(fmt.Sprintf("failed to find filter with id: %d. Maybe someone called Reset()?", id))
-}
-
-// Reset deregisters all the filters.
-func (c *CommandFilters) Reset() {
-	c.Lock()
-	defer c.Unlock()
-	c.filters = c.filters[:0]
-}
 
 // This flag controls whether Transaction entries are automatically gc'ed
 // upon EndTransaction if they only have local intents (which can be

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -55,8 +55,9 @@ func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, h roachp
 	}
 
 	// If a unittest filter was installed, check for an injected error; otherwise, continue.
-	if TestingCommandFilter != nil {
-		if err := TestingCommandFilter(r.store.StoreID(), args, h); err != nil {
+	if filter := r.store.ctx.TestingMocker.TestingCommandFilter; filter != nil {
+		err := filter(r.store.StoreID(), args, h)
+		if err != nil {
 			pErr := roachpb.NewErrorWithTxn(err, h.Txn)
 			log.Infof("test injecting error: %s", pErr)
 			return nil, nil, pErr

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -99,9 +99,16 @@ type testContext struct {
 	feed          *util.Feed
 }
 
-// testContext.Start initializes the test context with a single range covering the
+// Start initializes the test context with a single range covering the
 // entire keyspace.
 func (tc *testContext) Start(t testing.TB) {
+	ctx := TestStoreContext()
+	tc.StartWithStoreContext(t, ctx)
+}
+
+// StartWithStoreContext initializes the test context with a single
+// range covering the entire keyspace.
+func (tc *testContext) StartWithStoreContext(t testing.TB, ctx StoreContext) {
 	if tc.stopper == nil {
 		tc.stopper = stop.NewStopper()
 	}
@@ -126,7 +133,6 @@ func (tc *testContext) Start(t testing.TB) {
 	}
 
 	if tc.store == nil {
-		ctx := TestStoreContext()
 		ctx.Clock = tc.clock
 		ctx.Gossip = tc.gossip
 		ctx.Transport = tc.transport
@@ -1172,17 +1178,18 @@ func TestRangeCommandQueue(t *testing.T) {
 	// Intercept commands with matching command IDs and block them.
 	blockingStart := make(chan struct{})
 	blockingDone := make(chan struct{})
-	defer func() { TestingCommandFilter = nil }()
-	TestingCommandFilter = func(_ roachpb.StoreID, _ roachpb.Request, h roachpb.Header) error {
-		if h.UserPriority == 42 {
-			blockingStart <- struct{}{}
-			<-blockingDone
-		}
-		return nil
-	}
 
 	tc := testContext{}
-	tc.Start(t)
+	tsc := TestStoreContext()
+	tsc.TestingMocker.TestingCommandFilter =
+		func(_ roachpb.StoreID, _ roachpb.Request, h roachpb.Header) error {
+			if h.UserPriority == 42 {
+				blockingStart <- struct{}{}
+				<-blockingDone
+			}
+			return nil
+		}
+	tc.StartWithStoreContext(t, tsc)
 	defer tc.Stop()
 
 	defer close(blockingDone) // make sure teardown can happen
@@ -1285,32 +1292,33 @@ func TestRangeCommandQueue(t *testing.T) {
 // not wait for pending commands to complete through Raft.
 func TestRangeCommandQueueInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer func() { TestingCommandFilter = nil }()
 	key := roachpb.Key("key1")
 	blockingStart := make(chan struct{}, 1)
 	blockingDone := make(chan struct{})
-	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
-		if put, ok := args.(*roachpb.PutRequest); ok {
-			putBytes, err := put.Value.GetBytes()
-			if err != nil {
-				return err
-			}
-			if bytes.Equal(put.Key, key) && bytes.Equal(putBytes, []byte{1}) {
-				// Absence of replay protection can mean that we end up here
-				// more often than we expect, hence the select (#3669).
-				select {
-				case blockingStart <- struct{}{}:
-				default:
-				}
-				<-blockingDone
-			}
-		}
-
-		return nil
-	}
 
 	tc := testContext{}
-	tc.Start(t)
+	tsc := TestStoreContext()
+	tsc.TestingMocker.TestingCommandFilter =
+		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
+			if put, ok := args.(*roachpb.PutRequest); ok {
+				putBytes, err := put.Value.GetBytes()
+				if err != nil {
+					return err
+				}
+				if bytes.Equal(put.Key, key) && bytes.Equal(putBytes, []byte{1}) {
+					// Absence of replay protection can mean that we end up here
+					// more often than we expect, hence the select (#3669).
+					select {
+					case blockingStart <- struct{}{}:
+					default:
+					}
+					<-blockingDone
+				}
+			}
+
+			return nil
+		}
+	tc.StartWithStoreContext(t, tsc)
 	defer tc.Stop()
 	cmd1Done := make(chan struct{})
 	go func() {
@@ -2025,16 +2033,17 @@ func TestEndTransactionWithErrors(t *testing.T) {
 func TestEndTransactionLocalGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer setTxnAutoGC(true)()
-	defer func() { TestingCommandFilter = nil }()
-	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
-		// Make sure the direct GC path doesn't interfere with this test.
-		if args.Method() == roachpb.GC {
-			return util.Errorf("boom")
-		}
-		return nil
-	}
 	tc := testContext{}
-	tc.Start(t)
+	tsc := TestStoreContext()
+	tsc.TestingMocker.TestingCommandFilter =
+		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
+			// Make sure the direct GC path doesn't interfere with this test.
+			if args.Method() == roachpb.GC {
+				return util.Errorf("boom")
+			}
+			return nil
+		}
+	tc.StartWithStoreContext(t, tsc)
 	defer tc.Stop()
 
 	splitKey := roachpb.RKey("c")
@@ -2118,16 +2127,18 @@ func setupResolutionTest(t *testing.T, tc testContext, key roachpb.Key, splitKey
 func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}
+	tsc := TestStoreContext()
 	key := roachpb.Key("a")
 	splitKey := roachpb.RKey(key).Next()
-	defer func() { TestingCommandFilter = nil }()
-	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
-		if args.Method() == roachpb.ResolveIntentRange && args.Header().Key.Equal(splitKey.AsRawKey()) {
-			return util.Errorf("boom")
+	tsc.TestingMocker.TestingCommandFilter =
+		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
+			if args.Method() == roachpb.ResolveIntentRange && args.Header().Key.Equal(splitKey.AsRawKey()) {
+				return util.Errorf("boom")
+			}
+			return nil
 		}
-		return nil
-	}
-	tc.Start(t)
+
+	tc.StartWithStoreContext(t, tsc)
 	defer tc.Stop()
 
 	newRng, txn := setupResolutionTest(t, tc, key, splitKey)
@@ -2197,17 +2208,18 @@ func TestEndTransactionDirectGCFailure(t *testing.T) {
 	key := roachpb.Key("a")
 	splitKey := roachpb.RKey(key).Next()
 	var count int64
-	defer func() { TestingCommandFilter = nil }()
-	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
-		if args.Method() == roachpb.ResolveIntentRange && args.Header().Key.Equal(splitKey.AsRawKey()) {
-			atomic.AddInt64(&count, 1)
-			return util.Errorf("boom")
-		} else if args.Method() == roachpb.GC {
-			t.Fatalf("unexpected GCRequest: %+v", args)
+	tsc := TestStoreContext()
+	tsc.TestingMocker.TestingCommandFilter =
+		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
+			if args.Method() == roachpb.ResolveIntentRange && args.Header().Key.Equal(splitKey.AsRawKey()) {
+				atomic.AddInt64(&count, 1)
+				return util.Errorf("boom")
+			} else if args.Method() == roachpb.GC {
+				t.Fatalf("unexpected GCRequest: %+v", args)
+			}
+			return nil
 		}
-		return nil
-	}
-	tc.Start(t)
+	tc.StartWithStoreContext(t, tsc)
 	defer tc.Stop()
 
 	setupResolutionTest(t, tc, key, splitKey)
@@ -2263,18 +2275,19 @@ func TestEndTransactionDirectGC_1PC(t *testing.T) {
 
 func TestReplicaResolveIntentNoWait(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer func() { TestingCommandFilter = nil }()
 	var seen int32
 	key := roachpb.Key("zresolveme")
-	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
-		if args.Method() == roachpb.ResolveIntent && args.Header().Key.Equal(key) {
-			atomic.StoreInt32(&seen, 1)
+	tsc := TestStoreContext()
+	tsc.TestingMocker.TestingCommandFilter =
+		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
+			if args.Method() == roachpb.ResolveIntent && args.Header().Key.Equal(key) {
+				atomic.StoreInt32(&seen, 1)
+			}
+			return nil
 		}
-		return nil
-	}
 
 	tc := testContext{}
-	tc.Start(t)
+	tc.StartWithStoreContext(t, tsc)
 	defer tc.Stop()
 	splitKey := roachpb.RKey("aa")
 	setupResolutionTest(t, tc, roachpb.Key("a") /* irrelevant */, splitKey)
@@ -3177,16 +3190,17 @@ func TestAppliedIndex(t *testing.T) {
 func TestReplicaCorruption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	defer func() { TestingCommandFilter = nil }()
-	TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
-		if args.Header().Key.Equal(roachpb.Key("boom")) {
-			return newReplicaCorruptionError()
+	tsc := TestStoreContext()
+	tsc.TestingMocker.TestingCommandFilter =
+		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
+			if args.Header().Key.Equal(roachpb.Key("boom")) {
+				return newReplicaCorruptionError()
+			}
+			return nil
 		}
-		return nil
-	}
 
 	tc := testContext{}
-	tc.Start(t)
+	tc.StartWithStoreContext(t, tsc)
 	defer tc.Stop()
 
 	// First send a regular command.
@@ -4055,19 +4069,20 @@ func TestReplicaCancelRaft(t *testing.T) {
 			// Pick a key unlikely to be used by background processes.
 			key := []byte("acdfg")
 			ctx, cancel := context.WithCancel(context.Background())
+			tsc := TestStoreContext()
 			if !cancelEarly {
-				defer func() { TestingCommandFilter = nil }()
-				TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
-					if !args.Header().Key.Equal(key) {
+				tsc.TestingMocker.TestingCommandFilter =
+					func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
+						if !args.Header().Key.Equal(key) {
+							return nil
+						}
+						cancel()
 						return nil
 					}
-					cancel()
-					return nil
-				}
 
 			}
 			tc := testContext{}
-			tc.Start(t)
+			tc.StartWithStoreContext(t, tsc)
 			defer tc.Stop()
 			if cancelEarly {
 				cancel()

--- a/storage/store.go
+++ b/storage/store.go
@@ -361,6 +361,14 @@ type StoreContext struct {
 	// If LogRangeEvents is true, major changes to ranges will be logged into
 	// the range event log.
 	LogRangeEvents bool
+
+	TestingMocker StoreTestingMocker
+}
+
+// StoreTestingMocker is a part of the context used to control parts of the system.
+type StoreTestingMocker struct {
+	// A callback to be called when executing every replica command.
+	TestingCommandFilter CommandFilter
 }
 
 type storeMetrics struct {


### PR DESCRIPTION
This is useful for SQL tests which add one filter by default.

This also eliminates a race in TestTxnRestarts.

Fixes #4757, #4753

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4785)

<!-- Reviewable:end -->
