### PR TITLE
kv: Stop-gap to avoid sequence cache growth

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1805,7 +1805,7 @@ func (r *Replica) handleSkippedIntents(intents []intentsWithArg) {
 				log.Warningc(ctxWithTimeout, "failed to push during intent resolution: %s", pErr)
 				return
 			}
-			if pErr := r.resolveIntents(ctxWithTimeout, resolveIntents, true /* wait */, true /* poison */); pErr != nil {
+			if pErr := r.resolveIntents(ctxWithTimeout, resolveIntents, true /* wait */, false /* TODO(tschottdorf): #5088 */); pErr != nil {
 				log.Warningc(ctxWithTimeout, "failed to resolve intents: %s", pErr)
 				return
 			}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -2166,6 +2166,7 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 // sequence cache records are purged on the local range (and only there).
 func TestEndTransactionDirectGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("TODO(tschottdorf): #5088")
 	tc := testContext{}
 	key := roachpb.Key("a")
 	splitKey := roachpb.RKey(key).Next()


### PR DESCRIPTION
See #5088. Prior to this change, a transaction with external intents would poison the
external ranges' sequence caches prior to clearing the transaction record. This
is required for correctness, but leads to large sequence caches which come with
their own problems for GC queue and split latencies.

This change introduces a theoretical anomaly and will be superseded.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5093)

<!-- Reviewable:end -->
