### PR TITLE
cli: Enable use of environment variable to override configuration flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,8 @@ dupl:
 check:
 	@echo "checking for time.Now calls (use timeutil.Now() instead)"
 	@! git grep -E 'time\.Now' -- '*.go' | grep -vE '^util/(log|timeutil)/\w+\.go:'
+	@echo "checking for os.Getenv calls (use envutil.EnvOrDefault*() instead)"
+	@! git grep -e 'os\.Getenv' -- '*.go' | grep -vE '^(util/(log|envutil)|acceptance/.*)/\w+\.go:'
 	@echo "checking for proto.Clone calls (use util.CloneProto instead)"
 	@! git grep -E '\.Clone\([^)]+\)' -- '*.go' | grep -vE '^util/clone_proto(_test)?\.go:'
 	@echo "checking for grpc.NewServer calls (use rpc.NewServer instead)"

--- a/cli/debug.go
+++ b/cli/debug.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/util/envutil"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/timeutil"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -57,7 +58,7 @@ func parseRangeID(arg string) (roachpb.RangeID, error) {
 }
 
 func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (engine.Engine, error) {
-	initCacheSize()
+	setDefaultCacheSize(&cliContext.Context)
 
 	db := engine.NewRocksDB(roachpb.Attributes{}, dir,
 		cliContext.CacheSize, cliContext.MemtableBudget, 0, stopper)
@@ -473,6 +474,18 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+var debugEnvCmd = &cobra.Command{
+	Use:   "env",
+	Short: "output environment settings",
+	Long: `
+Output environment variables that influence configuration.
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		env := envutil.GetEnvReport()
+		fmt.Print(env)
+	},
+}
+
 func init() {
 	debugCmd.AddCommand(debugCmds...)
 }
@@ -485,6 +498,7 @@ var debugCmds = []*cobra.Command{
 	debugSplitKeyCmd,
 	kvCmd,
 	rangeCmd,
+	debugEnvCmd,
 }
 
 var debugCmd = &cobra.Command{

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -192,10 +192,6 @@ memory that the store may consume, for example:`) + `
 Commas are forbidden in all values, since they are used to separate fields.
 Also, if you use equal signs in the file path to a store, you must use the
 "path" field label.`),
