### PR TITLE
sql: Fix heterogeneous tuple comparisons

### DIFF
--- a/sql/testdata/select_index
+++ b/sql/testdata/select_index
@@ -287,3 +287,8 @@ query ITT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.0, 1)
 ----
 0 scan t@bc -
+
+query ITT
+EXPLAIN SELECT a FROM t WHERE b IN (5.0, 1)
+----
+0 scan t@b_desc -

--- a/sql/testdata/where
+++ b/sql/testdata/where
@@ -57,3 +57,11 @@ SELECT 'hello' SIMILAR TO v FROM kvString WHERE k SIMILAR TO 'like[1-2]'
 ----
 true
 false
+
+# Test mixed type tuple comparison.
+
+query II
+SELECT * FROM kv WHERE k IN (1, 5.0, 9)
+----
+1 2
+5 6


### PR DESCRIPTION
Fixes #3633.

Previously an IN comparision with a tuple value of a different type
(`1 IN (1.1, 2)`) would panic because `Datum.Compare` did not support
mixed types. This commit adds support for referencing mixed type
comparison ops when necessary in Compare. This allows operations like
sorting `DTuples`, making `DTuples` unique, and simplification to work correctly
when operating on heterogeneous types that are comparable.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5239)

<!-- Reviewable:end -->
