### PR TITLE
storage: Generate raft snapshots asynchronously

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -230,6 +230,12 @@ type Replica struct {
 		proposeRaftCommandFn func(*pendingCmd) error
 		// Computed checksum at a snapshot UUID.
 		checksums map[uuid.UUID]replicaChecksum
+
+		// Set to an open channel while a snapshot is being generated.
+		// When no snapshot is in progress, this field may either be nil
+		// or a closed channel. If an error occurs during generation,
+		// this channel may be closed without producing a result.
+		snapshotChan chan raftpb.Snapshot
 	}
 }
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -5139,3 +5139,93 @@ func TestDiffRange(t *testing.T) {
 		}
 	}
 }
+
+func TestAsyncSnapshot(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tsc := TestStoreContext()
+	tsc.BlockingSnapshotDuration = 0
+	tc := testContext{}
+	tc.StartWithStoreContext(t, tsc)
+	defer tc.Stop()
+
+	// Lock the replica manually instead of going through GetSnapshot()
+	// because we want to test the underlying async functionality.
+	tc.rng.mu.Lock()
+	_, err := tc.rng.Snapshot()
+	tc.rng.mu.Unlock()
+
+	// In async operation, the first call never succeeds.
+	if err != raft.ErrSnapshotTemporarilyUnavailable {
+		t.Fatalf("expected ErrSnapshotTemporarilyUnavailable, got %s", err)
+	}
+
+	// It will eventually succeed.
+	util.SucceedsSoon(t, func() error {
+		tc.rng.mu.Lock()
+		snap, err := tc.rng.Snapshot()
+		tc.rng.mu.Unlock()
+		if err != nil {
+			return err
+		}
+		if len(snap.Data) == 0 {
+			return util.Errorf("snapshot is empty")
+		}
+		return nil
+	})
+}
+
+func TestAsyncSnapshotMaxAge(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tsc := TestStoreContext()
+	tsc.BlockingSnapshotDuration = 0
+	tsc.AsyncSnapshotMaxAge = time.Millisecond
+	tc := testContext{}
+	tc.StartWithStoreContext(t, tsc)
+	defer tc.Stop()
+
+	// Lock the replica manually instead of going through GetSnapshot()
+	// because we want to test the underlying async functionality.
+	tc.rng.mu.Lock()
+	_, err := tc.rng.Snapshot()
+	tc.rng.mu.Unlock()
+
+	// In async operation, the first call never succeeds.
+	if err != raft.ErrSnapshotTemporarilyUnavailable {
+		t.Fatalf("expected ErrSnapshotTemporarilyUnavailable, got %s", err)
+	}
+
+	// Wait for the snapshot to be generated and abandoned.
+	time.Sleep(100 * time.Millisecond)
+	tc.rng.mu.Lock()
+	defer tc.rng.mu.Unlock()
+	// The channel was closed without producing a result.
+	snap, ok := <-tc.rng.mu.snapshotChan
+	if ok {
+		t.Fatalf("expected channel to be closed but got result: %v", snap)
+	}
+}
+
+func TestSyncSnapshot(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tsc := TestStoreContext()
+	tsc.BlockingSnapshotDuration = time.Second
+	tc := testContext{}
+	tc.StartWithStoreContext(t, tsc)
+	defer tc.Stop()
+
+	// With enough time in BlockingSnapshotDuration, we succeed on the
+	// first try.
+	tc.rng.mu.Lock()
+	snap, err := tc.rng.Snapshot()
+	tc.rng.mu.Unlock()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snap.Data) == 0 {
+		t.Fatal("snapshot is empty")
+	}
+}

--- a/storage/store.go
+++ b/storage/store.go
@@ -55,6 +55,7 @@ const (
 	defaultRaftTickInterval         = 100 * time.Millisecond
 	defaultHeartbeatIntervalTicks   = 3
 	defaultRaftElectionTimeoutTicks = 15
+	defaultAsyncSnapshotMaxAge      = time.Minute
 	// ttlStoreGossip is time-to-live for store-related info.
 	ttlStoreGossip = 2 * time.Minute
 
@@ -95,6 +96,7 @@ func TestStoreContext() StoreContext {
 		ScanInterval:                   10 * time.Minute,
 		ConsistencyCheckInterval:       10 * time.Minute,
 		ConsistencyCheckPanicOnFailure: true,
+		BlockingSnapshotDuration:       100 * time.Millisecond,
 	}
 }
 
@@ -374,6 +376,18 @@ type StoreContext struct {
 	// the range event log.
 	LogRangeEvents bool
 
+	// BlockingSnapshotDuration is the amount of time Replica.Snapshot
+	// will wait before switching to asynchronous mode. Zero is a good
+	// choice for production but non-zero values can speed up tests.
+	// (This only blocks on the first attempt; it will not block a
+	// second time if the generation is still in progress).
+	BlockingSnapshotDuration time.Duration
+
+	// AsyncSnapshotMaxAge is the maximum amount of time that an
+	// asynchronous snapshot will be held while waiting for raft to pick
+	// it up (counted from when the snapshot generation is completed).
+	AsyncSnapshotMaxAge time.Duration
+
 	TestingKnobs StoreTestingKnobs
 }
 
@@ -582,6 +596,9 @@ func (sc *StoreContext) setDefaults() {
 	}
 	if sc.RaftElectionTimeoutTicks == 0 {
 		sc.RaftElectionTimeoutTicks = defaultRaftElectionTimeoutTicks
+	}
+	if sc.AsyncSnapshotMaxAge == 0 {
+		sc.AsyncSnapshotMaxAge = defaultAsyncSnapshotMaxAge
 	}
 }
 


### PR DESCRIPTION
Blocking the processRaft goroutine for too long is problematic. In
extreme cases it can cause heartbeats to be missed and new elections to
start (a major cause of #5970). This commit moves the work of snapshot
generation to an asynchronous goroutine.

Fixes #6204.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6253)

<!-- Reviewable:end -->
