### PR TITLE
cli: rework the implementation of {-e,--execute}

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -151,6 +151,8 @@ func (c cliTest) RunWithCapture(line string) (out string, err error) {
 }
 
 func (c cliTest) RunWithArgs(a []string) {
+	cliContext.execStmts = nil
+
 	var args []string
 	args = append(args, a[0])
 	h, err := c.ServingHost()
@@ -547,24 +549,24 @@ func Example_sql() {
 	defer c.stop()
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
-	c.RunWithArgs([]string{"sql", "-e", "select 3", "select * from t.f"})
-	c.RunWithArgs([]string{"sql", "-e", "begin", "select 3", "commit"})
+	c.RunWithArgs([]string{"sql", "-e", "select 3", "-e", "select * from t.f"})
+	c.RunWithArgs([]string{"sql", "-e", "begin", "-e", "select 3", "-e", "commit"})
 	c.RunWithArgs([]string{"sql", "-e", "select * from t.f"})
-	c.RunWithArgs([]string{"sql", "-e", "show databases"})
+	c.RunWithArgs([]string{"sql", "--execute=show databases"})
 	c.RunWithArgs([]string{"sql", "-e", "explain select 3"})
 	c.RunWithArgs([]string{"sql", "-e", "select 1; select 2"})
 
 	// Output:
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
 	// INSERT 1
-	// sql -e select 3 select * from t.f
+	// sql -e select 3 -e select * from t.f
 	// 1 row
 	// 3
 	// 3
 	// 1 row
 	// x	y
 	// 42	69
-	// sql -e begin select 3 commit
+	// sql -e begin -e select 3 -e commit
 	// BEGIN
 	// 1 row
 	// 3
@@ -574,7 +576,7 @@ func Example_sql() {
 	// 1 row
 	// x	y
 	// 42	69
-	// sql -e show databases
+	// sql --execute=show databases
 	// 2 rows
 	// Database
 	// system

--- a/cli/context.go
+++ b/cli/context.go
@@ -16,17 +16,36 @@
 
 package cli
 
-import "github.com/cockroachdb/cockroach/server"
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroach/server"
+)
+
+// statementsValue is an implementation of pflag.Value that appends any
+// argument to a slice.
+type statementsValue []string
+
+func (s *statementsValue) String() string {
+	return strings.Join(*s, ";")
+}
+
+func (s *statementsValue) Type() string {
+	return "statementsValue"
+}
+
+func (s *statementsValue) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
 
 // Context contains global settings for the command-line client.
 type Context struct {
 	// Embed the server context.
 	server.Context
 
-	// OneShotSQL indicates the SQL client should run the command-line
-	// statement(s) and terminate directly, without presenting a REPL to
-	// the user.
-	OneShotSQL bool
+	// execStmts is a list of statements to execute.
+	execStmts statementsValue
 }
 
 // NewContext returns a Context with default values.
@@ -39,5 +58,4 @@ func NewContext() *Context {
 // InitDefaults sets up the default values for a Context.
 func (ctx *Context) InitDefaults() {
 	ctx.Context.InitDefaults()
-	ctx.OneShotSQL = false
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -72,13 +72,11 @@ Database server port to connect to for HTTP requests.`),
 The name of the database to connect to.`),
 
 	"execute": wrapText(`
-Execute the SQL statement(s) on the command line, then exit. Each
-subsequent positional argument on the command line may contain
-one or more SQL statements, separated by semicolons. If an
-error occurs in any statement, the command exits with a
-non-zero status code and further statements are not
-executed. The results of each SQL statement are printed on
-the standard output.`),
+Execute the SQL statement(s) on the command line, then exit. This flag may be
+specified multiple times and each value may contain multiple semicolon
+separated statements. If an error occurs in any statement, the command exits
+with a non-zero status code and further statements are not executed. The
+results of each SQL statement are printed on the standard output.`),
 
 	"join": wrapText(`
 A comma-separated list of addresses to use when a new node is joining
@@ -341,7 +339,7 @@ func initFlags(ctx *Context) {
 
 	{
 		f := sqlShellCmd.Flags()
-		f.BoolVarP(&ctx.OneShotSQL, "execute", "e", ctx.OneShotSQL, usage("execute"))
+		f.VarP(&ctx.execStmts, "execute", "e", usage("execute"))
 	}
 
 	// Commands that need the cockroach port.

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -258,7 +258,7 @@ func runStatements(conn *sqlConn, stmts []string) error {
 }
 
 func runTerm(cmd *cobra.Command, args []string) error {
-	if !(cliContext.OneShotSQL || len(args) == 0) {
+	if len(args) > 0 {
 		mustUsage(cmd)
 		return errMissingParams
 	}
@@ -266,9 +266,9 @@ func runTerm(cmd *cobra.Command, args []string) error {
 	conn := makeSQLClient()
 	defer conn.Close()
 
-	if cliContext.OneShotSQL {
+	if len(cliContext.execStmts) > 0 {
 		// Single-line sql; run as simple as possible, without noise on stdout.
-		return runStatements(conn, args)
+		return runStatements(conn, cliContext.execStmts)
 	}
 	return runInteractive(conn)
 }


### PR DESCRIPTION
The -e flag can now be specified multiple times on the command line. The
--execute=foo form of flag specification now works. The drawback is that
positional arguments are no longer interpreted as statements.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5127)

<!-- Reviewable:end -->
