### PR TITLE
sql: implement generic indexed variables for expressions

### DIFF
--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -422,8 +422,8 @@ func getQValColIdx(expr parser.Expr) (ok bool, colIdx int) {
 	case *qvalue:
 		return true, q.colRef.colIdx
 
-	case *scanQValue:
-		return true, q.colIdx
+	case *parser.IndexedVar:
+		return true, q.Idx
 	}
 	return false, -1
 }

--- a/sql/parser/indexed_vars.go
+++ b/sql/parser/indexed_vars.go
@@ -1,0 +1,97 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package parser
+
+import (
+	"fmt"
+)
+
+// IndexedVarContainer provides the implementation of TypeCheck, Eval, and
+// String for IndexedVars.
+type IndexedVarContainer interface {
+	IndexedVarTypeCheck(idx int, args MapArgs) (Datum, error)
+	IndexedVarEval(idx int, ctx EvalContext) (Datum, error)
+	IndexedVarString(idx int) string
+}
+
+// IndexedVar is a VariableExpr that can be used as a leaf in expressions; it
+// represents a dynamic value. It defers calls to TypeCheck, Eval, String to an
+// IndexedVarContainer.
+type IndexedVar struct {
+	Idx       int
+	container IndexedVarContainer
+}
+
+var _ VariableExpr = &IndexedVar{}
+
+// Variable is a dummy function part of the VariableExpr interface.
+func (*IndexedVar) Variable() {}
+
+// Walk is part of the Expr interface.
+func (v *IndexedVar) Walk(_ Visitor) Expr {
+	return v
+}
+
+// TypeCheck is part of the Expr interface.
+func (v *IndexedVar) TypeCheck(args MapArgs) (Datum, error) {
+	return v.container.IndexedVarTypeCheck(v.Idx, args)
+}
+
+// Eval is part of the Expr interface.
+func (v *IndexedVar) Eval(ctx EvalContext) (Datum, error) {
+	return v.container.IndexedVarEval(v.Idx, ctx)
+}
+
+func (v *IndexedVar) String() string {
+	return v.container.IndexedVarString(v.Idx)
+}
+
+// IndexedVarHelper is a structure that helps with initialization of IndexVars.
+type IndexedVarHelper struct {
+	vars      []IndexedVar
+	container IndexedVarContainer
+}
+
+// MakeIndexedVarHelper initializes an IndexedVarHelper structure.
+func MakeIndexedVarHelper(container IndexedVarContainer, numVars int) IndexedVarHelper {
+	return IndexedVarHelper{vars: make([]IndexedVar, numVars), container: container}
+}
+
+func (h *IndexedVarHelper) checkIndex(idx int) {
+	if idx < 0 || idx >= len(h.vars) {
+		panic(fmt.Sprintf("invalid var index %d (columns: %d)", idx, len(h.vars)))
+	}
+}
+
+// IndexedVar returns an IndexedVar for the given index. The index must be
+// valid.
+func (h *IndexedVarHelper) IndexedVar(idx int) *IndexedVar {
+	h.checkIndex(idx)
+	v := &h.vars[idx]
+	if v.container == nil {
+		v.Idx = idx
+		v.container = h.container
+	}
+	return v
+}
+
+// IndexedVarUsed returns true if IndexedVar() was called for the given index.
+// The index must be valid.
+func (h *IndexedVarHelper) IndexedVarUsed(idx int) bool {
+	h.checkIndex(idx)
+	return h.vars[idx].container != nil
+}

