### PR TITLE
sql: preallocate buffers for valuesNode

### DIFF
--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -23,6 +23,7 @@ import (
 
 func (p *planner) expandSubqueries(expr parser.Expr, columns int) (parser.Expr, *roachpb.Error) {
 	p.subqueryVisitor = subqueryVisitor{planner: p, columns: columns}
+	p.subqueryVisitor.path = p.subqueryVisitor.pathBuf[:0]
 	expr, _ = parser.WalkExpr(&p.subqueryVisitor, expr)
 	return expr, p.subqueryVisitor.pErr
 }
@@ -31,6 +32,7 @@ type subqueryVisitor struct {
 	*planner
 	columns int
 	path    []parser.Expr // parent expressions
+	pathBuf [4]parser.Expr
 	pErr    *roachpb.Error
 }
 

--- a/sql/values.go
+++ b/sql/values.go
@@ -32,30 +32,34 @@ func (p *planner) ValuesClause(n *parser.ValuesClause) (planNode, *roachpb.Error
 	v := &valuesNode{
 		rows: make([]parser.DTuple, 0, len(n.Tuples)),
 	}
+	if len(n.Tuples) == 0 {
+		return v, nil
+	}
 
-	for num, tupleOrig := range n.Tuples {
-		if num == 0 {
-			v.columns = make([]ResultColumn, 0, len(tupleOrig.Exprs))
-		} else if a, e := len(tupleOrig.Exprs), len(v.columns); a != e {
+	numCols := len(n.Tuples[0].Exprs)
+	rowBuf := make(parser.DTuple, len(n.Tuples)*numCols)
+	v.columns = make([]ResultColumn, 0, numCols)
+
+	for num, tuple := range n.Tuples {
+		if a, e := len(tuple.Exprs), numCols; a != e {
 			return nil, roachpb.NewUErrorf("VALUES lists must all be the same length, %d for %d", a, e)
 		}
 
-		// We must not modify the ValuesClause node in-place (or the changes will leak if we retry this
-		// transaction).
-		tuple := parser.Tuple{Exprs: parser.Exprs(append([]parser.Expr(nil), tupleOrig.Exprs...))}
+		// Chop off prefix of rowBuf and limit its capacity.
+		row := rowBuf[:numCols:numCols]
+		rowBuf = rowBuf[numCols:]
 
 		for i := range tuple.Exprs {
-			var pErr *roachpb.Error
-			tuple.Exprs[i], pErr = p.expandSubqueries(tuple.Exprs[i], 1)
+			expr, pErr := p.expandSubqueries(tuple.Exprs[i], 1)
 			if pErr != nil {
 				return nil, pErr
 			}
 			var err error
-			typ, err := tuple.Exprs[i].TypeCheck(p.evalCtx.Args)
+			typ, err := expr.TypeCheck(p.evalCtx.Args)
 			if err != nil {
 				return nil, roachpb.NewError(err)
 			}
-			tuple.Exprs[i], err = p.parser.NormalizeExpr(p.evalCtx, tuple.Exprs[i])
+			expr, err = p.parser.NormalizeExpr(p.evalCtx, expr)
 			if err != nil {
 				return nil, roachpb.NewError(err)
 			}
@@ -66,16 +70,12 @@ func (p *planner) ValuesClause(n *parser.ValuesClause) (planNode, *roachpb.Error
 			} else if typ != parser.DNull && !typ.TypeEqual(v.columns[i].Typ) {
 				return nil, roachpb.NewUErrorf("VALUES list type mismatch, %s for %s", typ.Type(), v.columns[i].Typ.Type())
 			}
+			row[i], err = expr.Eval(p.evalCtx)
+			if err != nil {
+				return nil, roachpb.NewError(err)
+			}
 		}
-		data, err := tuple.Eval(p.evalCtx)
-		if err != nil {
-			return nil, roachpb.NewError(err)
-		}
-		vals, ok := data.(*parser.DTuple)
-		if !ok {
-			return nil, roachpb.NewUErrorf("expected a tuple, but found %T", data)
-		}
-		v.rows = append(v.rows, *vals)
+		v.rows = append(v.rows, row)
 	}
 
 	return v, nil


### PR DESCRIPTION
Reduce allocations in ValuesClause execution. When transforming a
ValuesClause into a valuesNode we know how many values there will
be (the number of values per row \* the number of rows). We can also
avoid copying the source tuple because doing so was only necessary to
evaluate the tuple which we can easily manually perform. This reduces
the number of allocations in ValuesClause from (at least) 2 per row to a
handful total.

Add a small buffer in subqueryVisitor to avoid an allocation per
expression when expanding subqueries, even if no subqueries were
present.

```
name                  old time/op    new time/op    delta
KVInsert1_SQL-32         514µs ± 2%     510µs ± 2%     ~     (p=0.063 n=20+20)
KVInsert10_SQL-32       1.01ms ± 2%    1.00ms ± 2%     ~     (p=0.175 n=19+20)
KVInsert100_SQL-32      5.76ms ± 6%    5.63ms ± 4%   -2.16%  (p=0.011 n=19+20)
KVInsert1000_SQL-32     56.3ms ± 5%    55.9ms ± 5%     ~     (p=0.624 n=19+19)
KVInsert10000_SQL-32     740ms ±11%     750ms ±11%     ~     (p=0.313 n=18+19)

name                  old allocs/op  new allocs/op  delta
KVInsert1_SQL-32           326 ± 0%       318 ± 0%   -2.36%  (p=0.000 n=18+20)
KVInsert10_SQL-32          981 ± 0%       883 ± 0%   -9.97%  (p=0.000 n=19+15)
KVInsert100_SQL-32       7.35k ± 0%     6.35k ± 0%  -13.58%  (p=0.000 n=20+20)
KVInsert1000_SQL-32      71.9k ± 1%     61.9k ± 1%  -13.95%  (p=0.000 n=20+20)
KVInsert10000_SQL-32      836k ± 4%      725k ± 9%  -13.32%  (p=0.000 n=16+19)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6176)

<!-- Reviewable:end -->
