### PR TITLE
storage: set version on all consistency checksum requests

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1400,7 +1400,7 @@ func (r *Replica) CheckConsistency(args roachpb.CheckConsistencyRequest, desc *r
 }
 
 const (
-	replicaChecksumVersion    = 0
+	replicaChecksumVersion    = 1
 	replicaChecksumGCInterval = time.Hour
 )
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -4506,6 +4506,7 @@ func TestComputeVerifyChecksum(t *testing.T) {
 	id := uuid.MakeV4()
 	args := roachpb.ComputeChecksumRequest{
 		ChecksumID: id,
+		Version:    replicaChecksumVersion,
 	}
 	_, err := rng.ComputeChecksum(nil, nil, roachpb.Header{}, args)
 	if err != nil {
@@ -4554,6 +4555,7 @@ func TestComputeVerifyChecksum(t *testing.T) {
 	// Sending a VerifyChecksum with a bad checksum is a noop.
 	verifyArgs = roachpb.VerifyChecksumRequest{
 		ChecksumID: id,
+		Version:    replicaChecksumVersion,
 		Checksum:   []byte("bad checksum"),
 	}
 	_, err = rng.VerifyChecksum(nil, nil, roachpb.Header{}, verifyArgs)


### PR DESCRIPTION
Also fix bug with version not being set everywhere.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5524)

<!-- Reviewable:end -->
