### PR TITLE
util/timeutil: new time-mocking utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,10 +173,12 @@ dupl:
 
 .PHONY: check
 check:
+	@echo "checking for time.Now calls (use timeutil.Now() instead)"
+	@! git grep -E 'time\.Now' -- '*.go' | grep -vE '^util/(log|timeutil)/\w+\.go:'
 	@echo "checking for proto.Clone calls (use util.CloneProto instead)"
-	@! git grep -E '\.Clone\([^)]+\)' | grep -vE '^util/clone_proto(_test)?\.go:'
+	@! git grep -E '\.Clone\([^)]+\)' -- '*.go' | grep -vE '^util/clone_proto(_test)?\.go:'
 	@echo "checking for grpc.NewServer calls (use rpc.NewServer instead)"
-	@! git grep -E 'grpc\.NewServer\(\)' | grep -vE '^rpc/context(_test)?\.go:'
+	@! git grep -E 'grpc\.NewServer\(\)' -- '*.go' | grep -vE '^rpc/context(_test)?\.go:'
 	@echo "checking for missing defer leaktest.AfterTest"
 	@util/leaktest/check-leaktest.sh
 	@echo "misspell"

--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/randutil"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 var maxTransfer = flag.Int("max-transfer", 999, "Maximum amount to transfer in one transaction.")
@@ -62,7 +63,7 @@ type testState struct {
 }
 
 func (state *testState) done() bool {
-	return !time.Now().Before(state.deadline) || atomic.LoadInt32(&state.stalled) == 1
+	return !timeutil.Now().Before(state.deadline) || atomic.LoadInt32(&state.stalled) == 1
 }
 
 // initClient initializes the client talking to node "i".
