### PR TITLE
UI Next: React, Browserify, CommonJS modules

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -43,7 +43,8 @@ GOPATH_BIN := $(GOPATH)/bin
 GO_BINDATA := $(GOPATH_BIN)/go-bindata
 
 TYPESCRIPT_TARGET       := build/app.js
-TYPESCRIPT_NEXT_TARGET  := next/build/app.js
+TYPESCRIPT_NEXT_TARGET  := next/build/browser.js
+TYPESCRIPT_TSC_OUTPUT   := next/build/app.js
 TEST_TARGET             := build/test.js
 CSS_TARGET              := build/app.css
 CSS_DEBUG_TARGET        := build/app_debug.css
@@ -125,6 +126,7 @@ $(TYPESCRIPT_TARGET): $(shell find $(TS_ROOT)) $(REMOTE_DEPS)
 
 $(TYPESCRIPT_NEXT_TARGET): $(shell find $(TS_NEXT_ROOT)) $(REMOTE_DEPS)
 	tsc -p $(TS_NEXT_ROOT)
+	browserify $(TYPESCRIPT_TSC_OUTPUT) > $(TYPESCRIPT_NEXT_TARGET)
 
 $(TEST_TARGET): $(shell find $(TS_ROOT)) $(REMOTE_DEPS)
 	tsc -p $(TEST_ROOT)

--- a/ui/next/index.html
+++ b/ui/next/index.html
@@ -28,9 +28,7 @@ Author: Matt Tracy (matt@cockroachlabs.com)
     <title>Cockroach Console Next</title>
   </head>
   <body>
-    <h1>Cockroach Admin UI Next</h1>
-    <p>The Cockroach Admin UI Next version is a major refactoring of the current
-    web UI which is under development.</p>
-    <script src="/build/next/app.js"></script>
+    <div id="root"></div>
+    <script src="/next/build/browser.js"></script>
   </body>
 </html>

--- a/ui/next/ts/app.ts
+++ b/ui/next/ts/app.ts
@@ -1,4 +1,0 @@
-// app.ts - currently empty.
-export namespace AdminNext {
-  console.log("hello world");
-}

--- a/ui/next/ts/app.tsx
+++ b/ui/next/ts/app.tsx
@@ -1,0 +1,14 @@
+/// <reference path="../../typings/main.d.ts" />
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+ReactDOM.render(
+  <div id="content">
+    <h1>Cockroach Admin UI Next</h1>
+    <p>
+      The Cockroach Admin UI Next version is a major refactoring of the current web UI which is under development.
+    </p>
+  </div>,
+  document.getElementById("root")
+);

--- a/ui/next/ts/tsconfig.json
+++ b/ui/next/ts/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES5",
-    "outFile": "../build/app_next.js"
+    "module": "commonjs",
+    "jsx": "react",
+    "outDir": "../build"
   },
   "files": [
-    "./app.ts"
+    "./app.tsx"
   ]
 }

--- a/ui/next/ts/tslint.json
+++ b/ui/next/ts/tslint.json
@@ -1,0 +1,126 @@
+{
+  "rules": {
+    "align": [
+      true,
+      "parameters",
+      "arguments",
+      "statements"
+    ],
+    "ban": false,
+    "class-name": true,
+    "comment-format": [
+      true,
+      "check-space"
+    ],
+    "curly": true,
+    "eofline": true,
+    "forin": true,
+    "indent": [
+      true,
+      2
+    ],
+    "interface-name": false,
+    "jsdoc-format": true,
+    "label-position": true,
+    "label-undefined": true,
+    "max-line-length": [
+      false,
+      140
+    ],
+    "member-ordering": [
+      true,
+      "public-before-private",
+      "static-before-instance",
+      "variables-before-functions"
+    ],
+    "no-any": false,
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-console": [
+      true,
+      "debug",
+      "info",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-consecutive-blank-lines": true,
+    "no-construct": true,
+    "no-constructor-vars": false,
+    "no-debugger": true,
+    "no-duplicate-key": true,
+    "no-duplicate-variable": true,
+    "no-shadowed-variable": true,
+    "no-empty": false,
+    "no-eval": true,
+    "no-require-imports": false,
+    "no-string-literal": true,
+    "no-switch-case-fall-through": true,
+    "trailing-comma": [true, {
+        "multiline": "always",
+        "singleline": "never"
+    }],
+    "no-trailing-whitespace": true,
+    "no-unreachable": true,
+    "no-unused-expression": true,
+    "no-unused-variable": [
+      true,
+      "react"
+    ],
+    "no-use-before-declare": true,
+    "no-var-keyword": true,
+    "no-var-requires": true,
+    "one-line": [
+      true,
+      "check-catch",
+      "check-else",
+      "check-open-brace",
+      "check-whitespace"
+    ],
+    "quotemark": [
+      true,
+      "double"
+    ],
+    "radix": true,
+    "semicolon": true,
+    "switch-default": true,
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "typedef": [
+      true,
+      "call-signature",
+      "parameter",
+      "property-declaration",
+      "member-variable-declaration"
+    ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "use-strict": [
+      true,
+      "check-module",
+      "check-function"
+    ],
+    "variable-name": [
+      true,
+      "allow-leading-underscore"
+    ],
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ]
+  }
+}

