### PR TITLE
cli: Define all flags as constants in the cli/flag package

### DIFF
--- a/base/context.go
+++ b/base/context.go
@@ -20,13 +20,12 @@ import (
 	"crypto/tls"
 	"log"
 	"net/http"
-	"reflect"
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/cli/cliflags"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
-	"github.com/spf13/pflag"
 )
 
 // Base context defaults.
@@ -46,32 +45,6 @@ const (
 	// NetworkTimeout is the timeout used for network operations.
 	NetworkTimeout = 3 * time.Second
 )
-
-// FlagMap maps pointer values to the flags that set them.
-var FlagMap = make(map[interface{}]*pflag.Flag)
-
-// Used to convert pointers to unexported pflag types to pointers to
-// standard Go types.
-var (
-	strPtrType   = reflect.PtrTo(reflect.TypeOf(""))
-	intPtrType   = reflect.PtrTo(reflect.TypeOf(0))
-	int64PtrType = reflect.PtrTo(reflect.TypeOf(int64(0)))
-	boolPtrType  = reflect.PtrTo(reflect.TypeOf(false))
-	flagPtrTypes = []reflect.Type{strPtrType, intPtrType, int64PtrType, boolPtrType}
-)
-
-// AddToFlagMap adds the provided flag to FlagMap, mapping the flag's
-// value reference to the flag itself.
-func AddToFlagMap(f *pflag.Flag) {
-	val := reflect.ValueOf(f.Value)
-	for _, t := range flagPtrTypes {
-		if val.Type().ConvertibleTo(t) {
-			FlagMap[val.Convert(t).Interface()] = f
-			return
-		}
-	}
-	FlagMap[val.Interface()] = f
-}
 
 type lazyTLSConfig struct {
 	once      sync.Once
@@ -167,13 +140,8 @@ func (ctx *Context) GetServerTLSConfig() (*tls.Config, error) {
 				ctx.serverTLSConfig.err = util.Errorf("error setting up client TLS config: %s", ctx.serverTLSConfig.err)
 			}
 		} else {
-			insecureFlag := "insecure"
-			certFlag := "cert"
-			if len(FlagMap) > 0 {
-				insecureFlag = FlagMap[&ctx.Insecure].Name
-				certFlag = FlagMap[&ctx.SSLCert].Name
-			}
-			ctx.serverTLSConfig.err = util.Errorf("--%s=false, but --%s is empty. Certificates must be specified.", insecureFlag, certFlag)
+			ctx.serverTLSConfig.err = util.Errorf("--%s=false, but --%s is empty. Certificates must be specified.",
+				cliflags.InsecureName, cliflags.CertName)
 		}
 	})
 

--- a/cli/cliflags/names.go
+++ b/cli/cliflags/names.go
@@ -1,0 +1,45 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package cliflags
+
+// AttrsName and others are flag names.
+const (
+	AttrsName      = "attrs"
+	CacheName      = "cache"
+	DatabaseName   = "database"
+	ExecuteName    = "execute"
+	JoinName       = "join"
+	HostName       = "host"
+	InsecureName   = "insecure"
+	KeySizeName    = "key-size"
+	MaxResultsName = "max-results"
+	PasswordName   = "password"
+	PortName       = "port"
+	HTTPPortName   = "http-port"
+	CACertName     = "ca-cert"
+	CAKeyName      = "ca-key"
+	CertName       = "cert"
+	KeyName        = "key"
+	StoreName      = "store"
+	SocketName     = "socket"
+	URLName        = "url"
+	UserName       = "user"
+	FromName       = "from"
+	ToName         = "to"
+	RawName        = "raw"
+	ValuesName     = "values"
+)

--- a/server/context.go
+++ b/server/context.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/gosigar"
 
 	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/cli/cliflags"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql"
