### PR TITLE
gossip: deflake TestGossipStorage

### DIFF
--- a/gossip/storage_test.go
+++ b/gossip/storage_test.go
@@ -178,7 +178,7 @@ func TestGossipStorage(t *testing.T) {
 	}
 
 	network.SimulateNetwork(func(cycle int, network *simulation.Network) bool {
-		if cycle > 100 {
+		if cycle > 1000 {
 			t.Fatal("failed to connect to gossip")
 		}
 		select {


### PR DESCRIPTION
The network frequently fails to connect within 100 cycles when running
`make stress`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5217)

<!-- Reviewable:end -->
