### PR TITLE
server: reduce defaultMemtableBudget to 16 MB

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -44,12 +44,18 @@ import (
 
 // Context defaults.
 const (
-	defaultCGroupMemPath            = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
-	defaultAddr                     = ":" + base.DefaultPort
-	defaultHTTPAddr                 = ":" + base.DefaultHTTPPort
-	defaultMaxOffset                = 250 * time.Millisecond
-	defaultCacheSize                = 512 << 20 // 512 MB
-	defaultMemtableBudget           = 512 << 20 // 512 MB
+	defaultCGroupMemPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	defaultAddr          = ":" + base.DefaultPort
+	defaultHTTPAddr      = ":" + base.DefaultHTTPPort
+	defaultMaxOffset     = 250 * time.Millisecond
+	defaultCacheSize     = 512 << 20 // 512 MB
+	// defaultMemtableBudget controls how much memory can be used for memory
+	// tables. The way we initialize RocksDB, 150% (24 MB) of this setting can be
+	// used for memory tables and each memory table will be 25% of the size (4
+	// MB). This corresponds to the default RocksDB memtable size. Note that
+	// larger values do not necessarily improve performance, so benchmark any
+	// changes to this value.
+	defaultMemtableBudget           = 16 << 20 // 16 MB
 	defaultScanInterval             = 10 * time.Minute
 	defaultConsistencyCheckInterval = 24 * time.Hour
 	defaultScanMaxIdleTime          = 5 * time.Second


### PR DESCRIPTION
The way we use defaultMemtableBudget to initialize RocksDB, this setting
corresponds to a 4 MB write_buffer_size (i.e. the size of the memtable
is allowed to reach before being flushed). This is the default memtable
size for RocksDB. I'm not sure where the previous value of 512 MB came
from, but perhaps from the default value for
ColumnFamilyOptions::OptimizeLevelStyleCompaction(). The 16 MB value
will allow for a maximum of 24 MB (vs 768 MB previously) to be tied up
in the memtables being flushed before throttling writes.

Note that this appears to improve and stabilize performance. The
following table shows the number of ops performed using the "photos"
load tester in 3 min with various settings of defaultMemtableBudget:

```
  1 MB      34778 ops
  4 MB      35125 ops
  16 MB     35648 ops
  64 MB     32771 ops
  512 MB    30967 ops
```

We could conceivably reduce defaultMemtableBudget further, but I feel
most comfortable using the default RocksDB setting.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5637)

<!-- Reviewable:end -->
