### PR TITLE
acceptance: enables clusters of both 5 and 7 nodes in all acceptance tests

### DIFF
--- a/acceptance/cluster/testconfig.go
+++ b/acceptance/cluster/testconfig.go
@@ -44,7 +44,6 @@ func DefaultConfigs() []TestConfig {
 				},
 			},
 		},
-		/*  TODO(bram): #4445 skipping these test cases until is resolved.
 		{
 			Name:     "5x1",
 			Duration: DefaultDuration,
@@ -57,7 +56,7 @@ func DefaultConfigs() []TestConfig {
 			},
 		},
 		{
-			Name: "7x1",
+			Name:     "7x1",
 			Duration: DefaultDuration,
 			Stall:    DefaultStall,
 			Nodes: []NodeConfig{
@@ -66,7 +65,7 @@ func DefaultConfigs() []TestConfig {
 					Stores: []StoreConfig{{Count: 1}},
 				},
 			},
-		},*/
+		},
 	}
 }
 


### PR DESCRIPTION
This was waiting on #4445 which has been resolved.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5269)

<!-- Reviewable:end -->
