### PR TITLE
Add UI Settings Reducer + mocha testing

### DIFF
--- a/ui/next/Makefile
+++ b/ui/next/Makefile
@@ -19,7 +19,7 @@
 SHELL         := /bin/bash
 
 # Update the path to prefer binstubs over globals
-PATH          := ../node_modules/.bin:$(PATH)
+PATH          := ./node_modules/.bin:$(PATH)
 
 NODE_MODULES  := node_modules
 JSPM_PACKAGES := jspm_packages
@@ -49,3 +49,9 @@ jspm.installed: npm.installed
 	rm -rf $(JSPM_PACKAGES)/
 	jspm install
 	touch $@
+
+.PHONY: test
+test: PATH := ../node_modules/.bin:$(PATH)
+test:
+# Execute in /app directory, so that ts-node can pick up tsconfig.json.
+	cd app && mocha **/*.spec.ts --require ts-node/register

--- a/ui/next/app/app.tsx
+++ b/ui/next/app/app.tsx
@@ -9,6 +9,7 @@ import { syncHistoryWithStore, routerReducer } from "react-router-redux";
 import thunk from "redux-thunk";
 
 import nodesReducer from "./redux/nodes";
+import uiReducer from "./redux/ui";
 
 import Layout from "./containers/layout";
 import { ClusterMain, ClusterTitle } from "./containers/cluster";
@@ -16,10 +17,16 @@ import { DatabasesMain, DatabasesTitle } from "./containers/databases";
 import { HelpUsMain, HelpUsTitle } from "./containers/helpus";
 import { NodesMain, NodesTitle } from "./containers/nodes";
 
+// TODO(mrtracy): Redux now provides official typings, and their Store
+// definition is generic. That would let us enforce that the store actually has
+// the shape of the AdminUIStore interface (defined in /interfaces/store.d.ts).
+// However, that typings file is currently incompatible with any available
+// typings for react-redux.
 const store = createStore(
   combineReducers({
     routing: routerReducer,
     nodes: nodesReducer,
+    ui: uiReducer,
   }),
   applyMiddleware(thunk)
 );

--- a/ui/next/app/containers/nodes.tsx
+++ b/ui/next/app/containers/nodes.tsx
@@ -5,8 +5,8 @@ import * as _ from "lodash";
 import { connect } from "react-redux";
 
 import { refreshNodes, NodeStatusState } from "../redux/nodes";
-import { NodeStatus } from "../interfaces/proto.d.ts";
-import { MetricConstants } from "../util/proto.ts";
+import { NodeStatus } from "../interfaces/proto";
+import { MetricConstants } from "../util/proto";
 
 /**
  * NodesMainProps are the properties which can be passed to the NodesMain

--- a/ui/next/app/interfaces/action.d.ts
+++ b/ui/next/app/interfaces/action.d.ts
@@ -1,9 +1,17 @@
 /// <reference path="../../typings/main.d.ts" />
 
+/**
+ * Action is the interface that should be implemented by all redux actions in
+ * this application.
+ */
 export interface Action {
   type: string;
 }
 
+/**
+ * PayloadAction implements the very common case of an action that includes a
+ * single data object as a payload.
+ */
 export interface PayloadAction<T> extends Action {
   payload: T;
 }

--- a/ui/next/app/interfaces/store.d.ts
+++ b/ui/next/app/interfaces/store.d.ts
@@ -1,0 +1,11 @@
+import { NodeStatusState } from "../redux/nodes";
+import { UISettingsDict } from "../redux/ui";
+
+export interface AdminUIStore {
+  // Nodes status query.
+  nodes: NodeStatusState;
+  // UI Settings.
+  ui: UISettingsDict;
+  // React-router-redux (we don't need access to this).
+  routing: any;
+}

--- a/ui/next/app/redux/nodes.ts
+++ b/ui/next/app/redux/nodes.ts
@@ -6,10 +6,11 @@
  * '/_status/nodes/' endpoint.
  */
 
+import * as _ from "lodash";
+import { Dispatch } from "redux";
+import assign = require("object-assign");
 import { Action, PayloadAction } from "../interfaces/action";
 import { NodeStatus, RollupStoreMetrics } from "../util/proto";
