### PR TITLE
sql: allow RETURNING clause to access all columns

### DIFF
--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -335,9 +335,16 @@ INSERT INTO return VALUES (default) RETURNING return.a
 statement ok
 INSERT INTO return VALUES (default) RETURNING rowid != unique_rowid()
 
-# Cannot return non-default columns when columns specified.
-statement error pq: qualified name "b" not found
+query I colnames
 INSERT INTO return (a) VALUES (default) RETURNING b
+----
+b
+NULL
+
+query III
+INSERT INTO return (b) VALUES (1) RETURNING *, a+1
+----
+3 1 4
 
 query II colnames
 INSERT INTO return VALUES (default) RETURNING *
@@ -366,6 +373,11 @@ INSERT INTO return VALUES (1) RETURNING *
 a b
 1 NULL
 
+query II colnames
+INSERT INTO return (a) VALUES (1) RETURNING *
+----
+a b
+1 NULL
 
 statement error pq: "return.*" cannot be aliased
 INSERT INTO return VALUES (1, 2), (3, 4) RETURNING return.* as x

--- a/sql/testdata/update
+++ b/sql/testdata/update
@@ -183,23 +183,35 @@ UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING b as col1, c as col2, 4 as col
 col1 col2 col3
 8    9    4
 
-# Issue #4368: we should be able to return other columns.
-query error pq: qualified name "a" not found
+query I colnames
 UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING a
-
-# Issue #4368: this should return all columns in the table.
-query II colnames
-UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING *
 ----
-b c
-8 9
+a
+1
 
-# Issue #4368: this should return all columns in the table.
-query II colnames
+query IIII colnames
+UPDATE abc SET (b, c) = (VALUES (5, 6)) RETURNING a, b, c, 4
+----
+a b c 4
+1 5 6 4
+
+query III colnames
+UPDATE abc SET (b, c) = (VALUES (7, 8)) RETURNING *
+----
+a b c
+1 7 8
+
+query IIII colnames
+UPDATE abc SET (b, c) = (VALUES (7, 8)) RETURNING *, 4
+----
+a b c 4
+1 7 8 4
+
+query III colnames
 UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING abc.*
 ----
-b c
-8 9
+a b c
+1 8 9
 
 statement error pq: "abc.*" cannot be aliased
 UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING abc.* as x
@@ -217,7 +229,3 @@ UPDATE abc SET (b, b) = (10, 11)
 
 statement error multiple assignments to same column "b"
 UPDATE abc SET (b, c) = (10, 11), b = 12
-
-# Cannot return non-specified columns.
-statement error pq: qualified name "a" not found
-UPDATE abc SET (b, c) = (13, 14) RETURNING a


### PR DESCRIPTION
The RETURNING clause can only access columns that are being updated or inserted.
This is fixed by always providing all columns to ReturningHelper. For update we
already have values for all columns in rowVals; for insert we fill in the
provided values and let the other values be NULL.

Fixes #4368.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5044)

<!-- Reviewable:end -->
