### PR TITLE
kv: document DeleteRange (SI) and Delete (SSI) anomalies

### DIFF
--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -677,12 +677,14 @@ func checkConcurrency(name string, isolations []roachpb.IsolationType, txns []st
 //   R(x) - read from key "x"
 //   I(x) - increment key "x" by 1 (shorthand for W(x,x+1)
 //   SC(x-y) - scan values from keys "x"-"y"
+//   DR(x-y) - delete range of keys "x"-"y"
 //   W(x,y[+z+...]) - writes sum of values y+z+... to x
 //   C - commit
 //
 // Notation for actual histories:
 //   Rn.m(x) - read from txn "n" ("m"th retry) of key "x"
 //   In.m(x) - increment from txn "n" ("m"th retry) of key "x"
+//   DRn.m(x-y) - delete range from txn "n" ("m"th retry) of keys "x"-"y"
 //   SCn.m(x-y) - scan from txn "n" ("m"th retry) of keys "x"-"y"
 //   Wn.m(x,y[+z+...]) - write sum of values y+z+... to x from txn "n" ("m"th retry)
 //   Cn.m - commit of txn "n" ("m"th retry)
@@ -743,6 +745,34 @@ func TestTxnDBLostUpdateAnomaly(t *testing.T) {
 		},
 	}
 	checkConcurrency("lost update", bothIsolations, []string{txn, txn}, verify, true, t)
+}
+
+func TestTxnDBLostUpdateAnomaly_DeleteRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Currently fails with variations of
+	//   iso=[SNAPSHOT SNAPSHOT SNAPSHOT], pri=[3 2 1]
+	//   I1.1(A)[1] C1.1 DR3.1(A-C) R2.1(A)[1] C3.1 W2.1(B-A)[1] C2.1
+	// and
+	//   iso=[SNAPSHOT SNAPSHOT SNAPSHOT], pri=[2 3 1]
+	//   I1.1(A)[1] C1.1 R2.1(A)[1] DR3.1(A-C) W2.1(B-A)[1] C3.1 C2.1
+	t.Skip("TODO(tschottdorf): see #6240")
+
+	// When serializable, B can't exceed A.
+	txn1 := "I(A) C"
+	txn2 := "R(A) W(B,A) C"
+	txn3 := "DR(A-C) C"
+	verify := &verifier{
+		history: "R(A) R(B)",
+		checkFn: func(env map[string]int64) error {
+			if env["B"] != 0 && env["A"] == 0 {
+				return util.Errorf("expected B = %d <= %d = A", env["B"], env["A"])
+			}
+			return nil
+		},
+		pruneTo: regexp.MustCompile(`^I1\(A\) C1`),
+	}
+	checkConcurrency("lost update (range delete)", onlySnapshot,
+		[]string{txn1, txn2, txn3}, verify, true, t)
 }
 
 // TestTxnDBPhantomReadAnomaly verifies that neither SI nor SSI isolation

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -161,6 +161,11 @@ func readCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 	return nil
 }
 
+// deleteCmd deletes the value at the given key from the db.
+func deleteCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
+	return txn.Del(c.getKey())
+}
+
 // deleteRngCmd deletes the range of values from the db from [key, endKey).
 func deleteRngCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 	return txn.DelRange(c.getKey(), c.getEndKey())
@@ -233,6 +238,11 @@ var cmdSpecs = []*cmdSpec{
 		incCmd,
 		regexp.MustCompile(`(I)\(([A-Z]+)\)`),
 	},
