### PR TITLE
sql: only fast-path delete for scans

### DIFF
--- a/sql/testdata/delete
+++ b/sql/testdata/delete
@@ -116,4 +116,8 @@ SELECT k, v FROM unindexed
 ----
 k v
 
+statement ok
+CREATE TABLE indexed (id int primary key, value int, other int, index (value));
 
+statement ok
+DELETE FROM indexed WHERE value = 5;


### PR DESCRIPTION
Fast-path only handles scans for now -- we could probably be smarter with index-joins as well
but it might not be worth the effort since this is dead-code-walking: this somewhat special case
goes away when we push down / distribute more of SQL.

As is, the invalid type assertion was causing a panic.

Fixes #5808.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5840)

<!-- Reviewable:end -->
