### PR TITLE
sql: Create ExecutorContext to thread testing flags

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -129,7 +130,8 @@ type Context struct {
 // TestingMocker is a struct containing facilities for mocking
 // or otherwise controlling various parts of the system.
 type TestingMocker struct {
-	StoreTestingMocker storage.StoreTestingMocker
+	StoreTestingMocker    storage.StoreTestingMocker
+	ExecutorTestingMocker sql.ExecutorTestingMocker
 }
 
 // GetTotalMemory returns either the total system memory or if possible the

--- a/server/server.go
+++ b/server/server.go
@@ -164,8 +164,15 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 
 	s.leaseMgr = sql.NewLeaseManager(0, *s.db, s.clock)
 	s.leaseMgr.RefreshLeases(s.stopper, s.db, s.gossip)
+	eCtx := sql.ExecutorContext{
+		DB:            s.db,
+		Gossip:        s.gossip,
+		LeaseManager:  s.leaseMgr,
+		TestingMocker: ctx.TestingMocker.ExecutorTestingMocker,
+	}
+
 	sqlRegistry := metric.NewRegistry()
-	s.sqlExecutor = sql.NewExecutor(*s.db, s.gossip, s.leaseMgr, s.stopper, sqlRegistry)
+	s.sqlExecutor = sql.NewExecutor(eCtx, s.stopper, sqlRegistry)
 
 	s.pgServer = pgwire.MakeServer(&s.ctx.Context, s.sqlExecutor, sqlRegistry)
 

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
-	csql "github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -244,6 +243,8 @@ func (t *logicTest) setup() {
 	// MySQL or Postgres instance.
 	ctx := server.NewTestContext()
 	ctx.MaxOffset = logicMaxOffset
+	ctx.TestingMocker.ExecutorTestingMocker.WaitForGossipUpdate = true
+	ctx.TestingMocker.ExecutorTestingMocker.CheckStmtStringChange = true
 	t.srv = setupTestServerWithContext(t.T, ctx)
 
 	// db may change over the lifetime of this function, with intermediate
@@ -693,7 +694,6 @@ func (t *logicTest) traceStop() {
 
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer csql.TestingWaitForGossipUpdate()()
 
 	// TODO(marc): splitting ranges at table boundaries causes
 	// a blocked task and won't drain. Investigate and fix.

--- a/sql/parallel_test.go
+++ b/sql/parallel_test.go
@@ -101,17 +101,14 @@ func (t *parallelTest) processTestFile(path string, db *sql.DB, ch chan bool) {
 }
 
 func (t *parallelTest) run(dir string) {
-	fmt.Printf("Running test %s\n", dir)
-	// Set up database
 	defer t.close()
-	ctx := server.NewTestContext()
-	ctx.MaxOffset = logicMaxOffset
-	t.srv = setupTestServer(t.T)
+	t.setup()
 
 	// Add the main client and set up the database.
 	t.addClient(true)
 
 	// Open the main faile.
+	fmt.Printf("Running test %s\n", dir)
 	mainFile := filepath.Join(dir, "main")
 	file, err := os.Open(mainFile)
 	if err != nil {
@@ -150,6 +147,14 @@ func (t *parallelTest) run(dir string) {
 			t.Fatalf("%s:%d: unknown command: %s", mainFile, s.line, cmd)
 		}
 	}
+}
+
+func (t *parallelTest) setup() {
+	ctx := server.NewTestContext()
+	ctx.MaxOffset = logicMaxOffset
+	ctx.TestingMocker.ExecutorTestingMocker.WaitForGossipUpdate = true
+	ctx.TestingMocker.ExecutorTestingMocker.CheckStmtStringChange = true
+	t.srv = setupTestServerWithContext(t.T, ctx)
 }
 
 func TestParallel(t *testing.T) {


### PR DESCRIPTION
Fixes #4966.

Adds flags for
- CheckStmtStringChange
- WaitForGossipUpdate

Because this gates the verifying `stmt` modification, it should have the following performance impact:

```
name                          old time/op    new time/op    delta
Bank_Cockroach-2                 418µs ± 1%     377µs ± 3%   -9.83%  (p=0.000 n=10+10)
Select1_Cockroach-2             62.0µs ± 2%    45.9µs ± 2%  -25.91%  (p=0.000 n=10+10)
Select2_Cockroach-2             1.03ms ± 2%    0.91ms ± 1%  -11.57%  (p=0.000 n=10+10)
Insert1_Cockroach-2              502µs ± 1%     481µs ± 0%   -4.07%   (p=0.000 n=10+9)
Insert10_Cockroach-2             896µs ± 1%     837µs ± 1%   -6.61%  (p=0.000 n=10+10)
Insert100_Cockroach-2           4.61ms ± 1%    4.18ms ± 1%   -9.33%   (p=0.000 n=9+10)
Insert1000_Cockroach-2          44.4ms ± 1%    40.6ms ± 2%   -8.38%  (p=0.000 n=10+10)
Update1_Cockroach-2              762µs ± 2%     725µs ± 2%   -4.79%   (p=0.000 n=10+9)
Update10_Cockroach-2            1.42ms ± 2%    1.38ms ± 2%   -2.68%   (p=0.000 n=9+10)
Update100_Cockroach-2           7.53ms ± 2%    7.42ms ± 2%   -1.36%  (p=0.005 n=10+10)
Update1000_Cockroach-2          68.7ms ± 2%    66.1ms ± 2%   -3.82%  (p=0.000 n=10+10)
Delete1_Cockroach-2              700µs ± 4%     676µs ± 1%   -3.42%   (p=0.000 n=10+9)
Delete10_Cockroach-2            2.12ms ± 2%    2.08ms ± 2%   -1.70%   (p=0.004 n=9+10)
Delete100_Cockroach-2           17.9ms ± 1%    17.3ms ± 1%   -3.22%   (p=0.000 n=8+10)
Delete1000_Cockroach-2           190ms ± 1%     185ms ± 3%   -2.43%   (p=0.000 n=9+10)
Scan1_Cockroach-2                272µs ± 1%     247µs ± 1%   -9.20%  (p=0.000 n=10+10)
Scan10_Cockroach-2               318µs ± 2%     289µs ± 2%   -8.98%  (p=0.000 n=10+10)
Scan100_Cockroach-2              668µs ± 1%     644µs ± 2%   -3.56%   (p=0.000 n=9+10)
Scan1000_Cockroach-2            3.95ms ± 1%    3.95ms ± 2%     ~     (p=0.579 n=10+10)
Scan10000_Cockroach-2           40.8ms ± 3%    41.0ms ± 1%     ~      (p=0.156 n=10+9)
Scan1000Limit1_Cockroach-2       285µs ± 1%     257µs ± 1%   -9.81%    (p=0.000 n=9+9)
Scan1000Limit10_Cockroach-2      330µs ± 1%     302µs ± 1%   -8.72%  (p=0.000 n=10+10)
Scan1000Limit100_Cockroach-2     691µs ± 3%     664µs ± 3%   -3.87%  (p=0.000 n=10+10)
PgbenchQuery_Cockroach-2        3.93ms ± 6%    3.62ms ± 5%   -7.78%  (p=0.000 n=10+10)

name                          old alloc/op   new alloc/op   delta
Bank_Cockroach-2                68.5kB ± 0%    60.9kB ± 0%  -11.02%  (p=0.000 n=10+10)
Select1_Cockroach-2             3.91kB ± 0%    2.26kB ± 0%  -42.20%    (p=0.001 n=7+7)
Select2_Cockroach-2             80.7kB ± 0%    72.1kB ± 0%  -10.58%  (p=0.000 n=10+10)
Insert1_Cockroach-2             22.9kB ± 0%    22.1kB ± 0%   -3.60%   (p=0.000 n=10+9)
Insert10_Cockroach-2            67.1kB ± 0%    61.1kB ± 0%   -8.94%   (p=0.000 n=9+10)
Insert100_Cockroach-2            508kB ± 0%     453kB ± 0%  -10.96%   (p=0.000 n=9+10)
Insert1000_Cockroach-2          4.56MB ± 1%    4.02MB ± 1%  -11.78%   (p=0.000 n=9+10)
Update1_Cockroach-2             36.7kB ± 0%    34.5kB ± 0%   -6.20%    (p=0.000 n=8+9)
Update10_Cockroach-2             100kB ± 0%      97kB ± 0%   -3.39%    (p=0.000 n=8+9)
Update100_Cockroach-2            705kB ± 0%     686kB ± 0%   -2.71%   (p=0.000 n=9+10)
Update1000_Cockroach-2          6.12MB ± 1%    5.92MB ± 1%   -3.35%    (p=0.000 n=9+9)
Delete1_Cockroach-2             29.8kB ± 0%    28.6kB ± 0%   -3.87%  (p=0.000 n=10+10)
Delete10_Cockroach-2            75.5kB ± 0%    73.3kB ± 0%   -2.82%    (p=0.000 n=9+9)
Delete100_Cockroach-2            536kB ± 0%     521kB ± 0%   -2.78%   (p=0.000 n=9+10)
Delete1000_Cockroach-2          4.85MB ± 3%    4.65MB ± 3%   -4.15%  (p=0.000 n=10+10)
Scan1_Cockroach-2               13.2kB ± 0%    10.9kB ± 0%  -17.34%   (p=0.000 n=10+9)
Scan10_Cockroach-2              17.1kB ± 0%    14.8kB ± 0%  -13.41%   (p=0.000 n=10+9)
Scan100_Cockroach-2             49.3kB ± 0%    47.0kB ± 0%   -4.66%    (p=0.000 n=9+9)
Scan1000_Cockroach-2             331kB ± 0%     329kB ± 0%   -0.71%   (p=0.000 n=10+7)
Scan10000_Cockroach-2           5.72MB ± 0%    5.71MB ± 0%   -0.05%   (p=0.000 n=10+9)
Scan1000Limit1_Cockroach-2      14.0kB ± 0%    11.5kB ± 1%  -17.89%  (p=0.000 n=10+10)
Scan1000Limit10_Cockroach-2     17.9kB ± 0%    15.2kB ± 0%  -14.64%    (p=0.000 n=9+9)
Scan1000Limit100_Cockroach-2    50.0kB ± 0%    47.4kB ± 0%   -5.29%   (p=0.000 n=9+10)
PgbenchQuery_Cockroach-2         222kB ±12%     210kB ± 5%     ~     (p=0.105 n=10+10)

name                          old allocs/op  new allocs/op  delta
Bank_Cockroach-2                 1.67k ± 0%     1.42k ± 0%  -15.13%   (p=0.000 n=10+8)
Select1_Cockroach-2               97.0 ± 0%      49.0 ± 0%  -49.48%  (p=0.000 n=10+10)
Select2_Cockroach-2              2.70k ± 0%     2.34k ± 0%  -13.30%  (p=0.000 n=10+10)
Insert1_Cockroach-2                356 ± 0%       330 ± 0%   -7.22%   (p=0.000 n=8+10)
Insert10_Cockroach-2               907 ± 0%       748 ± 0%  -17.47%  (p=0.000 n=10+10)
Insert100_Cockroach-2            6.18k ± 0%     4.76k ± 0%  -22.97%   (p=0.000 n=9+10)
Insert1000_Cockroach-2           59.0k ± 0%     45.0k ± 0%  -23.71%   (p=0.000 n=9+10)
Update1_Cockroach-2                719 ± 0%       634 ± 0%  -11.76%    (p=0.000 n=7+9)
Update10_Cockroach-2             1.41k ± 0%     1.29k ± 0%   -8.52%    (p=0.000 n=8+9)
Update100_Cockroach-2            7.95k ± 0%     7.46k ± 0%   -6.14%  (p=0.000 n=10+10)
Update1000_Cockroach-2           70.4k ± 0%     66.3k ± 0%   -5.86%    (p=0.000 n=9+9)
Delete1_Cockroach-2                567 ± 0%       521 ± 0%   -8.11%    (p=0.000 n=8+8)
Delete10_Cockroach-2             1.24k ± 0%     1.15k ± 0%   -6.70%   (p=0.000 n=10+9)
Delete100_Cockroach-2            7.68k ± 0%     7.22k ± 0%   -5.91%   (p=0.000 n=8+10)
Delete1000_Cockroach-2           71.9k ± 1%     67.8k ± 1%   -5.69%  (p=0.000 n=10+10)
Scan1_Cockroach-2                  275 ± 0%       213 ± 0%  -22.55%    (p=0.000 n=8+8)
Scan10_Cockroach-2                 355 ± 0%       293 ± 0%  -17.46%    (p=0.000 n=8+8)
Scan100_Cockroach-2              1.08k ± 0%     1.02k ± 0%   -5.74%   (p=0.000 n=9+10)
Scan1000_Cockroach-2             8.29k ± 0%     8.23k ± 0%   -0.76%    (p=0.000 n=8+8)
Scan10000_Cockroach-2            80.4k ± 0%     80.4k ± 0%   -0.08%   (p=0.000 n=10+9)
Scan1000Limit1_Cockroach-2         298 ± 0%       231 ± 1%  -22.55%   (p=0.000 n=8+10)
Scan1000Limit10_Cockroach-2        378 ± 0%       309 ± 0%  -18.06%  (p=0.000 n=10+10)
Scan1000Limit100_Cockroach-2     1.10k ± 0%     1.04k ± 0%   -6.22%   (p=0.000 n=9+10)
PgbenchQuery_Cockroach-2         4.00k ± 8%     3.63k ± 3%   -9.07%  (p=0.000 n=10+10)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5009)

<!-- Reviewable:end -->
