### PR TITLE
Support ORDER BY and LIMIT on all SELECT-like statements

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -41,7 +41,7 @@ func (p *planner) Delete(n *parser.Delete, autoCommit bool) (planNode, *roachpb.
 
 	// TODO(tamird,pmattis): avoid going through Select to avoid encoding
 	// and decoding keys.
-	rows, pErr := p.Select(&parser.Select{
+	rows, pErr := p.SelectClause(&parser.SelectClause{
 		Exprs: tableDesc.allColumnsSelector(),
 		From:  parser.TableExprs{n.Table},
 		Where: n.Where,

--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -25,7 +25,7 @@ import (
 )
 
 // distinct constructs a distinctNode.
-func (*planner) distinct(n *parser.Select, p planNode) planNode {
+func (*planner) distinct(n *parser.SelectClause, p planNode) planNode {
 	if !n.Distinct {
 		return p
 	}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -958,7 +958,7 @@ func (e *Executor) updateStmtCounts(stmt parser.Statement) {
 	switch stmt.(type) {
 	case *parser.BeginTransaction:
 		e.txnBeginCount.Inc(1)
-	case *parser.SelectClause:
+	case *parser.Select:
 		e.selectCount.Inc(1)
 	case *parser.Update:
 		e.updateCount.Inc(1)

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -958,7 +958,7 @@ func (e *Executor) updateStmtCounts(stmt parser.Statement) {
 	switch stmt.(type) {
 	case *parser.BeginTransaction:
 		e.txnBeginCount.Inc(1)
-	case *parser.Select:
+	case *parser.SelectClause:
 		e.selectCount.Inc(1)
 	case *parser.Update:
 		e.updateCount.Inc(1)

--- a/sql/group.go
+++ b/sql/group.go
@@ -43,7 +43,7 @@ var aggregates = map[string]func() aggregateImpl{
 
 // groupBy constructs a groupNode according to grouping functions or clauses. This may adjust the
 // render targets in the selectNode as necessary.
-func (p *planner) groupBy(n *parser.Select, s *selectNode) (*groupNode, *roachpb.Error) {
+func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, *roachpb.Error) {
 	// Determine if aggregation is being performed. This check is done on the raw
 	// Select expressions as simplification might have removed aggregation
 	// functions (e.g. `SELECT MIN(1)` -> `SELECT 1`).
@@ -533,7 +533,7 @@ func (p *planner) aggregateInExpr(expr parser.Expr) bool {
 	return false
 }
 
-func (p *planner) isAggregate(n *parser.Select) bool {
+func (p *planner) isAggregate(n *parser.SelectClause) bool {
 	if n.Having != nil || len(n.GroupBy) > 0 {
 		return true
 	}

--- a/sql/group.go
+++ b/sql/group.go
@@ -79,7 +79,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, *r
 		// NB: This is not a deep copy, and thus when extractAggregateFuncs runs
 		// on s.render, the GroupBy expressions can contain wrapped qvalues.
 		// aggregateFunc's Eval() method handles being called during grouping.
-		if col, err := s.colIndex(norm); err != nil {
+		if col, err := colIndex(s.numOriginalCols, norm); err != nil {
 			return nil, roachpb.NewError(err)
 		} else if col >= 0 {
 			groupBy[i] = s.render[col]

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -315,9 +315,9 @@ func (p *planner) fillDefaults(defaultExprs []parser.Expr,
 		return &parser.ValuesClause{Tuples: []*parser.Tuple{{Exprs: row}}}
 	}
 
-	values, ok := n.Rows.(*parser.ValuesClause)
+	values, ok := n.Rows.Select.(*parser.ValuesClause)
 	if !ok {
-		return n.Rows
+		return n.Rows.Select
 	}
 
 	ret := values

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -312,10 +312,10 @@ func (p *planner) fillDefaults(defaultExprs []parser.Expr,
 			}
 			row = append(row, defaultExprs[i])
 		}
-		return &parser.Values{Tuples: []*parser.Tuple{{Exprs: row}}}
+		return &parser.ValuesClause{Tuples: []*parser.Tuple{{Exprs: row}}}
 	}
 
-	values, ok := n.Rows.(*parser.Values)
+	values, ok := n.Rows.(*parser.ValuesClause)
 	if !ok {
 		return n.Rows
 	}
@@ -328,7 +328,7 @@ func (p *planner) fillDefaults(defaultExprs []parser.Expr,
 			case parser.DefaultVal:
 				if !tupleCopied {
 					if ret == values {
-						ret = &parser.Values{Tuples: append([]*parser.Tuple(nil), values.Tuples...)}
+						ret = &parser.ValuesClause{Tuples: append([]*parser.Tuple(nil), values.Tuples...)}
 					}
 					ret.Tuples[tIdx] =
 						&parser.Tuple{Exprs: append([]parser.Expr(nil), tuple.Exprs...)}

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -26,8 +26,8 @@ import (
 )
 
 // limit constructs a limitNode based on the LIMIT and OFFSET clauses.
-func (p *planner) limit(n *parser.SelectClause, plan planNode) (planNode, error) {
-	if n.Limit == nil {
+func (p *planner) limit(limit *parser.Limit, plan planNode) (planNode, error) {
+	if limit == nil {
 		return plan, nil
 	}
 
@@ -39,8 +39,8 @@ func (p *planner) limit(n *parser.SelectClause, plan planNode) (planNode, error)
 		dst        *int64
 		defaultVal int64
 	}{
-		{"LIMIT", n.Limit.Count, &count, math.MaxInt64},
-		{"OFFSET", n.Limit.Offset, &offset, 0},
+		{"LIMIT", limit.Count, &count, math.MaxInt64},
+		{"OFFSET", limit.Offset, &offset, 0},
 	}
 
 	for _, datum := range data {

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -26,7 +26,7 @@ import (
 )
 
 // limit constructs a limitNode based on the LIMIT and OFFSET clauses.
-func (p *planner) limit(n *parser.Select, plan planNode) (planNode, error) {
+func (p *planner) limit(n *parser.SelectClause, plan planNode) (planNode, error) {
 	if n.Limit == nil {
 		return plan, nil
 	}

--- a/sql/parser/insert.go
+++ b/sql/parser/insert.go
@@ -31,7 +31,7 @@ import (
 type Insert struct {
 	Table     *QualifiedName
 	Columns   QualifiedNames
-	Rows      SelectStatement
+	Rows      *Select
 	Returning ReturningExprs
 }
 
@@ -52,5 +52,5 @@ func (node *Insert) String() string {
 
 // DefaultValues returns true iff only default values are being inserted.
 func (node *Insert) DefaultValues() bool {
-	return node.Rows == nil
+	return node.Rows.Select == nil
 }

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -135,7 +135,7 @@ func parseExpr(expr string, syntax Syntax) (Expr, error) {
 	if err != nil {
 		return nil, err
 	}
-	sel, ok := stmt.(*Select)
+	sel, ok := stmt.(*SelectClause)
 	if !ok {
 		return nil, util.Errorf("expected a SELECT statement, but found %T", stmt)
 	}

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -135,14 +135,18 @@ func parseExpr(expr string, syntax Syntax) (Expr, error) {
 	if err != nil {
 		return nil, err
 	}
-	sel, ok := stmt.(*SelectClause)
+	sel, ok := stmt.(*Select)
 	if !ok {
 		return nil, util.Errorf("expected a SELECT statement, but found %T", stmt)
 	}
-	if n := len(sel.Exprs); n != 1 {
+	selClause, ok := sel.Select.(*SelectClause)
+	if !ok {
+		return nil, util.Errorf("expected a SELECT statement, but found %T", sel.Select)
+	}
+	if n := len(selClause.Exprs); n != 1 {
 		return nil, util.Errorf("expected 1 expression, but found %d", n)
 	}
-	return sel.Exprs[0].Expr, nil
+	return selClause.Exprs[0].Expr, nil
 }
 
 // ParseExprTraditional is a short-hand for parseExpr(sql, Traditional)

--- a/sql/parser/select.go
+++ b/sql/parser/select.go
@@ -38,9 +38,20 @@ func (*SelectClause) selectStatement() {}
 func (*UnionClause) selectStatement()  {}
 func (ValuesClause) selectStatement()  {}
 
+// Select represents a SelectStatement with an ORDER and/or LIMIT.
+type Select struct {
+	Select  SelectStatement
+	OrderBy OrderBy
+	Limit   *Limit
+}
+
+func (node *Select) String() string {
+	return fmt.Sprintf("%s%s%s", node.Select, node.OrderBy, node.Limit)
+}
+
 // ParenSelect represents a parenthesized SELECT/UNION/VALUES statement.
 type ParenSelect struct {
-	Select SelectStatement
+	Select *Select
 }
 
 func (node *ParenSelect) String() string {
@@ -55,8 +66,6 @@ type SelectClause struct {
 	Where       *Where
 	GroupBy     GroupBy
 	Having      *Where
-	OrderBy     OrderBy
-	Limit       *Limit
 	Lock        string
 	tableSelect bool
 }
@@ -69,11 +78,10 @@ func (node *SelectClause) String() string {
 	if node.Distinct {
 		distinct = " DISTINCT"
 	}
-	return fmt.Sprintf("SELECT%s%s%s%s%s%s%s%s%s",
+	return fmt.Sprintf("SELECT%s%s%s%s%s%s%s",
 		distinct, node.Exprs,
 		node.From, node.Where,
-		node.GroupBy, node.Having, node.OrderBy,
-		node.Limit, node.Lock)
+		node.GroupBy, node.Having, node.Lock)
 }
 
 // SelectExprs represents SELECT expressions.

--- a/sql/parser/select.go
+++ b/sql/parser/select.go
@@ -33,10 +33,10 @@ type SelectStatement interface {
 	selectStatement()
 }
 
-func (*ParenSelect) selectStatement() {}
-func (*Select) selectStatement()      {}
-func (*Union) selectStatement()       {}
-func (Values) selectStatement()       {}
+func (*ParenSelect) selectStatement()  {}
+func (*SelectClause) selectStatement() {}
+func (*UnionClause) selectStatement()  {}
+func (ValuesClause) selectStatement()  {}
 
 // ParenSelect represents a parenthesized SELECT/UNION/VALUES statement.
 type ParenSelect struct {
@@ -47,8 +47,8 @@ func (node *ParenSelect) String() string {
 	return fmt.Sprintf("(%s)", node.Select)
 }
 
-// Select represents a SELECT statement.
-type Select struct {
+// SelectClause represents a SELECT statement.
+type SelectClause struct {
 	Distinct    bool
 	Exprs       SelectExprs
 	From        TableExprs
@@ -61,7 +61,7 @@ type Select struct {
 	tableSelect bool
 }
 
-func (node *Select) String() string {
+func (node *SelectClause) String() string {
 	if node.tableSelect && len(node.From) == 1 {
 		return fmt.Sprintf("TABLE %s", node.From[0])
 	}

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -5638,7 +5638,7 @@ sqldefault:
 		//line sql.y:1849
 		{
 			sqlVAL.union.val = sqlDollar[1].union.selectStmt()
-			if s, ok := sqlVAL.union.val.(*Select); ok {
+			if s, ok := sqlVAL.union.val.(*SelectClause); ok {
 				s.OrderBy = sqlDollar[2].union.orderBy()
 			}
 		}
@@ -5647,7 +5647,7 @@ sqldefault:
 		//line sql.y:1856
 		{
 			sqlVAL.union.val = sqlDollar[1].union.selectStmt()
-			if s, ok := sqlVAL.union.val.(*Select); ok {
+			if s, ok := sqlVAL.union.val.(*SelectClause); ok {
 				s.OrderBy = sqlDollar[2].union.orderBy()
 				s.Limit = sqlDollar[3].union.limit()
 			}
@@ -5663,7 +5663,7 @@ sqldefault:
 		//line sql.y:1868
 		{
 			sqlVAL.union.val = sqlDollar[2].union.selectStmt()
-			if s, ok := sqlVAL.union.val.(*Select); ok {
+			if s, ok := sqlVAL.union.val.(*SelectClause); ok {
 				s.OrderBy = sqlDollar[3].union.orderBy()
 			}
 		}
@@ -5672,7 +5672,7 @@ sqldefault:
 		//line sql.y:1875
 		{
 			sqlVAL.union.val = sqlDollar[2].union.selectStmt()
-			if s, ok := sqlVAL.union.val.(*Select); ok {
+			if s, ok := sqlVAL.union.val.(*SelectClause); ok {
 				s.OrderBy = sqlDollar[3].union.orderBy()
 				s.Limit = sqlDollar[4].union.limit()
 			}
@@ -5681,7 +5681,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
 		//line sql.y:1913
 		{
-			sqlVAL.union.val = &Select{
+			sqlVAL.union.val = &SelectClause{
 				Exprs:   sqlDollar[3].union.selExprs(),
 				From:    sqlDollar[4].union.tblExprs(),
 				Where:   newWhere(astWhere, sqlDollar[5].union.expr()),
@@ -5693,7 +5693,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
 		//line sql.y:1925
 		{
-			sqlVAL.union.val = &Select{
+			sqlVAL.union.val = &SelectClause{
 				Distinct: sqlDollar[2].union.bool(),
 				Exprs:    sqlDollar[3].union.selExprs(),
 				From:     sqlDollar[4].union.tblExprs(),
@@ -5706,7 +5706,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:1937
 		{
-			sqlVAL.union.val = &Select{
+			sqlVAL.union.val = &SelectClause{
 				Exprs:       SelectExprs{starSelectExpr()},
 				From:        TableExprs{&AliasedTableExpr{Expr: sqlDollar[2].union.qname()}},
 				tableSelect: true,
@@ -5716,7 +5716,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
 		//line sql.y:1945
 		{
-			sqlVAL.union.val = &Union{
+			sqlVAL.union.val = &UnionClause{
 				Type:  UnionOp,
 				Left:  sqlDollar[1].union.selectStmt(),
 				Right: sqlDollar[4].union.selectStmt(),
@@ -5727,7 +5727,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
 		//line sql.y:1954
 		{
-			sqlVAL.union.val = &Union{
+			sqlVAL.union.val = &UnionClause{
 				Type:  IntersectOp,
 				Left:  sqlDollar[1].union.selectStmt(),
 				Right: sqlDollar[4].union.selectStmt(),
@@ -5738,7 +5738,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
 		//line sql.y:1963
 		{
-			sqlVAL.union.val = &Union{
+			sqlVAL.union.val = &UnionClause{
 				Type:  ExceptOp,
 				Left:  sqlDollar[1].union.selectStmt(),
 				Right: sqlDollar[4].union.selectStmt(),
@@ -5964,13 +5964,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:2177
 		{
-			sqlVAL.union.val = &Values{[]*Tuple{{sqlDollar[2].union.exprs()}}}
+			sqlVAL.union.val = &ValuesClause{[]*Tuple{{sqlDollar[2].union.exprs()}}}
 		}
 	case 339:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:2181
 		{
-			valNode := sqlDollar[1].union.selectStmt().(*Values)
+			valNode := sqlDollar[1].union.selectStmt().(*ValuesClause)
 			valNode.Tuples = append(valNode.Tuples, &Tuple{sqlDollar[3].union.exprs()})
 			sqlVAL.union.val = valNode
 		}

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -83,6 +83,12 @@ func (u *sqlSymUnion) stmt() Statement {
 func (u *sqlSymUnion) stmts() []Statement {
 	return u.val.([]Statement)
 }
+func (u *sqlSymUnion) slct() *Select {
+	if selectStmt, ok := u.val.(*Select); ok {
+		return selectStmt
+	}
+	return nil
+}
 func (u *sqlSymUnion) selectStmt() SelectStatement {
 	if selectStmt, ok := u.val.(SelectStatement); ok {
 		return selectStmt
@@ -225,7 +231,7 @@ func (u *sqlSymUnion) idxElems() IndexElemList {
 	return u.val.(IndexElemList)
 }
 
-//line sql.y:244
+//line sql.y:250
 type sqlSymType struct {
 	yys   int
 	id    int
@@ -769,7 +775,7 @@ const sqlEofCode = 1
 const sqlErrCode = 2
 const sqlInitialStackSize = 16
 
-//line sql.y:4096
+//line sql.y:4094
 
 //line yacctab:1
 var sqlExca = [...]int{
@@ -3193,7 +3199,7 @@ var sqlPgo = [...]int{
 
 	0, 1556, 1553, 1217, 1552, 1551, 1550, 1549, 1548, 81,
 	1545, 1543, 117, 1542, 78, 1541, 1540, 1539, 60, 1535,
-	1534, 1529, 1527, 63, 50, 1964, 114, 112, 1524, 1516,
+	1534, 1529, 1527, 63, 50, 114, 1964, 112, 1524, 1516,
 	1511, 12, 90, 88, 1509, 106, 85, 102, 1377, 44,
 	38, 32, 26, 72, 1503, 1502, 1501, 1500, 25, 1498,
 	1497, 1496, 10, 41, 13, 1495, 20, 70, 1494, 1492,
@@ -3245,7 +3251,7 @@ var sqlR1 = [...]int{
 	106, 106, 106, 36, 6, 6, 14, 44, 44, 99,
 	99, 99, 101, 101, 101, 100, 100, 100, 79, 79,
 	23, 70, 70, 71, 71, 144, 72, 72, 18, 18,
-	25, 25, 24, 24, 24, 24, 24, 24, 26, 26,
+	26, 26, 24, 24, 24, 24, 24, 24, 25, 25,
 	27, 27, 27, 27, 27, 27, 27, 197, 197, 197,
 	199, 199, 196, 15, 15, 15, 15, 198, 198, 220,
 	220, 80, 80, 80, 51, 50, 50, 54, 54, 53,
@@ -3417,9 +3423,9 @@ var sqlChk = [...]int{
 
 	-1000, -1, -2, -3, -4, -5, -9, -10, -11, -13,
 	-14, -16, -17, -18, -19, -20, -21, -22, -23, 19,
-	-6, -7, -8, -198, 83, 89, 101, 186, -24, -25,
+	-6, -7, -8, -198, 83, 89, 101, 186, -24, -26,
 	199, 200, 29, 207, 52, 85, 188, 225, 58, -197,
-	-27, -26, 269, 245, 251, 195, -28, 213, 238, 272,
+	-27, -25, 269, 245, 251, 195, -28, 213, 238, 272,
 	213, 70, 112, 78, 116, 232, 70, 112, 213, -12,
 	269, -18, -14, -23, -9, -216, 18, -217, -218, 58,
 	83, 101, 195, 116, 78, 232, -216, -103, 135, 197,
@@ -3439,8 +3445,8 @@ var sqlChk = [...]int{
 	154, 163, 167, 171, 173, 178, 190, 203, 209, 211,
 	218, 222, 223, 238, 239, 4, 70, 51, 71, 102,
 	112, 113, 127, 214, 217, 221, 18, -221, 221, 221,
-	-221, -221, -221, -220, 213, 213, -92, 70, 230, -26,
-	-27, -25, -53, -54, 229, 120, 87, 161, -24, -25,
+	-221, -221, -221, -220, 213, 213, -92, 70, 230, -25,
+	-27, -26, -53, -54, 229, 120, 87, 161, -24, -26,
 	-197, -199, 179, -196, -38, 135, 144, 197, 221, 217,
 	-199, -50, -51, 18, 80, 273, -141, -42, 159, -38,
 	-75, 269, -3, -141, 109, -38, -42, 109, 99, 122,
@@ -3455,7 +3461,7 @@ var sqlChk = [...]int{
 	-80, 18, 80, -80, -80, 37, 270, 270, 273, -199,
 	-58, 269, -69, -68, -143, -114, 262, -116, 260, 261,
 	266, 149, 250, -125, -42, -117, 9, 269, -128, -194,
-	-25, 88, 24, -126, -127, 190, -38, 8, 5, 6,
+	-26, 88, 24, -126, -127, 190, -38, 8, 5, 6,
 	7, -40, -149, -158, 224, 91, 151, 41, -192, -193,
 	4, -177, -172, -150, -160, -154, -157, 121, 49, 63,
 	66, 64, 67, 198, 233, 42, 90, 167, 171, 211,
@@ -3482,12 +3488,12 @@ var sqlChk = [...]int{
 	234, 240, 242, 243, 244, 245, -170, -215, 97, -212,
 	-170, -170, -170, -170, 132, 273, 273, -35, 273, 269,
 	149, -39, 109, -38, 149, -77, -96, -95, -97, -114,
-	18, -114, -116, -26, -26, -26, -55, -137, -114, -196,
+	18, -114, -116, -25, -25, -25, -55, -137, -114, -196,
 	25, -57, -38, -60, 99, 273, 10, 48, 28, 260,
 	261, 262, 263, 264, 257, 258, 259, 256, 252, 253,
 	254, 54, 139, 192, 12, 13, 14, 22, 160, 133,
 	250, 201, 123, 30, 111, 25, 4, -114, -114, -114,
-	-114, -114, 166, -25, -114, -66, -73, -25, -122, 267,
+	-114, -114, 166, -26, -114, -66, -73, -26, -122, 267,
 	269, -73, 269, 6, 6, 269, -129, -114, -200, 246,
 	97, 269, 269, 269, 269, 269, 269, 269, 269, 269,
 	269, 269, 269, 269, 269, 269, 173, -165, 241, -165,
@@ -3502,7 +3508,7 @@ var sqlChk = [...]int{
 	8, 8, 6, -171, -214, -38, -37, -36, -141, -48,
 	-49, -109, -108, -183, -181, 112, 230, 88, 158, 149,
 	88, -98, 190, 191, 273, -31, 26, 79, 269, 273,
-	270, -110, -61, -139, -141, -25, -140, 269, -143, -147,
+	270, -110, -61, -139, -141, -26, -140, 269, -143, -147,
 	-148, -150, -159, -153, -157, -158, 33, 39, 38, 215,
 	209, 117, 118, 119, 203, 31, 178, 95, 82, 75,
 	74, 154, 35, 34, -161, -162, -155, -156, 72, 218,
@@ -3510,7 +3516,7 @@ var sqlChk = [...]int{
 	-114, -114, -114, -114, -114, -114, -114, -114, -114, -114,
 	-114, -114, -114, -114, -114, -114, -114, 133, 201, 30,
 	111, 219, 151, 149, 224, 91, 231, 80, 155, -222,
-	212, 27, -120, -25, 269, -171, -125, 190, 269, 270,
+	212, 27, -120, -26, 269, -171, -125, 190, 269, 270,
 	273, -66, -124, 268, -114, -122, -66, 270, 270, -66,
 	240, 18, 80, 262, -89, 248, 142, 73, 108, 141,
 	-90, 194, 8, -132, -131, 242, -201, 93, 104, 269,
@@ -3526,7 +3532,7 @@ var sqlChk = [...]int{
 	228, 53, 177, -175, -89, 273, 270, 273, -39, 112,
 	-64, -42, 88, -38, -137, -15, -18, -14, -23, -9,
 	-38, -76, 104, 273, 59, -83, 125, 145, 100, 131,
-	187, 115, -136, -135, 25, -38, -136, -25, -140, -139,
+	187, 115, -136, -135, 25, -38, -136, -26, -140, -139,
 	-59, 24, -89, 269, 249, -114, 219, -222, 212, -120,
 	-114, 151, 224, 91, 231, 80, 155, 99, 269, -115,
 	-115, -66, 269, -66, -114, 273, 268, 268, 273, 270,
@@ -3565,7 +3571,7 @@ var sqlChk = [...]int{
 	270, 273, 270, 270, 270, -202, -108, -38, -64, 151,
 	126, 269, -115, -42, -107, -219, 57, 210, 270, 270,
 	151, 151, -114, -147, -35, -35, 219, 219, 81, -56,
-	56, -75, -25, 269, 270, 273, -41, -73, 48, -41,
+	56, -75, -26, 269, 270, 273, -41, -73, 48, -41,
 	-114, 269, -56, 270, 270, -42, -203, -205, -38, -82,
 	269, -114, -139, -57, 270, 268, 268, -114, -114, 270,
 	-147, 270, -54, -204, 169, 270, -115, 99, 269, -123,
@@ -4137,13 +4143,13 @@ sqldefault:
 
 	case 1:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:623
+		//line sql.y:629
 		{
 			sqllex.(*scanner).stmts = sqlDollar[1].union.stmts()
 		}
 	case 2:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:629
+		//line sql.y:635
 		{
 			if sqlDollar[3].union.stmt() != nil {
 				sqlVAL.union.val = append(sqlDollar[1].union.stmts(), sqlDollar[3].union.stmt())
@@ -4151,7 +4157,7 @@ sqldefault:
 		}
 	case 3:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:635
+		//line sql.y:641
 		{
 			if sqlDollar[1].union.stmt() != nil {
 				sqlVAL.union.val = []Statement{sqlDollar[1].union.stmt()}
@@ -4161,596 +4167,596 @@ sqldefault:
 		}
 	case 13:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:654
+		//line sql.y:660
 		{
-			sqlVAL.union.val = sqlDollar[1].union.selectStmt()
+			sqlVAL.union.val = sqlDollar[1].union.slct()
 		}
 	case 19:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:663
+		//line sql.y:669
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 20:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:669
+		//line sql.y:675
 		{
 			sqlVAL.union.val = &AlterTable{Table: sqlDollar[3].union.qname(), IfExists: false, Cmds: sqlDollar[4].union.alterTableCmds()}
 		}
 	case 21:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:673
+		//line sql.y:679
 		{
 			sqlVAL.union.val = &AlterTable{Table: sqlDollar[5].union.qname(), IfExists: true, Cmds: sqlDollar[6].union.alterTableCmds()}
 		}
 	case 22:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:679
+		//line sql.y:685
 		{
 			sqlVAL.union.val = AlterTableCmds{sqlDollar[1].union.alterTableCmd()}
 		}
 	case 23:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:683
+		//line sql.y:689
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.alterTableCmds(), sqlDollar[3].union.alterTableCmd())
 		}
 	case 24:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:690
+		//line sql.y:696
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: false, IfNotExists: false, ColumnDef: sqlDollar[2].union.colDef()}
 		}
 	case 25:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:695
+		//line sql.y:701
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: false, IfNotExists: true, ColumnDef: sqlDollar[5].union.colDef()}
 		}
 	case 26:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:700
+		//line sql.y:706
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: true, IfNotExists: false, ColumnDef: sqlDollar[3].union.colDef()}
 		}
 	case 27:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:705
+		//line sql.y:711
 		{
 			sqlVAL.union.val = &AlterTableAddColumn{columnKeyword: true, IfNotExists: true, ColumnDef: sqlDollar[6].union.colDef()}
 		}
 	case 28:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:709
+		//line sql.y:715
 		{
 			unimplemented()
 		}
 	case 29:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:711
+		//line sql.y:717
 		{
 			unimplemented()
 		}
 	case 30:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:713
+		//line sql.y:719
 		{
 			unimplemented()
 		}
 	case 31:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:716
+		//line sql.y:722
 		{
 			sqlVAL.union.val = &AlterTableDropColumn{columnKeyword: sqlDollar[2].union.bool(), IfExists: true, Column: sqlDollar[5].str}
 		}
 	case 32:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:721
+		//line sql.y:727
 		{
 			sqlVAL.union.val = &AlterTableDropColumn{columnKeyword: sqlDollar[2].union.bool(), IfExists: false, Column: sqlDollar[3].str}
 		}
 	case 33:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:726
+		//line sql.y:732
 		{
 		}
 	case 34:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:729
+		//line sql.y:735
 		{
 			sqlVAL.union.val = &AlterTableAddConstraint{ConstraintDef: sqlDollar[2].union.constraintDef()}
 		}
 	case 35:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:733
+		//line sql.y:739
 		{
 			unimplemented()
 		}
 	case 36:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:735
+		//line sql.y:741
 		{
 			unimplemented()
 		}
 	case 37:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:738
+		//line sql.y:744
 		{
 			sqlVAL.union.val = &AlterTableDropConstraint{IfExists: true, Constraint: sqlDollar[5].str}
 		}
 	case 38:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:743
+		//line sql.y:749
 		{
 			sqlVAL.union.val = &AlterTableDropConstraint{IfExists: false, Constraint: sqlDollar[3].str}
 		}
 	case 39:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:748
+		//line sql.y:754
 		{
 			unimplemented()
 		}
 	case 40:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:749
+		//line sql.y:755
 		{
 			unimplemented()
 		}
 	case 41:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:752
+		//line sql.y:758
 		{
 			unimplemented()
 		}
 	case 42:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:753
+		//line sql.y:759
 		{
 			unimplemented()
 		}
 	case 43:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:754
+		//line sql.y:760
 		{
 		}
 	case 44:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:757
+		//line sql.y:763
 		{
 			unimplemented()
 		}
 	case 45:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:758
+		//line sql.y:764
 		{
 		}
 	case 46:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:761
+		//line sql.y:767
 		{
 			unimplemented()
 		}
 	case 47:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:762
+		//line sql.y:768
 		{
 		}
 	case 51:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:773
+		//line sql.y:779
 		{
 			sqlVAL.union.val = &Delete{Table: sqlDollar[4].union.tblExpr(), Where: newWhere(astWhere, sqlDollar[5].union.expr()), Returning: sqlDollar[6].union.retExprs()}
 		}
 	case 52:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:780
+		//line sql.y:786
 		{
 			sqlVAL.union.val = &DropDatabase{Name: Name(sqlDollar[3].str), IfExists: false}
 		}
 	case 53:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:784
+		//line sql.y:790
 		{
 			sqlVAL.union.val = &DropDatabase{Name: Name(sqlDollar[5].str), IfExists: true}
 		}
 	case 54:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:788
+		//line sql.y:794
 		{
 			sqlVAL.union.val = &DropIndex{Names: sqlDollar[3].union.qnames(), IfExists: false}
 		}
 	case 55:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:792
+		//line sql.y:798
 		{
 			sqlVAL.union.val = &DropIndex{Names: sqlDollar[5].union.qnames(), IfExists: true}
 		}
 	case 56:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:796
+		//line sql.y:802
 		{
 			sqlVAL.union.val = &DropTable{Names: sqlDollar[3].union.qnames(), IfExists: false}
 		}
 	case 57:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:800
+		//line sql.y:806
 		{
 			sqlVAL.union.val = &DropTable{Names: sqlDollar[5].union.qnames(), IfExists: true}
 		}
 	case 58:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:806
+		//line sql.y:812
 		{
 			sqlVAL.union.val = QualifiedNames{sqlDollar[1].union.qname()}
 		}
 	case 59:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:810
+		//line sql.y:816
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.qnames(), sqlDollar[3].union.qname())
 		}
 	case 60:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:816
+		//line sql.y:822
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 61:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:820
+		//line sql.y:826
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: sqlDollar[2].union.indirect()}
 		}
 	case 62:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:826
+		//line sql.y:832
 		{
 			sqlVAL.union.val = Indirection{NameIndirection(sqlDollar[2].str)}
 		}
 	case 63:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:830
+		//line sql.y:836
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.indirect(), NameIndirection(sqlDollar[3].str))
 		}
 	case 64:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:837
+		//line sql.y:843
 		{
 			sqlVAL.union.val = &Explain{Statement: sqlDollar[2].union.stmt()}
 		}
 	case 65:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:841
+		//line sql.y:847
 		{
 			sqlVAL.union.val = &Explain{Options: sqlDollar[3].union.strs(), Statement: sqlDollar[5].union.stmt()}
 		}
 	case 66:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:847
+		//line sql.y:853
 		{
-			sqlVAL.union.val = sqlDollar[1].union.selectStmt()
+			sqlVAL.union.val = sqlDollar[1].union.slct()
 		}
 	case 70:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:856
+		//line sql.y:862
 		{
 			sqlVAL.union.val = []string{sqlDollar[1].str}
 		}
 	case 71:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:860
+		//line sql.y:866
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.strs(), sqlDollar[3].str)
 		}
 	case 73:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:870
+		//line sql.y:876
 		{
 			sqlVAL.union.val = &Grant{Privileges: sqlDollar[2].union.privilegeList(), Grantees: NameList(sqlDollar[6].union.strs()), Targets: sqlDollar[4].union.targetList()}
 		}
 	case 74:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:877
+		//line sql.y:883
 		{
 			sqlVAL.union.val = &Revoke{Privileges: sqlDollar[2].union.privilegeList(), Grantees: NameList(sqlDollar[6].union.strs()), Targets: sqlDollar[4].union.targetList()}
 		}
 	case 75:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:884
+		//line sql.y:890
 		{
 			sqlVAL.union.val = TargetList{Tables: QualifiedNames(sqlDollar[1].union.qnames())}
 		}
 	case 76:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:888
+		//line sql.y:894
 		{
 			sqlVAL.union.val = TargetList{Tables: QualifiedNames(sqlDollar[2].union.qnames())}
 		}
 	case 77:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:892
+		//line sql.y:898
 		{
 			sqlVAL.union.val = TargetList{Databases: NameList(sqlDollar[2].union.strs())}
 		}
 	case 78:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:899
+		//line sql.y:905
 		{
 			sqlVAL.union.val = privilege.List{privilege.ALL}
 		}
 	case 79:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:902
+		//line sql.y:908
 		{
 		}
 	case 80:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:906
+		//line sql.y:912
 		{
 			sqlVAL.union.val = privilege.List{sqlDollar[1].union.privilegeType()}
 		}
 	case 81:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:910
+		//line sql.y:916
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.privilegeList(), sqlDollar[3].union.privilegeType())
 		}
 	case 82:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:917
+		//line sql.y:923
 		{
 			sqlVAL.union.val = privilege.CREATE
 		}
 	case 83:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:921
+		//line sql.y:927
 		{
 			sqlVAL.union.val = privilege.DROP
 		}
 	case 84:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:925
+		//line sql.y:931
 		{
 			sqlVAL.union.val = privilege.GRANT
 		}
 	case 85:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:929
+		//line sql.y:935
 		{
 			sqlVAL.union.val = privilege.SELECT
 		}
 	case 86:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:933
+		//line sql.y:939
 		{
 			sqlVAL.union.val = privilege.INSERT
 		}
 	case 87:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:937
+		//line sql.y:943
 		{
 			sqlVAL.union.val = privilege.DELETE
 		}
 	case 88:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:941
+		//line sql.y:947
 		{
 			sqlVAL.union.val = privilege.UPDATE
 		}
 	case 89:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:949
+		//line sql.y:955
 		{
 			sqlVAL.union.val = []string{sqlDollar[1].str}
 		}
 	case 90:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:953
+		//line sql.y:959
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.strs(), sqlDollar[3].str)
 		}
 	case 91:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:961
+		//line sql.y:967
 		{
 			sqlVAL.union.val = sqlDollar[2].union.stmt()
 		}
 	case 92:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:965
+		//line sql.y:971
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 93:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:969
+		//line sql.y:975
 		{
 			sqlVAL.union.val = &SetDefaultIsolation{Isolation: sqlDollar[6].union.isoLevel()}
 		}
 	case 94:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:973
+		//line sql.y:979
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 95:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:979
+		//line sql.y:985
 		{
 			sqlVAL.union.val = sqlDollar[2].union.stmt()
 		}
 	case 97:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:986
+		//line sql.y:992
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: UnspecifiedUserPriority}
 		}
 	case 98:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:990
+		//line sql.y:996
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: UnspecifiedIsolation, UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 99:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:994
+		//line sql.y:1000
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: sqlDollar[3].union.userPriority()}
 		}
 	case 100:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:998
+		//line sql.y:1004
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[3].union.isoLevel(), UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 101:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1005
+		//line sql.y:1011
 		{
 			sqlVAL.union.val = sqlDollar[2].union.userPriority()
 		}
 	case 102:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1011
+		//line sql.y:1017
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.qname(), Values: sqlDollar[3].union.exprs()}
 		}
 	case 103:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1015
+		//line sql.y:1021
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.qname(), Values: sqlDollar[3].union.exprs()}
 		}
 	case 104:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1019
+		//line sql.y:1025
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.qname()}
 		}
 	case 105:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1023
+		//line sql.y:1029
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.qname()}
 		}
 	case 107:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1030
+		//line sql.y:1036
 		{
 			unimplemented()
 		}
 	case 108:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1033
+		//line sql.y:1039
 		{
 			sqlVAL.union.val = &SetTimeZone{Value: sqlDollar[3].union.expr()}
 		}
 	case 109:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1036
+		//line sql.y:1042
 		{
 			unimplemented()
 		}
 	case 111:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1043
+		//line sql.y:1049
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 112:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1047
+		//line sql.y:1053
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 115:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1055
+		//line sql.y:1061
 		{
 			sqlVAL.union.val = ValArg{name: sqlDollar[1].str}
 		}
 	case 116:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1061
+		//line sql.y:1067
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 117:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1065
+		//line sql.y:1071
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 118:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1069
+		//line sql.y:1075
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 119:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1073
+		//line sql.y:1079
 		{
 			sqlVAL.union.val = SerializableIsolation
 		}
 	case 120:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1077
+		//line sql.y:1083
 		{
 			sqlVAL.union.val = SerializableIsolation
 		}
 	case 121:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1083
+		//line sql.y:1089
 		{
 			sqlVAL.union.val = Low
 		}
 	case 122:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1087
+		//line sql.y:1093
 		{
 			sqlVAL.union.val = Normal
 		}
 	case 123:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1091
+		//line sql.y:1097
 		{
 			sqlVAL.union.val = High
 		}
 	case 124:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1097
+		//line sql.y:1103
 		{
 			sqlVAL.union.val = DBool(true)
 		}
 	case 125:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1101
+		//line sql.y:1107
 		{
 			sqlVAL.union.val = DBool(false)
 		}
 	case 126:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1105
+		//line sql.y:1111
 		{
 			sqlVAL.union.val = DString(sqlDollar[1].str)
 		}
 	case 128:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1120
+		//line sql.y:1126
 		{
 			sqlVAL.union.val = DString(sqlDollar[1].str)
 		}
 	case 129:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1124
+		//line sql.y:1130
 		{
 			sqlVAL.union.val = DString(sqlDollar[1].str)
 		}
 	case 130:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1128
+		//line sql.y:1134
 		{
 			expr := &CastExpr{Expr: DString(sqlDollar[2].str), Type: sqlDollar[1].union.colType()}
 			var ctx EvalContext
@@ -4766,265 +4772,265 @@ sqldefault:
 		}
 	case 132:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1143
+		//line sql.y:1149
 		{
 			sqlVAL.union.val = DString(sqlDollar[1].str)
 		}
 	case 133:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1147
+		//line sql.y:1153
 		{
 			sqlVAL.union.val = DString(sqlDollar[1].str)
 		}
 	case 134:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1152
+		//line sql.y:1158
 		{
 			unimplemented()
 		}
 	case 135:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1153
+		//line sql.y:1159
 		{
 			unimplemented()
 		}
 	case 136:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1154
+		//line sql.y:1160
 		{
 		}
 	case 137:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1158
+		//line sql.y:1164
 		{
 			sqlVAL.union.val = DString(sqlDollar[1].str)
 		}
 	case 138:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1162
+		//line sql.y:1168
 		{
 			sqlVAL.union.val = DString(sqlDollar[1].str)
 		}
 	case 139:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1168
+		//line sql.y:1174
 		{
 			sqlVAL.union.val = &Show{Name: sqlDollar[2].str}
 		}
 	case 140:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1172
+		//line sql.y:1178
 		{
 			sqlVAL.union.val = &Show{Name: sqlDollar[2].str}
 		}
 	case 141:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1176
+		//line sql.y:1182
 		{
 			sqlVAL.union.val = &ShowColumns{Table: sqlDollar[4].union.qname()}
 		}
 	case 142:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1180
+		//line sql.y:1186
 		{
 			sqlVAL.union.val = &ShowDatabases{}
 		}
 	case 143:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1184
+		//line sql.y:1190
 		{
 			sqlVAL.union.val = &ShowGrants{Targets: sqlDollar[3].union.targetListPtr(), Grantees: sqlDollar[4].union.strs()}
 		}
 	case 144:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1188
+		//line sql.y:1194
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.qname()}
 		}
 	case 145:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1192
+		//line sql.y:1198
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.qname()}
 		}
 	case 146:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1196
+		//line sql.y:1202
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.qname()}
 		}
 	case 147:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1200
+		//line sql.y:1206
 		{
 			sqlVAL.union.val = &ShowTables{Name: sqlDollar[3].union.qname()}
 		}
 	case 148:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1204
+		//line sql.y:1210
 		{
 			sqlVAL.union.val = &Show{Name: "TIME ZONE"}
 		}
 	case 149:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1208
+		//line sql.y:1214
 		{
 			sqlVAL.union.val = &Show{Name: "TRANSACTION ISOLATION LEVEL"}
 		}
 	case 150:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1212
+		//line sql.y:1218
 		{
 			sqlVAL.union.val = &Show{Name: "TRANSACTION PRIORITY"}
 		}
 	case 151:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1216
+		//line sql.y:1222
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 152:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1222
+		//line sql.y:1228
 		{
 			sqlVAL.union.val = sqlDollar[2].union.qname()
 		}
 	case 153:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1226
+		//line sql.y:1232
 		{
 			sqlVAL.union.val = (*QualifiedName)(nil)
 		}
 	case 154:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1232
+		//line sql.y:1238
 		{
 			tmp := sqlDollar[2].union.targetList()
 			sqlVAL.union.val = &tmp
 		}
 	case 155:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1237
+		//line sql.y:1243
 		{
 			sqlVAL.union.val = (*TargetList)(nil)
 		}
 	case 156:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1243
+		//line sql.y:1249
 		{
 			sqlVAL.union.val = sqlDollar[2].union.strs()
 		}
 	case 157:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1247
+		//line sql.y:1253
 		{
 			sqlVAL.union.val = []string(nil)
 		}
 	case 158:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1254
+		//line sql.y:1260
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[3].union.qname(), IfNotExists: false, Defs: sqlDollar[5].union.tblDefs()}
 		}
 	case 159:
 		sqlDollar = sqlS[sqlpt-9 : sqlpt+1]
-		//line sql.y:1258
+		//line sql.y:1264
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[6].union.qname(), IfNotExists: true, Defs: sqlDollar[8].union.tblDefs()}
 		}
 	case 161:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1265
+		//line sql.y:1271
 		{
 			sqlVAL.union.val = TableDefs(nil)
 		}
 	case 162:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1271
+		//line sql.y:1277
 		{
 			sqlVAL.union.val = TableDefs{sqlDollar[1].union.tblDef()}
 		}
 	case 163:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1275
+		//line sql.y:1281
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tblDefs(), sqlDollar[3].union.tblDef())
 		}
 	case 164:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1281
+		//line sql.y:1287
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colDef()
 		}
 	case 166:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1286
+		//line sql.y:1292
 		{
 			sqlVAL.union.val = sqlDollar[1].union.constraintDef()
 		}
 	case 167:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1292
+		//line sql.y:1298
 		{
 			sqlVAL.union.val = newColumnTableDef(Name(sqlDollar[1].str), sqlDollar[2].union.colType(), sqlDollar[3].union.colQuals())
 		}
 	case 168:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1298
+		//line sql.y:1304
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.colQuals(), sqlDollar[2].union.colQual())
 		}
 	case 169:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1302
+		//line sql.y:1308
 		{
 			sqlVAL.union.val = []ColumnQualification(nil)
 		}
 	case 170:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1308
+		//line sql.y:1314
 		{
 			sqlVAL.union.val = sqlDollar[3].union.colQual()
 		}
 	case 172:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1312
+		//line sql.y:1318
 		{
 			unimplemented()
 		}
 	case 173:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1328
+		//line sql.y:1334
 		{
 			sqlVAL.union.val = NotNullConstraint{}
 		}
 	case 174:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1332
+		//line sql.y:1338
 		{
 			sqlVAL.union.val = NullConstraint{}
 		}
 	case 175:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1336
+		//line sql.y:1342
 		{
 			sqlVAL.union.val = UniqueConstraint{}
 		}
 	case 176:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1340
+		//line sql.y:1346
 		{
 			sqlVAL.union.val = PrimaryKeyConstraint{}
 		}
 	case 177:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1343
+		//line sql.y:1349
 		{
 			unimplemented()
 		}
 	case 178:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1345
+		//line sql.y:1351
 		{
 			if ContainsVars(sqlDollar[2].union.expr()) {
 				sqllex.Error("default expression contains a variable")
@@ -5038,13 +5044,13 @@ sqldefault:
 		}
 	case 179:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1356
+		//line sql.y:1362
 		{
 			unimplemented()
 		}
 	case 180:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1360
+		//line sql.y:1366
 		{
 			sqlVAL.union.val = &IndexTableDef{
 				Name:    Name(sqlDollar[2].str),
@@ -5054,7 +5060,7 @@ sqldefault:
 		}
 	case 181:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:1368
+		//line sql.y:1374
 		{
 			sqlVAL.union.val = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -5066,26 +5072,26 @@ sqldefault:
 		}
 	case 182:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1383
+		//line sql.y:1389
 		{
 			sqlVAL.union.val = sqlDollar[3].union.constraintDef()
 			sqlVAL.union.val.(ConstraintTableDef).setName(Name(sqlDollar[2].str))
 		}
 	case 183:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1388
+		//line sql.y:1394
 		{
 			sqlVAL.union.val = sqlDollar[1].union.constraintDef()
 		}
 	case 184:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1393
+		//line sql.y:1399
 		{
 			unimplemented()
 		}
 	case 185:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1395
+		//line sql.y:1401
 		{
 			sqlVAL.union.val = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -5096,7 +5102,7 @@ sqldefault:
 		}
 	case 186:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1404
+		//line sql.y:1410
 		{
 			sqlVAL.union.val = &UniqueConstraintTableDef{
 				IndexTableDef: IndexTableDef{
@@ -5107,155 +5113,155 @@ sqldefault:
 		}
 	case 187:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1413
+		//line sql.y:1419
 		{
 			unimplemented()
 		}
 	case 190:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1430
+		//line sql.y:1436
 		{
 			sqlVAL.union.val = sqlDollar[3].union.strs()
 		}
 	case 191:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1434
+		//line sql.y:1440
 		{
 			sqlVAL.union.val = []string(nil)
 		}
 	case 192:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1440
+		//line sql.y:1446
 		{
 			sqlVAL.union.val = sqlDollar[2].union.strs()
 		}
 	case 193:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1444
+		//line sql.y:1450
 		{
 			sqlVAL.union.val = []string(nil)
 		}
 	case 194:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1449
+		//line sql.y:1455
 		{
 			unimplemented()
 		}
 	case 195:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1450
+		//line sql.y:1456
 		{
 			unimplemented()
 		}
 	case 196:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1451
+		//line sql.y:1457
 		{
 			unimplemented()
 		}
 	case 197:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1452
+		//line sql.y:1458
 		{
 		}
 	case 198:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1459
+		//line sql.y:1465
 		{
 			unimplemented()
 		}
 	case 199:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1460
+		//line sql.y:1466
 		{
 			unimplemented()
 		}
 	case 200:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1461
+		//line sql.y:1467
 		{
 			unimplemented()
 		}
 	case 201:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1462
+		//line sql.y:1468
 		{
 			unimplemented()
 		}
 	case 202:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1463
+		//line sql.y:1469
 		{
 		}
 	case 203:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1466
+		//line sql.y:1472
 		{
 			unimplemented()
 		}
 	case 204:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1469
+		//line sql.y:1475
 		{
 			unimplemented()
 		}
 	case 205:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1472
+		//line sql.y:1478
 		{
 			unimplemented()
 		}
 	case 206:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1473
+		//line sql.y:1479
 		{
 			unimplemented()
 		}
 	case 207:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1474
+		//line sql.y:1480
 		{
 			unimplemented()
 		}
 	case 208:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1475
+		//line sql.y:1481
 		{
 			unimplemented()
 		}
 	case 209:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1476
+		//line sql.y:1482
 		{
 			unimplemented()
 		}
 	case 210:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1480
+		//line sql.y:1486
 		{
 			sqlVAL.union.val = NumVal(sqlDollar[1].str)
 		}
 	case 211:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1484
+		//line sql.y:1490
 		{
 			sqlVAL.union.val = NumVal("-" + sqlDollar[2].str)
 		}
 	case 212:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1488
+		//line sql.y:1494
 		{
 			sqlVAL.union.val = DInt(sqlDollar[1].union.ival().Val)
 		}
 	case 213:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1495
+		//line sql.y:1501
 		{
 			sqlVAL.union.val = &Truncate{Tables: sqlDollar[3].union.qnames()}
 		}
 	case 214:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1502
+		//line sql.y:1508
 		{
 			sqlVAL.union.val = &CreateIndex{
 				Name:    Name(sqlDollar[4].str),
@@ -5267,7 +5273,7 @@ sqldefault:
 		}
 	case 215:
 		sqlDollar = sqlS[sqlpt-13 : sqlpt+1]
-		//line sql.y:1512
+		//line sql.y:1518
 		{
 			sqlVAL.union.val = &CreateIndex{
 				Name:        Name(sqlDollar[7].str),
@@ -5280,242 +5286,242 @@ sqldefault:
 		}
 	case 216:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1525
+		//line sql.y:1531
 		{
 			sqlVAL.union.val = true
 		}
 	case 217:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1529
+		//line sql.y:1535
 		{
 			sqlVAL.union.val = false
 		}
 	case 218:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1535
+		//line sql.y:1541
 		{
 			sqlVAL.union.val = IndexElemList{sqlDollar[1].union.idxElem()}
 		}
 	case 219:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1539
+		//line sql.y:1545
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.idxElems(), sqlDollar[3].union.idxElem())
 		}
 	case 220:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1548
+		//line sql.y:1554
 		{
 			sqlVAL.union.val = IndexElem{Column: Name(sqlDollar[1].str), Direction: sqlDollar[3].union.dir()}
 		}
 	case 221:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1551
+		//line sql.y:1557
 		{
 			unimplemented()
 		}
 	case 222:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1552
+		//line sql.y:1558
 		{
 			unimplemented()
 		}
 	case 223:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1555
+		//line sql.y:1561
 		{
 			unimplemented()
 		}
 	case 224:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1556
+		//line sql.y:1562
 		{
 		}
 	case 225:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1560
+		//line sql.y:1566
 		{
 			sqlVAL.union.val = Ascending
 		}
 	case 226:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1564
+		//line sql.y:1570
 		{
 			sqlVAL.union.val = Descending
 		}
 	case 227:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1568
+		//line sql.y:1574
 		{
 			sqlVAL.union.val = DefaultDirection
 		}
 	case 228:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1575
+		//line sql.y:1581
 		{
 			sqlVAL.union.val = &RenameDatabase{Name: Name(sqlDollar[3].str), NewName: Name(sqlDollar[6].str)}
 		}
 	case 229:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1579
+		//line sql.y:1585
 		{
 			sqlVAL.union.val = &RenameTable{Name: sqlDollar[3].union.qname(), NewName: sqlDollar[6].union.qname(), IfExists: false}
 		}
 	case 230:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1583
+		//line sql.y:1589
 		{
 			sqlVAL.union.val = &RenameTable{Name: sqlDollar[5].union.qname(), NewName: sqlDollar[8].union.qname(), IfExists: true}
 		}
 	case 231:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1587
+		//line sql.y:1593
 		{
 			sqlVAL.union.val = &RenameIndex{Name: sqlDollar[3].union.qname(), NewName: Name(sqlDollar[6].str), IfExists: false}
 		}
 	case 232:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1591
+		//line sql.y:1597
 		{
 			sqlVAL.union.val = &RenameIndex{Name: sqlDollar[5].union.qname(), NewName: Name(sqlDollar[8].str), IfExists: true}
 		}
 	case 233:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1595
+		//line sql.y:1601
 		{
 			sqlVAL.union.val = &RenameColumn{Table: sqlDollar[3].union.qname(), Name: Name(sqlDollar[6].str), NewName: Name(sqlDollar[8].str), IfExists: false}
 		}
 	case 234:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1599
+		//line sql.y:1605
 		{
 			sqlVAL.union.val = &RenameColumn{Table: sqlDollar[5].union.qname(), Name: Name(sqlDollar[8].str), NewName: Name(sqlDollar[10].str), IfExists: true}
 		}
 	case 235:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1603
+		//line sql.y:1609
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 236:
 		sqlDollar = sqlS[sqlpt-10 : sqlpt+1]
-		//line sql.y:1607
+		//line sql.y:1613
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 237:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1613
+		//line sql.y:1619
 		{
 			sqlVAL.union.val = true
 		}
 	case 238:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1617
+		//line sql.y:1623
 		{
 			sqlVAL.union.val = false
 		}
 	case 239:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1622
+		//line sql.y:1628
 		{
 		}
 	case 240:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1623
+		//line sql.y:1629
 		{
 		}
 	case 241:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1628
+		//line sql.y:1634
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 242:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1632
+		//line sql.y:1638
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 243:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1636
+		//line sql.y:1642
 		{
 			sqlVAL.union.val = &CommitTransaction{}
 		}
 	case 244:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1640
+		//line sql.y:1646
 		{
 			sqlVAL.union.val = &CommitTransaction{}
 		}
 	case 245:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1644
+		//line sql.y:1650
 		{
 			sqlVAL.union.val = &RollbackTransaction{}
 		}
 	case 246:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1649
+		//line sql.y:1655
 		{
 		}
 	case 247:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1650
+		//line sql.y:1656
 		{
 		}
 	case 248:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1654
+		//line sql.y:1660
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: UnspecifiedUserPriority}
 		}
 	case 249:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1658
+		//line sql.y:1664
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: UnspecifiedIsolation, UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 250:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1662
+		//line sql.y:1668
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: sqlDollar[3].union.userPriority()}
 		}
 	case 251:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1666
+		//line sql.y:1672
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: sqlDollar[3].union.isoLevel(), UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 252:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1670
+		//line sql.y:1676
 		{
 			sqlVAL.union.val = &BeginTransaction{Isolation: UnspecifiedIsolation, UserPriority: UnspecifiedUserPriority}
 		}
 	case 253:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1676
+		//line sql.y:1682
 		{
 			sqlVAL.union.val = sqlDollar[3].union.isoLevel()
 		}
 	case 254:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1682
+		//line sql.y:1688
 		{
 			sqlVAL.union.val = &CreateDatabase{Name: Name(sqlDollar[3].str)}
 		}
 	case 255:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1686
+		//line sql.y:1692
 		{
 			sqlVAL.union.val = &CreateDatabase{IfNotExists: true, Name: Name(sqlDollar[6].str)}
 		}
 	case 256:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:1692
+		//line sql.y:1698
 		{
 			sqlVAL.union.val = sqlDollar[5].union.stmt()
 			sqlVAL.union.val.(*Insert).Table = sqlDollar[4].union.qname()
@@ -5523,163 +5529,161 @@ sqldefault:
 		}
 	case 259:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1709
+		//line sql.y:1715
 		{
-			sqlVAL.union.val = &Insert{Rows: sqlDollar[1].union.selectStmt()}
+			sqlVAL.union.val = &Insert{Rows: sqlDollar[1].union.slct()}
 		}
 	case 260:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1713
+		//line sql.y:1719
 		{
-			sqlVAL.union.val = &Insert{Columns: sqlDollar[2].union.qnames(), Rows: sqlDollar[4].union.selectStmt()}
+			sqlVAL.union.val = &Insert{Columns: sqlDollar[2].union.qnames(), Rows: sqlDollar[4].union.slct()}
 		}
 	case 261:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1717
+		//line sql.y:1723
 		{
-			sqlVAL.union.val = &Insert{}
+			sqlVAL.union.val = &Insert{Rows: &Select{}}
 		}
 	case 262:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1724
+		//line sql.y:1730
 		{
 			unimplemented()
 		}
 	case 263:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1725
+		//line sql.y:1731
 		{
 			unimplemented()
 		}
 	case 264:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1726
+		//line sql.y:1732
 		{
 		}
 	case 265:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1729
+		//line sql.y:1735
 		{
 			unimplemented()
 		}
 	case 266:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1730
+		//line sql.y:1736
 		{
 			unimplemented()
 		}
 	case 267:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1731
+		//line sql.y:1737
 		{
 		}
 	case 268:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1735
+		//line sql.y:1741
 		{
 			sqlVAL.union.val = sqlDollar[2].union.selExprs()
 		}
 	case 269:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1739
+		//line sql.y:1745
 		{
 			sqlVAL.union.val = SelectExprs(nil)
 		}
 	case 270:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1746
+		//line sql.y:1752
 		{
 			sqlVAL.union.val = &Update{Table: sqlDollar[3].union.tblExpr(), Exprs: sqlDollar[5].union.updateExprs(), Where: newWhere(astWhere, sqlDollar[7].union.expr()), Returning: sqlDollar[8].union.retExprs()}
 		}
 	case 271:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1752
+		//line sql.y:1758
 		{
 			sqlVAL.union.val = UpdateExprs{sqlDollar[1].union.updateExpr()}
 		}
 	case 272:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1756
+		//line sql.y:1762
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.updateExprs(), sqlDollar[3].union.updateExpr())
 		}
 	case 275:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1766
+		//line sql.y:1772
 		{
 			sqlVAL.union.val = &UpdateExpr{Names: QualifiedNames{sqlDollar[1].union.qname()}, Expr: sqlDollar[3].union.expr()}
 		}
 	case 276:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1778
+		//line sql.y:1784
 		{
 			sqlVAL.union.val = &UpdateExpr{Tuple: true, Names: sqlDollar[2].union.qnames(), Expr: &Tuple{sqlDollar[5].union.exprs()}}
 		}
 	case 277:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1782
+		//line sql.y:1788
 		{
 			sqlVAL.union.val = &UpdateExpr{Tuple: true, Names: sqlDollar[2].union.qnames(), Expr: &Subquery{Select: sqlDollar[5].union.selectStmt()}}
 		}
+	case 279:
+		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
+		//line sql.y:1832
+		{
+			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt()}
+		}
 	case 280:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1829
+		//line sql.y:1838
 		{
-			sqlVAL.union.val = &ParenSelect{Select: sqlDollar[2].union.selectStmt()}
+			sqlVAL.union.val = &ParenSelect{Select: sqlDollar[2].union.slct()}
 		}
 	case 281:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1833
+		//line sql.y:1842
 		{
-			sqlVAL.union.val = &ParenSelect{Select: sqlDollar[2].union.selectStmt()}
+			sqlVAL.union.val = &ParenSelect{Select: &Select{Select: sqlDollar[2].union.selectStmt()}}
+		}
+	case 282:
+		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
+		//line sql.y:1857
+		{
+			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 283:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1849
+		//line sql.y:1861
 		{
-			sqlVAL.union.val = sqlDollar[1].union.selectStmt()
-			if s, ok := sqlVAL.union.val.(*SelectClause); ok {
-				s.OrderBy = sqlDollar[2].union.orderBy()
-			}
+			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt(), OrderBy: sqlDollar[2].union.orderBy()}
 		}
 	case 284:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1856
+		//line sql.y:1865
 		{
-			sqlVAL.union.val = sqlDollar[1].union.selectStmt()
-			if s, ok := sqlVAL.union.val.(*SelectClause); ok {
-				s.OrderBy = sqlDollar[2].union.orderBy()
-				s.Limit = sqlDollar[3].union.limit()
-			}
+			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt(), OrderBy: sqlDollar[2].union.orderBy(), Limit: sqlDollar[3].union.limit()}
 		}
 	case 285:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1864
+		//line sql.y:1869
 		{
-			sqlVAL.union.val = sqlDollar[2].union.selectStmt()
+			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt()}
 		}
 	case 286:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1868
+		//line sql.y:1873
 		{
-			sqlVAL.union.val = sqlDollar[2].union.selectStmt()
-			if s, ok := sqlVAL.union.val.(*SelectClause); ok {
-				s.OrderBy = sqlDollar[3].union.orderBy()
-			}
+			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt(), OrderBy: sqlDollar[3].union.orderBy()}
 		}
 	case 287:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1875
+		//line sql.y:1877
 		{
-			sqlVAL.union.val = sqlDollar[2].union.selectStmt()
-			if s, ok := sqlVAL.union.val.(*SelectClause); ok {
-				s.OrderBy = sqlDollar[3].union.orderBy()
-				s.Limit = sqlDollar[4].union.limit()
-			}
+			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt(), OrderBy: sqlDollar[3].union.orderBy(), Limit: sqlDollar[4].union.limit()}
 		}
 	case 290:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1913
+		//line sql.y:1911
 		{
 			sqlVAL.union.val = &SelectClause{
 				Exprs:   sqlDollar[3].union.selExprs(),
@@ -5691,7 +5695,7 @@ sqldefault:
 		}
 	case 291:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1925
+		//line sql.y:1923
 		{
 			sqlVAL.union.val = &SelectClause{
 				Distinct: sqlDollar[2].union.bool(),
@@ -5704,7 +5708,7 @@ sqldefault:
 		}
 	case 293:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1937
+		//line sql.y:1935
 		{
 			sqlVAL.union.val = &SelectClause{
 				Exprs:       SelectExprs{starSelectExpr()},
@@ -5714,173 +5718,173 @@ sqldefault:
 		}
 	case 294:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1945
+		//line sql.y:1943
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  UnionOp,
-				Left:  sqlDollar[1].union.selectStmt(),
-				Right: sqlDollar[4].union.selectStmt(),
+				Left:  &Select{Select: sqlDollar[1].union.selectStmt()},
+				Right: &Select{Select: sqlDollar[4].union.selectStmt()},
 				All:   sqlDollar[3].union.bool(),
 			}
 		}
 	case 295:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1954
+		//line sql.y:1952
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  IntersectOp,
-				Left:  sqlDollar[1].union.selectStmt(),
-				Right: sqlDollar[4].union.selectStmt(),
+				Left:  &Select{Select: sqlDollar[1].union.selectStmt()},
+				Right: &Select{Select: sqlDollar[4].union.selectStmt()},
 				All:   sqlDollar[3].union.bool(),
 			}
 		}
 	case 296:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1963
+		//line sql.y:1961
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  ExceptOp,
-				Left:  sqlDollar[1].union.selectStmt(),
-				Right: sqlDollar[4].union.selectStmt(),
+				Left:  &Select{Select: sqlDollar[1].union.selectStmt()},
+				Right: &Select{Select: sqlDollar[4].union.selectStmt()},
 				All:   sqlDollar[3].union.bool(),
 			}
 		}
 	case 297:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1981
+		//line sql.y:1979
 		{
 			unimplemented()
 		}
 	case 298:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1982
+		//line sql.y:1980
 		{
 			unimplemented()
 		}
 	case 299:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1983
+		//line sql.y:1981
 		{
 			unimplemented()
 		}
 	case 300:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1986
+		//line sql.y:1984
 		{
 			unimplemented()
 		}
 	case 301:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1987
+		//line sql.y:1985
 		{
 			unimplemented()
 		}
 	case 302:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1990
+		//line sql.y:1988
 		{
 			unimplemented()
 		}
 	case 303:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1994
+		//line sql.y:1992
 		{
-			sqlVAL.union.val = sqlDollar[1].union.selectStmt()
+			sqlVAL.union.val = sqlDollar[1].union.slct()
 		}
 	case 307:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2002
+		//line sql.y:2000
 		{
 			unimplemented()
 		}
 	case 308:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2003
+		//line sql.y:2001
 		{
 		}
 	case 309:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2006
+		//line sql.y:2004
 		{
 		}
 	case 310:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2007
+		//line sql.y:2005
 		{
 		}
 	case 311:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2011
+		//line sql.y:2009
 		{
 			sqlVAL.union.val = true
 		}
 	case 312:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2015
+		//line sql.y:2013
 		{
 			sqlVAL.union.val = false
 		}
 	case 313:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2019
+		//line sql.y:2017
 		{
 			sqlVAL.union.val = false
 		}
 	case 314:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2025
+		//line sql.y:2023
 		{
 			sqlVAL.union.val = true
 		}
 	case 315:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2030
+		//line sql.y:2028
 		{
 		}
 	case 316:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2031
+		//line sql.y:2029
 		{
 		}
 	case 317:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2035
+		//line sql.y:2033
 		{
 			sqlVAL.union.val = sqlDollar[1].union.orderBy()
 		}
 	case 318:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2039
+		//line sql.y:2037
 		{
 			sqlVAL.union.val = OrderBy(nil)
 		}
 	case 319:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2045
+		//line sql.y:2043
 		{
 			sqlVAL.union.val = OrderBy(sqlDollar[3].union.orders())
 		}
 	case 320:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2051
+		//line sql.y:2049
 		{
 			sqlVAL.union.val = []*Order{sqlDollar[1].union.order()}
 		}
 	case 321:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2055
+		//line sql.y:2053
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.orders(), sqlDollar[3].union.order())
 		}
 	case 322:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2061
+		//line sql.y:2059
 		{
 			sqlVAL.union.val = &Order{Expr: sqlDollar[1].union.expr(), Direction: sqlDollar[2].union.dir()}
 		}
 	case 323:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2069
+		//line sql.y:2067
 		{
 			if sqlDollar[1].union.limit() == nil {
 				sqlVAL.union.val = sqlDollar[2].union.limit()
@@ -5891,7 +5895,7 @@ sqldefault:
 		}
 	case 324:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2078
+		//line sql.y:2076
 		{
 			sqlVAL.union.val = sqlDollar[1].union.limit()
 			if sqlDollar[2].union.limit() != nil {
@@ -5900,7 +5904,7 @@ sqldefault:
 		}
 	case 327:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2089
+		//line sql.y:2087
 		{
 			if sqlDollar[2].union.expr() == nil {
 				sqlVAL.union.val = (*Limit)(nil)
@@ -5910,65 +5914,65 @@ sqldefault:
 		}
 	case 328:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2102
+		//line sql.y:2100
 		{
 			sqlVAL.union.val = &Limit{Offset: sqlDollar[2].union.expr()}
 		}
 	case 329:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2109
+		//line sql.y:2107
 		{
 			sqlVAL.union.val = &Limit{Offset: sqlDollar[2].union.expr()}
 		}
 	case 331:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2116
+		//line sql.y:2114
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 332:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2130
+		//line sql.y:2128
 		{
 		}
 	case 333:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2131
+		//line sql.y:2129
 		{
 		}
 	case 334:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2157
+		//line sql.y:2155
 		{
 			sqlVAL.union.val = GroupBy(sqlDollar[3].union.exprs())
 		}
 	case 335:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2161
+		//line sql.y:2159
 		{
 			sqlVAL.union.val = GroupBy(nil)
 		}
 	case 336:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2167
+		//line sql.y:2165
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 337:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2171
+		//line sql.y:2169
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 338:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2177
+		//line sql.y:2175
 		{
 			sqlVAL.union.val = &ValuesClause{[]*Tuple{{sqlDollar[2].union.exprs()}}}
 		}
 	case 339:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2181
+		//line sql.y:2179
 		{
 			valNode := sqlDollar[1].union.selectStmt().(*ValuesClause)
 			valNode.Tuples = append(valNode.Tuples, &Tuple{sqlDollar[3].union.exprs()})
@@ -5976,2011 +5980,2011 @@ sqldefault:
 		}
 	case 340:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2193
+		//line sql.y:2191
 		{
 			sqlVAL.union.val = sqlDollar[2].union.tblExprs()
 		}
 	case 341:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2197
+		//line sql.y:2195
 		{
 			sqlVAL.union.val = TableExprs(nil)
 		}
 	case 342:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2203
+		//line sql.y:2201
 		{
 			sqlVAL.union.val = TableExprs{sqlDollar[1].union.tblExpr()}
 		}
 	case 343:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2207
+		//line sql.y:2205
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tblExprs(), sqlDollar[3].union.tblExpr())
 		}
 	case 344:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2214
+		//line sql.y:2212
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname(), As: sqlDollar[2].union.aliasClause()}
 		}
 	case 345:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2218
+		//line sql.y:2216
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: &Subquery{Select: sqlDollar[1].union.selectStmt()}, As: sqlDollar[2].union.aliasClause()}
 		}
 	case 347:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2222
+		//line sql.y:2220
 		{
 			unimplemented()
 		}
 	case 348:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2240
+		//line sql.y:2238
 		{
 			sqlVAL.union.val = &ParenTableExpr{Expr: sqlDollar[2].union.tblExpr()}
 		}
 	case 349:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2244
+		//line sql.y:2242
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astCrossJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr()}
 		}
 	case 350:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2248
+		//line sql.y:2246
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: sqlDollar[2].str, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr(), Cond: sqlDollar[5].union.joinCond()}
 		}
 	case 351:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2252
+		//line sql.y:2250
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[3].union.tblExpr(), Cond: sqlDollar[4].union.joinCond()}
 		}
 	case 352:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2256
+		//line sql.y:2254
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astNaturalJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[5].union.tblExpr()}
 		}
 	case 353:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2260
+		//line sql.y:2258
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astNaturalJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr()}
 		}
 	case 354:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2266
+		//line sql.y:2264
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[2].str), Cols: NameList(sqlDollar[4].union.strs())}
 		}
 	case 355:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2270
