### PR TITLE
Fix "use strict" error in admin UI

### DIFF
--- a/ui/ts/components/metrics.ts
+++ b/ui/ts/components/metrics.ts
@@ -152,12 +152,12 @@ module Components {
               let yAxisDomain: AxisDomain = new AxisDomain();
               let xAxisDomain: AxisDomain = new AxisDomain();
 
-              function computeFullAxisDomain(domain: AxisDomain, values: number[]): AxisDomain {
+              let computeFullAxisDomain = (domain: AxisDomain, values: number[]): AxisDomain => {
                 return new AxisDomain(
                   Math.min(domain.min, ...values),
                   Math.max(domain.max, ...values)
                 );
-              }
+              };
 
               this.vm.axis.selectors().forEach((s: Models.Metrics.Select.Selector) => {
                 let key: string = Models.Metrics.QueryInfoKey(s.request());


### PR DESCRIPTION
A javascript statement was running afoul of "use strict" rules on firefox and
safari; apparently, this particular rule was not being enforced in chrome.

Rule in question: "Strict mode does not allow function declarations in a
lexically nested statement."

Fixes #5464

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5548)

<!-- Reviewable:end -->
