### PR TITLE
sql:tests for default current_timestamp and transaction_timestamp()

### DIFF
--- a/sql/testdata/alter_table
+++ b/sql/testdata/alter_table
@@ -231,6 +231,41 @@ SELECT * from add_default WHERE a=5
 ----
 5 NULL
 
+# Add a column with a default current_timestamp()
+statement ok
+ALTER TABLE add_default ADD COLUMN c TIMESTAMP DEFAULT current_timestamp()
+
+query II
+SELECT a,b FROM add_default WHERE current_timestamp > c AND current_timestamp() - c < interval '10s'
+----
+2 42
+3 10
+5 NULL
+
+# Add a column with a default transaction_timestamp()
+statement ok
+ALTER TABLE add_default ADD COLUMN d TIMESTAMP DEFAULT transaction_timestamp()
+
+query II
+SELECT a,b FROM add_default WHERE d > c AND d - c < interval '10s'
+----
+2 42
+3 10
+5 NULL
+
+# Add a column with a default statement_timestamp()
+statement ok
+ALTER TABLE add_default ADD COLUMN e TIMESTAMP DEFAULT statement_timestamp()
+
+query II
+SELECT a,b FROM add_default WHERE e > d AND e - d < interval '10s'
+----
+2 42
+3 10
+5 NULL
+
+# Test privileges.
+
 statement ok
 CREATE TABLE privs (a INT PRIMARY KEY, b INT)
 


### PR DESCRIPTION
closes #5954

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6103)

<!-- Reviewable:end -->
