### PR TITLE
acceptance/cluster: additional logging when retrying docker api calls

### DIFF
--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -307,7 +307,7 @@ func (cli resilientDockerClient) ContainerCreate(
 				if n != containerName {
 					continue
 				}
-				log.Infof("Trying to remove %s", c.ID)
+				log.Infof("trying to remove %s", c.ID)
 				roptions := types.ContainerRemoveOptions{
 					ContainerID:   c.ID,
 					RemoveVolumes: true,
@@ -353,95 +353,83 @@ type retryingDockerClient struct {
 	timeout  time.Duration
 }
 
+func (cli retryingDockerClient) retry(ctx context.Context, timeout time.Duration,
+	name string, f func(ctx context.Context) error) error {
+	for i := 0; i < cli.attempts; i++ {
+		timeoutCtx, _ := context.WithTimeout(ctx, timeout)
+		err := f(timeoutCtx)
+		if err != context.DeadlineExceeded {
+			if err != nil {
+				log.Infof("%s: %T: %v", name, err, err)
+			}
+			return err
+		}
+		log.Infof("%s: %v", name, err)
+	}
+	return fmt.Errorf("%s: exceeded %d tries with a %s timeout", name, cli.attempts, cli.timeout)
+}
+
 func (cli retryingDockerClient) ContainerCreate(
 	ctx context.Context, config *container.Config, hostConfig *container.HostConfig,
-	networkingConfig *network.NetworkingConfig, containerName string,
-) (types.ContainerCreateResponse, error) {
-	for i := 0; i < cli.attempts; i++ {
-		timeoutCtx, _ := context.WithTimeout(ctx, cli.timeout)
-		ret, err := cli.APIClient.ContainerCreate(timeoutCtx, config, hostConfig, networkingConfig, containerName)
-		if err == context.DeadlineExceeded {
-			continue
-		}
-		return ret, err
-	}
-	err := fmt.Errorf("exceeded %d tries of ContainerCreate with a %s timeout", cli.attempts, cli.timeout)
-	return types.ContainerCreateResponse{}, err
+	networkingConfig *network.NetworkingConfig, containerName string) (
+	types.ContainerCreateResponse, error) {
+
+	var ret types.ContainerCreateResponse
+	return ret, cli.retry(ctx, cli.timeout, "ContainerCreate",
+		func(timeoutCtx context.Context) error {
+			var err error
+			ret, err = cli.APIClient.ContainerCreate(timeoutCtx, config, hostConfig, networkingConfig, containerName)
+			_ = ret // silence incorrect unused warning
+			return err
+		})
 }
 
 func (cli retryingDockerClient) ContainerStart(ctx context.Context, containerID string) error {
-	for i := 0; i < cli.attempts; i++ {
-		timeoutCtx, _ := context.WithTimeout(ctx, cli.timeout)
-		err := cli.APIClient.ContainerStart(timeoutCtx, containerID)
-		if err == nil {
-			return nil
-		} else if strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
-			continue
-		} else {
-			return err
-		}
-	}
-	return fmt.Errorf("exceeded %d tries of ContainerStart with a %s timeout", cli.attempts, cli.timeout)
+	return cli.retry(ctx, cli.timeout, "ContainerStart",
+		func(timeoutCtx context.Context) error {
+			return cli.APIClient.ContainerStart(timeoutCtx, containerID)
+		})
 }
 
 func (cli retryingDockerClient) ContainerRemove(ctx context.Context, options types.ContainerRemoveOptions) error {
-	for i := 0; i < cli.attempts; i++ {
-		timeoutCtx, _ := context.WithTimeout(ctx, cli.timeout)
-		err := cli.APIClient.ContainerRemove(timeoutCtx, options)
-		if err == nil {
-			return nil
-		} else if strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
-			continue
-		} else {
-			return err
-		}
-	}
-	return fmt.Errorf("exceeded %d tries of ContainerRemove with a %s timeout", cli.attempts, cli.timeout)
+	return cli.retry(ctx, cli.timeout, "ContainerRemove",
+		func(timeoutCtx context.Context) error {
+			return cli.APIClient.ContainerRemove(timeoutCtx, options)
+		})
 }
 
 func (cli retryingDockerClient) ContainerKill(ctx context.Context, containerID, signal string) error {
-	for i := 0; i < cli.attempts; i++ {
-		timeoutCtx, _ := context.WithTimeout(ctx, cli.timeout)
-		err := cli.APIClient.ContainerKill(timeoutCtx, containerID, signal)
-		if err == nil {
-			return nil
-		} else if strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
-			continue
-		} else {
+	return cli.retry(ctx, cli.timeout, "ContainerKill",
+		func(timeoutCtx context.Context) error {
+			return cli.APIClient.ContainerKill(timeoutCtx, containerID, signal)
+		})
+}
+
+func (cli retryingDockerClient) ContainerWait(ctx context.Context, containerID string) (int, error) {
+	var ret int
+	return ret, cli.retry(ctx, cli.timeout, "ContainerWait",
+		func(timeoutCtx context.Context) error {
+			var err error
+			ret, err = cli.APIClient.ContainerWait(timeoutCtx, containerID)
+			_ = ret // silence incorrect unused warning
 			return err
-		}
-	}
-	return fmt.Errorf("exceeded %d tries of ContainerKill with a %s timeout", cli.attempts, cli.timeout)
+		})
 }
 
 func (cli retryingDockerClient) ImagePull(
 	ctx context.Context, options types.ImagePullOptions, privilegeFunc client.RequestPrivilegeFunc,
 ) (io.ReadCloser, error) {
-	for i := 0; i < cli.attempts; i++ {
-		timeoutCtx, _ := context.WithTimeout(ctx, cli.timeout)
-		ret, err := cli.APIClient.ImagePull(timeoutCtx, options, privilegeFunc)
-		if err == nil {
-			return ret, nil
-		} else if strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
-			continue
-		} else {
-			return nil, err
-		}
+	// Image pulling is potentially slow. Make sure the timeout is sufficient.
+	timeout := cli.timeout
+	if minTimeout := 2 * time.Minute; timeout < minTimeout {
+		timeout = minTimeout
 	}
-	return nil, fmt.Errorf("exceeded %d tries of ImagePull with a %s timeout", cli.attempts, cli.timeout)
-}
-
-func (cli retryingDockerClient) ContainerWait(ctx context.Context, containerID string) (int, error) {
-	for i := 0; i < cli.attempts; i++ {
-		timeoutCtx, _ := context.WithTimeout(ctx, cli.timeout)
-		ret, err := cli.APIClient.ContainerWait(timeoutCtx, containerID)
-		if err == nil {
-			return ret, nil
-		} else if strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
-			continue
-		} else {
-			return 0, err
-		}
-	}
-	return 0, fmt.Errorf("exceeded %d tries of ContainerWait with a %s timeout", cli.attempts, cli.timeout)
+	var ret io.ReadCloser
+	return ret, cli.retry(ctx, timeout, "ImagePull",
+		func(timeoutCtx context.Context) error {
+			var err error
+			ret, err = cli.APIClient.ImagePull(timeoutCtx, options, privilegeFunc)
+			_ = ret // silence incorrect unused warning
+			return err
+		})
 }

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -162,8 +162,8 @@ func CreateLocal(cfg TestConfig, logDir string, stopper chan struct{}) *LocalClu
 	resilientClient := resilientDockerClient{APIClient: cli}
 	retryingClient := retryingDockerClient{
 		APIClient: resilientClient,
-		attempts:  3,
-		timeout:   time.Minute,
+		attempts:  10,
+		timeout:   10 * time.Second,
 	}
 
 	return &LocalCluster{
@@ -667,6 +667,9 @@ func (l *LocalCluster) stop() {
 	}
 	outputLogDir := l.logDir
 	for i, n := range l.Nodes {
+		if n.Container == nil {
+			continue
+		}
 		ci, err := n.Inspect()
 		crashed := err != nil || (!ci.State.Running && ci.State.ExitCode != 0)
 		maybePanic(n.Kill())


### PR DESCRIPTION
Also refactored the retry code.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5770)

<!-- Reviewable:end -->
