### PR TITLE
sql: better batch sizing for limits

### DIFF
--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -637,40 +637,35 @@ func runBenchmarkScanFilter(b *testing.B, db *sql.DB, count1, count2 int, limit 
 	}
 }
 
+func filterLimitBenchFn(limit int) func(*testing.B, *sql.DB) {
+	return func(b *testing.B, db *sql.DB) {
+		runBenchmarkScanFilter(b, db, 25, 400, limit,
+			`a IN (1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 20, 21, 23) AND b < 10*a`)
+	}
+}
+
 func BenchmarkScan10000FilterLimit1_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) {
-		runBenchmarkScanFilter(b, db, 10, 1000, 1, `a IN (1, 3, 5, 7) AND b < 10*a`)
-	})
+	benchmarkCockroach(b, filterLimitBenchFn(1))
 }
 
 func BenchmarkScan10000FilterLimit1_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) {
-		runBenchmarkScanFilter(b, db, 10, 1000, 1, `a IN (1, 3, 5, 7) AND b < 10*a`)
-	})
+	benchmarkPostgres(b, filterLimitBenchFn(1))
 }
 
 func BenchmarkScan10000FilterLimit10_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) {
-		runBenchmarkScanFilter(b, db, 10, 1000, 10, `a IN (1, 3, 5, 7) AND b < 10*a`)
-	})
+	benchmarkCockroach(b, filterLimitBenchFn(10))
 }
 
 func BenchmarkScan10000FilterLimit10_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) {
-		runBenchmarkScanFilter(b, db, 10, 1000, 10, `a IN (1, 3, 5, 7) AND b < 10*a`)
-	})
+	benchmarkPostgres(b, filterLimitBenchFn(10))
 }
 
 func BenchmarkScan10000FilterLimit50_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) {
-		runBenchmarkScanFilter(b, db, 10, 1000, 50, `a IN (1, 3, 5, 7) AND b < 10*a`)
-	})
+	benchmarkCockroach(b, filterLimitBenchFn(50))
 }
 
 func BenchmarkScan10000FilterLimit50_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) {
-		runBenchmarkScanFilter(b, db, 10, 1000, 50, `a IN (1, 3, 5, 7) AND b < 10*a`)
-	})
+	benchmarkPostgres(b, filterLimitBenchFn(50))
 }
 
 // runBenchmarkOrderBy benchmarks scanning a table and sorting the results.

--- a/sql/scan_test.go
+++ b/sql/scan_test.go
@@ -185,7 +185,7 @@ func TestScanBatches(t *testing.T) {
 	numSpanValues := []int{0, 1, 2, 3}
 
 	for _, batch := range batchSizes {
-		csql.SetKVBatchSize(batch)
+		csql.SetKVBatchSize(int64(batch))
 		for _, numSpans := range numSpanValues {
 			testScanBatchQuery(t, db, numSpans, numAs, numBs, false)
 			testScanBatchQuery(t, db, numSpans, numAs, numBs, true)


### PR DESCRIPTION
Improvements to batch sizing when we have a limit:
- if the limit is "soft" (e.g. we have a filter in-between the scan and the
  limit), we double the initial batch size
- if we need a second batch, instead of jumping directly to batches of 10,000,
  we get a batch that's 10x larger than the first batch, and at least 1,000.

```
name                                old time/op  new time/op  delta
Scan10000FilterLimit1_Cockroach-4    343µs ±15%   369µs ±33%     ~     (p=0.780 n=10+9)
Scan10000FilterLimit10_Cockroach-4   385µs ± 5%   396µs ± 7%     ~      (p=0.277 n=8+9)
Scan10000FilterLimit50_Cockroach-4  13.2ms ± 6%   3.6ms ± 7%  -72.50%  (p=0.000 n=9+10)
```

Closes #5267

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5640)

<!-- Reviewable:end -->
