### PR TITLE
UI: Adds the ability to shift the metric graph timescales

### DIFF
--- a/ui/styl/partials/layout.styl
+++ b/ui/styl/partials/layout.styl
@@ -45,6 +45,8 @@ body
   position relative
   padding-left $nav-width
   min-height "calc(100vh - %s - 1px)" % $footer-height // 1 more than footer height to account for the border
+  @media (max-height: 415px) // handles the case where the height is smaller than the side-nav
+    min-height 341px
 
   &:after
     content ""
@@ -76,7 +78,7 @@ body
     padding-top $top-bar-height + 10px
     width 100%
 
-  .nav + &
+  .nav-container + &
     padding-top "calc(%s + 3rem)" % ($top-bar-height + $subnav-height)
 
   &.table
@@ -84,7 +86,7 @@ body
     padding-left 0
     padding-right 0
 
-    .nav + &
+    .nav-container + &
       padding-top $top-bar-height + $subnav-height
 
   h1
@@ -183,6 +185,11 @@ button
     &:hover
       background-color $secondary-gray-14
 
+  &.timescale
+    whitespace nowrap
+    padding 10px
+    width auto
+
 .topbar
   padding 0 3rem 1rem
   background-color white
@@ -266,7 +273,7 @@ button
     strong
       font-family Lato-Bold
 
-.page .nav
+.page .nav-container
   padding 0 3rem 1rem
   background-color $subnav-background
   text-transform uppercase
@@ -568,7 +575,7 @@ table
       text-decoration none
       color $main-gray
 
-.tooltip
+.tooltip, .timescale-selector
   position absolute
   z-index $tooltip-layer
   padding 35px
@@ -606,3 +613,36 @@ div.charts
     left auto
     bottom 100%
     top auto
+
+.timescale-selector-container
+  position relative
+
+.timescale-selector
+  right auto
+  left 0
+  top auto
+  white-space nowrap
+  padding 15px 25px
+
+  .text
+    margin-right 30px
+
+  button
+    background-color white
+    color $main-navy
+    width auto
+    padding 10px
+    margin 5px
+    font-family Lato-Semibold
+    &:focus
+      outline 0
+
+    &.selected
+      background-color $secondary-blue
+      color white
+      border-radius 23px
+      font-family Lato-Heavy
+      font-size 13px
+
+  &.show
+    display flex

--- a/ui/styl/partials/navigation-bar.styl
+++ b/ui/styl/partials/navigation-bar.styl
@@ -114,35 +114,61 @@ header
           letter-spacing 1px
 
 .page
-  ul.nav
-    modular-font-size '1'
-    color $subnav-text-color
-    list-style-type none
-    line-height $subnav-height - $subnav-underline-height
+  .nav-container
 
-    font-family Lato-Bold
-    font-size 1.1rem
+    ul.nav
+      display flex
+      flex-flow row nowrap
+      justify-content flex-start
+      modular-font-size '1'
+      color $subnav-text-color
+      list-style-type none
+      line-height $subnav-height - $subnav-underline-height
 
-    li
-      display inline-block
-      margin-right 3rem
+      font-family Lato-Bold
+      font-size 1.1rem
+      max-width calc(100vw - 80px)
+      @media (min-width: 1300px)
+        max-width 1300px
 
-      &.active, &.active:hover
-        color $subnav-active-color
-        font-weight 600
-        border-bottom $subnav-underline-height solid $subnav-active-color
+      li
+        display inline-block
+        margin-right 3rem
+        height $subnav-height
 
-      &:hover
-        color $main-nav-hover
-      a
-        height 100%
-        display block
-        color inherit
-        text-decoration none
+        &.active, &.active:hover
+          color $subnav-active-color
+          font-weight 600
+          border-bottom $subnav-underline-height solid $subnav-active-color
+
         &:hover
-        &:visited
-        &:active
-          color @color
+          color $main-nav-hover
+        a
+          height 100%
+          display block
+          color inherit
+          text-decoration none
+          &:hover
+          &:visited
+          &:active
+            color @color
 
-        div
-          display inline
+          div
+            display inline
+
+        &.timescale-button
+          align-self flex-start
+          flex-basis 100%
+          // width 100%
+          display flex
+          justify-content flex-start
+          flex-flow row nowrap
+          align-items flex-start
+
+          button
+            margin-top auto
+            margin-bottom auto
+            align-self flex-start
+            text-transform none
+            &:focus
+              outline 0

--- a/ui/ts/components/navbar.ts
+++ b/ui/ts/components/navbar.ts
@@ -2,6 +2,7 @@
 /// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
 /// <reference path="../../typings/browser.d.ts" />
 /// <reference path="../util/property.ts" />
