### PR TITLE
util/encoding: avoid an allocation and copy in DecodeString*

### DIFF
--- a/sql/show.go
+++ b/sql/show.go
@@ -106,7 +106,7 @@ func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, *roachpb.Err
 	}
 	v := &valuesNode{columns: []ResultColumn{{Name: "Database", Typ: parser.DummyString}}}
 	for _, row := range sr {
-		_, name, err := encoding.DecodeStringAscending(
+		_, name, err := encoding.DecodeUnsafeStringAscending(
 			bytes.TrimPrefix(row.Key, prefix), nil)
 		if err != nil {
 			return nil, roachpb.NewError(err)

--- a/sql/table.go
+++ b/sql/table.go
@@ -334,7 +334,7 @@ func (p *planner) getTableNames(dbDesc *DatabaseDescriptor) (parser.QualifiedNam
 
 	var qualifiedNames parser.QualifiedNames
 	for _, row := range sr {
-		_, tableName, err := encoding.DecodeStringAscending(
+		_, tableName, err := encoding.DecodeUnsafeStringAscending(
 			bytes.TrimPrefix(row.Key, prefix), nil)
 		if err != nil {
 			return nil, roachpb.NewError(err)
@@ -737,9 +737,9 @@ func decodeTableKey(a *datumAlloc, valType parser.Datum, key []byte, dir encodin
 	case *parser.DString:
 		var r string
 		if dir == encoding.Ascending {
-			rkey, r, err = encoding.DecodeStringAscending(key, nil)
+			rkey, r, err = encoding.DecodeUnsafeStringAscending(key, nil)
 		} else {
-			rkey, r, err = encoding.DecodeStringDescending(key, nil)
+			rkey, r, err = encoding.DecodeUnsafeStringDescending(key, nil)
 		}
 		return a.newDString(parser.DString(r)), rkey, err
 	case *parser.DBytes:

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -494,7 +494,7 @@ func TestEncodeDecodeBytesDescending(t *testing.T) {
 	}
 }
 
-func TestEncodeDecodeString(t *testing.T) {
+func TestEncodeDecodeUnsafeString(t *testing.T) {
 	testCases := []struct {
 		value   string
 		encoded []byte
@@ -522,7 +522,7 @@ func TestEncodeDecodeString(t *testing.T) {
 					c.value, testCases[i-1].encoded, enc)
 			}
 		}
-		remainder, dec, err := DecodeStringAscending(enc, nil)
+		remainder, dec, err := DecodeUnsafeStringAscending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -535,7 +535,7 @@ func TestEncodeDecodeString(t *testing.T) {
 		}
 
 		enc = append(enc, "remainder"...)
-		remainder, _, err = DecodeStringAscending(enc, nil)
+		remainder, _, err = DecodeUnsafeStringAscending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -546,7 +546,7 @@ func TestEncodeDecodeString(t *testing.T) {
 	}
 }
 
-func TestEncodeDecodeStringDescending(t *testing.T) {
+func TestEncodeDecodeUnsafeStringDescending(t *testing.T) {
 	testCases := []struct {
 		value   string
 		encoded []byte
@@ -574,7 +574,7 @@ func TestEncodeDecodeStringDescending(t *testing.T) {
 					c.value, testCases[i-1].encoded, enc)
 			}
 		}
-		remainder, dec, err := DecodeStringDescending(enc, nil)
+		remainder, dec, err := DecodeUnsafeStringDescending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -587,7 +587,7 @@ func TestEncodeDecodeStringDescending(t *testing.T) {
 		}
 
 		enc = append(enc, "remainder"...)
-		remainder, _, err = DecodeStringDescending(enc, nil)
+		remainder, _, err = DecodeUnsafeStringDescending(enc, nil)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -1025,7 +1025,7 @@ func BenchmarkEncodeStringDescending(b *testing.B) {
 	}
 }
 
-func BenchmarkDecodeString(b *testing.B) {
+func BenchmarkDecodeUnsafeString(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 
 	vals := make([][]byte, 10000)
@@ -1037,11 +1037,11 @@ func BenchmarkDecodeString(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeStringAscending(vals[i%len(vals)], buf)
+		_, _, _ = DecodeUnsafeStringAscending(vals[i%len(vals)], buf)
 	}
 }
 
-func BenchmarkDecodeStringDescending(b *testing.B) {
+func BenchmarkDecodeUnsafeStringDescending(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 
 	vals := make([][]byte, 10000)
@@ -1053,7 +1053,7 @@ func BenchmarkDecodeStringDescending(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeStringDescending(vals[i%len(vals)], buf)
+		_, _, _ = DecodeUnsafeStringDescending(vals[i%len(vals)], buf)
 	}
 }
 


### PR DESCRIPTION
```
name                old time/op    new time/op    delta
KVScan1_SQL-32         189µs ± 2%     183µs ± 3%   -3.03%  (p=0.000 n=10+10)
KVScan10_SQL-32        260µs ± 4%     259µs ± 3%     ~     (p=0.971 n=10+10)
KVScan100_SQL-32       865µs ± 6%     888µs ± 4%     ~     (p=0.063 n=10+10)
KVScan1000_SQL-32     7.25ms ± 6%    7.03ms ± 5%   -3.11%  (p=0.023 n=10+10)
KVScan10000_SQL-32    71.0ms ± 6%    70.0ms ± 8%     ~     (p=0.796 n=10+10)

name                old allocs/op  new allocs/op  delta
KVScan1_SQL-32           208 ± 0%       206 ± 0%   -0.96%  (p=0.000 n=10+10)
KVScan10_SQL-32          299 ± 0%       279 ± 0%   -6.69%   (p=0.000 n=9+10)
KVScan100_SQL-32       1.14k ± 0%     0.94k ± 0%  -17.56%    (p=0.000 n=9+8)
KVScan1000_SQL-32      9.45k ± 0%     7.45k ± 0%  -21.16%  (p=0.000 n=10+10)
KVScan10000_SQL-32     92.5k ± 0%     72.6k ± 0%  -21.61%   (p=0.000 n=9+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6164)

<!-- Reviewable:end -->
