### PR TITLE
add suport for replay protection to TestingCommandFilter

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -146,7 +146,7 @@ type Context struct {
 	TestingKnobs TestingKnobs
 }
 
-// TestingKnobs is a contains facilities for controlling various parts of the
+// TestingKnobs contains facilities for controlling various parts of the
 // system for testing.
 type TestingKnobs struct {
 	StoreTestingKnobs    storage.StoreTestingKnobs

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/randutil"
@@ -79,16 +80,16 @@ func TestIntentResolution(t *testing.T) {
 			var done bool
 			ctx := NewTestContext()
 			ctx.TestingKnobs.StoreTestingKnobs.TestingCommandFilter =
-				func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
+				func(filterArgs storageutils.FilterArgs) error {
 					mu.Lock()
 					defer mu.Unlock()
-					header := args.Header()
+					header := filterArgs.Req.Header()
 					// Ignore anything outside of the intent key range of "a" - "z"
 					if header.Key.Compare(roachpb.Key("a")) < 0 || header.Key.Compare(roachpb.Key("z")) > 0 {
 						return nil
 					}
 					var entry string
-					switch arg := args.(type) {
+					switch arg := filterArgs.Req.(type) {
 					case *roachpb.ResolveIntentRequest:
 						if arg.Status == roachpb.COMMITTED {
 							entry = string(header.Key)

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	_ "github.com/cockroachdb/pq"
 )
@@ -77,9 +78,9 @@ func TestTxnRestart(t *testing.T) {
 		vals:          []string{"boulanger", "dromedary", "fajita", "hooly", "josephine", "laureal"},
 	}
 	cleanupFilter := cmdFilters.AppendFilter(
-		func(sid roachpb.StoreID, req roachpb.Request, hdr roachpb.Header) error {
-			return injectRetriableErrors(sid, req, hdr, magicVals)
-		})
+		func(args storageutils.FilterArgs) error {
+			return injectRetriableErrors(args.Sid, args.Req, args.Hdr, magicVals)
+		}, false)
 	func() {
 		if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
@@ -122,9 +123,9 @@ INSERT INTO t.test (k, v) VALUES ('k', 'laureal');
 		restartCounts: make(map[string]int),
 	}
 	cleanupFilter = cmdFilters.AppendFilter(
-		func(sid roachpb.StoreID, req roachpb.Request, hdr roachpb.Header) error {
-			return injectRetriableErrors(sid, req, hdr, magicVals)
-		})
+		func(args storageutils.FilterArgs) error {
+			return injectRetriableErrors(args.Sid, args.Req, args.Hdr, magicVals)
+		}, false)
 	defer cleanupFilter()
 
 	// Start a txn.

--- a/storage/client_replica_gc_test.go
+++ b/storage/client_replica_gc_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -46,9 +47,9 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 	ctx := storage.TestStoreContext()
 	mtc.storeContext = &ctx
 	mtc.storeContext.TestingKnobs.TestingCommandFilter =
-		func(id roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
-			et, ok := args.(*roachpb.EndTransactionRequest)
-			if !ok || id != 2 {
+		func(filterArgs storageutils.FilterArgs) error {
+			et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest)
+			if !ok || filterArgs.Sid != 2 {
 				return nil
 			}
 			rct := et.InternalCommitTrigger.GetChangeReplicasTrigger()

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -194,10 +195,10 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	defer stopper.Stop()
 	ctx := storage.TestStoreContext()
 	ctx.TestingKnobs.TestingCommandFilter =
-		func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
-			if _, ok := args.(*roachpb.GetRequest); ok &&
-				args.Header().Key.Equal(roachpb.Key(key)) &&
-				h.Txn == nil {
+		func(filterArgs storageutils.FilterArgs) error {
+			if _, ok := filterArgs.Req.(*roachpb.GetRequest); ok &&
+				filterArgs.Req.Header().Key.Equal(roachpb.Key(key)) &&
+				filterArgs.Hdr.Txn == nil {
 				// The Reader executes two get operations, each of which triggers two get requests
 				// (the first request fails and triggers txn push, and then the second request
 				// succeeds). Returns an error for the fourth get request to avoid timestamp cache

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -343,8 +344,8 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	tc := testContext{}
 	tsc := TestStoreContext()
 	tsc.TestingKnobs.TestingCommandFilter =
-		func(_ roachpb.StoreID, req roachpb.Request, _ roachpb.Header) error {
-			if resArgs, ok := req.(*roachpb.ResolveIntentRequest); ok {
+		func(filterArgs storageutils.FilterArgs) error {
+			if resArgs, ok := filterArgs.Req.(*roachpb.ResolveIntentRequest); ok {
 				id := string(resArgs.IntentTxn.Key)
 				resolved[id] = append(resolved[id], roachpb.Span{
 					Key:    resArgs.Key,

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -75,13 +76,6 @@ const (
 	// to gossip after performing an update to the map.
 	configGossipInterval = 1 * time.Minute
 )
-
-// CommandFilter may be used in tests through the StorageTestingKnobs to
-// intercept the handling of commands and artificially generate errors. Return
-// nil to continue with regular processing or non-nil to terminate processing
-// with the returned error. Note that in a multi-replica test this filter will
-// be run once for each replica and must produce consistent results each time.
-type CommandFilter func(roachpb.StoreID, roachpb.Request, roachpb.Header) error
 
 // This flag controls whether Transaction entries are automatically gc'ed
 // upon EndTransaction if they only have local intents (which can be
@@ -133,12 +127,10 @@ func usesTimestampCache(r roachpb.Request) bool {
 // via the done channel.
 type pendingCmd struct {
 	ctx     context.Context
-	idKey   cmdIDKey
+	idKey   storagebase.CmdIDKey
 	raftCmd roachpb.RaftCommand
 	done    chan roachpb.ResponseWithError // Used to signal waiting RPC handler
 }
-
-type cmdIDKey string
 
 type replicaChecksum struct {
 	// Set to true when the checksum computation is ready. The checksum
@@ -177,14 +169,15 @@ type Replica struct {
 		lastIndex      uint64 // Last index persisted to the raft log (not necessarily committed).
 		leaderLease    *roachpb.Lease
 		maxBytes       int64 // Max bytes before split.
-		pendingCmds    map[cmdIDKey]*pendingCmd
+		pendingCmds    map[storagebase.CmdIDKey]*pendingCmd
+		pendingSeq     uint64 // atomic sequence counter for CmdIDKey generation.
 		raftGroup      *raft.RawNode
 		replicaID      roachpb.ReplicaID
 		truncatedState *roachpb.RaftTruncatedState
 		tsCache        *TimestampCache       // Most recent timestamps for keys / key ranges
 		llChans        []chan *roachpb.Error // Slice of channels to send on after leader lease acquisition
 		// proposeRaftCommandFn can be set to mock out the propose operation.
-		proposeRaftCommandFn func(cmdIDKey, *pendingCmd) error
+		proposeRaftCommandFn func(*pendingCmd) error
 		checksums            map[uuid.UUID]replicaChecksum // computed checksum at a snapshot UUID.
 		checksumNotify       map[uuid.UUID]chan []byte     // notify of computed checksum.
 	}
@@ -223,7 +216,7 @@ func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor, clock *hlc.Cloc
 
 	r.mu.cmdQ = NewCommandQueue()
 	r.mu.tsCache = NewTimestampCache(clock)
-	r.mu.pendingCmds = map[cmdIDKey]*pendingCmd{}
+	r.mu.pendingCmds = map[storagebase.CmdIDKey]*pendingCmd{}
 	r.mu.checksums = map[uuid.UUID]replicaChecksum{}
 	r.mu.checksumNotify = map[uuid.UUID]chan []byte{}
 	r.setDescWithoutProcessUpdateLocked(desc)
@@ -282,7 +275,7 @@ func (r *Replica) Destroy(origDesc roachpb.RangeDescriptor) error {
 		}
 	}
 	// Clear the map.
-	r.mu.pendingCmds = map[cmdIDKey]*pendingCmd{}
+	r.mu.pendingCmds = map[storagebase.CmdIDKey]*pendingCmd{}
 	r.mu.Unlock()
 
 	return r.store.destroyReplicaData(desc)
@@ -916,7 +909,7 @@ func (r *Replica) addReadOnlyCmd(ctx context.Context, ba roachpb.BatchRequest) (
 	// that holding readMu throughout is important to avoid reads from the
 	// "wrong" key range being served after the range has been split.
 	var intents []intentsWithArg
-	br, intents, pErr = r.executeBatch(r.store.Engine(), nil, ba)
+	br, intents, pErr = r.executeBatch(ctx, storagebase.CmdIDKey(""), r.store.Engine(), nil, ba)
 
 	if pErr == nil && ba.Txn != nil {
 		// Checking the sequence cache on reads makes sure that when our
@@ -1056,7 +1049,7 @@ func (r *Replica) addWriteCmd(ctx context.Context, ba roachpb.BatchRequest, wg *
 // map. This is possible until execution of the command at the local replica
 // has already begun, in which case false is returned and the client needs to
 // continue waiting for successful execution.
-func (r *Replica) tryAbandon(idKey cmdIDKey) bool {
+func (r *Replica) tryAbandon(idKey storagebase.CmdIDKey) bool {
 	r.mu.Lock()
 	_, ok := r.mu.pendingCmds[idKey]
 	delete(r.mu.pendingCmds, idKey)
@@ -1077,7 +1070,7 @@ func (r *Replica) proposeRaftCommand(ctx context.Context, ba roachpb.BatchReques
 	}
 	idKeyBuf := make([]byte, 0, raftCommandIDLen)
 	idKeyBuf = encoding.EncodeUint64Ascending(idKeyBuf, uint64(rand.Int63()))
-	idKey := cmdIDKey(idKeyBuf)
+	idKey := storagebase.CmdIDKey(idKeyBuf)
 	pendingCmd := &pendingCmd{
 		ctx:   ctx,
 		idKey: idKey,
@@ -1103,9 +1096,9 @@ func (r *Replica) proposeRaftCommand(ctx context.Context, ba roachpb.BatchReques
 
 // proposePendingCmdLocked proposes or re-proposes a command in r.mu.pendingCmds.
 // The replica lock must be held.
-func (r *Replica) proposePendingCmdLocked(idKey cmdIDKey, p *pendingCmd) error {
+func (r *Replica) proposePendingCmdLocked(idKey storagebase.CmdIDKey, p *pendingCmd) error {
 	if r.mu.proposeRaftCommandFn != nil {
-		return r.mu.proposeRaftCommandFn(idKey, p)
+		return r.mu.proposeRaftCommandFn(p)
 	}
 
 	if p.raftCmd.Cmd.Timestamp == roachpb.ZeroTimestamp {
@@ -1220,7 +1213,7 @@ func (r *Replica) handleRaftReady() error {
 
 			// Discard errors from processRaftCommand. The error has been sent
 			// to the client that originated it, where it will be handled.
-			_ = r.processRaftCommand(cmdIDKey(commandID), e.Index, command)
+			_ = r.processRaftCommand(storagebase.CmdIDKey(commandID), e.Index, command)
 
 		case raftpb.EntryConfChange:
 			var cc raftpb.ConfChange
@@ -1235,7 +1228,7 @@ func (r *Replica) handleRaftReady() error {
 			if err := command.Unmarshal(ctx.Payload); err != nil {
 				return err
 			}
-			if err := r.processRaftCommand(cmdIDKey(ctx.CommandID), e.Index, command); err != nil {
+			if err := r.processRaftCommand(storagebase.CmdIDKey(ctx.CommandID), e.Index, command); err != nil {
 				// If processRaftCommand failed, tell raft that the config change was aborted.
 				cc = raftpb.ConfChange{}
 			}
@@ -1333,7 +1326,7 @@ func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 // struct to get args and reply and then applying the command to the
 // state machine via applyRaftCommand(). The error result is sent on
 // the command's done channel, if available.
-func (r *Replica) processRaftCommand(idKey cmdIDKey, index uint64, raftCmd roachpb.RaftCommand) *roachpb.Error {
+func (r *Replica) processRaftCommand(idKey storagebase.CmdIDKey, index uint64, raftCmd roachpb.RaftCommand) *roachpb.Error {
 	if index == 0 {
 		log.Fatalc(r.context(), "processRaftCommand requires a non-zero index")
 	}
@@ -1356,7 +1349,7 @@ func (r *Replica) processRaftCommand(idKey cmdIDKey, index uint64, raftCmd roach
 	// applyRaftCommand will return "expected" errors, but may also indicate
 	// replica corruption (as of now, signaled by a replicaCorruptionError).
 	// We feed its return through maybeSetCorrupt to act when that happens.
-	br, err := r.applyRaftCommand(ctx, index, raftCmd.OriginReplica, raftCmd.Cmd)
+	br, err := r.applyRaftCommand(idKey, ctx, index, raftCmd.OriginReplica, raftCmd.Cmd)
 	err = r.maybeSetCorrupt(err)
 
 	if cmd != nil {
@@ -1372,8 +1365,9 @@ func (r *Replica) processRaftCommand(idKey cmdIDKey, index uint64, raftCmd roach
 // underlying state machine (i.e. the engine).
 // When certain critical operations fail, a replicaCorruptionError may be
 // returned and must be handled by the caller.
-func (r *Replica) applyRaftCommand(ctx context.Context, index uint64, originReplica roachpb.ReplicaDescriptor,
-	ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+func (r *Replica) applyRaftCommand(idKey storagebase.CmdIDKey, ctx context.Context, index uint64,
+	originReplica roachpb.ReplicaDescriptor, ba roachpb.BatchRequest) (
+	*roachpb.BatchResponse, *roachpb.Error) {
 	if index <= 0 {
 		log.Fatalc(ctx, "raft command index is <= 0")
 	}
@@ -1390,7 +1384,7 @@ func (r *Replica) applyRaftCommand(ctx context.Context, index uint64, originRepl
 	// Call the helper, which returns a batch containing data written
 	// during command execution and any associated error.
 	ms := engine.MVCCStats{}
-	batch, br, intents, rErr := r.applyRaftCommandInBatch(ctx, index, originReplica, ba, &ms)
+	batch, br, intents, rErr := r.applyRaftCommandInBatch(ctx, idKey, originReplica, ba, &ms)
 	defer batch.Close()
 
 	// Advance the last applied index and commit the batch.
@@ -1440,8 +1434,10 @@ func (r *Replica) applyRaftCommand(ctx context.Context, index uint64, originRepl
 // applyRaftCommandInBatch executes the command in a batch engine and
 // returns the batch containing the results. The caller is responsible
 // for committing the batch, even on error.
-func (r *Replica) applyRaftCommandInBatch(ctx context.Context, index uint64, originReplica roachpb.ReplicaDescriptor,
-	ba roachpb.BatchRequest, ms *engine.MVCCStats) (engine.Engine, *roachpb.BatchResponse, []intentsWithArg, *roachpb.Error) {
+func (r *Replica) applyRaftCommandInBatch(
+	ctx context.Context, idKey storagebase.CmdIDKey, originReplica roachpb.ReplicaDescriptor,
+	ba roachpb.BatchRequest, ms *engine.MVCCStats) (
+	engine.Engine, *roachpb.BatchResponse, []intentsWithArg, *roachpb.Error) {
 	// Create a new batch for the command to ensure all or nothing semantics.
 	btch := r.store.Engine().NewBatch()
 
@@ -1488,7 +1484,7 @@ func (r *Replica) applyRaftCommandInBatch(ctx context.Context, index uint64, ori
 	// Execute the commands. If this returns without an error, the batch must
 	// be committed (EndTransaction with a CommitTrigger may unlock
 	// readOnlyCmdMu via a batch.Defer).
-	br, intents, err := r.executeBatch(btch, ms, ba)
+	br, intents, err := r.executeBatch(ctx, idKey, btch, ms, ba)
 
 	// Regardless of error, add result to the sequence cache if this is
 	// a write method. This must be done as part of the execution of
@@ -1580,7 +1576,10 @@ type intentsWithArg struct {
 	intents []roachpb.Intent
 }
 
-func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba roachpb.BatchRequest) (*roachpb.BatchResponse, []intentsWithArg, *roachpb.Error) {
+func (r *Replica) executeBatch(
+	ctx context.Context, idKey storagebase.CmdIDKey,
+	batch engine.Engine, ms *engine.MVCCStats, ba roachpb.BatchRequest) (
+	*roachpb.BatchResponse, []intentsWithArg, *roachpb.Error) {
 	br := &roachpb.BatchResponse{}
 	var intents []intentsWithArg
 	// If transactional, we use ba.Txn for each individual command and
@@ -1645,7 +1644,8 @@ func (r *Replica) executeBatch(batch engine.Engine, ms *engine.MVCCStats, ba roa
 			header.Timestamp = ba.Timestamp.Add(0, int32(1-len(ba.Requests)+index))
 		}
 
-		reply, curIntents, pErr := r.executeCmd(batch, ms, header, remScanResults, args)
+		reply, curIntents, pErr := r.executeCmd(
+			ctx, idKey, index, batch, ms, header, remScanResults, args)
 
 		// Collect intents skipped over the course of execution.
 		if len(curIntents) > 0 {
@@ -1869,7 +1869,8 @@ func (r *Replica) loadSystemConfigSpan() ([]roachpb.KeyValue, []byte, error) {
 	ba.ReadConsistency = roachpb.INCONSISTENT
 	ba.Timestamp = r.store.Clock().Now()
 	ba.Add(&roachpb.ScanRequest{Span: keys.SystemConfigSpan})
-	br, intents, pErr := r.executeBatch(r.store.Engine(), nil, ba)
+	br, intents, pErr :=
+		r.executeBatch(r.context(), storagebase.CmdIDKey(""), r.store.Engine(), nil, ba)
 	if pErr != nil {
 		return nil, nil, pErr.GoError()
 	}

--- a/storage/storagebase/base.go
+++ b/storage/storagebase/base.go
@@ -1,0 +1,20 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Andrei Matei (andreimatei1@gmail.com)
+
+package storagebase
+
+// CmdIDKey is a Raft command id.
+type CmdIDKey string

--- a/storage/store.go
+++ b/storage/store.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/cache"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -371,7 +372,9 @@ type StoreContext struct {
 // StoreTestingKnobs is a part of the context used to control parts of the system.
 type StoreTestingKnobs struct {
 	// A callback to be called when executing every replica command.
-	TestingCommandFilter CommandFilter
+	// If your filter is not idempotent, consider wrapping it in a
+	// ReplayProtectionFilterWrapper.
+	TestingCommandFilter storageutils.ReplicaCommandFilter
 	// A callback to be called instead of panicking due to a
 	// checksum mismatch in VerifyChecksum()
 	BadChecksumPanic func()

--- a/testutils/storageutils/mocking.go
+++ b/testutils/storageutils/mocking.go
@@ -1,0 +1,106 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Andrei Matei (andreimatei1@gmail.com)
+
+package storageutils
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
+)
+
+// savedError silences the linter from complaining when detectReplayLocks wants
+// to return an error as the first (as opposed to the last) return value.
+type savedError error
+
+// FilterArgs groups the arguments to a ReplicaCommandFilter.
+type FilterArgs struct {
+	Ctx   context.Context
+	CmdID storagebase.CmdIDKey
+	Index int
+	Sid   roachpb.StoreID
+	Req   roachpb.Request
+	Hdr   roachpb.Header
+}
+
+// raftCmdIDAndIndex identifies a batch and a command within it.
+type raftCmdIDAndIndex struct {
+	IDKey storagebase.CmdIDKey
+	Index int
+}
+
+// InRaftCmd returns true if the filter is running in the context of a Raft
+// command (it could be running outside of one, for example for a read).
+func (f *FilterArgs) InRaftCmd() bool {
+	return f.CmdID != ""
+}
+
+// ReplicaCommandFilter may be used in tests through the StorageTestingMocker to
+// intercept the handling of commands and artificially generate errors. Return
+// nil to continue with regular processing or non-nil to terminate processing
+// with the returned error. Note that in a multi-replica test this filter will
+// be run once for each replica and must produce consistent results each time.
+type ReplicaCommandFilter func(args FilterArgs) error
+
+// ReplayProtectionFilterWrapper wraps a CommandFilter and assures protection
+// from Raft replays.
+type ReplayProtectionFilterWrapper struct {
+	sync.RWMutex
+	processedCommands map[raftCmdIDAndIndex]savedError
+	filter            ReplicaCommandFilter
+}
+
+// WrapFilterForReplayProtection wraps a filter into another one that adds Raft
+// replay protection.
+func WrapFilterForReplayProtection(
+	filter ReplicaCommandFilter) ReplicaCommandFilter {
+	wrapper := ReplayProtectionFilterWrapper{
+		processedCommands: make(map[raftCmdIDAndIndex]savedError),
+		filter:            filter,
+	}
+	return wrapper.run
+}
+
+func (c *ReplayProtectionFilterWrapper) detectReplayLocked(
+	cmdID storagebase.CmdIDKey, index int) (savedError, bool) {
+	err, found := c.processedCommands[raftCmdIDAndIndex{cmdID, index}]
+	// We've detected a replay.
+	return err, found
+}
+
+// run executes the wrapped filter.
+func (c *ReplayProtectionFilterWrapper) run(args FilterArgs) error {
+
+	c.RLock()
+	defer c.RUnlock()
+
+	if args.InRaftCmd() {
+		if err, found := c.detectReplayLocked(args.CmdID, args.Index); found {
+			return err.(error)
+		}
+	}
+
+	err := c.filter(args)
+
+	if args.InRaftCmd() {
+		c.processedCommands[raftCmdIDAndIndex{args.CmdID, args.Index}] = savedError(err)
+	}
+
+	return err
+}


### PR DESCRIPTION
Turns out there can be raft replays in tests. This adds optional support for
replay protection in the mock by saving the raft cmd id in the context,
and uses it in the sql mocks.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5184)

<!-- Reviewable:end -->
