### PR TITLE
Observe timestamp for uncertainty on every request

### DIFF
--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -443,7 +443,7 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 		err   error
 		retry bool // Expect retry?
 	}{
-		{&roachpb.ReadWithinUncertaintyIntervalError{}, true},
+		{roachpb.NewReadWithinUncertaintyIntervalError(roachpb.ZeroTimestamp, roachpb.ZeroTimestamp), true},
 		{&roachpb.TransactionAbortedError{}, true},
 		{&roachpb.TransactionPushError{}, true},
 		{&roachpb.TransactionRetryError{}, true},
@@ -495,7 +495,7 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 		err   error
 		abort bool
 	}{
-		{&roachpb.ReadWithinUncertaintyIntervalError{}, true},
+		{roachpb.NewReadWithinUncertaintyIntervalError(roachpb.ZeroTimestamp, roachpb.ZeroTimestamp), true},
 		{&roachpb.TransactionAbortedError{}, false},
 		{&roachpb.TransactionPushError{}, true},
 		{&roachpb.TransactionRetryError{}, true},

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -470,7 +470,7 @@ func (ds *DistSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 			// something of size zero but with capacity, we don't re-use the
 			// existing space (which others may also use). This is just to
 			// satisfy paranoia/OCD and not expected to matter in practice.
-			txnShallow.ObservedTimestamps = nil
+			txnShallow.ResetObservedTimestamps()
 			// OrigTimestamp is the HLC timestamp at which the Txn started, so
 			// this effectively means no more uncertainty on this node.
 			txnShallow.UpdateObservedTimestamp(nDesc.NodeID, txnShallow.OrigTimestamp)

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -476,10 +476,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 	storage.TestingCommandFilter = func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
 		if _, ok := args.(*roachpb.ConditionalPutRequest); ok && args.Header().Key.Equal(targetKey) {
 			if atomic.AddInt32(&numGets, 1) == 1 {
-				return &roachpb.ReadWithinUncertaintyIntervalError{
-					Timestamp:         h.Timestamp,
-					ExistingTimestamp: h.Timestamp,
-				}
+				return roachpb.NewReadWithinUncertaintyIntervalError(roachpb.ZeroTimestamp, roachpb.ZeroTimestamp)
 
 			}
 		}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -398,9 +398,9 @@ func TestOwnNodeCertain(t *testing.T) {
 	v := roachpb.MakeValueFromString("value")
 	put := roachpb.NewPut(roachpb.Key("a"), v)
 	if _, err := client.SendWrappedWith(ds, nil, roachpb.Header{
-		// ObservedTimestamp is set very high so that all uncertainty updates have
+		// MaxTimestamp is set very high so that all uncertainty updates have
 		// effect.
-		Txn: &roachpb.Transaction{OrigTimestamp: expTS, ObservedTimestamp: roachpb.MaxTimestamp},
+		Txn: &roachpb.Transaction{OrigTimestamp: expTS, MaxTimestamp: roachpb.MaxTimestamp},
 	}, put); err != nil {
 		t.Fatalf("put encountered error: %s", err)
 	}

--- a/roachpb/data.pb.go
+++ b/roachpb/data.pb.go
@@ -419,16 +419,16 @@ type Transaction struct {
 	// transaction will retry.
 	OrigTimestamp Timestamp `protobuf:"bytes,6,opt,name=orig_timestamp" json:"orig_timestamp"`
 	// Initial Timestamp + clock skew. Reads which encounter values with
-	// timestamps between timestamp and observed_timestamp trigger a txn
-	// retry error, unless the node being read is listed in certain_nodes
+	// timestamps between timestamp and max_timestamp trigger a txn
+	// retry error, unless the node being read is listed in observed_timestamps
 	// (in which case no more read uncertainty can occur).
-	// The case observed_timestamp < timestamp is possible for transactions which have
-	// been pushed; in this case, observed_timestamp should be ignored.
-	ObservedTimestamp Timestamp `protobuf:"bytes,7,opt,name=observed_timestamp" json:"observed_timestamp"`
+	// The case max_timestamp < timestamp is possible for transactions which have
+	// been pushed; in this case, max_timestamp should be ignored.
+	MaxTimestamp Timestamp `protobuf:"bytes,7,opt,name=max_timestamp" json:"max_timestamp"`
 	// A map of NodeID to timestamps as observed from their local clock during
 	// this transaction. The purpose of this map is to avoid uncertainty related
 	// restarts which normally occur when reading a value in the near future as
-	// per the observed_timestamp field.
+	// per the max_timestamp field.
 	// When this map holds a corresponding entry for the node the current request
 	// is executing on, we can run the command with the map's timestamp as the
 	// top boundary of our uncertainty interval, limiting (and often avoiding)
@@ -959,8 +959,8 @@ func (m *Transaction) MarshalTo(data []byte) (int, error) {
 	i += n17
 	data[i] = 0x3a
 	i++
-	i = encodeVarintData(data, i, uint64(m.ObservedTimestamp.Size()))
-	n18, err := m.ObservedTimestamp.MarshalTo(data[i:])
+	i = encodeVarintData(data, i, uint64(m.MaxTimestamp.Size()))
+	n18, err := m.MaxTimestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -1305,7 +1305,7 @@ func (m *Transaction) Size() (n int) {
 	}
 	l = m.OrigTimestamp.Size()
 	n += 1 + l + sovData(uint64(l))
-	l = m.ObservedTimestamp.Size()
+	l = m.MaxTimestamp.Size()
 	n += 1 + l + sovData(uint64(l))
 	if len(m.ObservedTimestamps) > 0 {
 		for k, v := range m.ObservedTimestamps {
@@ -2927,7 +2927,7 @@ func (m *Transaction) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 7:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ObservedTimestamp", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxTimestamp", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2951,7 +2951,7 @@ func (m *Transaction) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.ObservedTimestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
+			if err := m.MaxTimestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -251,16 +251,16 @@ message Transaction {
   // transaction will retry.
   optional Timestamp orig_timestamp = 6 [(gogoproto.nullable) = false];
   // Initial Timestamp + clock skew. Reads which encounter values with
-  // timestamps between timestamp and observed_timestamp trigger a txn
-  // retry error, unless the node being read is listed in certain_nodes
+  // timestamps between timestamp and max_timestamp trigger a txn
+  // retry error, unless the node being read is listed in observed_timestamps
   // (in which case no more read uncertainty can occur).
-  // The case observed_timestamp < timestamp is possible for transactions which have
-  // been pushed; in this case, observed_timestamp should be ignored.
-  optional Timestamp observed_timestamp = 7 [(gogoproto.nullable) = false];
+  // The case max_timestamp < timestamp is possible for transactions which have
+  // been pushed; in this case, max_timestamp should be ignored.
+  optional Timestamp max_timestamp = 7 [(gogoproto.nullable) = false];
   // A map of NodeID to timestamps as observed from their local clock during
   // this transaction. The purpose of this map is to avoid uncertainty related
   // restarts which normally occur when reading a value in the near future as
-  // per the observed_timestamp field.
+  // per the max_timestamp field.
   // When this map holds a corresponding entry for the node the current request
   // is executing on, we can run the command with the map's timestamp as the
   // top boundary of our uncertainty interval, limiting (and often avoiding)

--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -444,6 +444,16 @@ func (e *WriteTooOldError) message(pErr *Error) string {
 
 var _ ErrorDetailInterface = &WriteTooOldError{}
 
+// NewReadWithinUncertaintyIntervalError creates a new uncertainty retry error.
+// The read and existing timestamps are purely informational and used for
+// formatting the error message.
+func NewReadWithinUncertaintyIntervalError(readTS, existingTS Timestamp) *ReadWithinUncertaintyIntervalError {
+	return &ReadWithinUncertaintyIntervalError{
+		ReadTimestamp:     readTS,
+		ExistingTimestamp: existingTS,
+	}
+}
+
 // Error formats error.
 func (e *ReadWithinUncertaintyIntervalError) Error() string {
 	return e.message(nil)
@@ -451,7 +461,7 @@ func (e *ReadWithinUncertaintyIntervalError) Error() string {
 
 // message returns an error message.
 func (e *ReadWithinUncertaintyIntervalError) message(pErr *Error) string {
-	return fmt.Sprintf("read at time %s encountered previous write with future timestamp %s within uncertainty interval", e.Timestamp, e.ExistingTimestamp)
+	return fmt.Sprintf("read at time %s encountered previous write with future timestamp %s within uncertainty interval", e.ReadTimestamp, e.ExistingTimestamp)
 }
 
 var _ ErrorDetailInterface = &ReadWithinUncertaintyIntervalError{}

--- a/roachpb/errors.pb.go
+++ b/roachpb/errors.pb.go
@@ -106,13 +106,14 @@ func (m *RangeKeyMismatchError) String() string { return proto.CompactTextString
 func (*RangeKeyMismatchError) ProtoMessage()    {}
 
 // A ReadWithinUncertaintyIntervalError indicates that a read at timestamp
-// encountered a versioned value at existing_timestamp within the uncertainty
-// interval of the reader.
-// The read should be retried at existing_timestamp+1.
+// encountered a write within the uncertainty interval of the reader.
+// The read should be retried at a higher timestamp; the timestamps contained
+// within are purely informational, though typically existing_timestamp is a
+// lower bound for a new timestamp at which at least the read producing
+// this error would succeed on retry.
 type ReadWithinUncertaintyIntervalError struct {
-	Timestamp         Timestamp `protobuf:"bytes,1,opt,name=timestamp" json:"timestamp"`
+	ReadTimestamp     Timestamp `protobuf:"bytes,1,opt,name=read_timestamp" json:"read_timestamp"`
 	ExistingTimestamp Timestamp `protobuf:"bytes,2,opt,name=existing_timestamp" json:"existing_timestamp"`
-	NodeID            NodeID    `protobuf:"varint,3,opt,name=node_id,casttype=NodeID" json:"node_id"`
 }
 
 func (m *ReadWithinUncertaintyIntervalError) Reset()         { *m = ReadWithinUncertaintyIntervalError{} }
@@ -345,14 +346,16 @@ type Error struct {
 	// If transaction_restart is not ABORT, the error condition may be handled by
 	// restarting the transaction (with or without a backoff).
 	TransactionRestart TransactionRestart `protobuf:"varint,3,opt,name=transaction_restart,enum=cockroach.roachpb.TransactionRestart" json:"transaction_restart"`
-	// Transaction where the error is generated.
-	UnexposedTxn *Transaction `protobuf:"bytes,4,opt,name=txn" json:"txn,omitempty"`
+	// An optional transaction related to this error. Not to be accessed directly.
+	UnexposedTxn *Transaction `protobuf:"bytes,4,opt,name=unexposed_txn" json:"unexposed_txn,omitempty"`
+	// Node at which the error was generated (zero if does not apply).
+	OriginNode NodeID `protobuf:"varint,5,opt,name=origin_node,casttype=NodeID" json:"origin_node"`
 	// If an ErrorDetail is present, it may contain additional structured data
 	// about the error.
-	Detail *ErrorDetail `protobuf:"bytes,5,opt,name=detail" json:"detail,omitempty"`
+	Detail *ErrorDetail `protobuf:"bytes,6,opt,name=detail" json:"detail,omitempty"`
 	// The index, if given, contains the index of the request (in the batch)
 	// whose execution caused the error.
-	Index *ErrPosition `protobuf:"bytes,6,opt,name=index" json:"index,omitempty"`
+	Index *ErrPosition `protobuf:"bytes,7,opt,name=index" json:"index,omitempty"`
 }
 
 func (m *Error) Reset()      { *m = Error{} }
@@ -522,8 +525,8 @@ func (m *ReadWithinUncertaintyIntervalError) MarshalTo(data []byte) (int, error)
 	_ = l
 	data[i] = 0xa
 	i++
-	i = encodeVarintErrors(data, i, uint64(m.Timestamp.Size()))
-	n4, err := m.Timestamp.MarshalTo(data[i:])
+	i = encodeVarintErrors(data, i, uint64(m.ReadTimestamp.Size()))
+	n4, err := m.ReadTimestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
@@ -536,9 +539,6 @@ func (m *ReadWithinUncertaintyIntervalError) MarshalTo(data []byte) (int, error)
 		return 0, err
 	}
 	i += n5
-	data[i] = 0x18
-	i++
-	i = encodeVarintErrors(data, i, uint64(m.NodeID))
 	return i, nil
 }
 
@@ -1233,8 +1233,11 @@ func (m *Error) MarshalTo(data []byte) (int, error) {
 		}
 		i += n33
 	}
+	data[i] = 0x28
+	i++
+	i = encodeVarintErrors(data, i, uint64(m.OriginNode))
 	if m.Detail != nil {
-		data[i] = 0x2a
+		data[i] = 0x32
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Detail.Size()))
 		n34, err := m.Detail.MarshalTo(data[i:])
@@ -1244,7 +1247,7 @@ func (m *Error) MarshalTo(data []byte) (int, error) {
 		i += n34
 	}
 	if m.Index != nil {
-		data[i] = 0x32
+		data[i] = 0x3a
 		i++
 		i = encodeVarintErrors(data, i, uint64(m.Index.Size()))
 		n35, err := m.Index.MarshalTo(data[i:])
@@ -1332,11 +1335,10 @@ func (m *RangeKeyMismatchError) Size() (n int) {
 func (m *ReadWithinUncertaintyIntervalError) Size() (n int) {
 	var l int
 	_ = l
-	l = m.Timestamp.Size()
+	l = m.ReadTimestamp.Size()
 	n += 1 + l + sovErrors(uint64(l))
 	l = m.ExistingTimestamp.Size()
 	n += 1 + l + sovErrors(uint64(l))
-	n += 1 + sovErrors(uint64(m.NodeID))
 	return n
 }
 
@@ -1575,6 +1577,7 @@ func (m *Error) Size() (n int) {
 		l = m.UnexposedTxn.Size()
 		n += 1 + l + sovErrors(uint64(l))
 	}
+	n += 1 + sovErrors(uint64(m.OriginNode))
 	if m.Detail != nil {
 		l = m.Detail.Size()
 		n += 1 + l + sovErrors(uint64(l))
@@ -2145,7 +2148,7 @@ func (m *ReadWithinUncertaintyIntervalError) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field ReadTimestamp", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2169,7 +2172,7 @@ func (m *ReadWithinUncertaintyIntervalError) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if err := m.Timestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
+			if err := m.ReadTimestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -2203,25 +2206,6 @@ func (m *ReadWithinUncertaintyIntervalError) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field NodeID", wireType)
-			}
-			m.NodeID = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowErrors
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				m.NodeID |= (NodeID(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipErrors(data[iNdEx:])
@@ -4376,6 +4360,25 @@ func (m *Error) Unmarshal(data []byte) error {
 			}
 			iNdEx = postIndex
 		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OriginNode", wireType)
+			}
+			m.OriginNode = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowErrors
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.OriginNode |= (NodeID(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 6:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Detail", wireType)
 			}
@@ -4408,7 +4411,7 @@ func (m *Error) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 6:
+		case 7:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Index", wireType)
 			}

--- a/roachpb/errors.proto
+++ b/roachpb/errors.proto
@@ -59,13 +59,14 @@ message RangeKeyMismatchError {
 }
 
 // A ReadWithinUncertaintyIntervalError indicates that a read at timestamp
-// encountered a versioned value at existing_timestamp within the uncertainty
-// interval of the reader.
-// The read should be retried at existing_timestamp+1.
+// encountered a write within the uncertainty interval of the reader.
+// The read should be retried at a higher timestamp; the timestamps contained
+// within are purely informational, though typically existing_timestamp is a
+// lower bound for a new timestamp at which at least the read producing
+// this error would succeed on retry.
 message ReadWithinUncertaintyIntervalError {
-  optional Timestamp timestamp = 1 [(gogoproto.nullable) = false];
+  optional Timestamp read_timestamp = 1 [(gogoproto.nullable) = false];
   optional Timestamp existing_timestamp = 2 [(gogoproto.nullable) = false];
-  optional int32 node_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeID", (gogoproto.casttype) = "NodeID"];
 }
 
 // A TransactionAbortedError indicates that the transaction was
@@ -246,14 +247,17 @@ message Error {
   // restarting the transaction (with or without a backoff).
   optional TransactionRestart transaction_restart = 3 [(gogoproto.nullable) = false];
 
-  // Transaction where the error is generated.
-  optional Transaction txn = 4 [(gogoproto.customname) = "UnexposedTxn"];
+  // An optional transaction related to this error. Not to be accessed directly.
+  optional Transaction unexposed_txn = 4;
+
+  // Node at which the error was generated (zero if does not apply).
+  optional int32 origin_node = 5 [(gogoproto.nullable) = false, (gogoproto.casttype) = "NodeID" ];
 
   // If an ErrorDetail is present, it may contain additional structured data
   // about the error.
-  optional ErrorDetail detail = 5;
+  optional ErrorDetail detail = 6;
 
   // The index, if given, contains the index of the request (in the batch)
   // whose execution caused the error.
-  optional ErrPosition index = 6;
+  optional ErrPosition index = 7;
 }

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -244,7 +244,7 @@ func (t *logicTest) setup() {
 	// MySQL or Postgres instance.
 	ctx := server.NewTestContext()
 	ctx.MaxOffset = logicMaxOffset
-	t.srv = setupTestServer(t.T)
+	t.srv = setupTestServerWithContext(t.T, ctx)
 
 	// db may change over the lifetime of this function, with intermediate
 	// values cached in t.clients and finally closed in t.close().

--- a/sql/testdata/snapshot_certain_read
+++ b/sql/testdata/snapshot_certain_read
@@ -1,6 +1,6 @@
 # This test verifies that when a SNAPSHOT transaction reads without
 # uncertainty, it actually does that. We had a performance bug which caused the
-# ObservedTimestamp to be set to the Timestamp instead of OrigTimestamp on such
+# MaxTimestamp to be set to the Timestamp instead of OrigTimestamp on such
 # reads, which always left the interval (OrigTimestamp, Timestamp) open to
 # read uncertainty errors.
 

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -38,10 +38,7 @@ func injectRetriableErrors(
 	for _, val := range magicVals {
 		if restarts[val] < 2 && bytes.Contains(cput.Value.RawBytes, []byte(val)) {
 			restarts[val]++
-			return &roachpb.ReadWithinUncertaintyIntervalError{
-				Timestamp:         hdr.Timestamp,
-				ExistingTimestamp: hdr.Timestamp,
-			}
+			return roachpb.NewReadWithinUncertaintyIntervalError(roachpb.ZeroTimestamp, roachpb.ZeroTimestamp)
 		}
 	}
 	return nil

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -590,12 +590,12 @@ func mvccGetUsingIter(iter Iterator, key roachpb.Key, timestamp roachpb.Timestam
 // The read is carried out without the chance of uncertainty restarts.
 func MVCCGetAsTxn(engine Engine, key roachpb.Key, timestamp roachpb.Timestamp, consistent bool, txnMeta roachpb.TxnMeta) (*roachpb.Value, []roachpb.Intent, error) {
 	txn := &roachpb.Transaction{
-		TxnMeta:           txnMeta,
-		Priority:          roachpb.MakePriority(roachpb.MinUserPriority),
-		Status:            roachpb.PENDING,
-		Writing:           true,
-		OrigTimestamp:     txnMeta.Timestamp,
-		ObservedTimestamp: txnMeta.Timestamp,
+		TxnMeta:       txnMeta,
+		Priority:      roachpb.MakePriority(roachpb.MinUserPriority),
+		Status:        roachpb.PENDING,
+		Writing:       true,
+		OrigTimestamp: txnMeta.Timestamp,
+		MaxTimestamp:  txnMeta.Timestamp,
 	}
 	return MVCCGet(engine, key, timestamp, consistent, txn)
 }
@@ -711,26 +711,24 @@ func mvccGetInternal(iter Iterator, metaKey MVCCKey,
 			}
 			seekKey = seekKey.Next()
 		}
-	} else if txn != nil && timestamp.Less(txn.ObservedTimestamp) {
+	} else if txn != nil && timestamp.Less(txn.MaxTimestamp) {
 		// In this branch, the latest timestamp is ahead, and so the read of an
-		// "old" value in a transactional context at time (timestamp, ObservedTimestamp]
+		// "old" value in a transactional context at time (timestamp, MaxTimestamp]
 		// occurs, leading to a clock uncertainty error if a version exists in
 		// that time interval.
-		if !txn.ObservedTimestamp.Less(meta.Timestamp) {
+		if !txn.MaxTimestamp.Less(meta.Timestamp) {
 			// Second case: Our read timestamp is behind the latest write, but the
 			// latest write could possibly have happened before our read in
 			// absolute time if the writer had a fast clock.
 			// The reader should try again with a later timestamp than the
 			// one given below.
-			return nil, nil, &roachpb.ReadWithinUncertaintyIntervalError{
-				Timestamp:         timestamp,
-				ExistingTimestamp: meta.Timestamp,
-			}
+			return nil, nil, roachpb.NewReadWithinUncertaintyIntervalError(
+				timestamp, meta.Timestamp)
 		}
 
 		// We want to know if anything has been written ahead of timestamp, but
-		// before ObservedTimestamp.
-		seekKey.Timestamp = txn.ObservedTimestamp
+		// before MaxTimestamp.
+		seekKey.Timestamp = txn.MaxTimestamp
 		checkValueTimestamp = true
 	} else {
 		// Third case: We're reading a historic value either outside of a
@@ -767,12 +765,10 @@ func mvccGetInternal(iter Iterator, metaKey MVCCKey,
 			// value, but there is another previous write with the same issues as in
 			// the second case, so the reader will have to come again with a higher
 			// read timestamp.
-			return nil, nil, &roachpb.ReadWithinUncertaintyIntervalError{
-				Timestamp:         timestamp,
-				ExistingTimestamp: unsafeKey.Timestamp,
-			}
+			return nil, nil, roachpb.NewReadWithinUncertaintyIntervalError(
+				timestamp, unsafeKey.Timestamp)
 		}
-		// Fifth case: There's no value in our future up to ObservedTimestamp, and those
+		// Fifth case: There's no value in our future up to MaxTimestamp, and those
 		// are the only ones that we're not certain about. The correct key has
 		// already been read above, so there's nothing left to do.
 	}

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.cc
@@ -274,7 +274,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fdata_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, status_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, last_heartbeat_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, orig_timestamp_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, observed_timestamp_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, max_timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, observed_timestamps_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, writing_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Transaction, sequence_),
@@ -488,42 +488,41 @@ void protobuf_AddDesc_cockroach_2froachpb_2fdata_2eproto() {
     " .cockroach.roachpb.IsolationTypeB\004\310\336\037\000\022"
     "\024\n\003key\030\003 \001(\014B\007\372\336\037\003Key\022\023\n\005epoch\030\004 \001(\rB\004\310\336"
     "\037\000\0225\n\ttimestamp\030\005 \001(\0132\034.cockroach.roachp"
-    "b.TimestampB\004\310\336\037\000\"\376\004\n\013Transaction\0222\n\004met"
+    "b.TimestampB\004\310\336\037\000\"\371\004\n\013Transaction\0222\n\004met"
     "a\030\001 \001(\0132\032.cockroach.roachpb.TxnMetaB\010\310\336\037"
     "\000\320\336\037\001\022\022\n\004name\030\002 \001(\tB\004\310\336\037\000\022\026\n\010priority\030\003 "
     "\001(\005B\004\310\336\037\000\022:\n\006status\030\004 \001(\0162$.cockroach.ro"
     "achpb.TransactionStatusB\004\310\336\037\000\0224\n\016last_he"
     "artbeat\030\005 \001(\0132\034.cockroach.roachpb.Timest"
     "amp\022:\n\016orig_timestamp\030\006 \001(\0132\034.cockroach."
-    "roachpb.TimestampB\004\310\336\037\000\022>\n\022observed_time"
-    "stamp\030\007 \001(\0132\034.cockroach.roachpb.Timestam"
-    "pB\004\310\336\037\000\022c\n\023observed_timestamps\030\010 \003(\01326.c"
-    "ockroach.roachpb.Transaction.ObservedTim"
-    "estampsEntryB\016\310\336\037\000\202\337\037\006NodeID\022\025\n\007Writing\030"
-    "\t \001(\010B\004\310\336\037\000\022\026\n\010Sequence\030\n \001(\rB\004\310\336\037\000\022.\n\007I"
-    "ntents\030\013 \003(\0132\027.cockroach.roachpb.SpanB\004\310"
-    "\336\037\000\032W\n\027ObservedTimestampsEntry\022\013\n\003key\030\001 "
-    "\001(\005\022+\n\005value\030\002 \001(\0132\034.cockroach.roachpb.T"
-    "imestamp:\0028\001:\004\230\240\037\000\"\244\001\n\006Intent\022/\n\004span\030\001 "
-    "\001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-"
-    "\n\003txn\030\002 \001(\0132\032.cockroach.roachpb.TxnMetaB"
-    "\004\310\336\037\000\022:\n\006status\030\003 \001(\0162$.cockroach.roachp"
-    "b.TransactionStatusB\004\310\336\037\000\"\265\001\n\005Lease\0221\n\005s"
-    "tart\030\001 \001(\0132\034.cockroach.roachpb.Timestamp"
-    "B\004\310\336\037\000\0226\n\nexpiration\030\002 \001(\0132\034.cockroach.r"
-    "oachpb.TimestampB\004\310\336\037\000\022;\n\007replica\030\003 \001(\0132"
-    "$.cockroach.roachpb.ReplicaDescriptorB\004\310"
-    "\336\037\000:\004\230\240\037\000\"a\n\022SequenceCacheEntry\022\024\n\003key\030\001"
-    " \001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockr"
-    "oach.roachpb.TimestampB\004\310\336\037\000*^\n\tValueTyp"
-    "e\022\013\n\007UNKNOWN\020\000\022\007\n\003INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BY"
-    "TES\020\003\022\010\n\004TIME\020\004\022\013\n\007DECIMAL\020\005\022\016\n\nTIMESERI"
-    "ES\020d*>\n\021ReplicaChangeType\022\017\n\013ADD_REPLICA"
-    "\020\000\022\022\n\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolatio"
-    "nType\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210"
-    "\243\036\000*B\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r\n"
-    "\tCOMMITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\tZ\007roach"
-    "pbX\001", 3204);
+    "roachpb.TimestampB\004\310\336\037\000\0229\n\rmax_timestamp"
+    "\030\007 \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336"
+    "\037\000\022c\n\023observed_timestamps\030\010 \003(\01326.cockro"
+    "ach.roachpb.Transaction.ObservedTimestam"
+    "psEntryB\016\310\336\037\000\202\337\037\006NodeID\022\025\n\007Writing\030\t \001(\010"
+    "B\004\310\336\037\000\022\026\n\010Sequence\030\n \001(\rB\004\310\336\037\000\022.\n\007Intent"
+    "s\030\013 \003(\0132\027.cockroach.roachpb.SpanB\004\310\336\037\000\032W"
+    "\n\027ObservedTimestampsEntry\022\013\n\003key\030\001 \001(\005\022+"
+    "\n\005value\030\002 \001(\0132\034.cockroach.roachpb.Timest"
+    "amp:\0028\001:\004\230\240\037\000\"\244\001\n\006Intent\022/\n\004span\030\001 \001(\0132\027"
+    ".cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\003txn"
+    "\030\002 \001(\0132\032.cockroach.roachpb.TxnMetaB\004\310\336\037\000"
+    "\022:\n\006status\030\003 \001(\0162$.cockroach.roachpb.Tra"
+    "nsactionStatusB\004\310\336\037\000\"\265\001\n\005Lease\0221\n\005start\030"
+    "\001 \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037"
+    "\000\0226\n\nexpiration\030\002 \001(\0132\034.cockroach.roachp"
+    "b.TimestampB\004\310\336\037\000\022;\n\007replica\030\003 \001(\0132$.coc"
+    "kroach.roachpb.ReplicaDescriptorB\004\310\336\037\000:\004"
+    "\230\240\037\000\"a\n\022SequenceCacheEntry\022\024\n\003key\030\001 \001(\014B"
+    "\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach."
+    "roachpb.TimestampB\004\310\336\037\000*^\n\tValueType\022\013\n\007"
+    "UNKNOWN\020\000\022\007\n\003INT\020\001\022\t\n\005FLOAT\020\002\022\t\n\005BYTES\020\003"
+    "\022\010\n\004TIME\020\004\022\013\n\007DECIMAL\020\005\022\016\n\nTIMESERIES\020d*"
+    ">\n\021ReplicaChangeType\022\017\n\013ADD_REPLICA\020\000\022\022\n"
+    "\016REMOVE_REPLICA\020\001\032\004\210\243\036\000*5\n\rIsolationType"
+    "\022\020\n\014SERIALIZABLE\020\000\022\014\n\010SNAPSHOT\020\001\032\004\210\243\036\000*B"
+    "\n\021TransactionStatus\022\013\n\007PENDING\020\000\022\r\n\tCOMM"
+    "ITTED\020\001\022\013\n\007ABORTED\020\002\032\004\210\243\036\000B\tZ\007roachpbX\001", 3199);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/data.proto", &protobuf_RegisterTypes);
   Span::default_instance_ = new Span();
@@ -5327,7 +5326,7 @@ const int Transaction::kPriorityFieldNumber;
 const int Transaction::kStatusFieldNumber;
 const int Transaction::kLastHeartbeatFieldNumber;
 const int Transaction::kOrigTimestampFieldNumber;
-const int Transaction::kObservedTimestampFieldNumber;
+const int Transaction::kMaxTimestampFieldNumber;
 const int Transaction::kObservedTimestampsFieldNumber;
 const int Transaction::kWritingFieldNumber;
 const int Transaction::kSequenceFieldNumber;
@@ -5344,7 +5343,7 @@ void Transaction::InitAsDefaultInstance() {
   meta_ = const_cast< ::cockroach::roachpb::TxnMeta*>(&::cockroach::roachpb::TxnMeta::default_instance());
   last_heartbeat_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
   orig_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
-  observed_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
+  max_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
 }
 
 Transaction::Transaction(const Transaction& from)
@@ -5364,7 +5363,7 @@ void Transaction::SharedCtor() {
   status_ = 0;
   last_heartbeat_ = NULL;
   orig_timestamp_ = NULL;
-  observed_timestamp_ = NULL;
+  max_timestamp_ = NULL;
   observed_timestamps_.SetAssignDescriptorCallback(
       protobuf_AssignDescriptorsOnce);
   observed_timestamps_.SetEntryDescriptor(
@@ -5385,7 +5384,7 @@ void Transaction::SharedDtor() {
     delete meta_;
     delete last_heartbeat_;
     delete orig_timestamp_;
-    delete observed_timestamp_;
+    delete max_timestamp_;
   }
 }
 
@@ -5437,8 +5436,8 @@ void Transaction::Clear() {
     if (has_orig_timestamp()) {
       if (orig_timestamp_ != NULL) orig_timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
-    if (has_observed_timestamp()) {
-      if (observed_timestamp_ != NULL) observed_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+    if (has_max_timestamp()) {
+      if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
   }
   ZR_(writing_, sequence_);
@@ -5550,16 +5549,16 @@ bool Transaction::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(58)) goto parse_observed_timestamp;
+        if (input->ExpectTag(58)) goto parse_max_timestamp;
         break;
       }
 
-      // optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
+      // optional .cockroach.roachpb.Timestamp max_timestamp = 7;
       case 7: {
         if (tag == 58) {
-         parse_observed_timestamp:
+         parse_max_timestamp:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_observed_timestamp()));
+               input, mutable_max_timestamp()));
         } else {
           goto handle_unusual;
         }
@@ -5697,10 +5696,10 @@ void Transaction::SerializeWithCachedSizes(
       6, *this->orig_timestamp_, output);
   }
 
-  // optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
-  if (has_observed_timestamp()) {
+  // optional .cockroach.roachpb.Timestamp max_timestamp = 7;
+  if (has_max_timestamp()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      7, *this->observed_timestamp_, output);
+      7, *this->max_timestamp_, output);
   }
 
   // map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;
@@ -5784,11 +5783,11 @@ void Transaction::SerializeWithCachedSizes(
         6, *this->orig_timestamp_, target);
   }
 
-  // optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
-  if (has_observed_timestamp()) {
+  // optional .cockroach.roachpb.Timestamp max_timestamp = 7;
+  if (has_max_timestamp()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        7, *this->observed_timestamp_, target);
+        7, *this->max_timestamp_, target);
   }
 
   // map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;
@@ -5874,11 +5873,11 @@ int Transaction::ByteSize() const {
           *this->orig_timestamp_);
     }
 
-    // optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
-    if (has_observed_timestamp()) {
+    // optional .cockroach.roachpb.Timestamp max_timestamp = 7;
+    if (has_max_timestamp()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->observed_timestamp_);
+          *this->max_timestamp_);
     }
 
   }
@@ -5964,8 +5963,8 @@ void Transaction::MergeFrom(const Transaction& from) {
     if (from.has_orig_timestamp()) {
       mutable_orig_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.orig_timestamp());
     }
-    if (from.has_observed_timestamp()) {
-      mutable_observed_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.observed_timestamp());
+    if (from.has_max_timestamp()) {
+      mutable_max_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.max_timestamp());
     }
   }
   if (from._has_bits_[8 / 32] & (0xffu << (8 % 32))) {
@@ -6009,7 +6008,7 @@ void Transaction::InternalSwap(Transaction* other) {
   std::swap(status_, other->status_);
   std::swap(last_heartbeat_, other->last_heartbeat_);
   std::swap(orig_timestamp_, other->orig_timestamp_);
-  std::swap(observed_timestamp_, other->observed_timestamp_);
+  std::swap(max_timestamp_, other->max_timestamp_);
   observed_timestamps_.Swap(&other->observed_timestamps_);
   std::swap(writing_, other->writing_);
   std::swap(sequence_, other->sequence_);
@@ -6261,47 +6260,47 @@ void Transaction::set_allocated_orig_timestamp(::cockroach::roachpb::Timestamp* 
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.orig_timestamp)
 }
 
-// optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
-bool Transaction::has_observed_timestamp() const {
+// optional .cockroach.roachpb.Timestamp max_timestamp = 7;
+bool Transaction::has_max_timestamp() const {
   return (_has_bits_[0] & 0x00000040u) != 0;
 }
-void Transaction::set_has_observed_timestamp() {
+void Transaction::set_has_max_timestamp() {
   _has_bits_[0] |= 0x00000040u;
 }
-void Transaction::clear_has_observed_timestamp() {
+void Transaction::clear_has_max_timestamp() {
   _has_bits_[0] &= ~0x00000040u;
 }
-void Transaction::clear_observed_timestamp() {
-  if (observed_timestamp_ != NULL) observed_timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_observed_timestamp();
+void Transaction::clear_max_timestamp() {
+  if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_max_timestamp();
 }
-const ::cockroach::roachpb::Timestamp& Transaction::observed_timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.observed_timestamp)
-  return observed_timestamp_ != NULL ? *observed_timestamp_ : *default_instance_->observed_timestamp_;
+const ::cockroach::roachpb::Timestamp& Transaction::max_timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.max_timestamp)
+  return max_timestamp_ != NULL ? *max_timestamp_ : *default_instance_->max_timestamp_;
 }
-::cockroach::roachpb::Timestamp* Transaction::mutable_observed_timestamp() {
-  set_has_observed_timestamp();
-  if (observed_timestamp_ == NULL) {
-    observed_timestamp_ = new ::cockroach::roachpb::Timestamp;
+::cockroach::roachpb::Timestamp* Transaction::mutable_max_timestamp() {
+  set_has_max_timestamp();
+  if (max_timestamp_ == NULL) {
+    max_timestamp_ = new ::cockroach::roachpb::Timestamp;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.observed_timestamp)
-  return observed_timestamp_;
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.max_timestamp)
+  return max_timestamp_;
 }
-::cockroach::roachpb::Timestamp* Transaction::release_observed_timestamp() {
-  clear_has_observed_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = observed_timestamp_;
-  observed_timestamp_ = NULL;
+::cockroach::roachpb::Timestamp* Transaction::release_max_timestamp() {
+  clear_has_max_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = max_timestamp_;
+  max_timestamp_ = NULL;
   return temp;
 }
-void Transaction::set_allocated_observed_timestamp(::cockroach::roachpb::Timestamp* observed_timestamp) {
-  delete observed_timestamp_;
-  observed_timestamp_ = observed_timestamp;
-  if (observed_timestamp) {
-    set_has_observed_timestamp();
+void Transaction::set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp) {
+  delete max_timestamp_;
+  max_timestamp_ = max_timestamp;
+  if (max_timestamp) {
+    set_has_max_timestamp();
   } else {
-    clear_has_observed_timestamp();
+    clear_has_max_timestamp();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.observed_timestamp)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.max_timestamp)
 }
 
 // map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;

--- a/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/data.pb.h
@@ -1491,14 +1491,14 @@ class Transaction : public ::google::protobuf::Message {
   ::cockroach::roachpb::Timestamp* release_orig_timestamp();
   void set_allocated_orig_timestamp(::cockroach::roachpb::Timestamp* orig_timestamp);
 
-  // optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
-  bool has_observed_timestamp() const;
-  void clear_observed_timestamp();
-  static const int kObservedTimestampFieldNumber = 7;
-  const ::cockroach::roachpb::Timestamp& observed_timestamp() const;
-  ::cockroach::roachpb::Timestamp* mutable_observed_timestamp();
-  ::cockroach::roachpb::Timestamp* release_observed_timestamp();
-  void set_allocated_observed_timestamp(::cockroach::roachpb::Timestamp* observed_timestamp);
+  // optional .cockroach.roachpb.Timestamp max_timestamp = 7;
+  bool has_max_timestamp() const;
+  void clear_max_timestamp();
+  static const int kMaxTimestampFieldNumber = 7;
+  const ::cockroach::roachpb::Timestamp& max_timestamp() const;
+  ::cockroach::roachpb::Timestamp* mutable_max_timestamp();
+  ::cockroach::roachpb::Timestamp* release_max_timestamp();
+  void set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp);
 
   // map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;
   int observed_timestamps_size() const;
@@ -1549,8 +1549,8 @@ class Transaction : public ::google::protobuf::Message {
   inline void clear_has_last_heartbeat();
   inline void set_has_orig_timestamp();
   inline void clear_has_orig_timestamp();
-  inline void set_has_observed_timestamp();
-  inline void clear_has_observed_timestamp();
+  inline void set_has_max_timestamp();
+  inline void clear_has_max_timestamp();
   inline void set_has_writing();
   inline void clear_has_writing();
   inline void set_has_sequence();
@@ -1565,7 +1565,7 @@ class Transaction : public ::google::protobuf::Message {
   int status_;
   ::cockroach::roachpb::Timestamp* last_heartbeat_;
   ::cockroach::roachpb::Timestamp* orig_timestamp_;
-  ::cockroach::roachpb::Timestamp* observed_timestamp_;
+  ::cockroach::roachpb::Timestamp* max_timestamp_;
   typedef ::google::protobuf::internal::MapEntryLite<
       ::google::protobuf::int32, ::cockroach::roachpb::Timestamp,
       ::google::protobuf::internal::WireFormatLite::TYPE_INT32,
@@ -3363,47 +3363,47 @@ inline void Transaction::set_allocated_orig_timestamp(::cockroach::roachpb::Time
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.orig_timestamp)
 }
 
-// optional .cockroach.roachpb.Timestamp observed_timestamp = 7;
-inline bool Transaction::has_observed_timestamp() const {
+// optional .cockroach.roachpb.Timestamp max_timestamp = 7;
+inline bool Transaction::has_max_timestamp() const {
   return (_has_bits_[0] & 0x00000040u) != 0;
 }
-inline void Transaction::set_has_observed_timestamp() {
+inline void Transaction::set_has_max_timestamp() {
   _has_bits_[0] |= 0x00000040u;
 }
-inline void Transaction::clear_has_observed_timestamp() {
+inline void Transaction::clear_has_max_timestamp() {
   _has_bits_[0] &= ~0x00000040u;
 }
-inline void Transaction::clear_observed_timestamp() {
-  if (observed_timestamp_ != NULL) observed_timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_observed_timestamp();
+inline void Transaction::clear_max_timestamp() {
+  if (max_timestamp_ != NULL) max_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_max_timestamp();
 }
-inline const ::cockroach::roachpb::Timestamp& Transaction::observed_timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.observed_timestamp)
-  return observed_timestamp_ != NULL ? *observed_timestamp_ : *default_instance_->observed_timestamp_;
+inline const ::cockroach::roachpb::Timestamp& Transaction::max_timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Transaction.max_timestamp)
+  return max_timestamp_ != NULL ? *max_timestamp_ : *default_instance_->max_timestamp_;
 }
-inline ::cockroach::roachpb::Timestamp* Transaction::mutable_observed_timestamp() {
-  set_has_observed_timestamp();
-  if (observed_timestamp_ == NULL) {
-    observed_timestamp_ = new ::cockroach::roachpb::Timestamp;
+inline ::cockroach::roachpb::Timestamp* Transaction::mutable_max_timestamp() {
+  set_has_max_timestamp();
+  if (max_timestamp_ == NULL) {
+    max_timestamp_ = new ::cockroach::roachpb::Timestamp;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.observed_timestamp)
-  return observed_timestamp_;
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Transaction.max_timestamp)
+  return max_timestamp_;
 }
-inline ::cockroach::roachpb::Timestamp* Transaction::release_observed_timestamp() {
-  clear_has_observed_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = observed_timestamp_;
-  observed_timestamp_ = NULL;
+inline ::cockroach::roachpb::Timestamp* Transaction::release_max_timestamp() {
+  clear_has_max_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = max_timestamp_;
+  max_timestamp_ = NULL;
   return temp;
 }
-inline void Transaction::set_allocated_observed_timestamp(::cockroach::roachpb::Timestamp* observed_timestamp) {
-  delete observed_timestamp_;
-  observed_timestamp_ = observed_timestamp;
-  if (observed_timestamp) {
-    set_has_observed_timestamp();
+inline void Transaction::set_allocated_max_timestamp(::cockroach::roachpb::Timestamp* max_timestamp) {
+  delete max_timestamp_;
+  max_timestamp_ = max_timestamp;
+  if (max_timestamp) {
+    set_has_max_timestamp();
   } else {
-    clear_has_observed_timestamp();
+    clear_has_max_timestamp();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.observed_timestamp)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Transaction.max_timestamp)
 }
 
 // map<int32, .cockroach.roachpb.Timestamp> observed_timestamps = 8;

--- a/storage/engine/rocksdb/cockroach/roachpb/errors.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/errors.pb.cc
@@ -169,10 +169,9 @@ void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RangeKeyMismatchError, _internal_metadata_),
       -1);
   ReadWithinUncertaintyIntervalError_descriptor_ = file->message_type(4);
-  static const int ReadWithinUncertaintyIntervalError_offsets_[3] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWithinUncertaintyIntervalError, timestamp_),
+  static const int ReadWithinUncertaintyIntervalError_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWithinUncertaintyIntervalError, read_timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWithinUncertaintyIntervalError, existing_timestamp_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ReadWithinUncertaintyIntervalError, node_id_),
   };
   ReadWithinUncertaintyIntervalError_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -474,11 +473,12 @@ void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ErrPosition, _internal_metadata_),
       -1);
   Error_descriptor_ = file->message_type(23);
-  static const int Error_offsets_[6] = {
+  static const int Error_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, message_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, retryable_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, transaction_restart_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, txn_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, unexposed_txn_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, origin_node_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, detail_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Error, index_),
   };
@@ -632,83 +632,83 @@ void protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto() {
     "eID\"\220\001\n\025RangeKeyMismatchError\022\"\n\021request"
     "_start_key\030\001 \001(\014B\007\372\336\037\003Key\022 \n\017request_end"
     "_key\030\002 \001(\014B\007\372\336\037\003Key\0221\n\005range\030\003 \001(\0132\".coc"
-    "kroach.roachpb.RangeDescriptor\"\306\001\n\"ReadW"
-    "ithinUncertaintyIntervalError\0225\n\ttimesta"
-    "mp\030\001 \001(\0132\034.cockroach.roachpb.TimestampB\004"
-    "\310\336\037\000\022>\n\022existing_timestamp\030\002 \001(\0132\034.cockr"
-    "oach.roachpb.TimestampB\004\310\336\037\000\022)\n\007node_id\030"
-    "\003 \001(\005B\030\310\336\037\000\342\336\037\006NodeID\372\336\037\006NodeID\"\031\n\027Trans"
-    "actionAbortedError\"P\n\024TransactionPushErr"
-    "or\0228\n\npushee_txn\030\001 \001(\0132\036.cockroach.roach"
-    "pb.TransactionB\004\310\336\037\000\"\027\n\025TransactionRetry"
-    "Error\"+\n\026TransactionStatusError\022\021\n\003msg\030\001"
-    " \001(\tB\004\310\336\037\000\"\\\n\020WriteIntentError\0220\n\007intent"
-    "s\030\001 \003(\0132\031.cockroach.roachpb.IntentB\004\310\336\037\000"
-    "\022\026\n\010resolved\030\002 \001(\010B\004\310\336\037\000\"\211\001\n\020WriteTooOld"
-    "Error\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach.roa"
-    "chpb.TimestampB\004\310\336\037\000\022>\n\022existing_timesta"
-    "mp\030\002 \001(\0132\034.cockroach.roachpb.TimestampB\004"
-    "\310\336\037\000\"\024\n\022OpRequiresTxnError\"F\n\024ConditionF"
-    "ailedError\022.\n\014actual_value\030\001 \001(\0132\030.cockr"
-    "oach.roachpb.Value\"\220\001\n\022LeaseRejectedErro"
-    "r\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\0221\n\trequested\030\002 "
-    "\001(\0132\030.cockroach.roachpb.LeaseB\004\310\336\037\000\0220\n\010e"
-    "xisting\030\003 \001(\0132\030.cockroach.roachpb.LeaseB"
-    "\004\310\336\037\000\";\n\tSendError\022\025\n\007message\030\001 \001(\tB\004\310\336\037"
-    "\000\022\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\"\027\n\025RaftGroupD"
-    "eletedError\"J\n\026ReplicaCorruptionError\022\027\n"
-    "\terror_msg\030\001 \001(\tB\004\310\336\037\000\022\027\n\tprocessed\030\002 \001("
-    "\010B\004\310\336\037\000\"\032\n\030LeaseVersionChangedError\"\034\n\032D"
-    "idntUpdateDescriptorError\"\034\n\032SqlTransact"
-    "ionAbortedError\" \n\036ExistingSchemaChangeL"
-    "easeError\"\303\013\n\013ErrorDetail\0225\n\nnot_leader\030"
-    "\001 \001(\0132!.cockroach.roachpb.NotLeaderError"
-    "\022>\n\017range_not_found\030\002 \001(\0132%.cockroach.ro"
-    "achpb.RangeNotFoundError\022D\n\022range_key_mi"
-    "smatch\030\003 \001(\0132(.cockroach.roachpb.RangeKe"
-    "yMismatchError\022_\n read_within_uncertaint"
-    "y_interval\030\004 \001(\01325.cockroach.roachpb.Rea"
-    "dWithinUncertaintyIntervalError\022G\n\023trans"
-    "action_aborted\030\005 \001(\0132*.cockroach.roachpb"
-    ".TransactionAbortedError\022A\n\020transaction_"
-    "push\030\006 \001(\0132\'.cockroach.roachpb.Transacti"
-    "onPushError\022C\n\021transaction_retry\030\007 \001(\0132("
-    ".cockroach.roachpb.TransactionRetryError"
-    "\022E\n\022transaction_status\030\010 \001(\0132).cockroach"
-    ".roachpb.TransactionStatusError\0229\n\014write"
-    "_intent\030\t \001(\0132#.cockroach.roachpb.WriteI"
-    "ntentError\022:\n\rwrite_too_old\030\n \001(\0132#.cock"
-    "roach.roachpb.WriteTooOldError\022>\n\017op_req"
-    "uires_txn\030\013 \001(\0132%.cockroach.roachpb.OpRe"
-    "quiresTxnError\022A\n\020condition_failed\030\014 \001(\013"
-    "2\'.cockroach.roachpb.ConditionFailedErro"
-    "r\022=\n\016lease_rejected\030\r \001(\0132%.cockroach.ro"
-    "achpb.LeaseRejectedError\022A\n\020node_unavail"
-    "able\030\016 \001(\0132\'.cockroach.roachpb.NodeUnava"
-    "ilableError\022*\n\004send\030\017 \001(\0132\034.cockroach.ro"
-    "achpb.SendError\022D\n\022raft_group_deleted\030\020 "
-    "\001(\0132(.cockroach.roachpb.RaftGroupDeleted"
-    "Error\022E\n\022replica_corruption\030\021 \001(\0132).cock"
-    "roach.roachpb.ReplicaCorruptionError\022J\n\025"
-    "lease_version_changed\030\022 \001(\0132+.cockroach."
-    "roachpb.LeaseVersionChangedError\022N\n\027didn"
-    "t_update_descriptor\030\023 \001(\0132-.cockroach.ro"
-    "achpb.DidntUpdateDescriptorError\022N\n\027sql_"
-    "tranasction_aborted\030\024 \001(\0132-.cockroach.ro"
-    "achpb.SqlTransactionAbortedError\022W\n\034exis"
-    "ting_scheme_change_lease\030\025 \001(\01321.cockroa"
-    "ch.roachpb.ExistingSchemaChangeLeaseErro"
-    "r:\004\310\240\037\001\"\"\n\013ErrPosition\022\023\n\005index\030\001 \001(\005B\004\310"
-    "\336\037\000\"\245\002\n\005Error\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027\n\t"
-    "retryable\030\002 \001(\010B\004\310\336\037\000\022H\n\023transaction_res"
-    "tart\030\003 \001(\0162%.cockroach.roachpb.Transacti"
-    "onRestartB\004\310\336\037\000\022=\n\003txn\030\004 \001(\0132\036.cockroach"
-    ".roachpb.TransactionB\020\342\336\037\014UnexposedTxn\022."
-    "\n\006detail\030\005 \001(\0132\036.cockroach.roachpb.Error"
-    "Detail\022-\n\005index\030\006 \001(\0132\036.cockroach.roachp"
-    "b.ErrPosition:\004\230\240\037\000*;\n\022TransactionRestar"
-    "t\022\t\n\005ABORT\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002"
-    "B\tZ\007roachpbX\002", 3573);
+    "kroach.roachpb.RangeDescriptor\"\240\001\n\"ReadW"
+    "ithinUncertaintyIntervalError\022:\n\016read_ti"
+    "mestamp\030\001 \001(\0132\034.cockroach.roachpb.Timest"
+    "ampB\004\310\336\037\000\022>\n\022existing_timestamp\030\002 \001(\0132\034."
+    "cockroach.roachpb.TimestampB\004\310\336\037\000\"\031\n\027Tra"
+    "nsactionAbortedError\"P\n\024TransactionPushE"
+    "rror\0228\n\npushee_txn\030\001 \001(\0132\036.cockroach.roa"
+    "chpb.TransactionB\004\310\336\037\000\"\027\n\025TransactionRet"
+    "ryError\"+\n\026TransactionStatusError\022\021\n\003msg"
+    "\030\001 \001(\tB\004\310\336\037\000\"\\\n\020WriteIntentError\0220\n\007inte"
+    "nts\030\001 \003(\0132\031.cockroach.roachpb.IntentB\004\310\336"
+    "\037\000\022\026\n\010resolved\030\002 \001(\010B\004\310\336\037\000\"\211\001\n\020WriteTooO"
+    "ldError\0225\n\ttimestamp\030\001 \001(\0132\034.cockroach.r"
+    "oachpb.TimestampB\004\310\336\037\000\022>\n\022existing_times"
+    "tamp\030\002 \001(\0132\034.cockroach.roachpb.Timestamp"
+    "B\004\310\336\037\000\"\024\n\022OpRequiresTxnError\"F\n\024Conditio"
+    "nFailedError\022.\n\014actual_value\030\001 \001(\0132\030.coc"
+    "kroach.roachpb.Value\"\220\001\n\022LeaseRejectedEr"
+    "ror\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\0221\n\trequested\030"
+    "\002 \001(\0132\030.cockroach.roachpb.LeaseB\004\310\336\037\000\0220\n"
+    "\010existing\030\003 \001(\0132\030.cockroach.roachpb.Leas"
+    "eB\004\310\336\037\000\";\n\tSendError\022\025\n\007message\030\001 \001(\tB\004\310"
+    "\336\037\000\022\027\n\tretryable\030\002 \001(\010B\004\310\336\037\000\"\027\n\025RaftGrou"
+    "pDeletedError\"J\n\026ReplicaCorruptionError\022"
+    "\027\n\terror_msg\030\001 \001(\tB\004\310\336\037\000\022\027\n\tprocessed\030\002 "
+    "\001(\010B\004\310\336\037\000\"\032\n\030LeaseVersionChangedError\"\034\n"
+    "\032DidntUpdateDescriptorError\"\034\n\032SqlTransa"
+    "ctionAbortedError\" \n\036ExistingSchemaChang"
+    "eLeaseError\"\303\013\n\013ErrorDetail\0225\n\nnot_leade"
+    "r\030\001 \001(\0132!.cockroach.roachpb.NotLeaderErr"
+    "or\022>\n\017range_not_found\030\002 \001(\0132%.cockroach."
+    "roachpb.RangeNotFoundError\022D\n\022range_key_"
+    "mismatch\030\003 \001(\0132(.cockroach.roachpb.Range"
+    "KeyMismatchError\022_\n read_within_uncertai"
+    "nty_interval\030\004 \001(\01325.cockroach.roachpb.R"
+    "eadWithinUncertaintyIntervalError\022G\n\023tra"
+    "nsaction_aborted\030\005 \001(\0132*.cockroach.roach"
+    "pb.TransactionAbortedError\022A\n\020transactio"
+    "n_push\030\006 \001(\0132\'.cockroach.roachpb.Transac"
+    "tionPushError\022C\n\021transaction_retry\030\007 \001(\013"
+    "2(.cockroach.roachpb.TransactionRetryErr"
+    "or\022E\n\022transaction_status\030\010 \001(\0132).cockroa"
+    "ch.roachpb.TransactionStatusError\0229\n\014wri"
+    "te_intent\030\t \001(\0132#.cockroach.roachpb.Writ"
+    "eIntentError\022:\n\rwrite_too_old\030\n \001(\0132#.co"
+    "ckroach.roachpb.WriteTooOldError\022>\n\017op_r"
+    "equires_txn\030\013 \001(\0132%.cockroach.roachpb.Op"
+    "RequiresTxnError\022A\n\020condition_failed\030\014 \001"
+    "(\0132\'.cockroach.roachpb.ConditionFailedEr"
+    "ror\022=\n\016lease_rejected\030\r \001(\0132%.cockroach."
+    "roachpb.LeaseRejectedError\022A\n\020node_unava"
+    "ilable\030\016 \001(\0132\'.cockroach.roachpb.NodeUna"
+    "vailableError\022*\n\004send\030\017 \001(\0132\034.cockroach."
+    "roachpb.SendError\022D\n\022raft_group_deleted\030"
+    "\020 \001(\0132(.cockroach.roachpb.RaftGroupDelet"
+    "edError\022E\n\022replica_corruption\030\021 \001(\0132).co"
+    "ckroach.roachpb.ReplicaCorruptionError\022J"
+    "\n\025lease_version_changed\030\022 \001(\0132+.cockroac"
+    "h.roachpb.LeaseVersionChangedError\022N\n\027di"
+    "dnt_update_descriptor\030\023 \001(\0132-.cockroach."
+    "roachpb.DidntUpdateDescriptorError\022N\n\027sq"
+    "l_tranasction_aborted\030\024 \001(\0132-.cockroach."
+    "roachpb.SqlTransactionAbortedError\022W\n\034ex"
+    "isting_scheme_change_lease\030\025 \001(\01321.cockr"
+    "oach.roachpb.ExistingSchemaChangeLeaseEr"
+    "ror:\004\310\240\037\001\"\"\n\013ErrPosition\022\023\n\005index\030\001 \001(\005B"
+    "\004\310\336\037\000\"\302\002\n\005Error\022\025\n\007message\030\001 \001(\tB\004\310\336\037\000\022\027"
+    "\n\tretryable\030\002 \001(\010B\004\310\336\037\000\022H\n\023transaction_r"
+    "estart\030\003 \001(\0162%.cockroach.roachpb.Transac"
+    "tionRestartB\004\310\336\037\000\0225\n\runexposed_txn\030\004 \001(\013"
+    "2\036.cockroach.roachpb.Transaction\022#\n\013orig"
+    "in_node\030\005 \001(\005B\016\310\336\037\000\372\336\037\006NodeID\022.\n\006detail\030"
+    "\006 \001(\0132\036.cockroach.roachpb.ErrorDetail\022-\n"
+    "\005index\030\007 \001(\0132\036.cockroach.roachpb.ErrPosi"
+    "tion:\004\230\240\037\000*;\n\022TransactionRestart\022\t\n\005ABOR"
+    "T\020\000\022\013\n\007BACKOFF\020\001\022\r\n\tIMMEDIATE\020\002B\tZ\007roach"
+    "pbX\002", 3564);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/errors.proto", &protobuf_RegisterTypes);
   NotLeaderError::default_instance_ = new NotLeaderError();
@@ -2164,9 +2164,8 @@ void RangeKeyMismatchError::set_allocated_range(::cockroach::roachpb::RangeDescr
 // ===================================================================
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int ReadWithinUncertaintyIntervalError::kTimestampFieldNumber;
+const int ReadWithinUncertaintyIntervalError::kReadTimestampFieldNumber;
 const int ReadWithinUncertaintyIntervalError::kExistingTimestampFieldNumber;
-const int ReadWithinUncertaintyIntervalError::kNodeIdFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ReadWithinUncertaintyIntervalError::ReadWithinUncertaintyIntervalError()
@@ -2176,7 +2175,7 @@ ReadWithinUncertaintyIntervalError::ReadWithinUncertaintyIntervalError()
 }
 
 void ReadWithinUncertaintyIntervalError::InitAsDefaultInstance() {
-  timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
+  read_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
   existing_timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
 }
 
@@ -2190,9 +2189,8 @@ ReadWithinUncertaintyIntervalError::ReadWithinUncertaintyIntervalError(const Rea
 
 void ReadWithinUncertaintyIntervalError::SharedCtor() {
   _cached_size_ = 0;
-  timestamp_ = NULL;
+  read_timestamp_ = NULL;
   existing_timestamp_ = NULL;
-  node_id_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -2203,7 +2201,7 @@ ReadWithinUncertaintyIntervalError::~ReadWithinUncertaintyIntervalError() {
 
 void ReadWithinUncertaintyIntervalError::SharedDtor() {
   if (this != default_instance_) {
-    delete timestamp_;
+    delete read_timestamp_;
     delete existing_timestamp_;
   }
 }
@@ -2234,14 +2232,13 @@ ReadWithinUncertaintyIntervalError* ReadWithinUncertaintyIntervalError::New(::go
 }
 
 void ReadWithinUncertaintyIntervalError::Clear() {
-  if (_has_bits_[0 / 32] & 7u) {
-    if (has_timestamp()) {
-      if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  if (_has_bits_[0 / 32] & 3u) {
+    if (has_read_timestamp()) {
+      if (read_timestamp_ != NULL) read_timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
     if (has_existing_timestamp()) {
       if (existing_timestamp_ != NULL) existing_timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
-    node_id_ = 0;
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2259,11 +2256,11 @@ bool ReadWithinUncertaintyIntervalError::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.roachpb.Timestamp timestamp = 1;
+      // optional .cockroach.roachpb.Timestamp read_timestamp = 1;
       case 1: {
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_timestamp()));
+               input, mutable_read_timestamp()));
         } else {
           goto handle_unusual;
         }
@@ -2277,21 +2274,6 @@ bool ReadWithinUncertaintyIntervalError::MergePartialFromCodedStream(
          parse_existing_timestamp:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_existing_timestamp()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(24)) goto parse_node_id;
-        break;
-      }
-
-      // optional int32 node_id = 3;
-      case 3: {
-        if (tag == 24) {
-         parse_node_id:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 input, &node_id_)));
-          set_has_node_id();
         } else {
           goto handle_unusual;
         }
@@ -2324,21 +2306,16 @@ failure:
 void ReadWithinUncertaintyIntervalError::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.roachpb.ReadWithinUncertaintyIntervalError)
-  // optional .cockroach.roachpb.Timestamp timestamp = 1;
-  if (has_timestamp()) {
+  // optional .cockroach.roachpb.Timestamp read_timestamp = 1;
+  if (has_read_timestamp()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      1, *this->timestamp_, output);
+      1, *this->read_timestamp_, output);
   }
 
   // optional .cockroach.roachpb.Timestamp existing_timestamp = 2;
   if (has_existing_timestamp()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       2, *this->existing_timestamp_, output);
-  }
-
-  // optional int32 node_id = 3;
-  if (has_node_id()) {
-    ::google::protobuf::internal::WireFormatLite::WriteInt32(3, this->node_id(), output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2351,11 +2328,11 @@ void ReadWithinUncertaintyIntervalError::SerializeWithCachedSizes(
 ::google::protobuf::uint8* ReadWithinUncertaintyIntervalError::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.ReadWithinUncertaintyIntervalError)
-  // optional .cockroach.roachpb.Timestamp timestamp = 1;
-  if (has_timestamp()) {
+  // optional .cockroach.roachpb.Timestamp read_timestamp = 1;
+  if (has_read_timestamp()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        1, *this->timestamp_, target);
+        1, *this->read_timestamp_, target);
   }
 
   // optional .cockroach.roachpb.Timestamp existing_timestamp = 2;
@@ -2363,11 +2340,6 @@ void ReadWithinUncertaintyIntervalError::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         2, *this->existing_timestamp_, target);
-  }
-
-  // optional int32 node_id = 3;
-  if (has_node_id()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(3, this->node_id(), target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -2381,12 +2353,12 @@ void ReadWithinUncertaintyIntervalError::SerializeWithCachedSizes(
 int ReadWithinUncertaintyIntervalError::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 7u) {
-    // optional .cockroach.roachpb.Timestamp timestamp = 1;
-    if (has_timestamp()) {
+  if (_has_bits_[0 / 32] & 3u) {
+    // optional .cockroach.roachpb.Timestamp read_timestamp = 1;
+    if (has_read_timestamp()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->timestamp_);
+          *this->read_timestamp_);
     }
 
     // optional .cockroach.roachpb.Timestamp existing_timestamp = 2;
@@ -2394,13 +2366,6 @@ int ReadWithinUncertaintyIntervalError::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->existing_timestamp_);
-    }
-
-    // optional int32 node_id = 3;
-    if (has_node_id()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::Int32Size(
-          this->node_id());
     }
 
   }