+		//line sql.y:2268
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[2].str)}
 		}
 	case 356:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2274
+		//line sql.y:2272
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[1].str), Cols: NameList(sqlDollar[3].union.strs())}
 		}
 	case 357:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2278
+		//line sql.y:2276
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[1].str)}
 		}
 	case 359:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2285
+		//line sql.y:2283
 		{
 			sqlVAL.union.val = AliasClause{}
 		}
 	case 360:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2291
+		//line sql.y:2289
 		{
 			sqlVAL.str = astFullJoin
 		}
 	case 361:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2295
+		//line sql.y:2293
 		{
 			sqlVAL.str = astLeftJoin
 		}
 	case 362:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2299
+		//line sql.y:2297
 		{
 			sqlVAL.str = astRightJoin
 		}
 	case 363:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2303
+		//line sql.y:2301
 		{
 			sqlVAL.str = astInnerJoin
 		}
 	case 364:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2309
+		//line sql.y:2307
 		{
 		}
 	case 365:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2310
+		//line sql.y:2308
 		{
 		}
 	case 366:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2321
+		//line sql.y:2319
 		{
 			sqlVAL.union.val = &UsingJoinCond{Cols: NameList(sqlDollar[3].union.strs())}
 		}
 	case 367:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2325
+		//line sql.y:2323
 		{
 			sqlVAL.union.val = &OnJoinCond{Expr: sqlDollar[2].union.expr()}
 		}
 	case 368:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2331
