### PR TITLE
acceptance: Move HostConfig.NetworkMode setting into createContainer

### DIFF
--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -52,7 +52,7 @@ func dockerIP() net.IP {
 		return net.ParseIP(h)
 	}
 	if runtime.GOOS == "linux" {
-		return net.IPv4zero
+		return net.IPv4(127, 0, 0, 1)
 	}
 	panic("unable to determine docker ip address")
 }

--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
-	"github.com/docker/engine-api/types/network"
 	"github.com/docker/go-connections/nat"
 	"golang.org/x/net/context"
 
@@ -99,11 +98,17 @@ func pullImage(l *LocalCluster, options types.ImagePullOptions) error {
 	}
 }
 
-// createContainer creates a new container using the specified options. Per the
-// docker API, the created container is not running and must be started
-// explicitly.
-func createContainer(l *LocalCluster, containerConfig container.Config, hostConfig container.HostConfig, networkConfig *network.NetworkingConfig, containerName string) (*Container, error) {
-	resp, err := l.client.ContainerCreate(&containerConfig, &hostConfig, networkConfig, containerName)
+// createContainer creates a new container using the specified
+// options. Per the docker API, the created container is not running
+// and must be started explicitly. Note that the passed-in hostConfig
+// will be augmented with the necessary settings to use the network
+// defined by l.createNetwork().
+func createContainer(l *LocalCluster, containerConfig container.Config, hostConfig container.HostConfig, containerName string) (*Container, error) {
+	hostConfig.NetworkMode = container.NetworkMode(l.networkID)
+	// Disable DNS search under the host machine's domain. This can
+	// catch upstream wildcard DNS matching and result in odd behavior.
+	hostConfig.DNSSearch = []string{"."}
+	resp, err := l.client.ContainerCreate(&containerConfig, &hostConfig, nil, containerName)
 	if err != nil {
 		return nil, err
 	}

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -241,12 +241,11 @@ func testDocker(t *testing.T, name string, cmd []string) error {
 	l := StartCluster(t, readConfigFromFlags()).(*cluster.LocalCluster)
 
 	defer l.AssertAndStop(t)
-	addr := l.Nodes[0].Addr(cluster.DefaultTCP)
 	containerConfig := container.Config{
 		Image: fmt.Sprintf(image + ":" + postgresTestTag),
 		Env: []string{
-			fmt.Sprintf("PGHOST=%s", addr.IP),
-			fmt.Sprintf("PGPORT=%d", addr.Port),
+			"PGHOST=roach0",
+			fmt.Sprintf("PGPORT=%s", base.DefaultPort),
 			"PGSSLCERT=/certs/node.client.crt",
 			"PGSSLKEY=/certs/node.client.key",
 		},


### PR DESCRIPTION
This puts the containers used for cross-language testing on the same
network as the nodes and gets the tests passing reliably for me.
(I don't understand why the tests were passing some of the time before).

Removed redundant alias specification and restricted the DNS search path
to avoid querying outside networks.

Fixes #4894

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4953)

<!-- Reviewable:end -->
