### PR TITLE
Fix Time Series Merge Inconsistency

### DIFF
--- a/ts/timeseries_test.go
+++ b/ts/timeseries_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -144,5 +145,46 @@ func TestToInternal(t *testing.T) {
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Errorf("case %d fails: ToInternal result was %v, expected %v", i, actual, tc.expected)
 		}
+	}
+}
+
+// TestNegativeMax is a regression test for github issue #5414; the max value
+// could be improperly set on disk if the real maximum was a negative number.
+func TestNegativeMax(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ts := ts("test.series",
+		tsdp((time.Hour*5)+(time.Minute*5), -1.0),
+		tsdp((time.Hour*5)+(time.Minute*5), -2.0),
+	)
+	internal, err := ts.ToInternal(Resolution10s.KeyDuration(), Resolution10s.SampleDuration())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := engine.MergeInternalTimeSeriesData(internal...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if maxVal := out.Samples[0].Max; maxVal == nil {
+		t.Fatal("Expected maximum of sample 0 to be non-nil after initial merge.")
+	} else if *maxVal != -1.0 {
+		t.Fatalf("Expected maximum of sample 0 to be -1.0 after initial merge, was %f", *maxVal)
+	}
+
+	// Prevent regression of #5414: The negative number was only improperly set
+	// if a sample with an explicitly set negative max value is merged (it did
+	// not occur when individual samples were merged, because a sample with
+	// count=1 does not have an explicitly set max). Therefore, it could only
+	// happen if a sample is merged twice.
+	out, err = engine.MergeInternalTimeSeriesData(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if maxVal := out.Samples[0].Max; maxVal == nil {
+		t.Fatal("Expected maximum of sample 0 to be non-nil after initial merge.")
+	} else if *maxVal != -1.0 {
+		t.Fatalf("Expected maximum of sample 0 to be -1.0 after initial merge, was %f", *maxVal)
 	}
 }


### PR DESCRIPTION
There was a bug in the Time Series system where the "Max" value for time series
could be different if an accumulated value was "merged" multiple times.

The specific bug was that we were using `std::numeric_limits<double>::min()` as if
it represented the lowest finite value (a very large negative number); however,
for floating point values, `numeric_limits::min` represents the smallest
  _positive_ value. Because of this, when merging an existing sample with an
  explicit max, _if_ the existing max was _negative_ then the new explicit max
  was being set to `std::numeric_limits<double>::min()`, which was unintended.

The fix is to use `std::numeric_limits::lowest()`, which does provide the lowest
finite value as expected.

This was discovered by the replica consistency checker - the "max" value for
some samples was different when the value was read from different replicas,
because the RocksDB merge operator had been executed more times on one replica
than the other.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5515)

<!-- Reviewable:end -->
