### PR TITLE
storage: Trim overlapping timestamp intervals in TimestampCache

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -110,7 +110,7 @@ func (tm *txnMetadata) addKeyRange(start, end roachpb.Key) {
 		if o.Key.Contains(key) {
 			return
 		} else if key.Contains(*o.Key) {
-			tm.keys.Del(o.Key)
+			tm.keys.DelEntry(o.Entry)
 		}
 	}
 

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -152,7 +152,6 @@ func (tc *TimestampCache) Add(start, end roachpb.Key, timestamp roachpb.Timestam
 					// Old: ------------
 					//
 					// New: ------------
-					// Res: ------------ (new)
 					*cv = cacheValue{timestamp: timestamp, txnID: txnID}
 					cache.MoveToEnd(o.Entry)
 					return
@@ -163,9 +162,7 @@ func (tc *TimestampCache) Add(start, end roachpb.Key, timestamp roachpb.Timestam
 					// Old:   --------
 					//
 					// Old:
-					// TODO(nvanbenschoten) Avoid internal lookup of overlapping entry on deletion
-					// by adding a cache.DelEntry method and including the entry in a cache.Overlap.
-					cache.Del(o.Key)
+					cache.DelEntry(o.Entry)
 				case sCmp > 0 && eCmp < 0:
 					// Old contains new; split up old into two.
 					//

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -17,11 +17,13 @@
 package storage
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/cache"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/interval"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
 
@@ -45,7 +47,7 @@ const (
 // with monotonic increases. The low water mark is initialized to
 // the current system time plus the maximum clock offset.
 type TimestampCache struct {
-	cache            *cache.IntervalCache
+	rCache, wCache   *cache.IntervalCache
 	lowWater, latest roachpb.Timestamp
 }
 
@@ -74,17 +76,20 @@ func makeCacheEntry(key cache.IntervalKey, value cacheValue) *cache.Entry {
 // hybrid clock.
 func NewTimestampCache(clock *hlc.Clock) *TimestampCache {
 	tc := &TimestampCache{
-		cache: cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}),
+		rCache: cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}),
+		wCache: cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}),
 	}
 	tc.Clear(clock)
