### PR TITLE
sql: Default key value encoding direction to avoid implicit slice

### DIFF
--- a/sql/scan.go
+++ b/sql/scan.go
@@ -468,12 +468,8 @@ func (n *scanNode) processKV(kv client.KeyValue) bool {
 		}
 	} else {
 		if n.implicitVals != nil {
-			implicitDirs := make([]encoding.Direction, 0, len(n.index.ImplicitColumnIDs))
-			for range n.index.ImplicitColumnIDs {
-				implicitDirs = append(implicitDirs, encoding.Ascending)
-			}
 			var err error
-			_, err = decodeKeyVals(n.implicitValTypes, n.implicitVals, implicitDirs, kv.ValueBytes())
+			_, err = decodeKeyVals(n.implicitValTypes, n.implicitVals, nil, kv.ValueBytes())
 			n.pErr = roachpb.NewError(err)
 			if n.pErr != nil {
 				return false

--- a/sql/table.go
+++ b/sql/table.go
@@ -539,16 +539,22 @@ func decodeIndexKey(desc *TableDescriptor, indexID IndexID,
 // len(valTypes). The types of the decoded values will match the corresponding
 // entry in the valTypes parameter with the exception that a value might also
 // be parser.DNull. The remaining bytes in the key after decoding the values
-// are returned.
+// are returned. A slice of directions can be provided to enforce encoding
+// direction on each value in valTypes. If this slice is nil, the direction
+// used will default to encoding.Ascending.
 func decodeKeyVals(valTypes, vals []parser.Datum, directions []encoding.Direction,
 	key []byte) ([]byte, error) {
-	if len(directions) != len(valTypes) {
+	if directions != nil && len(directions) != len(valTypes) {
 		return nil, util.Errorf("encoding directions doesn't parallel valTypes: %d vs %d.",
 			len(directions), len(valTypes))
 	}
 	for j := range valTypes {
+		direction := encoding.Ascending
+		if directions != nil {
+			direction = directions[j]
+		}
 		var err error
-		vals[j], key, err = decodeTableKey(valTypes[j], key, directions[j])
+		vals[j], key, err = decodeTableKey(valTypes[j], key, direction)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously we allocated a slice to hold constant encoding directions for
implicit values. This was a waste as we can just default the encoding
direction to Ascending.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5203)

<!-- Reviewable:end -->