--- a/ui/npm-shrinkwrap.json
+++ b/ui/npm-shrinkwrap.json
@@ -11,10 +11,16 @@
         "glob": {
           "version": "7.0.3"
         },
+        "lodash": {
+          "version": "4.6.1"
+        },
         "semver": {
           "version": "5.1.0"
         }
       }
+    },
+    "acorn": {
+      "version": "1.2.2"
     },
     "agent-base": {
       "version": "2.0.1",
@@ -37,7 +43,7 @@
       "version": "2.0.0"
     },
     "ansi-styles": {
-      "version": "2.1.0"
+      "version": "2.2.1"
     },
     "any-promise": {
       "version": "1.1.0"
@@ -57,8 +63,17 @@
     "array-differ": {
       "version": "1.0.0"
     },
+    "array-filter": {
+      "version": "0.0.1"
+    },
     "array-find-index": {
       "version": "1.0.1"
+    },
+    "array-map": {
+      "version": "0.0.0"
+    },
+    "array-reduce": {
+      "version": "0.0.0"
     },
     "array-union": {
       "version": "1.0.1"
@@ -72,14 +87,35 @@
     "arrify": {
       "version": "1.0.1"
     },
+    "asap": {
+      "version": "2.0.3"
+    },
+    "asn1.js": {
+      "version": "4.5.2"
+    },
+    "assert": {
+      "version": "1.3.0"
+    },
+    "astw": {
+      "version": "2.0.0"
+    },
     "async": {
       "version": "0.2.10"
     },
     "async-each": {
       "version": "0.1.6"
     },
+    "babel-plugin-syntax-flow": {
+      "version": "6.5.0"
+    },
+    "babel-runtime": {
+      "version": "5.8.38"
+    },
     "balanced-match": {
       "version": "0.3.0"
+    },
+    "base64-js": {
+      "version": "1.1.2"
     },
     "beeper": {
       "version": "1.1.0"
@@ -90,6 +126,9 @@
     "bluebird": {
       "version": "3.3.4"
     },
+    "bn.js": {
+      "version": "4.11.1"
+    },
     "body-parser": {
       "version": "1.14.2",
       "dependencies": {
@@ -99,7 +138,7 @@
       }
     },
     "bower": {
-      "version": "1.7.7"
+      "version": "1.7.9"
     },
     "boxen": {
       "version": "0.3.1"
@@ -110,17 +149,61 @@
     "braces": {
       "version": "1.8.3"
     },
+    "brorand": {
+      "version": "1.0.5"
+    },
+    "browser-pack": {
+      "version": "6.0.1"
+    },
+    "browser-resolve": {
+      "version": "1.11.1"
+    },
+    "browserify": {
+      "version": "13.0.0"
+    },
+    "browserify-aes": {
+      "version": "1.0.6"
+    },
+    "browserify-cipher": {
+      "version": "1.0.0"
+    },
+    "browserify-des": {
+      "version": "1.0.0"
+    },
+    "browserify-rsa": {
+      "version": "4.0.1"
+    },
+    "browserify-sign": {
+      "version": "4.0.0"
+    },
+    "browserify-zlib": {
+      "version": "0.1.4"
+    },
+    "buffer": {
+      "version": "4.5.1",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "buffer-xor": {
+      "version": "1.0.3"
+    },
     "builtin-modules": {
       "version": "1.1.1"
+    },
+    "builtin-status-codes": {
+      "version": "2.0.0"
     },
     "bytes": {
       "version": "2.2.0"
     },
     "camelcase": {
-      "version": "2.1.0"
+      "version": "2.1.1"
     },
     "camelcase-keys": {
-      "version": "2.0.0"
+      "version": "2.1.0"
     },
     "capture-stack-trace": {
       "version": "1.0.0"
@@ -129,10 +212,13 @@
       "version": "0.1.3"
     },
     "chalk": {
-      "version": "1.1.1"
+      "version": "1.1.3"
     },
     "chokidar": {
       "version": "1.2.0"
+    },
+    "cipher-base": {
+      "version": "1.0.2"
     },
     "cliui": {
       "version": "2.1.0"
@@ -152,6 +238,9 @@
     "columnify": {
       "version": "1.5.4"
     },
+    "combine-source-map": {
+      "version": "0.7.1"
+    },
     "combined-stream": {
       "version": "0.0.7"
     },
@@ -159,33 +248,49 @@
       "version": "0.0.1"
     },
     "concat-stream": {
-      "version": "1.5.1",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
-        }
-      }
+      "version": "1.5.1"
     },
     "configstore": {
       "version": "2.0.0"
+    },
+    "console-browserify": {
+      "version": "1.1.0"
+    },
+    "constants-browserify": {
+      "version": "1.0.0"
     },
     "content-type": {
       "version": "1.0.1"
     },
     "convert-source-map": {
-      "version": "1.2.0"
+      "version": "1.1.3"
+    },
+    "core-js": {
+      "version": "1.2.6"
     },
     "core-util-is": {
       "version": "1.0.2"
     },
+    "create-ecdh": {
+      "version": "4.0.0"
+    },
     "create-error-class": {
-      "version": "2.0.1"
+      "version": "3.0.2"
+    },
+    "create-hash": {
+      "version": "1.1.2"
+    },
+    "create-hmac": {
+      "version": "1.1.4"
+    },
+    "crypto-browserify": {
+      "version": "3.11.0"
     },
     "css-parse": {
       "version": "1.7.0"
+    },
+    "date-now": {
+      "version": "0.1.4"
     },
     "dateformat": {
       "version": "1.0.12"
@@ -202,6 +307,9 @@
     "defaults": {
       "version": "1.0.3"
     },
+    "defined": {
+      "version": "1.0.0"
+    },
     "del": {
       "version": "2.2.0"
     },
@@ -214,11 +322,26 @@
     "deprecated": {
       "version": "0.0.1"
     },
+    "deps-sort": {
+      "version": "2.0.0"
+    },
+    "des.js": {
+      "version": "1.0.0"
+    },
     "detect-indent": {
       "version": "4.0.0"
     },
+    "detective": {
+      "version": "4.3.1"
+    },
     "diff": {
       "version": "2.2.2"
+    },
+    "diffie-hellman": {
+      "version": "5.0.2"
+    },
+    "domain-browser": {
+      "version": "1.1.7"
     },
     "dot-prop": {
       "version": "2.4.0"
@@ -227,21 +350,24 @@
       "version": "0.1.1"
     },
     "duplexer2": {
-      "version": "0.0.2"
+      "version": "0.1.4"
     },
     "duplexify": {
       "version": "3.4.3",
       "dependencies": {
         "end-of-stream": {
           "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.0.5"
         }
       }
     },
     "ee-first": {
       "version": "1.1.1"
+    },
+    "elliptic": {
+      "version": "6.2.3"
+    },
+    "encoding": {
+      "version": "0.1.12"
     },
     "end-of-stream": {
       "version": "0.1.5"
@@ -255,8 +381,14 @@
     "event-stream": {
       "version": "3.3.2"
     },
+    "events": {
+      "version": "1.1.0"
+    },
+    "evp_bytestokey": {
+      "version": "1.0.0"
+    },
     "expand-brackets": {
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "expand-range": {
       "version": "1.8.1"
@@ -276,6 +408,9 @@
     "faye-websocket": {
       "version": "0.7.3"
     },
+    "fbjs": {
+      "version": "0.8.0"
+    },
     "filename-regex": {
       "version": "2.0.0"
     },
@@ -292,18 +427,13 @@
       "version": "1.1.2"
     },
     "findup-sync": {
-      "version": "0.3.0",
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15"
-        }
-      }
+      "version": "0.3.0"
     },
     "first-chunk-stream": {
       "version": "1.0.0"
     },
     "flagged-respawn": {
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     "fobject": {
       "version": "0.0.3",
@@ -314,10 +444,10 @@
       }
     },
     "for-in": {
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "for-own": {
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     "form-data": {
       "version": "0.2.0",
@@ -337,7 +467,7 @@
       "version": "0.1.3"
     },
     "fsevents": {
-      "version": "1.0.9",
+      "version": "1.0.11",
       "dependencies": {
         "ansi": {
           "version": "0.3.1"
@@ -346,7 +476,7 @@
           "version": "2.0.0"
         },
         "ansi-styles": {
-          "version": "2.2.0"
+          "version": "2.2.1"
         },
         "are-we-there-yet": {
           "version": "1.1.2"
@@ -367,7 +497,7 @@
           "version": "1.3.2",
           "dependencies": {
             "lru-cache": {
-              "version": "4.0.0",
+              "version": "4.0.1",
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2"
@@ -392,10 +522,7 @@
           "version": "0.11.0"
         },
         "chalk": {
-          "version": "1.1.1"
-        },
-        "color-convert": {
-          "version": "1.0.0"
+          "version": "1.1.3"
         },
         "combined-stream": {
           "version": "1.0.5"
@@ -574,7 +701,7 @@
           "version": "0.7.1"
         },
         "node-pre-gyp": {
-          "version": "0.6.24",
+          "version": "0.6.25",
           "dependencies": {
             "nopt": {
               "version": "3.0.6",
@@ -709,7 +836,7 @@
           "version": "0.4.2"
         },
         "tweetnacl": {
-          "version": "0.14.1"
+          "version": "0.14.3"
         },
         "uid-number": {
           "version": "0.0.6"
@@ -738,7 +865,7 @@
       "version": "4.0.1"
     },
     "glob": {
-      "version": "6.0.4"
+      "version": "5.0.15"
     },
     "glob-base": {
       "version": "0.3.0"
@@ -770,7 +897,12 @@
       "version": "0.0.12"
     },
     "globby": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4"
+        }
+      }
     },
     "globule": {
       "version": "0.1.0",
@@ -796,18 +928,7 @@
       "version": "1.0.0"
     },
     "got": {
-      "version": "5.5.0",
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4"
-        },
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
-        }
-      }
+      "version": "5.6.0"
     },
     "graceful-fs": {
       "version": "4.1.3"
@@ -853,13 +974,10 @@
       "version": "2.3.1"
     },
     "gulp-typescript": {
-      "version": "2.12.1",
+      "version": "2.12.2",
       "dependencies": {
         "extend": {
           "version": "3.0.0"
-        },
-        "glob": {
-          "version": "5.0.15"
         },
         "glob-stream": {
           "version": "5.3.2",
@@ -872,11 +990,14 @@
             }
           }
         },
+        "json-stable-stringify": {
+          "version": "1.0.1"
+        },
         "ordered-read-streams": {
           "version": "0.3.0"
         },
-        "readable-stream": {
-          "version": "2.0.5"
+        "source-map": {
+          "version": "0.5.3"
         },
         "typescript": {
           "version": "1.8.7"
@@ -912,8 +1033,14 @@
     "has-gulplog": {
       "version": "0.1.0"
     },
+    "hash.js": {
+      "version": "1.0.3"
+    },
     "hosted-git-info": {
       "version": "2.1.4"
+    },
+    "htmlescape": {
+      "version": "1.1.1"
     },
     "http-errors": {
       "version": "1.3.1"
@@ -926,6 +1053,9 @@
         }
       }
     },
+    "https-browserify": {
+      "version": "0.0.1"
+    },
     "https-proxy-agent": {
       "version": "1.0.0",
       "dependencies": {
@@ -937,11 +1067,17 @@
     "iconv-lite": {
       "version": "0.4.13"
     },
+    "ieee754": {
+      "version": "1.1.6"
+    },
     "imurmurhash": {
       "version": "0.1.4"
     },
     "indent-string": {
       "version": "2.1.0"
+    },
+    "indexof": {
+      "version": "0.0.1"
     },
     "indx": {
       "version": "0.2.3"
@@ -955,6 +1091,12 @@
     "ini": {
       "version": "1.3.4"
     },
+    "inline-source-map": {
+      "version": "0.6.1"
+    },
+    "insert-module-globals": {
+      "version": "7.0.1"
+    },
     "interpret": {
       "version": "1.0.0"
     },
@@ -965,7 +1107,7 @@
       "version": "1.0.0"
     },
     "is-absolute": {
-      "version": "0.2.4"
+      "version": "0.2.5"
     },
     "is-arrayish": {
       "version": "0.2.1"
@@ -1021,6 +1163,9 @@
     "is-plain-obj": {
       "version": "1.1.0"
     },
+    "is-posix-bracket": {
+      "version": "0.1.1"
+    },
     "is-primitive": {
       "version": "2.0.0"
     },
@@ -1054,17 +1199,29 @@
     "isobject": {
       "version": "2.0.0"
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1"
+    },
     "js-tokens": {
       "version": "1.0.3"
     },
     "json-stable-stringify": {
-      "version": "1.0.1"
+      "version": "0.0.1"
     },
     "jsonify": {
       "version": "0.0.0"
     },
+    "jsonparse": {
+      "version": "1.2.0"
+    },
+    "JSONStream": {
+      "version": "1.1.1"
+    },
     "kind-of": {
       "version": "3.0.2"
+    },
+    "labeled-stream-splicer": {
+      "version": "2.0.0"
     },
     "latest-version": {
       "version": "2.0.0"
@@ -1075,8 +1232,11 @@
     "lcid": {
       "version": "1.0.0"
     },
+    "lexical-scope": {
+      "version": "1.2.0"
+    },
     "liftoff": {
-      "version": "2.2.0"
+      "version": "2.2.1"
     },
     "listify": {
       "version": "1.0.0"
@@ -1091,7 +1251,7 @@
       "version": "1.0.1"
     },
     "lodash": {
-      "version": "4.6.1"
+      "version": "4.9.0"
     },
     "lodash._baseassign": {
       "version": "3.2.0"
@@ -1153,6 +1313,9 @@
     "lodash.keys": {
       "version": "3.1.2"
     },
+    "lodash.memoize": {
+      "version": "3.0.4"
+    },
     "lodash.restparam": {
       "version": "3.6.1"
     },
@@ -1196,18 +1359,16 @@
       "version": "3.7.0"
     },
     "merge-stream": {
-      "version": "1.0.0",
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.5"
-        }
-      }
+      "version": "1.0.0"
     },
     "methods": {
       "version": "1.1.2"
     },
     "micromatch": {
       "version": "2.3.7"
+    },
+    "miller-rabin": {
+      "version": "4.0.0"
     },
     "mime-db": {
       "version": "1.22.0"
@@ -1217,6 +1378,9 @@
     },
     "mini-lr": {
       "version": "0.1.9"
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0"
     },
     "minimatch": {
       "version": "3.0.0"
@@ -1232,6 +1396,9 @@
         }
       }
     },
+    "module-deps": {
+      "version": "4.0.5"
+    },
     "moment": {
       "version": "2.12.0"
     },
@@ -1245,7 +1412,15 @@
       "version": "0.7.1"
     },
     "multipipe": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.0.2"
+        },
+        "readable-stream": {
+          "version": "1.1.13"
+        }
+      }
     },
     "nan": {
       "version": "2.2.1"
@@ -1270,6 +1445,9 @@
         }
       }
     },
