### PR TITLE
build: hack around unnecessary docker image pulls on circleci

### DIFF
--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -72,7 +72,37 @@ func (c Container) Name() string {
 	return c.name
 }
 
+func hasImage(l *LocalCluster, name, tag string) bool {
+	images, err := l.client.ImageList(context.Background(), types.ImageListOptions{MatchName: name})
+	if err != nil {
+		log.Fatal(err)
+	}
+	nameAndTag := name + ":" + tag
+	for _, image := range images {
+		for _, repoTag := range image.RepoTags {
+			// The Image.RepoTags field contains strings of the form <repo>:<tag>.
+			if nameAndTag == repoTag {
+				return true
+			}
+		}
+	}
+	for _, image := range images {
+		for _, tag := range image.RepoTags {
+			log.Infof("ImageList %s %s", tag, image.ID)
+		}
+	}
+	return false
+}
+
 func pullImage(l *LocalCluster, options types.ImagePullOptions) error {
+	// Hack: on CircleCI, docker pulls the image on the first access from an
+	// acceptance test even though that image is already present. So we first
+	// check to see if our image is present in order to avoid this slowness.
+	if hasImage(l, options.ImageID, options.Tag) {
+		log.Infof("ImagePull %s:%s already exists", options.ImageID, options.Tag)
+		return nil
+	}
+
 	log.Infof("ImagePull %s:%s starting", options.ImageID, options.Tag)
 	defer log.Infof("ImagePull %s:%s complete", options.ImageID, options.Tag)
 
@@ -417,6 +447,19 @@ func (cli retryingDockerClient) ContainerWait(ctx context.Context, containerID s
 		func(timeoutCtx context.Context) error {
 			var err error
 			ret, err = cli.APIClient.ContainerWait(timeoutCtx, containerID)
+			_ = ret // silence incorrect unused warning
+			return err
+		})
+}
+
+func (cli retryingDockerClient) ImageList(
+	ctx context.Context, options types.ImageListOptions,
+) ([]types.Image, error) {
+	var ret []types.Image
+	return ret, cli.retry(ctx, cli.timeout, "ImageList",
+		func(timeoutCtx context.Context) error {
+			var err error
+			ret, err = cli.APIClient.ImageList(timeoutCtx, options)
 			_ = ret // silence incorrect unused warning
 			return err
 		})


### PR DESCRIPTION
Before `TestAdminLossOfQuorum` was taking ~45-50s. After it is taking ~6-7s.

Fixes #5849.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5854)

<!-- Reviewable:end -->
