### PR TITLE
cli: Define flags for kvCmds and rangeCmds on subcommands

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -304,12 +304,12 @@ func Example_insecure() {
 	}
 	defer c.stop()
 
-	c.Run("debug kv --insecure put a 1 b 2")
-	c.Run("debug kv --insecure scan")
+	c.Run("debug kv put --insecure a 1 b 2")
+	c.Run("debug kv scan --insecure")
 
 	// Output:
-	// debug kv --insecure put a 1 b 2
-	// debug kv --insecure scan
+	// debug kv put --insecure a 1 b 2
+	// debug kv scan --insecure
 	// "a"	"1"
 	// "b"	"2"
 	// 2 result(s)

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -320,9 +320,10 @@ func initFlags(ctx *Context) {
 	setUserCmd.Flags().StringVar(&password, "password", "", usage("password"))
 
 	clientCmds := []*cobra.Command{
-		sqlShellCmd, kvCmd, rangeCmd,
-		exterminateCmd, quitCmd, /* startCmd is covered above */
+		sqlShellCmd, exterminateCmd, quitCmd, /* startCmd is covered above */
 	}
+	clientCmds = append(clientCmds, kvCmds...)
+	clientCmds = append(clientCmds, rangeCmds...)
 	clientCmds = append(clientCmds, userCmds...)
 	clientCmds = append(clientCmds, zoneCmds...)
 	clientCmds = append(clientCmds, nodeCmds...)
@@ -343,7 +344,9 @@ func initFlags(ctx *Context) {
 	}
 
 	// Commands that need the cockroach port.
-	simpleCmds := []*cobra.Command{kvCmd, rangeCmd, exterminateCmd}
+	simpleCmds := []*cobra.Command{exterminateCmd}
+	simpleCmds = append(simpleCmds, kvCmds...)
+	simpleCmds = append(simpleCmds, rangeCmds...)
 	for _, cmd := range simpleCmds {
 		f := cmd.PersistentFlags()
 		f.StringVarP(&connPort, "port", "p", base.DefaultPort, usage("client_port"))


### PR DESCRIPTION
The client commands and port command should have been defined on the
subcommands of `kv` and `range`. This was missed in #5131.

@jseldess 

```
Nathans-MacBook-Pro:cockroach$ ./cockroach debug range ls --help
Lists the ranges in a cluster.

Usage:
  cockroach debug range ls [options] [<start-key>] [flags]

Flags:
      --ca-cert string
        Path to the CA certificate. Needed by clients and servers in secure
        mode.

      --cert string
        Path to the client or server certificate. Needed in secure mode.

      --host string
        Database server host to connect to.

      --insecure
        Run over plain HTTP. WARNING: this is strongly discouraged.

      --key string
        Path to the key protecting --cert. Needed in secure mode.

      --max-results int
        Define the maximum number of results that will be retrieved.
        (default 1000)
  -p, --port string
        Database server port to connect to.
        (default "26257")

Global Flags:
      --alsologtostderr value[=INFO]   logs at or above this threshold go to stderr (default ERROR)
      --log-backtrace-at value         when logging hits line file:N, emit a stack trace (default :0)
      --log-dir value                  if non-empty, write log files in this directory
      --logtostderr value[=true]       log to standard error instead of files
      --no-color value                 disable standard error log colorization
      --verbosity value                log level for V logs
      --vmodule value                  comma-separated list of pattern=N settings for file-filtered logging
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5397)

<!-- Reviewable:end -->
