### PR TITLE
sql: add start of schema change backfill notification for tests

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -204,6 +204,10 @@ type ExecutorTestingKnobs struct {
 	// Note that this has nothing to do with the async path for running schema
 	// changers. To block that, see TestDisableAsyncSchemaChangeExec().
 	SyncSchemaChangersFilter SyncSchemaChangersFilter
+
+	// SchemaChangersStartBackfillNotification is called before applying the
+	// backfill for a schema change operation.
+	SchemaChangersStartBackfillNotification func()
 }
 
 // NewExecutor creates an Executor and registers a callback on the

--- a/sql/session.go
+++ b/sql/session.go
@@ -269,7 +269,9 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 			} else if done {
 				break
 			}
-			if pErr := sc.exec(); pErr != nil {
+			if pErr := sc.exec(
+				e.ctx.TestingKnobs.SchemaChangersStartBackfillNotification,
+			); pErr != nil {
 				if _, ok := pErr.GetDetail().(*roachpb.ExistingSchemaChangeLeaseError); ok {
 					// Try again.
 					continue


### PR DESCRIPTION
Also reduce the size of the table used in the test so that the test
doesn't trigger a context.DeadlineExceeded error. See #6333

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6334)

<!-- Reviewable:end -->
