### PR TITLE
sql: add an experimental_uuid_v4 alias for uuid_v4

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -504,16 +504,8 @@ var Builtins = map[string][]Builtin{
 		},
 	},
 
-	"uuid_v4": {
-		Builtin{
-			Types:      ArgTypes{},
-			ReturnType: TypeBytes,
-			impure:     true,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				return DBytes(uuid.NewV4().GetBytes()), nil
-			},
-		},
-	},
+	"experimental_uuid_v4": {uuidV4Impl},
+	"uuid_v4":              {uuidV4Impl},
 
 	"greatest": {
 		Builtin{
@@ -1105,6 +1097,15 @@ var substringImpls = []Builtin{
 			escape := string(args[2].(DString))
 			return regexpExtract(ctx, s, pattern, escape)
 		},
+	},
+}
+
+var uuidV4Impl = Builtin{
+	Types:      ArgTypes{},
+	ReturnType: TypeBytes,
+	impure:     true,
+	fn: func(_ EvalContext, args DTuple) (Datum, error) {
+		return DBytes(uuid.NewV4().GetBytes()), nil
 	},
 }
 


### PR DESCRIPTION
Some apps (such as our `photos` load generate) might have baked the
function name into DEFAULT columns.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5889)

<!-- Reviewable:end -->