@@ -2430,14 +2395,11 @@ void ReadWithinUncertaintyIntervalError::MergeFrom(const ::google::protobuf::Mes
 void ReadWithinUncertaintyIntervalError::MergeFrom(const ReadWithinUncertaintyIntervalError& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_timestamp()) {
-      mutable_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.timestamp());
+    if (from.has_read_timestamp()) {
+      mutable_read_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.read_timestamp());
     }
     if (from.has_existing_timestamp()) {
       mutable_existing_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.existing_timestamp());
-    }
-    if (from.has_node_id()) {
-      set_node_id(from.node_id());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -2467,9 +2429,8 @@ void ReadWithinUncertaintyIntervalError::Swap(ReadWithinUncertaintyIntervalError
   InternalSwap(other);
 }
 void ReadWithinUncertaintyIntervalError::InternalSwap(ReadWithinUncertaintyIntervalError* other) {
-  std::swap(timestamp_, other->timestamp_);
+  std::swap(read_timestamp_, other->read_timestamp_);
   std::swap(existing_timestamp_, other->existing_timestamp_);
-  std::swap(node_id_, other->node_id_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -2486,47 +2447,47 @@ void ReadWithinUncertaintyIntervalError::InternalSwap(ReadWithinUncertaintyInter
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // ReadWithinUncertaintyIntervalError
 
-// optional .cockroach.roachpb.Timestamp timestamp = 1;
-bool ReadWithinUncertaintyIntervalError::has_timestamp() const {
+// optional .cockroach.roachpb.Timestamp read_timestamp = 1;
+bool ReadWithinUncertaintyIntervalError::has_read_timestamp() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-void ReadWithinUncertaintyIntervalError::set_has_timestamp() {
+void ReadWithinUncertaintyIntervalError::set_has_read_timestamp() {
   _has_bits_[0] |= 0x00000001u;
 }
-void ReadWithinUncertaintyIntervalError::clear_has_timestamp() {
+void ReadWithinUncertaintyIntervalError::clear_has_read_timestamp() {
   _has_bits_[0] &= ~0x00000001u;
 }
-void ReadWithinUncertaintyIntervalError::clear_timestamp() {
-  if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_timestamp();
+void ReadWithinUncertaintyIntervalError::clear_read_timestamp() {
+  if (read_timestamp_ != NULL) read_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_read_timestamp();
 }
-const ::cockroach::roachpb::Timestamp& ReadWithinUncertaintyIntervalError::timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.ReadWithinUncertaintyIntervalError.timestamp)
-  return timestamp_ != NULL ? *timestamp_ : *default_instance_->timestamp_;
+const ::cockroach::roachpb::Timestamp& ReadWithinUncertaintyIntervalError::read_timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ReadWithinUncertaintyIntervalError.read_timestamp)
+  return read_timestamp_ != NULL ? *read_timestamp_ : *default_instance_->read_timestamp_;
 }
-::cockroach::roachpb::Timestamp* ReadWithinUncertaintyIntervalError::mutable_timestamp() {
-  set_has_timestamp();
-  if (timestamp_ == NULL) {
-    timestamp_ = new ::cockroach::roachpb::Timestamp;
+::cockroach::roachpb::Timestamp* ReadWithinUncertaintyIntervalError::mutable_read_timestamp() {
+  set_has_read_timestamp();
+  if (read_timestamp_ == NULL) {
+    read_timestamp_ = new ::cockroach::roachpb::Timestamp;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ReadWithinUncertaintyIntervalError.timestamp)
-  return timestamp_;
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ReadWithinUncertaintyIntervalError.read_timestamp)
+  return read_timestamp_;
 }
-::cockroach::roachpb::Timestamp* ReadWithinUncertaintyIntervalError::release_timestamp() {
-  clear_has_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = timestamp_;
-  timestamp_ = NULL;
+::cockroach::roachpb::Timestamp* ReadWithinUncertaintyIntervalError::release_read_timestamp() {
+  clear_has_read_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = read_timestamp_;
+  read_timestamp_ = NULL;
   return temp;
 }
-void ReadWithinUncertaintyIntervalError::set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp) {
-  delete timestamp_;
-  timestamp_ = timestamp;
-  if (timestamp) {
-    set_has_timestamp();
+void ReadWithinUncertaintyIntervalError::set_allocated_read_timestamp(::cockroach::roachpb::Timestamp* read_timestamp) {
+  delete read_timestamp_;
+  read_timestamp_ = read_timestamp;
+  if (read_timestamp) {
+    set_has_read_timestamp();
   } else {
-    clear_has_timestamp();
+    clear_has_read_timestamp();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ReadWithinUncertaintyIntervalError.timestamp)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ReadWithinUncertaintyIntervalError.read_timestamp)
 }
 
 // optional .cockroach.roachpb.Timestamp existing_timestamp = 2;
@@ -2570,30 +2531,6 @@ void ReadWithinUncertaintyIntervalError::set_allocated_existing_timestamp(::cock
     clear_has_existing_timestamp();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ReadWithinUncertaintyIntervalError.existing_timestamp)
-}
-
-// optional int32 node_id = 3;
-bool ReadWithinUncertaintyIntervalError::has_node_id() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-void ReadWithinUncertaintyIntervalError::set_has_node_id() {
-  _has_bits_[0] |= 0x00000004u;
-}
-void ReadWithinUncertaintyIntervalError::clear_has_node_id() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-void ReadWithinUncertaintyIntervalError::clear_node_id() {
-  node_id_ = 0;
-  clear_has_node_id();
-}
- ::google::protobuf::int32 ReadWithinUncertaintyIntervalError::node_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.ReadWithinUncertaintyIntervalError.node_id)
-  return node_id_;
-}
- void ReadWithinUncertaintyIntervalError::set_node_id(::google::protobuf::int32 value) {
-  set_has_node_id();
-  node_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.ReadWithinUncertaintyIntervalError.node_id)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
@@ -9215,7 +9152,8 @@ void ErrPosition::clear_index() {
 const int Error::kMessageFieldNumber;
 const int Error::kRetryableFieldNumber;
 const int Error::kTransactionRestartFieldNumber;
-const int Error::kTxnFieldNumber;
+const int Error::kUnexposedTxnFieldNumber;
+const int Error::kOriginNodeFieldNumber;
 const int Error::kDetailFieldNumber;
 const int Error::kIndexFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
@@ -9227,7 +9165,7 @@ Error::Error()
 }
 
 void Error::InitAsDefaultInstance() {
-  txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
+  unexposed_txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
   detail_ = const_cast< ::cockroach::roachpb::ErrorDetail*>(&::cockroach::roachpb::ErrorDetail::default_instance());
   index_ = const_cast< ::cockroach::roachpb::ErrPosition*>(&::cockroach::roachpb::ErrPosition::default_instance());
 }
@@ -9246,7 +9184,8 @@ void Error::SharedCtor() {
   message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   retryable_ = false;
   transaction_restart_ = 0;
-  txn_ = NULL;
+  unexposed_txn_ = NULL;
+  origin_node_ = 0;
   detail_ = NULL;
   index_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -9260,7 +9199,7 @@ Error::~Error() {
 void Error::SharedDtor() {
   message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (this != default_instance_) {
-    delete txn_;
+    delete unexposed_txn_;
     delete detail_;
     delete index_;
   }
@@ -9300,14 +9239,15 @@ void Error::Clear() {
            ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
 } while (0)
 
-  if (_has_bits_[0 / 32] & 63u) {
+  if (_has_bits_[0 / 32] & 127u) {
     ZR_(retryable_, transaction_restart_);
     if (has_message()) {
       message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
     }
-    if (has_txn()) {
-      if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
+    if (has_unexposed_txn()) {
+      if (unexposed_txn_ != NULL) unexposed_txn_->::cockroach::roachpb::Transaction::Clear();
     }
+    origin_node_ = 0;
     if (has_detail()) {
       if (detail_ != NULL) detail_->::cockroach::roachpb::ErrorDetail::Clear();
     }
@@ -9382,39 +9322,54 @@ bool Error::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(34)) goto parse_txn;
+        if (input->ExpectTag(34)) goto parse_unexposed_txn;
         break;
       }
 
-      // optional .cockroach.roachpb.Transaction txn = 4;
+      // optional .cockroach.roachpb.Transaction unexposed_txn = 4;
       case 4: {
         if (tag == 34) {
-         parse_txn:
+         parse_unexposed_txn:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_txn()));
+               input, mutable_unexposed_txn()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(42)) goto parse_detail;
+        if (input->ExpectTag(40)) goto parse_origin_node;
         break;
       }
 
-      // optional .cockroach.roachpb.ErrorDetail detail = 5;
+      // optional int32 origin_node = 5;
       case 5: {
-        if (tag == 42) {
+        if (tag == 40) {
+         parse_origin_node:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &origin_node_)));
+          set_has_origin_node();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(50)) goto parse_detail;
+        break;
+      }
+
+      // optional .cockroach.roachpb.ErrorDetail detail = 6;
+      case 6: {
+        if (tag == 50) {
          parse_detail:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_detail()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(50)) goto parse_index;
+        if (input->ExpectTag(58)) goto parse_index;
         break;
       }
 
-      // optional .cockroach.roachpb.ErrPosition index = 6;
-      case 6: {
-        if (tag == 50) {
+      // optional .cockroach.roachpb.ErrPosition index = 7;
+      case 7: {
+        if (tag == 58) {
          parse_index:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_index()));
@@ -9471,22 +9426,27 @@ void Error::SerializeWithCachedSizes(
       3, this->transaction_restart(), output);
   }
 
-  // optional .cockroach.roachpb.Transaction txn = 4;
-  if (has_txn()) {
+  // optional .cockroach.roachpb.Transaction unexposed_txn = 4;
+  if (has_unexposed_txn()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      4, *this->txn_, output);
+      4, *this->unexposed_txn_, output);
   }
 
-  // optional .cockroach.roachpb.ErrorDetail detail = 5;
+  // optional int32 origin_node = 5;
+  if (has_origin_node()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(5, this->origin_node(), output);
+  }
+
+  // optional .cockroach.roachpb.ErrorDetail detail = 6;
   if (has_detail()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      5, *this->detail_, output);
+      6, *this->detail_, output);
   }
 
-  // optional .cockroach.roachpb.ErrPosition index = 6;
+  // optional .cockroach.roachpb.ErrPosition index = 7;
   if (has_index()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      6, *this->index_, output);
+      7, *this->index_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -9521,25 +9481,30 @@ void Error::SerializeWithCachedSizes(
       3, this->transaction_restart(), target);
   }
 
-  // optional .cockroach.roachpb.Transaction txn = 4;
-  if (has_txn()) {
+  // optional .cockroach.roachpb.Transaction unexposed_txn = 4;
+  if (has_unexposed_txn()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        4, *this->txn_, target);
+        4, *this->unexposed_txn_, target);
   }
 
