### PR TITLE
acceptance: adds sizes and more configuration options to the tests

### DIFF
--- a/acceptance/cluster/testconfig.go
+++ b/acceptance/cluster/testconfig.go
@@ -16,11 +16,7 @@
 
 package cluster
 
-import (
-	"bytes"
-	"fmt"
-	"time"
-)
+import "time"
 
 const (
 	// DefaultStall is the default value for stall detection time.
@@ -34,9 +30,7 @@ const (
 func DefaultConfigs() []TestConfig {
 	return []TestConfig{
 		{
-			Name:     "3x1",
-			Duration: DefaultDuration,
-			Stall:    DefaultStall,
+			Name: "3x1",
 			Nodes: []NodeConfig{
 				{
 					Count:  3,
@@ -45,9 +39,7 @@ func DefaultConfigs() []TestConfig {
 			},
 		},
 		{
-			Name:     "5x1",
-			Duration: DefaultDuration,
-			Stall:    DefaultStall,
+			Name: "5x1",
 			Nodes: []NodeConfig{
 				{
 					Count:  5,
@@ -56,9 +48,7 @@ func DefaultConfigs() []TestConfig {
 			},
 		},
 		{
-			Name:     "7x1",
-			Duration: DefaultDuration,
-			Stall:    DefaultStall,
+			Name: "7x1",
 			Nodes: []NodeConfig{
 				{
 					Count:  7,
@@ -66,38 +56,57 @@ func DefaultConfigs() []TestConfig {
 				},
 			},
 		},
+		{
+			Name: "3x2",
+			Nodes: []NodeConfig{
+				{
+					Count:  3,
+					Stores: []StoreConfig{{Count: 2}},
+				},
+			},
+		},
+		{
+			Name: "1x1L,1x1M,1x1S",
+			Nodes: []NodeConfig{
+				{
+					Count: 1,
+					Stores: []StoreConfig{{
+						Count:     1,
+						MaxRanges: 10,
+					}},
+				},
+				{
+					Count: 1,
+					Stores: []StoreConfig{{
+						Count:     1,
+						MaxRanges: 20,
+					}},
+				},
+				{
+					Count: 1,
+					Stores: []StoreConfig{{
+						Count:     1,
+						MaxRanges: 30,
+					}},
+				},
+			},
+		},
+		{
+			Name: "1x1,1x2,1x3",
+			Nodes: []NodeConfig{
+				{
+					Count:  1,
+					Stores: []StoreConfig{{Count: 1}},
+				},
+				{
+					Count:  1,
+					Stores: []StoreConfig{{Count: 2}},
+				},
+				{
+					Count:  1,
+					Stores: []StoreConfig{{Count: 3}},
+				},
+			},
+		},
 	}
-}
-
-// PrettyString creates a human readable string depicting the test and cluster
-// setup designed for output while running tests.
-func (tc TestConfig) PrettyString() string {
-	var nodeCount int
-	var storeCount int
-	var buffer bytes.Buffer
-
-	buffer.WriteString(fmt.Sprintf("Cluster Setup: %s\nDuration: %s, Stall: %s\n", tc.Name, tc.Duration, tc.Stall))
-	for _, nc := range tc.Nodes {
-		for i := 0; i < int(nc.Count); i++ {
-			buffer.WriteString(fmt.Sprintf("Node %d - ", nodeCount))
-			nodeCount++
-			var tmpStoreCount int
-			for _, sc := range nc.Stores {
-				for j := 0; j < int(sc.Count); j++ {
-					if tmpStoreCount > 0 {
-						buffer.WriteString(", ")
-					}
-					// TODO(bram): #4561 Add store details (size) here when
-					// they are available.
-					buffer.WriteString(fmt.Sprintf("Store %d", tmpStoreCount))
-					tmpStoreCount++
-					storeCount++
-				}
-			}
-			buffer.WriteString("\n")
-		}
-	}
-	buffer.WriteString(fmt.Sprintf("Total Nodes Count:%d, Total Store Count:%d\n", nodeCount, storeCount))
-
-	return buffer.String()
 }

--- a/acceptance/cluster/testconfig.pb.go
+++ b/acceptance/cluster/testconfig.pb.go
@@ -32,7 +32,8 @@ var _ = math.Inf
 
 // StoreConfig holds the configuration of a collection of similar stores.
 type StoreConfig struct {
-	Count int32 `protobuf:"varint,1,opt,name=count" json:"count"`
+	Count     int32 `protobuf:"varint,1,opt,name=count" json:"count"`
+	MaxRanges int32 `protobuf:"varint,2,opt,name=max_ranges" json:"max_ranges"`
 }
 
 func (m *StoreConfig) Reset()         { *m = StoreConfig{} }
@@ -87,6 +88,9 @@ func (m *StoreConfig) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x8
 	i++
 	i = encodeVarintTestconfig(data, i, uint64(m.Count))
+	data[i] = 0x10
+	i++
+	i = encodeVarintTestconfig(data, i, uint64(m.MaxRanges))
 	return i, nil
 }
 
@@ -194,6 +198,7 @@ func (m *StoreConfig) Size() (n int) {
 	var l int
 	_ = l
 	n += 1 + sovTestconfig(uint64(m.Count))
+	n += 1 + sovTestconfig(uint64(m.MaxRanges))
 	return n
 }
 
@@ -283,6 +288,25 @@ func (m *StoreConfig) Unmarshal(data []byte) error {
 				b := data[iNdEx]
 				iNdEx++
 				m.Count |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxRanges", wireType)
+			}
+			m.MaxRanges = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTestconfig
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.MaxRanges |= (int32(b) & 0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/acceptance/cluster/testconfig.proto
+++ b/acceptance/cluster/testconfig.proto
@@ -23,7 +23,7 @@ import weak "gogoproto/gogo.proto";
 // StoreConfig holds the configuration of a collection of similar stores.
 message StoreConfig {
   optional int32 count = 1 [(gogoproto.nullable) = false];
-// TODO(bram): #4561 something for different store sizes here
+  optional int32 max_ranges = 2 [(gogoproto.nullable) = false];
 }
 
 // NodeConfig holds the configuration of a collection of similar nodes.


### PR DESCRIPTION
This change adds size, in terms of max number of ranges, to store configs. This
should unlock adding rebalance acceptance tests.

This change also adds the ability to override any passed in testConfig's (or
the set of default ones') duration and stall times.

Finally, this change converts the output of the running testConfig to json
which can now be rerun directly using the new flag --config. This is mentioned
in #4015.

Fixes #4095

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5281)

<!-- Reviewable:end -->
