### PR TITLE
sql: separate row formation from scanNode

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -243,7 +243,7 @@ func (d *deleteNode) fastDelete() *roachpb.Error {
 				continue
 			}
 
-			after, err := scan.readIndexKey(i)
+			after, err := scan.fetcher.readIndexKey(i)
 			if err != nil {
 				return roachpb.NewError(err)
 			}

--- a/sql/kvfetcher.go
+++ b/sql/kvfetcher.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/sql/parser"
 )
 
 type span struct {
@@ -59,14 +58,6 @@ func prettyKey(key roachpb.Key, skip int) string {
 		p = p[n+1:]
 	}
 	return p
-}
-
-func prettyDatums(vals []parser.Datum) string {
-	var buf bytes.Buffer
-	for _, v := range vals {
-		fmt.Fprintf(&buf, "/%v", v)
-	}
-	return buf.String()
 }
 
 func prettySpan(span span, skip int) string {

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -33,8 +33,9 @@ type returningHelper struct {
 	rowCount int
 }
 
-func (p *planner) makeReturningHelper(r parser.ReturningExprs,
-	alias string, tablecols []ColumnDescriptor) (returningHelper, error) {
+func (p *planner) makeReturningHelper(
+	r parser.ReturningExprs, alias string, tablecols []ColumnDescriptor,
+) (returningHelper, error) {
 	rh := returningHelper{p: p}
 	if len(r) == 0 {
 		return rh, nil

--- a/sql/rowfetcher.go
+++ b/sql/rowfetcher.go
@@ -1,0 +1,367 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sql
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+// rowFetcher handles fetching kvs and forming table rows.
+// Usage:
+//   var rf rowFetcher
+//   err := rf.init(..)
+//   // Handle err
+//   pErr := rf.startScan(..)
+//   // Handle pErr
+//   for {
+//      row, pErr := rf.nextRow()
+//      // Handle pErr
+//      if row == nil {
+//         // Done
+//         break
+//      }
+//      // Process row
+//   }
+type rowFetcher struct {
+	// -- Fields initialized once --
+
+	desc             *TableDescriptor
+	index            *IndexDescriptor
+	reverse          bool
+	isSecondaryIndex bool
+	indexColumnDirs  []encoding.Direction
+
+	// For each column in desc.Columns, indicates if the value is needed (used
+	// as an optimization when the upper layer doesn't need all values).
+	valNeededForCol []bool
+
+	// Map used to get the index for columns in desc.Columns.
+	colIdxMap map[ColumnID]int
+
+	// One value per column that is part of the key; each value is a column
+	// index (into desc.Columns).
+	indexColIdx []int
+
+	// -- Fields updated during a scan --
+
+	kvFetcher        kvFetcher
+	keyValTypes      []parser.Datum // the index key value types for the current row
+	keyVals          []parser.Datum // the index key values for the current row
+	implicitValTypes []parser.Datum // the implicit value types for unique indexes
+	implicitVals     []parser.Datum // the implicit values for unique indexes
+	indexKey         []byte         // the index key of the current row
+	row              parser.DTuple
+
+	// The current key/value, unless kvEnd is true.
+	kv    client.KeyValue
+	kvEnd bool
+
+	// Buffered allocation of decoded datums.
+	alloc datumAlloc
+}
+
+// init sets up a rowFetcher for a given table and index. If we are using a
+// non-primary index, valNeededForCol can only be true for the columns in the
+// index.
+func (rf *rowFetcher) init(
+	desc *TableDescriptor,
+	colIdxMap map[ColumnID]int,
+	index *IndexDescriptor,
+	reverse, isSecondaryIndex bool,
+	valNeededForCol []bool,
+) error {
+	rf.desc = desc
+	rf.colIdxMap = colIdxMap
+	rf.index = index
+	rf.reverse = reverse
+	rf.isSecondaryIndex = isSecondaryIndex
+	rf.valNeededForCol = valNeededForCol
+	rf.row = make([]parser.Datum, len(rf.desc.Columns))
+
+	var indexColumnIDs []ColumnID
+	indexColumnIDs, rf.indexColumnDirs = index.fullColumnIDs()
+
+	rf.indexColIdx = make([]int, len(indexColumnIDs))
+	for i, id := range indexColumnIDs {
+		rf.indexColIdx[i] = rf.colIdxMap[id]
+	}
+
+	var err error
+	// Prepare our index key vals slice.
+	rf.keyValTypes, err = makeKeyVals(rf.desc, indexColumnIDs)
+	if err != nil {
+		return err
+	}
+	rf.keyVals = make([]parser.Datum, len(rf.keyValTypes))
+
+	if isSecondaryIndex && index.Unique {
+		// Unique secondary indexes have a value that is the primary index
+		// key. Prepare implicitVals for use in decoding this value.
+		// Primary indexes only contain ascendingly-encoded values. If this
+		// ever changes, we'll probably have to figure out the directions here too.
+		rf.implicitValTypes, err = makeKeyVals(desc, index.ImplicitColumnIDs)
+		if err != nil {
+			return err
+		}
+		rf.implicitVals = make([]parser.Datum, len(rf.implicitValTypes))
+	}
+	return nil
+}
+
+// startScan initializes and starts the key-value scan. Can be used multiple
+// times.
+func (rf *rowFetcher) startScan(txn *client.Txn, spans spans, limitHint int64) *roachpb.Error {
+	rf.indexKey = nil
+
+	// If we have a limit hint, we limit the first batch size. Subsequent
+	// batches get larger to avoid making things too slow (e.g. in case we have
+	// a very restrictive filter and actually have to retrieve a lot of rows).
+	firstBatchLimit := limitHint
+	if firstBatchLimit != 0 {
+		// For a secondary index, we have one key per row.
+		if !rf.isSecondaryIndex {
+			// We have a sentinel key per row plus at most one key per non-PK column. Of course, we
+			// may have other keys due to a schema change, but this is only a hint.
+			firstBatchLimit *= int64(1 + len(rf.desc.Columns) - len(rf.index.ColumnIDs))
+		}
+		// We need an extra key to make sure we form the last row.
+		firstBatchLimit++
+	}
+
+	rf.kvFetcher = makeKVFetcher(txn, spans, rf.reverse, firstBatchLimit)
+
+	// Retrieve the first key.
+	_, pErr := rf.nextKey()
+	return pErr
+}
+
+// nextKey retrieves the next key/value and sets kv/kvEnd. Returns whether a row
+// has been completed.
+func (rf *rowFetcher) nextKey() (rowDone bool, pErr *roachpb.Error) {
+	var ok bool
+	ok, rf.kv, pErr = rf.kvFetcher.nextKV()
+	if pErr != nil {
+		return false, pErr
+	}
+	rf.kvEnd = !ok
+
+	// For unique secondary indexes, the index-key does not distinguish one row
+	// from the next if both rows contain identical values along with a
+	// NULL. Consider the keys:
+	//
+	//   /test/unique_idx/NULL/0
+	//   /test/unique_idx/NULL/1
+	//
+	// The index-key extracted from the above keys is /test/unique_idx/NULL. The
+	// trailing /0 and /1 are the primary key used to unique-ify the keys when a
+	// NULL is present. Currently we don't detect NULLs on decoding. If we did we
+	// could detect this case and enlarge the index-key. A simpler fix for this
+	// problem is to simply always output a row for each key scanned from a
+	// secondary index as secondary indexes have only one key per row.
+
+	if rf.indexKey != nil &&
+		(rf.isSecondaryIndex || rf.kvEnd ||
+			!bytes.HasPrefix(rf.kv.Key, rf.indexKey)) {
+		// The current key belongs to a new row. Output the current row.
+		rf.indexKey = nil
+
+		// Fill in any missing values with NULLs
+		for i, col := range rf.desc.Columns {
+			if rf.valNeededForCol[i] && rf.row[i] == nil {
+				if !col.Nullable {
+					panic("Non-nullable column with no value!")
+				}
+				rf.row[i] = parser.DNull
+			}
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func prettyDatums(vals []parser.Datum) string {
+	var buf bytes.Buffer
+	for _, v := range vals {
+		fmt.Fprintf(&buf, "/%v", v)
+	}
+	return buf.String()
+}
+
+func (rf *rowFetcher) readIndexKey(k roachpb.Key) (remaining []byte, err error) {
+	return decodeIndexKey(&rf.alloc, rf.desc, rf.index.ID, rf.keyValTypes, rf.keyVals,
+		rf.indexColumnDirs, k)
+}
+
+// processKV processes the given key/value, setting values in the row
+// accordingly. If debugStrings is true, returns pretty printed key and value
+// information in prettyKey/prettyValue (otherwise they are empty strings).
+func (rf *rowFetcher) processKV(kv client.KeyValue, debugStrings bool) (
+	prettyKey string, prettyValue string, err error,
+) {
+	remaining, err := rf.readIndexKey(kv.Key)
+	if err != nil {
+		return "", "", err
+	}
+
+	if debugStrings {
+		prettyKey = fmt.Sprintf("/%s/%s%s", rf.desc.Name, rf.index.Name, prettyDatums(rf.keyVals))
+	}
+
+	if rf.indexKey == nil {
+		// This is the first key for the row.
+		rf.indexKey = []byte(kv.Key[:len(kv.Key)-len(remaining)])
+
+		// Reset the row to nil; it will get filled in with the column
+		// values as we decode the key-value pairs for the row.
+		for i := range rf.row {
+			rf.row[i] = nil
+		}
+
+		// Fill in the column values that are part of the index key.
+		for i, v := range rf.keyVals {
+			rf.row[rf.indexColIdx[i]] = v
+		}
+	}
+
+	if !rf.isSecondaryIndex && len(remaining) > 0 {
+		_, colID, err := encoding.DecodeUvarintAscending(remaining)
+		if err != nil {
+			return "", "", err
+		}
+
+		idx, ok := rf.colIdxMap[ColumnID(colID)]
+		if ok && (debugStrings || rf.valNeededForCol[idx]) {
+			if debugStrings {
+				prettyKey = fmt.Sprintf("%s/%s", prettyKey, rf.desc.Columns[idx].Name)
+			}
+			kind := rf.desc.Columns[idx].Type.Kind
+			value, err := unmarshalColumnValue(&rf.alloc, kind, kv.Value)
+			if err != nil {
+				return "", "", err
+			}
+			prettyValue = value.String()
+			if rf.row[idx] != nil {
+				panic(fmt.Sprintf("duplicate value for column %d", idx))
+			}
+			rf.row[idx] = value
+			if log.V(3) {
+				log.Infof("Scan %s -> %v", kv.Key, value)
+			}
+		} else {
+			// No need to unmarshal the column value. Either the column was part of
+			// the index key or it isn't needed.
+			if log.V(3) {
+				log.Infof("Scan %s -> [%d] (skipped)", kv.Key, colID)
+			}
+		}
+	} else {
+		if rf.implicitVals != nil {
+			// This is a unique index; decode the implicit column values from
+			// the value.
+			_, err := decodeKeyVals(&rf.alloc, rf.implicitValTypes, rf.implicitVals, nil,
+				kv.ValueBytes())
+			if err != nil {
+				return "", "", err
+			}
+			for i, id := range rf.index.ImplicitColumnIDs {
+				if idx, ok := rf.colIdxMap[id]; ok && rf.valNeededForCol[idx] {
+					rf.row[idx] = rf.implicitVals[i]
+				}
+			}
+			if debugStrings {
+				prettyValue = prettyDatums(rf.implicitVals)
+			}
+		}
+
+		if log.V(2) {
+			if rf.implicitVals != nil {
+				log.Infof("Scan %s -> %s", kv.Key, prettyDatums(rf.implicitVals))
+			} else {
+				log.Infof("Scan %s", kv.Key)
+			}
+		}
+	}
+
+	if debugStrings && prettyValue == "" {
+		prettyValue = parser.DNull.String()
+	}
+
+	return prettyKey, prettyValue, nil
+}
+
+// nextRow processes keys until we complete one row, which is returned as a
+// DTuple. The row contains one value per table column, regardless of the index
+// used; values that are not needed (as per valNeededForCol) are nil.
+//
+// The DTuple should not be modified and is only valid until the next call. When
+// there are no more rows, the DTuple is nil.
+func (rf *rowFetcher) nextRow() (parser.DTuple, *roachpb.Error) {
+	if rf.kvEnd {
+		return nil, nil
+	}
+
+	// All of the columns for a particular row will be grouped together. We loop
+	// over the key/value pairs and decode the key to extract the columns encoded
+	// within the key and the column ID. We use the column ID to lookup the
+	// column and decode the value. All of these values go into a map keyed by
+	// column name. When the index key changes we output a row containing the
+	// current values.
+	for {
+		_, _, err := rf.processKV(rf.kv, false)
+		if err != nil {
+			return nil, roachpb.NewError(err)
+		}
+		rowDone, pErr := rf.nextKey()
+		if pErr != nil {
+			return nil, pErr
+		}
+		if rowDone {
+			return rf.row, nil
+		}
+	}
+}
+
+// nextKeyDebug processes one key at a time and returns a pretty printed key and
+// value. If we completed a row, the row is returned as well (see nextRow). If
+// there are no more keys, prettyKey is "".
+func (rf *rowFetcher) nextKeyDebug() (
+	prettyKey string, prettyValue string, row parser.DTuple, pErr *roachpb.Error,
+) {
+	if rf.kvEnd {
+		return "", "", nil, nil
+	}
+	prettyKey, prettyValue, err := rf.processKV(rf.kv, true)
+	if err != nil {
+		return "", "", nil, roachpb.NewError(err)
+	}
+	rowDone, pErr := rf.nextKey()
+	if pErr != nil {
+		return "", "", nil, pErr
+	}
+	if rowDone {
+		row = rf.row
+	}
+	return prettyKey, prettyValue, row, nil
+}

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -17,15 +17,12 @@
 package sql
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
-	"github.com/cockroachdb/cockroach/util/encoding"
-	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/tracing"
 )
 
@@ -42,12 +39,12 @@ type scanNode struct {
 	// Set if the NO_INDEX_JOIN hint was given.
 	noIndexJoin bool
 
-	// There is a 1-1 correspondence between desc.Column sand resultColumns.
+	// There is a 1-1 correspondence between desc.Columns and resultColumns.
 	resultColumns []ResultColumn
-	// row contains values for the current row. There is a 1-1 correspondence
-	// between resultColumns and vals.
+	// Contains values for the current row. There is a 1-1 correspondence
+	// between resultColumns and values in row.
 	row parser.DTuple
-	// for each column in resultColumns, indicates if the value is needed (used
+	// For each column in resultColumns, indicates if the value is needed (used
 	// as an optimization when the upper layer doesn't need all values).
 	valNeededForCol []bool
 
@@ -57,21 +54,12 @@ type scanNode struct {
 	spans            []span
 	isSecondaryIndex bool
 	reverse          bool
-	columnIDs        []ColumnID
-	// The direction with which the corresponding column was encoded.
-	columnDirs       []encoding.Direction
 	ordering         orderingInfo
 	pErr             *roachpb.Error
-	indexKey         []byte         // the index key of the current row
-	rowIndex         int            // the index of the current row
-	colID            ColumnID       // column ID of the current key
-	valTypes         []parser.Datum // the index key value types for the current row
-	vals             []parser.Datum // the index key values for the current row
-	implicitValTypes []parser.Datum // the implicit value types for unique indexes
-	implicitVals     []parser.Datum // the implicit values for unique indexes
-	explain          explainMode
-	explainValue     parser.Datum
-	debugVals        debugValues
+
+	explain   explainMode
+	rowIndex  int // the index of the current row
+	debugVals debugValues
 
 	// filter that can be evaluated using only this table/index; it contains scanQValues.
 	filter parser.Expr
@@ -79,14 +67,9 @@ type scanNode struct {
 	qvals []scanQValue
 
 	scanInitialized bool
-	fetcher         kvFetcher
-	// The current key/value, unless kvEnd is true.
-	kv        client.KeyValue
-	kvEnd     bool
-	limitHint int64
+	fetcher         rowFetcher
 
-	// Buffered allocation of decoded datums.
-	alloc datumAlloc
+	limitHint int64
 }
 
 func (n *scanNode) Columns() []ResultColumn {
@@ -123,19 +106,62 @@ func (n *scanNode) SetLimitHint(numRows int64, soft bool) {
 	}
 }
 
-// nextKey gets the next key and sets kv and kvEnd. Returns false on errors.
-func (n *scanNode) nextKey() bool {
-	var ok bool
-	ok, n.kv, n.pErr = n.fetcher.nextKV()
+func (n *scanNode) Start() *roachpb.Error {
+	return nil
+}
+
+// initScan sets up the rowFetcher and starts a scan. On error, sets n.pErr and
+// returns false.
+func (n *scanNode) initScan() (success bool) {
+	// TODO(radu): we could call init() just once, after the index and
+	// valNeededForCol are set.
+	err := n.fetcher.init(&n.desc, n.colIdxMap, n.index, n.reverse, n.isSecondaryIndex,
+		n.valNeededForCol)
+	if err != nil {
+		n.pErr = roachpb.NewError(err)
+		return false
+	}
+
+	if len(n.spans) == 0 {
+		// If no spans were specified retrieve all of the keys that start with our
+		// index key prefix.
+		start := roachpb.Key(MakeIndexKeyPrefix(n.desc.ID, n.index.ID))
+		n.spans = append(n.spans, span{start: start, end: start.PrefixEnd()})
+	}
+
+	n.pErr = n.fetcher.startScan(n.txn, n.spans, n.limitHint)
 	if n.pErr != nil {
 		return false
 	}
-	n.kvEnd = !ok
+	n.scanInitialized = true
 	return true
 }
 
-func (n *scanNode) Start() *roachpb.Error {
-	return nil
+// debugNext is a helper function used by Next() when in explainDebug mode.
+func (n *scanNode) debugNext() bool {
+	// In debug mode, we output a set of debug values for each key.
+	n.debugVals.rowIdx = n.rowIndex
+	n.debugVals.key, n.debugVals.value, n.row, n.pErr = n.fetcher.nextKeyDebug()
+	if n.pErr != nil || n.debugVals.key == "" {
+		return false
+	}
+
+	if n.row != nil {
+		passesFilter, err := runFilter(n.filter, n.planner.evalCtx)
+		if err != nil {
+			n.pErr = roachpb.NewError(err)
+			return false
+		}
+		if passesFilter {
+			n.debugVals.output = debugValueRow
+		} else {
+			n.debugVals.output = debugValueFiltered
+		}
+		n.rowIndex++
+	} else {
+		n.debugVals.output = debugValuePartial
+	}
+	return true
 }
 
 func (n *scanNode) Next() bool {
@@ -145,38 +171,28 @@ func (n *scanNode) Next() bool {
 		return false
 	}
 
-	if !n.scanInitialized {
-		if !n.initScan() {
-			// Hit error.
-			return false
-		}
-		if !n.nextKey() {
-			// Hit error.
-			return false
-		}
+	if !n.scanInitialized && !n.initScan() {
+		// Hit error during initScan
+		return false
 	}
 
-	// All of the columns for a particular row will be grouped together. We loop
-	// over the key/value pairs and decode the key to extract the columns encoded
-	// within the key and the column ID. We use the column ID to lookup the
-	// column and decode the value. All of these values go into a map keyed by
-	// column name. When the index key changes we output a row containing the
-	// current values.
+	if n.explain == explainDebug {
+		return n.debugNext()
+	}
+
+	// We fetch one row at a time until we find one that passes the filter.
 	for {
-		if n.maybeOutputRow() {
-			return n.pErr == nil
-		}
-		if n.kvEnd {
-			// End of scan.
+		n.row, n.pErr = n.fetcher.nextRow()
+		if n.pErr != nil || n.row == nil {
 			return false
 		}
-		if !n.processKV(n.kv) {
-			// Hit error.
+		passesFilter, err := runFilter(n.filter, n.planner.evalCtx)
+		if err != nil {
+			n.pErr = roachpb.NewError(err)
 			return false
 		}
-		if !n.nextKey() {
-			// Hit error.
-			return false
+		if passesFilter {
+			return true
 		}
 	}
 }
@@ -298,71 +314,12 @@ func (n *scanNode) initDescDefaults() {
 	}
 }
 
-// initScan initializes but does not perform the key-value scan.
-func (n *scanNode) initScan() bool {
-	// Initialize our key/values.
-	if len(n.spans) == 0 {
-		// If no spans were specified retrieve all of the keys that start with our
-		// index key prefix.
-		start := roachpb.Key(MakeIndexKeyPrefix(n.desc.ID, n.index.ID))
-		n.spans = append(n.spans, span{
-			start: start,
-			end:   start.PrefixEnd(),
-		})
-	}
-
-	if n.valTypes == nil {
-		// Prepare our index key vals slice.
-		var err error
-		n.valTypes, err = makeKeyVals(&n.desc, n.columnIDs)
-		n.pErr = roachpb.NewError(err)
-		if n.pErr != nil {
-			return false
-		}
-		n.vals = make([]parser.Datum, len(n.valTypes))
-
-		if n.isSecondaryIndex && n.index.Unique {
-			// Unique secondary indexes have a value that is the primary index
-			// key. Prepare implicitVals for use in decoding this value.
-			// Primary indexes only contain ascendingly-encoded values. If this
-			// ever changes, we'll probably have to figure out the directions here too.
-			var err error
-			n.implicitValTypes, err = makeKeyVals(&n.desc, n.index.ImplicitColumnIDs)
-			n.pErr = roachpb.NewError(err)
-			if n.pErr != nil {
-				return false
-			}
-			n.implicitVals = make([]parser.Datum, len(n.implicitValTypes))
-		}
-	}
-
-	// If we have a limit hint, we limit the first batch size. Subsequent
-	// batches get larger to avoid making things too slow (e.g. in case we have
-	// a very restrictive filter and actually have to retrieve a lot of rows).
-	firstBatchLimit := n.limitHint
-	if firstBatchLimit != 0 {
-		// For a secondary index, we have one key per row.
-		if !n.isSecondaryIndex {
-			// We have a sentinel key per row plus at most one key per non-PK column. Of course, we
-			// may have other keys due to a schema change, but this is only a hint.
-			firstBatchLimit *= int64(1 + len(n.desc.Columns) - len(n.index.ColumnIDs))
-		}
-		// We need an extra key to make sure we form the last row.
-		firstBatchLimit++
-	}
-
-	n.fetcher = makeKVFetcher(n.txn, n.spans, n.reverse, firstBatchLimit)
-	n.scanInitialized = true
-	return true
-}
-
 // initOrdering initializes the ordering info using the selected index. This
 // must be called after index selection is performed.
 func (n *scanNode) initOrdering(exactPrefix int) {
 	if n.index == nil {
 		return
 	}
-	n.columnIDs, n.columnDirs = n.index.fullColumnIDs()
 	n.ordering = n.computeOrdering(n.index, exactPrefix, n.reverse)
 }
 
@@ -370,7 +327,9 @@ func (n *scanNode) initOrdering(exactPrefix int) {
 //    - we scan a given index (potentially in reverse order), and
 //    - the first `exactPrefix` columns of the index each have an exact (single value) match
 //      (see orderingInfo).
-func (n *scanNode) computeOrdering(index *IndexDescriptor, exactPrefix int, reverse bool) orderingInfo {
+func (n *scanNode) computeOrdering(
+	index *IndexDescriptor, exactPrefix int, reverse bool,
+) orderingInfo {
 	var ordering orderingInfo
 
 	columnIDs, dirs := index.fullColumnIDs()
@@ -393,218 +352,6 @@ func (n *scanNode) computeOrdering(index *IndexDescriptor, exactPrefix int, reve
 	// We included any implicit columns, so the results are unique.
 	ordering.unique = true
 	return ordering
-}
-
-func (n *scanNode) readIndexKey(k roachpb.Key) ([]byte, error) {
-	return decodeIndexKey(&n.alloc, &n.desc, n.index.ID, n.valTypes, n.vals, n.columnDirs, k)
-}
-
-func (n *scanNode) processKV(kv client.KeyValue) bool {
-	if n.indexKey == nil {
-		// Reset the row to nil; it will get filled in in with the column
-		// values as we decode the key-value pairs for the row.
-		for i := range n.row {
-			n.row[i] = nil
-		}
-	}
-
-	var remaining []byte
-	var err error
-	remaining, err = n.readIndexKey(kv.Key)
-	n.pErr = roachpb.NewError(err)
-	if n.pErr != nil {
-		return false
-	}
-
-	if n.indexKey == nil {
-		n.indexKey = []byte(kv.Key[:len(kv.Key)-len(remaining)])
-
-		// This is the first key for the row, initialize the column values that are
-		// part of the index key.
-		for i, id := range n.columnIDs {
-			if idx, ok := n.colIdxMap[id]; ok {
-				n.row[idx] = n.vals[i]
-			}
-		}
-	}
-
-	var value parser.Datum
-	n.colID = 0
-
-	if !n.isSecondaryIndex && len(remaining) > 0 {
-		var v uint64
-		var err error
-		_, v, err = encoding.DecodeUvarintAscending(remaining)
-		n.pErr = roachpb.NewError(err)
-		if n.pErr != nil {
-			return false
-		}
-		n.colID = ColumnID(v)
-		if idx, ok := n.colIdxMap[n.colID]; ok && n.valNeededForCol[idx] {
-			value, ok = n.unmarshalValue(kv)
-			if !ok {
-				return false
-			}
-			if n.row[idx] != nil {
-				panic(fmt.Sprintf("duplicate value for column %d", idx))
-			}
-			n.row[idx] = value
-			if log.V(2) {
-				log.Infof("Scan %s -> %v", kv.Key, value)
-			}
-		} else {
-			// No need to unmarshal the column value. Either the column was part of
-			// the index key or it isn't needed.
-			if log.V(2) {
-				log.Infof("Scan %s -> [%d] (skipped)", kv.Key, n.colID)
-			}
-		}
-	} else {
-		if n.implicitVals != nil {
-			var err error
-			_, err = decodeKeyVals(&n.alloc, n.implicitValTypes, n.implicitVals, nil, kv.ValueBytes())
-			n.pErr = roachpb.NewError(err)
-			if n.pErr != nil {
-				return false
-			}
-			for i, id := range n.index.ImplicitColumnIDs {
-				if idx, ok := n.colIdxMap[id]; ok && n.valNeededForCol[idx] {
-					n.row[idx] = n.implicitVals[i]
-				}
-			}
-		}
-
-		if log.V(2) {
-			if n.implicitVals != nil {
-				log.Infof("Scan %s -> %s", kv.Key, prettyDatums(n.implicitVals))
-			} else {
-				log.Infof("Scan %s", kv.Key)
-			}
-		}
-	}
-
-	if n.explain == explainDebug {
-		if value == nil {
-			if n.colID > 0 {
-				var ok bool
-				value, ok = n.unmarshalValue(kv)
-				if !ok {
-					return false
-				}
-			} else {
-				value = parser.DNull
-			}
-		}
-		n.explainValue = value
-	}
-	return true
-}
-
-// maybeOutputRow checks to see if the current key belongs to a new row and if
-// it does it outputs the last row. The return value indicates whether a row
-// was output or an error occurred. In either case, iteration should terminate.
-func (n *scanNode) maybeOutputRow() bool {
-	// For unique secondary indexes, the index-key does not distinguish one row
-	// from the next if both rows contain identical values along with a
-	// NULL. Consider the keys:
-	//
-	//   /test/unique_idx/NULL/0
-	//   /test/unique_idx/NULL/1
-	//
-	// The index-key extracted from the above keys is /test/unique_idx/NULL. The
-	// trailing /0 and /1 are the primary key used to unique-ify the keys when a
-	// NULL is present. Currently we don't detect NULLs on decoding. If we did we
-	// could detect this case and enlarge the index-key. A simpler fix for this
-	// problem is to simply always output a row for each key scanned from a
-	// secondary index as secondary indexes have only one key per row.
-
-	if n.indexKey != nil &&
-		(n.isSecondaryIndex || n.kvEnd ||
-			!bytes.HasPrefix(n.kv.Key, n.indexKey)) {
-		// The current key belongs to a new row. Output the current row.
-		n.indexKey = nil
-
-		// Fill in any missing values with NULLs
-		for i, col := range n.desc.Columns {
-			if n.valNeededForCol[i] && n.row[i] == nil {
-				if !col.Nullable {
-					panic("Non-nullable column with no value!")
-				}
-				n.row[i] = parser.DNull
-			}
-		}
-
-		// Run the filter.
-		passesFilter, err := runFilter(n.filter, n.planner.evalCtx)
-		if err != nil {
-			n.pErr = roachpb.NewError(err)
-			return true
-		}
-		if n.explainValue != nil {
-			n.explainDebug(true, passesFilter)
-			return true
-		}
-		return passesFilter
-	} else if n.explainValue != nil {
-		n.explainDebug(false, false)
-		return true
-	}
-	return false
-}
-
-// explainDebug fills in n.debugVals.
-func (n *scanNode) explainDebug(endOfRow bool, passesFilter bool) {
-	n.debugVals.rowIdx = n.rowIndex
-	n.debugVals.key = n.prettyKey()
-
-	if n.implicitVals != nil {
-		n.debugVals.value = prettyDatums(n.implicitVals)
-	} else {
-		// We convert any datum to string, which will eventually be returned as a DString.
-		// This conversion to DString is odd. `n.explainValue` is already a `Datum`, but logic_test
-		// currently expects EXPLAIN DEBUG output to come out formatted using `encodeSQLString`.
-		// This is not consistent across all printing of strings in logic_test, though.
-		// TODO(tamird/pmattis): figure out a consistent story for string
-		// printing in logic_test.
-		n.debugVals.value = n.explainValue.String()
-	}
-	if endOfRow {
-		if passesFilter {
-			n.debugVals.output = debugValueRow
-		} else {
-			n.debugVals.output = debugValueFiltered
-		}
-		n.rowIndex++
-	} else {
-		n.debugVals.output = debugValuePartial
-	}
-	n.explainValue = nil
-}
-
-func (n *scanNode) prettyKey() string {
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "/%s/%s%s", n.desc.Name, n.index.Name, prettyDatums(n.vals))
-	if n.colID > 0 {
-		// TODO(pmattis): This is inefficient, but does it matter?
-		col, err := n.desc.FindActiveColumnByID(n.colID)
-		if err != nil {
-			panic(err)
-		}
-		fmt.Fprintf(&buf, "/%s", col.Name)
-	}
-	return buf.String()
-}
-
-func (n *scanNode) unmarshalValue(kv client.KeyValue) (parser.Datum, bool) {
-	idx, ok := n.colIdxMap[n.colID]
-	if !ok {
-		n.pErr = roachpb.NewUErrorf("column-id \"%d\" does not exist", n.colID)
-		return nil, false
-	}
-	kind := n.desc.Columns[idx].Type.Kind
-	d, err := unmarshalColumnValue(&n.alloc, kind, kv.Value)
-	n.pErr = roachpb.NewError(err)
-	return d, n.pErr == nil
 }
 
 // scanQValue implements the parser.VariableExpr interface and is used as a replacement node for

--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -284,7 +284,7 @@ INSERT INTO kv5 VALUES('a', NULL)
 query ITTT
 EXPLAIN (DEBUG) SELECT * FROM kv5@a
 ----
-0 /kv5/a/NULL/'a' ROW
+0 /kv5/a/NULL/'a' NULL ROW
 
 query TT
 SELECT v, k FROM kv5@a


### PR DESCRIPTION
Separating the code to convert from key/values to rows into rowFetcher. The
rowFetcher will be used by the new TableReader.

Had to refactor a few things, especially the way we generate debug values (we
now generate them in processKV instead of "leaking" things from the function).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6193)

<!-- Reviewable:end -->
