### PR TITLE
Remove Timestamp from (individual) ResponseHeader

### DIFF
--- a/client/sender.go
+++ b/client/sender.go
@@ -59,6 +59,8 @@ func SendWrappedWith(sender Sender, ctx context.Context, h roachpb.Header, args 
 }
 
 // SendWrapped is identical to SendWrappedAt with a zero header.
+// TODO(tschottdorf): should move this to testutils and merge with other helpers
+// which are used, for example, in `storage`.
 func SendWrapped(sender Sender, ctx context.Context, args roachpb.Request) (roachpb.Response, *roachpb.Error) {
 	return SendWrappedWith(sender, ctx, roachpb.Header{}, args)
 }

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -33,7 +33,7 @@ import (
 var (
 	testKey     = roachpb.Key("a")
 	testTS      = roachpb.Timestamp{WallTime: 1, Logical: 1}
-	testPutResp = &roachpb.PutResponse{ResponseHeader: roachpb.ResponseHeader{Timestamp: testTS}}
+	testPutResp = &roachpb.PutResponse{}
 )
 
 func newDB(sender Sender) *DB {

--- a/roachpb/api.go
+++ b/roachpb/api.go
@@ -132,9 +132,6 @@ type combinable interface {
 // to merge their headers.
 func (rh *ResponseHeader) combine(otherRH *ResponseHeader) error {
 	if rh != nil && otherRH != nil {
-		if ts := otherRH.Timestamp; rh.Timestamp.Less(ts) {
-			rh.Timestamp = ts
-		}
 		if rh.Txn != nil && otherRH.Txn == nil {
 			rh.Txn = nil
 		}

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -237,14 +237,6 @@ func (x *PushTxnType) UnmarshalJSON(data []byte) error {
 
 // ResponseHeader is returned with every storage node response.
 type ResponseHeader struct {
-	// timestamp specifies time at which read or write actually was
-	// performed. In the case of both reads and writes, if the timestamp
-	// supplied to the request was 0, the wall time of the node
-	// servicing the request will be set here. Additionally, in the case
-	// of writes, this value may be increased from the timestamp passed
-	// with the Span if the key being written was either read
-	// or written more recently.
-	Timestamp Timestamp `protobuf:"bytes,2,opt,name=timestamp" json:"timestamp"`
 	// txn is non-nil if the request specified a non-nil transaction.
 	// The transaction timestamp and/or priority may have been updated,
 	// depending on the outcome of the request.
@@ -1090,6 +1082,10 @@ func (*BatchResponse) ProtoMessage() {}
 type BatchResponse_Header struct {
 	// error is non-nil if an error occurred.
 	Error *Error `protobuf:"bytes,1,opt,name=error" json:"error,omitempty"`
+	// timestamp is set only for non-transactional responses and denotes the
+	// highest timestamp at which a command from the batch executed. At the
+	// time of writing, it is used solely for informational purposes and tests.
+	Timestamp Timestamp `protobuf:"bytes,2,opt,name=Timestamp" json:"Timestamp"`
 	// txn is non-nil if the request specified a non-nil
 	// transaction. The transaction timestamp and/or priority may have
 	// been updated, depending on the outcome of the request.
@@ -1299,23 +1295,15 @@ func (m *ResponseHeader) MarshalTo(data []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n1, err := m.Timestamp.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n2, err := m.Txn.MarshalTo(data[i:])
+		n1, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n2
+		i += n1
 	}
 	return i, nil
 }
@@ -1338,11 +1326,11 @@ func (m *GetRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n3, err := m.Span.MarshalTo(data[i:])
+	n2, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n3
+	i += n2
 	return i, nil
 }
 
@@ -1364,20 +1352,20 @@ func (m *GetResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n4, err := m.ResponseHeader.MarshalTo(data[i:])
+	n3, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n4
+	i += n3
 	if m.Value != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-		n5, err := m.Value.MarshalTo(data[i:])
+		n4, err := m.Value.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n5
+		i += n4
 	}
 	return i, nil
 }
@@ -1400,19 +1388,19 @@ func (m *PutRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n6, err := m.Span.MarshalTo(data[i:])
+	n5, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n5
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n6, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n6
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n7, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n7
 	return i, nil
 }
 
@@ -1434,11 +1422,11 @@ func (m *PutResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n8, err := m.ResponseHeader.MarshalTo(data[i:])
+	n7, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n8
+	i += n7
 	return i, nil
 }
 
@@ -1460,28 +1448,28 @@ func (m *ConditionalPutRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n9, err := m.Span.MarshalTo(data[i:])
+	n8, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n8
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n9, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n9
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n10, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n10
 	if m.ExpValue != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ExpValue.Size()))
-		n11, err := m.ExpValue.MarshalTo(data[i:])
+		n10, err := m.ExpValue.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n11
+		i += n10
 	}
 	return i, nil
 }
@@ -1504,11 +1492,11 @@ func (m *ConditionalPutResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n12, err := m.ResponseHeader.MarshalTo(data[i:])
+	n11, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n12
+	i += n11
 	return i, nil
 }
 
@@ -1530,11 +1518,11 @@ func (m *IncrementRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n13, err := m.Span.MarshalTo(data[i:])
+	n12, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n13
+	i += n12
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Increment))
@@ -1559,11 +1547,11 @@ func (m *IncrementResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n14, err := m.ResponseHeader.MarshalTo(data[i:])
+	n13, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n14
+	i += n13
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.NewValue))
@@ -1588,11 +1576,11 @@ func (m *DeleteRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n15, err := m.Span.MarshalTo(data[i:])
+	n14, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n15
+	i += n14
 	return i, nil
 }
 
@@ -1614,11 +1602,11 @@ func (m *DeleteResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n16, err := m.ResponseHeader.MarshalTo(data[i:])
+	n15, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n16
+	i += n15
 	return i, nil
 }
 
@@ -1640,11 +1628,11 @@ func (m *DeleteRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n17, err := m.Span.MarshalTo(data[i:])
+	n16, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n17
+	i += n16
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxEntriesToDelete))
@@ -1677,11 +1665,11 @@ func (m *DeleteRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n18, err := m.ResponseHeader.MarshalTo(data[i:])
+	n17, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n18
+	i += n17
 	if len(m.Keys) > 0 {
 		for _, b := range m.Keys {
 			data[i] = 0x12
@@ -1711,11 +1699,11 @@ func (m *ScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n19, err := m.Span.MarshalTo(data[i:])
+	n18, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n19
+	i += n18
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -1740,11 +1728,11 @@ func (m *ScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n20, err := m.ResponseHeader.MarshalTo(data[i:])
+	n19, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n20
+	i += n19
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -1778,11 +1766,11 @@ func (m *ReverseScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n21, err := m.Span.MarshalTo(data[i:])
+	n20, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n21
+	i += n20
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -1807,11 +1795,11 @@ func (m *ReverseScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n22, err := m.ResponseHeader.MarshalTo(data[i:])
+	n21, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n22
+	i += n21
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -1845,11 +1833,11 @@ func (m *CheckConsistencyRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n23, err := m.Span.MarshalTo(data[i:])
+	n22, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n22
 	return i, nil
 }
 
@@ -1871,11 +1859,11 @@ func (m *CheckConsistencyResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n24, err := m.ResponseHeader.MarshalTo(data[i:])
+	n23, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n24
+	i += n23
 	return i, nil
 }
 
@@ -1897,11 +1885,11 @@ func (m *BeginTransactionRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n25, err := m.Span.MarshalTo(data[i:])
+	n24, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n25
+	i += n24
 	return i, nil
 }
 
@@ -1923,11 +1911,11 @@ func (m *BeginTransactionResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n26, err := m.ResponseHeader.MarshalTo(data[i:])
+	n25, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n26
+	i += n25
 	return i, nil
 }
 
@@ -1949,11 +1937,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n27, err := m.Span.MarshalTo(data[i:])
+	n26, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n27
+	i += n26
 	data[i] = 0x10
 	i++
 	if m.Commit {
@@ -1966,21 +1954,21 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Deadline.Size()))
-		n28, err := m.Deadline.MarshalTo(data[i:])
+		n27, err := m.Deadline.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n28
+		i += n27
 	}
 	if m.InternalCommitTrigger != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.InternalCommitTrigger.Size()))
-		n29, err := m.InternalCommitTrigger.MarshalTo(data[i:])
+		n28, err := m.InternalCommitTrigger.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n29
+		i += n28
 	}
 	if len(m.IntentSpans) > 0 {
 		for _, msg := range m.IntentSpans {
@@ -2015,11 +2003,11 @@ func (m *EndTransactionResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n30, err := m.ResponseHeader.MarshalTo(data[i:])
+	n29, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n30
+	i += n29
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.CommitWait))
@@ -2052,11 +2040,11 @@ func (m *AdminSplitRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n31, err := m.Span.MarshalTo(data[i:])
+	n30, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n31
+	i += n30
 	if m.SplitKey != nil {
 		data[i] = 0x12
 		i++
@@ -2084,11 +2072,11 @@ func (m *AdminSplitResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n32, err := m.ResponseHeader.MarshalTo(data[i:])
+	n31, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n32
+	i += n31
 	return i, nil
 }
 
@@ -2110,11 +2098,11 @@ func (m *AdminMergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n33, err := m.Span.MarshalTo(data[i:])
+	n32, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n33
+	i += n32
 	return i, nil
 }
 
@@ -2136,11 +2124,11 @@ func (m *AdminMergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n34, err := m.ResponseHeader.MarshalTo(data[i:])
+	n33, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n34
+	i += n33
 	return i, nil
 }
 
@@ -2162,11 +2150,11 @@ func (m *RangeLookupRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n35, err := m.Span.MarshalTo(data[i:])
+	n34, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n35
+	i += n34
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxRanges))
@@ -2207,11 +2195,11 @@ func (m *RangeLookupResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n36, err := m.ResponseHeader.MarshalTo(data[i:])
+	n35, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n36
+	i += n35
 	if len(m.Ranges) > 0 {
 		for _, msg := range m.Ranges {
 			data[i] = 0x12
@@ -2245,19 +2233,19 @@ func (m *HeartbeatTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n37, err := m.Span.MarshalTo(data[i:])
+	n36, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n36
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
+	n37, err := m.Now.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n37
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n38, err := m.Now.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n38
 	return i, nil
 }
 
@@ -2279,11 +2267,11 @@ func (m *HeartbeatTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n39, err := m.ResponseHeader.MarshalTo(data[i:])
+	n38, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n39
+	i += n38
 	return i, nil
 }
 
@@ -2305,11 +2293,11 @@ func (m *GCRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n40, err := m.Span.MarshalTo(data[i:])
+	n39, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n40
+	i += n39
 	if len(m.Keys) > 0 {
 		for _, msg := range m.Keys {
 			data[i] = 0x1a
@@ -2349,11 +2337,11 @@ func (m *GCRequest_GCKey) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n41, err := m.Timestamp.MarshalTo(data[i:])
+	n40, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n41
+	i += n40
 	return i, nil
 }
 
@@ -2375,11 +2363,11 @@ func (m *GCResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n42, err := m.ResponseHeader.MarshalTo(data[i:])
+	n41, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n42
+	i += n41
 	return i, nil
 }
 
@@ -2401,43 +2389,43 @@ func (m *PushTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n43, err := m.Span.MarshalTo(data[i:])
+	n42, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n42
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
+	n43, err := m.PusherTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n43
-	data[i] = 0x12
+	data[i] = 0x1a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
-	n44, err := m.PusherTxn.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
+	n44, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n44
-	data[i] = 0x1a
+	data[i] = 0x22
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-	n45, err := m.PusheeTxn.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
+	n45, err := m.PushTo.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n45
-	data[i] = 0x22
+	data[i] = 0x2a
 	i++
-	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
-	n46, err := m.PushTo.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
+	n46, err := m.Now.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n46
-	data[i] = 0x2a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n47, err := m.Now.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n47
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.PushType))
@@ -2462,19 +2450,19 @@ func (m *PushTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n48, err := m.ResponseHeader.MarshalTo(data[i:])
+	n47, err := m.ResponseHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n47
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
+	n48, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n48
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-	n49, err := m.PusheeTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n49
 	return i, nil
 }
 
@@ -2496,19 +2484,19 @@ func (m *ResolveIntentRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n50, err := m.Span.MarshalTo(data[i:])
+	n49, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n49
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
+	n50, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n50
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n51, err := m.IntentTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n51
 	data[i] = 0x18
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Status))
@@ -2541,11 +2529,11 @@ func (m *ResolveIntentResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n52, err := m.ResponseHeader.MarshalTo(data[i:])
+	n51, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n52
+	i += n51
 	return i, nil
 }
 
@@ -2567,19 +2555,19 @@ func (m *ResolveIntentRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n53, err := m.Span.MarshalTo(data[i:])
+	n52, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n52
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
+	n53, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n53
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n54, err := m.IntentTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n54
 	data[i] = 0x18
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Status))
@@ -2612,11 +2600,11 @@ func (m *NoopResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n55, err := m.ResponseHeader.MarshalTo(data[i:])
+	n54, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n55
+	i += n54
 	return i, nil
 }
 
@@ -2638,11 +2626,11 @@ func (m *NoopRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n56, err := m.Span.MarshalTo(data[i:])
+	n55, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n56
+	i += n55
 	return i, nil
 }
 
@@ -2664,11 +2652,11 @@ func (m *ResolveIntentRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n57, err := m.ResponseHeader.MarshalTo(data[i:])
+	n56, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n57
+	i += n56
 	return i, nil
 }
 
@@ -2690,19 +2678,19 @@ func (m *MergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n58, err := m.Span.MarshalTo(data[i:])
+	n57, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n57
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n58, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n58
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n59, err := m.Value.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n59
 	return i, nil
 }
 
@@ -2724,11 +2712,11 @@ func (m *MergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n60, err := m.ResponseHeader.MarshalTo(data[i:])
+	n59, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n60
+	i += n59
 	return i, nil
 }
 
@@ -2750,11 +2738,11 @@ func (m *TruncateLogRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n61, err := m.Span.MarshalTo(data[i:])
+	n60, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n61
+	i += n60
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Index))
@@ -2782,11 +2770,11 @@ func (m *TruncateLogResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n62, err := m.ResponseHeader.MarshalTo(data[i:])
+	n61, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n62
+	i += n61
 	return i, nil
 }
 
@@ -2808,19 +2796,19 @@ func (m *LeaderLeaseRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n63, err := m.Span.MarshalTo(data[i:])
+	n62, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n62
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
+	n63, err := m.Lease.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n63
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
-	n64, err := m.Lease.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n64
 	return i, nil
 }
 
@@ -2842,11 +2830,11 @@ func (m *LeaderLeaseResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n65, err := m.ResponseHeader.MarshalTo(data[i:])
+	n64, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n65
+	i += n64
 	return i, nil
 }
 
@@ -2868,22 +2856,22 @@ func (m *ComputeChecksumRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n66, err := m.Span.MarshalTo(data[i:])
+	n65, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n66
+	i += n65
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Version))
 	data[i] = 0x1a
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ChecksumID.Size()))
-	n67, err := m.ChecksumID.MarshalTo(data[i:])
+	n66, err := m.ChecksumID.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n67
+	i += n66
 	return i, nil
 }
 
@@ -2905,11 +2893,11 @@ func (m *ComputeChecksumResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n68, err := m.ResponseHeader.MarshalTo(data[i:])
+	n67, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n68
+	i += n67
 	return i, nil
 }
 
@@ -2931,22 +2919,22 @@ func (m *VerifyChecksumRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n69, err := m.Span.MarshalTo(data[i:])
+	n68, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n69
+	i += n68
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Version))
 	data[i] = 0x1a
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ChecksumID.Size()))
-	n70, err := m.ChecksumID.MarshalTo(data[i:])
+	n69, err := m.ChecksumID.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n70
+	i += n69
 	if m.Checksum != nil {
 		data[i] = 0x22
 		i++
@@ -2974,11 +2962,11 @@ func (m *VerifyChecksumResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n71, err := m.ResponseHeader.MarshalTo(data[i:])
+	n70, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n71
+	i += n70
 	return i, nil
 }
 
@@ -3001,151 +2989,151 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n72, err := m.Get.MarshalTo(data[i:])
+		n71, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n72
+		i += n71
 	}
 	if m.Put != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n73, err := m.Put.MarshalTo(data[i:])
