### PR TITLE
Event Log entry when node joins cluster

### DIFF
--- a/acceptance/event_log_test.go
+++ b/acceptance/event_log_test.go
@@ -1,0 +1,173 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Tracy (matt@cockroachlabs.com)
+
+package acceptance
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/roachpb"
+	csql "github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/uuid"
+)
+
+// TestEventLog verifies that "node joined" and "node restart" events are
+// recorded whenever a node starts and contacts the cluster.
+func TestEventLog(t *testing.T) {
+	runTestOnConfigs(t, testEventLogInner)
+}
+
+func testEventLogInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
+	num := c.NumNodes()
+	if num <= 0 {
+		t.Fatalf("%d nodes in cluster", num)
+	}
+
+	var confirmedClusterID uuid.UUID
+	type nodeEventInfo struct {
+		Descriptor roachpb.NodeDescriptor
+		ClusterID  uuid.UUID
+		Started    int64
+	}
+
+	// Verify that a node_join message was logged for each node in the cluster.
+	// We expect there to eventually be one such message for each node in the
+	// cluster, and each message must be correctly formatted.
+	util.SucceedsSoon(t, func() error {
+		db := makePGClient(t, c.PGUrl(0))
+		defer db.Close()
+
+		// Query all node join events. There should be one for each node in the
+		// cluster.
+		rows, err := db.Query(
+			"SELECT targetID, info FROM system.eventlog WHERE eventType = $1",
+			string(csql.EventLogNodeJoin))
+		if err != nil {
+			return err
+		}
+		seenIds := make(map[int64]struct{})
+		var clusterID uuid.UUID
+		for rows.Next() {
+			var targetID int64
+			var infoStr sql.NullString
+			if err := rows.Scan(&targetID, &infoStr); err != nil {
+				t.Fatal(err)
+			}
+
+			// Verify the stored node descriptor.
+			if !infoStr.Valid {
+				t.Fatalf("info not recorded for node join, target node %d", targetID)
+			}
+			var info nodeEventInfo
+			if err := json.Unmarshal([]byte(infoStr.String), &info); err != nil {
+				t.Fatal(err)
+			}
+			if a, e := int64(info.Descriptor.NodeID), targetID; a != e {
+				t.Fatalf("Node join with targetID %d had descriptor for wrong node %d", e, a)
+			}
+
+			// Verify cluster ID is recorded, and is the same for all nodes.
+			if uuid.Equal(info.ClusterID, *uuid.EmptyUUID) {
+				t.Fatalf("Node join recorded nil cluster id, info: %v", info)
+			}
+			if uuid.Equal(clusterID, *uuid.EmptyUUID) {
+				clusterID = info.ClusterID
+			} else if !uuid.Equal(clusterID, info.ClusterID) {
+				t.Fatalf(
+					"Node join recorded different cluster ID than earlier node. Expected %s, got %s. Info: %v",
+					clusterID, info.ClusterID, info)
+			}
+
+			// Verify that all NodeIDs are different.
+			if _, ok := seenIds[targetID]; ok {
+				t.Fatalf("Node ID %d seen in two different node join messages", targetID)
+			}
+			seenIds[targetID] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+
+		if a, e := len(seenIds), c.NumNodes(); a != e {
+			return util.Errorf("expected %d node join messages, found %d: %v", e, a, seenIds)
+		}
+
+		confirmedClusterID = clusterID
+		return nil
+	})
+
+	// Stop and Start Node 0, and verify the node restart message.
+	if err := c.Kill(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Restart(0); err != nil {
+		t.Fatal(err)
+	}
+
+	util.SucceedsSoon(t, func() error {
+		db := makePGClient(t, c.PGUrl(0))
+		defer db.Close()
+
+		// Query all node restart events. There should only be one.
+		rows, err := db.Query(
+			"SELECT targetID, info FROM system.eventlog WHERE eventType = $1",
+			string(csql.EventLogNodeRestart))
+		if err != nil {
+			return err
+		}
+
+		seenCount := 0
+		for rows.Next() {
+			var targetID int64
+			var infoStr sql.NullString
+			if err := rows.Scan(&targetID, &infoStr); err != nil {
+				t.Fatal(err)
+			}
+
+			// Verify the stored node descriptor.
+			if !infoStr.Valid {
+				t.Fatalf("info not recorded for node join, target node %d", targetID)
+			}
+			var info nodeEventInfo
+			if err := json.Unmarshal([]byte(infoStr.String), &info); err != nil {
+				t.Fatal(err)
+			}
+			if a, e := int64(info.Descriptor.NodeID), targetID; a != e {
+				t.Fatalf("Node join with targetID %d had descriptor for wrong node %d", e, a)
+			}
+
+			// Verify cluster ID is recorded, and is the same for all nodes.
+			if !uuid.Equal(confirmedClusterID, info.ClusterID) {
+				t.Fatalf(
+					"Node restart recorded different cluster ID than earlier join. Expected %s, got %s. Info: %v",
+					confirmedClusterID, info.ClusterID, info)
+			}
+
+			seenCount++
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		if seenCount != 1 {
+			return util.Errorf("Expected only one node restart event, found %d", seenCount)
+		}
+		return nil
+	})
+}

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -429,7 +429,9 @@ func TestAdminAPIEvents(t *testing.T) {
 		eventType sql.EventLogType
 		expCount  int
 	}{
-		{"", 6},
+		{"", 7},
+		{sql.EventLogNodeJoin, 1},
+		{sql.EventLogNodeRestart, 0},
 		{sql.EventLogDropDatabase, 0},
 		{sql.EventLogCreateDatabase, 1},
 		{sql.EventLogDropTable, 2},

--- a/server/node.go
+++ b/server/node.go
@@ -110,15 +110,16 @@ func (nm nodeMetrics) callComplete(d time.Duration, pErr *roachpb.Error) {
 // IDs for bootstrapping the node itself or new stores as they're added
 // on subsequent instantiations.
 type Node struct {
-	stopper    *stop.Stopper
-	ClusterID  uuid.UUID              // UUID for Cockroach cluster
-	Descriptor roachpb.NodeDescriptor // Node ID, network/physical topology
-	ctx        storage.StoreContext   // Context to use and pass to stores
-	stores     *storage.Stores        // Access to node-local stores
-	metrics    nodeMetrics
-	recorder   *status.MetricsRecorder
-	startedAt  int64
-	txnMetrics *kv.TxnMetrics
+	stopper     *stop.Stopper
+	ClusterID   uuid.UUID              // UUID for Cockroach cluster
+	Descriptor  roachpb.NodeDescriptor // Node ID, network/physical topology
+	ctx         storage.StoreContext   // Context to use and pass to stores
+	stores      *storage.Stores        // Access to node-local stores
+	metrics     nodeMetrics
+	recorder    *status.MetricsRecorder
+	startedAt   int64
+	initialBoot bool // True if this is the first time this node has started.
+	txnMetrics  *kv.TxnMetrics
 }
 
 // allocateNodeID increments the node id generator key to allocate
@@ -294,6 +295,7 @@ func (n *Node) start(addr net.Addr, engines []engine.Engine, attrs roachpb.Attri
 	// Initialize stores, including bootstrapping new ones.
 	if err := n.initStores(engines, n.stopper); err != nil {
 		if err == errNeedsBootstrap {
+			n.initialBoot = true
 			// This node has no initialized stores and no way to connect to
 			// an existing cluster, so we bootstrap it.
 			clusterID, err := bootstrapCluster(engines, n.txnMetrics)
@@ -324,6 +326,9 @@ func (n *Node) start(addr net.Addr, engines []engine.Engine, attrs roachpb.Attri
 
 	n.startComputePeriodicMetrics(n.stopper)
 	n.startGossip(n.stopper)
+
+	// Record node started event.
+	n.recordJoinEvent()
 
 	log.Infoc(n.context(), "Started node with %v engine(s) and attributes %v", engines, attrs.Attrs)
 	return nil
@@ -399,6 +404,7 @@ func (n *Node) initStores(engines []engine.Engine, stopper *stop.Stopper) error 
 	// supplying 0 to initNodeID.
 	if n.Descriptor.NodeID == 0 {
 		n.initNodeID(0)
+		n.initialBoot = true
 	}
 
 	// Bootstrap any uninitialized stores asynchronously.
@@ -615,6 +621,48 @@ func (n *Node) writeSummaries() error {
 		}
 	})
 	return err
+}
+
+// recordJoinEvent begins an asynchronous task which attempts to log a "node
+// join" or "node restart" event. This query will retry until it succeeds or the
+// server stops.
+func (n *Node) recordJoinEvent() {
+	if !n.ctx.LogRangeEvents {
+		return
+	}
+
+	logEventType := sql.EventLogNodeRestart
+	if n.initialBoot {
+		logEventType = sql.EventLogNodeJoin
+	}
+
+	n.stopper.RunWorker(func() {
+		for {
+			if err := n.ctx.DB.Txn(func(txn *client.Txn) *roachpb.Error {
+				return sql.MakeEventLogger(n.ctx.SQLExecutor.LeaseManager).InsertEventRecord(txn,
+					logEventType,
+					int32(n.Descriptor.NodeID),
+					int32(n.Descriptor.NodeID),
+					struct {
+						Descriptor roachpb.NodeDescriptor
+						ClusterID  uuid.UUID
+						StartedAt  int64
+					}{n.Descriptor, n.ClusterID, n.startedAt},
+				)
+			}); err != nil {
+				log.Warningc(n.context(), "unable to log %s event for node %d: %s", logEventType, n.Descriptor.NodeID, err)
+			} else {
+				return
+			}
+
+			select {
+			case <-n.stopper.ShouldStop():
+				return
+			default:
+				// Break.
+			}
+		}
+	})
 }
 
 // Batch implements the roachpb.KVServer interface.

--- a/sql/create.go
+++ b/sql/create.go
@@ -44,7 +44,7 @@ func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, *roachpb.E
 	}
 	if created {
 		// Log Create Database event.
-		if pErr := MakeEventLogger(p.leaseMgr).insertEventRecord(p.txn,
+		if pErr := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
 			EventLogCreateDatabase,
 			int32(desc.ID),
 			int32(p.evalCtx.NodeID),
@@ -174,7 +174,7 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, *roachpb.Error) 
 
 	if created {
 		// Log Create Table event.
-		if pErr := MakeEventLogger(p.leaseMgr).insertEventRecord(p.txn,
+		if pErr := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
 			EventLogCreateTable,
 			int32(desc.ID),
 			int32(p.evalCtx.NodeID),

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -109,7 +109,7 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, *roachpb.Error
 	}
 
 	// Log Drop Database event.
-	if pErr := MakeEventLogger(p.leaseMgr).insertEventRecord(p.txn,
+	if pErr := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
 		EventLogDropDatabase,
 		int32(dbDesc.ID),
 		int32(p.evalCtx.NodeID),
@@ -202,7 +202,7 @@ func (p *planner) DropTable(n *parser.DropTable) (planNode, *roachpb.Error) {
 			return nil, roachpb.NewUErrorf("table %q does not exist", n.Names[i].Table())
 		}
 		// Log a Drop Table event for this table.
-		if pErr := MakeEventLogger(p.leaseMgr).insertEventRecord(p.txn,
+		if pErr := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
 			EventLogDropTable,
 			int32(droppedDesc.ID),
 			int32(p.evalCtx.NodeID),

--- a/sql/event_log.go
+++ b/sql/event_log.go
@@ -39,6 +39,11 @@ const (
 	EventLogCreateTable EventLogType = "create_table"
 	// EventLogDropTable is recorded when a table is dropped.
 	EventLogDropTable EventLogType = "drop_table"
+	// EventLogNodeJoin is recorded when a node joins the cluster.
+	EventLogNodeJoin EventLogType = "node_join"
+	// EventLogNodeRestart is recorded when an existing node rejoins the cluster
+	// after being offline.
+	EventLogNodeRestart EventLogType = "node_restart"
 )
 
 // eventTableSchema describes the schema of the event log table.
@@ -72,9 +77,9 @@ func MakeEventLogger(leaseMgr *LeaseManager) EventLogger {
 	}}
 }
 
-// insertEventRecord inserts a single event into the event log as part of the
+// InsertEventRecord inserts a single event into the event log as part of the
 // provided transaction.
-func (ev EventLogger) insertEventRecord(txn *client.Txn, eventType EventLogType, targetID, reportingID int32, info interface{}) *roachpb.Error {
+func (ev EventLogger) InsertEventRecord(txn *client.Txn, eventType EventLogType, targetID, reportingID int32, info interface{}) *roachpb.Error {
 	const insertEventTableStmt = `
 INSERT INTO system.eventlog (
   timestamp, eventType, targetID, reportingID, info

--- a/util/uuid/uuid.go
+++ b/util/uuid/uuid.go
@@ -83,3 +83,8 @@ func FromString(input string) (*UUID, error) {
 	u, err := uuid.FromString(input)
 	return &UUID{u}, err
 }
+
+// Equal delegates to "github.com/satori/go.uuid".Equal.
+func Equal(u1, u2 UUID) bool {
+	return uuid.Equal(u1.UUID, u2.UUID)
+}


### PR DESCRIPTION
Nodes will now log an event into the `system.eventlog` table after joining a
cluster. The event type is different depending on if this is the first time a
node is joining the cluster: if it is the first time, a "node_join" event is
logged. Otherwise, a "node_restart" event is logged.

Includes a new acceptance test to verify that this event is logged correctly in
the multi-node and restart case.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5550)

<!-- Reviewable:end -->
