### PR TITLE
Build and push binaries with race-detection enabled.

### DIFF
--- a/build/build-race-binaries.sh
+++ b/build/build-race-binaries.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Build cockroach binary with race detection enabled.
+
+set -euo pipefail
+
+source $(dirname $0)/build-common.sh
+
+# This is mildly tricky: This script runs itself recursively. The
+# first time it is run it does not take the if-branch below and
+# executes on the host computer. It uses the builder.sh script to run
+# itself inside of docker passing "docker" as the argument causing the
+# commands in the if-branch to be executed within the docker
+# container.
+if [ "${1-}" = "docker" ]; then
+    time make STATIC=1 build GOFLAGS="-race"
+    check_static cockroach
+    strip -S cockroach
+    exit 0
+fi
+
+# Build the cockroach and test binaries.
+$(dirname $0)/builder.sh $0 docker

--- a/circle.yml
+++ b/circle.yml
@@ -70,3 +70,9 @@ deployment:
 
       - build/build-osx.sh
       - build/push-tagged-aws.sh
+  datarace:
+    branch: data-race
+    commands:
+      - aws configure set region us-east-1
+      - build/build-race-binaries.sh
+      - build/push-one-binary.sh "${CIRCLE_SHA1-$(git rev-parse HEAD)}" cockroach cockroach.race


### PR DESCRIPTION
We really don't need to build those every time, so I'm using the branch
'data-race' as the trigger.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6228)

<!-- Reviewable:end -->
