### PR TITLE
storage/engine: prevent batch-backed iter use after batch closed

### DIFF
--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -150,6 +150,10 @@ type Engine interface {
 	// with the defer statement, the last callback to be deferred is the
 	// first to be executed.
 	Defer(fn func())
+	// Closed returns true if the engine has been close or not usable.
+	// Objects backed by this engine (e.g. Iterators) can check this to ensure
+	// that they are not using an closed engine.
+	Closed() bool
 }
 
 var bufferPool = sync.Pool{

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -740,12 +740,19 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 		t.Fatal("committed write missing by non-batch iter created after commit")
 	}
 
-	// NB(dt): `Commit` frees the underlying batch, rendering iterators that
-	// are backed by it invalid, but they can still return (incorrect) results.
-	// if after.Seek(k); !after.Valid() {
-	// 	t.Fatal("write missing on batch iter created after write")
-	// }
-	// if before.Seek(k); !before.Valid() {
-	// 	t.Fatalf("write missing on batch iter created before write")
-	// }
+	// `Commit` frees the batch, so iterators backed by it should panic.
+	func() {
+		defer func() {
+			if err, expected := recover(), "iterator used after backing engine closed"; err != expected {
+				t.Fatalf("Unexpected panic: expected %q, got %q", expected, err)
+			}
+		}()
+		after.Seek(k)
+		t.Fatalf(`Seek on batch-backed iter after batched closed should panic.
+			iter.engine: %T, iter.engine.Closed: %v, batch.Closed %v`,
+			after.(*rocksDBIterator).engine,
+			after.(*rocksDBIterator).engine.Closed(),
+			b.Closed(),
+		)
+	}()
 }


### PR DESCRIPTION
Exploratory testing of batch-backed iterators revealed that they could _appear_
to continue to function (not immediately crash when used) after the batch
backing them was committed and its memory freed, although the results they returned
changed and obviously the usual risks of reading freed memory still applied.

Guarding against this potentially non-deterministic crash / correctness issue, by
crashing immediately if a read is attempted after the batch is closed, adds a
small runtime penalty (just the extra pointer in rocksDBIterator) but seems like
it might be worth it overall.

```
name                         old time/op    new time/op    delta
Insert10_Cockroach-8            662µs ± 2%     666µs ± 1%    ~           (p=0.105 n=10+10)
Update10_Cockroach-8           1.08ms ± 1%    1.09ms ± 1%    ~           (p=0.123 n=10+10)
Delete10_Cockroach-8           1.59ms ± 1%    1.59ms ± 1%    ~           (p=0.529 n=10+10)
Scan10_Cockroach-8              182µs ± 1%     181µs ± 3%    ~             (p=0.387 n=9+9)
Scan1000Limit10_Cockroach-8     191µs ± 2%     191µs ± 2%    ~            (p=0.549 n=9+10)
Insert1000_Cockroach-8         31.1ms ±10%    30.3ms ± 2%    ~           (p=0.481 n=10+10)
Update1000_Cockroach-8         52.9ms ± 3%    53.6ms ± 8%    ~           (p=1.000 n=10+10)
Delete1000_Cockroach-8          148ms ± 1%     148ms ± 7%    ~            (p=0.173 n=8+10)
Scan1000_Cockroach-8           3.12ms ± 2%    3.12ms ± 2%    ~           (p=0.853 n=10+10)

name                         old alloc/op   new alloc/op   delta
Insert10_Cockroach-8           64.7kB ± 0%    65.1kB ± 0%  +0.56%        (p=0.000 n=10+10)
Update10_Cockroach-8            102kB ± 0%     103kB ± 0%  +0.55%         (p=0.000 n=10+9)
Delete10_Cockroach-8           72.3kB ± 0%    72.8kB ± 0%  +0.75%        (p=0.000 n=10+10)
Scan10_Cockroach-8             15.2kB ± 0%    15.3kB ± 0%  +0.14%         (p=0.001 n=9+10)
Scan1000Limit10_Cockroach-8    15.6kB ± 0%    15.7kB ± 0%  +0.21%          (p=0.000 n=8+9)
Insert1000_Cockroach-8         4.22MB ± 1%    4.23MB ± 0%    ~            (p=0.315 n=10+9)
Update1000_Cockroach-8         6.26MB ± 1%    6.26MB ± 0%    ~           (p=0.529 n=10+10)
Delete1000_Cockroach-8         4.38MB ± 1%    4.42MB ± 1%  +0.71%        (p=0.029 n=10+10)
Scan1000_Cockroach-8            328kB ± 0%     328kB ± 0%    ~            (p=0.915 n=8+10)

name                         old allocs/op  new allocs/op  delta
Insert10_Cockroach-8              774 ± 0%       774 ± 0%    ~           (p=0.975 n=10+10)
Update10_Cockroach-8            1.31k ± 0%     1.31k ± 0%    ~            (p=0.294 n=10+8)
Delete10_Cockroach-8            1.12k ± 0%     1.12k ± 0%    ~     (all samples are equal)
Scan10_Cockroach-8                299 ± 0%       299 ± 0%    ~           (p=0.650 n=10+10)
Scan1000Limit10_Cockroach-8       315 ± 0%       315 ± 0%    ~     (all samples are equal)
Insert1000_Cockroach-8          46.8k ± 0%     46.8k ± 1%    ~           (p=0.927 n=10+10)
Update1000_Cockroach-8          67.9k ± 0%     67.8k ± 0%    ~           (p=0.117 n=10+10)
Delete1000_Cockroach-8          63.7k ± 0%     63.7k ± 0%    ~            (p=0.968 n=10+9)
Scan1000_Cockroach-8            8.24k ± 0%     8.24k ± 0%    ~           (p=1.000 n=10+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5210)

<!-- Reviewable:end -->
