### PR TITLE
Add (human-friendly) start and end key flags to `debug keys`

### DIFF
--- a/cli/context.go
+++ b/cli/context.go
@@ -42,6 +42,7 @@ func (s *statementsValue) Set(value string) error {
 type debugContext struct {
 	startKey, endKey string
 	raw              bool
+	values           bool
 }
 
 // Context contains global settings for the command-line client.

--- a/cli/context.go
+++ b/cli/context.go
@@ -39,6 +39,11 @@ func (s *statementsValue) Set(value string) error {
 	return nil
 }
 
+type debugContext struct {
+	startKey, endKey string
+	raw              bool
+}
+
 // Context contains global settings for the command-line client.
 type Context struct {
 	// Embed the server context.
@@ -46,6 +51,8 @@ type Context struct {
 
 	// execStmts is a list of statements to execute.
 	execStmts statementsValue
+	// debugContext holds values used by debug cli commands.
+	debug debugContext
 }
 
 // NewContext returns a Context with default values.

--- a/cli/debug.go
+++ b/cli/debug.go
@@ -82,7 +82,33 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := db.Iterate(engine.NilKey, engine.MVCCKeyMax, printKey); err != nil {
+	from := engine.NilKey
+	to := engine.MVCCKeyMax
+	if d := cliContext.debug; d.raw {
+		if len(d.startKey) > 0 {
+			from = engine.MakeMVCCMetadataKey(roachpb.Key(d.startKey))
+		}
+		if len(d.endKey) > 0 {
+			to = engine.MakeMVCCMetadataKey(roachpb.Key(d.endKey))
+		}
+	} else {
+		if len(d.startKey) > 0 {
+			startKey, err := keys.UglyPrint(d.startKey)
+			if err != nil {
+				return err
+			}
+			from = engine.MakeMVCCMetadataKey(startKey)
+		}
+		if len(d.endKey) > 0 {
+			endKey, err := keys.UglyPrint(d.endKey)
+			if err != nil {
+				return err
+			}
+			to = engine.MakeMVCCMetadataKey(endKey)
+		}
+	}
+
+	if err := db.Iterate(from, to, printKey); err != nil {
 		return err
 	}
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -190,6 +190,15 @@ database, insecure, certs).`),
 
 	"user": wrapText(`
 Database user name.`),
+
+	"from": wrapText(`
+Start key in pretty-printed format. See also --raw.`),
+
+	"to": wrapText(`
+Exclusive end key in pretty-printed format. See also --raw.`),
+
+	"raw": wrapText(`
+Interpret keys as raw bytes.`),
 }
 
 const usageIndentation = 8
@@ -377,6 +386,14 @@ func initFlags(ctx *Context) {
 	for _, cmd := range []*cobra.Command{scanCmd, reverseScanCmd, lsRangesCmd} {
 		f := cmd.Flags()
 		f.Int64Var(&maxResults, "max-results", 1000, usage("max-results"))
+	}
+
+	// Debug commands.
+	{
+		f := debugKeysCmd.Flags()
+		f.StringVar(&cliContext.debug.startKey, "from", "", usage("from"))
+		f.StringVar(&cliContext.debug.endKey, "to", "", usage("to"))
+		f.BoolVar(&cliContext.debug.raw, "raw", false, usage("raw"))
 	}
 }
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -199,6 +199,9 @@ Exclusive end key in pretty-printed format. See also --raw.`),
 
 	"raw": wrapText(`
 Interpret keys as raw bytes.`),
+
+	"values": wrapText(`
+Print values along with their associated key.`),
 }
 
 const usageIndentation = 8
@@ -394,6 +397,7 @@ func initFlags(ctx *Context) {
 		f.StringVar(&cliContext.debug.startKey, "from", "", usage("from"))
 		f.StringVar(&cliContext.debug.endKey, "to", "", usage("to"))
 		f.BoolVar(&cliContext.debug.raw, "raw", false, usage("raw"))
+		f.BoolVar(&cliContext.debug.values, "values", false, usage("values"))
 	}
 }
 

