### PR TITLE
storage: invoke a separate raft RPC on snapshot

### DIFF
--- a/storage/raft_transport_test.go
+++ b/storage/raft_transport_test.go
@@ -18,11 +18,11 @@ package storage_test
 
 import (
 	"math/rand"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/gogo/protobuf/proto"
 
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -73,8 +73,8 @@ func TestSendAndReceive(t *testing.T) {
 	// stores in reverse order to ensure that the various IDs are not
 	// equal: replica 1 is store 5, replica 2 is store 3, and replica 3
 	// is store 1.
-	const numServers = 3
-	const storesPerServer = 2
+	const numNodes = 3
+	const storesPerNode = 2
 	nextNodeID := roachpb.NodeID(2)
 	nextStoreID := roachpb.StoreID(2)
 
@@ -90,12 +90,11 @@ func TestSendAndReceive(t *testing.T) {
 		5: 1,
 	}
 
-	for serverIndex := 0; serverIndex < numServers; serverIndex++ {
+	for nodeIndex := 0; nodeIndex < numNodes; nodeIndex++ {
 		nodeID := nextNodeID
 		nextNodeID++
 		grpcServer := rpc.NewServer(nodeRPCContext)
-		ln, err := util.ListenAndServeGRPC(stopper, grpcServer,
-			util.TestAddr)
+		ln, err := util.ListenAndServeGRPC(stopper, grpcServer, util.TestAddr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -111,11 +110,10 @@ func TestSendAndReceive(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		transport := storage.NewRaftTransport(storage.GossipAddressResolver(g),
-			grpcServer, nodeRPCContext)
+		transport := storage.NewRaftTransport(storage.GossipAddressResolver(g), grpcServer, nodeRPCContext)
 		transports[nodeID] = transport
 
-		for store := 0; store < storesPerServer; store++ {
+		for storeIndex := 0; storeIndex < storesPerNode; storeIndex++ {
 			storeID := nextStoreID
 			nextStoreID++
 
@@ -131,26 +129,23 @@ func TestSendAndReceive(t *testing.T) {
 	for fromStoreID, fromNodeID := range storeNodes {
 		for toStoreID, toNodeID := range storeNodes {
 			req := &storage.RaftMessageRequest{
-				GroupID: 0,
 				Message: raftpb.Message{
 					Type: raftpb.MsgHeartbeat,
 					From: uint64(fromStoreID),
 					To:   uint64(toStoreID),
 				},
 				FromReplica: roachpb.ReplicaDescriptor{
-					NodeID:    fromNodeID,
-					StoreID:   fromStoreID,
-					ReplicaID: 0,
+					NodeID:  fromNodeID,
+					StoreID: fromStoreID,
 				},
 				ToReplica: roachpb.ReplicaDescriptor{
-					NodeID:    toNodeID,
-					StoreID:   toStoreID,
-					ReplicaID: 0,
+					NodeID:  toNodeID,
+					StoreID: toStoreID,
 				},
 			}
 
 			if err := transports[fromNodeID].Send(req); err != nil {
-				t.Errorf("Unable to send message from %d to %d: %s", fromNodeID, toNodeID, err)
+				t.Errorf("unable to send %s from %d to %d: %s", req.Message.Type, fromNodeID, toNodeID, err)
 			}
 		}
 	}
@@ -164,8 +159,7 @@ func TestSendAndReceive(t *testing.T) {
 			select {
 			case req := <-channels[toStoreID].ch:
 				if req.Message.To != uint64(toStoreID) {
-					t.Errorf("invalid message received on channel %d: %+v",
-						toStoreID, req)
+					t.Errorf("got unexpected message %v on channel %d", req, toStoreID)
 				}
 			case <-time.After(5 * time.Second):
 				t.Fatal("timed out waiting for message")
@@ -174,7 +168,7 @@ func TestSendAndReceive(t *testing.T) {
 
 		select {
 		case req := <-channels[toStoreID].ch:
-			t.Errorf("got unexpected message %+v on channel %d", req, toStoreID)
+			t.Errorf("got unexpected message %v on channel %d", req, toStoreID)
 		default:
 		}
 	}
@@ -183,7 +177,7 @@ func TestSendAndReceive(t *testing.T) {
 	// Send a message from replica 2 (on store 3, node 2) to replica 1 (on store 5, node 3)
 	fromStoreID := roachpb.StoreID(3)
 	toStoreID := roachpb.StoreID(5)
-	req := &storage.RaftMessageRequest{
+	expReq := &storage.RaftMessageRequest{
 		GroupID: 1,
 		Message: raftpb.Message{
 			Type: raftpb.MsgApp,
@@ -201,22 +195,16 @@ func TestSendAndReceive(t *testing.T) {
 			ReplicaID: replicaIDs[toStoreID],
 		},
 	}
-	if err := transports[storeNodes[fromStoreID]].Send(req); err != nil {
-		t.Errorf("Unable to send message from %d to %d: %s", fromStoreID, toStoreID, err)
+	if err := transports[storeNodes[fromStoreID]].Send(expReq); err != nil {
+		t.Errorf("unable to send message from %d to %d: %s", fromStoreID, toStoreID, err)
 	}
-	select {
-	case req2 := <-channels[toStoreID].ch:
-		if !reflect.DeepEqual(req, req2) {
-			t.Errorf("got unexpected message %+v", req2)
-		}
-
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for message")
+	if req := <-channels[toStoreID].ch; !proto.Equal(req, expReq) {
+		t.Errorf("got unexpected message %v on channel %d", req, toStoreID)
 	}
 
 	select {
 	case req := <-channels[toStoreID].ch:
-		t.Errorf("got unexpected message %+v on channel %d", req, toStoreID)
+		t.Errorf("got unexpected message %v on channel %d", req, toStoreID)
 	default:
 	}
 }


### PR DESCRIPTION
Fixes #3013.

I suppose I'd call this a WIP, since it's untested and currently just spawns an untracked goroutine. Should we track said goroutine?

I'm not sure how to test this except by inducing message reordering, which seems sketchy.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5276)

<!-- Reviewable:end -->
