### PR TITLE
util/cache: avoid panic when removing a list element twice

### DIFF
--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -129,10 +129,17 @@ func (l *entryList) remove(e *Entry) *Entry {
 	if e == &l.root {
 		panic("cannot remove root list node")
 	}
-	e.prev.next = e.next
-	e.next.prev = e.prev
-	e.next = nil // avoid memory leaks
-	e.prev = nil // avoid memory leaks
+	// TODO(peter): Revert this protection against removing a non-existent entry
+	// from the list when the cause of
+	// https://github.com/cockroachdb/cockroach/issues/6190 is determined. Should
+	// be replaced with an explicit panic instead of the implicit one of a
+	// nil-pointer dereference.
+	if e.next != nil {
+		e.prev.next = e.next
+		e.next.prev = e.prev
+		e.next = nil // avoid memory leaks
+		e.prev = nil // avoid memory leaks
+	}
 	return e
 }
 


### PR DESCRIPTION
This brings back the behavior that was present prior to #6140.

See #6190.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6235)

<!-- Reviewable:end -->
