### PR TITLE
util/duration: simple, conservative overflow handling

### DIFF
--- a/util/duration/duration_test.go
+++ b/util/duration/duration_test.go
@@ -69,7 +69,7 @@ func fullDurationTests() []durationTest {
 	for _, test := range positiveDurationTests {
 		d := test.duration
 		negDuration := Duration{Months: -d.Months, Days: -d.Days, Nanos: -d.Nanos}
-		ret = append(ret, durationTest{cmpToPrev: -test.cmpToPrev, duration: negDuration})
+		ret = append(ret, durationTest{cmpToPrev: -test.cmpToPrev, duration: negDuration, err: test.err})
 	}
 	ret = append(ret, positiveDurationTests...)
 	return ret
@@ -79,8 +79,7 @@ func TestEncodeDecode(t *testing.T) {
 	for i, test := range fullDurationTests() {
 		sortNanos, months, days, err := test.duration.Encode()
 		if test.err && err == nil {
-			// TODO(dan): Uncomment this when over and underflow are checked.
-			// t.Errorf("%d expected error but didn't get one", i)
+			t.Errorf("%d expected error but didn't get one", i)
 		} else if !test.err && err != nil {
 			t.Errorf("%d expected no error but got one: %s", i, err)
 		}


### PR DESCRIPTION
Unless there's something I'm missing, it is tricky to compute exactly when a
given Duration will overflow during Encode. This commit adds a very simple impl
that always returns an error when it would have overflowed, but sometimes
returns false positives.

This is good enough to prevent data corruption. We don't need the full impl
until we'd like to support sql intervals of longer than 292 years.

For #5580.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5895)

<!-- Reviewable:end -->
