### PR TITLE
storage: reuse iter and buffer between mvcc calls

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1371,27 +1371,29 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 // Doesn't look like this code here caught that. Shouldn't resolve intents
 // when they're not at the timestamp the Txn mandates them to be.
 func MVCCResolveWriteIntent(engine Engine, ms *MVCCStats, intent roachpb.Intent) error {
+	buf := putBufferPool.Get().(*putBuffer)
+	iter := engine.NewIterator(intent.Key)
+	err := mvccResolveWriteIntent(engine, iter, ms, intent, buf)
+	// Using defer would be more convenient, but it is measurably slower.
+	putBufferPool.Put(buf)
+	iter.Close()
+	return err
+}
+
+// MVCCResolveWriteIntentUsingIter is a variant of MVCCResolveWriteIntent that
+// uses iterator and buffer passed as parameters (e.g. when used in a loop).
+func MVCCResolveWriteIntentUsingIter(engine Engine, iterAndBuf IterAndBuf, ms *MVCCStats, intent roachpb.Intent) error {
+	return mvccResolveWriteIntent(engine, iterAndBuf.iter, ms, intent, iterAndBuf.buf)
+}
+
+func mvccResolveWriteIntent(engine Engine, iter Iterator, ms *MVCCStats,
+	intent roachpb.Intent, buf *putBuffer) error {
 	if len(intent.Key) == 0 {
 		return emptyKeyError()
 	}
 	if len(intent.EndKey) > 0 {
 		return util.Errorf("can't resolve range intent as point intent")
 	}
-
-	buf := putBufferPool.Get().(*putBuffer)
-
-	iter := engine.NewIterator(intent.Key)
-	defer iter.Close()
-
-	err := mvccResolveWriteIntent(engine, iter, ms, intent, buf)
-
-	// Using defer would be more convenient, but it is measurably slower.
-	putBufferPool.Put(buf)
-	return err
-}
-
-func mvccResolveWriteIntent(engine Engine, iter Iterator, ms *MVCCStats,
-	intent roachpb.Intent, buf *putBuffer) error {
 	metaKey := MakeMVCCMetadataKey(intent.Key)
 	meta := &buf.meta
 	ok, origMetaKeySize, origMetaValSize, err := mvccGetMetadata(iter, metaKey, meta)
@@ -1560,42 +1562,71 @@ func mvccResolveWriteIntent(engine Engine, iter Iterator, ms *MVCCStats,
 	return nil
 }
 
+// IterAndBuf used to pass iterators and buffers between MVCC* calls, allowing
+// reuse without the callers needing to know the particulars.
+type IterAndBuf struct {
+	buf  *putBuffer
+	iter Iterator
+}
+
+// GetIterAndBuf returns a IterAndBuf for passing into various MVCC* methods.
+func GetIterAndBuf(engine Engine) IterAndBuf {
+	return IterAndBuf{
+		buf:  putBufferPool.Get().(*putBuffer),
+		iter: engine.NewIterator(nil),
+	}
+}
+
+// Cleanup must be called to release the resources when done.
+func (b IterAndBuf) Cleanup() {
+	putBufferPool.Put(b.buf)
+	b.iter.Close()
+}
+
 // MVCCResolveWriteIntentRange commits or aborts (rolls back) the
 // range of write intents specified by start and end keys for a given
 // txn. ResolveWriteIntentRange will skip write intents of other
 // txns. Specify max=0 for unbounded resolves.
 func MVCCResolveWriteIntentRange(engine Engine, ms *MVCCStats, intent roachpb.Intent, max int64) (int64, error) {
-	encKey := MakeMVCCMetadataKey(intent.Key)
-	encEndKey := MakeMVCCMetadataKey(intent.EndKey)
-	nextKey := encKey
-
 	buf := putBufferPool.Get().(*putBuffer)
 	defer putBufferPool.Put(buf)
 
 	iter := engine.NewIterator(nil)
 	defer iter.Close()
 
+	return MVCCResolveWriteIntentRangeUsingIter(engine, IterAndBuf{buf, iter}, ms, intent, max)
+}
+
+// MVCCResolveWriteIntentRangeUsingIter commits or aborts (rolls back) the
+// range of write intents specified by start and end keys for a given
+// txn. ResolveWriteIntentRange will skip write intents of other
+// txns. Specify max=0 for unbounded resolves.
+func MVCCResolveWriteIntentRangeUsingIter(engine Engine, iterAndBuf IterAndBuf, ms *MVCCStats, intent roachpb.Intent, max int64) (int64, error) {
+	encKey := MakeMVCCMetadataKey(intent.Key)
+	encEndKey := MakeMVCCMetadataKey(intent.EndKey)
+	nextKey := encKey
+
 	var keyBuf []byte
 	num := int64(0)
 	intent.EndKey = nil
 
 	for {
-		iter.Seek(nextKey)
-		if !iter.Valid() || !iter.unsafeKey().Less(encEndKey) {
+		iterAndBuf.iter.Seek(nextKey)
+		if !iterAndBuf.iter.Valid() || !iterAndBuf.iter.unsafeKey().Less(encEndKey) {
 			// No more keys exists in the given range.
 			break
 		}
 
 		// Manually copy the underlying bytes of the unsafe key. This construction
 		// reuses keyBuf across iterations.
-		key := iter.unsafeKey()
+		key := iterAndBuf.iter.unsafeKey()
 		keyBuf = append(keyBuf[:0], key.Key...)
 		key.Key = keyBuf
 
 		var err error
 		if !key.IsValue() {
 			intent.Key = key.Key
-			err = mvccResolveWriteIntent(engine, iter, ms, intent, buf)
+			err = mvccResolveWriteIntent(engine, iterAndBuf.iter, ms, intent, iterAndBuf.buf)
 		}
 		if err != nil {
 			log.Warningf("failed to resolve intent for key %q: %v", key.Key, err)


### PR DESCRIPTION
```
name                    old time/op    new time/op    delta
Insert1_Cockroach-8        385µs ± 2%     388µs ± 1%    ~       (p=0.114 n=9+8)
Insert10_Cockroach-8       749µs ± 2%     734µs ± 1%  -2.12%    (p=0.000 n=9+7)
Insert100_Cockroach-8     3.48ms ± 0%    3.32ms ± 1%  -4.67%    (p=0.000 n=9+9)
Insert1000_Cockroach-8    34.4ms ± 7%    32.8ms ± 7%  -4.64%  (p=0.043 n=10+10)

name                    old alloc/op   new alloc/op   delta
Insert1_Cockroach-8       23.0kB ± 0%    23.0kB ± 0%    ~     (p=0.670 n=10+10)
Insert10_Cockroach-8      67.3kB ± 0%    66.7kB ± 0%  -0.83%   (p=0.000 n=10+9)
Insert100_Cockroach-8      508kB ± 0%     501kB ± 0%  -1.26%  (p=0.000 n=10+10)
Insert1000_Cockroach-8    4.56MB ± 1%    4.50MB ± 1%  -1.47%  (p=0.000 n=10+10)

name                    old allocs/op  new allocs/op  delta
Insert1_Cockroach-8          357 ± 0%       357 ± 0%    ~      (p=0.294 n=10+8)
Insert10_Cockroach-8         908 ± 0%       899 ± 0%  -0.99%    (p=0.002 n=7+8)
Insert100_Cockroach-8      6.18k ± 0%     6.08k ± 0%  -1.60%  (p=0.000 n=10+10)
Insert1000_Cockroach-8     59.0k ± 0%     57.9k ± 1%  -1.72%  (p=0.000 n=10+10)

name                    old time/op    new time/op    delta
Delete1_Cockroach-8        566µs ± 3%     560µs ± 3%    ~     (p=0.218 n=10+10)
Delete10_Cockroach-8      1.78ms ± 2%    1.74ms ± 3%  -1.92%  (p=0.023 n=10+10)
Delete100_Cockroach-8     13.7ms ± 2%    13.5ms ± 3%    ~       (p=0.442 n=8+8)
Delete1000_Cockroach-8     156ms ± 9%     150ms ± 6%    ~     (p=0.165 n=10+10)

name                    old alloc/op   new alloc/op   delta
Delete1_Cockroach-8       29.9kB ± 0%    29.9kB ± 0%    ~     (p=0.896 n=10+10)
Delete10_Cockroach-8      75.7kB ± 0%    75.1kB ± 0%  -0.72%   (p=0.000 n=9+10)
Delete100_Cockroach-8      537kB ± 0%     530kB ± 0%  -1.24%   (p=0.000 n=10+9)
Delete1000_Cockroach-8    4.83MB ± 1%    4.76MB ± 1%  -1.35%  (p=0.000 n=10+10)

name                    old allocs/op  new allocs/op  delta
Delete1_Cockroach-8          567 ± 0%       567 ± 0%    ~     (p=0.650 n=10+10)
Delete10_Cockroach-8       1.24k ± 0%     1.23k ± 0%  -0.70%    (p=0.000 n=9+9)
Delete100_Cockroach-8      7.68k ± 0%     7.58k ± 0%  -1.32%   (p=0.000 n=10+9)
Delete1000_Cockroach-8     71.8k ± 1%     70.8k ± 1%  -1.41%  (p=0.000 n=10+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5031)

<!-- Reviewable:end -->
