### PR TITLE
Limit leader lease proposals to one outstanding per range

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -210,8 +210,8 @@ func NewDistSender(ctx *DistSenderContext, gossip *gossip.Gossip) *DistSender {
 	return ds
 }
 
-// RangeLookup dispatches an RangeLookup request for the given
-// metadata key to the replicas of the given range. Note that we allow
+// RangeLookup dispatches a RangeLookup request for the given metadata
+// key to the replicas of the given range. Note that we allow
 // inconsistent reads when doing range lookups for efficiency. Getting
 // stale data is not a correctness problem but instead may
 // infrequently result in additional latency as additional range

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -703,8 +703,13 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 // can arrange for both possible outcomes of the race.
 //
 // Range 1 is the system keyspace, located on node 0.
-// The range containing leftKey is the left side of the split, located on nodes 1, 2, and 3.
-// The range containing rightKey is the right side of the split, located on nodes 3, 4, and 5.
+//
+// The range containing leftKey is the left side of the split, located
+// on nodes 1, 2, and 3.
+//
+// The range containing rightKey is the right side of the split,
+// located on nodes 3, 4, and 5.
+//
 // Nodes 1-5 are stopped; only node 0 is running.
 //
 // See https://github.com/cockroachdb/cockroach/issues/1644.
@@ -777,7 +782,7 @@ func setupSplitSnapshotRace(t *testing.T) (mtc *multiTestContext, leftKey roachp
 	// unreplicateRange call above. It has four members which means it
 	// can only tolerate one failure without losing quorum. That failure
 	// is store 3 which we stopped earlier. Stopping store 1 too soon
-	// (before it has committed the final config change *and* propagate
+	// (before it has committed the final config change *and* propagated
 	// that commit to the followers 4 and 5) would constitute a second
 	// failure and render the range unable to achieve quorum after
 	// restart (in the SnapshotWins branch).
@@ -833,7 +838,7 @@ func TestSplitSnapshotRace_SplitWins(t *testing.T) {
 	mtc.waitForValues(rightKey, []int64{0, 0, 0, 25, 25, 25})
 }
 
-// TestSplitSnapshotRace_SplitWins exercises one outcome of the
+// TestSplitSnapshotRace_SnapshotWins exercises one outcome of the
 // split/snapshot race: The right side of the split replicates first,
 // so target node sees a raft snapshot before it has processed the split,
 // so it still has a conflicting range.

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -309,58 +309,105 @@ func (m *multiTestContext) Stop() {
 // implementation of "rpcSend" is used to multiplex calls between many
 // local senders in a simple way; It sends the request to
 // multiTestContext's localSenders specified in addrs. The request is
-// sent in round-robin order (except if there's a not-leader error)
-// until no error is returned.
+// sent in slice order, and there's a timeout on sending to a replica
+// before moving to the next.
 //
 // TODO(bdarnell): This is mostly obsolete now that we have a real network
 //   stack available. However, it's still needed to handle the interaction
 //   with our manual clock in the event of retries.
-// TODO(spencer): this rpc sender is limited in that it won't try other
-//   replicas after timeouts (like the one in kv/ does). That means that
-//   if a batch is sent to a node which will never be able to make forward
-//   progress in a test, it will get stuck there forever. We should implement
-//   timeouts here if other tests run into problems.
 func (m *multiTestContext) rpcSend(_ kv.SendOptions, replicas kv.ReplicaSlice,
 	ba roachpb.BatchRequest, _ *rpc.Context) (*roachpb.BatchResponse, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	// This wait group ensures that we don't leave any tasks open before
+	// existing and unlocking the mutex.
+	var wg sync.WaitGroup
+	defer func() {
+		wg.Wait()
+	}()
+
+	type result struct {
+		br   *roachpb.BatchResponse
+		pErr *roachpb.Error
+	}
+
+	// Cancellable context.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Sending loop.
+	sendChan := make(chan result, len(replicas))
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for replicaIndex := range replicas {
+			// Reverse-map the address to its index.
+			var nodeID roachpb.NodeID
+			for i, addr := range m.nodeIDtoAddr {
+				if addr.String() == replicas[replicaIndex].NodeDesc.Address.String() {
+					nodeID = i
+					break
+				}
+			}
+			// Node IDs are assigned in the order the nodes are created by
+			// the multi test context, so we can derive the index for stoppers
+			// and senders by subtracting 1 from the node ID.
+			nodeIndex := int(nodeID) - 1
+
+			// The rpcSend method crosses store boundaries: it is possible that the
+			// destination store is stopped while the source is still running.
+			// Run the send in a Task on the destination store to simulate what
+			// would happen with real RPCs.
+			done := make(chan bool, 1)
+			wg.Add(1)
+			if s := m.stoppers[nodeIndex]; s == nil || !s.RunAsyncTask(func() {
+				defer wg.Done()
+				sender := m.senders[nodeIndex]
+				// Make a copy and clone txn of batch args for sending.
+				baCopy := ba
+				if txn := ba.Txn; txn != nil {
+					txnClone := ba.Txn.Clone()
+					baCopy.Txn = &txnClone
+				}
+				br, pErr := sender.Send(ctx, baCopy)
+				sendChan <- result{br, pErr}
+				done <- pErr == nil
+			}) {
+				wg.Done()
+				sendChan <- result{nil, roachpb.NewError(roachpb.NewSendError("store is stopped", true))}
+				m.expireLeaderLeases()
+				continue
+			}
+
+			select {
+			case <-time.After(100 * time.Millisecond):
+				log.Infof("timeout in client_test rpcSender to replica %s; trying next replica", m.stores[nodeIndex])
+			case success := <-done:
+				if success {
+					return
+				}
+			}
+		}
+	}()
+
 	fail := func(pErr *roachpb.Error) (*roachpb.BatchResponse, error) {
 		br := &roachpb.BatchResponse{}
 		br.Error = pErr
 		return br, nil
 	}
-	var br *roachpb.BatchResponse
+
+	// Loop waiting for responses from replicas.
 	var pErr *roachpb.Error
-	for replicaIndex := 0; replicaIndex < len(replicas); {
-		if txn := ba.Txn; txn != nil {
-			txnClone := ba.Txn.Clone()
-			ba.Txn = &txnClone
+	for range replicas {
+		// Wait for next response.
+		res := <-sendChan
+		if res.pErr == nil {
+			return res.br, nil
 		}
-		// Reverse-map the address to its index.
-		var nodeIndex int
-		for i, addr := range m.nodeIDtoAddr {
-			if addr.String() == replica.NodeDesc.Address.String() {
-				nodeIndex = int(i) - 1
-				break
-			}
-		}
-		// The rpcSend method crosses store boundaries: it is possible that the
-		// destination store is stopped while the source is still running.
-		// Run the send in a Task on the destination store to simulate what
-		// would happen with real RPCs.
-		if s := m.stoppers[nodeIndex]; s == nil || !s.RunTask(func() {
-			sender := m.senders[nodeIndex]
-			br, pErr = sender.Send(context.Background(), ba)
-		}) {
-			pErr = roachpb.NewError(roachpb.NewSendError("store is stopped", true))
-			m.expireLeaderLeases()
-			replicaIndex++
-			continue
-		}
-		if pErr == nil {
-			return br, nil
-		}
+		pErr = res.pErr
 		switch tErr := pErr.GetDetail().(type) {
+		case *roachpb.SendError:
 		case *roachpb.RangeKeyMismatchError:
 		case *roachpb.NotLeaderError:
 			if tErr.Leader == nil {
@@ -372,30 +419,16 @@ func (m *multiTestContext) rpcSend(_ kv.SendOptions, replicas kv.ReplicaSlice,
 			} else if m.stores[tErr.Leader.NodeID-1] == nil {
 				// The leader is known but down, so expire its lease.
 				m.expireLeaderLeases()
-			} else {
-				// Find replica for redirect.
-				found := false
-				for i, r := range replicas {
-					if r.NodeDesc.NodeID == tErr.Leader.NodeID {
-						replicaIndex = i
-						found = true
-						break
-					}
-				}
-				if found {
-					continue
-				}
 			}
 		default:
-			if testutils.IsPError(pErr, `store \d+ not found`) {
+			if testutils.IsPError(res.pErr, `store \d+ not found`) {
 				break
 			}
 			// If any store fails with an error that doesn't indicate we simply
 			// sent to the wrong store, it must have been the correct one and
 			// the command failed.
-			return fail(pErr)
+			return fail(res.pErr)
 		}
-		replicaIndex++
 	}
 	if pErr == nil {
 		panic("err must not be nil here")

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -305,13 +305,21 @@ func (m *multiTestContext) Stop() {
 	}
 }
 
-// rpcSend implements the client.rpcSender interface. This implementation of "rpcSend" is
-// used to multiplex calls between many local senders in a simple way; It sends
-// the request to multiTestContext's localSenders specified in addrs. The request is
-// sent in order until no error is returned.
+// rpcSend implements the client.rpcSender interface. This
+// implementation of "rpcSend" is used to multiplex calls between many
+// local senders in a simple way; It sends the request to
+// multiTestContext's localSenders specified in addrs. The request is
+// sent in round-robin order (except if there's a not-leader error)
+// until no error is returned.
+//
 // TODO(bdarnell): This is mostly obsolete now that we have a real network
-// stack available. However, it's still needed to handle the interaction
-// with our manual clock in the event of retries.
+//   stack available. However, it's still needed to handle the interaction
+//   with our manual clock in the event of retries.
+// TODO(spencer): this rpc sender is limited in that it won't try other
+//   replicas after timeouts (like the one in kv/ does). That means that
+//   if a batch is sent to a node which will never be able to make forward
+//   progress in a test, it will get stuck there forever. We should implement
+//   timeouts here if other tests run into problems.
 func (m *multiTestContext) rpcSend(_ kv.SendOptions, replicas kv.ReplicaSlice,
 	ba roachpb.BatchRequest, _ *rpc.Context) (*roachpb.BatchResponse, error) {
 	m.mu.RLock()
@@ -323,7 +331,7 @@ func (m *multiTestContext) rpcSend(_ kv.SendOptions, replicas kv.ReplicaSlice,
 	}
 	var br *roachpb.BatchResponse
 	var pErr *roachpb.Error
-	for _, replica := range replicas {
+	for replicaIndex := 0; replicaIndex < len(replicas); {
 		if txn := ba.Txn; txn != nil {
 			txnClone := ba.Txn.Clone()
 			ba.Txn = &txnClone
@@ -346,6 +354,7 @@ func (m *multiTestContext) rpcSend(_ kv.SendOptions, replicas kv.ReplicaSlice,
 		}) {
 			pErr = roachpb.NewError(roachpb.NewSendError("store is stopped", true))
 			m.expireLeaderLeases()
+			replicaIndex++
 			continue
 		}
 		if pErr == nil {
@@ -363,6 +372,19 @@ func (m *multiTestContext) rpcSend(_ kv.SendOptions, replicas kv.ReplicaSlice,
 			} else if m.stores[tErr.Leader.NodeID-1] == nil {
 				// The leader is known but down, so expire its lease.
 				m.expireLeaderLeases()
+			} else {
+				// Find replica for redirect.
+				found := false
+				for i, r := range replicas {
+					if r.NodeDesc.NodeID == tErr.Leader.NodeID {
+						replicaIndex = i
+						found = true
+						break
+					}
+				}
+				if found {
+					continue
+				}
 			}
 		default:
 			if testutils.IsPError(pErr, `store \d+ not found`) {
@@ -373,6 +395,7 @@ func (m *multiTestContext) rpcSend(_ kv.SendOptions, replicas kv.ReplicaSlice,
 			// the command failed.
 			return fail(pErr)
 		}
+		replicaIndex++
 	}
 	if pErr == nil {
 		panic("err must not be nil here")

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -96,7 +96,6 @@ func (*gcQueue) acceptsUnsplitRanges() bool {
 // intents exceed thresholds.
 func (*gcQueue) shouldQueue(now roachpb.Timestamp, repl *Replica,
 	sysCfg *config.SystemConfig) (shouldQ bool, priority float64) {
-
 	desc := repl.Desc()
 	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
 	if err != nil {

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -414,7 +414,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 		span := repl.store.Tracer().StartSpan("queue")
 		defer span.Finish()
 		// Create a "fake" get request in order to invoke redirectOnOrAcquireLease.
-		if err := repl.redirectOnOrAcquireLeaderLease(span); err != nil {
+		if err := repl.redirectOnOrAcquireLeaderLease(span, repl.context()); err != nil {
 			bq.eventLog.Infof(log.V(3), "%s: could not acquire leader lease; skipping", repl)
 			return nil
 		}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -170,13 +170,6 @@ type Replica struct {
 	// RWMutex
 	readOnlyCmdMu sync.RWMutex
 
-	llMu struct {
-		sync.Mutex                // Protects all fields in the ll struct.
-		cond       *sync.Cond     // Condition variable for ops waiting on leader lease acquisition
-		cmd        *pendingCmd    // Pending leader lease request
-		err        *roachpb.Error // Error for leader lease request
-	}
-
 	mu struct {
 		sync.Mutex                   // Protects all fields in the mu struct.
 		appliedIndex   uint64        // Last index applied to the state machine.
@@ -190,7 +183,8 @@ type Replica struct {
 		raftGroup      *raft.RawNode
 		replicaID      roachpb.ReplicaID
 		truncatedState *roachpb.RaftTruncatedState
-		tsCache        *TimestampCache // Most recent timestamps for keys / key ranges
+		tsCache        *TimestampCache       // Most recent timestamps for keys / key ranges
+		llChans        []chan *roachpb.Error // Slice of channels to send on after leader lease acquisition
 		// proposeRaftCommandFn can be set to mock out the propose operation.
 		proposeRaftCommandFn func(cmdIDKey, *pendingCmd) error
 		checksums            map[uuid.UUID]replicaChecksum // computed checksum at a snapshot UUID.
@@ -210,7 +204,6 @@ func NewReplica(desc *roachpb.RangeDescriptor, store *Store, replicaID roachpb.R
 		sequence: NewSequenceCache(desc.RangeID),
 		RangeID:  desc.RangeID,
 	}
-	r.llMu.cond = sync.NewCond(&r.llMu.Mutex)
 
 	if err := r.newReplicaInner(desc, store.Clock(), replicaID); err != nil {
 		return nil, err
@@ -283,18 +276,16 @@ func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor) error {
 	}
 
 	// Clear the pending command queue.
-	{
-		r.mu.Lock()
-		defer r.mu.Unlock()
-		for _, p := range r.mu.pendingCmds {
-			p.done <- roachpb.ResponseWithError{
-				Reply: &roachpb.BatchResponse{},
-				Err:   roachpb.NewError(roachpb.NewRangeNotFoundError(r.RangeID)),
-			}
+	r.mu.Lock()
+	for _, p := range r.mu.pendingCmds {
+		p.done <- roachpb.ResponseWithError{
+			Reply: &roachpb.BatchResponse{},
+			Err:   roachpb.NewError(roachpb.NewRangeNotFoundError(r.RangeID)),
 		}
-		// Clear the map.
-		r.mu.pendingCmds = map[cmdIDKey]*pendingCmd{}
 	}
+	// Clear the map.
+	r.mu.pendingCmds = map[cmdIDKey]*pendingCmd{}
+	r.mu.Unlock()
 
 	return r.store.destroyReplicaData(desc)
 }
@@ -420,55 +411,78 @@ func (r *Replica) newNotLeaderError(l *roachpb.Lease, originStoreID roachpb.Stor
 // lease for this replica. Unless an error is returned, the obtained
 // lease will be valid for a time interval containing the requested
 // timestamp. Only a single lease request may be pending at a time.
-func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) (*pendingCmd, *roachpb.Error) {
-	// TODO(Tobias): get duration from configuration, either as a config flag
-	// or, later, dynamically adjusted.
-	duration := DefaultLeaderLeaseDuration
+func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) <-chan *roachpb.Error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	// Prepare a Raft command to get a leader lease for this replica.
-	expiration := timestamp.Add(int64(duration), 0)
-	desc := r.Desc()
-	_, replica := desc.FindReplica(r.store.StoreID())
-	if replica == nil {
-		return nil, roachpb.NewError(roachpb.NewRangeNotFoundError(r.RangeID))
-	}
-	args := &roachpb.LeaderLeaseRequest{
-		Span: roachpb.Span{
-			Key: desc.StartKey.AsRawKey(),
-		},
-		Lease: roachpb.Lease{
-			Start:      timestamp,
-			Expiration: expiration,
-			Replica:    *replica,
-		},
-	}
-	ba := roachpb.BatchRequest{}
-	ba.Timestamp = r.store.Clock().Now()
-	ba.RangeID = r.RangeID
-	ba.Add(args)
-
-	// Send lease request directly to raft in order to skip unnecessary
-	// checks from normal request machinery, (e.g. the command queue).
-	// Note that the command itself isn't traced, but usually the caller
-	// waiting for the result has an active Trace.
-	cmd, err := r.proposeRaftCommand(r.context(), ba)
-	log.Infof("%s: proposed lease with cmd %p (%s)", r.store, cmd, desc)
-	if err != nil {
-		return nil, roachpb.NewError(err)
+	llChan := make(chan *roachpb.Error, 1)
+	if len(r.mu.llChans) > 0 {
+		r.mu.llChans = append(r.mu.llChans, llChan)
+		return llChan
 	}
 
-	go func() {
-		// If the command was committed, wait for the range to apply it.
-		c := <-cmd.done
-		log.Infof("%s: lease finished with cmd %p: %s", r.store, cmd, c.Err)
-		r.llMu.Lock()
-		r.llMu.err = c.Err
-		r.llMu.cmd = nil
-		r.llMu.cond.Broadcast()
-		r.llMu.Unlock()
-	}()
+	r.store.Stopper().RunWorker(func() {
+		pErr := func() *roachpb.Error {
+			// TODO(Tobias): get duration from configuration, either as a config flag
+			// or, later, dynamically adjusted.
+			duration := DefaultLeaderLeaseDuration
 
-	return cmd, nil
+			// Prepare a Raft command to get a leader lease for this replica.
+			expiration := timestamp.Add(int64(duration), 0)
+			desc := r.Desc()
+			_, replica := desc.FindReplica(r.store.StoreID())
+			if replica == nil {
+				return roachpb.NewError(roachpb.NewRangeNotFoundError(r.RangeID))
+			}
+			args := &roachpb.LeaderLeaseRequest{
+				Span: roachpb.Span{
+					Key: desc.StartKey.AsRawKey(),
+				},
+				Lease: roachpb.Lease{
+					Start:      timestamp,
+					Expiration: expiration,
+					Replica:    *replica,
+				},
+			}
+			ba := roachpb.BatchRequest{}
+			ba.Timestamp = r.store.Clock().Now()
+			ba.RangeID = r.RangeID
+			ba.Add(args)
+
+			// Send lease request directly to raft in order to skip unnecessary
+			// checks from normal request machinery, (e.g. the command queue).
+			// Note that the command itself isn't traced, but usually the caller
+			// waiting for the result has an active Trace.
+			cmd, err := r.proposeRaftCommand(r.context(), ba)
+			if err != nil {
+				return roachpb.NewError(err)
+			}
+
+			// If the command was committed, wait for the range to apply it.
+			select {
+			case c := <-cmd.done:
+				if c.Err != nil {
+					if log.V(1) {
+						log.Infof("failed to acquire leader lease for replica %s: %s", r.store, c.Err)
+					}
+				}
+				return c.Err
+			case <-r.store.Stopper().ShouldStop():
+				return roachpb.NewError(r.newNotLeaderError(nil, r.store.StoreID()))
+			}
+		}()
+
+		// Send result of leader lease to all waiter channels.
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		for _, llChan := range r.mu.llChans {
+			llChan <- pErr
+		}
+		r.mu.llChans = r.mu.llChans[:0]
+	})
+
+	r.mu.llChans = append(r.mu.llChans, llChan)
+	return llChan
 }
 
 // redirectOnOrAcquireLeaderLease checks whether this replica has the
@@ -487,18 +501,11 @@ func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) (*pendingCmd, 
 //  will fail as well. If it succeeds, as is likely, then the write
 //  will not incur latency waiting for the command to complete.
 //  Reads, however, must wait.
-func (r *Replica) redirectOnOrAcquireLeaderLease(trace opentracing.Span) *roachpb.Error {
-	// llMU is used to throttle all incoming leader lease requests and is not
-	// used to protect any variables.
-	r.llMu.Lock()
-	defer r.llMu.Unlock()
-
+func (r *Replica) redirectOnOrAcquireLeaderLease(trace opentracing.Span, ctx context.Context) *roachpb.Error {
 	// Loop until the lease is held or the replica ascertains the actual
-	// lease holder.
-	var pErr *roachpb.Error
-	var timestamp roachpb.Timestamp
+	// lease holder. Returns also on context.Done() (timeout or cancellation).
 	for attempt := 1; ; attempt++ {
-		timestamp = r.store.Clock().Now()
+		timestamp := r.store.Clock().Now()
 		if lease := r.getLeaderLease(); lease.Covers(timestamp) {
 			if lease.OwnedBy(r.store.StoreID()) {
 				// Happy path: We have an active lease, nothing to do.
@@ -509,46 +516,31 @@ func (r *Replica) redirectOnOrAcquireLeaderLease(trace opentracing.Span) *roachp
 		}
 
 		// Otherwise, no active lease: Request renewal if a renewal is not already pending.
-		if r.llMu.cmd == nil {
-			trace.LogEvent(fmt.Sprintf("request leader lease (attempt #%d)", attempt))
-			r.llMu.cmd, pErr = r.requestLeaderLease(timestamp)
-			if pErr != nil && pErr.GetDetail() == nil {
-				log.Fatalf("pErr is nil, but get detail isn't")
-			}
-			if pErr.GetDetail() != nil {
-				break
-			}
-		}
-		r.llMu.cond.Wait()
-		if r.llMu.err != nil && r.llMu.err.GetDetail() == nil {
-			log.Fatalf("pErr is nil, but get detail isn't")
-		}
-		if r.llMu.err.GetDetail() != nil {
-			pErr = r.llMu.err
-			break
-		}
-	}
+		trace.LogEvent(fmt.Sprintf("request leader lease (attempt #%d)", attempt))
+		llChan := r.requestLeaderLease(timestamp)
 
-	// Getting a LeaseRejectedError back means someone else got there first, or
-	// the lease request was somehow invalid due to a concurrent change.
-	//
-	// In the case where another machine obtained the lease, we are certain that
-	// it can't be this replica because we're holding a lock.
-	//
-	// In all cases, the error is converted to a NotLeaderError.
-	if _, ok := pErr.GetDetail().(*roachpb.LeaseRejectedError); ok {
-		lease := r.getLeaderLease()
-		if !lease.Covers(timestamp) {
-			// The lease was rejected even though it was not obtained by another
-			// replica.
-			if log.V(1) {
-				log.Warningf("lease for range %s rejected at timestamp %v: %s", r, timestamp, pErr)
+		// Wait for the leader lease to finish, or the context to expire.
+		select {
+		case pErr := <-llChan:
+			if pErr != nil {
+				// Getting a LeaseRejectedError back means someone else got there
+				// first, or the lease request was somehow invalid due to a
+				// concurrent change. Convert the error to a NotLeaderError.
+				if _, ok := pErr.GetDetail().(*roachpb.LeaseRejectedError); ok {
+					lease := r.getLeaderLease()
+					if !lease.Covers(r.store.Clock().Now()) {
+						lease = nil
+					}
+					return roachpb.NewError(r.newNotLeaderError(lease, r.store.StoreID()))
+				}
+				return pErr
 			}
-			lease = nil
+			continue
+		case <-ctx.Done():
+		case <-r.store.Stopper().ShouldStop():
 		}
-		return roachpb.NewError(r.newNotLeaderError(lease, r.store.StoreID()))
+		return roachpb.NewError(r.newNotLeaderError(nil, r.store.StoreID()))
 	}
-	return pErr
 }
 
 // IsInitialized is true if we know the metadata of this range, either
@@ -862,7 +854,7 @@ func (r *Replica) addAdminCmd(ctx context.Context, ba roachpb.BatchRequest) (*ro
 	sp.SetOperationName(reflect.TypeOf(args).String())
 
 	// Admin commands always require the leader lease.
-	if pErr := r.redirectOnOrAcquireLeaderLease(sp); pErr != nil {
+	if pErr := r.redirectOnOrAcquireLeaderLease(sp, ctx); pErr != nil {
 		return nil, pErr
 	}
 
@@ -903,7 +895,7 @@ func (r *Replica) addReadOnlyCmd(ctx context.Context, ba roachpb.BatchRequest) (
 
 	// If the read is consistent, the read requires the leader lease.
 	if ba.ReadConsistency != roachpb.INCONSISTENT {
-		if pErr = r.redirectOnOrAcquireLeaderLease(sp); pErr != nil {
+		if pErr = r.redirectOnOrAcquireLeaderLease(sp, ctx); pErr != nil {
 			return nil, pErr
 		}
 	}
@@ -978,7 +970,7 @@ func (r *Replica) addWriteCmd(ctx context.Context, ba roachpb.BatchRequest, wg *
 	}()
 
 	// This replica must have leader lease to process a write.
-	if pErr = r.redirectOnOrAcquireLeaderLease(sp); pErr != nil {
+	if pErr = r.redirectOnOrAcquireLeaderLease(sp, ctx); pErr != nil {
 		return nil, pErr
 	}
 
@@ -1695,7 +1687,7 @@ func (r *Replica) getLeaseForGossip(ctx context.Context) (bool, *roachpb.Error) 
 		// Check for or obtain the lease, if none active.
 		sp, cleanupSp := tracing.SpanFromContext(opReplica, r.store.Tracer(), ctx)
 		defer cleanupSp()
-		pErr = r.redirectOnOrAcquireLeaderLease(sp)
+		pErr = r.redirectOnOrAcquireLeaderLease(sp, ctx)
 		hasLease = pErr == nil
 		if pErr != nil {
 			switch e := pErr.GetDetail().(type) {

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -163,13 +163,19 @@ type Replica struct {
 	store        *Store
 	stats        *rangeStats    // Range statistics
 	systemDBHash []byte         // sha1 hash of the system config @ last gossip
-	llMu         sync.Mutex     // Synchronizes (throttles) readers' requests for leader lease
 	sequence     *SequenceCache // Provides txn replay protection
 
 	// Held in read mode during read-only commands. Held in exclusive mode to
 	// prevent read-only commands from executing. Acquired before the embedded
 	// RWMutex
 	readOnlyCmdMu sync.RWMutex
+
+	llMu struct {
+		sync.Mutex                // Protects all fields in the ll struct.
+		cond       *sync.Cond     // Condition variable for ops waiting on leader lease acquisition
+		cmd        *pendingCmd    // Pending leader lease request
+		err        *roachpb.Error // Error for leader lease request
+	}
 
 	mu struct {
 		sync.Mutex                   // Protects all fields in the mu struct.
@@ -186,7 +192,7 @@ type Replica struct {
 		truncatedState *roachpb.RaftTruncatedState
 		tsCache        *TimestampCache // Most recent timestamps for keys / key ranges
 		// proposeRaftCommandFn can be set to mock out the propose operation.
-		proposeRaftCommandFn func(cmdIDKey, roachpb.RaftCommand) error
+		proposeRaftCommandFn func(cmdIDKey, *pendingCmd) error
 		checksums            map[uuid.UUID]replicaChecksum // computed checksum at a snapshot UUID.
 		checksumNotify       map[uuid.UUID]chan []byte     // notify of computed checksum.
 	}
@@ -204,6 +210,7 @@ func NewReplica(desc *roachpb.RangeDescriptor, store *Store, replicaID roachpb.R
 		sequence: NewSequenceCache(desc.RangeID),
 		RangeID:  desc.RangeID,
 	}
+	r.llMu.cond = sync.NewCond(&r.llMu.Mutex)
 
 	if err := r.newReplicaInner(desc, store.Clock(), replicaID); err != nil {
 		return nil, err
@@ -266,13 +273,29 @@ func (r *Replica) String() string {
 	return fmt.Sprintf("range=%d [%s-%s)", desc.RangeID, desc.StartKey, desc.EndKey)
 }
 
-// Destroy cleans up all data associated with this range, leaving a tombstone.
+// Destroy clears pending command queue by sending each pending
+// command an error and cleans up all data associated with this range.
 func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor) error {
 	desc := r.Desc()
 	if _, rd := desc.FindReplica(r.store.StoreID()); rd != nil && rd.ReplicaID >= origDesc.NextReplicaID {
 		return util.Errorf("cannot destroy replica %s; replica ID has changed (%s >= %s)",
 			r, rd.ReplicaID, origDesc.NextReplicaID)
 	}
+
+	// Clear the pending command queue.
+	{
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		for _, p := range r.mu.pendingCmds {
+			p.done <- roachpb.ResponseWithError{
+				Reply: &roachpb.BatchResponse{},
+				Err:   roachpb.NewError(roachpb.NewRangeNotFoundError(r.RangeID)),
+			}
+		}
+		// Clear the map.
+		r.mu.pendingCmds = map[cmdIDKey]*pendingCmd{}
+	}
+
 	return r.store.destroyReplicaData(desc)
 }
 
@@ -393,10 +416,11 @@ func (r *Replica) newNotLeaderError(l *roachpb.Lease, originStoreID roachpb.Stor
 	return err
 }
 
-// requestLeaderLease sends a request to obtain or extend a leader lease for
-// this replica. Unless an error is returned, the obtained lease will be valid
-// for a time interval containing the requested timestamp.
-func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) *roachpb.Error {
+// requestLeaderLease sends a request to obtain or extend a leader
+// lease for this replica. Unless an error is returned, the obtained
+// lease will be valid for a time interval containing the requested
+// timestamp. Only a single lease request may be pending at a time.
+func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) (*pendingCmd, *roachpb.Error) {
 	// TODO(Tobias): get duration from configuration, either as a config flag
 	// or, later, dynamically adjusted.
 	duration := DefaultLeaderLeaseDuration
@@ -406,7 +430,7 @@ func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) *roachpb.Error
 	desc := r.Desc()
 	_, replica := desc.FindReplica(r.store.StoreID())
 	if replica == nil {
-		return roachpb.NewError(roachpb.NewRangeNotFoundError(r.RangeID))
+		return nil, roachpb.NewError(roachpb.NewRangeNotFoundError(r.RangeID))
 	}
 	args := &roachpb.LeaderLeaseRequest{
 		Span: roachpb.Span{
@@ -423,32 +447,28 @@ func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) *roachpb.Error
 	ba.RangeID = r.RangeID
 	ba.Add(args)
 
-	// The raft command becomes moot after its expiration, so give it an expiring
-	// context.
-	//
-	// We use a timeout here instead of a deadline of expiration.GoTime() because
-	// database time uses a fake clock in many tests.
-	ctx, cancel := context.WithTimeout(r.context(), duration)
-	defer cancel()
-
 	// Send lease request directly to raft in order to skip unnecessary
 	// checks from normal request machinery, (e.g. the command queue).
 	// Note that the command itself isn't traced, but usually the caller
 	// waiting for the result has an active Trace.
-	pendingCmd, err := r.proposeRaftCommand(ctx, ba)
+	cmd, err := r.proposeRaftCommand(r.context(), ba)
+	log.Infof("%s: proposed lease with cmd %p (%s)", r.store, cmd, desc)
 	if err != nil {
-		return roachpb.NewError(err)
+		return nil, roachpb.NewError(err)
 	}
 
-	// Next if the command was committed, wait for the range to apply it.
-	select {
-	case c := <-pendingCmd.done:
-		return c.Err
-	case <-ctx.Done():
-		// If the context expired we don't know who got the lease but we
-		// know we didn't.
-		return roachpb.NewError(r.newNotLeaderError(nil, r.store.StoreID()))
-	}
+	go func() {
+		// If the command was committed, wait for the range to apply it.
+		c := <-cmd.done
+		log.Infof("%s: lease finished with cmd %p: %s", r.store, cmd, c.Err)
+		r.llMu.Lock()
+		r.llMu.err = c.Err
+		r.llMu.cmd = nil
+		r.llMu.cond.Broadcast()
+		r.llMu.Unlock()
+	}()
+
+	return cmd, nil
 }
 
 // redirectOnOrAcquireLeaderLease checks whether this replica has the
@@ -473,19 +493,41 @@ func (r *Replica) redirectOnOrAcquireLeaderLease(trace opentracing.Span) *roachp
 	r.llMu.Lock()
 	defer r.llMu.Unlock()
 
-	timestamp := r.store.Clock().Now()
-
-	if lease := r.getLeaderLease(); lease.Covers(timestamp) {
-		if lease.OwnedBy(r.store.StoreID()) {
-			// Happy path: We have an active lease, nothing to do.
-			return nil
+	// Loop until the lease is held or the replica ascertains the actual
+	// lease holder.
+	var pErr *roachpb.Error
+	var timestamp roachpb.Timestamp
+	for attempt := 1; ; attempt++ {
+		timestamp = r.store.Clock().Now()
+		if lease := r.getLeaderLease(); lease.Covers(timestamp) {
+			if lease.OwnedBy(r.store.StoreID()) {
+				// Happy path: We have an active lease, nothing to do.
+				return nil
+			}
+			// If lease is currently held by another, redirect to holder.
+			return roachpb.NewError(r.newNotLeaderError(lease, r.store.StoreID()))
 		}
-		// If lease is currently held by another, redirect to holder.
-		return roachpb.NewError(r.newNotLeaderError(lease, r.store.StoreID()))
+
+		// Otherwise, no active lease: Request renewal if a renewal is not already pending.
+		if r.llMu.cmd == nil {
+			trace.LogEvent(fmt.Sprintf("request leader lease (attempt #%d)", attempt))
+			r.llMu.cmd, pErr = r.requestLeaderLease(timestamp)
+			if pErr != nil && pErr.GetDetail() == nil {
+				log.Fatalf("pErr is nil, but get detail isn't")
+			}
+			if pErr.GetDetail() != nil {
+				break
+			}
+		}
+		r.llMu.cond.Wait()
+		if r.llMu.err != nil && r.llMu.err.GetDetail() == nil {
+			log.Fatalf("pErr is nil, but get detail isn't")
+		}
+		if r.llMu.err.GetDetail() != nil {
+			pErr = r.llMu.err
+			break
+		}
 	}
-	trace.LogEvent("request leader lease")
-	// Otherwise, no active lease: Request renewal.
-	pErr := r.requestLeaderLease(timestamp)
 
 	// Getting a LeaseRejectedError back means someone else got there first, or
 	// the lease request was somehow invalid due to a concurrent change.
@@ -500,8 +542,7 @@ func (r *Replica) redirectOnOrAcquireLeaderLease(trace opentracing.Span) *roachp
 			// The lease was rejected even though it was not obtained by another
 			// replica.
 			if log.V(1) {
-				log.Warningf("Lease for range %s rejected at timestamp %v: %s",
-					r, timestamp, pErr)
+				log.Warningf("lease for range %s rejected at timestamp %v: %s", r, timestamp, pErr)
 			}
 			lease = nil
 		}
@@ -1079,7 +1120,7 @@ func (r *Replica) proposeRaftCommand(ctx context.Context, ba roachpb.BatchReques
 // The replica lock must be held.
 func (r *Replica) proposePendingCmdLocked(idKey cmdIDKey, p *pendingCmd) error {
 	if r.mu.proposeRaftCommandFn != nil {
-		return r.mu.proposeRaftCommandFn(idKey, p.raftCmd)
+		return r.mu.proposeRaftCommandFn(idKey, p)
 	}
 
 	if p.raftCmd.Cmd.Timestamp == roachpb.ZeroTimestamp {


### PR DESCRIPTION
The intent of this change is to avoid endlessly proposing leader
lease commands on timeout expirations.

Remove the expiring context when getting leader leases. Instead if
there's an outstanding leader lease, all commands requiring it will
block until the proposed command succeeds or fails.

When a range is garbage collected, we return errors for all of its
pending Raft commands.

Because there's no longer a timeout for leader leases, the test rpc
sender in client_test.go had to be modified to more directly support
requests redirect to the existing leader replica instead of just
waiting for a timeout.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5032)

<!-- Reviewable:end -->
