### PR TITLE
storage/engine: use prefix_same_as_start instead of iterate_upper_bound

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -23,7 +23,7 @@ github.com/chzyer/readline dc5da28fbf5287157fcd4719c794b59cd8852115
 github.com/client9/misspell 4f5982f81a18693b85c9926407fc4f61102ee0e7
 github.com/cockroachdb/c-jemalloc 6362977a9a1989062dccfa5fe314d6c864e7590c
 github.com/cockroachdb/c-protobuf a6f3c8c4bc8a36a44d7c876c37a3198ba3923316
-github.com/cockroachdb/c-rocksdb 7d9da2c20d8f436e36dc0114b1a516f386e47009
+github.com/cockroachdb/c-rocksdb 262e1481c23f8ca2826d86bdc39087580716a086
 github.com/cockroachdb/c-snappy 36be97020133fa143426c56cc975a415417fc3fb
 github.com/cockroachdb/cmux 9d8f8e431ac319fe4e84d8eaffa4061ddfea1efb
 github.com/cockroachdb/pq 3d7f893b32668bbf6dacfc59367d7a4c004457cc

--- a/storage/engine/bench_test.go
+++ b/storage/engine/bench_test.go
@@ -461,7 +461,7 @@ func runMVCCComputeStats(emk engineMaker, valueBytes int, b *testing.B) {
 	var stats MVCCStats
 	var err error
 	for i := 0; i < b.N; i++ {
-		iter := eng.NewIterator(nil)
+		iter := eng.NewIterator(false)
 		stats, err = iter.ComputeStats(mvccKey(roachpb.KeyMin), mvccKey(roachpb.KeyMax), 0)
 		iter.Close()
 		if err != nil {
@@ -472,6 +472,7 @@ func runMVCCComputeStats(emk engineMaker, valueBytes int, b *testing.B) {
 	b.StopTimer()
 	log.Infof("live_bytes: %d", stats.LiveBytes)
 }
+
 func BenchmarkMVCCPutDelete_RocksDB(b *testing.B) {
 	rocksdb, stopper := setupMVCCInMemRocksDB(b, "put_delete")
 	defer stopper.Stop()

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -138,12 +138,12 @@ type Engine interface {
 	// immediately.
 	Flush() error
 	// NewIterator returns a new instance of an Iterator over this engine. When
-	// prefix is non-nil, Seek will use the user-key prefix of the supplied MVCC
-	// key to restrict which sstables are searched, but iteration (using Next)
-	// over keys without the same user-key prefix will not work correctly (keys
-	// may be skipped). The caller must invoke Iterator.Close() when finished
-	// with the iterator to free resources.
-	NewIterator(prefix roachpb.Key) Iterator
+	// prefix is true, Seek will use the user-key prefix of the supplied MVCC key
+	// to restrict which sstables are searched, but iteration (using Next) over
+	// keys without the same user-key prefix will not work correctly (keys may be
+	// skipped). The caller must invoke Iterator.Close() when finished with the
+	// iterator to free resources.
+	NewIterator(prefix bool) Iterator
 	// NewSnapshot returns a new instance of a read-only snapshot
 	// engine. Snapshots are instantaneous and, as long as they're
 	// released relatively quickly, inexpensive. Snapshots are released

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -215,7 +215,7 @@ func TestEngineBatch(t *testing.T) {
 				t.Errorf("%d: expected %s, but got %s", i, expectedValue, actualValue)
 			}
 			// Try using an iterator to get the value from the batch.
-			iter := b.NewIterator(nil)
+			iter := b.NewIterator(false)
 			iter.Seek(key)
 			if !iter.Valid() {
 				if currentBatch[len(currentBatch)-1].value != nil {
@@ -694,7 +694,7 @@ func TestSnapshotMethods(t *testing.T) {
 		}
 
 		// Verify NewIterator still iterates over original snapshot.
-		iter := snap.NewIterator(nil)
+		iter := snap.NewIterator(false)
 		iter.Seek(newKey)
 		if iter.Valid() {
 			t.Error("expected invalid iterator when seeking to element which shouldn't be visible to snapshot")

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -602,7 +602,7 @@ func MVCCGet(
 	consistent bool,
 	txn *roachpb.Transaction,
 ) (*roachpb.Value, []roachpb.Intent, error) {
-	iter := engine.NewIterator(key)
+	iter := engine.NewIterator(true)
 	defer iter.Close()
 
 	return mvccGetUsingIter(ctx, iter, key, timestamp, consistent, txn)
@@ -921,7 +921,7 @@ func MVCCPut(
 	value roachpb.Value,
 	txn *roachpb.Transaction,
 ) error {
-	iter := engine.NewIterator(key)
+	iter := engine.NewIterator(true)
 	defer iter.Close()
 
 	return mvccPutUsingIter(ctx, engine, iter, ms, key, timestamp, value, txn, nil /* valueFn */)
@@ -953,7 +953,7 @@ func MVCCDelete(
 	timestamp roachpb.Timestamp,
 	txn *roachpb.Transaction,
 ) error {
-	iter := engine.NewIterator(key)
+	iter := engine.NewIterator(true)
 	defer iter.Close()
 
 	return mvccPutUsingIter(ctx, engine, iter, ms, key, timestamp, noValue, txn, nil /* valueFn */)
@@ -1204,7 +1204,7 @@ func MVCCIncrement(
 	txn *roachpb.Transaction,
 	inc int64,
 ) (int64, error) {
-	iter := engine.NewIterator(key)
+	iter := engine.NewIterator(true)
 	defer iter.Close()
 
 	var int64Val int64
@@ -1247,7 +1247,7 @@ func MVCCConditionalPut(
 	expVal *roachpb.Value,
 	txn *roachpb.Transaction,
 ) error {
-	iter := engine.NewIterator(key)
+	iter := engine.NewIterator(true)
 	defer iter.Close()
 
 	return mvccConditionalPutUsingIter(ctx, engine, iter, ms, key, timestamp, value, expVal, txn)
@@ -1313,7 +1313,7 @@ func MVCCInitPut(
 	value roachpb.Value,
 	txn *roachpb.Transaction,
 ) error {
-	iter := engine.NewIterator(key)
+	iter := engine.NewIterator(true)
 	defer iter.Close()
 
 	err := mvccPutUsingIter(ctx, engine, iter, ms, key, timestamp, noValue, txn,
@@ -1393,7 +1393,7 @@ func MVCCDeleteRange(
 	var keys []roachpb.Key
 	num := int64(0)
 	buf := newPutBuffer()
-	iter := engine.NewIterator(endKey)
+	iter := engine.NewIterator(false)
 	f := func(kv roachpb.KeyValue) (bool, error) {
 		if err := mvccPutInternal(ctx, engine, iter, ms, kv.Key, timestamp, nil, txn, buf, nil); err != nil {
 			return true, err
@@ -1594,7 +1594,7 @@ func MVCCIterate(ctx context.Context,
 	}
 
 	// Get a new iterator.
-	iter := engine.NewIterator(nil)
+	iter := engine.NewIterator(false)
 	defer iter.Close()
 
 	// Seeking for the first defined position.
@@ -1748,7 +1748,7 @@ func MVCCResolveWriteIntent(ctx context.Context,
 	intent roachpb.Intent,
 ) error {
 	buf := newPutBuffer()
-	iter := engine.NewIterator(intent.Key)
+	iter := engine.NewIterator(true)
 	err := mvccResolveWriteIntent(ctx, engine, iter, ms, intent, buf)
 	// Using defer would be more convenient, but it is measurably slower.
 	buf.release()
@@ -1969,7 +1969,7 @@ type IterAndBuf struct {
 func GetIterAndBuf(engine Engine) IterAndBuf {
 	return IterAndBuf{
 		buf:  newPutBuffer(),
-		iter: engine.NewIterator(nil),
+		iter: engine.NewIterator(false),
 	}
 }
 
@@ -2058,7 +2058,7 @@ func MVCCGarbageCollect(
 	keys []roachpb.GCRequest_GCKey,
 	timestamp roachpb.Timestamp,
 ) error {
-	iter := engine.NewIterator(nil)
+	iter := engine.NewIterator(false)
 	defer iter.Close()
 	// Iterate through specified GC keys.
 	meta := &MVCCMetadata{}

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -3116,7 +3116,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		// Every 10th step, verify the stats via manual engine scan.
 		if i%10 == 0 {
 			// Compute the stats manually.
-			iter := engine.NewIterator(nil)
+			iter := engine.NewIterator(false)
 			expMS, err := iter.ComputeStats(mvccKey(roachpb.KeyMin),
 				mvccKey(roachpb.KeyMax), ts.WallTime)
 			iter.Close()
@@ -3227,7 +3227,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 	}
 
 	// Verify aggregated stats match computed stats after GC.
-	iter := engine.NewIterator(nil)
+	iter := engine.NewIterator(false)
 	expMS, err := iter.ComputeStats(mvccKey(roachpb.KeyMin),
 		mvccKey(roachpb.KeyMax), ts3.WallTime)
 	iter.Close()
@@ -3249,7 +3249,7 @@ func TestMVCCComputeStatsError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	iter := engine.NewIterator(nil)
+	iter := engine.NewIterator(false)
 	_, err := iter.ComputeStats(mvccKey(roachpb.KeyMin),
 		mvccKey(roachpb.KeyMax), 100)
 	iter.Close()

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -114,13 +114,13 @@ DBEngine* DBNewSnapshot(DBEngine* db);
 // DBClose().
 DBEngine* DBNewBatch(DBEngine *db);
 
-// Creates a new database iterator. When prefix is not empty, Seek
-// will use the user-key prefix of the supplied MVCC key to restrict
+// Creates a new database iterator. When prefix is true, Seek will use
+// the user-key prefix of the key supplied to DBIterSeek() to restrict
 // which sstables are searched, but iteration (using Next) over keys
 // without the same user-key prefix will not work correctly (keys may
-// be skipped). It is the caller's responsibility to call
+// be skipped). It is the callers responsibility to call
 // DBIterDestroy().
-DBIterator* DBNewIter(DBEngine* db, DBSlice prefix);
+DBIterator* DBNewIter(DBEngine* db, bool prefix);
 
 // Destroys an iterator, freeing up any associated memory.
 void DBIterDestroy(DBIterator* iter);

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -52,17 +52,17 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 
 	k := MakeMVCCMetadataKey(testKey1)
 
-	before := b.NewIterator(nil)
+	before := b.NewIterator(false)
 	defer before.Close()
 
-	nonBatchBefore := db.NewIterator(nil)
+	nonBatchBefore := db.NewIterator(false)
 	defer nonBatchBefore.Close()
 
 	if err := b.Put(k, []byte("abc")); err != nil {
 		t.Fatal(err)
 	}
 
-	after := b.NewIterator(nil)
+	after := b.NewIterator(false)
 	defer after.Close()
 
 	if after.Seek(k); !after.Valid() {
@@ -79,7 +79,7 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	nonBatchAfter := db.NewIterator(nil)
+	nonBatchAfter := db.NewIterator(false)
 	defer nonBatchAfter.Close()
 
 	if nonBatchBefore.Seek(k); nonBatchBefore.Valid() {
@@ -136,7 +136,7 @@ func benchmarkIterOnBatch(b *testing.B, writes int) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		key := makeKey(r.Intn(writes))
-		iter := batch.NewIterator(key.Key)
+		iter := batch.NewIterator(true)
 		iter.Seek(key)
 		iter.Close()
 	}

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2261,7 +2261,7 @@ func (r *Replica) mergeTrigger(
 	}
 
 	// Add in the stats for the subsumed range's range keys.
-	iter := batch.NewIterator(nil)
+	iter := batch.NewIterator(false)
 	defer iter.Close()
 	localRangeKeyStart := engine.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(merge.SubsumedDesc.StartKey))
 	localRangeKeyEnd := engine.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(merge.SubsumedDesc.EndKey))

--- a/storage/replica_data_iter.go
+++ b/storage/replica_data_iter.go
@@ -83,7 +83,7 @@ func newReplicaDataIterator(d *roachpb.RangeDescriptor, e engine.Engine, replica
 	}
 	ri := &replicaDataIterator{
 		ranges:   rangeFunc(d),
-		Iterator: e.NewIterator(nil),
+		Iterator: e.NewIterator(false),
 	}
 	ri.Seek(ri.ranges[ri.curIndex].start)
 	return ri

--- a/storage/stats.go
+++ b/storage/stats.go
@@ -131,7 +131,7 @@ func (rs *rangeStats) GetGCBytesAge(nowNanos int64) int64 {
 // iterating over all key ranges for the given range that should
 // be accounted for in its stats.
 func ComputeStatsForRange(d *roachpb.RangeDescriptor, e engine.Engine, nowNanos int64) (engine.MVCCStats, error) {
-	iter := e.NewIterator(nil)
+	iter := e.NewIterator(false)
 	defer iter.Close()
 
 	ms := engine.MVCCStats{}


### PR DESCRIPTION
The performance on the relevant
benchmarks (`storage/engine.Benchmark{PutDelete,IterOnBatch}*`) are
unchanged. The big advantage to this change is that you can create a
prefix iterator that can be used to iterate over multiple distinct
prefixes. For example, a single prefix iterator can be used across
multiple `MVCCPut` calls.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6394)

<!-- Reviewable:end -->
