### PR TITLE
storage: move node initialization to before serving

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -295,10 +295,6 @@ func (s *Server) Start() error {
 		}))
 	})
 
-	s.stopper.RunWorker(func() {
-		util.FatalIfUnexpected(m.Serve())
-	})
-
 	s.gossip.Start(s.grpc, unresolvedAddr)
 
 	// Register admin service
@@ -330,6 +326,10 @@ func (s *Server) Start() error {
 
 	log.Infof("starting %s server at %s", s.ctx.HTTPRequestScheme(), unresolvedHTTPAddr)
 	log.Infof("starting grpc/postgres server at %s", unresolvedAddr)
+
+	s.stopper.RunWorker(func() {
+		util.FatalIfUnexpected(m.Serve())
+	})
 
 	return nil
 }


### PR DESCRIPTION
This is not guaranteed to fix the bug but I'm marking it fixed for now. Let's see if we see it after this fix.

closes #5024 

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5441)

<!-- Reviewable:end -->
