### PR TITLE
all: Demote noisy log.V(1) lines to V(2)

### DIFF
--- a/gossip/server.go
+++ b/gossip/server.go
@@ -257,7 +257,7 @@ func (s *server) InfosReceived() int {
 // to start a new client connection.
 func (s *server) maybeTighten() {
 	distantNodeID, distantHops := s.is.mostDistant()
-	if log.V(1) {
+	if log.V(2) {
 		log.Infof("@%d: distantHops: %d from %d", s.is.NodeID, distantHops, distantNodeID)
 	}
 	if distantHops > MaxHops {

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -290,9 +290,9 @@ func (rdc *rangeDescriptorCache) LookupRangeDescriptor(
 		return desc, returnToken, nil
 	}
 
-	if log.V(2) {
+	if log.V(3) {
 		log.Infof("lookup range descriptor: key=%s\n%s", key, rdc.stringLocked())
-	} else if log.V(1) {
+	} else if log.V(2) {
 		log.Infof("lookup range descriptor: key=%s", key)
 	}
 
@@ -456,9 +456,9 @@ func (rdc *rangeDescriptorCache) evictCachedRangeDescriptorLocked(descKey roachp
 	}
 
 	for {
-		if log.V(2) {
+		if log.V(3) {
 			log.Infof("evict cached descriptor: key=%s desc=%s\n%s", descKey, cachedDesc, rdc.stringLocked())
-		} else if log.V(1) {
+		} else if log.V(2) {
 			log.Infof("evict cached descriptor: key=%s desc=%s", descKey, cachedDesc)
 		}
 		rdc.rangeCache.cache.Del(rngKey)
@@ -567,7 +567,7 @@ func (rdc *rangeDescriptorCache) insertRangeDescriptorsLocked(rs ...roachpb.Rang
 		if err != nil {
 			return err
 		}
-		if log.V(1) {
+		if log.V(2) {
 			log.Infof("adding descriptor: key=%s desc=%s", rangeKey, &rs[i])
 		}
 		rdc.rangeCache.cache.Add(rangeCacheKey(rangeKey), &rs[i])
@@ -591,7 +591,7 @@ func (rdc *rangeDescriptorCache) clearOverlappingCachedRangeDescriptors(desc *ro
 	if ok {
 		descriptor := v.(*roachpb.RangeDescriptor)
 		if descriptor.StartKey.Less(key) && !descriptor.EndKey.Less(key) {
-			if log.V(1) {
+			if log.V(2) {
 				log.Infof("clearing overlapping descriptor: key=%s desc=%s", k, descriptor)
 			}
 			rdc.rangeCache.cache.Del(k.(rangeCacheKey))
@@ -612,7 +612,7 @@ func (rdc *rangeDescriptorCache) clearOverlappingCachedRangeDescriptors(desc *ro
 	// when there's a lot of concurrency). Iterate from the range meta key
 	// after RangeMetaKey(desc.StartKey) to the range meta key for desc.EndKey.
 	rdc.rangeCache.cache.DoRange(func(k, v interface{}) {
-		if log.V(1) {
+		if log.V(2) {
 			log.Infof("clearing subsumed descriptor: key=%s desc=%s", k, v.(*roachpb.RangeDescriptor))
 		}
 		rdc.rangeCache.cache.Del(k.(rangeCacheKey))

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -100,7 +100,7 @@ func (c *cmd) execute(txn *client.Txn, t *testing.T) (string, *roachpb.Error) {
 	if c.prev != nil {
 		<-c.prev
 	}
-	if log.V(1) {
+	if log.V(2) {
 		log.Infof("executing %s", c)
 	}
 	pErr := c.fn(c, txn, t)
@@ -547,7 +547,7 @@ func (hv *historyVerifier) runHistory(historyIdx int, priorities []int32,
 	isolations []roachpb.IsolationType, cmds []*cmd, db *client.DB, t *testing.T) error {
 	plannedStr := historyString(cmds)
 	if p := hv.verify.pruneTo; p != nil && !p.MatchString(plannedStr) {
-		if log.V(1) {
+		if log.V(2) {
 			log.Infof("skipping iso=%v pri=%v history=%s", isolations, priorities, plannedStr)
 		}
 		return nil
@@ -640,7 +640,7 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 				c.done()
 			}
 		}
-		if log.V(1) {
+		if log.V(2) {
 			log.Infof("%s, retry=%d", txnName, retry)
 		}
 		for i := range cmds {

--- a/server/node.go
+++ b/server/node.go
@@ -624,7 +624,7 @@ func (n *Node) writeSummaries() error {
 				err = pErr.GoError()
 				return
 			}
-			if log.V(1) {
+			if log.V(2) {
 				statusJSON, err := json.Marshal(nodeStatus)
 				if err != nil {
 					log.Errorf("error marshaling nodeStatus to json: %s", err)

--- a/storage/raft.go
+++ b/storage/raft.go
@@ -59,25 +59,25 @@ func (r *raftLogger) logPrefix() string {
 }
 
 func (r *raftLogger) Debug(v ...interface{}) {
-	if log.V(2) {
+	if log.V(3) {
 		log.InfofDepth(1, r.logPrefix(), v...)
 	}
 }
 
 func (r *raftLogger) Debugf(format string, v ...interface{}) {
-	if log.V(2) {
+	if log.V(3) {
 		log.InfofDepth(1, r.logPrefix()+format, v...)
 	}
 }
 
 func (r *raftLogger) Info(v ...interface{}) {
-	if log.V(1) {
+	if log.V(2) {
 		log.InfofDepth(1, r.logPrefix(), v...)
 	}
 }
 
 func (r *raftLogger) Infof(format string, v ...interface{}) {
-	if log.V(1) {
+	if log.V(2) {
 		log.InfofDepth(1, r.logPrefix()+format, v...)
 	}
 }

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -2030,7 +2030,7 @@ func (r *Replica) maybeGossipSystemConfig() {
 		return
 	}
 
-	if log.V(1) {
+	if log.V(2) {
 		log.Infoc(ctx, "gossiping system config from store %d, range %d, hash %x",
 			r.store.StoreID(), r.RangeID, hash)
 	}

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -588,7 +588,7 @@ func (r *Replica) resolveLocalIntents(ctx context.Context, batch engine.Engine, 
 func updateTxnWithExternalIntents(ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, args roachpb.EndTransactionRequest, txn *roachpb.Transaction, externalIntents []roachpb.Intent) error {
 	key := keys.TransactionKey(txn.Key, txn.ID)
 	if txnAutoGC && len(externalIntents) == 0 {
-		if log.V(1) {
+		if log.V(2) {
 			log.Infof("auto-gc'ed %s (%d intents)", txn.ID.Short(), len(args.IntentSpans))
 		}
 		return engine.MVCCDelete(ctx, batch, ms, key, roachpb.ZeroTimestamp, nil /* txn */)


### PR DESCRIPTION
These changes reduce the size of our test logs (in the configuration
used on circleci) from 12MB to 5.5MB.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6269)

<!-- Reviewable:end -->
