### PR TITLE
storage: replication error when not enough nodes to meet target

### DIFF
--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -84,6 +84,13 @@ const (
 	BalanceModeRangeCount
 )
 
+func pluralize(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
 // allocatorError indicates a retryable error condition which sends replicas
 // being processed through the replicate_queue into purgatory so that they
 // can be retried quickly as soon as new stores come online, or additional
@@ -91,15 +98,16 @@ const (
 type allocatorError struct {
 	required         roachpb.Attributes
 	relaxConstraints bool
+	aliveStoreCount  int
 }
 
 func (ae *allocatorError) Error() string {
-	anyAll := "all"
+	anyAll := "all attributes"
 	if ae.relaxConstraints {
-		anyAll = "any"
+		anyAll = "an attribute"
 	}
-	return fmt.Sprintf("no target store with %s attributes matching %s available, are you running enough nodes?",
-		anyAll, ae.required)
+	return fmt.Sprintf("0 of %d store%s with %s matching [%s]",
+		ae.aliveStoreCount, pluralize(ae.aliveStoreCount), anyAll, ae.required)
 }
 
 func (*allocatorError) purgatoryErrorMarker() {}
@@ -252,12 +260,16 @@ func (a *Allocator) AllocateTarget(required roachpb.Attributes, existing []roach
 	// matching here is lenient, and tries to find a target by relaxing an
 	// attribute constraint, from last attribute to first.
 	for attrs := append([]string(nil), required.Attrs...); ; attrs = attrs[:len(attrs)-1] {
-		sl := a.storePool.getStoreList(roachpb.Attributes{Attrs: attrs}, a.options.Deterministic)
+		sl, aliveStoreCount := a.storePool.getStoreList(roachpb.Attributes{Attrs: attrs}, a.options.Deterministic)
 		if target := a.balancer.selectGood(sl, existingNodes); target != nil {
 			return target, nil
 		}
 		if len(attrs) == 0 || !relaxConstraints {
-			return nil, &allocatorError{required: required, relaxConstraints: relaxConstraints}
+			return nil, &allocatorError{
+				required:         required,
+				relaxConstraints: relaxConstraints,
+				aliveStoreCount:  aliveStoreCount,
+			}
 		}
 	}
 }
@@ -320,7 +332,7 @@ func (a Allocator) RebalanceTarget(storeID roachpb.StoreID, required roachpb.Att
 		existingNodes[repl.NodeID] = struct{}{}
 	}
 	storeDesc := a.storePool.getStoreDescriptor(storeID)
-	sl := a.storePool.getStoreList(required, a.options.Deterministic)
+	sl, _ := a.storePool.getStoreList(required, a.options.Deterministic)
 	if replacement := a.balancer.improve(storeDesc, sl, existingNodes); replacement != nil {
 		return replacement
 	}
@@ -350,7 +362,7 @@ func (a Allocator) ShouldRebalance(storeID roachpb.StoreID) bool {
 		return false
 	}
 
-	sl := a.storePool.getStoreList(*storeDesc.CombinedAttrs(), a.options.Deterministic)
+	sl, _ := a.storePool.getStoreList(*storeDesc.CombinedAttrs(), a.options.Deterministic)
 
 	// ShouldRebalance is true if a suitable replacement can be found.
 	return a.balancer.improve(storeDesc, sl, makeNodeIDSet(storeDesc.Node.NodeID)) != nil

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -1069,6 +1069,35 @@ func TestAllocatorComputeActionNoStorePool(t *testing.T) {
 	}
 }
 
+// TestAllocatorError ensures that the correctly formatted error message is
+// returned from an allocatorError.
+func TestAllocatorError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	attribute := roachpb.Attributes{Attrs: []string{"one"}}
+	attributes := roachpb.Attributes{Attrs: []string{"one", "two"}}
+
+	testCases := []struct {
+		ae       allocatorError
+		expected string
+	}{
+		{allocatorError{attribute, false, 1}, "0 of 1 store with all attributes matching [one]"},
+		{allocatorError{attribute, true, 1}, "0 of 1 store with an attribute matching [one]"},
+		{allocatorError{attribute, false, 2}, "0 of 2 stores with all attributes matching [one]"},
+		{allocatorError{attribute, true, 2}, "0 of 2 stores with an attribute matching [one]"},
+		{allocatorError{attributes, false, 1}, "0 of 1 store with all attributes matching [one,two]"},
+		{allocatorError{attributes, true, 1}, "0 of 1 store with an attribute matching [one,two]"},
+		{allocatorError{attributes, false, 2}, "0 of 2 stores with all attributes matching [one,two]"},
+		{allocatorError{attributes, true, 2}, "0 of 2 stores with an attribute matching [one,two]"},
+	}
+
+	for i, testCase := range testCases {
+		if actual := testCase.ae.Error(); testCase.expected != actual {
+			t.Errorf("%d: actual error message \"%s\" does not match expected \"%s\"", i, actual, testCase.expected)
+		}
+	}
+}
+
 type testStore struct {
 	roachpb.StoreDescriptor
 }

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -303,11 +303,12 @@ func (sl *StoreList) add(s *roachpb.StoreDescriptor) {
 }
 
 // GetStoreList returns a storeList that contains all active stores that
