### PR TITLE
rpc: gRPC provided options should override default options

### DIFF
--- a/rpc/context.go
+++ b/rpc/context.go
@@ -152,7 +152,11 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 		dialOpt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 
-	conn, err := grpc.Dial(target, append(opts, dialOpt, grpc.WithTimeout(base.NetworkTimeout))...)
+	dialOpts := make([]grpc.DialOption, 0, 2+len(opts))
+	dialOpts = append(dialOpts, dialOpt, grpc.WithTimeout(base.NetworkTimeout))
+	dialOpts = append(dialOpts, opts...)
+
+	conn, err := grpc.Dial(target, dialOpts...)
 	if err == nil {
 		if ctx.conns.cache == nil {
 			ctx.conns.cache = make(map[string]*grpc.ClientConn)


### PR DESCRIPTION
New options need to be appended to the end of the default options when
passed to `grpc.Dial`. If you really want, we can make this a little uglier and
avoid the guaranteed slice allocation.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5420)

<!-- Reviewable:end -->
