### PR TITLE
storage.engine: add version file to store directory

### DIFF
--- a/storage/engine/version.go
+++ b/storage/engine/version.go
@@ -1,0 +1,78 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const (
+	versionFilename     = "COCKROACHDB_VERSION"
+	versionFilenameTemp = "COCKROACHDB_VERSION_TEMP"
+	versionNoFile       = 0
+	versionCurrent      = 1
+	versionMinimum      = versionNoFile
+)
+
+// Version stores all the version information for all stores and is used as
+// the format for the version file.
+type Version struct {
+	Version int
+}
+
+// getVersionFilename returns the filename for the version file stored in the
+// data directory.
+func getVersionFilename(dir string) string {
+	return filepath.Join(dir, versionFilename)
+}
+
+// getVersion returns the current on disk cockroach version from the version
+// file in the passed in directory. If there is no version file yet, it
+// returns 0.
+func getVersion(dir string) (int, error) {
+	filename := getVersionFilename(dir)
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return versionNoFile, nil
+		}
+		return 0, err
+	}
+	var ver Version
+	if err := json.Unmarshal(b, &ver); err != nil {
+		return 0, fmt.Errorf("version file %s is not formatted correctly; %s", filename, err)
+	}
+	return ver.Version, nil
+}
+
+// writeVersionFile overwrites the version file to contain the latest version.
+func writeVersionFile(dir string) error {
+	tempFilename := filepath.Join(dir, versionFilenameTemp)
+	filename := getVersionFilename(dir)
+	b, err := json.Marshal(Version{versionCurrent})
+	if err != nil {
+		return err
+	}
+	// First write to a temp file.
+	if err := ioutil.WriteFile(tempFilename, b, 0644); err != nil {
+		return err
+	}
+	// Atomically rename the file to overwrite the version file on disk.
+	return os.Rename(tempFilename, filename)
+}

--- a/storage/engine/version_test.go
+++ b/storage/engine/version_test.go
@@ -1,0 +1,73 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+// TestVersions verifies that both getVersions() and writeVersionFile work
+// correctly.
+func TestVersions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	dir, err := ioutil.TempDir("", "testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// First test when no file exists yet.
+	ver, err := getVersion(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ver != versionNoFile {
+		t.Errorf("no version file version should be %d, got %d", versionNoFile, ver)
+	}
+
+	// Write the current versions to the file.
+	if err := writeVersionFile(dir); err != nil {
+		t.Fatal(err)
+	}
+	ver, err = getVersion(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ver != versionCurrent {
+		t.Errorf("current versions do not match, expected %d got %d", versionCurrent, ver)
+	}
+
+	// Write gibberish to the file.
+	filename := getVersionFilename(dir)
+	if err := os.Remove(filename); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filename, []byte("cause an error please"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := getVersion(dir); !testutils.IsError(err, "is not formatted correctly") {
+		t.Errorf("expected error contains '%s', got '%s'", "is not formatted correctly", err)
+	}
+}


### PR DESCRIPTION
This adds a new file VERSION to all store directories. To facilitate this, I've
added a new proto to keep track the format. This has a tiny bit of future
proofing to allow us to have multiple database types with different data
versions as well as a minimum value we support.

When needed, having this file will allow us to automatically perform migrations
during the call to rocksDB.Open().

Fixes #2718.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5693)

<!-- Reviewable:end -->
