### PR TITLE
all: stop using pErr above the senders layer

### DIFF
--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
-	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/timeutil"
@@ -199,12 +198,12 @@ func testGossipRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestCon
 				}
 			}
 			var kv client.KeyValue
-			if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
-				var pErr *roachpb.Error
-				kv, pErr = txn.Inc("count", 1)
-				return pErr
-			}); pErr != nil {
-				t.Fatal(pErr)
+			if err := db.Txn(func(txn *client.Txn) error {
+				var err error
+				kv, err = txn.Inc("count", 1)
+				return err
+			}); err != nil {
+				t.Fatal(err)
 			} else if v := kv.ValueInt(); v != int64(i+1) {
 				t.Fatalf("unexpected value %d for write #%d (expected %d)", v, i, i+1)
 			}

--- a/acceptance/put_test.go
+++ b/acceptance/put_test.go
@@ -50,8 +50,8 @@ func testPutInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
 			for timeutil.Now().Before(deadline) {
 				k := atomic.AddInt64(&count, 1)
 				v := value[:r.Intn(len(value))]
-				if pErr := db.Put(fmt.Sprintf("%08d", k), v); pErr != nil {
-					errs <- pErr.GoError()
+				if err := db.Put(fmt.Sprintf("%08d", k), v); err != nil {
+					errs <- err
 					return
 				}
 			}

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -31,8 +31,8 @@ import (
 
 func countRangeReplicas(db *client.DB) (int, error) {
 	desc := &roachpb.RangeDescriptor{}
-	if pErr := db.GetProto(keys.RangeDescriptorKey(roachpb.RKeyMin), desc); pErr != nil {
-		return 0, pErr.GoError()
+	if err := db.GetProto(keys.RangeDescriptorKey(roachpb.RKeyMin), desc); err != nil {
+		return 0, err
 	}
 	return len(desc.Replicas), nil
 }

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -155,15 +155,15 @@ func runCPut(cmd *cobra.Command, args []string) {
 
 	key := unquoteArg(args[0], true /* disallow system keys */)
 	value := unquoteArg(args[1], false)
-	var pErr *roachpb.Error
+	var err error
 	if len(args) == 3 {
-		pErr = kvDB.CPut(key, value, unquoteArg(args[2], false))
+		err = kvDB.CPut(key, value, unquoteArg(args[2], false))
 	} else {
-		pErr = kvDB.CPut(key, value, nil)
+		err = kvDB.CPut(key, value, nil)
 	}
 
-	if pErr != nil {
-		panicf("conditional put failed: %s", pErr)
+	if err != nil {
+		panicf("conditional put failed: %s", err)
 	}
 }
 

--- a/client/batch.go
+++ b/client/batch.go
@@ -58,10 +58,10 @@ type Batch struct {
 	rowsStaticIdx int
 }
 
-func (b *Batch) prepare() *roachpb.Error {
+func (b *Batch) prepare() error {
 	for _, r := range b.Results {
-		if pErr := r.Err; pErr != nil {
-			return pErr
+		if r.Err() != nil {
+			return r.Err()
 		}
 	}
 	return nil
@@ -69,7 +69,7 @@ func (b *Batch) prepare() *roachpb.Error {
 
 func (b *Batch) initResult(calls, numRows int, err error) {
 	// TODO(tschottdorf): assert that calls is 0 or 1?
-	r := Result{calls: calls, Err: roachpb.NewError(err)}
+	r := Result{calls: calls, PErr: roachpb.NewError(err)}
 	if numRows > 0 {
 		if b.rowsStaticIdx+numRows <= len(b.rowsStaticBuf) {
 			r.Rows = b.rowsStaticBuf[b.rowsStaticIdx : b.rowsStaticIdx+numRows]
@@ -105,7 +105,8 @@ func (b *Batch) initResult(calls, numRows int, err error) {
 	b.Results = append(b.Results, r)
 }
 
-func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roachpb.Error {
+// Returns the first error.
+func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) error {
 	offset := 0
 	for i := range b.Results {
 		result := &b.Results[i]
@@ -114,9 +115,9 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 			args := b.reqs[offset+k]
 
 			var reply roachpb.Response
-			if result.Err == nil {
-				result.Err = pErr
-				if result.Err == nil {
+			if result.PErr == nil {
+				result.PErr = pErr
+				if result.PErr == nil {
 					if br != nil && offset+k < len(br.Responses) {
 						reply = br.Responses[offset+k].GetInner()
 					} else if args.Method() != roachpb.EndTransaction {
@@ -133,37 +134,37 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 			case *roachpb.GetRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.Err == nil {
+				if result.Err() == nil {
 					row.Value = reply.(*roachpb.GetResponse).Value
 				}
 			case *roachpb.PutRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.Err == nil {
+				if result.Err() == nil {
 					row.Value = &req.Value
 				}
 			case *roachpb.ConditionalPutRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.Err == nil {
+				if result.Err() == nil {
 					row.Value = &req.Value
 				}
 			case *roachpb.InitPutRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.Err == nil {
+				if result.Err() == nil {
 					row.Value = &req.Value
 				}
 			case *roachpb.IncrementRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.Err == nil {
+				if result.Err() == nil {
 					t := reply.(*roachpb.IncrementResponse)
 					row.Value = &roachpb.Value{}
 					row.Value.SetInt(t.NewValue)
 				}
 			case *roachpb.ScanRequest:
-				if result.Err == nil {
+				if result.Err() == nil {
 					t := reply.(*roachpb.ScanResponse)
 					result.Rows = make([]KeyValue, len(t.Rows))
 					for j := range t.Rows {
@@ -174,7 +175,7 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 					}
 				}
 			case *roachpb.ReverseScanRequest:
-				if result.Err == nil {
+				if result.Err() == nil {
 					t := reply.(*roachpb.ReverseScanResponse)
 					result.Rows = make([]KeyValue, len(t.Rows))
 					for j := range t.Rows {
@@ -189,7 +190,7 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 				row.Key = []byte(args.(*roachpb.DeleteRequest).Key)
 
 			case *roachpb.DeleteRangeRequest:
-				if result.Err == nil {
+				if result.Err() == nil {
 					result.Keys = reply.(*roachpb.DeleteRangeResponse).Keys
 				}
 
@@ -211,8 +212,8 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 				// rows.
 
 			default:
-				if result.Err == nil {
-					result.Err = roachpb.NewErrorf("unsupported reply: %T", reply)
+				if result.PErr == nil {
+					result.PErr = roachpb.NewErrorf("unsupported reply: %T", reply)
 				}
 			}
 		}
@@ -221,8 +222,8 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 
 	for i := range b.Results {
 		result := &b.Results[i]
-		if result.Err != nil {
-			return result.Err
+		if result.PErr != nil {
+			return result.Err()
 		}
 	}
 	return nil

--- a/client/batch.go
+++ b/client/batch.go
@@ -60,7 +60,7 @@ type Batch struct {
 
 func (b *Batch) prepare() *roachpb.Error {
 	for _, r := range b.Results {
-		if pErr := r.PErr; pErr != nil {
+		if pErr := r.Err; pErr != nil {
 			return pErr
 		}
 	}
@@ -69,7 +69,7 @@ func (b *Batch) prepare() *roachpb.Error {
 
 func (b *Batch) initResult(calls, numRows int, err error) {
 	// TODO(tschottdorf): assert that calls is 0 or 1?
-	r := Result{calls: calls, PErr: roachpb.NewError(err)}
+	r := Result{calls: calls, Err: roachpb.NewError(err)}
 	if numRows > 0 {
 		if b.rowsStaticIdx+numRows <= len(b.rowsStaticBuf) {
 			r.Rows = b.rowsStaticBuf[b.rowsStaticIdx : b.rowsStaticIdx+numRows]
@@ -114,9 +114,9 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 			args := b.reqs[offset+k]
 
 			var reply roachpb.Response
-			if result.PErr == nil {
-				result.PErr = pErr
-				if result.PErr == nil {
+			if result.Err == nil {
+				result.Err = pErr
+				if result.Err == nil {
 					if br != nil && offset+k < len(br.Responses) {
 						reply = br.Responses[offset+k].GetInner()
 					} else if args.Method() != roachpb.EndTransaction {
@@ -133,37 +133,37 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 			case *roachpb.GetRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.PErr == nil {
+				if result.Err == nil {
 					row.Value = reply.(*roachpb.GetResponse).Value
 				}
 			case *roachpb.PutRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.PErr == nil {
+				if result.Err == nil {
 					row.Value = &req.Value
 				}
 			case *roachpb.ConditionalPutRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.PErr == nil {
+				if result.Err == nil {
 					row.Value = &req.Value
 				}
 			case *roachpb.InitPutRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.PErr == nil {
+				if result.Err == nil {
 					row.Value = &req.Value
 				}
 			case *roachpb.IncrementRequest:
 				row := &result.Rows[k]
 				row.Key = []byte(req.Key)
-				if result.PErr == nil {
+				if result.Err == nil {
 					t := reply.(*roachpb.IncrementResponse)
 					row.Value = &roachpb.Value{}
 					row.Value.SetInt(t.NewValue)
 				}
 			case *roachpb.ScanRequest:
-				if result.PErr == nil {
+				if result.Err == nil {
 					t := reply.(*roachpb.ScanResponse)
 					result.Rows = make([]KeyValue, len(t.Rows))
 					for j := range t.Rows {
@@ -174,7 +174,7 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 					}
 				}
 			case *roachpb.ReverseScanRequest:
-				if result.PErr == nil {
+				if result.Err == nil {
 					t := reply.(*roachpb.ReverseScanResponse)
 					result.Rows = make([]KeyValue, len(t.Rows))
 					for j := range t.Rows {
@@ -189,7 +189,7 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 				row.Key = []byte(args.(*roachpb.DeleteRequest).Key)
 
 			case *roachpb.DeleteRangeRequest:
-				if result.PErr == nil {
+				if result.Err == nil {
 					result.Keys = reply.(*roachpb.DeleteRangeResponse).Keys
 				}
 
@@ -211,8 +211,8 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 				// rows.
 
 			default:
-				if result.PErr == nil {
-					result.PErr = roachpb.NewErrorf("unsupported reply: %T", reply)
+				if result.Err == nil {
+					result.Err = roachpb.NewErrorf("unsupported reply: %T", reply)
 				}
 			}
 		}
@@ -221,8 +221,8 @@ func (b *Batch) fillResults(br *roachpb.BatchResponse, pErr *roachpb.Error) *roa
 
 	for i := range b.Results {
 		result := &b.Results[i]
-		if result.PErr != nil {
-			return result.PErr
+		if result.Err != nil {
+			return result.Err
 		}
 	}
 	return nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -543,7 +543,7 @@ func TestClientBatch(t *testing.T) {
 		} else {
 			var foundError bool
 			for _, result := range b.Results {
-				if result.PErr != nil {
+				if result.Err != nil {
 					foundError = true
 					break
 				}
@@ -570,7 +570,7 @@ func TestClientBatch(t *testing.T) {
 		} else {
 			var foundError bool
 			for _, result := range b.Results {
-				if result.PErr != nil {
+				if result.Err != nil {
 					foundError = true
 					break
 				}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -149,18 +150,18 @@ func TestClientRetryNonTxn(t *testing.T) {
 		// doneCall signals when the non-txn read or write has completed.
 		doneCall := make(chan struct{})
 		count := 0 // keeps track of retries
-		pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+		err := db.Txn(func(txn *client.Txn) error {
 			if test.isolation == roachpb.SNAPSHOT {
 				if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-					return roachpb.NewError(err)
+					return err
 				}
 			}
 			txn.InternalSetPriority(txnPri)
 
 			count++
 			// Lay down the intent.
-			if pErr := txn.Put(key, "txn-value"); pErr != nil {
-				return pErr
+			if err := txn.Put(key, "txn-value"); err != nil {
+				return err
 			}
 			// On the first true, send the non-txn put or get.
 			if count == 1 {
@@ -175,41 +176,41 @@ func TestClientRetryNonTxn(t *testing.T) {
 				// it might have to retry and will only succeed immediately in
 				// the event we can push.
 				go func() {
-					var pErr *roachpb.Error
+					var err error
 					for {
 						if _, ok := test.args.(*roachpb.GetRequest); ok {
-							_, pErr = db.Get(key)
+							_, err = db.Get(key)
 						} else {
-							pErr = db.Put(key, "value")
+							err = db.Put(key, "value")
 						}
 						// The above Get/Put() calls Send() which releases
 						// notify below; the txn proceeds to succeed.
 						// The above Get/Put() is repeated until no WriteIntentError
 						// is seen.
-						if _, ok := pErr.GetDetail().(*roachpb.WriteIntentError); !ok {
+						if _, ok := err.(*roachpb.WriteIntentError); !ok {
 							break
 						}
 					}
 					close(doneCall)
-					if pErr != nil {
-						t.Fatalf("%d: expected success on non-txn call to %s; got %s", i, test.args.Method(), pErr)
+					if err != nil {
+						t.Fatalf("%d: expected success on non-txn call to %s; got %s", i, test.args.Method(), err)
 					}
 				}()
 				<-notify
 			}
 			return nil
 		})
-		if pErr != nil {
-			t.Fatalf("%d: expected success writing transactionally; got %s", i, pErr)
+		if err != nil {
+			t.Fatalf("%d: expected success writing transactionally; got %s", i, err)
 		}
 
 		// Make sure non-txn put or get has finished.
 		<-doneCall
 
 		// Get the current value to verify whether the txn happened first.
-		gr, pErr := db.Get(key)
-		if pErr != nil {
-			t.Fatalf("%d: expected success getting %q: %s", i, key, pErr)
+		gr, err := db.Get(key)
+		if err != nil {
+			t.Fatalf("%d: expected success getting %q: %s", i, key, err)
 		}
 
 		if _, isGet := test.args.(*roachpb.GetRequest); isGet || test.canPush {
@@ -249,48 +250,48 @@ func TestClientRunTransaction(t *testing.T) {
 		key := []byte(fmt.Sprintf("%s/key-%t", testUser, commit))
 
 		// Use snapshot isolation so non-transactional read can always push.
-		pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+		err := db.Txn(func(txn *client.Txn) error {
 			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-				return roachpb.NewError(err)
+				return err
 			}
 
 			// Put transactional value.
-			if pErr := txn.Put(key, value); pErr != nil {
-				return pErr
+			if err := txn.Put(key, value); err != nil {
+				return err
 			}
 			// Attempt to read outside of txn.
-			if gr, pErr := db.Get(key); pErr != nil {
-				return pErr
+			if gr, err := db.Get(key); err != nil {
+				return err
 			} else if gr.Value != nil {
-				return roachpb.NewErrorf("expected nil value; got %+v", gr.Value)
+				return util.Errorf("expected nil value; got %+v", gr.Value)
 			}
 			// Read within the transaction.
-			if gr, pErr := txn.Get(key); pErr != nil {
-				return pErr
+			if gr, err := txn.Get(key); err != nil {
+				return err
 			} else if gr.Value == nil || !bytes.Equal(gr.ValueBytes(), value) {
-				return roachpb.NewErrorf("expected value %q; got %q", value, gr.ValueBytes())
+				return util.Errorf("expected value %q; got %q", value, gr.ValueBytes())
 			}
 			if !commit {
-				return roachpb.NewErrorf("purposefully failing transaction")
+				return util.Errorf("purposefully failing transaction")
 			}
 			return nil
 		})
 
-		if commit != (pErr == nil) {
-			t.Errorf("expected success? %t; got %s", commit, pErr)
-		} else if !commit && !testutils.IsPError(pErr, "purposefully failing transaction") {
-			t.Errorf("unexpected failure with !commit: %s", pErr)
+		if commit != (err == nil) {
+			t.Errorf("expected success? %t; got %s", commit, err)
+		} else if !commit && !testutils.IsError(err, "purposefully failing transaction") {
+			t.Errorf("unexpected failure with !commit: %s", err)
 		}
 
 		// Verify the value is now visible on commit == true, and not visible otherwise.
-		gr, pErr := db.Get(key)
+		gr, err := db.Get(key)
 		if commit {
-			if pErr != nil || gr.Value == nil || !bytes.Equal(gr.ValueBytes(), value) {
-				t.Errorf("expected success reading value: %+v, %s", gr.Value, pErr)
+			if err != nil || gr.Value == nil || !bytes.Equal(gr.ValueBytes(), value) {
+				t.Errorf("expected success reading value: %+v, %s", gr.Value, err)
 			}
 		} else {
-			if pErr != nil || gr.Value != nil {
-				t.Errorf("expected success and nil value: %+v, %s", gr.Value, pErr)
+			if err != nil || gr.Value != nil {
+				t.Errorf("expected success and nil value: %+v, %s", gr.Value, err)
 			}
 		}
 	}
@@ -314,13 +315,13 @@ func TestClientGetAndPutProto(t *testing.T) {
 	}
 
 	key := roachpb.Key(testUser + "/zone-config")
-	if pErr := db.Put(key, zoneConfig); pErr != nil {
-		t.Fatalf("unable to put proto: %s", pErr)
+	if err := db.Put(key, zoneConfig); err != nil {
+		t.Fatalf("unable to put proto: %s", err)
 	}
 
 	readZoneConfig := &config.ZoneConfig{}
-	if pErr := db.GetProto(key, readZoneConfig); pErr != nil {
-		t.Fatalf("unable to get proto: %s", pErr)
+	if err := db.GetProto(key, readZoneConfig); err != nil {
+		t.Fatalf("unable to get proto: %s", err)
 	}
 	if !proto.Equal(zoneConfig, readZoneConfig) {
 		t.Errorf("expected %+v, but found %+v", zoneConfig, readZoneConfig)
@@ -336,12 +337,12 @@ func TestClientGetAndPut(t *testing.T) {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
 	value := []byte("value")
-	if pErr := db.Put(testUser+"/key", value); pErr != nil {
-		t.Fatalf("unable to put value: %s", pErr)
+	if err := db.Put(testUser+"/key", value); err != nil {
+		t.Fatalf("unable to put value: %s", err)
 	}
-	gr, pErr := db.Get(testUser + "/key")
-	if pErr != nil {
-		t.Fatalf("unable to get value: %s", pErr)
+	gr, err := db.Get(testUser + "/key")
+	if err != nil {
+		t.Fatalf("unable to get value: %s", err)
 	}
 	if !bytes.Equal(value, gr.ValueBytes()) {
 		t.Errorf("expected values equal; %s != %s", value, gr.ValueBytes())
@@ -358,12 +359,12 @@ func TestClientPutInline(t *testing.T) {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
 	value := []byte("value")
-	if pErr := db.PutInline(testUser+"/key", value); pErr != nil {
-		t.Fatalf("unable to put value: %s", pErr)
+	if err := db.PutInline(testUser+"/key", value); err != nil {
+		t.Fatalf("unable to put value: %s", err)
 	}
-	gr, pErr := db.Get(testUser + "/key")
-	if pErr != nil {
-		t.Fatalf("unable to get value: %s", pErr)
+	gr, err := db.Get(testUser + "/key")
+	if err != nil {
+		t.Fatalf("unable to get value: %s", err)
 	}
 	if !bytes.Equal(value, gr.ValueBytes()) {
 		t.Errorf("expected values equal; %s != %s", value, gr.ValueBytes())
@@ -384,20 +385,20 @@ func TestClientEmptyValues(t *testing.T) {
 	defer s.Stop()
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
-	if pErr := db.Put(testUser+"/a", []byte{}); pErr != nil {
-		t.Error(pErr)
+	if err := db.Put(testUser+"/a", []byte{}); err != nil {
+		t.Error(err)
 	}
-	if gr, pErr := db.Get(testUser + "/a"); pErr != nil {
-		t.Error(pErr)
+	if gr, err := db.Get(testUser + "/a"); err != nil {
+		t.Error(err)
 	} else if bytes := gr.ValueBytes(); bytes == nil || len(bytes) != 0 {
 		t.Errorf("expected non-nil empty byte slice; got %q", bytes)
 	}
 
-	if _, pErr := db.Inc(testUser+"/b", 0); pErr != nil {
-		t.Error(pErr)
+	if _, err := db.Inc(testUser+"/b", 0); err != nil {
+		t.Error(err)
 	}
-	if gr, pErr := db.Get(testUser + "/b"); pErr != nil {
-		t.Error(pErr)
+	if gr, err := db.Get(testUser + "/b"); err != nil {
+		t.Error(err)
 	} else if gr.Value == nil {
 		t.Errorf("expected non-nil integer")
 	} else if gr.ValueInt() != 0 {
@@ -422,8 +423,8 @@ func TestClientBatch(t *testing.T) {
 			b.Inc(key, int64(i))
 		}
 
-		if pErr := db.Run(b); pErr != nil {
-			t.Error(pErr)
+		if err := db.Run(b); err != nil {
+			t.Error(err)
 		}
 
 		for i, result := range b.Results {
@@ -438,8 +439,8 @@ func TestClientBatch(t *testing.T) {
 		b := &client.Batch{}
 		b.Scan(testUser+"/key 00", testUser+"/key 05", 0)
 		b.Scan(testUser+"/key 05", testUser+"/key 10", 0)
-		if pErr := db.Run(b); pErr != nil {
-			t.Error(pErr)
+		if err := db.Run(b); err != nil {
+			t.Error(err)
 		}
 		client.CheckKVs(t, b.Results[0].Rows, keys[0], 0, keys[1], 1, keys[2], 2, keys[3], 3, keys[4], 4)
 		client.CheckKVs(t, b.Results[1].Rows, keys[5], 5, keys[6], 6, keys[7], 7, keys[8], 8, keys[9], 9)
@@ -450,8 +451,8 @@ func TestClientBatch(t *testing.T) {
 		b := &client.Batch{MaxScanResults: 7}
 		b.Scan(testUser+"/key 00", testUser+"/key 05", 0)
 		b.Scan(testUser+"/key 05", testUser+"/key 10", 0)
-		if pErr := db.Run(b); pErr != nil {
-			t.Error(pErr)
+		if err := db.Run(b); err != nil {
+			t.Error(err)
 		}
 		client.CheckKVs(t, b.Results[0].Rows, keys[0], 0, keys[1], 1, keys[2], 2, keys[3], 3, keys[4], 4)
 		client.CheckKVs(t, b.Results[1].Rows, keys[5], 5, keys[6], 6)
@@ -462,8 +463,8 @@ func TestClientBatch(t *testing.T) {
 		b := &client.Batch{MaxScanResults: 7}
 		b.Scan(testUser+"/key 05", testUser+"/key 10", 0)
 		b.Scan(testUser+"/key 00", testUser+"/key 05", 0)
-		if pErr := db.Run(b); pErr != nil {
-			t.Error(pErr)
+		if err := db.Run(b); err != nil {
+			t.Error(err)
 		}
 		client.CheckKVs(t, b.Results[0].Rows, keys[5], 5, keys[6], 6, keys[7], 7, keys[8], 8, keys[9], 9)
 		client.CheckKVs(t, b.Results[1].Rows, keys[0], 0, keys[1], 1)
@@ -474,8 +475,8 @@ func TestClientBatch(t *testing.T) {
 		b := &client.Batch{MaxScanResults: 3}
 		b.Scan(testUser+"/key 00", testUser+"/key 05", 0)
 		b.Scan(testUser+"/key 05", testUser+"/key 10", 0)
-		if pErr := db.Run(b); pErr != nil {
-			t.Error(pErr)
+		if err := db.Run(b); err != nil {
+			t.Error(err)
 		}
 		client.CheckKVs(t, b.Results[0].Rows, keys[0], 0, keys[1], 1, keys[2], 2)
 		client.CheckKVs(t, b.Results[1].Rows)
@@ -486,8 +487,8 @@ func TestClientBatch(t *testing.T) {
 		b := &client.Batch{}
 		b.ReverseScan(testUser+"/key 00", testUser+"/key 05", 0)
 		b.ReverseScan(testUser+"/key 05", testUser+"/key 10", 0)
-		if pErr := db.Run(b); pErr != nil {
-			t.Error(pErr)
+		if err := db.Run(b); err != nil {
+			t.Error(err)
 		}
 		client.CheckKVs(t, b.Results[0].Rows, keys[4], 4, keys[3], 3, keys[2], 2, keys[1], 1, keys[0], 0)
 		client.CheckKVs(t, b.Results[1].Rows, keys[9], 9, keys[8], 8, keys[7], 7, keys[6], 6, keys[5], 5)
@@ -498,8 +499,8 @@ func TestClientBatch(t *testing.T) {
 		b := &client.Batch{MaxScanResults: 7}
 		b.ReverseScan(testUser+"/key 00", testUser+"/key 05", 0)
 		b.ReverseScan(testUser+"/key 05", testUser+"/key 10", 0)
-		if pErr := db.Run(b); pErr != nil {
-			t.Error(pErr)
+		if err := db.Run(b); err != nil {
+			t.Error(err)
 		}
 		client.CheckKVs(t, b.Results[0].Rows, keys[4], 4, keys[3], 3, keys[2], 2, keys[1], 1, keys[0], 0)
 		client.CheckKVs(t, b.Results[1].Rows, keys[9], 9, keys[8], 8)
@@ -510,8 +511,8 @@ func TestClientBatch(t *testing.T) {
 		b := &client.Batch{MaxScanResults: 7}
 		b.ReverseScan(testUser+"/key 05", testUser+"/key 10", 0)
 		b.ReverseScan(testUser+"/key 00", testUser+"/key 05", 0)
-		if pErr := db.Run(b); pErr != nil {
-			t.Error(pErr)
+		if err := db.Run(b); err != nil {
+			t.Error(err)
 		}
 		client.CheckKVs(t, b.Results[0].Rows, keys[9], 9, keys[8], 8, keys[7], 7, keys[6], 6, keys[5], 5)
 		client.CheckKVs(t, b.Results[1].Rows, keys[4], 4, keys[3], 3)
@@ -522,8 +523,8 @@ func TestClientBatch(t *testing.T) {
 		b := &client.Batch{MaxScanResults: 3}
 		b.ReverseScan(testUser+"/key 00", testUser+"/key 05", 0)
 		b.ReverseScan(testUser+"/key 05", testUser+"/key 10", 0)
-		if pErr := db.Run(b); pErr != nil {
-			t.Error(pErr)
+		if err := db.Run(b); err != nil {
+			t.Error(err)
 		}
 		client.CheckKVs(t, b.Results[0].Rows, keys[4], 4, keys[3], 3, keys[2], 2)
 		client.CheckKVs(t, b.Results[1].Rows)
@@ -532,18 +533,18 @@ func TestClientBatch(t *testing.T) {
 	// Induce a non-transactional failure.
 	{
 		key := roachpb.Key("conditionalPut")
-		if pErr := db.Put(key, "hello"); pErr != nil {
-			t.Fatal(pErr)
+		if err := db.Put(key, "hello"); err != nil {
+			t.Fatal(err)
 		}
 
 		b := &client.Batch{}
 		b.CPut(key, "goodbyte", nil) // should fail
-		if pErr := db.Run(b); pErr == nil {
+		if err := db.Run(b); err == nil {
 			t.Error("unexpected success")
 		} else {
 			var foundError bool
 			for _, result := range b.Results {
-				if result.Err != nil {
+				if result.Err() != nil {
 					foundError = true
 					break
 				}
@@ -557,20 +558,20 @@ func TestClientBatch(t *testing.T) {
 	// Induce a transactional failure.
 	{
 		key := roachpb.Key("conditionalPut")
-		if pErr := db.Put(key, "hello"); pErr != nil {
-			t.Fatal(pErr)
+		if err := db.Put(key, "hello"); err != nil {
+			t.Fatal(err)
 		}
 
 		b := &client.Batch{}
 		b.CPut(key, "goodbyte", nil) // should fail
-		if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+		if err := db.Txn(func(txn *client.Txn) error {
 			return txn.Run(b)
-		}); pErr == nil {
+		}); err == nil {
 			t.Error("unexpected success")
 		} else {
 			var foundError bool
 			for _, result := range b.Results {
-				if result.Err != nil {
+				if result.Err() != nil {
 					foundError = true
 					break
 				}
@@ -603,13 +604,13 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 			// Wait until the other goroutines are running.
 			wgStart.Wait()
 
-			if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+			if err := db.Txn(func(txn *client.Txn) error {
 				txn.SetDebugName(fmt.Sprintf("test-%d", i), 0)
 
 				// Retrieve the other key.
-				gr, pErr := txn.Get(readKey)
-				if pErr != nil {
-					return pErr
+				gr, err := txn.Get(readKey)
+				if err != nil {
+					return err
 				}
 
 				otherValue := int64(0)
@@ -617,10 +618,10 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 					otherValue = gr.ValueInt()
 				}
 
-				_, pErr = txn.Inc(writeKey, 1+otherValue)
-				return pErr
-			}); pErr != nil {
-				t.Error(pErr)
+				_, err = txn.Inc(writeKey, 1+otherValue)
+				return err
+			}); err != nil {
+				t.Error(err)
 			}
 		}(i)
 	}
@@ -636,9 +637,9 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 	results := []int64(nil)
 	for i := 0; i < 2; i++ {
 		readKey := []byte(fmt.Sprintf(testUser+"/value-%d", i))
-		gr, pErr := db.Get(readKey)
-		if pErr != nil {
-			t.Fatal(pErr)
+		gr, err := db.Get(readKey)
+		if err != nil {
+			t.Fatal(err)
 		}
 		if gr.Value == nil {
 			t.Fatalf("unexpected empty key: %s=%v", readKey, gr.Value)
@@ -665,8 +666,8 @@ func TestConcurrentIncrements(t *testing.T) {
 	// Convenience loop: Crank up this number for testing this
 	// more often. It'll increase test duration though.
 	for k := 0; k < 5; k++ {
-		if pErr := db.DelRange(testUser+"/value-0", testUser+"/value-1x"); pErr != nil {
-			t.Fatalf("%d: unable to clean up: %s", k, pErr)
+		if err := db.DelRange(testUser+"/value-0", testUser+"/value-1x"); err != nil {
+			t.Fatalf("%d: unable to clean up: %s", k, err)
 		}
 		concurrentIncrements(db, t)
 	}
@@ -707,13 +708,13 @@ func TestClientPermissions(t *testing.T) {
 	value := []byte("value")
 	const matchErr = "is not allowed"
 	for tcNum, tc := range testCases {
-		pErr := tc.client.Put(tc.path, value)
-		if (pErr == nil) != tc.allowed || (!tc.allowed && !testutils.IsPError(pErr, matchErr)) {
-			t.Errorf("#%d: expected allowed=%t, got err=%s", tcNum, tc.allowed, pErr)
+		err := tc.client.Put(tc.path, value)
+		if (err == nil) != tc.allowed || (!tc.allowed && !testutils.IsError(err, matchErr)) {
+			t.Errorf("#%d: expected allowed=%t, got err=%s", tcNum, tc.allowed, err)
 		}
-		_, pErr = tc.client.Get(tc.path)
-		if (pErr == nil) != tc.allowed || (!tc.allowed && !testutils.IsPError(pErr, matchErr)) {
-			t.Errorf("#%d: expected allowed=%t, got err=%s", tcNum, tc.allowed, pErr)
+		_, err = tc.client.Get(tc.path)
+		if (err == nil) != tc.allowed || (!tc.allowed && !testutils.IsError(err, matchErr)) {
+			t.Errorf("#%d: expected allowed=%t, got err=%s", tcNum, tc.allowed, err)
 		}
 	}
 }
@@ -738,16 +739,16 @@ func TestInconsistentReads(t *testing.T) {
 	// Perform inconsistent reads through the mocked sender function.
 	{
 		key := roachpb.Key([]byte("key"))
-		if _, pErr := db.GetInconsistent(key); pErr != nil {
-			t.Fatal(pErr)
+		if _, err := db.GetInconsistent(key); err != nil {
+			t.Fatal(err)
 		}
 	}
 
 	{
 		key := roachpb.Key([]byte("key"))
 		var p roachpb.BatchRequest
-		if pErr := db.GetProtoInconsistent(key, &p); pErr != nil {
-			t.Fatal(pErr)
+		if err := db.GetProtoInconsistent(key, &p); err != nil {
+			t.Fatal(err)
 		}
 	}
 
@@ -755,8 +756,8 @@ func TestInconsistentReads(t *testing.T) {
 		key1 := roachpb.Key([]byte("key1"))
 		key2 := roachpb.Key([]byte("key2"))
 		const dontCareMaxRows = 1000
-		if _, pErr := db.ScanInconsistent(key1, key2, dontCareMaxRows); pErr != nil {
-			t.Fatal(pErr)
+		if _, err := db.ScanInconsistent(key1, key2, dontCareMaxRows); err != nil {
+			t.Fatal(err)
 		}
 	}
 
@@ -765,8 +766,8 @@ func TestInconsistentReads(t *testing.T) {
 		ba := db.NewBatch()
 		ba.ReadConsistency = roachpb.INCONSISTENT
 		ba.Get(key)
-		if pErr := db.Run(ba); pErr != nil {
-			t.Fatal(pErr)
+		if err := db.Run(ba); err != nil {
+			t.Fatal(err)
 		}
 	}
 }
@@ -779,16 +780,16 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	defer s.Stop()
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
-	if pErr := db.Put("k", "v"); pErr != nil {
-		t.Fatal(pErr)
+	if err := db.Put("k", "v"); err != nil {
+		t.Fatal(err)
 	}
 
-	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		// Set deadline to sometime in the past.
 		txn.SetDeadline(roachpb.Timestamp{WallTime: timeutil.Now().Add(-time.Second).UnixNano()})
-		_, pErr := txn.Get("k")
-		return pErr
-	}); !testutils.IsPError(pErr, "read-only txn timestamp violates deadline") {
-		t.Fatal(pErr)
+		_, err := txn.Get("k")
+		return err
+	}); !testutils.IsError(err, "read-only txn timestamp violates deadline") {
+		t.Fatal(err)
 	}
 }

--- a/client/db.go
+++ b/client/db.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"golang.org/x/net/context"
@@ -119,8 +120,9 @@ func (kv *KeyValue) ValueProto(msg proto.Message) error {
 // etc).
 type Result struct {
 	calls int
-	// Err contains any error encountered when performing the operation.
-	Err *roachpb.Error
+	// PErr contains any error encountered when performing the operation.
+	// Code that doesn't need a pErr (so, most code) should use Err() instead.
+	PErr *roachpb.Error
 	// Rows contains the key/value pairs for the operation. The number of rows
 	// returned varies by operation. For Get, Put, CPut, Inc and Del the number
 	// of rows returned is the number of keys operated on. For Scan the number of
@@ -132,9 +134,14 @@ type Result struct {
 	Keys []roachpb.Key
 }
 
+// Err returns the error that encountered when performing the operation, if any.
+func (r Result) Err() error {
+	return r.PErr.GoError()
+}
+
 func (r Result) String() string {
-	if r.Err != nil {
-		return r.Err.String()
+	if r.Err() != nil {
+		return r.Err().Error()
 	}
 	var buf bytes.Buffer
 	for i, row := range r.Rows {
@@ -192,14 +199,14 @@ func (db *DB) NewBatch() *Batch {
 //   // string(r.Key) == "a"
 //
 // key can be either a byte slice or a string.
-func (db *DB) Get(key interface{}) (KeyValue, *roachpb.Error) {
+func (db *DB) Get(key interface{}) (KeyValue, error) {
 	b := db.NewBatch()
 	b.Get(key)
 	return runOneRow(db, b)
 }
 
 // GetInconsistent is Get with an inconsistent read.
-func (db *DB) GetInconsistent(key interface{}) (KeyValue, *roachpb.Error) {
+func (db *DB) GetInconsistent(key interface{}) (KeyValue, error) {
 	b := db.NewBatch()
 	b.ReadConsistency = roachpb.INCONSISTENT
 	b.Get(key)
@@ -210,32 +217,32 @@ func (db *DB) GetInconsistent(key interface{}) (KeyValue, *roachpb.Error) {
 // message.
 //
 // key can be either a byte slice or a string.
-func (db *DB) GetProto(key interface{}, msg proto.Message) *roachpb.Error {
-	r, pErr := db.Get(key)
-	if pErr != nil {
-		return pErr
+func (db *DB) GetProto(key interface{}, msg proto.Message) error {
+	r, err := db.Get(key)
+	if err != nil {
+		return err
 	}
-	return roachpb.NewError(r.ValueProto(msg))
+	return r.ValueProto(msg)
 }
 
 // GetProtoInconsistent is GetProto with an inconsistent read.
-func (db *DB) GetProtoInconsistent(key interface{}, msg proto.Message) *roachpb.Error {
-	r, pErr := db.GetInconsistent(key)
-	if pErr != nil {
-		return pErr
+func (db *DB) GetProtoInconsistent(key interface{}, msg proto.Message) error {
+	r, err := db.GetInconsistent(key)
+	if err != nil {
+		return err
 	}
-	return roachpb.NewError(r.ValueProto(msg))
+	return r.ValueProto(msg)
 }
 
 // Put sets the value for a key.
 //
 // key can be either a byte slice or a string. value can be any key type, a
 // proto.Message or any Go primitive type (bool, int, etc).
-func (db *DB) Put(key, value interface{}) *roachpb.Error {
+func (db *DB) Put(key, value interface{}) error {
 	b := db.NewBatch()
 	b.Put(key, value)
-	_, pErr := runOneResult(db, b)
-	return pErr
+	_, err := runOneResult(db, b)
+	return err
 }
 
 // PutInline sets the value for a key, but does not maintain
@@ -245,11 +252,11 @@ func (db *DB) Put(key, value interface{}) *roachpb.Error {
 //
 // key can be either a byte slice or a string. value can be any key type, a
 // proto.Message or any Go primitive type (bool, int, etc).
-func (db *DB) PutInline(key, value interface{}) *roachpb.Error {
+func (db *DB) PutInline(key, value interface{}) error {
 	b := db.NewBatch()
 	b.PutInline(key, value)
-	_, pErr := runOneResult(db, b)
-	return pErr
+	_, err := runOneResult(db, b)
+	return err
 }
 
 // CPut conditionally sets the value for a key if the existing value is equal
@@ -259,11 +266,11 @@ func (db *DB) PutInline(key, value interface{}) *roachpb.Error {
 //
 // key can be either a byte slice or a string. value can be any key type, a
 // proto.Message or any Go primitive type (bool, int, etc).
-func (db *DB) CPut(key, value, expValue interface{}) *roachpb.Error {
+func (db *DB) CPut(key, value, expValue interface{}) error {
 	b := db.NewBatch()
 	b.CPut(key, value, expValue)
-	_, pErr := runOneResult(db, b)
-	return pErr
+	_, err := runOneResult(db, b)
+	return err
 }
 
 // InitPut sets the first value for a key to value. An error is reported if a
@@ -272,11 +279,11 @@ func (db *DB) CPut(key, value, expValue interface{}) *roachpb.Error {
 // key can be either a byte slice or a string. value can be any key type, a
 // proto.Message or any Go primitive type (bool, int, etc). It is illegal to
 // set value to nil.
-func (db *DB) InitPut(key, value interface{}) *roachpb.Error {
+func (db *DB) InitPut(key, value interface{}) error {
 	b := db.NewBatch()
 	b.InitPut(key, value)
-	_, pErr := runOneResult(db, b)
-	return pErr
+	_, err := runOneResult(db, b)
+	return err
 }
 
 // Inc increments the integer value at key. If the key does not exist it will
@@ -284,7 +291,7 @@ func (db *DB) InitPut(key, value interface{}) *roachpb.Error {
 // key exists but was set using Put or CPut an error will be returned.
 //
 // key can be either a byte slice or a string.
-func (db *DB) Inc(key interface{}, value int64) (KeyValue, *roachpb.Error) {
+func (db *DB) Inc(key interface{}, value int64) (KeyValue, error) {
 	b := db.NewBatch()
 	b.Inc(key, value)
 	return runOneRow(db, b)
@@ -295,7 +302,7 @@ func (db *DB) scan(
 	maxRows int64,
 	isReverse bool,
 	readConsistency roachpb.ReadConsistencyType,
-) ([]KeyValue, *roachpb.Error) {
+) ([]KeyValue, error) {
 	b := db.NewBatch()
 	b.ReadConsistency = readConsistency
 	if !isReverse {
@@ -303,8 +310,8 @@ func (db *DB) scan(
 	} else {
 		b.ReverseScan(begin, end, maxRows)
 	}
-	r, pErr := runOneResult(db, b)
-	return r.Rows, pErr
+	r, err := runOneResult(db, b)
+	return r.Rows, err
 }
 
 // Scan retrieves the rows between begin (inclusive) and end (exclusive) in
@@ -313,12 +320,12 @@ func (db *DB) scan(
 // The returned []KeyValue will contain up to maxRows elements.
 //
 // key can be either a byte slice or a string.
-func (db *DB) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, *roachpb.Error) {
+func (db *DB) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
 	return db.scan(begin, end, maxRows, false, roachpb.CONSISTENT)
 }
 
 // ScanInconsistent is Scan with an inconsistent read.
-func (db *DB) ScanInconsistent(begin, end interface{}, maxRows int64) ([]KeyValue, *roachpb.Error) {
+func (db *DB) ScanInconsistent(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
 	return db.scan(begin, end, maxRows, false, roachpb.INCONSISTENT)
 }
 
@@ -328,18 +335,18 @@ func (db *DB) ScanInconsistent(begin, end interface{}, maxRows int64) ([]KeyValu
 // The returned []KeyValue will contain up to maxRows elements.
 //
 // key can be either a byte slice or a string.
-func (db *DB) ReverseScan(begin, end interface{}, maxRows int64) ([]KeyValue, *roachpb.Error) {
+func (db *DB) ReverseScan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
 	return db.scan(begin, end, maxRows, true, roachpb.CONSISTENT)
 }
 
 // Del deletes one or more keys.
 //
 // key can be either a byte slice or a string.
-func (db *DB) Del(keys ...interface{}) *roachpb.Error {
+func (db *DB) Del(keys ...interface{}) error {
 	b := db.NewBatch()
 	b.Del(keys...)
-	_, pErr := runOneResult(db, b)
-	return pErr
+	_, err := runOneResult(db, b)
+	return err
 }
 
 // DelRange deletes the rows between begin (inclusive) and end (exclusive).
@@ -347,11 +354,11 @@ func (db *DB) Del(keys ...interface{}) *roachpb.Error {
 // TODO(pmattis): Perhaps the result should return which rows were deleted.
 //
 // key can be either a byte slice or a string.
-func (db *DB) DelRange(begin, end interface{}) *roachpb.Error {
+func (db *DB) DelRange(begin, end interface{}) error {
 	b := db.NewBatch()
 	b.DelRange(begin, end, false)
-	_, pErr := runOneResult(db, b)
-	return pErr
+	_, err := runOneResult(db, b)
+	return err
 }
 
 // AdminMerge merges the range containing key and the subsequent
@@ -360,37 +367,41 @@ func (db *DB) DelRange(begin, end interface{}) *roachpb.Error {
 // and the subsequent range will no longer exist.
 //
 // key can be either a byte slice or a string.
-func (db *DB) AdminMerge(key interface{}) *roachpb.Error {
+func (db *DB) AdminMerge(key interface{}) error {
 	b := db.NewBatch()
 	b.adminMerge(key)
-	_, pErr := runOneResult(db, b)
-	return pErr
+	_, err := runOneResult(db, b)
+	return err
 }
 
 // AdminSplit splits the range at splitkey.
 //
 // key can be either a byte slice or a string.
-func (db *DB) AdminSplit(splitKey interface{}) *roachpb.Error {
+func (db *DB) AdminSplit(splitKey interface{}) error {
 	b := db.NewBatch()
 	b.adminSplit(splitKey)
-	_, pErr := runOneResult(db, b)
-	return pErr
+	_, err := runOneResult(db, b)
+	return err
 }
 
 // CheckConsistency runs a consistency check on all the ranges containing
 // the key span. It logs a diff of all the keys that are inconsistent
 // when withDiff is set to true.
-func (db *DB) CheckConsistency(begin, end interface{}, withDiff bool) *roachpb.Error {
+func (db *DB) CheckConsistency(begin, end interface{}, withDiff bool) error {
 	b := db.NewBatch()
 	b.CheckConsistency(begin, end, withDiff)
-	_, pErr := runOneResult(db, b)
-	return pErr
+	_, err := runOneResult(db, b)
+	return err
 }
 
 // sendAndFill is a helper which sends the given batch and fills its results,
 // returning the appropriate error which is either from the first failing call,
 // or an "internal" error.
-func sendAndFill(send func(int64, roachpb.ReadConsistencyType, ...roachpb.Request) (*roachpb.BatchResponse, *roachpb.Error), b *Batch) (*roachpb.BatchResponse, *roachpb.Error) {
+func sendAndFill(
+	send func(int64, roachpb.ReadConsistencyType, ...roachpb.Request,
+	) (*roachpb.BatchResponse, *roachpb.Error),
+	b *Batch,
+) (*roachpb.BatchResponse, error) {
 	// Errors here will be attached to the results, so we will get them from
 	// the call to fillResults in the regular case in which an individual call
 	// fails. But send() also returns its own errors, so there's some dancing
@@ -400,36 +411,24 @@ func sendAndFill(send func(int64, roachpb.ReadConsistencyType, ...roachpb.Reques
 	if pErr != nil {
 		// Discard errors from fillResults.
 		_ = b.fillResults(nil, pErr)
-		return nil, pErr
+		return nil, pErr.GoError()
 	}
-	pErr = b.fillResults(br, nil)
-
-	if pErr != nil {
-		return nil, pErr
+	if err := b.fillResults(br, nil); err != nil {
+		return nil, err
 	}
 	return br, nil
 }
 
-// Run executes the operations queued up within a batch. Before executing any
-// of the operations the batch is first checked to see if there were any errors
-// during its construction (e.g. failure to marshal a proto message).
-//
-// The operations within a batch are run in parallel and the order is
-// non-deterministic. It is an unspecified behavior to modify and retrieve the
-// same key within a batch.
-//
-// Upon completion, Batch.Results will contain the results for each
-// operation. The order of the results matches the order the operations were
-// added to the batch.
-func (db *DB) Run(b *Batch) *roachpb.Error {
-	_, pErr := db.RunWithResponse(b)
-	return pErr
+// Run implements Runner.Run(). See comments there.
+func (db *DB) Run(b *Batch) error {
+	_, err := db.RunWithResponse(b)
+	return err
 }
 
 // RunWithResponse is a version of Run that returns the BatchResponse.
-func (db *DB) RunWithResponse(b *Batch) (*roachpb.BatchResponse, *roachpb.Error) {
-	if pErr := b.prepare(); pErr != nil {
-		return nil, pErr
+func (db *DB) RunWithResponse(b *Batch) (*roachpb.BatchResponse, error) {
+	if err := b.prepare(); err != nil {
+		return nil, err
 	}
 	return sendAndFill(db.send, b)
 }
@@ -441,19 +440,25 @@ func (db *DB) RunWithResponse(b *Batch) (*roachpb.BatchResponse, *roachpb.Error)
 // cause problems in the event it must be run more than once.
 //
 // If you need more control over how the txn is executed, check out txn.Exec().
-func (db *DB) Txn(retryable func(txn *Txn) *roachpb.Error) *roachpb.Error {
+func (db *DB) Txn(retryable func(txn *Txn) error) error {
 	// TODO(dan): This context should, at longest, live for the lifetime of this
 	// method. Add a defered cancel.
 	txn := NewTxn(context.TODO(), *db)
 	txn.SetDebugName("", 1)
-	pErr := txn.Exec(TxnExecOptions{AutoRetry: true, AutoCommit: true},
-		func(txn *Txn, _ *TxnExecOptions) *roachpb.Error {
+	err := txn.Exec(TxnExecOptions{AutoRetry: true, AutoCommit: true},
+		func(txn *Txn, _ *TxnExecOptions) error {
 			return retryable(txn)
 		})
-	if pErr != nil {
-		txn.CleanupOnError(pErr)
+	if err != nil {
+		txn.CleanupOnError(err)
 	}
-	return pErr
+	// Terminate RetryableTxnError here, so it doesn't cause a higher-level txn to
+	// be retried. We don't do this in any of the other functions in DB; I guess
+	// we should.
+	if _, ok := err.(*roachpb.RetryableTxnError); ok {
+		return errors.New(err.Error())
+	}
+	return err
 }
 
 // send runs the specified calls synchronously in a single batch and returns
@@ -496,21 +501,38 @@ func (db *DB) send(maxScanResults int64, readConsistency roachpb.ReadConsistency
 
 // Runner only exports the Run method on a batch of operations.
 type Runner interface {
-	Run(b *Batch) *roachpb.Error
+	// Run executes the operations queued up within a batch. Before executing any
+	// of the operations the batch is first checked to see if there were any errors
+	// during its construction (e.g. failure to marshal a proto message).
+	//
+	// The operations within a batch are run in parallel and the order is
+	// non-deterministic. It is an unspecified behavior to modify and retrieve the
+	// same key within a batch.
+	//
+	// Upon completion, Batch.Results will contain the results for each
+	// operation. The order of the results matches the order the operations were
+	// added to the batch.
+	Run(b *Batch) error
 }
 
-func runOneResult(r Runner, b *Batch) (Result, *roachpb.Error) {
-	if pErr := r.Run(b); pErr != nil {
-		return Result{Err: pErr}, pErr
+func runOneResult(r Runner, b *Batch) (Result, error) {
+	if err := r.Run(b); err != nil {
+		if len(b.Results) > 0 {
+			return b.Results[0], b.Results[0].Err()
+		}
+		return Result{PErr: roachpb.NewError(err)}, err
 	}
 	res := b.Results[0]
-	return res, res.Err
+	if res.Err() != nil {
+		panic("r.Run() succeeded even through the result has an error")
+	}
+	return res, nil
 }
 
-func runOneRow(r Runner, b *Batch) (KeyValue, *roachpb.Error) {
-	if pErr := r.Run(b); pErr != nil {
-		return KeyValue{}, pErr
+func runOneRow(r Runner, b *Batch) (KeyValue, error) {
+	res, err := runOneResult(r, b)
+	if err != nil {
+		return KeyValue{}, err
 	}
-	res := b.Results[0]
-	return res.Rows[0], res.Err
+	return res.Rows[0], nil
 }

--- a/client/db.go
+++ b/client/db.go
@@ -120,7 +120,7 @@ func (kv *KeyValue) ValueProto(msg proto.Message) error {
 type Result struct {
 	calls int
 	// Err contains any error encountered when performing the operation.
-	PErr *roachpb.Error
+	Err *roachpb.Error
 	// Rows contains the key/value pairs for the operation. The number of rows
 	// returned varies by operation. For Get, Put, CPut, Inc and Del the number
 	// of rows returned is the number of keys operated on. For Scan the number of
@@ -133,8 +133,8 @@ type Result struct {
 }
 
 func (r Result) String() string {
-	if r.PErr != nil {
-		return r.PErr.String()
+	if r.Err != nil {
+		return r.Err.String()
 	}
 	var buf bytes.Buffer
 	for i, row := range r.Rows {
@@ -501,10 +501,10 @@ type Runner interface {
 
 func runOneResult(r Runner, b *Batch) (Result, *roachpb.Error) {
 	if pErr := r.Run(b); pErr != nil {
-		return Result{PErr: pErr}, pErr
+		return Result{Err: pErr}, pErr
 	}
 	res := b.Results[0]
-	return res, res.PErr
+	return res, res.Err
 }
 
 func runOneRow(r Runner, b *Batch) (KeyValue, *roachpb.Error) {
@@ -512,5 +512,5 @@ func runOneRow(r Runner, b *Batch) (KeyValue, *roachpb.Error) {
 		return KeyValue{}, pErr
 	}
 	res := b.Results[0]
-	return res.Rows[0], res.PErr
+	return res.Rows[0], res.Err
 }

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -23,10 +23,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/server"
-	"github.com/cockroachdb/cockroach/testutils"
-	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/caller"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -41,9 +38,9 @@ func ExampleDB_Get() {
 	s, db := setup()
 	defer s.Stop()
 
-	result, pErr := db.Get("aa")
-	if pErr != nil {
-		panic(pErr)
+	result, err := db.Get("aa")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
@@ -55,12 +52,12 @@ func ExampleDB_Put() {
 	s, db := setup()
 	defer s.Stop()
 
-	if pErr := db.Put("aa", "1"); pErr != nil {
-		panic(pErr)
+	if err := db.Put("aa", "1"); err != nil {
+		panic(err)
 	}
-	result, pErr := db.Get("aa")
-	if pErr != nil {
-		panic(pErr)
+	result, err := db.Get("aa")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
@@ -72,41 +69,41 @@ func ExampleDB_CPut() {
 	s, db := setup()
 	defer s.Stop()
 
-	if pErr := db.Put("aa", "1"); pErr != nil {
-		panic(pErr)
+	if err := db.Put("aa", "1"); err != nil {
+		panic(err)
 	}
-	if pErr := db.CPut("aa", "2", "1"); pErr != nil {
-		panic(pErr)
+	if err := db.CPut("aa", "2", "1"); err != nil {
+		panic(err)
 	}
-	result, pErr := db.Get("aa")
-	if pErr != nil {
-		panic(pErr)
-	}
-	fmt.Printf("aa=%s\n", result.ValueBytes())
-
-	if pErr = db.CPut("aa", "3", "1"); pErr == nil {
-		panic("expected pError from conditional put")
-	}
-	result, pErr = db.Get("aa")
-	if pErr != nil {
-		panic(pErr)
+	result, err := db.Get("aa")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
-	if pErr = db.CPut("bb", "4", "1"); pErr == nil {
+	if err = db.CPut("aa", "3", "1"); err == nil {
 		panic("expected error from conditional put")
 	}
-	result, pErr = db.Get("bb")
-	if pErr != nil {
-		panic(pErr)
+	result, err = db.Get("aa")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("aa=%s\n", result.ValueBytes())
+
+	if err = db.CPut("bb", "4", "1"); err == nil {
+		panic("expected error from conditional put")
+	}
+	result, err = db.Get("bb")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("bb=%s\n", result.ValueBytes())
-	if pErr = db.CPut("bb", "4", nil); pErr != nil {
-		panic(pErr)
+	if err = db.CPut("bb", "4", nil); err != nil {
+		panic(err)
 	}
-	result, pErr = db.Get("bb")
-	if pErr != nil {
-		panic(pErr)
+	result, err = db.Get("bb")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("bb=%s\n", result.ValueBytes())
 
@@ -121,18 +118,18 @@ func ExampleDB_InitPut() {
 	s, db := setup()
 	defer s.Stop()
 
-	if pErr := db.InitPut("aa", "1"); pErr != nil {
-		panic(pErr)
+	if err := db.InitPut("aa", "1"); err != nil {
+		panic(err)
 	}
-	if pErr := db.InitPut("aa", "1"); pErr != nil {
-		panic(pErr)
+	if err := db.InitPut("aa", "1"); err != nil {
+		panic(err)
 	}
-	if pErr := db.InitPut("aa", "2"); pErr == nil {
+	if err := db.InitPut("aa", "2"); err == nil {
 		panic("expected error from init put")
 	}
-	result, pErr := db.Get("aa")
-	if pErr != nil {
-		panic(pErr)
+	result, err := db.Get("aa")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
@@ -144,12 +141,12 @@ func ExampleDB_Inc() {
 	s, db := setup()
 	defer s.Stop()
 
-	if _, pErr := db.Inc("aa", 100); pErr != nil {
-		panic(pErr)
+	if _, err := db.Inc("aa", 100); err != nil {
+		panic(err)
 	}
-	result, pErr := db.Get("aa")
-	if pErr != nil {
-		panic(pErr)
+	result, err := db.Get("aa")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("aa=%d\n", result.ValueInt())
 
@@ -164,8 +161,8 @@ func ExampleBatch() {
 	b := &client.Batch{}
 	b.Get("aa")
 	b.Put("bb", "2")
-	if pErr := db.Run(b); pErr != nil {
-		panic(pErr)
+	if err := db.Run(b); err != nil {
+		panic(err)
 	}
 	for _, result := range b.Results {
 		for _, row := range result.Rows {
@@ -186,12 +183,12 @@ func ExampleDB_Scan() {
 	b.Put("aa", "1")
 	b.Put("ab", "2")
 	b.Put("bb", "3")
-	if pErr := db.Run(b); pErr != nil {
-		panic(pErr)
+	if err := db.Run(b); err != nil {
+		panic(err)
 	}
-	rows, pErr := db.Scan("a", "b", 100)
-	if pErr != nil {
-		panic(pErr)
+	rows, err := db.Scan("a", "b", 100)
+	if err != nil {
+		panic(err)
 	}
 	for i, row := range rows {
 		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())
@@ -210,12 +207,12 @@ func ExampleDB_ReverseScan() {
 	b.Put("aa", "1")
 	b.Put("ab", "2")
 	b.Put("bb", "3")
-	if pErr := db.Run(b); pErr != nil {
-		panic(pErr)
+	if err := db.Run(b); err != nil {
+		panic(err)
 	}
-	rows, pErr := db.ReverseScan("ab", "c", 100)
-	if pErr != nil {
-		panic(pErr)
+	rows, err := db.ReverseScan("ab", "c", 100)
+	if err != nil {
+		panic(err)
 	}
 	for i, row := range rows {
 		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())
@@ -234,15 +231,15 @@ func ExampleDB_Del() {
 	b.Put("aa", "1")
 	b.Put("ab", "2")
 	b.Put("ac", "3")
-	if pErr := db.Run(b); pErr != nil {
-		panic(pErr)
+	if err := db.Run(b); err != nil {
+		panic(err)
 	}
-	if pErr := db.Del("ab"); pErr != nil {
-		panic(pErr)
+	if err := db.Del("ab"); err != nil {
+		panic(err)
 	}
-	rows, pErr := db.Scan("a", "b", 100)
-	if pErr != nil {
-		panic(pErr)
+	rows, err := db.Scan("a", "b", 100)
+	if err != nil {
+		panic(err)
 	}
 	for i, row := range rows {
 		fmt.Printf("%d: %s=%s\n", i, row.Key, row.ValueBytes())
@@ -257,21 +254,21 @@ func ExampleTxn_Commit() {
 	s, db := setup()
 	defer s.Stop()
 
-	pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	err := db.Txn(func(txn *client.Txn) error {
 		b := txn.NewBatch()
 		b.Put("aa", "1")
 		b.Put("ab", "2")
 		return txn.CommitInBatch(b)
 	})
-	if pErr != nil {
-		panic(pErr)
+	if err != nil {
+		panic(err)
 	}
 
 	b := &client.Batch{}
 	b.Get("aa")
 	b.Get("ab")
-	if pErr := db.Run(b); pErr != nil {
-		panic(pErr)
+	if err := db.Run(b); err != nil {
+		panic(err)
 	}
 	for i, result := range b.Results {
 		for j, row := range result.Rows {
@@ -288,18 +285,18 @@ func ExampleDB_Put_insecure() {
 	s := &server.TestServer{}
 	s.Ctx = server.NewTestContext()
 	s.Ctx.Insecure = true
-	if pErr := s.Start(); pErr != nil {
-		log.Fatalf("Could not start server: %v", pErr)
+	if err := s.Start(); err != nil {
+		log.Fatalf("Could not start server: %v", err)
 	}
 	defer s.Stop()
 
 	db := s.DB()
-	if pErr := db.Put("aa", "1"); pErr != nil {
-		panic(pErr)
+	if err := db.Put("aa", "1"); err != nil {
+		panic(err)
 	}
-	result, pErr := db.Get("aa")
-	if pErr != nil {
-		panic(pErr)
+	result, err := db.Get("aa")
+	if err != nil {
+		panic(err)
 	}
 	fmt.Printf("aa=%s\n", result.ValueBytes())
 
@@ -313,13 +310,13 @@ func TestDebugName(t *testing.T) {
 	defer s.Stop()
 
 	file, _, _ := caller.Lookup(0)
-	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		if !strings.HasPrefix(txn.DebugName(), file+":") {
 			t.Fatalf("expected \"%s\" to have the prefix \"%s:\"", txn.DebugName(), file)
 		}
 		return nil
-	}); pErr != nil {
-		t.Errorf("txn failed: %s", pErr)
+	}); err != nil {
+		t.Errorf("txn failed: %s", err)
 	}
 }
 
@@ -403,35 +400,5 @@ func TestCommonMethods(t *testing.T) {
 				}
 			}
 		}
-	}
-}
-
-// Verifies that an inner transaction in a nested transaction strips the transaction
-// information in its error when propagating it to an other transaction.
-func TestNestedTransaction(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	s, db := setup()
-	defer s.Stop()
-
-	pErr := db.Txn(func(txn1 *client.Txn) *roachpb.Error {
-		if pErr := txn1.Put("a", "1"); pErr != nil {
-			t.Fatalf("unexpected put error: %s", pErr)
-		}
-		iPErr := db.Txn(func(txn2 *client.Txn) *roachpb.Error {
-			txnProto := roachpb.NewTransaction("test", roachpb.Key("a"), 1, roachpb.SERIALIZABLE, roachpb.Timestamp{}, 0)
-			return roachpb.NewErrorWithTxn(util.Errorf("inner txn error"), txnProto)
-		})
-
-		if iPErr.GetTxn() != nil {
-			t.Errorf("error txn must be stripped: %s", iPErr)
-		}
-		return iPErr
-
-	})
-	if pErr == nil {
-		t.Fatal("unexpected success of txn")
-	}
-	if !testutils.IsPError(pErr, "inner txn error") {
-		t.Errorf("unexpected failure: %s", pErr)
 	}
 }

--- a/client/txn.go
+++ b/client/txn.go
@@ -17,6 +17,7 @@
 package client
 
 import (
+	"errors"
 	"strconv"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/tracing"
+	"github.com/cockroachdb/cockroach/util/uuid"
 	"github.com/gogo/protobuf/proto"
 	basictracer "github.com/opentracing/basictracer-go"
 )
@@ -222,7 +224,7 @@ func (txn *Txn) NewBatch() *Batch {
 //   // string(r.Key) == "a"
 //
 // key can be either a byte slice or a string.
-func (txn *Txn) Get(key interface{}) (KeyValue, *roachpb.Error) {
+func (txn *Txn) Get(key interface{}) (KeyValue, error) {
 	b := txn.NewBatch()
 	b.Get(key)
 	return runOneRow(txn, b)
@@ -232,23 +234,23 @@ func (txn *Txn) Get(key interface{}) (KeyValue, *roachpb.Error) {
 // message.
 //
 // key can be either a byte slice or a string.
-func (txn *Txn) GetProto(key interface{}, msg proto.Message) *roachpb.Error {
-	r, pErr := txn.Get(key)
-	if pErr != nil {
-		return pErr
+func (txn *Txn) GetProto(key interface{}, msg proto.Message) error {
+	r, err := txn.Get(key)
+	if err != nil {
+		return err
 	}
-	return roachpb.NewError(r.ValueProto(msg))
+	return r.ValueProto(msg)
 }
 
 // Put sets the value for a key
 //
 // key can be either a byte slice or a string. value can be any key type, a
 // proto.Message or any Go primitive type (bool, int, etc).
-func (txn *Txn) Put(key, value interface{}) *roachpb.Error {
+func (txn *Txn) Put(key, value interface{}) error {
 	b := txn.NewBatch()
 	b.Put(key, value)
-	_, pErr := runOneResult(txn, b)
-	return pErr
+	_, err := runOneResult(txn, b)
+	return err
 }
 
 // CPut conditionally sets the value for a key if the existing value is equal
@@ -258,11 +260,11 @@ func (txn *Txn) Put(key, value interface{}) *roachpb.Error {
 //
 // key can be either a byte slice or a string. value can be any key type, a
 // proto.Message or any Go primitive type (bool, int, etc).
-func (txn *Txn) CPut(key, value, expValue interface{}) *roachpb.Error {
+func (txn *Txn) CPut(key, value, expValue interface{}) error {
 	b := txn.NewBatch()
 	b.CPut(key, value, expValue)
-	_, pErr := runOneResult(txn, b)
-	return pErr
+	_, err := runOneResult(txn, b)
+	return err
 }
 
 // InitPut sets the first value for a key to value. An error is reported if a
@@ -271,11 +273,11 @@ func (txn *Txn) CPut(key, value, expValue interface{}) *roachpb.Error {
 // key can be either a byte slice or a string. value can be any key type, a
 // proto.Message or any Go primitive type (bool, int, etc). It is illegal to
 // set value to nil.
-func (txn *Txn) InitPut(key, value interface{}) *roachpb.Error {
+func (txn *Txn) InitPut(key, value interface{}) error {
 	b := txn.NewBatch()
 	b.InitPut(key, value)
-	_, pErr := runOneResult(txn, b)
-	return pErr
+	_, err := runOneResult(txn, b)
+	return err
 }
 
 // Inc increments the integer value at key. If the key does not exist it will
@@ -286,21 +288,21 @@ func (txn *Txn) InitPut(key, value interface{}) *roachpb.Error {
 // success or failure.
 //
 // key can be either a byte slice or a string.
-func (txn *Txn) Inc(key interface{}, value int64) (KeyValue, *roachpb.Error) {
+func (txn *Txn) Inc(key interface{}, value int64) (KeyValue, error) {
 	b := txn.NewBatch()
 	b.Inc(key, value)
 	return runOneRow(txn, b)
 }
 
-func (txn *Txn) scan(begin, end interface{}, maxRows int64, isReverse bool) ([]KeyValue, *roachpb.Error) {
+func (txn *Txn) scan(begin, end interface{}, maxRows int64, isReverse bool) ([]KeyValue, error) {
 	b := txn.NewBatch()
 	if !isReverse {
 		b.Scan(begin, end, maxRows)
 	} else {
 		b.ReverseScan(begin, end, maxRows)
 	}
-	r, pErr := runOneResult(txn, b)
-	return r.Rows, pErr
+	r, err := runOneResult(txn, b)
+	return r.Rows, err
 }
 
 // Scan retrieves the rows between begin (inclusive) and end (exclusive) in
@@ -309,7 +311,7 @@ func (txn *Txn) scan(begin, end interface{}, maxRows int64, isReverse bool) ([]K
 // The returned []KeyValue will contain up to maxRows elements.
 //
 // key can be either a byte slice or a string.
-func (txn *Txn) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, *roachpb.Error) {
+func (txn *Txn) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
 	return txn.scan(begin, end, maxRows, false)
 }
 
@@ -319,7 +321,7 @@ func (txn *Txn) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, *roachp
 // The returned []KeyValue will contain up to maxRows elements.
 //
 // key can be either a byte slice or a string.
-func (txn *Txn) ReverseScan(begin, end interface{}, maxRows int64) ([]KeyValue, *roachpb.Error) {
+func (txn *Txn) ReverseScan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
 	return txn.scan(begin, end, maxRows, true)
 }
 
@@ -330,11 +332,11 @@ var _ = (*Txn)(nil).ReverseScan
 // Del deletes one or more keys.
 //
 // key can be either a byte slice or a string.
-func (txn *Txn) Del(keys ...interface{}) *roachpb.Error {
+func (txn *Txn) Del(keys ...interface{}) error {
 	b := txn.NewBatch()
 	b.Del(keys...)
-	_, pErr := runOneResult(txn, b)
-	return pErr
+	_, err := runOneResult(txn, b)
+	return err
 }
 
 // DelRange deletes the rows between begin (inclusive) and end (exclusive).
@@ -343,62 +345,52 @@ func (txn *Txn) Del(keys ...interface{}) *roachpb.Error {
 // or failure.
 //
 // key can be either a byte slice or a string.
-func (txn *Txn) DelRange(begin, end interface{}) *roachpb.Error {
+func (txn *Txn) DelRange(begin, end interface{}) error {
 	b := txn.NewBatch()
 	b.DelRange(begin, end, false)
-	_, pErr := runOneResult(txn, b)
-	return pErr
+	_, err := runOneResult(txn, b)
+	return err
 }
 
-// Run executes the operations queued up within a batch. Before executing any
-// of the operations the batch is first checked to see if there were any errors
-// during its construction (e.g. failure to marshal a proto message).
-//
-// The operations within a batch are run in parallel and the order is
-// non-deterministic. It is an unspecified behavior to modify and retrieve the
-// same key within a batch.
-//
-// Upon completion, Batch.Results will contain the results for each
-// operation. The order of the results matches the order the operations were
-// added to the batch.
-func (txn *Txn) Run(b *Batch) *roachpb.Error {
-	_, pErr := txn.RunWithResponse(b)
-	return pErr
+// Run implements Runner.Run(). See comments there.
+func (txn *Txn) Run(b *Batch) error {
+	_, err := txn.RunWithResponse(b)
+	return err
 }
 
 // RunWithResponse is a version of Run that returns the BatchResponse.
-func (txn *Txn) RunWithResponse(b *Batch) (*roachpb.BatchResponse, *roachpb.Error) {
+func (txn *Txn) RunWithResponse(b *Batch) (*roachpb.BatchResponse, error) {
 	tracing.AnnotateTrace()
 	defer tracing.AnnotateTrace()
 
-	if pErr := b.prepare(); pErr != nil {
-		return nil, pErr
+	if err := b.prepare(); err != nil {
+		return nil, err
 	}
 	return sendAndFill(txn.send, b)
 }
 
-func (txn *Txn) commit() *roachpb.Error {
-	pErr := txn.sendEndTxnReq(true /* commit */, txn.deadline)
-	if pErr == nil {
+func (txn *Txn) commit() error {
+	err := txn.sendEndTxnReq(true /* commit */, txn.deadline)
+	if err == nil {
 		txn.finalized = true
 	}
-	return pErr
+	return err
 }
 
 // CleanupOnError cleans up the transaction as a result of an error.
-func (txn *Txn) CleanupOnError(pErr *roachpb.Error) {
-	if pErr == nil {
+func (txn *Txn) CleanupOnError(err error) {
+	if err == nil {
 		panic("no error")
 	}
 	if replyErr := txn.Rollback(); replyErr != nil {
-		log.Errorf("failure aborting transaction: %s; abort caused by: %s", replyErr, pErr)
+		log.Errorf("failure aborting transaction: %s; abort caused by: %s", replyErr, err)
 	}
 }
 
 // Commit is the same as CommitOrCleanup but will not attempt to clean
 // up on failure. This can be used when the caller is prepared to do proper
 // cleanup.
-func (txn *Txn) Commit() *roachpb.Error {
+func (txn *Txn) Commit() error {
 	return txn.commit()
 }
 
@@ -410,38 +402,38 @@ func (txn *Txn) Commit() *roachpb.Error {
 // If the command completes successfully, the txn is considered finalized. On
 // error, no attempt is made to clean up the (possibly still pending)
 // transaction.
-func (txn *Txn) CommitInBatch(b *Batch) *roachpb.Error {
-	_, pErr := txn.CommitInBatchWithResponse(b)
-	return pErr
+func (txn *Txn) CommitInBatch(b *Batch) error {
+	_, err := txn.CommitInBatchWithResponse(b)
+	return err
 }
 
 // CommitInBatchWithResponse is a version of CommitInBatch that returns the
 // BatchResponse.
-func (txn *Txn) CommitInBatchWithResponse(b *Batch) (*roachpb.BatchResponse, *roachpb.Error) {
+func (txn *Txn) CommitInBatchWithResponse(b *Batch) (*roachpb.BatchResponse, error) {
 	if txn != b.txn {
-		return nil, roachpb.NewErrorf("a batch b can only be committed by b.txn")
+		return nil, util.Errorf("a batch b can only be committed by b.txn")
 	}
 	b.reqs = append(b.reqs, endTxnReq(true /* commit */, txn.deadline, txn.SystemConfigTrigger()))
 	b.initResult(1, 0, nil)
-	resp, pErr := txn.RunWithResponse(b)
-	if pErr == nil {
+	resp, err := txn.RunWithResponse(b)
+	if err == nil {
 		txn.finalized = true
 	}
-	return resp, pErr
+	return resp, err
 }
 
 // CommitOrCleanup sends an EndTransactionRequest with Commit=true.
 // If that fails, an attempt to rollback is made.
 // txn should not be used to send any more commands after this call.
-func (txn *Txn) CommitOrCleanup() *roachpb.Error {
-	pErr := txn.commit()
-	if pErr != nil {
-		txn.CleanupOnError(pErr)
+func (txn *Txn) CommitOrCleanup() error {
+	err := txn.commit()
+	if err != nil {
+		txn.CleanupOnError(err)
 	}
 	if !txn.IsFinalized() {
 		panic("Commit() failed to move txn to a final state")
 	}
-	return pErr
+	return err
 }
 
 // SetDeadline sets the transactions deadline.
@@ -452,15 +444,15 @@ func (txn *Txn) SetDeadline(deadline roachpb.Timestamp) {
 // Rollback sends an EndTransactionRequest with Commit=false.
 // The txn's status is set to ABORTED in case of error. txn is
 // considered finalized and cannot be used to send any more commands.
-func (txn *Txn) Rollback() *roachpb.Error {
+func (txn *Txn) Rollback() error {
 	err := txn.sendEndTxnReq(false /* commit */, nil)
 	txn.finalized = true
 	return err
 }
 
-func (txn *Txn) sendEndTxnReq(commit bool, deadline *roachpb.Timestamp) *roachpb.Error {
-	_, pErr := txn.send(0, roachpb.CONSISTENT, endTxnReq(commit, deadline, txn.SystemConfigTrigger()))
-	return pErr
+func (txn *Txn) sendEndTxnReq(commit bool, deadline *roachpb.Timestamp) error {
+	_, err := txn.send(0, roachpb.CONSISTENT, endTxnReq(commit, deadline, txn.SystemConfigTrigger()))
+	return err.GoError()
 }
 
 func endTxnReq(commit bool, deadline *roachpb.Timestamp, hasTrigger bool) roachpb.Request {
@@ -511,19 +503,29 @@ type TxnExecOptions struct {
 // to clean up the transaction before returning an error. In case of
 // TransactionAbortedError, txn is reset to a fresh transaction, ready to be
 // used.
-//
-// TODO(andrei): Make Exec() return error; make fn return an error + a retriable
-// bit. There's no reason to propagate roachpb.Error (protos) above this point.
 func (txn *Txn) Exec(
 	opt TxnExecOptions,
-	fn func(txn *Txn, opt *TxnExecOptions) *roachpb.Error) *roachpb.Error {
+	fn func(txn *Txn, opt *TxnExecOptions) error) (err error) {
 	// Run fn in a retry loop until we encounter a success or
 	// error condition this loop isn't capable of handling.
-	var pErr *roachpb.Error
 	var retryOptions retry.Options
 	if txn == nil && (opt.AutoRetry || opt.AutoCommit) {
 		panic("asked to retry or commit a txn that is already aborted")
 	}
+
+	// Ensure that a RetryableTxnError escaping this function is not used by
+	// another (higher-level) Exec() invocation to restart its unrelated
+	// transaction. Technically, setting TxnID to nil here is best-effort and
+	// doesn't ensure that (the error will be wrongly used if the outer txn also
+	// has a nil TxnID).
+	// TODO(andrei): set TxnID to a bogus non-nil value once we get rid of the
+	// retErr.Transaction field.
+	defer func() {
+		if retErr, ok := err.(*roachpb.RetryableTxnError); ok {
+			retErr.TxnID = nil
+			retErr.Transaction = nil
+		}
+	}()
 
 	if opt.AutoRetry {
 		retryOptions = txn.db.txnRetryOptions
@@ -539,51 +541,51 @@ RetryLoop:
 			}
 		}
 
-		pErr = fn(txn, &opt)
+		err = fn(txn, &opt)
 		if txn != nil {
 			txn.retrying = true
 			defer func() {
 				txn.retrying = false
 			}()
 		}
-		if (pErr == nil) && opt.AutoCommit && (txn.Proto.Status == roachpb.PENDING) {
+		if (err == nil) && opt.AutoCommit && (txn.Proto.Status == roachpb.PENDING) {
 			// fn succeeded, but didn't commit.
-			pErr = txn.Commit()
+			err = txn.Commit()
 		}
 
-		if pErr == nil {
+		if err == nil {
 			break
-		}
-
-		// Make sure the txn record that pErr carries is for this txn.
-		// We check only when txn.Proto.ID has been initialized after an initial successful send.
-		if pErr.GetTxn() != nil && txn.Proto.ID != nil {
-			if errTxn := pErr.GetTxn(); !errTxn.Equal(&txn.Proto) {
-				return roachpb.NewErrorf("mismatching transaction record in the error:\n%s\nv.s.\n%s",
-					errTxn, txn.Proto)
-			}
 		}
 
 		if !opt.AutoRetry {
 			break RetryLoop
 		}
-		switch pErr.TransactionRestart {
-		case roachpb.TransactionRestart_IMMEDIATE:
-			r.Reset()
-		case roachpb.TransactionRestart_BACKOFF:
-		default:
+
+		if retErr, retryable := err.(*roachpb.RetryableTxnError); retryable {
+			// Make sure the txn record that err carries is for this txn.
+			// If it's not, we terminate the "retryable" character of the error.
+			if txn.Proto.ID != nil {
+				if retErr.TxnID == nil {
+					return errors.New(retErr.Error())
+				}
+				if !uuid.Equal(*retErr.TxnID, *txn.Proto.ID) {
+					return errors.New(retErr.Error())
+				}
+			}
+
+			if !retErr.Backoff {
+				r.Reset()
+			}
+		} else {
 			break RetryLoop
 		}
 		if log.V(2) {
 			log.Infof("automatically retrying transaction: %s because of error: %s",
-				txn.DebugName(), pErr)
+				txn.DebugName(), err)
 		}
 	}
 
-	if pErr != nil {
-		pErr.StripErrorTransaction()
-	}
-	return pErr
+	return err
 }
 
 // send runs the specified calls synchronously in a single batch and

--- a/client/txn_test.go
+++ b/client/txn_test.go
@@ -25,7 +25,10 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
 
@@ -199,13 +202,13 @@ func TestTransactionConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	db := NewDB(newTestSender(nil, nil))
 	db.userPriority = 101
-	if pErr := db.Txn(func(txn *Txn) *roachpb.Error {
+	if err := db.Txn(func(txn *Txn) error {
 		if txn.db.userPriority != db.userPriority {
 			t.Errorf("expected txn user priority %f; got %f", db.userPriority, txn.db.userPriority)
 		}
 		return nil
-	}); pErr != nil {
-		t.Errorf("unexpected error on commit: %s", pErr)
+	}); err != nil {
+		t.Errorf("unexpected error on commit: %s", err)
 	}
 }
 
@@ -219,11 +222,11 @@ func TestCommitReadOnlyTransaction(t *testing.T) {
 		calls = append(calls, ba.Methods()...)
 		return ba.CreateReply(), nil
 	}, nil))
-	if pErr := db.Txn(func(txn *Txn) *roachpb.Error {
-		_, pErr := txn.Get("a")
-		return pErr
-	}); pErr != nil {
-		t.Errorf("unexpected error on commit: %s", pErr)
+	if err := db.Txn(func(txn *Txn) error {
+		_, err := txn.Get("a")
+		return err
+	}); err != nil {
+		t.Errorf("unexpected error on commit: %s", err)
 	}
 	expectedCalls := []roachpb.Method{roachpb.Get}
 	if !reflect.DeepEqual(expectedCalls, calls) {
@@ -242,14 +245,14 @@ func TestCommitReadOnlyTransactionExplicit(t *testing.T) {
 			calls = append(calls, ba.Methods()...)
 			return ba.CreateReply(), nil
 		}, nil))
-		if pErr := db.Txn(func(txn *Txn) *roachpb.Error {
+		if err := db.Txn(func(txn *Txn) error {
 			b := txn.NewBatch()
 			if withGet {
 				b.Get("foo")
 			}
 			return txn.CommitInBatch(b)
-		}); pErr != nil {
-			t.Errorf("unexpected error on commit: %s", pErr)
+		}); err != nil {
+			t.Errorf("unexpected error on commit: %s", err)
 		}
 		expectedCalls := []roachpb.Method(nil)
 		if withGet {
@@ -280,24 +283,24 @@ func TestCommitMutatingTransaction(t *testing.T) {
 
 	// Test all transactional write methods.
 	testArgs := []struct {
-		f         func(txn *Txn) *roachpb.Error
+		f         func(txn *Txn) error
 		expMethod roachpb.Method
 	}{
-		{func(txn *Txn) *roachpb.Error { return txn.Put("a", "b") }, roachpb.Put},
-		{func(txn *Txn) *roachpb.Error { return txn.CPut("a", "b", nil) }, roachpb.ConditionalPut},
-		{func(txn *Txn) *roachpb.Error {
-			_, pErr := txn.Inc("a", 1)
-			return pErr
+		{func(txn *Txn) error { return txn.Put("a", "b") }, roachpb.Put},
+		{func(txn *Txn) error { return txn.CPut("a", "b", nil) }, roachpb.ConditionalPut},
+		{func(txn *Txn) error {
+			_, err := txn.Inc("a", 1)
+			return err
 		}, roachpb.Increment},
-		{func(txn *Txn) *roachpb.Error { return txn.Del("a") }, roachpb.Delete},
-		{func(txn *Txn) *roachpb.Error { return txn.DelRange("a", "b") }, roachpb.DeleteRange},
+		{func(txn *Txn) error { return txn.Del("a") }, roachpb.Delete},
+		{func(txn *Txn) error { return txn.DelRange("a", "b") }, roachpb.DeleteRange},
 	}
 	for i, test := range testArgs {
 		calls = []roachpb.Method{}
-		if pErr := db.Txn(func(txn *Txn) *roachpb.Error {
+		if err := db.Txn(func(txn *Txn) error {
 			return test.f(txn)
-		}); pErr != nil {
-			t.Errorf("%d: unexpected error on commit: %s", i, pErr)
+		}); err != nil {
+			t.Errorf("%d: unexpected error on commit: %s", i, err)
 		}
 		expectedCalls := []roachpb.Method{roachpb.BeginTransaction, test.expMethod, roachpb.EndTransaction}
 		if !reflect.DeepEqual(expectedCalls, calls) {
@@ -315,13 +318,13 @@ func TestTxnInsertBeginTransaction(t *testing.T) {
 		calls = append(calls, ba.Methods()...)
 		return ba.CreateReply(), nil
 	}, nil))
-	if pErr := db.Txn(func(txn *Txn) *roachpb.Error {
-		if _, pErr := txn.Get("foo"); pErr != nil {
-			return pErr
+	if err := db.Txn(func(txn *Txn) error {
+		if _, err := txn.Get("foo"); err != nil {
+			return err
 		}
 		return txn.Put("a", "b")
-	}); pErr != nil {
-		t.Errorf("unexpected error on commit: %s", pErr)
+	}); err != nil {
+		t.Errorf("unexpected error on commit: %s", err)
 	}
 	expectedCalls := []roachpb.Method{roachpb.Get, roachpb.BeginTransaction, roachpb.Put, roachpb.EndTransaction}
 	if !reflect.DeepEqual(expectedCalls, calls) {
@@ -338,16 +341,20 @@ func TestBeginTransactionErrorIndex(t *testing.T) {
 		pErr.SetErrorIndex(0)
 		return nil, pErr
 	}, nil))
-	pErr := db.Txn(func(txn *Txn) *roachpb.Error {
-		return txn.Put("a", "b")
+	_ = db.Txn(func(txn *Txn) error {
+		b := txn.NewBatch()
+		b.Put("a", "b")
+		_, err := runOneResult(txn, b)
+		pErr := b.Results[0].PErr
+		// Verify that the original error type is preserved, but the error index is unset.
+		if _, ok := pErr.GetDetail().(*roachpb.WriteIntentError); !ok {
+			t.Fatalf("unexpected error %s", pErr)
+		}
+		if pErr.Index != nil {
+			t.Errorf("error index must not be set, but got %s", pErr.Index)
+		}
+		return err
 	})
-	// Verify that the original error type is preserved, but the error index is unset.
-	if _, ok := pErr.GetDetail().(*roachpb.WriteIntentError); !ok {
-		t.Fatalf("unexpected error %s", pErr)
-	}
-	if pErr.Index != nil {
-		t.Errorf("error index must not be set, but got %s", pErr.Index)
-	}
 }
 
 // TestCommitTransactionOnce verifies that if the transaction is
@@ -360,12 +367,12 @@ func TestCommitTransactionOnce(t *testing.T) {
 		count++
 		return ba.CreateReply(), nil
 	}, nil))
-	if pErr := db.Txn(func(txn *Txn) *roachpb.Error {
+	if err := db.Txn(func(txn *Txn) error {
 		b := txn.NewBatch()
 		b.Put("z", "adding a write exposed a bug in #1882")
 		return txn.CommitInBatch(b)
-	}); pErr != nil {
-		t.Errorf("unexpected error on commit: %s", pErr)
+	}); err != nil {
+		t.Errorf("unexpected error on commit: %s", err)
 	}
 	if count != 1 {
 		t.Errorf("expected single Batch, got %d sent calls", count)
@@ -382,9 +389,9 @@ func TestAbortReadOnlyTransaction(t *testing.T) {
 		}
 		return ba.CreateReply(), nil
 	}, nil))
-	if pErr := db.Txn(func(txn *Txn) *roachpb.Error {
-		return roachpb.NewError(errors.New("foo"))
-	}); pErr == nil {
+	if err := db.Txn(func(txn *Txn) error {
+		return errors.New("foo")
+	}); err == nil {
 		t.Error("expected error on abort")
 	}
 }
@@ -404,20 +411,22 @@ func TestEndWriteRestartReadOnlyTransaction(t *testing.T) {
 			return ba.CreateReply(), nil
 		}, nil))
 		ok := false
-		if pErr := db.Txn(func(txn *Txn) *roachpb.Error {
+		if err := db.Txn(func(txn *Txn) error {
 			if !ok {
-				if pErr := txn.Put("consider", "phlebas"); pErr != nil {
-					t.Fatal(pErr)
+				if err := txn.Put("consider", "phlebas"); err != nil {
+					t.Fatal(err)
 				}
 				ok = true
-				return roachpb.NewError(&roachpb.TransactionRetryError{}) // immediate txn retry
+				// Return an immediate txn retry error. We need to go through the pErr
+				// and back to get a RetryableTxnError.
+				return roachpb.NewErrorWithTxn(roachpb.NewTransactionRetryError(), &txn.Proto).GoError()
 			}
 			if !success {
-				return roachpb.NewError(errors.New("aborting on purpose"))
+				return errors.New("aborting on purpose")
 			}
 			return nil
-		}); pErr == nil != success {
-			t.Errorf("expected error: %t, got error: %v", !success, pErr)
+		}); err == nil != success {
+			t.Errorf("expected error: %t, got error: %v", !success, err)
 		}
 		if !reflect.DeepEqual(expCalls, calls) {
 			t.Fatalf("expected %v, got %v", expCalls, calls)
@@ -438,12 +447,12 @@ func TestAbortMutatingTransaction(t *testing.T) {
 		return ba.CreateReply(), nil
 	}, nil))
 
-	if pErr := db.Txn(func(txn *Txn) *roachpb.Error {
-		if pErr := txn.Put("a", "b"); pErr != nil {
-			return pErr
+	if err := db.Txn(func(txn *Txn) error {
+		if err := txn.Put("a", "b"); err != nil {
+			return err
 		}
-		return roachpb.NewErrorf("foo")
-	}); pErr == nil {
+		return util.Errorf("foo")
+	}); err == nil {
 		t.Error("expected error on abort")
 	}
 	expectedCalls := []roachpb.Method{roachpb.BeginTransaction, roachpb.Put, roachpb.EndTransaction}
@@ -477,28 +486,28 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 			if _, ok := ba.GetArg(roachpb.Put); ok {
 				count++
 				if count == 1 {
-					return nil, roachpb.NewError(test.err)
+					return nil, roachpb.NewErrorWithTxn(test.err, ba.Txn)
 				}
 			}
 			return ba.CreateReply(), nil
 		}, nil))
 		db.txnRetryOptions.InitialBackoff = 1 * time.Millisecond
-		pErr := db.Txn(func(txn *Txn) *roachpb.Error {
+		err := db.Txn(func(txn *Txn) error {
 			return txn.Put("a", "b")
 		})
 		if test.retry {
 			if count != 2 {
 				t.Errorf("%d: expected one retry; got %d", i, count-1)
 			}
-			if pErr != nil {
-				t.Errorf("%d: expected success on retry; got %s", i, pErr)
+			if err != nil {
+				t.Errorf("%d: expected success on retry; got %s", i, err)
 			}
 		} else {
 			if count != 1 {
 				t.Errorf("%d: expected no retries; got %d", i, count)
 			}
-			if reflect.TypeOf(pErr.GetDetail()) != reflect.TypeOf(test.err) {
-				t.Errorf("%d: expected error of type %T; got %T", i, test.err, pErr)
+			if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
+				t.Errorf("%d: expected error of type %T; got %T", i, test.err, err)
 			}
 		}
 	}
@@ -521,7 +530,7 @@ func TestAbortedRetryPreservesTimestamp(t *testing.T) {
 		return ba.CreateReply(), nil
 	}, nil))
 
-	txnClosure := func(txn *Txn, opt *TxnExecOptions) *roachpb.Error {
+	txnClosure := func(txn *Txn, opt *TxnExecOptions) error {
 		// Ensure the KV transaction is created.
 		return txn.Put("a", "b")
 	}
@@ -534,8 +543,8 @@ func TestAbortedRetryPreservesTimestamp(t *testing.T) {
 	execOpt.MinInitialTimestamp = refTimestamp
 
 	// Perform the transaction.
-	if pErr := txn.Exec(execOpt, txnClosure); pErr != nil {
-		t.Fatal(pErr)
+	if err := txn.Exec(execOpt, txnClosure); err != nil {
+		t.Fatal(err)
 	}
 
 	// Check the timestamp was preserved.
@@ -654,13 +663,13 @@ func TestTimestampSelectionInOptions(t *testing.T) {
 	refTimestamp := roachpb.Timestamp{WallTime: 42, Logical: 69}
 	execOpt.MinInitialTimestamp = refTimestamp
 
-	txnClosure := func(txn *Txn, opt *TxnExecOptions) *roachpb.Error {
+	txnClosure := func(txn *Txn, opt *TxnExecOptions) error {
 		// Ensure the KV transaction is created.
 		return txn.Put("a", "b")
 	}
 
-	if pErr := txn.Exec(execOpt, txnClosure); pErr != nil {
-		t.Fatal(pErr)
+	if err := txn.Exec(execOpt, txnClosure); err != nil {
+		t.Fatal(err)
 	}
 
 	// Check the timestamp was preserved.
@@ -706,5 +715,42 @@ func TestSetPriority(t *testing.T) {
 	txn.InternalSetPriority(13)
 	if _, pErr := txn.db.sender.Send(context.Background(), roachpb.BatchRequest{}); pErr != nil {
 		t.Fatal(pErr)
+	}
+}
+
+// Tests that a retryable error for an inner txn doesn't cause the outer txn to
+// be retried.
+func TestWrongTxnRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	db := newDB(newTestSender(nil, nil))
+
+	var retries int
+	txnClosure := func(outerTxn *Txn) error {
+		log.Infof("outer retry")
+		retries++
+		// Ensure the KV transaction is created.
+		if err := outerTxn.Put("a", "b"); err != nil {
+			t.Fatal(err)
+		}
+		var execOpt TxnExecOptions
+		execOpt.AutoRetry = false
+		err := outerTxn.Exec(
+			execOpt,
+			func(innerTxn *Txn, opt *TxnExecOptions) error {
+				// Ensure the KV transaction is created.
+				if err := innerTxn.Put("x", "y"); err != nil {
+					t.Fatal(err)
+				}
+				return roachpb.NewErrorWithTxn(&roachpb.TransactionPushError{
+					PusheeTxn: outerTxn.Proto}, &innerTxn.Proto).GoError()
+			})
+		return err
+	}
+
+	if err := db.Txn(txnClosure); !testutils.IsError(err, "failed to push") {
+		t.Fatal(err)
+	}
+	if retries != 1 {
+		t.Fatalf("unexpected retries: %d", retries)
 	}
 }

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -69,7 +69,7 @@ func startTestWriter(db *client.DB, i int64, valBytes int32, wg *sync.WaitGroup,
 			return
 		default:
 			first := true
-			pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+			err := db.Txn(func(txn *client.Txn) error {
 				if first && txnChannel != nil {
 					select {
 					case txnChannel <- struct{}{}:
@@ -82,15 +82,15 @@ func startTestWriter(db *client.DB, i int64, valBytes int32, wg *sync.WaitGroup,
 				for j := 0; j <= int(src.Int31n(10)); j++ {
 					key := randutil.RandBytes(src, 10)
 					val := randutil.RandBytes(src, int(src.Int31n(valBytes)))
-					if pErr := txn.Put(key, val); pErr != nil {
-						log.Infof("experienced an error in routine %d: %s", i, pErr)
-						return pErr
+					if err := txn.Put(key, val); err != nil {
+						log.Infof("experienced an error in routine %d: %s", i, err)
+						return err
 					}
 				}
 				return nil
 			})
-			if pErr != nil {
-				t.Error(pErr)
+			if err != nil {
+				t.Error(err)
 			} else {
 				time.Sleep(1 * time.Millisecond)
 			}
@@ -112,8 +112,8 @@ func TestRangeSplitMeta(t *testing.T) {
 	// Execute the consecutive splits.
 	for _, splitKey := range splitKeys {
 		log.Infof("starting split at key %q...", splitKey)
-		if pErr := s.DB.AdminSplit(roachpb.Key(splitKey)); pErr != nil {
-			t.Fatal(pErr)
+		if err := s.DB.AdminSplit(roachpb.Key(splitKey)); err != nil {
+			t.Fatal(err)
 		}
 		log.Infof("split at key %q complete", splitKey)
 	}
@@ -236,13 +236,13 @@ func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 		t.Fatal(err)
 	}
 	log.Infof("split at key %q first time complete", splitKey)
-	ch := make(chan *roachpb.Error)
+	ch := make(chan error)
 	go func() {
 		// should return error other than infinite loop
 		ch <- s.DB.AdminSplit(splitKey)
 	}()
 
-	if pErr := <-ch; pErr == nil {
+	if err := <-ch; err == nil {
 		t.Error("range split on same splitKey should fail")
 	}
 }

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -341,10 +341,8 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 	})
 
 	// Trying to do something else should give us a TransactionAbortedError.
-	_, pErr := initialTxn.Get("a")
-	if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
-		t.Fatalf("expected a TransactionAbortedError, but got %v (%T)", pErr, pErr.GetDetail())
-	}
+	_, err := initialTxn.Get("a")
+	assertTransactionAbortedError(t, err)
 }
 
 // getTxn fetches the requested key and returns the transaction info.
@@ -412,7 +410,7 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 		pushedTimestamp := conflictTxn.Proto.Timestamp.Next().Next()
 
 		{
-			var pErr *roachpb.Error
+			var err error
 			switch i {
 			case 0:
 				// No deadline.
@@ -429,28 +427,26 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 				// Future deadline.
 				txn.SetDeadline(pushedTimestamp.Next())
 			}
-			pErr = txn.CommitOrCleanup()
+			err = txn.CommitOrCleanup()
 
 			switch i {
 			case 0:
 				// No deadline.
-				if pErr != nil {
-					t.Error(pErr)
+				if err != nil {
+					t.Error(err)
 				}
 			case 1:
 				// Past deadline.
-				if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
-					t.Errorf("expected TransactionAbortedError but got %T: %s", pErr, pErr)
-				}
+				assertTransactionAbortedError(t, err)
 			case 2:
 				// Equal deadline.
-				if pErr != nil {
-					t.Error(pErr)
+				if err != nil {
+					t.Error(err)
 				}
 			case 3:
 				// Future deadline.
-				if pErr != nil {
-					t.Error(pErr)
+				if err != nil {
+					t.Error(err)
 				}
 			}
 		}
@@ -472,7 +468,7 @@ func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 	if err := txn.Put("x", "y"); err != nil {
 		t.Fatal(err)
 	}
-	err, ok := txn.CPut(key, []byte("x"), []byte("born to fail")).GetDetail().(*roachpb.ConditionFailedError)
+	err, ok := txn.CPut(key, []byte("x"), []byte("born to fail")).(*roachpb.ConditionFailedError)
 	if !ok {
 		t.Fatal(err)
 	}
@@ -482,11 +478,33 @@ func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 	expSpans := []roachpb.Span{{Key: key, EndKey: []byte("")}}
 	equal := !reflect.DeepEqual(intentSpans, expSpans)
 	sender.Unlock()
-	if pErr := txn.Rollback(); pErr != nil {
-		t.Fatal(pErr)
+	if err := txn.Rollback(); err != nil {
+		t.Fatal(err)
 	}
 	if !equal {
 		t.Fatalf("expected stored intents %v, got %v", expSpans, intentSpans)
+	}
+}
+
+func assertTransactionRetryError(t *testing.T, e error) {
+	if retErr, ok := e.(*roachpb.RetryableTxnError); ok {
+		if _, ok := retErr.Cause.(*roachpb.TransactionRetryError); !ok {
+			t.Fatalf("expected a TransactionRetryError, but got %s (%T)",
+				retErr.Cause, retErr.Cause)
+		}
+	} else {
+		t.Fatalf("expected a retryable error, but got %s (%T)", e, e)
+	}
+}
+
+func assertTransactionAbortedError(t *testing.T, e error) {
+	if retErr, ok := e.(*roachpb.RetryableTxnError); ok {
+		if _, ok := retErr.Cause.(*roachpb.TransactionAbortedError); !ok {
+			t.Fatalf("expected a TransactionAbortedError, but got %s (%T)",
+				retErr.Cause, retErr.Cause)
+		}
+	} else {
+		t.Fatalf("expected a retryable error, but got %s (%T)", e, e)
 	}
 }
 
@@ -501,28 +519,23 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 	key := roachpb.Key("a")
 	txn1 := client.NewTxn(context.Background(), *s.DB)
 	txn1.InternalSetPriority(1)
-	if pErr := txn1.Put(key, []byte("value")); pErr != nil {
-		t.Fatal(pErr)
+	if err := txn1.Put(key, []byte("value")); err != nil {
+		t.Fatal(err)
 	}
 
 	// Push the transaction (by writing key "a" with higher priority) to abort it.
 	txn2 := client.NewTxn(context.Background(), *s.DB)
 	txn2.InternalSetPriority(2)
-	if pErr := txn2.Put(key, []byte("value2")); pErr != nil {
-		t.Fatal(pErr)
+	if err := txn2.Put(key, []byte("value2")); err != nil {
+		t.Fatal(err)
 	}
 
 	// Now end the transaction and verify we've cleanup up, even though
 	// end transaction failed.
-	pErr := txn1.CommitOrCleanup()
-	switch pErr.GetDetail().(type) {
-	case *roachpb.TransactionAbortedError:
-		// Expected
-	default:
-		t.Fatalf("expected transaction aborted error; got %s", pErr)
-	}
-	if pErr := txn2.CommitOrCleanup(); pErr != nil {
-		t.Fatal(pErr)
+	err := txn1.CommitOrCleanup()
+	assertTransactionAbortedError(t, err)
+	if err := txn2.CommitOrCleanup(); err != nil {
+		t.Fatal(err)
 	}
 	verifyCleanup(key, sender, s.Eng, t)
 }
@@ -539,8 +552,8 @@ func TestTxnCoordSenderGCTimeout(t *testing.T) {
 
 	txn := client.NewTxn(context.Background(), *s.DB)
 	key := roachpb.Key("a")
-	if pErr := txn.Put(key, []byte("value")); pErr != nil {
-		t.Fatal(pErr)
+	if err := txn.Put(key, []byte("value")); err != nil {
+		t.Fatal(err)
 	}
 
 	// Now, advance clock past the default client timeout.
@@ -727,12 +740,12 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 		txn.InternalSetPriority(1)
 		txn.Proto.Name = "test txn"
 		key := roachpb.Key("test-key")
-		_, pErr := txn.Get(key)
+		_, err := txn.Get(key)
 		teardownHeartbeats(ts)
 		stopper.Stop()
 
-		if reflect.TypeOf(test.pErr) != reflect.TypeOf(pErr) {
-			t.Fatalf("%d: expected %T; got %T: %v", i, test.pErr, pErr, pErr)
+		if test.pErr != nil && err == nil {
+			t.Fatalf("expected an error")
 		}
 		if txn.Proto.Epoch != test.expEpoch {
 			t.Errorf("%d: expected epoch = %d; got %d",
@@ -767,8 +780,8 @@ func TestTxnCoordIdempotentCleanup(t *testing.T) {
 	txn := client.NewTxn(context.Background(), *s.DB)
 	ba := txn.NewBatch()
 	ba.Put(roachpb.Key("a"), []byte("value"))
-	if pErr := txn.Run(ba); pErr != nil {
-		t.Fatal(pErr)
+	if err := txn.Run(ba); err != nil {
+		t.Fatal(err)
 	}
 
 	sender.Lock()
@@ -782,9 +795,9 @@ func TestTxnCoordIdempotentCleanup(t *testing.T) {
 	// terminated the heartbeat goroutine)
 	ba = txn.NewBatch()
 	ba.InternalAddRequest(&roachpb.EndTransactionRequest{})
-	pErr := txn.Run(ba)
-	if pErr != nil && !testutils.IsPError(pErr, errNoState.Error()) {
-		t.Fatal(pErr)
+	err := txn.Run(ba)
+	if err != nil && !testutils.IsError(err, errNoState.Error()) {
+		t.Fatal(err)
 	}
 }
 
@@ -1093,24 +1106,24 @@ func TestTxnCommit(t *testing.T) {
 	db := client.NewDB(sender)
 
 	// Test normal commit.
-	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		key := []byte("key-commit")
 
 		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-			return roachpb.NewError(err)
+			return err
 		}
 
-		if pErr := txn.Put(key, value); pErr != nil {
-			return pErr
+		if err := txn.Put(key, value); err != nil {
+			return err
 		}
 
-		if pErr := txn.CommitOrCleanup(); pErr != nil {
-			return pErr
+		if err := txn.CommitOrCleanup(); err != nil {
+			return err
 		}
 
 		return nil
-	}); pErr != nil {
-		t.Fatal(pErr)
+	}); err != nil {
+		t.Fatal(err)
 	}
 	teardownHeartbeats(sender)
 	checkTxnMetrics(t, sender, "commit txn", 1, 0 /* not 1PC */, 0, 0, 0)
@@ -1124,13 +1137,13 @@ func TestTxnOnePhaseCommit(t *testing.T) {
 	value := []byte("value")
 	db := client.NewDB(sender)
 
-	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		key := []byte("key-commit")
 		b := txn.NewBatch()
 		b.Put(key, value)
 		return txn.CommitInBatch(b)
-	}); pErr != nil {
-		t.Fatal(pErr)
+	}); err != nil {
+		t.Fatal(err)
 	}
 	teardownHeartbeats(sender)
 	checkTxnMetrics(t, sender, "commit 1PC txn", 1, 1 /* 1PC */, 0, 0, 0)
@@ -1148,15 +1161,15 @@ func TestTxnAbandonCount(t *testing.T) {
 	// abandoned transactions.
 	sender.heartbeatInterval = 2 * time.Millisecond
 	sender.clientTimeout = 1 * time.Millisecond
-	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		key := []byte("key-abandon")
 
 		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-			return roachpb.NewError(err)
+			return err
 		}
 
-		if pErr := txn.Put(key, value); pErr != nil {
-			return pErr
+		if err := txn.Put(key, value); err != nil {
+			return err
 		}
 
 		manual.Increment(int64(sender.clientTimeout + sender.heartbeatInterval*2))
@@ -1164,8 +1177,8 @@ func TestTxnAbandonCount(t *testing.T) {
 		checkTxnMetrics(t, sender, "abandon txn", 0, 0, 1, 0, 0)
 
 		return nil
-	}); !testutils.IsPError(pErr, "writing transaction timed out") {
-		t.Fatalf("unexpected error: %s", pErr)
+	}); !testutils.IsError(err, "writing transaction timed out") {
+		t.Fatalf("unexpected error: %s", err)
 	}
 }
 
@@ -1185,31 +1198,31 @@ func TestTxnReadAfterAbandon(t *testing.T) {
 	sender.heartbeatInterval = 2 * time.Millisecond
 	sender.clientTimeout = 1 * time.Millisecond
 
-	pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	err := db.Txn(func(txn *client.Txn) error {
 		key := []byte("key-abandon")
 
 		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
 			t.Fatal(err)
 		}
 
-		if pErr := txn.Put(key, value); pErr != nil {
-			t.Fatal(pErr)
+		if err := txn.Put(key, value); err != nil {
+			t.Fatal(err)
 		}
 
 		manual.Increment(int64(sender.clientTimeout + sender.heartbeatInterval*2))
 
 		checkTxnMetrics(t, sender, "abandon txn", 0, 0, 1, 0, 0)
 
-		_, pErr := txn.Get(key)
-		if pErr == nil {
+		_, err := txn.Get(key)
+		if err == nil {
 			t.Fatalf("Get succeeded on abandoned txn")
-		} else if !testutils.IsPError(pErr, "writing transaction timed out") {
-			t.Fatalf("unexpected error from Get on abandoned txn: %s", pErr)
+		} else if !testutils.IsError(err, "writing transaction timed out") {
+			t.Fatalf("unexpected error from Get on abandoned txn: %s", err)
 		}
-		return pErr
+		return err
 	})
 
-	if pErr == nil {
+	if err == nil {
 		t.Fatalf("abandoned txn didn't fail")
 	}
 }
@@ -1224,20 +1237,20 @@ func TestTxnAbortCount(t *testing.T) {
 
 	intentionalErrText := "intentional error to cause abort"
 	// Test aborted transaction.
-	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		key := []byte("key-abort")
 
 		if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-			return roachpb.NewError(err)
+			return err
 		}
 
-		if pErr := txn.Put(key, value); pErr != nil {
-			t.Fatal(pErr)
+		if err := txn.Put(key, value); err != nil {
+			t.Fatal(err)
 		}
 
-		return roachpb.NewErrorf(intentionalErrText)
-	}); !testutils.IsPError(pErr, intentionalErrText) {
-		t.Fatalf("unexpected error: %s", pErr)
+		return errors.New(intentionalErrText)
+	}); !testutils.IsError(err, intentionalErrText) {
+		t.Fatalf("unexpected error: %s", err)
 	}
 	teardownHeartbeats(sender)
 	checkTxnMetrics(t, sender, "abort txn", 0, 0, 0, 1, 0)
@@ -1273,10 +1286,8 @@ func TestTxnRestartCount(t *testing.T) {
 	}
 
 	// Commit (should cause restart metric to increase).
-	pErr := txn.CommitOrCleanup()
-	if _, ok := pErr.GetDetail().(*roachpb.TransactionRetryError); !ok {
-		t.Errorf("expected transaction retry err; got %s", pErr)
-	}
+	err := txn.CommitOrCleanup()
+	assertTransactionRetryError(t, err)
 
 	teardownHeartbeats(sender)
 	checkTxnMetrics(t, sender, "restart txn", 0, 0, 0, 1, 1)
@@ -1293,17 +1304,17 @@ func TestTxnDurations(t *testing.T) {
 	const incr int64 = 1000
 	for i := 0; i < puts; i++ {
 		key := roachpb.Key(fmt.Sprintf("key-txn-durations-%d", i))
-		if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+		if err := db.Txn(func(txn *client.Txn) error {
 			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-				return roachpb.NewError(err)
+				return err
 			}
 			if err := txn.Put(key, []byte("val")); err != nil {
 				return err
 			}
 			manual.Increment(incr)
 			return nil
-		}); pErr != nil {
-			t.Fatal(pErr)
+		}); err != nil {
+			t.Fatal(err)
 		}
 	}
 

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -80,7 +80,7 @@ type cmd struct {
 	txnIdx      int    // transaction index in the history
 	historyIdx  int    // this suffixes key so tests get unique keys
 	fn          func(
-		c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error // execution function
+		c *cmd, txn *client.Txn, t *testing.T) error // execution function
 	ch   chan struct{}    // channel for other commands to wait
 	prev <-chan struct{}  // channel this command must wait on before executing
 	env  map[string]int64 // contains all previously read values
@@ -96,24 +96,24 @@ func (c *cmd) init(prevCmd *cmd) {
 	c.debug = ""
 }
 
-func (c *cmd) execute(txn *client.Txn, t *testing.T) (string, *roachpb.Error) {
+func (c *cmd) execute(txn *client.Txn, t *testing.T) (string, error) {
 	if c.prev != nil {
 		<-c.prev
 	}
 	if log.V(2) {
 		log.Infof("executing %s", c)
 	}
-	pErr := c.fn(c, txn, t)
+	err := c.fn(c, txn, t)
 	if c.ch != nil {
 		c.ch <- struct{}{}
 	}
 	if len(c.key) > 0 && len(c.endKey) > 0 {
-		return fmt.Sprintf("%s%%d.%%d(%s-%s)%s", c.name, c.key, c.endKey, c.debug), pErr
+		return fmt.Sprintf("%s%%d.%%d(%s-%s)%s", c.name, c.key, c.endKey, c.debug), err
 	}
 	if len(c.key) > 0 {
-		return fmt.Sprintf("%s%%d.%%d(%s)%s", c.name, c.key, c.debug), pErr
+		return fmt.Sprintf("%s%%d.%%d(%s)%s", c.name, c.key, c.debug), err
 	}
-	return fmt.Sprintf("%s%%d.%%d%s", c.name, c.debug), pErr
+	return fmt.Sprintf("%s%%d.%%d%s", c.name, c.debug), err
 }
 
 func (c *cmd) done() {
@@ -149,10 +149,10 @@ func (c *cmd) String() string {
 }
 
 // readCmd reads a value from the db and stores it in the env.
-func readCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
-	r, pErr := txn.Get(c.getKey())
-	if pErr != nil {
-		return pErr
+func readCmd(c *cmd, txn *client.Txn, t *testing.T) error {
+	r, err := txn.Get(c.getKey())
+	if err != nil {
+		return err
 	}
 	var value int64
 	if r.Value != nil {
@@ -164,20 +164,20 @@ func readCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 }
 
 // deleteCmd deletes the value at the given key from the db.
-func deleteCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
+func deleteCmd(c *cmd, txn *client.Txn, t *testing.T) error {
 	return txn.Del(c.getKey())
 }
 
 // deleteRngCmd deletes the range of values from the db from [key, endKey).
-func deleteRngCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
+func deleteRngCmd(c *cmd, txn *client.Txn, t *testing.T) error {
 	return txn.DelRange(c.getKey(), c.getEndKey())
 }
 
 // scanCmd reads the values from the db from [key, endKey).
-func scanCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
-	rows, pErr := txn.Scan(c.getKey(), c.getEndKey(), 0)
-	if pErr != nil {
-		return pErr
+func scanCmd(c *cmd, txn *client.Txn, t *testing.T) error {
+	rows, err := txn.Scan(c.getKey(), c.getEndKey(), 0)
+	if err != nil {
+		return err
 	}
 	var vals []string
 	keyPrefix := []byte(fmt.Sprintf("%d.", c.historyIdx))
@@ -193,14 +193,14 @@ func scanCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 // incCmd adds one to the value of c.key in the env (as determined by
 // a previous read or write, or else assumed to be zero) and writes it
 // to the db.
-func incCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
+func incCmd(c *cmd, txn *client.Txn, t *testing.T) error {
 	val, ok := c.env[c.key]
 	if !ok {
 		panic(fmt.Sprintf("can't increment key %q; not yet read", c.key))
 	}
 	r := val + 1
-	if pErr := txn.Put(c.getKey(), r); pErr != nil {
-		return pErr
+	if err := txn.Put(c.getKey(), r); err != nil {
+		return err
 	}
 	c.env[c.key] = r
 	c.debug = fmt.Sprintf("[%d]", r)
@@ -211,7 +211,7 @@ func incCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 // and writes the value to the db. "c.endKey" here needs to be parsed
 // in the context of this command, which is a "+"-separated list of
 // keys from the env or numeric constants to sum.
-func writeCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
+func writeCmd(c *cmd, txn *client.Txn, t *testing.T) error {
 	sum := int64(0)
 	for _, sp := range strings.Split(c.endKey, "+") {
 		if constant, err := strconv.Atoi(sp); err != nil {
@@ -220,18 +220,18 @@ func writeCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
 			sum += int64(constant)
 		}
 	}
-	pErr := txn.Put(c.getKey(), sum)
+	err := txn.Put(c.getKey(), sum)
 	c.debug = fmt.Sprintf("[%d]", sum)
-	return pErr
+	return err
 }
 
 // commitCmd commits the transaction.
-func commitCmd(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error {
+func commitCmd(c *cmd, txn *client.Txn, t *testing.T) error {
 	return txn.Commit()
 }
 
 type cmdSpec struct {
-	fn func(c *cmd, txn *client.Txn, t *testing.T) *roachpb.Error
+	fn func(c *cmd, txn *client.Txn, t *testing.T) error
 	re *regexp.Regexp
 }
 
@@ -574,8 +574,8 @@ func (hv *historyVerifier) runHistory(historyIdx int, priorities []int32,
 	}
 	for i, txnCmds := range txnMap {
 		go func(i int, txnCmds []*cmd) {
-			if pErr := hv.runTxn(i, priorities[i-1], isolations[i-1], txnCmds, db, t); pErr != nil {
-				t.Errorf("(%s): unexpected failure running %s: %v", cmds, cmds[i], pErr)
+			if err := hv.runTxn(i, priorities[i-1], isolations[i-1], txnCmds, db, t); err != nil {
+				t.Errorf("(%s): unexpected failure running %s: %v", cmds, cmds[i], err)
 			}
 		}(i, txnCmds)
 	}
@@ -591,18 +591,18 @@ func (hv *historyVerifier) runHistory(historyIdx int, priorities []int32,
 		c.historyIdx = historyIdx
 		c.env = verifyEnv
 		c.init(nil)
-		pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
-			fmtStr, pErr := c.execute(txn, t)
-			if pErr != nil {
-				return pErr
+		err := db.Txn(func(txn *client.Txn) error {
+			fmtStr, err := c.execute(txn, t)
+			if err != nil {
+				return err
 			}
 			cmdStr := fmt.Sprintf(fmtStr, 0, 0)
 			verifyStrs = append(verifyStrs, cmdStr)
 			return nil
 		})
-		if pErr != nil {
-			t.Errorf("failed on execution of verification cmd %s: %s", c, pErr)
-			return pErr.GoError()
+		if err != nil {
+			t.Errorf("failed on execution of verification cmd %s: %s", c, err)
+			return err
 		}
 	}
 
@@ -621,14 +621,14 @@ func (hv *historyVerifier) runHistory(historyIdx int, priorities []int32,
 }
 
 func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
-	isolation roachpb.IsolationType, cmds []*cmd, db *client.DB, t *testing.T) *roachpb.Error {
+	isolation roachpb.IsolationType, cmds []*cmd, db *client.DB, t *testing.T) error {
 	var retry int
 	txnName := fmt.Sprintf("txn%d", txnIdx)
-	pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	err := db.Txn(func(txn *client.Txn) error {
 		txn.SetDebugName(txnName, 0)
 		if isolation == roachpb.SNAPSHOT {
 			if err := txn.SetIsolation(roachpb.SNAPSHOT); err != nil {
-				return roachpb.NewError(err)
+				return err
 			}
 		}
 		txn.InternalSetPriority(priority)
@@ -651,20 +651,20 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 		}
 		for i := range cmds {
 			cmds[i].env = env
-			if pErr := hv.runCmd(txn, txnIdx, retry, i, cmds, t); pErr != nil {
-				return pErr
+			if err := hv.runCmd(txn, txnIdx, retry, i, cmds, t); err != nil {
+				return err
 			}
 		}
 		return nil
 	})
 	hv.wg.Done()
-	return pErr
+	return err
 }
 
-func (hv *historyVerifier) runCmd(txn *client.Txn, txnIdx, retry, cmdIdx int, cmds []*cmd, t *testing.T) *roachpb.Error {
-	fmtStr, pErr := cmds[cmdIdx].execute(txn, t)
-	if pErr != nil {
-		return pErr
+func (hv *historyVerifier) runCmd(txn *client.Txn, txnIdx, retry, cmdIdx int, cmds []*cmd, t *testing.T) error {
+	fmtStr, err := cmds[cmdIdx].execute(txn, t)
+	if err != nil {
+		return err
 	}
 	hv.Lock()
 	cmdStr := fmt.Sprintf(fmtStr, txnIdx, retry)

--- a/roachpb/errors_test.go
+++ b/roachpb/errors_test.go
@@ -70,25 +70,3 @@ func TestErrorTxn(t *testing.T) {
 		t.Fatalf("wanted name %s, unexpected: %+v", name, txn)
 	}
 }
-
-// TestStripErrorTransaction verifies that StripErrorTransaction
-// strips the transaction information on an error, but it does not
-// update the error message.
-func TestStripErrorTransaction(t *testing.T) {
-	txn := NewTransaction("test", Key("a"), 1, SERIALIZABLE, Timestamp{}, 0)
-	pErr := NewErrorWithTxn(NewTransactionAbortedError(), txn)
-	if pErr.GetTxn() == nil {
-		t.Errorf("no txn on error: %s", pErr)
-	}
-	if !strings.HasPrefix(pErr.Message, "txn aborted \"test\"") {
-		t.Errorf("unexpected message: %s", pErr.Message)
-	}
-
-	pErr.StripErrorTransaction()
-	if pErr.GetTxn() != nil {
-		t.Errorf("txn must be stripped: %s", pErr)
-	}
-	if !strings.HasPrefix(pErr.Message, "txn aborted \"test\"") {
-		t.Errorf("unexpected message: %s", pErr.Message)
-	}
-}

--- a/server/admin.go
+++ b/server/admin.go
@@ -529,12 +529,12 @@ func (s *adminServer) TableDetails(ctx context.Context, req *TableDetailsRequest
 	{
 		var iexecutor sql.InternalExecutor
 		var tableSpan roachpb.Span
-		if pErr := s.server.db.Txn(func(txn *client.Txn) *roachpb.Error {
-			var pErr *roachpb.Error
-			tableSpan, pErr = iexecutor.GetTableSpan(s.getUser(req), txn, escDbName, escTableName)
-			return pErr
-		}); pErr != nil {
-			return nil, s.serverError(pErr.GoError())
+		if err := s.server.db.Txn(func(txn *client.Txn) error {
+			var err error
+			tableSpan, err = iexecutor.GetTableSpan(s.getUser(req), txn, escDbName, escTableName)
+			return err
+		}); err != nil {
+			return nil, s.serverError(err)
 		}
 		tableRSpan := roachpb.RSpan{}
 		var err error

--- a/server/node.go
+++ b/server/node.go
@@ -660,8 +660,7 @@ func (n *Node) writeSummaries() error {
 			// node status, writing one of these every 10s will generate
 			// more versions than will easily fit into a range over the
 			// course of a day.
-			if pErr := n.ctx.DB.PutInline(key, nodeStatus); pErr != nil {
-				err = pErr.GoError()
+			if err = n.ctx.DB.PutInline(key, nodeStatus); err != nil {
 				return
 			}
 			if log.V(2) {
@@ -691,7 +690,7 @@ func (n *Node) recordJoinEvent() {
 
 	n.stopper.RunWorker(func() {
 		for r := retry.Start(retry.Options{Closer: n.stopper.ShouldStop()}); r.Next(); {
-			if err := n.ctx.DB.Txn(func(txn *client.Txn) *roachpb.Error {
+			if err := n.ctx.DB.Txn(func(txn *client.Txn) error {
 				return n.eventLogger.InsertEventRecord(txn,
 					logEventType,
 					int32(n.Descriptor.NodeID),

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -401,10 +401,10 @@ func TestSystemConfigGossip(t *testing.T) {
 	}
 
 	// Now do it as part of a transaction, but without the trigger set.
-	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		return txn.Put(key, valAt(1))
-	}); pErr != nil {
-		t.Fatal(pErr)
+	}); err != nil {
+		t.Fatal(err)
 	}
 
 	// Gossip channel should be dormant.
@@ -422,11 +422,11 @@ func TestSystemConfigGossip(t *testing.T) {
 	}
 
 	// This time mark the transaction as having a Gossip trigger.
-	if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	if err := db.Txn(func(txn *client.Txn) error {
 		txn.SetSystemConfigTrigger()
 		return txn.Put(key, valAt(2))
-	}); pErr != nil {
-		t.Fatal(pErr)
+	}); err != nil {
+		t.Fatal(err)
 	}
 
 	// New system config received.

--- a/server/status.go
+++ b/server/status.go
@@ -526,19 +526,19 @@ func (s *statusServer) handleNodesStatus(w http.ResponseWriter, r *http.Request,
 	startKey := keys.StatusNodePrefix
 	endKey := startKey.PrefixEnd()
 
-	rows, pErr := s.db.ScanInconsistent(startKey, endKey, 0)
-	if pErr != nil {
-		log.Error(pErr)
-		http.Error(w, pErr.String(), http.StatusInternalServerError)
+	rows, err := s.db.ScanInconsistent(startKey, endKey, 0)
+	if err != nil {
+		log.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	nodeStatuses := []status.NodeStatus{}
 	for _, row := range rows {
 		nodeStatus := &status.NodeStatus{}
-		if pErr := row.ValueProto(nodeStatus); pErr != nil {
-			log.Error(pErr)
-			http.Error(w, pErr.Error(), http.StatusInternalServerError)
+		if err := row.ValueProto(nodeStatus); err != nil {
+			log.Error(err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		nodeStatuses = append(nodeStatuses, *nodeStatus)
@@ -556,9 +556,9 @@ func (s *statusServer) handleNodeStatus(w http.ResponseWriter, r *http.Request, 
 
 	key := keys.NodeStatusKey(int32(nodeID))
 	nodeStatus := &status.NodeStatus{}
-	if pErr := s.db.GetProtoInconsistent(key, nodeStatus); pErr != nil {
-		log.Error(pErr)
-		http.Error(w, pErr.String(), http.StatusInternalServerError)
+	if err := s.db.GetProtoInconsistent(key, nodeStatus); err != nil {
+		log.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -502,7 +502,7 @@ func TestMetricsRecording(t *testing.T) {
 	checkTimeSeriesKey := func(now int64, keyName string) error {
 		key := ts.MakeDataKey(keyName, "", ts.Resolution10s, now)
 		data := roachpb.InternalTimeSeriesData{}
-		return tsrv.db.GetProto(key, &data).GoError()
+		return tsrv.db.GetProto(key, &data)
 	}
 
 	// Verify that metrics for the current timestamp are recorded. This should

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -282,9 +282,9 @@ func waitForInitialSplits(db *client.DB) error {
 	expectedRanges := ExpectedInitialRangeCount()
 	return util.RetryForDuration(initialSplitsTimeout, func() error {
 		// Scan all keys in the Meta2Prefix; we only need a count.
-		rows, pErr := db.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
-		if pErr != nil {
-			return pErr.GoError()
+		rows, err := db.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+		if err != nil {
+			return err
 		}
 		if a, e := len(rows), expectedRanges; a != e {
 			return util.Errorf("had %d ranges at startup, expected %d", a, e)

--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -17,7 +17,8 @@
 package sql
 
 import (
-	"github.com/cockroachdb/cockroach/roachpb"
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 )
@@ -26,24 +27,24 @@ import (
 // Privileges: CREATE on table.
 //   notes: postgres requires CREATE on the table.
 //          mysql requires ALTER, CREATE, INSERT on the table.
-func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
+func (p *planner) AlterTable(n *parser.AlterTable) (planNode, error) {
 	if err := n.Table.NormalizeTableName(p.session.Database); err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 
-	dbDesc, pErr := p.getDatabaseDesc(n.Table.Database())
-	if pErr != nil {
-		return nil, pErr
+	dbDesc, err := p.getDatabaseDesc(n.Table.Database())
+	if err != nil {
+		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, roachpb.NewError(databaseDoesNotExistError(n.Table.Database()))
+		return nil, databaseDoesNotExistError(n.Table.Database())
 	}
 
 	// Check if table exists.
 	tbKey := tableKey{dbDesc.ID, n.Table.Table()}.Key()
-	gr, pErr := p.txn.Get(tbKey)
-	if pErr != nil {
-		return nil, pErr
+	gr, err := p.txn.Get(tbKey)
+	if err != nil {
+		return nil, err
 	}
 	if !gr.Exists() {
 		if n.IfExists {
@@ -51,19 +52,19 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 			return &emptyNode{}, nil
 		}
 		// Key does not exist, but we want it to: error out.
-		return nil, roachpb.NewUErrorf("table %q does not exist", n.Table.Table())
+		return nil, fmt.Errorf("table %q does not exist", n.Table.Table())
 	}
 
-	tableDesc, pErr := p.getTableDesc(n.Table)
-	if pErr != nil {
-		return nil, pErr
+	tableDesc, err := p.getTableDesc(n.Table)
+	if err != nil {
+		return nil, err
 	}
 	if tableDesc == nil {
-		return nil, roachpb.NewError(tableDoesNotExistError(n.Table.String()))
+		return nil, tableDoesNotExistError(n.Table.String())
 	}
 
 	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 
 	// Commands can either change the descriptor directly (for
@@ -78,12 +79,12 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 			d := t.ColumnDef
 			col, idx, err := makeColumnDefDescs(d)
 			if err != nil {
-				return nil, roachpb.NewError(err)
+				return nil, err
 			}
 			status, i, err := tableDesc.FindColumnByName(col.Name)
 			if err == nil {
 				if status == DescriptorIncomplete && tableDesc.Mutations[i].Direction == DescriptorMutation_DROP {
-					return nil, roachpb.NewUErrorf("column %q being dropped, try again later", col.Name)
+					return nil, fmt.Errorf("column %q being dropped, try again later", col.Name)
 				}
 			}
 			tableDesc.addColumnMutation(*col, DescriptorMutation_ADD)
@@ -95,7 +96,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 			switch d := t.ConstraintDef.(type) {
 			case *parser.UniqueConstraintTableDef:
 				if d.PrimaryKey {
-					return nil, roachpb.NewUErrorf("multiple primary keys for table %q are not allowed", tableDesc.Name)
+					return nil, fmt.Errorf("multiple primary keys for table %q are not allowed", tableDesc.Name)
 				}
 				name := string(d.Name)
 				idx := IndexDescriptor{
@@ -104,18 +105,18 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 					StoreColumnNames: d.Storing,
 				}
 				if err := idx.fillColumns(d.Columns); err != nil {
-					return nil, roachpb.NewError(err)
+					return nil, err
 				}
 				status, i, err := tableDesc.FindIndexByName(name)
 				if err == nil {
 					if status == DescriptorIncomplete && tableDesc.Mutations[i].Direction == DescriptorMutation_DROP {
-						return nil, roachpb.NewUErrorf("index %q being dropped, try again later", name)
+						return nil, fmt.Errorf("index %q being dropped, try again later", name)
 					}
 				}
 				tableDesc.addIndexMutation(idx, DescriptorMutation_ADD)
 
 			default:
-				return nil, roachpb.NewErrorf("unsupported constraint: %T", t.ConstraintDef)
+				return nil, fmt.Errorf("unsupported constraint: %T", t.ConstraintDef)
 			}
 
 		case *parser.AlterTableDropColumn:
@@ -125,17 +126,17 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 					// Noop.
 					continue
 				}
-				return nil, roachpb.NewError(err)
+				return nil, err
 			}
 			switch status {
 			case DescriptorActive:
 				col := tableDesc.Columns[i]
 				if tableDesc.PrimaryIndex.containsColumnID(col.ID) {
-					return nil, roachpb.NewUErrorf("column %q is referenced by the primary key", col.Name)
+					return nil, fmt.Errorf("column %q is referenced by the primary key", col.Name)
 				}
 				for _, idx := range tableDesc.allNonDropIndexes() {
 					if idx.containsColumnID(col.ID) {
-						return nil, roachpb.NewUErrorf("column %q is referenced by existing index %q", col.Name, idx.Name)
+						return nil, fmt.Errorf("column %q is referenced by existing index %q", col.Name, idx.Name)
 					}
 				}
 				tableDesc.addColumnMutation(col, DescriptorMutation_DROP)
@@ -144,7 +145,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 			case DescriptorIncomplete:
 				switch tableDesc.Mutations[i].Direction {
 				case DescriptorMutation_ADD:
-					return nil, roachpb.NewUErrorf("column %q in the middle of being added, try again later", t.Column)
+					return nil, fmt.Errorf("column %q in the middle of being added, try again later", t.Column)
 
 				case DescriptorMutation_DROP:
 					// Noop.
@@ -158,7 +159,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 					// Noop.
 					continue
 				}
-				return nil, roachpb.NewError(err)
+				return nil, err
 			}
 			switch status {
 			case DescriptorActive:
@@ -168,7 +169,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 			case DescriptorIncomplete:
 				switch tableDesc.Mutations[i].Direction {
 				case DescriptorMutation_ADD:
-					return nil, roachpb.NewUErrorf("constraint %q in the middle of being added, try again later", t.Constraint)
+					return nil, fmt.Errorf("constraint %q in the middle of being added, try again later", t.Constraint)
 
 				case DescriptorMutation_DROP:
 					// Noop.
@@ -179,7 +180,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 			// Column mutations
 			status, i, err := tableDesc.FindColumnByName(t.GetColumn())
 			if err != nil {
-				return nil, roachpb.NewError(err)
+				return nil, err
 			}
 
 			switch status {
@@ -190,14 +191,14 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 			case DescriptorIncomplete:
 				switch tableDesc.Mutations[i].Direction {
 				case DescriptorMutation_ADD:
-					return nil, roachpb.NewUErrorf("column %q in the middle of being added, try again later", t.GetColumn())
+					return nil, fmt.Errorf("column %q in the middle of being added, try again later", t.GetColumn())
 				case DescriptorMutation_DROP:
-					return nil, roachpb.NewUErrorf("column %q in the middle of being dropped", t.GetColumn())
+					return nil, fmt.Errorf("column %q in the middle of being dropped", t.GetColumn())
 				}
 			}
 
 		default:
-			return nil, roachpb.NewErrorf("unsupported alter cmd: %T", cmd)
+			return nil, fmt.Errorf("unsupported alter cmd: %T", cmd)
 		}
 	}
 	// Were some changes made?
@@ -213,22 +214,21 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, *roachpb.Error) {
 	}
 
 	mutationID := invalidMutationID
-	var err error
 	if addedMutations {
 		mutationID, err = tableDesc.finalizeMutation()
 	} else {
 		err = tableDesc.setUpVersion()
 	}
 	if err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 
 	if err := tableDesc.AllocateIDs(); err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 
-	if pErr := p.writeTableDesc(tableDesc); pErr != nil {
-		return nil, pErr
+	if err := p.writeTableDesc(tableDesc); err != nil {
+		return nil, err
 	}
 	p.notifySchemaChange(tableDesc.ID, mutationID)
 

--- a/sql/config_test.go
+++ b/sql/config_test.go
@@ -49,11 +49,11 @@ func forceNewConfig(t *testing.T, s *testServer) config.SystemConfig {
 	}
 
 	// This needs to be done in a transaction with the system trigger set.
-	if pErr := s.DB().Txn(func(txn *client.Txn) *roachpb.Error {
+	if err := s.DB().Txn(func(txn *client.Txn) error {
 		txn.SetSystemConfigTrigger()
 		return txn.Put(configDescKey, configDesc)
-	}); pErr != nil {
-		t.Fatal(pErr)
+	}); err != nil {
+		t.Fatal(err)
 	}
 	return waitForConfigChange(t, s)
 }

--- a/sql/create.go
+++ b/sql/create.go
@@ -17,23 +17,25 @@
 package sql
 
 import (
-	"github.com/cockroachdb/cockroach/roachpb"
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
+	"github.com/cockroachdb/cockroach/util"
 )
 
 // CreateDatabase creates a database.
 // Privileges: security.RootUser user.
 //   Notes: postgres requires superuser or "CREATEDB".
 //          mysql uses the mysqladmin command.
-func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, *roachpb.Error) {
+func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, error) {
 	if n.Name == "" {
-		return nil, roachpb.NewError(errEmptyDatabaseName)
+		return nil, errEmptyDatabaseName
 	}
 
 	if p.session.User != security.RootUser {
-		return nil, roachpb.NewUErrorf("only %s is allowed to create databases", security.RootUser)
+		return nil, util.Errorf("only %s is allowed to create databases", security.RootUser)
 	}
 
 	desc := makeDatabaseDesc(n)
@@ -44,7 +46,7 @@ func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, *roachpb.E
 	}
 	if created {
 		// Log Create Database event.
-		if pErr := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
+		if err := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
 			EventLogCreateDatabase,
 			int32(desc.ID),
 			int32(p.evalCtx.NodeID),
@@ -53,8 +55,8 @@ func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, *roachpb.E
 				Statement    string
 				User         string
 			}{n.Name.String(), n.String(), p.session.User},
-		); pErr != nil {
-			return nil, pErr
+		); err != nil {
+			return nil, err
 		}
 	}
 	return &emptyNode{}, nil
@@ -64,13 +66,13 @@ func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, *roachpb.E
 // Privileges: CREATE on table.
 //   notes: postgres requires CREATE on the table.
 //          mysql requires INDEX on the table.
-func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) {
-	tableDesc, pErr := p.getTableDesc(n.Table)
-	if pErr != nil {
-		return nil, pErr
+func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
+	tableDesc, err := p.getTableDesc(n.Table)
+	if err != nil {
+		return nil, err
 	}
 	if tableDesc == nil {
-		return nil, roachpb.NewError(tableDoesNotExistError(n.Table.String()))
+		return nil, tableDoesNotExistError(n.Table.String())
 	}
 
 	status, i, err := tableDesc.FindIndexByName(string(n.Name))
@@ -78,7 +80,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) 
 		if status == DescriptorIncomplete {
 			switch tableDesc.Mutations[i].Direction {
 			case DescriptorMutation_DROP:
-				return nil, roachpb.NewUErrorf("index %q being dropped, try again later", string(n.Name))
+				return nil, fmt.Errorf("index %q being dropped, try again later", string(n.Name))
 
 			case DescriptorMutation_ADD:
 				// Noop, will fail in AllocateIDs below.
@@ -91,7 +93,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) 
 	}
 
 	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 
 	indexDesc := IndexDescriptor{
@@ -100,20 +102,20 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) 
 		StoreColumnNames: n.Storing,
 	}
 	if err := indexDesc.fillColumns(n.Columns); err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 
 	tableDesc.addIndexMutation(indexDesc, DescriptorMutation_ADD)
 	mutationID, err := tableDesc.finalizeMutation()
 	if err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 	if err := tableDesc.AllocateIDs(); err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 
-	if pErr := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc)); pErr != nil {
-		return nil, pErr
+	if err := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc)); err != nil {
+		return nil, err
 	}
 	p.notifySchemaChange(tableDesc.ID, mutationID)
 
@@ -123,26 +125,26 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, *roachpb.Error) 
 // CreateTable creates a table.
 // Privileges: CREATE on database.
 //   Notes: postgres/mysql require CREATE on database.
-func (p *planner) CreateTable(n *parser.CreateTable) (planNode, *roachpb.Error) {
+func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 	if err := n.Table.NormalizeTableName(p.session.Database); err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 
-	dbDesc, pErr := p.getDatabaseDesc(n.Table.Database())
-	if pErr != nil {
-		return nil, pErr
+	dbDesc, err := p.getDatabaseDesc(n.Table.Database())
+	if err != nil {
+		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, roachpb.NewError(databaseDoesNotExistError(n.Table.Database()))
+		return nil, databaseDoesNotExistError(n.Table.Database())
 	}
 
 	if err := p.checkPrivilege(dbDesc, privilege.CREATE); err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 
 	desc, err := makeTableDesc(n, dbDesc.ID)
 	if err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 	// Inherit permissions from the database descriptor.
 	desc.Privileges = dbDesc.GetPrivileges()
@@ -166,22 +168,22 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, *roachpb.Error) 
 			ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 		}
 		if err := desc.AddIndex(idx, true); err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 	}
 
 	if err := desc.AllocateIDs(); err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 
-	created, pErr := p.createDescriptor(tableKey{dbDesc.ID, n.Table.Table()}, &desc, n.IfNotExists)
-	if pErr != nil {
-		return nil, pErr
+	created, err := p.createDescriptor(tableKey{dbDesc.ID, n.Table.Table()}, &desc, n.IfNotExists)
+	if err != nil {
+		return nil, err
 	}
 
 	if created {
 		// Log Create Table event.
-		if pErr := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
+		if err := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
 			EventLogCreateTable,
 			int32(desc.ID),
 			int32(p.evalCtx.NodeID),
@@ -190,8 +192,8 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, *roachpb.Error) 
 				Statement string
 				User      string
 			}{n.Table.String(), n.String(), p.session.User},
-		); pErr != nil {
-			return nil, pErr
+		); err != nil {
+			return nil, err
 		}
 	}
 

--- a/sql/database.go
+++ b/sql/database.go
@@ -82,13 +82,13 @@ func makeDatabaseDesc(p *parser.CreateDatabase) DatabaseDescriptor {
 // getDatabaseDesc looks up the database descriptor given its name.
 // Returns nil if the descriptor is not found. If you want to turn the "not
 // found" condition into an error, use databaseDoesNotExistError().
-func (p *planner) getDatabaseDesc(name string) (*DatabaseDescriptor, *roachpb.Error) {
+func (p *planner) getDatabaseDesc(name string) (*DatabaseDescriptor, error) {
 	desc := &DatabaseDescriptor{}
-	found, pErr := p.getDescriptor(databaseKey{name}, desc)
+	found, err := p.getDescriptor(databaseKey{name}, desc)
 	if !found {
-		return nil, pErr
+		return nil, err
 	}
-	return desc, pErr
+	return desc, err
 }
 
 // getCachedDatabaseDesc looks up the database descriptor given its name in the
@@ -137,7 +137,7 @@ func getKeysForDatabaseDescriptor(
 	return
 }
 
-func (p *planner) getDatabaseID(name string) (ID, *roachpb.Error) {
+func (p *planner) getDatabaseID(name string) (ID, error) {
 	if id := p.databaseCache.getID(name); id != 0 {
 		return id, nil
 	}
@@ -150,13 +150,13 @@ func (p *planner) getDatabaseID(name string) (ID, *roachpb.Error) {
 		if log.V(3) {
 			log.Infof("%v", err)
 		}
-		var pErr *roachpb.Error
-		desc, pErr = p.getDatabaseDesc(name)
-		if pErr != nil {
-			return 0, pErr
+		var err error
+		desc, err = p.getDatabaseDesc(name)
+		if err != nil {
+			return 0, err
 		}
 		if desc == nil {
-			return 0, roachpb.NewError(databaseDoesNotExistError(name))
+			return 0, databaseDoesNotExistError(name)
 		}
 	}
 

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -17,6 +17,8 @@
 package sql
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -33,31 +35,31 @@ import (
 // (cockroach database == postgres schema). the postgres default of not
 // dropping the schema if there are dependent objects is more sensible
 // (see the RESTRICT and CASCADE options).
-func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, *roachpb.Error) {
+func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, error) {
 	if n.Name == "" {
-		return nil, roachpb.NewError(errEmptyDatabaseName)
+		return nil, errEmptyDatabaseName
 	}
 
 	// Check that the database exists.
-	dbDesc, pErr := p.getDatabaseDesc(string(n.Name))
-	if pErr != nil {
-		return nil, pErr
+	dbDesc, err := p.getDatabaseDesc(string(n.Name))
+	if err != nil {
+		return nil, err
 	}
 	if dbDesc == nil {
 		if n.IfExists {
 			// Noop.
 			return &emptyNode{}, nil
 		}
-		return nil, roachpb.NewError(databaseDoesNotExistError(string(n.Name)))
+		return nil, databaseDoesNotExistError(string(n.Name))
 	}
 
 	if err := p.checkPrivilege(dbDesc, privilege.DROP); err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 
-	tbNames, pErr := p.getTableNames(dbDesc)
-	if pErr != nil {
-		return nil, pErr
+	tbNames, err := p.getTableNames(dbDesc)
+	if err != nil {
+		return nil, err
 	}
 
 	tbNameStrings := make([]string, len(tbNames))
@@ -68,8 +70,8 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, *roachpb.Error
 		}
 		if tbDesc == nil {
 			// Database claims to have this table, but it does not exist.
-			return nil, roachpb.NewErrorf("table %q was described by database %q, but does not exist",
-				tbName.String())
+			return nil, util.Errorf("table %q was described by database %q, but does not exist",
+				tbName.String(), n.Name)
 		}
 		tbNameStrings[i] = tbDesc.Name
 	}
@@ -91,12 +93,12 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, *roachpb.Error
 		return nil
 	})
 
-	if pErr := p.txn.Run(b); pErr != nil {
-		return nil, pErr
+	if err := p.txn.Run(b); err != nil {
+		return nil, err
 	}
 
 	// Log Drop Database event.
-	if pErr := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
+	if err := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
 		EventLogDropDatabase,
 		int32(dbDesc.ID),
 		int32(p.evalCtx.NodeID),
@@ -106,8 +108,8 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, *roachpb.Error
 			User          string
 			DroppedTables []string
 		}{n.Name.String(), n.String(), p.session.User, tbNameStrings},
-	); pErr != nil {
-		return nil, pErr
+	); err != nil {
+		return nil, err
 	}
 	return &emptyNode{}, nil
 }
@@ -116,22 +118,22 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, *roachpb.Error
 // Privileges: CREATE on table.
 //   Notes: postgres allows only the index owner to DROP an index.
 //          mysql requires the INDEX privilege on the table.
-func (p *planner) DropIndex(n *parser.DropIndex) (planNode, *roachpb.Error) {
+func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 	for _, index := range n.IndexList {
 		if err := index.Table.NormalizeTableName(p.session.Database); err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 
-		tableDesc, pErr := p.getTableDesc(index.Table)
-		if pErr != nil {
-			return nil, pErr
+		tableDesc, err := p.getTableDesc(index.Table)
+		if err != nil {
+			return nil, err
 		}
 		if tableDesc == nil {
-			return nil, roachpb.NewError(tableDoesNotExistError(index.Table.String()))
+			return nil, tableDoesNotExistError(index.Table.String())
 		}
 
 		if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 		idxName := string(index.Index)
 		status, i, err := tableDesc.FindIndexByName(idxName)
@@ -141,7 +143,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, *roachpb.Error) {
 				return &emptyNode{}, nil
 			}
 			// Index does not exist, but we want it to: error out.
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 		// Queue the mutation.
 		switch status {
@@ -152,7 +154,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, *roachpb.Error) {
 		case DescriptorIncomplete:
 			switch tableDesc.Mutations[i].Direction {
 			case DescriptorMutation_ADD:
-				return nil, roachpb.NewUErrorf("index %q in the middle of being added, try again later", idxName)
+				return nil, fmt.Errorf("index %q in the middle of being added, try again later", idxName)
 
 			case DescriptorMutation_DROP:
 				return &emptyNode{}, nil
@@ -160,13 +162,13 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, *roachpb.Error) {
 		}
 		mutationID, err := tableDesc.finalizeMutation()
 		if err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
-		if err := tableDesc.Validate(); pErr != nil {
-			return nil, roachpb.NewError(err)
+		if err := tableDesc.Validate(); err != nil {
+			return nil, err
 		}
-		if pErr := p.writeTableDesc(tableDesc); pErr != nil {
-			return nil, pErr
+		if err := p.writeTableDesc(tableDesc); err != nil {
+			return nil, err
 		}
 		p.notifySchemaChange(tableDesc.ID, mutationID)
 	}
@@ -177,7 +179,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, *roachpb.Error) {
 // Privileges: DROP on table.
 //   Notes: postgres allows only the table owner to DROP a table.
 //          mysql requires the DROP privilege on the table.
-func (p *planner) DropTable(n *parser.DropTable) (planNode, *roachpb.Error) {
+func (p *planner) DropTable(n *parser.DropTable) (planNode, error) {
 	for i := range n.Names {
 		droppedDesc, err := p.dropTableImpl(n.Names[i])
 		if err != nil {
@@ -188,10 +190,10 @@ func (p *planner) DropTable(n *parser.DropTable) (planNode, *roachpb.Error) {
 				continue
 			}
 			// Table does not exist, but we want it to: error out.
-			return nil, roachpb.NewError(tableDoesNotExistError(n.Names[i].String()))
+			return nil, tableDoesNotExistError(n.Names[i].String())
 		}
 		// Log a Drop Table event for this table.
-		if pErr := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
+		if err := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
 			EventLogDropTable,
 			int32(droppedDesc.ID),
 			int32(p.evalCtx.NodeID),
@@ -200,8 +202,8 @@ func (p *planner) DropTable(n *parser.DropTable) (planNode, *roachpb.Error) {
 				Statement string
 				User      string
 			}{droppedDesc.Name, n.String(), p.session.User},
-		); pErr != nil {
-			return nil, pErr
+		); err != nil {
+			return nil, err
 		}
 	}
 	return &emptyNode{}, nil
@@ -219,26 +221,25 @@ func (p *planner) DropTable(n *parser.DropTable) (planNode, *roachpb.Error) {
 // released).
 // If the table does not exist, this function returns a nil descriptor.
 func (p *planner) dropTableImpl(name *parser.QualifiedName,
-) (*TableDescriptor, *roachpb.Error) {
-	tableDesc, pErr := p.getTableDesc(name)
-	if pErr != nil {
-		return nil, pErr
+) (*TableDescriptor, error) {
+	tableDesc, err := p.getTableDesc(name)
+	if err != nil {
+		return nil, err
 	}
 	if tableDesc == nil {
-		return nil, pErr
+		return nil, err
 	}
 
-	if pErr := p.checkPrivilege(tableDesc, privilege.DROP); pErr != nil {
-		return nil, roachpb.NewError(pErr)
+	if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
+		return nil, err
 	}
 
-	err := tableDesc.setUpVersion()
-	if err != nil {
-		return nil, roachpb.NewError(err)
+	if err := tableDesc.setUpVersion(); err != nil {
+		return nil, err
 	}
 	tableDesc.Deleted = true
-	if pErr = p.writeTableDesc(tableDesc); pErr != nil {
-		return nil, pErr
+	if err = p.writeTableDesc(tableDesc); err != nil {
+		return nil, err
 	}
 	p.notifySchemaChange(tableDesc.ID, invalidMutationID)
 
@@ -265,10 +266,10 @@ func (p *planner) dropTableImpl(name *parser.QualifiedName,
 // truncateAndDropTable batches all the commands required for truncating and deleting the
 // table descriptor.
 // It is called from a mutation, async wrt the DROP statement.
-func truncateAndDropTable(tableDesc *TableDescriptor, db *client.DB) *roachpb.Error {
-	return db.Txn(func(txn *client.Txn) *roachpb.Error {
-		if pErr := truncateTable(tableDesc, txn); pErr != nil {
-			return pErr
+func truncateAndDropTable(tableDesc *TableDescriptor, db *client.DB) error {
+	return db.Txn(func(txn *client.Txn) error {
+		if err := truncateTable(tableDesc, txn); err != nil {
+			return err
 		}
 		zoneKey, nameKey, descKey := getKeysForTableDescriptor(tableDesc)
 		// Delete table descriptor

--- a/sql/grant.go
+++ b/sql/grant.go
@@ -17,7 +17,6 @@
 package sql
 
 import (
-	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 )
@@ -26,7 +25,7 @@ func (p *planner) changePrivileges(
 	targets parser.TargetList,
 	grantees parser.NameList,
 	changePrivilege func(*PrivilegeDescriptor, string),
-) (planNode, *roachpb.Error) {
+) (planNode, error) {
 	descriptors, err := p.getDescriptorsFromTargetList(targets)
 	if err != nil {
 		return nil, err
@@ -34,7 +33,7 @@ func (p *planner) changePrivileges(
 
 	for _, descriptor := range descriptors {
 		if err := p.checkPrivilege(descriptor, privilege.GRANT); err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 		privileges := descriptor.GetPrivileges()
 		for _, grantee := range grantees {
@@ -42,13 +41,13 @@ func (p *planner) changePrivileges(
 		}
 
 		if err := descriptor.Validate(); err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 
 		tableDesc, updatingTable := descriptor.(*TableDescriptor)
 		if updatingTable {
 			if err := tableDesc.setUpVersion(); err != nil {
-				return nil, roachpb.NewError(err)
+				return nil, err
 			}
 			p.notifySchemaChange(tableDesc.ID, invalidMutationID)
 		}
@@ -75,7 +74,7 @@ func (p *planner) changePrivileges(
 // Privileges: GRANT on database/table.
 //   Notes: postgres requires the object owner.
 //          mysql requires the "grant option" and the same privileges, and sometimes superuser.
-func (p *planner) Grant(n *parser.Grant) (planNode, *roachpb.Error) {
+func (p *planner) Grant(n *parser.Grant) (planNode, error) {
 	return p.changePrivileges(n.Targets, n.Grantees, func(privDesc *PrivilegeDescriptor, grantee string) {
 		privDesc.Grant(grantee, n.Privileges)
 	})
@@ -90,7 +89,7 @@ func (p *planner) Grant(n *parser.Grant) (planNode, *roachpb.Error) {
 // Privileges: GRANT on database/table.
 //   Notes: postgres requires the object owner.
 //          mysql requires the "grant option" and the same privileges, and sometimes superuser.
-func (p *planner) Revoke(n *parser.Revoke) (planNode, *roachpb.Error) {
+func (p *planner) Revoke(n *parser.Revoke) (planNode, error) {
 	return p.changePrivileges(n.Targets, n.Grantees, func(privDesc *PrivilegeDescriptor, grantee string) {
 		privDesc.Revoke(grantee, n.Privileges)
 	})

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -265,8 +265,8 @@ func (n *insertNode) Start() *roachpb.Error {
 		return pErr
 	}
 
-	if pErr := n.run.startEditNode(&n.editNodeBase, rows, n.tw); pErr != nil {
-		return pErr
+	if err := n.run.startEditNode(&n.editNodeBase, rows, n.tw); err != nil {
+		return roachpb.NewError(err)
 	}
 
 	// Prepare structures for building values to pass to rh.
@@ -302,7 +302,7 @@ func (n *insertNode) Next() bool {
 
 	if !n.run.rows.Next() {
 		// We're done. Finish the batch.
-		n.run.pErr = n.tw.finalize()
+		n.run.pErr = roachpb.NewError(n.tw.finalize())
 		n.run.done = true
 		return false
 	}
@@ -369,7 +369,8 @@ func (n *insertNode) Next() bool {
 		}
 	}
 
-	_, n.run.pErr = n.tw.row(rowVals)
+	_, err := n.tw.row(rowVals)
+	n.run.pErr = roachpb.NewError(err)
 	if n.run.pErr != nil {
 		return false
 	}

--- a/sql/kv_test.go
+++ b/sql/kv_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
@@ -84,26 +83,26 @@ func newKVNative(b *testing.B) kvInterface {
 func (kv *kvNative) insert(rows, run int) error {
 	firstRow := rows * run
 	lastRow := rows * (run + 1)
-	pErr := kv.db.Txn(func(txn *client.Txn) *roachpb.Error {
+	err := kv.db.Txn(func(txn *client.Txn) error {
 		b := txn.NewBatch()
 		for i := firstRow; i < lastRow; i++ {
 			b.Put(fmt.Sprintf("%s%06d", kv.prefix, i), i)
 		}
 		return txn.CommitInBatch(b)
 	})
-	return pErr.GoError()
+	return err
 }
 
 func (kv *kvNative) update(rows, run int) error {
 	perm := rand.Perm(rows)
-	pErr := kv.db.Txn(func(txn *client.Txn) *roachpb.Error {
+	err := kv.db.Txn(func(txn *client.Txn) error {
 		// Read all values in a batch.
 		b := txn.NewBatch()
 		for i := 0; i < rows; i++ {
 			b.Get(fmt.Sprintf("%s%06d", kv.prefix, perm[i]))
 		}
-		if pErr := txn.Run(b); pErr != nil {
-			return pErr
+		if err := txn.Run(b); err != nil {
+			return err
 		}
 		// Now add one to each value and add as puts to write batch.
 		wb := txn.NewBatch()
@@ -111,38 +110,38 @@ func (kv *kvNative) update(rows, run int) error {
 			v := result.Rows[0].ValueInt()
 			wb.Put(fmt.Sprintf("%s%06d", kv.prefix, perm[i]), v+1)
 		}
-		if pErr := txn.CommitInBatch(wb); pErr != nil {
-			return pErr
+		if err := txn.CommitInBatch(wb); err != nil {
+			return err
 		}
 		return nil
 	})
-	return pErr.GoError()
+	return err
 }
 
 func (kv *kvNative) del(rows, run int) error {
 	firstRow := rows * run
 	lastRow := rows * (run + 1)
-	pErr := kv.db.Txn(func(txn *client.Txn) *roachpb.Error {
+	err := kv.db.Txn(func(txn *client.Txn) error {
 		b := txn.NewBatch()
 		for i := firstRow; i < lastRow; i++ {
 			b.Del(fmt.Sprintf("%s%06d", kv.prefix, i))
 		}
 		return txn.CommitInBatch(b)
 	})
-	return pErr.GoError()
+	return err
 }
 
 func (kv *kvNative) scan(rows, run int) error {
 	var kvs []client.KeyValue
-	pErr := kv.db.Txn(func(txn *client.Txn) *roachpb.Error {
-		var pErr *roachpb.Error
-		kvs, pErr = txn.Scan(fmt.Sprintf("%s%06d", kv.prefix, 0), fmt.Sprintf("%s%06d", kv.prefix, rows), int64(rows))
-		return pErr
+	err := kv.db.Txn(func(txn *client.Txn) error {
+		var err error
+		kvs, err = txn.Scan(fmt.Sprintf("%s%06d", kv.prefix, 0), fmt.Sprintf("%s%06d", kv.prefix, rows), int64(rows))
+		return err
 	})
 	if len(kvs) != rows {
 		return util.Errorf("expected %d rows; got %d", rows, len(kvs))
 	}
-	return pErr.GoError()
+	return err
 }
 
 func (kv *kvNative) prep(rows int, initData bool) error {
@@ -151,14 +150,14 @@ func (kv *kvNative) prep(rows int, initData bool) error {
 	if !initData {
 		return nil
 	}
-	pErr := kv.db.Txn(func(txn *client.Txn) *roachpb.Error {
+	err := kv.db.Txn(func(txn *client.Txn) error {
 		b := txn.NewBatch()
 		for i := 0; i < rows; i++ {
 			b.Put(fmt.Sprintf("%s%06d", kv.prefix, i), i)
 		}
 		return txn.CommitInBatch(b)
 	})
-	return pErr.GoError()
+	return err
 }
 
 func (kv *kvNative) done() {

--- a/sql/kvfetcher.go
+++ b/sql/kvfetcher.go
@@ -157,7 +157,7 @@ func makeKVFetcher(txn *client.Txn, spans spans, reverse bool, firstBatchLimit i
 }
 
 // fetch retrieves spans from the kv
-func (f *kvFetcher) fetch() *roachpb.Error {
+func (f *kvFetcher) fetch() error {
 	batchSize := f.getBatchSize()
 
 	b := &client.Batch{MaxScanResults: batchSize}
@@ -221,8 +221,8 @@ func (f *kvFetcher) fetch() *roachpb.Error {
 		return nil
 	}
 
-	if pErr := f.txn.Run(b); pErr != nil {
-		return pErr
+	if err := f.txn.Run(b); err != nil {
+		return err
 	}
 
 	if f.kvs == nil {
@@ -255,14 +255,14 @@ func (f *kvFetcher) fetch() *roachpb.Error {
 
 // nextKV returns the next key/value (initiating fetches as necessary). When there are no more keys,
 // returns false and an empty key/value.
-func (f *kvFetcher) nextKV() (bool, client.KeyValue, *roachpb.Error) {
+func (f *kvFetcher) nextKV() (bool, client.KeyValue, error) {
 	if f.kvIndex == len(f.kvs) {
 		if f.fetchEnd {
 			return false, client.KeyValue{}, nil
 		}
-		pErr := f.fetch()
-		if pErr != nil {
-			return false, client.KeyValue{}, pErr
+		err := f.fetch()
+		if err != nil {
+			return false, client.KeyValue{}, err
 		}
 		if len(f.kvs) == 0 {
 			return false, client.KeyValue{}, nil

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -145,7 +145,7 @@ func (s LeaseStore) Acquire(txn *client.Txn, tableID ID, minVersion DescriptorVe
 	// there is no harm in that as no other transaction will be attempting to
 	// modify the descriptor and even if the descriptor is never created we'll
 	// just have a dangling lease entry which will eventually get GC'd.
-	pErr = s.db.Txn(func(txn *client.Txn) *roachpb.Error {
+	err := s.db.Txn(func(txn *client.Txn) error {
 		p := makePlanner()
 		p.txn = txn
 		p.session.User = security.RootUser
@@ -153,19 +153,19 @@ func (s LeaseStore) Acquire(txn *client.Txn, tableID ID, minVersion DescriptorVe
 			`VALUES ($1, $2, $3, $4)`
 		count, epErr := p.exec(insertLease, lease.ID, int(lease.Version), s.nodeID, &lease.expiration)
 		if epErr != nil {
-			return epErr
+			return epErr.GoError()
 		}
 		if count != 1 {
-			return roachpb.NewErrorf("%s: expected 1 result, found %d", insertLease, count)
+			return util.Errorf("%s: expected 1 result, found %d", insertLease, count)
 		}
 		return nil
 	})
-	return lease, pErr
+	return lease, roachpb.NewError(err)
 }
 
 // Release a previously acquired table descriptor lease.
 func (s LeaseStore) Release(lease *LeaseState) error {
-	pErr := s.db.Txn(func(txn *client.Txn) *roachpb.Error {
+	err := s.db.Txn(func(txn *client.Txn) error {
 		p := makePlanner()
 		p.txn = txn
 		p.session.User = security.RootUser
@@ -174,14 +174,14 @@ func (s LeaseStore) Release(lease *LeaseState) error {
 			`WHERE (descID, version, nodeID, expiration) = ($1, $2, $3, $4)`
 		count, pErr := p.exec(deleteLease, lease.ID, int(lease.Version), s.nodeID, &lease.expiration)
 		if pErr != nil {
-			return pErr
+			return pErr.GoError()
 		}
 		if count != 1 {
-			return roachpb.NewErrorf("%s: expected 1 result, found %d", deleteLease, count)
+			return util.Errorf("%s: expected 1 result, found %d", deleteLease, count)
 		}
 		return nil
 	})
-	return pErr.GoError()
+	return err
 }
 
 // waitForOneVersion returns once there are no unexpired leases on the
@@ -198,8 +198,8 @@ func (s LeaseStore) waitForOneVersion(tableID ID, retryOpts retry.Options) (Desc
 		// Get the current version of the table descriptor non-transactionally.
 		//
 		// TODO(pmattis): Do an inconsistent read here?
-		if pErr := s.db.GetProto(descKey, desc); pErr != nil {
-			return 0, pErr.GoError()
+		if err := s.db.GetProto(descKey, desc); err != nil {
+			return 0, err
 		}
 		tableDesc = desc.GetTable()
 		if tableDesc == nil {
@@ -233,7 +233,7 @@ func (s LeaseStore) waitForOneVersion(tableID ID, retryOpts retry.Options) (Desc
 // Returns the updated version of the descriptor.
 func (s LeaseStore) Publish(
 	tableID ID, update func(*TableDescriptor) error,
-) (*Descriptor, *roachpb.Error) {
+) (*Descriptor, error) {
 	retryOpts := retry.Options{
 		InitialBackoff: 20 * time.Millisecond,
 		MaxBackoff:     2 * time.Second,
@@ -246,13 +246,13 @@ func (s LeaseStore) Publish(
 		// of the table.
 		expectedVersion, err := s.waitForOneVersion(tableID, retryOpts)
 		if err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 
 		desc := &Descriptor{}
 		// There should be only one version of the descriptor, but it's
 		// a race now to update to the next version.
-		pErr := s.db.Txn(func(txn *client.Txn) *roachpb.Error {
+		err = s.db.Txn(func(txn *client.Txn) error {
 			descKey := MakeDescMetadataKey(tableID)
 
 			// Re-read the current version of the table descriptor, this time
@@ -262,7 +262,7 @@ func (s LeaseStore) Publish(
 			}
 			tableDesc := desc.GetTable()
 			if tableDesc == nil {
-				return roachpb.NewErrorf("ID %d is not a table", tableID)
+				return util.Errorf("ID %d is not a table", tableID)
 			}
 			if expectedVersion != tableDesc.Version {
 				// The version changed out from under us. Someone else must be
@@ -270,12 +270,12 @@ func (s LeaseStore) Publish(
 				if log.V(3) {
 					log.Infof("publish (version changed): %d != %d", expectedVersion, tableDesc.Version)
 				}
-				return roachpb.NewError(&roachpb.LeaseVersionChangedError{})
+				return &roachpb.LeaseVersionChangedError{}
 			}
 
 			// Run the update closure.
 			if err := update(tableDesc); err != nil {
-				return roachpb.NewError(err)
+				return err
 			}
 
 			// Bump the version and modification time.
@@ -287,7 +287,7 @@ func (s LeaseStore) Publish(
 					tableDesc.ID, tableDesc.Name, tableDesc.Version, now.GoTime())
 			}
 			if err := tableDesc.Validate(); err != nil {
-				return roachpb.NewError(err)
+				return err
 			}
 
 			// Write the updated descriptor.
@@ -297,16 +297,16 @@ func (s LeaseStore) Publish(
 			return txn.CommitInBatch(b)
 		})
 
-		switch pErr.GetDetail().(type) {
+		switch err.(type) {
 		case *roachpb.LeaseVersionChangedError:
 			// will loop around to retry
 		case *roachpb.DidntUpdateDescriptorError:
 			return desc, nil
 		default:
-			if pErr == nil {
+			if err == nil {
 				return desc, nil
 			}
-			return nil, pErr
+			return nil, err
 		}
 	}
 
@@ -317,21 +317,21 @@ func (s LeaseStore) Publish(
 // of a descriptor.
 func (s LeaseStore) countLeases(descID ID, version DescriptorVersion, expiration time.Time) (int, error) {
 	var count int
-	pErr := s.db.Txn(func(txn *client.Txn) *roachpb.Error {
+	err := s.db.Txn(func(txn *client.Txn) error {
 		p := makePlanner()
 		p.txn = txn
 		p.session.User = security.RootUser
 
 		const countLeases = `SELECT COUNT(version) FROM system.lease ` +
 			`WHERE descID = $1 AND version = $2 AND expiration > $3`
-		values, pErr := p.queryRow(countLeases, descID, int(version), expiration)
-		if pErr != nil {
-			return pErr
+		values, err := p.queryRow(countLeases, descID, int(version), expiration)
+		if err != nil {
+			return err.GoError()
 		}
 		count = int(*(values[0].(*parser.DInt)))
 		return nil
 	})
-	return count, pErr.GoError()
+	return count, err
 }
 
 // leaseSet maintains an ordered set of LeaseState objects. It supports
@@ -602,7 +602,7 @@ func (t *tableState) purgeOldLeases(
 
 	// Acquire and release a lease on the table at a version >= minVersion.
 	var lease *LeaseState
-	pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+	err := db.Txn(func(txn *client.Txn) error {
 		var pErr *roachpb.Error
 		if !deleted {
 			lease, pErr = t.acquire(txn, minVersion, store)
@@ -621,14 +621,14 @@ func (t *tableState) purgeOldLeases(
 				toRelease = t.active.data[:len(t.active.data)-1]
 			}
 			if err := t.releaseLeasesIfNotActive(toRelease, store); err != nil {
-				return roachpb.NewError(err)
+				return err
 			}
 			return nil
 		}
-		return pErr
-	})
-	if pErr != nil {
 		return pErr.GoError()
+	})
+	if err != nil {
+		return err
 	}
 	if lease == nil {
 		return nil

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -97,12 +97,12 @@ func (t *leaseTest) expectLeases(descID csql.ID, expected string) {
 
 func (t *leaseTest) acquire(nodeID uint32, descID csql.ID, version csql.DescriptorVersion) (*csql.LeaseState, error) {
 	var lease *csql.LeaseState
-	pErr := t.server.DB().Txn(func(txn *client.Txn) *roachpb.Error {
+	err := t.server.DB().Txn(func(txn *client.Txn) error {
 		var pErr *roachpb.Error
 		lease, pErr = t.node(nodeID).Acquire(txn, descID, version)
-		return pErr
+		return pErr.GoError()
 	})
-	return lease, pErr.GoError()
+	return lease, err
 }
 
 func (t *leaseTest) mustAcquire(nodeID uint32, descID csql.ID, version csql.DescriptorVersion) *csql.LeaseState {
@@ -123,12 +123,12 @@ func (t *leaseTest) mustRelease(nodeID uint32, lease *csql.LeaseState) {
 	}
 }
 
-func (t *leaseTest) publish(nodeID uint32, descID csql.ID) *roachpb.Error {
-	_, pErr := t.node(nodeID).Publish(descID,
+func (t *leaseTest) publish(nodeID uint32, descID csql.ID) error {
+	_, err := t.node(nodeID).Publish(descID,
 		func(*csql.TableDescriptor) error {
 			return nil
 		})
-	return pErr
+	return err
 }
 
 func (t *leaseTest) mustPublish(nodeID uint32, descID csql.ID) {
@@ -445,12 +445,12 @@ func isDeleted(tableID csql.ID, cfg config.SystemConfig) bool {
 
 func acquire(s server.TestServer, descID csql.ID, version csql.DescriptorVersion) (*csql.LeaseState, error) {
 	var lease *csql.LeaseState
-	pErr := s.DB().Txn(func(txn *client.Txn) *roachpb.Error {
+	err := s.DB().Txn(func(txn *client.Txn) error {
 		var pErr *roachpb.Error
 		lease, pErr = s.LeaseManager().Acquire(txn, descID, version)
-		return pErr
+		return pErr.GoError()
 	})
-	return lease, pErr.GoError()
+	return lease, err
 }
 
 // Test that once a table is marked as deleted, a lease's refcount dropping to 0

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -199,48 +199,62 @@ func (p *planner) makePlan(stmt parser.Statement, desiredTypes []parser.Datum, a
 
 	switch n := stmt.(type) {
 	case *parser.AlterTable:
-		return p.AlterTable(n)
+		pNode, err := p.AlterTable(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.BeginTransaction:
 		pNode, err := p.BeginTransaction(n)
 		return pNode, roachpb.NewError(err)
 	case *parser.CreateDatabase:
-		return p.CreateDatabase(n)
+		pNode, err := p.CreateDatabase(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.CreateIndex:
-		return p.CreateIndex(n)
+		pNode, err := p.CreateIndex(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.CreateTable:
-		return p.CreateTable(n)
+		pNode, err := p.CreateTable(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.Delete:
 		return p.Delete(n, desiredTypes, autoCommit)
 	case *parser.DropDatabase:
-		return p.DropDatabase(n)
+		pNode, err := p.DropDatabase(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.DropIndex:
-		return p.DropIndex(n)
+		pNode, err := p.DropIndex(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.DropTable:
-		return p.DropTable(n)
+		pNode, err := p.DropTable(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.Explain:
 		return p.Explain(n, autoCommit)
 	case *parser.Grant:
-		return p.Grant(n)
+		pNode, err := p.Grant(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.Insert:
 		return p.Insert(n, desiredTypes, autoCommit)
 	case *parser.ParenSelect:
 		return p.makePlan(n.Select, desiredTypes, autoCommit)
 	case *parser.RenameColumn:
-		return p.RenameColumn(n)
+		pNode, err := p.RenameColumn(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.RenameDatabase:
-		return p.RenameDatabase(n)
+		pNode, err := p.RenameDatabase(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.RenameIndex:
-		return p.RenameIndex(n)
+		pNode, err := p.RenameIndex(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.RenameTable:
-		return p.RenameTable(n)
+		pNode, err := p.RenameTable(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.Revoke:
-		return p.Revoke(n)
+		pNode, err := p.Revoke(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.Select:
 		return p.Select(n, desiredTypes, autoCommit)
 	case *parser.SelectClause:
 		return p.SelectClause(n, desiredTypes)
 	case *parser.Set:
-		return p.Set(n)
+		pNode, err := p.Set(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.SetTimeZone:
 		pNode, err := p.SetTimeZone(n)
 		return pNode, roachpb.NewError(err)
@@ -254,19 +268,26 @@ func (p *planner) makePlan(stmt parser.Statement, desiredTypes []parser.Datum, a
 		pNode, err := p.Show(n)
 		return pNode, roachpb.NewError(err)
 	case *parser.ShowCreateTable:
-		return p.ShowCreateTable(n)
+		pNode, err := p.ShowCreateTable(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.ShowColumns:
-		return p.ShowColumns(n)
+		pNode, err := p.ShowColumns(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.ShowDatabases:
-		return p.ShowDatabases(n)
+		pNode, err := p.ShowDatabases(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.ShowGrants:
-		return p.ShowGrants(n)
+		pNode, err := p.ShowGrants(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.ShowIndex:
-		return p.ShowIndex(n)
+		pNode, err := p.ShowIndex(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.ShowTables:
-		return p.ShowTables(n)
+		pNode, err := p.ShowTables(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.Truncate:
-		return p.Truncate(n)
+		pNode, err := p.Truncate(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.UnionClause:
 		return p.UnionClause(n, desiredTypes, autoCommit)
 	case *parser.Update:
@@ -292,17 +313,23 @@ func (p *planner) prepare(stmt parser.Statement) (planNode, *roachpb.Error) {
 		pNode, err := p.Show(n)
 		return pNode, roachpb.NewError(err)
 	case *parser.ShowCreateTable:
-		return p.ShowCreateTable(n)
+		pNode, err := p.ShowCreateTable(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.ShowColumns:
-		return p.ShowColumns(n)
+		pNode, err := p.ShowColumns(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.ShowDatabases:
-		return p.ShowDatabases(n)
+		pNode, err := p.ShowDatabases(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.ShowGrants:
-		return p.ShowGrants(n)
+		pNode, err := p.ShowGrants(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.ShowIndex:
-		return p.ShowIndex(n)
+		pNode, err := p.ShowIndex(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.ShowTables:
-		return p.ShowTables(n)
+		pNode, err := p.ShowTables(n)
+		return pNode, roachpb.NewError(err)
 	case *parser.Update:
 		return p.Update(n, nil, false)
 	default:
@@ -324,6 +351,7 @@ func (p *planner) query(sql string, args ...interface{}) (planNode, *roachpb.Err
 	return p.makePlan(stmt, nil, false)
 }
 
+// TODO(andrei): change to return error.
 func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, *roachpb.Error) {
 	plan, err := p.query(sql, args...)
 	if err != nil {
@@ -348,6 +376,7 @@ func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, *roa
 	return values, nil
 }
 
+// TODO(andrei): change to return error.
 func (p *planner) exec(sql string, args ...interface{}) (int, *roachpb.Error) {
 	plan, pErr := p.query(sql, args...)
 	if pErr != nil {
@@ -400,7 +429,7 @@ func (p *planner) releaseLeases() {
 	}
 }
 
-func (p *planner) writeTableDesc(tableDesc *TableDescriptor) *roachpb.Error {
+func (p *planner) writeTableDesc(tableDesc *TableDescriptor) error {
 	return p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc))
 }
 
@@ -440,6 +469,7 @@ type planNode interface {
 	Next() bool
 
 	// PErr returns the error, if any, encountered during iteration.
+	// TODO(andrei): change to return error
 	PErr() *roachpb.Error
 
 	// ExplainPlan returns a name and description and a list of child nodes.

--- a/sql/rowfetcher.go
+++ b/sql/rowfetcher.go
@@ -175,9 +175,12 @@ func (rf *rowFetcher) startScan(txn *client.Txn, spans spans, limitHint int64) *
 
 // nextKey retrieves the next key/value and sets kv/kvEnd. Returns whether a row
 // has been completed.
+// TODO(andrei): change to return error
 func (rf *rowFetcher) nextKey() (rowDone bool, pErr *roachpb.Error) {
 	var ok bool
-	ok, rf.kv, pErr = rf.kvFetcher.nextKV()
+	var err error
+	ok, rf.kv, err = rf.kvFetcher.nextKV()
+	pErr = roachpb.NewError(err)
 	if pErr != nil {
 		return false, pErr
 	}

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -55,7 +55,8 @@ type scanNode struct {
 	isSecondaryIndex bool
 	reverse          bool
 	ordering         orderingInfo
-	pErr             *roachpb.Error
+	// TODO(andrei): change to error
+	pErr *roachpb.Error
 
 	explain   explainMode
 	rowIndex  int // the index of the current row

--- a/sql/session.go
+++ b/sql/session.go
@@ -179,29 +179,20 @@ func (ts *txnState) resetStateAndTxn(state TxnStateEnum) {
 // received. If it's a retriable error and we're going to retry the txn,
 // then the state moves to RestartWait. Otherwise, the state moves to Aborted
 // and the KV txn is cleaned up.
-func (ts *txnState) updateStateAndCleanupOnErr(pErr *roachpb.Error, e *Executor) {
-	if pErr == nil {
+func (ts *txnState) updateStateAndCleanupOnErr(err error, e *Executor) {
+	if err == nil {
 		panic("updateStateAndCleanupOnErr called with no error")
 	}
-	if pErr.TransactionRestart == roachpb.TransactionRestart_NONE || !ts.willBeRetried() {
+	if _, ok := err.(*roachpb.RetryableTxnError); !ok || !ts.willBeRetried() {
 		// We can't or don't want to retry this txn, so the txn is over.
 		e.txnAbortCount.Inc(1)
-		ts.txn.CleanupOnError(pErr)
+		ts.txn.CleanupOnError(err)
 		ts.resetStateAndTxn(Aborted)
 	} else {
 		// If we got a retriable error, move the SQL txn to the RestartWait state.
 		// Note that TransactionAborted is also a retriable error, handled here;
 		// in this case cleanup for the txn has been done for us under the hood.
-		switch pErr.TransactionRestart {
-		case roachpb.TransactionRestart_BACKOFF:
-			// TODO(spencer): Get rid of BACKOFF retries. Note that we don't propagate
-			// the backoff hint to the client anyway. See #5249
-			fallthrough
-		case roachpb.TransactionRestart_IMMEDIATE:
-			ts.State = RestartWait
-		default:
-			panic(fmt.Sprintf("unexpected restart value: %s", pErr.TransactionRestart))
-		}
+		ts.State = RestartWait
 	}
 }
 
@@ -269,10 +260,10 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 			} else if done {
 				break
 			}
-			if pErr := sc.exec(
+			if err := sc.exec(
 				e.ctx.TestingKnobs.SchemaChangersStartBackfillNotification,
-			); pErr != nil {
-				if _, ok := pErr.GetDetail().(*roachpb.ExistingSchemaChangeLeaseError); ok {
+			); err != nil {
+				if _, ok := err.(*roachpb.ExistingSchemaChangeLeaseError); ok {
 					// Try again.
 					continue
 				}
@@ -285,9 +276,9 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 				// statements in the current batch; we can't modify the results of older
 				// statements.
 				if scEntry.epoch == scc.curGroupNum {
-					results[scEntry.idx] = Result{PErr: pErr}
+					results[scEntry.idx] = Result{PErr: roachpb.NewError(err)}
 				}
-				log.Warningf("Error executing schema change: %s", pErr)
+				log.Warningf("Error executing schema change: %s", err)
 			}
 			break
 		}

--- a/sql/set.go
+++ b/sql/set.go
@@ -30,7 +30,7 @@ import (
 // Set sets session variables.
 // Privileges: None.
 //   Notes: postgres/mysql do not require privileges for session variables (some exceptions).
-func (p *planner) Set(n *parser.Set) (planNode, *roachpb.Error) {
+func (p *planner) Set(n *parser.Set) (planNode, error) {
 	// By using QualifiedName.String() here any variables that are keywords will
 	// be double quoted.
 	name := strings.ToUpper(n.Name.String())
@@ -38,7 +38,7 @@ func (p *planner) Set(n *parser.Set) (planNode, *roachpb.Error) {
 	for i, expr := range n.Values {
 		typedValue, err := parser.TypeCheck(expr, nil, parser.DummyString)
 		if err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 		typedValues[i] = typedValue
 	}
@@ -46,16 +46,16 @@ func (p *planner) Set(n *parser.Set) (planNode, *roachpb.Error) {
 	case `DATABASE`:
 		dbName, err := p.getStringVal(name, typedValues)
 		if err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 		if len(dbName) != 0 {
 			// Verify database descriptor exists.
-			dbDesc, pErr := p.getDatabaseDesc(dbName)
-			if pErr != nil {
-				return nil, pErr
+			dbDesc, err := p.getDatabaseDesc(dbName)
+			if err != nil {
+				return nil, err
 			}
 			if dbDesc == nil {
-				return nil, roachpb.NewError(databaseDoesNotExistError(dbName))
+				return nil, databaseDoesNotExistError(dbName)
 			}
 		}
 		p.session.Database = dbName
@@ -63,7 +63,7 @@ func (p *planner) Set(n *parser.Set) (planNode, *roachpb.Error) {
 	case `SYNTAX`:
 		s, err := p.getStringVal(name, typedValues)
 		if err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 		switch NormalizeName(s) {
 		case NormalizeName(parser.Modern.String()):
@@ -71,14 +71,14 @@ func (p *planner) Set(n *parser.Set) (planNode, *roachpb.Error) {
 		case NormalizeName(parser.Traditional.String()):
 			p.session.Syntax = int32(parser.Traditional)
 		default:
-			return nil, roachpb.NewUErrorf("%s: \"%s\" is not in (%q, %q)", name, s, parser.Modern, parser.Traditional)
+			return nil, fmt.Errorf("%s: \"%s\" is not in (%q, %q)", name, s, parser.Modern, parser.Traditional)
 		}
 
 	case `EXTRA_FLOAT_DIGITS`:
 		// These settings are sent by the JDBC driver but we silently ignore them.
 
 	default:
-		return nil, roachpb.NewUErrorf("unknown variable: %q", name)
+		return nil, fmt.Errorf("unknown variable: %q", name)
 	}
 	return &emptyNode{}, nil
 }

--- a/sql/split_test.go
+++ b/sql/split_test.go
@@ -39,9 +39,9 @@ func getFastScanContext() *server.Context {
 
 // getRangeKeys returns the end keys of all ranges.
 func getRangeKeys(db *client.DB) ([]roachpb.Key, error) {
-	rows, pErr := db.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
-	if pErr != nil {
-		return nil, pErr.GoError()
+	rows, err := db.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+	if err != nil {
+		return nil, err
 	}
 	ret := make([]roachpb.Key, len(rows), len(rows))
 	for i := 0; i < len(rows); i++ {

--- a/sql/sqlutil/internal_executor.go
+++ b/sql/sqlutil/internal_executor.go
@@ -16,10 +16,7 @@
 
 package sqlutil
 
-import (
-	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/roachpb"
-)
+import "github.com/cockroachdb/cockroach/client"
 
 // InternalExecutor is meant to be used by layers below SQL in the system that
 // nevertheless want to execute SQL queries (presumably against system tables).
@@ -29,5 +26,5 @@ type InternalExecutor interface {
 	// ExecuteStatementInTransaction executes the supplied SQL statement as part of
 	// the supplied transaction. Statements are currently executed as the root user.
 	ExecuteStatementInTransaction(
-		txn *client.Txn, statement string, params ...interface{}) (int, *roachpb.Error)
+		txn *client.Txn, statement string, params ...interface{}) (int, error)
 }

--- a/sql/table.go
+++ b/sql/table.go
@@ -263,22 +263,22 @@ func makeColumnDefDescs(d *parser.ColumnTableDef) (*ColumnDescriptor, *IndexDesc
 // found.
 // If you want to transform the not found condition into an error, use
 // tableDoesNotExistError().
-func (p *planner) getTableDesc(qname *parser.QualifiedName) (*TableDescriptor, *roachpb.Error) {
+func (p *planner) getTableDesc(qname *parser.QualifiedName) (*TableDescriptor, error) {
 	if err := qname.NormalizeTableName(p.session.Database); err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
-	dbDesc, pErr := p.getDatabaseDesc(qname.Database())
-	if pErr != nil {
-		return nil, pErr
+	dbDesc, err := p.getDatabaseDesc(qname.Database())
+	if err != nil {
+		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, roachpb.NewError(databaseDoesNotExistError(qname.Database()))
+		return nil, databaseDoesNotExistError(qname.Database())
 	}
 
 	desc := TableDescriptor{}
-	found, pErr := p.getDescriptor(tableKey{parentID: dbDesc.ID, name: qname.Table()}, &desc)
-	if pErr != nil {
-		return nil, pErr
+	found, err := p.getDescriptor(tableKey{parentID: dbDesc.ID, name: qname.Table()}, &desc)
+	if err != nil {
+		return nil, err
 	}
 	if !found {
 		return nil, nil
@@ -289,16 +289,16 @@ func (p *planner) getTableDesc(qname *parser.QualifiedName) (*TableDescriptor, *
 // get the table descriptor for the ID passed in using an existing txn.
 // returns an error if the descriptor doesn't exist or if it exists and is not
 // a table.
-func getTableDescFromID(txn *client.Txn, id ID) (*TableDescriptor, *roachpb.Error) {
+func getTableDescFromID(txn *client.Txn, id ID) (*TableDescriptor, error) {
 	desc := &Descriptor{}
 	descKey := MakeDescMetadataKey(id)
 
-	if pErr := txn.GetProto(descKey, desc); pErr != nil {
-		return nil, pErr
+	if err := txn.GetProto(descKey, desc); err != nil {
+		return nil, err
 	}
 	table := desc.GetTable()
 	if table == nil {
-		return nil, roachpb.NewError(&roachpb.DescriptorNotFoundError{DescriptorId: uint32(id)})
+		return nil, &roachpb.DescriptorNotFoundError{DescriptorId: uint32(id)}
 	}
 	return table, nil
 }
@@ -333,9 +333,9 @@ func (p *planner) getTableLease(qname *parser.QualifiedName) (TableDescriptor, *
 		// system.lease and system.descriptor table, in particular, are problematic
 		// because they are used for acquiring leases itself, creating a
 		// chicken&egg problem.
-		desc, pErr := p.getTableDesc(qname)
-		if pErr != nil {
-			return TableDescriptor{}, pErr
+		desc, err := p.getTableDesc(qname)
+		if err != nil {
+			return TableDescriptor{}, roachpb.NewError(err)
 		}
 		if desc == nil {
 			return TableDescriptor{}, roachpb.NewError(tableDoesNotExistError(qname.String()))
@@ -343,9 +343,9 @@ func (p *planner) getTableLease(qname *parser.QualifiedName) (TableDescriptor, *
 		return *desc, nil
 	}
 
-	tableID, pErr := p.getTableID(qname)
-	if pErr != nil {
-		return TableDescriptor{}, pErr
+	tableID, err := p.getTableID(qname)
+	if err != nil {
+		return TableDescriptor{}, roachpb.NewError(err)
 	}
 
 	var lease *LeaseState
@@ -377,14 +377,14 @@ func (p *planner) getTableLease(qname *parser.QualifiedName) (TableDescriptor, *
 // getTableID retrieves the table ID for the specified table. It uses the
 // descriptor cache to perform lookups, falling back to the KV store when
 // necessary.
-func (p *planner) getTableID(qname *parser.QualifiedName) (ID, *roachpb.Error) {
+func (p *planner) getTableID(qname *parser.QualifiedName) (ID, error) {
 	if err := qname.NormalizeTableName(p.session.Database); err != nil {
-		return 0, roachpb.NewError(err)
+		return 0, err
 	}
 
-	dbID, pErr := p.getDatabaseID(qname.Database())
-	if pErr != nil {
-		return 0, pErr
+	dbID, err := p.getDatabaseID(qname.Database())
+	if err != nil {
+		return 0, err
 	}
 
 	// Lookup the ID of the table in the cache. The use of the cache might cause
@@ -398,24 +398,24 @@ func (p *planner) getTableID(qname *parser.QualifiedName) (ID, *roachpb.Error) {
 	key := nameKey.Key()
 	if nameVal := p.systemConfig.GetValue(key); nameVal != nil {
 		id, err := nameVal.GetInt()
-		return ID(id), roachpb.NewError(err)
+		return ID(id), err
 	}
 
-	gr, pErr := p.txn.Get(key)
-	if pErr != nil {
-		return 0, pErr
+	gr, err := p.txn.Get(key)
+	if err != nil {
+		return 0, err
 	}
 	if !gr.Exists() {
-		return 0, roachpb.NewError(tableDoesNotExistError(qname.String()))
+		return 0, tableDoesNotExistError(qname.String())
 	}
 	return ID(gr.ValueInt()), nil
 }
 
-func (p *planner) getTableNames(dbDesc *DatabaseDescriptor) (parser.QualifiedNames, *roachpb.Error) {
+func (p *planner) getTableNames(dbDesc *DatabaseDescriptor) (parser.QualifiedNames, error) {
 	prefix := MakeNameMetadataKey(dbDesc.ID, "")
-	sr, pErr := p.txn.Scan(prefix, prefix.PrefixEnd(), 0)
-	if pErr != nil {
-		return nil, pErr
+	sr, err := p.txn.Scan(prefix, prefix.PrefixEnd(), 0)
+	if err != nil {
+		return nil, err
 	}
 
 	var qualifiedNames parser.QualifiedNames
@@ -423,14 +423,14 @@ func (p *planner) getTableNames(dbDesc *DatabaseDescriptor) (parser.QualifiedNam
 		_, tableName, err := encoding.DecodeUnsafeStringAscending(
 			bytes.TrimPrefix(row.Key, prefix), nil)
 		if err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 		qname := &parser.QualifiedName{
 			Base:     parser.Name(dbDesc.Name),
 			Indirect: parser.Indirection{parser.NameIndirection(tableName)},
 		}
 		if err := qname.NormalizeTableName(""); err != nil {
-			return nil, roachpb.NewError(err)
+			return nil, err
 		}
 		qualifiedNames = append(qualifiedNames, qname)
 	}

--- a/storage/client_metrics_test.go
+++ b/storage/client_metrics_test.go
@@ -171,8 +171,8 @@ func TestStoreMetrics(t *testing.T) {
 
 	// Add some data to the "right" range.
 	dataKey := []byte("z")
-	if _, pErr := mtc.dbs[0].Inc(dataKey, 5); pErr != nil {
-		t.Fatal(pErr)
+	if _, err := mtc.dbs[0].Inc(dataKey, 5); err != nil {
+		t.Fatal(err)
 	}
 	mtc.waitForValues(roachpb.Key("z"), []int64{5, 5, 5})
 
@@ -182,11 +182,11 @@ func TestStoreMetrics(t *testing.T) {
 
 	// Create a transaction statement that fails, but will add an entry to the
 	// sequence cache. Regression test for #4969.
-	if pErr := mtc.dbs[0].Txn(func(txn *client.Txn) *roachpb.Error {
+	if err := mtc.dbs[0].Txn(func(txn *client.Txn) error {
 		b := &client.Batch{}
 		b.CPut(dataKey, 7, 6)
 		return txn.Run(b)
-	}); pErr == nil {
+	}); err == nil {
 		t.Fatal("Expected transaction error, but none received")
 	}
 

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -87,7 +87,7 @@ func (s *Store) ForceRaftLogScanAndProcess() {
 
 // LogReplicaChangeTest adds a fake replica change event to the log for the
 // range which contains the given key. This is intended for usage only in unit tests.
-func (s *Store) LogReplicaChangeTest(txn *client.Txn, changeType roachpb.ReplicaChangeType, replica roachpb.ReplicaDescriptor, desc roachpb.RangeDescriptor) *roachpb.Error {
+func (s *Store) LogReplicaChangeTest(txn *client.Txn, changeType roachpb.ReplicaChangeType, replica roachpb.ReplicaDescriptor, desc roachpb.RangeDescriptor) error {
 	return s.logChange(txn, changeType, replica, desc)
 }
 

--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -97,25 +97,25 @@ func (ia *idAllocator) start() {
 			var newValue int64
 			for newValue <= int64(ia.minID) {
 				var (
-					pErr *roachpb.Error
-					res  client.KeyValue
+					err error
+					res client.KeyValue
 				)
 				for r := retry.Start(idAllocationRetryOpts); r.Next(); {
 					idKey := ia.idKey.Load().(roachpb.Key)
 					if !ia.stopper.RunTask(func() {
-						res, pErr = ia.db.Inc(idKey, int64(ia.blockSize))
+						res, err = ia.db.Inc(idKey, int64(ia.blockSize))
 					}) {
 						return
 					}
-					if pErr == nil {
+					if err == nil {
 						newValue = res.ValueInt()
 						break
 					}
 
-					log.Warningf("unable to allocate %d ids from %s: %s", ia.blockSize, idKey, pErr)
+					log.Warningf("unable to allocate %d ids from %s: %s", ia.blockSize, idKey, err)
 				}
-				if pErr != nil {
-					panic(fmt.Sprintf("unexpectedly exited id allocation retry loop: %s", pErr))
+				if err != nil {
+					panic(fmt.Sprintf("unexpectedly exited id allocation retry loop: %s", err))
 				}
 			}
 

--- a/storage/intent_resolver.go
+++ b/storage/intent_resolver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/cockroachdb/cockroach/util/uuid"
@@ -74,7 +75,7 @@ func newIntentResolver(store *Store) *intentResolver {
 // to cause the client to back off).
 func (ir *intentResolver) processWriteIntentError(ctx context.Context,
 	wiErr roachpb.WriteIntentError, r *Replica, args roachpb.Request, h roachpb.Header,
-	pushType roachpb.PushTxnType) *roachpb.Error {
+	pushType roachpb.PushTxnType) error {
 
 	if log.V(6) {
 		log.Infoc(ctx, "resolving write intent %s", wiErr)
@@ -111,13 +112,13 @@ func (ir *intentResolver) processWriteIntentError(ctx context.Context,
 		// conflicts, return the write intent error which engages
 		// backoff/retry (with !Resolved). We don't need to restart the
 		// txn, only resend the read with a backoff.
-		return roachpb.NewError(&wiErr)
+		return &wiErr
 	}
 
 	// We pushed all transactions, so tell the client everything's
 	// resolved and it can retry immediately.
 	wiErr.Resolved = true
-	return roachpb.NewError(&wiErr)
+	return &wiErr
 }
 
 // maybePushTransactions tries to push the conflicting transaction(s)
@@ -146,7 +147,7 @@ func (ir *intentResolver) processWriteIntentError(ctx context.Context,
 //    in non-pending state and doesn't require a push.
 func (ir *intentResolver) maybePushTransactions(ctx context.Context, intents []roachpb.Intent,
 	h roachpb.Header, pushType roachpb.PushTxnType, skipIfInFlight bool) (
-	[]roachpb.Intent, *roachpb.Error) {
+	[]roachpb.Intent, error) {
 
 	now := ir.store.Clock().Now()
 
@@ -168,7 +169,6 @@ func (ir *intentResolver) maybePushTransactions(ctx context.Context, intents []r
 	ir.mu.Lock()
 	// TODO(tschottdorf): can optimize this and use same underlying slice.
 	var pushIntents, nonPendingIntents []roachpb.Intent
-	var pErr *roachpb.Error
 	for _, intent := range intents {
 		if intent.Status != roachpb.PENDING {
 			// The current intent does not need conflict resolution
@@ -190,7 +190,7 @@ func (ir *intentResolver) maybePushTransactions(ctx context.Context, intents []r
 	}
 	ir.mu.Unlock()
 	if len(nonPendingIntents) > 0 {
-		return nil, roachpb.NewErrorf("unexpected aborted/resolved intents: %s", nonPendingIntents)
+		return nil, util.Errorf("unexpected aborted/resolved intents: %+v", nonPendingIntents)
 	}
 
 	// Attempt to push the transaction(s) which created the conflicting intent(s).
@@ -212,11 +212,13 @@ func (ir *intentResolver) maybePushTransactions(ctx context.Context, intents []r
 			PushType: pushType,
 		})
 	}
-	// TODO(kaneda): Set the transaction in the header so that the
-	// txn is correctly propagated in an error response.
 	b := &client.Batch{}
 	b.InternalAddRequest(pushReqs...)
-	br, pErr := ir.store.db.RunWithResponse(b)
+	// TODO(tschottdorf): We're getting an err here that will be turned (back) into a
+	// pErr in the caller. Stop using the external RunWithResponse() interface for
+	// running this internal batch. Instead use the TxnCoordSender directly, and make
+	// this function return pErr.
+	br, err := ir.store.db.RunWithResponse(b)
 	ir.mu.Lock()
 	for _, intent := range pushIntents {
 		ir.mu.inFlight[*intent.Txn.ID]--
@@ -225,8 +227,8 @@ func (ir *intentResolver) maybePushTransactions(ctx context.Context, intents []r
 		}
 	}
 	ir.mu.Unlock()
-	if pErr != nil {
-		return nil, pErr
+	if err != nil {
+		return nil, err
 	}
 
 	var resolveIntents []roachpb.Intent
@@ -424,7 +426,7 @@ func (ir *intentResolver) resolveIntents(ctx context.Context, r *Replica,
 		b.InternalAddRequest(reqsRemote...)
 		action := func() error {
 			// TODO(tschottdorf): no tracing here yet.
-			return r.store.DB().Run(b).GoError()
+			return r.store.DB().Run(b)
 		}
 		if wait || !r.store.Stopper().RunLimitedAsyncTask(ir.sem, func() {
 			if err := action(); err != nil {

--- a/storage/intent_resolver_test.go
+++ b/storage/intent_resolver_test.go
@@ -38,7 +38,7 @@ func TestPushTransactionsWithNonPendingIntent(t *testing.T) {
 
 	intents := []roachpb.Intent{{Span: roachpb.Span{Key: roachpb.Key("a")}, Status: roachpb.ABORTED}}
 	if _, pErr := tc.store.intentResolver.maybePushTransactions(
-		tc.rng.context(context.Background()), intents, roachpb.Header{}, roachpb.PUSH_TOUCH, true); !testutils.IsPError(pErr, "unexpected aborted/resolved intent") {
+		tc.rng.context(context.Background()), intents, roachpb.Header{}, roachpb.PUSH_TOUCH, true); !testutils.IsError(pErr, "unexpected aborted/resolved intent") {
 		t.Errorf("expected error on aborted/resolved intent, but got %s", pErr)
 	}
 }

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -146,25 +146,25 @@ func TestLogRebalances(t *testing.T) {
 	// this range's information to log fake rebalance events.
 	db := s.DB()
 	desc := &roachpb.RangeDescriptor{}
-	if pErr := db.GetProto(keys.RangeDescriptorKey(roachpb.RKeyMin), desc); pErr != nil {
-		t.Fatal(pErr)
+	if err := db.GetProto(keys.RangeDescriptorKey(roachpb.RKeyMin), desc); err != nil {
+		t.Fatal(err)
 	}
 
 	// This code assumes that there is only one TestServer, and thus that
 	// StoreID 1 is present on the testserver. If this assumption changes in the
 	// future, *any* store will work, but a new method will need to be added to
 	// Stores (or a creative usage of VisitStores could suffice).
-	store, pErr := s.Stores().GetStore(roachpb.StoreID(1))
-	if pErr != nil {
-		t.Fatal(pErr)
+	store, err := s.Stores().GetStore(roachpb.StoreID(1))
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// Log several fake events using the store.
 	logEvent := func(changeType roachpb.ReplicaChangeType) {
-		if pErr := db.Txn(func(txn *client.Txn) *roachpb.Error {
+		if err := db.Txn(func(txn *client.Txn) error {
 			return store.LogReplicaChangeTest(txn, changeType, desc.Replicas[0], *desc)
-		}); pErr != nil {
-			t.Fatal(pErr)
+		}); err != nil {
+			t.Fatal(err)
 		}
 	}
 	reg := store.Registry()

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -141,7 +141,7 @@ func (rlq *raftLogQueue) process(now roachpb.Timestamp, r *Replica, _ config.Sys
 			Index:   oldestIndex,
 			RangeID: r.RangeID,
 		})
-		return rlq.db.Run(b).GoError()
+		return rlq.db.Run(b)
 	}
 	return nil
 }

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -106,9 +106,9 @@ func (q *replicaGCQueue) process(now roachpb.Timestamp, rng *Replica, _ config.S
 		},
 		MaxRanges: 1,
 	})
-	br, pErr := q.db.RunWithResponse(b)
-	if pErr != nil {
-		return pErr.GoError()
+	br, err := q.db.RunWithResponse(b)
+	if err != nil {
+		return err
 	}
 	reply := br.Responses[0].GetInner().(*roachpb.RangeLookupResponse)
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -3170,8 +3170,8 @@ func TestEndTransactionDirectGCFailure(t *testing.T) {
 	util.SucceedsSoon(t, func() error {
 		if atomic.LoadInt64(&count) == 0 {
 			return util.Errorf("intent resolution not attempted yet")
-		} else if pErr := tc.store.DB().Put("panama", "banana"); pErr != nil {
-			return pErr.GoError()
+		} else if err := tc.store.DB().Put("panama", "banana"); err != nil {
+			return err
 		}
 		return nil
 	})

--- a/ts/db.go
+++ b/ts/db.go
@@ -135,5 +135,5 @@ func (db *DB) StoreData(r Resolution, data []TimeSeriesData) error {
 		})
 	}
 
-	return db.db.Run(&b).GoError()
+	return db.db.Run(&b)
 }

--- a/ts/query.go
+++ b/ts/query.go
@@ -431,10 +431,10 @@ func (db *DB) Query(query Query, r Resolution, startNanos, endNanos int64) ([]Ti
 		// query.
 		startKey := MakeDataKey(query.Name, "" /* source */, r, startNanos)
 		endKey := MakeDataKey(query.Name, "" /* source */, r, endNanos).PrefixEnd()
-		var pErr *roachpb.Error
-		rows, pErr = db.db.ScanInconsistent(startKey, endKey, 0)
-		if pErr != nil {
-			return nil, nil, pErr.GoError()
+		var err error
+		rows, err = db.db.ScanInconsistent(startKey, endKey, 0)
+		if err != nil {
+			return nil, nil, err
 		}
 	} else {
 		b := db.db.NewBatch()
@@ -450,9 +450,9 @@ func (db *DB) Query(query Query, r Resolution, startNanos, endNanos int64) ([]Ti
 				b.Get(key)
 			}
 		}
-		pErr := db.db.Run(b)
-		if pErr != nil {
-			return nil, nil, pErr.GoError()
+		err := db.db.Run(b)
+		if err != nil {
+			return nil, nil, err
 		}
 		for _, result := range b.Results {
 			row := result.Rows[0]


### PR DESCRIPTION
Tobias, this time I went ground-up. Changed the interface of `Txn` to return `error` everywhere, and from there on and on and on. Notably `DB.Txn()` now returns `error` too, and its closure returns `error`.
I didn't go all the way with the refactoring, there's still some leaves where I convert the `error` back to `pErr`. If it looks good, I'll go all the way, although I'm not sure how I'll ever get this merged. Might have to freeze the repo :).
Didn't run any tests yet. Started converting the KV tests over, but it takes time.

There was a place where I needed to convert a `pErr` to `error` and then back - in `Store.Send()`, which still needs to return `pErr`, it sometimes runs other batches, and takes an error from there, and then passes it back as the error for the original txn. So I've made `roachpb.NewError` recognize retryable errors and produce a `pErr` that's also retryable -> so that it will again be converted to a retryable `error`. Please see if this looks correct to you.

Otherwise the change was mostly mechanical. `pErr` has an index for its position within the batch, so I had to replace that with some code where it was used (see calls to `convertBatchError`).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6367)

<!-- Reviewable:end -->
