### PR TITLE
storage/engine: add MVCCBlind{Put,ConditionalPut} fast-path operations

### DIFF
--- a/storage/engine/bench_rocksdb_test.go
+++ b/storage/engine/bench_rocksdb_test.go
@@ -160,6 +160,22 @@ func BenchmarkMVCCPut10000_RocksDB(b *testing.B) {
 	runMVCCPut(setupMVCCInMemRocksDB, 10000, b)
 }
 
+func BenchmarkMVCCBlindPut10_RocksDB(b *testing.B) {
+	runMVCCBlindPut(setupMVCCInMemRocksDB, 10, b)
+}
+
+func BenchmarkMVCCBlindPut100_RocksDB(b *testing.B) {
+	runMVCCBlindPut(setupMVCCInMemRocksDB, 100, b)
+}
+
+func BenchmarkMVCCBlindPut1000_RocksDB(b *testing.B) {
+	runMVCCBlindPut(setupMVCCInMemRocksDB, 1000, b)
+}
+
+func BenchmarkMVCCBlindPut10000_RocksDB(b *testing.B) {
+	runMVCCBlindPut(setupMVCCInMemRocksDB, 10000, b)
+}
+
 func BenchmarkMVCCConditionalPutCreate10_RocksDB(b *testing.B) {
 	runMVCCConditionalPut(setupMVCCInMemRocksDB, 10, false, b)
 }
@@ -191,6 +207,23 @@ func BenchmarkMVCCConditionalPutReplace1000_RocksDB(b *testing.B) {
 func BenchmarkMVCCConditionalPutReplace10000_RocksDB(b *testing.B) {
 	runMVCCConditionalPut(setupMVCCInMemRocksDB, 10000, true, b)
 }
+
+func BenchmarkMVCCBlindConditionalPut10_RocksDB(b *testing.B) {
+	runMVCCBlindConditionalPut(setupMVCCInMemRocksDB, 10, b)
+}
+
+func BenchmarkMVCCBlindConditionalPut100_RocksDB(b *testing.B) {
+	runMVCCBlindConditionalPut(setupMVCCInMemRocksDB, 100, b)
+}
+
+func BenchmarkMVCCBlindConditionalPut1000_RocksDB(b *testing.B) {
+	runMVCCBlindConditionalPut(setupMVCCInMemRocksDB, 1000, b)
+}
+
+func BenchmarkMVCCBlindConditionalPut10000_RocksDB(b *testing.B) {
+	runMVCCBlindConditionalPut(setupMVCCInMemRocksDB, 10000, b)
+}
+
 func BenchmarkMVCCBatch1Put10_RocksDB(b *testing.B) {
 	runMVCCBatchPut(setupMVCCInMemRocksDB, 10, 1, b)
 }

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -673,8 +673,15 @@ func MVCCGetAsTxn(
 //    that is the usual contribution of the meta key). The value size returned
 //    will be zero.
 // The passed in MVCCMetadata must not be nil.
+//
+// If the supplied iterator is nil, no seek operation is performed. This is
+// used by the Blind{Put,ConditionalPut} operations to avoid seeking when the
+// metadata is known not to exist.
 func mvccGetMetadata(iter Iterator, metaKey MVCCKey,
 	meta *MVCCMetadata) (ok bool, keyBytes, valBytes int64, err error) {
+	if iter == nil {
+		return false, 0, 0, nil
+	}
 	iter.Seek(metaKey)
 	if !iter.Valid() {
 		return false, 0, 0, nil
@@ -918,6 +925,22 @@ func MVCCPut(
 	defer iter.Close()
 
 	return mvccPutUsingIter(ctx, engine, iter, ms, key, timestamp, value, txn, nil /* valueFn */)
+}
+
+// MVCCBlindPut is a fast-path of MVCCPut. See the MVCCPut comments for details
+// of the semantics. MVCCBlindPut skips retrieving the existing metadata for
+// the key requiring the caller to guarantee no versions for the key currently
+// exist.
+func MVCCBlindPut(
+	ctx context.Context,
+	engine Engine,
+	ms *MVCCStats,
+	key roachpb.Key,
+	timestamp roachpb.Timestamp,
+	value roachpb.Value,
+	txn *roachpb.Transaction,
+) error {
+	return mvccPutUsingIter(ctx, engine, nil, ms, key, timestamp, value, txn, nil /* valueFn */)
 }
 
 // MVCCDelete marks the key deleted so that it will not be returned in
@@ -1227,6 +1250,38 @@ func MVCCConditionalPut(
 	iter := engine.NewIterator(key)
 	defer iter.Close()
 
+	return mvccConditionalPutUsingIter(ctx, engine, iter, ms, key, timestamp, value, expVal, txn)
+}
+
+// MVCCBlindConditionalPut is a fast-path of MVCCConditionalPut. See the
+// MVCCConditionalPut comments for details of the
+// semantics. MVCCBlindConditionalPut skips retrieving the existing metadata
+// for the key requiring the caller to guarantee no versions for the key
+// currently exist.
+func MVCCBlindConditionalPut(
+	ctx context.Context,
+	engine Engine,
+	ms *MVCCStats,
+	key roachpb.Key,
+	timestamp roachpb.Timestamp,
+	value roachpb.Value,
+	expVal *roachpb.Value,
+	txn *roachpb.Transaction,
+) error {
+	return mvccConditionalPutUsingIter(ctx, engine, nil, ms, key, timestamp, value, expVal, txn)
+}
+
+func mvccConditionalPutUsingIter(
+	ctx context.Context,
+	engine Engine,
+	iter Iterator,
+	ms *MVCCStats,
+	key roachpb.Key,
+	timestamp roachpb.Timestamp,
+	value roachpb.Value,
+	expVal *roachpb.Value,
+	txn *roachpb.Transaction,
+) error {
 	return mvccPutUsingIter(ctx, engine, iter, ms, key, timestamp, noValue, txn, func(existVal *roachpb.Value) ([]byte, error) {
 		if expValPresent, existValPresent := expVal != nil, existVal != nil; expValPresent && existValPresent {
 			// Every type flows through here, so we can't use the typed getters.


### PR DESCRIPTION
See #6373.

```
name                                     speed
MVCCPut10_RocksDB-8                      2.83MB/s ± 3%
MVCCPut100_RocksDB-8                     27.2MB/s ± 3%
MVCCPut1000_RocksDB-8                     169MB/s ± 3%
MVCCPut10000_RocksDB-8                    459MB/s ± 2%
MVCCBlindPut10_RocksDB-8                 7.46MB/s ± 1%
MVCCBlindPut100_RocksDB-8                68.5MB/s ± 1%
MVCCBlindPut1000_RocksDB-8                342MB/s ± 0%
MVCCBlindPut10000_RocksDB-8               581MB/s ± 1%
MVCCConditionalPutCreate10_RocksDB-8     2.81MB/s ± 1%
MVCCConditionalPutCreate100_RocksDB-8    27.0MB/s ± 1%
MVCCConditionalPutCreate1000_RocksDB-8    167MB/s ± 3%
MVCCConditionalPutCreate10000_RocksDB-8   455MB/s ± 0%
MVCCBlindConditionalPut10_RocksDB-8      7.33MB/s ± 4%
MVCCBlindConditionalPut100_RocksDB-8     67.2MB/s ± 2%
MVCCBlindConditionalPut1000_RocksDB-8     342MB/s ± 1%
MVCCBlindConditionalPut10000_RocksDB-8    578MB/s ± 1%
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6375)

<!-- Reviewable:end -->
