### PR TITLE
ui: fix #5620: events page shows nothing

### DIFF
--- a/ui/ts/components/events.ts
+++ b/ui/ts/components/events.ts
@@ -17,7 +17,10 @@ module Components {
 
     export function view(ctrl: any, limit: number): MithrilVirtualElement {
       if (!Models.Events.eventSingleton.loaded) {
-        Models.Events.eventSingleton.refresh();
+        Models.Events.eventSingleton.refresh().then((): void => {
+          m.redraw();
+        });
+        return m("");
       }
 
       if (Models.Events.eventSingleton.loaded) {
@@ -33,7 +36,7 @@ module Components {
           })))),
         ]);
       } else {
-        return null;
+        return m("");
       }
     }
   }

--- a/ui/ts/models/events.ts
+++ b/ui/ts/models/events.ts
@@ -76,6 +76,20 @@ module Models {
           content: m("span", [`User ${eventRow.info.User} `, m("strong", "dropped table "), eventRow.info.TableName]),
         };
       },
+      "node_join": (eventRow: ClusterEvent): NormalizedRow => {
+        return {
+          icon: Icon.INFO,
+          timestamp: moment.utc(eventRow.timestamp),
+          content: m("span", [`Node ${eventRow.target_id} `, m("strong", "joined the cluster")]),
+        };
+      },
+      "node_restart": (eventRow: ClusterEvent): NormalizedRow => {
+        return {
+          icon: Icon.INFO,
+          timestamp: moment.utc(eventRow.timestamp),
+          content: m("span", [`Node ${eventRow.target_id} `, m("strong", "rejoined the cluster")]),
+        };
+      },
     };
 
     export class Events {
@@ -103,7 +117,8 @@ module Models {
 
       convertToNormalizedRows(events: ClusterEvent[]): NormalizedRow[] {
         let normalizedEvents: NormalizedRow[] = _.map(events, (e: ClusterEvent): NormalizedRow => {
-          return eventTemplates[e.event_type](e) || {icon: Icon.WARNING, timestamp: moment.utc(e.timestamp), content: m("span", "Unknown event type: " + e.event_type)};
+          return eventTemplates[e.event_type] && eventTemplates[e.event_type](e)
+            || {icon: Icon.WARNING, timestamp: moment.utc(e.timestamp), content: m("span", "Unknown event type: " + e.event_type)};
         });
 
         return _.orderBy(normalizedEvents, ["timestamp"], ["desc"]);


### PR DESCRIPTION
Fixed a couple of problems:
- The recent node join/restart event logging changes had no
  corresponding UI changes to render those event logs. This caused an
  error on the event log page with a fresh cluster.
- The UI code for handling unknown event log entries was itself
  dereferencing a null reference. This has been fixed.
- If the events XHR request hasn't returned data yet, we need to queue
  up a redraw.
- Mithril generates a JS error when you return null from a view method.
  So, fixed the Events page to return an empty HTML block when the
  event data's not ready yet.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5633)

<!-- Reviewable:end -->
