### PR TITLE
engine: remove unused C.DBCompactRange

### DIFF
--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1336,26 +1336,6 @@ DBStatus DBFlush(DBEngine* db) {
   return ToDBStatus(db->rep->Flush(options));
 }
 
-DBStatus DBCompactRange(DBEngine* db, DBKey* start, DBKey* end) {
-  std::string sbuf;
-  std::string ebuf;
-  rocksdb::Slice s;
-  rocksdb::Slice e;
-  rocksdb::Slice* sPtr = NULL;
-  rocksdb::Slice* ePtr = NULL;
-  if (start != NULL) {
-    sPtr = &s;
-    sbuf = EncodeKey(*start);
-    s = sbuf;
-  }
-  if (end != NULL) {
-    ePtr = &e;
-    ebuf = EncodeKey(*end);
-    e = ebuf;
-  }
-  return ToDBStatus(db->rep->CompactRange(rocksdb::CompactRangeOptions(), sPtr, ePtr));
-}
-
 uint64_t DBApproximateSize(DBEngine* db, DBKey start, DBKey end) {
   std::string s = EncodeKey(start);
   std::string e = EncodeKey(end);

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -80,13 +80,6 @@ void DBClose(DBEngine* db);
 // complete.
 DBStatus DBFlush(DBEngine* db);
 
-// Compacts the underlying storage for the key range
-// [start,end]. start==NULL is treated as a key before all keys in the
-// database. end==NULL is treated as a key after all keys in the
-// database. DBCompactRange(db, NULL, NULL) will compact the entire
-// database.
-DBStatus DBCompactRange(DBEngine* db, DBKey* start, DBKey* end);
-
 // Returns the approximate file system spaced used by keys in the
 // range [start,end].
 uint64_t DBApproximateSize(DBEngine* db, DBKey start, DBKey end);


### PR DESCRIPTION
Last usage from go was removed in #5597

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5780)

<!-- Reviewable:end -->
