### PR TITLE
Refactor Time Series Aggregators

### DIFF
--- a/roachpb/internal.go
+++ b/roachpb/internal.go
@@ -17,6 +17,11 @@
 
 package roachpb
 
+// Summation returns the sum value for this sample.
+func (samp *InternalTimeSeriesSample) Summation() float64 {
+	return samp.Sum
+}
+
 // Average returns the average value for this sample.
 func (samp *InternalTimeSeriesSample) Average() float64 {
 	if samp.Count == 0 {

--- a/ts/query.go
+++ b/ts/query.go
@@ -18,6 +18,7 @@ package ts
 
 import (
 	"container/heap"
+	"fmt"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -96,24 +97,29 @@ func (ds *dataSpan) addData(data *roachpb.InternalTimeSeriesData) error {
 	return nil
 }
 
+// downsampleFn is a function which extracts a float64 value from a time series
+// sample.
+type downsampleFn func(*roachpb.InternalTimeSeriesSample) float64
+
 // dataSpanIterator is used to iterate through the samples in a dataSpan.
 // Samples are spread across multiple InternalTimeSeriesData objects; this
 // iterator thus maintains a two-level index to point to a unique sample.
 type dataSpanIterator struct {
 	*dataSpan
-	offset    int32 // The calibrated offset of the current sample within the dataSpan
-	dataIdx   int   // Index of InternalTimeSeriesData which contains current Sample
-	sampleIdx int   // Index of current Sample within InternalTimeSeriesData
-	valid     bool  // True if this iterator points to a valid Sample
+	offset       int32        // The calibrated offset of the current sample within the dataSpan
+	dataIdx      int          // Index of InternalTimeSeriesData which contains current Sample
+	sampleIdx    int          // Index of current Sample within InternalTimeSeriesData
+	valid        bool         // True if this iterator points to a valid Sample
+	downsampleFn downsampleFn // Function to extract float64 values from samples
 }
 
-// sample returns the InternalTimeSeriesSample value currently pointed to by
-// this iterator.
-func (dsi *dataSpanIterator) sample() *roachpb.InternalTimeSeriesSample {
+// value returns a float64 value by applying downsampleFn to the
+// InternalTimeSeriesSample value currently pointed to by this iterator.
+func (dsi *dataSpanIterator) value() float64 {
 	if !dsi.valid {
-		return nil
+		panic(fmt.Sprintf("value called on invalid dataSpanIterator: %v", dsi))
 	}
-	return dsi.datas[dsi.dataIdx].Samples[dsi.sampleIdx]
+	return dsi.downsampleFn(dsi.datas[dsi.dataIdx].Samples[dsi.sampleIdx])
 }
 
 // advance moves the iterator to point to the next Sample.
@@ -163,13 +169,13 @@ func (ii *interpolatingIterator) isValid() bool {
 	return ii.nextReal.valid
 }
 
-// avg returns the average value at the current offset for this iterator.
-func (ii *interpolatingIterator) avg() float64 {
+// value returns the value at the current offset of this iterator.
+func (ii *interpolatingIterator) value() float64 {
 	if !ii.isValid() {
 		return 0
 	}
 	if ii.nextReal.offset == ii.offset {
-		return ii.nextReal.sample().Average()
+		return ii.nextReal.value()
 	}
 	// Cannot interpolate if previous value is invalid.
 	if !ii.prevReal.valid {
@@ -178,50 +184,40 @@ func (ii *interpolatingIterator) avg() float64 {
 
 	// Linear interpolation of value at the current offset.
 	off := float64(ii.offset)
-	nextAvg := ii.nextReal.sample().Average()
+	nextAvg := ii.nextReal.value()
 	nextOff := float64(ii.nextReal.offset)
-	prevAvg := ii.prevReal.sample().Average()
+	prevAvg := ii.prevReal.value()
 	prevOff := float64(ii.prevReal.offset)
 	return prevAvg + (nextAvg-prevAvg)*(off-prevOff)/(nextOff-prevOff)
 }
 
-// dAvg returns the derivative (rate of change) of the average value at the
-// current offset for this iterator.
-func (ii *interpolatingIterator) dAvg() float64 {
-	if !ii.isValid() || !ii.prevReal.valid {
-		return 0
-	}
-
-	nextAvg := ii.nextReal.sample().Average()
-	nextOff := float64(ii.nextReal.offset)
-	prevAvg := ii.prevReal.sample().Average()
-	prevOff := float64(ii.prevReal.offset)
-	return (nextAvg - prevAvg) / (nextOff - prevOff)
-}
-
 // newIterator returns an interpolating iterator for the given dataSpan. The
-// iterator is initialized to offset 0.
-func (ds *dataSpan) newIterator() interpolatingIterator {
+// iterator is initialized to position startOffset, which should be 0 when
+// querying non-derivatives and -1 when querying a derivative. Values returned
+// by the iterator will be generated from samples using the supplied
+// downsampleFn.
+func (ds *dataSpan) newIterator(startOffset int32, downsampleFn downsampleFn) interpolatingIterator {
 	if len(ds.datas) == 0 {
 		return interpolatingIterator{}
 	}
 
 	// The first data index necessarily contains the positive offset closest to
-	// 0. Use a binary search to find the lowest positive offset (or the zero
-	// offset).
+	// 0, along with 0 itself and negative offsets. Use a binary search to
+	// find the lowest offset greater than or equal to startOffset.
 	data := ds.datas[0]
 	innerIdx := sort.Search(len(data.Samples), func(i int) bool {
-		return data.offsetAt(i) >= 0
+		return data.offsetAt(i) >= startOffset
 	})
 
 	iterator := interpolatingIterator{
-		offset: 0,
+		offset: startOffset,
 		nextReal: dataSpanIterator{
-			dataSpan:  ds,
-			dataIdx:   0,
-			sampleIdx: innerIdx,
-			offset:    data.offsetAt(innerIdx),
-			valid:     true,
+			dataSpan:     ds,
+			dataIdx:      0,
+			sampleIdx:    innerIdx,
+			offset:       data.offsetAt(innerIdx),
+			valid:        true,
+			downsampleFn: downsampleFn,
 		},
 	}
 
@@ -230,11 +226,12 @@ func (ds *dataSpan) newIterator() interpolatingIterator {
 	// data.
 	if innerIdx > 0 {
 		iterator.prevReal = dataSpanIterator{
-			dataSpan:  ds,
-			dataIdx:   0,
-			sampleIdx: innerIdx - 1,
-			offset:    data.offsetAt(innerIdx - 1),
-			valid:     true,
+			dataSpan:     ds,
+			dataIdx:      0,
+			sampleIdx:    innerIdx - 1,
+			offset:       data.offsetAt(innerIdx - 1),
+			valid:        true,
+			downsampleFn: downsampleFn,
 		}
 	}
 
@@ -361,23 +358,50 @@ func (is unionIterator) timestamp() int64 {
 	return is[0].nextReal.timestampForOffset(is[0].offset)
 }
 
-// avg returns the sum of the averages of all iterators in the set.
-func (is unionIterator) avg() float64 {
+// offset returns the current offset of the iterator.
+func (is unionIterator) offset() int32 {
+	if !is.isValid() {
+		return 0
+	}
+	return is[0].offset
+}
+
+// sum returns the sum of the current values in the iterator.
+func (is unionIterator) sum() float64 {
 	var sum float64
 	for i := range is {
-		sum += is[i].avg()
+		sum = sum + is[i].value()
 	}
 	return sum
 }
 
-// dAvg returns the sum of the derivatives for the averages of all iterators in
-// the set.
-func (is unionIterator) dAvg() float64 {
-	var sum float64
-	for i := range is {
-		sum += is[i].dAvg()
+// avg returns the average of the current values in the iterator.
+func (is unionIterator) avg() float64 {
+	return is.sum() / float64(len(is))
+}
+
+// max return the maximum value of the current values in the iterator.
+func (is unionIterator) max() float64 {
+	max := is[0].value()
+	for i := range is[1:] {
+		val := is[i+1].value()
+		if val > max {
+			max = val
+		}
 	}
-	return sum
+	return max
+}
+
+// min return the minimum value of the current values in the iterator.
+func (is unionIterator) min() float64 {
+	min := is[0].value()
+	for i := range is[1:] {
+		val := is[i+1].value()
+		if val < min {
+			min = val
+		}
+	}
+	return min
 }
 
 // Query returns datapoints for the named time series during the supplied time
@@ -435,18 +459,112 @@ func (db *DB) Query(query TimeSeriesQueryRequest_Query, r Resolution,
 		}
 	}
 
-	// Construct a new dataSpan for each distinct source encountered in the
-	// query. Each dataspan will contain all data queried from the same source.
+	// Convert the queried source data into a set of data spans, one for each
+	// source.
+	sourceSpans, err := makeDataSpans(rows, startNanos)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Compute a downsample function which will be used to return values from
+	// each source for each sample period.
+	downsampler, err := getDownsampleFunction(query.GetDownsampler())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// If we are returning a derivative, iteration needs to start at offset -1
+	// (in order to correctly compute the rate of change at offset 0).
+	var startOffset int32
+	isDerivative := query.GetDerivative() != TimeSeriesQueryDerivative_NONE
+	if isDerivative {
+		startOffset = -1
+	}
+
+	// Create an interpolatingIterator for each dataSpan, adding each iterator
+	// into a unionIterator collection. This is also where we compute a list of
+	// all sources with data present in the query.
+	sources := make([]string, 0, len(sourceSpans))
+	iters := make(unionIterator, 0, len(sourceSpans))
+	for name, span := range sourceSpans {
+		sources = append(sources, name)
+		iters = append(iters, span.newIterator(startOffset, downsampler))
+	}
+
+	// Choose an aggregation function to use when taking values from the
+	// unionIterator.
+	var valueFn func() float64
+	switch query.GetSourceAggregator() {
+	case TimeSeriesQueryAggregator_SUM:
+		valueFn = iters.sum
+	case TimeSeriesQueryAggregator_AVG:
+		valueFn = iters.avg
+	case TimeSeriesQueryAggregator_MAX:
+		valueFn = iters.max
+	case TimeSeriesQueryAggregator_MIN:
+		valueFn = iters.min
+	}
+
+	// Iterate over all requested offsets, recording a value from the
+	// unionIterator at each offset encountered. If the query is requesting a
+	// derivative, a rate of change is recorded instead of the actual values.
+	iters.init()
+	var last TimeSeriesDatapoint
+	if isDerivative {
+		last = TimeSeriesDatapoint{
+			TimestampNanos: iters.timestamp(),
+			Value:          valueFn(),
+		}
+		// For derivatives, the iterator was initialized at offset -1 in order
+		// to calculate the rate of change at offset zero. However, in some
+		// cases (such as the very first value recorded) offset -1 is not
+		// available. In this case, we treat the rate-of-change at the first
+		// offset as zero.
+		if iters.offset() < 0 {
+			iters.advance()
+		}
+	}
+	var responseData []*TimeSeriesDatapoint
+	for iters.isValid() && iters.timestamp() <= endNanos {
+		current := TimeSeriesDatapoint{
+			TimestampNanos: iters.timestamp(),
+			Value:          valueFn(),
+		}
+		response := &TimeSeriesDatapoint{}
+		*response = current
+		if isDerivative {
+			dTime := (current.TimestampNanos - last.TimestampNanos) / r.SampleDuration()
+			if dTime == 0 {
+				response.Value = 0
+			} else {
+				response.Value = (current.Value - last.Value) / float64(dTime)
+			}
+			if response.Value < 0 &&
+				query.GetDerivative() == TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE {
+				response.Value = 0
+			}
+		}
+		responseData = append(responseData, response)
+		last = current
+		iters.advance()
+	}
+
+	return responseData, sources, nil
+}
+
+// makeDataSpans constructs a new dataSpan for each distinct source encountered
+// in the query. Each dataspan will contain all data queried from a single
+// source.
+func makeDataSpans(rows []client.KeyValue, startNanos int64) (map[string]*dataSpan, error) {
 	sourceSpans := make(map[string]*dataSpan)
 	for _, row := range rows {
 		data := &roachpb.InternalTimeSeriesData{}
 		if err := row.ValueProto(data); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-
 		_, source, _, _, err := DecodeDataKey(row.Key)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if _, ok := sourceSpans[source]; !ok {
 			sourceSpans[source] = &dataSpan{
@@ -456,38 +574,23 @@ func (db *DB) Query(query TimeSeriesQueryRequest_Query, r Resolution,
 			}
 		}
 		if err := sourceSpans[source].addData(data); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
+	return sourceSpans, nil
+}
 
-	var responseData []*TimeSeriesDatapoint
-	sources := make([]string, 0, len(sourceSpans))
-
-	// Create an interpolatingIterator for each dataSpan.
-	iters := make(unionIterator, 0, len(sourceSpans))
-	for name, span := range sourceSpans {
-		sources = append(sources, name)
-		iters = append(iters, span.newIterator())
-	}
-
-	// Iterate through all values in the iteratorSet, adding a datapoint to
-	// the response for each value.
-	var valueFn func() float64
-	switch query.GetAggregator() {
+// getDownsampleFunction returns
+func getDownsampleFunction(agg TimeSeriesQueryAggregator) (downsampleFn, error) {
+	switch agg {
 	case TimeSeriesQueryAggregator_AVG:
-		valueFn = iters.avg
-	case TimeSeriesQueryAggregator_AVG_RATE:
-		valueFn = iters.dAvg
+		return (*roachpb.InternalTimeSeriesSample).Average, nil
+	case TimeSeriesQueryAggregator_SUM:
+		return (*roachpb.InternalTimeSeriesSample).Summation, nil
+	case TimeSeriesQueryAggregator_MAX:
+		return (*roachpb.InternalTimeSeriesSample).Maximum, nil
+	case TimeSeriesQueryAggregator_MIN:
+		return (*roachpb.InternalTimeSeriesSample).Minimum, nil
 	}
-
-	iters.init()
-	for iters.isValid() && iters.timestamp() <= endNanos {
-		responseData = append(responseData, &TimeSeriesDatapoint{
-			TimestampNanos: iters.timestamp(),
-			Value:          valueFn(),
-		})
-		iters.advance()
-	}
-
-	return responseData, sources, nil
+	return nil, util.Errorf("query specified unknown time series aggregator %s", agg.String())
 }

--- a/ts/server.go
+++ b/ts/server.go
@@ -87,10 +87,11 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request, _ httproute
 			return
 		}
 		response.Results = append(response.Results, &TimeSeriesQueryResponse_Result{
-			Name:       q.Name,
-			Sources:    sources,
-			Datapoints: datapoints,
-			Aggregator: q.Aggregator,
+			Name:             q.Name,
+			Sources:          sources,
+			SourceAggregator: q.SourceAggregator,
+			Downsampler:      q.Downsampler,
+			Datapoints:       datapoints,
 		})
 	}
 

--- a/ts/timeseries.pb.go
+++ b/ts/timeseries.pb.go
@@ -29,31 +29,37 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-// TimeSeriesQueryAggregator describes a set of aggregation functions which are
-// applied to data points before returning them as part of a query.
+// TimeSeriesQueryAggregator describes a set of aggregation functions which can
+// be used to combine multiple datapoints into a single datapoint.
 //
-// Cockroach does not store data points at full fidelity, instead "downsampling"
-// data points into fixed-length sample periods. The value returned for each
-// sample period is equivalent to applying the supplied aggregator function to
-// the original data points that fell within the sample period.
+// Aggregators are used to "downsample" series by combining datapoints from the
+// same series at different times. They are also used to "aggregate" values from
+// different series, combining data points from different series at the same
+// time.
 type TimeSeriesQueryAggregator int32
 
 const (
-	// AVG returns the average value of points within the sample period.
+	// AVG returns the average value of datapoints.
 	TimeSeriesQueryAggregator_AVG TimeSeriesQueryAggregator = 1
-	// AVG_RATE returns the rate of change of the average over the sample period's
-	// duration.  This is computed via linear regression with the previous sample
-	// period's average value.
-	TimeSeriesQueryAggregator_AVG_RATE TimeSeriesQueryAggregator = 2
+	// SUM returns the sum value of datapoints.
+	TimeSeriesQueryAggregator_SUM TimeSeriesQueryAggregator = 2
+	// MAX returns the maximum value of datapoints.
+	TimeSeriesQueryAggregator_MAX TimeSeriesQueryAggregator = 3
+	// MIN returns the minimum value of datapoints.
+	TimeSeriesQueryAggregator_MIN TimeSeriesQueryAggregator = 4
 )
 
 var TimeSeriesQueryAggregator_name = map[int32]string{
 	1: "AVG",
-	2: "AVG_RATE",
+	2: "SUM",
+	3: "MAX",
+	4: "MIN",
 }
 var TimeSeriesQueryAggregator_value = map[string]int32{
-	"AVG":      1,
-	"AVG_RATE": 2,
+	"AVG": 1,
+	"SUM": 2,
+	"MAX": 3,
+	"MIN": 4,
 }
 
 func (x TimeSeriesQueryAggregator) Enum() *TimeSeriesQueryAggregator {
@@ -70,6 +76,49 @@ func (x *TimeSeriesQueryAggregator) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*x = TimeSeriesQueryAggregator(value)
+	return nil
+}
+
+// TimeSeriesQueryDerivative describes a derivative function used to convert
+// returned datapoints into a rate-of-change.
+type TimeSeriesQueryDerivative int32
+
+const (
+	// NONE is the default value, and does not apply a derivative function.
+	TimeSeriesQueryDerivative_NONE TimeSeriesQueryDerivative = 0
+	// DERIVATIVE returns the first-order derivative of values in the time series.
+	TimeSeriesQueryDerivative_DERIVATIVE TimeSeriesQueryDerivative = 1
+	// NON_NEGATIVE_DERIVATIVE returns only non-negative values of the first-order
+	// derivative; negative values are returned as zero. This should be used for
+	// counters that monotonically increase, but might wrap or reset.
+	TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE TimeSeriesQueryDerivative = 2
+)
+
+var TimeSeriesQueryDerivative_name = map[int32]string{
+	0: "NONE",
+	1: "DERIVATIVE",
+	2: "NON_NEGATIVE_DERIVATIVE",
+}
+var TimeSeriesQueryDerivative_value = map[string]int32{
+	"NONE":                    0,
+	"DERIVATIVE":              1,
+	"NON_NEGATIVE_DERIVATIVE": 2,
+}
+
+func (x TimeSeriesQueryDerivative) Enum() *TimeSeriesQueryDerivative {
+	p := new(TimeSeriesQueryDerivative)
+	*p = x
+	return p
+}
+func (x TimeSeriesQueryDerivative) String() string {
+	return proto.EnumName(TimeSeriesQueryDerivative_name, int32(x))
+}
+func (x *TimeSeriesQueryDerivative) UnmarshalJSON(data []byte) error {
+	value, err := proto.UnmarshalJSONEnum(TimeSeriesQueryDerivative_value, data, "TimeSeriesQueryDerivative")
+	if err != nil {
+		return err
+	}
+	*x = TimeSeriesQueryDerivative(value)
 	return nil
 }
 
@@ -128,18 +177,27 @@ func (*TimeSeriesQueryRequest) ProtoMessage()    {}
 type TimeSeriesQueryRequest_Query struct {
 	// The name of the time series to query.
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name"`
-	// The aggregation function to apply to points in the result.
-	Aggregator *TimeSeriesQueryAggregator `protobuf:"varint,2,opt,name=aggregator,enum=cockroach.ts.TimeSeriesQueryAggregator,def=1" json:"aggregator,omitempty"`
+	// A downsampling aggregation function to apply to datapoints within the
+	// same sample period.
+	Downsampler *TimeSeriesQueryAggregator `protobuf:"varint,2,opt,name=downsampler,enum=cockroach.ts.TimeSeriesQueryAggregator,def=1" json:"downsampler,omitempty"`
+	// An aggregation function used to combine timelike datapoints from the
+	// different sources being queried.
+	SourceAggregator *TimeSeriesQueryAggregator `protobuf:"varint,3,opt,name=source_aggregator,enum=cockroach.ts.TimeSeriesQueryAggregator,def=2" json:"source_aggregator,omitempty"`
+	// If set to a value other than 'NONE', query will return a derivative
+	// (rate of change) of the aggregated datapoints.
+	Derivative *TimeSeriesQueryDerivative `protobuf:"varint,4,opt,name=derivative,enum=cockroach.ts.TimeSeriesQueryDerivative,def=0" json:"derivative,omitempty"`
 	// An optional list of sources to restrict the time series query. If no
-	// sources are provided, all sources will be queried.
-	Sources []string `protobuf:"bytes,3,rep,name=sources" json:"sources,omitempty"`
+	// sources are provided, all available sources will be queried.
+	Sources []string `protobuf:"bytes,5,rep,name=sources" json:"sources,omitempty"`
 }
 
 func (m *TimeSeriesQueryRequest_Query) Reset()         { *m = TimeSeriesQueryRequest_Query{} }
 func (m *TimeSeriesQueryRequest_Query) String() string { return proto.CompactTextString(m) }
 func (*TimeSeriesQueryRequest_Query) ProtoMessage()    {}
 
-const Default_TimeSeriesQueryRequest_Query_Aggregator TimeSeriesQueryAggregator = TimeSeriesQueryAggregator_AVG
+const Default_TimeSeriesQueryRequest_Query_Downsampler TimeSeriesQueryAggregator = TimeSeriesQueryAggregator_AVG
+const Default_TimeSeriesQueryRequest_Query_SourceAggregator TimeSeriesQueryAggregator = TimeSeriesQueryAggregator_SUM
+const Default_TimeSeriesQueryRequest_Query_Derivative TimeSeriesQueryDerivative = TimeSeriesQueryDerivative_NONE
 
 func (m *TimeSeriesQueryRequest_Query) GetName() string {
 	if m != nil {
@@ -148,11 +206,25 @@ func (m *TimeSeriesQueryRequest_Query) GetName() string {
 	return ""
 }
 
-func (m *TimeSeriesQueryRequest_Query) GetAggregator() TimeSeriesQueryAggregator {
-	if m != nil && m.Aggregator != nil {
-		return *m.Aggregator
+func (m *TimeSeriesQueryRequest_Query) GetDownsampler() TimeSeriesQueryAggregator {
+	if m != nil && m.Downsampler != nil {
+		return *m.Downsampler
 	}
-	return Default_TimeSeriesQueryRequest_Query_Aggregator
+	return Default_TimeSeriesQueryRequest_Query_Downsampler
+}
+
+func (m *TimeSeriesQueryRequest_Query) GetSourceAggregator() TimeSeriesQueryAggregator {
+	if m != nil && m.SourceAggregator != nil {
+		return *m.SourceAggregator
+	}
+	return Default_TimeSeriesQueryRequest_Query_SourceAggregator
+}
+
+func (m *TimeSeriesQueryRequest_Query) GetDerivative() TimeSeriesQueryDerivative {
+	if m != nil && m.Derivative != nil {
+		return *m.Derivative
+	}
+	return Default_TimeSeriesQueryRequest_Query_Derivative
 }
 
 func (m *TimeSeriesQueryRequest_Query) GetSources() []string {
@@ -177,22 +249,30 @@ func (*TimeSeriesQueryResponse) ProtoMessage()    {}
 
 // Result is the data returned from a single metric query over a time span.
 type TimeSeriesQueryResponse_Result struct {
-	// A string which uniquely identifies the variable from which this data was
-	// measured.
+	// The name of the time series that was queried.
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name"`
-	// A list of sources from which the data was aggregated.
+	// A list of the different sources for which time series data was found
+	// and queried.
 	Sources []string `protobuf:"bytes,2,rep,name=sources" json:"sources,omitempty"`
-	// The aggregation function applied to points in the result.
-	Aggregator *TimeSeriesQueryAggregator `protobuf:"varint,3,opt,name=aggregator,enum=cockroach.ts.TimeSeriesQueryAggregator,def=1" json:"aggregator,omitempty"`
-	// Datapoints describing the queried data.
-	Datapoints []*TimeSeriesDatapoint `protobuf:"bytes,4,rep,name=datapoints" json:"datapoints,omitempty"`
+	// The downsampling aggregation function applied to datapoints within the
+	// same sample period.
+	Downsampler *TimeSeriesQueryAggregator `protobuf:"varint,3,opt,name=downsampler,enum=cockroach.ts.TimeSeriesQueryAggregator,def=1" json:"downsampler,omitempty"`
+	// The aggregation function applied to combine timelike datapoints from
+	// the different sources that were queried.
+	SourceAggregator *TimeSeriesQueryAggregator `protobuf:"varint,4,opt,name=source_aggregator,enum=cockroach.ts.TimeSeriesQueryAggregator,def=2" json:"source_aggregator,omitempty"`
+	// The derivative function applied to the results of this query.
+	Derivative *TimeSeriesQueryDerivative `protobuf:"varint,5,opt,name=derivative,enum=cockroach.ts.TimeSeriesQueryDerivative,def=0" json:"derivative,omitempty"`
+	// The result of the query expressed as a list of datapoints.
+	Datapoints []*TimeSeriesDatapoint `protobuf:"bytes,6,rep,name=datapoints" json:"datapoints,omitempty"`
 }
 
 func (m *TimeSeriesQueryResponse_Result) Reset()         { *m = TimeSeriesQueryResponse_Result{} }
 func (m *TimeSeriesQueryResponse_Result) String() string { return proto.CompactTextString(m) }
 func (*TimeSeriesQueryResponse_Result) ProtoMessage()    {}
 
-const Default_TimeSeriesQueryResponse_Result_Aggregator TimeSeriesQueryAggregator = TimeSeriesQueryAggregator_AVG
+const Default_TimeSeriesQueryResponse_Result_Downsampler TimeSeriesQueryAggregator = TimeSeriesQueryAggregator_AVG
+const Default_TimeSeriesQueryResponse_Result_SourceAggregator TimeSeriesQueryAggregator = TimeSeriesQueryAggregator_SUM
+const Default_TimeSeriesQueryResponse_Result_Derivative TimeSeriesQueryDerivative = TimeSeriesQueryDerivative_NONE
 
 func (m *TimeSeriesQueryResponse_Result) GetName() string {
 	if m != nil {
@@ -208,11 +288,25 @@ func (m *TimeSeriesQueryResponse_Result) GetSources() []string {
 	return nil
 }
 
-func (m *TimeSeriesQueryResponse_Result) GetAggregator() TimeSeriesQueryAggregator {
-	if m != nil && m.Aggregator != nil {
-		return *m.Aggregator
+func (m *TimeSeriesQueryResponse_Result) GetDownsampler() TimeSeriesQueryAggregator {
+	if m != nil && m.Downsampler != nil {
+		return *m.Downsampler
 	}
-	return Default_TimeSeriesQueryResponse_Result_Aggregator
+	return Default_TimeSeriesQueryResponse_Result_Downsampler
+}
+
+func (m *TimeSeriesQueryResponse_Result) GetSourceAggregator() TimeSeriesQueryAggregator {
+	if m != nil && m.SourceAggregator != nil {
+		return *m.SourceAggregator
+	}
+	return Default_TimeSeriesQueryResponse_Result_SourceAggregator
+}
+
+func (m *TimeSeriesQueryResponse_Result) GetDerivative() TimeSeriesQueryDerivative {
+	if m != nil && m.Derivative != nil {
+		return *m.Derivative
+	}
+	return Default_TimeSeriesQueryResponse_Result_Derivative
 }
 
 func (m *TimeSeriesQueryResponse_Result) GetDatapoints() []*TimeSeriesDatapoint {
@@ -230,6 +324,7 @@ func init() {
 	proto.RegisterType((*TimeSeriesQueryResponse)(nil), "cockroach.ts.TimeSeriesQueryResponse")
 	proto.RegisterType((*TimeSeriesQueryResponse_Result)(nil), "cockroach.ts.TimeSeriesQueryResponse.Result")
 	proto.RegisterEnum("cockroach.ts.TimeSeriesQueryAggregator", TimeSeriesQueryAggregator_name, TimeSeriesQueryAggregator_value)
+	proto.RegisterEnum("cockroach.ts.TimeSeriesQueryDerivative", TimeSeriesQueryDerivative_name, TimeSeriesQueryDerivative_value)
 }
 func (m *TimeSeriesDatapoint) Marshal() (data []byte, err error) {
 	size := m.Size()
@@ -348,14 +443,24 @@ func (m *TimeSeriesQueryRequest_Query) MarshalTo(data []byte) (int, error) {
 	i++
 	i = encodeVarintTimeseries(data, i, uint64(len(m.Name)))
 	i += copy(data[i:], m.Name)
-	if m.Aggregator != nil {
+	if m.Downsampler != nil {
 		data[i] = 0x10
 		i++
-		i = encodeVarintTimeseries(data, i, uint64(*m.Aggregator))
+		i = encodeVarintTimeseries(data, i, uint64(*m.Downsampler))
+	}
+	if m.SourceAggregator != nil {
+		data[i] = 0x18
+		i++
+		i = encodeVarintTimeseries(data, i, uint64(*m.SourceAggregator))
+	}
+	if m.Derivative != nil {
+		data[i] = 0x20
+		i++
+		i = encodeVarintTimeseries(data, i, uint64(*m.Derivative))
 	}
 	if len(m.Sources) > 0 {
 		for _, s := range m.Sources {
-			data[i] = 0x1a
+			data[i] = 0x2a
 			i++
 			l = len(s)
 			for l >= 1<<7 {
@@ -435,14 +540,24 @@ func (m *TimeSeriesQueryResponse_Result) MarshalTo(data []byte) (int, error) {
 			i += copy(data[i:], s)
 		}
 	}
-	if m.Aggregator != nil {
+	if m.Downsampler != nil {
 		data[i] = 0x18
 		i++
-		i = encodeVarintTimeseries(data, i, uint64(*m.Aggregator))
+		i = encodeVarintTimeseries(data, i, uint64(*m.Downsampler))
+	}
+	if m.SourceAggregator != nil {
+		data[i] = 0x20
+		i++
+		i = encodeVarintTimeseries(data, i, uint64(*m.SourceAggregator))
+	}
+	if m.Derivative != nil {
+		data[i] = 0x28
+		i++
+		i = encodeVarintTimeseries(data, i, uint64(*m.Derivative))
 	}
 	if len(m.Datapoints) > 0 {
 		for _, msg := range m.Datapoints {
-			data[i] = 0x22
+			data[i] = 0x32
 			i++
 			i = encodeVarintTimeseries(data, i, uint64(msg.Size()))
 			n, err := msg.MarshalTo(data[i:])
@@ -525,8 +640,14 @@ func (m *TimeSeriesQueryRequest_Query) Size() (n int) {
 	_ = l
 	l = len(m.Name)
 	n += 1 + l + sovTimeseries(uint64(l))
-	if m.Aggregator != nil {
-		n += 1 + sovTimeseries(uint64(*m.Aggregator))
+	if m.Downsampler != nil {
+		n += 1 + sovTimeseries(uint64(*m.Downsampler))
+	}
+	if m.SourceAggregator != nil {
+		n += 1 + sovTimeseries(uint64(*m.SourceAggregator))
+	}
+	if m.Derivative != nil {
+		n += 1 + sovTimeseries(uint64(*m.Derivative))
 	}
 	if len(m.Sources) > 0 {
 		for _, s := range m.Sources {
@@ -560,8 +681,14 @@ func (m *TimeSeriesQueryResponse_Result) Size() (n int) {
 			n += 1 + l + sovTimeseries(uint64(l))
 		}
 	}
-	if m.Aggregator != nil {
-		n += 1 + sovTimeseries(uint64(*m.Aggregator))
+	if m.Downsampler != nil {
+		n += 1 + sovTimeseries(uint64(*m.Downsampler))
+	}
+	if m.SourceAggregator != nil {
+		n += 1 + sovTimeseries(uint64(*m.SourceAggregator))
+	}
+	if m.Derivative != nil {
+		n += 1 + sovTimeseries(uint64(*m.Derivative))
 	}
 	if len(m.Datapoints) > 0 {
 		for _, e := range m.Datapoints {
@@ -990,7 +1117,7 @@ func (m *TimeSeriesQueryRequest_Query) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 2:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Aggregator", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Downsampler", wireType)
 			}
 			var v TimeSeriesQueryAggregator
 			for shift := uint(0); ; shift += 7 {
@@ -1007,8 +1134,48 @@ func (m *TimeSeriesQueryRequest_Query) Unmarshal(data []byte) error {
 					break
 				}
 			}
-			m.Aggregator = &v
+			m.Downsampler = &v
 		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SourceAggregator", wireType)
+			}
+			var v TimeSeriesQueryAggregator
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTimeseries
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (TimeSeriesQueryAggregator(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.SourceAggregator = &v
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Derivative", wireType)
+			}
+			var v TimeSeriesQueryDerivative
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTimeseries
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (TimeSeriesQueryDerivative(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Derivative = &v
+		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Sources", wireType)
 			}
@@ -1228,7 +1395,7 @@ func (m *TimeSeriesQueryResponse_Result) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 3:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Aggregator", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Downsampler", wireType)
 			}
 			var v TimeSeriesQueryAggregator
 			for shift := uint(0); ; shift += 7 {
@@ -1245,8 +1412,48 @@ func (m *TimeSeriesQueryResponse_Result) Unmarshal(data []byte) error {
 					break
 				}
 			}
-			m.Aggregator = &v
+			m.Downsampler = &v
 		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SourceAggregator", wireType)
+			}
+			var v TimeSeriesQueryAggregator
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTimeseries
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (TimeSeriesQueryAggregator(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.SourceAggregator = &v
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Derivative", wireType)
+			}
+			var v TimeSeriesQueryDerivative
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTimeseries
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (TimeSeriesQueryDerivative(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Derivative = &v
+		case 6:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Datapoints", wireType)
 			}

--- a/ts/timeseries.proto
+++ b/ts/timeseries.proto
@@ -44,20 +44,35 @@ message TimeSeriesData {
   repeated TimeSeriesDatapoint datapoints = 3;
 }
 
-// TimeSeriesQueryAggregator describes a set of aggregation functions which are
-// applied to data points before returning them as part of a query.
+// TimeSeriesQueryAggregator describes a set of aggregation functions which can
+// be used to combine multiple datapoints into a single datapoint.
 //
-// Cockroach does not store data points at full fidelity, instead "downsampling"
-// data points into fixed-length sample periods. The value returned for each
-// sample period is equivalent to applying the supplied aggregator function to
-// the original data points that fell within the sample period.
+// Aggregators are used to "downsample" series by combining datapoints from the
+// same series at different times. They are also used to "aggregate" values from
+// different series, combining data points from different series at the same
+// time.
 enum TimeSeriesQueryAggregator {
-  // AVG returns the average value of points within the sample period.
+  // AVG returns the average value of datapoints.
   AVG = 1;
-  // AVG_RATE returns the rate of change of the average over the sample period's
-  // duration.  This is computed via linear regression with the previous sample
-  // period's average value.
-  AVG_RATE = 2;
+  // SUM returns the sum value of datapoints.
+  SUM = 2;
+  // MAX returns the maximum value of datapoints.
+  MAX = 3;
+  // MIN returns the minimum value of datapoints.
+  MIN = 4;
+}
+
+// TimeSeriesQueryDerivative describes a derivative function used to convert
+// returned datapoints into a rate-of-change.
+enum TimeSeriesQueryDerivative {
+  // NONE is the default value, and does not apply a derivative function.
+  NONE = 0;
+  // DERIVATIVE returns the first-order derivative of values in the time series.
+  DERIVATIVE = 1;
+  // NON_NEGATIVE_DERIVATIVE returns only non-negative values of the first-order
+  // derivative; negative values are returned as zero. This should be used for
+  // counters that monotonically increase, but might wrap or reset.
+  NON_NEGATIVE_DERIVATIVE = 2;
 }
 
 // TimeSeriesQueryRequest is the standard incoming time series query request
@@ -77,11 +92,18 @@ message TimeSeriesQueryRequest {
 
         // The name of the time series to query.
         optional string name = 1 [(gogoproto.nullable) = false];
-        // The aggregation function to apply to points in the result.
-        optional TimeSeriesQueryAggregator aggregator = 2 [default = AVG];
+        // A downsampling aggregation function to apply to datapoints within the
+        // same sample period.
+        optional TimeSeriesQueryAggregator downsampler = 2 [default = AVG];
+        // An aggregation function used to combine timelike datapoints from the
+        // different sources being queried.
+        optional TimeSeriesQueryAggregator source_aggregator = 3 [default = SUM];
+        // If set to a value other than 'NONE', query will return a derivative
+        // (rate of change) of the aggregated datapoints.
+        optional TimeSeriesQueryDerivative derivative = 4 [default = NONE];
         // An optional list of sources to restrict the time series query. If no
-        // sources are provided, all sources will be queried.
-        repeated string sources = 3;
+        // sources are provided, all available sources will be queried.
+        repeated string sources = 5;
     }
 
     // A set of Queries for this request. A request must have at least one
@@ -96,15 +118,21 @@ message TimeSeriesQueryResponse {
     message Result {
         option (gogoproto.goproto_getters) = true;
 
-        // A string which uniquely identifies the variable from which this data was
-        // measured.
+        // The name of the time series that was queried.
         optional string name = 1 [(gogoproto.nullable) = false];
-        // A list of sources from which the data was aggregated.
+        // A list of the different sources for which time series data was found
+        // and queried.
         repeated string sources = 2;
-        // The aggregation function applied to points in the result.
-        optional TimeSeriesQueryAggregator aggregator = 3 [default = AVG];
-        // Datapoints describing the queried data.
-        repeated TimeSeriesDatapoint datapoints = 4;
+        // The downsampling aggregation function applied to datapoints within the
+        // same sample period.
+        optional TimeSeriesQueryAggregator downsampler = 3 [default = AVG];
+        // The aggregation function applied to combine timelike datapoints from
+        // the different sources that were queried.
+        optional TimeSeriesQueryAggregator source_aggregator = 4 [default = SUM];
+        // The derivative function applied to the results of this query.
+        optional TimeSeriesQueryDerivative derivative = 5 [default = NONE];
+        // The result of the query expressed as a list of datapoints.
+        repeated TimeSeriesDatapoint datapoints = 6;
     }
 
     // A set of Results; there will be one result for each Query in the matching

--- a/ui/ts/models/metrics.ts
+++ b/ui/ts/models/metrics.ts
@@ -26,7 +26,9 @@ module Models {
      */
     interface QueryInfo {
       name: string;
-      aggregator: Proto.QueryAggregator;
+      downsampler: Proto.QueryAggregator;
+      source_aggregator: Proto.QueryAggregator;
+      derivative: Proto.QueryDerivative;
     }
 
     /**
@@ -34,7 +36,7 @@ module Models {
      * server-side dataset referenced by the QueryInfo.
      */
     export function QueryInfoKey(qi: QueryInfo): string {
-      return Proto.QueryAggregator[qi.aggregator] + ":" + qi.name;
+      return Proto.QueryAggregator[qi.downsampler] + ":" + qi.name;
     }
 
     /**
@@ -133,7 +135,9 @@ module Models {
           return {
             name: this.seriesName,
             sources: this.sources(),
-            aggregator: Proto.QueryAggregator.AVG,
+            downsampler: Proto.QueryAggregator.AVG,
+            source_aggregator: Proto.QueryAggregator.SUM,
+            derivative: Proto.QueryDerivative.NONE,
           };
         };
       }
@@ -151,7 +155,9 @@ module Models {
           return {
             name: this.seriesName,
             sources: this.sources(),
-            aggregator: Proto.QueryAggregator.AVG_RATE,
+            downsampler: Proto.QueryAggregator.AVG,
+            source_aggregator: Proto.QueryAggregator.SUM,
+            derivative: Proto.QueryDerivative.DERIVATIVE,
           };
         };
       }

--- a/ui/ts/models/proto.ts
+++ b/ui/ts/models/proto.ts
@@ -198,7 +198,21 @@ module Models {
      */
     export enum QueryAggregator {
       AVG = 1,
-      AVG_RATE = 2,
+      SUM = 2,
+      MAX = 3,
+      MIN = 4,
+    }
+
+    /**
+     * QueryAggregator is an enumeration of the available derivative
+     * functions for time series queries.
+     *
+     * Source message = "TimeSeriesQueryDerivative"
+     */
+    export enum QueryDerivative {
+      NONE = 0,
+      DERIVATIVE = 1,
+      NON_NEGATIVE_DERIVATIVE = 2,
     }
 
     /**
@@ -218,8 +232,10 @@ module Models {
      */
     export interface QueryResult {
       name: string;
-      aggregator: QueryAggregator;
       datapoints: Datapoint[];
+      downsampler: QueryAggregator;
+      source_aggregator: QueryAggregator;
+      derivative: QueryDerivative;
     }
 
     /**
@@ -240,7 +256,9 @@ module Models {
     export interface QueryRequest {
       name: string;
       sources: string[];
-      aggregator: QueryAggregator;
+      downsampler: QueryAggregator;
+      source_aggregator: QueryAggregator;
+      derivative: QueryDerivative;
     }
 
     /**


### PR DESCRIPTION
This is an overdue refactoring of the way aggregation functions are chosen in
time series queries.

Previously, each time series query specified a single "aggregator"; however,
this aggregator was conflating three distinct concepts in the time series query:
1. **Downsample Function**: When querying data from a single series, individual
   data points are downsampled into aggregates over ten-second sample periods.
2. **Aggregation Function**: When querying multiple series, datapoints from the
   different series at the same timestamp are aggregated into a single value.
3. **Derivative Function**: Instead of returning the original values, the server
   can return a derivative (rate of change) of the values.

All three of these were specified with a single aggregator. There were only two
options available: "AVG" and "AVG_RATE".  "AVG" downsampled individual series
using average and aggregated multiple series by summing them. "AVG_RATE" did the
same, but returned the first derivative of the sample points.

This interface was going to prove very inflexible when more advanced queries
are inevitably required; for example, we currently have need of a "non-negative
derivative" function; there are also many valid queries involving Mins and Maxes
which were unavailable previously.

This commit separates the three concepts: each query now specifies a
"downsampler", a "source aggregator", and a "derivative" function.

Current UI graphs have not been changed, but have been updated to use the new
query format.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4950)

<!-- Reviewable:end -->
