### PR TITLE
sql: support placeholders in LIMIT statements

### DIFF
--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -412,6 +412,11 @@ func TestPGPreparedQuery(t *testing.T) {
 		"SELECT a FROM d.T WHERE a = $1 AND (SELECT a >= $2 FROM d.T WHERE a = $1)": {
 			base.Params(10, 5).Results(10),
 		},
+		"SELECT * FROM (VALUES (1), (2), (3), (4)) AS foo (a) LIMIT $1 OFFSET $2": {
+			base.Params(1, 0).Results(1),
+			base.Params(1, 1).Results(2),
+			base.Params(1, 2).Results(3),
+		},
 	}
 
 	s := server.StartTestServer(t)

--- a/sql/testdata/select
+++ b/sql/testdata/select
@@ -165,11 +165,17 @@ CREATE TABLE xyzw (
 statement ok
 INSERT INTO xyzw VALUES (4, 5, 6, 7), (1, 2, 3, 4);
 
-query error argument of LIMIT must not contain variables
-SELECT * FROM xyzw LIMIT a
+query error qualified name \"x\" not found
+SELECT * FROM xyzw LIMIT x
 
-query error argument of OFFSET must not contain variables
-SELECT * FROM xyzw OFFSET a
+query error qualified name \"y\" not found
+SELECT * FROM xyzw OFFSET 1 + y
+
+query error argument of LIMIT must be type int, not type string
+SELECT * FROM xyzw LIMIT '1'
+
+query error argument of OFFSET must be type int, not type float
+SELECT * FROM xyzw OFFSET 1.5
 
 query error negative value for LIMIT
 SELECT * FROM xyzw LIMIT -100


### PR DESCRIPTION
Adding support for valargs in LIMIT statements: run TypeCheck on the limit
expressions and try to infer the int type; and don't try to evaluate the
expressions in prepare mode.
@mjibson, @knz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5977)

<!-- Reviewable:end -->