+		//line sql.y:2329
 		{
 			sqlVAL.union.val = sqlDollar[1].union.qname()
 		}
 	case 369:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2335
+		//line sql.y:2333
 		{
 			sqlVAL.union.val = sqlDollar[1].union.qname()
 		}
 	case 370:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2339
+		//line sql.y:2337
 		{
 			sqlVAL.union.val = sqlDollar[2].union.qname()
 		}
 	case 371:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2343
+		//line sql.y:2341
 		{
 			sqlVAL.union.val = sqlDollar[3].union.qname()
 		}
 	case 372:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2349
+		//line sql.y:2347
 		{
 			sqlVAL.union.val = QualifiedNames{sqlDollar[1].union.qname()}
 		}
 	case 373:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2353
+		//line sql.y:2351
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.qnames(), sqlDollar[3].union.qname())
 		}
 	case 374:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2366
+		//line sql.y:2364
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname()}
 		}
 	case 375:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2370
+		//line sql.y:2368
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname(), As: AliasClause{Alias: Name(sqlDollar[2].str)}}
 		}
 	case 376:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2374
+		//line sql.y:2372
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname(), As: AliasClause{Alias: Name(sqlDollar[3].str)}}
 		}
 	case 377:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2380
+		//line sql.y:2378
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 378:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2384
+		//line sql.y:2382
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 379:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2396
+		//line sql.y:2394
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 		}
 	case 380:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2400
