### PR TITLE
server: call home to check for new versions and optionally report metrics

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -146,6 +146,12 @@ func runStart(_ *cobra.Command, _ []string) error {
 
 	log.Info("starting cockroach node")
 	s, err := server.NewServer(&cliContext.Context, stopper)
+
+	// We don't do this in NewServer since we don't want it in tests.
+	if err := s.SetupReportingURLs(); err != nil {
+		return err
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to start Cockroach server: %s", err)
 	}

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -186,8 +186,9 @@ var (
 	TimeseriesPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("tsd")))
 
 	// UpdateCheckPrefix is the key prefix for all update check times.
-	UpdateCheckPrefix  = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("update-")))
-	UpdateCheckCluster = roachpb.Key(makeKey(UpdateCheckPrefix, roachpb.RKey("cluster")))
+	UpdateCheckPrefix      = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("update-")))
+	UpdateCheckCluster     = roachpb.Key(makeKey(UpdateCheckPrefix, roachpb.RKey("cluster")))
+	UpdateCheckReportUsage = roachpb.Key(makeKey(UpdateCheckPrefix, roachpb.RKey("report")))
 
 	// TableDataMin is the start of the range of table data keys.
 	TableDataMin = roachpb.Key(encoding.EncodeVarintAscending(nil, math.MinInt64))

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -185,6 +185,10 @@ var (
 	// TimeseriesPrefix is the key prefix for all timeseries data.
 	TimeseriesPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("tsd")))
 
+	// UpdateCheckPrefix is the key prefix for all update check times.
+	UpdateCheckPrefix  = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("update-")))
+	UpdateCheckCluster = roachpb.Key(makeKey(UpdateCheckPrefix, roachpb.RKey("cluster")))
+
 	// TableDataMin is the start of the range of table data keys.
 	TableDataMin = roachpb.Key(encoding.EncodeVarintAscending(nil, math.MinInt64))
 	// TableDataMin is the end of the range of table data keys.

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -70,6 +70,13 @@ func NodeStatusKey(nodeID int32) roachpb.Key {
 	return key
 }
 