-	tc.cache.Config.ShouldEvict = tc.shouldEvict
+	tc.rCache.Config.ShouldEvict = tc.shouldEvict
+	tc.wCache.Config.ShouldEvict = tc.shouldEvict
 	return tc
 }
 
 // Clear clears the cache and resets the low water mark to the
 // current time plus the maximum clock offset.
 func (tc *TimestampCache) Clear(clock *hlc.Clock) {
-	tc.cache.Clear()
+	tc.rCache.Clear()
+	tc.wCache.Clear()
 	tc.lowWater = clock.Now()
 	tc.lowWater.WallTime += clock.MaxOffset().Nanoseconds()
 	tc.latest = tc.lowWater
@@ -114,61 +119,180 @@ func (tc *TimestampCache) Add(start, end roachpb.Key, timestamp roachpb.Timestam
 	// Only add to the cache if the timestamp is more recent than the
 	// low water mark.
 	if tc.lowWater.Less(timestamp) {
-		// Check existing, overlapping entries. Remove superseded
-		// entries or return without adding this entry if necessary.
-		key := tc.cache.MakeKey(start, end)
-		for _, o := range tc.cache.GetOverlaps(key.Start, key.End) {
-			ce := o.Value.(*cacheValue)
-			if ce.readOnly != readOnly {
-				continue
-			}
-			if o.Key.Contains(key) {
-				if !ce.timestamp.Less(timestamp) {
-					return // don't add this key; there's already a cache entry with >= timestamp.
-				}
-				if key.Contains(*o.Key) {
-					// The keys are equal, update the existing cache entry.
-					*ce = cacheValue{timestamp: timestamp, txnID: txnID, readOnly: readOnly}
+		cache := tc.wCache
+		if readOnly {
+			cache = tc.rCache
+		}
+
+		addRange := func(r interval.Range) {
+			value := cacheValue{timestamp: timestamp, txnID: txnID}
+			key := cache.MakeKey(r.Start, r.End)
+			entry := makeCacheEntry(key, value)
+			cache.AddEntry(entry)
+		}
+		r := interval.Range{
+			Start: interval.Comparable(start),
+			End:   interval.Comparable(end),
+		}
+
+		// Check existing, overlapping entries and truncate/split/remove if
+		// superseded and in the past. If existing entries are in the future,
+		// subtract from the range/ranges that need to be added to cache.
+		for _, o := range cache.GetOverlaps(r.Start, r.End) {
+			cv := o.Value.(*cacheValue)
+			sCmp := r.Start.Compare(o.Key.Start)
+			eCmp := r.End.Compare(o.Key.End)
+			if !timestamp.Less(cv.timestamp) {
+				// The existing interval has a timestamp less than or equal to the new interval.
+				// Compare interval ranges to determine how to modify existing interval.
+				switch {
+				case sCmp == 0 && eCmp == 0:
+					// New and old are equal; replace old with new and avoid the need to insert new.
+					//
+					// New: ------------
+					// Old: ------------
+					//
+					// New: ------------
+					*cv = cacheValue{timestamp: timestamp, txnID: txnID, readOnly: readOnly}
 					return
+				case sCmp <= 0 && eCmp >= 0:
+					// New contains or is equal to old; delete old.
+					//
+					// New: ------------
+					// Old:   --------
+					//
+					// Old:
+					// TODO(nvanbenschoten) Avoid internal lookup of overlapping entry on deletion
+					// by adding a cache.DelEntry method and including the entry in a cache.Overlap.
+					cache.Del(o.Key)
+				case sCmp > 0 && eCmp < 0:
+					// Old contains new; split up old into two.
+					//
+					// New:     ----
+					// Old: ------------
+					//
+					// Old: ----    ----
+					oldEnd := o.Key.End
+					o.Key.End = r.Start
+
+					// TODO(nvanbenschoten) Is it ok that this new interval will mess up the
+					// cache's FIFO ordering?
+					key := cache.MakeKey(r.End, oldEnd)
+					entry := makeCacheEntry(key, *cv)
+					cache.AddEntry(entry)
+				case eCmp >= 0:
+					// Left partial overlap; truncate old end.
+					//
+					// New:     --------
+					// Old: --------
+					//
+					// Old: ----
+					o.Key.End = r.Start
+				case sCmp <= 0:
+					// Right partial overlap; truncate old start.
+					//
+					// New: --------
+					// Old:     --------
+					//
+					// Old:         ----
+					o.Key.Start = r.End
+				default:
+					panic(fmt.Sprintf("no overlap between %v and %v", o.Key.Range, r))
 				}
-			} else if key.Contains(*o.Key) && !timestamp.Less(ce.timestamp) {
-				tc.cache.Del(o.Key) // delete existing key; this cache entry supersedes.
+			} else {
+				// The existing interval has a timestamp greater than the new interval.
+				// Compare interval ranges to determine how to modify new interval before
+				// adding it to the timestamp cache.
+				switch {
+				case sCmp >= 0 && eCmp <= 0:
+					// Old contains or is equal to new; no need to add.
+					//
+					// Old: ------------
+					// New:    ------
+					//
+					// New:
+					return
+				case sCmp < 0 && eCmp > 0:
+					// New contains old; split up old into two. We can add the left piece
+					// immediately because it is guaranteed to be before the rest of the
+					// overlaps.
+					//
+					// Old:    ------
+					// New: ------------
+					//
+					// New: ---      ---
+					lr := interval.Range{Start: r.Start, End: o.Key.Start}
+					addRange(lr)
+
+					r.Start = o.Key.End
+				case eCmp >= 0:
+					// Left partial overlap; truncate new start.
+					//
+					// Old: --------
+					// New:     --------
+					//
+					// New:         ----
+					r.Start = o.Key.End
+				case sCmp <= 0:
+					// Right partial overlap; truncate new end.
+					//
+					// Old:     --------
+					// New: --------
+					//
+					// New: ----
+					r.End = o.Key.Start
+				default:
+					panic(fmt.Sprintf("no overlap between %v and %v", o.Key.Range, r))
+				}
 			}
 		}
-		entry := makeCacheEntry(
-			key, cacheValue{timestamp: timestamp, txnID: txnID, readOnly: readOnly})
-		tc.cache.AddEntry(entry)
+		addRange(r)
 	}
 }
 
-// GetMax returns the maximum read and write timestamps which overlap
+// GetMaxRead returns the maximum read timestamps which overlap
 // the interval spanning from start to end. Cached timestamps matching
 // the specified txnID are not considered. If no part of the specified
-// range is overlapped by timestamps in the cache, the low water
-// timestamp is returned for both read and write timestamps.
+// range is overlapped by timestamps from different transactions in the
+// cache, the low water timestamp is returned for the read timestamps.
+func (tc *TimestampCache) GetMaxRead(start, end roachpb.Key, txnID *uuid.UUID) roachpb.Timestamp {
+	return tc.getMax(start, end, txnID, true)
+}
+
+// GetMaxWrite returns the maximum write timestamps which overlap
+// the interval spanning from start to end. Cached timestamps matching
+// the specified txnID are not considered. If no part of the specified
+// range is overlapped by timestamps from different transactions in the
+// cache, the low water timestamp is returned for the write timestamps.
 //
 // The txn ID prevents restarts with a pattern like: read("a"),
 // write("a"). The read adds a timestamp for "a". Then the write (for
 // the same transaction) would get that as the max timestamp and be
 // forced to increment it. This allows timestamps from the same txn
-// to be ignored.
-func (tc *TimestampCache) GetMax(start, end roachpb.Key, txnID *uuid.UUID) (roachpb.Timestamp, roachpb.Timestamp) {
+// to be ignored because the write would instead get the low water
+// timestamp.
+func (tc *TimestampCache) GetMaxWrite(start, end roachpb.Key, txnID *uuid.UUID) roachpb.Timestamp {
+	return tc.getMax(start, end, txnID, false)
+}
+
+func (tc *TimestampCache) getMax(start, end roachpb.Key, txnID *uuid.UUID, readOnly bool) roachpb.Timestamp {
 	if len(end) == 0 {
 		end = start.Next()
 	}
-	maxR := tc.lowWater
-	maxW := tc.lowWater
-	for _, o := range tc.cache.GetOverlaps(start, end) {
+	max := tc.lowWater
+	cache := tc.wCache
+	if readOnly {
+		cache = tc.rCache
+	}
+	for _, o := range cache.GetOverlaps(start, end) {
 		ce := o.Value.(*cacheValue)
 		if ce.txnID == nil || txnID == nil || !roachpb.TxnIDEqual(txnID, ce.txnID) {
-			if ce.readOnly && maxR.Less(ce.timestamp) {
-				maxR = ce.timestamp
-			} else if !ce.readOnly && maxW.Less(ce.timestamp) {
-				maxW = ce.timestamp
+			if max.Less(ce.timestamp) {
+				max = ce.timestamp
 			}
 		}
 	}
-	return maxR, maxW
+	return max
 }
 
 // MergeInto merges all entries from this timestamp cache into the
@@ -177,19 +301,39 @@ func (tc *TimestampCache) GetMax(start, end roachpb.Key, txnID *uuid.UUID) (roac
 // before merging in the source.
 func (tc *TimestampCache) MergeInto(dest *TimestampCache, clear bool) {
 	if clear {
-		dest.cache.Clear()
+		dest.rCache.Clear()
+		dest.wCache.Clear()
 		dest.lowWater = tc.lowWater
 		dest.latest = tc.latest
+
+		// Because we just cleared the destination cache, we can directly
+		// insert entries from this cache.
+		hardMerge := func(srcCache, destCache *cache.IntervalCache) {
+			srcCache.Do(func(k, v interface{}) {
+				// Cache entries are mutable (see Add), so we give each cache its own
+				// unique copy.
+				entry := makeCacheEntry(*k.(*cache.IntervalKey), *v.(*cacheValue))
+				destCache.AddEntry(entry)
+			})
+		}
+		hardMerge(tc.rCache, dest.rCache)
+		hardMerge(tc.wCache, dest.wCache)
 	} else {
 		dest.lowWater.Forward(tc.lowWater)
 		dest.latest.Forward(tc.latest)
+
+		// The cache was not cleared before, so we can't just insert entries because
+		// intervals may need to be adjusted or removed to maintain the non-overlapping
+		// guarantee.
+		softMerge := func(srcCache *cache.IntervalCache, readOnly bool) {
+			srcCache.Do(func(k, v interface{}) {
+				key, val := *k.(*cache.IntervalKey), *v.(*cacheValue)
+				dest.Add(roachpb.Key(key.Start), roachpb.Key(key.End), val.timestamp, val.txnID, readOnly)
+			})
+		}
+		softMerge(tc.rCache, true)
+		softMerge(tc.wCache, false)
 	}
-	tc.cache.Do(func(k, v interface{}) {
-		// Cache entries are mutable (see Add), so we give each cache its own
-		// unique copy.
-		entry := makeCacheEntry(*k.(*cache.IntervalKey), *v.(*cacheValue))
-		dest.cache.AddEntry(entry)
-	})
 }
 
 // shouldEvict returns true if the cache entry's timestamp is no

--- a/storage/timestamp_cache_test.go
+++ b/storage/timestamp_cache_test.go
@@ -41,23 +41,23 @@ func TestTimestampCache(t *testing.T) {
 	tc.Add(roachpb.Key("a"), nil, clock.Now(), nil, true)
 	// Although we added "a" at time 0, the internal cache should still
 	// be empty because the t=0 < lowWater.
-	if tc.cache.Len() > 0 {
-		t.Errorf("expected cache to be empty, but contains %d elements", tc.cache.Len())
+	if tc.rCache.Len() > 0 {
+		t.Errorf("expected cache to be empty, but contains %d elements", tc.rCache.Len())
 	}
 	// Verify GetMax returns the lowWater mark which is maxClockOffset.
-	if rTS, _ := tc.GetMax(roachpb.Key("a"), nil, nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
+	if rTS := tc.GetMaxRead(roachpb.Key("a"), nil, nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
 		t.Error("expected maxClockOffset for key \"a\"")
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("notincache"), nil, nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
+	if rTS := tc.GetMaxRead(roachpb.Key("notincache"), nil, nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
 		t.Error("expected maxClockOffset for key \"notincache\"")
 	}
 
 	// Advance the clock and verify same low water mark.
 	manual.Set(maxClockOffset.Nanoseconds() + 1)
-	if rTS, _ := tc.GetMax(roachpb.Key("a"), nil, nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
+	if rTS := tc.GetMaxRead(roachpb.Key("a"), nil, nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
 		t.Error("expected maxClockOffset for key \"a\"")
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("notincache"), nil, nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
+	if rTS := tc.GetMaxRead(roachpb.Key("notincache"), nil, nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
 		t.Error("expected maxClockOffset for key \"notincache\"")
 	}
 
@@ -66,43 +66,43 @@ func TestTimestampCache(t *testing.T) {
 	tc.Add(roachpb.Key("b"), roachpb.Key("c"), ts, nil, true)
 
 	// Verify all permutations of direct and range access.
-	if rTS, _ := tc.GetMax(roachpb.Key("b"), nil, nil); !rTS.Equal(ts) {
+	if rTS := tc.GetMaxRead(roachpb.Key("b"), nil, nil); !rTS.Equal(ts) {
 		t.Errorf("expected current time for key \"b\"; got %s", rTS)
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("bb"), nil, nil); !rTS.Equal(ts) {
+	if rTS := tc.GetMaxRead(roachpb.Key("bb"), nil, nil); !rTS.Equal(ts) {
 		t.Error("expected current time for key \"bb\"")
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("c"), nil, nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
+	if rTS := tc.GetMaxRead(roachpb.Key("c"), nil, nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
 		t.Error("expected maxClockOffset for key \"c\"")
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("b"), roachpb.Key("c"), nil); !rTS.Equal(ts) {
+	if rTS := tc.GetMaxRead(roachpb.Key("b"), roachpb.Key("c"), nil); !rTS.Equal(ts) {
 		t.Error("expected current time for key \"b\"-\"c\"")
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("bb"), roachpb.Key("bz"), nil); !rTS.Equal(ts) {
+	if rTS := tc.GetMaxRead(roachpb.Key("bb"), roachpb.Key("bz"), nil); !rTS.Equal(ts) {
 		t.Error("expected current time for key \"bb\"-\"bz\"")
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("a"), roachpb.Key("b"), nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
+	if rTS := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("b"), nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
 		t.Error("expected maxClockOffset for key \"a\"-\"b\"")
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("a"), roachpb.Key("bb"), nil); !rTS.Equal(ts) {
+	if rTS := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("bb"), nil); !rTS.Equal(ts) {
 		t.Error("expected current time for key \"a\"-\"bb\"")
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("a"), roachpb.Key("d"), nil); !rTS.Equal(ts) {
+	if rTS := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("d"), nil); !rTS.Equal(ts) {
 		t.Error("expected current time for key \"a\"-\"d\"")
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("bz"), roachpb.Key("c"), nil); !rTS.Equal(ts) {
+	if rTS := tc.GetMaxRead(roachpb.Key("bz"), roachpb.Key("c"), nil); !rTS.Equal(ts) {
 		t.Error("expected current time for key \"bz\"-\"c\"")
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("bz"), roachpb.Key("d"), nil); !rTS.Equal(ts) {
+	if rTS := tc.GetMaxRead(roachpb.Key("bz"), roachpb.Key("d"), nil); !rTS.Equal(ts) {
 		t.Error("expected current time for key \"bz\"-\"d\"")
 	}
-	if rTS, _ := tc.GetMax(roachpb.Key("c"), roachpb.Key("d"), nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
+	if rTS := tc.GetMaxRead(roachpb.Key("c"), roachpb.Key("d"), nil); rTS.WallTime != maxClockOffset.Nanoseconds() {
 		t.Error("expected maxClockOffset for key \"c\"-\"d\"")
 	}
 }
 
 // TestTimestampCacheSetLowWater verifies that setting the low
-// water mark moves max timestamps forward as appropriate.
+// water mark moves max timestamps forwards as appropriate.
 func TestTimestampCacheSetLowWater(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	manual := hlc.NewManualClock(0)
@@ -138,14 +138,14 @@ func TestTimestampCacheSetLowWater(t *testing.T) {
 		{roachpb.Key("c"), cTS},
 		{roachpb.Key("d"), bTS},
 	} {
-		if rTS, _ := tc.GetMax(test.key, nil, nil); !rTS.Equal(test.expTS) {
+		if rTS := tc.GetMaxRead(test.key, nil, nil); !rTS.Equal(test.expTS) {
 			t.Errorf("%d: expected ts %s, got %s", i, test.expTS, rTS)
 		}
 	}
 
 	// Try setting a lower low water mark than the previous value.
 	tc.SetLowWater(aTS)
-	if rTS, _ := tc.GetMax(roachpb.Key("d"), nil, nil); !rTS.Equal(bTS) {
+	if rTS := tc.GetMaxRead(roachpb.Key("d"), nil, nil); !rTS.Equal(bTS) {
 		t.Errorf("setting lower low water mark should not be allowed; expected %s; got %s", bTS, rTS)
 	}
 }
@@ -169,7 +169,7 @@ func TestTimestampCacheEviction(t *testing.T) {
 	tc.Add(roachpb.Key("b"), nil, clock.Now(), nil, true)
 
 	// Verify looking up key "c" returns the new low water mark ("a"'s timestamp).
-	if rTS, _ := tc.GetMax(roachpb.Key("c"), nil, nil); !rTS.Equal(aTS) {
+	if rTS := tc.GetMaxRead(roachpb.Key("c"), nil, nil); !rTS.Equal(aTS) {
 		t.Errorf("expected low water mark %s, got %s", aTS, rTS)
 	}
 }
@@ -183,8 +183,8 @@ func TestTimestampCacheMergeInto(t *testing.T) {
 		useClear bool
 		expLen   int
 	}{
-		{true, 3},
-		{false, 5},
+		{true, 4},
+		{false, 7},
 	}
 	for _, test := range testCases {
 		tc1 := NewTimestampCache(clock)
@@ -207,28 +207,28 @@ func TestTimestampCacheMergeInto(t *testing.T) {
 
 		tc1.MergeInto(tc2, test.useClear)
 
-		if tc2.cache.Len() != test.expLen {
-			t.Errorf("expected merged length of %d; got %d", test.expLen, tc2.cache.Len())
+		if tc2.rCache.Len() != test.expLen {
+			t.Errorf("expected merged length of %d; got %d", test.expLen, tc2.rCache.Len())
 		}
 		if !tc2.latest.Equal(tc1.latest) {
 			t.Errorf("expected latest to be updated to %s; got %s", tc1.latest, tc2.latest)
 		}
 
-		if rTS, _ := tc2.GetMax(roachpb.Key("a"), nil, nil); !rTS.Equal(adTS) {
+		if rTS := tc2.GetMaxRead(roachpb.Key("a"), nil, nil); !rTS.Equal(adTS) {
 			t.Error("expected \"a\" to have adTS timestamp")
 		}
-		if rTS, _ := tc2.GetMax(roachpb.Key("b"), nil, nil); !rTS.Equal(beTS) {
+		if rTS := tc2.GetMaxRead(roachpb.Key("b"), nil, nil); !rTS.Equal(beTS) {
 			t.Error("expected \"b\" to have beTS timestamp")
 		}
 		if test.useClear {
-			if rTS, _ := tc2.GetMax(roachpb.Key("aa"), nil, nil); !rTS.Equal(adTS) {
+			if rTS := tc2.GetMaxRead(roachpb.Key("aa"), nil, nil); !rTS.Equal(adTS) {
 				t.Error("expected \"aa\" to have adTS timestamp")
 			}
 		} else {
-			if rTS, _ := tc2.GetMax(roachpb.Key("aa"), nil, nil); !rTS.Equal(aaTS) {
+			if rTS := tc2.GetMaxRead(roachpb.Key("aa"), nil, nil); !rTS.Equal(aaTS) {
 				t.Error("expected \"aa\" to have aaTS timestamp")
 			}
-			if rTS, _ := tc2.GetMax(roachpb.Key("a"), roachpb.Key("c"), nil); !rTS.Equal(aaTS) {
+			if rTS := tc2.GetMaxRead(roachpb.Key("a"), roachpb.Key("c"), nil); !rTS.Equal(aaTS) {
 				t.Error("expected \"a\"-\"c\" to have aaTS timestamp")
 			}
 
@@ -242,56 +242,164 @@ func TestTimestampCacheMergeInto(t *testing.T) {
 	}
 }
 
+type layeredIntervalTestCase struct {
+	actions   []func(tc *TimestampCache, ts roachpb.Timestamp)
+	validator func(t *testing.T, tc *TimestampCache, tss []roachpb.Timestamp)
+}
+
+// layeredIntervalTestCase1 tests the left partial overlap and old containing
+// new cases for adding intervals to the interval cache when tested in order,
+// and tests the cases' inverses when tested in reverse.
+var layeredIntervalTestCase1 = layeredIntervalTestCase{
+	actions: []func(tc *TimestampCache, ts roachpb.Timestamp){
+		func(tc *TimestampCache, ts roachpb.Timestamp) {
+			// No overlap forwards.
+			// Right partial overlap backwards.
+			tc.Add(roachpb.Key("a"), roachpb.Key("bb"), ts, nil, true)
+		},
+		func(tc *TimestampCache, ts roachpb.Timestamp) {
+			// Left partial overlap forwards.
+			// New contains old backwards.
+			tc.Add(roachpb.Key("b"), roachpb.Key("e"), ts, nil, true)
+		},
+		func(tc *TimestampCache, ts roachpb.Timestamp) {
+			// Old contains new forwards.
+			// No overlap backwards.
+			tc.Add(roachpb.Key("c"), nil, ts, nil, true)
+		},
+	},
+	validator: func(t *testing.T, tc *TimestampCache, tss []roachpb.Timestamp) {
+		abbTS := tss[0]
+		beTS := tss[1]
+		cTS := tss[2]
+
+		// Try different sub ranges.
+		if rTS := tc.GetMaxRead(roachpb.Key("a"), nil, nil); !rTS.Equal(abbTS) {
+			t.Errorf("expected \"a\" to have abbTS %v timestamp, found %v", abbTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("b"), nil, nil); !rTS.Equal(beTS) {
+			t.Errorf("expected \"b\" to have beTS %v timestamp, found %v", beTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("c"), nil, nil); !rTS.Equal(cTS) {
+			t.Errorf("expected \"c\" to have cTS %v timestamp, found %v", cTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("d"), nil, nil); !rTS.Equal(beTS) {
+			t.Errorf("expected \"d\" to have beTS %v timestamp, found %v", beTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("b"), nil); !rTS.Equal(abbTS) {
+			t.Errorf("expected \"a\"-\"b\" to have abbTS %v timestamp, found %v", cTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("c"), nil); !rTS.Equal(beTS) {
+			t.Errorf("expected \"a\"-\"c\" to have beTS %v timestamp, found %v", beTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("d"), nil); !rTS.Equal(cTS) {
+			t.Errorf("expected \"a\"-\"d\" to have cTS %v timestamp, found %v", cTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("b"), roachpb.Key("d"), nil); !rTS.Equal(cTS) {
+			t.Errorf("expected \"b\"-\"d\" to have cTS %v timestamp, found %v", cTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("c"), roachpb.Key("d"), nil); !rTS.Equal(cTS) {
+			t.Errorf("expected \"c\"-\"d\" to have cTS %v timestamp, found %v", cTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("c0"), roachpb.Key("d"), nil); !rTS.Equal(beTS) {
+			t.Errorf("expected \"c0\"-\"d\" to have beTS %v timestamp, found %v", beTS, rTS)
+		}
+	},
+}
+
+// layeredIntervalTestCase2 tests the right partial overlap and new containing
+// old cases for adding intervals to the interval cache when tested in order,
+// and tests the cases' inverses when tested in reverse.
+var layeredIntervalTestCase2 = layeredIntervalTestCase{
+	actions: []func(tc *TimestampCache, ts roachpb.Timestamp){
+		func(tc *TimestampCache, ts roachpb.Timestamp) {
+			// No overlap forwards.
+			// Old contains new backwards.
+			tc.Add(roachpb.Key("d"), roachpb.Key("f"), ts, nil, true)
+		},
+		func(tc *TimestampCache, ts roachpb.Timestamp) {
+			// New contains old forwards.
+			// Left partial overlap backwards.
+			tc.Add(roachpb.Key("b"), roachpb.Key("f"), ts, nil, true)
+		},
+		func(tc *TimestampCache, ts roachpb.Timestamp) {
+			// Right partial overlap forwards.
+			// No overlap backwards.
+			tc.Add(roachpb.Key("a"), roachpb.Key("c"), ts, nil, true)
+		},
+	},
+	validator: func(t *testing.T, tc *TimestampCache, tss []roachpb.Timestamp) {
+		bfTS := tss[1]
+		acTS := tss[2]
+
+		// Try different sub ranges.
+		if rTS := tc.GetMaxRead(roachpb.Key("a"), nil, nil); !rTS.Equal(acTS) {
+			t.Errorf("expected \"a\" to have acTS %v timestamp, found %v", acTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("b"), nil, nil); !rTS.Equal(acTS) {
+			t.Errorf("expected \"b\" to have acTS %v timestamp, found %v", acTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("c"), nil, nil); !rTS.Equal(bfTS) {
+			t.Errorf("expected \"c\" to have bfTS %v timestamp, found %v", bfTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("d"), nil, nil); !rTS.Equal(bfTS) {
+			t.Errorf("expected \"d\" to have bfTS %v timestamp, found %v", bfTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("c"), nil); !rTS.Equal(acTS) {
+			t.Errorf("expected \"a\"-\"c\" to have acTS %v timestamp, found %v", acTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("b"), roachpb.Key("d"), nil); !rTS.Equal(acTS) {
+			t.Errorf("expected \"b\"-\"d\" to have acTS %v timestamp, found %v", acTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("c"), roachpb.Key("d"), nil); !rTS.Equal(bfTS) {
+			t.Errorf("expected \"c\"-\"d\" to have bfTS %v timestamp, found %v", bfTS, rTS)
+		}
+		if rTS := tc.GetMaxRead(roachpb.Key("c0"), roachpb.Key("d"), nil); !rTS.Equal(bfTS) {
+			t.Errorf("expected \"c0\"-\"d\" to have bfTS %v timestamp, found %v", bfTS, rTS)
+		}
+	},
+}
+
 // TestTimestampCacheLayeredIntervals verifies the maximum timestamp
 // is chosen if previous entries have ranges which are layered over
 // each other.
+//
+// The test uses the layeredIntervalTestCase struct to allow reordering
+// of interval insertions while keeping each interval's timestamp fixed.
+// This can be used to verify that only the provided timestamp is used to
+// determine layering, and that the interval insertion order is irrelevant.
 func TestTimestampCacheLayeredIntervals(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
-	clock.SetMaxOffset(maxClockOffset)
+	clock.SetMaxOffset(0)
 	tc := NewTimestampCache(clock)
-	manual.Set(maxClockOffset.Nanoseconds() + 1)
 
-	adTS := clock.Now()
-	tc.Add(roachpb.Key("a"), roachpb.Key("d"), adTS, nil, true)
+	for _, testCase := range []layeredIntervalTestCase{
+		layeredIntervalTestCase1,
+		layeredIntervalTestCase2,
+	} {
+		// Perform actions in order and validate.
+		tc.Clear(clock)
+		tss := make([]roachpb.Timestamp, len(testCase.actions))
+		for i := range testCase.actions {
+			tss[i] = clock.Now()
+		}
+		for i, action := range testCase.actions {
+			action(tc, tss[i])
+		}
+		testCase.validator(t, tc, tss)
 
-	beTS := clock.Now()
-	tc.Add(roachpb.Key("b"), roachpb.Key("e"), beTS, nil, true)
-
-	cTS := clock.Now()
-	tc.Add(roachpb.Key("c"), nil, cTS, nil, true)
-
-	// Try different sub ranges.
-	if rTS, _ := tc.GetMax(roachpb.Key("a"), nil, nil); !rTS.Equal(adTS) {
-		t.Error("expected \"a\" to have adTS timestamp")
-	}
-	if rTS, _ := tc.GetMax(roachpb.Key("b"), nil, nil); !rTS.Equal(beTS) {
-		t.Error("expected \"b\" to have beTS timestamp")
-	}
-	if rTS, _ := tc.GetMax(roachpb.Key("c"), nil, nil); !rTS.Equal(cTS) {
-		t.Error("expected \"b\" to have cTS timestamp")
-	}
-	if rTS, _ := tc.GetMax(roachpb.Key("d"), nil, nil); !rTS.Equal(beTS) {
-		t.Error("expected \"d\" to have beTS timestamp")
-	}
-	if rTS, _ := tc.GetMax(roachpb.Key("a"), roachpb.Key("b"), nil); !rTS.Equal(adTS) {
-		t.Error("expected \"a\"-\"b\" to have adTS timestamp")
-	}
-	if rTS, _ := tc.GetMax(roachpb.Key("a"), roachpb.Key("c"), nil); !rTS.Equal(beTS) {
-		t.Error("expected \"a\"-\"c\" to have beTS timestamp")
-	}
-	if rTS, _ := tc.GetMax(roachpb.Key("a"), roachpb.Key("d"), nil); !rTS.Equal(cTS) {
-		t.Error("expected \"a\"-\"d\" to have cTS timestamp")
-	}
-	if rTS, _ := tc.GetMax(roachpb.Key("b"), roachpb.Key("d"), nil); !rTS.Equal(cTS) {
-		t.Error("expected \"b\"-\"d\" to have cTS timestamp")
-	}
-	if rTS, _ := tc.GetMax(roachpb.Key("c"), roachpb.Key("d"), nil); !rTS.Equal(cTS) {
-		t.Error("expected \"c\"-\"d\" to have cTS timestamp")
-	}
-	if rTS, _ := tc.GetMax(roachpb.Key("c0"), roachpb.Key("d"), nil); !rTS.Equal(beTS) {
-		t.Error("expected \"c0\"-\"d\" to have beTS timestamp")
+		// Perform actions out of order and validate.
+		tc.Clear(clock)
+		for i := range testCase.actions {
+			// Recreate timestamps because Clear() sets lowWater to Now().
+			tss[i] = clock.Now()
+		}
+		for i := len(testCase.actions) - 1; i >= 0; i-- {
+			testCase.actions[i](tc, tss[i])
+		}
+		testCase.validator(t, tc, tss)
 	}
 }
 
@@ -314,7 +422,7 @@ func TestTimestampCacheClear(t *testing.T) {
 	// Fetching any keys should give current time + maxClockOffset
 	expTS := clock.Timestamp()
 	expTS.WallTime += maxClockOffset.Nanoseconds()
-	if rTS, _ := tc.GetMax(roachpb.Key("a"), nil, nil); !rTS.Equal(expTS) {
+	if rTS := tc.GetMaxRead(roachpb.Key("a"), nil, nil); !rTS.Equal(expTS) {
 		t.Error("expected \"a\" to have cleared timestamp")
 	}
 }
@@ -333,41 +441,41 @@ func TestTimestampCacheReplacements(t *testing.T) {
 
 	ts1 := clock.Now()
 	tc.Add(roachpb.Key("a"), nil, ts1, nil, true)
-	if ts, _ := tc.GetMax(roachpb.Key("a"), nil, nil); !ts.Equal(ts1) {
+	if ts := tc.GetMaxRead(roachpb.Key("a"), nil, nil); !ts.Equal(ts1) {
 		t.Errorf("expected %s; got %s", ts1, ts)
 	}
 	// Write overlapping value with txn1 and verify with txn1--we should get
 	// low water mark, not ts1.
 	ts2 := clock.Now()
 	tc.Add(roachpb.Key("a"), nil, ts2, txn1ID, true)
-	if ts, _ := tc.GetMax(roachpb.Key("a"), nil, txn1ID); !ts.Equal(tc.lowWater) {
+	if ts := tc.GetMaxRead(roachpb.Key("a"), nil, txn1ID); !ts.Equal(tc.lowWater) {
 		t.Errorf("expected low water (empty) time; got %s", ts)
 	}
 	// Write range which overlaps "a" with txn2 and verify with txn2--we should
 	// get low water mark, not ts2.
 	ts3 := clock.Now()
 	tc.Add(roachpb.Key("a"), roachpb.Key("c"), ts3, txn2ID, true)
-	if ts, _ := tc.GetMax(roachpb.Key("a"), nil, txn2ID); !ts.Equal(tc.lowWater) {
+	if ts := tc.GetMaxRead(roachpb.Key("a"), nil, txn2ID); !ts.Equal(tc.lowWater) {
 		t.Errorf("expected low water (empty) time; got %s", ts)
 	}
 	// Also, verify txn1 sees ts3.
-	if ts, _ := tc.GetMax(roachpb.Key("a"), nil, txn1ID); !ts.Equal(ts3) {
+	if ts := tc.GetMaxRead(roachpb.Key("a"), nil, txn1ID); !ts.Equal(ts3) {
 		t.Errorf("expected %s; got %s", ts3, ts)
 	}
 	// Now, write to "b" with a higher timestamp and no txn. Should be
 	// visible to all txns.
 	ts4 := clock.Now()
 	tc.Add(roachpb.Key("b"), nil, ts4, nil, true)
-	if ts, _ := tc.GetMax(roachpb.Key("b"), nil, nil); !ts.Equal(ts4) {
+	if ts := tc.GetMaxRead(roachpb.Key("b"), nil, nil); !ts.Equal(ts4) {
 		t.Errorf("expected %s; got %s", ts4, ts)
 	}
-	if ts, _ := tc.GetMax(roachpb.Key("b"), nil, txn1ID); !ts.Equal(ts4) {
+	if ts := tc.GetMaxRead(roachpb.Key("b"), nil, txn1ID); !ts.Equal(ts4) {
 		t.Errorf("expected %s; got %s", ts4, ts)
 	}
 	// Finally, write an earlier version of "a"; should simply get
 	// tossed and we should see ts4 still.
 	tc.Add(roachpb.Key("b"), nil, ts1, nil, true)
-	if ts, _ := tc.GetMax(roachpb.Key("b"), nil, nil); !ts.Equal(ts4) {
+	if ts := tc.GetMaxRead(roachpb.Key("b"), nil, nil); !ts.Equal(ts4) {
 		t.Errorf("expected %s; got %s", ts4, ts)
 	}
 }
@@ -390,15 +498,15 @@ func TestTimestampCacheWithTxnID(t *testing.T) {
 	tc.Add(roachpb.Key("b"), roachpb.Key("d"), ts2, txn2ID, true)
 
 	// Fetching with no transaction gets latest value.
-	if ts, _ := tc.GetMax(roachpb.Key("b"), nil, nil); !ts.Equal(ts2) {
+	if ts := tc.GetMaxRead(roachpb.Key("b"), nil, nil); !ts.Equal(ts2) {
 		t.Errorf("expected %s; got %s", ts2, ts)
 	}
 	// Fetching with txn ID "1" gets most recent.
-	if ts, _ := tc.GetMax(roachpb.Key("b"), nil, txn1ID); !ts.Equal(ts2) {
+	if ts := tc.GetMaxRead(roachpb.Key("b"), nil, txn1ID); !ts.Equal(ts2) {
 		t.Errorf("expected %s; got %s", ts2, ts)
 	}
 	// Fetching with txn ID "2" skips most recent.
-	if ts, _ := tc.GetMax(roachpb.Key("b"), nil, txn2ID); !ts.Equal(ts1) {
+	if ts := tc.GetMaxRead(roachpb.Key("b"), nil, txn2ID); !ts.Equal(tc.lowWater) {
 		t.Errorf("expected %s; got %s", ts1, ts)
 	}
 }
@@ -424,15 +532,15 @@ func TestTimestampCacheReadVsWrite(t *testing.T) {
 	tc.Add(roachpb.Key("a"), nil, ts3, txn2ID, false)
 
 	// Fetching with no transaction gets latest values.
-	if rTS, wTS := tc.GetMax(roachpb.Key("a"), nil, nil); !rTS.Equal(ts2) || !wTS.Equal(ts3) {
+	if rTS, wTS := tc.GetMaxRead(roachpb.Key("a"), nil, nil), tc.GetMaxWrite(roachpb.Key("a"), nil, nil); !rTS.Equal(ts2) || !wTS.Equal(ts3) {
 		t.Errorf("expected %s %s; got %s %s", ts2, ts3, rTS, wTS)
 	}
-	// Fetching with txn ID "1" gets original for read and most recent for write.
-	if rTS, wTS := tc.GetMax(roachpb.Key("a"), nil, txn1ID); !rTS.Equal(ts1) || !wTS.Equal(ts3) {
+	// Fetching with txn ID "1" gets low water mark for read and most recent for write.
+	if rTS, wTS := tc.GetMaxRead(roachpb.Key("a"), nil, txn1ID), tc.GetMaxWrite(roachpb.Key("a"), nil, txn1ID); !rTS.Equal(tc.lowWater) || !wTS.Equal(ts3) {
 		t.Errorf("expected %s %s; got %s %s", ts1, ts3, rTS, wTS)
 	}
 	// Fetching with txn ID "2" gets ts2 for read and low water mark for write.
-	if rTS, wTS := tc.GetMax(roachpb.Key("a"), nil, txn2ID); !rTS.Equal(ts2) || !wTS.Equal(tc.lowWater) {
+	if rTS, wTS := tc.GetMaxRead(roachpb.Key("a"), nil, txn2ID), tc.GetMaxWrite(roachpb.Key("a"), nil, txn2ID); !rTS.Equal(ts2) || !wTS.Equal(tc.lowWater) {
 		t.Errorf("expected %s %s; got %s %s", ts2, tc.lowWater, rTS, wTS)
 	}
 }

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -100,14 +100,14 @@ func (e *Entry) Range() interval.Range {
 
 // cacheStore is an interface for the backing store used for the cache.
 type cacheStore interface {
+	// init initializes or clears all entries.
+	init()
 	// get returns the entry by key.
 	get(key interface{}) *Entry
 	// add stores an entry.
 	add(e *Entry)
 	// del removes an entry.
 	del(key interface{})
-	// clear clears all entries.
-	clear()
 	// len is number of items in store.
 	length() int
 }
@@ -131,6 +131,7 @@ func newBaseCache(config Config) baseCache {
 func (bc *baseCache) init(store cacheStore) {
 	bc.ll.Init()
 	bc.store = store
+	bc.store.init()
 }
 
 // Add adds a value to the cache.
@@ -168,12 +169,10 @@ func (bc *baseCache) add(key, value interface{}, entry, after *Entry) {
 	if e == nil {
 		e = &Entry{Key: key, Value: value}
 	}
-	if bc.Policy != CacheNone {
-		if after != nil {
-			e.le = bc.ll.InsertBefore(e, after.le)
-		} else {
-			e.le = bc.ll.PushFront(e)
-		}
+	if after != nil {
+		e.le = bc.ll.InsertBefore(e, after.le)
+	} else {
+		e.le = bc.ll.PushFront(e)
 	}
 	bc.store.add(e)
 	// Evict as many elements as we can.
@@ -205,7 +204,14 @@ func (bc *baseCache) DelEntry(entry *Entry) {
 
 // Clear clears all entries from the cache.
 func (bc *baseCache) Clear() {
-	bc.store.clear()
+	if bc.OnEvicted != nil {
+		for e := bc.ll.Back(); e != nil; e = e.Prev() {
+			entry := e.Value.(*Entry)
+			bc.OnEvicted(entry.Key, entry.Value)
+		}
+	}
+	bc.ll.Init()
+	bc.store.init()
 }
 
 // Len returns the number of items in the cache.
@@ -220,9 +226,7 @@ func (bc *baseCache) access(e *Entry) {
 }
 
 func (bc *baseCache) removeElement(e *Entry) {
-	if bc.Policy != CacheNone {
-		bc.ll.Remove(e.le)
-	}
+	bc.ll.Remove(e.le)
 	bc.store.del(e.Key)
 	if bc.OnEvicted != nil {
 		bc.OnEvicted(e.Key, e.Value)
@@ -266,13 +270,15 @@ type UnorderedCache struct {
 func NewUnorderedCache(config Config) *UnorderedCache {
 	mc := &UnorderedCache{
 		baseCache: newBaseCache(config),
-		hmap:      make(map[interface{}]interface{}),
 	}
 	mc.baseCache.init(mc)
 	return mc
 }
 
 // Implementation of cacheStore interface.
+func (mc *UnorderedCache) init() {
+	mc.hmap = make(map[interface{}]interface{})
+}
 func (mc *UnorderedCache) get(key interface{}) *Entry {
 	if e, ok := mc.hmap[key].(*Entry); ok {
 		return e
@@ -284,11 +290,6 @@ func (mc *UnorderedCache) add(e *Entry) {
 }
 func (mc *UnorderedCache) del(key interface{}) {
 	delete(mc.hmap, key)
-}
-func (mc *UnorderedCache) clear() {
-	for key := range mc.hmap {
-		mc.Del(key)
-	}
 }
 func (mc *UnorderedCache) length() int {
 	return len(mc.hmap)
@@ -318,6 +319,9 @@ func NewOrderedCache(config Config) *OrderedCache {
 }
 
 // Implementation of cacheStore interface.
+func (oc *OrderedCache) init() {
+	oc.llrb = llrb.Tree{}
+}
 func (oc *OrderedCache) get(key interface{}) *Entry {
 	if e, ok := oc.llrb.Get(&Entry{Key: key}).(*Entry); ok {
 		return e
@@ -329,12 +333,6 @@ func (oc *OrderedCache) add(e *Entry) {
 }
 func (oc *OrderedCache) del(key interface{}) {
 	oc.llrb.Delete(&Entry{Key: key})
-}
-func (oc *OrderedCache) clear() {
-	oc.llrb.Do(func(e llrb.Comparable) (done bool) {
-		oc.Del(e.(*Entry).Key)
-		return
-	})
 }
 func (oc *OrderedCache) length() int {
 	return oc.llrb.Len()
@@ -419,7 +417,6 @@ func (ik IntervalKey) Contains(lk IntervalKey) bool {
 func NewIntervalCache(config Config) *IntervalCache {
 	ic := &IntervalCache{
 		baseCache: newBaseCache(config),
-		tree:      interval.Tree{Overlapper: interval.Range.OverlapExclusive},
 	}
 	ic.baseCache.init(ic)
 	return ic
@@ -446,6 +443,10 @@ func (ic *IntervalCache) MakeKey(start, end []byte) IntervalKey {
 }
 
 // Implementation of cacheStore interface.
+func (ic *IntervalCache) init() {
+	ic.tree = interval.Tree{Overlapper: interval.Range.OverlapExclusive}
+}
+
 func (ic *IntervalCache) get(key interface{}) *Entry {
 	ik := key.(*IntervalKey)
 	ic.getID = ik.id
@@ -475,13 +476,6 @@ func (ic *IntervalCache) del(key interface{}) {
 	if err := ic.tree.Delete(&ic.tmpEntry, false); err != nil {
 		log.Error(err)
 	}
-}
-
-func (ic *IntervalCache) clear() {
-	ic.tree.Do(func(e interval.Interface) (done bool) {
-		ic.Del(e.(*Entry).Key.(*IntervalKey))
-		return
-	})
 }
 
 func (ic *IntervalCache) length() int {

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -192,8 +192,14 @@ func (bc *baseCache) Get(key interface{}) (value interface{}, ok bool) {
 
 // Del removes the provided key from the cache.
 func (bc *baseCache) Del(key interface{}) {
-	if e := bc.store.get(key); e != nil {
-		bc.removeElement(e)
+	e := bc.store.get(key)
+	bc.DelEntry(e)
+}
+
+// DelEntry removes the provided entry from the cache.
+func (bc *baseCache) DelEntry(entry *Entry) {
+	if entry != nil {
+		bc.removeElement(entry)
 	}
 }
 

--- a/util/cache/cache_test.go
+++ b/util/cache/cache_test.go
@@ -102,6 +102,22 @@ func TestCacheDel(t *testing.T) {
 	}
 }
 
+func TestCacheAddDelEntry(t *testing.T) {
+	mc := NewUnorderedCache(Config{Policy: CacheLRU, ShouldEvict: noEviction})
+	e := &Entry{Key: testKey("myKey"), Value: 1234}
+	mc.AddEntry(e)
+	if val, ok := mc.Get(testKey("myKey")); !ok {
+		t.Fatal("TestDel returned no match")
+	} else if val != 1234 {
+		t.Fatalf("TestDel failed. Expected %d, got %v", 1234, val)
+	}
+
+	mc.DelEntry(e)
+	if _, ok := mc.Get(testKey("myKey")); ok {
+		t.Fatal("TestRemove returned a removed entry")
+	}
+}
+
 func TestCacheEviction(t *testing.T) {
 	mc := NewUnorderedCache(Config{Policy: CacheLRU, ShouldEvict: evictTwoOrMore})
 	// Insert two keys into cache which only holds 1.

--- a/util/interval/range_group_test.go
+++ b/util/interval/range_group_test.go
@@ -292,6 +292,12 @@ func testRangeGroupSubRanges(t *testing.T, rg RangeGroup) {
 		res []Range
 	}{
 		{
+			add: []Range{},
+			sub: Range{Start: []byte{0x10}, End: []byte{0x11}},
+			rem: false,
+			res: []Range{},
+		},
+		{
 			add: oneRange,
 			sub: Range{Start: []byte{0x10}, End: []byte{0x11}},
 			rem: false,


### PR DESCRIPTION
Fixes #4616 and closes #4700. This is an alternative to #4699.

Previously, we only removed timestamp intervals from the `TimestampCache`
during addition when a newer timestamp interval itself fully superseded
the earlier timestamp interval. This failed to take into account that only
the most recent timestamps for any given interval was needed to be
retained by the cache (we only need to keep the upper edge). With this new
assumption, newer timestamp intervals can be allowed to trim/split/or
delete any intervals that come before them and that they overlap. By
performing this reduction in size to any intervals that are overlapped,
we increase the chance that future timestamps will fully supersede past
timestamps, permitting their removal. It also seems to increase the
chance that past intervals can be replaced in-place with future intervals
by simply replacing their cache value. This allows us to more precisely
determine when a timestamp interval is still contributing to the cache's
maximum timestamp for some segment of the keyspace, and if it's not, remove
it on the spot instead of waiting for the `MinTSCacheWindow` (currently set
to 10 seconds) before evicting the interval.

This missing optimization during `TimestampCache` insertion meant that the
`TimestampCache` grew to extreme sizes, often accounting for over **300 MB**
per-node, which meant that it accounted for about **88%** of all memory
usage for Cockroach nodes. With this new optimization now being diligent
about removing timestamp intervals from the timestamp cache as soon as
they can be removed, we are able to reduce the upper bound for the per-node
`TimestampCache` size to about **3 MB**, a **100 x** reduction in size.
This means that we are able to reduce the total Cockroach node memory usage
from around **360 MB** to around **60 MB**!

Another key here is that when we adjust intervals in the `TimestampCache`,
we **NEED** to make sure the ordering in the FIFO queue stays consistent
with interval timestamps. For instance, if we don't move the interval back
in the queue in the value replacement case, intervals will get to a point
where their eviction is blocked on the newly replaced interval. This can
lead to memory growth of upwards of **40 MB**.

Because this optimization does more work during `TimestampCache` insertion, it
is expected that it will hurt performance slightly. That said, if benchmarks are
run as is, they will lead to misleading/incorrect results. This is because the
`MinTSCacheWindow` is currently set to 10 seconds, meaning that pre-optimization
benchmarks never had to perform costly timestamp cache deletions during eviction
because they always finished before this time. Keep in mind while looking at them
that after the 10 seconds, this `MinTSCacheWindow` eviction was previously still
happening synchronously during timestamp insertion, it was just pushing the cost
of deletion 10 seconds into the future. The only real discrepancies in
work comes from the need to now occasionally split intervals, which
results in an additional insertion and an additional deletion from the
cache.

Comparing this PR to #4699:

CPU performance
- Less computation needed on insert because fewer intervals will
  overlap since they will be trimmed as we go.
- This difference can be seen in each change's respective benchmarks.

Memory performance
- Average TSCache size is **3 MB** here vs. **4 MB** there
- #4699 will always have fewer TS cache entries because it does not chop
  up intervals that were superseded in the middle. These chops require
  inserting a whole new cache entry which requires allocations. However,
  only **.05%** of insertions are split in this PR, so it doesn't seem like this
  is causing an issue.
- **32%** of insertions resulting in a direct replacement here vs **~0%** there.
- **.25%** of insertions resulting in a deletion here vs **25%** there.

Perf Impact:

```
name                      old time/op    new time/op    delta
Bank_Cockroach-4             313µs ± 2%     339µs ±10%   +8.29%         (p=0.016 n=8+10)
Select1_Cockroach-4         52.7µs ± 1%    52.6µs ± 1%     ~            (p=0.549 n=9+10)
Select2_Cockroach-4          791µs ± 1%     775µs ± 1%   -2.07%          (p=0.000 n=9+9)
Insert1_Cockroach-4          393µs ±17%     371µs ± 2%     ~           (p=0.190 n=10+10)
Insert10_Cockroach-4         660µs ± 2%     650µs ± 0%   -1.48%          (p=0.001 n=8+9)
Insert100_Cockroach-4       3.39ms ± 1%    3.33ms ± 0%   -1.51%         (p=0.000 n=10+9)
Insert1000_Cockroach-4      33.1ms ± 7%    31.8ms ± 1%   -4.03%         (p=0.000 n=9+10)
Update1_Cockroach-4          591µs ± 9%     566µs ± 1%     ~             (p=0.063 n=9+9)
Update10_Cockroach-4        1.11ms ± 1%    1.10ms ± 0%     ~             (p=0.321 n=9+8)
Update100_Cockroach-4       6.12ms ± 5%    5.98ms ± 1%   -2.30%          (p=0.002 n=8+8)
Update1000_Cockroach-4      55.1ms ±10%    50.9ms ± 1%   -7.73%         (p=0.000 n=9+10)
Delete1_Cockroach-4          785µs ±22%     695µs ± 2%  -11.46%        (p=0.035 n=10+10)
Delete10_Cockroach-4        1.98ms ± 4%    2.09ms ± 3%   +5.36%        (p=0.000 n=10+10)
Delete100_Cockroach-4       18.0ms ±11%    17.3ms ± 1%     ~           (p=0.143 n=10+10)
Delete1000_Cockroach-4       144ms ± 5%     162ms ± 1%  +12.91%         (p=0.000 n=9+10)
Scan1_Cockroach-4            199µs ± 9%     183µs ± 1%   -7.83%        (p=0.015 n=10+10)
Scan10_Cockroach-4           241µs ±15%     215µs ± 1%  -10.74%         (p=0.000 n=10+9)
Scan100_Cockroach-4          478µs ± 1%     473µs ± 1%   -1.21%         (p=0.000 n=8+10)
Scan1000_Cockroach-4        3.12ms ± 5%    2.97ms ± 1%   -4.93%        (p=0.000 n=10+10)
Scan10000_Cockroach-4       32.2ms ± 3%    30.4ms ± 1%   -5.42%         (p=0.000 n=10+9)
PgbenchExec_Cockroach-4     2.83ms ±16%    2.75ms ± 5%     ~           (p=0.684 n=10+10)
PgbenchQuery_Cockroach-4    2.68ms ± 5%    2.63ms ± 3%     ~            (p=0.173 n=8+10)

name                      old alloc/op   new alloc/op   delta
Bank_Cockroach-4            69.1kB ± 1%    69.2kB ± 1%     ~           (p=0.403 n=10+10)
Select1_Cockroach-4         3.90kB ± 0%    3.90kB ± 0%     ~            (p=1.172 n=9+10)
Select2_Cockroach-4         80.5kB ± 0%    80.5kB ± 0%   -0.04%        (p=0.022 n=10+10)
Insert1_Cockroach-4         22.8kB ± 0%    22.7kB ± 0%   -0.12%        (p=0.023 n=10+10)
Insert10_Cockroach-4        66.8kB ± 0%    66.8kB ± 0%     ~           (p=0.565 n=10+10)
Insert100_Cockroach-4        506kB ± 0%     505kB ± 0%     ~            (p=0.156 n=10+9)
Insert1000_Cockroach-4      4.53MB ± 1%    4.51MB ± 0%   -0.51%         (p=0.008 n=10+9)
Update1_Cockroach-4         36.4kB ± 0%    36.4kB ± 0%     ~           (p=0.739 n=10+10)
Update10_Cockroach-4        98.8kB ± 0%    98.8kB ± 0%     ~           (p=0.382 n=10+10)
Update100_Cockroach-4        701kB ± 0%     699kB ± 0%   -0.30%        (p=0.023 n=10+10)
Update1000_Cockroach-4      6.05MB ± 0%    6.06MB ± 1%     ~            (p=0.780 n=9+10)
Delete1_Cockroach-4         35.3kB ± 0%    35.6kB ± 0%   +0.79%         (p=0.000 n=10+9)
Delete10_Cockroach-4         105kB ± 0%     108kB ± 0%   +2.56%         (p=0.000 n=10+9)
Delete100_Cockroach-4        788kB ± 0%     815kB ± 0%   +3.33%          (p=0.000 n=9+9)
Delete1000_Cockroach-4      7.13MB ± 1%    7.37MB ± 1%   +3.33%        (p=0.000 n=10+10)
Scan1_Cockroach-4           13.1kB ± 0%    13.1kB ± 0%     ~           (p=0.810 n=10+10)
Scan10_Cockroach-4          17.0kB ± 0%    17.0kB ± 0%   -0.15%         (p=0.041 n=9+10)
Scan100_Cockroach-4         49.2kB ± 0%    49.2kB ± 0%     ~           (p=0.955 n=10+10)
Scan1000_Cockroach-4         331kB ± 0%     331kB ± 0%   -0.04%        (p=0.000 n=10+10)
Scan10000_Cockroach-4       5.74MB ± 0%    5.72MB ± 0%   -0.37%        (p=0.000 n=10+10)
PgbenchExec_Cockroach-4      169kB ± 9%     174kB ±12%     ~             (p=0.387 n=9+9)
PgbenchQuery_Cockroach-4     213kB ± 0%     213kB ± 0%   +0.07%         (p=0.001 n=8+10)

name                      old allocs/op  new allocs/op  delta
Bank_Cockroach-4             1.67k ± 0%     1.68k ± 1%     ~            (p=0.633 n=8+10)
Select1_Cockroach-4           97.0 ± 0%      97.0 ± 0%     ~     (all samples are equal)
Select2_Cockroach-4          2.70k ± 0%     2.70k ± 0%     ~     (all samples are equal)
Insert1_Cockroach-4            352 ± 0%       352 ± 0%   -0.14%         (p=0.022 n=9+10)
Insert10_Cockroach-4           903 ± 0%       902 ± 0%     ~           (p=0.720 n=10+10)
Insert100_Cockroach-4        6.17k ± 0%     6.17k ± 0%     ~            (p=0.249 n=10+9)
Insert1000_Cockroach-4       58.8k ± 0%     58.7k ± 0%   -0.20%         (p=0.020 n=10+9)
Update1_Cockroach-4            712 ± 0%       712 ± 0%     ~     (all samples are equal)
Update10_Cockroach-4         1.40k ± 0%     1.40k ± 0%     ~           (p=0.720 n=10+10)
Update100_Cockroach-4        7.93k ± 0%     7.90k ± 0%     ~           (p=0.057 n=10+10)
Update1000_Cockroach-4       70.0k ± 0%     70.0k ± 1%     ~            (p=1.000 n=9+10)
Delete1_Cockroach-4            681 ± 0%       684 ± 0%   +0.46%        (p=0.000 n=10+10)
Delete10_Cockroach-4         1.66k ± 0%     1.69k ± 0%   +1.79%        (p=0.000 n=10+10)
Delete100_Cockroach-4        11.1k ± 0%     11.4k ± 0%   +2.66%          (p=0.000 n=8+8)
Delete1000_Cockroach-4        106k ± 0%      108k ± 0%   +2.52%        (p=0.000 n=10+10)
Scan1_Cockroach-4              272 ± 0%       272 ± 0%     ~     (all samples are equal)
Scan10_Cockroach-4             352 ± 0%       352 ± 0%     ~           (p=0.577 n=10+10)
Scan100_Cockroach-4          1.08k ± 0%     1.08k ± 0%     ~           (p=1.000 n=10+10)
Scan1000_Cockroach-4         8.29k ± 0%     8.29k ± 0%     ~     (all samples are equal)
Scan10000_Cockroach-4        80.4k ± 0%     80.4k ± 0%   +0.01%         (p=0.000 n=10+9)
PgbenchExec_Cockroach-4      3.29k ±21%     3.37k ±17%     ~           (p=0.436 n=10+10)
PgbenchQuery_Cockroach-4     3.87k ± 0%     3.88k ± 0%   +0.23%         (p=0.000 n=8+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4789)

<!-- Reviewable:end -->
