### PR TITLE
kv: reenable the local call optimization by default

### DIFF
--- a/kv/send.go
+++ b/kv/send.go
@@ -239,7 +239,7 @@ func splitHealthy(clients []batchClient) (int, error) {
 
 // Allow local calls to be dispatched directly to the local server without
 // sending an RPC.
-var enableLocalCalls = envutil.EnvOrDefaultBool("enable_local_calls", false)
+var enableLocalCalls = envutil.EnvOrDefaultBool("enable_local_calls", true)
 
 // sendOneFn is overwritten in tests to mock sendOne.
 var sendOneFn = sendOne


### PR DESCRIPTION
The local call optimization was accidentally disabled by #5430.

```
name                     old time/op  new time/op  delta
KVInsert1_Native-32       624µs ± 2%   266µs ± 1%  -57.35%  (p=0.000 n=10+10)
KVInsert1_SQL-32          801µs ± 2%   495µs ± 1%  -38.17%  (p=0.000 n=10+10)
KVInsert10_Native-32      871µs ± 2%   469µs ± 1%  -46.09%  (p=0.000 n=10+10)
KVInsert10_SQL-32        1.38ms ± 1%  0.96ms ± 1%  -30.60%   (p=0.000 n=9+10)
KVInsert100_Native-32    2.91ms ± 1%  2.22ms ± 1%  -23.74%  (p=0.000 n=10+10)
KVInsert100_SQL-32       6.21ms ± 2%  5.18ms ± 1%  -16.54%  (p=0.000 n=10+10)
KVInsert1000_Native-32   23.3ms ± 0%  20.2ms ± 1%  -13.33%   (p=0.000 n=8+10)
KVInsert1000_SQL-32      58.9ms ± 3%  52.2ms ± 3%  -11.45%  (p=0.000 n=10+10)
KVInsert10000_Native-32   259ms ± 3%   234ms ± 5%   -9.81%   (p=0.000 n=9+10)
KVInsert10000_SQL-32      778ms ± 7%   687ms ± 6%  -11.67%  (p=0.000 n=10+10)
KVUpdate1_Native-32       994µs ± 3%   359µs ± 2%  -63.93%  (p=0.000 n=10+10)
KVUpdate1_SQL-32         1.32ms ± 3%  0.67ms ± 3%  -49.02%   (p=0.000 n=9+10)
KVUpdate10_Native-32     1.56ms ± 1%  0.75ms ± 1%  -51.70%   (p=0.000 n=9+10)
KVUpdate10_SQL-32        2.03ms ± 2%  1.19ms ± 2%  -41.25%  (p=0.000 n=10+10)
KVUpdate100_Native-32    5.42ms ± 2%  3.89ms ± 1%  -28.19%   (p=0.000 n=10+9)
KVUpdate100_SQL-32       7.08ms ± 2%  5.51ms ± 1%  -22.12%   (p=0.000 n=10+9)
KVUpdate1000_Native-32   42.9ms ± 2%  36.3ms ± 2%  -15.23%  (p=0.000 n=10+10)
KVUpdate1000_SQL-32      57.2ms ± 3%  48.8ms ± 1%  -14.59%  (p=0.000 n=10+10)
KVUpdate10000_Native-32   523ms ± 4%   432ms ± 4%  -17.40%  (p=0.000 n=10+10)
KVUpdate10000_SQL-32      734ms ± 5%   637ms ± 3%  -13.22%  (p=0.000 n=10+10)
KVDelete1_Native-32       629µs ± 2%   265µs ± 3%  -57.80%  (p=0.000 n=10+10)
KVDelete1_SQL-32          850µs ± 2%   532µs ± 3%  -37.48%   (p=0.000 n=9+10)
KVDelete10_Native-32      917µs ± 1%   507µs ± 2%  -44.71%  (p=0.000 n=10+10)
KVDelete10_SQL-32        1.28ms ± 2%  0.89ms ± 2%  -30.69%   (p=0.000 n=10+9)
KVDelete100_Native-32    3.12ms ± 2%  2.40ms ± 2%  -23.03%  (p=0.000 n=10+10)
KVDelete100_SQL-32       4.45ms ± 2%  3.68ms ± 2%  -17.27%  (p=0.000 n=10+10)
KVDelete1000_Native-32   24.5ms ± 1%  21.6ms ± 2%  -11.78%   (p=0.000 n=8+10)
KVDelete1000_SQL-32      36.1ms ± 2%  33.0ms ± 2%   -8.69%  (p=0.000 n=10+10)
KVDelete10000_Native-32   267ms ± 3%   242ms ± 4%   -9.33%   (p=0.000 n=9+10)
KVDelete10000_SQL-32      474ms ± 9%   437ms ± 6%   -7.86%  (p=0.003 n=10+10)
KVScan1_Native-32         324µs ± 3%    61µs ± 2%  -81.18%  (p=0.000 n=10+10)
KVScan1_SQL-32            535µs ± 2%   198µs ± 1%  -63.02%   (p=0.000 n=10+9)
KVScan10_Native-32        388µs ± 1%    91µs ± 1%  -76.56%   (p=0.000 n=9+10)
KVScan10_SQL-32           706µs ± 2%   292µs ± 2%  -58.59%  (p=0.000 n=10+10)
KVScan100_Native-32       762µs ± 1%   324µs ± 3%  -57.42%   (p=0.000 n=9+10)
KVScan100_SQL-32         1.69ms ± 3%  1.05ms ± 9%  -37.64%  (p=0.000 n=10+10)
KVScan1000_Native-32     3.89ms ± 2%  2.54ms ± 3%  -34.62%   (p=0.000 n=10+9)
KVScan1000_SQL-32        10.5ms ± 4%   8.0ms ± 2%  -23.38%  (p=0.000 n=10+10)
KVScan10000_Native-32    39.9ms ± 5%  27.3ms ± 3%  -31.49%  (p=0.000 n=10+10)
KVScan10000_SQL-32        106ms ± 4%    80ms ± 5%  -24.49%  (p=0.000 n=10+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6021)

<!-- Reviewable:end -->
