### PR TITLE
roachpb: replacing {Key|RKey}.Next with ShallowNext approach

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -354,7 +354,7 @@ func AddrUpperBound(k roachpb.Key) (roachpb.RKey, error) {
 	if local := !rk.Equal(k); local {
 		// The upper bound for a range-local key that addresses to key k
 		// is the key directly after k.
-		rk = rk.ShallowNext()
+		rk = rk.Next()
 	}
 	return rk, nil
 }
@@ -431,7 +431,7 @@ func MetaScanBounds(key roachpb.RKey) (roachpb.Key, roachpb.Key, error) {
 		return Meta1KeyMax, Meta1Prefix.PrefixEnd(), nil
 	}
 	// Otherwise find the first entry greater than the given key in the same meta prefix.
-	return key.ShallowNext().AsRawKey(), key[:len(Meta1Prefix)].PrefixEnd().AsRawKey(), nil
+	return key.Next().AsRawKey(), key[:len(Meta1Prefix)].PrefixEnd().AsRawKey(), nil
 }
 
 // MetaReverseScanBounds returns the range [start,end) within which the desired
@@ -448,7 +448,7 @@ func MetaReverseScanBounds(key roachpb.RKey) (roachpb.Key, roachpb.Key, error) {
 	if key.Equal(Meta2Prefix) {
 		// Special case Meta2Prefix: this is the first key in Meta2, and the scan
 		// interval covers all of Meta1.
-		return Meta1Prefix, key.ShallowNext().AsRawKey(), nil
+		return Meta1Prefix, key.Next().AsRawKey(), nil
 	}
 	// Otherwise find the first entry greater than the given key and find the last entry
 	// in the same prefix. For MVCCReverseScan the endKey is exclusive, if we want to find

--- a/kv/batch.go
+++ b/kv/batch.go
@@ -148,7 +148,7 @@ func prev(ba roachpb.BatchRequest, k roachpb.RKey) (roachpb.RKey, error) {
 			return nil, err
 		}
 		if len(eAddr) == 0 {
-			eAddr = addr.ShallowNext()
+			eAddr = addr.Next()
 		}
 		if !eAddr.Less(k) {
 			if !k.Less(addr) {

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -88,7 +88,7 @@ func addKeyRange(keys interval.RangeGroup, start, end roachpb.Key) {
 	// a non-empty interval, so we create two key slices which
 	// share the same underlying byte array.
 	if len(end) == 0 {
-		end = start.ShallowNext()
+		end = start.Next()
 		start = end[:len(start)]
 	}
 	keyR := interval.Range{

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -76,16 +76,10 @@ func (rk RKey) Equal(other []byte) bool {
 }
 
 // Next returns the RKey that sorts immediately after the given one.
-func (rk RKey) Next() RKey {
-	return RKey(BytesNext(rk))
-}
-
-// ShallowNext returns the RKey that sorts immediately after the
-// given one, using extra capacity of the recevier key if possible.
 // The method may only take a shallow copy of the RKey, so both the
 // receiver and the return value should be treated as immutable after.
-func (rk RKey) ShallowNext() RKey {
-	return RKey(BytesNextShallow(rk))
+func (rk RKey) Next() RKey {
+	return RKey(BytesNext(rk))
 }
 
 // PrefixEnd determines the end key given key as a prefix, that is the
@@ -107,26 +101,21 @@ func (rk RKey) String() string {
 // messages which refer to Cockroach keys.
 type Key []byte
 
-// BytesNext returns the next possible byte slice by appending an \x00.
+// BytesNext returns the next possible byte slice, using the extra capacity
+// of the provided slice if possible, and if not, appending an \x00.
 func BytesNext(b []byte) []byte {
-	// TODO(spencer): Do we need to enforce KeyMaxLength here?
-	// Switched to "make and copy" pattern in #4963 for performance.
-	bn := make([]byte, len(b)+1)
-	copy(bn, b)
-	bn[len(bn)-1] = 0
-	return bn
-}
-
-// BytesNextShallow returns the next possible byte slice, using the extra
-// capacity of the provided slice if possible.
-func BytesNextShallow(b []byte) []byte {
 	if cap(b) > len(b) {
 		bNext := b[:len(b)+1]
 		if bNext[len(bNext)-1] == 0 {
 			return bNext
 		}
 	}
-	return BytesNext(b)
+	// TODO(spencer): Do we need to enforce KeyMaxLength here?
+	// Switched to "make and copy" pattern in #4963 for performance.
+	bn := make([]byte, len(b)+1)
+	copy(bn, b)
+	bn[len(bn)-1] = 0
+	return bn
 }
 
 func bytesPrefixEnd(b []byte) []byte {
@@ -144,17 +133,11 @@ func bytesPrefixEnd(b []byte) []byte {
 	return b
 }
 
-// Next returns the next key in lexicographic sort order.
-func (k Key) Next() Key {
-	return Key(BytesNext(k))
-}
-
-// ShallowNext returns the next key in lexicographic sort order, using
-// extra capacity of the recevier key if possible. The method may only
+// Next returns the next key in lexicographic sort order. The method may only
 // take a shallow copy of the Key, so both the receiver and the return
 // value should be treated as immutable after.
-func (k Key) ShallowNext() Key {
-	return Key(BytesNextShallow(k))
+func (k Key) Next() Key {
+	return Key(BytesNext(k))
 }
 
 // IsPrev is a more efficient version of k.Next().Equal(m).

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -68,16 +68,13 @@ func TestKeyNext(t *testing.T) {
 		{Key(noExtraCap), Key("xo\x00"), 1},
 	}
 	for i, c := range testCases {
-		if next := c.key.Next(); !bytes.Equal(next, c.next) {
+		next := c.key.Next()
+		if !bytes.Equal(next, c.next) {
 			t.Errorf("%d: unexpected next bytes for %q: %q", i, c.key, next)
 		}
-		shallowNext := c.key.ShallowNext()
-		if !bytes.Equal(shallowNext, c.next) {
-			t.Errorf("%d: unexpected shallow next bytes for %q: %q", i, c.key, shallowNext)
-		}
 		if c.expReallocate != 0 {
-			if expect, reallocated := c.expReallocate > 0, (&shallowNext[0] != &c.key[0]); expect != reallocated {
-				t.Errorf("%d: unexpected shallow next reallocation = %t, found reallocation = %t", i, expect, reallocated)
+			if expect, reallocated := c.expReallocate > 0, (&next[0] != &c.key[0]); expect != reallocated {
+				t.Errorf("%d: unexpected next reallocation = %t, found reallocation = %t", i, expect, reallocated)
 			}
 		}
 	}

--- a/sql/kvfetcher.go
+++ b/sql/kvfetcher.go
@@ -178,7 +178,7 @@ func (f *kvFetcher) fetch() *roachpb.Error {
 		// received key. To resume reverse scans we will set the (exclusive) scan end to the last
 		// received key.
 		if !f.reverse {
-			resumeKey = resumeKey.ShallowNext()
+			resumeKey = resumeKey.Next()
 		}
 	}
 

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -923,7 +923,8 @@ func TestStoreSplitReadRace(t *testing.T) {
 	defer config.TestingDisableTableSplits()()
 	splitKey := roachpb.Key("a")
 	key := func(i int) roachpb.Key {
-		return append(splitKey.Next(), []byte(fmt.Sprintf("%03d", i))...)
+		splitCopy := append([]byte(nil), splitKey.Next()...)
+		return append(splitCopy, []byte(fmt.Sprintf("%03d", i))...)
 	}
 
 	getContinues := make(chan struct{})

--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -92,7 +92,7 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 		// This gives us a memory-efficient end key if end is empty.
 		start, end := span.Key, span.EndKey
 		if len(end) == 0 {
-			end = start.ShallowNext()
+			end = start.Next()
 			start = end[:len(start)]
 		}
 		newCmdRange := interval.Range{
@@ -298,7 +298,7 @@ func (cq *CommandQueue) Add(readOnly bool, spans ...roachpb.Span) []interface{} 
 	for _, span := range spans {
 		start, end := span.Key, span.EndKey
 		if len(end) == 0 {
-			end = start.ShallowNext()
+			end = start.Next()
 			start = end[:len(start)]
 		}
 		alloc := struct {

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -62,7 +62,7 @@ func (k MVCCKey) Next() MVCCKey {
 	ts := k.Timestamp.Prev()
 	if ts == roachpb.ZeroTimestamp {
 		return MVCCKey{
-			Key: k.Key.ShallowNext(),
+			Key: k.Key.Next(),
 		}
 	}
 	return MVCCKey{
@@ -1448,7 +1448,7 @@ func MVCCIterate(engine Engine, startKey, endKey roachpb.Key, timestamp roachpb.
 			}
 
 		} else {
-			iter.Seek(MakeMVCCMetadataKey(metaKey.Key.ShallowNext()))
+			iter.Seek(MakeMVCCMetadataKey(metaKey.Key.Next()))
 			if !iter.Valid() {
 				if err := iter.Error(); err != nil {
 					return nil, err
@@ -1769,7 +1769,7 @@ func MVCCResolveWriteIntentRangeUsingIter(
 		}
 
 		// nextKey is already a metadata key.
-		nextKey.Key = key.Key.ShallowNext()
+		nextKey.Key = key.Key.Next()
 	}
 
 	return num, nil

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -128,7 +128,7 @@ func (tc *TimestampCache) SetLowWater(lowWater roachpb.Timestamp) {
 func (tc *TimestampCache) Add(start, end roachpb.Key, timestamp roachpb.Timestamp, txnID *uuid.UUID, readTSCache bool) {
 	// This gives us a memory-efficient end key if end is empty.
 	if len(end) == 0 {
-		end = start.ShallowNext()
+		end = start.Next()
 		start = end[:len(start)]
 	}
 	if tc.latest.Less(timestamp) {
@@ -292,7 +292,7 @@ func (tc *TimestampCache) GetMaxWrite(start, end roachpb.Key, txnID *uuid.UUID) 
 
 func (tc *TimestampCache) getMax(start, end roachpb.Key, txnID *uuid.UUID, readTSCache bool) roachpb.Timestamp {
 	if len(end) == 0 {
-		end = start.ShallowNext()
+		end = start.Next()
 	}
 	max := tc.lowWater
 	cache := tc.wCache


### PR DESCRIPTION
Fixes #5841.

This change makes sure that all keys that use `Next` are being
treated as immutable before and after. With this precondition, sharing
underlying arrays in keys should be safe, so we simply move the
`ShallowNext` implementation into `Next`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5899)

<!-- Reviewable:end -->
