### PR TITLE
storage/engine: add Iterator.{Next,Prev}Key operations

### DIFF
--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -49,7 +49,17 @@ type Iterator interface {
 	// in the iteration. After this call, Valid() will be true if the
 	// iterator was not positioned at the first key.
 	Prev()
-	// Key returns the current key as a byte slice.
+	// NextKey advances the iterator to the next MVCC key. This operation is
+	// distinct from Next which advances to the next version of the current key
+	// or the next key if the iterator is currently located at the last version
+	// for a key.
+	NextKey()
+	// PrevKey moves the iterator backward to the previous MVCC key. This
+	// operation is distinct from Prev which moves the iterator backward to the
+	// prev version of the current key or the prev key if the iterator is
+	// currently located at the first version for a key.
+	PrevKey()
+	// Key returns the current key.
 	Key() MVCCKey
 	// Value returns the current value as a byte slice.
 	Value() []byte

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -656,15 +656,6 @@ func (r *rocksDBIterator) Seek(key MVCCKey) {
 	}
 }
 
-func (r *rocksDBIterator) Valid() bool {
-	return r.valid
-}
-
-func (r *rocksDBIterator) Next() {
-	r.checkEngineOpen()
-	r.setState(C.DBIterNext(r.iter))
-}
-
 func (r *rocksDBIterator) SeekReverse(key MVCCKey) {
 	r.checkEngineOpen()
 	if len(key.Key) == 0 {
@@ -685,9 +676,28 @@ func (r *rocksDBIterator) SeekReverse(key MVCCKey) {
 	}
 }
 
+func (r *rocksDBIterator) Valid() bool {
+	return r.valid
+}
+
+func (r *rocksDBIterator) Next() {
+	r.checkEngineOpen()
+	r.setState(C.DBIterNext(r.iter, false /* !skip_current_key_versions */))
+}
+
 func (r *rocksDBIterator) Prev() {
 	r.checkEngineOpen()
-	r.setState(C.DBIterPrev(r.iter))
+	r.setState(C.DBIterPrev(r.iter, false /* !skip_current_key_versions */))
+}
+
+func (r *rocksDBIterator) NextKey() {
+	r.checkEngineOpen()
+	r.setState(C.DBIterNext(r.iter, true /* skip_current_key_versions */))
+}
+
+func (r *rocksDBIterator) PrevKey() {
+	r.checkEngineOpen()
+	r.setState(C.DBIterPrev(r.iter, true /* skip_current_key_versions */))
 }
 
 func (r *rocksDBIterator) Key() MVCCKey {

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -134,15 +134,17 @@ DBIterState DBIterSeekToFirst(DBIterator* iter);
 // Positions the iterator at the last key in the database.
 DBIterState DBIterSeekToLast(DBIterator* iter);
 
-// Advances the iterator to the next key. After this call,
-// DBIterValid() returns 1 iff the iterator was not positioned at the
-// last key.
-DBIterState DBIterNext(DBIterator* iter);
+// Advances the iterator to the next key. If skip_current_key_versions
+// is true, any remaining versions for the current key are
+// skipped. After this call, DBIterValid() returns 1 iff the iterator
+// was not positioned at the last key.
+DBIterState DBIterNext(DBIterator* iter, bool skip_current_key_versions);
 
-// Moves the iterator back to the previous key. After this call,
-// DBIterValid() returns 1 iff the iterator was not positioned at the
-// first key.
-DBIterState DBIterPrev(DBIterator* iter);
+// Moves the iterator back to the previous key. If
+// skip_current_key_versions is true, any remaining versions for the
+// current key are skipped. After this call, DBIterValid() returns 1
+// iff the iterator was not positioned at the first key.
+DBIterState DBIterPrev(DBIterator* iter, bool skip_current_key_versions);
 
 // Returns any error associated with the iterator.
 DBStatus DBIterError(DBIterator* iter);


### PR DESCRIPTION
The `Iterator.{Next,Prev}Key` operations advance (or move back) the
iterator to the next key as opposed to advancing to the next
version. This speeds up the common case of iteration over keys where
there is only a single version.

```
name                   old time/op    new time/op    delta
KVScan1_Native-32         388µs ± 5%     397µs ± 6%   +2.24%        (p=0.013 n=20+20)
KVScan1_SQL-32            208µs ± 4%     207µs ± 2%     ~           (p=0.192 n=20+20)
KVScan10_Native-32        438µs ± 5%     440µs ± 4%     ~           (p=0.166 n=19+20)
KVScan10_SQL-32           286µs ± 4%     267µs ± 2%   -6.59%        (p=0.000 n=20+20)
KVScan100_Native-32       782µs ± 3%     685µs ± 2%  -12.46%        (p=0.000 n=19+19)
KVScan100_SQL-32          947µs ± 6%     749µs ± 3%  -20.88%        (p=0.000 n=20+19)
KVScan1000_Native-32     3.77ms ± 3%    2.82ms ± 5%  -25.09%        (p=0.000 n=19+19)
KVScan1000_SQL-32        7.33ms ± 7%    5.17ms ± 2%  -29.51%        (p=0.000 n=20+17)
KVScan10000_Native-32    38.1ms ± 4%    28.2ms ± 4%  -26.00%        (p=0.000 n=19+20)
KVScan10000_SQL-32       73.9ms ± 6%    50.3ms ± 6%  -31.95%        (p=0.000 n=19+17)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6351)

<!-- Reviewable:end -->
