### PR TITLE
build: Pin docker image in builder.sh

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,6 +3,7 @@
 set -eu
 
 image="cockroachdb/builder"
+version="20160304-103033"
 
 function init() {
   docker build --tag="${image}" "$(dirname $0)"
@@ -23,6 +24,11 @@ if [ "${1-}" = "push" ]; then
   tag="$(date +%Y%m%d-%H%M%S)"
   docker tag "${image}" "${image}:${tag}"
   docker push "${image}"
+  exit 0
+fi
+
+if [ "${1-}" = "version" ]; then
+  echo "${version}"
   exit 0
 fi
 
@@ -75,4 +81,4 @@ docker run -i ${tty-} ${rm} \
   --env="TSD_GITHUB_TOKEN=${TSD_GITHUB_TOKEN-}" \
   --env="CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX-0}" \
   --env="CIRCLE_NODE_TOTAL=${CIRCLE_NODE_TOTAL-1}" \
-  "${image}" "$@"
+  "${image}:${version}" "$@"

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -130,9 +130,10 @@ mkdir -p "${builder_dir}"
 du -sh "${builder_dir}"
 ls -lah "${builder_dir}"
 
-# If the images below are updated, the new images will not be picked up until
-# the tags listed here are updated.
-fetch_docker "cockroachdb" "builder" "20160304-103033"
+# If the images below are updated, the new images will not be picked
+# up until the tags listed here (or in builder.sh for the builder
+# image) are updated.
+fetch_docker "cockroachdb" "builder" $($(dirname $0)/builder.sh version)
 
 fetch_docker "cockroachdb" "docker-spy" "20160209-143235"
 


### PR DESCRIPTION
This ensures that local runs of `make acceptance` get the correct
version of the image.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4883)

<!-- Reviewable:end -->
