### PR TITLE
storage: panic on consistency checksum mismatch

### DIFF
--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -418,8 +418,7 @@ func testNodeRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfi
 	log.Infof("%d %.1f/sec", count, float64(count)/elapsed.Seconds())
 	kvClient, kvStopper := c.NewClient(t, num-1)
 	defer kvStopper.Stop()
-	if pErr := kvClient.CheckConsistency(keys.TableDataMin, keys.TableDataMax); pErr != nil {
-		// TODO(.*): change back to t.Fatal after #5051.
-		log.Error(pErr)
+	if err := kvClient.CheckConsistency(keys.TableDataMin, keys.TableDataMax); err != nil {
+		log.Fatal(err)
 	}
 }

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1532,8 +1532,7 @@ func (r *Replica) VerifyChecksum(batch engine.Engine, ms *engine.MVCCStats, h ro
 		if p := r.store.ctx.TestingKnobs.BadChecksumPanic; p != nil {
 			p()
 		} else {
-			// TODO(.*): see #5051.
-			log.Errorf("checksum mismatch: e = %x, v = %x", args.Checksum, c.checksum)
+			panic(fmt.Sprintf("checksum mismatch: e = %x, v = %x", args.Checksum, c.checksum))
 		}
 	}
 	return roachpb.VerifyChecksumResponse{}, nil


### PR DESCRIPTION
closes #5051 

We've not seen an mismatching checksums on the Beta cluster for the last 48 hours, so it does look like a good time to clamp down on consistency.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5405)

<!-- Reviewable:end -->
