### PR TITLE
sql: Disallow index span constraints from mixed type comparison ops

### DIFF
--- a/sql/testdata/select_index
+++ b/sql/testdata/select_index
@@ -218,3 +218,72 @@ query ITT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
 0 empty -
+
+# Make sure that mixed type comparison operations are not used
+# for selecting indexes.
+
+statement ok
+DROP TABLE t
+
+statement ok
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  INDEX b_desc (b DESC),
+  INDEX bc (b, c)
+)
+
+statement ok
+INSERT INTO t VALUES (1, 2, 3), (3, 4, 5), (5, 6, 7)
+
+query I
+SELECT a FROM t WHERE a < 4.0
+----
+3
+1
+
+query I
+SELECT b FROM t WHERE c > 4.0 AND a < 4
+----
+4
+
+query ITT
+EXPLAIN SELECT a FROM t WHERE c > 1
+----
+0 scan t@bc -
+
+query ITT
+EXPLAIN SELECT a FROM t WHERE c < 1 AND b < 5
+----
+0 scan t@bc /#-/4/1
+
+query ITT
+EXPLAIN SELECT a FROM t WHERE c > 1.0
+----
+0 scan t@bc -
+
+query ITT
+EXPLAIN SELECT a FROM t WHERE c < 1.0
+----
+0 scan t@bc -
+
+query ITT
+EXPLAIN SELECT a FROM t WHERE c > 1.0 AND b < 5
+----
+0 scan t@bc /#-/5
+
+query ITT
+EXPLAIN SELECT a FROM t WHERE b < 5.0 AND c < 1
+----
+0 scan t@bc -
+
+query ITT
+EXPLAIN SELECT a FROM t WHERE (b, c) = (5, 1)
+----
+0 scan t@bc /5/1-/5/2
+
+query ITT
+EXPLAIN SELECT a FROM t WHERE (b, c) = (5.0, 1)
+----
+0 scan t@bc -


### PR DESCRIPTION
Fixes #4313.

Previously we allowed the use of mixed-type comparison operations
to be used to constrain index spans. This resulted in incorrect
constraints because the encoding of the constraint was for the wrong
type. This (temporary?) fix removes these invalid index constraints.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5175)

<!-- Reviewable:end -->
