### PR TITLE
sql: backfill index using InitPut()

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -420,10 +420,10 @@ func (sc *SchemaChanger) backfillIndexes(
 
 				for _, secondaryIndexEntry := range secondaryIndexEntries {
 					if log.V(2) {
-						log.Infof("CPut %s -> %v", secondaryIndexEntry.key,
+						log.Infof("InitPut %s -> %v", secondaryIndexEntry.key,
 							secondaryIndexEntry.value)
 					}
-					b.CPut(secondaryIndexEntry.key, secondaryIndexEntry.value, nil)
+					b.InitPut(secondaryIndexEntry.key, secondaryIndexEntry.value)
 				}
 			}
 		}


### PR DESCRIPTION
Ignore the first commit. It is being reviewed separately. There is value to putting these two commits in different PRs, in case we want to roll them out in different Beta releases for backwards compatibility reasons.

Added a lot more testing.

closes #5817

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5996)

<!-- Reviewable:end -->