-// contain the required attributes and their associated stats.
+// contain the required attributes and their associated stats. It also returns
+// the number of total alive stores.
 // TODO(embark, spencer): consider using a reverse index map from
 // Attr->stores, for efficiency. Ensure that entries in this map still
 // have an opportunity to be garbage collected.
-func (sp *StorePool) getStoreList(required roachpb.Attributes, deterministic bool) StoreList {
+func (sp *StorePool) getStoreList(required roachpb.Attributes, deterministic bool) (StoreList, int) {
 	sp.mu.RLock()
 	defer sp.mu.RUnlock()
 
@@ -321,12 +322,16 @@ func (sp *StorePool) getStoreList(required roachpb.Attributes, deterministic boo
 		sort.Sort(storeIDs)
 	}
 	sl := StoreList{}
+	var aliveStoreCount int
 	for _, storeID := range storeIDs {
 		detail := sp.stores[roachpb.StoreID(storeID)]
-		if !detail.dead && required.IsSubset(*detail.desc.CombinedAttrs()) {
-			desc := detail.desc
-			sl.add(&desc)
+		if !detail.dead {
+			aliveStoreCount++
+			if required.IsSubset(*detail.desc.CombinedAttrs()) {
+				desc := detail.desc
+				sl.add(&desc)
+			}
 		}
 	}
-	return sl
+	return sl, aliveStoreCount
 }

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -199,9 +199,13 @@ func TestStorePoolDies(t *testing.T) {
 }
 
 // verifyStoreList ensures that the returned list of stores is correct.
-func verifyStoreList(sp *StorePool, requiredAttrs []string, expected []int) error {
+func verifyStoreList(sp *StorePool, requiredAttrs []string, expected []int, expectedAliveStoreCount int) error {
 	var actual []int
-	sl := sp.getStoreList(roachpb.Attributes{Attrs: requiredAttrs}, false)
+	sl, aliveStoreCount := sp.getStoreList(roachpb.Attributes{Attrs: requiredAttrs}, false)
+	if aliveStoreCount != expectedAliveStoreCount {
+		return fmt.Errorf("expected AliveStoreCount %d does not match actual %d", expectedAliveStoreCount,
+			aliveStoreCount)
+	}
 	for _, store := range sl.stores {
 		actual = append(actual, int(store.StoreID))
 	}
@@ -223,7 +227,7 @@ func TestStorePoolGetStoreList(t *testing.T) {
 	sg := gossiputil.NewStoreGossiper(g)
 	required := []string{"ssd", "dc"}
 	// Nothing yet.
-	if sl := sp.getStoreList(roachpb.Attributes{Attrs: required}, false); len(sl.stores) != 0 {
+	if sl, _ := sp.getStoreList(roachpb.Attributes{Attrs: required}, false); len(sl.stores) != 0 {
 		t.Errorf("expected no stores, instead %+v", sl.stores)
 	}
 
@@ -266,7 +270,7 @@ func TestStorePoolGetStoreList(t *testing.T) {
 		int(matchingStore.StoreID),
 		int(supersetStore.StoreID),
 		int(deadStore.StoreID),
-	}); err != nil {
+	}, 5); err != nil {
 		t.Error(err)
 	}
 
@@ -278,7 +282,7 @@ func TestStorePoolGetStoreList(t *testing.T) {
 	if err := verifyStoreList(sp, required, []int{
 		int(matchingStore.StoreID),
 		int(supersetStore.StoreID),
-	}); err != nil {
+	}, 4); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
fixes #4623

This add the total number of available stores to StorePool.GetStores() and uses
that number for the improved error message as specified in #4623.

The new message 
`0 of %d stores with [any|all] attributes matching %s`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5244)

<!-- Reviewable:end -->
