### PR TITLE
kv: Improve intent deduplication and testing

### DIFF
--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -402,7 +402,7 @@ func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 	}
 	s.Sender.Lock()
 	txnID := *txn.Proto.ID
-	intentSpans := s.Sender.txns[txnID].intentSpans()
+	intentSpans := collectIntentSpans(s.Sender.txns[txnID].keys)
 	expSpans := []roachpb.Span{{Key: key, EndKey: []byte("")}}
 	equal := !reflect.DeepEqual(intentSpans, expSpans)
 	s.Sender.Unlock()

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -102,19 +102,17 @@ func (br *BatchResponse) Header() *BatchResponse_Header {
 	return &br.BatchResponse_Header
 }
 
-// GetIntentSpans returns a slice of key pairs corresponding to transactional
-// writes contained in the batch.
-func (ba *BatchRequest) GetIntentSpans() []Span {
-	var intents []Span
+// IntentSpanIterate calls the passed method with the key ranges of the
+// transactional writes contained in the batch.
+func (ba *BatchRequest) IntentSpanIterate(fn func(key, endKey Key)) {
 	for _, arg := range ba.Requests {
 		req := arg.GetInner()
 		if !IsTransactionWrite(req) {
 			continue
 		}
 		h := req.Header()
-		intents = append(intents, Span{Key: h.Key, EndKey: h.EndKey})
+		fn(h.Key, h.EndKey)
 	}
-	return intents
 }
 
 // ResetAll resets all the contained requests to their original state.


### PR DESCRIPTION
On commit, TxnCoordSender attaches the collected intent spans to EndTransaction.
There are two sources: spans from previous requests, and spans from the current
batch. Previous handling was asymmetrical and the test was actually broken
(i.e. not asserting properly).
Streamlined both.

@dt after this change you won't be seeing that double intent which highlighted the bug in #4521. You already have a smaller repro so doesn't matter, but wanted to give you a heads up.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5128)

<!-- Reviewable:end -->
