### PR TITLE
CircleCI: do not pass `-v` to `go test`

### DIFF
--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -134,7 +134,7 @@ if is_shard 0; then
   # Run "make test".
   echo "make test"
   time ${builder} make test \
-    TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2,tracer=2' | \
+    TESTFLAGS='--verbosity=1 --vmodule=monitor=2,tracer=2' | \
     tr -d '\r' | tee "${outdir}/test.log" | \
     grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
     awk '{print "test:", $0}'
@@ -150,7 +150,7 @@ if is_shard 0; then
     # this one runs outside the builder container (and inside the
     # container, something is already combining stdout and stderr).
     time $(dirname $0)/../acceptance.test -nodes 3 -l ${outdir}/acceptance \
-      -test.v -test.timeout 10m \
+      -test.timeout 10m \
       --verbosity=1 --vmodule=monitor=2 2>&1 | \
       tr -d '\r' | tee "${outdir}/acceptance.log" | \
       grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
@@ -164,7 +164,7 @@ if is_shard 1; then
   # Run "make testrace".
   echo "make testrace"
   time ${builder} make testrace \
-    TESTFLAGS='-v --verbosity=1 --vmodule=monitor=2' | \
+    TESTFLAGS='--verbosity=1 --vmodule=monitor=2' | \
     tr -d '\r' | tee "${outdir}/testrace.log" | \
     grep -E "^\--- (PASS|FAIL)|^(FAIL|ok)|${match}" |
     awk '{print "race:", $0}'


### PR DESCRIPTION
This option prevents `go test` from suppressing the output of passing
tests. This output is extremely verbose in practice, and causes both
log retrieval and log exploration to be painfully slow.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6065)

<!-- Reviewable:end -->
