### PR TITLE
tracing: use DelegatingCarrier to avoid serialization

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -19,7 +19,6 @@ github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store 3b4c041f52c224ee4a44f5c8b150d003a40643a0
 github.com/chzyer/readline 14e9df7f3c68bca64f111bab38196975d4696e2f
 github.com/client9/misspell c9127cb48d96739b0712cff253d86f05d1f431b1
-github.com/elastic/gosigar 45c54cc6e2ef4c3edc0f887f6a43aae6efe90421
 github.com/cockroachdb/c-lz4 c40aaae2fc50293eb8750b34632bc3efe813e23f
 github.com/cockroachdb/c-protobuf 4feb192131ea08dfbd7253a00868ad69cbb61b81
 github.com/cockroachdb/c-rocksdb c0124c907c74b579d9d3d48eb96471bef270bc25
@@ -34,6 +33,7 @@ github.com/docker/engine-api 12b79efa41ad2771ffb9849d698a255e2bcc4c9e
 github.com/docker/go-connections f549a9393d05688dff0992ef3efd8bbe6c628aeb
 github.com/docker/go-units 5d2041e26a699eaca682e2ea41c8f891e1060444
 github.com/dustin/go-humanize 8929fe90cee4b2cb9deb468b51fb34eba64d1bf0
+github.com/elastic/gosigar 45c54cc6e2ef4c3edc0f887f6a43aae6efe90421
 github.com/elazarl/go-bindata-assetfs 57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2
 github.com/go-sql-driver/mysql 0f2db9e6c9cff80a97ca5c2c5096242cc1554e16
 github.com/gogo/protobuf f4cc07910fc38f5b6b8d6e75d7457cf504157b6c
@@ -55,7 +55,7 @@ github.com/mibk/dupl c450df04426c2f8c35d91fb588feb88fbe328915
 github.com/olekukonko/tablewriter cca8bbc0798408af109aaaa239cbd2634846b340
 github.com/opencontainers/runc b86570a4d4a15f9fa2da9334e164b5f260552b4c
 github.com/opennota/check 2647c7f78677e5af42e988a36343bc83194b7109
-github.com/opentracing/basictracer-go e3aa2fac6d027e7d06f4948e9353c3c617c26105
+github.com/opentracing/basictracer-go bf4d751363c9a41be19a5b8b68d1ed3f8b8f8f72
 github.com/opentracing/opentracing-go 653d6d2241a086f59ae088d2b0159d880723cdaf
 github.com/rcrowley/go-metrics eeba7bd0dd01ace6e690fa833b3f22aaec29af43
 github.com/robfig/glock cb3c3ec56de988289cab7bbd284eddc04dfee6c9

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ check:
            test ! -s forbidden.log
 	@rm -f forbidden.log
 	@echo "ineffassign"
-	@! ineffassign . | grep -vE 'roachpb/data.pb.go|gossip/gossip.pb.go' # gogo/protobuf#152
+	@! ineffassign . | grep -vF '.pb.go' # gogo/protobuf#152
 	@echo "errcheck"
 	@errcheck -ignore 'bytes:Write.*,io:Close,net:Close,net/http:Close,net/rpc:Close,os:Close,database/sql:Close' $(PKG)
 	@echo "returncheck"

