### PR TITLE
add health check

### DIFF
--- a/ui/styl/partials/layout.styl
+++ b/ui/styl/partials/layout.styl
@@ -32,13 +32,14 @@ $subnav-background  = $secondary-gray-3
 html
 body
   height 100%
+  min-width 1480px
   background-color $secondary-gray-4
 
 #root
   position relative
   padding-left $nav-width
   min-height 100% // TODO or calc(100% - 4rem)
-  min-width 1500px
+  min-width 100%
 
   &:after
     content ""
@@ -62,7 +63,7 @@ body
 
   .topbar + &
     padding-top $top-bar-height + 10px
-    width 1500px
+    width 100%
 
   .nav + &
     padding-top $top-bar-height + $subnav-height + 10px
@@ -178,6 +179,34 @@ button
   img
     position relative
     top 8px
+
+  .health
+    font-variant small-caps
+    display block
+
+    span.health-icon
+      display inline-block
+      padding 0 3px
+      height 21px
+      border-radius 100%
+
+    .icon-check-circle
+      color $main-green
+    .icon-x
+      color $secondary-red
+    .icon-skull
+      background-color $secondary-gray-11
+      color white
+
+    *
+      display inline
+
+    .unreachable-text
+      position relative
+      top -3px
+      font-variant normal
+      font-family Lato-Medium
+      color $secondary-gray-2
 
   .info-container
     display inline-block

--- a/ui/ts/components/health.ts
+++ b/ui/ts/components/health.ts
@@ -1,0 +1,73 @@
+// source: components/health.ts
+/// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
+/// <reference path="../../typings/browser.d.ts" />
+/// <reference path="../util/property.ts" />
+
+// Author: Max Lang (max@cockroachlabs.com)
+
+module Components {
+  "use strict";
+
+  /**
+   * Health returns the health status as an icon
+   */
+  export module Health {
+
+    import MithrilPromise = _mithril.MithrilPromise;
+
+    class HealthController {
+      healthy: boolean = true; // Starts out OK because the page loaded
+      refreshing: boolean = true;
+      interval: number;
+      getHealth: () => MithrilPromise<void> = (): MithrilPromise<void> => {
+        this.refreshing = true;
+        m.redraw();
+        return m.request({
+          url: "/_admin/v1/health",
+          deserialize: (d: any): any => { return d; },
+          config: function(xhr: XMLHttpRequest): void { xhr.timeout = 2000; },
+        })
+        .then((r: any): void => {
+          this.healthy = _.startsWith(r.toString(), "ok");
+          this.refreshing = false;
+        })
+        .catch((r: any): void => {
+          this.healthy = _.startsWith(r.toString(), "ok");
+          this.refreshing = false;
+        });
+      };
+
+      startRefresh(): void {
+        this.interval = setInterval(this.getHealth, 2000);
+      }
+
+      onunload: () => void = (): void => {
+        if (this.interval) {
+          clearInterval(this.interval);
+        }
+      };
+    }
+
+    export function controller(): HealthController {
+      let hc: HealthController = new HealthController();
+      hc.startRefresh();
+      // TODO: create global refresher
+      return hc;
+    }
+
+    export function view(ctrl: HealthController): _mithril.MithrilVirtualElement {
+      if (ctrl.healthy) {
+        return m("div", [
+          m("span.health-icon.icon-check-circle" + (ctrl.refreshing ? ".refreshing" : "")),
+          m("span.refreshing-text", ctrl.refreshing ? " Refreshing..." : ""),
+        ]);
+      } else {
+        return m("div", [
+          m("span.health-icon.icon-x" + (ctrl.refreshing ? ".refreshing" : "")),
+          m("span.unreachable-text", " Can't reach node. "),
+          m("span.refreshing-text", ctrl.refreshing ? " Refreshing..." : ""),
+        ]);
+      }
+    }
+  }
+}

--- a/ui/ts/components/topbar.ts
+++ b/ui/ts/components/topbar.ts
@@ -1,5 +1,7 @@
 // source: components/topbar.ts
 
+/// <reference path="./health.ts" />
+
 // Author: Max Lang (max@cockroachlabs.com)
 
 module Components {
@@ -18,7 +20,7 @@ module Components {
       return m(".topbar", [
         (args.title && m("h2", args.title) || (args.titleImage)),
         m(".info-container", [
-          // TODO: health
+          m(".health", [m("strong", "health:"), m.component(Components.Health, {})]),
           m(".last-updated", [ m("strong", "Updated: "), updatedStr ]),
         ]),
       ]);


### PR DESCRIPTION
Adds the health check icon to the top bar. Currently it refreshes every 2 seconds (based on an interval timer) but in an upcoming PR I'm going to wire up all refreshes to a global refresh object that can change the refresh interval and allows pages to register/deregister refreshers.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4952)

<!-- Reviewable:end -->
