### PR TITLE
sql: fixes pgwire timestamp parsing (again)

### DIFF
--- a/sql/pgwire/types.go
+++ b/sql/pgwire/types.go
@@ -416,7 +416,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 	case oid.T_timestamp:
 		switch code {
 		case formatText:
-			ts, err := pq.ParseTimestamp(nil, string(b))
+			ts, err := parseTimestamp(string(b))
 			if err != nil {
 				return d, fmt.Errorf("could not parse string %q as timestamp", b)
 			}
@@ -427,7 +427,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 	case oid.T_date:
 		switch code {
 		case formatText:
-			ts, err := pq.ParseTimestamp(nil, string(b))
+			ts, err := parseTimestamp(string(b))
 			if err != nil {
 				return d, fmt.Errorf("could not parse string %q as date", b)
 			}
@@ -440,4 +440,15 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 		return d, fmt.Errorf("unsupported OID: %v", id)
 	}
 	return d, nil
+}
+
+func parseTimestamp(str string) (time.Time, error) {
+	// TODO(dan): The cockroach/pq driver encodes timestamps using
+	// time.RFC3339Nano, yet it cannot parse those timestamps using
+	// pq.ParseTimestamp. We should either fix pq.ParseTimestamp or replace this
+	// comment with one explaining the discrepancy.
+	if ts, err := time.Parse(time.RFC3339Nano, str); err == nil {
+		return ts, nil
+	}
+	return pq.ParseTimestamp(nil, str)
 }

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -367,11 +367,11 @@ func TestPGPreparedQuery(t *testing.T) {
 		},
 		"SELECT $1::date, $2::timestamp": {
 			base.Params(
-				time.Date(2006, 7, 8, 0, 0, 0, 0, time.FixedZone("", 0)),
-				time.Date(2001, 1, 2, 3, 4, 5, 0, time.FixedZone("", 0)),
+				time.Date(2006, 7, 8, 0, 0, 0, 9, time.FixedZone("", 0)),
+				time.Date(2001, 1, 2, 3, 4, 5, 6, time.FixedZone("", 0)),
 			).Results(
 				time.Date(2006, 7, 8, 0, 0, 0, 0, time.FixedZone("", 0)),
-				time.Date(2001, 1, 2, 3, 4, 5, 0, time.FixedZone("", 0)),
+				time.Date(2001, 1, 2, 3, 4, 5, 6, time.FixedZone("", 0)),
 			),
 		},
 		"INSERT INTO d.ts VALUES($1, $2) RETURNING *": {
@@ -388,6 +388,13 @@ func TestPGPreparedQuery(t *testing.T) {
 		"INSERT INTO d.ts VALUES(STATEMENT_TIMESTAMP(), $1) RETURNING b": {
 			base.Params("2006-07-08").Results(
 				time.Date(2006, 7, 8, 0, 0, 0, 0, time.FixedZone("", 0)),
+			),
+		},
+		"INSERT INTO d.ts (a) VALUES ($1) RETURNING a": {
+			base.Params(
+				time.Date(2006, 7, 8, 0, 0, 0, 123, time.FixedZone("", 0)),
+			).Results(
+				time.Date(2006, 7, 8, 0, 0, 0, 123, time.FixedZone("", 0)),
 			),
 		},
 


### PR DESCRIPTION
Closes #5609.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5611)

<!-- Reviewable:end -->
