### PR TITLE
sql: simplify schema change backfill to not care for table versions

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -89,46 +89,8 @@ func convertBackfillError(
 	return convertBatchError(tableDesc, *b, pErr)
 }
 
-var descriptorChangedVersionError = roachpb.NewErrorf("table descriptor has changed version")
-
-// getTableDescAtVersion attempts to read a descriptor from the database at a
-// specific version. It returns descriptorChangedVersionError if the current
-// version is not the passed in version.
-func getTableDescAtVersion(
-	txn *client.Txn, id ID, version DescriptorVersion,
-) (*TableDescriptor, *roachpb.Error) {
-	tableDesc, pErr := getTableDescFromID(txn, id)
-	if pErr != nil {
-		return nil, pErr
-	}
-	if tableDesc == nil {
-		return nil, roachpb.NewError(&roachpb.DescriptorDeletedError{})
-	}
-	if version != tableDesc.Version {
-		return nil, descriptorChangedVersionError
-	}
-	return tableDesc, nil
-}
-
-// runBackfill runs the backfill for the schema changer. It runs the entire
-// backfill at a specific version of the table descriptor, and re-attempts to
-// run the schema change when the version changes.
+// runBackfill runs the backfill for the schema changer.
 func (sc *SchemaChanger) runBackfill(lease *TableDescriptor_SchemaChangeLease) *roachpb.Error {
-	for {
-		pErr := sc.runBackfillAtLatestVersion(lease)
-		if pErr == descriptorChangedVersionError {
-			continue
-		}
-		return pErr
-	}
-}
-
-// Run the backfill at the latest table descriptor version. It returns
-// descriptorChangedVersionError when the table descriptor version changes
-// while it is running the backfill.
-func (sc *SchemaChanger) runBackfillAtLatestVersion(
-	lease *TableDescriptor_SchemaChangeLease,
-) *roachpb.Error {
 	l, pErr := sc.ExtendLease(*lease)
 	if pErr != nil {
 		return pErr
@@ -141,19 +103,12 @@ func (sc *SchemaChanger) runBackfillAtLatestVersion(
 	var droppedIndexDescs []IndexDescriptor
 	var addedColumnDescs []ColumnDescriptor
 	var addedIndexDescs []IndexDescriptor
-	// Remember the version at the start of the backfill so we can ensure
-	// later that the table descriptor hasn't changed during the backfill
-	// process.
-	var version DescriptorVersion
 	if pErr := sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		tableDesc, pErr := getTableDescFromID(txn, sc.tableID)
 		if pErr != nil {
 			return pErr
 		}
-		if tableDesc == nil {
-			return roachpb.NewError(&roachpb.DescriptorDeletedError{})
-		}
-		version = tableDesc.Version
+
 		for _, m := range tableDesc.Mutations {
 			if m.MutationID != sc.mutationID {
 				break
@@ -187,18 +142,18 @@ func (sc *SchemaChanger) runBackfillAtLatestVersion(
 
 	// Add and drop columns.
 	if pErr := sc.truncateAndBackfillColumns(
-		lease, addedColumnDescs, droppedColumnDescs, version,
+		lease, addedColumnDescs, droppedColumnDescs,
 	); pErr != nil {
 		return pErr
 	}
 
 	// Drop indexes.
-	if pErr := sc.truncateIndexes(lease, droppedIndexDescs, version); pErr != nil {
+	if pErr := sc.truncateIndexes(lease, droppedIndexDescs); pErr != nil {
 		return pErr
 	}
 
 	// Add new indexes.
-	if pErr := sc.backfillIndexes(lease, addedIndexDescs, version); pErr != nil {
+	if pErr := sc.backfillIndexes(lease, addedIndexDescs); pErr != nil {
 		return pErr
 	}
 
@@ -206,12 +161,11 @@ func (sc *SchemaChanger) runBackfillAtLatestVersion(
 }
 
 // getTableSpan returns a span containing the start and end key for a table.
-// It also checks that the version hasn't changed.
-func (sc *SchemaChanger) getTableSpan(version DescriptorVersion) (span, *roachpb.Error) {
+func (sc *SchemaChanger) getTableSpan() (span, *roachpb.Error) {
 	var tableDesc *TableDescriptor
 	if pErr := sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
 		var pErr *roachpb.Error
-		tableDesc, pErr = getTableDescAtVersion(txn, sc.tableID, version)
+		tableDesc, pErr = getTableDescFromID(txn, sc.tableID)
 		return pErr
 	}); pErr != nil {
 		return span{}, pErr
@@ -235,7 +189,6 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 	lease *TableDescriptor_SchemaChangeLease,
 	added []ColumnDescriptor,
 	dropped []ColumnDescriptor,
-	version DescriptorVersion,
 ) *roachpb.Error {
 	evalCtx := parser.EvalContext{}
 	// Set the eval context timestamps.
@@ -266,7 +219,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 		*lease = l
 
 		// Initialize start and end to represent a span of keys.
-		sp, err := sc.getTableSpan(version)
+		sp, err := sc.getTableSpan()
 		if err != nil {
 			return err
 		}
@@ -280,11 +233,16 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 			}
 			*lease = l
 
-			var currSentinel roachpb.Key
+			var curSentinel roachpb.Key
 			if pErr := sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
-				tableDesc, pErr := getTableDescAtVersion(txn, sc.tableID, version)
+				tableDesc, pErr := getTableDescFromID(txn, sc.tableID)
 				if pErr != nil {
 					return pErr
+				}
+				// Short circuit the backfill if the table has been deleted.
+				if tableDesc.Deleted {
+					done = true
+					return nil
 				}
 
 				// Run a scan across the table using the primary key. Running
@@ -318,7 +276,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 							sentinelKey = stripColumnIDLength(kv.Key)
 							// Store away key for the next table row as the
 							// point from which to start from.
-							currSentinel = sentinelKey
+							curSentinel = sentinelKey
 
 							// Delete the entire dropped columns. This used to
 							// use SQL UPDATE in the past to update the
@@ -379,7 +337,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 				return pErr
 			}
 			// Store away next starting point.
-			sp.start = currSentinel.PrefixEnd()
+			sp.start = curSentinel.PrefixEnd()
 		}
 	}
 	return nil
@@ -388,7 +346,6 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 func (sc *SchemaChanger) truncateIndexes(
 	lease *TableDescriptor_SchemaChangeLease,
 	dropped []IndexDescriptor,
-	version DescriptorVersion,
 ) *roachpb.Error {
 	for _, desc := range dropped {
 		// First extend the schema change lease.
@@ -398,9 +355,13 @@ func (sc *SchemaChanger) truncateIndexes(
 		}
 		*lease = l
 		if pErr := sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
-			tableDesc, pErr := getTableDescAtVersion(txn, sc.tableID, version)
+			tableDesc, pErr := getTableDescFromID(txn, sc.tableID)
 			if pErr != nil {
 				return pErr
+			}
+			// Short circuit the truncation if the table has been deleted.
+			if tableDesc.Deleted {
+				return nil
 			}
 
 			indexPrefix := MakeIndexKeyPrefix(tableDesc.ID, desc.ID)
@@ -436,7 +397,6 @@ const IndexBackfillChunkSize = 100
 func (sc *SchemaChanger) backfillIndexes(
 	lease *TableDescriptor_SchemaChangeLease,
 	added []IndexDescriptor,
-	version DescriptorVersion,
 ) *roachpb.Error {
 	if len(added) == 0 {
 		return nil
@@ -449,7 +409,7 @@ func (sc *SchemaChanger) backfillIndexes(
 	*lease = l
 
 	// Initialize start and end to represent a span of keys.
-	sp, err := sc.getTableSpan(version)
+	sp, err := sc.getTableSpan()
 	if err != nil {
 		return err
 	}
@@ -464,9 +424,14 @@ func (sc *SchemaChanger) backfillIndexes(
 		*lease = l
 		var nextKey roachpb.Key
 		pErr = sc.db.Txn(func(txn *client.Txn) *roachpb.Error {
-			tableDesc, pErr := getTableDescAtVersion(txn, sc.tableID, version)
+			tableDesc, pErr := getTableDescFromID(txn, sc.tableID)
 			if pErr != nil {
 				return pErr
+			}
+			// Short circuit the backfill if the table has been deleted.
+			if tableDesc.Deleted {
+				done = true
+				return nil
 			}
 
 			// Get the next set of rows.


### PR DESCRIPTION
The schema change backfill is applied as long as the table is not marked for deletion.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6361)

<!-- Reviewable:end -->
