### PR TITLE
Add c-jemalloc to GLOCK

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -21,6 +21,7 @@ github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store 3b4c041f52c224ee4a44f5c8b150d003a40643a0
 github.com/chzyer/readline dc5da28fbf5287157fcd4719c794b59cd8852115
 github.com/client9/misspell 4f5982f81a18693b85c9926407fc4f61102ee0e7
+github.com/cockroachdb/c-jemalloc 2541f4cab8e2731fb6111e7765c1d7c3efafea87
 github.com/cockroachdb/c-protobuf 4feb192131ea08dfbd7253a00868ad69cbb61b81
 github.com/cockroachdb/c-rocksdb b80d2efe8e544bbcc4b50dec8e89f9305f5da745
 github.com/cockroachdb/c-snappy 5c6d0932e0adaffce4bfca7bdf2ac37f79952ccf


### PR DESCRIPTION
I forgot it earlier, making circle-ci builds always fail.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6344)

<!-- Reviewable:end -->
