### PR TITLE
sql: restore + complete support for non-aggregated aggregate funcs

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -657,14 +657,27 @@ var builtins = map[string][]builtin{
 		builtin{
 			types:      argTypes{intType},
 			returnType: typeFloat,
+			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+				if args[0] == DNull {
+					return args[0], nil
+				}
+				// AVG returns a float when given an int argument.
+				return DFloat(args[0].(DInt)), nil
+			},
 		},
 		builtin{
 			types:      argTypes{floatType},
 			returnType: typeFloat,
+			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+				return args[0], nil
+			},
 		},
 		builtin{
 			types:      argTypes{decimalType},
 			returnType: typeDecimal,
+			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+				return args[0], nil
+			},
 		},
 	},
 
@@ -678,14 +691,17 @@ var builtins = map[string][]builtin{
 		builtin{
 			types:      argTypes{intType},
 			returnType: typeDecimal,
+			fn:         funcNull,
 		},
 		builtin{
 			types:      argTypes{decimalType},
 			returnType: typeDecimal,
+			fn:         funcNull,
 		},
 		builtin{
 			types:      argTypes{floatType},
 			returnType: typeFloat,
+			fn:         funcNull,
 		},
 	},
 
@@ -693,14 +709,17 @@ var builtins = map[string][]builtin{
 		builtin{
 			types:      argTypes{intType},
 			returnType: typeDecimal,
+			fn:         funcNull,
 		},
 		builtin{
 			types:      argTypes{decimalType},
 			returnType: typeDecimal,
+			fn:         funcNull,
 		},
 		builtin{
 			types:      argTypes{floatType},
 			returnType: typeFloat,
+			fn:         funcNull,
 		},
 	},
 
@@ -974,6 +993,10 @@ var builtins = map[string][]builtin{
 	},
 }
 
+func funcNull(_ EvalContext, _ DTuple) (Datum, error) {
+	return DNull, nil
+}
+
 // The aggregate functions all just return their first argument. We don't
 // perform any type checking here either. The bulk of the aggregate function
 // implementation is performed at a higher level in sql.groupNode.
@@ -992,7 +1015,7 @@ func aggregateImpls(types ...reflect.Type) []builtin {
 
 func countImpls() []builtin {
 	var r []builtin
-	types := argTypes{boolType, intType, floatType, stringType, bytesType, dateType, timestampType, intervalType, tupleType}
+	types := argTypes{boolType, intType, floatType, decimalType, stringType, bytesType, dateType, timestampType, intervalType, tupleType}
 	for _, t := range types {
 		r = append(r, builtin{
 			impure:     true, // COUNT(1) is not a const. #5170.

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -588,3 +588,28 @@ EXPLAIN (DEBUG) SELECT MIN(z) FROM xyz
 ----
 0 /xyz/zyx/3.0/2/1 NULL  BUFFERED
 0 0                (3.0) ROW
+
+query RRR
+SELECT AVG(1::int), AVG(2::float), AVG(3::decimal)
+----
+1 2 3
+
+query III
+SELECT COUNT(2::int), COUNT(3::float), COUNT(4::decimal)
+----
+1 1 1
+
+query IRR
+SELECT SUM(1::int), SUM(2::float), SUM(3::decimal)
+----
+1 2 3
+
+query RRR
+SELECT VARIANCE(1::int), VARIANCE(1::float), VARIANCE(1::decimal)
+----
+NULL NULL NULL
+
+query RRR
+SELECT STDDEV(1::int), STDDEV(1::float), STDDEV(1::decimal)
+----
+NULL NULL NULL


### PR DESCRIPTION
Aggregate functions, when called without column data, are invoked like
normal functions. That is, their `fn` property is executed. Aggregate funcs
don't include that property, so a panic was produced (for something like
`SELECT AVG(1)`). Some of these used to function properly, but that was
removed (see listed revert commit).

Restore that functionality and complete this support for the remainder of
the aggregate functions and types. Return values (including NULL) match
the behavior of postgres.

Also add decimal support to COUNT.

Partially reverts commit a55f0548af82f6899ccf6fff96dd6509d41173fa.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5654)

<!-- Reviewable:end -->
