### PR TITLE
sql: explain should pass autoCommit through

### DIFF
--- a/sql/explain.go
+++ b/sql/explain.go
@@ -40,7 +40,7 @@ const (
 // info about a DELETE, INSERT, SELECT or UPDATE statement.
 //
 // Privileges: the same privileges as the statement being explained.
-func (p *planner) Explain(n *parser.Explain) (planNode, *roachpb.Error) {
+func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, *roachpb.Error) {
 	mode := explainNone
 	if len(n.Options) == 1 {
 		if strings.EqualFold(n.Options[0], "DEBUG") {
@@ -64,7 +64,7 @@ func (p *planner) Explain(n *parser.Explain) (planNode, *roachpb.Error) {
 		}
 	}
 
-	plan, err := p.makePlan(n.Statement, false)
+	plan, err := p.makePlan(n.Statement, autoCommit)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -115,7 +115,7 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, *r
 	case *parser.DropTable:
 		return p.DropTable(n)
 	case *parser.Explain:
-		return p.Explain(n)
+		return p.Explain(n, autoCommit)
 	case *parser.Grant:
 		return p.Grant(n)
 	case *parser.Insert:


### PR DESCRIPTION
otherwise the plan it explains isn't actually reflective of what might be executed normally.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/4971)

<!-- Reviewable:end -->
