### PR TITLE
Add optional jemalloc build

### DIFF
--- a/main_jemalloc.go
+++ b/main_jemalloc.go
@@ -1,0 +1,33 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+// +build jemalloc
+
+package main
+
+// #cgo darwin CPPFLAGS: -I../c-jemalloc/darwin_includes/internal/include
+// #cgo linux CPPFLAGS: -I../c-jemalloc/linux_includes/internal/include
+// #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
+// #cgo linux LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+//
+// #include <jemalloc/jemalloc.h>
+import "C"
+
+import _ "github.com/cockroachdb/c-jemalloc"
+
+func init() {
+	C.malloc_stats_print(nil, nil, nil)
+}


### PR DESCRIPTION
This just needs `make build TAGS=jemalloc`.

This goes hand in hand with
https://github.com/cockroachdb/c-rocksdb/pull/19 and the same for all
the `c-*` repos.

I still think I'm doing something wrong through, I can't get the numbers
to add up.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6239)

<!-- Reviewable:end -->