+		//line sql.y:2398
 		{
 			unimplemented()
 		}
 	case 381:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2401
+		//line sql.y:2399
 		{
 			unimplemented()
 		}
 	case 382:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2404
+		//line sql.y:2402
 		{
 			unimplemented()
 		}
 	case 383:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2405
+		//line sql.y:2403
 		{
 			unimplemented()
 		}
 	case 384:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2406
+		//line sql.y:2404
 		{
 		}
 	case 390:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2414
+		//line sql.y:2412
 		{
 			unimplemented()
 		}
 	case 391:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2416
+		//line sql.y:2414
 		{
 			sqlVAL.union.val = &BytesType{Name: "BLOB"}
 		}
 	case 392:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2420
+		//line sql.y:2418
 		{
 			sqlVAL.union.val = &BytesType{Name: "BYTES"}
 		}
 	case 393:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2424
+		//line sql.y:2422
 		{
 			sqlVAL.union.val = &BytesType{Name: "BYTEA"}
 		}
 	case 394:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2428
+		//line sql.y:2426
 		{
 			sqlVAL.union.val = &StringType{Name: "TEXT"}
 		}
 	case 395:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2432
+		//line sql.y:2430
 		{
 			sqlVAL.union.val = &StringType{Name: "STRING"}
 		}
 	case 400:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2453
