### PR TITLE
storage: Close replicaConsistencyQueue from the stopper's closer

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -608,6 +608,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 		s.replicateQueue.Close()
 		s.replicaGCQueue.Close()
 		s.raftLogQueue.Close()
+		s.replicaConsistencyQueue.Close()
 	}))
 
 	if s.Ident.NodeID == 0 {


### PR DESCRIPTION
Close `replicaConsistencyQueue` as we do for other queues.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5226)

<!-- Reviewable:end -->
