### PR TITLE
Add backfilling functionality for altering tables by adding columns

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -71,6 +71,7 @@ func (ids indexesByID) Swap(i, j int) {
 func (p *planner) backfillBatch(b *client.Batch, tableDesc *TableDescriptor) *roachpb.Error {
 	var droppedColumnDescs []ColumnDescriptor
 	var droppedIndexDescs []IndexDescriptor
+	var newColumnDescs []ColumnDescriptor
 	var newIndexDescs []IndexDescriptor
 	// Mutations are applied in a FIFO order. Only apply the first set
 	// of mutations.
@@ -84,8 +85,7 @@ func (p *planner) backfillBatch(b *client.Batch, tableDesc *TableDescriptor) *ro
 		case DescriptorMutation_ADD:
 			switch t := m.Descriptor_.(type) {
 			case *DescriptorMutation_Column:
-				// TODO(vivek): Add column to new columns and use it
-				// to fill in default values.
+				newColumnDescs = append(newColumnDescs, *t.Column)
 
 			case *DescriptorMutation_Index:
 				newIndexDescs = append(newIndexDescs, *t.Index)
@@ -105,12 +105,21 @@ func (p *planner) backfillBatch(b *client.Batch, tableDesc *TableDescriptor) *ro
 	// TODO(vivek): Break these backfill operations into chunks. All of them
 	// will fail on big tables (see #3274).
 
-	// Delete the entire dropped columns.
-	// This used to use SQL UPDATE in the past to update the dropped
-	// column to NULL; but a column in the process of being
-	// dropped is placed in the table descriptor mutations, and
-	// a SQL UPDATE of a column in mutations will fail.
-	if len(droppedColumnDescs) > 0 {
+	defaultExprs, err := p.makeDefaultExprs(newColumnDescs)
+	if err != nil {
+		return roachpb.NewError(err)
+	}
+
+	nonNullableColumn := ""
+	// Add the column to the table descriptor.
+	for _, columnDesc := range newColumnDescs {
+		if columnDesc.DefaultExpr == nil && !columnDesc.Nullable {
+			nonNullableColumn = columnDesc.Name
+		}
+		tableDesc.AddColumn(columnDesc)
+	}
+
+	if len(droppedColumnDescs) > 0 || nonNullableColumn != "" || len(defaultExprs) > 0 {
 		// Run a scan across the table using the primary key.
 		start := roachpb.Key(MakeIndexKeyPrefix(tableDesc.ID, tableDesc.PrimaryIndex.ID))
 		// Use a different batch to perform the scan.
@@ -119,6 +128,15 @@ func (p *planner) backfillBatch(b *client.Batch, tableDesc *TableDescriptor) *ro
 		if pErr := p.txn.Run(batch); pErr != nil {
 			return pErr
 		}
+
+		if nonNullableColumn != "" {
+			for _, result := range batch.Results {
+				if len(result.Rows) > 0 {
+					return roachpb.NewErrorf("column %s contains null values", nonNullableColumn)
+				}
+			}
+		}
+
 		for _, result := range batch.Results {
 			var sentinelKey roachpb.Key
 			for _, kv := range result.Rows {
@@ -127,6 +145,12 @@ func (p *planner) backfillBatch(b *client.Batch, tableDesc *TableDescriptor) *ro
 					// ID. Strip off that suffix to determine the prefix shared with the
 					// other keys for the row.
 					sentinelKey = stripColumnIDLength(kv.Key)
+
+					// Delete the entire dropped columns.
+					// This used to use SQL UPDATE in the past to update the dropped
+					// column to NULL; but a column in the process of being
+					// dropped is placed in the table descriptor mutations, and
+					// a SQL UPDATE of a column in mutations will fail.
 					for _, columnDesc := range droppedColumnDescs {
 						// Delete the dropped column.
 						colKey := keys.MakeColumnKey(sentinelKey, uint32(columnDesc.ID))
@@ -134,6 +158,26 @@ func (p *planner) backfillBatch(b *client.Batch, tableDesc *TableDescriptor) *ro
 							log.Infof("Del %s", colKey)
 						}
 						b.Del(colKey)
+					}
+					// Add the new columns and backfill the values.
+					for i, expr := range defaultExprs {
+						if expr == nil {
+							continue
+						}
+						col := newColumnDescs[i]
+						colKey := keys.MakeColumnKey(sentinelKey, uint32(col.ID))
+						d, err := expr.Eval(p.evalCtx)
+						if err != nil {
+							return roachpb.NewError(err)
+						}
+						val, err := marshalColumnValue(col, d, p.evalCtx.Args)
+						if err != nil {
+							return roachpb.NewError(err)
+						}
+						if log.V(2) {
+							log.Infof("CPut %s -> %v", colKey, val)
+						}
+						b.CPut(colKey, val, nil)
 					}
 				}
 			}

--- a/sql/testdata/alter_table
+++ b/sql/testdata/alter_table
@@ -128,3 +128,69 @@ INSERT INTO t VALUES (4, 1)
 
 statement error duplicate key value \(d\)=\(1\) violates unique constraint \"t_d_key\"
 INSERT INTO t VALUES (5, 1)
+
+# Add a column with no default value
+statement ok
+ALTER TABLE t ADD COLUMN x DECIMAL
+
+# Add a non NULL column with a default value
+statement ok
+ALTER TABLE t ADD COLUMN y DECIMAL NOT NULL DEFAULT (DECIMAL '1.3')
+
+# Add a non NULL column with no default value
+statement error column q contains null values
+ALTER TABLE t ADD COLUMN q DECIMAL NOT NULL
+
+statement ok
+ALTER TABLE t ADD COLUMN z DECIMAL DEFAULT (DECIMAL '1.4')
+
+statement ok
+INSERT INTO t VALUES (11, 12, DECIMAL '1.0')
+
+statement ok
+INSERT INTO t (a, d) VALUES (13, 14)
+
+statement ok
+INSERT INTO t (a, d, y) VALUES (21, 22, DECIMAL '1.0')
+
+statement ok
+INSERT INTO t (a, d) VALUES (23, 24)
+
+statement ok
+INSERT INTO t VALUES (31, 32)
+
+statement ok
+INSERT INTO t (a, d, x, y, z) VALUES (33, 34, DECIMAL '2.0', DECIMAL '2.1', DECIMAL '2.2')
+
+query IITTT colnames
+SELECT * FROM t
+----
+a   d     x     y     z
+1   NULL  NULL  1.3   1.4
+2   NULL  NULL  1.3   1.4
+3   NULL  NULL  1.3   1.4
+4   1     NULL  1.3   1.4
+11  12    1     1.3   1.4
+13  14    NULL  1.3   1.4
+21  22    NULL  1     1.4
+23  24    NULL  1.3   1.4
+31  32    NULL  1.3   1.4
+33  34    2     2.1   2.2
+
+# Subsequent operations succeed because the table is empty
+statement ok
+CREATE TABLE tt (a INT PRIMARY KEY)
+
+statement ok
+ALTER TABLE tt ADD COLUMN q DECIMAL NOT NULL
+
+statement ok
+ALTER table tt ADD COLUMN r DECIMAL
+
+query TTBT colnames
+SHOW COLUMNS FROM tt
+----
+Field  Type     Null   Default
+a      INT      false  NULL
+q      DECIMAL  false  NULL
+r      DECIMAL  true   NULL


### PR DESCRIPTION
 When adding new columns make sure default values are backfilled.
 If a column is to be mutated with a non-null column but no default
 value, return error.

Fixes #5751
- [x] implement backfilling
- [x] check for default != nil && !nullable
- [x] Add unit tests

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5759)

<!-- Reviewable:end -->
