### PR TITLE
Contacts the Cockroach Labs server when saving opt-in data

### DIFF
--- a/ui/ts/models/api.ts
+++ b/ui/ts/models/api.ts
@@ -95,6 +95,8 @@ module Models {
       });
     }
 
+    // TODO: Refactor getUIData and setUIData so they just return <any> and we
+    // don't have to scatter encoding and decoding everywhere they are used.
     export function getUIData(keys: string[]): MithrilPromise<GetUIDataResponse> {
       let d: MithrilDeferred<GetUIDataResponse> = m.deferred();
       // Create the URL, which looks like this:
@@ -124,6 +126,23 @@ module Models {
           key_values: keyValues,
         },
       });
+    }
+
+    interface ClusterID {
+      cluster_id: string;
+    }
+
+    let clusterID: string;
+
+    export function getClusterID(): MithrilPromise<string> {
+      let d: MithrilDeferred<string> = m.deferred();
+      if (clusterID) {
+        d.resolve(clusterID);
+      } else {
+        m.request<ClusterID>({url: "/_admin/v1/cluster", config: Utils.Http.XHRConfig})
+          .then((data: ClusterID) => d.resolve(data.cluster_id));
+      }
+      return d.promise;
     }
   }
 }

--- a/ui/ts/models/cockroachlabs.ts
+++ b/ui/ts/models/cockroachlabs.ts
@@ -23,6 +23,12 @@ module Models {
     // tracks when the version check was last dismissed
     const VERSION_DISMISSED_KEY = "version_dismissed";
 
+    // tracks whether the latest registration data has been synchronized with the Cockroach Labs servers
+    export const REGISTRATION_SYNCHRONIZED_KEY = "registration_synchronized";
+
+    // Address of the Cockroach Labs servers.
+    const COCKROACHLABS_ADDR = "https://register.cockroachdb.com";
+
     export interface Version {
       version: string;
       detail: string;
@@ -54,20 +60,38 @@ module Models {
         laterVersions: null,
       };
       nodes: Nodes = nodeStatusSingleton;
+      synchronized: boolean;
 
-      constructor(clusterID: string) {
-        // TODO: get cluster ID from the node
-        this.clusterID = "00000000-0000-0000-0000-000000000000";
+      loading: boolean = true;
+      loadingPromise: MithrilPromise<any>;
+
+      // TODO: create using a factory to better handle promises/errors
+      constructor() {
         // TODO: get rid of double nodestatus refresh on cluster/nodes pages
-        m.sync([this.nodes.refresh(), Models.API.getUIData([VERSION_DISMISSED_KEY])]).then((data: [any, GetUIDataResponse]): void => {
-          try {
-            let dismissedCheckRaw: string = _.get<string>(data, `1.key_values.${VERSION_DISMISSED_KEY}.value`);
-            this.dismissedCheck = dismissedCheckRaw && parseInt(atob(dismissedCheckRaw), 10);
-          } catch (e) {
-            console.warn(e);
-          }
-          this.versionCheck();
-        });
+        this.loadingPromise = m.sync([
+          this.nodes.refresh(),
+          Models.API.getUIData([VERSION_DISMISSED_KEY, REGISTRATION_SYNCHRONIZED_KEY]),
+          Models.API.getClusterID(),
+        ]).then((data: [any, GetUIDataResponse]): void => {
+
+            // TODO: better error handling story, perhaps refactor error handling into Models.API.getUIData
+            try {
+              let dismissedCheckRaw: string = _.get<string>(data, `1.key_values.${VERSION_DISMISSED_KEY}.value`);
+              this.dismissedCheck = dismissedCheckRaw && parseInt(atob(dismissedCheckRaw), 10);
+
+              let synchronizedRaw: string = _.get<string>(data, `1.key_values.${REGISTRATION_SYNCHRONIZED_KEY}.value`);
+              this.synchronized = synchronizedRaw && (atob(synchronizedRaw).toLowerCase() === "true") || false;
+            } catch (e) {
+              console.warn(e);
+            }
+
+            this.clusterID = data[2];
+
+            this.loading = false;
+            this.versionCheck();
+          }).catch((e: Error) => {
+            console.error(e);
+          });
       }
 
       // versionCheck checks whether all the node versions match and, if so, if the current version is outdated
@@ -102,7 +126,7 @@ module Models {
           } else {
             // contact Cockroach Labs to check latest version
             m.request<VersionList>({
-              url: `https://register.cockroachdb.com/api/clusters/updates?uuid=${this.clusterID}&version=${nodeStatuses[0].build_info.tag}`,
+              url: `${COCKROACHLABS_ADDR}/api/clusters/updates?uuid=${this.clusterID}&version=${nodeStatuses[0].build_info.tag}`,
               config: Utils.Http.XHRConfig,
             }).then((laterVersions: VersionList) => {
               if (!_.isEmpty(laterVersions.details)) {
@@ -142,8 +166,59 @@ module Models {
           m.redraw();
         });
       };
+
+      // save saves the latest user optin values to the Cockroach Labs server.
+      // If the user has opted in, it uses the registration endpoint.
+      // If the user has not opted in or has opted out, it uses the unregistration endpoint.
+      // It then saves the synchronization status to the current cluster.
+      save(data: OptInAttributes): MithrilPromise<void> {
+        let d: MithrilDeferred<any> = m.deferred();
+        let p: MithrilPromise<any>;
+        if (data && data.optin) {
+          p = this.register({
+            first_name: data.firstname,
+            last_name: data.lastname,
+            company: data.company,
+            email: data.email,
+          });
+        } else {
+          p = this.unregister();
+        }
+
+        p.then(() => {
+            this.saveSync(true).then(() => d.resolve());
+          })
+          .catch((e: Error) => {
+            console.warn("Error attempting to contact Cockroach Labs server.", e);
+            this.saveSync(false).then(() => d.resolve());
+          });
+
+        return p;
+      }
+
+      register(data: RegisterData): MithrilPromise<any> {
+        return m.request<VersionList>({
+          url: `${COCKROACHLABS_ADDR}/api/clusters/register?uuid=${this.clusterID}`,
+          method: "POST",
+          data: data,
+          config: Utils.Http.XHRConfig,
+        });
+      }
+
+      unregister(): MithrilPromise<any> {
+        return m.request<VersionList>({
+          url: `${COCKROACHLABS_ADDR}/api/clusters/unregister?uuid=${this.clusterID}`,
+          method: "DELETE",
+          config: Utils.Http.XHRConfig,
+        });
+      }
+
+      saveSync(synchronized: boolean): MithrilPromise<any> {
+        this.synchronized = synchronized;
+        return Models.API.setUIData({[REGISTRATION_SYNCHRONIZED_KEY]: btoa(JSON.stringify(synchronized))});
+      }
     }
 
-    export let cockroachLabsSingleton = new CockroachLabs(null);
+    export let cockroachLabsSingleton = new CockroachLabs();
   }
 }

--- a/ui/ts/models/helpus.ts
+++ b/ui/ts/models/helpus.ts
@@ -85,13 +85,22 @@ module Models {
 
       constructor() {
         this.loadPromise = this.load();
+
+        this.loadPromise.then(() => {
+          Models.CockroachLabs.cockroachLabsSingleton.loadingPromise.then(() => {
+            if (!Models.CockroachLabs.cockroachLabsSingleton.synchronized) {
+              Models.CockroachLabs.cockroachLabsSingleton.save(this.attributes);
+            }
+          });
+        });
       }
 
       save(): MithrilPromise<void> {
         // Make sure we loaded the data first
         // TODO: check timestamp on the backend to prevent overwriting data without loading first
         if (this.loaded) {
-          return setHelpUsData(this.attributes)
+          // save the data both to the backend and the Cockroach Labs servers
+          return m.sync([Models.CockroachLabs.cockroachLabsSingleton.save(this.attributes), setHelpUsData(this.attributes)])
           .then(() => {
             this.savedAttributes = _.clone(this.attributes);
           });


### PR DESCRIPTION
This wires up registering clusters on the registration server. The only thing remaining is to add the appropriate Cluster ID once https://github.com/cockroachdb/cockroach/pull/5647 is merged.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5656)

<!-- Reviewable:end -->
