### PR TITLE
util/encoding: Fix Float and Decimal decoding functions use of temp buffers

### DIFF
--- a/util/encoding/decimal.go
+++ b/util/encoding/decimal.go
@@ -172,28 +172,28 @@ func decodeDecimal(buf []byte, tmp []byte, invert bool) ([]byte, *inf.Dec, error
 	switch {
 	case buf[0] == floatNegLarge:
 		// Negative large.
-		e, m := decodeLargeNumber(true, buf[:idx+1], tmp)
-		return buf[idx+1:], makeDecimalFromMandE(!invert, e, m, tmp), nil
+		e, m, tmp2 := decodeLargeNumber(true, buf[:idx+1], tmp)
+		return buf[idx+1:], makeDecimalFromMandE(!invert, e, m, tmp2), nil
 	case buf[0] > floatNegLarge && buf[0] <= floatNegMedium:
 		// Negative medium.
-		e, m := decodeMediumNumber(true, buf[:idx+1], tmp)
-		return buf[idx+1:], makeDecimalFromMandE(!invert, e, m, tmp), nil
+		e, m, tmp2 := decodeMediumNumber(true, buf[:idx+1], tmp)
+		return buf[idx+1:], makeDecimalFromMandE(!invert, e, m, tmp2), nil
 	case buf[0] == floatNegSmall:
 		// Negative small.
-		e, m := decodeSmallNumber(true, buf[:idx+1], tmp)
-		return buf[idx+1:], makeDecimalFromMandE(!invert, e, m, tmp), nil
+		e, m, tmp2 := decodeSmallNumber(true, buf[:idx+1], tmp)
+		return buf[idx+1:], makeDecimalFromMandE(!invert, e, m, tmp2), nil
 	case buf[0] == floatPosLarge:
 		// Positive large.
-		e, m := decodeLargeNumber(false, buf[:idx+1], tmp)
-		return buf[idx+1:], makeDecimalFromMandE(invert, e, m, tmp), nil
+		e, m, tmp2 := decodeLargeNumber(false, buf[:idx+1], tmp)
+		return buf[idx+1:], makeDecimalFromMandE(invert, e, m, tmp2), nil
 	case buf[0] >= floatPosMedium && buf[0] < floatPosLarge:
 		// Positive medium.
-		e, m := decodeMediumNumber(false, buf[:idx+1], tmp)
-		return buf[idx+1:], makeDecimalFromMandE(invert, e, m, tmp), nil
+		e, m, tmp2 := decodeMediumNumber(false, buf[:idx+1], tmp)
+		return buf[idx+1:], makeDecimalFromMandE(invert, e, m, tmp2), nil
 	case buf[0] == floatPosSmall:
 		// Positive small.
-		e, m := decodeSmallNumber(false, buf[:idx+1], tmp)
-		return buf[idx+1:], makeDecimalFromMandE(invert, e, m, tmp), nil
+		e, m, tmp2 := decodeSmallNumber(false, buf[:idx+1], tmp)
+		return buf[idx+1:], makeDecimalFromMandE(invert, e, m, tmp2), nil
 	default:
 		return nil, nil, util.Errorf("unknown prefix of the encoded byte slice: %q", buf)
 	}


### PR DESCRIPTION
Fixes #5199.

We were previously overwriting mantissas when Float and Decimal decoding
functions were provided with a temp scratch buffer.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5201)

<!-- Reviewable:end -->
