### PR TITLE
storage/engine: convert version to an named type

### DIFF
--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -116,7 +116,7 @@ func (r *RocksDB) Open() error {
 			humanize.IBytes(minMemtableBudget), util.IBytes(r.memtableBudget))
 	}
 
-	var ver int
+	var ver storageVersion
 	if len(r.dir) != 0 {
 		log.Infof("opening rocksdb instance at %q", r.dir)
 

--- a/storage/engine/version.go
+++ b/storage/engine/version.go
@@ -22,18 +22,24 @@ import (
 	"path/filepath"
 )
 
+type storageVersion int
+
+const (
+	versionNoFile storageVersion = iota
+	versionBeta20160331
+)
+
 const (
 	versionFilename     = "COCKROACHDB_VERSION"
 	versionFilenameTemp = "COCKROACHDB_VERSION_TEMP"
-	versionNoFile       = 0
-	versionCurrent      = 1
 	versionMinimum      = versionNoFile
+	versionCurrent      = versionBeta20160331
 )
 
 // Version stores all the version information for all stores and is used as
 // the format for the version file.
 type Version struct {
-	Version int
+	Version storageVersion
 }
 
 // getVersionFilename returns the filename for the version file stored in the
@@ -45,7 +51,7 @@ func getVersionFilename(dir string) string {
 // getVersion returns the current on disk cockroach version from the version
 // file in the passed in directory. If there is no version file yet, it
 // returns 0.
-func getVersion(dir string) (int, error) {
+func getVersion(dir string) (storageVersion, error) {
 	filename := getVersionFilename(dir)
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {


### PR DESCRIPTION
This was meant to be part of #5693.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5772)

<!-- Reviewable:end -->