-  // optional .cockroach.roachpb.ErrorDetail detail = 5;
+  // optional int32 origin_node = 5;
+  if (has_origin_node()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(5, this->origin_node(), target);
+  }
+
+  // optional .cockroach.roachpb.ErrorDetail detail = 6;
   if (has_detail()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        5, *this->detail_, target);
+        6, *this->detail_, target);
   }
 
-  // optional .cockroach.roachpb.ErrPosition index = 6;
+  // optional .cockroach.roachpb.ErrPosition index = 7;
   if (has_index()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        6, *this->index_, target);
+        7, *this->index_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -9553,7 +9518,7 @@ void Error::SerializeWithCachedSizes(
 int Error::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 63u) {
+  if (_has_bits_[0 / 32] & 127u) {
     // optional string message = 1;
     if (has_message()) {
       total_size += 1 +
@@ -9572,21 +9537,28 @@ int Error::ByteSize() const {
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->transaction_restart());
     }
 
-    // optional .cockroach.roachpb.Transaction txn = 4;
-    if (has_txn()) {
+    // optional .cockroach.roachpb.Transaction unexposed_txn = 4;
+    if (has_unexposed_txn()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->txn_);
+          *this->unexposed_txn_);
     }
 
-    // optional .cockroach.roachpb.ErrorDetail detail = 5;
+    // optional int32 origin_node = 5;
+    if (has_origin_node()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->origin_node());
+    }
+
+    // optional .cockroach.roachpb.ErrorDetail detail = 6;
     if (has_detail()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->detail_);
     }
 
