### PR TITLE
storage/engine: benchmark seek on iterator backed by non-empty batch

### DIFF
--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -755,4 +756,80 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 			b.Closed(),
 		)
 	}()
+}
+
+func BenchmarkIterOnBatch10(b *testing.B) {
+	benchmarkIterOnBatch(b, 10)
+}
+
+func BenchmarkIterOnBatch100(b *testing.B) {
+	benchmarkIterOnBatch(b, 100)
+}
+
+func BenchmarkIterOnBatch1000(b *testing.B) {
+	benchmarkIterOnBatch(b, 1000)
+}
+
+func BenchmarkIterOnBatch10000(b *testing.B) {
+	benchmarkIterOnBatch(b, 10000)
+}
+
+func makeKey(i int) MVCCKey {
+	return MakeMVCCMetadataKey(roachpb.Key(strconv.Itoa(i)))
+}
+
+func benchmarkIterOnBatch(b *testing.B, writes int) {
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+
+	engine := createTestEngine(stopper)
+
+	// Additional keys to write to base beyond what will be deleted / seeked to.
+	// Adding lots of extra keys makes seek much faster.
+	extra, err := strconv.Atoi(os.Getenv("EXTRA"))
+	if err != nil {
+		extra = 0
+	}
+
+	// Move the region of deleted and seeked keys up into middle of written base keys.
+	// moving this up to 50 or 100 makes seek much faster.
+	// with extra=500, changing this from 50 to 150, seek is 4.5x faster.
+	offset, err := strconv.Atoi(os.Getenv("OFFSET"))
+	if err != nil {
+		offset = 0
+	}
+
+	for i := 0; i < writes+extra; i++ {
+		if err := engine.Put(makeKey(i), []byte(strconv.Itoa(i))); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	batch := engine.NewBatch()
+	defer batch.Close()
+
+	// shuffling the order of these doesn't change anything.
+	for i := 0; i < writes; i++ {
+		if err := batch.Clear(makeKey(i + offset)); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	if os.Getenv("FLUSH_BATCH") == "1" {
+		if err := batch.Commit(); err != nil {
+			b.Fatal(err)
+		} else {
+			batch = engine.NewBatch()
+		}
+	}
+
+	iter := batch.NewIterator(nil)
+	defer iter.Close()
+	r := rand.New(rand.NewSource(5))
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		iter.Seek(makeKey(r.Intn(writes) + offset))
+	}
 }


### PR DESCRIPTION
running with and without FLUSH_BATCH:

```
name                old time/op    new time/op    delta
IterOnBatch1-8         833ns ± 1%     644ns ± 1%  -22.69%          (p=0.008 n=5+5)
IterOnBatch10-8       3.26µs ± 7%    0.97µs ± 1%  -70.06%          (p=0.008 n=5+5)
IterOnBatch100-8      31.7µs ± 5%     3.4µs ± 1%  -89.24%          (p=0.008 n=5+5)
IterOnBatch1000-8      477µs ± 2%      27µs ± 0%  -94.28%          (p=0.008 n=5+5)
IterOnBatch10000-8    8.63ms ± 4%    0.40ms ± 1%  -95.37%          (p=0.008 n=5+5)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5278)

<!-- Reviewable:end -->
