### PR TITLE
Add many stats to single-node graphs page

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -149,6 +149,7 @@ type Executor struct {
 	deleteCount      *metric.Counter
 	ddlCount         *metric.Counter
 	miscCount        *metric.Counter
+	queryCount       *metric.Counter
 
 	// System Config and mutex.
 	systemConfig   config.SystemConfig
@@ -208,6 +209,7 @@ func NewExecutor(ctx ExecutorContext, stopper *stop.Stopper, registry *metric.Re
 		deleteCount:      registry.Counter("delete.count"),
 		ddlCount:         registry.Counter("ddl.count"),
 		miscCount:        registry.Counter("misc.count"),
+		queryCount:       registry.Counter("query.count"),
 	}
 	exec.systemConfigCond = sync.NewCond(exec.systemConfigMu.RLocker())
 
@@ -1067,6 +1069,7 @@ func (e *Executor) execStmt(
 // updateStmtCounts updates metrics for the number of times the different types of SQL
 // statements have been received by this node.
 func (e *Executor) updateStmtCounts(stmt parser.Statement) {
+	e.queryCount.Inc(1)
 	switch stmt.(type) {
 	case *parser.BeginTransaction:
 		e.txnBeginCount.Inc(1)

--- a/ts/query.go
+++ b/ts/query.go
@@ -20,6 +20,7 @@ import (
 	"container/heap"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -535,7 +536,7 @@ func (db *DB) Query(query Query, r Resolution, startNanos, endNanos int64) ([]*T
 		response := &TimeSeriesDatapoint{}
 		*response = current
 		if isDerivative {
-			dTime := (current.TimestampNanos - last.TimestampNanos) / r.SampleDuration()
+			dTime := (current.TimestampNanos - last.TimestampNanos) / time.Second.Nanoseconds()
 			if dTime == 0 {
 				response.Value = 0
 			} else {

--- a/ts/query_test.go
+++ b/ts/query_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
@@ -357,7 +358,7 @@ func (tm *testModel) assertQuery(name string, sources []string,
 		result := &TimeSeriesDatapoint{}
 		*result = current
 		if isDerivative {
-			dTime := (current.TimestampNanos - last.TimestampNanos) / r.SampleDuration()
+			dTime := (current.TimestampNanos - last.TimestampNanos) / int64(time.Second)
 			if dTime == 0 {
 				result.Value = 0
 			} else {

--- a/ts/server_test.go
+++ b/ts/server_test.go
@@ -154,15 +154,15 @@ func TestHttpQuery(t *testing.T) {
 				Datapoints: []*ts.TimeSeriesDatapoint{
 					{
 						TimestampNanos: 505 * 1e9,
-						Value:          10.0,
+						Value:          1.0,
 					},
 					{
 						TimestampNanos: 515 * 1e9,
-						Value:          50.0,
+						Value:          5.0,
 					},
 					{
 						TimestampNanos: 525 * 1e9,
-						Value:          50.0,
+						Value:          5.0,
 					},
 				},
 			},


### PR DESCRIPTION
Resolves #5275

I had to restructure NodePage slightly. I pulled out the graph
construction into a NodePage._initGraphs(), so that it can be called
multiple times. We need this, because we need the store_ids from our
NodeStatus, which is not available when the constructor is called.

Also made rates per second instead of per sample period.

Currently, when retrieving derivatives from the TS DB, we return the rate
per sample period. It seems more generally useful to return rate per
second, for metrics like queries per second and bytes per second.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5395)

<!-- Reviewable:end -->
