### PR TITLE
Makefile: Remove pb.gw.go files from dupl target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,13 @@ acceptance:
 
 .PHONY: dupl
 dupl:
-	find . -name '*.go' -not -name '*.pb.go' -not -name 'embedded.go' -not -name '*_string.go' -not -name 'sql.go' | dupl -files $(DUPLFLAGS)
+	find . -name '*.go'             \
+	       -not -name '*.pb.go'     \
+	       -not -name '*.pb.gw.go'  \
+	       -not -name 'embedded.go' \
+	       -not -name '*_string.go' \
+	       -not -name 'sql.go'      \
+	| dupl -files $(DUPLFLAGS)
 
 .PHONY: check
 check:


### PR DESCRIPTION
This reduces the number of clone groups from 37 to 29.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6364)

<!-- Reviewable:end -->
