### PR TITLE
sql: small test fix

### DIFF
--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -110,7 +110,6 @@ func injectErrors(
 
 	switch req := req.(type) {
 	case *roachpb.ConditionalPutRequest:
-		txnID := *hdr.Txn.TxnMeta.ID
 		for key, count := range magicVals.restartCounts {
 			checkCorrectTxn(string(req.Value.RawBytes), magicVals, hdr.Txn)
 			if count > 0 && bytes.Contains(req.Value.RawBytes, []byte(key)) {
@@ -136,6 +135,7 @@ func injectErrors(
 		// keep track of the txn id so we can fail it later on.
 		for key, count := range magicVals.endTxnRestartCounts {
 			if count > 0 && bytes.Contains(req.Value.RawBytes, []byte(key)) {
+				txnID := *hdr.Txn.TxnMeta.ID
 				if _, found := magicVals.txnsToFail[txnID]; found {
 					continue
 				}


### PR DESCRIPTION
fixes #5832

The test failed with a nil ptr dereference on `*hdr.Txn.TxnMeta.ID` which I couldn't repro, but I guess could happen if a non-transactional CPut is run.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6139)

<!-- Reviewable:end -->
