### PR TITLE
TxnCoordSender's heartbeat uses Context cancellation when available

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -409,7 +409,9 @@ func (db *DB) RunWithResponse(b *Batch) (*roachpb.BatchResponse, *roachpb.Error)
 //
 // If you need more control over how the txn is executed, check out txn.Exec().
 func (db *DB) Txn(retryable func(txn *Txn) *roachpb.Error) *roachpb.Error {
-	txn := NewTxn(*db)
+	// TODO(dan): This context should, at longest, live for the lifetime of this
+	// method. Add a defered cancel.
+	txn := NewTxn(context.TODO(), *db)
 	txn.SetDebugName("", 1)
 	pErr := txn.Exec(TxnExecOptions{AutoRetry: true, AutoCommit: true},
 		func(txn *Txn, _ *TxnExecOptions) *roachpb.Error {

--- a/client/txn.go
+++ b/client/txn.go
@@ -112,11 +112,11 @@ type Txn struct {
 }
 
 // NewTxn returns a new txn.
-func NewTxn(db DB) *Txn {
+func NewTxn(ctx context.Context, db DB) *Txn {
 	txn := &Txn{
 		db:      db,
 		wrapped: db.sender,
-		Context: context.Background(),
+		Context: ctx,
 	}
 	txn.db.sender = (*txnSender)(txn)
 	return txn

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -150,7 +150,7 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 		return br, nil
 	}))
 
-	txn := NewTxn(*db)
+	txn := NewTxn(context.Background(), *db)
 
 	for testIdx = range testCases {
 		if _, pErr := txn.db.sender.Send(context.Background(), ba); pErr != nil {
@@ -166,7 +166,7 @@ func TestTxnResetTxnOnAbort(t *testing.T) {
 		return nil, roachpb.NewErrorWithTxn(&roachpb.TransactionAbortedError{}, ba.Txn)
 	}, nil))
 
-	txn := NewTxn(*db)
+	txn := NewTxn(context.Background(), *db)
 	_, pErr := txn.db.sender.Send(context.Background(), testPut())
 	if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
 		t.Fatalf("expected TransactionAbortedError, got %v", pErr)
@@ -523,7 +523,7 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 			return ba.CreateReply(), nil
 		}, nil))
 
-		txn := NewTxn(*db)
+		txn := NewTxn(context.Background(), *db)
 		if pErr := txn.Put("a", "b"); pErr != nil {
 			t.Fatalf("put failed: %s", pErr)
 		}
