### PR TITLE
storage: add more info to a raft truncation error message

### DIFF
--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -97,7 +97,8 @@ func getTruncatableIndexes(r *Replica) (uint64, uint64, error) {
 	}
 
 	if oldestIndex < firstIndex {
-		return 0, 0, util.Errorf("raft log's oldest index is less than the first index for range %d", rangeID)
+		return 0, 0, util.Errorf("raft log's oldest index (%d) is less than the first index (%d) for range %d",
+			oldestIndex, firstIndex, rangeID)
 	}
 
 	// Return the number of truncatable indexes.


### PR DESCRIPTION
This should help with #4890.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5354)

<!-- Reviewable:end -->
