### PR TITLE
storage: Remove spurious timestamp modification

### DIFF
--- a/client/sender.go
+++ b/client/sender.go
@@ -38,9 +38,9 @@ func (f SenderFunc) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb
 }
 
 // SendWrappedWith is a convenience function which wraps the request in a batch
-// and sends it via the provided Sender at the given timestamp. It returns the
-// unwrapped response or an error. It's valid to pass a `nil` context;
-// context.Background() is used in that case.
+// and sends it via the provided Sender and headers. It returns the unwrapped
+// response or an error. It's valid to pass a `nil` context; an empty one is
+// used in that case.
 func SendWrappedWith(
 	sender Sender, ctx context.Context, h roachpb.Header, args roachpb.Request,
 ) (roachpb.Response, *roachpb.Error) {

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1338,7 +1338,7 @@ func TestReplicateRogueRemovedNode(t *testing.T) {
 		incArgs := incrementArgs([]byte("a"), 23)
 		startWG.Done()
 		defer finishWG.Done()
-		if _, err := client.SendWrapped(rng, nil, &incArgs); err == nil {
+		if _, err := client.SendWrappedWith(rng, nil, roachpb.Header{Timestamp: mtc.stores[2].Clock().Now()}, &incArgs); err == nil {
 			t.Fatal("expected error during shutdown")
 		}
 	}()
@@ -1533,7 +1533,9 @@ func TestCheckConsistencyMultiStore(t *testing.T) {
 			EndKey: []byte("aa"),
 		},
 	}
-	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &checkArgs); err != nil {
+	if _, err := client.SendWrappedWith(rg1(mtc.stores[0]), nil, roachpb.Header{
+		Timestamp: mtc.stores[0].Clock().Now(),
+	}, &checkArgs); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/storage/intent_resolver.go
+++ b/storage/intent_resolver.go
@@ -312,6 +312,8 @@ func (ir *intentResolver) processIntentsAsync(r *Replica, intents []intentsWithA
 				// We successfully resolved the intents, so we're able to GC from
 				// the txn span directly.
 				var ba roachpb.BatchRequest
+				ba.Timestamp = now
+
 				txn := item.intents[0].Txn
 				gcArgs := roachpb.GCRequest{
 					Span: roachpb.Span{
@@ -349,6 +351,7 @@ func (ir *intentResolver) resolveIntents(ctx context.Context, r *Replica,
 
 	var reqsRemote []roachpb.Request
 	baLocal := roachpb.BatchRequest{}
+	baLocal.Timestamp = ir.store.Clock().Now()
 	for i := range intents {
 		intent := intents[i] // avoids a race in `i, intent := range ...`
 		var resolveArgs roachpb.Request

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1388,6 +1388,7 @@ func (r *Replica) CheckConsistency(
 			ChecksumID: id,
 		}
 		ba.Add(checkArgs)
+		ba.Timestamp = r.store.Clock().Now()
 		_, pErr := r.Send(ctx, ba)
 		if pErr != nil {
 			return roachpb.CheckConsistencyResponse{}, pErr
@@ -1419,6 +1420,7 @@ func (r *Replica) CheckConsistency(
 			Checksum:   c.checksum,
 		}
 		ba.Add(checkArgs)
+		ba.Timestamp = r.store.Clock().Now()
 		_, pErr := r.Send(ctx, ba)
 		if pErr != nil {
 			return roachpb.CheckConsistencyResponse{}, pErr

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -114,7 +114,9 @@ func (sq *splitQueue) process(now roachpb.Timestamp, rng *Replica,
 	// FIXME: why is this implementation not the same as the one above?
 	if float64(rng.stats.GetSize())/float64(zone.RangeMaxBytes) > 1 {
 		log.Infof("splitting %s size=%d max=%d", rng, rng.stats.GetSize(), zone.RangeMaxBytes)
-		if _, pErr := client.SendWrapped(rng, ctx, &roachpb.AdminSplitRequest{
+		if _, pErr := client.SendWrappedWith(rng, ctx, roachpb.Header{
+			Timestamp: now,
+		}, &roachpb.AdminSplitRequest{
 			Span: roachpb.Span{Key: desc.StartKey.AsRawKey()},
 		}); pErr != nil {
 			return pErr.GoError()


### PR DESCRIPTION
This was only used in tests and in some code paths that bypassed `Store`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5652)

<!-- Reviewable:end -->