+// NodeLastUsageReportKey returns the key for accessing the node last update check
+// time (when version check or usage reporting was done).
+func NodeLastUsageReportKey(nodeID int32) roachpb.Key {
+	prefix := append([]byte(nil), UpdateCheckPrefix...)
+	return encoding.EncodeUvarintAscending(prefix, uint64(nodeID))
+}
+
 func makePrefixWithRangeID(prefix []byte, rangeID roachpb.RangeID, infix roachpb.RKey) roachpb.Key {
 	// Size the key buffer so that it is large enough for most callers.
 	key := make(roachpb.Key, 0, 32)

--- a/server/server.go
+++ b/server/server.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -83,6 +84,8 @@ type Server struct {
 	sqlExecutor         *sql.Executor
 	leaseMgr            *sql.LeaseManager
 	schemaChangeManager *sql.SchemaChangeManager
+	parsedUpdatesURL    *url.URL
+	parsedReportingURL  *url.URL
 }
 
 // NewServer creates a Server from a server.Context.
@@ -346,6 +349,8 @@ func (s *Server) Start() error {
 	// has been assigned.
 	s.schemaChangeManager = sql.NewSchemaChangeManager(*s.db, s.gossip, s.leaseMgr)
 	s.schemaChangeManager.Start(s.stopper)
+
+	s.periodicallyCheckForUpdates()
 
 	log.Infof("starting %s server at %s", s.ctx.HTTPRequestScheme(), unresolvedHTTPAddr)
 	log.Infof("starting grpc/postgres server at %s", unresolvedAddr)

--- a/server/updates.go
+++ b/server/updates.go
@@ -1,0 +1,162 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/timeutil"
+)
+
+const baseUpdatesURL = `https://register.cockroachdb.com/api/clusters/updates`
+
+const updateCheckFrequency = time.Hour * 24
+const updateCheckJitterSeconds = 120
+const updateCheckRetryFrequency = time.Hour
+
+type versionInfo struct {
+	Version string `json:"version"`
+	Details string `json:"details"`
+}
+
+// SetupReportingURLs parses the phone-home for version updates URL and should be
+// called before server starts except in tests.
+func (s *Server) SetupReportingURLs() error {
+	var err error
+	s.parsedUpdatesURL, err = url.Parse(baseUpdatesURL)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Server) periodicallyCheckForUpdates() {
+	s.stopper.RunWorker(func() {
+		for {
+			wait := s.maybeCheckForUpdates()
+			jitter := rand.Intn(updateCheckJitterSeconds) - updateCheckJitterSeconds/2
+			wait = wait + (time.Duration(jitter) * time.Second)
+			select {
+			case <-s.stopper.ShouldDrain():
+				return
+			case <-time.After(wait):
+			}
+		}
+	})
+}
+
+// Determines if it is time to check for updates and does so if it is.
+// Returns a duration indicating when to make the next call to this method.
+func (s *Server) maybeCheckForUpdates() time.Duration {
+	return s.maybeRunPeriodicCheck("updates check", keys.UpdateCheckCluster, s.checkForUpdates)
+}
+
+// If the time is greater than the timestamp stored at `key`, run `f`.
+// Before running `f`, the timestamp is updated forward by a small amount via
+// a compare-and-swap to ensure at-most-one concurrent execution. After `f`
+// executes the timestamp is set to the next execution time.
+// Returns how long until `f` should be run next (i.e. when this method should
+// be called again).
+func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) time.Duration {
+	resp, err := s.db.Get(key)
+	if err != nil {
+		log.Infof("Error reading %s time: %v", op, err)
+		return updateCheckRetryFrequency
+	}
+
+	// We should early returned below if either the next check time is in the
+	// future or if the atomic compare-and-set of that time failed (which
+	// would happen if two nodes tried at the same time).
+	if resp.Exists() {
+		whenToCheck, pErr := resp.Value.GetTime()
+		if pErr != nil {
+			log.Warningf("Error decoding %s time: %v", op, err)
+			return updateCheckRetryFrequency
+		} else if delay := whenToCheck.Sub(timeutil.Now()); delay > 0 {
+			return delay
+		}
+
+		nextRetry := whenToCheck.Add(updateCheckRetryFrequency)
+		if err := s.db.CPut(key, nextRetry, whenToCheck); err != nil {
+			if log.V(2) {
+				log.Infof("Could not set next version check time (maybe another node checked?)", err)
+			}
+			return updateCheckRetryFrequency
+		}
+	} else {
+		log.Infof("No previous %s time.", op)
+		nextRetry := timeutil.Now().Add(updateCheckRetryFrequency)
+		// CPut with `nil` prev value to assert that no other node has checked.
+		if err := s.db.CPut(key, nextRetry, nil); err != nil {
+			if log.V(2) {
+				log.Infof("Could not set %s time (maybe another node checked?): %v", op, err)
+			}
+			return updateCheckRetryFrequency
+		}
+	}
+
+	f()
+
+	if err := s.db.Put(key, timeutil.Now().Add(updateCheckFrequency)); err != nil {
+		log.Infof("Error updating %s time: %v", op, err)
+	}
+	return updateCheckFrequency
+}
+
+func (s *Server) checkForUpdates() {
+	// TestServer.Start nils these out to prevent tests possibly phoning home.
+	if s.parsedUpdatesURL == nil {
+		return
+	}
+
+	q := s.parsedUpdatesURL.Query()
+	q.Set("version", util.GetBuildInfo().Tag)
+	q.Set("uuid", s.node.ClusterID.String())
+	s.parsedUpdatesURL.RawQuery = q.Encode()
+
+	res, err := http.Get(s.parsedUpdatesURL.String())
+	if err != nil {
+		// This is probably going to be relatively common in production
+		// environments where network access is usually curtailed.
+		if log.V(2) {
+			log.Warning("Error checking for updates: ", err)
+		}
+	}
+	defer res.Body.Close()
+
+	decoder := json.NewDecoder(res.Body)
+	r := struct {
+		Details []versionInfo `json:"details"`
+	}{}
+
+	err = decoder.Decode(&r)
+	if err != nil && err != io.EOF {
+		log.Warning("Error decoding updates info: ", err)
+		return
+	}
+
+	for _, v := range r.Details {
+		log.Info("A new version is available: %s\n\t%s", v.Version, v.Details)
+	}
+}

--- a/server/updates_test.go
+++ b/server/updates_test.go
@@ -1,0 +1,71 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func TestSetupReportingURLs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s := new(Server) // don't actually need a testserver here
+
+	if err := s.SetupReportingURLs(); err != nil {
+		t.Fatal(err)
+	}
+	if s.parsedUpdatesURL == nil {
+		t.Fatal("updates url should be set")
+	}
+}
+
+func TestCheckVersion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	updateChecks := int32(0)
+	uuid := ""
+	version := ""
+
+	recorder := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		atomic.AddInt32(&updateChecks, 1)
+		uuid = r.URL.Query().Get("uuid")
+		version = r.URL.Query().Get("version")
+	}))
+
+	s := StartTestServer(t)
+	s.parsedUpdatesURL, _ = url.Parse(recorder.URL)
+	s.checkForUpdates()
+	recorder.Close()
+	s.Stop()
+
+	if expected, actual := int32(1), atomic.LoadInt32(&updateChecks); actual != expected {
+		t.Fatalf("expected %v update checks, got %v", expected, actual)
+	}
+
+	if expected, actual := s.node.ClusterID.String(), uuid; expected != actual {
+		t.Errorf("expected uuid %v, got %v", expected, actual)
+	}
+
+	if expected, actual := util.GetBuildInfo().Tag, version; expected != actual {
+		t.Errorf("expected version tag %v, got %v", expected, actual)
+	}
+}

