### PR TITLE
client: Proper timestamp initialization in aborted txns

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -514,20 +514,20 @@ func (txn *Txn) Exec(
 		panic("asked to retry or commit a txn that is already aborted")
 	}
 
-	if txn != nil {
-		// If we're looking at a brand new transaction, then communicate
-		// what should be used as initial timestamp for the KV txn created
-		// by TxnCoordSender.
-		if txn.Proto.OrigTimestamp == roachpb.ZeroTimestamp {
-			txn.Proto.OrigTimestamp = opt.MinInitialTimestamp
-		}
-	}
-
 	if opt.AutoRetry {
 		retryOptions = txn.db.txnRetryOptions
 	}
 RetryLoop:
 	for r := retry.Start(retryOptions); r.Next(); {
+		if txn != nil {
+			// If we're looking at a brand new transaction, then communicate
+			// what should be used as initial timestamp for the KV txn created
+			// by TxnCoordSender.
+			if txn.Proto.OrigTimestamp == roachpb.ZeroTimestamp {
+				txn.Proto.OrigTimestamp = opt.MinInitialTimestamp
+			}
+		}
+
 		pErr = fn(txn, &opt)
 		if txn != nil {
 			txn.retrying = true

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -490,6 +490,46 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 	}
 }
 
+// TestAbortedRetryPreservesTimestamp verifies that the minimum timestamp
+// set by the client is preserved across retries of aborted transactions.
+func TestAbortedRetryPreservesTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Create a TestSender that aborts a transaction 2 times before succeeding.
+	count := 0
+	db := newDB(newTestSender(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		if _, ok := ba.GetArg(roachpb.Put); ok {
+			count++
+			if count < 3 {
+				return nil, roachpb.NewError(&roachpb.TransactionAbortedError{})
+			}
+		}
+		return ba.CreateReply(), nil
+	}, nil))
+
+	txnClosure := func(txn *Txn, opt *TxnExecOptions) *roachpb.Error {
+		// Ensure the KV transaction is created.
+		return txn.Put("a", "b")
+	}
+
+	txn := NewTxn(context.Background(), *db)
+
+	// Request a client-defined timestamp.
+	refTimestamp := roachpb.Timestamp{WallTime: 42, Logical: 69}
+	execOpt := TxnExecOptions{AutoRetry: true, AutoCommit: true}
+	execOpt.MinInitialTimestamp = refTimestamp
+
+	// Perform the transaction.
+	if pErr := txn.Exec(execOpt, txnClosure); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	// Check the timestamp was preserved.
+	if txn.Proto.OrigTimestamp != refTimestamp {
+		t.Errorf("expected txn orig ts to be %s; got %s", refTimestamp, txn.Proto.OrigTimestamp)
+	}
+}
+
 // TestAbortTransactionOnCommitErrors verifies that transactions are
 // aborted on the correct errors.
 func TestAbortTransactionOnCommitErrors(t *testing.T) {

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
-	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 var errNoTransactionInProgress = errors.New("there is no transaction in progress")
@@ -774,8 +773,7 @@ func (e *Executor) execStmtInOpenTxn(
 	if txnState.tr != nil {
 		txnState.tr.LazyLog(stmt, true /* sensitive */)
 	}
-	result, pErr := e.execStmt(stmt, planMaker, timeutil.Now(),
-		implicitTxn /* autoCommit */)
+	result, pErr := e.execStmt(stmt, planMaker, implicitTxn /* autoCommit */)
 	if pErr != nil {
 		if txnState.tr != nil {
 			txnState.tr.LazyPrintf("ERROR: %v", pErr)
@@ -870,7 +868,7 @@ func commitSQLTransaction(txnState *txnState, p *planner,
 // the current transaction might have been committed/rolled back when this returns.
 func (e *Executor) execStmt(
 	stmt parser.Statement, planMaker *planner,
-	timestamp time.Time, autoCommit bool) (Result, *roachpb.Error) {
+	autoCommit bool) (Result, *roachpb.Error) {
 	var result Result
 	plan, pErr := planMaker.makePlan(stmt, autoCommit)
 	if pErr != nil {

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -215,7 +215,7 @@ func TestTxnRestart(t *testing.T) {
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
-CREATE TABLE t.test (k TEXT PRIMARY KEY, v TEXT);
+CREATE TABLE t.test (k TEXT PRIMARY KEY, v TEXT, t DECIMAL);
 `); err != nil {
 		t.Fatal(err)
 	}
@@ -229,6 +229,9 @@ CREATE TABLE t.test (k TEXT PRIMARY KEY, v TEXT);
 		"hooly":     2,
 		"josephine": 2,
 		"laureal":   2,
+	}
+	magicVals.abortCounts = map[string]int{
+		"boulanger": 2,
 	}
 	magicVals.endTxnRestartCounts = map[string]int{
 		"boulanger": 2,
@@ -246,16 +249,18 @@ CREATE TABLE t.test (k TEXT PRIMARY KEY, v TEXT);
 
 	// Test that implicit txns - txns for which we see all the statements and prefixes
 	// of txns (statements batched together with the BEGIN stmt) - are retried.
+	// We also exercise the SQL cluster logical timestamp in here, because
+	// this must be properly propagated across retries.
 	if _, err := sqlDB.Exec(`
-INSERT INTO t.test (k, v) VALUES ('a', 'boulanger');
+INSERT INTO t.test (k, v, t) VALUES ('a', 'boulanger', cluster_logical_timestamp());
 BEGIN;
-INSERT INTO t.test (k, v) VALUES ('c', 'dromedary');
-INSERT INTO t.test (k, v) VALUES ('e', 'fajita');
+INSERT INTO t.test (k, v, t) VALUES ('c', 'dromedary', cluster_logical_timestamp());
+INSERT INTO t.test (k, v, t) VALUES ('e', 'fajita', cluster_logical_timestamp());
 END;
-INSERT INTO t.test (k, v) VALUES ('g', 'hooly');
+INSERT INTO t.test (k, v, t) VALUES ('g', 'hooly', cluster_logical_timestamp());
 BEGIN;
-INSERT INTO t.test (k, v) VALUES ('i', 'josephine');
-INSERT INTO t.test (k, v) VALUES ('k', 'laureal');
+INSERT INTO t.test (k, v, t) VALUES ('i', 'josephine', cluster_logical_timestamp());
+INSERT INTO t.test (k, v, t) VALUES ('k', 'laureal', cluster_logical_timestamp());
 `); err != nil {
 		t.Fatal(err)
 	}
@@ -300,7 +305,7 @@ BEGIN;
 	}
 
 	// Continue the txn in a new request, which is not retriable.
-	_, err := sqlDB.Exec("INSERT INTO t.test (k, v) VALUES ('g', 'hooly')")
+	_, err := sqlDB.Exec("INSERT INTO t.test (k, v, t) VALUES ('g', 'hooly', cluster_logical_timestamp())")
 	if !testutils.IsError(
 		err, "encountered previous write with future timestamp") {
 		t.Errorf("didn't get expected injected error. Got: %s", err)


### PR DESCRIPTION
Fixes #5588.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5776)

<!-- Reviewable:end -->
