### PR TITLE
Rename *TestingMocker to *TestingKnobs

### DIFF
--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -505,7 +505,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 	var numGets int32
 
 	ctx := server.NewTestContext()
-	ctx.TestingMocker.StoreTestingKnobs.TestingCommandFilter =
+	ctx.TestingKnobs.StoreTestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
 			if _, ok := args.(*roachpb.ConditionalPutRequest); ok && args.Header().Key.Equal(targetKey) {
 				if atomic.AddInt32(&numGets, 1) == 1 {

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -505,7 +505,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 	var numGets int32
 
 	ctx := server.NewTestContext()
-	ctx.TestingMocker.StoreTestingMocker.TestingCommandFilter =
+	ctx.TestingMocker.StoreTestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
 			if _, ok := args.(*roachpb.ConditionalPutRequest); ok && args.Header().Key.Equal(targetKey) {
 				if atomic.AddInt32(&numGets, 1) == 1 {

--- a/server/context.go
+++ b/server/context.go
@@ -149,7 +149,7 @@ type Context struct {
 // TestingMocker is a struct containing facilities for mocking
 // or otherwise controlling various parts of the system.
 type TestingMocker struct {
-	StoreTestingMocker   storage.StoreTestingMocker
+	StoreTestingKnobs    storage.StoreTestingKnobs
 	ExecutorTestingKnobs sql.ExecutorTestingKnobs
 }
 

--- a/server/context.go
+++ b/server/context.go
@@ -142,13 +142,13 @@ type Context struct {
 	// Environment Variable: COCKROACH_TIME_UNTIL_STORE_DEAD
 	TimeUntilStoreDead time.Duration
 
-	// TestingMocker is used for internal test mocking only.
-	TestingMocker TestingMocker
+	// TestingKnobs is used for internal test controls only.
+	TestingKnobs TestingKnobs
 }
 
-// TestingMocker is a struct containing facilities for mocking
-// or otherwise controlling various parts of the system.
-type TestingMocker struct {
+// TestingKnobs is a contains facilities for controlling various parts of the
+// system for testing.
+type TestingKnobs struct {
 	StoreTestingKnobs    storage.StoreTestingKnobs
 	ExecutorTestingKnobs sql.ExecutorTestingKnobs
 }

--- a/server/context.go
+++ b/server/context.go
@@ -149,8 +149,8 @@ type Context struct {
 // TestingMocker is a struct containing facilities for mocking
 // or otherwise controlling various parts of the system.
 type TestingMocker struct {
-	StoreTestingMocker    storage.StoreTestingMocker
-	ExecutorTestingMocker sql.ExecutorTestingMocker
+	StoreTestingMocker   storage.StoreTestingMocker
+	ExecutorTestingKnobs sql.ExecutorTestingKnobs
 }
 
 // GetTotalMemory returns either the total system memory or if possible the

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -78,7 +78,7 @@ func TestIntentResolution(t *testing.T) {
 			closer := make(chan struct{}, 2)
 			var done bool
 			ctx := NewTestContext()
-			ctx.TestingMocker.StoreTestingMocker.TestingCommandFilter =
+			ctx.TestingMocker.StoreTestingKnobs.TestingCommandFilter =
 				func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 					mu.Lock()
 					defer mu.Unlock()

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -78,7 +78,7 @@ func TestIntentResolution(t *testing.T) {
 			closer := make(chan struct{}, 2)
 			var done bool
 			ctx := NewTestContext()
-			ctx.TestingMocker.StoreTestingKnobs.TestingCommandFilter =
+			ctx.TestingKnobs.StoreTestingKnobs.TestingCommandFilter =
 				func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 					mu.Lock()
 					defer mu.Unlock()

--- a/server/server.go
+++ b/server/server.go
@@ -157,11 +157,11 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	s.leaseMgr = sql.NewLeaseManager(0, *s.db, s.clock)
 	s.leaseMgr.RefreshLeases(s.stopper, s.db, s.gossip)
 	eCtx := sql.ExecutorContext{
-		DB:            s.db,
-		Gossip:        s.gossip,
-		LeaseManager:  s.leaseMgr,
-		Clock:         s.clock,
-		TestingMocker: &ctx.TestingMocker.ExecutorTestingMocker,
+		DB:           s.db,
+		Gossip:       s.gossip,
+		LeaseManager: s.leaseMgr,
+		Clock:        s.clock,
+		TestingKnobs: &ctx.TestingMocker.ExecutorTestingKnobs,
 	}
 
 	sqlRegistry := metric.NewRegistry()

--- a/server/server.go
+++ b/server/server.go
@@ -161,7 +161,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		Gossip:       s.gossip,
 		LeaseManager: s.leaseMgr,
 		Clock:        s.clock,
-		TestingKnobs: &ctx.TestingMocker.ExecutorTestingKnobs,
+		TestingKnobs: &ctx.TestingKnobs.ExecutorTestingKnobs,
 	}
 
 	sqlRegistry := metric.NewRegistry()
@@ -188,7 +188,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 			AllowRebalance: true,
 			Mode:           storage.BalanceModeUsage,
 		},
-		TestingKnobs: ctx.TestingMocker.StoreTestingKnobs,
+		TestingKnobs: ctx.TestingKnobs.StoreTestingKnobs,
 	}
 
 	s.recorder = status.NewMetricsRecorder(s.clock)

--- a/server/server.go
+++ b/server/server.go
@@ -188,7 +188,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 			AllowRebalance: true,
 			Mode:           storage.BalanceModeUsage,
 		},
-		TestingMocker: ctx.TestingMocker.StoreTestingMocker,
+		TestingKnobs: ctx.TestingMocker.StoreTestingKnobs,
 	}
 
 	s.recorder = status.NewMetricsRecorder(s.clock)

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -245,8 +245,8 @@ func (t *logicTest) setup() {
 	// MySQL or Postgres instance.
 	ctx := server.NewTestContext()
 	ctx.MaxOffset = logicMaxOffset
-	ctx.TestingMocker.ExecutorTestingMocker.WaitForGossipUpdate = true
-	ctx.TestingMocker.ExecutorTestingMocker.CheckStmtStringChange = true
+	ctx.TestingMocker.ExecutorTestingKnobs.WaitForGossipUpdate = true
+	ctx.TestingMocker.ExecutorTestingKnobs.CheckStmtStringChange = true
 	t.srv = setupTestServerWithContext(t.T, ctx)
 
 	// db may change over the lifetime of this function, with intermediate
@@ -499,8 +499,8 @@ func (t *logicTest) processTestFile(path string) {
 			}
 			fmt.Println("Setting deterministic priorities.")
 
-			testingMocker.ExecutorTestingMocker.FixTxnPriority = true
-			defer func() { testingMocker.ExecutorTestingMocker.FixTxnPriority = false }()
+			testingKnobs.ExecutorTestingKnobs.FixTxnPriority = true
+			defer func() { testingKnobs.ExecutorTestingKnobs.FixTxnPriority = false }()
 		default:
 			t.Fatalf("%s:%d: unknown command: %s", path, s.line, cmd)
 		}

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -245,8 +245,8 @@ func (t *logicTest) setup() {
 	// MySQL or Postgres instance.
 	ctx := server.NewTestContext()
 	ctx.MaxOffset = logicMaxOffset
-	ctx.TestingMocker.ExecutorTestingKnobs.WaitForGossipUpdate = true
-	ctx.TestingMocker.ExecutorTestingKnobs.CheckStmtStringChange = true
+	ctx.TestingKnobs.ExecutorTestingKnobs.WaitForGossipUpdate = true
+	ctx.TestingKnobs.ExecutorTestingKnobs.CheckStmtStringChange = true
 	t.srv = setupTestServerWithContext(t.T, ctx)
 
 	// db may change over the lifetime of this function, with intermediate
@@ -273,7 +273,7 @@ func (t *logicTest) processTestFile(path string) {
 
 	t.lastProgress = timeutil.Now()
 
-	testingMocker := &t.srv.Ctx.TestingMocker
+	testingKnobs := &t.srv.Ctx.TestingKnobs
 
 	repeat := 1
 	s := newLineScanner(file)

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -153,7 +153,7 @@ func createTestServerContext() (*server.Context, *CommandFilters) {
 	ctx := server.NewTestContext()
 	var cmdFilters CommandFilters
 	cmdFilters.AppendFilter(checkEndTransactionTrigger)
-	ctx.TestingMocker.StoreTestingMocker.TestingCommandFilter = cmdFilters.runFilters
+	ctx.TestingMocker.StoreTestingKnobs.TestingCommandFilter = cmdFilters.runFilters
 	return ctx, &cmdFilters
 }
 

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -153,7 +153,7 @@ func createTestServerContext() (*server.Context, *CommandFilters) {
 	ctx := server.NewTestContext()
 	var cmdFilters CommandFilters
 	cmdFilters.AppendFilter(checkEndTransactionTrigger)
-	ctx.TestingMocker.StoreTestingKnobs.TestingCommandFilter = cmdFilters.runFilters
+	ctx.TestingKnobs.StoreTestingKnobs.TestingCommandFilter = cmdFilters.runFilters
 	return ctx, &cmdFilters
 }
 

--- a/sql/parallel_test.go
+++ b/sql/parallel_test.go
@@ -152,8 +152,8 @@ func (t *parallelTest) run(dir string) {
 func (t *parallelTest) setup() {
 	ctx := server.NewTestContext()
 	ctx.MaxOffset = logicMaxOffset
-	ctx.TestingMocker.ExecutorTestingKnobs.WaitForGossipUpdate = true
-	ctx.TestingMocker.ExecutorTestingKnobs.CheckStmtStringChange = true
+	ctx.TestingKnobs.ExecutorTestingKnobs.WaitForGossipUpdate = true
+	ctx.TestingKnobs.ExecutorTestingKnobs.CheckStmtStringChange = true
 	t.srv = setupTestServerWithContext(t.T, ctx)
 }
 

--- a/sql/parallel_test.go
+++ b/sql/parallel_test.go
@@ -152,8 +152,8 @@ func (t *parallelTest) run(dir string) {
 func (t *parallelTest) setup() {
 	ctx := server.NewTestContext()
 	ctx.MaxOffset = logicMaxOffset
-	ctx.TestingMocker.ExecutorTestingMocker.WaitForGossipUpdate = true
-	ctx.TestingMocker.ExecutorTestingMocker.CheckStmtStringChange = true
+	ctx.TestingMocker.ExecutorTestingKnobs.WaitForGossipUpdate = true
+	ctx.TestingMocker.ExecutorTestingKnobs.CheckStmtStringChange = true
 	t.srv = setupTestServerWithContext(t.T, ctx)
 }
 

--- a/sql/txn.go
+++ b/sql/txn.go
@@ -81,19 +81,19 @@ func (p *planner) setUserPriority(userPriority parser.UserPriority) error {
 	case parser.UnspecifiedUserPriority:
 		return nil
 	case parser.Low:
-		if p.execCtx.TestingMocker.FixTxnPriority {
+		if p.execCtx.TestingKnobs.FixTxnPriority {
 			p.txn.InternalSetPriority(1)
 			return nil
 		}
 		return p.txn.SetUserPriority(roachpb.LowUserPriority)
 	case parser.Normal:
-		if p.execCtx.TestingMocker.FixTxnPriority {
+		if p.execCtx.TestingKnobs.FixTxnPriority {
 			p.txn.InternalSetPriority(10000)
 			return nil
 		}
 		return p.txn.SetUserPriority(roachpb.NormalUserPriority)
 	case parser.High:
-		if p.execCtx.TestingMocker.FixTxnPriority {
+		if p.execCtx.TestingKnobs.FixTxnPriority {
 			p.txn.InternalSetPriority(1000000000)
 			return nil
 		}

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -168,7 +168,7 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 		stopper := stop.NewStopper()
 		defer stopper.Stop()
 		sCtx := storage.TestStoreContext()
-		sCtx.TestingMocker.TestingCommandFilter =
+		sCtx.TestingKnobs.TestingCommandFilter =
 			func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 				if _, ok := args.(*roachpb.IncrementRequest); ok && args.Header().Key.Equal(roachpb.Key("a")) {
 					numIncrements++
@@ -369,7 +369,7 @@ func TestFailedReplicaChange(t *testing.T) {
 	ctx := storage.TestStoreContext()
 	mtc := &multiTestContext{}
 	mtc.storeContext = &ctx
-	mtc.storeContext.TestingMocker.TestingCommandFilter =
+	mtc.storeContext.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 			if runFilter.Load().(bool) {
 				if et, ok := args.(*roachpb.EndTransactionRequest); ok && et.Commit {
@@ -1549,7 +1549,7 @@ func TestCheckInconsistent(t *testing.T) {
 	// The consistency check will panic on store 1. Let it panic only
 	// if the checksums match.
 	notify := make(chan struct{}, 1)
-	mtc.stores[1].TestingMocker().BadChecksumPanic = func() {
+	mtc.stores[1].TestingKnobs().BadChecksumPanic = func() {
 		notify <- struct{}{}
 	}
 	// Run consistency check.

--- a/storage/client_replica_gc_test.go
+++ b/storage/client_replica_gc_test.go
@@ -45,7 +45,7 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 	// waits for the first.
 	ctx := storage.TestStoreContext()
 	mtc.storeContext = &ctx
-	mtc.storeContext.TestingMocker.TestingCommandFilter =
+	mtc.storeContext.TestingKnobs.TestingCommandFilter =
 		func(id roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 			et, ok := args.(*roachpb.EndTransactionRequest)
 			if !ok || id != 2 {

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -193,7 +193,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	ctx := storage.TestStoreContext()
-	ctx.TestingMocker.TestingCommandFilter =
+	ctx.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
 			if _, ok := args.(*roachpb.GetRequest); ok &&
 				args.Header().Key.Equal(roachpb.Key(key)) &&

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -921,7 +921,7 @@ func TestStoreSplitReadRace(t *testing.T) {
 	getContinues := make(chan struct{})
 	var getStarted sync.WaitGroup
 	sCtx := storage.TestStoreContext()
-	sCtx.TestingMocker.TestingCommandFilter =
+	sCtx.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
 			if et, ok := args.(*roachpb.EndTransactionRequest); ok {
 				st := et.InternalCommitTrigger.GetSplitTrigger()

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -342,7 +342,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 
 	tc := testContext{}
 	tsc := TestStoreContext()
-	tsc.TestingMocker.TestingCommandFilter =
+	tsc.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, req roachpb.Request, _ roachpb.Header) error {
 			if resArgs, ok := req.(*roachpb.ResolveIntentRequest); ok {
 				id := string(resArgs.IntentTxn.Key)

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -76,7 +76,7 @@ const (
 	configGossipInterval = 1 * time.Minute
 )
 
-// CommandFilter may be used in tests through the StorageTestingMocker to
+// CommandFilter may be used in tests through the StorageTestingKnobs to
 // intercept the handling of commands and artificially generate errors. Return
 // nil to continue with regular processing or non-nil to terminate processing
 // with the returned error. Note that in a multi-replica test this filter will

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -60,7 +60,7 @@ func (r *Replica) executeCmd(batch engine.Engine, ms *engine.MVCCStats, h roachp
 	}
 
 	// If a unittest filter was installed, check for an injected error; otherwise, continue.
-	if filter := r.store.ctx.TestingMocker.TestingCommandFilter; filter != nil {
+	if filter := r.store.ctx.TestingKnobs.TestingCommandFilter; filter != nil {
 		err := filter(r.store.StoreID(), args, h)
 		if err != nil {
 			pErr := roachpb.NewErrorWithTxn(err, h.Txn)
@@ -1530,7 +1530,7 @@ func (r *Replica) VerifyChecksum(batch engine.Engine, ms *engine.MVCCStats, h ro
 	if c, ok := r.mu.checksums[id]; ok {
 		if c.ok {
 			if c.checksum != nil && !bytes.Equal(c.checksum, args.Checksum) {
-				if p := r.store.ctx.TestingMocker.BadChecksumPanic; p != nil {
+				if p := r.store.ctx.TestingKnobs.BadChecksumPanic; p != nil {
 					p()
 				} else {
 					// TODO(.*): see #5051.

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1171,7 +1171,7 @@ func TestRangeCommandQueue(t *testing.T) {
 
 	tc := testContext{}
 	tsc := TestStoreContext()
-	tsc.TestingMocker.TestingCommandFilter =
+	tsc.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, _ roachpb.Request, h roachpb.Header) error {
 			if h.UserPriority == 42 {
 				blockingStart <- struct{}{}
@@ -1288,7 +1288,7 @@ func TestRangeCommandQueueInconsistent(t *testing.T) {
 
 	tc := testContext{}
 	tsc := TestStoreContext()
-	tsc.TestingMocker.TestingCommandFilter =
+	tsc.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 			if put, ok := args.(*roachpb.PutRequest); ok {
 				putBytes, err := put.Value.GetBytes()
@@ -2070,7 +2070,7 @@ func TestEndTransactionLocalGC(t *testing.T) {
 	defer setTxnAutoGC(true)()
 	tc := testContext{}
 	tsc := TestStoreContext()
-	tsc.TestingMocker.TestingCommandFilter =
+	tsc.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 			// Make sure the direct GC path doesn't interfere with this test.
 			if args.Method() == roachpb.GC {
@@ -2165,7 +2165,7 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 	tsc := TestStoreContext()
 	key := roachpb.Key("a")
 	splitKey := roachpb.RKey(key).Next()
-	tsc.TestingMocker.TestingCommandFilter =
+	tsc.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 			if args.Method() == roachpb.ResolveIntentRange && args.Header().Key.Equal(splitKey.AsRawKey()) {
 				return util.Errorf("boom")
@@ -2245,7 +2245,7 @@ func TestEndTransactionDirectGCFailure(t *testing.T) {
 	splitKey := roachpb.RKey(key).Next()
 	var count int64
 	tsc := TestStoreContext()
-	tsc.TestingMocker.TestingCommandFilter =
+	tsc.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 			if args.Method() == roachpb.ResolveIntentRange && args.Header().Key.Equal(splitKey.AsRawKey()) {
 				atomic.AddInt64(&count, 1)
@@ -2314,7 +2314,7 @@ func TestReplicaResolveIntentNoWait(t *testing.T) {
 	var seen int32
 	key := roachpb.Key("zresolveme")
 	tsc := TestStoreContext()
-	tsc.TestingMocker.TestingCommandFilter =
+	tsc.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 			if args.Method() == roachpb.ResolveIntent && args.Header().Key.Equal(key) {
 				atomic.StoreInt32(&seen, 1)
@@ -3298,7 +3298,7 @@ func TestReplicaCorruption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tsc := TestStoreContext()
-	tsc.TestingMocker.TestingCommandFilter =
+	tsc.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 			if args.Header().Key.Equal(roachpb.Key("boom")) {
 				return newReplicaCorruptionError()
@@ -4116,7 +4116,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			tsc := TestStoreContext()
 			if !cancelEarly {
-				tsc.TestingMocker.TestingCommandFilter =
+				tsc.TestingKnobs.TestingCommandFilter =
 					func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 						if !args.Header().Key.Equal(key) {
 							return nil
@@ -4238,7 +4238,7 @@ func TestComputeVerifyChecksum(t *testing.T) {
 	}
 	// Set a callback for checksum mismatch panics.
 	var panicked bool
-	rng.store.ctx.TestingMocker.BadChecksumPanic = func() { panicked = true }
+	rng.store.ctx.TestingKnobs.BadChecksumPanic = func() { panicked = true }
 	select {
 	case <-notify:
 		// First test that sending a Verification request with a bad version and

--- a/storage/store.go
+++ b/storage/store.go
@@ -365,11 +365,11 @@ type StoreContext struct {
 	// the range event log.
 	LogRangeEvents bool
 
-	TestingMocker StoreTestingMocker
+	TestingKnobs StoreTestingKnobs
 }
 
-// StoreTestingMocker is a part of the context used to control parts of the system.
-type StoreTestingMocker struct {
+// StoreTestingKnobs is a part of the context used to control parts of the system.
+type StoreTestingKnobs struct {
 	// A callback to be called when executing every replica command.
 	TestingCommandFilter CommandFilter
 	// A callback to be called instead of panicking due to a
@@ -1143,8 +1143,8 @@ func (s *Store) Stopper() *stop.Stopper { return s.stopper }
 // Tracer accessor.
 func (s *Store) Tracer() opentracing.Tracer { return s.ctx.Tracer }
 
-// TestingMocker accessor.
-func (s *Store) TestingMocker() *StoreTestingMocker { return &s.ctx.TestingMocker }
+// TestingKnobs accessor.
+func (s *Store) TestingKnobs() *StoreTestingKnobs { return &s.ctx.TestingKnobs }
 
 // NewRangeDescriptor creates a new descriptor based on start and end
 // keys and the supplied roachpb.Replicas slice. It allocates new

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -610,7 +610,7 @@ func TestStoreObservedTimestamp(t *testing.T) {
 	for _, test := range testCases {
 		func() {
 			ctx := TestStoreContext()
-			ctx.TestingMocker.TestingCommandFilter =
+			ctx.TestingKnobs.TestingCommandFilter =
 				func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 					if bytes.Equal(args.Header().Key, badKey) {
 						return fmt.Errorf("boom")
@@ -672,7 +672,7 @@ func TestStoreAnnotateNow(t *testing.T) {
 		for _, test := range testCases {
 			func() {
 				ctx := TestStoreContext()
-				ctx.TestingMocker.TestingCommandFilter =
+				ctx.TestingKnobs.TestingCommandFilter =
 					func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 						if bytes.Equal(args.Header().Key, badKey) {
 							return fmt.Errorf("boom")
@@ -1018,7 +1018,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 	var store *Store
 	var stopper *stop.Stopper
 	ctx := TestStoreContext()
-	ctx.TestingMocker.TestingCommandFilter =
+	ctx.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, h roachpb.Header) error {
 			pr, ok := args.(*roachpb.PushTxnRequest)
 			if !ok || pr.PusherTxn.Name != "test" {
@@ -1491,7 +1491,7 @@ func TestStoreScanIntents(t *testing.T) {
 	var count int32
 	countPtr := &count
 
-	ctx.TestingMocker.TestingCommandFilter =
+	ctx.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 			if _, ok := args.(*roachpb.ScanRequest); ok {
 				atomic.AddInt32(countPtr, 1)
@@ -1608,7 +1608,7 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	var intercept atomic.Value
 	intercept.Store(true)
 	ctx := TestStoreContext()
-	ctx.TestingMocker.TestingCommandFilter =
+	ctx.TestingKnobs.TestingCommandFilter =
 		func(_ roachpb.StoreID, args roachpb.Request, _ roachpb.Header) error {
 			if _, ok := args.(*roachpb.ResolveIntentRequest); ok && intercept.Load().(bool) {
 				return util.Errorf("error on purpose")


### PR DESCRIPTION
The TestingMocker structures contain various "knobs" to tweak things for tests; they are not "mocking" anything. Renaming all of them. Mechanic change, just a lot of `:GoRename`s.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5359)

<!-- Reviewable:end -->
