### PR TITLE
Add a replica GC "last-checked" timestamp for replica GC queue

### DIFF
--- a/keys/constants.go
+++ b/keys/constants.go
@@ -109,6 +109,9 @@ var (
 	localRaftLastIndexSuffix = []byte("rfti")
 	// localRaftLogSuffix is the suffix for the raft log.
 	localRaftLogSuffix = []byte("rftl")
+	// localRangeLastReplicaGCTimestampSuffix is the suffix for a range's
+	// last replica GC timestamp (for GC of old replicas).
+	localRangeLastReplicaGCTimestampSuffix = []byte("rlrt")
 	// localRangeLastVerificationTimestampSuffix is the suffix for a range's
 	// last verification timestamp (for checking integrity of on-disk data).
 	localRangeLastVerificationTimestampSuffix = []byte("rlvt")

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -234,6 +234,12 @@ func RaftLogKey(rangeID roachpb.RangeID, logIndex uint64) roachpb.Key {
 	return key
 }
 
+// RangeLastReplicaGCTimestampKey returns a range-local key for
+// the range's last replica GC timestamp.
+func RangeLastReplicaGCTimestampKey(rangeID roachpb.RangeID) roachpb.Key {
+	return MakeRangeIDUnreplicatedKey(rangeID, localRangeLastReplicaGCTimestampSuffix, nil)
+}
+
 // RangeLastVerificationTimestampKey returns a range-local key for
 // the range's last verification timestamp.
 func RangeLastVerificationTimestampKey(rangeID roachpb.RangeID) roachpb.Key {

--- a/keys/printer.go
+++ b/keys/printer.go
@@ -93,6 +93,7 @@ var (
 		{name: "RaftLog", suffix: localRaftLogSuffix, ppFunc: raftLogKeyPrint},
 		{name: "RaftTruncatedState", suffix: localRaftTruncatedStateSuffix},
 		{name: "RaftLastIndex", suffix: localRaftLastIndexSuffix},
+		{name: "RangeLastReplicaGCTimestamp", suffix: localRangeLastReplicaGCTimestampSuffix},
 		{name: "RangeLastVerificationTimestamp", suffix: localRangeLastVerificationTimestampSuffix},
 		{name: "RangeLeaderLease", suffix: localRangeLeaderLeaseSuffix},
 		{name: "RangeStats", suffix: localRangeStatsSuffix},
@@ -287,6 +288,7 @@ func prettyPrintInternal(key roachpb.Key) (string, bool) {
 //			/[rangeid]/RaftLog/logIndex:[logIndex]    "\x01s"+[rangeid]+"rftl"+[logIndex]
 //			/[rangeid]/RaftTruncatedState             "\x01s"+[rangeid]+"rftt"
 //			/[rangeid]/RaftLastIndex                  "\x01s"+[rangeid]+"rfti"
+//			/[rangeid]/RangeLastReplicaGCTimestamp    "\x01s"+[rangeid]+"rlrt"
 //			/[rangeid]/RangeLastVerificationTimestamp "\x01s"+[rangeid]+"rlvt"
 //			/[rangeid]/RangeStats                     "\x01s"+[rangeid]+"stat"
 //		/Range/...                                  "\x01k"+...

--- a/keys/printer_test.go
+++ b/keys/printer_test.go
@@ -53,6 +53,7 @@ func TestPrettyPrint(t *testing.T) {
 		{RaftHardStateKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RaftHardState"},
 		{RaftLastIndexKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RaftLastIndex"},
 		{RaftLogKey(roachpb.RangeID(1000001), uint64(200001)), "/Local/RangeID/1000001/u/RaftLog/logIndex:200001"},
+		{RangeLastReplicaGCTimestampKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RangeLastReplicaGCTimestamp"},
 		{RangeLastVerificationTimestampKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RangeLastVerificationTimestamp"},
 
 		{MakeRangeKeyPrefix(roachpb.RKey("ok")), `/Local/Range/"ok"`},

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -303,7 +303,7 @@ func (gcq *gcQueue) process(now roachpb.Timestamp, repl *Replica,
 
 	// Store current timestamp as last verification for this replica, as
 	// we've just successfully scanned.
-	if err := repl.SetLastVerificationTimestamp(now); err != nil {
+	if err := repl.setLastVerificationTimestamp(now); err != nil {
 		log.Errorf("failed to set last verification timestamp for replica %s: %s", repl, err)
 	}
 

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -296,7 +296,7 @@ func TestGCQueueProcess(t *testing.T) {
 	}
 
 	// Verify that the last verification timestamp was updated as whole range was scanned.
-	if _, err := tc.rng.GetLastVerificationTimestamp(); err != nil {
+	if _, err := tc.rng.getLastVerificationTimestamp(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -181,6 +181,7 @@ type baseQueue struct {
 	// Some tests in this package disable queues.
 	disabled int32 // updated atomically
 
+	// TODO(tamird): update all queues to use eventLog.
 	eventLog queueLog
 }
 

--- a/storage/replica_data_iter_test.go
+++ b/storage/replica_data_iter_test.go
@@ -71,6 +71,7 @@ func createRangeData(r *Replica, t *testing.T) []engine.MVCCKey {
 		{keys.RaftHardStateKey(r.RangeID), ts0},
 		{keys.RaftLogKey(r.RangeID, 1), ts0},
 		{keys.RaftLogKey(r.RangeID, 2), ts0},
+		{keys.RangeLastReplicaGCTimestampKey(r.RangeID), ts0},
 		{keys.RangeLastVerificationTimestampKey(r.RangeID), ts0},
 		{keys.RangeDescriptorKey(desc.StartKey), ts},
 		{keys.TransactionKey(roachpb.Key(desc.StartKey), uuid.NewV4()), ts0},

--- a/storage/store.go
+++ b/storage/store.go
@@ -541,7 +541,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 	s.splitQueue = newSplitQueue(s.db, s.ctx.Gossip)
 	s.verifyQueue = newVerifyQueue(s.ctx.Gossip, s.ReplicaCount)
 	s.replicateQueue = newReplicateQueue(s.ctx.Gossip, s.allocator, s.ctx.Clock, s.ctx.AllocatorOptions)
-	s.replicaGCQueue = newReplicaGCQueue(s.db, s.ctx.Gossip, &s.mu.Mutex)
+	s.replicaGCQueue = newReplicaGCQueue(s.db, s.ctx.Gossip)
 	s.raftLogQueue = newRaftLogQueue(s.db, s.ctx.Gossip)
 	s.scanner.AddQueues(s.gcQueue, s.splitQueue, s.verifyQueue, s.replicateQueue, s.replicaGCQueue, s.raftLogQueue)
 
@@ -995,9 +995,10 @@ func (s *Store) BootstrapRange(initialValues []roachpb.KeyValue) error {
 	if err := engine.MVCCPutProto(batch, ms, keys.RangeDescriptorKey(desc.StartKey), now, nil, desc); err != nil {
 		return err
 	}
-	// Verification timestamp.
-	// TODO(nvanbenschoten) update stats again here when #4710 is resolved
-	// and the LastVerificationTimestampKey is replicated again.
+	// Replica GC & Verification timestamps.
+	if err := engine.MVCCPutProto(batch, nil /* ms */, keys.RangeLastReplicaGCTimestampKey(desc.RangeID), roachpb.ZeroTimestamp, nil, &now); err != nil {
+		return err
+	}
 	if err := engine.MVCCPutProto(batch, nil /* ms */, keys.RangeLastVerificationTimestampKey(desc.RangeID), roachpb.ZeroTimestamp, nil, &now); err != nil {
 		return err
 	}

--- a/storage/verify_queue.go
+++ b/storage/verify_queue.go
@@ -68,7 +68,7 @@ func (*verifyQueue) shouldQueue(now roachpb.Timestamp, rng *Replica,
 	_ *config.SystemConfig) (shouldQ bool, priority float64) {
 
 	// Get last verification timestamp.
-	lastVerify, err := rng.GetLastVerificationTimestamp()
+	lastVerify, err := rng.getLastVerificationTimestamp()
 	if err != nil {
 		log.Errorf("unable to fetch last verification timestamp: %s", err)
 		return
@@ -105,7 +105,7 @@ func (*verifyQueue) process(now roachpb.Timestamp, rng *Replica,
 	}
 
 	// Store current timestamp as last verification for this range.
-	return rng.SetLastVerificationTimestamp(now)
+	return rng.setLastVerificationTimestamp(now)
 }
 
 // timer returns the duration of intervals between successive range


### PR DESCRIPTION
With this timestamp, we no longer need to refresh the leader lease
when checking a replica for GC.

Removed spurious TODOs for nathan regarding the last verification
timestamp replication.

Closes #4710

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5016)

<!-- Reviewable:end -->
