### PR TITLE
kv: avoid pretty-printing keys during noop tracing

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -425,7 +425,17 @@ func (ds *DistSender) getDescriptors(
 func (ds *DistSender) sendSingleRange(
 	ctx context.Context, ba roachpb.BatchRequest, desc *roachpb.RangeDescriptor,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
-	log.Trace(ctx, fmt.Sprintf("sending RPC to [%s, %s)", desc.StartKey, desc.EndKey))
+	// Hack: avoid formatting the message passed to Span.LogEvent for
+	// opentracing.noopSpans. We can't actually tell if we have a noopSpan, but
+	// we can see if the span as a NoopTracer. Note that this particular
+	// invocation is expensive because we're pretty-printing keys.
+	//
+	// TODO(tschottdorf): This hack can go away when something like
+	// Span.LogEventf is added.
+	sp := opentracing.SpanFromContext(ctx)
+	if sp != nil && sp.Tracer() != (opentracing.NoopTracer{}) {
+		sp.LogEvent(fmt.Sprintf("sending RPC to [%s, %s)", desc.StartKey, desc.EndKey))
+	}
 
 	// Try to send the call.
 	replicas := newReplicaSlice(ds.gossip, desc)


### PR DESCRIPTION
Key pretty-printing involves a number of allocations and isn't
particularly fast.

```
name              old time/op    new time/op    delta
KVScan1_Native-8    52.1µs ± 2%    45.3µs ± 2%  -12.91%  (p=0.000 n=10+10)
KVScan1_SQL-8        184µs ± 1%     172µs ± 2%   -6.63%   (p=0.000 n=10+9)

name              old alloc/op   new alloc/op   delta
KVScan1_Native-8    7.39kB ± 0%    6.95kB ± 0%   -5.88%    (p=0.001 n=8+9)
KVScan1_SQL-8       12.4kB ± 0%    12.0kB ± 0%   -3.49%   (p=0.000 n=9+10)

name              old allocs/op  new allocs/op  delta
KVScan1_Native-8       117 ± 0%       103 ± 0%  -11.97%  (p=0.000 n=10+10)
KVScan1_SQL-8          229 ± 0%       215 ± 0%   -6.11%  (p=0.000 n=10+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6088)

<!-- Reviewable:end -->
