### PR TITLE
storage: deflake TestBaseQueueProcess

### DIFF
--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -302,6 +302,10 @@ func TestBaseQueueProcess(t *testing.T) {
 		}
 		return nil
 	})
+
+	// Ensure the test queue is not blocked on a stray call to
+	// testQueueImpl.timer().
+	close(testQueue.blocker)
 }
 
 // TestBaseQueueAddRemove adds then removes a range; ensure range is


### PR DESCRIPTION
Ensure the test queue is not blocked on a stray call to
`testQueueImpl.timer()`.

Fixes #5289.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5296)

<!-- Reviewable:end -->
