### PR TITLE
acceptance: add basic test of on-disk compat with reference version

### DIFF
--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -196,6 +196,7 @@ func (l *LocalCluster) expectEvent(c *Container, msgs ...string) {
 // OneShot runs a container, expecting it to successfully run to completion
 // and die, after which it is removed. Not goroutine safe: only one OneShot
 // can be running at once.
+// Adds the same binds as the cluster containers (certs, binary, etc).
 func (l *LocalCluster) OneShot(
 	ipo types.ImagePullOptions,
 	containerConfig container.Config,
@@ -205,6 +206,7 @@ func (l *LocalCluster) OneShot(
 	if err := pullImage(l, ipo); err != nil {
 		return err
 	}
+	hostConfig.VolumesFrom = []string{l.vols.id}
 	container, err := createContainer(l, containerConfig, hostConfig, name)
 	if err != nil {
 		return err

--- a/acceptance/reference_test.go
+++ b/acceptance/reference_test.go
@@ -1,0 +1,61 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package acceptance
+
+import "testing"
+
+func TestDockerReadWriteReferenceVersion(t *testing.T) {
+	testDockerSuccess(t, "reference", []string{"/bin/bash", "-c", `
+set -xe
+mkdir /old
+cd /old
+
+export PGHOST=localhost
+export PGPORT=""
+
+bin=/reference-version/cockroach
+$bin start &
+sleep 1
+echo "Use the reference binary to write a couple rows, then render its output to a file and shut down."
+$bin sql -e "CREATE DATABASE old"
+$bin sql -d old -e "CREATE TABLE testing (i int primary key, b bool, s string unique, d decimal, f float, t timestamp, v interval, index sb (s, b))"
+$bin sql -d old -e "INSERT INTO testing values (1, true, 'hello', decimal '3.14159', 3.14159, NOW(), interval '1h')"
+$bin sql -d old -e "INSERT INTO testing values (2, false, 'world', decimal '0.14159', 0.14159, NOW(), interval '234h45m2s234ms')"
+$bin sql -d old -e "SELECT * FROM testing" > old.everything
+$bin quit && wait # wait will block until all background jobs finish.
+
+bin=/cockroach
+$bin start &
+sleep 1
+echo "Read data written by referencce version using new binary"
+$bin sql -d old -e "SELECT * FROM testing" > new.everything
+# diff returns non-zero if different. With set -e above, that would exit here.
+diff new.everything old.everything
+
+echo "Add a row with the new binary and render the updated data before shutting down."
+$bin sql -d old -e "INSERT INTO testing values (3, false, '!', decimal '2.14159', 2.14159, NOW(), interval '3h')"
+$bin sql -d old -e "SELECT * FROM testing" > new.everything
+$bin quit && wait
+
+echo "Read the modified data using the reference binary again."
+bin=/reference-version/cockroach
+$bin start &
+sleep 1
+$bin sql -d old -e "SELECT * FROM testing" > old.everything
+# diff returns non-zero if different. With set -e above, that would exit here.
+diff new.everything old.everything
+$bin quit && wait
+`})
+}

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -283,7 +283,7 @@ func testDockerSuccess(t *testing.T, name string, cmd []string) {
 }
 
 const (
-	postgresTestTag = "20160406-1730"
+	postgresTestTag = "20160413-1457"
 )
 
 func testDocker(t *testing.T, name string, cmd []string) error {

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -283,17 +283,18 @@ func testDockerSuccess(t *testing.T, name string, cmd []string) {
 }
 
 const (
-	postgresTestTag = "20160413-1457"
+	postgresTestImage = "cockroachdb/postgres-test"
+	postgresTestTag   = "20160413-1457"
 )
 
 func testDocker(t *testing.T, name string, cmd []string) error {
-	const image = "cockroachdb/postgres-test"
 	SkipUnlessLocal(t)
 	l := StartCluster(t, readConfigFromFlags()).(*cluster.LocalCluster)
 
 	defer l.AssertAndStop(t)
+
 	containerConfig := container.Config{
-		Image: fmt.Sprintf(image + ":" + postgresTestTag),
+		Image: fmt.Sprintf(postgresTestImage + ":" + postgresTestTag),
 		Env: []string{
 			"PGHOST=roach0",
 			fmt.Sprintf("PGPORT=%s", base.DefaultPort),
@@ -307,7 +308,7 @@ func testDocker(t *testing.T, name string, cmd []string) error {
 		NetworkMode: "host",
 	}
 	ipo := types.ImagePullOptions{
-		ImageID: image,
+		ImageID: postgresTestImage,
 		Tag:     postgresTestTag,
 	}
 	return l.OneShot(ipo, containerConfig, hostConfig, "docker-"+name)

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -270,14 +270,14 @@ func postJSON(url, rel string, reqBody interface{}, v interface{}) error {
 
 // testDockerFail ensures the specified docker cmd fails.
 func testDockerFail(t *testing.T, name string, cmd []string) {
-	if err := testDocker(t, name, cmd); err == nil {
+	if err := testDockerSingleNode(t, name, cmd); err == nil {
 		t.Error("expected failure")
 	}
 }
 
 // testDockerSuccess ensures the specified docker cmd succeeds.
 func testDockerSuccess(t *testing.T, name string, cmd []string) {
-	if err := testDocker(t, name, cmd); err != nil {
+	if err := testDockerSingleNode(t, name, cmd); err != nil {
 		t.Errorf("expected success: %s", err)
 	}
 }
@@ -287,10 +287,14 @@ const (
 	postgresTestTag   = "20160413-1457"
 )
 
-func testDocker(t *testing.T, name string, cmd []string) error {
+func testDockerSingleNode(t *testing.T, name string, cmd []string) error {
 	SkipUnlessLocal(t)
-	l := StartCluster(t, readConfigFromFlags()).(*cluster.LocalCluster)
-
+	cfg := cluster.TestConfig{
+		Name:     name,
+		Duration: *flagDuration,
+		Nodes:    []cluster.NodeConfig{{Count: 1, Stores: []cluster.StoreConfig{{Count: 1}}}},
+	}
+	l := StartCluster(t, cfg).(*cluster.LocalCluster)
 	defer l.AssertAndStop(t)
 
 	containerConfig := container.Config{

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -284,7 +284,7 @@ func testDockerSuccess(t *testing.T, name string, cmd []string) {
 
 const (
 	postgresTestImage = "cockroachdb/postgres-test"
-	postgresTestTag   = "20160413-1457"
+	postgresTestTag   = "20160414-1710"
 )
 
 func testDockerSingleNode(t *testing.T, name string, cmd []string) error {
@@ -307,13 +307,7 @@ func testDockerSingleNode(t *testing.T, name string, cmd []string) error {
 		},
 		Cmd: cmd,
 	}
-	hostConfig := container.HostConfig{
-		Binds:       []string{l.CertsDir + ":/certs"},
-		NetworkMode: "host",
-	}
-	ipo := types.ImagePullOptions{
-		ImageID: postgresTestImage,
-		Tag:     postgresTestTag,
-	}
+	hostConfig := container.HostConfig{NetworkMode: "host"}
+	ipo := types.ImagePullOptions{ImageID: postgresTestImage, Tag: postgresTestTag}
 	return l.OneShot(ipo, containerConfig, hostConfig, "docker-"+name)
 }


### PR DESCRIPTION
This verifies that the tested binary can read data written to disk by a
reference binary and that after it is allowed to modify that data, the
reference binary can still read it.

Note: Comparing the output of 'select *' is used to determine if the data was
read correctly for now, but we'll need to revisit that if/when we change the
default string format of the types used here.

Also changed the default cluster spun up for the `testDocker{Success,Failure}` helpers, that are used exclusively in the per-language tests, to an explicit single node config. The per-language tests are mostly about verifying pgwire behavior so the extra nodes don't really add coverage there and were just slowing things down.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6054)

<!-- Reviewable:end -->
