### PR TITLE
cli: Make cert flag omissions much more obvious

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -380,10 +380,26 @@ func initFlags(ctx *Context) {
 	}
 }
 
+func visitCmds(cmd *cobra.Command, fn func(*cobra.Command)) {
+	fn(cmd)
+	for _, sub := range cmd.Commands() {
+		visitCmds(sub, fn)
+	}
+}
+
+func visitFlags(cmd *cobra.Command, fn func(*pflag.Flag)) {
+	cmd.PersistentFlags().VisitAll(fn)
+	cmd.Flags().VisitAll(fn)
+}
+
 func init() {
 	initFlags(cliContext)
 
 	cobra.OnInitialize(func() {
+		visitCmds(cockroachCmd, func(cmd *cobra.Command) {
+			visitFlags(cmd, base.AddToFlagMap)
+		})
+
 		cliContext.Addr = net.JoinHostPort(connHost, connPort)
 		cliContext.HTTPAddr = net.JoinHostPort(connHost, httpPort)
 	})

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -47,9 +47,8 @@ var sqlShellCmd = &cobra.Command{
 	Long: `
 Open a sql shell running against a cockroach database.
 `,
-	RunE:          runTerm,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	RunE:         runTerm,
+	SilenceUsage: true,
 }
 
 const (
@@ -263,7 +262,10 @@ func runTerm(cmd *cobra.Command, args []string) error {
 		return errMissingParams
 	}
 
-	conn := makeSQLClient()
+	conn, err := makeSQLClient()
+	if err != nil {
+		return err
+	}
 	defer conn.Close()
 
 	if len(cliContext.execStmts) > 0 {

--- a/cli/sql_util.go
+++ b/cli/sql_util.go
@@ -142,14 +142,17 @@ func makeSQLConn(url string) *sqlConn {
 	}
 }
 
-func makeSQLClient() *sqlConn {
+func makeSQLClient() (*sqlConn, error) {
 	sqlURL := connURL
 	if len(connURL) == 0 {
-		u := cliContext.PGURL(connUser)
+		u, err := cliContext.PGURL(connUser)
+		if err != nil {
+			return nil, err
+		}
 		u.Path = connDBName
 		sqlURL = u.String()
 	}
-	return makeSQLConn(sqlURL)
+	return makeSQLConn(sqlURL), nil
 }
 
 type queryFunc func(conn *sqlConn) (*sqlRows, error)

--- a/cli/start.go
+++ b/cli/start.go
@@ -154,10 +154,15 @@ func runStart(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("cockroach server exited with error: %s", err)
 	}
 
+	pgURL, err := cliContext.PGURL(connUser)
+	if err != nil {
+		return err
+	}
+
 	tw := tabwriter.NewWriter(os.Stdout, 2, 1, 2, ' ', 0)
 	fmt.Fprintf(tw, "build:\t%s @ %s (%s)\n", info.Tag, info.Time, info.Vers)
 	fmt.Fprintf(tw, "admin:\t%s\n", cliContext.AdminURL())
-	fmt.Fprintf(tw, "sql:\t%s\n", cliContext.PGURL(connUser).String())
+	fmt.Fprintf(tw, "sql:\t%s\n", pgURL)
 	fmt.Fprintf(tw, "logs:\t%s\n", flag.Lookup("log-dir").Value)
 	for i, spec := range cliContext.Stores.Specs {
 		fmt.Fprintf(tw, "store[%d]:\t%s\n", i, spec)

--- a/cli/user.go
+++ b/cli/user.go
@@ -43,9 +43,12 @@ func runGetUser(cmd *cobra.Command, args []string) {
 		mustUsage(cmd)
 		return
 	}
-	conn := makeSQLClient()
+	conn, err := makeSQLClient()
+	if err != nil {
+		panic(err)
+	}
 	defer conn.Close()
-	err := runPrettyQuery(conn, os.Stdout,
+	err = runPrettyQuery(conn, os.Stdout,
 		makeQuery(`SELECT * FROM system.users WHERE username=$1`, args[0]))
 	if err != nil {
 		panic(err)
@@ -68,9 +71,12 @@ func runLsUsers(cmd *cobra.Command, args []string) {
 		mustUsage(cmd)
 		return
 	}
-	conn := makeSQLClient()
+	conn, err := makeSQLClient()
+	if err != nil {
+		panic(err)
+	}
 	defer conn.Close()
-	err := runPrettyQuery(conn, os.Stdout,
+	err = runPrettyQuery(conn, os.Stdout,
 		makeQuery(`SELECT username FROM system.users`))
 	if err != nil {
 		panic(err)
@@ -93,9 +99,12 @@ func runRmUser(cmd *cobra.Command, args []string) {
 		mustUsage(cmd)
 		return
 	}
-	conn := makeSQLClient()
+	conn, err := makeSQLClient()
+	if err != nil {
+		panic(err)
+	}
 	defer conn.Close()
-	err := runPrettyQuery(conn, os.Stdout,
+	err = runPrettyQuery(conn, os.Stdout,
 		makeQuery(`DELETE FROM system.users WHERE username=$1`, args[0]))
 	if err != nil {
 		panic(err)
@@ -161,7 +170,10 @@ func runSetUser(cmd *cobra.Command, args []string) {
 			panic(err)
 		}
 	}
-	conn := makeSQLClient()
+	conn, err := makeSQLClient()
+	if err != nil {
+		panic(err)
+	}
 	defer conn.Close()
 	// TODO(marc): switch to UPSERT.
 	err = runPrettyQuery(conn, os.Stdout,

--- a/cli/zone.go
+++ b/cli/zone.go
@@ -227,7 +227,10 @@ func runGetZone(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	conn := makeSQLClient()
+	conn, err := makeSQLClient()
+	if err != nil {
+		return err
+	}
 	defer conn.Close()
 
 	path, err := queryDescriptorIDPath(conn, names)
@@ -279,7 +282,10 @@ func runLsZones(cmd *cobra.Command, args []string) error {
 		mustUsage(cmd)
 		return nil
 	}
-	conn := makeSQLClient()
+	conn, err := makeSQLClient()
+	if err != nil {
+		return err
+	}
 	defer conn.Close()
 
 	zones, err := queryZones(conn)
@@ -357,7 +363,10 @@ func runRmZone(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	conn := makeSQLClient()
+	conn, err := makeSQLClient()
+	if err != nil {
+		return err
+	}
 	defer conn.Close()
 
 	if err := conn.Exec(`BEGIN`, nil); err != nil {
@@ -423,7 +432,10 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	conn := makeSQLClient()
+	conn, err := makeSQLClient()
+	if err != nil {
+		return err
+	}
 	defer conn.Close()
 
 	names, err := parseZoneName(args[0])


### PR DESCRIPTION
Fixes part of #5433.

We should make sure the ssl flags are correctly set on our end before
sending a partially populated PGURL to pg/lib, or we'll end up with a
much more esoteric error. I'm not in love with how this ties values back
to the flags names, but I'm not sure of a better way without some
rearchitecting.

Instead of the delayed and misleading error from the issue listed above,
we now get:

```
Nathans-MacBook-Pro:cockroach$ ./cockroach sql --ca-cert=certs/ca.cert --cert=certs/node.cert
Error: missing --key flag
Failed running "sql"
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5442)

<!-- Reviewable:end -->
