### PR TITLE
roachpb: make SetInner MustSetInner

### DIFF
--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -74,9 +73,8 @@ func newTestSender(pre, post func(roachpb.BatchRequest) (*roachpb.BatchResponse,
 			args := req.GetInner()
 			if _, ok := args.(*roachpb.PutRequest); ok {
 				testPutRespCopy := testPutResp
-				if union := &br.Responses[i]; !union.SetInner(&testPutRespCopy) {
-					panic(fmt.Sprintf("%T excludes %T", union, testPutRespCopy))
-				}
+				union := &br.Responses[i] // avoid operating on copy
+				union.MustSetInner(&testPutRespCopy)
 			}
 			if roachpb.IsTransactionWrite(args) {
 				writing = true

--- a/kv/batch.go
+++ b/kv/batch.go
@@ -17,8 +17,6 @@
 package kv
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
@@ -108,9 +106,7 @@ func truncate(ba roachpb.BatchRequest, rs roachpb.RSpan) (roachpb.BatchRequest, 
 			// We omit this one, i.e. replace it with a Noop.
 			numNoop++
 			union := roachpb.RequestUnion{}
-			if !union.SetInner(&noopRequest) {
-				panic(fmt.Sprintf("%T excludes %T", union, noopRequest))
-			}
+			union.MustSetInner(&noopRequest)
 			ba.Requests[pos] = union
 		} else {
 			// Keep the old one. If we must adjust the header, must copy.
@@ -119,9 +115,8 @@ func truncate(ba roachpb.BatchRequest, rs roachpb.RSpan) (roachpb.BatchRequest, 
 			} else {
 				shallowCopy := inner.ShallowCopy()
 				shallowCopy.SetHeader(newHeader)
-				if union := &ba.Requests[pos]; !union.SetInner(shallowCopy) {
-					panic(fmt.Sprintf("%T excludes %T", union, shallowCopy))
-				}
+				union := &ba.Requests[pos] // avoid operating on copy
+				union.MustSetInner(shallowCopy)
 			}
 		}
 		if err != nil {

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -867,9 +867,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 						_ = req.GetInner().(*roachpb.ReverseScanRequest)
 						reply = &roachpb.ReverseScanResponse{}
 					}
-					if !union.SetInner(reply) {
-						panic(fmt.Sprintf("%T excludes %T", union, reply))
-					}
+					union.MustSetInner(reply)
 					br.Responses[i] = union
 				}
 				return br, nil, false
@@ -924,10 +922,8 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 					// We've hit max results for this piece of the batch. Mask
 					// it out (we've copied the requests slice above, so this
 					// is kosher).
-					ba.Requests[i].Reset() // necessary (no one-of?)
-					if union := &ba.Requests[i]; !union.SetInner(&noopRequest) {
-						panic(fmt.Sprintf("%T excludes %T", union, noopRequest))
-					}
+					union := &ba.Requests[i] // avoid working on copy
+					union.MustSetInner(&noopRequest)
 					continue
 				}
 				// The request isn't saturated yet.

--- a/roachpb/api.go
+++ b/roachpb/api.go
@@ -293,14 +293,24 @@ func (ru ResponseUnion) GetInner() Response {
 	return ru.GetValue().(Response)
 }
 
-// SetInner sets the Request contained in the union.
-func (ru *RequestUnion) SetInner(args Request) bool {
-	return ru.SetValue(args)
+// MustSetInner sets the Request contained in the union. It panics if the
+// request is not recognized by the union type. The RequestUnion is reset
+// before being repopulated.
+func (ru *RequestUnion) MustSetInner(args Request) {
+	ru.Reset()
+	if !ru.SetValue(args) {
+		panic(fmt.Sprintf("%T excludes %T", ru, args))
+	}
 }
 
-// SetInner sets the Response contained in the union.
-func (ru *ResponseUnion) SetInner(reply Response) bool {
-	return ru.SetValue(reply)
+// MustSetInner sets the Response contained in the union. It panics if the
+// response is not recognized by the union type. The ResponseUnion is reset
+// before being repopulated.
+func (ru *ResponseUnion) MustSetInner(reply Response) {
+	ru.Reset()
+	if !ru.SetValue(reply) {
+		panic(fmt.Sprintf("%T excludes %T", ru, reply))
+	}
 }
 
 // Bounded is implemented by request types which have a bounded number of

--- a/roachpb/api_test.go
+++ b/roachpb/api_test.go
@@ -87,3 +87,23 @@ func TestCombinable(t *testing.T) {
 		t.Errorf("wanted %v, got %v", wantedDR, dr1)
 	}
 }
+
+// TestMustSetInner makes sure that calls to MustSetInner correctly reset the
+// union before repopulating to avoid having more than one value set.
+func TestMustSetInner(t *testing.T) {
+	req := RequestUnion{}
+	res := ResponseUnion{}
+
+	// GetRequest is checked first in the generated code for SetValue.
+	req.MustSetInner(&GetRequest{})
+	res.MustSetInner(&GetResponse{})
+	req.MustSetInner(&EndTransactionRequest{})
+	res.MustSetInner(&EndTransactionResponse{})
+
+	if m := req.GetInner().Method(); m != EndTransaction {
+		t.Fatalf("unexpected request: %s in %+v", m, req)
+	}
+	if _, isET := res.GetValue().(*EndTransactionResponse); !isET {
+		t.Fatalf("unexpected response union: %+v", res)
+	}
+}

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -159,9 +159,7 @@ func (br *BatchResponse) Combine(otherBatch *BatchResponse) error {
 func (ba *BatchRequest) Add(requests ...Request) {
 	for _, args := range requests {
 		union := RequestUnion{}
-		if !union.SetInner(args) {
-			panic(fmt.Sprintf("%T excludes %T", union, args))
-		}
+		union.MustSetInner(args)
 		ba.Requests = append(ba.Requests, union)
 	}
 }
@@ -169,9 +167,7 @@ func (ba *BatchRequest) Add(requests ...Request) {
 // Add adds a response to the batch response.
 func (br *BatchResponse) Add(reply Response) {
 	union := ResponseUnion{}
-	if !union.SetInner(reply) {
-		panic(fmt.Sprintf("%T excludes %T", union, reply))
-	}
+	union.MustSetInner(reply)
 	br.Responses = append(br.Responses, union)
 }
 

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -307,7 +307,7 @@ func (r *Replica) ReverseScan(batch engine.Engine, h roachpb.Header, remScanResu
 
 func verifyTransaction(h roachpb.Header, args roachpb.Request) error {
 	if h.Txn == nil {
-		return util.Errorf("no transaction specified to HeartbeatTxn")
+		return util.Errorf("no transaction specified to %s", args.Method())
 	}
 	if !bytes.Equal(args.Header().Key, h.Txn.Key) {
 		return util.Errorf("request key %s should match txn key %s", args.Header().Key, h.Txn.Key)


### PR DESCRIPTION
This was always how it was used. Add comments on a particular
fallacy surrounding the Requests and Responses slices in BatchRequest
and BatchResponse, respectively.
Add a call to Reset in MustSetInner (or multiple values may end up
being set, which causes the first one to be returned from GetInner).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/5997)

<!-- Reviewable:end -->
