### PR TITLE
optionally serve postgres on unix socket.

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -94,6 +94,11 @@ is one of:`) + `
 The address to listen on. The node will also advertise itself using this
 hostname; it must resolve from other nodes in the cluster.`),
 
+	"socket": wrapText(`
+Unix socket file, postgresql protocol only.
+Note: when given a path to a unix socket, most postgres clients will
+open "<given path>/.s.PGSQL.<server port>"`),
+
 	"insecure": wrapText(`
 Run over plain HTTP. WARNING: this is strongly discouraged.`),
 
@@ -284,6 +289,13 @@ func initFlags(ctx *Context) {
 		f.StringVar(&httpPort, "http-port", base.DefaultHTTPPort, usage("server_http_port"))
 		f.StringVar(&ctx.Attrs, "attrs", ctx.Attrs, usage("attrs"))
 		f.VarP(&ctx.Stores, "store", "s", usage("store"))
+
+		// Usage for the unix socket is odd as we use a real file, whereas
+		// postgresql and clients consider it a directory and build a filename
+		// inside it using the port.
+		// Thus, we keep it hidden and use it for testing only.
+		f.StringVar(&ctx.SocketFile, "socket", "", usage("socket"))
+		_ = f.MarkHidden("socket")
 
 		// Security flags.
 		f.BoolVar(&ctx.Insecure, "insecure", ctx.Insecure, usage("insecure"))

--- a/cli/start.go
+++ b/cli/start.go
@@ -163,6 +163,9 @@ func runStart(_ *cobra.Command, _ []string) error {
 	fmt.Fprintf(tw, "build:\t%s @ %s (%s)\n", info.Tag, info.Time, info.Vers)
 	fmt.Fprintf(tw, "admin:\t%s\n", cliContext.AdminURL())
 	fmt.Fprintf(tw, "sql:\t%s\n", pgURL)
+	if len(cliContext.SocketFile) != 0 {
+		fmt.Fprintf(tw, "socket:\t%s\n", cliContext.SocketFile)
+	}
 	fmt.Fprintf(tw, "logs:\t%s\n", flag.Lookup("log-dir").Value)
 	for i, spec := range cliContext.Stores.Specs {
 		fmt.Fprintf(tw, "store[%d]:\t%s\n", i, spec)

--- a/server/context.go
+++ b/server/context.go
@@ -73,6 +73,9 @@ type Context struct {
 	// addressed upstream. See https://github.com/grpc/grpc-go/issues/586.
 	HTTPAddr string
 
+	// Unix socket: for postgres only.
+	SocketFile string
+
 	// Stores is specified to enable durable key-value storage.
 	Stores StoreSpecList
 


### PR DESCRIPTION
Fixes #5469

This is mainly needed for things like the testserver-from-real-binaries
which needs dynamic ports, but those are hard, it's easier to create a
temporary file.

Note: unix sockets in postgres are weird. If you pass
`--host=/var/lib/postgresql`, the actual socket file is
`/var/lib/postgresql/.s.PGSQL.5432`.

So when using existing clients (including the go libpq), you need to run it as follows:

```
$ ./cockroach start --insecure --socket=/tmp/.s.PGSQL.12345
$ ./cockroach sql --insecure --url=postgresql://:12345/?host=%2Ftmp%2F
```

Since this is so weird, I'm hidding the flag for now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5513)

<!-- Reviewable:end -->
