### PR TITLE
sql: don't mark subqueries as aggregated

### DIFF
--- a/sql/group.go
+++ b/sql/group.go
@@ -537,11 +537,14 @@ type isAggregateVisitor struct {
 }
 
 func (v *isAggregateVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
-	if t, ok := expr.(*parser.FuncExpr); ok {
+	switch t := expr.(type) {
+	case *parser.FuncExpr:
 		if _, ok := aggregates[strings.ToLower(string(t.Name.Base))]; ok {
 			v.aggregated = true
 			return false, expr
 		}
+	case *parser.Subquery:
+		return false, expr
 	}
 
 	return true, expr

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -613,3 +613,9 @@ query RRR
 SELECT STDDEV(1::int), STDDEV(1::float), STDDEV(1::decimal)
 ----
 NULL NULL NULL
+
+# Ensure subqueries don't trigger aggregation.
+query B
+SELECT x > (SELECT avg(0)) FROM xyz LIMIT 1
+----
+true


### PR DESCRIPTION
Previously, if a subquery used an aggregation function it was marked as
aggregated. This fixes a case in sqllogic select1.test.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5794)

<!-- Reviewable:end -->
