### PR TITLE
encoding: Avoid initially setting decimal value to 0 when decoding

### DIFF
--- a/util/encoding/decimal.go
+++ b/util/encoding/decimal.go
@@ -217,7 +217,7 @@ func decodeDecimal(buf []byte, invert bool, tmp []byte) ([]byte, *inf.Dec, error
 	if idx == -1 {
 		return nil, nil, util.Errorf("did not find terminator %#x in buffer %#x", decimalTerminator, buf)
 	}
-	dec := inf.NewDec(0, 1)
+	dec := new(inf.Dec).SetScale(1)
 	switch {
 	case buf[0] == decimalNegValPosExp:
 		decodeDecimalValue(dec, true, false, buf[1:idx], tmp)


### PR DESCRIPTION
This squeezes a little extra performance out of
`DecodeDecimalAscending`.

```
name             old time/op    new time/op    delta
DecodeDecimal-4     238ns ± 1%     220ns ± 1%  -7.64%          (p=0.000 n=9+9)

name             old alloc/op   new alloc/op   delta
DecodeDecimal-4     96.0B ± 0%     96.0B ± 0%    ~     (all samples are equal)

name             old allocs/op  new allocs/op  delta
DecodeDecimal-4      2.00 ± 0%      2.00 ± 0%    ~     (all samples are equal)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5392)

<!-- Reviewable:end -->
