### PR TITLE
stress: get all stack traces when testing

### DIFF
--- a/cloud/aws/stress/stress.sh
+++ b/cloud/aws/stress/stress.sh
@@ -12,6 +12,9 @@ MAX_FAILS=1
 STRESS_FLAGS="-maxruns ${MAX_RUNS} -maxtime ${MAX_TIME} -maxfails ${MAX_FAILS} -stderr"
 TEST_FLAGS="-test.v"
 
+# Enable dumping of all goroutine stacks due to unrecovered panics.
+export GOTRACEBACK=all
+
 # takes the full path to the test binary.
 function run_one_test {
   test_binary=$1


### PR DESCRIPTION
This will help debugging panicked stress tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5233)

<!-- Reviewable:end -->
