### PR TITLE
storage: fix TestRebalanceInterval race

### DIFF
--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -160,15 +160,22 @@ var multiDCStores = []*roachpb.StoreDescriptor{
 	},
 }
 
-// createTestAllocator creates a stopper, gossip, store pool and allocator for
-// use in tests. Stopper must be stopped by the caller.
-func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator) {
+// createTestGossip creates a stopper, gossip, and clock for use in tests.
+// Stopper must be stopped by the caller.
+func createTestGossip() (*stop.Stopper, *gossip.Gossip, *hlc.Clock) {
 	stopper := stop.NewStopper()
 	clock := hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(nil, clock, stopper)
 	g := gossip.New(rpcContext, nil, stopper)
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
+	return stopper, g, clock
+}
+
+// createTestAllocator creates a stopper, gossip, store pool and allocator for
+// use in tests. Stopper must be stopped by the caller.
+func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator) {
+	stopper, g, clock := createTestGossip()
 	storePool := NewStorePool(g, clock, TestTimeUntilStoreDeadOff, stopper)
 	a := MakeAllocator(storePool, AllocatorOptions{AllowRebalance: true})
 	return stopper, g, storePool, a
@@ -1171,8 +1178,14 @@ func TestRebalanceInterval(t *testing.T) {
 			defaultMinRebalanceInterval, defaultMaxRebalanceInterval)
 	}
 
-	stopper, g, _, a := createTestAllocator()
+	stopper, g, clock := createTestGossip()
 	defer stopper.Stop()
+	storePoolStopper := stop.NewStopper()
+	storePool := NewStorePool(g, clock, TestTimeUntilStoreDeadOff, storePoolStopper)
+	a := MakeAllocator(storePool, AllocatorOptions{AllowRebalance: true})
+	// Stop the StorePool's goroutine, to prevent a race between its use of
+	// timeutil and ours.
+	storePoolStopper.Stop()
 
 	stores := []*roachpb.StoreDescriptor{
 		{


### PR DESCRIPTION
This test was calling `timeutil.SetOffset`, which was racing with calls
to `timeutil.Now` made from `StorePool`'s background goroutine. Now the
test stops the goroutine before making any calls to `timeutil`
functions.

Verified with 200k runs of test race. Was previously easily reproducible
after about 100k runs.

Fixes #6200

cc @tamird in case there's some simpler way to avoid `timeutil` races

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6301)

<!-- Reviewable:end -->
