### PR TITLE
gossip: deflake TestGossipGetNextBootstrapAddress

### DIFF
--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -57,6 +57,7 @@ func TestGossipInfoStore(t *testing.T) {
 
 func TestGossipGetNextBootstrapAddress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer resolver.SetLookupTimeout(time.Minute)()
 
 	// Set up an http server for testing the http load balancer.
 	i := 0


### PR DESCRIPTION
On a slow machine resolving a load-balanced bootstrap address might fail
as the default timeout is 3sec. Allow that timeout to be bumped
significantly higher in the test.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5218)

<!-- Reviewable:end -->
