### PR TITLE
storage: break the dependency of the storage package on the sql package

### DIFF
--- a/server/node_test.go
+++ b/server/node_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/server/status"
+	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/testutils"
@@ -95,7 +96,8 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	ctx.DB = client.NewDB(sender)
 	ctx.Transport = storage.NewDummyRaftTransport()
 	ctx.Tracer = tracer
-	node := NewNode(ctx, status.NewMetricsRecorder(ctx.Clock), stopper, kv.NewTxnMetrics(metric.NewRegistry()))
+	node := NewNode(ctx, status.NewMetricsRecorder(ctx.Clock), stopper,
+		kv.NewTxnMetrics(metric.NewRegistry()), sql.MakeEventLogger(nil))
 	roachpb.RegisterInternalServer(grpcServer, node)
 	return grpcServer, ln.Addr(), ctx.Clock, node, stopper
 }

--- a/server/server.go
+++ b/server/server.go
@@ -202,7 +202,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	s.runtime = status.MakeRuntimeStatSampler(s.clock)
 	s.recorder.AddNodeRegistry("sys.%s", s.runtime.Registry())
 
-	s.node = NewNode(nCtx, s.recorder, s.stopper, txnMetrics)
+	s.node = NewNode(nCtx, s.recorder, s.stopper, txnMetrics, sql.MakeEventLogger(s.leaseMgr))
 	roachpb.RegisterInternalServer(s.grpc, s.node)
 
 	s.admin = newAdminServer(s.db, s.stopper, s.sqlExecutor, ds, s.node)

--- a/sql/internal.go
+++ b/sql/internal.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/sqlutil"
 )
 
 // InternalExecutor can be used internally by cockroach to execute SQL
@@ -31,6 +32,8 @@ import (
 type InternalExecutor struct {
 	LeaseManager *LeaseManager
 }
+
+var _ sqlutil.InternalExecutor = InternalExecutor{}
 
 // ExecuteStatementInTransaction executes the supplied SQL statement as part of
 // the supplied transaction. Statements are currently executed as the root user.

--- a/sql/sqlutil/internal_executor.go
+++ b/sql/sqlutil/internal_executor.go
@@ -1,0 +1,33 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Andrei Matei (andreimatei1@gmail.com)
+
+package sqlutil
+
+import (
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/roachpb"
+)
+
+// InternalExecutor is meant to be used by layers below SQL in the system that
+// nevertheless want to execute SQL queries (presumably against system tables).
+// It is extracted in this "sql/util" package to avoid circular references and
+// is implemented by sql.InternalExecutor.
+type InternalExecutor interface {
+	// ExecuteStatementInTransaction executes the supplied SQL statement as part of
+	// the supplied transaction. Statements are currently executed as the root user.
+	ExecuteStatementInTransaction(
+		txn *client.Txn, statement string, params ...interface{}) (int, *roachpb.Error)
+}

--- a/storage/log.go
+++ b/storage/log.go
@@ -22,10 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/sql"
-	"github.com/cockroachdb/cockroach/sql/privilege"
 )
 
 // TODO(mrtracy): All of this logic should probably be moved into the SQL
@@ -48,10 +45,10 @@ const (
 	RangeEventLogRemove RangeEventLogType = "remove"
 )
 
-// rangeEventTableSchema defines the schema of the event log table. It is
+// RangeEventTableSchema defines the schema of the event log table. It is
 // currently envisioned as a wide table; many different event types can be
 // recorded to the table.
-const rangeEventTableSchema = `
+const RangeEventTableSchema = `
 CREATE TABLE system.rangelog (
   timestamp     TIMESTAMP  NOT NULL,
   rangeID       INT        NOT NULL,
@@ -116,12 +113,6 @@ VALUES(
 		return roachpb.NewErrorf("%d rows affected by log insertion; expected exactly one row affected.", rows)
 	}
 	return nil
-}
-
-// AddEventLogToMetadataSchema adds the range event log table to the supplied
-// MetadataSchema.
-func AddEventLogToMetadataSchema(schema *sql.MetadataSchema) {
-	schema.AddTable(keys.RangeEventTableID, rangeEventTableSchema, privilege.List{privilege.ALL})
 }
 
 // logSplit logs a range split event into the event table. The affected range is

--- a/storage/store.go
+++ b/storage/store.go
@@ -35,7 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
@@ -328,7 +328,7 @@ type StoreContext struct {
 
 	// SQLExecutor is used by the store to execute SQL statements in a way that
 	// is more direct than using a sql.Executor.
-	SQLExecutor sql.InternalExecutor
+	SQLExecutor sqlutil.InternalExecutor
 
 	// RangeRetryOptions are the retry options when retryable errors are
 	// encountered sending commands to ranges.


### PR DESCRIPTION
This is so that in the future SQL can import KV (which imports storage).

The dependency was only because of the sorry InternalExecutor which I've
extracted in an interface in a new sql/util package.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6223)

<!-- Reviewable:end -->
