### PR TITLE
roachpb: Create roachpb.Value benchmarks and replace decimal encoding

### DIFF
--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -739,3 +739,137 @@ func TestRSpanIntersect(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkValueSetBytes(b *testing.B) {
+	v := Value{}
+	bytes := make([]byte, 16)
+
+	for i := 0; i < b.N; i++ {
+		v.SetBytes(bytes)
+	}
+}
+
+func BenchmarkValueSetFloat(b *testing.B) {
+	v := Value{}
+	f := 1.1
+
+	for i := 0; i < b.N; i++ {
+		v.SetFloat(f)
+	}
+}
+
+func BenchmarkValueSetInt(b *testing.B) {
+	v := Value{}
+	in := int64(1)
+
+	for i := 0; i < b.N; i++ {
+		v.SetInt(in)
+	}
+}
+
+func BenchmarkValueSetProto(b *testing.B) {
+	v := Value{}
+	p := &Value{}
+
+	for i := 0; i < b.N; i++ {
+		if err := v.SetProto(p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValueSetTime(b *testing.B) {
+	v := Value{}
+	ti := time.Time{}
+
+	for i := 0; i < b.N; i++ {
+		v.SetTime(ti)
+	}
+}
+
+func BenchmarkValueSetDecimal(b *testing.B) {
+	v := Value{}
+	dec := inf.NewDec(11, 1)
+
+	for i := 0; i < b.N; i++ {
+		if err := v.SetDecimal(dec); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValueGetBytes(b *testing.B) {
+	v := Value{}
+	bytes := make([]byte, 16)
+	v.SetBytes(bytes)
+
+	for i := 0; i < b.N; i++ {
+		if _, err := v.GetBytes(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValueGetFloat(b *testing.B) {
+	v := Value{}
+	f := 1.1
+	v.SetFloat(f)
+
+	for i := 0; i < b.N; i++ {
+		if _, err := v.GetFloat(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValueGetInt(b *testing.B) {
+	v := Value{}
+	in := int64(1)
+	v.SetInt(in)
+
+	for i := 0; i < b.N; i++ {
+		if _, err := v.GetInt(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValueGetProto(b *testing.B) {
+	v := Value{}
+	p, dst := &Value{}, &Value{}
+	if err := v.SetProto(p); err != nil {
+		b.Fatal(err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		if err := v.GetProto(dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValueGetTime(b *testing.B) {
+	v := Value{}
+	ti := time.Time{}
+	v.SetTime(ti)
+
+	for i := 0; i < b.N; i++ {
+		if _, err := v.GetTime(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValueGetDecimal(b *testing.B) {
+	v := Value{}
+	dec := inf.NewDec(11, 1)
+	if err := v.SetDecimal(dec); err != nil {
+		b.Fatal(err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		if _, err := v.GetDecimal(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/util/encoding/decimal.go
+++ b/util/encoding/decimal.go
@@ -294,6 +294,17 @@ func decodeDecimalValueWithoutExp(dec *inf.Dec, negVal bool, buf, tmp []byte) {
 	}
 }
 
+// UpperBoundDecimalSize returns the upper bound number of bytes that the
+// decimal will need for encoding.
+func UpperBoundDecimalSize(d *inf.Dec) int {
+	// Makeup of upper bound size:
+	// - 1 byte for the prefix
+	// - maxVarintSize for the exponent
+	// - wordLen for the big.Int bytes
+	// - 1 byte for the terminator
+	return 2 + maxVarintSize + wordLen(d.UnscaledBig().Bits())
+}
+
 // Taken from math/big/arith.go.
 const bigWordSize = int(unsafe.Sizeof(big.Word(0)))
 


### PR DESCRIPTION
### Benchmarks Initial Results

```
name               time/op
ValueSetBytes-4    73.6ns ± 4%
ValueSetFloat-4    67.3ns ± 1%
ValueSetInt-4      65.0ns ± 3%
ValueSetProto-4     174ns ± 2%
ValueSetTime-4     88.6ns ± 2%
ValueSetDecimal-4   183ns ± 2%
ValueGetBytes-4    7.71ns ± 2%
ValueGetFloat-4    17.0ns ± 1%
ValueGetInt-4      13.5ns ± 1%
ValueGetProto-4    62.7ns ± 3%
ValueGetTime-4     43.2ns ± 2%
ValueGetDecimal-4   235ns ± 2%

name               alloc/op
ValueSetBytes-4     32.0B ± 0%
ValueSetFloat-4     16.0B ± 0%
ValueSetInt-4       16.0B ± 0%
ValueSetProto-4     24.0B ± 0%
ValueSetTime-4      16.0B ± 0%
ValueSetDecimal-4   32.0B ± 0%
ValueGetBytes-4    0.00B ±NaN%
ValueGetFloat-4    0.00B ±NaN%
ValueGetInt-4      0.00B ±NaN%
ValueGetProto-4    0.00B ±NaN%
ValueGetTime-4     0.00B ±NaN%
ValueGetDecimal-4   96.0B ± 0%

name               allocs/op
ValueSetBytes-4      1.00 ± 0%
ValueSetFloat-4      1.00 ± 0%
ValueSetInt-4        1.00 ± 0%
ValueSetProto-4      2.00 ± 0%
ValueSetTime-4       1.00 ± 0%
ValueSetDecimal-4    1.00 ± 0%
ValueGetBytes-4     0.00 ±NaN%
ValueGetFloat-4     0.00 ±NaN%
ValueGetInt-4       0.00 ±NaN%
ValueGetProto-4     0.00 ±NaN%
ValueGetTime-4      0.00 ±NaN%
ValueGetDecimal-4    2.00 ± 0%
```
### New Decimal Value Encoding

The previous decimal roachpb.Value encoding (which used GobEncoding
internally) suffered from a lack of exponent normalization. This means
that `20 * 10^1` would not encode to the same value as `2*10^2`. This
issue was minor, but would mess up operations like conditional puts.
This commit replaces the GobEncoding with the same encoding we use for
decimal keys, which does perform this normalization. The change speeds
up encoding but slows down decoding.

```
name               old time/op    new time/op    delta
ValueSetDecimal-4     258ns ± 2%     184ns ± 2%  -28.74%        (p=0.000 n=10+10)
ValueGetDecimal-4     158ns ± 1%     219ns ± 2%  +38.42%        (p=0.000 n=10+10)

name               old alloc/op   new alloc/op   delta
ValueSetDecimal-4     48.0B ± 0%     32.0B ± 0%  -33.33%        (p=0.000 n=10+10)
ValueGetDecimal-4     96.0B ± 0%     96.0B ± 0%     ~     (all samples are equal)

name               old allocs/op  new allocs/op  delta
ValueSetDecimal-4      4.00 ± 0%      1.00 ± 0%  -75.00%        (p=0.000 n=10+10)
ValueGetDecimal-4      2.00 ± 0%      2.00 ± 0%     ~     (all samples are equal)
```

The reason for the reduced decoding speed is twofold. First, our custom
encoding uses a null terminator, which is searched for on decoding. This
accounts for about 2/3 of the speed discrepancy. Second, our custom
encoding uses a more memory conscious varint encoding for exponent,
instead of encoding the int value directly. This accounts for the other
1/3 of the speed difference. Both of these could be conditionally gated
within the encoding/decoding routines if performance becomes an issue. I
would believe that the varint memory benefits actually outweighs its 
performance overhead, but it might make sense to add a `useTerminator` 
parameter to the encoding functions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5391)

<!-- Reviewable:end -->
