### PR TITLE
Fix #5284 - connections graph at 0 even under load

### DIFF
--- a/ui/ts/pages/cluster.ts
+++ b/ui/ts/pages/cluster.ts
@@ -144,7 +144,6 @@ module AdminViews {
           this._addChart(
             Metrics.NewAxis(
               Metrics.Select.Avg(_nodeMetric("sql.conns"))
-                .nonNegativeRate()
                 .title("Connections")
               ).format(d3.format("d")).title("Connections").range([0])
           );


### PR DESCRIPTION
We want the current value of `sql.conns` (the current # of connections), not the
derivative (the connection rate). Perhaps we'll want the latter at
some point, but not now.

This is broken on the cluster overview but working on single-node graphs.

cc @mrtracy

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5287)

<!-- Reviewable:end -->
