### PR TITLE
storage: turn off panic on consistency failure

### DIFF
--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -458,7 +458,7 @@ func (l *LocalCluster) startNode(node *testNode) {
 			"--logtostderr=false")
 
 	}
-	env := []string{"COCKROACH_SCAN_MAX_IDLE_TIME=200ms"}
+	env := []string{"COCKROACH_SCAN_MAX_IDLE_TIME=200ms", "COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE=true"}
 	l.createRoach(node, l.vols, env, cmd...)
 	maybePanic(node.Start())
 	log.Infof(`*** started %[1]s ***

--- a/server/context.go
+++ b/server/context.go
@@ -147,6 +147,10 @@ type Context struct {
 	// ConsistencyCheckInterval
 	ConsistencyCheckInterval time.Duration
 
+	// ConsistencyCheckPanicOnFailure causes the node to panic when it detects a
+	// replication consistency check failure.
+	ConsistencyCheckPanicOnFailure bool
+
 	// TimeUntilStoreDead is the time after which if there is no new gossiped
 	// information about a store, it is considered dead.
 	// Environment Variable: COCKROACH_TIME_UNTIL_STORE_DEAD
@@ -299,6 +303,20 @@ func (ctx *Context) InitNode() error {
 	return nil
 }
 
+// parseBoolEnv parses a bool from an environment variable. This
+// function assumes that the default value is already present in boolVar.
+func parseBoolEnv(env, internalName string, boolVar *bool) {
+	if valueString := os.Getenv(env); len(valueString) != 0 {
+		if v, err := strconv.ParseBool(valueString); err != nil {
+			log.Errorf("could not parse environment variable %s=%s, setting to default of %t, error: %s",
+				env, valueString, *boolVar, err)
+		} else {
+			*boolVar = v
+			log.Infof("\"%s\" set to %t based on %s environment variable", internalName, v, env)
+		}
+	}
+}
+
 // parseDurationEnv parses a time.Duration from an environment variable. This
 // function assumes that the default value is already present in duration.
 func parseDurationEnv(env, internalName string, duration *time.Duration) {
@@ -317,17 +335,8 @@ func parseDurationEnv(env, internalName string, duration *time.Duration) {
 // variable based. Note that this only happens when initializing a node and not
 // when NewContext is called.
 func (ctx *Context) readEnvironmentVariables() {
-	// cockroach-linearizable
-	if linearizableString := os.Getenv("COCKROACH_LINEARIZABLE"); len(linearizableString) != 0 {
-		if linearizable, err := strconv.ParseBool(linearizableString); err != nil {
-			log.Errorf("could not parse environment variable COCKROACH_LINEARIZABLE=%s, setting to default of %t, error: %s",
-				linearizableString, ctx.Linearizable, err)
-		} else {
-			ctx.Linearizable = linearizable
-			log.Infof("\"linearizable\" set to %t based on COCKROACH_LINEARIZABLE environment variable", ctx.Linearizable)
-		}
-	}
-
+	parseBoolEnv("COCKROACH_LINEARIZABLE", "linearizable", &ctx.Linearizable)
+	parseBoolEnv("COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE", "consistency check panic on failure", &ctx.ConsistencyCheckPanicOnFailure)
 	parseDurationEnv("COCKROACH_MAX_OFFSET", "max offset", &ctx.MaxOffset)
 	parseDurationEnv("COCKROACH_METRICS_FREQUENCY", "metrics frequency", &ctx.MetricsFrequency)
 	parseDurationEnv("COCKROACH_SCAN_INTERVAL", "scan interval", &ctx.ScanInterval)

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -94,10 +94,13 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		if err := os.Unsetenv("COCKROACH_SCAN_INTERVAL"); err != nil {
 			t.Fatal(err)
 		}
+		if err := os.Unsetenv("COCKROACH_SCAN_MAX_IDLE_TIME"); err != nil {
+			t.Fatal(err)
+		}
 		if err := os.Unsetenv("COCKROACH_CONSISTENCY_CHECK_INTERVAL"); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.Unsetenv("COCKROACH_SCAN_MAX_IDLE_TIME"); err != nil {
+		if err := os.Unsetenv("COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE"); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.Unsetenv("COCKROACH_TIME_UNTIL_STORE_DEAD"); err != nil {
@@ -134,14 +137,18 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctxExpected.ScanInterval = time.Hour * 48
-	if err := os.Setenv("COCKROACH_CONSISTENCY_CHECK_INTERVAL", "48h"); err != nil {
-		t.Fatal(err)
-	}
-	ctxExpected.ConsistencyCheckInterval = time.Hour * 48
 	if err := os.Setenv("COCKROACH_SCAN_MAX_IDLE_TIME", "100ns"); err != nil {
 		t.Fatal(err)
 	}
 	ctxExpected.ScanMaxIdleTime = time.Nanosecond * 100
+	if err := os.Setenv("COCKROACH_CONSISTENCY_CHECK_INTERVAL", "48h"); err != nil {
+		t.Fatal(err)
+	}
+	ctxExpected.ConsistencyCheckInterval = time.Hour * 48
+	if err := os.Setenv("COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE", "true"); err != nil {
+		t.Fatal(err)
+	}
+	ctxExpected.ConsistencyCheckPanicOnFailure = true
 	if err := os.Setenv("COCKROACH_TIME_UNTIL_STORE_DEAD", "10ms"); err != nil {
 		t.Fatal(err)
 	}
@@ -169,10 +176,13 @@ func TestReadEnvironmentVariables(t *testing.T) {
 	if err := os.Setenv("COCKROACH_SCAN_INTERVAL", "abcd"); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Setenv("COCKROACH_SCAN_MAX_IDLE_TIME", "abcd"); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.Setenv("COCKROACH_CONSISTENCY_CHECK_INTERVAL", "abcd"); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Setenv("COCKROACH_SCAN_MAX_IDLE_TIME", "abcd"); err != nil {
+	if err := os.Setenv("COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE", "abcd"); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Setenv("COCKROACH_TIME_UNTIL_STORE_DEAD", "abcd"); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -176,15 +176,16 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 
 	// TODO(bdarnell): make StoreConfig configurable.
 	nCtx := storage.StoreContext{
-		Clock:                    s.clock,
-		DB:                       s.db,
-		Gossip:                   s.gossip,
-		Transport:                s.raftTransport,
-		ScanInterval:             s.ctx.ScanInterval,
-		ConsistencyCheckInterval: s.ctx.ConsistencyCheckInterval,
-		ScanMaxIdleTime:          s.ctx.ScanMaxIdleTime,
-		Tracer:                   s.Tracer,
-		StorePool:                s.storePool,
+		Clock:                          s.clock,
+		DB:                             s.db,
+		Gossip:                         s.gossip,
+		Transport:                      s.raftTransport,
+		ScanInterval:                   s.ctx.ScanInterval,
+		ScanMaxIdleTime:                s.ctx.ScanMaxIdleTime,
+		ConsistencyCheckInterval:       s.ctx.ConsistencyCheckInterval,
+		ConsistencyCheckPanicOnFailure: s.ctx.ConsistencyCheckPanicOnFailure,
+		Tracer:    s.Tracer,
+		StorePool: s.storePool,
 		SQLExecutor: sql.InternalExecutor{
 			LeaseManager: s.leaseMgr,
 		},

--- a/storage/store.go
+++ b/storage/store.go
@@ -88,12 +88,13 @@ var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeTy
 // in tests.
 func TestStoreContext() StoreContext {
 	return StoreContext{
-		Tracer:                     tracing.NewTracer(),
-		RaftTickInterval:           100 * time.Millisecond,
-		RaftHeartbeatIntervalTicks: 1,
-		RaftElectionTimeoutTicks:   2,
-		ScanInterval:               10 * time.Minute,
-		ConsistencyCheckInterval:   10 * time.Minute,
+		Tracer:                         tracing.NewTracer(),
+		RaftTickInterval:               100 * time.Millisecond,
+		RaftHeartbeatIntervalTicks:     1,
+		RaftElectionTimeoutTicks:       2,
+		ScanInterval:                   10 * time.Minute,
+		ConsistencyCheckInterval:       10 * time.Minute,
+		ConsistencyCheckPanicOnFailure: true,
 	}
 }
 
@@ -357,6 +358,10 @@ type StoreContext struct {
 	// ConsistencyCheckInterval is the default time period in between consecutive
 	// consistency checks on a range.
 	ConsistencyCheckInterval time.Duration
+
+	// ConsistencyCheckPanicOnFailure causes the node to panic when it detects a
+	// replication consistency check failure.
+	ConsistencyCheckPanicOnFailure bool
 
 	// AllocatorOptions configures how the store will attempt to rebalance its
 	// replicas to other stores.


### PR DESCRIPTION
Added COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE to turn on
panic in acceptance tests and beta clusters.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5687)

<!-- Reviewable:end -->
