### PR TITLE
rpc: return an error instead of calling log.Fatal and add a test

### DIFF
--- a/cli/node.go
+++ b/cli/node.go
@@ -139,9 +139,9 @@ func nodeStatusesToRows(statuses []status.NodeStatus) [][]string {
 	var rows [][]string
 	for _, nodeStatus := range statuses {
 		hostPort := nodeStatus.Desc.Address.AddressField
-		updatedAt := time.Unix(nodeStatus.UpdatedAt/1e9, nodeStatus.UpdatedAt%1e9)
+		updatedAt := time.Unix(0, nodeStatus.UpdatedAt)
 		updatedAtStr := updatedAt.Format(localTimeFormat)
-		startedAt := time.Unix(nodeStatus.StartedAt/1e9, nodeStatus.StartedAt%1e9)
+		startedAt := time.Unix(0, nodeStatus.StartedAt)
 		startedAtStr := startedAt.Format(localTimeFormat)
 
 		rows = append(rows, []string{

--- a/kv/send.go
+++ b/kv/send.go
@@ -245,7 +245,7 @@ func sendOne(client batchClient, timeout time.Duration,
 		ctx, _ = context.WithTimeout(ctx, timeout)
 	}
 
-	if localServer := rpcContext.LocalInternalServer; enableLocalCalls && localServer != nil && addr == rpcContext.LocalAddr {
+	if localServer := rpcContext.GetLocalInternalServerForAddr(addr); enableLocalCalls && localServer != nil {
 		reply, err := localServer.Batch(ctx, &client.args)
 		done <- batchCall{reply: reply, err: err}
 		return

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -856,8 +856,9 @@ func (t Transaction) GetObservedTimestamp(nodeID NodeID) (Timestamp, bool) {
 var _ fmt.Stringer = &Lease{}
 
 func (l Lease) String() string {
-	t := time.Unix(l.Start.WallTime/1E9, 0).UTC()
-	return fmt.Sprintf("replica %s %s +%.3fs", l.Replica, t, float64(l.Expiration.WallTime-l.Start.WallTime)/1E9)
+	start := time.Unix(0, l.Start.WallTime).UTC()
+	expiration := time.Unix(0, l.Expiration.WallTime).UTC()
+	return fmt.Sprintf("replica %s %s %s", l.Replica, start, expiration.Sub(start))
 }
 
 // Covers returns true if the given timestamp is strictly less than the

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -116,6 +116,11 @@ func (r *RemoteClockMonitor) UpdateOffset(addr string, offset RemoteOffset) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	var emptyOffset RemoteOffset
+	if offset == emptyOffset {
+		return
+	}
+
 	if oldOffset, ok := r.mu.offsets[addr]; !ok {
 		r.mu.offsets[addr] = offset
 	} else if oldOffset.measuredAt().Before(r.mu.lastMonitoredAt) {

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -175,7 +175,7 @@ func (r *RemoteClockMonitor) MonitorRemoteOffsets(stopper *stop.Stopper) {
 					log.Fatalf("clock offset from the cluster time "+
 						"for remote clocks: %v is in interval: %s, which "+
 						"indicates that the true offset is greater than %s",
-						r.offsets, offsetInterval, time.Duration(r.lClock.MaxOffset()))
+						r.offsets, offsetInterval, r.lClock.MaxOffset())
 				}
 				if log.V(1) {
 					log.Infof("healthy cluster offset: %s", offsetInterval)

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -42,15 +42,12 @@ type RemoteClockMonitor struct {
 	lastMonitoredAt int64
 }
 
-// ClusterOffsetInterval is the best interval we can construct to estimate this
-// node's offset from the cluster.
-type ClusterOffsetInterval struct {
-	Lowerbound int64 // The lowerbound on the offset in nanoseconds.
-	Upperbound int64 // The upperbound on the offset in nanoseconds.
+type clusterOffsetInterval struct {
+	lowerbound, upperbound int64
 }
 
-func (i ClusterOffsetInterval) String() string {
-	return fmt.Sprintf("{%s, %s}", time.Duration(i.Lowerbound), time.Duration(i.Upperbound))
+func (i clusterOffsetInterval) String() string {
+	return fmt.Sprintf("{%s, %s}", time.Duration(i.lowerbound), time.Duration(i.upperbound))
 }
 
 // majorityIntervalNotFoundError indicates that we could not find a majority
@@ -183,21 +180,17 @@ func (r *RemoteClockMonitor) MonitorRemoteOffsets(stopper *stop.Stopper) {
 	}
 }
 
-// isHealthyOffsetInterval returns true if the ClusterOffsetInterval indicates
+// isHealthyOffsetInterval returns true if the clusterOffsetInterval indicates
 // that the node's offset is within maxOffset, else false. For example, if the
 // offset interval is [-20, -11] and the maxOffset is 10 nanoseconds, then the
 // clock offset must be too great, because no point in the interval is within
 // the maxOffset.
-func isHealthyOffsetInterval(i ClusterOffsetInterval, maxOffset time.Duration) bool {
-	if i.Lowerbound > maxOffset.Nanoseconds() ||
-		i.Upperbound < -maxOffset.Nanoseconds() {
-		return false
-	}
-	return true
+func isHealthyOffsetInterval(i clusterOffsetInterval, maxOffset time.Duration) bool {
+	return i.lowerbound <= maxOffset.Nanoseconds() && i.upperbound >= -maxOffset.Nanoseconds()
 }
 
 // The routine that measures this node's probable offset from the rest of the
-// cluster. This offset is measured as a ClusterOffsetInterval. For example,
+// cluster. This offset is measured as a clusterOffsetInterval. For example,
 // the output might be [-5, 10], which would indicate that this node's offset
 // is likely between -5 and 10 nanoseconds from the average clock of the
 // cluster.
@@ -212,7 +205,7 @@ func isHealthyOffsetInterval(i ClusterOffsetInterval, maxOffset time.Duration) b
 //
 // If an interval cannot be found, an error is returned, indicating that
 // a majority of remote node offset intervals do not overlap the cluster time.
-func (r *RemoteClockMonitor) findOffsetInterval() (ClusterOffsetInterval, error) {
+func (r *RemoteClockMonitor) findOffsetInterval() (clusterOffsetInterval, error) {
 	endpoints := r.buildEndpointList()
 	sort.Sort(endpoints)
 	numClocks := len(endpoints) / 2
@@ -221,9 +214,9 @@ func (r *RemoteClockMonitor) findOffsetInterval() (ClusterOffsetInterval, error)
 			monitorInterval, numClocks)
 	}
 	if numClocks == 0 {
-		return ClusterOffsetInterval{
-			Lowerbound: 0,
-			Upperbound: 0,
+		return clusterOffsetInterval{
+			lowerbound: 0,
+			upperbound: 0,
 		}, nil
 	}
 
@@ -247,9 +240,9 @@ func (r *RemoteClockMonitor) findOffsetInterval() (ClusterOffsetInterval, error)
 	// Indicates that fewer than a majority of connected remote clocks seem to
 	// encompass the central offset from the cluster, an error condition.
 	if best <= numClocks/2 {
-		return ClusterOffsetInterval{
-				Lowerbound: math.MaxInt64,
-				Upperbound: math.MaxInt64,
+		return clusterOffsetInterval{
+				lowerbound: math.MaxInt64,
+				upperbound: math.MaxInt64,
 			}, &majorityIntervalNotFoundError{
 				endpoints: endpoints,
 			}
@@ -257,9 +250,9 @@ func (r *RemoteClockMonitor) findOffsetInterval() (ClusterOffsetInterval, error)
 
 	// A majority of offset intervals overlap at this interval, which should
 	// contain the true cluster offset.
-	return ClusterOffsetInterval{
-		Lowerbound: lowerbound,
-		Upperbound: upperbound,
+	return clusterOffsetInterval{
+		lowerbound: lowerbound,
+		upperbound: upperbound,
 	}, nil
 }
 

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -118,10 +118,6 @@ func newRemoteClockMonitor(clock *hlc.Clock) *RemoteClockMonitor {
 // monitorInterval to be too large, else we might end up relying on old
 // information.
 func (r *RemoteClockMonitor) UpdateOffset(addr string, offset RemoteOffset) {
-	if r == nil {
-		return
-	}
-
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -264,6 +264,7 @@ func (r *RemoteClockMonitor) buildEndpointList() endpointList {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	maxOffset := r.clock.MaxOffset()
 	endpoints := make(endpointList, 0, len(r.mu.offsets)*2)
 	for addr, o := range r.mu.offsets {
 		// Remove anything that hasn't been updated since the last time offest
@@ -275,11 +276,11 @@ func (r *RemoteClockMonitor) buildEndpointList() endpointList {
 		}
 
 		lowpoint := endpoint{
-			offset:  time.Duration(o.Offset-o.Uncertainty)*time.Nanosecond - r.clock.MaxOffset(),
+			offset:  time.Duration(o.Offset-o.Uncertainty)*time.Nanosecond - maxOffset,
 			endType: -1,
 		}
 		highpoint := endpoint{
-			offset:  time.Duration(o.Offset+o.Uncertainty)*time.Nanosecond + r.clock.MaxOffset(),
+			offset:  time.Duration(o.Offset+o.Uncertainty)*time.Nanosecond + maxOffset,
 			endType: +1,
 		}
 		endpoints = append(endpoints, lowpoint, highpoint)

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -163,8 +163,6 @@ func (r *RemoteClockMonitor) MonitorRemoteOffsets(stopper *stop.Stopper) {
 			// propagate the information to a status node.
 			// TODO(embark): once there is a framework for collecting timeseries
 			// data about the db, propagate the offset status to that.
-			// Don't forget to protect r.offsets through the Mutex if those
-			// Fatalf's below ever turn into something less destructive.
 			if r.lClock.MaxOffset() != 0 {
 				if err != nil {
 					log.Fatalf("clock offset from the cluster time "+

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -47,7 +47,7 @@ type clusterOffsetInterval struct {
 }
 
 func (i clusterOffsetInterval) String() string {
-	return fmt.Sprintf("{%s, %s}", time.Duration(i.lowerbound), time.Duration(i.upperbound))
+	return fmt.Sprintf("[%s, %s]", time.Duration(i.lowerbound), time.Duration(i.upperbound))
 }
 
 // majorityIntervalNotFoundError indicates that we could not find a majority

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -207,18 +207,15 @@ func isHealthyOffsetInterval(i clusterOffsetInterval, maxOffset time.Duration) b
 // a majority of remote node offset intervals do not overlap the cluster time.
 func (r *RemoteClockMonitor) findOffsetInterval() (clusterOffsetInterval, error) {
 	endpoints := r.buildEndpointList()
-	sort.Sort(endpoints)
 	numClocks := len(endpoints) / 2
 	if log.V(1) {
 		log.Infof("finding offset interval for monitorInterval: %s, numOffsets %d",
 			monitorInterval, numClocks)
 	}
 	if numClocks == 0 {
-		return clusterOffsetInterval{
-			lowerbound: 0,
-			upperbound: 0,
-		}, nil
+		return clusterOffsetInterval{}, nil
 	}
+	sort.Sort(endpoints)
 
 	best := 0
 	count := 0

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -18,7 +18,6 @@ package rpc
 
 import (
 	"fmt"
-	"math"
 	"sort"
 	"sync"
 	"time"
@@ -38,16 +37,16 @@ type RemoteClockMonitor struct {
 	offsets map[string]RemoteOffset // Maps remote string addr to offset.
 	lClock  *hlc.Clock              // The server clock.
 	mu      sync.Mutex
-	// Wall time in nanoseconds when we last monitored cluster offset.
-	lastMonitoredAt int64
+
+	lastMonitoredAt time.Time
 }
 
 type clusterOffsetInterval struct {
-	lowerbound, upperbound int64
+	lowerbound, upperbound time.Duration
 }
 
 func (i clusterOffsetInterval) String() string {
-	return fmt.Sprintf("[%s, %s]", time.Duration(i.lowerbound), time.Duration(i.upperbound))
+	return fmt.Sprintf("[%s, %s]", i.lowerbound, i.upperbound)
 }
 
 // majorityIntervalNotFoundError indicates that we could not find a majority
@@ -69,8 +68,8 @@ func (m *majorityIntervalNotFoundError) Error() string {
 // endpoint{offset: -5, endType: -1}
 // endpoint{offset: 10, endType: +1}
 type endpoint struct {
-	offset  int64 // The boundary offset represented by this endpoint.
-	endType int   // -1 if lowpoint, +1 if highpoint.
+	offset  time.Duration // The boundary offset represented by this endpoint.
+	endType int           // -1 if lowpoint, +1 if highpoint.
 }
 
 // endpointList is a slice of endpoints, sorted by endpoint offset.
@@ -120,7 +119,7 @@ func (r *RemoteClockMonitor) UpdateOffset(addr string, offset RemoteOffset) {
 
 	if oldOffset, ok := r.offsets[addr]; !ok {
 		r.offsets[addr] = offset
-	} else if oldOffset.MeasuredAt < r.lastMonitoredAt {
+	} else if oldOffset.measuredAt().Before(r.lastMonitoredAt) {
 		// No matter what offset is, we weren't going to use oldOffset again,
 		// because it was measured before the last cluster offset calculation.
 		r.offsets[addr] = offset
@@ -156,25 +155,25 @@ func (r *RemoteClockMonitor) MonitorRemoteOffsets(stopper *stop.Stopper) {
 			// propagate the information to a status node.
 			// TODO(embark): once there is a framework for collecting timeseries
 			// data about the db, propagate the offset status to that.
-			if r.lClock.MaxOffset() != 0 {
+			if maxOffset := r.lClock.MaxOffset(); maxOffset != 0 {
 				if err != nil {
 					log.Fatalf("clock offset from the cluster time "+
 						"for remote clocks %v could not be determined: %s",
 						r.offsets, err)
 				}
 
-				if !isHealthyOffsetInterval(offsetInterval, r.lClock.MaxOffset()) {
+				if !isHealthyOffsetInterval(offsetInterval, maxOffset) {
 					log.Fatalf("clock offset from the cluster time "+
 						"for remote clocks: %v is in interval: %s, which "+
 						"indicates that the true offset is greater than %s",
-						r.offsets, offsetInterval, r.lClock.MaxOffset())
+						r.offsets, offsetInterval, maxOffset)
 				}
 				if log.V(1) {
 					log.Infof("healthy cluster offset: %s", offsetInterval)
 				}
 			}
 			r.mu.Lock()
-			r.lastMonitoredAt = r.lClock.PhysicalNow()
+			r.lastMonitoredAt = r.lClock.PhysicalTime()
 			r.mu.Unlock()
 		}
 	}
@@ -186,7 +185,7 @@ func (r *RemoteClockMonitor) MonitorRemoteOffsets(stopper *stop.Stopper) {
 // clock offset must be too great, because no point in the interval is within
 // the maxOffset.
 func isHealthyOffsetInterval(i clusterOffsetInterval, maxOffset time.Duration) bool {
-	return i.lowerbound <= maxOffset.Nanoseconds() && i.upperbound >= -maxOffset.Nanoseconds()
+	return i.lowerbound <= maxOffset && i.upperbound >= -maxOffset
 }
 
 // The routine that measures this node's probable offset from the rest of the
@@ -219,38 +218,29 @@ func (r *RemoteClockMonitor) findOffsetInterval() (clusterOffsetInterval, error)
 
 	best := 0
 	count := 0
-	var lowerbound int64
-	var upperbound int64
+	var interval clusterOffsetInterval
 
 	// Find the interval which the most offset intervals overlap.
 	for i, endpoint := range endpoints {
 		count -= endpoint.endType
 		if count > best {
 			best = count
-			lowerbound = endpoint.offset
+			interval.lowerbound = endpoint.offset
 			// Note the endType of the last endpoint is +1, so count < best.
 			// Thus this code will never run when i = len(endpoint)-1.
-			upperbound = endpoints[i+1].offset
+			interval.upperbound = endpoints[i+1].offset
 		}
 	}
 
 	// Indicates that fewer than a majority of connected remote clocks seem to
 	// encompass the central offset from the cluster, an error condition.
 	if best <= numClocks/2 {
-		return clusterOffsetInterval{
-				lowerbound: math.MaxInt64,
-				upperbound: math.MaxInt64,
-			}, &majorityIntervalNotFoundError{
-				endpoints: endpoints,
-			}
+		return interval, &majorityIntervalNotFoundError{endpoints: endpoints}
 	}
 
 	// A majority of offset intervals overlap at this interval, which should
 	// contain the true cluster offset.
-	return clusterOffsetInterval{
-		lowerbound: lowerbound,
-		upperbound: upperbound,
-	}, nil
+	return interval, nil
 }
 
 // buildEndpointList() takes all the RemoteOffsets that are in the monitor, and
@@ -280,17 +270,17 @@ func (r *RemoteClockMonitor) buildEndpointList() endpointList {
 		// Remove anything that hasn't been updated since the last time offest
 		// was measured. This indicates that we no longer have a connection to
 		// that addr.
-		if o.MeasuredAt < r.lastMonitoredAt {
+		if o.measuredAt().Before(r.lastMonitoredAt) {
 			delete(r.offsets, addr)
 			continue
 		}
 
 		lowpoint := endpoint{
-			offset:  o.Offset - o.Uncertainty - r.lClock.MaxOffset().Nanoseconds(),
+			offset:  time.Duration(o.Offset-o.Uncertainty)*time.Nanosecond - r.lClock.MaxOffset(),
 			endType: -1,
 		}
 		highpoint := endpoint{
-			offset:  o.Offset + o.Uncertainty + r.lClock.MaxOffset().Nanoseconds(),
+			offset:  time.Duration(o.Offset+o.Uncertainty)*time.Nanosecond + r.lClock.MaxOffset(),
 			endType: +1,
 		}
 		endpoints = append(endpoints, lowpoint, highpoint)

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -277,10 +277,10 @@ func (r *RemoteClockMonitor) findOffsetInterval() (ClusterOffsetInterval, error)
 // prevent us from running through the list an extra time under a lock).
 //
 // A RemoteOffset r is represented by this interval:
-// [r.Offset - r.Error - MaxOffset, r.Offset + r.Error + MaxOffset],
+// [r.Offset - r.Uncertainty - MaxOffset, r.Offset + r.Uncertainty + MaxOffset],
 // where MaxOffset is the furthest a node's clock can deviate from the cluster
 // time. While the offset between this node and the remote time is actually
-// within [r.Offset - r.Error, r.Offset + r.Error], we also must expand the
+// within [r.Offset - r.Uncertainty, r.Offset + r.Uncertainty], we also must expand the
 // interval by MaxOffset. This accounts for the fact that the remote clock is at
 // most MaxOffset distance from the cluster time. Thus the expanded interval
 // ought to contain this node's offset from the true cluster time, not just the

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -34,11 +34,13 @@ var monitorInterval = defaultHeartbeatInterval * 10
 // RemoteClockMonitor keeps track of the most recent measurements of remote
 // offsets from this node to connected nodes.
 type RemoteClockMonitor struct {
-	offsets map[string]RemoteOffset // Maps remote string addr to offset.
-	lClock  *hlc.Clock              // The server clock.
-	mu      sync.Mutex
+	clock *hlc.Clock
 
-	lastMonitoredAt time.Time
+	mu struct {
+		sync.Mutex
+		offsets         map[string]RemoteOffset
+		lastMonitoredAt time.Time
+	}
 }
 
 type clusterOffsetInterval struct {
@@ -91,18 +93,17 @@ func (l endpointList) Less(i, j int) bool {
 
 // newRemoteClockMonitor returns a monitor with the given server clock.
 func newRemoteClockMonitor(clock *hlc.Clock) *RemoteClockMonitor {
-	return &RemoteClockMonitor{
-		offsets: map[string]RemoteOffset{},
-		lClock:  clock,
-	}
+	r := RemoteClockMonitor{clock: clock}
+	r.mu.offsets = make(map[string]RemoteOffset)
+	return &r
 }
 
 // UpdateOffset is a thread-safe way to update the remote clock measurements.
 //
 // It only updates the offset for addr if one the following three cases holds:
 // 1. There is no prior offset for that address.
-// 2. The old offset for addr was measured before r.lastMonitoredAt. We never
-// use values during monitoring that are older than r.lastMonitoredAt.
+// 2. The old offset for addr was measured before r.mu.lastMonitoredAt. We never
+// use values during monitoring that are older than r.mu.lastMonitoredAt.
 // 3. The new offset's error is smaller than the old offset's error.
 //
 // The third case allows the monitor to use the most precise clock reading of
@@ -117,18 +118,18 @@ func (r *RemoteClockMonitor) UpdateOffset(addr string, offset RemoteOffset) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if oldOffset, ok := r.offsets[addr]; !ok {
-		r.offsets[addr] = offset
-	} else if oldOffset.measuredAt().Before(r.lastMonitoredAt) {
+	if oldOffset, ok := r.mu.offsets[addr]; !ok {
+		r.mu.offsets[addr] = offset
+	} else if oldOffset.measuredAt().Before(r.mu.lastMonitoredAt) {
 		// No matter what offset is, we weren't going to use oldOffset again,
 		// because it was measured before the last cluster offset calculation.
-		r.offsets[addr] = offset
+		r.mu.offsets[addr] = offset
 	} else if offset.Uncertainty < oldOffset.Uncertainty {
-		r.offsets[addr] = offset
+		r.mu.offsets[addr] = offset
 	}
 
 	if log.V(2) {
-		log.Infof("update offset: %s %v", addr, r.offsets[addr])
+		log.Infof("update offset: %s %v", addr, r.mu.offsets[addr])
 	}
 }
 
@@ -155,25 +156,25 @@ func (r *RemoteClockMonitor) MonitorRemoteOffsets(stopper *stop.Stopper) {
 			// propagate the information to a status node.
 			// TODO(embark): once there is a framework for collecting timeseries
 			// data about the db, propagate the offset status to that.
-			if maxOffset := r.lClock.MaxOffset(); maxOffset != 0 {
+			if maxOffset := r.clock.MaxOffset(); maxOffset != 0 {
 				if err != nil {
 					log.Fatalf("clock offset from the cluster time "+
 						"for remote clocks %v could not be determined: %s",
-						r.offsets, err)
+						r.mu.offsets, err)
 				}
 
 				if !isHealthyOffsetInterval(offsetInterval, maxOffset) {
 					log.Fatalf("clock offset from the cluster time "+
 						"for remote clocks: %v is in interval: %s, which "+
 						"indicates that the true offset is greater than %s",
-						r.offsets, offsetInterval, maxOffset)
+						r.mu.offsets, offsetInterval, maxOffset)
 				}
 				if log.V(1) {
 					log.Infof("healthy cluster offset: %s", offsetInterval)
 				}
 			}
 			r.mu.Lock()
-			r.lastMonitoredAt = r.lClock.PhysicalTime()
+			r.mu.lastMonitoredAt = r.clock.PhysicalTime()
 			r.mu.Unlock()
 		}
 	}
@@ -265,22 +266,22 @@ func (r *RemoteClockMonitor) buildEndpointList() endpointList {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	endpoints := make(endpointList, 0, len(r.offsets)*2)
-	for addr, o := range r.offsets {
+	endpoints := make(endpointList, 0, len(r.mu.offsets)*2)
+	for addr, o := range r.mu.offsets {
 		// Remove anything that hasn't been updated since the last time offest
 		// was measured. This indicates that we no longer have a connection to
 		// that addr.
-		if o.measuredAt().Before(r.lastMonitoredAt) {
-			delete(r.offsets, addr)
+		if o.measuredAt().Before(r.mu.lastMonitoredAt) {
+			delete(r.mu.offsets, addr)
 			continue
 		}
 
 		lowpoint := endpoint{
-			offset:  time.Duration(o.Offset-o.Uncertainty)*time.Nanosecond - r.lClock.MaxOffset(),
+			offset:  time.Duration(o.Offset-o.Uncertainty)*time.Nanosecond - r.clock.MaxOffset(),
 			endType: -1,
 		}
 		highpoint := endpoint{
-			offset:  time.Duration(o.Offset+o.Uncertainty)*time.Nanosecond + r.lClock.MaxOffset(),
+			offset:  time.Duration(o.Offset+o.Uncertainty)*time.Nanosecond + r.clock.MaxOffset(),
 			endType: +1,
 		}
 		endpoints = append(endpoints, lowpoint, highpoint)

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -140,7 +140,7 @@ func (r *RemoteClockMonitor) UpdateOffset(addr string, offset RemoteOffset) {
 // clock from the true cluster time is within MaxOffset. If the offset exceeds
 // MaxOffset, then this method will trigger a fatal error, causing the node to
 // suicide.
-func (r *RemoteClockMonitor) MonitorRemoteOffsets(stopper *stop.Stopper) {
+func (r *RemoteClockMonitor) MonitorRemoteOffsets(stopper *stop.Stopper) error {
 	if log.V(1) {
 		log.Infof("monitoring cluster offset every %s", r.monitorInterval)
 	}
@@ -150,7 +150,7 @@ func (r *RemoteClockMonitor) MonitorRemoteOffsets(stopper *stop.Stopper) {
 		monitorTimer.Reset(r.monitorInterval)
 		select {
 		case <-stopper.ShouldStop():
-			return
+			return nil
 		case <-monitorTimer.C:
 			monitorTimer.Read = true
 			offsetInterval, err := r.findOffsetInterval()
@@ -161,16 +161,14 @@ func (r *RemoteClockMonitor) MonitorRemoteOffsets(stopper *stop.Stopper) {
 			// data about the db, propagate the offset status to that.
 			if maxOffset := r.clock.MaxOffset(); maxOffset != 0 {
 				if err != nil {
-					log.Fatalf("clock offset from the cluster time "+
-						"for remote clocks %v could not be determined: %s",
-						r.mu.offsets, err)
+					return util.Errorf("clock offset could not be determined: %s", err)
 				}
 
 				if !isHealthyOffsetInterval(offsetInterval, maxOffset) {
-					log.Fatalf("clock offset from the cluster time "+
-						"for remote clocks: %v is in interval: %s, which "+
-						"indicates that the true offset is greater than %s",
-						r.mu.offsets, offsetInterval, maxOffset)
+					return util.Errorf(
+						"clock offset is in interval: %s, which indicates that the true offset is greater than the max offset: %s",
+						offsetInterval, maxOffset,
+					)
 				}
 				if log.V(1) {
 					log.Infof("healthy cluster offset: %s", offsetInterval)

--- a/rpc/clock_offset_test.go
+++ b/rpc/clock_offset_test.go
@@ -363,12 +363,9 @@ func TestIsHealthyOffsetInterval(t *testing.T) {
 }
 
 func assertMajorityIntervalError(clocks *RemoteClockMonitor, t *testing.T) {
-	interval, err := clocks.findOffsetInterval()
-	expectedErr := MajorityIntervalNotFoundError{}
-	if err == nil {
-		t.Errorf("expected MajorityIntervalNotFoundError, instead %v", interval)
-	} else if err != expectedErr {
-		t.Errorf("expected MajorityIntervalNotFoundError, instead: %s", err)
+	_, err := clocks.findOffsetInterval()
+	if _, ok := err.(*majorityIntervalNotFoundError); !ok {
+		t.Errorf("expected a %T, got: %+v", &majorityIntervalNotFoundError{}, err)
 	}
 }
 

--- a/rpc/clock_offset_test.go
+++ b/rpc/clock_offset_test.go
@@ -202,7 +202,7 @@ func TestFindOffsetInterval(t *testing.T) {
 		offsets: offsets,
 		lClock:  clock,
 	}
-	expectedInterval := ClusterOffsetInterval{Lowerbound: 60, Upperbound: 78}
+	expectedInterval := clusterOffsetInterval{lowerbound: 60, upperbound: 78}
 	assertClusterOffset(remoteClocks, expectedInterval, t)
 }
 
@@ -241,7 +241,7 @@ func TestFindOffsetIntervalNoRemotes(t *testing.T) {
 		offsets: offsets,
 		lClock:  clock,
 	}
-	expectedInterval := ClusterOffsetInterval{Lowerbound: 0, Upperbound: 0}
+	expectedInterval := clusterOffsetInterval{lowerbound: 0, upperbound: 0}
 	assertClusterOffset(remoteClocks, expectedInterval, t)
 }
 
@@ -262,7 +262,7 @@ func TestFindOffsetIntervalOneClock(t *testing.T) {
 		offsets: offsets,
 		lClock:  clock,
 	}
-	expectedInterval := ClusterOffsetInterval{Lowerbound: -20, Upperbound: 20}
+	expectedInterval := clusterOffsetInterval{lowerbound: -20, upperbound: 20}
 	assertClusterOffset(remoteClocks, expectedInterval, t)
 }
 
@@ -282,7 +282,7 @@ func TestFindOffsetIntervalTwoClocks(t *testing.T) {
 	// Two intervals overlap.
 	offsets["0"] = RemoteOffset{Offset: 0, Uncertainty: 10}
 	offsets["1"] = RemoteOffset{Offset: 20, Uncertainty: 10}
-	expectedInterval := ClusterOffsetInterval{Lowerbound: 10, Upperbound: 10}
+	expectedInterval := clusterOffsetInterval{lowerbound: 10, upperbound: 10}
 	assertClusterOffset(remoteClocks, expectedInterval, t)
 
 	// Two intervals don't overlap.
@@ -316,7 +316,7 @@ func TestFindOffsetWithLargeError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedInterval := ClusterOffsetInterval{Lowerbound: -270, Upperbound: 510}
+	expectedInterval := clusterOffsetInterval{lowerbound: -270, upperbound: 510}
 	if interval != expectedInterval {
 		t.Errorf("expected interval %v, instead %v", expectedInterval, interval)
 	}
@@ -325,39 +325,39 @@ func TestFindOffsetWithLargeError(t *testing.T) {
 }
 
 // TestIsHealthyOffsetInterval tests if we correctly determine if
-// a ClusterOffsetInterval is healthy or not i.e. if it indicates that the
+// a clusterOffsetInterval is healthy or not i.e. if it indicates that the
 // local clock has too great an offset or not.
 func TestIsHealthyOffsetInterval(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	maxOffset := 10 * time.Nanosecond
 
-	interval := ClusterOffsetInterval{
-		Lowerbound: 0,
-		Upperbound: 0,
+	interval := clusterOffsetInterval{
+		lowerbound: 0,
+		upperbound: 0,
 	}
 	assertIntervalHealth(true, interval, maxOffset, t)
 
-	interval = ClusterOffsetInterval{
-		Lowerbound: -11,
-		Upperbound: 11,
+	interval = clusterOffsetInterval{
+		lowerbound: -11,
+		upperbound: 11,
 	}
 	assertIntervalHealth(true, interval, maxOffset, t)
 
-	interval = ClusterOffsetInterval{
-		Lowerbound: -20,
-		Upperbound: -11,
+	interval = clusterOffsetInterval{
+		lowerbound: -20,
+		upperbound: -11,
 	}
 	assertIntervalHealth(false, interval, maxOffset, t)
 
-	interval = ClusterOffsetInterval{
-		Lowerbound: 11,
-		Upperbound: 20,
+	interval = clusterOffsetInterval{
+		lowerbound: 11,
+		upperbound: 20,
 	}
 	assertIntervalHealth(false, interval, maxOffset, t)
 
-	interval = ClusterOffsetInterval{
-		Lowerbound: math.MaxInt64,
-		Upperbound: math.MaxInt64,
+	interval = clusterOffsetInterval{
+		lowerbound: math.MaxInt64,
+		upperbound: math.MaxInt64,
 	}
 	assertIntervalHealth(false, interval, maxOffset, t)
 }
@@ -369,8 +369,7 @@ func assertMajorityIntervalError(clocks *RemoteClockMonitor, t *testing.T) {
 	}
 }
 
-func assertClusterOffset(clocks *RemoteClockMonitor,
-	expected ClusterOffsetInterval, t *testing.T) {
+func assertClusterOffset(clocks *RemoteClockMonitor, expected clusterOffsetInterval, t *testing.T) {
 	interval, err := clocks.findOffsetInterval()
 	if err != nil {
 		t.Errorf("expected interval %v, instead err: %s",
@@ -380,8 +379,7 @@ func assertClusterOffset(clocks *RemoteClockMonitor,
 	}
 }
 
-func assertIntervalHealth(expectedHealthy bool, i ClusterOffsetInterval,
-	maxOffset time.Duration, t *testing.T) {
+func assertIntervalHealth(expectedHealthy bool, i clusterOffsetInterval, maxOffset time.Duration, t *testing.T) {
 	if expectedHealthy {
 		if !isHealthyOffsetInterval(i, maxOffset) {
 			t.Errorf("expected interval %v for offset %d nanoseconds to be healthy",

--- a/rpc/clock_offset_test.go
+++ b/rpc/clock_offset_test.go
@@ -22,9 +22,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
+
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
-	"github.com/gogo/protobuf/proto"
 )
 
 // TestUpdateOffset tests the three cases that UpdateOffset should or should
@@ -41,7 +42,7 @@ func TestUpdateOffset(t *testing.T) {
 	}
 
 	// Case 2: The old offset for addr was measured before lastMonitoredAt.
-	monitor.lastMonitoredAt = 5
+	monitor.lastMonitoredAt = time.Unix(0, 5)
 	offset2 := RemoteOffset{
 		Offset:      0,
 		Uncertainty: 20,
@@ -169,7 +170,7 @@ func TestBuildEndpointListRemoveStagnantClocks(t *testing.T) {
 	remoteClocks := &RemoteClockMonitor{
 		offsets:         offsets,
 		lClock:          clock,
-		lastMonitoredAt: 10, // offsets measured before this will be removed.
+		lastMonitoredAt: time.Unix(0, 10), // offsets measured before this will be removed.
 	}
 
 	remoteClocks.buildEndpointList()

--- a/rpc/clock_offset_test.go
+++ b/rpc/clock_offset_test.go
@@ -159,13 +159,12 @@ func TestBuildEndpointListRemoveStagnantClocks(t *testing.T) {
 		"stagnant1": {Offset: 3, Uncertainty: 10, MeasuredAt: 9},
 	}
 
-	// The stagnant offsets older than 10ns ago will be removed.
-	monitorInterval = 10 * time.Nanosecond
-
 	manual := hlc.NewManualClock(0)
 	clock := hlc.NewClock(manual.UnixNano)
 	clock.SetMaxOffset(5 * time.Nanosecond)
 	remoteClocks := newRemoteClockMonitor(clock)
+	// The stagnant offsets older than this will be removed.
+	remoteClocks.monitorInterval = 10 * time.Nanosecond
 	remoteClocks.mu.offsets = offsets
 	remoteClocks.mu.lastMonitoredAt = time.Unix(0, 10) // offsets measured before this will be removed.
 

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -172,7 +172,7 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 }
 
 func (ctx *Context) runHeartbeat(cc *grpc.ClientConn, remoteAddr string) error {
-	var request PingRequest
+	request := PingRequest{Addr: ctx.localAddr}
 	heartbeatClient := NewHeartbeatClient(cc)
 
 	var heartbeatTimer util.Timer

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -62,8 +62,8 @@ type Context struct {
 	HeartbeatInterval time.Duration
 	HeartbeatTimeout  time.Duration
 
-	LocalInternalServer roachpb.InternalServer
-	LocalAddr           string
+	localInternalServer roachpb.InternalServer
+	localAddr           string
 
 	conns struct {
 		sync.Mutex
@@ -108,10 +108,19 @@ func NewContext(baseCtx *base.Context, clock *hlc.Clock, stopper *stop.Stopper) 
 	return ctx
 }
 
+// GetLocalInternalServerForAddr returns the context's internal batch server
+// for addr, if it exists.
+func (ctx *Context) GetLocalInternalServerForAddr(addr string) roachpb.InternalServer {
+	if addr == ctx.localAddr {
+		return ctx.localInternalServer
+	}
+	return nil
+}
+
 // SetLocalInternalServer sets the context's local internal batch server.
 func (ctx *Context) SetLocalInternalServer(internalServer roachpb.InternalServer, addr string) {
-	ctx.LocalInternalServer = internalServer
-	ctx.LocalAddr = addr
+	ctx.localInternalServer = internalServer
+	ctx.localAddr = addr
 }
 
 func (ctx *Context) removeConn(key string, conn *grpc.ClientConn) {

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -58,7 +58,7 @@ func TestOffsetMeasurement(t *testing.T) {
 
 	heartbeat := &HeartbeatService{
 		clock:              serverClock,
-		remoteClockMonitor: newRemoteClockMonitor(serverClock),
+		remoteClockMonitor: ctx.RemoteClocks,
 	}
 	RegisterHeartbeatServer(s, heartbeat)
 
@@ -101,7 +101,7 @@ func TestDelayedOffsetMeasurement(t *testing.T) {
 
 	heartbeat := &HeartbeatService{
 		clock:              serverClock,
-		remoteClockMonitor: newRemoteClockMonitor(serverClock),
+		remoteClockMonitor: ctx.RemoteClocks,
 	}
 	RegisterHeartbeatServer(s, heartbeat)
 
@@ -142,7 +142,7 @@ func TestFailedOffsetMeasurement(t *testing.T) {
 
 	heartbeat := &ManualHeartbeatService{
 		clock:              serverClock,
-		remoteClockMonitor: newRemoteClockMonitor(serverClock),
+		remoteClockMonitor: ctx.RemoteClocks,
 		ready:              make(chan struct{}),
 		stopper:            stopper,
 	}

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -77,7 +77,7 @@ func TestOffsetMeasurement(t *testing.T) {
 		context.RemoteClocks.mu.Lock()
 		defer context.RemoteClocks.mu.Unlock()
 
-		if o := context.RemoteClocks.offsets[remoteAddr]; o != expectedOffset {
+		if o := context.RemoteClocks.mu.offsets[remoteAddr]; o != expectedOffset {
 			return util.Errorf("expected:\n%v\nactual:\n%v", expectedOffset, o)
 		}
 		return nil
@@ -122,7 +122,7 @@ func TestDelayedOffsetMeasurement(t *testing.T) {
 	// though the client is still healthy because it received a heartbeat
 	// reply.
 	context.RemoteClocks.mu.Lock()
-	if o, ok := context.RemoteClocks.offsets[remoteAddr]; ok {
+	if o, ok := context.RemoteClocks.mu.offsets[remoteAddr]; ok {
 		t.Errorf("expected offset to not exist, but found %v", o)
 	}
 	context.RemoteClocks.mu.Unlock()
@@ -165,7 +165,7 @@ func TestFailedOffsetMeasurement(t *testing.T) {
 		context.RemoteClocks.mu.Lock()
 		defer context.RemoteClocks.mu.Unlock()
 
-		if _, ok := context.RemoteClocks.offsets[remoteAddr]; !ok {
+		if _, ok := context.RemoteClocks.mu.offsets[remoteAddr]; !ok {
 			return util.Errorf("expected offset of %s to be initialized, but it was not", remoteAddr)
 		}
 		return nil
@@ -176,7 +176,7 @@ func TestFailedOffsetMeasurement(t *testing.T) {
 		context.RemoteClocks.mu.Lock()
 		defer context.RemoteClocks.mu.Unlock()
 
-		if o := context.RemoteClocks.offsets[remoteAddr]; o != expectedOffset {
+		if o := context.RemoteClocks.mu.offsets[remoteAddr]; o != expectedOffset {
 			return util.Errorf("expected offset of %s to be empty, got %v", remoteAddr, o)
 		}
 		return nil

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -56,11 +56,10 @@ func TestOffsetMeasurement(t *testing.T) {
 	s, ln := newTestServer(t, ctx, true)
 	remoteAddr := ln.Addr().String()
 
-	heartbeat := &HeartbeatService{
+	RegisterHeartbeatServer(s, &HeartbeatService{
 		clock:              serverClock,
 		remoteClockMonitor: ctx.RemoteClocks,
-	}
-	RegisterHeartbeatServer(s, heartbeat)
+	})
 
 	// Create a client that is 10 nanoseconds behind the server.
 	// Use the server context (heartbeat is node-to-node).
@@ -99,11 +98,10 @@ func TestDelayedOffsetMeasurement(t *testing.T) {
 	s, ln := newTestServer(t, ctx, true)
 	remoteAddr := ln.Addr().String()
 
-	heartbeat := &HeartbeatService{
+	RegisterHeartbeatServer(s, &HeartbeatService{
 		clock:              serverClock,
 		remoteClockMonitor: ctx.RemoteClocks,
-	}
-	RegisterHeartbeatServer(s, heartbeat)
+	})
 
 	// Create a client that receives a heartbeat right after the
 	// maximumClockReadingDelay.

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -190,4 +191,124 @@ func (ac *AdvancingClock) UnixNano() int64 {
 	time := ac.time
 	ac.time = time + ac.advancementInterval
 	return time
+}
+
+func TestRemoteOffsetUnhealthy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+
+	const maxOffset = 100 * time.Millisecond
+
+	type nodeContext struct {
+		offset  time.Duration
+		ctx     *Context
+		errChan chan error
+	}
+
+	start := time.Date(2012, 12, 07, 0, 0, 0, 0, time.UTC)
+	offsetClock := func(offset time.Duration) *hlc.Clock {
+		return hlc.NewClock(func() int64 {
+			return start.Add(offset).UnixNano()
+		})
+	}
+
+	nodeCtxs := []nodeContext{
+		{offset: 0},
+		{offset: 0},
+		{offset: 0},
+		// Due to measurement uncertainty being at least equal to maxOffset (see
+		// comments in clock_offset.go), this is the minimum offset that actually
+		// triggers node death.
+		{offset: maxOffset*2 + 1},
+	}
+
+	for i := range nodeCtxs {
+		clock := offsetClock(nodeCtxs[i].offset)
+		nodeCtxs[i].errChan = make(chan error, 1)
+
+		clock.SetMaxOffset(maxOffset)
+		nodeCtxs[i].ctx = newNodeTestContext(clock, stopper)
+		nodeCtxs[i].ctx.RemoteClocks.monitorInterval = maxOffset / 2
+		// Apparently heartbeats must happen more frequently than monitor events.
+		// Good thing this is documented.
+		nodeCtxs[i].ctx.HeartbeatInterval = nodeCtxs[i].ctx.RemoteClocks.monitorInterval / 2
+
+		s, ln := newTestServer(t, nodeCtxs[i].ctx, true)
+		RegisterHeartbeatServer(s, &HeartbeatService{
+			clock:              clock,
+			remoteClockMonitor: nodeCtxs[i].ctx.RemoteClocks,
+		})
+		nodeCtxs[i].ctx.localAddr = ln.Addr().String()
+	}
+
+	// Fully connect the nodes.
+	for i, clientNodeContext := range nodeCtxs {
+		for j, serverNodeContext := range nodeCtxs {
+			if i == j {
+				continue
+			}
+			if _, err := clientNodeContext.ctx.GRPCDial(serverNodeContext.ctx.localAddr); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Wait until all nodes are connected to all other nodes. We do this before
+	// starting the clock monitors to prevent the case where a node is connected
+	// e.g. only to the outlier node at the time of the first clock monitor
+	// event. This would cause that node to incorrectly deduce that it is offset
+	// from the cluster and commit suicide.
+	//
+	// TODO(tamird): The code responsible for this should be made more resilient (e.g.
+	// don't commit suicide if there are only two known nodes). This is likely
+	// not a problem in practice, since the clock monitor interval is quite
+	// large.
+	for _, nodeCtx := range nodeCtxs {
+		util.SucceedsSoon(t, func() error {
+			nodeCtx.ctx.RemoteClocks.mu.Lock()
+			defer nodeCtx.ctx.RemoteClocks.mu.Unlock()
+
+			if a, e := len(nodeCtx.ctx.RemoteClocks.mu.offsets), len(nodeCtxs)-1; a != e {
+				return util.Errorf("not yet fully connected: have %d of %d connections: %v", a, e, nodeCtx.ctx.RemoteClocks.mu.offsets)
+			}
+			return nil
+		})
+	}
+
+	// Now that all the nodes are connected, start the clock monitors.
+	for _, nodeCtx := range nodeCtxs {
+		// Asynchronously closing over a range variable is unsafe.
+		ctx := nodeCtx.ctx
+		errChan := nodeCtx.errChan
+		stopper.RunWorker(func() {
+			errChan <- ctx.RemoteClocks.MonitorRemoteOffsets(stopper)
+		})
+	}
+
+	const errOffsetGreaterThanMaxOffset = "the true offset is greater than the max offset"
+	for i, nodeCtx := range nodeCtxs {
+		waitTime := nodeCtx.ctx.RemoteClocks.monitorInterval * 5
+
+		if nodeOffset := nodeCtx.offset; nodeOffset > maxOffset {
+			select {
+			case err := <-nodeCtx.errChan:
+				if testutils.IsError(err, errOffsetGreaterThanMaxOffset) {
+					t.Logf("max offset: %s - node %d with excessive clock offset of %s returned expected error: %s", maxOffset, i, nodeOffset, err)
+				} else {
+					t.Errorf("max offset: %s - node %d with excessive clock offset of %s returned unexpected error: %s", maxOffset, i, nodeOffset, err)
+				}
+			case <-time.After(waitTime):
+				t.Errorf("max offset: %s - node %d with excessive clock offset of %s should have return an error, but did not", maxOffset, i, nodeOffset)
+			}
+		} else {
+			select {
+			case err := <-nodeCtx.errChan:
+				t.Errorf("max offset: %s - node %d with acceptable clock offset of %s returned unexpected error: %s", maxOffset, i, nodeOffset, err)
+			case <-time.After(waitTime):
+				t.Logf("max offset: %s - node %d with acceptable clock offset of %s did not return an error, as expected", maxOffset, i, nodeOffset)
+			}
+		}
+	}
 }

--- a/rpc/heartbeat.go
+++ b/rpc/heartbeat.go
@@ -37,10 +37,13 @@ func (*PingRequest) GetUser() string {
 	return security.NodeUser
 }
 
+func (r RemoteOffset) measuredAt() time.Time {
+	return time.Unix(0, r.MeasuredAt).UTC()
+}
+
 // String formats the RemoteOffset for human readability.
 func (r RemoteOffset) String() string {
-	t := time.Unix(r.MeasuredAt/1E9, 0).UTC()
-	return fmt.Sprintf("off=%.9fs, err=%.9fs, at=%s", float64(r.Offset)/1E9, float64(r.Uncertainty)/1E9, t)
+	return fmt.Sprintf("off=%s, err=%s, at=%s", time.Duration(r.Offset), time.Duration(r.Uncertainty), r.measuredAt())
 }
 
 // A HeartbeatService exposes a method to echo its request params. It doubles

--- a/rpc/heartbeat.go
+++ b/rpc/heartbeat.go
@@ -63,16 +63,16 @@ type HeartbeatService struct {
 // The requester should also estimate its offset from this server along
 // with the requester's address.
 func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingResponse, error) {
-	reply := &PingResponse{}
-	reply.Pong = args.Ping
 	serverOffset := args.Offset
 	// The server offset should be the opposite of the client offset.
 	serverOffset.Offset = -serverOffset.Offset
 	if peer, ok := peer.FromContext(ctx); ok {
 		hs.remoteClockMonitor.UpdateOffset(peer.Addr.String(), serverOffset)
 	}
-	reply.ServerTime = hs.clock.PhysicalNow()
-	return reply, nil
+	return &PingResponse{
+		Pong:       args.Ping,
+		ServerTime: hs.clock.PhysicalNow(),
+	}, nil
 }
 
 // A ManualHeartbeatService allows manual control of when heartbeats occur, to

--- a/rpc/heartbeat.go
+++ b/rpc/heartbeat.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
-	"google.golang.org/grpc/peer"
 
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -66,9 +65,7 @@ func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingR
 	serverOffset := args.Offset
 	// The server offset should be the opposite of the client offset.
 	serverOffset.Offset = -serverOffset.Offset
-	if peer, ok := peer.FromContext(ctx); ok {
-		hs.remoteClockMonitor.UpdateOffset(peer.Addr.String(), serverOffset)
-	}
+	hs.remoteClockMonitor.UpdateOffset(args.Addr, serverOffset)
 	return &PingResponse{
 		Pong:       args.Ping,
 		ServerTime: hs.clock.PhysicalNow(),

--- a/rpc/heartbeat.proto
+++ b/rpc/heartbeat.proto
@@ -47,6 +47,8 @@ message PingRequest {
   optional string ping = 1 [(gogoproto.nullable) = false];
   // The last offset the client measured with the server.
   optional RemoteOffset offset = 2 [(gogoproto.nullable) = false];
+  // The address of the client.
+  optional string addr = 3 [(gogoproto.nullable) = false];
 }
 
 // A PingResponse contains the echoed ping request string.

--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -34,7 +34,7 @@ func TestRemoteOffsetString(t *testing.T) {
 		Uncertainty: 351698,
 		MeasuredAt:  1430348776127420269,
 	}
-	expStr := "off=-0.501584461s, err=0.000351698s, at=2015-04-29 23:06:16 +0000 UTC"
+	expStr := "off=-501.584461ms, err=351.698µs, at=2015-04-29 23:06:16.127420269 +0000 UTC"
 	if str := ro.String(); str != expStr {
 		t.Errorf("expected %s; got %s", expStr, str)
 	}

--- a/rpc/heartbeat_test.go
+++ b/rpc/heartbeat_test.go
@@ -115,11 +115,13 @@ func TestUpdateOffsetOnHeartbeat(t *testing.T) {
 
 	_, ln := newTestServer(t, ctx, false)
 	remoteAddr := ln.Addr().String()
-	ctx.RemoteClocks.offsets[remoteAddr] = RemoteOffset{
+	ctx.RemoteClocks.mu.Lock()
+	ctx.RemoteClocks.mu.offsets[remoteAddr] = RemoteOffset{
 		Offset:      10,
 		Uncertainty: 5,
 		MeasuredAt:  20,
 	}
+	ctx.RemoteClocks.mu.Unlock()
 	// Create a client and set its remote offset. On first heartbeat,
 	// it will update the server's remote clocks map.
 	_, err := ctx.GRPCDial(remoteAddr)
@@ -128,7 +130,7 @@ func TestUpdateOffsetOnHeartbeat(t *testing.T) {
 	}
 
 	ctx.RemoteClocks.mu.Lock()
-	o := ctx.RemoteClocks.offsets[remoteAddr]
+	o := ctx.RemoteClocks.mu.offsets[remoteAddr]
 	ctx.RemoteClocks.mu.Unlock()
 	expServerOffset := RemoteOffset{Offset: -10, Uncertainty: 5, MeasuredAt: 20}
 	if proto.Equal(&o, &expServerOffset) {
@@ -140,12 +142,12 @@ func TestUpdateOffsetOnHeartbeat(t *testing.T) {
 	// remote end. A new offset for the server should not be added to the clock
 	// monitor.
 	ctx.RemoteClocks.mu.Lock()
-	delete(ctx.RemoteClocks.offsets, remoteAddr)
+	delete(ctx.RemoteClocks.mu.offsets, remoteAddr)
 	ln.Close()
 	ctx.RemoteClocks.mu.Unlock()
 
 	ctx.RemoteClocks.mu.Lock()
-	if offset, ok := ctx.RemoteClocks.offsets[remoteAddr]; ok {
+	if offset, ok := ctx.RemoteClocks.mu.offsets[remoteAddr]; ok {
 		t.Errorf("unexpected updated offset: %v", offset)
 	}
 	ctx.RemoteClocks.mu.Unlock()

--- a/server/server.go
+++ b/server/server.go
@@ -117,7 +117,9 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 
 	s.rpcContext = rpc.NewContext(&ctx.Context, s.clock, stopper)
 	stopper.RunWorker(func() {
-		s.rpcContext.RemoteClocks.MonitorRemoteOffsets(stopper)
+		if err := s.rpcContext.RemoteClocks.MonitorRemoteOffsets(stopper); err != nil {
+			log.Fatal(err)
+		}
 	})
 
 	s.gossip = gossip.New(s.rpcContext, s.ctx.GossipBootstrapResolvers, stopper)

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -55,7 +55,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	if !validExpirationTime(lease.ExpirationTime) {
-		t.Fatalf("invalid expiration time: %s", time.Unix(lease.ExpirationTime, 0))
+		t.Fatalf("invalid expiration time: %s", time.Unix(0, lease.ExpirationTime))
 	}
 
 	// Acquiring another lease will fail.
@@ -72,7 +72,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	if !validExpirationTime(newLease.ExpirationTime) {
-		t.Fatalf("invalid expiration time: %s", time.Unix(newLease.ExpirationTime, 0))
+		t.Fatalf("invalid expiration time: %s", time.Unix(0, newLease.ExpirationTime))
 	}
 
 	// Extending an old lease fails.

--- a/util/hlc/hlc.go
+++ b/util/hlc/hlc.go
@@ -176,8 +176,7 @@ func (c *Clock) PhysicalNow() int64 {
 
 // PhysicalTime returns a time.Time struct using the local wall time.
 func (c *Clock) PhysicalTime() time.Time {
-	physNow := c.PhysicalNow()
-	return time.Unix(physNow/1E9, physNow%1E9)
+	return time.Unix(0, c.PhysicalNow())
 }
 
 // Update takes a hybrid timestamp, usually originating from

--- a/util/hlc/hlc.go
+++ b/util/hlc/hlc.go
@@ -205,11 +205,9 @@ func (c *Clock) Update(rt roachpb.Timestamp) roachpb.Timestamp {
 	// as it is behind the local and remote wall times. Instead,
 	// the logical clock comes into play.
 	if rt.WallTime > c.state.WallTime {
-		if c.maxOffset.Nanoseconds() > 0 &&
-			rt.WallTime-physicalClock > c.maxOffset.Nanoseconds() {
-			// The remote wall time is too far ahead to be trustworthy.
-			log.Errorf("Remote wall time offsets from local physical clock: %d (%dns ahead)",
-				rt.WallTime, rt.WallTime-physicalClock)
+		offset := time.Duration(rt.WallTime-physicalClock) * time.Nanosecond
+		if c.maxOffset > 0 && offset > c.maxOffset {
+			log.Warningf("remote wall time is too far ahead (%s) to be trustworthy - updating anyway", offset)
 		}
 		// The remote clock is ahead of ours, and we update
 		// our own logical clock with theirs.

--- a/util/hlc/hlc.go
+++ b/util/hlc/hlc.go
@@ -176,7 +176,7 @@ func (c *Clock) PhysicalNow() int64 {
 
 // PhysicalTime returns a time.Time struct using the local wall time.
 func (c *Clock) PhysicalTime() time.Time {
-	return time.Unix(0, c.PhysicalNow())
+	return time.Unix(0, c.PhysicalNow()).UTC()
 }
 
 // Update takes a hybrid timestamp, usually originating from

--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -582,7 +582,7 @@ func (buf *buffer) someDigits(i, d int) int {
 }
 
 func formatLogEntry(entry Entry, stacks []byte, colors *colorProfile) *buffer {
-	buf := formatHeader(Severity(entry.Severity), time.Unix(entry.Time/1E9, entry.Time%1E9),
+	buf := formatHeader(Severity(entry.Severity), time.Unix(0, entry.Time),
 		entry.File, entry.Line, colors)
 	_, _ = buf.WriteString(entry.Message)
 	if buf.Bytes()[buf.Len()-1] != '\n' {


### PR DESCRIPTION
This adds a unit test for the issue reported in #4884. However, it seems that the current implementation works correctly. Perhaps my test here could be more focused with respect to the clock offsets used? Suggestions welcome.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5107)

<!-- Reviewable:end -->
