### PR TITLE
cli: avoid creating thousands of sstables for debug commands

### DIFF
--- a/cli/debug.go
+++ b/cli/debug.go
@@ -42,7 +42,10 @@ Pretty-prints all keys in a store.
 }
 
 func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (engine.Engine, error) {
-	db := engine.NewRocksDB(roachpb.Attributes{}, dir, 0, 0, 0, stopper)
+	initCacheSize()
+
+	db := engine.NewRocksDB(roachpb.Attributes{}, dir,
+		cliContext.CacheSize, cliContext.MemtableBudget, 0, stopper)
 	if err := db.Open(); err != nil {
 		return nil, err
 	}

--- a/cli/start.go
+++ b/cli/start.go
@@ -93,16 +93,20 @@ uninitialized, specify the --join flag to point to any healthy node
 	RunE:         runStart,
 }
 
-// runStart starts the cockroach node using --store as the list of
-// storage devices ("stores") on this machine and --join as the list
-// of other active nodes used to join this node to the cockroach
-// cluster, if this is its first time connecting.
-func runStart(_ *cobra.Command, _ []string) error {
+func initCacheSize() {
 	if !cacheSize.isSet {
 		if size, err := server.GetTotalMemory(); err == nil {
 			cliContext.CacheSize = size / 2
 		}
 	}
+}
+
+// runStart starts the cockroach node using --store as the list of
+// storage devices ("stores") on this machine and --join as the list
+// of other active nodes used to join this node to the cockroach
+// cluster, if this is its first time connecting.
+func runStart(_ *cobra.Command, _ []string) error {
+	initCacheSize()
 
 	// Default the log directory to the the "logs" subdirectory of the first
 	// non-memory store. We only do this for the "start" command which is why


### PR DESCRIPTION
Pass a non-zero memtable-budget when opening a RocksDB instance. When
RocksDB opens it scans the wal loading entries into the memtable. By
setting a memtable-budget of zero we were causing these entries to
immediately be flushed. If there were thousands of entries in your wal
you would create thousands of sstables. This affected the `debug
{keys,raft-log,range-descriptors}` commands.

Fixes #4493.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5098)

<!-- Reviewable:end -->