@@ -255,7 +256,7 @@ func chaosMonkey(state *testState, c cluster.Cluster, stopClients bool, pickNode
 // Wait until all clients have stopped.
 func waitClientsStop(num int, state *testState, stallDuration time.Duration) {
 	prevRound := atomic.LoadUint64(&state.monkeyIteration)
-	stallTime := time.Now().Add(stallDuration)
+	stallTime := timeutil.Now().Add(stallDuration)
 	var prevOutput string
 	// Spin until all clients are shut.
 	for numShutClients := 0; numShutClients < num; {
@@ -272,16 +273,16 @@ func waitClientsStop(num int, state *testState, stallDuration time.Duration) {
 
 		case <-time.After(time.Second):
 			var newOutput string
-			if time.Now().Before(state.deadline) {
+			if timeutil.Now().Before(state.deadline) {
 				curRound := atomic.LoadUint64(&state.monkeyIteration)
 				if curRound == prevRound {
-					if time.Now().After(stallTime) {
+					if timeutil.Now().After(stallTime) {
 						atomic.StoreInt32(&state.stalled, 1)
 						state.t.Fatalf("Stall detected at round %d, no forward progress for %s", curRound, stallDuration)
 					}
 				} else {
 					prevRound = curRound
-					stallTime = time.Now().Add(stallDuration)
+					stallTime = timeutil.Now().Add(stallDuration)
 				}
 				// Periodically print out progress so that we know the test is
 				// still running and making progress.
@@ -320,7 +321,7 @@ func testClusterRecoveryInner(t *testing.T, c cluster.Cluster, cfg cluster.TestC
 	// One client for each node.
 	initBank(t, c.PGUrl(0))
 
-	start := time.Now()
+	start := timeutil.Now()
 	state := testState{
 		t:        t,
 		errChan:  make(chan error, num),
@@ -380,7 +381,7 @@ func testNodeRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfi
 	// One client for each node.
 	initBank(t, c.PGUrl(0))
 
-	start := time.Now()
+	start := timeutil.Now()
 	state := testState{
 		t:        t,
 		errChan:  make(chan error, 1),

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 const (
@@ -658,7 +659,7 @@ func (l *LocalCluster) stop() {
 			// structured logs?
 			file := filepath.Join(outputLogDir, nodeStr(i),
 				fmt.Sprintf("stderr.%s.log", strings.Replace(
-					time.Now().Format(time.RFC3339), ":", "_", -1)))
+					timeutil.Now().Format(time.RFC3339), ":", "_", -1)))
 
 			maybePanic(os.MkdirAll(filepath.Dir(file), 0777))
 			w, err := os.Create(file)

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 const longWaitTime = 2 * time.Minute
@@ -110,14 +111,14 @@ func TestGossipPeerings(t *testing.T) {
 func testGossipPeeringsInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
 	num := c.NumNodes()
 
-	deadline := time.Now().Add(cfg.Duration)
+	deadline := timeutil.Now().Add(cfg.Duration)
 
 	waitTime := longWaitTime
 	if cfg.Duration < waitTime {
 		waitTime = shortWaitTime
 	}
 
-	for time.Now().Before(deadline) {
+	for timeutil.Now().Before(deadline) {
 		checkGossip(t, c, waitTime, hasPeers(num))
 
 		// Restart the first node.
@@ -158,14 +159,14 @@ func testGossipRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestCon
 	// lease can be acquired.
 	num := c.NumNodes()
 
-	deadline := time.Now().Add(cfg.Duration)
+	deadline := timeutil.Now().Add(cfg.Duration)
 
 	waitTime := longWaitTime
 	if cfg.Duration < waitTime {
 		waitTime = shortWaitTime
 	}
 
-	for time.Now().Before(deadline) {
+	for timeutil.Now().Before(deadline) {
 		log.Infof("waiting for initial gossip connections")
 		checkGossip(t, c, waitTime, hasPeers(num))
 		checkGossip(t, c, waitTime, hasClusterID)

--- a/acceptance/put_test.go
+++ b/acceptance/put_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/randutil"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // TestPut starts up an N node cluster and runs N workers that write
@@ -38,7 +39,7 @@ func testPutInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
 	defer dbStopper.Stop()
 
 	errs := make(chan error, c.NumNodes())
-	start := time.Now()
+	start := timeutil.Now()
 	deadline := start.Add(cfg.Duration)
 	var count int64
 	for i := 0; i < c.NumNodes(); i++ {
@@ -46,7 +47,7 @@ func testPutInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
 			r, _ := randutil.NewPseudoRand()
 			value := randutil.RandBytes(r, 8192)
 
-			for time.Now().Before(deadline) {
+			for timeutil.Now().Before(deadline) {
 				k := atomic.AddInt64(&count, 1)
 				v := value[:r.Intn(len(value))]
 				if pErr := db.Put(fmt.Sprintf("%08d", k), v); pErr != nil {

--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -3,7 +3,7 @@
 set -eu
 
 source $(dirname $0)/../build/init-docker.sh
-$(dirname $0)/../build/builder.sh make install
+$(dirname $0)/../build/builder.sh make install GOFLAGS='-tags clockoffset'
 
 set -x
 go test -tags acceptance ./acceptance ${GOFLAGS-} -run "${TESTS-.}" -timeout ${TESTTIMEOUT-5m} ${TESTFLAGS--v -nodes 3}

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // TestSingleKey stresses the transaction retry machinery by starting
@@ -51,7 +52,7 @@ func testSingleKeyInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig)
 	}
 
 	resultCh := make(chan result, num)
-	deadline := time.Now().Add(cfg.Duration)
+	deadline := timeutil.Now().Add(cfg.Duration)
 	var expected int64
 
 	// Start up num workers each reading and writing the same
@@ -62,8 +63,8 @@ func testSingleKeyInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig)
 		defer dbStopper.Stop()
 		go func() {
 			var r result
-			for time.Now().Before(deadline) {
-				start := time.Now()
+			for timeutil.Now().Before(deadline) {
+				start := timeutil.Now()
 				pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
 					minExp := atomic.LoadInt64(&expected)
 					r, pErr := txn.Get(key)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 type cliTest struct {
@@ -777,7 +778,7 @@ func Example_node() {
 func TestNodeStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	start := time.Now()
+	start := timeutil.Now()
 	c := newCLITest()
 	defer c.stop()
 

--- a/gossip/info_test.go
+++ b/gossip/info_test.go
@@ -22,10 +22,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 func newInfo(val float64) Info {
-	now := time.Now()
+	now := timeutil.Now()
 
 	v := roachpb.Value{Timestamp: roachpb.Timestamp{WallTime: now.UnixNano()}}
 	v.SetFloat(val)

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 type stringMatcher interface {
@@ -88,7 +89,7 @@ func monotonicUnixNano() int64 {
 	monoTime.Lock()
 	defer monoTime.Unlock()
 
-	now := time.Now().UnixNano()
+	now := timeutil.Now().UnixNano()
 	if now <= monoTime.last {
 		now = monoTime.last + 1
 	}
@@ -152,7 +153,7 @@ func (is *infoStore) newInfo(val []byte, ttl time.Duration) *Info {
 func (is *infoStore) getInfo(key string) *Info {
 	if info, ok := is.Infos[key]; ok {
 		// Check TTL and discard if too old.
-		if info.expired(time.Now().UnixNano()) {
+		if info.expired(timeutil.Now().UnixNano()) {
 			delete(is.Infos, key)
 		} else {
 			return info
@@ -289,7 +290,7 @@ func (is *infoStore) runCallbacks(key string, content roachpb.Value, callbacks .
 // function against each info in turn. Be sure to skip over any expired
 // infos.
 func (is *infoStore) visitInfos(visitInfo func(string, *Info) error) error {
-	now := time.Now().UnixNano()
+	now := timeutil.Now().UnixNano()
 
 	if visitInfo != nil {
 		for k, i := range is.Infos {

--- a/security/x509.go
+++ b/security/x509.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // Utility to generate x509 certificates, both CA and not.
@@ -85,7 +86,7 @@ func newTemplate(commonName string) (*x509.Certificate, error) {
 		return nil, err
 	}
 
-	notBefore := time.Now().Add(validFrom)
+	notBefore := timeutil.Now().Add(validFrom)
 	notAfter := notBefore.Add(validFor)
 
 	cert := &x509.Certificate{

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // getText fetches the HTTP response body as text in the form of a
@@ -483,7 +484,7 @@ func TestAdminAPIUIData(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 
-	start := time.Now()
+	start := timeutil.Now()
 
 	mustSetUIData := func(key string, val []byte) {
 		var resp struct{}
@@ -505,7 +506,7 @@ func TestAdminAPIUIData(t *testing.T) {
 		}
 
 		// Sanity check LastUpdated.
-		now := time.Now()
+		now := timeutil.Now()
 		lastUpdated := time.Unix(resp.LastUpdated.Sec, int64(resp.LastUpdated.Nsec))
 		if lastUpdated.Before(start) {
 			t.Fatalf("lastUpdated %s < start %s", lastUpdated, start)

--- a/server/node.go
+++ b/server/node.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
@@ -683,7 +684,7 @@ func (n *Node) Batch(ctx context.Context, args *roachpb.BatchRequest) (*roachpb.
 		defer sp.Finish()
 		ctx := opentracing.ContextWithSpan((*Node)(n).context(), sp)
 
-		tStart := time.Now()
+		tStart := timeutil.Now()
 		var pErr *roachpb.Error
 		br, pErr = n.stores.Send(ctx, *args)
 		if pErr != nil {
@@ -693,7 +694,7 @@ func (n *Node) Batch(ctx context.Context, args *roachpb.BatchRequest) (*roachpb.
 		if br.Error != nil {
 			panic(roachpb.ErrorUnexpectedlySet(n.stores, br))
 		}
-		n.metrics.callComplete(time.Now().Sub(tStart), pErr)
+		n.metrics.callComplete(timeutil.Now().Sub(tStart), pErr)
 		br.Error = pErr
 	}
 

--- a/server/status.go
+++ b/server/status.go
@@ -24,7 +24,8 @@ import (
 	"regexp"
 	"runtime"
 	"strconv"
-	"time"
+
+	"github.com/julienschmidt/httprouter"
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
@@ -35,7 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/julienschmidt/httprouter"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 const (
@@ -400,7 +401,7 @@ func (s *statusServer) handleLogsLocal(w http.ResponseWriter, r *http.Request, _
 
 	startTimestamp, err := parseInt64WithDefault(
 		r.URL.Query().Get("starttime"),
-		time.Now().AddDate(0, 0, -1).UnixNano())
+		timeutil.Now().AddDate(0, 0, -1).UnixNano())
 	if err != nil {
 		http.Error(w,
 			fmt.Sprintf("starttime could not be parsed: %s", err),
@@ -410,7 +411,7 @@ func (s *statusServer) handleLogsLocal(w http.ResponseWriter, r *http.Request, _
 
 	endTimestamp, err := parseInt64WithDefault(
 		r.URL.Query().Get("endtime"),
-		time.Now().UnixNano())
+		timeutil.Now().UnixNano())
 	if err != nil {
 		http.Error(w,
 			fmt.Sprintf("endtime could not be parsed: %s", err),

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // TestStatusLocalStacks verifies that goroutine stack traces are available
@@ -303,13 +304,13 @@ func TestStatusLocalLogs(t *testing.T) {
 	defer ts.Stop()
 
 	// Log an error which we expect to show up on every log file.
-	timestamp := time.Now().UnixNano()
+	timestamp := timeutil.Now().UnixNano()
 	log.Errorf("TestStatusLocalLogFile test message-Error")
-	timestampE := time.Now().UnixNano()
+	timestampE := timeutil.Now().UnixNano()
 	log.Warningf("TestStatusLocalLogFile test message-Warning")
-	timestampEW := time.Now().UnixNano()
+	timestampEW := timeutil.Now().UnixNano()
 	log.Infof("TestStatusLocalLogFile test message-Info")
-	timestampEWI := time.Now().UnixNano()
+	timestampEWI := timeutil.Now().UnixNano()
 
 	type logsWrapper struct {
 		Data []log.FileInfo `json:"d"`

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
@@ -30,6 +29,7 @@ import (
 	csql "github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 type leaseTest struct {
@@ -255,7 +255,7 @@ func TestLeaseManagerReacquire(testingT *testing.T) {
 	defer func() {
 		csql.LeaseDuration, csql.MinLeaseDuration = savedLeaseDuration, savedMinLeaseDuration
 	}()
-	csql.MinLeaseDuration = l1.Expiration().Sub(time.Now())
+	csql.MinLeaseDuration = l1.Expiration().Sub(timeutil.Now())
 	csql.LeaseDuration = 2 * csql.MinLeaseDuration
 
 	// Another lease acquisition from the same node will result in a new lease.

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 var (
@@ -269,7 +270,7 @@ func (t *logicTest) processTestFile(path string) {
 	}
 	defer file.Close()
 
-	t.lastProgress = time.Now()
+	t.lastProgress = timeutil.Now()
 
 	repeat := 1
 	s := newLineScanner(file)
@@ -663,7 +664,7 @@ func (t *logicTest) execQuery(query logicQuery) {
 
 func (t *logicTest) success(file string) {
 	t.progress++
-	now := time.Now()
+	now := timeutil.Now()
 	if now.Sub(t.lastProgress) >= 2*time.Second {
 		t.lastProgress = now
 		fmt.Printf("%s: %d\n", file, t.progress)

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/decimal"
 	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
 
@@ -568,7 +569,7 @@ var builtins = map[string][]builtin{
 			returnType: typeTimestamp,
 			impure:     true,
 			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				return DTimestamp{Time: time.Now()}, nil
+				return DTimestamp{Time: timeutil.Now()}, nil
 			},
 		},
 	},
@@ -1555,14 +1556,14 @@ var uniqueBytesState struct {
 func generateUniqueBytes(nodeID roachpb.NodeID) DBytes {
 	// Unique bytes are composed of the current time in nanoseconds and the
 	// node-id. If the nanosecond value is the same on two consecutive calls to
-	// time.Now() the nanoseconds value is incremented. The node-id is varint
+	// timeutil.Now() the nanoseconds value is incremented. The node-id is varint
 	// encoded. Since node-ids are allocated consecutively starting at 1, the
 	// node-id field will consume 1 or 2 bytes for any reasonably sized cluster.
 	//
 	// TODO(pmattis): Do we have to worry about persisting the milliseconds value
 	// periodically to avoid the clock ever going backwards (e.g. due to NTP
 	// adjustment)?
-	nanos := uint64(time.Now().UnixNano())
+	nanos := uint64(timeutil.Now().UnixNano())
 	uniqueBytesState.Lock()
 	if nanos <= uniqueBytesState.nanos {
 		nanos = uniqueBytesState.nanos + 1
@@ -1603,7 +1604,7 @@ func generateUniqueInt(nodeID roachpb.NodeID) DInt {
 	const precision = uint64(10 * time.Microsecond)
 	const nodeIDBits = 15
 
-	nowNanos := time.Now().UnixNano()
+	nowNanos := timeutil.Now().UnixNano()
 	// Paranoia: nowNanos should never be less than uniqueIntEpoch.
 	if nowNanos < uniqueIntEpoch {
 		nowNanos = uniqueIntEpoch

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/retry"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 func TestSchemaChangeLease(t *testing.T) {
@@ -107,7 +108,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 }
 
 func validExpirationTime(expirationTime int64) bool {
-	now := time.Now()
+	now := timeutil.Now()
 	return expirationTime > now.Add(csql.LeaseDuration/2).UnixNano() && expirationTime < now.Add(csql.LeaseDuration*3/2).UnixNano()
 }
 

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 func TestValues(t *testing.T) {
@@ -166,7 +167,7 @@ func TestGolangParams(t *testing.T) {
 
 		// Interval and timestamp.
 		{time.Duration(1), reflect.TypeOf(parser.DummyInterval)},
-		{time.Now(), reflect.TypeOf(parser.DummyTimestamp)},
+		{timeutil.Now(), reflect.TypeOf(parser.DummyTimestamp)},
 
 		// Primitive type aliases.
 		{roachpb.NodeID(1), reflect.TypeOf(parser.DummyInt)},

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/termie/go-shutil"
 
@@ -36,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/randutil"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 const testCacheSize = 1 << 30 // 1 GB
@@ -374,7 +374,7 @@ func runMVCCPut(valueSize int, b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
-		ts := makeTS(time.Now().UnixNano(), 0)
+		ts := makeTS(timeutil.Now().UnixNano(), 0)
 		if err := MVCCPut(rocksdb, nil, key, ts, value, nil); err != nil {
 			b.Fatalf("failed put: %s", err)
 		}
@@ -413,7 +413,7 @@ func runMVCCConditionalPut(valueSize int, createFirst bool, b *testing.B) {
 	if createFirst {
 		for i := 0; i < b.N; i++ {
 			key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
-			ts := makeTS(time.Now().UnixNano(), 0)
+			ts := makeTS(timeutil.Now().UnixNano(), 0)
 			if err := MVCCPut(rocksdb, nil, key, ts, value, nil); err != nil {
 				b.Fatalf("failed put: %s", err)
 			}
@@ -425,7 +425,7 @@ func runMVCCConditionalPut(valueSize int, createFirst bool, b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
-		ts := makeTS(time.Now().UnixNano(), 0)
+		ts := makeTS(timeutil.Now().UnixNano(), 0)
 		if err := MVCCConditionalPut(rocksdb, nil, key, ts, value, expected, nil); err != nil {
 			b.Fatalf("failed put: %s", err)
 		}
@@ -488,7 +488,7 @@ func runMVCCBatchPut(valueSize, batchSize int, b *testing.B) {
 
 		for j := i; j < end; j++ {
 			key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(j)))
-			ts := makeTS(time.Now().UnixNano(), 0)
+			ts := makeTS(timeutil.Now().UnixNano(), 0)
 			if err := MVCCPut(batch, nil, key, ts, value, nil); err != nil {
 				b.Fatalf("failed put: %s", err)
 			}
@@ -671,7 +671,7 @@ func BenchmarkMVCCPutDelete(b *testing.B) {
 	rocksdb := NewInMem(roachpb.Attributes{}, cacheSize, stopper)
 	defer stopper.Stop()
 
-	r := rand.New(rand.NewSource(int64(time.Now().UnixNano())))
+	r := rand.New(rand.NewSource(int64(timeutil.Now().UnixNano())))
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(r, 10))
 	zeroTS := roachpb.ZeroTimestamp
 	var blockNum int64

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 const (
@@ -421,7 +422,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 	}
 
 	bq.eventLog.Infof(log.V(3), "%s: processing", repl)
-	start := time.Now()
+	start := timeutil.Now()
 	if err := bq.impl.process(clock.Now(), repl, cfg); err != nil {
 		return err
 	}

--- a/storage/scanner.go
+++ b/storage/scanner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // A replicaQueue is a prioritized queue of replicas for which work is
@@ -172,7 +173,7 @@ func (rs *replicaScanner) paceInterval(start, now time.Time) time.Duration {
 // is signaled via the removed channel.
 func (rs *replicaScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stopper *stop.Stopper,
 	repl *Replica) bool {
-	waitInterval := rs.paceInterval(start, time.Now())
+	waitInterval := rs.paceInterval(start, timeutil.Now())
 	rs.waitTimer.Reset(waitInterval)
 	if log.V(6) {
 		log.Infof("Wait time interval set to %s", waitInterval)
@@ -210,7 +211,7 @@ func (rs *replicaScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stop
 // is paced to complete a full scan in approximately the scan interval.
 func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 	stopper.RunWorker(func() {
-		start := time.Now()
+		start := timeutil.Now()
 
 		// waitTimer is reset in each call to waitAndProcess.
 		defer rs.waitTimer.Stop()
@@ -232,7 +233,7 @@ func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 				// Increment iteration count.
 				rs.completedScan.L.Lock()
 				rs.count++
-				rs.total += time.Now().Sub(start)
+				rs.total += timeutil.Now().Sub(start)
 				rs.completedScan.Broadcast()
 				rs.completedScan.L.Unlock()
 				if log.V(6) {
@@ -240,7 +241,7 @@ func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 				}
 
 				// Reset iteration and start time.
-				start = time.Now()
+				start = timeutil.Now()
 			})
 			if shouldStop {
 				return

--- a/storage/scanner_test.go
+++ b/storage/scanner_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // Test implementation of a range set backed by btree.BTree.
@@ -281,7 +282,7 @@ func TestScannerPaceInterval(t *testing.T) {
 		}
 	}
 	for _, duration := range durations {
-		startTime := time.Now()
+		startTime := timeutil.Now()
 		ranges := newTestRangeSet(count, t)
 		s := newReplicaScanner(duration, 0, ranges)
 		interval := s.paceInterval(startTime, startTime)

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 var uniqueStore = []*roachpb.StoreDescriptor{
@@ -91,9 +92,9 @@ func TestStorePoolGossipUpdate(t *testing.T) {
 
 // waitUntilDead will block until the specified store is marked as dead.
 func waitUntilDead(t *testing.T, mc *hlc.ManualClock, sp *StorePool, storeID roachpb.StoreID) {
-	lastTime := time.Now()
+	lastTime := timeutil.Now()
 	util.SucceedsSoon(t, func() error {
-		curTime := time.Now()
+		curTime := timeutil.Now()
 		mc.Increment(curTime.UnixNano() - lastTime.UnixNano())
 		lastTime = curTime
 

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -58,7 +58,7 @@ type Config struct {
 	// To support max TTL in the cache, use something like:
 	//
 	//   func(size int, key Key, value interface{}) {
-	//     return time.Now().UnixNano() - value.(int64) > maxTTLNanos
+	//     return timeutil.Now().UnixNano() - value.(int64) > maxTTLNanos
 	//   }
 	ShouldEvict func(size int, key, value interface{}) bool
 

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/inf.v0"
 
 	"github.com/cockroachdb/cockroach/util/randutil"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 func testBasicEncodeDecode32(encFunc func([]byte, uint32) []byte,
@@ -733,8 +734,8 @@ func TestPeekType(t *testing.T) {
 		{EncodeDecimalDescending(nil, inf.NewDec(0, 0)), Float},
 		{EncodeBytesAscending(nil, []byte("")), Bytes},
 		{EncodeBytesDescending(nil, []byte("")), BytesDesc},
-		{EncodeTimeAscending(nil, time.Now()), Time},
-		{EncodeTimeDescending(nil, time.Now()), TimeDesc},
+		{EncodeTimeAscending(nil, timeutil.Now()), Time},
+		{EncodeTimeDescending(nil, timeutil.Now()), TimeDesc},
 	}
 	for i, c := range testCases {
 		typ := PeekType(c.enc)

--- a/util/hlc/hlc.go
+++ b/util/hlc/hlc.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // TODO(Tobias): Figure out if it would make sense to save some
@@ -89,7 +90,7 @@ func (m *ManualClock) Set(nanos int64) {
 // unix epoch timestamp as a convenience to create a HLC via
 // c := hlc.NewClock(hlc.UnixNano).
 func UnixNano() int64 {
-	return time.Now().UnixNano()
+	return timeutil.Now().UnixNano()
 }
 
 // NewClock creates a new hybrid logical clock associated

--- a/util/leaktest/leaktest.go
+++ b/util/leaktest/leaktest.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // interestingGoroutines returns all goroutines we care about for the purpose
@@ -61,7 +63,7 @@ func AfterTest(t testing.TB) func() {
 	return func() {
 		// Loop, waiting for goroutines to shut down.
 		// Wait up to 5 seconds, but finish as quickly as possible.
-		deadline := time.Now().Add(5 * time.Second)
+		deadline := timeutil.Now().Add(5 * time.Second)
 		for {
 			var leaked []string
 			for _, g := range interestingGoroutines() {
@@ -72,7 +74,7 @@ func AfterTest(t testing.TB) func() {
 			if len(leaked) == 0 {
 				return
 			}
-			if time.Now().Before(deadline) {
+			if timeutil.Now().Before(deadline) {
 				time.Sleep(50 * time.Millisecond)
 				continue
 			}

--- a/util/metric/metric.go
+++ b/util/metric/metric.go
@@ -25,6 +25,8 @@ import (
 	"github.com/VividCortex/ewma"
 	"github.com/codahale/hdrhistogram"
 	"github.com/rcrowley/go-metrics"
+
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 const histWrapNum = 4 // number of histograms to keep in rolling window
@@ -76,7 +78,7 @@ type periodic interface {
 var _ periodic = &Histogram{}
 var _ periodic = &Rate{}
 
-var now = time.Now
+var now = timeutil.Now
 
 func maybeTick(m periodic) {
 	for m.nextTick().Before(now()) {

--- a/util/retry/retry_test.go
+++ b/util/retry/retry_test.go
@@ -19,6 +19,8 @@ package retry
 import (
 	"testing"
 	"time"
+
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 func TestRetryExceedsMaxBackoff(t *testing.T) {
@@ -34,7 +36,7 @@ func TestRetryExceedsMaxBackoff(t *testing.T) {
 	fudgeFactor := opts.Multiplier / 100
 
 	attempts := 0
-	start := time.Now()
+	start := timeutil.Now()
 	for r := Start(opts); r.Next(); attempts++ {
 	}
 

--- a/util/testing.go
+++ b/util/testing.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // Tester is a proxy for e.g. testing.T which does not introduce a dependency
@@ -136,9 +137,9 @@ func SucceedsSoonDepth(depth int, t Tester, fn func() error) {
 // immediately at first and then successively with an exponential backoff
 // starting at 1ns and ending at the specified duration.
 func RetryForDuration(duration time.Duration, fn func() error) error {
-	deadline := time.Now().Add(duration)
+	deadline := timeutil.Now().Add(duration)
 	var lastErr error
-	for wait := time.Duration(1); time.Now().Before(deadline); wait *= 2 {
+	for wait := time.Duration(1); timeutil.Now().Before(deadline); wait *= 2 {
 		lastErr = fn()
 		if lastErr == nil {
 			return nil

--- a/util/testing_test.go
+++ b/util/testing_test.go
@@ -19,6 +19,8 @@ package util
 import (
 	"testing"
 	"time"
+
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 func TestSucceedsSoon(t *testing.T) {
@@ -26,7 +28,7 @@ func TestSucceedsSoon(t *testing.T) {
 	SucceedsSoon(t, func() error { return nil })
 
 	// Try a method which succeeds after a known duration.
-	start := time.Now()
+	start := timeutil.Now()
 	duration := time.Millisecond * 10
 	SucceedsSoon(t, func() error {
 		elapsed := time.Since(start)

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -1,0 +1,55 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tamir Duberstein (tamird@gmail.com)
+
+package timeutil
+
+import (
+	"os"
+	"time"
+)
+
+const offsetEnvKey = "COCKROACH_SIMULATED_OFFSET"
+
+var (
+	nowFunc = time.Now
+
+	offset time.Duration
+)
+
+func initFakeTime() {
+	if offsetStr := os.Getenv(offsetEnvKey); offsetStr != "" {
+		var err error
+		if offset, err = time.ParseDuration(offsetStr); err != nil {
+			panic(err)
+		}
+	}
+	if offset == 0 {
+		nowFunc = time.Now
+	} else {
+		nowFunc = func() time.Time {
+			return time.Now().Add(offset)
+		}
+	}
+}
+
+// Now returns the current local time with an optional offset specified by the
+// environment. The offset functionality is guarded by the  "clockoffset" build
+// tag - if built with that tag, the clock offset is parsed from the
+// "COCKROACH_SIMULATED_OFFSET" environment variable using time.ParseDuration,
+// which supports quasi-human values like "1h" or "1m".
+func Now() time.Time {
+	return nowFunc()
+}

--- a/util/timeutil/time_fake.go
+++ b/util/timeutil/time_fake.go
@@ -1,0 +1,23 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tamir Duberstein (tamird@gmail.com)
+
+// +build clockoffset
+
+package timeutil
+
+func init() {
+	initFakeTime()
+}

--- a/util/timeutil/time_fake_test.go
+++ b/util/timeutil/time_fake_test.go
@@ -1,0 +1,43 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tamir Duberstein (tamird@gmail.com)
+
+package timeutil
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/cockroachdb/cockroach/util/log" // for flags
+)
+
+func TestOffset(t *testing.T) {
+	for _, expectedOffset := range []time.Duration{-time.Hour, time.Hour} {
+		if err := os.Setenv(offsetEnvKey, expectedOffset.String()); err != nil {
+			t.Fatal(err)
+		}
+
+		initFakeTime()
+
+		lowerBound := time.Now().Add(expectedOffset)
+		offsetTime := Now()
+		upperBound := time.Now().Add(expectedOffset)
+
+		if offsetTime.Before(lowerBound) || offsetTime.After(upperBound) {
+			t.Errorf("expected offset time %s to be in the interval\n[%s,%s]", offsetTime, lowerBound, upperBound)
+		}
+	}
+}


### PR DESCRIPTION
Also adds a lint to ensure `time.Now()` isn't used anywhere.

Note that this is a parial mock that doesn't mess with `time.After` or
`time.Sleep`.

cc @knz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5019)

<!-- Reviewable:end -->
