### PR TITLE
Fix UI location in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Other operating systems will have a similar set of commands. Please check Docker
 Pull the CockroachDB Docker image and drop into a shell within it:
 ```bash
 docker pull cockroachdb/cockroach
-docker run -p 26257:26257 -t -i cockroachdb/cockroach shell
+docker run -p 26257:26257 -p 8080:8080 -t -i cockroachdb/cockroach shell
 # root@82cb657cdc42:/cockroach#
 ```
 
@@ -72,7 +72,7 @@ Setting up Cockroach is easy, but starting a test node is even easier. All it ta
 
 Verify that you're up and running by visiting the cluster UI. If you're running
 without Docker (or on Linux), you'll find it at
-[localhost:26257](http://localhost:26257); for OSX under Docker, things are a
+[localhost:8080](http://localhost:8080); for OSX under Docker, things are a
 little more complicated and you need to run `docker-machine ip default` to get
 the correct address (but the port is the same).
 

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -8,5 +8,5 @@ COPY cockroach.sh cockroach /cockroach/
 # are resolved appropriately when passed as args.
 WORKDIR /cockroach/
 
-EXPOSE 26257
+EXPOSE 26257 8080
 ENTRYPOINT ["/cockroach/cockroach.sh"]


### PR DESCRIPTION
UI location is running on port 8080. In the old readme it was written as 26257.

I took me a while to find out how to access admin UI. Also, I exposed port 8080 in Dockerfile and added instructions for how to port forward it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5393)

<!-- Reviewable:end -->
