### PR TITLE
cli: update the external dependency on readline.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -19,7 +19,7 @@ github.com/Sirupsen/logrus 4b6ea7319e214d98c938f12692336f7ca9348d6b
 github.com/VividCortex/ewma c34099b489e4ac33ca8d8c5f9d29d6eeaf69f2ed
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store 3b4c041f52c224ee4a44f5c8b150d003a40643a0
-github.com/chzyer/readline fd07ffef1be0a5af7f4f632248c1afaf81ca90a4
+github.com/chzyer/readline dc5da28fbf5287157fcd4719c794b59cd8852115
 github.com/client9/misspell 4f5982f81a18693b85c9926407fc4f61102ee0e7
 github.com/cockroachdb/c-protobuf 4feb192131ea08dfbd7253a00868ad69cbb61b81
 github.com/cockroachdb/c-rocksdb b80d2efe8e544bbcc4b50dec8e89f9305f5da745


### PR DESCRIPTION
This fixes an error when loading a previously saved command history
containing empty lines.

As suggested in https://github.com/cockroachdb/cockroach/issues/6172#issuecomment-212695546.

Fixes #6172.

Thanks to @chzyer for the fix upstream!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6192)

<!-- Reviewable:end -->
