### PR TITLE
Temporarily increase test timeout to avoid test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,10 @@ STATIC :=
 PKG          := ./...
 TAGS         :=
 TESTS        := .
-TESTTIMEOUT  := 1m10s
-RACETIMEOUT  := 5m
-BENCHTIMEOUT := 5m
+# TODO(radu): restore timeouts to 1m10s, 5m, 5m after #5376 is fixed.
+TESTTIMEOUT  := 3m
+RACETIMEOUT  := 10m
+BENCHTIMEOUT := 10m
 TESTFLAGS    :=
 STRESSFLAGS  := -stderr -maxfails 1
 DUPLFLAGS    := -t 100


### PR DESCRIPTION
Issue #5376 is causing a lot of test failures due to timeouts in the sql tests.
Temporarily increasing the timeouts until the issue is resolved.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5528)

<!-- Reviewable:end -->
