### PR TITLE
sql: embed qnameVisitor in sql.planner to avoid multiple allocations

### DIFF
--- a/sql/plan.go
+++ b/sql/plan.go
@@ -46,10 +46,13 @@ type planner struct {
 	testingVerifyMetadataFn func(config.SystemConfig) error
 	verifyFnCheckedOnce     bool
 
-	parser             parser.Parser
+	parser parser.Parser
+	params parameters
+
+	// Avoid allocations by embedding commonly used visitors.
 	isAggregateVisitor isAggregateVisitor
-	params             parameters
 	subqueryVisitor    subqueryVisitor
+	qnameVisitor       qnameVisitor
 
 	execCtx *ExecutorContext
 }

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -63,7 +63,7 @@ func makeReturningHelper(p *planner, r parser.ReturningExprs,
 		// manipulations to the expression.
 		outputName := getRenderColName(target)
 
-		expr, err := resolveQNames(&table, rh.qvals, target.Expr)
+		expr, err := resolveQNames(target.Expr, &table, rh.qvals, &p.qnameVisitor)
 		if err != nil {
 			return returningHelper{}, err
 		}


### PR DESCRIPTION
#### Perf Improvements:

```
name                                old alloc/op   new alloc/op   delta
Select1_Cockroach-2                   2.26kB ± 0%    2.23kB ± 0%  -1.39%         (p=0.000 n=10+9)
Select2_Cockroach-2                    114kB ± 0%     113kB ± 0%  -0.20%         (p=0.000 n=10+9)
Insert1_Cockroach-2                   37.2kB ± 0%    37.2kB ± 0%    ~           (p=0.927 n=10+10)
Insert10_Cockroach-2                  91.4kB ± 0%    91.4kB ± 0%    ~            (p=0.304 n=8+10)
Insert100_Cockroach-2                  628kB ± 0%     629kB ± 0%    ~            (p=1.000 n=9+10)
Insert1000_Cockroach-2                5.57MB ± 1%    5.56MB ± 1%    ~           (p=0.971 n=10+10)
Update1_Cockroach-2                   58.4kB ± 0%    58.3kB ± 0%  -0.21%        (p=0.000 n=10+10)
Update10_Cockroach-2                   158kB ± 0%     158kB ± 0%  -0.10%         (p=0.000 n=10+9)
Update100_Cockroach-2                 1.08MB ± 0%    1.08MB ± 0%    ~            (p=0.434 n=9+10)
Update1000_Cockroach-2                9.20MB ± 0%    9.20MB ± 1%    ~           (p=0.971 n=10+10)
Delete1_Cockroach-2                   43.7kB ± 0%    43.6kB ± 0%  -0.37%         (p=0.000 n=9+10)
Delete10_Cockroach-2                  62.4kB ± 0%    62.3kB ± 0%  -0.24%         (p=0.000 n=10+9)
Delete100_Cockroach-2                  238kB ± 0%     238kB ± 0%    ~            (p=0.051 n=9+10)
Delete1000_Cockroach-2                2.32MB ± 0%    2.32MB ± 0%    ~             (p=0.743 n=8+9)
Scan1_Cockroach-2                     19.3kB ± 0%    19.3kB ± 0%    ~            (p=0.759 n=9+10)
Scan10_Cockroach-2                    26.3kB ± 0%    26.3kB ± 0%    ~           (p=0.154 n=10+10)
Scan100_Cockroach-2                   85.0kB ± 0%    85.0kB ± 0%    ~            (p=0.777 n=10+8)
Scan1000_Cockroach-2                   638kB ± 0%     638kB ± 0%    ~           (p=0.075 n=10+10)
Scan10000_Cockroach-2                 10.6MB ± 0%    10.6MB ± 0%    ~            (p=0.762 n=8+10)
Scan1000Limit1_Cockroach-2            20.1kB ± 0%    20.1kB ± 0%    ~           (p=0.294 n=10+10)
Scan1000Limit10_Cockroach-2           27.0kB ± 0%    27.0kB ± 0%    ~           (p=0.530 n=10+10)
Scan1000Limit100_Cockroach-2          85.3kB ± 0%    85.3kB ± 0%    ~           (p=0.265 n=10+10)
Scan10000FilterLimit1_Cockroach-2     69.6kB ± 0%    69.6kB ± 0%  -0.05%          (p=0.000 n=9+9)
Scan10000FilterLimit10_Cockroach-2    83.2kB ± 0%    83.2kB ± 0%  -0.04%         (p=0.000 n=10+8)
Scan10000FilterLimit50_Cockroach-2     937kB ± 0%     937kB ± 0%  -0.01%         (p=0.000 n=9+10)

name                                old allocs/op  new allocs/op  delta
Select1_Cockroach-2                     49.0 ± 0%      48.0 ± 0%  -2.04%        (p=0.000 n=10+10)
Select2_Cockroach-2                    2.68k ± 0%     2.67k ± 0%  -0.26%          (p=0.001 n=8+9)
Insert1_Cockroach-2                      473 ± 0%       473 ± 0%    ~           (p=0.087 n=10+10)
Insert10_Cockroach-2                     908 ± 0%       908 ± 0%    ~            (p=0.557 n=8+10)
Insert100_Cockroach-2                  5.11k ± 0%     5.11k ± 0%    ~           (p=0.836 n=10+10)
Insert1000_Cockroach-2                 47.3k ± 0%     47.3k ± 0%    ~           (p=0.315 n=10+10)
Update1_Cockroach-2                      903 ± 0%       899 ± 0%  -0.44%        (p=0.000 n=10+10)
Update10_Cockroach-2                   1.66k ± 0%     1.65k ± 0%  -0.24%        (p=0.000 n=10+10)
Update100_Cockroach-2                  8.72k ± 0%     8.72k ± 0%  -0.03%         (p=0.025 n=9+10)
Update1000_Cockroach-2                 75.0k ± 0%     75.1k ± 0%    ~           (p=0.358 n=10+10)
Delete1_Cockroach-2                      675 ± 0%       670 ± 0%  -0.70%         (p=0.000 n=8+10)
Delete10_Cockroach-2                   1.11k ± 0%     1.11k ± 0%  -0.46%         (p=0.000 n=10+9)
Delete100_Cockroach-2                  5.36k ± 0%     5.35k ± 0%  -0.11%         (p=0.000 n=9+10)
Delete1000_Cockroach-2                 47.7k ± 0%     47.7k ± 0%    ~            (p=0.590 n=10+9)
Scan1_Cockroach-2                        332 ± 0%       332 ± 0%    ~     (all samples are equal)
Scan10_Cockroach-2                       434 ± 0%       434 ± 0%    ~     (all samples are equal)
Scan100_Cockroach-2                    1.34k ± 0%     1.34k ± 0%  +0.06%         (p=0.023 n=8+10)
Scan1000_Cockroach-2                   10.4k ± 0%     10.4k ± 0%  +0.00%         (p=0.043 n=10+9)
Scan10000_Cockroach-2                   101k ± 0%      101k ± 0%    ~            (p=0.752 n=10+7)
Scan1000Limit1_Cockroach-2               347 ± 0%       347 ± 0%    ~     (all samples are equal)
Scan1000Limit10_Cockroach-2              447 ± 0%       447 ± 0%    ~     (all samples are equal)
Scan1000Limit100_Cockroach-2           1.36k ± 0%     1.36k ± 0%    ~     (all samples are equal)
Scan10000FilterLimit1_Cockroach-2        832 ± 0%       831 ± 0%  -0.12%        (p=0.000 n=10+10)
Scan10000FilterLimit10_Cockroach-2     1.06k ± 0%     1.06k ± 0%  -0.09%        (p=0.000 n=10+10)
Scan10000FilterLimit50_Cockroach-2     12.8k ± 0%     12.8k ± 0%  -0.01%        (p=0.000 n=10+10)
```

Also, no this isn't actually embedding in the Go struct sense.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5942)

<!-- Reviewable:end -->
