### PR TITLE
sql: a more flexible mechanism for blocking schema changers in tests

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -162,6 +162,26 @@ type ExecutorContext struct {
 	TestingKnobs *ExecutorTestingKnobs
 }
 
+// TestingSchemaChangerCollection is an exported (for testing) version of
+// schemaChangerCollection.
+// TODO(andrei): get rid of this type once we can have tests internal to the sql
+// package (as of April 2016 we can't because sql can't import server).
+type TestingSchemaChangerCollection struct {
+	scc *schemaChangerCollection
+}
+
+// ClearSchemaChangers clears the schema changers from the collection.
+// If this is called from a SyncSchemaChangersFilter, no schema changer will be
+// run.
+func (tscc TestingSchemaChangerCollection) ClearSchemaChangers() {
+	tscc.scc.schemaChangers = tscc.scc.schemaChangers[:0]
+}
+
+// SyncSchemaChangersFilter is the type of a hook to be installed through the
+// ExecutorContext for blocking or otherwise manipulating schema changers run
+// through the sync schema changers path.
+type SyncSchemaChangersFilter func(TestingSchemaChangerCollection)
+
 // ExecutorTestingKnobs is part of the context used to control parts of the
 // system during testing.
 type ExecutorTestingKnobs struct {
@@ -176,6 +196,14 @@ type ExecutorTestingKnobs struct {
 	// FixTxnPriority causes transaction priority values to be hardcoded (for
 	// each priority level) to avoid the randomness in the normal generation.
 	FixTxnPriority bool
+
+	// SyncSchemaChangersFilter is called before running schema changers
+	// synchronously (at the end of a txn). The function can be used to clear the
+	// schema changers (if the test doesn't want them run using the synchronous
+	// path) or to temporarily block execution.
+	// Note that this has nothing to do with the async path for running schema
+	// changers. To block that, see TestDisableAsyncSchemaChangeExec().
+	SyncSchemaChangersFilter SyncSchemaChangersFilter
 }
 
 // NewExecutor creates an Executor and registers a callback on the

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -393,7 +393,6 @@ func NewSchemaChangeManager(db client.DB, gossip *gossip.Gossip, leaseMgr *Lease
 }
 
 var (
-	disableSyncSchemaChangeExec  = false
 	disableAsyncSchemaChangeExec = false
 	// How often does the SchemaChangeManager attempt to execute
 	// pending schema changes.
@@ -403,19 +402,16 @@ var (
 	asyncSchemaChangeExecDelay = 360 * time.Second
 )
 
-// TestDisableSyncSchemaChangeExec is used in tests to
-// disable the synchronous execution of schema changes,
-// so that the asynchronous schema changer can run the
-// schema changes.
-func TestDisableSyncSchemaChangeExec() func() {
-	disableSyncSchemaChangeExec = true
-	// Attempt to execute almost immediately.
-	asyncSchemaChangeExecInterval = 20 * time.Millisecond
+// TestSpeedupAsyncSchemaChanges can be used in tests to manipulate the async
+// executor timing and make it run quickly and often.  Returns a cleanup
+// function restoring original values.
+func TestSpeedupAsyncSchemaChanges() func() {
+	origInterval, origDelay := asyncSchemaChangeExecInterval, asyncSchemaChangeExecDelay
 	asyncSchemaChangeExecDelay = 20 * time.Millisecond
+	asyncSchemaChangeExecInterval = 20 * time.Millisecond
 	return func() {
-		disableSyncSchemaChangeExec = false
-		asyncSchemaChangeExecInterval = 60 * time.Second
-		asyncSchemaChangeExecDelay = 360 * time.Second
+		asyncSchemaChangeExecDelay = origDelay
+		asyncSchemaChangeExecInterval = origInterval
 	}
 }
 

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -289,14 +289,19 @@ INSERT INTO t.test VALUES ('a', 'b'), ('c', 'd');
 
 func TestAsyncSchemaChanger(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	// Disable synchronous schema change execution so
-	// the asynchronous schema changer executes all
-	// schema changes.
-	defer csql.TestDisableSyncSchemaChangeExec()()
 	// The descriptor changes made must have an immediate effect
 	// so disable leases on tables.
 	defer csql.TestDisableTableLeases()()
-	server, sqlDB, kvDB := setup(t)
+	// Disable synchronous schema change execution so the asynchronous schema
+	// changer executes all schema changes.
+	ctx, _ := createTestServerContext()
+	ctx.TestingKnobs.ExecutorTestingKnobs.SyncSchemaChangersFilter =
+		func(tscc csql.TestingSchemaChangerCollection) {
+			tscc.ClearSchemaChangers()
+		}
+	defer csql.TestSpeedupAsyncSchemaChanges()()
+
+	server, sqlDB, kvDB := setupWithContext(t, ctx)
 	defer cleanup(server, sqlDB)
 
 	if _, err := sqlDB.Exec(`

--- a/sql/session.go
+++ b/sql/session.go
@@ -285,10 +285,8 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 	}
 	// Release the leases once a transaction is complete.
 	planMaker.releaseLeases()
-	if len(scc.schemaChangers) == 0 ||
-		// Disable execution in some tests.
-		disableSyncSchemaChangeExec {
-		return
+	if e.ctx.TestingKnobs.SyncSchemaChangersFilter != nil {
+		e.ctx.TestingKnobs.SyncSchemaChangersFilter(TestingSchemaChangerCollection{scc})
 	}
 	// Execute any schema changes that were scheduled, in the order of the
 	// statements that scheduled them.


### PR DESCRIPTION
Before this we have DisableSyncSchemaChanges, but that guy can only be
called before the server is created (otherwise it races with schema
changers). I need to be able to let schema changes run in the beginning
of the test, and block them later on. 
This will be used in a next PR that needs to start blocking schema changes in the middle of the test.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6207)

<!-- Reviewable:end -->