+/// <reference path="../components/timescaleselector.ts" />
 
 // Author: Matt Tracy (matt@cockroachlabs.com)
 
@@ -32,8 +33,8 @@ module Components {
 
     export function controller(): void {}
 
-    export function view(ctrl: any, args: {ts: TargetSet; }): _mithril.MithrilVirtualElement {
-      return m(
+    export function view(ctrl: any, args: {ts: TargetSet; timescaleSelector?: boolean; }): _mithril.MithrilVirtualElement {
+      return m(".nav-container", m(
         "ul.nav",
         _.map(args.ts.targets(), function generateLinks(t: Target): MithrilVirtualElement {
           // settings for a relative URL using the mithril router
@@ -59,8 +60,8 @@ module Components {
               t.view
             )
           );
-        })
-      );
+        }).concat(args.timescaleSelector ? m("li.timescale-button", m.component(TimescaleSelector)) : [])
+      ));
     }
   }
 }

--- a/ui/ts/components/timescaleselector.ts
+++ b/ui/ts/components/timescaleselector.ts
@@ -1,0 +1,34 @@
+// source: component/timescaleselector.ts
+/// <reference path="../../typings/browser.d.ts" />
+/// <reference path="../../bower_components/mithriljs/mithril.d.ts" />
+/// <reference path="../util/convert.ts" />
+/// <reference path="../models/timescale.ts" />
+
+module Components {
+  "use strict";
+
+  /**
+   * TimescaleSelector is a component that allows the graph timescale to be changed
+   */
+  export module TimescaleSelector {
+    import MithrilVirtualElement = _mithril.MithrilVirtualElement;
+    import Timescale = Models.Timescale.Timescale;
+    export function controller(): { showTimescales: boolean; } {
+      return {
+        showTimescales: false,
+      };
+    }
+
+    export function view(ctrl: { showTimescales: boolean; }): _mithril.MithrilVirtualElement {
+      return m(".timescale-selector-container", [
+        m("button.timescale", { onclick: (): void => { ctrl.showTimescales = !ctrl.showTimescales; } }, "Select Timescale"),
+        m(".timescale-selector" + (ctrl.showTimescales ? ".show" : ""), [m(".text", "View Last: ")].concat(_.map(Models.Timescale.timescales, (t: Timescale): MithrilVirtualElement => {
+            return m(
+              "button" + (t.selected ? ".selected" : ""),
+              { onclick: (): void => { Models.Timescale.setTimescale(t); } },
+              t.name);
+        }))),
+      ]);
+    }
+  }
+}

--- a/ui/ts/models/metrics.ts
+++ b/ui/ts/models/metrics.ts
@@ -5,6 +5,7 @@
 /// <reference path="../util/convert.ts" />
 /// <reference path="../util/http.ts" />
 /// <reference path="../util/querycache.ts" />
