### PR TITLE
storage: do not share *roachpb.Error

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -513,8 +513,12 @@ func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) <-chan *roachp
 		// Send result of leader lease to all waiter channels.
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		for _, llChan := range r.mu.llChans {
-			llChan <- pErr
+		for i, llChan := range r.mu.llChans {
+			if i == 0 {
+				llChan <- pErr
+			} else {
+				llChan <- protoutil.Clone(pErr).(*roachpb.Error)
+			}
 		}
 		r.mu.llChans = r.mu.llChans[:0]
 	}) {


### PR DESCRIPTION
Previous code was returning the same `*roachpb.Error` to multiple
clients blocked on a LeaderLease request, which cause data races.

In the absence of similar issues present elsewhere, this fixes #6100
and fixes #6099.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6111)

<!-- Reviewable:end -->