--- a/keys/printer_test.go
+++ b/keys/printer_test.go
@@ -17,6 +17,7 @@
 package keys
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"testing"
@@ -145,6 +146,20 @@ func TestPrettyPrint(t *testing.T) {
 
 		if exp != MassagePrettyPrintedSpanForTest(test.key.String(), nil) {
 			t.Errorf("%d: expected %s, got %s", i, exp, test.key.String())
+		}
+
+		parsed, err := UglyPrint(keyInfo)
+		if err != nil {
+			if _, ok := err.(*errUglifyUnsupported); !ok {
+				t.Errorf("%d: %s: %s", i, keyInfo, err)
+			} else {
+				t.Logf("%d: skipping parsing of %s; key is unsupported: %v", i, keyInfo, err)
+			}
+		} else if exp, act := test.key, parsed; !bytes.Equal(exp, act) {
+			t.Errorf("%d: expected %q, got %q", i, exp, act)
+		}
+		if t.Failed() {
+			return
 		}
 	}
 }


### PR DESCRIPTION
Support is spotty but given that it feels like writing a parser by hand, it doesn't seem reasonable to put this on solid footing. However, it is useful for debugging and easy enough to add key types which we find us wanting to search for in the future.

Add `--values` flag to `debug keys`

which handles some common values (but by far not all).
The ones it handles are the ones I immediately plan to use it for:
RangeDescriptor, Meta, Transaction, Sequence, Raft Log entries.

The `range-descriptors` and `raft-log` subcommands could be
removed at this point, though I have not done so.

Examples:

```
/Local/RangeID/1/u/RaftLog/logIndex:44: Type:EntryNormal Term:7 Index:44  by {1 1 1}
LeaderLease [/Min,/Min)
range_id:1 origin_replica:<node_id:1 store_id:1 replica_id:1 > cmd:<header:<timestamp:<wall_time:1458589793945222748 logical:0 > replica:<node_id:0 store_id:0 replica_id:0 > range_id:1 user_priority:NORMAL read_consistency:CONSISTENT max_scan_results:0 > requests:<leader_lease:<header:<key:"" > lease:<start:<wall_time:1458589793945199512 logical:0 > expiration:<wall_time:1458589794945199512 logical:0 > replica:<node_id:1 store_id:1 replica_id:1 > > > > 

/Local/RangeID/2/r/SequenceCache/"dc1b439f-9eb5-4907-9b26-d59de523e2f2"/epoch:0/seq:7: ts=1458589774.191459078,6, key=/Local/Range/"\x93"/RangeDescriptor
range_id:4 origin_replica:<node_id:1 store_id:1 replica_id:1 > cmd:<header:<timestamp:<wall_time:1458589774191459078 logical:746 > replica:<node_id:0 store_id:0 replica_id:0 > range_id:0 user_priority:NORMAL read_consistency:CONSISTENT max_scan_results:0 > requests:<gc:<header:<key:"\225" end_key:"\226" > keys:<key:"\001k\022\226\000\001txn-\014\007\227\355\017\373O>\215L\260\256$\205\313[" timestamp:<wall_time:0 logical:0 > > > > >

/Local/Range/"\x94"/Transaction/addrKey:/id:"1fd73b08-e3a2-4bf6-a146-ebdf30032e5c": "storage/replica_command.go:1613 (*Replica).AdminSplit" id=1fd73b08 key=/Local/Range/"\x94"/RangeDescriptor rw=false pri=0.00486285 iso=SERIALIZABLE stat=COMMITTED epo=0 ts=1458589774.191459078,374 orig=1458589774.191459078,374 max=1458589774.191459078,374
1458589774.191459078,634 /Local/Range/"\x95"/RangeDescriptor: [/Table/13, /Table/14)
    Raw:range_id:4 start_key:"\225" end_key:"\226" replicas:<node_id:1 store_id:1 replica_id:1 > next_replica_id:2

1458589774.191459078,6 /Local/Range/""/RangeDescriptor: [/Min, /Table/11)
    Raw:range_id:1 start_key:"" end_key:"\223" replicas:<node_id:1 store_id:1 replica_id:1 > next_replica_id:2

1458589774.191459078,634 /Meta2/Table/14: [/Table/13, /Table/14)
    Raw:range_id:4 start_key:"\225" end_key:"\226" replicas:<node_id:1 store_id:1 replica_id:1 > next_replica_id:2
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5444)

<!-- Reviewable:end -->
