### PR TITLE
storage: In multiTestContext, give each store its own Gossip

### DIFF
--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -50,7 +50,7 @@ func startGossip(nodeID roachpb.NodeID, stopper *stop.Stopper, t *testing.T) *Go
 	if err != nil {
 		t.Fatal(err)
 	}
-	g := New(rpcContext, TestBootstrap, stopper)
+	g := New(rpcContext, nil, stopper)
 	g.SetNodeID(nodeID)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{
 		NodeID:  nodeID,
@@ -114,7 +114,7 @@ func startFakeServerGossips(t *testing.T) (local *Gossip, remote *fakeGossipServ
 	if err != nil {
 		t.Fatal(err)
 	}
-	local = New(lRPCContext, TestBootstrap, stopper)
+	local = New(lRPCContext, nil, stopper)
 	local.start(lserver, lln.Addr())
 
 	rRPCContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -104,11 +104,6 @@ const (
 	defaultCullInterval = 60 * time.Second
 )
 
-var (
-	// TestBootstrap is the default gossip bootstrap used for running tests.
-	TestBootstrap = []resolver.Resolver{}
-)
-
 // Storage is an interface which allows the gossip instance
 // to read and write bootstrapping data to persistent storage
 // between instantiations.

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -40,7 +40,7 @@ func TestGossipInfoStore(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	rpcContext := rpc.NewContext(nil, nil, stopper)
-	g := New(rpcContext, TestBootstrap, stopper)
+	g := New(rpcContext, nil, stopper)
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	slice := []byte("b")

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -74,7 +74,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester) {
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano)
 	ltc.Stopper = stop.NewStopper()
 	rpcContext := rpc.NewContext(testutils.NewNodeTestBaseContext(), ltc.Clock, ltc.Stopper)
-	ltc.Gossip = gossip.New(rpcContext, gossip.TestBootstrap, ltc.Stopper)
+	ltc.Gossip = gossip.New(rpcContext, nil, ltc.Stopper)
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20, ltc.Stopper)
 
 	ltc.stores = storage.NewStores(ltc.Clock)

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -165,7 +165,7 @@ func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator
 	stopper := stop.NewStopper()
 	clock := hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(nil, clock, stopper)
-	g := gossip.New(rpcContext, gossip.TestBootstrap, stopper)
+	g := gossip.New(rpcContext, nil, stopper)
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	storePool := NewStorePool(g, clock, TestTimeUntilStoreDeadOff, stopper)

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -568,7 +568,7 @@ func getRangeMetadata(key roachpb.RKey, mtc *multiTestContext, t *testing.T) roa
 		MaxRanges: 1,
 	})
 	var reply *roachpb.RangeLookupResponse
