### PR TITLE
sql: various allocation optimizations

### DIFF
--- a/client/util.go
+++ b/client/util.go
@@ -52,6 +52,9 @@ func marshalValue(v interface{}) (roachpb.Value, error) {
 
 	// Handle a few common types via a type switch.
 	switch t := v.(type) {
+	case *roachpb.Value:
+		return *t, nil
+
 	case nil:
 		return r, nil
 

--- a/client/util.go
+++ b/client/util.go
@@ -35,10 +35,12 @@ import (
 
 func marshalKey(k interface{}) (roachpb.Key, error) {
 	switch t := k.(type) {
-	case string:
-		return roachpb.Key(t), nil
+	case *roachpb.Key:
+		return *t, nil
 	case roachpb.Key:
 		return t, nil
+	case string:
+		return roachpb.Key(t), nil
 	case []byte:
 		return roachpb.Key(t), nil
 	}

--- a/roachpb/api.go
+++ b/roachpb/api.go
@@ -667,7 +667,9 @@ func NewConditionalPut(key Key, value, expValue Value) Request {
 	value.InitChecksum(key)
 	var expValuePtr *Value
 	if expValue.RawBytes != nil {
-		expValuePtr = &expValue
+		// Make a copy to avoid forcing expValue itself on to the heap.
+		expValueTmp := expValue
+		expValuePtr = &expValueTmp
 		expValue.InitChecksum(key)
 	}
 	return &ConditionalPutRequest{

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -347,7 +347,7 @@ func (v *Value) ShallowClone() *Value {
 // MakeValueFromString returns a value with bytes and tag set.
 func MakeValueFromString(s string) Value {
 	v := Value{}
-	v.SetBytes([]byte(s))
+	v.SetString(s)
 	return v
 }
 
@@ -386,6 +386,15 @@ func (v Value) dataBytes() []byte {
 func (v *Value) SetBytes(b []byte) {
 	v.RawBytes = make([]byte, headerSize+len(b))
 	copy(v.dataBytes(), b)
+	v.setTag(ValueType_BYTES)
+}
+
+// SetString sets the bytes and tag field of the receiver and clears the
+// checksum. This is identical to SetBytes, but specialized for a string
+// argument.
+func (v *Value) SetString(s string) {
+	v.RawBytes = make([]byte, headerSize+len(s))
+	copy(v.dataBytes(), s)
 	v.setTag(ValueType_BYTES)
 }
 

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -246,6 +246,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 	if err != nil {
 		return roachpb.NewError(err)
 	}
+	marshalled := make([]roachpb.Value, len(defaultExprs))
 
 	// Remember any new non nullable column with no default value.
 	nonNullableColumn := ""
@@ -345,13 +346,13 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 								if err != nil {
 									return roachpb.NewError(err)
 								}
-								val, err := marshalColumnValue(col, d)
+								marshalled[i], err = marshalColumnValue(col, d)
 								if err != nil {
 									return roachpb.NewError(err)
 								}
 
 								if log.V(2) {
-									log.Infof("Put %s -> %v", colKey, val)
+									log.Infof("Put %s -> %v", colKey, d)
 								}
 								// Insert default value into the column. If
 								// this row was recently added the default
@@ -365,7 +366,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 								// SQL INSERT cannot directly reference the
 								// column, and the INSERT populates the column
 								// with the default value.
-								writeBatch.Put(colKey, val)
+								writeBatch.Put(colKey, &marshalled[i])
 							}
 						}
 					}

--- a/sql/rowwriter.go
+++ b/sql/rowwriter.go
@@ -123,7 +123,9 @@ type rowInserter struct {
 	cols      []ColumnDescriptor
 
 	// For allocation avoidance.
-	marshalled []roachpb.Value
+	marshalled    []roachpb.Value
+	key           roachpb.Key
+	sentinelValue roachpb.Value
 }
 
 // makeRowInserter creates a rowInserter for the given table.
@@ -154,11 +156,12 @@ func makeRowInserter(
 		return rowInserter{}, err
 	}
 
-	return rowInserter{
+	ri := rowInserter{
 		rowHelper:  rh,
 		cols:       cols,
 		marshalled: make([]roachpb.Value, len(cols)),
-	}, nil
+	}
+	return ri, nil
 }
 
 // insertRow adds to the batch the kv operations necessary to insert a table row
@@ -188,20 +191,24 @@ func (ri *rowInserter) insertRow(b *client.Batch, values []parser.Datum) *roachp
 	// we are trying to insert a duplicate primary key: if we write the
 	// secondary indexes first, we may get an error that looks like a
 	// uniqueness violation on a non-unique index.
-	sentinelKey := keys.MakeNonColumnKey(primaryIndexKey)
+	ri.key = keys.MakeNonColumnKey(primaryIndexKey)
 	if log.V(2) {
-		log.Infof("CPut %s -> NULL", roachpb.Key(sentinelKey))
+		log.Infof("CPut %s -> NULL", ri.key)
 	}
-	// This is subtle: An interface{}(nil) deletes the value, so we pass in
-	// []byte{} as a non-nil value.
-	b.CPut(sentinelKey, []byte{}, nil)
+	// Each sentinel value needs a distinct RawBytes field as the computed
+	// checksum includes the key the value is associated with.
+	ri.sentinelValue.SetBytes([]byte{})
+	b.CPut(&ri.key, &ri.sentinelValue, nil)
+	ri.key = nil
 
 	for _, secondaryIndexEntry := range secondaryIndexEntries {
 		if log.V(2) {
 			log.Infof("CPut %s -> %v", secondaryIndexEntry.key, secondaryIndexEntry.value)
 		}
-		b.CPut(secondaryIndexEntry.key, secondaryIndexEntry.value, nil)
+		ri.key = secondaryIndexEntry.key
+		b.CPut(&ri.key, secondaryIndexEntry.value, nil)
 	}
+	ri.key = nil
 
 	// Write the row columns.
 	for i, val := range values {
@@ -219,12 +226,13 @@ func (ri *rowInserter) insertRow(b *client.Batch, values []parser.Datum) *roachp
 			// considered NULL during scanning and the row sentinel ensures we know
 			// the row exists.
 
-			key := keys.MakeColumnKey(primaryIndexKey, uint32(col.ID))
+			ri.key = keys.MakeColumnKey(primaryIndexKey, uint32(col.ID))
 			if log.V(2) {
-				log.Infof("CPut %s -> %v", roachpb.Key(key), val)
+				log.Infof("CPut %s -> %v", ri.key, val)
 			}
 
-			b.CPut(key, &ri.marshalled[i], nil)
+			b.CPut(&ri.key, &ri.marshalled[i], nil)
+			ri.key = nil
 		}
 	}
 
@@ -243,6 +251,7 @@ type rowUpdater struct {
 	// For allocation avoidance.
 	marshalled []roachpb.Value
 	newValues  []parser.Datum
+	key        roachpb.Key
 }
 
 // makeRowUpdater creates a rowUpdater for the given table.
@@ -445,26 +454,26 @@ func (ru *rowUpdater) updateRow(
 			continue
 		}
 
-		key := keys.MakeColumnKey(newPrimaryIndexKey, uint32(col.ID))
+		ru.key = keys.MakeColumnKey(newPrimaryIndexKey, uint32(col.ID))
 		if ru.marshalled[i].RawBytes != nil {
 			// We only output non-NULL values. Non-existent column keys are
 			// considered NULL during scanning and the row sentinel ensures we know
 			// the row exists.
 			if log.V(2) {
-				log.Infof("Put %s -> %v", roachpb.Key(key), val)
+				log.Infof("Put %s -> %v", ru.key, val)
 			}
 
-			b.Put(key, &ru.marshalled[i])
+			b.Put(&ru.key, &ru.marshalled[i])
 		} else {
 			// The column might have already existed but is being set to NULL, so
 			// delete it.
 			if log.V(2) {
-				log.Infof("Del %s", roachpb.Key(key))
+				log.Infof("Del %s", ru.key)
 			}
 
-			b.Del(key)
+			b.Del(&ru.key)
 		}
-
+		ru.key = nil
 	}
 
 	return ru.newValues, nil
@@ -473,6 +482,10 @@ func (ru *rowUpdater) updateRow(
 // rowDeleter abstracts the key/value operations for deleting table rows.
 type rowDeleter struct {
 	rowHelper rowHelper
+
+	// For allocation avoidance.
+	startKey roachpb.Key
+	endKey   roachpb.Key
 }
 
 // makeRowDeleter creates a rowDeleter for the given table.
@@ -494,7 +507,7 @@ func makeRowDeleter(
 	if err := rowHelper.requireAllIndexCols(); err != nil {
 		return rowDeleter{}, err
 	}
-	return rowDeleter{rowHelper}, nil
+	return rowDeleter{rowHelper: rowHelper}, nil
 }
 
 // deleteRow adds to the batch the kv operations necessary to delete a table row
@@ -513,12 +526,13 @@ func (rd *rowDeleter) deleteRow(b *client.Batch, values []parser.Datum) *roachpb
 	}
 
 	// Delete the row.
-	rowStartKey := roachpb.Key(primaryIndexKey)
-	rowEndKey := rowStartKey.PrefixEnd()
+	rd.startKey = roachpb.Key(primaryIndexKey)
+	rd.endKey = rd.startKey.PrefixEnd()
 	if log.V(2) {
-		log.Infof("DelRange %s - %s", rowStartKey, rowEndKey)
+		log.Infof("DelRange %s - %s", rd.startKey, rd.endKey)
 	}
-	b.DelRange(rowStartKey, rowEndKey, false)
+	b.DelRange(&rd.startKey, &rd.endKey, false)
+	rd.startKey, rd.endKey = nil, nil
 
 	return nil
 }


### PR DESCRIPTION
- client: reduce allocations in Batch.initResult()
- sql: avoid allocations when passing keys to `client` methods
- sql: change marshalColumnValue() to return a roachpb.Value
- roachpb: avoid an allocation NewConditionalPut

```
name                  old time/op    new time/op    delta
KVInsert1_SQL-32         494µs ± 2%     494µs ± 3%     ~     (p=0.799 n=20+20)
KVInsert10_SQL-32        959µs ± 2%     947µs ± 2%   -1.17%  (p=0.001 n=19+20)
KVInsert100_SQL-32      5.22ms ± 3%    5.11ms ± 1%   -2.11%  (p=0.000 n=19+20)
KVInsert1000_SQL-32     52.2ms ± 4%    50.2ms ± 5%   -3.86%  (p=0.000 n=20+19)
KVInsert10000_SQL-32     669ms ± 8%     646ms ± 7%   -3.50%  (p=0.035 n=20+19)

name                  old alloc/op   new alloc/op   delta
KVInsert1_SQL-32        25.2kB ± 0%    25.1kB ± 0%   -0.32%  (p=0.000 n=20+20)
KVInsert10_SQL-32        101kB ± 0%     100kB ± 0%   -1.82%  (p=0.000 n=20+20)
KVInsert100_SQL-32       850kB ± 0%     832kB ± 0%   -2.17%  (p=0.000 n=18+20)
KVInsert1000_SQL-32     9.65MB ± 3%    9.51MB ± 4%   -1.37%  (p=0.001 n=19+20)
KVInsert10000_SQL-32     157MB ±29%     152MB ±18%     ~     (p=0.070 n=20+19)

name                  old allocs/op  new allocs/op  delta
KVInsert1_SQL-32           310 ± 0%       304 ± 0%   -1.94%  (p=0.000 n=17+20)
KVInsert10_SQL-32          825 ± 0%       754 ± 0%   -8.64%  (p=0.000 n=19+18)
KVInsert100_SQL-32       5.83k ± 0%     5.04k ± 0%  -13.48%  (p=0.000 n=20+20)
KVInsert1000_SQL-32      56.5k ± 1%     48.6k ± 2%  -13.87%  (p=0.000 n=19+20)
KVInsert10000_SQL-32      647k ±13%      563k ± 9%  -13.03%  (p=0.000 n=20+19)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6378)

<!-- Reviewable:end -->