--- a/server/updates_test.go
+++ b/server/updates_test.go
@@ -15,12 +15,14 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"sync/atomic"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -31,6 +33,9 @@ func TestSetupReportingURLs(t *testing.T) {
 
 	if err := s.SetupReportingURLs(); err != nil {
 		t.Fatal(err)
+	}
+	if s.parsedReportingURL == nil {
+		t.Fatal("reporting url should be set")
 	}
 	if s.parsedUpdatesURL == nil {
 		t.Fatal("updates url should be set")
@@ -68,4 +73,88 @@ func TestCheckVersion(t *testing.T) {
 	if expected, actual := util.GetBuildInfo().Tag, version; expected != actual {
 		t.Errorf("expected version tag %v, got %v", expected, actual)
 	}
+}
+
+func TestReportUsage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	usageReports := int32(0)
+	uuid := ""
+	reported := reportingInfo{}
+
+	recorder := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		atomic.AddInt32(&usageReports, 1)
+		uuid = r.URL.Query().Get("uuid")
+		if err := json.NewDecoder(r.Body).Decode(&reported); err != nil {
+			t.Fatal(err)
+		}
+	}))
+
+	var s TestServer
+	s.Ctx = NewTestContext()
+	s.StoresPerNode = 2
+	if err := s.Start(); err != nil {
+		t.Fatalf("failed to start test server: %s", err)
+	}
+	s.parsedReportingURL, _ = url.Parse(recorder.URL)
+
+	if err := s.WaitForInitialSplits(); err != nil {
+		t.Fatal(err)
+	}
+
+	node := s.node.recorder.GetStatusSummary()
+	s.reportUsage()
+
+	s.Stop() // stopper will wait for the update/report loop to finish too.
+	recorder.Close()
+
+	keyCounts := make(map[roachpb.StoreID]int)
+	rangeCounts := make(map[roachpb.StoreID]int)
+	totalKeys := 0
+	totalRanges := 0
+
+	for _, store := range node.StoreStatuses {
+		if keys, ok := store.Metrics["keycount"]; ok {
+			totalKeys += int(keys)
+			keyCounts[store.Desc.StoreID] = int(keys)
+		} else {
+			t.Fatal("keycount not in metrics")
+		}
+		if replicas, ok := store.Metrics["replicas"]; ok {
+			totalRanges += int(replicas)
+			rangeCounts[store.Desc.StoreID] = int(replicas)
+		} else {
+			t.Fatal("replicas not in metrics")
+		}
+	}
+
+	if expected, actual := int32(1), atomic.LoadInt32(&usageReports); expected != actual {
+		t.Fatalf("expected %v reports, got %v", expected, actual)
+	}
+	if expected, actual := s.node.ClusterID.String(), uuid; expected != actual {
+		t.Errorf("expected cluster id %v got %v", expected, actual)
+	}
+	if expected, actual := s.node.Descriptor.NodeID, reported.Node.NodeID; expected != actual {
+		t.Errorf("expected node id %v got %v", expected, actual)
+	}
+	if expected, actual := totalKeys, reported.Node.KeyCount; expected != actual {
+		t.Errorf("expected node keys %v got %v", expected, actual)
+	}
+	if expected, actual := totalRanges, reported.Node.RangeCount; expected != actual {
+		t.Errorf("expected node ranges %v got %v", expected, actual)
+	}
+	if expected, actual := s.StoresPerNode, len(reported.Stores); expected != actual {
+		t.Errorf("expected %v stores got %v", expected, actual)
+	}
+
+	for _, store := range reported.Stores {
+		if expected, actual := keyCounts[store.StoreID], store.KeyCount; expected != actual {
+			t.Errorf("expected %v keys in store %v got %v", expected, store.StoreID, actual)
+		}
+		if expected, actual := rangeCounts[store.StoreID], store.RangeCount; expected != actual {
+			t.Errorf("expected %v ranges in store %v got %v", expected, store.StoreID, actual)
+		}
+	}
+
 }


### PR DESCRIPTION
Uses the KV to persist next-check-time across restarts as well as avoid concurrent checks by more than one node by updating said time using a compare-and-swap conditional-put.

A single worker loop does both the updates checks (per cluster per 24h) and metrics reporting (per nod per 24h), sleeping until the next of these two will need to run (plus jitter).

To prevent test runs from spamming the registration servers, `TestServer.Start` nils the package-level `url.URL`s for the registration server, which changes the reporting/checking methods into no-ops. The rest of machinery (the scheduling side) is unchanged in tests though just to keep it as close to reality as possible, and the specific tests can point these globals to their recording test servers to collect requests.

Closes #5295.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5496)

<!-- Reviewable:end -->
