### PR TITLE
Add "Next" target to UI Makefile

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -12,6 +12,7 @@ typings.installed
 
 # Generated intermediates
 /build
+/next/build
 /index.html
 
 # Generated proto json/typescript/javascript

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -28,6 +28,7 @@ BOWER_COMPONENTS     := bower_components
 NODE_MODULES         := node_modules
 TYPINGS              := typings
 TS_ROOT              := ts
+TS_NEXT_ROOT         := next/ts
 STYL_ROOT            := styl
 TEST_ROOT            := ts/test
 GENERATED_ROOT       := generated
@@ -42,6 +43,7 @@ GOPATH_BIN := $(GOPATH)/bin
 GO_BINDATA := $(GOPATH_BIN)/go-bindata
 
 TYPESCRIPT_TARGET       := build/app.js
+TYPESCRIPT_NEXT_TARGET  := next/build/app.js
 TEST_TARGET             := build/test.js
 CSS_TARGET              := build/app.css
 CSS_DEBUG_TARGET        := build/app_debug.css
@@ -51,6 +53,7 @@ GOBINDATA_FONTS         := ./fonts/*
 GOBINDATA_ASSETS        := ./assets/*
 GOBINDATA_DEPS          := $(TYPESCRIPT_TARGET) $(CSS_TARGET)
 GOBINDATA_DEBUG_DEPS    := $(TYPESCRIPT_TARGET) $(CSS_DEBUG_TARGET)
+GOBINDATA_NEXT_DEPS     := $(TYPESCRIPT_NEXT_TARGET) $(CSS_DEBUG_TARGET)
 GOBINDATA_SOURCES       := $(BOWER_COMPONENTS)/d3/d3.min.js \
                            $(NODE_MODULES)/lodash/lodash.min.js \
                            $(BOWER_COMPONENTS)/mithriljs/mithril.js \
@@ -73,12 +76,18 @@ GOBINDATA_DEBUG_SOURCES := $(BOWER_COMPONENTS)/d3/d3.js \
                            $(GOBINDATA_ASSETS) \
                            favicon.ico \
                            apple-touch-icon.png
+GOBINDATA_NEXT_SOURCES  := $(GOBINDATA_FONTS) \
+                           $(GOBINDATA_ASSETS) \
+                           favicon.ico \
+                           apple-touch-icon.png
 GOBINDATA_TARGET        := ./embedded.go
 GOBINDATA_DEBUG_TARGET  := ./embedded_debug.go
+GOBINDATA_NEXT_TARGET   := ./embedded_next.go
 
 .PHONY: all
 all: lint $(GOBINDATA_TARGET) $(TEST_TARGET)
 	rm -f $(GOBINDATA_DEBUG_TARGET)
+	rm -f $(GOBINDATA_NEXT_TARGET)
 
 .PHONY: lint
 lint: npm.installed
@@ -88,6 +97,12 @@ lint: npm.installed
 .PHONY: debug
 debug: $(GOBINDATA_DEBUG_TARGET) $(TEST_TARGET)
 	rm -f $(GOBINDATA_TARGET)
+	rm -f $(GOBINDATA_NEXT_TARGET)
+
+.PHONY: next
+next: $(GOBINDATA_NEXT_TARGET)
+	rm -f $(GOBINDATA_TARGET)
+	rm -f $(GOBINDATA_DEBUG_TARGET)
 
 bower.installed: bower.json npm.installed
 	rm -rf $(BOWER_COMPONENTS)/
@@ -107,6 +122,9 @@ typings.installed: typings.json npm.installed
 
 $(TYPESCRIPT_TARGET): $(shell find $(TS_ROOT)) $(REMOTE_DEPS)
 	tsc -p $(TS_ROOT)
+
+$(TYPESCRIPT_NEXT_TARGET): $(shell find $(TS_NEXT_ROOT)) $(REMOTE_DEPS)
+	tsc -p $(TS_NEXT_ROOT)
 
 $(TEST_TARGET): $(shell find $(TS_ROOT)) $(REMOTE_DEPS)
 	tsc -p $(TEST_ROOT)
@@ -136,7 +154,13 @@ $(GOBINDATA_DEBUG_TARGET): $(GOBINDATA_DEBUG_DEPS) bower.installed debug/$(INDEX
 	rm -f $(INDEX)
 	cp debug/$(INDEX) $(INDEX)
 	chmod a-w $(INDEX)
-	$(GO_BINDATA) -nometadata -pkg ui -o $@ -debug $(GOBINDATA_DEBUG_DEPS) $(INDEX) $(GOBINDATA_DEBUG_SOURCES)
+	$(GO_BINDATA) -nometadata -pkg ui -o $@ -debug $(GOBINDATA_DEBUG_DEPS) $(INDEX) $(INDEX_NEXT) $(GOBINDATA_DEBUG_SOURCES)
+
+$(GOBINDATA_NEXT_TARGET): $(GOBINDATA_NEXT_DEPS) bower.installed next/$(INDEX)
+	rm -f $(INDEX)
+	cp next/$(INDEX) $(INDEX)
+	chmod a-w $(INDEX)
+	$(GO_BINDATA) -nometadata -pkg ui -o $@ -debug $(GOBINDATA_NEXT_DEPS) $(INDEX) $(GOBINDATA_NEXT_SOURCES)
 
 watch: debug
 	gulp watch

--- a/ui/next/index.html
+++ b/ui/next/index.html
@@ -1,0 +1,36 @@
+<!--
+Copyright 2016 The Cockroach Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+
+Author: Matt Tracy (matt@cockroachlabs.com)
+-->
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+
+    <link rel="stylesheet" href="/build/app_debug.css">
+    <title>Cockroach Console Next</title>
+  </head>
+  <body>
+    <h1>Cockroach Admin UI Next</h1>
+    <p>The Cockroach Admin UI Next version is a major refactoring of the current
+    web UI which is under development.</p>
+    <script src="/build/next/app.js"></script>
+  </body>
+</html>

--- a/ui/next/ts/app.ts
+++ b/ui/next/ts/app.ts
@@ -1,0 +1,4 @@
+// app.ts - currently empty.
+export namespace AdminNext {
+  console.log("hello world");
+}

--- a/ui/next/ts/tsconfig.json
+++ b/ui/next/ts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "outFile": "../build/app_next.js"
+  },
+  "files": [
+    "./app.ts"
+  ]
+}


### PR DESCRIPTION
Commit adds a "next" target to the UI makefile, which provides an effective and
simple mechanism for isolating a planned overhaul of the UI.

This is an alternative to working on a separate fork or branch; I believe that
this will help keep progress on this UI version more visible to all contributors.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5936)

<!-- Reviewable:end -->