+		//line sql.y:2451
 		{
 			sqlVAL.union.val = &DecimalType{Prec: int(sqlDollar[2].union.ival().Val)}
 		}
 	case 401:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2457
+		//line sql.y:2455
 		{
 			sqlVAL.union.val = &DecimalType{Prec: int(sqlDollar[2].union.ival().Val), Scale: int(sqlDollar[4].union.ival().Val)}
 		}
 	case 402:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2461
+		//line sql.y:2459
 		{
 			sqlVAL.union.val = &DecimalType{}
 		}
 	case 403:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2468
+		//line sql.y:2466
 		{
 			sqlVAL.union.val = &IntType{Name: "INT"}
 		}
 	case 404:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2472
+		//line sql.y:2470
 		{
 			sqlVAL.union.val = &IntType{Name: "INT64"}
 		}
 	case 405:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2476
+		//line sql.y:2474
 		{
 			sqlVAL.union.val = &IntType{Name: "INTEGER"}
 		}
 	case 406:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2480
+		//line sql.y:2478
 		{
 			sqlVAL.union.val = &IntType{Name: "SMALLINT"}
 		}
 	case 407:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2484
+		//line sql.y:2482
 		{
 			sqlVAL.union.val = &IntType{Name: "BIGINT"}
 		}
 	case 408:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2488
+		//line sql.y:2486
 		{
 			sqlVAL.union.val = &FloatType{Name: "REAL"}
 		}
 	case 409:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2492
+		//line sql.y:2490
 		{
 			sqlVAL.union.val = &FloatType{Name: "FLOAT", Prec: int(sqlDollar[2].union.ival().Val)}
 		}
 	case 410:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2496
+		//line sql.y:2494
 		{
 			sqlVAL.union.val = &FloatType{Name: "DOUBLE PRECISION"}
 		}
 	case 411:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2500
+		//line sql.y:2498
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			sqlVAL.union.val.(*DecimalType).Name = "DECIMAL"
 		}
 	case 412:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2505
+		//line sql.y:2503
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			sqlVAL.union.val.(*DecimalType).Name = "DEC"
 		}
 	case 413:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2510
+		//line sql.y:2508
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			sqlVAL.union.val.(*DecimalType).Name = "NUMERIC"
 		}
 	case 414:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2515
+		//line sql.y:2513
 		{
 			sqlVAL.union.val = &BoolType{Name: "BOOLEAN"}
 		}
 	case 415:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2519
+		//line sql.y:2517
 		{
 			sqlVAL.union.val = &BoolType{Name: "BOOL"}
 		}
 	case 416:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2525
+		//line sql.y:2523
 		{
 			sqlVAL.union.val = sqlDollar[2].union.ival()
 		}
 	case 417:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2529
+		//line sql.y:2527
 		{
 			sqlVAL.union.val = IntVal{}
 		}
 	case 422:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2547
+		//line sql.y:2545
 		{
 			sqlVAL.union.val = &IntType{Name: "BIT", N: int(sqlDollar[4].union.ival().Val)}
 		}
 	case 423:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2553
+		//line sql.y:2551
 		{
 			sqlVAL.union.val = &IntType{Name: "BIT"}
 		}
 	case 428:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2569
+		//line sql.y:2567
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 			sqlVAL.union.val.(*StringType).N = int(sqlDollar[3].union.ival().Val)
 		}
 	case 429:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2576
+		//line sql.y:2574
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 		}
 	case 430:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2582
+		//line sql.y:2580
 		{
 			sqlVAL.union.val = &StringType{Name: "CHAR"}
 		}
 	case 431:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2586
+		//line sql.y:2584
 		{
 			sqlVAL.union.val = &StringType{Name: "CHAR"}
 		}
 	case 432:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2590
+		//line sql.y:2588
 		{
 			sqlVAL.union.val = &StringType{Name: "VARCHAR"}
 		}
 	case 433:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2595
+		//line sql.y:2593
 		{
 		}
 	case 434:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2596
+		//line sql.y:2594
 		{
 		}
 	case 435:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2601
+		//line sql.y:2599
 		{
 			sqlVAL.union.val = &DateType{}
 		}
 	case 436:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2605
+		//line sql.y:2603
 		{
 			sqlVAL.union.val = &TimestampType{}
 		}
 	case 437:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2610
+		//line sql.y:2608
 		{
 			sqlVAL.union.val = &IntervalType{}
 		}
 	case 438:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2615
+		//line sql.y:2613
 		{
 			unimplemented()
 		}
 	case 439:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2616
+		//line sql.y:2614
 		{
 			unimplemented()
 		}
 	case 440:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2617
+		//line sql.y:2615
 		{
 			unimplemented()
 		}
 	case 441:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2618
+		//line sql.y:2616
 		{
 			unimplemented()
 		}
 	case 442:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2619
+		//line sql.y:2617
 		{
 			unimplemented()
 		}
 	case 443:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2620
+		//line sql.y:2618
 		{
 			unimplemented()
 		}
 	case 444:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2621
+		//line sql.y:2619
 		{
 			unimplemented()
 		}
 	case 445:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2622
+		//line sql.y:2620
 		{
 			unimplemented()
 		}
 	case 446:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2623
+		//line sql.y:2621
 		{
 			unimplemented()
 		}
 	case 447:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2624
+		//line sql.y:2622
 		{
 			unimplemented()
 		}
 	case 448:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2625
+		//line sql.y:2623
 		{
 			unimplemented()
 		}
 	case 449:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2626
+		//line sql.y:2624
 		{
 			unimplemented()
 		}
 	case 450:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2627
+		//line sql.y:2625
 		{
 			unimplemented()
 		}
 	case 451:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2628
+		//line sql.y:2626
 		{
 		}
 	case 452:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2631
+		//line sql.y:2629
 		{
 			unimplemented()
 		}
 	case 453:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2632