+		n72, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n73
+		i += n72
 	}
 	if m.ConditionalPut != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n74, err := m.ConditionalPut.MarshalTo(data[i:])
+		n73, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n74
+		i += n73
 	}
 	if m.Increment != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n75, err := m.Increment.MarshalTo(data[i:])
+		n74, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n75
+		i += n74
 	}
 	if m.Delete != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n76, err := m.Delete.MarshalTo(data[i:])
+		n75, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n76
+		i += n75
 	}
 	if m.DeleteRange != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n77, err := m.DeleteRange.MarshalTo(data[i:])
+		n76, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n77
+		i += n76
 	}
 	if m.Scan != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n78, err := m.Scan.MarshalTo(data[i:])
+		n77, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n78
+		i += n77
 	}
 	if m.BeginTransaction != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
-		n79, err := m.BeginTransaction.MarshalTo(data[i:])
+		n78, err := m.BeginTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n79
+		i += n78
 	}
 	if m.EndTransaction != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n80, err := m.EndTransaction.MarshalTo(data[i:])
+		n79, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n80
+		i += n79
 	}
 	if m.AdminSplit != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n81, err := m.AdminSplit.MarshalTo(data[i:])
+		n80, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n81
+		i += n80
 	}
 	if m.AdminMerge != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n82, err := m.AdminMerge.MarshalTo(data[i:])
+		n81, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n82
+		i += n81
 	}
 	if m.HeartbeatTxn != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n83, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		n82, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n83
+		i += n82
 	}
 	if m.Gc != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n84, err := m.Gc.MarshalTo(data[i:])
+		n83, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n84
+		i += n83
 	}
 	if m.PushTxn != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n85, err := m.PushTxn.MarshalTo(data[i:])
+		n84, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n85
+		i += n84
 	}
 	if m.RangeLookup != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n86, err := m.RangeLookup.MarshalTo(data[i:])
+		n85, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n86
+		i += n85
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x82
@@ -3153,11 +3141,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n87, err := m.ResolveIntent.MarshalTo(data[i:])
+		n86, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n87
+		i += n86
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x8a
@@ -3165,11 +3153,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n88, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n87, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n88
+		i += n87
 	}
 	if m.Merge != nil {
 		data[i] = 0x92
@@ -3177,11 +3165,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n89, err := m.Merge.MarshalTo(data[i:])
+		n88, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n89
+		i += n88
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x9a
@@ -3189,11 +3177,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n90, err := m.TruncateLog.MarshalTo(data[i:])
+		n89, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n90
+		i += n89
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0xa2
@@ -3201,11 +3189,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n91, err := m.LeaderLease.MarshalTo(data[i:])
+		n90, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n91
+		i += n90
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xaa
@@ -3213,11 +3201,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n92, err := m.ReverseScan.MarshalTo(data[i:])
+		n91, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n92
+		i += n91
 	}
 	if m.ComputeChecksum != nil {
 		data[i] = 0xb2
@@ -3225,11 +3213,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ComputeChecksum.Size()))
-		n93, err := m.ComputeChecksum.MarshalTo(data[i:])
+		n92, err := m.ComputeChecksum.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n93
+		i += n92
 	}
 	if m.VerifyChecksum != nil {
 		data[i] = 0xba
@@ -3237,11 +3225,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.VerifyChecksum.Size()))
-		n94, err := m.VerifyChecksum.MarshalTo(data[i:])
+		n93, err := m.VerifyChecksum.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n94
+		i += n93
 	}
 	if m.CheckConsistency != nil {
 		data[i] = 0xc2
@@ -3249,11 +3237,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.CheckConsistency.Size()))
-		n95, err := m.CheckConsistency.MarshalTo(data[i:])
+		n94, err := m.CheckConsistency.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n95
+		i += n94
 	}
 	if m.Noop != nil {
 		data[i] = 0xca
@@ -3261,11 +3249,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n96, err := m.Noop.MarshalTo(data[i:])
+		n95, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n96
+		i += n95
 	}
 	return i, nil
 }
@@ -3289,151 +3277,151 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n97, err := m.Get.MarshalTo(data[i:])
+		n96, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n97
+		i += n96
 	}
 	if m.Put != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n98, err := m.Put.MarshalTo(data[i:])
+		n97, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n98
+		i += n97
 	}
 	if m.ConditionalPut != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n99, err := m.ConditionalPut.MarshalTo(data[i:])
+		n98, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n99
+		i += n98
 	}
 	if m.Increment != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n100, err := m.Increment.MarshalTo(data[i:])
+		n99, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n100
+		i += n99
 	}
 	if m.Delete != nil {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n101, err := m.Delete.MarshalTo(data[i:])
+		n100, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n101
+		i += n100
 	}
 	if m.DeleteRange != nil {
 		data[i] = 0x32
 		i++
 		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n102, err := m.DeleteRange.MarshalTo(data[i:])
+		n101, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n102
+		i += n101
 	}
 	if m.Scan != nil {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n103, err := m.Scan.MarshalTo(data[i:])
+		n102, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n103
+		i += n102
 	}
 	if m.BeginTransaction != nil {
 		data[i] = 0x42
 		i++
 		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
-		n104, err := m.BeginTransaction.MarshalTo(data[i:])
+		n103, err := m.BeginTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n104
+		i += n103
 	}
 	if m.EndTransaction != nil {
 		data[i] = 0x4a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n105, err := m.EndTransaction.MarshalTo(data[i:])
+		n104, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n105
+		i += n104
 	}
 	if m.AdminSplit != nil {
 		data[i] = 0x52
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n106, err := m.AdminSplit.MarshalTo(data[i:])
+		n105, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n106
+		i += n105
 	}
 	if m.AdminMerge != nil {
 		data[i] = 0x5a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n107, err := m.AdminMerge.MarshalTo(data[i:])
+		n106, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n107
+		i += n106
 	}
 	if m.HeartbeatTxn != nil {
 		data[i] = 0x62
 		i++
 		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n108, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		n107, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n108
+		i += n107
 	}
 	if m.Gc != nil {
 		data[i] = 0x6a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n109, err := m.Gc.MarshalTo(data[i:])
+		n108, err := m.Gc.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n109
+		i += n108
 	}
 	if m.PushTxn != nil {
 		data[i] = 0x72
 		i++
 		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n110, err := m.PushTxn.MarshalTo(data[i:])
+		n109, err := m.PushTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n110
+		i += n109
 	}
 	if m.RangeLookup != nil {
 		data[i] = 0x7a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n111, err := m.RangeLookup.MarshalTo(data[i:])
+		n110, err := m.RangeLookup.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n111
+		i += n110
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x82
@@ -3441,11 +3429,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n112, err := m.ResolveIntent.MarshalTo(data[i:])
+		n111, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n112
+		i += n111
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x8a
@@ -3453,11 +3441,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n113, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n112, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n113
+		i += n112
 	}
 	if m.Merge != nil {
 		data[i] = 0x92
@@ -3465,11 +3453,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n114, err := m.Merge.MarshalTo(data[i:])
+		n113, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n114
+		i += n113
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x9a
@@ -3477,11 +3465,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n115, err := m.TruncateLog.MarshalTo(data[i:])
+		n114, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n115
+		i += n114
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0xa2
@@ -3489,11 +3477,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n116, err := m.LeaderLease.MarshalTo(data[i:])
+		n115, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n116
+		i += n115
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xaa
@@ -3501,11 +3489,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n117, err := m.ReverseScan.MarshalTo(data[i:])
+		n116, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n117
+		i += n116
 	}
 	if m.ComputeChecksum != nil {
 		data[i] = 0xb2
@@ -3513,11 +3501,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ComputeChecksum.Size()))
-		n118, err := m.ComputeChecksum.MarshalTo(data[i:])
+		n117, err := m.ComputeChecksum.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n118
+		i += n117
 	}
 	if m.VerifyChecksum != nil {
 		data[i] = 0xba
@@ -3525,11 +3513,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.VerifyChecksum.Size()))
-		n119, err := m.VerifyChecksum.MarshalTo(data[i:])
+		n118, err := m.VerifyChecksum.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n119
+		i += n118
 	}
 	if m.CheckConsistency != nil {
 		data[i] = 0xc2
@@ -3537,11 +3525,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.CheckConsistency.Size()))
-		n120, err := m.CheckConsistency.MarshalTo(data[i:])
+		n119, err := m.CheckConsistency.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n120
+		i += n119
 	}
 	if m.Noop != nil {
 		data[i] = 0xca
@@ -3549,11 +3537,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n121, err := m.Noop.MarshalTo(data[i:])
+		n120, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n121
+		i += n120
 	}
 	return i, nil
 }
