### PR TITLE
util/metric: remove unused (*Histogram).Duration()

### DIFF
--- a/util/metric/metric.go
+++ b/util/metric/metric.go
@@ -130,15 +130,6 @@ func (h *Histogram) nextTick() time.Time {
 	return h.nextT
 }
 
-// Duration returns the duration that this histogram spans.
-func (h *Histogram) Duration() time.Duration {
-	return h.duration
-}
-
-// TODO(pmattis): Histogram.Duration is neither used or tested. Silence unused
-// warning.
-var _ = (*Histogram).Duration
-
 // MarshalJSON outputs to JSON.
 func (h *Histogram) MarshalJSON() ([]byte, error) {
 	return json.Marshal(h.Current().CumulativeDistribution())


### PR DESCRIPTION
This isn't needed, because the intended function is served by
`(*Histogram).Current()`.

Fixes #5601

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6281)

<!-- Reviewable:end -->
