### PR TITLE
Fix master build break

### DIFF
--- a/acceptance/cluster/stdcopy.go
+++ b/acceptance/cluster/stdcopy.go
@@ -1,3 +1,5 @@
+// Copyright 2016 The Cockroach Authors.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/acceptance/cluster/stdcopy_test.go
+++ b/acceptance/cluster/stdcopy_test.go
@@ -1,3 +1,5 @@
+// Copyright 2016 The Cockroach Authors.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
`make check` broken due to a post-CI merge skew. A new linter was introduced;
simultaneously, a commit was merged which did not pass the linter.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6134)

<!-- Reviewable:end -->
