### PR TITLE
server: Register metrics debug handler and redirect to root on incorrect path

### DIFF
--- a/server/admin.go
+++ b/server/admin.go
@@ -102,6 +102,10 @@ func init() {
 	}
 
 	debugServeMux.HandleFunc(debugEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != debugEndpoint {
+			http.Redirect(w, r, debugEndpoint, http.StatusMovedPermanently)
+		}
+
 		// The explicit header is necessary or (at least Chrome) will try to
 		// download a gzipped file (Content-type comes back application/x-gzip).
 		w.Header().Add("Content-type", "text/html")

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -90,6 +90,26 @@ func TestAdminDebugExpVar(t *testing.T) {
 	}
 }
 
+// TestAdminDebugMetrics verifies that cmdline and memstats variables are
+// available via the /debug/metrics link.
+func TestAdminDebugMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s := StartTestServer(t)
+	defer s.Stop()
+
+	jI, err := getJSON(s.Ctx.HTTPRequestScheme() + "://" + s.HTTPAddr() + debugEndpoint + "metrics")
+	if err != nil {
+		t.Fatalf("failed to fetch JSON: %v", err)
+	}
+	j := jI.(map[string]interface{})
+	if _, ok := j["cmdline"]; !ok {
+		t.Error("cmdline not found in JSON response")
+	}
+	if _, ok := j["memstats"]; !ok {
+		t.Error("memstats not found in JSON response")
+	}
+}
+
 // TestAdminDebugPprof verifies that pprof tools are available.
 // via the /debug/pprof/* links.
 func TestAdminDebugPprof(t *testing.T) {
@@ -108,7 +128,7 @@ func TestAdminDebugPprof(t *testing.T) {
 
 // TestAdminDebugTrace verifies that the net/trace endpoints are available
 // via /debug/{requests,events}.
-func TestAdminNetTrace(t *testing.T) {
+func TestAdminDebugTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := StartTestServer(t)
 	defer s.Stop()

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -20,8 +20,10 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"reflect"
 	"sort"
@@ -70,6 +72,11 @@ func getJSON(url string) (interface{}, error) {
 	return jI, nil
 }
 
+// debugURL returns the root debug URL.
+func debugURL(s *TestServer) string {
+	return s.Ctx.HTTPRequestScheme() + "://" + s.HTTPAddr() + debugEndpoint
+}
+
 // TestAdminDebugExpVar verifies that cmdline and memstats variables are
 // available via the /debug/vars link.
 func TestAdminDebugExpVar(t *testing.T) {
@@ -77,7 +84,7 @@ func TestAdminDebugExpVar(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 
-	jI, err := getJSON(s.Ctx.HTTPRequestScheme() + "://" + s.HTTPAddr() + debugEndpoint + "vars")
+	jI, err := getJSON(debugURL(s) + "vars")
 	if err != nil {
 		t.Fatalf("failed to fetch JSON: %v", err)
 	}
@@ -97,7 +104,7 @@ func TestAdminDebugMetrics(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 
-	jI, err := getJSON(s.Ctx.HTTPRequestScheme() + "://" + s.HTTPAddr() + debugEndpoint + "metrics")
+	jI, err := getJSON(debugURL(s) + "metrics")
 	if err != nil {
 		t.Fatalf("failed to fetch JSON: %v", err)
 	}
@@ -117,7 +124,7 @@ func TestAdminDebugPprof(t *testing.T) {
 	s := StartTestServer(t)
 	defer s.Stop()
 
-	body, err := getText(s.Ctx.HTTPRequestScheme() + "://" + s.HTTPAddr() + debugEndpoint + "pprof/block")
+	body, err := getText(debugURL(s) + "pprof/block")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,12 +148,54 @@ func TestAdminDebugTrace(t *testing.T) {
 	}
 
 	for _, c := range tc {
-		body, err := getText(s.Ctx.HTTPRequestScheme() + "://" + s.HTTPAddr() + debugEndpoint + c.segment)
+		body, err := getText(debugURL(s) + c.segment)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if !bytes.Contains(body, []byte(c.search)) {
 			t.Errorf("expected %s to be contained in %s", c.search, body)
+		}
+	}
+}
+
+// TestAdminDebugRedirect verifies that the /debug/ endpoint is redirected to on
+// incorrect /debug/ paths.
+func TestAdminDebugRedirect(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s := StartTestServer(t)
+	defer s.Stop()
+
+	expURL := debugURL(s)
+	origURL := expURL + "incorrect"
+
+	// There are no particular permissions on admin endpoints, TestUser is fine.
+	client, err := testutils.NewTestBaseContext(TestUser).GetHTTPClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Don't follow redirects automatically.
+	redirectAttemptedError := errors.New("redirect")
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return redirectAttemptedError
+	}
+
+	resp, err := client.Get(origURL)
+	if urlError, ok := err.(*url.Error); ok && urlError.Err == redirectAttemptedError {
+		// Ignore the redirectAttemptedError.
+		err = nil
+	}
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusMovedPermanently {
+			t.Errorf("expected status code %d; got %d", http.StatusMovedPermanently, resp.StatusCode)
+		}
+		if redirectURL, err := resp.Location(); err != nil {
+			t.Error(err)
+		} else if foundURL := redirectURL.String(); foundURL != expURL {
+			t.Errorf("expected location %s; got %s", expURL, foundURL)
 		}
 	}
 }


### PR DESCRIPTION
### Registers the metrics debug handler

This change registers the `/debug/metrics` endpoint, which is a superset of
the variables exposed through the /debug/vars endpoint. It includes all
expvars registered globally and all metrics registered on the DefaultRegistry.
### Redirect incorrect debug paths to debug overview

This will redirect paths like `/debug/wrong` back to `/debug/`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5894)

<!-- Reviewable:end -->
