### PR TITLE
sql: generate spans for filters with OR

### DIFF
--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -136,24 +136,20 @@ func selectIndex(s *scanNode, analyzeOrdering analyzeOrderingFn, preferOrderMatc
 		}
 
 		// TODO(pmattis): If "len(exprs) > 1" then we have multiple disjunctive
-		// expressions. For example, "a=1 OR a=3" will get translated into "[[a=1],
-		// [a=3]]".
-		// Right now we don't generate any constraints if we have multiple disjunctions.
-		// We would need to perform index selection independently for each of
-		// the disjunctive expressions and then take the resulting index info and
-		// determine if we're performing distinct scans in the indexes or if the
-		// scans overlap. If the scans overlap we'll need to union the output
-		// keys. If the scans are distinct (such as in the "a=1 OR a=3" case) then
-		// we can sort the scans by start key.
+		// expressions. For example, "a <= 1 OR a >= 5" will get translated into
+		// "[[a <= 1], [a >= 5]]".
 		//
-		// There are complexities: if there are a large number of disjunctive
-		// expressions we should limit how many indexes we use. We probably should
-		// optimize the common case of "a IN (1, 3)" so that we only perform index
-		// selection once even though we generate multiple scan ranges for the
-		// index.
+		// We currently map all disjunctions onto the same index; this works
+		// well if we can derive constraints for a set of columns from all
+		// disjunctions, e.g. `a < 5 OR a > 10`.
 		//
