### PR TITLE
acceptance: adding repair test

### DIFF
--- a/acceptance/cluster/cluster.go
+++ b/acceptance/cluster/cluster.go
@@ -50,6 +50,8 @@ type Cluster interface {
 	Restart(int) error
 	// URL returns the HTTP(s) endpoint.
 	URL(int) string
+	// Addr returns the host and port from the node in the format HOST:PORT.
+	Addr(int) string
 }
 
 // Consistent performs a replication consistency check on all the ranges

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -736,3 +736,8 @@ func (l *LocalCluster) Restart(i int) error {
 func (l *LocalCluster) URL(i int) string {
 	return "https://" + l.Nodes[i].Addr(defaultHTTP).String()
 }
+
+// Addr returns the host and port from the node in the format HOST:PORT.
+func (l *LocalCluster) Addr(i int) string {
+	return l.Nodes[i].Addr(defaultHTTP).String()
+}

--- a/acceptance/dynamic_client.go
+++ b/acceptance/dynamic_client.go
@@ -1,0 +1,138 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package acceptance
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/stop"
+)
+
+// dynamicClient should be used in acceptance tests when connecting to a
+// cluster that may lose and gain nodes as the test proceeds.
+type dynamicClient struct {
+	cluster cluster.Cluster
+	stopper *stop.Stopper
+
+	mu struct {
+		sync.Mutex
+		// clients is a map from node indexes used by methods passed to the
+		// cluster `c` to db clients.
+		clients map[int]*sql.DB
+	}
+}
+
+// newDyanmicClient creates a dynamic client. `close()` must be called after
+// the dynamic client is no longer needed.
+func newDynamicClient(cluster cluster.Cluster, stopper *stop.Stopper) *dynamicClient {
+	dc := &dynamicClient{
+		cluster: cluster,
+		stopper: stopper,
+	}
+	dc.mu.clients = make(map[int]*sql.DB)
+	return dc
+}
+
+// Close closes all connected database clients. Close implements the Closer
+// interface.
+func (dc *dynamicClient) Close() {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	for i, client := range dc.mu.clients {
+		log.Infof("closing connection to %s", dc.cluster.Addr(i))
+		client.Close()
+		delete(dc.mu.clients, i)
+	}
+}
+
+// isRetryableError returns true for any errors that show a connection issue
+// or an issue with the node itself. This can occur when a node is restarting
+// or is unstable in some other way.
+func isRetryableError(err error) bool {
+	return testutils.IsError(err, "(connection reset by peer|connection refused|failed to send RPC|EOF)")
+}
+
+var errTestFinished = errors.New("test is shutting down")
+
+// exec calls exec on a client using a preexisting or new connection.
+func (dc *dynamicClient) exec(query string, args ...interface{}) (sql.Result, error) {
+	for dc.isRunning() {
+		client, err := dc.getClient()
+		if err != nil {
+			return nil, err
+		}
+		if result, err := client.Exec(query, args...); err == nil || !isRetryableError(err) {
+			return result, err
+		}
+	}
+	return nil, errTestFinished
+}
+
+// queryRowScan performs first a QueryRow and follows that up with a Scan using
+// a preexisting or new connection.
+func (dc *dynamicClient) queryRowScan(query string, queryArgs, destArgs []interface{}) error {
+	for dc.isRunning() {
+		client, err := dc.getClient()
+		if err != nil {
+			return err
+		}
+		if err := client.QueryRow(query, queryArgs...).Scan(destArgs...); err == nil || !isRetryableError(err) {
+			return err
+		}
+	}
+	return errTestFinished
+}
+
+// getClient returns open client to a random node from the cluster.
+func (dc *dynamicClient) getClient() (*sql.DB, error) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	indexes := rand.Perm(dc.cluster.NumNodes())
+	for _, index := range indexes {
+		if client, ok := dc.mu.clients[index]; ok {
+			return client, nil
+		}
+		client, err := sql.Open("postgres", dc.cluster.PGUrl(index))
+		if err != nil {
+			log.Infof("could not establish connection to %s: %s", dc.cluster.Addr(index), err)
+			continue
+		}
+		log.Infof("connection established to %s", dc.cluster.Addr(index))
+		dc.mu.clients[index] = client
+		return client, nil
+	}
+
+	// If we find that we end up having no connections often, consider putting
+	// in a retry loop for this whole function.
+	return nil, fmt.Errorf("there are no available connections to the cluster")
+}
+
+// isRunning returns true as long as the stopper is still running.
+func (dc *dynamicClient) isRunning() bool {
+	select {
+	case <-dc.stopper.ShouldStop():
+		return false
+	default:
+	}
+	return true
+}

