### PR TITLE
kv: add per-batch limit on scan results

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -334,13 +334,13 @@ func (db *DB) CheckConsistency(begin, end interface{}) *roachpb.Error {
 // sendAndFill is a helper which sends the given batch and fills its results,
 // returning the appropriate error which is either from the first failing call,
 // or an "internal" error.
-func sendAndFill(send func(...roachpb.Request) (*roachpb.BatchResponse, *roachpb.Error), b *Batch) (*roachpb.BatchResponse, *roachpb.Error) {
+func sendAndFill(send func(int64, ...roachpb.Request) (*roachpb.BatchResponse, *roachpb.Error), b *Batch) (*roachpb.BatchResponse, *roachpb.Error) {
 	// Errors here will be attached to the results, so we will get them from
 	// the call to fillResults in the regular case in which an individual call
 	// fails. But send() also returns its own errors, so there's some dancing
 	// here to do because we want to run fillResults() so that the individual
 	// result gets initialized with an error from the corresponding call.
-	br, pErr := send(b.reqs...)
+	br, pErr := send(b.MaxScanResults, b.reqs...)
 	if pErr != nil {
 		// Discard errors from fillResults.
 		_ = b.fillResults(nil, pErr)
@@ -396,7 +396,8 @@ func (db *DB) Txn(retryable func(txn *Txn) *roachpb.Error) *roachpb.Error {
 
 // send runs the specified calls synchronously in a single batch and returns
 // any errors. Returns a nil response for empty input (no requests).
-func (db *DB) send(reqs ...roachpb.Request) (*roachpb.BatchResponse, *roachpb.Error) {
+func (db *DB) send(maxScanResults int64, reqs ...roachpb.Request) (
+	*roachpb.BatchResponse, *roachpb.Error) {
 	if len(reqs) == 0 {
 		return nil, nil
 	}
@@ -404,7 +405,8 @@ func (db *DB) send(reqs ...roachpb.Request) (*roachpb.BatchResponse, *roachpb.Er
 	ba := roachpb.BatchRequest{}
 	ba.Add(reqs...)
 
-	if ba.UserPriority == 0 && db.userPriority != 1 {
+	ba.MaxScanResults = maxScanResults
+	if db.userPriority != 1 {
 		ba.UserPriority = db.userPriority
 	}
 

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -858,6 +858,7 @@ func (tc *TxnCoordSender) resendWithTxn(ba roachpb.BatchRequest) (*roachpb.Batch
 	pErr := tmpDB.Txn(func(txn *client.Txn) *roachpb.Error {
 		txn.SetDebugName("auto-wrap", 0)
 		b := txn.NewBatch()
+		b.MaxScanResults = ba.MaxScanResults
 		for _, arg := range ba.Requests {
 			req := arg.GetInner()
 			b.InternalAddRequest(req)

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -673,6 +673,9 @@ message Header {
   optional ReadConsistencyType read_consistency = 6 [(gogoproto.nullable) = false];
   // trace, if set, is the active span of an OpenTracing distributed trace.
   optional util.tracing.Span trace = 7;
+  // if set to a non-zero value, limits the total number of results for
+  // Scan/ReverseScan requests in the batch.
+  optional int64 max_scan_results = 8 [(gogoproto.nullable) = false];
 }
 
 

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -1116,7 +1116,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseUnion, _internal_metadata_),
       -1);
   Header_descriptor_ = file->message_type(53);
-  static const int Header_offsets_[7] = {
+  static const int Header_offsets_[8] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, replica_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, range_id_),
@@ -1124,6 +1124,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, txn_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, read_consistency_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, trace_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Header, max_scan_results_),
   };
   Header_reflection_ =
     ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
@@ -1682,7 +1683,7 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "erifyChecksumResponse\022F\n\021check_consisten"
     "cy\030\030 \001(\0132+.cockroach.roachpb.CheckConsis"
     "tencyResponse\022-\n\004noop\030\031 \001(\0132\037.cockroach."
-    "roachpb.NoopResponse:\004\310\240\037\001\"\371\002\n\006Header\0225\n"
+    "roachpb.NoopResponse:\004\310\240\037\001\"\231\003\n\006Header\0225\n"
     "\ttimestamp\030\001 \001(\0132\034.cockroach.roachpb.Tim"
     "estampB\004\310\336\037\000\022;\n\007replica\030\002 \001(\0132$.cockroac"
     "h.roachpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010ran"
@@ -1692,25 +1693,26 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "ansaction\022F\n\020read_consistency\030\006 \001(\0162&.co"
     "ckroach.roachpb.ReadConsistencyTypeB\004\310\336\037"
     "\000\022+\n\005trace\030\007 \001(\0132\034.cockroach.util.tracin"
-    "g.Span\"\202\001\n\014BatchRequest\0223\n\006header\030\001 \001(\0132"
-    "\031.cockroach.roachpb.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010"
-    "requests\030\002 \003(\0132\037.cockroach.roachpb.Reque"
-    "stUnionB\004\310\336\037\000:\004\230\240\037\000\"\214\002\n\rBatchResponse\022A\n"
-    "\006header\030\001 \001(\0132\'.cockroach.roachpb.BatchR"
-    "esponse.HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 "
-    "\003(\0132 .cockroach.roachpb.ResponseUnionB\004\310"
-    "\336\037\000\032w\n\006Header\022\'\n\005error\030\001 \001(\0132\030.cockroach"
-    ".roachpb.Error\022+\n\003txn\030\003 \001(\0132\036.cockroach."
-    "roachpb.Transaction\022\027\n\017collected_spans\030\004"
-    " \003(\014:\004\230\240\037\000*L\n\023ReadConsistencyType\022\016\n\nCON"
-    "SISTENT\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT"
-    "\020\002\032\004\210\243\036\000*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAM"
-    "P\020\000\022\016\n\nPUSH_ABORT\020\001\022\016\n\nPUSH_TOUCH\020\002\032\004\210\243\036"
-    "\0002X\n\010Internal\022L\n\005Batch\022\037.cockroach.roach"
-    "pb.BatchRequest\032 .cockroach.roachpb.Batc"
-    "hResponse\"\0002X\n\010External\022L\n\005Batch\022\037.cockr"
-    "oach.roachpb.BatchRequest\032 .cockroach.ro"
-    "achpb.BatchResponse\"\000B\tZ\007roachpbX\004", 10434);
+    "g.Span\022\036\n\020max_scan_results\030\010 \001(\003B\004\310\336\037\000\"\202"
+    "\001\n\014BatchRequest\0223\n\006header\030\001 \001(\0132\031.cockro"
+    "ach.roachpb.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests"
+    "\030\002 \003(\0132\037.cockroach.roachpb.RequestUnionB"
+    "\004\310\336\037\000:\004\230\240\037\000\"\214\002\n\rBatchResponse\022A\n\006header\030"
+    "\001 \001(\0132\'.cockroach.roachpb.BatchResponse."
+    "HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .co"
+    "ckroach.roachpb.ResponseUnionB\004\310\336\037\000\032w\n\006H"
+    "eader\022\'\n\005error\030\001 \001(\0132\030.cockroach.roachpb"
+    ".Error\022+\n\003txn\030\003 \001(\0132\036.cockroach.roachpb."
+    "Transaction\022\027\n\017collected_spans\030\004 \003(\014:\004\230\240"
+    "\037\000*L\n\023ReadConsistencyType\022\016\n\nCONSISTENT\020"
+    "\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000"
+    "*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\016\n\nP"
+    "USH_ABORT\020\001\022\016\n\nPUSH_TOUCH\020\002\032\004\210\243\036\0002X\n\010Int"
+    "ernal\022L\n\005Batch\022\037.cockroach.roachpb.Batch"
+    "Request\032 .cockroach.roachpb.BatchRespons"
+    "e\"\0002X\n\010External\022L\n\005Batch\022\037.cockroach.roa"
+    "chpb.BatchRequest\032 .cockroach.roachpb.Ba"
+    "tchResponse\"\000B\tZ\007roachpbX\004", 10466);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ResponseHeader::default_instance_ = new ResponseHeader();
@@ -25314,6 +25316,7 @@ const int Header::kUserPriorityFieldNumber;
 const int Header::kTxnFieldNumber;
 const int Header::kReadConsistencyFieldNumber;
 const int Header::kTraceFieldNumber;
+const int Header::kMaxScanResultsFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Header::Header()
@@ -25346,6 +25349,7 @@ void Header::SharedCtor() {
   txn_ = NULL;
   read_consistency_ = 0;
   trace_ = NULL;
+  max_scan_results_ = GOOGLE_LONGLONG(0);
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -25397,8 +25401,9 @@ void Header::Clear() {
            ZR_HELPER_(last) - ZR_HELPER_(first) + sizeof(last));\
 } while (0)
 
-  if (_has_bits_[0 / 32] & 127u) {
+  if (_has_bits_[0 / 32] & 255u) {
     ZR_(range_id_, user_priority_);
+    ZR_(max_scan_results_, read_consistency_);
     if (has_timestamp()) {
       if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
@@ -25408,7 +25413,6 @@ void Header::Clear() {
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
     }
-    read_consistency_ = 0;
     if (has_trace()) {
       if (trace_ != NULL) trace_->::cockroach::util::tracing::Span::Clear();
     }
@@ -25530,6 +25534,21 @@ bool Header::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(64)) goto parse_max_scan_results;
+        break;
+      }
+
+      // optional int64 max_scan_results = 8;
+      case 8: {
+        if (tag == 64) {
+         parse_max_scan_results:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &max_scan_results_)));
+          set_has_max_scan_results();
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectAtEnd()) goto success;
         break;
       }
@@ -25599,6 +25618,11 @@ void Header::SerializeWithCachedSizes(
       7, *this->trace_, output);
   }
 
+  // optional int64 max_scan_results = 8;
+  if (has_max_scan_results()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(8, this->max_scan_results(), output);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -25653,6 +25677,11 @@ void Header::SerializeWithCachedSizes(
         7, *this->trace_, target);
   }
 
+  // optional int64 max_scan_results = 8;
+  if (has_max_scan_results()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(8, this->max_scan_results(), target);
+  }
+
   if (_internal_metadata_.have_unknown_fields()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -25664,7 +25693,7 @@ void Header::SerializeWithCachedSizes(
 int Header::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 127u) {
+  if (_has_bits_[0 / 32] & 255u) {
     // optional .cockroach.roachpb.Timestamp timestamp = 1;
     if (has_timestamp()) {
       total_size += 1 +
@@ -25709,6 +25738,13 @@ int Header::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->trace_);
+    }
+
+    // optional int64 max_scan_results = 8;
+    if (has_max_scan_results()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int64Size(
+          this->max_scan_results());
     }
 
   }
@@ -25759,6 +25795,9 @@ void Header::MergeFrom(const Header& from) {
     if (from.has_trace()) {
       mutable_trace()->::cockroach::util::tracing::Span::MergeFrom(from.trace());
     }
+    if (from.has_max_scan_results()) {
+      set_max_scan_results(from.max_scan_results());
+    }
   }
   if (from._internal_metadata_.have_unknown_fields()) {
     mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -25794,6 +25833,7 @@ void Header::InternalSwap(Header* other) {
   std::swap(txn_, other->txn_);
   std::swap(read_consistency_, other->read_consistency_);
   std::swap(trace_, other->trace_);
+  std::swap(max_scan_results_, other->max_scan_results_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -26053,6 +26093,30 @@ void Header::set_allocated_trace(::cockroach::util::tracing::Span* trace) {
     clear_has_trace();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Header.trace)
+}
+
+// optional int64 max_scan_results = 8;
+bool Header::has_max_scan_results() const {
+  return (_has_bits_[0] & 0x00000080u) != 0;
+}
+void Header::set_has_max_scan_results() {
+  _has_bits_[0] |= 0x00000080u;
+}
+void Header::clear_has_max_scan_results() {
+  _has_bits_[0] &= ~0x00000080u;
+}
+void Header::clear_max_scan_results() {
+  max_scan_results_ = GOOGLE_LONGLONG(0);
+  clear_has_max_scan_results();
+}
+ ::google::protobuf::int64 Header::max_scan_results() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Header.max_scan_results)
+  return max_scan_results_;
+}
+ void Header::set_max_scan_results(::google::protobuf::int64 value) {
+  set_has_max_scan_results();
+  max_scan_results_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.Header.max_scan_results)
 }
 
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -6335,6 +6335,13 @@ class Header : public ::google::protobuf::Message {
   ::cockroach::util::tracing::Span* release_trace();
   void set_allocated_trace(::cockroach::util::tracing::Span* trace);
 
+  // optional int64 max_scan_results = 8;
+  bool has_max_scan_results() const;
+  void clear_max_scan_results();
+  static const int kMaxScanResultsFieldNumber = 8;
+  ::google::protobuf::int64 max_scan_results() const;
+  void set_max_scan_results(::google::protobuf::int64 value);
+
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.Header)
  private:
   inline void set_has_timestamp();
@@ -6351,6 +6358,8 @@ class Header : public ::google::protobuf::Message {
   inline void clear_has_read_consistency();
   inline void set_has_trace();
   inline void clear_has_trace();
+  inline void set_has_max_scan_results();
+  inline void clear_has_max_scan_results();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
@@ -6361,6 +6370,7 @@ class Header : public ::google::protobuf::Message {
   double user_priority_;
   ::cockroach::roachpb::Transaction* txn_;
   ::cockroach::util::tracing::Span* trace_;
+  ::google::protobuf::int64 max_scan_results_;
   int read_consistency_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
@@ -13289,6 +13299,30 @@ inline void Header::set_allocated_trace(::cockroach::util::tracing::Span* trace)
     clear_has_trace();
   }
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.Header.trace)
+}
+
+// optional int64 max_scan_results = 8;
+inline bool Header::has_max_scan_results() const {
+  return (_has_bits_[0] & 0x00000080u) != 0;
+}
+inline void Header::set_has_max_scan_results() {
+  _has_bits_[0] |= 0x00000080u;
+}
+inline void Header::clear_has_max_scan_results() {
+  _has_bits_[0] &= ~0x00000080u;
+}
+inline void Header::clear_max_scan_results() {
+  max_scan_results_ = GOOGLE_LONGLONG(0);
+  clear_has_max_scan_results();
+}
+inline ::google::protobuf::int64 Header::max_scan_results() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.Header.max_scan_results)
+  return max_scan_results_;
+}
+inline void Header::set_max_scan_results(::google::protobuf::int64 value) {
+  set_has_max_scan_results();
+  max_scan_results_ = value;
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.Header.max_scan_results)
 }
 
 // -------------------------------------------------------------------

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"reflect"
 	"sync"
