### PR TITLE
cli: default --insecure=true

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -101,12 +102,36 @@ func initCacheSize() {
 	}
 }
 
+func initInsecure() error {
+	if !cliContext.Insecure || insecure.isSet {
+		return nil
+	}
+	// The --insecure flag was not specified on the command line, verify that the
+	// host refers to a loopback address.
+	if connHost != "" {
+		addr, err := net.ResolveIPAddr("ip", connHost)
+		if err != nil {
+			return err
+		}
+		if !addr.IP.IsLoopback() {
+			return fmt.Errorf("specify --insecure to listen on external address %s", connHost)
+		}
+	} else if connHost == "" {
+		cliContext.Addr = net.JoinHostPort("localhost", connPort)
+		cliContext.HTTPAddr = net.JoinHostPort("localhost", httpPort)
+	}
+	return nil
+}
+
 // runStart starts the cockroach node using --store as the list of
 // storage devices ("stores") on this machine and --join as the list
 // of other active nodes used to join this node to the cockroach
 // cluster, if this is its first time connecting.
 func runStart(_ *cobra.Command, _ []string) error {
 	initCacheSize()
+	if err := initInsecure(); err != nil {
+		return err
+	}
 
 	// Default the log directory to the the "logs" subdirectory of the first
 	// non-memory store. We only do this for the "start" command which is why

--- a/cli/start_test.go
+++ b/cli/start_test.go
@@ -1,0 +1,70 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func TestInitInsecure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	f := startCmd.Flags()
+	ctx := cliContext
+
+	testCases := []struct {
+		args     []string
+		insecure bool
+		expected string
+	}{
+		{[]string{}, true, ""},
+		{[]string{"--insecure"}, true, ""},
+		{[]string{"--insecure=true"}, true, ""},
+		{[]string{"--insecure=false"}, false, ""},
+		{[]string{"--host", "localhost"}, true, ""},
+		{[]string{"--host", "127.0.0.1"}, true, ""},
+		{[]string{"--host", "::1"}, true, ""},
+		{[]string{"--host", "192.168.1.1"}, true,
+			`specify --insecure to listen on external address 192\.168\.1\.1`},
+		{[]string{"--insecure", "--host", "192.168.1.1"}, true, ""},
+	}
+	for i, c := range testCases {
+		// Reset the context and insecure flag for every test case.
+		ctx.InitDefaults()
+		ctx.Insecure = true
+		insecure.isSet = false
+
+		if err := f.Parse(c.args); err != nil {
+			t.Fatal(err)
+		}
+		if c.insecure != ctx.Insecure {
+			t.Fatalf("%d: expected %v, but found %v", i, c.insecure, ctx.Insecure)
+		}
+
+		err := initInsecure()
+		if c.expected == "" {
+			if err != nil {
+				t.Fatalf("%d: expected success, but found %v", i, err)
+			}
+		} else if !testutils.IsError(err, c.expected) {
+			t.Fatalf("%d: expected %s, but found %v", i, c.expected, err)
+		}
+	}
+}


### PR DESCRIPTION
Default --insecure=true, but refuse to listen on external (non-loopback)
addresses unless --insecure is specified on the command line.

Fixes #4269.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5622)

<!-- Reviewable:end -->