+	{
+		deleteCmd,
+		regexp.MustCompile(`(D)\(([A-Z]+)\)`),
+	},
+
 	{
 		deleteRngCmd,
 		regexp.MustCompile(`(DR)\(([A-Z]+)-([A-Z]+)\)`),
@@ -677,6 +687,7 @@ func checkConcurrency(name string, isolations []roachpb.IsolationType, txns []st
 //   R(x) - read from key "x"
 //   I(x) - increment key "x" by 1 (shorthand for W(x,x+1)
 //   SC(x-y) - scan values from keys "x"-"y"
+//   D(x) - delete key "x"
 //   DR(x-y) - delete range of keys "x"-"y"
 //   W(x,y[+z+...]) - writes sum of values y+z+... to x
 //   C - commit
@@ -684,6 +695,7 @@ func checkConcurrency(name string, isolations []roachpb.IsolationType, txns []st
 // Notation for actual histories:
 //   Rn.m(x) - read from txn "n" ("m"th retry) of key "x"
 //   In.m(x) - increment from txn "n" ("m"th retry) of key "x"
+//   Dn.m(x) - delete key from txn ("m"th retry) of key "x"
 //   DRn.m(x-y) - delete range from txn "n" ("m"th retry) of keys "x"-"y"
 //   SCn.m(x-y) - scan from txn "n" ("m"th retry) of keys "x"-"y"
 //   Wn.m(x,y[+z+...]) - write sum of values y+z+... to x from txn "n" ("m"th retry)

--- a/util/leaktest/leaktest.go
+++ b/util/leaktest/leaktest.go
@@ -61,6 +61,9 @@ func AfterTest(t testing.TB) func() {
 		orig[g] = true
 	}
 	return func() {
+		if t.Failed() {
+			return
+		}
 		// Loop, waiting for goroutines to shut down.
 		// Wait up to 5 seconds, but finish as quickly as possible.
 		deadline := timeutil.Now().Add(5 * time.Second)


### PR DESCRIPTION
# DeleteRange

The newly added test (which was pruned to make its runtime palatable) currently
returns ~22 failing histories at SNAPSHOT isolation owing to two anomalies.
This was found looking into #6124, but is not technically related to it (but see the next section).
The first (and more severe) anomaly:

```
iso=[SNAPSHOT SNAPSHOT SNAPSHOT], pri=[3 2 1]
I1.1(A)[1] C1.1 DR3.1(A-C) R2.1(A)[1] C3.1 W2.1(B-A)[1] C2.1
```

In other words
- the value A=1 is written and committed
- transaction 3 deletes A-C (which means leaving an intent on A and
  populating the write timestamp cache interval A-C.
- transaction 2 pushes the intent on A and reads A=1.
  The write timestamp cache entry on A isn't updated properly in the process
  (which is an unrelated issue that likely incurs anomalies).
- transaction 2 writes B=1, commits.
  This is the anomaly: logically, there is DeleteRange intent sitting there
  with a higher timestamp, so this should be a write-write conflict. But there
  isn't an actual intent there (since the key was previously vacant, just like
  the countably infinite rest of vacant keys around it).
- transaction 3 commits (at its higher timestamp), so now A=<nil>,
  but note that we still have B=1 (written by transaction 2).

Note that this example should fail in the same way with only transaction 3 at
SNAPSHOT isolation.

The one obvious fix that comes to mind is to "somehow" push the whole range
entry in the timestamp cache forward along with the push of one of its intents.
However, that seems brittle and may not reliably be possible since the
timestamp cache's current implementation freely splits up its intervals as new
entries are added.

Then there's also this failing history (the key point is essentially that the
read of A and the range deletion are interchanged):

```
iso=[SNAPSHOT SNAPSHOT SNAPSHOT], pri=[2 3 1]
I1.1(A)[1] C1.1 R2.1(A)[1] DR3.1(A-C) W2.1(B-A)[1] C3.1 C2.1
```

In other words:
- write and commit A=1 as before
- txn2 reads A=1
- txn3 deletes A-C (so `ts(txn3) > ts(txn2)`)
- txn2 writes B=1 (pushing its timestamp due to tsCache entry on A-C); now
  again `ts(txn3) < ts(txn2)`
- both commit and the visible values are A=<nil>, B=1; we've again lost txn3's
  deletion of B.

This seems a little less anomalous than the above since essentially what
happens is that txn2 has write skew: It reads a stale value of A and writes
it somewhere, except that this "somewhere" would be a write-write conflict in
most monolithic databases.
# Delete

As pointed out in #6124, `Delete` currently neither populates the timestamp
cache nor leaves a tombstone when there is no previous value.

Consider the history `I1(A) C1 R2(A) D3(A) D3(B) W2(B-A) C2 C3`
- A=1 is written and committed
- txn2 reads `A=1`
- txn3 deletes A and B (the latter of which is vacant, i.e. has no old version)
  There is no conflict since `ts(txn3) > ts(txn2)`.
- txn2 writes `B=1` and both txns commit.
  This is illegal since `txn2` wrote into the past of `txn3`s deletion of B.

A tombstone on B would have fixed this (txn2 would have caught write-too-old),
or an entry in the write timestamp cache.

Writing the tombstone is likely the more economical option.

See #6124 for discovery and discussion of this anomaly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6227)

<!-- Reviewable:end -->
