### PR TITLE
storage: Avoid deadlock between competing pushers

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -440,7 +440,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 	if tc.linearizable && sleepNS > 0 {
 		defer func() {
 			if log.V(1) {
-				log.Infof("%v: waiting %s on EndTransaction for linearizability", br.Txn.Short(), util.TruncateDuration(sleepNS, time.Millisecond))
+				log.Infof("%v: waiting %s on EndTransaction for linearizability", br.Txn.ID.Short(), util.TruncateDuration(sleepNS, time.Millisecond))
 			}
 			time.Sleep(sleepNS)
 		}()

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -26,7 +26,6 @@ import (
 	"math/rand"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -615,15 +614,6 @@ func NewTransaction(name string, baseKey Key, userPriority UserPriority,
 	}
 }
 
-// GetMeta returns the Transaction's metadata, or nil if the transaction
-// is nil.
-func (t *Transaction) GetMeta() *TxnMeta {
-	if t == nil {
-		return nil
-	}
-	return &t.TxnMeta
-}
-
 // Clone creates a copy of the given transaction. The copy is "mostly" deep,
 // but does share pieces of memory with the original such as Key, ID and the
 // keys with the intent spans.
@@ -840,16 +830,8 @@ func (t Transaction) String() string {
 		fmt.Fprintf(&buf, "%q ", t.Name)
 	}
 	fmt.Fprintf(&buf, "id=%s key=%s rw=%t pri=%.8f iso=%s stat=%s epo=%d ts=%s orig=%s max=%s wto=%t",
-		t.Short(), t.Key, t.Writing, floatPri, t.Isolation, t.Status, t.Epoch, t.Timestamp, t.OrigTimestamp, t.MaxTimestamp, t.WriteTooOld)
+		t.ID.Short(), t.Key, t.Writing, floatPri, t.Isolation, t.Status, t.Epoch, t.Timestamp, t.OrigTimestamp, t.MaxTimestamp, t.WriteTooOld)
 	return buf.String()
-}
-
-// Short returns the short form of the Transaction's UUID.
-func (t Transaction) Short() string {
-	if t.ID == nil {
-		return strings.Repeat("?", 8)
-	}
-	return t.ID.String()[:8]
 }
 
 // ResetObservedTimestamps clears out all timestamps recorded from individual

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1047,7 +1047,13 @@ func mvccPutInternal(
 			return nil
 		}
 	}
