### PR TITLE
sql: add logic and parallel test files to static-tests package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,12 @@ endif
 	for p in $(shell $(GO) list $(PKG)); do \
 	  NAME=$$(basename "$$p"); \
 	  PKGDIR=$$($(GO) list -f {{.ImportPath}} $$p); \
-		OUTPUT_FILE="$(DIR)/$${PKGDIR}/$${NAME}.test"; \
+	  OUTPUT_FILE="$(DIR)/$${PKGDIR}/$${NAME}.test"; \
 	  $(GO) test -v $(GOFLAGS) -o $${OUTPUT_FILE} -ldflags '$(LDFLAGS)' "$$p" $(TESTFLAGS) || exit 1; \
-	  if [ -s $${OUTPUT_FILE} ]; then strip -S $${OUTPUT_FILE}; fi \
+	  if [ -s $${OUTPUT_FILE} ]; then strip -S $${OUTPUT_FILE}; fi; \
+	  if [ $${NAME} = "sql" ]; then \
+	     cp -r sql/testdata sql/partestdata "$(DIR)/$${PKGDIR}/" || exit 1; \
+	  fi \
 	done
 
 # Similar to "testrace", we want to cache the build before running the

--- a/cloud/aws/stress/stress.sh
+++ b/cloud/aws/stress/stress.sh
@@ -20,10 +20,15 @@ function run_one_test {
   test_binary=$1
   name=$(basename ${test_binary})
   package=$(dirname ${test_binary})
-  log_dir="${LOG_DIR}/${package}"
+  cur_dir=$(pwd -P)
+  log_dir="${cur_dir}/${LOG_DIR}/${package}"
   mkdir -p "${log_dir}"
   echo "${name}: ${test_binary} ${log_dir}"
-  ./stress ${STRESS_FLAGS} ${test_binary} ${TEST_FLAGS} 2> ${log_dir}/${name}.stderr > ${log_dir}/${name}.stdout
+  # Each test must be run from the respective package directory
+  stress_bin="${cur_dir}/stress"
+  pushd ${package}
+  ${stress_bin} ${STRESS_FLAGS} ./${name} ${TEST_FLAGS} 2> ${log_dir}/${name}.stderr > ${log_dir}/${name}.stdout
+  popd
 }
 
 for test in $(find cockroach/ -type f -name '*.test' | sort); do

--- a/sql/parallel_test.go
+++ b/sql/parallel_test.go
@@ -160,9 +160,13 @@ func (t *parallelTest) setup() {
 func TestParallel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	paths, err := filepath.Glob(*paralleltestdata)
+	glob := string(*paralleltestdata)
+	paths, err := filepath.Glob(glob)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("No testfiles found (glob: %s)", glob)
 	}
 	total := 0
 	for _, p := range paths {

--- a/sql/partestdata/subquery_retry/txn
+++ b/sql/partestdata/subquery_retry/txn
@@ -2,6 +2,6 @@
 # inadvertently reuse the previous results of the subquery during a retry, we might insert
 # duplicate values.
 
-repeat 50
+repeat 10
 statement ok
 INSERT INTO T VALUES ((SELECT MAX(k+1) FROM T))


### PR DESCRIPTION
The static test package did not include the sql test files. Until recently the
tests just silently did not run anything (now they fail). This change copies the
test files in the staging directory for the package (as part of `make
testbuildall`). The `stress.sh` script is also fixed to run each test binary
from the respective package directory.

Tested by running `build/build-static-binaries.sh`, unpacking the bundle in a
temp dir, copying stress, and running `cloud/aws/stress.sh`.

Fixes #5339.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5358)

<!-- Reviewable:end -->
