### PR TITLE
util: io.EOF also indicates a closed connection

### DIFF
--- a/util/net.go
+++ b/util/net.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"crypto/tls"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -161,10 +162,11 @@ func ServeHandler(stopper *stop.Stopper, handler http.Handler, ln net.Listener, 
 	}
 }
 
-// IsClosedConnection returns true if err is cmux.ErrListenerClosed, or the net
-// package's errClosed.
+// IsClosedConnection returns true if err is cmux.ErrListenerClosed, io.EOF, or
+// the net package's errClosed.
 func IsClosedConnection(err error) bool {
-	return err == cmux.ErrListenerClosed || strings.Contains(err.Error(), "use of closed network connection")
+	return err == cmux.ErrListenerClosed || err == io.EOF ||
+		strings.Contains(err.Error(), "use of closed network connection")
 }
 
 // FatalIfUnexpected calls Log.Fatal(err) unless err is nil,


### PR DESCRIPTION
This prevents logging an error when a client connection closes. Easy
reproduction is to start a server and then execute invalid sql:

  cockroach sql -e "select ("

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5125)

<!-- Reviewable:end -->
