### PR TITLE
storage: efficient abort cache GC

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -586,7 +586,7 @@ func (txn *Txn) send(maxScanResults int64, readConsistency roachpb.ReadConsisten
 
 	if txn.Proto.Status != roachpb.PENDING || txn.IsFinalized() {
 		return nil, roachpb.NewErrorf(
-			"attempting to use transaction with wrong status or finalized: ", txn.Proto.Status)
+			"attempting to use transaction with wrong status or finalized: %s", txn.Proto.Status)
 	}
 
 	// It doesn't make sense to use inconsistent reads in a transaction. However,

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -570,7 +570,7 @@ func (ds *DistSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 		}
 		// Propagate transaction from last reply to next request. The final
 		// update is taken and put into the response's main header.
-		ba.Txn.Update(rpl.Header().Txn)
+		ba.Txn.Update(rpl.Txn)
 		rplChunks = append(rplChunks, rpl)
 		parts = parts[1:]
 	}

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -641,9 +641,8 @@ func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context, txnID uuid.UUID) {
 func (tc *TxnCoordSender) tryAsyncAbort(txnID uuid.UUID) {
 	tc.Lock()
 	txnMeta := tc.txns[txnID]
-	var intentSpans []roachpb.Span
 	// Grab the intents and clone the txn to avoid data races.
-	intentSpans = collectIntentSpans(txnMeta.keys)
+	intentSpans := collectIntentSpans(txnMeta.keys)
 	txnMeta.keys.Clear()
 	txn := txnMeta.txn.Clone()
 	tc.Unlock()
@@ -657,9 +656,6 @@ func (tc *TxnCoordSender) tryAsyncAbort(txnID uuid.UUID) {
 
 	ba := roachpb.BatchRequest{}
 	ba.Txn = &txn
-
-	if txn.Status != roachpb.PENDING {
-	}
 
 	et := &roachpb.EndTransactionRequest{
 		Span: roachpb.Span{
@@ -727,20 +723,20 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
 	// in the case of an ABORTED transaction, but if we can't reach the
 	// transaction record at all, we're going to have to assume we're aborted
 	// as well.
-	if err == nil {
-		txn.Update(br.Responses[0].GetInner().(*roachpb.HeartbeatTxnResponse).Txn)
-	} else if err != nil {
+	if err != nil {
 		log.Warningf("heartbeat to %s failed: %s", txn, err)
 		// We're not going to let the client carry out additional requests, so
 		// try to clean up.
 		tc.tryAsyncAbort(*txn.ID)
 		txn.Status = roachpb.ABORTED
+	} else {
+		txn.Update(br.Responses[0].GetInner().(*roachpb.HeartbeatTxnResponse).Txn)
 	}
 
 	// Give the news to the stored proto. This will give long-running
 	// transactions free updates (and more up-to-date information about whether
 	// they have to restart), but in particular makes sure that they notice
-	// when they've been aborted (in which case we'll give tem an error on
+	// when they've been aborted (in which case we'll give them an error on
 	// their next request).
 	tc.Lock()
 	tc.txns[txnID].txn.Update(&txn)

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -335,11 +335,30 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 		// coordinator previously.
 		if ba.Txn.Writing {
 			tc.Lock()
-			_, ok := tc.txns[txnID]
-			tc.Unlock()
-			if !ok {
-				pErr := roachpb.NewErrorf("writing transaction timed out, was aborted, " +
+			txnMeta, ok := tc.txns[txnID]
+			// Check whether the transaction is still tracked and has a chance
+			// of completing. It's possible that the coordinator learns about
+			// the transaction having terminated from a heartbeat, and
+			// correctness (along with common sense) mandates that we don't let
+			// the client continue.
+			var pErr *roachpb.Error
+			switch {
+			case !ok:
+				pErr = roachpb.NewErrorf("writing transaction timed out, was aborted, " +
 					"or ran on multiple coordinators")
+			case txnMeta.txn.Status == roachpb.ABORTED:
+				txn := txnMeta.txn.Clone()
+				pErr = roachpb.NewErrorWithTxn(roachpb.NewTransactionAbortedError(),
+					&txn)
+				defer tc.cleanupTxn(ctx, txn)
+			case txnMeta.txn.Status == roachpb.COMMITTED:
+				txn := txnMeta.txn.Clone()
+				pErr = roachpb.NewErrorWithTxn(roachpb.NewTransactionStatusError(
+					"transaction is already committed"), &txn)
+				defer tc.cleanupTxn(ctx, txn)
+			}
+			tc.Unlock()
+			if pErr != nil {
 				return nil, pErr
 			}
 		}
@@ -608,7 +627,7 @@ func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context, txnID uuid.UUID) {
 			// responsible for timing out transactions. If ctx.Done() is not nil, then
 			// then heartbeat loop ignores the timeout check and this case is
 			// responsible for client timeouts.
-			tc.clientHasAbandoned(txnID)
+			tc.tryAsyncAbort(txnID)
 			return
 		case <-tc.stopper.ShouldDrain():
 			return
@@ -616,32 +635,32 @@ func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context, txnID uuid.UUID) {
 	}
 }
 
-func (tc *TxnCoordSender) clientHasAbandoned(txnID uuid.UUID) {
+// tryAsyncAbort (synchronously) grabs a copy of the txn proto and the intents
+// (which it then clears from txnMeta), and asynchronously tries to abort the
+// transaction.
+func (tc *TxnCoordSender) tryAsyncAbort(txnID uuid.UUID) {
 	tc.Lock()
 	txnMeta := tc.txns[txnID]
 	var intentSpans []roachpb.Span
-
-	// TODO(tschottdorf): should we be more proactive here?
-	// The client might be continuing the transaction
-	// through another coordinator, but in the most likely
-	// case it's just gone and the open transaction record
-	// could block concurrent operations.
-	if log.V(1) {
-		log.Infof("transaction %s abandoned; stopping heartbeat", txnMeta.txn)
-	}
-	// Grab the intents here to avoid potential race.
+	// Grab the intents and clone the txn to avoid data races.
 	intentSpans = collectIntentSpans(txnMeta.keys)
 	txnMeta.keys.Clear()
-
-	// txnMeta.txn is possibly replaced concurrently,
-	// so grab a copy before unlocking.
 	txn := txnMeta.txn.Clone()
 	tc.Unlock()
+
+	// Since we don't hold the lock continuously, it's possible that two aborts
+	// raced here. That's fine (and probably better than the alternative, which
+	// is missing new intents sometimes).
+	if txn.Status != roachpb.PENDING {
+		return
+	}
 
 	ba := roachpb.BatchRequest{}
 	ba.Txn = &txn
 
-	// Actively abort the transaction and its intents since we assume it's abandoned.
+	if txn.Status != roachpb.PENDING {
+	}
+
 	et := &roachpb.EndTransactionRequest{
 		Span: roachpb.Span{
 			Key: txn.Key,
@@ -651,8 +670,8 @@ func (tc *TxnCoordSender) clientHasAbandoned(txnID uuid.UUID) {
 	}
 	ba.Add(et)
 	tc.stopper.RunAsyncTask(func() {
-		// Use the wrapped sender since the normal Sender
-		// does not allow clients to specify intents.
+		// Use the wrapped sender since the normal Sender does not allow
+		// clients to specify intents.
 		// TODO(tschottdorf): not using the existing context here since that
 		// leads to use-after-finish of the contained trace. Should fork off
 		// before the goroutine.
@@ -668,14 +687,26 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
 	tc.Lock()
 	txnMeta := tc.txns[txnID]
 	txn := txnMeta.txn.Clone()
+	hasAbandoned := txnMeta.hasClientAbandonedCoord(tc.clock.PhysicalNow())
 	tc.Unlock()
+
+	if txn.Status != roachpb.PENDING {
+		// A previous iteration has already determined that the transaction is
+		// not ongoing any more, we're just waiting for the client to realize
+		// and want to keep our state for the time being (to dish out the right
+		// error once it returns).
+		return true
+	}
 
 	// Before we send a heartbeat, determine whether this transaction should be
 	// considered abandoned. If so, exit heartbeat. If ctx.Done() is not nil, then
 	// it is a cancellable Context and we skip this check and use the ctx lifetime
 	// instead of a timeout.
-	if ctx.Done() == nil && txnMeta.hasClientAbandonedCoord(tc.clock.PhysicalNow()) {
-		tc.clientHasAbandoned(txnID)
+	if ctx.Done() == nil && hasAbandoned {
+		if log.V(1) {
+			log.Infof("transaction %s abandoned; stopping heartbeat", txnMeta.txn)
+		}
+		tc.tryAsyncAbort(txnID)
 		return false
 	}
 
@@ -689,22 +720,32 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
 	ba.Add(hb)
 
 	log.Trace(ctx, "heartbeat")
-	_, err := tc.wrapped.Send(ctx, ba)
-	// If the transaction is not in pending state, then we can stop
-	// the heartbeat. It's either aborted or committed, and we resolve
-	// write intents accordingly.
-	if err != nil {
+	br, err := tc.wrapped.Send(ctx, ba)
+
+	// Correctness mandates that when we can't heartbeat the transaction, we
+	// make sure the client doesn't keep going. This is particularly relevant
+	// in the case of an ABORTED transaction, but if we can't reach the
+	// transaction record at all, we're going to have to assume we're aborted
+	// as well.
+	if err == nil {
+		txn.Update(br.Responses[0].GetInner().(*roachpb.HeartbeatTxnResponse).Txn)
+	} else if err != nil {
 		log.Warningf("heartbeat to %s failed: %s", txn, err)
+		// We're not going to let the client carry out additional requests, so
+		// try to clean up.
+		tc.tryAsyncAbort(*txn.ID)
+		txn.Status = roachpb.ABORTED
 	}
-	// TODO(bdarnell): once we have gotten a heartbeat response with
-	// Status != PENDING, future heartbeats are useless. However, we
-	// need to continue the heartbeatLoop until the client either
-	// commits or abandons the transaction. We could save a little
-	// pointless work by restructuring this loop to stop sending
-	// heartbeats between the time that the transaction is aborted and
-	// the client finds out. Furthermore, we could use this information
-	// to send TransactionAbortedErrors to the client so it can restart
-	// immediately instead of running until its EndTransaction.
+
+	// Give the news to the stored proto. This will give long-running
+	// transactions free updates (and more up-to-date information about whether
+	// they have to restart), but in particular makes sure that they notice
+	// when they've been aborted (in which case we'll give tem an error on
+	// their next request).
+	tc.Lock()
+	tc.txns[txnID].txn.Update(&txn)
+	tc.Unlock()
+
 	return true
 }
 
@@ -713,9 +754,22 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
 // object when adequate. It also updates certain errors with the
 // updated transaction for use by client restarts.
 func (tc *TxnCoordSender) updateState(
-	startNS int64, ctx context.Context, ba roachpb.BatchRequest,
-	br *roachpb.BatchResponse, pErr *roachpb.Error) *roachpb.Error {
-	newTxn := &roachpb.Transaction{}
+	startNS int64,
+	ctx context.Context,
+	ba roachpb.BatchRequest,
+	br *roachpb.BatchResponse,
+	pErr *roachpb.Error,
+) *roachpb.Error {
+
+	tc.Lock()
+	defer tc.Unlock()
+
+	if ba.Txn == nil {
+		// Not a transactional request.
+		return pErr
+	}
+
+	var newTxn roachpb.Transaction
 	newTxn.Update(ba.Txn)
 	if pErr == nil {
 		newTxn.Update(br.Txn)

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -756,7 +756,9 @@ func TestTxnCoordIdempotentCleanup(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	s.Sender.cleanupTxn(context.Background(), txn.Proto)
+	s.Sender.Lock()
+	s.Sender.cleanupTxnLocked(context.Background(), txn.Proto)
+	s.Sender.Unlock()
 
 	ba = txn.NewBatch()
 	ba.InternalAddRequest(&roachpb.EndTransactionRequest{})

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -307,7 +307,7 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 			s.Sender.Lock()
 			s.Manual.Increment(1)
 			s.Sender.Unlock()
-			if heartbeatTS.Less(*txn.LastHeartbeat) {
+			if txn.LastHeartbeat != nil && heartbeatTS.Less(*txn.LastHeartbeat) {
 				heartbeatTS = *txn.LastHeartbeat
 				return nil
 			}
@@ -322,10 +322,7 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 			Commit: false,
 			Span:   roachpb.Span{Key: initialTxn.Proto.Key},
 		})
-		txn := initialTxn.Proto.Clone()
-		// TODO(tschottdorf): illegaly mutated in DistSender.Send, fixed in
-		// upcoming commit.
-		ba.Txn = &txn
+		ba.Txn = &initialTxn.Proto
 		if _, pErr := s.distSender.Send(context.Background(), ba); pErr != nil {
 			t.Fatal(pErr)
 		}

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -105,11 +105,6 @@ func (br *BatchResponse) String() string {
 	return strings.Join(str, ", ")
 }
 
-// Header returns a pointer to the header.
-func (br *BatchResponse) Header() *BatchResponse_Header {
-	return &br.BatchResponse_Header
-}
-
 // IntentSpanIterate calls the passed method with the key ranges of the
 // transactional writes contained in the batch.
 func (ba *BatchRequest) IntentSpanIterate(fn func(key, endKey Key)) {

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -612,8 +612,8 @@ func NewTransaction(name string, baseKey Key, userPriority UserPriority,
 // occurred, i.e. the maximum of OrigTimestamp and LastHeartbeat.
 func (t Transaction) LastActive() Timestamp {
 	candidate := t.OrigTimestamp
-	if t.LastHeartbeat != nil {
-		candidate.Forward(*t.LastHeartbeat)
+	if t.LastHeartbeat != nil && candidate.Less(*t.LastHeartbeat) {
+		candidate = *t.LastHeartbeat
 	}
 	return candidate
 }

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -608,6 +608,16 @@ func NewTransaction(name string, baseKey Key, userPriority UserPriority,
 	}
 }
 
+// LastActive returns the last timestamp at which client activity definitely
+// occurred, i.e. the maximum of OrigTimestamp and LastHeartbeat.
+func (t Transaction) LastActive() Timestamp {
+	candidate := t.OrigTimestamp
+	if t.LastHeartbeat != nil {
+		candidate.Forward(*t.LastHeartbeat)
+	}
+	return candidate
+}
+
 // Clone creates a copy of the given transaction. The copy is "mostly" deep,
 // but does share pieces of memory with the original such as Key, ID and the
 // keys with the intent spans.

--- a/roachpb/data.pb.go
+++ b/roachpb/data.pb.go
@@ -516,7 +516,8 @@ func (*Lease) Descriptor() ([]byte, []int) { return fileDescriptorData, []int{13
 type AbortCacheEntry struct {
 	// The key of the associated transaction.
 	Key Key `protobuf:"bytes,1,opt,name=key,casttype=Key" json:"key,omitempty"`
-	// The original timestamp of the associated transaction.
+	// The candidate commit timestamp the transaction record held at the time
+	// it was aborted.
 	Timestamp Timestamp `protobuf:"bytes,2,opt,name=timestamp" json:"timestamp"`
 	// The priority of the transaction.
 	Priority int32 `protobuf:"varint,3,opt,name=priority" json:"priority"`

--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -318,7 +318,8 @@ message Lease {
 message AbortCacheEntry {
   // The key of the associated transaction.
   optional bytes key = 1 [(gogoproto.casttype) = "Key"];
-  // The original timestamp of the associated transaction.
+  // The candidate commit timestamp the transaction record held at the time
+  // it was aborted.
   optional Timestamp timestamp = 2 [(gogoproto.nullable) = false];
   // The priority of the transaction.
   optional int32 priority = 3 [(gogoproto.nullable) = false];

--- a/storage/abort_cache.go
+++ b/storage/abort_cache.go
@@ -93,6 +93,7 @@ func (sc *AbortCache) Get(e engine.Engine, txnID *uuid.UUID, entry *roachpb.Abor
 // Iterate walks through the abort cache, invoking the given callback for
 // each unmarshaled entry with the key, the transaction ID and the decoded
 // entry.
+// TODO(tschottdorf): should not use a pointer to UUID.
 func (sc *AbortCache) Iterate(
 	e engine.Engine, f func([]byte, *uuid.UUID, roachpb.AbortCacheEntry),
 ) {

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1032,8 +1032,17 @@ func (r *Replica) GC(
 //
 // If the pusher is non-transactional, args.PusherTxn is an empty
 // proto with only the priority set.
+//
+// If the pushee is aborted, its timestamp will be forwarded to match its last
+// client activity timestamp (i.e. last heartbeat), if available. This is done
+// so that the updated timestamp populates the abort cache, allowing the GC
+// queue to purge entries for which the transaction coordinator must have found
+// out via its heartbeats that the transaction has failed.
 func (r *Replica) PushTxn(
-	batch engine.Engine, ms *engine.MVCCStats, h roachpb.Header, args roachpb.PushTxnRequest,
+	batch engine.Engine,
+	ms *engine.MVCCStats,
+	h roachpb.Header,
+	args roachpb.PushTxnRequest,
 ) (roachpb.PushTxnResponse, error) {
 	var reply roachpb.PushTxnResponse
 
@@ -1090,6 +1099,7 @@ func (r *Replica) PushTxn(
 		// using a trivial Transaction proto here. Maybe some fields ought
 		// to receive dummy values.
 		reply.PusheeTxn.TxnMeta = args.PusheeTxn
+		reply.PusheeTxn.Timestamp = args.Now // see method comment
 		reply.PusheeTxn.Status = roachpb.ABORTED
 		return reply, engine.MVCCPutProto(batch, ms, key, roachpb.ZeroTimestamp, nil, &reply.PusheeTxn)
 	}
@@ -1124,12 +1134,8 @@ func (r *Replica) PushTxn(
 	var pusherWins bool
 	var reason string
 
-	lastActive := reply.PusheeTxn.OrigTimestamp
-	if realHB := reply.PusheeTxn.LastHeartbeat; realHB != nil {
-		lastActive.Forward(*realHB)
-	}
 	switch {
-	case lastActive.Less(args.Now.Add(-2*DefaultHeartbeatInterval.Nanoseconds(), 0)):
+	case reply.PusheeTxn.LastActive().Less(args.Now.Add(-2*DefaultHeartbeatInterval.Nanoseconds(), 0)):
 		reason = "pushee is expired"
 		// When cleaning up, actually clean up (as opposed to simply pushing
 		// the garbage in the path of future writers).
@@ -1178,6 +1184,9 @@ func (r *Replica) PushTxn(
 	// If aborting transaction, set new status and return success.
 	if args.PushType == roachpb.PUSH_ABORT {
 		reply.PusheeTxn.Status = roachpb.ABORTED
+		// Forward the timestamp to accommodate abort cache GC. See method
+		// comment for details.
+		reply.PusheeTxn.Timestamp.Forward(reply.PusheeTxn.LastActive())
 	} else if args.PushType == roachpb.PUSH_TIMESTAMP {
 		// Otherwise, update timestamp to be one greater than the request's timestamp.
 		reply.PusheeTxn.Timestamp = args.PushTo


### PR DESCRIPTION
Implement a TODO: delete sequence cache entries solely based on the
last client activity on the Txn at abort time.
To be 100% correct, this requires a corresponding update to the coordinator to
prevent client activity after a failed heartbeat (see second commit):

To effectively garbage-collect abort cache entries, it is important to know
that a client who is running a transaction which has been aborted finds out
about this in a timely manner. This mechanism relies on the last heartbeat
timestamp observed at the time of the abort.

This chance also brings the coordinator side on par with this assumption: When
a heartbeat comes back with a non-PENDING transaction (or fails, in which case
we assume ABORTED), we lock down the coordinator for that client and serve it
a `TransactionAbortedError` directly from the coordinator. This error contains
the latest information from the transaction record, so it plays along nicely
with priority upgrades and the like.
In the process, fix an issue with mutating ba.Txn in `(*DistSender).Send`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5882)

<!-- Reviewable:end -->
