### PR TITLE
Make terraform+CockroachDB work on GCE

### DIFF
--- a/cloud/gce/README.md
+++ b/cloud/gce/README.md
@@ -1,3 +1,111 @@
-# Deploy cockroach cluster on Google Cloud using Terraform
+***WARNING*** Use this only for development or testing. This is currently partly
+functional due to GCE network load balancing configuration. Also, this does not
+yet support the creation of secure clusters.
 
-***WARNING*** This is currently non-functional due to GCE network load balancing configuration.
+# Deploy cockroach cluster on Google Cloud Engine using Terraform
+
+This directory contains the [Terraform](https://terraform.io/) configuration
+files needed to launch a Cockroach cluster on GCE (Google Compute Engine).
+
+Terraform stores the state of the cloud resources locally (in a file called
+`terraform.tfstate`), so this is meant to be used by a single user.
+For multi-user cooperation, please see [Terraform's documentation on remote state](https://terraform.io/docs/state/remote.html).
+
+## One-time setup steps
+1. Have a [Google Cloud Platform](https://cloud.google.com/compute/) account
+2. [Download terraform](https://terraform.io/downloads.html), *version 0.6.7 or greater*, unzip, and add to your `PATH`.
+3. [Create and download GCE credentials](https://developers.google.com/identity/protocols/application-default-credentials#howtheywork).
+
+## Variables
+
+Some configuration can be performed by using the `--var` command line parameter
+to override the variables in `variables.tf`.
+
+The following variables are likely to change based on your account or setup:
+* `gce_zone`: availability zone for instances
+* `gce_region`: region for forwarding rules and target pools
+* `key_name`: base name of the Google Cloud SSH key
+* `gce_project`: name of the GCE project for your instances
+* `gce_account_file`: JSON-formatted Google Cloud app credentials
+
+The following variables can be modified if necessary:
+* `sql_port`: the port for the backends and load balancer
+* `machine_type`: type of machine to run instances on
+* `gce_image`: OS image for your GCE instances
+* `action`: default action. Defaults to `start`. Override is specified in
+  initialization step
+
+
+#### Create a cockroach cluster with 3 nodes
+
+```
+$ terraform apply --var=gce_account_file=/path/to/your/gce/credentials.json --var=gce_project=your-gce-project --var=num_instances=3 --var=gce_region=us-east1 --var=gce_zone=us-east1-b
+
+
+Outputs:
+
+  admin_lb_url = http://127.196.119.186:8080/
+  admin_urls   = http://127.196.142.127:8080/, http://127.196.17.15:8080/, http://127.196.139.40:8080/
+  instances    = cockroach-0, cockroach-1, cockroach-2
+  sql_urls     = postgresql://root@127.196.142.127:26257/?sslmode=disable, postgresql://root@127.196.17.15:26257/?sslmode=disable, postgresql://root@127.196.139.40:26257/?sslmode=disable
+```
+
+To see the actions that will be performed by terraform, use `plan` instead of `apply`.
+
+The cluster is now running with three nodes and is reachable through the any of the `instances`
+or through the provided URLs (see `Using the cluster`).
+
+## Using the cluster
+
+#### Connect to the cluster
+
+Use one of the URLs in `sql_urls` in the terraform output to issue SQL queries
+to your new cluster:
+
+```
+$ cockroach sql --url postgresql://root@127.196.142.127:26257/?sslmode=disable
+# Welcome to the cockroach SQL interface.
+# All statements must be terminated by a semicolon.
+# To exit: CTRL + D.
+root@127.196.138.149:26257> show databases;
++----------+
+| Database |
++----------+
+| system   |
++----------+
+```
+
+#### View the admin UI
+
+To view the admin web UI, visit the URL indicated in the `admin_lb_url` part
+of the terraform output. Alternatively, you can visit the admin UI through a
+particular instance by using one of the `admin_urls`.
+
+#### SSH into individual instances
+
+The names of the GCE instances are shown as a comma-separated list in the
+terraform output. Use the `gcloud` tool, included with the [Google Cloud SDK](https://cloud.google.com/sdk/#Quick_Start),
+to SSH into one of the machines:
+
+```
+$ gcloud compute ssh ubuntu@cockroach-1 --zone=us-east1-b
+
+ubuntu@cockroach-1:~$ ps -Af|grep cockroach
+ubuntu    1500     1  0 15:16 ?        00:00:01 ./cockroach start --log-dir=cockroach-data/logs --logtostderr=false --insecure --host=10.142.0.4 --port=26257 --http-port=8080 --join=10.142.0.3
+
+ubuntu@cockroach-1:~$ ls logs
+$ ls cockroach-data/logs
+cockroach.cockroach-1.ubuntu.log.INFO.2016-04-06T15_16_45Z.1500     cockroach.INFO    cockroach.STDOUT
+cockroach.cockroach-1.ubuntu.log.WARNING.2016-04-06T15_16_45Z.1500  cockroach.STDERR  cockroach.WARNING
+```
+
+Note the `ubuntu` user in the above command-line.
+
+## Destroy the cluster
+
+```
+$ terraform destroy --var=gce_account_file=/path/to/your/gce/credentials.json --var=gce_project=your-gce-project
+
+```
+
+The `destroy` command requires confirmation.

--- a/cloud/gce/config.sh.tpl
+++ b/cloud/gce/config.sh.tpl
@@ -1,0 +1,4 @@
+SQL_PORT=${sql_port}
+HTTP_PORT=${http_port}
+LOCAL_ADDRESS=${local_address}
+JOIN_ADDRESS=${join_address}

--- a/cloud/gce/config.tpl
+++ b/cloud/gce/config.tpl
@@ -1,4 +1,0 @@
-PORT=${var.cockroach_port}
-GOSSIP=${var.gossip}
-LB_ADDRESS=${var.load_balancer_address}
-LOCAL_ADDRESS=${self.network_interface.0.address}

--- a/cloud/gce/download_binary.sh
+++ b/cloud/gce/download_binary.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# This script takes the name of a binary and downloads it from S3.
+# It takes the repo_name/binary_name and an optional sha.
+# If the sha is not specified, the latest binary is downloaded.
+# to download latest binary:
+# ./download_binary.sh cockroach/sql.test
+# to download a specific sha:
+# ./download_binary.sh examples-go/block_writer f1ab4265aa72cda950fdd032de3f2dbecaeff866
+#
+# This downloads the binary to the local directory with name: <binary>.<sha>
+# and creates a symlink: <binary> -> <binary>.<sha>
+#
+# This is meant to be copied over to the instance first, then invoked
+# in a "remote-exec" provisioner.
+#
+# eg:
+# myexample.tf <<<
+# ...
+# provisioner "file" {
+#   source = "download_binary.sh"
+#   destination = "/home/ubuntu/download_binary.sh"
+# }
+# provisioner "remote-exec" {
+#   inline = [
+#     "bash download_binary.sh examples-go/block_writer",
+#     "nohup ./block_writer --db-url=localhost:26259 > example.STDOUT 2>&1 &",
+#     "sleep 5",
+#   ]
+# }
+# ...
+# <<<
+set -ex
+
+BUCKET_NAME="cockroach"
+LATEST_SUFFIX=".LATEST"
+
+binary_path=$1
+if [ -z "${binary_path}" ]; then
+  echo "binary not specified, run with: $0 [repo-name]/[binary-name]"
+  exit 1
+fi
+
+sha=$2
+if [ -z "${sha}" ]; then
+  echo "Looking for latest sha for ${binary_path}"
+  latest_url="https://s3.amazonaws.com/${BUCKET_NAME}/${binary_path}${LATEST_SUFFIX}"
+  sha=$(curl ${latest_url})
+  if [ -z "${sha}" ]; then
+    echo "Could not fetch latest binary: ${latest_url}"
+    exit 1
+  fi
+fi
+
+# Fetch binary and symlink.
+binary_url="https://s3.amazonaws.com/${BUCKET_NAME}/${binary_path}.${sha}"
+time curl -O ${binary_url}
+
+# Chmod and symlink.
+binary_name=$(basename ${binary_path})
+chmod 755 ${binary_name}.${sha}
+ln -s -f ${binary_name}.${sha} ${binary_name}
+
+echo "Successfully fetched ${binary_path}.${sha}"

--- a/cloud/gce/launch.sh
+++ b/cloud/gce/launch.sh
@@ -2,38 +2,25 @@
 # This is a simple wrapper script around the cockroach binary.
 # It must be in the same directory as the cockroach binary, and invoked in one of two ways:
 #
-# To start the first node and initialize the cluster:
-# ./launch init [load balancer address:port]
 # To start a node:
-# ./launch start [load balancer address:port]
+# ./launch.sh
 set -ex
 
 source config.sh
 
-DATA_DIR="data"
-LOG_DIR="logs"
-STORES="ssd=${DATA_DIR}"
-COMMON_FLAGS="--log-dir=${LOG_DIR} --logtostderr=false ${STORES}"
-START_FLAGS="--insecure --addr=${LOCAL_ADDRESS}:${PORT}"
-
-action=$1
-if [ "${action}" != "init" -a "${action}" != "start" ]; then
-  echo "Usage: ${0} [init|start] [load balancer address:port]"
-  exit 1
-fi
+DATA_DIR="cockroach-data"
+LOG_DIR="cockroach-data/logs"
+COMMON_FLAGS="--log-dir=${LOG_DIR} --logtostderr=false"
+START_FLAGS="--insecure --host=${LOCAL_ADDRESS} --port=${SQL_PORT} --http-port=${HTTP_PORT} --join=${JOIN_ADDRESS}"
 
 # Setup iptables rules.
-sudo iptables -t nat -A PREROUTING -p tcp --dport ${PORT} -j DNAT --to-destination ${LOCAL_ADDRESS}
-sudo iptables -t nat -A POSTROUTING -p tcp -d ${LB_ADDRESS} --dport ${PORT} -j SNAT --to-source ${LOCAL_ADDRESS}
+sudo iptables -t nat -A PREROUTING -p tcp --dport ${SQL_PORT} -j DNAT --to-destination ${LOCAL_ADDRESS}
+sudo iptables -t nat -A PREROUTING -p tcp --dport ${HTTP_PORT} -j DNAT --to-destination ${LOCAL_ADDRESS}
 
 chmod 755 cockroach
 mkdir -p ${DATA_DIR} ${LOG_DIR}
 
-if [ "${action}" == "init" ]; then
-  ./cockroach init ${COMMON_FLAGS}
-fi
-
-cmd="./cockroach start ${COMMON_FLAGS} ${START_FLAGS} --gossip=${GOSSIP}"
+cmd="./cockroach start ${COMMON_FLAGS} ${START_FLAGS}"
 nohup ${cmd} > ${LOG_DIR}/cockroach.STDOUT 2> ${LOG_DIR}/cockroach.STDERR < /dev/null &
 pid=$!
 echo "Launched ${cmd}: pid=${pid}"

--- a/cloud/gce/output.tf
+++ b/cloud/gce/output.tf
@@ -1,15 +1,23 @@
-output "port" {
-  value = "${var.cockroach_port}"
+# Load-balanced admin UI URL.
+output "admin_lb_url" {
+  value = "http://${google_compute_forwarding_rule.default.ip_address}:${var.http_port}/"
 }
 
-output "forwarding_rule" {
-  value = "${google_compute_forwarding_rule.default.ip_address}"
+# Admin URLs for individual instances.
+output "admin_urls" {
+    value = "${join(", ", formatlist("http://%s:%s/", google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip, var.http_port))}"
 }
 
-output "gossip_variable" {
-  value = "${format("lb=%s:%s", google_compute_forwarding_rule.default.ip_address, var.cockroach_port)}"
+# We do not have a load-balanced SQL URL, because the GCE TCP load balancer may
+# exhibit behavior that breaks the SQL wire protocol.
+
+# Postgres URLs for individual instances.
+output "sql_urls" {
+  value = "${join(", ", formatlist("postgresql://root@%s:%s/?sslmode=disable", google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip, var.sql_port))}"
 }
 
+# Google Cloud names (not DNS names) for CockroachDB instances. These can be
+# used with `gcloud compute ssh`.
 output "instances" {
-  value = "${join(",", google_compute_instance.cockroach.*.network_interface.0.access_config.0.nat_ip)}"
+  value = "${join(", ", google_compute_instance.cockroach.*.name)}"
 }

--- a/cloud/gce/variables.tf
+++ b/cloud/gce/variables.tf
@@ -1,6 +1,10 @@
 # Port used for the load balancer and backends.
-variable "cockroach_port" {
+variable "sql_port" {
   default = "26257"
+}
+
+variable "http_port" {
+  default = "8080"
 }
 
 # GCE region to use.
@@ -13,55 +17,45 @@ variable "gce_zone" {
   default = "us-east1-b"
 }
 
-# GCE project name.
-variable "gce_project" {
-  default = "cockroach-marc"
-}
+# The GCE project under which you want to run your cluster. You'll want to
+# change this.
+variable "gce_project" { }
 
-# GCE account file.
-variable "gce_account_file" {
-  default = "~/terraform/cockroach-marc-64455dfdb138.json"
-}
+# Your JSON-format Google Cloud application credentials. You'll want to change this.
+# To learn how to download your credentials, go here:
+#
+# https://developers.google.com/identity/protocols/application-default-credentials#howtheywork
+variable "gce_account_file" { }
 
 # GCE image name.
 variable "gce_image" {
   default = "ubuntu-os-cloud/ubuntu-1510-wily-v20151021"
 }
 
-# Path to the cockroach binary.
+# Path to the cockroach binary. An empty value results in the latest official
+# binary being used.
 variable "cockroach_binary" {
-  default = "~/cockroach/src/github.com/cockroachdb/cockroach/cockroach"
+  default = ""
 }
 
 # Name of the ssh key pair to use for GCE instances.
 # The public key will be passed at instance creation, and the private
 # key will be used by the local ssh client.
+#
 # The path is expanded to: ~/.ssh/<key_name>.pub
+#
+# If you use `gcloud compute ssh` or `gcloud compute copy-files`, you may want
+# to leave this as "google_compute_engine" for convenience.
 variable "key_name" {
-  default = "gce_cockroach"
-}
-
-# Action is one of "init" or "start". init should only be specified when
-# running `terraform apply` on the first node.
-variable "action" {
-  default = "start"
-}
-
-# Value of the --gossip flag to pass to the backends.
-# This should be populated with the load balancer address.
-# Make sure to populate this before changing num_instances to greater than 0.
-# eg: lb=elb-893485366.us-east-1.elb.amazonaws.com:26257
-variable "gossip" {
-  default = "http-lb=104.196.4.96:26257"
-  #default = ""
-}
-
-variable "load_balancer_address" {
-  default = "104.196.4.96"
-  #default = ""
+  default = "google_compute_engine"
 }
 
 # Number of instances to start.
 variable "num_instances" {
-  default = 3
 }
+
+# SHA of the cockroach binary to pull down. If none, the latest is fetched.
+variable "cockroach_sha" {
+  default = ""
+}
+


### PR DESCRIPTION
This updated terraform config allows one to create an insecure
CockroachDB cluster on GCE.

Caveats:
- Secure clusters are NOT supported.
- I didn't investigate the load balancer issues at all, so that's
  probably still broken.
- There's no supervisor config for running `cockroach`.
- I'm new to terraform, so I'm probably not doing things particularly
  elegantly.

Preview the updated `README.md` here:
https://github.com/cuongdo/cockroach/blob/terraform_gce/cloud/gce/README.md

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5890)

<!-- Reviewable:end -->
