### PR TITLE
sql: delay effecting UPDATE/DELETE/INSERT until actual execution. 

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -291,7 +291,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 							if err != nil {
 								return roachpb.NewError(err)
 							}
-							val, err := marshalColumnValue(col, d, evalCtx.Args)
+							val, err := marshalColumnValue(col, d)
 							if err != nil {
 								return roachpb.NewError(err)
 							}

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -291,6 +291,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 							if err != nil {
 								return roachpb.NewError(err)
 							}
+
 							val, err := marshalColumnValue(col, d)
 							if err != nil {
 								return roachpb.NewError(err)

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -18,6 +18,7 @@ package sql
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -25,133 +26,159 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-// Delete deletes rows from a table.
+type deleteNode struct {
+	editNodeBase
+	n *parser.Delete
+
+	run struct {
+		editNodeRun
+
+		colIDtoRowIndex map[ColumnID]int
+		fastPath        bool
+	}
+}
+
+// Delete removes rows from a table.
 // Privileges: DELETE and SELECT on table. We currently always use a SELECT statement.
 //   Notes: postgres requires DELETE. Also requires SELECT for "USING" and "WHERE" with tables.
 //          mysql requires DELETE. Also requires SELECT if a table is used in the "WHERE" clause.
 func (p *planner) Delete(n *parser.Delete, autoCommit bool) (planNode, *roachpb.Error) {
-	tableDesc, pErr := p.getAliasedTableLease(n.Table)
+	en, pErr := p.makeEditNode(n.Table, n.Returning, autoCommit, privilege.DELETE)
 	if pErr != nil {
 		return nil, pErr
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.DELETE); err != nil {
-		return nil, roachpb.NewError(err)
-	}
-
-	// TODO(tamird,pmattis): avoid going through Select to avoid encoding
-	// and decoding keys.
-	rows, pErr := p.SelectClause(&parser.SelectClause{
-		Exprs: tableDesc.allColumnsSelector(),
+	// TODO(knz): Until we split the creation of the node from Start()
+	// for the SelectClause too, we cannot cache this. This is because
+	// this node's initSelect() method both does type checking and also
+	// performs index selection. We cannot perform index selection
+	// properly until the placeholder values are known.
+	_, pErr = p.SelectClause(&parser.SelectClause{
+		Exprs: en.tableDesc.allColumnsSelector(),
 		From:  []parser.TableExpr{n.Table},
 		Where: n.Where,
 	})
 	if pErr != nil {
 		return nil, pErr
 	}
-	sel := rows.(*selectNode)
 
-	rh, err := makeReturningHelper(p, n.Returning, tableDesc.Name, tableDesc.Columns)
-	if err != nil {
-		return nil, roachpb.NewError(err)
+	if pErr := en.rh.TypeCheck(); pErr != nil {
+		return nil, pErr
 	}
 
-	if p.evalCtx.PrepareOnly {
-		// Return the result column types.
-		return rh.getResults()
+	return &deleteNode{
+		n:            n,
+		editNodeBase: en,
+	}, nil
+}
+
+func (d *deleteNode) Start() *roachpb.Error {
+	// TODO(knz): See the comment above in Delete().
+	rows, pErr := d.p.SelectClause(&parser.SelectClause{
+		Exprs: d.tableDesc.allColumnsSelector(),
+		From:  []parser.TableExpr{d.n.Table},
+		Where: d.n.Where,
+	})
+	if pErr != nil {
+		return pErr
+	}
+
+	if pErr := rows.Start(); pErr != nil {
+		return pErr
 	}
 
 	// Construct a map from column ID to the index the value appears at within a
 	// row.
-	colIDtoRowIndex, err := makeColIDtoRowIndex(rows, tableDesc)
+	colIDtoRowIndex, err := makeColIDtoRowIndex(rows, d.tableDesc)
 	if err != nil {
-		return nil, roachpb.NewError(err)
+		return roachpb.NewError(err)
 	}
-
-	primaryIndex := tableDesc.PrimaryIndex
-	primaryIndexKeyPrefix := MakeIndexKeyPrefix(tableDesc.ID, primaryIndex.ID)
+	d.run.colIDtoRowIndex = colIDtoRowIndex
 
 	// Determine the secondary indexes that need to be updated as well.
-	indexes := tableDesc.Indexes
+	indexes := d.tableDesc.Indexes
 	// Also include all the indexes under mutation; mutation state is
 	// irrelevant for deletions.
-	for _, m := range tableDesc.Mutations {
+	for _, m := range d.tableDesc.Mutations {
 		if index := m.GetIndex(); index != nil {
 			indexes = append(indexes, *index)
 		}
 	}
 
-	if isSystemConfigID(tableDesc.GetID()) {
-		// Mark transaction as operating on the system DB.
-		p.txn.SetSystemConfigTrigger()
-	}
+	d.run.startEditNode(&d.editNodeBase, rows, indexes)
 
 	// Check if we can avoid doing a round-trip to read the values and just
 	// "fast-path" skip to deleting the key ranges without reading them first.
 	// TODO(dt): We could probably be smarter when presented with an index-join,
 	// but this goes away anyway once we push-down more of SQL.
-	if scan, ok := sel.table.node.(*scanNode); ok && canDeleteWithoutScan(n, scan, len(indexes)) {
-		cols, err := rh.getResults()
-		if err != nil {
-			return nil, err
-		}
-		return p.fastDelete(scan, cols, autoCommit)
+	sel := rows.(*selectNode)
+	if scan, ok := sel.table.node.(*scanNode); ok && canDeleteWithoutScan(d.n, scan, len(indexes)) {
+		d.run.fastPath = true
+		d.run.pErr = d.fastDelete()
+		d.run.done = true
+		return d.run.pErr
 	}
 
-	b := p.txn.NewBatch()
+	return nil
+}
 
-	for rows.Next() {
-		rowVals := rows.Values()
+func (d *deleteNode) FastPathResults() (int, bool) {
+	if d.run.fastPath {
+		return d.rh.rowCount, true
+	}
+	return 0, false
+}
 
-		primaryIndexKey, _, err := encodeIndexKey(
-			&primaryIndex, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
-		if err != nil {
-			return nil, roachpb.NewError(err)
-		}
+func (d *deleteNode) Next() bool {
+	if d.run.done || d.run.pErr != nil {
+		return false
+	}
 
-		secondaryIndexEntries, err := encodeSecondaryIndexes(
-			tableDesc.ID, indexes, colIDtoRowIndex, rowVals)
-		if err != nil {
-			return nil, roachpb.NewError(err)
-		}
+	if !d.run.rows.Next() {
+		// We're done. Finish the batch.
+		d.run.finalize(&d.editNodeBase, false)
+		return false
+	}
 
-		for _, secondaryIndexEntry := range secondaryIndexEntries {
-			if log.V(2) {
-				log.Infof("Del %s", secondaryIndexEntry.key)
-			}
-			b.Del(secondaryIndexEntry.key)
-		}
+	rowVals := d.run.rows.Values()
 
-		// Delete the row.
-		rowStartKey := roachpb.Key(primaryIndexKey)
-		rowEndKey := rowStartKey.PrefixEnd()
+	primaryIndexKey, _, err := encodeIndexKey(
+		&d.run.primaryIndex, d.run.colIDtoRowIndex, rowVals, d.run.primaryIndexKeyPrefix)
+	if err != nil {
+		d.run.pErr = roachpb.NewError(err)
+		return false
+	}
+
+	secondaryIndexEntries, err := encodeSecondaryIndexes(
+		d.tableDesc.ID, d.run.indexes, d.run.colIDtoRowIndex, rowVals)
+	if err != nil {
+		d.run.pErr = roachpb.NewError(err)
+		return false
+	}
+
+	for _, secondaryIndexEntry := range secondaryIndexEntries {
 		if log.V(2) {
-			log.Infof("DelRange %s - %s", rowStartKey, rowEndKey)
+			log.Infof("Del %s", secondaryIndexEntry.key)
 		}
-		b.DelRange(rowStartKey, rowEndKey, false)
-
-		if err := rh.append(rowVals); err != nil {
-			return nil, roachpb.NewError(err)
-		}
+		d.run.b.Del(secondaryIndexEntry.key)
 	}
 
-	if pErr := rows.PErr(); pErr != nil {
-		return nil, pErr
+	// Delete the row.
+	rowStartKey := roachpb.Key(primaryIndexKey)
+	rowEndKey := rowStartKey.PrefixEnd()
+	if log.V(2) {
+		log.Infof("DelRange %s - %s", rowStartKey, rowEndKey)
 	}
+	d.run.b.DelRange(rowStartKey, rowEndKey, false)
 
-	if autoCommit {
-		// An auto-txn can commit the transaction with the batch. This is an
-		// optimization to avoid an extra round-trip to the transaction
-		// coordinator.
-		pErr = p.txn.CommitInBatch(b)
-	} else {
-		pErr = p.txn.Run(b)
+	resultRow, err := d.rh.cookResultRow(rowVals)
+	if err != nil {
+		d.run.pErr = roachpb.NewError(err)
+		return false
 	}
-	if pErr != nil {
-		return nil, pErr
-	}
+	d.run.resultRow = resultRow
 
-	return rh.getResults()
+	return true
 }
 
 // Determine if the deletion of `rows` can be done without actually scanning them,
@@ -182,34 +209,33 @@ func canDeleteWithoutScan(n *parser.Delete, scan *scanNode, indexCount int) bool
 // `fastDelete` skips the scan of rows and just deletes the ranges that
 // `rows` would scan. Should only be used if `canDeleteWithoutScan` indicates
 // that it is safe to do so.
-func (p *planner) fastDelete(scan *scanNode, result *returningNode, autoCommit bool) (planNode, *roachpb.Error) {
-	b := p.txn.NewBatch()
-
+func (d *deleteNode) fastDelete() *roachpb.Error {
+	scan := d.run.rows.(*selectNode).table.node.(*scanNode)
 	if !scan.initScan() {
-		return nil, scan.pErr
+		return scan.pErr
 	}
 
 	for _, span := range scan.spans {
 		if log.V(2) {
 			log.Infof("Skipping scan and just deleting %s - %s", span.start, span.end)
 		}
-		b.DelRange(span.start, span.end, true)
+		d.run.b.DelRange(span.start, span.end, true)
 	}
 
-	if autoCommit {
+	if d.autoCommit {
 		// An auto-txn can commit the transaction with the batch. This is an
 		// optimization to avoid an extra round-trip to the transaction
 		// coordinator.
-		if pErr := p.txn.CommitInBatch(b); pErr != nil {
-			return nil, pErr
+		if pErr := d.p.txn.CommitInBatch(d.run.b); pErr != nil {
+			return pErr
 		}
 	} else {
-		if pErr := p.txn.Run(b); pErr != nil {
-			return nil, pErr
+		if pErr := d.p.txn.Run(d.run.b); pErr != nil {
+			return pErr
 		}
 	}
 
-	for _, r := range b.Results {
+	for _, r := range d.run.b.Results {
 		var prev []byte
 		for _, i := range r.Keys {
 			// If prefix is same, don't bother decoding key.
@@ -219,14 +245,53 @@ func (p *planner) fastDelete(scan *scanNode, result *returningNode, autoCommit b
 
 			after, err := scan.readIndexKey(i)
 			if err != nil {
-				return nil, roachpb.NewError(err)
+				return roachpb.NewError(err)
 			}
 			k := i[:len(i)-len(after)]
 			if !bytes.Equal(k, prev) {
 				prev = k
-				result.rowCount++
+				d.rh.rowCount++
 			}
 		}
 	}
-	return result, nil
+	return nil
 }
+
+func (d *deleteNode) Columns() []ResultColumn {
+	return d.rh.columns
+}
+
+func (d *deleteNode) Values() parser.DTuple {
+	return d.run.resultRow
+}
+
+func (d *deleteNode) MarkDebug(mode explainMode) {
+	d.run.rows.MarkDebug(mode)
+}
+
+func (d *deleteNode) DebugValues() debugValues {
+	return d.run.rows.DebugValues()
+}
+
+func (d *deleteNode) Ordering() orderingInfo {
+	return d.run.rows.Ordering()
+}
+
+func (d *deleteNode) PErr() *roachpb.Error {
+	return d.run.pErr
+}
+
+func (d *deleteNode) ExplainPlan() (name, description string, children []planNode) {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "from %s returning (", d.tableDesc.Name)
+	for i, col := range d.rh.columns {
+		if i > 0 {
+			fmt.Fprintf(&buf, ", ")
+		}
+		fmt.Fprintf(&buf, "%s", col.Name)
+	}
+	fmt.Fprintf(&buf, ")")
+	return "delete", buf.String(), []planNode{d.run.rows}
+}
+
+func (d *deleteNode) SetLimitHint(numRows int64, soft bool) {}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -881,6 +881,10 @@ func (e *Executor) execStmt(
 		return result, pErr
 	}
 
+	if pErr := plan.Start(); pErr != nil {
+		return result, pErr
+	}
+
 	result.PGTag = stmt.StatementTag()
 	result.Type = stmt.StatementType()
 

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -451,7 +451,7 @@ func (e *Executor) execRequest(ctx context.Context, session *Session, sql string
 	return res
 }
 
-// If the plan has a fast path we query that,
+// If the plan has a fast path we attempt to query that,
 // otherwise we fall back to counting via plan.Next().
 func countRowsAffected(p planNode) int {
 	if a, ok := p.(planNodeFastPath); ok {

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -71,6 +71,9 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, *roachp
 	if err != nil {
 		return nil, err
 	}
+	if err := plan.Start(); err != nil {
+		return nil, err
+	}
 	switch mode {
 	case explainDebug:
 		plan.MarkDebug(mode)
@@ -202,8 +205,10 @@ var debugColumns = []ResultColumn{
 func (*explainDebugNode) Columns() []ResultColumn { return debugColumns }
 func (*explainDebugNode) Ordering() orderingInfo  { return orderingInfo{} }
 
-func (n *explainDebugNode) PErr() *roachpb.Error { return n.plan.PErr() }
-func (n *explainDebugNode) Next() bool           { return n.plan.Next() }
+func (n *explainDebugNode) PErr() *roachpb.Error  { return n.plan.PErr() }
+func (n *explainDebugNode) Start() *roachpb.Error { return n.plan.Start() }
+
+func (n *explainDebugNode) Next() bool { return n.plan.Next() }
 
 func (n *explainDebugNode) ExplainPlan() (name, description string, children []planNode) {
 	return n.plan.ExplainPlan()

--- a/sql/group.go
+++ b/sql/group.go
@@ -247,6 +247,10 @@ func (n *groupNode) DebugValues() debugValues {
 	return vals
 }
 
+func (n *groupNode) Start() *roachpb.Error {
+	return n.plan.Start()
+}
+
 func (n *groupNode) Next() bool {
 	var scratch []byte
 

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -17,6 +17,7 @@
 package sql
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/keys"
@@ -27,32 +28,39 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
+type insertNode struct {
+	// The following fields are populated during makePlan.
+	rowCreatorNodeBase
+	n          *parser.Insert
+	qvals      qvalMap
+	insertRows parser.SelectStatement
+	checkExprs []parser.Expr
+
+	run struct {
+		// The following fields are populated during Start().
+		rowCreatorNodeRun
+		rowIdxToRetIdx []int
+		rowTemplate    parser.DTuple
+	}
+}
+
 // Insert inserts rows into the database.
 // Privileges: INSERT on table
 //   Notes: postgres requires INSERT. No "on duplicate key update" option.
 //          mysql requires INSERT. Also requires UPDATE on "ON DUPLICATE KEY UPDATE".
 func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.Error) {
-	// TODO(marcb): We can't use the cached descriptor here because a recent
-	// update of the schema (e.g. the addition of an index) might not be
-	// reflected in the cached version (yet). Perhaps schema modification
-	// routines such as CREATE INDEX should not return until the schema change
-	// has been pushed everywhere.
-	tableDesc, pErr := p.getAliasedTableLease(n.Table)
+	en, pErr := p.makeEditNode(n.Table, n.Returning, autoCommit, privilege.INSERT)
 	if pErr != nil {
 		return nil, pErr
-	}
-
-	if err := p.checkPrivilege(tableDesc, privilege.INSERT); err != nil {
-		return nil, roachpb.NewError(err)
 	}
 
 	var cols []ColumnDescriptor
 	// Determine which columns we're inserting into.
 	if n.DefaultValues() {
-		cols = tableDesc.Columns
+		cols = en.tableDesc.Columns
 	} else {
 		var err error
-		if cols, err = p.processColumns(tableDesc, n.Columns); err != nil {
+		if cols, err = p.processColumns(en.tableDesc, n.Columns); err != nil {
 			return nil, roachpb.NewError(err)
 		}
 	}
@@ -78,12 +86,12 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 	}
 
 	// Add any column that has a DEFAULT expression.
-	for _, col := range tableDesc.Columns {
+	for _, col := range en.tableDesc.Columns {
 		addIfDefault(col)
 	}
 	// Also add any column in a mutation that is WRITE_ONLY and has
 	// a DEFAULT expression.
-	for _, m := range tableDesc.Mutations {
+	for _, m := range en.tableDesc.Mutations {
 		if m.State != DescriptorMutation_WRITE_ONLY {
 			continue
 		}
@@ -92,24 +100,25 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 		}
 	}
 
+	rc, rcErr := p.makeRowCreatorNode(en, cols, colIDtoRowIndex, true)
+	if rcErr != nil {
+		return nil, rcErr
+	}
+
 	// Verify we have at least the columns that are part of the primary key.
 	primaryKeyCols := map[ColumnID]struct{}{}
-	for i, id := range tableDesc.PrimaryIndex.ColumnIDs {
+	for i, id := range en.tableDesc.PrimaryIndex.ColumnIDs {
 		if _, ok := colIDtoRowIndex[id]; !ok {
-			return nil, roachpb.NewUErrorf("missing %q primary key column", tableDesc.PrimaryIndex.ColumnNames[i])
+			return nil, roachpb.NewUErrorf("missing %q primary key column", en.tableDesc.PrimaryIndex.ColumnNames[i])
 		}
 		primaryKeyCols[id] = struct{}{}
 	}
 
-	// Construct the default expressions. The returned slice will be nil if no
-	// column in the table has a default expression.
-	defaultExprs, err := makeDefaultExprs(cols, &p.parser, p.evalCtx)
+	// Replace any DEFAULT markers with the corresponding default expressions.
+	insertRows, err := p.fillDefaults(rc.defaultExprs, cols, n)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}
-
-	// Replace any DEFAULT markers with the corresponding default expressions.
-	insertRows := p.fillDefaults(defaultExprs, cols, n)
 
 	// Construct the check expressions. The returned slice will be nil if no
 	// column in the table has a check expression.
@@ -123,7 +132,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 	if len(checkExprs) > 0 {
 		qvals = make(qvalMap)
 		table := tableInfo{
-			columns: makeResultColumns(tableDesc.Columns),
+			columns: makeResultColumns(en.tableDesc.Columns),
 		}
 		for i := range checkExprs {
 			expr, err := resolveQNames(checkExprs[i], &table, qvals, &p.qnameVisitor)
@@ -133,8 +142,8 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 			checkExprs[i] = expr
 		}
 	}
-	// Transform the values into a rows object. This expands SELECT statements or
-	// generates rows from the values contained within the query.
+
+	// Analyze the expressions for column information and typing.
 	rows, pErr := p.makePlan(insertRows, false)
 	if pErr != nil {
 		return nil, pErr
@@ -144,220 +153,248 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 		return nil, roachpb.NewUErrorf("INSERT has more expressions than target columns: %d/%d", expressions, numInputColumns)
 	}
 
-	primaryIndex := tableDesc.PrimaryIndex
-	primaryIndexKeyPrefix := MakeIndexKeyPrefix(tableDesc.ID, primaryIndex.ID)
-
-	marshalled := make([]interface{}, len(cols))
-
-	b := p.txn.NewBatch()
-	rh, err := makeReturningHelper(p, n.Returning, tableDesc.Name, tableDesc.Columns)
-	if err != nil {
-		return nil, roachpb.NewError(err)
-	}
-
-	// Prepare structures for building values to pass to rh.
-	var retVals parser.DTuple
-	var rowIdxToRetIdx []int
-	if rh.exprs != nil {
-		// In some cases (e.g. `INSERT INTO t (a) ...`) rowVals does not contain all the table
-		// columns. We need to pass values for all table columns to rh, in the correct order; we
-		// will use retVals for this. We also need a table that maps row indices to retVals indices
-		// to fill in the row values; any absent values will be NULLs.
-
-		retVals = make(parser.DTuple, len(tableDesc.Columns))
-		for i := range retVals {
-			retVals[i] = parser.DNull
-		}
-
-		colIDToRetIndex := map[ColumnID]int{}
-		for i, col := range tableDesc.Columns {
-			colIDToRetIndex[col.ID] = i
-		}
-
-		rowIdxToRetIdx = make([]int, len(cols))
-		for i, col := range cols {
-			rowIdxToRetIdx[i] = colIDToRetIndex[col.ID]
-		}
-	}
-
-	for rows.Next() {
-		rowVals := rows.Values()
-
-		// The values for the row may be shorter than the number of columns being
-		// inserted into. Generate default values for those columns using the
-		// default expressions.
-		for i := len(rowVals); i < len(cols); i++ {
-			if defaultExprs == nil {
-				rowVals = append(rowVals, parser.DNull)
-				continue
-			}
-			d, err := defaultExprs[i].Eval(p.evalCtx)
-			if err != nil {
-				return nil, roachpb.NewError(err)
-			}
-			rowVals = append(rowVals, d)
-		}
-
-		// Check to see if NULL is being inserted into any non-nullable column.
-		for _, col := range tableDesc.Columns {
-			if !col.Nullable {
-				if i, ok := colIDtoRowIndex[col.ID]; !ok || rowVals[i] == parser.DNull {
-					return nil, roachpb.NewUErrorf("null value in column %q violates not-null constraint", col.Name)
+	// Type check the tuples, if any, to collect placeholder types.
+	if values, ok := n.Rows.Select.(*parser.ValuesClause); ok {
+		for _, tuple := range values.Tuples {
+			for eIdx, val := range tuple.Exprs {
+				if _, ok := val.(parser.DefaultVal); ok {
+					continue
 				}
-			}
-		}
-
-		// Ensure that the values honor the specified column widths.
-		for i := range rowVals {
-			if err := checkValueWidth(cols[i], rowVals[i]); err != nil {
-				return nil, roachpb.NewError(err)
-			}
-		}
-
-		if len(checkExprs) > 0 {
-			// Populate qvals.
-			for ref, qval := range qvals {
-				// The colIdx is 0-based, we need to change it to 1-based.
-				ri, has := colIDtoRowIndex[ColumnID(ref.colIdx+1)]
-				if !has {
-					return nil, roachpb.NewUErrorf("failed to to find column %d in row", ColumnID(ref.colIdx+1))
-				}
-				qval.datum = rowVals[ri]
-			}
-			for _, expr := range checkExprs {
-				if d, err := expr.Eval(p.evalCtx); err != nil {
+				typ, err := val.TypeCheck(p.evalCtx.Args)
+				if err != nil {
 					return nil, roachpb.NewError(err)
-				} else if res, err := parser.GetBool(d); err != nil {
+				}
+				if err := checkColumnType(cols[eIdx], typ, p.evalCtx.Args); err != nil {
 					return nil, roachpb.NewError(err)
-				} else if !res {
-					// Failed to satisfy CHECK constraint.
-					return nil, roachpb.NewUErrorf("failed to satisfy CHECK constraint (%s)", expr.String())
 				}
 			}
-		}
-
-		// Check that the row value types match the column types. This needs to
-		// happen before index encoding because certain datum types (i.e. tuple)
-		// cannot be used as index values.
-		for i, val := range rowVals {
-			// Make sure the value can be written to the column before proceeding.
-			if mErr := checkColumnType(cols[i], val, p.evalCtx.Args); mErr != nil {
-				return nil, roachpb.NewError(mErr)
-			}
-		}
-
-		if p.evalCtx.PrepareOnly {
-			continue
-		}
-
-		// Marshal the column values.
-		for i, val := range rowVals {
-			var mErr error
-			if marshalled[i], mErr = marshalColumnValue(cols[i], val); mErr != nil {
-				return nil, roachpb.NewError(mErr)
-			}
-		}
-
-		primaryIndexKey, _, eErr := encodeIndexKey(
-			&primaryIndex, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
-		if eErr != nil {
-			return nil, roachpb.NewError(eErr)
-		}
-
-		// Write the row sentinel. We want to write the sentinel first in case
-		// we are trying to insert a duplicate primary key: if we write the
-		// secondary indexes first, we may get an error that looks like a
-		// uniqueness violation on a non-unique index.
-		sentinelKey := keys.MakeNonColumnKey(primaryIndexKey)
-		if log.V(2) {
-			log.Infof("CPut %s -> NULL", roachpb.Key(sentinelKey))
-		}
-		// This is subtle: An interface{}(nil) deletes the value, so we pass in
-		// []byte{} as a non-nil value.
-		b.CPut(sentinelKey, []byte{}, nil)
-
-		// Write the secondary indexes.
-		indexes := tableDesc.Indexes
-		// Also include the secondary indexes in mutation state WRITE_ONLY.
-		for _, m := range tableDesc.Mutations {
-			if m.State == DescriptorMutation_WRITE_ONLY {
-				if index := m.GetIndex(); index != nil {
-					indexes = append(indexes, *index)
-				}
-			}
-		}
-		secondaryIndexEntries, eErr := encodeSecondaryIndexes(
-			tableDesc.ID, indexes, colIDtoRowIndex, rowVals)
-		if eErr != nil {
-			return nil, roachpb.NewError(eErr)
-		}
-
-		for _, secondaryIndexEntry := range secondaryIndexEntries {
-			if log.V(2) {
-				log.Infof("CPut %s -> %v", secondaryIndexEntry.key,
-					secondaryIndexEntry.value)
-			}
-			b.CPut(secondaryIndexEntry.key, secondaryIndexEntry.value, nil)
-		}
-
-		// Write the row columns.
-		for i, val := range rowVals {
-			col := cols[i]
-			if retVals != nil {
-				retVals[rowIdxToRetIdx[i]] = val
-			}
-
-			if _, ok := primaryKeyCols[col.ID]; ok {
-				// Skip primary key columns as their values are encoded in the row
-				// sentinel key which is guaranteed to exist for as long as the row
-				// exists.
-				continue
-			}
-
-			if marshalled[i] != nil {
-				// We only output non-NULL values. Non-existent column keys are
-				// considered NULL during scanning and the row sentinel ensures we know
-				// the row exists.
-
-				key := keys.MakeColumnKey(primaryIndexKey, uint32(col.ID))
-				if log.V(2) {
-					log.Infof("CPut %s -> %v", roachpb.Key(key), val)
-				}
-
-				b.CPut(key, marshalled[i], nil)
-			}
-		}
-
-		if err := rh.append(retVals); err != nil {
-			return nil, roachpb.NewError(err)
 		}
 	}
-	if pErr := rows.PErr(); pErr != nil {
+
+	if pErr := en.rh.TypeCheck(); pErr != nil {
 		return nil, pErr
 	}
 
-	if p.evalCtx.PrepareOnly {
-		// Return the result column types.
-		return rh.getResults()
-	}
+	return &insertNode{
+		n:                  n,
+		rowCreatorNodeBase: rc,
+		checkExprs:         checkExprs,
+		qvals:              qvals,
+		insertRows:         insertRows,
+	}, nil
+}
 
-	if isSystemConfigID(tableDesc.GetID()) {
-		// Mark transaction as operating on the system DB.
-		p.txn.SetSystemConfigTrigger()
-	}
+func (n *insertNode) Start() *roachpb.Error {
+	// TODO(knz): We need to re-run makePlan here again
+	// because that's when we can expand sub-queries.
+	// This goes away when sub-query expansion is moved
+	// to the Start() method of the insertRows object.
 
-	if autoCommit {
-		// An auto-txn can commit the transaction with the batch. This is an
-		// optimization to avoid an extra round-trip to the transaction
-		// coordinator.
-		pErr = p.txn.CommitInBatch(b)
-	} else {
-		pErr = p.txn.Run(b)
-	}
+	// Transform the values into a rows object. This expands SELECT statements or
+	// generates rows from the values contained within the query.
+	rows, pErr := n.p.makePlan(n.insertRows, false)
 	if pErr != nil {
-		return nil, convertBatchError(tableDesc, *b, pErr)
+		return pErr
 	}
-	return rh.getResults()
+
+	if pErr := rows.Start(); pErr != nil {
+		return pErr
+	}
+
+	// Determine the secondary indexes that need to be updated as well.
+	indexes := n.tableDesc.Indexes
+	// Also include the secondary indexes in mutation state WRITE_ONLY.
+	for _, m := range n.tableDesc.Mutations {
+		if m.State == DescriptorMutation_WRITE_ONLY {
+			if index := m.GetIndex(); index != nil {
+				indexes = append(indexes, *index)
+			}
+		}
+	}
+
+	n.run.startRowCreatorNode(&n.rowCreatorNodeBase, rows, indexes)
+
+	// Prepare structures for building values to pass to rh.
+	if n.rh.exprs != nil {
+		// In some cases (e.g. `INSERT INTO t (a) ...`) rowVals does not contain all the table
+		// columns. We need to pass values for all table columns to rh, in the correct order; we
+		// will use rowTemplate for this. We also need a table that maps row indices to rowTemplate indices
+		// to fill in the row values; any absent values will be NULLs.
+
+		n.run.rowTemplate = make(parser.DTuple, len(n.tableDesc.Columns))
+		for i := range n.run.rowTemplate {
+			n.run.rowTemplate[i] = parser.DNull
+		}
+
+		colIDToRetIndex := map[ColumnID]int{}
+		for i, col := range n.tableDesc.Columns {
+			colIDToRetIndex[col.ID] = i
+		}
+
+		n.run.rowIdxToRetIdx = make([]int, len(n.cols))
+		for i, col := range n.cols {
+			n.run.rowIdxToRetIdx[i] = colIDToRetIndex[col.ID]
+		}
+	}
+
+	return nil
+}
+
+func (n *insertNode) Next() bool {
+	if n.run.done || n.run.pErr != nil {
+		return false
+	}
+
+	if !n.run.rows.Next() {
+		// We're done. Finish the batch.
+		n.run.finalize(&n.editNodeBase, true)
+		return false
+	}
+
+	rowVals := n.run.rows.Values()
+
+	// The values for the row may be shorter than the number of columns being
+	// inserted into. Generate default values for those columns using the
+	// default expressions.
+	for i := len(rowVals); i < len(n.cols); i++ {
+		if n.defaultExprs == nil {
+			rowVals = append(rowVals, parser.DNull)
+			continue
+		}
+		d, err := n.defaultExprs[i].Eval(n.p.evalCtx)
+		if err != nil {
+			n.run.pErr = roachpb.NewError(err)
+			return false
+		}
+		rowVals = append(rowVals, d)
+	}
+
+	// Check to see if NULL is being inserted into any non-nullable column.
+	for _, col := range n.tableDesc.Columns {
+		if !col.Nullable {
+			if i, ok := n.colIDtoRowIndex[col.ID]; !ok || rowVals[i] == parser.DNull {
+				n.run.pErr = roachpb.NewUErrorf("null value in column %q violates not-null constraint", col.Name)
+				return false
+			}
+		}
+	}
+
+	// Ensure that the values honor the specified column widths.
+	for i := range rowVals {
+		if err := checkValueWidth(n.cols[i], rowVals[i]); err != nil {
+			n.run.pErr = roachpb.NewError(err)
+			return false
+		}
+	}
+
+	if len(n.checkExprs) > 0 {
+		// Populate qvals.
+		for ref, qval := range n.qvals {
+			// The colIdx is 0-based, we need to change it to 1-based.
+			ri, has := n.colIDtoRowIndex[ColumnID(ref.colIdx+1)]
+			if !has {
+				n.run.pErr = roachpb.NewUErrorf("failed to to find column %d in row", ColumnID(ref.colIdx+1))
+				return false
+			}
+			qval.datum = rowVals[ri]
+		}
+		for _, expr := range n.checkExprs {
+			if d, err := expr.Eval(n.p.evalCtx); err != nil {
+				n.run.pErr = roachpb.NewError(err)
+				return false
+			} else if res, err := parser.GetBool(d); err != nil {
+				n.run.pErr = roachpb.NewError(err)
+				return false
+			} else if !res {
+				// Failed to satisfy CHECK constraint.
+				n.run.pErr = roachpb.NewUErrorf("failed to satisfy CHECK constraint (%s)", expr.String())
+				return false
+			}
+		}
+	}
+
+	// Encode the values to the expected column type. This needs to
+	// happen before index encoding because certain datum types (i.e. tuple)
+	// cannot be used as index values.
+	for i, val := range rowVals {
+		// Make sure the value can be written to the column before proceeding.
+		var mErr error
+		if n.run.marshalled[i], mErr = marshalColumnValue(n.cols[i], val); mErr != nil {
+			n.run.pErr = roachpb.NewError(mErr)
+			return false
+		}
+	}
+
+	primaryIndexKey, _, eErr := encodeIndexKey(
+		&n.run.primaryIndex, n.colIDtoRowIndex, rowVals, n.run.primaryIndexKeyPrefix)
+	if eErr != nil {
+		n.run.pErr = roachpb.NewError(eErr)
+		return false
+	}
+
+	// Write the row sentinel. We want to write the sentinel first in case
+	// we are trying to insert a duplicate primary key: if we write the
+	// secondary indexes first, we may get an error that looks like a
+	// uniqueness violation on a non-unique index.
+	sentinelKey := keys.MakeNonColumnKey(primaryIndexKey)
+	if log.V(2) {
+		log.Infof("CPut %s -> NULL", roachpb.Key(sentinelKey))
+	}
+	// This is subtle: An interface{}(nil) deletes the value, so we pass in
+	// []byte{} as a non-nil value.
+	n.run.b.CPut(sentinelKey, []byte{}, nil)
+
+	secondaryIndexEntries, eErr := encodeSecondaryIndexes(
+		n.tableDesc.ID, n.run.indexes, n.colIDtoRowIndex, rowVals)
+	if eErr != nil {
+		n.run.pErr = roachpb.NewError(eErr)
+		return false
+	}
+
+	for _, secondaryIndexEntry := range secondaryIndexEntries {
+		if log.V(2) {
+			log.Infof("CPut %s -> %v", secondaryIndexEntry.key,
+				secondaryIndexEntry.value)
+		}
+		n.run.b.CPut(secondaryIndexEntry.key, secondaryIndexEntry.value, nil)
+	}
+
+	// Write the row columns.
+	for i, val := range rowVals {
+		col := n.cols[i]
+		if n.run.rowTemplate != nil {
+			n.run.rowTemplate[n.run.rowIdxToRetIdx[i]] = val
+		}
+
+		if _, ok := n.primaryKeyCols[col.ID]; ok {
+			// Skip primary key columns as their values are encoded in the row
+			// sentinel key which is guaranteed to exist for as long as the row
+			// exists.
+			continue
+		}
+
+		if n.run.marshalled[i] != nil {
+			// We only output non-NULL values. Non-existent column keys are
+			// considered NULL during scanning and the row sentinel ensures we know
+			// the row exists.
+
+			key := keys.MakeColumnKey(primaryIndexKey, uint32(col.ID))
+			if log.V(2) {
+				log.Infof("CPut %s -> %v", roachpb.Key(key), val)
+			}
+
+			n.run.b.CPut(key, n.run.marshalled[i], nil)
+		}
+	}
+
+	resultRow, err := n.rh.cookResultRow(n.run.rowTemplate)
+	if err != nil {
+		n.run.pErr = roachpb.NewError(err)
+		return false
+	}
+	n.run.resultRow = resultRow
+
+	return true
 }
 
 func (p *planner) processColumns(tableDesc *TableDescriptor,
@@ -393,7 +430,7 @@ func (p *planner) processColumns(tableDesc *TableDescriptor,
 }
 
 func (p *planner) fillDefaults(defaultExprs []parser.Expr,
-	cols []ColumnDescriptor, n *parser.Insert) parser.SelectStatement {
+	cols []ColumnDescriptor, n *parser.Insert) (parser.SelectStatement, error) {
 	if n.DefaultValues() {
 		row := make(parser.Exprs, 0, len(cols))
 		for i := range cols {
@@ -403,12 +440,12 @@ func (p *planner) fillDefaults(defaultExprs []parser.Expr,
 			}
 			row = append(row, defaultExprs[i])
 		}
-		return &parser.ValuesClause{Tuples: []*parser.Tuple{{Exprs: row}}}
+		return &parser.ValuesClause{Tuples: []*parser.Tuple{{Exprs: row}}}, nil
 	}
 
 	values, ok := n.Rows.Select.(*parser.ValuesClause)
 	if !ok {
-		return n.Rows.Select
+		return n.Rows.Select, nil
 	}
 
 	ret := values
@@ -433,7 +470,7 @@ func (p *planner) fillDefaults(defaultExprs []parser.Expr,
 			}
 		}
 	}
-	return ret
+	return ret, nil
 }
 
 func makeDefaultExprs(
@@ -507,3 +544,49 @@ func (p *planner) makeCheckExprs(cols []ColumnDescriptor) ([]parser.Expr, error)
 	}
 	return checkExprs, nil
 }
+
+func (n *insertNode) Columns() []ResultColumn {
+	return n.rh.columns
+}
+
+func (n *insertNode) Values() parser.DTuple {
+	return n.run.resultRow
+}
+
+func (n *insertNode) MarkDebug(mode explainMode) {
+	n.run.rows.MarkDebug(mode)
+}
+
+func (n *insertNode) DebugValues() debugValues {
+	return n.run.rows.DebugValues()
+}
+
+func (n *insertNode) Ordering() orderingInfo {
+	return n.run.rows.Ordering()
+}
+
+func (n *insertNode) PErr() *roachpb.Error {
+	return n.run.pErr
+}
+
+func (n *insertNode) ExplainPlan() (name, description string, children []planNode) {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "into %s (", n.tableDesc.Name)
+	for i, col := range n.cols {
+		if i > 0 {
+			fmt.Fprintf(&buf, ", ")
+		}
+		fmt.Fprintf(&buf, "%s", col.Name)
+	}
+	fmt.Fprintf(&buf, ") returning (")
+	for i, col := range n.rh.columns {
+		if i > 0 {
+			fmt.Fprintf(&buf, ", ")
+		}
+		fmt.Fprintf(&buf, "%s", col.Name)
+	}
+	fmt.Fprintf(&buf, ")")
+	return "insert", buf.String(), []planNode{n.run.rows}
+}
+
+func (n *insertNode) SetLimitHint(numRows int64, soft bool) {}

--- a/sql/join.go
+++ b/sql/join.go
@@ -136,6 +136,13 @@ func (n *indexJoinNode) DebugValues() debugValues {
 	return n.debugVals
 }
 
+func (n *indexJoinNode) Start() *roachpb.Error {
+	if err := n.table.Start(); err != nil {
+		return err
+	}
+	return n.index.Start()
+}
+
 func (n *indexJoinNode) Next() bool {
 	// Loop looking up the next row. We either are going to pull a row from the
 	// table or a batch of rows from the index. If we pull a batch of rows from

--- a/sql/parser/insert.go
+++ b/sql/parser/insert.go
@@ -29,7 +29,7 @@ import (
 
 // Insert represents an INSERT statement.
 type Insert struct {
-	Table     *QualifiedName
+	Table     TableExpr
 	Columns   QualifiedNames
 	Rows      *Select
 	Returning ReturningExprs

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -799,7 +799,7 @@ const sqlEofCode = 1
 const sqlErrCode = 2
 const sqlInitialStackSize = 16
 
-//line sql.y:4270
+//line sql.y:4275
 
 //line yacctab:1
 var sqlExca = [...]int{
@@ -5725,166 +5725,178 @@ sqldefault:
 		//line sql.y:1811
 		{
 			sqlVAL.union.val = sqlDollar[5].union.stmt()
-			sqlVAL.union.val.(*Insert).Table = sqlDollar[4].union.qname()
+			sqlVAL.union.val.(*Insert).Table = sqlDollar[4].union.tblExpr()
 			sqlVAL.union.val.(*Insert).Returning = sqlDollar[7].union.retExprs()
+		}
+	case 267:
+		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
+		//line sql.y:1823
+		{
+			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname()}
+		}
+	case 268:
+		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
+		//line sql.y:1827
+		{
+			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname(), As: AliasClause{Alias: Name(sqlDollar[3].str)}}
 		}
 	case 269:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1828
+		//line sql.y:1833
 		{
 			sqlVAL.union.val = &Insert{Rows: sqlDollar[1].union.slct()}
 		}
 	case 270:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1832
+		//line sql.y:1837
 		{
 			sqlVAL.union.val = &Insert{Columns: sqlDollar[2].union.qnames(), Rows: sqlDollar[4].union.slct()}
 		}
 	case 271:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1836
+		//line sql.y:1841
 		{
 			sqlVAL.union.val = &Insert{Rows: &Select{}}
 		}
 	case 272:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1843
+		//line sql.y:1848
 		{
 			unimplemented()
 		}
 	case 273:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1844
+		//line sql.y:1849
 		{
 			unimplemented()
 		}
 	case 274:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1845
+		//line sql.y:1850
 		{
 		}
 	case 275:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1848
+		//line sql.y:1853
 		{
 			unimplemented()
 		}
 	case 276:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1849
+		//line sql.y:1854
 		{
 			unimplemented()
 		}
 	case 277:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1850
+		//line sql.y:1855
 		{
 		}
 	case 278:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1854
+		//line sql.y:1859
 		{
 			sqlVAL.union.val = sqlDollar[2].union.selExprs()
 		}
 	case 279:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1858
+		//line sql.y:1863
 		{
 			sqlVAL.union.val = SelectExprs(nil)
 		}
 	case 280:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:1865
+		//line sql.y:1870
 		{
 			sqlVAL.union.val = &Update{Table: sqlDollar[3].union.tblExpr(), Exprs: sqlDollar[5].union.updateExprs(), Where: newWhere(astWhere, sqlDollar[7].union.expr()), Returning: sqlDollar[8].union.retExprs()}
 		}
 	case 281:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1871
+		//line sql.y:1876
 		{
 			sqlVAL.union.val = UpdateExprs{sqlDollar[1].union.updateExpr()}
 		}
 	case 282:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1875
+		//line sql.y:1880
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.updateExprs(), sqlDollar[3].union.updateExpr())
 		}
 	case 285:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1885
+		//line sql.y:1890
 		{
 			sqlVAL.union.val = &UpdateExpr{Names: QualifiedNames{sqlDollar[1].union.qname()}, Expr: sqlDollar[3].union.expr()}
 		}
 	case 286:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1897
+		//line sql.y:1902
 		{
 			sqlVAL.union.val = &UpdateExpr{Tuple: true, Names: sqlDollar[2].union.qnames(), Expr: &Tuple{sqlDollar[5].union.exprs()}}
 		}
 	case 287:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:1901
+		//line sql.y:1906
 		{
 			sqlVAL.union.val = &UpdateExpr{Tuple: true, Names: sqlDollar[2].union.qnames(), Expr: &Subquery{Select: sqlDollar[5].union.selectStmt()}}
 		}
 	case 289:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1945
+		//line sql.y:1950
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 290:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1951
+		//line sql.y:1956
 		{
 			sqlVAL.union.val = &ParenSelect{Select: sqlDollar[2].union.slct()}
 		}
 	case 291:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1955
+		//line sql.y:1960
 		{
 			sqlVAL.union.val = &ParenSelect{Select: &Select{Select: sqlDollar[2].union.selectStmt()}}
 		}
 	case 292:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1970
+		//line sql.y:1975
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 293:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1974
+		//line sql.y:1979
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt(), OrderBy: sqlDollar[2].union.orderBy()}
 		}
 	case 294:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1978
+		//line sql.y:1983
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[1].union.selectStmt(), OrderBy: sqlDollar[2].union.orderBy(), Limit: sqlDollar[3].union.limit()}
 		}
 	case 295:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1982
+		//line sql.y:1987
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt()}
 		}
 	case 296:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1986
+		//line sql.y:1991
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt(), OrderBy: sqlDollar[3].union.orderBy()}
 		}
 	case 297:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1990
+		//line sql.y:1995
 		{
 			sqlVAL.union.val = &Select{Select: sqlDollar[2].union.selectStmt(), OrderBy: sqlDollar[3].union.orderBy(), Limit: sqlDollar[4].union.limit()}
 		}
 	case 300:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2024
+		//line sql.y:2029
 		{
 			sqlVAL.union.val = &SelectClause{
 				Exprs:   sqlDollar[3].union.selExprs(),
@@ -5896,7 +5908,7 @@ sqldefault:
 		}
 	case 301:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:2036
+		//line sql.y:2041
 		{
 			sqlVAL.union.val = &SelectClause{
 				Distinct: sqlDollar[2].union.bool(),
@@ -5909,7 +5921,7 @@ sqldefault:
 		}
 	case 303:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2048
+		//line sql.y:2053
 		{
 			sqlVAL.union.val = &SelectClause{
 				Exprs:       SelectExprs{starSelectExpr()},
@@ -5919,7 +5931,7 @@ sqldefault:
 		}
 	case 304:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2056
+		//line sql.y:2061
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  UnionOp,
@@ -5930,7 +5942,7 @@ sqldefault:
 		}
 	case 305:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2065
+		//line sql.y:2070
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  IntersectOp,
@@ -5941,7 +5953,7 @@ sqldefault:
 		}
 	case 306:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2074
+		//line sql.y:2079
 		{
 			sqlVAL.union.val = &UnionClause{
 				Type:  ExceptOp,
@@ -5952,140 +5964,140 @@ sqldefault:
 		}
 	case 307:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2092
+		//line sql.y:2097
 		{
 			unimplemented()
 		}
 	case 308:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2093
+		//line sql.y:2098
 		{
 			unimplemented()
 		}
 	case 309:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2094
+		//line sql.y:2099
 		{
 			unimplemented()
 		}
 	case 310:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2097
+		//line sql.y:2102
 		{
 			unimplemented()
 		}
 	case 311:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2098
+		//line sql.y:2103
 		{
 			unimplemented()
 		}
 	case 312:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2101
+		//line sql.y:2106
 		{
 			unimplemented()
 		}
 	case 313:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2105
+		//line sql.y:2110
 		{
 			sqlVAL.union.val = sqlDollar[1].union.slct()
 		}
 	case 317:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2113
+		//line sql.y:2118
 		{
 			unimplemented()
 		}
 	case 318:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2114
+		//line sql.y:2119
 		{
 		}
 	case 319:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2117
+		//line sql.y:2122
 		{
 		}
 	case 320:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2118
+		//line sql.y:2123
 		{
 		}
 	case 321:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2122
+		//line sql.y:2127
 		{
 			sqlVAL.union.val = true
 		}
 	case 322:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2126
+		//line sql.y:2131
 		{
 			sqlVAL.union.val = false
 		}
 	case 323:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2130
+		//line sql.y:2135
 		{
 			sqlVAL.union.val = false
 		}
 	case 324:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2136
+		//line sql.y:2141
 		{
 			sqlVAL.union.val = true
 		}
 	case 325:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2141
+		//line sql.y:2146
 		{
 		}
 	case 326:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2142
+		//line sql.y:2147
 		{
 		}
 	case 327:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2146
+		//line sql.y:2151
 		{
 			sqlVAL.union.val = sqlDollar[1].union.orderBy()
 		}
 	case 328:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2150
+		//line sql.y:2155
 		{
 			sqlVAL.union.val = OrderBy(nil)
 		}
 	case 329:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2156
+		//line sql.y:2161
 		{
 			sqlVAL.union.val = OrderBy(sqlDollar[3].union.orders())
 		}
 	case 330:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2162
+		//line sql.y:2167
 		{
 			sqlVAL.union.val = []*Order{sqlDollar[1].union.order()}
 		}
 	case 331:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2166
+		//line sql.y:2171
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.orders(), sqlDollar[3].union.order())
 		}
 	case 332:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2172
+		//line sql.y:2177
 		{
 			sqlVAL.union.val = &Order{Expr: sqlDollar[1].union.expr(), Direction: sqlDollar[2].union.dir()}
 		}
 	case 333:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2180
+		//line sql.y:2185
 		{
 			if sqlDollar[1].union.limit() == nil {
 				sqlVAL.union.val = sqlDollar[2].union.limit()
@@ -6096,7 +6108,7 @@ sqldefault:
 		}
 	case 334:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2189
+		//line sql.y:2194
 		{
 			sqlVAL.union.val = sqlDollar[1].union.limit()
 			if sqlDollar[2].union.limit() != nil {
@@ -6105,7 +6117,7 @@ sqldefault:
 		}
 	case 337:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2200
+		//line sql.y:2205
 		{
 			if sqlDollar[2].union.expr() == nil {
 				sqlVAL.union.val = (*Limit)(nil)
@@ -6115,65 +6127,65 @@ sqldefault:
 		}
 	case 338:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2213
+		//line sql.y:2218
 		{
 			sqlVAL.union.val = &Limit{Offset: sqlDollar[2].union.expr()}
 		}
 	case 339:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2220
+		//line sql.y:2225
 		{
 			sqlVAL.union.val = &Limit{Offset: sqlDollar[2].union.expr()}
 		}
 	case 341:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2227
+		//line sql.y:2232
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 342:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2241
+		//line sql.y:2246
 		{
 		}
 	case 343:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2242
+		//line sql.y:2247
 		{
 		}
 	case 344:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2268
+		//line sql.y:2273
 		{
 			sqlVAL.union.val = GroupBy(sqlDollar[3].union.exprs())
 		}
 	case 345:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2272
+		//line sql.y:2277
 		{
 			sqlVAL.union.val = GroupBy(nil)
 		}
 	case 346:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2278
+		//line sql.y:2283
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 347:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2282
+		//line sql.y:2287
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 348:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2288
+		//line sql.y:2293
 		{
 			sqlVAL.union.val = &ValuesClause{[]*Tuple{{sqlDollar[2].union.exprs()}}}
 		}
 	case 349:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2292
+		//line sql.y:2297
 		{
 			valNode := sqlDollar[1].union.selectStmt().(*ValuesClause)
 			valNode.Tuples = append(valNode.Tuples, &Tuple{sqlDollar[3].union.exprs()})
@@ -6181,49 +6193,49 @@ sqldefault:
 		}
 	case 350:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2304
+		//line sql.y:2309
 		{
 			sqlVAL.union.val = sqlDollar[2].union.tblExprs()
 		}
 	case 351:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2308
+		//line sql.y:2313
 		{
 			sqlVAL.union.val = TableExprs(nil)
 		}
 	case 352:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2314
+		//line sql.y:2319
 		{
 			sqlVAL.union.val = TableExprs{sqlDollar[1].union.tblExpr()}
 		}
 	case 353:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2318
+		//line sql.y:2323
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tblExprs(), sqlDollar[3].union.tblExpr())
 		}
 	case 354:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2324
+		//line sql.y:2329
 		{
 			sqlVAL.union.val = &IndexHints{Index: Name(sqlDollar[3].str)}
 		}
 	case 355:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2329
+		//line sql.y:2334
 		{
 			sqlVAL.union.val = &IndexHints{NoIndexJoin: true}
 		}
 	case 356:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2335
+		//line sql.y:2340
 		{
 			sqlVAL.union.val = sqlDollar[1].union.indexHints()
 		}
 	case 357:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2340
+		//line sql.y:2345
 		{
 			a := sqlDollar[1].union.indexHints()
 			b := sqlDollar[3].union.indexHints()
@@ -6243,2017 +6255,2017 @@ sqldefault:
 		}
 	case 358:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2360
+		//line sql.y:2365
 		{
 			sqlVAL.union.val = &IndexHints{Index: Name(sqlDollar[2].str)}
 		}
 	case 359:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2364
+		//line sql.y:2369
 		{
 			sqlVAL.union.val = sqlDollar[3].union.indexHints()
 		}
 	case 360:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2368
+		//line sql.y:2373
 		{
 			sqlVAL.union.val = (*IndexHints)(nil)
 		}
 	case 361:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2375
+		//line sql.y:2380
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname(), Hints: sqlDollar[2].union.indexHints(), As: sqlDollar[3].union.aliasClause()}
 		}
 	case 362:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2379
+		//line sql.y:2384
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: &Subquery{Select: sqlDollar[1].union.selectStmt()}, As: sqlDollar[2].union.aliasClause()}
 		}
 	case 364:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2383
+		//line sql.y:2388
 		{
 			unimplemented()
 		}
 	case 365:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2401
+		//line sql.y:2406
 		{
 			sqlVAL.union.val = &ParenTableExpr{Expr: sqlDollar[2].union.tblExpr()}
 		}
 	case 366:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2405
+		//line sql.y:2410
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astCrossJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr()}
 		}
 	case 367:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2409
+		//line sql.y:2414
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: sqlDollar[2].str, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr(), Cond: sqlDollar[5].union.joinCond()}
 		}
 	case 368:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2413
+		//line sql.y:2418
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[3].union.tblExpr(), Cond: sqlDollar[4].union.joinCond()}
 		}
 	case 369:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2417
+		//line sql.y:2422
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astNaturalJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[5].union.tblExpr()}
 		}
 	case 370:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2421
+		//line sql.y:2426
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astNaturalJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr()}
 		}
 	case 371:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2427
+		//line sql.y:2432
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[2].str), Cols: NameList(sqlDollar[4].union.strs())}
 		}
 	case 372:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2431
+		//line sql.y:2436
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[2].str)}
 		}
 	case 373:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2435
