### PR TITLE
sql: batch datum allocations during decoding

### DIFF
--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -81,8 +81,13 @@ func checkEquivExpr(a, b parser.Expr, qvals qvalMap) error {
 	// The expressions above only use the values 1 and 2. Verify that the
 	// simplified expressions evaluate to the same value as the original
 	// expression for interesting values.
-	zero := parser.DInt(0)
-	for _, v := range []parser.Datum{zero, zero + 1, zero + 2, zero + 3, parser.DNull} {
+	for _, v := range []parser.Datum{
+		parser.NewDInt(0),
+		parser.NewDInt(1),
+		parser.NewDInt(2),
+		parser.NewDInt(3),
+		parser.DNull,
+	} {
 		for _, q := range qvals {
 			q.datum = v
 		}
@@ -97,7 +102,7 @@ func checkEquivExpr(a, b parser.Expr, qvals qvalMap) error {
 		// This is tricky: we don't require the expressions to produce identical
 		// results, but to either both return true or both return not true (either
 		// false or NULL).
-		if (da == parser.DBool(true)) != (db == parser.DBool(true)) {
+		if (da == parser.DBoolTrue) != (db == parser.DBoolTrue) {
 			return fmt.Errorf("%s: %s: expected %s, but found %s", a, v, da, db)
 		}
 	}

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -140,6 +140,7 @@ func convertBatchError(tableDesc *TableDescriptor, b client.Batch, origPErr *roa
 		panic(fmt.Sprintf("index %d outside of results: %+v", index, b.Results))
 	}
 	result := b.Results[index]
+	var alloc datumAlloc
 	if _, ok := origPErr.GetDetail().(*roachpb.ConditionFailedError); ok {
 		for _, row := range result.Rows {
 			indexID, key, err := decodeIndexKeyPrefix(tableDesc, row.Key)
@@ -163,7 +164,7 @@ func convertBatchError(tableDesc *TableDescriptor, b client.Batch, origPErr *roa
 				dirs = append(dirs, convertedDir)
 			}
 			vals := make([]parser.Datum, len(valTypes))
-			if _, err := decodeKeyVals(valTypes, vals, dirs, key); err != nil {
+			if _, err := decodeKeyVals(&alloc, valTypes, vals, dirs, key); err != nil {
 				return roachpb.NewError(err)
 			}
 

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -1014,9 +1014,9 @@ func (gp golangParameters) Arg(name string) (parser.Datum, bool) {
 		return t, true
 	// Time datatypes get special representation in the database.
 	case time.Time:
-		return parser.DTimestamp{Time: t}, true
+		return &parser.DTimestamp{Time: t}, true
 	case time.Duration:
-		return parser.DInterval{Duration: duration.Duration{Nanos: t.Nanoseconds()}}, true
+		return &parser.DInterval{Duration: duration.Duration{Nanos: t.Nanoseconds()}}, true
 	case *inf.Dec:
 		dd := &parser.DDecimal{}
 		dd.Set(t)
@@ -1031,19 +1031,19 @@ func (gp golangParameters) Arg(name string) (parser.Datum, bool) {
 	val := reflect.ValueOf(arg)
 	switch val.Kind() {
 	case reflect.Bool:
-		return parser.DBool(val.Bool()), true
+		return parser.MakeDBool(parser.DBool(val.Bool())), true
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return parser.DInt(val.Int()), true
+		return parser.NewDInt(parser.DInt(val.Int())), true
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return parser.DInt(val.Uint()), true
+		return parser.NewDInt(parser.DInt(val.Uint())), true
 	case reflect.Float32, reflect.Float64:
-		return parser.DFloat(val.Float()), true
+		return parser.NewDFloat(parser.DFloat(val.Float())), true
 	case reflect.String:
-		return parser.DString(val.String()), true
+		return parser.NewDString(val.String()), true
 	case reflect.Slice:
 		// Handle byte slices.
 		if val.Type().Elem().Kind() == reflect.Uint8 {
-			return parser.DBytes(val.Bytes()), true
+			return parser.NewDBytes(parser.DBytes(val.Bytes())), true
 		}
 	}
 
@@ -1056,16 +1056,16 @@ func checkResultDatum(datum parser.Datum) error {
 	}
 
 	switch datum.(type) {
-	case parser.DBool:
-	case parser.DInt:
-	case parser.DFloat:
+	case *parser.DBool:
+	case *parser.DInt:
+	case *parser.DFloat:
 	case *parser.DDecimal:
-	case parser.DBytes:
-	case parser.DString:
-	case parser.DDate:
-	case parser.DTimestamp:
-	case parser.DInterval:
-	case parser.DValArg:
+	case *parser.DBytes:
+	case *parser.DString:
+	case *parser.DDate:
+	case *parser.DTimestamp:
+	case *parser.DInterval:
+	case *parser.DValArg:
 		return fmt.Errorf("could not determine data type of %s %s", datum.Type(), datum)
 	default:
 		return util.Errorf("unsupported result type: %s", datum.Type())

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -107,9 +107,9 @@ func populateExplain(v *valuesNode, plan planNode, level int) {
 	name, description, children := plan.ExplainPlan()
 
 	row := parser.DTuple{
-		parser.DInt(level),
-		parser.DString(name),
-		parser.DString(description),
+		parser.NewDInt(parser.DInt(level)),
+		parser.NewDString(name),
+		parser.NewDString(description),
 	}
 	v.rows = append(v.rows, row)
 
@@ -165,7 +165,7 @@ type debugValues struct {
 func (vals *debugValues) AsRow() parser.DTuple {
 	keyVal := parser.DNull
 	if vals.key != "" {
-		keyVal = parser.DString(vals.key)
+		keyVal = parser.NewDString(vals.key)
 	}
 
 	// The "output" value is NULL for partial rows, or a DBool indicating if the row passed the
@@ -174,16 +174,16 @@ func (vals *debugValues) AsRow() parser.DTuple {
 
 	switch vals.output {
 	case debugValueFiltered:
-		outputVal = parser.DBool(false)
+		outputVal = parser.MakeDBool(false)
 
 	case debugValueRow:
-		outputVal = parser.DBool(true)
+		outputVal = parser.MakeDBool(true)
 	}
 
 	return parser.DTuple{
-		parser.DInt(vals.rowIdx),
+		parser.NewDInt(parser.DInt(vals.rowIdx)),
 		keyVal,
-		parser.DString(vals.value),
+		parser.NewDString(vals.value),
 		outputVal,
 	}
 }
@@ -219,14 +219,14 @@ func (n *explainDebugNode) Values() parser.DTuple {
 
 	keyVal := parser.DNull
 	if vals.key != "" {
-		keyVal = parser.DString(vals.key)
+		keyVal = parser.NewDString(vals.key)
 	}
 
 	return parser.DTuple{
-		parser.DInt(vals.rowIdx),
+		parser.NewDInt(parser.DInt(vals.rowIdx)),
 		keyVal,
-		parser.DString(vals.value),
-		parser.DString(vals.output.String()),
+		parser.NewDString(vals.value),
+		parser.NewDString(vals.output.String()),
 	}
 }
 

--- a/sql/group_test.go
+++ b/sql/group_test.go
@@ -67,7 +67,7 @@ func makeIntTestDatum(count int) []parser.Datum {
 
 	vals := make([]parser.Datum, count)
 	for i := range vals {
-		vals[i] = parser.DInt(rng.Int63())
+		vals[i] = parser.NewDInt(parser.DInt(rng.Int63()))
 	}
 	return vals
 }
@@ -77,7 +77,7 @@ func makeFloatTestDatum(count int) []parser.Datum {
 
 	vals := make([]parser.Datum, count)
 	for i := range vals {
-		vals[i] = parser.DFloat(rng.Float64())
+		vals[i] = parser.NewDFloat(parser.DFloat(rng.Float64()))
 	}
 	return vals
 }

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -73,7 +73,7 @@ func (p *planner) evalLimit(limit *parser.Limit) (count, offset int64, err error
 				continue
 			}
 
-			dstDInt := dstDatum.(parser.DInt)
+			dstDInt := *dstDatum.(*parser.DInt)
 			val := int64(dstDInt)
 			if val < 0 {
 				return 0, 0, fmt.Errorf("negative value for %s", datum.name)

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -84,13 +84,13 @@ var UnaryOps = map[UnaryArgs]UnaryOp{
 	UnaryArgs{UnaryMinus, intType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, d Datum) (Datum, error) {
-			return -d.(DInt), nil
+			return NewDInt(-*d.(*DInt)), nil
 		},
 	},
 	UnaryArgs{UnaryMinus, floatType}: {
 		ReturnType: DummyFloat,
 		fn: func(_ EvalContext, d Datum) (Datum, error) {
-			return -d.(DFloat), nil
+			return NewDFloat(-*d.(*DFloat)), nil
 		},
 	},
 	UnaryArgs{UnaryMinus, decimalType}: {
@@ -106,7 +106,7 @@ var UnaryOps = map[UnaryArgs]UnaryOp{
 	UnaryArgs{UnaryComplement, intType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, d Datum) (Datum, error) {
-			return ^d.(DInt), nil
+			return NewDInt(^*d.(*DInt)), nil
 		},
 	},
 }
@@ -130,21 +130,21 @@ var BinOps = map[BinArgs]BinOp{
 	BinArgs{Bitand, intType, intType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DInt) & right.(DInt), nil
+			return NewDInt(*left.(*DInt) & *right.(*DInt)), nil
 		},
 	},
 
 	BinArgs{Bitor, intType, intType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DInt) | right.(DInt), nil
+			return NewDInt(*left.(*DInt) | *right.(*DInt)), nil
 		},
 	},
 
 	BinArgs{Bitxor, intType, intType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DInt) ^ right.(DInt), nil
+			return NewDInt(*left.(*DInt) ^ *right.(*DInt)), nil
 		},
 	},
 
@@ -153,13 +153,13 @@ var BinOps = map[BinArgs]BinOp{
 	BinArgs{Plus, intType, intType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DInt) + right.(DInt), nil
+			return NewDInt(*left.(*DInt) + *right.(*DInt)), nil
 		},
 	},
 	BinArgs{Plus, floatType, floatType}: {
 		ReturnType: DummyFloat,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DFloat) + right.(DFloat), nil
+			return NewDFloat(*left.(*DFloat) + *right.(*DFloat)), nil
 		},
 	},
 	BinArgs{Plus, decimalType, decimalType}: {
@@ -175,43 +175,43 @@ var BinOps = map[BinArgs]BinOp{
 	BinArgs{Plus, dateType, intType}: {
 		ReturnType: DummyDate,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DDate) + DDate(right.(DInt)), nil
+			return NewDDate(*left.(*DDate) + DDate(*right.(*DInt))), nil
 		},
 	},
 	BinArgs{Plus, intType, dateType}: {
 		ReturnType: DummyDate,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return DDate(left.(DInt)) + right.(DDate), nil
+			return NewDDate(DDate(*left.(*DInt)) + *right.(*DDate)), nil
 		},
 	},
 	BinArgs{Plus, timestampType, intervalType}: {
 		ReturnType: DummyTimestamp,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return DTimestamp{Time: duration.Add(left.(DTimestamp).Time, right.(DInterval).Duration)}, nil
+			return &DTimestamp{Time: duration.Add(left.(*DTimestamp).Time, right.(*DInterval).Duration)}, nil
 		},
 	},
 	BinArgs{Plus, intervalType, timestampType}: {
 		ReturnType: DummyTimestamp,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return DTimestamp{Time: duration.Add(right.(DTimestamp).Time, left.(DInterval).Duration)}, nil
+			return &DTimestamp{Time: duration.Add(right.(*DTimestamp).Time, left.(*DInterval).Duration)}, nil
 		},
 	},
 	BinArgs{Plus, intervalType, intervalType}: {
 		ReturnType: DummyInterval,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return DInterval{Duration: left.(DInterval).Duration.Add(right.(DInterval).Duration)}, nil
+			return &DInterval{Duration: left.(*DInterval).Duration.Add(right.(*DInterval).Duration)}, nil
 		},
 	},
 	BinArgs{Minus, intType, intType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DInt) - right.(DInt), nil
+			return NewDInt(*left.(*DInt) - *right.(*DInt)), nil
 		},
 	},
 	BinArgs{Minus, floatType, floatType}: {
 		ReturnType: DummyFloat,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DFloat) - right.(DFloat), nil
