### PR TITLE
sql: Fix Walk implementation for IsOfTypeExpr

### DIFF
--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -211,7 +211,15 @@ func (expr *IfExpr) Walk(v Visitor) Expr {
 }
 
 // Walk implements the Expr interface.
-func (expr *IsOfTypeExpr) Walk(_ Visitor) Expr { return expr }
+func (expr *IsOfTypeExpr) Walk(v Visitor) Expr {
+	e, changed := WalkExpr(v, expr.Expr)
+	if changed {
+		exprCopy := *expr
+		exprCopy.Expr = e
+		return &exprCopy
+	}
+	return expr
+}
 
 // Walk implements the Expr interface.
 func (expr *NotExpr) Walk(v Visitor) Expr {

--- a/sql/parser/walk_test.go
+++ b/sql/parser/walk_test.go
@@ -79,6 +79,7 @@ func TestFillArgs(t *testing.T) {
 		{`ROW($1, $2, $3)`, `ROW(1, 2, '3')`, MapArgs{`1`: dint(1), `2`: dint(2), `3`: dstring("3")}},
 		{`(SELECT $1)`, `(SELECT 'a')`, MapArgs{`1`: dstring("a")}},
 		{`EXISTS (SELECT $1)`, `EXISTS (SELECT 'a')`, MapArgs{`1`: dstring("a")}},
+		{`($1 >= $2) IS OF (BOOL)`, `(1 >= 2) IS OF (BOOL)`, MapArgs{`1`: dint(1), `2`: dint(2)}},
 	}
 
 	for _, d := range testData {


### PR DESCRIPTION
Previously `parser.IsOfTypeExpr.Walk` did not actually walk sub-expressions.
This change fixes that and adds a tests which would previously have failed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6221)

<!-- Reviewable:end -->
