### PR TITLE
cli: Fix NPE when server startup returns an error

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -146,14 +146,13 @@ func runStart(_ *cobra.Command, _ []string) error {
 
 	log.Info("starting cockroach node")
 	s, err := server.NewServer(&cliContext.Context, stopper)
+	if err != nil {
+		return fmt.Errorf("failed to start Cockroach server: %s", err)
+	}
 
 	// We don't do this in NewServer since we don't want it in tests.
 	if err := s.SetupReportingURLs(); err != nil {
 		return err
-	}
-
-	if err != nil {
-		return fmt.Errorf("failed to start Cockroach server: %s", err)
 	}
 
 	if err := s.Start(); err != nil {


### PR DESCRIPTION
Fixes #5600.

Looks like this issue got introduced in https://github.com/cockroachdb/cockroach/commit/7146da7b0d23bf077b76289210f20ba77cc00321. 
The `NewServer` err check got pushed below `SetupReportingURLs`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5610)

<!-- Reviewable:end -->
