### PR TITLE
sql: plumb a soft/hard flag for the limit hint

### DIFF
--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -184,4 +184,7 @@ func (n *distinctNode) ExplainPlan() (string, string, []planNode) {
 	return "distinct", description, []planNode{n.planNode}
 }
 
-func (*distinctNode) SetLimitHint(_ int64) {}
+func (n *distinctNode) SetLimitHint(numRows int64, soft bool) {
+	// Any limit becomes a "soft" limit underneath.
+	n.planNode.SetLimitHint(numRows, true)
+}

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -230,4 +230,4 @@ func (*explainDebugNode) DebugValues() debugValues {
 	panic("debug mode not implemented in explainDebugNode")
 }
 
-func (*explainDebugNode) SetLimitHint(_ int64) {}
+func (*explainDebugNode) SetLimitHint(_ int64, _ bool) {}

--- a/sql/group.go
+++ b/sql/group.go
@@ -358,7 +358,7 @@ func (n *groupNode) ExplainPlan() (name, description string, children []planNode
 	return name, description, []planNode{n.plan}
 }
 
-func (*groupNode) SetLimitHint(_ int64) {}
+func (*groupNode) SetLimitHint(_ int64, _ bool) {}
 
 // wrap the supplied planNode with the groupNode if grouping/aggregation is required.
 func (n *groupNode) wrap(plan planNode) planNode {

--- a/sql/join.go
+++ b/sql/join.go
@@ -213,9 +213,9 @@ func (n *indexJoinNode) ExplainPlan() (name, description string, children []plan
 	return "index-join", "", []planNode{n.index, n.table}
 }
 
-func (n *indexJoinNode) SetLimitHint(numRows int64) {
+func (n *indexJoinNode) SetLimitHint(numRows int64, soft bool) {
 	if numRows < joinBatchSize {
 		numRows = joinBatchSize
 	}
-	n.index.SetLimitHint(numRows)
+	n.index.SetLimitHint(numRows, soft)
 }

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -75,7 +75,7 @@ func (p *planner) limit(limit *parser.Limit, plan planNode) (planNode, error) {
 	}
 
 	if count != math.MaxInt64 {
-		plan.SetLimitHint(offset + count)
+		plan.SetLimitHint(offset+count, true)
 	}
 
 	return &limitNode{planNode: plan, count: count, offset: offset}, nil
@@ -151,4 +151,4 @@ func (n *limitNode) ExplainPlan() (string, string, []planNode) {
 	return "limit", fmt.Sprintf("count: %s, offset: %d", count, n.offset), []planNode{n.planNode}
 }
 
-func (*limitNode) SetLimitHint(_ int64) {}
+func (*limitNode) SetLimitHint(_ int64, _ bool) {}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -299,28 +299,43 @@ type planNode interface {
 	// returned slice is guaranteed to be equal to the length of the
 	// tuple returned by Values().
 	Columns() []ResultColumn
+
 	// The indexes of the columns the output is ordered by.
 	Ordering() orderingInfo
+
 	// Values returns the values at the current row. The result is only valid
 	// until the next call to Next().
 	Values() parser.DTuple
-	// DebugValues returns a set of debug values, valid until the next call to Next(). This is only
-	// available for nodes that have been put in a special "explainDebug" mode (using
-	// MarkDebug). When the output field in the result is debugValueRow, a set of values is
-	// also available through Values().
+
+	// DebugValues returns a set of debug values, valid until the next call to
+	// Next(). This is only available for nodes that have been put in a special
+	// "explainDebug" mode (using MarkDebug). When the output field in the
+	// result is debugValueRow, a set of values is also available through
+	// Values().
 	DebugValues() debugValues
+
 	// Next advances to the next row, returning false if an error is encountered
 	// or if there is no next row.
 	Next() bool
+
 	// PErr returns the error, if any, encountered during iteration.
 	PErr() *roachpb.Error
+
 	// ExplainPlan returns a name and description and a list of child nodes.
 	ExplainPlan() (name, description string, children []planNode)
-	// SetLimitHint tells this node to optimize things under the assumption that we will only need
-	// the first `numRows` rows. This is only a hint; the node must still be able to produce all
-	// results if requested.
-	SetLimitHint(numRows int64)
-	// MarkDebug puts the node in a special debugging mode, which allows DebugValues to be used.
+
+	// SetLimitHint tells this node to optimize things under the assumption that
+	// we will only need the first `numRows` rows.
+	//
+	// If soft is true, this is a "soft" limit and is only a hint; the node must
+	// still be able to produce all results if requested.
+	//
+	// If soft is false, this is a "hard" limit and is a promise that Next will
+	// never be called more than numRows times.
+	SetLimitHint(numRows int64, soft bool)
+
+	// MarkDebug puts the node in a special debugging mode, which allows
+	// DebugValues to be used.
 	MarkDebug(mode explainMode)
 }
 
@@ -372,4 +387,4 @@ func (e *emptyNode) Next() bool {
 	return r
 }
 
-func (*emptyNode) SetLimitHint(_ int64) {}
+func (*emptyNode) SetLimitHint(_ int64, _ bool) {}

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -110,7 +110,9 @@ func (n *scanNode) DebugValues() debugValues {
 	return n.debugVals
 }
 
-func (n *scanNode) SetLimitHint(numRows int64) {
+func (n *scanNode) SetLimitHint(numRows int64, soft bool) {
+	// TODO(radu): maybe make the limitHint higher if soft is true or there is
+	// no filter? (#5267)
 	n.limitHint = numRows
 }
 

--- a/sql/select.go
+++ b/sql/select.go
@@ -153,8 +153,8 @@ func (s *selectNode) ExplainPlan() (name, description string, children []planNod
 	return s.table.node.ExplainPlan()
 }
 
-func (s *selectNode) SetLimitHint(numRows int64) {
-	s.table.node.SetLimitHint(numRows)
+func (s *selectNode) SetLimitHint(numRows int64, soft bool) {
+	s.table.node.SetLimitHint(numRows, soft || s.filter != nil)
 }
 
 // Select selects rows from a SELECT/UNION/VALUES, ordering and/or limiting them.

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -229,10 +229,10 @@ func (n *sortNode) ExplainPlan() (name, description string, children []planNode)
 	return name, description, []planNode{n.plan}
 }
 
-func (n *sortNode) SetLimitHint(numRows int64) {
+func (n *sortNode) SetLimitHint(numRows int64, soft bool) {
 	// The limit is only useful to the wrapped node if we don't need to sort.
 	if !n.needSort {
-		n.plan.SetLimitHint(numRows)
+		n.plan.SetLimitHint(numRows, soft)
 	}
 }
 

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -139,4 +139,4 @@ func (*explainTraceNode) DebugValues() debugValues {
 	panic("debug mode not implemented in explainTraceNode")
 }
 
-func (*explainTraceNode) SetLimitHint(_ int64) {}
+func (*explainTraceNode) SetLimitHint(_ int64, _ bool) {}

--- a/sql/union.go
+++ b/sql/union.go
@@ -158,9 +158,9 @@ func (n *unionNode) Values() parser.DTuple {
 		return nil
 	}
 }
-func (n *unionNode) SetLimitHint(numRows int64) {
-	n.right.SetLimitHint(numRows)
-	n.left.SetLimitHint(numRows)
+func (n *unionNode) SetLimitHint(numRows int64, soft bool) {
+	n.right.SetLimitHint(numRows, true)
+	n.left.SetLimitHint(numRows, true)
 }
 
 func (n *unionNode) ExplainPlan() (name, description string, children []planNode) {

--- a/sql/values.go
+++ b/sql/values.go
@@ -170,4 +170,4 @@ func (n *valuesNode) ExplainPlan() (name, description string, children []planNod
 	return name, description, nil
 }
 
-func (*valuesNode) SetLimitHint(_ int64) {}
+func (*valuesNode) SetLimitHint(_ int64, _ bool) {}


### PR DESCRIPTION
There are situations where if we know for sure the upper layer only needs X rows
we can be more efficient: Nate is looking at making the sortNode use only O(X)
memory in this case. This change improves the SetLimitHint API by adding a
soft vs hard limit flag. Soft limits are "hints", hard limits are "promises".

@nvanbenschoten

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5270)

<!-- Reviewable:end -->
