### PR TITLE
storage: Make Allocator.ComputeAction return noop if the store pool is nil

### DIFF
--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -198,6 +198,11 @@ func MakeAllocator(storePool *StorePool, options AllocatorOptions) Allocator {
 // be performed.
 func (a *Allocator) ComputeAction(zone config.ZoneConfig, desc *roachpb.RangeDescriptor) (
 	AllocatorAction, float64) {
+	if a.storePool == nil {
+		// Do nothing if storePool is nil for some unittests.
+		return AllocatorNoop, 0
+	}
+
 	deadReplicas := a.storePool.deadReplicas(desc.Replicas)
 	if len(deadReplicas) > 0 {
 		// The range has dead replicas, which should be removed immediately.

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -1055,6 +1055,20 @@ func TestAllocatorComputeAction(t *testing.T) {
 	}
 }
 
+// TestAllocatorComputeActionNoStorePool verifies that
+// ComputeAction returns AllocatorNoop when storePool is nil.
+func TestAllocatorComputeActionNoStorePool(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	a := MakeAllocator(nil /* storePool */, AllocatorOptions{})
+	action, priority := a.ComputeAction(config.ZoneConfig{}, nil)
+	if action != AllocatorNoop {
+		t.Errorf("expected AllocatorNoop, but got %v", action)
+	}
+	if priority != 0 {
+		t.Errorf("expected priority 0, but got %f", priority)
+	}
+}
+
 type testStore struct {
 	roachpb.StoreDescriptor
 }


### PR DESCRIPTION
`replicateQueue` calls `Allocator.ComputeAction`, which accesses `storePool`. Some tests will fail by accessing nil `storePool` when `ScanInterval` is set to a short interval (e.g., 100ms).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5186)

<!-- Reviewable:end -->
