### PR TITLE
util/timeutil: remove SetTimeOffset

### DIFF
--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/envutil"
 	"github.com/cockroachdb/cockroach/util/log"
-	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 const (
@@ -327,7 +326,7 @@ func (a *Allocator) ShouldRebalance(storeID roachpb.StoreID) bool {
 		return false
 	}
 
-	now := timeutil.Now()
+	now := a.storePool.Clock().Now().GoTime()
 	if now.Before(a.nextRebalance) {
 		if log.V(2) {
 			log.Infof("ineligible to rebalance for %s", a.nextRebalance.Sub(now))
@@ -362,7 +361,7 @@ func (a *Allocator) ShouldRebalance(storeID roachpb.StoreID) bool {
 func (a *Allocator) UpdateNextRebalance() {
 	a.nextRebalance = a.proposedNextRebalance
 	if log.V(2) {
-		log.Infof("next rebalance opportunity in %s", a.nextRebalance.Sub(timeutil.Now()))
+		log.Infof("next rebalance opportunity in %s", a.nextRebalance.Sub(a.storePool.Clock().Now().GoTime()))
 	}
 }
 

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -165,6 +165,11 @@ func NewStorePool(g *gossip.Gossip, clock *hlc.Clock, timeUntilStoreDead time.Du
 	return sp
 }
 
+// Clock returns the storepool's clock.
+func (sp *StorePool) Clock() *hlc.Clock {
+	return sp.clock
+}
+
 // storeGossipUpdate is the gossip callback used to keep the StorePool up to date.
 func (sp *StorePool) storeGossipUpdate(_ string, content roachpb.Value) {
 	var storeDesc roachpb.StoreDescriptor

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -26,20 +26,14 @@ var (
 	nowFunc = time.Now
 )
 
-// SetTimeOffset configures a fixed offset to reported time samples.
-func SetTimeOffset(offset time.Duration) {
-	if offset == 0 {
+func initFakeTime() {
+	if offset := envutil.EnvOrDefaultDuration("simulated_offset", 0); offset == 0 {
 		nowFunc = time.Now
 	} else {
 		nowFunc = func() time.Time {
 			return time.Now().Add(offset)
 		}
 	}
-}
-
-func initFakeTime() {
-	offset := envutil.EnvOrDefaultDuration("simulated_offset", 0)
-	SetTimeOffset(offset)
 }
 
 // Now returns the current local time with an optional offset specified by the


### PR DESCRIPTION
Using this function is an anti pattern; timeutil was never meant to
provide time mocking at runtime (there are better libraries for that).

This reverts commit 413ca7222011937c9e2c93aa81e2c61079579c2f; an
hlc.Clock is plumbed to the allocator, and a manual clock is used in
tests to provide the necessary time manipulation.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6382)

<!-- Reviewable:end -->
