### PR TITLE
acceptance: log docker-spy output

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -eu
 
 image="cockroachdb/builder"
-version="20160305-182433"
+version="20160305-182433"  # keep in sync with acceptance/cluster/localcluster.go
 
 function init() {
   docker build --tag="${image}" "$(dirname $0)"

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -135,7 +135,8 @@ ls -lah "${builder_dir}"
 # image) are updated.
 fetch_docker "cockroachdb" "builder" $($(dirname $0)/builder.sh version)
 
-fetch_docker "cockroachdb" "docker-spy" "20160209-143235"
+# Keep the tag in sync with acceptance/cluster/localcluster.go
+fetch_docker "cockroachdb" "docker-spy" "20160306-214457"
 
 if is_shard 0; then
   # Dockerfile at: https://github.com/cockroachdb/postgres-test


### PR DESCRIPTION
Trying to track down DNS failures as seen in #4894..

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4924)

<!-- Reviewable:end -->
