### PR TITLE
kv: local keys spanning ranges should be trimmed without throwing error

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -346,6 +346,23 @@ func Addr(k roachpb.Key) roachpb.RKey {
 	return nil
 }
 
+// AddrUpperBound returns the address for the key, used to lookup the range containing
+// the key. However, unlike Addr, it will return the following key that local range
+// keys address to. This is necessary because range-local keys exist conceptually in the
+// space between regular keys. Addr() returns the regular key that is just to the left
+// of a range-local key, which is guaranteed to be located on the same range. AddrUpperBound()
+// returns the regular key that is just to the right, which may not be on the same range
+// but is suitable for use as the EndKey of a span involving a range-local key.
+func AddrUpperBound(k roachpb.Key) roachpb.RKey {
+	rk := Addr(k)
+	if local := !rk.Equal(k); local {
+		// The upper bound for a range-local key that addresses to key k
+		// is the key directly after k.
+		rk = rk.ShallowNext()
+	}
+	return rk
+}
+
 // RangeMetaKey returns a range metadata (meta1, meta2) indexing key
 // for the given key. For ordinary keys this returns a level 2
 // metadata key - for level 2 keys, it returns a level 1 key. For
@@ -538,7 +555,8 @@ func Range(ba roachpb.BatchRequest) roachpb.RSpan {
 			// Key.Next() is larger than `to`.
 			to = key.Next()
 		}
-		if endKey := Addr(h.EndKey); to.Less(endKey) {
+		endKey := AddrUpperBound(h.EndKey)
+		if to.Less(endKey) {
 			// EndKey is larger than `to`.
 			to = endKey
 		}

--- a/kv/batch_test.go
+++ b/kv/batch_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -27,6 +28,9 @@ import (
 // TestBatchPrevNext tests batch.{Prev,Next}.
 func TestBatchPrevNext(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	loc := func(s string) string {
+		return string(keys.RangeDescriptorKey(roachpb.RKey(s)))
+	}
 	span := func(strs ...string) []roachpb.Span {
 		var r []roachpb.Span
 		for i, str := range strs {
@@ -52,6 +56,8 @@ func TestBatchPrevNext(t *testing.T) {
 		{spans: abc, key: "b\x00", expFW: "c", expBW: "b\x00"},
 		{spans: abc, key: "bb", expFW: "c", expBW: "b"},
 		{spans: span(), key: "whatevs", expFW: max, expBW: min},
+		{spans: span(loc("a"), loc("c")), key: "c", expFW: "c", expBW: "c"},
+		{spans: span(loc("a"), loc("c")), key: "c\x00", expFW: max, expBW: "c\x00"},
 	}
 
 	for i, test := range testCases {

--- a/kv/send.go
+++ b/kv/send.go
@@ -39,7 +39,7 @@ type orderingPolicy int
 
 const (
 	// orderStable uses endpoints in the order provided.
-	orderStable = iota
+	orderStable orderingPolicy = iota
 	// orderRandom randomly orders available endpoints.
 	orderRandom
 )

--- a/kv/truncate_test.go
+++ b/kv/truncate_test.go
@@ -17,6 +17,9 @@ func TestTruncate(t *testing.T) {
 	loc := func(s string) string {
 		return string(keys.RangeDescriptorKey(roachpb.RKey(s)))
 	}
+	locPrefix := func(s string) string {
+		return string(keys.MakeRangeKeyPrefix(roachpb.RKey(s)))
+	}
 	testCases := []struct {
 		keys     [][2]string
 		expKeys  [][2]string
@@ -54,12 +57,35 @@ func TestTruncate(t *testing.T) {
 			expKeys: [][2]string{{loc("b"), loc("e") + "\x00"}},
 			from:    "b", to: "e\x00",
 		},
-
 		{
 			// Range-local range not contained in active range.
-			keys: [][2]string{{loc("a"), loc("b")}},
-			from: "b", to: "e",
-			err: "local key range must not span ranges",
+			keys:    [][2]string{{loc("a"), loc("b")}},
+			expKeys: [][2]string{{}},
+			from:    "c", to: "e",
+		},
+		{
+			// Range-local range not contained in active range.
+			keys:    [][2]string{{loc("a"), locPrefix("b")}, {loc("e"), loc("f")}},
+			expKeys: [][2]string{{}, {}},
+			from:    "b", to: "e",
+		},
+		{
+			// Range-local range partially contained in active range.
+			keys:    [][2]string{{loc("a"), loc("b")}},
+			expKeys: [][2]string{{loc("a"), locPrefix("b")}},
+			from:    "a", to: "b",
+		},
+		{
+			// Range-local range partially contained in active range.
+			keys:    [][2]string{{loc("a"), loc("b")}},
+			expKeys: [][2]string{{locPrefix("b"), loc("b")}},
+			from:    "b", to: "e",
+		},
+		{
+			// Range-local range contained in active range.
+			keys:    [][2]string{{locPrefix("b"), loc("b")}},
+			expKeys: [][2]string{{locPrefix("b"), loc("b")}},
+			from:    "b", to: "c",
 		},
 		{
 			// Mixed range-local vs global key range.

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -926,7 +926,7 @@ func (rs RSpan) Intersect(desc *RangeDescriptor) (RSpan, error) {
 	}
 
 	key := rs.Key
-	if !desc.ContainsKey(key) {
+	if key.Less(desc.StartKey) {
 		key = desc.StartKey
 	}
 	endKey := rs.EndKey


### PR DESCRIPTION
Related to https://github.com/cockroachdb/cockroach/issues/5060#issuecomment-197147508.

As discussed in person, a Range-local key being truncated by `DistSender`
should simply be thrown away (turned into an empty span) when it addresses
outside of the RangeDescriptor's range. This means that the local keys
should behave the same as normal keys in that regard.

This also cleans up `RSpan.Intersect`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5459)

<!-- Reviewable:end -->
