### PR TITLE
sql: Clean up code in the sql package

### DIFF
--- a/sql/plan.go
+++ b/sql/plan.go
@@ -446,7 +446,7 @@ var _ planNode = &explainDebugNode{}
 var _ planNode = &explainTraceNode{}
 
 // emptyNode is a planNode with no columns and either no rows (default) or a single row with empty
-// results (if results is initializer to true). The former is used for nodes that have no results
+// results (if results is initialized to true). The former is used for nodes that have no results
 // (e.g. a table for which the filtering condition has a contradiction), the latter is used by
 // select statements that have no table or where we detect the filtering condition throws away all
 // results.

--- a/sql/select.go
+++ b/sql/select.go
@@ -186,13 +186,13 @@ func (p *planner) Select(n *parser.Select, autoCommit bool) (planNode, *roachpb.
 	// investigating a general mechanism for passing some context down during
 	// plan node construction.
 	default:
-		plan, pberr := p.makePlan(s, autoCommit)
-		if pberr != nil {
-			return nil, pberr
+		plan, pErr := p.makePlan(s, autoCommit)
+		if pErr != nil {
+			return nil, pErr
 		}
-		sort, pberr := p.orderBy(orderBy, plan)
-		if pberr != nil {
-			return nil, pberr
+		sort, pErr := p.orderBy(orderBy, plan)
+		if pErr != nil {
+			return nil, pErr
 		}
 		count, offset, err := p.evalLimit(limit)
 		if err != nil {
@@ -343,7 +343,7 @@ func (p *planner) initSelect(
 	return p.limit(limitCount, limitOffset, p.distinct(parsed, sort.wrap(group.wrap(s)))), nil
 }
 
-// Initializes the table node, given the parsed select expression
+// initFrom initializes the table node, given the parsed select expression
 func (s *selectNode) initFrom(p *planner, parsed *parser.SelectClause) *roachpb.Error {
 	from := parsed.From
 	var colAlias parser.NameList
@@ -481,8 +481,9 @@ func (s *selectNode) initWhere(where *parser.Where) *roachpb.Error {
 // we match the prefix of the qualified name to one of the tables in the query and then expand the
 // "*" into a list of columns. The qvalMap is updated to include all the relevant columns. A
 // ResultColumns and Expr pair is returned for each column.
-func checkRenderStar(target parser.SelectExpr, table *tableInfo, qvals qvalMap) (isStar bool,
-	columns []ResultColumn, exprs []parser.Expr, err error) {
+func checkRenderStar(
+	target parser.SelectExpr, table *tableInfo, qvals qvalMap,
+) (isStar bool, columns []ResultColumn, exprs []parser.Expr, err error) {
 	qname, ok := target.Expr.(*parser.QualifiedName)
 	if !ok {
 		return false, nil, nil, nil


### PR DESCRIPTION
The change includes a small amount of cleanup I felt compelled to do
while reacquainting myself with the sql package.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5941)

<!-- Reviewable:end -->
