### PR TITLE
acceptance: use the same docker tag for building and running

### DIFF
--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -45,9 +45,8 @@ import (
 )
 
 const (
-	builderImage = "cockroachdb/builder"
-	builderTag   = "20160218-125307"
-
+	builderImage     = "cockroachdb/builder"
+	builderTag       = "20160305-182433"
 	builderImageFull = builderImage + ":" + builderTag
 )
 

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -242,16 +242,19 @@ func testDockerSuccess(t *testing.T, name string, cmd []string) {
 	}
 }
 
+const (
+	postgresTestTag = "20160203-140220"
+)
+
 func testDocker(t *testing.T, name string, cmd []string) error {
 	const image = "cockroachdb/postgres-test"
-	const tag = "20160203-140220"
 	SkipUnlessLocal(t)
 	l := StartCluster(t, readConfigFromFlags()).(*cluster.LocalCluster)
 
 	defer l.AssertAndStop(t)
 	addr := l.Nodes[0].Addr()
 	containerConfig := container.Config{
-		Image: fmt.Sprintf(image + ":" + tag),
+		Image: fmt.Sprintf(image + ":" + postgresTestTag),
 		Env: []string{
 			fmt.Sprintf("PGHOST=%s", addr.IP),
 			fmt.Sprintf("PGPORT=%d", addr.Port),
@@ -266,7 +269,7 @@ func testDocker(t *testing.T, name string, cmd []string) error {
 	}
 	ipo := types.ImagePullOptions{
 		ImageID: image,
-		Tag:     tag,
+		Tag:     postgresTestTag,
 	}
 	return l.OneShot(ipo, containerConfig, hostConfig, "docker-"+name)
 }

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,16 @@
 set -eu
 
 image="cockroachdb/builder"
-version="20160305-182433"
+
+# Grab the builder tag from the acceptance tests. We're looking for a
+# variable named builderTag, splitting the line on double quotes (")
+# and taking the second component.
+version=$(awk -F\" '/builderTag *=/ {print $2}' \
+            $(dirname $0)/../acceptance/cluster/localcluster.go)
+if [ -z "${version}" ]; then
+  echo "unable to determine builder tag"
+  exit 1
+fi
 
 function init() {
   docker build --tag="${image}" "$(dirname $0)"

--- a/build/circle-deps.sh
+++ b/build/circle-deps.sh
@@ -136,8 +136,15 @@ ls -lah "${builder_dir}"
 fetch_docker "cockroachdb" "builder" $($(dirname $0)/builder.sh version)
 
 if is_shard 0; then
+  # See the comment in build/builder.sh about this awk line.
+  postgresTestTag=$(awk -F\" '/postgresTestTag *=/ {print $2}' \
+                      $(dirname $0)/../acceptance/util_test.go)
+  if [ -z "${postgresTestTag}" ]; then
+    echo "unable to determine postgres-test tag"
+    exit 1
+  fi
   # Dockerfile at: https://github.com/cockroachdb/postgres-test
-  fetch_docker "cockroachdb" "postgres-test" "20160203-140220"
+  fetch_docker "cockroachdb" "postgres-test" "${postgresTestTag}"
 fi
 
 # Recursively invoke this script inside the builder docker container,


### PR DESCRIPTION
Ensure that the docker image tags are the same in build/circle-deps.sh
and their usage in the acceptance tests.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4928)

<!-- Reviewable:end -->
