### PR TITLE
Correctly reset start time at beginning of each scanner loop

### DIFF
--- a/storage/scanner.go
+++ b/storage/scanner.go
@@ -207,13 +207,12 @@ func (rs *replicaScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stop
 // is paced to complete a full scan in approximately the scan interval.
 func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 	stopper.RunWorker(func() {
-		start := time.Now()
-
 		// waitTimer is reset in each call to waitAndProcess.
 		defer rs.waitTimer.Stop()
 
 		for {
 			var shouldStop bool
+			start := time.Now()
 			count := 0
 			rs.replicas.Visit(func(repl *Replica) bool {
 				count++


### PR DESCRIPTION
This was causing the remaining time for the iteration to always be
zero, which would cause pegged CPU after enough scan cycles were
completed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5117)

<!-- Reviewable:end -->
