### PR TITLE
Consolidate References into app.tsx

### DIFF
--- a/ui/next/app/components/layoutHeader.tsx
+++ b/ui/next/app/components/layoutHeader.tsx
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 import * as React from "react";
 
 /**

--- a/ui/next/app/components/layoutSidebar.tsx
+++ b/ui/next/app/components/layoutSidebar.tsx
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 import * as React from "react";
 import { Link, RouterOnContext } from "react-router";
 import * as Icons from "./icons";

--- a/ui/next/app/components/sortabletable.spec.tsx
+++ b/ui/next/app/components/sortabletable.spec.tsx
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 import * as React from "react";
 import * as _ from "lodash";
 import { assert } from "chai";

--- a/ui/next/app/components/sortabletable.tsx
+++ b/ui/next/app/components/sortabletable.tsx
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 import * as React from "react";
 import * as _ from "lodash";
 

--- a/ui/next/app/containers/cluster.tsx
+++ b/ui/next/app/containers/cluster.tsx
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 import * as React from "react";
 
 /**

--- a/ui/next/app/containers/databases.tsx
+++ b/ui/next/app/containers/databases.tsx
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 import * as React from "react";
 
 /**

--- a/ui/next/app/containers/helpus.tsx
+++ b/ui/next/app/containers/helpus.tsx
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 import * as React from "react";
 
 /**

--- a/ui/next/app/containers/layout.tsx
+++ b/ui/next/app/containers/layout.tsx
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 import * as React from "react";
 import SideBar from "../components/layoutSidebar";
 import Header from "../components/layoutHeader";

--- a/ui/next/app/containers/nodes.tsx
+++ b/ui/next/app/containers/nodes.tsx
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 import * as React from "react";
 import * as _ from "lodash";
 import { Link } from "react-router";

--- a/ui/next/app/interfaces/action.d.ts
+++ b/ui/next/app/interfaces/action.d.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 /**
  * Action is the interface that should be implemented by all redux actions in
  * this application.

--- a/ui/next/app/interfaces/proto.d.ts
+++ b/ui/next/app/interfaces/proto.d.ts
@@ -1,7 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-// Author: Matt Tracy (matt@cockroachlabs.com)
-// Author: Bram Gruneir (bram+code@cockroachlabs.com)
-
 /* tslint:disable:jsdoc-format */
 
 /**

--- a/ui/next/app/redux/nodes.ts
+++ b/ui/next/app/redux/nodes.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 /**
  * This module maintains the state of a read-only, periodically refreshed query
  * for the status of all nodes in the cluster. Data is fetched from the

--- a/ui/next/app/redux/ui.spec.ts
+++ b/ui/next/app/redux/ui.spec.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 import reducer, { UISetting, setUISetting, UISettingsDict } from "./ui";
 import { assert } from "chai";
 

--- a/ui/next/app/redux/ui.ts
+++ b/ui/next/app/redux/ui.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 /**
  * This module maintains various ephemeral UI settings. These settings should be
  * maintained within a session, but not saved between sessions.

--- a/ui/next/app/util/proto.ts
+++ b/ui/next/app/util/proto.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/main.d.ts" />
-
 import * as _ from "lodash";
 import { NodeStatus, StatusMetrics } from "../interfaces/proto";
 


### PR DESCRIPTION
As our knowledge of typescript expands, we now know that we only need one
`reference` tag to our typings file in the entire project; since we are always
compiling a project (based on our tsconfig.json file), rather than individual
files, this is sufficient to make the typings available everywhere.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6329)

<!-- Reviewable:end -->
