### PR TITLE
acceptance: deal with all retry errors

### DIFF
--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -394,7 +394,6 @@ func (cli retryingDockerClient) retry(ctx context.Context, timeout time.Duration
 				log.Infof("%s: %v", name, err)
 				continue
 			}
-			log.Infof("%s: %T: %v", name, err, err)
 		}
 		return err
 	}


### PR DESCRIPTION
I don't think there's an issue open for it right now, but we're not
catching all of the error-after-context-timeout errors properly,
which caused me a bunch of red on CI this morning. Hopefully this
catches them all. I took the error messages from my local docker
client; they seem to match what I've seen, but we may need to adjust
them as docker gets upgraded and wording changes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6035)

<!-- Reviewable:end -->
