### PR TITLE
sql/parser: Use new Decimal.Cbrt function for sql builtin

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -742,10 +742,16 @@ var builtins = map[string][]builtin{
 		}),
 	},
 
-	// TODO(nvanbenschoten) Add native support for decimal.
-	"cbrt": floatOrDecimalBuiltin1(func(x float64) (Datum, error) {
-		return DFloat(math.Cbrt(x)), nil
-	}),
+	"cbrt": {
+		floatBuiltin1(func(x float64) (Datum, error) {
+			return DFloat(math.Cbrt(x)), nil
+		}),
+		decimalBuiltin1(func(x *inf.Dec) (Datum, error) {
+			dd := &DDecimal{}
+			decimal.Cbrt(&dd.Dec, x, decimal.Precision)
+			return dd, nil
+		}),
+	},
 
 	"ceil":    ceilImpl,
 	"ceiling": ceilImpl,

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -436,7 +436,7 @@ SELECT atan2(-10.0, 5.0), atan2(10.0, 5.0)
 query RRR
 SELECT cbrt(-1.0), cbrt(27.0), cbrt(19.3::decimal)
 ----
--1 3 2.682372592629673
+-1 3 2.6823725926296730
 
 query RRRRR
 SELECT ceil(-0.5), ceil(0.5), ceiling(0.5), ceil(0.1::decimal), ceiling(-0.9::decimal)

--- a/util/decimal/decimal.go
+++ b/util/decimal/decimal.go
@@ -154,6 +154,92 @@ func Sqrt(z, x *inf.Dec, s inf.Scale) *inf.Dec {
 	return z.Round(z, s, inf.RoundHalfUp)
 }
 
+// Cbrt calculates the cube root of x to the specified scale
+// and stores the result in z, which is also the return value.
+//
+// The cube root calculation is implemented using Newton-Raphson
+// method. We start with an initial estimate for cbrt(d), and
+// then iterate:
+//     x_{n+1} = 1/3 * ( 2 * x_n + (d / x_n / x_n) ).
+func Cbrt(z, x *inf.Dec, s inf.Scale) *inf.Dec {
+	switch z {
+	case nil:
+		z = new(inf.Dec)
+	case x:
+		x = new(inf.Dec)
+		x.Set(z)
+	}
+
+	// Validate the sign of x.
+	switch x.Sign() {
+	case -1:
+		// Make sure args aren't mutated and return -Cbrt(-x).
+		x = new(inf.Dec).Neg(x)
+		z = Cbrt(z, x, s)
+		return z.Neg(z)
+	case 0:
+		return z.SetUnscaled(0).SetScale(0)
+	}
+
+	z.Set(x)
+	exp8 := 0
+
+	// Follow Ken Turkowski paper:
+	// https://people.freebsd.org/~lstewart/references/apple_tr_kt32_cuberoot.pdf
+	//
+	// Computing the cube root of any number is reduced to computing
+	// the cube root of a number between 0.125 and 1. After the next loops,
+	// x = z * 8^exp8 will hold.
+	for z.Cmp(decimalOneEighth) < 0 {
+		exp8--
+		z.Mul(z, decimalEight)
+	}
+
+	for z.Cmp(decimalOne) > 0 {
+		exp8++
+		z.Mul(z, decimalOneEighth)
+	}
+
+	// Use this polynomial to approximate the cube root between 0.125 and 1.
+	// z = (-0.46946116 * z + 1.072302) * z + 0.3812513
+	// It will serve as an initial estimate, hence the precision of this
+	// computation may only impact performance, not correctness.
+	z0 := new(inf.Dec).Set(z)
+	z.Mul(z, decimalCbrtC1)
+	z.Add(z, decimalCbrtC2)
+	z.Mul(z, z0)
+	z.Add(z, decimalCbrtC3)
+
+	for ; exp8 < 0; exp8++ {
+		z.Mul(z, decimalHalf)
+	}
+
+	for ; exp8 > 0; exp8-- {
+		z.Mul(z, decimalTwo)
+	}
+
+	z0.Set(z)
+
+	// Loop until convergence.
+	for loop := newLoop("cbrt", x, s, 1); ; {
+		// z = (2.0 * z0 +  x / (z0 * z0) ) / 3.0;
+		z.Set(z0)
+		z.Mul(z, z0)
+		z.QuoRound(x, z, s+2, inf.RoundHalfUp)
+		z.Add(z, z0)
+		z.Add(z, z0)
+		z.QuoRound(z, decimalThree, s+2, inf.RoundHalfUp)
+
+		if loop.done(z) {
+			break
+		}
+		z0.Set(z)
+	}
+
+	// Round to the desired scale.
+	return z.Round(z, s, inf.RoundHalfUp)
+}
+
 // LogN computes the log of x with base n to the specified scale and
 // stores the result in z, which is also the return value. The function
 // will panic if x is a negative number or if n is a negative number.
