### PR TITLE
Add jemalloc circle-ci rule.

### DIFF
--- a/build/build-jemalloc-binaries.sh
+++ b/build/build-jemalloc-binaries.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Build cockroach binary using jemalloc as the allocator.
+
+set -euo pipefail
+
+source $(dirname $0)/build-common.sh
+
+# This is mildly tricky: This script runs itself recursively. The
+# first time it is run it does not take the if-branch below and
+# executes on the host computer. It uses the builder.sh script to run
+# itself inside of docker passing "docker" as the argument causing the
+# commands in the if-branch to be executed within the docker
+# container.
+if [ "${1-}" = "docker" ]; then
+    time make STATIC=1 build TAGS="jemalloc"
+    check_static cockroach
+    strip -S cockroach
+    exit 0
+fi
+
+# Build the cockroach and test binaries.
+$(dirname $0)/builder.sh $0 docker

--- a/build/build-jemalloc-binaries.sh
+++ b/build/build-jemalloc-binaries.sh
@@ -5,18 +5,6 @@ set -euo pipefail
 
 source $(dirname $0)/build-common.sh
 
-# This is mildly tricky: This script runs itself recursively. The
-# first time it is run it does not take the if-branch below and
-# executes on the host computer. It uses the builder.sh script to run
-# itself inside of docker passing "docker" as the argument causing the
-# commands in the if-branch to be executed within the docker
-# container.
-if [ "${1-}" = "docker" ]; then
-    time make STATIC=1 build TAGS="jemalloc"
-    check_static cockroach
-    strip -S cockroach
-    exit 0
-fi
-
-# Build the cockroach and test binaries.
-$(dirname $0)/builder.sh $0 docker
+time make STATIC=1 build TAGS="jemalloc"
+check_static cockroach
+strip -S cockroach

--- a/build/build-race-binaries.sh
+++ b/build/build-race-binaries.sh
@@ -5,18 +5,6 @@ set -euo pipefail
 
 source $(dirname $0)/build-common.sh
 
-# This is mildly tricky: This script runs itself recursively. The
-# first time it is run it does not take the if-branch below and
-# executes on the host computer. It uses the builder.sh script to run
-# itself inside of docker passing "docker" as the argument causing the
-# commands in the if-branch to be executed within the docker
-# container.
-if [ "${1-}" = "docker" ]; then
-    time make STATIC=1 build GOFLAGS="-race"
-    check_static cockroach
-    strip -S cockroach
-    exit 0
-fi
-
-# Build the cockroach and test binaries.
-$(dirname $0)/builder.sh $0 docker
+time make STATIC=1 build GOFLAGS="-race"
+check_static cockroach
+strip -S cockroach

--- a/build/build-static-binaries.sh
+++ b/build/build-static-binaries.sh
@@ -5,37 +5,25 @@ set -euo pipefail
 
 source $(dirname $0)/build-common.sh
 
-# This is mildly tricky: This script runs itself recursively. The
-# first time it is run it does not take the if-branch below and
-# executes on the host computer. It uses the builder.sh script to run
-# itself inside of docker passing "docker" as the argument causing the
-# commands in the if-branch to be executed within the docker
-# container.
-if [ "${1-}" = "docker" ]; then
-    test_build_dir=$(mktemp -d test-binaries.XXXX)
-    time make STATIC=1 build
-    # sql/sql.test is built standalone as well to simplify the nightly logictest runs.
-    time make STATIC=1 testbuild PKG=./sql
-    time make STATIC=1 testbuild PKG=./acceptance TAGS=acceptance
-    time make STATIC=1 testbuildall DIR=${test_build_dir}
+test_build_dir=$(mktemp -d test-binaries.XXXX)
+time make STATIC=1 build
+# sql/sql.test is built standalone as well to simplify the nightly logictest runs.
+time make STATIC=1 testbuild PKG=./sql
+time make STATIC=1 testbuild PKG=./acceptance TAGS=acceptance
+time make STATIC=1 testbuildall DIR=${test_build_dir}
 
