### PR TITLE
Make the flag map safer.

### DIFF
--- a/base/context.go
+++ b/base/context.go
@@ -73,6 +73,15 @@ func AddToFlagMap(f *pflag.Flag) {
 	FlagMap[val.Interface()] = f
 }
 
+// GetFlagName takes a flag value reference and looks it up in the flag map.
+// If not found, it returns the passed in default value.
+func GetFlagName(key interface{}, defaultName string) string {
+	if val, ok := FlagMap[key]; ok {
+		return val.Name
+	}
+	return defaultName
+}
+
 type lazyTLSConfig struct {
 	once      sync.Once
 	tlsConfig *tls.Config
@@ -167,12 +176,8 @@ func (ctx *Context) GetServerTLSConfig() (*tls.Config, error) {
 				ctx.serverTLSConfig.err = util.Errorf("error setting up client TLS config: %s", ctx.serverTLSConfig.err)
 			}
 		} else {
-			insecureFlag := "insecure"
-			certFlag := "cert"
-			if len(FlagMap) > 0 {
-				insecureFlag = FlagMap[&ctx.Insecure].Name
-				certFlag = FlagMap[&ctx.SSLCert].Name
-			}
+			insecureFlag := GetFlagName(&ctx.Insecure, "insecure")
+			certFlag := GetFlagName(&ctx.SSLCert, "cert")
 			ctx.serverTLSConfig.err = util.Errorf("--%s=false, but --%s is empty. Certificates must be specified.", insecureFlag, certFlag)
 		}
 	})

--- a/server/context.go
+++ b/server/context.go
@@ -351,20 +351,22 @@ func (ctx *Context) PGURL(user string) (*url.URL, error) {
 	} else {
 		options.Add("sslmode", "verify-full")
 		requiredFlags := []struct {
-			name  string
-			value *string
+			name     string
+			value    *string
+			flagName string
 		}{
-			{"sslcert", &ctx.SSLCert},
-			{"sslkey", &ctx.SSLCertKey},
-			{"sslrootcert", &ctx.SSLCA},
+			{"sslcert", &ctx.SSLCert, "cert"},
+			{"sslkey", &ctx.SSLCertKey, "key"},
+			{"sslrootcert", &ctx.SSLCA, "ca-cert"},
 		}
 		for _, c := range requiredFlags {
+			flagName := base.GetFlagName(c.value, c.flagName)
 			if *c.value == "" {
-				return nil, fmt.Errorf("missing --%s flag", base.FlagMap[c.value].Name)
+				return nil, fmt.Errorf("missing --%s flag", flagName)
 			}
 			path := absPath(*c.value)
 			if _, err := os.Stat(path); err != nil {
-				return nil, fmt.Errorf("file for --%s flag gave error: %v", base.FlagMap[c.value].Name, err)
+				return nil, fmt.Errorf("file for --%s flag gave error: %v", flagName, err)
 			}
 			options.Add(c.name, path)
 		}


### PR DESCRIPTION
For example, context.Insecure is now overwritten after init.
This means the value reference is not in the map, and calling .name
crashes.

Honestly, I'd rather just remove the flagmap entirely.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5642)

<!-- Reviewable:end -->
