### PR TITLE
storage: Fix nil pointer in markDead on log

### DIFF
--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -54,7 +54,11 @@ func (sd *storeDetail) markDead(foundDeadOn roachpb.Timestamp) {
 	sd.dead = true
 	sd.foundDeadOn = foundDeadOn
 	sd.timesDied++
-	log.Warningf("store %s on node %s is now considered offline", sd.desc.StoreID, sd.desc.Node.NodeID)
+	if sd.desc != nil {
+		// sd.desc can still be nil if it was markedAlive and enqueued in getStoreDetailLocked
+		// and never markedAlive again.
+		log.Warningf("store %s on node %s is now considered offline", sd.desc.StoreID, sd.desc.Node.NodeID)
+	}
 }
 
 // markAlive sets the storeDetail to alive(active) and saves the updated time


### PR DESCRIPTION
Fixes #6001.

The descriptor could have never been set on the `storeDetail` if it was
markedAlive and enqueue'd in getStoreDetailLocked and never markedAlive again.
I'm not sure if it makes sense to log anything, because chances are the
store was never alive to begin with.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6013)

<!-- Reviewable:end -->