-	buf.newMeta = MVCCMetadata{Txn: txn.GetMeta(), Timestamp: timestamp}
+	{
+		var txnMeta *roachpb.TxnMeta
+		if txn != nil {
+			txnMeta = &txn.TxnMeta
+		}
+		buf.newMeta = MVCCMetadata{Txn: txnMeta, Timestamp: timestamp}
+	}
 	newMeta := &buf.newMeta
 
 	versionKey := metaKey

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1605,7 +1605,7 @@ func (r *Replica) checkIfTxnAborted(b engine.Engine, txn roachpb.Transaction) *r
 	if aborted {
 		// We hit the cache, so let the transaction restart.
 		if log.V(1) {
-			log.Infof("found abort cache entry for %s with priority %d", txn.Short(), entry.Priority)
+			log.Infof("found abort cache entry for %s with priority %d", txn.ID.Short(), entry.Priority)
 		}
 		newTxn := txn.Clone()
 		if entry.Priority > newTxn.Priority {

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -992,6 +992,10 @@ func (r *Replica) PushTxn(
 ) (roachpb.PushTxnResponse, error) {
 	var reply roachpb.PushTxnResponse
 
+	if args.Now.Equal(roachpb.ZeroTimestamp) {
+		return reply, util.Errorf("the field Now must be provided")
+	}
+
 	if args.PusherTxn.ID != nil {
 		reply.Txn = &args.PusherTxn
 	}
@@ -1071,51 +1075,49 @@ func (r *Replica) PushTxn(
 		return reply, nil
 	}
 
-	// pusherWins bool is true in the event the pusher prevails.
-	var pusherWins bool
-
 	priority := args.PusherTxn.Priority
 
-	// Check for txn timeout.
-	if reply.PusheeTxn.LastHeartbeat == nil {
-		reply.PusheeTxn.LastHeartbeat = &reply.PusheeTxn.Timestamp
-	}
-	if args.Now.Equal(roachpb.ZeroTimestamp) {
-		return reply, util.Errorf("the field Now must be provided")
-	}
-	// Compute heartbeat expiration (all replicas must see the same result).
-	expiry := args.Now
-	expiry.WallTime -= 2 * DefaultHeartbeatInterval.Nanoseconds()
+	var pusherWins bool
+	var reason string
 
-	if reply.PusheeTxn.LastHeartbeat.Less(expiry) {
-		if log.V(1) {
-			log.Infof("pushing expired txn %s", reply.PusheeTxn)
-		}
-		pusherWins = true
+	lastActive := reply.PusheeTxn.OrigTimestamp
+	if realHB := reply.PusheeTxn.LastHeartbeat; realHB != nil {
+		lastActive.Forward(*realHB)
+	}
+	switch {
+	case lastActive.Less(args.Now.Add(-2*DefaultHeartbeatInterval.Nanoseconds(), 0)):
+		reason = "pushee is expired"
 		// When cleaning up, actually clean up (as opposed to simply pushing
 		// the garbage in the path of future writers).
 		args.PushType = roachpb.PUSH_ABORT
-	} else if reply.PusheeTxn.Isolation == roachpb.SNAPSHOT && args.PushType == roachpb.PUSH_TIMESTAMP {
-		if log.V(1) {
-			log.Infof("pushing timestamp for snapshot isolation txn")
-		}
 		pusherWins = true
-	} else if args.PushType == roachpb.PUSH_TOUCH {
+	case args.PushType == roachpb.PUSH_TOUCH:
 		// If just attempting to cleanup old or already-committed txns,
 		// pusher always fails.
 		pusherWins = false
-	} else if reply.PusheeTxn.Priority < priority ||
-		(reply.PusheeTxn.Priority == priority && args.PusherTxn.ID != nil &&
-			(args.PusherTxn.Timestamp.Less(reply.PusheeTxn.Timestamp) ||
-				(args.PusherTxn.Timestamp.Equal(reply.PusheeTxn.Timestamp) &&
-					bytes.Compare(reply.PusheeTxn.ID.GetBytes(), args.PusherTxn.ID.GetBytes()) < 0))) {
-		// Pusher wins based on priority; if priorities are equal, order
-		// by lower txn timestamp; if priorities & timestamps are equal,
-		// the greater transaction ID wins.
-		if log.V(1) {
-			log.Infof("pushing intent from txn with lower priority %s vs %d", reply.PusheeTxn, priority)
-		}
+	case args.PushType == roachpb.PUSH_TIMESTAMP &&
+		reply.PusheeTxn.Isolation == roachpb.SNAPSHOT:
+		// Can always push a SNAPSHOT txn's timestamp.
+		reason = "pushee is SNAPSHOT"
 		pusherWins = true
+	case reply.PusheeTxn.Priority != priority:
+		reason = "priority"
+		pusherWins = reply.PusheeTxn.Priority < priority
+	case args.PusherTxn.ID == nil:
+		reason = "equal priorities; pusher not transactional"
+		pusherWins = false
+	default:
+		reason = "equal priorities; greater ID wins"
+		pusherWins = bytes.Compare(reply.PusheeTxn.ID.GetBytes(),
+			args.PusherTxn.ID.GetBytes()) < 0
+	}
+
+	if log.V(1) && reason != "" {
+		s := "pushed"
+		if !pusherWins {
+			s = "failed to push"
+		}
+		log.Infof("%s "+s+" %s: %s", args.PusherTxn.ID.Short(), reply.PusheeTxn.ID.Short(), reason)
 	}
 
 	if !pusherWins {

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -533,7 +533,7 @@ func (r *Replica) EndTransaction(
 		var err error
 		if txnAutoGC && len(externalIntents) == 0 {
 			if log.V(1) {
-				log.Infof("auto-gc'ed %s (%d intents)", h.Txn.Short(), len(args.IntentSpans))
+				log.Infof("auto-gc'ed %s (%d intents)", h.Txn.ID.Short(), len(args.IntentSpans))
 			}
 			err = engine.MVCCDelete(batch, ms, key, roachpb.ZeroTimestamp, nil /* txn */)
 		} else {

--- a/util/uuid/uuid.go
+++ b/util/uuid/uuid.go
@@ -31,6 +31,20 @@ type UUID struct {
 	uuid.UUID
 }
 
+// String returns the canonical representation of the UUID. For nil UUIDs,
+// returns xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+func (u *UUID) String() string {
+	if u == nil {
+		u = EmptyUUID
+	}
+	return u.UUID.String()
+}
+
+// Short returns the first eight characters of the output of String().
+func (u *UUID) Short() string {
+	return u.String()[:8]
+}
+
 // Bytes shadows (*github.com/satori/go.uuid.UUID).Bytes() to prevent confusing
 // our default proto stringer.
 // TODO(tschottdorf): fix upstream.

--- a/util/uuid/uuid.go
+++ b/util/uuid/uuid.go
@@ -32,16 +32,19 @@ type UUID struct {
 }
 
 // String returns the canonical representation of the UUID. For nil UUIDs,
-// returns xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+// returns <nil>.
 func (u *UUID) String() string {
 	if u == nil {
-		u = EmptyUUID
+		return "<nil>"
 	}
 	return u.UUID.String()
 }
 
 // Short returns the first eight characters of the output of String().
 func (u *UUID) Short() string {
+	if u == nil {
+		return u.String()
+	}
 	return u.String()[:8]
 }
 


### PR DESCRIPTION
When two transactions try to push each other, one of them must be able to win
in order to avoid deadlock. This was (seemingly) achieved by, in that order,
using priority, timestamp and transaction ID as criterions.
In particular, when priorities were equal, we chose to let the transaction with
the lower timestamp win based on seniority.
The issue with that lies in the asynchronicity between the active KV client and
the persisted record. While the record is the source of truth, the client may
actually operate at a higher timestamp and will supply that higher timestamp
with its Pushes. On the other hand, when being pushed, the timestamp used is
that of the record, which may be smaller.

Consequently, the following situation could occur:
- Transactions A and B end up with the same priority, B has the larger ID. This
- can easily happen if they both lose against a higher-priority transaction[1].
- Based on their persisted record's timestamps, B should lose: it has the higher
  timestamp.
- A operates at a timestamp which is higher than that of its persisted record,
- and also higher than that of B.
- B operates at its true timestamp (for simplicity).

Consequently, since priorities are equal,
- A can't push B: it uses its client timestamp, which is higher than that of
  B's record.
- B can't push A: it uses its client=real timestamp, but that can't win against
  A's persisted record (which is lower than B's).

A simple alternative fix would have been to let the larger timestamp win, but
this is also dangerous (though it should ultimately work): The persisted
timestamp can also be larger than the active timestamp; this commonly happens
when a transaction gets pushed but does not know it yet. We update the
transaction entry after a failed Push, so this scenario would resolve in
practice, but it demonstrates that the lack of synchronicity leads to
surprising situations which are best avoided.

Fixes #5685 (though low throughput still happens, I'll investigate this more).

[1]: Independently from this change, we may want to reevaluate this strategy at
some point. If A at priority 1 and B at priority 2^16 both lose against
priority 2^25, it does not seem fair that both should end up at priority
2^25-1. Instead, it would seem more reasonable that their priority be increased
as a fraction of the difference, for instance bumping A by (2^25-1)/2 and B by
(2^25-2^16)/2, which preserves the relative ordering of A and B but still lets
them approach the priority of their mutual enemy.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5710)

<!-- Reviewable:end -->
