### PR TITLE
sql: Clarify the output of SQL tests.

### DIFF
--- a/sql/descriptor_mutation_test.go
+++ b/sql/descriptor_mutation_test.go
@@ -79,16 +79,16 @@ func (mt mutationTest) checkQueryResponse(q string, e [][]string) int {
 					s = fmt.Sprint(val)
 				}
 				if e[i][j] != s {
-					mt.Fatalf("e:%v, v:%v", e[i][j], s)
+					mt.Fatalf("expected %v, found %v", e[i][j], s)
 				}
 				numVals++
 			} else if e[i][j] != "NULL" {
-				mt.Fatalf("e:%v, v:%v", e[i][j], "NULL")
+				mt.Fatalf("expected %v, found %v", e[i][j], "NULL")
 			}
 		}
 	}
 	if i != len(e) {
-		mt.Fatalf("fewer rows read than expected: %d, e=%v", i, e)
+		mt.Fatalf("fewer rows read than expected: found %d, expected %v", i, e)
 	}
 	return numVals
 }

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/pq"
 )
 
@@ -443,6 +444,9 @@ func TestPGPreparedQuery(t *testing.T) {
 
 	runTests := func(query string, tests []preparedQueryTest, queryFunc func(...interface{}) (*sql.Rows, error)) {
 		for _, test := range tests {
+			if testing.Verbose() || log.V(1) {
+				log.Infof("query: %s", query)
+			}
 			rows, err := queryFunc(test.params...)
 			if err != nil {
 				if test.error == "" {
@@ -642,6 +646,9 @@ func TestPGPreparedExec(t *testing.T) {
 
 	runTests := func(query string, tests []preparedExecTest, execFunc func(...interface{}) (sql.Result, error)) {
 		for _, test := range tests {
+			if testing.Verbose() || log.V(1) {
+				log.Infof("exec: %s", query)
+			}
 			if result, err := execFunc(test.params...); err != nil {
 				if test.error == "" {
 					t.Errorf("%s: %v: unexpected error: %s", query, test.params, err)
@@ -665,6 +672,9 @@ func TestPGPreparedExec(t *testing.T) {
 	}
 
 	for _, execTest := range execTests {
+		if testing.Verbose() || log.V(1) {
+			log.Infof("prepare: %s", execTest.query)
+		}
 		if stmt, err := db.Prepare(execTest.query); err != nil {
 			t.Errorf("%s: prepare error: %s", execTest.query, err)
 		} else {


### PR DESCRIPTION
Split from #5903 for discussion.

Rationale: When printing the query at the end, if there is a panic during the test you don't know which query caused the panic.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6095)

<!-- Reviewable:end -->
