### PR TITLE
Improve transaction correctness test to find hidden anomalies

### DIFF
--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -122,15 +123,19 @@ func (c *cmd) done() {
 	c.debug = ""
 }
 
+func (c *cmd) makeKey(key string) []byte {
+	return []byte(fmt.Sprintf("%d.%s", c.historyIdx, key))
+}
+
 func (c *cmd) getKey() []byte {
-	return []byte(fmt.Sprintf("%d.%s", c.historyIdx, c.key))
+	return c.makeKey(c.key)
 }
 
 func (c *cmd) getEndKey() []byte {
 	if len(c.endKey) == 0 {
 		return nil
 	}
-	return []byte(fmt.Sprintf("%d.%s", c.historyIdx, c.endKey))
+	return c.makeKey(c.endKey)
 }
 
 func (c *cmd) String() string {
@@ -178,28 +183,33 @@ func scanCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 	return nil
 }
 
-// incCmd adds one to the value of c.key in the env and writes
-// it to the db. If c.key isn't in the db, writes 1.
+// incCmd adds one to the value of c.key in the env (as determined by
+// a previous read or write, or else assumed to be zero) and writes it
+// to the db.
 func incCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
-	r, pErr := txn.Inc(c.getKey(), 1)
-	if pErr != nil {
+	r := c.env[c.key] + 1
+	if pErr := txn.Put(c.getKey(), r); pErr != nil {
 		return pErr
 	}
-	c.env[c.key] = r.ValueInt()
-	c.debug = fmt.Sprintf("[%d]", r.ValueInt())
+	c.env[c.key] = r
+	c.debug = fmt.Sprintf("[%d]", r)
 	return nil
 }
 
-// sumCmd sums the values of all keys != c.key read during the transaction and
-// writes the result to the db.
-func sumCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
+// writeCmd sums values from the env (and possibly numeric constants)
+// and writes the value to the db. "c.endKey" here needs to be parsed
+// in the context of this command, which is a "+"-separated list of
+// keys from the env or numeric constants to sum.
+func writeCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 	sum := int64(0)
-	for k, v := range c.env {
-		if k != c.key {
-			sum += v
+	for _, sp := range strings.Split(c.endKey, "+") {
+		if constant, err := strconv.Atoi(sp); err != nil {
+			sum += c.env[sp]
+		} else {
+			sum += int64(constant)
 		}
 	}
-	_, pErr := txn.Inc(c.getKey(), sum)
+	pErr := txn.Put(c.getKey(), sum)
 	c.debug = fmt.Sprintf("[%d]", sum)
 	return pErr
 }
@@ -209,18 +219,37 @@ func commitCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 	return txn.CommitNoCleanup()
 }
 