--- a/client/txn.go
+++ b/client/txn.go
@@ -29,8 +29,8 @@ import (
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/gogo/protobuf/proto"
-	"github.com/opentracing/basictracer-go"
-	"github.com/opentracing/opentracing-go"
+	basictracer "github.com/opentracing/basictracer-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // DefaultTxnRetryOptions are the standard retry options used

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -35,7 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/gogo/protobuf/proto"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // Default constants for timeouts.

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/gogo/protobuf/proto"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // A LocalTestCluster encapsulates an in-memory instantiation of a

--- a/kv/send.go
+++ b/kv/send.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/gogo/protobuf/proto"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // orderingPolicy is an enum for ordering strategies when there

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/gogo/protobuf/proto"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // newNodeTestContext returns a rpc.Context for testing.

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	basictracer "github.com/opentracing/basictracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 
@@ -309,21 +310,22 @@ func (tc *TxnCoordSender) startStats() {
 // write intents; they're tagged to an outgoing EndTransaction request, with
 // the receiving replica in charge of resolving them.
 func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+	// Start new or pick up active trace and embed its trace metadata into
+	// header for use by RPC recipients. From here on, there's always an active
+	// Trace, though its overhead is small unless it's sampled.
 	sp, cleanupSp := tracing.SpanFromContext(opTxnCoordSender, tc.tracer, ctx)
 	defer cleanupSp()
-	// TODO(tschottdorf): real tracing should still propagate here, but the
-	// serialization is currently pretty slow and that sucks for benchmarks.
-	if sp.BaggageItem(tracing.Snowball) != "" {
-		carrier := &opentracing.SplitBinaryCarrier{
-			TracerState: ba.Trace.Context,
-			Baggage:     ba.Trace.Baggage,
-		}
-		if err := tc.tracer.Inject(sp, opentracing.SplitBinary, carrier); err != nil {
-			return nil, roachpb.NewError(err)
-		}
-		// TODO(tschottdorf): this isn't pretty; should make it better.
-		ba.Trace.Context = carrier.TracerState
-		ba.Trace.Baggage = carrier.Baggage
+	// TODO(tschottdorf): To get rid of the spurious alloc below we need to
+	// implement the carrier interface on ba.Header or make Span non-nullable,
+	// both of which force all of ba on the Heap. It's already there, so may
+	// not be a big deal, but ba should live on the stack. Also not easy to use
+	// a buffer pool here since anything that goes into the RPC layer could be
+	// used by goroutines we didn't wait for.
+	if ba.Header.Trace == nil {
+		ba.Header.Trace = &tracing.Span{}
+	}
+	if err := tc.tracer.Inject(sp, basictracer.Delegator, ba.Trace); err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	if err := tc.maybeBeginTxn(&ba); err != nil {

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -610,20 +610,14 @@ message Header {
   // operations. The default is CONSISTENT. This value is ignored for
   // write operations.
   optional ReadConsistencyType read_consistency = 6 [(gogoproto.nullable) = false];
-  // trace is the active span of an OpenTracing distributed trace. It is
-  // empty if tracing the request is not desired.
-  optional util.tracing.WireSpan trace = 7 [(gogoproto.nullable) = false];
+  // trace, if set, is the active span of an OpenTracing distributed trace.
+  optional util.tracing.Span trace = 7;
 }
 
 
 // A BatchRequest contains one or more requests to be executed in
 // parallel, or if applicable (based on write-only commands and
 // range-locality), as a single update.
-//
-// The Span should contain the Key of the first request
-// in the batch. It also contains the transaction itself; individual
-// calls must not have transactions specified. The same applies to
-// the User and UserPriority fields.
 message BatchRequest {
   option (gogoproto.goproto_stringer) = false;
 

--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,7 @@ import (
 	"golang.org/x/net/http2"
 
 	assetfs "github.com/elazarl/go-bindata-assetfs"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 
 	snappy "github.com/cockroachdb/c-snappy"

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/tracing"
-	"github.com/opentracing/basictracer-go"
+	basictracer "github.com/opentracing/basictracer-go"
 )
 
 type explainMode int
@@ -57,7 +57,7 @@ func (p *planner) Explain(n *parser.Explain) (planNode, *roachpb.Error) {
 
 	if mode == explainTrace {
 		var err error
-		if p.txn.Trace, err = tracing.JoinOrNewSnowball("coordinator", tracing.WireSpan{}, func(sp basictracer.RawSpan) {
+		if p.txn.Trace, err = tracing.JoinOrNewSnowball("coordinator", nil, func(sp basictracer.RawSpan) {
 			p.txn.CollectedSpans = append(p.txn.CollectedSpans, sp)
 		}); err != nil {
 			return nil, roachpb.NewError(err)

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -1509,7 +1509,7 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     ".LeaderLeaseResponse\022<\n\014reverse_scan\030\025 \001"
     "(\0132&.cockroach.roachpb.ReverseScanRespon"
     "se\022-\n\004noop\030\026 \001(\0132\037.cockroach.roachpb.Noo"
-    "pResponse:\004\310\240\037\001\"\203\003\n\006Header\0225\n\ttimestamp\030"
+    "pResponse:\004\310\240\037\001\"\371\002\n\006Header\0225\n\ttimestamp\030"
     "\001 \001(\0132\034.cockroach.roachpb.TimestampB\004\310\336\037"
     "\000\022;\n\007replica\030\002 \001(\0132$.cockroach.roachpb.R"
     "eplicaDescriptorB\004\310\336\037\000\022,\n\010range_id\030\003 \001(\003"
@@ -1517,24 +1517,24 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "ority\030\004 \001(\001B\024\310\336\037\000\372\336\037\014UserPriority\022+\n\003txn"
     "\030\005 \001(\0132\036.cockroach.roachpb.Transaction\022F"
     "\n\020read_consistency\030\006 \001(\0162&.cockroach.roa"
-    "chpb.ReadConsistencyTypeB\004\310\336\037\000\0225\n\005trace\030"
-    "\007 \001(\0132 .cockroach.util.tracing.WireSpanB"
-    "\004\310\336\037\000\"\202\001\n\014BatchRequest\0223\n\006header\030\001 \001(\0132\031"
-    ".cockroach.roachpb.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010r"
-    "equests\030\002 \003(\0132\037.cockroach.roachpb.Reques"
-    "tUnionB\004\310\336\037\000:\004\230\240\037\000\"\304\002\n\rBatchResponse\022A\n\006"
-    "header\030\001 \001(\0132\'.cockroach.roachpb.BatchRe"
-    "sponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003"
-    "(\0132 .cockroach.roachpb.ResponseUnionB\004\310\336"
-    "\037\000\032\256\001\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockroach"
-    ".roachpb.Error\0225\n\ttimestamp\030\002 \001(\0132\034.cock"
-    "roach.roachpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001"
-    "(\0132\036.cockroach.roachpb.Transaction\022\027\n\017co"
-    "llected_spans\030\004 \003(\014:\004\230\240\037\000*L\n\023ReadConsist"
-    "encyType\022\016\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022"
-    "\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022"
-    "\n\016PUSH_TIMESTAMP\020\000\022\016\n\nPUSH_ABORT\020\001\022\016\n\nPU"
-    "SH_TOUCH\020\002\032\004\210\243\036\000B\tZ\007roachpbX\004", 9109);
+    "chpb.ReadConsistencyTypeB\004\310\336\037\000\022+\n\005trace\030"
+    "\007 \001(\0132\034.cockroach.util.tracing.Span\"\202\001\n\014"
+    "BatchRequest\0223\n\006header\030\001 \001(\0132\031.cockroach"
+    ".roachpb.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 "
+    "\003(\0132\037.cockroach.roachpb.RequestUnionB\004\310\336"
+    "\037\000:\004\230\240\037\000\"\304\002\n\rBatchResponse\022A\n\006header\030\001 \001"
+    "(\0132\'.cockroach.roachpb.BatchResponse.Hea"
+    "derB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .cockr"
+    "oach.roachpb.ResponseUnionB\004\310\336\037\000\032\256\001\n\006Hea"
+    "der\022\'\n\005error\030\001 \001(\0132\030.cockroach.roachpb.E"
+    "rror\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roac"
+    "hpb.TimestampB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockr"
+    "oach.roachpb.Transaction\022\027\n\017collected_sp"
+    "ans\030\004 \003(\014:\004\230\240\037\000*L\n\023ReadConsistencyType\022\016"
+    "\n\nCONSISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSI"
+    "STENT\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIM"
+    "ESTAMP\020\000\022\016\n\nPUSH_ABORT\020\001\022\016\n\nPUSH_TOUCH\020\002"
+    "\032\004\210\243\036\000B\tZ\007roachpbX\004", 9099);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ResponseHeader::default_instance_ = new ResponseHeader();
@@ -22396,7 +22396,7 @@ void Header::InitAsDefaultInstance() {
   timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
   replica_ = const_cast< ::cockroach::roachpb::ReplicaDescriptor*>(&::cockroach::roachpb::ReplicaDescriptor::default_instance());
   txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
-  trace_ = const_cast< ::cockroach::util::tracing::WireSpan*>(&::cockroach::util::tracing::WireSpan::default_instance());
+  trace_ = const_cast< ::cockroach::util::tracing::Span*>(&::cockroach::util::tracing::Span::default_instance());
 }
 
 Header::Header(const Header& from)
@@ -22480,7 +22480,7 @@ void Header::Clear() {
     }
     read_consistency_ = 0;
     if (has_trace()) {
-      if (trace_ != NULL) trace_->::cockroach::util::tracing::WireSpan::Clear();
+      if (trace_ != NULL) trace_->::cockroach::util::tracing::Span::Clear();
     }
   }
 
@@ -22591,7 +22591,7 @@ bool Header::MergePartialFromCodedStream(
         break;
       }
 
-      // optional .cockroach.util.tracing.WireSpan trace = 7;
+      // optional .cockroach.util.tracing.Span trace = 7;
       case 7: {
         if (tag == 58) {
          parse_trace:
@@ -22663,7 +22663,7 @@ void Header::SerializeWithCachedSizes(
       6, this->read_consistency(), output);
   }
 
-  // optional .cockroach.util.tracing.WireSpan trace = 7;
+  // optional .cockroach.util.tracing.Span trace = 7;
   if (has_trace()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       7, *this->trace_, output);
@@ -22716,7 +22716,7 @@ void Header::SerializeWithCachedSizes(
       6, this->read_consistency(), target);
   }
 
-  // optional .cockroach.util.tracing.WireSpan trace = 7;
+  // optional .cockroach.util.tracing.Span trace = 7;
   if (has_trace()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
@@ -22774,7 +22774,7 @@ int Header::ByteSize() const {
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->read_consistency());
     }
 
-    // optional .cockroach.util.tracing.WireSpan trace = 7;
+    // optional .cockroach.util.tracing.Span trace = 7;
     if (has_trace()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
@@ -22827,7 +22827,7 @@ void Header::MergeFrom(const Header& from) {
       set_read_consistency(from.read_consistency());
     }
     if (from.has_trace()) {
-      mutable_trace()->::cockroach::util::tracing::WireSpan::MergeFrom(from.trace());
+      mutable_trace()->::cockroach::util::tracing::Span::MergeFrom(from.trace());
     }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
@@ -23082,7 +23082,7 @@ void Header::clear_read_consistency() {
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Header.read_consistency)
 }
 
-// optional .cockroach.util.tracing.WireSpan trace = 7;
+// optional .cockroach.util.tracing.Span trace = 7;
 bool Header::has_trace() const {
   return (_has_bits_[0] & 0x00000040u) != 0;
 }
@@ -23093,28 +23093,28 @@ void Header::clear_has_trace() {
   _has_bits_[0] &= ~0x00000040u;
 }
 void Header::clear_trace() {
-  if (trace_ != NULL) trace_->::cockroach::util::tracing::WireSpan::Clear();
+  if (trace_ != NULL) trace_->::cockroach::util::tracing::Span::Clear();
   clear_has_trace();
 }
-const ::cockroach::util::tracing::WireSpan& Header::trace() const {
+const ::cockroach::util::tracing::Span& Header::trace() const {
   // @@protoc_insertion_point(field_get:cockroach.roachpb.Header.trace)
   return trace_ != NULL ? *trace_ : *default_instance_->trace_;
 }
-::cockroach::util::tracing::WireSpan* Header::mutable_trace() {
+::cockroach::util::tracing::Span* Header::mutable_trace() {
   set_has_trace();
   if (trace_ == NULL) {
-    trace_ = new ::cockroach::util::tracing::WireSpan;
+    trace_ = new ::cockroach::util::tracing::Span;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Header.trace)
   return trace_;
 }
-::cockroach::util::tracing::WireSpan* Header::release_trace() {
+::cockroach::util::tracing::Span* Header::release_trace() {
   clear_has_trace();
-  ::cockroach::util::tracing::WireSpan* temp = trace_;
+  ::cockroach::util::tracing::Span* temp = trace_;
   trace_ = NULL;
   return temp;
 }
-void Header::set_allocated_trace(::cockroach::util::tracing::WireSpan* trace) {
+void Header::set_allocated_trace(::cockroach::util::tracing::Span* trace) {
   delete trace_;
   trace_ = trace;
   if (trace) {

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -5625,14 +5625,14 @@ class Header : public ::google::protobuf::Message {
   ::cockroach::roachpb::ReadConsistencyType read_consistency() const;
   void set_read_consistency(::cockroach::roachpb::ReadConsistencyType value);
 
-  // optional .cockroach.util.tracing.WireSpan trace = 7;
+  // optional .cockroach.util.tracing.Span trace = 7;
   bool has_trace() const;
   void clear_trace();
   static const int kTraceFieldNumber = 7;
-  const ::cockroach::util::tracing::WireSpan& trace() const;
-  ::cockroach::util::tracing::WireSpan* mutable_trace();
-  ::cockroach::util::tracing::WireSpan* release_trace();
-  void set_allocated_trace(::cockroach::util::tracing::WireSpan* trace);
+  const ::cockroach::util::tracing::Span& trace() const;
+  ::cockroach::util::tracing::Span* mutable_trace();
+  ::cockroach::util::tracing::Span* release_trace();
+  void set_allocated_trace(::cockroach::util::tracing::Span* trace);
 
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.Header)
  private:
@@ -5659,7 +5659,7 @@ class Header : public ::google::protobuf::Message {
   ::google::protobuf::int64 range_id_;
   double user_priority_;
   ::cockroach::roachpb::Transaction* txn_;
-  ::cockroach::util::tracing::WireSpan* trace_;
+  ::cockroach::util::tracing::Span* trace_;
   int read_consistency_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
@@ -11769,7 +11769,7 @@ inline void Header::set_read_consistency(::cockroach::roachpb::ReadConsistencyTy
   // @@protoc_insertion_point(field_set:cockroach.roachpb.Header.read_consistency)
 }
 
-// optional .cockroach.util.tracing.WireSpan trace = 7;
+// optional .cockroach.util.tracing.Span trace = 7;
 inline bool Header::has_trace() const {
   return (_has_bits_[0] & 0x00000040u) != 0;
 }
@@ -11780,28 +11780,28 @@ inline void Header::clear_has_trace() {
   _has_bits_[0] &= ~0x00000040u;
 }
 inline void Header::clear_trace() {
-  if (trace_ != NULL) trace_->::cockroach::util::tracing::WireSpan::Clear();
+  if (trace_ != NULL) trace_->::cockroach::util::tracing::Span::Clear();
   clear_has_trace();
 }
-inline const ::cockroach::util::tracing::WireSpan& Header::trace() const {
+inline const ::cockroach::util::tracing::Span& Header::trace() const {
   // @@protoc_insertion_point(field_get:cockroach.roachpb.Header.trace)
   return trace_ != NULL ? *trace_ : *default_instance_->trace_;
 }
-inline ::cockroach::util::tracing::WireSpan* Header::mutable_trace() {
+inline ::cockroach::util::tracing::Span* Header::mutable_trace() {
   set_has_trace();
   if (trace_ == NULL) {
-    trace_ = new ::cockroach::util::tracing::WireSpan;
+    trace_ = new ::cockroach::util::tracing::Span;
   }
   // @@protoc_insertion_point(field_mutable:cockroach.roachpb.Header.trace)
   return trace_;
 }
-inline ::cockroach::util::tracing::WireSpan* Header::release_trace() {
+inline ::cockroach::util::tracing::Span* Header::release_trace() {
   clear_has_trace();
-  ::cockroach::util::tracing::WireSpan* temp = trace_;
+  ::cockroach::util::tracing::Span* temp = trace_;
   trace_ = NULL;
   return temp;
 }
-inline void Header::set_allocated_trace(::cockroach::util::tracing::WireSpan* trace) {
+inline void Header::set_allocated_trace(::cockroach::util::tracing::Span* trace) {
   delete trace_;
   trace_ = trace;
   if (trace) {

--- a/storage/engine/rocksdb/cockroach/util/tracing/span.pb.cc
+++ b/storage/engine/rocksdb/cockroach/util/tracing/span.pb.cc
@@ -23,9 +23,10 @@ namespace tracing {
 
 namespace {
 
-const ::google::protobuf::Descriptor* WireSpan_descriptor_ = NULL;
+const ::google::protobuf::Descriptor* Span_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
-  WireSpan_reflection_ = NULL;
+  Span_reflection_ = NULL;
+const ::google::protobuf::Descriptor* Span_BaggageEntry_descriptor_ = NULL;
 
 }  // namespace
 
@@ -36,22 +37,25 @@ void protobuf_AssignDesc_cockroach_2futil_2ftracing_2fspan_2eproto() {
     ::google::protobuf::DescriptorPool::generated_pool()->FindFileByName(
       "cockroach/util/tracing/span.proto");
   GOOGLE_CHECK(file != NULL);
-  WireSpan_descriptor_ = file->message_type(0);
-  static const int WireSpan_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WireSpan, context_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WireSpan, baggage_),
+  Span_descriptor_ = file->message_type(0);
+  static const int Span_offsets_[4] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Span, trace_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Span, span_id_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Span, sampled_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Span, baggage_),
   };
-  WireSpan_reflection_ =
+  Span_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
-      WireSpan_descriptor_,
-      WireSpan::default_instance_,
-      WireSpan_offsets_,
+      Span_descriptor_,
+      Span::default_instance_,
+      Span_offsets_,
       -1,
       -1,
       -1,
-      sizeof(WireSpan),
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WireSpan, _internal_metadata_),
-      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WireSpan, _is_default_instance_));
+      sizeof(Span),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Span, _internal_metadata_),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Span, _is_default_instance_));
+  Span_BaggageEntry_descriptor_ = Span_descriptor_->nested_type(0);
 }
 
 namespace {
@@ -65,14 +69,23 @@ inline void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
-      WireSpan_descriptor_, &WireSpan::default_instance());
+      Span_descriptor_, &Span::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+        Span_BaggageEntry_descriptor_,
+        ::google::protobuf::internal::MapEntry<
+            ::std::string,
+            ::std::string,
+            ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+            ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+            0>::CreateDefaultInstance(
+                Span_BaggageEntry_descriptor_));
 }
 
 }  // namespace
 
 void protobuf_ShutdownFile_cockroach_2futil_2ftracing_2fspan_2eproto() {
-  delete WireSpan::default_instance_;
-  delete WireSpan_reflection_;
+  delete Span::default_instance_;
+  delete Span_reflection_;
 }
 
 void protobuf_AddDesc_cockroach_2futil_2ftracing_2fspan_2eproto() {
@@ -85,12 +98,16 @@ void protobuf_AddDesc_cockroach_2futil_2ftracing_2fspan_2eproto() {
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n!cockroach/util/tracing/span.proto\022\026coc"
     "kroach.util.tracing\032\024gogoproto/gogo.prot"
-    "o\",\n\010WireSpan\022\017\n\007context\030\001 \001(\014\022\017\n\007baggag"
-    "e\030\002 \001(\014B\tZ\007tracingX\000b\006proto3", 148);
+    "o\"\277\001\n\004Span\022\035\n\010trace_id\030\001 \001(\003B\013\342\336\037\007TraceI"
+    "D\022\033\n\007span_id\030\002 \001(\003B\n\342\336\037\006SpanID\022\017\n\007sample"
+    "d\030\003 \001(\010\022:\n\007baggage\030\004 \003(\0132).cockroach.uti"
+    "l.tracing.Span.BaggageEntry\032.\n\014BaggageEn"
+    "try\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001B\tZ\007t"
+    "racingX\000b\006proto3", 296);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/util/tracing/span.proto", &protobuf_RegisterTypes);
-  WireSpan::default_instance_ = new WireSpan();
-  WireSpan::default_instance_->InitAsDefaultInstance();
+  Span::default_instance_ = new Span();
+  Span::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_cockroach_2futil_2ftracing_2fspan_2eproto);
 }
 
@@ -114,109 +131,173 @@ static void MergeFromFail(int line) {
 // ===================================================================
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int WireSpan::kContextFieldNumber;
-const int WireSpan::kBaggageFieldNumber;
+const int Span::kTraceIdFieldNumber;
+const int Span::kSpanIdFieldNumber;
+const int Span::kSampledFieldNumber;
+const int Span::kBaggageFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
-WireSpan::WireSpan()
+Span::Span()
   : ::google::protobuf::Message(), _internal_metadata_(NULL) {
   SharedCtor();
-  // @@protoc_insertion_point(constructor:cockroach.util.tracing.WireSpan)
+  // @@protoc_insertion_point(constructor:cockroach.util.tracing.Span)
 }
 
-void WireSpan::InitAsDefaultInstance() {
+void Span::InitAsDefaultInstance() {
   _is_default_instance_ = true;
 }
 
-WireSpan::WireSpan(const WireSpan& from)
+Span::Span(const Span& from)
   : ::google::protobuf::Message(),
     _internal_metadata_(NULL) {
   SharedCtor();
   MergeFrom(from);
-  // @@protoc_insertion_point(copy_constructor:cockroach.util.tracing.WireSpan)
+  // @@protoc_insertion_point(copy_constructor:cockroach.util.tracing.Span)
 }
 
-void WireSpan::SharedCtor() {
+void Span::SharedCtor() {
     _is_default_instance_ = false;
-  ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
-  context_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  baggage_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  trace_id_ = GOOGLE_LONGLONG(0);
+  span_id_ = GOOGLE_LONGLONG(0);
+  sampled_ = false;
+  baggage_.SetAssignDescriptorCallback(
+      protobuf_AssignDescriptorsOnce);
+  baggage_.SetEntryDescriptor(
+      &::cockroach::util::tracing::Span_BaggageEntry_descriptor_);
 }
 
-WireSpan::~WireSpan() {
-  // @@protoc_insertion_point(destructor:cockroach.util.tracing.WireSpan)
+Span::~Span() {
+  // @@protoc_insertion_point(destructor:cockroach.util.tracing.Span)
   SharedDtor();
 }
 
-void WireSpan::SharedDtor() {
-  context_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  baggage_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+void Span::SharedDtor() {
   if (this != default_instance_) {
   }
 }
 
-void WireSpan::SetCachedSize(int size) const {
+void Span::SetCachedSize(int size) const {
   GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
   _cached_size_ = size;
   GOOGLE_SAFE_CONCURRENT_WRITES_END();
 }
-const ::google::protobuf::Descriptor* WireSpan::descriptor() {
+const ::google::protobuf::Descriptor* Span::descriptor() {
   protobuf_AssignDescriptorsOnce();
-  return WireSpan_descriptor_;
+  return Span_descriptor_;
 }
 
-const WireSpan& WireSpan::default_instance() {
+const Span& Span::default_instance() {
   if (default_instance_ == NULL) protobuf_AddDesc_cockroach_2futil_2ftracing_2fspan_2eproto();
   return *default_instance_;
 }
 
-WireSpan* WireSpan::default_instance_ = NULL;
+Span* Span::default_instance_ = NULL;
 
-WireSpan* WireSpan::New(::google::protobuf::Arena* arena) const {
-  WireSpan* n = new WireSpan;
+Span* Span::New(::google::protobuf::Arena* arena) const {
+  Span* n = new Span;
   if (arena != NULL) {
     arena->Own(n);
   }
   return n;
 }
 
-void WireSpan::Clear() {
-  context_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  baggage_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+void Span::Clear() {
+#define ZR_HELPER_(f) reinterpret_cast<char*>(\
+  &reinterpret_cast<Span*>(16)->f)
+
+#define ZR_(first, last) do {\
+  ::memset(&first, 0,\
+           ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
+} while (0)
+
+  ZR_(trace_id_, span_id_);
+  sampled_ = false;
+
+#undef ZR_HELPER_
+#undef ZR_
+
+  baggage_.Clear();
 }
 
-bool WireSpan::MergePartialFromCodedStream(
+bool Span::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:cockroach.util.tracing.WireSpan)
+  // @@protoc_insertion_point(parse_start:cockroach.util.tracing.Span)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional bytes context = 1;
+      // optional int64 trace_id = 1;
       case 1: {
-        if (tag == 10) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_context()));
+        if (tag == 8) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &trace_id_)));
+
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(18)) goto parse_baggage;
+        if (input->ExpectTag(16)) goto parse_span_id;
         break;
       }
 
-      // optional bytes baggage = 2;
+      // optional int64 span_id = 2;
       case 2: {
-        if (tag == 18) {
-         parse_baggage:
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_baggage()));
+        if (tag == 16) {
+         parse_span_id:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &span_id_)));
+
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(24)) goto parse_sampled;
+        break;
+      }
+
+      // optional bool sampled = 3;
+      case 3: {
+        if (tag == 24) {
+         parse_sampled:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &sampled_)));
+
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(34)) goto parse_baggage;
+        break;
+      }
+
+      // map<string, string> baggage = 4;
+      case 4: {
+        if (tag == 34) {
+         parse_baggage:
+          DO_(input->IncrementRecursionDepth());
+         parse_loop_baggage:
+          ::google::protobuf::scoped_ptr<Span_BaggageEntry> entry(baggage_.NewEntry());
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, entry.get()));
+          (*mutable_baggage())[entry->key()] = *entry->mutable_value();
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            entry->key().data(), entry->key().length(),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "cockroach.util.tracing.Span.BaggageEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            entry->mutable_value()->data(),
+            entry->mutable_value()->length(),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "cockroach.util.tracing.Span.BaggageEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(34)) goto parse_loop_baggage;
+        input->UnsafeDecrementRecursionDepth();
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -234,68 +315,131 @@ bool WireSpan::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:cockroach.util.tracing.WireSpan)
+  // @@protoc_insertion_point(parse_success:cockroach.util.tracing.Span)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:cockroach.util.tracing.WireSpan)
+  // @@protoc_insertion_point(parse_failure:cockroach.util.tracing.Span)
   return false;
 #undef DO_
 }
 
-void WireSpan::SerializeWithCachedSizes(
+void Span::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:cockroach.util.tracing.WireSpan)
-  // optional bytes context = 1;
-  if (this->context().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      1, this->context(), output);
+  // @@protoc_insertion_point(serialize_start:cockroach.util.tracing.Span)
+  // optional int64 trace_id = 1;
+  if (this->trace_id() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(1, this->trace_id(), output);
   }
 
-  // optional bytes baggage = 2;
-  if (this->baggage().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      2, this->baggage(), output);
+  // optional int64 span_id = 2;
+  if (this->span_id() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(2, this->span_id(), output);
   }
 
-  // @@protoc_insertion_point(serialize_end:cockroach.util.tracing.WireSpan)
+  // optional bool sampled = 3;
+  if (this->sampled() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(3, this->sampled(), output);
+  }
+
+  // map<string, string> baggage = 4;
+  {
+    ::google::protobuf::scoped_ptr<Span_BaggageEntry> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->baggage().begin();
+        it != this->baggage().end(); ++it) {
+      entry.reset(baggage_.NewEntryWrapper(it->first, it->second));
+      ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+          4, *entry, output);
+      ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+        it->first.data(), it->first.length(),
+        ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+        "cockroach.util.tracing.Span.BaggageEntry.key");
+      ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+        it->second.data(), it->second.length(),
+        ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+        "cockroach.util.tracing.Span.BaggageEntry.value");
+    }
+  }
+
+  // @@protoc_insertion_point(serialize_end:cockroach.util.tracing.Span)
 }
 
