### PR TITLE
Avoid advertising environment variables that are actually not used.

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -474,15 +474,15 @@ func initFlags(ctx *Context) {
 	// Debug commands.
 	{
 		f := debugKeysCmd.Flags()
-		f.StringVar(&cliContext.debug.startKey, cliflags.FromName, "", usageEnv(cliflags.FromName))
-		f.StringVar(&cliContext.debug.endKey, cliflags.ToName, "", usageEnv(cliflags.ToName))
-		f.BoolVar(&cliContext.debug.raw, cliflags.RawName, false, usageEnv(cliflags.RawName))
-		f.BoolVar(&cliContext.debug.values, cliflags.ValuesName, false, usageEnv(cliflags.ValuesName))
+		f.StringVar(&cliContext.debug.startKey, cliflags.FromName, "", usageNoEnv(cliflags.FromName))
+		f.StringVar(&cliContext.debug.endKey, cliflags.ToName, "", usageNoEnv(cliflags.ToName))
+		f.BoolVar(&cliContext.debug.raw, cliflags.RawName, false, usageNoEnv(cliflags.RawName))
+		f.BoolVar(&cliContext.debug.values, cliflags.ValuesName, false, usageNoEnv(cliflags.ValuesName))
 	}
 
 	{
 		f := versionCmd.Flags()
-		f.BoolVar(&versionIncludesDeps, cliflags.DepsName, false, usageEnv(cliflags.DepsName))
+		f.BoolVar(&versionIncludesDeps, cliflags.DepsName, false, usageNoEnv(cliflags.DepsName))
 	}
 }
 


### PR DESCRIPTION
This addresses an oversight of
5657da4c044aabe49edfd10fa3cecdaae1d94a21: although the CLI commands
"debug keys" and "version" are not influenced by env. vars, the help
text stated they are. This patch removes the advertisement from the
help text.

Thanks to @jseldess for bringing up the issue.

Fixes #6185.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6234)

<!-- Reviewable:end -->
