### PR TITLE
gossip: reduce chance of TestGossipNoForwardSelf failing

### DIFF
--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -157,7 +157,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 		})
 	}
 
-	const numClients = 100
+	const numClients = 50
 	disconnectedCh := make(chan *client)
 	numFailedConns := 0
 


### PR DESCRIPTION
This kept failing on my macbook because it was exceeding the number of file descriptors.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5949)

<!-- Reviewable:end -->