+		//line sql.y:2440
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[1].str), Cols: NameList(sqlDollar[3].union.strs())}
 		}
 	case 374:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2439
+		//line sql.y:2444
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[1].str)}
 		}
 	case 376:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2446
+		//line sql.y:2451
 		{
 			sqlVAL.union.val = AliasClause{}
 		}
 	case 377:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2452
+		//line sql.y:2457
 		{
 			sqlVAL.str = astFullJoin
 		}
 	case 378:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2456
+		//line sql.y:2461
 		{
 			sqlVAL.str = astLeftJoin
 		}
 	case 379:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2460
+		//line sql.y:2465
 		{
 			sqlVAL.str = astRightJoin
 		}
 	case 380:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2464
+		//line sql.y:2469
 		{
 			sqlVAL.str = astInnerJoin
 		}
 	case 381:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2470
+		//line sql.y:2475
 		{
 		}
 	case 382:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2471
+		//line sql.y:2476
 		{
 		}
 	case 383:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2482
+		//line sql.y:2487
 		{
 			sqlVAL.union.val = &UsingJoinCond{Cols: NameList(sqlDollar[3].union.strs())}
 		}
 	case 384:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2486
+		//line sql.y:2491
 		{
 			sqlVAL.union.val = &OnJoinCond{Expr: sqlDollar[2].union.expr()}
 		}
 	case 385:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2492
