### PR TITLE
storage: Remove a comment on gossip config with a write command

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1513,7 +1513,7 @@ func (r *Replica) applyRaftCommand(idKey storagebase.CmdIDKey, ctx context.Conte
 	}
 
 	// On successful write commands handle write-related triggers including
-	// splitting and config gossip updates.
+	// splitting.
 	if rErr == nil && ba.IsWrite() {
 		// If the commit succeeded, potentially add range to split queue.
 		r.maybeAddToSplitQueue()


### PR DESCRIPTION
We no longer update config gossip when applyRaftCommand() processes a write command.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5824)

<!-- Reviewable:end -->
