### PR TITLE
Announce pending shutdown on stdout

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -175,7 +175,9 @@ func runStart(_ *cobra.Command, _ []string) error {
 		go s.Stop()
 	}
 
-	log.Info("initiating graceful shutdown of server")
+	const msgDrain = "initiating graceful shutdown of server"
+	log.Info(msgDrain)
+	fmt.Fprintln(os.Stdout, msgDrain)
 
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
@@ -195,11 +197,13 @@ func runStart(_ *cobra.Command, _ []string) error {
 
 	select {
 	case <-signalCh:
-		log.Warningf("second signal received, initiating hard shutdown")
+		log.Errorf("second signal received, initiating hard shutdown")
 	case <-time.After(time.Minute):
-		log.Warningf("time limit reached, initiating hard shutdown")
+		log.Errorf("time limit reached, initiating hard shutdown")
 	case <-stopper.IsStopped():
-		log.Infof("server drained and shutdown completed")
+		const msgDone = "server drained and shutdown completed"
+		log.Infof(msgDone)
+		fmt.Fprintln(os.Stdout, msgDone)
 	}
 	log.Flush()
 	return nil


### PR DESCRIPTION
Before:

```
21:35 $ ./cockroach start --insecure
build:     alpha.v1-681-ge48daa5 @ 2016/03/06 02:34:04 (go1.6)
admin:     http://macts.local:26257
sql:       postgresql://root@macts.local:26257?sslmode=disable
logs:      cockroach-data/logs
store[0]:  path=cockroach-data
^C
```

After:

```
$ ./cockroach start --insecure
build:     alpha.v1-681-ge48daa5-dirty @ 2016/03/06 02:40:02 (go1.6)
admin:     http://macts.local:26257
sql:       postgresql://root@macts.local:26257?sslmode=disable
logs:      cockroach-data/logs
store[0]:  path=cockroach-data
^Cinitiating graceful shutdown of server
server drained and shutdown completed
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4898)

<!-- Reviewable:end -->