+		//line sql.y:2497
 		{
 			sqlVAL.union.val = sqlDollar[1].union.qname()
 		}
 	case 386:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2496
+		//line sql.y:2501
 		{
 			sqlVAL.union.val = sqlDollar[1].union.qname()
 		}
 	case 387:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2500
+		//line sql.y:2505
 		{
 			sqlVAL.union.val = sqlDollar[2].union.qname()
 		}
 	case 388:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2504
+		//line sql.y:2509
 		{
 			sqlVAL.union.val = sqlDollar[3].union.qname()
 		}
 	case 389:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2510
+		//line sql.y:2515
 		{
 			sqlVAL.union.val = QualifiedNames{sqlDollar[1].union.qname()}
 		}
 	case 390:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2514
+		//line sql.y:2519
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.qnames(), sqlDollar[3].union.qname())
 		}
 	case 391:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2527
+		//line sql.y:2532
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname()}
 		}
 	case 392:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2531
+		//line sql.y:2536
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname(), As: AliasClause{Alias: Name(sqlDollar[2].str)}}
 		}
 	case 393:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2535
+		//line sql.y:2540
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname(), As: AliasClause{Alias: Name(sqlDollar[3].str)}}
 		}
 	case 394:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2541
+		//line sql.y:2546
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 395:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2545
+		//line sql.y:2550
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 396:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2557
+		//line sql.y:2562
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 		}
 	case 397:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2561
