### PR TITLE
storage: reduce allocations in snapshot()

### DIFF
--- a/storage/engine/allocator.go
+++ b/storage/engine/allocator.go
@@ -16,19 +16,19 @@
 
 package engine
 
-// chunkAllocator provides chunk allocation of []byte, amortizing the overhead
+// ChunkAllocator provides chunk allocation of []byte, amortizing the overhead
 // of each allocation. Because the underlying storage for the slices is shared,
 // they should share a similar lifetime in order to avoid pinning large amounts
 // of memory unnecessarily. The allocator itself is a []byte where cap()
 // indicates the total amount of memory and len() is the amount already
 // allocated. The size of the buffer to allocate from is grown exponentially
 // when it runs out of room up to a maximum size (chunkAllocMaxSize).
-type chunkAllocator []byte
+type ChunkAllocator []byte
 
 const chunkAllocMinSize = 512
 const chunkAllocMaxSize = 16384
 
-func (a chunkAllocator) reserve(n int) chunkAllocator {
+func (a ChunkAllocator) reserve(n int) ChunkAllocator {
 	allocSize := cap(a) * 2
 	if allocSize < chunkAllocMinSize {
 		allocSize = chunkAllocMinSize
@@ -44,7 +44,7 @@ func (a chunkAllocator) reserve(n int) chunkAllocator {
 // newChunk allocates a new chunk of memory, initializing it from src. extra
 // indicates additional zero bytes that will be present in the returned []byte,
 // but not part of the length.
-func (a chunkAllocator) newChunk(src []byte, extra int) (chunkAllocator, []byte) {
+func (a ChunkAllocator) newChunk(src []byte, extra int) (ChunkAllocator, []byte) {
 	n := len(src)
 	if cap(a)-len(a) < n+extra {
 		a = a.reserve(n + extra)
@@ -54,4 +54,14 @@ func (a chunkAllocator) newChunk(src []byte, extra int) (chunkAllocator, []byte)
 	a = a[:p+n+extra]
 	copy(r, src)
 	return a, r
+}
+
+// IterKeyValue returns iter.Key() and iter.Value() with the underlying storage
+// allocated from the receiver.
+func (a ChunkAllocator) IterKeyValue(iter Iterator) (ChunkAllocator, MVCCKey, []byte) {
+	key := iter.unsafeKey()
+	a, key.Key = a.newChunk(key.Key, 0)
+	value := iter.unsafeValue()
+	a, value = a.newChunk(value, 0)
+	return a, key, value
 }

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -62,6 +62,9 @@ type Iterator interface {
 	// unsafeKey returns the same value as Value, but the memory is invalidated
 	// on the next call to {Next,Prev,Seek,SeekReverse,Close}.
 	unsafeValue() []byte
+	// Less returns true if the key the iterator is currently positioned at is
+	// less than the specified key.
+	Less(key MVCCKey) bool
 	// Error returns the error, if any, which the iterator encountered.
 	Error() error
 	// ComputeStats scans the underlying engine from start to end keys and

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1571,7 +1571,7 @@ func MVCCIterate(ctx context.Context,
 	// Gathers up all the intents from WriteIntentErrors. We only get those if
 	// the scan is consistent.
 	var wiErr error
-	var alloc chunkAllocator
+	var alloc ChunkAllocator
 
 	for {
 		metaKey, err := getMeta(iter, encEndKey, &buf.meta)

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -720,6 +720,10 @@ func (r *rocksDBIterator) Error() error {
 	return statusToError(C.DBIterError(r.iter))
 }
 
+func (r *rocksDBIterator) Less(key MVCCKey) bool {
+	return r.unsafeKey().Less(key)
+}
+
 func (r *rocksDBIterator) setState(state C.DBIterState) {
 	r.valid = bool(state.valid)
 	r.key = state.key

--- a/storage/replica_data_iter.go
+++ b/storage/replica_data_iter.go
@@ -113,7 +113,7 @@ func (ri *replicaDataIterator) Next() {
 // invalid.
 func (ri *replicaDataIterator) advance() {
 	for {
-		if !ri.Valid() || ri.Key().Less(ri.ranges[ri.curIndex].end) {
+		if !ri.Valid() || ri.Less(ri.ranges[ri.curIndex].end) {
 			return
 		}
 		ri.curIndex++

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -461,12 +461,15 @@ func snapshot(
 	// the sequence cache.
 	iter := newReplicaDataIterator(&desc, snap, true /* !replicatedOnly */)
 	defer iter.Close()
+	var alloc engine.ChunkAllocator
 	for ; iter.Valid(); iter.Next() {
-		key := iter.Key()
+		var key engine.MVCCKey
+		var value []byte
+		alloc, key, value = alloc.IterKeyValue(iter.Iterator)
 		snapData.KV = append(snapData.KV,
 			roachpb.RaftSnapshotData_KeyValue{
 				Key:       key.Key,
-				Value:     iter.Value(),
+				Value:     value,
 				Timestamp: key.Timestamp,
 			})
 	}


### PR DESCRIPTION
```
name                old time/op    new time/op    delta
ReplicaSnapshot-32     151ms ± 3%     136ms ± 2%   -9.81%  (p=0.000 n=19+19)

name                old alloc/op   new alloc/op   delta
ReplicaSnapshot-32     162MB ± 0%     154MB ± 0%   -4.85%  (p=0.000 n=20+20)

name                old allocs/op  new allocs/op  delta
ReplicaSnapshot-32      117k ± 0%       32k ± 0%  -73.03%  (p=0.000 n=20+19)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6322)

<!-- Reviewable:end -->
