### PR TITLE
kv: Properly thread context with timeout through kv sendOne

### DIFF
--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -180,8 +180,8 @@ func TestUnretryableError(t *testing.T) {
 		Context:         context.Background(),
 	}
 
-	sendOneFn = func(_ batchClient, _ time.Duration,
-		_ *rpc.Context, done chan batchCall) {
+	sendOneFn = func(_ SendOptions, _ *rpc.Context,
+		_ batchClient, done chan batchCall) {
 		done <- batchCall{
 			reply: &roachpb.BatchResponse{},
 			err:   errors.New("unretryable"),
@@ -341,8 +341,8 @@ func TestComplexScenarios(t *testing.T) {
 		}
 
 		// Mock sendOne.
-		sendOneFn = func(client batchClient, _ time.Duration,
-			_ *rpc.Context, done chan batchCall) {
+		sendOneFn = func(_ SendOptions, _ *rpc.Context,
+			client batchClient, done chan batchCall) {
 			addrID := -1
 			for serverAddrID, serverAddr := range serverAddrs {
 				if serverAddr.String() == client.remoteAddr {


### PR DESCRIPTION
The context was available, but we weren't using it before.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5552)

<!-- Reviewable:end -->
