### PR TITLE
Recommend that comments are wrapped at 80 characters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ fairly closely. In particular, you want to watch out for proper
 punctuation and capitalization in comments. We use two-space indents
 in non-Go code (in Go, we follow `gofmt` which indents with
 tabs). Format your code assuming it will be read in a window 100
-columns wide. Wrap code and comments at 100 characters unless doing so
+columns wide. Wrap code at 100 characters and comments at 80 unless doing so
 makes the code less legible.
 
 ### Code review workflow


### PR DESCRIPTION
80 is the recommended line length for comments in
https://github.com/golang/go/wiki/CodeReviewComments#line-length.

It is also closer to the optimal length for english text (which is believed to
be around 55-75) and is a common limit in other style guides.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4796)

<!-- Reviewable:end -->
