### PR TITLE
storage: don't consider incomplete stores as replication targets

### DIFF
--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -183,13 +183,13 @@ func mockStorePool(storePool *StorePool, aliveStoreIDs, deadStoreIDs []roachpb.S
 	for _, storeID := range aliveStoreIDs {
 		storePool.stores[storeID] = &storeDetail{
 			dead: false,
-			desc: roachpb.StoreDescriptor{StoreID: storeID},
+			desc: &roachpb.StoreDescriptor{StoreID: storeID},
 		}
 	}
 	for _, storeID := range deadStoreIDs {
 		storePool.stores[storeID] = &storeDetail{
 			dead: true,
-			desc: roachpb.StoreDescriptor{StoreID: storeID},
+			desc: &roachpb.StoreDescriptor{StoreID: storeID},
 		}
 	}
 }

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -41,9 +41,8 @@ const (
 )
 
 type storeDetail struct {
-	desc            roachpb.StoreDescriptor
+	desc            *roachpb.StoreDescriptor
 	dead            bool
-	gossiped        bool // Was this store updated via gossip?
 	timesDied       int
 	foundDeadOn     roachpb.Timestamp
 	lastUpdatedTime roachpb.Timestamp // This is also the priority for the queue.
@@ -60,10 +59,9 @@ func (sd *storeDetail) markDead(foundDeadOn roachpb.Timestamp) {
 
 // markAlive sets the storeDetail to alive(active) and saves the updated time
 // and descriptor.
-func (sd *storeDetail) markAlive(foundAliveOn roachpb.Timestamp, storeDesc roachpb.StoreDescriptor, gossiped bool) {
+func (sd *storeDetail) markAlive(foundAliveOn roachpb.Timestamp, storeDesc *roachpb.StoreDescriptor) {
 	sd.desc = storeDesc
 	sd.dead = false
-	sd.gossiped = gossiped
 	sd.lastUpdatedTime = foundAliveOn
 }
 
@@ -179,7 +177,7 @@ func (sp *StorePool) storeGossipUpdate(_ string, content roachpb.Value) {
 		detail = &storeDetail{index: -1}
 		sp.stores[storeDesc.StoreID] = detail
 	}
-	detail.markAlive(sp.clock.Now(), storeDesc, true)
+	detail.markAlive(sp.clock.Now(), &storeDesc)
 	sp.queue.enqueue(detail)
 }
 
@@ -224,26 +222,27 @@ func (sp *StorePool) start(stopper *stop.Stopper) {
 	})
 }
 