@@ -238,92 +324,6 @@ func Log(z *inf.Dec, x *inf.Dec, s inf.Scale) *inf.Dec {
 		z.Neg(z)
 	}
 	z.Add(z, exp)
-
-	// Round to the desired scale.
-	return z.Round(z, s, inf.RoundHalfUp)
-}
-
-// Cbrt calculates the cube root of x to the specified scale
-// and stores the result in z, which is also the return value.
-//
-// The cube root calculation is implemented using Newton-Raphson
-// method. We start with an initial estimate for cbrt(d), and
-// then iterate:
-//     x_{n+1} = 1/3 * ( 2 * x_n + (d / x_n / x_n) ).
-func Cbrt(z, x *inf.Dec, s inf.Scale) *inf.Dec {
-	switch z {
-	case nil:
-		z = new(inf.Dec)
-	case x:
-		x = new(inf.Dec)
-		x.Set(z)
-	}
-
-	// Validate the sign of x.
-	switch x.Sign() {
-	case -1:
-		// Make sure args aren't mutated and return -Cbrt(-x).
-		x = new(inf.Dec).Neg(x)
-		z = Cbrt(z, x, s)
-		return z.Neg(z)
-	case 0:
-		return z.SetUnscaled(0).SetScale(0)
-	}
-
-	z.Set(x)
-	exp8 := 0
-
-	// Follow Ken Turkowski paper:
-	// https://people.freebsd.org/~lstewart/references/apple_tr_kt32_cuberoot.pdf
-	//
-	// Computing the cube root of any number is reduced to computing
-	// the cube root of a number between 0.125 and 1. After the next loops,
-	// x = z * 8^exp8 will hold.
-	for z.Cmp(decimalOneEighth) < 0 {
-		exp8--
-		z.Mul(z, decimalEight)
-	}
-
-	for z.Cmp(decimalOne) > 0 {
-		exp8++
-		z.Mul(z, decimalOneEighth)
-	}
-
-	// Use this polynomial to approximate the cube root between 0.125 and 1.
-	// z = (-0.46946116 * z + 1.072302) * z + 0.3812513
-	// It will serve as an initial estimate, hence the precision of this
-	// computation may only impact performance, not correctness.
-	z0 := new(inf.Dec).Set(z)
-	z.Mul(z, decimalCbrtC1)
-	z.Add(z, decimalCbrtC2)
-	z.Mul(z, z0)
-	z.Add(z, decimalCbrtC3)
-
-	for ; exp8 < 0; exp8++ {
-		z.Mul(z, decimalHalf)
-	}
-
-	for ; exp8 > 0; exp8-- {
-		z.Mul(z, decimalTwo)
-	}
-
-	z0.Set(z)
-
-	// Loop until convergence.
-	for loop := newLoop("cbrt", x, s, 1); ; {
-		// z = (2.0 * z0 +  x / (z0 * z0) ) / 3.0;
-		z.Set(z0)
-		z.Mul(z, z0)
-		z.QuoRound(x, z, s+2, inf.RoundHalfUp)
-		z.Add(z, z0)
-		z.Add(z, z0)
-		z.QuoRound(z, decimalThree, s+2, inf.RoundHalfUp)
-
-		if loop.done(z) {
-			break
-		}
-		z0.Set(z)
-	}
 
 	// Round to the desired scale.
 	return z.Round(z, s, inf.RoundHalfUp)

--- a/util/decimal/decimal_test.go
+++ b/util/decimal/decimal_test.go
@@ -230,6 +230,57 @@ func BenchmarkDecimalSqrt(b *testing.B) {
 	}
 }
 
