### PR TITLE
sql: Redirect all type checking through parser.PerformTypeChecking

### DIFF
--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -71,7 +71,7 @@ func parseAndNormalizeExpr(t *testing.T, sql string) (parser.Expr, qvalMap) {
 	if nErr != nil {
 		t.Fatalf("%s: %v", sql, nErr)
 	}
-	if _, err := expr.TypeCheck(nil); err != nil {
+	if _, err := parser.PerformTypeChecking(expr, nil); err != nil {
 		t.Fatalf("%s: %v", sql, err)
 	}
 	return expr, sel.qvals

--- a/sql/group.go
+++ b/sql/group.go
@@ -66,7 +66,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, *r
 
 		// We could potentially skip this, since it will be checked in addRender,
 		// but checking now allows early err return.
-		if _, err := resolved.TypeCheck(p.evalCtx.Args); err != nil {
+		if _, err := parser.PerformTypeChecking(resolved, p.evalCtx.Args); err != nil {
 			return nil, roachpb.NewError(err)
 		}
 
@@ -95,7 +95,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, *r
 			return nil, roachpb.NewError(err)
 		}
 
-		havingType, err := having.TypeCheck(p.evalCtx.Args)
+		havingType, err := parser.PerformTypeChecking(having, p.evalCtx.Args)
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -499,6 +499,8 @@ func ContainsVars(expr Expr) bool {
 
 type constantFolderVisitor struct{}
 
+var _ Visitor = constantFolderVisitor{}
+
 func (constantFolderVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	return expr != nil, expr
 }

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -81,6 +81,17 @@ func (p *Parser) Parse(sql string, syntax Syntax) (stmts StatementList, err erro
 	return p.scanner.stmts, nil
 }
 
+// PerformTypeChecking performs type checking on the provided expression. While doing
+// so, it will fold numeric constants and bind var argument names to their inferred
+// types in the args parameter.
+func PerformTypeChecking(expr Expr, args MapArgs) (Datum, error) {
+	expr, err := foldNumericConstants(expr)
+	if err != nil {
+		return nil, err
+	}
+	return expr.TypeCheck(args)
+}
+
 // NormalizeExpr is wrapper around ctx.NormalizeExpr which avoids allocation of
 // a normalizeVisitor.
 func (p *Parser) NormalizeExpr(ctx EvalContext, expr Expr) (Expr, error) {

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -98,7 +98,7 @@ func (rh *returningHelper) cookResultRow(rowVals parser.DTuple) (parser.DTuple, 
 // ought to be split into two phases.
 func (rh *returningHelper) TypeCheck() *roachpb.Error {
 	for i, expr := range rh.exprs {
-		typ, err := expr.TypeCheck(rh.p.evalCtx.Args)
+		typ, err := parser.PerformTypeChecking(expr, rh.p.evalCtx.Args)
 		if err != nil {
 			return roachpb.NewError(err)
 		}

--- a/sql/select.go
+++ b/sql/select.go
@@ -462,7 +462,7 @@ func (s *selectNode) initWhere(where *parser.Where) *roachpb.Error {
 		return s.pErr
 	}
 
-	whereType, err := s.filter.TypeCheck(s.planner.evalCtx.Args)
+	whereType, err := parser.PerformTypeChecking(s.filter, s.planner.evalCtx.Args)
 	if err != nil {
 		s.pErr = roachpb.NewError(err)
 		return s.pErr
@@ -578,12 +578,12 @@ func (s *selectNode) addRender(target parser.SelectExpr) *roachpb.Error {
 		return s.pErr
 	}
 
-	var typ parser.Datum
-	typ, err = resolved.TypeCheck(s.planner.evalCtx.Args)
-	s.pErr = roachpb.NewError(err)
-	if s.pErr != nil {
+	typ, err := parser.PerformTypeChecking(resolved, s.planner.evalCtx.Args)
+	if err != nil {
+		s.pErr = roachpb.NewError(err)
 		return s.pErr
 	}
+
 	var normalized parser.Expr
 	normalized, err = s.planner.parser.NormalizeExpr(s.planner.evalCtx, resolved)
 	s.pErr = roachpb.NewError(err)

--- a/sql/table.go
+++ b/sql/table.go
@@ -195,7 +195,7 @@ func makeColumnDefDescs(d *parser.ColumnTableDef) (*ColumnDescriptor, *IndexDesc
 
 	if d.DefaultExpr != nil {
 		// Verify the default expression type is compatible with the column type.
-		defaultType, err := d.DefaultExpr.TypeCheck(nil)
+		defaultType, err := parser.PerformTypeChecking(d.DefaultExpr, nil)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/sql/update.go
+++ b/sql/update.go
@@ -293,7 +293,7 @@ func (p *planner) Update(n *parser.Update, autoCommit bool) (planNode, *roachpb.
 		if _, ok := target.(parser.DefaultVal); ok {
 			continue
 		}
-		d, err := target.TypeCheck(p.evalCtx.Args)
+		d, err := parser.PerformTypeChecking(target, p.evalCtx.Args)
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}

--- a/sql/values.go
+++ b/sql/values.go
@@ -55,7 +55,7 @@ func (p *planner) ValuesClause(n *parser.ValuesClause) (planNode, *roachpb.Error
 				return nil, pErr
 			}
 			var err error
-			typ, err := expr.TypeCheck(p.evalCtx.Args)
+			typ, err := parser.PerformTypeChecking(expr, p.evalCtx.Args)
 			if err != nil {
 				return nil, roachpb.NewError(err)
 			}


### PR DESCRIPTION
This allows type checking to do more than just call the `TypeCheck`
method, and will be used heavily in coming change.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6325)

<!-- Reviewable:end -->
