### PR TITLE
sql: Avoid evaluating VALUES expressions during prepare.

### DIFF
--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -412,6 +412,9 @@ func TestPGPreparedQuery(t *testing.T) {
 			base.Params(1).Results(1),
 			base.Params(nil).Results(1),
 		},
+		"INSERT INTO d.T VALUES ($1::INT) RETURNING 1": {
+			base.Params(1).Results(1),
+		},
 		"INSERT INTO d.T VALUES ($1) RETURNING $1": {
 			base.Params(1).Results(1),
 			base.Params(3).Results(3),

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -456,7 +456,9 @@ type planNode interface {
 	SetLimitHint(numRows int64, soft bool)
 
 	// MarkDebug puts the node in a special debugging mode, which allows
-	// DebugValues to be used.
+	// DebugValues to be used. This should be called after Start() and
+	// before the first call to Next() since it may need to recurse into
+	// sub-nodes created by Start().
 	MarkDebug(mode explainMode)
 }
 

--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -69,6 +69,10 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 		return false, expr
 	}
 
+	if v.pErr = plan.Start(); v.pErr != nil {
+		return false, expr
+	}
+
 	if exists != nil {
 		// For EXISTS expressions, all we want to know is if there is at least one
 		// result.

--- a/sql/testdata/explain_plan
+++ b/sql/testdata/explain_plan
@@ -31,13 +31,13 @@ query ITT colnames
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
 ----
 Level  Type    Description
-0      values  3 columns, 2 rows
+0      values  3 columns
 
 query ITT colnames
 EXPLAIN VALUES (1)
 ----
 Level  Type    Description
-0      values  1 column, 1 row
+0      values  1 column
 
 query ITT colnames
 EXPLAIN SELECT * FROM t LIMIT 1 OFFSET 1

--- a/sql/testdata/subquery
+++ b/sql/testdata/subquery
@@ -258,7 +258,7 @@ EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS
 ----
 0 sort   +foo1
 1 sort   +moo2
-2 values 3 columns, 3 rows
+2 values 3 columns
 
 query II colnames
 SELECT a, b FROM (VALUES (1, 2, 3), (3, 4, 7), (5, 6, 10)) AS foo (a, b, c) WHERE a + b = c

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -52,7 +52,11 @@ func (*explainTraceNode) Ordering() orderingInfo  { return orderingInfo{} }
 
 func (n *explainTraceNode) PErr() *roachpb.Error { return nil }
 func (n *explainTraceNode) Start() *roachpb.Error {
-	return n.plan.Start()
+	if pErr := n.plan.Start(); pErr != nil {
+		return pErr
+	}
+	n.plan.MarkDebug(explainDebug)
+	return nil
 }
 func (n *explainTraceNode) Next() bool {
 	first := n.rows == nil

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -114,6 +114,10 @@ func TestValues(t *testing.T) {
 			t.Errorf("%d: error_expected=%t, but got error %v", i, tc.ok, pErr)
 		}
 		if plan != nil {
+			if pErr := plan.Start(); pErr != nil {
+				t.Errorf("%d: unexpected error in start: %v", i, pErr)
+				continue
+			}
 			var rows []parser.DTuple
 			for plan.Next() {
 				rows = append(rows, plan.Values())


### PR DESCRIPTION
Spotted by @nvanbenschoten: prior to this patch VALUES would evaluate
its expressions during prepare, and thus fail (with either a crash or
an obscure error) if the expression contains a placeholder as argument
to a function.

Fixes #6225.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6242)

<!-- Reviewable:end -->
