### PR TITLE
sql: Add VERSION() builtin

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -39,6 +39,7 @@ import (
 	"gopkg.in/inf.v0"
 
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/decimal"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/timeutil"
@@ -990,6 +991,15 @@ var builtins = map[string][]builtin{
 			dd.Round(x, 0, inf.RoundDown)
 			return dd, nil
 		}),
+	},
+	"version": {
+		builtin{
+			returnType: typeString,
+			types:      argTypes{},
+			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+				return DString(util.GetBuildInfo().Short()), nil
+			},
+		},
 	},
 }
 

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -247,7 +247,7 @@ SELECT overlay('123456789' placing 'xxxx' from 3);
 12xxxx789
 
 query T
-SELECT overlay('123456789' placing 'xxxx' from 3 for 2); 
+SELECT overlay('123456789' placing 'xxxx' from 3 for 2);
 ----
 12xxxx56789
 
@@ -1043,3 +1043,8 @@ query BBBB
 select 1::decimal >= 1.0, 1.0 >= 1::decimal, 1.0 >= 2::decimal, 1::decimal >= 2.0
 ----
 true true false false
+
+query I
+SELECT strpos(version(), 'CockroachDB')
+----
+1

--- a/util/build.go
+++ b/util/build.go
@@ -42,6 +42,11 @@ var (
 	buildPlatform    = fmt.Sprintf("%s %s", runtime.GOOS, runtime.GOARCH)
 )
 
+// Short returns a pretty printed build and version summary.
+func (b BuildInfo) Short() string {
+	return fmt.Sprintf("CockroachDB %s (%s, built %s, %s)", b.Tag, b.Platform, b.Time, b.GoVersion)
+}
+
 // GetBuildInfo ...
 func GetBuildInfo() BuildInfo {
 	return BuildInfo{


### PR DESCRIPTION
Clients can use this to determine what version of cockroach they are talking to, or that they are talking to cockroach at all.

```
$ echo "select version();" | psql postgresql://localhost:26257?sslmode=disable
                                version()
--------------------------------------------------------------------------
 CockroachDB beta-20160330-49-g144e56e (built 2016/03/31 13:22:02, go1.6)
(1 row)
```

Closes #5760

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5763)

<!-- Reviewable:end -->
