### PR TITLE
storage/engine/rocksdb: DBBatch::NewIter should always return delta iter

### DIFF
--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1440,12 +1440,8 @@ DBIterator* DBBatch::NewIter(DBSlice prefix) {
   opts.iterate_upper_bound = iter->upper_bound();
   opts.total_order_seek = iter->upper_bound() == NULL;
   rocksdb::Iterator* base = rep->NewIterator(opts);
-  if (updates == 0) {
-    iter->rep.reset(base);
-  } else {
-    rocksdb::WBWIIterator* delta = batch.NewIterator();
-    iter->rep.reset(new BaseDeltaIterator(base, delta));
-  }
+  rocksdb::WBWIIterator* delta = batch.NewIterator();
+  iter->rep.reset(new BaseDeltaIterator(base, delta));
   return iter;
 }
 


### PR DESCRIPTION
returning a non-delta iterator if the batch is empty means that that iterator
will _not_ see future writes to the batch, contrary to the expectation that
an iterator on a writebatchwithindex should see writes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5183)

<!-- Reviewable:end -->