-::google::protobuf::uint8* WireSpan::SerializeWithCachedSizesToArray(
+::google::protobuf::uint8* Span::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
-  // @@protoc_insertion_point(serialize_to_array_start:cockroach.util.tracing.WireSpan)
-  // optional bytes context = 1;
-  if (this->context().size() > 0) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        1, this->context(), target);
+  // @@protoc_insertion_point(serialize_to_array_start:cockroach.util.tracing.Span)
+  // optional int64 trace_id = 1;
+  if (this->trace_id() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(1, this->trace_id(), target);
   }
 
-  // optional bytes baggage = 2;
-  if (this->baggage().size() > 0) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        2, this->baggage(), target);
+  // optional int64 span_id = 2;
+  if (this->span_id() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(2, this->span_id(), target);
   }
 
-  // @@protoc_insertion_point(serialize_to_array_end:cockroach.util.tracing.WireSpan)
+  // optional bool sampled = 3;
+  if (this->sampled() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(3, this->sampled(), target);
+  }
+
+  // map<string, string> baggage = 4;
+  {
+    ::google::protobuf::scoped_ptr<Span_BaggageEntry> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->baggage().begin();
+        it != this->baggage().end(); ++it) {
+      entry.reset(baggage_.NewEntryWrapper(it->first, it->second));
+      target = ::google::protobuf::internal::WireFormatLite::
+          WriteMessageNoVirtualToArray(
+              4, *entry, target);
+      ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+        it->first.data(), it->first.length(),
+        ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+        "cockroach.util.tracing.Span.BaggageEntry.key");
+      ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+        it->second.data(), it->second.length(),
+        ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+        "cockroach.util.tracing.Span.BaggageEntry.value");
+    }
+  }
+
+  // @@protoc_insertion_point(serialize_to_array_end:cockroach.util.tracing.Span)
   return target;
 }
 
