### PR TITLE
Adds a footer with helpful links

### DIFF
--- a/ui/debug/index.html
+++ b/ui/debug/index.html
@@ -38,7 +38,10 @@ Author: Bram Gruneir (bram+code@cockroachlabs.com)
     <div id="banner"></div>
     <div id="content">
       <div id="header"></div>
-      <div id="root"></div>
+      <div id="page-container">
+        <div id="root"></div>
+        <div id="footer"></div>
+      </div>
     </div>
     <script src="/build/app.js"></script>
   </body>

--- a/ui/release/index.html
+++ b/ui/release/index.html
@@ -38,7 +38,10 @@ Author: Bram Gruneir (bram+code@cockroachlabs.com)
     <div id="banner"></div>
     <div id="content">
       <div id="header"></div>
-      <div id="root"></div>
+      <div>
+        <div id="root"></div>
+        <div id="footer"></div>
+      </div>
     </div>
     <script src="/build/app.js"></script>
   </body>

--- a/ui/styl/modules/layout-vars.styl
+++ b/ui/styl/modules/layout-vars.styl
@@ -20,3 +20,4 @@ $nav-width      = 80px
 $top-bar-height = 95px
 $subnav-height  = 60px
 $chart-width    = 1300px
+$footer-height  = 73px

--- a/ui/styl/partials/layout.styl
+++ b/ui/styl/partials/layout.styl
@@ -33,12 +33,16 @@ html
 body
   height 100%
   background-color $secondary-gray-4
-  min-width 650px
+  min-width 700px
+
+#page-container
+  position relative
+  min-height 100vh
 
 #root
   position relative
   padding-left $nav-width
-  min-height 100% // TODO or calc(100% - 4rem)
+  min-height calc(100vh - $footer-height) // TODO or calc(100% - 4rem)
 
   &:after
     content ""
@@ -544,3 +548,18 @@ a.toggle
 table
   td:first-child
     padding-left 3rem
+
+#footer
+  height $footer-height
+  padding-left 80px
+  border-top 1px solid $secondary-gray-1
+
+  .links
+    width 600px
+    margin auto
+    a
+      line-height $footer-height
+      margin 20px
+      text-decoration none
+      color $main-gray
+

--- a/ui/styl/partials/navigation-bar.styl
+++ b/ui/styl/partials/navigation-bar.styl
@@ -38,6 +38,7 @@ $subnav-underline-height = 3px
   position absolute
   top 0
   left 0
+  bottom 0
   z-index 1
   width $nav-width
   modular-font-size '1'

--- a/ui/ts/app.ts
+++ b/ui/ts/app.ts
@@ -9,8 +9,10 @@
 /// <reference path="pages/events.ts" />
 /// <reference path="pages/databases.ts" />
 /// <reference path="pages/banner.ts" />
+/// <reference path="pages/footer.ts" />
 
 m.mount(document.getElementById("header"), AdminViews.SubModules.TitleBar);
+m.mount(document.getElementById("footer"), AdminViews.SubModules.Footer);
 
 m.route.mode = "hash";
 m.route(document.getElementById("root"), "/cluster", {

--- a/ui/ts/pages/footer.ts
+++ b/ui/ts/pages/footer.ts
@@ -1,0 +1,27 @@
+// source: pages/footer.ts
+/// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
+
+module AdminViews {
+  "use strict";
+
+  export module SubModules {
+    /**
+     * Banner is used for all the different banners
+     */
+    export module Footer {
+
+      export function controller(): any {}
+
+      export function view(ctrl: any): _mithril.MithrilVirtualElement {
+        return m(".footer", m(".links", [
+          m("a", {href: "https://gitter.im/cockroachdb/cockroach"}, "Gitter"),
+          m("a", {href: "https://groups.google.com/forum/#!forum/cockroach-db"}, "Google Groups"),
+          m("a", {href: "https://twitter.com/cockroachdb"}, "Twitter"),
+          m("a", {href: "https://github.com/cockroachdb/cockroach"}, "Github"),
+          m("a", {href: "https://www.cockroachlabs.com/"}, "Homepage"),
+          m("a", {href: "https://www.cockroachlabs.com/docs/"}, "Docs"),
+        ]));
+      }
+    }
+  }
+}


### PR DESCRIPTION
Sits at the bottom of the page when the page height is larger than the window height:
<img width="962" alt="screen shot 2016-03-29 at 3 09 13 pm" src="https://cloud.githubusercontent.com/assets/3691886/14125915/91bfe11e-f5c2-11e5-8bf8-fab9526423b2.png">
(scrolled down)
<img width="956" alt="screen shot 2016-03-29 at 3 09 20 pm" src="https://cloud.githubusercontent.com/assets/3691886/14125914/91bf23f0-f5c2-11e5-9390-b9e7d04b04a6.png">
Doesn't wrap when the width is too small
<img width="278" alt="screen shot 2016-03-29 at 3 09 00 pm" src="https://cloud.githubusercontent.com/assets/3691886/14125916/91c46c70-f5c2-11e5-90ac-ba74e985640a.png">
Sits at the bottom when the window height is small
<img width="1171" alt="screen shot 2016-03-29 at 3 08 48 pm" src="https://cloud.githubusercontent.com/assets/3691886/14125917/91c4f546-f5c2-11e5-821c-036fc8f6a4c9.png">
Or large
<img width="1170" alt="screen shot 2016-03-29 at 3 08 39 pm" src="https://cloud.githubusercontent.com/assets/3691886/14125918/91ca75f2-f5c2-11e5-8221-855f20a60777.png">
Thinner example
<img width="666" alt="screen shot 2016-03-29 at 3 08 29 pm" src="https://cloud.githubusercontent.com/assets/3691886/14125919/91cd5204-f5c2-11e5-83d7-1fc0f5d03a87.png">

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5696)

<!-- Reviewable:end -->
