### PR TITLE
Fixes and acceptance tests including upstream integration tests for finagle-postgres 

### DIFF
--- a/acceptance/finagle_test.go
+++ b/acceptance/finagle_test.go
@@ -1,0 +1,28 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package acceptance
+
+import "testing"
+
+func TestDockerFinagle(t *testing.T) {
+	testDockerSuccess(t, "finagle", []string{"/bin/sh", "-c", finagle})
+}
+
+const finagle = `
+set -e
+openssl pkcs12 -export -in $PGSSLCERT -inkey $PGSSLKEY -out /client.p12 -name "Whatever" -password pass:
+echo "CREATE DATABASE finagle_postgres_test" | psql
+PGHOSTPORT=$PGHOST:$PGPORT USE_PG_SSL=1 RUN_PG_INTEGRATION_TESTS=1 PGUSER="root" PG_PKCS12=/client.p12 java -jar /finagle-postgres-tests.jar com.twitter.finagle.postgres.integration.IntegrationSpec
+`

--- a/acceptance/java_test.go
+++ b/acceptance/java_test.go
@@ -105,7 +105,7 @@ EOF
 # See: https://basildoncoder.com/blog/postgresql-jdbc-client-certificates.html
 openssl pkcs8 -topk8 -inform PEM -outform DER -in /certs/node.key -out key.pk8 -nocrypt
 
-export PATH=$PATH:/usr/lib/jvm/java-1.7-openjdk/bin
+export PATH=$PATH:/usr/lib/jvm/java-1.8-openjdk/bin
 javac main.java
 java -cp /postgres.jar:. main
 `

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -283,7 +283,7 @@ func testDockerSuccess(t *testing.T, name string, cmd []string) {
 }
 
 const (
-	postgresTestTag = "20160404-130000"
+	postgresTestTag = "20160405-1938"
 )
 
 func testDocker(t *testing.T, name string, cmd []string) error {

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -283,7 +283,7 @@ func testDockerSuccess(t *testing.T, name string, cmd []string) {
 }
 
 const (
-	postgresTestTag = "20160405-1938"
+	postgresTestTag = "20160406-1730"
 )
 
 func testDocker(t *testing.T, name string, cmd []string) error {

--- a/sql/pgwire/types.go
+++ b/sql/pgwire/types.go
@@ -82,7 +82,7 @@ func typeForDatum(d parser.Datum) pgType {
 		return pgType{oid.T_date, 8}
 
 	case parser.DTimestamp:
-		return pgType{oid.T_timestamp, 8}
+		return pgType{oid.T_timestamptz, 8}
 
 	case parser.DInterval:
 		return pgType{oid.T_interval, 8}
@@ -257,19 +257,20 @@ func parseTs(str string) (time.Time, error) {
 
 var (
 	oidToDatum = map[oid.Oid]parser.Datum{
-		oid.T_bool:      parser.DummyBool,
-		oid.T_bytea:     parser.DummyBytes,
-		oid.T_date:      parser.DummyDate,
-		oid.T_float4:    parser.DummyFloat,
-		oid.T_float8:    parser.DummyFloat,
-		oid.T_int2:      parser.DummyInt,
-		oid.T_int4:      parser.DummyInt,
-		oid.T_int8:      parser.DummyInt,
-		oid.T_interval:  parser.DummyInterval,
-		oid.T_numeric:   parser.DummyDecimal,
-		oid.T_text:      parser.DummyString,
-		oid.T_timestamp: parser.DummyTimestamp,
-		oid.T_varchar:   parser.DummyString,
+		oid.T_bool:        parser.DummyBool,
+		oid.T_bytea:       parser.DummyBytes,
+		oid.T_date:        parser.DummyDate,
+		oid.T_float4:      parser.DummyFloat,
+		oid.T_float8:      parser.DummyFloat,
+		oid.T_int2:        parser.DummyInt,
+		oid.T_int4:        parser.DummyInt,
+		oid.T_int8:        parser.DummyInt,
+		oid.T_interval:    parser.DummyInterval,
+		oid.T_numeric:     parser.DummyDecimal,
+		oid.T_text:        parser.DummyString,
+		oid.T_timestamp:   parser.DummyTimestamp,
+		oid.T_timestamptz: parser.DummyTimestamp,
+		oid.T_varchar:     parser.DummyString,
 	}
 	// Using reflection to support unhashable types.
 	datumToOid = map[reflect.Type]oid.Oid{
@@ -281,7 +282,7 @@ var (
 		reflect.TypeOf(parser.DummyInterval):  oid.T_interval,
 		reflect.TypeOf(parser.DummyDecimal):   oid.T_numeric,
 		reflect.TypeOf(parser.DummyString):    oid.T_text,
-		reflect.TypeOf(parser.DummyTimestamp): oid.T_timestamp,
+		reflect.TypeOf(parser.DummyTimestamp): oid.T_timestamptz,
 	}
 )
 
@@ -432,7 +433,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 		default:
 			return d, fmt.Errorf("unsupported bytea format code: %d", code)
 		}
-	case oid.T_timestamp:
+	case oid.T_timestamp, oid.T_timestamptz:
 		switch code {
 		case formatText:
 			ts, err := parseTs(string(b))

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -696,7 +696,10 @@ func (c *v3Conn) sendError(errCode string, errToSend string) error {
 	if err := c.writeBuf.WriteByte(0); err != nil {
 		return err
 	}
-	return c.writeBuf.finishMsg(c.wr)
+	if err := c.writeBuf.finishMsg(c.wr); err != nil {
+		return err
+	}
+	return c.wr.Flush()
 }
 
 func (c *v3Conn) sendResponse(results sql.ResultList, formatCodes []formatCode, sendDescription bool, limit int32) error {


### PR DESCRIPTION
Fixes for two pgwire issues this uncovered, but more significantly this includes running `finagle-postgres`'s own integration tests in our acceptance tests.

Our fork of their repo contains a patchset that lets us build a "fat jar" that includes all its own dependencies, meaning we don't need to resolve the class path and have scala etc all available at testing time. During build of the docker image (in our postgres-test repo) we build said fat-jar and include it in the image. This lets us run tests in a reasonable amount of time, but the downside is that modifying their tests is a much trickier process -- we need to rebase our patchset, tag and build a new docker image and then bump the version. Overall though we modify an acceptance test rarely compared to how often we run them, so saving 5-20 minutes per run at the expense of more difficult packaging makes sense.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5909)

<!-- Reviewable:end -->
