### PR TITLE
Add redirect to actual binary on S3.

### DIFF
--- a/build/build-osx.sh
+++ b/build/build-osx.sh
@@ -4,4 +4,4 @@ set -eu
 
 go get github.com/karalabe/xgo
 # OSX 10.9 is the most recent version available at time of writing.
-xgo --targets=darwin-10.9/amd64 --go=1.6rc2 --ldflags="$($(dirname "${0}")/ldflags.sh)" ${GOPATH%%:*}/src/github.com/cockroachdb/cockroach
+xgo --targets=darwin-10.9/amd64 --go=1.6 --ldflags="$($(dirname "${0}")/ldflags.sh)" ${GOPATH%%:*}/src/github.com/cockroachdb/cockroach

--- a/build/push-one-binary.sh
+++ b/build/push-one-binary.sh
@@ -11,7 +11,9 @@ REPO_NAME="cockroach"
 # $0 takes the path to the binary inside the repo.
 # eg: $0 sql/sql.test sql/sql-foo.test
 # The file will be pushed to: s3://BUCKET_NAME/REPO_NAME/sql-foo.test.SHA
-# The S3 basename will be stored in s3://BUCKET_NAME/REPO_NAME/sql-foo.test.LATEST
+# The binary's sha will be stored in s3://BUCKET_NAME/REPO_NAME/sql-foo.test.LATEST
+# The .LATEST file will also redirect to the latest binary when fetching through
+# the S3 static-website.
 
 sha=$1
 rel_path=$2
@@ -23,5 +25,5 @@ time aws s3 cp ${rel_path} s3://${BUCKET_NAME}/${REPO_NAME}/${binary_name}.${sha
 # Upload LATEST file.
 tmpfile=$(mktemp /tmp/cockroach-push.XXXXXX)
 echo ${sha} > ${tmpfile}
-time aws s3 cp ${tmpfile} s3://${BUCKET_NAME}/${REPO_NAME}/${binary_name}${LATEST_SUFFIX}
+time aws s3 cp --website-redirect "/${REPO_NAME}/${binary_name}.${sha}" ${tmpfile} s3://${BUCKET_NAME}/${REPO_NAME}/${binary_name}${LATEST_SUFFIX}
 rm -f ${tmpfile}


### PR DESCRIPTION
This works when accessing the file through S3's static-hosting.
eg: http://cockroach.s3-website-us-east-1.amazonaws.com/cockroach.LATEST
Accessing through https://s3.amazonaws.com/cockroach/cockroach/cockroach.LATEST
will keep the same behavior.

I just want to have these pushed for now, then I'll tweak the fetch
scripts here and there. The ultimate goal is to point to a redirect from
the download docs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5029)

<!-- Reviewable:end -->
