### PR TITLE
sql: fix bug in updating one column of multi-column primary key

### DIFF
--- a/sql/testdata/update
+++ b/sql/testdata/update
@@ -267,3 +267,14 @@ INSERT INTO pks VALUES (1, 2, 3), (4, 5, 3)
 
 statement error duplicate key value \(k2,v\)=\(5,3\) violates unique constraint "i"
 UPDATE pks SET k2 = 5 where k1 = 1
+
+# Test updating only one of the columns of a multi-column primary key.
+
+statement ok
+UPDATE pks SET k1 = 2 WHERE k1 = 1
+
+query ITTT
+EXPLAIN (DEBUG) SELECT * FROM pks WHERE k1 = 2
+----
+0  /pks/primary/2/2    NULL  PARTIAL
+0  /pks/primary/2/2/v  3     ROW

--- a/sql/update.go
+++ b/sql/update.go
@@ -333,6 +333,9 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 				if _, ok := colIDSet[col.ID]; ok {
 					continue
 				}
+				if _, ok := primaryKeyCols[col.ID]; ok {
+					continue
+				}
 				key := keys.MakeColumnKey(newPrimaryIndexKey, uint32(col.ID))
 				val := rowVals[i]
 				marshalledVal, mErr := marshalColumnValue(col, val, p.evalCtx.Args)


### PR DESCRIPTION
Previously, updating a single column of a primary key would create a
spurious keys for the other primary key columns which would cause a
panic when scanning the row because primary key columns are not expected
to have column keys. We could relax that panic, but it did catch this
error which otherwise could have gone undetected for a long time.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6055)

<!-- Reviewable:end -->