@@ -3576,19 +3564,19 @@ func (m *Header) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n122, err := m.Timestamp.MarshalTo(data[i:])
+	n121, err := m.Timestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n121
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
+	n122, err := m.Replica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n122
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
-	n123, err := m.Replica.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n123
 	data[i] = 0x18
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RangeID))
@@ -3599,11 +3587,11 @@ func (m *Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n124, err := m.Txn.MarshalTo(data[i:])
+		n123, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n124
+		i += n123
 	}
 	data[i] = 0x30
 	i++
@@ -3612,11 +3600,11 @@ func (m *Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Trace.Size()))
-		n125, err := m.Trace.MarshalTo(data[i:])
+		n124, err := m.Trace.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n125
+		i += n124
 	}
 	data[i] = 0x40
 	i++
@@ -3642,11 +3630,11 @@ func (m *BatchRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Header.Size()))
-	n126, err := m.Header.MarshalTo(data[i:])
+	n125, err := m.Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n126
+	i += n125
 	if len(m.Requests) > 0 {
 		for _, msg := range m.Requests {
 			data[i] = 0x12
@@ -3680,11 +3668,11 @@ func (m *BatchResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchResponse_Header.Size()))
-	n127, err := m.BatchResponse_Header.MarshalTo(data[i:])
+	n126, err := m.BatchResponse_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n127
+	i += n126
 	if len(m.Responses) > 0 {
 		for _, msg := range m.Responses {
 			data[i] = 0x12
@@ -3719,12 +3707,20 @@ func (m *BatchResponse_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Error.Size()))
-		n128, err := m.Error.MarshalTo(data[i:])
+		n127, err := m.Error.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n128
+		i += n127
 	}
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
+	n128, err := m.Timestamp.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n128
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
@@ -3776,8 +3772,6 @@ func encodeVarintApi(data []byte, offset int, v uint64) int {
 func (m *ResponseHeader) Size() (n int) {
 	var l int
 	_ = l
-	l = m.Timestamp.Size()
-	n += 1 + l + sovApi(uint64(l))
 	if m.Txn != nil {
 		l = m.Txn.Size()
 		n += 1 + l + sovApi(uint64(l))
@@ -4580,6 +4574,8 @@ func (m *BatchResponse_Header) Size() (n int) {
 		l = m.Error.Size()
 		n += 1 + l + sovApi(uint64(l))
 	}
+	l = m.Timestamp.Size()
+	n += 1 + l + sovApi(uint64(l))
 	if m.Txn != nil {
 		l = m.Txn.Size()
 		n += 1 + l + sovApi(uint64(l))
@@ -4907,36 +4903,6 @@ func (m *ResponseHeader) Unmarshal(data []byte) error {
 			return fmt.Errorf("proto: ResponseHeader: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowApi
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthApi
-			}
-			postIndex := iNdEx + msglen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.Timestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Txn", wireType)
@@ -12597,6 +12563,36 @@ func (m *BatchResponse_Header) Unmarshal(data []byte) error {
 				m.Error = &Error{}
 			}
 			if err := m.Error.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Timestamp.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -45,14 +45,6 @@ enum ReadConsistencyType {
 
 // ResponseHeader is returned with every storage node response.
 message ResponseHeader {
-  // timestamp specifies time at which read or write actually was
-  // performed. In the case of both reads and writes, if the timestamp
-  // supplied to the request was 0, the wall time of the node
-  // servicing the request will be set here. Additionally, in the case
-  // of writes, this value may be increased from the timestamp passed
-  // with the Span if the key being written was either read
-  // or written more recently.
-  optional Timestamp timestamp = 2 [(gogoproto.nullable) = false];
   // txn is non-nil if the request specified a non-nil transaction.
   // The transaction timestamp and/or priority may have been updated,
   // depending on the outcome of the request.
@@ -699,6 +691,10 @@ message BatchResponse {
   message Header {
     // error is non-nil if an error occurred.
     optional Error error = 1;
+    // timestamp is set only for non-transactional responses and denotes the
+    // highest timestamp at which a command from the batch executed. At the
+    // time of writing, it is used solely for informational purposes and tests.
+    optional Timestamp Timestamp = 2 [(gogoproto.nullable) = false];
     // txn is non-nil if the request specified a non-nil
     // transaction. The transaction timestamp and/or priority may have
     // been updated, depending on the outcome of the request.

--- a/roachpb/api_test.go
+++ b/roachpb/api_test.go
@@ -31,7 +31,6 @@ func TestCombinable(t *testing.T) {
 	}
 	// Test that {Scan,DeleteRange}Response properly implement it.
 	sr1 := &ScanResponse{
-		ResponseHeader: ResponseHeader{Timestamp: MinTimestamp},
 		Rows: []KeyValue{
 			{Key: Key("A"), Value: MakeValueFromString("V")},
 		},
@@ -42,16 +41,13 @@ func TestCombinable(t *testing.T) {
 	}
 
 	sr2 := &ScanResponse{
-		ResponseHeader: ResponseHeader{Timestamp: MinTimestamp},
 		Rows: []KeyValue{
 			{Key: Key("B"), Value: MakeValueFromString("W")},
 		},
 	}
-	sr2.Timestamp = MaxTimestamp
 
 	wantedSR := &ScanResponse{
-		ResponseHeader: ResponseHeader{Timestamp: MaxTimestamp},
-		Rows:           append(append([]KeyValue(nil), sr1.Rows...), sr2.Rows...),
+		Rows: append(append([]KeyValue(nil), sr1.Rows...), sr2.Rows...),
 	}
 
 	if err := sr1.combine(sr2); err != nil {
@@ -66,23 +62,19 @@ func TestCombinable(t *testing.T) {
 	}
 
 	dr1 := &DeleteRangeResponse{
-		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 100}},
-		Keys:           []Key{[]byte("1")},
+		Keys: []Key{[]byte("1")},
 	}
 	if _, ok := interface{}(dr1).(combinable); !ok {
 		t.Fatalf("DeleteRangeResponse does not implement combinable")
 	}
 	dr2 := &DeleteRangeResponse{
-		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 1}},
-		Keys:           []Key{[]byte("2")},
+		Keys: []Key{[]byte("2")},
 	}
 	dr3 := &DeleteRangeResponse{
-		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 111}},
-		Keys:           nil,
+		Keys: nil,
 	}
 	wantedDR := &DeleteRangeResponse{
-		ResponseHeader: ResponseHeader{Timestamp: Timestamp{Logical: 111}},
-		Keys:           []Key{[]byte("1"), []byte("2")},
+		Keys: []Key{[]byte("1"), []byte("2")},
 	}
 	if err := dr2.combine(dr3); err != nil {
 		t.Fatal(err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -232,10 +232,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 			t.Fatal(err)
 		}
 		scan := roachpb.NewScan(writes[0], writes[len(writes)-1].Next(), 0).(*roachpb.ScanRequest)
-		// The Put ts may have been pushed by tsCache,
-		// so make sure we see their values in our Scan.
-		delTS = reply.(*roachpb.PutResponse).Timestamp
-		reply, err = client.SendWrappedWith(tds, nil, roachpb.Header{Timestamp: delTS}, scan)
+		reply, err = client.SendWrapped(tds, nil, scan)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
@@ -966,12 +968,12 @@ func TestStoreSplitReadRace(t *testing.T) {
 		h.Timestamp = now
 		args := putArgs(key(i), []byte("foo"))
 		h.RangeID = store.LookupReplica(keys.Addr(args.Key), nil).RangeID
-		reply, pErr := client.SendWrappedWith(store, nil, h, &args)
+		_, respH, pErr := storage.SendWrapped(store, context.Background(), h, &args)
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
-		if reply.Header().Timestamp.Less(ts(i)) {
-			t.Fatalf("%d: expected Put to be forced higher than %s by timestamp caches, but wrote at %s", i, ts(i), reply.Header().Timestamp)
+		if respH.Timestamp.Less(ts(i)) {
+			t.Fatalf("%d: expected Put to be forced higher than %s by timestamp caches, but wrote at %s", i, ts(i), respH.Timestamp)
 		}
 	}
 }

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.cc
@@ -209,8 +209,7 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       "cockroach/roachpb/api.proto");
   GOOGLE_CHECK(file != NULL);
   ResponseHeader_descriptor_ = file->message_type(0);
-  static const int ResponseHeader_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseHeader, timestamp_),
+  static const int ResponseHeader_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ResponseHeader, txn_),
   };
   ResponseHeader_reflection_ =
@@ -1170,8 +1169,9 @@ void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto() {
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse, _internal_metadata_),
       -1);
   BatchResponse_Header_descriptor_ = BatchResponse_descriptor_->nested_type(0);
-  static const int BatchResponse_Header_offsets_[3] = {
+  static const int BatchResponse_Header_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse_Header, error_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse_Header, timestamp_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse_Header, txn_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(BatchResponse_Header, collected_spans_),
   };
@@ -1456,263 +1456,263 @@ void protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto() {
     "to\032\034cockroach/roachpb/data.proto\032\036cockro"
     "ach/roachpb/errors.proto\032!cockroach/util"
     "/tracing/span.proto\032\024gogoproto/gogo.prot"
-    "o\"t\n\016ResponseHeader\0225\n\ttimestamp\030\002 \001(\0132\034"
-    ".cockroach.roachpb.TimestampB\004\310\336\037\000\022+\n\003tx"
-    "n\030\003 \001(\0132\036.cockroach.roachpb.Transaction\""
-    "\?\n\nGetRequest\0221\n\006header\030\001 \001(\0132\027.cockroac"
-    "h.roachpb.SpanB\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse\022"
-    ";\n\006header\030\001 \001(\0132!.cockroach.roachpb.Resp"
-    "onseHeaderB\010\310\336\037\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.co"
-    "ckroach.roachpb.Value\"n\n\nPutRequest\0221\n\006h"
-    "eader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336"
-    "\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachp"
-    "b.ValueB\004\310\336\037\000\"J\n\013PutResponse\022;\n\006header\030\001"
-    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
-    "\010\310\336\037\000\320\336\037\001\"\246\001\n\025ConditionalPutRequest\0221\n\006h"
-    "eader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336"
-    "\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachp"
-    "b.ValueB\004\310\336\037\000\022+\n\texp_value\030\003 \001(\0132\030.cockr"
-    "oach.roachpb.Value\"U\n\026ConditionalPutResp"
-    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
-    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\"^\n\020IncrementRe"
-    "quest\0221\n\006header\030\001 \001(\0132\027.cockroach.roachp"
-    "b.SpanB\010\310\336\037\000\320\336\037\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336\037"
-    "\000\"i\n\021IncrementResponse\022;\n\006header\030\001 \001(\0132!"
-    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
-    "\336\037\001\022\027\n\tnew_value\030\002 \001(\003B\004\310\336\037\000\"B\n\rDeleteRe"
-    "quest\0221\n\006header\030\001 \001(\0132\027.cockroach.roachp"
-    "b.SpanB\010\310\336\037\000\320\336\037\001\"M\n\016DeleteResponse\022;\n\006he"
-    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
-    "eaderB\010\310\336\037\000\320\336\037\001\"\207\001\n\022DeleteRangeRequest\0221"
+    "o\"=\n\016ResponseHeader\022+\n\003txn\030\003 \001(\0132\036.cockr"
+    "oach.roachpb.Transaction\"\?\n\nGetRequest\0221"
     "\n\006header\030\001 \001(\0132\027.cockroach.roachpb.SpanB"
-    "\010\310\336\037\000\320\336\037\001\022#\n\025max_entries_to_delete\030\002 \001(\003"
-    "B\004\310\336\037\000\022\031\n\013return_keys\030\003 \001(\010B\004\310\336\037\000\"i\n\023Del"
-    "eteRangeResponse\022;\n\006header\030\001 \001(\0132!.cockr"
-    "oach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\025\n"
-    "\004keys\030\002 \003(\014B\007\372\336\037\003Key\"[\n\013ScanRequest\0221\n\006h"
-    "eader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336"
-    "\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004\310\336\037\000\"|\n\014Sca"
-    "nResponse\022;\n\006header\030\001 \001(\0132!.cockroach.ro"
-    "achpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002"
-    " \003(\0132\033.cockroach.roachpb.KeyValueB\004\310\336\037\000\""
-    "b\n\022ReverseScanRequest\0221\n\006header\030\001 \001(\0132\027."
-    "cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\031\n\013max_"
-    "results\030\002 \001(\003B\004\310\336\037\000\"\203\001\n\023ReverseScanRespo"
-    "nse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb."
-    "ResponseHeaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033"
-    ".cockroach.roachpb.KeyValueB\004\310\336\037\000\"L\n\027Che"
-    "ckConsistencyRequest\0221\n\006header\030\001 \001(\0132\027.c"
-    "ockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\"W\n\030Check"
-    "ConsistencyResponse\022;\n\006header\030\001 \001(\0132!.co"
-    "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"L\n\027BeginTransactionRequest\0221\n\006header\030\001 "
-    "\001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\"W"
-    "\n\030BeginTransactionResponse\022;\n\006header\030\001 \001"
-    "(\0132!.cockroach.roachpb.ResponseHeaderB\010\310"
-    "\336\037\000\320\336\037\001\"\220\002\n\025EndTransactionRequest\0221\n\006hea"
-    "der\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000"
-    "\320\336\037\001\022\024\n\006commit\030\002 \001(\010B\004\310\336\037\000\022.\n\010deadline\030\003"
-    " \001(\0132\034.cockroach.roachpb.Timestamp\022I\n\027in"
-    "ternal_commit_trigger\030\004 \001(\0132(.cockroach."
-    "roachpb.InternalCommitTrigger\0223\n\014intent_"
-    "spans\030\005 \003(\0132\027.cockroach.roachpb.SpanB\004\310\336"
-    "\037\000\"\213\001\n\026EndTransactionResponse\022;\n\006header\030"
+    "\010\310\336\037\000\320\336\037\001\"s\n\013GetResponse\022;\n\006header\030\001 \001(\013"
+    "2!.cockroach.roachpb.ResponseHeaderB\010\310\336\037"
+    "\000\320\336\037\001\022\'\n\005value\030\002 \001(\0132\030.cockroach.roachpb"
+    ".Value\"n\n\nPutRequest\0221\n\006header\030\001 \001(\0132\027.c"
+    "ockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\005value"
+    "\030\002 \001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\"J"
+    "\n\013PutResponse\022;\n\006header\030\001 \001(\0132!.cockroac"
+    "h.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\246\001\n\025C"
+    "onditionalPutRequest\0221\n\006header\030\001 \001(\0132\027.c"
+    "ockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\005value"
+    "\030\002 \001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\022+"
+    "\n\texp_value\030\003 \001(\0132\030.cockroach.roachpb.Va"
+    "lue\"U\n\026ConditionalPutResponse\022;\n\006header\030"
     "\001 \001(\0132!.cockroach.roachpb.ResponseHeader"
-    "B\010\310\336\037\000\320\336\037\001\022\031\n\013commit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n"
-    "\010resolved\030\003 \003(\014B\007\372\336\037\003Key\"b\n\021AdminSplitRe"
-    "quest\0221\n\006header\030\001 \001(\0132\027.cockroach.roachp"
-    "b.SpanB\010\310\336\037\000\320\336\037\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037"
-    "\003Key\"Q\n\022AdminSplitResponse\022;\n\006header\030\001 \001"
-    "(\0132!.cockroach.roachpb.ResponseHeaderB\010\310"
-    "\336\037\000\320\336\037\001\"F\n\021AdminMergeRequest\0221\n\006header\030\001"
-    " \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\""
-    "Q\n\022AdminMergeResponse\022;\n\006header\030\001 \001(\0132!."
-    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\"\230\001\n\022RangeLookupRequest\0221\n\006header\030\001 \001("
-    "\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\030\n\n"
-    "max_ranges\030\002 \001(\005B\004\310\336\037\000\022\036\n\020consider_inten"
-    "ts\030\003 \001(\010B\004\310\336\037\000\022\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001"
-    "\n\023RangeLookupResponse\022;\n\006header\030\001 \001(\0132!."
-    "cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336"
-    "\037\001\0228\n\006ranges\030\002 \003(\0132\".cockroach.roachpb.R"
-    "angeDescriptorB\004\310\336\037\000\"y\n\023HeartbeatTxnRequ"
-    "est\0221\n\006header\030\001 \001(\0132\027.cockroach.roachpb."
-    "SpanB\010\310\336\037\000\320\336\037\001\022/\n\003now\030\002 \001(\0132\034.cockroach."
-    "roachpb.TimestampB\004\310\336\037\000\"S\n\024HeartbeatTxnR"
+    "B\010\310\336\037\000\320\336\037\001\"^\n\020IncrementRequest\0221\n\006header"
+    "\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037"
+    "\001\022\027\n\tincrement\030\002 \001(\003B\004\310\336\037\000\"i\n\021IncrementR"
     "esponse\022;\n\006header\030\001 \001(\0132!.cockroach.roac"
-    "hpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\314\001\n\tGCReque"
-    "st\0221\n\006header\030\001 \001(\0132\027.cockroach.roachpb.S"
-    "panB\010\310\336\037\000\320\336\037\001\0226\n\004keys\030\003 \003(\0132\".cockroach."
-    "roachpb.GCRequest.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024"
-    "\n\003key\030\001 \001(\014B\007\372\336\037\003Key\0225\n\ttimestamp\030\002 \001(\0132"
-    "\034.cockroach.roachpb.TimestampB\004\310\336\037\000\"I\n\nG"
-    "CResponse\022;\n\006header\030\001 \001(\0132!.cockroach.ro"
-    "achpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\322\002\n\016PushT"
-    "xnRequest\0221\n\006header\030\001 \001(\0132\027.cockroach.ro"
-    "achpb.SpanB\010\310\336\037\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\013"
-    "2\036.cockroach.roachpb.TransactionB\004\310\336\037\000\0224"
-    "\n\npushee_txn\030\003 \001(\0132\032.cockroach.roachpb.T"
-    "xnMetaB\004\310\336\037\000\0223\n\007push_to\030\004 \001(\0132\034.cockroac"
-    "h.roachpb.TimestampB\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034"
-    ".cockroach.roachpb.TimestampB\004\310\336\037\000\0227\n\tpu"
-    "sh_type\030\006 \001(\0162\036.cockroach.roachpb.PushTx"
-    "nTypeB\004\310\336\037\000\"\210\001\n\017PushTxnResponse\022;\n\006heade"
-    "r\030\001 \001(\0132!.cockroach.roachpb.ResponseHead"
-    "erB\010\310\336\037\000\320\336\037\001\0228\n\npushee_txn\030\002 \001(\0132\036.cockr"
-    "oach.roachpb.TransactionB\004\310\336\037\000\"\321\001\n\024Resol"
-    "veIntentRequest\0221\n\006header\030\001 \001(\0132\027.cockro"
-    "ach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\0224\n\nintent_txn"
-    "\030\002 \001(\0132\032.cockroach.roachpb.TxnMetaB\004\310\336\037\000"
-    "\022:\n\006status\030\003 \001(\0162$.cockroach.roachpb.Tra"
-    "nsactionStatusB\004\310\336\037\000\022\024\n\006poison\030\004 \001(\010B\004\310\336"
-    "\037\000\"T\n\025ResolveIntentResponse\022;\n\006header\030\001 "
-    "\001(\0132!.cockroach.roachpb.ResponseHeaderB\010"
-    "\310\336\037\000\320\336\037\001\"\326\001\n\031ResolveIntentRangeRequest\0221"
-    "\n\006header\030\001 \001(\0132\027.cockroach.roachpb.SpanB"
-    "\010\310\336\037\000\320\336\037\001\0224\n\nintent_txn\030\002 \001(\0132\032.cockroac"
-    "h.roachpb.TxnMetaB\004\310\336\037\000\022:\n\006status\030\003 \001(\0162"
-    "$.cockroach.roachpb.TransactionStatusB\004\310"
-    "\336\037\000\022\024\n\006poison\030\004 \001(\010B\004\310\336\037\000\"K\n\014NoopRespons"
-    "e\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Re"
-    "sponseHeaderB\010\310\336\037\000\320\336\037\001\"@\n\013NoopRequest\0221\n"
-    "\006header\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010"
-    "\310\336\037\000\320\336\037\001\"Y\n\032ResolveIntentRangeResponse\022;"
-    "\n\006header\030\001 \001(\0132!.cockroach.roachpb.Respo"
-    "nseHeaderB\010\310\336\037\000\320\336\037\001\"p\n\014MergeRequest\0221\n\006h"
-    "eader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336"
-    "\037\000\320\336\037\001\022-\n\005value\030\002 \001(\0132\030.cockroach.roachp"
-    "b.ValueB\004\310\336\037\000\"L\n\rMergeResponse\022;\n\006header"
-    "\030\001 \001(\0132!.cockroach.roachpb.ResponseHeade"
-    "rB\010\310\336\037\000\320\336\037\001\"\212\001\n\022TruncateLogRequest\0221\n\006he"
-    "ader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037"
-    "\000\320\336\037\001\022\023\n\005index\030\002 \001(\004B\004\310\336\037\000\022,\n\010range_id\030\003"
-    " \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\"R\n\023Trun"
-    "cateLogResponse\022;\n\006header\030\001 \001(\0132!.cockro"
-    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"v\n\022"
-    "LeaderLeaseRequest\0221\n\006header\030\001 \001(\0132\027.coc"
-    "kroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002"
-    " \001(\0132\030.cockroach.roachpb.LeaseB\004\310\336\037\000\"R\n\023"
-    "LeaderLeaseResponse\022;\n\006header\030\001 \001(\0132!.co"
+    "hpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\027\n\tnew_valu"
+    "e\030\002 \001(\003B\004\310\336\037\000\"B\n\rDeleteRequest\0221\n\006header"
+    "\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037"
+    "\001\"M\n\016DeleteResponse\022;\n\006header\030\001 \001(\0132!.co"
     "ckroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001"
-    "\"\276\001\n\026ComputeChecksumRequest\0221\n\006header\030\001 "
-    "\001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\025"
-    "\n\007version\030\002 \001(\rB\004\310\336\037\000\022Z\n\013checksum_id\030\003 \001"
-    "(\014BE\310\336\037\000\342\336\037\nChecksumID\332\336\037/github.com/coc"
-    "kroachdb/cockroach/util/uuid.UUID\"V\n\027Com"
-    "puteChecksumResponse\022;\n\006header\030\001 \001(\0132!.c"
-    "ockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037"
-    "\001\"\317\001\n\025VerifyChecksumRequest\0221\n\006header\030\001 "
-    "\001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\025"
-    "\n\007version\030\002 \001(\rB\004\310\336\037\000\022Z\n\013checksum_id\030\003 \001"
-    "(\014BE\310\336\037\000\342\336\037\nChecksumID\332\336\037/github.com/coc"
-    "kroachdb/cockroach/util/uuid.UUID\022\020\n\010che"
-    "cksum\030\004 \001(\014\"U\n\026VerifyChecksumResponse\022;\n"
-    "\006header\030\001 \001(\0132!.cockroach.roachpb.Respon"
-    "seHeaderB\010\310\336\037\000\320\336\037\001\"\320\013\n\014RequestUnion\022*\n\003g"
-    "et\030\001 \001(\0132\035.cockroach.roachpb.GetRequest\022"
-    "*\n\003put\030\002 \001(\0132\035.cockroach.roachpb.PutRequ"
-    "est\022A\n\017conditional_put\030\003 \001(\0132(.cockroach"
-    ".roachpb.ConditionalPutRequest\0226\n\tincrem"
-    "ent\030\004 \001(\0132#.cockroach.roachpb.IncrementR"
-    "equest\0220\n\006delete\030\005 \001(\0132 .cockroach.roach"
-    "pb.DeleteRequest\022;\n\014delete_range\030\006 \001(\0132%"
-    ".cockroach.roachpb.DeleteRangeRequest\022,\n"
-    "\004scan\030\007 \001(\0132\036.cockroach.roachpb.ScanRequ"
-    "est\022E\n\021begin_transaction\030\010 \001(\0132*.cockroa"
-    "ch.roachpb.BeginTransactionRequest\022A\n\017en"
-    "d_transaction\030\t \001(\0132(.cockroach.roachpb."
-    "EndTransactionRequest\0229\n\013admin_split\030\n \001"
-    "(\0132$.cockroach.roachpb.AdminSplitRequest"
-    "\0229\n\013admin_merge\030\013 \001(\0132$.cockroach.roachp"
-    "b.AdminMergeRequest\022=\n\rheartbeat_txn\030\014 \001"
-    "(\0132&.cockroach.roachpb.HeartbeatTxnReque"
-    "st\022(\n\002gc\030\r \001(\0132\034.cockroach.roachpb.GCReq"
-    "uest\0223\n\010push_txn\030\016 \001(\0132!.cockroach.roach"
-    "pb.PushTxnRequest\022;\n\014range_lookup\030\017 \001(\0132"
-    "%.cockroach.roachpb.RangeLookupRequest\022\?"
-    "\n\016resolve_intent\030\020 \001(\0132\'.cockroach.roach"
-    "pb.ResolveIntentRequest\022J\n\024resolve_inten"
-    "t_range\030\021 \001(\0132,.cockroach.roachpb.Resolv"
-    "eIntentRangeRequest\022.\n\005merge\030\022 \001(\0132\037.coc"
-    "kroach.roachpb.MergeRequest\022;\n\014truncate_"
-    "log\030\023 \001(\0132%.cockroach.roachpb.TruncateLo"
-    "gRequest\022;\n\014leader_lease\030\024 \001(\0132%.cockroa"
-    "ch.roachpb.LeaderLeaseRequest\022;\n\014reverse"
-    "_scan\030\025 \001(\0132%.cockroach.roachpb.ReverseS"
-    "canRequest\022C\n\020compute_checksum\030\026 \001(\0132).c"
-    "ockroach.roachpb.ComputeChecksumRequest\022"
-    "A\n\017verify_checksum\030\027 \001(\0132(.cockroach.roa"
-    "chpb.VerifyChecksumRequest\022E\n\021check_cons"
-    "istency\030\030 \001(\0132*.cockroach.roachpb.CheckC"
-    "onsistencyRequest\022,\n\004noop\030\031 \001(\0132\036.cockro"
-    "ach.roachpb.NoopRequest:\004\310\240\037\001\"\352\013\n\rRespon"
-    "seUnion\022+\n\003get\030\001 \001(\0132\036.cockroach.roachpb"
-    ".GetResponse\022+\n\003put\030\002 \001(\0132\036.cockroach.ro"
-    "achpb.PutResponse\022B\n\017conditional_put\030\003 \001"
-    "(\0132).cockroach.roachpb.ConditionalPutRes"
-    "ponse\0227\n\tincrement\030\004 \001(\0132$.cockroach.roa"
-    "chpb.IncrementResponse\0221\n\006delete\030\005 \001(\0132!"
-    ".cockroach.roachpb.DeleteResponse\022<\n\014del"
-    "ete_range\030\006 \001(\0132&.cockroach.roachpb.Dele"
-    "teRangeResponse\022-\n\004scan\030\007 \001(\0132\037.cockroac"
-    "h.roachpb.ScanResponse\022F\n\021begin_transact"
-    "ion\030\010 \001(\0132+.cockroach.roachpb.BeginTrans"
-    "actionResponse\022B\n\017end_transaction\030\t \001(\0132"
-    ").cockroach.roachpb.EndTransactionRespon"
-    "se\022:\n\013admin_split\030\n \001(\0132%.cockroach.roac"
-    "hpb.AdminSplitResponse\022:\n\013admin_merge\030\013 "
-    "\001(\0132%.cockroach.roachpb.AdminMergeRespon"
-    "se\022>\n\rheartbeat_txn\030\014 \001(\0132\'.cockroach.ro"
-    "achpb.HeartbeatTxnResponse\022)\n\002gc\030\r \001(\0132\035"
-    ".cockroach.roachpb.GCResponse\0224\n\010push_tx"
-    "n\030\016 \001(\0132\".cockroach.roachpb.PushTxnRespo"
-    "nse\022<\n\014range_lookup\030\017 \001(\0132&.cockroach.ro"
-    "achpb.RangeLookupResponse\022@\n\016resolve_int"
-    "ent\030\020 \001(\0132(.cockroach.roachpb.ResolveInt"
-    "entResponse\022K\n\024resolve_intent_range\030\021 \001("
-    "\0132-.cockroach.roachpb.ResolveIntentRange"
-    "Response\022/\n\005merge\030\022 \001(\0132 .cockroach.roac"
-    "hpb.MergeResponse\022<\n\014truncate_log\030\023 \001(\0132"
-    "&.cockroach.roachpb.TruncateLogResponse\022"
-    "<\n\014leader_lease\030\024 \001(\0132&.cockroach.roachp"
-    "b.LeaderLeaseResponse\022<\n\014reverse_scan\030\025 "
-    "\001(\0132&.cockroach.roachpb.ReverseScanRespo"
-    "nse\022D\n\020compute_checksum\030\026 \001(\0132*.cockroac"
-    "h.roachpb.ComputeChecksumResponse\022B\n\017ver"
-    "ify_checksum\030\027 \001(\0132).cockroach.roachpb.V"
-    "erifyChecksumResponse\022F\n\021check_consisten"
-    "cy\030\030 \001(\0132+.cockroach.roachpb.CheckConsis"
-    "tencyResponse\022-\n\004noop\030\031 \001(\0132\037.cockroach."
-    "roachpb.NoopResponse:\004\310\240\037\001\"\231\003\n\006Header\0225\n"
-    "\ttimestamp\030\001 \001(\0132\034.cockroach.roachpb.Tim"
-    "estampB\004\310\336\037\000\022;\n\007replica\030\002 \001(\0132$.cockroac"
-    "h.roachpb.ReplicaDescriptorB\004\310\336\037\000\022,\n\010ran"
-    "ge_id\030\003 \001(\003B\032\310\336\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022"
-    "+\n\ruser_priority\030\004 \001(\001B\024\310\336\037\000\372\336\037\014UserPrio"
-    "rity\022+\n\003txn\030\005 \001(\0132\036.cockroach.roachpb.Tr"
-    "ansaction\022F\n\020read_consistency\030\006 \001(\0162&.co"
-    "ckroach.roachpb.ReadConsistencyTypeB\004\310\336\037"
-    "\000\022+\n\005trace\030\007 \001(\0132\034.cockroach.util.tracin"
-    "g.Span\022\036\n\020max_scan_results\030\010 \001(\003B\004\310\336\037\000\"\202"
-    "\001\n\014BatchRequest\0223\n\006header\030\001 \001(\0132\031.cockro"
-    "ach.roachpb.HeaderB\010\310\336\037\000\320\336\037\001\0227\n\010requests"
-    "\030\002 \003(\0132\037.cockroach.roachpb.RequestUnionB"
-    "\004\310\336\037\000:\004\230\240\037\000\"\214\002\n\rBatchResponse\022A\n\006header\030"
-    "\001 \001(\0132\'.cockroach.roachpb.BatchResponse."
-    "HeaderB\010\310\336\037\000\320\336\037\001\0229\n\tresponses\030\002 \003(\0132 .co"
-    "ckroach.roachpb.ResponseUnionB\004\310\336\037\000\032w\n\006H"
-    "eader\022\'\n\005error\030\001 \001(\0132\030.cockroach.roachpb"
-    ".Error\022+\n\003txn\030\003 \001(\0132\036.cockroach.roachpb."
-    "Transaction\022\027\n\017collected_spans\030\004 \003(\014:\004\230\240"
-    "\037\000*L\n\023ReadConsistencyType\022\016\n\nCONSISTENT\020"
-    "\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036\000"
-    "*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\016\n\nP"
-    "USH_ABORT\020\001\022\016\n\nPUSH_TOUCH\020\002\032\004\210\243\036\0002X\n\010Int"
-    "ernal\022L\n\005Batch\022\037.cockroach.roachpb.Batch"
-    "Request\032 .cockroach.roachpb.BatchRespons"
-    "e\"\0002X\n\010External\022L\n\005Batch\022\037.cockroach.roa"
-    "chpb.BatchRequest\032 .cockroach.roachpb.Ba"
-    "tchResponse\"\000B\tZ\007roachpbX\004", 10466);
+    "\"\207\001\n\022DeleteRangeRequest\0221\n\006header\030\001 \001(\0132"
+    "\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022#\n\025ma"
+    "x_entries_to_delete\030\002 \001(\003B\004\310\336\037\000\022\031\n\013retur"
+    "n_keys\030\003 \001(\010B\004\310\336\037\000\"i\n\023DeleteRangeRespons"
+    "e\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Re"
+    "sponseHeaderB\010\310\336\037\000\320\336\037\001\022\025\n\004keys\030\002 \003(\014B\007\372\336"
+    "\037\003Key\"[\n\013ScanRequest\0221\n\006header\030\001 \001(\0132\027.c"
+    "ockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\031\n\013max_r"
+    "esults\030\002 \001(\003B\004\310\336\037\000\"|\n\014ScanResponse\022;\n\006he"
+    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
+    "eaderB\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroac"
+    "h.roachpb.KeyValueB\004\310\336\037\000\"b\n\022ReverseScanR"
+    "equest\0221\n\006header\030\001 \001(\0132\027.cockroach.roach"
+    "pb.SpanB\010\310\336\037\000\320\336\037\001\022\031\n\013max_results\030\002 \001(\003B\004"
+    "\310\336\037\000\"\203\001\n\023ReverseScanResponse\022;\n\006header\030\001"
+    " \001(\0132!.cockroach.roachpb.ResponseHeaderB"
+    "\010\310\336\037\000\320\336\037\001\022/\n\004rows\030\002 \003(\0132\033.cockroach.roac"
+    "hpb.KeyValueB\004\310\336\037\000\"L\n\027CheckConsistencyRe"
+    "quest\0221\n\006header\030\001 \001(\0132\027.cockroach.roachp"
+    "b.SpanB\010\310\336\037\000\320\336\037\001\"W\n\030CheckConsistencyResp"
+    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
+    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\"L\n\027BeginTransa"
+    "ctionRequest\0221\n\006header\030\001 \001(\0132\027.cockroach"
+    ".roachpb.SpanB\010\310\336\037\000\320\336\037\001\"W\n\030BeginTransact"
+    "ionResponse\022;\n\006header\030\001 \001(\0132!.cockroach."
+    "roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\220\002\n\025End"
+    "TransactionRequest\0221\n\006header\030\001 \001(\0132\027.coc"
+    "kroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\024\n\006commit\030"
+    "\002 \001(\010B\004\310\336\037\000\022.\n\010deadline\030\003 \001(\0132\034.cockroac"
+    "h.roachpb.Timestamp\022I\n\027internal_commit_t"
+    "rigger\030\004 \001(\0132(.cockroach.roachpb.Interna"
+    "lCommitTrigger\0223\n\014intent_spans\030\005 \003(\0132\027.c"
+    "ockroach.roachpb.SpanB\004\310\336\037\000\"\213\001\n\026EndTrans"
+    "actionResponse\022;\n\006header\030\001 \001(\0132!.cockroa"
+    "ch.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\022\031\n\013c"
+    "ommit_wait\030\002 \001(\003B\004\310\336\037\000\022\031\n\010resolved\030\003 \003(\014"
+    "B\007\372\336\037\003Key\"b\n\021AdminSplitRequest\0221\n\006header"
+    "\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037"
+    "\001\022\032\n\tsplit_key\030\002 \001(\014B\007\372\336\037\003Key\"Q\n\022AdminSp"
+    "litResponse\022;\n\006header\030\001 \001(\0132!.cockroach."
+    "roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"F\n\021Admi"
+    "nMergeRequest\0221\n\006header\030\001 \001(\0132\027.cockroac"
+    "h.roachpb.SpanB\010\310\336\037\000\320\336\037\001\"Q\n\022AdminMergeRe"
+    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
+    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\230\001\n\022RangeLoo"
+    "kupRequest\0221\n\006header\030\001 \001(\0132\027.cockroach.r"
+    "oachpb.SpanB\010\310\336\037\000\320\336\037\001\022\030\n\nmax_ranges\030\002 \001("
+    "\005B\004\310\336\037\000\022\036\n\020consider_intents\030\003 \001(\010B\004\310\336\037\000\022"
+    "\025\n\007reverse\030\004 \001(\010B\004\310\336\037\000\"\214\001\n\023RangeLookupRe"
+    "sponse\022;\n\006header\030\001 \001(\0132!.cockroach.roach"
+    "pb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0228\n\006ranges\030\002 "
+    "\003(\0132\".cockroach.roachpb.RangeDescriptorB"
+    "\004\310\336\037\000\"y\n\023HeartbeatTxnRequest\0221\n\006header\030\001"
+    " \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022"
+    "/\n\003now\030\002 \001(\0132\034.cockroach.roachpb.Timesta"
+    "mpB\004\310\336\037\000\"S\n\024HeartbeatTxnResponse\022;\n\006head"
+    "er\030\001 \001(\0132!.cockroach.roachpb.ResponseHea"
+    "derB\010\310\336\037\000\320\336\037\001\"\314\001\n\tGCRequest\0221\n\006header\030\001 "
+    "\001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\0226"
+    "\n\004keys\030\003 \003(\0132\".cockroach.roachpb.GCReque"
+    "st.GCKeyB\004\310\336\037\000\032T\n\005GCKey\022\024\n\003key\030\001 \001(\014B\007\372\336"
+    "\037\003Key\0225\n\ttimestamp\030\002 \001(\0132\034.cockroach.roa"
+    "chpb.TimestampB\004\310\336\037\000\"I\n\nGCResponse\022;\n\006he"
+    "ader\030\001 \001(\0132!.cockroach.roachpb.ResponseH"
+    "eaderB\010\310\336\037\000\320\336\037\001\"\322\002\n\016PushTxnRequest\0221\n\006he"
+    "ader\030\001 \001(\0132\027.cockroach.roachpb.SpanB\010\310\336\037"
+    "\000\320\336\037\001\0228\n\npusher_txn\030\002 \001(\0132\036.cockroach.ro"
+    "achpb.TransactionB\004\310\336\037\000\0224\n\npushee_txn\030\003 "
+    "\001(\0132\032.cockroach.roachpb.TxnMetaB\004\310\336\037\000\0223\n"
+    "\007push_to\030\004 \001(\0132\034.cockroach.roachpb.Times"
+    "tampB\004\310\336\037\000\022/\n\003now\030\005 \001(\0132\034.cockroach.roac"
+    "hpb.TimestampB\004\310\336\037\000\0227\n\tpush_type\030\006 \001(\0162\036"
+    ".cockroach.roachpb.PushTxnTypeB\004\310\336\037\000\"\210\001\n"
+    "\017PushTxnResponse\022;\n\006header\030\001 \001(\0132!.cockr"
+    "oach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\0228\n"
+    "\npushee_txn\030\002 \001(\0132\036.cockroach.roachpb.Tr"
+    "ansactionB\004\310\336\037\000\"\321\001\n\024ResolveIntentRequest"
+    "\0221\n\006header\030\001 \001(\0132\027.cockroach.roachpb.Spa"
+    "nB\010\310\336\037\000\320\336\037\001\0224\n\nintent_txn\030\002 \001(\0132\032.cockro"
+    "ach.roachpb.TxnMetaB\004\310\336\037\000\022:\n\006status\030\003 \001("
+    "\0162$.cockroach.roachpb.TransactionStatusB"
+    "\004\310\336\037\000\022\024\n\006poison\030\004 \001(\010B\004\310\336\037\000\"T\n\025ResolveIn"
+    "tentResponse\022;\n\006header\030\001 \001(\0132!.cockroach"
+    ".roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\326\001\n\031Re"
+    "solveIntentRangeRequest\0221\n\006header\030\001 \001(\0132"
+    "\027.cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\0224\n\nin"
+    "tent_txn\030\002 \001(\0132\032.cockroach.roachpb.TxnMe"
+    "taB\004\310\336\037\000\022:\n\006status\030\003 \001(\0162$.cockroach.roa"
+    "chpb.TransactionStatusB\004\310\336\037\000\022\024\n\006poison\030\004"
+    " \001(\010B\004\310\336\037\000\"K\n\014NoopResponse\022;\n\006header\030\001 \001"
+    "(\0132!.cockroach.roachpb.ResponseHeaderB\010\310"
+    "\336\037\000\320\336\037\001\"@\n\013NoopRequest\0221\n\006header\030\001 \001(\0132\027"
+    ".cockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\"Y\n\032Res"
+    "olveIntentRangeResponse\022;\n\006header\030\001 \001(\0132"
+    "!.cockroach.roachpb.ResponseHeaderB\010\310\336\037\000"
+    "\320\336\037\001\"p\n\014MergeRequest\0221\n\006header\030\001 \001(\0132\027.c"
+    "ockroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022-\n\005value"
+    "\030\002 \001(\0132\030.cockroach.roachpb.ValueB\004\310\336\037\000\"L"
+    "\n\rMergeResponse\022;\n\006header\030\001 \001(\0132!.cockro"
+    "ach.roachpb.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\212\001\n"
+    "\022TruncateLogRequest\0221\n\006header\030\001 \001(\0132\027.co"
+    "ckroach.roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\023\n\005index\030"
+    "\002 \001(\004B\004\310\336\037\000\022,\n\010range_id\030\003 \001(\003B\032\310\336\037\000\342\336\037\007R"
+    "angeID\372\336\037\007RangeID\"R\n\023TruncateLogResponse"
+    "\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb.Res"
+    "ponseHeaderB\010\310\336\037\000\320\336\037\001\"v\n\022LeaderLeaseRequ"
+    "est\0221\n\006header\030\001 \001(\0132\027.cockroach.roachpb."
+    "SpanB\010\310\336\037\000\320\336\037\001\022-\n\005lease\030\002 \001(\0132\030.cockroac"
+    "h.roachpb.LeaseB\004\310\336\037\000\"R\n\023LeaderLeaseResp"
+    "onse\022;\n\006header\030\001 \001(\0132!.cockroach.roachpb"
+    ".ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\276\001\n\026ComputeChe"
+    "cksumRequest\0221\n\006header\030\001 \001(\0132\027.cockroach"
+    ".roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\025\n\007version\030\002 \001(\r"
+    "B\004\310\336\037\000\022Z\n\013checksum_id\030\003 \001(\014BE\310\336\037\000\342\336\037\nChe"
+    "cksumID\332\336\037/github.com/cockroachdb/cockro"
+    "ach/util/uuid.UUID\"V\n\027ComputeChecksumRes"
+    "ponse\022;\n\006header\030\001 \001(\0132!.cockroach.roachp"
+    "b.ResponseHeaderB\010\310\336\037\000\320\336\037\001\"\317\001\n\025VerifyChe"
+    "cksumRequest\0221\n\006header\030\001 \001(\0132\027.cockroach"
+    ".roachpb.SpanB\010\310\336\037\000\320\336\037\001\022\025\n\007version\030\002 \001(\r"
+    "B\004\310\336\037\000\022Z\n\013checksum_id\030\003 \001(\014BE\310\336\037\000\342\336\037\nChe"
+    "cksumID\332\336\037/github.com/cockroachdb/cockro"
+    "ach/util/uuid.UUID\022\020\n\010checksum\030\004 \001(\014\"U\n\026"
+    "VerifyChecksumResponse\022;\n\006header\030\001 \001(\0132!"
+    ".cockroach.roachpb.ResponseHeaderB\010\310\336\037\000\320"
+    "\336\037\001\"\320\013\n\014RequestUnion\022*\n\003get\030\001 \001(\0132\035.cock"
+    "roach.roachpb.GetRequest\022*\n\003put\030\002 \001(\0132\035."
+    "cockroach.roachpb.PutRequest\022A\n\017conditio"
+    "nal_put\030\003 \001(\0132(.cockroach.roachpb.Condit"
+    "ionalPutRequest\0226\n\tincrement\030\004 \001(\0132#.coc"
+    "kroach.roachpb.IncrementRequest\0220\n\006delet"
+    "e\030\005 \001(\0132 .cockroach.roachpb.DeleteReques"
+    "t\022;\n\014delete_range\030\006 \001(\0132%.cockroach.roac"
+    "hpb.DeleteRangeRequest\022,\n\004scan\030\007 \001(\0132\036.c"
+    "ockroach.roachpb.ScanRequest\022E\n\021begin_tr"
+    "ansaction\030\010 \001(\0132*.cockroach.roachpb.Begi"
+    "nTransactionRequest\022A\n\017end_transaction\030\t"
+    " \001(\0132(.cockroach.roachpb.EndTransactionR"
+    "equest\0229\n\013admin_split\030\n \001(\0132$.cockroach."
+    "roachpb.AdminSplitRequest\0229\n\013admin_merge"
+    "\030\013 \001(\0132$.cockroach.roachpb.AdminMergeReq"
+    "uest\022=\n\rheartbeat_txn\030\014 \001(\0132&.cockroach."
+    "roachpb.HeartbeatTxnRequest\022(\n\002gc\030\r \001(\0132"
+    "\034.cockroach.roachpb.GCRequest\0223\n\010push_tx"
+    "n\030\016 \001(\0132!.cockroach.roachpb.PushTxnReque"
+    "st\022;\n\014range_lookup\030\017 \001(\0132%.cockroach.roa"
+    "chpb.RangeLookupRequest\022\?\n\016resolve_inten"
+    "t\030\020 \001(\0132\'.cockroach.roachpb.ResolveInten"
+    "tRequest\022J\n\024resolve_intent_range\030\021 \001(\0132,"
+    ".cockroach.roachpb.ResolveIntentRangeReq"
+    "uest\022.\n\005merge\030\022 \001(\0132\037.cockroach.roachpb."
+    "MergeRequest\022;\n\014truncate_log\030\023 \001(\0132%.coc"
+    "kroach.roachpb.TruncateLogRequest\022;\n\014lea"
+    "der_lease\030\024 \001(\0132%.cockroach.roachpb.Lead"
+    "erLeaseRequest\022;\n\014reverse_scan\030\025 \001(\0132%.c"
+    "ockroach.roachpb.ReverseScanRequest\022C\n\020c"
+    "ompute_checksum\030\026 \001(\0132).cockroach.roachp"
+    "b.ComputeChecksumRequest\022A\n\017verify_check"
+    "sum\030\027 \001(\0132(.cockroach.roachpb.VerifyChec"
+    "ksumRequest\022E\n\021check_consistency\030\030 \001(\0132*"
+    ".cockroach.roachpb.CheckConsistencyReque"
+    "st\022,\n\004noop\030\031 \001(\0132\036.cockroach.roachpb.Noo"
+    "pRequest:\004\310\240\037\001\"\352\013\n\rResponseUnion\022+\n\003get\030"
+    "\001 \001(\0132\036.cockroach.roachpb.GetResponse\022+\n"
+    "\003put\030\002 \001(\0132\036.cockroach.roachpb.PutRespon"
+    "se\022B\n\017conditional_put\030\003 \001(\0132).cockroach."
+    "roachpb.ConditionalPutResponse\0227\n\tincrem"
+    "ent\030\004 \001(\0132$.cockroach.roachpb.IncrementR"
+    "esponse\0221\n\006delete\030\005 \001(\0132!.cockroach.roac"
+    "hpb.DeleteResponse\022<\n\014delete_range\030\006 \001(\013"
+    "2&.cockroach.roachpb.DeleteRangeResponse"
+    "\022-\n\004scan\030\007 \001(\0132\037.cockroach.roachpb.ScanR"
+    "esponse\022F\n\021begin_transaction\030\010 \001(\0132+.coc"
+    "kroach.roachpb.BeginTransactionResponse\022"
+    "B\n\017end_transaction\030\t \001(\0132).cockroach.roa"
+    "chpb.EndTransactionResponse\022:\n\013admin_spl"
+    "it\030\n \001(\0132%.cockroach.roachpb.AdminSplitR"
+    "esponse\022:\n\013admin_merge\030\013 \001(\0132%.cockroach"
+    ".roachpb.AdminMergeResponse\022>\n\rheartbeat"
+    "_txn\030\014 \001(\0132\'.cockroach.roachpb.Heartbeat"
+    "TxnResponse\022)\n\002gc\030\r \001(\0132\035.cockroach.roac"
+    "hpb.GCResponse\0224\n\010push_txn\030\016 \001(\0132\".cockr"
+    "oach.roachpb.PushTxnResponse\022<\n\014range_lo"
+    "okup\030\017 \001(\0132&.cockroach.roachpb.RangeLook"
+    "upResponse\022@\n\016resolve_intent\030\020 \001(\0132(.coc"
+    "kroach.roachpb.ResolveIntentResponse\022K\n\024"
+    "resolve_intent_range\030\021 \001(\0132-.cockroach.r"
+    "oachpb.ResolveIntentRangeResponse\022/\n\005mer"
+    "ge\030\022 \001(\0132 .cockroach.roachpb.MergeRespon"
+    "se\022<\n\014truncate_log\030\023 \001(\0132&.cockroach.roa"
+    "chpb.TruncateLogResponse\022<\n\014leader_lease"
+    "\030\024 \001(\0132&.cockroach.roachpb.LeaderLeaseRe"
+    "sponse\022<\n\014reverse_scan\030\025 \001(\0132&.cockroach"
+    ".roachpb.ReverseScanResponse\022D\n\020compute_"
+    "checksum\030\026 \001(\0132*.cockroach.roachpb.Compu"
+    "teChecksumResponse\022B\n\017verify_checksum\030\027 "
+    "\001(\0132).cockroach.roachpb.VerifyChecksumRe"
+    "sponse\022F\n\021check_consistency\030\030 \001(\0132+.cock"
+    "roach.roachpb.CheckConsistencyResponse\022-"
+    "\n\004noop\030\031 \001(\0132\037.cockroach.roachpb.NoopRes"
+    "ponse:\004\310\240\037\001\"\231\003\n\006Header\0225\n\ttimestamp\030\001 \001("
+    "\0132\034.cockroach.roachpb.TimestampB\004\310\336\037\000\022;\n"
+    "\007replica\030\002 \001(\0132$.cockroach.roachpb.Repli"
+    "caDescriptorB\004\310\336\037\000\022,\n\010range_id\030\003 \001(\003B\032\310\336"
+    "\037\000\342\336\037\007RangeID\372\336\037\007RangeID\022+\n\ruser_priorit"
+    "y\030\004 \001(\001B\024\310\336\037\000\372\336\037\014UserPriority\022+\n\003txn\030\005 \001"
+    "(\0132\036.cockroach.roachpb.Transaction\022F\n\020re"
+    "ad_consistency\030\006 \001(\0162&.cockroach.roachpb"
+    ".ReadConsistencyTypeB\004\310\336\037\000\022+\n\005trace\030\007 \001("
+    "\0132\034.cockroach.util.tracing.Span\022\036\n\020max_s"
+    "can_results\030\010 \001(\003B\004\310\336\037\000\"\202\001\n\014BatchRequest"
+    "\0223\n\006header\030\001 \001(\0132\031.cockroach.roachpb.Hea"
+    "derB\010\310\336\037\000\320\336\037\001\0227\n\010requests\030\002 \003(\0132\037.cockro"
+    "ach.roachpb.RequestUnionB\004\310\336\037\000:\004\230\240\037\000\"\304\002\n"
+    "\rBatchResponse\022A\n\006header\030\001 \001(\0132\'.cockroa"
+    "ch.roachpb.BatchResponse.HeaderB\010\310\336\037\000\320\336\037"
+    "\001\0229\n\tresponses\030\002 \003(\0132 .cockroach.roachpb"
+    ".ResponseUnionB\004\310\336\037\000\032\256\001\n\006Header\022\'\n\005error"
+    "\030\001 \001(\0132\030.cockroach.roachpb.Error\0225\n\tTime"
+    "stamp\030\002 \001(\0132\034.cockroach.roachpb.Timestam"
+    "pB\004\310\336\037\000\022+\n\003txn\030\003 \001(\0132\036.cockroach.roachpb"
+    ".Transaction\022\027\n\017collected_spans\030\004 \003(\014:\004\230"
+    "\240\037\000*L\n\023ReadConsistencyType\022\016\n\nCONSISTENT"
+    "\020\000\022\r\n\tCONSENSUS\020\001\022\020\n\014INCONSISTENT\020\002\032\004\210\243\036"
+    "\000*G\n\013PushTxnType\022\022\n\016PUSH_TIMESTAMP\020\000\022\016\n\n"
+    "PUSH_ABORT\020\001\022\016\n\nPUSH_TOUCH\020\002\032\004\210\243\036\0002X\n\010In"
+    "ternal\022L\n\005Batch\022\037.cockroach.roachpb.Batc"
+    "hRequest\032 .cockroach.roachpb.BatchRespon"
+    "se\"\0002X\n\010External\022L\n\005Batch\022\037.cockroach.ro"
+    "achpb.BatchRequest\032 .cockroach.roachpb.B"
+    "atchResponse\"\000B\tZ\007roachpbX\004", 10467);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "cockroach/roachpb/api.proto", &protobuf_RegisterTypes);
   ResponseHeader::default_instance_ = new ResponseHeader();
