### PR TITLE
gossip: deflake TestClientNodeID

### DIFF
--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -168,13 +168,12 @@ func TestClientNodeID(t *testing.T) {
 	nodeID := roachpb.NodeID(1)
 	local.SetNodeID(nodeID)
 
-	disconnected := make(chan *client, 1)
-
 	// Use an insecure context. We're talking to tcp socket which are not in the certs.
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
-
-	// Start a gossip client.
 	c := newClient(&remote.nodeAddr)
+	disconnected := make(chan *client, 1)
+	disconnected <- c
+
 	defer func() {
 		stopper.Stop()
 		if c != <-disconnected {
@@ -182,10 +181,21 @@ func TestClientNodeID(t *testing.T) {
 		}
 	}()
 
-	c.start(local, disconnected, rpcContext, stopper)
-	// Wait for c.gossip to start.
-	if receivedNodeID := <-remote.nodeIDChan; receivedNodeID != nodeID {
-		t.Errorf("client should send NodeID with %v, got %v", nodeID, receivedNodeID)
+	// A gossip client may fail to start if the grpc connection times out which
+	// can happen under load (such as in CircleCI or using `make stress`). So we
+	// loop creating clients until success or the test times out.
+	for {
+		// Wait for c.gossip to start.
+		select {
+		case receivedNodeID := <-remote.nodeIDChan:
+			if receivedNodeID != nodeID {
+				t.Fatalf("client should send NodeID with %v, got %v", nodeID, receivedNodeID)
+			}
+			return
+		case <-disconnected:
+			// The client hasn't been started or failed to start, loop and try again.
+			c.start(local, disconnected, rpcContext, stopper)
+		}
 	}
 }
 


### PR DESCRIPTION
A gossip client may fail to start if the grpc connection times out which
can happen under load (such as in CircleCI or using `make stress`). We
now loop creating clients until success or the test times out.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5172)

<!-- Reviewable:end -->
