### PR TITLE
gossip: always merge bootsrtap addrs

### DIFF
--- a/gossip/storage_test.go
+++ b/gossip/storage_test.go
@@ -191,4 +191,9 @@ func TestGossipStorage(t *testing.T) {
 			return true
 		}
 	})
+
+	if expected, actual := len(network.Nodes)-1 /* -1 is ourself */, ts2.Len(); expected != actual {
+		t.Fatalf("expected %v, got %v (info: %#v)", expected, actual, ts2.info.Addresses)
+	}
+
 }


### PR DESCRIPTION
The map of existing was populated during the merge of existing and new bootstrap, but that block
was skipped when there were no existing addrs. Removing the skip means we always go though
g.maybeAddBootstrapAddress, which correctly populates the set, and doesn't actually mean
doing much more work in the empty existing case since those will be zero-iteration loops.

Fixes #5730

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5731)

<!-- Reviewable:end -->
