### PR TITLE
gossip: remove Resolver.IsExhausted

### DIFF
--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -369,14 +369,10 @@ func (tr *testResolver) Addr() string { return tr.addr }
 
 func (tr *testResolver) GetAddress() (net.Addr, error) {
 	defer func() { tr.numTries++ }()
-	if tr.numTries < tr.numFails || tr.IsExhausted() {
+	if tr.numTries < tr.numFails {
 		return nil, errors.New("bad address")
 	}
 	return util.NewUnresolvedAddr("tcp", tr.addr), nil
-}
-
-func (tr *testResolver) IsExhausted() bool {
-	return tr.numTries > tr.numFails+tr.numSuccesses
 }
 
 // TestClientRetryBootstrap verifies that an initial failure to connect

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -699,9 +699,6 @@ func (g *Gossip) getNextBootstrapAddress() net.Addr {
 		g.resolverIdx %= len(g.resolvers)
 		g.resolversTried[g.resolverIdx] = struct{}{}
 		resolver := g.resolvers[g.resolverIdx]
-		if resolver.IsExhausted() {
-			continue
-		}
 		if addr, err := resolver.GetAddress(); err != nil {
 			log.Errorf("invalid bootstrap address: %+v, %v", resolver, err)
 			continue

--- a/gossip/resolver/node_lookup.go
+++ b/gossip/resolver/node_lookup.go
@@ -97,7 +97,3 @@ func resolveAddress(network, address string) (net.Addr, error) {
 	}
 	return nil, util.Errorf("unknown address type: %q", network)
 }
-
-// IsExhausted always returns false, as there's no way to know how many
-// nodes are behind a load balancer.
-func (nl *nodeLookupResolver) IsExhausted() bool { return false }

--- a/gossip/resolver/resolver.go
+++ b/gossip/resolver/resolver.go
@@ -31,7 +31,6 @@ type Resolver interface {
 	Type() string
 	Addr() string
 	GetAddress() (net.Addr, error)
-	IsExhausted() bool
 }
 
 var validTypes = map[string]struct{}{

--- a/gossip/resolver/resolver_test.go
+++ b/gossip/resolver/resolver_test.go
@@ -73,15 +73,14 @@ func TestGetAddress(t *testing.T) {
 	testCases := []struct {
 		resolverSpec string
 		success      bool
-		oneShot      bool
 		addressType  string
 		addressValue string
 	}{
-		{"tcp=127.0.0.1:26222", true, true, "tcp", "127.0.0.1:26222"},
-		{"tcp=127.0.0.1", true, true, "tcp", "127.0.0.1:" + base.DefaultPort},
-		{"tcp=localhost:80", true, true, "tcp", "localhost:80"},
+		{"tcp=127.0.0.1:26222", true, "tcp", "127.0.0.1:26222"},
+		{"tcp=127.0.0.1", true, "tcp", "127.0.0.1:" + base.DefaultPort},
+		{"tcp=localhost:80", true, "tcp", "localhost:80"},
 		// We should test unresolvable dns too, but this would be fragile.
-		{"unix=/tmp/foo", true, true, "unix", "/tmp/foo"},
+		{"unix=/tmp/foo", true, "unix", "/tmp/foo"},
 	}
 
 	for tcNum, tc := range testCases {
@@ -95,9 +94,6 @@ func TestGetAddress(t *testing.T) {
 		}
 		if err != nil {
 			continue
-		}
-		if resolver.IsExhausted() != tc.oneShot {
-			t.Errorf("#%d: expected exhausted resolver=%t, but is: %+v", tcNum, tc.oneShot, resolver)
 		}
 		if address.Network() != tc.addressType {
 			t.Errorf("#%d: expected address type=%s, got %+v", tcNum, tc.addressType, address)

--- a/gossip/resolver/socket.go
+++ b/gossip/resolver/socket.go
@@ -56,7 +56,3 @@ func (sr *socketResolver) GetAddress() (net.Addr, error) {
 	}
 	return nil, util.Errorf("unknown address type: %q", sr.typ)
 }
-
-// IsExhausted returns whether the resolver can yield further
-// addresses.
-func (sr *socketResolver) IsExhausted() bool { return sr.exhausted }


### PR DESCRIPTION
The IsExhausted mechanism was preventing a node from connecting to the
gossip cluster if the bootstrap addresses were all uneachable when it
started up. We want to retry the bootstrap addresses indefinitely.

Fixes #5902.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5916)

<!-- Reviewable:end -->