@@ -1884,7 +1884,6 @@ static void MergeFromFail(int line) {
 // ===================================================================
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int ResponseHeader::kTimestampFieldNumber;
 const int ResponseHeader::kTxnFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
@@ -1895,7 +1894,6 @@ ResponseHeader::ResponseHeader()
 }
 
 void ResponseHeader::InitAsDefaultInstance() {
-  timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
   txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
 }
 
@@ -1909,7 +1907,6 @@ ResponseHeader::ResponseHeader(const ResponseHeader& from)
 
 void ResponseHeader::SharedCtor() {
   _cached_size_ = 0;
-  timestamp_ = NULL;
   txn_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -1921,7 +1918,6 @@ ResponseHeader::~ResponseHeader() {
 
 void ResponseHeader::SharedDtor() {
   if (this != default_instance_) {
-    delete timestamp_;
     delete txn_;
   }
 }
@@ -1952,13 +1948,8 @@ ResponseHeader* ResponseHeader::New(::google::protobuf::Arena* arena) const {
 }
 
 void ResponseHeader::Clear() {
-  if (_has_bits_[0 / 32] & 3u) {
-    if (has_timestamp()) {
-      if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
-    }
-    if (has_txn()) {
-      if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
-    }
+  if (has_txn()) {
+    if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   if (_internal_metadata_.have_unknown_fields()) {
@@ -1976,22 +1967,9 @@ bool ResponseHeader::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // optional .cockroach.roachpb.Timestamp timestamp = 2;
-      case 2: {
-        if (tag == 18) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_timestamp()));
-        } else {
-          goto handle_unusual;
-        }
-        if (input->ExpectTag(26)) goto parse_txn;
-        break;
-      }
-
       // optional .cockroach.roachpb.Transaction txn = 3;
       case 3: {
         if (tag == 26) {
-         parse_txn:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_txn()));
         } else {
@@ -2026,12 +2004,6 @@ failure:
 void ResponseHeader::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
   // @@protoc_insertion_point(serialize_start:cockroach.roachpb.ResponseHeader)
-  // optional .cockroach.roachpb.Timestamp timestamp = 2;
-  if (has_timestamp()) {
-    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      2, *this->timestamp_, output);
-  }
-
   // optional .cockroach.roachpb.Transaction txn = 3;
   if (has_txn()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -2048,13 +2020,6 @@ void ResponseHeader::SerializeWithCachedSizes(
 ::google::protobuf::uint8* ResponseHeader::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
   // @@protoc_insertion_point(serialize_to_array_start:cockroach.roachpb.ResponseHeader)
-  // optional .cockroach.roachpb.Timestamp timestamp = 2;
-  if (has_timestamp()) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteMessageNoVirtualToArray(
-        2, *this->timestamp_, target);
-  }
-
   // optional .cockroach.roachpb.Transaction txn = 3;
   if (has_txn()) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -2073,22 +2038,13 @@ void ResponseHeader::SerializeWithCachedSizes(
 int ResponseHeader::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 3u) {
-    // optional .cockroach.roachpb.Timestamp timestamp = 2;
-    if (has_timestamp()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->timestamp_);
-    }
-
-    // optional .cockroach.roachpb.Transaction txn = 3;
-    if (has_txn()) {
-      total_size += 1 +
-        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *this->txn_);
-    }
-
+  // optional .cockroach.roachpb.Transaction txn = 3;
+  if (has_txn()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        *this->txn_);
   }
+
   if (_internal_metadata_.have_unknown_fields()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -2115,9 +2071,6 @@ void ResponseHeader::MergeFrom(const ::google::protobuf::Message& from) {
 void ResponseHeader::MergeFrom(const ResponseHeader& from) {
   if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_timestamp()) {
-      mutable_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.timestamp());
-    }
     if (from.has_txn()) {
       mutable_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.txn());
     }
@@ -2149,7 +2102,6 @@ void ResponseHeader::Swap(ResponseHeader* other) {
   InternalSwap(other);
 }
 void ResponseHeader::InternalSwap(ResponseHeader* other) {
-  std::swap(timestamp_, other->timestamp_);
   std::swap(txn_, other->txn_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -2167,58 +2119,15 @@ void ResponseHeader::InternalSwap(ResponseHeader* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // ResponseHeader
 
-// optional .cockroach.roachpb.Timestamp timestamp = 2;
-bool ResponseHeader::has_timestamp() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-void ResponseHeader::set_has_timestamp() {
-  _has_bits_[0] |= 0x00000001u;
-}
-void ResponseHeader::clear_has_timestamp() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-void ResponseHeader::clear_timestamp() {
-  if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_timestamp();
-}
-const ::cockroach::roachpb::Timestamp& ResponseHeader::timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResponseHeader.timestamp)
-  return timestamp_ != NULL ? *timestamp_ : *default_instance_->timestamp_;
-}
-::cockroach::roachpb::Timestamp* ResponseHeader::mutable_timestamp() {
-  set_has_timestamp();
-  if (timestamp_ == NULL) {
-    timestamp_ = new ::cockroach::roachpb::Timestamp;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ResponseHeader.timestamp)
-  return timestamp_;
-}
-::cockroach::roachpb::Timestamp* ResponseHeader::release_timestamp() {
-  clear_has_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = timestamp_;
-  timestamp_ = NULL;
-  return temp;
-}
-void ResponseHeader::set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp) {
-  delete timestamp_;
-  timestamp_ = timestamp;
-  if (timestamp) {
-    set_has_timestamp();
-  } else {
-    clear_has_timestamp();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseHeader.timestamp)
-}
-
 // optional .cockroach.roachpb.Transaction txn = 3;
 bool ResponseHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
+  return (_has_bits_[0] & 0x00000001u) != 0;
 }
 void ResponseHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000002u;
