### PR TITLE
Fix garbled transaction ID in protos

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -108,7 +108,7 @@ func MakeRangeIDReplicatedKey(rangeID roachpb.RangeID, suffix, detail roachpb.RK
 // for the given transaction ID.
 func SequenceCacheKeyPrefix(rangeID roachpb.RangeID, txnID *uuid.UUID) roachpb.Key {
 	key := MakeRangeIDReplicatedKey(rangeID, LocalSequenceCacheSuffix, nil)
-	key = encoding.EncodeBytesAscending(key, txnID.Bytes())
+	key = encoding.EncodeBytesAscending(key, txnID.GetBytes())
 	return key
 }
 
@@ -307,7 +307,7 @@ func RangeDescriptorKey(key roachpb.RKey) roachpb.Key {
 // transaction key and ID. The base key is encoded in order to
 // guarantee that all transaction records for a range sort together.
 func TransactionKey(key roachpb.Key, txnID *uuid.UUID) roachpb.Key {
-	return MakeRangeKey(Addr(key), localTransactionSuffix, roachpb.RKey(txnID.Bytes()))
+	return MakeRangeKey(Addr(key), localTransactionSuffix, roachpb.RKey(txnID.GetBytes()))
 }
 
 // Addr returns the address for the key, used to lookup the range containing

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -18,10 +18,12 @@ package roachpb
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"math/rand"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -425,6 +427,12 @@ func TestTransactionString(t *testing.T) {
 
 	var txnEmpty Transaction
 	_ = txnEmpty.String() // prevent regression of NPE
+
+	var cmd RaftCommand
+	cmd.Cmd.Txn = &txn
+	if actStr, idStr := fmt.Sprintf("%s", &cmd), txn.ID.String(); !strings.Contains(actStr, idStr) {
+		t.Fatalf("expected to find '%s' in '%s'", idStr, actStr)
+	}
 }
 
 // TestTransactionObservedTimestamp verifies that txn.{Get,Update}ObservedTimestamp work as

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -503,7 +503,7 @@ var builtins = map[string][]builtin{
 			returnType: typeBytes,
 			impure:     true,
 			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				return DBytes(uuid.NewV4().Bytes()), nil
+				return DBytes(uuid.NewV4().GetBytes()), nil
 			},
 		},
 	},

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1756,7 +1756,7 @@ func (r *Replica) maybeGossipFirstRange() *roachpb.Error {
 		log.Infoc(ctx, "gossiping cluster id %q from store %d, range %d", r.store.ClusterID(),
 			r.store.StoreID(), r.RangeID)
 	}
-	if err := r.store.Gossip().AddInfo(gossip.KeyClusterID, r.store.ClusterID().Bytes(), 0*time.Second); err != nil {
+	if err := r.store.Gossip().AddInfo(gossip.KeyClusterID, r.store.ClusterID().GetBytes(), 0*time.Second); err != nil {
 		log.Errorc(ctx, "failed to gossip cluster ID: %s", err)
 	}
 	if ok, pErr := r.getLeaseForGossip(ctx); !ok || pErr != nil {
@@ -1765,7 +1765,7 @@ func (r *Replica) maybeGossipFirstRange() *roachpb.Error {
 	if log.V(1) {
 		log.Infoc(ctx, "gossiping sentinel from store %d, range %d", r.store.StoreID(), r.RangeID)
 	}
-	if err := r.store.Gossip().AddInfo(gossip.KeySentinel, r.store.ClusterID().Bytes(), sentinelGossipTTL); err != nil {
+	if err := r.store.Gossip().AddInfo(gossip.KeySentinel, r.store.ClusterID().GetBytes(), sentinelGossipTTL); err != nil {
 		log.Errorc(ctx, "failed to gossip sentinel: %s", err)
 	}
 	if log.V(1) {

--- a/storage/sequence_cache.go
+++ b/storage/sequence_cache.go
@@ -74,10 +74,10 @@ var txnIDMin = new(uuid.UUID)
 var txnIDMax = new(uuid.UUID)
 
 func init() {
-	for i := range txnIDMin.Bytes() {
+	for i := range txnIDMin.GetBytes() {
 		txnIDMin.UUID[i] = '\x00'
 	}
-	for i := range txnIDMax.Bytes() {
+	for i := range txnIDMax.GetBytes() {
 		txnIDMax.UUID[i] = '\xff'
 	}
 }

--- a/util/uuid/uuid.go
+++ b/util/uuid/uuid.go
@@ -16,7 +16,11 @@
 
 package uuid
 
-import "github.com/satori/go.uuid"
+import (
+	"errors"
+
+	"github.com/satori/go.uuid"
+)
 
 // EmptyUUID is the zero-UUID.
 var EmptyUUID = &UUID{}
@@ -25,6 +29,18 @@ var EmptyUUID = &UUID{}
 // used as a gogo/protobuf customtype.
 type UUID struct {
 	uuid.UUID
+}
+
+// Bytes shadows (*github.com/satori/go.uuid.UUID).Bytes() to prevent confusing
+// our default proto stringer.
+// TODO(tschottdorf): fix upstream.
+func (u UUID) Bytes() error {
+	return errors.New("intentionally shadowed; use GetBytes()")
+}
+
+// GetBytes returns the UUID as a byte slice.
+func (u UUID) GetBytes() []byte {
+	return u.UUID.Bytes()
 }
 
 // Size returns the marshalled size of u, in bytes.


### PR DESCRIPTION
Prior to this change, the default protobuf stringer would use the `Bytes`
method on `UUID` to get its hand on something it could (not actually) parse.

The real fix is to make the stringer smarter, added a TODO do that effect.

This change is a big improvement for the `cli/debug` commands.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5490)

<!-- Reviewable:end -->