--- a/acceptance/load.go
+++ b/acceptance/load.go
@@ -1,0 +1,85 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/timeutil"
+)
+
+// insertLoad add a very basic load that inserts into a unique table and checks
+// that the inserted values are indeed correct.
+func insertLoad(t *testing.T, dc *dynamicClient, ID int) {
+	// Initialize the db.
+	if _, err := dc.exec(`CREATE DATABASE IF NOT EXISTS Insert`); err != nil {
+		t.Fatal(err)
+	}
+
+	tableName := fmt.Sprintf("Insert.Table%d", ID)
+	createTableStatement := fmt.Sprintf(`
+CREATE TABLE %s (
+	key INT PRIMARY KEY,
+	value INT NOT NULL
+)`, tableName)
+	insertStatement := fmt.Sprintf(`INSERT INTO %s (key, value) VALUES ($1, $1)`, tableName)
+	selectStatement := fmt.Sprintf(`SELECT key-value AS "total" FROM %s WHERE key = $1`, tableName)
+
+	// Init the db for the basic insert.
+	if _, err := dc.exec(createTableStatement); err != nil {
+		t.Fatal(err)
+	}
+
+	var valueCheck, valueInsert int
+	nextUpdate := timeutil.Now()
+
+	// Perform inserts and selects
+	for dc.isRunning() {
+
+		// Insert some values.
+		valueInsert++
+		if _, err := dc.exec(insertStatement, valueInsert); err != nil {
+			if err == errTestFinished {
+				return
+			}
+			t.Fatal(err)
+		}
+
+		// Check that another value is still correct.
+		valueCheck--
+		if valueCheck < 1 {
+			valueCheck = valueInsert
+		}
+
+		var total int
+		if err := dc.queryRowScan(selectStatement, []interface{}{valueCheck}, []interface{}{&total}); err != nil {
+			if err == errTestFinished {
+				return
+			}
+			t.Fatal(err)
+		}
+		if total != 0 {
+			t.Fatalf("total expected to be 0, is %d", total)
+		}
+
+		if timeutil.Now().After(nextUpdate) {
+			log.Infof("Insert %d: inserted and checked %d values", ID, valueInsert)
+			nextUpdate = timeutil.Now().Add(time.Second)
+		}
+	}
+}

--- a/acceptance/repair_test.go
+++ b/acceptance/repair_test.go
@@ -1,0 +1,52 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+package acceptance
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/util/stop"
+)
+
+// RepairTest kills and starts new nodes systematically to ensure we do
+// indeed repair the cluster.
+func TestRepair(t *testing.T) {
+	runTestOnConfigs(t, testRepairInner)
+}
+
+func testRepairInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
+	testStopper := stop.NewStopper()
+	dc := newDynamicClient(c, testStopper)
+	testStopper.AddCloser(dc)
+	defer testStopper.Stop()
+
+	// Add some loads.
+	for i := 0; i < c.NumNodes()*2; i++ {
+		ID := i
+		testStopper.RunWorker(func() {
+			insertLoad(t, dc, ID)
+		})
+	}
+
+	// TODO(bram): #5345 add repair mechanism.
+
+	select {
+	case <-stopper:
+	case <-time.After(cfg.Duration):
+	}
+}

--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -255,6 +255,11 @@ func (f *Farmer) URL(i int) string {
 	return "http://" + net.JoinHostPort(f.Nodes()[i], base.DefaultHTTPPort)
 }
 
+// Addr returns the host and port from the node in the format HOST:PORT.
+func (f *Farmer) Addr(i int) string {
+	return net.JoinHostPort(f.Nodes()[i], base.DefaultHTTPPort)
+}
+
 func (f *Farmer) logf(format string, args ...interface{}) {
 	if f.Output != nil {
 		fmt.Fprintf(f.Output, format, args...)


### PR DESCRIPTION
This commit adds a dynamic client which is designed to handle clusters with
changing shapes. So it is adaptable to adding and removing nodes.

Also, this includes the first isolated load. This is the first of many loads
that we will be able to apply to tests in a more generic way. This load is
designed to be a non-contentious one that just inserts into a table and checks
that the values in the table are still correct.

The repair test so far is only an insert test. I will be following this up with
changes to cluster to handle adding and permanently removing nodes.

This is part of #5345.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5481)

<!-- Reviewable:end -->
