### PR TITLE
sql: Pull column to parser.Datum conversion into getTypeForColumn

### DIFF
--- a/sql/scan.go
+++ b/sql/scan.go
@@ -253,32 +253,11 @@ func makeResultColumns(colDescs []ColumnDescriptor) []ResultColumn {
 	cols := make([]ResultColumn, 0, len(colDescs))
 	for _, colDesc := range colDescs {
 		// Convert the ColumnDescriptor to ResultColumn.
-		var typ parser.Datum
-
-		switch colDesc.Type.Kind {
-		case ColumnType_INT:
-			typ = parser.DummyInt
-		case ColumnType_BOOL:
-			typ = parser.DummyBool
-		case ColumnType_FLOAT:
-			typ = parser.DummyFloat
-		case ColumnType_DECIMAL:
-			typ = parser.DummyDecimal
-		case ColumnType_STRING:
-			typ = parser.DummyString
-		case ColumnType_BYTES:
-			typ = parser.DummyBytes
-		case ColumnType_DATE:
-			typ = parser.DummyDate
-		case ColumnType_TIMESTAMP:
-			typ = parser.DummyTimestamp
-		case ColumnType_TIMESTAMPTZ:
-			typ = parser.DummyTimestampTZ
-		case ColumnType_INTERVAL:
-			typ = parser.DummyInterval
-		default:
+		typ := getTypeForColumn(colDesc)
+		if typ == nil {
 			panic(fmt.Sprintf("unsupported column type: %s", colDesc.Type.Kind))
 		}
+
 		hidden := colDesc.Hidden
 		cols = append(cols, ResultColumn{Name: colDesc.Name, Typ: typ, hidden: hidden})
 	}

--- a/sql/table.go
+++ b/sql/table.go
@@ -531,29 +531,9 @@ func makeKeyVals(desc *TableDescriptor, columnIDs []ColumnID) ([]parser.Datum, e
 		if err != nil {
 			return nil, err
 		}
-		switch col.Type.Kind {
-		case ColumnType_BOOL:
-			vals[i] = parser.DummyBool
-		case ColumnType_INT:
-			vals[i] = parser.DummyInt
-		case ColumnType_FLOAT:
-			vals[i] = parser.DummyFloat
-		case ColumnType_DECIMAL:
-			vals[i] = parser.DummyDecimal
-		case ColumnType_STRING:
-			vals[i] = parser.DummyString
-		case ColumnType_BYTES:
-			vals[i] = parser.DummyBytes
-		case ColumnType_DATE:
-			vals[i] = parser.DummyDate
-		case ColumnType_TIMESTAMP:
-			vals[i] = parser.DummyTimestamp
-		case ColumnType_TIMESTAMPTZ:
-			vals[i] = parser.DummyTimestampTZ
-		case ColumnType_INTERVAL:
-			vals[i] = parser.DummyInterval
-		default:
-			return nil, util.Errorf("TODO(pmattis): decoded index key: %s", col.Type.Kind)
+
+		if vals[i] = getTypeForColumn(*col); vals[i] == nil {
+			panic(fmt.Sprintf("unsupported column type: %s", col.Type.Kind))
 		}
 	}
 	return vals, nil
@@ -954,6 +934,34 @@ func checkColumnType(col ColumnDescriptor, val parser.Datum, args parser.MapArgs
 			val.Type(), col.Type.Kind, col.Name)
 	}
 	return err
+}
+
+// getTypeForColumn returns the corresponding Datum type for the given
+// ColumnDescriptor's Type, or nil if there is no correspondence.
+func getTypeForColumn(col ColumnDescriptor) parser.Datum {
+	switch col.Type.Kind {
+	case ColumnType_BOOL:
+		return parser.DummyBool
+	case ColumnType_INT:
+		return parser.DummyInt
+	case ColumnType_FLOAT:
+		return parser.DummyFloat
+	case ColumnType_DECIMAL:
+		return parser.DummyDecimal
+	case ColumnType_STRING:
+		return parser.DummyString
+	case ColumnType_BYTES:
+		return parser.DummyBytes
+	case ColumnType_DATE:
+		return parser.DummyDate
+	case ColumnType_TIMESTAMP:
+		return parser.DummyTimestamp
+	case ColumnType_TIMESTAMPTZ:
+		return parser.DummyTimestampTZ
+	case ColumnType_INTERVAL:
+		return parser.DummyInterval
+	}
+	return nil
 }
 
 // marshalColumnValue returns a Go primitive value equivalent of val, of the


### PR DESCRIPTION
Previously we had a this logic in a few different places. This change
pulls the logic into a single function, which returns the corresponding
Datum type for the given ColumnDescriptor's Type, or nil if there is no
correspondence.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6337)

<!-- Reviewable:end -->
