### PR TITLE
storage: add delayed acks for snapshots

### DIFF
--- a/storage/raft_transport.go
+++ b/storage/raft_transport.go
@@ -56,10 +56,18 @@ func GossipAddressResolver(gossip *gossip.Gossip) NodeAddressResolver {
 	}
 }
 
+// RaftSnapshotStatus contains a MsgSnap message and its resulting
+// error, for asynchronous notification of completion.
+type RaftSnapshotStatus struct {
+	Req *RaftMessageRequest
+	Err error
+}
+
 // RaftTransport handles the rpc messages for raft.
 type RaftTransport struct {
-	resolver   NodeAddressResolver
-	rpcContext *rpc.Context
+	resolver           NodeAddressResolver
+	rpcContext         *rpc.Context
+	SnapshotStatusChan chan RaftSnapshotStatus
 
 	mu struct {
 		sync.Mutex
@@ -75,10 +83,12 @@ func NewDummyRaftTransport() *RaftTransport {
 }
 
 // NewRaftTransport creates a new RaftTransport with specified resolver and grpc server.
+// Callers are responsible for monitoring RaftTransport.SnapshotStatusChan.
 func NewRaftTransport(resolver NodeAddressResolver, grpcServer *grpc.Server, rpcContext *rpc.Context) *RaftTransport {
 	t := &RaftTransport{
-		resolver:   resolver,
-		rpcContext: rpcContext,
+		resolver:           resolver,
+		rpcContext:         rpcContext,
+		SnapshotStatusChan: make(chan RaftSnapshotStatus),
 	}
 	t.mu.handlers = make(map[roachpb.StoreID]raftMessageHandler)
 	t.mu.queues = make(map[roachpb.NodeID]chan *RaftMessageRequest)
@@ -235,11 +245,13 @@ func (t *RaftTransport) processQueue(nodeID roachpb.NodeID) {
 					return
 				}
 				t.rpcContext.Stopper.RunAsyncTask(func() {
-					if err := snapStream.Send(req); err != nil {
+					err := snapStream.Send(req)
+					if err != nil {
 						log.Errorf("failed to send Raft snapshot to node %d at %s: %s", nodeID, addr, err)
 					} else if log.V(1) {
 						log.Infof("successfully sent a Raft snapshot to node %d at %s", nodeID, addr)
 					}
+					t.SnapshotStatusChan <- RaftSnapshotStatus{req, err}
 				})
 			} else {
 				if err := stream.Send(req); err != nil {

--- a/storage/store.go
+++ b/storage/store.go
@@ -1887,6 +1887,15 @@ func (s *Store) processRaft() {
 				}
 				s.processRaftMu.Unlock()
 
+			case st := <-s.ctx.Transport.SnapshotStatusChan:
+				s.processRaftMu.Lock()
+				s.mu.Lock()
+				if r, ok := s.mu.replicas[st.Req.GroupID]; ok {
+					r.reportSnapshotStatus(st.Req.Message.To, st.Err)
+				}
+				s.mu.Unlock()
+				s.processRaftMu.Unlock()
+
 			case <-ticker.C:
 				// TODO(bdarnell): rework raft ticker.
 				s.processRaftMu.Lock()


### PR DESCRIPTION
We were previously calling raft.RawNode.ReportSnapshot as soon as we
passed the snapshot message to the transport, which defeated raft's
internal flow control and could cause pending snapshot messages to pile
up if they could not be completely transmitted in less than the
heartbeat interval.

This commit adds a channel to the RaftTransport object that can be used
to report the status of the snapshot as soon as the last of the data has
been sent.

Fixes #5709

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5721)

<!-- Reviewable:end -->
