### PR TITLE
acceptance: increase timeout to 10m

### DIFF
--- a/acceptance/run.sh
+++ b/acceptance/run.sh
@@ -6,4 +6,4 @@ source $(dirname $0)/../build/init-docker.sh
 $(dirname $0)/../build/builder.sh make install GOFLAGS='-tags clockoffset'
 
 set -x
-go test -tags acceptance ./acceptance ${GOFLAGS-} -run "${TESTS-.}" -timeout ${TESTTIMEOUT-5m} ${TESTFLAGS--v -nodes 3}
+go test -tags acceptance ./acceptance ${GOFLAGS-} -run "${TESTS-.}" -timeout ${TESTTIMEOUT-10m} ${TESTFLAGS--v -nodes 3}


### PR DESCRIPTION
Timeouts are common on CI, and even successful runs are often taking
more than 4:30.

This may be a temporary measure until we can figure out why the tests take as long as they do.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5843)

<!-- Reviewable:end -->