-// GetStoreDescriptor returns the store detail for the given storeID.
-func (sp *StorePool) getStoreDetail(storeID roachpb.StoreID) storeDetail {
-	sp.mu.Lock()
-	defer sp.mu.Unlock()
-
+// getStoreDetailLocked returns the store detail for the given storeID.
+// The lock must be held *in write mode* even though this looks like a
+// read-only method.
+func (sp *StorePool) getStoreDetailLocked(storeID roachpb.StoreID) storeDetail {
 	detail, ok := sp.stores[storeID]
 	if !ok {
-		// We don't seem to have that store yet, create a new detail and add
-		// it to the queue. This will give it the full timeout before it is
-		// considered dead.
+		// We don't have this store yet (this is normal when we're
+		// starting up and don't have full information from the gossip
+		// network). The first time this occurs, presume the store is
+		// alive, but start the clock so it will become dead if enough
+		// time passes without updates from gossip.
 		detail = &storeDetail{index: -1}
 		sp.stores[storeID] = detail
-		detail.markAlive(sp.clock.Now(), roachpb.StoreDescriptor{StoreID: storeID}, false)
+		detail.markAlive(sp.clock.Now(), nil)
 		sp.queue.enqueue(detail)
 	}
 
 	return *detail
 }
 
-// GetStoreDescriptor returns the latest store descriptor for the given
+// getStoreDescriptor returns the latest store descriptor for the given
 // storeID.
 func (sp *StorePool) getStoreDescriptor(storeID roachpb.StoreID) *roachpb.StoreDescriptor {
 	sp.mu.RLock()
@@ -254,21 +253,18 @@ func (sp *StorePool) getStoreDescriptor(storeID roachpb.StoreID) *roachpb.StoreD
 		return nil
 	}
 
-	// Only return gossiped stores.
-	if !detail.gossiped {
-		return nil
-	}
-
-	desc := detail.desc
-	return &desc
+	return detail.desc
 }
 
 // deadReplicas returns any replicas from the supplied slice that are
 // located on dead stores.
 func (sp *StorePool) deadReplicas(repls []roachpb.ReplicaDescriptor) []roachpb.ReplicaDescriptor {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+
 	var deadReplicas []roachpb.ReplicaDescriptor
 	for _, repl := range repls {
-		if sp.getStoreDetail(repl.StoreID).dead {
+		if sp.getStoreDetailLocked(repl.StoreID).dead {
 			deadReplicas = append(deadReplicas, repl)
 		}
 	}
@@ -325,11 +321,10 @@ func (sp *StorePool) getStoreList(required roachpb.Attributes, deterministic boo
 	var aliveStoreCount int
 	for _, storeID := range storeIDs {
 		detail := sp.stores[roachpb.StoreID(storeID)]
-		if !detail.dead && detail.gossiped {
+		if !detail.dead && detail.desc != nil {
 			aliveStoreCount++
 			if required.IsSubset(*detail.desc.CombinedAttrs()) {
-				desc := detail.desc
-				sl.add(&desc)
+				sl.add(detail.desc)
 			}
 		}
 	}

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -263,7 +263,7 @@ func (sp *StorePool) getStoreDescriptor(storeID roachpb.StoreID) *roachpb.StoreD
 	return &desc
 }
 
-// findDeadReplicas returns any replicas from the supplied slice that are
+// deadReplicas returns any replicas from the supplied slice that are
 // located on dead stores.
 func (sp *StorePool) deadReplicas(repls []roachpb.ReplicaDescriptor) []roachpb.ReplicaDescriptor {
 	var deadReplicas []roachpb.ReplicaDescriptor
@@ -325,7 +325,7 @@ func (sp *StorePool) getStoreList(required roachpb.Attributes, deterministic boo
 	var aliveStoreCount int
 	for _, storeID := range storeIDs {
 		detail := sp.stores[roachpb.StoreID(storeID)]
-		if !detail.dead {
+		if !detail.dead && detail.gossiped {
 			aliveStoreCount++
 			if required.IsSubset(*detail.desc.CombinedAttrs()) {
 				desc := detail.desc

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -294,11 +294,13 @@ func TestStorePoolGetStoreDetails(t *testing.T) {
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(uniqueStore, t)
 
-	if detail := sp.getStoreDetail(roachpb.StoreID(1)); detail.dead {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	if detail := sp.getStoreDetailLocked(roachpb.StoreID(1)); detail.dead {
 		t.Errorf("Present storeDetail came back as dead, expected it to be alive. %+v", detail)
 	}
 
-	if detail := sp.getStoreDetail(roachpb.StoreID(2)); detail.dead {
+	if detail := sp.getStoreDetailLocked(roachpb.StoreID(2)); detail.dead {
 		t.Errorf("Absent storeDetail came back as dead, expected it to be alive. %+v", detail)
 	}
 }


### PR DESCRIPTION
The store pool may contain references to incomplete stores that are not
yet considered dead, but these stores should not actually be used by the
replica allocator.

Fixes #5844

storage: make storeDetail.desc nullable
This gives incomplete storeDetails a clearly-invalid nil pointer instead
of a partial protobuf which can be used accidentally (as in #5844), and
removes the need for a separate boolean.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5856)

<!-- Reviewable:end -->
