### PR TITLE
sql: re-enable fast-path delete

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -163,7 +163,7 @@ func canDeleteWithoutScan(n *parser.Delete, rows planNode, indexCount int) bool 
 			}
 			return false
 		}
-		if n.Where != nil {
+		if scan := sel.table.node.(*scanNode); scan.filter != nil {
 			if log.V(2) {
 				log.Infof("delete forced to scan: values required for filter (%s)", sel.filter)
 			}


### PR DESCRIPTION
regression from #4713: `n.Where` is not usually nil, but often `scan.filter` is, if the WHERE was reduced to just spans.

```
name                    old time/op    new time/op    delta
Delete1_Cockroach-8        676µs ± 4%     547µs ± 1%  -19.17%  (p=0.000 n=10+10)
Delete10_Cockroach-8      2.10ms ± 1%    1.70ms ± 2%  -18.91%  (p=0.000 n=10+10)
Delete100_Cockroach-8     17.0ms ± 9%    13.5ms ± 2%  -20.33%  (p=0.000 n=10+10)
Delete1000_Cockroach-8     178ms ±10%     154ms ± 2%  -13.35%    (p=0.001 n=7+7)

name                    old alloc/op   new alloc/op   delta
Delete1_Cockroach-8       36.1kB ± 0%    30.0kB ± 0%  -16.98%  (p=0.000 n=10+10)
Delete10_Cockroach-8       110kB ± 0%      76kB ± 0%  -30.55%  (p=0.000 n=10+10)
Delete100_Cockroach-8      827kB ± 0%     541kB ± 0%  -34.59%  (p=0.000 n=10+10)
Delete1000_Cockroach-8    7.48MB ± 1%    4.87MB ± 1%  -34.92%   (p=0.000 n=7+10)

name                    old allocs/op  new allocs/op  delta
Delete1_Cockroach-8          696 ± 0%       570 ± 0%  -18.10%   (p=0.000 n=10+7)
Delete10_Cockroach-8       1.73k ± 0%     1.25k ± 0%  -27.60%   (p=0.000 n=10+8)
Delete100_Cockroach-8      11.6k ± 0%      7.8k ± 0%  -32.97%  (p=0.000 n=10+10)
Delete1000_Cockroach-8      110k ± 0%       73k ± 1%  -34.02%   (p=0.000 n=7+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4941)

<!-- Reviewable:end -->
