### PR TITLE
gossip: Fix data race in TestGossipStorage.

### DIFF
--- a/gossip/storage_test.go
+++ b/gossip/storage_test.go
@@ -49,6 +49,12 @@ func (ts *testStorage) isWrite() bool {
 	return ts.write
 }
 
+func (ts *testStorage) Info() gossip.BootstrapInfo {
+	ts.Lock()
+	defer ts.Unlock()
+	return ts.info
+}
+
 func (ts *testStorage) Len() int {
 	ts.Lock()
 	defer ts.Unlock()
@@ -193,7 +199,7 @@ func TestGossipStorage(t *testing.T) {
 	})
 
 	if expected, actual := len(network.Nodes)-1 /* -1 is ourself */, ts2.Len(); expected != actual {
-		t.Fatalf("expected %v, got %v (info: %#v)", expected, actual, ts2.info.Addresses)
+		t.Fatalf("expected %v, got %v (info: %#v)", expected, actual, ts2.Info().Addresses)
 	}
 
 }


### PR DESCRIPTION
Fixes #5782.

The data race was caused by concurrent access to the `testStorage.info`
field. One of the accesses of the field was during gossip bootstrapping
in `WriteBootstrapInfo`, where the `testStorage` was under lock. The
other access was during the call to `test.Fatalf` on a failed test.
This means that the test would have failed regardless, but we still can
remove the race entirely. The issue of the test failing is unrelated,
but should be inspected if it pops up again, as the test may be flaky.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5786)

<!-- Reviewable:end -->
