### PR TITLE
all: bump unused tool version

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -77,4 +77,4 @@ golang.org/x/tools fcde77432eb91f1389e8b5be6a4d018536ceac02
 google.golang.org/grpc d3ddb4469d5a1b949fc7a7da7c1d6a0d1b6de994
 gopkg.in/inf.v0 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 gopkg.in/yaml.v1 9f9df34309c04878acc86042b16630b0f696e1de
-honnef.co/go/unused eb1701f4aae9ed22fa0e62bc7314e23b711fbf0e
+honnef.co/go/unused 4dba7690cbd5a207a5a2260063d598f42038c525

--- a/Makefile
+++ b/Makefile
@@ -239,9 +239,7 @@ check:
 
 .PHONY: unused
 unused:
-# The -fields option generates false-positives for embedded mutex and
-# related types. See https://github.com/dominikh/go-unused/issues/18.
-	-unused -fields ./... | grep -v -E '(\.pb\.go:|/C:|_string.go:|parser/(yacc|sql.y)|_cgo|Mutex)'
+	-unused ./... | grep -v -E '(\.pb\.go:|/C:|_string.go:|parser/(yacc|sql.y)|_cgo)'
 
 .PHONY: clean
 clean:

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -94,7 +94,6 @@ func (*gcQueue) acceptsUnsplitRanges() bool {
 	return false
 }
 
-type logFunc func(fmt string, args ...interface{})
 type pushFunc func(roachpb.Timestamp, *roachpb.Transaction, roachpb.PushTxnType, *sync.WaitGroup)
 type resolveFunc func([]roachpb.Intent, bool, bool) *roachpb.Error
 

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -170,7 +170,6 @@ type Replica struct {
 		leaderLease    *roachpb.Lease
 		maxBytes       int64 // Max bytes before split.
 		pendingCmds    map[storagebase.CmdIDKey]*pendingCmd
-		pendingSeq     uint64 // atomic sequence counter for CmdIDKey generation.
 		raftGroup      *raft.RawNode
 		replicaID      roachpb.ReplicaID
 		truncatedState *roachpb.RaftTruncatedState

--- a/util/interval/interval.go
+++ b/util/interval/interval.go
@@ -684,7 +684,7 @@ func (n *Node) doMatch(fn Operation, r Range, overlaps func(Range, Range) bool) 
 // intervals' sort relationships, future tree operation behaviors are undefined.
 func (t *Tree) DoMatchingReverse(fn Operation, r Range) bool {
 	if t.Root != nil && t.Overlapper(r, t.Root.Range) {
-		return t.Root.doMatch(fn, r, t.Overlapper)
+		return t.Root.doMatchReverse(fn, r, t.Overlapper)
 	}
 	return false
 }


### PR DESCRIPTION
Perform another pass of unused removal. This actually found a bug in
`util/interval.Tree`, but in code we're not
using (`Tree.DoMatchingReverse`).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5406)

<!-- Reviewable:end -->
