### PR TITLE
storage: Hopefully de-flake TestReplicateRogueRemovedNode

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1347,6 +1347,8 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 	// lease will cause GC to do a consistent range lookup, where it
 	// will see that the range has been moved and delete the old
 	// replica.
+	mtc.manualClock.Increment(int64(storage.DefaultLeaderLeaseDuration+
+		storage.ReplicaGCQueueInactivityThreshold) + 1)
 	mtc.stores[2].ForceReplicaGCScanAndProcess()
 	mtc.waitForValues(roachpb.Key("a"), []int64{16, 0, 0})
 


### PR DESCRIPTION
Advance the clock to ensure that the range can be GC'd.
This is a shot in the dark, but my guess is that a background
scan is updating the LastReplicaGCTimestamp and preventing
this call from having an effect.

Fixes #4692

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5438)

<!-- Reviewable:end -->
