### PR TITLE
Avoid failing when reading a zero transaction timestamp during Prepare.

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -61,7 +61,7 @@ func (p *planner) Delete(n *parser.Delete, autoCommit bool) (planNode, *roachpb.
 		return nil, roachpb.NewError(err)
 	}
 
-	if p.prepareOnly {
+	if p.evalCtx.PrepareOnly {
 		// Return the result column types.
 		return rh.getResults(), nil
 	}

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -196,7 +196,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 			}
 		}
 
-		if p.prepareOnly {
+		if p.evalCtx.PrepareOnly {
 			continue
 		}
 
@@ -275,7 +275,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 		return nil, pErr
 	}
 
-	if p.prepareOnly {
+	if p.evalCtx.PrepareOnly {
 		// Return the result column types.
 		return rh.getResults(), nil
 	}

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -368,6 +368,16 @@ func TestPGPreparedQuery(t *testing.T) {
 				time.Date(2006, 7, 8, 0, 0, 0, 0, time.FixedZone("", 0)),
 			),
 		},
+		"INSERT INTO d.ts VALUES(CURRENT_TIMESTAMP(), $1) RETURNING b": {
+			base.Params("2006-07-08").Results(
+				time.Date(2006, 7, 8, 0, 0, 0, 0, time.FixedZone("", 0)),
+			),
+		},
+		"INSERT INTO d.ts VALUES(STATEMENT_TIMESTAMP(), $1) RETURNING b": {
+			base.Params("2006-07-08").Results(
+				time.Date(2006, 7, 8, 0, 0, 0, 0, time.FixedZone("", 0)),
+			),
+		},
 
 		"INSERT INTO d.T VALUES ($1) RETURNING 1": {
 			base.Params(1).Results(1),

--- a/sql/select.go
+++ b/sql/select.go
@@ -282,7 +282,7 @@ func (p *planner) initSelect(
 
 		// If we are only preparing, the filter expression can contain unexpanded subqueries which
 		// are not supported by splitFilter.
-		if !p.prepareOnly {
+		if !p.evalCtx.PrepareOnly {
 			// Compute a filter expression for the scan node.
 			convFunc := func(expr parser.VariableExpr) (bool, parser.VariableExpr) {
 				qval := expr.(*qvalue)

--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -63,7 +63,7 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 		return false, expr
 	}
 
-	if v.prepareOnly {
+	if v.evalCtx.PrepareOnly {
 		return false, expr
 	}
 

--- a/sql/update.go
+++ b/sql/update.go
@@ -154,7 +154,7 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 	// types are inferred. For the simpler case ("SET a = $1"), populate them
 	// using marshalColumnValue. This step also verifies that the expression
 	// types match the column types.
-	if p.prepareOnly {
+	if p.evalCtx.PrepareOnly {
 		for i, target := range rows.(*selectNode).render[exprTargetIdx:] {
 			// DefaultVal doesn't implement TypeCheck
 			if _, ok := target.(parser.DefaultVal); ok {


### PR DESCRIPTION
This is a temporary fix for an issue uncovered by an earlier change.

The previous change: during SQL evaluation the time-related functions
now check that the transaction and statement timestamp are properly
set (to a non-zero value).  The revealed issue: during Prepare some
SQL expressions are also evaluated, which is incorrect. This will need
to be addressed.

Meanwhile this patch temporarily works around the issue by only
complaining about unset timestamps if they are requested outside of
Prepare.

Fixes #5333.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5341)

<!-- Reviewable:end -->
