### PR TITLE
storage: Factor CommandQueue write dependencies to minimum read overlaps

### DIFF
--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -51,7 +51,7 @@ import (
 type CommandQueue struct {
 	cache   *cache.IntervalCache
 	idAlloc int64
-	rg      interval.RangeGroup // avoids allocating in GetWait.
+	rg, wRg interval.RangeGroup // avoids allocating in GetWait.
 }
 
 type cmd struct {
@@ -65,6 +65,7 @@ func NewCommandQueue() *CommandQueue {
 	cq := &CommandQueue{
 		cache: cache.NewIntervalCache(cache.Config{Policy: cache.CacheNone}),
 		rg:    interval.NewRangeTree(),
+		wRg:   interval.NewRangeTree(),
 	}
 	cq.cache.OnEvicted = cq.onEvicted
 	return cq
@@ -110,18 +111,19 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 		// dependencies to all gating commands for each new command, which could result
 		// in an exponential dependency explosion.
 		//
-		// For example, consider the following 5 commands, each with key ranges represented
-		// on the x axis and WaitGroup dependencies represented by vertical lines:
+		// For example, consider the following 5 write commands, each with key ranges
+		// represented on the x axis and WaitGroup dependencies represented by vertical
+		// lines:
 		//
-		// cmd 1:  --------------
-		//          |      |
-		// cmd 2:   |  -------------
-		//          |    |    |
-		// cmd 3:   -------   |
-		//               |    |
-		// cmd 4:        -------
-		//                  |
-		// cmd 5:        -------
+		// cmd 1:   --------------
+		//           |      |
+		// cmd 2:    |  -------------
+		//           |    |    |
+		// cmd 3:    -------   |
+		//                |    |
+		// cmd 4:         -------
+		//                   |
+		// cmd 5:         -------
 		//
 		// Instead of having each command establish explicit dependencies on all previous
 		// overlapping commands, each command only needs to establish explicit dependencies
@@ -129,28 +131,57 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 		// the new commands overlapped range. Following this strategy, the other dependencies
 		// will be implicitly enforced, which reduces memory utilization and synchronization
 		// costs.
+		//
 		// The exception are existing reads: since reads don't wait for each other, an incoming
 		// write must wait for reads even when they are covered by a "later" read (since that
-		// "later" read won't wait for the earlier read to complete).
+		// "later" read won't wait for the earlier read to complete). However, if that read is
+		// covered by a "later" write, we don't need to wait because writes can't be reordered.
 		//
-		// TODO(nvanbeschoten): some (likely minimal) gains are possible: The writer does not
-		// have to blindly wait for all reads; only those which aren't already covered directly
-		// by writes are relevant.
+		// Two example of how this logic works are shown below. Notice in the first example how
+		// the overlapping reads do not establish dependencies on each other, and can therefore
+		// be reordered. Also notice in the second example that once read command 4 overlaps
+		// a "later" write, it no longer needs to be a dependency for the new write command 5.
+		// However, because read command 3 does not overlap a "later" write, it is still a
+		// dependency for the new write, but can be safely reordered before or after command 4.
+		//
+		// cmd 1 [R]:                -----               ----------
+		//                             |                        |
+		// cmd 2 [W]:              ========                 ========
+		//                          |   |                    |   |
+		// cmd 3 [R]:             --+------                --+------
+		//                          | |                      | |
+		// cmd 4 [R]:          -------+-----        -----------+-----
+		//                       |    |              |         |
+		// cmd 5 [W]:   =====    |    |          =======       |
+		//                |      |    |            |           |
+		// cmd 5 [W]:   ====================     ====================
+		//
 		sort.Sort(overlapSorter(overlaps))
 		for i := len(overlaps) - 1; i >= 0; i-- {
 			keyRange, cmd := overlaps[i].Key.Range, overlaps[i].Value.(*cmd)
-			// If we're a write and the current overlap is a read, we always wait
-			// as discussed above. There's some flexibility about adding to the
-			// RangeGroup in that case (currently we do).
-			if cq.rg.Add(keyRange) || (!readOnly && cmd.readOnly) {
+			if cmd.readOnly {
+				// If the current overlap is a read (meaning we're a write because other reads will
+				// be filtered out if we're a read as well), we only need to wait if the write RangeGroup
+				// doesn't already enclose the read.
+				if !cq.wRg.Overlaps(keyRange) {
+					cq.rg.Add(keyRange)
+					cmd.pending = append(cmd.pending, wg)
+					wg.Add(1)
+				}
+			} else if cq.rg.Add(keyRange) {
+				// We only need to establish a write dependency when this key range is not covered
+				// by any other reads or writes. If so, add this key range to the write RangeGroup
+				// so that we can avoid previous read dependencies that are enforced by this write.
+				cq.wRg.Add(keyRange)
 				cmd.pending = append(cmd.pending, wg)
 				wg.Add(1)
 			}
 		}
 
-		// Clear the RangeGroup so that it can be used again. This is an alternative
-		// to using a local variable that must be allocated in every iteration.
+		// Clear the RangeGroups so that they can be used again. This is an alternative
+		// to using local variables that must be allocated in every iteration.
 		cq.rg.Clear()
+		cq.wRg.Clear()
 	}
 }
 

--- a/util/interval/interval.go
+++ b/util/interval/interval.go
@@ -253,8 +253,14 @@ func (t *Tree) Len() int {
 
 // Get returns a slice of Interfaces that overlap r in the Tree.
 func (t *Tree) Get(r Range) (o []Interface) {
-	if t.Root != nil && t.Overlapper(r, t.Root.Range) {
-		t.Root.doMatch(func(e Interface) (done bool) { o = append(o, e); return }, r, t.Overlapper)
+	return t.GetWithOverlapper(r, t.Overlapper)
+}
+
+// GetWithOverlapper returns a slice of Interfaces that overlap r
+// in the Tree using the provided overlapper function.
+func (t *Tree) GetWithOverlapper(r Range, overlapper func(Range, Range) bool) (o []Interface) {
+	if t.Root != nil && overlapper(r, t.Root.Range) {
+		t.Root.doMatch(func(e Interface) (done bool) { o = append(o, e); return }, r, overlapper)
 	}
 	return
 }


### PR DESCRIPTION
This PR includes two separate but related optimizations to the `CommandQueue.GetWait`
routine. They can be considered together or separately.
## Factor write dependencies to minimum read overlaps

When @tschottdorf's #4651 fixed a read-read anomaly in `CommandQueue`, it
did so by having write commands depend on all overlapping previous read commands.
This can be further reduced to a dependence on only the read commands that are
not already dependencies to other write commands. This was discussed briefly in
the PR from #4651.

This change makes the change to reduce write command dependencies to their
minimum group of commands using a second `RangeGroup` to keep track of
write commands alone. This change actually has a negative impact on the 
benchmarks, as is shown below. Still, I included it here so we could have a 
discussion about it. @bdarnell mentioned [here](https://github.com/cockroachdb/cockroach/pull/4651#issuecomment-189024715) that without an
optimization like this, the worst-case performance of `CommandQueue.GetWait`
would be the same as it used to be. This change allows us to once again 
achieve the better worst-case complexity (in terms of command 
dependencies) by doing some extra work upfront. I think it's at least worth a 
discussion as to if this small hit to performance is worth the guarantee that 
in a worst-case scenario the command dependency tree wouldn't explode.
##### Perf impact:

```
me                          old time/op    new time/op    delta
Bank_Cockroach-2                 417µs ± 2%     424µs ± 2%  +1.69%        (p=0.022 n=10+10)
Select1_Cockroach-2             58.6µs ± 1%    59.2µs ± 1%  +1.00%        (p=0.000 n=10+10)
Select2_Cockroach-2             1.02ms ± 1%    1.04ms ± 1%  +1.54%         (p=0.000 n=10+9)
Insert1_Cockroach-2              499µs ± 1%     511µs ± 1%  +2.40%        (p=0.000 n=10+10)
Insert10_Cockroach-2             881µs ± 1%     909µs ± 0%  +3.13%        (p=0.000 n=10+10)
Insert100_Cockroach-2           4.49ms ± 1%    4.63ms ± 1%  +2.95%         (p=0.000 n=9+10)
Insert1000_Cockroach-2          43.3ms ± 1%    44.8ms ± 1%  +3.46%        (p=0.000 n=10+10)
Update1_Cockroach-2              756µs ± 1%     768µs ± 1%  +1.62%        (p=0.000 n=10+10)
Update10_Cockroach-2            1.43ms ± 2%    1.45ms ± 1%  +1.72%         (p=0.000 n=10+8)
Update100_Cockroach-2           7.64ms ± 3%    7.81ms ± 2%  +2.26%        (p=0.002 n=10+10)
Update1000_Cockroach-2          68.4ms ± 1%    71.3ms ± 3%  +4.23%         (p=0.000 n=9+10)
Delete1_Cockroach-2              827µs ± 2%     840µs ± 1%  +1.59%        (p=0.000 n=10+10)
Delete10_Cockroach-2            2.48ms ± 3%    2.50ms ± 5%    ~           (p=0.315 n=10+10)
Delete100_Cockroach-2           19.4ms ± 2%    19.9ms ± 1%  +2.24%        (p=0.000 n=10+10)
Delete1000_Cockroach-2           204ms ± 1%     206ms ± 1%  +1.28%        (p=0.002 n=10+10)
Scan1_Cockroach-2                264µs ± 1%     265µs ± 1%    ~            (p=0.811 n=8+10)
Scan10_Cockroach-2               311µs ± 2%     312µs ± 1%    ~           (p=0.436 n=10+10)
Scan100_Cockroach-2              665µs ± 1%     678µs ± 1%  +1.99%        (p=0.000 n=10+10)
Scan1000_Cockroach-2            4.01ms ± 1%    4.12ms ± 1%  +2.78%        (p=0.000 n=10+10)
Scan10000_Cockroach-2           41.9ms ± 1%    43.1ms ± 1%  +2.95%        (p=0.000 n=10+10)
Scan1000Limit1_Cockroach-2       379µs ± 1%     380µs ± 1%  +0.39%        (p=0.015 n=10+10)
Scan1000Limit10_Cockroach-2      422µs ± 1%     425µs ± 1%  +0.69%        (p=0.003 n=10+10)
Scan1000Limit100_Cockroach-2     770µs ± 1%     783µs ± 1%  +1.62%         (p=0.000 n=10+9)
PgbenchQuery_Cockroach-2        3.95ms ± 5%    3.98ms ± 4%    ~           (p=0.393 n=10+10)

name                          old alloc/op   new alloc/op   delta
Bank_Cockroach-2                68.4kB ± 0%    68.4kB ± 0%    ~           (p=0.698 n=10+10)
Select1_Cockroach-2             3.90kB ± 0%    3.90kB ± 0%    ~            (p=0.710 n=7+10)
Select2_Cockroach-2             80.5kB ± 0%    80.5kB ± 0%    ~           (p=0.470 n=10+10)
Insert1_Cockroach-2             22.8kB ± 0%    22.8kB ± 0%    ~           (p=0.897 n=10+10)
Insert10_Cockroach-2            66.8kB ± 0%    66.8kB ± 0%    ~           (p=0.470 n=10+10)
Insert100_Cockroach-2            506kB ± 0%     506kB ± 0%    ~            (p=0.182 n=10+9)
Insert1000_Cockroach-2          4.58MB ± 1%    4.55MB ± 1%    ~           (p=0.075 n=10+10)
Update1_Cockroach-2             36.4kB ± 0%    36.4kB ± 0%    ~            (p=0.889 n=9+10)
Update10_Cockroach-2            99.3kB ± 0%    99.3kB ± 0%    ~            (p=0.219 n=9+10)
Update100_Cockroach-2            703kB ± 0%     702kB ± 0%    ~           (p=0.912 n=10+10)
Update1000_Cockroach-2          6.12MB ± 1%    6.10MB ± 1%    ~           (p=0.315 n=10+10)
Delete1_Cockroach-2             35.3kB ± 0%    35.3kB ± 0%    ~           (p=0.089 n=10+10)
Delete10_Cockroach-2             105kB ± 0%     105kB ± 0%    ~            (p=0.082 n=10+9)
Delete100_Cockroach-2            788kB ± 0%     788kB ± 0%    ~             (p=0.666 n=9+9)
Delete1000_Cockroach-2          7.13MB ± 2%    7.15MB ± 2%    ~           (p=0.796 n=10+10)
Scan1_Cockroach-2               13.1kB ± 1%    13.1kB ± 0%    ~           (p=0.323 n=10+10)
Scan10_Cockroach-2              16.9kB ± 0%    17.0kB ± 0%    ~            (p=0.150 n=9+10)
Scan100_Cockroach-2             49.2kB ± 0%    49.2kB ± 0%    ~           (p=0.492 n=10+10)
Scan1000_Cockroach-2             331kB ± 0%     331kB ± 0%    ~            (p=0.780 n=10+9)
Scan10000_Cockroach-2           5.75MB ± 0%    5.75MB ± 0%  +0.08%         (p=0.007 n=10+9)
Scan1000Limit1_Cockroach-2      13.9kB ± 0%    13.9kB ± 0%    ~            (p=0.473 n=8+10)
Scan1000Limit10_Cockroach-2     17.7kB ± 0%    17.7kB ± 0%    ~            (p=0.325 n=9+10)
Scan1000Limit100_Cockroach-2    49.9kB ± 0%    49.9kB ± 0%    ~            (p=0.246 n=10+8)
PgbenchQuery_Cockroach-2         221kB ± 4%     219kB ± 5%    ~           (p=0.869 n=10+10)

name                          old allocs/op  new allocs/op  delta
Bank_Cockroach-2                 1.67k ± 0%     1.67k ± 0%    ~           (p=0.465 n=10+10)
Select1_Cockroach-2               97.0 ± 0%      97.0 ± 0%    ~     (all samples are equal)
Select2_Cockroach-2              2.70k ± 0%     2.70k ± 0%    ~            (p=0.137 n=10+8)
Insert1_Cockroach-2                352 ± 0%       352 ± 0%    ~            (p=0.549 n=10+8)
Insert10_Cockroach-2               902 ± 0%       902 ± 0%    ~           (p=1.000 n=10+10)
Insert100_Cockroach-2            6.18k ± 0%     6.17k ± 0%    ~            (p=0.762 n=10+8)
Insert1000_Cockroach-2           59.1k ± 0%     59.0k ± 0%    ~           (p=0.289 n=10+10)
Update1_Cockroach-2                712 ± 0%       712 ± 0%    ~            (p=0.970 n=9+10)
Update10_Cockroach-2             1.41k ± 0%     1.41k ± 0%    ~            (p=0.603 n=9+10)
Update100_Cockroach-2            7.94k ± 0%     7.94k ± 0%    ~           (p=0.724 n=10+10)
Update1000_Cockroach-2           70.5k ± 0%     70.5k ± 0%    ~           (p=0.539 n=10+10)
Delete1_Cockroach-2                682 ± 0%       682 ± 0%    ~           (p=0.087 n=10+10)
Delete10_Cockroach-2             1.67k ± 0%     1.66k ± 0%  -0.06%         (p=0.013 n=10+9)
Delete100_Cockroach-2            11.1k ± 0%     11.1k ± 0%    ~             (p=0.490 n=9+8)
Delete1000_Cockroach-2            106k ± 1%      106k ± 1%    ~           (p=0.643 n=10+10)
Scan1_Cockroach-2                  272 ± 1%       272 ± 0%    ~            (p=0.133 n=10+9)
Scan10_Cockroach-2                 352 ± 0%       352 ± 0%    ~            (p=0.081 n=7+10)
Scan100_Cockroach-2              1.08k ± 0%     1.08k ± 0%    ~           (p=0.656 n=10+10)
Scan1000_Cockroach-2             8.29k ± 0%     8.29k ± 0%  -0.01%         (p=0.000 n=10+9)
Scan10000_Cockroach-2            80.4k ± 0%     80.4k ± 0%  +0.00%        (p=0.025 n=10+10)
Scan1000Limit1_Cockroach-2         295 ± 0%       295 ± 0%  +0.17%         (p=0.043 n=9+10)
Scan1000Limit10_Cockroach-2        374 ± 0%       374 ± 0%    ~            (p=1.172 n=9+10)
Scan1000Limit100_Cockroach-2     1.10k ± 0%     1.10k ± 0%    ~     (all samples are equal)
PgbenchQuery_Cockroach-2         3.96k ± 3%     3.94k ± 3%    ~           (p=0.928 n=10+10)
```
## Cut dependency search short when possible

In our current implementation of the `CommandQueue` dependency search,
we first sort all overlapping commands by their timestamp and iterate
over these commands in reverse, building up a `RangeGroup` as we go.
Through this approach, we can logically prove that if the `RangeGroup`
fully encloses the new range, then no older commands are needed to be
added as dependencies. Because of this, we can cut the search off early
when we detect this situation.
##### Perf impact:

```
name                          old time/op    new time/op    delta
Bank_Cockroach-2                 424µs ± 2%     426µs ± 2%    ~           (p=0.529 n=10+10)
Select1_Cockroach-2             59.2µs ± 1%    58.9µs ± 2%    ~           (p=0.075 n=10+10)
Select2_Cockroach-2             1.04ms ± 1%    1.02ms ± 1%  -1.52%         (p=0.000 n=9+10)
Insert1_Cockroach-2              511µs ± 1%     497µs ± 1%  -2.68%        (p=0.000 n=10+10)
Insert10_Cockroach-2             909µs ± 0%     882µs ± 1%  -2.92%        (p=0.000 n=10+10)
Insert100_Cockroach-2           4.63ms ± 1%    4.46ms ± 1%  -3.53%        (p=0.000 n=10+10)
Insert1000_Cockroach-2          44.8ms ± 1%    43.2ms ± 1%  -3.53%         (p=0.000 n=10+9)
Update1_Cockroach-2              768µs ± 1%     755µs ± 1%  -1.66%        (p=0.000 n=10+10)
Update10_Cockroach-2            1.45ms ± 1%    1.42ms ± 2%  -1.87%         (p=0.002 n=8+10)
Update100_Cockroach-2           7.81ms ± 2%    7.62ms ± 2%  -2.44%        (p=0.000 n=10+10)
Update1000_Cockroach-2          71.3ms ± 3%    69.3ms ± 1%  -2.82%        (p=0.000 n=10+10)
Delete1_Cockroach-2              840µs ± 1%     829µs ± 2%  -1.30%        (p=0.009 n=10+10)
Delete10_Cockroach-2            2.50ms ± 5%    2.48ms ± 3%    ~           (p=0.218 n=10+10)
Delete100_Cockroach-2           19.9ms ± 1%    19.8ms ± 2%    ~           (p=0.739 n=10+10)
Delete1000_Cockroach-2           206ms ± 1%     203ms ± 1%  -1.41%        (p=0.000 n=10+10)
Scan1_Cockroach-2                265µs ± 1%     263µs ± 1%  -0.80%        (p=0.029 n=10+10)
Scan10_Cockroach-2               312µs ± 1%     309µs ± 1%  -0.94%        (p=0.002 n=10+10)
Scan100_Cockroach-2              678µs ± 1%     672µs ± 2%  -0.87%        (p=0.035 n=10+10)
Scan1000_Cockroach-2            4.12ms ± 1%    4.04ms ± 1%  -1.95%        (p=0.000 n=10+10)
Scan10000_Cockroach-2           43.1ms ± 1%    42.1ms ± 1%  -2.23%         (p=0.000 n=10+9)
Scan1000Limit1_Cockroach-2       380µs ± 1%     378µs ± 1%  -0.51%        (p=0.002 n=10+10)
Scan1000Limit10_Cockroach-2      425µs ± 1%     422µs ± 0%  -0.72%         (p=0.002 n=10+9)
Scan1000Limit100_Cockroach-2     783µs ± 1%     779µs ± 3%    ~            (p=0.156 n=9+10)
PgbenchQuery_Cockroach-2        3.98ms ± 4%    3.88ms ± 4%  -2.73%        (p=0.023 n=10+10)

name                          old alloc/op   new alloc/op   delta
Bank_Cockroach-2                68.4kB ± 0%    68.4kB ± 0%    ~           (p=0.753 n=10+10)
Select1_Cockroach-2             3.90kB ± 0%    3.90kB ± 0%    ~            (p=0.750 n=10+9)
Select2_Cockroach-2             80.5kB ± 0%    80.5kB ± 0%    ~            (p=0.326 n=10+9)
Insert1_Cockroach-2             22.8kB ± 0%    22.8kB ± 0%    ~           (p=0.643 n=10+10)
Insert10_Cockroach-2            66.8kB ± 0%    66.7kB ± 0%  -0.05%         (p=0.029 n=10+9)
Insert100_Cockroach-2            506kB ± 0%     506kB ± 0%    ~             (p=0.222 n=9+9)
Insert1000_Cockroach-2          4.55MB ± 1%    4.56MB ± 1%    ~           (p=0.912 n=10+10)
Update1_Cockroach-2             36.4kB ± 0%    36.4kB ± 0%    ~           (p=0.956 n=10+10)
Update10_Cockroach-2            99.3kB ± 0%    99.3kB ± 0%    ~            (p=0.460 n=10+8)
Update100_Cockroach-2            702kB ± 0%     702kB ± 0%    ~           (p=0.579 n=10+10)
Update1000_Cockroach-2          6.10MB ± 1%    6.09MB ± 1%    ~           (p=0.353 n=10+10)
Delete1_Cockroach-2             35.3kB ± 0%    35.3kB ± 0%    ~           (p=0.210 n=10+10)
Delete10_Cockroach-2             105kB ± 0%     105kB ± 0%    ~             (p=0.222 n=9+9)
Delete100_Cockroach-2            788kB ± 0%     788kB ± 0%    ~            (p=0.905 n=9+10)
Delete1000_Cockroach-2          7.15MB ± 2%    7.10MB ± 0%    ~            (p=0.315 n=10+8)
Scan1_Cockroach-2               13.1kB ± 0%    13.1kB ± 0%    ~           (p=1.000 n=10+10)
Scan10_Cockroach-2              17.0kB ± 0%    17.0kB ± 0%    ~           (p=0.927 n=10+10)
Scan100_Cockroach-2             49.2kB ± 0%    49.2kB ± 0%    ~            (p=0.459 n=10+9)
Scan1000_Cockroach-2             331kB ± 0%     331kB ± 0%    ~            (p=0.305 n=9+10)
Scan10000_Cockroach-2           5.75MB ± 0%    5.75MB ± 0%    ~             (p=0.308 n=9+9)
Scan1000Limit1_Cockroach-2      13.9kB ± 0%    13.9kB ± 0%    ~            (p=0.340 n=10+8)
Scan1000Limit10_Cockroach-2     17.7kB ± 0%    17.7kB ± 0%    ~            (p=0.285 n=10+9)
Scan1000Limit100_Cockroach-2    49.9kB ± 0%    49.9kB ± 0%    ~            (p=0.530 n=8+10)
PgbenchQuery_Cockroach-2         219kB ± 5%     219kB ±12%    ~           (p=0.481 n=10+10)

name                          old allocs/op  new allocs/op  delta
Bank_Cockroach-2                 1.67k ± 0%     1.67k ± 0%    ~            (p=0.325 n=10+9)
Select1_Cockroach-2               97.0 ± 0%      97.0 ± 0%    ~     (all samples are equal)
Select2_Cockroach-2              2.70k ± 0%     2.70k ± 0%    ~     (all samples are equal)
Insert1_Cockroach-2                352 ± 0%       352 ± 0%    ~     (all samples are equal)
Insert10_Cockroach-2               902 ± 0%       902 ± 0%  -0.04%         (p=0.046 n=10+8)
Insert100_Cockroach-2            6.17k ± 0%     6.18k ± 0%    ~            (p=0.312 n=8+10)
Insert1000_Cockroach-2           59.0k ± 0%     59.1k ± 0%    ~           (p=0.739 n=10+10)
Update1_Cockroach-2                712 ± 0%       712 ± 0%    ~           (p=1.000 n=10+10)
Update10_Cockroach-2             1.41k ± 0%     1.41k ± 0%    ~            (p=1.235 n=10+8)
Update100_Cockroach-2            7.94k ± 0%     7.94k ± 0%    ~           (p=0.513 n=10+10)
Update1000_Cockroach-2           70.5k ± 0%     70.4k ± 0%    ~           (p=0.168 n=10+10)
Delete1_Cockroach-2                682 ± 0%       682 ± 0%    ~           (p=0.211 n=10+10)
Delete10_Cockroach-2             1.66k ± 0%     1.67k ± 0%  +0.05%          (p=0.047 n=9+8)
Delete100_Cockroach-2            11.1k ± 0%     11.1k ± 0%    ~            (p=0.091 n=8+10)
Delete1000_Cockroach-2            106k ± 1%      105k ± 0%    ~            (p=0.263 n=10+8)
Scan1_Cockroach-2                  272 ± 0%       272 ± 0%    ~     (all samples are equal)
Scan10_Cockroach-2                 352 ± 0%       352 ± 0%    ~           (p=0.650 n=10+10)
Scan100_Cockroach-2              1.08k ± 0%     1.08k ± 0%    ~            (p=0.176 n=10+7)
Scan1000_Cockroach-2             8.29k ± 0%     8.29k ± 0%    ~            (p=0.065 n=9+10)
Scan10000_Cockroach-2            80.4k ± 0%     80.4k ± 0%    ~            (p=0.745 n=10+9)
Scan1000Limit1_Cockroach-2         295 ± 0%       295 ± 0%    ~           (p=1.000 n=10+10)
Scan1000Limit10_Cockroach-2        374 ± 0%       375 ± 0%    ~           (p=1.000 n=10+10)
Scan1000Limit100_Cockroach-2     1.10k ± 0%     1.10k ± 0%    ~            (p=0.137 n=8+10)
PgbenchQuery_Cockroach-2         3.94k ± 3%     3.94k ± 8%    ~           (p=0.698 n=10+10)
```

_(as an interesting note, together these optimizations are basically a wash in terms of benchmark
performance, but improve our worst-case command dependency complexity)_

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4842)

<!-- Reviewable:end -->
