### PR TITLE
Write time series about ranges with active lease and lease errors

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -147,6 +147,11 @@ func (r *Replica) executeCmd(ctx context.Context, raftCmdID storagebase.CmdIDKey
 	case *roachpb.LeaderLeaseRequest:
 		resp := reply.(*roachpb.LeaderLeaseResponse)
 		*resp, err = r.LeaderLease(ctx, batch, ms, h, *tArgs)
+		if err == nil {
+			r.store.metrics.leaseRequestSuccessRate.Add(1.0)
+		} else {
+			r.store.metrics.leaseRequestErrorRate.Add(1.0)
+		}
 	case *roachpb.ComputeChecksumRequest:
 		resp := reply.(*roachpb.ComputeChecksumResponse)
 		*resp, err = r.ComputeChecksum(ctx, batch, ms, h, *tArgs)

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -147,11 +147,7 @@ func (r *Replica) executeCmd(ctx context.Context, raftCmdID storagebase.CmdIDKey
 	case *roachpb.LeaderLeaseRequest:
 		resp := reply.(*roachpb.LeaderLeaseResponse)
 		*resp, err = r.LeaderLease(ctx, batch, ms, h, *tArgs)
-		if err == nil {
-			r.store.metrics.leaseRequestSuccessRate.Add(1.0)
-		} else {
-			r.store.metrics.leaseRequestErrorRate.Add(1.0)
-		}
+		r.store.metrics.leaseRequestComplete(err)
 	case *roachpb.ComputeChecksumRequest:
 		resp := reply.(*roachpb.ComputeChecksumResponse)
 		*resp, err = r.ComputeChecksum(ctx, batch, ms, h, *tArgs)

--- a/storage/store.go
+++ b/storage/store.go
@@ -399,6 +399,10 @@ type storeMetrics struct {
 	replicatedRangeCount *metric.Gauge
 	availableRangeCount  *metric.Gauge
 
+	// Lease data metrics.
+	leaseRequestSuccessRate metric.Rates
+	leaseRequestErrorRate   metric.Rates
+
 	// Storage metrics.
 	liveBytes       *metric.Gauge
 	keyBytes        *metric.Gauge
@@ -447,26 +451,28 @@ type storeMetrics struct {
 func newStoreMetrics() *storeMetrics {
 	storeRegistry := metric.NewRegistry()
 	return &storeMetrics{
-		registry:             storeRegistry,
-		replicaCount:         storeRegistry.Counter("replicas"),
-		leaderRangeCount:     storeRegistry.Gauge("ranges.leader"),
-		replicatedRangeCount: storeRegistry.Gauge("ranges.replicated"),
-		availableRangeCount:  storeRegistry.Gauge("ranges.available"),
-		liveBytes:            storeRegistry.Gauge("livebytes"),
-		keyBytes:             storeRegistry.Gauge("keybytes"),
-		valBytes:             storeRegistry.Gauge("valbytes"),
-		intentBytes:          storeRegistry.Gauge("intentbytes"),
-		liveCount:            storeRegistry.Gauge("livecount"),
-		keyCount:             storeRegistry.Gauge("keycount"),
-		valCount:             storeRegistry.Gauge("valcount"),
-		intentCount:          storeRegistry.Gauge("intentcount"),
-		intentAge:            storeRegistry.Gauge("intentage"),
-		gcBytesAge:           storeRegistry.Gauge("gcbytesage"),
-		lastUpdateNanos:      storeRegistry.Gauge("lastupdatenanos"),
-		capacity:             storeRegistry.Gauge("capacity"),
-		available:            storeRegistry.Gauge("capacity.available"),
-		sysBytes:             storeRegistry.Gauge("sysbytes"),
-		sysCount:             storeRegistry.Gauge("syscount"),
+		registry:                storeRegistry,
+		replicaCount:            storeRegistry.Counter("replicas"),
+		leaderRangeCount:        storeRegistry.Gauge("ranges.leader"),
+		replicatedRangeCount:    storeRegistry.Gauge("ranges.replicated"),
+		availableRangeCount:     storeRegistry.Gauge("ranges.available"),
+		leaseRequestSuccessRate: storeRegistry.Rates("leases.success"),
+		leaseRequestErrorRate:   storeRegistry.Rates("leases.error"),
+		liveBytes:               storeRegistry.Gauge("livebytes"),
+		keyBytes:                storeRegistry.Gauge("keybytes"),
+		valBytes:                storeRegistry.Gauge("valbytes"),
+		intentBytes:             storeRegistry.Gauge("intentbytes"),
+		liveCount:               storeRegistry.Gauge("livecount"),
+		keyCount:                storeRegistry.Gauge("keycount"),
+		valCount:                storeRegistry.Gauge("valcount"),
+		intentCount:             storeRegistry.Gauge("intentcount"),
+		intentAge:               storeRegistry.Gauge("intentage"),
+		gcBytesAge:              storeRegistry.Gauge("gcbytesage"),
+		lastUpdateNanos:         storeRegistry.Gauge("lastupdatenanos"),
+		capacity:                storeRegistry.Gauge("capacity"),
+		available:               storeRegistry.Gauge("capacity.available"),
+		sysBytes:                storeRegistry.Gauge("sysbytes"),
+		sysCount:                storeRegistry.Gauge("syscount"),
 
 		// RocksDB metrics.
 		rdbBlockCacheHits:           storeRegistry.Gauge("rocksdb.block.cache.hits"),

--- a/storage/store.go
+++ b/storage/store.go
@@ -400,8 +400,8 @@ type storeMetrics struct {
 	availableRangeCount  *metric.Gauge
 
 	// Lease data metrics.
-	leaseRequestSuccessRate metric.Rates
-	leaseRequestErrorRate   metric.Rates
+	leaseRequestSuccessCount *metric.Counter
+	leaseRequestErrorCount   *metric.Counter
 
 	// Storage metrics.
 	liveBytes       *metric.Gauge
@@ -451,28 +451,28 @@ type storeMetrics struct {
 func newStoreMetrics() *storeMetrics {
 	storeRegistry := metric.NewRegistry()
 	return &storeMetrics{
-		registry:                storeRegistry,
-		replicaCount:            storeRegistry.Counter("replicas"),
-		leaderRangeCount:        storeRegistry.Gauge("ranges.leader"),
-		replicatedRangeCount:    storeRegistry.Gauge("ranges.replicated"),
-		availableRangeCount:     storeRegistry.Gauge("ranges.available"),
-		leaseRequestSuccessRate: storeRegistry.Rates("leases.success"),
-		leaseRequestErrorRate:   storeRegistry.Rates("leases.error"),
-		liveBytes:               storeRegistry.Gauge("livebytes"),
-		keyBytes:                storeRegistry.Gauge("keybytes"),
-		valBytes:                storeRegistry.Gauge("valbytes"),
-		intentBytes:             storeRegistry.Gauge("intentbytes"),
-		liveCount:               storeRegistry.Gauge("livecount"),
-		keyCount:                storeRegistry.Gauge("keycount"),
-		valCount:                storeRegistry.Gauge("valcount"),
-		intentCount:             storeRegistry.Gauge("intentcount"),
-		intentAge:               storeRegistry.Gauge("intentage"),
-		gcBytesAge:              storeRegistry.Gauge("gcbytesage"),
-		lastUpdateNanos:         storeRegistry.Gauge("lastupdatenanos"),
-		capacity:                storeRegistry.Gauge("capacity"),
-		available:               storeRegistry.Gauge("capacity.available"),
-		sysBytes:                storeRegistry.Gauge("sysbytes"),
-		sysCount:                storeRegistry.Gauge("syscount"),
+		registry:                 storeRegistry,
+		replicaCount:             storeRegistry.Counter("replicas"),
+		leaderRangeCount:         storeRegistry.Gauge("ranges.leader"),
+		replicatedRangeCount:     storeRegistry.Gauge("ranges.replicated"),
+		availableRangeCount:      storeRegistry.Gauge("ranges.available"),
+		leaseRequestSuccessCount: storeRegistry.Counter("leases.success"),
+		leaseRequestErrorCount:   storeRegistry.Counter("leases.error"),
+		liveBytes:                storeRegistry.Gauge("livebytes"),
+		keyBytes:                 storeRegistry.Gauge("keybytes"),
+		valBytes:                 storeRegistry.Gauge("valbytes"),
+		intentBytes:              storeRegistry.Gauge("intentbytes"),
+		liveCount:                storeRegistry.Gauge("livecount"),
+		keyCount:                 storeRegistry.Gauge("keycount"),
+		valCount:                 storeRegistry.Gauge("valcount"),
+		intentCount:              storeRegistry.Gauge("intentcount"),
+		intentAge:                storeRegistry.Gauge("intentage"),
+		gcBytesAge:               storeRegistry.Gauge("gcbytesage"),
+		lastUpdateNanos:          storeRegistry.Gauge("lastupdatenanos"),
+		capacity:                 storeRegistry.Gauge("capacity"),
+		available:                storeRegistry.Gauge("capacity.available"),
+		sysBytes:                 storeRegistry.Gauge("sysbytes"),
+		sysCount:                 storeRegistry.Gauge("syscount"),
 
 		// RocksDB metrics.
 		rdbBlockCacheHits:           storeRegistry.Gauge("rocksdb.block.cache.hits"),
@@ -562,6 +562,14 @@ func (sm *storeMetrics) updateRocksDBStats(stats engine.Stats) {
 	sm.rdbFlushes.Update(int64(stats.Flushes))
 	sm.rdbCompactions.Update(int64(stats.Compactions))
 	sm.rdbTableReadersMemEstimate.Update(int64(stats.TableReadersMemEstimate))
+}
+
+func (sm *storeMetrics) leaseRequestComplete(err error) {
+	if err == nil {
+		sm.leaseRequestSuccessCount.Inc(1)
+	} else {
+		sm.leaseRequestErrorCount.Inc(1)
+	}
 }
 
 // Valid returns true if the StoreContext is populated correctly.


### PR DESCRIPTION
Added two new counters on storeMetrics to record lease errors and successes. #869

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5596)

<!-- Reviewable:end -->
