### PR TITLE
util: make 'unknown' compiler name more specific

### DIFF
--- a/util/build.go
+++ b/util/build.go
@@ -27,7 +27,7 @@ import (
 // #elif defined(__GNUC__) || defined(__GNUG__)
 // 	return "gcc " __VERSION__;
 // #else
-// 	return "unknown";
+// 	return "non-gcc, non-clang (or an unrecognized version)";
 // #endif
 // }
 import "C"


### PR DESCRIPTION
It was suggested that a user seeing 'unknown' might assume an error occured.
Being specific that it is just not the two we check for should prevent that.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5773)

<!-- Reviewable:end -->
