### PR TITLE
Synchronize SQL timestamps with KV timestamps. 

### DIFF
--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -584,3 +584,29 @@ func TestCommitInBatchWithResponse(t *testing.T) {
 		t.Error("this batch should not be committed")
 	}
 }
+
+// TestTimestampSelectionInOptions verifies that a client can set the
+// Txn timestamp using client.TxnExecOptions.
+func TestTimestampSelectionInOptions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	db := newDB(newTestSender(nil, nil))
+	txn := NewTxn(*db)
+
+	var execOpt TxnExecOptions
+	refTimestamp := roachpb.Timestamp{WallTime: 42, Logical: 69}
+	execOpt.MinInitialTimestamp = refTimestamp
+
+	txnClosure := func(txn *Txn, opt *TxnExecOptions) *roachpb.Error {
+		// Ensure the KV transaction is created.
+		return txn.Put("a", "b")
+	}
+
+	if pErr := txn.Exec(execOpt, txnClosure); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	// Check the timestamp was preserved.
+	if txn.Proto.OrigTimestamp != refTimestamp {
+		t.Errorf("expected txn orig ts to be %s; got %s", refTimestamp, txn.Proto.OrigTimestamp)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -160,6 +160,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		DB:            s.db,
 		Gossip:        s.gossip,
 		LeaseManager:  s.leaseMgr,
+		Clock:         s.clock,
 		TestingMocker: ctx.TestingMocker.ExecutorTestingMocker,
 	}
 

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/retry"
@@ -175,6 +176,7 @@ type ExecutorContext struct {
 	DB           *client.DB
 	Gossip       *gossip.Gossip
 	LeaseManager *LeaseManager
+	Clock        *hlc.Clock
 
 	TestingMocker ExecutorTestingMocker
 }
@@ -295,10 +297,8 @@ func (e *Executor) Prepare(user string, query string, session *Session, args par
 		session:       session,
 	}
 
-	timestamp := timeutil.Now()
 	txn := e.newTxn(session)