--- a/sql/parser/indexed_vars_test.go
+++ b/sql/parser/indexed_vars_test.go
@@ -1,0 +1,82 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package parser
+
+import (
+	"fmt"
+	"testing"
+)
+
+type testVarContainer []Datum
+
+func (d testVarContainer) IndexedVarTypeCheck(idx int, args MapArgs) (Datum, error) {
+	return d[idx].TypeCheck(args)
+}
+
+func (d testVarContainer) IndexedVarEval(idx int, ctx EvalContext) (Datum, error) {
+	return d[idx].Eval(ctx)
+}
+
+func (d testVarContainer) IndexedVarString(idx int) string {
+	return fmt.Sprintf("var%d", idx)
+}
+
+func TestIndexedVars(t *testing.T) {
+	c := make(testVarContainer, 4)
+	h := MakeIndexedVarHelper(c, 4)
+
+	// We use only the first three variables.
+	v0 := h.IndexedVar(0)
+	v1 := h.IndexedVar(1)
+	v2 := h.IndexedVar(2)
+
+	if !h.IndexedVarUsed(0) || !h.IndexedVarUsed(1) || !h.IndexedVarUsed(2) || h.IndexedVarUsed(3) {
+		t.Errorf("invalid IndexedVarUsed results %t %t %t %t (expected false false false true)",
+			h.IndexedVarUsed(0), h.IndexedVarUsed(1), h.IndexedVarUsed(2), h.IndexedVarUsed(3))
+	}
+
+	binary := func(op BinaryOp, left, right Expr) Expr {
+		return &BinaryExpr{Operator: op, Left: left, Right: right}
+	}
+	expr := binary(Plus, v0, binary(Mult, v1, v2))
+
+	str := expr.String()
+	expectedStr := "var0 + (var1 * var2)"
+	if str != expectedStr {
+		t.Errorf("invalid expression string '%s', expected '%s'", str, expectedStr)
+	}
+
+	// Set values for the variables and verify the expression evaluates
+	// correctly.
+	c[0] = NewDInt(3)
+	c[1] = NewDInt(5)
+	c[2] = NewDInt(6)
+	d, err := expr.TypeCheck(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.TypeEqual(DummyInt) {
+		t.Errorf("invalid expression type %s", d.Type())
+	}
+	d, err = expr.Eval(defaultContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Compare(NewDInt(3+5*6)) != 0 {
+		t.Errorf("invalid result %s (expected %d)", d, 3+5*6)
+	}
+}

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -61,10 +61,10 @@ type scanNode struct {
 	rowIndex  int // the index of the current row
 	debugVals debugValues
 
-	// filter that can be evaluated using only this table/index; it contains scanQValues.
-	filter parser.Expr
-	// qvalues (one per column) which can be part of the filter expression.
-	qvals []scanQValue
+	// filter that can be evaluated using only this table/index; it contains
+	// parser.IndexedVar leaves generated using filterVars.
+	filter     parser.Expr
+	filterVars parser.IndexedVarHelper
 
 	scanInitialized bool
 	fetcher         rowFetcher
@@ -308,10 +308,7 @@ func (n *scanNode) initDescDefaults() {
 		n.valNeededForCol[i] = true
 	}
 	n.row = make([]parser.Datum, len(cols))
-	n.qvals = make([]scanQValue, len(cols))
-	for i := range n.qvals {
-		n.qvals[i] = n.makeQValue(i)
-	}
+	n.filterVars = parser.MakeIndexedVarHelper(n, len(cols))
 }
 
 // initOrdering initializes the ordering info using the selected index. This
@@ -354,42 +351,17 @@ func (n *scanNode) computeOrdering(
 	return ordering
 }
 
-// scanQValue implements the parser.VariableExpr interface and is used as a replacement node for
-// QualifiedNames in expressions that can change their values for each row.
-//
-// It is analogous to qvalue but allows expressions to be evaluated in the context of a scanNode.
-type scanQValue struct {
-	scan   *scanNode
-	colIdx int
+// scanNode implements parser.IndexedVarContainer.
+var _ parser.IndexedVarContainer = &scanNode{}
+
+func (n *scanNode) IndexedVarTypeCheck(idx int, args parser.MapArgs) (parser.Datum, error) {
+	return n.resultColumns[idx].Typ.TypeCheck(args)
 }
 
-var _ parser.VariableExpr = &scanQValue{}
-
-func (*scanQValue) Variable() {}
-
-func (q *scanQValue) String() string {
-	return string(q.scan.resultColumns[q.colIdx].Name)
+func (n *scanNode) IndexedVarEval(idx int, ctx parser.EvalContext) (parser.Datum, error) {
+	return n.row[idx].Eval(ctx)
 }
 
-func (q *scanQValue) Walk(_ parser.Visitor) parser.Expr {
-	panic("not implemented")
-}
-
-func (q *scanQValue) TypeCheck(args parser.MapArgs) (parser.Datum, error) {
-	return q.scan.resultColumns[q.colIdx].Typ.TypeCheck(args)
-}
-
-func (q *scanQValue) Eval(ctx parser.EvalContext) (parser.Datum, error) {
-	return q.scan.row[q.colIdx].Eval(ctx)
-}
-
-func (n *scanNode) makeQValue(colIdx int) scanQValue {
-	if colIdx < 0 || colIdx >= len(n.row) {
-		panic(fmt.Sprintf("invalid colIdx %d (columns: %d)", colIdx, len(n.row)))
-	}
-	return scanQValue{n, colIdx}
-}
-
-func (n *scanNode) getQValue(colIdx int) *scanQValue {
-	return &n.qvals[colIdx]
+func (n *scanNode) IndexedVarString(idx int) string {
+	return string(n.resultColumns[idx].Name)
 }

--- a/sql/select.go
+++ b/sql/select.go
@@ -309,7 +309,7 @@ func (p *planner) initSelect(
 					// will be a valid case.
 					panic("scan qvalue refers to unknown table")
 				}
-				return true, scan.getQValue(qval.colRef.colIdx)
+				return true, scan.filterVars.IndexedVar(qval.colRef.colIdx)
 			}
 
 			scan.filter, s.filter = splitFilter(s.filter, convFunc)


### PR DESCRIPTION
Implementing generic support for expression variables that are addressed using
an index. This replaces the `scanQValues` and will also be used by the new
TableReader.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6316)

<!-- Reviewable:end -->