+			return NewDFloat(*left.(*DFloat) - *right.(*DFloat)), nil
 		},
 	},
 	BinArgs{Minus, decimalType, decimalType}: {
@@ -227,45 +227,45 @@ var BinOps = map[BinArgs]BinOp{
 	BinArgs{Minus, dateType, intType}: {
 		ReturnType: DummyDate,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DDate) - DDate(right.(DInt)), nil
+			return NewDDate(*left.(*DDate) - DDate(*right.(*DInt))), nil
 		},
 	},
 	BinArgs{Minus, dateType, dateType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return DInt(left.(DDate) - right.(DDate)), nil
+			return NewDInt(DInt(*left.(*DDate) - *right.(*DDate))), nil
 		},
 	},
 	BinArgs{Minus, timestampType, timestampType}: {
 		ReturnType: DummyInterval,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			nanos := left.(DTimestamp).Sub(right.(DTimestamp).Time).Nanoseconds()
-			return DInterval{Duration: duration.Duration{Nanos: nanos}}, nil
+			nanos := left.(*DTimestamp).Sub(right.(*DTimestamp).Time).Nanoseconds()
+			return &DInterval{Duration: duration.Duration{Nanos: nanos}}, nil
 		},
 	},
 	BinArgs{Minus, timestampType, intervalType}: {
 		ReturnType: DummyTimestamp,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return DTimestamp{Time: duration.Add(left.(DTimestamp).Time, right.(DInterval).Duration.Mul(-1))}, nil
+			return &DTimestamp{Time: duration.Add(left.(*DTimestamp).Time, right.(*DInterval).Duration.Mul(-1))}, nil
 		},
 	},
 	BinArgs{Minus, intervalType, intervalType}: {
 		ReturnType: DummyInterval,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return DInterval{Duration: left.(DInterval).Duration.Sub(right.(DInterval).Duration)}, nil
+			return &DInterval{Duration: left.(*DInterval).Duration.Sub(right.(*DInterval).Duration)}, nil
 		},
 	},
 
 	BinArgs{Mult, intType, intType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DInt) * right.(DInt), nil
+			return NewDInt(*left.(*DInt) * *right.(*DInt)), nil
 		},
 	},
 	BinArgs{Mult, floatType, floatType}: {
 		ReturnType: DummyFloat,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DFloat) * right.(DFloat), nil
+			return NewDFloat(*left.(*DFloat) * *right.(*DFloat)), nil
 		},
 	},
 	BinArgs{Mult, decimalType, decimalType}: {
@@ -281,30 +281,30 @@ var BinOps = map[BinArgs]BinOp{
 	BinArgs{Mult, intType, intervalType}: {
 		ReturnType: DummyInterval,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return DInterval{Duration: right.(DInterval).Duration.Mul(int64(left.(DInt)))}, nil
+			return &DInterval{Duration: right.(*DInterval).Duration.Mul(int64(*left.(*DInt)))}, nil
 		},
 	},
 	BinArgs{Mult, intervalType, intType}: {
 		ReturnType: DummyInterval,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return DInterval{Duration: left.(DInterval).Duration.Mul(int64(right.(DInt)))}, nil
+			return &DInterval{Duration: left.(*DInterval).Duration.Mul(int64(*right.(*DInt)))}, nil
 		},
 	},
 
 	BinArgs{Div, intType, intType}: {
 		ReturnType: DummyFloat,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			rInt := right.(DInt)
+			rInt := *right.(*DInt)
 			if rInt == 0 {
 				return nil, errDivByZero
 			}
-			return DFloat(left.(DInt)) / DFloat(rInt), nil
+			return NewDFloat(DFloat(*left.(*DInt)) / DFloat(rInt)), nil
 		},
 	},
 	BinArgs{Div, floatType, floatType}: {
 		ReturnType: DummyFloat,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DFloat) / right.(DFloat), nil
+			return NewDFloat(*left.(*DFloat) / *right.(*DFloat)), nil
 		},
 	},
 	BinArgs{Div, decimalType, decimalType}: {
@@ -323,28 +323,28 @@ var BinOps = map[BinArgs]BinOp{
 	BinArgs{Div, intervalType, intType}: {
 		ReturnType: DummyInterval,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			rInt := right.(DInt)
+			rInt := *right.(*DInt)
 			if rInt == 0 {
 				return nil, errDivByZero
 			}
-			return DInterval{Duration: left.(DInterval).Duration.Div(int64(rInt))}, nil
+			return &DInterval{Duration: left.(*DInterval).Duration.Div(int64(rInt))}, nil
 		},
 	},
 
 	BinArgs{Mod, intType, intType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			r := right.(DInt)
+			r := *right.(*DInt)
 			if r == 0 {
 				return nil, errZeroModulus
 			}
-			return left.(DInt) % r, nil
+			return NewDInt(*left.(*DInt) % r), nil
 		},
 	},
 	BinArgs{Mod, floatType, floatType}: {
 		ReturnType: DummyFloat,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return DFloat(math.Mod(float64(left.(DFloat)), float64(right.(DFloat)))), nil
+			return NewDFloat(DFloat(math.Mod(float64(*left.(*DFloat)), float64(*right.(*DFloat))))), nil
 		},
 	},
 	BinArgs{Mod, decimalType, decimalType}: {
@@ -364,13 +364,13 @@ var BinOps = map[BinArgs]BinOp{
 	BinArgs{Concat, stringType, stringType}: {
 		ReturnType: DummyString,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DString) + right.(DString), nil
+			return NewDString(string(*left.(*DString) + *right.(*DString))), nil
 		},
 	},
 	BinArgs{Concat, bytesType, bytesType}: {
 		ReturnType: DummyBytes,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DBytes) + right.(DBytes), nil
+			return NewDBytes(*left.(*DBytes) + *right.(*DBytes)), nil
 		},
 	},
 
@@ -378,13 +378,13 @@ var BinOps = map[BinArgs]BinOp{
 	BinArgs{LShift, intType, intType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DInt) << uint(right.(DInt)), nil
+			return NewDInt(*left.(*DInt) << uint(*right.(*DInt))), nil
 		},
 	},
 	BinArgs{RShift, intType, intType}: {
 		ReturnType: DummyInt,
 		fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-			return left.(DInt) >> uint(right.(DInt)), nil
+			return NewDInt(*left.(*DInt) >> uint(*right.(*DInt))), nil
 		},
 	},
 }
@@ -401,34 +401,32 @@ type CmpOp struct {
 	fn func(EvalContext, Datum, Datum) (DBool, error)
 }
 
-var cmpOpResultType = reflect.New(reflect.TypeOf(CmpOp{}).Field(0).Type.Out(0)).Elem().Interface().(DBool)
-
 // CmpOps contains the comparison operations indexed by operation type and
 // argument types.
 var CmpOps = map[CmpArgs]CmpOp{
 	CmpArgs{EQ, stringType, stringType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DString) == right.(DString)), nil
+			return DBool(*left.(*DString) == *right.(*DString)), nil
 		},
 	},
 	CmpArgs{EQ, bytesType, bytesType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DBytes) == right.(DBytes)), nil
+			return DBool(*left.(*DBytes) == *right.(*DBytes)), nil
 		},
 	},
 	CmpArgs{EQ, boolType, boolType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DBool) == right.(DBool)), nil
+			return DBool(*left.(*DBool) == *right.(*DBool)), nil
 		},
 	},
 	CmpArgs{EQ, intType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DInt) == right.(DInt)), nil
+			return DBool(*left.(*DInt) == *right.(*DInt)), nil
 		},
 	},
 	CmpArgs{EQ, floatType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DFloat) == right.(DFloat)), nil
+			return DBool(*left.(*DFloat) == *right.(*DFloat)), nil
 		},
 	},
 	CmpArgs{EQ, decimalType, decimalType}: {
@@ -440,24 +438,24 @@ var CmpOps = map[CmpArgs]CmpOp{
 	},
 	CmpArgs{EQ, floatType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DFloat) == DFloat(right.(DInt))), nil
+			return DBool(*left.(*DFloat) == DFloat(*right.(*DInt))), nil
 		},
 	},
 	CmpArgs{EQ, intType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(DFloat(left.(DInt)) == right.(DFloat)), nil
+			return DBool(DFloat(*left.(*DInt)) == *right.(*DFloat)), nil
 		},
 	},
 	CmpArgs{EQ, decimalType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := left.(*DDecimal).Dec
-			r := inf.NewDec(int64(right.(DInt)), 0)
+			r := inf.NewDec(int64(*right.(*DInt)), 0)
 			return DBool(l.Cmp(r) == 0), nil
 		},
 	},
 	CmpArgs{EQ, intType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := inf.NewDec(int64(left.(DInt)), 0)
+			l := inf.NewDec(int64(*left.(*DInt)), 0)
 			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) == 0), nil
 		},
@@ -465,56 +463,56 @@ var CmpOps = map[CmpArgs]CmpOp{
 	CmpArgs{EQ, decimalType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := left.(*DDecimal).Dec
-			r := decimal.NewDecFromFloat(float64(right.(DFloat)))
+			r := decimal.NewDecFromFloat(float64(*right.(*DFloat)))
 			return DBool(l.Cmp(r) == 0), nil
 		},
 	},
 	CmpArgs{EQ, floatType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := decimal.NewDecFromFloat(float64(left.(DFloat)))
+			l := decimal.NewDecFromFloat(float64(*left.(*DFloat)))
 			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) == 0), nil
 		},
 	},
 	CmpArgs{EQ, dateType, dateType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DDate) == right.(DDate)), nil
+			return DBool(*left.(*DDate) == *right.(*DDate)), nil
 		},
 	},
 	CmpArgs{EQ, timestampType, timestampType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DTimestamp).Equal(right.(DTimestamp).Time)), nil
+			return DBool(left.(*DTimestamp).Equal(right.(*DTimestamp).Time)), nil
 		},
 	},
 	CmpArgs{EQ, intervalType, intervalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DInterval) == right.(DInterval)), nil
+			return DBool(*left.(*DInterval) == *right.(*DInterval)), nil
 		},
 	},
 
 	CmpArgs{LT, stringType, stringType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DString) < right.(DString)), nil
+			return DBool(*left.(*DString) < *right.(*DString)), nil
 		},
 	},
 	CmpArgs{LT, bytesType, bytesType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DBytes) < right.(DBytes)), nil
+			return DBool(*left.(*DBytes) < *right.(*DBytes)), nil
 		},
 	},
 	CmpArgs{LT, boolType, boolType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(!left.(DBool) && right.(DBool)), nil
+			return DBool(!*left.(*DBool) && *right.(*DBool)), nil
 		},
 	},
 	CmpArgs{LT, intType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DInt) < right.(DInt)), nil
