### PR TITLE
sql: raise error for invalid precision and width of decimal columns

### DIFF
--- a/sql/table.go
+++ b/sql/table.go
@@ -18,6 +18,7 @@ package sql
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -172,6 +173,17 @@ func makeColumnDefDescs(d *parser.ColumnTableDef) (*ColumnDescriptor, *IndexDesc
 		colDatumType = parser.DummyBytes
 	default:
 		return nil, nil, util.Errorf("unexpected type %T", t)
+	}
+
+	if col.Type.Kind == ColumnType_DECIMAL {
+		switch {
+		case col.Type.Precision == 0 && col.Type.Width > 0:
+			// TODO (seif): Find right range for error message.
+			return nil, nil, errors.New("invalid NUMERIC precision 0")
+		case col.Type.Precision < col.Type.Width:
+			return nil, nil, fmt.Errorf("NUMERIC scale %d must be between 0 and precision %d",
+				col.Type.Width, col.Type.Precision)
+		}
 	}
 
 	if d.DefaultExpr != nil {

--- a/sql/table_test.go
+++ b/sql/table_test.go
@@ -54,8 +54,8 @@ func TestMakeTableDescColumns(t *testing.T) {
 			true,
 		},
 		{
-			"DECIMAL(5,6)",
-			ColumnType{Kind: ColumnType_DECIMAL, Precision: 5, Width: 6},
+			"DECIMAL(6,5)",
+			ColumnType{Kind: ColumnType_DECIMAL, Precision: 6, Width: 5},
 			true,
 		},
 		{

--- a/sql/testdata/table
+++ b/sql/testdata/table
@@ -158,3 +158,9 @@ users primary true   1   id     ASC       false
 users foo     false  1   name   ASC       false
 users bar     true   1   id     ASC       false
 users bar     true   2   name   ASC       false
+
+statement error invalid NUMERIC precision 0
+CREATE TABLE test.d (x DECIMAL(0, 2))
+
+statement error NUMERIC scale 4 must be between 0 and precision 2
+CREATE TABLE test.d (x DECIMAL(2, 4))


### PR DESCRIPTION
DECIMAL should not allow a scale if precision = 0 and not allow
a scale > precision.

Fixes #5813

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5866)

<!-- Reviewable:end -->
