### PR TITLE
encoding: Use temp buffers when decoding series of keys

### DIFF
--- a/sql/table.go
+++ b/sql/table.go
@@ -548,13 +548,17 @@ func decodeKeyVals(valTypes, vals []parser.Datum, directions []encoding.Directio
 		return nil, util.Errorf("encoding directions doesn't parallel valTypes: %d vs %d.",
 			len(directions), len(valTypes))
 	}
+	var tmp []byte
+	if len(valTypes) > 1 {
+		tmp = make([]byte, 0, 64)
+	}
 	for j := range valTypes {
 		direction := encoding.Ascending
 		if directions != nil {
 			direction = directions[j]
 		}
 		var err error
-		vals[j], key, err = decodeTableKey(valTypes[j], key, direction)
+		vals[j], key, err = decodeTableKey(valTypes[j], key, direction, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -562,7 +566,7 @@ func decodeKeyVals(valTypes, vals []parser.Datum, directions []encoding.Directio
 	return key, nil
 }
 
-func decodeTableKey(valType parser.Datum, key []byte, dir encoding.Direction) (
+func decodeTableKey(valType parser.Datum, key []byte, dir encoding.Direction, tmp []byte) (
 	parser.Datum, []byte, error) {
 	if (dir != encoding.Ascending) && (dir != encoding.Descending) {
 		return nil, nil, util.Errorf("invalid direction: %d", dir)
@@ -593,17 +597,17 @@ func decodeTableKey(valType parser.Datum, key []byte, dir encoding.Direction) (
 	case parser.DFloat:
 		var f float64
 		if dir == encoding.Ascending {
-			rkey, f, err = encoding.DecodeFloatAscending(key, nil)
+			rkey, f, err = encoding.DecodeFloatAscending(key, tmp)
 		} else {
-			rkey, f, err = encoding.DecodeFloatDescending(key, nil)
+			rkey, f, err = encoding.DecodeFloatDescending(key, tmp)
 		}
 		return parser.DFloat(f), rkey, err
 	case *parser.DDecimal:
 		var d *inf.Dec
 		if dir == encoding.Ascending {
-			rkey, d, err = encoding.DecodeDecimalAscending(key, nil)
+			rkey, d, err = encoding.DecodeDecimalAscending(key, tmp)
 		} else {
-			rkey, d, err = encoding.DecodeDecimalDescending(key, nil)
+			rkey, d, err = encoding.DecodeDecimalDescending(key, tmp)
 		}
 		dd := &parser.DDecimal{}
 		dd.Set(d)
@@ -611,9 +615,9 @@ func decodeTableKey(valType parser.Datum, key []byte, dir encoding.Direction) (
 	case parser.DString:
 		var r string
 		if dir == encoding.Ascending {
-			rkey, r, err = encoding.DecodeStringAscending(key, nil)
+			rkey, r, err = encoding.DecodeStringAscending(key, tmp)
 		} else {
-			rkey, r, err = encoding.DecodeStringDescending(key, nil)
+			rkey, r, err = encoding.DecodeStringDescending(key, tmp)
 		}
 		return parser.DString(r), rkey, err
 	case parser.DBytes:

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -690,8 +690,9 @@ func PeekType(b []byte) Type {
 // values in the provided byte slice, separated by a provided separator.
 func PrettyPrintValue(b []byte, sep string) string {
 	var buf bytes.Buffer
+	tmp := make([]byte, 0, 64)
 	for len(b) > 0 {
-		bb, s, err := prettyPrintFirstValue(b)
+		bb, s, err := prettyPrintFirstValue(b, tmp)
 		if err != nil {
 			fmt.Fprintf(&buf, "%s<%v>", sep, err)
 		} else {
@@ -705,7 +706,7 @@ func PrettyPrintValue(b []byte, sep string) string {
 // prettyPrintFirstValue returns a string representation of the first decodable
 // value in the provided byte slice, along with the remaining byte slice
 // after decoding.
-func prettyPrintFirstValue(b []byte) ([]byte, string, error) {
+func prettyPrintFirstValue(b, tmp []byte) ([]byte, string, error) {
 	var err error
 	switch PeekType(b) {
 	case Null:
@@ -734,21 +735,21 @@ func prettyPrintFirstValue(b []byte) ([]byte, string, error) {
 		// Decode both floats and decimals as decimals to avoid
 		// overflow.
 		var d *inf.Dec
-		b, d, err = DecodeDecimalAscending(b, nil)
+		b, d, err = DecodeDecimalAscending(b, tmp)
 		if err != nil {
 			return b, "", err
 		}
 		return b, d.String(), nil
 	case Bytes:
 		var s string
-		b, s, err = DecodeStringAscending(b, nil)
+		b, s, err = DecodeStringAscending(b, tmp)
 		if err != nil {
 			return b, "", err
 		}
 		return b, strconv.Quote(s), nil
 	case BytesDesc:
 		var s string
-		b, s, err = DecodeStringDescending(b, nil)
+		b, s, err = DecodeStringDescending(b, tmp)
 		if err != nil {
 			return b, "", err
 		}


### PR DESCRIPTION
We support providing temporary buffers to decoding routines to avoid
internal allocations, however, before this change we were never taking
advantage of this.

This change should speed up:
- Index decoding
- Pretty printing

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5277)

<!-- Reviewable:end -->