-    # We don't check all test binaries, but one from each invocation.
-    check_static cockroach
-    check_static sql/sql.test
-    check_static acceptance/acceptance.test
-    check_static ${test_build_dir}/github.com/cockroachdb/cockroach/sql/sql.test
+# We don't check all test binaries, but one from each invocation.
+check_static cockroach
+check_static sql/sql.test
+check_static acceptance/acceptance.test
+check_static ${test_build_dir}/github.com/cockroachdb/cockroach/sql/sql.test
 
-    strip -S cockroach
-    strip -S sql/sql.test
-    strip -S acceptance/acceptance.test
+strip -S cockroach
+strip -S sql/sql.test
+strip -S acceptance/acceptance.test
 
-    rm -f static-tests.tar.gz
-    # Skip the project/repo part of the path inside the tarball.
-    # Even for stripped binaries, gzip results in 167MB (21s spent) vs 512MB (3s spent).
-    # It makes a big difference when fetching from outside AWS.
-    time tar cfz static-tests.tar.gz -C ${test_build_dir}/github.com/cockroachdb/ cockroach/
-    exit 0
-fi
-
-# Build the cockroach and test binaries.
-$(dirname $0)/builder.sh $0 docker
+rm -f static-tests.tar.gz
+# Skip the project/repo part of the path inside the tarball.
+# Even for stripped binaries, gzip results in 167MB (21s spent) vs 512MB (3s spent).
+# It makes a big difference when fetching from outside AWS.
+time tar cfz static-tests.tar.gz -C ${test_build_dir}/github.com/cockroachdb/ cockroach/

--- a/circle.yml
+++ b/circle.yml
@@ -42,7 +42,7 @@ deployment:
             build/push-docker-deploy.sh
           fi
       - aws configure set region us-east-1
-      - build/build-static-binaries.sh
+      - build/builder.sh build/build-static-binaries.sh
       - mkdir -p "${CIRCLE_ARTIFACTS}/acceptance_deploy"
       - time acceptance/acceptance.test -test.v -test.timeout 10m
           -i cockroachdb/cockroach -nodes 3
@@ -61,7 +61,7 @@ deployment:
             build/push-docker-deploy.sh
           fi
       - aws configure set region us-east-1
-      - build/build-static-binaries.sh
+      - build/builder.sh build/build-static-binaries.sh
       - mkdir -p "${CIRCLE_ARTIFACTS}/acceptance_deploy"
       - time acceptance/acceptance.test -test.v -test.timeout 10m
           -i cockroachdb/cockroach -nodes 3
@@ -74,11 +74,11 @@ deployment:
     branch: data-race
     commands:
       - aws configure set region us-east-1
-      - build/build-race-binaries.sh
+      - build/builder.sh build/build-race-binaries.sh
       - build/push-one-binary.sh "${CIRCLE_SHA1-$(git rev-parse HEAD)}" cockroach cockroach.race
   jemalloc:
     branch: jemalloc
     commands:
       - aws configure set region us-east-1
-      - build/build-jemalloc-binaries.sh
+      - build/builder.sh build/build-jemalloc-binaries.sh
       - build/push-one-binary.sh "${CIRCLE_SHA1-$(git rev-parse HEAD)}" cockroach cockroach.jemalloc

--- a/circle.yml
+++ b/circle.yml
@@ -76,3 +76,9 @@ deployment:
       - aws configure set region us-east-1
       - build/build-race-binaries.sh
       - build/push-one-binary.sh "${CIRCLE_SHA1-$(git rev-parse HEAD)}" cockroach cockroach.race
+  jemalloc:
+    branch: jemalloc
+    commands:
+      - aws configure set region us-east-1
+      - build/build-jemalloc-binaries.sh
+      - build/push-one-binary.sh "${CIRCLE_SHA1-$(git rev-parse HEAD)}" cockroach cockroach.jemalloc


### PR DESCRIPTION
This adds a new `jemalloc` deployment rule in circle-ci, triggered by
pushes to the `jemalloc` branch. It adds the `jemalloc` build tag, which
switches the allocator to jemalloc.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6247)

<!-- Reviewable:end -->
