### PR TITLE
build: remove build number from circleci issue titles

### DIFF
--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -96,7 +96,7 @@ prepare_artifacts() {
       fi
 
       # JSON monster to post the issue.
-      post issues "{ \"title\": \"circleci: failed tests (${CIRCLE_BUILD_NUM}): ${FAILEDTESTS}\", \"body\": \"The following test appears to have failed:\n\n[#${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}):\n\n\`\`\`\n$(python -c 'import json,sys; print json.dumps(sys.stdin.read()).strip("\"")' < ${outdir}/excerpt.txt)\n\`\`\`\nPlease assign, take a look and update the issue accordingly.\", \"labels\": [\"test-failure\", \"Robot\"], \"milestone\": 1 }" > /dev/null
+      post issues "{ \"title\": \"circleci: failed tests: ${FAILEDTESTS}\", \"body\": \"The following test appears to have failed:\n\n[#${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}):\n\n\`\`\`\n$(python -c 'import json,sys; print json.dumps(sys.stdin.read()).strip("\"")' < ${outdir}/excerpt.txt)\n\`\`\`\nPlease assign, take a look and update the issue accordingly.\", \"labels\": [\"test-failure\", \"Robot\"], \"milestone\": 1 }" > /dev/null
       echo "Found test/race failures in test logs, see excerpt.log and the newly created issue on our issue tracker"
   fi
 


### PR DESCRIPTION
The build number prevents easy clustering of issues by sorting on the
issue title. As the build number is already present in the body of the
issue (and clickable there), duplicating the information in the title
isn't very useful.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5881)

<!-- Reviewable:end -->
