### PR TITLE
storage: Set LastUpdateNanos for split and merge stats to txn timestamp

### DIFF
--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -66,7 +66,7 @@ func createSplitRanges(store *storage.Store) (*roachpb.RangeDescriptor, *roachpb
 func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 
 	if _, _, err := createSplitRanges(store); err != nil {
@@ -94,7 +94,7 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 
 	scan := func(f func(roachpb.KeyValue) (bool, error)) {
@@ -172,7 +172,7 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 func TestStoreRangeMergeWithData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 
 	content := roachpb.Key("testing!")
@@ -299,7 +299,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 func TestStoreRangeMergeLastRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 
 	// Merge last range.
@@ -365,7 +365,7 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 func TestStoreRangeMergeStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, manual := createTestStore(t)
 	defer stopper.Stop()
 
 	// Split the range.
@@ -390,12 +390,14 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	}
 
 	// Stats should agree with recomputation.
-	if err := verifyRecomputedStats(snap, aDesc, msA); err != nil {
+	if err := verifyRecomputedStats(snap, aDesc, msA, manual.UnixNano()); err != nil {
 		t.Fatalf("failed to verify range A's stats before split: %v", err)
 	}
-	if err := verifyRecomputedStats(snap, bDesc, msB); err != nil {
+	if err := verifyRecomputedStats(snap, bDesc, msB, manual.UnixNano()); err != nil {
 		t.Fatalf("failed to verify range B's stats before split: %v", err)
 	}
+
+	manual.Increment(100)
 
 	// Merge the b range back into the a range.
 	args := adminMergeArgs(roachpb.KeyMin)
@@ -413,7 +415,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	}
 
 	// Merged stats should agree with recomputation.
-	if err := verifyRecomputedStats(snap, rngMerged.Desc(), msMerged); err != nil {
+	if err := verifyRecomputedStats(snap, rngMerged.Desc(), msMerged, manual.UnixNano()); err != nil {
 		t.Errorf("failed to verify range's stats after merge: %v", err)
 	}
 }
@@ -421,7 +423,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 func BenchmarkStoreRangeMerge(b *testing.B) {
 	defer tracing.Disable()()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(b)
+	store, stopper, _ := createTestStore(b)
 	defer stopper.Stop()
 
 	// Perform initial split of ranges.

--- a/storage/client_range_tree_test.go
+++ b/storage/client_range_tree_test.go
@@ -177,7 +177,7 @@ func verifyProperty5(t *testing.T, nodes map[string]roachpb.RangeTreeNode, testN
 func TestSetupRangeTree(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 	db := store.DB()
 
@@ -196,7 +196,7 @@ func TestSetupRangeTree(t *testing.T) {
 func TestTree(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 	db := store.DB()
 

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -323,7 +323,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 func TestRangeLookupUseReverse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 
 	// Init test ranges:

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -58,7 +58,7 @@ func adminSplitArgs(key, splitKey roachpb.Key) roachpb.AdminSplitRequest {
 // at illegal keys.
 func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 
 	for _, key := range []roachpb.Key{
@@ -81,7 +81,7 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 
 	key := keys.MakeNonColumnKey(append([]byte(nil), keys.UserTableDataMin...))
@@ -132,7 +132,7 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 func TestStoreRangeSplitInsideRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 
 	// Manually create some the column keys corresponding to the table:
@@ -187,7 +187,7 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 
 	args := adminSplitArgs(roachpb.KeyMin, []byte("a"))
@@ -211,7 +211,7 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 func TestStoreRangeSplitConcurrent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 
 	splitKey := roachpb.Key("a")
@@ -254,7 +254,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 func TestStoreRangeSplitIdempotency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 	rangeID := roachpb.RangeID(1)
 	splitKey := roachpb.Key("m")
@@ -393,7 +393,7 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 func TestStoreRangeSplitStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(t)
+	store, stopper, manual := createTestStore(t)
 	defer stopper.Stop()
 
 	// Split the range after the last table data key.
@@ -407,7 +407,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	rng := store.LookupReplica(keyPrefix, nil)
 	// NOTE that this value is expected to change over time, depending on what
 	// we store in the sys-local keyspace. Update it accordingly for this test.
-	if err := verifyRangeStats(store.Engine(), rng.RangeID, engine.MVCCStats{}); err != nil {
+	if err := verifyRangeStats(store.Engine(), rng.RangeID, engine.MVCCStats{LastUpdateNanos: manual.UnixNano()}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -421,9 +421,11 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	if err := engine.MVCCGetRangeStats(snap, rng.RangeID, &ms); err != nil {
 		t.Fatal(err)
 	}
-	if err := verifyRecomputedStats(snap, rng.Desc(), ms); err != nil {
+	if err := verifyRecomputedStats(snap, rng.Desc(), ms, manual.UnixNano()); err != nil {
 		t.Fatalf("failed to verify range's stats before split: %v", err)
 	}
+
+	manual.Increment(100)
 
 	// Split the range at approximate halfway point ("Z" in string "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz").
 	midKey := append([]byte(nil), keyPrefix...)
@@ -459,15 +461,25 @@ func TestStoreRangeSplitStats(t *testing.T) {
 		IntentCount: msLeft.IntentCount + msRight.IntentCount,
 	}
 	ms.SysBytes, ms.SysCount = 0, 0
+	ms.LastUpdateNanos = 0
 	if expMS != ms {
 		t.Errorf("expected left and right ranges to equal original: %+v + %+v != %+v", msLeft, msRight, ms)
 	}
 
+	// Stats should both have the new timestamp.
+	now := manual.UnixNano()
+	if lTs := msLeft.LastUpdateNanos; lTs != now {
+		t.Errorf("expected left range stats to have new timestamp, want %d, got %d", now, lTs)
+	}
+	if rTs := msRight.LastUpdateNanos; rTs != now {
+		t.Errorf("expected right range stats to have new timestamp, want %d, got %d", now, rTs)
+	}
+
 	// Stats should agree with recomputation.
-	if err := verifyRecomputedStats(snap, rng.Desc(), msLeft); err != nil {
+	if err := verifyRecomputedStats(snap, rng.Desc(), msLeft, now); err != nil {
 		t.Fatalf("failed to verify left range's stats after split: %v", err)
 	}
-	if err := verifyRecomputedStats(snap, rngRight.Desc(), msRight); err != nil {
+	if err := verifyRecomputedStats(snap, rngRight.Desc(), msRight, now); err != nil {
 		t.Fatalf("failed to verify right range's stats after split: %v", err)
 	}
 }
@@ -509,7 +521,7 @@ func fillRange(store *storage.Store, rangeID roachpb.RangeID, prefix roachpb.Key
 // exceeding zone's RangeMaxBytes.
 func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	config.TestingSetupZoneConfigHook(stopper)
 	defer stopper.Stop()
 
@@ -564,7 +576,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 // split.
 func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	config.TestingSetupZoneConfigHook(stopper)
 	defer stopper.Stop()
 
@@ -598,7 +610,7 @@ func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 // the SystemConfig span.
 func TestStoreRangeSystemSplits(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, stopper := createTestStore(t)
+	store, stopper, _ := createTestStore(t)
 	defer stopper.Stop()
 
 	schema := sql.MakeMetadataSchema()
@@ -924,7 +936,7 @@ func TestStoreSplitReadRace(t *testing.T) {
 			}
 			return nil
 		}
-	store, stopper := createTestStoreWithContext(t, &sCtx)
+	store, stopper, _ := createTestStoreWithContext(t, &sCtx)
 	defer stopper.Stop()
 
 	now := store.Clock().Now()
@@ -1015,7 +1027,7 @@ func TestLeaderAfterSplit(t *testing.T) {
 func BenchmarkStoreRangeSplit(b *testing.B) {
 	defer tracing.Disable()()
 	defer config.TestingDisableTableSplits()()
-	store, stopper := createTestStore(b)
+	store, stopper, _ := createTestStore(b)
 	defer stopper.Stop()
 
 	// Perform initial split of ranges.


### PR DESCRIPTION
This change builds on #5245, by making sure that the `LastUpdateNanos`
are consistently replicated. However, it now increments the split/merge
stats `LastUpdateNanos` to the timestamp of the transaction with the
split/merge trigger which is causing them.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5265)

<!-- Reviewable:end -->
