### PR TITLE
sql: reenable TestRaceWithBackfill by reducing the size of backfill

### DIFF
--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -551,7 +551,6 @@ func runSchemaChangeWithOperations(
 // that run simultaneously.
 func TestRaceWithBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("TODO(vivekmenezes): see #6293")
 	server, sqlDB, kvDB := setup(t)
 	defer cleanup(server, sqlDB)
 
@@ -565,7 +564,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 
 	// Bulk insert.
 	// TODO(vivek): increase maxValue once #3274 is fixed.
-	maxValue := 400
+	maxValue := 100
 	insert := fmt.Sprintf(`INSERT INTO t.test VALUES (%d, %d)`, 0, maxValue)
 	for i := 1; i <= maxValue; i++ {
 		insert += fmt.Sprintf(` ,(%d, %d)`, i, maxValue-i)


### PR DESCRIPTION
We reduce the size of the backfill to allow the backfill transaction
to not time out. Eventually the backfill will be split into many
transactions allowing us to increase the total size of the backfill
later.

fixes #6293

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6310)

<!-- Reviewable:end -->
