### PR TITLE
server/status: deflake TestMetricsRecorder

### DIFF
--- a/server/status/recorder_test.go
+++ b/server/status/recorder_test.go
@@ -166,6 +166,13 @@ func TestMetricsRecorder(t *testing.T) {
 	recorder.AddStore(store2)
 	recorder.NodeStarted(nodeDesc, 50)
 
+	// Ensure the metric system's view of time does not advance during this test
+	// as the test expects time to not advance too far which would age the actual
+	// data (e.g. in histogram's) unexpectedly.
+	defer metric.TestingSetNow(func() time.Time {
+		return time.Unix(0, manual.UnixNano()).UTC()
+	})()
+
 	// Create a flat array of registries, along with metadata for each, to help
 	// generate expected results.
 	regList := []struct {

--- a/util/metric/metric.go
+++ b/util/metric/metric.go
@@ -80,6 +80,16 @@ var _ periodic = &Rate{}
 
 var now = timeutil.Now
 
+// TestingSetNow changes the clock used by the metric system. For use by
+// testing to precisely control the clock.
+func TestingSetNow(f func() time.Time) func() {
+	origNow := now
+	now = f
+	return func() {
+		now = origNow
+	}
+}
+
 func maybeTick(m periodic) {
 	for m.nextTick().Before(now()) {
 		m.tick()

--- a/util/metric/metric_test.go
+++ b/util/metric/metric_test.go
@@ -59,6 +59,7 @@ func setNow(d time.Duration) {
 }
 
 func TestHistogramRotate(t *testing.T) {
+	defer TestingSetNow(nil)()
 	setNow(0)
 	h := NewHistogram(histWrapNum*time.Second, 1000+10*histWrapNum, 3)
 	var cur time.Duration
@@ -87,6 +88,8 @@ func TestHistogramRotate(t *testing.T) {
 }
 
 func TestHistogramJSON(t *testing.T) {
+	defer TestingSetNow(nil)()
+	setNow(0)
 	h := NewHistogram(0, 1, 3)
 	testMarshal(t, h, `[{"Quantile":100,"Count":0,"ValueAt":0}]`)
 	h.RecordValue(1)
@@ -94,6 +97,7 @@ func TestHistogramJSON(t *testing.T) {
 }
 
 func TestRateRotate(t *testing.T) {
+	defer TestingSetNow(nil)()
 	setNow(0)
 	const interval = 10 * time.Second
 	r := NewRate(interval)


### PR DESCRIPTION
This test was sensitive to the wall clock time. In particular, the
actual histogram values could age unexpectedly if a second of wall clock
time elapsed between when the histogram values were recorded and when
they were retrieved. While this is very unlikely in real life, it
happened repeatedly (though rarely) using `make stress`.

Fixes #4855.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5260)

<!-- Reviewable:end -->
