### PR TITLE
storage: Return an error when a non-pending intent is found

### DIFF
--- a/storage/intent_resolver_test.go
+++ b/storage/intent_resolver_test.go
@@ -1,0 +1,42 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Kenji Kaneda (kenji.kaneda@gmail.com)
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+// TestPushTransactionsWithNonPendingIntent verifies that maybePushTransactions
+// returns an error when a non-pending intent is passed.
+func TestPushTransactionsWithNonPendingIntent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tc := testContext{}
+	tc.Start(t)
+	defer tc.Stop()
+
+	intents := []roachpb.Intent{{Span: roachpb.Span{Key: roachpb.Key("a")}, Status: roachpb.ABORTED}}
+	if _, pErr := tc.store.intentResolver.maybePushTransactions(
+		tc.rng.context(), intents, roachpb.Header{}, roachpb.PUSH_TOUCH, true); !testutils.IsPError(pErr, "unexpected aborted/resolved intent") {
+		t.Errorf("expected error on aborted/resolved intent, but got %s", pErr)
+	}
+}


### PR DESCRIPTION
Address a TODO comment in intentResolver.maybePushTransactions.

Confirmed that
- all intents created in mvcc.go have the PENDING status, and
- all tests passed even if we call panic() when a non-pending intent is found.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5470)

<!-- Reviewable:end -->