+			return DBool(*left.(*DInt) < *right.(*DInt)), nil
 		},
 	},
 	CmpArgs{LT, floatType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DFloat) < right.(DFloat)), nil
+			return DBool(*left.(*DFloat) < *right.(*DFloat)), nil
 		},
 	},
 	CmpArgs{LT, decimalType, decimalType}: {
@@ -526,24 +524,24 @@ var CmpOps = map[CmpArgs]CmpOp{
 	},
 	CmpArgs{LT, floatType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DFloat) < DFloat(right.(DInt))), nil
+			return DBool(*left.(*DFloat) < DFloat(*right.(*DInt))), nil
 		},
 	},
 	CmpArgs{LT, intType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(DFloat(left.(DInt)) < right.(DFloat)), nil
+			return DBool(DFloat(*left.(*DInt)) < *right.(*DFloat)), nil
 		},
 	},
 	CmpArgs{LT, decimalType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := left.(*DDecimal).Dec
-			r := inf.NewDec(int64(right.(DInt)), 0)
+			r := inf.NewDec(int64(*right.(*DInt)), 0)
 			return DBool(l.Cmp(r) < 0), nil
 		},
 	},
 	CmpArgs{LT, intType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := inf.NewDec(int64(left.(DInt)), 0)
+			l := inf.NewDec(int64(*left.(*DInt)), 0)
 			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) < 0), nil
 		},
@@ -551,56 +549,56 @@ var CmpOps = map[CmpArgs]CmpOp{
 	CmpArgs{LT, decimalType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := left.(*DDecimal).Dec
-			r := decimal.NewDecFromFloat(float64(right.(DFloat)))
+			r := decimal.NewDecFromFloat(float64(*right.(*DFloat)))
 			return DBool(l.Cmp(r) < 0), nil
 		},
 	},
 	CmpArgs{LT, floatType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := decimal.NewDecFromFloat(float64(left.(DFloat)))
+			l := decimal.NewDecFromFloat(float64(*left.(*DFloat)))
 			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) < 0), nil
 		},
 	},
 	CmpArgs{LT, dateType, dateType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DDate) < right.(DDate)), nil
+			return DBool(*left.(*DDate) < *right.(*DDate)), nil
 		},
 	},
 	CmpArgs{LT, timestampType, timestampType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DTimestamp).Before(right.(DTimestamp).Time)), nil
+			return DBool(left.(*DTimestamp).Before(right.(*DTimestamp).Time)), nil
 		},
 	},
 	CmpArgs{LT, intervalType, intervalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DInterval).Duration.Compare(right.(DInterval).Duration) < 0), nil
+			return DBool(left.(*DInterval).Duration.Compare(right.(*DInterval).Duration) < 0), nil
 		},
 	},
 
 	CmpArgs{LE, stringType, stringType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DString) <= right.(DString)), nil
+			return DBool(*left.(*DString) <= *right.(*DString)), nil
 		},
 	},
 	CmpArgs{LE, bytesType, bytesType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DBytes) <= right.(DBytes)), nil
+			return DBool(*left.(*DBytes) <= *right.(*DBytes)), nil
 		},
 	},
 	CmpArgs{LE, boolType, boolType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(!left.(DBool) || right.(DBool)), nil
+			return DBool(!*left.(*DBool) || *right.(*DBool)), nil
 		},
 	},
 	CmpArgs{LE, intType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DInt) <= right.(DInt)), nil
+			return DBool(*left.(*DInt) <= *right.(*DInt)), nil
 		},
 	},
 	CmpArgs{LE, floatType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DFloat) <= right.(DFloat)), nil
+			return DBool(*left.(*DFloat) <= *right.(*DFloat)), nil
 		},
 	},
 	CmpArgs{LE, decimalType, decimalType}: {
@@ -612,24 +610,24 @@ var CmpOps = map[CmpArgs]CmpOp{
 	},
 	CmpArgs{LE, floatType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DFloat) <= DFloat(right.(DInt))), nil
+			return DBool(*left.(*DFloat) <= DFloat(*right.(*DInt))), nil
 		},
 	},
 	CmpArgs{LE, intType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(DFloat(left.(DInt)) <= right.(DFloat)), nil
+			return DBool(DFloat(*left.(*DInt)) <= *right.(*DFloat)), nil
 		},
 	},
 	CmpArgs{LE, decimalType, intType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := left.(*DDecimal).Dec
-			r := inf.NewDec(int64(right.(DInt)), 0)
+			r := inf.NewDec(int64(*right.(*DInt)), 0)
 			return DBool(l.Cmp(r) <= 0), nil
 		},
 	},
 	CmpArgs{LE, intType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := inf.NewDec(int64(left.(DInt)), 0)
+			l := inf.NewDec(int64(*left.(*DInt)), 0)
 			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) <= 0), nil
 		},
@@ -637,36 +635,36 @@ var CmpOps = map[CmpArgs]CmpOp{
 	CmpArgs{LE, decimalType, floatType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 			l := left.(*DDecimal).Dec
-			r := decimal.NewDecFromFloat(float64(right.(DFloat)))
+			r := decimal.NewDecFromFloat(float64(*right.(*DFloat)))
 			return DBool(l.Cmp(r) <= 0), nil
 		},
 	},
 	CmpArgs{LE, floatType, decimalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			l := decimal.NewDecFromFloat(float64(left.(DFloat)))
+			l := decimal.NewDecFromFloat(float64(*left.(*DFloat)))
 			r := right.(*DDecimal).Dec
 			return DBool(l.Cmp(&r) <= 0), nil
 		},
 	},
 	CmpArgs{LE, dateType, dateType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DDate) <= right.(DDate)), nil
