### PR TITLE
cli: Add cli/debug split-key <rangeID>

### DIFF
--- a/cli/debug.go
+++ b/cli/debug.go
@@ -50,6 +50,9 @@ func parseRangeID(arg string) (roachpb.RangeID, error) {
 	if err != nil {
 		return 0, err
 	}
+	if rangeIDInt < 1 {
+		return 0, fmt.Errorf("illegal RangeID: %d", rangeIDInt)
+	}
 	return roachpb.RangeID(rangeIDInt), nil
 }
 
@@ -137,6 +140,62 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 
 	if err := db.Iterate(from, to, printer); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+var debugSplitKeyCmd = &cobra.Command{
+	Use:   "split-key [directory] [rangeid]",
+	Short: "Compute a split key for the given key range",
+	Long: `
+Runs MVCCFindSplitKey on the given key range and prints debug information
+and the obtained split key.
+`,
+	RunE: runDebugSplitKey,
+}
+
+func runDebugSplitKey(cmd *cobra.Command, args []string) error {
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+
+	if len(args) != 2 {
+		return errors.New("store and rangeID must be specified")
+	}
+
+	db, err := openStore(cmd, args[0], stopper)
+	if err != nil {
+		return err
+	}
+	rangeID, err := parseRangeID(args[1])
+	if err != nil {
+		return err
+	}
+
+	snap := db.NewSnapshot()
+	defer snap.Close()
+
+	var desc roachpb.RangeDescriptor
+	if err := storage.IterateRangeDescriptors(snap, func(descInside roachpb.RangeDescriptor) (bool, error) {
+		if descInside.RangeID == rangeID {
+			desc = descInside
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		return err
+	}
+
+	if desc.RangeID != rangeID {
+		return fmt.Errorf("range %d not found", rangeID)
+	}
+
+	if splitKey, err := engine.MVCCFindSplitKey(snap, rangeID, desc.StartKey, desc.EndKey, func(msg string, args ...interface{}) {
+		fmt.Printf(msg+"\n", args...)
+	}); err != nil {
+		fmt.Println("No SplitKey found:", err)
+	} else {
+		fmt.Println("Computed SplitKey:", splitKey)
 	}
 
 	return nil
@@ -423,6 +482,7 @@ var debugCmds = []*cobra.Command{
 	debugRangeDescriptorsCmd,
 	debugRaftLogCmd,
 	debugGCCmd,
+	debugSplitKeyCmd,
 	kvCmd,
 	rangeCmd,
 }

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -2059,7 +2059,7 @@ func TestFindSplitKey(t *testing.T) {
 	}
 	snap := engine.NewSnapshot()
 	defer snap.Close()
-	humanSplitKey, err := MVCCFindSplitKey(snap, rangeID, roachpb.RKeyMin, roachpb.RKeyMax)
+	humanSplitKey, err := MVCCFindSplitKey(snap, rangeID, roachpb.RKeyMin, roachpb.RKeyMax, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2178,7 +2178,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 		defer snap.Close()
 		rangeStart := test.keys[0]
 		rangeEnd := test.keys[len(test.keys)-1].Next()
-		splitKey, err := MVCCFindSplitKey(snap, rangeID, keys.Addr(rangeStart), keys.Addr(rangeEnd))
+		splitKey, err := MVCCFindSplitKey(snap, rangeID, keys.Addr(rangeStart), keys.Addr(rangeEnd), nil)
 		if test.expError {
 			if !testutils.IsError(err, "has no valid splits") {
 				t.Errorf("%d: unexpected error: %v", i, err)
@@ -2266,7 +2266,7 @@ func TestFindBalancedSplitKeys(t *testing.T) {
 		}
 		snap := engine.NewSnapshot()
 		defer snap.Close()
-		splitKey, err := MVCCFindSplitKey(snap, rangeID, roachpb.RKey("\x02"), roachpb.RKeyMax)
+		splitKey, err := MVCCFindSplitKey(snap, rangeID, roachpb.RKey("\x02"), roachpb.RKeyMax, nil)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 			continue

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1568,7 +1568,7 @@ func (r *Replica) AdminSplit(ctx context.Context, args roachpb.AdminSplitRequest
 			snap := r.store.NewSnapshot()
 			defer snap.Close()
 			var err error
-			foundSplitKey, err = engine.MVCCFindSplitKey(snap, desc.RangeID, desc.StartKey, desc.EndKey)
+			foundSplitKey, err = engine.MVCCFindSplitKey(snap, desc.RangeID, desc.StartKey, desc.EndKey, nil /* logFn */)
 			if err != nil {
 				return reply, roachpb.NewErrorf("unable to determine split key: %s", err)
 			}


### PR DESCRIPTION
For #5501. The result of running it against #5501 is a little boring:

```
[...]
better split: diff 14161 at /System/StatusNode/4/1458696823.168982825,0
better split: diff 6542 at /System/StatusNode/4/1458696813.172379557,0
better split: diff 1077 at /System/StatusNode/4/1458696803.185926328,0
No SplitKey found: storage/engine/mvcc.go:1821: the range cannot be split; considered range "/System/StatusNode/4"-"/System/\"tsd\\x12cr.node.exec.latency-10m-p90\\x00\\x01\\x89\\xf8\\x06.\\xc13\"" has no valid splits
```

So essentially we just happen to have a Range whose StartKey has so many
versions that it's chosen as the SplitKey, which isn't legal.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5516)

<!-- Reviewable:end -->