-	"time-until-store-dead": wrapText(`
-Adjusts the timeout for stores. If there's been no gossiped update
-from a store after this time, the store is considered unavailable.
-Replicas on an unavailable store will be moved to available ones.`),
 
 	cliflags.URLName: wrapText(`
 Connection url. eg: postgresql://myuser@localhost:26257/mydb

--- a/cli/start.go
+++ b/cli/start.go
@@ -94,15 +94,13 @@ uninitialized, specify the --join flag to point to any healthy node
 	RunE:         runStart,
 }
 
-func initCacheSize() {
-	if !cacheSize.isSet {
-		if size, err := server.GetTotalMemory(); err == nil {
-			// Default the cache size to 1/4 of total memory. A larger cache size
-			// doesn't necessarily improve performance as this is memory that is
-			// dedicated to uncompressed blocks in RocksDB. A larger value here will
-			// compete with the OS buffer cache which holds compressed blocks.
-			cliContext.CacheSize = size / 4
-		}
+func setDefaultCacheSize(ctx *server.Context) {
+	if size, err := server.GetTotalMemory(); err == nil {
+		// Default the cache size to 1/4 of total memory. A larger cache size
+		// doesn't necessarily improve performance as this is memory that is
+		// dedicated to uncompressed blocks in RocksDB. A larger value here will
+		// compete with the OS buffer cache which holds compressed blocks.
+		ctx.CacheSize = size / 4
 	}
 }
 
@@ -132,7 +130,6 @@ func initInsecure() error {
 // of other active nodes used to join this node to the cockroach
 // cluster, if this is its first time connecting.
 func runStart(_ *cobra.Command, _ []string) error {
-	initCacheSize()
 	if err := initInsecure(); err != nil {
 		return err
 	}

--- a/kv/send.go
+++ b/kv/send.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"os"
 	"time"
 
 	"golang.org/x/net/context"
@@ -29,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/envutil"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
 )
@@ -239,7 +239,7 @@ func splitHealthy(clients []batchClient) (int, error) {
 
 // Allow local calls to be dispatched directly to the local server without
 // sending an RPC.
-var enableLocalCalls = os.Getenv("ENABLE_LOCAL_CALLS") != "0"
+var enableLocalCalls = envutil.EnvOrDefaultBool("enable_local_calls", false)
 
 // sendOneFn is overwritten in tests to mock sendOne.
 var sendOneFn = sendOne

--- a/server/context.go
+++ b/server/context.go
@@ -38,7 +38,8 @@ import (
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/envutil"
+	"github.com/cockroachdb/cockroach/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
@@ -60,7 +61,7 @@ const (
 	defaultScanInterval             = 10 * time.Minute
 	defaultConsistencyCheckInterval = 24 * time.Hour
 	defaultScanMaxIdleTime          = 5 * time.Second
-	defaultMetricsFrequency         = 10 * time.Second
+	defaultMetricsSampleInterval    = 10 * time.Second
 	defaultTimeUntilStoreDead       = 5 * time.Minute
 )
 
@@ -128,10 +129,10 @@ type Context struct {
 	// Environment Variable: COCKROACH_MAX_OFFSET
 	MaxOffset time.Duration
 
-	// MetricsFrequency determines the frequency at which the server should
-	// record internal metrics.
-	// Environment Variable: COCKROACH_METRICS_FREQUENCY
-	MetricsFrequency time.Duration
+	// MetricsSamplePeriod determines the time between records of
+	// server internal metrics.
+	// Environment Variable: COCKROACH_METRICS_SAMPLE_INTERVAL
+	MetricsSampleInterval time.Duration
 
 	// ScanInterval determines a duration during which each range should be
 	// visited approximately once by the range scanner.
@@ -144,7 +145,8 @@ type Context struct {
 	// Environment Variable: COCKROACH_SCAN_MAX_IDLE_TIME
 	ScanMaxIdleTime time.Duration
 
-	// ConsistencyCheckInterval
+	// ConsistencyCheckInterval determines the time between range consistency checks.
+	// Environment Variable: COCKROACH_CONSISTENCY_CHECK_INTERVAL
 	ConsistencyCheckInterval time.Duration
 
 	// ConsistencyCheckPanicOnFailure causes the node to panic when it detects a
@@ -185,7 +187,7 @@ func GetTotalMemory() (int64, error) {
 		if buf, err = ioutil.ReadFile(defaultCGroupMemPath); err != nil {
 			if log.V(1) {
 				log.Infof("can't read available memory from cgroups (%s), using system memory %s instead", err,
-					util.IBytes(totalMem))
+					humanizeutil.IBytes(totalMem))
 			}
 			return totalMem, nil
 		}
@@ -193,14 +195,14 @@ func GetTotalMemory() (int64, error) {
 		if cgAvlMem, err = strconv.ParseUint(strings.TrimSpace(string(buf)), 10, 64); err != nil {
 			if log.V(1) {
 				log.Infof("can't parse available memory from cgroups (%s), using system memory %s instead", err,
-					util.IBytes(totalMem))
+					humanizeutil.IBytes(totalMem))
 			}
 			return totalMem, nil
 		}
 		if cgAvlMem > math.MaxInt64 {
 			if log.V(1) {
 				log.Infof("available memory from cgroups is too large and unsupported %s using system memory %s instead",
-					humanize.IBytes(cgAvlMem), util.IBytes(totalMem))
+					humanize.IBytes(cgAvlMem), humanizeutil.IBytes(totalMem))
 
 			}
 			return totalMem, nil
@@ -234,7 +236,7 @@ func (ctx *Context) InitDefaults() {
 	ctx.ScanInterval = defaultScanInterval
 	ctx.ScanMaxIdleTime = defaultScanMaxIdleTime
 	ctx.ConsistencyCheckInterval = defaultConsistencyCheckInterval
-	ctx.MetricsFrequency = defaultMetricsFrequency
+	ctx.MetricsSampleInterval = defaultMetricsSampleInterval
 	ctx.TimeUntilStoreDead = defaultTimeUntilStoreDead
 	ctx.Stores.Specs = append(ctx.Stores.Specs, StoreSpec{Path: "cockroach-data"})
 }
@@ -256,7 +258,7 @@ func (ctx *Context) InitStores(stopper *stop.Stopper) error {
 			}
 			if sizeInBytes != 0 && sizeInBytes < minimumStoreSize {
 				return fmt.Errorf("%f%% of memory is only %s bytes, which is below the minimum requirement of %s",
-					spec.SizePercent, util.IBytes(sizeInBytes), util.IBytes(minimumStoreSize))
+					spec.SizePercent, humanizeutil.IBytes(sizeInBytes), humanizeutil.IBytes(minimumStoreSize))
 			}
 			ctx.Engines = append(ctx.Engines, engine.NewInMem(spec.Attributes, sizeInBytes, stopper))
 		} else {
@@ -269,7 +271,7 @@ func (ctx *Context) InitStores(stopper *stop.Stopper) error {
 			}
 			if sizeInBytes != 0 && sizeInBytes < minimumStoreSize {
 				return fmt.Errorf("%f%% of %s's total free space is only %s bytes, which is below the minimum requirement of %s",
-					spec.SizePercent, spec.Path, util.IBytes(sizeInBytes), util.IBytes(minimumStoreSize))
+					spec.SizePercent, spec.Path, humanizeutil.IBytes(sizeInBytes), humanizeutil.IBytes(minimumStoreSize))
 			}
 			ctx.Engines = append(ctx.Engines, engine.NewRocksDB(spec.Attributes, spec.Path,
 				ctx.CacheSize/int64(len(ctx.Stores.Specs)), ctx.MemtableBudget, sizeInBytes, stopper))
@@ -303,46 +305,19 @@ func (ctx *Context) InitNode() error {
 	return nil
 }
 
-// parseBoolEnv parses a bool from an environment variable. This
-// function assumes that the default value is already present in boolVar.
-func parseBoolEnv(env, internalName string, boolVar *bool) {
-	if valueString := os.Getenv(env); len(valueString) != 0 {
-		if v, err := strconv.ParseBool(valueString); err != nil {
-			log.Errorf("could not parse environment variable %s=%s, setting to default of %t, error: %s",
-				env, valueString, *boolVar, err)
-		} else {
-			*boolVar = v
-			log.Infof("\"%s\" set to %t based on %s environment variable", internalName, v, env)
-		}
-	}
-}
-
-// parseDurationEnv parses a time.Duration from an environment variable. This
-// function assumes that the default value is already present in duration.
-func parseDurationEnv(env, internalName string, duration *time.Duration) {
-	if valueString := os.Getenv(env); len(valueString) != 0 {
-		if value, err := time.ParseDuration(valueString); err != nil {
-			log.Errorf("could not parse environment variable %s=%s, setting to default of %s, error: %s",
-				env, valueString, duration, err)
-		} else {
-			*duration = value
-			log.Infof("\"%s\" set to %s based on %s environment variable", internalName, *duration, env)
-		}
-	}
-}
-
 // readEnvironmentVariables populates all context values that are environment
 // variable based. Note that this only happens when initializing a node and not
 // when NewContext is called.
 func (ctx *Context) readEnvironmentVariables() {
-	parseBoolEnv("COCKROACH_LINEARIZABLE", "linearizable", &ctx.Linearizable)
-	parseBoolEnv("COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE", "consistency check panic on failure", &ctx.ConsistencyCheckPanicOnFailure)
-	parseDurationEnv("COCKROACH_MAX_OFFSET", "max offset", &ctx.MaxOffset)
-	parseDurationEnv("COCKROACH_METRICS_FREQUENCY", "metrics frequency", &ctx.MetricsFrequency)
-	parseDurationEnv("COCKROACH_SCAN_INTERVAL", "scan interval", &ctx.ScanInterval)
-	parseDurationEnv("COCKROACH_CONSISTENCY_CHECK_INTERVAL", "consistency check interval", &ctx.ConsistencyCheckInterval)
-	parseDurationEnv("COCKROACH_SCAN_MAX_IDLE_TIME", "scan max idle time", &ctx.ScanMaxIdleTime)
-	parseDurationEnv("COCKROACH_TIME_UNTIL_STORE_DEAD", "time until store dead", &ctx.TimeUntilStoreDead)
+	// cockroach-linearizable
+	ctx.Linearizable = envutil.EnvOrDefaultBool("linearizable", ctx.Linearizable)
+	ctx.ConsistencyCheckPanicOnFailure = envutil.EnvOrDefaultBool("consistency_check_panic_on_failure", ctx.ConsistencyCheckPanicOnFailure)
+	ctx.MaxOffset = envutil.EnvOrDefaultDuration("max_offset", ctx.MaxOffset)
+	ctx.MetricsSampleInterval = envutil.EnvOrDefaultDuration("metrics_sample_interval", ctx.MetricsSampleInterval)
+	ctx.ScanInterval = envutil.EnvOrDefaultDuration("scan_interval", ctx.ScanInterval)
+	ctx.ScanMaxIdleTime = envutil.EnvOrDefaultDuration("scan_max_idle_time", ctx.ScanMaxIdleTime)
+	ctx.TimeUntilStoreDead = envutil.EnvOrDefaultDuration("time_until_store_dead", ctx.TimeUntilStoreDead)
+	ctx.ConsistencyCheckInterval = envutil.EnvOrDefaultDuration("consistency_check_interval", ctx.ConsistencyCheckInterval)
 }
 
 // AdminURL returns the URL for the admin UI.

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/gossip/resolver"
+	"github.com/cockroachdb/cockroach/util/envutil"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
@@ -88,7 +89,7 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		if err := os.Unsetenv("COCKROACH_MAX_OFFSET"); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.Unsetenv("COCKROACH_METRICS_FREQUENCY"); err != nil {
+		if err := os.Unsetenv("COCKROACH_METRICS_SAMPLE_INTERVAL"); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.Unsetenv("COCKROACH_SCAN_INTERVAL"); err != nil {
@@ -104,6 +105,9 @@ func TestReadEnvironmentVariables(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := os.Unsetenv("COCKROACH_TIME_UNTIL_STORE_DEAD"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Unsetenv("COCKROACH_CONSISTENCY_CHECK_INTERVAL"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -129,10 +133,10 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctxExpected.MaxOffset = time.Second
-	if err := os.Setenv("COCKROACH_METRICS_FREQUENCY", "1h10m"); err != nil {
+	if err := os.Setenv("COCKROACH_METRICS_SAMPLE_INTERVAL", "1h10m"); err != nil {
 		t.Fatal(err)
 	}
-	ctxExpected.MetricsFrequency = time.Hour + time.Minute*10
+	ctxExpected.MetricsSampleInterval = time.Hour + time.Minute*10
 	if err := os.Setenv("COCKROACH_SCAN_INTERVAL", "48h"); err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +157,12 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctxExpected.TimeUntilStoreDead = time.Millisecond * 10
+	if err := os.Setenv("COCKROACH_CONSISTENCY_CHECK_INTERVAL", "10ms"); err != nil {
+		t.Fatal(err)
+	}
+	ctxExpected.ConsistencyCheckInterval = time.Millisecond * 10
 
+	envutil.ClearEnvCache()
 	ctx.readEnvironmentVariables()
 	if !reflect.DeepEqual(ctx, ctxExpected) {
 		t.Fatalf("actual context does not match expected:\nactual:%+v\nexpected:%+v", ctx, ctxExpected)
@@ -170,7 +179,7 @@ func TestReadEnvironmentVariables(t *testing.T) {
 	if err := os.Setenv("COCKROACH_MAX_OFFSET", "abcd"); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Setenv("COCKROACH_METRICS_FREQUENCY", "abcd"); err != nil {
+	if err := os.Setenv("COCKROACH_METRICS_SAMPLE_INTERVAL", "abcd"); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Setenv("COCKROACH_SCAN_INTERVAL", "abcd"); err != nil {
@@ -188,7 +197,11 @@ func TestReadEnvironmentVariables(t *testing.T) {
 	if err := os.Setenv("COCKROACH_TIME_UNTIL_STORE_DEAD", "abcd"); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Setenv("COCKROACH_CONSISTENCY_CHECK_INTERVAL", "abcd"); err != nil {
+		t.Fatal(err)
+	}
 
+	envutil.ClearEnvCache()
 	ctx.readEnvironmentVariables()
 	if !reflect.DeepEqual(ctx, ctxExpected) {
 		t.Fatalf("actual context does not match expected:\nactual:%+v\nexpected:%+v", ctx, ctxExpected)

--- a/server/server.go
+++ b/server/server.go
@@ -346,13 +346,13 @@ func (s *Server) Start() error {
 	}
 
 	// Begin recording runtime statistics.
-	s.startSampleEnvironment(s.ctx.MetricsFrequency)
+	s.startSampleEnvironment(s.ctx.MetricsSampleInterval)
 
 	// Begin recording time series data collected by the status monitor.
-	s.tsDB.PollSource(s.recorder, s.ctx.MetricsFrequency, ts.Resolution10s, s.stopper)
+	s.tsDB.PollSource(s.recorder, s.ctx.MetricsSampleInterval, ts.Resolution10s, s.stopper)
 
 	// Begin recording status summaries.
-	s.node.startWriteSummaries(s.ctx.MetricsFrequency)
+	s.node.startWriteSummaries(s.ctx.MetricsSampleInterval)
 
 	s.sqlExecutor.SetNodeID(s.node.Descriptor.NodeID)
 	// Create and start the schema change manager only after a NodeID

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -493,7 +493,7 @@ func TestMetricsRecording(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tsrv := TestServer{}
 	tsrv.Ctx = NewTestContext()
-	tsrv.Ctx.MetricsFrequency = 5 * time.Millisecond
+	tsrv.Ctx.MetricsSampleInterval = 5 * time.Millisecond
 	if err := tsrv.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/server/store_spec.go
+++ b/server/store_spec.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/humanizeutil"
 )
 
 var minimumStoreSize = 10 * int64(config.DefaultZoneConfig().RangeMaxBytes)
@@ -53,7 +53,7 @@ func (ss StoreSpec) String() string {
 		fmt.Fprint(&buffer, "type=mem,")
 	}
 	if ss.SizeInBytes > 0 {
-		fmt.Fprintf(&buffer, "size=%s,", util.IBytes(ss.SizeInBytes))
+		fmt.Fprintf(&buffer, "size=%s,", humanizeutil.IBytes(ss.SizeInBytes))
 	}
 	if ss.SizePercent > 0 {
 		fmt.Fprintf(&buffer, "size=%s%%,", humanize.Ftoa(ss.SizePercent))
@@ -159,13 +159,13 @@ func newStoreSpec(value string) (StoreSpec, error) {
 				}
 			} else {
 				var err error
-				ss.SizeInBytes, err = util.ParseBytes(value)
+				ss.SizeInBytes, err = humanizeutil.ParseBytes(value)
 				if err != nil {
 					return StoreSpec{}, fmt.Errorf("could not parse store size (%s) %s", value, err)
 				}
 				if ss.SizeInBytes < minimumStoreSize {
 					return StoreSpec{}, fmt.Errorf("store size (%s) must be larger than %s", value,
-						util.IBytes(minimumStoreSize))
+						humanizeutil.IBytes(minimumStoreSize))
 				}
 			}
 		case "attrs":

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine/rocksdb"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
@@ -114,7 +115,7 @@ func (r *RocksDB) Open() error {
 
 	if r.memtableBudget < minMemtableBudget {
 		return util.Errorf("memtable budget must be at least %s: %s",
-			humanize.IBytes(minMemtableBudget), util.IBytes(r.memtableBudget))
+			humanize.IBytes(minMemtableBudget), humanizeutil.IBytes(r.memtableBudget))
 	}
 
 	var ver storageVersion
@@ -254,11 +255,11 @@ func (r *RocksDB) Capacity() (roachpb.StoreCapacity, error) {
 
 	if fileSystemUsage.Total > math.MaxInt64 {
 		return roachpb.StoreCapacity{}, fmt.Errorf("unsupported disk size %s, max supported size is %s",
-			humanize.IBytes(fileSystemUsage.Total), util.IBytes(math.MaxInt64))
+			humanize.IBytes(fileSystemUsage.Total), humanizeutil.IBytes(math.MaxInt64))
 	}
 	if fileSystemUsage.Avail > math.MaxInt64 {
 		return roachpb.StoreCapacity{}, fmt.Errorf("unsupported disk size %s, max supported size is %s",
-			humanize.IBytes(fileSystemUsage.Avail), util.IBytes(math.MaxInt64))
+			humanize.IBytes(fileSystemUsage.Avail), humanizeutil.IBytes(math.MaxInt64))
 	}
 	fsuTotal := int64(fileSystemUsage.Total)
 	fsuAvail := int64(fileSystemUsage.Avail)

--- a/util/envutil/env.go
+++ b/util/envutil/env.go
@@ -1,0 +1,152 @@
+package envutil
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+type envVarInfo struct {
+	consumer string
+	present  bool
+	value    string
+}
+
+var envVarRegistry map[string]envVarInfo
+
+func init() {
+	ClearEnvCache()
+}
+
+// VarName returns the name of the environment variable
+// corresponding to a configuration key or command-line flag name.
+func VarName(name string) string {
+	return "COCKROACH_" + strings.ToUpper(strings.Replace(name, "-", "_", -1))
+}
+
+// getEnv retrieves an environment variable, keeps track of where
+// it was accessed, and checks that each environment variable is accessed
+// from at most one place.
+// The bookkeeping enables a report of all influential environment
+// variables with "cockroach debug env". To keep this report useful,
+// all relevant environment variables should be read during start up.
+func getEnv(name string) (string, bool) {
+	_, consumer, _, _ := runtime.Caller(2)
+	varName := VarName(name)
+	if f, ok := envVarRegistry[varName]; ok {
+		if f.consumer != consumer {
+			panic("environment variable " + varName + " already used from " + f.consumer)
+		}
+		return f.value, f.present
+	}
+	v, found := os.LookupEnv(varName)
+	envVarRegistry[varName] = envVarInfo{consumer: consumer, present: found, value: v}
+	return v, found
+}
+
+// ClearEnvCache clears saved environment values so that
+// a new read access the environment again. (Used for testing)
+func ClearEnvCache() {
+	envVarRegistry = make(map[string]envVarInfo)
+}
+
+// GetEnvReport dumps all configuration variables that may have been
+// used and their value.
+func GetEnvReport() string {
+	var b bytes.Buffer
+	for k, v := range envVarRegistry {
+		if v.present {
+			fmt.Fprintf(&b, "%s = %s # %s\n", k, v.value, v.consumer)
+		} else {
+			fmt.Fprintf(&b, "# %s is not set (read from %s)\n", k, v.consumer)
+		}
+	}
+	return b.String()
+}
+
+// EnvOrDefaultString returns the value set by the specified
+// environment variable, if any, otherwise the specified default
+// value.
+func EnvOrDefaultString(name string, value string) string {
+	if v, present := getEnv(name); present {
+		return v
+	}
+	return value
+}
+
+// EnvOrDefaultBool returns the value set by the specified environment
+// variable, if any, otherwise the specified default value.
+func EnvOrDefaultBool(name string, value bool) bool {
+	if str, present := getEnv(name); present {
+		v, err := strconv.ParseBool(str)
+		if err != nil {
+			log.Errorf("error parsing %s: %s", VarName(name), err)
+			return value
+		}
+		return v
+	}
+	return value
+}
+
+// EnvOrDefaultInt returns the value set by the specified environment
+// variable, if any, otherwise the specified default value.
+func EnvOrDefaultInt(name string, value int) int {
+	if str, present := getEnv(name); present {
+		v, err := strconv.ParseInt(str, 0, 0)
+		if err != nil {
+			log.Errorf("error parsing %s: %s", VarName(name), err)
+			return value
+		}
+		return int(v)
+	}
+	return value
+}
+
+// EnvOrDefaultInt64 returns the value set by the specified environment
+// variable, if any, otherwise the specified default value.
+func EnvOrDefaultInt64(name string, value int64) int64 {
+	if str, present := getEnv(name); present {
+		v, err := strconv.ParseInt(str, 0, 64)
+		if err != nil {
+			log.Errorf("error parsing %s: %s", VarName(name), err)
+			return value
+		}
+		return v
+	}
+	return value
+}
+
+// EnvOrDefaultBytes returns the value set by the specified environment
+// variable, if any, otherwise the specified default value.
+func EnvOrDefaultBytes(name string, value int64) int64 {
+	if str, present := getEnv(name); present {
+		v, err := humanizeutil.ParseBytes(str)
+		if err != nil {
+			log.Errorf("error parsing %s: %s", VarName(name), err)
+			return value
+		}
+		return v
+	}
+	return value
+}
+
+// EnvOrDefaultDuration returns the value set by the specified environment
+// variable, if any, otherwise the specified default value.
+func EnvOrDefaultDuration(name string, value time.Duration) time.Duration {
+	if str, present := getEnv(name); present {
+		v, err := time.ParseDuration(str)
+		if err != nil {
+			log.Errorf("error parsing %s: %s", VarName(name), err)
+			return value
+		}
+		return v
+	}
+	return value
+}

--- a/util/humanizeutil/humanize.go
+++ b/util/humanizeutil/humanize.go
@@ -14,7 +14,7 @@
 //
 // Author: Bram Gruneir (bram+code@cockroachlabs.com)
 
-package util
+package humanizeutil
 
 import (
 	"fmt"

--- a/util/humanizeutil/humanize_test.go
+++ b/util/humanizeutil/humanize_test.go
@@ -14,12 +14,13 @@
 //
 // Author: Bram Gruneir (bram+code@cockroachlabs.com)
 
-package util
+package humanizeutil_test
 
 import (
 	"math"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -47,16 +48,16 @@ func TestBytes(t *testing.T) {
 
 	for i, testCase := range testCases {
 		// Test IBytes.
-		if actual := IBytes(testCase.value); actual != testCase.exp {
+		if actual := humanizeutil.IBytes(testCase.value); actual != testCase.exp {
 			t.Errorf("%d: IBytes(%d) actual:%s does not match expected:%s", i, testCase.value, actual, testCase.exp)
 		}
 		// Test negative IBytes.
-		if actual := IBytes(-testCase.value); actual != testCase.expNeg {
+		if actual := humanizeutil.IBytes(-testCase.value); actual != testCase.expNeg {
 			t.Errorf("%d: IBytes(%d) actual:%s does not match expected:%s", i, -testCase.value, actual,
 				testCase.expNeg)
 		}
 		// Test ParseBytes.
-		if actual, err := ParseBytes(testCase.exp); err != nil {
+		if actual, err := humanizeutil.ParseBytes(testCase.exp); err != nil {
 			if len(testCase.parseErr) > 0 {
 				if testCase.parseErr != err.Error() {
 					t.Errorf("%d: ParseBytes(%s) caused an incorrect error actual:%s, expected:%s", i, testCase.exp,
@@ -70,7 +71,7 @@ func TestBytes(t *testing.T) {
 				testCase.parseExp)
 		}
 		// Test negative ParseBytes.
-		if actual, err := ParseBytes(testCase.expNeg); err != nil {
+		if actual, err := humanizeutil.ParseBytes(testCase.expNeg); err != nil {
 			if len(testCase.parseErrNeg) > 0 {
 				if testCase.parseErrNeg != err.Error() {
 					t.Errorf("%d: ParseBytes(%s) caused an incorrect error actual:%s, expected:%s", i, testCase.expNeg,
@@ -101,7 +102,7 @@ func TestBytes(t *testing.T) {
 		{"-10 EiB", "too large: -10 EiB"},      // our error
 	}
 	for i, testCase := range testFailCases {
-		if _, err := ParseBytes(testCase.value); err.Error() != testCase.expected {
+		if _, err := humanizeutil.ParseBytes(testCase.value); err.Error() != testCase.expected {
 			t.Errorf("%d: ParseBytes(%s) caused an incorrect error actual:%s, expected:%s", i, testCase.value, err,
 				testCase.expected)
 		}

--- a/util/randutil/rand.go
+++ b/util/randutil/rand.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"log" // Don't bring cockroach/util/log into this low-level package.
 	"math/rand"
-	"os"
-	"strconv"
+
+	"github.com/cockroachdb/cockroach/util/envutil"
 )
 
 // NewPseudoSeed generates a seed from crypto/rand.
@@ -67,21 +67,11 @@ func RandBytes(r *rand.Rand, size int) []byte {
 
 // SeedForTests seeds the random number generator and prints the seed
 // value used. This value can be specified via an environment variable
-// RANDOM_SEED=x to reuse the same value later. This function should
+// COCKROACH_RANDOM_SEED=x to reuse the same value later. This function should
 // be called from TestMain; individual tests should not touch the seed
 // of the global random number generator.
 func SeedForTests() {
-	var seed int64
-	env := os.Getenv("RANDOM_SEED")
-	if env == "" {
-		seed = NewPseudoSeed()
-	} else {
-		var err error
-		seed, err = strconv.ParseInt(env, 10, 64)
-		if err != nil {
-			panic(err)
-		}
-	}
+	seed := envutil.EnvOrDefaultInt64("random_seed", NewPseudoSeed())
 	rand.Seed(seed)
 	log.Printf("Random seed: %v", seed)
 }

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -17,11 +17,10 @@
 package timeutil
 
 import (
-	"os"
 	"time"
-)
 
-const offsetEnvKey = "COCKROACH_SIMULATED_OFFSET"
+	"github.com/cockroachdb/cockroach/util/envutil"
+)
 
 var (
 	nowFunc = time.Now
@@ -39,13 +38,8 @@ func SetTimeOffset(offset time.Duration) {
 }
 
 func initFakeTime() {
-	if offsetStr := os.Getenv(offsetEnvKey); offsetStr != "" {
-		offset, err := time.ParseDuration(offsetStr)
-		if err != nil {
-			panic(err)
-		}
-		SetTimeOffset(offset)
-	}
+	offset := envutil.EnvOrDefaultDuration("simulated_offset", 0)
+	SetTimeOffset(offset)
 }
 
 // Now returns the current local time with an optional offset specified by the

--- a/util/timeutil/time_fake_test.go
+++ b/util/timeutil/time_fake_test.go
@@ -21,14 +21,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/util/envutil"
 	_ "github.com/cockroachdb/cockroach/util/log" // for flags
 )
 
 func TestOffset(t *testing.T) {
 	for _, expectedOffset := range []time.Duration{-time.Hour, time.Hour} {
-		if err := os.Setenv(offsetEnvKey, expectedOffset.String()); err != nil {
+		if err := os.Setenv("COCKROACH_SIMULATED_OFFSET", expectedOffset.String()); err != nil {
 			t.Fatal(err)
 		}
+
+		envutil.ClearEnvCache()
 
 		initFakeTime()
 

--- a/util/tracing/annotate.go
+++ b/util/tracing/annotate.go
@@ -19,9 +19,9 @@ package tracing
 // static void annotateTrace() {
 // }
 import "C"
-import "os"
+import "github.com/cockroachdb/cockroach/util/envutil"
 
-var annotationEnabled = os.Getenv("ANNOTATE_TRACES") == "1"
+var annotationEnabled = envutil.EnvOrDefaultBool("annotate_traces", false)
 
 // AnnotateTrace adds an annotation to the golang executation tracer by calling
 // a no-op cgo function.


### PR DESCRIPTION
The order of configuration is:
1. command line flag, if set,
2. env var, if set and valid,
3. default value

For each flag "x", the env var is COCKROACH_X ("x" upper-cased)

A new CLI command "env" dumps all known environment variables.

**noteworthy**:
- "MetricsFrequency" has been renamed to "MetricsSampleInterval"
  (the accompanying env. var. is COCKROACH_METRICS_SAMPLE_INTERVAL)
- the following environment variables have been renamed:
  - ANNOTATE_TRACES -> COCKROACH_ANNOTATE_TRACES
  - RANDOM_SEED -> COCKROACH_RANDOM_SEED
  - ENABLE_LOCAL_CALLS -> COCKROACH_ENABLE_LOCAL_CALLS

Fixes #2706.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5430)

<!-- Reviewable:end -->