+		//line sql.y:2566
 		{
 			unimplemented()
 		}
 	case 398:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2562
+		//line sql.y:2567
 		{
 			unimplemented()
 		}
 	case 399:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2565
+		//line sql.y:2570
 		{
 			unimplemented()
 		}
 	case 400:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2566
+		//line sql.y:2571
 		{
 			unimplemented()
 		}
 	case 401:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2567
+		//line sql.y:2572
 		{
 		}
 	case 407:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2575
+		//line sql.y:2580
 		{
 			unimplemented()
 		}
 	case 408:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2577
+		//line sql.y:2582
 		{
 			sqlVAL.union.val = &BytesType{Name: "BLOB"}
 		}
 	case 409:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2581
+		//line sql.y:2586
 		{
 			sqlVAL.union.val = &BytesType{Name: "BYTES"}
 		}
 	case 410:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2585
+		//line sql.y:2590
 		{
 			sqlVAL.union.val = &BytesType{Name: "BYTEA"}
 		}
 	case 411:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2589
+		//line sql.y:2594
 		{
 			sqlVAL.union.val = &StringType{Name: "TEXT"}
 		}
 	case 416:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2610
+		//line sql.y:2615
 		{
 			sqlVAL.union.val = &DecimalType{Prec: int(sqlDollar[2].union.ival().Val)}
 		}
 	case 417:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2614
+		//line sql.y:2619
 		{
 			sqlVAL.union.val = &DecimalType{Prec: int(sqlDollar[2].union.ival().Val), Scale: int(sqlDollar[4].union.ival().Val)}
 		}
 	case 418:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2618
+		//line sql.y:2623
 		{
 			sqlVAL.union.val = &DecimalType{}
 		}
 	case 419:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2625
+		//line sql.y:2630
 		{
 			sqlVAL.union.val = &IntType{Name: "INT"}
 		}
 	case 420:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2629
+		//line sql.y:2634
 		{
 			sqlVAL.union.val = &IntType{Name: "INT64"}
 		}
 	case 421:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2633
+		//line sql.y:2638
 		{
 			sqlVAL.union.val = &IntType{Name: "INTEGER"}
 		}
 	case 422:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2637
+		//line sql.y:2642
 		{
 			sqlVAL.union.val = &IntType{Name: "SMALLINT"}
 		}
 	case 423:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2641
+		//line sql.y:2646
 		{
 			sqlVAL.union.val = &IntType{Name: "BIGINT"}
 		}
 	case 424:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2645
+		//line sql.y:2650
 		{
 			sqlVAL.union.val = &FloatType{Name: "REAL"}
 		}
 	case 425:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2649
+		//line sql.y:2654
 		{
 			sqlVAL.union.val = &FloatType{Name: "FLOAT", Prec: int(sqlDollar[2].union.ival().Val)}
 		}
 	case 426:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2653
+		//line sql.y:2658
 		{
 			sqlVAL.union.val = &FloatType{Name: "DOUBLE PRECISION"}
 		}
 	case 427:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2657
+		//line sql.y:2662
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			sqlVAL.union.val.(*DecimalType).Name = "DECIMAL"
 		}
 	case 428:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2662
+		//line sql.y:2667
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			sqlVAL.union.val.(*DecimalType).Name = "DEC"
 		}
 	case 429:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2667
+		//line sql.y:2672
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			sqlVAL.union.val.(*DecimalType).Name = "NUMERIC"
 		}
 	case 430:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2672
+		//line sql.y:2677
 		{
 			sqlVAL.union.val = &BoolType{Name: "BOOLEAN"}
 		}
 	case 431:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2676
+		//line sql.y:2681
 		{
 			sqlVAL.union.val = &BoolType{Name: "BOOL"}
 		}
 	case 432:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2682
+		//line sql.y:2687
 		{
 			sqlVAL.union.val = sqlDollar[2].union.ival()
 		}
 	case 433:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2686
+		//line sql.y:2691
 		{
 			sqlVAL.union.val = IntVal{}
 		}
 	case 438:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2704
+		//line sql.y:2709
 		{
 			sqlVAL.union.val = &IntType{Name: "BIT", N: int(sqlDollar[4].union.ival().Val)}
 		}
 	case 439:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2710
+		//line sql.y:2715
 		{
 			sqlVAL.union.val = &IntType{Name: "BIT"}
 		}
 	case 444:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2726
+		//line sql.y:2731
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 			sqlVAL.union.val.(*StringType).N = int(sqlDollar[3].union.ival().Val)
 		}
 	case 445:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2733
+		//line sql.y:2738
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 		}
 	case 446:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2739
+		//line sql.y:2744
 		{
 			sqlVAL.union.val = &StringType{Name: "CHAR"}
 		}
 	case 447:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2743
+		//line sql.y:2748
 		{
 			sqlVAL.union.val = &StringType{Name: "CHAR"}
 		}
 	case 448:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2747
+		//line sql.y:2752
 		{
 			sqlVAL.union.val = &StringType{Name: "VARCHAR"}
 		}
 	case 449:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2751
+		//line sql.y:2756
 		{
 			sqlVAL.union.val = &StringType{Name: "STRING"}
 		}
 	case 450:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2756
+		//line sql.y:2761
 		{
 		}
 	case 451:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2757
+		//line sql.y:2762
 		{
 		}
 	case 452:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2762
+		//line sql.y:2767
 		{
 			sqlVAL.union.val = &DateType{}
 		}
 	case 453:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2766
+		//line sql.y:2771
 		{
 			sqlVAL.union.val = &TimestampType{}
 		}
 	case 454:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2770
+		//line sql.y:2775
 		{
 			sqlVAL.union.val = &TimestampType{withZone: true}
 		}
 	case 455:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2775
+		//line sql.y:2780
 		{
 			sqlVAL.union.val = &IntervalType{}
 		}
 	case 456:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2780
+		//line sql.y:2785
 		{
 			unimplemented()
 		}
 	case 457:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2781
+		//line sql.y:2786
 		{
 			unimplemented()
 		}
 	case 458:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2782
+		//line sql.y:2787
 		{
 			unimplemented()
 		}
 	case 459:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2783
+		//line sql.y:2788
 		{
 			unimplemented()
 		}
 	case 460:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2784
+		//line sql.y:2789
 		{
 			unimplemented()
 		}
 	case 461:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2785
+		//line sql.y:2790
 		{
 			unimplemented()
 		}
 	case 462:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2786
+		//line sql.y:2791
 		{
 			unimplemented()
 		}
 	case 463:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2787
+		//line sql.y:2792
 		{
 			unimplemented()
 		}
 	case 464:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2788
+		//line sql.y:2793
 		{
 			unimplemented()
 		}
 	case 465:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2789
+		//line sql.y:2794
 		{
 			unimplemented()
 		}
 	case 466:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2790
+		//line sql.y:2795
 		{
 			unimplemented()
 		}
 	case 467:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2791
+		//line sql.y:2796
 		{
 			unimplemented()
 		}
 	case 468:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2792
+		//line sql.y:2797
 		{
 			unimplemented()
 		}
 	case 469:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2793
+		//line sql.y:2798
 		{
 		}
 	case 470:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2796
+		//line sql.y:2801
 		{
 			unimplemented()
 		}
 	case 471:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2797
+		//line sql.y:2802
 		{
 			unimplemented()
 		}
 	case 473:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2821
+		//line sql.y:2826
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
 		}
 	case 474:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2824
+		//line sql.y:2829
 		{
 			unimplemented()
 		}
 	case 475:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2825
+		//line sql.y:2830
 		{
 			unimplemented()
 		}
 	case 476:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2834
+		//line sql.y:2839
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 477:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2838
+		//line sql.y:2843
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 478:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2842
+		//line sql.y:2847
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].union.expr()}
 		}
 	case 479:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2846
+		//line sql.y:2851
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 480:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2850
+		//line sql.y:2855
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 481:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2854
+		//line sql.y:2859
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 482:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2858
+		//line sql.y:2863
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Div, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 483:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2862
+		//line sql.y:2867
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 484:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2866
+		//line sql.y:2871
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 485:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2870
+		//line sql.y:2875
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 486:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2874
+		//line sql.y:2879
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 487:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2878
+		//line sql.y:2883
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 488:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2882
+		//line sql.y:2887
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 489:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2886
+		//line sql.y:2891
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 490:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2890
+		//line sql.y:2895
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 491:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2894
+		//line sql.y:2899
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 492:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2898
+		//line sql.y:2903
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 493:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2902
+		//line sql.y:2907
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 494:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2906
+		//line sql.y:2911
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 495:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2910
+		//line sql.y:2915
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 496:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2914
+		//line sql.y:2919
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 497:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2918
+		//line sql.y:2923
 		{
 			sqlVAL.union.val = &AndExpr{Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 498:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2922
+		//line sql.y:2927
 		{
 			sqlVAL.union.val = &OrExpr{Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 499:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2926
+		//line sql.y:2931
 		{
 			sqlVAL.union.val = &NotExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 500:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2930
+		//line sql.y:2935
 		{
 			sqlVAL.union.val = &NotExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 501:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2934
+		//line sql.y:2939
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Like, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 502:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2938
+		//line sql.y:2943
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotLike, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 503:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2942
+		//line sql.y:2947
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: SimilarTo, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 504:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2946
+		//line sql.y:2951
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotSimilarTo, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 505:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2950
+		//line sql.y:2955
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 506:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2954
+		//line sql.y:2959
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 507:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2957
+		//line sql.y:2962
 		{
 			unimplemented()
 		}
 	case 508:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2959
+		//line sql.y:2964
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DBool(true)}
 		}
 	case 509:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2963
+		//line sql.y:2968
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DBool(true)}
 		}
 	case 510:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2967
+		//line sql.y:2972
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DBool(false)}
 		}
 	case 511:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2971
+		//line sql.y:2976
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DBool(false)}
 		}
 	case 512:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2975
+		//line sql.y:2980
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 513:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2979
+		//line sql.y:2984
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 514:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2983
+		//line sql.y:2988
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 515:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2987
+		//line sql.y:2992
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[6].union.expr()}
 		}
 	case 516:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2991
+		//line sql.y:2996
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Expr: sqlDollar[1].union.expr(), Types: sqlDollar[5].union.colTypes()}
 		}
 	case 517:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:2995
+		//line sql.y:3000
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].union.expr(), Types: sqlDollar[6].union.colTypes()}
 		}
 	case 518:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:2999
+		//line sql.y:3004
 		{
 			sqlVAL.union.val = &RangeCond{Left: sqlDollar[1].union.expr(), From: sqlDollar[4].union.expr(), To: sqlDollar[6].union.expr()}
 		}
 	case 519:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3003
+		//line sql.y:3008
 		{
 			sqlVAL.union.val = &RangeCond{Not: true, Left: sqlDollar[1].union.expr(), From: sqlDollar[5].union.expr(), To: sqlDollar[7].union.expr()}
 		}
 	case 520:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3007
+		//line sql.y:3012
 		{
 			sqlVAL.union.val = &RangeCond{Left: sqlDollar[1].union.expr(), From: sqlDollar[4].union.expr(), To: sqlDollar[6].union.expr()}
 		}
 	case 521:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3011
+		//line sql.y:3016
 		{
 			sqlVAL.union.val = &RangeCond{Not: true, Left: sqlDollar[1].union.expr(), From: sqlDollar[5].union.expr(), To: sqlDollar[7].union.expr()}
 		}
 	case 522:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3015
+		//line sql.y:3020
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: In, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 523:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3019
+		//line sql.y:3024
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotIn, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 525:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3036
+		//line sql.y:3041
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
 		}
 	case 526:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3040
+		//line sql.y:3045
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 527:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3044
+		//line sql.y:3049
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 528:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3048
+		//line sql.y:3053
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].union.expr()}
 		}
 	case 529:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3052
+		//line sql.y:3057
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 530:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3056
+		//line sql.y:3061
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 531:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3060
+		//line sql.y:3065
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 532:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3064
+		//line sql.y:3069
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Div, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 533:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3068
+		//line sql.y:3073
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 534:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3072
+		//line sql.y:3077
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 535:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3076
+		//line sql.y:3081
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 536:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3080
+		//line sql.y:3085
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 537:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3084
+		//line sql.y:3089
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 538:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3088
+		//line sql.y:3093
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 539:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3092
+		//line sql.y:3097
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 540:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3096
+		//line sql.y:3101
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 541:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3100
+		//line sql.y:3105
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 542:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3104
+		//line sql.y:3109
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 543:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3108
+		//line sql.y:3113
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 544:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3112
+		//line sql.y:3117
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 545:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3116
+		//line sql.y:3121
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 546:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3120
+		//line sql.y:3125
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 547:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3124
+		//line sql.y:3129
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 548:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3128
+		//line sql.y:3133
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[6].union.expr()}
 		}
 	case 549:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3132
+		//line sql.y:3137
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Expr: sqlDollar[1].union.expr(), Types: sqlDollar[5].union.colTypes()}
 		}
 	case 550:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3136
+		//line sql.y:3141
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].union.expr(), Types: sqlDollar[6].union.colTypes()}
 		}
 	case 551:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3148
+		//line sql.y:3153
 		{
 			sqlVAL.union.val = sqlDollar[1].union.qname()
 		}
 	case 553:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3153
+		//line sql.y:3158
 		{
 			sqlVAL.union.val = ValArg{name: sqlDollar[1].str}
 		}
 	case 554:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3157
+		//line sql.y:3162
 		{
 			sqlVAL.union.val = &ParenExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 557:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3163
+		//line sql.y:3168
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 558:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3167
+		//line sql.y:3172
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 559:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3171
+		//line sql.y:3176
 		{
 			sqlVAL.union.val = &ExistsExpr{Subquery: &Subquery{Select: sqlDollar[2].union.selectStmt()}}
 		}
 	case 560:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3177
+		//line sql.y:3182
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 561:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3181
+		//line sql.y:3186
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 562:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3185
+		//line sql.y:3190
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 563:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3193
+		//line sql.y:3198
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname()}
 		}
 	case 564:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3197
