### PR TITLE
sql: fix single-key optimization bug

### DIFF
--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -219,11 +219,14 @@ func selectIndex(
 	}
 
 	// If we have no filter, we can request a single key in some cases.
-	if noFilter && analyzeOrdering != nil {
+	if noFilter && analyzeOrdering != nil && s.isSecondaryIndex {
 		_, _, singleKey := analyzeOrdering(plan.Ordering())
 		if singleKey {
-			s.spans = s.spans[:1]
-			s.spans[0].count = 1
+			// We only need to retrieve one key, but some spans might contain no
+			// keys so we need to keep all of them.
+			for i := range s.spans {
+				s.spans[i].count = 1
+			}
 		}
 	}
 

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -415,8 +415,8 @@ func (v *indexInfo) analyzeOrdering(scan *scanNode, analyzeOrdering analyzeOrder
 	}
 
 	if log.V(2) {
-		log.Infof("%s: analyzeOrdering: weight=%0.2f reverse=%v index=%d",
-			v.index.Name, weight, v.reverse, fwdIndexOrdering)
+		log.Infof("%s: analyzeOrdering: weight=%0.2f reverse=%v match=%d",
+			v.index.Name, weight, v.reverse, match)
 	}
 }
 

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -399,6 +399,13 @@ CREATE TABLE abc (
 statement ok
 INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::decimal)
 
+# Verify we don't try to apply the single-key optimization to the primary index.
+query ITT
+EXPLAIN SELECT MIN(a) FROM abc
+----
+0 group MIN(a)
+1 scan  abc@primary -
+
 query TRBR
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
 ----
@@ -454,6 +461,17 @@ EXPLAIN SELECT MIN(x) FROM xyz
 ----
 0 group MIN(x)
 1 scan  xyz@xy 1:-
+
+query I
+SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
+----
+4
+
+query ITT
+EXPLAIN SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
+----
+0 group MIN(x)
+1 scan  xyz@xy 1:/0-/1 1:/4-/5 1:/7-/8
 
 query I
 SELECT MAX(x) FROM xyz


### PR DESCRIPTION
In situations where we only need a single key (e.g. `SELECT MIN(x)` with an
index on `x`), we only retain the first span. This is incorrect as the span
might contain no results. Keeping all spans and limiting them to one key. Also,
the single key optimization only works on an index (a primary table row uses
multiple keys).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6380)

<!-- Reviewable:end -->