-int WireSpan::ByteSize() const {
+int Span::ByteSize() const {
   int total_size = 0;
 
-  // optional bytes context = 1;
-  if (this->context().size() > 0) {
+  // optional int64 trace_id = 1;
+  if (this->trace_id() != 0) {
     total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::BytesSize(
-        this->context());
+      ::google::protobuf::internal::WireFormatLite::Int64Size(
+        this->trace_id());
   }
 
-  // optional bytes baggage = 2;
-  if (this->baggage().size() > 0) {
+  // optional int64 span_id = 2;
+  if (this->span_id() != 0) {
     total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::BytesSize(
-        this->baggage());
+      ::google::protobuf::internal::WireFormatLite::Int64Size(
+        this->span_id());
+  }
+
+  // optional bool sampled = 3;
+  if (this->sampled() != 0) {
+    total_size += 1 + 1;
+  }
+
+  // map<string, string> baggage = 4;
+  total_size += 1 * this->baggage_size();
+  {
+    ::google::protobuf::scoped_ptr<Span_BaggageEntry> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->baggage().begin();
+        it != this->baggage().end(); ++it) {
+      entry.reset(baggage_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
   }
 
   GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
@@ -304,10 +448,10 @@ int WireSpan::ByteSize() const {
   return total_size;
 }
 
-void WireSpan::MergeFrom(const ::google::protobuf::Message& from) {
+void Span::MergeFrom(const ::google::protobuf::Message& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  const WireSpan* source = 
-      ::google::protobuf::internal::DynamicCastToGenerated<const WireSpan>(
+  const Span* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const Span>(
           &from);
   if (source == NULL) {
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
@@ -316,141 +460,119 @@ void WireSpan::MergeFrom(const ::google::protobuf::Message& from) {
   }
 }
 
-void WireSpan::MergeFrom(const WireSpan& from) {
+void Span::MergeFrom(const Span& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
-  if (from.context().size() > 0) {
-
-    context_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.context_);
+  baggage_.MergeFrom(from.baggage_);
+  if (from.trace_id() != 0) {
+    set_trace_id(from.trace_id());
   }
-  if (from.baggage().size() > 0) {
-
-    baggage_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.baggage_);
+  if (from.span_id() != 0) {
+    set_span_id(from.span_id());
+  }
+  if (from.sampled() != 0) {
+    set_sampled(from.sampled());
   }
 }
 
-void WireSpan::CopyFrom(const ::google::protobuf::Message& from) {
+void Span::CopyFrom(const ::google::protobuf::Message& from) {
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void WireSpan::CopyFrom(const WireSpan& from) {
+void Span::CopyFrom(const Span& from) {
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool WireSpan::IsInitialized() const {
+bool Span::IsInitialized() const {
 
   return true;
 }
 
-void WireSpan::Swap(WireSpan* other) {
+void Span::Swap(Span* other) {
   if (other == this) return;
   InternalSwap(other);
 }
-void WireSpan::InternalSwap(WireSpan* other) {
-  context_.Swap(&other->context_);
+void Span::InternalSwap(Span* other) {
+  std::swap(trace_id_, other->trace_id_);
+  std::swap(span_id_, other->span_id_);
+  std::swap(sampled_, other->sampled_);
   baggage_.Swap(&other->baggage_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
 }
 
-::google::protobuf::Metadata WireSpan::GetMetadata() const {
+::google::protobuf::Metadata Span::GetMetadata() const {
   protobuf_AssignDescriptorsOnce();
   ::google::protobuf::Metadata metadata;
-  metadata.descriptor = WireSpan_descriptor_;
-  metadata.reflection = WireSpan_reflection_;
+  metadata.descriptor = Span_descriptor_;
+  metadata.reflection = Span_reflection_;
   return metadata;
 }
 
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
-// WireSpan
+// Span
 
-// optional bytes context = 1;
-void WireSpan::clear_context() {
-  context_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+// optional int64 trace_id = 1;
+void Span::clear_trace_id() {
+  trace_id_ = GOOGLE_LONGLONG(0);
 }
- const ::std::string& WireSpan::context() const {
-  // @@protoc_insertion_point(field_get:cockroach.util.tracing.WireSpan.context)
-  return context_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+ ::google::protobuf::int64 Span::trace_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.util.tracing.Span.trace_id)
+  return trace_id_;
 }
- void WireSpan::set_context(const ::std::string& value) {
+ void Span::set_trace_id(::google::protobuf::int64 value) {
   
-  context_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.util.tracing.WireSpan.context)
-}
- void WireSpan::set_context(const char* value) {
-  
-  context_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.util.tracing.WireSpan.context)
-}
- void WireSpan::set_context(const void* value, size_t size) {
-  
-  context_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.util.tracing.WireSpan.context)
-}
- ::std::string* WireSpan::mutable_context() {
-  
-  // @@protoc_insertion_point(field_mutable:cockroach.util.tracing.WireSpan.context)
-  return context_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- ::std::string* WireSpan::release_context() {
-  
-  return context_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
- void WireSpan::set_allocated_context(::std::string* context) {
-  if (context != NULL) {
-    
-  } else {
-    
-  }
-  context_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), context);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.util.tracing.WireSpan.context)
+  trace_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.util.tracing.Span.trace_id)
 }
 
-// optional bytes baggage = 2;
-void WireSpan::clear_baggage() {
-  baggage_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+// optional int64 span_id = 2;
+void Span::clear_span_id() {
+  span_id_ = GOOGLE_LONGLONG(0);
 }
- const ::std::string& WireSpan::baggage() const {
-  // @@protoc_insertion_point(field_get:cockroach.util.tracing.WireSpan.baggage)
-  return baggage_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+ ::google::protobuf::int64 Span::span_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.util.tracing.Span.span_id)
+  return span_id_;
 }
- void WireSpan::set_baggage(const ::std::string& value) {
+ void Span::set_span_id(::google::protobuf::int64 value) {
   
-  baggage_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.util.tracing.WireSpan.baggage)
+  span_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.util.tracing.Span.span_id)
 }
- void WireSpan::set_baggage(const char* value) {
+
+// optional bool sampled = 3;
+void Span::clear_sampled() {
+  sampled_ = false;
+}
+ bool Span::sampled() const {
+  // @@protoc_insertion_point(field_get:cockroach.util.tracing.Span.sampled)
+  return sampled_;
+}
+ void Span::set_sampled(bool value) {
   
-  baggage_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.util.tracing.WireSpan.baggage)
+  sampled_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.util.tracing.Span.sampled)
 }
- void WireSpan::set_baggage(const void* value, size_t size) {
-  
-  baggage_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.util.tracing.WireSpan.baggage)
+
+// map<string, string> baggage = 4;
+int Span::baggage_size() const {
+  return baggage_.size();
 }
- ::std::string* WireSpan::mutable_baggage() {
-  
-  // @@protoc_insertion_point(field_mutable:cockroach.util.tracing.WireSpan.baggage)
-  return baggage_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+void Span::clear_baggage() {
+  baggage_.Clear();
 }
- ::std::string* WireSpan::release_baggage() {
-  
-  return baggage_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+ const ::google::protobuf::Map< ::std::string, ::std::string >&
+Span::baggage() const {
+  // @@protoc_insertion_point(field_map:cockroach.util.tracing.Span.baggage)
+  return baggage_.GetMap();
 }
- void WireSpan::set_allocated_baggage(::std::string* baggage) {
-  if (baggage != NULL) {
-    
-  } else {
-    
-  }
-  baggage_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), baggage);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.util.tracing.WireSpan.baggage)
+ ::google::protobuf::Map< ::std::string, ::std::string >*
+Span::mutable_baggage() {
+  // @@protoc_insertion_point(field_mutable_map:cockroach.util.tracing.Span.baggage)
+  return baggage_.MutableMap();
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/util/tracing/span.pb.h
+++ b/storage/engine/rocksdb/cockroach/util/tracing/span.pb.h
@@ -26,6 +26,8 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/extension_set.h>
+#include <google/protobuf/map.h>
+#include <google/protobuf/map_field_inl.h>
 #include <google/protobuf/unknown_field_set.h>
 #include "gogoproto/gogo.pb.h"
 // @@protoc_insertion_point(includes)
@@ -39,36 +41,36 @@ void protobuf_AddDesc_cockroach_2futil_2ftracing_2fspan_2eproto();
 void protobuf_AssignDesc_cockroach_2futil_2ftracing_2fspan_2eproto();
 void protobuf_ShutdownFile_cockroach_2futil_2ftracing_2fspan_2eproto();
 
-class WireSpan;
+class Span;
 
 // ===================================================================
 
-class WireSpan : public ::google::protobuf::Message {
+class Span : public ::google::protobuf::Message {
  public:
-  WireSpan();
-  virtual ~WireSpan();
+  Span();
+  virtual ~Span();
 
-  WireSpan(const WireSpan& from);
+  Span(const Span& from);
 
-  inline WireSpan& operator=(const WireSpan& from) {
+  inline Span& operator=(const Span& from) {
     CopyFrom(from);
     return *this;
   }
 
   static const ::google::protobuf::Descriptor* descriptor();
-  static const WireSpan& default_instance();
+  static const Span& default_instance();
 
-  void Swap(WireSpan* other);
+  void Swap(Span* other);
 
   // implements Message ----------------------------------------------
 
-  inline WireSpan* New() const { return New(NULL); }
+  inline Span* New() const { return New(NULL); }
 
-  WireSpan* New(::google::protobuf::Arena* arena) const;
+  Span* New(::google::protobuf::Arena* arena) const;
   void CopyFrom(const ::google::protobuf::Message& from);
   void MergeFrom(const ::google::protobuf::Message& from);
-  void CopyFrom(const WireSpan& from);
-  void MergeFrom(const WireSpan& from);
+  void CopyFrom(const Span& from);
+  void MergeFrom(const Span& from);
   void Clear();
   bool IsInitialized() const;
 
@@ -83,7 +85,7 @@ class WireSpan : public ::google::protobuf::Message {
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const;
-  void InternalSwap(WireSpan* other);
+  void InternalSwap(Span* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
     return _internal_metadata_.arena();
@@ -97,44 +99,62 @@ class WireSpan : public ::google::protobuf::Message {
 
   // nested types ----------------------------------------------------
 
+
   // accessors -------------------------------------------------------
 
-  // optional bytes context = 1;
-  void clear_context();
-  static const int kContextFieldNumber = 1;
-  const ::std::string& context() const;
-  void set_context(const ::std::string& value);
-  void set_context(const char* value);
-  void set_context(const void* value, size_t size);
-  ::std::string* mutable_context();
-  ::std::string* release_context();
-  void set_allocated_context(::std::string* context);
+  // optional int64 trace_id = 1;
+  void clear_trace_id();
+  static const int kTraceIdFieldNumber = 1;
+  ::google::protobuf::int64 trace_id() const;
+  void set_trace_id(::google::protobuf::int64 value);
 
-  // optional bytes baggage = 2;
+  // optional int64 span_id = 2;
+  void clear_span_id();
+  static const int kSpanIdFieldNumber = 2;
+  ::google::protobuf::int64 span_id() const;
+  void set_span_id(::google::protobuf::int64 value);
+
+  // optional bool sampled = 3;
+  void clear_sampled();
+  static const int kSampledFieldNumber = 3;
+  bool sampled() const;
+  void set_sampled(bool value);
+
+  // map<string, string> baggage = 4;
+  int baggage_size() const;
   void clear_baggage();
-  static const int kBaggageFieldNumber = 2;
-  const ::std::string& baggage() const;
-  void set_baggage(const ::std::string& value);
-  void set_baggage(const char* value);
-  void set_baggage(const void* value, size_t size);
-  ::std::string* mutable_baggage();
-  ::std::string* release_baggage();
-  void set_allocated_baggage(::std::string* baggage);
+  static const int kBaggageFieldNumber = 4;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      baggage() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_baggage();
 
-  // @@protoc_insertion_point(class_scope:cockroach.util.tracing.WireSpan)
+  // @@protoc_insertion_point(class_scope:cockroach.util.tracing.Span)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   bool _is_default_instance_;
-  ::google::protobuf::internal::ArenaStringPtr context_;
-  ::google::protobuf::internal::ArenaStringPtr baggage_;
+  ::google::protobuf::int64 trace_id_;
+  ::google::protobuf::int64 span_id_;
+  typedef ::google::protobuf::internal::MapEntryLite<
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 >
+      Span_BaggageEntry;
+  ::google::protobuf::internal::MapField<
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > baggage_;
+  bool sampled_;
   mutable int _cached_size_;
   friend void  protobuf_AddDesc_cockroach_2futil_2ftracing_2fspan_2eproto();
   friend void protobuf_AssignDesc_cockroach_2futil_2ftracing_2fspan_2eproto();
   friend void protobuf_ShutdownFile_cockroach_2futil_2ftracing_2fspan_2eproto();
 
   void InitAsDefaultInstance();
-  static WireSpan* default_instance_;
+  static Span* default_instance_;
 };
 // ===================================================================
 
@@ -142,92 +162,66 @@ class WireSpan : public ::google::protobuf::Message {
 // ===================================================================
 
 #if !PROTOBUF_INLINE_NOT_IN_HEADERS
-// WireSpan
+// Span
 
-// optional bytes context = 1;
-inline void WireSpan::clear_context() {
-  context_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+// optional int64 trace_id = 1;
+inline void Span::clear_trace_id() {
+  trace_id_ = GOOGLE_LONGLONG(0);
 }
-inline const ::std::string& WireSpan::context() const {
-  // @@protoc_insertion_point(field_get:cockroach.util.tracing.WireSpan.context)
-  return context_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+inline ::google::protobuf::int64 Span::trace_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.util.tracing.Span.trace_id)
+  return trace_id_;
 }
-inline void WireSpan::set_context(const ::std::string& value) {
+inline void Span::set_trace_id(::google::protobuf::int64 value) {
   
-  context_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.util.tracing.WireSpan.context)
-}
-inline void WireSpan::set_context(const char* value) {
-  
-  context_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.util.tracing.WireSpan.context)
-}
-inline void WireSpan::set_context(const void* value, size_t size) {
-  
-  context_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.util.tracing.WireSpan.context)
-}
-inline ::std::string* WireSpan::mutable_context() {
-  
-  // @@protoc_insertion_point(field_mutable:cockroach.util.tracing.WireSpan.context)
-  return context_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* WireSpan::release_context() {
-  
-  return context_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void WireSpan::set_allocated_context(::std::string* context) {
-  if (context != NULL) {
-    
-  } else {
-    
-  }
-  context_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), context);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.util.tracing.WireSpan.context)
+  trace_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.util.tracing.Span.trace_id)
 }
 
-// optional bytes baggage = 2;
-inline void WireSpan::clear_baggage() {
-  baggage_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+// optional int64 span_id = 2;
+inline void Span::clear_span_id() {
+  span_id_ = GOOGLE_LONGLONG(0);
 }
-inline const ::std::string& WireSpan::baggage() const {
-  // @@protoc_insertion_point(field_get:cockroach.util.tracing.WireSpan.baggage)
-  return baggage_.GetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+inline ::google::protobuf::int64 Span::span_id() const {
+  // @@protoc_insertion_point(field_get:cockroach.util.tracing.Span.span_id)
+  return span_id_;
 }
-inline void WireSpan::set_baggage(const ::std::string& value) {
+inline void Span::set_span_id(::google::protobuf::int64 value) {
   
-  baggage_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:cockroach.util.tracing.WireSpan.baggage)
+  span_id_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.util.tracing.Span.span_id)
 }
-inline void WireSpan::set_baggage(const char* value) {
+
+// optional bool sampled = 3;
+inline void Span::clear_sampled() {
+  sampled_ = false;
+}
+inline bool Span::sampled() const {
+  // @@protoc_insertion_point(field_get:cockroach.util.tracing.Span.sampled)
+  return sampled_;
+}
+inline void Span::set_sampled(bool value) {
   
-  baggage_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:cockroach.util.tracing.WireSpan.baggage)
+  sampled_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.util.tracing.Span.sampled)
 }
-inline void WireSpan::set_baggage(const void* value, size_t size) {
-  
-  baggage_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:cockroach.util.tracing.WireSpan.baggage)
+
+// map<string, string> baggage = 4;
+inline int Span::baggage_size() const {
+  return baggage_.size();
 }
-inline ::std::string* WireSpan::mutable_baggage() {
-  
-  // @@protoc_insertion_point(field_mutable:cockroach.util.tracing.WireSpan.baggage)
-  return baggage_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+inline void Span::clear_baggage() {
+  baggage_.Clear();
 }
-inline ::std::string* WireSpan::release_baggage() {
-  
-  return baggage_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+Span::baggage() const {
+  // @@protoc_insertion_point(field_map:cockroach.util.tracing.Span.baggage)
+  return baggage_.GetMap();
 }
-inline void WireSpan::set_allocated_baggage(::std::string* baggage) {
-  if (baggage != NULL) {
-    
-  } else {
-    
-  }
-  baggage_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), baggage);
-  // @@protoc_insertion_point(field_set_allocated:cockroach.util.tracing.WireSpan.baggage)
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+Span::mutable_baggage() {
+  // @@protoc_insertion_point(field_mutable_map:cockroach.util.tracing.Span.baggage)
+  return baggage_.MutableMap();
 }
 
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/util/tracing/span.go
+++ b/util/tracing/span.go
@@ -1,0 +1,48 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package tracing
+
+import basictracer "github.com/opentracing/basictracer-go"
+
+var _ basictracer.DelegatingCarrier = &Span{}
+
+// SetState implements basictracer.DelegatingCarrier.
+func (sp *Span) SetState(traceID, spanID int64, sampled bool) {
+	sp.TraceID = traceID
+	sp.SpanID = spanID
+	sp.Sampled = sampled
+}
+
+// State implements basictracer.DelegatingCarrier.
+func (sp *Span) State() (traceID, spanID int64, sampled bool) {
+	return sp.TraceID, sp.SpanID, sp.Sampled
+}
+
+// SetBaggageItem implements basictracer.DelegatingCarrier.
+func (sp *Span) SetBaggageItem(key, value string) {
+	if sp.Baggage == nil {
+		sp.Baggage = make(map[string]string)
+	}
+	sp.Baggage[key] = value
+}
+
+// GetBaggage implements basictracer.DelegatingCarrier.
+func (sp *Span) GetBaggage(fn func(key, value string)) {
+	for k, v := range sp.Baggage {
+		fn(k, v)
+	}
+}

--- a/util/tracing/span.proto
+++ b/util/tracing/span.proto
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-// Author: Tobias Schottdorf
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
 
 syntax = "proto3";
 package cockroach.util.tracing;
@@ -20,12 +20,12 @@ option go_package = "tracing";
 
 import weak "gogoproto/gogo.proto";
 
-// A WireSpan message holds the serialized meta information of a (potentially
-// ongoing) span of a distributed trace as per the OpenTracing specification.
-// See http://opentracing.io/spec/ for details.
-message WireSpan {
-  // context is the serialized span context.
-  bytes context = 1;
-  // baggage is the serialized trace baggage.
-  bytes baggage = 2;
+// A Span message holds metadata of a (potentially ongoing) span of a
+// distributed trace as per the OpenTracing specification. See
+// http://opentracing.io/spec/ for details.
+message Span {
+  int64 trace_id = 1 [(gogoproto.customname) = "TraceID"];
+  int64 span_id = 2 [(gogoproto.customname) = "SpanID"];
+  bool sampled = 3;
+  map<string, string> baggage = 4;
 }


### PR DESCRIPTION
Introduced this carrier type upstream. It allows us to embed the Span
information directly into our protos.
Will run the benchmarks since now we always embed a Span in outgoing RPCs.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4902)

<!-- Reviewable:end -->
