### PR TITLE
storage/engine: batch allocations in MVCCIterate

### DIFF
--- a/storage/engine/allocator.go
+++ b/storage/engine/allocator.go
@@ -1,0 +1,57 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package engine
+
+// chunkAllocator provides chunk allocation of []byte, amortizing the overhead
+// of each allocation. Because the underlying storage for the slices is shared,
+// they should share a similar lifetime in order to avoid pinning large amounts
+// of memory unnecessarily. The allocator itself is a []byte where cap()
+// indicates the total amount of memory and len() is the amount already
+// allocated. The size of the buffer to allocate from is grown exponentially
+// when it runs out of room up to a maximum size (chunkAllocMaxSize).
+type chunkAllocator []byte
+
+const chunkAllocMinSize = 512
+const chunkAllocMaxSize = 16384
+
+func (a chunkAllocator) reserve(n int) chunkAllocator {
+	allocSize := cap(a) * 2
+	if allocSize < chunkAllocMinSize {
+		allocSize = chunkAllocMinSize
+	} else if allocSize > chunkAllocMaxSize {
+		allocSize = chunkAllocMaxSize
+	}
+	if allocSize < n {
+		allocSize = n
+	}
+	return make([]byte, 0, allocSize)
+}
+
+// newChunk allocates a new chunk of memory, initializing it from src. extra
+// indicates additional zero bytes that will be present in the returned []byte,
+// but not part of the length.
+func (a chunkAllocator) newChunk(src []byte, extra int) (chunkAllocator, []byte) {
+	n := len(src)
+	if cap(a)-len(a) < n+extra {
+		a = a.reserve(n + extra)
+	}
+	p := len(a)
+	r := a[p : p+n : p+n+extra]
+	a = a[:p+n+extra]
+	copy(r, src)
+	return a, r
+}

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -629,8 +629,8 @@ func mvccGetUsingIter(
 		return nil, nil, err
 	}
 
