### PR TITLE
storage: reduce allocations when populating BatchResponse

### DIFF
--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -174,11 +174,264 @@ func (ba *BatchRequest) Methods() []Method {
 }
 
 // CreateReply creates replies for each of the contained requests, wrapped in a
-// BatchResponse.
+// BatchResponse. The response objects are batch allocated to minimize
+// allocation overhead which adds a bit of complexity to this function.
 func (ba *BatchRequest) CreateReply() *BatchResponse {
 	br := &BatchResponse{}
+	br.Responses = make([]ResponseUnion, len(ba.Requests))
+
+	var counts struct {
+		get                int
+		put                int
+		conditionalPut     int
+		initPut            int
+		increment          int
+		delete             int
+		deleteRange        int
+		scan               int
+		beginTransaction   int
+		endTransaction     int
+		adminSplit         int
+		adminMerge         int
+		heartbeatTxn       int
+		gc                 int
+		pushTxn            int
+		rangeLookup        int
+		resolveIntent      int
+		resolveIntentRange int
+		merge              int
+		truncateLog        int
+		leaderLease        int
+		reverseScan        int
+		computeChecksum    int
+		verifyChecksum     int
+		checkConsistency   int
+		noop               int
+	}
 	for _, union := range ba.Requests {
-		br.Add(union.GetInner().createReply())
+		switch union.GetInner().(type) {
+		case *GetRequest:
+			counts.get++
+		case *PutRequest:
+			counts.put++
+		case *ConditionalPutRequest:
+			counts.conditionalPut++
+		case *InitPutRequest:
+			counts.initPut++
+		case *IncrementRequest:
+			counts.increment++
+		case *DeleteRequest:
+			counts.delete++
+		case *DeleteRangeRequest:
+			counts.deleteRange++
+		case *ScanRequest:
+			counts.scan++
+		case *BeginTransactionRequest:
+			counts.beginTransaction++
+		case *EndTransactionRequest:
+			counts.endTransaction++
+		case *AdminSplitRequest:
+			counts.adminSplit++
+		case *AdminMergeRequest:
+			counts.adminMerge++
+		case *HeartbeatTxnRequest:
+			counts.heartbeatTxn++
+		case *GCRequest:
+			counts.gc++
+		case *PushTxnRequest:
+			counts.pushTxn++
+		case *RangeLookupRequest:
+			counts.rangeLookup++
+		case *ResolveIntentRequest:
+			counts.resolveIntent++
+		case *ResolveIntentRangeRequest:
+			counts.resolveIntentRange++
+		case *MergeRequest:
+			counts.merge++
+		case *TruncateLogRequest:
+			counts.truncateLog++
+		case *LeaderLeaseRequest:
+			counts.leaderLease++
+		case *ReverseScanRequest:
+			counts.reverseScan++
+		case *ComputeChecksumRequest:
+			counts.computeChecksum++
+		case *VerifyChecksumRequest:
+			counts.verifyChecksum++
+		case *CheckConsistencyRequest:
+			counts.checkConsistency++
+		case *NoopRequest:
+			counts.noop++
+		default:
+			panic(fmt.Sprintf("unsupported type %T", union.GetInner()))
+		}
+	}
+
+	var bufs struct {
+		get                []GetResponse
+		put                []PutResponse
+		conditionalPut     []ConditionalPutResponse
+		initPut            []InitPutResponse
+		increment          []IncrementResponse
+		delete             []DeleteResponse
+		deleteRange        []DeleteRangeResponse
+		scan               []ScanResponse
+		beginTransaction   []BeginTransactionResponse
+		endTransaction     []EndTransactionResponse
+		adminSplit         []AdminSplitResponse
+		adminMerge         []AdminMergeResponse
+		heartbeatTxn       []HeartbeatTxnResponse
+		gc                 []GCResponse
+		pushTxn            []PushTxnResponse
+		rangeLookup        []RangeLookupResponse
+		resolveIntent      []ResolveIntentResponse
+		resolveIntentRange []ResolveIntentRangeResponse
+		merge              []MergeResponse
+		truncateLog        []TruncateLogResponse
+		leaderLease        []LeaderLeaseResponse
+		reverseScan        []ReverseScanResponse
+		computeChecksum    []ComputeChecksumResponse
+		verifyChecksum     []VerifyChecksumResponse
+		checkConsistency   []CheckConsistencyResponse
+		noop               []NoopResponse
+	}
+	for i, union := range ba.Requests {
+		var reply Response
+		switch union.GetInner().(type) {
+		case *GetRequest:
+			if bufs.get == nil {
+				bufs.get = make([]GetResponse, counts.get)
+			}
+			reply, bufs.get = &bufs.get[0], bufs.get[1:]
+		case *PutRequest:
+			if bufs.put == nil {
+				bufs.put = make([]PutResponse, counts.put)
+			}
+			reply, bufs.put = &bufs.put[0], bufs.put[1:]
+		case *ConditionalPutRequest:
+			if bufs.conditionalPut == nil {
+				bufs.conditionalPut = make([]ConditionalPutResponse, counts.conditionalPut)
+			}
+			reply, bufs.conditionalPut = &bufs.conditionalPut[0], bufs.conditionalPut[1:]
+		case *InitPutRequest:
+			if bufs.initPut == nil {
+				bufs.initPut = make([]InitPutResponse, counts.initPut)
+			}
+			reply, bufs.initPut = &bufs.initPut[0], bufs.initPut[1:]
+		case *IncrementRequest:
+			if bufs.increment == nil {
+				bufs.increment = make([]IncrementResponse, counts.increment)
+			}
+			reply, bufs.increment = &bufs.increment[0], bufs.increment[1:]
+		case *DeleteRequest:
+			if bufs.delete == nil {
+				bufs.delete = make([]DeleteResponse, counts.delete)
+			}
+			reply, bufs.delete = &bufs.delete[0], bufs.delete[1:]
+		case *DeleteRangeRequest:
+			if bufs.deleteRange == nil {
+				bufs.deleteRange = make([]DeleteRangeResponse, counts.deleteRange)
+			}
+			reply, bufs.deleteRange = &bufs.deleteRange[0], bufs.deleteRange[1:]
+		case *ScanRequest:
+			if bufs.scan == nil {
+				bufs.scan = make([]ScanResponse, counts.scan)
+			}
+			reply, bufs.scan = &bufs.scan[0], bufs.scan[1:]
+		case *BeginTransactionRequest:
+			if bufs.beginTransaction == nil {
+				bufs.beginTransaction = make([]BeginTransactionResponse, counts.beginTransaction)
+			}
+			reply, bufs.beginTransaction = &bufs.beginTransaction[0], bufs.beginTransaction[1:]
+		case *EndTransactionRequest:
+			if bufs.endTransaction == nil {
+				bufs.endTransaction = make([]EndTransactionResponse, counts.endTransaction)
+			}
+			reply, bufs.endTransaction = &bufs.endTransaction[0], bufs.endTransaction[1:]
+		case *AdminSplitRequest:
+			if bufs.adminSplit == nil {
+				bufs.adminSplit = make([]AdminSplitResponse, counts.adminSplit)
+			}
+			reply, bufs.adminSplit = &bufs.adminSplit[0], bufs.adminSplit[1:]
+		case *AdminMergeRequest:
+			if bufs.adminMerge == nil {
+				bufs.adminMerge = make([]AdminMergeResponse, counts.adminMerge)
+			}
+			reply, bufs.adminMerge = &bufs.adminMerge[0], bufs.adminMerge[1:]
+		case *HeartbeatTxnRequest:
+			if bufs.heartbeatTxn == nil {
+				bufs.heartbeatTxn = make([]HeartbeatTxnResponse, counts.heartbeatTxn)
+			}
+			reply, bufs.heartbeatTxn = &bufs.heartbeatTxn[0], bufs.heartbeatTxn[1:]
+		case *GCRequest:
+			if bufs.gc == nil {
+				bufs.gc = make([]GCResponse, counts.gc)
+			}
+			reply, bufs.gc = &bufs.gc[0], bufs.gc[1:]
+		case *PushTxnRequest:
+			if bufs.pushTxn == nil {
+				bufs.pushTxn = make([]PushTxnResponse, counts.pushTxn)
+			}
+			reply, bufs.pushTxn = &bufs.pushTxn[0], bufs.pushTxn[1:]
+		case *RangeLookupRequest:
+			if bufs.rangeLookup == nil {
+				bufs.rangeLookup = make([]RangeLookupResponse, counts.rangeLookup)
+			}
+			reply, bufs.rangeLookup = &bufs.rangeLookup[0], bufs.rangeLookup[1:]
+		case *ResolveIntentRequest:
+			if bufs.resolveIntent == nil {
+				bufs.resolveIntent = make([]ResolveIntentResponse, counts.resolveIntent)
+			}
+			reply, bufs.resolveIntent = &bufs.resolveIntent[0], bufs.resolveIntent[1:]
+		case *ResolveIntentRangeRequest:
+			if bufs.resolveIntentRange == nil {
+				bufs.resolveIntentRange = make([]ResolveIntentRangeResponse, counts.resolveIntentRange)
+			}
+			reply, bufs.resolveIntentRange = &bufs.resolveIntentRange[0], bufs.resolveIntentRange[1:]
+		case *MergeRequest:
+			if bufs.merge == nil {
+				bufs.merge = make([]MergeResponse, counts.merge)
+			}
+			reply, bufs.merge = &bufs.merge[0], bufs.merge[1:]
+		case *TruncateLogRequest:
+			if bufs.truncateLog == nil {
+				bufs.truncateLog = make([]TruncateLogResponse, counts.truncateLog)
+			}
+			reply, bufs.truncateLog = &bufs.truncateLog[0], bufs.truncateLog[1:]
+		case *LeaderLeaseRequest:
+			if bufs.leaderLease == nil {
+				bufs.leaderLease = make([]LeaderLeaseResponse, counts.leaderLease)
+			}
+			reply, bufs.leaderLease = &bufs.leaderLease[0], bufs.leaderLease[1:]
+		case *ReverseScanRequest:
+			if bufs.reverseScan == nil {
+				bufs.reverseScan = make([]ReverseScanResponse, counts.reverseScan)
+			}
+			reply, bufs.reverseScan = &bufs.reverseScan[0], bufs.reverseScan[1:]
+		case *ComputeChecksumRequest:
+			if bufs.computeChecksum == nil {
+				bufs.computeChecksum = make([]ComputeChecksumResponse, counts.computeChecksum)
+			}
+			reply, bufs.computeChecksum = &bufs.computeChecksum[0], bufs.computeChecksum[1:]
+		case *VerifyChecksumRequest:
+			if bufs.verifyChecksum == nil {
+				bufs.verifyChecksum = make([]VerifyChecksumResponse, counts.verifyChecksum)
+			}
+			reply, bufs.verifyChecksum = &bufs.verifyChecksum[0], bufs.verifyChecksum[1:]
+		case *CheckConsistencyRequest:
+			if bufs.checkConsistency == nil {
+				bufs.checkConsistency = make([]CheckConsistencyResponse, counts.checkConsistency)
+			}
+			reply, bufs.checkConsistency = &bufs.checkConsistency[0], bufs.checkConsistency[1:]
+		case *NoopRequest:
+			if bufs.noop == nil {
+				bufs.noop = make([]NoopResponse, counts.noop)
+			}
+			reply, bufs.noop = &bufs.noop[0], bufs.noop[1:]
+		default:
+			panic(fmt.Sprintf("unsupported type %T", union.GetInner()))
+		}
+		br.Responses[i].MustSetInner(reply)
 	}
 	return br
 }


