### PR TITLE
util/tracing: Temporarily remove trace sampling completely

### DIFF
--- a/util/tracing/tracer.go
+++ b/util/tracing/tracer.go
@@ -72,6 +72,7 @@ func JoinOrNewSnowball(opName string, carrier *Span, callback func(sp basictrace
 
 func defaultOptions(recorder func(basictracer.RawSpan)) basictracer.Options {
 	opts := basictracer.DefaultOptions()
+	opts.ShouldSample = func(traceID int64) bool { return false }
 	opts.TrimUnsampledSpans = true
 	opts.Recorder = CallbackRecorder(recorder)
 	opts.NewSpanEventListener = basictracer.NetTraceIntegrator


### PR DESCRIPTION
We can add generic sampling rate logic back in later using code
that looks something like:

```
opts.ShouldSample = func(traceID int64) bool {
    rate := samplingFracFrom0to1
    inv := false
    if rate > .5 {
        rate = 1 - rate
        inv = true
    }
    if rate == 0 {
        return inv
    }
    return inv != (math.Mod(float64(traceID), 1.0/rate) < 0)
}
```

Or more simply:

```
opts.ShouldSample = func(traceID int64) bool {
    return traceID % samplingRateDenominator == 0
}
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5012)

<!-- Reviewable:end -->
