### PR TITLE
gossip: add a version number to gossip RPCs

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -195,8 +195,9 @@ func (c *client) gossip(g *Gossip, gossipClient GossipClient, stopper *stop.Stop
 	addr := g.is.NodeAddr
 	g.mu.Unlock()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(grpcutil.WithVersionNumber(context.Background()))
 	defer cancel()
+
 	stream, err := gossipClient.Gossip(ctx)
 	if err != nil {
 		return err

--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -24,7 +24,10 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
@@ -32,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/grpcutil"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
@@ -436,5 +440,96 @@ func TestClientForwardUnresolved(t *testing.T) {
 	}
 	if !reflect.DeepEqual(client.forwardAddr, &newAddr) {
 		t.Fatalf("unexpected forward address %v, expected %v", client.forwardAddr, &newAddr)
+	}
+}
+
+// TestServerRequiresVersion ensures that all gossip connections must contain a
+// version number.
+func TestServerRequiresVersion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+
+	// Setup and start the remote gossip.
+	remote := startGossip(1, stopper, t)
+	remote.mu.Lock()
+	rAddr := remote.is.NodeAddr
+	remote.mu.Unlock()
+
+	// Get the local gossip ready, but don't start it.
+	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
+	server := rpc.NewServer(rpcContext)
+	ln, err := util.ListenAndServeGRPC(stopper, server, util.TestAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lAddr := ln.Addr()
+	local := New(rpcContext, nil, stopper)
+	local.SetNodeID(2)
+	if err := local.SetNodeDescriptor(&roachpb.NodeDescriptor{
+		NodeID:  2,
+		Address: util.MakeUnresolvedAddr(lAddr.Network(), lAddr.String()),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := local.rpcContext.GRPCDial(rAddr.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	openStreamAndRequestGossip := func(ctx context.Context) error {
+		gossipClient := NewGossipClient(conn)
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		stream, err := gossipClient.Gossip(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		client := newClient(&rAddr)
+		err = client.requestGossip(local, rAddr, stream)
+
+		_, err = stream.Recv()
+		return err
+	}
+
+	// no metadata
+	ctx := context.Background()
+	if err := openStreamAndRequestGossip(ctx); !testutils.IsError(err, "no metadata found in the context") {
+		t.Fatalf("expected err 'no metadata found in the context', got %s", err)
+	}
+
+	// no version number
+	md := metadata.Pairs("something", "something")
+	ctx = metadata.NewContext(context.Background(), md)
+	if err := openStreamAndRequestGossip(ctx); !testutils.IsError(err, "no version number in the RPC context") {
+		t.Fatalf("no version number in the RPC context', got %s", err)
+	}
+
+	// too many version numbers
+	md = metadata.Pairs(grpcutil.RPCVersionKey, grpcutil.RPCVersion, grpcutil.RPCVersionKey, grpcutil.RPCVersion)
+	ctx = metadata.NewContext(context.Background(), md)
+	if err := openStreamAndRequestGossip(ctx); !testutils.IsError(err, "expected only 1 RPC context version number, got 2") {
+		t.Fatalf("expected err 'expected only 1 RPC context version number, got 2', got '%s'", err)
+	}
+
+	// incorrect version number
+	md = metadata.Pairs(grpcutil.RPCVersionKey, "wrong")
+	ctx = metadata.NewContext(context.Background(), md)
+	if err := openStreamAndRequestGossip(ctx); !testutils.IsError(err, "RPC version numbers do not match expected: 1, received: wrong") {
+		t.Fatalf("expected err 'RPC version numbers do not match expected: 1, received: wrong', got %s", err)
+	}
+
+	// the correct version number
+	ctx = grpcutil.WithVersionNumber(context.Background())
+	if err := openStreamAndRequestGossip(ctx); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/util/grpcutil/grpc_util.go
+++ b/util/grpcutil/grpc_util.go
@@ -17,15 +17,26 @@
 package grpcutil
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"golang.org/x/net/context"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/transport"
 
 	"github.com/cockroachdb/cockroach/util"
+)
+
+const (
+	// RPCVersion is used in all GRPC context's metadata to ensure that
+	// messages from different versions don't conflict.
+	RPCVersion = "1"
+	// RPCVersionKey is the key used to store and retrieve the version from an
+	// RPC context's metadata.
+	RPCVersionKey = "ver"
 )
 
 // IsClosedConnection returns true if err is an error produced by gRPC on closed connections.
@@ -40,4 +51,34 @@ func IsClosedConnection(err error) bool {
 		return true
 	}
 	return util.IsClosedConnection(err)
+}
+
+// WithVersionNumber adds the current RPC version number to a context for use
+// by GRPC.
+func WithVersionNumber(ctx context.Context) context.Context {
+	md := metadata.Pairs(RPCVersionKey, RPCVersion)
+	return metadata.NewContext(ctx, md)
+}
+
+var errNoMetadata = errors.New("no metadata found in the context")
+var errNoVersionNumber = errors.New("no version number in the RPC context")
+
+// CheckVersionNumber checks that the number supplied in an GRPC context is
+// the correct one.
+func CheckVersionNumber(ctx context.Context) error {
+	md, ok := metadata.FromContext(ctx)
+	if !ok {
+		return errNoMetadata
+	}
+	versionNumber, ok := md[RPCVersionKey]
+	if !ok {
+		return errNoVersionNumber
+	}
+	if len(versionNumber) != 1 {
+		return fmt.Errorf("expected only 1 RPC context version number, got %d", len(versionNumber))
+	}
+	if versionNumber[0] != RPCVersion {
+		return fmt.Errorf("RPC version numbers do not match expected: %s, received: %s", RPCVersion, versionNumber[0])
+	}
+	return nil
 }

--- a/util/grpcutil/grpc_util_test.go
+++ b/util/grpcutil/grpc_util_test.go
@@ -1,0 +1,63 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package grpcutil
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+
+	"golang.org/x/net/context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func TestVersions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// no metadata
+	ctx := context.Background()
+	if err := CheckVersionNumber(ctx); err == nil || err != errNoMetadata {
+		t.Fatalf("expected err '%s', got '%s'", errNoMetadata, err)
+	}
+
+	// no version number
+	md := metadata.Pairs("something", "something")
+	ctx = metadata.NewContext(context.Background(), md)
+	if err := CheckVersionNumber(ctx); err == nil || err != errNoVersionNumber {
+		t.Fatalf("expected err '%s', got '%s'", errNoVersionNumber, err)
+	}
+
+	// too many version numbers
+	md = metadata.Pairs(RPCVersionKey, RPCVersion, RPCVersionKey, RPCVersion)
+	ctx = metadata.NewContext(context.Background(), md)
+	if err := CheckVersionNumber(ctx); !testutils.IsError(err, "expected only 1 RPC context version number, got 2") {
+		t.Fatalf("expected err 'expected only 1 RPC context version number, got 2', got '%s'", err)
+	}
+
+	// incorrect version number
+	md = metadata.Pairs(RPCVersionKey, "wrong")
+	ctx = metadata.NewContext(context.Background(), md)
+	if err := CheckVersionNumber(ctx); !testutils.IsError(err, "RPC version numbers do not match expected: 1, received: wrong") {
+		t.Fatalf("expected err 'RPC version numbers do not match expected: 1, received: wrong', got %s", err)
+	}
+
+	// the correct version number
+	ctx = WithVersionNumber(context.Background())
+	if err := CheckVersionNumber(ctx); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This ensures that all gossip RPCs will now be required to contain a version
number to prevent different versions of cockroach gossiping to each other.

Part of #2719

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5619)

<!-- Reviewable:end -->