-	if br, err := mtc.db.RunWithResponse(b); err != nil {
+	if br, err := mtc.dbs[0].RunWithResponse(b); err != nil {
 		t.Fatalf("error getting range metadata: %s", err)
 	} else {
 		reply = br.Responses[0].GetInner().(*roachpb.RangeLookupResponse)

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1056,7 +1056,7 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 		NodeID:    roachpb.NodeID(mtc.stores[2].StoreID()),
 		StoreID:   mtc.stores[2].StoreID(),
 	}
-	if err := mtc.transport.Send(&storage.RaftMessageRequest{
+	if err := mtc.transports[2].Send(&storage.RaftMessageRequest{
 		GroupID:     0,
 		ToReplica:   replica1,
 		FromReplica: replica2,

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -750,7 +750,7 @@ func setupSplitSnapshotRace(t *testing.T) (mtc *multiTestContext, leftKey roachp
 
 	// Split the data range.
 	splitArgs = adminSplitArgs(keys.SystemMax, roachpb.Key("m"))
-	if _, pErr := client.SendWrapped(mtc.distSender, nil, &splitArgs); pErr != nil {
+	if _, pErr := client.SendWrapped(mtc.distSenders[0], nil, &splitArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -782,7 +782,7 @@ func setupSplitSnapshotRace(t *testing.T) (mtc *multiTestContext, leftKey roachp
 	// failure and render the range unable to achieve quorum after
 	// restart (in the SnapshotWins branch).
 	incArgs = incrementArgs(rightKey, 3)
-	if _, pErr := client.SendWrapped(mtc.distSender, nil, &incArgs); pErr != nil {
+	if _, pErr := client.SendWrapped(mtc.distSenders[0], nil, &incArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -816,7 +816,7 @@ func TestSplitSnapshotRace_SplitWins(t *testing.T) {
 
 	// Perform a write on the left range and wait for it to propagate.
 	incArgs := incrementArgs(leftKey, 10)
-	if _, pErr := client.SendWrapped(mtc.distSender, nil, &incArgs); pErr != nil {
+	if _, pErr := client.SendWrapped(mtc.distSenders[0], nil, &incArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 	mtc.waitForValues(leftKey, []int64{0, 11, 11, 11, 0, 0})
@@ -827,7 +827,7 @@ func TestSplitSnapshotRace_SplitWins(t *testing.T) {
 
 	// Write to the right range.
 	incArgs = incrementArgs(rightKey, 20)
-	if _, pErr := client.SendWrapped(mtc.distSender, nil, &incArgs); pErr != nil {
+	if _, pErr := client.SendWrapped(mtc.distSenders[0], nil, &incArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 	mtc.waitForValues(rightKey, []int64{0, 0, 0, 25, 25, 25})
@@ -849,7 +849,7 @@ func TestSplitSnapshotRace_SnapshotWins(t *testing.T) {
 
 	// Perform a write on the right range.
 	incArgs := incrementArgs(rightKey, 20)
-	if _, pErr := client.SendWrapped(mtc.distSender, nil, &incArgs); pErr != nil {
+	if _, pErr := client.SendWrapped(mtc.distSenders[0], nil, &incArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -873,13 +873,13 @@ func TestSplitSnapshotRace_SnapshotWins(t *testing.T) {
 	// it helps wake up dormant ranges that would otherwise have to wait
 	// for retry timeouts.
 	incArgs = incrementArgs(leftKey, 10)
-	if _, pErr := client.SendWrapped(mtc.distSender, nil, &incArgs); pErr != nil {
+	if _, pErr := client.SendWrapped(mtc.distSenders[0], nil, &incArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 	mtc.waitForValues(leftKey, []int64{0, 11, 11, 11, 0, 0})
 
 	incArgs = incrementArgs(rightKey, 200)
-	if _, pErr := client.SendWrapped(mtc.distSender, nil, &incArgs); pErr != nil {
+	if _, pErr := client.SendWrapped(mtc.distSenders[0], nil, &incArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 	mtc.waitForValues(rightKey, []int64{0, 0, 0, 225, 225, 225})
@@ -990,17 +990,17 @@ func TestLeaderAfterSplit(t *testing.T) {
 	rightKey := roachpb.Key("z")
 
 	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
-	if _, pErr := client.SendWrapped(mtc.distSender, nil, &splitArgs); pErr != nil {
+	if _, pErr := client.SendWrapped(mtc.distSenders[0], nil, &splitArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 
 	incArgs := incrementArgs(leftKey, 1)
-	if _, pErr := client.SendWrapped(mtc.distSender, nil, &incArgs); pErr != nil {
+	if _, pErr := client.SendWrapped(mtc.distSenders[0], nil, &incArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 
 	incArgs = incrementArgs(rightKey, 2)
-	if _, pErr := client.SendWrapped(mtc.distSender, nil, &incArgs); pErr != nil {
+	if _, pErr := client.SendWrapped(mtc.distSenders[0], nil, &incArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -38,7 +38,7 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/kr/pretty"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -163,11 +163,9 @@ type multiTestContext struct {
 	storeContext *storage.StoreContext
 	manualClock  *hlc.ManualClock
 	clock        *hlc.Clock
-	grpcServer   *grpc.Server
 	rpcContext   *rpc.Context
 	gossip       *gossip.Gossip
 	storePool    *storage.StorePool
-	transport    *storage.RaftTransport
 	distSender   *kv.DistSender
 	db           *client.DB
 
@@ -176,12 +174,16 @@ type multiTestContext struct {
 	// The per-store clocks slice normally contains aliases of
 	// multiTestContext.clock, but it may be populated before Start() to
 	// use distinct clocks per store.
-	clocks  []*hlc.Clock
-	engines []engine.Engine
+	clocks      []*hlc.Clock
+	engines     []engine.Engine
+	grpcServers []*grpc.Server
+	transports  []*storage.RaftTransport
 	// We use multiple stoppers so we can restart different parts of the
 	// test individually. clientStopper is for 'db', transportStopper is
-	// for 'transport', and the 'stoppers' slice corresponds to the
+	// for 'transports', and the 'stoppers' slice corresponds to the
 	// 'stores'.
+	// TODO(bdarnell): now that there are multiple transports, do we
+	// need transportStopper?
 	clientStopper      *stop.Stopper
 	transportStopper   *stop.Stopper
 	engineStoppers     []*stop.Stopper
@@ -247,12 +249,6 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	}
 	if m.clientStopper == nil {
 		m.clientStopper = stop.NewStopper()
-	}
-	if m.grpcServer == nil {
-		m.grpcServer = rpc.NewServer(m.rpcContext)
-	}
-	if m.transport == nil {
-		m.transport = storage.NewRaftTransport(m.getNodeIDAddress, m.grpcServer, m.rpcContext)
 	}
 	if m.storePool == nil {
 		if m.timeUntilStoreDead == 0 {
@@ -471,10 +467,10 @@ func (m *multiTestContext) makeContext(i int) storage.StoreContext {
 		ctx = storage.TestStoreContext()
 	}
 	ctx.Clock = m.clocks[i]
+	ctx.Transport = m.transports[i]
 	ctx.DB = m.db
 	ctx.Gossip = m.gossip
 	ctx.StorePool = m.storePool
-	ctx.Transport = m.transport
 	return ctx
 }
 
@@ -500,6 +496,13 @@ func (m *multiTestContext) addStore() {
 		eng = engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)
 		m.engines = append(m.engines, eng)
 		needBootstrap = true
+	}
+	if len(m.grpcServers) <= idx {
+		m.grpcServers = append(m.grpcServers, rpc.NewServer(m.rpcContext))
+	}
+	if len(m.transports) <= idx {
+		m.transports = append(m.transports,
+			storage.NewRaftTransport(m.getNodeIDAddress, m.grpcServers[idx], m.rpcContext))
 	}
 
 	stopper := stop.NewStopper()
@@ -531,7 +534,7 @@ func (m *multiTestContext) addStore() {
 	if m.nodeIDtoAddr == nil {
 		m.nodeIDtoAddr = make(map[roachpb.NodeID]net.Addr)
 	}
-	ln, err := util.ListenAndServe(m.transportStopper, m.grpcServer, util.CreateTestAddr("tcp"), tlsConfig)
+	ln, err := util.ListenAndServe(m.transportStopper, m.grpcServers[idx], util.CreateTestAddr("tcp"), tlsConfig)
 	if err != nil {
 		m.t.Fatal(err)
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -26,12 +26,10 @@ package storage_test
 
 import (
 	"fmt"
-	"math"
 	"math/rand"
 	"net"
 	"reflect"
 	"sort"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -46,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -121,9 +120,10 @@ func createTestStoreWithEngine(t testing.TB, eng engine.Engine, clock *hlc.Clock
 		return br, nil
 	}
 
-	if err := gossipNodeDesc(sCtx.Gossip, nodeDesc.NodeID); err != nil {
+	if err := sCtx.Gossip.SetNodeDescriptor(nodeDesc); err != nil {
 		t.Fatal(err)
 	}
+
 	retryOpts := kv.GetDefaultDistSenderRetryOptions()
 	retryOpts.Closer = stopper.ShouldDrain()
 	distSender := kv.NewDistSender(&kv.DistSenderContext{
@@ -164,8 +164,6 @@ type multiTestContext struct {
 	manualClock  *hlc.ManualClock
 	clock        *hlc.Clock
 	rpcContext   *rpc.Context
-	gossip       *gossip.Gossip
-	storePool    *storage.StorePool
 
 	nodeIDtoAddr map[roachpb.NodeID]net.Addr
 
@@ -178,6 +176,8 @@ type multiTestContext struct {
 	transports  []*storage.RaftTransport
 	distSenders []*kv.DistSender
 	dbs         []*client.DB
+	gossips     []*gossip.Gossip
+	storePools  []*storage.StorePool
 	// We use multiple stoppers so we can restart different parts of the
 	// test individually. clientStopper is for 'db', transportStopper is
 	// for 'transports', and the 'stoppers' slice corresponds to the
@@ -243,18 +243,8 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	if m.rpcContext == nil {
 		m.rpcContext = rpc.NewContext(&base.Context{Insecure: true}, m.clock, m.transportStopper)
 	}
-	if m.gossip == nil {
-		m.gossip = gossip.New(m.rpcContext, gossip.TestBootstrap, m.transportStopper)
-		m.gossip.SetNodeID(math.MaxInt32)
-	}
 	if m.clientStopper == nil {
 		m.clientStopper = stop.NewStopper()
-	}
-	if m.storePool == nil {
-		if m.timeUntilStoreDead == 0 {
-			m.timeUntilStoreDead = storage.TestTimeUntilStoreDeadOff
-		}
-		m.storePool = storage.NewStorePool(m.gossip, m.clock, m.timeUntilStoreDead, m.clientStopper)
 	}
 
 	for i := 0; i < numStores; i++ {
@@ -263,8 +253,10 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 
 	// Wait for gossip to startup.
 	util.SucceedsSoon(t, func() error {
-		if m.gossip.GetSystemConfig() == nil {
-			return util.Errorf("system config not available")
+		for i, g := range m.gossips {
+			if g.GetSystemConfig() == nil {
+				return util.Errorf("system config not available at index %d", i)
+			}
 		}
 		return nil
 	})
@@ -317,6 +309,9 @@ func (m *multiTestContext) Stop() {
 // used to multiplex calls between many local senders in a simple way; It sends
 // the request to multiTestContext's localSenders specified in addrs. The request is
 // sent in order until no error is returned.
+// TODO(bdarnell): This is mostly obsolete now that we have a real network
+// stack available. However, it's still needed to handle the interaction
+// with our manual clock in the event of retries.
 func (m *multiTestContext) rpcSend(_ kv.SendOptions, replicas kv.ReplicaSlice,
 	ba roachpb.BatchRequest, _ *rpc.Context) (*roachpb.BatchResponse, error) {
 	m.mu.RLock()
@@ -333,12 +328,14 @@ func (m *multiTestContext) rpcSend(_ kv.SendOptions, replicas kv.ReplicaSlice,
 			txnClone := ba.Txn.Clone()
 			ba.Txn = &txnClone
 		}
-		// Node ID is encoded in the address.
-		nodeID, stErr := strconv.Atoi(replica.NodeDesc.Address.String())
-		if stErr != nil {
-			m.t.Fatal(stErr)
+		// Reverse-map the address to its index.
+		var nodeIndex int
+		for i, addr := range m.nodeIDtoAddr {
+			if addr.String() == replica.NodeDesc.Address.String() {
+				nodeIndex = int(i) - 1
+				break
+			}
 		}
-		nodeIndex := nodeID - 1
 		// The rpcSend method crosses store boundaries: it is possible that the
 		// destination store is stopped while the source is still running.
 		// Run the send in a Task on the destination store to simulate what
@@ -455,8 +452,8 @@ func (m *multiTestContext) makeContext(i int) storage.StoreContext {
 	ctx.Clock = m.clocks[i]
 	ctx.Transport = m.transports[i]
 	ctx.DB = m.dbs[i]
-	ctx.Gossip = m.gossip
-	ctx.StorePool = m.storePool
+	ctx.Gossip = m.gossips[i]
+	ctx.StorePool = m.storePools[i]
 	return ctx
 }
 
@@ -490,6 +487,27 @@ func (m *multiTestContext) addStore() {
 		m.transports = append(m.transports,
 			storage.NewRaftTransport(m.getNodeIDAddress, m.grpcServers[idx], m.rpcContext))
 	}
+	if len(m.gossips) <= idx {
+		// Give this store all previous stores as gossip bootstraps.
+		var resolvers []resolver.Resolver
+		m.mu.Lock()
+		for _, addr := range m.nodeIDtoAddr {
+			r, err := resolver.NewResolverFromAddress(addr)
+			if err != nil {
+				m.t.Fatal(err)
+			}
+			resolvers = append(resolvers, r)
+		}
+		m.mu.Unlock()
+		m.gossips = append(m.gossips, gossip.New(m.rpcContext, resolvers, m.transportStopper))
+		m.gossips[idx].SetNodeID(roachpb.NodeID(idx + 1))
+	}
+	if len(m.storePools) <= idx {
+		if m.timeUntilStoreDead == 0 {
+			m.timeUntilStoreDead = storage.TestTimeUntilStoreDeadOff
+		}
+		m.storePools = append(m.storePools, storage.NewStorePool(m.gossips[idx], m.clock, m.timeUntilStoreDead, m.clientStopper))
+	}
 	if len(m.dbs) <= idx {
 		retryOpts := kv.GetDefaultDistSenderRetryOptions()
 		retryOpts.Closer = m.clientStopper.ShouldDrain()
@@ -499,7 +517,7 @@ func (m *multiTestContext) addStore() {
 				RangeDescriptorDB: m,
 				RPCSend:           m.rpcSend,
 				RPCRetryOptions:   &retryOpts,
-			}, m.gossip))
+			}, m.gossips[idx]))
 		sender := kv.NewTxnCoordSender(m.distSenders[idx], m.clock, false, tracing.NewTracer(),
 			m.clientStopper, kv.NewTxnMetrics(metric.NewRegistry()))
 		m.dbs = append(m.dbs, client.NewDB(sender))
@@ -547,6 +565,7 @@ func (m *multiTestContext) addStore() {
 	if ok {
 		m.t.Fatalf("node %d already listening", nodeID)
 	}
+	m.gossips[idx].Start(m.grpcServers[idx], ln.Addr())
 	// Add newly created objects to the multiTestContext's collections.
 	// (these must be populated before the store is started so that
 	// FirstRange() can find the sender)
@@ -560,14 +579,10 @@ func (m *multiTestContext) addStore() {
 	// replication operations even while the store is stopped.
 	m.idents = append(m.idents, store.Ident)
 	m.mu.Unlock()
-	// Because we use a single gossip instance, make sure we always
-	// reset the node ID before setting the node descriptor and calling
-	// start.
-	m.gossip.ResetNodeID(0)
 	if err := store.Start(stopper); err != nil {
 		m.t.Fatal(err)
 	}
-	if err := gossipNodeDesc(m.gossip, nodeID); err != nil {
+	if err := m.gossipNodeDesc(m.gossips[idx], nodeID); err != nil {
 		m.t.Fatal(err)
 	}
 	store.WaitForInit()
@@ -575,12 +590,11 @@ func (m *multiTestContext) addStore() {
 
 // gossipNodeDesc adds the node descriptor to the gossip network.
 // Mostly makes sure that we don't see a warning per request.
-func gossipNodeDesc(g *gossip.Gossip, nodeID roachpb.NodeID) error {
+func (m *multiTestContext) gossipNodeDesc(g *gossip.Gossip, nodeID roachpb.NodeID) error {
+	addr := m.nodeIDtoAddr[nodeID]
 	nodeDesc := &roachpb.NodeDescriptor{
-		NodeID: nodeID,
-		// Encode the node ID in the address so that rpcSend
-		// can figure out where requests must be sent.
-		Address: util.MakeUnresolvedAddr("localhost", fmt.Sprintf("%d", nodeID)),
+		NodeID:  nodeID,
+		Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),
 	}
 	if err := g.SetNodeDescriptor(nodeDesc); err != nil {
 		return err
@@ -607,8 +621,6 @@ func (m *multiTestContext) restartStore(i int) {
 
 	ctx := m.makeContext(i)
 	m.stores[i] = storage.NewStore(ctx, m.engines[i], &roachpb.NodeDescriptor{NodeID: roachpb.NodeID(i + 1)})
-	// Because we use a single gossip instance, reset node ID before calling Start().
-	m.gossip.ResetNodeID(0)
 	if err := m.stores[i].Start(m.stoppers[i]); err != nil {
 		m.t.Fatal(err)
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -166,8 +166,6 @@ type multiTestContext struct {
 	rpcContext   *rpc.Context
 	gossip       *gossip.Gossip
 	storePool    *storage.StorePool
-	distSender   *kv.DistSender
-	db           *client.DB
 
 	nodeIDtoAddr map[roachpb.NodeID]net.Addr
 
@@ -178,6 +176,8 @@ type multiTestContext struct {
 	engines     []engine.Engine
 	grpcServers []*grpc.Server
 	transports  []*storage.RaftTransport
+	distSenders []*kv.DistSender
+	dbs         []*client.DB
 	// We use multiple stoppers so we can restart different parts of the
 	// test individually. clientStopper is for 'db', transportStopper is
 	// for 'transports', and the 'stoppers' slice corresponds to the
@@ -255,20 +255,6 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 			m.timeUntilStoreDead = storage.TestTimeUntilStoreDeadOff
 		}
 		m.storePool = storage.NewStorePool(m.gossip, m.clock, m.timeUntilStoreDead, m.clientStopper)
-	}
-
-	if m.db == nil {
-		retryOpts := kv.GetDefaultDistSenderRetryOptions()
-		retryOpts.Closer = m.clientStopper.ShouldDrain()
-		m.distSender = kv.NewDistSender(&kv.DistSenderContext{
-			Clock:             m.clock,
-			RangeDescriptorDB: m,
-			RPCSend:           m.rpcSend,
-			RPCRetryOptions:   &retryOpts,
-		}, m.gossip)
-		sender := kv.NewTxnCoordSender(m.distSender, m.clock, false, tracing.NewTracer(),
-			m.clientStopper, kv.NewTxnMetrics(metric.NewRegistry()))
-		m.db = client.NewDB(sender)
 	}
 
 	for i := 0; i < numStores; i++ {
@@ -456,7 +442,7 @@ func (m *multiTestContext) RangeLookup(key roachpb.RKey, desc *roachpb.RangeDesc
 	// DistSender's RangeLookup function will work correctly, as long as
 	// multiTestContext's FirstRange() method returns the correct descriptor for the
 	// first range.
-	return m.distSender.RangeLookup(key, desc, considerIntents, useReverseScan)
+	return m.distSenders[0].RangeLookup(key, desc, considerIntents, useReverseScan)
 }
 
 func (m *multiTestContext) makeContext(i int) storage.StoreContext {
@@ -468,7 +454,7 @@ func (m *multiTestContext) makeContext(i int) storage.StoreContext {
 	}
 	ctx.Clock = m.clocks[i]
 	ctx.Transport = m.transports[i]
-	ctx.DB = m.db
+	ctx.DB = m.dbs[i]
 	ctx.Gossip = m.gossip
 	ctx.StorePool = m.storePool
 	return ctx
@@ -503,6 +489,20 @@ func (m *multiTestContext) addStore() {
 	if len(m.transports) <= idx {
 		m.transports = append(m.transports,
 			storage.NewRaftTransport(m.getNodeIDAddress, m.grpcServers[idx], m.rpcContext))
+	}
+	if len(m.dbs) <= idx {
+		retryOpts := kv.GetDefaultDistSenderRetryOptions()
+		retryOpts.Closer = m.clientStopper.ShouldDrain()
+		m.distSenders = append(m.distSenders,
+			kv.NewDistSender(&kv.DistSenderContext{
+				Clock:             m.clock,
+				RangeDescriptorDB: m,
+				RPCSend:           m.rpcSend,
+				RPCRetryOptions:   &retryOpts,
+			}, m.gossip))
+		sender := kv.NewTxnCoordSender(m.distSenders[idx], m.clock, false, tracing.NewTracer(),
+			m.clientStopper, kv.NewTxnMetrics(metric.NewRegistry()))
+		m.dbs = append(m.dbs, client.NewDB(sender))
 	}
 
 	stopper := stop.NewStopper()
@@ -672,7 +672,7 @@ func (m *multiTestContext) replicateRange(rangeID roachpb.RangeID, dests ...int)
 		// By the time ChangeReplicas returns the raft leader is
 		// guaranteed to have the updated version, but followers are not.
 		var desc roachpb.RangeDescriptor
-		if err := m.db.GetProto(keys.RangeDescriptorKey(startKey), &desc); err != nil {
+		if err := m.dbs[0].GetProto(keys.RangeDescriptorKey(startKey), &desc); err != nil {
 			m.t.Fatal(err)
 		}
 
@@ -712,7 +712,7 @@ func (m *multiTestContext) unreplicateRange(rangeID roachpb.RangeID, dest int) {
 	startKey := m.findStartKeyLocked(rangeID)
 
 	var desc roachpb.RangeDescriptor
-	if err := m.db.GetProto(keys.RangeDescriptorKey(startKey), &desc); err != nil {
+	if err := m.dbs[0].GetProto(keys.RangeDescriptorKey(startKey), &desc); err != nil {
 		m.t.Fatal(err)
 	}
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -102,7 +102,7 @@ func createTestStoreWithEngine(t testing.TB, eng engine.Engine, clock *hlc.Clock
 		sCtx = &ctx
 	}
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
-	sCtx.Gossip = gossip.New(rpcContext, gossip.TestBootstrap, stopper)
+	sCtx.Gossip = gossip.New(rpcContext, nil, stopper)
 	sCtx.Gossip.SetNodeID(nodeDesc.NodeID)
 	sCtx.ScanMaxIdleTime = 1 * time.Second
 	sCtx.Tracer = tracing.NewTracer()

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -40,7 +40,7 @@ func gossipForTest(t *testing.T) (*gossip.Gossip, *stop.Stopper) {
 	config.TestingSetupZoneConfigHook(stopper)
 
 	rpcContext := rpc.NewContext(nil, nil, stopper)
-	g := gossip.New(rpcContext, gossip.TestBootstrap, stopper)
+	g := gossip.New(rpcContext, nil, stopper)
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	// Put an empty system config into gossip.

--- a/storage/raft_transport_test.go
+++ b/storage/raft_transport_test.go
@@ -62,7 +62,7 @@ func TestSendAndReceive(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	nodeRPCContext := rpc.NewContext(testutils.NewNodeTestBaseContext(), nil, stopper)
-	g := gossip.New(nodeRPCContext, gossip.TestBootstrap, stopper)
+	g := gossip.New(nodeRPCContext, nil, stopper)
 	g.SetNodeID(roachpb.NodeID(1))
 
 	// Create several servers, each of which has two stores (A raft
@@ -231,7 +231,7 @@ func TestInOrderDelivery(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	nodeRPCContext := rpc.NewContext(testutils.NewNodeTestBaseContext(), nil, stopper)
-	g := gossip.New(nodeRPCContext, gossip.TestBootstrap, stopper)
+	g := gossip.New(nodeRPCContext, nil, stopper)
 
 	grpcServer := rpc.NewServer(nodeRPCContext)
 	tlsConfig, err := nodeRPCContext.GetServerTLSConfig()

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -114,7 +114,7 @@ func (tc *testContext) StartWithStoreContext(t testing.TB, ctx StoreContext) {
 	config.TestingSetupZoneConfigHook(tc.stopper)
 	if tc.gossip == nil {
 		rpcContext := rpc.NewContext(nil, nil, tc.stopper)
-		tc.gossip = gossip.New(rpcContext, gossip.TestBootstrap, tc.stopper)
+		tc.gossip = gossip.New(rpcContext, nil, tc.stopper)
 		tc.gossip.SetNodeID(1)
 	}
 	if tc.manualClock == nil {

--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -68,7 +68,7 @@ type Cluster struct {
 func createCluster(stopper *stop.Stopper, nodeCount int, epochWriter, actionWriter io.Writer, script Script, rand *rand.Rand) *Cluster {
 	clock := hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(nil, clock, stopper)
-	g := gossip.New(rpcContext, gossip.TestBootstrap, stopper)
+	g := gossip.New(rpcContext, nil, stopper)
 	storePool := storage.NewStorePool(g, clock, storage.TestTimeUntilStoreDeadOff, stopper)
 	c := &Cluster{
 		stopper:   stopper,

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -56,7 +56,7 @@ func createTestStorePool(timeUntilStoreDead time.Duration) (*stop.Stopper, *goss
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
 	rpcContext := rpc.NewContext(nil, clock, stopper)
-	g := gossip.New(rpcContext, gossip.TestBootstrap, stopper)
+	g := gossip.New(rpcContext, nil, stopper)
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	storePool := NewStorePool(g, clock, timeUntilStoreDead, stopper)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -128,7 +128,7 @@ func createTestStoreWithoutStart(t *testing.T, ctx *StoreContext) (*Store, *hlc.
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
 	rpcContext := rpc.NewContext(nil, nil, stopper)
-	ctx.Gossip = gossip.New(rpcContext, gossip.TestBootstrap, stopper)
+	ctx.Gossip = gossip.New(rpcContext, nil, stopper)
 	ctx.Gossip.SetNodeID(1)
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)


### PR DESCRIPTION
Removes a problematic use of ResetNodeID which could result in panics.

Also move other pieces of `multiTestContext` from shared objects to per-store fields as needed to change Gossip.

Fixes #4821

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4926)

<!-- Reviewable:end -->
