### PR TITLE
roachpb: remove unnecessary allocation in BatchRequest.Add

### DIFF
--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -153,17 +153,15 @@ func (br *BatchResponse) Combine(otherBatch *BatchResponse) error {
 // Add adds a request to the batch request.
 func (ba *BatchRequest) Add(requests ...Request) {
 	for _, args := range requests {
-		union := RequestUnion{}
-		union.MustSetInner(args)
-		ba.Requests = append(ba.Requests, union)
+		ba.Requests = append(ba.Requests, RequestUnion{})
+		ba.Requests[len(ba.Requests)-1].MustSetInner(args)
 	}
 }
 
 // Add adds a response to the batch response.
 func (br *BatchResponse) Add(reply Response) {
-	n := len(br.Responses)
 	br.Responses = append(br.Responses, ResponseUnion{})
-	br.Responses[n].MustSetInner(reply)
+	br.Responses[len(br.Responses)-1].MustSetInner(reply)
 }
 
 // Methods returns a slice of the contained methods.


### PR DESCRIPTION
Similar to an earlier change which fixed BatchResponse.Add, calling
RequestUnion.MustSetInner on a stack variable was forcing it to the
heap.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6205)

<!-- Reviewable:end -->