+func TestDecimalCbrt(t *testing.T) {
+	tests := []decimalOneArgTestCase{
+		{"-567", "-8.2767725291433620"},
+		{"-1", "-1.0"},
+		{"-0.001", "-0.1"},
+		{".00000001", "0.0021544346900319"},
+		{".001234567898217312", "0.1072765982021206"},
+		{".001", "0.1"},
+		{".123", "0.4973189833268590"},
+		{"0", "0"},
+		{"1", "1"},
+		{"2", "1.2599210498948732"},
+		{"1000", "10.0"},
+		{"1234567898765432112.2763812", "1072765.9821799668569064"},
+	}
+	testDecimalSingleArgFunc(t, Cbrt, 16, tests)
+}
+
+func TestDecimalCbrtDoubleScale(t *testing.T) {
+	tests := []decimalOneArgTestCase{
+		{"-567", "-8.27677252914336200839737332507556"},
+		{"-1", "-1.0"},
+		{"-0.001", "-0.1"},
+		{".00000001", "0.00215443469003188372175929356652"},
+		{".001234567898217312", "0.10727659820212056117037629887220"},
+		{".001", "0.1"},
+		{".123", "0.49731898332685904156500833828550"},
+		{"0", "0"},
+		{"1", "1"},
+		{"2", "1.25992104989487316476721060727823"},
+		{"1000", "10.0"},
+		{"1234567898765432112.2763812", "1072765.98217996685690644770246374397146"},
+	}
+	testDecimalSingleArgFunc(t, Cbrt, 32, tests)
+}
+
+func BenchmarkDecimalCbrt(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+
+	vals := make([]*inf.Dec, 10000)
+	for i := range vals {
+		vals[i] = NewDecFromFloat(rng.Float64())
+	}
+
+	z := new(inf.Dec)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Cbrt(z, vals[i%len(vals)], 16)
+	}
+}
+
 func TestDecimalLog(t *testing.T) {
 	tests := []decimalOneArgTestCase{
 		{".001234567898217312", "-6.6970342501104617"},
@@ -322,56 +373,5 @@ func BenchmarkDecimalLog(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Log(z, vals[i%len(vals)], 16)
-	}
-}
-
-func TestDecimalCbrt(t *testing.T) {
-	tests := []decimalOneArgTestCase{
-		{"-567", "-8.2767725291433620"},
-		{"-1", "-1.0"},
-		{"-0.001", "-0.1"},
-		{".00000001", "0.0021544346900319"},
-		{".001234567898217312", "0.1072765982021206"},
-		{".001", "0.1"},
-		{".123", "0.4973189833268590"},
-		{"0", "0"},
-		{"1", "1"},
-		{"2", "1.2599210498948732"},
-		{"1000", "10.0"},
-		{"1234567898765432112.2763812", "1072765.9821799668569064"},
-	}
-	testDecimalSingleArgFunc(t, Cbrt, 16, tests)
-}
-
-func TestDecimalCbrtDoubleScale(t *testing.T) {
-	tests := []decimalOneArgTestCase{
-		{"-567", "-8.27677252914336200839737332507556"},
-		{"-1", "-1.0"},
-		{"-0.001", "-0.1"},
-		{".00000001", "0.00215443469003188372175929356652"},
-		{".001234567898217312", "0.10727659820212056117037629887220"},
-		{".001", "0.1"},
-		{".123", "0.49731898332685904156500833828550"},
-		{"0", "0"},
-		{"1", "1"},
-		{"2", "1.25992104989487316476721060727823"},
-		{"1000", "10.0"},
-		{"1234567898765432112.2763812", "1072765.98217996685690644770246374397146"},
-	}
-	testDecimalSingleArgFunc(t, Cbrt, 32, tests)
-}
-
-func BenchmarkDecimalCbrt(b *testing.B) {
-	rng, _ := randutil.NewPseudoRand()
-
-	vals := make([]*inf.Dec, 10000)
-	for i := range vals {
-		vals[i] = NewDecFromFloat(rng.Float64())
-	}
-
-	z := new(inf.Dec)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		Cbrt(z, vals[i%len(vals)], 16)
 	}
 }


### PR DESCRIPTION
Now that we have a native arbitrary-precision decimal cube root
routine thanks to #4776, we can use it for the sql builtin `cbrt`
function. This change uses the new function in `cbrt` so that we
dont need to compute through float64s, and also moves the `Cbrt`
functions up in the `decimal.go` file so they are next to `Sqrt`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4863)

<!-- Reviewable:end -->
