### PR TITLE
keys: Malformed keys no longer crash keys.Addr

### DIFF
--- a/cli/range.go
+++ b/cli/range.go
@@ -48,7 +48,11 @@ func runLsRanges(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
 			k = roachpb.Key(args[0])
 		}
-		startKey = keys.RangeMetaKey(keys.Addr(k))
+		rk, err := keys.Addr(k)
+		if err != nil {
+			panic(err)
+		}
+		startKey = keys.RangeMetaKey(rk)
 	}
 	endKey := keys.Meta2Prefix.PrefixEnd()
 

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
-	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
 
@@ -314,43 +313,53 @@ func RangeDescriptorKey(key roachpb.RKey) roachpb.Key {
 // transaction key and ID. The base key is encoded in order to
 // guarantee that all transaction records for a range sort together.
 func TransactionKey(key roachpb.Key, txnID *uuid.UUID) roachpb.Key {
-	return MakeRangeKey(Addr(key), localTransactionSuffix, roachpb.RKey(txnID.GetBytes()))
+	rk, err := Addr(key)
+	if err != nil {
+		panic(err)
+	}
+	return MakeRangeKey(rk, localTransactionSuffix, roachpb.RKey(txnID.GetBytes()))
 }
 
 // Addr returns the address for the key, used to lookup the range containing
 // the key. In the normal case, this is simply the key's value. However, for
 // local keys, such as transaction records, range-spanning binary tree node
-// pointers, the address is the trailing suffix of the key, with the local key
-// prefix removed. In this way, local keys address to the same range as
-// non-local keys, but are stored separately so that they don't collide with
-// user-space or global system keys.
+// pointers, the address is the inner encoded key, with the local key prefix
+// and the suffix and optional detail removed. This address unwrapping is
+// performed repeatedly in the case of doubly-local keys. In this way, local
+// keys address to the same range as non-local keys, but are stored separately
+// so that they don't collide with user-space or global system keys.
 //
 // However, not all local keys are addressable in the global map. Only range
 // local keys incorporating a range key (start key or transaction key) are
 // addressable (e.g. range metadata and txn records). Range local keys
 // incorporating the Range ID are not (e.g. sequence cache entries, and range
 // stats).
-//
-// TODO(pmattis): Should KeyAddress return an error when the key is malformed?
-func Addr(k roachpb.Key) roachpb.RKey {
+func Addr(k roachpb.Key) (roachpb.RKey, error) {
 	if k == nil {
-		return nil
+		return nil, nil
 	}
 
-	if !bytes.HasPrefix(k, localPrefix) {
-		return roachpb.RKey(k)
-	}
-	if bytes.HasPrefix(k, LocalRangePrefix) {
-		k = k[len(LocalRangePrefix):]
-		_, k, err := encoding.DecodeBytesAscending(k, nil)
-		if err != nil {
-			panic(err)
+	for bytes.HasPrefix(k, localPrefix) {
+		if !bytes.HasPrefix(k, LocalRangePrefix) {
+			return nil, util.Errorf("local key %q malformed; should contain prefix %q",
+				k, LocalRangePrefix)
 		}
-		return roachpb.RKey(k)
+		k = k[len(LocalRangePrefix):]
+		var err error
+		// Decode the encoded key, throw away the suffix and detail.
+		if _, k, err = encoding.DecodeBytesAscending(k, nil); err != nil {
+			return nil, err
+		}
 	}
-	log.Fatalf("local key %q malformed; should contain prefix %q",
-		k, LocalRangePrefix)
-	return nil
+	return roachpb.RKey(k), nil
+}
+
+func mustAddr(k roachpb.Key) roachpb.RKey {
+	rk, err := Addr(k)
+	if err != nil {
+		panic(err)
+	}
+	return rk
 }
 
 // AddrUpperBound returns the address for the key, used to lookup the range containing
@@ -360,14 +369,17 @@ func Addr(k roachpb.Key) roachpb.RKey {
 // of a range-local key, which is guaranteed to be located on the same range. AddrUpperBound()
 // returns the regular key that is just to the right, which may not be on the same range
 // but is suitable for use as the EndKey of a span involving a range-local key.
-func AddrUpperBound(k roachpb.Key) roachpb.RKey {
-	rk := Addr(k)
+func AddrUpperBound(k roachpb.Key) (roachpb.RKey, error) {
+	rk, err := Addr(k)
+	if err != nil {
+		return rk, err
+	}
 	if local := !rk.Equal(k); local {
 		// The upper bound for a range-local key that addresses to key k
 		// is the key directly after k.
 		rk = rk.ShallowNext()
 	}
-	return rk
+	return rk, nil
 }
 
 // RangeMetaKey returns a range metadata (meta1, meta2) indexing key
@@ -542,9 +554,7 @@ func MakeSplitKey(key roachpb.Key) (roachpb.Key, error) {
 }
 
 // Range returns a key range encompassing all the keys in the Batch.
-// TODO(tschottdorf): there is no protection for doubly-local keys here;
-// maybe Range should return an error.
-func Range(ba roachpb.BatchRequest) roachpb.RSpan {
+func Range(ba roachpb.BatchRequest) (roachpb.RSpan, error) {
 	from := roachpb.RKeyMax
 	to := roachpb.RKeyMin
 	for _, arg := range ba.Requests {
@@ -553,7 +563,10 @@ func Range(ba roachpb.BatchRequest) roachpb.RSpan {
 			continue
 		}
 		h := req.Header()
-		key := Addr(h.Key)
+		key, err := Addr(h.Key)
+		if err != nil {
+			return roachpb.RSpan{}, err
+		}
 		if key.Less(from) {
 			// Key is smaller than `from`.
 			from = key
@@ -562,11 +575,14 @@ func Range(ba roachpb.BatchRequest) roachpb.RSpan {
 			// Key.Next() is larger than `to`.
 			to = key.Next()
 		}
-		endKey := AddrUpperBound(h.EndKey)
+		endKey, err := AddrUpperBound(h.EndKey)
+		if err != nil {
+			return roachpb.RSpan{}, err
+		}
 		if to.Less(endKey) {
 			// EndKey is larger than `to`.
 			to = endKey
 		}
 	}
-	return roachpb.RSpan{Key: from, EndKey: to}
+	return roachpb.RSpan{Key: from, EndKey: to}, nil
 }

--- a/keys/printer.go
+++ b/keys/printer.go
@@ -80,7 +80,7 @@ var (
 					if len(unq) == 0 {
 						return "", Meta1Prefix
 					}
-					return "", RangeMetaKey(Addr(RangeMetaKey(Addr(
+					return "", RangeMetaKey(mustAddr(RangeMetaKey(mustAddr(
 						roachpb.Key(unq)))))
 				},
 			}},
@@ -96,7 +96,7 @@ var (
 					if len(unq) == 0 {
 						return "", Meta2Prefix
 					}
-					return "", RangeMetaKey(Addr(roachpb.Key(unq)))
+					return "", RangeMetaKey(mustAddr(roachpb.Key(unq)))
 				},
 			}},
 		},

--- a/kv/batch_test.go
+++ b/kv/batch_test.go
@@ -67,10 +67,14 @@ func TestBatchPrevNext(t *testing.T) {
 			args.Key, args.EndKey = span.Key, span.EndKey
 			ba.Add(args)
 		}
-		if next := next(ba, roachpb.RKey(test.key)); !bytes.Equal(next, roachpb.Key(test.expFW)) {
+		if next, err := next(ba, roachpb.RKey(test.key)); err != nil {
+			t.Errorf("%d: %v", i, err)
+		} else if !bytes.Equal(next, roachpb.Key(test.expFW)) {
 			t.Errorf("%d: next: expected %q, got %q", i, test.expFW, next)
 		}
-		if prev := prev(ba, roachpb.RKey(test.key)); !bytes.Equal(prev, roachpb.Key(test.expBW)) {
+		if prev, err := prev(ba, roachpb.RKey(test.key)); err != nil {
+			t.Errorf("%d: %v", i, err)
+		} else if !bytes.Equal(prev, roachpb.Key(test.expBW)) {
 			t.Errorf("%d: prev: expected %q, got %q", i, test.expBW, prev)
 		}
 	}

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -375,7 +375,7 @@ func (ds *DistSender) CountRanges(rs roachpb.RSpan) (int64, *roachpb.Error) {
 // already (via KeyAddress).
 func (ds *DistSender) getDescriptors(
 	rs roachpb.RSpan, considerIntents, useReverseScan bool,
-) (*roachpb.RangeDescriptor, bool, func(), *roachpb.Error) {
+) (*roachpb.RangeDescriptor, bool, func() error, *roachpb.Error) {
 	var desc *roachpb.RangeDescriptor
 	var pErr *roachpb.Error
 	var descKey roachpb.RKey
@@ -398,8 +398,8 @@ func (ds *DistSender) getDescriptors(
 		return desc.EndKey.Less(rs.EndKey)
 	}
 
-	evict := func() {
-		ds.rangeCache.EvictCachedRangeDescriptor(descKey, desc, useReverseScan)
+	evict := func() error {
+		return ds.rangeCache.EvictCachedRangeDescriptor(descKey, desc, useReverseScan)
 	}
 
 	return desc, needAnother(desc, useReverseScan), evict, nil
@@ -607,7 +607,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			// error handling below may clear them on certain errors, so we
 			// refresh (likely from the cache) on every retry.
 			log.Trace(ctx, "meta descriptor lookup")
-			var evictDesc func()
+			var evictDesc func() error
 			desc, needAnother, evictDesc, pErr = ds.getDescriptors(rs, considerIntents, isReverse)
 
 			// getDescriptors may fail retryably if the first range isn't
@@ -650,7 +650,9 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			// returns descriptor [c,d) -> [d,g) is never scanned.
 			// We evict and retry in such a case.
 			if (isReverse && !desc.ContainsKeyRange(desc.StartKey, rs.EndKey)) || (!isReverse && !desc.ContainsKeyRange(rs.Key, desc.EndKey)) {
-				evictDesc()
+				if err := evictDesc(); err != nil {
+					return nil, roachpb.NewError(err), false
+				}
 				continue
 			}
 
@@ -698,13 +700,17 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 				// TODO(tschottdorf): If a replica group goes dead, this
 				// will cause clients to put high read pressure on the first
 				// range, so there should be some rate limiting here.
-				evictDesc()
+				if err := evictDesc(); err != nil {
+					return nil, roachpb.NewError(err), false
+				}
 				if tErr.CanRetry() {
 					continue
 				}
 			case *roachpb.RangeNotFoundError, *roachpb.RangeKeyMismatchError:
 				// Range descriptor might be out of date - evict it.
-				evictDesc()
+				if err := evictDesc(); err != nil {
+					return nil, roachpb.NewError(err), false
+				}
 				// On addressing errors, don't backoff; retry immediately.
 				r.Reset()
 				if log.V(1) {
@@ -730,7 +736,9 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 						if log.V(1) {
 							log.Infof("error indicates unknown leader %s, expunging descriptor %s", newLeader, desc)
 						}
-						evictDesc()
+						if err := evictDesc(); err != nil {
+							return nil, roachpb.NewError(err), false
+						}
 					}
 				} else {
 					// If the new leader is unknown, we were talking to a
@@ -743,7 +751,9 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 					// another node (at a lower level), and then if it reaches
 					// this level then we know we've exhausted our options and
 					// must clear the cache.
-					evictDesc()
+					if err := evictDesc(); err != nil {
+						return nil, roachpb.NewError(err), false
+					}
 					newLeader = &roachpb.ReplicaDescriptor{}
 				}
 				// Next, cache the new leader.

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -568,8 +568,9 @@ func TestEvictCacheOnError(t *testing.T) {
 		if cur := ds.leaderCache.Lookup(1); reflect.DeepEqual(cur, &roachpb.ReplicaDescriptor{}) && !tc.shouldClearLeader {
 			t.Errorf("%d: leader cache eviction: shouldClearLeader=%t, but value is %v", i, tc.shouldClearLeader, cur)
 		}
-		_, cachedDesc := ds.rangeCache.getCachedRangeDescriptor(roachpb.RKey(key), false /* !inclusive */)
-		if cachedDesc == nil != tc.shouldClearReplica {
+		if _, cachedDesc, err := ds.rangeCache.getCachedRangeDescriptor(roachpb.RKey(key), false /* !inclusive */); err != nil {
+			t.Error(err)
+		} else if cachedDesc == nil != tc.shouldClearReplica {
 			t.Errorf("%d: unexpected second replica lookup behaviour: wanted=%t", i, tc.shouldClearReplica)
 		}
 	}

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -43,7 +43,11 @@ func (a rangeCacheKey) Compare(b llrb.Comparable) int {
 }
 
 func meta(k roachpb.RKey) roachpb.RKey {
-	return keys.Addr(keys.RangeMetaKey(k))
+	rk, err := keys.Addr(keys.RangeMetaKey(k))
+	if err != nil {
+		panic(err)
+	}
+	return rk
 }
 
 // RangeDescriptorDB is a type which can query range descriptors from an

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -42,12 +42,16 @@ func (a rangeCacheKey) Compare(b llrb.Comparable) int {
 	return bytes.Compare(a, b.(rangeCacheKey))
 }
 
-func meta(k roachpb.RKey) roachpb.RKey {
-	rk, err := keys.Addr(keys.RangeMetaKey(k))
+func meta(k roachpb.RKey) (roachpb.RKey, error) {
+	return keys.Addr(keys.RangeMetaKey(k))
+}
+
+func mustMeta(k roachpb.RKey) roachpb.RKey {
+	m, err := meta(k)
 	if err != nil {
 		panic(err)
 	}
-	return rk
+	return m
 }
 
 // RangeDescriptorDB is a type which can query range descriptors from an
@@ -122,7 +126,9 @@ func (rdc *rangeDescriptorCache) stringLocked() string {
 // the key's data, or an error if any occurred.
 func (rdc *rangeDescriptorCache) LookupRangeDescriptor(key roachpb.RKey,
 	considerIntents, useReverseScan bool) (*roachpb.RangeDescriptor, *roachpb.Error) {
-	if _, r := rdc.getCachedRangeDescriptor(key, useReverseScan); r != nil {
+	if _, r, err := rdc.getCachedRangeDescriptor(key, useReverseScan); err != nil {
+		return nil, roachpb.NewError(err)
+	} else if r != nil {
 		return r, nil
 	}
 
@@ -132,15 +138,20 @@ func (rdc *rangeDescriptorCache) LookupRangeDescriptor(key roachpb.RKey,
 		log.Infof("lookup range descriptor: key=%s", key)
 	}
 	rs, pErr := func(key roachpb.RKey, considerIntents, useReverseScan bool) ([]roachpb.RangeDescriptor, *roachpb.Error) {
+		// metadataKey is sent to rangeLookup to find the
+		// RangeDescriptor which contains key.
+		metadataKey, err := meta(key)
+		if err != nil {
+			return nil, roachpb.NewError(err)
+		}
+
 		var (
-			// metadataKey is sent to rangeLookup to find the
-			// RangeDescriptor which contains key.
-			metadataKey = meta(key)
 			// desc is the RangeDescriptor for the range which contains
 			// metadataKey.
 			desc *roachpb.RangeDescriptor
 			pErr *roachpb.Error
 		)
+
 		if bytes.Equal(metadataKey, roachpb.RKeyMin) {
 			// In this case, the requested key is stored in the cluster's first
 			// range. Return the first range, which is always gossiped and not
@@ -188,11 +199,16 @@ func (rdc *rangeDescriptorCache) LookupRangeDescriptor(key roachpb.RKey,
 		// Before adding a new descriptor, make sure we clear out any
 		// pre-existing, overlapping descriptor which might have been
 		// re-inserted due to concurrent range lookups.
-		rangeKey := meta(rs[i].EndKey)
+		rangeKey, err := meta(rs[i].EndKey)
+		if err != nil {
+			return nil, roachpb.NewError(err)
+		}
 		if log.V(1) {
 			log.Infof("adding descriptor: key=%s desc=%s", rangeKey, &rs[i])
 		}
-		rdc.clearOverlappingCachedRangeDescriptors(&rs[i])
+		if err := rdc.clearOverlappingCachedRangeDescriptors(&rs[i]); err != nil {
+			return nil, roachpb.NewError(err)
+		}
 		rdc.rangeCache.Add(rangeCacheKey(rangeKey), &rs[i])
 	}
 	rdc.rangeCacheMu.Unlock()
@@ -207,7 +223,7 @@ func (rdc *rangeDescriptorCache) LookupRangeDescriptor(key roachpb.RKey,
 // compare-and-evict (as pointers); if it is nil, eviction is unconditional
 // but a warning will be logged.
 func (rdc *rangeDescriptorCache) EvictCachedRangeDescriptor(descKey roachpb.RKey,
-	seenDesc *roachpb.RangeDescriptor, inclusive bool) {
+	seenDesc *roachpb.RangeDescriptor, inclusive bool) error {
 	if seenDesc == nil {
 		log.Warningf("compare-and-evict for key %s with nil descriptor; clearing unconditionally", descKey)
 	}
@@ -215,14 +231,17 @@ func (rdc *rangeDescriptorCache) EvictCachedRangeDescriptor(descKey roachpb.RKey
 	rdc.rangeCacheMu.Lock()
 	defer rdc.rangeCacheMu.Unlock()
 
-	rngKey, cachedDesc := rdc.getCachedRangeDescriptorLocked(descKey, inclusive)
+	rngKey, cachedDesc, err := rdc.getCachedRangeDescriptorLocked(descKey, inclusive)
+	if err != nil {
+		return err
+	}
 	// Note that we're doing a "compare-and-erase": If seenDesc is not nil,
 	// we want to clean the cache only if it equals the cached range
 	// descriptor as a pointer. If not, then likely some other caller
 	// already evicted previously, and we can save work by not doing it
 	// again (which would prompt another expensive lookup).
 	if seenDesc != nil && seenDesc != cachedDesc {
-		return
+		return nil
 	}
 
 	for {
@@ -236,8 +255,14 @@ func (rdc *rangeDescriptorCache) EvictCachedRangeDescriptor(descKey roachpb.RKey
 		// Retrieve the metadata range key for the next level of metadata, and
 		// evict that key as well. This loop ends after the meta1 range, which
 		// returns KeyMin as its metadata key.
-		descKey = meta(descKey)
-		rngKey, cachedDesc = rdc.getCachedRangeDescriptorLocked(descKey, inclusive)
+		descKey, err = meta(descKey)
+		if err != nil {
+			return err
+		}
+		rngKey, cachedDesc, err = rdc.getCachedRangeDescriptorLocked(descKey, inclusive)
+		if err != nil {
+			return err
+		}
 		// TODO(tschottdorf): write a test that verifies that the first descriptor
 		// can also be evicted. This is necessary since the initial range
 		// [KeyMin,KeyMax) may turn into [KeyMin, "something"), after which
@@ -246,6 +271,7 @@ func (rdc *rangeDescriptorCache) EvictCachedRangeDescriptor(descKey roachpb.RKey
 			break
 		}
 	}
+	return nil
 }
 
 // getCachedRangeDescriptor is a helper function to retrieve the descriptor of
@@ -256,7 +282,7 @@ func (rdc *rangeDescriptorCache) EvictCachedRangeDescriptor(descKey roachpb.RKey
 // and `key` is the EndKey and StartKey of two adjacent ranges, the first range
 // is returned instead of the second (which technically contains the given key).
 func (rdc *rangeDescriptorCache) getCachedRangeDescriptor(key roachpb.RKey, inclusive bool) (
-	rangeCacheKey, *roachpb.RangeDescriptor) {
+	rangeCacheKey, *roachpb.RangeDescriptor, error) {
 	rdc.rangeCacheMu.RLock()
 	defer rdc.rangeCacheMu.RUnlock()
 	return rdc.getCachedRangeDescriptorLocked(key, inclusive)
@@ -266,19 +292,23 @@ func (rdc *rangeDescriptorCache) getCachedRangeDescriptor(key roachpb.RKey, incl
 // descriptor of the range which contains the given key, if present in the
 // cache. It is assumed that the caller holds a read lock on rdc.rangeCacheMu.
 func (rdc *rangeDescriptorCache) getCachedRangeDescriptorLocked(key roachpb.RKey, inclusive bool) (
-	rangeCacheKey, *roachpb.RangeDescriptor) {
+	rangeCacheKey, *roachpb.RangeDescriptor, error) {
 	// The cache is indexed using the end-key of the range, but the
 	// end-key is non-inclusive by default.
 	var metaKey roachpb.RKey
+	var err error
 	if !inclusive {
-		metaKey = meta(key.Next())
+		metaKey, err = meta(key.Next())
 	} else {
-		metaKey = meta(key)
+		metaKey, err = meta(key)
+	}
+	if err != nil {
+		return nil, nil, err
 	}
 
 	k, v, ok := rdc.rangeCache.Ceil(rangeCacheKey(metaKey))
 	if !ok {
-		return nil, nil
+		return nil, nil, nil
 	}
 	metaEndKey := k.(rangeCacheKey)
 	rd := v.(*roachpb.RangeDescriptor)
@@ -287,24 +317,27 @@ func (rdc *rangeDescriptorCache) getCachedRangeDescriptorLocked(key roachpb.RKey
 	if !rd.ContainsKey(key) {
 		// The key is the EndKey and we're inclusive, so just return the range descriptor.
 		if inclusive && key.Equal(rd.EndKey) {
-			return metaEndKey, rd
+			return metaEndKey, rd, nil
 		}
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// The key is the StartKey, but we're inclusive and thus need to return the
 	// previous range descriptor, but it is not in the cache yet.
 	if inclusive && key.Equal(rd.StartKey) {
-		return nil, nil
+		return nil, nil, nil
 	}
-	return metaEndKey, rd
+	return metaEndKey, rd, nil
 }
 
 // clearOverlappingCachedRangeDescriptors looks up and clears any
 // cache entries which overlap the specified descriptor.
-func (rdc *rangeDescriptorCache) clearOverlappingCachedRangeDescriptors(desc *roachpb.RangeDescriptor) {
+func (rdc *rangeDescriptorCache) clearOverlappingCachedRangeDescriptors(desc *roachpb.RangeDescriptor) error {
 	key := desc.EndKey
-	metaKey := meta(key)
+	metaKey, err := meta(key)
+	if err != nil {
+		return err
+	}
 
 	// Clear out any descriptors which subsume the key which we're going
 	// to cache. For example, if an existing KeyMin->KeyMax descriptor
@@ -319,6 +352,16 @@ func (rdc *rangeDescriptorCache) clearOverlappingCachedRangeDescriptors(desc *ro
 			rdc.rangeCache.Del(k.(rangeCacheKey))
 		}
 	}
+
+	startMeta, err := meta(desc.StartKey)
+	if err != nil {
+		return err
+	}
+	endMeta, err := meta(desc.EndKey)
+	if err != nil {
+		return err
+	}
+
 	// Also clear any descriptors which are subsumed by the one we're
 	// going to cache. This could happen on a merge (and also happens
 	// when there's a lot of concurrency). Iterate from the range meta key
@@ -328,6 +371,6 @@ func (rdc *rangeDescriptorCache) clearOverlappingCachedRangeDescriptors(desc *ro
 			log.Infof("clearing subsumed descriptor: key=%s desc=%s", k, v.(*roachpb.RangeDescriptor))
 		}
 		rdc.rangeCache.Del(k.(rangeCacheKey))
-	}, rangeCacheKey(meta(desc.StartKey).Next()),
-		rangeCacheKey(meta(desc.EndKey)))
+	}, rangeCacheKey(startMeta.Next()), rangeCacheKey(endMeta))
+	return nil
 }

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
-	"github.com/cockroachdb/cockroach/util/log"
 )
 
 type testDescriptorDB struct {
@@ -46,7 +45,6 @@ func (a testDescriptorNode) Compare(b llrb.Comparable) int {
 }
 
 func (db *testDescriptorDB) getDescriptor(key roachpb.RKey) []roachpb.RangeDescriptor {
-	log.Infof("getDescriptor: %s", key)
 	response := make([]roachpb.RangeDescriptor, 0, 3)
 	for i := 0; i < 3; i++ {
 		v := db.data.Ceil(testDescriptorNode{
@@ -131,10 +129,13 @@ func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) *roachpb.Range
 	if pErr != nil {
 		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", pErr)
 	}
-	if !r.ContainsKey(keys.Addr(roachpb.Key(key))) {
+	keyAddr, err := keys.Addr(roachpb.Key(key))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.ContainsKey(keyAddr) {
 		t.Fatalf("Returned range did not contain key: %s-%s, %s", r.StartKey, r.EndKey, key)
 	}
-	log.Infof("doLookup: %s %+v", key, r)
 	return r
 }
 

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -141,7 +141,7 @@ func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) *roachpb.Range
 
 func TestRangeCacheAssumptions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	expKeyMin := meta(meta(meta(roachpb.RKey("test"))))
+	expKeyMin := mustMeta(mustMeta(mustMeta(roachpb.RKey("test"))))
 	if !bytes.Equal(expKeyMin, roachpb.RKeyMin) {
 		t.Fatalf("RangeCache relies on RangeMetaKey returning KeyMin after two levels, but got %s", expKeyMin)
 	}
@@ -157,7 +157,7 @@ func TestRangeCache(t *testing.T) {
 	for i, char := range "abcdefghijklmnopqrstuvwx" {
 		db.splitRange(t, roachpb.RKey(string(char)))
 		if i > 0 && i%6 == 0 {
-			db.splitRange(t, meta(roachpb.RKey(string(char))))
+			db.splitRange(t, mustMeta(roachpb.RKey(string(char))))
 		}
 	}
 
@@ -195,7 +195,9 @@ func TestRangeCache(t *testing.T) {
 	db.assertLookupCount(t, 0, "xx")
 
 	// Evict clears one level 1 and one level 2 cache
-	db.cache.EvictCachedRangeDescriptor(roachpb.RKey("da"), nil, false)
+	if err := db.cache.EvictCachedRangeDescriptor(roachpb.RKey("da"), nil, false); err != nil {
+		t.Fatal(err)
+	}
 	doLookup(t, db.cache, "fa")
 	db.assertLookupCount(t, 0, "fa")
 	doLookup(t, db.cache, "da")
@@ -208,12 +210,16 @@ func TestRangeCache(t *testing.T) {
 
 	// Attempt to compare-and-evict with a descriptor that is not equal to the
 	// cached one; it should not alter the cache.
-	db.cache.EvictCachedRangeDescriptor(roachpb.RKey("cz"), &roachpb.RangeDescriptor{}, false)
+	if err := db.cache.EvictCachedRangeDescriptor(roachpb.RKey("cz"), &roachpb.RangeDescriptor{}, false); err != nil {
+		t.Fatal(err)
+	}
 	doLookup(t, db.cache, "cz")
 	db.assertLookupCount(t, 0, "cz")
 	// Now evict with the actual descriptor. The cache should clear the
 	// descriptor and the cached meta key.
-	db.cache.EvictCachedRangeDescriptor(roachpb.RKey("cz"), doLookup(t, db.cache, "cz"), false)
+	if err := db.cache.EvictCachedRangeDescriptor(roachpb.RKey("cz"), doLookup(t, db.cache, "cz"), false); err != nil {
+		t.Fatal(err)
+	}
 	doLookup(t, db.cache, "cz")
 	db.assertLookupCount(t, 2, "cz")
 
@@ -241,22 +247,34 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 		StartKey: roachpb.RKey("b"),
 		EndKey:   roachpb.RKeyMax,
 	}
-	cache.clearOverlappingCachedRangeDescriptors(minToBDesc)
-	cache.rangeCache.Add(rangeCacheKey(meta(roachpb.RKey("b"))), minToBDesc)
-	if _, desc := cache.getCachedRangeDescriptor(roachpb.RKey("b"), false); desc != nil {
+	if err := cache.clearOverlappingCachedRangeDescriptors(minToBDesc); err != nil {
+		t.Fatal(err)
+	}
+	cache.rangeCache.Add(rangeCacheKey(mustMeta(roachpb.RKey("b"))), minToBDesc)
+	if _, desc, err := cache.getCachedRangeDescriptor(roachpb.RKey("b"), false); err != nil {
+		t.Fatal(err)
+	} else if desc != nil {
 		t.Errorf("descriptor unexpectedly non-nil: %s", desc)
 	}
-	cache.clearOverlappingCachedRangeDescriptors(bToMaxDesc)
-	cache.rangeCache.Add(rangeCacheKey(meta(roachpb.RKeyMax)), bToMaxDesc)
-	if _, desc := cache.getCachedRangeDescriptor(roachpb.RKey("b"), false); desc != bToMaxDesc {
+	if err := cache.clearOverlappingCachedRangeDescriptors(bToMaxDesc); err != nil {
+		t.Fatal(err)
+	}
+	cache.rangeCache.Add(rangeCacheKey(mustMeta(roachpb.RKeyMax)), bToMaxDesc)
+	if _, desc, err := cache.getCachedRangeDescriptor(roachpb.RKey("b"), false); err != nil {
+		t.Fatal(err)
+	} else if desc != bToMaxDesc {
 		t.Errorf("expected descriptor %s; got %s", bToMaxDesc, desc)
 	}
 
 	// Add default descriptor back which should remove two split descriptors.
-	cache.clearOverlappingCachedRangeDescriptors(defDesc)
+	if err := cache.clearOverlappingCachedRangeDescriptors(defDesc); err != nil {
+		t.Fatal(err)
+	}
 	cache.rangeCache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKeyMax)), defDesc)
 	for _, key := range []roachpb.RKey{roachpb.RKey("a"), roachpb.RKey("b")} {
-		if _, desc := cache.getCachedRangeDescriptor(key, false); desc != defDesc {
+		if _, desc, err := cache.getCachedRangeDescriptor(key, false); err != nil {
+			t.Fatal(err)
+		} else if desc != defDesc {
 			t.Errorf("expected descriptor %s for key %s; got %s", defDesc, key, desc)
 		}
 	}
@@ -266,9 +284,13 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 		StartKey: roachpb.RKey("b"),
 		EndKey:   roachpb.RKey("c"),
 	}
-	cache.clearOverlappingCachedRangeDescriptors(bToCDesc)
-	cache.rangeCache.Add(rangeCacheKey(meta(roachpb.RKey("c"))), bToCDesc)
-	if _, desc := cache.getCachedRangeDescriptor(roachpb.RKey("c"), true); desc != bToCDesc {
+	if err := cache.clearOverlappingCachedRangeDescriptors(bToCDesc); err != nil {
+		t.Fatal(err)
+	}
+	cache.rangeCache.Add(rangeCacheKey(mustMeta(roachpb.RKey("c"))), bToCDesc)
+	if _, desc, err := cache.getCachedRangeDescriptor(roachpb.RKey("c"), true); err != nil {
+		t.Fatal(err)
+	} else if desc != bToCDesc {
 		t.Errorf("expected descriptor %s; got %s", bToCDesc, desc)
 	}
 
@@ -276,9 +298,13 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 		StartKey: roachpb.RKey("a"),
 		EndKey:   roachpb.RKey("b"),
 	}
-	cache.clearOverlappingCachedRangeDescriptors(aToBDesc)
-	cache.rangeCache.Add(rangeCacheKey(meta(roachpb.RKey("b"))), aToBDesc)
-	if _, desc := cache.getCachedRangeDescriptor(roachpb.RKey("c"), true); desc != bToCDesc {
+	if err := cache.clearOverlappingCachedRangeDescriptors(aToBDesc); err != nil {
+		t.Fatal(err)
+	}
+	cache.rangeCache.Add(rangeCacheKey(mustMeta(roachpb.RKey("b"))), aToBDesc)
+	if _, desc, err := cache.getCachedRangeDescriptor(roachpb.RKey("c"), true); err != nil {
+		t.Fatal(err)
+	} else if desc != bToCDesc {
 		t.Errorf("expected descriptor %s; got %s", bToCDesc, desc)
 	}
 }
@@ -313,7 +339,7 @@ func TestRangeCacheClearOverlappingMeta(t *testing.T) {
 	// Add new range, corresponding to splitting the first range at a meta key.
 	metaSplitDesc := &roachpb.RangeDescriptor{
 		StartKey: roachpb.RKeyMin,
-		EndKey:   meta(roachpb.RKey("foo")),
+		EndKey:   mustMeta(roachpb.RKey("foo")),
 	}
 	func() {
 		defer func() {
@@ -321,7 +347,9 @@ func TestRangeCacheClearOverlappingMeta(t *testing.T) {
 				t.Fatalf("invocation of clearOverlappingCachedRangeDescriptors panicked: %v", r)
 			}
 		}()
-		cache.clearOverlappingCachedRangeDescriptors(metaSplitDesc)
+		if err := cache.clearOverlappingCachedRangeDescriptors(metaSplitDesc); err != nil {
+			t.Fatal(err)
+		}
 	}()
 }
 
@@ -379,7 +407,10 @@ func TestGetCachedRangeDescriptorInclusive(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		cacheKey, targetRange := cache.getCachedRangeDescriptor(test.queryKey, true /* inclusive */)
+		cacheKey, targetRange, err := cache.getCachedRangeDescriptor(test.queryKey, true /* inclusive */)
+		if err != nil {
+			t.Error(err)
+		}
 		if !reflect.DeepEqual(targetRange, test.rng) {
 			t.Fatalf("expect range %v, actual get %v", test.rng, targetRange)
 		}

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -104,8 +104,8 @@ func TestRangeSplitMeta(t *testing.T) {
 	s := createTestDB(t)
 	defer s.Stop()
 
-	splitKeys := []roachpb.RKey{roachpb.RKey("G"), meta(roachpb.RKey("F")),
-		meta(roachpb.RKey("K")), meta(roachpb.RKey("H"))}
+	splitKeys := []roachpb.RKey{roachpb.RKey("G"), mustMeta(roachpb.RKey("F")),
+		mustMeta(roachpb.RKey("K")), mustMeta(roachpb.RKey("H"))}
 
 	// Execute the consecutive splits.
 	for _, splitKey := range splitKeys {

--- a/server/admin.go
+++ b/server/admin.go
@@ -468,9 +468,15 @@ func (s *adminServer) TableDetails(_ context.Context, req *TableDetailsRequest) 
 		}); pErr != nil {
 			return nil, s.serverError(pErr.GoError())
 		}
-		tableRSpan := roachpb.RSpan{
-			Key:    keys.Addr(tableSpan.Key),
-			EndKey: keys.Addr(tableSpan.EndKey),
+		tableRSpan := roachpb.RSpan{}
+		var err error
+		tableRSpan.Key, err = keys.Addr(tableSpan.Key)
+		if err != nil {
+			return nil, s.serverError(err)
+		}
+		tableRSpan.EndKey, err = keys.Addr(tableSpan.EndKey)
+		if err != nil {
+			return nil, s.serverError(err)
 		}
 		rangeCount, pErr := s.distSender.CountRanges(tableRSpan)
 		if pErr != nil {

--- a/sql/keys_test.go
+++ b/sql/keys_test.go
@@ -55,7 +55,11 @@ func TestKeyAddress(t *testing.T) {
 	}
 	var lastKey roachpb.Key
 	for i, test := range testCases {
-		result := keys.Addr(test.key).AsRawKey()
+		resultAddr, err := keys.Addr(test.key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := resultAddr.AsRawKey()
 		if result.Compare(lastKey) <= 0 {
 			t.Errorf("%d: key address %q is <= %q", i, result, lastKey)
 		}

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -153,9 +153,12 @@ func checkEndTransactionTrigger(args storageutils.FilterArgs) error {
 
 	var hasSystemKey bool
 	for _, span := range req.IntentSpans {
-		addr := keys.Addr(span.Key)
-		if bytes.Compare(addr, keys.SystemConfigSpan.Key) >= 0 &&
-			bytes.Compare(addr, keys.SystemConfigSpan.EndKey) < 0 {
+		keyAddr, err := keys.Addr(span.Key)
+		if err != nil {
+			return err
+		}
+		if bytes.Compare(keyAddr, keys.SystemConfigSpan.Key) >= 0 &&
+			bytes.Compare(keyAddr, keys.SystemConfigSpan.EndKey) < 0 {
 			hasSystemKey = true
 			break
 		}

--- a/storage/addressing_test.go
+++ b/storage/addressing_test.go
@@ -52,7 +52,11 @@ func meta2Key(key roachpb.RKey) []byte {
 }
 
 func metaKey(key roachpb.RKey) []byte {
-	return keys.Addr(keys.RangeMetaKey(key))
+	rk, err := keys.Addr(keys.RangeMetaKey(key))
+	if err != nil {
+		panic(err)
+	}
+	return rk
 }
 
 // TestUpdateRangeAddressing verifies range addressing records are

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -304,7 +304,11 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 	}
 
 	// Verify no intents remains on range descriptor keys.
-	for _, key := range []roachpb.Key{keys.RangeDescriptorKey(roachpb.RKeyMin), keys.RangeDescriptorKey(keys.Addr(splitKey))} {
+	splitKeyAddr, err := keys.Addr(splitKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []roachpb.Key{keys.RangeDescriptorKey(roachpb.RKeyMin), keys.RangeDescriptorKey(splitKeyAddr)} {
 		if _, _, err := engine.MVCCGet(store.Engine(), key, store.Clock().Now(), true, nil); err != nil {
 			t.Fatal(err)
 		}
@@ -980,7 +984,11 @@ func TestStoreSplitReadRace(t *testing.T) {
 		var h roachpb.Header
 		h.Timestamp = now
 		args := putArgs(key(i), []byte("foo"))
-		h.RangeID = store.LookupReplica(keys.Addr(args.Key), nil).RangeID
+		keyAddr, err := keys.Addr(args.Key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		h.RangeID = store.LookupReplica(keyAddr, nil).RangeID
 		_, respH, pErr := storage.SendWrapped(store, context.Background(), h, &args)
 		if pErr != nil {
 			t.Fatal(pErr)

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1870,7 +1870,7 @@ func MVCCFindSplitKey(
 	debugFn func(msg string, args ...interface{}),
 ) (roachpb.Key, error) {
 	if key.Less(roachpb.RKey(keys.LocalMax)) {
-		key = keys.Addr(keys.LocalMax)
+		key = roachpb.RKey(keys.LocalMax)
 	}
 
 	logf := func(msg string, args ...interface{}) {

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -2362,7 +2362,15 @@ func TestFindValidSplitKeys(t *testing.T) {
 		defer snap.Close()
 		rangeStart := test.keys[0]
 		rangeEnd := test.keys[len(test.keys)-1].Next()
-		splitKey, err := MVCCFindSplitKey(snap, rangeID, keys.Addr(rangeStart), keys.Addr(rangeEnd), nil)
+		rangeStartAddr, err := keys.Addr(rangeStart)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rangeEndAddr, err := keys.Addr(rangeEnd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		splitKey, err := MVCCFindSplitKey(snap, rangeID, rangeStartAddr, rangeEndAddr, nil)
 		if test.expError {
 			if !testutils.IsError(err, "has no valid splits") {
 				t.Errorf("%d: unexpected error: %v", i, err)

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -355,12 +355,17 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	g, stopper := gossipForTest(t)
 	defer stopper.Stop()
 
+	dataMaxAddr, err := keys.Addr(keys.SystemConfigTableDataMax)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// This range can never be split due to zone configs boundaries.
 	neverSplits := &Replica{RangeID: 1}
 	if err := neverSplits.setDesc(&roachpb.RangeDescriptor{
 		RangeID:  1,
 		StartKey: roachpb.RKeyMin,
-		EndKey:   keys.Addr(keys.SystemConfigTableDataMax),
+		EndKey:   dataMaxAddr,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -369,7 +374,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	willSplit := &Replica{RangeID: 2}
 	if err := willSplit.setDesc(&roachpb.RangeDescriptor{
 		RangeID:  2,
-		StartKey: keys.Addr(keys.SystemConfigTableDataMax),
+		StartKey: dataMaxAddr,
 		EndKey:   roachpb.RKeyMax,
 	}); err != nil {
 		t.Fatal(err)

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -664,7 +664,11 @@ func containsKey(desc roachpb.RangeDescriptor, key roachpb.Key) bool {
 	if bytes.HasPrefix(key, keys.LocalRangeIDPrefix) {
 		return bytes.HasPrefix(key, keys.MakeRangeIDPrefix(desc.RangeID))
 	}
-	return desc.ContainsKey(keys.Addr(key))
+	keyAddr, err := keys.Addr(key)
+	if err != nil {
+		return false
+	}
+	return desc.ContainsKey(keyAddr)
 }
 
 // ContainsKeyRange returns whether this range contains the specified
@@ -674,7 +678,15 @@ func (r *Replica) ContainsKeyRange(start, end roachpb.Key) bool {
 }
 
 func containsKeyRange(desc roachpb.RangeDescriptor, start, end roachpb.Key) bool {
-	return desc.ContainsKeyRange(keys.Addr(start), keys.Addr(end))
+	startKeyAddr, err := keys.Addr(start)
+	if err != nil {
+		return false
+	}
+	endKeyAddr, err := keys.Addr(end)
+	if err != nil {
+		return false
+	}
+	return desc.ContainsKeyRange(startKeyAddr, endKeyAddr)
 }
 
 // getLastReplicaGCTimestamp reads the timestamp at which the replica was

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -696,7 +696,10 @@ func (r *Replica) RangeLookup(
 ) (roachpb.RangeLookupResponse, []roachpb.Intent, error) {
 	var reply roachpb.RangeLookupResponse
 	ts := h.Timestamp // all we're going to use from the header.
-	key := keys.Addr(args.Key)
+	key, err := keys.Addr(args.Key)
+	if err != nil {
+		return reply, nil, err
+	}
 	if !key.Equal(args.Key) {
 		return reply, nil, util.Errorf("illegal lookup of range-local key")
 	}
@@ -772,7 +775,11 @@ func (r *Replica) RangeLookup(
 			if err := v.GetProto(&r); err != nil {
 				return nil, err
 			}
-			if !keys.Addr(keys.RangeMetaKey(r.StartKey)).Less(key) {
+			startKeyAddr, err := keys.Addr(keys.RangeMetaKey(r.StartKey))
+			if err != nil {
+				return nil, err
+			}
+			if !startKeyAddr.Less(key) {
 				// This is the case in which we've picked up an extra descriptor
 				// we don't want.
 				return nil, nil
@@ -781,7 +788,7 @@ func (r *Replica) RangeLookup(
 			return &r, nil
 		}
 
-		if key.Less(keys.Addr(keys.Meta2KeyMax)) {
+		if key.Less(roachpb.RKey(keys.Meta2KeyMax)) {
 			startKey, endKey, err := keys.MetaScanBounds(key)
 			if err != nil {
 				return reply, nil, err
@@ -1653,7 +1660,10 @@ func (r *Replica) AdminSplit(
 			return reply, roachpb.NewErrorf("cannot split range at key %s: %v", splitKey, err)
 		}
 
-		splitKey = keys.Addr(foundSplitKey)
+		splitKey, err = keys.Addr(foundSplitKey)
+		if err != nil {
+			return reply, roachpb.NewError(err)
+		}
 		if !splitKey.Equal(foundSplitKey) {
 			return reply, roachpb.NewErrorf("cannot split range at range-local key %s", splitKey)
 		}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -3652,7 +3652,11 @@ func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 
 	origDesc := rlReply.Ranges[0]
 	newDesc := origDesc
-	newDesc.EndKey = keys.Addr(key)
+	var err error
+	newDesc.EndKey, err = keys.Addr(key)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Write the new descriptor as an intent.
 	data, err := proto.Marshal(&newDesc)
@@ -3853,6 +3857,14 @@ func TestReplicaLookup(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
+	mustAddr := func(k roachpb.Key) roachpb.RKey {
+		rk, err := keys.Addr(k)
+		if err != nil {
+			panic(err)
+		}
+		return rk
+	}
+
 	expected := []roachpb.RangeDescriptor{*tc.rng.Desc()}
 	testCases := []struct {
 		key      roachpb.RKey
@@ -3867,10 +3879,10 @@ func TestReplicaLookup(t *testing.T) {
 		{key: roachpb.RKeyMin, reverse: false, expected: expected},
 		// Test with the last key in a meta prefix. This is an edge case in the
 		// implementation.
-		{key: keys.Addr(keys.Meta1KeyMax), reverse: false, expected: expected},
-		{key: keys.Addr(keys.Meta2KeyMax), reverse: false, expected: nil},
-		{key: keys.Addr(keys.Meta1KeyMax), reverse: true, expected: expected},
-		{key: keys.Addr(keys.Meta2KeyMax), reverse: true, expected: expected},
+		{key: mustAddr(keys.Meta1KeyMax), reverse: false, expected: expected},
+		{key: mustAddr(keys.Meta2KeyMax), reverse: false, expected: nil},
+		{key: mustAddr(keys.Meta1KeyMax), reverse: true, expected: expected},
+		{key: mustAddr(keys.Meta2KeyMax), reverse: true, expected: expected},
 	}
 
 	for _, c := range testCases {
@@ -4040,7 +4052,11 @@ func TestReplicaLoadSystemConfigSpanIntent(t *testing.T) {
 	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()
-	rng := tc.store.LookupReplica(keys.Addr(keys.SystemConfigSpan.Key), nil)
+	scStartSddr, err := keys.Addr(keys.SystemConfigSpan.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rng := tc.store.LookupReplica(scStartSddr, nil)
 	if rng == nil {
 		t.Fatalf("no replica contains the SystemConfig span")
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -120,7 +120,14 @@ func verifyKeys(start, end roachpb.Key, checkEndKey bool) error {
 		return util.Errorf("end key %q must be less than or equal to KeyMax", end)
 	}
 	{
-		sAddr, eAddr := keys.Addr(start), keys.Addr(end)
+		sAddr, err := keys.Addr(start)
+		if err != nil {
+			return err
+		}
+		eAddr, err := keys.Addr(end)
+		if err != nil {
+			return err
+		}
 		if !sAddr.Less(eAddr) {
 			return util.Errorf("end key %q must be greater than start %q", end, start)
 		}
@@ -1103,7 +1110,11 @@ func (s *Store) BootstrapRange(initialValues []roachpb.KeyValue) error {
 		return err
 	}
 	// Range addressing for meta1.
-	meta1Key := keys.RangeMetaKey(keys.Addr(meta2Key))
+	meta2KeyAddr, err := keys.Addr(meta2Key)
+	if err != nil {
+		return err
+	}
+	meta1Key := keys.RangeMetaKey(meta2KeyAddr)
 	if err := engine.MVCCPutProto(batch, ms, meta1Key, now, nil, desc); err != nil {
 		return err
 	}

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -132,7 +132,10 @@ func (ls *Stores) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 	// If we aren't given a Replica, then a little bending over
 	// backwards here. This case applies exclusively to unittests.
 	if ba.RangeID == 0 || ba.Replica.StoreID == 0 {
-		rs := keys.Range(ba)
+		rs, err := keys.Range(ba)
+		if err != nil {
+			return nil, roachpb.NewError(err)
+		}
 		rangeID, repl, err := ls.lookupReplica(rs.Key, rs.EndKey)
 		if err != nil {
 			return nil, roachpb.NewError(err)


### PR DESCRIPTION
Fixes #5500.
- `keys.Addr` (and related functions) now return an error on
  unaddressable keys
- `keys.Addr` now properly handles doubly-encoded range-locally
  addressed keys

The following no longer crashes a node.

```
for i in $(seq 0 255); do echo $i; ./cockroach debug kv scan --insecure '' $(printf "\x$(printf %x ${i})"); done
```

The majority of this is error plumbing, but there are a few changes in the `keys` and `kv` package that are important.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5604)

<!-- Reviewable:end -->
