### PR TITLE
mvcc: always fail when SplitKey = StartKey

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1795,7 +1795,7 @@ func MVCCFindSplitKey(engine Engine, rangeID roachpb.RangeID, key, endKey roachp
 		return nil, err
 	}
 
-	if bestSplitKey.Equal(encStartKey) {
+	if bestSplitKey.Key.Equal(encStartKey.Key) {
 		return nil, util.Errorf("the range cannot be split; considered range %q-%q has no valid splits", key, endKey)
 	}
 


### PR DESCRIPTION
Previous code would return the descriptor's StartKey as valid SplitKey if there
was a value at StartKey. It isn't supposed to do that since the range is
already split at that point. See #5501.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5510)

<!-- Reviewable:end -->
