### PR TITLE
util/encoding: manually search for the decimal terminator

### DIFF
--- a/util/encoding/decimal.go
+++ b/util/encoding/decimal.go
@@ -17,7 +17,6 @@
 package encoding
 
 import (
-	"bytes"
 	"math/big"
 	"strconv"
 	"unsafe"
@@ -213,7 +212,16 @@ func decodeDecimal(buf []byte, invert bool, tmp []byte) ([]byte, *inf.Dec, error
 		return buf[1:], inf.NewDec(0, 0), nil
 	}
 
-	idx := bytes.IndexByte(buf, decimalTerminator)
+	// TODO(pmattis): bytes.IndexByte is inefficient for small slices. This is
+	// apparently fixed in go1.7. For now, we manually search for the terminator.
+	// idx := bytes.IndexByte(buf, decimalTerminator)
+	idx := -1
+	for i, b := range buf {
+		if b == decimalTerminator {
+			idx = i
+			break
+		}
+	}
 	if idx == -1 {
 		return nil, nil, util.Errorf("did not find terminator %#x in buffer %#x", decimalTerminator, buf)
 	}


### PR DESCRIPTION
bytes.IndexByte is inefficient for small slices. This is apparently
fixed in go1.7. For now, we manually search for the terminator.

```
name             old time/op  new time/op  delta
DecodeDecimal-8   214ns ± 1%   188ns ± 1%  -12.23%  (p=0.000 n=8+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5401)

<!-- Reviewable:end -->
