### PR TITLE
sql: fix error message when hitting conflicts on non-unique index

### DIFF
--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -67,7 +67,7 @@ EXPLAIN (DEBUG) SELECT * FROM kv@a
 8  /kv/a/'f'  /'e'     ROW
 
 statement error pgcode 23505 duplicate key value \(v\)=\('f'\) violates unique constraint "a"
-INSERT INTO kv VALUES ('e', 'f')
+INSERT INTO kv VALUES ('h', 'f')
 
 query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv
@@ -388,3 +388,20 @@ INSERT INTO return VALUES (1, 2), (3, 4) RETURNING return.*, a + b
 a b a + b
 1 2 3
 3 4 7
+
+statement ok
+CREATE TABLE abc (
+  a INT,
+  b INT,
+  c INT,
+  PRIMARY KEY (a, b),
+  INDEX a (a)
+)
+
+statement ok
+INSERT INTO abc VALUES (1, 2, 10)
+
+# Verify we get the correct message, even though internally the ConditionalPut
+# for the index key will also fail.
+statement error pgcode 23505 duplicate key value \(a,b\)=\(1,2\) violates unique constraint "primary"
+INSERT INTO abc VALUES (1, 2, 20)


### PR DESCRIPTION
If we try to insert a duplicate primary key, we may get a ConditionalPut error
on a _non-unique_ index. This results in an incorrect message that complains
about a uniqueness violation on that index. The change fixes this: if the index
is not unique, we show the error as a primary key violation.

Without the change, the new testcase returned `pq: duplicate key value (a)=(1)
violates unique constraint "a"`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5720)

<!-- Reviewable:end -->
