### PR TITLE
Fix docker image cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,9 @@ install:
 # eg: to statically build the sql tests, run:
 #   make testbuild PKG=./sql STATIC=1
 .PHONY: testbuild
-testbuild: TESTS := $(shell $(GO) list -tags '$(TAGS)' $(PKG))
 testbuild: GOFLAGS += -c
 testbuild:
-	for p in $(TESTS); do \
+	for p in $(shell $(GO) list -tags '$(TAGS)' $(PKG)); do \
 	  NAME=$$(basename "$$p"); \
 	  OUT="$$NAME.test"; \
 	  DIR=$$($(GO) list -f {{.Dir}} -tags '$(TAGS)' $$p); \
@@ -90,13 +89,12 @@ testbuild:
 # Build all tests into DIR and strips each.
 # DIR is required.
 .PHONY: testbuildall
-testbuildall: TESTS := $(shell $(GO) list $(PKG))
 testbuildall: GOFLAGS += -c
 testbuildall:
 ifndef DIR
 	$(error DIR is undefined)
 endif
-	for p in $(TESTS); do \
+	for p in $(shell $(GO) list $(PKG)); do \
 	  NAME=$$(basename "$$p"); \
 	  PKGDIR=$$($(GO) list -f {{.ImportPath}} $$p); \
 		OUTPUT_FILE="$(DIR)/$${PKGDIR}/$${NAME}.test"; \

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -15,23 +15,30 @@ function fetch_docker() {
   local tag="${3}"
   local name="${user}/${repo}"
   local ref="${name}:${tag}"
-  if ! docker images --format {{.Repository}}:{{.Tag}} | grep -q "${ref}"; then
+  # TODO(tamird): uncomment when CircleCI supports `docker images --format`
+  #
+  # if ! docker images --format {{.Repository}}:{{.Tag}} | grep -q "${ref}"; then
     # If we have a saved image, load it.
     imgcache="${builder_dir}/${user}.${repo}.tar"
     if [[ -e "${imgcache}" ]]; then
       time docker load -i "${imgcache}"
     fi
 
+    # TODO(tamird): uncomment when CircleCI supports `docker images --format`
+    #
     # If we still don't have the tag we want: pull it and save it.
-    if ! docker images --format {{.Repository}}:{{.Tag}} | grep -q "${ref}"; then
+    # if ! docker images --format {{.Repository}}:{{.Tag}} | grep -q "${ref}"; then
       time docker pull "${ref}"
       time docker save -o "${imgcache}" "${ref}"
-    fi
-  fi
+    # fi
+  # fi
 
-  if ! docker images --format {{.Repository}}:{{.Tag}} | grep -q "${name}:latest"; then
+
+  # TODO(tamird): uncomment when CircleCI supports `docker images --format`
+  #
+  # if ! docker images --format {{.Repository}}:{{.Tag}} | grep -q "${name}:latest"; then
     docker tag "${ref}" "${name}:latest"
-  fi
+  # fi
 }
 
 # This is mildly tricky: This script runs itself recursively. The


### PR DESCRIPTION
Extracted from #4860 so that the builder image can be at least partially cached in that PR and doesn't time out on pull.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4864)

<!-- Reviewable:end -->
