### PR TITLE
storage: use int64 instead of uint64 for byte sizes

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -22,13 +22,13 @@ import (
 	"net"
 	"strings"
 
-	"github.com/dustin/go-humanize"
 	"github.com/kr/text"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/util"
 )
 
 var maxResults int64
@@ -195,16 +195,16 @@ const usageIndentation = 8
 const wrapWidth = 79 - usageIndentation
 
 type bytesValue struct {
-	val   *uint64
+	val   *int64
 	isSet bool
 }
 
-func newBytesValue(val *uint64) *bytesValue {
+func newBytesValue(val *int64) *bytesValue {
 	return &bytesValue{val: val}
 }
 
 func (b *bytesValue) Set(s string) error {
-	v, err := humanize.ParseBytes(s)
+	v, err := util.ParseBytes(s)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func (b *bytesValue) String() string {
 	// This uses the MiB, GiB, etc suffixes. If we use humanize.Bytes() we get
 	// the MB, GB, etc suffixes, but the conversion is done in multiples of 1000
 	// vs 1024.
-	return humanize.IBytes(*b.val)
+	return util.IBytes(*b.val)
 }
 
 func wrapText(s string) string {

--- a/server/context.go
+++ b/server/context.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/elastic/gosigar"
 
 	"github.com/cockroachdb/cockroach/base"
@@ -36,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
@@ -226,7 +226,7 @@ func (ctx *Context) InitStores(stopper *stop.Stopper) error {
 			}
 			if sizeInBytes != 0 && sizeInBytes < minimumStoreSize {
 				return fmt.Errorf("%f%% of memory is only %s bytes, which is below the minimum requirement of %s",
-					spec.SizePercent, humanize.IBytes(uint64(sizeInBytes)), humanize.IBytes(uint64(minimumStoreSize)))
+					spec.SizePercent, util.IBytes(sizeInBytes), util.IBytes(minimumStoreSize))
 			}
 			ctx.Engines = append(ctx.Engines, engine.NewInMem(spec.Attributes, uint64(sizeInBytes), stopper))
 		} else {
@@ -239,8 +239,7 @@ func (ctx *Context) InitStores(stopper *stop.Stopper) error {
 			}
 			if sizeInBytes != 0 && sizeInBytes < minimumStoreSize {
 				return fmt.Errorf("%f%% of %s's total free space is only %s bytes, which is below the minimum requirement of %s",
-					spec.SizePercent, spec.Path, humanize.IBytes(uint64(sizeInBytes)),
-					humanize.IBytes(uint64(minimumStoreSize)))
+					spec.SizePercent, spec.Path, util.IBytes(sizeInBytes), util.IBytes(minimumStoreSize))
 			}
 			ctx.Engines = append(ctx.Engines, engine.NewRocksDB(spec.Attributes, spec.Path,
 				ctx.CacheSize/uint64(len(ctx.Stores.Specs)), ctx.MemtableBudget, sizeInBytes, stopper))

--- a/server/context.go
+++ b/server/context.go
@@ -19,6 +19,7 @@ package server
 import (
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -27,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/elastic/gosigar"
 
 	"github.com/cockroachdb/cockroach/base"
@@ -84,12 +86,12 @@ type Context struct {
 
 	// CacheSize is the amount of memory in bytes to use for caching data.
 	// The value is split evenly between the stores if there are more than one.
-	CacheSize uint64
+	CacheSize int64
 
-	// MemtableBudget is the amount of memory in bytes to use for the memory
-	// table.
+	// MemtableBudget is the amount of memory, per store, in bytes to use for
+	// the memory table.
 	// This value is no longer settable by the end user.
-	MemtableBudget uint64
+	MemtableBudget int64
 
 	// Parsed values.
 
@@ -153,29 +155,43 @@ type TestingMocker struct {
 
 // GetTotalMemory returns either the total system memory or if possible the
 // cgroups available memory.
-func GetTotalMemory() (uint64, error) {
+func GetTotalMemory() (int64, error) {
 	mem := gosigar.Mem{}
 	if err := mem.Get(); err != nil {
 		return 0, err
 	}
-	totalMem := mem.Total
-	var cgAvlMem uint64
+	if mem.Total > math.MaxInt64 {
+		return 0, fmt.Errorf("inferred memory size %s exceeds maximum supported memory size %s",
+			humanize.IBytes(mem.Total), humanize.Bytes(math.MaxInt64))
+	}
+	totalMem := int64(mem.Total)
 	if runtime.GOOS == "linux" {
 		var err error
 		var buf []byte
 		if buf, err = ioutil.ReadFile(defaultCGroupMemPath); err != nil {
 			if log.V(1) {
-				log.Infof("can't read available memory from cgroups (%s)", err)
+				log.Infof("can't read available memory from cgroups (%s), using system memory %s instead", err,
+					util.IBytes(totalMem))
 			}
 			return totalMem, nil
 		}
+		var cgAvlMem uint64
 		if cgAvlMem, err = strconv.ParseUint(strings.TrimSpace(string(buf)), 10, 64); err != nil {
 			if log.V(1) {
-				log.Infof("can't parse available memory from cgroups (%s)", err)
+				log.Infof("can't parse available memory from cgroups (%s), using system memory %s instead", err,
+					util.IBytes(totalMem))
 			}
 			return totalMem, nil
 		}
-		return cgAvlMem, nil
+		if cgAvlMem > math.MaxInt64 {
+			if log.V(1) {
+				log.Infof("available memory from cgroups is too large and unsupported %s using system memory %s instead",
+					humanize.IBytes(cgAvlMem), util.IBytes(totalMem))
+
+			}
+			return totalMem, nil
+		}
+		return int64(cgAvlMem), nil
 	}
 	return totalMem, nil
 }
@@ -228,7 +244,7 @@ func (ctx *Context) InitStores(stopper *stop.Stopper) error {
 				return fmt.Errorf("%f%% of memory is only %s bytes, which is below the minimum requirement of %s",
 					spec.SizePercent, util.IBytes(sizeInBytes), util.IBytes(minimumStoreSize))
 			}
-			ctx.Engines = append(ctx.Engines, engine.NewInMem(spec.Attributes, uint64(sizeInBytes), stopper))
+			ctx.Engines = append(ctx.Engines, engine.NewInMem(spec.Attributes, sizeInBytes, stopper))
 		} else {
 			if spec.SizePercent > 0 {
 				fileSystemUsage := gosigar.FileSystemUsage{}
@@ -242,7 +258,7 @@ func (ctx *Context) InitStores(stopper *stop.Stopper) error {
 					spec.SizePercent, spec.Path, util.IBytes(sizeInBytes), util.IBytes(minimumStoreSize))
 			}
 			ctx.Engines = append(ctx.Engines, engine.NewRocksDB(spec.Attributes, spec.Path,
-				ctx.CacheSize/uint64(len(ctx.Stores.Specs)), ctx.MemtableBudget, sizeInBytes, stopper))
+				ctx.CacheSize/int64(len(ctx.Stores.Specs)), ctx.MemtableBudget, sizeInBytes, stopper))
 		}
 	}
 	if len(ctx.Engines) == 1 {

--- a/server/store_spec.go
+++ b/server/store_spec.go
@@ -24,11 +24,11 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/dustin/go-humanize"
+
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
-
-	"github.com/dustin/go-humanize"
 )
 
 var minimumStoreSize = 10 * int64(config.DefaultZoneConfig().RangeMaxBytes)

--- a/server/store_spec.go
+++ b/server/store_spec.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util"
 
 	"github.com/dustin/go-humanize"
 )
