### PR TITLE
roachpb: Introduce roachpb.Key ShallowNext calls to avoid allocating

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -418,7 +418,7 @@ func MetaScanBounds(key roachpb.RKey) (roachpb.Key, roachpb.Key, error) {
 		return Meta1KeyMax, Meta1Prefix.PrefixEnd(), nil
 	}
 	// Otherwise find the first entry greater than the given key in the same meta prefix.
-	return key.Next().AsRawKey(), key[:len(Meta1Prefix)].PrefixEnd().AsRawKey(), nil
+	return key.ShallowNext().AsRawKey(), key[:len(Meta1Prefix)].PrefixEnd().AsRawKey(), nil
 }
 
 // MetaReverseScanBounds returns the range [start,end) within which the desired
@@ -435,7 +435,7 @@ func MetaReverseScanBounds(key roachpb.RKey) (roachpb.Key, roachpb.Key, error) {
 	if key.Equal(Meta2Prefix) {
 		// Special case Meta2Prefix: this is the first key in Meta2, and the scan
 		// interval covers all of Meta1.
-		return Meta1Prefix, key.Next().AsRawKey(), nil
+		return Meta1Prefix, key.ShallowNext().AsRawKey(), nil
 	}
 	// Otherwise find the first entry greater than the given key and find the last entry
 	// in the same prefix. For MVCCReverseScan the endKey is exclusive, if we want to find

--- a/kv/batch.go
+++ b/kv/batch.go
@@ -118,9 +118,7 @@ func prev(ba roachpb.BatchRequest, k roachpb.RKey) roachpb.RKey {
 		addr := keys.Addr(h.Key)
 		eAddr := keys.Addr(h.EndKey)
 		if len(eAddr) == 0 {
-			// Can probably avoid having to compute Next() here if
-			// we're in the mood for some more complexity.
-			eAddr = addr.Next()
+			eAddr = addr.ShallowNext()
 		}
 		if !eAddr.Less(k) {
 			if !k.Less(addr) {

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -103,7 +103,7 @@ func addKeyRange(keys interval.RangeGroup, start, end roachpb.Key) {
 	// a non-empty interval, so we create two key slices which
 	// share the same underlying byte array.
 	if len(end) == 0 {
-		end = start.Next()
+		end = start.ShallowNext()
 		start = end[:len(start)]
 	}
 	keyR := interval.Range{

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -139,6 +139,14 @@ func (k Key) Next() Key {
 	return Key(BytesNext(k))
 }
 
+// ShallowNext returns the next key in lexicographic sort order, using
+// extra capacity of the recevier key if possible. The method may only
+// take a shallow copy of the RKey, so it should be treated as immutable
+// after.
+func (k Key) ShallowNext() Key {
+	return append(k, 0)
+}
+
 // IsPrev is a more efficient version of k.Next().Equal(m).
 func (k Key) IsPrev(m Key) bool {
 	l := len(m) - 1

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -80,6 +80,14 @@ func (rk RKey) Next() RKey {
 	return RKey(BytesNext(rk))
 }
 
+// ShallowNext returns the RKey that sorts immediately after the
+// given one, using extra capacity of the recevier key if possible.
+// The method may only take a shallow copy of the RKey, so both the
+// receiver and the return value should be treated as immutable after.
+func (rk RKey) ShallowNext() RKey {
+	return append(rk, 0)
+}
+
 // PrefixEnd determines the end key given key as a prefix, that is the
 // key that sorts precisely behind all keys starting with prefix: "1"
 // is added to the final byte and the carry propagated. The special
@@ -141,8 +149,8 @@ func (k Key) Next() Key {
 
 // ShallowNext returns the next key in lexicographic sort order, using
 // extra capacity of the recevier key if possible. The method may only
-// take a shallow copy of the RKey, so it should be treated as immutable
-// after.
+// take a shallow copy of the Key, so both the receiver and the return
+// value should be treated as immutable after.
 func (k Key) ShallowNext() Key {
 	return append(k, 0)
 }

--- a/sql/kvfetcher.go
+++ b/sql/kvfetcher.go
@@ -164,7 +164,7 @@ func (f *kvFetcher) fetch() *roachpb.Error {
 			start := f.spans[0].start
 			if len(f.kvs) > 0 {
 				// the new range starts after the last key
-				start = f.kvs[len(f.kvs)-1].Key.Next()
+				start = f.kvs[len(f.kvs)-1].Key.ShallowNext()
 				if start.Equal(f.spans[0].end) {
 					// No more keys
 					f.kvs = nil

--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -92,7 +92,7 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 		// This gives us a memory-efficient end key if end is empty.
 		start, end := span.Key, span.EndKey
 		if len(end) == 0 {
-			end = start.Next()
+			end = start.ShallowNext()
 			start = end[:len(start)]
 		}
 		newCmdRange := interval.Range{
@@ -298,7 +298,8 @@ func (cq *CommandQueue) Add(readOnly bool, spans ...roachpb.Span) []interface{} 
 	for _, span := range spans {
 		start, end := span.Key, span.EndKey
 		if len(end) == 0 {
-			end = start.Next()
+			end = start.ShallowNext()
+			start = end[:len(start)]
 		}
 		alloc := struct {
 			key   cache.IntervalKey

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -61,7 +61,7 @@ func (k MVCCKey) Next() MVCCKey {
 	ts := k.Timestamp.Prev()
 	if ts == roachpb.ZeroTimestamp {
 		return MVCCKey{
-			Key: k.Key.Next(),
+			Key: k.Key.ShallowNext(),
 		}
 	}
 	return MVCCKey{
@@ -1332,7 +1332,7 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 			}
 
 		} else {
-			iter.Seek(MakeMVCCMetadataKey(metaKey.Key.Next()))
+			iter.Seek(MakeMVCCMetadataKey(metaKey.Key.ShallowNext()))
 			if !iter.Valid() {
 				if err := iter.Error(); err != nil {
 					return nil, err

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -109,7 +109,7 @@ func (tc *TimestampCache) SetLowWater(lowWater roachpb.Timestamp) {
 func (tc *TimestampCache) Add(start, end roachpb.Key, timestamp roachpb.Timestamp, txnID *uuid.UUID, readOnly bool) {
 	// This gives us a memory-efficient end key if end is empty.
 	if len(end) == 0 {
-		end = start.Next()
+		end = start.ShallowNext()
 		start = end[:len(start)]
 	}
 	if tc.latest.Less(timestamp) {
@@ -273,7 +273,7 @@ func (tc *TimestampCache) GetMaxWrite(start, end roachpb.Key, txnID *uuid.UUID) 
 
 func (tc *TimestampCache) getMax(start, end roachpb.Key, txnID *uuid.UUID, readOnly bool) roachpb.Timestamp {
 	if len(end) == 0 {
-		end = start.Next()
+		end = start.ShallowNext()
 	}
 	max := tc.lowWater
 	cache := tc.wCache


### PR DESCRIPTION
Closes #5038.

In the majority of the times that we call `Key.Next()`, allocating the
key and copying is not necessary because neither the current or the
next key will ever be mutated during their lifetime. This means that it
is safe to share a backing array. Luckily, protobuffer unmarshalling 
into byte slices almost always over-allocates the capacity of
the slice. This means that in the majority of cases, we have a little
extra slice capacity to play with. This change introduces a `Key.ShallowNext`
method that will create the next key in the excess capacity of the
receiver key if possible, or default to reallocating if needed. It also
uses this new method to replace previous `Key.Next` calls that did not
require a deep copy.

The second commit here provides a similar treatment to `roachpb.RKey`.

The change has minimal impact on cpu performance, but does seem to have
a significant impact on the memory behavior of certain workloads.

```
name                          old alloc/op   new alloc/op   delta
Bank_Cockroach-2                61.4kB ± 0%    61.5kB ± 0%     ~           (p=0.469 n=10+10)
Select1_Cockroach-2             2.28kB ± 0%    2.28kB ± 0%     ~            (p=0.858 n=10+9)
Select2_Cockroach-2             72.1kB ± 0%    72.2kB ± 0%     ~           (p=0.753 n=10+10)
Insert1_Cockroach-2             23.6kB ± 0%    23.5kB ± 0%   -0.37%        (p=0.001 n=10+10)
Insert10_Cockroach-2            65.1kB ± 0%    64.7kB ± 0%   -0.67%         (p=0.000 n=10+9)
Insert100_Cockroach-2            477kB ± 0%     473kB ± 0%   -0.92%         (p=0.000 n=10+9)
Insert1000_Cockroach-2          4.29MB ± 1%    4.25MB ± 1%   -1.05%         (p=0.000 n=10+9)
Update1_Cockroach-2             36.4kB ± 0%    36.3kB ± 0%   -0.21%         (p=0.000 n=9+10)
Update10_Cockroach-2             103kB ± 0%     102kB ± 0%   -0.64%         (p=0.000 n=10+8)
Update100_Cockroach-2            727kB ± 0%     723kB ± 0%   -0.53%         (p=0.000 n=10+9)
Update1000_Cockroach-2          6.34MB ± 1%    6.30MB ± 1%     ~           (p=0.052 n=10+10)
Delete1_Cockroach-2             30.0kB ± 0%    30.0kB ± 0%     ~             (p=0.174 n=9+8)
Delete10_Cockroach-2            72.0kB ± 0%    72.0kB ± 0%     ~            (p=0.604 n=9+10)
Delete100_Cockroach-2            488kB ± 0%     488kB ± 0%     ~             (p=0.863 n=9+9)
Delete1000_Cockroach-2          4.36MB ± 0%    4.36MB ± 0%     ~            (p=0.720 n=9+10)
Scan1_Cockroach-2               11.4kB ± 0%    11.4kB ± 0%     ~            (p=0.680 n=10+8)
Scan10_Cockroach-2              15.2kB ± 0%    15.2kB ± 0%     ~            (p=0.150 n=10+9)
Scan100_Cockroach-2             46.7kB ± 0%    46.7kB ± 0%     ~            (p=0.234 n=10+9)
Scan1000_Cockroach-2             327kB ± 0%     327kB ± 0%     ~            (p=0.189 n=9+10)
Scan10000_Cockroach-2           5.71MB ± 0%    5.71MB ± 0%     ~           (p=0.796 n=10+10)
Scan1000Limit1_Cockroach-2      11.9kB ± 0%    11.9kB ± 0%     ~             (p=0.309 n=9+8)
Scan1000Limit10_Cockroach-2     15.6kB ± 0%    15.6kB ± 0%     ~            (p=0.305 n=9+10)
Scan1000Limit100_Cockroach-2    47.0kB ± 0%    47.0kB ± 0%     ~           (p=0.381 n=10+10)
PgbenchQuery_Cockroach-2         213kB ± 5%     205kB ± 0%   -4.02%          (p=0.002 n=5+8)

name                          old allocs/op  new allocs/op  delta
Bank_Cockroach-2                 1.43k ± 0%     1.43k ± 0%     ~           (p=0.748 n=10+10)
Select1_Cockroach-2               50.0 ± 0%      50.0 ± 0%     ~     (all samples are equal)
Select2_Cockroach-2              2.35k ± 0%     2.35k ± 0%     ~           (p=0.796 n=10+10)
Insert1_Cockroach-2                341 ± 0%       332 ± 0%   -2.69%         (p=0.000 n=9+10)
Insert10_Cockroach-2               782 ± 0%       728 ± 0%   -6.91%          (p=0.000 n=8+7)
Insert100_Cockroach-2            5.07k ± 0%     4.56k ± 0%  -10.06%        (p=0.000 n=10+10)
Insert1000_Cockroach-2           48.0k ± 0%     42.8k ± 0%  -10.70%         (p=0.000 n=10+9)
Update1_Cockroach-2                649 ± 0%       640 ± 0%   -1.39%         (p=0.002 n=8+10)
Update10_Cockroach-2             1.33k ± 0%     1.27k ± 0%   -4.28%         (p=0.000 n=10+9)
Update100_Cockroach-2            7.76k ± 0%     7.26k ± 0%   -6.45%        (p=0.000 n=10+10)
Update1000_Cockroach-2           69.2k ± 0%     64.4k ± 0%   -6.92%        (p=0.000 n=10+10)
Delete1_Cockroach-2                529 ± 0%       525 ± 0%   -0.71%          (p=0.000 n=9+7)
Delete10_Cockroach-2             1.12k ± 0%     1.11k ± 0%   -0.36%          (p=0.000 n=9+7)
Delete100_Cockroach-2            6.82k ± 0%     6.81k ± 0%   -0.05%          (p=0.000 n=8+9)
Delete1000_Cockroach-2           63.6k ± 0%     63.6k ± 0%     ~            (p=0.075 n=9+10)
Scan1_Cockroach-2                  219 ± 0%       219 ± 0%     ~     (all samples are equal)
Scan10_Cockroach-2                 300 ± 0%       299 ± 0%     ~           (p=0.656 n=10+10)
Scan100_Cockroach-2              1.03k ± 0%     1.03k ± 0%     ~            (p=0.332 n=10+9)
Scan1000_Cockroach-2             8.23k ± 0%     8.23k ± 0%     ~            (p=0.230 n=9+10)
Scan10000_Cockroach-2            80.4k ± 0%     80.4k ± 0%     ~           (p=0.636 n=10+10)
Scan1000Limit1_Cockroach-2         236 ± 0%       236 ± 0%     ~     (all samples are equal)
Scan1000Limit10_Cockroach-2        315 ± 0%       315 ± 0%     ~            (p=0.248 n=9+10)
Scan1000Limit100_Cockroach-2     1.04k ± 0%     1.04k ± 0%     ~           (p=1.000 n=10+10)
PgbenchQuery_Cockroach-2         3.60k ± 4%     3.42k ± 0%   -4.84%          (p=0.000 n=5+7)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5197)

<!-- Reviewable:end -->