+    "node-fetch": {
+      "version": "1.5.0"
+    },
     "node-status-codes": {
       "version": "1.0.0"
     },
@@ -1283,7 +1461,7 @@
       "version": "2.0.1"
     },
     "npm": {
-      "version": "3.8.5",
+      "version": "3.8.7",
       "dependencies": {
         "abbrev": {
           "version": "1.0.7"
@@ -1471,13 +1649,13 @@
           "version": "3.1.0"
         },
         "lodash._baseuniq": {
-          "version": "4.5.0",
+          "version": "4.5.1",
           "dependencies": {
             "lodash._createset": {
-              "version": "4.0.0"
+              "version": "4.0.1"
             },
             "lodash._setcache": {
-              "version": "4.1.0"
+              "version": "4.1.1"
             }
           }
         },
@@ -1494,7 +1672,7 @@
           "version": "3.9.1"
         },
         "lodash.clonedeep": {
-          "version": "4.3.1",
+          "version": "4.3.2",
           "dependencies": {
             "lodash._baseclone": {
               "version": "4.5.3"
@@ -1505,16 +1683,16 @@
           "version": "4.0.0"
         },
         "lodash.keys": {
-          "version": "4.0.5"
+          "version": "4.0.6"
         },
         "lodash.restparam": {
           "version": "3.6.1"
         },
         "lodash.union": {
-          "version": "4.2.0",
+          "version": "4.2.1",
           "dependencies": {
             "lodash._baseflatten": {
-              "version": "4.1.0"
+              "version": "4.1.1"
             },
             "lodash.rest": {
               "version": "4.0.1"
@@ -1522,13 +1700,13 @@
           }
         },
         "lodash.uniq": {
-          "version": "4.2.0"
+          "version": "4.2.1"
         },
         "lodash.without": {
-          "version": "4.1.1",
+          "version": "4.1.2",
           "dependencies": {
             "lodash._basedifference": {
-              "version": "4.4.0",
+              "version": "4.4.1",
               "dependencies": {
                 "lodash._setcache": {
                   "version": "4.1.1"
@@ -1826,21 +2004,29 @@
           "version": "3.0.1"
         },
         "request": {
-          "version": "2.69.0",
+          "version": "2.70.0",
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0"
             },
             "aws4": {
-              "version": "1.2.1",
+              "version": "1.3.2",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.7.3"
+                  "version": "4.0.1",
+                  "dependencies": {
+                    "pseudomap": {
+                      "version": "1.0.2"
+                    },
+                    "yallist": {
+                      "version": "2.0.0"
+                    }
+                  }
                 }
               }
             },
             "bl": {
-              "version": "1.0.1"
+              "version": "1.1.2"
             },
             "caseless": {
               "version": "0.11.0"
@@ -1860,7 +2046,7 @@
               "version": "0.6.1"
             },
             "form-data": {
-              "version": "1.0.0-rc3",
+              "version": "1.0.0-rc4",
               "dependencies": {
                 "async": {
                   "version": "1.5.2"
@@ -1871,13 +2057,13 @@
               "version": "2.0.6",
               "dependencies": {
                 "chalk": {
-                  "version": "1.1.1",
+                  "version": "1.1.3",
                   "dependencies": {
                     "ansi-styles": {
-                      "version": "2.1.0"
+                      "version": "2.2.1"
                     },
                     "escape-string-regexp": {
-                      "version": "1.0.4"
+                      "version": "1.0.5"
                     },
                     "has-ansi": {
                       "version": "2.0.0"
@@ -1896,7 +2082,7 @@
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.12.4",
+                  "version": "2.13.1",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0"
@@ -1921,7 +2107,7 @@
                   "version": "2.0.0",
                   "dependencies": {
                     "pinkie": {
-                      "version": "2.0.1"
+                      "version": "2.0.4"
                     }
                   }
                 }
@@ -1965,13 +2151,18 @@
                   }
                 },
                 "sshpk": {
-                  "version": "1.7.3",
+                  "version": "1.7.4",
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3"
                     },
                     "dashdash": {
-                      "version": "1.12.2"
+                      "version": "1.13.0",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0"
+                        }
+                      }
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1"
@@ -1983,7 +2174,7 @@
                       "version": "0.1.0"
                     },
                     "tweetnacl": {
-                      "version": "0.13.3"
+                      "version": "0.14.3"
                     }
                   }
                 }
@@ -1999,10 +2190,10 @@
               "version": "5.0.1"
             },
             "mime-types": {
-              "version": "2.1.9",
+              "version": "2.1.10",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.21.0"
+                  "version": "1.22.0"
                 }
               }
             },
@@ -2010,16 +2201,16 @@
               "version": "1.4.7"
             },
             "oauth-sign": {
-              "version": "0.8.0"
+              "version": "0.8.1"
             },
             "qs": {
-              "version": "6.0.2"
+              "version": "6.1.0"
             },
             "stringstream": {
               "version": "0.0.5"
             },
             "tough-cookie": {
-              "version": "2.2.1"
+              "version": "2.2.2"
             },
             "tunnel-agent": {
               "version": "0.4.2"
@@ -2163,6 +2354,9 @@
     "ordered-read-streams": {
       "version": "0.1.0"
     },
+    "os-browserify": {
+      "version": "0.1.2"
+    },
     "os-homedir": {
       "version": "1.0.1"
     },
@@ -2176,12 +2370,21 @@
       "version": "0.1.3"
     },
     "package-json": {
-      "version": "2.3.1",
+      "version": "2.3.2",
       "dependencies": {
         "semver": {
           "version": "5.1.0"
         }
       }
+    },
+    "pako": {
+      "version": "0.2.8"
+    },
+    "parents": {
+      "version": "1.0.1"
+    },
+    "parse-asn1": {
+      "version": "5.0.0"
     },
     "parse-glob": {
       "version": "3.0.4"
@@ -2192,6 +2395,9 @@
     "parseurl": {
       "version": "1.3.1"
     },
+    "path-browserify": {
+      "version": "0.0.0"
+    },
     "path-exists": {
       "version": "2.1.0"
     },
@@ -2201,11 +2407,17 @@
     "path-is-inside": {
       "version": "1.0.1"
     },
+    "path-platform": {
+      "version": "0.11.15"
+    },
     "path-type": {
       "version": "1.1.0"
     },
     "pause-stream": {
       "version": "0.0.11"
+    },
+    "pbkdf2": {
+      "version": "3.0.4"
     },
     "pify": {
       "version": "2.3.0"
@@ -2217,16 +2429,16 @@
       "version": "2.0.0"
     },
     "popsicle": {
-      "version": "5.0.0"
+      "version": "5.0.1"
     },
     "popsicle-proxy-agent": {
       "version": "1.0.0"
     },
     "popsicle-retry": {
-      "version": "1.0.1"
+      "version": "2.0.0"
     },
     "popsicle-status": {
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "prepend-http": {
       "version": "1.0.3"
@@ -2237,17 +2449,38 @@
     "pretty-hrtime": {
       "version": "1.0.2"
     },
+    "process": {
+      "version": "0.11.2"
+    },
     "process-nextick-args": {
       "version": "1.0.6"
+    },
+    "promise": {
+      "version": "7.1.1"
     },
     "promise-finally": {
       "version": "2.1.0"
     },
+    "public-encrypt": {
+      "version": "4.0.0"
+    },
+    "punycode": {
+      "version": "1.4.1"
+    },
     "qs": {
       "version": "2.2.5"
     },
+    "querystring": {
+      "version": "0.2.0"
+    },
+    "querystring-es3": {
+      "version": "0.2.1"
+    },
     "randomatic": {
       "version": "1.1.5"
+    },
+    "randombytes": {
+      "version": "2.0.3"
     },
     "raw-body": {
       "version": "2.1.6",
@@ -2260,16 +2493,17 @@
     "rc": {
       "version": "1.1.6"
     },
+    "react": {
+      "version": "15.0.1"
+    },
+    "react-dom": {
+      "version": "15.0.1"
+    },
     "read-all-stream": {
-      "version": "3.1.0",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
-        }
-      }
+      "version": "3.1.0"
+    },
+    "read-only-stream": {
+      "version": "2.0.0"
     },
     "read-pkg": {
       "version": "1.1.0"
@@ -2278,19 +2512,18 @@
       "version": "1.0.1"
     },
     "readable-stream": {
-      "version": "1.1.13"
+      "version": "2.0.6",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
     },
     "readdirp": {
       "version": "2.0.0",
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
         "minimatch": {
           "version": "2.0.10"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
         }
       }
     },
@@ -2301,10 +2534,10 @@
       "version": "1.0.0"
     },
     "regex-cache": {
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "registry-url": {
-      "version": "3.0.3"
+      "version": "3.1.0"
     },
     "repeat-element": {
       "version": "1.1.2"
@@ -2332,6 +2565,9 @@
         }
       }
     },
+    "ripemd160": {
+      "version": "1.0.1"
+    },
     "sax": {
       "version": "0.5.8"
     },
@@ -2349,6 +2585,15 @@
     "sequencify": {
       "version": "0.0.7"
     },
+    "sha.js": {
+      "version": "2.4.5"
+    },
+    "shasum": {
+      "version": "1.0.2"
+    },
+    "shell-quote": {
+      "version": "1.5.0"
+    },
     "shonkwrap": {
       "version": "1.3.0"
     },
@@ -2365,7 +2610,7 @@
       "version": "1.1.1"
     },
     "source-map": {
-      "version": "0.5.3"
+      "version": "0.4.2"
     },
     "sparkles": {
       "version": "1.0.0"
@@ -2380,7 +2625,7 @@
       "version": "1.0.2"
     },
     "spdx-license-ids": {
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     "split": {
       "version": "0.3.3"
@@ -2391,11 +2636,23 @@
     "statuses": {
       "version": "1.2.1"
     },
+    "stream-browserify": {
+      "version": "2.0.1"
+    },
     "stream-combiner": {
       "version": "0.0.4"
     },
+    "stream-combiner2": {
+      "version": "1.1.1"
+    },
     "stream-consume": {
       "version": "0.1.0"
+    },
+    "stream-http": {
+      "version": "2.2.1"
+    },
+    "stream-splicer": {
+      "version": "2.0.0"
     },
     "string_decoder": {
       "version": "0.10.31"
@@ -2422,16 +2679,13 @@
       "version": "1.0.4"
     },
     "stylint": {
-      "version": "1.3.7",
+      "version": "1.3.8",
       "dependencies": {
         "async": {
           "version": "1.4.2"
         },
         "camelcase": {
           "version": "1.2.1"
-        },
-        "glob": {
-          "version": "5.0.15"
         },
         "window-size": {
           "version": "0.1.4"
@@ -2455,22 +2709,31 @@
         }
       }
     },
+    "subarg": {
+      "version": "1.0.0"
+    },
     "supports-color": {
       "version": "2.0.0"
     },
+    "syntax-error": {
+      "version": "1.1.6",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0"
+        }
+      }
+    },
     "thenify": {
       "version": "3.2.0"
+    },
+    "throat": {
+      "version": "2.0.2"
     },
     "through": {
       "version": "2.3.8"
     },
     "through2": {
-      "version": "2.0.1",
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.5"
-        }
-      }
+      "version": "2.0.1"
     },
     "through2-filter": {
       "version": "2.0.0"
@@ -2479,13 +2742,19 @@
       "version": "1.1.2"
     },
     "time-stamp": {
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     "timed-out": {
       "version": "2.0.0"
     },
+    "timers-browserify": {
+      "version": "1.4.2"
+    },
     "to-absolute-glob": {
       "version": "0.1.1"
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1"
     },
     "touch": {
       "version": "1.0.0"
@@ -2497,7 +2766,7 @@
       "version": "1.0.0"
     },
     "tslint": {
-      "version": "3.6.0",
+      "version": "3.7.1",
       "dependencies": {
         "findup-sync": {
           "version": "0.2.1",
@@ -2507,10 +2776,16 @@
             }
           }
         },
+        "glob": {
+          "version": "6.0.4"
+        },
         "minimatch": {
           "version": "2.0.10"
         }
       }
