### PR TITLE
storage: Set the observed timestamp when retries finish

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -1683,7 +1683,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 	// and the original error otherwise.
 	sp.LogEvent("store retry limit exceeded") // good to check for if tests fail
 	if ba.Txn != nil {
-		return nil, roachpb.NewErrorWithTxn(roachpb.NewTransactionRetryError(), ba.Txn)
+		pErr = roachpb.NewErrorWithTxn(roachpb.NewTransactionRetryError(), ba.Txn)
 	}
 	return nil, pErr
 }


### PR DESCRIPTION
Store.Send sets up a defer that updates the observed timestamp of pErr. So, we need to update pErr before returning at every place in Send().

This change fixes a bug where we didn't update pErr when retries finish. This happens only in unittests, but it would be still nice to fix this.

Wasn't able to write a test to reproduce a bug..

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5286)

<!-- Reviewable:end -->
