### PR TITLE
sql: tie SQL timestamp functions to the gateway physical clock

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -372,9 +372,8 @@ func (e *Executor) execRequest(ctx context.Context, session *Session, sql string
 			txnState.reset(ctx, e, session)
 			txnState.State = Open
 			txnState.autoRetry = true
-			now := e.ctx.Clock.Now()
-			txnState.sqlTimestamp = now
-			execOpt.MinInitialTimestamp = now
+			execOpt.MinInitialTimestamp = e.ctx.Clock.Now()
+			txnState.sqlTimestamp = e.ctx.Clock.PhysicalTime()
 			if execOpt.AutoCommit {
 				txnState.txn.SetDebugName(sqlImplicitTxnName, 0)
 			} else {
@@ -685,7 +684,7 @@ func (e *Executor) execStmtInOpenTxn(
 	}
 
 	planMaker.evalCtx.SetTxnTimestamp(txnState.sqlTimestamp)
-	planMaker.evalCtx.SetStmtTimestamp(e.ctx.Clock.Now())
+	planMaker.evalCtx.SetStmtTimestamp(e.ctx.Clock.PhysicalTime())
 
 	// TODO(cdo): Figure out how to not double count on retries.
 	e.updateStmtCounts(stmt)

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -820,13 +820,13 @@ func (ctx *EvalContext) GetTxnTimestamp() DTimestamp {
 }
 
 // SetTxnTimestamp sets the corresponding timestamp in the EvalContext.
-func (ctx *EvalContext) SetTxnTimestamp(ts roachpb.Timestamp) {
-	ctx.txnTimestamp.Time = ts.GoTime()
+func (ctx *EvalContext) SetTxnTimestamp(ts time.Time) {
+	ctx.txnTimestamp.Time = ts
 }
 
 // SetStmtTimestamp sets the corresponding timestamp in the EvalContext.
-func (ctx *EvalContext) SetStmtTimestamp(ts roachpb.Timestamp) {
-	ctx.stmtTimestamp.Time = ts.GoTime()
+func (ctx *EvalContext) SetStmtTimestamp(ts time.Time) {
+	ctx.stmtTimestamp.Time = ts
 }
 
 var tenBillion = big.NewInt(1e10)

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -18,6 +18,7 @@ package sql
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
@@ -163,8 +164,8 @@ func (p *planner) setTxn(txn *client.Txn) {
 	if txn != nil {
 		p.evalCtx.SetClusterTimestamp(txn.Proto.OrigTimestamp)
 	} else {
-		p.evalCtx.SetTxnTimestamp(roachpb.ZeroTimestamp)
-		p.evalCtx.SetStmtTimestamp(roachpb.ZeroTimestamp)
+		p.evalCtx.SetTxnTimestamp(time.Time{})
+		p.evalCtx.SetStmtTimestamp(time.Time{})
 		p.evalCtx.SetClusterTimestamp(roachpb.ZeroTimestamp)
 	}
 }

--- a/sql/session.go
+++ b/sql/session.go
@@ -176,7 +176,7 @@ type txnState struct {
 
 	// The timestamp to report for current_timestamp(), now() etc.
 	// This must be constant for the lifetime of a SQL transaction.
-	sqlTimestamp roachpb.Timestamp
+	sqlTimestamp time.Time
 }
 
 // reset creates a new Txn and initializes it using the session defaults.


### PR DESCRIPTION
A previous commit decoupled the SQL timestamp functions
(current_timestamp() and statement_timestamp()) from the database
transaction timestamp, because users expect the former to change
"faster" than the latter does in practice. However this change tied
the SQL functions to the gateway's _logical_ clock, which still yields
surprising behavior: the logical clock may also jump forward in time
and stall there due to being pushed forward due to clock drifts
between nodes, etc.

This changeset completes the decoupling further by using the
physical clock for SQL's current_timestamp() / statement_timestamp().

Requested by @tschottdorf in https://github.com/cockroachdb/cockroach/pull/5805#discussion_r58826689

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5915)

<!-- Reviewable:end -->
