### PR TITLE
sql: add 'typeof' builtin function to get type of expression

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -74,10 +74,16 @@ func (a ArgTypes) match(types ArgTypes) bool {
 	return true
 }
 
-// AnyType accepts any arguments.
-type AnyType struct{}
+// AnyType accepts arguments of any type.
+// If `count` is non-zero, the number of args must match `count`.
+type AnyType struct {
+	count int
+}
 
-func (AnyType) match(types ArgTypes) bool {
+func (a AnyType) match(types ArgTypes) bool {
+	if a.count > 0 {
+		return a.count == len(types)
+	}
 	return true
 }
 
@@ -997,6 +1003,15 @@ var Builtins = map[string][]Builtin{
 			dd.Round(x, 0, inf.RoundDown)
 			return dd, nil
 		}),
+	},
+	"typeof": {
+		Builtin{
+			ReturnType: TypeString,
+			Types:      AnyType{1},
+			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+				return DString(args[0].Type()), nil
+			},
+		},
 	},
 	"version": {
 		Builtin{

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -1048,3 +1048,16 @@ query I
 SELECT strpos(version(), 'CockroachDB')
 ----
 1
+
+query T
+SELECT typeof('hello world')
+----
+string
+
+query T
+SELECT typeof(1.9 > 1.1)
+----
+bool
+
+query error unknown signature for typeof: typeof\(string, int\)
+SELECT typeof('hello world', 1)


### PR DESCRIPTION
I found myself wanting to know the type inferred for an expression, and given the upcoming work
on typing, I imagine that we'll be asking that more often too.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5993)

<!-- Reviewable:end -->