-		// Each disjunctive expression might generate multiple ranges of an index
-		// to scan. An examples of this is "a IN (1, 2, 3)".
+		// However, we can't generate any constraints if the disjunctions refer
+		// to different columns, e.g. `a > 1 OR b > 1`. We would need to perform
+		// index selection independently for each of the disjunctive
+		// expressions, and we would need infrastructure to do a
+		// multi-index-join. There are complexities: if there are a large
+		// number of disjunctive expressions we should limit how many indexes we
+		// use.
 
 		for _, c := range candidates {
 			c.analyzeExprs(exprs)
@@ -232,23 +228,23 @@ type indexConstraint struct {
 
 // numColumns returns the number of columns this constraint applies to. Only
 // constraints for expressions with tuple comparisons apply to multiple columns.
-func (c indexConstraint) numColumns() int {
-	if c.tupleMap == nil {
+func (ic indexConstraint) numColumns() int {
+	if ic.tupleMap == nil {
 		return 1
 	}
-	return len(c.tupleMap)
+	return len(ic.tupleMap)
 }
 
-func (c indexConstraint) String() string {
+func (ic indexConstraint) String() string {
 	var buf bytes.Buffer
-	if c.start != nil {
-		fmt.Fprintf(&buf, "%s", c.start)
+	if ic.start != nil {
+		fmt.Fprintf(&buf, "%s", ic.start)
 	}
-	if c.end != nil && c.end != c.start {
-		if c.start != nil {
+	if ic.end != nil && ic.end != ic.start {
+		if ic.start != nil {
 			buf.WriteString(", ")
 		}
-		fmt.Fprintf(&buf, "%s", c.end)
+		fmt.Fprintf(&buf, "%s", ic.end)
 	}
 	return buf.String()
 }
@@ -259,23 +255,39 @@ func (c indexConstraint) String() string {
 // its .tupleMap).
 type indexConstraints []indexConstraint
 
-func (c indexConstraints) String() string {
+func (ic indexConstraints) String() string {
 	var buf bytes.Buffer
 	buf.WriteString("[")
-	for i := range c {
+	for i := range ic {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		buf.WriteString(c[i].String())
+		buf.WriteString(ic[i].String())
 	}
 	buf.WriteString("]")
+	return buf.String()
+}
+
+// orIndexConstraints stores multiple indexConstraints, one for each top level
+// disjunction in our filtering expression. Each indexConstraints element
+// generates a set of spans; these sets of spans are merged.
+type orIndexConstraints []indexConstraints
+
+func (oic orIndexConstraints) String() string {
+	var buf bytes.Buffer
+	for i := range oic {
+		if i > 0 {
+			buf.WriteString(" OR ")
+		}
+		buf.WriteString(oic[i].String())
+	}
 	return buf.String()
 }
 
 type indexInfo struct {
 	desc        *TableDescriptor
 	index       *IndexDescriptor
-	constraints indexConstraints
+	constraints orIndexConstraints
 	cost        float64
 	covering    bool // Does the index cover the required qvalues?
 	reverse     bool
@@ -304,7 +316,7 @@ func (v *indexInfo) init(s *scanNode) {
 // analyzeExprs examines the range map to determine the cost of using the
 // index.
 func (v *indexInfo) analyzeExprs(exprs []parser.Exprs) {
-	if err := v.makeConstraints(exprs); err != nil {
+	if err := v.makeOrConstraints(exprs); err != nil {
 		panic(err)
 	}
 
@@ -316,11 +328,25 @@ func (v *indexInfo) analyzeExprs(exprs []parser.Exprs) {
 		// make any index which does restrict the keys more desirable.
 		v.cost *= 1000
 	} else {
-		numCols := 0
-		for _, c := range v.constraints {
-			numCols += c.numColumns()
+		// When we have multiple indexConstraints, each one is for a top-level
+		// disjunction (OR); together they are no more restrictive than any one of
+		// them. We thus calculate the cost based on the disjunction which restricts
+		// the smallest number of columns.
+		//
+		// TODO(radu): we need to be more discriminating - constraints such as
+		// "NOT NULL" are almost as useless as no constraints, whereas "exact value"
+		// constraints are very restrictive.
+		minNumCols := len(v.index.ColumnIDs)
+		for _, cset := range v.constraints {
+			numCols := 0
+			for _, c := range cset {
+				numCols += c.numColumns()
+			}
+			if numCols < minNumCols {
+				minNumCols = numCols
+			}
 		}
-		v.cost *= float64(len(v.index.ColumnIDs)) / float64(numCols)
+		v.cost *= float64(len(v.index.ColumnIDs)) / float64(minNumCols)
 	}
 }
 
@@ -334,7 +360,7 @@ func (v *indexInfo) analyzeOrdering(scan *scanNode, analyzeOrdering analyzeOrder
 	preferOrderMatching bool) {
 	// Compute the prefix of the index for which we have exact constraints. This
 	// prefix is inconsequential for ordering because the values are identical.
-	v.exactPrefix = exactPrefix(v.constraints)
+	v.exactPrefix = v.constraints.exactPrefix()
 
 	// Analyze the ordering provided by the index (either forward or reverse).
 	fwdIndexOrdering := scan.computeOrdering(v.index, v.exactPrefix, false)
@@ -378,10 +404,35 @@ func getQValColIdx(expr parser.Expr) (ok bool, colIdx int) {
 	return false, -1
 }
 
-// makeConstraints populates the indexInfo.constraints field based on the
-// analyzed expressions. The constraints are a start and end expressions for a
-// prefix of the columns that make up the index. For example, consider
-// the expression "a >= 1 AND b >= 2":
+// makeOrConstraints populates the indexInfo.constraints field based on the
+// analyzed expressions. Each element of constraints corresponds to one
+// of the top-level disjunctions and is generated using makeIndexConstraint.
+func (v *indexInfo) makeOrConstraints(orExprs []parser.Exprs) error {
+	constraints := make(orIndexConstraints, len(orExprs))
+	for i, e := range orExprs {
+		var err error
+		constraints[i], err = v.makeIndexConstraints(e)
+		if err != nil {
+			return err
+		}
+		// If an OR branch has no constraints, we cannot have _any_
+		// constraints.
+		if len(constraints[i]) == 0 {
+			return nil
+		}
+	}
+
+	v.constraints = constraints
+	return nil
+}
+
+// makeIndexConstraints generates constraints for a set of conjunctions (AND
+// expressions). These expressions can be the entire filter, or they can be one
+// of multiple top-level disjunctions (ORs).
+//
+// The constraints consist of start and end expressions for a prefix of the
+// columns that make up the index. For example, consider the expression
+// "a >= 1 AND b >= 2":
 //
 //   {a: {start: >= 1}, b: {start: >= 2}}
 //
@@ -392,10 +443,11 @@ func getQValColIdx(expr parser.Expr) (ok bool, colIdx int) {
 // once a constraint doesn't have a .start, no further constraints will
 // have one). This is because they wouldn't be useful when generating spans.
 //
-// makeConstraints takes into account the direction of the columns in the index.
-// For ascending cols, start constraints look for comparison expressions with the
-// operators >, >=, = or IN and end constraints look for comparison expressions
-// with the operators <, <=, = or IN. Vice versa for descending cols.
+// makeIndexConstraints takes into account the direction of the columns in the
+// index.  For ascending cols, start constraints look for comparison expressions
+// with the operators >, >=, = or IN and end constraints look for comparison
+// expressions with the operators <, <=, = or IN. Vice versa for descending
+// cols.
 //
 // Whenever possible, < and > are converted to <= and >=, respectively.
 // This is because we can use inclusive constraints better than exclusive ones;
@@ -415,13 +467,9 @@ func getQValColIdx(expr parser.Expr) (ok bool, colIdx int) {
 // 1", but if we performed this transform in simpilfyComparisonExpr it would
 // simplify to "a < 1 OR a >= 2" which is also the same as "a != 1", but not so
 // obvious based on comparisons of the constants.
-func (v *indexInfo) makeConstraints(exprs []parser.Exprs) error {
-	if len(exprs) != 1 {
-		// TODO(andrei): what should we do with ORs?
-		return nil
-	}
+func (v *indexInfo) makeIndexConstraints(andExprs parser.Exprs) (indexConstraints, error) {
+	var constraints indexConstraints
 
-	andExprs := exprs[0]
 	trueStartDone := false
 	trueEndDone := false
 
@@ -430,7 +478,7 @@ func (v *indexInfo) makeConstraints(exprs []parser.Exprs) error {
 		var colDir encoding.Direction
 		var err error
 		if colDir, err = v.index.ColumnDirections[i].toEncodingDirection(); err != nil {
-			return err
+			return nil, err
 		}
 
 		var constraint indexConstraint
@@ -532,7 +580,7 @@ func (v *indexInfo) makeConstraints(exprs []parser.Exprs) error {
 					// generated. Consider the constraints [a >= 1, a <= 2, b IN (1,
 					// 2)]. This would turn into the spans /1/1-/3/2 and /1/2-/3/3.
 					ok := true
-					for _, c := range v.constraints {
+					for _, c := range constraints {
 						ok = ok && (c.start == c.end) && (c.start.Operator == parser.EQ)
 					}
 					if !ok {
@@ -610,14 +658,14 @@ func (v *indexInfo) makeConstraints(exprs []parser.Exprs) error {
 				// encoding would be incorrect. See #4313.
 				if preStart != *startExpr {
 					if mixed, err := isMixedTypeComparison(*startExpr); err != nil {
-						return err
+						return nil, err
 					} else if mixed {
 						*startExpr = nil
 					}
 				}
 				if preEnd != *endExpr {
 					if mixed, err := isMixedTypeComparison(*endExpr); err != nil {
-						return err
+						return nil, err
 					} else if mixed {
 						*endExpr = nil
 					}
@@ -650,7 +698,7 @@ func (v *indexInfo) makeConstraints(exprs []parser.Exprs) error {
 		}
 
 		if constraint.start != nil || constraint.end != nil {
-			v.constraints = append(v.constraints, constraint)
+			constraints = append(constraints, constraint)
 		}
 
 		if *endExpr == nil {
@@ -663,7 +711,7 @@ func (v *indexInfo) makeConstraints(exprs []parser.Exprs) error {
 			break
 		}
 	}
-	return nil
+	return constraints, nil
 }
 
 // isCoveringIndex returns true if all of the columns needed from the scanNode are contained within
@@ -999,12 +1047,90 @@ func applyInConstraint(spans []span, c indexConstraint, firstCol int,
 	return spans
 }
 
-// makeSpans constructs the spans for an index given a set of constraints.
-// The resulting spans are non-overlapping (by virtue of the input constraints
-// being disjunct) and are ordered as the index is (i.e. scanning them in order
-// would require only iterating forward through the index).
-func makeSpans(constraints indexConstraints,
-	tableID ID, index *IndexDescriptor) []span {
+// spanEvent corresponds to either the start or the end of a span. It is used
+// internally by mergeAndSortSpans.
+type spanEvent struct {
+	start bool
+	key   roachpb.Key
+}
+
+type spanEvents []spanEvent
+
+// implement Sort.Interface
+func (a spanEvents) Len() int      { return len(a) }
+func (a spanEvents) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a spanEvents) Less(i, j int) bool {
+	cmp := a[i].key.Compare(a[j].key)
+	if cmp != 0 {
+		return cmp < 0
+	}
+	// For the same key, prefer "start" events.
+	return a[i].start && !a[j].start
+}
+
+// makeSpans constructs the spans for an index given the orIndexConstraints by
+// merging the spans for the disjunctions (top-level OR branches). The resulting
+// spans are non-overlapping and ordered.
+func makeSpans(constraints orIndexConstraints, tableID ID, index *IndexDescriptor) spans {
+	if len(constraints) == 0 {
+		return makeSpansForIndexConstraints(nil, tableID, index)
+	}
+	var allSpans spans
+	for _, c := range constraints {
+		s := makeSpansForIndexConstraints(c, tableID, index)
+		allSpans = append(allSpans, s...)
+	}
+	return mergeAndSortSpans(allSpans)
+}
+
+// mergeAndSortSpans is used to merge a set of potentially overlapping spans
+// into a sorted set of non-overlapping spans.
+func mergeAndSortSpans(s spans) spans {
+	// This is the classic 1D geometry problem of merging overlapping segments
+	// on the X axis. It can be solved using a scan algorithm: we go through all
+	// segment starting and ending points in X order (as "events") and keep
+	// track of how many open segments we have at each point.
+	events := make(spanEvents, 2*len(s))
+	for i := range s {
+		events[2*i] = spanEvent{start: true, key: s[i].start}
+		events[2*i+1] = spanEvent{start: false, key: s[i].end}
+		if s[i].start.Compare(s[i].end) >= 0 {
+			panic(fmt.Sprintf("invalid input span %s", prettySpan(s[i], 0)))
+		}
+	}
+	sort.Sort(events)
+	openSpans := 0
+	s = s[:0]
+	for _, e := range events {
+		if e.start {
+			if openSpans == 0 {
+				// Start a new span. Because for equal keys the start events
+				// come first, there can't be end events for this key.
+				// The end of the span will be adjusted as we move forward.
+				s = append(s, span{start: e.key, end: e.key})
+			}
+			openSpans++
+		} else {
+			openSpans--
+			if openSpans < 0 {
+				panic("end span with no spans started")
+			} else if openSpans == 0 {
+				// Adjust the end of the last span.
+				s[len(s)-1].end = e.key
+			}
+		}
+	}
+	if openSpans != 0 {
+		panic("scan ended with open spans")
+	}
+	return s
+}
+
+// makeSpansForIndexConstraints constructs the spans for an index given an
+// instance of indexConstraints. The resulting spans are non-overlapping (by
+// virtue of the input constraints being disjunct).
+func makeSpansForIndexConstraints(constraints indexConstraints, tableID ID,
+	index *IndexDescriptor) spans {
 	prefix := roachpb.Key(MakeIndexKeyPrefix(tableID, index.ID))
 	// We have one constraint per column, so each contributes something
 	// to the start and/or the end key of the span.
@@ -1070,28 +1196,28 @@ func makeSpans(constraints indexConstraints,
 			n++
 		}
 	}
-	resultSpans = resultSpans[:n]
-	// Sort the spans to return them in index order.
-	sort.Sort(resultSpans)
-	return resultSpans
+	return resultSpans[:n]
 }
 
 // exactPrefix returns the count of the columns of the index for which an exact
-// prefix match was requested. For example, if an index was defined on the
-// columns (a, b, c) and the WHERE clause was "(a, b) = (1, 2)", exactPrefix()
-// would return 2.
-func exactPrefix(constraints []indexConstraint) int {
+// prefix match was requested in the indexConstraints (which can be one of
+// multiple OR branches in the WHERE clause). For example, if an index was
+// defined on the columns (a, b, c) and the index constraints are derived from
+// "(a, b) = (1, 2)", exactPrefix() would return 2.
+func (ic indexConstraints) exactPrefix() int {
 	prefix := 0
-	for _, c := range constraints {
+	for _, c := range ic {
 		if c.start == nil || c.end == nil || c.start != c.end {
 			return prefix
 		}
 		switch c.start.Operator {
 		case parser.EQ:
 			prefix++
-			continue
 		case parser.In:
 			if tuple, ok := c.start.Right.(parser.DTuple); !ok || len(tuple) != 1 {
+				// TODO(radu): we may still have an exact prefix if the first
+				// value in each tuple is the same, e.g.
+				// `(a, b) IN ((1, 2), (1, 3))`
 				return prefix
 			}
 			if _, ok := c.start.Left.(*parser.Tuple); ok {
@@ -1104,6 +1230,97 @@ func exactPrefix(constraints []indexConstraint) int {
 		}
 	}
 	return prefix
+
+}
+
+// exactPrefixDatums returns the first num exact prefix values as Datums; num
+// must be at most ic.exactPrefix()
+func (ic indexConstraints) exactPrefixDatums(num int) []parser.Datum {
+	if num == 0 {
+		return nil
+	}
+	datums := make([]parser.Datum, 0, num)
+	for _, c := range ic {
+		if c.start == nil || c.end == nil || c.start != c.end {
+			break
+		}
+		switch c.start.Operator {
+		case parser.EQ:
+			datums = append(datums, c.start.Right.(parser.Datum))
+		case parser.In:
+			right := c.start.Right.(parser.DTuple)[0]
+			if _, ok := c.start.Left.(*parser.Tuple); ok {
+				// We have something like `(a,b,c) IN (1,2,3)`
+				rtuple := right.(parser.DTuple)
+				for _, tupleIdx := range c.tupleMap {
+					datums = append(datums, rtuple[tupleIdx])
+					if len(datums) == num {
+						return datums
+					}
+				}
+			} else {
+				// We have something like `a IN (1)`.
+				datums = append(datums, right)
+			}
+		default:
+			panic("asking for too many datums")
+		}
+		if len(datums) == num {
+			return datums
+		}
+	}
+	panic("asking for too many datums")
+}
+
+// exactPrefix returns the count of the columns of the index for which an exact
+// prefix match was requested. Some examples if an index was defined on the
+// columns (a, b, c):
+//
+//    |----------------------------------------------------------|
+//    |            WHERE clause                    | exactPrefix |
+//    |----------------------------------------------------------|
+//    |  (a, b) = (1, 2)                           |      2      |
+//    |  (a, b) = (1, 2) OR (a, b, c) = (1, 3, 0)  |      1      |
+//    |  (a, b) = (1, 2) OR (a, b, c) = (3, 4, 0)  |      0      |
+//    |  (a, b) = (1, 2) OR a = 1                  |      1      |
+//    |  (a, b) = (1, 2) OR a = 2                  |      0      |
+//    |----------------------------------------------------------|
+func (oic orIndexConstraints) exactPrefix() int {
+	if len(oic) == 0 {
+		return 0
+	}
+	// To have an exact prefix of length L:
+	//  - all "or" constraints must have an exact prefix of at least L
+	//  - for each of the L columns in the exact prefix, all constraints must
+	//    resolve to the *same* value for that column.
+
+	// We start by finding the minimum length of all exact prefixes.
+	minPrefix := oic[0].exactPrefix()
+	for i := 1; i < len(oic) && minPrefix > 0; i++ {
+		p := oic[i].exactPrefix()
+		if minPrefix > p {
+			minPrefix = p
+		}
+	}
+	if minPrefix == 0 || len(oic) == 1 {
+		return minPrefix
+	}
+
+	// Get the exact values for the first constraint.
+	datums := oic[0].exactPrefixDatums(minPrefix)
+
+	for i := 1; i < len(oic); i++ {
+		iDatums := oic[i].exactPrefixDatums(len(datums))
+		// Compare the exact values of this constraint, keep the matching
+		// prefix.
+		for i, d := range datums {
+			if !(d.TypeEqual(iDatums[i]) && d.Compare(iDatums[i]) == 0) {
+				datums = datums[:i]
+				break
+			}
+		}
+	}
+	return len(datums)
 }
 
 // applyConstraints applies the constraints on values specified by constraints
@@ -1113,9 +1330,14 @@ func exactPrefix(constraints []indexConstraint) int {
 // constraint is "a = 1", the expression is simplified to "b > 2".
 //
 // Note that applyConstraints currently only handles simple cases.
-func applyConstraints(expr parser.Expr, constraints indexConstraints) parser.Expr {
+func applyConstraints(expr parser.Expr, constraints orIndexConstraints) parser.Expr {
+	if len(constraints) != 1 {
+		// We only support simplifying the expressions if there aren't multiple
+		// disjunctions (top-level OR branches).
+		return expr
+	}
 	v := &applyConstraintsVisitor{}
-	for _, c := range constraints {
+	for _, c := range constraints[0] {
 		v.constraint = c
 		expr, _ = parser.WalkExpr(v, expr)
 		// We can only continue to apply the constraints if the constraints we have

--- a/sql/index_selection_test.go
+++ b/sql/index_selection_test.go
@@ -53,6 +53,23 @@ func makeTestIndex(t *testing.T, columns []string, dirs []encoding.Direction) (
 	return desc, idx
 }
 
+// makeTestIndexFromStr creates a test index from a string that enumerates the
+// columns, separated by commas. Each column has an optional '-' at the end if
+// it is descending.
+func makeTestIndexFromStr(t *testing.T, columnsStr string) (*TableDescriptor, *IndexDescriptor) {
+	columns := strings.Split(columnsStr, ",")
+	dirs := make([]encoding.Direction, len(columns))
+	for i, c := range columns {
+		if c[len(c)-1] == '-' {
+			dirs[i] = encoding.Descending
+			columns[i] = columns[i][:len(c)-1]
+		} else {
+			dirs[i] = encoding.Ascending
+		}
+	}
+	return makeTestIndex(t, columns, dirs)
+}
+
 func makeConstraints(t *testing.T, sql string, desc *TableDescriptor,
 	index *IndexDescriptor) (indexConstraints, parser.Expr) {
 	expr, _ := parseAndNormalizeExpr(t, sql)
@@ -75,92 +92,88 @@ func TestMakeConstraints(t *testing.T) {
 
 	testData := []struct {
 		expr     string
-		columns  []string
+		columns  string
 		expected string
 	}{
-		{`a = 1`, []string{"b"}, `[]`},
-		{`a = 1`, []string{"a"}, `[a = 1]`},
-		{`a != 1`, []string{"a"}, `[a IS NOT NULL]`},
-		{`a > 1`, []string{"a"}, `[a >= 2]`},
-		{`a >= 1`, []string{"a"}, `[a >= 1]`},
-		{`a < 1`, []string{"a"}, `[a IS NOT NULL, a <= 0]`},
-		{`a <= 1`, []string{"a"}, `[a IS NOT NULL, a <= 1]`},
+		{`a = 1`, `b`, `[]`},
+		{`a = 1`, `a`, `[a = 1]`},
+		{`a != 1`, `a`, `[a IS NOT NULL]`},
+		{`a > 1`, `a`, `[a >= 2]`},
+		{`a >= 1`, `a`, `[a >= 1]`},
+		{`a < 1`, `a`, `[a IS NOT NULL, a <= 0]`},
+		{`a <= 1`, `a`, `[a IS NOT NULL, a <= 1]`},
 
-		{`a IN (1,2,3)`, []string{"a"}, `[a IN (1, 2, 3)]`},
-		{`a IN (1,2,3) AND b = 1`, []string{"a", "b"}, `[a IN (1, 2, 3), b = 1]`},
-		{`a = 1 AND b IN (1,2,3)`, []string{"a", "b"}, `[a = 1, b IN (1, 2, 3)]`},
+		{`a IN (1,2,3)`, `a`, `[a IN (1, 2, 3)]`},
+		{`a IN (1,2,3) AND b = 1`, `a,b`, `[a IN (1, 2, 3), b = 1]`},
+		{`a = 1 AND b IN (1,2,3)`, `a,b`, `[a = 1, b IN (1, 2, 3)]`},
 
 		// Prefer EQ over IN.
-		{`a IN (1) AND a = 1`, []string{"a"}, `[a = 1]`},
-		// TODO(pmattis): We could conceivably propagate the "a = 1" down to the IN
+		{`a IN (1) AND a = 1`, `a`, `[a = 1]`},
+		// TODO(pmattis): We could conceivably propagate the `a = 1` down to the IN
 		// expression and simplify. Doesn't seem worth it at this time. Issue #3472.
-		{`a = 1 AND (a, b) IN ((1, 2))`, []string{"a", "b"}, `[a = 1]`},
-		{`(a, b) IN ((1, 2)) AND a = 1`, []string{"a", "b"}, `[a = 1]`},
+		{`a = 1 AND (a, b) IN ((1, 2))`, `a,b`, `[a = 1]`},
+		{`(a, b) IN ((1, 2)) AND a = 1`, `a,b`, `[a = 1]`},
 
-		{`a = 1 AND b = 1`, []string{"a", "b"}, `[a = 1, b = 1]`},
-		{`a = 1 AND b != 1`, []string{"a", "b"}, `[a = 1, b IS NOT NULL]`},
-		{`a = 1 AND b > 1`, []string{"a", "b"}, `[a = 1, b >= 2]`},
-		{`a = 1 AND b >= 1`, []string{"a", "b"}, `[a = 1, b >= 1]`},
-		{`a = 1 AND b < 1`, []string{"a", "b"}, `[a = 1, b IS NOT NULL, b <= 0]`},
-		{`a = 1 AND b <= 1`, []string{"a", "b"}, `[a = 1, b IS NOT NULL, b <= 1]`},
+		{`a = 1 AND b = 1`, `a,b`, `[a = 1, b = 1]`},
+		{`a = 1 AND b != 1`, `a,b`, `[a = 1, b IS NOT NULL]`},
+		{`a = 1 AND b > 1`, `a,b`, `[a = 1, b >= 2]`},
+		{`a = 1 AND b >= 1`, `a,b`, `[a = 1, b >= 1]`},
+		{`a = 1 AND b < 1`, `a,b`, `[a = 1, b IS NOT NULL, b <= 0]`},
+		{`a = 1 AND b <= 1`, `a,b`, `[a = 1, b IS NOT NULL, b <= 1]`},
 
-		{`a != 1 AND b = 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
-		{`a != 1 AND b != 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
-		{`a != 1 AND b > 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
-		{`a != 1 AND b >= 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
-		{`a != 1 AND b < 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
-		{`a != 1 AND b <= 1`, []string{"a", "b"}, `[a IS NOT NULL]`},
+		{`a != 1 AND b = 1`, `a,b`, `[a IS NOT NULL]`},
+		{`a != 1 AND b != 1`, `a,b`, `[a IS NOT NULL]`},
+		{`a != 1 AND b > 1`, `a,b`, `[a IS NOT NULL]`},
+		{`a != 1 AND b >= 1`, `a,b`, `[a IS NOT NULL]`},
+		{`a != 1 AND b < 1`, `a,b`, `[a IS NOT NULL]`},
+		{`a != 1 AND b <= 1`, `a,b`, `[a IS NOT NULL]`},
 
-		{`a > 1 AND b = 1`, []string{"a", "b"}, `[a >= 2, b = 1]`},
-		{`a > 1 AND b != 1`, []string{"a", "b"}, `[a >= 2, b IS NOT NULL]`},
-		{`a > 1 AND b > 1`, []string{"a", "b"}, `[a >= 2, b >= 2]`},
-		{`a > 1 AND b >= 1`, []string{"a", "b"}, `[a >= 2, b >= 1]`},
-		{`a > 1 AND b < 1`, []string{"a", "b"}, `[a >= 2]`},
-		{`a > 1 AND b <= 1`, []string{"a", "b"}, `[a >= 2]`},
+		{`a > 1 AND b = 1`, `a,b`, `[a >= 2, b = 1]`},
+		{`a > 1 AND b != 1`, `a,b`, `[a >= 2, b IS NOT NULL]`},
+		{`a > 1 AND b > 1`, `a,b`, `[a >= 2, b >= 2]`},
+		{`a > 1 AND b >= 1`, `a,b`, `[a >= 2, b >= 1]`},
+		{`a > 1 AND b < 1`, `a,b`, `[a >= 2]`},
+		{`a > 1 AND b <= 1`, `a,b`, `[a >= 2]`},
 
-		{`a >= 1 AND b = 1`, []string{"a", "b"}, `[a >= 1, b = 1]`},
-		{`a >= 1 AND b != 1`, []string{"a", "b"}, `[a >= 1, b IS NOT NULL]`},
-		{`a >= 1 AND b > 1`, []string{"a", "b"}, `[a >= 1, b >= 2]`},
-		{`a >= 1 AND b >= 1`, []string{"a", "b"}, `[a >= 1, b >= 1]`},
-		{`a >= 1 AND b < 1`, []string{"a", "b"}, `[a >= 1]`},
-		{`a >= 1 AND b <= 1`, []string{"a", "b"}, `[a >= 1]`},
+		{`a >= 1 AND b = 1`, `a,b`, `[a >= 1, b = 1]`},
+		{`a >= 1 AND b != 1`, `a,b`, `[a >= 1, b IS NOT NULL]`},
+		{`a >= 1 AND b > 1`, `a,b`, `[a >= 1, b >= 2]`},
+		{`a >= 1 AND b >= 1`, `a,b`, `[a >= 1, b >= 1]`},
+		{`a >= 1 AND b < 1`, `a,b`, `[a >= 1]`},
+		{`a >= 1 AND b <= 1`, `a,b`, `[a >= 1]`},
 
-		{`a < 1 AND b = 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0, b = 1]`},
-		{`a < 1 AND b != 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0]`},
-		{`a < 1 AND b > 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0]`},
-		{`a < 1 AND b >= 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0]`},
-		{`a < 1 AND b < 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0, b <= 0]`},
-		{`a < 1 AND b <= 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 0, b <= 1]`},
+		{`a < 1 AND b = 1`, `a,b`, `[a IS NOT NULL, a <= 0, b = 1]`},
+		{`a < 1 AND b != 1`, `a,b`, `[a IS NOT NULL, a <= 0]`},
+		{`a < 1 AND b > 1`, `a,b`, `[a IS NOT NULL, a <= 0]`},
+		{`a < 1 AND b >= 1`, `a,b`, `[a IS NOT NULL, a <= 0]`},
+		{`a < 1 AND b < 1`, `a,b`, `[a IS NOT NULL, a <= 0, b <= 0]`},
+		{`a < 1 AND b <= 1`, `a,b`, `[a IS NOT NULL, a <= 0, b <= 1]`},
 
-		{`a <= 1 AND b = 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1, b = 1]`},
-		{`a <= 1 AND b != 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1]`},
-		{`a <= 1 AND b > 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1]`},
-		{`a <= 1 AND b >= 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1]`},
-		{`a <= 1 AND b < 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1, b <= 0]`},
-		{`a <= 1 AND b <= 1`, []string{"a", "b"}, `[a IS NOT NULL, a <= 1, b <= 1]`},
+		{`a <= 1 AND b = 1`, `a,b`, `[a IS NOT NULL, a <= 1, b = 1]`},
+		{`a <= 1 AND b != 1`, `a,b`, `[a IS NOT NULL, a <= 1]`},
+		{`a <= 1 AND b > 1`, `a,b`, `[a IS NOT NULL, a <= 1]`},
+		{`a <= 1 AND b >= 1`, `a,b`, `[a IS NOT NULL, a <= 1]`},
+		{`a <= 1 AND b < 1`, `a,b`, `[a IS NOT NULL, a <= 1, b <= 0]`},
+		{`a <= 1 AND b <= 1`, `a,b`, `[a IS NOT NULL, a <= 1, b <= 1]`},
 
-		{`a IN (1) AND b = 1`, []string{"a", "b"}, `[a IN (1), b = 1]`},
-		{`a IN (1) AND b != 1`, []string{"a", "b"}, `[a IN (1), b IS NOT NULL]`},
-		{`a IN (1) AND b > 1`, []string{"a", "b"}, `[a IN (1), b >= 2]`},
-		{`a IN (1) AND b >= 1`, []string{"a", "b"}, `[a IN (1), b >= 1]`},
-		{`a IN (1) AND b < 1`, []string{"a", "b"}, `[a IN (1), b IS NOT NULL, b <= 0]`},
-		{`a IN (1) AND b <= 1`, []string{"a", "b"}, `[a IN (1), b IS NOT NULL, b <= 1]`},
+		{`a IN (1) AND b = 1`, `a,b`, `[a IN (1), b = 1]`},
+		{`a IN (1) AND b != 1`, `a,b`, `[a IN (1), b IS NOT NULL]`},
+		{`a IN (1) AND b > 1`, `a,b`, `[a IN (1), b >= 2]`},
+		{`a IN (1) AND b >= 1`, `a,b`, `[a IN (1), b >= 1]`},
+		{`a IN (1) AND b < 1`, `a,b`, `[a IN (1), b IS NOT NULL, b <= 0]`},
+		{`a IN (1) AND b <= 1`, `a,b`, `[a IN (1), b IS NOT NULL, b <= 1]`},
 
-		{`(a, b) IN ((1, 2))`, []string{"a", "b"}, `[(a, b) IN ((1, 2))]`},
-		{`(b, a) IN ((1, 2))`, []string{"a", "b"}, `[(b, a) IN ((1, 2))]`},
-		{`(b, a) IN ((1, 2))`, []string{"a"}, `[(b, a) IN ((1, 2))]`},
+		{`(a, b) IN ((1, 2))`, `a,b`, `[(a, b) IN ((1, 2))]`},
+		{`(b, a) IN ((1, 2))`, `a,b`, `[(b, a) IN ((1, 2))]`},
+		{`(b, a) IN ((1, 2))`, `a`, `[(b, a) IN ((1, 2))]`},
 
-		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, []string{"a", "b"}, `[(a, b) IN ((1, 2))]`},
+		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, `a,b`, `[(a, b) IN ((1, 2))]`},
 
-		{`a IS NULL`, []string{"a"}, `[a IS NULL]`},
-		{`a IS NOT NULL`, []string{"a"}, `[a IS NOT NULL]`},
+		{`a IS NULL`, `a`, `[a IS NULL]`},
+		{`a IS NOT NULL`, `a`, `[a IS NOT NULL]`},
 	}
 	for _, d := range testData {
-		dirs := make([]encoding.Direction, 0, len(d.columns))
-		for range d.columns {
-			dirs = append(dirs, encoding.Ascending)
-		}
-		desc, index := makeTestIndex(t, d.columns, dirs)
+		desc, index := makeTestIndexFromStr(t, d.columns)
 		constraints, _ := makeConstraints(t, d.expr, desc, index)
 		if s := constraints.String(); d.expected != s {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
@@ -185,114 +198,115 @@ func TestMakeSpans(t *testing.T) {
 
 	testData := []struct {
 		expr         string
-		columns      []string
+		columns      string
 		expectedAsc  string
 		expectedDesc string
 	}{
-		{`a = 1`, []string{"a"}, `/1-/2`, `/1-/0`},
-		{`a != 1`, []string{"a"}, `/#-`, `-/#`},
-		{`a > 1`, []string{"a"}, `/2-`, `-/1`},
-		{`a >= 1`, []string{"a"}, `/1-`, `-/0`},
-		{`a < 1`, []string{"a"}, `/#-/1`, `/0-/#`},
-		{`a <= 1`, []string{"a"}, `/#-/2`, `/1-/#`},
-		{`a IS NULL`, []string{"a"}, `-/#`, `/NULL-`},
-		{`a IS NOT NULL`, []string{"a"}, `/#-`, `-/#`},
+		{`a = 1`, `a`, `/1-/2`, `/1-/0`},
+		{`a != 1`, `a`, `/#-`, `-/#`},
+		{`a > 1`, `a`, `/2-`, `-/1`},
+		{`a >= 1`, `a`, `/1-`, `-/0`},
+		{`a < 1`, `a`, `/#-/1`, `/0-/#`},
+		{`a <= 1`, `a`, `/#-/2`, `/1-/#`},
+		{`a IS NULL`, `a`, `-/#`, `/NULL-`},
+		{`a IS NOT NULL`, `a`, `/#-`, `-/#`},
 
-		{`a IN (1,2,3)`, []string{"a"}, `/1-/2 /2-/3 /3-/4`, `/3-/2 /2-/1 /1-/0`},
-		{`a IN (1,2,3) AND b = 1`, []string{"a", "b"},
+		{`a IN (1,2,3)`, `a`, `/1-/2 /2-/3 /3-/4`, `/3-/2 /2-/1 /1-/0`},
+		{`a IN (1,2,3) AND b = 1`, `a,b`,
 			`/1/1-/1/2 /2/1-/2/2 /3/1-/3/2`, `/3/1-/3/0 /2/1-/2/0 /1/1-/1/0`},
-		{`a = 1 AND b IN (1,2,3)`, []string{"a", "b"},
+		{`a = 1 AND b IN (1,2,3)`, `a,b`,
 			`/1/1-/1/2 /1/2-/1/3 /1/3-/1/4`, `/1/3-/1/2 /1/2-/1/1 /1/1-/1/0`},
-		{`a >= 1 AND b IN (1,2,3)`, []string{"a", "b"}, `/1-`, `-/0`},
-		{`a <= 1 AND b IN (1,2,3)`, []string{"a", "b"}, `/#-/2`, `/1-/#`},
-		{`(a, b) IN ((1, 2), (3, 4))`, []string{"a", "b"},
+		{`a >= 1 AND b IN (1,2,3)`, `a,b`, `/1-`, `-/0`},
+		{`a <= 1 AND b IN (1,2,3)`, `a,b`, `/#-/2`, `/1-/#`},
+		{`(a, b) IN ((1, 2), (3, 4))`, `a,b`,
 			`/1/2-/1/3 /3/4-/3/5`, `/3/4-/3/3 /1/2-/1/1`},
-		{`(b, a) IN ((1, 2), (3, 4))`, []string{"a", "b"},
+		{`(b, a) IN ((1, 2), (3, 4))`, `a,b`,
 			`/2/1-/2/2 /4/3-/4/4`, `/4/3-/4/2 /2/1-/2/0`},
-		{`(a, b) IN ((1, 2), (3, 4))`, []string{"b"}, `/2-/3 /4-/5`, `/4-/3 /2-/1`},
+		{`(a, b) IN ((1, 2), (3, 4))`, `b`, `/2-/3 /4-/5`, `/4-/3 /2-/1`},
 
-		{`a = 1 AND b = 1`, []string{"a", "b"}, `/1/1-/1/2`, `/1/1-/1/0`},
-		{`a = 1 AND b != 1`, []string{"a", "b"}, `/1/#-/2`, `/1-/1/#`},
-		{`a = 1 AND b > 1`, []string{"a", "b"}, `/1/2-/2`, `/1-/1/1`},
-		{`a = 1 AND b >= 1`, []string{"a", "b"}, `/1/1-/2`, `/1-/1/0`},
-		{`a = 1 AND b < 1`, []string{"a", "b"}, `/1/#-/1/1`, `/1/0-/1/#`},
-		{`a = 1 AND b <= 1`, []string{"a", "b"}, `/1/#-/1/2`, `/1/1-/1/#`},
-		{`a = 1 AND b IS NULL`, []string{"a", "b"}, `/1-/1/#`, `/1/NULL-/0`},
-		{`a = 1 AND b IS NOT NULL`, []string{"a", "b"}, `/1/#-/2`, `/1-/1/#`},
+		{`a = 1 AND b = 1`, `a,b`, `/1/1-/1/2`, `/1/1-/1/0`},
+		{`a = 1 AND b != 1`, `a,b`, `/1/#-/2`, `/1-/1/#`},
+		{`a = 1 AND b > 1`, `a,b`, `/1/2-/2`, `/1-/1/1`},
+		{`a = 1 AND b >= 1`, `a,b`, `/1/1-/2`, `/1-/1/0`},
+		{`a = 1 AND b < 1`, `a,b`, `/1/#-/1/1`, `/1/0-/1/#`},
+		{`a = 1 AND b <= 1`, `a,b`, `/1/#-/1/2`, `/1/1-/1/#`},
+		{`a = 1 AND b IS NULL`, `a,b`, `/1-/1/#`, `/1/NULL-/0`},
+		{`a = 1 AND b IS NOT NULL`, `a,b`, `/1/#-/2`, `/1-/1/#`},
 
-		{`a != 1 AND b = 1`, []string{"a", "b"}, `/#-`, `-/#`},
-		{`a != 1 AND b != 1`, []string{"a", "b"}, `/#-`, `-/#`},
-		{`a != 1 AND b > 1`, []string{"a", "b"}, `/#-`, `-/#`},
-		{`a != 1 AND b >= 1`, []string{"a", "b"}, `/#-`, `-/#`},
-		{`a != 1 AND b < 1`, []string{"a", "b"}, `/#-`, `-/#`},
-		{`a != 1 AND b <= 1`, []string{"a", "b"}, `/#-`, `-/#`},
-		{`a != 1 AND b IS NULL`, []string{"a", "b"}, `/#-`, `-/#`},
-		{`a != 1 AND b IS NOT NULL`, []string{"a", "b"}, `/#-`, `-/#`},
+		{`a != 1 AND b = 1`, `a,b`, `/#-`, `-/#`},
+		{`a != 1 AND b != 1`, `a,b`, `/#-`, `-/#`},
+		{`a != 1 AND b > 1`, `a,b`, `/#-`, `-/#`},
+		{`a != 1 AND b >= 1`, `a,b`, `/#-`, `-/#`},
+		{`a != 1 AND b < 1`, `a,b`, `/#-`, `-/#`},
+		{`a != 1 AND b <= 1`, `a,b`, `/#-`, `-/#`},
+		{`a != 1 AND b IS NULL`, `a,b`, `/#-`, `-/#`},
+		{`a != 1 AND b IS NOT NULL`, `a,b`, `/#-`, `-/#`},
 
-		{`a > 1 AND b = 1`, []string{"a", "b"}, `/2/1-`, `-/2/0`},
-		{`a > 1 AND b != 1`, []string{"a", "b"}, `/2/#-`, `-/2/#`},
-		{`a > 1 AND b > 1`, []string{"a", "b"}, `/2/2-`, `-/2/1`},
-		{`a > 1 AND b >= 1`, []string{"a", "b"}, `/2/1-`, `-/2/0`},
-		{`a > 1 AND b < 1`, []string{"a", "b"}, `/2-`, `-/1`},
-		{`a > 1 AND b <= 1`, []string{"a", "b"}, `/2-`, `-/1`},
-		{`a > 1 AND b IS NULL`, []string{"a", "b"}, `/2-`, `-/1`},
-		{`a > 1 AND b IS NOT NULL`, []string{"a", "b"}, `/2/#-`, `-/2/#`},
+		{`a > 1 AND b = 1`, `a,b`, `/2/1-`, `-/2/0`},
+		{`a > 1 AND b != 1`, `a,b`, `/2/#-`, `-/2/#`},
+		{`a > 1 AND b > 1`, `a,b`, `/2/2-`, `-/2/1`},
+		{`a > 1 AND b >= 1`, `a,b`, `/2/1-`, `-/2/0`},
+		{`a > 1 AND b < 1`, `a,b`, `/2-`, `-/1`},
+		{`a > 1 AND b <= 1`, `a,b`, `/2-`, `-/1`},
+		{`a > 1 AND b IS NULL`, `a,b`, `/2-`, `-/1`},
+		{`a > 1 AND b IS NOT NULL`, `a,b`, `/2/#-`, `-/2/#`},
 
-		{`a >= 1 AND b = 1`, []string{"a", "b"}, `/1/1-`, `-/1/0`},
-		{`a >= 1 AND b != 1`, []string{"a", "b"}, `/1/#-`, `-/1/#`},
-		{`a >= 1 AND b > 1`, []string{"a", "b"}, `/1/2-`, `-/1/1`},
-		{`a >= 1 AND b >= 1`, []string{"a", "b"}, `/1/1-`, `-/1/0`},
-		{`a >= 1 AND b < 1`, []string{"a", "b"}, `/1-`, `-/0`},
-		{`a >= 1 AND b <= 1`, []string{"a", "b"}, `/1-`, `-/0`},
-		{`a >= 1 AND b IS NULL`, []string{"a", "b"}, `/1-`, `-/0`},
-		{`a >= 1 AND b IS NOT NULL`, []string{"a", "b"}, `/1/#-`, `-/1/#`},
+		{`a >= 1 AND b = 1`, `a,b`, `/1/1-`, `-/1/0`},
+		{`a >= 1 AND b != 1`, `a,b`, `/1/#-`, `-/1/#`},
+		{`a >= 1 AND b > 1`, `a,b`, `/1/2-`, `-/1/1`},
+		{`a >= 1 AND b >= 1`, `a,b`, `/1/1-`, `-/1/0`},
+		{`a >= 1 AND b < 1`, `a,b`, `/1-`, `-/0`},
+		{`a >= 1 AND b <= 1`, `a,b`, `/1-`, `-/0`},
+		{`a >= 1 AND b IS NULL`, `a,b`, `/1-`, `-/0`},
+		{`a >= 1 AND b IS NOT NULL`, `a,b`, `/1/#-`, `-/1/#`},
 
-		{`a < 1 AND b = 1`, []string{"a", "b"}, `/#-/0/2`, `/0/1-/#`},
-		{`a < 1 AND b != 1`, []string{"a", "b"}, `/#-/1`, `/0-/#`},
-		{`a < 1 AND b > 1`, []string{"a", "b"}, `/#-/1`, `/0-/#`},
-		{`a < 1 AND b >= 1`, []string{"a", "b"}, `/#-/1`, `/0-/#`},
-		{`a < 1 AND b < 1`, []string{"a", "b"}, `/#-/0/1`, `/0/0-/#`},
-		{`a < 1 AND b <= 1`, []string{"a", "b"}, `/#-/0/2`, `/0/1-/#`},
-		{`a < 1 AND b IS NULL`, []string{"a", "b"}, `/#-/0/#`, `/0/NULL-/#`},
-		{`a < 1 AND b IS NOT NULL`, []string{"a", "b"}, `/#-/1`, `/0-/#`},
+		{`a < 1 AND b = 1`, `a,b`, `/#-/0/2`, `/0/1-/#`},
+		{`a < 1 AND b != 1`, `a,b`, `/#-/1`, `/0-/#`},
+		{`a < 1 AND b > 1`, `a,b`, `/#-/1`, `/0-/#`},
+		{`a < 1 AND b >= 1`, `a,b`, `/#-/1`, `/0-/#`},
+		{`a < 1 AND b < 1`, `a,b`, `/#-/0/1`, `/0/0-/#`},
+		{`a < 1 AND b <= 1`, `a,b`, `/#-/0/2`, `/0/1-/#`},
+		{`a < 1 AND b IS NULL`, `a,b`, `/#-/0/#`, `/0/NULL-/#`},
+		{`a < 1 AND b IS NOT NULL`, `a,b`, `/#-/1`, `/0-/#`},
 
-		{`a <= 1 AND b = 1`, []string{"a", "b"}, `/#-/1/2`, `/1/1-/#`},
-		{`a <= 1 AND b != 1`, []string{"a", "b"}, `/#-/2`, `/1-/#`},
-		{`a <= 1 AND b > 1`, []string{"a", "b"}, `/#-/2`, `/1-/#`},
-		{`a <= 1 AND b >= 1`, []string{"a", "b"}, `/#-/2`, `/1-/#`},
-		{`a <= 1 AND b < 1`, []string{"a", "b"}, `/#-/1/1`, `/1/0-/#`},
-		{`a <= 1 AND b <= 1`, []string{"a", "b"}, `/#-/1/2`, `/1/1-/#`},
-		{`a <= 1 AND b IS NULL`, []string{"a", "b"}, `/#-/1/#`, `/1/NULL-/#`},
-		{`a <= 1 AND b IS NOT NULL`, []string{"a", "b"}, `/#-/2`, `/1-/#`},
+		{`a <= 1 AND b = 1`, `a,b`, `/#-/1/2`, `/1/1-/#`},
+		{`a <= 1 AND b != 1`, `a,b`, `/#-/2`, `/1-/#`},
+		{`a <= 1 AND b > 1`, `a,b`, `/#-/2`, `/1-/#`},
+		{`a <= 1 AND b >= 1`, `a,b`, `/#-/2`, `/1-/#`},
+		{`a <= 1 AND b < 1`, `a,b`, `/#-/1/1`, `/1/0-/#`},
+		{`a <= 1 AND b <= 1`, `a,b`, `/#-/1/2`, `/1/1-/#`},
+		{`a <= 1 AND b IS NULL`, `a,b`, `/#-/1/#`, `/1/NULL-/#`},
+		{`a <= 1 AND b IS NOT NULL`, `a,b`, `/#-/2`, `/1-/#`},
 
-		{`a IN (1) AND b = 1`, []string{"a", "b"}, `/1/1-/1/2`, `/1/1-/1/0`},
-		{`a IN (1) AND b != 1`, []string{"a", "b"}, `/1/#-/2`, `/1-/1/#`},
-		{`a IN (1) AND b > 1`, []string{"a", "b"}, `/1/2-/2`, `/1-/1/1`},
-		{`a IN (1) AND b >= 1`, []string{"a", "b"}, `/1/1-/2`, `/1-/1/0`},
-		{`a IN (1) AND b < 1`, []string{"a", "b"}, `/1/#-/1/1`, `/1/0-/1/#`},
-		{`a IN (1) AND b <= 1`, []string{"a", "b"}, `/1/#-/1/2`, `/1/1-/1/#`},
-		{`a IN (1) AND b IS NULL`, []string{"a", "b"}, `/1-/1/#`, `/1/NULL-/0`},
-		{`a IN (1) AND b IS NOT NULL`, []string{"a", "b"}, `/1/#-/2`, `/1-/1/#`},
+		{`a IN (1) AND b = 1`, `a,b`, `/1/1-/1/2`, `/1/1-/1/0`},
+		{`a IN (1) AND b != 1`, `a,b`, `/1/#-/2`, `/1-/1/#`},
+		{`a IN (1) AND b > 1`, `a,b`, `/1/2-/2`, `/1-/1/1`},
+		{`a IN (1) AND b >= 1`, `a,b`, `/1/1-/2`, `/1-/1/0`},
+		{`a IN (1) AND b < 1`, `a,b`, `/1/#-/1/1`, `/1/0-/1/#`},
+		{`a IN (1) AND b <= 1`, `a,b`, `/1/#-/1/2`, `/1/1-/1/#`},
+		{`a IN (1) AND b IS NULL`, `a,b`, `/1-/1/#`, `/1/NULL-/0`},
+		{`a IN (1) AND b IS NOT NULL`, `a,b`, `/1/#-/2`, `/1-/1/#`},
 
-		{`(a, b) = (1, 2)`, []string{"a"}, `/1-/2`, `/1-/0`},
-		{`(a, b) = (1, 2)`, []string{"a", "b"}, `/1/2-/1/3`, `/1/2-/1/1`},
+		{`(a, b) = (1, 2)`, `a`, `/1-/2`, `/1-/0`},
+		{`(a, b) = (1, 2)`, `a,b`, `/1/2-/1/3`, `/1/2-/1/1`},
 
 		// When encoding an end constraint for a maximal datum, we use
 		// bytes.PrefixEnd() to go beyond the normal encodings of that datatype.
-		{fmt.Sprintf(`a = %d`, math.MaxInt64), []string{"a"},
+		{fmt.Sprintf(`a = %d`, math.MaxInt64), `a`,
 			`/9223372036854775807-/<util/encoding/encoding.go: ` +
 				`varint 9223372036854775808 overflows int64>`, `/9223372036854775807-/9223372036854775806`},
-		{fmt.Sprintf(`a = %d`, math.MinInt64), []string{"a"},
+		{fmt.Sprintf(`a = %d`, math.MinInt64), `a`,
 			`/-9223372036854775808-/-9223372036854775807`,
 			`/-9223372036854775808-/<util/encoding/encoding.go: varint 9223372036854775808 overflows int64>`},
 	}
 	for _, d := range testData {
 		for _, dir := range []encoding.Direction{encoding.Ascending, encoding.Descending} {
-			dirs := make([]encoding.Direction, 0, len(d.columns))
-			for range d.columns {
+			columns := strings.Split(d.columns, ",")
+			dirs := make([]encoding.Direction, 0, len(columns))
+			for range columns {
 				dirs = append(dirs, dir)
 			}
-			desc, index := makeTestIndex(t, d.columns, dirs)
+			desc, index := makeTestIndex(t, columns, dirs)
 			constraints, _ := makeConstraints(t, d.expr, desc, index)
 			spans := makeSpans(constraints, desc.ID, index)
 			s := prettySpans(spans, 2)
@@ -309,46 +323,27 @@ func TestMakeSpans(t *testing.T) {
 		}
 	}
 
-	type Col struct {
-		col string
-		dir encoding.Direction
-	}
-
 	// Test indexes with mixed-directions (some cols Asc, some cols Desc) and other edge cases.
 	testData2 := []struct {
 		expr     string
-		columns  []Col
+		columns  string
 		expected string
 	}{
-		{`a = 1 AND b = 5`,
-			[]Col{{"a", encoding.Ascending}, {"b", encoding.Descending}, {"c", encoding.Ascending}},
-			`/1/5-/1/4`},
-		{`a = 7 AND b IN (1,2,3) AND c = false`,
-			[]Col{{"a", encoding.Ascending}, {"b", encoding.Descending}, {"c", encoding.Ascending}},
+		{`a = 1 AND b = 5`, `a,b-,c`, `/1/5-/1/4`},
+		{`a = 7 AND b IN (1,2,3) AND c = false`, `a,b-,c`,
 			`/7/3/0-/7/3/1 /7/2/0-/7/2/1 /7/1/0-/7/1/1`},
 		// Test different directions for te columns inside a tuple.
-		{`(a,b,j) IN ((1,2,3), (4,5,6))`,
-			[]Col{{"a", encoding.Descending}, {"b", encoding.Ascending}, {"j", encoding.Descending}},
-			`/4/5/6-/4/5/5 /1/2/3-/1/2/2`},
-		{`i = E'\xff'`,
-			[]Col{{"i", encoding.Ascending}},
-			`/"\xff"-/"\xff\x00"`},
+		{`(a,b,j) IN ((1,2,3), (4,5,6))`, `a-,b,j-`, `/4/5/6-/4/5/5 /1/2/3-/1/2/2`},
+		{`i = E'\xff'`, `i`, `/"\xff"-/"\xff\x00"`},
 		// Test that limits on bytes work correctly: when encoding a descending limit for bytes,
 		// we need to go outside the bytes encoding.
 		// "\xaa" is encoded as [bytesDescMarker, ^0xaa, <term escape sequence>]
-		{`i = E'\xaa'`,
-			[]Col{{"i", encoding.Descending}},
+		{`i = E'\xaa'`, `i-`,
 			fmt.Sprintf("raw:%c%c\xff\xfe-%c%c\xff\xff",
 				encoding.BytesDescMarker, ^byte(0xaa), encoding.BytesDescMarker, ^byte(0xaa))},
 	}
 	for _, d := range testData2 {
-		cols := make([]string, 0, len(d.columns))
-		dirs := make([]encoding.Direction, 0, len(d.columns))
-		for _, col := range d.columns {
-			cols = append(cols, col.col)
-			dirs = append(dirs, col.dir)
-		}
-		desc, index := makeTestIndex(t, cols, dirs)
+		desc, index := makeTestIndexFromStr(t, d.columns)
 		constraints, _ := makeConstraints(t, d.expr, desc, index)
 		spans := makeSpans(constraints, desc.ID, index)
 		var got string
@@ -378,25 +373,21 @@ func TestExactPrefix(t *testing.T) {
 
 	testData := []struct {
 		expr     string
-		columns  []string
+		columns  string
 		expected int
 	}{
-		{`a = 1`, []string{"a"}, 1},
-		{`a != 1`, []string{"a"}, 0},
-		{`a IN (1)`, []string{"a"}, 1},
-		{`a = 1 AND b = 1`, []string{"a", "b"}, 2},
-		{`(a, b) IN ((1, 2))`, []string{"a", "b"}, 2},
-		{`(a, b) IN ((1, 2))`, []string{"a"}, 1},
-		{`(a, b) IN ((1, 2))`, []string{"b"}, 1},
-		{`(a, b) IN ((1, 2)) AND c = true`, []string{"a", "b", "c"}, 3},
-		{`a = 1 AND (b, c) IN ((2, true))`, []string{"a", "b", "c"}, 3},
+		{`a = 1`, `a`, 1},
+		{`a != 1`, `a`, 0},
+		{`a IN (1)`, `a`, 1},
+		{`a = 1 AND b = 1`, `a,b`, 2},
+		{`(a, b) IN ((1, 2))`, `a,b`, 2},
+		{`(a, b) IN ((1, 2))`, `a`, 1},
+		{`(a, b) IN ((1, 2))`, `b`, 1},
+		{`(a, b) IN ((1, 2)) AND c = true`, `a,b,c`, 3},
+		{`a = 1 AND (b, c) IN ((2, true))`, `a,b,c`, 3},
 	}
 	for _, d := range testData {
-		dirs := make([]encoding.Direction, 0, len(d.columns))
-		for range d.columns {
-			dirs = append(dirs, encoding.Ascending)
-		}
-		desc, index := makeTestIndex(t, d.columns, dirs)
+		desc, index := makeTestIndexFromStr(t, d.columns)
 		constraints, _ := makeConstraints(t, d.expr, desc, index)
 		prefix := exactPrefix(constraints)
 		if d.expected != prefix {
@@ -410,41 +401,37 @@ func TestApplyConstraints(t *testing.T) {
 
 	testData := []struct {
 		expr     string
-		columns  []string
+		columns  string
 		expected string
 	}{
-		{`a = 1`, []string{"a"}, `<nil>`},
-		{`a = 1 AND b = 1`, []string{"a", "b"}, `<nil>`},
-		{`a = 1 AND b = 1`, []string{"a"}, `b = 1`},
-		{`a = 1 AND b = 1`, []string{"b"}, `a = 1`},
-		{`a = 1 AND b > 1`, []string{"a", "b"}, `b > 1`},
-		{`a > 1 AND b = 1`, []string{"a", "b"}, `a > 1 AND b = 1`},
-		{`a IN (1)`, []string{"a"}, `<nil>`},
-		{`a IN (1) OR a IN (2)`, []string{"a"}, `<nil>`},
-		{`a = 1 OR a = 2`, []string{"a"}, `<nil>`},
-		{`a = 1 OR b = 2`, []string{"a"}, `a = 1 OR b = 2`},
-		{`NOT (a != 1)`, []string{"a"}, `<nil>`},
-		{`a != 1`, []string{"a"}, `a != 1`},
-		{`a IS NOT NULL`, []string{"a"}, `<nil>`},
-		{`a = 1 AND b IS NOT NULL`, []string{"a", "b"}, `<nil>`},
-		{`a >= 1 AND b = 2`, []string{"a", "b"}, `a >= 1 AND b = 2`},
-		{`a >= 1 AND a <= 3 AND b = 2`, []string{"a", "b"}, `a >= 1 AND a <= 3 AND b = 2`},
-		{`(a, b) = (1, 2) AND c IS NOT NULL`, []string{"a", "b", "c"}, `<nil>`},
-		{`a IN (1, 2) AND b = 3`, []string{"a", "b"}, `b = 3`},
-		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, []string{"a", "b"}, `a <= 5 AND b >= 6`},
-		{`a IN (1) AND a = 1`, []string{"a"}, `<nil>`},
-		{`(a, b) = (1, 2)`, []string{"a"}, `(a, b) IN ((1, 2))`},
+		{`a = 1`, `a`, `<nil>`},
+		{`a = 1 AND b = 1`, `a,b`, `<nil>`},
+		{`a = 1 AND b = 1`, `a`, `b = 1`},
+		{`a = 1 AND b = 1`, `b`, `a = 1`},
+		{`a = 1 AND b > 1`, `a,b`, `b > 1`},
+		{`a > 1 AND b = 1`, `a,b`, `a > 1 AND b = 1`},
+		{`a IN (1)`, `a`, `<nil>`},
+		{`a IN (1) OR a IN (2)`, `a`, `<nil>`},
+		{`a = 1 OR a = 2`, `a`, `<nil>`},
+		{`a = 1 OR b = 2`, `a`, `a = 1 OR b = 2`},
+		{`NOT (a != 1)`, `a`, `<nil>`},
+		{`a != 1`, `a`, `a != 1`},
+		{`a IS NOT NULL`, `a`, `<nil>`},
+		{`a = 1 AND b IS NOT NULL`, `a,b`, `<nil>`},
+		{`a >= 1 AND b = 2`, `a,b`, `a >= 1 AND b = 2`},
+		{`a >= 1 AND a <= 3 AND b = 2`, `a,b`, `a >= 1 AND a <= 3 AND b = 2`},
+		{`(a, b) = (1, 2) AND c IS NOT NULL`, `a,b,c`, `<nil>`},
+		{`a IN (1, 2) AND b = 3`, `a,b`, `b = 3`},
+		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, `a,b`, `a <= 5 AND b >= 6`},
+		{`a IN (1) AND a = 1`, `a`, `<nil>`},
+		{`(a, b) = (1, 2)`, `a`, `(a, b) IN ((1, 2))`},
 		// Filters that are not trimmed as of Dec 2015, although they could be.
 		// Issue #3473.
-		// {`a > 1`, []string{"a"}, `<nil>`},
-		// {`a < 1`, []string{"a"}, `<nil>`},
+		// {`a > 1`, `a`, `<nil>`},
+		// {`a < 1`, `a`, `<nil>`},
 	}
 	for _, d := range testData {
-		dirs := make([]encoding.Direction, 0, len(d.columns))
-		for range d.columns {
-			dirs = append(dirs, encoding.Ascending)
-		}
-		desc, index := makeTestIndex(t, d.columns, dirs)
+		desc, index := makeTestIndexFromStr(t, d.columns)
 		constraints, expr := makeConstraints(t, d.expr, desc, index)
 		expr2 := applyConstraints(expr, constraints)
 		if s := fmt.Sprint(expr2); d.expected != s {

--- a/sql/index_selection_test.go
+++ b/sql/index_selection_test.go
@@ -26,7 +26,95 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/log"
 )
+
+func TestMergeAndSortSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Each testcase is a list of ranges; each range gets converted into a span.
+	testCases := [][][2]int{
+		{{1, 10}},
+		{{1, 2}, {2, 3}},
+		{{1, 2}, {2, 3}, {2, 4}, {2, 5}, {3, 4}, {3, 4}, {3, 5}},
+		{{2, 4}, {1, 3}},
+		{{1, 2}, {2, 3}, {2, 4}, {3, 6}, {4, 6}, {5, 6}},
+		{{3, 4}, {1, 2}},
+		{{3, 5}, {1, 2}, {4, 7}},
+		{{1, 50}, {1, 2}, {1, 3}, {3, 5}, {3, 10}, {9, 30}, {30, 49}},
+		{{10, 15}, {5, 9}, {20, 30}, {40, 50}, {35, 36}},
+		{{10, 15}, {5, 9}, {20, 30}, {40, 50}, {35, 36}, {36, 40}},
+		{{10, 15}, {5, 9}, {20, 30}, {9, 10}, {40, 50}, {35, 36}, {36, 40}},
+		{{14, 21}, {10, 15}, {5, 9}, {20, 30}, {9, 10}, {40, 50}, {35, 36}, {36, 40}},
+		{{14, 21}, {10, 15}, {5, 9}, {20, 30}, {9, 10}, {40, 50}, {35, 36}, {36, 40}, {30, 35}},
+	}
+
+	for _, tc := range testCases {
+		// We use a bitmap on the keyspace to verify the results:
+		//  - we set the bits for all areas covered by the ranges;
+		//  - we verify that merged spans are ordered, non-overlapping, and
+		//    contain only covered areas of the bitmap;
+		//  - we verify that after we unset all areas covered by the merged
+		//    spans, there are no bits that remain set.
+		bitmap := make([]bool, 100)
+		var s spans
+		for _, v := range tc {
+			start := v[0]
+			end := v[1]
+			for j := start; j < end; j++ {
+				bitmap[j] = true
+			}
+			s = append(s, span{start: []byte{byte(start)}, end: []byte{byte(end)}})
+		}
+
+		printSpans := func(s spans, title string) {
+			fmt.Printf("%s:", title)
+			for _, span := range s {
+				fmt.Printf(" %d-%d", span.start[0], span.end[0])
+			}
+			fmt.Printf("\n")
+		}
+
+		if testing.Verbose() || log.V(1) {
+			printSpans(s, "Input spans ")
+		}
+
+		s = mergeAndSortSpans(s)
+
+		if testing.Verbose() || log.V(1) {
+			printSpans(s, "Output spans")
+		}
+
+		last := -1
+		for i := range s {
+			start := int(s[i].start[0])
+			end := int(s[i].end[0])
+			if start >= end {
+				t.Fatalf("invalid span %d-%d", start, end)
+			}
+			if start <= last {
+				t.Fatalf("span %d-%d starts before previous span ends", start, end)
+			}
+			last = end
+			for j := start; j < end; j++ {
+				if !bitmap[j] {
+					t.Fatalf("span %d-%d incorrectly contains %d", start, end, j)
+				}
+				bitmap[j] = false
+			}
+			if start != 0 && bitmap[start-1] {
+				t.Fatalf("span %d-%d should begin earlier", start, end)
+			}
+			if bitmap[end] {
+				t.Fatalf("span %d-%d should end later", start, end)
+			}
+		}
+		for i, val := range bitmap {
+			if val {
+				t.Fatalf("key %d not covered by any spans", i)
+			}
+		}
+	}
+}
 
 func makeTestIndex(t *testing.T, columns []string, dirs []encoding.Direction) (
 	*TableDescriptor, *IndexDescriptor) {
@@ -71,7 +159,7 @@ func makeTestIndexFromStr(t *testing.T, columnsStr string) (*TableDescriptor, *I
 }
 
 func makeConstraints(t *testing.T, sql string, desc *TableDescriptor,
-	index *IndexDescriptor) (indexConstraints, parser.Expr) {
+	index *IndexDescriptor) (orIndexConstraints, parser.Expr) {
 	expr, _ := parseAndNormalizeExpr(t, sql)
 	exprs, equiv := analyzeExpr(expr)
 
@@ -95,7 +183,7 @@ func TestMakeConstraints(t *testing.T) {
 		columns  string
 		expected string
 	}{
-		{`a = 1`, `b`, `[]`},
+		{`a = 1`, `b`, ``},
 		{`a = 1`, `a`, `[a = 1]`},
 		{`a != 1`, `a`, `[a IS NOT NULL]`},
 		{`a > 1`, `a`, `[a >= 2]`},
@@ -167,10 +255,45 @@ func TestMakeConstraints(t *testing.T) {
 		{`(b, a) IN ((1, 2))`, `a,b`, `[(b, a) IN ((1, 2))]`},
 		{`(b, a) IN ((1, 2))`, `a`, `[(b, a) IN ((1, 2))]`},
 
+		{`(a, b) = (1, 2)`, `a,b`, `[(a, b) IN ((1, 2))]`},
+		{`(b, a) = (1, 2)`, `a,b`, `[(b, a) IN ((1, 2))]`},
+		{`(b, a) = (1, 2)`, `a`, `[(b, a) IN ((1, 2))]`},
+
 		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, `a,b`, `[(a, b) IN ((1, 2))]`},
 
 		{`a IS NULL`, `a`, `[a IS NULL]`},
 		{`a IS NOT NULL`, `a`, `[a IS NOT NULL]`},
+
+		{`a = 1 OR a = 3`, `a`, `[a IN (1, 3)]`},
+		{`a <= 1 OR a >= 8`, `a`, `[a IS NOT NULL, a <= 1] OR [a >= 8]`},
+		{`a < 1 OR a > 2`, `a`, `[a IS NOT NULL, a <= 0] OR [a >= 3]`},
+		{`a < 1 OR a = 3 OR a > 5`, `a`, `[a IS NOT NULL, a <= 0] OR [a = 3] OR [a >= 6]`},
+
+		{`a = 1 OR b = 3`, `a,b`, ``},
+		{`a = 1 OR b > 3`, `a,b`, ``},
+		{`a > 1 OR b > 3`, `a,b`, ``},
+
+		{`(a > 1 AND a < 10) OR (a = 15)`, `a`, `[a >= 2, a <= 9] OR [a = 15]`},
+		{`(a >= 1 AND a <= 10) OR (a >= 20 AND a <= 30)`, `a`,
+			`[a >= 1, a <= 10] OR [a >= 20, a <= 30]`},
+		{`(a > 1 AND a < 10) OR (a > 20 AND a < 30)`, `a`,
+			`[a >= 2, a <= 9] OR [a >= 21, a <= 29]`},
+
+		{`a = 1 OR (a = 3 AND b = 2)`, `a`, `[a = 1] OR [a = 3]`},
+		{`a = 1 OR (a = 3 AND b = 2)`, `b`, ``},
+		{`a = 1 OR (a = 3 AND b = 2)`, `a,b`, `[a = 1] OR [a = 3, b = 2]`},
+		{`a < 2 OR (a > 5 AND b > 2)`, `a`,
+			`[a IS NOT NULL, a <= 1] OR [a >= 6]`},
+		{`a < 2 OR (a > 5 AND b > 2)`, `b`, ``},
+		{`a < 2 OR (a > 5 AND b > 2)`, `a,b`,
+			`[a IS NOT NULL, a <= 1] OR [a >= 6, b >= 3]`},
+
+		{`(a = 1 AND b >= 10 AND b <= 20) OR (a = 2 AND b >= 1 AND b <= 9)`,
+			`a`, `[a = 1] OR [a = 2]`},
+		{`(a = 1 AND b >= 10 AND b <= 20) OR (a = 2 AND b >= 1 AND b <= 9)`,
+			`b`, `[b >= 10, b <= 20] OR [b >= 1, b <= 9]`},
+		{`(a = 1 AND b >= 10 AND b <= 20) OR (a = 2 AND b >= 1 AND b <= 9)`,
+			`a,b`, `[a = 1, b >= 10, b <= 20] OR [a = 2, b >= 1, b <= 9]`},
 	}
 	for _, d := range testData {
 		desc, index := makeTestIndexFromStr(t, d.columns)
@@ -211,11 +334,14 @@ func TestMakeSpans(t *testing.T) {
 		{`a IS NULL`, `a`, `-/#`, `/NULL-`},
 		{`a IS NOT NULL`, `a`, `/#-`, `-/#`},
 
-		{`a IN (1,2,3)`, `a`, `/1-/2 /2-/3 /3-/4`, `/3-/2 /2-/1 /1-/0`},
+		{`a IN (1,2,3)`, `a`, `/1-/4`, `/3-/0`},
+		{`a IN (1,3,5)`, `a`, `/1-/2 /3-/4 /5-/6`, `/5-/4 /3-/2 /1-/0`},
 		{`a IN (1,2,3) AND b = 1`, `a,b`,
 			`/1/1-/1/2 /2/1-/2/2 /3/1-/3/2`, `/3/1-/3/0 /2/1-/2/0 /1/1-/1/0`},
 		{`a = 1 AND b IN (1,2,3)`, `a,b`,
-			`/1/1-/1/2 /1/2-/1/3 /1/3-/1/4`, `/1/3-/1/2 /1/2-/1/1 /1/1-/1/0`},
+			`/1/1-/1/4`, `/1/3-/1/0`},
+		{`a = 1 AND b IN (1,3,5)`, `a,b`,
+			`/1/1-/1/2 /1/3-/1/4 /1/5-/1/6`, `/1/5-/1/4 /1/3-/1/2 /1/1-/1/0`},
 		{`a >= 1 AND b IN (1,2,3)`, `a,b`, `/1-`, `-/0`},
 		{`a <= 1 AND b IN (1,2,3)`, `a,b`, `/#-/2`, `/1-/#`},
 		{`(a, b) IN ((1, 2), (3, 4))`, `a,b`,
@@ -289,6 +415,53 @@ func TestMakeSpans(t *testing.T) {
 
 		{`(a, b) = (1, 2)`, `a`, `/1-/2`, `/1-/0`},
 		{`(a, b) = (1, 2)`, `a,b`, `/1/2-/1/3`, `/1/2-/1/1`},
+
+		{`a > 1 OR a >= 5`, `a`, `/2-`, `-/1`},
+		{`a < 5 OR a >= 1`, `a`, `/#-`, `-/#`},
+		{`a < 1 OR a >= 5`, `a`, `/#-/1 /5-`, `-/4 /0-/#`},
+		{`a = 1 OR a > 8`, `a`, `/1-/2 /9-`, `-/8 /1-/0`},
+		{`a = 8 OR a > 1`, `a`, `/2-`, `-/1`},
+		{`a < 1 OR a = 5 OR a > 8`, `a`, `/#-/1 /5-/6 /9-`, `-/8 /5-/4 /0-/#`},
+		{`a < 8 OR a = 8 OR a > 8`, `a`, `/#-`, `-/#`},
+
+		{`(a = 1 AND b = 5) OR (a = 3 AND b = 7)`, `a`, `/1-/2 /3-/4`, `/3-/2 /1-/0`},
+		{`(a = 1 AND b = 5) OR (a = 3 AND b = 7)`, `b`, `/5-/6 /7-/8`, `/7-/6 /5-/4`},
+		{`(a = 1 AND b = 5) OR (a = 3 AND b = 7)`, `a,b`,
+			`/1/5-/1/6 /3/7-/3/8`, `/3/7-/3/6 /1/5-/1/4`},
+
+		{`(a = 1 AND b < 5) OR (a = 3 AND b > 7)`, `a`, `/1-/2 /3-/4`, `/3-/2 /1-/0`},
+		{`(a = 1 AND b < 5) OR (a = 3 AND b > 7)`, `b`, `/#-/5 /8-`, `-/7 /4-/#`},
+		{`(a = 1 AND b < 5) OR (a = 3 AND b > 7)`, `a,b`,
+			`/1/#-/1/5 /3/8-/4`, `/3-/3/7 /1/4-/1/#`},
+
+		{`(a = 1 AND b > 5) OR (a = 3 AND b > 7)`, `a`, `/1-/2 /3-/4`, `/3-/2 /1-/0`},
+		{`(a = 1 AND b > 5) OR (a = 3 AND b > 7)`, `b`, `/6-`, `-/5`},
+		{`(a = 1 AND b > 5) OR (a = 3 AND b > 7)`, `a,b`,
+			`/1/6-/2 /3/8-/4`, `/3-/3/7 /1-/1/5`},
+
+		{`(a = 1 AND b > 5) OR (a = 3 AND b < 7)`, `a`, `/1-/2 /3-/4`, `/3-/2 /1-/0`},
+		{`(a = 1 AND b > 5) OR (a = 3 AND b < 7)`, `b`, `/#-`, `-/#`},
+		{`(a = 1 AND b > 5) OR (a = 3 AND b < 7)`, `a,b`,
+			`/1/6-/2 /3/#-/3/7`, `/3/6-/3/# /1-/1/5`},
+
+		{`(a < 1 AND b < 5) OR (a > 3 AND b > 7)`, `a`, `/#-/1 /4-`, `-/3 /0-/#`},
+		{`(a < 1 AND b < 5) OR (a > 3 AND b > 7)`, `b`, `/#-/5 /8-`, `-/7 /4-/#`},
+		{`(a < 1 AND b < 5) OR (a > 3 AND b > 7)`, `a,b`,
+			`/#-/0/5 /4/8-`, `-/4/7 /0/4-/#`},
+
+		{`(a > 3 AND b < 5) OR (a < 1 AND b > 7)`, `a`, `/#-/1 /4-`, `-/3 /0-/#`},
+		{`(a > 3 AND b < 5) OR (a < 1 AND b > 7)`, `b`, `/#-/5 /8-`, `-/7 /4-/#`},
+		{`(a > 3 AND b < 5) OR (a < 1 AND b > 7)`, `a,b`,
+			`/#-/1 /4-`, `-/3 /0-/#`},
+
+		{`(a > 1 AND b < 5) OR (a < 3 AND b > 7)`, `a`, `/#-`, `-/#`},
+		{`(a > 1 AND b < 5) OR (a < 3 AND b > 7)`, `b`, `/#-/5 /8-`, `-/7 /4-/#`},
+		{`(a > 1 AND b < 5) OR (a < 3 AND b > 7)`, `a,b`, `/#-`, `-/#`},
+
+		{`(a = 5) OR (a, b) IN ((1, 1), (3, 3))`, `a`, `/1-/2 /3-/4 /5-/6`, `/5-/4 /3-/2 /1-/0`},
+		{`(a = 5) OR (a, b) IN ((1, 1), (3, 3))`, `b`, `-`, `-`},
+		{`(a = 5) OR (a, b) IN ((1, 1), (3, 3))`, `a,b`,
+			`/1/1-/1/2 /3/3-/3/4 /5-/6`, `/5-/4 /3/3-/3/2 /1/1-/1/0`},
 
 		// When encoding an end constraint for a maximal datum, we use
 		// bytes.PrefixEnd() to go beyond the normal encodings of that datatype.
@@ -385,11 +558,37 @@ func TestExactPrefix(t *testing.T) {
 		{`(a, b) IN ((1, 2))`, `b`, 1},
 		{`(a, b) IN ((1, 2)) AND c = true`, `a,b,c`, 3},
 		{`a = 1 AND (b, c) IN ((2, true))`, `a,b,c`, 3},
+
+		{`(a, b) = (1, 2) OR (a, b, c) = (1, 3, true)`, `a,b`, 1},
+		{`(a, b) = (1, 2) OR (a, b, c) = (3, 4, true)`, `a,b`, 0},
+		{`(a, b) = (1, 2) OR a = 1`, `a,b`, 1},
+		{`(a, b) = (1, 2) OR a = 2`, `a,b`, 0},
+
+		{`a = 1 OR (a = 1 AND b = 2)`, `a`, 1},
+		{`a = 1 OR (a = 1 AND b = 2)`, `b`, 0},
+		{`a = 1 OR (a = 1 AND b = 2)`, `a,b`, 1},
+		{`a = 1 OR (a = 2 AND b = 2)`, `a`, 0},
+
+		{`(a = 1 AND b = 2) OR (a = 1 AND b = 2)`, `a`, 1},
+		{`(a = 1 AND b = 2) OR (a = 1 AND b = 2)`, `b`, 1},
+		{`(a = 1 AND b = 2) OR (a = 1 AND b = 2)`, `b,a`, 2},
+		{`(a = 1 AND b = 2) OR (a = 1 AND b = 2)`, `a,b`, 2},
+		{`(a = 1 AND b = 1) OR (a = 1 AND b = 2)`, `a`, 1},
+		{`(a = 1 AND b = 1) OR (a = 1 AND b = 2)`, `b`, 0},
+		{`(a = 1 AND b = 1) OR (a = 1 AND b = 2)`, `a,b`, 1},
+		{`(a = 1 AND b = 1) OR (a = 1 AND b = 2)`, `b,a`, 0},
+		{`(a = 1 AND b = 1) OR (a = 2 AND b = 2)`, `a`, 0},
+		{`(a = 1 AND b = 1) OR (a = 2 AND b = 2)`, `b`, 0},
+		{`(a = 1 AND b = 1) OR (a = 2 AND b = 2)`, `a,b`, 0},
+
+		{`(a = 1 AND b > 4) OR (a = 1 AND b < 1)`, `a`, 1},
+		{`(a = 1 AND b > 4) OR (a = 1 AND b < 1)`, `b`, 0},
+		{`(a = 1 AND b > 4) OR (a = 1 AND b < 1)`, `a,b`, 1},
 	}
 	for _, d := range testData {
 		desc, index := makeTestIndexFromStr(t, d.columns)
 		constraints, _ := makeConstraints(t, d.expr, desc, index)
-		prefix := exactPrefix(constraints)
+		prefix := constraints.exactPrefix()
 		if d.expected != prefix {
 			t.Errorf("%s: expected %d, but found %d", d.expr, d.expected, prefix)
 		}


### PR DESCRIPTION
Note -- the first commit is a cosmetic test change, I recommend reviewing commit 2 separately.

This change adds basic support for top-level ORs in filters. Previously only a
few simplifications were supported, e.g. `a = 1 OR a = 3` gets converted to `a
in (1,2)`.

We don't support using multiple indexes in parallel the same time; we take into
account all disjunctions with respect to the same index. We generate the
indexConstraints for each disjunction; we then generate spans for each
disjunction separately, and finally merge the spans.

This works for a large class of expressions (with the proper index), like
- `a < 5 OR a > 10`
- `(a >= 1 AND a <= 10) OR (a >= 20 AND a <= 30)`
- `(a = 1 AND b > 10) OR (a = 5 AND b < 10)`

Expressions like `a > 1 OR b > 1` will still not generate any constraints (we
would have to support joining from multiple indexes).

Fixes #5189.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5521)

<!-- Reviewable:end -->
