### PR TITLE
acceptance: remove old network before creating new one

### DIFF
--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -241,8 +241,18 @@ func (l *LocalCluster) panicOnStop() {
 func (l *LocalCluster) createNetwork() {
 	l.panicOnStop()
 
+	const networkName = "cockroachdb_acceptance"
+
+	nets, err := l.client.NetworkList(types.NetworkListOptions{})
+	maybePanic(err)
+	for _, net := range nets {
+		if net.Name == networkName {
+			maybePanic(l.client.NetworkRemove(net.ID))
+		}
+	}
+
 	resp, err := l.client.NetworkCreate(types.NetworkCreate{
-		Name:   "cockroachdb_acceptance",
+		Name:   networkName,
 		Driver: "bridge",
 		// Docker gets very confused if two networks have the same name.
 		CheckDuplicate: true,


### PR DESCRIPTION
For some reason the network is more likely to be left around
after a failed test run than the containers.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5121)

<!-- Reviewable:end -->
