### PR TITLE
gossip: fix test flakiness

### DIFF
--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -42,11 +42,7 @@ func startGossip(nodeID roachpb.NodeID, stopper *stop.Stopper, t *testing.T) *Go
 
 	addr := util.CreateTestAddr("tcp")
 	server := rpc.NewServer(rpcContext)
-	tlsConfig, err := rpcContext.GetServerTLSConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-	ln, err := util.ListenAndServe(stopper, server, addr, tlsConfig)
+	ln, err := util.ListenAndServeGRPC(stopper, server, addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,11 +102,7 @@ func startFakeServerGossips(t *testing.T) (local *Gossip, remote *fakeGossipServ
 
 	laddr := util.CreateTestAddr("tcp")
 	lserver := rpc.NewServer(lRPCContext)
-	lTLSConfig, err := lRPCContext.GetServerTLSConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-	lln, err := util.ListenAndServe(stopper, lserver, laddr, lTLSConfig)
+	lln, err := util.ListenAndServeGRPC(stopper, lserver, laddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,11 +113,7 @@ func startFakeServerGossips(t *testing.T) (local *Gossip, remote *fakeGossipServ
 
 	raddr := util.CreateTestAddr("tcp")
 	rserver := rpc.NewServer(rRPCContext)
-	rTLSConfig, err := rRPCContext.GetServerTLSConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-	rln, err := util.ListenAndServe(stopper, rserver, raddr, rTLSConfig)
+	rln, err := util.ListenAndServeGRPC(stopper, rserver, raddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +121,6 @@ func startFakeServerGossips(t *testing.T) (local *Gossip, remote *fakeGossipServ
 	remote = newFakeGossipServer(rserver, stopper)
 	addr := rln.Addr()
 	remote.nodeAddr = util.MakeUnresolvedAddr(addr.Network(), addr.String())
-	time.Sleep(time.Millisecond)
 	return
 }
 
@@ -324,11 +311,7 @@ func TestClientRegisterWithInitNodeID(t *testing.T) {
 
 		addr := util.CreateTestAddr("tcp")
 		server := rpc.NewServer(RPCContext)
-		TLSConfig, err := RPCContext.GetServerTLSConfig()
-		if err != nil {
-			t.Fatal(err)
-		}
-		ln, err := util.ListenAndServe(stopper, server, addr, TLSConfig)
+		ln, err := util.ListenAndServeGRPC(stopper, server, addr)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -89,7 +89,7 @@ func NewNetwork(nodeCount int) *Network {
 func (n *Network) CreateNode() (*Node, error) {
 	server := rpc.NewServer(n.rpcContext)
 	testAddr := util.CreateTestAddr("tcp")
-	ln, err := util.ListenAndServe(n.Stopper, server, testAddr, n.tlsConfig)
+	ln, err := util.ListenAndServeGRPC(n.Stopper, server, testAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -49,18 +49,8 @@ func newNodeTestContext(clock *hlc.Clock, stopper *stop.Stopper) *rpc.Context {
 func newTestServer(t *testing.T, ctx *rpc.Context) (*grpc.Server, net.Listener) {
 	s := rpc.NewServer(ctx)
 
-	tlsConfig, err := ctx.GetServerTLSConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// We may be called in a loop, meaning tlsConfig is may be in used by a
-	// running server during a call to `util.ListenAndServe`, which may
-	// mutate it (due to http2.ConfigureServer). Make a copy to avoid trouble.
-	tlsConfigCopy := *tlsConfig
-
 	addr := util.CreateTestAddr("tcp")
-	ln, err := util.ListenAndServe(ctx.Stopper, s, addr, &tlsConfigCopy)
+	ln, err := util.ListenAndServeGRPC(ctx.Stopper, s, addr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -29,15 +30,14 @@ import (
 )
 
 func newTestServer(t *testing.T, ctx *Context, manual bool) (*grpc.Server, net.Listener) {
-	s := grpc.NewServer()
-
 	tlsConfig, err := ctx.GetServerTLSConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
+	s := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
 
 	addr := util.CreateTestAddr("tcp")
-	ln, err := util.ListenAndServe(ctx.Stopper, s, addr, tlsConfig)
+	ln, err := util.ListenAndServeGRPC(ctx.Stopper, s, addr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -61,11 +61,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	ctx.ScanInterval = 10 * time.Hour
 	ctx.ConsistencyCheckInterval = 10 * time.Hour
 	grpcServer := rpc.NewServer(nodeRPCContext)
-	tlsConfig, err := nodeRPCContext.GetServerTLSConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-	ln, err := util.ListenAndServe(stopper, grpcServer, addr, tlsConfig)
+	ln, err := util.ListenAndServeGRPC(stopper, grpcServer, addr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -544,15 +544,11 @@ func (m *multiTestContext) addStore() {
 		}
 	}
 
-	tlsConfig, err := m.rpcContext.GetServerTLSConfig()
-	if err != nil {
-		m.t.Fatal(err)
-	}
-
 	if m.nodeIDtoAddr == nil {
 		m.nodeIDtoAddr = make(map[roachpb.NodeID]net.Addr)
 	}
-	ln, err := util.ListenAndServe(m.transportStopper, m.grpcServers[idx], util.CreateTestAddr("tcp"), tlsConfig)
+	ln, err := util.ListenAndServeGRPC(m.transportStopper,
+		m.grpcServers[idx], util.CreateTestAddr("tcp"))
 	if err != nil {
 		m.t.Fatal(err)
 	}

--- a/util/leaktest/leaktest.go
+++ b/util/leaktest/leaktest.go
@@ -32,7 +32,7 @@ func interestingGoroutines() (gs []string) {
 
 		if stack == "" ||
 			strings.Contains(stack, "github.com/cockroachdb/cockroach/util/log.init") ||
-
+			// Below are the stacks ignored by the upstream leaktest code.
 			strings.Contains(stack, "testing.Main(") ||
 			strings.Contains(stack, "runtime.goexit") ||
 			strings.Contains(stack, "created by runtime.gc") ||


### PR DESCRIPTION
Use grpc.Server.Serve instead of grpc.Server.ServeHTTP.

Fixes #5136.

Well, this only fixes `TestClientNodeID` flakiness. I don't consider this a real fix, but it is interesting that the flakiness goes away when using `grpc.Server.Serve` instead of `grpc.Serve.ServeHTTP`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5169)

<!-- Reviewable:end -->
