### PR TITLE
storage: avoid partial Transaction protos

### DIFF
--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -80,7 +80,7 @@ func TestIntentResolution(t *testing.T) {
 			var done bool
 			ctx := NewTestContext()
 			ctx.TestingKnobs.StoreTestingKnobs.TestingCommandFilter =
-				func(filterArgs storageutils.FilterArgs) error {
+				func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 					mu.Lock()
 					defer mu.Unlock()
 					header := filterArgs.Req.Header()

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -61,7 +61,7 @@ type CommandFilters struct {
 
 // runFilters executes the registered filters, stopping at the first one
 // that returns an error.
-func (c *CommandFilters) runFilters(args storageutils.FilterArgs) error {
+func (c *CommandFilters) runFilters(args storageutils.FilterArgs) *roachpb.Error {
 
 	c.RLock()
 	defer c.RUnlock()
@@ -73,10 +73,10 @@ func (c *CommandFilters) runFilters(args storageutils.FilterArgs) error {
 	}
 }
 
-func (c *CommandFilters) runFiltersInternal(args storageutils.FilterArgs) error {
+func (c *CommandFilters) runFiltersInternal(args storageutils.FilterArgs) *roachpb.Error {
 	for _, f := range c.filters {
-		if err := f.filter(args); err != nil {
-			return err
+		if pErr := f.filter(args); pErr != nil {
+			return pErr
 		}
 	}
 	return nil
@@ -137,7 +137,7 @@ func (c *CommandFilters) removeFilter(id int) {
 
 // checkEndTransactionTrigger verifies that an EndTransactionRequest
 // that includes intents for the SystemDB keys sets the proper trigger.
-func checkEndTransactionTrigger(args storageutils.FilterArgs) error {
+func checkEndTransactionTrigger(args storageutils.FilterArgs) *roachpb.Error {
 	req, ok := args.Req.(*roachpb.EndTransactionRequest)
 	if !ok {
 		return nil
@@ -170,8 +170,8 @@ func checkEndTransactionTrigger(args storageutils.FilterArgs) error {
 	// For more information, see the related comment at the beginning of
 	// planner.makePlan().
 	if hasSystemKey && !modifiedSystemConfigSpan {
-		return util.Errorf("EndTransaction hasSystemKey=%t, but hasSystemConfigTrigger=%t",
-			hasSystemKey, modifiedSystemConfigSpan)
+		return roachpb.NewError(util.Errorf("EndTransaction hasSystemKey=%t, but hasSystemConfigTrigger=%t",
+			hasSystemKey, modifiedSystemConfigSpan))
 	}
 
 	return nil

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -236,8 +236,11 @@ CREATE TABLE t.test (k TEXT PRIMARY KEY, v TEXT);
 		"hooly":     2,
 	}
 	cleanupFilter := cmdFilters.AppendFilter(
-		func(args storageutils.FilterArgs) error {
-			return injectErrors(args.Sid, args.Req, args.Hdr, magicVals)
+		func(args storageutils.FilterArgs) *roachpb.Error {
+			if err := injectErrors(args.Sid, args.Req, args.Hdr, magicVals); err != nil {
+				return roachpb.NewErrorWithTxn(err, args.Hdr.Txn)
+			}
+			return nil
 		}, false)
 
 	// Test that implicit txns - txns for which we see all the statements and prefixes
@@ -279,8 +282,11 @@ INSERT INTO t.test (k, v) VALUES ('k', 'laureal');
 		"hooly": 2,
 	}
 	cleanupFilter = cmdFilters.AppendFilter(
-		func(args storageutils.FilterArgs) error {
-			return injectErrors(args.Sid, args.Req, args.Hdr, magicVals)
+		func(args storageutils.FilterArgs) *roachpb.Error {
+			if err := injectErrors(args.Sid, args.Req, args.Hdr, magicVals); err != nil {
+				return roachpb.NewErrorWithTxn(err, args.Hdr.Txn)
+			}
+			return nil
 		}, false)
 	defer cleanupFilter()
 
@@ -420,8 +426,11 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 	for _, tc := range testCases {
 		log.Infof("starting test for: %+v", tc)
 		cleanupFilter := cmdFilters.AppendFilter(
-			func(args storageutils.FilterArgs) error {
-				return injectErrors(args.Sid, args.Req, args.Hdr, tc.magicVals)
+			func(args storageutils.FilterArgs) *roachpb.Error {
+				if err := injectErrors(args.Sid, args.Req, args.Hdr, tc.magicVals); err != nil {
+					return roachpb.NewErrorWithTxn(err, args.Hdr.Txn)
+				}
+				return nil
 			}, false)
 
 		// Also inject an error at RELEASE time, besides the error injected by magicVals.

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -170,7 +170,7 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 		defer stopper.Stop()
 		sCtx := storage.TestStoreContext()
 		sCtx.TestingKnobs.TestingCommandFilter =
-			func(filterArgs storageutils.FilterArgs) error {
+			func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 				_, ok := filterArgs.Req.(*roachpb.IncrementRequest)
 				if ok && filterArgs.Req.Header().Key.Equal(roachpb.Key("a")) {
 					numIncrements++
@@ -372,10 +372,10 @@ func TestFailedReplicaChange(t *testing.T) {
 	mtc := &multiTestContext{}
 	mtc.storeContext = &ctx
 	mtc.storeContext.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) error {
+		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 			if runFilter.Load().(bool) {
 				if et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest); ok && et.Commit {
-					return util.Errorf("boom")
+					return roachpb.NewErrorWithTxn(util.Errorf("boom"), filterArgs.Hdr.Txn)
 				}
 				return nil
 			}

--- a/storage/client_replica_gc_test.go
+++ b/storage/client_replica_gc_test.go
@@ -47,7 +47,7 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 	ctx := storage.TestStoreContext()
 	mtc.storeContext = &ctx
 	mtc.storeContext.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) error {
+		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 			et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest)
 			if !ok || filterArgs.Sid != 2 {
 				return nil

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -195,7 +195,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	defer stopper.Stop()
 	ctx := storage.TestStoreContext()
 	ctx.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) error {
+		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 			if _, ok := filterArgs.Req.(*roachpb.GetRequest); ok &&
 				filterArgs.Req.Header().Key.Equal(roachpb.Key(key)) &&
 				filterArgs.Hdr.Txn == nil {
@@ -204,7 +204,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 				// succeeds). Returns an error for the fourth get request to avoid timestamp cache
 				// update after the third get operation pushes the txn timestamp.
 				if atomic.AddInt32(&numGets, 1) == 4 {
-					return util.Errorf("Test")
+					return roachpb.NewErrorWithTxn(util.Errorf("Test"), filterArgs.Hdr.Txn)
 				}
 			}
 			return nil

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -923,7 +923,7 @@ func TestStoreSplitReadRace(t *testing.T) {
 	var getStarted sync.WaitGroup
 	sCtx := storage.TestStoreContext()
 	sCtx.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) error {
+		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 			if et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest); ok {
 				st := et.InternalCommitTrigger.GetSplitTrigger()
 				if st == nil || !st.UpdatedDesc.EndKey.Equal(splitKey) {

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -345,7 +345,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	tc := testContext{}
 	tsc := TestStoreContext()
 	tsc.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) error {
+		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 			if resArgs, ok := filterArgs.Req.(*roachpb.ResolveIntentRequest); ok {
 				id := string(resArgs.IntentTxn.Key)
 				resolved[id] = append(resolved[id], roachpb.Span{
@@ -355,7 +355,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 				// We've special cased one test case. Note that the intent is still
 				// counted in `resolved`.
 				if testCases[id].failResolve {
-					return util.Errorf("boom")
+					return roachpb.NewErrorWithTxn(util.Errorf("boom"), filterArgs.Hdr.Txn)
 				}
 			}
 			return nil

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -67,9 +67,7 @@ func (r *Replica) executeCmd(ctx context.Context, raftCmdID storagebase.CmdIDKey
 	if filter := r.store.ctx.TestingKnobs.TestingCommandFilter; filter != nil {
 		filterArgs := storageutils.FilterArgs{Ctx: ctx, CmdID: raftCmdID, Index: index,
 			Sid: r.store.StoreID(), Req: args, Hdr: h}
-		err := filter(filterArgs)
-		if err != nil {
-			pErr := roachpb.NewErrorWithTxn(err, h.Txn)
+		if pErr := filter(filterArgs); pErr != nil {
 			log.Infof("test injecting error: %s", pErr)
 			return nil, nil, pErr
 		}

--- a/storage/store.go
+++ b/storage/store.go
@@ -1554,13 +1554,13 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 				pErr.OriginNode = ba.Replica.NodeID
 				txn := pErr.GetTxn()
 				if txn == nil {
-					txn = &roachpb.Transaction{}
+					txn = ba.Txn
 				}
 				txn.UpdateObservedTimestamp(ba.Replica.NodeID, now)
 				pErr.SetTxn(txn)
 			} else {
 				if br.Txn == nil {
-					br.Txn = &roachpb.Transaction{}
+					br.Txn = ba.Txn
 				}
 				br.Txn.UpdateObservedTimestamp(ba.Replica.NodeID, now)
 				// Update our clock with the outgoing response txn timestamp.

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -614,7 +614,7 @@ func TestStoreObservedTimestamp(t *testing.T) {
 			ctx.TestingKnobs.TestingCommandFilter =
 				func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 					if bytes.Equal(filterArgs.Req.Header().Key, badKey) {
-						return roachpb.NewErrorWithTxn(util.Errorf("boom"), filterArgs.Hdr.Txn)
+						return roachpb.NewError(util.Errorf("boom"))
 					}
 					return nil
 				}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -579,8 +579,8 @@ func TestStoreObservedTimestamp(t *testing.T) {
 					t.Fatal("expected an error")
 				}
 				txn := pErr.GetTxn()
-				if txn == nil {
-					t.Fatalf("expected transaction in %s", pErr)
+				if txn == nil || txn.ID == nil {
+					t.Fatalf("expected nontrivial transaction in %s", pErr)
 				}
 				if ts, _ := txn.GetObservedTimestamp(desc.NodeID); ts.WallTime != wallTime {
 					t.Fatalf("unexpected observed timestamps, expected %d->%d but got map %+v",
@@ -598,7 +598,7 @@ func TestStoreObservedTimestamp(t *testing.T) {
 					t.Fatal(pErr)
 				}
 				txn := pReply.Header().Txn
-				if txn == nil {
+				if txn == nil || txn.ID == nil {
 					t.Fatal("expected transactional response")
 				}
 				obs, _ := txn.GetObservedTimestamp(desc.NodeID)
@@ -612,9 +612,9 @@ func TestStoreObservedTimestamp(t *testing.T) {
 		func() {
 			ctx := TestStoreContext()
 			ctx.TestingKnobs.TestingCommandFilter =
-				func(filterArgs storageutils.FilterArgs) error {
+				func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 					if bytes.Equal(filterArgs.Req.Header().Key, badKey) {
-						return fmt.Errorf("boom")
+						return roachpb.NewErrorWithTxn(util.Errorf("boom"), filterArgs.Hdr.Txn)
 					}
 					return nil
 				}
@@ -674,9 +674,9 @@ func TestStoreAnnotateNow(t *testing.T) {
 			func() {
 				ctx := TestStoreContext()
 				ctx.TestingKnobs.TestingCommandFilter =
-					func(filterArgs storageutils.FilterArgs) error {
+					func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 						if bytes.Equal(filterArgs.Req.Header().Key, badKey) {
-							return fmt.Errorf("boom")
+							return roachpb.NewErrorWithTxn(util.Errorf("boom"), filterArgs.Hdr.Txn)
 						}
 						return nil
 					}
@@ -1079,13 +1079,13 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 	var stopper *stop.Stopper
 	ctx := TestStoreContext()
 	ctx.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) error {
+		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 			pr, ok := filterArgs.Req.(*roachpb.PushTxnRequest)
 			if !ok || pr.PusherTxn.Name != "test" {
 				return nil
 			}
 			if exp, act := mc.UnixNano(), pr.PushTo.WallTime; exp > act {
-				return fmt.Errorf("expected PushTo >= WallTime, but got %d < %d:\n%+v", act, exp, pr)
+				return roachpb.NewError(fmt.Errorf("expected PushTo >= WallTime, but got %d < %d:\n%+v", act, exp, pr))
 			}
 			return nil
 		}
@@ -1551,7 +1551,7 @@ func TestStoreScanIntents(t *testing.T) {
 	countPtr := &count
 
 	ctx.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) error {
+		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 			if _, ok := filterArgs.Req.(*roachpb.ScanRequest); ok {
 				atomic.AddInt32(countPtr, 1)
 			}
@@ -1668,10 +1668,10 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	intercept.Store(true)
 	ctx := TestStoreContext()
 	ctx.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) error {
+		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
 			_, ok := filterArgs.Req.(*roachpb.ResolveIntentRequest)
 			if ok && intercept.Load().(bool) {
-				return util.Errorf("error on purpose")
+				return roachpb.NewErrorWithTxn(util.Errorf("boom"), filterArgs.Hdr.Txn)
 			}
 			return nil
 		}


### PR DESCRIPTION
Using partial Transaction protos (i.e. uninitialized ID) is bad because
that is not what the callers expect to get back from `Store`.

First commit is mechanical.

Fixes #5591.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5593)

<!-- Reviewable:end -->