@@ -52,7 +53,7 @@ func (ss StoreSpec) String() string {
 		fmt.Fprint(&buffer, "type=mem,")
 	}
 	if ss.SizeInBytes > 0 {
-		fmt.Fprintf(&buffer, "size=%s,", humanize.IBytes(uint64(ss.SizeInBytes)))
+		fmt.Fprintf(&buffer, "size=%s,", util.IBytes(ss.SizeInBytes))
 	}
 	if ss.SizePercent > 0 {
 		fmt.Fprintf(&buffer, "size=%s%%,", humanize.Ftoa(ss.SizePercent))
@@ -157,16 +158,14 @@ func newStoreSpec(value string) (StoreSpec, error) {
 					return StoreSpec{}, fmt.Errorf("store size (%s) must be between 1%% and 100%%", value)
 				}
 			} else {
-				// Value is a specific size in bytes. The backwards ordering
-				// is due to the linter complaining.
-				if sib, err := humanize.ParseBytes(value); err == nil {
-					ss.SizeInBytes = int64(sib)
-				} else {
+				var err error
+				ss.SizeInBytes, err = util.ParseBytes(value)
+				if err != nil {
 					return StoreSpec{}, fmt.Errorf("could not parse store size (%s) %s", value, err)
 				}
 				if ss.SizeInBytes < minimumStoreSize {
 					return StoreSpec{}, fmt.Errorf("store size (%s) must be larger than %s", value,
-						humanize.IBytes(uint64(minimumStoreSize)))
+						util.IBytes(minimumStoreSize))
 				}
 			}
 		case "attrs":