@@ -1611,6 +1612,13 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba roa
 	// Have to discuss how we go about it.
 	fiddleWithTimestamps := !isTxn && ba.IsWrite()
 
+	remScanResults := int64(math.MaxInt64)
+	if ba.Header.MaxScanResults != 0 {
+		// We have a batch of Scan or ReverseScan requests with a limit. We keep track of how many
+		// remaining results we can return.
+		remScanResults = ba.Header.MaxScanResults
+	}
+
 	// TODO(tschottdorf): provisionals ahead. This loop needs to execute each
 	// command and propagate txn and timestamp to the next (and, eventually,
 	// to the batch response header). We're currently in an intermediate stage
@@ -1636,7 +1644,7 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba roa
 			header.Timestamp = ba.Timestamp.Add(0, int32(index))
 		}
 
-		reply, curIntents, pErr := r.executeCmd(batch, ms, header, args)
+		reply, curIntents, pErr := r.executeCmd(batch, ms, header, remScanResults, args)
 
 		// Collect intents skipped over the course of execution.
 		if len(curIntents) > 0 {
@@ -1648,6 +1656,15 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba roa
 			// Initialize the error index.
 			pErr.SetErrorIndex(int32(index))
 			return nil, intents, pErr
+		}
+		if remScanResults != math.MaxInt64 {
+			if cReply, ok := reply.(roachpb.Countable); ok {
+				retResults := cReply.Count()
+				if retResults > remScanResults {
+					panic(fmt.Sprintf("received %d results, limit was %d", retResults, remScanResults))
+				}
+				remScanResults -= retResults
+			}
 		}
 
 		// Add the response to the batch, updating the timestamp.

--- a/util/testing.go
+++ b/util/testing.go
@@ -32,6 +32,7 @@ import (
 // on "testing".
 type Tester interface {
 	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
 	Failed() bool
 	Fatal(args ...interface{})
 	Fatalf(format string, args ...interface{})


### PR DESCRIPTION
To scan tables in batches (#2966) when there are multiple spans, we need a
per-batch limit on the total number of scan results for all scans and reverse
scans in the batch. This change adds this limit as a parameter in the
BatchRequest header.

Addresses #4696.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5092)

<!-- Reviewable:end -->
