### PR TITLE
Fix wrapping on single node graphs page

### DIFF
--- a/ui/styl/partials/layout.styl
+++ b/ui/styl/partials/layout.styl
@@ -264,16 +264,20 @@ a.toggle
   &.healthy
     color $main-green
 
-.section.charts
-  h2
-    clear both
-    padding-top 15px
-
-    &:first-child
-      padding-top 0
-
+.section.overview
   .charts
     width $chart-width
+
+.section.node
+  .charts
+    width $chart-width
+
+    h2
+      clear both
+      padding-top 15px
+
+      &:first-child
+        padding-top 0
 
 .banner
   width 100%

--- a/ui/ts/pages/cluster.ts
+++ b/ui/ts/pages/cluster.ts
@@ -316,7 +316,7 @@ module AdminViews {
         if (detail === "events") {
           primaryContent = m(".section.table", m.component(Components.Events, 10));
         } else  {
-          primaryContent = m(".section.charts", [
+          primaryContent = m(".section.overview", [
             ctrl.RenderGraphsSmall(),
             ctrl.RenderGraphs(),
           ]);

--- a/ui/ts/pages/nodes.ts
+++ b/ui/ts/pages/nodes.ts
@@ -630,7 +630,7 @@ module AdminViews {
         return m(".page", [
           m.component(Components.Topbar, {title: title, updated: updated}),
           m.component(NavigationBar, {ts: ctrl.TargetSet()}),
-          m(".section", primaryContent),
+          m(".section.node", primaryContent),
         ]);
       }
     }


### PR DESCRIPTION
The stylus selector for the header was broken, so "clear:both" wasn't being applied to the chart section header.

Also, especially for larger charges, the reviewer should try the new version of the UI by pulling the branch that the PR is based on. Max mentioned that he's seen this done in other places, and I think that would prevent similar issues from occurring in the future.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5271)

<!-- Reviewable:end -->
