### PR TITLE
util: simplify CreateTestAddr

### DIFF
--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -40,12 +40,12 @@ import (
 func startGossip(nodeID roachpb.NodeID, stopper *stop.Stopper, t *testing.T) *Gossip {
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
 
-	addr := util.CreateTestAddr("tcp")
 	server := rpc.NewServer(rpcContext)
-	ln, err := util.ListenAndServeGRPC(stopper, server, addr)
+	ln, err := util.ListenAndServeGRPC(stopper, server, util.TestAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
+	addr := ln.Addr()
 	g := New(rpcContext, nil, stopper)
 	g.SetNodeID(nodeID)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{
@@ -54,7 +54,7 @@ func startGossip(nodeID roachpb.NodeID, stopper *stop.Stopper, t *testing.T) *Go
 	}); err != nil {
 		t.Fatal(err)
 	}
-	g.start(server, ln.Addr())
+	g.start(server, addr)
 	time.Sleep(time.Millisecond)
 	return g
 }
@@ -100,9 +100,8 @@ func startFakeServerGossips(t *testing.T) (local *Gossip, remote *fakeGossipServ
 	stopper = stop.NewStopper()
 	lRPCContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
 
-	laddr := util.CreateTestAddr("tcp")
 	lserver := rpc.NewServer(lRPCContext)
-	lln, err := util.ListenAndServeGRPC(stopper, lserver, laddr)
+	lln, err := util.ListenAndServeGRPC(stopper, lserver, util.TestAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,9 +110,8 @@ func startFakeServerGossips(t *testing.T) (local *Gossip, remote *fakeGossipServ
 
 	rRPCContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
 
-	raddr := util.CreateTestAddr("tcp")
 	rserver := rpc.NewServer(rRPCContext)
-	rln, err := util.ListenAndServeGRPC(stopper, rserver, raddr)
+	rln, err := util.ListenAndServeGRPC(stopper, rserver, util.TestAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,9 +307,8 @@ func TestClientRegisterWithInitNodeID(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		RPCContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
 
-		addr := util.CreateTestAddr("tcp")
 		server := rpc.NewServer(RPCContext)
-		ln, err := util.ListenAndServeGRPC(stopper, server, addr)
+		ln, err := util.ListenAndServeGRPC(stopper, server, util.TestAddr)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -88,8 +88,7 @@ func NewNetwork(nodeCount int) *Network {
 // CreateNode creates a simulation node and starts an RPC server for it.
 func (n *Network) CreateNode() (*Node, error) {
 	server := rpc.NewServer(n.rpcContext)
-	testAddr := util.CreateTestAddr("tcp")
-	ln, err := util.ListenAndServeGRPC(n.Stopper, server, testAddr)
+	ln, err := util.ListenAndServeGRPC(n.Stopper, server, util.TestAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -49,8 +49,7 @@ func newNodeTestContext(clock *hlc.Clock, stopper *stop.Stopper) *rpc.Context {
 func newTestServer(t *testing.T, ctx *rpc.Context) (*grpc.Server, net.Listener) {
 	s := rpc.NewServer(ctx)
 
-	addr := util.CreateTestAddr("tcp")
-	ln, err := util.ListenAndServeGRPC(ctx.Stopper, s, addr)
+	ln, err := util.ListenAndServeGRPC(ctx.Stopper, s, util.TestAddr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -36,8 +36,7 @@ func newTestServer(t *testing.T, ctx *Context, manual bool) (*grpc.Server, net.L
 	}
 	s := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
 
-	addr := util.CreateTestAddr("tcp")
-	ln, err := util.ListenAndServeGRPC(ctx.Stopper, s, addr)
+	ln, err := util.ListenAndServeGRPC(ctx.Stopper, s, util.TestAddr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -181,7 +181,7 @@ func TestBootstrapNewStore(t *testing.T) {
 		engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper),
 		engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper),
 	}
-	_, _, node, stopper := createAndStartTestNode(util.CreateTestAddr("tcp"), engines, util.CreateTestAddr("tcp"), t)
+	_, _, node, stopper := createAndStartTestNode(util.TestAddr, engines, util.TestAddr, t)
 	defer stopper.Stop()
 
 	// Non-initialized stores (in this case the new in-memory-based
@@ -219,14 +219,12 @@ func TestNodeJoin(t *testing.T) {
 
 	// Start the bootstrap node.
 	engines1 := []engine.Engine{e}
-	addr1 := util.CreateTestAddr("tcp")
-	_, server1Addr, node1, stopper1 := createAndStartTestNode(addr1, engines1, addr1, t)
+	_, server1Addr, node1, stopper1 := createAndStartTestNode(util.TestAddr, engines1, util.TestAddr, t)
 	defer stopper1.Stop()
 
 	// Create a new node.
 	engines2 := []engine.Engine{engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)}
-	addr2 := util.CreateTestAddr("tcp")
-	_, server2Addr, node2, stopper2 := createAndStartTestNode(addr2, engines2, server1Addr, t)
+	_, server2Addr, node2, stopper2 := createAndStartTestNode(util.TestAddr, engines2, server1Addr, t)
 	defer stopper2.Stop()
 
 	// Verify new node is able to bootstrap its store.
@@ -267,8 +265,7 @@ func TestNodeJoinSelf(t *testing.T) {
 	engineStopper := stop.NewStopper()
 	defer engineStopper.Stop()
 	engines := []engine.Engine{engine.NewInMem(roachpb.Attributes{}, 1<<20, engineStopper)}
-	addr := util.CreateTestAddr("tcp")
-	_, addr, _, node, stopper := createTestNode(addr, engines, addr, t)
+	_, addr, _, node, stopper := createTestNode(util.TestAddr, engines, util.TestAddr, t)
 	defer stopper.Stop()
 	err := node.start(addr, engines, roachpb.Attributes{})
 	if err != errCannotJoinSelf {
@@ -298,7 +295,7 @@ func TestCorruptedClusterID(t *testing.T) {
 	}
 
 	engines := []engine.Engine{e}
-	_, serverAddr, _, node, stopper := createTestNode(util.CreateTestAddr("tcp"), engines, nil, t)
+	_, serverAddr, _, node, stopper := createTestNode(util.TestAddr, engines, nil, t)
 	stopper.Stop()
 	if err := node.start(serverAddr, engines, roachpb.Attributes{}); !testutils.IsError(err, "unidentified store") {
 		t.Errorf("unexpected error %v", err)

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -548,7 +548,7 @@ func (m *multiTestContext) addStore() {
 		m.nodeIDtoAddr = make(map[roachpb.NodeID]net.Addr)
 	}
 	ln, err := util.ListenAndServeGRPC(m.transportStopper,
-		m.grpcServers[idx], util.CreateTestAddr("tcp"))
+		m.grpcServers[idx], util.TestAddr)
 	if err != nil {
 		m.t.Fatal(err)
 	}

--- a/storage/raft_transport_test.go
+++ b/storage/raft_transport_test.go
@@ -96,7 +96,7 @@ func TestSendAndReceive(t *testing.T) {
 		nextNodeID++
 		grpcServer := rpc.NewServer(nodeRPCContext)
 		ln, err := util.ListenAndServeGRPC(stopper, grpcServer,
-			util.CreateTestAddr("tcp"))
+			util.TestAddr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -232,7 +232,7 @@ func TestInOrderDelivery(t *testing.T) {
 	g := gossip.New(nodeRPCContext, nil, stopper)
 
 	grpcServer := rpc.NewServer(nodeRPCContext)
-	ln, err := util.ListenAndServeGRPC(stopper, grpcServer, util.CreateTestAddr("tcp"))
+	ln, err := util.ListenAndServeGRPC(stopper, grpcServer, util.TestAddr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/util/testing.go
+++ b/util/testing.go
@@ -19,7 +19,6 @@ package util
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -54,26 +53,6 @@ func (pt panicTesterImpl) Fatal(args ...interface{}) {
 
 func (panicTesterImpl) Fatalf(format string, args ...interface{}) {
 	panic(fmt.Sprintf(format, args...))
-}
-
-// tempUnixFile creates a temporary file for use with a unix domain socket.
-// TODO(bdarnell): use TempDir instead to make this atomic.
-func tempUnixFile() string {
-	f, err := ioutil.TempFile("", "unix-socket")
-	if err != nil {
-		panic(fmt.Sprintf("unable to create temp file: %s", err))
-	}
-	f.Close()
-	if err := os.Remove(f.Name()); err != nil {
-		panic(fmt.Sprintf("unable to remove temp file: %s", err))
-	}
-	return f.Name()
-}
-
-// tempLocalhostAddr creates an address to localhost using a monotonically
-// increasing port number in the range [minLocalhostPort, ...].
-func tempLocalhostAddr() string {
-	return "127.0.0.1:0"
 }
 
 // CreateTempDir creates a temporary directory and returns its path.
@@ -130,26 +109,6 @@ func CleanupDirs(dirs []string) {
 	for _, dir := range dirs {
 		_ = os.RemoveAll(dir)
 	}
-}
-
-// CreateTestAddr creates an unused address for testing. The "network"
-// parameter should be one of "tcp" or "unix".
-func CreateTestAddr(network string) net.Addr {
-	switch network {
-	case "tcp":
-		addr, err := net.ResolveTCPAddr("tcp", tempLocalhostAddr())
-		if err != nil {
-			panic(err)
-		}
-		return addr
-	case "unix":
-		addr, err := net.ResolveUnixAddr("unix", tempUnixFile())
-		if err != nil {
-			panic(err)
-		}
-		return addr
-	}
-	panic(fmt.Sprintf("unknown network type: %s", network))
 }
 
 const defaultSucceedsSoonDuration = 15 * time.Second

--- a/util/testing_test.go
+++ b/util/testing_test.go
@@ -17,48 +17,9 @@
 package util
 
 import (
-	"net"
 	"testing"
 	"time"
 )
-
-// verifyAddr starts a server listener at the specified addr and
-// then dials a client to verify a connection is established.
-func verifyAddr(addr net.Addr, t *testing.T) {
-	ln, err := net.Listen(addr.Network(), addr.String())
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	acceptChan := make(chan struct{})
-	go func() {
-		_, err := ln.Accept()
-		if err != nil {
-			t.Error(err)
-		}
-		close(acceptChan)
-	}()
-
-	addr = ln.Addr()
-	conn, err := net.Dial(addr.Network(), addr.String())
-	if err != nil {
-		t.Errorf("could not connect to %s", addr)
-		return
-	}
-	select {
-	case <-acceptChan:
-		// success.
-	case <-time.After(500 * time.Millisecond):
-		t.Error("timeout waiting for client connection after 500ms")
-	}
-	conn.Close()
-}
-
-func TestCreateTestAddr(t *testing.T) {
-	verifyAddr(CreateTestAddr("unix"), t)
-	verifyAddr(CreateTestAddr("tcp"), t)
-}
 
 func TestSucceedsSoon(t *testing.T) {
 	// Try a method which always succeeds.

--- a/util/unresolved_addr.go
+++ b/util/unresolved_addr.go
@@ -21,6 +21,9 @@ import (
 	"net"
 )
 
+// TestAddr is an unused address for testing.
+var TestAddr = NewUnresolvedAddr("tcp", "127.0.0.1:0")
+
 // MakeUnresolvedAddr populates an UnresolvedAddr from a network and raw
 // address string.
 func MakeUnresolvedAddr(network, addr string) UnresolvedAddr {


### PR DESCRIPTION
No need to pass in the network to CreateTestAddr when it is always
"tcp".

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5178)

<!-- Reviewable:end -->