+		//line sql.y:2630
 		{
 			unimplemented()
 		}
 	case 455:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2656
+		//line sql.y:2654
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
 		}
 	case 456:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2659
+		//line sql.y:2657
 		{
 			unimplemented()
 		}
 	case 457:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2660
+		//line sql.y:2658
 		{
 			unimplemented()
 		}
 	case 458:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2669
+		//line sql.y:2667
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 459:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2673
+		//line sql.y:2671
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 460:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2677
+		//line sql.y:2675
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].union.expr()}
 		}
 	case 461:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2681
+		//line sql.y:2679
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 462:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2685
+		//line sql.y:2683
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 463:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2689
+		//line sql.y:2687
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 464:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2693
+		//line sql.y:2691
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Div, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 465:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2697
+		//line sql.y:2695
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 466:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2701
+		//line sql.y:2699
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 467:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2705
+		//line sql.y:2703
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 468:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2709
+		//line sql.y:2707
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 469:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2713
+		//line sql.y:2711
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 470:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2717
+		//line sql.y:2715
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 471:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2721
+		//line sql.y:2719
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 472:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2725
+		//line sql.y:2723
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 473:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2729
+		//line sql.y:2727
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 474:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2733
+		//line sql.y:2731
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 475:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2737
+		//line sql.y:2735
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 476:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2741
+		//line sql.y:2739
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 477:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2745
+		//line sql.y:2743
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 478:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2749
+		//line sql.y:2747
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 479:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2753
+		//line sql.y:2751
 		{
 			sqlVAL.union.val = &AndExpr{Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 480:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2757
+		//line sql.y:2755
 		{
 			sqlVAL.union.val = &OrExpr{Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 481:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2761
+		//line sql.y:2759
 		{
 			sqlVAL.union.val = &NotExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 482:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2765
+		//line sql.y:2763
 		{
 			sqlVAL.union.val = &NotExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 483:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2769
+		//line sql.y:2767
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Like, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 484:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2773
+		//line sql.y:2771
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotLike, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 485:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2777
+		//line sql.y:2775
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: SimilarTo, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 486:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2781
+		//line sql.y:2779
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotSimilarTo, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 487:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2785
+		//line sql.y:2783
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 488:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2789
+		//line sql.y:2787
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 489:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2792
+		//line sql.y:2790
 		{
 			unimplemented()
 		}
 	case 490:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2794
+		//line sql.y:2792
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DBool(true)}
 		}
 	case 491:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2798
+		//line sql.y:2796
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DBool(true)}
 		}
 	case 492:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2802
+		//line sql.y:2800
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DBool(false)}
 		}
 	case 493:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2806
+		//line sql.y:2804
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DBool(false)}
 		}
 	case 494:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2810
+		//line sql.y:2808
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 495:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2814
+		//line sql.y:2812
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 496:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2818
+		//line sql.y:2816
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 497:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2822
+		//line sql.y:2820
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[6].union.expr()}
 		}
 	case 498:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2826
+		//line sql.y:2824
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Expr: sqlDollar[1].union.expr(), Types: sqlDollar[5].union.colTypes()}
 		}
 	case 499:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2830
+		//line sql.y:2828
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].union.expr(), Types: sqlDollar[6].union.colTypes()}
 		}
 	case 500:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2834
+		//line sql.y:2832
 		{
 			sqlVAL.union.val = &RangeCond{Left: sqlDollar[1].union.expr(), From: sqlDollar[4].union.expr(), To: sqlDollar[6].union.expr()}
 		}
 	case 501:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2838
+		//line sql.y:2836
 		{
 			sqlVAL.union.val = &RangeCond{Not: true, Left: sqlDollar[1].union.expr(), From: sqlDollar[5].union.expr(), To: sqlDollar[7].union.expr()}
 		}
 	case 502:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2842
+		//line sql.y:2840
 		{
 			sqlVAL.union.val = &RangeCond{Left: sqlDollar[1].union.expr(), From: sqlDollar[4].union.expr(), To: sqlDollar[6].union.expr()}
 		}
 	case 503:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2846
+		//line sql.y:2844
 		{
 			sqlVAL.union.val = &RangeCond{Not: true, Left: sqlDollar[1].union.expr(), From: sqlDollar[5].union.expr(), To: sqlDollar[7].union.expr()}
 		}
 	case 504:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2850
+		//line sql.y:2848
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: In, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 505:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2854
+		//line sql.y:2852
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotIn, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 507:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2871
+		//line sql.y:2869
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
 		}
 	case 508:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2875
+		//line sql.y:2873
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 509:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2879
+		//line sql.y:2877
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 510:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2883
+		//line sql.y:2881
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].union.expr()}
 		}
 	case 511:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2887
+		//line sql.y:2885
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 512:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2891
+		//line sql.y:2889
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 513:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2895
+		//line sql.y:2893
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 514:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2899
+		//line sql.y:2897
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Div, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 515:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2903
+		//line sql.y:2901
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 516:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2907
+		//line sql.y:2905
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 517:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2911
+		//line sql.y:2909
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 518:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2915
+		//line sql.y:2913
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 519:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2919
+		//line sql.y:2917
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 520:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2923
+		//line sql.y:2921
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 521:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2927
+		//line sql.y:2925
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 522:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2931
+		//line sql.y:2929
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 523:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2935
+		//line sql.y:2933
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 524:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2939
+		//line sql.y:2937
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 525:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2943
+		//line sql.y:2941
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 526:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2947
+		//line sql.y:2945
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 527:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2951
+		//line sql.y:2949
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 528:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2955
+		//line sql.y:2953
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 529:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2959
+		//line sql.y:2957
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 530:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2963
+		//line sql.y:2961
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[6].union.expr()}
 		}
 	case 531:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2967
+		//line sql.y:2965
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Expr: sqlDollar[1].union.expr(), Types: sqlDollar[5].union.colTypes()}
 		}
 	case 532:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2971
+		//line sql.y:2969
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].union.expr(), Types: sqlDollar[6].union.colTypes()}
 		}
 	case 533:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2983
+		//line sql.y:2981
 		{
 			sqlVAL.union.val = sqlDollar[1].union.qname()
 		}
 	case 535:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2988
+		//line sql.y:2986
 		{
 			sqlVAL.union.val = ValArg{name: sqlDollar[1].str}
 		}
 	case 536:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2992
+		//line sql.y:2990
 		{
 			sqlVAL.union.val = &ParenExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 539:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2998
+		//line sql.y:2996
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 540:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3002
+		//line sql.y:3000
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 541:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3006
+		//line sql.y:3004
 		{
 			sqlVAL.union.val = &ExistsExpr{Subquery: &Subquery{Select: sqlDollar[2].union.selectStmt()}}
 		}
 	case 542:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3012
+		//line sql.y:3010
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 543:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3016
+		//line sql.y:3014
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 544:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3020
+		//line sql.y:3018
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 545:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3028
+		//line sql.y:3026
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname()}
 		}
 	case 546:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3032
+		//line sql.y:3030
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 547:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3035
+		//line sql.y:3033
 		{
 			unimplemented()
 		}
 	case 548:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:3036
+		//line sql.y:3034
 		{
 			unimplemented()
 		}
 	case 549:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3038
+		//line sql.y:3036
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Type: All, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 550:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3042
+		//line sql.y:3040
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Type: Distinct, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 551:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3046
+		//line sql.y:3044
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Exprs: Exprs{StarExpr()}}
 		}
 	case 552:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3059
+		//line sql.y:3057
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 553:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3063
+		//line sql.y:3061
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 554:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3072
+		//line sql.y:3070
 		{
 			unimplemented()
 		}
 	case 555:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3073
+		//line sql.y:3071
 		{
 			unimplemented()
 		}
 	case 556:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3077
+		//line sql.y:3075
 		{
 			unimplemented()
 		}
 	case 557:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3079
+		//line sql.y:3077
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 558:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3083
+		//line sql.y:3081
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 559:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3087
+		//line sql.y:3085
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 560:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3091
+		//line sql.y:3089
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 561:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3094
+		//line sql.y:3092
 		{
 			unimplemented()
 		}
 	case 562:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3095
+		//line sql.y:3093
 		{
 			unimplemented()
 		}
 	case 563:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3096
+		//line sql.y:3094
 		{
 			unimplemented()
 		}
 	case 564:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3097
+		//line sql.y:3095
 		{
 			unimplemented()
 		}
 	case 565:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3099
+		//line sql.y:3097
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[3].union.expr(), Type: sqlDollar[5].union.colType()}
 		}
 	case 566:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3103
+		//line sql.y:3101
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 567:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3107
+		//line sql.y:3105
 		{
 			sqlVAL.union.val = &OverlayExpr{FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}}
 		}
 	case 568:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3111
+		//line sql.y:3109
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "STRPOS"}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 569:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3115
+		//line sql.y:3113
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 570:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3118
+		//line sql.y:3116
 		{
 			unimplemented()
 		}
 	case 571:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3120
+		//line sql.y:3118
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "BTRIM"}, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 572:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3124
+		//line sql.y:3122
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "LTRIM"}, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 573:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3128
+		//line sql.y:3126
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "RTRIM"}, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 574:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3132
+		//line sql.y:3130
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "BTRIM"}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 575:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:3136
+		//line sql.y:3134
 		{
 			sqlVAL.union.val = &IfExpr{Cond: sqlDollar[3].union.expr(), True: sqlDollar[5].union.expr(), Else: sqlDollar[7].union.expr()}
 		}
 	case 576:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3140
+		//line sql.y:3138
 		{
 			sqlVAL.union.val = &NullIfExpr{Expr1: sqlDollar[3].union.expr(), Expr2: sqlDollar[5].union.expr()}
 		}
 	case 577:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3144
+		//line sql.y:3142
 		{
 			sqlVAL.union.val = &CoalesceExpr{Name: "IFNULL", Exprs: Exprs{sqlDollar[3].union.expr(), sqlDollar[5].union.expr()}}
 		}
 	case 578:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3148
+		//line sql.y:3146
 		{
 			sqlVAL.union.val = &CoalesceExpr{Name: "COALESCE", Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 579:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3152
+		//line sql.y:3150
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 580:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3156
+		//line sql.y:3154
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 581:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3162
+		//line sql.y:3160
 		{
 			unimplemented()
 		}
 	case 582:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3163
+		//line sql.y:3161
 		{
 		}
 	case 583:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3166
+		//line sql.y:3164
 		{
 			unimplemented()
 		}
 	case 584:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3167
+		//line sql.y:3165
 		{
 		}
 	case 585:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3171
+		//line sql.y:3169
 		{
 			unimplemented()
 		}
 	case 586:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3172
+		//line sql.y:3170
 		{
 		}
 	case 587:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3175
+		//line sql.y:3173
 		{
 			unimplemented()
 		}
 	case 588:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3176
+		//line sql.y:3174
 		{
 			unimplemented()
 		}
 	case 589:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3179
+		//line sql.y:3177
 		{
 			unimplemented()
 		}
 	case 590:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3182
+		//line sql.y:3180
 		{
 			unimplemented()
 		}
 	case 591:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3183
+		//line sql.y:3181
 		{
 			unimplemented()
 		}
 	case 592:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3184
+		//line sql.y:3182
 		{
 		}
 	case 593:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3188
+		//line sql.y:3186
 		{
 			unimplemented()
 		}
 	case 594:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3199
+		//line sql.y:3197
 		{
 			unimplemented()
 		}
 	case 595:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3200
+		//line sql.y:3198
 		{
 		}
 	case 596:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3203
+		//line sql.y:3201
 		{
 			unimplemented()
 		}
 	case 597:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3204
+		//line sql.y:3202
 		{
 		}
 	case 598:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3212
+		//line sql.y:3210
 		{
 			unimplemented()
 		}
 	case 599:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3213
+		//line sql.y:3211
 		{
 			unimplemented()
 		}
 	case 600:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3214
+		//line sql.y:3212
 		{
 		}
 	case 601:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3217
+		//line sql.y:3215
 		{
 			unimplemented()
 		}
 	case 602:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3218
+		//line sql.y:3216
 		{
 			unimplemented()
 		}
 	case 603:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3224
+		//line sql.y:3222
 		{
 			unimplemented()
 		}
 	case 604:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3225
+		//line sql.y:3223
 		{
 			unimplemented()
 		}
 	case 605:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3226
+		//line sql.y:3224
 		{
 			unimplemented()
 		}
 	case 606:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3227
+		//line sql.y:3225
 		{
 			unimplemented()
 		}
 	case 607:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3228
+		//line sql.y:3226
 		{
 			unimplemented()
 		}
 	case 608:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3239
+		//line sql.y:3237
 		{
 			sqlVAL.union.val = &Row{sqlDollar[3].union.exprs()}
 		}
 	case 609:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3243
+		//line sql.y:3241
 		{
 			sqlVAL.union.val = &Row{nil}
 		}
 	case 610:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3247
+		//line sql.y:3245
 		{
 			sqlVAL.union.val = &Tuple{append(sqlDollar[2].union.exprs(), sqlDollar[4].union.expr())}
 		}
 	case 611:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3253
+		//line sql.y:3251
 		{
 			sqlVAL.union.val = &Row{sqlDollar[3].union.exprs()}
 		}
 	case 612:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3257
+		//line sql.y:3255
 		{
 			sqlVAL.union.val = &Row{nil}
 		}
 	case 613:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3263
+		//line sql.y:3261
 		{
 			sqlVAL.union.val = &Tuple{append(sqlDollar[2].union.exprs(), sqlDollar[4].union.expr())}
 		}
 	case 614:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3304
+		//line sql.y:3302
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 615:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3308
+		//line sql.y:3306
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 616:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3314
+		//line sql.y:3312
 		{
 			sqlVAL.union.val = []ColumnType{sqlDollar[1].union.colType()}
 		}
 	case 617:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3318
+		//line sql.y:3316
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.colTypes(), sqlDollar[3].union.colType())
 		}
 	case 618:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3324
+		//line sql.y:3322
 		{
 			sqlVAL.union.val = &Array{sqlDollar[2].union.exprs()}
 		}
 	case 619:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3328
+		//line sql.y:3326
 		{
 			sqlVAL.union.val = &Array{sqlDollar[2].union.exprs()}
 		}
 	case 620:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3332
+		//line sql.y:3330
 		{
 			sqlVAL.union.val = &Array{nil}
 		}
 	case 621:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3338
+		//line sql.y:3336
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 622:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3342
+		//line sql.y:3340
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 623:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3348
+		//line sql.y:3346
 		{
 			sqlVAL.union.val = Exprs{DString(sqlDollar[1].str), sqlDollar[3].union.expr()}
 		}
 	case 631:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3370
+		//line sql.y:3368
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr(), sqlDollar[4].union.expr()}
 		}
 	case 632:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3374
+		//line sql.y:3372
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr()}
 		}
 	case 633:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3380
+		//line sql.y:3378
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 634:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3387
+		//line sql.y:3385
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[3].union.expr(), sqlDollar[1].union.expr()}
 		}
 	case 635:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3391
+		//line sql.y:3389
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 636:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3408
+		//line sql.y:3406
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr()}
 		}
 	case 637:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3412
+		//line sql.y:3410
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[3].union.expr(), sqlDollar[2].union.expr()}
 		}
 	case 638:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3416
+		//line sql.y:3414
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr()}
 		}
 	case 639:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3420
+		//line sql.y:3418
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), DInt(1), sqlDollar[2].union.expr()}
 		}
 	case 640:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3424
+		//line sql.y:3422
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 641:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3428
+		//line sql.y:3426
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 642:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3434
+		//line sql.y:3432
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 643:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3440
+		//line sql.y:3438
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 644:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3446
+		//line sql.y:3444
 		{
 			sqlVAL.union.val = append(sqlDollar[3].union.exprs(), sqlDollar[1].union.expr())
 		}
 	case 645:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3450
