### PR TITLE
don't import both lib/pq and our fork

### DIFF
--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -33,13 +33,13 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
-	_ "github.com/lib/pq"
 
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/acceptance/terrafarm"
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/util/caller"
 	"github.com/cockroachdb/cockroach/util/log"
+	_ "github.com/cockroachdb/pq"
 )
 
 var flagDuration = flag.Duration("d", cluster.DefaultDuration, "duration to run the test")

--- a/sql/pgbench/cmd/pgbenchsetup/main.go
+++ b/sql/pgbench/cmd/pgbenchsetup/main.go
@@ -23,9 +23,8 @@ import (
 	"net/url"
 	"os"
 
-	_ "github.com/lib/pq"
-
 	"github.com/cockroachdb/cockroach/sql/pgbench"
+	_ "github.com/cockroachdb/pq"
 )
 
 var usage = func() {


### PR DESCRIPTION
Linking both causes a double registration of the "postgres" driver.

Fixes #5320.
Fixes #5321.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5324)

<!-- Reviewable:end -->
