### PR TITLE
storage: HeapSort CommandQueue overlaps to permit early sort termination

### DIFF
--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -52,6 +52,7 @@ type CommandQueue struct {
 	cache     *cache.IntervalCache
 	idAlloc   int64
 	wRg, rwRg interval.RangeGroup // avoids allocating in GetWait.
+	oHeap     overlapHeap         // avoids allocating in GetWait.
 }
 
 type cmd struct {
@@ -160,10 +161,9 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 		//                |      |    |            |           |
 		// cmd 5 [W]:   ====================     ====================
 		//
-		overlapHeap := overlapHeap(overlaps)
-		heap.Init(&overlapHeap)
-		for enclosed := false; overlapHeap.Len() > 0 && !enclosed; {
-			o := heap.Pop(&overlapHeap).(cache.Overlap)
+		cq.oHeap.Init(overlaps)
+		for enclosed := false; cq.oHeap.Len() > 0 && !enclosed; {
+			o := cq.oHeap.PopOverlap()
 			keyRange, cmd := o.Key.Range, o.Value.(*cmd)
 			if cmd.readOnly {
 				// If the current overlap is a read (meaning we're a write because other reads will
@@ -223,6 +223,9 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 			}
 		}
 
+		// Clear heap to avoid leaking anything it is currently storing.
+		cq.oHeap.Clear()
+
 		// Clear the RangeGroups so that they can be used again. This is an alternative
 		// to using local variables that must be allocated in every iteration.
 		cq.wRg.Clear()
@@ -256,14 +259,31 @@ func (o overlapHeap) Less(i, j int) bool {
 func (o overlapHeap) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
 
 func (o *overlapHeap) Push(x interface{}) {
-	*o = append(*o, x.(cache.Overlap))
+	panic("unimplemented")
 }
 
 func (o *overlapHeap) Pop() interface{} {
 	n := len(*o) - 1
-	x := (*o)[n]
-	*o = (*o)[0:n]
+	// Returning a pointer to avoid an allocation when storing the cache.Overlap in an interface{}.
+	// A *cache.Overlap stored in an interface{} won't allocate, but the value pointed to may
+	// change if the heap is later modified, so the pointer should be dereferenced immediately.
+	x := &(*o)[n]
+	*o = (*o)[:n]
 	return x
+}
+
+func (o *overlapHeap) Init(overlaps []cache.Overlap) {
+	*o = overlaps
+	heap.Init(o)
+}
+
+func (o *overlapHeap) Clear() {
+	*o = nil
+}
+
+func (o *overlapHeap) PopOverlap() cache.Overlap {
+	x := heap.Pop(o)
+	return *x.(*cache.Overlap)
 }
 
 // Add adds commands to the queue which affect the specified key ranges. Ranges


### PR DESCRIPTION
We previously introduced an optimization where we could cut dependency
searching in `CommandQueue.GetWait` short once the established
dependencies fully enclosed the new command. This opened an opportunity
to avoid sorting the entire overlapping command slice and instead
sorting on demand using a Heap. As @bdarnell mentioned:

> "You don't need to know the top K in advance or do any chunking; just
> make the whole overlaps array into a heap (O(n)), then peel off one
> element at a time (O(log(n))). If you do need the entire array then
> it's the same O(n*log(n)) of the Sort() call, although with a somewhat
> higher constant factor."

This PR makes this proposed change and hopes to serve as a discussion
about its performance impacts.
#### `GetWait` Dependency Calculation Stats:

The following metrics were gathered by instrumenting `GetWait` with
`go-metric` and hitting a single node with a photos example app.
This was meant to be a representative example of semi-contentious load.
The metrics gathered were:
- `pre overlap`: the number of overlapping commands
- `post overlap`: the number of commands left in the heap after
  calculating dependencies. These are the commands that we avoided
  sorting
- `percent bailed`: the percent of commands that we avoided sorting by
  using an online heapsort
##### 50 users:

```
percent bailed.50-percentile: 67,
percent bailed.75-percentile: 76,
percent bailed.95-percentile: 89,
percent bailed.99-percentile: 98,
percent bailed.999-percentile: 99,
percent bailed.count: 70215,
percent bailed.max: 99,
percent bailed.mean: 49.1632080078125,
percent bailed.min: 0,
percent bailed.std-dev: 34.15071502588194,
post overlap length.50-percentile: 2,
post overlap length.75-percentile: 4,
post overlap length.95-percentile: 10,
post overlap length.99-percentile: 60,
post overlap length.999-percentile: 83,
post overlap length.count: 70215,
post overlap length.max: 96,
post overlap length.mean: 3.9793701171875,
post overlap length.min: 0,
post overlap length.std-dev: 9.756680363352212,
pre overlap length.50-percentile: 3,
pre overlap length.75-percentile: 5,
pre overlap length.95-percentile: 33,
pre overlap length.99-percentile: 69,
pre overlap length.999-percentile: 91,
pre overlap length.count: 70215,
pre overlap length.max: 97,
pre overlap length.mean: 6.13134765625,
pre overlap length.min: 1,
pre overlap length.std-dev: 12.64766621491185
```
##### 1000 users:

```
percent bailed.50-percentile: 80,
percent bailed.75-percentile: 91,
percent bailed.95-percentile: 99,
percent bailed.99-percentile: 100,
percent bailed.999-percentile: 100,
percent bailed.count: 19316,
percent bailed.max: 100,
percent bailed.mean: 68.78369140625,
percent bailed.min: 0,
percent bailed.std-dev: 33.37719207522773,
post overlap length.50-percentile: 4,
post overlap length.75-percentile: 10,
post overlap length.95-percentile: 174,
post overlap length.99-percentile: 1063.0699999999997,
post overlap length.999-percentile: 1482.4209999999994,
post overlap length.count: 19316,
post overlap length.max: 1496,
post overlap length.mean: 43.474609375,
post overlap length.min: 0,
post overlap length.std-dev: 161.09362296868096,
pre overlap length.50-percentile: 6,
pre overlap length.75-percentile: 11,
pre overlap length.95-percentile: 175,
pre overlap length.99-percentile: 1051,
pre overlap length.999-percentile: 1473.6139999999996,
pre overlap length.count: 19316,
pre overlap length.max: 1497,
pre overlap length.mean: 44.2047119140625,
pre overlap length.min: 1,
pre overlap length.std-dev: 157.83892248564868
```
#### Heapsort vs. Quicksort Performance:

Benchmarking the old and new sorting algorithms independently. Notice
that a major issue with heapsort is that `heap.Pop` allocates, so the
number of allocations is linear with respect to the number of
dependencies we search. Also notice that it is roughly twice as slow to
sort the same size slice, which coincidentally lines with the fact that
from the above stats, it looks like we avoid sorting about half of the
elements.
##### 97 elements (max overlaps from above):

```
BenchmarkQsort-4     1000000          1087 ns/op          32 B/op          1 allocs/op
BenchmarkHeap-4      1000000          1619 ns/op          80 B/op          7 allocs/op
```
##### 6 elements (average overlaps from above):

```
BenchmarkQsort-4      200000          9037 ns/op          32 B/op          1 allocs/op
BenchmarkHeap-4       100000         16547 ns/op         816 B/op         98 allocs/op
```
##### 1497 elements (max overlaps from 1000 users above):

```
BenchmarkQsort-4       10000        178428 ns/op          32 B/op          1 allocs/op
BenchmarkHeap-4         5000        342415 ns/op       12016 B/op       1498 allocs/op
```
##### 6 elements, only pop 2 for heapsort:

```
BenchmarkQsort-4     1000000          1045 ns/op          32 B/op          1 allocs/op
BenchmarkHeap-4      1000000          1284 ns/op          48 B/op          3 allocs/op
```
##### 44 elements, only pop 15 for heapsort:

```
BenchmarkQsort-4      300000          4255 ns/op          32 B/op          1 allocs/op
BenchmarkHeap-4       300000          4619 ns/op         160 B/op         16 allocs/op
```
#### SQL Benchmarks:

```
name                          old time/op    new time/op    delta
Bank_Cockroach-2                 421µs ± 2%     424µs ± 1%    ~           (p=0.089 n=10+10)
Select1_Cockroach-2             60.0µs ± 1%    60.4µs ± 1%    ~           (p=0.052 n=10+10)
Select2_Cockroach-2             1.03ms ± 2%    1.02ms ± 1%    ~           (p=0.436 n=10+10)
Insert1_Cockroach-2              500µs ± 1%     500µs ± 1%    ~           (p=0.796 n=10+10)
Insert10_Cockroach-2             887µs ± 1%     886µs ± 1%    ~            (p=0.447 n=10+9)
Insert100_Cockroach-2           4.51ms ± 1%    4.48ms ± 1%  -0.60%        (p=0.023 n=10+10)
Insert1000_Cockroach-2          43.7ms ± 1%    43.4ms ± 1%    ~           (p=0.052 n=10+10)
Update1_Cockroach-2              757µs ± 2%     752µs ± 1%    ~            (p=0.122 n=8+10)
Update10_Cockroach-2            1.40ms ± 1%    1.40ms ± 2%    ~            (p=0.905 n=9+10)
Update100_Cockroach-2           7.54ms ± 3%    7.51ms ± 2%    ~           (p=0.579 n=10+10)
Update1000_Cockroach-2          66.8ms ± 1%    66.9ms ± 3%    ~            (p=0.661 n=9+10)
Delete1_Cockroach-2              844µs ± 2%     842µs ± 2%    ~           (p=0.739 n=10+10)
Delete10_Cockroach-2            2.62ms ± 5%    2.59ms ± 4%    ~           (p=0.190 n=10+10)
Delete100_Cockroach-2           21.1ms ± 1%    21.2ms ± 2%    ~            (p=0.497 n=10+9)
Delete1000_Cockroach-2           222ms ± 2%     223ms ± 2%    ~           (p=0.796 n=10+10)
Scan1_Cockroach-2                268µs ± 1%     268µs ± 1%    ~            (p=0.762 n=8+10)
Scan10_Cockroach-2               315µs ± 1%     318µs ± 2%    ~           (p=0.063 n=10+10)
Scan100_Cockroach-2              666µs ± 1%     668µs ± 1%    ~            (p=0.549 n=9+10)
Scan1000_Cockroach-2            3.97ms ± 1%    3.97ms ± 1%    ~           (p=0.853 n=10+10)
Scan10000_Cockroach-2           40.6ms ± 1%    40.9ms ± 1%  +0.87%        (p=0.015 n=10+10)
Scan1000Limit1_Cockroach-2       284µs ± 1%     285µs ± 1%    ~             (p=1.000 n=9+9)
Scan1000Limit10_Cockroach-2      331µs ± 2%     330µs ± 1%    ~           (p=0.684 n=10+10)
Scan1000Limit100_Cockroach-2     677µs ± 1%     686µs ± 3%    ~           (p=0.052 n=10+10)
PgbenchQuery_Cockroach-2        3.95ms ± 5%    3.96ms ± 3%    ~           (p=0.853 n=10+10)

name                          old alloc/op   new alloc/op   delta
Bank_Cockroach-2                68.6kB ± 0%    68.6kB ± 0%    ~            (p=0.858 n=10+9)
Select1_Cockroach-2             3.90kB ± 0%    3.91kB ± 0%  +0.11%        (p=0.016 n=10+10)
Select2_Cockroach-2             80.8kB ± 0%    80.8kB ± 0%    ~            (p=0.371 n=8+10)
Insert1_Cockroach-2             23.1kB ± 0%    23.1kB ± 0%    ~           (p=0.868 n=10+10)
Insert10_Cockroach-2            67.6kB ± 0%    67.5kB ± 0%    ~            (p=0.128 n=9+10)
Insert100_Cockroach-2            512kB ± 0%     512kB ± 0%    ~           (p=1.000 n=10+10)
Insert1000_Cockroach-2          4.61MB ± 1%    4.59MB ± 1%    ~           (p=0.436 n=10+10)
Update1_Cockroach-2             37.0kB ± 0%    37.0kB ± 0%    ~             (p=0.713 n=9+9)
Update10_Cockroach-2             101kB ± 0%     101kB ± 0%    ~            (p=0.633 n=8+10)
Update100_Cockroach-2            712kB ± 0%     712kB ± 0%    ~             (p=0.743 n=9+8)
Update1000_Cockroach-2          6.21MB ± 1%    6.18MB ± 1%    ~            (p=0.156 n=10+9)
Delete1_Cockroach-2             36.1kB ± 0%    36.2kB ± 0%    ~            (p=0.180 n=8+10)
Delete10_Cockroach-2             110kB ± 0%     110kB ± 0%    ~             (p=0.352 n=9+9)
Delete100_Cockroach-2            824kB ± 0%     825kB ± 0%    ~            (p=0.356 n=9+10)
Delete1000_Cockroach-2          7.44MB ± 0%    7.47MB ± 1%    ~            (p=0.237 n=8+10)
Scan1_Cockroach-2               13.3kB ± 0%    13.3kB ± 0%    ~             (p=0.199 n=9+9)
Scan10_Cockroach-2              17.2kB ± 0%    17.2kB ± 0%    ~           (p=0.810 n=10+10)
Scan100_Cockroach-2             49.4kB ± 0%    49.5kB ± 0%    ~            (p=0.387 n=9+10)
Scan1000_Cockroach-2             331kB ± 0%     331kB ± 0%  +0.01%          (p=0.012 n=9+8)
Scan10000_Cockroach-2           5.72MB ± 0%    5.72MB ± 0%    ~            (p=0.986 n=9+10)
Scan1000Limit1_Cockroach-2      14.1kB ± 0%    14.1kB ± 0%    ~           (p=0.593 n=10+10)
Scan1000Limit10_Cockroach-2     17.9kB ± 0%    18.0kB ± 0%  +0.12%          (p=0.021 n=9+8)
Scan1000Limit100_Cockroach-2    50.1kB ± 0%    50.1kB ± 0%    ~             (p=0.531 n=9+9)
PgbenchQuery_Cockroach-2         227kB ±10%     227kB ±10%    ~           (p=0.853 n=10+10)

name                          old allocs/op  new allocs/op  delta
Bank_Cockroach-2                 1.67k ± 0%     1.67k ± 0%    ~            (p=0.294 n=8+10)
Select1_Cockroach-2               97.0 ± 0%      97.0 ± 0%    ~     (all samples are equal)
Select2_Cockroach-2              2.70k ± 0%     2.70k ± 0%    ~            (p=0.612 n=9+10)
Insert1_Cockroach-2                357 ± 0%       357 ± 0%    ~           (p=1.000 n=10+10)
Insert10_Cockroach-2               916 ± 0%       916 ± 0%    ~           (p=0.559 n=10+10)
Insert100_Cockroach-2            6.28k ± 0%     6.28k ± 0%    ~             (p=0.327 n=8+9)
Insert1000_Cockroach-2           60.1k ± 0%     60.0k ± 0%    ~           (p=0.315 n=10+10)
Update1_Cockroach-2                720 ± 0%       720 ± 0%    ~             (p=0.388 n=9+8)
Update10_Cockroach-2             1.43k ± 0%     1.43k ± 0%    ~            (p=0.758 n=8+10)
Update100_Cockroach-2            8.15k ± 0%     8.15k ± 0%    ~             (p=0.516 n=7+8)
Update1000_Cockroach-2           72.4k ± 1%     72.3k ± 0%    ~            (p=0.588 n=10+9)
Delete1_Cockroach-2                693 ± 0%       693 ± 0%    ~            (p=0.500 n=7+10)
Delete10_Cockroach-2             1.72k ± 0%     1.72k ± 0%  -0.06%          (p=0.009 n=9+8)
Delete100_Cockroach-2            11.6k ± 0%     11.6k ± 0%  +0.03%         (p=0.036 n=8+10)
Delete1000_Cockroach-2            110k ± 0%      110k ± 0%    ~            (p=0.166 n=8+10)
Scan1_Cockroach-2                  276 ± 1%       276 ± 1%    ~           (p=0.825 n=10+10)
Scan10_Cockroach-2                 356 ± 0%       355 ± 0%    ~           (p=0.714 n=10+10)
Scan100_Cockroach-2              1.08k ± 0%     1.08k ± 0%    ~            (p=0.506 n=7+10)
Scan1000_Cockroach-2             8.29k ± 0%     8.29k ± 0%    ~     (all samples are equal)
Scan10000_Cockroach-2            80.4k ± 0%     80.4k ± 0%    ~           (p=0.287 n=10+10)
Scan1000Limit1_Cockroach-2         298 ± 0%       298 ± 0%    ~            (p=0.549 n=10+8)
Scan1000Limit10_Cockroach-2        377 ± 0%       378 ± 0%  +0.21%         (p=0.008 n=8+10)
Scan1000Limit100_Cockroach-2     1.10k ± 0%     1.10k ± 0%    ~           (p=1.000 n=10+10)
PgbenchQuery_Cockroach-2         4.05k ± 7%     4.05k ± 7%    ~           (p=0.934 n=10+10)
```
#### Analysis:

All in all, this looks pretty insignificant either way. 99th percentile
performance could be argued as a reason for this change. The worse
constant factor for all sorting could be argued as a reason against it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4878)

<!-- Reviewable:end -->