-	planMaker.setTxn(txn, timestamp)
-	planMaker.evalCtx.StmtTimestamp = parser.DTimestamp{Time: timestamp}
+	planMaker.setTxn(txn)
 	plan, pErr := planMaker.prepare(stmt)
 	if pErr != nil {
 		return nil, pErr
@@ -413,9 +413,6 @@ type txnState struct {
 	// true if we were inside a txn at some point and that txn was aborted. We
 	// need to reject every subsequent statement.
 	aborted bool
-	// Timestamp to be used by SQL (transaction_timestamp()) in the above
-	// transaction.
-	txnTimestamp time.Time
 	// The schema change closures to run when this txn is done.
 	schemaChangers schemaChangerCollection
 }
@@ -461,25 +458,21 @@ func (e *Executor) ExecuteStatements(
 		session:       session,
 	}
 
-	// Move the transaction state from the session to curTxnState, a struct
-	// that only lives for the duration of this request.
-	// If a pending transaction is present, it will be resumed.
 	curTxnState := txnState{
-		txn:          nil,
-		aborted:      false,
-		txnTimestamp: time.Time{},
+		txn:     nil,
+		aborted: session.Txn.TxnAborted,
 	}
-	txnProto := session.Txn.Txn
-	curTxnState.aborted = session.Txn.TxnAborted
-	if txnProto != nil {
-		curTxnState.txn = e.newTxn(session)
+	if txnProto := session.Txn.Txn; txnProto != nil {
+		// A pending transaction is already present, resume it.
+		curTxnState.txn = client.NewTxn(*e.ctx.DB)
 		curTxnState.txn.Proto = *txnProto
 		curTxnState.txn.UserPriority = session.Txn.UserPriority
 		if session.Txn.MutatesSystemConfig {
 			curTxnState.txn.SetSystemConfigTrigger()
 		}
-		curTxnState.txnTimestamp = session.Txn.TxnTimestamp.GoTime()
+		planMaker.setTxn(curTxnState.txn)
 	}
+
 	session.Txn = Session_Transaction{}
 
 	// Send the Request for SQL execution and set the application-level error
@@ -489,20 +482,16 @@ func (e *Executor) ExecuteStatements(
 
 	// Send back the session state even if there were application-level errors.
 	// Add transaction to session state.
+	session.Txn.TxnAborted = curTxnState.aborted
 	if curTxnState.txn != nil {
 		// TODO(pmattis): Need to associate the leases used by a transaction with
 		// the session state.
 		planMaker.releaseLeases()
-		session.Txn = Session_Transaction{
-			Txn:          &curTxnState.txn.Proto,
-			TxnTimestamp: Timestamp(curTxnState.txnTimestamp),
-			UserPriority: curTxnState.txn.UserPriority,
-		}
+		session.Txn.Txn = &curTxnState.txn.Proto
+		session.Txn.UserPriority = curTxnState.txn.UserPriority
 		session.Txn.MutatesSystemConfig = curTxnState.txn.SystemConfigTrigger()
-		session.Txn.TxnAborted = curTxnState.aborted
 	} else {
 		session.Txn.Txn = nil
-		session.Txn.TxnAborted = curTxnState.aborted
 		session.Txn.MutatesSystemConfig = false
 	}
 
@@ -599,7 +588,7 @@ func (e *Executor) execRequest(
 			}
 			txnState.txn = e.newTxn(planMaker.session)
 			execOpt.AutoRetry = true
-			txnState.txnTimestamp = timeutil.Now()
+			execOpt.MinInitialTimestamp = e.ctx.Clock.Now()
 			txnState.txn.SetDebugName(fmt.Sprintf("sql implicit: %t", execOpt.AutoCommit), 0)
 		}
 		if txnState.state() == noTransaction {
@@ -715,7 +704,7 @@ func runTxnAttempt(
 	txnState.schemaChangers = schemaChangerCollection{}
 	planMaker.schemaChangeCallback = txnState.schemaChangers.queueSchemaChanger
 
-	planMaker.setTxn(txn, txnState.txnTimestamp)
+	planMaker.setTxn(txn)
 	var pErr *roachpb.Error
 	*results, *remainingStmts, pErr = e.execStmtsInCurrentTxn(
 		stmts, planMaker, txnState,
@@ -770,12 +759,9 @@ func (e *Executor) execStmtsInCurrentTxn(
 			log.Infof("about to execute sql statement (%d/%d): %s", i+1, len(stmts), stmt)
 		}
 		txnState.schemaChangers.curStatementIdx = i
-		// For implicit transactions, the transaction timestamp is also
-		// used as the statement_transaction() too.
-		stmtTimestamp := planMaker.evalCtx.TxnTimestamp
-		if !implicitTxn {
-			stmtTimestamp = parser.DTimestamp{Time: timeutil.Now()}
-		}
+
+		stmtTimestamp := parser.DTimestamp{Time: timeutil.Now()}
+
 		var stmtStrBefore string
 		if e.ctx.TestingMocker.CheckStmtStringChange {
 			stmtStrBefore = stmt.String()

--- a/sql/internal.go
+++ b/sql/internal.go
@@ -34,7 +34,7 @@ type InternalExecutor struct {
 // the supplied transaction. Statements are currently executed as the root user.
 func (ie InternalExecutor) ExecuteStatementInTransaction(txn *client.Txn, statement string, params ...interface{}) (int, *roachpb.Error) {
 	p := makePlanner()
-	p.setTxn(txn, txn.Proto.Timestamp.GoTime())
+	p.setTxn(txn)
 	p.user = security.RootUser
 	p.leaseMgr = ie.LeaseManager
 	return p.exec(statement, params...)

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -63,13 +63,18 @@ func makePlanner() *planner {
 	return &planner{session: &Session{}}
 }
 
-func (p *planner) setTxn(txn *client.Txn, timestamp time.Time) {
+func (p *planner) setTxn(txn *client.Txn) {
 	p.txn = txn
-	p.evalCtx.TxnTimestamp = parser.DTimestamp{Time: timestamp}
+	if txn != nil {
+		p.evalCtx.SetTxnTimestamp(txn.Proto.OrigTimestamp)
+	} else {
+		p.evalCtx.SetTxnTimestamp(roachpb.ZeroTimestamp)
+		p.evalCtx.StmtTimestamp.Time = time.Time{}
+	}
 }
 
 func (p *planner) resetTxn() {
-	p.setTxn(nil, time.Time{})
+	p.setTxn(nil)
 }
 
 // makePlan creates the query plan for a single SQL statement. The returned

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -60,7 +60,7 @@ func (sc *SchemaChanger) applyMutations(lease *TableDescriptor_SchemaChangeLease
 		p.user = security.RootUser
 		p.systemConfig = sc.cfg
 		p.leaseMgr = sc.leaseMgr
-		p.setTxn(txn, timeutil.Now())
+		p.setTxn(txn)
 
 		tableDesc, pErr := getTableDescFromID(txn, sc.tableID)
 		if pErr != nil {

--- a/sql/session.pb.go
+++ b/sql/session.pb.go
@@ -139,15 +139,11 @@ type Session_Transaction struct {
 	// txnAborted is set once executing a statement returned an error from KV.
 	// While in this state, every subsequent statement must be rejected until
 	// a COMMIT/ROLLBACK is seen.
-	TxnAborted bool `protobuf:"varint,2,opt,name=txnAborted" json:"txnAborted"`
-	// Timestamp to be used by SQL (transaction_timestamp()) in the above
-	// transaction. Note: this is not the transaction timestamp in
-	// roachpb.Transaction above, although it probably should be (#4393).
-	TxnTimestamp Session_Timestamp                                     `protobuf:"bytes,3,opt,name=txn_timestamp" json:"txn_timestamp"`
-	UserPriority github_com_cockroachdb_cockroach_roachpb.UserPriority `protobuf:"fixed64,4,opt,name=user_priority,casttype=github.com/cockroachdb/cockroach/roachpb.UserPriority" json:"user_priority"`
+	TxnAborted   bool                                                  `protobuf:"varint,2,opt,name=txnAborted" json:"txnAborted"`
+	UserPriority github_com_cockroachdb_cockroach_roachpb.UserPriority `protobuf:"fixed64,3,opt,name=user_priority,casttype=github.com/cockroachdb/cockroach/roachpb.UserPriority" json:"user_priority"`
 	// Indicates that the transaction is mutating keys in the
 	// SystemConfig span.
-	MutatesSystemConfig bool `protobuf:"varint,5,opt,name=mutates_system_config" json:"mutates_system_config"`
+	MutatesSystemConfig bool `protobuf:"varint,4,opt,name=mutates_system_config" json:"mutates_system_config"`
 }
 
 func (m *Session_Transaction) Reset()         { *m = Session_Transaction{} }
@@ -274,18 +270,10 @@ func (m *Session_Transaction) MarshalTo(data []byte) (int, error) {
 		data[i] = 0
 	}
 	i++
-	data[i] = 0x1a
-	i++
-	i = encodeVarintSession(data, i, uint64(m.TxnTimestamp.Size()))
-	n4, err := m.TxnTimestamp.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n4
-	data[i] = 0x21
+	data[i] = 0x19
 	i++
 	i = encodeFixed64Session(data, i, uint64(math.Float64bits(float64(m.UserPriority))))
-	data[i] = 0x28
+	data[i] = 0x20
 	i++
 	if m.MutatesSystemConfig {
 		data[i] = 1
@@ -367,8 +355,6 @@ func (m *Session_Transaction) Size() (n int) {
 		n += 1 + l + sovSession(uint64(l))
 	}
 	n += 2
-	l = m.TxnTimestamp.Size()
-	n += 1 + l + sovSession(uint64(l))
 	n += 9
 	n += 2
 	return n
@@ -754,36 +740,6 @@ func (m *Session_Transaction) Unmarshal(data []byte) error {
 			}
 			m.TxnAborted = bool(v != 0)
 		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field TxnTimestamp", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowSession
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthSession
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.TxnTimestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		case 4:
 			if wireType != 1 {
 				return fmt.Errorf("proto: wrong wireType = %d for field UserPriority", wireType)
 			}
@@ -801,7 +757,7 @@ func (m *Session_Transaction) Unmarshal(data []byte) error {
 			v |= uint64(data[iNdEx-2]) << 48
 			v |= uint64(data[iNdEx-1]) << 56
 			m.UserPriority = github_com_cockroachdb_cockroach_roachpb.UserPriority(math.Float64frombits(v))
-		case 5:
+		case 4:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field MutatesSystemConfig", wireType)
 			}

--- a/sql/session.proto
+++ b/sql/session.proto
@@ -39,15 +39,11 @@ message Session {
     // While in this state, every subsequent statement must be rejected until
     // a COMMIT/ROLLBACK is seen.
     optional bool txnAborted = 2 [(gogoproto.nullable) = false];
-    // Timestamp to be used by SQL (transaction_timestamp()) in the above
-    // transaction. Note: this is not the transaction timestamp in
-    // roachpb.Transaction above, although it probably should be (#4393).
-    optional Timestamp txn_timestamp = 3 [(gogoproto.nullable) = false];
-    optional double user_priority = 4 [(gogoproto.nullable) = false,
+    optional double user_priority = 3 [(gogoproto.nullable) = false,
         (gogoproto.casttype) = "github.com/cockroachdb/cockroach/roachpb.UserPriority"];
     // Indicates that the transaction is mutating keys in the
     // SystemConfig span.
-    optional bool mutates_system_config = 5 [(gogoproto.nullable) = false];
+    optional bool mutates_system_config = 4 [(gogoproto.nullable) = false];
   }
   // Info about the open transaction (if any).
   optional Transaction txn = 3 [(gogoproto.nullable) = false];

--- a/sql/testdata/datetime
+++ b/sql/testdata/datetime
@@ -91,7 +91,7 @@ SELECT age(timestamp '2001-04-10 22:06:45', timestamp '1957-06-13')
 384190h6m45s
 
 query B
-SELECT age(timestamp '1957-06-13') - age(now(), timestamp '1957-06-13') < interval '10s'
+SELECT age(timestamp '1957-06-13') - age(now(), timestamp '1957-06-13') = interval '0s'
 ----
 true
 
@@ -121,7 +121,7 @@ SELECT now() - current_timestamp = interval '0s'
 true
 
 query B
-SELECT now() - statement_timestamp() = interval '0s'
+SELECT now() - statement_timestamp() < interval '10s'
 ----
 true
 
@@ -130,8 +130,6 @@ SELECT clock_timestamp() - statement_timestamp() < interval '10s'
 ----
 true
 
-# Test that implicit transactions use the transaction_timestamp() as
-# the statement_timestamp.
 query B
 SELECT now() - transaction_timestamp() = interval '0s'
 ----
@@ -162,9 +160,10 @@ a
 statement ok
 COMMIT TRANSACTION
 
-# Test that the transaction_timestamp can differ from the current_timestamp.
+# Check that the current_timestamp, now and transaction_timestamp are the same.
+# Test that the transaction_timestamp can differ from the statement_timestamp.
 # Check that the transaction_timestamp changes with each transaction.
-# We use, SELECT * FROM kv, to insert delays of more than a nonsecond.
+# We use, SELECT * FROM kv, to insert delays of more than a nanosecond.
 statement ok
 BEGIN;
 INSERT INTO kv (k,v) VALUES ('b', transaction_timestamp());
@@ -172,11 +171,19 @@ SELECT * FROM kv;
 INSERT INTO kv (k,v) VALUES ('c', transaction_timestamp());
 SELECT * FROM kv;
 INSERT INTO kv (k,v) VALUES ('d', current_timestamp());
-SELECT * FROM KV;
+SELECT * FROM kv;
+INSERT INTO kv (k,v) VALUES ('e', current_timestamp());
+SELECT * FROM kv;
+INSERT INTO kv (k,v) VALUES ('f', now());
+SELECT * FROM kv;
+INSERT INTO kv (k,v) VALUES ('g', now());
+SELECT * FROM kv;
+INSERT INTO kv (k,v) VALUES ('h', statement_timestamp());
+SELECT * FROM kv;
 COMMIT;
 BEGIN;
 SELECT * FROM KV;
-INSERT INTO kv (k,v) VALUES ('e', transaction_timestamp());
+INSERT INTO kv (k,v) VALUES ('i', transaction_timestamp());
 COMMIT;
 
 query I


### PR DESCRIPTION
User-visible changes:
- the SQL `transaction_timestamp()` is now following the KV txn  timestamp. This buys us monotonically increasing SQL timestamps (in the same order as txn commit order)
- `current_timestamp()`, `now()` and `transaction_timestamp()` now refer to the same thing. `age()` computes relative to that too. (This is also what PostgreSQL does).
- `statement_timestamp()` evolves with each statement executed, as in PG.
- a new SQL function `transaction_timestamp_unique()` enables clients to observe strictly monotonically increasing timestamps across different timestamps (when combined with `transaction_timestamp()`).

Fixes #4393

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5037)

<!-- Reviewable:end -->
