### PR TITLE
POC: add LMDB as a storage engine (instead of RocksDB)

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -19,6 +19,7 @@ github.com/Sirupsen/logrus 4b6ea7319e214d98c938f12692336f7ca9348d6b
 github.com/VividCortex/ewma c34099b489e4ac33ca8d8c5f9d29d6eeaf69f2ed
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store 3b4c041f52c224ee4a44f5c8b150d003a40643a0
+github.com/bmatsuo/lmdb-go 7ed073bca400c16a43dd504a35d857939c0d8806
 github.com/chzyer/readline dc5da28fbf5287157fcd4719c794b59cd8852115
 github.com/client9/misspell 4f5982f81a18693b85c9926407fc4f61102ee0e7
 github.com/cockroachdb/c-protobuf 4feb192131ea08dfbd7253a00868ad69cbb61b81

--- a/storage/engine/bench_lmdb_test.go
+++ b/storage/engine/bench_lmdb_test.go
@@ -1,0 +1,235 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package engine
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util/stop"
+)
+
+var mvccLMDBMaker = engineMaker{
+	suffix: "lmdb",
+	new: func(b testing.TB, loc string) (Engine, *stop.Stopper) {
+		const size = 1 << 35 // 32GB
+		eng := NewLMDB(size, loc)
+		if err := eng.Open(); err != nil {
+			b.Fatalf("could not open LMDB instance at %s: %v", loc, err)
+		}
+		return eng, stop.NewStopper()
+	},
+}
+
+var mvccTransientLMDBMaker = engineMaker{
+	suffix: "lmdb_transient",
+	new: func(b testing.TB, loc string) (Engine, *stop.Stopper) {
+		eng, stopper := mvccLMDBMaker.new(b, loc)
+		stopper.RunWorker(func() {
+			<-stopper.ShouldStop()
+			if err := os.RemoveAll(loc); err != nil {
+				panic(err)
+			}
+		})
+		return eng, stopper
+	},
+}
+
+// Read benchmarks. All of them run with on-disk data.
+
+func BenchmarkMVCCScan10Versions1Row64Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 1, 10, 64, b)
+}
+
+func BenchmarkMVCCScan10Versions1Row512Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 1, 10, 512, b)
+}
+
+func BenchmarkMVCCScan10Versions10Rows8Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 10, 10, 8, b)
+}
+
+func BenchmarkMVCCScan10Versions10Rows64Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 10, 10, 64, b)
+}
+
+func BenchmarkMVCCScan10Versions10Rows512Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 10, 10, 512, b)
+}
+
+func BenchmarkMVCCScan10Versions100Rows8Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 100, 10, 8, b)
+}
+
+func BenchmarkMVCCScan10Versions100Rows64Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 100, 10, 64, b)
+}
+
+func BenchmarkMVCCScan10Versions100Rows512Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 100, 10, 512, b)
+}
+
+func BenchmarkMVCCScan10Versions1000Rows8Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 1000, 10, 8, b)
+}
+
+func BenchmarkMVCCScan10Versions1000Rows64Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 1000, 10, 64, b)
+}
+
+func BenchmarkMVCCScan10Versions1000Rows512Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 1000, 10, 512, b)
+}
+
+func BenchmarkMVCCScan100Versions1Row512Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 1, 100, 512, b)
+}
+
+func BenchmarkMVCCScan100Versions10Rows512Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 10, 100, 512, b)
+}
+
+func BenchmarkMVCCScan100Versions100Rows512Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 100, 100, 512, b)
+}
+
+func BenchmarkMVCCScan100Versions1000Rows512Bytes_LMDB(b *testing.B) {
+	runMVCCScan(mvccLMDBMaker, 1000, 100, 512, b)
+}
+
+func BenchmarkMVCCGet1Version8Bytes_LMDB(b *testing.B) {
+	runMVCCGet(mvccLMDBMaker, 1, 8, b)
+}
+
+func BenchmarkMVCCGet10Versions8Bytes_LMDB(b *testing.B) {
+	runMVCCGet(mvccLMDBMaker, 10, 8, b)
+}
+
+func BenchmarkMVCCGet100Versions8Bytes_LMDB(b *testing.B) {
+	runMVCCGet(mvccLMDBMaker, 100, 8, b)
+}
+
+func BenchmarkMVCCComputeStats1Version8Bytes_LMDB(b *testing.B) {
+	b.Skip("unimplemented")
+	runMVCCComputeStats(mvccLMDBMaker, 8, b)
+}
+
+func BenchmarkMVCCComputeStats1Version32Bytes_LMDB(b *testing.B) {
+	b.Skip("unimplemented")
+	runMVCCComputeStats(mvccLMDBMaker, 32, b)
+}
+
+func BenchmarkMVCCComputeStats1Version256Bytes_LMDB(b *testing.B) {
+	b.Skip("unimplemented")
+	runMVCCComputeStats(mvccLMDBMaker, 256, b)
+}
+
+func BenchmarkIterOnBatch10_LMDB(b *testing.B) {
+	benchmarkIterOnBatch(b, 10)
+}
+
+func BenchmarkIterOnBatch100_LMDB(b *testing.B) {
+	benchmarkIterOnBatch(b, 100)
+}
+
+func BenchmarkIterOnBatch1000_LMDB(b *testing.B) {
+	benchmarkIterOnBatch(b, 1000)
+}
+
+func BenchmarkIterOnBatch10000_LMDB(b *testing.B) {
+	benchmarkIterOnBatch(b, 10000)
+}
+
+// Write benchmarks. Unlike with RocksDB, all of them use on-disk data (which
+// puts them at a disadvantage).
+
+func BenchmarkMVCCPut10_LMDB(b *testing.B) {
+	runMVCCPut(mvccTransientLMDBMaker, 10, b)
+}
+
+func BenchmarkMVCCPut100_LMDB(b *testing.B) {
+	runMVCCPut(mvccTransientLMDBMaker, 100, b)
+}
+
+func BenchmarkMVCCPut1000_LMDB(b *testing.B) {
+	runMVCCPut(mvccTransientLMDBMaker, 1000, b)
+}
+
+func BenchmarkMVCCPut10000_LMDB(b *testing.B) {
+	runMVCCPut(mvccTransientLMDBMaker, 10000, b)
+}
+
+func BenchmarkMVCCConditionalPutCreate10_LMDB(b *testing.B) {
+	runMVCCConditionalPut(mvccTransientLMDBMaker, 10, false, b)
+}
+
+func BenchmarkMVCCConditionalPutCreate100_LMDB(b *testing.B) {
+	runMVCCConditionalPut(mvccTransientLMDBMaker, 100, false, b)
+}
+
+func BenchmarkMVCCConditionalPutCreate1000_LMDB(b *testing.B) {
+	runMVCCConditionalPut(mvccTransientLMDBMaker, 1000, false, b)
+}
+
+func BenchmarkMVCCConditionalPutCreate10000_LMDB(b *testing.B) {
+	runMVCCConditionalPut(mvccTransientLMDBMaker, 10000, false, b)
+}
+
+func BenchmarkMVCCConditionalPutReplace10_LMDB(b *testing.B) {
+	runMVCCConditionalPut(mvccTransientLMDBMaker, 10, true, b)
+}
+
+func BenchmarkMVCCConditionalPutReplace100_LMDB(b *testing.B) {
+	runMVCCConditionalPut(mvccTransientLMDBMaker, 100, true, b)
+}
+
+func BenchmarkMVCCConditionalPutReplace1000_LMDB(b *testing.B) {
+	runMVCCConditionalPut(mvccTransientLMDBMaker, 1000, true, b)
+}
+
+func BenchmarkMVCCConditionalPutReplace10000_LMDB(b *testing.B) {
+	runMVCCConditionalPut(mvccTransientLMDBMaker, 10000, true, b)
+}
+func BenchmarkMVCCBatch1Put10_LMDB(b *testing.B) {
+	runMVCCBatchPut(mvccTransientLMDBMaker, 10, 1, b)
+}
+
+func BenchmarkMVCCBatch100Put10_LMDB(b *testing.B) {
+	runMVCCBatchPut(mvccTransientLMDBMaker, 10, 100, b)
+}
+
+func BenchmarkMVCCBatch10000Put10_LMDB(b *testing.B) {
+	runMVCCBatchPut(mvccTransientLMDBMaker, 10, 10000, b)
+}
+
+func BenchmarkMVCCBatch100000Put10_LMDB(b *testing.B) {
+	runMVCCBatchPut(mvccTransientLMDBMaker, 10, 100000, b)
+}
+
+// DeleteRange benchmarks below (still using on-disk data).
+
+func BenchmarkMVCCDeleteRange1Version8Bytes_LMDB(b *testing.B) {
+	runMVCCDeleteRange(mvccLMDBMaker, 8, b)
+}
+
+func BenchmarkMVCCDeleteRange1Version32Bytes_LMDB(b *testing.B) {
+	runMVCCDeleteRange(mvccLMDBMaker, 32, b)
+}
+
+func BenchmarkMVCCDeleteRange1Version256Bytes_LMDB(b *testing.B) {
+	runMVCCDeleteRange(mvccLMDBMaker, 256, b)
+}

