### PR TITLE
sql: deflake TestExplainTrace

### DIFF
--- a/sql/trace_test.go
+++ b/sql/trace_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"text/tabwriter"
 
+	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -82,6 +83,8 @@ func prettyPrint(m [][]string) string {
 
 func TestExplainTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer config.TestingDisableTableSplits()()
+
 	s, sqlDB, _ := setup(t)
 	defer cleanup(s, sqlDB)
 


### PR DESCRIPTION
Disable table splits for TestExplainTrace. Table splits need special
handling when shutting down a test server which the sql tests are not
implementing.

Fixes #4965.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5007)

<!-- Reviewable:end -->
