### PR TITLE
sim: fix panic on startup

### DIFF
--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -75,6 +75,9 @@ func createCluster(
 	clock := hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(nil, clock, stopper)
 	g := gossip.New(rpcContext, nil, stopper)
+	// NodeID is required for Gossip, so set it to -1 for the cluster Gossip
+	// instance to prevent conflicts with real NodeIDs.
+	g.SetNodeID(-1)
 	storePool := storage.NewStorePool(g, clock, storage.TestTimeUntilStoreDeadOff, stopper)
 	c := &Cluster{
 		stopper:   stopper,


### PR DESCRIPTION
Fixes this panic during the startup of the rebalancing simulator:

```
panic: gossip infostore's NodeID is 0
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5904)

<!-- Reviewable:end -->
