### PR TITLE
kv: fix cleanupTxn race

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -342,7 +342,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 			tc.Unlock()
 			if !ok {
 				pErr := roachpb.NewErrorf("writing transaction timed out, was aborted, " +
-					" or ran on multiple coordinators")
+					"or ran on multiple coordinators")
 				return nil, pErr
 			}
 		}
@@ -522,8 +522,9 @@ func (tc *TxnCoordSender) cleanupTxn(ctx context.Context, txn roachpb.Transactio
 	tc.Lock()
 	defer tc.Unlock()
 	txnMeta, ok := tc.txns[*txn.ID]
-	// The heartbeat might've already removed the record.
-	if !ok {
+	// The heartbeat might've already removed the record. Or we may have already
+	// closed txnEnd but we are racing with the heartbeat cleanup.
+	if !ok || txnMeta.txnEnd == nil {
 		return
 	}
 
@@ -551,7 +552,7 @@ func (tc *TxnCoordSender) unregisterTxnLocked(txnID uuid.UUID) (duration, restar
 
 	delete(tc.txns, txnID)
 
-	return
+	return duration, restarts, status
 }
 
 // heartbeatLoop periodically sends a HeartbeatTxn RPC to an extant

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -641,6 +641,30 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 	}
 }
 
+// TestTxnCoordIdempotentCleanup verifies that cleanupTxn is idempotent.
+func TestTxnCoordIdempotentCleanup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s := createTestDB(t)
+	defer s.Stop()
+	defer teardownHeartbeats(s.Sender)
+
+	txn := client.NewTxn(*s.DB)
+	ba := txn.NewBatch()
+	ba.Put(roachpb.Key("a"), []byte("value"))
+	if pErr := txn.Run(ba); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	s.Sender.cleanupTxn(context.Background(), txn.Proto)
+
+	ba = txn.NewBatch()
+	ba.InternalAddRequest(&roachpb.EndTransactionRequest{})
+	pErr := txn.Run(ba)
+	if pErr != nil && !testutils.IsPError(pErr, "aborted") {
+		t.Fatal(pErr)
+	}
+}
+
 // TestTxnMultipleCoord checks that a coordinator uses the Writing flag to
 // enforce that only one coordinator can be used for transactional writes.
 func TestTxnMultipleCoord(t *testing.T) {


### PR DESCRIPTION
There is a window between when `cleanupTxn` runs and when the heartbeat
goroutine unregisters the txn. During this window another op might start on the
txn, causing a second call to `cleanupTxn`, which crashes (close of nil
channel). This change fixes this by adding a check for the nil channel.

TestTxnCoordIdempotentCleanup is resurrected, though it had to be rewritten.
Verified that the test causes the crash without the fix.  I also ran all tests
with a 1ms sleep added in heartbeatLoop before unregistering the txn.

Fixes #4426.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5408)

<!-- Reviewable:end -->
