### PR TITLE
Downgrade consistency checksum mismatch to Error

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1493,7 +1493,8 @@ func (r *Replica) VerifyChecksum(batch engine.Engine, ms *engine.MVCCStats, h ro
 				if p := r.store.ctx.TestingMocker.BadChecksumPanic; p != nil {
 					p()
 				} else {
-					panic(fmt.Sprintf("checksums: e = %v, v = %v", args.Checksum, c.checksum))
+					// TODO(.*): see #5051.
+					log.Errorf("checksums: e = %v, v = %v", args.Checksum, c.checksum)
 				}
 			}
 		} else {


### PR DESCRIPTION
See #5051 (and I am sure many others to follow). It is nice that this
catches something, but now it interferes with existing test coverage.
We need to solve #5051 and then revert this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5053)

<!-- Reviewable:end -->
