### PR TITLE
Metrics for range splits & replica adds/removes

### DIFF
--- a/storage/log.go
+++ b/storage/log.go
@@ -96,6 +96,18 @@ VALUES(
 		args[5] = *event.info
 	}
 
+	// Update range event metrics. We do this close to the insertion of the
+	// corresponding range log entry to reduce potential skew between metrics and
+	// range log.
+	switch event.eventType {
+	case RangeEventLogSplit:
+		s.metrics.rangeSplits.Inc(1)
+	case RangeEventLogAdd:
+		s.metrics.rangeAdds.Inc(1)
+	case RangeEventLogRemove:
+		s.metrics.rangeRemoves.Inc(1)
+	}
+
 	rows, err := s.ctx.SQLExecutor.ExecuteStatementInTransaction(txn, insertEventTableStmt, args...)
 	if err != nil {
 		return err

--- a/storage/store.go
+++ b/storage/store.go
@@ -412,6 +412,7 @@ type storeMetrics struct {
 	sysBytes        *metric.Gauge
 	sysCount        *metric.Gauge
 
+	// RocksDB metrics.
 	rdbBlockCacheHits           *metric.Gauge
 	rdbBlockCacheMisses         *metric.Gauge
 	rdbBlockCacheUsage          *metric.Gauge
@@ -424,6 +425,11 @@ type storeMetrics struct {
 	rdbFlushes                  *metric.Gauge
 	rdbCompactions              *metric.Gauge
 	rdbTableReadersMemEstimate  *metric.Gauge
+
+	// Range event metrics.
+	rangeSplits  *metric.Counter
+	rangeAdds    *metric.Counter
+	rangeRemoves *metric.Counter
 
 	// Stats for efficient merges.
 	// TODO(mrtracy): This should be removed as part of #4465. This is only
@@ -458,7 +464,7 @@ func newStoreMetrics() *storeMetrics {
 		sysBytes:             storeRegistry.Gauge("sysbytes"),
 		sysCount:             storeRegistry.Gauge("syscount"),
 
-		// RocksDB stats.
+		// RocksDB metrics.
 		rdbBlockCacheHits:           storeRegistry.Gauge("rocksdb.block.cache.hits"),
 		rdbBlockCacheMisses:         storeRegistry.Gauge("rocksdb.block.cache.misses"),
 		rdbBlockCacheUsage:          storeRegistry.Gauge("rocksdb.block.cache.usage"),
@@ -471,6 +477,11 @@ func newStoreMetrics() *storeMetrics {
 		rdbFlushes:                  storeRegistry.Gauge("rocksdb.flushes"),
 		rdbCompactions:              storeRegistry.Gauge("rocksdb.compactions"),
 		rdbTableReadersMemEstimate:  storeRegistry.Gauge("rocksdb.table-readers-mem-estimate"),
+
+		// Range event metrics.
+		rangeSplits:  storeRegistry.Counter("range.splits"),
+		rangeAdds:    storeRegistry.Counter("range.adds"),
+		rangeRemoves: storeRegistry.Counter("range.removes"),
 	}
 }
 

--- a/ui/ts/pages/nodes.ts
+++ b/ui/ts/pages/nodes.ts
@@ -375,6 +375,22 @@ module AdminViews {
           this._addChart(
             this.internalsAxes,
             Metrics.NewAxis(
+              Metrics.Select.Avg(_storeMetric("range.splits"))
+                .nonNegativeRate()
+                .title("Splits"),
+              Metrics.Select.Avg(_storeMetric("range.adds"))
+                .nonNegativeRate()
+                .title("Adds"),
+              Metrics.Select.Avg(_storeMetric("range.removes"))
+                .nonNegativeRate()
+                .title("Removes")
+            ).format(d3.format(".1f"))
+            .title("Range Events")
+            .stacked(true)
+          );
+          this._addChart(
+            this.internalsAxes,
+            Metrics.NewAxis(
               Metrics.Select.Avg(_storeMetric("rocksdb.flushes"))
                 .nonNegativeRate()
                 .title("Flushes"),
@@ -911,6 +927,25 @@ module AdminViews {
                 .nonNegativeRate()
                 .title("Cache Misses")
             ).format(d3.format("d")).title("Block Cache Hits/Misses").stacked(true)
+          );
+          this._addChart(
+            this.internalsAxes,
+            Metrics.NewAxis(
+              Metrics.Select.Avg(_storeMetric("range.splits"))
+                .sources(this._storeIds)
+                .nonNegativeRate()
+                .title("Splits"),
+              Metrics.Select.Avg(_storeMetric("range.adds"))
+                .sources(this._storeIds)
+                .nonNegativeRate()
+                .title("Adds"),
+              Metrics.Select.Avg(_storeMetric("range.removes"))
+                .sources(this._storeIds)
+                .nonNegativeRate()
+                .title("Removes")
+            ).format(d3.format(".1f"))
+            .title("Range Events")
+            .stacked(true)
           );
           this._addChart(
             this.internalsAxes,


### PR DESCRIPTION
This change adds metrics and graphs for the range events that we currently log:
- range split
- range add replica
- range remove replica

Resolves #5651

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5666)

<!-- Reviewable:end -->
