### PR TITLE
cli: Define flags for userCmds, zoneCmds, nodeCmds on subcommands

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -323,9 +323,11 @@ func initFlags(ctx *Context) {
 
 	clientCmds := []*cobra.Command{
 		sqlShellCmd, kvCmd, rangeCmd,
-		userCmd, zoneCmd, nodeCmd,
 		exterminateCmd, quitCmd, /* startCmd is covered above */
 	}
+	clientCmds = append(clientCmds, userCmds...)
+	clientCmds = append(clientCmds, zoneCmds...)
+	clientCmds = append(clientCmds, nodeCmds...)
 	for _, cmd := range clientCmds {
 		f := cmd.PersistentFlags()
 		f.BoolVar(&ctx.Insecure, "insecure", ctx.Insecure, usage("insecure"))
@@ -349,13 +351,18 @@ func initFlags(ctx *Context) {
 		f.StringVarP(&connPort, "port", "p", base.DefaultPort, usage("client_port"))
 	}
 
-	for _, cmd := range []*cobra.Command{nodeCmd, quitCmd} {
+	// Commands that need an http port.
+	httpCmds := []*cobra.Command{quitCmd}
+	httpCmds = append(httpCmds, nodeCmds...)
+	for _, cmd := range httpCmds {
 		f := cmd.PersistentFlags()
 		f.StringVar(&httpPort, "http-port", base.DefaultHTTPPort, usage("client_http_port"))
 	}
 
 	// Commands that establish a SQL connection.
-	sqlCmds := []*cobra.Command{sqlShellCmd, userCmd, zoneCmd}
+	sqlCmds := []*cobra.Command{sqlShellCmd}
+	sqlCmds = append(sqlCmds, zoneCmds...)
+	sqlCmds = append(sqlCmds, userCmds...)
 	for _, cmd := range sqlCmds {
 		f := cmd.PersistentFlags()
 		f.StringVar(&connURL, "url", "", usage("url"))


### PR DESCRIPTION
Fixes #5089.

Previously we were defining flags on the user, zone, and node commands
themselves, even though these commands were just proxies for their
subcommands. This caused the flags to show up as "global flags". By
defining these flags on the subcommands themselves, the flags will show
up correctly in the usage statements.

The issues example now looks like:

```
Nathans-MacBook-Pro:cockroach$ ./cockroach help zone get
Fetches and displays the zone configuration for the specified database or
table.

Usage:
  cockroach zone get [options] <database[.table]> [flags]

Flags:
      --ca-cert string
        Path to the CA certificate. Needed by clients and servers in secure
        mode.

      --cert string
        Path to the client or server certificate. Needed in secure mode.

  -d, --database string
        The name of the database to connect to.

      --host string
        Database server host to connect to.

      --insecure
        Run over plain HTTP. WARNING: this is strongly discouraged.

      --key string
        Path to the key protecting --cert. Needed in secure mode.

  -p, --port string
        Database server port to connect to.
        (default "26257")
      --url string
        Connection url. eg: postgresql://myuser@localhost:26257/mydb If left
        empty, the connection flags are used (host, port, user, database,
        insecure, certs).

  -u, --user string
        Database user name.
        (default "root")

Global Flags:
      --alsologtostderr value[=INFO]   logs at or above this threshold go to stderr (default ERROR)
      --log-backtrace-at value         when logging hits line file:N, emit a stack trace (default :0)
      --log-dir value                  if non-empty, write log files in this directory
      --logtostderr value[=true]       log to standard error instead of files
      --no-color value                 disable standard error log colorization
      --verbosity value                log level for V logs
      --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5131)

<!-- Reviewable:end -->
