### PR TITLE
client: set retrying to false only if no error

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -529,15 +529,30 @@ func (txn *Txn) Exec(
 RetryLoop:
 	for r := retry.Start(retryOptions); r.Next(); {
 		pErr = fn(txn, &opt)
-		if txn != nil {
-			txn.retrying = true
-			defer func() {
-				txn.retrying = false
-			}()
-		}
-		if (pErr == nil) && opt.AutoCommit && (txn.Proto.Status == roachpb.PENDING) {
+		if pErr == nil && opt.AutoCommit && txn.Proto.Status == roachpb.PENDING {
 			// fn succeeded, but didn't commit.
 			pErr = txn.Commit()
+		}
+
+		// The following state diagram shows how retrying change its state:
+		//
+		//                          another retry
+		//                          +-----+
+		//                          |     |
+		//                          | +---+
+		//          first try       | v
+		// false------------------>true------------------------+
+		//  ^                       | ^                        |
+		//  |                       | |                        |
+		//  | exit loop w/o error   | | exit loop w/ error     |
+		//  +-----------------------+ +------------------------+
+		if txn != nil && !txn.retrying {
+			txn.retrying = true
+			defer func() {
+				if pErr == nil {
+					txn.retrying = false
+				}
+			}()
 		}
 
 		if pErr == nil {

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -615,7 +615,6 @@ func (e *Executor) execStmtInAbortedTxn(
 		if txnState.State == RestartWait {
 			// Reset the state. Txn is Open again.
 			txnState.State = Open
-			txnState.retrying = true
 			// TODO(andrei/cdo): add a counter for user-directed retries.
 			return Result{}, nil
 		}
@@ -737,11 +736,7 @@ func (e *Executor) execStmtInOpenTxn(
 		// The executor should not be doing that. But it's also what the planner does for
 		// SET TRANSACTION ISOLATION ... It feels ever more wrong here.
 		// TODO(andrei): find a better way to track this running state.
-		// TODO(andrei): the check for retrying is a hack - we erroneously allow
-		// SAVEPOINT to be issued at any time during a retry, not just in the
-		// beginning. We should figure out how to track whether we started using the
-		// transaction during a retry.
-		if txnState.txn.Proto.IsInitialized() && !txnState.retrying {
+		if txnState.txn.Proto.IsInitialized() {
 			pErr := roachpb.NewError(util.Errorf(
 				"SAVEPOINT %s needs to be the first statement in a transaction",
 				parser.RestartSavepointName))

--- a/sql/session.go
+++ b/sql/session.go
@@ -148,12 +148,6 @@ type txnState struct {
 	txn   *client.Txn
 	State TxnStateEnum
 
-	// false at first, true since the moment when a transaction is retried.
-	// TODO(andrei): this duplicates the retrying field in client.Txn, but the
-	// state of that one is not reliable because of #5531. Clean this field up
-	// once that bug is settled.
-	retrying bool
-
 	// If set, the user declared the intention to retry the txn in case of retriable
 	// errors. The txn will enter a RestartWait state in case of such errors.
 	retryIntent bool


### PR DESCRIPTION
Fixes #5531

The following state machine shows how `retrying` change its state now:

```
                          another retry
                          +-----+
                          |     |
                          | +---+
          first try       | v    
 false------------------>true------------------------+
  ^                       | ^                        |
  |                       | |                        |
  | exit loop w/o error   | | exit loop w/ error     |
  +-----------------------+ +------------------------+
```

This is a quick fix of my previous change. I also feel that `kv` and `sql` layers should have a better way to handle transaction retries. For example, `txnState` has a `autoRetry` field and `TxnExecOptions` also have a `AutoRetry` field for now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5618)

<!-- Reviewable:end -->
