### PR TITLE
acceptance: Fix event flakiness

### DIFF
--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -85,6 +85,7 @@ func pullImage(l *LocalCluster, options types.ImagePullOptions) error {
 		var message interface{}
 		if err := dec.Decode(&message); err != nil {
 			if err == io.EOF {
+				_, _ = fmt.Fprintln(os.Stderr)
 				return nil
 			}
 			return err
@@ -252,6 +253,7 @@ func (c *Container) Inspect() (types.ContainerJSON, error) {
 func (c *Container) Addr(port nat.Port) *net.TCPAddr {
 	containerInfo, err := c.Inspect()
 	if err != nil {
+		log.Error(err)
 		return nil
 	}
 	bindings, ok := containerInfo.NetworkSettings.Ports[port]
@@ -260,6 +262,7 @@ func (c *Container) Addr(port nat.Port) *net.TCPAddr {
 	}
 	portNum, err := strconv.Atoi(bindings[0].HostPort)
 	if err != nil {
+		log.Error(err)
 		return nil
 	}
 	return &net.TCPAddr{


### PR DESCRIPTION
The goroutine streaming from the events API sometimes spontanously gets a
string-wrapped EOF error back right at the beginning.

We now simply retry on all errors until the context gets canceled.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5041)

<!-- Reviewable:end -->
