### PR TITLE
Rename "Ranges" stat to "Replicas" stat.

### DIFF
--- a/server/node_test.go
+++ b/server/node_test.go
@@ -400,7 +400,7 @@ func compareNodeStatus(t *testing.T, ts *TestServer, expectedNodeStatus *status.
 		// Directly verify a subset of metrics which have predictable output.
 		compareMetricMaps(actualStores[key].Metrics, expectedStores[key].Metrics,
 			[]string{
-				"ranges",
+				"replicas",
 				"ranges.replicated",
 			},
 			[]string{
@@ -483,15 +483,15 @@ func TestStatusSummaries(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		expectedRanges := 0
+		expectedReplicas := 0
 		if s.StoreID() == roachpb.StoreID(1) {
-			expectedRanges = initialRanges
+			expectedReplicas = initialRanges
 		}
 		stat := status.StoreStatus{
 			Desc: *desc,
 			Metrics: map[string]float64{
-				"ranges":            float64(expectedRanges),
-				"ranges.replicated": float64(expectedRanges),
+				"replicas":          float64(expectedReplicas),
+				"ranges.replicated": float64(expectedReplicas),
 				"livebytes":         0,
 				"keybytes":          0,
 				"valbytes":          0,
@@ -585,7 +585,7 @@ func TestStatusSummaries(t *testing.T) {
 
 	// Increment metrics on the first store.
 	store1 = expectedStoreStatuses[roachpb.StoreID(1)].Metrics
-	store1["ranges"]++
+	store1["replicas"]++
 	store1["ranges.leader"]++
 	store1["ranges.available"]++
 	store1["ranges.replicated"]++

--- a/storage/client_metrics_test.go
+++ b/storage/client_metrics_test.go
@@ -157,7 +157,7 @@ func TestStoreMetrics(t *testing.T) {
 	}
 
 	// Verify range count is as expected
-	checkCounter(t, mtc.stores[0], "ranges", 2)
+	checkCounter(t, mtc.stores[0], "replicas", 2)
 
 	// Verify all stats on store0 after split.
 	verifyStats(t, mtc, 0)
@@ -192,7 +192,7 @@ func TestStoreMetrics(t *testing.T) {
 
 	// Verify stats after sequence cache addition.
 	verifyStats(t, mtc, 0)
-	checkCounter(t, mtc.stores[0], "ranges", 2)
+	checkCounter(t, mtc.stores[0], "replicas", 2)
 
 	// Unreplicate range from the first store.
 	mtc.unreplicateRange(replica.RangeID, 0)
@@ -202,8 +202,8 @@ func TestStoreMetrics(t *testing.T) {
 	mtc.waitForValues(roachpb.Key("z"), []int64{0, 5, 5})
 
 	// Verify range count is as expected.
-	checkCounter(t, mtc.stores[0], "ranges", 1)
-	checkCounter(t, mtc.stores[1], "ranges", 1)
+	checkCounter(t, mtc.stores[0], "replicas", 1)
+	checkCounter(t, mtc.stores[1], "replicas", 1)
 
 	// Verify all stats on store0 and store1 after range is removed.
 	verifyStats(t, mtc, 0)

--- a/ui/ts/models/proto.ts
+++ b/ui/ts/models/proto.ts
@@ -74,7 +74,7 @@ module Models {
      * CockroachDB.
      */
     export module MetricConstants {
-      export var ranges: string = "ranges";
+      export var replicas: string = "replicas";
       export var leaderRanges: string = "ranges.leader";
       export var replicatedRanges: string = "ranges.replicated";
       export var availableRanges: string = "ranges.available";

--- a/ui/ts/pages/cluster.ts
+++ b/ui/ts/pages/cluster.ts
@@ -259,7 +259,7 @@ module AdminViews {
                   title: "Total Ranges",
                   visualizationArguments: {
                     format: ".0s",
-                    data: {value: totalStats[MetricNames.ranges]},
+                    data: {value: totalStats[MetricNames.leaderRanges]},
                   },
                 },
                 {

--- a/ui/ts/pages/nodes.ts
+++ b/ui/ts/pages/nodes.ts
@@ -144,14 +144,14 @@ module AdminViews {
             },
           },
           {
-            title: "Ranges",
+            title: "Replicas",
             view: (status: NodeStatus): string => {
-             return status.metrics[MetricNames.ranges].toString();
+             return status.metrics[MetricNames.replicas].toString();
             },
             sortable: true,
-            sortValue: (status: NodeStatus): number => status.metrics[MetricNames.ranges],
+            sortValue: (status: NodeStatus): number => status.metrics[MetricNames.replicas],
             rollup: function(rows: NodeStatus[]): string {
-              return sumReducer("ranges", _.map(rows, (r: NodeStatus) => r.metrics)).toString();
+              return sumReducer(MetricNames.replicas, _.map(rows, (r: NodeStatus) => r.metrics)).toString();
             },
           },
           // TODO: add more stats
@@ -403,10 +403,10 @@ module AdminViews {
           if (allStats) {
             return m(".primary-stats", [
                 {
-                  title: "Total Ranges",
+                  title: "Total Replicas",
                   visualizationArguments: {
                     format: ".0s",
-                    data: {value: allStats[MetricNames.ranges]},
+                    data: {value: allStats[MetricNames.replicas]},
                   },
                 },
                 {
@@ -598,7 +598,7 @@ module AdminViews {
             {title: "Intent Bytes", valueFn: (s: Status): string => Utils.Format.Bytes(s[MetricNames.intentBytes])},
             {title: "Sys Bytes", valueFn: (s: Status): string => Utils.Format.Bytes(s[MetricNames.sysBytes])},
             {title: "GC Bytes Age", valueFn: (s: Status): string => s[MetricNames.gcBytesAge].toString()},
-            {title: "Total Ranges", valueFn: (s: Status): string => s[MetricNames.ranges].toString()},
+            {title: "Total Replicas", valueFn: (s: Status): string => s[MetricNames.replicas].toString()},
             {title: "Leader Ranges", valueFn: (s: Status): string => s[MetricNames.leaderRanges].toString()},
             {title: "Available", valueFn: (s: Status): string => Utils.Format.Percentage(s[MetricNames.availableRanges], s[MetricNames.leaderRanges])},
             {title: "Fully Replicated", valueFn: (s: Status): string => Utils.Format.Percentage(s[MetricNames.replicatedRanges], s[MetricNames.leaderRanges])},


### PR DESCRIPTION
There were several places in the UI where the total replica count was being
referred to as "total ranges" or an equivalent. This commit changes "ranges" to
"replicas" in all such cases.

Resolves #4626

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5458)

<!-- Reviewable:end -->