+			return DBool(*left.(*DDate) <= *right.(*DDate)), nil
 		},
 	},
 	CmpArgs{LE, timestampType, timestampType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return !DBool(right.(DTimestamp).Before(left.(DTimestamp).Time)), nil
+			return !DBool(right.(*DTimestamp).Before(left.(*DTimestamp).Time)), nil
 		},
 	},
 	CmpArgs{LE, intervalType, intervalType}: {
 		fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-			return DBool(left.(DInterval).Duration.Compare(right.(DInterval).Duration) <= 0), nil
+			return DBool(left.(*DInterval).Duration.Compare(right.(*DInterval).Duration) <= 0), nil
 		},
 	},
 
 	CmpArgs{Like, stringType, stringType}: {
 		fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
-			pattern := string(right.(DString))
+			pattern := string(*right.(*DString))
 			like := optimizedLikeFunc(pattern)
 			if like == nil {
 				key := likeKey(pattern)
@@ -676,26 +674,26 @@ var CmpOps = map[CmpArgs]CmpOp{
 				}
 				like = re.MatchString
 			}
-			return DBool(like(string(left.(DString)))), nil
+			return DBool(like(string(*left.(*DString)))), nil
 		},
 	},
 
 	CmpArgs{SimilarTo, stringType, stringType}: {
 		fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
-			key := similarToKey(right.(DString))
+			key := similarToKey(*right.(*DString))
 			re, err := ctx.ReCache.GetRegexp(key)
 			if err != nil {
 				return DBool(false), err
 			}
-			return DBool(re.MatchString(string(left.(DString)))), nil
+			return DBool(re.MatchString(string(*left.(*DString)))), nil
 		},
 	},
 }
 
 var evalTupleEQ = CmpOp{
 	fn: func(ctx EvalContext, ldatum, rdatum Datum) (DBool, error) {
-		left := ldatum.(DTuple)
-		right := rdatum.(DTuple)
+		left := *ldatum.(*DTuple)
+		right := *rdatum.(*DTuple)
 		if len(left) != len(right) {
 			return DBool(false), nil
 		}
@@ -720,7 +718,7 @@ var evalTupleIN = CmpOp{
 			return DBool(false), nil
 		}
 
-		vtuple := values.(DTuple)
+		vtuple := *values.(*DTuple)
 		i := sort.Search(len(vtuple), func(i int) bool { return vtuple[i].Compare(arg) >= 0 })
 		found := i < len(vtuple) && vtuple[i].Compare(arg) == 0
 		return DBool(found), nil
@@ -770,13 +768,13 @@ type EvalContext struct {
 
 // GetStmtTimestamp retrieves the current statement timestamp as per
 // the evaluation context. The timestamp is guaranteed to be nonzero.
-func (ctx *EvalContext) GetStmtTimestamp() DTimestamp {
+func (ctx *EvalContext) GetStmtTimestamp() *DTimestamp {
 	// TODO(knz) a zero timestamp should never be read, even during
 	// Prepare. This will need to be addressed.
 	if !ctx.PrepareOnly && ctx.stmtTimestamp.Time.IsZero() {
 		panic("zero statement timestamp in EvalContext")
 	}
-	return ctx.stmtTimestamp
+	return &ctx.stmtTimestamp
 }
 
 // GetClusterTimestamp retrieves the current cluster timestamp as per
@@ -810,13 +808,13 @@ func (ctx *EvalContext) GetClusterTimestamp() *DDecimal {
 
 // GetTxnTimestamp retrieves the current transaction timestamp as per
 // the evaluation context. The timestamp is guaranteed to be nonzero.
-func (ctx *EvalContext) GetTxnTimestamp() DTimestamp {
+func (ctx *EvalContext) GetTxnTimestamp() *DTimestamp {
 	// TODO(knz) a zero timestamp should never be read, even during
 	// Prepare. This will need to be addressed.
 	if !ctx.PrepareOnly && ctx.txnTimestamp.Time.IsZero() {
 		panic("zero transaction timestamp in EvalContext")
 	}
-	return ctx.txnTimestamp
+	return &ctx.txnTimestamp
 }
 
 // SetTxnTimestamp sets the corresponding timestamp in the EvalContext.
@@ -843,14 +841,14 @@ var defaultContext = EvalContext{
 }
 
 // makeDDate constructs a DDate from a time.Time in the session time zone.
-func (ctx EvalContext) makeDDate(t time.Time) (DDate, error) {
+func (ctx EvalContext) makeDDate(t time.Time) (*DDate, error) {
 	loc, err := ctx.GetLocation()
 	if err != nil {
-		return DDate(0), err
+		return NewDDate(0), err
 	}
 	year, month, day := t.In(loc).Date()
 	secs := time.Date(year, month, day, 0, 0, 0, 0, time.UTC).Unix()
-	return DDate(secs / secondsInDay), nil
+	return NewDDate(DDate(secs / secondsInDay)), nil
 }
 
 // Eval implements the Expr interface.
@@ -863,7 +861,7 @@ func (expr *AndExpr) Eval(ctx EvalContext) (Datum, error) {
 		if v, err := GetBool(left); err != nil {
 			return DNull, err
 		} else if !v {
-			return v, nil
+			return left, nil
 		}
 	}
 	right, err := expr.Right.Eval(ctx)
@@ -876,7 +874,7 @@ func (expr *AndExpr) Eval(ctx EvalContext) (Datum, error) {
 	if v, err := GetBool(right); err != nil {
 		return DNull, err
 	} else if !v {
-		return v, nil
+		return right, nil
 	}
 	return left, nil
 }
@@ -968,39 +966,39 @@ func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
 	switch expr.Type.(type) {
 	case *BoolType:
 		switch v := d.(type) {
-		case DBool:
+		case *DBool:
 			return d, nil
-		case DInt:
-			return DBool(v != 0), nil
-		case DFloat:
-			return DBool(v != 0), nil
+		case *DInt:
+			return MakeDBool(*v != 0), nil
+		case *DFloat:
+			return MakeDBool(*v != 0), nil
 		case *DDecimal:
-			return DBool(v.Sign() != 0), nil
-		case DString:
+			return MakeDBool(v.Sign() != 0), nil
+		case *DString:
 			// TODO(pmattis): strconv.ParseBool is more permissive than the SQL
 			// spec. Is that ok?
-			b, err := strconv.ParseBool(string(v))
+			b, err := strconv.ParseBool(string(*v))
 			if err != nil {
 				return nil, err
 			}
-			return DBool(b), nil
+			return MakeDBool(DBool(b)), nil
 		}
 
 	case *IntType:
 		switch v := d.(type) {
-		case DBool:
-			if v {
-				return DInt(1), nil
+		case *DBool:
+			if *v {
+				return NewDInt(1), nil
 			}
-			return DInt(0), nil
-		case DInt:
+			return NewDInt(0), nil
+		case *DInt:
 			return d, nil
-		case DFloat:
-			f, err := round(float64(v), 0)
+		case *DFloat:
+			f, err := round(float64(*v), 0)
 			if err != nil {
 				panic(fmt.Sprintf("round should never fail with digits hardcoded to 0: %s", err))
 			}
-			return DInt(f.(DFloat)), nil
+			return NewDInt(DInt(*f.(*DFloat))), nil
 		case *DDecimal:
 			dec := new(inf.Dec)
 			dec.Round(&v.Dec, 0, inf.RoundHalfUp)
@@ -1008,58 +1006,58 @@ func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
 			if !ok {
 				return nil, errIntOutOfRange
 			}
-			return DInt(i), nil
-		case DString:
-			i, err := strconv.ParseInt(string(v), 0, 64)
+			return NewDInt(DInt(i)), nil
+		case *DString:
+			i, err := strconv.ParseInt(string(*v), 0, 64)
 			if err != nil {
 				return nil, err
 			}
-			return DInt(i), nil
+			return NewDInt(DInt(i)), nil
 		}
 
 	case *FloatType:
 		switch v := d.(type) {
-		case DBool:
-			if v {
-				return DFloat(1), nil
+		case *DBool:
+			if *v {
+				return NewDFloat(1), nil
 			}
-			return DFloat(0), nil
-		case DInt:
-			return DFloat(v), nil
-		case DFloat:
+			return NewDFloat(0), nil
+		case *DInt:
+			return NewDFloat(DFloat(*v)), nil
+		case *DFloat:
 			return d, nil
 		case *DDecimal:
 			f, err := decimal.Float64FromDec(&v.Dec)
 			if err != nil {
 				return nil, errFloatOutOfRange
 			}
-			return DFloat(f), nil
-		case DString:
-			f, err := strconv.ParseFloat(string(v), 64)
+			return NewDFloat(DFloat(f)), nil
+		case *DString:
+			f, err := strconv.ParseFloat(string(*v), 64)
 			if err != nil {
 				return nil, err
 			}
-			return DFloat(f), nil
+			return NewDFloat(DFloat(f)), nil
 		}
 
 	case *DecimalType:
 		dd := &DDecimal{}
 		switch v := d.(type) {
-		case DBool:
-			if v {
+		case *DBool:
+			if *v {
 				dd.SetUnscaled(1)
 			}
 			return dd, nil
-		case DInt:
-			dd.SetUnscaled(int64(v))
+		case *DInt:
+			dd.SetUnscaled(int64(*v))
 			return dd, nil
-		case DFloat:
-			decimal.SetFromFloat(&dd.Dec, float64(v))
+		case *DFloat:
+			decimal.SetFromFloat(&dd.Dec, float64(*v))
 			return dd, nil
 		case *DDecimal:
 			return d, nil
-		case DString:
-			if _, ok := dd.SetString(string(v)); !ok {
+		case *DString:
+			if _, ok := dd.SetString(string(*v)); !ok {
 				return nil, fmt.Errorf("could not parse string %q as decimal", v)
 			}
 			return dd, nil
@@ -1068,15 +1066,15 @@ func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
 	case *StringType:
 		var s DString
 		switch t := d.(type) {
-		case DBool, DInt, DFloat, *DDecimal, dNull:
+		case *DBool, *DInt, *DFloat, *DDecimal, dNull:
 			s = DString(d.String())
-		case DString:
-			s = t
-		case DBytes:
-			if !utf8.ValidString(string(t)) {
-				return nil, fmt.Errorf("invalid utf8: %q", string(t))
+		case *DString:
+			s = *t
+		case *DBytes:
+			if !utf8.ValidString(string(*t)) {
+				return nil, fmt.Errorf("invalid utf8: %q", string(*t))
 			}
-			s = DString(t)
+			s = DString(*t)
 		}
 		if c, ok := expr.Type.(*StringType); ok {
 			// If the CHAR type specifies a limit we truncate to that limit:
@@ -1085,48 +1083,48 @@ func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
 				s = s[:c.N]
 			}
 		}
-		return s, nil
+		return &s, nil
 
 	case *BytesType:
 		switch t := d.(type) {
-		case DString:
-			return DBytes(t), nil
-		case DBytes:
+		case *DString:
+			return NewDBytes(DBytes(*t)), nil
+		case *DBytes:
 			return d, nil
 		}
 
 	case *DateType:
 		switch d := d.(type) {
-		case DString:
-			return ParseDate(d)
-		case DTimestamp:
+		case *DString:
+			return ParseDate(*d)
+		case *DTimestamp:
 			return ctx.makeDDate(d.Time)
 		}
 
 	case *TimestampType:
 		switch d := d.(type) {
-		case DString:
-			return ctx.ParseTimestamp(d)
-		case DDate:
+		case *DString:
+			return ctx.ParseTimestamp(*d)
+		case *DDate:
 			loc, err := ctx.GetLocation()
 			if err != nil {
 				return nil, err
 			}
-			year, month, day := time.Unix(int64(d)*secondsInDay, 0).UTC().Date()
-			return DTimestamp{Time: time.Date(year, month, day, 0, 0, 0, 0, loc)}, nil
+			year, month, day := time.Unix(int64(*d)*secondsInDay, 0).UTC().Date()
+			return &DTimestamp{Time: time.Date(year, month, day, 0, 0, 0, 0, loc)}, nil
 		}
 
 	case *IntervalType:
-		switch d.(type) {
-		case DString:
+		switch d := d.(type) {
+		case *DString:
 			// We use the Golang format for specifying duration.
 			// TODO(vivek): we might consider using the postgres format as well.
-			d, err := time.ParseDuration(string(d.(DString)))
-			return DInterval{Duration: duration.Duration{Nanos: d.Nanoseconds()}}, err
+			t, err := time.ParseDuration(string(*d))
+			return &DInterval{Duration: duration.Duration{Nanos: t.Nanoseconds()}}, err
 
-		case DInt:
+		case *DInt:
 			// An integer duration represents a duration in nanoseconds.
-			return DInterval{Duration: duration.Duration{Nanos: int64(d.(DInt))}}, nil
+			return &DInterval{Duration: duration.Duration{Nanos: int64(*d)}}, nil
 		}
 	}
 
@@ -1161,14 +1159,14 @@ func (expr *ComparisonExpr) Eval(ctx EvalContext) (Datum, error) {
 	if left == DNull || right == DNull {
 		switch expr.Operator {
 		case IsDistinctFrom:
-			return !DBool(left == DNull && right == DNull), nil
+			return MakeDBool(!DBool(left == DNull && right == DNull)), nil
 		case IsNotDistinctFrom:
-			return DBool(left == DNull && right == DNull), nil
+			return MakeDBool(left == DNull && right == DNull), nil
 		case Is:
 			// IS and IS NOT can compare against NULL.
-			return DBool(left == right), nil
+			return MakeDBool(left == right), nil
 		case IsNot:
-			return DBool(left != right), nil
+			return MakeDBool(left != right), nil
 		default:
 			return DNull, nil
 		}
@@ -1190,9 +1188,9 @@ func (expr *ComparisonExpr) Eval(ctx EvalContext) (Datum, error) {
 	_, newLeft, newRight, not := foldComparisonExpr(expr.Operator, left, right)
 	d, err := expr.fn.fn(ctx, newLeft, newRight)
 	if err == nil && not {
-		return !d, nil
+		return MakeDBool(!d), nil
 	}
-	return d, err
+	return MakeDBool(d), err
 }
 
 // Eval implements the Expr interface.
@@ -1242,7 +1240,7 @@ func (expr *IfExpr) Eval(ctx EvalContext) (Datum, error) {
 	if err != nil {
 		return DNull, err
 	}
-	if cond == DBool(true) {
+	if cond == DBoolTrue {
 		return expr.True.Eval(ctx)
 	}
 	return expr.Else.Eval(ctx)
@@ -1261,71 +1259,71 @@ func (expr *IsOfTypeExpr) Eval(ctx EvalContext) (Datum, error) {
 	}
 
 	switch d.(type) {
-	case DBool:
+	case *DBool:
 		for _, t := range expr.Types {
 			if _, ok := t.(*BoolType); ok {
-				return result, nil
+				return MakeDBool(result), nil
 			}
 		}
 
-	case DInt:
+	case *DInt:
 		for _, t := range expr.Types {
 			if _, ok := t.(*IntType); ok {
-				return result, nil
+				return MakeDBool(result), nil
 			}
 		}
 
-	case DFloat:
+	case *DFloat:
 		for _, t := range expr.Types {
 			if _, ok := t.(*FloatType); ok {
-				return result, nil
+				return MakeDBool(result), nil
 			}
 		}
 
 	case *DDecimal:
 		for _, t := range expr.Types {
 			if _, ok := t.(*DecimalType); ok {
-				return result, nil
+				return MakeDBool(result), nil
 			}
 		}
 
-	case DString:
+	case *DString:
 		for _, t := range expr.Types {
 			if _, ok := t.(*StringType); ok {
-				return result, nil
+				return MakeDBool(result), nil
 			}
 		}
 
-	case DBytes:
+	case *DBytes:
 		for _, t := range expr.Types {
 			if _, ok := t.(*BytesType); ok {
-				return result, nil
+				return MakeDBool(result), nil
 			}
 		}
 
-	case DDate:
+	case *DDate:
 		for _, t := range expr.Types {
 			if _, ok := t.(*DateType); ok {
-				return result, nil
+				return MakeDBool(result), nil
 			}
 		}
 
-	case DTimestamp:
+	case *DTimestamp:
 		for _, t := range expr.Types {
 			if _, ok := t.(*TimestampType); ok {
-				return result, nil
+				return MakeDBool(result), nil
 			}
 		}
 
-	case DInterval:
+	case *DInterval:
 		for _, t := range expr.Types {
 			if _, ok := t.(*IntervalType); ok {
-				return result, nil
+				return MakeDBool(result), nil
 			}
 		}
 	}
 
-	return !result, nil
+	return MakeDBool(!result), nil
 }
 
 // Eval implements the Expr interface.
@@ -1341,7 +1339,7 @@ func (expr *NotExpr) Eval(ctx EvalContext) (Datum, error) {
 	if err != nil {
 		return DNull, err
 	}
-	return !v, nil
+	return MakeDBool(!v), nil
 }
 
 // Eval implements the Expr interface.
@@ -1358,7 +1356,7 @@ func (expr *NullIfExpr) Eval(ctx EvalContext) (Datum, error) {
 	if err != nil {
 		return DNull, err
 	}
-	if cond == DBool(true) {
+	if cond == DBoolTrue {
 		return DNull, nil
 	}
 	return expr1, nil
@@ -1374,7 +1372,7 @@ func (expr *OrExpr) Eval(ctx EvalContext) (Datum, error) {
 		if v, err := GetBool(left); err != nil {
 			return DNull, err
 		} else if v {
-			return v, nil
+			return left, nil
 		}
 	}
 	right, err := expr.Right.Eval(ctx)
@@ -1387,12 +1385,12 @@ func (expr *OrExpr) Eval(ctx EvalContext) (Datum, error) {
 	if v, err := GetBool(right); err != nil {
 		return DNull, err
 	} else if v {
-		return v, nil
+		return right, nil
 	}
 	if left == DNull {
 		return DNull, nil
 	}
-	return DBool(false), nil
+	return DBoolFalse, nil
 }
 
 // Eval implements the Expr interface.
@@ -1447,7 +1445,7 @@ func (t *IntVal) Eval(_ EvalContext) (Datum, error) {
 	if t.Val < 0 {
 		return nil, fmt.Errorf("integer value out of range: %s", t)
 	}
-	return DInt(t.Val), nil
+	return &t.Val, nil
 }
 
 // Eval implements the Expr interface.
@@ -1466,7 +1464,7 @@ func (t NumVal) Eval(_ EvalContext) (Datum, error) {
 	if err != nil {
 		return DNull, err
 	}
-	return DFloat(v), nil
+	return NewDFloat(DFloat(v)), nil
 }
 
 func evalExprs(ctx EvalContext, exprs []Expr) (Datum, error) {
@@ -1478,7 +1476,7 @@ func evalExprs(ctx EvalContext, exprs []Expr) (Datum, error) {
 		}
 		tuple = append(tuple, d)
 	}
-	return tuple, nil
+	return &tuple, nil
 }
 
 // Eval implements the Expr interface.
@@ -1493,26 +1491,26 @@ func (t *Tuple) Eval(ctx EvalContext) (Datum, error) {
 
 // Eval implements the Expr interface.
 func (t ValArg) Eval(_ EvalContext) (Datum, error) {
-	return DValArg{name: t.name}, nil
+	return &DValArg{name: t.name}, nil
 }
 
 // Eval implements the Expr interface.
-func (t DBool) Eval(_ EvalContext) (Datum, error) {
+func (t *DBool) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t DBytes) Eval(_ EvalContext) (Datum, error) {
+func (t *DBytes) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t DDate) Eval(_ EvalContext) (Datum, error) {
+func (t *DDate) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t DFloat) Eval(_ EvalContext) (Datum, error) {
+func (t *DFloat) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 
@@ -1522,12 +1520,12 @@ func (t *DDecimal) Eval(_ EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (t DInt) Eval(_ EvalContext) (Datum, error) {
+func (t *DInt) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t DInterval) Eval(_ EvalContext) (Datum, error) {
+func (t *DInterval) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 
@@ -1537,22 +1535,22 @@ func (t dNull) Eval(_ EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (t DString) Eval(_ EvalContext) (Datum, error) {
+func (t *DString) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t DTimestamp) Eval(_ EvalContext) (Datum, error) {
+func (t *DTimestamp) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t DTuple) Eval(_ EvalContext) (Datum, error) {
+func (t *DTuple) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t DValArg) Eval(_ EvalContext) (Datum, error) {
+func (t *DValArg) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 
@@ -1562,7 +1560,8 @@ func evalComparison(ctx EvalContext, op ComparisonOp, left, right Datum) (Datum,
 	}
 
 	if f, ok := CmpOps[CmpArgs{op, reflect.TypeOf(left), reflect.TypeOf(right)}]; ok {
-		return f.fn(ctx, left, right)
+		v, err := f.fn(ctx, left, right)
+		return MakeDBool(v), err
 	}
 
 	return nil, fmt.Errorf("unsupported comparison operator: <%s> %s <%s>",
@@ -1644,23 +1643,23 @@ var timeFormats = []string{
 }
 
 // ParseDate parses a date.
-func ParseDate(s DString) (DDate, error) {
+func ParseDate(s DString) (*DDate, error) {
 	// No need to ParseInLocation here because we're only parsing dates.
 	for _, format := range dateFormats {
 		if t, err := time.Parse(format, string(s)); err == nil {
 			return defaultContext.makeDDate(t)
 		}
 	}
-	return DDate(0), fmt.Errorf("could not parse %s in any supported date format", s)
+	return NewDDate(0), fmt.Errorf("could not parse '%s' in any supported date format", s)
 }
 
 // ParseTimestamp parses the timestamp.
-func (ctx EvalContext) ParseTimestamp(s DString) (DTimestamp, error) {
+func (ctx EvalContext) ParseTimestamp(s DString) (*DTimestamp, error) {
 	loc := time.UTC
 	if ctx.GetLocation != nil {
 		var err error
 		if loc, err = ctx.GetLocation(); err != nil {
-			return DTimestamp{}, err
+			return &DTimestamp{}, err
 		}
 	}
 
@@ -1668,11 +1667,11 @@ func (ctx EvalContext) ParseTimestamp(s DString) (DTimestamp, error) {
 
 	for _, format := range timeFormats {
 		if t, err := time.ParseInLocation(format, str, loc); err == nil {
-			return DTimestamp{Time: t}, nil
+			return &DTimestamp{Time: t}, nil
 		}
 	}
 
-	return DTimestamp{}, fmt.Errorf("could not parse %s in any supported timestamp format", s)
+	return &DTimestamp{}, fmt.Errorf("could not parse '%s' in any supported timestamp format", s)
 }
 
 // Simplifies LIKE expressions that do not need full regular expressions to evaluate the condition.

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -438,8 +438,8 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 	for _, d := range testExprs {
 		expr := &ComparisonExpr{
 			Operator: d.op,
-			Left:     DString(d.left),
-			Right:    DString(d.right),
+			Left:     NewDString(d.left),
+			Right:    NewDString(d.right),
 		}
 		ctx := defaultContext
 		ctx.ReCache = NewRegexpCache(8)
@@ -520,7 +520,7 @@ func benchmarkLike(b *testing.B, ctx EvalContext) {
 	likeFn := CmpOps[CmpArgs{Like, stringType, stringType}].fn
 	iter := func() {
 		for _, p := range benchmarkLikePatterns {
-			if _, err := likeFn(ctx, DString("test"), DString(p)); err != nil {
+			if _, err := likeFn(ctx, NewDString("test"), NewDString(p)); err != nil {
 				b.Fatalf("LIKE evaluation failed with error: %v", err)
 			}
 		}

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -229,7 +229,7 @@ func (node *CoalesceExpr) String() string {
 
 // IntVal represents an integer.
 type IntVal struct {
-	Val int64
+	Val DInt
 	Str string
 }
 

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -214,12 +214,13 @@ func (expr *ComparisonExpr) normalize(v *normalizeVisitor) Expr {
 	case In, NotIn:
 		// If the right tuple in an In or NotIn comparison expression is constant, it can
 		// be normalized.
-		tuple, ok := expr.Right.(DTuple)
+		tuple, ok := expr.Right.(*DTuple)
 		if ok {
-			tuple.Normalize()
+			tupleCopy := *tuple
+			tupleCopy.Normalize()
 			exprCopy := *expr
 			expr = &exprCopy
-			expr.Right = tuple
+			expr.Right = &tupleCopy
 		}
 	}
 
@@ -323,7 +324,7 @@ func (expr *UnaryExpr) normalize(v *normalizeVisitor) Expr {
 	// UnaryExprs.
 	if expr.Operator == UnaryMinus {
 		if d, ok := expr.Expr.(*IntVal); ok && d.Val == math.MinInt64 {
-			return DInt(math.MinInt64)
+			return NewDInt(math.MinInt64)
 		}
 	}
 

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -629,7 +629,7 @@ func TestParse2(t *testing.T) {
 		}
 		s := stmts.String()
 		if d.expected != s {
-			t.Errorf("%s: expected %s, but found (%d statements): %q", d.sql, d.expected, len(stmts), s)
+			t.Errorf("%s: expected %s, but found (%d statements): %s", d.sql, d.expected, len(stmts), s)
 		}
 		if _, err := parseTraditional(s); err != nil {
 			t.Errorf("expected string found, but not parsable: %s:\n%s", err, s)

--- a/sql/parser/scan.go
+++ b/sql/parser/scan.go
@@ -560,7 +560,7 @@ func (s *scanner) scanNumber(lval *sqlSymType, ch int) {
 	}
 	// uval is now in the range [0, 1<<63]. Casting to an int64 leaves the range
 	// [0, 1<<63 - 1] intact and moves 1<<63 to -1<<63 (a.k.a. math.MinInt64).
-	lval.union.val = IntVal{Val: int64(uval), Str: lval.str}
+	lval.union.val = IntVal{Val: DInt(uval), Str: lval.str}
 	if err != nil {
 		lval.id = ERROR
 		lval.str = err.Error()
@@ -583,7 +583,7 @@ func (s *scanner) scanParam(lval *sqlSymType) {
 	}
 	// uval is now in the range [0, 1<<63]. Casting to an int64 leaves the range
 	// [0, 1<<63 - 1] intact and moves 1<<63 to -1<<63 (a.k.a. math.MinInt64).
-	lval.union.val = IntVal{Val: int64(uval), Str: lval.str}
+	lval.union.val = IntVal{Val: DInt(uval), Str: lval.str}
 	if err != nil {
 		lval.id = ERROR
 		lval.str = err.Error()

--- a/sql/parser/scan_test.go
+++ b/sql/parser/scan_test.go
@@ -256,7 +256,7 @@ func TestScanNumber(t *testing.T) {
 func TestScanParam(t *testing.T) {
 	testData := []struct {
 		sql      string
-		expected int64
+		expected DInt
 	}{
 		{`$1`, 1},
 		{`$1a`, 1},

--- a/sql/parser/set.go
+++ b/sql/parser/set.go
@@ -68,11 +68,11 @@ type SetTimeZone struct {
 func (node *SetTimeZone) String() string {
 	prefix := "SET TIME ZONE"
 	switch v := node.Value.(type) {
-	case DInterval:
+	case *DInterval:
 		return fmt.Sprintf("%s INTERVAL '%s'", prefix, v)
 
-	case DString:
-		if zone := string(v); zone == "DEFAULT" || zone == "LOCAL" {
+	case *DString:
+		if zone := string(*v); zone == "DEFAULT" || zone == "LOCAL" {
 			return fmt.Sprintf("%s %s", prefix, zone)
 		}
 	}

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -4877,44 +4877,44 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1169
 		{
-			sqlVAL.union.val = DBool(true)
+			sqlVAL.union.val = MakeDBool(true)
 		}
 	case 127:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1173
 		{
-			sqlVAL.union.val = DBool(false)
+			sqlVAL.union.val = MakeDBool(false)
 		}
 	case 128:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1177
 		{
-			sqlVAL.union.val = DString(sqlDollar[1].str)
+			sqlVAL.union.val = NewDString(sqlDollar[1].str)
 		}
 	case 130:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1192
 		{
-			sqlVAL.union.val = DString(sqlDollar[1].str)
+			sqlVAL.union.val = NewDString(sqlDollar[1].str)
 		}
 	case 131:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1196
 		{
-			sqlVAL.union.val = DString(sqlDollar[1].str)
+			sqlVAL.union.val = NewDString(sqlDollar[1].str)
 		}
 	case 132:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:1200
 		{
-			expr := &CastExpr{Expr: DString(sqlDollar[2].str), Type: sqlDollar[1].union.colType()}
+			expr := &CastExpr{Expr: NewDString(sqlDollar[2].str), Type: sqlDollar[1].union.colType()}
 			var ctx EvalContext
 			d, err := expr.Eval(ctx)
 			if err != nil {
 				sqllex.Error("cannot evaluate to an interval type")
 				return 1
 			}
-			if _, ok := d.(DInterval); !ok {
+			if _, ok := d.(*DInterval); !ok {
 				panic("not an interval type")
 			}
 			sqlVAL.union.val = d
@@ -4923,13 +4923,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1215
 		{
-			sqlVAL.union.val = DString(sqlDollar[1].str)
+			sqlVAL.union.val = NewDString(sqlDollar[1].str)
 		}
 	case 135:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1219
 		{
-			sqlVAL.union.val = DString(sqlDollar[1].str)
+			sqlVAL.union.val = NewDString(sqlDollar[1].str)
 		}
 	case 136:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
@@ -4952,13 +4952,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1230
 		{
-			sqlVAL.union.val = DString(sqlDollar[1].str)
+			sqlVAL.union.val = NewDString(sqlDollar[1].str)
 		}
 	case 140:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1234
 		{
-			sqlVAL.union.val = DString(sqlDollar[1].str)
+			sqlVAL.union.val = NewDString(sqlDollar[1].str)
 		}
 	case 141:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
@@ -5400,7 +5400,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1563
 		{
-			sqlVAL.union.val = DInt(sqlDollar[1].union.ival().Val)
+			sqlVAL.union.val = NewDInt(DInt(sqlDollar[1].union.ival().Val))
 		}
 	case 215:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
@@ -7035,25 +7035,25 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:2964
 		{
-			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DBool(true)}
+			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: MakeDBool(true)}
 		}
 	case 509:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
 		//line sql.y:2968
 		{
-			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DBool(true)}
+			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: MakeDBool(true)}
 		}
 	case 510:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:2972
 		{
-			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DBool(false)}
+			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: MakeDBool(false)}
 		}
 	case 511:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
 		//line sql.y:2976
 		{
-			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DBool(false)}
+			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: MakeDBool(false)}
 		}
 	case 512:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
@@ -7802,7 +7802,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:3518
 		{
-			sqlVAL.union.val = Exprs{DString(sqlDollar[1].str), sqlDollar[3].union.expr()}
+			sqlVAL.union.val = Exprs{NewDString(sqlDollar[1].str), sqlDollar[3].union.expr()}
 		}
 	case 649:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
@@ -7856,7 +7856,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:3590
 		{
-			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), DInt(1), sqlDollar[2].union.expr()}
+			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), NewDInt(1), sqlDollar[2].union.expr()}
 		}
 	case 658:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
@@ -8201,13 +8201,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3910
 		{
-			sqlVAL.union.val = DString(sqlDollar[1].str)
+			sqlVAL.union.val = NewDString(sqlDollar[1].str)
 		}
 	case 718:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3914
 		{
-			sqlVAL.union.val = DBytes(sqlDollar[1].str)
+			sqlVAL.union.val = NewDBytes(DBytes(sqlDollar[1].str))
 		}
 	case 719:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
@@ -8219,31 +8219,31 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:3919
 		{
-			sqlVAL.union.val = &CastExpr{Expr: DString(sqlDollar[2].str), Type: sqlDollar[1].union.colType()}
+			sqlVAL.union.val = &CastExpr{Expr: NewDString(sqlDollar[2].str), Type: sqlDollar[1].union.colType()}
 		}
 	case 721:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:3923
 		{
-			sqlVAL.union.val = &CastExpr{Expr: DString(sqlDollar[2].str), Type: sqlDollar[1].union.colType()}
+			sqlVAL.union.val = &CastExpr{Expr: NewDString(sqlDollar[2].str), Type: sqlDollar[1].union.colType()}
 		}
 	case 722:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
 		//line sql.y:3927
 		{
-			sqlVAL.union.val = &CastExpr{Expr: DString(sqlDollar[5].str), Type: sqlDollar[1].union.colType()}
+			sqlVAL.union.val = &CastExpr{Expr: NewDString(sqlDollar[5].str), Type: sqlDollar[1].union.colType()}
 		}
 	case 723:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3931
 		{
-			sqlVAL.union.val = DBool(true)
+			sqlVAL.union.val = MakeDBool(true)
 		}
 	case 724:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3935
 		{
-			sqlVAL.union.val = DBool(false)
+			sqlVAL.union.val = MakeDBool(false)
 		}
 	case 725:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -1167,15 +1167,15 @@ user_priority:
 opt_boolean_or_string:
   TRUE
   {
-    $$.val = DBool(true)
+    $$.val = MakeDBool(true)
   }
 | FALSE
   {
-    $$.val = DBool(false)
+    $$.val = MakeDBool(false)
   }
 | ON
   {
-    $$.val = DString($1)
+    $$.val = NewDString($1)
   }
   // OFF is also accepted as a boolean value, but is handled by the
   // non_reserved_word rule. The action for booleans and strings is the same,
@@ -1190,22 +1190,22 @@ opt_boolean_or_string:
 zone_value:
   SCONST
   {
-    $$.val = DString($1)
+    $$.val = NewDString($1)
   }
 | IDENT
   {
-    $$.val = DString($1)
+    $$.val = NewDString($1)
   }
 | const_interval SCONST opt_interval
   {
-    expr := &CastExpr{Expr: DString($2), Type: $1.colType()}
+    expr := &CastExpr{Expr: NewDString($2), Type: $1.colType()}
     var ctx EvalContext
     d, err := expr.Eval(ctx)
     if err != nil {
       sqllex.Error("cannot evaluate to an interval type")
       return 1
     }
-    if _, ok := d.(DInterval); !ok {
+    if _, ok := d.(*DInterval); !ok {
       panic("not an interval type")
     }
     $$.val = d
@@ -1213,11 +1213,11 @@ zone_value:
 | numeric_only
 | DEFAULT
   {
-    $$.val = DString($1)
+    $$.val = NewDString($1)
   }
 | LOCAL
   {
-    $$.val = DString($1)
+    $$.val = NewDString($1)
   }
 
 opt_encoding:
@@ -1228,11 +1228,11 @@ opt_encoding:
 non_reserved_word_or_sconst:
   non_reserved_word
   {
-    $$.val = DString($1)
+    $$.val = NewDString($1)
   }
 | SCONST
   {
-    $$.val = DString($1)
+    $$.val = NewDString($1)
   }
 
 show_stmt:
@@ -1561,7 +1561,7 @@ numeric_only:
   }
 | signed_iconst
   {
-    $$.val = DInt($1.ival().Val)
+    $$.val = NewDInt(DInt($1.ival().Val))
   }
 
 // TRUNCATE table relname1, relname2, ...
@@ -2962,19 +2962,19 @@ a_expr:
 | row OVERLAPS row { unimplemented() }
 | a_expr IS TRUE %prec IS
   {
-    $$.val = &ComparisonExpr{Operator: Is, Left: $1.expr(), Right: DBool(true)}
+    $$.val = &ComparisonExpr{Operator: Is, Left: $1.expr(), Right: MakeDBool(true)}
   }
 | a_expr IS NOT TRUE %prec IS
   {
-    $$.val = &ComparisonExpr{Operator: IsNot, Left: $1.expr(), Right: DBool(true)}
+    $$.val = &ComparisonExpr{Operator: IsNot, Left: $1.expr(), Right: MakeDBool(true)}
   }
 | a_expr IS FALSE %prec IS
   {
-    $$.val = &ComparisonExpr{Operator: Is, Left: $1.expr(), Right: DBool(false)}
+    $$.val = &ComparisonExpr{Operator: Is, Left: $1.expr(), Right: MakeDBool(false)}
   }
 | a_expr IS NOT FALSE %prec IS
   {
-    $$.val = &ComparisonExpr{Operator: IsNot, Left: $1.expr(), Right: DBool(false)}
+    $$.val = &ComparisonExpr{Operator: IsNot, Left: $1.expr(), Right: MakeDBool(false)}
   }
 | a_expr IS UNKNOWN %prec IS
   {
@@ -3516,7 +3516,7 @@ array_expr_list:
 extract_list:
   extract_arg FROM a_expr
   {
-    $$.val = Exprs{DString($1), $3.expr()}
+    $$.val = Exprs{NewDString($1), $3.expr()}
   }
 
 // TODO(vivek): Narrow down to just IDENT once the other
@@ -3588,7 +3588,7 @@ substr_list:
   }
 | a_expr substr_for
   {
-    $$.val = Exprs{$1.expr(), DInt(1), $2.expr()}
+    $$.val = Exprs{$1.expr(), NewDInt(1), $2.expr()}
   }
 | expr_list
   {
@@ -3908,32 +3908,32 @@ a_expr_const:
   }
 | SCONST
   {
-    $$.val = DString($1)
+    $$.val = NewDString($1)
   }
 | BCONST
   {
-    $$.val = DBytes($1)
+    $$.val = NewDBytes(DBytes($1))
   }
 | func_name '(' expr_list opt_sort_clause ')' SCONST { unimplemented() }
 | const_typename SCONST
   {
-    $$.val = &CastExpr{Expr: DString($2), Type: $1.colType()}
+    $$.val = &CastExpr{Expr: NewDString($2), Type: $1.colType()}
   }
 | const_interval SCONST opt_interval
   {
-    $$.val = &CastExpr{Expr: DString($2), Type: $1.colType()}
+    $$.val = &CastExpr{Expr: NewDString($2), Type: $1.colType()}
   }
 | const_interval '(' ICONST ')' SCONST
   {
-    $$.val = &CastExpr{Expr: DString($5), Type: $1.colType()}
+    $$.val = &CastExpr{Expr: NewDString($5), Type: $1.colType()}
   }
 | TRUE
   {
-    $$.val = DBool(true)
+    $$.val = MakeDBool(true)
   }
 | FALSE
   {
-    $$.val = DBool(false)
+    $$.val = MakeDBool(false)
   }
 | NULL
   {

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -344,40 +344,40 @@ func (expr NumVal) Walk(_ Visitor) Expr { return expr }
 func (expr ValArg) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr DBool) Walk(_ Visitor) Expr { return expr }
+func (expr *DBool) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr DBytes) Walk(_ Visitor) Expr { return expr }
+func (expr *DBytes) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr DDate) Walk(_ Visitor) Expr { return expr }
+func (expr *DDate) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr DFloat) Walk(_ Visitor) Expr { return expr }
+func (expr *DFloat) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
 func (expr *DDecimal) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr DInt) Walk(_ Visitor) Expr { return expr }
+func (expr *DInt) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr DInterval) Walk(_ Visitor) Expr { return expr }
+func (expr *DInterval) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
 func (expr dNull) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr DString) Walk(_ Visitor) Expr { return expr }
+func (expr *DString) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr DTimestamp) Walk(_ Visitor) Expr { return expr }
+func (expr *DTimestamp) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr DTuple) Walk(_ Visitor) Expr { return expr }
+func (expr *DTuple) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr DValArg) Walk(_ Visitor) Expr { return expr }
+func (expr *DValArg) Walk(_ Visitor) Expr { return expr }
 
 // WalkExpr traverses the nodes in an expression.
 func WalkExpr(v Visitor, expr Expr) (newExpr Expr, changed bool) {
@@ -753,7 +753,7 @@ func (m MapArgs) SetInferredType(d, typ Datum) (set Datum, err error) {
 	if m == nil {
 		return nil, nil
 	}
-	v, ok := d.(DValArg)
+	v, ok := d.(*DValArg)
 	if !ok {
 		return nil, nil
 	}

--- a/sql/parser/walk_test.go
+++ b/sql/parser/walk_test.go
@@ -24,56 +24,61 @@ import (
 
 // TestFillArgs tests both FillArgs and WalkExpr.
 func TestFillArgs(t *testing.T) {
+	dstring := NewDString
+	dint := NewDInt
+	dfloat := NewDFloat
+	dbool := MakeDBool
+
 	testData := []struct {
 		expr     string
 		expected string
 		args     MapArgs
 	}{
-		{`$1`, `'a'`, MapArgs{`1`: DString(`a`)}},
-		{`($1, $1, $1)`, `('a', 'a', 'a')`, MapArgs{`1`: DString(`a`)}},
-		{`$1 & $2`, `1 & 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 | $2`, `1 | 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 ^ $2`, `1 ^ 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 + $2`, `1 + 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 - $2`, `1 - 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 * $2`, `1 * 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 % $2`, `1 % 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 / $2`, `1 / 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 / $2`, `1 / 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
+		{`$1`, `'a'`, MapArgs{`1`: dstring(`a`)}},
+		{`($1, $1, $1)`, `('a', 'a', 'a')`, MapArgs{`1`: dstring(`a`)}},
+		{`$1 & $2`, `1 & 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 | $2`, `1 | 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 ^ $2`, `1 ^ 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 + $2`, `1 + 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 - $2`, `1 - 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 * $2`, `1 * 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 % $2`, `1 % 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 / $2`, `1 / 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 / $2`, `1 / 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
 		{`$1 + $2 + ($3 * $4)`, `1 + 2 + (3 * 4)`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3), `4`: DInt(4)}},
-		{`$1 || $2`, `'a' || 'b'`, MapArgs{`1`: DString("a"), `2`: DString("b")}},
-		{`$1 OR $2`, `true OR false`, MapArgs{`1`: DBool(true), `2`: DBool(false)}},
-		{`$1 AND $2`, `true AND false`, MapArgs{`1`: DBool(true), `2`: DBool(false)}},
-		{`$1 = $2`, `1 = 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 != $2`, `1 != 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 <> $2`, `1 != 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 < $2`, `1 < 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 <= $2`, `1 <= 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 > $2`, `1 > 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 >= $2`, `1 >= 2`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
-		{`$1 IS NULL`, `1 IS NULL`, MapArgs{`1`: DInt(1)}},
-		{`$1 IS NOT NULL`, `1 IS NOT NULL`, MapArgs{`1`: DInt(1)}},
-		{`$1 BETWEEN $2 AND $3`, `1 BETWEEN 2 AND 3`, MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
+			MapArgs{`1`: dint(1), `2`: dint(2), `3`: dint(3), `4`: dint(4)}},
+		{`$1 || $2`, `'a' || 'b'`, MapArgs{`1`: dstring("a"), `2`: dstring("b")}},
+		{`$1 OR $2`, `true OR false`, MapArgs{`1`: dbool(true), `2`: dbool(false)}},
+		{`$1 AND $2`, `true AND false`, MapArgs{`1`: dbool(true), `2`: dbool(false)}},
+		{`$1 = $2`, `1 = 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 != $2`, `1 != 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 <> $2`, `1 != 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 < $2`, `1 < 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 <= $2`, `1 <= 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 > $2`, `1 > 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 >= $2`, `1 >= 2`, MapArgs{`1`: dint(1), `2`: dint(2)}},
+		{`$1 IS NULL`, `1 IS NULL`, MapArgs{`1`: dint(1)}},
+		{`$1 IS NOT NULL`, `1 IS NOT NULL`, MapArgs{`1`: dint(1)}},
+		{`$1 BETWEEN $2 AND $3`, `1 BETWEEN 2 AND 3`, MapArgs{`1`: dint(1), `2`: dint(2), `3`: dint(3)}},
 		{`$1 NOT BETWEEN $2 AND $3`, `1 NOT BETWEEN 2 AND 3`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
-		{`CASE WHEN $1 THEN $2 END`, `CASE WHEN 1 THEN 2 END`, MapArgs{`1`: DInt(1), `2`: DInt(2)}},
+			MapArgs{`1`: dint(1), `2`: dint(2), `3`: dint(3)}},
+		{`CASE WHEN $1 THEN $2 END`, `CASE WHEN 1 THEN 2 END`, MapArgs{`1`: dint(1), `2`: dint(2)}},
 		{`CASE WHEN $1 THEN $2 ELSE $3 END`, `CASE WHEN 1 THEN 2 ELSE 3 END`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
+			MapArgs{`1`: dint(1), `2`: dint(2), `3`: dint(3)}},
 		{`CASE $1 WHEN $2 THEN $3 ELSE $4 END`, `CASE 1 WHEN 2 THEN 3 ELSE 4 END`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3), `4`: DInt(4)}},
+			MapArgs{`1`: dint(1), `2`: dint(2), `3`: dint(3), `4`: dint(4)}},
 		{`($1, $2) = ($3, $4)`, `(1, 2) = (3, 4)`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3), `4`: DInt(4)}},
+			MapArgs{`1`: dint(1), `2`: dint(2), `3`: dint(3), `4`: dint(4)}},
 		{`$1 IN ($2, $3)`, `1 IN (2, 3)`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
+			MapArgs{`1`: dint(1), `2`: dint(2), `3`: dint(3)}},
 		{`$1 NOT IN ($2, $3)`, `1 NOT IN (2, 3)`,
-			MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DInt(3)}},
-		{`length($1)`, `length('a')`, MapArgs{`1`: DString("a")}},
-		{`length($1, $2)`, `length('a', 'b')`, MapArgs{`1`: DString("a"), `2`: DString("b")}},
-		{`CAST($1 AS INT)`, `CAST(1.1 AS INT)`, MapArgs{`1`: DFloat(1.1)}},
-		{`ROW($1, $2, $3)`, `ROW(1, 2, '3')`, MapArgs{`1`: DInt(1), `2`: DInt(2), `3`: DString("3")}},
-		{`(SELECT $1)`, `(SELECT 'a')`, MapArgs{`1`: DString("a")}},
-		{`EXISTS (SELECT $1)`, `EXISTS (SELECT 'a')`, MapArgs{`1`: DString("a")}},
+			MapArgs{`1`: dint(1), `2`: dint(2), `3`: dint(3)}},
+		{`length($1)`, `length('a')`, MapArgs{`1`: dstring("a")}},
+		{`length($1, $2)`, `length('a', 'b')`, MapArgs{`1`: dstring("a"), `2`: dstring("b")}},
+		{`CAST($1 AS INT)`, `CAST(1.1 AS INT)`, MapArgs{`1`: dfloat(1.1)}},
+		{`ROW($1, $2, $3)`, `ROW(1, 2, '3')`, MapArgs{`1`: dint(1), `2`: dint(2), `3`: dstring("3")}},
+		{`(SELECT $1)`, `(SELECT 'a')`, MapArgs{`1`: dstring("a")}},
+		{`EXISTS (SELECT $1)`, `EXISTS (SELECT 'a')`, MapArgs{`1`: dstring("a")}},
 	}
 
 	for _, d := range testData {
@@ -114,6 +119,10 @@ func TestFillArgsError(t *testing.T) {
 }
 
 func TestWalkStmt(t *testing.T) {
+	dstring := NewDString
+	dint := NewDInt
+	dfloat := NewDFloat
+
 	testData := []struct {
 		sql      string
 		expected string
@@ -121,19 +130,19 @@ func TestWalkStmt(t *testing.T) {
 	}{
 		{`DELETE FROM db.table WHERE k IN ($1, $2)`,
 			`DELETE FROM db.table WHERE k IN ('a', 'c')`,
-			MapArgs{`1`: DString(`a`), `2`: DString(`c`)}},
+			MapArgs{`1`: dstring(`a`), `2`: dstring(`c`)}},
 		{`INSERT INTO db.table (k, v) VALUES (1, 2), ($1, $2)`,
 			`INSERT INTO db.table (k, v) VALUES (1, 2), (3, 4)`,
-			MapArgs{`1`: DInt(3), `2`: DInt(4)}},
+			MapArgs{`1`: dint(3), `2`: dint(4)}},
 		{`SELECT $1, $2 FROM db.table ORDER BY $1 DESC LIMIT $3 OFFSET $4`,
 			`SELECT 'a', 'b' FROM db.table ORDER BY 'a' DESC LIMIT 5 OFFSET 2`,
-			MapArgs{`1`: DString(`a`), `2`: DString(`b`), `3`: DInt(5), `4`: DInt(2)}},
+			MapArgs{`1`: dstring(`a`), `2`: dstring(`b`), `3`: dint(5), `4`: dint(2)}},
 		{`SELECT $1, $2 FROM db.table WHERE c in ($3, 2 * $4) GROUP BY $1 HAVING COUNT($5) > $6`,
 			`SELECT 'a', 'b' FROM db.table WHERE c in (1.1, 2 * 6.5) GROUP BY 'a' HAVING COUNT('d') > 6`,
-			MapArgs{`1`: DString(`a`), `2`: DString(`b`), `3`: DFloat(1.1), `4`: DFloat(6.5), `5`: DString('d'), `6`: DInt(6)}},
+			MapArgs{`1`: dstring(`a`), `2`: dstring(`b`), `3`: dfloat(1.1), `4`: dfloat(6.5), `5`: dstring(`d`), `6`: dint(6)}},
 		{`UPDATE db.table SET v = $3 WHERE k IN ($1, $2)`,
 			`UPDATE db.table SET v = 2 WHERE k IN ('a', 'b')`,
-			MapArgs{`1`: DString(`a`), `2`: DString(`b`), `3`: DInt(2)}},
+			MapArgs{`1`: dstring(`a`), `2`: dstring(`b`), `3`: dint(2)}},
 	}
 	for _, d := range testData {
 		q, err := ParseOneTraditional(d.sql)

--- a/sql/set.go
+++ b/sql/set.go
@@ -79,12 +79,12 @@ func (p *planner) getStringVal(name string, values parser.Exprs) (string, error)
 	if err != nil {
 		return "", err
 	}
-	s, ok := val.(parser.DString)
+	s, ok := val.(*parser.DString)
 	if !ok {
 		return "", fmt.Errorf("%s: requires a single string value: %s is a %s",
 			name, values[0], val.Type())
 	}
-	return string(s), nil
+	return string(*s), nil
 }
 
 func (p *planner) SetDefaultIsolation(n *parser.SetDefaultIsolation) (planNode, error) {
@@ -106,8 +106,8 @@ func (p *planner) SetTimeZone(n *parser.SetTimeZone) (planNode, error) {
 	}
 	var offset int64
 	switch v := d.(type) {
-	case parser.DString:
-		location := string(v)
+	case *parser.DString:
+		location := string(*v)
 		if location == "DEFAULT" || location == "LOCAL" {
 			location = "UTC"
 		}
@@ -116,17 +116,17 @@ func (p *planner) SetTimeZone(n *parser.SetTimeZone) (planNode, error) {
 		}
 		p.session.Timezone = &SessionLocation{Location: location}
 
-	case parser.DInterval:
+	case *parser.DInterval:
 		offset, _, _, err = v.Duration.Div(time.Second.Nanoseconds()).Encode()
 		if err != nil {
 			return nil, err
 		}
 
-	case parser.DInt:
-		offset = int64(v) * 60 * 60
+	case *parser.DInt:
+		offset = int64(*v) * 60 * 60
 
-	case parser.DFloat:
-		offset = int64(float64(v) * 60.0 * 60.0)
+	case *parser.DFloat:
+		offset = int64(float64(*v) * 60.0 * 60.0)
 
 	case *parser.DDecimal:
 		sixty := inf.NewDec(60, 0)

--- a/sql/show.go
+++ b/sql/show.go
@@ -35,22 +35,22 @@ func (p *planner) Show(n *parser.Show) (planNode, error) {
 
 	switch name {
 	case `DATABASE`:
-		v.rows = append(v.rows, []parser.Datum{parser.DString(p.session.Database)})
+		v.rows = append(v.rows, []parser.Datum{parser.NewDString(p.session.Database)})
 	case `TIME ZONE`:
 		loc, err := p.evalCtx.GetLocation()
 		if err != nil {
 			return nil, err
 		}
-		v.rows = append(v.rows, []parser.Datum{parser.DString(loc.String())})
+		v.rows = append(v.rows, []parser.Datum{parser.NewDString(loc.String())})
 	case `SYNTAX`:
-		v.rows = append(v.rows, []parser.Datum{parser.DString(parser.Syntax(p.session.Syntax).String())})
+		v.rows = append(v.rows, []parser.Datum{parser.NewDString(parser.Syntax(p.session.Syntax).String())})
 	case `DEFAULT_TRANSACTION_ISOLATION`:
 		level := p.session.DefaultIsolationLevel.String()
-		v.rows = append(v.rows, []parser.Datum{parser.DString(level)})
+		v.rows = append(v.rows, []parser.Datum{parser.NewDString(level)})
 	case `TRANSACTION ISOLATION LEVEL`:
-		v.rows = append(v.rows, []parser.Datum{parser.DString(p.txn.Proto.Isolation.String())})
+		v.rows = append(v.rows, []parser.Datum{parser.NewDString(p.txn.Proto.Isolation.String())})
 	case `TRANSACTION PRIORITY`:
-		v.rows = append(v.rows, []parser.Datum{parser.DString(p.txn.UserPriority.String())})
+		v.rows = append(v.rows, []parser.Datum{parser.NewDString(p.txn.UserPriority.String())})
 	default:
 		return nil, fmt.Errorf("unknown variable: %q", name)
 	}
@@ -78,12 +78,12 @@ func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, *roachpb.Error) 
 	for i, col := range desc.Columns {
 		defaultExpr := parser.Datum(parser.DNull)
 		if e := desc.Columns[i].DefaultExpr; e != nil {
-			defaultExpr = parser.DString(*e)
+			defaultExpr = parser.NewDString(*e)
 		}
 		v.rows = append(v.rows, []parser.Datum{
-			parser.DString(desc.Columns[i].Name),
-			parser.DString(col.Type.SQLString()),
-			parser.DBool(desc.Columns[i].Nullable),
+			parser.NewDString(desc.Columns[i].Name),
+			parser.NewDString(col.Type.SQLString()),
+			parser.MakeDBool(parser.DBool(desc.Columns[i].Nullable)),
 			defaultExpr,
 		})
 	}
@@ -111,7 +111,7 @@ func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, *roachpb.Err
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
-		v.rows = append(v.rows, []parser.Datum{parser.DString(name)})
+		v.rows = append(v.rows, []parser.Datum{parser.NewDString(name)})
 	}
 	return v, nil
 }
@@ -159,9 +159,9 @@ func (p *planner) ShowGrants(n *parser.ShowGrants) (planNode, *roachpb.Error) {
 				}
 			}
 			v.rows = append(v.rows, []parser.Datum{
-				parser.DString(descriptor.GetName()),
-				parser.DString(userPriv.User),
-				parser.DString(userPriv.Privileges),
+				parser.NewDString(descriptor.GetName()),
+				parser.NewDString(userPriv.User),
+				parser.NewDString(userPriv.Privileges),
 			})
 		}
 	}
@@ -193,13 +193,13 @@ func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, *roachpb.Error) {
 	appendRow := func(index IndexDescriptor, colName string, sequence int,
 		direction string, isStored bool) {
 		v.rows = append(v.rows, []parser.Datum{
-			parser.DString(n.Table.Table()),
-			parser.DString(index.Name),
-			parser.DBool(index.Unique),
-			parser.DInt(sequence),
-			parser.DString(colName),
-			parser.DString(direction),
-			parser.DBool(isStored),
+			parser.NewDString(n.Table.Table()),
+			parser.NewDString(index.Name),
+			parser.MakeDBool(parser.DBool(index.Unique)),
+			parser.NewDInt(parser.DInt(sequence)),
+			parser.NewDString(colName),
+			parser.NewDString(direction),
+			parser.MakeDBool(parser.DBool(isStored)),
 		})
 	}
 	for _, index := range append([]IndexDescriptor{desc.PrimaryIndex}, desc.Indexes...) {
@@ -245,7 +245,7 @@ func (p *planner) ShowTables(n *parser.ShowTables) (planNode, *roachpb.Error) {
 	}
 	v := &valuesNode{columns: []ResultColumn{{Name: "Table", Typ: parser.DummyString}}}
 	for _, name := range tableNames {
-		v.rows = append(v.rows, []parser.Datum{parser.DString(name.Table())})
+		v.rows = append(v.rows, []parser.Datum{parser.NewDString(name.Table())})
 	}
 
 	return v, nil

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -143,8 +143,8 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, *roach
 // Here "1" refers to the first render target "a". The returned index is 0.
 func colIndex(numOriginalCols int, expr parser.Expr) (int, error) {
 	switch i := expr.(type) {
-	case parser.DInt:
-		index := int(i)
+	case *parser.DInt:
+		index := int(*i)
 		if numCols := numOriginalCols; index < 1 || index > numCols {
 			return -1, fmt.Errorf("invalid column index: %d not in range [1, %d]", index, numCols)
 		}

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -103,15 +103,15 @@ func (n *explainTraceNode) Next() bool {
 					duration = fmt.Sprintf("%.3fms", time.Duration(entry.Timestamp.Sub(n.lastTS)).Seconds()*1000)
 				}
 				cols := append(parser.DTuple{
-					parser.DString(commulativeDuration),
-					parser.DString(duration),
-					parser.DInt(basePos + i),
-					parser.DString(sp.Operation),
-					parser.DString(entry.Event),
+					parser.NewDString(commulativeDuration),
+					parser.NewDString(duration),
+					parser.NewDInt(parser.DInt(basePos + i)),
+					parser.NewDString(sp.Operation),
+					parser.NewDString(entry.Event),
 				}, vals.AsRow()...)
 
 				// Timestamp is added for sorting, but will be removed after sort.
-				n.rows = append(n.rows, append(cols, parser.DTimestamp{Time: entry.Timestamp}))
+				n.rows = append(n.rows, append(cols, &parser.DTimestamp{Time: entry.Timestamp}))
 				n.lastTS, n.lastPos = entry.Timestamp, i
 			}
 		}

--- a/sql/update.go
+++ b/sql/update.go
@@ -211,8 +211,8 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 			switch t := newExpr.(type) {
 			case *parser.Tuple:
 				n = len(t.Exprs)
-			case parser.DTuple:
-				n = len(t)
+			case *parser.DTuple:
+				n = len(*t)
 			default:
 				return nil, roachpb.NewErrorf("unsupported tuple assignment: %T", newExpr)
 			}
@@ -349,8 +349,8 @@ func (u *updateNode) Start() *roachpb.Error {
 					targets = append(targets, parser.SelectExpr{Expr: e})
 					i++
 				}
-			case parser.DTuple:
-				for _, e := range t {
+			case *parser.DTuple:
+				for _, e := range *t {
 					targets = append(targets, parser.SelectExpr{Expr: e})
 					i++
 				}

--- a/sql/values.go
+++ b/sql/values.go
@@ -71,11 +71,11 @@ func (p *planner) ValuesClause(n *parser.ValuesClause) (planNode, *roachpb.Error
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
-		vals, ok := data.(parser.DTuple)
+		vals, ok := data.(*parser.DTuple)
 		if !ok {
 			return nil, roachpb.NewUErrorf("expected a tuple, but found %T", data)
 		}
-		v.rows = append(v.rows, vals)
+		v.rows = append(v.rows, *vals)
 	}
 
 	return v, nil

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -43,7 +43,7 @@ func TestValues(t *testing.T) {
 	unsupp := &parser.RangeCond{}
 
 	intVal := func(v int64) *parser.IntVal {
-		return &parser.IntVal{Val: v}
+		return &parser.IntVal{Val: parser.DInt(v)}
 	}
 	asRow := func(datums ...parser.Datum) []parser.DTuple {
 		return []parser.DTuple{datums}
@@ -63,32 +63,32 @@ func TestValues(t *testing.T) {
 	}{
 		{
 			makeValues(makeTuple(intVal(vInt))),
-			asRow(parser.DInt(vInt)),
+			asRow(parser.NewDInt(parser.DInt(vInt))),
 			true,
 		},
 		{
 			makeValues(makeTuple(intVal(vInt), intVal(vInt))),
-			asRow(parser.DInt(vInt), parser.DInt(vInt)),
+			asRow(parser.NewDInt(parser.DInt(vInt)), parser.NewDInt(parser.DInt(vInt))),
 			true,
 		},
 		{
 			makeValues(makeTuple(parser.NumVal(fmt.Sprintf("%0.5f", vNum)))),
-			asRow(parser.DFloat(vNum)),
+			asRow(parser.NewDFloat(parser.DFloat(vNum))),
 			true,
 		},
 		{
-			makeValues(makeTuple(parser.DString(vStr))),
-			asRow(parser.DString(vStr)),
+			makeValues(makeTuple(parser.NewDString(vStr))),
+			asRow(parser.NewDString(vStr)),
 			true,
 		},
 		{
-			makeValues(makeTuple(parser.DBytes(vStr))),
-			asRow(parser.DBytes(vStr)),
+			makeValues(makeTuple(parser.NewDBytes(parser.DBytes(vStr)))),
+			asRow(parser.NewDBytes(parser.DBytes(vStr))),
 			true,
 		},
 		{
-			makeValues(makeTuple(parser.DBool(vBool))),
-			asRow(parser.DBool(vBool)),
+			makeValues(makeTuple(parser.MakeDBool(parser.DBool(vBool)))),
+			asRow(parser.MakeDBool(parser.DBool(vBool))),
 			true,
 		},
 		{


### PR DESCRIPTION
```
name                old time/op    new time/op    delta
KVScan1_SQL-32         189µs ± 3%     186µs ± 2%   -1.65%  (p=0.023 n=10+10)
KVScan10_SQL-32        263µs ± 6%     268µs ± 4%     ~     (p=0.190 n=10+10)
KVScan100_SQL-32       938µs ± 3%     945µs ± 4%     ~     (p=0.739 n=10+10)
KVScan1000_SQL-32     7.63ms ± 9%    7.35ms ± 6%     ~     (p=0.089 n=10+10)
KVScan10000_SQL-32    74.8ms ± 7%    71.0ms ± 5%   -4.99%  (p=0.007 n=10+10)

name                old allocs/op  new allocs/op  delta
KVScan1_SQL-32           213 ± 0%       209 ± 0%   -1.88%  (p=0.000 n=10+10)
KVScan10_SQL-32          356 ± 0%       308 ± 0%  -13.48%  (p=0.000 n=10+10)
KVScan100_SQL-32       1.72k ± 0%     1.24k ± 0%  -28.05%   (p=0.000 n=10+9)
KVScan1000_SQL-32      15.2k ± 0%     10.4k ± 0%  -31.57%   (p=0.000 n=10+9)
KVScan10000_SQL-32      151k ± 0%      102k ± 0%  -31.97%   (p=0.000 n=9+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6142)

<!-- Reviewable:end -->
