### PR TITLE
sql: change table@foo semantics

### DIFF
--- a/sql/descriptor_mutation_test.go
+++ b/sql/descriptor_mutation_test.go
@@ -401,7 +401,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo (v));
 	}
 
 	starQuery := `SELECT * FROM t.test`
-	indexQuery := `SELECT * FROM t.test@foo`
+	indexQuery := `SELECT v FROM t.test@foo`
 	// See the effect of the operations depending on the state.
 	for _, state := range []csql.DescriptorMutation_State{csql.DescriptorMutation_DELETE_ONLY, csql.DescriptorMutation_WRITE_ONLY} {
 		// Init table with some entries.

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -82,19 +82,19 @@ type analyzeOrderingFn func(indexOrdering orderingInfo) (matchingCols, totalCols
 // If preferOrderMatching is true, we prefer an index that matches the desired
 // ordering completely, even if it is not a covering index.
 func selectIndex(s *scanNode, analyzeOrdering analyzeOrderingFn, preferOrderMatching bool) planNode {
-	if s.desc.isEmpty() || (s.filter == nil && analyzeOrdering == nil) {
-		// No table or no where-clause and no ordering.
+	if s.desc.isEmpty() || (s.filter == nil && analyzeOrdering == nil && s.specifiedIndex == nil) {
+		// No table or no where-clause, no ordering, and no specified index.
 		s.initOrdering(0)
 		return s
 	}
 
 	candidates := make([]*indexInfo, 0, len(s.desc.Indexes)+1)
-	if s.isSecondaryIndex {
+	if s.specifiedIndex != nil {
 		// An explicit secondary index was requested. Only add it to the candidate
 		// indexes list.
 		candidates = append(candidates, &indexInfo{
 			desc:  &s.desc,
-			index: s.index,
+			index: s.specifiedIndex,
 		})
 	} else {
 		candidates = append(candidates, &indexInfo{

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -725,7 +725,7 @@ func (v *indexInfo) isCoveringIndex(scan *scanNode) bool {
 
 	for i, needed := range scan.valNeededForCol {
 		if needed {
-			colID := scan.visibleCols[i].ID
+			colID := v.desc.Columns[i].ID
 			if !v.index.containsColumnID(colID) {
 				return false
 			}

--- a/sql/join.go
+++ b/sql/join.go
@@ -69,7 +69,7 @@ func makeIndexJoin(indexScan *scanNode, exactPrefix int) *indexJoinNode {
 		table.valNeededForCol[i] = indexScan.valNeededForCol[i]
 
 		// For the index node, we set valNeededForCol for columns that are part of the index.
-		id := indexScan.visibleCols[i].ID
+		id := indexScan.desc.Columns[i].ID
 		_, found := colIDtoRowIndex[id]
 		indexScan.valNeededForCol[i] = found
 	}

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -44,7 +44,7 @@ func makeReturningHelper(p *planner, r parser.ReturningExprs,
 
 	rh.results.columns = make([]ResultColumn, 0, len(r))
 	table := tableInfo{
-		columns: makeResultColumns(tablecols, 0),
+		columns: makeResultColumns(tablecols),
 		alias:   alias,
 	}
 	rh.qvals = make(qvalMap)

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -348,7 +348,7 @@ CREATE INDEX foo ON t.test (v)
 		descKey: descKey,
 		desc:    desc,
 	}
-	indexQuery := `SELECT * FROM t.test@foo`
+	indexQuery := `SELECT v FROM t.test@foo`
 	_ = mTest.checkQueryResponse(indexQuery, [][]string{{"b"}, {"d"}})
 
 	// Ensure that the version has been incremented.
@@ -403,7 +403,7 @@ ALTER INDEX t.test@foo RENAME TO ufo
 		}
 	}
 	for i := 0; i < count; i++ {
-		indexQuery := fmt.Sprintf(`SELECT * FROM t.test@foo%d`, i)
+		indexQuery := fmt.Sprintf(`SELECT v FROM t.test@foo%d`, i)
 		_ = mTest.checkQueryResponse(indexQuery, [][]string{{"b"}, {"d"}})
 	}
 }

--- a/sql/testdata/alter_table
+++ b/sql/testdata/alter_table
@@ -31,7 +31,7 @@ statement ok
 ALTER TABLE t ADD CONSTRAINT foo UNIQUE (b)
 
 query ITTT
-EXPLAIN (DEBUG) SELECT * FROM t@foo
+EXPLAIN (DEBUG) SELECT b FROM t@foo
 ----
 0 /t/foo/NULL /1 ROW
 

--- a/sql/testdata/explain_debug
+++ b/sql/testdata/explain_debug
@@ -68,10 +68,10 @@ EXPLAIN (DEBUG) SELECT * FROM abc ORDER BY b DESC
 query ITTT
 EXPLAIN (DEBUG) SELECT * FROM abc ORDER BY b DESC LIMIT 1 OFFSET 1
 ----
-0  /abc/foo/'two'          /2    PARTIAL   
-0  /abc/primary/2/'two'    NULL  FILTERED  
-1  /abc/foo/'three'        /3    PARTIAL   
-1  /abc/primary/3/'three'  NULL  ROW       
+0  /abc/foo/'two'          /2    PARTIAL
+0  /abc/primary/2/'two'    NULL  FILTERED
+1  /abc/foo/'three'        /3    PARTIAL
+1  /abc/primary/3/'three'  NULL  ROW
 
 query ITTT
 EXPLAIN (DEBUG) SELECT * FROM abc WHERE a = 2
@@ -79,14 +79,14 @@ EXPLAIN (DEBUG) SELECT * FROM abc WHERE a = 2
 0  /abc/primary/2/'two'  NULL  ROW
 
 query ITTT
-EXPLAIN (DEBUG) SELECT * FROM abc@foo
+EXPLAIN (DEBUG) SELECT b FROM abc@foo
 ----
 0  /abc/foo/'one'    /1  ROW
 1  /abc/foo/'three'  /3  ROW
 2  /abc/foo/'two'    /2  ROW
 
 query ITTT
-EXPLAIN (DEBUG) SELECT * FROM abc@bar
+EXPLAIN (DEBUG) SELECT a FROM abc@bar
 ----
 0  /abc/bar/1/'one'    NULL  ROW
 1  /abc/bar/2/'two'    NULL  ROW

--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -287,7 +287,7 @@ EXPLAIN (DEBUG) SELECT * FROM kv5@a
 0 /kv5/a/NULL/'a' ROW
 
 query TT
-SELECT * FROM kv5@a
+SELECT v, k FROM kv5@a
 ----
 NULL a
 

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -370,21 +370,21 @@ INSERT INTO abcd VALUES (1, 4, 2, 3), (2, 3, 4, 1), (3, 2, 1, 2), (4, 4, 1, 1)
 
 # The following tests verify we recognize that sorting is not necessary
 query ITT
-EXPLAIN SELECT * FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
+EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
 0 scan abcd@abc /1/4-/1/5
 
 query ITT
-EXPLAIN SELECT * FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
+EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
 0 scan abcd@abc /1/4-/1/5
 
 query ITT
-EXPLAIN SELECT * FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
+EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
 0 scan abcd@abc /1/4-/1/5
 
 query ITT
-EXPLAIN SELECT * FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
+EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
 0 scan abcd@abc /1/4-/1/5

--- a/sql/testdata/select
+++ b/sql/testdata/select
@@ -203,7 +203,7 @@ query error multiple LIMIT clauses not allowed
 ((SELECT a FROM t LIMIT 1)) LIMIT 1
 
 query II
-SELECT * FROM xyzw@foo
+SELECT z, y FROM xyzw@foo
 ----
 3 2
 6 5
@@ -214,7 +214,7 @@ SELECT z FROM test.xyzw@foo WHERE y = 5
 6
 
 query I
-SELECT foo.y FROM test.xyzw@foo WHERE z = 3
+SELECT xyzw.y FROM test.xyzw@foo WHERE z = 3
 ----
 2
 
@@ -224,8 +224,10 @@ SELECT z FROM test.unknown@foo WHERE y = 5
 query error index "unknown" not found
 SELECT z FROM test.xyzw@unknown WHERE y = 5
 
-query error qualified name "w" not found
+query I
 SELECT w FROM test.xyzw@foo WHERE y = 5
+----
+7
 
 statement ok
 CREATE TABLE boolean_table (

--- a/sql/testdata/select_index_hints
+++ b/sql/testdata/select_index_hints
@@ -1,0 +1,142 @@
+statement ok
+CREATE TABLE abcd (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  INDEX b (b),
+  INDEX cd (c,d),
+  UNIQUE INDEX bcd (b,c,d)
+)
+
+statement ok
+INSERT INTO abcd VALUES (10, 11, 12, 13), (20, 21, 22, 23), (30, 31, 32, 33), (40, 41, 42, 43)
+
+# No hint
+
+query IIII
+SELECT * FROM abcd WHERE a >= 20 AND a <= 30
+----
+20 21 22 23
+30 31 32 33
+
+query ITT
+EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
+----
+0 scan       abcd@primary /20-/31
+
+# Force primary
+
+query IIII
+SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
+----
+20 21 22 23
+30 31 32 33
+
+query ITT
+EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
+----
+0 scan       abcd@primary /20-/31
+
+# Force index b
+
+query IIII
+SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
+----
+20 21 22 23
+30 31 32 33
+
+query ITT
+EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
+----
+0 index-join
+1 scan       abcd@b       -
+1 scan       abcd@primary
+
+# Force index cd
+
+query IIII
+SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
+----
+20 21 22 23
+30 31 32 33
+
+query ITT
+EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
+----
+0 index-join
+1 scan       abcd@cd      -
+1 scan       abcd@primary
+
+# Force index bcd
+
+query ITT
+EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
+----
+0 scan       abcd@bcd     -
+
+query IIII
+SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
+----
+20 21 22 23
+30 31 32 33
+
+# Force index b (covering)
+
+query ITT
+EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
+----
+0 scan       abcd@b       -
+
+# Force index b (non-covering due to WHERE clause)
+
+query ITT
+EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
+----
+0 index-join
+1 scan       abcd@b       -
+1 scan       abcd@primary
+
+# No hint, should be using index cd
+
+query II
+SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
+----
+22 23
+32 33
+
+query ITT
+EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
+----
+0 scan       abcd@cd /20-/40
+
+# Force no index
+
+query II
+SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
+----
+22 23
+32 33
+
+query ITT
+EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
+----
+0 scan       abcd@primary -
+
+# Force index b
+
+query II
+SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
+----
+22 23
+32 33
+
+query ITT
+EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
+----
+0 index-join
+1 scan       abcd@b       -
+1 scan       abcd@primary
+
+query error index \"badidx\" not found
+SELECT * FROM abcd@badidx

--- a/sql/testdata/storing
+++ b/sql/testdata/storing
@@ -48,7 +48,7 @@ statement ok
 CREATE INDEX d_idx ON t (d) STORING (a, b)
 
 query ITTT
-EXPLAIN (DEBUG) SELECT * FROM t@d_idx
+EXPLAIN (DEBUG) SELECT a, b, d FROM t@d_idx
 ----
 0 /t/d_idx/4/1/2 NULL ROW
 


### PR DESCRIPTION
Changing `table@foo` semantics to behave the same as `table` but force the use
of the given index, as per the index_hints RFC.

Part of #5625.

Second commit is minor cleanup, easier to review separately.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5785)

<!-- Reviewable:end -->