@@ -357,20 +358,21 @@ func (ctx *Context) PGURL(user string) (*url.URL, error) {
 	} else {
 		options.Add("sslmode", "verify-full")
 		requiredFlags := []struct {
-			name  string
-			value *string
+			name     string
+			value    string
+			flagName string
 		}{
-			{"sslcert", &ctx.SSLCert},
-			{"sslkey", &ctx.SSLCertKey},
-			{"sslrootcert", &ctx.SSLCA},
+			{"sslcert", ctx.SSLCert, cliflags.CertName},
+			{"sslkey", ctx.SSLCertKey, cliflags.KeyName},
+			{"sslrootcert", ctx.SSLCA, cliflags.CACertName},
 		}
 		for _, c := range requiredFlags {
-			if *c.value == "" {
-				return nil, fmt.Errorf("missing --%s flag", base.FlagMap[c.value].Name)
+			if c.value == "" {
+				return nil, fmt.Errorf("missing --%s flag", c.flagName)
 			}
-			path := absPath(*c.value)
+			path := absPath(c.value)
 			if _, err := os.Stat(path); err != nil {
-				return nil, fmt.Errorf("file for --%s flag gave error: %v", base.FlagMap[c.value].Name, err)
+				return nil, fmt.Errorf("file for --%s flag gave error: %v", c.flagName, err)
 			}
 			options.Add(c.name, path)
 		}

--- a/util/log/flags.go
+++ b/util/log/flags.go
@@ -29,5 +29,5 @@ func init() {
 	// We define this flag here because stderrThreshold has the type Severity
 	// which we can't pass to logflags without creating an import cycle.
 	flag.Var(&logging.stderrThreshold,
-		"alsologtostderr", "logs at or above this threshold go to stderr")
+		logflags.AlsoLogToStderrName, "logs at or above this threshold go to stderr")
 }

--- a/util/log/logflags/logflags.go
+++ b/util/log/logflags/logflags.go
@@ -50,15 +50,26 @@ func (ab *atomicBool) Set(s string) error {
 
 var _ flag.Value = &atomicBool{}
 
+// LogToStderrName and others are flag names.
+const (
+	LogToStderrName     = "logtostderr"
+	AlsoLogToStderrName = "alsologtostderr"
+	NoColorName         = "no-color"
+	VerbosityName       = "verbosity"
+	VModuleName         = "vmodule"
+	LogBacktraceAtName  = "log-backtrace-at"
+	LogDirName          = "log-dir"
+)
+
 // InitFlags creates logging flags which update the given variables. The passed mutex is
 // locked while the boolean variables are accessed during flag updates.
 func InitFlags(mu sync.Locker, toStderr *bool, logDir flag.Value,
 	nocolor *bool, verbosity, vmodule, traceLocation flag.Value) {
 	*toStderr = true // wonky way of specifying a default
-	flag.Var(&atomicBool{Locker: mu, b: toStderr}, "logtostderr", "log to standard error instead of files")
-	flag.BoolVar(nocolor, "no-color", *nocolor, "disable standard error log colorization")
-	flag.Var(verbosity, "verbosity", "log level for V logs")
-	flag.Var(vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
-	flag.Var(traceLocation, "log-backtrace-at", "when logging hits line file:N, emit a stack trace")
-	flag.Var(logDir, "log-dir", "if non-empty, write log files in this directory")
+	flag.Var(&atomicBool{Locker: mu, b: toStderr}, LogToStderrName, "log to standard error instead of files")
+	flag.BoolVar(nocolor, NoColorName, *nocolor, "disable standard error log colorization")
+	flag.Var(verbosity, VerbosityName, "log level for V logs")
+	flag.Var(vmodule, VModuleName, "comma-separated list of pattern=N settings for file-filtered logging")
+	flag.Var(traceLocation, LogBacktraceAtName, "when logging hits line file:N, emit a stack trace")
+	flag.Var(logDir, LogDirName, "if non-empty, write log files in this directory")
 }


### PR DESCRIPTION
Closes #5645.
Closes #5642.

This allows us to get rid of the `FlagMap` and reference constants for
all flag names. The constants needed their own package to avoid cyclic
dependencies.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5680)

<!-- Reviewable:end -->
