### PR TITLE
Tweak rocksdb file sizes.

### DIFF
--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1297,6 +1297,14 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   options.prefix_extractor.reset(new DBPrefixExtractor);
   options.statistics = rocksdb::CreateDBStatistics();
   options.table_factory.reset(rocksdb::NewBlockBasedTableFactory(table_options));
+
+  // File size settings: TODO(marc): investigate and determine better long-term settings:
+  // https://github.com/cockroachdb/cockroach/issues/5852
+  options.target_file_size_base = 64 << 20;
+  options.target_file_size_multiplier = 8;
+  options.max_bytes_for_level_base = 512 << 20;
+  options.max_bytes_for_level_multiplier = 8;
+
   if (row_cache_size > 0) {
     options.row_cache = rocksdb::NewLRUCache(
         row_cache_size, num_cache_shard_bits);


### PR DESCRIPTION
This is merely a short-term fix until the investigation in #5852 is
performed.
Right now, we generate thousands of 2MB files which quickly reaches the
open FD limit.

The rocksdb tuning guide has a lot more details. For now, I just grabbed
parts of the flash configuration.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5888)

<!-- Reviewable:end -->
