### PR TITLE
engine: plumb a Context into MVCC

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -636,6 +636,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			// getDescriptors may fail retryably if the first range isn't
 			// available via Gossip.
 			if pErr != nil {
+				log.Trace(ctx, "range descriptor lookup failed: "+pErr.String())
 				if pErr.Retryable {
 					if log.V(1) {
 						log.Warning(pErr)
@@ -643,6 +644,8 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 					continue
 				}
 				break
+			} else {
+				log.Trace(ctx, "looked up range descriptor")
 			}
 
 			if needAnother && br == nil {

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -21,6 +21,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
@@ -56,7 +58,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 	key := testutils.MakeKey(keys.Meta1Prefix, roachpb.KeyMax)
 	now := s.Clock().Now()
 	txn := roachpb.NewTransaction("txn", roachpb.Key("foobar"), 0, roachpb.SERIALIZABLE, now, 0)
-	if err := engine.MVCCPutProto(s.Ctx.Engines[0], nil, key, now, txn, &roachpb.RangeDescriptor{}); err != nil {
+	if err := engine.MVCCPutProto(context.Background(), s.Ctx.Engines[0], nil, key, now, txn, &roachpb.RangeDescriptor{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
@@ -117,7 +119,7 @@ func TestRangeSplitMeta(t *testing.T) {
 	}
 
 	util.SucceedsSoon(t, func() error {
-		if _, _, err := engine.MVCCScan(s.Eng, keys.LocalMax, roachpb.KeyMax, 0, roachpb.MaxTimestamp, true, nil); err != nil {
+		if _, _, err := engine.MVCCScan(context.Background(), s.Eng, keys.LocalMax, roachpb.KeyMax, 0, roachpb.MaxTimestamp, true, nil); err != nil {
 			return util.Errorf("failed to verify no dangling intents: %s", err)
 		}
 		return nil
@@ -214,7 +216,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// for timing of finishing the test writer and a possibly-ongoing
 	// asynchronous split.
 	util.SucceedsSoon(t, func() error {
-		if _, _, err := engine.MVCCScan(s.Eng, keys.LocalMax, roachpb.KeyMax, 0, roachpb.MaxTimestamp, true, nil); err != nil {
+		if _, _, err := engine.MVCCScan(context.Background(), s.Eng, keys.LocalMax, roachpb.KeyMax, 0, roachpb.MaxTimestamp, true, nil); err != nil {
 			return util.Errorf("failed to verify no dangling intents: %s", err)
 		}
 		return nil

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -452,12 +454,12 @@ func TestUncertaintyMaxTimestampForwarding(t *testing.T) {
 	futureTS := s.Clock.Now()
 	futureTS.WallTime += offsetNS
 	val := roachpb.MakeValueFromBytes(valSlow)
-	if err := engine.MVCCPut(s.Eng, nil, keySlow, futureTS, val, nil); err != nil {
+	if err := engine.MVCCPut(context.Background(), s.Eng, nil, keySlow, futureTS, val, nil); err != nil {
 		t.Fatal(err)
 	}
 	futureTS.WallTime += offsetNS
 	val.SetBytes(valFast)
-	if err := engine.MVCCPut(s.Eng, nil, keyFast, futureTS, val, nil); err != nil {
+	if err := engine.MVCCPut(context.Background(), s.Eng, nil, keyFast, futureTS, val, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -135,7 +137,7 @@ func TestBootstrapCluster(t *testing.T) {
 	}
 
 	// Scan the complete contents of the local database directly from the engine.
-	rows, _, err := engine.MVCCScan(e, keys.LocalMax, roachpb.KeyMax, 0, roachpb.MaxTimestamp, true, nil)
+	rows, _, err := engine.MVCCScan(context.Background(), e, keys.LocalMax, roachpb.KeyMax, 0, roachpb.MaxTimestamp, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +293,7 @@ func TestCorruptedClusterID(t *testing.T) {
 		NodeID:    1,
 		StoreID:   1,
 	}
-	if err := engine.MVCCPutProto(e, nil, keys.StoreIdentKey(), roachpb.ZeroTimestamp, nil, &sIdent); err != nil {
+	if err := engine.MVCCPutProto(context.Background(), e, nil, keys.StoreIdentKey(), roachpb.ZeroTimestamp, nil, &sIdent); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/addressing_test.go
+++ b/storage/addressing_test.go
@@ -23,6 +23,8 @@ import (
 	"sort"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -137,7 +139,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Scan meta keys directly from engine.
-		kvs, _, err := engine.MVCCScan(store.Engine(), keys.MetaMin, keys.MetaMax, 0, roachpb.MaxTimestamp, true, nil)
+		kvs, _, err := engine.MVCCScan(context.Background(), store.Engine(), keys.MetaMin, keys.MetaMax, 0, roachpb.MaxTimestamp, true, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -98,7 +98,7 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	defer stopper.Stop()
 
 	scan := func(f func(roachpb.KeyValue) (bool, error)) {
-		if _, err := engine.MVCCIterate(store.Engine(), roachpb.KeyMin, roachpb.KeyMax, roachpb.ZeroTimestamp, true, nil, false, f); err != nil {
+		if _, err := engine.MVCCIterate(context.Background(), store.Engine(), roachpb.KeyMin, roachpb.KeyMax, roachpb.ZeroTimestamp, true, nil, false, f); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -222,7 +222,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Verify no intents remains on range descriptor keys.
 	for _, key := range []roachpb.Key{keys.RangeDescriptorKey(aDesc.StartKey), keys.RangeDescriptorKey(bDesc.StartKey)} {
-		if _, _, err := engine.MVCCGet(store.Engine(), key, store.Clock().Now(), true, nil); err != nil {
+		if _, _, err := engine.MVCCGet(context.Background(), store.Engine(), key, store.Clock().Now(), true, nil); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -382,10 +382,10 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	var msA, msB engine.MVCCStats
 	snap := store.Engine().NewSnapshot()
 	defer snap.Close()
-	if err := engine.MVCCGetRangeStats(snap, aDesc.RangeID, &msA); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), snap, aDesc.RangeID, &msA); err != nil {
 		t.Fatal(err)
 	}
-	if err := engine.MVCCGetRangeStats(snap, bDesc.RangeID, &msB); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), snap, bDesc.RangeID, &msB); err != nil {
 		t.Fatal(err)
 	}
 
@@ -410,7 +410,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	snap = store.Engine().NewSnapshot()
 	defer snap.Close()
 	var msMerged engine.MVCCStats
-	if err := engine.MVCCGetRangeStats(snap, rngMerged.RangeID, &msMerged); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), snap, rngMerged.RangeID, &msMerged); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -241,7 +241,7 @@ func TestReplicateRange(t *testing.T) {
 	// Verify no intent remains on range descriptor key.
 	key := keys.RangeDescriptorKey(rng.Desc().StartKey)
 	desc := roachpb.RangeDescriptor{}
-	if ok, err := engine.MVCCGetProto(mtc.stores[0].Engine(), key, mtc.stores[0].Clock().Now(), true, nil, &desc); !ok || err != nil {
+	if ok, err := engine.MVCCGetProto(context.Background(), mtc.stores[0].Engine(), key, mtc.stores[0].Clock().Now(), true, nil, &desc); !ok || err != nil {
 		t.Fatalf("fetching range descriptor yielded %t, %s", ok, err)
 	}
 	// Verify that in time, no intents remain on meta addressing
@@ -257,7 +257,7 @@ func TestReplicateRange(t *testing.T) {
 		}
 		for _, key := range []roachpb.RKey{meta2, meta1} {
 			metaDesc := roachpb.RangeDescriptor{}
-			if ok, err := engine.MVCCGetProto(mtc.stores[0].Engine(), key.AsRawKey(), mtc.stores[0].Clock().Now(), true, nil, &metaDesc); !ok || err != nil {
+			if ok, err := engine.MVCCGetProto(context.Background(), mtc.stores[0].Engine(), key.AsRawKey(), mtc.stores[0].Clock().Now(), true, nil, &metaDesc); !ok || err != nil {
 				return util.Errorf("failed to resolve %s", key.AsRawKey())
 			}
 			if !reflect.DeepEqual(metaDesc, desc) {
@@ -767,7 +767,7 @@ func TestProgressWithDownNode(t *testing.T) {
 		util.SucceedsSoon(t, func() error {
 			values := []int64{}
 			for _, eng := range mtc.engines {
-				val, _, err := engine.MVCCGet(eng, roachpb.Key("a"), mtc.clock.Now(), true, nil)
+				val, _, err := engine.MVCCGet(context.Background(), eng, roachpb.Key("a"), mtc.clock.Now(), true, nil)
 				if err != nil {
 					return err
 				}
@@ -816,7 +816,7 @@ func TestReplicateAddAndRemove(t *testing.T) {
 			util.SucceedsSoon(t, func() error {
 				values := []int64{}
 				for _, eng := range mtc.engines {
-					val, _, err := engine.MVCCGet(eng, roachpb.Key("a"), mtc.clock.Now(), true, nil)
+					val, _, err := engine.MVCCGet(context.Background(), eng, roachpb.Key("a"), mtc.clock.Now(), true, nil)
 					if err != nil {
 						return err
 					}
@@ -1475,7 +1475,7 @@ func TestRemoveRangeWithoutGC(t *testing.T) {
 	// object is removed.
 	var desc roachpb.RangeDescriptor
 	descKey := keys.RangeDescriptorKey(roachpb.RKeyMin)
-	if ok, err := engine.MVCCGetProto(mtc.stores[0].Engine(), descKey,
+	if ok, err := engine.MVCCGetProto(context.Background(), mtc.stores[0].Engine(), descKey,
 		mtc.stores[0].Clock().Now(), true, nil, &desc); err != nil {
 		t.Fatal(err)
 	} else if !ok {
@@ -1500,7 +1500,7 @@ func TestRemoveRangeWithoutGC(t *testing.T) {
 	}
 
 	// And the data is no longer on disk.
-	if ok, err := engine.MVCCGetProto(mtc.stores[0].Engine(), descKey,
+	if ok, err := engine.MVCCGetProto(context.Background(), mtc.stores[0].Engine(), descKey,
 		mtc.stores[0].Clock().Now(), true, nil, &desc); err != nil {
 		t.Fatal(err)
 	} else if ok {
@@ -1565,7 +1565,7 @@ func TestCheckInconsistent(t *testing.T) {
 	var val roachpb.Value
 	val.SetInt(42)
 	timestamp := mtc.stores[1].Clock().Timestamp()
-	if err := engine.MVCCPut(mtc.stores[1].Engine(), nil, key, timestamp, val, nil); err != nil {
+	if err := engine.MVCCPut(context.Background(), mtc.stores[1].Engine(), nil, key, timestamp, val, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
@@ -71,7 +73,7 @@ func TestRangeCommandClockUpdate(t *testing.T) {
 	util.SucceedsSoon(t, func() error {
 		values := []int64{}
 		for _, eng := range mtc.engines {
-			val, _, err := engine.MVCCGet(eng, roachpb.Key("a"), clocks[0].Now(), true, nil)
+			val, _, err := engine.MVCCGet(context.Background(), eng, roachpb.Key("a"), clocks[0].Now(), true, nil)
 			if err != nil {
 				return err
 			}
@@ -148,7 +150,7 @@ func TestRejectFutureCommand(t *testing.T) {
 	if now := clock.Now(); now.WallTime != int64(190*time.Millisecond) {
 		t.Errorf("expected clock to advance to 190ms; got %s", now)
 	}
-	val, _, err := engine.MVCCGet(mtc.engines[0], roachpb.Key("a"), clock.Now(), true, nil)
+	val, _, err := engine.MVCCGet(context.Background(), mtc.engines[0], roachpb.Key("a"), clock.Now(), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -295,7 +295,7 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 
 	// Get the original stats for key and value bytes.
 	var ms engine.MVCCStats
-	if err := engine.MVCCGetRangeStats(store.Engine(), rangeID, &ms); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), rangeID, &ms); err != nil {
 		t.Fatal(err)
 	}
 	keyBytes, valBytes := ms.KeyBytes, ms.ValBytes
@@ -312,7 +312,7 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, key := range []roachpb.Key{keys.RangeDescriptorKey(roachpb.RKeyMin), keys.RangeDescriptorKey(splitKeyAddr)} {
-		if _, _, err := engine.MVCCGet(store.Engine(), key, store.Clock().Now(), true, nil); err != nil {
+		if _, _, err := engine.MVCCGet(context.Background(), store.Engine(), key, store.Clock().Now(), true, nil); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -370,11 +370,11 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 	// Compare stats of split ranges to ensure they are non zero and
 	// exceed the original range when summed.
 	var left, right engine.MVCCStats
-	if err := engine.MVCCGetRangeStats(store.Engine(), rangeID, &left); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), rangeID, &left); err != nil {
 		t.Fatal(err)
 	}
 	lKeyBytes, lValBytes := left.KeyBytes, left.ValBytes
-	if err := engine.MVCCGetRangeStats(store.Engine(), newRng.RangeID, &right); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), newRng.RangeID, &right); err != nil {
 		t.Fatal(err)
 	}
 	rKeyBytes, rValBytes := right.KeyBytes, right.ValBytes
@@ -426,7 +426,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	snap := store.Engine().NewSnapshot()
 	defer snap.Close()
 	var ms engine.MVCCStats
-	if err := engine.MVCCGetRangeStats(snap, rng.RangeID, &ms); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), snap, rng.RangeID, &ms); err != nil {
 		t.Fatal(err)
 	}
 	if err := verifyRecomputedStats(snap, rng.Desc(), ms, manual.UnixNano()); err != nil {
@@ -449,11 +449,11 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	snap = store.Engine().NewSnapshot()
 	defer snap.Close()
 	var msLeft, msRight engine.MVCCStats
-	if err := engine.MVCCGetRangeStats(snap, rng.RangeID, &msLeft); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), snap, rng.RangeID, &msLeft); err != nil {
 		t.Fatal(err)
 	}
 	rngRight := store.LookupReplica(midKey, nil)
-	if err := engine.MVCCGetRangeStats(snap, rngRight.RangeID, &msRight); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), snap, rngRight.RangeID, &msRight); err != nil {
 		t.Fatal(err)
 	}
 
@@ -498,7 +498,7 @@ func fillRange(store *storage.Store, rangeID roachpb.RangeID, prefix roachpb.Key
 	src := rand.New(rand.NewSource(0))
 	for {
 		var ms engine.MVCCStats
-		if err := engine.MVCCGetRangeStats(store.Engine(), rangeID, &ms); err != nil {
+		if err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), rangeID, &ms); err != nil {
 			t.Fatal(err)
 		}
 		keyBytes, valBytes := ms.KeyBytes, ms.ValBytes

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -804,7 +804,7 @@ func (m *multiTestContext) unreplicateRange(rangeID roachpb.RangeID, dest int) {
 func (m *multiTestContext) readIntFromEngines(key roachpb.Key) []int64 {
 	results := make([]int64, len(m.engines))
 	for i, eng := range m.engines {
-		val, _, err := engine.MVCCGet(eng, key, m.clock.Now(), true, nil)
+		val, _, err := engine.MVCCGet(context.Background(), eng, key, m.clock.Now(), true, nil)
 		if err != nil {
 			log.Errorf("engine %d: error reading from key %s: %s", i, key, err)
 		} else if val == nil {
@@ -977,7 +977,7 @@ func TestSortRangeDescByAge(t *testing.T) {
 
 func verifyRangeStats(eng engine.Engine, rangeID roachpb.RangeID, expMS engine.MVCCStats) error {
 	var ms engine.MVCCStats
-	if err := engine.MVCCGetRangeStats(eng, rangeID, &ms); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), eng, rangeID, &ms); err != nil {
 		return err
 	}
 	// Clear system counts as these are expected to vary.

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -89,7 +91,7 @@ func TestIDAllocatorNegativeValue(t *testing.T) {
 	defer stopper.Stop()
 
 	// Increment our key to a negative value.
-	newValue, err := engine.MVCCIncrement(store.Engine(), nil, keys.RangeIDGenerator, store.ctx.Clock.Now(), nil, -1024)
+	newValue, err := engine.MVCCIncrement(context.Background(), store.Engine(), nil, keys.RangeIDGenerator, store.ctx.Clock.Now(), nil, -1024)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -86,39 +86,39 @@ func (r *Replica) executeCmd(ctx context.Context, raftCmdID storagebase.CmdIDKey
 	switch tArgs := args.(type) {
 	case *roachpb.GetRequest:
 		var resp roachpb.GetResponse
-		resp, intents, err = r.Get(batch, h, *tArgs)
+		resp, intents, err = r.Get(ctx, batch, h, *tArgs)
 		reply = &resp
 	case *roachpb.PutRequest:
 		var resp roachpb.PutResponse
-		resp, err = r.Put(batch, ms, h, *tArgs)
+		resp, err = r.Put(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.ConditionalPutRequest:
 		var resp roachpb.ConditionalPutResponse
-		resp, err = r.ConditionalPut(batch, ms, h, *tArgs)
+		resp, err = r.ConditionalPut(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.IncrementRequest:
 		var resp roachpb.IncrementResponse
-		resp, err = r.Increment(batch, ms, h, *tArgs)
+		resp, err = r.Increment(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.DeleteRequest:
 		var resp roachpb.DeleteResponse
-		resp, err = r.Delete(batch, ms, h, *tArgs)
+		resp, err = r.Delete(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.DeleteRangeRequest:
 		var resp roachpb.DeleteRangeResponse
-		resp, err = r.DeleteRange(batch, ms, h, *tArgs)
+		resp, err = r.DeleteRange(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.ScanRequest:
 		var resp roachpb.ScanResponse
-		resp, intents, err = r.Scan(batch, h, remScanResults, *tArgs)
+		resp, intents, err = r.Scan(ctx, batch, h, remScanResults, *tArgs)
 		reply = &resp
 	case *roachpb.ReverseScanRequest:
 		var resp roachpb.ReverseScanResponse
-		resp, intents, err = r.ReverseScan(batch, h, remScanResults, *tArgs)
+		resp, intents, err = r.ReverseScan(ctx, batch, h, remScanResults, *tArgs)
 		reply = &resp
 	case *roachpb.BeginTransactionRequest:
 		var resp roachpb.BeginTransactionResponse
-		resp, err = r.BeginTransaction(batch, ms, h, *tArgs)
+		resp, err = r.BeginTransaction(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.EndTransactionRequest:
 		var resp roachpb.EndTransactionResponse
@@ -126,47 +126,47 @@ func (r *Replica) executeCmd(ctx context.Context, raftCmdID storagebase.CmdIDKey
 		reply = &resp
 	case *roachpb.RangeLookupRequest:
 		var resp roachpb.RangeLookupResponse
-		resp, intents, err = r.RangeLookup(batch, h, *tArgs)
+		resp, intents, err = r.RangeLookup(ctx, batch, h, *tArgs)
 		reply = &resp
 	case *roachpb.HeartbeatTxnRequest:
 		var resp roachpb.HeartbeatTxnResponse
-		resp, err = r.HeartbeatTxn(batch, ms, h, *tArgs)
+		resp, err = r.HeartbeatTxn(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.GCRequest:
 		var resp roachpb.GCResponse
-		resp, err = r.GC(batch, ms, h, *tArgs)
+		resp, err = r.GC(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.PushTxnRequest:
 		var resp roachpb.PushTxnResponse
-		resp, err = r.PushTxn(batch, ms, h, *tArgs)
+		resp, err = r.PushTxn(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.ResolveIntentRequest:
 		var resp roachpb.ResolveIntentResponse
-		resp, err = r.ResolveIntent(batch, ms, h, *tArgs)
+		resp, err = r.ResolveIntent(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.ResolveIntentRangeRequest:
 		var resp roachpb.ResolveIntentRangeResponse
-		resp, err = r.ResolveIntentRange(batch, ms, h, *tArgs)
+		resp, err = r.ResolveIntentRange(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.MergeRequest:
 		var resp roachpb.MergeResponse
-		resp, err = r.Merge(batch, ms, h, *tArgs)
+		resp, err = r.Merge(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.TruncateLogRequest:
 		var resp roachpb.TruncateLogResponse
-		resp, err = r.TruncateLog(batch, ms, h, *tArgs)
+		resp, err = r.TruncateLog(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.LeaderLeaseRequest:
 		var resp roachpb.LeaderLeaseResponse
-		resp, err = r.LeaderLease(batch, ms, h, *tArgs)
+		resp, err = r.LeaderLease(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.ComputeChecksumRequest:
 		var resp roachpb.ComputeChecksumResponse
-		resp, err = r.ComputeChecksum(batch, ms, h, *tArgs)
+		resp, err = r.ComputeChecksum(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	case *roachpb.VerifyChecksumRequest:
 		var resp roachpb.VerifyChecksumResponse
-		resp, err = r.VerifyChecksum(batch, ms, h, *tArgs)
+		resp, err = r.VerifyChecksum(ctx, batch, ms, h, *tArgs)
 		reply = &resp
 	default:
 		err = util.Errorf("unrecognized command %s", args.Method())
@@ -190,67 +190,67 @@ func (r *Replica) executeCmd(ctx context.Context, raftCmdID storagebase.CmdIDKey
 
 // Get returns the value for a specified key.
 func (r *Replica) Get(
-	batch engine.Engine, h roachpb.Header, args roachpb.GetRequest,
+	ctx context.Context, batch engine.Engine, h roachpb.Header, args roachpb.GetRequest,
 ) (roachpb.GetResponse, []roachpb.Intent, error) {
 	var reply roachpb.GetResponse
 
-	val, intents, err := engine.MVCCGet(batch, args.Key, h.Timestamp, h.ReadConsistency == roachpb.CONSISTENT, h.Txn)
+	val, intents, err := engine.MVCCGet(ctx, batch, args.Key, h.Timestamp, h.ReadConsistency == roachpb.CONSISTENT, h.Txn)
 	reply.Value = val
 	return reply, intents, err
 }
 
 // Put sets the value for a specified key.
 func (r *Replica) Put(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.PutRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.PutRequest,
 ) (roachpb.PutResponse, error) {
 	var reply roachpb.PutResponse
 	ts := roachpb.ZeroTimestamp
 	if !args.Inline {
 		ts = h.Timestamp
 	}
-	return reply, engine.MVCCPut(batch, ms, args.Key, ts, args.Value, h.Txn)
+	return reply, engine.MVCCPut(ctx, batch, ms, args.Key, ts, args.Value, h.Txn)
 }
 
 // ConditionalPut sets the value for a specified key only if
 // the expected value matches. If not, the return value contains
 // the actual value.
 func (r *Replica) ConditionalPut(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.ConditionalPutRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.ConditionalPutRequest,
 ) (roachpb.ConditionalPutResponse, error) {
 	var reply roachpb.ConditionalPutResponse
 
-	return reply, engine.MVCCConditionalPut(batch, ms, args.Key, h.Timestamp, args.Value, args.ExpValue, h.Txn)
+	return reply, engine.MVCCConditionalPut(ctx, batch, ms, args.Key, h.Timestamp, args.Value, args.ExpValue, h.Txn)
 }
 
 // Increment increments the value (interpreted as varint64 encoded) and
 // returns the newly incremented value (encoded as varint64). If no value
 // exists for the key, zero is incremented.
 func (r *Replica) Increment(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.IncrementRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.IncrementRequest,
 ) (roachpb.IncrementResponse, error) {
 	var reply roachpb.IncrementResponse
 
-	newVal, err := engine.MVCCIncrement(batch, ms, args.Key, h.Timestamp, h.Txn, args.Increment)
+	newVal, err := engine.MVCCIncrement(ctx, batch, ms, args.Key, h.Timestamp, h.Txn, args.Increment)
 	reply.NewValue = newVal
 	return reply, err
 }
 
 // Delete deletes the key and value specified by key.
 func (r *Replica) Delete(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.DeleteRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.DeleteRequest,
 ) (roachpb.DeleteResponse, error) {
 	var reply roachpb.DeleteResponse
 
-	return reply, engine.MVCCDelete(batch, ms, args.Key, h.Timestamp, h.Txn)
+	return reply, engine.MVCCDelete(ctx, batch, ms, args.Key, h.Timestamp, h.Txn)
 }
 
 // DeleteRange deletes the range of key/value pairs specified by
 // start and end keys.
 func (r *Replica) DeleteRange(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.DeleteRangeRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.DeleteRangeRequest,
 ) (roachpb.DeleteRangeResponse, error) {
 	var reply roachpb.DeleteRangeResponse
-	deleted, err := engine.MVCCDeleteRange(batch, ms, args.Key, args.EndKey, args.MaxEntriesToDelete, h.Timestamp, h.Txn, args.ReturnKeys)
+	deleted, err := engine.MVCCDeleteRange(ctx, batch, ms, args.Key, args.EndKey, args.MaxEntriesToDelete, h.Timestamp, h.Txn, args.ReturnKeys)
 	reply.Keys = deleted
 	return reply, err
 }
@@ -276,7 +276,7 @@ func scanMaxResultsValue(remScanResults int64, scanMaxResults int64) int64 {
 // Scan scans the key range specified by start key through end key in ascending order up to some
 // maximum number of results. remScanResults stores the number of scan results remaining for this
 // batch (MaxInt64 for no limit).
-func (r *Replica) Scan(batch engine.Engine, h roachpb.Header, remScanResults int64,
+func (r *Replica) Scan(ctx context.Context, batch engine.Engine, h roachpb.Header, remScanResults int64,
 	args roachpb.ScanRequest) (roachpb.ScanResponse, []roachpb.Intent, error) {
 	if remScanResults == 0 {
 		// We can't return any more results; skip the scan
@@ -284,7 +284,7 @@ func (r *Replica) Scan(batch engine.Engine, h roachpb.Header, remScanResults int
 	}
 	maxResults := scanMaxResultsValue(remScanResults, args.MaxResults)
 
-	rows, intents, err := engine.MVCCScan(batch, args.Key, args.EndKey, maxResults, h.Timestamp,
+	rows, intents, err := engine.MVCCScan(ctx, batch, args.Key, args.EndKey, maxResults, h.Timestamp,
 		h.ReadConsistency == roachpb.CONSISTENT, h.Txn)
 	return roachpb.ScanResponse{Rows: rows}, intents, err
 }
@@ -292,7 +292,7 @@ func (r *Replica) Scan(batch engine.Engine, h roachpb.Header, remScanResults int
 // ReverseScan scans the key range specified by start key through end key in descending order up to
 // some maximum number of results. remScanResults stores the number of scan results remaining for
 // this batch (MaxInt64 for no limit).
-func (r *Replica) ReverseScan(batch engine.Engine, h roachpb.Header, remScanResults int64,
+func (r *Replica) ReverseScan(ctx context.Context, batch engine.Engine, h roachpb.Header, remScanResults int64,
 	args roachpb.ReverseScanRequest) (roachpb.ReverseScanResponse, []roachpb.Intent, error) {
 	if remScanResults == 0 {
 		// We can't return any more results; skip the scan
@@ -300,7 +300,7 @@ func (r *Replica) ReverseScan(batch engine.Engine, h roachpb.Header, remScanResu
 	}
 	maxResults := scanMaxResultsValue(remScanResults, args.MaxResults)
 
-	rows, intents, err := engine.MVCCReverseScan(batch, args.Key, args.EndKey, maxResults,
+	rows, intents, err := engine.MVCCReverseScan(ctx, batch, args.Key, args.EndKey, maxResults,
 		h.Timestamp, h.ReadConsistency == roachpb.CONSISTENT, h.Txn)
 	return roachpb.ReverseScanResponse{Rows: rows}, intents, err
 }
@@ -322,7 +322,7 @@ func verifyTransaction(h roachpb.Header, args roachpb.Request) error {
 // to receive the write batch before a heartbeat or txn push is
 // performed first and aborts the transaction.
 func (r *Replica) BeginTransaction(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.BeginTransactionRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.BeginTransactionRequest,
 ) (roachpb.BeginTransactionResponse, error) {
 	var reply roachpb.BeginTransactionResponse
 
@@ -335,7 +335,7 @@ func (r *Replica) BeginTransaction(
 
 	// Verify transaction does not already exist.
 	txn := roachpb.Transaction{}
-	ok, err := engine.MVCCGetProto(batch, key, roachpb.ZeroTimestamp, true, nil, &txn)
+	ok, err := engine.MVCCGetProto(ctx, batch, key, roachpb.ZeroTimestamp, true, nil, &txn)
 	if err != nil {
 		return reply, err
 	}
@@ -357,7 +357,7 @@ func (r *Replica) BeginTransaction(
 
 	// Write the txn record.
 	reply.Txn.Writing = true
-	return reply, engine.MVCCPutProto(batch, ms, key, roachpb.ZeroTimestamp, nil, reply.Txn)
+	return reply, engine.MVCCPutProto(ctx, batch, ms, key, roachpb.ZeroTimestamp, nil, reply.Txn)
 }
 
 // EndTransaction either commits or aborts (rolls back) an extant
@@ -376,7 +376,7 @@ func (r *Replica) EndTransaction(
 
 	// Fetch existing transaction.
 	reply.Txn = &roachpb.Transaction{}
-	if ok, err := engine.MVCCGetProto(batch, key, roachpb.ZeroTimestamp, true, nil, reply.Txn); err != nil {
+	if ok, err := engine.MVCCGetProto(ctx, batch, key, roachpb.ZeroTimestamp, true, nil, reply.Txn); err != nil {
 		return reply, nil, err
 	} else if !ok {
 		// Return a fresh empty reply because there's an empty Transaction
@@ -405,8 +405,8 @@ func (r *Replica) EndTransaction(
 			// The transaction has already been aborted by other.
 			// Do not return TransactionAbortedError since the client anyway
 			// wanted to abort the transaction.
-			externalIntents := r.resolveLocalIntents(batch, ms, args, reply.Txn)
-			if err := updateTxnWithExternalIntents(batch, ms, args, reply.Txn, externalIntents); err != nil {
+			externalIntents := r.resolveLocalIntents(ctx, batch, ms, args, reply.Txn)
+			if err := updateTxnWithExternalIntents(ctx, batch, ms, args, reply.Txn, externalIntents); err != nil {
 				return reply, nil, err
 			}
 			return reply, externalIntents, nil
@@ -460,8 +460,8 @@ func (r *Replica) EndTransaction(
 		reply.Txn.Status = roachpb.ABORTED
 	}
 
-	externalIntents := r.resolveLocalIntents(batch, ms, args, reply.Txn)
-	if err := updateTxnWithExternalIntents(batch, ms, args, reply.Txn, externalIntents); err != nil {
+	externalIntents := r.resolveLocalIntents(ctx, batch, ms, args, reply.Txn)
+	if err := updateTxnWithExternalIntents(ctx, batch, ms, args, reply.Txn, externalIntents); err != nil {
 		return reply, nil, err
 	}
 
@@ -521,7 +521,7 @@ func isEndTransactionTriggeringRetryError(headerTxn, currentTxn *roachpb.Transac
 // local to this range in the same batch. The remainder are collected
 // and returned so that they can be handed off to asynchronous
 // processing.
-func (r *Replica) resolveLocalIntents(batch engine.Engine, ms *engine.MVCCStats, args roachpb.EndTransactionRequest, txn *roachpb.Transaction) []roachpb.Intent {
+func (r *Replica) resolveLocalIntents(ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, args roachpb.EndTransactionRequest, txn *roachpb.Transaction) []roachpb.Intent {
 	desc := r.Desc()
 	var preMergeDesc *roachpb.RangeDescriptor
 	if mergeTrigger := args.InternalCommitTrigger.GetMergeTrigger(); mergeTrigger != nil {
@@ -554,7 +554,7 @@ func (r *Replica) resolveLocalIntents(batch engine.Engine, ms *engine.MVCCStats,
 					// merge trigger.
 					resolveMs = nil
 				}
-				return engine.MVCCResolveWriteIntentUsingIter(batch, iterAndBuf, resolveMs, intent)
+				return engine.MVCCResolveWriteIntentUsingIter(ctx, batch, iterAndBuf, resolveMs, intent)
 			}
 			// For intent ranges, cut into parts inside and outside our key
 			// range. Resolve locally inside, delegate the rest. In particular,
@@ -567,7 +567,7 @@ func (r *Replica) resolveLocalIntents(batch engine.Engine, ms *engine.MVCCStats,
 			}
 			if inSpan != nil {
 				intent.Span = *inSpan
-				_, err := engine.MVCCResolveWriteIntentRangeUsingIter(batch, iterAndBuf, ms, intent, 0)
+				_, err := engine.MVCCResolveWriteIntentRangeUsingIter(ctx, batch, iterAndBuf, ms, intent, 0)
 				return err
 			}
 			return nil
@@ -585,19 +585,19 @@ func (r *Replica) resolveLocalIntents(batch engine.Engine, ms *engine.MVCCStats,
 // updated status (& possibly timestamp). If we've already resolved
 // all intents locally, we actually delete the record right away - no
 // use in keeping it around.
-func updateTxnWithExternalIntents(batch engine.Engine, ms *engine.MVCCStats, args roachpb.EndTransactionRequest, txn *roachpb.Transaction, externalIntents []roachpb.Intent) error {
+func updateTxnWithExternalIntents(ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, args roachpb.EndTransactionRequest, txn *roachpb.Transaction, externalIntents []roachpb.Intent) error {
 	key := keys.TransactionKey(txn.Key, txn.ID)
 	if txnAutoGC && len(externalIntents) == 0 {
 		if log.V(1) {
 			log.Infof("auto-gc'ed %s (%d intents)", txn.ID.Short(), len(args.IntentSpans))
 		}
-		return engine.MVCCDelete(batch, ms, key, roachpb.ZeroTimestamp, nil /* txn */)
+		return engine.MVCCDelete(ctx, batch, ms, key, roachpb.ZeroTimestamp, nil /* txn */)
 	}
 	txn.Intents = make([]roachpb.Span, len(externalIntents))
 	for i := range externalIntents {
 		txn.Intents[i] = externalIntents[i].Span
 	}
-	return engine.MVCCPutProto(batch, ms, key, roachpb.ZeroTimestamp, nil /* txn */, txn)
+	return engine.MVCCPutProto(ctx, batch, ms, key, roachpb.ZeroTimestamp, nil /* txn */, txn)
 }
 
 // intersectSpan takes an intent and a descriptor. It then splits the
@@ -670,13 +670,13 @@ func (r *Replica) runCommitTrigger(ctx context.Context, batch engine.Engine, ms 
 			*ms = engine.MVCCStats{} // clear stats, as split recomputed.
 		}
 		if ct.GetMergeTrigger() != nil {
-			if err := r.mergeTrigger(batch, ms, ct.MergeTrigger, txn.Timestamp); err != nil {
+			if err := r.mergeTrigger(ctx, batch, ms, ct.MergeTrigger, txn.Timestamp); err != nil {
 				return err
 			}
 			*ms = engine.MVCCStats{} // clear stats, as merge recomputed.
 		}
 		if ct.GetChangeReplicasTrigger() != nil {
-			if err := r.changeReplicasTrigger(batch, ct.ChangeReplicasTrigger); err != nil {
+			if err := r.changeReplicasTrigger(ctx, batch, ct.ChangeReplicasTrigger); err != nil {
 				return err
 			}
 		}
@@ -728,7 +728,7 @@ func (r *Replica) runCommitTrigger(ctx context.Context, batch engine.Engine, ms 
 // specifies whether descriptors are prefetched in descending or ascending
 // order.
 func (r *Replica) RangeLookup(
-	batch engine.Engine, h roachpb.Header, args roachpb.RangeLookupRequest,
+	ctx context.Context, batch engine.Engine, h roachpb.Header, args roachpb.RangeLookupRequest,
 ) (roachpb.RangeLookupResponse, []roachpb.Intent, error) {
 	var reply roachpb.RangeLookupResponse
 	ts := h.Timestamp // all we're going to use from the header.
@@ -778,7 +778,7 @@ func (r *Replica) RangeLookup(
 		}
 
 		// Scan for descriptors.
-		kvs, intents, err = engine.MVCCScan(batch, startKey, endKey, rangeCount,
+		kvs, intents, err = engine.MVCCScan(ctx, batch, startKey, endKey, rangeCount,
 			ts, consistent, h.Txn)
 		if err != nil {
 			// An error here is likely a WriteIntentError when reading consistently.
@@ -830,7 +830,7 @@ func (r *Replica) RangeLookup(
 				return reply, nil, err
 			}
 
-			kvs, intents, err = engine.MVCCScan(batch, startKey, endKey, 1,
+			kvs, intents, err = engine.MVCCScan(ctx, batch, startKey, endKey, 1,
 				ts, consistent, h.Txn)
 			if err != nil {
 				return reply, nil, err
@@ -845,7 +845,7 @@ func (r *Replica) RangeLookup(
 			return reply, nil, err
 		}
 		// Reverse scan for descriptors.
-		revKvs, revIntents, err := engine.MVCCReverseScan(batch, startKey, endKey, rangeCount,
+		revKvs, revIntents, err := engine.MVCCReverseScan(ctx, batch, startKey, endKey, rangeCount,
 			ts, consistent, h.Txn)
 		if err != nil {
 			// An error here is likely a WriteIntentError when reading consistently.
@@ -890,7 +890,7 @@ func (r *Replica) RangeLookup(
 		// observed intents could be returned when MaxRanges is set to 1 and
 		// the ConsiderIntents flag is set.
 		for _, intent := range intents {
-			val, _, err := engine.MVCCGetAsTxn(batch, intent.Key, intent.Txn.Timestamp, true, intent.Txn)
+			val, _, err := engine.MVCCGetAsTxn(ctx, batch, intent.Key, intent.Txn.Timestamp, true, intent.Txn)
 			if err != nil {
 				return reply, nil, err
 			}
@@ -935,7 +935,7 @@ func (r *Replica) RangeLookup(
 // timestamp after receiving transaction heartbeat messages from
 // coordinator. Returns the updated transaction.
 func (r *Replica) HeartbeatTxn(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.HeartbeatTxnRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.HeartbeatTxnRequest,
 ) (roachpb.HeartbeatTxnResponse, error) {
 	var reply roachpb.HeartbeatTxnResponse
 
@@ -946,7 +946,7 @@ func (r *Replica) HeartbeatTxn(
 	key := keys.TransactionKey(h.Txn.Key, h.Txn.ID)
 
 	var txn roachpb.Transaction
-	if ok, err := engine.MVCCGetProto(batch, key, roachpb.ZeroTimestamp, true, nil, &txn); err != nil {
+	if ok, err := engine.MVCCGetProto(ctx, batch, key, roachpb.ZeroTimestamp, true, nil, &txn); err != nil {
 		return reply, err
 	} else if !ok {
 		// If no existing transaction record was found, skip heartbeat.
@@ -961,7 +961,7 @@ func (r *Replica) HeartbeatTxn(
 			txn.LastHeartbeat = &roachpb.Timestamp{}
 		}
 		txn.LastHeartbeat.Forward(args.Now)
-		if err := engine.MVCCPutProto(batch, ms, key, roachpb.ZeroTimestamp, nil, &txn); err != nil {
+		if err := engine.MVCCPutProto(ctx, batch, ms, key, roachpb.ZeroTimestamp, nil, &txn); err != nil {
 			return reply, err
 		}
 	}
@@ -975,7 +975,7 @@ func (r *Replica) HeartbeatTxn(
 // listed key along with the expiration timestamp. The GC metadata
 // specified in the args is persisted after GC.
 func (r *Replica) GC(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.GCRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.GCRequest,
 ) (roachpb.GCResponse, error) {
 	// All keys must be inside the current replica range. Keys outside
 	// of this range in the GC request are dropped silently, which is
@@ -991,7 +991,7 @@ func (r *Replica) GC(
 
 	var reply roachpb.GCResponse
 	// Garbage collect the specified keys by expiration timestamps.
-	err := engine.MVCCGarbageCollect(batch, ms, keys, h.Timestamp)
+	err := engine.MVCCGarbageCollect(ctx, batch, ms, keys, h.Timestamp)
 	return reply, err
 }
 
@@ -1039,7 +1039,7 @@ func (r *Replica) GC(
 // queue to purge entries for which the transaction coordinator must have found
 // out via its heartbeats that the transaction has failed.
 func (r *Replica) PushTxn(
-	batch engine.Engine,
+	ctx context.Context, batch engine.Engine,
 	ms *engine.MVCCStats,
 	h roachpb.Header,
 	args roachpb.PushTxnRequest,
@@ -1060,7 +1060,7 @@ func (r *Replica) PushTxn(
 
 	// Fetch existing transaction; if missing, we're allowed to abort.
 	existTxn := &roachpb.Transaction{}
-	ok, err := engine.MVCCGetProto(batch, key, roachpb.ZeroTimestamp,
+	ok, err := engine.MVCCGetProto(ctx, batch, key, roachpb.ZeroTimestamp,
 		true /* consistent */, nil /* txn */, existTxn)
 	if err != nil {
 		return reply, err
@@ -1101,7 +1101,7 @@ func (r *Replica) PushTxn(
 		reply.PusheeTxn.TxnMeta = args.PusheeTxn
 		reply.PusheeTxn.Timestamp = args.Now // see method comment
 		reply.PusheeTxn.Status = roachpb.ABORTED
-		return reply, engine.MVCCPutProto(batch, ms, key, roachpb.ZeroTimestamp, nil, &reply.PusheeTxn)
+		return reply, engine.MVCCPutProto(ctx, batch, ms, key, roachpb.ZeroTimestamp, nil, &reply.PusheeTxn)
 	}
 	// Start with the persisted transaction record as final transaction.
 	reply.PusheeTxn = existTxn.Clone()
@@ -1194,7 +1194,7 @@ func (r *Replica) PushTxn(
 	}
 
 	// Persist the pushed transaction using zero timestamp for inline value.
-	if err := engine.MVCCPutProto(batch, ms, key, roachpb.ZeroTimestamp, nil, &reply.PusheeTxn); err != nil {
+	if err := engine.MVCCPutProto(ctx, batch, ms, key, roachpb.ZeroTimestamp, nil, &reply.PusheeTxn); err != nil {
 		return reply, err
 	}
 	return reply, nil
@@ -1204,22 +1204,22 @@ func (r *Replica) PushTxn(
 // Otherwise, if poison is true, creates an entry for this transaction
 // in the abort cache to prevent future reads or writes from
 // spuriously succeeding on this range.
-func (r *Replica) setAbortCache(batch engine.Engine, ms *engine.MVCCStats, txn roachpb.TxnMeta, poison bool) error {
+func (r *Replica) setAbortCache(ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, txn roachpb.TxnMeta, poison bool) error {
 	if !poison {
-		return r.abortCache.Del(batch, ms, txn.ID)
+		return r.abortCache.Del(ctx, batch, ms, txn.ID)
 	}
 	entry := roachpb.AbortCacheEntry{
 		Key:       txn.Key,
 		Timestamp: txn.Timestamp,
 		Priority:  txn.Priority,
 	}
-	return r.abortCache.Put(batch, ms, txn.ID, &entry)
+	return r.abortCache.Put(ctx, batch, ms, txn.ID, &entry)
 }
 
 // ResolveIntent resolves a write intent from the specified key
 // according to the status of the transaction which created it.
 func (r *Replica) ResolveIntent(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.ResolveIntentRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.ResolveIntentRequest,
 ) (roachpb.ResolveIntentResponse, error) {
 	var reply roachpb.ResolveIntentResponse
 	if h.Txn != nil {
@@ -1231,18 +1231,18 @@ func (r *Replica) ResolveIntent(
 		Txn:    args.IntentTxn,
 		Status: args.Status,
 	}
-	if err := engine.MVCCResolveWriteIntent(batch, ms, intent); err != nil {
+	if err := engine.MVCCResolveWriteIntent(ctx, batch, ms, intent); err != nil {
 		return reply, err
 	}
 	if intent.Status == roachpb.ABORTED {
-		return reply, r.setAbortCache(batch, ms, args.IntentTxn, args.Poison)
+		return reply, r.setAbortCache(ctx, batch, ms, args.IntentTxn, args.Poison)
 	}
 	return reply, nil
 }
 
 // ResolveIntentRange resolves write intents in the specified
 // key range according to the status of the transaction which created it.
-func (r *Replica) ResolveIntentRange(batch engine.Engine, ms *engine.MVCCStats,
+func (r *Replica) ResolveIntentRange(ctx context.Context, batch engine.Engine, ms *engine.MVCCStats,
 	h roachpb.Header, args roachpb.ResolveIntentRangeRequest) (roachpb.ResolveIntentRangeResponse, error) {
 	var reply roachpb.ResolveIntentRangeResponse
 	if h.Txn != nil {
@@ -1255,11 +1255,11 @@ func (r *Replica) ResolveIntentRange(batch engine.Engine, ms *engine.MVCCStats,
 		Status: args.Status,
 	}
 
-	if _, err := engine.MVCCResolveWriteIntentRange(batch, ms, intent, 0); err != nil {
+	if _, err := engine.MVCCResolveWriteIntentRange(ctx, batch, ms, intent, 0); err != nil {
 		return reply, err
 	}
 	if intent.Status == roachpb.ABORTED {
-		return reply, r.setAbortCache(batch, ms, args.IntentTxn, args.Poison)
+		return reply, r.setAbortCache(ctx, batch, ms, args.IntentTxn, args.Poison)
 	}
 	return reply, nil
 }
@@ -1271,18 +1271,18 @@ func (r *Replica) ResolveIntentRange(batch engine.Engine, ms *engine.MVCCStats,
 // transactional, merges are not currently exposed directly to
 // clients. Merged values are explicitly not MVCC data.
 func (r *Replica) Merge(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.MergeRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.MergeRequest,
 ) (roachpb.MergeResponse, error) {
 	var reply roachpb.MergeResponse
 
-	return reply, engine.MVCCMerge(batch, ms, args.Key, h.Timestamp, args.Value)
+	return reply, engine.MVCCMerge(ctx, batch, ms, args.Key, h.Timestamp, args.Value)
 }
 
 // TruncateLog discards a prefix of the raft log. Truncating part of a log that
 // has already been truncated has no effect. If this range is not the one
 // specified within the request body, the request will also be ignored.
 func (r *Replica) TruncateLog(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.TruncateLogRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.TruncateLogRequest,
 ) (roachpb.TruncateLogResponse, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -1328,7 +1328,7 @@ func (r *Replica) TruncateLog(
 		Index: args.Index - 1,
 		Term:  term,
 	}
-	return reply, engine.MVCCPutProto(batch, ms, keys.RaftTruncatedStateKey(r.RangeID), roachpb.ZeroTimestamp, nil, &tState)
+	return reply, engine.MVCCPutProto(ctx, batch, ms, keys.RaftTruncatedStateKey(r.RangeID), roachpb.ZeroTimestamp, nil, &tState)
 }
 
 // LeaderLease sets the leader lease for this range. The command fails
@@ -1339,7 +1339,7 @@ func (r *Replica) TruncateLog(
 // lease, all duties required of the range leader are commenced, including
 // clearing the command queue and timestamp cache.
 func (r *Replica) LeaderLease(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.LeaderLeaseRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.LeaderLeaseRequest,
 ) (roachpb.LeaderLeaseResponse, error) {
 	// maybeGossipSystemConfig cannot be called while the replica is locked,
 	// so we defer it here so it is called once the replica lock is released.
@@ -1406,7 +1406,7 @@ func (r *Replica) LeaderLease(
 	args.Lease.Start = effectiveStart
 
 	// Store the lease to disk & in-memory.
-	if err := engine.MVCCPutProto(batch, ms, keys.RangeLeaderLeaseKey(r.RangeID), roachpb.ZeroTimestamp, nil, &args.Lease); err != nil {
+	if err := engine.MVCCPutProto(ctx, batch, ms, keys.RangeLeaderLeaseKey(r.RangeID), roachpb.ZeroTimestamp, nil, &args.Lease); err != nil {
 		return reply, err
 	}
 	r.mu.leaderLease = &args.Lease
@@ -1554,7 +1554,7 @@ func (r *Replica) computeChecksumDone(id uuid.UUID, sha []byte, snapshot *roachp
 // replica at a particular snapshot. The checksum is later verified
 // through the VerifyChecksum request.
 func (r *Replica) ComputeChecksum(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.ComputeChecksumRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.ComputeChecksumRequest,
 ) (roachpb.ComputeChecksumResponse, error) {
 	if args.Version != replicaChecksumVersion {
 		log.Errorf("Incompatible versions: e=%d, v=%d", replicaChecksumVersion, args.Version)
@@ -1660,7 +1660,7 @@ func (r *Replica) sha512(desc roachpb.RangeDescriptor, snap engine.Engine, snaps
 // guaranteed to be seen on other replicas. In other words, a command needs
 // to be consistent both in success and failure.
 func (r *Replica) VerifyChecksum(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.VerifyChecksumRequest,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.VerifyChecksumRequest,
 ) (roachpb.VerifyChecksumResponse, error) {
 	if args.Version != replicaChecksumVersion {
 		log.Errorf("Incompatible versions: e=%d, v=%d", replicaChecksumVersion, args.Version)
@@ -1837,7 +1837,7 @@ func (r *Replica) AdminSplit(
 			snap := r.store.NewSnapshot()
 			defer snap.Close()
 			var err error
-			foundSplitKey, err = engine.MVCCFindSplitKey(snap, desc.RangeID, desc.StartKey, desc.EndKey, nil /* logFn */)
+			foundSplitKey, err = engine.MVCCFindSplitKey(ctx, snap, desc.RangeID, desc.StartKey, desc.EndKey, nil /* logFn */)
 			if err != nil {
 				return reply, roachpb.NewErrorf("unable to determine split key: %s", err)
 			}
@@ -1985,14 +1985,14 @@ func (r *Replica) splitTrigger(
 	if err != nil {
 		return util.Errorf("unable to fetch last replica GC timestamp: %s", err)
 	}
-	if err := engine.MVCCPutProto(batch, nil, keys.RangeLastReplicaGCTimestampKey(split.NewDesc.RangeID), roachpb.ZeroTimestamp, nil, &replicaGCTS); err != nil {
+	if err := engine.MVCCPutProto(ctx, batch, nil, keys.RangeLastReplicaGCTimestampKey(split.NewDesc.RangeID), roachpb.ZeroTimestamp, nil, &replicaGCTS); err != nil {
 		return util.Errorf("unable to copy last replica GC timestamp: %s", err)
 	}
 	verifyTS, err := r.getLastVerificationTimestamp()
 	if err != nil {
 		return util.Errorf("unable to fetch last verification timestamp: %s", err)
 	}
-	if err := engine.MVCCPutProto(batch, nil, keys.RangeLastVerificationTimestampKey(split.NewDesc.RangeID), roachpb.ZeroTimestamp, nil, &verifyTS); err != nil {
+	if err := engine.MVCCPutProto(ctx, batch, nil, keys.RangeLastVerificationTimestampKey(split.NewDesc.RangeID), roachpb.ZeroTimestamp, nil, &verifyTS); err != nil {
 		return util.Errorf("unable to copy last verification timestamp: %s", err)
 	}
 
@@ -2196,7 +2196,7 @@ func (r *Replica) AdminMerge(
 // mergeTrigger is called on a successful commit of an AdminMerge
 // transaction. It recomputes stats for the receiving range.
 func (r *Replica) mergeTrigger(
-	batch engine.Engine, ms *engine.MVCCStats, merge *roachpb.MergeTrigger, ts roachpb.Timestamp,
+	ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, merge *roachpb.MergeTrigger, ts roachpb.Timestamp,
 ) error {
 	desc := r.Desc()
 	if !bytes.Equal(desc.StartKey, merge.UpdatedDesc.StartKey) {
@@ -2221,14 +2221,14 @@ func (r *Replica) mergeTrigger(
 	// Add in stats for right half of merge, excluding system-local stats, which
 	// will need to be recomputed.
 	var rightMs engine.MVCCStats
-	if err := engine.MVCCGetRangeStats(batch, subsumedRangeID, &rightMs); err != nil {
+	if err := engine.MVCCGetRangeStats(ctx, batch, subsumedRangeID, &rightMs); err != nil {
 		return err
 	}
 	rightMs.SysBytes, rightMs.SysCount = 0, 0
 	mergedMs.Add(rightMs)
 
 	// Copy the subsumed range's abort cache to the subsuming one.
-	_, err := r.abortCache.CopyFrom(batch, &mergedMs, subsumedRangeID)
+	_, err := r.abortCache.CopyFrom(ctx, batch, &mergedMs, subsumedRangeID)
 	if err != nil {
 		return util.Errorf("unable to copy abort cache to new split range: %s", err)
 	}
@@ -2237,7 +2237,7 @@ func (r *Replica) mergeTrigger(
 	// keep track of stats here, because we already set the right range's
 	// system-local stats contribution to 0.
 	localRangeIDKeyPrefix := keys.MakeRangeIDPrefix(subsumedRangeID)
-	if _, err := engine.MVCCDeleteRange(batch, nil, localRangeIDKeyPrefix, localRangeIDKeyPrefix.PrefixEnd(), 0, roachpb.ZeroTimestamp, nil, false); err != nil {
+	if _, err := engine.MVCCDeleteRange(ctx, batch, nil, localRangeIDKeyPrefix, localRangeIDKeyPrefix.PrefixEnd(), 0, roachpb.ZeroTimestamp, nil, false); err != nil {
 		return util.Errorf("cannot remove range metadata %s", err)
 	}
 
@@ -2274,7 +2274,7 @@ func (r *Replica) mergeTrigger(
 	return nil
 }
 
-func (r *Replica) changeReplicasTrigger(batch engine.Engine, change *roachpb.ChangeReplicasTrigger) error {
+func (r *Replica) changeReplicasTrigger(ctx context.Context, batch engine.Engine, change *roachpb.ChangeReplicasTrigger) error {
 	cpy := *r.Desc()
 	cpy.Replicas = change.UpdatedReplicas
 	cpy.NextReplicaID = change.NextReplicaID

--- a/storage/replica_data_iter_test.go
+++ b/storage/replica_data_iter_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -89,7 +91,7 @@ func createRangeData(t *testing.T, r *Replica) []engine.MVCCKey {
 
 	keys := []engine.MVCCKey{}
 	for _, keyTS := range keyTSs {
-		if err := engine.MVCCPut(r.store.Engine(), nil, keyTS.key, keyTS.ts, roachpb.MakeValueFromString("value"), nil); err != nil {
+		if err := engine.MVCCPut(context.Background(), r.store.Engine(), nil, keyTS.key, keyTS.ts, roachpb.MakeValueFromString("value"), nil); err != nil {
 			t.Fatal(err)
 		}
 		keys = append(keys, engine.MVCCKey{Key: keyTS.key, Timestamp: keyTS.ts})

--- a/storage/stats.go
+++ b/storage/stats.go
@@ -19,6 +19,8 @@ package storage
 import (
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
 )
@@ -44,7 +46,7 @@ type rangeStats struct {
 // require the values to be read from the engine).
 func newRangeStats(rangeID roachpb.RangeID, e engine.Engine) (*rangeStats, error) {
 	rs := &rangeStats{rangeID: rangeID}
-	if err := engine.MVCCGetRangeStats(e, rangeID, &rs.MVCCStats); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), e, rangeID, &rs.MVCCStats); err != nil {
 		return nil, err
 	}
 	return rs, nil
@@ -89,7 +91,7 @@ func (rs *rangeStats) MergeMVCCStats(e engine.Engine, ms engine.MVCCStats) error
 	rs.Lock()
 	defer rs.Unlock()
 	rs.MVCCStats.Add(ms)
-	return engine.MVCCSetRangeStats(e, rs.rangeID, &rs.MVCCStats)
+	return engine.MVCCSetRangeStats(context.Background(), e, rs.rangeID, &rs.MVCCStats)
 }
 
 // SetStats sets stats wholesale.
@@ -97,7 +99,7 @@ func (rs *rangeStats) SetMVCCStats(e engine.Engine, ms engine.MVCCStats) error {
 	rs.Lock()
 	defer rs.Unlock()
 	rs.MVCCStats = ms
-	return engine.MVCCSetRangeStats(e, rs.rangeID, &ms)
+	return engine.MVCCSetRangeStats(context.Background(), e, rs.rangeID, &ms)
 }
 
 // GetAvgIntentAge returns the average age of outstanding intents,

--- a/storage/stats_test.go
+++ b/storage/stats_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -56,7 +58,7 @@ func TestRangeStatsInit(t *testing.T) {
 		GCBytesAge:      10,
 		LastUpdateNanos: 11,
 	}
-	if err := engine.MVCCSetRangeStats(tc.engine, 1, &ms); err != nil {
+	if err := engine.MVCCSetRangeStats(context.Background(), tc.engine, 1, &ms); err != nil {
 		t.Fatal(err)
 	}
 	s, err := newRangeStats(1, tc.engine)
@@ -100,7 +102,7 @@ func TestRangeStatsMerge(t *testing.T) {
 	expMS := ms
 	expMS.AgeTo(10 * 1E9)
 
-	if err := engine.MVCCGetRangeStats(tc.engine, 1, &initialMS); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), tc.engine, 1, &initialMS); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(ms, expMS) {
@@ -115,7 +117,7 @@ func TestRangeStatsMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 	expMS.Add(ms)
-	if err := engine.MVCCGetRangeStats(tc.engine, 1, &ms); err != nil {
+	if err := engine.MVCCGetRangeStats(context.Background(), tc.engine, 1, &ms); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(ms, expMS) {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -197,7 +197,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	if err := eng.Flush(); err != nil {
 		t.Fatal(err)
 	}
-	if value, _, err := engine.MVCCGet(eng, keys.StoreIdentKey(), roachpb.ZeroTimestamp, true, nil); err != nil {
+	if value, _, err := engine.MVCCGet(context.Background(), eng, keys.StoreIdentKey(), roachpb.ZeroTimestamp, true, nil); err != nil {
 		t.Fatal(err)
 	} else if value == nil {
 		t.Fatalf("unable to read store ident")
@@ -1126,7 +1126,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 			}
 			txnKey := keys.TransactionKey(pushee.Key, pushee.ID)
 			var txn roachpb.Transaction
-			ok, err := engine.MVCCGetProto(store.Engine(), txnKey, roachpb.ZeroTimestamp, true, nil, &txn)
+			ok, err := engine.MVCCGetProto(context.Background(), store.Engine(), txnKey, roachpb.ZeroTimestamp, true, nil, &txn)
 			if !ok || err != nil {
 				t.Fatalf("not found or err: %s", err)
 			}
@@ -1391,7 +1391,7 @@ func TestStoreResolveWriteIntentNoTxn(t *testing.T) {
 	// Read pushee's txn.
 	txnKey := keys.TransactionKey(pushee.Key, pushee.ID)
 	var txn roachpb.Transaction
-	if ok, err := engine.MVCCGetProto(store.Engine(), txnKey, roachpb.ZeroTimestamp, true, nil, &txn); !ok || err != nil {
+	if ok, err := engine.MVCCGetProto(context.Background(), store.Engine(), txnKey, roachpb.ZeroTimestamp, true, nil, &txn); !ok || err != nil {
 		t.Fatalf("not found or err: %s", err)
 	}
 	if txn.Status != roachpb.ABORTED {

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -274,7 +274,7 @@ func (ls *Stores) ReadBootstrapInfo(bi *gossip.BootstrapInfo) error {
 	// Find the most recent bootstrap info.
 	for _, s := range ls.storeMap {
 		var storeBI gossip.BootstrapInfo
-		ok, err := engine.MVCCGetProto(s.engine, keys.StoreGossipKey(), roachpb.ZeroTimestamp, true, nil, &storeBI)
+		ok, err := engine.MVCCGetProto(context.Background(), s.engine, keys.StoreGossipKey(), roachpb.ZeroTimestamp, true, nil, &storeBI)
 		if err != nil {
 			return err
 		}
@@ -311,7 +311,7 @@ func (ls *Stores) updateBootstrapInfo(bi *gossip.BootstrapInfo) error {
 	ls.latestBI = util.CloneProto(bi).(*gossip.BootstrapInfo)
 	// Update all stores.
 	for _, s := range ls.storeMap {
-		if err := engine.MVCCPutProto(s.engine, nil, keys.StoreGossipKey(), roachpb.ZeroTimestamp, nil, bi); err != nil {
+		if err := engine.MVCCPutProto(context.Background(), s.engine, nil, keys.StoreGossipKey(), roachpb.ZeroTimestamp, nil, bi); err != nil {
 			return err
 		}
 	}

--- a/storage/verify_queue_test.go
+++ b/storage/verify_queue_test.go
@@ -20,6 +20,8 @@ import (
 	"math"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -38,7 +40,7 @@ func TestVerifyQueueShouldQueue(t *testing.T) {
 
 	// Put empty verification timestamp
 	key := keys.RangeLastVerificationTimestampKey(tc.rng.RangeID)
-	if err := engine.MVCCPutProto(tc.rng.store.Engine(), nil, key, roachpb.ZeroTimestamp, nil, &roachpb.Timestamp{}); err != nil {
+	if err := engine.MVCCPutProto(context.Background(), tc.rng.store.Engine(), nil, key, roachpb.ZeroTimestamp, nil, &roachpb.Timestamp{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -79,7 +81,7 @@ func (tm *testModel) getActualData() map[string]roachpb.Value {
 	// Scan over all TS Keys stored in the engine
 	startKey := keys.TimeseriesPrefix
 	endKey := startKey.PrefixEnd()
-	keyValues, _, err := engine.MVCCScan(tm.Eng, startKey, endKey, 0, tm.Clock.Now(), true, nil)
+	keyValues, _, err := engine.MVCCScan(context.Background(), tm.Eng, startKey, endKey, 0, tm.Clock.Now(), true, nil)
 	if err != nil {
 		tm.t.Fatalf("error scanning TS data from engine: %s", err.Error())
 	}


### PR DESCRIPTION
This will make it much easier to debug those performance issues which can be
triggered through `EXPLAIN (TRACE) <STMT>` in a development setting.

There currently is no good story for different verbosity levels, so the goal is
not to place regular tracepoints around but to have the infrastructure for
ad-hoc debugging performance issues in place. I imagine this could be useful
for issues such as #4386 or #5981.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5255)

<!-- Reviewable:end -->
