### PR TITLE
roachpb: remove unnecessary allocation in BatchResponse.Add

### DIFF
--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -161,9 +161,9 @@ func (ba *BatchRequest) Add(requests ...Request) {
 
 // Add adds a response to the batch response.
 func (br *BatchResponse) Add(reply Response) {
-	union := ResponseUnion{}
-	union.MustSetInner(reply)
-	br.Responses = append(br.Responses, union)
+	n := len(br.Responses)
+	br.Responses = append(br.Responses, ResponseUnion{})
+	br.Responses[n].MustSetInner(reply)
 }
 
 // Methods returns a slice of the contained methods.


### PR DESCRIPTION
Calling RequestUnion.MustSetInner on a stack variable was forcing it to
the heap. Easy enough to reorg the code so that we call MustSetInner on
a member of the Responses slice which is already on the heap.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6178)

<!-- Reviewable:end -->
