### PR TITLE
sql: fix len(constraints) bug in index selection

### DIFF
--- a/sql/testdata/select_index
+++ b/sql/testdata/select_index
@@ -292,3 +292,25 @@ query ITT
 EXPLAIN SELECT a FROM t WHERE b IN (5.0, 1)
 ----
 0 scan t@b_desc -
+
+statement ok
+CREATE TABLE abcd (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  INDEX adb (a, d, b),
+  INDEX abcd (a, b, c, d)
+)
+
+# Verify that we prefer the index where more columns are constrained, even if it
+# has more keys per row.
+query ITT
+EXPLAIN SELECT b FROM abcd WHERE (a, b) = (1, 4)
+----
+0 scan abcd@abcd /1/4-/1/5
+
+query ITT
+EXPLAIN SELECT b FROM abcd WHERE (a, b) IN ((1, 4), (2, 9))
+----
+0 scan abcd@abcd /1/4-/1/5 /2/9-/2/10


### PR DESCRIPTION
When we rank indexes we take into account how many columns are constrained (e.g.
a span range of `/1/4-/1/5` is preferable to a span range of `/1-/2`). However,
the code does not correctly count constraints that apply to multiple columns,
like `(a, b) = (1, 4)`. Fixing this, adding tests (which I confirmed fail
without this change) and doing some minor related cleanup.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5478)

<!-- Reviewable:end -->