+		//line sql.y:3202
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 565:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3200
+		//line sql.y:3205
 		{
 			unimplemented()
 		}
 	case 566:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:3201
+		//line sql.y:3206
 		{
 			unimplemented()
 		}
 	case 567:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3203
+		//line sql.y:3208
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Type: All, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 568:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3207
+		//line sql.y:3212
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Type: Distinct, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 569:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3211
+		//line sql.y:3216
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Exprs: Exprs{StarExpr()}}
 		}
 	case 570:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3224
+		//line sql.y:3229
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 571:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3228
+		//line sql.y:3233
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 572:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3237
+		//line sql.y:3242
 		{
 			unimplemented()
 		}
 	case 573:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3238
+		//line sql.y:3243
 		{
 			unimplemented()
 		}
 	case 574:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3242
+		//line sql.y:3247
 		{
 			unimplemented()
 		}
 	case 575:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3244
+		//line sql.y:3249
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 576:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3248
+		//line sql.y:3253
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 577:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3252
+		//line sql.y:3257
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 578:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3256
+		//line sql.y:3261
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 579:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3259
+		//line sql.y:3264
 		{
 			unimplemented()
 		}
 	case 580:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3260
+		//line sql.y:3265
 		{
 			unimplemented()
 		}
 	case 581:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3261
+		//line sql.y:3266
 		{
 			unimplemented()
 		}
 	case 582:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3262
+		//line sql.y:3267
 		{
 			unimplemented()
 		}
 	case 583:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3264
+		//line sql.y:3269
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[3].union.expr(), Type: sqlDollar[5].union.colType()}
 		}
 	case 584:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3268
+		//line sql.y:3273
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 585:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3272
+		//line sql.y:3277
 		{
 			sqlVAL.union.val = &OverlayExpr{FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}}
 		}
 	case 586:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3276
+		//line sql.y:3281
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "STRPOS"}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 587:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3280
+		//line sql.y:3285
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 588:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3283
+		//line sql.y:3288
 		{
 			unimplemented()
 		}
 	case 589:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3285
+		//line sql.y:3290
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "BTRIM"}, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 590:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3289
+		//line sql.y:3294
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "LTRIM"}, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 591:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3293
+		//line sql.y:3298
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "RTRIM"}, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 592:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3297
+		//line sql.y:3302
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "BTRIM"}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 593:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:3301
+		//line sql.y:3306
 		{
 			sqlVAL.union.val = &IfExpr{Cond: sqlDollar[3].union.expr(), True: sqlDollar[5].union.expr(), Else: sqlDollar[7].union.expr()}
 		}
 	case 594:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3305
+		//line sql.y:3310
 		{
 			sqlVAL.union.val = &NullIfExpr{Expr1: sqlDollar[3].union.expr(), Expr2: sqlDollar[5].union.expr()}
 		}
 	case 595:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3309
+		//line sql.y:3314
 		{
 			sqlVAL.union.val = &CoalesceExpr{Name: "IFNULL", Exprs: Exprs{sqlDollar[3].union.expr(), sqlDollar[5].union.expr()}}
 		}
 	case 596:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3313
+		//line sql.y:3318
 		{
 			sqlVAL.union.val = &CoalesceExpr{Name: "COALESCE", Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 597:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3317
+		//line sql.y:3322
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 598:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3321
+		//line sql.y:3326
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 599:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3327
+		//line sql.y:3332
 		{
 			unimplemented()
 		}
 	case 600:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3328
+		//line sql.y:3333
 		{
 		}
 	case 601:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3331
+		//line sql.y:3336
 		{
 			unimplemented()
 		}
 	case 602:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3332
+		//line sql.y:3337
 		{
 		}
 	case 603:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3336
+		//line sql.y:3341
 		{
 			unimplemented()
 		}
 	case 604:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3337
+		//line sql.y:3342
 		{
 		}
 	case 605:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3340
+		//line sql.y:3345
 		{
 			unimplemented()
 		}
 	case 606:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3341
+		//line sql.y:3346
 		{
 			unimplemented()
 		}
 	case 607:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3344
+		//line sql.y:3349
 		{
 			unimplemented()
 		}
 	case 608:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3347
+		//line sql.y:3352
 		{
 			unimplemented()
 		}
 	case 609:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3348
+		//line sql.y:3353
 		{
 			unimplemented()
 		}
 	case 610:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3349
+		//line sql.y:3354
 		{
 		}
 	case 611:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3353
+		//line sql.y:3358
 		{
 			unimplemented()
 		}
 	case 612:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3364
+		//line sql.y:3369
 		{
 			unimplemented()
 		}
 	case 613:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3365
+		//line sql.y:3370
 		{
 		}
 	case 614:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3368
+		//line sql.y:3373
 		{
 			unimplemented()
 		}
 	case 615:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3369
+		//line sql.y:3374
 		{
 		}
 	case 616:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3377
+		//line sql.y:3382
 		{
 			unimplemented()
 		}
 	case 617:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3378
+		//line sql.y:3383
 		{
 			unimplemented()
 		}
 	case 618:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3379
+		//line sql.y:3384
 		{
 		}
 	case 619:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3382
+		//line sql.y:3387
 		{
 			unimplemented()
 		}
 	case 620:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3383
+		//line sql.y:3388
 		{
 			unimplemented()
 		}
 	case 621:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3389
+		//line sql.y:3394
 		{
 			unimplemented()
 		}
 	case 622:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3390
+		//line sql.y:3395
 		{
 			unimplemented()
 		}
 	case 623:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3391
+		//line sql.y:3396
 		{
 			unimplemented()
 		}
 	case 624:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3392
+		//line sql.y:3397
 		{
 			unimplemented()
 		}
 	case 625:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3393
+		//line sql.y:3398
 		{
 			unimplemented()
 		}
 	case 626:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3404
+		//line sql.y:3409
 		{
 			sqlVAL.union.val = &Row{sqlDollar[3].union.exprs()}
 		}
 	case 627:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3408
+		//line sql.y:3413
 		{
 			sqlVAL.union.val = &Row{nil}
 		}
 	case 628:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3412
+		//line sql.y:3417
 		{
 			sqlVAL.union.val = &Tuple{append(sqlDollar[2].union.exprs(), sqlDollar[4].union.expr())}
 		}
 	case 629:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3418
+		//line sql.y:3423
 		{
 			sqlVAL.union.val = &Row{sqlDollar[3].union.exprs()}
 		}
 	case 630:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3422
+		//line sql.y:3427
 		{
 			sqlVAL.union.val = &Row{nil}
 		}
 	case 631:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3428
+		//line sql.y:3433
 		{
 			sqlVAL.union.val = &Tuple{append(sqlDollar[2].union.exprs(), sqlDollar[4].union.expr())}
 		}
 	case 632:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3469
+		//line sql.y:3474
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 633:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3473
+		//line sql.y:3478
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 634:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3479
+		//line sql.y:3484
 		{
 			sqlVAL.union.val = []ColumnType{sqlDollar[1].union.colType()}
 		}
 	case 635:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3483
+		//line sql.y:3488
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.colTypes(), sqlDollar[3].union.colType())
 		}
 	case 636:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3489
+		//line sql.y:3494
 		{
 			sqlVAL.union.val = &Array{sqlDollar[2].union.exprs()}
 		}
 	case 637:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3493
+		//line sql.y:3498
 		{
 			sqlVAL.union.val = &Array{sqlDollar[2].union.exprs()}
 		}
 	case 638:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3497
+		//line sql.y:3502
 		{
 			sqlVAL.union.val = &Array{nil}
 		}
 	case 639:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3503
+		//line sql.y:3508
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 640:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3507
+		//line sql.y:3512
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 641:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3513
+		//line sql.y:3518
 		{
 			sqlVAL.union.val = Exprs{DString(sqlDollar[1].str), sqlDollar[3].union.expr()}
 		}
 	case 649:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3535
+		//line sql.y:3540
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr(), sqlDollar[4].union.expr()}
 		}
 	case 650:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3539
+		//line sql.y:3544
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr()}
 		}
 	case 651:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3545
+		//line sql.y:3550
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 652:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3552
+		//line sql.y:3557
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[3].union.expr(), sqlDollar[1].union.expr()}
 		}
 	case 653:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3556
+		//line sql.y:3561
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 654:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3573
+		//line sql.y:3578
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr()}
 		}
 	case 655:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3577
+		//line sql.y:3582
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[3].union.expr(), sqlDollar[2].union.expr()}
 		}
 	case 656:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3581
+		//line sql.y:3586
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr()}
 		}
 	case 657:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3585
+		//line sql.y:3590
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), DInt(1), sqlDollar[2].union.expr()}
 		}
 	case 658:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3589
+		//line sql.y:3594
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 659:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3593
+		//line sql.y:3598
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 660:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3599
+		//line sql.y:3604
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 661:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3605
+		//line sql.y:3610
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 662:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3611
+		//line sql.y:3616
 		{
 			sqlVAL.union.val = append(sqlDollar[3].union.exprs(), sqlDollar[1].union.expr())
 		}
 	case 663:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3615
+		//line sql.y:3620
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 664:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3619
+		//line sql.y:3624
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 665:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3625
+		//line sql.y:3630
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 666:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3629
+		//line sql.y:3634
 		{
 			sqlVAL.union.val = &Tuple{sqlDollar[2].union.exprs()}
 		}
 	case 667:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3640
+		//line sql.y:3645
 		{
 			sqlVAL.union.val = &CaseExpr{Expr: sqlDollar[2].union.expr(), Whens: sqlDollar[3].union.whens(), Else: sqlDollar[4].union.expr()}
 		}
 	case 668:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3647
+		//line sql.y:3652
 		{
 			sqlVAL.union.val = []*When{sqlDollar[1].union.when()}
 		}
 	case 669:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3651
+		//line sql.y:3656
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.whens(), sqlDollar[2].union.when())
 		}
 	case 670:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3657
+		//line sql.y:3662
 		{
 			sqlVAL.union.val = &When{Cond: sqlDollar[2].union.expr(), Val: sqlDollar[4].union.expr()}
 		}
 	case 671:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3663
+		//line sql.y:3668
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 672:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3667
+		//line sql.y:3672
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 674:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3674
+		//line sql.y:3679
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 675:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3680
+		//line sql.y:3685
 		{
 			sqlVAL.union.val = sqlDollar[1].union.indirectElem()
 		}
 	case 676:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3684
+		//line sql.y:3689
 		{
 			sqlVAL.union.val = sqlDollar[1].union.indirectElem()
 		}
 	case 677:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3688
+		//line sql.y:3693
 		{
 			sqlVAL.union.val = &ArrayIndirection{Begin: sqlDollar[2].union.expr()}
 		}
 	case 678:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3692
+		//line sql.y:3697
 		{
 			sqlVAL.union.val = &ArrayIndirection{Begin: sqlDollar[2].union.expr(), End: sqlDollar[4].union.expr()}
 		}
 	case 679:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3698
+		//line sql.y:3703
 		{
 			sqlVAL.union.val = NameIndirection(sqlDollar[2].str)
 		}
 	case 680:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3704
+		//line sql.y:3709
 		{
 			sqlVAL.union.val = qualifiedStar
 		}
 	case 681:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3710
+		//line sql.y:3715
 		{
 			sqlVAL.union.val = Indirection{sqlDollar[1].union.indirectElem()}
 		}
 	case 682:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3714
+		//line sql.y:3719
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.indirect(), sqlDollar[2].union.indirectElem())
 		}
 	case 683:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3719
+		//line sql.y:3724
 		{
 		}
 	case 684:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3720
+		//line sql.y:3725
 		{
 		}
 	case 686:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3729
+		//line sql.y:3734
 		{
 			sqlVAL.union.val = DefaultVal{}
 		}
 	case 687:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3735
+		//line sql.y:3740
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 688:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3739
+		//line sql.y:3744
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 689:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3748
+		//line sql.y:3753
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 690:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3754
+		//line sql.y:3759
 		{
 			sqlVAL.union.val = SelectExprs{sqlDollar[1].union.selExpr()}
 		}
 	case 691:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3758
+		//line sql.y:3763
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.selExprs(), sqlDollar[3].union.selExpr())
 		}
 	case 692:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3764
+		//line sql.y:3769
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr(), As: Name(sqlDollar[3].str)}
 		}
 	case 693:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3773
+		//line sql.y:3778
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr(), As: Name(sqlDollar[2].str)}
 		}
 	case 694:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3777
+		//line sql.y:3782
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr()}
 		}
 	case 695:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3781
+		//line sql.y:3786
 		{
 			sqlVAL.union.val = starSelectExpr()
 		}
 	case 696:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3789
+		//line sql.y:3794
 		{
 			sqlVAL.union.val = QualifiedNames{sqlDollar[1].union.qname()}
 		}
 	case 697:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3793
+		//line sql.y:3798
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.qnames(), sqlDollar[3].union.qname())
 		}
 	case 698:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3799
+		//line sql.y:3804
 		{
 			sqlVAL.union.val = TableNameWithIndexList{sqlDollar[1].union.tableWithIdx()}
 		}
 	case 699:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3803
+		//line sql.y:3808
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tableWithIdxList(), sqlDollar[3].union.tableWithIdx())
 		}
 	case 700:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3809
+		//line sql.y:3814
 		{
 			sqlVAL.union.val = QualifiedNames{sqlDollar[1].union.qname()}
 		}
 	case 701:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3813
+		//line sql.y:3818
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.qnames(), sqlDollar[3].union.qname())
 		}
 	case 702:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3824
+		//line sql.y:3829
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 703:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3828
+		//line sql.y:3833
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: sqlDollar[2].union.indirect()}
 		}
 	case 704:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3834
+		//line sql.y:3839
 		{
 			sqlVAL.union.val = &TableNameWithIndex{Table: sqlDollar[1].union.qname(), Index: Name(sqlDollar[3].str)}
 		}
 	case 705:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3845
+		//line sql.y:3850
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 706:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3849
+		//line sql.y:3854
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: Indirection{sqlDollar[2].union.indirectElem()}}
 		}
 	case 707:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3853
+		//line sql.y:3858
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: Indirection{sqlDollar[2].union.indirectElem()}}
 		}
 	case 708:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3857
+		//line sql.y:3862
 		{
 			sqlVAL.union.val = &QualifiedName{Indirect: Indirection{unqualifiedStar}}
 		}
 	case 709:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3863
+		//line sql.y:3868
 		{
 			sqlVAL.union.val = []string{sqlDollar[1].str}
 		}
 	case 710:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3867
+		//line sql.y:3872
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.strs(), sqlDollar[3].str)
 		}
 	case 711:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3873
+		//line sql.y:3878
 		{
 			sqlVAL.union.val = sqlDollar[2].union.strs()
 		}
 	case 712:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3876
+		//line sql.y:3881
 		{
 		}
 	case 713:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3886
+		//line sql.y:3891
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 714:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3890
+		//line sql.y:3895
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: sqlDollar[2].union.indirect()}
 		}
 	case 715:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3897
+		//line sql.y:3902
 		{
 			sqlVAL.union.val = &IntVal{Val: sqlDollar[1].union.ival().Val, Str: sqlDollar[1].union.ival().Str}
 		}
 	case 716:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3901
+		//line sql.y:3906
 		{
 			sqlVAL.union.val = NumVal(sqlDollar[1].str)
 		}
 	case 717:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3905
+		//line sql.y:3910
 		{
 			sqlVAL.union.val = DString(sqlDollar[1].str)
 		}
 	case 718:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3909
+		//line sql.y:3914
 		{
 			sqlVAL.union.val = DBytes(sqlDollar[1].str)
 		}
 	case 719:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3912
+		//line sql.y:3917
 		{
 			unimplemented()
 		}
 	case 720:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3914
+		//line sql.y:3919
 		{
 			sqlVAL.union.val = &CastExpr{Expr: DString(sqlDollar[2].str), Type: sqlDollar[1].union.colType()}
 		}
 	case 721:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3918
+		//line sql.y:3923
 		{
 			sqlVAL.union.val = &CastExpr{Expr: DString(sqlDollar[2].str), Type: sqlDollar[1].union.colType()}
 		}
 	case 722:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3922
+		//line sql.y:3927
 		{
 			sqlVAL.union.val = &CastExpr{Expr: DString(sqlDollar[5].str), Type: sqlDollar[1].union.colType()}
 		}
 	case 723:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3926
+		//line sql.y:3931
 		{
 			sqlVAL.union.val = DBool(true)
 		}
 	case 724:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3930
+		//line sql.y:3935
 		{
 			sqlVAL.union.val = DBool(false)
 		}
 	case 725:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3934
+		//line sql.y:3939
 		{
 			sqlVAL.union.val = DNull
 		}
 	case 727:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3941
+		//line sql.y:3946
 		{
 			sqlVAL.union.val = sqlDollar[2].union.ival()
 		}
 	case 728:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3945
+		//line sql.y:3950
 		{
 			sqlVAL.union.val = IntVal{Val: -sqlDollar[2].union.ival().Val, Str: "-" + sqlDollar[2].union.ival().Str}
 		}
 	case 733:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3967
