### PR TITLE
build: add uidebug target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,14 @@ all: build test check
 .PHONY: release
 release: build
 
+# The uidebug build tag is used to turn off embedding of UI assets into the
+# cockroach binary, loading them from the local filesystem at run time instead.
+# This build target is intended for use by UI developers, as it provides a
+# faster iteration cycle which doesn't require recompilation of the binary.
+.PHONY: uidebug
+uidebug: TAGS += uidebug
+uidebug: build
+
 .PHONY: build
 build: GOFLAGS += -i -o cockroach
 build: BUILDMODE = build
@@ -80,7 +88,7 @@ install:
 	@echo "GOPATH set to $$GOPATH"
 	@echo "$$GOPATH/bin added to PATH"
 	@echo $(GO) $(BUILDMODE) -v $(GOFLAGS)
-	@$(GO) $(BUILDMODE) -v $(GOFLAGS) -ldflags '$(LDFLAGS)'
+	@$(GO) $(BUILDMODE) -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)'
 
 # Build, but do not run the tests.
 # PKG is expanded and all packages are built and moved to their directory.

--- a/server/server.go
+++ b/server/server.go
@@ -29,7 +29,6 @@ import (
 	"sync"
 	"time"
 
-	assetfs "github.com/elazarl/go-bindata-assetfs"
 	opentracing "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 
@@ -45,7 +44,6 @@ import (
 	"github.com/cockroachdb/cockroach/sql/pgwire"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/ts"
-	"github.com/cockroachdb/cockroach/ui"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -396,15 +394,11 @@ func (s *Server) startSampleEnvironment(frequency time.Duration) {
 	})
 }
 
+var uiFileSystem http.FileSystem
+
 // initHTTP registers http prefixes.
 func (s *Server) initHTTP() {
-	s.mux.Handle("/", http.FileServer(
-		&assetfs.AssetFS{
-			Asset:     ui.Asset,
-			AssetDir:  ui.AssetDir,
-			AssetInfo: ui.AssetInfo,
-		},
-	))
+	s.mux.Handle("/", http.FileServer(uiFileSystem))
 
 	// The admin server handles both /debug/ and /_admin/
 	// TODO(marc): when cookie-based authentication exists,

--- a/server/ui_fs_debug.go
+++ b/server/ui_fs_debug.go
@@ -1,0 +1,25 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tamir Duberstein(tamird@gmail.com)
+
+// +build uidebug
+
+package server
+
+import "net/http"
+
+func init() {
+	uiFileSystem = http.Dir("ui")
+}

--- a/server/ui_fs_release.go
+++ b/server/ui_fs_release.go
@@ -1,0 +1,32 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tamir Duberstein(tamird@gmail.com)
+
+// +build !uidebug
+
+package server
+
+import (
+	"github.com/cockroachdb/cockroach/ui"
+	"github.com/elazarl/go-bindata-assetfs"
+)
+
+func init() {
+	uiFileSystem = &assetfs.AssetFS{
+		Asset:     ui.Asset,
+		AssetDir:  ui.AssetDir,
+		AssetInfo: ui.AssetInfo,
+	}
+}


### PR DESCRIPTION
This target compiles a Cockroach binary that doesn't use go-bindata,
serving directly from the file system instead. This should provide a
much nicer UI development experience.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5989)

<!-- Reviewable:end -->
