### PR TITLE
Fix gossip skip its own nodeDesc when updating nodeDescs cache 

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -428,11 +428,16 @@ func (g *Gossip) updateNodeAddress(_ string, content roachpb.Value) {
 		g.outgoing.setMaxSize(maxPeers)
 	}()
 
-	// Skip if the node has already been seen or it's our own address.
-	if _, ok := g.nodeDescs[desc.NodeID]; ok || desc.Address == g.is.NodeAddr {
+	// Skip if the node has already been seen.
+	if _, ok := g.nodeDescs[desc.NodeID]; ok {
 		return
 	}
 	g.nodeDescs[desc.NodeID] = &desc
+
+	// Skip if it's our own address.
+	if desc.Address == g.is.NodeAddr {
+		return
+	}
 
 	// Add this new node address (if it's not already there) to our list
 	// of resolvers so we can keep connecting to gossip if the original


### PR DESCRIPTION
This commit remove the gossip NodeAddr filter when update nodeDescs cache,so that its own nodeDesc could be added into nodeDescs cache.
Because the gossip's own nodeDesc is used frequently,so adding it to the nodeDesc can promote performance  obviously.
Of course,I still add the filter before maybeAddResolver and maybeAddBootstrapAddress in the updateNodeAddress method.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5791)

<!-- Reviewable:end -->