+		//line sql.y:3972
 		{
 			sqlVAL.str = ""
 		}

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -461,8 +461,6 @@ func (stmt *Explain) WalkStmt(v Visitor) Statement {
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
 func (stmt *Insert) CopyNode() *Insert {
 	stmtCopy := *stmt
-	tableCopy := *stmt.Table
-	stmtCopy.Table = &tableCopy
 	stmtCopy.Columns = copyQualifiedNames(stmt.Columns)
 	stmtCopy.Returning = ReturningExprs(append([]SelectExpr(nil), stmt.Returning...))
 	return &stmtCopy

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -602,15 +602,27 @@ func TestPGPreparedExec(t *testing.T) {
 			},
 		},
 		{
+			"INSERT INTO d.t VALUES ($1), ($2) RETURNING $3 + 1",
+			[]preparedExecTest{
+				base.Params(3, 4, 5).RowsAffected(2),
+			},
+		},
+		{
 			"UPDATE d.t SET i = CASE WHEN $1 THEN i-$3 WHEN $2 THEN i+$3 END",
 			[]preparedExecTest{
-				base.Params(true, true, 3).RowsAffected(3),
+				base.Params(true, true, 3).RowsAffected(5),
 			},
 		},
 		{
 			"UPDATE d.t SET i = CASE i WHEN $1 THEN i-$3 WHEN $2 THEN i+$3 END",
 			[]preparedExecTest{
-				base.Params(1, 2, 3).RowsAffected(3),
+				base.Params(1, 2, 3).RowsAffected(5),
+			},
+		},
+		{
+			"DELETE FROM d.t RETURNING $1+1",
+			[]preparedExecTest{
+				base.Params(1).RowsAffected(5),
 			},
 		},
 		{

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -436,6 +436,12 @@ type planNode interface {
 	MarkDebug(mode explainMode)
 }
 
+type planNodeFastPath interface {
+	// FastPathResults returns the affected row count and true if the
+	// node has no result set and has already executed when Start() completes.
+	FastPathResults() (int, bool)
+}
+
 var _ planNode = &distinctNode{}
 var _ planNode = &groupNode{}
 var _ planNode = &indexJoinNode{}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -325,6 +325,9 @@ func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, *roa
 	if err != nil {
 		return nil, err
 	}
+	if err := plan.Start(); err != nil {
+		return nil, err
+	}
 	if !plan.Next() {
 		if pErr := plan.PErr(); pErr != nil {
 			return nil, pErr
@@ -421,8 +424,11 @@ type planNode interface {
 	// and Start/Next should be only called during "execute".
 	Start() *roachpb.Error
 
-	// Next advances to the next row, returning false if an error is encountered
-	// or if there is no next row.
+	// Next performs one unit of work, returning false if an error is
+	// encountered or if there is no more work to do. For statements
+	// that return a result set, the Value() method will return one row
+	// of results each time that Next() returns true.
+	// See executor.go: countRowsAffected() and execStmt() for an example.
 	Next() bool
 
 	// PErr returns the error, if any, encountered during iteration.

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -346,6 +346,9 @@ func (p *planner) exec(sql string, args ...interface{}) (int, *roachpb.Error) {
 	if pErr != nil {
 		return 0, pErr
 	}
+	if pErr := plan.Start(); pErr != nil {
+		return 0, pErr
+	}
 	return countRowsAffected(plan), plan.PErr()
 }
 
@@ -410,6 +413,13 @@ type planNode interface {
 	// result is debugValueRow, a set of values is also available through
 	// Values().
 	DebugValues() debugValues
+
+	// Start begins the query/statement and initializes what needs to be
+	// initialized (e.g. final type checking of placeholders, first query
+	// plan). Returns an error if initialization fails.
+	// The SQL "prepare" phase should merely build the plan node(s),
+	// and Start/Next should be only called during "execute".
+	Start() *roachpb.Error
 
 	// Next advances to the next row, returning false if an error is encountered
 	// or if there is no next row.
@@ -482,6 +492,10 @@ func (*emptyNode) DebugValues() debugValues {
 		value:  parser.DNull.String(),
 		output: debugValueRow,
 	}
+}
+
+func (e *emptyNode) Start() *roachpb.Error {
+	return nil
 }
 
 func (e *emptyNode) Next() bool {

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -28,6 +28,10 @@ type returningNode struct {
 	rowCount int
 }
 
+func (r *returningNode) FastPathResults() (int, bool) {
+	return r.rowCount, true
+}
+
 // returningHelper implements the logic used for statements with RETURNING clauses. It accumulates
 // result rows, one for each call to append().
 type returningHelper struct {

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -21,39 +21,26 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 )
 
-// returningNode accumulates the results for a RETURNING clause. If the rows are empty, we just
-// keep track of the count.
-type returningNode struct {
-	valuesNode
-	rowCount int
-}
-
-func (r *returningNode) FastPathResults() (int, bool) {
-	return r.rowCount, true
-}
-
-func (r *returningNode) Start() *roachpb.Error {
-	return nil
-}
-
 // returningHelper implements the logic used for statements with RETURNING clauses. It accumulates
 // result rows, one for each call to append().
 type returningHelper struct {
-	p       *planner
-	results *returningNode
+	p *planner
+	// Expected columns.
+	columns []ResultColumn
 	// Processed copies of expressions from ReturningExprs.
-	exprs parser.Exprs
-	qvals qvalMap
+	exprs    parser.Exprs
+	qvals    qvalMap
+	rowCount int
 }
 
-func makeReturningHelper(p *planner, r parser.ReturningExprs,
+func (p *planner) makeReturningHelper(r parser.ReturningExprs,
 	alias string, tablecols []ColumnDescriptor) (returningHelper, error) {
-	rh := returningHelper{p: p, results: &returningNode{}}
+	rh := returningHelper{p: p}
 	if len(r) == 0 {
 		return rh, nil
 	}
 
-	rh.results.columns = make([]ResultColumn, 0, len(r))
+	rh.columns = make([]ResultColumn, 0, len(r))
 	table := tableInfo{
 		columns: makeResultColumns(tablecols),
 		alias:   alias,
@@ -65,7 +52,7 @@ func makeReturningHelper(p *planner, r parser.ReturningExprs,
 			return returningHelper{}, err
 		} else if isStar {
 			rh.exprs = append(rh.exprs, exprs...)
-			rh.results.columns = append(rh.results.columns, cols...)
+			rh.columns = append(rh.columns, cols...)
 			continue
 		}
 
@@ -79,41 +66,43 @@ func makeReturningHelper(p *planner, r parser.ReturningExprs,
 			return returningHelper{}, err
 		}
 		rh.exprs = append(rh.exprs, expr)
-		rh.results.columns = append(rh.results.columns, ResultColumn{Name: outputName})
+		rh.columns = append(rh.columns, ResultColumn{Name: outputName})
 	}
 	return rh, nil
 }
 
-// append adds a result row. The row is computed according to the ReturningExprs, with input values
+// cookResultRow prepares a row according to the ReturningExprs, with input values
 // from rowVals.
-func (rh *returningHelper) append(rowVals parser.DTuple) error {
+func (rh *returningHelper) cookResultRow(rowVals parser.DTuple) (parser.DTuple, error) {
 	if rh.exprs == nil {
-		rh.results.rowCount++
-		return nil
+		rh.rowCount++
+		return rowVals, nil
 	}
 	rh.qvals.populateQVals(rowVals)
-	resrow := make(parser.DTuple, len(rh.exprs))
+	resRow := make(parser.DTuple, len(rh.exprs))
 	for i, e := range rh.exprs {
 		d, err := e.Eval(rh.p.evalCtx)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		resrow[i] = d
+		resRow[i] = d
 	}
-	rh.results.rows = append(rh.results.rows, resrow)
-	return nil
+	return resRow, nil
 }
 
-// getResults returns the results as a returningNode. The return column types are populated
-// from evalCtx.Args. This is needed because when makeReturningHelper is first
-// called, the MapArgs aren't yet inferred.
-func (rh *returningHelper) getResults() (*returningNode, *roachpb.Error) {
+// TypeCheck ensures that the expressions mentioned in the
+// returningHelper have the right type.
+// TODO(knz): this both annotates the type of placeholders
+// (a task for prepare) and controls that provided values
+// for placeholders match their context (a task for exec). This
+// ought to be split into two phases.
+func (rh *returningHelper) TypeCheck() *roachpb.Error {
 	for i, expr := range rh.exprs {
 		typ, err := expr.TypeCheck(rh.p.evalCtx.Args)
 		if err != nil {
-			return nil, roachpb.NewError(err)
+			return roachpb.NewError(err)
 		}
-		rh.results.columns[i].Typ = typ
+		rh.columns[i].Typ = typ
 	}
-	return rh.results, nil
+	return nil
 }

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -32,6 +32,10 @@ func (r *returningNode) FastPathResults() (int, bool) {
 	return r.rowCount, true
 }
 
+func (r *returningNode) Start() *roachpb.Error {
+	return nil
+}
+
 // returningHelper implements the logic used for statements with RETURNING clauses. It accumulates
 // result rows, one for each call to append().
 type returningHelper struct {

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -131,6 +131,10 @@ func (n *scanNode) nextKey() bool {
 	return true
 }
 
+func (n *scanNode) Start() *roachpb.Error {
+	return nil
+}
+
 func (n *scanNode) Next() bool {
 	tracing.AnnotateTrace()
 

--- a/sql/select.go
+++ b/sql/select.go
@@ -103,6 +103,10 @@ func (s *selectNode) DebugValues() debugValues {
 	return s.debugVals
 }
 
+func (s *selectNode) Start() *roachpb.Error {
+	return s.table.node.Start()
+}
+
 func (s *selectNode) Next() bool {
 	for {
 		if !s.table.node.Next() {

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -281,6 +281,10 @@ func (n *sortNode) wrap(plan planNode) planNode {
 	return plan
 }
 
+func (n *sortNode) Start() *roachpb.Error {
+	return n.plan.Start()
+}
+
 func (n *sortNode) Next() bool {
 	if n.pErr != nil {
 		return false

--- a/sql/table.go
+++ b/sql/table.go
@@ -729,10 +729,65 @@ func encodeSecondaryIndexes(tableID ID, indexes []IndexDescriptor,
 	return secondaryIndexEntries, nil
 }
 
+// checkColumnType verifies that a given value is compatible
+// with the type requested by the column. If the value is a
+// placeholder, the type of the placeholder gets populated.
+func checkColumnType(col ColumnDescriptor, val parser.Datum, args parser.MapArgs) error {
+	if val == parser.DNull {
+		return nil
+	}
+
+	var ok bool
+	var err error
+	var set parser.Datum
+	switch col.Type.Kind {
+	case ColumnType_BOOL:
+		_, ok = val.(parser.DBool)
+		set, err = args.SetInferredType(val, parser.DummyBool)
+	case ColumnType_INT:
+		_, ok = val.(parser.DInt)
+		set, err = args.SetInferredType(val, parser.DummyInt)
+	case ColumnType_FLOAT:
+		_, ok = val.(parser.DFloat)
+		set, err = args.SetInferredType(val, parser.DummyFloat)
+	case ColumnType_DECIMAL:
+		_, ok = val.(*parser.DDecimal)
+		set, err = args.SetInferredType(val, parser.DummyDecimal)
+	case ColumnType_STRING:
+		_, ok = val.(parser.DString)
+		set, err = args.SetInferredType(val, parser.DummyString)
+	case ColumnType_BYTES:
+		_, ok = val.(parser.DBytes)
+		if !ok {
+			_, ok = val.(parser.DString)
+		}
+		set, err = args.SetInferredType(val, parser.DummyBytes)
+	case ColumnType_DATE:
+		_, ok = val.(parser.DDate)
+		set, err = args.SetInferredType(val, parser.DummyDate)
+	case ColumnType_TIMESTAMP:
+		_, ok = val.(parser.DTimestamp)
+		set, err = args.SetInferredType(val, parser.DummyTimestamp)
+	case ColumnType_INTERVAL:
+		_, ok = val.(parser.DInterval)
+		set, err = args.SetInferredType(val, parser.DummyInterval)
+	default:
+		return util.Errorf("unsupported column type: %s", col.Type.Kind)
+	}
+	// Check that the value cast has succeeded.
+	// We ignore the case where it has failed because val was a DArg,
+	// which is signalled by SetInferredType returning a non-nil assignment.
+	if !ok && set == nil {
+		return fmt.Errorf("value type %s doesn't match type %s of column %q",
+			val.Type(), col.Type.Kind, col.Name)
+	}
+	return err
+}
+
 // marshalColumnValue returns a Go primitive value equivalent of val, of the
 // type expected by col. If val's type is incompatible with col, or if
 // col's type is not yet implemented, an error is returned.
-func marshalColumnValue(col ColumnDescriptor, val parser.Datum, args parser.MapArgs) (interface{}, error) {
+func marshalColumnValue(col ColumnDescriptor, val parser.Datum) (interface{}, error) {
 	if val == parser.DNull {
 		return nil, nil
 	}
@@ -742,46 +797,21 @@ func marshalColumnValue(col ColumnDescriptor, val parser.Datum, args parser.MapA
 		if v, ok := val.(parser.DBool); ok {
 			return bool(v), nil
 		}
-		if set, err := args.SetInferredType(val, parser.DummyBool); err != nil {
-			return nil, err
-		} else if set != nil {
-			return nil, nil
-		}
 	case ColumnType_INT:
 		if v, ok := val.(parser.DInt); ok {
 			return int64(v), nil
-		}
-		if set, err := args.SetInferredType(val, parser.DummyInt); err != nil {
-			return nil, err
-		} else if set != nil {
-			return nil, nil
 		}
 	case ColumnType_FLOAT:
 		if v, ok := val.(parser.DFloat); ok {
 			return float64(v), nil
 		}
-		if set, err := args.SetInferredType(val, parser.DummyFloat); err != nil {
-			return nil, err
-		} else if set != nil {
-			return nil, nil
-		}
 	case ColumnType_DECIMAL:
 		if v, ok := val.(*parser.DDecimal); ok {
 			return v.Dec, nil
 		}
-		if set, err := args.SetInferredType(val, parser.DummyDecimal); err != nil {
-			return nil, err
-		} else if set != nil {
-			return nil, nil
-		}
 	case ColumnType_STRING:
 		if v, ok := val.(parser.DString); ok {
 			return string(v), nil
-		}
-		if set, err := args.SetInferredType(val, parser.DummyString); err != nil {
-			return nil, err
-		} else if set != nil {
-			return nil, nil
 		}
 	case ColumnType_BYTES:
 		if v, ok := val.(parser.DBytes); ok {
@@ -790,37 +820,17 @@ func marshalColumnValue(col ColumnDescriptor, val parser.Datum, args parser.MapA
 		if v, ok := val.(parser.DString); ok {
 			return string(v), nil
 		}
-		if set, err := args.SetInferredType(val, parser.DummyBytes); err != nil {
-			return nil, err
-		} else if set != nil {
-			return nil, nil
-		}
 	case ColumnType_DATE:
 		if v, ok := val.(parser.DDate); ok {
 			return int64(v), nil
-		}
-		if set, err := args.SetInferredType(val, parser.DummyDate); err != nil {
-			return nil, err
-		} else if set != nil {
-			return nil, nil
 		}
 	case ColumnType_TIMESTAMP:
 		if v, ok := val.(parser.DTimestamp); ok {
 			return v.Time, nil
 		}
-		if set, err := args.SetInferredType(val, parser.DummyTimestamp); err != nil {
-			return nil, err
-		} else if set != nil {
-			return nil, nil
-		}
 	case ColumnType_INTERVAL:
 		if v, ok := val.(parser.DInterval); ok {
 			return v.Duration, nil
-		}
-		if set, err := args.SetInferredType(val, parser.DummyInterval); err != nil {
-			return nil, err
-		} else if set != nil {
-			return nil, nil
 		}
 	default:
 		return nil, util.Errorf("unsupported column type: %s", col.Type.Kind)

--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -389,6 +389,14 @@ a b a + b
 1 2 3
 3 4 7
 
+# Table alias
+statement ok
+INSERT INTO return AS r VALUES (5, 6)
+
+# TODO(knz) after #6092 is fixed
+# statement ok
+# INSERT INTO return AS r VALUES (5, 6) RETURNING r.a
+
 statement ok
 CREATE TABLE abc (
   a INT,

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -51,6 +51,9 @@ func (*explainTraceNode) Columns() []ResultColumn { return traceColumns }
 func (*explainTraceNode) Ordering() orderingInfo  { return orderingInfo{} }
 
 func (n *explainTraceNode) PErr() *roachpb.Error { return nil }
+func (n *explainTraceNode) Start() *roachpb.Error {
+	return n.plan.Start()
+}
 func (n *explainTraceNode) Next() bool {
 	first := n.rows == nil
 	if first {

--- a/sql/union.go
+++ b/sql/union.go
@@ -244,6 +244,13 @@ func (n *unionNode) readLeft() bool {
 	return false
 }
 
+func (n *unionNode) Start() *roachpb.Error {
+	if err := n.right.Start(); err != nil {
+		return err
+	}
+	return n.left.Start()
+}
+
 func (n *unionNode) Next() bool {
 	switch {
 	case !n.rightDone:

--- a/sql/update.go
+++ b/sql/update.go
@@ -18,7 +18,9 @@ package sql
 
 import (
 	"bytes"
+	"fmt"
 
+	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -27,6 +29,154 @@ import (
 	"github.com/cockroachdb/cockroach/util/tracing"
 )
 
+// editNode (Base, Run) is shared between all row updating
+// statements (DELETE, UPDATE, INSERT).
+
+// editNodeBase holds the common (prepare+execute) state needed to run
+// row-modifying statements.
+type editNodeBase struct {
+	p          *planner
+	rh         returningHelper
+	tableDesc  *TableDescriptor
+	autoCommit bool
+}
+
+func (p *planner) makeEditNode(t parser.TableExpr, r parser.ReturningExprs, autoCommit bool, priv privilege.Kind) (editNodeBase, *roachpb.Error) {
+	// TODO(marcb): We can't use the cached descriptor here because a recent
+	// update of the schema (e.g. the addition of an index) might not be
+	// reflected in the cached version (yet). Perhaps schema modification
+	// routines such as CREATE INDEX should not return until the schema change
+	// has been pushed everywhere.
+	tableDesc, pErr := p.getAliasedTableLease(t)
+	if pErr != nil {
+		return editNodeBase{}, pErr
+	}
+
+	if err := p.checkPrivilege(tableDesc, priv); err != nil {
+		return editNodeBase{}, roachpb.NewError(err)
+	}
+
+	rh, err := p.makeReturningHelper(r, tableDesc.Name, tableDesc.Columns)
+	if err != nil {
+		return editNodeBase{}, roachpb.NewError(err)
+	}
+
+	return editNodeBase{
+		p:          p,
+		rh:         rh,
+		tableDesc:  tableDesc,
+		autoCommit: autoCommit,
+	}, nil
+}
+
+// editNodeRun holds the runtime (execute) state needed to run
+// row-modifying statements.
+type editNodeRun struct {
+	rows                  planNode
+	primaryIndex          IndexDescriptor
+	primaryIndexKeyPrefix []byte
+	indexes               []IndexDescriptor
+	pErr                  *roachpb.Error
+	b                     *client.Batch
+	resultRow             parser.DTuple
+	done                  bool
+}
+
+func (r *editNodeRun) startEditNode(en *editNodeBase, rows planNode, indexes []IndexDescriptor) {
+	if isSystemConfigID(en.tableDesc.GetID()) {
+		// Mark transaction as operating on the system DB.
+		en.p.txn.SetSystemConfigTrigger()
+	}
+
+	r.rows = rows
+	r.primaryIndex = en.tableDesc.PrimaryIndex
+	r.primaryIndexKeyPrefix = MakeIndexKeyPrefix(en.tableDesc.ID, r.primaryIndex.ID)
+	r.b = en.p.txn.NewBatch()
+	r.indexes = indexes
+}
+
+func (r *editNodeRun) finalize(en *editNodeBase, convertError bool) {
+	if en.autoCommit {
+		// An auto-txn can commit the transaction with the batch. This is an
+		// optimization to avoid an extra round-trip to the transaction
+		// coordinator.
+		r.pErr = en.p.txn.CommitInBatch(r.b)
+	} else {
+		r.pErr = en.p.txn.Run(r.b)
+	}
+	if r.pErr != nil && convertError {
+		r.pErr = convertBatchError(en.tableDesc, *r.b, r.pErr)
+	}
+
+	r.done = true
+	r.b = nil
+}
+
+// recordCreatorNode (Base, Run) is shared by row creating statements
+// (UPDATE, INSERT).
+
+// rowCreatorNodeBase holds the common (prepare+execute) state needed
+// to run statements that create row values.
+type rowCreatorNodeBase struct {
+	editNodeBase
+	defaultExprs    []parser.Expr
+	cols            []ColumnDescriptor
+	primaryKeyCols  map[ColumnID]struct{}
+	colIDtoRowIndex map[ColumnID]int
+}
+
+func (p *planner) makeRowCreatorNode(en editNodeBase, cols []ColumnDescriptor, colIDtoRowIndex map[ColumnID]int, forInsert bool) (rowCreatorNodeBase, *roachpb.Error) {
+	defaultExprs, err := makeDefaultExprs(cols, &p.parser, p.evalCtx)
+	if err != nil {
+		return rowCreatorNodeBase{}, roachpb.NewError(err)
+	}
+
+	primaryKeyCols := map[ColumnID]struct{}{}
+	for i, id := range en.tableDesc.PrimaryIndex.ColumnIDs {
+		if forInsert {
+			// Verify we have at least the columns that are part of the primary key.
+			if _, ok := colIDtoRowIndex[id]; !ok {
+				return rowCreatorNodeBase{}, roachpb.NewUErrorf("missing %q primary key column", en.tableDesc.PrimaryIndex.ColumnNames[i])
+			}
+		}
+		primaryKeyCols[id] = struct{}{}
+	}
+
+	return rowCreatorNodeBase{
+		editNodeBase:    en,
+		defaultExprs:    defaultExprs,
+		cols:            cols,
+		primaryKeyCols:  primaryKeyCols,
+		colIDtoRowIndex: colIDtoRowIndex,
+	}, nil
+}
+
+// rowCreatorNodeBase holds the runtime (execute) state needed to run
+// statements that create row values.
+type rowCreatorNodeRun struct {
+	editNodeRun
+	marshalled []interface{}
+}
+
+func (r *rowCreatorNodeRun) startRowCreatorNode(en *rowCreatorNodeBase, rows planNode, indexes []IndexDescriptor) {
+	r.startEditNode(&en.editNodeBase, rows, indexes)
+	r.marshalled = make([]interface{}, len(en.cols))
+}
+
+type updateNode struct {
+	// The following fields are populated during makePlan.
+	rowCreatorNodeBase
+	n                   *parser.Update
+	colIDSet            map[ColumnID]struct{}
+	primaryKeyColChange bool
+
+	run struct {
+		// The following fields are populated during Start().
+		rowCreatorNodeRun
+		deleteOnlyIndex map[int]struct{}
+	}
+}
+
 // Update updates columns for a selection of rows from a table.
 // Privileges: UPDATE and SELECT on table. We currently always use a select statement.
 //   Notes: postgres requires UPDATE. Requires SELECT with WHERE clause with table.
@@ -34,19 +184,10 @@ import (
 // TODO(guanqun): need to support CHECK in UPDATE
 func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.Error) {
 	tracing.AnnotateTrace()
-	tableDesc, pErr := p.getAliasedTableLease(n.Table)
+
+	en, pErr := p.makeEditNode(n.Table, n.Returning, autoCommit, privilege.UPDATE)
 	if pErr != nil {
 		return nil, pErr
-	}
-
-	if err := p.checkPrivilege(tableDesc, privilege.UPDATE); err != nil {
-		return nil, roachpb.NewError(err)
-	}
-
-	// TODO(dan): Consider caching this on the TableDescriptor.
-	primaryKeyCols := map[ColumnID]struct{}{}
-	for _, id := range tableDesc.PrimaryIndex.ColumnIDs {
-		primaryKeyCols[id] = struct{}{}
 	}
 
 	exprs := make([]parser.UpdateExpr, len(n.Exprs))
@@ -56,17 +197,16 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 
 	// Determine which columns we're inserting into.
 	var names parser.QualifiedNames
-	for i, expr := range exprs {
+	for _, expr := range n.Exprs {
+		// TODO(knz): We need to (attempt to) expand subqueries here already
+		// so that it retrieves the column names. But then we need to do
+		// it again when the placeholder values are known below.
 		newExpr, epErr := p.expandSubqueries(expr.Expr, len(expr.Names))
 		if epErr != nil {
 			return nil, epErr
 		}
-		exprs[i].Expr = newExpr
 
 		if expr.Tuple {
-			// TODO(pmattis): The distinction between Tuple and DTuple here is
-			// irritating. We'll see a DTuple if the expression was a subquery that
-			// has been evaluated. We'll see a Tuple in other cases.
 			n := 0
 			switch t := newExpr.(type) {
 			case *parser.Tuple:
@@ -83,9 +223,15 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 		}
 		names = append(names, expr.Names...)
 	}
-	cols, err := p.processColumns(tableDesc, names)
+
+	cols, err := p.processColumns(en.tableDesc, names)
 	if err != nil {
 		return nil, roachpb.NewError(err)
+	}
+
+	rc, rcErr := p.makeRowCreatorNode(en, cols, nil, false)
+	if rcErr != nil {
+		return nil, rcErr
 	}
 
 	// Set of columns being updated
@@ -93,15 +239,12 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 	colIDSet := map[ColumnID]struct{}{}
 	for _, c := range cols {
 		colIDSet[c.ID] = struct{}{}
-		if _, ok := primaryKeyCols[c.ID]; ok {
+		if _, ok := rc.primaryKeyCols[c.ID]; ok {
 			primaryKeyColChange = true
 		}
 	}
 
-	defaultExprs, err := makeDefaultExprs(cols, &p.parser, p.evalCtx)
-	if err != nil {
-		return nil, roachpb.NewError(err)
-	}
+	tracing.AnnotateTrace()
 
 	// Generate the list of select targets. We need to select all of the columns
 	// plus we select all of the update expressions in case those expressions
@@ -111,16 +254,98 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 	// "*, 1, 2", not "*, (1, 2)".
 	// TODO(radu): we only need to select columns necessary to generate primary and
 	// secondary indexes keys, and columns needed by returningHelper.
-	targets := tableDesc.allColumnsSelector()
+	targets := en.tableDesc.allColumnsSelector()
 	i := 0
 	// Remember the index where the targets for exprs start.
 	exprTargetIdx := len(targets)
+	for _, expr := range n.Exprs {
+		if expr.Tuple {
+			if t, ok := expr.Expr.(*parser.Tuple); ok {
+				for _, e := range t.Exprs {
+					e = fillDefault(e, i, rc.defaultExprs)
+					targets = append(targets, parser.SelectExpr{Expr: e})
+					i++
+				}
+			}
+		} else {
+			e := fillDefault(expr.Expr, i, rc.defaultExprs)
+			targets = append(targets, parser.SelectExpr{Expr: e})
+			i++
+		}
+	}
+
+	// TODO(knz): Until we split the creation of the node from Start()
+	// for the SelectClause too, we cannot cache this. This is because
+	// this node's initSelect() method both does type checking and also
+	// performs index selection. We cannot perform index selection
+	// properly until the placeholder values are known.
+	rows, pErr := p.SelectClause(&parser.SelectClause{
+		Exprs: targets,
+		From:  []parser.TableExpr{n.Table},
+		Where: n.Where,
+	})
+	if pErr != nil {
+		return nil, pErr
+	}
+
+	// ValArgs have their types populated in the above Select if they are part
+	// of an expression ("SET a = 2 + $1") in the type check step where those
+	// types are inferred. For the simpler case ("SET a = $1"), populate them
+	// using checkColumnType. This step also verifies that the expression
+	// types match the column types.
+	for i, target := range rows.(*selectNode).render[exprTargetIdx:] {
+		// DefaultVal doesn't implement TypeCheck
+		if _, ok := target.(parser.DefaultVal); ok {
+			continue
+		}
+		d, err := target.TypeCheck(p.evalCtx.Args)
+		if err != nil {
+			return nil, roachpb.NewError(err)
+		}
+		if err := checkColumnType(cols[i], d, p.evalCtx.Args); err != nil {
+			return nil, roachpb.NewError(err)
+		}
+	}
+
+	if pErr := en.rh.TypeCheck(); pErr != nil {
+		return nil, pErr
+	}
+
+	return &updateNode{
+		n:                   n,
+		rowCreatorNodeBase:  rc,
+		primaryKeyColChange: primaryKeyColChange,
+		colIDSet:            colIDSet,
+	}, nil
+}
+
+func (u *updateNode) Start() *roachpb.Error {
+	exprs := make([]parser.UpdateExpr, len(u.n.Exprs))
+	for i, expr := range u.n.Exprs {
+		exprs[i] = *expr
+	}
+
+	// Expand the sub-queries and construct the real list of targets.
+	for i, expr := range exprs {
+		newExpr, epErr := u.p.expandSubqueries(expr.Expr, len(expr.Names))
+		if epErr != nil {
+			return epErr
+		}
+		exprs[i].Expr = newExpr
+	}
+
+	// Really generate the list of select targets.
+	// TODO(radu): we only need to select columns necessary to generate primary and
+	// secondary indexes keys, and columns needed by returningHelper.
+	targets := u.tableDesc.allColumnsSelector()
+	i := 0
 	for _, expr := range exprs {
 		if expr.Tuple {
 			switch t := expr.Expr.(type) {
 			case *parser.Tuple:
+				//panic("unreachable xz")
 				for _, e := range t.Exprs {
-					e = fillDefault(e, i, defaultExprs)
+					e = fillDefault(e, i, u.defaultExprs)
 					targets = append(targets, parser.SelectExpr{Expr: e})
 					i++
 				}
@@ -131,85 +356,58 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 				}
 			}
 		} else {
-			e := fillDefault(expr.Expr, i, defaultExprs)
+			e := fillDefault(expr.Expr, i, u.defaultExprs)
 			targets = append(targets, parser.SelectExpr{Expr: e})
 			i++
 		}
 	}
 
-	tracing.AnnotateTrace()
-
-	// Query the rows that need updating.
-	rows, pErr := p.SelectClause(&parser.SelectClause{
+	// Create the workhorse select clause for rows that need updating.
+	// TODO(knz): See comment above in Update().
+	rows, pErr := u.p.SelectClause(&parser.SelectClause{
 		Exprs: targets,
-		From:  []parser.TableExpr{n.Table},
-		Where: n.Where,
+		From:  []parser.TableExpr{u.n.Table},
+		Where: u.n.Where,
 	})
 	if pErr != nil {
-		return nil, pErr
+		return pErr
 	}
 
-	rh, err := makeReturningHelper(p, n.Returning, tableDesc.Name, tableDesc.Columns)
-	if err != nil {
-		return nil, roachpb.NewError(err)
-	}
-
-	// ValArgs have their types populated in the above Select if they are part
-	// of an expression ("SET a = 2 + $1") in the type check step where those
-	// types are inferred. For the simpler case ("SET a = $1"), populate them
-	// using marshalColumnValue. This step also verifies that the expression
-	// types match the column types.
-	if p.evalCtx.PrepareOnly {
-		for i, target := range rows.(*selectNode).render[exprTargetIdx:] {
-			// DefaultVal doesn't implement TypeCheck
-			if _, ok := target.(parser.DefaultVal); ok {
-				continue
-			}
-			d, err := target.TypeCheck(p.evalCtx.Args)
-			if err != nil {
-				return nil, roachpb.NewError(err)
-			}
-			if err := checkColumnType(cols[i], d, p.evalCtx.Args); err != nil {
-				return nil, roachpb.NewError(err)
-			}
-		}
-		// Return the result column types.
-		return rh.getResults()
+	if pErr := rows.Start(); pErr != nil {
+		return pErr
 	}
 
 	// Construct a map from column ID to the index the value appears at within a
 	// row.
 	colIDtoRowIndex := map[ColumnID]int{}
-	for i, col := range tableDesc.Columns {
+	for i, col := range u.tableDesc.Columns {
 		colIDtoRowIndex[col.ID] = i
 	}
-
-	primaryIndex := tableDesc.PrimaryIndex
-	primaryIndexKeyPrefix := MakeIndexKeyPrefix(tableDesc.ID, primaryIndex.ID)
+	u.colIDtoRowIndex = colIDtoRowIndex
 
 	// Secondary indexes needing updating.
 	needsUpdate := func(index IndexDescriptor) bool {
 		// If the primary key changed, we need to update all of them.
-		if primaryKeyColChange {
+		if u.primaryKeyColChange {
 			return true
 		}
 		for _, id := range index.ColumnIDs {
-			if _, ok := colIDSet[id]; ok {
+			if _, ok := u.colIDSet[id]; ok {
 				return true
 			}
 		}
 		return false
 	}
 
-	indexes := make([]IndexDescriptor, 0, len(tableDesc.Indexes)+len(tableDesc.Mutations))
+	indexes := make([]IndexDescriptor, 0, len(u.tableDesc.Indexes)+len(u.tableDesc.Mutations))
 	var deleteOnlyIndex map[int]struct{}
 
-	for _, index := range tableDesc.Indexes {
+	for _, index := range u.tableDesc.Indexes {
 		if needsUpdate(index) {
 			indexes = append(indexes, index)
 		}
 	}
-	for _, m := range tableDesc.Mutations {
+	for _, m := range u.tableDesc.Mutations {
 		if index := m.GetIndex(); index != nil {
 			if needsUpdate(*index) {
 				indexes = append(indexes, *index)
@@ -218,7 +416,7 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 				case DescriptorMutation_DELETE_ONLY:
 					if deleteOnlyIndex == nil {
 						// Allocate at most once.
-						deleteOnlyIndex = make(map[int]struct{}, len(tableDesc.Mutations))
+						deleteOnlyIndex = make(map[int]struct{}, len(u.tableDesc.Mutations))
 					}
 					deleteOnlyIndex[len(indexes)-1] = struct{}{}
 
@@ -228,217 +426,217 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 		}
 	}
 
-	marshalled := make([]interface{}, len(cols))
+	u.run.startRowCreatorNode(&u.rowCreatorNodeBase, rows, indexes)
 
-	b := p.txn.NewBatch()
+	u.run.deleteOnlyIndex = deleteOnlyIndex
+
+	return nil
+}
+
+func (u *updateNode) Next() bool {
+	if u.run.done || u.run.pErr != nil {
+		return false
+	}
+
+	if !u.run.rows.Next() {
+		u.run.finalize(&u.editNodeBase, true)
+		return false
+	}
+
 	tracing.AnnotateTrace()
-	for rows.Next() {
-		tracing.AnnotateTrace()
 
-		rowVals := rows.Values()
+	rowVals := u.run.rows.Values()
 
-		primaryIndexKey, _, err := encodeIndexKey(
-			&primaryIndex, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
+	primaryIndexKey, _, err := encodeIndexKey(
+		&u.run.primaryIndex, u.colIDtoRowIndex, rowVals, u.run.primaryIndexKeyPrefix)
+	if err != nil {
+		u.run.pErr = roachpb.NewError(err)
+		return false
+	}
+	// Compute the current secondary index key:value pairs for this row.
+	secondaryIndexEntries, err := encodeSecondaryIndexes(
+		u.tableDesc.ID, u.run.indexes, u.colIDtoRowIndex, rowVals)
+	if err != nil {
+		u.run.pErr = roachpb.NewError(err)
+		return false
+	}
+
+	// Our updated value expressions occur immediately after the plain
+	// columns in the output.
+	newVals := rowVals[len(u.tableDesc.Columns):]
+
+	// Ensure that the values honor the specified column widths.
+	for i := range newVals {
+		if err := checkValueWidth(u.cols[i], newVals[i]); err != nil {
+			u.run.pErr = roachpb.NewError(err)
+			return false
+		}
+	}
+
+	// Update the row values.
+	for i, col := range u.cols {
+		val := newVals[i]
+		if !col.Nullable && val == parser.DNull {
+			u.run.pErr = roachpb.NewUErrorf("null value in column %q violates not-null constraint", col.Name)
+			return false
+		}
+		rowVals[u.colIDtoRowIndex[col.ID]] = val
+	}
+
+	// Check that the new value types match the column types. This needs to
+	// happen before index encoding because certain datum types (i.e. tuple)
+	// cannot be used as index values.
+	for i, val := range newVals {
+		var mErr error
+		if u.run.marshalled[i], mErr = marshalColumnValue(u.cols[i], val); mErr != nil {
+			u.run.pErr = roachpb.NewError(mErr)
+			return false
+		}
+	}
+
+	// Compute the new primary index key for this row.
+	newPrimaryIndexKey := primaryIndexKey
+	var rowPrimaryKeyChanged bool
+	if u.primaryKeyColChange {
+		newPrimaryIndexKey, _, err = encodeIndexKey(
+			&u.run.primaryIndex, u.colIDtoRowIndex, rowVals, u.run.primaryIndexKeyPrefix)
 		if err != nil {
-			return nil, roachpb.NewError(err)
+			u.run.pErr = roachpb.NewError(err)
+			return false
 		}
-		// Compute the current secondary index key:value pairs for this row.
-		secondaryIndexEntries, err := encodeSecondaryIndexes(
-			tableDesc.ID, indexes, colIDtoRowIndex, rowVals)
-		if err != nil {
-			return nil, roachpb.NewError(err)
+		// Note that even if primaryIndexColChange is true, it's possible that
+		// primary key fields in this particular row didn't change.
+		rowPrimaryKeyChanged = !bytes.Equal(primaryIndexKey, newPrimaryIndexKey)
+	}
+
+	// Compute the new secondary index key:value pairs for this row.
+	newSecondaryIndexEntries, eErr := encodeSecondaryIndexes(
+		u.tableDesc.ID, u.run.indexes, u.colIDtoRowIndex, rowVals)
+	if eErr != nil {
+		u.run.pErr = roachpb.NewError(eErr)
+		return false
+	}
+
+	if rowPrimaryKeyChanged {
+		// Delete all the data stored under the old primary key.
+		rowStartKey := roachpb.Key(primaryIndexKey)
+		rowEndKey := rowStartKey.PrefixEnd()
+		if log.V(2) {
+			log.Infof("DelRange %s - %s", rowStartKey, rowEndKey)
 		}
+		u.run.b.DelRange(rowStartKey, rowEndKey, false)
 
-		// Our updated value expressions occur immediately after the plain
-		// columns in the output.
-		newVals := rowVals[len(tableDesc.Columns):]
-
-		// Ensure that the values honor the specified column widths.
-		for i := range newVals {
-			if err := checkValueWidth(cols[i], newVals[i]); err != nil {
-				return nil, roachpb.NewError(err)
-			}
-		}
-
-		// Update the row values.
-		for i, col := range cols {
-			val := newVals[i]
-			if !col.Nullable && val == parser.DNull {
-				return nil, roachpb.NewUErrorf("null value in column %q violates not-null constraint", col.Name)
-			}
-			rowVals[colIDtoRowIndex[col.ID]] = val
-		}
-
-		// Check that the new value types match the column types. This needs to
-		// happen before index encoding because certain datum types (i.e. tuple)
-		// cannot be used as index values.
-		for i, val := range newVals {
-			var mErr error
-			if marshalled[i], mErr = marshalColumnValue(cols[i], val); mErr != nil {
-				return nil, roachpb.NewError(mErr)
-			}
-		}
-
-		// Compute the new primary index key for this row.
-		newPrimaryIndexKey := primaryIndexKey
-		var rowPrimaryKeyChanged bool
-		if primaryKeyColChange {
-			newPrimaryIndexKey, _, err = encodeIndexKey(
-				&primaryIndex, colIDtoRowIndex, rowVals, primaryIndexKeyPrefix)
-			if err != nil {
-				return nil, roachpb.NewError(err)
-			}
-			// Note that even if primaryIndexColChange is true, it's possible that
-			// primary key fields in this particular row didn't change.
-			rowPrimaryKeyChanged = !bytes.Equal(primaryIndexKey, newPrimaryIndexKey)
-		}
-
-		// Compute the new secondary index key:value pairs for this row.
-		newSecondaryIndexEntries, eErr := encodeSecondaryIndexes(
-			tableDesc.ID, indexes, colIDtoRowIndex, rowVals)
-		if eErr != nil {
-			return nil, roachpb.NewError(eErr)
-		}
-
-		if rowPrimaryKeyChanged {
-			// Delete all the data stored under the old primary key.
-			rowStartKey := roachpb.Key(primaryIndexKey)
-			rowEndKey := rowStartKey.PrefixEnd()
+		// Delete all the old secondary indexes.
+		for _, secondaryIndexEntry := range secondaryIndexEntries {
 			if log.V(2) {
-				log.Infof("DelRange %s - %s", rowStartKey, rowEndKey)
+				log.Infof("Del %s", secondaryIndexEntry.key)
 			}
-			b.DelRange(rowStartKey, rowEndKey, false)
-
-			// Delete all the old secondary indexes.
-			for _, secondaryIndexEntry := range secondaryIndexEntries {
-				if log.V(2) {
-					log.Infof("Del %s", secondaryIndexEntry.key)
-				}
-				b.Del(secondaryIndexEntry.key)
-			}
-
-			// Write the new row sentinel. We want to write the sentinel first in case
-			// we are trying to insert a duplicate primary key: if we write the
-			// secondary indexes first, we may get an error that looks like a
-			// uniqueness violation on a non-unique index.
-			sentinelKey := keys.MakeNonColumnKey(newPrimaryIndexKey)
-			if log.V(2) {
-				log.Infof("CPut %s -> NULL", roachpb.Key(sentinelKey))
-			}
-			// This is subtle: An interface{}(nil) deletes the value, so we pass in
-			// []byte{} as a non-nil value.
-			b.CPut(sentinelKey, []byte{}, nil)
-
-			// Write any fields from the old row that were not modified by the UPDATE.
-			for i, col := range tableDesc.Columns {
-				if _, ok := colIDSet[col.ID]; ok {
-					continue
-				}
-				if _, ok := primaryKeyCols[col.ID]; ok {
-					continue
-				}
-				key := keys.MakeColumnKey(newPrimaryIndexKey, uint32(col.ID))
-				val := rowVals[i]
-				marshalledVal, mErr := marshalColumnValue(col, val)
-				if mErr != nil {
-					return nil, roachpb.NewError(mErr)
-				}
-
-				if log.V(2) {
-					log.Infof("Put %s -> %v", roachpb.Key(key), val)
-				}
-				b.Put(key, marshalledVal)
-			}
-			// At this point, we've deleted the old row and associated index data and
-			// written the sentinel keys and column keys for non-updated columns. Fall
-			// through to below where the index keys and updated column keys will be
-			// written.
+			u.run.b.Del(secondaryIndexEntry.key)
 		}
 
-		// Update secondary indexes.
-		for i, newSecondaryIndexEntry := range newSecondaryIndexEntries {
-			secondaryIndexEntry := secondaryIndexEntries[i]
-			secondaryKeyChanged := !bytes.Equal(newSecondaryIndexEntry.key, secondaryIndexEntry.key)
-			if secondaryKeyChanged {
-				if log.V(2) {
-					log.Infof("Del %s", secondaryIndexEntry.key)
-				}
-				b.Del(secondaryIndexEntry.key)
-			}
-			if rowPrimaryKeyChanged || secondaryKeyChanged {
-				// Do not update Indexes in the DELETE_ONLY state.
-				if _, ok := deleteOnlyIndex[i]; !ok {
-					if log.V(2) {
-						log.Infof("CPut %s -> %v", newSecondaryIndexEntry.key,
-							newSecondaryIndexEntry.value)
-					}
-					b.CPut(newSecondaryIndexEntry.key, newSecondaryIndexEntry.value, nil)
-				}
-			}
+		// Write the new row sentinel. We want to write the sentinel first in case
+		// we are trying to insert a duplicate primary key: if we write the
+		// secondary indexes first, we may get an error that looks like a
+		// uniqueness violation on a non-unique index.
+		sentinelKey := keys.MakeNonColumnKey(newPrimaryIndexKey)
+		if log.V(2) {
+			log.Infof("CPut %s -> NULL", roachpb.Key(sentinelKey))
 		}
+		// This is subtle: An interface{}(nil) deletes the value, so we pass in
+		// []byte{} as a non-nil value.
+		u.run.b.CPut(sentinelKey, []byte{}, nil)
 
-		// Add the new values.
-		for i, val := range newVals {
-			col := cols[i]
-
-			if _, ok := primaryKeyCols[col.ID]; ok {
-				// Skip primary key columns as their values are encoded in the row
-				// sentinel key which is guaranteed to exist for as long as the row
-				// exists.
+		// Write any fields from the old row that were not modified by the UPDATE.
+		for i, col := range u.tableDesc.Columns {
+			if _, ok := u.colIDSet[col.ID]; ok {
 				continue
 			}
-
+			if _, ok := u.primaryKeyCols[col.ID]; ok {
+				continue
+			}
 			key := keys.MakeColumnKey(newPrimaryIndexKey, uint32(col.ID))
-			if marshalled[i] != nil {
-				// We only output non-NULL values. Non-existent column keys are
-				// considered NULL during scanning and the row sentinel ensures we know
-				// the row exists.
-				if log.V(2) {
-					log.Infof("Put %s -> %v", roachpb.Key(key), val)
-				}
+			val := rowVals[i]
+			marshalledVal, mErr := marshalColumnValue(col, val)
+			if mErr != nil {
+				u.run.pErr = roachpb.NewError(mErr)
+				return false
+			}
 
-				b.Put(key, marshalled[i])
-			} else {
-				// The column might have already existed but is being set to NULL, so
-				// delete it.
-				if log.V(2) {
-					log.Infof("Del %s", key)
-				}
+			if log.V(2) {
+				log.Infof("Put %s -> %v", roachpb.Key(key), val)
+			}
+			u.run.b.Put(key, marshalledVal)
+		}
+		// At this point, we've deleted the old row and associated index data and
+		// written the sentinel keys and column keys for non-updated columns. Fall
+		// through to below where the index keys and updated column keys will be
+		// written.
+	}
 
-				b.Del(key)
+	// Update secondary indexes.
+	for i, newSecondaryIndexEntry := range newSecondaryIndexEntries {
+		secondaryIndexEntry := secondaryIndexEntries[i]
+		secondaryKeyChanged := !bytes.Equal(newSecondaryIndexEntry.key, secondaryIndexEntry.key)
+		if secondaryKeyChanged {
+			if log.V(2) {
+				log.Infof("Del %s", secondaryIndexEntry.key)
+			}
+			u.run.b.Del(secondaryIndexEntry.key)
+		}
+		if rowPrimaryKeyChanged || secondaryKeyChanged {
+			// Do not update Indexes in the DELETE_ONLY state.
+			if _, ok := u.run.deleteOnlyIndex[i]; !ok {
+				if log.V(2) {
+					log.Infof("CPut %s -> %v", newSecondaryIndexEntry.key,
+						newSecondaryIndexEntry.value)
+				}
+				u.run.b.CPut(newSecondaryIndexEntry.key, newSecondaryIndexEntry.value, nil)
 			}
 		}
+	}
 
-		// rowVals[:len(tableDesc.Columns)] have been updated with the new values above.
-		if err := rh.append(rowVals[:len(tableDesc.Columns)]); err != nil {
-			return nil, roachpb.NewError(err)
+	// Add the new values.
+	for i, val := range newVals {
+		col := u.cols[i]
+
+		if _, ok := u.primaryKeyCols[col.ID]; ok {
+			// Skip primary key columns as their values are encoded in the row
+			// sentinel key which is guaranteed to exist for as long as the row
+			// exists.
+			continue
 		}
-	}
-	tracing.AnnotateTrace()
 
-	if pErr := rows.PErr(); pErr != nil {
-		return nil, pErr
+		key := keys.MakeColumnKey(newPrimaryIndexKey, uint32(col.ID))
+		if u.run.marshalled[i] != nil {
+			// We only output non-NULL values. Non-existent column keys are
+			// considered NULL during scanning and the row sentinel ensures we know
+			// the row exists.
+			if log.V(2) {
+				log.Infof("Put %s -> %v", roachpb.Key(key), val)
+			}
+
+			u.run.b.Put(key, u.run.marshalled[i])
+		} else {
+			// The column might have already existed but is being set to NULL, so
+			// delete it.
+			if log.V(2) {
+				log.Infof("Del %s", key)
+			}
+
+			u.run.b.Del(key)
+		}
+
 	}
 
-	if isSystemConfigID(tableDesc.GetID()) {
-		// Mark transaction as operating on the system DB.
-		p.txn.SetSystemConfigTrigger()
+	// rowVals[:len(tableDesc.Columns)] have been updated with the new values above.
+	resultRow, err := u.rh.cookResultRow(rowVals[:len(u.tableDesc.Columns)])
+	if err != nil {
+		u.run.pErr = roachpb.NewError(err)
+		return false
 	}
+	u.run.resultRow = resultRow
 
-	if autoCommit {
-		// An auto-txn can commit the transaction with the batch. This is an
-		// optimization to avoid an extra round-trip to the transaction
-		// coordinator.
-		pErr = p.txn.CommitInBatch(b)
-	} else {
-		pErr = p.txn.Run(b)
-	}
-	if pErr != nil {
-		return nil, convertBatchError(tableDesc, *b, pErr)
-	}
-
-	tracing.AnnotateTrace()
-	return rh.getResults()
+	return true
 }
 
 func fillDefault(expr parser.Expr, index int, defaultExprs []parser.Expr) parser.Expr {
@@ -448,3 +646,49 @@ func fillDefault(expr parser.Expr, index int, defaultExprs []parser.Expr) parser
 	}
 	return expr
 }
+
+func (u *updateNode) Columns() []ResultColumn {
+	return u.rh.columns
+}
+
+func (u *updateNode) Values() parser.DTuple {
+	return u.run.resultRow
+}
+
+func (u *updateNode) MarkDebug(mode explainMode) {
+	u.run.rows.MarkDebug(mode)
+}
+
+func (u *updateNode) DebugValues() debugValues {
+	return u.run.rows.DebugValues()
+}
+
+func (u *updateNode) Ordering() orderingInfo {
+	return u.run.rows.Ordering()
+}
+
+func (u *updateNode) PErr() *roachpb.Error {
+	return u.run.pErr
+}
+
+func (u *updateNode) ExplainPlan() (name, description string, children []planNode) {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "set %s (", u.tableDesc.Name)
+	for i, col := range u.cols {
+		if i > 0 {
+			fmt.Fprintf(&buf, ", ")
+		}
+		fmt.Fprintf(&buf, "%s", col.Name)
+	}
+	fmt.Fprintf(&buf, ") returning (")
+	for i, col := range u.rh.columns {
+		if i > 0 {
+			fmt.Fprintf(&buf, ", ")
+		}
+		fmt.Fprintf(&buf, "%s", col.Name)
+	}
+	fmt.Fprintf(&buf, ")")
+	return "update", buf.String(), []planNode{u.run.rows}
+}
+
+func (u *updateNode) SetLimitHint(numRows int64, soft bool) {}

--- a/sql/update.go
+++ b/sql/update.go
@@ -169,7 +169,7 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 			if err != nil {
 				return nil, roachpb.NewError(err)
 			}
-			if _, err := marshalColumnValue(cols[i], d, p.evalCtx.Args); err != nil {
+			if err := checkColumnType(cols[i], d, p.evalCtx.Args); err != nil {
 				return nil, roachpb.NewError(err)
 			}
 		}
@@ -274,7 +274,7 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 		// cannot be used as index values.
 		for i, val := range newVals {
 			var mErr error
-			if marshalled[i], mErr = marshalColumnValue(cols[i], val, p.evalCtx.Args); mErr != nil {
+			if marshalled[i], mErr = marshalColumnValue(cols[i], val); mErr != nil {
 				return nil, roachpb.NewError(mErr)
 			}
 		}
@@ -339,7 +339,7 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 				}
 				key := keys.MakeColumnKey(newPrimaryIndexKey, uint32(col.ID))
 				val := rowVals[i]
-				marshalledVal, mErr := marshalColumnValue(col, val, p.evalCtx.Args)
+				marshalledVal, mErr := marshalColumnValue(col, val)
 				if mErr != nil {
 					return nil, roachpb.NewError(mErr)
 				}

--- a/sql/values.go
+++ b/sql/values.go
@@ -114,6 +114,10 @@ func (n *valuesNode) DebugValues() debugValues {
 	}
 }
 
+func (n *valuesNode) Start() *roachpb.Error {
+	return nil
+}
+
 func (n *valuesNode) Next() bool {
 	if n.nextRow >= len(n.rows) {
 		return false


### PR DESCRIPTION
Prior to this patch, UPDATE/DELETE/INSERT would execute their effects
once during the SQL "prepare" phase and then once again during the
"execute" phase. Moreover, when the RETURNING clause was used, the
results of the operation would be collected in memory (in a
resultNode) prior to being consumed by the Executor. This incurred a
memory cost always proportional with the number of rows being updated.

This patch addresses these issues by splitting the behavior of these
statements in two, so that their effects only start when the
planNode.Next() method is called.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5903)

<!-- Reviewable:end -->