--- a/storage/engine/in_mem.go
+++ b/storage/engine/in_mem.go
@@ -27,7 +27,7 @@ type InMem struct {
 }
 
 // NewInMem allocates and returns a new, opened InMem engine.
-func NewInMem(attrs roachpb.Attributes, cacheSize uint64, stopper *stop.Stopper) InMem {
+func NewInMem(attrs roachpb.Attributes, cacheSize int64, stopper *stop.Stopper) InMem {
 	db := InMem{
 		RocksDB: newMemRocksDB(attrs, cacheSize, 512<<20 /* 512 MB */, stopper),
 	}

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -22,18 +22,20 @@ package engine
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"unsafe"
+
+	"github.com/dustin/go-humanize"
+	"github.com/elastic/gosigar"
+	"github.com/gogo/protobuf/proto"
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine/rocksdb"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
-	"github.com/dustin/go-humanize"
-	"github.com/elastic/gosigar"
-	"github.com/gogo/protobuf/proto"
 )
 
 // #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
@@ -55,15 +57,15 @@ type RocksDB struct {
 	rdb            *C.DBEngine
 	attrs          roachpb.Attributes // Attributes for this engine
 	dir            string             // The data directory
-	cacheSize      uint64             // Memory to use to cache values.
-	memtableBudget uint64             // Memory to use for the memory table.
+	cacheSize      int64              // Memory to use to cache values.
+	memtableBudget int64              // Memory to use for the memory table.
 	maxSize        int64              // Used for calculating rebalancing and free space.
 	stopper        *stop.Stopper
 	deallocated    chan struct{} // Closed when the underlying handle is deallocated.
 }
 
 // NewRocksDB allocates and returns a new RocksDB object.
-func NewRocksDB(attrs roachpb.Attributes, dir string, cacheSize, memtableBudget uint64, maxSize int64,
+func NewRocksDB(attrs roachpb.Attributes, dir string, cacheSize, memtableBudget, maxSize int64,
 	stopper *stop.Stopper) *RocksDB {
 	if dir == "" {
 		panic("dir must be non-empty")
@@ -79,8 +81,7 @@ func NewRocksDB(attrs roachpb.Attributes, dir string, cacheSize, memtableBudget 
 	}
 }
 
-func newMemRocksDB(attrs roachpb.Attributes, cacheSize, memtableBudget uint64,
-	stopper *stop.Stopper) *RocksDB {
+func newMemRocksDB(attrs roachpb.Attributes, cacheSize, memtableBudget int64, stopper *stop.Stopper) *RocksDB {
 	return &RocksDB{
 		attrs: attrs,
 		// dir: empty dir == "mem" RocksDB instance.
@@ -110,7 +111,7 @@ func (r *RocksDB) Open() error {
 
 	if r.memtableBudget < minMemtableBudget {
 		return util.Errorf("memtable budget must be at least %s: %s",
-			humanize.Bytes(minMemtableBudget), humanize.Bytes(r.memtableBudget))
+			humanize.IBytes(minMemtableBudget), util.IBytes(r.memtableBudget))
 	}
 
 	if len(r.dir) != 0 {
@@ -218,14 +219,16 @@ func (r *RocksDB) Capacity() (roachpb.StoreCapacity, error) {
 		return roachpb.StoreCapacity{}, err
 	}
 
+	if fileSystemUsage.Total > math.MaxInt64 {
+		return roachpb.StoreCapacity{}, fmt.Errorf("unsupported disk size %s, max supported size is %s",
+			humanize.IBytes(fileSystemUsage.Total), util.IBytes(math.MaxInt64))
+	}
+	if fileSystemUsage.Avail > math.MaxInt64 {
+		return roachpb.StoreCapacity{}, fmt.Errorf("unsupported disk size %s, max supported size is %s",
+			humanize.IBytes(fileSystemUsage.Avail), util.IBytes(math.MaxInt64))
+	}
 	fsuTotal := int64(fileSystemUsage.Total)
-	if fsuTotal < 0 {
-		return roachpb.StoreCapacity{}, fmt.Errorf("unsupported disk size: %s", humanize.IBytes(fileSystemUsage.Total))
-	}
 	fsuAvail := int64(fileSystemUsage.Avail)
-	if fsuAvail < 0 {
-		return roachpb.StoreCapacity{}, fmt.Errorf("unsupported disk size: %s", humanize.IBytes(fileSystemUsage.Avail))
-	}
 
 	// If no size limitation have been placed on the store size or if the
 	// limitation is greater than what's available, just return the actual

--- a/util/humanize.go
+++ b/util/humanize.go
@@ -1,0 +1,56 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Bram Gruneir (bram+code@cockroachlabs.com)
+
+package util
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/dustin/go-humanize"
+)
+
+// IBytes is an int64 version of go-humanize's IBytes.
+func IBytes(value int64) string {
+	if value < 0 {
+		return fmt.Sprintf("-%s", humanize.IBytes(uint64(-value)))
+	}
+	return humanize.IBytes(uint64(value))
+}
+
+// ParseBytes is an int64 version of go-humanize's ParseBytes.
+func ParseBytes(s string) (int64, error) {
+	if len(s) == 0 {
+		return 0, fmt.Errorf("parsing \"\": invalid syntax")
+	}
+	var startIndex int
+	var negative bool
+	if s[0] == '-' {
+		negative = true
+		startIndex = 1
+	}
+	value, err := humanize.ParseBytes(s[startIndex:])
+	if err != nil {
+		return 0, err
+	}
+	if value > math.MaxInt64 {
+		return 0, fmt.Errorf("too large: %s", s)
+	}
+	if negative {
+		return -int64(value), nil
+	}
+	return int64(value), nil
+}

--- a/util/humanize_test.go
+++ b/util/humanize_test.go
@@ -1,0 +1,109 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Bram Gruneir (bram+code@cockroachlabs.com)
+
+package util
+
+import (
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+// TestHumanizeBytes verifies both IBytes and ParseBytes.
+func TestBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		value       int64
+		exp         string
+		expNeg      string
+		parseExp    int64
+		parseErr    string
+		parseErrNeg string
+	}{
+		{0, "0 B", "0 B", 0, "", ""},
+		{1024, "1.0 KiB", "-1.0 KiB", 1024, "", ""},
+		{1024 << 10, "1.0 MiB", "-1.0 MiB", 1024 << 10, "", ""},
+		{1024 << 20, "1.0 GiB", "-1.0 GiB", 1024 << 20, "", ""},
+		{1024 << 30, "1.0 TiB", "-1.0 TiB", 1024 << 30, "", ""},
+		{1024 << 40, "1.0 PiB", "-1.0 PiB", 1024 << 40, "", ""},
+		{1024 << 50, "1.0 EiB", "-1.0 EiB", 1024 << 50, "", ""},
+		{int64(math.MaxInt64), "8.0 EiB", "-8.0 EiB", 0, "too large: 8.0 EiB", "too large: -8.0 EiB"},
+	}
+
+	for i, testCase := range testCases {
+		// Test IBytes.
+		if actual := IBytes(testCase.value); actual != testCase.exp {
+			t.Errorf("%d: IBytes(%d) actual:%s does not match expected:%s", i, testCase.value, actual, testCase.exp)
+		}
+		// Test negative IBytes.
+		if actual := IBytes(-testCase.value); actual != testCase.expNeg {
+			t.Errorf("%d: IBytes(%d) actual:%s does not match expected:%s", i, -testCase.value, actual,
+				testCase.expNeg)
+		}
+		// Test ParseBytes.
+		if actual, err := ParseBytes(testCase.exp); err != nil {
+			if len(testCase.parseErr) > 0 {
+				if testCase.parseErr != err.Error() {
+					t.Errorf("%d: ParseBytes(%s) caused an incorrect error actual:%s, expected:%s", i, testCase.exp,
+						err, testCase.parseErr)
+				}
+			} else {
+				t.Errorf("%d: ParseBytes(%s) caused an unexpected error:%s", i, testCase.exp, err)
+			}
+		} else if actual != testCase.parseExp {
+			t.Errorf("%d: ParseBytes(%s) actual:%d does not match expected:%d", i, testCase.exp, actual,
+				testCase.parseExp)
+		}
+		// Test negative ParseBytes.
+		if actual, err := ParseBytes(testCase.expNeg); err != nil {
+			if len(testCase.parseErrNeg) > 0 {
+				if testCase.parseErrNeg != err.Error() {
+					t.Errorf("%d: ParseBytes(%s) caused an incorrect error actual:%s, expected:%s", i, testCase.expNeg,
+						err, testCase.parseErrNeg)
+				}
+			} else {
+				t.Errorf("%d: ParseBytes(%s) caused an unexpected error:%s", i, testCase.expNeg, err)
+			}
+		} else if actual != -testCase.parseExp {
+			t.Errorf("%d: ParseBytes(%s) actual:%d does not match expected:%d", i, testCase.expNeg, actual,
+				-testCase.parseExp)
+		}
+	}
+
+	// Some extra error cases for good measure.
+	testFailCases := []struct {
+		value    string
+		expected string
+	}{
+		{"", "parsing \"\": invalid syntax"},   // our error
+		{"1 ZB", "unhandled size name: zb"},    // humanize's error
+		{"-1 ZB", "unhandled size name: zb"},   // humanize's error
+		{"1 ZiB", "unhandled size name: zib"},  // humanize's error
+		{"-1 ZiB", "unhandled size name: zib"}, // humanize's error
+		{"100 EiB", "too large: 100 EiB"},      // humanize's error
+		{"-100 EiB", "too large: 100 EiB"},     // humanize's error
+		{"10 EiB", "too large: 10 EiB"},        // our error
+		{"-10 EiB", "too large: -10 EiB"},      // our error
+	}
+	for i, testCase := range testFailCases {
+		if _, err := ParseBytes(testCase.value); err.Error() != testCase.expected {
+			t.Errorf("%d: ParseBytes(%s) caused an incorrect error actual:%s, expected:%s", i, testCase.value, err,
+				testCase.expected)
+		}
+	}
+}


### PR DESCRIPTION
Internally, we use int64 instead of uint64 when dealing with disk sizes to avoid having to constantly worry about underflows during calculations.

The other option here is to go the other way and convert the StoreCapacity proto to uint64.  Which if we're going to do, we should do very soon.

I just don't want to leave this with different types.

attn: @tamird, @bdarnell

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5008)

<!-- Reviewable:end -->
