### PR TITLE
Rename stats `pgwire.*` to `sql.*`

### DIFF
--- a/server/testserver.go
+++ b/server/testserver.go
@@ -342,9 +342,10 @@ func (ts *TestServer) MustGetSQLCounter(name string) int64 {
 	return c
 }
 
-// MustGetPGWireCounter returns the value of a counter metric from the server's
-// PGWire server. Runs in O(# of metrics) time, which is fine for test code.
-func (ts *TestServer) MustGetPGWireCounter(name string) int64 {
+// MustGetSQLNetworkCounter returns the value of a counter metric from the
+// server's SQL server. Runs in O(# of metrics) time, which is fine for test
+// code.
+func (ts *TestServer) MustGetSQLNetworkCounter(name string) int64 {
 	var c int64
 	var found bool
 

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -183,8 +183,8 @@ type Executor struct {
 
 // NewExecutor creates an Executor and registers a callback on the
 // system config.
-func NewExecutor(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, stopper *stop.Stopper) *Executor {
-	registry := metric.NewRegistry()
+func NewExecutor(db client.DB, gossip *gossip.Gossip, leaseMgr *LeaseManager, stopper *stop.Stopper,
+	registry *metric.Registry) *Executor {
 	exec := &Executor{
 		db:       db,
 		reCache:  parser.NewRegexpCache(512),

--- a/sql/pgwire/server.go
+++ b/sql/pgwire/server.go
@@ -58,10 +58,8 @@ type serverMetrics struct {
 	conns         *metric.Counter
 }
 
-// MakeServer creates a Server.
-func MakeServer(context *base.Context, executor *sql.Executor) Server {
-	// Create a registry to hold pgwire stats.
-	reg := metric.NewRegistry()
+// MakeServer creates a Server, adding network stats to the given Registry.
+func MakeServer(context *base.Context, executor *sql.Executor, reg *metric.Registry) Server {
 	return Server{
 		context:  context,
 		executor: executor,

--- a/ui/ts/pages/cluster.ts
+++ b/ui/ts/pages/cluster.ts
@@ -120,10 +120,10 @@ module AdminViews {
 
           this._addChartSmall(
             Metrics.NewAxis(
-              Metrics.Select.AvgRate(_nodeMetric("pgwire.bytesin"))
+              Metrics.Select.AvgRate(_nodeMetric("sql.bytesin"))
                 .sources([])
                 .title("Bytes In"),
-              Metrics.Select.AvgRate(_nodeMetric("pgwire.bytesout"))
+              Metrics.Select.AvgRate(_nodeMetric("sql.bytesout"))
                 .sources([])
                 .title("Bytes Out")
             ).format(Utils.Format.Bytes).title("data")

--- a/ui/ts/pages/nodes.ts
+++ b/ui/ts/pages/nodes.ts
@@ -379,7 +379,7 @@ module AdminViews {
           this._addChart(
             this.networkAxes,
             Metrics.NewAxis(
-              Metrics.Select.Avg(_nodeMetric("pgwire.conns"))
+              Metrics.Select.Avg(_nodeMetric("sql.conns"))
                 .sources([nodeId])
                 .title("Client Connections")
               )
@@ -387,7 +387,7 @@ module AdminViews {
           this._addChart(
             this.networkAxes,
             Metrics.NewAxis(
-              Metrics.Select.AvgRate(_nodeMetric("pgwire.bytesin"))
+              Metrics.Select.AvgRate(_nodeMetric("sql.bytesin"))
                 .sources([nodeId])
                 .title("Client Bytes In")
               )
@@ -395,7 +395,7 @@ module AdminViews {
           this._addChart(
             this.networkAxes,
             Metrics.NewAxis(
-              Metrics.Select.AvgRate(_nodeMetric("pgwire.bytesout"))
+              Metrics.Select.AvgRate(_nodeMetric("sql.bytesout"))
                 .sources([nodeId])
                 .title("Client Bytes Out")
               )


### PR DESCRIPTION
This affects the SQL network I/O and connection stats. I've also
pulled the registry out of `sql.Executor` and am now passing it in,
to make the sharing of the registry with the pgwire server a little
cleaner.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4943)

<!-- Reviewable:end -->
