### PR TITLE
Bug fixes for time series queries

### DIFF
--- a/ts/query.go
+++ b/ts/query.go
@@ -440,7 +440,10 @@ func (db *DB) Query(query TimeSeriesQueryRequest_Query, r Resolution,
 		b := db.db.NewBatch()
 		// Iterate over all key timestamps which may contain data for the given
 		// sources, based on the given start/end time and the resolution.
-		for currentTimestamp := startNanos; currentTimestamp <= endNanos; currentTimestamp += r.KeyDuration() {
+		kd := r.KeyDuration()
+		startKeyNanos := startNanos - (startNanos % kd)
+		endKeyNanos := endNanos - (endNanos % kd)
+		for currentTimestamp := startKeyNanos; currentTimestamp <= endKeyNanos; currentTimestamp += kd {
 			for _, source := range query.Sources {
 				key := MakeDataKey(query.Name, source, r, currentTimestamp)
 				b.Get(key)

--- a/ts/query_test.go
+++ b/ts/query_test.go
@@ -352,7 +352,7 @@ func (tm *testModel) assertQuery(name string, sources []string,
 			iters.advance()
 		}
 	}
-	for iters.isValid() {
+	for iters.isValid() && iters.timestamp() <= end {
 		current := currentVal()
 		result := &TimeSeriesDatapoint{}
 		*result = current
@@ -510,5 +510,12 @@ func TestQuery(t *testing.T) {
 
 	tm.assertKeyCount(31)
 	tm.assertModelCorrect()
+
+	// Assert querying data from subset of sources. Includes source with no
+	// data.
 	tm.assertQuery("test.specificmetric", []string{"source2", "source4", "source6"}, nil, nil, nil, resolution1ns, 0, 90, 7, 2)
+
+	// Assert querying data over limited range for single source. Regression
+	// test for #4987.
+	tm.assertQuery("test.specificmetric", []string{"source4", "source5"}, nil, nil, nil, resolution1ns, 5, 24, 4, 2)
 }

--- a/ts/server.go
+++ b/ts/server.go
@@ -89,8 +89,9 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request, _ httproute
 		response.Results = append(response.Results, &TimeSeriesQueryResponse_Result{
 			Name:             q.Name,
 			Sources:          sources,
-			SourceAggregator: q.SourceAggregator,
-			Downsampler:      q.Downsampler,
+			SourceAggregator: q.GetSourceAggregator().Enum(),
+			Downsampler:      q.GetDownsampler().Enum(),
+			Derivative:       q.GetDerivative().Enum(),
 			Datapoints:       datapoints,
 		})
 	}

--- a/ts/server_test.go
+++ b/ts/server_test.go
@@ -102,8 +102,11 @@ func TestHttpQuery(t *testing.T) {
 	expectedResult := &ts.TimeSeriesQueryResponse{
 		Results: []*ts.TimeSeriesQueryResponse_Result{
 			{
-				Name:    "test.metric",
-				Sources: []string{"source1", "source2"},
+				Name:             "test.metric",
+				Sources:          []string{"source1", "source2"},
+				Downsampler:      ts.TimeSeriesQueryAggregator_AVG.Enum(),
+				SourceAggregator: ts.TimeSeriesQueryAggregator_SUM.Enum(),
+				Derivative:       ts.TimeSeriesQueryDerivative_NONE.Enum(),
 				Datapoints: []*ts.TimeSeriesDatapoint{
 					{
 						TimestampNanos: 505 * 1e9,
@@ -120,8 +123,11 @@ func TestHttpQuery(t *testing.T) {
 				},
 			},
 			{
-				Name:    "other.metric",
-				Sources: []string{""},
+				Name:             "other.metric",
+				Sources:          []string{""},
+				Downsampler:      ts.TimeSeriesQueryAggregator_AVG.Enum(),
+				SourceAggregator: ts.TimeSeriesQueryAggregator_SUM.Enum(),
+				Derivative:       ts.TimeSeriesQueryDerivative_NONE.Enum(),
 				Datapoints: []*ts.TimeSeriesDatapoint{
 					{
 						TimestampNanos: 505 * 1e9,
@@ -130,6 +136,27 @@ func TestHttpQuery(t *testing.T) {
 					{
 						TimestampNanos: 515 * 1e9,
 						Value:          250.0,
+					},
+				},
+			},
+			{
+				Name:             "test.metric",
+				Sources:          []string{"source1", "source2"},
+				Downsampler:      ts.TimeSeriesQueryAggregator_MAX.Enum(),
+				SourceAggregator: ts.TimeSeriesQueryAggregator_MAX.Enum(),
+				Derivative:       ts.TimeSeriesQueryDerivative_DERIVATIVE.Enum(),
+				Datapoints: []*ts.TimeSeriesDatapoint{
+					{
+						TimestampNanos: 505 * 1e9,
+						Value:          10.0,
+					},
+					{
+						TimestampNanos: 515 * 1e9,
+						Value:          50.0,
+					},
+					{
+						TimestampNanos: 525 * 1e9,
+						Value:          50.0,
 					},
 				},
 			},
@@ -148,13 +175,19 @@ func TestHttpQuery(t *testing.T) {
 			{
 				Name: "other.metric",
 			},
+			{
+				Name:             "test.metric",
+				Downsampler:      ts.TimeSeriesQueryAggregator_MAX.Enum(),
+				SourceAggregator: ts.TimeSeriesQueryAggregator_MAX.Enum(),
+				Derivative:       ts.TimeSeriesQueryDerivative_DERIVATIVE.Enum(),
+			},
 		},
 	}, response)
 	for _, r := range response.Results {
 		sort.Strings(r.Sources)
 	}
 	if !reflect.DeepEqual(response, expectedResult) {
-		t.Fatalf("actual response %v did not match expected response %v",
+		t.Fatalf("actual response \n%v\n did not match expected response \n%v",
 			response, expectedResult)
 	}
 }


### PR DESCRIPTION
Fix two bugs in time series query:
- Due to an oversight while generating keys, it was possible for a query to miss
  some data. This occurred when the `start` timestamp and the `end` timestamp of the
  query were in different storage keys, and `start + KeyDuration() > end`.
- Fixed bug where the derivative function specified in a query was not reflected
  back in the response.

Fixes #4987
Fixes #5003

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5014)

<!-- Reviewable:end -->