-	value, intents, err := mvccGetInternal(ctx, iter, metaKey,
-		timestamp, consistent, txn, buf)
+	value, intents, _, err := mvccGetInternal(ctx, iter, metaKey,
+		timestamp, consistent, safeValue, txn, buf)
 	if value == &buf.value {
 		value = &roachpb.Value{}
 		*value = buf.value
@@ -703,6 +703,13 @@ func mvccGetMetadata(iter Iterator, metaKey MVCCKey,
 	return err == nil, int64(unsafeKey.EncodedSize()) - meta.KeyBytes, 0, err
 }
 
+type valueSafety int
+
+const (
+	unsafeValue valueSafety = iota
+	safeValue
+)
+
 // mvccGetInternal parses the MVCCMetadata from the specified raw key
 // value, and reads the versioned value indicated by timestamp, taking
 // the transaction txn into account. getValue is a helper function to
@@ -719,11 +726,13 @@ func mvccGetInternal(
 	metaKey MVCCKey,
 	timestamp roachpb.Timestamp,
 	consistent bool,
+	allowedSafety valueSafety,
 	txn *roachpb.Transaction,
 	buf *getBuffer,
-) (*roachpb.Value, []roachpb.Intent, error) {
+) (*roachpb.Value, []roachpb.Intent, valueSafety, error) {
 	if !consistent && txn != nil {
-		return nil, nil, util.Errorf("cannot allow inconsistent reads within a transaction")
+		return nil, nil, safeValue, util.Errorf(
+			"cannot allow inconsistent reads within a transaction")
 	}
 
 	meta := &buf.meta
@@ -733,10 +742,9 @@ func mvccGetInternal(
 		value := &buf.value
 		*value = roachpb.Value{RawBytes: meta.RawBytes}
 		if err := value.Verify(metaKey.Key); err != nil {
-			return nil, nil, err
+			return nil, nil, safeValue, err
 		}
-		buf.isUnsafeValue = false
-		return value, nil, nil
+		return value, nil, safeValue, nil
 	}
 	var ignoredIntents []roachpb.Intent
 	if !consistent && meta.Txn != nil && !timestamp.Less(meta.Timestamp) {
@@ -753,7 +761,7 @@ func mvccGetInternal(
 	if !timestamp.Less(meta.Timestamp) && meta.Txn != nil && !ownIntent {
 		// Trying to read the last value, but it's another transaction's intent;
 		// the reader will have to act on this.
-		return nil, nil, &roachpb.WriteIntentError{
+		return nil, nil, safeValue, &roachpb.WriteIntentError{
 			Intents: []roachpb.Intent{{Span: roachpb.Span{Key: metaKey.Key}, Status: roachpb.PENDING, Txn: *meta.Txn}},
 		}
 	}
@@ -775,7 +783,8 @@ func mvccGetInternal(
 		// we're now reading. In this case, we skip the intent.
 		if ownIntent && txn.Epoch != meta.Txn.Epoch {
 			if txn.Epoch < meta.Txn.Epoch {
-				return nil, nil, util.Errorf("failed to read with epoch %d due to a write intent with epoch %d",
+				return nil, nil, safeValue, util.Errorf(
+					"failed to read with epoch %d due to a write intent with epoch %d",
 					txn.Epoch, meta.Txn.Epoch)
 			}
 			seekKey = seekKey.Next()
@@ -791,7 +800,7 @@ func mvccGetInternal(
 			// absolute time if the writer had a fast clock.
 			// The reader should try again with a later timestamp than the
 			// one given below.
-			return nil, nil, roachpb.NewReadWithinUncertaintyIntervalError(
+			return nil, nil, safeValue, roachpb.NewReadWithinUncertaintyIntervalError(
 				timestamp, meta.Timestamp)
 		}
 
@@ -805,7 +814,7 @@ func mvccGetInternal(
 		// would apply to.
 		seekKey.Timestamp = timestamp
 		if seekKey.Timestamp == roachpb.ZeroTimestamp {
-			return nil, ignoredIntents, nil
+			return nil, ignoredIntents, safeValue, nil
 		}
 	}
 
@@ -814,17 +823,18 @@ func mvccGetInternal(
 	}
 	if !iter.Valid() {
 		if err := iter.Error(); err != nil {
-			return nil, nil, err
+			return nil, nil, safeValue, err
 		}
-		return nil, ignoredIntents, nil
+		return nil, ignoredIntents, safeValue, nil
 	}
 
 	unsafeKey := iter.unsafeKey()
 	if !unsafeKey.Key.Equal(metaKey.Key) {
-		return nil, ignoredIntents, nil
+		return nil, ignoredIntents, safeValue, nil
 	}
 	if !unsafeKey.IsValue() {
-		return nil, nil, util.Errorf("expected scan to versioned value reading key %s; got %s %s",
+		return nil, nil, safeValue, util.Errorf(
+			"expected scan to versioned value reading key %s; got %s %s",
 			metaKey.Key, unsafeKey, unsafeKey.Timestamp)
 	}
 
@@ -834,7 +844,7 @@ func mvccGetInternal(
 			// value, but there is another previous write with the same issues as in
 			// the second case, so the reader will have to come again with a higher
 			// read timestamp.
-			return nil, nil, roachpb.NewReadWithinUncertaintyIntervalError(
+			return nil, nil, safeValue, roachpb.NewReadWithinUncertaintyIntervalError(
 				timestamp, unsafeKey.Timestamp)
 		}
 		// Fifth case: There's no value in our future up to MaxTimestamp, and those
@@ -844,21 +854,20 @@ func mvccGetInternal(
 
 	if len(iter.unsafeValue()) == 0 {
 		// Value is deleted.
-		return nil, ignoredIntents, nil
+		return nil, ignoredIntents, safeValue, nil
 	}
 
 	value := &buf.value
-	buf.isUnsafeValue = buf.allowUnsafeValue
-	if buf.allowUnsafeValue {
+	if allowedSafety == unsafeValue {
 		value.RawBytes = iter.unsafeValue()
 	} else {
 		value.RawBytes = iter.Value()
 	}
 	value.Timestamp = unsafeKey.Timestamp
 	if err := value.Verify(metaKey.Key); err != nil {
-		return nil, nil, err
+		return nil, nil, safeValue, err
 	}
-	return value, ignoredIntents, nil
+	return value, ignoredIntents, allowedSafety, nil
 }
 
 // putBuffer holds pointer data needed by mvccPutInternal. Bundling
@@ -1005,7 +1014,8 @@ func mvccPutInternal(
 			getBuf := newGetBuffer()
 			defer getBuf.release()
 			getBuf.meta = buf.meta // initialize get metadata from what we've already read
-			if exVal, _, err = mvccGetInternal(ctx, iter, metaKey, readTS, true /* consistent */, txn, getBuf); err != nil {
+			if exVal, _, _, err = mvccGetInternal(
+				ctx, iter, metaKey, readTS, true /* consistent */, safeValue, txn, getBuf); err != nil {
 				return nil, err
 			}
 		}
@@ -1579,15 +1589,13 @@ func MVCCIterate(ctx context.Context,
 		alloc, metaKey.Key = alloc.newChunk(metaKey.Key, 1)
 
 		// Indicate that we're fine with an unsafe Value.RawBytes being returned.
-		buf.allowUnsafeValue = true
-		buf.isUnsafeValue = false
-		value, newIntents, err := mvccGetInternal(ctx, iter, metaKey, timestamp, consistent, txn, buf)
+		value, newIntents, valueSafety, err := mvccGetInternal(
+			ctx, iter, metaKey, timestamp, consistent, unsafeValue, txn, buf)
 		intents = append(intents, newIntents...)
 		if value != nil {
-			if buf.isUnsafeValue {
+			if valueSafety == unsafeValue {
 				// Copy the unsafe value into our allocation buffer.
 				alloc, value.RawBytes = alloc.newChunk(value.RawBytes, 0)
-				buf.isUnsafeValue = false
 			}
 			done, err := f(roachpb.KeyValue{Key: metaKey.Key, Value: *value})
 			if err != nil {

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -550,8 +550,10 @@ func MVCCPutProto(
 }
 
 type getBuffer struct {
-	meta  MVCCMetadata
-	value roachpb.Value
+	meta             MVCCMetadata
+	value            roachpb.Value
+	allowUnsafeValue bool
+	isUnsafeValue    bool
 }
 
 var getBufferPool = sync.Pool{
@@ -561,7 +563,10 @@ var getBufferPool = sync.Pool{
 }
 
 func newGetBuffer() *getBuffer {
-	return getBufferPool.Get().(*getBuffer)
+	buf := getBufferPool.Get().(*getBuffer)
+	buf.allowUnsafeValue = false
+	buf.isUnsafeValue = false
+	return buf
 }
 
 func (b *getBuffer) release() {
@@ -730,6 +735,7 @@ func mvccGetInternal(
 		if err := value.Verify(metaKey.Key); err != nil {
 			return nil, nil, err
 		}
+		buf.isUnsafeValue = false
 		return value, nil, nil
 	}
 	var ignoredIntents []roachpb.Intent
@@ -842,7 +848,12 @@ func mvccGetInternal(
 	}
 
 	value := &buf.value
-	value.RawBytes = iter.Value()
+	buf.isUnsafeValue = buf.allowUnsafeValue
+	if buf.allowUnsafeValue {
+		value.RawBytes = iter.unsafeValue()
+	} else {
+		value.RawBytes = iter.Value()
+	}
 	value.Timestamp = unsafeKey.Timestamp
 	if err := value.Verify(metaKey.Key); err != nil {
 		return nil, nil, err
@@ -1348,8 +1359,12 @@ func MVCCDeleteRange(
 	return keys, err
 }
 
+// getScanMeta returns the MVCCMetadata the iterator is currently pointed at
+// (reconstructing it if the metadata is implicit). Note that the returned
+// MVCCKey is unsafe and will be invalidated by the next call to
+// Iterator.{Next,Prev,Seek,SeekReverse,Close}.
 func getScanMeta(iter Iterator, encEndKey MVCCKey, meta *MVCCMetadata) (MVCCKey, error) {
-	metaKey := iter.Key()
+	metaKey := iter.unsafeKey()
 	if !metaKey.Less(encEndKey) {
 		return NilKey, iter.Error()
 	}
@@ -1370,8 +1385,12 @@ func getScanMeta(iter Iterator, encEndKey MVCCKey, meta *MVCCMetadata) (MVCCKey,
 	return metaKey, nil
 }
 
+// getReverseScanMeta returns the MVCCMetadata the iterator is currently
+// pointed at (reconstructing it if the metadata is implicit). Note that the
+// returned MVCCKey is unsafe and will be invalidated by the next call to
+// Iterator.{Next,Prev,Seek,SeekReverse,Close}.
 func getReverseScanMeta(iter Iterator, encEndKey MVCCKey, meta *MVCCMetadata) (MVCCKey, error) {
-	metaKey := iter.Key()
+	metaKey := iter.unsafeKey()
 	// The metaKey < encEndKey is exceeding the boundary.
 	if metaKey.Less(encEndKey) {
 		return NilKey, iter.Error()
@@ -1381,6 +1400,8 @@ func getReverseScanMeta(iter Iterator, encEndKey MVCCKey, meta *MVCCMetadata) (M
 	// TODO(tschottdorf): can we save any work here or leverage
 	// getScanMetaKey() above after doing the Seek() below?
 	if metaKey.IsValue() {
+		// Need a "safe" key because we're seeking the iterator.
+		metaKey = iter.Key()
 		// The row with oldest version will be got by seeking reversely. We use the
 		// key of this row to get the MVCC metadata key.
 		iter.Seek(MakeMVCCMetadataKey(metaKey.Key))
@@ -1389,7 +1410,7 @@ func getReverseScanMeta(iter Iterator, encEndKey MVCCKey, meta *MVCCMetadata) (M
 		}
 
 		meta.Reset()
-		metaKey = iter.Key()
+		metaKey = iter.unsafeKey()
 		meta.Timestamp = metaKey.Timestamp
 		if metaKey.IsValue() {
 			// For values, the size of keys is always account for as
@@ -1543,6 +1564,7 @@ func MVCCIterate(ctx context.Context,
 	// Gathers up all the intents from WriteIntentErrors. We only get those if
 	// the scan is consistent.
 	var wiErr error
+	var alloc chunkAllocator
 
 	for {
 		metaKey, err := getMeta(iter, encEndKey, &buf.meta)
@@ -1554,9 +1576,19 @@ func MVCCIterate(ctx context.Context,
 			break
 		}
 
+		alloc, metaKey.Key = alloc.newChunk(metaKey.Key, 1)
+
+		// Indicate that we're fine with an unsafe Value.RawBytes being returned.
+		buf.allowUnsafeValue = true
+		buf.isUnsafeValue = false
 		value, newIntents, err := mvccGetInternal(ctx, iter, metaKey, timestamp, consistent, txn, buf)
 		intents = append(intents, newIntents...)
 		if value != nil {
+			if buf.isUnsafeValue {
+				// Copy the unsafe value into our allocation buffer.
+				alloc, value.RawBytes = alloc.newChunk(value.RawBytes, 0)
+				buf.isUnsafeValue = false
+			}
 			done, err := f(roachpb.KeyValue{Key: metaKey.Key, Value: *value})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
```
name                old time/op    new time/op    delta
KVScan1_SQL-32         206µs ± 4%     208µs ± 6%     ~     (p=0.365 n=19+20)
KVScan10_SQL-32        291µs ± 6%     287µs ± 5%     ~     (p=0.134 n=20+20)
KVScan100_SQL-32      1.00ms ± 9%    0.95ms ± 8%   -4.73%  (p=0.000 n=20+19)
KVScan1000_SQL-32     7.80ms ± 4%    7.51ms ± 8%   -3.66%  (p=0.000 n=20+19)
KVScan10000_SQL-32    76.9ms ± 4%    73.4ms ± 6%   -4.59%  (p=0.000 n=19+18)

name                old allocs/op  new allocs/op  delta
KVScan1_SQL-32           208 ± 0%       205 ± 0%   -1.44%  (p=0.000 n=20+20)
KVScan10_SQL-32          299 ± 0%       260 ± 0%  -13.04%  (p=0.000 n=19+18)
KVScan100_SQL-32       1.14k ± 0%     0.74k ± 0%  -34.72%  (p=0.000 n=20+20)
KVScan1000_SQL-32      9.45k ± 0%     5.46k ± 0%  -42.26%  (p=0.000 n=19+18)
KVScan10000_SQL-32     92.5k ± 0%     52.6k ± 0%  -43.18%  (p=0.000 n=20+19)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6175)

<!-- Reviewable:end -->
