### PR TITLE
sql: track uniqueness of results in ordering information

### DIFF
--- a/sql/ordering_test.go
+++ b/sql/ordering_test.go
@@ -55,20 +55,22 @@ func TestComputeOrderingMatch(t *testing.T) {
 	desc := encoding.Descending
 	testSets := []computeOrderCase{
 		{
-			// No existing ordering
+			// No existing ordering.
 			existing: orderingInfo{
 				exactMatchCols: nil,
 				ordering:       nil,
+				unique:         false,
 			},
 			cases: []desiredCase{
 				defTestCase(0, 0, columnOrdering{{1, desc}, {5, asc}}),
 			},
 		},
 		{
-			// Ordering with no exact-match columns
+			// Ordering with no exact-match columns.
 			existing: orderingInfo{
 				exactMatchCols: nil,
 				ordering:       []columnOrderInfo{{1, desc}, {2, asc}},
+				unique:         false,
 			},
 			cases: []desiredCase{
 				defTestCase(1, 0, columnOrdering{{1, desc}, {5, asc}}),
@@ -76,10 +78,27 @@ func TestComputeOrderingMatch(t *testing.T) {
 			},
 		},
 		{
-			// Ordering with only exact-match columns
+			// Ordering with no exact-match columns but with distinct.
+			existing: orderingInfo{
+				exactMatchCols: nil,
+				ordering:       []columnOrderInfo{{1, desc}, {2, asc}},
+				unique:         true,
+			},
+			cases: []desiredCase{
+				defTestCase(1, 0, columnOrdering{{1, desc}, {5, asc}}),
+				defTestCase(3, 0, columnOrdering{{1, desc}, {2, asc}, {5, asc}}),
+				defTestCase(4, 0, columnOrdering{{1, desc}, {2, asc}, {5, asc}, {6, desc}}),
+				defTestCase(0, 1, columnOrdering{{1, asc}, {5, asc}, {2, asc}}),
+				defTestCase(0, 3, columnOrdering{{1, asc}, {2, desc}, {5, asc}}),
+				defTestCase(0, 4, columnOrdering{{1, asc}, {2, desc}, {5, asc}, {6, asc}}),
+			},
+		},
+		{
+			// Ordering with only exact-match columns.
 			existing: orderingInfo{
 				exactMatchCols: map[int]struct{}{1: e, 2: e},
 				ordering:       nil,
+				unique:         false,
 			},
 			cases: []desiredCase{
 				defTestCase(1, 1, columnOrdering{{2, desc}, {5, asc}, {1, asc}}),
@@ -87,15 +106,37 @@ func TestComputeOrderingMatch(t *testing.T) {
 			},
 		},
 		{
+			// Ordering with exact-match columns.
 			existing: orderingInfo{
 				exactMatchCols: map[int]struct{}{0: e, 5: e, 6: e},
 				ordering:       []columnOrderInfo{{1, desc}, {2, asc}},
+				unique:         false,
 			},
 			cases: []desiredCase{
 				defTestCase(2, 0, columnOrdering{{1, desc}, {5, asc}}),
+				defTestCase(2, 1, columnOrdering{{5, asc}, {1, desc}}),
 				defTestCase(2, 2, columnOrdering{{0, desc}, {5, asc}}),
 				defTestCase(1, 0, columnOrdering{{1, desc}, {2, desc}}),
 				defTestCase(5, 2, columnOrdering{{0, asc}, {6, desc}, {1, desc}, {5, desc}, {2, asc}}),
+				defTestCase(2, 2, columnOrdering{{0, asc}, {6, desc}, {2, asc}, {5, desc}, {1, desc}}),
+			},
+		},
+		{
+			// Ordering with exact-match columns and distinct.
+			existing: orderingInfo{
+				exactMatchCols: map[int]struct{}{0: e, 5: e, 6: e},
+				ordering:       []columnOrderInfo{{1, desc}, {2, asc}},
+				unique:         true,
+			},
+			cases: []desiredCase{
+				defTestCase(2, 0, columnOrdering{{1, desc}, {5, asc}}),
+				defTestCase(2, 1, columnOrdering{{5, asc}, {1, desc}}),
+				defTestCase(4, 0, columnOrdering{{1, desc}, {5, asc}, {2, asc}, {7, desc}}),
+				defTestCase(4, 1, columnOrdering{{5, asc}, {1, desc}, {2, asc}, {7, desc}}),
+				defTestCase(2, 2, columnOrdering{{0, desc}, {5, asc}}),
+				defTestCase(2, 1, columnOrdering{{5, asc}, {1, desc}, {2, desc}}),
+				defTestCase(1, 0, columnOrdering{{1, desc}, {2, desc}}),
+				defTestCase(6, 2, columnOrdering{{0, asc}, {6, desc}, {1, desc}, {5, desc}, {2, asc}, {9, asc}}),
 				defTestCase(2, 2, columnOrdering{{0, asc}, {6, desc}, {2, asc}, {5, desc}, {1, desc}}),
 			},
 		},

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -397,6 +397,8 @@ func (n *scanNode) computeOrdering(index *IndexDescriptor, exactPrefix int, reve
 			ordering.addColumn(idx, dir)
 		}
 	}
+	// We included any implicit columns, so the results are unique.
+	ordering.unique = true
 	return ordering
 }
 

--- a/sql/select.go
+++ b/sql/select.go
@@ -611,10 +611,12 @@ func (s *selectNode) computeOrdering(fromOrder orderingInfo) orderingInfo {
 		colRef := columnRef{&s.table, colOrder.colIdx}
 		renderIdx, ok := s.findRenderIndexForCol(colRef)
 		if !ok {
-			break
+			return ordering
 		}
 		ordering.addColumn(renderIdx, colOrder.direction)
 	}
+	// We added all columns in fromOrder; we can copy the distinct flag.
+	ordering.unique = fromOrder.unique
 	return ordering
 }
 

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -89,6 +89,18 @@ EXPLAIN SELECT b FROM t ORDER BY a DESC
 0 nosort -a
 1 revscan t@primary -
 
+query ITT
+EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
+----
+0 nosort -a,+b
+1 revscan t@primary -
+
+query ITT
+EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
+----
+0 nosort -a,-b
+1 revscan t@primary -
+
 statement ok
 INSERT INTO t VALUES (4, 7), (5, 7)
 
@@ -191,6 +203,49 @@ query ITT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, a
 ----
 0 scan abc@ba -
+
+# The non-unique index ba includes column c (required to make the keys unique)
+# so the results will already be sorted.
+query ITT
+EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
+----
+0 scan abc@ba -
+
+# We use the WHERE condition to force the use of index ba.
+query ITT
+EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
+----
+0 sort       +b,+a,+d
+1 index-join
+2 scan       abc@ba /11-
+2 scan       abc@primary
+
+# We cannot have rows with identical values for a,b,c so we don't need to
+# sort for d.
+query ITT
+EXPLAIN SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
+----
+0 index-join
+1 scan       abc@ba /11-
+1 scan       abc@primary
+
+query ITT
+EXPLAIN SELECT a, b FROM abc ORDER BY b, c
+----
+0 nosort +b,+c
+1 scan   abc@bc -
+
+query ITT
+EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
+----
+0 nosort +b,+c,+a
+1 scan   abc@bc -
+
+query ITT
+EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
+----
+0 nosort +b,+c,-a
+1 scan   abc@bc -
 
 query ITTT
 EXPLAIN (DEBUG) SELECT b, c FROM abc ORDER BY b, c


### PR DESCRIPTION
Consider a very basic example: on `TABLE kv (k INT PRIMARY KEY, v INT)`
we do a `SELECT * from kv ORDER BY k, v`.

Before this change we would sort the results but that's not necessary: the
data is already sorted by `k` and there are no duplicate values of `k` so the
extra refinement by `v` can be ignored.

In this change we fix cases like this by adding a `unique` flag to
`orderingInfo`; if set it indicates that we cannot have duplicate tuples for the
columns in the ordering (and thus any further refinement of results by other
columns is a no-op).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4798)

<!-- Reviewable:end -->
