### PR TITLE
util/log: combine --alsologtostderr and --log-threshold

### DIFF
--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -417,7 +417,7 @@ func (l *LocalCluster) startNode(node *testNode) {
 		"--certs=/certs",
 		"--host=" + node.nodeStr,
 		"--port=" + base.DefaultPort,
-		"--log-threshold=INFO",
+		"--alsologtostderr=INFO",
 		"--scan-max-idle-time=200ms", // set low to speed up tests
 	}
 	for _, store := range node.stores {
@@ -437,7 +437,7 @@ func (l *LocalCluster) startNode(node *testNode) {
 			cmd,
 			"--log-dir="+dockerlogDir,
 			"--logtostderr=false",
-			"--alsologtostderr=true")
+			"--alsologtostderr=INFO")
 	}
 	l.createRoach(node, l.dns, l.vols, cmd...)
 	maybePanic(node.Start())

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -716,10 +716,9 @@ Available Commands:
   debug       debugging commands
 
 Flags:
-      --alsologtostderr value[=true]   log to standard error as well as files
+      --alsologtostderr value[=INFO]   logs at or above this threshold go to stderr (default ERROR)
       --log-backtrace-at value         when logging hits line file:N, emit a stack trace (default :0)
       --log-dir value                  if non-empty, write log files in this directory
-      --log-threshold value            logs at or above this threshold go to stderr (default ERROR)
       --logtostderr value[=true]       log to standard error instead of files
       --no-color value                 disable standard error log colorization
       --verbosity value                log level for V logs

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -280,6 +280,8 @@ func initFlags(ctx *Context) {
 	// The --log-dir default changes depending on the command. Avoid confusion by
 	// simply clearing it.
 	pf.Lookup("log-dir").DefValue = ""
+	// If no value is specified for --alsologtostderr output everything.
+	pf.Lookup("alsologtostderr").NoOptDefVal = "INFO"
 
 	{
 		f := startCmd.Flags()

--- a/util/log/doc.go
+++ b/util/log/doc.go
@@ -46,7 +46,7 @@
 //
 //	--logtostderr=true
 //		Logs are written to standard error instead of to files.
-//	--alsologtostderr=false
+//	--alsologtostderr=INFO
 //		Logs are written to standard error as well as to files.
 //	--log-dir=""
 //		Log files will be written to this directory instead of the

--- a/util/log/flags.go
+++ b/util/log/flags.go
@@ -23,10 +23,11 @@ import (
 )
 
 func init() {
-	logflags.InitFlags(&logging.mu, &logging.toStderr, &logging.alsoToStderr,
+	logflags.InitFlags(&logging.mu, &logging.toStderr,
 		newStringValue(&logDir, &logDirSet), &logging.nocolor, &logging.verbosity,
 		&logging.vmodule, &logging.traceLocation)
 	// We define this flag here because stderrThreshold has the type Severity
 	// which we can't pass to logflags without creating an import cycle.
-	flag.Var(&logging.stderrThreshold, "log-threshold", "logs at or above this threshold go to stderr")
+	flag.Var(&logging.stderrThreshold,
+		"alsologtostderr", "logs at or above this threshold go to stderr")
 }

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -50,7 +50,7 @@ func EnableLogFileOutput(dir string) {
 	defer logging.mu.Unlock()
 	logDir = dir
 	logging.toStderr = false
-	logging.alsoToStderr = true
+	logging.stderrThreshold = InfoLog
 }
 
 // DisableLogFileOutput turns off logging. For unittesting only.
@@ -62,7 +62,7 @@ func DisableLogFileOutput() {
 	}
 	logDir = ""
 	logging.toStderr = true
-	logging.alsoToStderr = false
+	logging.stderrThreshold = NumSeverity
 }
 
 // logDepth uses the PrintWith to format the output string and

--- a/util/log/logflags/logflags.go
+++ b/util/log/logflags/logflags.go
@@ -56,11 +56,10 @@ var _ flag.Value = &atomicBool{}
 
 // InitFlags creates logging flags which update the given variables. The passed mutex is
 // locked while the boolean variables are accessed during flag updates.
-func InitFlags(mu sync.Locker, toStderr *bool, alsoToStderr *bool, logDir flag.Value,
+func InitFlags(mu sync.Locker, toStderr *bool, logDir flag.Value,
 	nocolor *bool, verbosity, vmodule, traceLocation flag.Value) {
 	*toStderr = true // wonky way of specifying a default
 	flag.Var(&atomicBool{Locker: mu, b: toStderr}, "logtostderr", "log to standard error instead of files")
-	flag.Var(&atomicBool{Locker: mu, b: alsoToStderr}, "alsologtostderr", "log to standard error as well as files")
 	flag.BoolVar(nocolor, "no-color", *nocolor, "disable standard error log colorization")
 	flag.Var(verbosity, "verbosity", "log level for V logs")
 	flag.Var(vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")


### PR DESCRIPTION
The --alsologtostderr flag is equivalent to --log-threshold=INFO. Moved
the severity functionality from --log-threshold to --alsologtostderr.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4820)

<!-- Reviewable:end -->
