### PR TITLE
storage: remove BalanceMode

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -192,7 +192,6 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		LogRangeEvents: true,
 		AllocatorOptions: storage.AllocatorOptions{
 			AllowRebalance: true,
-			Mode:           storage.BalanceModeUsage,
 		},
 		TestingKnobs: ctx.TestingKnobs.StoreTestingKnobs,
 	}


### PR DESCRIPTION
A previous refactoring caused BalanceMode to always be set to
BalanceModeUsage. Remove it completely.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5733)

<!-- Reviewable:end -->
