### PR TITLE
storage: log binary checksum data using %x, not %v

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1494,7 +1494,7 @@ func (r *Replica) VerifyChecksum(batch engine.Engine, ms *engine.MVCCStats, h ro
 					p()
 				} else {
 					// TODO(.*): see #5051.
-					log.Errorf("checksums: e = %v, v = %v", args.Checksum, c.checksum)
+					log.Errorf("checksum mismatch: e = %x, v = %x", args.Checksum, c.checksum)
 				}
 			}
 		} else {


### PR DESCRIPTION
This might be going away soon, but right now it is offending my eyes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5162)

<!-- Reviewable:end -->
