### PR TITLE
sql: mark trace logs of executed statements as sensitive

### DIFF
--- a/server/admin.go
+++ b/server/admin.go
@@ -54,13 +54,16 @@ import (
 )
 
 func init() {
-	// Tweak the authentication logic for the tracing endpoint.
-	// By default it's open for localhost only, but with Docker
-	// we want to get there from anywhere.
+	// Tweak the authentication logic for the tracing endpoint. By default it's
+	// open for localhost only, but with Docker we want to get there from
+	// anywhere. We maintain the default behavior of only allowing access to
+	// sensitive logs from localhost.
+	//
 	// TODO(mberhault): properly secure this once we require client certs.
-	trace.AuthRequest = func(_ *http.Request) (bool, bool) {
-		// Open-door policy except traces marked "sensitive".
-		return true, false
+	origAuthRequest := trace.AuthRequest
+	trace.AuthRequest = func(req *http.Request) (bool, bool) {
+		_, sensitive := origAuthRequest(req)
+		return true, sensitive
 	}
 }
 

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -1000,8 +1000,7 @@ func (e *Executor) execStmtInOpenTxn(
 	}
 
 	if txnState.tr != nil {
-		// TODO(pmattis): Should "sensitive" be true here?
-		txnState.tr.LazyLog(stmt, false)
+		txnState.tr.LazyLog(stmt, true /* sensitive */)
 	}
 	result, pErr := e.execStmt(stmt, planMaker, timeutil.Now(),
 		implicitTxn /* autoCommit */)


### PR DESCRIPTION
Only allow viewing of sensitive trace logs when viewing from localhost.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5407)

<!-- Reviewable:end -->
