### PR TITLE
Add RocksDB stats

### DIFF
--- a/server/status.go
+++ b/server/status.go
@@ -91,7 +91,9 @@ const (
 	// statusStorePattern exposes status for a single store.
 	statusStorePattern = statusPrefix + "stores/:store_id"
 
-	// statusMetricsPattern exposes transient stats / metrics for a node.
+	// statusMetricsPrefix exposes transient stats.
+	statusMetricsPrefix = statusPrefix + "metrics/"
+	// statusMetricsPattern exposes transient stats for a node.
 	statusMetricsPattern = statusPrefix + "metrics/:node_id"
 
 	// healthEndpoint is a shortcut for local details, intended for use by

--- a/server/status/recorder.go
+++ b/server/status/recorder.go
@@ -165,10 +165,11 @@ func (mr *MetricsRecorder) MarshalJSON() ([]byte, error) {
 	topLevel := map[string]interface{}{
 		fmt.Sprintf("node.%d", mr.mu.nodeID): mr.nodeRegistry,
 	}
-	// Add collection of stores to top level.
-	storeLevel := map[roachpb.StoreID]interface{}{}
+	// Add collection of stores to top level. JSON requires that keys be strings,
+	// so we must convert the store ID to a string.
+	storeLevel := make(map[string]interface{})
 	for id, reg := range mr.mu.storeRegistries {
-		storeLevel[id] = reg
+		storeLevel[strconv.Itoa(int(id))] = reg
 	}
 	topLevel["stores"] = storeLevel
 	return json.Marshal(topLevel)

--- a/server/status/runtime.go
+++ b/server/status/runtime.go
@@ -106,6 +106,9 @@ func (rsr *RuntimeStatRecorder) GetTimeSeriesData() []ts.TimeSeriesData {
 	// Determine an appropriate way to compute total memory usage.
 	numCgoCall := runtime.NumCgoCall()
 	numGoroutine := runtime.NumGoroutine()
+
+	// It might be useful to call ReadMemStats() more often, but it stops the
+	// world while collecting stats so shouldn't be called too often.
 	ms := runtime.MemStats{}
 	runtime.ReadMemStats(&ms)
 

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -571,3 +571,16 @@ func TestMetricsRecording(t *testing.T) {
 		return nil
 	})
 }
+
+// TestMetricsEndpoint retrieves the metrics endpoint, which is currently only
+// used for development purposes. The metrics within the response are verified
+// in other tests.
+func TestMetricsEndpoint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s := startServer(t)
+	defer s.Stop()
+
+	nodeID := s.Gossip().GetNodeID()
+	url := fmt.Sprintf("%s/%s", statusMetricsPrefix, nodeID)
+	getRequest(t, s, url)
+}

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -154,6 +154,33 @@ type Engine interface {
 	// Objects backed by this engine (e.g. Iterators) can check this to ensure
 	// that they are not using an closed engine.
 	Closed() bool
+	// GetStats retrieves stats from the engine.
+	GetStats() (*Stats, error)
+}
+
+// Stats is a set of RocksDB stats. These are all described in RocksDB
+//
+// Currently, we collect stats from the following sources:
+// 1. RocksDB's internal "tickers" (i.e. counters). They're defined in
+//    rocksdb/statistics.h
+// 2. DBEventListener, which implements RocksDB's EventListener interface.
+// 3. rocksdb::DB::GetProperty().
+//
+// This is a good resource describing RocksDB's memory-related stats:
+// https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
+type Stats struct {
+	BlockCacheHits           int64
+	BlockCacheMisses         int64
+	BlockCacheUsage          int64
+	BlockCachePinnedUsage    int64
+	BloomFilterPrefixChecked int64
+	BloomFilterPrefixUseful  int64
+	MemtableHits             int64
+	MemtableMisses           int64
+	MemtableTotalSize        int64
+	Flushes                  int64
+	Compactions              int64
+	TableReadersMemEstimate  int64
 }
 
 var bufferPool = sync.Pool{

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -16,6 +16,7 @@
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 
 #include <algorithm>
+#include <atomic>
 #include <limits>
 #include <stdarg.h>
 #include <google/protobuf/repeated_field.h>
@@ -37,6 +38,7 @@
 #include "cockroach/storage/engine/mvcc.pb.h"
 #include "db.h"
 #include "encoding.h"
+#include "eventlistener.h"
 
 extern "C" {
 #include "_cgo_export.h"
@@ -55,20 +57,26 @@ struct DBEngine {
   virtual DBStatus WriteBatch() = 0;
   virtual DBStatus Get(DBKey key, DBString* value) = 0;
   virtual DBIterator* NewIter(DBSlice prefix) = 0;
+  virtual DBStatus GetStats(DBStatsResult* stats) = 0;
 };
 
 struct DBImpl : public DBEngine {
   std::unique_ptr<rocksdb::Env> memenv;
   std::unique_ptr<rocksdb::DB> rep_deleter;
   rocksdb::ReadOptions const read_opts;
+  std::shared_ptr<rocksdb::Cache> block_cache;
+  std::shared_ptr<DBEventListener> event_listener;
 
   // Construct a new DBImpl from the specified DB and Env. Both the DB
   // and Env will be deleted when the DBImpl is deleted. It is ok to
   // pass NULL for the Env.
-  DBImpl(rocksdb::DB* r, rocksdb::Env* m)
+  DBImpl(rocksdb::DB* r, rocksdb::Env* m, std::shared_ptr<rocksdb::Cache> bc,
+    std::shared_ptr<DBEventListener> event_listener)
       : DBEngine(r),
         memenv(m),
-        rep_deleter(r) {
+        rep_deleter(r),
+        block_cache(bc),
+        event_listener(event_listener) {
   }
   virtual ~DBImpl() {
     const rocksdb::Options &opts = rep->GetOptions();
@@ -84,6 +92,7 @@ struct DBImpl : public DBEngine {
   virtual DBStatus WriteBatch();
   virtual DBStatus Get(DBKey key, DBString* value);
   virtual DBIterator* NewIter(DBSlice prefix);
+  virtual DBStatus GetStats(DBStatsResult* stats);
 };
 
 struct DBBatch : public DBEngine {
@@ -101,6 +110,7 @@ struct DBBatch : public DBEngine {
   virtual DBStatus WriteBatch();
   virtual DBStatus Get(DBKey key, DBString* value);
   virtual DBIterator* NewIter(DBSlice prefix);
+  virtual DBStatus GetStats(DBStatsResult* stats);
 };
 
 struct DBSnapshot : public DBEngine {
@@ -122,6 +132,7 @@ struct DBSnapshot : public DBEngine {
   virtual DBStatus WriteBatch();
   virtual DBStatus Get(DBKey key, DBString* value);
   virtual DBIterator* NewIter(DBSlice prefix);
+  virtual DBStatus GetStats(DBStatsResult* stats);
 };
 
 struct DBIterator {
@@ -1257,6 +1268,10 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
         row_cache_size, num_cache_shard_bits);
   }
 
+  // Register listener for tracking RocksDB stats.
+  std::shared_ptr<DBEventListener> event_listener(new DBEventListener);
+  options.listeners.emplace_back(event_listener);
+
   std::unique_ptr<rocksdb::Env> memenv;
   if (dir.len == 0) {
     memenv.reset(rocksdb::NewMemEnv(rocksdb::Env::Default()));
@@ -1268,7 +1283,7 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   if (!status.ok()) {
     return ToDBStatus(status);
   }
-  *db = new DBImpl(db_ptr, memenv.release());
+  *db = new DBImpl(db_ptr, memenv.release(), table_options.block_cache, event_listener);
   return kSuccess;
 }
 
@@ -1452,6 +1467,43 @@ DBIterator* DBSnapshot::NewIter(DBSlice prefix) {
   opts.total_order_seek = iter->upper_bound() == NULL;
   iter->rep.reset(rep->NewIterator(opts));
   return iter;
+}
+
+// GetStats retrieves a subset of RocksDB stats that are relevant to
+// CockroachDB.
+DBStatus DBImpl::GetStats(DBStatsResult* stats) {
+  const rocksdb::Options &opts = rep->GetOptions();
+  const std::shared_ptr<rocksdb::Statistics> &s = opts.statistics;
+
+  std::string memtable_total_size;
+  rep->GetProperty("rocksdb.cur-size-all-mem-tables", &memtable_total_size);
+
+  std::string table_readers_mem_estimate;
+  rep->GetProperty("rocksdb.estimate-table-readers-mem", &table_readers_mem_estimate);
+
+  stats->block_cache_hits = (int64_t)s->getTickerCount(rocksdb::BLOCK_CACHE_HIT);
+  stats->block_cache_misses = (int64_t)s->getTickerCount(rocksdb::BLOCK_CACHE_MISS);
+  stats->block_cache_usage = (int64_t)block_cache->GetUsage();
+  stats->block_cache_pinned_usage = (int64_t)block_cache->GetPinnedUsage();
+  stats->bloom_filter_prefix_checked =
+    (int64_t)s->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_CHECKED);
+  stats->bloom_filter_prefix_useful =
+    (int64_t)s->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_USEFUL);
+  stats->memtable_hits = (int64_t)s->getTickerCount(rocksdb::MEMTABLE_HIT);
+  stats->memtable_misses = (int64_t)s->getTickerCount(rocksdb::MEMTABLE_MISS);
+  stats->memtable_total_size = std::stoll(memtable_total_size);
+  stats->flushes = (int64_t)event_listener->GetFlushes();
+  stats->compactions = (int64_t)event_listener->GetCompactions();
+  stats->table_readers_mem_estimate = std::stoll(table_readers_mem_estimate);
+  return kSuccess;
+}
+
+DBStatus DBBatch::GetStats(DBStatsResult* stats) {
+  return FmtStatus("unsupported");
+}
+
+DBStatus DBSnapshot::GetStats(DBStatsResult* stats) {
+  return FmtStatus("unsupported");
 }
 
 DBIterator::DBIterator(DBSlice prefix)
@@ -1638,4 +1690,10 @@ MVCCStatsResult MVCCComputeStats(
 
   stats.last_update_nanos = now_nanos;
   return stats;
+}
+
+// DBGetStats queries the given DBEngine for various operational stats and
+// write them to the provided DBStatsResult instance.
+DBStatus DBGetStats(DBEngine* db, DBStatsResult* stats) {
+  return db->GetStats(stats);
 }

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -175,6 +175,24 @@ typedef struct {
 
 MVCCStatsResult MVCCComputeStats(DBIterator* iter, DBKey start, DBKey end, int64_t now_nanos);
 
+// DBStatsResult contains various runtime stats for RocksDB.
+typedef struct {
+  int64_t block_cache_hits;
+  int64_t block_cache_misses;
+  size_t  block_cache_usage;
+  size_t  block_cache_pinned_usage;
+  int64_t bloom_filter_prefix_checked;
+  int64_t bloom_filter_prefix_useful;
+  int64_t memtable_hits;
+  int64_t memtable_misses;
+  int64_t memtable_total_size;
+  int64_t flushes;
+  int64_t compactions;
+  int64_t table_readers_mem_estimate;
+} DBStatsResult;
+
+DBStatus DBGetStats(DBEngine* db, DBStatsResult* stats);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/storage/engine/rocksdb/eventlistener.cc
+++ b/storage/engine/rocksdb/eventlistener.cc
@@ -1,0 +1,39 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Cuong Do <cdo@cockroachlabs.com>
+
+#include "eventlistener.h"
+
+DBEventListener::DBEventListener()
+  : flushes_(0),
+    compactions_(0) {
+}
+
+void DBEventListener::OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobInfo& flush_job_info) {
+  ++flushes_;
+}
+
+void DBEventListener::OnCompactionCompleted(rocksdb::DB* db, const rocksdb::CompactionJobInfo& ci) {
+  ++compactions_;
+}
+
+uint64_t DBEventListener::GetFlushes() const {
+  return flushes_.load();
+}
+
+uint64_t DBEventListener::GetCompactions() const {
+  return compactions_.load();
+}
+

--- a/storage/engine/rocksdb/eventlistener.h
+++ b/storage/engine/rocksdb/eventlistener.h
@@ -1,0 +1,45 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Cuong Do <cdo@cockroachlabs.com>
+
+#ifndef ROACHLIB_EVENTLISTENER_H
+#define ROACHLIB_EVENTLISTENER_H
+
+#include <atomic>
+
+#include <rocksdb/db.h>
+
+// DBEventListener is an implementation of RocksDB's EventListener interface
+// used to collect information on RocksDB events that could be of interest
+// to CockroachDB users.
+class DBEventListener : public rocksdb::EventListener {
+ public:
+  DBEventListener();
+  virtual ~DBEventListener() { }
+
+  uint64_t GetFlushes() const;
+  uint64_t GetCompactions() const;
+
+  // EventListener methods.
+  virtual void OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobInfo& flush_job_info) override;
+  virtual void OnCompactionCompleted(rocksdb::DB* db, const rocksdb::CompactionJobInfo& ci) override;
+
+ private:
+  std::atomic<uint64_t> flushes_;
+  std::atomic<uint64_t> compactions_;
+};
+
+
+#endif // ROACHLIB_EVENTLISTENER_H


### PR DESCRIPTION
This adds a variety of store-level RocksDB stats with the goal of better
understanding the memory and performance characteristics of RocksDB.
For now, these stats are recorded to time series and are viewable
through `/_status/metrics/NODEID`.

Also fixes a problem with a call to `MarshalJSON` while servicing
`/_status/metrics/NODEID`.

Resolves #1179.

cc @petermattis for RocksDB aspects, @mrtracy for stats backend

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5099)

<!-- Reviewable:end -->
