### PR TITLE
Only check sequence cache for txn writes

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1617,6 +1617,29 @@ func TestRangeSequenceCacheStoredTxnRetryError(t *testing.T) {
 	}
 }
 
+// TestRangeSequenceCacheOnlyWithIntent verifies that a transactional command
+// which goes through Raft but is not a transactional write (i.e. does not
+// leave intents) passes the sequence cache unhindered.
+func TestRangeSequenceCacheOnlyWithIntent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+
+	txn := newTransaction("test", []byte("test"), 10, roachpb.SERIALIZABLE, tc.clock)
+	txn.Sequence = 100
+	if err := tc.rng.sequence.Put(tc.engine, nil, txn.ID, uint32(txn.Epoch), txn.Sequence, txn.Key, txn.Timestamp, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	args, h := heartbeatArgs(txn)
+	// If the sequence cache were active for this request, we'd catch a txn retry.
+	// Instead, we expect the error from heartbeating a nonexistent txn.
+	if _, pErr := client.SendWrappedWith(tc.Sender(), tc.rng.context(), h, &args); !testutils.IsPError(pErr, "record not present") {
+		t.Fatal(pErr)
+	}
+}
+
 // TestEndTransactionDeadline verifies that EndTransaction respects the
 // transaction deadline.
 func TestEndTransactionDeadline(t *testing.T) {


### PR DESCRIPTION
Fixes #4781. We erroneously checked the sequence cache for all `Write`
commands, but we only need to do it for commands which leave intents.
TestTxnCoordSenderHeartbeat failed spuriously because the transaction
it uses to heartbeat does not update its sequence number (which would
also not happen in practice, at least not instantly).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4795)

<!-- Reviewable:end -->