+    },
+    "tty-browserify": {
+      "version": "0.0.0"
     },
     "type-is": {
       "version": "1.6.12"
@@ -2522,7 +2797,7 @@
       "version": "1.8.9"
     },
     "typings": {
-      "version": "0.7.9",
+      "version": "0.7.12",
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0"
@@ -2530,13 +2805,24 @@
       }
     },
     "typings-core": {
-      "version": "0.2.13"
+      "version": "0.2.16"
+    },
+    "ua-parser-js": {
+      "version": "0.7.10"
     },
     "uglify-js": {
-      "version": "2.6.2"
+      "version": "2.6.2",
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.3"
+        }
+      }
     },
     "uglify-to-browserify": {
       "version": "1.0.2"
+    },
+    "umd": {
+      "version": "3.0.1"
     },
     "unc-path-regex": {
       "version": "0.1.1"
@@ -2556,11 +2842,22 @@
     "update-notifier": {
       "version": "0.6.3"
     },
+    "url": {
+      "version": "0.11.0",
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2"
+        }
+      }
+    },
     "url-parse-lax": {
       "version": "1.0.0"
     },
     "user-home": {
       "version": "1.1.1"
+    },
+    "util": {
+      "version": "0.10.3"
     },
     "util-deprecate": {
       "version": "1.0.2"
@@ -2601,7 +2898,15 @@
       }
     },
     "vinyl-sourcemaps-apply": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.3"
