### PR TITLE
sql: Implement a more verbose EXPLAIN for SELECT nodes.

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -281,16 +281,18 @@ func (d *deleteNode) PErr() *roachpb.Error {
 	return d.run.pErr
 }
 
-func (d *deleteNode) ExplainPlan() (name, description string, children []planNode) {
+func (d *deleteNode) ExplainPlan(v bool) (name, description string, children []planNode) {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "from %s returning (", d.tableDesc.Name)
-	for i, col := range d.rh.columns {
-		if i > 0 {
-			fmt.Fprintf(&buf, ", ")
+	if v {
+		fmt.Fprintf(&buf, "from %s returning (", d.tableDesc.Name)
+		for i, col := range d.rh.columns {
+			if i > 0 {
+				fmt.Fprintf(&buf, ", ")
+			}
+			fmt.Fprintf(&buf, "%s", col.Name)
 		}
-		fmt.Fprintf(&buf, "%s", col.Name)
+		fmt.Fprintf(&buf, ")")
 	}
-	fmt.Fprintf(&buf, ")")
 	return "delete", buf.String(), []planNode{d.run.rows}
 }
 

--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -169,7 +169,7 @@ func (n *distinctNode) encodeValues(values parser.DTuple) ([]byte, []byte) {
 	return prefix, suffix
 }
 
-func (n *distinctNode) ExplainPlan() (string, string, []planNode) {
+func (n *distinctNode) ExplainPlan(_ bool) (string, string, []planNode) {
 	var description string
 	if n.columnsInOrder != nil {
 		columns := n.Columns()

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -43,17 +43,29 @@ const (
 // Privileges: the same privileges as the statement being explained.
 func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, *roachpb.Error) {
 	mode := explainNone
-	if len(n.Options) == 1 {
-		if strings.EqualFold(n.Options[0], "DEBUG") {
-			mode = explainDebug
-		} else if strings.EqualFold(n.Options[0], "TRACE") {
-			mode = explainTrace
+	verbose := false
+	for _, opt := range n.Options {
+		newMode := explainNone
+		if strings.EqualFold(opt, "DEBUG") {
+			newMode = explainDebug
+		} else if strings.EqualFold(opt, "TRACE") {
+			newMode = explainTrace
+		} else if strings.EqualFold(opt, "PLAN") {
+			newMode = explainPlan
+		} else if strings.EqualFold(opt, "VERBOSE") {
+			verbose = true
+		} else {
+			return nil, roachpb.NewUErrorf("unsupported EXPLAIN option: %s", opt)
 		}
-	} else if len(n.Options) == 0 {
-		mode = explainPlan
+		if newMode != explainNone {
+			if mode != explainNone {
+				return nil, roachpb.NewUErrorf("cannot set EXPLAIN mode more than once: %s", opt)
+			}
+			mode = newMode
+		}
 	}
 	if mode == explainNone {
-		return nil, roachpb.NewUErrorf("unsupported EXPLAIN options: %s", n)
+		mode = explainPlan
 	}
 
 	if mode == explainTrace {
@@ -88,7 +100,7 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, *roachp
 			{Name: "Type", Typ: parser.DummyString},
 			{Name: "Description", Typ: parser.DummyString},
 		}
-		populateExplain(v, plan, 0)
+		populateExplain(verbose, v, plan, 0)
 		return v, nil
 
 	case explainTrace:
@@ -103,8 +115,8 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, *roachp
 	}
 }
 
-func populateExplain(v *valuesNode, plan planNode, level int) {
-	name, description, children := plan.ExplainPlan()
+func populateExplain(verbose bool, v *valuesNode, plan planNode, level int) {
+	name, description, children := plan.ExplainPlan(verbose)
 
 	row := parser.DTuple{
 		parser.NewDInt(parser.DInt(level)),
@@ -114,7 +126,7 @@ func populateExplain(v *valuesNode, plan planNode, level int) {
 	v.rows = append(v.rows, row)
 
 	for _, child := range children {
-		populateExplain(v, child, level+1)
+		populateExplain(verbose, v, child, level+1)
 	}
 }
 
@@ -210,8 +222,8 @@ func (n *explainDebugNode) Start() *roachpb.Error { return n.plan.Start() }
 
 func (n *explainDebugNode) Next() bool { return n.plan.Next() }
 
-func (n *explainDebugNode) ExplainPlan() (name, description string, children []planNode) {
-	return n.plan.ExplainPlan()
+func (n *explainDebugNode) ExplainPlan(v bool) (name, description string, children []planNode) {
+	return n.plan.ExplainPlan(v)
 }
 
 func (n *explainDebugNode) Values() parser.DTuple {

--- a/sql/group.go
+++ b/sql/group.go
@@ -352,7 +352,7 @@ func (n *groupNode) PErr() *roachpb.Error {
 	return n.pErr
 }
 
-func (n *groupNode) ExplainPlan() (name, description string, children []planNode) {
+func (n *groupNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	name = "group"
 	strs := make([]string, 0, len(n.funcs))
 	for _, f := range n.funcs {

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -569,23 +569,25 @@ func (n *insertNode) PErr() *roachpb.Error {
 	return n.run.pErr
 }
 
-func (n *insertNode) ExplainPlan() (name, description string, children []planNode) {
+func (n *insertNode) ExplainPlan(v bool) (name, description string, children []planNode) {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "into %s (", n.tableDesc.Name)
-	for i, col := range n.cols {
-		if i > 0 {
-			fmt.Fprintf(&buf, ", ")
+	if v {
+		fmt.Fprintf(&buf, "into %s (", n.tableDesc.Name)
+		for i, col := range n.cols {
+			if i > 0 {
+				fmt.Fprintf(&buf, ", ")
+			}
+			fmt.Fprintf(&buf, "%s", col.Name)
 		}
-		fmt.Fprintf(&buf, "%s", col.Name)
-	}
-	fmt.Fprintf(&buf, ") returning (")
-	for i, col := range n.rh.columns {
-		if i > 0 {
-			fmt.Fprintf(&buf, ", ")
+		fmt.Fprintf(&buf, ") returning (")
+		for i, col := range n.rh.columns {
+			if i > 0 {
+				fmt.Fprintf(&buf, ", ")
+			}
+			fmt.Fprintf(&buf, "%s", col.Name)
 		}
-		fmt.Fprintf(&buf, "%s", col.Name)
+		fmt.Fprintf(&buf, ")")
 	}
-	fmt.Fprintf(&buf, ")")
 	return "insert", buf.String(), []planNode{n.run.rows}
 }
 

--- a/sql/join.go
+++ b/sql/join.go
@@ -216,7 +216,7 @@ func (n *indexJoinNode) PErr() *roachpb.Error {
 	return n.pErr
 }
 
-func (n *indexJoinNode) ExplainPlan() (name, description string, children []planNode) {
+func (n *indexJoinNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	return "index-join", "", []planNode{n.index, n.table}
 }
 

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -156,7 +156,7 @@ func (n *limitNode) Next() bool {
 	}
 }
 
-func (n *limitNode) ExplainPlan() (string, string, []planNode) {
+func (n *limitNode) ExplainPlan(_ bool) (string, string, []planNode) {
 	var count string
 	if n.count == math.MaxInt64 {
 		count = "ALL"

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -435,7 +435,7 @@ type planNode interface {
 	PErr() *roachpb.Error
 
 	// ExplainPlan returns a name and description and a list of child nodes.
-	ExplainPlan() (name, description string, children []planNode)
+	ExplainPlan(verbose bool) (name, description string, children []planNode)
 
 	// SetLimitHint tells this node to optimize things under the assumption that
 	// we will only need the first `numRows` rows.
@@ -485,7 +485,7 @@ func (*emptyNode) Ordering() orderingInfo  { return orderingInfo{} }
 func (*emptyNode) Values() parser.DTuple   { return nil }
 func (*emptyNode) PErr() *roachpb.Error    { return nil }
 
-func (*emptyNode) ExplainPlan() (name, description string, children []planNode) {
+func (*emptyNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	return "empty", "-", nil
 }
 

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -185,7 +185,7 @@ func (n *scanNode) PErr() *roachpb.Error {
 	return n.pErr
 }
 
-func (n *scanNode) ExplainPlan() (name, description string, children []planNode) {
+func (n *scanNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	if n.reverse {
 		name = "revscan"
 	} else {

--- a/sql/select.go
+++ b/sql/select.go
@@ -17,6 +17,7 @@
 package sql
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -149,7 +150,20 @@ func (s *selectNode) PErr() *roachpb.Error {
 }
 
 func (s *selectNode) ExplainPlan(v bool) (name, description string, children []planNode) {
-	return s.table.node.ExplainPlan(v)
+	if !v {
+		return s.table.node.ExplainPlan(v)
+	}
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "(")
+	for i, col := range s.columns {
+		if i > 0 {
+			fmt.Fprintf(&buf, ", ")
+		}
+		fmt.Fprintf(&buf, "%s", col.Name)
+	}
+	fmt.Fprintf(&buf, ")@%s", s.table.alias)
+	return "select", buf.String(), []planNode{s.table.node}
 }
 
 func (s *selectNode) SetLimitHint(numRows int64, soft bool) {

--- a/sql/select.go
+++ b/sql/select.go
@@ -148,8 +148,8 @@ func (s *selectNode) PErr() *roachpb.Error {
 	return s.table.node.PErr()
 }
 
-func (s *selectNode) ExplainPlan() (name, description string, children []planNode) {
-	return s.table.node.ExplainPlan()
+func (s *selectNode) ExplainPlan(v bool) (name, description string, children []planNode) {
+	return s.table.node.ExplainPlan(v)
 }
 
 func (s *selectNode) SetLimitHint(numRows int64, soft bool) {

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -209,7 +209,7 @@ func (n *sortNode) PErr() *roachpb.Error {
 	return n.pErr
 }
 
-func (n *sortNode) ExplainPlan() (name, description string, children []planNode) {
+func (n *sortNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	if n.needSort {
 		name = "sort"
 	} else {

--- a/sql/testdata/explain
+++ b/sql/testdata/explain
@@ -7,20 +7,16 @@ Level  Type  Description
 query ITT colnames
 EXPLAIN (PLAN, VERBOSE) SELECT 1
 ----
-Level  Type  Description
-0      empty -
+Level  Type    Description
+0      select  (1)@
+1      empty   -
 
 query ITT colnames
 EXPLAIN (VERBOSE, PLAN) SELECT 1
 ----
 Level  Type  Description
-0      empty -
-
-query ITT colnames
-EXPLAIN (VERBOSE, PLAN) SELECT 1
-----
-Level  Type  Description
-0      empty -
+0      select  (1)@
+1      empty   -
 
 query ITTT colnames
 EXPLAIN (DEBUG) SELECT 1

--- a/sql/testdata/explain
+++ b/sql/testdata/explain
@@ -1,0 +1,53 @@
+query ITT colnames
+EXPLAIN (PLAN) SELECT 1
+----
+Level  Type  Description
+0      empty -
+
+query ITT colnames
+EXPLAIN (PLAN, VERBOSE) SELECT 1
+----
+Level  Type  Description
+0      empty -
+
+query ITT colnames
+EXPLAIN (VERBOSE, PLAN) SELECT 1
+----
+Level  Type  Description
+0      empty -
+
+query ITT colnames
+EXPLAIN (VERBOSE, PLAN) SELECT 1
+----
+Level  Type  Description
+0      empty -
+
+query ITTT colnames
+EXPLAIN (DEBUG) SELECT 1
+----
+RowIdx  Key  Value  Disposition
+0       NULL NULL   ROW
+
+query ITTT colnames
+EXPLAIN (DEBUG, VERBOSE) SELECT 1
+----
+RowIdx  Key  Value  Disposition
+0       NULL NULL   ROW
+
+query TTITTITTT
+EXPLAIN (TRACE) SELECT 1
+----
+0.000ms   1                                   0 NULL NULL t
+0.000ms   0 coordinator tracing completed     0 NULL NULL
+
+statement error cannot set EXPLAIN mode more than once
+EXPLAIN (TRACE, TRACE) SELECT 1
+
+statement error cannot set EXPLAIN mode more than once
+EXPLAIN (DEBUG, TRACE) SELECT 1
+
+statement error cannot set EXPLAIN mode more than once
+EXPLAIN (PLAN, DEBUG) SELECT 1
+
+statement error unsupported EXPLAIN option
+EXPLAIN (TRACE, UNKNOWN) SELECT 1

--- a/sql/testdata/explain_plan
+++ b/sql/testdata/explain_plan
@@ -14,6 +14,14 @@ Level  Type  Description
 0      scan  t@primary
 
 query ITT colnames
+EXPLAIN (VERBOSE) SELECT * FROM t
+----
+Level  Type   Description
+0      select (k, v)@t 
+1      scan   t@primary
+
+
+query ITT colnames
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ----
 Level  Type  Description

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -128,8 +128,8 @@ func (n *explainTraceNode) Next() bool {
 	return true
 }
 
-func (n *explainTraceNode) ExplainPlan() (name, description string, children []planNode) {
-	return n.plan.ExplainPlan()
+func (n *explainTraceNode) ExplainPlan(v bool) (name, description string, children []planNode) {
+	return n.plan.ExplainPlan(v)
 }
 
 func (n *explainTraceNode) Values() parser.DTuple {

--- a/sql/union.go
+++ b/sql/union.go
@@ -163,7 +163,7 @@ func (n *unionNode) SetLimitHint(numRows int64, soft bool) {
 	n.left.SetLimitHint(numRows, true)
 }
 
-func (n *unionNode) ExplainPlan() (name, description string, children []planNode) {
+func (n *unionNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	return "union", "-", []planNode{n.left, n.right}
 }
 

--- a/sql/update.go
+++ b/sql/update.go
@@ -671,23 +671,25 @@ func (u *updateNode) PErr() *roachpb.Error {
 	return u.run.pErr
 }
 
-func (u *updateNode) ExplainPlan() (name, description string, children []planNode) {
+func (u *updateNode) ExplainPlan(v bool) (name, description string, children []planNode) {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "set %s (", u.tableDesc.Name)
-	for i, col := range u.cols {
-		if i > 0 {
-			fmt.Fprintf(&buf, ", ")
+	if v {
+		fmt.Fprintf(&buf, "set %s (", u.tableDesc.Name)
+		for i, col := range u.cols {
+			if i > 0 {
+				fmt.Fprintf(&buf, ", ")
+			}
+			fmt.Fprintf(&buf, "%s", col.Name)
 		}
-		fmt.Fprintf(&buf, "%s", col.Name)
-	}
-	fmt.Fprintf(&buf, ") returning (")
-	for i, col := range u.rh.columns {
-		if i > 0 {
-			fmt.Fprintf(&buf, ", ")
+		fmt.Fprintf(&buf, ") returning (")
+		for i, col := range u.rh.columns {
+			if i > 0 {
+				fmt.Fprintf(&buf, ", ")
+			}
+			fmt.Fprintf(&buf, "%s", col.Name)
 		}
-		fmt.Fprintf(&buf, "%s", col.Name)
+		fmt.Fprintf(&buf, ")")
 	}
-	fmt.Fprintf(&buf, ")")
 	return "update", buf.String(), []planNode{u.run.rows}
 }
 

--- a/sql/values.go
+++ b/sql/values.go
@@ -220,7 +220,7 @@ func (n *valuesNode) InitMinHeap() {
 	heap.Init(n)
 }
 
-func (n *valuesNode) ExplainPlan() (name, description string, children []planNode) {
+func (n *valuesNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	name = "values"
 	pluralize := func(n int) string {
 		if n == 1 {


### PR DESCRIPTION
This is motivated by a few factors:
- the select node is responsible for filters and computations.  When there are multiple stages, it clarifies matter to see where in the plan these operations take place. Consider for example `UPDATE t SET x  = y + 1` on a table with columns `x` and `y`. Is the UPDATE node responsible to compute `y+1`?

Compare the outputs:

```
explain update t set x=y+1;
+-------+--------+------------------------+
| Level |  Type  |      Description       |
+-------+--------+------------------------+
|     0 | update | set t (x) returning () |
|     1 | scan   | t@primary              |
+-------+--------+------------------------+
```

and

```
explain update t set x=y+1;
+-------+--------+------------------------+
| Level |  Type  |      Description       |
+-------+--------+------------------------+
|     0 | update | set t (x) returning () |
|     1 | select | (x, y, rowid, y + 1)@t |
|     2 | scan   | t@primary              |
+-------+--------+------------------------+
```

This shows that the computation is not performed by the `update` node itself.
- it is desirable to know which columns are being manipulated at each stage of the query plan: aren't there too many? Where is an intermediate result computed?

For example:

```
explain select max(x) from t group by x order by x+10;
+-------+--------+-----------------------+
| Level |  Type  |      Description      |
+-------+--------+-----------------------+
|     0 | sort   | +x + 10               |
|     1 | group  | max(x), x             |
|     2 | scan   | t@primary             |
+-------+--------+-----------------------+
```

This suggests (wrongly) that the sort node is computing the expression x+1. However once we display the select node:

```
explain select max(x) from t group by x order by x+10;
+-------+--------+-----------------------+
| Level |  Type  |      Description      |
+-------+--------+-----------------------+
|     0 | sort   | +x + 10               |
|     1 | group  | max(x), x             |
|     2 | select | (max(x), x + 10, x)@t |
|     3 | scan   | t@primary             |
+-------+--------+-----------------------+
```

it becomes clear where each expression is computed.

cc @RaduBerinde

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6057)

<!-- Reviewable:end -->
