### PR TITLE
storage: write a tombstone for a delete of a nonexistent key

### DIFF
--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -765,7 +765,6 @@ func TestTxnDBLostUpdateAnomaly_Delete(t *testing.T) {
 	// I1(A) C1 D3(A) R2(A) D3(B) C3 W2(B-A) C2
 	// I1(A) C1 R2(A) D3(A) D3(B) C3 W2(B-A) C2
 	// I1(A) C1 R2(A) D3(A) D3(B) W2(B-A) C3 C2
-	t.Skip("TODO(tschottdorf): see #6124")
 
 	// When serializable, B can't exceed A.
 	txn1 := "I(A) C"
@@ -781,10 +780,11 @@ func TestTxnDBLostUpdateAnomaly_Delete(t *testing.T) {
 		},
 		pruneTo: regexp.MustCompile(`^I1\(A\) C1`),
 	}
-	// TODO(vivekmenezes): when fixed, should pass with bothIsolations as well.
-	// SNAPSHOT currently shows more anomalies (likely similar to #6240).
 	checkConcurrency("lost update (delete)", onlySerializable,
 		[]string{txn1, txn2, txn3}, verify, true, t)
+	// TODO(vivek): Enable this once these tests can run faster.
+	//checkConcurrency("lost update (delete)", onlySnapshot,
+	//	[]string{txn1, txn2, txn3}, verify, true, t)
 }
 
 func TestTxnDBLostUpdateAnomaly_DeleteRange(t *testing.T) {

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1117,13 +1117,10 @@ func mvccPutInternal(
 			}
 		}
 	} else {
+		// There is no existing value for this key. Even if the new value is
+		// nil write a deletion tombstone for the key.
 		if value, err = maybeGetValue(ok, timestamp); err != nil {
 			return err
-		}
-		// No existing metadata record. If this is a delete, do nothing;
-		// otherwise we can perform the write.
-		if value == nil {
-			return nil
 		}
 	}
 	{


### PR DESCRIPTION
This tombstone allows writes that come earlier to be pushed ahead of
the tombstone.
#6124

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6243)

<!-- Reviewable:end -->
