### PR TITLE
storage/engine: optimize iteration over inline values

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1634,9 +1634,16 @@ func MVCCIterate(ctx context.Context,
 				}
 				break
 			}
-
 		} else {
-			iter.Seek(MakeMVCCMetadataKey(metaKey.Key.Next()))
+			if buf.meta.IsInline() {
+				// The current entry is an inline value. We can reach the next entry
+				// using Next().
+				iter.Next()
+			} else {
+				// The current entry is a versioned value. Seek to the next metadata
+				// key.
+				iter.Seek(MakeMVCCMetadataKey(metaKey.Key.Next()))
+			}
 			if !iter.Valid() {
 				if err := iter.Error(); err != nil {
 					return nil, err


### PR DESCRIPTION
When iterating over inline values, we can use iter.Next() to get to the
next entry as opposed to the more general, but slower, iter.Seek().

```
name                old time/op    new time/op    delta
ReplicaSnapshot-32     207ms ± 7%     151ms ± 2%  -26.80%  (p=0.000 n=20+18)

name                old alloc/op   new alloc/op   delta
ReplicaSnapshot-32     162MB ± 0%     162MB ± 0%   -0.01%  (p=0.022 n=20+18)

name                old allocs/op  new allocs/op  delta
ReplicaSnapshot-32      117k ± 0%      117k ± 0%   -0.06%  (p=0.000 n=20+20)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6320)

<!-- Reviewable:end -->