### PR DESCRIPTION
Instead of creating the response structs individually, we now loop over
the request and batch allocate all of the responses for a particular
type.

I'm not sure why there is so much variation in the allocations for the
Insert10000 benchmark.

```
name                  old time/op    new time/op    delta
KVInsert1_SQL-32         498µs ± 3%     504µs ± 2%  +1.24%  (p=0.001 n=20+20)
KVInsert10_SQL-32        971µs ± 2%     965µs ± 2%    ~     (p=0.175 n=19+20)
KVInsert100_SQL-32      5.34ms ± 4%    5.34ms ± 5%    ~     (p=0.840 n=19+19)
KVInsert1000_SQL-32     53.9ms ± 8%    53.9ms ±10%    ~     (p=0.779 n=20+20)
KVInsert10000_SQL-32     726ms ± 7%     705ms ±10%    ~     (p=0.091 n=17+20)

name                  old allocs/op  new allocs/op  delta
KVInsert1_SQL-32           316 ± 0%       314 ± 0%  -0.76%  (p=0.000 n=20+17)
KVInsert10_SQL-32          863 ± 0%       838 ± 0%  -2.81%  (p=0.000 n=20+20)
KVInsert100_SQL-32       6.15k ± 0%     5.94k ± 0%  -3.35%  (p=0.000 n=20+20)
KVInsert1000_SQL-32      59.5k ± 1%     57.5k ± 1%  -3.29%  (p=0.000 n=18+20)
KVInsert10000_SQL-32      690k ± 7%      684k ± 9%    ~     (p=0.305 n=19+20)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6222)

<!-- Reviewable:end -->