-// cmdDict maps from command name to function implementing the command.
-// Use only upper case letters for commands. More than one letter is OK.
-var cmdDict = map[string]func(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error{
-	"R":   readCmd,
-	"I":   incCmd,
-	"DR":  deleteRngCmd,
-	"SC":  scanCmd,
-	"SUM": sumCmd,
-	"C":   commitCmd,
+type cmdSpec struct {
+	fn func(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error
+	re *regexp.Regexp
 }
 
-var cmdRE = regexp.MustCompile(`([A-Z]+)(?:\(([A-Z]+)(?:-([A-Z]+))?\))?`)
+var cmdSpecs = []*cmdSpec{
+	{
+		readCmd,
+		regexp.MustCompile(`(R)\(([A-Z]+)\)`),
+	},
+	{
+		incCmd,
+		regexp.MustCompile(`(I)\(([A-Z]+)\)`),
+	},
+	{
+		deleteRngCmd,
+		regexp.MustCompile(`(DR)\(([A-Z]+)-([A-Z]+)\)`),
+	},
+	{
+		scanCmd,
+		regexp.MustCompile(`(SC)\(([A-Z]+)-([A-Z]+)\)`),
+	},
+	{
+		writeCmd,
+		regexp.MustCompile(`(W)\(([A-Z]+),([A-Z0-9+]+)\)`),
+	},
+	{
+		commitCmd,
+		regexp.MustCompile(`(C)`),
+	},
+}
 
 func historyString(cmds []*cmd) string {
 	var cmdStrs []string
@@ -237,22 +266,25 @@ func parseHistory(txnIdx int, history string, t *testing.T) []*cmd {
 	var cmds []*cmd
 	elems := strings.Split(history, " ")
 	for _, elem := range elems {
-		match := cmdRE.FindStringSubmatch(elem)
-		if len(match) < 2 {
+		var c *cmd
+		for _, spec := range cmdSpecs {
+			match := spec.re.FindStringSubmatch(elem)
+			if len(match) < 2 {
+				continue
+			}
+			var key, endKey string
+			if len(match) > 2 {
+				key = match[2]
+			}
+			if len(match) > 3 {
+				endKey = match[3]
+			}
+			c = &cmd{name: match[1], key: key, endKey: endKey, txnIdx: txnIdx, fn: spec.fn}
+			break
+		}
+		if c == nil {
 			t.Fatalf("failed to parse command %q", elem)
 		}
-		fn, ok := cmdDict[match[1]]
-		if !ok {
-			t.Fatalf("cmd %s not defined", match[1])
-		}
-		var key, endKey string
-		if len(match) > 2 {
-			key = match[2]
-		}
-		if len(match) > 3 {
-			endKey = match[3]
-		}
-		c := &cmd{name: match[1], key: key, endKey: endKey, txnIdx: txnIdx, fn: fn}
 		cmds = append(cmds, c)
 	}
 	return cmds
@@ -634,16 +666,16 @@ func checkConcurrency(name string, isolations []roachpb.IsolationType, txns []st
 //
 // Notation for planned histories:
 //   R(x) - read from key "x"
-//   I(x) - increment key "x" by 1
+//   I(x) - increment key "x" by 1 (shorthand for W(x,x+1)
 //   SC(x-y) - scan values from keys "x"-"y"
-//   SUM(x) - sums all values read during txn and writes sum to "x"
+//   W(x,y[+z+...]) - writes sum of values y+z+... to x
 //   C - commit
 //
 // Notation for actual histories:
 //   Rn.m(x) - read from txn "n" ("m"th retry) of key "x"
 //   In.m(x) - increment from txn "n" ("m"th retry) of key "x"
 //   SCn.m(x-y) - scan from txn "n" ("m"th retry) of keys "x"-"y"
-//   SUMn.m(x) - sums all values read from txn "n" ("m"th retry)
+//   Wn.m(x,y[+z+...]) - write sum of values y+z+... to x from txn "n" ("m"th retry)
 //   Cn.m - commit of txn "n" ("m"th retry)
 
 // TestTxnDBInconsistentAnalysisAnomaly verifies that neither SI nor
@@ -656,10 +688,10 @@ func checkConcurrency(name string, isolations []roachpb.IsolationType, txns []st
 // reader must not see intermediate results from the reader/writer.
 //
 // Inconsistent analysis would typically fail with a history such as:
-//    R1(A) R2(B) W2(B) R2(A) W2(A) R1(B) C1 C2
+//    R1(A) R2(B) I2(B) R2(A) I2(A) R1(B) C1 C2
 func TestTxnDBInconsistentAnalysisAnomaly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	txn1 := "R(A) R(B) SUM(C) C"
+	txn1 := "R(A) R(B) W(C,A+B) C"
 	txn2 := "I(A) I(B) C"
 	verify := &verifier{
 		history: "R(C)",
@@ -690,6 +722,7 @@ func TestTxnDBInconsistentAnalysisAnomaly(t *testing.T) {
 // READ_COMMITTED and in practice requires REPEATABLE_READ to avoid.
 //   R1(A) R2(A) I1(A) C1 I2(A) C2
 func TestTxnDBLostUpdateAnomaly(t *testing.T) {
+	t.Skip("TODO(spencer): see #5404")
 	defer leaktest.AfterTest(t)()
 	txn := "R(A) I(A) C"
 	verify := &verifier{
@@ -715,16 +748,16 @@ func TestTxnDBLostUpdateAnomaly(t *testing.T) {
 // ranges when settling concurrency issues.
 //
 // Phantom reads would typically fail with a history such as:
-//   SC1(A-C) I2(B) C2 SC1(A-C) C1
+//   R2(B) SC1(A-C) I2(B) C2 SC1(A-C) C1
 func TestTxnDBPhantomReadAnomaly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	txn1 := "SC(A-C) SUM(D) SC(A-C) SUM(E) C"
-	txn2 := "I(B) C"
+	txn1 := "SC(A-C) W(D,A+B) SC(A-C) W(E,A+B) C"
+	txn2 := "R(B) I(B) C"
 	verify := &verifier{
 		history: "R(D) R(E)",
 		checkFn: func(env map[string]int64) error {
 			if env["D"] != env["E"] {
-				return util.Errorf("expected first SUM == second SUM (%d != %d)", env["D"], env["E"])
+				return util.Errorf("expected D == E (%d != %d)", env["D"], env["E"])
 			}
 			return nil
 		},
@@ -738,11 +771,12 @@ func TestTxnDBPhantomReadAnomaly(t *testing.T) {
 // functionality causes read/write conflicts.
 //
 // Phantom deletes would typically fail with a history such as:
-//   DR1(A-C) I2(B) C2 SC1(A-C) C1
+//   R2(B) DR1(A-C) I2(B) C2 SC1(A-C) C1
 func TestTxnDBPhantomDeleteAnomaly(t *testing.T) {
+	t.Skip("TODO(spencer): see #5404")
 	defer leaktest.AfterTest(t)()
-	txn1 := "DR(A-C) SC(A-C) SUM(D) C"
-	txn2 := "I(B) C"
+	txn1 := "DR(A-C) SC(A-C) W(D,A+B) C"
+	txn2 := "R(B) I(B) C"
 	verify := &verifier{
 		history: "R(D)",
 		checkFn: func(env map[string]int64) error {
@@ -765,7 +799,7 @@ func TestTxnDBPhantomDeleteAnomaly(t *testing.T) {
 // "skew". Only serializable isolation prevents this anomaly.
 //
 // Write skew would typically fail with a history such as:
-//   SC1(A-C) SC2(A-C) I1(A) SUM1(A) I2(B) SUM2(B)
+//   SC1(A-C) SC2(A-C) W1(A,A+B+1) C1 W2(B,A+B+1) C2
 //
 // In the test below, each txn reads A and B and increments one by 1.
 // The read values and increment are then summed and written either to
@@ -776,8 +810,8 @@ func TestTxnDBPhantomDeleteAnomaly(t *testing.T) {
 // history above) and may set A=1, B=1.
 func TestTxnDBWriteSkewAnomaly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	txn1 := "SC(A-C) I(A) SUM(A) C"
-	txn2 := "SC(A-C) I(B) SUM(B) C"
+	txn1 := "SC(A-C) W(A,A+B+1) C"
+	txn2 := "SC(A-C) W(B,A+B+1) C"
 	verify := &verifier{
 		history: "R(A) R(B)",
 		checkFn: func(env map[string]int64) error {


### PR DESCRIPTION
The txn correctness test prior to this change was no longer
effectively discovering lost updates and phantom deletes -- both
of which were reintroduced in various changes over the past year.

For now, disabling those two tests pending another change which
fixes the correctness issues which have crept in over time.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5404)

<!-- Reviewable:end -->