-import { Dispatch } from "redux";
-import assign from "object-assign";
 
 const REQUEST = "cockroachui/nodes/REQUEST";
 const RECEIVE = "cockroachui/nodes/RECEIVE";

--- a/ui/next/app/redux/ui.spec.ts
+++ b/ui/next/app/redux/ui.spec.ts
@@ -1,0 +1,61 @@
+/// <reference path="../../typings/main.d.ts" />
+
+import reducer, { UISetting, setUISetting, UISettingsDict } from "./ui";
+import { assert } from "chai";
+
+describe("ui reducer", () => {
+  describe("actions", () => {
+    it("should create the correct action to set a ui setting", () => {
+      const settingName = "test-setting";
+      const settingValue = { val: "arbitrary-value" };
+      const expectedSetting: UISetting = {
+        key: settingName,
+        value: settingValue,
+      };
+      assert.deepEqual(
+        setUISetting(settingName, settingValue).payload,
+        expectedSetting);
+    });
+  });
+
+  describe("reducer", () => {
+    it("should have the correct default value.", () => {
+      assert.deepEqual(
+        reducer(undefined, { type: "unknown" }),
+        new UISettingsDict()
+      );
+    });
+
+    describe("SET_UI_VALUE", () => {
+      it("should correctly set UI values by key.", () => {
+        const key = "test-setting";
+        const value = "test-value";
+        let expected: UISettingsDict = {
+          [key]: value,
+        };
+        let actual = reducer(undefined, setUISetting(key, value));
+        assert.deepEqual(actual, expected);
+
+        const key2 = "another-setting";
+        expected[key2] = value;
+        actual = reducer(actual, setUISetting(key2, value));
+        assert.deepEqual(actual, expected);
+      });
+
+      it("should correctly overwrite previous values.", () => {
+        const key = "test-setting";
+        const value = "test-value";
+        let expected: UISettingsDict = {
+          [key]: value,
+        };
+        let initial: UISettingsDict = {
+          [key]: "oldvalue",
+        };
+        assert.deepEqual(
+          reducer(initial, setUISetting(key, value)),
+          expected
+        );
+      });
+    });
+  });
+});

--- a/ui/next/app/redux/ui.ts
+++ b/ui/next/app/redux/ui.ts
@@ -1,0 +1,50 @@
+/// <reference path="../../typings/main.d.ts" />
+
+/**
+ * This module maintains various ephemeral UI settings. These settings should be
+ * maintained within a session, but not saved between sessions.
+ */
+
+import assign = require("object-assign");
+import { Action, PayloadAction } from "../interfaces/action";
+
+const SET_UI_VALUE = "cockroachui/ui/SET_UI_VALUE";
+
+export class UISetting {
+  key: string;
+  value: any;
+}
+
+export class UISettingsDict {
+  [key: string]: any;
+}
+
+export default function reducer(state: UISettingsDict, action: Action): UISettingsDict {
+  if (action === undefined) {
+    return;
+  }
+  if (state === undefined) {
+    state = {};
+  }
+
+  switch (action.type) {
+    case SET_UI_VALUE:
+      let { payload } = action as PayloadAction<UISetting>;
+      return assign({}, state, {[payload.key]: payload.value});
+    default:
+      return state;
+  }
+}
+
+/**
+ * Set an ephemeral UI setting.
+ */
+export function setUISetting(key: string, value: any): PayloadAction<UISetting> {
+  return {
+    type: SET_UI_VALUE,
+    payload: {
+      key: key,
+      value: value,
+    },
+  };
+}

--- a/ui/next/app/tsconfig.json
+++ b/ui/next/app/tsconfig.json
@@ -1,13 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES5",
-    "module": "system",
+    "module": "commonjs",
     "jsx": "react",
     "noImplicitAny": true,
-    "allowSyntheticDefaultImports": true,
     "noEmit": true
-  },
-  "files": [
-    "./app.tsx"
-  ]
+  }
 }

--- a/ui/next/config.js
+++ b/ui/next/config.js
@@ -297,6 +297,16 @@ System.config({
       "stream-browserify": "npm:stream-browserify@1.0.0",
       "string_decoder": "npm:string_decoder@0.10.31"
     },
+    "npm:readable-stream@1.1.14": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "core-util-is": "npm:core-util-is@1.0.2",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "inherits": "npm:inherits@2.0.1",
+      "isarray": "npm:isarray@0.0.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stream-browserify": "npm:stream-browserify@1.0.0",
+      "string_decoder": "npm:string_decoder@0.10.31"
+    },
     "npm:readable-stream@2.1.0": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "core-util-is": "npm:core-util-is@1.0.2",
