### PR TITLE
storage: Use RunAsyncTask instead of RunWorker to acquire lease

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -451,7 +451,7 @@ func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) <-chan *roachp
 		return llChan
 	}
 
-	r.store.Stopper().RunWorker(func() {
+	if !r.store.Stopper().RunAsyncTask(func() {
 		pErr := func() *roachpb.Error {
 			// TODO(Tobias): get duration from configuration, either as a config flag
 			// or, later, dynamically adjusted.
@@ -509,7 +509,11 @@ func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) <-chan *roachp
 			llChan <- pErr
 		}
 		r.mu.llChans = r.mu.llChans[:0]
-	})
+	}) {
+		// We failed to start the asynchronous task.
+		llChan <- roachpb.NewErrorf("shutting down")
+		return llChan
+	}
 
 	r.mu.llChans = append(r.mu.llChans, llChan)
 	return llChan


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5873)

<!-- Reviewable:end -->