+		//line sql.y:3448
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 646:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3454
+		//line sql.y:3452
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 647:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3460
+		//line sql.y:3458
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 648:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3464
+		//line sql.y:3462
 		{
 			sqlVAL.union.val = &Tuple{sqlDollar[2].union.exprs()}
 		}
 	case 649:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3475
+		//line sql.y:3473
 		{
 			sqlVAL.union.val = &CaseExpr{Expr: sqlDollar[2].union.expr(), Whens: sqlDollar[3].union.whens(), Else: sqlDollar[4].union.expr()}
 		}
 	case 650:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3482
+		//line sql.y:3480
 		{
 			sqlVAL.union.val = []*When{sqlDollar[1].union.when()}
 		}
 	case 651:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3486
+		//line sql.y:3484
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.whens(), sqlDollar[2].union.when())
 		}
 	case 652:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3492
+		//line sql.y:3490
 		{
 			sqlVAL.union.val = &When{Cond: sqlDollar[2].union.expr(), Val: sqlDollar[4].union.expr()}
 		}
 	case 653:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3498
+		//line sql.y:3496
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 654:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3502
+		//line sql.y:3500
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 656:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3509
+		//line sql.y:3507
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 657:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3515
+		//line sql.y:3513
 		{
 			sqlVAL.union.val = sqlDollar[1].union.indirectElem()
 		}
 	case 658:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3519
+		//line sql.y:3517
 		{
 			sqlVAL.union.val = sqlDollar[1].union.indirectElem()
 		}
 	case 659:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3523
+		//line sql.y:3521
 		{
 			sqlVAL.union.val = IndexIndirection(sqlDollar[2].str)
 		}
 	case 660:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3527
+		//line sql.y:3525
 		{
 			sqlVAL.union.val = &ArrayIndirection{Begin: sqlDollar[2].union.expr()}
 		}
 	case 661:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3531
+		//line sql.y:3529
 		{
 			sqlVAL.union.val = &ArrayIndirection{Begin: sqlDollar[2].union.expr(), End: sqlDollar[4].union.expr()}
 		}
 	case 662:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3537
+		//line sql.y:3535
 		{
 			sqlVAL.union.val = NameIndirection(sqlDollar[2].str)
 		}
 	case 663:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3543
+		//line sql.y:3541
 		{
 			sqlVAL.union.val = qualifiedStar
 		}
 	case 664:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3549
+		//line sql.y:3547
 		{
 			sqlVAL.union.val = Indirection{sqlDollar[1].union.indirectElem()}
 		}
 	case 665:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3553
+		//line sql.y:3551
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.indirect(), sqlDollar[2].union.indirectElem())
 		}
 	case 666:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3558
+		//line sql.y:3556
 		{
 		}
 	case 667:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3559
+		//line sql.y:3557
 		{
 		}
 	case 669:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3568
+		//line sql.y:3566
 		{
 			sqlVAL.union.val = DefaultVal{}
 		}
 	case 670:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3574
+		//line sql.y:3572
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 671:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3578
+		//line sql.y:3576
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 672:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3587
+		//line sql.y:3585
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 674:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3595
+		//line sql.y:3593
 		{
 			sqlVAL.union.val = SelectExprs(nil)
 		}
 	case 675:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3601
+		//line sql.y:3599
 		{
 			sqlVAL.union.val = SelectExprs{sqlDollar[1].union.selExpr()}
 		}
 	case 676:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3605
+		//line sql.y:3603
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.selExprs(), sqlDollar[3].union.selExpr())
 		}
 	case 677:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3611
+		//line sql.y:3609
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr(), As: Name(sqlDollar[3].str)}
 		}
 	case 678:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3620
+		//line sql.y:3618
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr(), As: Name(sqlDollar[2].str)}
 		}
 	case 679:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3624
+		//line sql.y:3622
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr()}
 		}
 	case 680:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3628
+		//line sql.y:3626
 		{
 			sqlVAL.union.val = starSelectExpr()
 		}
 	case 681:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3636
+		//line sql.y:3634
 		{
 			sqlVAL.union.val = QualifiedNames{sqlDollar[1].union.qname()}
 		}
 	case 682:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3640
+		//line sql.y:3638
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.qnames(), sqlDollar[3].union.qname())
 		}
 	case 683:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3646
+		//line sql.y:3644
 		{
 			sqlVAL.union.val = QualifiedNames{sqlDollar[1].union.qname()}
 		}
 	case 684:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3650
+		//line sql.y:3648
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.qnames(), sqlDollar[3].union.qname())
 		}
 	case 685:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3661
+		//line sql.y:3659
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 686:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3665
+		//line sql.y:3663
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: sqlDollar[2].union.indirect()}
 		}
 	case 687:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3676
+		//line sql.y:3674
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 688:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3680
+		//line sql.y:3678
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: Indirection{sqlDollar[2].union.indirectElem()}}
 		}
 	case 689:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3684
+		//line sql.y:3682
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: Indirection{sqlDollar[2].union.indirectElem()}}
 		}
 	case 690:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3688
+		//line sql.y:3686
 		{
 			sqlVAL.union.val = &QualifiedName{Indirect: Indirection{unqualifiedStar}}
 		}
 	case 691:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3694
+		//line sql.y:3692
 		{
 			sqlVAL.union.val = []string{sqlDollar[1].str}
 		}
 	case 692:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3698
+		//line sql.y:3696
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.strs(), sqlDollar[3].str)
 		}
 	case 693:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3704
+		//line sql.y:3702
 		{
 			sqlVAL.union.val = sqlDollar[2].union.strs()
 		}
 	case 694:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3707
+		//line sql.y:3705
 		{
 		}
 	case 695:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3717
+		//line sql.y:3715
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 696:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3721
+		//line sql.y:3719
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: sqlDollar[2].union.indirect()}
 		}
 	case 697:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3728
+		//line sql.y:3726
 		{
 			sqlVAL.union.val = &IntVal{Val: sqlDollar[1].union.ival().Val, Str: sqlDollar[1].union.ival().Str}
 		}
 	case 698:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3732
+		//line sql.y:3730
 		{
 			sqlVAL.union.val = NumVal(sqlDollar[1].str)
 		}
 	case 699:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3736
+		//line sql.y:3734
 		{
 			sqlVAL.union.val = DString(sqlDollar[1].str)
 		}
 	case 700:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3740
+		//line sql.y:3738
 		{
 			sqlVAL.union.val = DBytes(sqlDollar[1].str)
 		}
 	case 701:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3743
+		//line sql.y:3741
 		{
 			unimplemented()
 		}
 	case 702:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3745
+		//line sql.y:3743
 		{
 			sqlVAL.union.val = &CastExpr{Expr: DString(sqlDollar[2].str), Type: sqlDollar[1].union.colType()}
 		}
 	case 703:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3749
+		//line sql.y:3747
 		{
 			sqlVAL.union.val = &CastExpr{Expr: DString(sqlDollar[2].str), Type: sqlDollar[1].union.colType()}
 		}
 	case 704:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3753
+		//line sql.y:3751
 		{
 			sqlVAL.union.val = &CastExpr{Expr: DString(sqlDollar[5].str), Type: sqlDollar[1].union.colType()}
 		}
 	case 705:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3757
+		//line sql.y:3755
 		{
 			sqlVAL.union.val = DBool(true)
 		}
 	case 706:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3761
+		//line sql.y:3759
 		{
 			sqlVAL.union.val = DBool(false)
 		}
 	case 707:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3765
+		//line sql.y:3763
 		{
 			sqlVAL.union.val = DNull
 		}
 	case 709:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3772
+		//line sql.y:3770
 		{
 			sqlVAL.union.val = sqlDollar[2].union.ival()
 		}
 	case 710:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3776
+		//line sql.y:3774
 		{
 			sqlVAL.union.val = IntVal{Val: -sqlDollar[2].union.ival().Val, Str: "-" + sqlDollar[2].union.ival().Str}
 		}
 	case 715:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3798
