### PR TITLE
ui: add sys.sysbytes metric that tracks MemStats.Sys

### DIFF
--- a/server/status/runtime.go
+++ b/server/status/runtime.go
@@ -32,6 +32,7 @@ const (
 	nameCgoCalls       = "cgocalls"
 	nameGoroutines     = "goroutines"
 	nameAllocBytes     = "allocbytes"
+	nameSysBytes       = "sysbytes"
 	nameGCCount        = "gc.count"
 	nameGCPauseNS      = "gc.pause.ns"
 	nameGCPausePercent = "gc.pause.percent"
@@ -39,7 +40,7 @@ const (
 	nameCPUUserPercent = "cpu.user.percent"
 	nameCPUSysNS       = "cpu.sys.ns"
 	nameCPUSysPercent  = "cpu.sys.percent"
-	nameRSS            = "maxrss" // TODO(cdo): rename to rss
+	nameRSS            = "rss"
 )
 
 // logOSStats is a function that logs OS-specific stats. We will not necessarily
@@ -67,6 +68,7 @@ type RuntimeStatSampler struct {
 	cgoCalls       *metric.Gauge
 	goroutines     *metric.Gauge
 	allocBytes     *metric.Gauge
+	sysBytes       *metric.Gauge
 	gcCount        *metric.Gauge
 	gcPauseNS      *metric.Gauge
 	gcPausePercent *metric.GaugeFloat64
@@ -86,6 +88,7 @@ func MakeRuntimeStatSampler(clock *hlc.Clock) RuntimeStatSampler {
 		cgoCalls:       reg.Gauge(nameCgoCalls),
 		goroutines:     reg.Gauge(nameGoroutines),
 		allocBytes:     reg.Gauge(nameAllocBytes),
+		sysBytes:       reg.Gauge(nameSysBytes),
 		gcCount:        reg.Gauge(nameGCCount),
 		gcPauseNS:      reg.Gauge(nameGCPauseNS),
 		gcPausePercent: reg.GaugeFloat64(nameGCPausePercent),
@@ -167,6 +170,7 @@ func (rsr *RuntimeStatSampler) SampleEnvironment() {
 	rsr.cgoCalls.Update(numCgoCall)
 	rsr.goroutines.Update(int64(numGoroutine))
 	rsr.allocBytes.Update(int64(ms.Alloc))
+	rsr.sysBytes.Update(int64(ms.Sys))
 	rsr.gcCount.Update(int64(ms.NumGC))
 	rsr.gcPauseNS.Update(int64(ms.PauseTotalNs))
 	rsr.gcPausePercent.Update(pausePerc)

--- a/ui/ts/models/proto.ts
+++ b/ui/ts/models/proto.ts
@@ -110,7 +110,7 @@ module Models {
       export var sysCPUPercent: string = "sys.cpu.sys.percent";
       export var allocBytes: string = "sys.allocbytes";
       export var sqlConns: string = "sql.conns";
-      export var maxRSS: string = "sys.maxrss";
+      export var rss: string = "sys.rss";
     }
 
     /**

--- a/ui/ts/pages/nodes.ts
+++ b/ui/ts/pages/nodes.ts
@@ -184,12 +184,12 @@ module AdminViews {
           {
             title: "Mem Usage",
             view: (status: NodeStatus): string => {
-              return Utils.Format.Bytes(status.metrics[MetricNames.maxRSS]);
+              return Utils.Format.Bytes(status.metrics[MetricNames.rss]);
             },
             sortable: true,
-            sortValue: (status: NodeStatus): number => status.metrics[MetricNames.maxRSS],
+            sortValue: (status: NodeStatus): number => status.metrics[MetricNames.rss],
             rollup: function(rows: NodeStatus[]): string {
-              return Utils.Format.Bytes(_.sumBy(rows, (r: NodeStatus) => r.metrics[MetricNames.maxRSS]));
+              return Utils.Format.Bytes(_.sumBy(rows, (r: NodeStatus) => r.metrics[MetricNames.rss]));
             },
           },
           {
@@ -309,8 +309,10 @@ module AdminViews {
             this.systemAxes,
             Metrics.NewAxis(
               Metrics.Select.Avg(_sysMetric("allocbytes"))
-                .title("Go Memory"),
-              Metrics.Select.Avg(_sysMetric("maxrss"))
+                .title("Go In Use"),
+              Metrics.Select.Avg(_sysMetric("sysbytes"))
+                .title("Go Sys"),
+              Metrics.Select.Avg(_sysMetric("rss"))
                 .title("RSS")
             ).format(Utils.Format.Bytes).title("Memory Usage")
           );
@@ -835,8 +837,11 @@ module AdminViews {
             Metrics.NewAxis(
               Metrics.Select.Avg(_sysMetric("allocbytes"))
                 .sources([this._nodeId])
-                .title("Go Memory"),
-              Metrics.Select.Avg(_sysMetric("maxrss"))
+                .title("Go In Use"),
+              Metrics.Select.Avg(_sysMetric("sysbytes"))
+                .sources([this._nodeId])
+                .title("Go Sys"),
+              Metrics.Select.Avg(_sysMetric("rss"))
                 .sources([this._nodeId])
                 .title("RSS")
             ).format(Utils.Format.Bytes).title("Memory Usage")


### PR DESCRIPTION
From the go documentation: `Sys` is the "bytes obtained from
system". This is memory that the Go runtime has allocated from the
system and will be strictly greater than the "allocbytes" metric.

I cargo-culted the typescript changes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5657)

<!-- Reviewable:end -->
