### PR TITLE
sql: support NULL in tuple comparison

### DIFF
--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -735,20 +735,20 @@ var CmpOps = map[CmpArgs]CmpOp{
 
 	CmpArgs{EQ, tupleType, tupleType}: {
 		fn: func(_ EvalContext, ldatum, rdatum Datum) (DBool, error) {
-			c := cmpTuple(ldatum, rdatum)
-			return DBool(c == 0), nil
+			c, err := cmpTuple(ldatum, rdatum)
+			return DBool(c == 0), err
 		},
 	},
 	CmpArgs{LE, tupleType, tupleType}: {
 		fn: func(_ EvalContext, ldatum, rdatum Datum) (DBool, error) {
-			c := cmpTuple(ldatum, rdatum)
-			return DBool(c <= 0), nil
+			c, err := cmpTuple(ldatum, rdatum)
+			return DBool(c <= 0), err
 		},
 	},
 	CmpArgs{LT, tupleType, tupleType}: {
 		fn: func(_ EvalContext, ldatum, rdatum Datum) (DBool, error) {
-			c := cmpTuple(ldatum, rdatum)
-			return DBool(c < 0), nil
+			c, err := cmpTuple(ldatum, rdatum)
+			return DBool(c < 0), err
 		},
 	},
 
@@ -764,9 +764,22 @@ var CmpOps = map[CmpArgs]CmpOp{
 	CmpArgs{In, tupleType, tupleType}:       evalTupleIN,
 }
 
-func cmpTuple(ldatum, rdatum Datum) int {
+var errCmpNull = errors.New("NULL comparison")
+
+func cmpTuple(ldatum, rdatum Datum) (int, error) {
 	left := *ldatum.(*DTuple)
-	return left.Compare(rdatum)
+	right := *rdatum.(*DTuple)
+	for i, l := range left {
+		r := right[i]
+		if l == DNull || r == DNull {
+			return 0, errCmpNull
+		}
+		c := l.Compare(r)
+		if c != 0 {
+			return c, nil
+		}
+	}
+	return 0, nil
 }
 
 var evalTupleIN = CmpOp{
@@ -1268,6 +1281,9 @@ func (expr *ComparisonExpr) Eval(ctx EvalContext) (Datum, error) {
 
 	_, newLeft, newRight, not := foldComparisonExpr(expr.Operator, left, right)
 	d, err := expr.fn.fn(ctx, newLeft, newRight)
+	if err == errCmpNull {
+		return DNull, nil
+	}
 	if err == nil && not {
 		return MakeDBool(!d), nil
 	}

--- a/sql/testdata/tuple
+++ b/sql/testdata/tuple
@@ -82,6 +82,15 @@ SELECT
 ----
 true true true true false true true true true
 
+query BBBB
+SELECT
+	(1, 1) > (0, NULL),
+	(1, 1) > (1, NULL),
+	(1, 1) > (2, NULL),
+	(1, 1) > (NULL, 0)
+----
+true NULL false NULL
+
 statement error pq: unsupported comparison operator: <string> = <int>
 SELECT (1, 2) > (1, 'hi')
 


### PR DESCRIPTION
Since parser.CmpOp.fn's signature returns a DBool, use a sentinel error
to indicate NULL. A cleaner solution may be to change the signature to
allow for explicitly returning a NULL.

Matches postgres behavior.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6370)

<!-- Reviewable:end -->
