### PR TITLE
Rename tarball contents

### DIFF
--- a/build/push-release-tarball.sh
+++ b/build/push-release-tarball.sh
@@ -8,7 +8,7 @@ BUCKET_NAME="binaries.cockroachdb.com"
 
 # $0 takes the path to the binary inside the repo and the tarball base name.
 # eg: $0 cockroach-darwin-10.9-amd64 cockroach.darwin-amd64
-#   generates cockroach.darwin-amd64.tgz which expands into cockroach/cockroach.darwin-amd64
+#   generates cockroach.darwin-amd64.tgz which expands into cockroach.darwin-amd64/cockroach
 #   copies tarball to s3://BUCKET_NAME/cockroach.darwin-amd64.tgz
 
 rel_path=$1
@@ -17,10 +17,11 @@ tarball_base=$2
 cd "$(dirname "${0}")/.."
 
 tmpdir=$(mktemp -d /tmp/cockroach-push.XXXXXX)
-mkdir -p "${tmpdir}/cockroach"
+mkdir -p "${tmpdir}/${tarball_base}"
 
-cp ${rel_path} "${tmpdir}/cockroach/${tarball_base}"
-time tar cz -C ${tmpdir} -f ${tarball_base}.tgz cockroach
+# Make sure the binary is named 'cockroach'.
+cp ${rel_path} "${tmpdir}/${tarball_base}/cockroach"
+time tar cz -C ${tmpdir} -f ${tarball_base}.tgz ${tarball_base}
 time aws s3 cp ${tarball_base}.tgz s3://${BUCKET_NAME}/${tarball_base}.tgz
 
 rm -rf ${tmpdir}


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/docs/issues/34

The generated tarballs are now:

```
$ tar tfz cockroach.linux-amd64.tgz
cockroach.linux-amd64/
cockroach.linux-amd64/cockroach
$ tar tfz cockroach.darwin-10.9-amd64.tgz
cockroach.darwin-10.9-amd64/
cockroach.darwin-10.9-amd64/cockroach
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5112)

<!-- Reviewable:end -->
