### PR TITLE
sql: Create constantFolderVisitor to fold ConstVals using exact arithmetic

### DIFF
--- a/sql/group.go
+++ b/sql/group.go
@@ -95,17 +95,16 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, *r
 			return nil, roachpb.NewError(err)
 		}
 
-		having, err = p.parser.NormalizeExpr(p.evalCtx, having)
-		if err != nil {
-			return nil, roachpb.NewError(err)
-		}
-
 		havingType, err := having.TypeCheck(p.evalCtx.Args)
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
 		if !(havingType.TypeEqual(parser.DummyBool) || havingType == parser.DNull) {
 			return nil, roachpb.NewUErrorf("argument of HAVING must be type %s, not type %s", parser.DummyBool.Type(), havingType.Type())
+		}
+
+		if having, err = p.parser.NormalizeExpr(p.evalCtx, having); err != nil {
+			return nil, roachpb.NewError(err)
 		}
 		n.Having.Expr = having
 	}

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -501,8 +501,7 @@ func makeDefaultExprs(
 		if err != nil {
 			return nil, err
 		}
-		expr, err = parse.NormalizeExpr(evalCtx, expr)
-		if err != nil {
+		if expr, err = parse.NormalizeExpr(evalCtx, expr); err != nil {
 			return nil, err
 		}
 		if parser.ContainsVars(expr) {

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -496,3 +496,92 @@ func ContainsVars(expr Expr) bool {
 	WalkExprConst(&v, expr)
 	return v.containsVars
 }
+
+type constantFolderVisitor struct{}
+
+func (constantFolderVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
+	return expr != nil, expr
+}
+
+var unaryOpToToken = map[UnaryOperator]token.Token{
+	UnaryPlus:  token.ADD,
+	UnaryMinus: token.SUB,
+}
+var unaryOpToTokenIntOnly = map[UnaryOperator]token.Token{
+	UnaryComplement: token.XOR,
+}
+var binaryOpToToken = map[BinaryOp]token.Token{
+	Plus:  token.ADD,
+	Minus: token.SUB,
+	Mult:  token.MUL,
+	Div:   token.QUO, // token.QUO_ASSIGN to force integer division.
+}
+var binaryOpToTokenIntOnly = map[BinaryOp]token.Token{
+	Mod:    token.REM,
+	Bitand: token.AND,
+	Bitor:  token.OR,
+	Bitxor: token.XOR,
+}
+var binaryShiftOpToToken = map[BinaryOp]token.Token{
+	LShift: token.SHL,
+	RShift: token.SHR,
+}
+var comparisonOpToToken = map[ComparisonOp]token.Token{
+	EQ: token.EQL,
+	NE: token.NEQ,
+	LT: token.LSS,
+	LE: token.LEQ,
+	GT: token.GTR,
+	GE: token.GEQ,
+}
+
+func (constantFolderVisitor) VisitPost(expr Expr) Expr {
+	switch t := expr.(type) {
+	case *UnaryExpr:
+		if cv, ok := t.Expr.(*ConstVal); ok {
+			if token, ok := unaryOpToToken[t.Operator]; ok {
+				return &ConstVal{Value: constant.UnaryOp(token, cv.Value, 0)}
+			}
+			if cv.Kind() == constant.Int {
+				if token, ok := unaryOpToTokenIntOnly[t.Operator]; ok {
+					return &ConstVal{Value: constant.UnaryOp(token, cv.Value, 0)}
+				}
+			}
+		}
+	case *BinaryExpr:
+		l, okL := t.Left.(*ConstVal)
+		r, okR := t.Right.(*ConstVal)
+		if okL && okR {
+			if token, ok := binaryOpToToken[t.Operator]; ok {
+				return &ConstVal{Value: constant.BinaryOp(l.Value, token, r.Value)}
+			}
+			if l.Kind() == constant.Int && r.Kind() == constant.Int {
+				if token, ok := binaryOpToTokenIntOnly[t.Operator]; ok {
+					return &ConstVal{Value: constant.BinaryOp(l.Value, token, r.Value)}
+				}
+				if rInt, err := r.asInt(); err == nil && rInt >= 0 {
+					if token, ok := binaryShiftOpToToken[t.Operator]; ok {
+						return &ConstVal{Value: constant.Shift(l.Value, token, uint(rInt))}
+					}
+				}
+			}
+		}
+	case *ComparisonExpr:
+		l, okL := t.Left.(*ConstVal)
+		r, okR := t.Right.(*ConstVal)
+		if okL && okR {
+			if token, ok := comparisonOpToToken[t.Operator]; ok {
+				return MakeDBool(DBool(constant.Compare(l.Value, token, r.Value)))
+			}
+		}
+	}
+	return expr
+}
+
+func foldNumericConstants(expr Expr) (Expr, error) {
+	// TODO(nvanbenschoten) Investigate normalizing associative operations to group
+	// constants together and permit further numeric constant folding.
+	v := constantFolderVisitor{}
+	expr, _ = WalkExpr(v, expr)
+	return expr, nil
+}

--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -22,6 +22,115 @@ import (
 	"github.com/cockroachdb/cockroach/testutils"
 )
 
+func TestFoldNumericConstants(t *testing.T) {
+	testData := []struct {
+		expr     string
+		expected string
+	}{
+		// Unary ops.
+		{`+1`, `1`},
+		{`+1.2`, `1.2`},
+		{`-1`, `-1`},
+		{`-1.2`, `-1.2`},
+		// Unary ops (int only).
+		{`~1`, `-2`},
+		{`~1.2`, `~ 1.2`},
+		// Binary ops.
+		{`1 + 1`, `2`},
+		{`1.2 + 2.3`, `3.5`},
+		{`1 + 2.3`, `3.3`},
+		{`2 - 1`, `1`},
+		{`1.2 - 2.3`, `-1.1`},
+		{`1 - 2.3`, `-1.3`},
+		{`2 * 1`, `2`},
+		{`1.2 * 2.3`, `2.76`},
+		{`1 * 2.3`, `2.3`},
+		{`123456789.987654321 * 987654321`, `1.21933e+17`},
+		{`9 / 4`, `2.25`},
+		{`9.7 / 4`, `2.425`},
+		{`4.72 / 2.36`, `2`},
+		// Binary ops (int only).
+		{`9 % 2`, `1`},
+		{`100 % 17`, `15`},
+		{`100.43 % 17.82`, `100.43 % 17.82`}, // Constant folding won't fold float modulo.
+		{`1 & 3`, `1`},
+		{`1.3 & 3.2`, `1.3 & 3.2`}, // Will be caught during type checking.
+		{`1 | 2`, `3`},
+		{`1.3 | 2.8`, `1.3 | 2.8`}, // Will be caught during type checking.
+		{`1 ^ 3`, `2`},
+		{`1.3 ^ 3.9`, `1.3 ^ 3.9`}, // Will be caught during type checking.
+		// Shift ops (int only).
+		{`1 << 2`, `4`},
+		{`1.2 << 2.4`, `1.2 << 2.4`}, // Will be caught during type checking.
+		{`4 >> 2`, `1`},
+		{`4.1 >> 2.9`, `4.1 >> 2.9`}, // Will be caught during type checking.
+		// Comparison ops.
+		{`4 = 2`, `false`},
+		{`4 = 4.0`, `true`},
+		{`4.0 = 4`, `true`},
+		{`4.9 = 4`, `false`},
+		{`4.9 = 4.9`, `true`},
+		{`4 != 2`, `true`},
+		{`4 != 4.0`, `false`},
+		{`4.0 != 4`, `false`},
+		{`4.9 != 4`, `true`},
+		{`4.9 != 4.9`, `false`},
+		{`4 < 2`, `false`},
+		{`4 < 4.0`, `false`},
+		{`4.0 < 4`, `false`},
+		{`4.9 < 4`, `false`},
+		{`4.9 < 4.9`, `false`},
+		{`4 <= 2`, `false`},
+		{`4 <= 4.0`, `true`},
+		{`4.0 <= 4`, `true`},
+		{`4.9 <= 4`, `false`},
+		{`4.9 <= 4.9`, `true`},
+		{`4 > 2`, `true`},
+		{`4 > 4.0`, `false`},
+		{`4.0 > 4`, `false`},
+		{`4.9 > 4`, `true`},
+		{`4.9 > 4.9`, `false`},
+		{`4 >= 2`, `true`},
+		{`4 >= 4.0`, `true`},
+		{`4.0 >= 4`, `true`},
+		{`4.9 >= 4`, `true`},
+		{`4.9 >= 4.9`, `true`},
+		// Folding with non-constants.
+		{`a + 5 * b`, `a + (5 * b)`},
+		{`a + 5 + b + 7`, `((a + 5) + b) + 7`},
+		{`a + 5 * 2`, `a + 10`},
+		{`a * b + 5 / 2`, `(a * b) + 2.5`},
+		{`a - b * 5 - 3`, `(a - (b * 5)) - 3`},
+		{`a - b + 5 * 3`, `(a - b) + 15`},
+	}
+	for _, d := range testData {
+		expr, err := ParseExprTraditional(d.expr)
+		if err != nil {
+			t.Fatalf("%s: %v", d.expr, err)
+		}
+		rOrig := expr.String()
+		r, err := foldNumericConstants(expr)
+		if err != nil {
+			t.Fatalf("%s: %v", d.expr, err)
+		}
+		if s := r.String(); d.expected != s {
+			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
+		}
+		// Folding again should be a no-op.
+		r2, err := foldNumericConstants(r)
+		if err != nil {
+			t.Fatalf("%s: %v", d.expr, err)
+		}
+		if s := r2.String(); d.expected != s {
+			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
+		}
+		// The original expression should be unchanged.
+		if rStr := expr.String(); rOrig != rStr {
+			t.Fatalf("Original expression `%s` changed to `%s`", rOrig, rStr)
+		}
+	}
+}
+
 func TestNormalizeExpr(t *testing.T) {
 	testData := []struct {
 		expr     string

--- a/sql/select.go
+++ b/sql/select.go
@@ -577,6 +577,7 @@ func (s *selectNode) addRender(target parser.SelectExpr) *roachpb.Error {
 	if resolved, s.pErr = s.planner.expandSubqueries(resolved, 1); s.pErr != nil {
 		return s.pErr
 	}
+
 	var typ parser.Datum
 	typ, err = resolved.TypeCheck(s.planner.evalCtx.Args)
 	s.pErr = roachpb.NewError(err)


### PR DESCRIPTION
Create an initial implementation of `constantFolderVisitor`, which will
walk an `Expr` tree and fold all `ConstVals` using exact arithmetic.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6298)

<!-- Reviewable:end -->