@@ -550,7 +550,7 @@ func TestTransactionStatus(t *testing.T) {
 	db := NewDB(newTestSender(nil, nil))
 	for _, write := range []bool{true, false} {
 		for _, commit := range []bool{true, false} {
-			txn := NewTxn(*db)
+			txn := NewTxn(context.Background(), *db)
 
 			if _, pErr := txn.Get("a"); pErr != nil {
 				t.Fatal(pErr)
@@ -582,7 +582,7 @@ func TestTransactionStatus(t *testing.T) {
 func TestCommitInBatchWithResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	db := NewDB(newTestSender(nil, nil))
-	txn := NewTxn(*db)
+	txn := NewTxn(context.Background(), *db)
 	b := &Batch{}
 	if _, pErr := txn.CommitInBatchWithResponse(b); pErr == nil {
 		t.Error("this batch should not be committed")
@@ -594,7 +594,7 @@ func TestCommitInBatchWithResponse(t *testing.T) {
 func TestTimestampSelectionInOptions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	db := newDB(newTestSender(nil, nil))
-	txn := NewTxn(*db)
+	txn := NewTxn(context.Background(), *db)
 
 	var execOpt TxnExecOptions
 	refTimestamp := roachpb.Timestamp{WallTime: 42, Logical: 69}
@@ -638,7 +638,7 @@ func TestSetPriority(t *testing.T) {
 
 	// Verify the normal priority setting path.
 	expected = roachpb.HighUserPriority
-	txn := NewTxn(*db)
+	txn := NewTxn(context.Background(), *db)
 	if err := txn.SetUserPriority(expected); err != nil {
 		t.Fatal(err)
 	}
@@ -648,7 +648,7 @@ func TestSetPriority(t *testing.T) {
 
 	// Verify the internal (fixed value) priority setting path.
 	expected = roachpb.UserPriority(-13)
-	txn = NewTxn(*db)
+	txn = NewTxn(context.Background(), *db)
 	txn.InternalSetPriority(13)
 	if _, pErr := txn.db.sender.Send(context.Background(), roachpb.BatchRequest{}); pErr != nil {
 		t.Fatal(pErr)

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -542,12 +542,17 @@ func (tc *TxnCoordSender) unregisterTxnLocked(txnID uuid.UUID) (duration, restar
 	return duration, restarts, status
 }
 
-// heartbeatLoop periodically sends a HeartbeatTxn RPC to an extant
-// transaction, stopping in the event the transaction is aborted or
-// committed after attempting to resolve the intents. When the
-// heartbeat stops, the transaction is unregistered from the
-// coordinator,
-func (tc *TxnCoordSender) heartbeatLoop(txnID uuid.UUID) {
+// heartbeatLoop periodically sends a HeartbeatTxn RPC to an extant transaction,
+// stopping in the event the transaction is aborted or committed after
+// attempting to resolve the intents. When the heartbeat stops, the transaction
+// is unregistered from the coordinator.
+//
+// TODO(dan): The Context we use for this is currently the one from the first
+// request in a Txn, but the semantics of this aren't good. Each context has its
+// own associated lifetime and we're ignoring all but the first. It happens now
+// that we pass the same one in every request, but it's brittle to rely on this
+// forever.
+func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context, txnID uuid.UUID) {
 	var tickChan <-chan time.Time
 	{
 		ticker := time.NewTicker(tc.heartbeatInterval)
@@ -566,7 +571,7 @@ func (tc *TxnCoordSender) heartbeatLoop(txnID uuid.UUID) {
 	// which starts this goroutine.
 	sp := tc.tracer.StartSpan(opHeartbeatLoop)
 	defer sp.Finish()
-	ctx := opentracing.ContextWithSpan(context.Background(), sp)
+	ctx = opentracing.ContextWithSpan(ctx, sp)
 
 	{
 		tc.Lock()
@@ -589,35 +594,37 @@ func (tc *TxnCoordSender) heartbeatLoop(txnID uuid.UUID) {
 		case <-closer:
 			// Transaction finished normally.
 			return
-
+		case <-ctx.Done():
+			// Note that if ctx is not cancellable, then ctx.Done() returns a nil
+			// channel, which blocks forever. In this case, the heartbeat loop is
+			// responsible for timing out transactions. If ctx.Done() is not nil, then
+			// then heartbeat loop ignores the timeout check and this case is
+			// responsible for client timeouts.
+			tc.clientHasAbandoned(txnID)
+			return
 		case <-tc.stopper.ShouldDrain():
 			return
 		}
 	}
 }
 
-func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
+func (tc *TxnCoordSender) clientHasAbandoned(txnID uuid.UUID) {
 	tc.Lock()
-	proceed := true
 	txnMeta := tc.txns[txnID]
 	var intentSpans []roachpb.Span
-	// Before we send a heartbeat, determine whether this transaction
-	// should be considered abandoned. If so, exit heartbeat.
-	if txnMeta.hasClientAbandonedCoord(tc.clock.PhysicalNow()) {
-		// TODO(tschottdorf): should we be more proactive here?
-		// The client might be continuing the transaction
-		// through another coordinator, but in the most likely
-		// case it's just gone and the open transaction record
-		// could block concurrent operations.
-		if log.V(1) {
-			log.Infof("transaction %s abandoned; stopping heartbeat",
-				txnMeta.txn)
-		}
-		proceed = false
-		// Grab the intents here to avoid potential race.
-		intentSpans = collectIntentSpans(txnMeta.keys)
-		txnMeta.keys.Clear()
+
+	// TODO(tschottdorf): should we be more proactive here?
+	// The client might be continuing the transaction
+	// through another coordinator, but in the most likely
+	// case it's just gone and the open transaction record
+	// could block concurrent operations.
+	if log.V(1) {
+		log.Infof("transaction %s abandoned; stopping heartbeat", txnMeta.txn)
 	}
+	// Grab the intents here to avoid potential race.
+	intentSpans = collectIntentSpans(txnMeta.keys)
+	txnMeta.keys.Clear()
+
 	// txnMeta.txn is possibly replaced concurrently,
 	// so grab a copy before unlocking.
 	txn := txnMeta.txn.Clone()
@@ -626,30 +633,46 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
 	ba := roachpb.BatchRequest{}
 	ba.Txn = &txn
 
-	if !proceed {
-		// Actively abort the transaction and its intents since we assume it's abandoned.
-		et := &roachpb.EndTransactionRequest{
-			Span: roachpb.Span{
-				Key: txn.Key,
-			},
-			Commit:      false,
-			IntentSpans: intentSpans,
-		}
-		ba.Add(et)
-		tc.stopper.RunAsyncTask(func() {
-			// Use the wrapped sender since the normal Sender
-			// does not allow clients to specify intents.
-			// TODO(tschottdorf): not using the existing context here since that
-			// leads to use-after-finish of the contained trace. Should fork off
-			// before the goroutine.
-			if _, pErr := tc.wrapped.Send(context.Background(), ba); pErr != nil {
-				if log.V(1) {
-					log.Warningf("abort due to inactivity failed for %s: %s ", txn, pErr)
-				}
+	// Actively abort the transaction and its intents since we assume it's abandoned.
+	et := &roachpb.EndTransactionRequest{
+		Span: roachpb.Span{
+			Key: txn.Key,
+		},
+		Commit:      false,
+		IntentSpans: intentSpans,
+	}
+	ba.Add(et)
+	tc.stopper.RunAsyncTask(func() {
+		// Use the wrapped sender since the normal Sender
+		// does not allow clients to specify intents.
+		// TODO(tschottdorf): not using the existing context here since that
+		// leads to use-after-finish of the contained trace. Should fork off
+		// before the goroutine.
+		if _, pErr := tc.wrapped.Send(context.Background(), ba); pErr != nil {
+			if log.V(1) {
+				log.Warningf("abort due to inactivity failed for %s: %s ", txn, pErr)
 			}
-		})
+		}
+	})
+}
+
+func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
+	tc.Lock()
+	txnMeta := tc.txns[txnID]
+	txn := txnMeta.txn.Clone()
+	tc.Unlock()
+
+	// Before we send a heartbeat, determine whether this transaction should be
+	// considered abandoned. If so, exit heartbeat. If ctx.Done() is not nil, then
+	// it is a cancellable Context and we skip this check and use the ctx lifetime
+	// instead of a timeout.
+	if ctx.Done() == nil && txnMeta.hasClientAbandonedCoord(tc.clock.PhysicalNow()) {
+		tc.clientHasAbandoned(txnID)
 		return false
 	}
+
+	ba := roachpb.BatchRequest{}
+	ba.Txn = &txn
 
 	hb := &roachpb.HeartbeatTxnRequest{
 		Now: tc.clock.Now(),
@@ -801,7 +824,7 @@ func (tc *TxnCoordSender) updateState(ctx context.Context, ba roachpb.BatchReque
 				tc.txns[txnID] = txnMeta
 
 				if !tc.stopper.RunAsyncTask(func() {
-					tc.heartbeatLoop(txnID)
+					tc.heartbeatLoop(ctx, txnID)
 				}) {
 					// The system is already draining and we can't start the
 					// heartbeat. We refuse new transactions for now because

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -18,6 +18,7 @@ package kv
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -90,7 +91,7 @@ func TestTxnCoordSenderAddRequest(t *testing.T) {
 	defer s.Stop()
 	defer teardownHeartbeats(s.Sender)
 
-	txn := client.NewTxn(*s.DB)
+	txn := client.NewTxn(context.Background(), *s.DB)
 
 	// Put request will create a new transaction.
 	if err := txn.Put(roachpb.Key("a"), []byte("value")); err != nil {
@@ -131,7 +132,7 @@ func TestTxnCoordSenderBeginTransaction(t *testing.T) {
 	defer s.Stop()
 	defer teardownHeartbeats(s.Sender)
 
-	txn := client.NewTxn(*s.DB)
+	txn := client.NewTxn(context.Background(), *s.DB)
 
 	// Put request will create a new transaction.
 	key := roachpb.Key("key")
@@ -163,7 +164,7 @@ func TestTxnInitialTimestamp(t *testing.T) {
 	defer s.Stop()
 	defer teardownHeartbeats(s.Sender)
 
-	txn := client.NewTxn(*s.DB)
+	txn := client.NewTxn(context.Background(), *s.DB)
 
 	// Request a specific timestamp.
 	refTimestamp := roachpb.Timestamp{WallTime: 42, Logical: 69}
@@ -193,7 +194,7 @@ func TestTxnCoordSenderBeginTransactionMinPriority(t *testing.T) {
 	defer s.Stop()
 	defer teardownHeartbeats(s.Sender)
 
-	txn := client.NewTxn(*s.DB)
+	txn := client.NewTxn(context.Background(), *s.DB)
 
 	// Put request will create a new transaction.
 	key := roachpb.Key("key")
@@ -228,7 +229,7 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 	defer s.Stop()
 	defer teardownHeartbeats(s.Sender)
 
-	txn := client.NewTxn(*s.DB)
+	txn := client.NewTxn(context.Background(), *s.DB)
 	for _, rng := range ranges {
 		if rng.end != nil {
 			if err := txn.DelRange(rng.start, rng.end); err != nil {
@@ -262,8 +263,8 @@ func TestTxnCoordSenderMultipleTxns(t *testing.T) {
 	defer s.Stop()
 	defer teardownHeartbeats(s.Sender)
 
-	txn1 := client.NewTxn(*s.DB)
-	txn2 := client.NewTxn(*s.DB)
+	txn1 := client.NewTxn(context.Background(), *s.DB)
+	txn2 := client.NewTxn(context.Background(), *s.DB)
 
 	if err := txn1.Put(roachpb.Key("a"), []byte("value")); err != nil {
 		t.Fatal(err)
@@ -288,7 +289,7 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 	// Set heartbeat interval to 1ms for testing.
 	s.Sender.heartbeatInterval = 1 * time.Millisecond
 
-	initialTxn := client.NewTxn(*s.DB)
+	initialTxn := client.NewTxn(context.Background(), *s.DB)
 	if err := initialTxn.Put(roachpb.Key("a"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +363,7 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 	// 4 cases: no deadline, past deadline, equal deadline, future deadline.
 	for i := 0; i < 4; i++ {
 		key := roachpb.Key("key: " + strconv.Itoa(i))
-		txn := client.NewTxn(*s.DB)
+		txn := client.NewTxn(context.Background(), *s.DB)
 		// Initialize the transaction
 		if pErr := txn.Put(key, []byte("value")); pErr != nil {
 			t.Fatal(pErr)
@@ -421,7 +422,7 @@ func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 
 	// Create a transaction with intent at "a".
 	key := roachpb.Key("x")
-	txn := client.NewTxn(*s.DB)
+	txn := client.NewTxn(context.Background(), *s.DB)
 	// Write so that the coordinator begins tracking this txn.
 	if err := txn.Put("x", "y"); err != nil {
 		t.Fatal(err)
@@ -453,14 +454,14 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 
 	// Create a transaction with intent at "a".
 	key := roachpb.Key("a")
-	txn1 := client.NewTxn(*s.DB)
+	txn1 := client.NewTxn(context.Background(), *s.DB)
 	txn1.InternalSetPriority(1)
 	if pErr := txn1.Put(key, []byte("value")); pErr != nil {
 		t.Fatal(pErr)
 	}
 
 	// Push the transaction (by writing key "a" with higher priority) to abort it.
-	txn2 := client.NewTxn(*s.DB)
+	txn2 := client.NewTxn(context.Background(), *s.DB)
 	txn2.InternalSetPriority(2)
 	if pErr := txn2.Put(key, []byte("value2")); pErr != nil {
 		t.Fatal(pErr)
@@ -481,9 +482,9 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 	verifyCleanup(key, s.Sender, s.Eng, t)
 }
 
-// TestTxnCoordSenderGC verifies that the coordinator cleans up extant
+// TestTxnCoordSenderGCTimeout verifies that the coordinator cleans up extant
 // transactions and intents after the lastUpdateNanos exceeds the timeout.
-func TestTxnCoordSenderGC(t *testing.T) {
+func TestTxnCoordSenderGCTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := createTestDB(t)
 	defer s.Stop()
@@ -491,7 +492,7 @@ func TestTxnCoordSenderGC(t *testing.T) {
 	// Set heartbeat interval to 1ms for testing.
 	s.Sender.heartbeatInterval = 1 * time.Millisecond
 
-	txn := client.NewTxn(*s.DB)
+	txn := client.NewTxn(context.Background(), *s.DB)
 	key := roachpb.Key("a")
 	if pErr := txn.Put(key, []byte("value")); pErr != nil {
 		t.Fatal(pErr)
@@ -505,6 +506,72 @@ func TestTxnCoordSenderGC(t *testing.T) {
 
 	txnID := *txn.Proto.ID
 
+	util.SucceedsSoon(t, func() error {
+		// Locking the TxnCoordSender to prevent a data race.
+		s.Sender.Lock()
+		_, ok := s.Sender.txns[txnID]
+		s.Sender.Unlock()
+		if ok {
+			return util.Errorf("expected garbage collection")
+		}
+		return nil
+	})
+
+	verifyCleanup(key, s.Sender, s.Eng, t)
+}
+
+// TestTxnCoordSenderGCWithCancel verifies that the coordinator cleans up extant
+// transactions and intents after transaction context is cancelled.
+func TestTxnCoordSenderGCWithCancel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s := createTestDB(t)
+	defer s.Stop()
+
+	// Set heartbeat interval to 1ms for testing.
+	s.Sender.heartbeatInterval = 1 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	txn := client.NewTxn(ctx, *s.DB)
+	key := roachpb.Key("a")
+	if pErr := txn.Put(key, []byte("value")); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	// Now, advance clock past the default client timeout.
+	// Locking the TxnCoordSender to prevent a data race.
+	s.Sender.Lock()
+	s.Manual.Set(defaultClientTimeout.Nanoseconds() + 1)
+	s.Sender.Unlock()
+
+	txnID := *txn.Proto.ID
+
+	// Verify that the transaction is alive despite the timeout having been
+	// exceeded.
+	errStillActive := errors.New("transaction is still active")
+	// TODO(dan): Figure out how to run the heartbeat manually instead of this.
+	if err := util.RetryForDuration(1*time.Second, func() error {
+		// Locking the TxnCoordSender to prevent a data race.
+		s.Sender.Lock()
+		_, ok := s.Sender.txns[txnID]
+		s.Sender.Unlock()
+		if !ok {
+			return nil
+		}
+		meta := &engine.MVCCMetadata{}
+		ok, _, _, err := s.Eng.GetProto(engine.MakeMVCCMetadataKey(key), meta)
+		if err != nil {
+			t.Fatalf("error getting MVCC metadata: %s", err)
+		}
+		if !ok || meta.Txn == nil {
+			return nil
+		}
+		return errStillActive
+	}); err != errStillActive {
+		t.Fatalf("expected transaction to be active, got: %v", err)
+	}
+
+	// After the context is cancelled, the transaction should be cleaned up.
+	cancel()
 	util.SucceedsSoon(t, func() error {
 		// Locking the TxnCoordSender to prevent a data race.
 		s.Sender.Lock()
@@ -609,7 +676,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			return reply, test.pErr
 		}), clock, false, tracing.NewTracer(), stopper, NewTxnMetrics(metric.NewRegistry()))
 		db := client.NewDB(ts)
-		txn := client.NewTxn(*db)
+		txn := client.NewTxn(context.Background(), *db)
 		txn.InternalSetPriority(1)
 		txn.Proto.Name = "test txn"
 		key := roachpb.Key("test-key")
@@ -650,7 +717,7 @@ func TestTxnCoordIdempotentCleanup(t *testing.T) {
 	defer s.Stop()
 	defer teardownHeartbeats(s.Sender)
 
-	txn := client.NewTxn(*s.DB)
+	txn := client.NewTxn(context.Background(), *s.DB)
 	ba := txn.NewBatch()
 	ba.Put(roachpb.Key("a"), []byte("value"))
 	if pErr := txn.Run(ba); pErr != nil {
@@ -818,7 +885,7 @@ func TestTxnCoordSenderReleaseTxnMeta(t *testing.T) {
 	defer s.Stop()
 	defer teardownHeartbeats(s.Sender)
 
-	txn := client.NewTxn(*s.DB)
+	txn := client.NewTxn(context.Background(), *s.DB)
 	ba := txn.NewBatch()
 	ba.Put(roachpb.Key("a"), []byte("value"))
 	ba.Put(roachpb.Key("b"), []byte("value"))
@@ -864,7 +931,7 @@ func TestTxnCoordSenderNoDuplicateIntents(t *testing.T) {
 	defer teardownHeartbeats(ts)
 
 	db := client.NewDB(ts)
-	txn := client.NewTxn(*db)
+	txn := client.NewTxn(context.Background(), *db)
 
 	// Write to a, b, u-w before the final batch.
 
@@ -1112,7 +1179,7 @@ func TestTxnRestartCount(t *testing.T) {
 	db := client.NewDB(sender)
 
 	// Start a transaction and do a GET. This forces a timestamp to be chosen for the transaction.
-	txn := client.NewTxn(*db)
+	txn := client.NewTxn(context.Background(), *db)
 	if _, err := txn.Get(key); err != nil {
 		t.Fatal(err)
 	}
@@ -1180,5 +1247,32 @@ func TestTxnDurations(t *testing.T) {
 
 	if min := hist.Min(); min < incr {
 		t.Fatalf("min %d < %d", min, incr)
+	}
+}
+
+// We rely on context.Background() having a nil Done() channel. It's documented
+// as "Done may return nil if this context can never be canceled", so we check
+// that the "may" is actually "will".
+//
+// TODO(dan): If this ever breaks, we can do something with the context values:
+// type contextLifetimeKey struct{}
+// func SetIsContextLifetime(ctx) context.Context {
+//   return context.WithValue(ctx, contextLifetimeKey{}, struct{}{})
+// }
+// func HasContextLifetime(ctx) bool {
+//   _, ok := ctx.Value(contextLifetimeKey{})
+//   return ok
+// }
+//
+// In TxnCoordSender:
+// func heartbeatLoop(ctx context.Context, ...) {
+//   if !HasContextLifetime(ctx) && txnMeta.hasClientAbandonedCoord ... {
+//     tc.clientHasAbandoned(txnID)
+//   }
+// }
+func TestContextDoneNil(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	if context.Background().Done() != nil {
+		t.Error("context.Background().Done()'s behavior has changed")
 	}
 }

--- a/server/admin.go
+++ b/server/admin.go
@@ -256,9 +256,9 @@ func (s *adminServer) firstNotFoundError(results []sql.Result) *roachpb.Error {
 }
 
 // Databases is an endpoint that returns a list of databases.
-func (s *adminServer) Databases(_ context.Context, req *DatabasesRequest) (*DatabasesResponse, error) {
+func (s *adminServer) Databases(ctx context.Context, req *DatabasesRequest) (*DatabasesResponse, error) {
 	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.sqlExecutor, nil)
-	r := s.sqlExecutor.ExecuteStatements(session, "SHOW DATABASES;", nil)
+	r := s.sqlExecutor.ExecuteStatements(ctx, session, "SHOW DATABASES;", nil)
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, s.serverError(err)
 	}
@@ -277,7 +277,7 @@ func (s *adminServer) Databases(_ context.Context, req *DatabasesRequest) (*Data
 
 // DatabaseDetails is an endpoint that returns grants and a list of table names
 // for the specified database.
-func (s *adminServer) DatabaseDetails(_ context.Context, req *DatabaseDetailsRequest) (*DatabaseDetailsResponse, error) {
+func (s *adminServer) DatabaseDetails(ctx context.Context, req *DatabaseDetailsRequest) (*DatabaseDetailsResponse, error) {
 	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.sqlExecutor, nil)
 
 	// Placeholders don't work with SHOW statements, so we need to manually
@@ -286,7 +286,7 @@ func (s *adminServer) DatabaseDetails(_ context.Context, req *DatabaseDetailsReq
 	// TODO(cdo): Use placeholders when they're supported by SHOW.
 	escDBName := parser.Name(req.Database).String()
 	query := fmt.Sprintf("SHOW GRANTS ON DATABASE %s; SHOW TABLES FROM %s;", escDBName, escDBName)
-	r := s.sqlExecutor.ExecuteStatements(session, query, nil)
+	r := s.sqlExecutor.ExecuteStatements(ctx, session, query, nil)
 	if pErr := s.firstNotFoundError(r.ResultList); pErr != nil {
 		return nil, grpc.Errorf(codes.NotFound, "%s", pErr)
 	}
@@ -339,7 +339,7 @@ func (s *adminServer) DatabaseDetails(_ context.Context, req *DatabaseDetailsReq
 
 // TableDetails is an endpoint that returns columns, indices, and other
 // relevant details for the specified table.
-func (s *adminServer) TableDetails(_ context.Context, req *TableDetailsRequest) (
+func (s *adminServer) TableDetails(ctx context.Context, req *TableDetailsRequest) (
 	*TableDetailsResponse, error) {
 	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.sqlExecutor, nil)
 
@@ -350,7 +350,7 @@ func (s *adminServer) TableDetails(_ context.Context, req *TableDetailsRequest) 
 	escQualTable := fmt.Sprintf("%s.%s", escDbName, escTableName)
 	query := fmt.Sprintf("SHOW COLUMNS FROM %s; SHOW INDEX FROM %s; SHOW GRANTS ON TABLE %s",
 		escQualTable, escQualTable, escQualTable)
-	r := s.sqlExecutor.ExecuteStatements(session, query, nil)
+	r := s.sqlExecutor.ExecuteStatements(ctx, session, query, nil)
 	if pErr := s.firstNotFoundError(r.ResultList); pErr != nil {
 		return nil, grpc.Errorf(codes.NotFound, "%s", pErr)
 	}
@@ -483,10 +483,10 @@ func (s *adminServer) TableDetails(_ context.Context, req *TableDetailsRequest) 
 }
 
 // Users returns a list of users, stripped of any passwords.
-func (s *adminServer) Users(c context.Context, req *UsersRequest) (*UsersResponse, error) {
+func (s *adminServer) Users(ctx context.Context, req *UsersRequest) (*UsersResponse, error) {
 	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.sqlExecutor, nil)
 	query := "SELECT username FROM system.users"
-	r := s.sqlExecutor.ExecuteStatements(session, query, nil)
+	r := s.sqlExecutor.ExecuteStatements(ctx, session, query, nil)
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, s.serverError(err)
 	}
@@ -503,7 +503,7 @@ func (s *adminServer) Users(c context.Context, req *UsersRequest) (*UsersRespons
 //
 // type=STRING  returns events with this type (e.g. "create_table")
 // targetID=INT returns events for that have this targetID
-func (s *adminServer) Events(c context.Context, req *EventsRequest) (*EventsResponse, error) {
+func (s *adminServer) Events(ctx context.Context, req *EventsRequest) (*EventsResponse, error) {
 	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.sqlExecutor, nil)
 
 	// Execute the query.
@@ -522,7 +522,7 @@ func (s *adminServer) Events(c context.Context, req *EventsRequest) (*EventsResp
 	if len(q.Errors()) > 0 {
 		return nil, s.serverErrors(q.Errors())
 	}
-	r := s.sqlExecutor.ExecuteStatements(session, q.String(), q.Params())
+	r := s.sqlExecutor.ExecuteStatements(ctx, session, q.String(), q.Params())
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, s.serverError(err)
 	}
@@ -567,7 +567,7 @@ func (s *adminServer) getUIData(session *sql.Session, user, key string) ([]byte,
 	// Query database.
 	query := "SELECT value, lastUpdated FROM system.ui WHERE key = $1"
 	params := []parser.Datum{parser.DString(key)}
-	r := s.sqlExecutor.ExecuteStatements(session, query, params)
+	r := s.sqlExecutor.ExecuteStatements(context.Background(), session, query, params)
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, zeroTimestamp, s.serverError(err)
 	}
@@ -593,7 +593,7 @@ func (s *adminServer) getUIData(session *sql.Session, user, key string) ([]byte,
 
 // SetUIData is an endpoint that stores the given key/value pairs in the
 // system.ui table.
-func (s *adminServer) SetUIData(_ context.Context, req *SetUIDataRequest) (*SetUIDataResponse, error) {
+func (s *adminServer) SetUIData(ctx context.Context, req *SetUIDataRequest) (*SetUIDataResponse, error) {
 	if len(req.KeyValues) == 0 {
 		return nil, grpc.Errorf(codes.InvalidArgument, "KeyValues cannot be empty")
 	}
@@ -616,7 +616,7 @@ func (s *adminServer) SetUIData(_ context.Context, req *SetUIDataRequest) (*SetU
 
 		// Do an upsert of the key. We update each key in a separate transaction to
 		// avoid long-running transactions and possible deadlocks.
-		br := s.sqlExecutor.ExecuteStatements(session, "BEGIN;", nil)
+		br := s.sqlExecutor.ExecuteStatements(ctx, session, "BEGIN;", nil)
 		if err := s.checkQueryResults(br.ResultList, 1); err != nil {
 			return nil, s.serverError(err)
 		}
@@ -637,7 +637,7 @@ func (s *adminServer) SetUIData(_ context.Context, req *SetUIDataRequest) (*SetU
 				parser.DString(val), // $1
 				parser.DString(key), // $2
 			}
-			r := s.sqlExecutor.ExecuteStatements(session, query, params)
+			r := s.sqlExecutor.ExecuteStatements(ctx, session, query, params)
 			if err := s.checkQueryResults(r.ResultList, 2); err != nil {
 				return nil, s.serverError(err)
 			}
@@ -650,7 +650,7 @@ func (s *adminServer) SetUIData(_ context.Context, req *SetUIDataRequest) (*SetU
 				parser.DString(key), // $1
 				parser.DBytes(val),  // $2
 			}
-			r := s.sqlExecutor.ExecuteStatements(session, query, params)
+			r := s.sqlExecutor.ExecuteStatements(ctx, session, query, params)
 			if err := s.checkQueryResults(r.ResultList, 2); err != nil {
 				return nil, s.serverError(err)
 			}

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/testutils"
@@ -159,7 +161,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 	const testdb = "test"
 	session := sql.NewSession(sql.SessionArgs{User: security.RootUser}, s.sqlExecutor, nil)
 	query := "CREATE DATABASE " + testdb
-	createRes := s.sqlExecutor.ExecuteStatements(session, query, nil)
+	createRes := s.sqlExecutor.ExecuteStatements(context.Background(), session, query, nil)
 	if createRes.ResultList[0].PErr != nil {
 		t.Fatal(createRes.ResultList[0].PErr)
 	}
@@ -186,7 +188,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 	privileges := []string{"SELECT", "UPDATE"}
 	testuser := "testuser"
 	grantQuery := "GRANT " + strings.Join(privileges, ", ") + " ON DATABASE " + testdb + " TO " + testuser
-	grantRes := s.sqlExecutor.ExecuteStatements(session, grantQuery, nil)
+	grantRes := s.sqlExecutor.ExecuteStatements(context.Background(), session, grantQuery, nil)
 	if grantRes.ResultList[0].PErr != nil {
 		t.Fatal(grantRes.ResultList[0].PErr)
 	}
@@ -293,7 +295,7 @@ CREATE TABLE test.tbl (
 	}
 
 	for _, q := range setupQueries {
-		res := s.sqlExecutor.ExecuteStatements(session, q, nil)
+		res := s.sqlExecutor.ExecuteStatements(context.Background(), session, q, nil)
 		if res.ResultList[0].PErr != nil {
 			t.Fatalf("error executing '%s': %s", q, res.ResultList[0].PErr)
 		}
@@ -374,7 +376,7 @@ func TestAdminAPIUsers(t *testing.T) {
 	query := `
 INSERT INTO system.users (username, hashedPassword)
 VALUES ('admin', 'abc'), ('bob', 'xyz')`
-	res := s.sqlExecutor.ExecuteStatements(session, query, nil)
+	res := s.sqlExecutor.ExecuteStatements(context.Background(), session, query, nil)
 	if a, e := len(res.ResultList), 1; a != e {
 		t.Fatalf("len(results) %d != %d", a, e)
 	} else if res.ResultList[0].PErr != nil {
@@ -417,7 +419,7 @@ func TestAdminAPIEvents(t *testing.T) {
 		"DROP TABLE api_test.tbl2",
 	}
 	for _, q := range setupQueries {
-		res := s.sqlExecutor.ExecuteStatements(session, q, nil)
+		res := s.sqlExecutor.ExecuteStatements(context.Background(), session, q, nil)
 		if res.ResultList[0].PErr != nil {
 			t.Fatalf("error executing '%s': %s", q, res.ResultList[0].PErr)
 		}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
 	"gopkg.in/inf.v0"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -246,7 +247,7 @@ func (e *Executor) getSystemConfig() (config.SystemConfig, *databaseCache) {
 // Prepare returns the result types of the given statement. Args may be a
 // partially populated val args map. Prepare will populate the missing val
 // args. The column result types are returned (or nil if there are no results).
-func (e *Executor) Prepare(query string, session *Session, args parser.MapArgs) (
+func (e *Executor) Prepare(ctx context.Context, query string, session *Session, args parser.MapArgs) (
 	[]ResultColumn, *roachpb.Error) {
 	stmt, err := parser.ParseOne(query, parser.Syntax(session.Syntax))
 	if err != nil {
@@ -258,7 +259,7 @@ func (e *Executor) Prepare(query string, session *Session, args parser.MapArgs) 
 	session.planner.evalCtx.PrepareOnly = true
 
 	// TODO(andrei): does the prepare phase really need a Txn?
-	txn := client.NewTxn(*e.ctx.DB)
+	txn := client.NewTxn(ctx, *e.ctx.DB)
 	txn.Proto.Isolation = session.DefaultIsolationLevel
 	session.planner.setTxn(txn)
 	defer session.planner.setTxn(nil)
@@ -282,7 +283,7 @@ func (e *Executor) Prepare(query string, session *Session, args parser.MapArgs) 
 // ExecuteStatements executes the given statement(s) and returns a response.
 // On error, the returned integer is an HTTP error code.
 func (e *Executor) ExecuteStatements(
-	session *Session, stmts string,
+	ctx context.Context, session *Session, stmts string,
 	params []parser.Datum) StatementResults {
 
 	session.planner.resetForBatch(e)
@@ -290,7 +291,7 @@ func (e *Executor) ExecuteStatements(
 
 	// Send the Request for SQL execution and set the application-level error
 	// for each result in the reply.
-	res := e.execRequest(session, stmts)
+	res := e.execRequest(ctx, session, stmts)
 	return res
 }
 
@@ -326,7 +327,7 @@ func (e *Executor) waitForConfigUpdate() {
 // Args:
 //  txnState: State about about ongoing transaction (if any). The state will be
 //   updated.
-func (e *Executor) execRequest(session *Session, sql string) StatementResults {
+func (e *Executor) execRequest(ctx context.Context, session *Session, sql string) StatementResults {
 	var res StatementResults
 	txnState := &session.TxnState
 	planMaker := &session.planner
@@ -369,7 +370,7 @@ func (e *Executor) execRequest(session *Session, sql string) StatementResults {
 				execOpt.AutoCommit = true
 				stmtsToExec = stmtsToExec[0:1]
 			}
-			txnState.reset(e, session)
+			txnState.reset(ctx, e, session)
 			txnState.State = Open
 			txnState.autoRetry = true
 			execOpt.MinInitialTimestamp = e.ctx.Clock.Now()

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -24,6 +24,8 @@ import (
 	"reflect"
 	"strconv"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -169,6 +171,9 @@ func parseOptions(data []byte) (sql.SessionArgs, error) {
 }
 
 func (c *v3Conn) serve(authenticationHook func(string, bool) error) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	if authenticationHook != nil {
 		if err := authenticationHook(c.session.User, true /* public */); err != nil {
 			return c.sendInternalError(err.Error())
@@ -260,14 +265,14 @@ func (c *v3Conn) serve(authenticationHook func(string, bool) error) error {
 
 		case clientMsgSimpleQuery:
 			c.doingExtendedQueryMessage = false
-			err = c.handleSimpleQuery(&c.readBuf)
+			err = c.handleSimpleQuery(ctx, &c.readBuf)
 
 		case clientMsgTerminate:
 			return nil
 
 		case clientMsgParse:
 			c.doingExtendedQueryMessage = true
-			err = c.handleParse(&c.readBuf)
+			err = c.handleParse(ctx, &c.readBuf)
 
 		case clientMsgDescribe:
 			c.doingExtendedQueryMessage = true
@@ -283,7 +288,7 @@ func (c *v3Conn) serve(authenticationHook func(string, bool) error) error {
 
 		case clientMsgExecute:
 			c.doingExtendedQueryMessage = true
-			err = c.handleExecute(&c.readBuf)
+			err = c.handleExecute(ctx, &c.readBuf)
 
 		default:
 			err = c.sendInternalError(fmt.Sprintf("unrecognized client message type %s", typ))
@@ -294,16 +299,16 @@ func (c *v3Conn) serve(authenticationHook func(string, bool) error) error {
 	}
 }
 
-func (c *v3Conn) handleSimpleQuery(buf *readBuffer) error {
+func (c *v3Conn) handleSimpleQuery(ctx context.Context, buf *readBuffer) error {
 	query, err := buf.getString()
 	if err != nil {
 		return err
 	}
 
-	return c.executeStatements(query, nil, nil, true, 0)
+	return c.executeStatements(ctx, query, nil, nil, true, 0)
 }
 
-func (c *v3Conn) handleParse(buf *readBuffer) error {
+func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 	name, err := buf.getString()
 	if err != nil {
 		return err
@@ -342,7 +347,7 @@ func (c *v3Conn) handleParse(buf *readBuffer) error {
 		}
 		args[fmt.Sprint(i+1)] = v
 	}
-	cols, pErr := c.executor.Prepare(query, c.session, args)
+	cols, pErr := c.executor.Prepare(ctx, query, c.session, args)
 	if pErr != nil {
 		return c.sendPError(pErr)
 	}
@@ -564,7 +569,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 	return c.writeBuf.finishMsg(c.wr)
 }
 
-func (c *v3Conn) handleExecute(buf *readBuffer) error {
+func (c *v3Conn) handleExecute(ctx context.Context, buf *readBuffer) error {
 	portalName, err := buf.getString()
 	if err != nil {
 		return err
@@ -578,12 +583,12 @@ func (c *v3Conn) handleExecute(buf *readBuffer) error {
 		return err
 	}
 
-	return c.executeStatements(portal.stmt.query, portal.params, portal.outFormats, false, limit)
+	return c.executeStatements(ctx, portal.stmt.query, portal.params, portal.outFormats, false, limit)
 }
 
-func (c *v3Conn) executeStatements(stmts string, params []parser.Datum, formatCodes []formatCode, sendDescription bool, limit int32) error {
+func (c *v3Conn) executeStatements(ctx context.Context, stmts string, params []parser.Datum, formatCodes []formatCode, sendDescription bool, limit int32) error {
 	tracing.AnnotateTrace()
-	results := c.executor.ExecuteStatements(c.session, stmts, params)
+	results := c.executor.ExecuteStatements(ctx, c.session, stmts, params)
 
 	tracing.AnnotateTrace()
 	if results.Empty {

--- a/sql/session.go
+++ b/sql/session.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"golang.org/x/net/trace"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -175,9 +177,9 @@ type txnState struct {
 }
 
 // reset creates a new Txn and initializes it using the session defaults.
-func (ts *txnState) reset(e *Executor, s *Session) {
+func (ts *txnState) reset(ctx context.Context, e *Executor, s *Session) {
 	*ts = txnState{}
-	ts.txn = client.NewTxn(*e.ctx.DB)
+	ts.txn = client.NewTxn(ctx, *e.ctx.DB)
 	ts.txn.Proto.Isolation = s.DefaultIsolationLevel
 	ts.tr = s.Trace
 	// Discard the old schemaChangers, if any.


### PR DESCRIPTION
Previously, the heartbeat was purely based on timeouts. Now, when given a context.Context with a non-nil Done channel (which indicates that it is cancellable), use that instead.

 Plumb a cancellable Context from a pgwire connection down to this heartbeat.

Closes #3031.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5447)

<!-- Reviewable:end -->
