### PR TITLE
Revert "Temporarily increase test timeout to avoid test failures"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,9 @@ STATIC :=
 PKG          := ./...
 TAGS         :=
 TESTS        := .
-# TODO(radu): restore timeouts to 1m10s, 5m, 5m after #5376 is fixed.
-TESTTIMEOUT  := 3m
-RACETIMEOUT  := 10m
-BENCHTIMEOUT := 10m
+TESTTIMEOUT  := 1m10s
+RACETIMEOUT  := 5m
+BENCHTIMEOUT := 5m
 TESTFLAGS    :=
 STRESSFLAGS  := -stderr -maxfails 1
 DUPLFLAGS    := -t 100


### PR DESCRIPTION
Reverts cockroachdb/cockroach#5528

Heh, the fix for #5376 went in earlier than I thought; reverting the change I just made to the test timeouts. Verified the tests are now back to normal

```
ok      github.com/cockroachdb/cockroach/sql    33.591s
ok      github.com/cockroachdb/cockroach/sql    30.567s
ok      github.com/cockroachdb/cockroach/sql    26.237s
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5534)

<!-- Reviewable:end -->
