### PR TITLE
fix broken overview for secure mode

### DIFF
--- a/ui/ts/models/events.ts
+++ b/ui/ts/models/events.ts
@@ -146,6 +146,8 @@ module Models {
           });
           this.normalizedRows = this.convertToNormalizedRows(<RangeRow[]>promises[0], <EventRow[]>promises[1]);
           this.updated = moment();
+        }).catch((error) => {
+          this.normalizedRows = [];
         });
       }
 

--- a/ui/ts/models/sqlquery.ts
+++ b/ui/ts/models/sqlquery.ts
@@ -94,6 +94,15 @@ module Models {
         config: xhrConfig,
         method: "POST",
         data: data,
+        // Otherwise this breaks when it doesn't receive JSON
+        deserialize: (d): any => {
+          try {
+            return JSON.parse(d);
+          } catch (e) {
+            console.error(e);
+            return null;
+          }
+        },
       });
 
       if (parse) {


### PR DESCRIPTION
This fixes the issue where, when running in secure mode, the cluster overview is currently blank.

cc @tamird once this goes in you can remove the SQL endpoint

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4809)

<!-- Reviewable:end -->
