### PR TITLE
testutils: move build.go into a subpackage

### DIFF
--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/testutils/buildutil"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -45,13 +45,14 @@ func TestNoLinkForbidden(t *testing.T) {
 		t.Skip("GOPATH isn't set")
 	}
 
-	imports, err := testutils.TransitiveImports("github.com/cockroachdb/cockroach", true)
+	imports, err := buildutil.TransitiveImports("github.com/cockroachdb/cockroach", true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, forbidden := range []string{
-		"testing", // defines flags
+		"testing",  // defines flags
+		"go/build", // probably not something we want in the main binary
 		"github.com/cockroachdb/cockroach/security/securitytest", // contains certificates
 	} {
 		if _, ok := imports[forbidden]; ok {

--- a/testutils/buildutil/build.go
+++ b/testutils/buildutil/build.go
@@ -14,7 +14,7 @@
 //
 // Author: Peter Mattis (peter@cockroachlabs.com)
 
-package testutils
+package buildutil
 
 import "go/build"
 


### PR DESCRIPTION
This removes a dependency on go/build from the main binary.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5487)

<!-- Reviewable:end -->
