### PR TITLE
Add debug command to "simulate" GC run

### DIFF
--- a/cli/debug.go
+++ b/cli/debug.go
@@ -22,13 +22,17 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 
+	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/kr/pretty"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +43,14 @@ var debugKeysCmd = &cobra.Command{
 Pretty-prints all keys in a store.
 `,
 	RunE: runDebugKeys,
+}
+
+func parseRangeID(arg string) (roachpb.RangeID, error) {
+	rangeIDInt, err := strconv.ParseInt(arg, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return roachpb.RangeID(rangeIDInt), nil
 }
 
 func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (engine.Engine, error) {
@@ -177,11 +189,10 @@ func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	rangeIDInt, err := strconv.ParseInt(args[1], 10, 64)
+	rangeID, err := parseRangeID(args[1])
 	if err != nil {
 		return err
 	}
-	rangeID := roachpb.RangeID(rangeIDInt)
 
 	start := engine.MakeMVCCMetadataKey(keys.RaftLogPrefix(rangeID))
 	end := engine.MakeMVCCMetadataKey(keys.RaftLogPrefix(rangeID).PrefixEnd())
@@ -192,10 +203,98 @@ func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+var debugGCCmd = &cobra.Command{
+	Use:   "estimate-gc [directory] [range id]",
+	Short: "find out what a GC run would do",
+	Long: `
+Sets up (but does not run) a GC collection cycle, giving insight into how much
+work would be done (assuming all intent resolution and pushes succeed).
+
+Without a RangeID specified on the command line, runs the analysis for all
+ranges individually.
+
+Uses a hard-coded GC policy with a 24 hour TTL for old versions.
+`,
+	RunE: runDebugGCCmd,
+}
+
+func runDebugGCCmd(cmd *cobra.Command, args []string) error {
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+
+	if len(args) != 1 {
+		return errors.New("required arguments: dir")
+	}
+
+	var rangeID roachpb.RangeID
+	if len(args) == 2 {
+		var err error
+		if rangeID, err = parseRangeID(args[1]); err != nil {
+			return err
+		}
+	}
+
+	db, err := openStore(cmd, args[0], stopper)
+	if err != nil {
+		return err
+	}
+
+	start := keys.RangeDescriptorKey(roachpb.RKeyMin)
+	end := keys.RangeDescriptorKey(roachpb.RKeyMax)
+
+	var descs []roachpb.RangeDescriptor
+
+	if _, err := engine.MVCCIterate(db, start, end, roachpb.MaxTimestamp,
+		false /* !consistent */, nil, /* txn */
+		false /* !reverse */, func(kv roachpb.KeyValue) (bool, error) {
+			var desc roachpb.RangeDescriptor
+			_, suffix, _, err := keys.DecodeRangeKey(kv.Key)
+			if err != nil {
+				return false, err
+			}
+			if !bytes.Equal(suffix, keys.LocalRangeDescriptorSuffix) {
+				return false, nil
+			}
+			if err := kv.Value.GetProto(&desc); err != nil {
+				return false, err
+			}
+			if desc.RangeID == rangeID || rangeID == 0 {
+				descs = append(descs, desc)
+			}
+			return desc.RangeID == rangeID, nil
+		}); err != nil {
+		return err
+	}
+
+	if len(descs) == 0 {
+		return fmt.Errorf("no range matching the criteria found")
+	}
+
+	for _, desc := range descs {
+		snap := db.NewSnapshot()
+		defer snap.Close()
+		_, info, err := storage.RunGC(&desc, snap, roachpb.Timestamp{WallTime: timeutil.Now().UnixNano()},
+			config.GCPolicy{TTLSeconds: 24 * 60 * 60 /* 1 day */}, func(_ roachpb.Timestamp, _ *roachpb.Transaction, _ roachpb.PushTxnType, wg *sync.WaitGroup) {
+				wg.Done()
+			}, func(_ []roachpb.Intent, _, _ bool) *roachpb.Error { return nil })
+		if err != nil {
+			return err
+		}
+		fmt.Printf("RangeID: %d [%s, %s):\n", desc.RangeID, desc.StartKey, desc.EndKey)
+		_, _ = pretty.Println(info)
+	}
+	return nil
+}
+
+func init() {
+	debugCmd.AddCommand(debugCmds...)
+}
+
 var debugCmds = []*cobra.Command{
 	debugKeysCmd,
 	debugRangeDescriptorsCmd,
 	debugRaftLogCmd,
+	debugGCCmd,
 	kvCmd,
 	rangeCmd,
 }
@@ -211,8 +310,4 @@ process that has failed and cannot restart.
 	Run: func(cmd *cobra.Command, args []string) {
 		mustUsage(cmd)
 	},
-}
-
-func init() {
-	debugCmd.AddCommand(debugCmds...)
 }

--- a/storage/engine/gc.go
+++ b/storage/engine/gc.go
@@ -30,9 +30,9 @@ type GarbageCollector struct {
 	policy     config.GCPolicy
 }
 
-// NewGarbageCollector allocates and returns a new GC, with expiration
+// MakeGarbageCollector allocates and returns a new GC, with expiration
 // computed based on current time and policy.TTLSeconds.
-func NewGarbageCollector(now roachpb.Timestamp, policy config.GCPolicy) GarbageCollector {
+func MakeGarbageCollector(now roachpb.Timestamp, policy config.GCPolicy) GarbageCollector {
 	ttlNanos := int64(policy.TTLSeconds) * 1E9
 	return GarbageCollector{
 		expiration: roachpb.Timestamp{WallTime: now.WallTime - ttlNanos},

--- a/storage/engine/gc.go
+++ b/storage/engine/gc.go
@@ -32,9 +32,9 @@ type GarbageCollector struct {
 
 // NewGarbageCollector allocates and returns a new GC, with expiration
 // computed based on current time and policy.TTLSeconds.
-func NewGarbageCollector(now roachpb.Timestamp, policy config.GCPolicy) *GarbageCollector {
+func NewGarbageCollector(now roachpb.Timestamp, policy config.GCPolicy) GarbageCollector {
 	ttlNanos := int64(policy.TTLSeconds) * 1E9
-	return &GarbageCollector{
+	return GarbageCollector{
 		expiration: roachpb.Timestamp{WallTime: now.WallTime - ttlNanos},
 		policy:     policy,
 	}
@@ -45,7 +45,7 @@ func NewGarbageCollector(now roachpb.Timestamp, policy config.GCPolicy) *Garbage
 // Returns the timestamp including, and after which, all values should
 // be garbage collected. If no values should be GC'd, returns
 // roachpb.ZeroTimestamp.
-func (gc *GarbageCollector) Filter(keys []MVCCKey, values [][]byte) roachpb.Timestamp {
+func (gc GarbageCollector) Filter(keys []MVCCKey, values [][]byte) roachpb.Timestamp {
 	if gc.policy.TTLSeconds <= 0 {
 		return roachpb.ZeroTimestamp
 	}

--- a/storage/engine/gc_test.go
+++ b/storage/engine/gc_test.go
@@ -46,8 +46,8 @@ var (
 // different sorts of MVCC keys.
 func TestGarbageCollectorFilter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	gcA := NewGarbageCollector(makeTS(0, 0), config.GCPolicy{TTLSeconds: 1})
-	gcB := NewGarbageCollector(makeTS(0, 0), config.GCPolicy{TTLSeconds: 2})
+	gcA := MakeGarbageCollector(makeTS(0, 0), config.GCPolicy{TTLSeconds: 1})
+	gcB := MakeGarbageCollector(makeTS(0, 0), config.GCPolicy{TTLSeconds: 2})
 	n := []byte("data")
 	d := []byte(nil)
 	testData := []struct {

--- a/storage/engine/gc_test.go
+++ b/storage/engine/gc_test.go
@@ -51,7 +51,7 @@ func TestGarbageCollectorFilter(t *testing.T) {
 	n := []byte("data")
 	d := []byte(nil)
 	testData := []struct {
-		gc       *GarbageCollector
+		gc       GarbageCollector
 		time     roachpb.Timestamp
 		keys     []MVCCKey
 		values   [][]byte

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -243,9 +243,7 @@ func processSequenceCache(snap engine.Engine, rangeID roachpb.RangeID, now, cuto
 	infoMu.Unlock()
 
 	var wg sync.WaitGroup
-	// TODO(tschottdorf): a lot of these transactions will be on our local range,
-	// so we should simply read those from a snapshot, and only push those which
-	// are PENDING.
+	// TODO(tschottdorf): use stopper.LimitedAsyncTask.
 	wg.Add(len(txns))
 	for _, txn := range txns {
 		if txn.Status != roachpb.PENDING {
@@ -425,7 +423,7 @@ func RunGC(desc *roachpb.RangeDescriptor, snap engine.Engine, now roachpb.Timest
 		}
 	}
 
-	gc := engine.NewGarbageCollector(now, policy)
+	gc := engine.MakeGarbageCollector(now, policy)
 
 	var gcKeys []roachpb.GCRequest_GCKey
 


### PR DESCRIPTION
`./cockroach estimate-gc <dir> [range_id]`

The output format is

```
RangeID: 92 [/Table/53/2/"k\xcaPe\xce\xe6I\xbc\x8af\xd9\xf8V[L\xdb"/Tue Mar 15 17:24:18 UTC 2016, /Max):
storage.GCInfo{
    Now:                        roachpb.Timestamp{WallTime:1458267071598809847, Logical:0},
    Policy:                     config.GCPolicy{TTLSeconds:86400},
    GCKeys:                     22448,
    IntentsConsidered:          0,
    IntentTxns:                 0,
    TransactionSpanTotal:       38,
    TransactionSpanGCAborted:   23,
    TransactionSpanGCCommitted: 15,
    TransactionSpanGCPending:   0,
    TransactionSpanGCNum:       38,
    SequenceSpanTotal:          65026,
    SequenceSpanConsidered:     65026,
    SequenceSpanGCNum:          0,
    PushTxn:                    63691,
    ResolveTotal:               170,
    ResolveSuccess:             170,
}
```

The alert observer will note that this indicates a horrible upcoming GC
performance, in particular regarding the sequence span and the associated
pushes. Improving on that is the next step.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5367)

<!-- Reviewable:end -->
