### PR TITLE
UI: Add support for using Redux DevTools

### DIFF
--- a/ui/next/app/app.tsx
+++ b/ui/next/app/app.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { createStore, combineReducers, applyMiddleware } from "redux";
+import { createStore, combineReducers, applyMiddleware, compose } from "redux";
 import { Provider } from "react-redux";
 import { Router, Route, IndexRedirect, hashHistory } from "react-router";
 import { syncHistoryWithStore, routerReducer } from "react-router-redux";
@@ -28,7 +28,12 @@ const store = createStore(
     nodes: nodesReducer,
     ui: uiReducer,
   }),
-  applyMiddleware(thunk)
+  compose(
+    applyMiddleware(thunk),
+    // Support for redux dev tools
+    // https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd
+    (window as any).devToolsExtension ? (window as any).devToolsExtension() : (f: any): any => f
+  )
 );
 
 // Connect react-router history with redux.


### PR DESCRIPTION
Redux devtools are useful for debugging redux apps. This doesn't
need to be removed from the production code, since it will only
work if the user has redux devtools installed.

https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6356)

<!-- Reviewable:end -->
