### PR TITLE
storage: A tiny comment fix to mvccPutInternal on seq/batch_index retry

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -987,8 +987,8 @@ func mvccPutInternal(
 					txn.Epoch, meta.Txn.Epoch, txn.ID)
 			} else if txn.Sequence < meta.Txn.Sequence ||
 				(txn.Sequence == meta.Txn.Sequence && txn.BatchIndex <= meta.Txn.BatchIndex) {
-				// Replay error if we encounter an older sequence number or
-				// the same (or earlier) batch index for the same sequence.
+				// Replay error if we encounter a newer sequence number or
+				// the same (or newer) batch index for the same sequence.
 				return roachpb.NewTransactionRetryError()
 			}
 			// Make sure we process valueFn before clearing any earlier


### PR DESCRIPTION
   Replay error if we encounter an older sequence number
-> Replay error if we encounter a newer sequence number

   the same (or earlier) batch index
-> the same (or newer) batch index

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5798)

<!-- Reviewable:end -->
