### PR TITLE
storage: Fix LastUpdateNanos becoming inconsistent with splits/merges.

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1699,8 +1699,7 @@ func (r *Replica) splitTrigger(batch engine.Engine, ms *engine.MVCCStats, split 
 	}
 
 	// Compute stats for updated range.
-	now := r.store.Clock().Timestamp()
-	leftMs, err := ComputeStatsForRange(&split.UpdatedDesc, batch, now.WallTime)
+	leftMs, err := ComputeStatsForRange(&split.UpdatedDesc, batch, origStats.LastUpdateNanos)
 	if err != nil {
 		return util.Errorf("unable to compute stats for updated range after split: %s", err)
 	}
@@ -1975,8 +1974,7 @@ func (r *Replica) mergeTrigger(batch engine.Engine, ms *engine.MVCCStats, merge 
 	defer iter.Close()
 	localRangeKeyStart := engine.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(merge.SubsumedDesc.StartKey))
 	localRangeKeyEnd := engine.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(merge.SubsumedDesc.EndKey))
-	now := r.store.Clock().Timestamp()
-	msRange, err := iter.ComputeStats(localRangeKeyStart, localRangeKeyEnd, now.WallTime)
+	msRange, err := iter.ComputeStats(localRangeKeyStart, localRangeKeyEnd, mergedMs.LastUpdateNanos)
 	if err != nil {
 		return util.Errorf("unable to compute subsumed range's local stats: %s", err)
 	}


### PR DESCRIPTION
Because RangeStats are meant to be consistent the LastUpdateNanos
cannot be set using the wallclock on the local node. During a
split/merge the new replica uses a LastUpdateNanos value from an
existing consistent value.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5245)

<!-- Reviewable:end -->