+		//line sql.y:3796
 		{
 			sqlVAL.str = ""
 		}

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -98,6 +98,12 @@ func (u *sqlSymUnion) stmt() Statement {
 func (u *sqlSymUnion) stmts() []Statement {
     return u.val.([]Statement)
 }
+func (u *sqlSymUnion) slct() *Select {
+    if selectStmt, ok := u.val.(*Select); ok {
+        return selectStmt
+    }
+    return nil
+}
 func (u *sqlSymUnion) selectStmt() SelectStatement {
     if selectStmt, ok := u.val.(SelectStatement); ok {
         return selectStmt
@@ -267,15 +273,15 @@ func (u *sqlSymUnion) idxElems() IndexElemList {
 %type <Statement> preparable_stmt
 %type <Statement> rename_stmt
 %type <Statement> revoke_stmt
-%type <SelectStatement> select_stmt
+%type <*Select> select_stmt
 %type <Statement> set_stmt
 %type <Statement> show_stmt
 %type <Statement> transaction_stmt
 %type <Statement> truncate_stmt
 %type <Statement> update_stmt
 
-%type <SelectStatement> select_no_parens select_with_parens select_clause
-%type <SelectStatement> simple_select values_clause
+%type <*Select> select_no_parens
+%type <SelectStatement> select_clause select_with_parens simple_select values_clause
 
 %type <empty> alter_column_default alter_using
 %type <Direction> opt_asc_desc
@@ -652,7 +658,7 @@ stmt:
 | revoke_stmt
 | select_stmt
   {
-    $$.val = $1.selectStmt()
+    $$.val = $1.slct()
   }
 | set_stmt
 | show_stmt
@@ -845,7 +851,7 @@ explain_stmt:
 explainable_stmt:
   select_stmt
   {
-    $$.val = $1.selectStmt()
+    $$.val = $1.slct()
   }
 | insert_stmt
 | update_stmt
@@ -1707,15 +1713,15 @@ insert_target:
 insert_rest:
   select_stmt
   {
-    $$.val = &Insert{Rows: $1.selectStmt()}
+    $$.val = &Insert{Rows: $1.slct()}
   }
 | '(' qualified_name_list ')' select_stmt
   {
-    $$.val = &Insert{Columns: $2.qnames(), Rows: $4.selectStmt()}
+    $$.val = &Insert{Columns: $2.qnames(), Rows: $4.slct()}
   }
 | DEFAULT VALUES
   {
-    $$.val = &Insert{}
+    $$.val = &Insert{Rows: &Select{}}
   }
 
 // TODO(andrei): If this is ever supported, `opt_conf_expr` needs to use something different
@@ -1823,15 +1829,18 @@ multiple_set_clause:
 select_stmt:
   select_no_parens %prec UMINUS
 | select_with_parens %prec UMINUS
+  {
+    $$.val = &Select{Select: $1.selectStmt()}
+  }
 
 select_with_parens:
   '(' select_no_parens ')'
   {
-    $$.val = &ParenSelect{Select: $2.selectStmt()}
+    $$.val = &ParenSelect{Select: $2.slct()}
   }
 | '(' select_with_parens ')'
   {
-    $$.val = &ParenSelect{Select: $2.selectStmt()}
+    $$.val = &ParenSelect{Select: &Select{Select: $2.selectStmt()}}
   }
 
 // This rule parses the equivalent of the standard's <query expression>. The
@@ -1845,39 +1854,28 @@ select_with_parens:
 //      - 2002-08-28 bjm
 select_no_parens:
   simple_select
+  {
+    $$.val = &Select{Select: $1.selectStmt()}
+  }
 | select_clause sort_clause
   {
-    $$.val = $1.selectStmt()
-    if s, ok := $$.val.(*SelectClause); ok {
-      s.OrderBy = $2.orderBy()
-    }
+    $$.val = &Select{Select: $1.selectStmt(), OrderBy: $2.orderBy()}
   }
 | select_clause opt_sort_clause select_limit
   {
-    $$.val = $1.selectStmt()
-    if s, ok := $$.val.(*SelectClause); ok {
-      s.OrderBy = $2.orderBy()
-      s.Limit = $3.limit()
-    }
+    $$.val = &Select{Select: $1.selectStmt(), OrderBy: $2.orderBy(), Limit: $3.limit()}
   }
 | with_clause select_clause
   {
-    $$.val = $2.selectStmt()
+    $$.val = &Select{Select: $2.selectStmt()}
   }
 | with_clause select_clause sort_clause
   {
-    $$.val = $2.selectStmt()
-    if s, ok := $$.val.(*SelectClause); ok {
-      s.OrderBy = $3.orderBy()
-    }
+    $$.val = &Select{Select: $2.selectStmt(), OrderBy: $3.orderBy()}
   }
 | with_clause select_clause opt_sort_clause select_limit
   {
-    $$.val = $2.selectStmt()
-    if s, ok := $$.val.(*SelectClause); ok {
-      s.OrderBy = $3.orderBy()
-      s.Limit = $4.limit()
-    }
+    $$.val = &Select{Select: $2.selectStmt(), OrderBy: $3.orderBy(), Limit: $4.limit()}
   }
 
 select_clause:
@@ -1945,8 +1943,8 @@ simple_select:
   {
     $$.val = &UnionClause{
       Type:  UnionOp,
-      Left:  $1.selectStmt(),
-      Right: $4.selectStmt(),
+      Left:  &Select{Select: $1.selectStmt()},
+      Right: &Select{Select: $4.selectStmt()},
       All:   $3.bool(),
     }
   }
@@ -1954,8 +1952,8 @@ simple_select:
   {
     $$.val = &UnionClause{
       Type:  IntersectOp,
-      Left:  $1.selectStmt(),
-      Right: $4.selectStmt(),
+      Left:  &Select{Select: $1.selectStmt()},
+      Right: &Select{Select: $4.selectStmt()},
       All:   $3.bool(),
     }
   }
@@ -1963,8 +1961,8 @@ simple_select:
   {
     $$.val = &UnionClause{
       Type:  ExceptOp,
-      Left:  $1.selectStmt(),
-      Right: $4.selectStmt(),
+      Left:  &Select{Select: $1.selectStmt()},
+      Right: &Select{Select: $4.selectStmt()},
       All:   $3.bool(),
     }
   }
@@ -1992,7 +1990,7 @@ common_table_expr:
 preparable_stmt:
   select_stmt
   {
-    $$.val = $1.selectStmt()
+    $$.val = $1.slct()
   }
 | insert_stmt
 | update_stmt

--- a/sql/parser/stmt.go
+++ b/sql/parser/stmt.go
@@ -184,10 +184,10 @@ func (*RollbackTransaction) StatementType() StatementType { return Ack }
 func (*RollbackTransaction) StatementTag() string { return "ROLLBACK" }
 
 // StatementType implements the Statement interface.
-func (*Select) StatementType() StatementType { return Rows }
+func (*SelectClause) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*Select) StatementTag() string { return "SELECT" }
+func (*SelectClause) StatementTag() string { return "SELECT" }
 
 // StatementType implements the Statement interface.
 func (*Set) StatementType() StatementType { return Ack }
@@ -262,13 +262,13 @@ func (n *Update) StatementType() StatementType { return n.Returning.StatementTyp
 func (*Update) StatementTag() string { return "UPDATE" }
 
 // StatementType implements the Statement interface.
-func (*Union) StatementType() StatementType { return Rows }
+func (*UnionClause) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*Union) StatementTag() string { return "UNION" }
+func (*UnionClause) StatementTag() string { return "UNION" }
 
 // StatementType implements the Statement interface.
-func (Values) StatementType() StatementType { return Rows }
+func (ValuesClause) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
-func (Values) StatementTag() string { return "VALUES" }
+func (ValuesClause) StatementTag() string { return "VALUES" }

--- a/sql/parser/stmt.go
+++ b/sql/parser/stmt.go
@@ -184,6 +184,12 @@ func (*RollbackTransaction) StatementType() StatementType { return Ack }
 func (*RollbackTransaction) StatementTag() string { return "ROLLBACK" }
 
 // StatementType implements the Statement interface.
+func (*Select) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*Select) StatementTag() string { return "SELECT" }
+
+// StatementType implements the Statement interface.
 func (*SelectClause) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.

--- a/sql/parser/union.go
+++ b/sql/parser/union.go
@@ -27,7 +27,7 @@ import "fmt"
 // UnionClause represents a UNION statement.
 type UnionClause struct {
 	Type        UnionType
-	Left, Right SelectStatement
+	Left, Right *Select
 	All         bool
 }
 

--- a/sql/parser/union.go
+++ b/sql/parser/union.go
@@ -24,8 +24,8 @@ package parser
 
 import "fmt"
 
-// Union represents a UNION statement.
-type Union struct {
+// UnionClause represents a UNION statement.
+type UnionClause struct {
 	Type        UnionType
 	Left, Right SelectStatement
 	All         bool
@@ -54,7 +54,7 @@ func (i UnionType) String() string {
 	return unionTypeName[i]
 }
 
-func (node *Union) String() string {
+func (node *UnionClause) String() string {
 	all := ""
 	if node.All {
 		all = " ALL"

--- a/sql/parser/values.go
+++ b/sql/parser/values.go
@@ -24,12 +24,12 @@ package parser
 
 import "strings"
 
-// Values represents a VALUES clause.
-type Values struct {
+// ValuesClause represents a VALUES clause.
+type ValuesClause struct {
 	Tuples []*Tuple
 }
 
-func (node *Values) String() string {
+func (node *ValuesClause) String() string {
 	strs := make([]string, 0, len(node.Tuples))
 	for _, n := range node.Tuples {
 		strs = append(strs, n.String())

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -500,7 +500,7 @@ func (stmt *ParenSelect) WalkStmt(v Visitor) Statement {
 }
 
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
-func (stmt *Select) CopyNode() *Select {
+func (stmt *SelectClause) CopyNode() *SelectClause {
 	stmtCopy := *stmt
 	stmtCopy.Exprs = SelectExprs(append([]SelectExpr(nil), stmt.Exprs...))
 	stmtCopy.From = TableExprs(append([]TableExpr(nil), stmt.From...))
@@ -526,7 +526,7 @@ func (stmt *Select) CopyNode() *Select {
 }
 
 // WalkStmt is part of the WalkableStmt interface.
-func (stmt *Select) WalkStmt(v Visitor) Statement {
+func (stmt *SelectClause) WalkStmt(v Visitor) Statement {
 	ret := stmt
 
 	for i, expr := range stmt.Exprs {
@@ -676,13 +676,13 @@ func (stmt *Update) WalkStmt(v Visitor) Statement {
 }
 
 // WalkStmt is part of the WalkableStmt interface.
-func (stmt *Values) WalkStmt(v Visitor) Statement {
+func (stmt *ValuesClause) WalkStmt(v Visitor) Statement {
 	ret := stmt
 	for i, tuple := range stmt.Tuples {
 		t, changed := WalkExpr(v, tuple)
 		if changed {
 			if ret == stmt {
-				ret = &Values{append([]*Tuple(nil), stmt.Tuples...)}
+				ret = &ValuesClause{append([]*Tuple(nil), stmt.Tuples...)}
 			}
 			ret.Tuples[i] = t.(*Tuple)
 		}
@@ -694,10 +694,10 @@ var _ WalkableStmt = &Delete{}
 var _ WalkableStmt = &Explain{}
 var _ WalkableStmt = &Insert{}
 var _ WalkableStmt = &ParenSelect{}
-var _ WalkableStmt = &Select{}
+var _ WalkableStmt = &SelectClause{}
 var _ WalkableStmt = &Set{}
 var _ WalkableStmt = &Update{}
-var _ WalkableStmt = &Values{}
+var _ WalkableStmt = &ValuesClause{}
 
 // WalkStmt walks the entire parsed stmt calling WalkExpr on each
 // expression, and replacing each expression with the one returned

--- a/sql/parser/walk_test.go
+++ b/sql/parser/walk_test.go
@@ -85,7 +85,7 @@ func TestFillArgs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		if s := q.(*SelectClause).Exprs[0].Expr.String(); d.expected != s {
+		if s := q.(*Select).Select.(*SelectClause).Exprs[0].Expr.String(); d.expected != s {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 		}
 	}

--- a/sql/parser/walk_test.go
+++ b/sql/parser/walk_test.go
@@ -85,7 +85,7 @@ func TestFillArgs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		if s := q.(*Select).Exprs[0].Expr.String(); d.expected != s {
+		if s := q.(*SelectClause).Exprs[0].Expr.String(); d.expected != s {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 		}
 	}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -134,8 +134,8 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, *r
 		return p.Revoke(n)
 	case *parser.RollbackTransaction:
 		return p.RollbackTransaction(n)
-	case *parser.Select:
-		return p.Select(n)
+	case *parser.SelectClause:
+		return p.SelectClause(n)
 	case *parser.Set:
 		return p.Set(n)
 	case *parser.SetTimeZone:
@@ -162,12 +162,12 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, *r
 		return p.ShowTables(n)
 	case *parser.Truncate:
 		return p.Truncate(n)
-	case *parser.Union:
-		return p.Union(n, autoCommit)
+	case *parser.UnionClause:
+		return p.UnionClause(n, autoCommit)
 	case *parser.Update:
 		return p.Update(n, autoCommit)
-	case *parser.Values:
-		return p.Values(n)
+	case *parser.ValuesClause:
+		return p.ValuesClause(n)
 	default:
 		return nil, roachpb.NewErrorf("unknown statement type: %T", stmt)
 	}
@@ -180,8 +180,8 @@ func (p *planner) prepare(stmt parser.Statement) (planNode, *roachpb.Error) {
 		return p.Delete(n, false)
 	case *parser.Insert:
 		return p.Insert(n, false)
-	case *parser.Select:
-		return p.Select(n)
+	case *parser.SelectClause:
+		return p.SelectClause(n)
 	case *parser.Show:
 		pNode, err := p.Show(n)
 		return pNode, roachpb.NewError(err)

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -134,6 +134,8 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, *r
 		return p.Revoke(n)
 	case *parser.RollbackTransaction:
 		return p.RollbackTransaction(n)
+	case *parser.Select:
+		return p.Select(n, autoCommit)
 	case *parser.SelectClause:
 		return p.SelectClause(n)
 	case *parser.Set:
@@ -180,6 +182,8 @@ func (p *planner) prepare(stmt parser.Statement) (planNode, *roachpb.Error) {
 		return p.Delete(n, false)
 	case *parser.Insert:
 		return p.Insert(n, false)
+	case *parser.Select:
+		return p.Select(n, false)
 	case *parser.SelectClause:
 		return p.SelectClause(n)
 	case *parser.Show:

--- a/sql/select.go
+++ b/sql/select.go
@@ -149,21 +149,21 @@ func (s *selectNode) SetLimitHint(numRows int64) {
 	s.table.node.SetLimitHint(numRows)
 }
 
-// Select selects rows from a single table. Select is the workhorse of the SQL
-// statements. In the slowest and most general case, select must perform full
-// table scans across multiple tables and sort and join the resulting rows on
-// arbitrary columns. Full table scans can be avoided when indexes can be used
-// to satisfy the where-clause.
+// SelectClause selects rows from a single table. Select is the workhorse of the
+// SQL statements. In the slowest and most general case, select must perform
+// full table scans across multiple tables and sort and join the resulting rows
+// on arbitrary columns. Full table scans can be avoided when indexes can be
+// used to satisfy the where-clause.
 //
 // Privileges: SELECT on table
 //   Notes: postgres requires SELECT. Also requires UPDATE on "FOR UPDATE".
 //          mysql requires SELECT.
-func (p *planner) Select(parsed *parser.Select) (planNode, *roachpb.Error) {
+func (p *planner) SelectClause(parsed *parser.SelectClause) (planNode, *roachpb.Error) {
 	node := &selectNode{planner: p}
 	return p.initSelect(node, parsed)
 }
 
-func (p *planner) initSelect(s *selectNode, parsed *parser.Select) (planNode, *roachpb.Error) {
+func (p *planner) initSelect(s *selectNode, parsed *parser.SelectClause) (planNode, *roachpb.Error) {
 	s.qvals = make(qvalMap)
 
 	if pErr := s.initFrom(p, parsed); pErr != nil {
@@ -253,7 +253,7 @@ func (p *planner) initSelect(s *selectNode, parsed *parser.Select) (planNode, *r
 }
 
 // Initializes the table node, given the parsed select expression
-func (s *selectNode) initFrom(p *planner, parsed *parser.Select) *roachpb.Error {
+func (s *selectNode) initFrom(p *planner, parsed *parser.SelectClause) *roachpb.Error {
 	from := parsed.From
 	var colAlias parser.NameList
 	switch len(from) {

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -30,7 +30,7 @@ import (
 // orderBy constructs a sortNode based on the ORDER BY clause. Construction of
 // the sortNode might adjust the number of render targets in the selectNode if
 // any ordering expressions are specified.
-func (p *planner) orderBy(n *parser.Select, s *selectNode) (*sortNode, *roachpb.Error) {
+func (p *planner) orderBy(n *parser.SelectClause, s *selectNode) (*sortNode, *roachpb.Error) {
 	if n.OrderBy == nil {
 		return nil, nil
 	}

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -145,6 +145,17 @@ SELECT a FROM t ORDER BY (((a)))
 4
 5
 
+query I
+(((SELECT a FROM t))) ORDER BY a DESC LIMIT 4
+----
+5
+4
+3
+2
+
+query error multiple ORDER BY clauses not allowed
+((SELECT a FROM t ORDER BY a)) ORDER BY a
+
 query error incompatible value types bool, int
 SELECT CASE a WHEN 1 THEN b ELSE c END as val FROM t ORDER BY val
 

--- a/sql/testdata/select
+++ b/sql/testdata/select
@@ -193,6 +193,9 @@ query IIII
 SELECT * FROM xyzw LIMIT (RANDOM() * 0.0)::int OFFSET (RANDOM() * 0.0)::int
 ----
 
+query error multiple LIMIT clauses not allowed
+((SELECT a FROM t LIMIT 1)) LIMIT 1
+
 query II
 SELECT * FROM xyzw@foo
 ----

--- a/sql/testdata/union
+++ b/sql/testdata/union
@@ -49,6 +49,19 @@ VALUES (1, 2), (1, 1), (1, 2), (2, 1), (2, 1) UNION VALUES (1, 3), (3, 4), (1, 1
 2 1
 3 4
 
+query I
+(VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)) ORDER BY 1 DESC LIMIT 2
+----
+3
+2
+
+# The ORDER BY and LIMIT apply to the UNION, not the last VALUES.
+query I
+VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC LIMIT 2
+----
+3
+2
+
 statement ok
 CREATE TABLE uniontest (
   k INT,
@@ -108,6 +121,19 @@ SELECT v FROM uniontest WHERE k = 1 EXCEPT ALL SELECT v FROM uniontest WHERE k =
 2
 2
 
+query I
+(SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 2) ORDER BY 1 DESC LIMIT 2
+----
+3
+2
+
+# The ORDER BY and LIMIT apply to the UNION, not the last SELECT.
+query I
+SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 2 ORDER BY 1 DESC LIMIT 2
+----
+3
+2
+
 query ITT rowsort
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
@@ -132,3 +158,6 @@ SELECT 1 INTERSECT SELECT '3'
 
 query error EXCEPT types int and string cannot be matched
 SELECT 1 EXCEPT SELECT '3'
+
+query error column z does not exist
+SELECT 1 UNION SELECT 3 ORDER BY z

--- a/sql/testdata/values
+++ b/sql/testdata/values
@@ -7,3 +7,13 @@ column1 column2 column3
 
 query error VALUES lists must all be the same length
 VALUES (1), (2, 3)
+
+query I
+VALUES (1), (1), (2), (3) ORDER BY 1 DESC LIMIT 3
+----
+3
+2
+1
+
+query error column z does not exist
+VALUES (1), (1), (2), (3) ORDER BY z

--- a/sql/union.go
+++ b/sql/union.go
@@ -21,8 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 )
 
-// Union constructs a planNode from a UNION/INTERSECT/EXCEPT expression.
-func (p *planner) Union(n *parser.Union, autoCommit bool) (planNode, *roachpb.Error) {
+// UnionClause constructs a planNode from a UNION/INTERSECT/EXCEPT expression.
+func (p *planner) UnionClause(n *parser.UnionClause, autoCommit bool) (planNode, *roachpb.Error) {
 	var emitAll = false
 	var emit unionNodeEmit
 	switch n.Type {

--- a/sql/union.go
+++ b/sql/union.go
@@ -86,11 +86,6 @@ func (p *planner) UnionClause(n *parser.UnionClause, autoCommit bool) (planNode,
 		emit:      emit,
 		scratch:   make([]byte, 0),
 	}
-
-	// TODO(dan): Support ORDER BY. It's currently blocked on
-	// https://github.com/cockroachdb/cockroach/issues/4734. Once that's done, it
-	// should be possible to read all the values from node, put them in a
-	// valuesNode, and sort it.
 	return node, nil
 }
 

--- a/sql/update.go
+++ b/sql/update.go
@@ -133,7 +133,7 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 	tracing.AnnotateTrace()
 
 	// Query the rows that need updating.
-	rows, pErr := p.Select(&parser.Select{
+	rows, pErr := p.SelectClause(&parser.SelectClause{
 		Exprs: targets,
 		From:  parser.TableExprs{n.Table},
 		Where: n.Where,

--- a/sql/values.go
+++ b/sql/values.go
@@ -25,8 +25,8 @@ import (
 	"github.com/cockroachdb/cockroach/util/encoding"
 )
 
-// Values constructs a valuesNode from a VALUES expression.
-func (p *planner) Values(n *parser.Values) (planNode, *roachpb.Error) {
+// ValuesClause constructs a valuesNode from a VALUES expression.
+func (p *planner) ValuesClause(n *parser.ValuesClause) (planNode, *roachpb.Error) {
 	v := &valuesNode{
 		rows: make([]parser.DTuple, 0, len(n.Tuples)),
 	}
@@ -38,7 +38,7 @@ func (p *planner) Values(n *parser.Values) (planNode, *roachpb.Error) {
 			return nil, roachpb.NewUErrorf("VALUES lists must all be the same length, %d for %d", a, e)
 		}
 
-		// We must not modify the Values node in-place (or the changes will leak if we retry this
+		// We must not modify the ValuesClause node in-place (or the changes will leak if we retry this
 		// transaction).
 		tuple := parser.Tuple{Exprs: parser.Exprs(append([]parser.Expr(nil), tupleOrig.Exprs...))}
 

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -48,15 +48,15 @@ func TestValues(t *testing.T) {
 		return []parser.DTuple{datums}
 	}
 
-	makeValues := func(tuples ...*parser.Tuple) *parser.Values {
-		return &parser.Values{Tuples: tuples}
+	makeValues := func(tuples ...*parser.Tuple) *parser.ValuesClause {
+		return &parser.ValuesClause{Tuples: tuples}
 	}
 	makeTuple := func(exprs ...parser.Expr) *parser.Tuple {
 		return &parser.Tuple{Exprs: exprs}
 	}
 
 	testCases := []struct {
-		stmt *parser.Values
+		stmt *parser.ValuesClause
 		rows []parser.DTuple
 		ok   bool
 	}{
@@ -104,7 +104,7 @@ func TestValues(t *testing.T) {
 					pErr = roachpb.NewErrorf("%v", r)
 				}
 			}()
-			return p.Values(tc.stmt)
+			return p.ValuesClause(tc.stmt)
 		}()
 		if pErr == nil != tc.ok {
 			t.Errorf("%d: error_expected=%t, but got error %v", i, tc.ok, pErr)


### PR DESCRIPTION
We were previously accepting these parses, but losing the sort and limit data. This commit adds a generalized sortNode and limitNode for any select-like, but keeps the optimization of passing them down to Select itself.

Closes #4734.
Closes #2691.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4862)

<!-- Reviewable:end -->
