### PR TITLE
Don't use cgroups memory if it exceeds system memory.

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -208,6 +208,14 @@ func GetTotalMemory() (int64, error) {
 			}
 			return totalMem, nil
 		}
+		if cgAvlMem > mem.Total {
+			if log.V(1) {
+				log.Infof("available memory from cgroups %s exceeds system memory %s, using system memory",
+					humanize.IBytes(cgAvlMem), humanizeutil.IBytes(totalMem))
+			}
+			return totalMem, nil
+		}
+
 		return int64(cgAvlMem), nil
 	}
 	return totalMem, nil


### PR DESCRIPTION
Fixes #6352

On GCE, we have the following:

```
$ cat /sys/fs/cgroup/memory/memory.limit_in_bytes
9223372036854771712
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6379)

<!-- Reviewable:end -->
