### PR TITLE
cli: Tweak `range-descriptors` output

### DIFF
--- a/cli/debug.go
+++ b/cli/debug.go
@@ -114,7 +114,8 @@ func printRangeDescriptor(kv engine.MVCCKeyValue) (bool, error) {
 	if err := value.GetProto(&desc); err != nil {
 		return false, err
 	}
-	fmt.Printf("Range descriptor with start key %s at time %s\n%s\n", startKey, kv.Key.Timestamp.GoTime(), &desc)
+	fmt.Printf("Range descriptor %s at time %s\n\tCovers: [%s, %s)\n\tRaw:%s\n\n",
+		startKey, kv.Key.Timestamp.GoTime(), desc.StartKey, desc.EndKey, &desc)
 	return false, nil
 }
 


### PR DESCRIPTION
```
Range descriptor /Table/53/2/""/Tue Mar 15 18:23:13 UTC 2016 at time 2016-03-15 15:58:14.159086249 -0400 EDT
        Covers: [/Table/53/2/""/Tue Mar 15 18:23:13 UTC 2016, /Max)
        Raw:range_id:27 start_key:"\275\[omitted]

Range descriptor /Table/53/2/"k\xcaPe\xce\xe6I\xbc\x8af\xd9\xf8V[L\xdb"/Tue Mar 15 17:24:18 UTC 2016 at time 2016-03-15 22:38:05.667140187 -0400 EDT
        Covers: [/Table/53/2/"k\xcaPe\xce\xe6I\xbc\x8af\xd9\xf8V[L\xdb"/Tue Mar 15 17:24:18 UTC 2016, /Max)
        Raw:range_id:92 start_key:"\275\[omitted]
```

(the `[omitted]` are mine)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5390)

<!-- Reviewable:end -->
