### PR TITLE
sql/parser: Use new Decimal.Exp and Decimal.Pow for sql builtins

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -828,9 +828,16 @@ var Builtins = map[string][]Builtin{
 	},
 
 	// TODO(nvanbenschoten) Add native support for decimal.
-	"exp": floatOrDecimalBuiltin1(func(x float64) (Datum, error) {
-		return NewDFloat(DFloat(math.Exp(x))), nil
-	}),
+	"exp": {
+		floatBuiltin1(func(x float64) (Datum, error) {
+			return NewDFloat(DFloat(math.Exp(x))), nil
+		}),
+		decimalBuiltin1(func(x *inf.Dec) (Datum, error) {
+			dd := &DDecimal{}
+			decimal.Exp(&dd.Dec, x, decimal.Precision)
+			return dd, nil
+		}),
+	},
 
 	"floor": {
 		floatBuiltin1(func(x float64) (Datum, error) {
@@ -1139,10 +1146,16 @@ var txnTSImpl = Builtin{
 	},
 }
 
-// TODO(nvanbenschoten) Add native support for decimal.
-var powImpls = floatOrDecimalBuiltin2(func(x, y float64) (Datum, error) {
-	return NewDFloat(DFloat(math.Pow(x, y))), nil
-})
+var powImpls = []Builtin{
+	floatBuiltin2(func(x, y float64) (Datum, error) {
+		return NewDFloat(DFloat(math.Pow(x, y))), nil
+	}),
+	decimalBuiltin2(func(x, y *inf.Dec) (Datum, error) {
+		dd := &DDecimal{}
+		decimal.Pow(&dd.Dec, x, y, decimal.Precision)
+		return dd, nil
+	}),
+}
 
 func decimalLogFn(logFn func(*inf.Dec, *inf.Dec, inf.Scale) *inf.Dec) Builtin {
 	return decimalBuiltin1(func(x *inf.Dec) (Datum, error) {

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -469,7 +469,7 @@ SELECT div(1.0::decimal, 0.0::decimal)
 query RRR
 SELECT exp(-1.0), exp(1.0), exp(2.0::decimal)
 ----
-0.36787944117144233 2.718281828459045 7.38905609893065
+0.36787944117144233 2.718281828459045 7.3890560989306502
 
 query RRR
 SELECT floor(-1.5), floor(1.5), floor(9.123456789::decimal)
@@ -582,7 +582,12 @@ SELECT pi()
 query RRR
 SELECT pow(-3.0, 2.0), power(3.0, 2.0), pow(5.0::decimal, 2.0::decimal)
 ----
-9 9 25
+9 9 25.0000000000000000
+
+query R
+SELECT pow(CAST (pi() AS DECIMAL), DECIMAL '2.0')
+----
+9.8696044010893571
 
 query RR
 SELECT radians(-45.0), radians(45.0)


### PR DESCRIPTION
Now that we have native arbitrary-precision decimal `Pow` and `Exp`
functions we can use them for the sql builtin `pow` and `exp` DECIMAL
functions to avoid marshaling DECIMALs through FLOATs during the
function evaluation.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6170)

<!-- Reviewable:end -->
