### PR TITLE
ci: log stderr in acceptance-deploy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -65,8 +65,8 @@ deployment:
       - mkdir -p "${CIRCLE_ARTIFACTS}/acceptance_deploy"
       - time acceptance/acceptance.test -test.v -test.timeout 10m
           -i cockroachdb/cockroach -nodes 3
-          -l "${CIRCLE_ARTIFACTS}"/acceptance_deploy 2>&1 >
-          "${CIRCLE_ARTIFACTS}/acceptance_deploy.log"
+          -l "${CIRCLE_ARTIFACTS}"/acceptance_deploy >
+          "${CIRCLE_ARTIFACTS}/acceptance_deploy.log" 2>&1
 
       - build/build-osx.sh
       - build/push-tagged-aws.sh


### PR DESCRIPTION
This was previously only sending stdout to the log file and redirected stderr
to (pre-redirect) stdout.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6074)

<!-- Reviewable:end -->