--- a/storage/engine/bench_rocksdb_test.go
+++ b/storage/engine/bench_rocksdb_test.go
@@ -23,106 +23,112 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
-func setupMVCCRocksDB(b testing.TB, loc string) (Engine, *stop.Stopper) {
-	const cacheSize = 0
-	const memtableBudget = 512 << 20 // 512 MB
-	stopper := stop.NewStopper()
-	rocksdb := NewRocksDB(roachpb.Attributes{}, loc, cacheSize, memtableBudget, 0, stopper)
-	if err := rocksdb.Open(); err != nil {
-		b.Fatalf("could not create new rocksdb db instance at %s: %v", loc, err)
-	}
-	return rocksdb, stopper
+var mvccRocksDBMaker = engineMaker{
+	suffix: "rocksdb",
+	new: func(b testing.TB, loc string) (Engine, *stop.Stopper) {
+		const cacheSize = 0
+		const memtableBudget = 512 << 20 // 512 MB
+		stopper := stop.NewStopper()
+		rocksdb := NewRocksDB(roachpb.Attributes{}, loc, cacheSize, memtableBudget, 0, stopper)
+		if err := rocksdb.Open(); err != nil {
+			b.Fatalf("could not create new rocksdb db instance at %s: %v", loc, err)
+		}
+		return rocksdb, stopper
+	},
 }
 
-func setupMVCCInMemRocksDB(_ testing.TB, loc string) (Engine, *stop.Stopper) {
-	stopper := stop.NewStopper()
-	return NewInMem(roachpb.Attributes{}, testCacheSize, stopper), stopper
+var mvccInMemRocksDBMaker = engineMaker{
+	suffix: "rocksdb_inmem",
+	new: func(_ testing.TB, loc string) (Engine, *stop.Stopper) {
+		stopper := stop.NewStopper()
+		return NewInMem(roachpb.Attributes{}, testCacheSize, stopper), stopper
+	},
 }
 
 // Read benchmarks. All of them run with on-disk data.
 
 func BenchmarkMVCCScan10Versions1Row64Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 1, 10, 64, b)
+	runMVCCScan(mvccRocksDBMaker, 1, 10, 64, b)
 }
 
 func BenchmarkMVCCScan10Versions1Row512Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 1, 10, 512, b)
+	runMVCCScan(mvccRocksDBMaker, 1, 10, 512, b)
 }
 
 func BenchmarkMVCCScan10Versions10Rows8Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 10, 10, 8, b)
+	runMVCCScan(mvccRocksDBMaker, 10, 10, 8, b)
 }
 
 func BenchmarkMVCCScan10Versions10Rows64Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 10, 10, 64, b)
+	runMVCCScan(mvccRocksDBMaker, 10, 10, 64, b)
 }
 
 func BenchmarkMVCCScan10Versions10Rows512Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 10, 10, 512, b)
+	runMVCCScan(mvccRocksDBMaker, 10, 10, 512, b)
 }
 
 func BenchmarkMVCCScan10Versions100Rows8Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 100, 10, 8, b)
+	runMVCCScan(mvccRocksDBMaker, 100, 10, 8, b)
 }
 
 func BenchmarkMVCCScan10Versions100Rows64Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 100, 10, 64, b)
+	runMVCCScan(mvccRocksDBMaker, 100, 10, 64, b)
 }
 
 func BenchmarkMVCCScan10Versions100Rows512Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 100, 10, 512, b)
+	runMVCCScan(mvccRocksDBMaker, 100, 10, 512, b)
 }
 
 func BenchmarkMVCCScan10Versions1000Rows8Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 1000, 10, 8, b)
+	runMVCCScan(mvccRocksDBMaker, 1000, 10, 8, b)
 }
 
 func BenchmarkMVCCScan10Versions1000Rows64Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 1000, 10, 64, b)
+	runMVCCScan(mvccRocksDBMaker, 1000, 10, 64, b)
 }
 
 func BenchmarkMVCCScan10Versions1000Rows512Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 1000, 10, 512, b)
+	runMVCCScan(mvccRocksDBMaker, 1000, 10, 512, b)
 }
 
 func BenchmarkMVCCScan100Versions1Row512Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 1, 100, 512, b)
+	runMVCCScan(mvccRocksDBMaker, 1, 100, 512, b)
 }
 
 func BenchmarkMVCCScan100Versions10Rows512Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 10, 100, 512, b)
+	runMVCCScan(mvccRocksDBMaker, 10, 100, 512, b)
 }
 
 func BenchmarkMVCCScan100Versions100Rows512Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 100, 100, 512, b)
