### PR TITLE
acceptance: allow tests to run without configs

### DIFF
--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -109,12 +109,13 @@ func readConfigFromFlags() cluster.TestConfig {
 // getConfigs returns a list of test configs based on the passed in flags.
 func getConfigs(t *testing.T) []cluster.TestConfig {
 	// If a config not supplied, just read the flags.
-	if flagConfig == nil && flagTestConfigs == nil {
+	if (flagConfig == nil || len(*flagConfig) == 0) &&
+		(flagTestConfigs == nil || !*flagTestConfigs) {
 		return []cluster.TestConfig{readConfigFromFlags()}
 	}
 
 	var configs []cluster.TestConfig
-	if *flagTestConfigs {
+	if flagTestConfigs != nil && *flagTestConfigs {
 		configs = append(configs, cluster.DefaultConfigs()...)
 	}
 
@@ -145,6 +146,9 @@ func getConfigs(t *testing.T) []cluster.TestConfig {
 // passed in test against each on serially.
 func runTestOnConfigs(t *testing.T, testFunc func(*testing.T, cluster.Cluster, cluster.TestConfig)) {
 	cfgs := getConfigs(t)
+	if len(cfgs) == 0 {
+		t.Fatal("no config defined so most tests won't run")
+	}
 	for _, cfg := range cfgs {
 		func() {
 			cluster := StartCluster(t, cfg)


### PR DESCRIPTION
Checking for nil just checks to make sure that flag.parse() was run. The
default values have to be checked for as well.  So any test without a
specific config won't run.

Fixes #5365.

Thanks for finding this @knz!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5366)

<!-- Reviewable:end -->