+/// <reference path="../models/timescale.ts" />
 // Author: Matt Tracy (matt@cockroachlabs.com)
 
 /**
@@ -201,6 +202,22 @@ module Models {
       export function Recent(duration: number): TimeSpan {
         return {
           timespan: function(): number[] {
+            let endTime: Date = new Date();
+            let startTime: Date = new Date(endTime.getTime() - duration);
+            return [startTime.getTime(), endTime.getTime()];
+          },
+        };
+      }
+
+      /**
+       * Recent selects a duration of constant size extending backwards
+       * from the current time. The current time is recomputed each time
+       * Recent's timespan() method is called.
+       */
+      export function GlobalTimeSpan(): TimeSpan {
+        return {
+          timespan: function(): number[] {
+            let duration: number = Models.Timescale.getCurrentTimescale();
             let endTime: Date = new Date();
             let startTime: Date = new Date(endTime.getTime() - duration);
             return [startTime.getTime(), endTime.getTime()];

--- a/ui/ts/models/timescale.ts
+++ b/ui/ts/models/timescale.ts
@@ -1,0 +1,35 @@
+// source: models/timescale.ts
+
+/// <reference path="../../typings/browser.d.ts" />
+
+module Models {
+  "use strict";
+  export module Timescale {
+    export interface Timescale {
+      name: string;
+      scale: number;
+      selected?: boolean;
+    };
+
+    export function getScale(amount: number, unit: string): number {
+      return moment.duration(amount, unit).asMilliseconds();
+    }
+
+    export let timescales: Timescale[] = [
+      { name: "10 min", scale: getScale(10, "minutes"), selected: true },
+      { name: "1 hour", scale: getScale(1, "hour") },
+      { name: "6 hours", scale: getScale(6, "hours") },
+      { name: "12 hours", scale: getScale(12, "hours") },
+      { name: "1 day", scale: getScale(1, "day") },
+      // TODO: handle higher time scales
+    ];
+
+    export function setTimescale(t: Timescale): void {
+      _.each(timescales, (ts: Timescale): void => { ts.selected = false; });
+      t.selected = true;
+      // TODO: refresh graphs
+    }
+
+    export let getCurrentTimescale: () => number = (): number => (_.find(timescales, { selected: true }) || _.first(timescales)).scale;
+  }
+}

--- a/ui/ts/pages/cluster.ts
+++ b/ui/ts/pages/cluster.ts
@@ -3,6 +3,7 @@
 /// <reference path="../../typings/browser.d.ts"/>
 /// <reference path="../models/status.ts" />
 /// <reference path="../models/events.ts" />
+/// <reference path="../models/metrics.ts" />
 /// <reference path="../components/metrics.ts" />
 /// <reference path="../components/table.ts" />
 /// <reference path="../components/navbar.ts" />
@@ -85,6 +86,8 @@ module AdminViews {
 
         public constructor(nodeId?: string) {
           this._query = Metrics.NewQuery();
+
+          this._query.timespan(Metrics.Time.GlobalTimeSpan());
 
           this.axesSmall.push({
             titleFn: (allStats: Models.Proto.NodeStatus[]): string => {
@@ -346,7 +349,7 @@ module AdminViews {
 
         return m(".page.cluster", [
           m.component(Components.Topbar, {title: "Cluster", updated: mostRecentlyUpdated}),
-          m.component(NavigationBar, {ts: ctrl.TargetSet()}),
+          m.component(NavigationBar, {ts: ctrl.TargetSet(), timescaleSelector: (detail !== "events")}),
           primaryContent,
         ]);
       }

--- a/ui/ts/pages/nodes.ts
+++ b/ui/ts/pages/nodes.ts
@@ -8,6 +8,8 @@
 /// <reference path="../components/topbar.ts" />
 /// <reference path="../util/format.ts" />
 /// <reference path="../components/visualizations/visualizations.ts" />
+/// <reference path="../models/metrics.ts" />
+/// <reference path="../models/timescale.ts" />
 
 // Author: Bram Gruneir (bram+code@cockroachlabs.com)
 // Author: Matt Tracy (matt@cockroachlabs.com)
@@ -214,6 +216,8 @@ module AdminViews {
 
         public constructor(nodeId?: string) {
           this._query = Metrics.NewQuery();
+
+          this._query.timespan(Metrics.Time.GlobalTimeSpan());
 
           // General activity stats.
           this._addChart(
@@ -572,7 +576,7 @@ module AdminViews {
         let mostRecentlyUpdated: number = _.max(_.map(nodeStatuses.allStatuses(), (s: NodeStatus) => s.updated_at));
         return m(".page", [
           m.component(Components.Topbar, {title: "Nodes", updated: mostRecentlyUpdated}),
-          m.component(NavigationBar, {ts: ctrl.TargetSet()}),
+          m.component(NavigationBar, {ts: ctrl.TargetSet(), timescaleSelector: !isOverview}),
           primaryContent,
         ]);
       }
@@ -593,7 +597,7 @@ module AdminViews {
           },
           {
             view: "Graphs",
-            route: "graph",
+            route: "graphs",
           },
           {
             view: "Logs",
@@ -1046,7 +1050,7 @@ module AdminViews {
 
         // Primary content
         let primaryContent: MithrilElement;
-        if (detail === "graph") {
+        if (detail === "graphs") {
           primaryContent = ctrl.RenderGraphs();
         } else {
           primaryContent = [
@@ -1060,8 +1064,8 @@ module AdminViews {
 
         return m(".page", [
           m.component(Components.Topbar, {title: title, updated: updated}),
-          m.component(NavigationBar, {ts: ctrl.TargetSet()}),
-          detail === "graph" ? m(".section.node", primaryContent) : primaryContent,
+          m.component(NavigationBar, {ts: ctrl.TargetSet(), timescaleSelector: m.route.param("detail") === "graphs"}),
+          detail === "graphs" ? m(".section.node", primaryContent) : primaryContent,
         ]);
       }
     }


### PR DESCRIPTION
Currently the UI chokes on values larger than 1 day, so I've
restricted it to a day until we can fix the performance.

Partially addresses #4986 

<img width="1319" alt="screen shot 2016-04-19 at 12 32 17 am" src="https://cloud.githubusercontent.com/assets/3691886/14628040/3dbbed86-05c8-11e6-8f95-361926dc2db8.png">

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6145)

<!-- Reviewable:end -->
