### PR TITLE
rocksdb: assert when a timeseries sample doesn't have a value

### DIFF
--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -486,6 +486,8 @@ double GetMin(const cockroach::roachpb::InternalTimeSeriesSample *sample) {
 // is modified to contain the accumulated values.
 void AccumulateTimeSeriesSamples(cockroach::roachpb::InternalTimeSeriesSample* dest,
                                  const cockroach::roachpb::InternalTimeSeriesSample &src) {
+  assert(src.has_sum());
+  assert(src.count() > 0);
   // Accumulate integer values
   int total_count = dest->count() + src.count();
   if (total_count > 1) {
@@ -493,9 +495,7 @@ void AccumulateTimeSeriesSamples(cockroach::roachpb::InternalTimeSeriesSample* d
     dest->set_max(std::max(GetMax(dest), GetMax(&src)));
     dest->set_min(std::min(GetMin(dest), GetMin(&src)));
   }
-  if (total_count > 0) {
-    dest->set_sum(dest->sum() + src.sum());
-  }
+  dest->set_sum(dest->sum() + src.sum());
   dest->set_count(total_count);
 }
 


### PR DESCRIPTION
I'm seeing time series sample protobufs while doing a rocksdb iteration over a range, containing a max value of: `2.2250738585072014e-308`, which is the min double value. max can be set to the min double value only when `(dest.has_sum() || src.has_sum()) == false`. I can see how dest.has_sum() == false but not the latter.

Furthermore, for a particular timeseries value, I'm seeing inconsistencies where the leader is setting max to the min double value, while the replica has max set to 0. 

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5475)

<!-- Reviewable:end -->
