### PR TITLE
added a new KV API method called InitPut()

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -266,6 +266,19 @@ func (db *DB) CPut(key, value, expValue interface{}) *roachpb.Error {
 	return pErr
 }
 
+// InitPut sets the first value for a key to value. An error is reported if a
+// value already exists for the key and it's not equal to the value passed in.
+//
+// key can be either a byte slice or a string. value can be any key type, a
+// proto.Message or any Go primitive type (bool, int, etc). It is illegal to
+// set value to nil.
+func (db *DB) InitPut(key, value interface{}) *roachpb.Error {
+	b := db.NewBatch()
+	b.InitPut(key, value)
+	_, pErr := runOneResult(db, b)
+	return pErr
+}
+
 // Inc increments the integer value at key. If the key does not exist it will
 // be created with an initial value of 0 which will then be incremented. If the
 // key exists but was set using Put or CPut an error will be returned.

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -117,6 +117,29 @@ func ExampleDB_CPut() {
 	// bb=4
 }
 
+func ExampleDB_InitPut() {
+	s, db := setup()
+	defer s.Stop()
+
+	if pErr := db.InitPut("aa", "1"); pErr != nil {
+		panic(pErr)
+	}
+	if pErr := db.InitPut("aa", "1"); pErr != nil {
+		panic(pErr)
+	}
+	if pErr := db.InitPut("aa", "2"); pErr == nil {
+		panic("expected error from init put")
+	}
+	result, pErr := db.Get("aa")
+	if pErr != nil {
+		panic(pErr)
+	}
+	fmt.Printf("aa=%s\n", result.ValueBytes())
+
+	// Output:
+	// aa=1
+}
+
 func ExampleDB_Inc() {
 	s, db := setup()
 	defer s.Stop()

--- a/client/txn.go
+++ b/client/txn.go
@@ -262,6 +262,19 @@ func (txn *Txn) CPut(key, value, expValue interface{}) *roachpb.Error {
 	return pErr
 }
 
+// InitPut sets the first value for a key to value. An error is reported if a
+// value already exists for the key and it's not equal to the value passed in.
+//
+// key can be either a byte slice or a string. value can be any key type, a
+// proto.Message or any Go primitive type (bool, int, etc). It is illegal to
+// set value to nil.
+func (txn *Txn) InitPut(key, value interface{}) *roachpb.Error {
+	b := txn.NewBatch()
+	b.InitPut(key, value)
+	_, pErr := runOneResult(txn, b)
+	return pErr
+}
+
 // Inc increments the integer value at key. If the key does not exist it will
 // be created with an initial value of 0 which will then be incremented. If the
 // key exists but was set using Put or CPut an error will be returned.

--- a/roachpb/api.go
+++ b/roachpb/api.go
@@ -366,6 +366,9 @@ func (*PutRequest) Method() Method { return Put }
 func (*ConditionalPutRequest) Method() Method { return ConditionalPut }
 
 // Method implements the Request interface.
+func (*InitPutRequest) Method() Method { return InitPut }
+
+// Method implements the Request interface.
 func (*IncrementRequest) Method() Method { return Increment }
 
 // Method implements the Request interface.
@@ -446,6 +449,12 @@ func (pr *PutRequest) ShallowCopy() Request {
 // ShallowCopy implements the Request interface.
 func (cpr *ConditionalPutRequest) ShallowCopy() Request {
 	shallowCopy := *cpr
+	return &shallowCopy
+}
+
+// ShallowCopy implements the Request interface.
+func (pr *InitPutRequest) ShallowCopy() Request {
+	shallowCopy := *pr
 	return &shallowCopy
 }
 
@@ -584,6 +593,7 @@ func (vcr *VerifyChecksumRequest) ShallowCopy() Request {
 func (*GetRequest) createReply() Response                { return &GetResponse{} }
 func (*PutRequest) createReply() Response                { return &PutResponse{} }
 func (*ConditionalPutRequest) createReply() Response     { return &ConditionalPutResponse{} }
+func (*InitPutRequest) createReply() Response            { return &InitPutResponse{} }
 func (*IncrementRequest) createReply() Response          { return &IncrementResponse{} }
 func (*DeleteRequest) createReply() Response             { return &DeleteResponse{} }
 func (*DeleteRangeRequest) createReply() Response        { return &DeleteRangeResponse{} }
@@ -669,6 +679,19 @@ func NewConditionalPut(key Key, value, expValue Value) Request {
 	}
 }
 
+// NewInitPut returns a Request initialized to put the value at key,
+// as long as the key doesn't exist, returning an error if the key
+// exists and the existing value is different from value.
+func NewInitPut(key Key, value Value) Request {
+	value.InitChecksum(key)
+	return &InitPutRequest{
+		Span: Span{
+			Key: key,
+		},
+		Value: value,
+	}
+}
+
 // NewDelete returns a Request initialized to delete the value at key.
 func NewDelete(key Key) Request {
 	return &DeleteRequest{
@@ -728,6 +751,7 @@ func NewReverseScan(key, endKey Key, maxResults int64) Request {
 func (*GetRequest) flags() int                { return isRead | isTxn }
 func (*PutRequest) flags() int                { return isWrite | isTxn | isTxnWrite }
 func (*ConditionalPutRequest) flags() int     { return isRead | isWrite | isTxn | isTxnWrite }
+func (*InitPutRequest) flags() int            { return isRead | isWrite | isTxn | isTxnWrite }
 func (*IncrementRequest) flags() int          { return isRead | isWrite | isTxn | isTxnWrite }
 func (*DeleteRequest) flags() int             { return isWrite | isTxn | isTxnWrite }
 func (*DeleteRangeRequest) flags() int        { return isWrite | isTxn | isTxnWrite | isRange }

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -21,6 +21,8 @@
 		PutResponse
 		ConditionalPutRequest
 		ConditionalPutResponse
+		InitPutRequest
+		InitPutResponse
 		IncrementRequest
 		IncrementResponse
 		DeleteRequest
@@ -337,6 +339,30 @@ func (m *ConditionalPutResponse) String() string            { return proto.Compa
 func (*ConditionalPutResponse) ProtoMessage()               {}
 func (*ConditionalPutResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{6} }
 
+// An InitPutRequest is the argument to the InitPut() method.
+//
+// - If key doesn't exist, sets value.
+// - If key exists, returns an error if value != existing value.
+type InitPutRequest struct {
+	Span  `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+	Value Value `protobuf:"bytes,2,opt,name=value" json:"value"`
+}
+
+func (m *InitPutRequest) Reset()                    { *m = InitPutRequest{} }
+func (m *InitPutRequest) String() string            { return proto.CompactTextString(m) }
+func (*InitPutRequest) ProtoMessage()               {}
+func (*InitPutRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{7} }
+
+// A InitPutResponse is the return value from the InitPut() method.
+type InitPutResponse struct {
+	ResponseHeader `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
+}
+
+func (m *InitPutResponse) Reset()                    { *m = InitPutResponse{} }
+func (m *InitPutResponse) String() string            { return proto.CompactTextString(m) }
+func (*InitPutResponse) ProtoMessage()               {}
+func (*InitPutResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{8} }
+
 // An IncrementRequest is the argument to the Increment() method. It
 // increments the value for key, and returns the new value. If no
 // value exists for a key, incrementing by 0 is not a noop, but will
@@ -351,7 +377,7 @@ type IncrementRequest struct {
 func (m *IncrementRequest) Reset()                    { *m = IncrementRequest{} }
 func (m *IncrementRequest) String() string            { return proto.CompactTextString(m) }
 func (*IncrementRequest) ProtoMessage()               {}
-func (*IncrementRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{7} }
+func (*IncrementRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{9} }
 
 // An IncrementResponse is the return value from the Increment
 // method. The new value after increment is specified in NewValue. If
@@ -364,7 +390,7 @@ type IncrementResponse struct {
 func (m *IncrementResponse) Reset()                    { *m = IncrementResponse{} }
 func (m *IncrementResponse) String() string            { return proto.CompactTextString(m) }
 func (*IncrementResponse) ProtoMessage()               {}
-func (*IncrementResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{8} }
+func (*IncrementResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{10} }
 
 // A DeleteRequest is the argument to the Delete() method.
 type DeleteRequest struct {
@@ -374,7 +400,7 @@ type DeleteRequest struct {
 func (m *DeleteRequest) Reset()                    { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string            { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()               {}
-func (*DeleteRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{9} }
+func (*DeleteRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{11} }
 
 // A DeleteResponse is the return value from the Delete() method.
 type DeleteResponse struct {
@@ -384,7 +410,7 @@ type DeleteResponse struct {
 func (m *DeleteResponse) Reset()                    { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string            { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()               {}
-func (*DeleteResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{10} }
+func (*DeleteResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{12} }
 
 // A DeleteRangeRequest is the argument to the DeleteRange() method. It
 // specifies the range of keys to delete.
@@ -399,7 +425,7 @@ type DeleteRangeRequest struct {
 func (m *DeleteRangeRequest) Reset()                    { *m = DeleteRangeRequest{} }
 func (m *DeleteRangeRequest) String() string            { return proto.CompactTextString(m) }
 func (*DeleteRangeRequest) ProtoMessage()               {}
-func (*DeleteRangeRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{11} }
+func (*DeleteRangeRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{13} }
 
 // A DeleteRangeResponse is the return value from the DeleteRange()
 // method.
@@ -412,7 +438,7 @@ type DeleteRangeResponse struct {
 func (m *DeleteRangeResponse) Reset()                    { *m = DeleteRangeResponse{} }
 func (m *DeleteRangeResponse) String() string            { return proto.CompactTextString(m) }
 func (*DeleteRangeResponse) ProtoMessage()               {}
-func (*DeleteRangeResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{12} }
+func (*DeleteRangeResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{14} }
 
 // A ScanRequest is the argument to the Scan() method. It specifies the
 // start and end keys for an ascending scan of [start,end) and the maximum
@@ -426,7 +452,7 @@ type ScanRequest struct {
 func (m *ScanRequest) Reset()                    { *m = ScanRequest{} }
 func (m *ScanRequest) String() string            { return proto.CompactTextString(m) }
 func (*ScanRequest) ProtoMessage()               {}
-func (*ScanRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{13} }
+func (*ScanRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{15} }
 
 // A ScanResponse is the return value from the Scan() method.
 type ScanResponse struct {
@@ -438,7 +464,7 @@ type ScanResponse struct {
 func (m *ScanResponse) Reset()                    { *m = ScanResponse{} }
 func (m *ScanResponse) String() string            { return proto.CompactTextString(m) }
 func (*ScanResponse) ProtoMessage()               {}
-func (*ScanResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{14} }
+func (*ScanResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{16} }
 
 // A ReverseScanRequest is the argument to the ReverseScan() method. It specifies the
 // start and end keys for a descending scan of [start,end) and the maximum
@@ -452,7 +478,7 @@ type ReverseScanRequest struct {
 func (m *ReverseScanRequest) Reset()                    { *m = ReverseScanRequest{} }
 func (m *ReverseScanRequest) String() string            { return proto.CompactTextString(m) }
 func (*ReverseScanRequest) ProtoMessage()               {}
-func (*ReverseScanRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{15} }
+func (*ReverseScanRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{17} }
 
 // A ReverseScanResponse is the return value from the ReverseScan() method.
 type ReverseScanResponse struct {
@@ -464,7 +490,7 @@ type ReverseScanResponse struct {
 func (m *ReverseScanResponse) Reset()                    { *m = ReverseScanResponse{} }
 func (m *ReverseScanResponse) String() string            { return proto.CompactTextString(m) }
 func (*ReverseScanResponse) ProtoMessage()               {}
-func (*ReverseScanResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{16} }
+func (*ReverseScanResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{18} }
 
 // A CheckConsistencyRequest is the argument to the CheckConsistency() method.
 // It specifies the start and end keys for a span of ranges to which a consistency
@@ -479,7 +505,7 @@ type CheckConsistencyRequest struct {
 func (m *CheckConsistencyRequest) Reset()                    { *m = CheckConsistencyRequest{} }
 func (m *CheckConsistencyRequest) String() string            { return proto.CompactTextString(m) }
 func (*CheckConsistencyRequest) ProtoMessage()               {}
-func (*CheckConsistencyRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{17} }
+func (*CheckConsistencyRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{19} }
 
 // A CheckConsistencyResponse is the return value from the CheckConsistency() method.
 // If a replica finds itself to be inconsistent with its leader it will panic.
@@ -490,7 +516,7 @@ type CheckConsistencyResponse struct {
 func (m *CheckConsistencyResponse) Reset()                    { *m = CheckConsistencyResponse{} }
 func (m *CheckConsistencyResponse) String() string            { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse) ProtoMessage()               {}
-func (*CheckConsistencyResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{18} }
+func (*CheckConsistencyResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{20} }
 
 // A BeginTransactionRequest is the argument to the BeginTransaction() method.
 type BeginTransactionRequest struct {
@@ -500,7 +526,7 @@ type BeginTransactionRequest struct {
 func (m *BeginTransactionRequest) Reset()                    { *m = BeginTransactionRequest{} }
 func (m *BeginTransactionRequest) String() string            { return proto.CompactTextString(m) }
 func (*BeginTransactionRequest) ProtoMessage()               {}
-func (*BeginTransactionRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{19} }
+func (*BeginTransactionRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{21} }
 
 // A BeginTransactionResponse is the return value from the BeginTransaction() method.
 type BeginTransactionResponse struct {
@@ -510,7 +536,7 @@ type BeginTransactionResponse struct {
 func (m *BeginTransactionResponse) Reset()                    { *m = BeginTransactionResponse{} }
 func (m *BeginTransactionResponse) String() string            { return proto.CompactTextString(m) }
 func (*BeginTransactionResponse) ProtoMessage()               {}
-func (*BeginTransactionResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{20} }
+func (*BeginTransactionResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{22} }
 
 // An EndTransactionRequest is the argument to the EndTransaction() method. It
 // specifies whether to commit or roll back an extant transaction.
@@ -531,7 +557,7 @@ type EndTransactionRequest struct {
 func (m *EndTransactionRequest) Reset()                    { *m = EndTransactionRequest{} }
 func (m *EndTransactionRequest) String() string            { return proto.CompactTextString(m) }
 func (*EndTransactionRequest) ProtoMessage()               {}
-func (*EndTransactionRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{21} }
+func (*EndTransactionRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{23} }
 
 // An EndTransactionResponse is the return value from the
 // EndTransaction() method. The final transaction record is returned
@@ -558,7 +584,7 @@ type EndTransactionResponse struct {
 func (m *EndTransactionResponse) Reset()                    { *m = EndTransactionResponse{} }
 func (m *EndTransactionResponse) String() string            { return proto.CompactTextString(m) }
 func (*EndTransactionResponse) ProtoMessage()               {}
-func (*EndTransactionResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{22} }
+func (*EndTransactionResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{24} }
 
 // An AdminSplitRequest is the argument to the AdminSplit() method. The
 // existing range which contains header.key is split by
@@ -588,7 +614,7 @@ type AdminSplitRequest struct {
 func (m *AdminSplitRequest) Reset()                    { *m = AdminSplitRequest{} }
 func (m *AdminSplitRequest) String() string            { return proto.CompactTextString(m) }
 func (*AdminSplitRequest) ProtoMessage()               {}
-func (*AdminSplitRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{23} }
+func (*AdminSplitRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{25} }
 
 // An AdminSplitResponse is the return value from the AdminSplit()
 // method.
@@ -599,7 +625,7 @@ type AdminSplitResponse struct {
 func (m *AdminSplitResponse) Reset()                    { *m = AdminSplitResponse{} }
 func (m *AdminSplitResponse) String() string            { return proto.CompactTextString(m) }
 func (*AdminSplitResponse) ProtoMessage()               {}
-func (*AdminSplitResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{24} }
+func (*AdminSplitResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{26} }
 
 // An AdminMergeRequest is the argument to the AdminMerge() method. A
 // merge is performed by calling AdminMerge on the left-hand range of
@@ -617,7 +643,7 @@ type AdminMergeRequest struct {
 func (m *AdminMergeRequest) Reset()                    { *m = AdminMergeRequest{} }
 func (m *AdminMergeRequest) String() string            { return proto.CompactTextString(m) }
 func (*AdminMergeRequest) ProtoMessage()               {}
-func (*AdminMergeRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{25} }
+func (*AdminMergeRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{27} }
 
 // An AdminMergeResponse is the return value from the AdminMerge()
 // method.
@@ -628,7 +654,7 @@ type AdminMergeResponse struct {
 func (m *AdminMergeResponse) Reset()                    { *m = AdminMergeResponse{} }
 func (m *AdminMergeResponse) String() string            { return proto.CompactTextString(m) }
 func (*AdminMergeResponse) ProtoMessage()               {}
-func (*AdminMergeResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{26} }
+func (*AdminMergeResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{28} }
 
 // A RangeLookupRequest is arguments to the RangeLookup() method. A
 // forward lookup request returns a range containing the requested
@@ -657,7 +683,7 @@ type RangeLookupRequest struct {
 func (m *RangeLookupRequest) Reset()                    { *m = RangeLookupRequest{} }
 func (m *RangeLookupRequest) String() string            { return proto.CompactTextString(m) }
 func (*RangeLookupRequest) ProtoMessage()               {}
-func (*RangeLookupRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{27} }
+func (*RangeLookupRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{29} }
 
 // A RangeLookupResponse is the return value from the RangeLookup()
 // method. It returns metadata for the range containing the requested
@@ -673,7 +699,7 @@ type RangeLookupResponse struct {
 func (m *RangeLookupResponse) Reset()                    { *m = RangeLookupResponse{} }
 func (m *RangeLookupResponse) String() string            { return proto.CompactTextString(m) }
 func (*RangeLookupResponse) ProtoMessage()               {}
-func (*RangeLookupResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{28} }
+func (*RangeLookupResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{30} }
 
 // A HeartbeatTxnRequest is arguments to the HeartbeatTxn()
 // method. It's sent by transaction coordinators to let the system
@@ -688,7 +714,7 @@ type HeartbeatTxnRequest struct {
 func (m *HeartbeatTxnRequest) Reset()                    { *m = HeartbeatTxnRequest{} }
 func (m *HeartbeatTxnRequest) String() string            { return proto.CompactTextString(m) }
 func (*HeartbeatTxnRequest) ProtoMessage()               {}
-func (*HeartbeatTxnRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{29} }
+func (*HeartbeatTxnRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{31} }
 
 // A HeartbeatTxnResponse is the return value from the HeartbeatTxn()
 // method. It returns the transaction info in the response header. The
@@ -701,7 +727,7 @@ type HeartbeatTxnResponse struct {
 func (m *HeartbeatTxnResponse) Reset()                    { *m = HeartbeatTxnResponse{} }
 func (m *HeartbeatTxnResponse) String() string            { return proto.CompactTextString(m) }
 func (*HeartbeatTxnResponse) ProtoMessage()               {}
-func (*HeartbeatTxnResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{30} }
+func (*HeartbeatTxnResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{32} }
 
 // A GCRequest is arguments to the GC() method. It's sent by range
 // leaders after scanning range data to find expired MVCC values.
@@ -713,7 +739,7 @@ type GCRequest struct {
 func (m *GCRequest) Reset()                    { *m = GCRequest{} }
 func (m *GCRequest) String() string            { return proto.CompactTextString(m) }
 func (*GCRequest) ProtoMessage()               {}
-func (*GCRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{31} }
+func (*GCRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{33} }
 
 type GCRequest_GCKey struct {
 	Key       Key       `protobuf:"bytes,1,opt,name=key,casttype=Key" json:"key,omitempty"`
@@ -723,7 +749,7 @@ type GCRequest_GCKey struct {
 func (m *GCRequest_GCKey) Reset()                    { *m = GCRequest_GCKey{} }
 func (m *GCRequest_GCKey) String() string            { return proto.CompactTextString(m) }
 func (*GCRequest_GCKey) ProtoMessage()               {}
-func (*GCRequest_GCKey) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{31, 0} }
+func (*GCRequest_GCKey) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{33, 0} }
 
 // A GCResponse is the return value from the GC() method.
 type GCResponse struct {
@@ -733,7 +759,7 @@ type GCResponse struct {
 func (m *GCResponse) Reset()                    { *m = GCResponse{} }
 func (m *GCResponse) String() string            { return proto.CompactTextString(m) }
 func (*GCResponse) ProtoMessage()               {}
-func (*GCResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{32} }
+func (*GCResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{34} }
 
 // A PushTxnRequest is arguments to the PushTxn() method. It's sent by
 // readers or writers which have encountered an "intent" laid down by
@@ -780,7 +806,7 @@ type PushTxnRequest struct {
 func (m *PushTxnRequest) Reset()                    { *m = PushTxnRequest{} }
 func (m *PushTxnRequest) String() string            { return proto.CompactTextString(m) }
 func (*PushTxnRequest) ProtoMessage()               {}
-func (*PushTxnRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{33} }
+func (*PushTxnRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{35} }
 
 // A PushTxnResponse is the return value from the PushTxn() method. It
 // returns success and the resulting state of PusheeTxn if the
@@ -799,7 +825,7 @@ type PushTxnResponse struct {
 func (m *PushTxnResponse) Reset()                    { *m = PushTxnResponse{} }
 func (m *PushTxnResponse) String() string            { return proto.CompactTextString(m) }
 func (*PushTxnResponse) ProtoMessage()               {}
-func (*PushTxnResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{34} }
+func (*PushTxnResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{36} }
 
 // A ResolveIntentRequest is arguments to the ResolveIntent()
 // method. It is sent by transaction coordinators after success
@@ -819,7 +845,7 @@ type ResolveIntentRequest struct {
 func (m *ResolveIntentRequest) Reset()                    { *m = ResolveIntentRequest{} }
 func (m *ResolveIntentRequest) String() string            { return proto.CompactTextString(m) }
 func (*ResolveIntentRequest) ProtoMessage()               {}
-func (*ResolveIntentRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{35} }
+func (*ResolveIntentRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{37} }
 
 // A ResolveIntentResponse is the return value from the
 // ResolveIntent() method.
@@ -830,7 +856,7 @@ type ResolveIntentResponse struct {
 func (m *ResolveIntentResponse) Reset()                    { *m = ResolveIntentResponse{} }
 func (m *ResolveIntentResponse) String() string            { return proto.CompactTextString(m) }
 func (*ResolveIntentResponse) ProtoMessage()               {}
-func (*ResolveIntentResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{36} }
+func (*ResolveIntentResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{38} }
 
 // A ResolveIntentRangeRequest is arguments to the ResolveIntentRange() method.
 // It is sent by transaction coordinators after success calling PushTxn to
@@ -850,7 +876,7 @@ type ResolveIntentRangeRequest struct {
 func (m *ResolveIntentRangeRequest) Reset()                    { *m = ResolveIntentRangeRequest{} }
 func (m *ResolveIntentRangeRequest) String() string            { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeRequest) ProtoMessage()               {}
-func (*ResolveIntentRangeRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{37} }
+func (*ResolveIntentRangeRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{39} }
 
 // A NoopResponse is the return value from a no-op operation.
 type NoopResponse struct {
@@ -859,7 +885,7 @@ type NoopResponse struct {
 func (m *NoopResponse) Reset()                    { *m = NoopResponse{} }
 func (m *NoopResponse) String() string            { return proto.CompactTextString(m) }
 func (*NoopResponse) ProtoMessage()               {}
-func (*NoopResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{38} }
+func (*NoopResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{40} }
 
 // A NoopRequest is a no-op.
 type NoopRequest struct {
@@ -868,7 +894,7 @@ type NoopRequest struct {
 func (m *NoopRequest) Reset()                    { *m = NoopRequest{} }
 func (m *NoopRequest) String() string            { return proto.CompactTextString(m) }
 func (*NoopRequest) ProtoMessage()               {}
-func (*NoopRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{39} }
+func (*NoopRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{41} }
 
 // A ResolveIntentRangeResponse is the return value from the
 // ResolveIntent() method.
@@ -879,7 +905,7 @@ type ResolveIntentRangeResponse struct {
 func (m *ResolveIntentRangeResponse) Reset()                    { *m = ResolveIntentRangeResponse{} }
 func (m *ResolveIntentRangeResponse) String() string            { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeResponse) ProtoMessage()               {}
-func (*ResolveIntentRangeResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{40} }
+func (*ResolveIntentRangeResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{42} }
 
 // A MergeRequest contains arguments to the Merge() method. It
 // specifies a key and a value which should be merged into the
@@ -892,7 +918,7 @@ type MergeRequest struct {
 func (m *MergeRequest) Reset()                    { *m = MergeRequest{} }
 func (m *MergeRequest) String() string            { return proto.CompactTextString(m) }
 func (*MergeRequest) ProtoMessage()               {}
-func (*MergeRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{41} }
+func (*MergeRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{43} }
 
 // MergeResponse is the response to a Merge() operation.
 type MergeResponse struct {
@@ -902,7 +928,7 @@ type MergeResponse struct {
 func (m *MergeResponse) Reset()                    { *m = MergeResponse{} }
 func (m *MergeResponse) String() string            { return proto.CompactTextString(m) }
 func (*MergeResponse) ProtoMessage()               {}
-func (*MergeResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{42} }
+func (*MergeResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{44} }
 
 // TruncateLogRequest is used to remove a prefix of the raft log. While there
 // is no requirement for correctness that the raft log truncation be synchronized across
@@ -923,7 +949,7 @@ type TruncateLogRequest struct {
 func (m *TruncateLogRequest) Reset()                    { *m = TruncateLogRequest{} }
 func (m *TruncateLogRequest) String() string            { return proto.CompactTextString(m) }
 func (*TruncateLogRequest) ProtoMessage()               {}
-func (*TruncateLogRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{43} }
+func (*TruncateLogRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{45} }
 
 // TruncateLogResponse is the response to a TruncateLog() operation.
 type TruncateLogResponse struct {
@@ -933,7 +959,7 @@ type TruncateLogResponse struct {
 func (m *TruncateLogResponse) Reset()                    { *m = TruncateLogResponse{} }
 func (m *TruncateLogResponse) String() string            { return proto.CompactTextString(m) }
 func (*TruncateLogResponse) ProtoMessage()               {}
-func (*TruncateLogResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{44} }
+func (*TruncateLogResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{46} }
 
 // A LeaderLeaseRequest is arguments to the LeaderLease()
 // method. It is sent by the store on behalf of one of its ranges upon receipt
@@ -946,7 +972,7 @@ type LeaderLeaseRequest struct {
 func (m *LeaderLeaseRequest) Reset()                    { *m = LeaderLeaseRequest{} }
 func (m *LeaderLeaseRequest) String() string            { return proto.CompactTextString(m) }
 func (*LeaderLeaseRequest) ProtoMessage()               {}
-func (*LeaderLeaseRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{45} }
+func (*LeaderLeaseRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{47} }
 
 // A LeaderLeaseResponse is the response to a LeaderLease()
 // operation.
@@ -957,7 +983,7 @@ type LeaderLeaseResponse struct {
 func (m *LeaderLeaseResponse) Reset()                    { *m = LeaderLeaseResponse{} }
 func (m *LeaderLeaseResponse) String() string            { return proto.CompactTextString(m) }
 func (*LeaderLeaseResponse) ProtoMessage()               {}
-func (*LeaderLeaseResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{46} }
+func (*LeaderLeaseResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{48} }
 
 // A ComputeChecksumRequest is arguments to the ComputeChecksum() method, to
 // start computing the checksum for the specified range at the snapshot for
@@ -979,7 +1005,7 @@ type ComputeChecksumRequest struct {
 func (m *ComputeChecksumRequest) Reset()                    { *m = ComputeChecksumRequest{} }
 func (m *ComputeChecksumRequest) String() string            { return proto.CompactTextString(m) }
 func (*ComputeChecksumRequest) ProtoMessage()               {}
-func (*ComputeChecksumRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{47} }
+func (*ComputeChecksumRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{49} }
 
 // A ComputeChecksumResponse is the response to a ComputeChecksum() operation.
 type ComputeChecksumResponse struct {
@@ -989,7 +1015,7 @@ type ComputeChecksumResponse struct {
 func (m *ComputeChecksumResponse) Reset()                    { *m = ComputeChecksumResponse{} }
 func (m *ComputeChecksumResponse) String() string            { return proto.CompactTextString(m) }
 func (*ComputeChecksumResponse) ProtoMessage()               {}
-func (*ComputeChecksumResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{48} }
+func (*ComputeChecksumResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{50} }
 
 // A VerifyChecksumRequest is arguments to the VerifyChecksum() method, to
 // verify the checksum computed on the leader against the one requested
@@ -1008,7 +1034,7 @@ type VerifyChecksumRequest struct {
 func (m *VerifyChecksumRequest) Reset()                    { *m = VerifyChecksumRequest{} }
 func (m *VerifyChecksumRequest) String() string            { return proto.CompactTextString(m) }
 func (*VerifyChecksumRequest) ProtoMessage()               {}
-func (*VerifyChecksumRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{49} }
+func (*VerifyChecksumRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{51} }
 
 // A VerifyChecksumResponse is the response to a VerifyChecksum() operation.
 type VerifyChecksumResponse struct {
@@ -1018,7 +1044,7 @@ type VerifyChecksumResponse struct {
 func (m *VerifyChecksumResponse) Reset()                    { *m = VerifyChecksumResponse{} }
 func (m *VerifyChecksumResponse) String() string            { return proto.CompactTextString(m) }
 func (*VerifyChecksumResponse) ProtoMessage()               {}
-func (*VerifyChecksumResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{50} }
+func (*VerifyChecksumResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{52} }
 
 // A RequestUnion contains exactly one of the optional requests.
 // The values added here must match those in ResponseUnion.
@@ -1026,6 +1052,7 @@ type RequestUnion struct {
 	Get                *GetRequest                `protobuf:"bytes,1,opt,name=get" json:"get,omitempty"`
 	Put                *PutRequest                `protobuf:"bytes,2,opt,name=put" json:"put,omitempty"`
 	ConditionalPut     *ConditionalPutRequest     `protobuf:"bytes,3,opt,name=conditional_put,json=conditionalPut" json:"conditional_put,omitempty"`
+	InitPut            *InitPutRequest            `protobuf:"bytes,26,opt,name=init_put,json=initPut" json:"init_put,omitempty"`
 	Increment          *IncrementRequest          `protobuf:"bytes,4,opt,name=increment" json:"increment,omitempty"`
 	Delete             *DeleteRequest             `protobuf:"bytes,5,opt,name=delete" json:"delete,omitempty"`
 	DeleteRange        *DeleteRangeRequest        `protobuf:"bytes,6,opt,name=delete_range,json=deleteRange" json:"delete_range,omitempty"`
@@ -1053,7 +1080,7 @@ type RequestUnion struct {
 func (m *RequestUnion) Reset()                    { *m = RequestUnion{} }
 func (m *RequestUnion) String() string            { return proto.CompactTextString(m) }
 func (*RequestUnion) ProtoMessage()               {}
-func (*RequestUnion) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{51} }
+func (*RequestUnion) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{53} }
 
 // A ResponseUnion contains exactly one of the optional responses.
 // The values added here must match those in RequestUnion.
@@ -1061,6 +1088,7 @@ type ResponseUnion struct {
 	Get                *GetResponse                `protobuf:"bytes,1,opt,name=get" json:"get,omitempty"`
 	Put                *PutResponse                `protobuf:"bytes,2,opt,name=put" json:"put,omitempty"`
 	ConditionalPut     *ConditionalPutResponse     `protobuf:"bytes,3,opt,name=conditional_put,json=conditionalPut" json:"conditional_put,omitempty"`
+	InitPut            *InitPutResponse            `protobuf:"bytes,26,opt,name=init_put,json=initPut" json:"init_put,omitempty"`
 	Increment          *IncrementResponse          `protobuf:"bytes,4,opt,name=increment" json:"increment,omitempty"`
 	Delete             *DeleteResponse             `protobuf:"bytes,5,opt,name=delete" json:"delete,omitempty"`
 	DeleteRange        *DeleteRangeResponse        `protobuf:"bytes,6,opt,name=delete_range,json=deleteRange" json:"delete_range,omitempty"`
@@ -1088,7 +1116,7 @@ type ResponseUnion struct {
 func (m *ResponseUnion) Reset()                    { *m = ResponseUnion{} }
 func (m *ResponseUnion) String() string            { return proto.CompactTextString(m) }
 func (*ResponseUnion) ProtoMessage()               {}
-func (*ResponseUnion) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{52} }
+func (*ResponseUnion) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{54} }
 
 // A Header is attached to a BatchRequest, encapsulating routing and auxiliary
 // information required for executing it.
@@ -1133,7 +1161,7 @@ type Header struct {
 func (m *Header) Reset()                    { *m = Header{} }
 func (m *Header) String() string            { return proto.CompactTextString(m) }
 func (*Header) ProtoMessage()               {}
-func (*Header) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{53} }
+func (*Header) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{55} }
 
 // A BatchRequest contains one or more requests to be executed in
 // parallel, or if applicable (based on write-only commands and
@@ -1145,7 +1173,7 @@ type BatchRequest struct {
 
 func (m *BatchRequest) Reset()                    { *m = BatchRequest{} }
 func (*BatchRequest) ProtoMessage()               {}
-func (*BatchRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{54} }
+func (*BatchRequest) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{56} }
 
 // A BatchResponse contains one or more responses, one per request
 // corresponding to the requests in the matching BatchRequest. The
@@ -1158,7 +1186,7 @@ type BatchResponse struct {
 
 func (m *BatchResponse) Reset()                    { *m = BatchResponse{} }
 func (*BatchResponse) ProtoMessage()               {}
-func (*BatchResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{55} }
+func (*BatchResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{57} }
 
 type BatchResponse_Header struct {
 	// error is non-nil if an error occurred.
@@ -1182,7 +1210,7 @@ type BatchResponse_Header struct {
 func (m *BatchResponse_Header) Reset()                    { *m = BatchResponse_Header{} }
 func (m *BatchResponse_Header) String() string            { return proto.CompactTextString(m) }
 func (*BatchResponse_Header) ProtoMessage()               {}
-func (*BatchResponse_Header) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{55, 0} }
+func (*BatchResponse_Header) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{57, 0} }
 
 // A RaftCommand is a command which can be serialized and sent via
 // raft.
@@ -1195,7 +1223,7 @@ type RaftCommand struct {
 func (m *RaftCommand) Reset()                    { *m = RaftCommand{} }
 func (m *RaftCommand) String() string            { return proto.CompactTextString(m) }
 func (*RaftCommand) ProtoMessage()               {}
-func (*RaftCommand) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{56} }
+func (*RaftCommand) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{58} }
 
 func init() {
 	proto.RegisterType((*ResponseHeader)(nil), "cockroach.roachpb.ResponseHeader")
@@ -1205,6 +1233,8 @@ func init() {
 	proto.RegisterType((*PutResponse)(nil), "cockroach.roachpb.PutResponse")
 	proto.RegisterType((*ConditionalPutRequest)(nil), "cockroach.roachpb.ConditionalPutRequest")
 	proto.RegisterType((*ConditionalPutResponse)(nil), "cockroach.roachpb.ConditionalPutResponse")
+	proto.RegisterType((*InitPutRequest)(nil), "cockroach.roachpb.InitPutRequest")
+	proto.RegisterType((*InitPutResponse)(nil), "cockroach.roachpb.InitPutResponse")
 	proto.RegisterType((*IncrementRequest)(nil), "cockroach.roachpb.IncrementRequest")
 	proto.RegisterType((*IncrementResponse)(nil), "cockroach.roachpb.IncrementResponse")
 	proto.RegisterType((*DeleteRequest)(nil), "cockroach.roachpb.DeleteRequest")
@@ -1607,6 +1637,66 @@ func (m *ConditionalPutResponse) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
+func (m *InitPutRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *InitPutRequest) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
+	n12, err := m.Span.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n12
+	data[i] = 0x12
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
+	n13, err := m.Value.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n13
+	return i, nil
+}
+
+func (m *InitPutResponse) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *InitPutResponse) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
+	n14, err := m.ResponseHeader.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n14
+	return i, nil
+}
+
 func (m *IncrementRequest) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -1625,11 +1715,11 @@ func (m *IncrementRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n12, err := m.Span.MarshalTo(data[i:])
+	n15, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n12
+	i += n15
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Increment))
@@ -1654,11 +1744,11 @@ func (m *IncrementResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n13, err := m.ResponseHeader.MarshalTo(data[i:])
+	n16, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n13
+	i += n16
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.NewValue))
@@ -1683,11 +1773,11 @@ func (m *DeleteRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n14, err := m.Span.MarshalTo(data[i:])
+	n17, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n14
+	i += n17
 	return i, nil
 }
 
@@ -1709,11 +1799,11 @@ func (m *DeleteResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n15, err := m.ResponseHeader.MarshalTo(data[i:])
+	n18, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n15
+	i += n18
 	return i, nil
 }
 
@@ -1735,11 +1825,11 @@ func (m *DeleteRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n16, err := m.Span.MarshalTo(data[i:])
+	n19, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n16
+	i += n19
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxEntriesToDelete))
@@ -1772,11 +1862,11 @@ func (m *DeleteRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n17, err := m.ResponseHeader.MarshalTo(data[i:])
+	n20, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n17
+	i += n20
 	if len(m.Keys) > 0 {
 		for _, b := range m.Keys {
 			data[i] = 0x12
@@ -1806,11 +1896,11 @@ func (m *ScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n18, err := m.Span.MarshalTo(data[i:])
+	n21, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n18
+	i += n21
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -1835,11 +1925,11 @@ func (m *ScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n19, err := m.ResponseHeader.MarshalTo(data[i:])
+	n22, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n19
+	i += n22
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -1873,11 +1963,11 @@ func (m *ReverseScanRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n20, err := m.Span.MarshalTo(data[i:])
+	n23, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n20
+	i += n23
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxResults))
@@ -1902,11 +1992,11 @@ func (m *ReverseScanResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n21, err := m.ResponseHeader.MarshalTo(data[i:])
+	n24, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n21
+	i += n24
 	if len(m.Rows) > 0 {
 		for _, msg := range m.Rows {
 			data[i] = 0x12
@@ -1940,11 +2030,11 @@ func (m *CheckConsistencyRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n22, err := m.Span.MarshalTo(data[i:])
+	n25, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n22
+	i += n25
 	data[i] = 0x10
 	i++
 	if m.WithDiff {
@@ -1974,11 +2064,11 @@ func (m *CheckConsistencyResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n23, err := m.ResponseHeader.MarshalTo(data[i:])
+	n26, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n26
 	return i, nil
 }
 
@@ -2000,11 +2090,11 @@ func (m *BeginTransactionRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n24, err := m.Span.MarshalTo(data[i:])
+	n27, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n24
+	i += n27
 	return i, nil
 }
 
@@ -2026,11 +2116,11 @@ func (m *BeginTransactionResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n25, err := m.ResponseHeader.MarshalTo(data[i:])
+	n28, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n25
+	i += n28
 	return i, nil
 }
 
@@ -2052,11 +2142,11 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n26, err := m.Span.MarshalTo(data[i:])
+	n29, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n26
+	i += n29
 	data[i] = 0x10
 	i++
 	if m.Commit {
@@ -2069,21 +2159,21 @@ func (m *EndTransactionRequest) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Deadline.Size()))
-		n27, err := m.Deadline.MarshalTo(data[i:])
+		n30, err := m.Deadline.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n27
+		i += n30
 	}
 	if m.InternalCommitTrigger != nil {
 		data[i] = 0x22
 		i++
 		i = encodeVarintApi(data, i, uint64(m.InternalCommitTrigger.Size()))
-		n28, err := m.InternalCommitTrigger.MarshalTo(data[i:])
+		n31, err := m.InternalCommitTrigger.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n28
+		i += n31
 	}
 	if len(m.IntentSpans) > 0 {
 		for _, msg := range m.IntentSpans {
@@ -2118,11 +2208,11 @@ func (m *EndTransactionResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n29, err := m.ResponseHeader.MarshalTo(data[i:])
+	n32, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n29
+	i += n32
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.CommitWait))
@@ -2163,11 +2253,11 @@ func (m *AdminSplitRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n30, err := m.Span.MarshalTo(data[i:])
+	n33, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n30
+	i += n33
 	if m.SplitKey != nil {
 		data[i] = 0x12
 		i++
@@ -2195,11 +2285,11 @@ func (m *AdminSplitResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n31, err := m.ResponseHeader.MarshalTo(data[i:])
+	n34, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n31
+	i += n34
 	return i, nil
 }
 
@@ -2221,11 +2311,11 @@ func (m *AdminMergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n32, err := m.Span.MarshalTo(data[i:])
+	n35, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n32
+	i += n35
 	return i, nil
 }
 
@@ -2247,11 +2337,11 @@ func (m *AdminMergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n33, err := m.ResponseHeader.MarshalTo(data[i:])
+	n36, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n33
+	i += n36
 	return i, nil
 }
 
@@ -2273,11 +2363,11 @@ func (m *RangeLookupRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n34, err := m.Span.MarshalTo(data[i:])
+	n37, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n34
+	i += n37
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.MaxRanges))
@@ -2318,11 +2408,11 @@ func (m *RangeLookupResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n35, err := m.ResponseHeader.MarshalTo(data[i:])
+	n38, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n35
+	i += n38
 	if len(m.Ranges) > 0 {
 		for _, msg := range m.Ranges {
 			data[i] = 0x12
@@ -2368,19 +2458,19 @@ func (m *HeartbeatTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n36, err := m.Span.MarshalTo(data[i:])
+	n39, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n36
+	i += n39
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n37, err := m.Now.MarshalTo(data[i:])
+	n40, err := m.Now.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n37
+	i += n40
 	return i, nil
 }
 
@@ -2402,11 +2492,11 @@ func (m *HeartbeatTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n38, err := m.ResponseHeader.MarshalTo(data[i:])
+	n41, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n38
+	i += n41
 	return i, nil
 }
 
@@ -2428,11 +2518,11 @@ func (m *GCRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n39, err := m.Span.MarshalTo(data[i:])
+	n42, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n39
+	i += n42
 	if len(m.Keys) > 0 {
 		for _, msg := range m.Keys {
 			data[i] = 0x1a
@@ -2472,11 +2562,11 @@ func (m *GCRequest_GCKey) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n40, err := m.Timestamp.MarshalTo(data[i:])
+	n43, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n40
+	i += n43
 	return i, nil
 }
 
@@ -2498,11 +2588,11 @@ func (m *GCResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n41, err := m.ResponseHeader.MarshalTo(data[i:])
+	n44, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n41
+	i += n44
 	return i, nil
 }
 
@@ -2524,43 +2614,43 @@ func (m *PushTxnRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n42, err := m.Span.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n42
-	data[i] = 0x12
-	i++
-	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
-	n43, err := m.PusherTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n43
-	data[i] = 0x1a
-	i++
-	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-	n44, err := m.PusheeTxn.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n44
-	data[i] = 0x22
-	i++
-	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
-	n45, err := m.PushTo.MarshalTo(data[i:])
+	n45, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n45
-	data[i] = 0x2a
+	data[i] = 0x12
 	i++
-	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n46, err := m.Now.MarshalTo(data[i:])
+	i = encodeVarintApi(data, i, uint64(m.PusherTxn.Size()))
+	n46, err := m.PusherTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n46
+	data[i] = 0x1a
+	i++
+	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
+	n47, err := m.PusheeTxn.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n47
+	data[i] = 0x22
+	i++
+	i = encodeVarintApi(data, i, uint64(m.PushTo.Size()))
+	n48, err := m.PushTo.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n48
+	data[i] = 0x2a
+	i++
+	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
+	n49, err := m.Now.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n49
 	data[i] = 0x30
 	i++
 	i = encodeVarintApi(data, i, uint64(m.PushType))
@@ -2585,19 +2675,19 @@ func (m *PushTxnResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n47, err := m.ResponseHeader.MarshalTo(data[i:])
+	n50, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n47
+	i += n50
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.PusheeTxn.Size()))
-	n48, err := m.PusheeTxn.MarshalTo(data[i:])
+	n51, err := m.PusheeTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n48
+	i += n51
 	return i, nil
 }
 
@@ -2619,19 +2709,19 @@ func (m *ResolveIntentRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n49, err := m.Span.MarshalTo(data[i:])
+	n52, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n49
+	i += n52
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n50, err := m.IntentTxn.MarshalTo(data[i:])
+	n53, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n50
+	i += n53
 	data[i] = 0x18
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Status))
@@ -2664,11 +2754,11 @@ func (m *ResolveIntentResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n51, err := m.ResponseHeader.MarshalTo(data[i:])
+	n54, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n51
+	i += n54
 	return i, nil
 }
 
@@ -2690,19 +2780,19 @@ func (m *ResolveIntentRangeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n52, err := m.Span.MarshalTo(data[i:])
+	n55, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n52
+	i += n55
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.IntentTxn.Size()))
-	n53, err := m.IntentTxn.MarshalTo(data[i:])
+	n56, err := m.IntentTxn.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n53
+	i += n56
 	data[i] = 0x18
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Status))
@@ -2771,11 +2861,11 @@ func (m *ResolveIntentRangeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n54, err := m.ResponseHeader.MarshalTo(data[i:])
+	n57, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n54
+	i += n57
 	return i, nil
 }
 
@@ -2797,19 +2887,19 @@ func (m *MergeRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n55, err := m.Span.MarshalTo(data[i:])
+	n58, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n55
+	i += n58
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Value.Size()))
-	n56, err := m.Value.MarshalTo(data[i:])
+	n59, err := m.Value.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n56
+	i += n59
 	return i, nil
 }
 
@@ -2831,11 +2921,11 @@ func (m *MergeResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n57, err := m.ResponseHeader.MarshalTo(data[i:])
+	n60, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n57
+	i += n60
 	return i, nil
 }
 
@@ -2857,11 +2947,11 @@ func (m *TruncateLogRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n58, err := m.Span.MarshalTo(data[i:])
+	n61, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n58
+	i += n61
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Index))
@@ -2889,11 +2979,11 @@ func (m *TruncateLogResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n59, err := m.ResponseHeader.MarshalTo(data[i:])
+	n62, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n59
+	i += n62
 	return i, nil
 }
 
@@ -2915,19 +3005,19 @@ func (m *LeaderLeaseRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n60, err := m.Span.MarshalTo(data[i:])
+	n63, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n60
+	i += n63
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Lease.Size()))
-	n61, err := m.Lease.MarshalTo(data[i:])
+	n64, err := m.Lease.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n61
+	i += n64
 	return i, nil
 }
 
@@ -2949,11 +3039,11 @@ func (m *LeaderLeaseResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n62, err := m.ResponseHeader.MarshalTo(data[i:])
+	n65, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n62
+	i += n65
 	return i, nil
 }
 
@@ -2975,22 +3065,22 @@ func (m *ComputeChecksumRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n63, err := m.Span.MarshalTo(data[i:])
+	n66, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n63
+	i += n66
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Version))
 	data[i] = 0x1a
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ChecksumID.Size()))
-	n64, err := m.ChecksumID.MarshalTo(data[i:])
+	n67, err := m.ChecksumID.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n64
+	i += n67
 	data[i] = 0x20
 	i++
 	if m.Snapshot {
@@ -3020,11 +3110,11 @@ func (m *ComputeChecksumResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n65, err := m.ResponseHeader.MarshalTo(data[i:])
+	n68, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n65
+	i += n68
 	return i, nil
 }
 
@@ -3046,22 +3136,22 @@ func (m *VerifyChecksumRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Span.Size()))
-	n66, err := m.Span.MarshalTo(data[i:])
+	n69, err := m.Span.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n66
+	i += n69
 	data[i] = 0x10
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Version))
 	data[i] = 0x1a
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ChecksumID.Size()))
-	n67, err := m.ChecksumID.MarshalTo(data[i:])
+	n70, err := m.ChecksumID.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n67
+	i += n70
 	if m.Checksum != nil {
 		data[i] = 0x22
 		i++
@@ -3072,11 +3162,11 @@ func (m *VerifyChecksumRequest) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Snapshot.Size()))
-		n68, err := m.Snapshot.MarshalTo(data[i:])
+		n71, err := m.Snapshot.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n68
+		i += n71
 	}
 	return i, nil
 }
@@ -3099,11 +3189,11 @@ func (m *VerifyChecksumResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.ResponseHeader.Size()))
-	n69, err := m.ResponseHeader.MarshalTo(data[i:])
+	n72, err := m.ResponseHeader.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n69
+	i += n72
 	return i, nil
 }
 
@@ -3126,151 +3216,151 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n70, err := m.Get.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n70
-	}
-	if m.Put != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n71, err := m.Put.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n71
-	}
-	if m.ConditionalPut != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n72, err := m.ConditionalPut.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n72
-	}
-	if m.Increment != nil {
-		data[i] = 0x22
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n73, err := m.Increment.MarshalTo(data[i:])
+		n73, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n73
 	}
-	if m.Delete != nil {
-		data[i] = 0x2a
+	if m.Put != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n74, err := m.Delete.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
+		n74, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n74
 	}
-	if m.DeleteRange != nil {
-		data[i] = 0x32
+	if m.ConditionalPut != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n75, err := m.DeleteRange.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
+		n75, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n75
 	}
-	if m.Scan != nil {
-		data[i] = 0x3a
+	if m.Increment != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n76, err := m.Scan.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
+		n76, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n76
 	}
-	if m.BeginTransaction != nil {
-		data[i] = 0x42
+	if m.Delete != nil {
+		data[i] = 0x2a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
-		n77, err := m.BeginTransaction.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
+		n77, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n77
 	}
-	if m.EndTransaction != nil {
-		data[i] = 0x4a
+	if m.DeleteRange != nil {
+		data[i] = 0x32
 		i++
-		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n78, err := m.EndTransaction.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
+		n78, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n78
 	}
-	if m.AdminSplit != nil {
-		data[i] = 0x52
+	if m.Scan != nil {
+		data[i] = 0x3a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n79, err := m.AdminSplit.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
+		n79, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n79
 	}
-	if m.AdminMerge != nil {
-		data[i] = 0x5a
+	if m.BeginTransaction != nil {
+		data[i] = 0x42
 		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n80, err := m.AdminMerge.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
+		n80, err := m.BeginTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n80
 	}
-	if m.HeartbeatTxn != nil {
-		data[i] = 0x62
+	if m.EndTransaction != nil {
+		data[i] = 0x4a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n81, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
+		n81, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n81
 	}
-	if m.Gc != nil {
-		data[i] = 0x6a
+	if m.AdminSplit != nil {
+		data[i] = 0x52
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n82, err := m.Gc.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
+		n82, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n82
 	}
-	if m.PushTxn != nil {
-		data[i] = 0x72
+	if m.AdminMerge != nil {
+		data[i] = 0x5a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n83, err := m.PushTxn.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
+		n83, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n83
 	}
-	if m.RangeLookup != nil {
-		data[i] = 0x7a
+	if m.HeartbeatTxn != nil {
+		data[i] = 0x62
 		i++
-		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n84, err := m.RangeLookup.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
+		n84, err := m.HeartbeatTxn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n84
+	}
+	if m.Gc != nil {
+		data[i] = 0x6a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
+		n85, err := m.Gc.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n85
+	}
+	if m.PushTxn != nil {
+		data[i] = 0x72
+		i++
+		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
+		n86, err := m.PushTxn.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n86
+	}
+	if m.RangeLookup != nil {
+		data[i] = 0x7a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
+		n87, err := m.RangeLookup.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n87
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x82
@@ -3278,11 +3368,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n85, err := m.ResolveIntent.MarshalTo(data[i:])
+		n88, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n85
+		i += n88
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x8a
@@ -3290,11 +3380,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n86, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n89, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n86
+		i += n89
 	}
 	if m.Merge != nil {
 		data[i] = 0x92
@@ -3302,11 +3392,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n87, err := m.Merge.MarshalTo(data[i:])
+		n90, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n87
+		i += n90
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x9a
@@ -3314,11 +3404,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n88, err := m.TruncateLog.MarshalTo(data[i:])
+		n91, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n88
+		i += n91
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0xa2
@@ -3326,11 +3416,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n89, err := m.LeaderLease.MarshalTo(data[i:])
+		n92, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n89
+		i += n92
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xaa
@@ -3338,11 +3428,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n90, err := m.ReverseScan.MarshalTo(data[i:])
+		n93, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n90
+		i += n93
 	}
 	if m.ComputeChecksum != nil {
 		data[i] = 0xb2
@@ -3350,11 +3440,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ComputeChecksum.Size()))
-		n91, err := m.ComputeChecksum.MarshalTo(data[i:])
+		n94, err := m.ComputeChecksum.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n91
+		i += n94
 	}
 	if m.VerifyChecksum != nil {
 		data[i] = 0xba
@@ -3362,11 +3452,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.VerifyChecksum.Size()))
-		n92, err := m.VerifyChecksum.MarshalTo(data[i:])
+		n95, err := m.VerifyChecksum.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n92
+		i += n95
 	}
 	if m.CheckConsistency != nil {
 		data[i] = 0xc2
@@ -3374,11 +3464,11 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.CheckConsistency.Size()))
-		n93, err := m.CheckConsistency.MarshalTo(data[i:])
+		n96, err := m.CheckConsistency.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n93
+		i += n96
 	}
 	if m.Noop != nil {
 		data[i] = 0xca
@@ -3386,11 +3476,23 @@ func (m *RequestUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n94, err := m.Noop.MarshalTo(data[i:])
+		n97, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n94
+		i += n97
+	}
+	if m.InitPut != nil {
+		data[i] = 0xd2
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.InitPut.Size()))
+		n98, err := m.InitPut.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n98
 	}
 	return i, nil
 }
@@ -3414,151 +3516,151 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Get.Size()))
-		n95, err := m.Get.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n95
-	}
-	if m.Put != nil {
-		data[i] = 0x12
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
-		n96, err := m.Put.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n96
-	}
-	if m.ConditionalPut != nil {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
-		n97, err := m.ConditionalPut.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n97
-	}
-	if m.Increment != nil {
-		data[i] = 0x22
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
-		n98, err := m.Increment.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n98
-	}
-	if m.Delete != nil {
-		data[i] = 0x2a
-		i++
-		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
-		n99, err := m.Delete.MarshalTo(data[i:])
+		n99, err := m.Get.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n99
 	}
-	if m.DeleteRange != nil {
-		data[i] = 0x32
+	if m.Put != nil {
+		data[i] = 0x12
 		i++
-		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
-		n100, err := m.DeleteRange.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Put.Size()))
+		n100, err := m.Put.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n100
 	}
-	if m.Scan != nil {
-		data[i] = 0x3a
+	if m.ConditionalPut != nil {
+		data[i] = 0x1a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
-		n101, err := m.Scan.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.ConditionalPut.Size()))
+		n101, err := m.ConditionalPut.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n101
 	}
-	if m.BeginTransaction != nil {
-		data[i] = 0x42
+	if m.Increment != nil {
+		data[i] = 0x22
 		i++
-		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
-		n102, err := m.BeginTransaction.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Increment.Size()))
+		n102, err := m.Increment.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n102
 	}
-	if m.EndTransaction != nil {
-		data[i] = 0x4a
+	if m.Delete != nil {
+		data[i] = 0x2a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
-		n103, err := m.EndTransaction.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Delete.Size()))
+		n103, err := m.Delete.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n103
 	}
-	if m.AdminSplit != nil {
-		data[i] = 0x52
+	if m.DeleteRange != nil {
+		data[i] = 0x32
 		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
-		n104, err := m.AdminSplit.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.DeleteRange.Size()))
+		n104, err := m.DeleteRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n104
 	}
-	if m.AdminMerge != nil {
-		data[i] = 0x5a
+	if m.Scan != nil {
+		data[i] = 0x3a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
-		n105, err := m.AdminMerge.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.Scan.Size()))
+		n105, err := m.Scan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n105
 	}
-	if m.HeartbeatTxn != nil {
-		data[i] = 0x62
+	if m.BeginTransaction != nil {
+		data[i] = 0x42
 		i++
-		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
-		n106, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.BeginTransaction.Size()))
+		n106, err := m.BeginTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n106
 	}
-	if m.Gc != nil {
-		data[i] = 0x6a
+	if m.EndTransaction != nil {
+		data[i] = 0x4a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
-		n107, err := m.Gc.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.EndTransaction.Size()))
+		n107, err := m.EndTransaction.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n107
 	}
-	if m.PushTxn != nil {
-		data[i] = 0x72
+	if m.AdminSplit != nil {
+		data[i] = 0x52
 		i++
-		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
-		n108, err := m.PushTxn.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.AdminSplit.Size()))
+		n108, err := m.AdminSplit.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n108
 	}
-	if m.RangeLookup != nil {
-		data[i] = 0x7a
+	if m.AdminMerge != nil {
+		data[i] = 0x5a
 		i++
-		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
-		n109, err := m.RangeLookup.MarshalTo(data[i:])
+		i = encodeVarintApi(data, i, uint64(m.AdminMerge.Size()))
+		n109, err := m.AdminMerge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n109
+	}
+	if m.HeartbeatTxn != nil {
+		data[i] = 0x62
+		i++
+		i = encodeVarintApi(data, i, uint64(m.HeartbeatTxn.Size()))
+		n110, err := m.HeartbeatTxn.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n110
+	}
+	if m.Gc != nil {
+		data[i] = 0x6a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.Gc.Size()))
+		n111, err := m.Gc.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n111
+	}
+	if m.PushTxn != nil {
+		data[i] = 0x72
+		i++
+		i = encodeVarintApi(data, i, uint64(m.PushTxn.Size()))
+		n112, err := m.PushTxn.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n112
+	}
+	if m.RangeLookup != nil {
+		data[i] = 0x7a
+		i++
+		i = encodeVarintApi(data, i, uint64(m.RangeLookup.Size()))
+		n113, err := m.RangeLookup.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n113
 	}
 	if m.ResolveIntent != nil {
 		data[i] = 0x82
@@ -3566,11 +3668,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntent.Size()))
-		n110, err := m.ResolveIntent.MarshalTo(data[i:])
+		n114, err := m.ResolveIntent.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n110
+		i += n114
 	}
 	if m.ResolveIntentRange != nil {
 		data[i] = 0x8a
@@ -3578,11 +3680,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ResolveIntentRange.Size()))
-		n111, err := m.ResolveIntentRange.MarshalTo(data[i:])
+		n115, err := m.ResolveIntentRange.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n111
+		i += n115
 	}
 	if m.Merge != nil {
 		data[i] = 0x92
@@ -3590,11 +3692,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Merge.Size()))
-		n112, err := m.Merge.MarshalTo(data[i:])
+		n116, err := m.Merge.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n112
+		i += n116
 	}
 	if m.TruncateLog != nil {
 		data[i] = 0x9a
@@ -3602,11 +3704,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.TruncateLog.Size()))
-		n113, err := m.TruncateLog.MarshalTo(data[i:])
+		n117, err := m.TruncateLog.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n113
+		i += n117
 	}
 	if m.LeaderLease != nil {
 		data[i] = 0xa2
@@ -3614,11 +3716,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.LeaderLease.Size()))
-		n114, err := m.LeaderLease.MarshalTo(data[i:])
+		n118, err := m.LeaderLease.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n114
+		i += n118
 	}
 	if m.ReverseScan != nil {
 		data[i] = 0xaa
@@ -3626,11 +3728,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ReverseScan.Size()))
-		n115, err := m.ReverseScan.MarshalTo(data[i:])
+		n119, err := m.ReverseScan.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n115
+		i += n119
 	}
 	if m.ComputeChecksum != nil {
 		data[i] = 0xb2
@@ -3638,11 +3740,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.ComputeChecksum.Size()))
-		n116, err := m.ComputeChecksum.MarshalTo(data[i:])
+		n120, err := m.ComputeChecksum.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n116
+		i += n120
 	}
 	if m.VerifyChecksum != nil {
 		data[i] = 0xba
@@ -3650,11 +3752,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.VerifyChecksum.Size()))
-		n117, err := m.VerifyChecksum.MarshalTo(data[i:])
+		n121, err := m.VerifyChecksum.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n117
+		i += n121
 	}
 	if m.CheckConsistency != nil {
 		data[i] = 0xc2
@@ -3662,11 +3764,11 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.CheckConsistency.Size()))
-		n118, err := m.CheckConsistency.MarshalTo(data[i:])
+		n122, err := m.CheckConsistency.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n118
+		i += n122
 	}
 	if m.Noop != nil {
 		data[i] = 0xca
@@ -3674,11 +3776,23 @@ func (m *ResponseUnion) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Noop.Size()))
-		n119, err := m.Noop.MarshalTo(data[i:])
+		n123, err := m.Noop.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n119
+		i += n123
+	}
+	if m.InitPut != nil {
+		data[i] = 0xd2
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintApi(data, i, uint64(m.InitPut.Size()))
+		n124, err := m.InitPut.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n124
 	}
 	return i, nil
 }
@@ -3701,19 +3815,19 @@ func (m *Header) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n120, err := m.Timestamp.MarshalTo(data[i:])
+	n125, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n120
+	i += n125
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Replica.Size()))
-	n121, err := m.Replica.MarshalTo(data[i:])
+	n126, err := m.Replica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n121
+	i += n126
 	data[i] = 0x18
 	i++
 	i = encodeVarintApi(data, i, uint64(m.RangeID))
@@ -3724,11 +3838,11 @@ func (m *Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x2a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n122, err := m.Txn.MarshalTo(data[i:])
+		n127, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n122
+		i += n127
 	}
 	data[i] = 0x30
 	i++
@@ -3737,11 +3851,11 @@ func (m *Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x3a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Trace.Size()))
-		n123, err := m.Trace.MarshalTo(data[i:])
+		n128, err := m.Trace.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n123
+		i += n128
 	}
 	data[i] = 0x40
 	i++
@@ -3767,11 +3881,11 @@ func (m *BatchRequest) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Header.Size()))
-	n124, err := m.Header.MarshalTo(data[i:])
+	n129, err := m.Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n124
+	i += n129
 	if len(m.Requests) > 0 {
 		for _, msg := range m.Requests {
 			data[i] = 0x12
@@ -3805,11 +3919,11 @@ func (m *BatchResponse) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintApi(data, i, uint64(m.BatchResponse_Header.Size()))
-	n125, err := m.BatchResponse_Header.MarshalTo(data[i:])
+	n130, err := m.BatchResponse_Header.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n125
+	i += n130
 	if len(m.Responses) > 0 {
 		for _, msg := range m.Responses {
 			data[i] = 0x12
@@ -3844,29 +3958,29 @@ func (m *BatchResponse_Header) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Error.Size()))
-		n126, err := m.Error.MarshalTo(data[i:])
+		n131, err := m.Error.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n126
+		i += n131
 	}
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Timestamp.Size()))
-	n127, err := m.Timestamp.MarshalTo(data[i:])
+	n132, err := m.Timestamp.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n127
+	i += n132
 	if m.Txn != nil {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintApi(data, i, uint64(m.Txn.Size()))
-		n128, err := m.Txn.MarshalTo(data[i:])
+		n133, err := m.Txn.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n128
+		i += n133
 	}
 	if len(m.CollectedSpans) > 0 {
 		for _, b := range m.CollectedSpans {
@@ -3879,11 +3993,11 @@ func (m *BatchResponse_Header) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x2a
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Now.Size()))
-	n129, err := m.Now.MarshalTo(data[i:])
+	n134, err := m.Now.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n129
+	i += n134
 	return i, nil
 }
 
@@ -3908,19 +4022,19 @@ func (m *RaftCommand) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x12
 	i++
 	i = encodeVarintApi(data, i, uint64(m.OriginReplica.Size()))
-	n130, err := m.OriginReplica.MarshalTo(data[i:])
+	n135, err := m.OriginReplica.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n130
+	i += n135
 	data[i] = 0x1a
 	i++
 	i = encodeVarintApi(data, i, uint64(m.Cmd.Size()))
-	n131, err := m.Cmd.MarshalTo(data[i:])
+	n136, err := m.Cmd.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n131
+	i += n136
 	return i, nil
 }
 
@@ -4015,6 +4129,24 @@ func (m *ConditionalPutRequest) Size() (n int) {
 }
 
 func (m *ConditionalPutResponse) Size() (n int) {
+	var l int
+	_ = l
+	l = m.ResponseHeader.Size()
+	n += 1 + l + sovApi(uint64(l))
+	return n
+}
+
+func (m *InitPutRequest) Size() (n int) {
+	var l int
+	_ = l
+	l = m.Span.Size()
+	n += 1 + l + sovApi(uint64(l))
+	l = m.Value.Size()
+	n += 1 + l + sovApi(uint64(l))
+	return n
+}
+
+func (m *InitPutResponse) Size() (n int) {
 	var l int
 	_ = l
 	l = m.ResponseHeader.Size()
@@ -4600,6 +4732,10 @@ func (m *RequestUnion) Size() (n int) {
 		l = m.Noop.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
+	if m.InitPut != nil {
+		l = m.InitPut.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
 	return n
 }
 
@@ -4704,6 +4840,10 @@ func (m *ResponseUnion) Size() (n int) {
 	}
 	if m.Noop != nil {
 		l = m.Noop.Size()
+		n += 2 + l + sovApi(uint64(l))
+	}
+	if m.InitPut != nil {
+		l = m.InitPut.Size()
 		n += 2 + l + sovApi(uint64(l))
 	}
 	return n
@@ -4883,6 +5023,9 @@ func (this *RequestUnion) GetValue() interface{} {
 	if this.Noop != nil {
 		return this.Noop
 	}
+	if this.InitPut != nil {
+		return this.InitPut
+	}
 	return nil
 }
 
@@ -4938,6 +5081,8 @@ func (this *RequestUnion) SetValue(value interface{}) bool {
 		this.CheckConsistency = vt
 	case *NoopRequest:
 		this.Noop = vt
+	case *InitPutRequest:
+		this.InitPut = vt
 	default:
 		return false
 	}
@@ -5019,6 +5164,9 @@ func (this *ResponseUnion) GetValue() interface{} {
 	if this.Noop != nil {
 		return this.Noop
 	}
+	if this.InitPut != nil {
+		return this.InitPut
+	}
 	return nil
 }
 
@@ -5074,6 +5222,8 @@ func (this *ResponseUnion) SetValue(value interface{}) bool {
 		this.CheckConsistency = vt
 	case *NoopResponse:
 		this.Noop = vt
+	case *InitPutResponse:
+		this.InitPut = vt
 	default:
 		return false
 	}
@@ -5735,6 +5885,196 @@ func (m *ConditionalPutResponse) Unmarshal(data []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: ConditionalPutResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResponseHeader", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ResponseHeader.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipApi(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthApi
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *InitPutRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowApi
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: InitPutRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: InitPutRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Span", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Span.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Value.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipApi(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthApi
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *InitPutResponse) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowApi
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: InitPutResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: InitPutResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -11424,6 +11764,39 @@ func (m *RequestUnion) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 26:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InitPut", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.InitPut == nil {
+				m.InitPut = &InitPutRequest{}
+			}
+			if err := m.InitPut.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipApi(data[iNdEx:])
@@ -12296,6 +12669,39 @@ func (m *ResponseUnion) Unmarshal(data []byte) error {
 				m.Noop = &NoopResponse{}
 			}
 			if err := m.Noop.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 26:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InitPut", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowApi
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthApi
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.InitPut == nil {
+				m.InitPut = &InitPutResponse{}
+			}
+			if err := m.InitPut.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -13233,187 +13639,190 @@ var (
 )
 
 var fileDescriptorApi = []byte{
-	// 2897 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xdc, 0x5a, 0xcf, 0x6f, 0x1b, 0xc7,
-	0xf5, 0x17, 0x45, 0x51, 0xa2, 0x1e, 0x7f, 0x98, 0x1a, 0x4b, 0x16, 0xad, 0x24, 0xa2, 0xbc, 0xb1,
-	0x15, 0xdb, 0x49, 0xa4, 0x40, 0xf9, 0xe6, 0x9b, 0x5f, 0x2d, 0x1a, 0x51, 0x62, 0x62, 0x36, 0xb6,
-	0x2c, 0xaf, 0xa8, 0xd8, 0x49, 0x9b, 0x6c, 0x57, 0xdc, 0x11, 0xb9, 0x30, 0xb9, 0xcb, 0xec, 0x2e,
-	0x25, 0x19, 0x3d, 0x14, 0x28, 0xd0, 0x1f, 0x68, 0x2f, 0x2d, 0x50, 0x14, 0x05, 0x7a, 0x09, 0xda,
-	0x3f, 0xa0, 0x97, 0x02, 0x3d, 0xf6, 0x54, 0xc0, 0xa7, 0xc2, 0xc7, 0xa2, 0x07, 0xa3, 0x4d, 0xd1,
-	0x4b, 0x6f, 0x45, 0x7b, 0x69, 0xd0, 0x02, 0x9d, 0x5f, 0xbb, 0xdc, 0xe5, 0xee, 0x8a, 0xb4, 0xb3,
-	0xe9, 0xaf, 0x83, 0x04, 0xee, 0x9b, 0x79, 0x9f, 0x99, 0x79, 0x6f, 0x66, 0x3e, 0x6f, 0xde, 0x0c,
-	0x3c, 0xd1, 0x34, 0x9b, 0x77, 0x2d, 0x53, 0x6d, 0xb6, 0xd7, 0xd9, 0xff, 0xde, 0xc1, 0xba, 0xda,
-	0xd3, 0xd7, 0x7a, 0x96, 0xe9, 0x98, 0x68, 0xce, 0x2b, 0x5c, 0x13, 0x85, 0x4b, 0x4f, 0x86, 0xeb,
-	0x6b, 0xaa, 0xa3, 0x72, 0x85, 0xa5, 0xe5, 0x70, 0x29, 0xb6, 0x2c, 0xd3, 0xb2, 0x45, 0xf9, 0xa5,
-	0x70, 0xb9, 0x6e, 0x38, 0xd8, 0x32, 0xd4, 0x8e, 0x62, 0xa9, 0x87, 0x8e, 0xa8, 0xb6, 0x12, 0xae,
-	0xd6, 0xc5, 0x8e, 0xea, 0x6b, 0xe8, 0xc2, 0xa0, 0x46, 0xdf, 0xd1, 0x3b, 0xeb, 0x8e, 0xa5, 0x36,
-	0x75, 0xa3, 0xb5, 0x6e, 0xf7, 0x54, 0x43, 0x54, 0x99, 0x6f, 0x99, 0x2d, 0x93, 0xfd, 0x5c, 0xa7,
-	0xbf, 0xb8, 0x54, 0xaa, 0x42, 0x51, 0xc6, 0x76, 0xcf, 0x34, 0x6c, 0x7c, 0x0d, 0xab, 0x1a, 0xb6,
-	0xd0, 0x0b, 0x90, 0x76, 0x4e, 0x8c, 0x72, 0x7a, 0x25, 0x75, 0x39, 0xb7, 0xb1, 0xbc, 0x16, 0x1a,
-	0xf2, 0x5a, 0xc3, 0x52, 0x0d, 0x5b, 0x6d, 0x3a, 0xba, 0x69, 0xc8, 0xb4, 0xaa, 0xf4, 0x16, 0xc0,
-	0x5b, 0xd8, 0x91, 0xf1, 0x87, 0x7d, 0x6c, 0x3b, 0xe8, 0x55, 0x98, 0x6e, 0x33, 0xa4, 0x72, 0x8a,
-	0x41, 0x2c, 0x46, 0x40, 0xec, 0x91, 0x6e, 0x55, 0xb3, 0xf7, 0x1f, 0x56, 0x26, 0x1e, 0x3c, 0xac,
-	0xa4, 0x64, 0xa1, 0x20, 0x7d, 0x3d, 0x05, 0x39, 0x86, 0xc4, 0x3b, 0x84, 0xb6, 0x86, 0xa0, 0x2e,
-	0x44, 0x40, 0x05, 0x7b, 0x1f, 0x06, 0x45, 0x6b, 0x90, 0x39, 0x52, 0x3b, 0x7d, 0x5c, 0x9e, 0x64,
-	0x18, 0xe5, 0x08, 0x8c, 0x77, 0x68, 0xb9, 0xcc, 0xab, 0x49, 0x3f, 0x4e, 0x01, 0xec, 0xf6, 0x13,
-	0x18, 0x0e, 0xfa, 0xbf, 0x31, 0x5b, 0xae, 0x4e, 0x51, 0x55, 0xd1, 0x3e, 0x7a, 0x12, 0xa6, 0x75,
-	0xa3, 0xa3, 0x1b, 0x98, 0xb9, 0x20, 0x2b, 0x0a, 0x85, 0x4c, 0x92, 0x21, 0xc7, 0x3a, 0x97, 0xa0,
-	0x85, 0xa4, 0x5f, 0xa6, 0x60, 0x61, 0xcb, 0x34, 0x34, 0x9d, 0xba, 0x54, 0xed, 0xfc, 0x3b, 0x07,
-	0xff, 0x12, 0xcc, 0xe2, 0x93, 0x9e, 0xc2, 0x35, 0xd3, 0x23, 0x1c, 0x96, 0x25, 0x55, 0xd9, 0x2f,
-	0xe9, 0x7d, 0x38, 0x37, 0x3c, 0x80, 0x24, 0x0d, 0xf4, 0x21, 0x94, 0xea, 0x46, 0xd3, 0xc2, 0x5d,
-	0x6c, 0x24, 0x61, 0x1a, 0x09, 0x66, 0x75, 0x17, 0x8e, 0x99, 0x27, 0x2d, 0x8c, 0x30, 0x10, 0x4b,
-	0x5f, 0x85, 0x39, 0x5f, 0x93, 0x49, 0xae, 0x87, 0x0b, 0x30, 0x6b, 0xe0, 0x63, 0x65, 0xe0, 0x1c,
-	0xb7, 0xf5, 0x2c, 0x11, 0x73, 0x73, 0x7e, 0x11, 0x0a, 0xdb, 0xb8, 0x83, 0x1d, 0x9c, 0xc0, 0x9a,
-	0xde, 0x87, 0xa2, 0x8b, 0x95, 0xa4, 0x4b, 0x7e, 0x96, 0x02, 0x24, 0x70, 0x55, 0xa3, 0x95, 0x40,
-	0x47, 0xd1, 0xcb, 0xb0, 0xd0, 0x55, 0x4f, 0x14, 0x62, 0x6f, 0x4b, 0xc7, 0xb6, 0xe2, 0x98, 0x8a,
-	0xc6, 0xf0, 0x03, 0x36, 0x42, 0xa4, 0x4a, 0x8d, 0xd7, 0x68, 0x98, 0xbc, 0x7d, 0x74, 0x09, 0x72,
-	0x16, 0x76, 0xfa, 0x96, 0xa1, 0xdc, 0xc5, 0xf7, 0xec, 0xc0, 0xaa, 0x05, 0x5e, 0xf0, 0x36, 0x91,
-	0x4b, 0xc7, 0x70, 0x36, 0xd0, 0xe1, 0x24, 0x7d, 0xfa, 0x04, 0x4c, 0xb1, 0xb6, 0x27, 0x57, 0xd2,
-	0x97, 0xf3, 0xd5, 0x99, 0x4f, 0x1e, 0x56, 0xd2, 0xa4, 0x4d, 0x99, 0x09, 0x25, 0x13, 0x72, 0x7b,
-	0x4d, 0xd5, 0x48, 0xc0, 0x44, 0x64, 0xa4, 0xd4, 0x44, 0x16, 0xb6, 0xfb, 0x1d, 0xc7, 0x0e, 0x18,
-	0x06, 0x48, 0x81, 0xcc, 0xe5, 0xd2, 0x77, 0x52, 0x90, 0xe7, 0x2d, 0x26, 0x39, 0xc6, 0x97, 0x60,
-	0xca, 0x32, 0x8f, 0xf9, 0x18, 0x73, 0x1b, 0x4f, 0x44, 0x40, 0x90, 0x21, 0xfb, 0xb7, 0x14, 0x56,
-	0x5d, 0x3a, 0x02, 0x24, 0xe3, 0x23, 0x6c, 0xd9, 0xf8, 0x5f, 0x6b, 0x84, 0xef, 0xa7, 0xe0, 0x6c,
-	0xa0, 0xe1, 0xff, 0x00, 0x5b, 0x1c, 0xc3, 0xe2, 0x56, 0x1b, 0x37, 0xef, 0x92, 0xbd, 0xd2, 0xd6,
-	0x6d, 0x07, 0x1b, 0xcd, 0x7b, 0x09, 0x18, 0x84, 0x6c, 0x28, 0xc7, 0xba, 0xd3, 0x56, 0x34, 0xfd,
-	0xf0, 0x90, 0x99, 0xc3, 0x9d, 0xfd, 0x59, 0x2a, 0xde, 0x26, 0x52, 0x49, 0x81, 0x72, 0xb8, 0xe1,
-	0x24, 0xb7, 0x83, 0x06, 0x2c, 0x56, 0x71, 0x4b, 0x37, 0xfc, 0xb1, 0xc9, 0xa7, 0xdf, 0xbb, 0x48,
-	0xb7, 0xc3, 0xa8, 0x49, 0x76, 0xfb, 0xd7, 0x93, 0xb0, 0x50, 0x33, 0xb4, 0x44, 0x7b, 0x4d, 0x03,
-	0x88, 0xa6, 0xd9, 0xed, 0xea, 0x4e, 0xc0, 0x19, 0x42, 0x86, 0x5e, 0x81, 0xac, 0x46, 0xea, 0x79,
-	0x01, 0x46, 0x6e, 0xe3, 0xc9, 0xa8, 0x18, 0x4f, 0xef, 0x92, 0x5e, 0xa8, 0xdd, 0x9e, 0xec, 0xd5,
-	0x46, 0x5f, 0x81, 0x45, 0x2f, 0x38, 0xe5, 0x60, 0x0a, 0xd9, 0x08, 0x5b, 0x2d, 0xd2, 0xc7, 0x29,
-	0x06, 0x74, 0x39, 0x02, 0xa8, 0x2e, 0x34, 0xb6, 0x98, 0x42, 0x83, 0xd7, 0x97, 0x17, 0xf4, 0x28,
-	0x31, 0x7a, 0x03, 0xf2, 0xb4, 0xc0, 0x70, 0x14, 0x1a, 0xb7, 0xda, 0xe5, 0x0c, 0x9b, 0xde, 0xb1,
-	0x43, 0xe7, 0x03, 0xcb, 0x71, 0x15, 0x2a, 0xb1, 0xa5, 0x3f, 0xa6, 0xe0, 0xdc, 0xb0, 0x41, 0x93,
-	0x5c, 0x78, 0x64, 0xf1, 0x8b, 0xa1, 0x1f, 0xab, 0x7a, 0x90, 0xbc, 0x81, 0x17, 0xdc, 0x26, 0x72,
-	0xb4, 0x4e, 0xf6, 0xfa, 0xda, 0xae, 0x5c, 0xdb, 0xda, 0x6c, 0xd4, 0xb6, 0xe9, 0x56, 0x61, 0x76,
-	0x8e, 0xb0, 0x46, 0xec, 0x4d, 0xb6, 0x67, 0x19, 0x69, 0x5e, 0x91, 0x2c, 0x4a, 0x48, 0x90, 0x5a,
-	0x32, 0x0d, 0xac, 0xf4, 0xda, 0xaa, 0x8d, 0x85, 0x71, 0x99, 0x51, 0x5d, 0xef, 0x15, 0x49, 0xe9,
-	0x2e, 0x2d, 0xe4, 0x06, 0x93, 0x1c, 0x98, 0xdb, 0xd4, 0xba, 0xba, 0xb1, 0xd7, 0xeb, 0xe8, 0x49,
-	0x84, 0x24, 0x17, 0x61, 0xd6, 0xa6, 0x50, 0x94, 0xc2, 0xd8, 0xa8, 0x7c, 0x2c, 0x92, 0x65, 0x25,
-	0xe4, 0x97, 0xf4, 0x2e, 0x20, 0x7f, 0xab, 0x49, 0xae, 0x84, 0x1d, 0x31, 0xa0, 0x1b, 0xd8, 0x4a,
-	0x82, 0xcd, 0xbd, 0xae, 0x0a, 0xbc, 0x24, 0xbb, 0xfa, 0x2b, 0x12, 0x7a, 0x30, 0x0e, 0xbf, 0x6e,
-	0x9a, 0x77, 0xfb, 0xbd, 0x04, 0xac, 0xff, 0x34, 0x00, 0xa3, 0x14, 0x0a, 0xca, 0x19, 0x25, 0xe3,
-	0x46, 0x84, 0x94, 0x51, 0x98, 0x98, 0xcc, 0xa9, 0x52, 0x93, 0x6e, 0x9f, 0x44, 0x41, 0xe1, 0x53,
-	0x3e, 0x18, 0x6b, 0x9c, 0x71, 0x4b, 0xeb, 0xbc, 0x10, 0x2d, 0xc3, 0x8c, 0xc5, 0x09, 0x28, 0x30,
-	0x95, 0x5c, 0xa1, 0xf4, 0x17, 0xca, 0x50, 0xfe, 0x71, 0x24, 0xb9, 0x50, 0xde, 0x80, 0x69, 0x6f,
-	0x38, 0x74, 0x11, 0x4b, 0x51, 0x20, 0xb4, 0xc2, 0x36, 0xb6, 0x9b, 0x96, 0xde, 0x73, 0x4c, 0xcb,
-	0xdd, 0xa8, 0xb8, 0x1e, 0xda, 0x87, 0xb9, 0x9e, 0x85, 0x0f, 0xb1, 0xd3, 0x6c, 0x63, 0xcd, 0xb5,
-	0x4d, 0xfa, 0x11, 0xc1, 0x4a, 0x03, 0x08, 0x6e, 0x46, 0xe9, 0x9b, 0x64, 0xd4, 0xa4, 0xd7, 0x96,
-	0x73, 0x80, 0x55, 0xa7, 0x71, 0x62, 0x24, 0x72, 0xd4, 0x49, 0x1b, 0xe6, 0xb1, 0x38, 0xe8, 0x9c,
-	0xba, 0x9b, 0x8a, 0x5e, 0xd1, 0xea, 0xd2, 0x97, 0x60, 0x3e, 0xd8, 0x8f, 0x24, 0xe7, 0xe8, 0x9f,
-	0x52, 0x30, 0xfb, 0xd6, 0x56, 0x02, 0x63, 0xfb, 0x9c, 0x88, 0x2c, 0xe3, 0x0d, 0xef, 0x35, 0x43,
-	0x7e, 0x91, 0x4d, 0xc2, 0x0d, 0x38, 0xa8, 0xd6, 0x92, 0x06, 0x19, 0x26, 0x44, 0xe7, 0x21, 0x4d,
-	0x77, 0x96, 0x54, 0x70, 0x67, 0xa1, 0x32, 0x32, 0x53, 0x66, 0x1d, 0xd7, 0x3e, 0x8f, 0x60, 0xc3,
-	0x81, 0x92, 0x74, 0x0b, 0x80, 0x76, 0x22, 0x49, 0xfb, 0x7d, 0x2b, 0x0d, 0xc5, 0xdd, 0xbe, 0xdd,
-	0x4e, 0x66, 0x82, 0x6c, 0x01, 0xf4, 0x08, 0x18, 0x59, 0xb8, 0x34, 0xb3, 0x32, 0x39, 0x4e, 0x66,
-	0xc5, 0x1d, 0x25, 0xd7, 0x23, 0xdd, 0x40, 0x5f, 0x10, 0x20, 0x58, 0x19, 0xa4, 0x67, 0x96, 0xa2,
-	0x40, 0x4e, 0xc8, 0xa6, 0xe7, 0xa8, 0x01, 0x00, 0x4c, 0x01, 0x5e, 0x87, 0x19, 0xfa, 0x41, 0x4e,
-	0x36, 0x82, 0xaf, 0xc7, 0x31, 0xf3, 0x34, 0x55, 0x69, 0x98, 0xee, 0x1c, 0xcf, 0x3c, 0xd2, 0x1c,
-	0x47, 0x9b, 0x30, 0xcb, 0x9b, 0xbc, 0xd7, 0xc3, 0xe5, 0x69, 0xa2, 0x5b, 0x8c, 0x1c, 0xb7, 0xb0,
-	0x74, 0x83, 0xd4, 0x72, 0x43, 0x47, 0xd6, 0x2c, 0xf9, 0xa6, 0xe9, 0x98, 0x33, 0x9e, 0x27, 0x92,
-	0xdc, 0xa1, 0xb6, 0x02, 0xf6, 0x7c, 0x74, 0xa7, 0x50, 0x9b, 0x4a, 0x7f, 0x4d, 0xc1, 0xbc, 0x20,
-	0x71, 0xbe, 0xed, 0x26, 0x30, 0x5b, 0x88, 0xa3, 0x45, 0x14, 0x34, 0xe8, 0xd8, 0x18, 0x8e, 0xe6,
-	0x3a, 0xd4, 0xd1, 0x55, 0x98, 0x26, 0x9e, 0x70, 0xfa, 0x9c, 0x1f, 0x8a, 0x1b, 0x17, 0x4f, 0x1f,
-	0xd5, 0x1e, 0xab, 0xeb, 0xfa, 0x9b, 0x6b, 0xd2, 0x20, 0xb2, 0x67, 0xea, 0xb6, 0x69, 0x04, 0xb8,
-	0x43, 0xc8, 0xa4, 0x2f, 0xc3, 0xc2, 0xd0, 0xa8, 0x93, 0x5c, 0x7c, 0x7f, 0x4b, 0xc1, 0xf9, 0x20,
-	0x7c, 0x42, 0x47, 0xfc, 0xff, 0x02, 0xcb, 0x16, 0x21, 0xbf, 0x63, 0x9a, 0x1e, 0x19, 0x4b, 0x05,
-	0xc8, 0xf1, 0x6f, 0x36, 0x78, 0x49, 0x85, 0xa5, 0x28, 0xcb, 0x24, 0x69, 0xfd, 0xaf, 0x41, 0x3e,
-	0xa1, 0x20, 0xec, 0xf1, 0x72, 0x80, 0xe4, 0x2c, 0x57, 0xf8, 0x0c, 0xa2, 0xb6, 0x9f, 0x90, 0xa8,
-	0xad, 0x61, 0xf5, 0x8d, 0xa6, 0xea, 0x90, 0x80, 0xa7, 0x95, 0xc0, 0xe8, 0x96, 0x20, 0xa3, 0x1b,
-	0x1a, 0x3e, 0x61, 0xa3, 0x9b, 0x72, 0xc7, 0xc0, 0x44, 0xe4, 0x80, 0x9e, 0x65, 0x11, 0x8b, 0xa2,
-	0x6b, 0x6c, 0xaa, 0xa4, 0xab, 0x4b, 0xb4, 0xf8, 0xe3, 0x87, 0x95, 0x19, 0xe6, 0xb2, 0xfa, 0xf6,
-	0x27, 0x83, 0x9f, 0x24, 0x24, 0x63, 0x3f, 0x34, 0xe9, 0x3d, 0x38, 0x1b, 0xe8, 0x63, 0x92, 0x06,
-	0xf8, 0x06, 0x31, 0xc0, 0x75, 0xf6, 0x93, 0xfc, 0xb7, 0x13, 0x72, 0x6f, 0x87, 0x42, 0x9d, 0xe2,
-	0x5e, 0xd6, 0x94, 0x6b, 0x1a, 0x56, 0x99, 0x8e, 0x31, 0xd0, 0x8d, 0x24, 0xc7, 0xf8, 0x8f, 0x14,
-	0x4d, 0x04, 0x77, 0x7b, 0x7d, 0x07, 0xb3, 0x7c, 0x83, 0xdd, 0xef, 0x26, 0x30, 0x4e, 0x12, 0x48,
-	0xd3, 0x88, 0x99, 0x2c, 0x68, 0x36, 0xd2, 0x82, 0x1b, 0x48, 0x0b, 0x21, 0x3a, 0x24, 0x87, 0x42,
-	0xd1, 0x9a, 0xeb, 0xef, 0x7c, 0xb5, 0x46, 0xeb, 0xfc, 0xf6, 0x61, 0x65, 0xbd, 0xa5, 0x3b, 0xed,
-	0xfe, 0x01, 0x69, 0xad, 0xbb, 0xee, 0xb5, 0xa8, 0x1d, 0xac, 0x0f, 0x5d, 0xd8, 0xf4, 0xfb, 0xba,
-	0xb6, 0xb6, 0xbf, 0x5f, 0xdf, 0x26, 0x53, 0x04, 0xdc, 0xbe, 0x93, 0xa9, 0x01, 0x2e, 0x72, 0x5d,
-	0x43, 0x2b, 0x90, 0xb5, 0x0d, 0xb5, 0x67, 0xb7, 0xcd, 0xe0, 0xe1, 0xd0, 0x93, 0x4a, 0x1f, 0xc0,
-	0x62, 0x68, 0xf8, 0x49, 0xda, 0xf7, 0x17, 0x93, 0xb0, 0xf0, 0x0e, 0xb6, 0xf4, 0xc3, 0x7b, 0xff,
-	0x83, 0xe6, 0x5d, 0x82, 0xac, 0xfb, 0xc5, 0xcc, 0x9b, 0x97, 0xbd, 0x6f, 0xc2, 0x1c, 0x03, 0xd3,
-	0xf3, 0x18, 0xe8, 0xe9, 0xc8, 0x33, 0xc8, 0xa1, 0xb3, 0x27, 0xaa, 0x6d, 0xab, 0x8e, 0xea, 0xf3,
-	0xcc, 0xfb, 0x70, 0x6e, 0xd8, 0x70, 0x49, 0x3a, 0xe6, 0xef, 0x05, 0xc8, 0x0b, 0x57, 0xec, 0x1b,
-	0xd4, 0x68, 0xeb, 0x90, 0x6e, 0x61, 0x47, 0x40, 0x3e, 0x15, 0x15, 0xb6, 0x7b, 0x37, 0x76, 0x32,
-	0xad, 0x49, 0x15, 0xc8, 0xbc, 0x11, 0x4b, 0xf9, 0xa9, 0xc8, 0x20, 0x6d, 0xa0, 0x40, 0x6a, 0xa2,
-	0x5b, 0x40, 0x4f, 0x9c, 0xee, 0x9d, 0x8b, 0x42, 0x95, 0xd3, 0xb1, 0x69, 0xa0, 0xc8, 0xeb, 0x25,
-	0xb9, 0xd8, 0x0c, 0x88, 0x69, 0xb8, 0x38, 0xb8, 0x18, 0x99, 0x8a, 0x35, 0xf3, 0xf0, 0x5d, 0x8c,
-	0xef, 0xde, 0x04, 0xbd, 0x02, 0xd3, 0x22, 0x6d, 0xcf, 0xdd, 0xb4, 0x12, 0xa1, 0x1f, 0xb8, 0xdb,
-	0x90, 0x45, 0x7d, 0x74, 0x0d, 0xf2, 0xfc, 0x17, 0x3f, 0x6b, 0xb2, 0x70, 0x35, 0xb7, 0x71, 0x29,
-	0x5e, 0xdf, 0x17, 0x94, 0xc8, 0x39, 0x6d, 0x20, 0x43, 0x1b, 0x30, 0x65, 0x37, 0x55, 0xa3, 0x3c,
-	0x13, 0x1b, 0x53, 0xfa, 0x52, 0xd1, 0x32, 0xab, 0x8b, 0x6e, 0xc3, 0xdc, 0x01, 0x4d, 0x35, 0x2a,
-	0xce, 0x20, 0x7c, 0x28, 0x67, 0x19, 0xc0, 0xd5, 0x08, 0x80, 0x98, 0x64, 0xa7, 0x5c, 0x3a, 0x18,
-	0x2a, 0xa0, 0x6e, 0xc2, 0x86, 0x16, 0x80, 0x9d, 0x8d, 0x75, 0x53, 0x64, 0x2e, 0x52, 0x2e, 0xe2,
-	0x80, 0x18, 0xd5, 0x20, 0xa7, 0xd2, 0xdc, 0x8a, 0xc2, 0x12, 0x43, 0x65, 0x60, 0x70, 0x51, 0xa1,
-	0x50, 0x28, 0x45, 0x25, 0x83, 0xea, 0x89, 0x06, 0x30, 0x5d, 0xca, 0xf6, 0xe5, 0xdc, 0xe9, 0x30,
-	0xfe, 0x98, 0x44, 0xc0, 0x30, 0x11, 0x7a, 0x1b, 0x0a, 0x6d, 0xf7, 0x1c, 0xcd, 0xe2, 0xba, 0x3c,
-	0x03, 0x5a, 0x8d, 0x00, 0x8a, 0x38, 0xf7, 0xcb, 0xf9, 0xb6, 0x4f, 0x88, 0x9e, 0x83, 0xc9, 0x56,
-	0xb3, 0x5c, 0x88, 0x3d, 0xe5, 0x78, 0x87, 0x5d, 0x99, 0xd4, 0x23, 0x87, 0xe3, 0x2c, 0x3f, 0xde,
-	0x90, 0x56, 0x8b, 0xb1, 0x8b, 0x37, 0x78, 0x8e, 0x94, 0xd9, 0x21, 0x8c, 0xb6, 0x45, 0x26, 0x1c,
-	0x8f, 0x11, 0x3a, 0x2c, 0xff, 0x52, 0x3e, 0x13, 0x3b, 0xe1, 0xc2, 0xd9, 0x26, 0x39, 0x67, 0x0d,
-	0x64, 0x68, 0x07, 0x8a, 0x22, 0xc7, 0x28, 0x32, 0x43, 0xe5, 0x12, 0xc3, 0x7a, 0x26, 0x7a, 0x2b,
-	0x09, 0x9d, 0x56, 0xe4, 0x82, 0xe5, 0x97, 0xa2, 0x0f, 0x60, 0x3e, 0x88, 0x27, 0x96, 0xc4, 0x1c,
-	0x43, 0x7d, 0x6e, 0x24, 0xaa, 0x7f, 0x65, 0x20, 0x2b, 0x54, 0x44, 0xa2, 0xa3, 0x0c, 0xf7, 0x39,
-	0x62, 0x80, 0x95, 0x08, 0xc0, 0x80, 0xbb, 0x79, 0x6d, 0x6a, 0x30, 0x47, 0x44, 0x47, 0xc4, 0x66,
-	0xad, 0xf2, 0xd9, 0x58, 0x83, 0x85, 0x03, 0x3d, 0x39, 0xe7, 0x0c, 0x64, 0x14, 0xa9, 0xc3, 0x36,
-	0x4e, 0x85, 0x07, 0x30, 0xf3, 0xb1, 0x48, 0xe1, 0x88, 0x49, 0xce, 0x75, 0x06, 0x32, 0xe6, 0x44,
-	0x9e, 0x4f, 0x53, 0xd8, 0x9a, 0x5f, 0x88, 0x77, 0x62, 0xe8, 0x16, 0x8a, 0x38, 0x71, 0x20, 0x43,
-	0x0d, 0x9a, 0xdf, 0x63, 0xdc, 0xad, 0x78, 0x34, 0x74, 0x8e, 0xa1, 0x5d, 0x89, 0xdc, 0x50, 0xa3,
-	0xa2, 0x1c, 0x9a, 0x04, 0x0c, 0xc8, 0xe9, 0xf2, 0x3f, 0x62, 0xbc, 0x33, 0x00, 0x5d, 0x8c, 0x5d,
-	0xfe, 0x91, 0xd4, 0x2e, 0x17, 0x8f, 0x02, 0x62, 0xba, 0x55, 0x31, 0x2c, 0xa5, 0x39, 0xb8, 0xcd,
-	0x29, 0x97, 0x63, 0xb7, 0xaa, 0x98, 0x1b, 0x27, 0xb9, 0xd4, 0x1c, 0x2a, 0xa0, 0xfb, 0xa6, 0x41,
-	0xce, 0x3a, 0xe5, 0xf3, 0xb1, 0xfb, 0xa6, 0xef, 0x28, 0x24, 0xb3, 0xba, 0xaf, 0x4d, 0xdd, 0xff,
-	0xa8, 0x92, 0x92, 0x7e, 0x58, 0x84, 0x82, 0xcb, 0x91, 0x9c, 0xff, 0x5e, 0xf0, 0xf3, 0xdf, 0x72,
-	0x1c, 0xff, 0x71, 0x0d, 0x4e, 0x80, 0x2f, 0xf8, 0x09, 0x70, 0x39, 0x8e, 0x00, 0x5d, 0x0d, 0xca,
-	0x80, 0x72, 0x1c, 0x03, 0x5e, 0x19, 0x83, 0x01, 0x05, 0xd0, 0x30, 0x05, 0x56, 0xc3, 0x14, 0x78,
-	0xf1, 0x74, 0x0a, 0x14, 0x40, 0x3e, 0x0e, 0x7c, 0x75, 0x88, 0x03, 0x2f, 0x9c, 0xc2, 0x81, 0x42,
-	0xdb, 0x25, 0xc1, 0x7a, 0x24, 0x09, 0xae, 0x8e, 0x22, 0x41, 0x81, 0x12, 0x60, 0xc1, 0x17, 0x03,
-	0x2c, 0x58, 0x89, 0x65, 0x41, 0xa1, 0xcb, 0x69, 0xf0, 0x4e, 0x3c, 0x0d, 0x3e, 0x3b, 0x16, 0x0d,
-	0x0a, 0xb4, 0x30, 0x0f, 0xca, 0x71, 0x3c, 0x78, 0x65, 0x0c, 0x1e, 0x74, 0x9d, 0x35, 0x44, 0x84,
-	0x6f, 0x46, 0x11, 0xe1, 0xa5, 0x11, 0x44, 0x28, 0xb0, 0xfc, 0x4c, 0xf8, 0x66, 0x14, 0x13, 0x5e,
-	0x1a, 0xc1, 0x84, 0x01, 0x1c, 0x4e, 0x85, 0xd7, 0xa3, 0xa9, 0xf0, 0x99, 0x91, 0x54, 0x28, 0xb0,
-	0x82, 0x5c, 0xf8, 0xbc, 0x8f, 0x0b, 0x9f, 0x8a, 0xe1, 0x42, 0xa1, 0x48, 0xc9, 0xf0, 0xf3, 0x21,
-	0x32, 0x94, 0x4e, 0x23, 0x43, 0xa1, 0xe9, 0xb1, 0x61, 0x3d, 0x92, 0x0d, 0x57, 0x47, 0xb1, 0xa1,
-	0x3b, 0xf3, 0xfc, 0x74, 0x78, 0x33, 0x86, 0x0e, 0x2f, 0x8f, 0xa6, 0x43, 0x01, 0x37, 0xc4, 0x87,
-	0xca, 0xa9, 0x7c, 0xf8, 0xfc, 0x98, 0x7c, 0x28, 0xb0, 0xa3, 0x08, 0xf1, 0xff, 0x83, 0x84, 0xb8,
-	0x12, 0x4f, 0x88, 0x02, 0x44, 0x30, 0x62, 0x3d, 0x92, 0x11, 0x57, 0x47, 0x31, 0xa2, 0x6b, 0x34,
-	0x3f, 0x25, 0xd6, 0x23, 0x29, 0x71, 0x75, 0x14, 0x25, 0xba, 0x50, 0x7e, 0x4e, 0xac, 0x47, 0x72,
-	0xe2, 0xea, 0x28, 0x4e, 0xf4, 0x5c, 0xe9, 0x23, 0xc5, 0xfd, 0x58, 0x52, 0xbc, 0x3a, 0x0e, 0x29,
-	0x0a, 0xc8, 0x10, 0x2b, 0xca, 0x71, 0xac, 0x78, 0x65, 0x0c, 0x56, 0x74, 0x37, 0x83, 0x21, 0x5a,
-	0xbc, 0x13, 0x4f, 0x8b, 0xcf, 0x8e, 0x45, 0x8b, 0xee, 0xd6, 0x15, 0xe2, 0xc5, 0x17, 0x03, 0xbc,
-	0x58, 0x89, 0xe5, 0x45, 0x77, 0x27, 0xf5, 0x11, 0xe3, 0x9f, 0xd3, 0x30, 0x7d, 0xcd, 0xbd, 0x91,
-	0xf3, 0xdd, 0xb3, 0xa4, 0x1e, 0xe3, 0x9e, 0x05, 0x6d, 0xd3, 0x0b, 0x45, 0xb2, 0x61, 0x35, 0x55,
-	0xc1, 0x92, 0x17, 0x23, 0x5d, 0xca, 0x6a, 0x84, 0x6e, 0xe2, 0x5c, 0xd5, 0xc7, 0x4c, 0x8d, 0x11,
-	0x52, 0x2b, 0xf4, 0x6d, 0x32, 0x3b, 0x7b, 0x96, 0x6e, 0x5a, 0xba, 0x73, 0x8f, 0x91, 0x63, 0xaa,
-	0x3a, 0x4f, 0x75, 0x89, 0x42, 0x7e, 0x9f, 0x14, 0xee, 0x8a, 0x32, 0x39, 0xdf, 0xf7, 0x7d, 0xb9,
-	0x2f, 0x5a, 0x33, 0x63, 0xbf, 0x68, 0x25, 0x21, 0x4e, 0xc9, 0x22, 0x56, 0x0b, 0xb8, 0x92, 0x5f,
-	0x5f, 0x44, 0xcf, 0x62, 0x55, 0xf3, 0xf9, 0xcb, 0x77, 0x8d, 0x71, 0xc6, 0x0a, 0x16, 0x91, 0x10,
-	0x27, 0x43, 0x9f, 0xe6, 0x62, 0xc1, 0x8a, 0x7e, 0x07, 0xd0, 0x3c, 0xc5, 0x9a, 0x78, 0xb7, 0xcb,
-	0x52, 0x25, 0x32, 0xaf, 0x4a, 0xdf, 0x06, 0xd0, 0xdb, 0x61, 0xba, 0x94, 0xbc, 0x57, 0x47, 0x59,
-	0xdf, 0xc3, 0x83, 0x22, 0x29, 0x15, 0x2b, 0x88, 0xbd, 0x3c, 0xfa, 0x41, 0x0a, 0xf2, 0x55, 0xd5,
-	0x69, 0xb6, 0xdd, 0xdc, 0xcc, 0xeb, 0x43, 0x19, 0x86, 0xf3, 0xd1, 0x7c, 0x10, 0x7d, 0x4d, 0xb2,
-	0x49, 0xdc, 0xc5, 0x71, 0xdc, 0xab, 0xdc, 0x4a, 0xa4, 0x09, 0x06, 0xb9, 0x07, 0x37, 0x2b, 0xe5,
-	0xaa, 0xbd, 0x36, 0xf5, 0xa3, 0x8f, 0x2a, 0x13, 0xd2, 0xcf, 0xd3, 0x50, 0x10, 0xdd, 0x12, 0x99,
-	0x8f, 0xfa, 0x50, 0xbf, 0xa2, 0x78, 0x2a, 0xa0, 0x11, 0xdf, 0xcb, 0x6d, 0x98, 0xb5, 0x44, 0x25,
-	0xb7, 0x9b, 0x2b, 0xa7, 0xe4, 0x51, 0xfc, 0xfd, 0x1c, 0x28, 0x2e, 0x7d, 0x77, 0xd2, 0x5b, 0x2d,
-	0x6b, 0x90, 0x61, 0x2f, 0xb5, 0x45, 0xd7, 0xa2, 0x72, 0x9b, 0x35, 0x5a, 0x2e, 0xf3, 0x6a, 0x74,
-	0x75, 0x35, 0x3e, 0xd5, 0x2d, 0xe6, 0xa3, 0xbf, 0xbb, 0x46, 0xcf, 0xd0, 0xf8, 0xb3, 0xd3, 0xc1,
-	0x4d, 0x07, 0x6b, 0xe2, 0xc5, 0xcc, 0x14, 0x7b, 0x61, 0x52, 0xf4, 0xc4, 0xec, 0x55, 0xcc, 0xe3,
-	0x5d, 0xde, 0x09, 0xb7, 0x3d, 0x48, 0x41, 0x8e, 0xe6, 0xb5, 0xe8, 0xc3, 0x13, 0xd5, 0xd0, 0x02,
-	0xcb, 0x37, 0x35, 0xfe, 0xf2, 0xbd, 0x05, 0x45, 0xb2, 0x18, 0x69, 0x64, 0xf7, 0xf8, 0x5b, 0x48,
-	0x81, 0x23, 0x88, 0x62, 0xf4, 0x32, 0xa4, 0x9b, 0x5d, 0x4d, 0x18, 0xac, 0x12, 0x3f, 0x77, 0xd8,
-	0x2c, 0x74, 0x07, 0x46, 0x34, 0xae, 0x5e, 0xa7, 0x2f, 0xf3, 0x42, 0x4b, 0x16, 0x15, 0x01, 0xb6,
-	0x6e, 0xee, 0xec, 0xd5, 0xf7, 0x1a, 0xb5, 0x9d, 0x46, 0x69, 0x02, 0x15, 0x60, 0x96, 0x7e, 0xd7,
-	0x76, 0xf6, 0xf6, 0xf7, 0x4a, 0x29, 0x54, 0x82, 0x7c, 0x7d, 0xc7, 0x57, 0x61, 0x72, 0x69, 0xea,
-	0xdb, 0x3f, 0x5d, 0x9e, 0xb8, 0x7a, 0x9b, 0xbe, 0xc8, 0xf6, 0xee, 0x2f, 0x11, 0x82, 0xe2, 0xee,
-	0xfe, 0xde, 0x35, 0xa5, 0x51, 0xbf, 0x51, 0xdb, 0x6b, 0x6c, 0xde, 0xd8, 0x25, 0x48, 0x04, 0x99,
-	0xc9, 0x36, 0xab, 0x37, 0xe5, 0x06, 0x81, 0x72, 0xbf, 0x1b, 0x37, 0xf7, 0xb7, 0xae, 0x95, 0x26,
-	0xbd, 0xef, 0x5b, 0xfb, 0x35, 0xf9, 0xdd, 0x52, 0x9a, 0x03, 0x6f, 0xdc, 0x81, 0xac, 0xfb, 0x7a,
-	0x8a, 0x44, 0x76, 0x19, 0x36, 0x1a, 0x34, 0x6a, 0x9c, 0x4b, 0x2b, 0xa3, 0x16, 0x91, 0xc4, 0x90,
-	0x6b, 0x27, 0x9f, 0x05, 0x72, 0xf5, 0xc2, 0xfd, 0xdf, 0x2f, 0x4f, 0xdc, 0xff, 0x78, 0x39, 0xf5,
-	0x80, 0xfc, 0xfd, 0x86, 0xfc, 0xfd, 0x8e, 0xfc, 0x7d, 0xef, 0x0f, 0xcb, 0x13, 0xef, 0xcd, 0x08,
-	0x95, 0x3b, 0x99, 0x7f, 0x06, 0x00, 0x00, 0xff, 0xff, 0x08, 0xa4, 0x89, 0xc9, 0x64, 0x31, 0x00,
+	// 2945 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xdc, 0x5a, 0xcd, 0x6f, 0x1b, 0xc7,
+	0x15, 0xd7, 0x8a, 0xa2, 0x44, 0x3d, 0x7e, 0x98, 0x5a, 0x4b, 0x16, 0xcd, 0x24, 0xa2, 0xbc, 0xb1,
+	0x15, 0xdb, 0x49, 0xa4, 0x40, 0x69, 0x9a, 0xaf, 0x06, 0x8d, 0x28, 0x31, 0x36, 0x1b, 0x5b, 0x96,
+	0x57, 0x94, 0xed, 0xa4, 0x4d, 0xb6, 0x2b, 0xee, 0x88, 0x5c, 0x98, 0xdc, 0x65, 0x76, 0x97, 0x92,
+	0x8c, 0x1e, 0x8a, 0x16, 0xe8, 0x07, 0xda, 0x4b, 0x0b, 0xf4, 0x50, 0xa0, 0x97, 0xa0, 0xfd, 0x03,
+	0x7a, 0x29, 0x50, 0xa0, 0x97, 0x9e, 0x0a, 0xf8, 0x54, 0xf8, 0x52, 0xa0, 0xe8, 0xc1, 0x68, 0x53,
+	0xf4, 0xd2, 0x5b, 0xd1, 0x5e, 0x1a, 0xa0, 0x40, 0xe7, 0x6b, 0x97, 0xbb, 0xdc, 0x5d, 0x91, 0x76,
+	0x36, 0x4d, 0xdb, 0x83, 0x04, 0xee, 0x9b, 0x79, 0xbf, 0x99, 0xf7, 0xde, 0xcc, 0xfc, 0xde, 0x7c,
+	0xc0, 0x13, 0x4d, 0xb3, 0x79, 0xd7, 0x32, 0xd5, 0x66, 0x7b, 0x8d, 0xfe, 0xef, 0xed, 0xaf, 0xa9,
+	0x3d, 0x7d, 0xb5, 0x67, 0x99, 0x8e, 0x29, 0xce, 0x79, 0x85, 0xab, 0xbc, 0xb0, 0xfc, 0x64, 0xb8,
+	0xbe, 0xa6, 0x3a, 0x2a, 0x53, 0x28, 0x2f, 0x85, 0x4b, 0x91, 0x65, 0x99, 0x96, 0xcd, 0xcb, 0x2f,
+	0x84, 0xcb, 0x75, 0xc3, 0x41, 0x96, 0xa1, 0x76, 0x14, 0x4b, 0x3d, 0x70, 0x78, 0xb5, 0xe5, 0x70,
+	0xb5, 0x2e, 0x72, 0x54, 0x5f, 0x43, 0xe7, 0x06, 0x35, 0xfa, 0x8e, 0xde, 0x59, 0x73, 0x2c, 0xb5,
+	0xa9, 0x1b, 0xad, 0x35, 0xbb, 0xa7, 0x1a, 0xbc, 0xca, 0x7c, 0xcb, 0x6c, 0x99, 0xf4, 0xe7, 0x1a,
+	0xf9, 0xc5, 0xa4, 0x52, 0x15, 0x0a, 0x32, 0xb2, 0x7b, 0xa6, 0x61, 0xa3, 0xab, 0x48, 0xd5, 0x90,
+	0x25, 0xbe, 0x00, 0x29, 0xe7, 0xd8, 0x28, 0xa5, 0x96, 0x85, 0x8b, 0xd9, 0xf5, 0xa5, 0xd5, 0x90,
+	0xc9, 0xab, 0x0d, 0x4b, 0x35, 0x6c, 0xb5, 0xe9, 0xe8, 0xa6, 0x21, 0x93, 0xaa, 0xd2, 0x15, 0x80,
+	0x2b, 0xc8, 0x91, 0xd1, 0x07, 0x7d, 0x64, 0x3b, 0xe2, 0xab, 0x30, 0xdd, 0xa6, 0x48, 0x25, 0x81,
+	0x42, 0x2c, 0x46, 0x40, 0xec, 0xe2, 0x6e, 0x55, 0x33, 0xf7, 0x1f, 0x56, 0x26, 0x1e, 0x3c, 0xac,
+	0x08, 0x32, 0x57, 0x90, 0xbe, 0x29, 0x40, 0x96, 0x22, 0xb1, 0x0e, 0x89, 0x9b, 0x43, 0x50, 0xe7,
+	0x22, 0xa0, 0x82, 0xbd, 0x0f, 0x83, 0x8a, 0xab, 0x90, 0x3e, 0x54, 0x3b, 0x7d, 0x54, 0x9a, 0xa4,
+	0x18, 0xa5, 0x08, 0x8c, 0x5b, 0xa4, 0x5c, 0x66, 0xd5, 0xa4, 0x9f, 0x08, 0x00, 0x3b, 0xfd, 0x04,
+	0xcc, 0x11, 0x3f, 0x37, 0x66, 0xcb, 0xd5, 0x29, 0xa2, 0xca, 0xdb, 0x17, 0x9f, 0x84, 0x69, 0xdd,
+	0xe8, 0xe8, 0x06, 0xa2, 0x21, 0xc8, 0xf0, 0x42, 0x2e, 0x93, 0x64, 0xc8, 0xd2, 0xce, 0x25, 0xe8,
+	0x21, 0xe9, 0xd7, 0x02, 0x2c, 0x6c, 0x9a, 0x86, 0xa6, 0x93, 0x90, 0xaa, 0x9d, 0xcf, 0xd2, 0xf8,
+	0x97, 0x60, 0x16, 0x1d, 0xf7, 0x14, 0xa6, 0x99, 0x1a, 0x11, 0xb0, 0x0c, 0xae, 0x4a, 0x7f, 0x49,
+	0xef, 0xc1, 0x99, 0x61, 0x03, 0x92, 0x74, 0xd0, 0x37, 0x04, 0x28, 0xd4, 0x0d, 0xdd, 0xf9, 0x0c,
+	0x3d, 0x23, 0xdd, 0x82, 0x53, 0x5e, 0x17, 0x92, 0xb4, 0xed, 0x03, 0x28, 0xd6, 0x8d, 0xa6, 0x85,
+	0xba, 0xc8, 0x48, 0xc2, 0x38, 0x09, 0x66, 0x75, 0x17, 0x8e, 0x1a, 0x98, 0xe2, 0x66, 0x0c, 0xc4,
+	0xd2, 0xd7, 0x60, 0xce, 0xd7, 0x64, 0x92, 0x73, 0xfd, 0x1c, 0xcc, 0x1a, 0xe8, 0x48, 0x19, 0xb8,
+	0xd7, 0x6d, 0x3d, 0x83, 0xc5, 0x6c, 0xa8, 0x7c, 0x09, 0xf2, 0x5b, 0xa8, 0x83, 0x1c, 0x94, 0xc0,
+	0x7a, 0xb5, 0x07, 0x05, 0x17, 0x2b, 0xc9, 0x90, 0xfc, 0x5c, 0x00, 0x91, 0xe3, 0xaa, 0x46, 0x2b,
+	0x81, 0x8e, 0x8a, 0x2f, 0xc3, 0x42, 0x57, 0x3d, 0x56, 0xb0, 0xbf, 0x2d, 0x1d, 0xd9, 0x8a, 0x63,
+	0x2a, 0x1a, 0xc5, 0x0f, 0xf8, 0x48, 0xc4, 0x55, 0x6a, 0xac, 0x46, 0xc3, 0x64, 0xed, 0x8b, 0x17,
+	0x20, 0x6b, 0x21, 0xa7, 0x6f, 0x19, 0xca, 0x5d, 0x74, 0xcf, 0x0e, 0xac, 0x48, 0xc0, 0x0a, 0xde,
+	0xc6, 0x72, 0xe9, 0x08, 0x4e, 0x07, 0x3a, 0x9c, 0x64, 0x4c, 0x9f, 0x80, 0x29, 0xda, 0xf6, 0xe4,
+	0x72, 0xea, 0x62, 0xae, 0x3a, 0xf3, 0xf1, 0xc3, 0x4a, 0x0a, 0xb7, 0x29, 0x53, 0xa1, 0x64, 0x42,
+	0x76, 0xb7, 0xa9, 0x1a, 0x09, 0xb8, 0x08, 0x5b, 0x4a, 0x5c, 0x64, 0x21, 0xbb, 0xdf, 0x71, 0xec,
+	0x80, 0x63, 0x00, 0x17, 0xc8, 0x4c, 0x2e, 0x7d, 0x4f, 0x80, 0x1c, 0x6b, 0x31, 0x49, 0x1b, 0x5f,
+	0x82, 0x29, 0xcb, 0x3c, 0x62, 0x36, 0x66, 0xd7, 0x9f, 0x88, 0x80, 0xc0, 0x26, 0xfb, 0x17, 0x05,
+	0x5a, 0x5d, 0x3a, 0x04, 0x51, 0x46, 0x87, 0xc8, 0xb2, 0xd1, 0x7f, 0xd6, 0x09, 0x3f, 0x14, 0xe0,
+	0x74, 0xa0, 0xe1, 0xff, 0x02, 0x5f, 0x1c, 0xc1, 0xe2, 0x66, 0x1b, 0x35, 0xef, 0x62, 0x1e, 0xb0,
+	0x75, 0xdb, 0x41, 0x46, 0xf3, 0x5e, 0x02, 0x0e, 0xc1, 0x0b, 0xca, 0x91, 0xee, 0xb4, 0x15, 0x4d,
+	0x3f, 0x38, 0xa0, 0xee, 0x70, 0x47, 0x7f, 0x86, 0x88, 0xb7, 0xb0, 0x54, 0x52, 0xa0, 0x14, 0x6e,
+	0x38, 0xc9, 0xe5, 0xa0, 0x01, 0x8b, 0x55, 0xd4, 0xd2, 0x0d, 0x7f, 0xde, 0xf5, 0xc9, 0xd7, 0x2e,
+	0xdc, 0xed, 0x30, 0x6a, 0x92, 0xdd, 0xfe, 0xed, 0x24, 0x2c, 0xd4, 0x0c, 0x2d, 0xd1, 0x5e, 0x93,
+	0xe4, 0xa8, 0x69, 0x76, 0xbb, 0xba, 0x13, 0x08, 0x06, 0x97, 0x89, 0xaf, 0x40, 0x46, 0xc3, 0xf5,
+	0xbc, 0xe4, 0x29, 0xbb, 0xfe, 0x64, 0x54, 0xfe, 0xaa, 0x77, 0x71, 0x2f, 0xd4, 0x6e, 0x4f, 0xf6,
+	0x6a, 0x8b, 0x5f, 0x85, 0x45, 0x2f, 0xf1, 0x66, 0x60, 0x0a, 0x5e, 0x08, 0x5b, 0x2d, 0xdc, 0xc7,
+	0x29, 0x0a, 0x74, 0x31, 0x02, 0xa8, 0xce, 0x35, 0x36, 0xa9, 0x42, 0x83, 0xd5, 0x97, 0x17, 0xf4,
+	0x28, 0xb1, 0xf8, 0x26, 0xe4, 0x48, 0x81, 0xe1, 0x28, 0x24, 0x27, 0xb7, 0x4b, 0x69, 0x3a, 0xbc,
+	0x63, 0x4d, 0x67, 0x86, 0x65, 0x99, 0x0a, 0x91, 0xd8, 0xd2, 0x5f, 0x04, 0x38, 0x33, 0xec, 0xd0,
+	0x24, 0x27, 0x1e, 0x9e, 0xfc, 0xdc, 0xf4, 0x23, 0x55, 0x0f, 0x92, 0x37, 0xb0, 0x82, 0xdb, 0x58,
+	0x2e, 0xae, 0xe1, 0xb5, 0xbe, 0xb6, 0x23, 0xd7, 0x36, 0x37, 0x1a, 0xb5, 0x2d, 0xb2, 0x54, 0x98,
+	0x9d, 0x43, 0xa4, 0x61, 0x7f, 0xe3, 0xe5, 0x59, 0x16, 0x35, 0xaf, 0x48, 0xe6, 0x25, 0x38, 0x01,
+	0x2f, 0x9a, 0x06, 0x52, 0x7a, 0x6d, 0xd5, 0x46, 0xdc, 0xb9, 0xd4, 0xa9, 0x6e, 0xf4, 0x0a, 0xb8,
+	0x74, 0x87, 0x14, 0x32, 0x87, 0x49, 0x0e, 0xcc, 0x6d, 0x68, 0x5d, 0xdd, 0xd8, 0xed, 0x75, 0xf4,
+	0x24, 0x52, 0x92, 0xf3, 0x30, 0x6b, 0x13, 0x28, 0x42, 0x61, 0xd4, 0x2a, 0x1f, 0x8b, 0x64, 0x68,
+	0x09, 0xfe, 0x25, 0xbd, 0x03, 0xa2, 0xbf, 0xd5, 0x24, 0x67, 0xc2, 0x36, 0x37, 0xe8, 0x3a, 0xb2,
+	0x92, 0x60, 0x73, 0xaf, 0xab, 0x1c, 0x2f, 0xc9, 0xae, 0xfe, 0x06, 0xa7, 0x1e, 0x94, 0xc3, 0xaf,
+	0x99, 0xe6, 0xdd, 0x7e, 0x2f, 0x01, 0xef, 0x3f, 0x0d, 0x40, 0x29, 0x85, 0x80, 0x32, 0x46, 0x49,
+	0xbb, 0x19, 0x21, 0x61, 0x14, 0x2a, 0xc6, 0x63, 0xaa, 0xd8, 0x24, 0xcb, 0x27, 0x56, 0x50, 0xd8,
+	0x90, 0x0f, 0xe6, 0x1a, 0xa7, 0xdc, 0xd2, 0x3a, 0x2b, 0x14, 0x97, 0x60, 0xc6, 0x62, 0x04, 0x14,
+	0x18, 0x4a, 0xae, 0x50, 0xfa, 0x3b, 0x61, 0x28, 0xbf, 0x1d, 0x49, 0x4e, 0x94, 0x37, 0x61, 0xda,
+	0x33, 0x87, 0x4c, 0x62, 0x29, 0x0a, 0x84, 0x54, 0xd8, 0x42, 0x76, 0xd3, 0xd2, 0x7b, 0x8e, 0x69,
+	0xb9, 0x0b, 0x15, 0xd3, 0x13, 0xf7, 0x60, 0xae, 0x67, 0xa1, 0x03, 0xe4, 0x34, 0xdb, 0x48, 0x73,
+	0x7d, 0x93, 0x7a, 0x44, 0xb0, 0xe2, 0x00, 0x82, 0xb9, 0x51, 0xfa, 0x36, 0xb6, 0x1a, 0xf7, 0xda,
+	0x72, 0xf6, 0x91, 0xea, 0x34, 0x8e, 0x8d, 0x44, 0x36, 0x2b, 0x29, 0xc3, 0x3c, 0xe2, 0x5b, 0x95,
+	0x13, 0x57, 0x53, 0xde, 0x2b, 0x52, 0x5d, 0xfa, 0x32, 0xcc, 0x07, 0xfb, 0x91, 0xe4, 0x18, 0xfd,
+	0xab, 0x00, 0xb3, 0x57, 0x36, 0x13, 0xb0, 0xed, 0x0b, 0x3c, 0xb3, 0x8c, 0x77, 0xbc, 0xd7, 0x0c,
+	0xfe, 0x85, 0x17, 0x09, 0x37, 0xe1, 0x20, 0x5a, 0x65, 0x0d, 0xd2, 0x54, 0x28, 0x9e, 0x85, 0x14,
+	0x59, 0x59, 0x84, 0xe0, 0xca, 0x42, 0x64, 0x78, 0xa4, 0xcc, 0x3a, 0xae, 0x7f, 0x1e, 0xc1, 0x87,
+	0x03, 0x25, 0xe9, 0x26, 0x00, 0xe9, 0x44, 0x92, 0xfe, 0xfb, 0x4e, 0x0a, 0x0a, 0x3b, 0x7d, 0xbb,
+	0x9d, 0xcc, 0x00, 0xd9, 0x04, 0xe8, 0x61, 0x30, 0x3c, 0x71, 0xc9, 0xa9, 0xd1, 0xe4, 0x38, 0xa7,
+	0x46, 0xae, 0x95, 0x4c, 0x0f, 0x77, 0x43, 0xfc, 0x22, 0x07, 0x41, 0xca, 0xe0, 0xe8, 0xa9, 0x1c,
+	0x05, 0x72, 0x8c, 0x17, 0x3d, 0x47, 0x0d, 0x00, 0x20, 0x02, 0xf0, 0x3a, 0xcc, 0x90, 0x0f, 0xbc,
+	0xb3, 0xe1, 0x7c, 0x3d, 0x8e, 0x9b, 0xa7, 0x89, 0x4a, 0xc3, 0x74, 0xc7, 0x78, 0xfa, 0x91, 0xc6,
+	0xb8, 0xb8, 0x01, 0xb3, 0xac, 0xc9, 0x7b, 0x3d, 0x54, 0x9a, 0xc6, 0xba, 0x85, 0x48, 0xbb, 0xb9,
+	0xa7, 0x1b, 0xb8, 0x96, 0x9b, 0x3a, 0xd2, 0x66, 0xf1, 0x37, 0x39, 0x6a, 0x3a, 0xe5, 0x45, 0x22,
+	0xc9, 0x15, 0x6a, 0x33, 0xe0, 0xcf, 0x47, 0x0f, 0x0a, 0xf1, 0xa9, 0xf4, 0x0f, 0x01, 0xe6, 0x39,
+	0x89, 0xb3, 0x65, 0x37, 0x81, 0xd1, 0x82, 0x03, 0xcd, 0xb3, 0xa0, 0x41, 0xc7, 0xc6, 0x08, 0x34,
+	0xd3, 0x21, 0x81, 0xae, 0xc2, 0x34, 0x8e, 0x84, 0xd3, 0x67, 0xfc, 0x50, 0x58, 0x3f, 0x7f, 0xb2,
+	0x55, 0xbb, 0xb4, 0xae, 0x1b, 0x6f, 0xa6, 0x49, 0x92, 0xc8, 0x9e, 0xa9, 0xdb, 0xa6, 0x11, 0xe0,
+	0x0e, 0x2e, 0x93, 0xbe, 0x02, 0x0b, 0x43, 0x56, 0x27, 0x39, 0xf9, 0xfe, 0x29, 0xc0, 0xd9, 0x20,
+	0x7c, 0x42, 0x5b, 0xfc, 0xff, 0x01, 0xcf, 0x16, 0x20, 0xb7, 0x6d, 0x9a, 0x1e, 0x19, 0x4b, 0x79,
+	0xc8, 0xb2, 0x6f, 0x6a, 0xbc, 0xa4, 0x42, 0x39, 0xca, 0x33, 0x49, 0x7a, 0xff, 0xeb, 0x90, 0x4b,
+	0x28, 0x09, 0x7b, 0xcc, 0x53, 0xbc, 0x06, 0xe4, 0x3f, 0x85, 0xac, 0xed, 0xa7, 0x38, 0x6b, 0x6b,
+	0x58, 0x7d, 0xa3, 0xa9, 0x3a, 0x38, 0xe1, 0x69, 0x25, 0x60, 0x5d, 0x19, 0xd2, 0xba, 0xa1, 0xa1,
+	0x63, 0x6a, 0xdd, 0x94, 0x6b, 0x03, 0x15, 0xe1, 0x0d, 0x7a, 0x86, 0x66, 0x2c, 0x8a, 0xae, 0xd1,
+	0xa1, 0x92, 0xaa, 0x96, 0x49, 0xf1, 0x47, 0x0f, 0x2b, 0x33, 0x34, 0x64, 0xf5, 0xad, 0x8f, 0x07,
+	0x3f, 0x71, 0x4a, 0x46, 0x7f, 0x68, 0xd2, 0xbb, 0x70, 0x3a, 0xd0, 0xc7, 0x24, 0x1d, 0xf0, 0x2d,
+	0xec, 0x80, 0x6b, 0xf4, 0x27, 0xfe, 0x6f, 0x27, 0x14, 0xde, 0x0e, 0x81, 0x3a, 0x21, 0xbc, 0xb4,
+	0x29, 0xd7, 0x35, 0xb4, 0x32, 0xb1, 0x31, 0xd0, 0x8d, 0x24, 0x6d, 0xfc, 0x97, 0x40, 0x0e, 0xb9,
+	0xbb, 0xbd, 0xbe, 0x83, 0xe8, 0x79, 0x83, 0xdd, 0xef, 0x26, 0x60, 0x27, 0x4e, 0xa4, 0x49, 0xc6,
+	0x8c, 0x27, 0x34, 0xb5, 0x34, 0xef, 0x26, 0xd2, 0x5c, 0x28, 0x1e, 0xe0, 0x4d, 0x21, 0x6f, 0xcd,
+	0x8d, 0x77, 0xae, 0x5a, 0x23, 0x75, 0xfe, 0xf0, 0xb0, 0xb2, 0xd6, 0xd2, 0x9d, 0x76, 0x7f, 0x1f,
+	0xb7, 0xd6, 0x5d, 0xf3, 0x5a, 0xd4, 0xf6, 0xd7, 0x86, 0x2e, 0xa3, 0xfa, 0x7d, 0x5d, 0x5b, 0xdd,
+	0xdb, 0xab, 0x6f, 0xe1, 0x21, 0x02, 0x6e, 0xdf, 0xf1, 0xd0, 0x00, 0x17, 0xb9, 0xae, 0x89, 0xcb,
+	0x90, 0xb1, 0x0d, 0xb5, 0x67, 0xb7, 0xcd, 0xe0, 0xe6, 0xd0, 0x93, 0x4a, 0xef, 0xc3, 0x62, 0xc8,
+	0xfc, 0x24, 0xfd, 0xfb, 0xcb, 0x49, 0x58, 0xb8, 0x85, 0x2c, 0xfd, 0xe0, 0xde, 0xff, 0xa1, 0x7b,
+	0xcb, 0x90, 0x71, 0xbf, 0xa8, 0x7b, 0x73, 0xb2, 0xf7, 0x8d, 0x99, 0x63, 0xe0, 0x7a, 0x96, 0x03,
+	0x3d, 0x1d, 0xb9, 0x07, 0x39, 0x70, 0x76, 0x79, 0xb5, 0x2d, 0xd5, 0x51, 0x7d, 0x91, 0x79, 0x0f,
+	0xce, 0x0c, 0x3b, 0x2e, 0xc9, 0xc0, 0xfc, 0x0a, 0xf3, 0x06, 0x0f, 0xc5, 0x9e, 0x41, 0x9c, 0xb6,
+	0x06, 0xa9, 0x16, 0x72, 0x38, 0xe4, 0x53, 0x51, 0x69, 0xbb, 0x77, 0x1b, 0x29, 0x93, 0x9a, 0x44,
+	0x01, 0x8f, 0x1b, 0x3e, 0x95, 0x9f, 0x8a, 0x4c, 0xd2, 0x06, 0x0a, 0xb8, 0xa6, 0x78, 0x13, 0xc8,
+	0x8e, 0xd3, 0xbd, 0x4f, 0x52, 0x88, 0x72, 0x2a, 0xf6, 0x18, 0x28, 0xf2, 0xea, 0x4c, 0x2e, 0x34,
+	0x03, 0x62, 0x92, 0x2e, 0x0e, 0x2e, 0x46, 0xa6, 0x62, 0xdd, 0x3c, 0x7c, 0x17, 0xe3, 0xbb, 0x37,
+	0x11, 0x5f, 0x81, 0x69, 0x7e, 0x6c, 0xcf, 0xc2, 0xb4, 0x1c, 0xa1, 0x1f, 0xb8, 0xdb, 0x90, 0x79,
+	0x7d, 0xf1, 0x2a, 0xe4, 0xd8, 0x2f, 0xb6, 0xd7, 0xa4, 0xe9, 0x6a, 0x76, 0xfd, 0x42, 0xbc, 0xbe,
+	0x2f, 0x29, 0x91, 0xb3, 0xda, 0x40, 0x26, 0xae, 0xc3, 0x94, 0xdd, 0x54, 0x8d, 0xd2, 0x4c, 0x6c,
+	0x4e, 0xe9, 0x3b, 0x8a, 0x96, 0x69, 0x5d, 0xf1, 0x36, 0xcc, 0xed, 0x93, 0xa3, 0x46, 0xc5, 0x19,
+	0xa4, 0x0f, 0xa5, 0x0c, 0x05, 0xb8, 0x1c, 0x01, 0x10, 0x73, 0xd8, 0x29, 0x17, 0xf7, 0x87, 0x0a,
+	0x48, 0x98, 0x90, 0xa1, 0x05, 0x60, 0x67, 0x63, 0xc3, 0x14, 0x79, 0x16, 0x29, 0x17, 0x50, 0x40,
+	0x2c, 0xd6, 0x20, 0xab, 0x92, 0xb3, 0x15, 0x85, 0x1e, 0x0c, 0x95, 0x80, 0xc2, 0x45, 0xa5, 0x42,
+	0xa1, 0x23, 0x2a, 0x19, 0x54, 0x4f, 0x34, 0x80, 0xe9, 0x12, 0xb6, 0x2f, 0x65, 0x4f, 0x86, 0xf1,
+	0xe7, 0x24, 0x1c, 0x86, 0x8a, 0xc4, 0xb7, 0x21, 0xdf, 0x76, 0xf7, 0xd1, 0x34, 0xaf, 0xcb, 0x51,
+	0xa0, 0x95, 0x08, 0xa0, 0x88, 0x7d, 0xbf, 0x9c, 0x6b, 0xfb, 0x84, 0xe2, 0x73, 0x30, 0xd9, 0x6a,
+	0x96, 0xf2, 0xb1, 0xbb, 0x1c, 0x6f, 0xb3, 0x2b, 0xe3, 0x7a, 0x78, 0x73, 0x9c, 0x61, 0xdb, 0x1b,
+	0xdc, 0x6a, 0x21, 0x76, 0xf2, 0x06, 0xf7, 0x91, 0x32, 0xdd, 0x84, 0x91, 0xb6, 0xf0, 0x80, 0x63,
+	0x39, 0x42, 0x87, 0x9e, 0xbf, 0x94, 0x4e, 0xc5, 0x0e, 0xb8, 0xf0, 0x69, 0x93, 0x9c, 0xb5, 0x06,
+	0x32, 0x71, 0x1b, 0x0a, 0xfc, 0x8c, 0x91, 0x9f, 0x0c, 0x95, 0x8a, 0x14, 0xeb, 0x99, 0xe8, 0xa5,
+	0x24, 0xb4, 0x5b, 0x91, 0xf3, 0x96, 0x5f, 0x2a, 0xbe, 0x0f, 0xf3, 0x41, 0x3c, 0x3e, 0x25, 0xe6,
+	0x28, 0xea, 0x73, 0x23, 0x51, 0xfd, 0x33, 0x43, 0xb4, 0x42, 0x45, 0x38, 0x3b, 0x4a, 0xb3, 0x98,
+	0x8b, 0x14, 0xb0, 0x12, 0x01, 0x18, 0x08, 0x37, 0xab, 0x4d, 0x1c, 0xe6, 0xf0, 0xec, 0x08, 0xfb,
+	0xac, 0x55, 0x3a, 0x1d, 0xeb, 0xb0, 0x70, 0xa2, 0x27, 0x67, 0x9d, 0x81, 0x8c, 0x20, 0x75, 0xe8,
+	0xc2, 0xa9, 0xb0, 0x04, 0x66, 0x3e, 0x16, 0x29, 0x9c, 0x31, 0xc9, 0xd9, 0xce, 0x40, 0x46, 0x83,
+	0xc8, 0xce, 0xd3, 0x14, 0x3a, 0xe7, 0x17, 0xe2, 0x83, 0x18, 0xba, 0x85, 0xc2, 0x41, 0x1c, 0xc8,
+	0xc4, 0x06, 0x39, 0xdf, 0xa3, 0xdc, 0xad, 0x78, 0x34, 0x74, 0x86, 0xa2, 0x5d, 0x8a, 0x5c, 0x50,
+	0xa3, 0xb2, 0x1c, 0x72, 0x08, 0x18, 0x90, 0x93, 0xe9, 0x7f, 0x48, 0x79, 0x67, 0x00, 0xba, 0x18,
+	0x3b, 0xfd, 0x23, 0xa9, 0x5d, 0x2e, 0x1c, 0x06, 0xc4, 0x64, 0xa9, 0xa2, 0x58, 0x4a, 0x73, 0x70,
+	0x9b, 0x53, 0x2a, 0xc5, 0x2e, 0x55, 0x31, 0x37, 0x4e, 0x72, 0xb1, 0x39, 0x54, 0x40, 0xd6, 0x4d,
+	0x03, 0xef, 0x75, 0x4a, 0x67, 0x63, 0xd7, 0x4d, 0xdf, 0x56, 0x48, 0xa6, 0x75, 0xc9, 0x14, 0xd4,
+	0x0d, 0xdd, 0xa1, 0xf4, 0x53, 0x8e, 0x9d, 0x82, 0xc1, 0x87, 0x09, 0xf2, 0x8c, 0xce, 0xbe, 0x5f,
+	0x9b, 0xba, 0xff, 0x61, 0x45, 0x90, 0x7e, 0x57, 0x80, 0xbc, 0xcb, 0xb0, 0x8c, 0x3d, 0x5f, 0xf0,
+	0xb3, 0xe7, 0x52, 0x1c, 0x7b, 0x32, 0x0d, 0x46, 0x9f, 0x2f, 0xf8, 0xe9, 0x73, 0x29, 0x8e, 0x3e,
+	0x5d, 0x0d, 0xc2, 0x9f, 0x72, 0x1c, 0x7f, 0x5e, 0x1a, 0x83, 0x3f, 0x39, 0xd0, 0x30, 0x81, 0x56,
+	0xc3, 0x04, 0x7a, 0xfe, 0x64, 0x02, 0xe5, 0x40, 0x3e, 0x06, 0x7d, 0x75, 0x88, 0x41, 0xcf, 0x9d,
+	0xc0, 0xa0, 0x5c, 0xdb, 0xa5, 0xd0, 0x7a, 0x24, 0x85, 0xae, 0x8c, 0xa2, 0x50, 0x8e, 0x12, 0xe0,
+	0xd0, 0x17, 0x03, 0x1c, 0x5a, 0x89, 0xe5, 0x50, 0xae, 0xcb, 0x48, 0xf4, 0x4e, 0x3c, 0x89, 0x3e,
+	0x3b, 0x16, 0x89, 0x72, 0xb4, 0x30, 0x8b, 0xca, 0x71, 0x2c, 0x7a, 0x69, 0x0c, 0x16, 0x75, 0x83,
+	0x35, 0x44, 0xa3, 0x6f, 0x45, 0xd1, 0xe8, 0x85, 0x11, 0x34, 0xca, 0xb1, 0xfc, 0x3c, 0xfa, 0x56,
+	0x14, 0x8f, 0x5e, 0x18, 0xc1, 0xa3, 0x01, 0x1c, 0x46, 0xa4, 0xd7, 0xa2, 0x89, 0xf4, 0x99, 0x91,
+	0x44, 0xca, 0xb1, 0x82, 0x4c, 0xfa, 0xbc, 0x8f, 0x49, 0x9f, 0x8a, 0x61, 0x52, 0xae, 0x48, 0xa8,
+	0xf4, 0x8d, 0x10, 0x95, 0x4a, 0x27, 0x51, 0x29, 0xd7, 0xf4, 0xb8, 0xb4, 0x1e, 0xc9, 0xa5, 0x2b,
+	0xa3, 0xb8, 0xd4, 0x1d, 0x79, 0x7e, 0x32, 0xbd, 0x11, 0x43, 0xa6, 0x17, 0x47, 0x93, 0x29, 0x87,
+	0x1b, 0x62, 0x53, 0xe5, 0x44, 0x36, 0x7d, 0x7e, 0x4c, 0x36, 0xe5, 0xd8, 0x51, 0x74, 0xfa, 0xf9,
+	0x20, 0x9d, 0x2e, 0xc7, 0xd3, 0x29, 0x07, 0xe1, 0x7c, 0x5a, 0x8f, 0xe4, 0xd3, 0x95, 0x51, 0x7c,
+	0xea, 0x3a, 0xcd, 0x4f, 0xa8, 0xf5, 0x48, 0x42, 0x5d, 0x19, 0x45, 0xa8, 0x2e, 0x94, 0x9f, 0x51,
+	0xeb, 0x91, 0x8c, 0xba, 0x32, 0x8a, 0x51, 0xbd, 0x50, 0xfa, 0x28, 0x75, 0x2f, 0x96, 0x52, 0x2f,
+	0x8f, 0x43, 0xa9, 0x1c, 0x32, 0xc4, 0xa9, 0x72, 0x1c, 0xa7, 0x5e, 0x1a, 0x83, 0x53, 0xdd, 0xc5,
+	0x60, 0x88, 0x54, 0xef, 0xc4, 0x93, 0xea, 0xb3, 0x63, 0x91, 0xaa, 0xbb, 0x74, 0x85, 0x58, 0xf5,
+	0xc5, 0x00, 0xab, 0x56, 0x62, 0x59, 0xd5, 0x5d, 0x49, 0x29, 0xad, 0xbe, 0x11, 0xa2, 0x55, 0xe9,
+	0x24, 0x5a, 0x75, 0xa7, 0x63, 0x90, 0x57, 0xff, 0x96, 0x82, 0xe9, 0xab, 0xee, 0x75, 0xa0, 0xef,
+	0x92, 0x47, 0x78, 0x8c, 0x4b, 0x1e, 0x71, 0x8b, 0xdc, 0x66, 0xe2, 0xf5, 0xae, 0xa9, 0x72, 0x92,
+	0x3d, 0x1f, 0x39, 0x22, 0x68, 0x8d, 0xd0, 0x35, 0xa0, 0xab, 0xfa, 0x98, 0xe7, 0x72, 0x98, 0x13,
+	0xf3, 0x7d, 0x1b, 0x0f, 0xee, 0x9e, 0xa5, 0x9b, 0x96, 0xee, 0xdc, 0xa3, 0xdc, 0x2a, 0x54, 0xe7,
+	0x89, 0x2e, 0x56, 0xc8, 0xed, 0xe1, 0xc2, 0x1d, 0x5e, 0x26, 0xe7, 0xfa, 0xbe, 0x2f, 0xf7, 0xa9,
+	0x70, 0x7a, 0xec, 0xa7, 0xc2, 0x38, 0xbf, 0x2a, 0x5a, 0xd8, 0x6b, 0x81, 0x91, 0xc0, 0xee, 0x4e,
+	0xa2, 0x27, 0x81, 0xaa, 0xf9, 0xc2, 0xed, 0xbb, 0x43, 0x39, 0x65, 0x05, 0x8b, 0x70, 0x7e, 0x95,
+	0x26, 0x6f, 0x9e, 0x11, 0x27, 0x55, 0x7f, 0x00, 0xc8, 0x21, 0xc9, 0x2a, 0x7f, 0x10, 0x4d, 0xcf,
+	0x69, 0x64, 0x56, 0x95, 0x3c, 0x4c, 0x20, 0x57, 0xd3, 0x64, 0x26, 0x7a, 0x4f, 0x9e, 0x32, 0xbe,
+	0x57, 0x0f, 0x05, 0x5c, 0xca, 0x27, 0x20, 0x7d, 0xf6, 0xf4, 0x23, 0x01, 0x72, 0x55, 0xd5, 0x69,
+	0xb6, 0xdd, 0x83, 0xa1, 0xd7, 0x87, 0x8e, 0x37, 0xce, 0x46, 0xd3, 0x49, 0xf4, 0x1d, 0xcd, 0x06,
+	0x0e, 0x17, 0xc3, 0x71, 0xef, 0x91, 0x2b, 0x91, 0x2e, 0x18, 0x1c, 0x7c, 0xb8, 0x47, 0x62, 0xae,
+	0xda, 0x6b, 0x53, 0x3f, 0xfe, 0xb0, 0x32, 0x21, 0xfd, 0x22, 0x05, 0x79, 0xde, 0x2d, 0x7e, 0xec,
+	0x52, 0x1f, 0xea, 0x57, 0x14, 0xcd, 0x05, 0x34, 0xe2, 0x7b, 0xb9, 0x05, 0xb3, 0x16, 0xaf, 0xe4,
+	0x76, 0x73, 0xf9, 0x84, 0x43, 0x1c, 0x7f, 0x3f, 0x07, 0x8a, 0xe5, 0xef, 0x4f, 0x7a, 0xb3, 0x65,
+	0x15, 0xd2, 0xf4, 0x09, 0x3c, 0xef, 0x5a, 0xd4, 0xc1, 0x6a, 0x8d, 0x94, 0xcb, 0xac, 0x1a, 0x99,
+	0x5d, 0x8d, 0x4f, 0x74, 0x85, 0xfa, 0xe8, 0x0f, 0xda, 0xc5, 0x67, 0x48, 0xfa, 0xda, 0xe9, 0xa0,
+	0xa6, 0x83, 0x34, 0xfe, 0x5c, 0x67, 0x8a, 0x3e, 0x6f, 0x29, 0x78, 0x62, 0xfa, 0x24, 0xe7, 0xf1,
+	0x6e, 0x0e, 0x79, 0xd8, 0x1e, 0x08, 0x90, 0x25, 0x87, 0x6a, 0xe4, 0xd5, 0x8b, 0x6a, 0x68, 0x81,
+	0xe9, 0x2b, 0x8c, 0x3f, 0x7d, 0x6f, 0x42, 0x01, 0x4f, 0x46, 0x92, 0x18, 0x3e, 0xfe, 0x12, 0x92,
+	0x67, 0x08, 0xbc, 0x58, 0x7c, 0x19, 0x52, 0xcd, 0xae, 0xc6, 0x1d, 0x56, 0x89, 0x1f, 0x3b, 0x74,
+	0x14, 0xba, 0x86, 0x61, 0x8d, 0xcb, 0xd7, 0xc8, 0xb3, 0xc0, 0xd0, 0x94, 0x15, 0x0b, 0x00, 0x9b,
+	0x37, 0xb6, 0x77, 0xeb, 0xbb, 0x8d, 0xda, 0x76, 0xa3, 0x38, 0x21, 0xe6, 0x61, 0x96, 0x7c, 0xd7,
+	0xb6, 0x77, 0xf7, 0x76, 0x8b, 0x82, 0x58, 0x84, 0x5c, 0x7d, 0xdb, 0x57, 0x61, 0xb2, 0x3c, 0xf5,
+	0xdd, 0x9f, 0x2d, 0x4d, 0x5c, 0xbe, 0x4d, 0x9e, 0xba, 0x7b, 0x97, 0xa7, 0xa2, 0x08, 0x85, 0x9d,
+	0xbd, 0xdd, 0xab, 0x4a, 0xa3, 0x7e, 0xbd, 0xb6, 0xdb, 0xd8, 0xb8, 0xbe, 0x83, 0x91, 0x30, 0x32,
+	0x95, 0x6d, 0x54, 0x6f, 0xc8, 0x0d, 0x0c, 0xe5, 0x7e, 0x37, 0x6e, 0xec, 0x6d, 0x5e, 0x2d, 0x4e,
+	0x7a, 0xdf, 0x37, 0xf7, 0x6a, 0xf2, 0x3b, 0xc5, 0x14, 0x03, 0x5e, 0xbf, 0x03, 0x19, 0xf7, 0xe9,
+	0x16, 0x4e, 0x0c, 0xd3, 0xd4, 0x1a, 0x71, 0x94, 0x9d, 0xe5, 0xe5, 0x51, 0x93, 0x48, 0xa2, 0xc8,
+	0xb5, 0xe3, 0x4f, 0x03, 0xb9, 0x7a, 0xee, 0xfe, 0x9f, 0x96, 0x26, 0xee, 0x7f, 0xb4, 0x24, 0x3c,
+	0xc0, 0x7f, 0xbf, 0xc7, 0x7f, 0x7f, 0xc4, 0x7f, 0x3f, 0xf8, 0xf3, 0xd2, 0xc4, 0xbb, 0x33, 0x5c,
+	0xe5, 0x4e, 0xfa, 0xdf, 0x01, 0x00, 0x00, 0xff, 0xff, 0xf2, 0x4b, 0x70, 0xde, 0xbd, 0x32, 0x00,
 	0x00,
 }

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -101,6 +101,20 @@ message ConditionalPutResponse {
   optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
 }
 
+// An InitPutRequest is the argument to the InitPut() method.
+//
+// - If key doesn't exist, sets value.
+// - If key exists, returns an error if value != existing value.
+message InitPutRequest {
+  optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  optional Value value = 2 [(gogoproto.nullable) = false];
+}
+
+// A InitPutResponse is the return value from the InitPut() method.
+message InitPutResponse {
+  optional ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+}
+
 // An IncrementRequest is the argument to the Increment() method. It
 // increments the value for key, and returns the new value. If no
 // value exists for a key, incrementing by 0 is not a noop, but will
@@ -588,6 +602,7 @@ message RequestUnion {
   optional GetRequest get = 1;
   optional PutRequest put = 2;
   optional ConditionalPutRequest conditional_put = 3;
+  optional InitPutRequest init_put = 26;
   optional IncrementRequest increment = 4;
   optional DeleteRequest delete = 5;
   optional DeleteRangeRequest delete_range = 6;
@@ -620,6 +635,7 @@ message ResponseUnion {
   optional GetResponse get = 1;
   optional PutResponse put = 2;
   optional ConditionalPutResponse conditional_put = 3;
+  optional InitPutResponse init_put = 26;
   optional IncrementResponse increment = 4;
   optional DeleteResponse delete = 5;
   optional DeleteRangeResponse delete_range = 6;

--- a/roachpb/method.go
+++ b/roachpb/method.go
@@ -111,4 +111,8 @@ const (
 	// CheckConsistency verifies the consistency of all ranges falling within a
 	// key span.
 	CheckConsistency
+	// InitPut sets the value for a key if the key doesn't exist. It returns
+	// an error if the key exists and the existing value is different from the
+	// supplied one.
+	InitPut
 )

--- a/roachpb/method_string.go
+++ b/roachpb/method_string.go
@@ -4,9 +4,9 @@ package roachpb
 
 import "fmt"
 
-const _Method_name = "GetPutConditionalPutIncrementDeleteDeleteRangeScanReverseScanBeginTransactionEndTransactionAdminSplitAdminMergeHeartbeatTxnGCPushTxnRangeLookupResolveIntentResolveIntentRangeNoopMergeTruncateLogLeaderLeaseComputeChecksumVerifyChecksumCheckConsistency"
+const _Method_name = "GetPutConditionalPutIncrementDeleteDeleteRangeScanReverseScanBeginTransactionEndTransactionAdminSplitAdminMergeHeartbeatTxnGCPushTxnRangeLookupResolveIntentResolveIntentRangeNoopMergeTruncateLogLeaderLeaseComputeChecksumVerifyChecksumCheckConsistencyInitPut"
 
-var _Method_index = [...]uint8{0, 3, 6, 20, 29, 35, 46, 50, 61, 77, 91, 101, 111, 123, 125, 132, 143, 156, 174, 178, 183, 194, 205, 220, 234, 250}
+var _Method_index = [...]uint16{0, 3, 6, 20, 29, 35, 46, 50, 61, 77, 91, 101, 111, 123, 125, 132, 143, 156, 174, 178, 183, 194, 205, 220, 234, 250, 257}
 
 func (i Method) String() string {
 	if i < 0 || i >= Method(len(_Method_index)-1) {

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -19,6 +19,7 @@ package engine
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -1225,6 +1226,45 @@ func MVCCConditionalPut(
 		}
 		return value.RawBytes, nil
 	})
+}
+
+var errInitPutValueMatchesExisting = errors.New("the value matched the existing value")
+
+// MVCCInitPut sets the value for a specified key if the key doesn't exist. It
+// returns an error when the write fails or if the key exists with an
+// existing value that is different from the supplied value.
+func MVCCInitPut(
+	ctx context.Context,
+	engine Engine,
+	ms *MVCCStats,
+	key roachpb.Key,
+	timestamp roachpb.Timestamp,
+	value roachpb.Value,
+	txn *roachpb.Transaction,
+) error {
+	iter := engine.NewIterator(key)
+	defer iter.Close()
+
+	err := mvccPutUsingIter(ctx, engine, iter, ms, key, timestamp, noValue, txn,
+		func(existVal *roachpb.Value) ([]byte, error) {
+			if existVal != nil {
+				if !bytes.Equal(value.RawBytes, existVal.RawBytes) {
+					return nil, &roachpb.ConditionFailedError{
+						ActualValue: existVal.ShallowClone(),
+					}
+				}
+				// The existing value matches the supplied value; return an error
+				// to prevent rewriting the value.
+				return nil, errInitPutValueMatchesExisting
+			}
+			return value.RawBytes, nil
+		},
+	)
+	// Dummy error to prevent an unnecessary write.
+	if err == errInitPutValueMatchesExisting {
+		err = nil
+	}
+	return err
 }
 
 // MVCCMerge implements a merge operation. Merge adds integer values,

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -96,6 +96,10 @@ func (r *Replica) executeCmd(ctx context.Context, raftCmdID storagebase.CmdIDKey
 		var resp roachpb.ConditionalPutResponse
 		resp, err = r.ConditionalPut(ctx, batch, ms, h, *tArgs)
 		reply = &resp
+	case *roachpb.InitPutRequest:
+		var resp roachpb.InitPutResponse
+		resp, err = r.InitPut(ctx, batch, ms, h, *tArgs)
+		reply = &resp
 	case *roachpb.IncrementRequest:
 		var resp roachpb.IncrementResponse
 		resp, err = r.Increment(ctx, batch, ms, h, *tArgs)
@@ -220,6 +224,21 @@ func (r *Replica) ConditionalPut(
 	var reply roachpb.ConditionalPutResponse
 
 	return reply, engine.MVCCConditionalPut(ctx, batch, ms, args.Key, h.Timestamp, args.Value, args.ExpValue, h.Txn)
+}
+
+// InitPut sets the value for a specified key only if it doesn't exist. It
+// returns an error if the key exists with an existing value that is different
+// from the value provided.
+func (r *Replica) InitPut(
+	ctx context.Context,
+	batch engine.Engine,
+	ms *engine.MVCCStats,
+	h roachpb.Header,
+	args roachpb.InitPutRequest,
+) (roachpb.InitPutResponse, error) {
+	var reply roachpb.InitPutResponse
+
+	return reply, engine.MVCCInitPut(ctx, batch, ms, args.Key, h.Timestamp, args.Value, h.Txn)
 }
 
 // Increment increments the value (interpreted as varint64 encoded) and


### PR DESCRIPTION
InitPut(key, value) puts the value for the key if it doesn't exist.
It returns an error if the key exists and the existing value for the
key is not equal to the supplied value. This method will be used to
backfill a sql table index.

Another option to add a boolen to CPut() was considered, but during
the implementation that option looked so ugly, especially given the beauty
of CPut, that we decided to create a new method. This decision was also
influenced by an unwillingness to adopt the bad practice of putting
booleans in an API.

See: http://ariya.ofilabs.com/2011/08/hall-of-api-shame-boolean-trap.html

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6072)

<!-- Reviewable:end -->
