### PR TITLE
Write StatusSummaries and metrics at startup

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -470,6 +471,11 @@ func (n *Node) bootstrapStores(bootstraps []*storage.Store, stopper *stop.Stoppe
 		// until this store is used for range allocations.
 		s.GossipStore()
 	}
+	// write a new status summary after all stores have been bootstrapped; this
+	// helps the UI remain responsive when new nodes are added.
+	if err := n.writeSummaries(); err != nil {
+		log.Warningf("error writing node summary after store bootstrap: %s", err)
+	}
 }
 
 // connectGossip connects to gossip network and reads cluster ID. If
@@ -563,6 +569,70 @@ func (n *Node) computePeriodicMetrics() error {
 	return n.stores.VisitStores(func(store *storage.Store) error {
 		return store.ComputeMetrics()
 	})
+}
+
+// startWriteSummaries begins periodically persisting status summaries for the
+// node and its stores.
+func (n *Node) startWriteSummaries(frequency time.Duration) {
+	// Immediately record summaries once on server startup.
+	n.stopper.RunWorker(func() {
+		// Write a status summary immediately; this helps the UI remain
+		// responsive when new nodes are added.
+		if err := n.writeSummaries(); err != nil {
+			log.Warningf("error recording initial status summaries: %s", err)
+		}
+		ticker := time.NewTicker(frequency)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := n.writeSummaries(); err != nil {
+					log.Warningf("error recording status summaries: %s", err)
+				}
+			case <-n.stopper.ShouldStop():
+				return
+			}
+		}
+	})
+}
+
+// writeSummaries retrieves status summaries from the supplied
+// NodeStatusRecorder and persists them to the cockroach data store.
+func (n *Node) writeSummaries() error {
+	var err error
+	n.stopper.RunTask(func() {
+		nodeStatus, storeStatuses := n.recorder.GetStatusSummaries()
+		if nodeStatus != nil {
+			key := keys.NodeStatusKey(int32(nodeStatus.Desc.NodeID))
+			if pErr := n.ctx.DB.Put(key, nodeStatus); pErr != nil {
+				err = pErr.GoError()
+				return
+			}
+			if log.V(1) {
+				statusJSON, err := json.Marshal(nodeStatus)
+				if err != nil {
+					log.Errorf("error marshaling nodeStatus to json: %s", err)
+				}
+				log.Infof("node %d status: %s", nodeStatus.Desc.NodeID, statusJSON)
+			}
+		}
+
+		for _, ss := range storeStatuses {
+			key := keys.StoreStatusKey(int32(ss.Desc.StoreID))
+			if pErr := n.ctx.DB.Put(key, &ss); pErr != nil {
+				err = pErr.GoError()
+				return
+			}
+			if log.V(1) {
+				statusJSON, err := json.Marshal(&ss)
+				if err != nil {
+					log.Errorf("error marshaling storeStatus to json: %s", err)
+				}
+				log.Infof("store %d status: %s", ss.Desc.StoreID, statusJSON)
+			}
+		}
+	})
+	return err
 }
 
 // executeCmd interprets the given message as a *roachpb.BatchRequest and sends it

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -530,7 +530,7 @@ func TestStatusSummaries(t *testing.T) {
 		// Ensure that the event feed has been fully flushed.
 		ts.EventFeed().Flush()
 
-		if err := ts.writeSummaries(); err != nil {
+		if err := ts.WriteSummaries(); err != nil {
 			t.Fatalf("error writing summaries: %s", err)
 		}
 	}

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -277,7 +277,7 @@ func startServer(t *testing.T) TestServer {
 
 	ts.EventFeed().Flush()
 
-	if err := ts.writeSummaries(); err != nil {
+	if err := ts.WriteSummaries(); err != nil {
 		t.Fatalf("error writing summaries: %s", err)
 	}
 

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -321,7 +321,7 @@ func (ts *TestServer) SetRangeRetryOptions(ro retry.Options) {
 // WriteSummaries records summaries of time-series data, which is required for any tests
 // that query server stats.
 func (ts *TestServer) WriteSummaries() error {
-	return ts.Server.writeSummaries()
+	return ts.node.writeSummaries()
 }
 
 // MustGetSQLCounter returns the value of a counter metric from the server's SQL

--- a/ts/db.go
+++ b/ts/db.go
@@ -70,6 +70,8 @@ type poller struct {
 // time series data from the DataSource and store it.
 func (p *poller) start() {
 	p.stopper.RunWorker(func() {
+		// Poll once immediately.
+		p.poll()
 		ticker := time.NewTicker(p.frequency)
 		defer ticker.Stop()
 		for {

--- a/ui/ts/models/status.ts
+++ b/ui/ts/models/status.ts
@@ -129,7 +129,17 @@ module Models {
       private _data: Utils.QueryCache<Proto.NodeStatus[]> = new Utils.QueryCache((): promise<Proto.NodeStatus[]> => {
         return Utils.Http.Get("/_status/nodes/")
           .then((results: NodeStatusResponseSet) => {
-            return results.d;
+            let statuses = results.d;
+            statuses.forEach((ns: Proto.NodeStatus) => {
+              // store_ids will be null if the associated node has no
+              // bootstrapped stores; this causes significant null-handling
+              // problems in code. Convert "null" or "undefined" to an empty
+              // array.
+              if (!_.isArray(ns.store_ids)) {
+                ns.store_ids = [];
+              }
+            });
+            return statuses;
           });
       });
 


### PR DESCRIPTION
The server will now aggressively record node status summaries and metrics
immediately at startup; this alleviates the current poor experience in the UI,
where the server reports having zero nodes for the first ten seconds (a similar
delay occurs when other nodes are added, but are not immediately present in the
UI.)

Status summaries are also recorded as soon as stores are bootstrapped on new
nodes; this prevents nodes from existing with zero stores for a lengthy period.

Finally, this bug repairs a UI issue where a node is returned which has zero
stores (possible before stores have finished bootstrapping). This caused a
null-reference in the UI which blanked out the "Nodes" page. We discussed
several methods of preventing this particular null reference, including
modifications to the way protobuffers are marshalled to JSON; in the end, we
agreed that handling the possible null on the client side was the best option
for now. I have logged issue #4849 to follow up on this in the future.

Fixes #4747

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4850)

<!-- Reviewable:end -->
