### PR TITLE
acceptance: Replace docker-spy with docker's dns

### DIFF
--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/network"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/util/log"
@@ -100,8 +101,8 @@ func pullImage(l *LocalCluster, options types.ImagePullOptions) error {
 // createContainer creates a new container using the specified options. Per the
 // docker API, the created container is not running and must be started
 // explicitly.
-func createContainer(l *LocalCluster, containerConfig container.Config, hostConfig container.HostConfig, containerName string) (*Container, error) {
-	resp, err := l.client.ContainerCreate(&containerConfig, &hostConfig, nil, containerName)
+func createContainer(l *LocalCluster, containerConfig container.Config, hostConfig container.HostConfig, networkConfig *network.NetworkingConfig, containerName string) (*Container, error) {
+	resp, err := l.client.ContainerCreate(&containerConfig, &hostConfig, networkConfig, containerName)
 	if err != nil {
 		return nil, err
 	}

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -135,8 +135,6 @@ ls -lah "${builder_dir}"
 # image) are updated.
 fetch_docker "cockroachdb" "builder" $($(dirname $0)/builder.sh version)
 
-fetch_docker "cockroachdb" "docker-spy" "20160209-143235"
-
 if is_shard 0; then
   # Dockerfile at: https://github.com/cockroachdb/postgres-test
   fetch_docker "cockroachdb" "postgres-test" "20160203-140220"


### PR DESCRIPTION
Unfortunately this does not seem to fix #4894; I still see similar-looking failures locally.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4927)

<!-- Reviewable:end -->