+        }
+      }
+    },
+    "vm-browserify": {
+      "version": "0.0.4"
     },
     "wcwidth": {
       "version": "1.0.0"
@@ -2611,6 +2916,9 @@
     },
     "websocket-extensions": {
       "version": "0.1.1"
+    },
+    "whatwg-fetch": {
+      "version": "0.11.0"
     },
     "when": {
       "version": "3.7.7"

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "bower": ">=1.7.2",
+    "browserify": "^13.0.0",
     "del": ">=2.0.2",
     "gulp": ">=3.9.0",
     "gulp-livereload": ">=3.8.0",
@@ -14,10 +15,12 @@
     "moment-timezone": ">=0.4.1",
     "nib": ">=1.1.0",
     "npm": ">=3.3.4",
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1",
     "shonkwrap": ">=1.1.2",
     "stylint": ">=1.3.5",
     "stylus": ">=0.51.1",
-    "tslint": ">=3.0.0",
+    "tslint": "^3.7.1",
     "typescript": ">=1.6.2",
     "typings": ">=0.6.6"
   }

--- a/ui/typings.json
+++ b/ui/typings.json
@@ -8,6 +8,8 @@
     "moment": "github:DefinitelyTyped/DefinitelyTyped/moment/moment.d.ts#e5a27ea95e47b95333784f1f0d590127b4e39a89",
     "moment-node": "github:DefinitelyTyped/DefinitelyTyped/moment/moment-node.d.ts#e5a27ea95e47b95333784f1f0d590127b4e39a89",
     "moment-timezone": "github:DefinitelyTyped/DefinitelyTyped/moment-timezone/moment-timezone.d.ts#e5a27ea95e47b95333784f1f0d590127b4e39a89",
-    "nvd3": "github:DefinitelyTyped/DefinitelyTyped/nvd3/nvd3.d.ts#3d2f9971a107e2eee2de3ec5318f5c54071e16ed"
+    "nvd3": "github:DefinitelyTyped/DefinitelyTyped/nvd3/nvd3.d.ts#3d2f9971a107e2eee2de3ec5318f5c54071e16ed",
+    "react": "registry:dt/react#0.14.0+20160319053454",
+    "react-dom": "registry:dt/react-dom#0.14.0+20160316155526"
   }
 }


### PR DESCRIPTION
Further work to establish the skeleton of our next UI version. Of note:
- React and ReactDOM are used.
- Typescript now compiles using its support for the commonjs module system. The
  Typescript project does not output a single monolithic file, but rather outputs
  .js files (1:1 with ts files) which address dependencies using `require()`.
  single file.
- Browserify is used to compile the .js files into a browser-ready, monolithic
  javascript file with all dependencies involved. An alternative was webpack,
  but we do not require any of its more advanced features.

npm modules were updated by this change.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5986)

<!-- Reviewable:end -->
