### PR TITLE
Avoid warning about backward time jumps below 10% of MaxOffset.

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 // Context defaults.
@@ -273,6 +274,9 @@ func (ctx *Context) InitStores(stopper *stop.Stopper) error {
 // resolvers.
 func (ctx *Context) InitNode() error {
 	ctx.readEnvironmentVariables()
+
+	// Avoid reporting time jumps below 10% of MaxOffset.
+	timeutil.SetMonotonicityCheckThreshold(ctx.MaxOffset / 10)
 
 	// Initialize attributes.
 	ctx.NodeAttributes = parseAttributes(ctx.Attrs)


### PR DESCRIPTION
In some platforms small time jumps below 1µs are possible and
rather common. Since CockroachDB can tolerate those, and to reduce
noise in the logs, this patch avoids reporting time jumps below 10% of
MaxOffset, or 25ms in the default configuration.

cc @tschottdorf

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5472)

<!-- Reviewable:end -->
