### PR TITLE
sql: allow INSERT/DELETE/UPDATE ... RETURNING $1

### DIFF
--- a/sql/insert.go
+++ b/sql/insert.go
@@ -287,7 +287,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 
 	if p.evalCtx.PrepareOnly {
 		// Return the result column types.
-		return rh.getResults(), nil
+		return rh.getResults()
 	}
 
 	if isSystemConfigID(tableDesc.GetID()) {
@@ -306,7 +306,7 @@ func (p *planner) Insert(n *parser.Insert, autoCommit bool) (planNode, *roachpb.
 	if pErr != nil {
 		return nil, convertBatchError(&tableDesc, *b, pErr)
 	}
-	return rh.getResults(), nil
+	return rh.getResults()
 }
 
 func (p *planner) processColumns(tableDesc *TableDescriptor,

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -397,12 +397,10 @@ func TestPGPreparedQuery(t *testing.T) {
 				time.Date(2006, 7, 8, 0, 0, 0, 123, time.FixedZone("", 0)),
 			),
 		},
-
 		"INSERT INTO d.T VALUES ($1) RETURNING 1": {
 			base.Params(1).Results(1),
 			base.Params(nil).Results(1),
 		},
-		/* TODO(mjibson): fix #4658
 		"INSERT INTO d.T VALUES ($1) RETURNING $1": {
 			base.Params(1).Results(1),
 			base.Params(3).Results(3),
@@ -411,7 +409,6 @@ func TestPGPreparedQuery(t *testing.T) {
 			base.Params(1).Results(1, 2),
 			base.Params(3).Results(3, 4),
 		},
-		*/
 		"SELECT a FROM d.T WHERE a = $1 AND (SELECT a >= $2 FROM d.T WHERE a = $1)": {
 			base.Params(10, 5).Results(10),
 		},

--- a/sql/update.go
+++ b/sql/update.go
@@ -169,7 +169,7 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 			}
 		}
 		// Return the result column types.
-		return rh.getResults(), nil
+		return rh.getResults()
 	}
 
 	// Construct a map from column ID to the index the value appears at within a
@@ -350,7 +350,7 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 	}
 
 	tracing.AnnotateTrace()
-	return rh.getResults(), nil
+	return rh.getResults()
 }
 
 func fillDefault(expr parser.Expr, index int, defaultExprs []parser.Expr) parser.Expr {


### PR DESCRIPTION
Type check the val args after they have been inferred so they resolve to
their type datums instead of DValArgs.

Fixes #4658

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5934)

<!-- Reviewable:end -->