+	runMVCCScan(mvccRocksDBMaker, 100, 100, 512, b)
 }
 
 func BenchmarkMVCCScan100Versions1000Rows512Bytes_RocksDB(b *testing.B) {
-	runMVCCScan(setupMVCCRocksDB, 1000, 100, 512, b)
+	runMVCCScan(mvccRocksDBMaker, 1000, 100, 512, b)
 }
 
 func BenchmarkMVCCGet1Version8Bytes_RocksDB(b *testing.B) {
-	runMVCCGet(setupMVCCRocksDB, 1, 8, b)
+	runMVCCGet(mvccRocksDBMaker, 1, 8, b)
 }
 
 func BenchmarkMVCCGet10Versions8Bytes_RocksDB(b *testing.B) {
-	runMVCCGet(setupMVCCRocksDB, 10, 8, b)
+	runMVCCGet(mvccRocksDBMaker, 10, 8, b)
 }
 
 func BenchmarkMVCCGet100Versions8Bytes_RocksDB(b *testing.B) {
-	runMVCCGet(setupMVCCRocksDB, 100, 8, b)
+	runMVCCGet(mvccRocksDBMaker, 100, 8, b)
 }
 
 func BenchmarkMVCCComputeStats1Version8Bytes_RocksDB(b *testing.B) {
-	runMVCCComputeStats(setupMVCCRocksDB, 8, b)
+	runMVCCComputeStats(mvccRocksDBMaker, 8, b)
 }
 
 func BenchmarkMVCCComputeStats1Version32Bytes_RocksDB(b *testing.B) {
-	runMVCCComputeStats(setupMVCCRocksDB, 32, b)
+	runMVCCComputeStats(mvccRocksDBMaker, 32, b)
 }
 
 func BenchmarkMVCCComputeStats1Version256Bytes_RocksDB(b *testing.B) {
-	runMVCCComputeStats(setupMVCCRocksDB, 256, b)
+	runMVCCComputeStats(mvccRocksDBMaker, 256, b)
 }
 
 func BenchmarkIterOnBatch10_RocksDB(b *testing.B) {
@@ -145,78 +151,78 @@ func BenchmarkIterOnBatch10000_RocksDB(b *testing.B) {
 // which make more sense when data is present.
 
 func BenchmarkMVCCPut10_RocksDB(b *testing.B) {
-	runMVCCPut(setupMVCCInMemRocksDB, 10, b)
+	runMVCCPut(mvccInMemRocksDBMaker, 10, b)
 }
 
 func BenchmarkMVCCPut100_RocksDB(b *testing.B) {
-	runMVCCPut(setupMVCCInMemRocksDB, 100, b)
+	runMVCCPut(mvccInMemRocksDBMaker, 100, b)
 }
 
 func BenchmarkMVCCPut1000_RocksDB(b *testing.B) {
-	runMVCCPut(setupMVCCInMemRocksDB, 1000, b)
+	runMVCCPut(mvccInMemRocksDBMaker, 1000, b)
 }
 
 func BenchmarkMVCCPut10000_RocksDB(b *testing.B) {
-	runMVCCPut(setupMVCCInMemRocksDB, 10000, b)
+	runMVCCPut(mvccInMemRocksDBMaker, 10000, b)
 }
 
 func BenchmarkMVCCConditionalPutCreate10_RocksDB(b *testing.B) {
-	runMVCCConditionalPut(setupMVCCInMemRocksDB, 10, false, b)
+	runMVCCConditionalPut(mvccInMemRocksDBMaker, 10, false, b)
 }
 
 func BenchmarkMVCCConditionalPutCreate100_RocksDB(b *testing.B) {
-	runMVCCConditionalPut(setupMVCCInMemRocksDB, 100, false, b)
+	runMVCCConditionalPut(mvccInMemRocksDBMaker, 100, false, b)
 }
 
 func BenchmarkMVCCConditionalPutCreate1000_RocksDB(b *testing.B) {
-	runMVCCConditionalPut(setupMVCCInMemRocksDB, 1000, false, b)
+	runMVCCConditionalPut(mvccInMemRocksDBMaker, 1000, false, b)
 }
 
 func BenchmarkMVCCConditionalPutCreate10000_RocksDB(b *testing.B) {
-	runMVCCConditionalPut(setupMVCCInMemRocksDB, 10000, false, b)
+	runMVCCConditionalPut(mvccInMemRocksDBMaker, 10000, false, b)
 }
 
 func BenchmarkMVCCConditionalPutReplace10_RocksDB(b *testing.B) {
-	runMVCCConditionalPut(setupMVCCInMemRocksDB, 10, true, b)
+	runMVCCConditionalPut(mvccInMemRocksDBMaker, 10, true, b)
 }
 
 func BenchmarkMVCCConditionalPutReplace100_RocksDB(b *testing.B) {
-	runMVCCConditionalPut(setupMVCCInMemRocksDB, 100, true, b)
+	runMVCCConditionalPut(mvccInMemRocksDBMaker, 100, true, b)
 }
 
 func BenchmarkMVCCConditionalPutReplace1000_RocksDB(b *testing.B) {
-	runMVCCConditionalPut(setupMVCCInMemRocksDB, 1000, true, b)
+	runMVCCConditionalPut(mvccInMemRocksDBMaker, 1000, true, b)
 }
 
 func BenchmarkMVCCConditionalPutReplace10000_RocksDB(b *testing.B) {
-	runMVCCConditionalPut(setupMVCCInMemRocksDB, 10000, true, b)
+	runMVCCConditionalPut(mvccInMemRocksDBMaker, 10000, true, b)
 }
 func BenchmarkMVCCBatch1Put10_RocksDB(b *testing.B) {
-	runMVCCBatchPut(setupMVCCInMemRocksDB, 10, 1, b)
+	runMVCCBatchPut(mvccInMemRocksDBMaker, 10, 1, b)
 }
 
 func BenchmarkMVCCBatch100Put10_RocksDB(b *testing.B) {
-	runMVCCBatchPut(setupMVCCInMemRocksDB, 10, 100, b)
+	runMVCCBatchPut(mvccInMemRocksDBMaker, 10, 100, b)
 }
 
 func BenchmarkMVCCBatch10000Put10_RocksDB(b *testing.B) {
-	runMVCCBatchPut(setupMVCCInMemRocksDB, 10, 10000, b)
+	runMVCCBatchPut(mvccInMemRocksDBMaker, 10, 10000, b)
 }
 
 func BenchmarkMVCCBatch100000Put10_RocksDB(b *testing.B) {
-	runMVCCBatchPut(setupMVCCInMemRocksDB, 10, 100000, b)
+	runMVCCBatchPut(mvccInMemRocksDBMaker, 10, 100000, b)
 }
 
 // DeleteRange benchmarks below (using on-disk data).
 
 func BenchmarkMVCCDeleteRange1Version8Bytes_RocksDB(b *testing.B) {
-	runMVCCDeleteRange(setupMVCCRocksDB, 8, b)
+	runMVCCDeleteRange(mvccRocksDBMaker, 8, b)
 }
 
 func BenchmarkMVCCDeleteRange1Version32Bytes_RocksDB(b *testing.B) {
-	runMVCCDeleteRange(setupMVCCRocksDB, 32, b)
+	runMVCCDeleteRange(mvccRocksDBMaker, 32, b)
 }
 
 func BenchmarkMVCCDeleteRange1Version256Bytes_RocksDB(b *testing.B) {
-	runMVCCDeleteRange(setupMVCCRocksDB, 256, b)
+	runMVCCDeleteRange(mvccRocksDBMaker, 256, b)
 }

--- a/storage/engine/bench_test.go
+++ b/storage/engine/bench_test.go
@@ -54,7 +54,10 @@ func readAllFiles(pattern string) {
 	}
 }
 
-type engineMaker func(testing.TB, string) (Engine, *stop.Stopper)
+type engineMaker struct {
+	new    func(testing.TB, string) (Engine, *stop.Stopper)
+	suffix string
+}
 
 // setupMVCCData writes up to numVersions values at each of numKeys
 // keys. The number of versions written for each key is chosen
@@ -72,14 +75,14 @@ type engineMaker func(testing.TB, string) (Engine, *stop.Stopper)
 // the current directory as "mvcc_scan_<versions>_<keys>_<valueBytes>" (which
 // is also returned).
 func setupMVCCData(emk engineMaker, numVersions, numKeys, valueBytes int, b *testing.B) (Engine, string, *stop.Stopper) {
-	loc := fmt.Sprintf("mvcc_data_%d_%d_%d", numVersions, numKeys, valueBytes)
+	loc := fmt.Sprintf("mvcc_data_%d_%d_%d_%s", numVersions, numKeys, valueBytes, emk.suffix)
 
 	exists := true
 	if _, err := os.Stat(loc); os.IsNotExist(err) {
 		exists = false
 	}
 
-	eng, stopper := emk(b, loc)
+	eng, stopper := emk.new(b, loc)
 
 	if exists {
 		readAllFiles(filepath.Join(loc, "*"))
@@ -225,7 +228,7 @@ func runMVCCPut(emk engineMaker, valueSize int, b *testing.B) {
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 
-	eng, stopper := emk(b, fmt.Sprintf("put_%d", valueSize))
+	eng, stopper := emk.new(b, fmt.Sprintf("mvcc_data_put_%d", valueSize))
 	defer stopper.Stop()
 
 	b.SetBytes(int64(valueSize))
@@ -247,7 +250,7 @@ func runMVCCConditionalPut(emk engineMaker, valueSize int, createFirst bool, b *
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 
-	eng, stopper := emk(b, fmt.Sprintf("cput_%d", valueSize))
+	eng, stopper := emk.new(b, fmt.Sprintf("mvcc_data_cput_%d", valueSize))
 	defer stopper.Stop()
 
 	b.SetBytes(int64(valueSize))
@@ -261,6 +264,13 @@ func runMVCCConditionalPut(emk engineMaker, valueSize int, createFirst bool, b *
 			}
 		}
 		expected = &value
+	} else {
+		if err := eng.Iterate(NilKey, MVCCKeyMax, func(kv MVCCKeyValue) (bool, error) {
+			b.Fatal("underlying engine is not empty")
+			return false, nil
+		}); err != nil {
+			b.Fatalf("failed cput: %s", err)
+		}
 	}
 
 	b.ResetTimer()
@@ -281,7 +291,7 @@ func runMVCCBatchPut(emk engineMaker, valueSize, batchSize int, b *testing.B) {
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 
 	stopper := stop.NewStopper()
-	eng, stopper := emk(b, fmt.Sprintf("batch_put_%d_%d", valueSize, batchSize))
+	eng, stopper := emk.new(b, fmt.Sprintf("mvcc_data_batch_put_%d_%d", valueSize, batchSize))
 	defer stopper.Stop()
 
 	b.SetBytes(int64(valueSize))
@@ -315,7 +325,7 @@ func runMVCCBatchPut(emk engineMaker, valueSize, batchSize int, b *testing.B) {
 
 // runMVCCMerge merges value into numKeys separate keys.
 func runMVCCMerge(emk engineMaker, value *roachpb.Value, numKeys int, b *testing.B) {
-	eng, stopper := emk(b, fmt.Sprintf("merge_%d", numKeys))
+	eng, stopper := emk.new(b, fmt.Sprintf("mvcc_data_merge_%d", numKeys))
 	defer stopper.Stop()
 
 	// Precompute keys so we don't waste time formatting them at each iteration.
@@ -366,7 +376,7 @@ func BenchmarkMVCCMergeTimeSeries_RocksDB(b *testing.B) {
 	if err := value.SetProto(ts); err != nil {
 		b.Fatal(err)
 	}
-	runMVCCMerge(setupMVCCInMemRocksDB, &value, 1024, b)
+	runMVCCMerge(mvccInMemRocksDBMaker, &value, 1024, b)
 }
 
 func runMVCCDeleteRange(emk engineMaker, valueBytes int, b *testing.B) {
@@ -389,7 +399,7 @@ func runMVCCDeleteRange(emk engineMaker, valueBytes int, b *testing.B) {
 		if err := shutil.CopyTree(dir, locDirty, nil); err != nil {
 			b.Fatal(err)
 		}
-		dupEng, stopper := emk(b, locDirty)
+		dupEng, stopper := emk.new(b, locDirty)
 
 		b.StartTimer()
 		_, err := MVCCDeleteRange(context.Background(), dupEng, &MVCCStats{}, roachpb.KeyMin, roachpb.KeyMax, 0, roachpb.MaxTimestamp, nil, false)
@@ -430,7 +440,7 @@ func runMVCCComputeStats(emk engineMaker, valueBytes int, b *testing.B) {
 func BenchmarkMVCCPutDelete_RocksDB(b *testing.B) {
 	const cacheSize = 1 << 30 // 1 GB
 
-	rocksdb, stopper := setupMVCCInMemRocksDB(b, "put_delete")
+	rocksdb, stopper := mvccInMemRocksDBMaker.new(b, "put_delete")
 	defer stopper.Stop()
 
 	r := rand.New(rand.NewSource(int64(timeutil.Now().UnixNano())))

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -235,3 +235,18 @@ func ClearRange(engine Engine, start, end MVCCKey) (int, error) {
 	}
 	return count, b.Commit()
 }
+
+func iterFromTo(it Iterator, start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
+	it.Seek(start)
+	for ; it.Valid(); it.Next() {
+		k := it.Key()
+		if !it.Key().Less(end) {
+			break
+		}
+		if done, err := f(MVCCKeyValue{Key: k, Value: it.Value()}); done || err != nil {
+			return err
+		}
+	}
+	// Check for any errors during iteration.
+	return it.Error()
+}

--- a/storage/engine/lmdb.go
+++ b/storage/engine/lmdb.go
@@ -1,0 +1,388 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package engine
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/dustin/go-humanize"
+	"github.com/gogo/protobuf/proto"
+)
+
+// LMDB wraps a Lightning Memory-Mapped Database.
+// On linux, should build with the 'pwritev' build tag for optimal performance,
+// see https://github.com/bmatsuo/lmdb-go.
+type LMDB struct {
+	size int64
+	path string
+	env  *lmdb.Env
+}
+
+// NewLMDB creates a new LMDB handle of the given size in the given directory.
+func NewLMDB(size int64, path string) *LMDB {
+	return &LMDB{
+		size: size,
+		path: path,
+	}
+}
+
+var _ Engine = &LMDB{}
+
+// Open implements Engine.
+func (l *LMDB) Open() error {
+	env, err := lmdb.NewEnv()
+	if err != nil {
+		return err
+	}
+	if err := env.SetMapSize(l.size); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(l.path, 0770); err != nil {
+		return err
+	}
+	err = env.Open(l.path, 0, 0664)
+	if err != nil {
+		_ = env.Close()
+	}
+	log.Infof("opening lmdb instance at %q (%s)", l.path, humanize.Bytes(uint64(l.size)))
+	l.env = env
+	return err
+}
+
+// Close implements Engine.
+func (l *LMDB) Close() {
+	if err := l.env.Close(); err != nil {
+		panic(err)
+	}
+	l.env = nil
+}
+
+// Closed implements Engine.
+func (l *LMDB) Closed() bool {
+	return l.env == nil
+}
+
+// Attrs implements Engine.
+func (l *LMDB) Attrs() roachpb.Attributes {
+	var attr roachpb.Attributes
+	return attr
+}
+
+// lmdbEncode uses a horrible encoding, but it's improvable (see #5220).
+func lmdbEncode(key MVCCKey) []byte {
+	if key.Timestamp == roachpb.ZeroTimestamp {
+		key.Timestamp = roachpb.MaxTimestamp
+	}
+	var enc []byte
+	enc = encoding.EncodeBytesAscending(enc, key.Key)
+	enc = encoding.EncodeUint64Descending(enc, uint64(key.Timestamp.WallTime))
+	enc = encoding.EncodeUint32Descending(enc, uint32(key.Timestamp.Logical))
+	return enc
+}
+
+func lmdbDecode(key, value []byte, dest *MVCCKeyValue) {
+	if dest.Key.Key != nil {
+		dest.Key.Key = dest.Key.Key[:0]
+	}
+	dest.Value = value
+	dest.Key.Timestamp = roachpb.ZeroTimestamp
+
+	var tsPart []byte
+	var err error
+	tsPart, dest.Key.Key, err = encoding.DecodeBytesAscending(key, dest.Key.Key)
+	if err != nil {
+		panic(err)
+	}
+	var wt uint64
+	tsPart, wt, err = encoding.DecodeUint64Descending(tsPart)
+	if err != nil {
+		panic(err)
+	}
+	dest.Key.Timestamp.WallTime = int64(wt)
+
+	var lg uint32
+	tsPart, lg, err = encoding.DecodeUint32Descending(tsPart)
+	if err != nil {
+		panic(err)
+	}
+	dest.Key.Timestamp.Logical = int32(lg)
+
+	if len(tsPart) != 0 {
+		panic(fmt.Sprintf("remainder in key %v", key))
+	}
+
+	if dest.Key.Timestamp.Equal(roachpb.MaxTimestamp) {
+		dest.Key.Timestamp = roachpb.ZeroTimestamp
+	}
+}
+
+// Needs #5220 before it can be used.
+func lmdbEncodeWithComparator(key MVCCKey) []byte {
+	hasTS := key.Timestamp != roachpb.ZeroTimestamp
+	var enc []byte
+	if hasTS {
+		enc = make([]byte, 0, len(key.Key)+2)
+	} else {
+		enc = make([]byte, 0, len(key.Key)+1)
+	}
+	enc = append(enc, key.Key...)
+	if hasTS {
+		enc = append(enc, 0)
+		enc = encoding.EncodeUint64Descending(enc, uint64(key.Timestamp.WallTime))
+		enc = encoding.EncodeUint32Descending(enc, uint32(key.Timestamp.Logical))
+	}
+	return append(enc, byte(len(enc)-len(key.Key)))
+}
+
+// Needs #5220 before it can be used.
+func lmdbDecodeWithComparator(key, value []byte, dest *MVCCKeyValue) {
+	dest.Value = value
+	dest.Key.Timestamp = roachpb.ZeroTimestamp
+
+	tsLen, key := int(key[len(key)-1]), key[:len(key)-1]
+	keyPart, tsPart := key[:len(key)-tsLen], key[len(key)-tsLen:]
+	dest.Key.Key = keyPart
+	if len(tsPart) > 0 {
+		tsPart = tsPart[1:] // remove the null byte
+
+		var wt uint64
+		var err error
+		tsPart, wt, err = encoding.DecodeUint64Descending(tsPart)
+		if err != nil {
+			panic(err)
+		}
+		var lg uint32
+		tsPart, lg, err = encoding.DecodeUint32Descending(tsPart)
+		if err != nil {
+			panic(err)
+		}
+		if len(tsPart) > 0 {
+			panic(string(tsPart))
+		}
+		dest.Key.Timestamp.WallTime, dest.Key.Timestamp.Logical = int64(wt), int32(lg)
+	}
+}
+
+func lmdbPut(txn *lmdb.Txn, db lmdb.DBI, key, value []byte) error {
+	return txn.Put(db, key, value, 0)
+}
+
+// Put implements Engine.
+func (l *LMDB) Put(key MVCCKey, value []byte) error {
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+	return l.env.Update(func(txn *lmdb.Txn) error {
+		db, err := txn.OpenRoot(0)
+		if err != nil {
+			return err
+		}
+
+		return lmdbPut(txn, db, lmdbEncode(key), value)
+	})
+}
+
+func lmdbGet(txn *lmdb.Txn, db lmdb.DBI, key []byte) ([]byte, error) {
+	v, err := txn.Get(db, key)
+	if lmdb.IsNotFound(err) {
+		return nil, nil
+	}
+	return v, err
+}
+
+// Get implements Engine.
+func (l *LMDB) Get(key MVCCKey) (r []byte, err error) {
+	if len(key.Key) == 0 {
+		return nil, emptyKeyError()
+	}
+
+	_ = l.env.View(func(txn *lmdb.Txn) error {
+		var db lmdb.DBI
+		if db, err = txn.OpenRoot(0); err != nil {
+			return err
+		}
+		r, err = lmdbGet(txn, db, lmdbEncode(key))
+		return nil
+	})
+	return
+}
+
+func lmdbGetProto(key MVCCKey, data []byte, msg proto.Message) (ok bool, keyBytes, valBytes int64, err error) {
+	if data == nil {
+		msg.Reset()
+		return
+	}
+	ok = true
+	if msg != nil {
+		// Make a byte slice that is backed by result.data. This slice
+		// cannot live past the lifetime of this method, but we're only
+		// using it to unmarshal the roachpb.
+		err = proto.Unmarshal(data, msg)
+	}
+	keyBytes = int64(key.EncodedSize())
+	valBytes = int64(len(data))
+	return
+}
+
+// GetProto implements Engine.
+func (l *LMDB) GetProto(key MVCCKey, msg proto.Message) (ok bool, keyBytes int64, valBytes int64, err error) {
+	if len(key.Key) == 0 {
+		err = emptyKeyError()
+		return
+	}
+	var data []byte
+	if data, err = l.Get(key); err != nil {
+		return
+	}
+	return lmdbGetProto(key, data, msg)
+}
+
+// Iterate implements Engine.
+func (l *LMDB) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
+	iter := l.NewIterator(nil)
+	defer iter.Close()
+	return iterFromTo(iter, start, end, f)
+}
+
+func lmdbClear(txn *lmdb.Txn, db lmdb.DBI, key roachpb.Key) error {
+	err := txn.Del(db, key, nil)
+	if lmdb.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+// Clear implements Engine.
+func (l *LMDB) Clear(key MVCCKey) error {
+	if len(key.Key) == 0 {
+		return emptyKeyError()
+	}
+	return l.env.Update(func(txn *lmdb.Txn) error {
+		db, err := txn.OpenRoot(0)
+		if err != nil {
+			return err
+		}
+		return lmdbClear(txn, db, lmdbEncode(key))
+	})
+}
+
+// Merge implements Engine.
+func (l *LMDB) Merge(key MVCCKey, value []byte) error {
+	return nil // unimplemented
+}
+
+// Capacity implements Engine.
+func (l *LMDB) Capacity() (roachpb.StoreCapacity, error) {
+	cap := roachpb.StoreCapacity{}
+	return cap, nil
+}
+
+// ApproximateSize implements Engine.
+func (l *LMDB) ApproximateSize(start, end MVCCKey) (uint64, error) {
+	return 0, nil
+}
+
+// Flush implements Engine.
+func (l *LMDB) Flush() error {
+	return nil
+}
+
+// NewIterator implements Engine.
+func (l *LMDB) NewIterator(prefix roachpb.Key) Iterator {
+	txn := readOnlyTxn(l.env)
+	db, err := txn.OpenRoot(0)
+	if err != nil {
+		panic(err)
+	}
+	cursor, err := txn.OpenCursor(db)
+	if err != nil {
+		panic(err)
+	}
+	return &lmdbIterator{
+		onClose: func() {
+			cursor.Close()
+			txn.Abort()
+		},
+		cursor: cursor,
+	}
+}
+
+func readOnlyTxn(env *lmdb.Env) *lmdb.Txn {
+	txn, err := env.BeginTxn(nil, lmdb.Readonly)
+	if err != nil {
+		panic(err)
+	}
+	return txn
+}
+
+// NewSnapshot implements Engine.
+func (l *LMDB) NewSnapshot() Engine {
+	txn := readOnlyTxn(l.env)
+	db, err := txn.OpenRoot(0)
+	if err != nil {
+		panic(err)
+	}
+	return &lmdbBatch{
+		readonly: true,
+		l:        l,
+		onClose: func() {
+			txn.Abort()
+		},
+		txn: txn,
+		db:  db,
+	}
+}
+
+// NewBatch implements Engine.
+func (l *LMDB) NewBatch() Engine {
+	runtime.LockOSThread() // unlocked on Close or Commit
+	txn, err := l.env.BeginTxn(nil, 0)
+	if err != nil {
+		panic(err)
+	}
+	db, err := txn.OpenRoot(0)
+	if err != nil {
+		panic(err)
+	}
+	return &lmdbBatch{
+		l:       l,
+		onClose: runtime.UnlockOSThread,
+		txn:     txn,
+		db:      db,
+	}
+}
+
+// Commit implements Engine.
+func (l *LMDB) Commit() error {
+	return nil
+}
+
+// Defer implements Engine.
+func (l *LMDB) Defer(fn func()) {
+	panic("only implemented for batches")
+}
+
+// GetStats implements Engine.
+func (l *LMDB) GetStats() (*Stats, error) {
+	return &Stats{}, nil // TODO
+}

--- a/storage/engine/lmdb_batch.go
+++ b/storage/engine/lmdb_batch.go
@@ -1,0 +1,140 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package engine
+
+import (
+	"errors"
+
+	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/gogo/protobuf/proto"
+)
+
+type lmdbBatch struct {
+	onClose  func()
+	readonly bool
+	l        *LMDB
+	db       lmdb.DBI
+	txn      *lmdb.Txn
+}
+
+var _ Engine = &lmdbBatch{}
+
+func (l *lmdbBatch) Open() error {
+	panic("unimplemented")
+}
+
+func (l *lmdbBatch) Close() {
+	defer l.onClose()
+	l.txn.Abort()
+	l.txn = nil
+}
+
+func (l *lmdbBatch) Closed() bool {
+	return l.txn == nil
+}
+
+func (l *lmdbBatch) Attrs() roachpb.Attributes {
+	return l.l.Attrs()
+}
+
+func (l *lmdbBatch) Put(key MVCCKey, value []byte) error {
+	return lmdbPut(l.txn, l.db, lmdbEncode(key), value)
+}
+
+func (l *lmdbBatch) Get(key MVCCKey) ([]byte, error) {
+	return lmdbGet(l.txn, l.db, lmdbEncode(key))
+}
+
+func (l *lmdbBatch) GetProto(key MVCCKey, msg proto.Message) (ok bool, keyBytes, valBytes int64, err error) {
+	var data []byte
+	if data, err = l.txn.Get(l.db, lmdbEncode(key)); err != nil {
+		return
+	}
+	return lmdbGetProto(key, data, msg)
+}
+
+func (l *lmdbBatch) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
+	iter := l.NewIterator(nil)
+	defer iter.Close()
+	return iterFromTo(iter, start, end, f)
+}
+
+func (l *lmdbBatch) NewIterator(prefix roachpb.Key) Iterator {
+	if prefix != nil {
+		// Not using the prefix isn't incorrect, just means
+		// we're going to not use information given to us by the user.
+	}
+	cursor, err := l.txn.OpenCursor(l.db)
+	if err != nil {
+		panic(err)
+	}
+
+	return &lmdbIterator{
+		onClose: cursor.Close,
+		cursor:  cursor,
+	}
+}
+
+func (l *lmdbBatch) Clear(key MVCCKey) error {
+	return lmdbClear(l.txn, l.db, lmdbEncode(key))
+}
+
+func (l *lmdbBatch) Merge(key MVCCKey, value []byte) error {
+	if l.readonly {
+		return errors.New("cannot merge to a snapshot")
+	}
+	return nil // unimplemented
+}
+
+func (l *lmdbBatch) Capacity() (roachpb.StoreCapacity, error) {
+	return l.l.Capacity()
+}
+
+func (l *lmdbBatch) ApproximateSize(start, end MVCCKey) (uint64, error) {
+	return l.l.ApproximateSize(start, end)
+}
+
+func (l *lmdbBatch) Flush() error {
+	return nil
+}
+
+func (l *lmdbBatch) NewSnapshot() Engine {
+	panic("already a snapshot or batch")
+}
+
+func (l *lmdbBatch) NewBatch() Engine {
+	panic("already a snapshot or batch")
+}
+
+func (l *lmdbBatch) Commit() error {
+	if l.readonly {
+		return errors.New("cannot commit a snapshot")
+	}
+
+	defer l.onClose()
+	return l.txn.Commit()
+}
+
+func (l *lmdbBatch) Defer(fn func()) {
+	panic("only implemented for batches")
+}
+
+func (l *lmdbBatch) GetStats() (*Stats, error) {
+	return nil, util.Errorf("GetStats is not implemented for %T", l)
+}

--- a/storage/engine/lmdb_iter.go
+++ b/storage/engine/lmdb_iter.go
@@ -1,0 +1,128 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package engine
+
+import (
+	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/gogo/protobuf/proto"
+)
+
+type lmdbIterator struct {
+	onClose    func()
+	cursor     *lmdb.Cursor
+	scratchKey []byte
+	curKV      MVCCKeyValue
+	exhausted  bool
+	err        error
+}
+
+var _ Iterator = &lmdbIterator{}
+
+// The following methods implement the Iterator interface.
+func (l *lmdbIterator) Close() {
+	l.onClose()
+}
+
+func (l *lmdbIterator) Seek(key MVCCKey) {
+	if len(key.Key) == 0 {
+		l.setState(l.cursor.Get(key.Key, nil, lmdb.First))
+	} else {
+		if key.Equal(l.unsafeKey()) {
+			return
+		}
+		enc := lmdbEncode(key)
+		l.setState(l.cursor.Get(enc, nil, lmdb.SetRange))
+	}
+}
+
+func (l *lmdbIterator) Valid() bool {
+	return l.err == nil && !l.exhausted
+}
+
+func (l *lmdbIterator) Next() {
+	l.setState(l.cursor.Get(nil, nil, lmdb.Next))
+}
+
+func (l *lmdbIterator) SeekReverse(key MVCCKey) {
+	if len(key.Key) == 0 {
+		// Dubious convention taken from the RocksDB impl.
+		l.setState(l.cursor.Get(key.Key, nil, lmdb.Last))
+	} else {
+		if key.Equal(l.unsafeKey()) {
+			return
+		}
+		l.setState(l.cursor.Get(key.Key, nil, lmdb.SetRange))
+		if !l.Valid() {
+			l.setState(l.cursor.Get(key.Key, nil, lmdb.Last)) // seek to last
+		}
+		if !l.Valid() {
+			return
+		}
+		if key.Less(l.Key()) {
+			l.Prev()
+		}
+	}
+}
+
+func (l *lmdbIterator) setState(k, v []byte, err error) {
+	if lmdb.IsNotFound(err) {
+		l.exhausted = true
+	} else {
+		l.err = err
+		if err == nil {
+			lmdbDecode(k, v, &l.curKV)
+		}
+	}
+}
+
+func (l *lmdbIterator) Prev() {
+	l.setState(l.cursor.Get(l.scratchKey, l.curKV.Value, lmdb.Prev))
+}
+
+func (l *lmdbIterator) Key() MVCCKey {
+	k := l.curKV.Key
+	k.Key = append(roachpb.Key(nil), k.Key...)
+	return k
+}
+
+func (l *lmdbIterator) Value() []byte {
+	return append([]byte(nil), l.curKV.Value...)
+}
+
+func (l *lmdbIterator) ValueProto(msg proto.Message) error {
+	if v := l.unsafeValue(); len(v) > 0 {
+		return proto.Unmarshal(v, msg)
+	}
+	return nil
+}
+
+func (l *lmdbIterator) unsafeKey() MVCCKey {
+	return l.curKV.Key
+}
+
+func (l *lmdbIterator) unsafeValue() []byte {
+	return l.curKV.Value
+}
+
+func (l *lmdbIterator) Error() error {
+	return l.err
+}
+
+func (l *lmdbIterator) ComputeStats(start, end MVCCKey, nowNanos int64) (MVCCStats, error) {
+	panic("unimplemented")
+}

--- a/storage/engine/lmdb_test.go
+++ b/storage/engine/lmdb_test.go
@@ -1,0 +1,171 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package engine
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func TestLMDBEngine(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	path := util.CreateTempDir(t, ".lmdbtest")
+	defer func() {
+		if err := os.RemoveAll(path); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	l := NewLMDB(10485760, path)
+	if err := l.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	k1 := MVCCKeyValue{
+		Key: MVCCKey{
+			Key:       roachpb.Key("test"),
+			Timestamp: roachpb.ZeroTimestamp.Add(5, 6),
+		},
+		Value: []byte("test"),
+	}
+
+	if v, err := l.Get(k1.Key); err != nil || v != nil {
+		t.Fatalf("unexpected error or nonempty slice: %v, %q", err, v)
+	}
+	var keysSeen []string
+	appendSeen := func(kv MVCCKeyValue) (bool, error) {
+		keysSeen = append(keysSeen, fmt.Sprintf("%s@%s", kv.Key.Key, kv.Key.Timestamp))
+		return false, nil
+	}
+	keyMin := MakeMVCCMetadataKey(roachpb.KeyMin)
+	expKeysSeen := []string{`"boo"@0.000000001,2`, `"test"@0.000000000,0`, `"test"@0.000000005,6`}
+
+	for _, test := range []struct {
+		make  func() Engine
+		close func(Engine)
+	}{
+		{func() Engine { return l }, func(Engine) {}},
+		{func() Engine { return l.NewBatch() }, func(e Engine) { e.Close() }},
+	} {
+		func() {
+			eng := test.make()
+			defer test.close(eng)
+			if err := eng.Put(k1.Key, k1.Value); err != nil {
+				t.Fatal(err)
+			}
+
+			if v, err := eng.Get(k1.Key); err != nil {
+				t.Fatal(err)
+			} else if !bytes.Equal(v, k1.Value) {
+				t.Fatalf("expected %q, got %q", k1.Value, v)
+			}
+
+			k2 := k1
+			k2.Key.Key = roachpb.Key("boo")
+			k2.Key.Timestamp = roachpb.ZeroTimestamp.Add(1, 2)
+			k2.Value = []byte("foo")
+
+			if err := eng.Put(k2.Key, k2.Value); err != nil {
+				t.Fatal(err)
+			}
+
+			m1 := MVCCKeyValue{
+				Key: MVCCKey{
+					Key:       roachpb.Key("test"),
+					Timestamp: roachpb.ZeroTimestamp,
+				},
+				Value: []byte("goo"),
+			}
+			if err := eng.Put(m1.Key, m1.Value); err != nil {
+				t.Fatal(err)
+			}
+
+			keysSeen = keysSeen[:0]
+			if err := eng.Iterate(keyMin, MVCCKeyMax, appendSeen); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(expKeysSeen, keysSeen) {
+				t.Fatalf("expected:\n%v,\ngot:\n%v", expKeysSeen, keysSeen)
+			}
+		}()
+	}
+
+	{
+		snap := l.NewSnapshot()
+		batch := l.NewBatch()
+		for _, eng := range []Engine{snap, batch} {
+			keysSeen = keysSeen[:0]
+			if err := eng.Iterate(keyMin, MVCCKeyMax, appendSeen); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(expKeysSeen, keysSeen) {
+				t.Fatalf("expected:\n%v,\ngot:\n%v", expKeysSeen, keysSeen)
+			}
+		}
+		batch.Close()
+		snap.Close()
+	}
+	{
+		iter := l.NewIterator(nil)
+		iter.Seek(keyMin)
+		defer iter.Close()
+		keysSeen = keysSeen[:0]
+		for ; iter.Valid(); iter.Next() {
+			_, _ = appendSeen(MVCCKeyValue{
+				Key:   iter.Key(),
+				Value: iter.Value(),
+			})
+		}
+		if iter.Error() != nil {
+			t.Fatal(iter.Error())
+		}
+
+		if !reflect.DeepEqual(expKeysSeen, keysSeen) {
+			t.Fatalf("expected:\n%v,\ngot:\n%v", expKeysSeen, keysSeen)
+		}
+	}
+	{
+		iter := l.NewIterator(nil)
+		iter.SeekReverse(keyMin) // convention for seek-to-last
+		defer iter.Close()
+		keysSeen = keysSeen[:0]
+		for ; iter.Valid(); iter.Prev() {
+			_, _ = appendSeen(MVCCKeyValue{
+				Key:   iter.Key(),
+				Value: iter.Value(),
+			})
+		}
+		if iter.Error() != nil {
+			t.Fatal(iter.Error())
+		}
+		revSeen := make([]string, len(keysSeen))
+		for i := 0; i < len(revSeen); i++ {
+			revSeen[i] = keysSeen[len(keysSeen)-1-i]
+		}
+
+		if !reflect.DeepEqual(expKeysSeen, revSeen) {
+			t.Fatalf("expected:\n%v,\ngot:\n%v", expKeysSeen, revSeen)
+		}
+	}
+}

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1350,10 +1350,7 @@ func MVCCDeleteRange(
 		}
 		num++
 		// We check num rather than len(keys) since returnKeys could be false.
-		if max != 0 && max >= num {
-			return true, nil
-		}
-		return false, nil
+		return max != 0 && max >= num, nil
 	}
 
 	// In order to detect the potential write intent by another

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -943,17 +943,5 @@ func dbIterate(rdb *C.DBEngine, engine Engine, start, end MVCCKey,
 	}
 	it := newRocksDBIterator(rdb, nil, engine)
 	defer it.Close()
-
-	it.Seek(start)
-	for ; it.Valid(); it.Next() {
-		k := it.Key()
-		if !k.Less(end) {
-			break
-		}
-		if done, err := f(MVCCKeyValue{Key: k, Value: it.Value()}); done || err != nil {
-			return err
-		}
-	}
-	// Check for any errors during iteration.
-	return it.Error()
+	return iterFromTo(it, start, end, f)
 }

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -46,7 +46,7 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const cacheSize = 1 << 30 // 1 GB
 
-	db, stopper := setupMVCCInMemRocksDB(t, "iter_read_own_write")
+	db, stopper := mvccInMemRocksDBMaker.new(t, "iter_read_own_write")
 	defer stopper.Stop()
 
 	b := db.NewBatch()


### PR DESCRIPTION
LMDB, the Lightning Memory-Mapped Database, is a much simpler datastore than RocksDB. It uses memory-mapped files and a B+Tree, which is a read-optimized data structure.
Still interesting to play with it.
- In-memory stuff should be [much faster](http://symas.com/mdb/inmem/), in particular reads. But apparently writes are pretty fast too; after all, very little overhead in this design.
- seeing how RocksDB performs against a competitor in our benchmarks should be fun.

What's not so great:
- Uses C-bindings - batches actually need to be locked to the OS thread, which means same or worse loss of cheap concurrency as with RocksDB on writes.
- writes are serialized through a Mutex - easy to deadlock (just try to create two batches in the same goroutine); would need careful design to actually go into production.
- No prefix scans or other gimmicks; a lot of stuff which we pushed down into C++ for RocksDB would need to be reimplemented (`Merge`, `MVCCComputeStats`).

This is not yet fit for usage since merges and stats computations have not been
hoisted up from the RocksDB C++ code yet (we pushed it down for performance at
some point).
The encoding used is quite inefficient, but can be improved once
bmatsuo/lmdb-go#61 lands. Some of the horrendous
allocation and performance numbers likely go back to the encoding.

What's less clear is how the single-threaded model of lmdb can most efficiently
be used with Cockroach. Essentially, mutations need to be serialized, and this
is done through a single mutex. Additionally, transactions need to be pinned
to a OS thread. The ideal usage would see one large environment per store, with
individual databases per Replica (on which writes are already serialized
anyway).

```
name                                   old time/op    new time/op     delta
MVCCScan10Versions1Row64Bytes-8          15.3µs ± 5%      8.0µs ± 4%      -47.85%  (p=0.000 n=10+10)
MVCCScan10Versions1Row512Bytes-8         19.0µs ± 7%     10.5µs ± 8%      -44.81%  (p=0.000 n=10+10)
MVCCScan10Versions10Rows8Bytes-8         42.9µs ± 9%     31.9µs ± 1%      -25.70%   (p=0.000 n=10+9)
MVCCScan10Versions10Rows64Bytes-8        53.2µs ± 3%     35.5µs ± 6%      -33.33%   (p=0.000 n=9+10)
MVCCScan10Versions10Rows512Bytes-8        112µs ± 4%       52µs ± 4%      -53.55%  (p=0.000 n=10+10)
MVCCScan10Versions100Rows8Bytes-8         324µs ± 4%      247µs ± 3%      -23.60%    (p=0.000 n=9+9)
MVCCScan10Versions100Rows64Bytes-8        390µs ± 2%      267µs ± 3%      -31.40%   (p=0.000 n=8+10)
MVCCScan10Versions100Rows512Bytes-8       922µs ± 4%      397µs ± 1%      -56.93%   (p=0.000 n=10+8)
MVCCScan10Versions1000Rows8Bytes-8       3.07ms ± 5%     2.20ms ± 1%      -28.35%   (p=0.000 n=9+10)
MVCCScan10Versions1000Rows64Bytes-8      3.70ms ± 4%     2.42ms ± 2%      -34.64%  (p=0.000 n=10+10)
MVCCScan10Versions1000Rows512Bytes-8     9.16ms ± 5%     3.82ms ± 2%      -58.23%  (p=0.000 n=10+10)
MVCCScan100Versions1Row512Bytes-8        53.1µs ± 5%    654.6µs ±13%    +1133.60%   (p=0.000 n=10+9)
MVCCScan100Versions10Rows512Bytes-8       297µs ± 3%     3500µs ± 5%    +1077.73%   (p=0.000 n=10+9)
MVCCScan100Versions100Rows512Bytes-8     2.65ms ± 6%    29.69ms ±20%    +1021.57%  (p=0.000 n=10+10)
MVCCScan100Versions1000Rows512Bytes-8    25.4ms ± 4%    279.7ms ±31%     +998.93%   (p=0.000 n=10+9)
MVCCGet1Version8Bytes-8                  18.9µs ± 4%      8.4µs ± 2%      -55.61%   (p=0.000 n=10+8)
MVCCGet10Versions8Bytes-8                27.3µs ± 3%      9.1µs ± 2%      -66.75%  (p=0.000 n=10+10)
MVCCGet100Versions8Bytes-8               42.6µs ± 6%      9.0µs ± 5%      -78.80%  (p=0.000 n=10+10)
MVCCPut10-8                              3.86µs ± 5%   189.90µs ± 8%    +4825.43%  (p=0.000 n=10+10)
MVCCPut100-8                             4.04µs ± 7%   221.56µs ± 3%    +5382.69%   (p=0.000 n=10+8)
MVCCPut1000-8                            6.25µs ± 8%   244.94µs ± 1%    +3822.07%   (p=0.000 n=10+7)
MVCCPut10000-8                           23.8µs ± 1%    235.9µs ± 5%     +890.75%   (p=0.000 n=9+10)
MVCCConditionalPutCreate10-8             3.84µs ± 1%   185.22µs ± 1%    +4724.86%   (p=0.000 n=10+9)
MVCCConditionalPutCreate100-8            4.00µs ± 2%   211.05µs ± 5%    +5178.60%  (p=0.000 n=10+10)
MVCCConditionalPutCreate1000-8           6.24µs ± 2%   250.95µs ± 4%    +3922.77%    (p=0.000 n=8+9)
MVCCConditionalPutCreate10000-8          24.0µs ± 1%    235.6µs ± 3%     +883.37%   (p=0.000 n=10+9)
MVCCConditionalPutReplace10-8            5.42µs ± 2%   229.03µs ± 3%    +4127.67%   (p=0.000 n=10+9)
MVCCConditionalPutReplace100-8           5.70µs ± 2%   220.28µs ± 2%    +3765.44%  (p=0.000 n=10+10)
MVCCConditionalPutReplace1000-8          10.5µs ± 2%    234.1µs ± 4%    +2124.64%   (p=0.000 n=10+9)
MVCCConditionalPutReplace10000-8         48.9µs ± 3%    264.1µs ± 7%     +439.54%  (p=0.000 n=10+10)
MVCCBatch1Put10-8                        5.53µs ±15%   180.55µs ± 3%    +3164.48%   (p=0.000 n=9+10)
MVCCBatch100Put10-8                      3.66µs ± 6%     7.09µs ± 2%      +93.64%  (p=0.000 n=10+10)
MVCCBatch10000Put10-8                    4.17µs ± 5%     3.97µs ± 1%       -4.79%   (p=0.001 n=10+8)
MVCCBatch100000Put10-8                   4.18µs ± 5%     3.81µs ± 9%       -8.76%  (p=0.000 n=10+10)
MVCCDeleteRange1Version8Bytes-8           110ms ± 1%     1917ms ± 3%    +1648.32%  (p=0.000 n=10+10)
MVCCDeleteRange1Version32Bytes-8         79.5ms ± 2%   1338.7ms ± 4%    +1583.62%   (p=0.000 n=9+10)
MVCCDeleteRange1Version256Bytes-8        24.0ms ± 6%    365.7ms ± 5%    +1423.25%    (p=0.000 n=9+9)

name                                   old speed      new speed       delta
MVCCScan10Versions1Row64Bytes-8        4.19MB/s ± 5%   8.03MB/s ± 4%      +91.62%  (p=0.000 n=10+10)
MVCCScan10Versions1Row512Bytes-8       27.0MB/s ± 6%   48.9MB/s ± 9%      +81.36%  (p=0.000 n=10+10)
MVCCScan10Versions10Rows8Bytes-8       1.87MB/s ± 8%   2.51MB/s ± 1%      +34.57%   (p=0.000 n=10+9)
MVCCScan10Versions10Rows64Bytes-8      12.0MB/s ± 4%   18.1MB/s ± 5%      +50.82%  (p=0.000 n=10+10)
MVCCScan10Versions10Rows512Bytes-8     45.9MB/s ± 4%   98.9MB/s ± 4%     +115.26%  (p=0.000 n=10+10)
MVCCScan10Versions100Rows8Bytes-8      2.47MB/s ± 3%   3.23MB/s ± 3%      +30.77%    (p=0.000 n=9+9)
MVCCScan10Versions100Rows64Bytes-8     16.4MB/s ± 2%   23.9MB/s ± 3%      +45.81%   (p=0.000 n=8+10)
MVCCScan10Versions100Rows512Bytes-8    55.6MB/s ± 4%  128.9MB/s ± 1%     +132.02%   (p=0.000 n=10+8)
MVCCScan10Versions1000Rows8Bytes-8     2.59MB/s ± 7%   3.64MB/s ± 1%      +40.59%  (p=0.000 n=10+10)
MVCCScan10Versions1000Rows64Bytes-8    17.3MB/s ± 4%   26.5MB/s ± 2%      +52.97%  (p=0.000 n=10+10)
MVCCScan10Versions1000Rows512Bytes-8   56.0MB/s ± 5%  133.9MB/s ± 2%     +139.24%  (p=0.000 n=10+10)
MVCCScan100Versions1Row512Bytes-8      9.65MB/s ± 5%   0.78MB/s ±15%      -91.88%   (p=0.000 n=10+9)
MVCCScan100Versions10Rows512Bytes-8    17.2MB/s ± 3%    1.5MB/s ± 5%      -91.49%   (p=0.000 n=10+9)
MVCCScan100Versions100Rows512Bytes-8   19.4MB/s ± 5%    1.7MB/s ±23%      -91.00%  (p=0.000 n=10+10)
MVCCScan100Versions1000Rows512Bytes-8  20.1MB/s ± 4%    1.9MB/s ±25%      -90.68%   (p=0.000 n=10+9)
MVCCGet1Version8Bytes-8                 422kB/s ± 4%    947kB/s ± 4%     +124.33%   (p=0.000 n=10+9)
MVCCGet10Versions8Bytes-8               294kB/s ± 5%    880kB/s ± 0%     +199.32%   (p=0.000 n=10+6)
MVCCGet100Versions8Bytes-8              187kB/s ± 4%    881kB/s ± 4%     +371.18%   (p=0.000 n=10+9)
MVCCPut10-8                            2.60MB/s ± 5%   0.05MB/s ± 0%      -98.07%   (p=0.000 n=10+9)
MVCCPut100-8                           24.8MB/s ± 7%    0.5MB/s ± 4%      -98.17%   (p=0.000 n=10+8)
MVCCPut1000-8                           160MB/s ± 8%      4MB/s ± 1%      -97.46%   (p=0.000 n=10+7)
MVCCPut10000-8                          420MB/s ± 1%     42MB/s ± 5%      -89.90%   (p=0.000 n=9+10)
MVCCConditionalPutCreate10-8           2.60MB/s ± 1%   0.05MB/s ± 0%      -98.08%   (p=0.000 n=10+9)
MVCCConditionalPutCreate100-8          25.0MB/s ± 2%    0.5MB/s ± 3%      -98.09%   (p=0.000 n=10+9)
MVCCConditionalPutCreate1000-8          160MB/s ± 2%      4MB/s ± 4%      -97.51%    (p=0.000 n=8+9)
MVCCConditionalPutCreate10000-8         417MB/s ± 1%     42MB/s ± 3%      -89.83%   (p=0.000 n=10+9)
MVCCConditionalPutReplace10-8          1.85MB/s ± 2%   0.04MB/s ± 0%      -97.83%  (p=0.000 n=10+10)
MVCCConditionalPutReplace100-8         17.5MB/s ± 2%    0.5MB/s ± 3%      -97.41%  (p=0.000 n=10+10)
MVCCConditionalPutReplace1000-8        95.0MB/s ± 2%    4.3MB/s ± 3%      -95.50%   (p=0.000 n=10+9)
MVCCConditionalPutReplace10000-8        204MB/s ± 3%     38MB/s ± 6%      -81.43%  (p=0.000 n=10+10)
MVCCBatch1Put10-8                      1.82MB/s ±14%   0.06MB/s ±11%      -96.92%   (p=0.000 n=9+10)
MVCCBatch100Put10-8                    2.74MB/s ± 6%   1.41MB/s ± 1%      -48.41%  (p=0.000 n=10+10)
MVCCBatch10000Put10-8                  2.40MB/s ± 5%   2.52MB/s ± 1%       +5.04%   (p=0.001 n=10+8)
MVCCBatch100000Put10-8                 2.40MB/s ± 5%   2.63MB/s ± 8%       +9.65%  (p=0.000 n=10+10)
MVCCDeleteRange1Version8Bytes-8        4.78MB/s ± 2%   0.28MB/s ± 2%      -94.25%  (p=0.000 n=10+10)
MVCCDeleteRange1Version32Bytes-8       6.59MB/s ± 2%   0.39MB/s ± 3%      -94.07%   (p=0.000 n=9+10)
MVCCDeleteRange1Version256Bytes-8      21.8MB/s ± 5%    1.4MB/s ± 4%      -93.43%    (p=0.000 n=9+9)

name                                   old alloc/op   new alloc/op    delta
MVCCScan10Versions1Row64Bytes-8            576B ± 0%      1124B ± 0%      +95.14%  (p=0.000 n=10+10)
MVCCScan10Versions1Row512Bytes-8         1.60kB ± 0%     2.87kB ± 0%      +79.10%  (p=0.000 n=10+10)
MVCCScan10Versions10Rows8Bytes-8         2.50kB ± 0%     4.31kB ± 0%      +72.40%   (p=0.000 n=10+8)
MVCCScan10Versions10Rows64Bytes-8        3.52kB ± 0%     6.26kB ± 0%      +77.72%  (p=0.000 n=10+10)
MVCCScan10Versions10Rows512Bytes-8       9.68kB ± 0%    19.61kB ± 0%     +102.65%  (p=0.000 n=10+10)
MVCCScan10Versions100Rows8Bytes-8        19.9kB ± 0%     35.3kB ± 0%      +77.19%   (p=0.000 n=9+10)
MVCCScan10Versions100Rows64Bytes-8       32.2kB ± 0%     56.9kB ± 0%      +76.59%  (p=0.000 n=10+10)
MVCCScan10Versions100Rows512Bytes-8      81.5kB ± 0%    178.3kB ± 0%     +118.85%  (p=0.000 n=10+10)
MVCCScan10Versions1000Rows8Bytes-8        164kB ± 0%      314kB ± 0%      +92.12%   (p=0.000 n=9+10)
MVCCScan10Versions1000Rows64Bytes-8       213kB ± 0%      458kB ± 1%     +115.23%   (p=0.000 n=10+9)
MVCCScan10Versions1000Rows512Bytes-8      672kB ± 0%     1632kB ± 2%     +142.78%  (p=0.000 n=10+10)
MVCCScan100Versions1Row512Bytes-8        1.60kB ± 0%     2.90kB ± 0%      +80.97%  (p=0.000 n=10+10)
MVCCScan100Versions10Rows512Bytes-8      9.68kB ± 0%    19.90kB ± 0%     +105.62%   (p=0.000 n=10+7)
MVCCScan100Versions100Rows512Bytes-8     81.5kB ± 0%    181.6kB ± 3%     +122.94%  (p=0.000 n=10+10)
MVCCScan100Versions1000Rows512Bytes-8     672kB ± 0%     1683kB ± 7%     +150.30%   (p=0.000 n=8+10)
MVCCGet1Version8Bytes-8                   64.0B ± 0%     464.0B ± 0%     +625.00%  (p=0.000 n=10+10)
MVCCGet10Versions8Bytes-8                 64.0B ± 0%     514.5B ± 0%     +703.91%  (p=0.000 n=10+10)
MVCCGet100Versions8Bytes-8                64.0B ± 0%     520.0B ± 0%     +712.50%  (p=0.000 n=10+10)
MVCCPut10-8                              0.00B ±NaN%    560.00B ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCPut100-8                             0.00B ±NaN%    560.00B ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCPut1000-8                            0.00B ±NaN%    560.00B ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCPut10000-8                           0.00B ±NaN%    560.00B ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCConditionalPutCreate10-8             0.00B ±NaN%    560.00B ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCConditionalPutCreate100-8            0.00B ±NaN%    560.00B ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCConditionalPutCreate1000-8           0.00B ±NaN%    560.00B ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCConditionalPutCreate10000-8          0.00B ±NaN%    560.00B ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCConditionalPutReplace10-8             16.0B ± 0%     584.0B ± 0%    +3550.00%  (p=0.000 n=10+10)
MVCCConditionalPutReplace100-8             112B ± 0%       777B ± 0%     +593.75%  (p=0.000 n=10+10)
MVCCConditionalPutReplace1000-8          1.02kB ± 0%     2.60kB ± 0%     +153.89%  (p=0.000 n=10+10)
MVCCConditionalPutReplace10000-8         10.5kB ± 0%     21.6kB ± 0%     +105.17%   (p=0.000 n=8+10)
MVCCBatch1Put10-8                         48.0B ± 0%     488.0B ± 0%     +916.67%  (p=0.000 n=10+10)
MVCCBatch100Put10-8                      0.00B ±NaN%    337.00B ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCBatch10000Put10-8                    0.00B ±NaN%    336.00B ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCBatch100000Put10-8                   0.00B ±NaN%    336.00B ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCDeleteRange1Version8Bytes-8           214kB ± 0%     3743kB ± 0%    +1645.87%  (p=0.000 n=10+10)
MVCCDeleteRange1Version32Bytes-8          312kB ± 0%     3204kB ± 0%     +925.76%  (p=0.000 n=10+10)
MVCCDeleteRange1Version256Bytes-8         476kB ± 0%     2066kB ± 0%     +333.60%    (p=0.000 n=9+9)

name                                   old allocs/op  new allocs/op   delta
MVCCScan10Versions1Row64Bytes-8            2.00 ± 0%      20.00 ± 0%     +900.00%  (p=0.000 n=10+10)
MVCCScan10Versions1Row512Bytes-8           3.00 ± 0%      21.00 ± 0%     +600.00%  (p=0.000 n=10+10)
MVCCScan10Versions10Rows8Bytes-8           6.00 ± 0%      89.00 ± 0%    +1383.33%  (p=0.000 n=10+10)
MVCCScan10Versions10Rows64Bytes-8          7.00 ± 0%      90.00 ± 0%    +1185.71%  (p=0.000 n=10+10)
MVCCScan10Versions10Rows512Bytes-8         9.00 ± 0%      92.00 ± 0%     +922.22%  (p=0.000 n=10+10)
MVCCScan10Versions100Rows8Bytes-8          11.0 ± 0%      747.1 ± 1%    +6691.82%  (p=0.000 n=10+10)
MVCCScan10Versions100Rows64Bytes-8         13.0 ± 0%      749.5 ± 0%    +5665.38%  (p=0.000 n=10+10)
MVCCScan10Versions100Rows512Bytes-8        16.7 ± 4%      754.8 ± 0%    +4419.76%  (p=0.000 n=10+10)
MVCCScan10Versions1000Rows8Bytes-8         18.4 ± 3%     7254.4 ± 1%   +39326.09%  (p=0.000 n=10+10)
MVCCScan10Versions1000Rows64Bytes-8        22.0 ± 0%     7318.1 ± 1%   +33164.14%   (p=0.000 n=10+9)
MVCCScan10Versions1000Rows512Bytes-8       57.0 ± 0%     7300.3 ± 3%   +12707.54%  (p=0.000 n=10+10)
MVCCScan100Versions1Row512Bytes-8          3.00 ± 0%      21.00 ± 0%     +600.00%  (p=0.000 n=10+10)
MVCCScan100Versions10Rows512Bytes-8        9.00 ± 0%      94.40 ± 2%     +948.89%  (p=0.000 n=10+10)
MVCCScan100Versions100Rows512Bytes-8       16.3 ± 4%      779.7 ± 5%    +4683.44%  (p=0.000 n=10+10)
MVCCScan100Versions1000Rows512Bytes-8      56.5 ± 1%     7680.7 ±12%   +13494.16%  (p=0.000 n=10+10)
MVCCGet1Version8Bytes-8                    2.00 ± 0%      18.00 ± 0%     +800.00%  (p=0.000 n=10+10)
MVCCGet10Versions8Bytes-8                  2.00 ± 0%      20.00 ± 0%     +900.00%  (p=0.000 n=10+10)
MVCCGet100Versions8Bytes-8                 2.00 ± 0%      20.00 ± 0%     +900.00%  (p=0.000 n=10+10)
MVCCPut10-8                               0.00 ±NaN%      25.00 ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCPut100-8                              0.00 ±NaN%      25.00 ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCPut1000-8                             0.00 ±NaN%      25.00 ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCPut10000-8                            0.00 ±NaN%      25.00 ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCConditionalPutCreate10-8              0.00 ±NaN%      25.00 ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCConditionalPutCreate100-8             0.00 ±NaN%      25.00 ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCConditionalPutCreate1000-8            0.00 ±NaN%      25.00 ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCConditionalPutCreate10000-8           0.00 ±NaN%      25.00 ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCConditionalPutReplace10-8              1.00 ± 0%      26.00 ± 0%    +2500.00%  (p=0.000 n=10+10)
MVCCConditionalPutReplace100-8             1.00 ± 0%      26.00 ± 0%    +2500.00%  (p=0.000 n=10+10)
MVCCConditionalPutReplace1000-8            1.00 ± 0%      26.00 ± 0%    +2500.00%  (p=0.000 n=10+10)
MVCCConditionalPutReplace10000-8           1.00 ± 0%      26.00 ± 0%    +2500.00%  (p=0.000 n=10+10)
MVCCBatch1Put10-8                          1.00 ± 0%      20.00 ± 0%    +1900.00%  (p=0.000 n=10+10)
MVCCBatch100Put10-8                       0.00 ±NaN%      13.00 ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCBatch10000Put10-8                     0.00 ±NaN%      13.00 ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCBatch100000Put10-8                    0.00 ±NaN%      13.00 ± 0%        +Inf%  (p=0.000 n=10+10)
MVCCDeleteRange1Version8Bytes-8            20.0 ± 0%   187328.3 ± 0%  +936541.50%  (p=0.000 n=10+10)
MVCCDeleteRange1Version32Bytes-8           26.0 ± 0%   131152.9 ± 0%  +504334.23%  (p=0.000 n=10+10)
MVCCDeleteRange1Version256Bytes-8          39.8 ± 3%    34567.6 ± 0%   +86753.27%  (p=0.000 n=10+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5220)

<!-- Reviewable:end -->
