### PR TITLE
Downgrade ansi-styles to 2.1.0

### DIFF
--- a/ui/npm-shrinkwrap.json
+++ b/ui/npm-shrinkwrap.json
@@ -37,7 +37,7 @@
       "version": "2.0.0"
     },
     "ansi-styles": {
-      "version": "2.2.0"
+      "version": "2.1.0"
     },
     "any-promise": {
       "version": "1.1.0"


### PR DESCRIPTION
Breaking builds on master. Somehow, the NPM version decreased? Not sure
what happened here.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5649)

<!-- Reviewable:end -->
