### PR TITLE
storage: Enable raft.Config.CheckQuorum

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -356,6 +356,7 @@ func (r *Replica) setReplicaIDLocked(replicaID roachpb.ReplicaID) error {
 		// TODO(bdarnell): make these configurable; evaluate defaults.
 		MaxSizePerMsg:   1024 * 1024,
 		MaxInflightMsgs: 256,
+		CheckQuorum:     true,
 		Logger:          &raftLogger{group: uint64(r.RangeID)},
 	}
 	raftGroup, err := raft.NewRawNode(raftCfg, nil)


### PR DESCRIPTION
This feature makes a raft leader step down (i.e. revert to follower
mode) if it hasn't gotten enough heartbeat responses recently. This
reduces the amount of time that a partitioned node incorrectly believes
itself to be leader. We haven't turned it on because we don't care much
about a replica's belief about its raft state. However, it also enables
other stateful features in the raft implementation, namely the ability
to not try to send snapshots to nodes that haven't responded recently.

Fixes #6218

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6219)

<!-- Reviewable:end -->
