### PR TITLE
server: implement the systemd notification protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ check:
 	@echo "checking for time.Now and time.Since calls (use timeutil instead)"
 	@! git grep -nE 'time\.(Now|Since)' -- '*.go' | grep -vE '^util/(log|timeutil)/\w+\.go\b'
 	@echo "checking for os.Getenv calls (use envutil.EnvOrDefault*() instead)"
-	@! git grep -nF 'os.Getenv' -- '*.go' | grep -vE '^((util/(log|envutil))|acceptance(/.*)?)/\w+\.go\b'
+	@! git grep -nF 'os.Getenv' -- '*.go' | grep -vE '^((util/(log|envutil|sdnotify))|acceptance(/.*)?)/\w+\.go\b'
 	@echo "checking for proto.Clone calls (use protoutil.Clone instead)"
 	@! git grep -nE '\.Clone\([^)]+\)' -- '*.go' | grep -vF 'protoutil.Clone' | grep -vE '^util/protoutil/clone(_test)?\.go\b'
 	@echo "checking for proto.Marshal calls (use protoutil.Marshal instead)"

--- a/cli/cliflags/names.go
+++ b/cli/cliflags/names.go
@@ -19,6 +19,7 @@ package cliflags
 // AttrsName and others are flag names.
 const (
 	AttrsName      = "attrs"
+	BackgroundName = "background"
 	CacheName      = "cache"
 	DatabaseName   = "database"
 	DepsName       = "deps"

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -39,6 +39,7 @@ var maxResults int64
 
 var connURL string
 var connUser, connHost, connPort, httpPort, connDBName string
+var startBackground bool
 
 // cliContext is the CLI Context used for the command-line client.
 var cliContext = NewContext()
@@ -59,6 +60,12 @@ nodes. For example:`) + `
 
   --attrs=us-west-1b:gpu
 `,
+
+	cliflags.BackgroundName: wrapText(`
+Start the server in the background. This is similar to appending "&"
+to the command line, but when the server is started with --background,
+control is not returned to the shell until the server is ready to
+accept requests.`),
 
 	cliflags.CacheName: wrapText(`
 Total size in bytes for caches, shared evenly if there are multiple
@@ -356,6 +363,7 @@ func initFlags(ctx *Context) {
 		f.StringVar(&httpPort, cliflags.HTTPPortName, base.DefaultHTTPPort, usageNoEnv(forServer(cliflags.HTTPPortName)))
 		f.StringVar(&ctx.Attrs, cliflags.AttrsName, ctx.Attrs, usageNoEnv(cliflags.AttrsName))
 		f.VarP(&ctx.Stores, cliflags.StoreName, "s", usageNoEnv(cliflags.StoreName))
+		f.BoolVar(&startBackground, cliflags.BackgroundName, false, usageNoEnv(cliflags.BackgroundName))
 
 		// Usage for the unix socket is odd as we use a real file, whereas
 		// postgresql and clients consider it a directory and build a filename

--- a/cli/start.go
+++ b/cli/start.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"syscall"
@@ -36,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/sdnotify"
 	"github.com/cockroachdb/cockroach/util/stop"
 
 	"github.com/spf13/cobra"
@@ -131,6 +133,10 @@ func initInsecure() error {
 // of other active nodes used to join this node to the cockroach
 // cluster, if this is its first time connecting.
 func runStart(_ *cobra.Command, _ []string) error {
+	if startBackground {
+		return rerunBackground()
+	}
+
 	if err := initInsecure(); err != nil {
 		return err
 	}
@@ -256,6 +262,19 @@ func runStart(_ *cobra.Command, _ []string) error {
 	}
 	log.Flush()
 	return nil
+}
+
+// rerunBackground restarts the current process in the background.
+func rerunBackground() error {
+	args := append([]string(nil), os.Args...)
+	// TODO(bdarnell): this looks silly in ps. Try to remove the
+	// `--background` flag instead of adding a second flag to reverse
+	// it.
+	args = append(args, "--background=false")
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return sdnotify.Exec(cmd)
 }
 
 // exterminateCmd command shuts down the node server and

--- a/util/sdnotify/sdnotify.go
+++ b/util/sdnotify/sdnotify.go
@@ -1,0 +1,155 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+// Package sdnotify implements both sides of the systemd readiness
+// protocol. Servers can use sdnotify.Ready() to signal that they are
+// ready to receive traffic, and process managers can use
+// sdnotify.Exec() to run processes that implement this protocol.
+package sdnotify
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	envName  = "NOTIFY_SOCKET"
+	readyMsg = "READY=1"
+	netType  = "unixgram"
+)
+
+// Ready sends a readiness signal using the systemd notification
+// protocol. It should be called (once) by a server after it has
+// completed its initialization (including but not necessarily limited
+// to binding ports) and is ready to receive traffic.
+func Ready() error {
+	return notifyEnv(readyMsg)
+}
+
+func notifyEnv(msg string) error {
+	path := os.Getenv(envName)
+	if path == "" {
+		return nil
+	}
+	return notify(path, msg)
+}
+
+func notify(path, msg string) error {
+	addr := net.UnixAddr{
+		Net:  netType,
+		Name: path,
+	}
+	conn, err := net.DialUnix(netType, nil, &addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(msg))
+	return err
+}
+
+// Exec the given command in the background using the systemd
+// notification protocol. This function returns once the command has
+// either exited or signaled that it is ready. If the command exits
+// with a non-zero status before signaling readiness, returns an
+// exec.ExitError.
+func Exec(cmd *exec.Cmd) error {
+	l, err := listen()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = l.close() }()
+
+	if cmd.Env == nil {
+		// Default the environment to the parent process's, minus any
+		// existing versions of our variable.
+		varPrefix := fmt.Sprintf("%s=", envName)
+		for _, v := range os.Environ() {
+			if !strings.HasPrefix(v, varPrefix) {
+				cmd.Env = append(cmd.Env, v)
+			}
+		}
+	}
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", envName, l.Path))
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// This can leak goroutines, but we don't really care because we
+	// always exit after calling this function.
+	ch := make(chan error, 2)
+	go func() {
+		ch <- l.wait()
+	}()
+	go func() {
+		ch <- cmd.Wait()
+	}()
+	return <-ch
+}
+
+type listener struct {
+	Path string
+
+	tempDir string
+	conn    *net.UnixConn
+}
+
+func listen() (listener, error) {
+	dir, err := ioutil.TempDir("", "sdnotify")
+	if err != nil {
+		return listener{}, err
+	}
+
+	path := filepath.Join(dir, "notify.sock")
+	conn, err := net.ListenUnixgram(netType, &net.UnixAddr{
+		Net:  netType,
+		Name: path,
+	})
+	if err != nil {
+		return listener{}, err
+	}
+	l := listener{
+		Path:    path,
+		tempDir: dir,
+		conn:    conn}
+	return l, nil
+}
+
+func (l listener) wait() error {
+	buf := make([]byte, len(readyMsg))
+	for {
+		n, err := l.conn.Read(buf)
+		if err != nil {
+			return err
+		}
+		if string(buf[:n]) == readyMsg {
+			return nil
+		}
+	}
+}
+
+func (l listener) close() error {
+	l.conn.Close()
+	return os.RemoveAll(l.tempDir)
+}

--- a/util/sdnotify/sdnotify_test.go
+++ b/util/sdnotify/sdnotify_test.go
@@ -1,0 +1,44 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+package sdnotify
+
+import (
+	"testing"
+
+	_ "github.com/cockroachdb/cockroach/util/log" // for flags
+)
+
+func TestSDNotify(t *testing.T) {
+	l, err := listen()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = l.close() }()
+
+	ch := make(chan error)
+	go func() {
+		ch <- l.wait()
+	}()
+
+	if err := notify(l.Path, readyMsg); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-ch; err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Add `--background` flag to `cockroach start` that uses the readiness
protocol to decide when the parent process exits (this is a more
complicated version of the traditional daemonization protocol because Go
doesn't expose the necessary system calls). This can reduce the need to
sleep during test scripts, although until we make `quit` synchronous
we can't eliminate sleeps from reference_test.go.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6268)

<!-- Reviewable:end -->
