### PR TITLE
server: introduce a new port for HTTP requests

### DIFF
--- a/acceptance/cluster/cluster.go
+++ b/acceptance/cluster/cluster.go
@@ -17,7 +17,6 @@
 package cluster
 
 import (
-	"net"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -34,8 +33,6 @@ type Cluster interface {
 	NewClient(*testing.T, int) (*client.DB, *stop.Stopper)
 	// PGUrl returns a URL string for the given node postgres server.
 	PGUrl(int) string
-	// Addr returns the TCP address for the given node.
-	Addr(int) *net.TCPAddr
 	// Assert verifies that the cluster state is as expected (i.e. no unexpected
 	// restarts or node deaths occurred). Tests can call this periodically to
 	// ascertain cluster health.

--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -32,6 +32,7 @@ import (
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/network"
+	"github.com/docker/go-connections/nat"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/util/log"
@@ -243,21 +244,21 @@ func (c *Container) Inspect() (types.ContainerJSON, error) {
 }
 
 // Addr returns the TCP address to connect to.
-func (c *Container) Addr() *net.TCPAddr {
+func (c *Container) Addr(port nat.Port) *net.TCPAddr {
 	containerInfo, err := c.Inspect()
 	if err != nil {
 		return nil
 	}
-	bindings, ok := containerInfo.NetworkSettings.Ports[defaultTCP]
+	bindings, ok := containerInfo.NetworkSettings.Ports[port]
 	if !ok || len(bindings) == 0 {
 		return nil
 	}
-	port, err := strconv.Atoi(bindings[0].HostPort)
+	portNum, err := strconv.Atoi(bindings[0].HostPort)
 	if err != nil {
 		return nil
 	}
 	return &net.TCPAddr{
 		IP:   dockerIP(),
-		Port: port,
+		Port: portNum,
 	}
 }

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -410,7 +410,6 @@ func (l *LocalCluster) startNode(node *testNode) {
 		"start",
 		"--certs=/certs",
 		"--host=" + node.nodeStr,
-		"--port=" + base.DefaultPort,
 		"--alsologtostderr=INFO",
 	}
 	for _, store := range node.stores {
@@ -647,16 +646,11 @@ func (l *LocalCluster) NewClient(t *testing.T, i int) (*roachClient.DB, *stop.St
 		User:  security.NodeUser,
 		Certs: l.CertsDir,
 	}, nil, stopper)
-	sender, err := roachClient.NewSender(rpcContext, l.Addr(i).String())
+	sender, err := roachClient.NewSender(rpcContext, l.Nodes[i].Addr().String())
 	if err != nil {
 		t.Fatal(err)
 	}
 	return roachClient.NewDB(sender), stopper
-}
-
-// Addr returns the TCP address for the given node.
-func (l *LocalCluster) Addr(i int) *net.TCPAddr {
-	return l.Nodes[i].Addr()
 }
 
 // PGUrl returns a URL string for the given node postgres server.
@@ -670,7 +664,7 @@ func (l *LocalCluster) PGUrl(i int) string {
 	pgURL := url.URL{
 		Scheme:   "postgres",
 		User:     url.User(certUser),
-		Host:     l.Addr(i).String(),
+		Host:     l.Nodes[i].Addr().String(),
 		RawQuery: options.Encode(),
 	}
 	return pgURL.String()
@@ -693,5 +687,5 @@ func (l *LocalCluster) Restart(i int) error {
 
 // URL returns the base url.
 func (l *LocalCluster) URL(i int) string {
-	return "https://" + l.Addr(i).String()
+	return "https://" + l.Nodes[i].Addr().String()
 }

--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -29,8 +29,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/rpc"
-	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
@@ -168,25 +166,11 @@ func (f *Farmer) Exec(i int, cmd string) error {
 
 // NewClient implements the Cluster interface.
 func (f *Farmer) NewClient(t *testing.T, i int) (*client.DB, *stop.Stopper) {
-	// TODO(tschottdorf,mberhault): TLS all the things!
-	stopper := stop.NewStopper()
-	rpcContext := rpc.NewContext(&base.Context{
-		User: security.RootUser,
-	}, nil, stopper)
-	sender, err := client.NewSender(rpcContext, f.Addr(i).String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	return client.NewDB(sender), stopper
+	panic("unimplemented")
 }
 
 // PGUrl returns a URL string for the given node postgres server.
 func (f *Farmer) PGUrl(i int) string {
-	panic("unimplemented")
-}
-
-// Addr returns the TCP address for the given node.
-func (f *Farmer) Addr(i int) *net.TCPAddr {
 	panic("unimplemented")
 }
 

--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -252,7 +252,7 @@ func (f *Farmer) Restart(i int) error {
 
 // URL returns the HTTP(s) endpoint.
 func (f *Farmer) URL(i int) string {
-	return "http://" + net.JoinHostPort(f.Nodes()[i], base.DefaultPort)
+	return "http://" + net.JoinHostPort(f.Nodes()[i], base.DefaultHTTPPort)
 }
 
 func (f *Farmer) logf(format string, args ...interface{}) {

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -241,7 +241,7 @@ func testDocker(t *testing.T, name string, cmd []string) error {
 	l := StartCluster(t, readConfigFromFlags()).(*cluster.LocalCluster)
 
 	defer l.AssertAndStop(t)
-	addr := l.Nodes[0].Addr()
+	addr := l.Nodes[0].Addr(cluster.DefaultTCP)
 	containerConfig := container.Config{
 		Image: fmt.Sprintf(image + ":" + postgresTestTag),
 		Env: []string{

--- a/base/context.go
+++ b/base/context.go
@@ -45,6 +45,12 @@ const (
 	NetworkTimeout = 3 * time.Second
 )
 
+type lazyTLSConfig struct {
+	once      sync.Once
+	tlsConfig *tls.Config
+	err       error
+}
+
 // Context is embedded by server.Context. A base context is not meant to be
 // used directly, but embedding contexts should call ctx.InitDefaults().
 type Context struct {
@@ -60,12 +66,11 @@ type Context struct {
 	// the server is running or the user passed in client calls.
 	User string
 
-	// Protects both clientTLSConfig and serverTLSConfig.
-	tlsConfigMu sync.Mutex
 	// clientTLSConfig is the loaded client tlsConfig. It is initialized lazily.
-	clientTLSConfig *tls.Config
+	clientTLSConfig lazyTLSConfig
+
 	// serverTLSConfig is the loaded server tlsConfig. It is initialized lazily.
-	serverTLSConfig *tls.Config
+	serverTLSConfig lazyTLSConfig
 
 	// httpClient is a lazily-initialized http client.
 	// It should be accessed through Context.GetHTTPClient() which will
@@ -108,25 +113,19 @@ func (ctx *Context) GetClientTLSConfig() (*tls.Config, error) {
 		return nil, nil
 	}
 
-	ctx.tlsConfigMu.Lock()
-	defer ctx.tlsConfigMu.Unlock()
-
-	if ctx.clientTLSConfig != nil {
-		return ctx.clientTLSConfig, nil
-	}
-
-	if ctx.Certs != "" {
-		cfg, err := security.LoadClientTLSConfig(ctx.Certs, ctx.User)
-		if err != nil {
-			return nil, util.Errorf("error setting up client TLS config: %s", err)
+	ctx.clientTLSConfig.once.Do(func() {
+		if ctx.Certs != "" {
+			ctx.clientTLSConfig.tlsConfig, ctx.clientTLSConfig.err = security.LoadClientTLSConfig(ctx.Certs, ctx.User)
+			if ctx.clientTLSConfig.err != nil {
+				ctx.clientTLSConfig.err = util.Errorf("error setting up client TLS config: %s", ctx.clientTLSConfig.err)
+			}
+		} else {
+			log.Println("no certificates directory specified: using insecure TLS")
+			ctx.clientTLSConfig.tlsConfig = security.LoadInsecureClientTLSConfig()
 		}
-		ctx.clientTLSConfig = cfg
-	} else {
-		log.Println("no certificates directory specified: using insecure TLS")
-		ctx.clientTLSConfig = security.LoadInsecureClientTLSConfig()
-	}
+	})
 
-	return ctx.clientTLSConfig, nil
+	return ctx.clientTLSConfig.tlsConfig, ctx.clientTLSConfig.err
 }
 
 // GetServerTLSConfig returns the context server TLS config, initializing it if needed.
@@ -138,24 +137,18 @@ func (ctx *Context) GetServerTLSConfig() (*tls.Config, error) {
 		return nil, nil
 	}
 
-	ctx.tlsConfigMu.Lock()
-	defer ctx.tlsConfigMu.Unlock()
+	ctx.serverTLSConfig.once.Do(func() {
+		if ctx.Certs != "" {
+			ctx.serverTLSConfig.tlsConfig, ctx.serverTLSConfig.err = security.LoadServerTLSConfig(ctx.Certs, ctx.User)
+			if ctx.serverTLSConfig.err != nil {
+				ctx.serverTLSConfig.err = util.Errorf("error setting up client TLS config: %s", ctx.serverTLSConfig.err)
+			}
+		} else {
+			ctx.serverTLSConfig.err = util.Errorf("--insecure=false, but --certs is empty. We need a certs directory")
+		}
+	})
 
-	if ctx.serverTLSConfig != nil {
-		return ctx.serverTLSConfig, nil
-	}
-
-	if ctx.Certs == "" {
-		return nil, util.Errorf("--insecure=false, but --certs is empty. We need a certs directory")
-	}
-
-	cfg, err := security.LoadServerTLSConfig(ctx.Certs, ctx.User)
-	if err != nil {
-		return nil, util.Errorf("error setting up server TLS config: %s", err)
-	}
-	ctx.serverTLSConfig = cfg
-
-	return ctx.serverTLSConfig, nil
+	return ctx.serverTLSConfig.tlsConfig, ctx.serverTLSConfig.err
 }
 
 // GetHTTPClient returns the context http client, initializing it

--- a/base/context.go
+++ b/base/context.go
@@ -41,6 +41,9 @@ const (
 	// https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=cockroachdb
 	DefaultPort = "26257"
 
+	// The default port for HTTP-for-humans.
+	DefaultHTTPPort = "8080"
+
 	// NetworkTimeout is the timeout used for network operations.
 	NetworkTimeout = 3 * time.Second
 )

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -163,7 +164,15 @@ func (c cliTest) RunWithArgs(a []string) {
 		fmt.Println(err)
 	}
 	args = append(args, fmt.Sprintf("--host=%s", h))
-	args = append(args, fmt.Sprintf("--port=%s", p))
+	if a[0] == "node" || a[0] == "quit" {
+		_, httpPort, err := net.SplitHostPort(c.HTTPAddr())
+		if err != nil {
+			fmt.Println(err)
+		}
+		args = append(args, fmt.Sprintf("--http-port=%s", httpPort))
+	} else {
+		args = append(args, fmt.Sprintf("--port=%s", p))
+	}
 	// Always load test certs.
 	args = append(args, fmt.Sprintf("--certs=%s", c.certsDir))
 	args = append(args, a[1:]...)

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -34,7 +34,7 @@ import (
 var maxResults int64
 
 var connURL string
-var connUser, connHost, connPort, connDBName string
+var connUser, connHost, connPort, httpPort, connDBName string
 
 // cliContext is the CLI Context used for the command-line client.
 var cliContext = NewContext()
@@ -112,6 +112,9 @@ provide the password on standard input.`),
 
 	"server_port": wrapText(`
 The port to bind to.`),
+
+	"http_port": wrapText(`
+The host:port to bind for HTTP requests.`),
 
 	"store": wrapText(`
 The file path to a storage device. This flag must be specified separately for
@@ -257,6 +260,7 @@ func initFlags(ctx *Context) {
 		// Server flags.
 		f.StringVar(&connHost, "host", "", usage("server_host"))
 		f.StringVarP(&connPort, "port", "p", base.DefaultPort, usage("server_port"))
+		f.StringVar(&httpPort, "http-port", base.DefaultHTTPPort, usage("http_port"))
 		f.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, usage("attrs"))
 		f.VarP(&ctx.Stores, "store", "s", usage("store"))
 
@@ -320,10 +324,15 @@ func initFlags(ctx *Context) {
 	}
 
 	// Commands that need the cockroach port.
-	simpleCmds := []*cobra.Command{kvCmd, nodeCmd, rangeCmd, exterminateCmd, quitCmd}
+	simpleCmds := []*cobra.Command{kvCmd, rangeCmd, exterminateCmd}
 	for _, cmd := range simpleCmds {
 		f := cmd.PersistentFlags()
 		f.StringVarP(&connPort, "port", "p", base.DefaultPort, usage("client_port"))
+	}
+
+	for _, cmd := range []*cobra.Command{nodeCmd, quitCmd} {
+		f := cmd.PersistentFlags()
+		f.StringVar(&httpPort, "http-port", base.DefaultHTTPPort, usage("http_port"))
 	}
 
 	// Commands that establish a SQL connection.
@@ -349,5 +358,6 @@ func init() {
 
 	cobra.OnInitialize(func() {
 		cliContext.Addr = net.JoinHostPort(connHost, connPort)
+		cliContext.HTTPAddr = net.JoinHostPort(connHost, httpPort)
 	})
 }

--- a/cli/node.go
+++ b/cli/node.go
@@ -55,7 +55,7 @@ func runLsNodes(cmd *cobra.Command, args []string) error {
 
 	// Extract Node IDs from NodeStatuses.
 	nodeStatuses := map[string][]status.NodeStatus{}
-	if err := getJSON(cliContext.Addr, server.PathForNodeStatus(""), &nodeStatuses); err != nil {
+	if err := getJSON(cliContext.HTTPAddr, server.PathForNodeStatus(""), &nodeStatuses); err != nil {
 		return err
 	}
 
@@ -103,7 +103,7 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 	case 0:
 		// Show status for all nodes.
 		jsonResponse := map[string][]status.NodeStatus{}
-		if err := getJSON(cliContext.Addr, server.PathForNodeStatus(""), &jsonResponse); err != nil {
+		if err := getJSON(cliContext.HTTPAddr, server.PathForNodeStatus(""), &jsonResponse); err != nil {
 			return err
 		}
 		nodeStatuses = jsonResponse["d"]
@@ -111,7 +111,7 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 	case 1:
 		nodeStatus := status.NodeStatus{}
 		nodeID := args[0]
-		if err := getJSON(cliContext.Addr, server.PathForNodeStatus(nodeID), &nodeStatus); err != nil {
+		if err := getJSON(cliContext.HTTPAddr, server.PathForNodeStatus(nodeID), &nodeStatus); err != nil {
 			return err
 		}
 		if nodeStatus.Desc.NodeID == 0 {

--- a/cli/start.go
+++ b/cli/start.go
@@ -262,7 +262,7 @@ completed, the server exits.
 
 // runQuit accesses the quit shutdown path.
 func runQuit(_ *cobra.Command, _ []string) error {
-	admin, err := client.NewAdminClient(&cliContext.Context.Context, cliContext.Addr, client.Quit)
+	admin, err := client.NewAdminClient(&cliContext.Context.Context, cliContext.HTTPAddr, client.Quit)
 	if err != nil {
 		return err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -618,7 +618,6 @@ func TestConcurrentIncrements(t *testing.T) {
 // TestClientPermissions verifies permission enforcement.
 func TestClientPermissions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("TODO(tamird): grpc is listening on a cmux listener, not a tls.Listener. See https://github.com/golang/go/issues/14221")
 	s := server.StartTestServer(t)
 	defer s.Stop()
 

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -243,7 +243,6 @@ func TestKVDBTransaction(t *testing.T) {
 // TestAuthentication tests authentication for the KV endpoint.
 func TestAuthentication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("TODO(tamird): grpc is listening on a cmux listener, not a tls.Listener. See https://github.com/golang/go/issues/14221")
 	s := server.StartTestServer(t)
 	defer s.Stop()
 

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -33,7 +33,16 @@ const (
 // NewServer is a thin wrapper around grpc.NewServer that registers a heartbeat
 // service.
 func NewServer(ctx *Context) *grpc.Server {
-	s := grpc.NewServer()
+	var s *grpc.Server
+	if ctx.Insecure {
+		s = grpc.NewServer()
+	} else {
+		tlsConfig, err := ctx.GetServerTLSConfig()
+		if err != nil {
+			panic(err)
+		}
+		s = grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
+	}
 	RegisterHeartbeatServer(s, &HeartbeatService{
 		clock:              ctx.localClock,
 		remoteClockMonitor: ctx.RemoteClocks,

--- a/security/certs_test.go
+++ b/security/certs_test.go
@@ -106,6 +106,7 @@ func TestUseCerts(t *testing.T) {
 	testCtx.Certs = certsDir
 	testCtx.User = security.NodeUser
 	testCtx.Addr = "127.0.0.1:0"
+	testCtx.HTTPAddr = "127.0.0.1:0"
 	s := &server.TestServer{Ctx: testCtx}
 	if err := s.Start(); err != nil {
 		t.Fatal(err)
@@ -119,7 +120,7 @@ func TestUseCerts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req, err := http.NewRequest("GET", "https://"+s.ServingAddr()+"/_admin/v1/health", nil)
+	req, err := http.NewRequest("GET", testCtx.HTTPRequestScheme()+"://"+s.HTTPAddr()+"/_admin/v1/health", nil)
 	if err != nil {
 		t.Fatalf("could not create request: %v", err)
 	}
@@ -137,7 +138,7 @@ func TestUseCerts(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Endpoint that does not enforce client auth (see: server/authentication_test.go)
-	req, err = http.NewRequest("GET", "https://"+s.ServingAddr()+"/_admin/v1/health", nil)
+	req, err = http.NewRequest("GET", testCtx.HTTPRequestScheme()+"://"+s.HTTPAddr()+"/_admin/v1/health", nil)
 	if err != nil {
 		t.Fatalf("could not create request: %v", err)
 	}
@@ -157,7 +158,7 @@ func TestUseCerts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
-	req, err = http.NewRequest("GET", "https://"+s.ServingAddr()+"/_admin/v1/health", nil)
+	req, err = http.NewRequest("GET", testCtx.HTTPRequestScheme()+"://"+s.HTTPAddr()+"/_admin/v1/health", nil)
 	if err != nil {
 		t.Fatalf("could not create request: %v", err)
 	}

--- a/security/tls.go
+++ b/security/tls.go
@@ -149,8 +149,7 @@ func newClientTLSConfig(certPEM, keyPEM, caPEM []byte) (*tls.Config, error) {
 	certPool := x509.NewCertPool()
 
 	if ok := certPool.AppendCertsFromPEM(caPEM); !ok {
-		err := util.Errorf("failed to parse PEM data to pool")
-		return nil, err
+		return nil, util.Errorf("failed to parse PEM data to pool")
 	}
 
 	return &tls.Config{

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -73,7 +73,7 @@ func TestAdminDebugExpVar(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 
-	jI, err := getJSON(s.Ctx.HTTPRequestScheme() + "://" + s.ServingAddr() + debugEndpoint + "vars")
+	jI, err := getJSON(s.Ctx.HTTPRequestScheme() + "://" + s.HTTPAddr() + debugEndpoint + "vars")
 	if err != nil {
 		t.Fatalf("failed to fetch JSON: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestAdminDebugPprof(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 
-	body, err := getText(s.Ctx.HTTPRequestScheme() + "://" + s.ServingAddr() + debugEndpoint + "pprof/block")
+	body, err := getText(s.Ctx.HTTPRequestScheme() + "://" + s.HTTPAddr() + debugEndpoint + "pprof/block")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestAdminNetTrace(t *testing.T) {
 	}
 
 	for _, c := range tc {
-		body, err := getText(s.Ctx.HTTPRequestScheme() + "://" + s.ServingAddr() + debugEndpoint + c.segment)
+		body, err := getText(s.Ctx.HTTPRequestScheme() + "://" + s.HTTPAddr() + debugEndpoint + c.segment)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -135,7 +135,7 @@ func apiGet(s *TestServer, path string, v interface{}) error {
 	if err != nil {
 		return err
 	}
-	return util.GetJSON(client, s.Ctx.HTTPRequestScheme(), s.ServingAddr(), apiPath, v)
+	return util.GetJSON(client, s.Ctx.HTTPRequestScheme(), s.HTTPAddr(), apiPath, v)
 }
 
 // apiPost issues a POST to the provided server using the given API path and
@@ -146,7 +146,7 @@ func apiPost(s *TestServer, path, body string, v interface{}) error {
 	if err != nil {
 		return err
 	}
-	return util.PostJSON(client, s.Ctx.HTTPRequestScheme(), s.ServingAddr(), apiPath, body, v)
+	return util.PostJSON(client, s.Ctx.HTTPRequestScheme(), s.HTTPAddr(), apiPath, body, v)
 }
 
 func TestAdminAPIDatabases(t *testing.T) {

--- a/server/authentication_test.go
+++ b/server/authentication_test.go
@@ -123,7 +123,7 @@ func TestSSLEnforcement(t *testing.T) {
 		if err != nil {
 			t.Fatalf("[%d]: failed to get http client: %v", tcNum, err)
 		}
-		url := fmt.Sprintf("%s://%s%s", tc.ctx.HTTPRequestScheme(), s.ServingAddr(), tc.path)
+		url := fmt.Sprintf("%s://%s%s", tc.ctx.HTTPRequestScheme(), s.HTTPAddr(), tc.path)
 		resp, err := doHTTPReq(t, client, tc.method, url, tc.body)
 		if (err == nil) != tc.success {
 			t.Fatalf("[%d]: expected success=%t, got err=%v", tcNum, tc.success, err)

--- a/server/context.go
+++ b/server/context.go
@@ -45,6 +45,7 @@ import (
 const (
 	defaultCGroupMemPath      = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
 	defaultAddr               = ":" + base.DefaultPort
+	defaultHTTPAddr           = ":" + base.DefaultHTTPPort
 	defaultMaxOffset          = 250 * time.Millisecond
 	defaultCacheSize          = 512 << 20 // 512 MB
 	defaultMemtableBudget     = 512 << 20 // 512 MB
@@ -61,8 +62,13 @@ type Context struct {
 	// Embed the base context.
 	base.Context
 
-	// Addr is the host:port to bind for HTTP/RPC traffic.
+	// Addr is the host:port to bind.
 	Addr string
+
+	// HTTPAddr is the host:port to bind for HTTP requests. This is temporary,
+	// and will be removed when grpc.(*Server).ServeHTTP performance problems are
+	// addressed upstream. See https://github.com/grpc/grpc-go/issues/586.
+	HTTPAddr string
 
 	// Stores is specified to enable durable key-value storage.
 	Stores StoreSpecList
@@ -188,6 +194,7 @@ func NewContext() *Context {
 func (ctx *Context) InitDefaults() {
 	ctx.Context.InitDefaults()
 	ctx.Addr = defaultAddr
+	ctx.HTTPAddr = defaultHTTPAddr
 	ctx.MaxOffset = defaultMaxOffset
 	ctx.CacheSize = defaultCacheSize
 	ctx.MemtableBudget = defaultMemtableBudget

--- a/server/server.go
+++ b/server/server.go
@@ -218,21 +218,17 @@ func (s *Server) Start() error {
 	// (pg, http, h2) via the following construction:
 	//
 	// non-TLS case:
-	// net.Listen -> cmux.New
+	// net.Listen -> cmux.New -> pgwire.Match -> pgwire.Server.ServeConn
 	//               |
-	//               -  -> pgwire.Match -> pgwire.Server.ServeConn
 	//               -  -> cmux.HTTP2HeaderField("content-type", "application/grpc") -> grpc.(*Server).Serve
 	//               -  -> cmux.HTTP2 -> http2.(*Server).ServeConn
 	//               -  -> cmux.Any -> http.(*Server).Serve
 	//
 	// TLS case:
-	// net.Listen -> cmux.New
+	// net.Listen -> cmux.New -> pgwire.Match -> pgwire.Server.ServeConn
 	//               |
-	//               -  -> pgwire.Match -> pgwire.Server.ServeConn
-	//               -  -> cmux.Any -> tls.NewListener -> cmux.New
-	//                                                    |
-	//                                                    -  -> cmux.HTTP2HeaderField("content-type", "application/grpc") -> grpc.(*Server).Serve
-	//                                                    -  -> cmux.Any -> http.(*Server).Serve
+	//               -  -> cmux.HTTP2HeaderField("content-type", "application/grpc") -> grpc.(*Server).Serve
+	//               -  -> cmux.Any -> tls.NewListener -> http.(*Server).Serve
 	//
 	// Note that the difference between the TLS and non-TLS cases exists due to
 	// Go's lack of an h2c (HTTP2 Clear Text) implementation. See inline comments

--- a/server/server.go
+++ b/server/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/ts"
 	"github.com/cockroachdb/cockroach/ui"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/grpcutil"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/metric"
@@ -220,14 +221,12 @@ func (s *Server) Start() error {
 	// non-TLS case:
 	// net.Listen -> cmux.New -> pgwire.Match -> pgwire.Server.ServeConn
 	//               |
-	//               -  -> cmux.HTTP2HeaderField("content-type", "application/grpc") -> grpc.(*Server).Serve
 	//               -  -> cmux.HTTP2 -> http2.(*Server).ServeConn
 	//               -  -> cmux.Any -> http.(*Server).Serve
 	//
 	// TLS case:
 	// net.Listen -> cmux.New -> pgwire.Match -> pgwire.Server.ServeConn
 	//               |
-	//               -  -> cmux.HTTP2HeaderField("content-type", "application/grpc") -> grpc.(*Server).Serve
 	//               -  -> cmux.Any -> tls.NewListener -> http.(*Server).Serve
 	//
 	// Note that the difference between the TLS and non-TLS cases exists due to
@@ -256,26 +255,11 @@ func (s *Server) Start() error {
 	m := cmux.New(ln)
 	pgL := m.Match(pgwire.Match)
 
-	// GRPC connections get special handling because using GRPC's ServeHTTP is
-	// prohibitively slow. See https://github.com/grpc/grpc-go/issues/586
-	var grpcL net.Listener
-	grpcMatcher := cmux.HTTP2HeaderField("content-type", "application/grpc")
-
 	var serveConn func(net.Listener, func(net.Conn)) error
 	if tlsConfig != nil {
 		anyL := m.Match(cmux.Any())
-
-		tlsM := cmux.New(tls.NewListener(anyL, tlsConfig))
-		grpcL = tlsM.Match(grpcMatcher)
-
-		serveConn = util.ServeHandler(s.stopper, s, tlsM.Match(cmux.Any()), tlsConfig)
-
-		go func() {
-			util.FatalIfUnexpected(tlsM.Serve())
-		}()
+		serveConn = util.ServeHandler(s.stopper, s, tls.NewListener(anyL, tlsConfig), tlsConfig)
 	} else {
-		grpcL = m.Match(grpcMatcher)
-
 		h2L := m.Match(cmux.HTTP2())
 		anyL := m.Match(cmux.Any())
 
@@ -289,26 +273,22 @@ func (s *Server) Start() error {
 
 		serveConn = util.ServeHandler(s.stopper, s, anyL, tlsConfig)
 
-		go func() {
+		s.stopper.RunWorker(func() {
 			util.FatalIfUnexpected(serveConn(h2L, serveH2))
-		}()
+		})
 	}
 
-	go func() {
-		util.FatalIfUnexpected(s.grpc.Serve(grpcL))
-	}()
-
-	go func() {
+	s.stopper.RunWorker(func() {
 		util.FatalIfUnexpected(serveConn(pgL, func(conn net.Conn) {
 			if err := s.pgServer.ServeConn(conn); err != nil && !util.IsClosedConnection(err) {
 				log.Error(err)
 			}
 		}))
-	}()
+	})
 
-	go func() {
+	s.stopper.RunWorker(func() {
 		util.FatalIfUnexpected(m.Serve())
-	}()
+	})
 
 	s.gossip.Start(s.grpc, unresolvedAddr)
 
@@ -346,13 +326,13 @@ func (s *Server) Start() error {
 
 // initHTTP registers http prefixes.
 func (s *Server) initHTTP() {
-	s.mux.Handle("/", http.FileServer(
+	s.mux.Handle("/", grpcutil.GRPCHandlerFunc(s.grpc, http.FileServer(
 		&assetfs.AssetFS{
 			Asset:     ui.Asset,
 			AssetDir:  ui.AssetDir,
 			AssetInfo: ui.AssetInfo,
 		},
-	))
+	)))
 
 	// The admin server handles both /debug/ and /_admin/
 	// TODO(marc): when cookie-based authentication exists,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -59,7 +59,7 @@ func TestHealth(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := StartTestServer(t)
 	defer s.Stop()
-	url := testContext.HTTPRequestScheme() + "://" + s.ServingAddr() + healthPath
+	url := testContext.HTTPRequestScheme() + "://" + s.HTTPAddr() + healthPath
 	httpClient, err := testContext.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
@@ -86,6 +86,7 @@ func TestPlainHTTPServer(t *testing.T) {
 	// Create a custom context. The default one has a default --certs value.
 	ctx := NewContext()
 	ctx.Addr = "127.0.0.1:0"
+	ctx.HTTPAddr = "127.0.0.1:0"
 	ctx.Insecure = true
 	// TestServer.Start does not override the context if set.
 	s := &TestServer{Ctx: ctx}
@@ -98,7 +99,7 @@ func TestPlainHTTPServer(t *testing.T) {
 	if ctx.HTTPRequestScheme() != "http" {
 		t.Fatalf("expected context.HTTPRequestScheme == \"http\", got: %s", ctx.HTTPRequestScheme())
 	}
-	url := ctx.HTTPRequestScheme() + "://" + s.ServingAddr() + healthPath
+	url := ctx.HTTPRequestScheme() + "://" + s.HTTPAddr() + healthPath
 	httpClient, err := ctx.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +122,7 @@ func TestPlainHTTPServer(t *testing.T) {
 	if testContext.HTTPRequestScheme() != "https" {
 		t.Fatalf("expected context.HTTPRequestScheme == \"http\", got: %s", testContext.HTTPRequestScheme())
 	}
-	url = testContext.HTTPRequestScheme() + "://" + s.ServingAddr() + healthPath
+	url = testContext.HTTPRequestScheme() + "://" + s.HTTPAddr() + healthPath
 	httpClient, err = ctx.GetHTTPClient()
 	if err != nil {
 		t.Fatal(err)
@@ -169,7 +170,7 @@ func TestAcceptEncoding(t *testing.T) {
 		},
 	}
 	for _, d := range testData {
-		req, err := http.NewRequest("GET", testContext.HTTPRequestScheme()+"://"+s.ServingAddr()+healthPath, nil)
+		req, err := http.NewRequest("GET", testContext.HTTPRequestScheme()+"://"+s.HTTPAddr()+healthPath, nil)
 		if err != nil {
 			t.Fatalf("could not create request: %s", err)
 		}

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -49,7 +49,7 @@ func TestStatusLocalStacks(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 
-	body, err := getText(testContext.HTTPRequestScheme() + "://" + s.ServingAddr() + "/_status/stacks/local")
+	body, err := getText(testContext.HTTPRequestScheme() + "://" + s.HTTPAddr() + "/_status/stacks/local")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func TestStatusLocalStacks(t *testing.T) {
 		t.Errorf("expected %s to match %s", body, re)
 	}
 
-	body, err = getText(testContext.HTTPRequestScheme() + "://" + s.ServingAddr() + "/_status/stacks/1")
+	body, err = getText(testContext.HTTPRequestScheme() + "://" + s.HTTPAddr() + "/_status/stacks/1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestStatusJson(t *testing.T) {
 	for _, spec := range testCases {
 		contentTypes := []string{util.JSONContentType, util.ProtoContentType, util.YAMLContentType}
 		for _, contentType := range contentTypes {
-			req, err := http.NewRequest("GET", testContext.HTTPRequestScheme()+"://"+s.ServingAddr()+spec.keyPrefix, nil)
+			req, err := http.NewRequest("GET", testContext.HTTPRequestScheme()+"://"+s.HTTPAddr()+spec.keyPrefix, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -162,7 +162,7 @@ func TestStatusGossipJson(t *testing.T) {
 	}
 	contentTypes := []string{util.JSONContentType, util.ProtoContentType, util.YAMLContentType}
 	for _, contentType := range contentTypes {
-		req, err := http.NewRequest("GET", testContext.HTTPRequestScheme()+"://"+s.ServingAddr()+"/_status/gossip/local", nil)
+		req, err := http.NewRequest("GET", testContext.HTTPRequestScheme()+"://"+s.HTTPAddr()+"/_status/gossip/local", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -217,7 +217,7 @@ func getRequest(t *testing.T, ts TestServer, path string) []byte {
 		t.Fatal(err)
 	}
 
-	url := testContext.HTTPRequestScheme() + "://" + ts.ServingAddr() + path
+	url := testContext.HTTPRequestScheme() + "://" + ts.HTTPAddr() + path
 	for r := retry.Start(retryOptions); r.Next(); {
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -121,6 +121,7 @@ func NewTestContext() *Context {
 	// Start() to an available port.
 	// Call TestServer.ServingAddr() for the full address (including bound port).
 	ctx.Addr = "127.0.0.1:0"
+	ctx.HTTPAddr = "127.0.0.1:0"
 	// Set standard user for intra-cluster traffic.
 	ctx.User = security.NodeUser
 
@@ -281,9 +282,14 @@ func (ts *TestServer) Stores() *storage.Stores {
 	return ts.node.stores
 }
 
-// ServingAddr returns the rpc server's address. Should be used by clients.
+// ServingAddr returns the server's address. Should be used by clients.
 func (ts *TestServer) ServingAddr() string {
 	return ts.ctx.Addr
+}
+
+// HTTPAddr returns the server's HTTP address. Should be used by humans.
+func (ts *TestServer) HTTPAddr() string {
+	return ts.ctx.HTTPAddr
 }
 
 // ServingHost returns the host portion of the rpc server's address.

--- a/ts/server_test.go
+++ b/ts/server_test.go
@@ -170,7 +170,7 @@ func TestHttpQuery(t *testing.T) {
 	}
 
 	response := &ts.TimeSeriesQueryResponse{}
-	session := newTestHTTPSession(t, &base.Context{}, tsrv.ServingAddr())
+	session := newTestHTTPSession(t, &base.Context{}, tsrv.HTTPAddr())
 	session.PostProto(ts.URLQuery, &ts.TimeSeriesQueryRequest{
 		StartNanos: 500 * 1e9,
 		EndNanos:   526 * 1e9,

--- a/util/net.go
+++ b/util/net.go
@@ -118,7 +118,7 @@ func ServeHandler(stopper *stop.Stopper, handler http.Handler, ln net.Listener, 
 		log.Fatal(err)
 	}
 
-	go func() {
+	stopper.RunWorker(func() {
 		FatalIfUnexpected(httpServer.Serve(ln))
 
 		<-stopper.ShouldStop()
@@ -127,7 +127,7 @@ func ServeHandler(stopper *stop.Stopper, handler http.Handler, ln net.Listener, 
 			conn.Close()
 		}
 		mu.Unlock()
-	}()
+	})
 
 	logFn := logger.Printf
 	return func(l net.Listener, serveConn func(net.Conn)) error {


### PR DESCRIPTION
It turns out that accurately using cmux to sniff grpc connections is
hard. Most h2 clients behave as follows after connecting:
- S(Settings) -> S(WindowUpdate) -> R(SettingsAck) -> S(Headers)

Where S indicates sending and R indicates receiving.

grpc-go's h2 client behaves differently - it does not wait for the
SettingsAck. This allowed the old implementation to detect it based on
the headers it supplied, but broke all other h2 clients as connection
negotiation deadlocked.

This commit can be reverted wholesale when grpc.(*Server).ServeHTTP's
performance problems are addressed upstream.
See grpc/grpc-go#586.

Fixes #5020.
Fixes #5023.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5039)

<!-- Reviewable:end -->
