### PR TITLE
storage/engine: use pool to avoid newiterator alloc

### DIFF
--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sync"
 	"unsafe"
 
 	"github.com/dustin/go-humanize"
@@ -571,6 +572,12 @@ type rocksDBIterator struct {
 	value  C.DBSlice
 }
 
+var iterPool = sync.Pool{
+	New: func() interface{} {
+		return &rocksDBIterator{}
+	},
+}
+
 // newRocksDBIterator returns a new iterator over the supplied RocksDB
 // instance. If snapshotHandle is not nil, uses the indicated snapshot.
 // The caller must call rocksDBIterator.Close() when finished with the
@@ -580,10 +587,10 @@ func newRocksDBIterator(rdb *C.DBEngine, prefix roachpb.Key, engine Engine) Iter
 	// when performing scans. Any options set within the shared read
 	// options field that should be carried over needs to be set here
 	// as well.
-	return &rocksDBIterator{
-		iter:   C.DBNewIter(rdb, goToCSlice(prefix)),
-		engine: engine,
-	}
+	r := iterPool.Get().(*rocksDBIterator)
+	r.iter = C.DBNewIter(rdb, goToCSlice(prefix))
+	r.engine = engine
+	return r
 }
 
 func (r *rocksDBIterator) checkEngineOpen() {
@@ -595,6 +602,8 @@ func (r *rocksDBIterator) checkEngineOpen() {
 // The following methods implement the Iterator interface.
 func (r *rocksDBIterator) Close() {
 	C.DBIterDestroy(r.iter)
+	*r = rocksDBIterator{}
+	iterPool.Put(r)
 }
 
 func (r *rocksDBIterator) Seek(key MVCCKey) {


### PR DESCRIPTION
Easy to pool since we already have a `Close` method we need to call.

```
name                                    old time/op    new time/op    delta
IterOnBatch100_RocksDB-8                  4.81µs ± 3%    4.49µs ± 2%    -6.69%    (p=0.000 n=9+9)
MVCCPut100_RocksDB-8                      6.39µs ± 2%    6.24µs ± 1%    -2.49%   (p=0.000 n=10+9)
MVCCConditionalPutCreate100_RocksDB-8     6.41µs ± 2%    6.19µs ± 1%    -3.50%   (p=0.000 n=8+10)
MVCCConditionalPutReplace100_RocksDB-8    9.08µs ± 2%    8.56µs ± 2%    -5.76%  (p=0.000 n=10+10)

name                                    old alloc/op   new alloc/op   delta
IterOnBatch100_RocksDB-8                   96.0B ± 0%     16.0B ± 0%   -83.33%  (p=0.000 n=10+10)
MVCCPut100_RocksDB-8                       80.0B ± 0%     0.0B ±NaN%  -100.00%  (p=0.000 n=10+10)
MVCCConditionalPutCreate100_RocksDB-8      80.0B ± 0%     0.0B ±NaN%  -100.00%  (p=0.000 n=10+10)
MVCCConditionalPutReplace100_RocksDB-8      192B ± 0%      112B ± 0%   -41.67%  (p=0.000 n=10+10)

name                                    old allocs/op  new allocs/op  delta
IterOnBatch100_RocksDB-8                    3.00 ± 0%      2.00 ± 0%   -33.33%  (p=0.000 n=10+10)
MVCCPut100_RocksDB-8                        1.00 ± 0%     0.00 ±NaN%  -100.00%  (p=0.000 n=10+10)
MVCCConditionalPutCreate100_RocksDB-8       1.00 ± 0%     0.00 ±NaN%  -100.00%  (p=0.000 n=10+10)
MVCCConditionalPutReplace100_RocksDB-8      2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.000 n=10+10)

name                                    old speed      new speed      delta
MVCCPut100_RocksDB-8                    15.6MB/s ± 2%  16.0MB/s ± 1%    +2.54%   (p=0.000 n=10+9)
MVCCConditionalPutCreate100_RocksDB-8   15.6MB/s ± 2%  16.2MB/s ± 1%    +3.86%   (p=0.000 n=9+10)
MVCCConditionalPutReplace100_RocksDB-8  11.0MB/s ± 2%  11.7MB/s ± 2%    +6.12%  (p=0.000 n=10+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5663)

<!-- Reviewable:end -->
