### PR TITLE
storage: Update the retry comment on updatesTimestampCacheMethods

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -132,7 +132,8 @@ var updatesTimestampCacheMethods = [...]bool{
 	roachpb.ReverseScan: true,
 	// EndTransaction updates the write timestamp cache to prevent
 	// replays. Replays for the same transaction key and timestamp will
-	// have Txn.WriteTooOld=true and must retry on EndTransaction.
+	// have Txn.WriteTooOld=true and must retry on BeginTransaction or
+	// EndTransaction.
 	roachpb.EndTransaction: true,
 }
 


### PR DESCRIPTION
   ... Txn.WriteTooOld=true and must retry on EndTransaction
-> ... Txn.WriteTooOld=true and must retry on BeginTransaction or EndTransaction

If I understand the code correctly, both BeginTransaction and EndTransaction checks WriteTooOld.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5655)

<!-- Reviewable:end -->
