### PR TITLE
storage/engine: use unsafe{Key,Value} where possible

### DIFF
--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -679,7 +679,7 @@ func (r *rocksDBIterator) SeekReverse(key MVCCKey) {
 			return
 		}
 		// Make sure the current key is <= the provided key.
-		if key.Less(r.Key()) {
+		if key.Less(r.unsafeKey()) {
 			r.Prev()
 		}
 	}
@@ -936,7 +936,7 @@ func dbIterate(rdb *C.DBEngine, engine Engine, start, end MVCCKey,
 	it.Seek(start)
 	for ; it.Valid(); it.Next() {
 		k := it.Key()
-		if !it.Key().Less(end) {
+		if !k.Less(end) {
 			break
 		}
 		if done, err := f(MVCCKeyValue{Key: k, Value: it.Value()}); done || err != nil {


### PR DESCRIPTION
Use `rocksDBIterator.unsafe{Key,Value}` when we're not holding on to the
returned value passed the lifetime of the iterator/iteration.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6119)

<!-- Reviewable:end -->
