### PR TITLE
acceptance: allow "store not found" to be a retryable error

### DIFF
--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -138,7 +138,7 @@ func transferMoney(client *testClient, numAccounts, maxTransfer int) error {
 }
 
 func retryableError(err error) bool {
-	return testutils.IsError(err, "connection reset by peer") || testutils.IsError(err, "connection refused") || testutils.IsError(err, "failed to send RPC") || testutils.IsError(err, "EOF")
+	return testutils.IsError(err, "(connection reset by peer|connection refused|failed to send RPC|EOF|store.+not found)")
 }
 
 // Verify accounts.


### PR DESCRIPTION
A cockroach node can start serving before all its stores have been
bootstrapped, so when a store is not visible it would be okay to
retry the request later.

Another option is to hold the request for a while until the store
is available. Or not serve until all the stores have been bootstrapped
properly.

closes #5024

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5440)

<!-- Reviewable:end -->
