### PR TITLE
UI: Better handling of graph query timeouts

### DIFF
--- a/ui/styl/partials/visualizations.styl
+++ b/ui/styl/partials/visualizations.styl
@@ -48,6 +48,9 @@ $viz-sides = 62px
   float right
   margin 10px 15px 0 0
   color $secondary-gray-5
+  
+  .icon-warning
+    color $secondary-gold
 
 .viz-bottom
   height $viz-bottom
@@ -90,5 +93,8 @@ $viz-sides = 62px
       .linegraph
         height 70px
 
-
-
+.viz-faded
+  .visualization .number
+  .nv-group
+  .nv-areaWrap
+    opacity .2

--- a/ui/test.html
+++ b/ui/test.html
@@ -28,7 +28,7 @@ Author: Matt Tracy (matt@cockroachlabs.com)
     <div id="mocha"></div>
 
     <script src="bower_components/lodash/lodash.min.js"></script>
-    <script src="bower_components/mithril/mithril.min.js"></script>
+    <script src="bower_components/mithriljs/mithril.js"></script>
     <script src="bower_components/mocha/mocha.js"></script>
     <script src="bower_components/chai/chai.js"></script>
 

--- a/ui/ts/components/metrics.ts
+++ b/ui/ts/components/metrics.ts
@@ -124,7 +124,7 @@ module Components {
             // occurred. For now, we will just display the "No Data"
             // message until we decided on the proper way to display
             // error messages.
-            let qresult: Models.Metrics.QueryInfoSet<Models.Proto.QueryResult> = this.vm.query.result();
+            let qresult: Models.Metrics.QueryInfoSet<Models.Proto.QueryResult> = this.vm.query.lastResult();
             if (qresult) {
               // Iterate through each selector on the axis,
               // allowing each to select the necessary data from
@@ -166,16 +166,24 @@ module Components {
 
       export function view(ctrl: Controller): _mithril.MithrilVirtualElement {
         let g: _mithril.MithrilVirtualElement = null;
+        let icon: _mithril.MithrilVirtualElement = m(".icon-info");
+        let warningClass = "";
         if (ctrl.hasData()) {
           g = m(".linegraph", m("svg.graph", { config: ctrl.drawGraph }));
+          if (ctrl.vm.query.error() != null) {
+            icon = m(".icon-warning", {
+              title: ctrl.vm.query.error(),
+            });
+            warningClass = " .viz-faded";
+          }
         } else {
           g = m("", "loading...");
         }
         return m(
-          ".visualization-wrapper",
+          ".visualization-wrapper" + warningClass,
           [
             // TODO: pass in and display info icon tooltip
-            m(".viz-top", m(".viz-info-icon", m(".icon-info"))),
+            m(".viz-top", m(".viz-info-icon", icon)),
             g,
             m(".viz-bottom", m(".viz-title", ctrl.vm.axis.title())),
           ]

--- a/ui/ts/components/visualizations/visualizations.ts
+++ b/ui/ts/components/visualizations/visualizations.ts
@@ -18,6 +18,7 @@ module Visualizations {
     title: string;
     virtualVisualizationElement: MithrilVirtualElement;
     visualizationArguments?: any;
+    warning?: () => string;
   }
 
   export module VisualizationWrapper {
@@ -26,12 +27,20 @@ module Visualizations {
     export function controller(): void {}
 
     export function view(ctrl: any, info: VisualizationWrapperInfo): MithrilVirtualElement {
+      let icon: MithrilVirtualElement = m(".icon-info");
+      let warningClass = "";
+      if (info.warning && info.warning()) {
+        icon = m(".icon-warning", {
+                 title: info.warning(),
+        });
+        warningClass = " .viz-faded";
+      }
 
       return m(
-        ".visualization-wrapper",
+        ".visualization-wrapper" + warningClass,
         [
           // TODO: pass in and display info icon tooltip
-          m(".viz-top", m(".viz-info-icon", m(".icon-info"))),
+          m(".viz-top", m(".viz-info-icon", icon)),
           info.virtualVisualizationElement,
           m(".viz-bottom", m(".viz-title", info.title)),
         ]

--- a/ui/ts/models/api.ts
+++ b/ui/ts/models/api.ts
@@ -1,5 +1,8 @@
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
+/// <reference path="../../typings/browser.d.ts"/>
 /// <reference path="../models/proto.ts" />
+/// <reference path="../util/format.ts" />
+/// <reference path="../util/http.ts" />
 
 module Models {
   "use strict";
@@ -30,17 +33,11 @@ module Models {
       events: ClusterEvent[];
     }
 
-    // Timeout after 2s
-    let xhrConfig = function(xhr: XMLHttpRequest): XMLHttpRequest {
-      xhr.timeout = 2000;
-      return xhr;
-    };
-
     // gets a list of databases
     export function databases(): MithrilPromise<DatabaseList> {
       return m.request<DatabaseList>({
         url: "/_admin/v1/databases",
-        config: xhrConfig,
+        config: Utils.Http.XHRConfig,
       });
     }
 
@@ -48,7 +45,7 @@ module Models {
     export function database(database: string): MithrilPromise<Database> {
       return m.request<Database>({
         url: `/_admin/v1/databases/${database}`,
-        config: xhrConfig,
+        config: Utils.Http.XHRConfig,
       });
     }
 
@@ -56,7 +53,7 @@ module Models {
     export function table(database: string, table: string): MithrilPromise<SQLTable> {
       return m.request<SQLTable>({
         url: `/_admin/v1/databases/${database}/tables/${table}`,
-        config: xhrConfig,
+        config: Utils.Http.XHRConfig,
       });
     }
 
@@ -64,7 +61,7 @@ module Models {
     export function users(): MithrilPromise<Users> {
       return m.request<Users>({
         url: "/_admin/v1/users",
-        config: xhrConfig,
+        config: Utils.Http.XHRConfig,
       });
     }
 
@@ -73,7 +70,7 @@ module Models {
     export function events(): MithrilPromise<ClusterEvents> {
       return m.request<UnparsedClusterEvents>({
         url: "/_admin/v1/events",
-        config: xhrConfig,
+        config: Utils.Http.XHRConfig,
       }).then((response: UnparsedClusterEvents): ClusterEvents => {
         return {
           events: _.map<UnparsedClusterEvent, ClusterEvent>(response.events, (event: UnparsedClusterEvent): ClusterEvent => {
@@ -100,14 +97,14 @@ module Models {
     export function getUIData(key: string): MithrilPromise<GetUIDataResponse> {
       return m.request<GetUIDataResponse>({
         url: `/_admin/v1/uidata?key=${key}`,
-        config: xhrConfig,
+        config: Utils.Http.XHRConfig,
       });
     }
 
     export function setUIData(key: string, value: string): MithrilPromise<any> {
       return m.request<UnparsedClusterEvents>({
         url: `/_admin/v1/uidata`,
-        config: xhrConfig,
+        config: Utils.Http.XHRConfig,
         method: "POST",
         data: {
           key: key,

--- a/ui/ts/models/log.ts
+++ b/ui/ts/models/log.ts
@@ -35,7 +35,7 @@ module Models {
 
       private _data: Utils.QueryCache<Proto.LogEntry[]> = new Utils.QueryCache(
           (): Promise<Proto.LogEntry[]> => {
-              return m.request({ url: this._url(), method: "GET", extract: nonJsonErrors, config: function(xhr: XMLHttpRequest): void { xhr.timeout = 2000; } })
+              return m.request({ url: this._url(), method: "GET", extract: nonJsonErrors, config: function(xhr: XMLHttpRequest): void { xhr.timeout = 10000; } })
                   .then((results: LogResponseSet) => {
                       return results.d;
                   });

--- a/ui/ts/models/status.ts
+++ b/ui/ts/models/status.ts
@@ -86,11 +86,11 @@ module Models {
           });
       });
 
-      private _dataMap: Utils.ReadOnlyProperty<StoreStatusMap> = Utils.Computed(this._data.result, (list: Proto.StoreStatus[]) => {
+      private _dataMap: Utils.ReadOnlyProperty<StoreStatusMap> = Utils.Computed(this._data.lastResult, (list: Proto.StoreStatus[]) => {
         return _.keyBy(list, (status: Proto.StoreStatus) => status.desc.store_id);
       });
 
-      private _totalStatus: Utils.ReadOnlyProperty<Proto.Status> = Utils.Computed(this._data.result, (list: Proto.StoreStatus[]) => {
+      private _totalStatus: Utils.ReadOnlyProperty<Proto.Status> = Utils.Computed(this._data.lastResult, (list: Proto.StoreStatus[]) => {
         let status: Proto.Status = {
           range_count: 0,
           updated_at: 0,
@@ -109,7 +109,7 @@ module Models {
       });
 
       constructor() {
-        this.allStatuses = this._data.result;
+        this.allStatuses = this._data.lastResult;
         this.totalStatus = this._totalStatus;
       }
 
@@ -119,6 +119,10 @@ module Models {
 
       public refresh(): void {
         this._data.refresh();
+      }
+
+      public error(): Error {
+        return this._data.error();
       }
     }
 
@@ -143,11 +147,11 @@ module Models {
           });
       });
 
-      private _dataMap: Utils.ReadOnlyProperty<NodeStatusMap> = Utils.Computed(this._data.result, (list: Proto.NodeStatus[]) => {
+      private _dataMap: Utils.ReadOnlyProperty<NodeStatusMap> = Utils.Computed(this._data.lastResult, (list: Proto.NodeStatus[]) => {
         return _.keyBy(list, (status: Proto.NodeStatus) => status.desc.node_id);
       });
 
-      private _totalStatus: Utils.ReadOnlyProperty<Proto.Status> = Utils.Computed(this._data.result, (list: Proto.NodeStatus[]) => {
+      private _totalStatus: Utils.ReadOnlyProperty<Proto.Status> = Utils.Computed(this._data.lastResult, (list: Proto.NodeStatus[]) => {
         let status: Proto.Status = {
           range_count: 0,
           updated_at: 0,
@@ -166,7 +170,7 @@ module Models {
       });
 
       constructor() {
-        this.allStatuses = this._data.result;
+        this.allStatuses = this._data.lastResult;
         this.totalStatus = this._totalStatus;
       }
 
@@ -176,6 +180,10 @@ module Models {
 
       public refresh(): void {
         this._data.refresh();
+      }
+
+      public error(): Error {
+        return this._data.error();
       }
     }
   }

--- a/ui/ts/pages/cluster.ts
+++ b/ui/ts/pages/cluster.ts
@@ -213,6 +213,10 @@ module AdminViews {
               axis.visualizationArguments.data = axis.visualizationArguments.dataFn(allStats, allStoreStats, totalStats, totalStoreStats);
               axis.virtualVisualizationElement =
                 m.component(Visualizations.NumberVisualization, axis.visualizationArguments);
+              axis.warning = () => {
+                let warning: Error = nodeStatuses.error();
+                return warning && warning.toString();
+              };
               return m("", {style: "float:left"}, m.component(Visualizations.VisualizationWrapper, axis));
             }
           }));
@@ -234,6 +238,10 @@ module AdminViews {
               axis.visualizationArguments.data = axis.visualizationArguments.dataFn(allStats, allStoreStats, totalStats, totalStoreStats);
               axis.virtualVisualizationElement =
                 m.component(Visualizations.NumberVisualization, axis.visualizationArguments);
+              axis.warning = () => {
+                let warning: Error = nodeStatuses.error();
+                return warning && warning.toString();
+              };
               return m(".small.half", {style: "float:left"},  m.component(Visualizations.VisualizationWrapper, axis));
             }
           }));

--- a/ui/ts/test/util.ts
+++ b/ui/ts/test/util.ts
@@ -213,6 +213,29 @@ suite("QueryCache", () => {
     assert.isNull(cache.error(), "error should be empty after result.");
   });
 
+  test("LastResult remains cached after error.", () => {
+    cache.refresh();
+    activePromise().resolve("resolved");
+    assert.isTrue(cache.hasData(), "cache should have value");
+    assert.equal(cache.result(), "resolved");
+    assert.equal(cache.lastResult(), "resolved");
+    assert.isNull(cache.error(), "error should be empty after result.");
+
+    cache.refresh();
+    activePromise().reject(new Error("error"));
+    assert.isTrue(cache.hasData(), "cache should have value");
+    assert.isNull(cache.result(), "result should be null after error");
+    assert.equal(cache.lastResult(), "resolved");
+    assert.deepEqual(cache.error(), new Error("error"));
+
+    cache.refresh();
+    activePromise().resolve("resolved again");
+    assert.isTrue(cache.hasData(), "cache should have value");
+    assert.equal(cache.result(), "resolved again");
+    assert.equal(cache.lastResult(), "resolved again");
+    assert.isNull(cache.error(), "error should be empty after result.");
+  });
+
   test("Cached value not overwritten until next promise resolved.", () => {
     cache.refresh();
     activePromise().resolve("resolved");

--- a/ui/ts/util/http.ts
+++ b/ui/ts/util/http.ts
@@ -10,12 +10,17 @@ module Utils {
    * Cockroach HTTP endpoints.
    */
   export module Http {
+    export function XHRConfig(xhr: XMLHttpRequest): void {
+      // Ten second timeout.
+      xhr.timeout = 10000;
+    }
+
     /**
      * Get sends an GET request to the given relative URL, and returns
      * a mithril promise for the results of the request.
      */
     export function Get(url: string): _mithril.MithrilPromise<{}> {
-      return m.request({ url: url, method: "GET", extract: nonJsonErrors, config: function(xhr: XMLHttpRequest): void { xhr.timeout = 2000; } });
+      return m.request({ url: url, method: "GET", extract: nonJsonErrors, config: XHRConfig });
     }
 
     /**
@@ -24,7 +29,7 @@ module Utils {
      * encoded as JSON before being sent as the body of the request.
      */
     export function Post(url: string, data: any): _mithril.MithrilPromise<{}> {
-      return m.request({ url: url, method: "POST", extract: nonJsonErrors, data: data, config: function(xhr: XMLHttpRequest): void { xhr.timeout = 2000; }});
+      return m.request({ url: url, method: "POST", extract: nonJsonErrors, data: data, config: XHRConfig});
     }
 
     /**


### PR DESCRIPTION
We were encountering an issue on a heavily loaded cluster in which time series
queries were timing out. This was poorly messaged in the GUI. This commit makes
several changes to address this:
- Relevant timeouts have been increased to 10 seconds (from 2 seconds), which
  should make the appearance of this problem rare.
- Visualizations no longer display "Data not available" errors when a timeout
  occurs. Instead, they display the last data available along with a "warning"
  icon. The data is also faded out considerably, and the warning icon has a
  hover tooltip.

Our designers will be providing a better icon for us to use, but as of this
commit it will remain the yellow "warning" icon.

Fixes #5114

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5349)

<!-- Reviewable:end -->
