### PR TITLE
util/cache: avoid allocations in baseCache list

### DIFF
--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -20,7 +20,6 @@ package cache
 
 import (
 	"bytes"
-	"container/list"
 	"fmt"
 	"sync/atomic"
 
@@ -71,7 +70,7 @@ type Config struct {
 // which defines the eviction ordering.
 type Entry struct {
 	Key, Value interface{}
-	le         *list.Element
+	next, prev *Entry
 }
 
 func (e Entry) String() string {
@@ -98,6 +97,56 @@ func (e *Entry) Range() interval.Range {
 	return e.Key.(*IntervalKey).Range
 }
 
+// entryList is a double-linked circular list of *Entry elements. The code is
+// derived from the stdlib container/list but customized to Entry in order to
+// avoid a separate allocation for every element.
+type entryList struct {
+	root Entry
+}
+
+func (l *entryList) init() {
+	l.root.next = &l.root
+	l.root.prev = &l.root
+}
+
+func (l *entryList) back() *Entry {
+	return l.root.prev
+}
+
+func (l *entryList) insertAfter(e, at *Entry) {
+	n := at.next
+	at.next = e
+	e.prev = at
+	e.next = n
+	n.prev = e
+}
+
+func (l *entryList) insertBefore(e, mark *Entry) {
+	l.insertAfter(e, mark.prev)
+}
+
+func (l *entryList) remove(e *Entry) *Entry {
+	if e == &l.root {
+		panic("cannot remove root list node")
+	}
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil // avoid memory leaks
+	e.prev = nil // avoid memory leaks
+	return e
+}
+
+func (l *entryList) pushFront(e *Entry) {
+	l.insertAfter(e, &l.root)
+}
+
+func (l *entryList) moveToFront(e *Entry) {
+	if l.root.next == e {
+		return
+	}
+	l.insertAfter(l.remove(e), &l.root)
+}
+
 // cacheStore is an interface for the backing store used for the cache.
 type cacheStore interface {
 	// init initializes or clears all entries.
@@ -117,7 +166,7 @@ type cacheStore interface {
 type baseCache struct {
 	Config
 	store cacheStore
-	ll    list.List
+	ll    entryList
 }
 
 func newBaseCache(config Config) baseCache {
@@ -129,7 +178,7 @@ func newBaseCache(config Config) baseCache {
 // init initializes the baseCache with the provided cacheStore. It must be
 // called with a non-nil cacheStore before use of the cache.
 func (bc *baseCache) init(store cacheStore) {
-	bc.ll.Init()
+	bc.ll.init()
 	bc.store = store
 	bc.store.init()
 }
@@ -156,7 +205,7 @@ func (bc *baseCache) AddEntryAfter(entry, after *Entry) {
 
 // MoveToEnd moves the entry to the end of the eviction queue.
 func (bc *baseCache) MoveToEnd(entry *Entry) {
-	bc.ll.MoveToFront(entry.le)
+	bc.ll.moveToFront(entry)
 }
 
 func (bc *baseCache) add(key, value interface{}, entry, after *Entry) {
@@ -170,9 +219,9 @@ func (bc *baseCache) add(key, value interface{}, entry, after *Entry) {
 		e = &Entry{Key: key, Value: value}
 	}
 	if after != nil {
-		e.le = bc.ll.InsertBefore(e, after.le)
+		bc.ll.insertBefore(e, after)
 	} else {
-		e.le = bc.ll.PushFront(e)
+		bc.ll.pushFront(e)
 	}
 	bc.store.add(e)
 	// Evict as many elements as we can.
@@ -205,12 +254,11 @@ func (bc *baseCache) DelEntry(entry *Entry) {
 // Clear clears all entries from the cache.
 func (bc *baseCache) Clear() {
 	if bc.OnEvicted != nil {
-		for e := bc.ll.Back(); e != nil; e = e.Prev() {
-			entry := e.Value.(*Entry)
-			bc.OnEvicted(entry.Key, entry.Value)
+		for e := bc.ll.back(); e != &bc.ll.root; e = e.prev {
+			bc.OnEvicted(e.Key, e.Value)
 		}
 	}
-	bc.ll.Init()
+	bc.ll.init()
 	bc.store.init()
 }
 
@@ -221,12 +269,12 @@ func (bc *baseCache) Len() int {
 
 func (bc *baseCache) access(e *Entry) {
 	if bc.Policy == CacheLRU {
-		bc.ll.MoveToFront(e.le)
+		bc.ll.moveToFront(e)
 	}
 }
 
 func (bc *baseCache) removeElement(e *Entry) {
-	bc.ll.Remove(e.le)
+	bc.ll.remove(e)
 	bc.store.del(e.Key)
 	if bc.OnEvicted != nil {
 		bc.OnEvicted(e.Key, e.Value)
@@ -242,8 +290,7 @@ func (bc *baseCache) evict() bool {
 	}
 	l := bc.store.length()
 	if l > 0 {
-		ele := bc.ll.Back()
-		e := ele.Value.(*Entry)
+		e := bc.ll.back()
 		if bc.ShouldEvict(l, e.Key, e.Value) {
 			bc.removeElement(e)
 			return true


### PR DESCRIPTION
Use our own circularly linked list implementation derived from
`container/list` in order to avoid a separate allocation per Entry for
the linked-list Element.

Benchmark times are unchanged. Below is a snippet of the allocation
reduction.

```
name                 old allocs/op  new allocs/op  delta
KVInsert1_SQL-8           333 ± 0%       326 ± 0%  -2.10%  (p=0.000 n=10+10)
KVInsert10_SQL-8        1.07k ± 0%     1.02k ± 0%  -4.03%    (p=0.000 n=9+9)
KVInsert100_SQL-8       8.22k ± 0%     7.82k ± 0%  -4.91%   (p=0.000 n=9+10)
KVInsert1000_SQL-8      80.2k ± 1%     76.3k ± 1%  -4.86%   (p=0.000 n=9+10)
KVInsert10000_SQL-8      903k ± 0%      840k ± 6%  -6.99%   (p=0.000 n=7+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6140)

<!-- Reviewable:end -->