+  _has_bits_[0] |= 0x00000001u;
 }
 void ResponseHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000002u;
+  _has_bits_[0] &= ~0x00000001u;
 }
 void ResponseHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -26480,6 +26389,7 @@ BatchRequest::requests() const {
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int BatchResponse_Header::kErrorFieldNumber;
+const int BatchResponse_Header::kTimestampFieldNumber;
 const int BatchResponse_Header::kTxnFieldNumber;
 const int BatchResponse_Header::kCollectedSpansFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
@@ -26492,6 +26402,7 @@ BatchResponse_Header::BatchResponse_Header()
 
 void BatchResponse_Header::InitAsDefaultInstance() {
   error_ = const_cast< ::cockroach::roachpb::Error*>(&::cockroach::roachpb::Error::default_instance());
+  timestamp_ = const_cast< ::cockroach::roachpb::Timestamp*>(&::cockroach::roachpb::Timestamp::default_instance());
   txn_ = const_cast< ::cockroach::roachpb::Transaction*>(&::cockroach::roachpb::Transaction::default_instance());
 }
 
@@ -26507,6 +26418,7 @@ void BatchResponse_Header::SharedCtor() {
   ::google::protobuf::internal::GetEmptyString();
   _cached_size_ = 0;
   error_ = NULL;
+  timestamp_ = NULL;
   txn_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -26519,6 +26431,7 @@ BatchResponse_Header::~BatchResponse_Header() {
 void BatchResponse_Header::SharedDtor() {
   if (this != default_instance_) {
     delete error_;
+    delete timestamp_;
     delete txn_;
   }
 }
@@ -26549,9 +26462,12 @@ BatchResponse_Header* BatchResponse_Header::New(::google::protobuf::Arena* arena
 }
 
 void BatchResponse_Header::Clear() {
-  if (_has_bits_[0 / 32] & 3u) {
+  if (_has_bits_[0 / 32] & 7u) {
     if (has_error()) {
       if (error_ != NULL) error_->::cockroach::roachpb::Error::Clear();
+    }
+    if (has_timestamp()) {
+      if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
     }
     if (has_txn()) {
       if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -26579,6 +26495,19 @@ bool BatchResponse_Header::MergePartialFromCodedStream(
         if (tag == 10) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_error()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(18)) goto parse_Timestamp;
+        break;
+      }
+
+      // optional .cockroach.roachpb.Timestamp Timestamp = 2;
+      case 2: {
+        if (tag == 18) {
+         parse_Timestamp:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_timestamp()));
         } else {
           goto handle_unusual;
         }
@@ -26644,6 +26573,12 @@ void BatchResponse_Header::SerializeWithCachedSizes(
       1, *this->error_, output);
   }
 
+  // optional .cockroach.roachpb.Timestamp Timestamp = 2;
+  if (has_timestamp()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2, *this->timestamp_, output);
+  }
+
   // optional .cockroach.roachpb.Transaction txn = 3;
   if (has_txn()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -26673,6 +26608,13 @@ void BatchResponse_Header::SerializeWithCachedSizes(
         1, *this->error_, target);
   }
 
+  // optional .cockroach.roachpb.Timestamp Timestamp = 2;
+  if (has_timestamp()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        2, *this->timestamp_, target);
+  }
+
   // optional .cockroach.roachpb.Transaction txn = 3;
   if (has_txn()) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -26697,12 +26639,19 @@ void BatchResponse_Header::SerializeWithCachedSizes(
 int BatchResponse_Header::ByteSize() const {
   int total_size = 0;
 
-  if (_has_bits_[0 / 32] & 3u) {
+  if (_has_bits_[0 / 32] & 7u) {
     // optional .cockroach.roachpb.Error error = 1;
     if (has_error()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *this->error_);
+    }
+
+    // optional .cockroach.roachpb.Timestamp Timestamp = 2;
+    if (has_timestamp()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *this->timestamp_);
     }
 
     // optional .cockroach.roachpb.Transaction txn = 3;
@@ -26750,6 +26699,9 @@ void BatchResponse_Header::MergeFrom(const BatchResponse_Header& from) {
     if (from.has_error()) {
       mutable_error()->::cockroach::roachpb::Error::MergeFrom(from.error());
     }
+    if (from.has_timestamp()) {
+      mutable_timestamp()->::cockroach::roachpb::Timestamp::MergeFrom(from.timestamp());
+    }
     if (from.has_txn()) {
       mutable_txn()->::cockroach::roachpb::Transaction::MergeFrom(from.txn());
     }
@@ -26782,6 +26734,7 @@ void BatchResponse_Header::Swap(BatchResponse_Header* other) {
 }
 void BatchResponse_Header::InternalSwap(BatchResponse_Header* other) {
   std::swap(error_, other->error_);
+  std::swap(timestamp_, other->timestamp_);
   std::swap(txn_, other->txn_);
   collected_spans_.UnsafeArenaSwap(&other->collected_spans_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -27121,15 +27074,58 @@ void BatchResponse_Header::set_allocated_error(::cockroach::roachpb::Error* erro
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BatchResponse.Header.error)
 }
 
-// optional .cockroach.roachpb.Transaction txn = 3;
-bool BatchResponse_Header::has_txn() const {
+// optional .cockroach.roachpb.Timestamp Timestamp = 2;
+bool BatchResponse_Header::has_timestamp() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-void BatchResponse_Header::set_has_txn() {
+void BatchResponse_Header::set_has_timestamp() {
   _has_bits_[0] |= 0x00000002u;
 }
-void BatchResponse_Header::clear_has_txn() {
+void BatchResponse_Header::clear_has_timestamp() {
   _has_bits_[0] &= ~0x00000002u;
+}
+void BatchResponse_Header::clear_timestamp() {
+  if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_timestamp();
+}
+const ::cockroach::roachpb::Timestamp& BatchResponse_Header::timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.BatchResponse.Header.Timestamp)
+  return timestamp_ != NULL ? *timestamp_ : *default_instance_->timestamp_;
+}
+::cockroach::roachpb::Timestamp* BatchResponse_Header::mutable_timestamp() {
+  set_has_timestamp();
+  if (timestamp_ == NULL) {
+    timestamp_ = new ::cockroach::roachpb::Timestamp;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.BatchResponse.Header.Timestamp)
+  return timestamp_;
+}
+::cockroach::roachpb::Timestamp* BatchResponse_Header::release_timestamp() {
+  clear_has_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = timestamp_;
+  timestamp_ = NULL;
+  return temp;
+}
+void BatchResponse_Header::set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp) {
+  delete timestamp_;
+  timestamp_ = timestamp;
+  if (timestamp) {
+    set_has_timestamp();
+  } else {
+    clear_has_timestamp();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BatchResponse.Header.Timestamp)
+}
+
+// optional .cockroach.roachpb.Transaction txn = 3;
+bool BatchResponse_Header::has_txn() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+void BatchResponse_Header::set_has_txn() {
+  _has_bits_[0] |= 0x00000004u;
+}
+void BatchResponse_Header::clear_has_txn() {
+  _has_bits_[0] &= ~0x00000004u;
 }
 void BatchResponse_Header::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();

--- a/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
+++ b/storage/engine/rocksdb/cockroach/roachpb/api.pb.h
@@ -208,15 +208,6 @@ class ResponseHeader : public ::google::protobuf::Message {
 
   // accessors -------------------------------------------------------
 
-  // optional .cockroach.roachpb.Timestamp timestamp = 2;
-  bool has_timestamp() const;
-  void clear_timestamp();
-  static const int kTimestampFieldNumber = 2;
-  const ::cockroach::roachpb::Timestamp& timestamp() const;
-  ::cockroach::roachpb::Timestamp* mutable_timestamp();
-  ::cockroach::roachpb::Timestamp* release_timestamp();
-  void set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp);
-
   // optional .cockroach.roachpb.Transaction txn = 3;
   bool has_txn() const;
   void clear_txn();
@@ -228,15 +219,12 @@ class ResponseHeader : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:cockroach.roachpb.ResponseHeader)
  private:
-  inline void set_has_timestamp();
-  inline void clear_has_timestamp();
   inline void set_has_txn();
   inline void clear_has_txn();
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
-  ::cockroach::roachpb::Timestamp* timestamp_;
   ::cockroach::roachpb::Transaction* txn_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
   friend void protobuf_AssignDesc_cockroach_2froachpb_2fapi_2eproto();
@@ -6558,6 +6546,15 @@ class BatchResponse_Header : public ::google::protobuf::Message {
   ::cockroach::roachpb::Error* release_error();
   void set_allocated_error(::cockroach::roachpb::Error* error);
 
+  // optional .cockroach.roachpb.Timestamp Timestamp = 2;
+  bool has_timestamp() const;
+  void clear_timestamp();
+  static const int kTimestampFieldNumber = 2;
+  const ::cockroach::roachpb::Timestamp& timestamp() const;
+  ::cockroach::roachpb::Timestamp* mutable_timestamp();
+  ::cockroach::roachpb::Timestamp* release_timestamp();
+  void set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp);
+
   // optional .cockroach.roachpb.Transaction txn = 3;
   bool has_txn() const;
   void clear_txn();
@@ -6587,6 +6584,8 @@ class BatchResponse_Header : public ::google::protobuf::Message {
  private:
   inline void set_has_error();
   inline void clear_has_error();
+  inline void set_has_timestamp();
+  inline void clear_has_timestamp();
   inline void set_has_txn();
   inline void clear_has_txn();
 
@@ -6594,6 +6593,7 @@ class BatchResponse_Header : public ::google::protobuf::Message {
   ::google::protobuf::uint32 _has_bits_[1];
   mutable int _cached_size_;
   ::cockroach::roachpb::Error* error_;
+  ::cockroach::roachpb::Timestamp* timestamp_;
   ::cockroach::roachpb::Transaction* txn_;
   ::google::protobuf::RepeatedPtrField< ::std::string> collected_spans_;
   friend void  protobuf_AddDesc_cockroach_2froachpb_2fapi_2eproto();
@@ -6717,58 +6717,15 @@ class BatchResponse : public ::google::protobuf::Message {
 #if !PROTOBUF_INLINE_NOT_IN_HEADERS
 // ResponseHeader
 
-// optional .cockroach.roachpb.Timestamp timestamp = 2;
-inline bool ResponseHeader::has_timestamp() const {
-  return (_has_bits_[0] & 0x00000001u) != 0;
-}
-inline void ResponseHeader::set_has_timestamp() {
-  _has_bits_[0] |= 0x00000001u;
-}
-inline void ResponseHeader::clear_has_timestamp() {
-  _has_bits_[0] &= ~0x00000001u;
-}
-inline void ResponseHeader::clear_timestamp() {
-  if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
-  clear_has_timestamp();
-}
-inline const ::cockroach::roachpb::Timestamp& ResponseHeader::timestamp() const {
-  // @@protoc_insertion_point(field_get:cockroach.roachpb.ResponseHeader.timestamp)
-  return timestamp_ != NULL ? *timestamp_ : *default_instance_->timestamp_;
-}
-inline ::cockroach::roachpb::Timestamp* ResponseHeader::mutable_timestamp() {
-  set_has_timestamp();
-  if (timestamp_ == NULL) {
-    timestamp_ = new ::cockroach::roachpb::Timestamp;
-  }
-  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.ResponseHeader.timestamp)
-  return timestamp_;
-}
-inline ::cockroach::roachpb::Timestamp* ResponseHeader::release_timestamp() {
-  clear_has_timestamp();
-  ::cockroach::roachpb::Timestamp* temp = timestamp_;
-  timestamp_ = NULL;
-  return temp;
-}
-inline void ResponseHeader::set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp) {
-  delete timestamp_;
-  timestamp_ = timestamp;
-  if (timestamp) {
-    set_has_timestamp();
-  } else {
-    clear_has_timestamp();
-  }
-  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.ResponseHeader.timestamp)
-}
-
 // optional .cockroach.roachpb.Transaction txn = 3;
 inline bool ResponseHeader::has_txn() const {
-  return (_has_bits_[0] & 0x00000002u) != 0;
+  return (_has_bits_[0] & 0x00000001u) != 0;
 }
 inline void ResponseHeader::set_has_txn() {
-  _has_bits_[0] |= 0x00000002u;
+  _has_bits_[0] |= 0x00000001u;
 }
 inline void ResponseHeader::clear_has_txn() {
-  _has_bits_[0] &= ~0x00000002u;
+  _has_bits_[0] &= ~0x00000001u;
 }
 inline void ResponseHeader::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();
@@ -13449,15 +13406,58 @@ inline void BatchResponse_Header::set_allocated_error(::cockroach::roachpb::Erro
   // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BatchResponse.Header.error)
 }
 
-// optional .cockroach.roachpb.Transaction txn = 3;
-inline bool BatchResponse_Header::has_txn() const {
+// optional .cockroach.roachpb.Timestamp Timestamp = 2;
+inline bool BatchResponse_Header::has_timestamp() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void BatchResponse_Header::set_has_txn() {
+inline void BatchResponse_Header::set_has_timestamp() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void BatchResponse_Header::clear_has_txn() {
+inline void BatchResponse_Header::clear_has_timestamp() {
   _has_bits_[0] &= ~0x00000002u;
+}
+inline void BatchResponse_Header::clear_timestamp() {
+  if (timestamp_ != NULL) timestamp_->::cockroach::roachpb::Timestamp::Clear();
+  clear_has_timestamp();
+}
+inline const ::cockroach::roachpb::Timestamp& BatchResponse_Header::timestamp() const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.BatchResponse.Header.Timestamp)
+  return timestamp_ != NULL ? *timestamp_ : *default_instance_->timestamp_;
+}
+inline ::cockroach::roachpb::Timestamp* BatchResponse_Header::mutable_timestamp() {
+  set_has_timestamp();
+  if (timestamp_ == NULL) {
+    timestamp_ = new ::cockroach::roachpb::Timestamp;
+  }
+  // @@protoc_insertion_point(field_mutable:cockroach.roachpb.BatchResponse.Header.Timestamp)
+  return timestamp_;
+}
+inline ::cockroach::roachpb::Timestamp* BatchResponse_Header::release_timestamp() {
+  clear_has_timestamp();
+  ::cockroach::roachpb::Timestamp* temp = timestamp_;
+  timestamp_ = NULL;
+  return temp;
+}
+inline void BatchResponse_Header::set_allocated_timestamp(::cockroach::roachpb::Timestamp* timestamp) {
+  delete timestamp_;
+  timestamp_ = timestamp;
+  if (timestamp) {
+    set_has_timestamp();
+  } else {
+    clear_has_timestamp();
+  }
+  // @@protoc_insertion_point(field_set_allocated:cockroach.roachpb.BatchResponse.Header.Timestamp)
+}
+
+// optional .cockroach.roachpb.Transaction txn = 3;
+inline bool BatchResponse_Header::has_txn() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void BatchResponse_Header::set_has_txn() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void BatchResponse_Header::clear_has_txn() {
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline void BatchResponse_Header::clear_txn() {
   if (txn_ != NULL) txn_->::cockroach::roachpb::Transaction::Clear();

--- a/storage/store.go
+++ b/storage/store.go
@@ -1527,7 +1527,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 		// before we reach that point.
 		offset := time.Duration(ba.Timestamp.WallTime - s.Clock().PhysicalNow())
 		if offset > s.Clock().MaxOffset() {
-			return nil, roachpb.NewErrorf("Rejecting command with timestamp in the future: %d (%s ahead)",
+			return nil, roachpb.NewErrorf("rejecting command with timestamp in the future: %d (%s ahead)",
 				ba.Timestamp.WallTime, offset)
 		}
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -746,16 +746,15 @@ func TestStoreSendWithZeroTime(t *testing.T) {
 
 	// Set clock to time 1.
 	mc.Set(1)
-	resp, pErr := client.SendWrapped(store.testSender(), nil, &args)
+	_, respH, pErr := SendWrapped(store.testSender(), context.Background(), roachpb.Header{}, &args)
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
-	reply := resp.(*roachpb.GetResponse)
 	// The Logical time will increase over the course of the command
 	// execution so we can only rely on comparing the WallTime.
-	if reply.Timestamp.WallTime != store.ctx.Clock.Now().WallTime {
+	if respH.Timestamp.WallTime != store.ctx.Clock.Now().WallTime {
 		t.Errorf("expected reply to have store clock time %s; got %s",
-			store.ctx.Clock.Now(), reply.Timestamp)
+			store.ctx.Clock.Now(), respH.Timestamp)
 	}
 }
 


### PR DESCRIPTION
- drop ResponseHeader.Timestamp
- re-add Timestamp field on BatchResponse_Heaeder; it is set only for a batch
  of non-transactional writes.
- minor cleanups in executeBatch (more to come, in particular copy-on-write for
  the Txn)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5228)

<!-- Reviewable:end -->