-    // optional .cockroach.roachpb.ErrPosition index = 6;
+    // optional .cockroach.roachpb.ErrPosition index = 7;
     if (has_index()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -9630,8 +9602,11 @@ void Error::MergeFrom(const Error& from) {
     if (from.has_transaction_restart()) {
       set_transaction_restart(from.transaction_restart());
     }
-    if (from.has_txn()) {
-      mutable_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.txn());
+    if (from.has_unexposed_txn()) {
+      mutable_unexposed_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.unexposed_txn());
+    }
+    if (from.has_origin_node()) {
+      set_origin_node(from.origin_node());
     }
     if (from.has_detail()) {
       mutable_detail()->::cockroach::roachpb::ErrorDetail::MergeFrom(from.detail());
@@ -9670,7 +9645,8 @@ void Error::InternalSwap(Error* other) {
   message_.Swap(&other->message_);
   std::swap(retryable_, other->retryable_);
   std::swap(transaction_restart_, other->transaction_restart_);
-  std::swap(txn_, other->txn_);
+  std::swap(unexposed_txn_, other->unexposed_txn_);
+  std::swap(origin_node_, other->origin_node_);
   std::swap(detail_, other->detail_);
   std::swap(index_, other->index_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -9791,58 +9767,82 @@ void Error::clear_transaction_restart() {
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Error.transaction_restart)
 }
 
-// optional .cockroach.roachpb.Transaction txn = 4;
-bool Error::has_txn() const {
+// optional .cockroach.roachpb.Transaction unexposed_txn = 4;
+bool Error::has_unexposed_txn() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
-void Error::set_has_txn() {
+void Error::set_has_unexposed_txn() {
   _has_bits_[0] |= 0x00000008u;
 }
-void Error::clear_has_txn() {
+void Error::clear_has_unexposed_txn() {
   _has_bits_[0] &= ~0x00000008u;
 }
-void Error::clear_txn() {
-  if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
-  clear_has_txn();
+void Error::clear_unexposed_txn() {
+  if (unexposed_txn_ != NULL) unexposed_txn_->::cockroach::roachpb::Transaction::Clear();
+  clear_has_unexposed_txn();
 }
-const ::cockroach::roachpb::Transaction& Error::txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.Error.txn)
-  return txn_ != NULL ? *txn_ : *default_instance_->txn_;
+const ::cockroach::roachpb::Transaction& Error::unexposed_txn() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Error.unexposed_txn)
+  return unexposed_txn_ != NULL ? *unexposed_txn_ : *default_instance_->unexposed_txn_;
 }
-::cockroach::roachpb::Transaction* Error::mutable_txn() {
-  set_has_txn();
-  if (txn_ == NULL) {
-    txn_ = new ::cockroach::roachpb::Transaction;
+::cockroach::roachpb::Transaction* Error::mutable_unexposed_txn() {
+  set_has_unexposed_txn();
+  if (unexposed_txn_ == NULL) {
+    unexposed_txn_ = new ::cockroach::roachpb::Transaction;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Error.txn)
-  return txn_;
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Error.unexposed_txn)
+  return unexposed_txn_;
 }
-::cockroach::roachpb::Transaction* Error::release_txn() {
-  clear_has_txn();
-  ::cockroach::roachpb::Transaction* temp = txn_;
-  txn_ = NULL;
+::cockroach::roachpb::Transaction* Error::release_unexposed_txn() {
+  clear_has_unexposed_txn();
+  ::cockroach::roachpb::Transaction* temp = unexposed_txn_;
+  unexposed_txn_ = NULL;
   return temp;
 }
-void Error::set_allocated_txn(::cockroach::roachpb::Transaction* txn) {
-  delete txn_;
-  txn_ = txn;
-  if (txn) {
-    set_has_txn();
+void Error::set_allocated_unexposed_txn(::cockroach::roachpb::Transaction* unexposed_txn) {
+  delete unexposed_txn_;
+  unexposed_txn_ = unexposed_txn;
+  if (unexposed_txn) {
+    set_has_unexposed_txn();
   } else {
-    clear_has_txn();
+    clear_has_unexposed_txn();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.txn)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.unexposed_txn)
 }
 
-// optional .cockroach.roachpb.ErrorDetail detail = 5;
-bool Error::has_detail() const {
+// optional int32 origin_node = 5;
+bool Error::has_origin_node() const {
   return (_has_bits_[0] & 0x00000010u) != 0;
 }
-void Error::set_has_detail() {
+void Error::set_has_origin_node() {
   _has_bits_[0] |= 0x00000010u;
 }
-void Error::clear_has_detail() {
+void Error::clear_has_origin_node() {
   _has_bits_[0] &= ~0x00000010u;
+}
+void Error::clear_origin_node() {
+  origin_node_ = 0;
+  clear_has_origin_node();
+}
+ ::google::protobuf::int32 Error::origin_node() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Error.origin_node)
+  return origin_node_;
+}
+ void Error::set_origin_node(::google::protobuf::int32 value) {
+  set_has_origin_node();
+  origin_node_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.Error.origin_node)
+}
+
+// optional .cockroach.roachpb.ErrorDetail detail = 6;
+bool Error::has_detail() const {
+  return (_has_bits_[0] & 0x00000020u) != 0;
+}
+void Error::set_has_detail() {
+  _has_bits_[0] |= 0x00000020u;
+}
+void Error::clear_has_detail() {
+  _has_bits_[0] &= ~0x00000020u;
 }
 void Error::clear_detail() {
   if (detail_ != NULL) detail_->::cockroach::roachpb::ErrorDetail::Clear();
@@ -9877,15 +9877,15 @@ void Error::set_allocated_detail(::cockroach::roachpb::ErrorDetail* detail) {
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.detail)
 }
 
-// optional .cockroach.roachpb.ErrPosition index = 6;
+// optional .cockroach.roachpb.ErrPosition index = 7;
 bool Error::has_index() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000040u) != 0;
 }
 void Error::set_has_index() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000040u;
 }
 void Error::clear_has_index() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000040u;
 }
 void Error::clear_index() {
   if (index_ != NULL) index_->::cockroach::roachpb::ErrPosition::Clear();

--- a/storage/engine/rocksdb/cockroach/roachpb/errors.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/errors.pb.h
@@ -554,14 +554,14 @@ class ReadWithinUncertaintyIntervalError : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.roachpb.Timestamp timestamp = 1;
-  bool has_timestamp() const;
-  void clear_timestamp();
-  static const int kTimestampFieldNumber = 1;
-  const ::cockroach::roachpb::Timestamp& timestamp() const;
-  ::cockroach::roachpb::Timestamp* mutable_timestamp();
-  ::cockroach::roachpb::Timestamp* release_timestamp();
-  void set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp);
+  // optional .cockroach.roachpb.Timestamp read_timestamp = 1;
+  bool has_read_timestamp() const;
+  void clear_read_timestamp();
+  static const int kReadTimestampFieldNumber = 1;
+  const ::cockroach::roachpb::Timestamp& read_timestamp() const;
+  ::cockroach::roachpb::Timestamp* mutable_read_timestamp();
+  ::cockroach::roachpb::Timestamp* release_read_timestamp();
+  void set_allocated_read_timestamp(::cockroach::roachpb::Timestamp* read_timestamp);
 
   // optional .cockroach.roachpb.Timestamp existing_timestamp = 2;
   bool has_existing_timestamp() const;
@@ -572,28 +572,18 @@ class ReadWithinUncertaintyIntervalError : public ::google::protobuf::Message {
   ::cockroach::roachpb::Timestamp* release_existing_timestamp();
   void set_allocated_existing_timestamp(::cockroach::roachpb::Timestamp* existing_timestamp);
 
-  // optional int32 node_id = 3;
-  bool has_node_id() const;
-  void clear_node_id();
-  static const int kNodeIdFieldNumber = 3;
-  ::google::protobuf::int32 node_id() const;
-  void set_node_id(::google::protobuf::int32 value);
-
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.ReadWithinUncertaintyIntervalError)
  private:
-  inline void set_has_timestamp();
-  inline void clear_has_timestamp();
+  inline void set_has_read_timestamp();
+  inline void clear_has_read_timestamp();
   inline void set_has_existing_timestamp();
   inline void clear_has_existing_timestamp();
-  inline void set_has_node_id();
-  inline void clear_has_node_id();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::roachpb::Timestamp* timestamp_;
+  ::cockroach::roachpb::Timestamp* read_timestamp_;
   ::cockroach::roachpb::Timestamp* existing_timestamp_;
-  ::google::protobuf::int32 node_id_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
@@ -2552,28 +2542,35 @@ class Error : public ::google::protobuf::Message {
   ::cockroach::roachpb::TransactionRestart transaction_restart() const;
   void set_transaction_restart(::cockroach::roachpb::TransactionRestart value);
 
-  // optional .cockroach.roachpb.Transaction txn = 4;
-  bool has_txn() const;
-  void clear_txn();
-  static const int kTxnFieldNumber = 4;
-  const ::cockroach::roachpb::Transaction& txn() const;
-  ::cockroach::roachpb::Transaction* mutable_txn();
-  ::cockroach::roachpb::Transaction* release_txn();
-  void set_allocated_txn(::cockroach::roachpb::Transaction* txn);
+  // optional .cockroach.roachpb.Transaction unexposed_txn = 4;
+  bool has_unexposed_txn() const;
+  void clear_unexposed_txn();
+  static const int kUnexposedTxnFieldNumber = 4;
+  const ::cockroach::roachpb::Transaction& unexposed_txn() const;
+  ::cockroach::roachpb::Transaction* mutable_unexposed_txn();
+  ::cockroach::roachpb::Transaction* release_unexposed_txn();
+  void set_allocated_unexposed_txn(::cockroach::roachpb::Transaction* unexposed_txn);
 
-  // optional .cockroach.roachpb.ErrorDetail detail = 5;
+  // optional int32 origin_node = 5;
+  bool has_origin_node() const;
+  void clear_origin_node();
+  static const int kOriginNodeFieldNumber = 5;
+  ::google::protobuf::int32 origin_node() const;
+  void set_origin_node(::google::protobuf::int32 value);
+
+  // optional .cockroach.roachpb.ErrorDetail detail = 6;
   bool has_detail() const;
   void clear_detail();
-  static const int kDetailFieldNumber = 5;
+  static const int kDetailFieldNumber = 6;
   const ::cockroach::roachpb::ErrorDetail& detail() const;
   ::cockroach::roachpb::ErrorDetail* mutable_detail();
   ::cockroach::roachpb::ErrorDetail* release_detail();
   void set_allocated_detail(::cockroach::roachpb::ErrorDetail* detail);
 
-  // optional .cockroach.roachpb.ErrPosition index = 6;
+  // optional .cockroach.roachpb.ErrPosition index = 7;
   bool has_index() const;
   void clear_index();
-  static const int kIndexFieldNumber = 6;
+  static const int kIndexFieldNumber = 7;
   const ::cockroach::roachpb::ErrPosition& index() const;
   ::cockroach::roachpb::ErrPosition* mutable_index();
   ::cockroach::roachpb::ErrPosition* release_index();
@@ -2587,8 +2584,10 @@ class Error : public ::google::protobuf::Message {
   inline void clear_has_retryable();
   inline void set_has_transaction_restart();
   inline void clear_has_transaction_restart();
-  inline void set_has_txn();
-  inline void clear_has_txn();
+  inline void set_has_unexposed_txn();
+  inline void clear_has_unexposed_txn();
+  inline void set_has_origin_node();
+  inline void clear_has_origin_node();
   inline void set_has_detail();
   inline void clear_has_detail();
   inline void set_has_index();
@@ -2600,9 +2599,10 @@ class Error : public ::google::protobuf::Message {
   ::google::protobuf::internal::ArenaStringPtr message_;
   bool retryable_;
   int transaction_restart_;
-  ::cockroach::roachpb::Transaction* txn_;
+  ::cockroach::roachpb::Transaction* unexposed_txn_;
   ::cockroach::roachpb::ErrorDetail* detail_;
   ::cockroach::roachpb::ErrPosition* index_;
+  ::google::protobuf::int32 origin_node_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2ferrors_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2froachpb_2ferrors_2eproto();
@@ -2917,47 +2917,47 @@ inline void RangeKeyMismatchError::set_allocated_range(::cockroach::roachpb::Ran
 
 // ReadWithinUncertaintyIntervalError
 
-// optional .cockroach.roachpb.Timestamp timestamp = 1;
-inline bool ReadWithinUncertaintyIntervalError::has_timestamp() const {
+// optional .cockroach.roachpb.Timestamp read_timestamp = 1;
+inline bool ReadWithinUncertaintyIntervalError::has_read_timestamp() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void ReadWithinUncertaintyIntervalError::set_has_timestamp() {
+inline void ReadWithinUncertaintyIntervalError::set_has_read_timestamp() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void ReadWithinUncertaintyIntervalError::clear_has_timestamp() {
+inline void ReadWithinUncertaintyIntervalError::clear_has_read_timestamp() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void ReadWithinUncertaintyIntervalError::clear_timestamp() {
-  if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_timestamp();
+inline void ReadWithinUncertaintyIntervalError::clear_read_timestamp() {
+  if (read_timestamp_ != NULL) read_timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_read_timestamp();
 }
-inline const ::cockroach::roachpb::Timestamp& ReadWithinUncertaintyIntervalError::timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.ReadWithinUncertaintyIntervalError.timestamp)
-  return timestamp_ != NULL ? *timestamp_ : *default_instance_->timestamp_;
+inline const ::cockroach::roachpb::Timestamp& ReadWithinUncertaintyIntervalError::read_timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.ReadWithinUncertaintyIntervalError.read_timestamp)
+  return read_timestamp_ != NULL ? *read_timestamp_ : *default_instance_->read_timestamp_;
 }
-inline ::cockroach::roachpb::Timestamp* ReadWithinUncertaintyIntervalError::mutable_timestamp() {
-  set_has_timestamp();
-  if (timestamp_ == NULL) {
-    timestamp_ = new ::cockroach::roachpb::Timestamp;
+inline ::cockroach::roachpb::Timestamp* ReadWithinUncertaintyIntervalError::mutable_read_timestamp() {
+  set_has_read_timestamp();
+  if (read_timestamp_ == NULL) {
+    read_timestamp_ = new ::cockroach::roachpb::Timestamp;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ReadWithinUncertaintyIntervalError.timestamp)
-  return timestamp_;
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ReadWithinUncertaintyIntervalError.read_timestamp)
+  return read_timestamp_;
 }
-inline ::cockroach::roachpb::Timestamp* ReadWithinUncertaintyIntervalError::release_timestamp() {
-  clear_has_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = timestamp_;
-  timestamp_ = NULL;
+inline ::cockroach::roachpb::Timestamp* ReadWithinUncertaintyIntervalError::release_read_timestamp() {
+  clear_has_read_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = read_timestamp_;
+  read_timestamp_ = NULL;
   return temp;
 }
-inline void ReadWithinUncertaintyIntervalError::set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp) {
-  delete timestamp_;
-  timestamp_ = timestamp;
-  if (timestamp) {
-    set_has_timestamp();
+inline void ReadWithinUncertaintyIntervalError::set_allocated_read_timestamp(::cockroach::roachpb::Timestamp* read_timestamp) {
+  delete read_timestamp_;
+  read_timestamp_ = read_timestamp;
+  if (read_timestamp) {
+    set_has_read_timestamp();
   } else {
-    clear_has_timestamp();
+    clear_has_read_timestamp();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ReadWithinUncertaintyIntervalError.timestamp)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ReadWithinUncertaintyIntervalError.read_timestamp)
 }
 
 // optional .cockroach.roachpb.Timestamp existing_timestamp = 2;
@@ -3001,30 +3001,6 @@ inline void ReadWithinUncertaintyIntervalError::set_allocated_existing_timestamp
     clear_has_existing_timestamp();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ReadWithinUncertaintyIntervalError.existing_timestamp)
-}
-
-// optional int32 node_id = 3;
-inline bool ReadWithinUncertaintyIntervalError::has_node_id() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-inline void ReadWithinUncertaintyIntervalError::set_has_node_id() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void ReadWithinUncertaintyIntervalError::clear_has_node_id() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-inline void ReadWithinUncertaintyIntervalError::clear_node_id() {
-  node_id_ = 0;
-  clear_has_node_id();
-}
-inline ::google::protobuf::int32 ReadWithinUncertaintyIntervalError::node_id() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.ReadWithinUncertaintyIntervalError.node_id)
-  return node_id_;
-}
-inline void ReadWithinUncertaintyIntervalError::set_node_id(::google::protobuf::int32 value) {
-  set_has_node_id();
-  node_id_ = value;
-  // @@protoc_insertion_point(field_set:cockroach.roachpb.ReadWithinUncertaintyIntervalError.node_id)
 }
 
 // -------------------------------------------------------------------
@@ -4704,58 +4680,82 @@ inline void Error::set_transaction_restart(::cockroach::roachpb::TransactionRest
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Error.transaction_restart)
 }
 
-// optional .cockroach.roachpb.Transaction txn = 4;
-inline bool Error::has_txn() const {
+// optional .cockroach.roachpb.Transaction unexposed_txn = 4;
+inline bool Error::has_unexposed_txn() const {
   return (_has_bits_[0] & 0x00000008u) != 0;
 }
-inline void Error::set_has_txn() {
+inline void Error::set_has_unexposed_txn() {
   _has_bits_[0] |= 0x00000008u;
 }
-inline void Error::clear_has_txn() {
+inline void Error::clear_has_unexposed_txn() {
   _has_bits_[0] &= ~0x00000008u;
 }
-inline void Error::clear_txn() {
-  if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
-  clear_has_txn();
+inline void Error::clear_unexposed_txn() {
+  if (unexposed_txn_ != NULL) unexposed_txn_->::cockroach::roachpb::Transaction::Clear();
+  clear_has_unexposed_txn();
 }
-inline const ::cockroach::roachpb::Transaction& Error::txn() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.Error.txn)
-  return txn_ != NULL ? *txn_ : *default_instance_->txn_;
+inline const ::cockroach::roachpb::Transaction& Error::unexposed_txn() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Error.unexposed_txn)
+  return unexposed_txn_ != NULL ? *unexposed_txn_ : *default_instance_->unexposed_txn_;
 }
-inline ::cockroach::roachpb::Transaction* Error::mutable_txn() {
-  set_has_txn();
-  if (txn_ == NULL) {
-    txn_ = new ::cockroach::roachpb::Transaction;
+inline ::cockroach::roachpb::Transaction* Error::mutable_unexposed_txn() {
+  set_has_unexposed_txn();
+  if (unexposed_txn_ == NULL) {
+    unexposed_txn_ = new ::cockroach::roachpb::Transaction;
   }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Error.txn)
-  return txn_;
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Error.unexposed_txn)
+  return unexposed_txn_;
 }
-inline ::cockroach::roachpb::Transaction* Error::release_txn() {
-  clear_has_txn();
-  ::cockroach::roachpb::Transaction* temp = txn_;
-  txn_ = NULL;
+inline ::cockroach::roachpb::Transaction* Error::release_unexposed_txn() {
+  clear_has_unexposed_txn();
+  ::cockroach::roachpb::Transaction* temp = unexposed_txn_;
+  unexposed_txn_ = NULL;
   return temp;
 }
-inline void Error::set_allocated_txn(::cockroach::roachpb::Transaction* txn) {
-  delete txn_;
-  txn_ = txn;
-  if (txn) {
-    set_has_txn();
+inline void Error::set_allocated_unexposed_txn(::cockroach::roachpb::Transaction* unexposed_txn) {
+  delete unexposed_txn_;
+  unexposed_txn_ = unexposed_txn;
+  if (unexposed_txn) {
+    set_has_unexposed_txn();
   } else {
-    clear_has_txn();
+    clear_has_unexposed_txn();
   }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.txn)
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.unexposed_txn)
 }
 
-// optional .cockroach.roachpb.ErrorDetail detail = 5;
-inline bool Error::has_detail() const {
+// optional int32 origin_node = 5;
+inline bool Error::has_origin_node() const {
   return (_has_bits_[0] & 0x00000010u) != 0;
 }
-inline void Error::set_has_detail() {
+inline void Error::set_has_origin_node() {
   _has_bits_[0] |= 0x00000010u;
 }
-inline void Error::clear_has_detail() {
+inline void Error::clear_has_origin_node() {
   _has_bits_[0] &= ~0x00000010u;
+}
+inline void Error::clear_origin_node() {
+  origin_node_ = 0;
+  clear_has_origin_node();
+}
+inline ::google::protobuf::int32 Error::origin_node() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Error.origin_node)
+  return origin_node_;
+}
+inline void Error::set_origin_node(::google::protobuf::int32 value) {
+  set_has_origin_node();
+  origin_node_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.Error.origin_node)
+}
+
+// optional .cockroach.roachpb.ErrorDetail detail = 6;
+inline bool Error::has_detail() const {
+  return (_has_bits_[0] & 0x00000020u) != 0;
+}
+inline void Error::set_has_detail() {
+  _has_bits_[0] |= 0x00000020u;
+}
+inline void Error::clear_has_detail() {
+  _has_bits_[0] &= ~0x00000020u;
 }
 inline void Error::clear_detail() {
   if (detail_ != NULL) detail_->::cockroach::roachpb::ErrorDetail::Clear();
@@ -4790,15 +4790,15 @@ inline void Error::set_allocated_detail(::cockroach::roachpb::ErrorDetail* detai
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Error.detail)
 }
 
-// optional .cockroach.roachpb.ErrPosition index = 6;
+// optional .cockroach.roachpb.ErrPosition index = 7;
 inline bool Error::has_index() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000040u) != 0;
 }
 inline void Error::set_has_index() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000040u;
 }
 inline void Error::clear_has_index() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000040u;
 }
 inline void Error::clear_index() {
   if (index_ != NULL) index_->::cockroach::roachpb::ErrPosition::Clear();

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -50,9 +50,8 @@ func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, h roachp
 		return &roachpb.NoopResponse{}, nil, nil
 	}
 
-	if pErr := r.checkCmdHeader(args.Header()); pErr != nil {
-		pErr.SetTxn(h.Txn)
-		return nil, nil, pErr
+	if err := r.checkCmdHeader(args.Header()); err != nil {
+		return nil, nil, roachpb.NewErrorWithTxn(err, h.Txn)
 	}
 
 	// If a unittest filter was installed, check for an injected error; otherwise, continue.
@@ -161,22 +160,6 @@ func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, h roachp
 	// Propagate the request timestamp (which may have changed).
 	// TODO(tschottdorf): really? Think this should be done by executeBatch.
 	reply.Header().Timestamp = ts
-
-	// A ReadWithinUncertaintyIntervalError contains the timestamp of the value
-	// that provoked the conflict. However, we forward the timestamp to the
-	// node's time here. The reason is that the caller (which is always
-	// transactional when this error occurs) in our implementation wants to
-	// use this information to extract a timestamp after which reads from
-	// the nodes are causally consistent with the transaction. This allows
-	// the node to be classified as without further uncertain reads for the
-	// remainder of the transaction.
-	// See the comment on roachpb.Transaction.CertainNodes.
-	if tErr, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); ok {
-		// Note that we can use this node's clock (which may be different from
-		// other replicas') because this error attaches the existing timestamp
-		// to the node itself when retrying.
-		tErr.ExistingTimestamp.Forward(r.store.Clock().Now())
-	}
 
 	// Create a roachpb.Error by initializing txn from the request/response header.
 	var pErr *roachpb.Error


### PR DESCRIPTION
Still got to write a test, but there's some awkward mocking involved.
## 

When executing on a Store, a transactional command now always returns a
timestamp off the local HLC clock. Thus, the first request to a node will
likely shrink the uncertainty interval for that node from `[x, x+250ms)`
to `[x, time_on_node)`, which should remove a lot of uncertainty-related
restarts.
One common occurrence of such restarts was spurious: When pushing an intent,
that intent will be encountered in the near future when retrying the write.
To avoid a restart in that case, we
- generally push not the to the minimal timestamp ahead of us but all the way
  up to the local HLC timestamp, and
- lower our uncertainty interval to this timestamp.

Added an originating Node's ID to roachpb.Error. Together with always observing
a timestamp, this allowed completely removing the active payload from
ReadWithinUncertaintyIntervalError and removed some questionable logic in
`replica_command.go`.

Fixes #2861.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4814)

<!-- Reviewable:end -->
