### PR TITLE
Benchmarks to answer: "how much overhead is SQL vs native KV?"

### DIFF
--- a/sql/kv_test.go
+++ b/sql/kv_test.go
@@ -1,0 +1,460 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Spencer Kimball (spencer@cockroachlabs.com)
+
+package sql_test
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/tracing"
+)
+
+type keyValue struct {
+	key   []byte
+	value []byte
+}
+
+type kvInterface interface {
+	insert(rows, run int) error
+	update(rows, run int) error
+	del(rows, run int) error
+	scan(rows, run int) error
+
+	prep(rows int, initData bool) error
+	done()
+}
+
+// kvNative uses the native client package to implement kvInterface.
+type kvNative struct {
+	db     *client.DB
+	epoch  int
+	prefix string
+	doneFn func()
+}
+
+func newKVNative(b *testing.B) kvInterface {
+	enableTracing := tracing.Disable()
+	s := server.StartTestServer(b)
+
+	return &kvNative{
+		db: s.DB(),
+		doneFn: func() {
+			s.Stop()
+			enableTracing()
+		},
+	}
+}
+
+func (kv *kvNative) insert(rows, run int) error {
+	firstRow := rows * run
+	lastRow := rows * (run + 1)
+	pErr := kv.db.Txn(func(txn *client.Txn) *roachpb.Error {
+		b := txn.NewBatch()
+		for i := firstRow; i < lastRow; i++ {
+			b.Put(fmt.Sprintf("%s%06d", kv.prefix, i), i)
+		}
+		return txn.Run(b)
+	})
+	return pErr.GoError()
+}
+
+func (kv *kvNative) update(rows, run int) error {
+	pErr := kv.db.Txn(func(txn *client.Txn) *roachpb.Error {
+		// Read all values in a batch.
+		b := txn.NewBatch()
+		for i := 0; i < rows; i++ {
+			b.Get(fmt.Sprintf("%s%06d", kv.prefix, i))
+		}
+		if pErr := txn.Run(b); pErr != nil {
+			return pErr
+		}
+		// Now add one to each value and add as puts to write batch.
+		wb := txn.NewBatch()
+		for i, result := range b.Results {
+			v := result.Rows[0].ValueInt()
+			wb.Put(fmt.Sprintf("%s%06d", kv.prefix, i), v+1)
+		}
+		if pErr := txn.Run(wb); pErr != nil {
+			return pErr
+		}
+		return nil
+	})
+	return pErr.GoError()
+}
+
+func (kv *kvNative) del(rows, run int) error {
+	pErr := kv.db.Txn(func(txn *client.Txn) *roachpb.Error {
+		b := txn.NewBatch()
+		for i := 0; i < rows; i++ {
+			b.Del(fmt.Sprintf("%s%06d", kv.prefix, i))
+		}
+		return txn.Run(b)
+	})
+	return pErr.GoError()
+}
+
+func (kv *kvNative) scan(rows, run int) error {
+	pErr := kv.db.Txn(func(txn *client.Txn) *roachpb.Error {
+		kvs, pErr := txn.Scan(fmt.Sprintf("%s%06d", kv.prefix, 0), fmt.Sprintf("%s%06d", kv.prefix, rows), int64(rows))
+		if len(kvs) != rows {
+			return roachpb.NewErrorf("expected %d rows; got %d", rows, len(kvs))
+		}
+		return pErr
+	})
+	return pErr.GoError()
+}
+
+func (kv *kvNative) prep(rows int, initData bool) error {
+	kv.epoch++
+	kv.prefix = fmt.Sprintf("%d/", kv.epoch)
+	if !initData {
+		return nil
+	}
+	pErr := kv.db.Txn(func(txn *client.Txn) *roachpb.Error {
+		b := txn.NewBatch()
+		for i := 0; i < rows; i++ {
+			b.Put(fmt.Sprintf("%s%06d", kv.prefix, i), i)
+		}
+		return txn.Run(b)
+	})
+	return pErr.GoError()
+}
+
+func (kv *kvNative) done() {
+	kv.doneFn()
+}
+
+// kvSQL is a SQL-based implementation of the KV interface.
+type kvSQL struct {
+	db     *sql.DB
+	doneFn func()
+}
+
+func newKVSQL(b *testing.B) kvInterface {
+	enableTracing := tracing.Disable()
+	s := server.StartTestServer(b)
+	pgURL, cleanupURL := sqlutils.PGUrl(b, s, security.RootUser, "benchmarkCockroach")
+	pgURL.Path = "bench"
+	db, err := sql.Open("postgres", pgURL.String())
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS bench`); err != nil {
+		b.Fatal(err)
+	}
+
+	kv := &kvSQL{}
+	kv.db = db
+	kv.doneFn = func() {
+		db.Close()
+		cleanupURL()
+		s.Stop()
+		enableTracing()
+	}
+	return kv
+}
+
+func (kv *kvSQL) insert(rows, run int) error {
+	firstRow := rows * run
+	var buf bytes.Buffer
+	buf.WriteString(`INSERT INTO bench.kv VALUES `)
+	for i := 0; i < rows; i++ {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		fmt.Fprintf(&buf, "('%06d', %d)", i+firstRow, i)
+	}
+	_, err := kv.db.Exec(buf.String())
+	return err
+}
+
+func (kv *kvSQL) update(rows, run int) error {
+	var buf bytes.Buffer
+	buf.WriteString(`UPDATE bench.kv SET v = v + 1 WHERE k IN (`)
+	for j := 0; j < rows; j++ {
+		if j > 0 {
+			buf.WriteString(", ")
+		}
+		fmt.Fprintf(&buf, `'%06d'`, j)
+	}
+	buf.WriteString(`)`)
+	_, err := kv.db.Exec(buf.String())
+	return err
+}
+
+func (kv *kvSQL) del(rows, run int) error {
+	var buf bytes.Buffer
+	buf.WriteString(`DELETE FROM bench.kv WHERE k IN (`)
+	for j := 0; j < rows; j++ {
+		if j > 0 {
+			buf.WriteString(", ")
+		}
+		fmt.Fprintf(&buf, `'%06d'`, j)
+	}
+	buf.WriteString(`)`)
+	_, err := kv.db.Exec(buf.String())
+	return err
+}
+
+func (kv *kvSQL) scan(count, run int) error {
+	rows, err := kv.db.Query(fmt.Sprintf("SELECT * FROM bench.kv LIMIT %d", count))
+	if err != nil {
+		return err
+	}
+	n := 0
+	for rows.Next() {
+		n++
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if n != count {
+		return util.Errorf("unexpected result count: %d (expected %d)", n, count)
+	}
+	return nil
+}
+
+func (kv *kvSQL) prep(rows int, initData bool) error {
+	if _, err := kv.db.Exec(`DROP TABLE IF EXISTS bench.kv`); err != nil {
+		return err
+	}
+	if _, err := kv.db.Exec(`CREATE TABLE IF NOT EXISTS bench.kv (k STRING PRIMARY KEY, v INT)`); err != nil {
+		return err
+	}
+	if !initData {
+		return nil
+	}
+	var buf bytes.Buffer
+	buf.WriteString(`INSERT INTO bench.kv VALUES `)
+	for i := 0; i < rows; i++ {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		fmt.Fprintf(&buf, "('%06d', %d)", i, i)
+	}
+	_, err := kv.db.Exec(buf.String())
+	return err
+}
+
+func (kv *kvSQL) done() {
+	kv.doneFn()
+}
+
+func runKVBenchmark(b *testing.B, typ, op string, rows int) {
+	var kv kvInterface
+	switch typ {
+	case "Native":
+		kv = newKVNative(b)
+	case "SQL":
+		kv = newKVSQL(b)
+	default:
+		b.Fatalf("unknown implementation: %s", typ)
+	}
+	defer kv.done()
+
+	var opFn func(int, int) error
+	switch op {
+	case "insert":
+		opFn = kv.insert
+	case "update":
+		opFn = kv.update
+	case "delete":
+		opFn = kv.del
+	case "scan":
+		opFn = kv.scan
+	}
+
+	if err := kv.prep(rows, op != "insert"); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := opFn(rows, i); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkKVInsert1_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "insert", 1)
+}
+
+func BenchmarkKVInsert1_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "insert", 1)
+}
+
+func BenchmarkKVInsert10_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "insert", 10)
+}
+
+func BenchmarkKVInsert10_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "insert", 10)
+}
+
+func BenchmarkKVInsert100_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "insert", 100)
+}
+
+func BenchmarkKVInsert100_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "insert", 100)
+}
+
+func BenchmarkKVInsert1000_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "insert", 1000)
+}
+
+func BenchmarkKVInsert1000_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "insert", 1000)
+}
+
+func BenchmarkKVInsert10000_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "insert", 10000)
+}
+
+func BenchmarkKVInsert10000_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "insert", 10000)
+}
+
+func BenchmarkKVUpdate1_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "update", 1)
+}
+
+func BenchmarkKVUpdate1_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "update", 1)
+}
+
+func BenchmarkKVUpdate10_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "update", 10)
+}
+
+func BenchmarkKVUpdate10_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "update", 10)
+}
+
+func BenchmarkKVUpdate100_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "update", 100)
+}
+
+func BenchmarkKVUpdate100_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "update", 100)
+}
+
+func BenchmarkKVUpdate1000_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "update", 1000)
+}
+
+func BenchmarkKVUpdate1000_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "update", 1000)
+}
+
+func BenchmarkKVUpdate10000_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "update", 10000)
+}
+
+func BenchmarkKVUpdate10000_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "update", 10000)
+}
+
+func BenchmarkKVDelete1_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "delete", 1)
+}
+
+func BenchmarkKVDelete1_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "delete", 1)
+}
+
+func BenchmarkKVDelete10_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "delete", 10)
+}
+
+func BenchmarkKVDelete10_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "delete", 10)
+}
+
+func BenchmarkKVDelete100_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "delete", 100)
+}
+
+func BenchmarkKVDelete100_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "delete", 100)
+}
+
+func BenchmarkKVDelete1000_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "delete", 1000)
+}
+
+func BenchmarkKVDelete1000_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "delete", 1000)
+}
+
+func BenchmarkKVDelete10000_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "delete", 10000)
+}
+
+func BenchmarkKVDelete10000_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "delete", 10000)
+}
+
+func BenchmarkKVScan1_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "scan", 1)
+}
+
+func BenchmarkKVScan1_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "scan", 1)
+}
+
+func BenchmarkKVScan10_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "scan", 10)
+}
+
+func BenchmarkKVScan10_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "scan", 10)
+}
+
+func BenchmarkKVScan100_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "scan", 100)
+}
+
+func BenchmarkKVScan100_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "scan", 100)
+}
+
+func BenchmarkKVScan1000_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "scan", 1000)
+}
+
+func BenchmarkKVScan1000_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "scan", 1000)
+}
+
+func BenchmarkKVScan10000_Native(b *testing.B) {
+	runKVBenchmark(b, "Native", "scan", 10000)
+}
+
+func BenchmarkKVScan10000_SQL(b *testing.B) {
+	runKVBenchmark(b, "SQL", "scan", 10000)
+}


### PR DESCRIPTION
Note these results are on my laptop, so take with a grain of salt.

```
BenchmarkKVInsert1_Native-4         2000        839340 ns/op
BenchmarkKVInsert1_SQL-4            2000        649759 ns/op
BenchmarkKVInsert10_Native-4        2000       1099658 ns/op
BenchmarkKVInsert10_SQL-4           1000       1302572 ns/op
BenchmarkKVInsert100_Native-4        500       3374758 ns/op
BenchmarkKVInsert100_SQL-4           200       6999272 ns/op
BenchmarkKVInsert1000_Native-4        50      25849605 ns/op
BenchmarkKVInsert1000_SQL-4           20      72150309 ns/op
BenchmarkKVInsert10000_Native-4        5     299836340 ns/op
BenchmarkKVInsert10000_SQL-4           1    1045935749 ns/op
BenchmarkKVUpdate1_Native-4         2000       1143479 ns/op
BenchmarkKVUpdate1_SQL-4            2000       1006438 ns/op
BenchmarkKVUpdate10_Native-4        1000       1596340 ns/op
BenchmarkKVUpdate10_SQL-4           1000       1668788 ns/op
BenchmarkKVUpdate100_Native-4        300       5699316 ns/op
BenchmarkKVUpdate100_SQL-4           200       7261698 ns/op
BenchmarkKVUpdate1000_Native-4        30      45377174 ns/op
BenchmarkKVUpdate1000_SQL-4           30      63683670 ns/op
BenchmarkKVUpdate10000_Native-4        2     505973716 ns/op
BenchmarkKVUpdate10000_SQL-4           2     745406160 ns/op
BenchmarkKVDelete1_Native-4         2000        853446 ns/op
BenchmarkKVDelete1_SQL-4            2000        674473 ns/op
BenchmarkKVDelete10_Native-4        2000       1126234 ns/op
BenchmarkKVDelete10_SQL-4           2000       1045536 ns/op
BenchmarkKVDelete100_Native-4        500       3686083 ns/op
BenchmarkKVDelete100_SQL-4           300       4100471 ns/op
BenchmarkKVDelete1000_Native-4       100      30876116 ns/op
BenchmarkKVDelete1000_SQL-4           50      35879515 ns/op
BenchmarkKVDelete10000_Native-4        5     298790199 ns/op
BenchmarkKVDelete10000_SQL-4           2     619428898 ns/op
BenchmarkKVScan1_Native-4           5000        290198 ns/op
BenchmarkKVScan1_SQL-4              5000        415768 ns/op
BenchmarkKVScan10_Native-4          5000        327269 ns/op
BenchmarkKVScan10_SQL-4             3000        511777 ns/op
BenchmarkKVScan100_Native-4         2000        611106 ns/op
BenchmarkKVScan100_SQL-4            1000       1329626 ns/op
BenchmarkKVScan1000_Native-4         500       3263260 ns/op
BenchmarkKVScan1000_SQL-4            200       8956545 ns/op
BenchmarkKVScan10000_Native-4         50      33765755 ns/op
BenchmarkKVScan10000_SQL-4            20      87925350 ns/op
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5931)

<!-- Reviewable:end -->
