### PR TITLE
gce: make custom `cockroach` binary executable

### DIFF
--- a/cloud/gce/main.tf
+++ b/cloud/gce/main.tf
@@ -87,6 +87,7 @@ FILE
       "sudo apt-get -y install supervisor",
       "sudo service supervisor stop",
       "mkdir -p logs",
+      "chmod 755 cockroach",
       "[ $(stat --format=%s cockroach) -ne 0 ] || bash download_binary.sh cockroach/cockroach ${var.cockroach_sha}",
       "if [ ! -e supervisor.pid ]; then supervisord -c supervisor.conf; fi",
       "supervisorctl -c supervisor.conf start cockroach",


### PR DESCRIPTION
Without this, setting the `cockroach_binary` variable causes a failure
when launching CockroachDB.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6132)

<!-- Reviewable:end -->
