### PR TITLE
storage: Add info to a TransactionStatusError

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -351,7 +351,7 @@ func (r *Replica) BeginTransaction(
 			// command's txn and rewrite the record.
 			reply.Txn.Update(&txn)
 		} else {
-			return reply, roachpb.NewTransactionStatusError("non-aborted transaction exists already")
+			return reply, roachpb.NewTransactionStatusError(fmt.Sprintf("BeginTransaction can't overwrite %s", txn))
 		}
 	}
 


### PR DESCRIPTION
See #6275 (which is likely a rare issue). Since I wasn't able to reproduce
this in >10k runs, closes #6275 (we'll know a little more if it reoccurs).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6323)

<!-- Reviewable:end -->