@@ -332,7 +342,7 @@ System.config({
     "npm:stream-browserify@1.0.0": {
       "events": "github:jspm/nodelibs-events@0.1.1",
       "inherits": "npm:inherits@2.0.1",
-      "readable-stream": "npm:readable-stream@1.0.34"
+      "readable-stream": "npm:readable-stream@1.1.14"
     },
     "npm:string_decoder@0.10.31": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"

--- a/ui/next/package.json
+++ b/ui/next/package.json
@@ -1,7 +1,11 @@
 {
   "devDependencies": {
+    "chai": "^3.5.0",
     "jspm": "^0.16.33",
+    "mocha": "^2.4.5",
     "shonkwrap": "^1.3.0",
+    "ts-node": "^0.7.2",
+    "typescript": "^1.8.10",
     "typings": "^0.7.12"
   },
   "jspm": {

--- a/ui/next/typings.json
+++ b/ui/next/typings.json
@@ -1,12 +1,14 @@
 {
   "ambientDependencies": {
+    "chai": "registry:dt/chai#3.4.0+20160317120654",
     "es6-promise": "registry:dt/es6-promise#0.0.0+20160317120654",
-    "lodash": "registry:dt/lodash#3.10.0+20160330154726",
+    "fixed-data-table": "registry:dt/fixed-data-table#0.6.0+20160329212954",
+    "mocha": "registry:dt/mocha#2.2.5+20160317120654",
     "object-assign": "registry:dt/object-assign#4.0.1+20160316155526",
     "react": "registry:dt/react#0.14.0+20160319053454",
     "react-dom": "registry:dt/react-dom#0.14.0+20160316155526",
     "react-redux": "registry:dt/react-redux#4.4.0+20160406115600",
-    "react-router": "registry:dt/react-router#2.0.0+20160330124659",
+    "react-router": "registry:dt/react-router#2.0.0+20160423062133",
     "react-router-redux": "registry:dt/react-router-redux#4.0.0+20160316155526",
     "react-router/history": "registry:dt/react-router/history#2.0.0+20160316155526",
     "redux": "registry:dt/redux#3.3.1+20160326112656",


### PR DESCRIPTION
Add a "UI Settings" reducer, which can be used by pages to store simple,
ephemeral settings made to the UI. This is being created in advance of the Nodes
Table, which will use this reducer to store it's current sort settings.

Commit also creates `AdminUIStore` type, which represents the shape of our redux
store. Unfortunately, due to some incompatible typings (react-redux,
react-redux-router), we cannot currently use the official redux typings which
have a generic `createStore` method; a generic `createStore` would allow us to
enforce the shape. This shortcoming has been documented in a commment in
`app.tsx`.

Commit also introduces Mocha testing framework, in order to better test the UI
reducer. This can be run from the /next directory with `make next`.

In order to acheive compatibility with Mocha, the entire /app project is now
being compiled into commonjs modules instead of systemjs modules. This was due
to a complicated problem: you cannot compile typescript to systemjs modules
while using `import x = require("module")` to include a commonjs module with a
non-module export (i.e. module exports a function). Instead, you must use
typescript's `allowSyntheticDefaultImports` compiler option, and use the `import
x from "module"` syntax.

However, mocha runs in node, and thus all modules are required to compile to
commonjs; unfortunately, typescript's commonjs compiler does not work with the
`allowSyntheticDefaultImports` option, and instead single-function-exporting modules _must_
be imported using the `import = require()` syntax. Thus, the `import` statement
in typescript cannot be made compatible between commonjs and systemjs compilers,
if using a commonjs module which exports a single function.

Luckily, our systemjs loader and bundler still works if the typescript is
compiled to commonjs modules; therefore, we are now compiling typescript to
commonjs instead of systemjs. It does throw a warning in the transpile process,
"please consider compiling to systemjs", but we have a good reason for not doing
that.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6291)

<!-- Reviewable:end -->
