### PR TITLE
kv: Prioritize healthy clients, even for "stable" ordering

### DIFF
--- a/kv/send.go
+++ b/kv/send.go
@@ -128,24 +128,18 @@ func send(opts SendOptions, replicas ReplicaSlice,
 		})
 	}
 
+	// Put known-unhealthy clients last.
+	nHealthy, err := splitHealthy(clients)
+	if err != nil {
+		return nil, err
+	}
+
 	var orderedClients []batchClient
 	switch opts.Ordering {
 	case orderStable:
 		orderedClients = clients
 	case orderRandom:
 		// Randomly permute order, but keep known-unhealthy clients last.
-		var nHealthy int
-		for i, client := range clients {
-			clientState, err := client.conn.State()
-			if err != nil {
-				return nil, err
-			}
-			if clientState == grpc.Ready {
-				clients[i], clients[nHealthy] = clients[nHealthy], clients[i]
-				nHealthy++
-			}
-		}
-
 		shuffleClients(clients[:nHealthy])
 		shuffleClients(clients[nHealthy:])
 
@@ -213,6 +207,27 @@ func send(opts SendOptions, replicas ReplicaSlice,
 			}
 		}
 	}
+}
+
+// splitHealthy splits the provided client slice into healthy clients and
+// unhealthy clients, based on their connection state. Healthy clients will
+// be rearranged first in the slice, and unhealthy clients will be rearranged
+// last. Within these two groups, the rearrangement will be stable. The function
+// will then return the number of healthy clients.
+func splitHealthy(clients []batchClient) (int, error) {
+	var nHealthy int
+	for i, client := range clients {
+		clientState, err := client.conn.State()
+		if err != nil {
+			// This should not currently happen with the default grpc.Picker.
+			return 0, err
+		}
+		if clientState == grpc.Ready {
+			clients[i], clients[nHealthy] = clients[nHealthy], clients[i]
+			nHealthy++
+		}
+	}
+	return nHealthy, nil
 }
 
 // Allow local calls to be dispatched directly to the local server without


### PR DESCRIPTION
Previously we would try to optimize the replica ordering for single
range RPC calls. This ordering did not take into account replica health,
which meant that we could get in situations where we consistently
prioritized an unhealthy replica because we would try to optimize
with a stable ordering. This would bring throughput to a halt, and could
make it look like a single-node failure would prevent forward progress.

This change prioritizes the ordering of clients by health state even
for "stable" orderings. If this seems like it goes against the notion of
a stable ordering and we would prefer to have an ordering type that
strictly is stable, then we should introduce a third ordering that is
"stable-ish" and use that ordering type instead in all cases where we
previously used the stable ordering.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5418)

<!-- Reviewable:end -->
