### PR TITLE
circle: add Robot and milestone 1 (beta) to circle test script

### DIFF
--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -96,7 +96,7 @@ prepare_artifacts() {
       fi
 
       # JSON monster to post the issue.
-      post issues "{ \"title\": \"circleci: failed tests (${CIRCLE_BUILD_NUM}): ${FAILEDTESTS}\", \"body\": \"The following test appears to have failed:\n\n[#${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}):\n\n\`\`\`\n$(python -c 'import json,sys; print json.dumps(sys.stdin.read()).strip("\"")' < ${outdir}/excerpt.txt)\n\`\`\`\nPlease assign, take a look and update the issue accordingly.\", \"labels\": [\"test-failure\"] }" > /dev/null
+      post issues "{ \"title\": \"circleci: failed tests (${CIRCLE_BUILD_NUM}): ${FAILEDTESTS}\", \"body\": \"The following test appears to have failed:\n\n[#${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}):\n\n\`\`\`\n$(python -c 'import json,sys; print json.dumps(sys.stdin.read()).strip("\"")' < ${outdir}/excerpt.txt)\n\`\`\`\nPlease assign, take a look and update the issue accordingly.\", \"labels\": [\"test-failure\", \"Robot\"], \"milestone\": 1 }" > /dev/null
       echo "Found test/race failures in test logs, see excerpt.log and the newly created issue on our issue tracker"
   fi
 


### PR DESCRIPTION
Just a small change to clearly identify when an issue is generated by a robot and post it against the beta milestone.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5204)

<!-- Reviewable:end -->
