### PR TITLE
storage: fix newReplicaCorruptionError(nil)

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1893,6 +1893,9 @@ func newReplicaCorruptionError(errs ...error) *roachpb.ReplicaCorruptionError {
 	var errMsg string
 	for i := range errs {
 		err := errs[len(errs)-i-1]
+		if err == nil {
+			continue
+		}
 		if len(errMsg) == 0 {
 			errMsg = err.Error()
 		} else {

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -4658,5 +4659,17 @@ func TestComputeVerifyChecksum(t *testing.T) {
 	}
 	if panicked {
 		t.Fatal("VerifyChecksum panicked")
+	}
+}
+
+func TestNewReplicaCorruptionError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	err := newReplicaCorruptionError(errors.New("foo"), nil, errors.New("bar"), nil)
+	if cur, exp := err.String(), `error_msg:"foo (caused by bar)"`; !strings.Contains(cur, exp) {
+		t.Fatalf("expected '%s' contained in '%s'", exp, cur)
+	}
+	err = newReplicaCorruptionError(nil, nil, nil)
+	if exp, act := `error_msg:""`, err.String(); !strings.Contains(act, exp) {
+		t.Fatalf("expected '%s' contained in '%s'", exp, act)
 	}
 }


### PR DESCRIPTION
Previous code tried to call `.Error()` on `error(nil)`.

Fixes #5792 (as in, we'll get to see the real error next time it happens).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5793)

<!-- Reviewable:end -->
