### PR TITLE
sql: Only Unicode NFC normalize SQL names if necessary

### DIFF
--- a/sql/keys.go
+++ b/sql/keys.go
@@ -57,12 +57,25 @@ var normalize = unicode.SpecialCase{
 // NormalizeName normalizes to lowercase and Unicode Normalization Form C
 // (NFC).
 func NormalizeName(name string) string {
-	return norm.NFC.String(strings.Map(normalize.ToLower, name))
+	lower := strings.Map(normalize.ToLower, name)
+	if isASCII(lower) {
+		return lower
+	}
+	return norm.NFC.String(lower)
 }
 
 // equalName returns true iff the normalizations of a and b are equal.
 func equalName(a, b string) bool {
 	return NormalizeName(a) == NormalizeName(b)
+}
+
+func isASCII(s string) bool {
+	for _, c := range s {
+		if c > unicode.MaxASCII {
+			return false
+		}
+	}
+	return true
 }
 
 // MakeNameMetadataKey returns the key for the name. Pass name == "" in order

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -197,10 +197,10 @@ func (n *scanNode) initTable(p *planner, tableName *parser.QualifiedName) (strin
 
 	alias := n.desc.Name
 
-	indexName := tableName.Index()
-	if indexName != "" && !equalName(n.desc.PrimaryIndex.Name, indexName) {
+	indexName := NormalizeName(tableName.Index())
+	if indexName != "" && NormalizeName(n.desc.PrimaryIndex.Name) != indexName {
 		for i := range n.desc.Indexes {
-			if equalName(n.desc.Indexes[i].Name, indexName) {
+			if NormalizeName(n.desc.Indexes[i].Name) == indexName {
 				// Remove all but the matching index from the descriptor.
 				n.desc.Indexes = n.desc.Indexes[i : i+1]
 				n.index = &n.desc.Indexes[0]

--- a/sql/select_qvalue.go
+++ b/sql/select_qvalue.go
@@ -65,9 +65,9 @@ func (qt qvalResolver) findColumn(qname *parser.QualifiedName) (columnRef, error
 	// no alias is given, we will search for the column in all FROMs and make sure there is only
 	// one.  For now we just check that the name matches (if given).
 	if qname.Base == "" || equalName(qt.table.alias, string(qname.Base)) {
-		colName := qname.Column()
+		colName := NormalizeName(qname.Column())
 		for idx, col := range qt.table.columns {
-			if equalName(col.Name, colName) {
+			if NormalizeName(col.Name) == colName {
 				ref.table = qt.table
 				ref.colIdx = idx
 				return ref, nil

--- a/sql/set.go
+++ b/sql/set.go
@@ -53,7 +53,7 @@ func (p *planner) Set(n *parser.Set) (planNode, *roachpb.Error) {
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
-		switch NormalizeName(string(s)) {
+		switch NormalizeName(s) {
 		case NormalizeName(parser.Modern.String()):
 			p.session.Syntax = int32(parser.Modern)
 		case NormalizeName(parser.Traditional.String()):

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -71,9 +71,9 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, *roach
 				// handles cases like:
 				//
 				//   SELECT a AS b FROM t ORDER BY b
-				target := string(qname.Base)
+				target := NormalizeName(string(qname.Base))
 				for j, col := range columns {
-					if equalName(target, col.Name) {
+					if NormalizeName(col.Name) == target {
 						index = j
 						break
 					}
@@ -89,9 +89,10 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, *roach
 					return nil, roachpb.NewError(err)
 				}
 				if qname.Table() == "" || equalName(s.table.alias, qname.Table()) {
+					qnameCol := NormalizeName(qname.Column())
 					for j, r := range s.render {
 						if qval, ok := r.(*qvalue); ok {
-							if equalName(qval.colRef.get().Name, qname.Column()) {
+							if NormalizeName(qval.colRef.get().Name) == qnameCol {
 								index = j
 								break
 							}

--- a/sql/structured.go
+++ b/sql/structured.go
@@ -396,10 +396,12 @@ func (desc *TableDescriptor) Validate() error {
 		if column.ID == 0 {
 			return fmt.Errorf("invalid column ID %d", column.ID)
 		}
-		if _, ok := columnNames[NormalizeName(column.Name)]; ok {
+
+		normName := NormalizeName(column.Name)
+		if _, ok := columnNames[normName]; ok {
 			return fmt.Errorf("duplicate column name: \"%s\"", column.Name)
 		}
-		columnNames[NormalizeName(column.Name)] = column.ID
+		columnNames[normName] = column.ID
 
 		if other, ok := columnIDs[column.ID]; ok {
 			return fmt.Errorf("column \"%s\" duplicate ID of column \"%s\": %d",
@@ -447,10 +449,11 @@ func (desc *TableDescriptor) Validate() error {
 			return fmt.Errorf("invalid index ID %d", index.ID)
 		}
 
-		if _, ok := indexNames[NormalizeName(index.Name)]; ok {
+		normName := NormalizeName(index.Name)
+		if _, ok := indexNames[normName]; ok {
 			return fmt.Errorf("duplicate index name: \"%s\"", index.Name)
 		}
-		indexNames[NormalizeName(index.Name)] = struct{}{}
+		indexNames[normName] = struct{}{}
 
 		if other, ok := indexIDs[index.ID]; ok {
 			return fmt.Errorf("index \"%s\" duplicate ID of index \"%s\": %d",
@@ -520,14 +523,15 @@ func (desc *TableDescriptor) AddIndex(idx IndexDescriptor, primary bool) error {
 // DescriptorStatus for the column, and an index into either the columns
 // (status == DescriptorActive) or mutations (status == DescriptorIncomplete).
 func (desc *TableDescriptor) FindColumnByName(name string) (DescriptorStatus, int, error) {
+	normName := NormalizeName(name)
 	for i, c := range desc.Columns {
-		if equalName(c.Name, name) {
+		if NormalizeName(c.Name) == normName {
 			return DescriptorActive, i, nil
 		}
 	}
 	for i, m := range desc.Mutations {
 		if c := m.GetColumn(); c != nil {
-			if equalName(c.Name, name) {
+			if NormalizeName(c.Name) == normName {
 				return DescriptorIncomplete, i, nil
 			}
 		}
@@ -537,8 +541,9 @@ func (desc *TableDescriptor) FindColumnByName(name string) (DescriptorStatus, in
 
 // FindActiveColumnByName finds an active column with the specified name.
 func (desc *TableDescriptor) FindActiveColumnByName(name string) (ColumnDescriptor, error) {
+	normName := NormalizeName(name)
 	for _, c := range desc.Columns {
-		if equalName(c.Name, name) {
+		if NormalizeName(c.Name) == normName {
 			return c, nil
 		}
 	}
@@ -559,14 +564,15 @@ func (desc *TableDescriptor) FindColumnByID(id ColumnID) (*ColumnDescriptor, err
 // DescriptorStatus for the index, and an index into either the indexes
 // (status == DescriptorActive) or mutations (status == DescriptorIncomplete).
 func (desc *TableDescriptor) FindIndexByName(name string) (DescriptorStatus, int, error) {
+	normName := NormalizeName(name)
 	for i, idx := range desc.Indexes {
-		if equalName(idx.Name, name) {
+		if NormalizeName(idx.Name) == normName {
 			return DescriptorActive, i, nil
 		}
 	}
 	for i, m := range desc.Mutations {
 		if idx := m.GetIndex(); idx != nil {
-			if equalName(idx.Name, name) {
+			if NormalizeName(idx.Name) == normName {
 				return DescriptorIncomplete, i, nil
 			}
 		}


### PR DESCRIPTION
`NormalizeName` is currently the leading source of total allocations
(~7% of total allocations for a single-node under photos load). The function
consists of mapping the provided name to lower case, then Unicode NFC
normalizing the name. `strings.Map` will only allocate when it makes
changes, but `norm.NFC.String` allocates on all calls. This change
uses the `norm.NFC.IsNormalString` to avoid Unicode normalizing when
it isn't necessary.

Interestingly, the change seems to have increased allocation count, but
it also had a small speed performance improvement across the board.
Therefore, I'm not positive we actually want to merge the change. Still,
I'm hoping this will at least bring to light that `NormalizeName` is not
free, so we may want to consider saving/memoizing the result in cases
where it is called multiple times for the same name.

```
name                                old time/op    new time/op    delta
Bank2_Cockroach-2                    3.38ms ±268%    1.16ms ±12%    ~            (p=0.083 n=10+8)
Bank4_Cockroach-2                     1.19ms ± 7%    1.19ms ±10%    ~             (p=0.815 n=9+8)
Bank8_Cockroach-2                     1.16ms ± 3%    1.14ms ± 5%    ~           (p=0.190 n=10+10)
Bank16_Cockroach-2                    1.07ms ± 4%    1.08ms ± 6%    ~           (p=0.579 n=10+10)
Bank32_Cockroach-2                    1.01ms ± 6%    1.00ms ± 5%    ~            (p=0.447 n=9+10)
Bank64_Cockroach-2                     934µs ± 4%     931µs ± 6%    ~           (p=1.000 n=10+10)
Select1_Cockroach-2                   46.8µs ± 2%    46.2µs ± 1%  -1.20%         (p=0.017 n=10+9)
Select2_Cockroach-2                    856µs ± 2%     827µs ± 1%  -3.38%         (p=0.000 n=10+9)
Insert1_Cockroach-2                    451µs ± 1%     447µs ± 2%  -1.02%        (p=0.009 n=10+10)
Insert10_Cockroach-2                   802µs ± 1%     794µs ± 1%  -1.03%         (p=0.000 n=10+8)
Insert100_Cockroach-2                 4.13ms ± 2%    4.08ms ± 1%  -1.11%        (p=0.019 n=10+10)
Insert1000_Cockroach-2                40.0ms ± 1%    39.7ms ± 1%    ~           (p=0.190 n=10+10)
Update1_Cockroach-2                    653µs ± 2%     651µs ± 2%    ~           (p=0.529 n=10+10)
Update10_Cockroach-2                  1.33ms ± 1%    1.31ms ± 2%  -1.08%        (p=0.015 n=10+10)
Update100_Cockroach-2                 7.37ms ± 1%    7.19ms ± 1%  -2.44%        (p=0.000 n=10+10)
Update1000_Cockroach-2                65.9ms ± 3%    65.9ms ± 4%    ~           (p=0.971 n=10+10)
Delete1_Cockroach-2                    642µs ± 2%     640µs ± 2%    ~           (p=0.579 n=10+10)
Delete10_Cockroach-2                  2.00ms ± 1%    1.97ms ± 1%  -1.48%        (p=0.002 n=10+10)
Delete100_Cockroach-2                 16.6ms ± 2%    16.3ms ± 2%  -1.93%        (p=0.000 n=10+10)
Delete1000_Cockroach-2                 175ms ± 2%     173ms ± 1%    ~           (p=0.052 n=10+10)
Scan1_Cockroach-2                      170µs ± 2%     169µs ± 2%    ~            (p=0.315 n=8+10)
Scan10_Cockroach-2                     213µs ± 2%     212µs ± 2%    ~             (p=0.481 n=9+8)
Scan100_Cockroach-2                    589µs ± 1%     560µs ± 3%  -4.95%         (p=0.000 n=9+10)
Scan1000_Cockroach-2                  4.29ms ± 2%    3.99ms ± 1%  -7.17%        (p=0.000 n=10+10)
Scan10000_Cockroach-2                 44.5ms ± 0%    41.3ms ± 3%  -7.11%         (p=0.000 n=9+10)
Scan1000Limit1_Cockroach-2             182µs ± 1%     179µs ± 1%  -1.20%          (p=0.001 n=9+9)
Scan1000Limit10_Cockroach-2            223µs ± 1%     223µs ± 1%    ~           (p=0.684 n=10+10)
Scan1000Limit100_Cockroach-2           610µs ± 4%     586µs ± 3%  -4.01%        (p=0.000 n=10+10)
Scan10000FilterLimit1_Cockroach-2      290µs ± 2%     287µs ± 2%  -0.87%         (p=0.028 n=10+9)
Scan10000FilterLimit10_Cockroach-2     349µs ± 2%     344µs ± 1%  -1.25%        (p=0.004 n=10+10)
Scan10000FilterLimit50_Cockroach-2    14.5ms ± 1%    13.3ms ± 1%  -8.13%         (p=0.000 n=9+10)
PgbenchQuery_Cockroach-2              3.15ms ± 3%    3.20ms ± 8%    ~            (p=0.536 n=7+10)

name                                old alloc/op   new alloc/op   delta
Bank2_Cockroach-2                     95.9kB ± 2%    96.0kB ± 2%    ~           (p=0.853 n=10+10)
Bank4_Cockroach-2                     96.7kB ± 1%    97.3kB ± 1%  +0.53%        (p=0.029 n=10+10)
Bank8_Cockroach-2                     96.1kB ± 1%    96.6kB ± 1%    ~           (p=0.089 n=10+10)
Bank16_Cockroach-2                    95.0kB ± 2%    95.4kB ± 1%    ~           (p=0.143 n=10+10)
Bank32_Cockroach-2                    93.5kB ± 1%    94.1kB ± 1%  +0.62%        (p=0.043 n=10+10)
Bank64_Cockroach-2                    92.6kB ± 0%    93.0kB ± 0%  +0.39%        (p=0.015 n=10+10)
Select1_Cockroach-2                   2.27kB ± 0%    2.27kB ± 0%    ~            (p=0.134 n=8+10)
Select2_Cockroach-2                   72.9kB ± 0%    73.8kB ± 0%  +1.20%         (p=0.000 n=9+10)
Insert1_Cockroach-2                   23.7kB ± 0%    23.7kB ± 0%    ~            (p=0.473 n=8+10)
Insert10_Cockroach-2                  64.2kB ± 0%    64.3kB ± 0%  +0.14%         (p=0.002 n=10+9)
Insert100_Cockroach-2                  465kB ± 0%     465kB ± 0%    ~            (p=0.315 n=9+10)
Insert1000_Cockroach-2                4.20MB ± 2%    4.19MB ± 1%    ~           (p=0.353 n=10+10)
Update1_Cockroach-2                   36.4kB ± 0%    36.5kB ± 0%  +0.36%        (p=0.000 n=10+10)
Update10_Cockroach-2                   102kB ± 0%     102kB ± 0%    ~            (p=0.515 n=10+8)
Update100_Cockroach-2                  717kB ± 0%     717kB ± 0%    ~           (p=0.739 n=10+10)
Update1000_Cockroach-2                6.26MB ± 1%    6.28MB ± 1%    ~           (p=0.631 n=10+10)
Delete1_Cockroach-2                   30.2kB ± 0%    30.6kB ± 0%  +1.16%         (p=0.000 n=10+9)
Delete10_Cockroach-2                  72.8kB ± 0%    73.2kB ± 0%  +0.52%         (p=0.000 n=10+9)
Delete100_Cockroach-2                  494kB ± 0%     494kB ± 0%    ~            (p=0.113 n=10+9)
Delete1000_Cockroach-2                4.41MB ± 0%    4.43MB ± 1%    ~           (p=0.579 n=10+10)
Scan1_Cockroach-2                     11.3kB ± 0%    11.3kB ± 0%    ~            (p=0.795 n=10+9)
Scan10_Cockroach-2                    15.2kB ± 0%    15.2kB ± 0%    ~            (p=0.484 n=9+10)
Scan100_Cockroach-2                   47.4kB ± 0%    47.4kB ± 0%    ~           (p=0.425 n=10+10)
Scan1000_Cockroach-2                   336kB ± 0%     336kB ± 0%  -0.01%          (p=0.018 n=9+9)
Scan10000_Cockroach-2                 5.79MB ± 0%    5.79MB ± 0%  -0.01%        (p=0.000 n=10+10)
Scan1000Limit1_Cockroach-2            11.9kB ± 0%    11.9kB ± 0%    ~           (p=0.210 n=10+10)
Scan1000Limit10_Cockroach-2           15.7kB ± 0%    15.7kB ± 0%    ~             (p=0.863 n=9+9)
Scan1000Limit100_Cockroach-2          47.8kB ± 0%    47.9kB ± 0%  +0.03%        (p=0.050 n=10+10)
Scan10000FilterLimit1_Cockroach-2     24.0kB ± 0%    24.0kB ± 0%  +0.30%        (p=0.000 n=10+10)
Scan10000FilterLimit10_Cockroach-2    28.5kB ± 0%    28.6kB ± 0%  +0.24%        (p=0.000 n=10+10)
Scan10000FilterLimit50_Cockroach-2    1.29MB ± 0%    1.29MB ± 0%  +0.01%        (p=0.002 n=10+10)
PgbenchQuery_Cockroach-2               203kB ± 5%     209kB ±10%    ~            (p=0.055 n=7+10)

name                                old allocs/op  new allocs/op  delta
Bank2_Cockroach-2                      1.96k ± 2%     2.02k ± 2%  +2.79%        (p=0.000 n=10+10)
Bank4_Cockroach-2                      1.98k ± 1%     2.05k ± 1%  +3.21%         (p=0.000 n=10+9)
Bank8_Cockroach-2                      1.97k ± 1%     2.04k ± 1%  +3.19%        (p=0.000 n=10+10)
Bank16_Cockroach-2                     1.95k ± 1%     2.01k ± 1%  +3.13%        (p=0.000 n=10+10)
Bank32_Cockroach-2                     1.93k ± 1%     1.99k ± 1%  +3.39%        (p=0.000 n=10+10)
Bank64_Cockroach-2                     1.91k ± 0%     1.97k ± 1%  +3.14%        (p=0.000 n=10+10)
Select1_Cockroach-2                     50.0 ± 0%      50.0 ± 0%    ~     (all samples are equal)
Select2_Cockroach-2                    2.34k ± 0%     2.44k ± 0%  +4.35%         (p=0.000 n=6+10)
Insert1_Cockroach-2                      331 ± 0%       333 ± 0%  +0.45%         (p=0.001 n=9+10)
Insert10_Cockroach-2                     718 ± 0%       720 ± 0%  +0.25%         (p=0.002 n=6+10)
Insert100_Cockroach-2                  4.45k ± 0%     4.45k ± 0%    ~            (p=0.343 n=9+10)
Insert1000_Cockroach-2                 41.9k ± 1%     41.9k ± 0%    ~           (p=0.393 n=10+10)
Update1_Cockroach-2                      636 ± 0%       654 ± 0%  +2.80%         (p=0.000 n=9+10)
Update10_Cockroach-2                   1.26k ± 0%     1.27k ± 0%  +1.27%         (p=0.000 n=10+6)
Update100_Cockroach-2                  7.16k ± 0%     7.17k ± 0%  +0.25%         (p=0.000 n=9+10)
Update1000_Cockroach-2                 63.5k ± 0%     63.6k ± 1%  +0.15%        (p=0.022 n=10+10)
Delete1_Cockroach-2                      525 ± 0%       569 ± 0%  +8.38%          (p=0.000 n=7+8)
Delete10_Cockroach-2                   1.11k ± 0%     1.16k ± 0%  +3.99%         (p=0.000 n=8+10)
Delete100_Cockroach-2                  6.82k ± 0%     6.86k ± 0%  +0.64%         (p=0.000 n=10+9)
Delete1000_Cockroach-2                 63.6k ± 0%     63.7k ± 0%  +0.21%        (p=0.000 n=10+10)
Scan1_Cockroach-2                        215 ± 0%       216 ± 0%  +0.33%         (p=0.012 n=10+7)
Scan10_Cockroach-2                       295 ± 0%       297 ± 0%  +0.54%         (p=0.000 n=7+10)
Scan100_Cockroach-2                    1.02k ± 0%     1.02k ± 0%  +0.07%        (p=0.019 n=10+10)
Scan1000_Cockroach-2                   8.23k ± 0%     8.23k ± 0%  +0.01%          (p=0.000 n=9+9)
Scan10000_Cockroach-2                  80.4k ± 0%     80.4k ± 0%  +0.00%         (p=0.018 n=9+10)
Scan1000Limit1_Cockroach-2               232 ± 0%       233 ± 0%  +0.26%         (p=0.015 n=10+9)
Scan1000Limit10_Cockroach-2              311 ± 0%       312 ± 0%  +0.32%          (p=0.000 n=9+9)
Scan1000Limit100_Cockroach-2           1.04k ± 0%     1.04k ± 0%  +0.10%        (p=0.001 n=10+10)
Scan10000FilterLimit1_Cockroach-2        496 ± 0%       505 ± 0%  +1.79%        (p=0.000 n=10+10)
Scan10000FilterLimit10_Cockroach-2       656 ± 0%       665 ± 0%  +1.39%        (p=0.000 n=10+10)
Scan10000FilterLimit50_Cockroach-2     27.1k ± 0%     27.1k ± 0%  +0.03%        (p=0.000 n=10+10)
PgbenchQuery_Cockroach-2               3.22k ± 3%     3.40k ± 7%    ~            (p=0.053 n=7+10)
```
## EDIT

This now only limits the number of calls to the function. We had a few instances where we were calling it in loops unnecessarily.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5370)

<!-- Reviewable:end -->
