### PR TITLE
WIP: Add text format to metrics page, using prometheus formatter

### DIFF
--- a/server/status/recorder.go
+++ b/server/status/recorder.go
@@ -19,6 +19,7 @@ package status
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"strconv"
 	"sync"
 
@@ -169,6 +170,24 @@ func (mr *MetricsRecorder) MarshalJSON() ([]byte, error) {
 	}
 	topLevel["stores"] = storeLevel
 	return json.Marshal(topLevel)
+}
+
+// MarshalText writes the current metrics values as plain-text to the writer.
+func (mr *MetricsRecorder) PrintAsText(w io.Writer) {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+	if mr.mu.nodeID == 0 {
+		// We haven't yet processed initialization information; output nothing.
+		if log.V(1) {
+			log.Warning("MetricsRecorder.MarshalText() called before NodeID allocation")
+		}
+		return
+	}
+
+	mr.nodeRegistry.PrintAsText(w)
+	for _, reg := range mr.mu.storeRegistries {
+		reg.PrintAsText(w)
+	}
 }
 
 // GetTimeSeriesData serializes registered metrics for consumption by

--- a/util/metric/metric.go
+++ b/util/metric/metric.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/VividCortex/ewma"
 	"github.com/codahale/hdrhistogram"
+	"github.com/gogo/protobuf/proto"
+	prometheusgo "github.com/prometheus/client_model/go"
 	"github.com/rcrowley/go-metrics"
 
 	"github.com/cockroachdb/cockroach/util/timeutil"
@@ -59,6 +61,13 @@ type Iterable interface {
 	Each(func(string, interface{}))
 }
 
+// PrometheusExportable provides a method to fill in a prometheus object.
+type PrometheusExportable interface {
+	// FillPrometheusMetric takes an initialized prometheus metric object and
+	// fills the appropriate fields for the metric type.
+	FillPrometheusMetric(promMetric *prometheusgo.MetricFamily)
+}
+
 var _ Iterable = &Gauge{}
 var _ Iterable = &GaugeFloat64{}
 var _ Iterable = &Counter{}
@@ -71,6 +80,10 @@ var _ json.Marshaler = &Counter{}
 var _ json.Marshaler = &Histogram{}
 var _ json.Marshaler = &Rate{}
 var _ json.Marshaler = &Registry{}
+
+var _ PrometheusExportable = &Gauge{}
+var _ PrometheusExportable = &GaugeFloat64{}
+var _ PrometheusExportable = &Counter{}
 
 type periodic interface {
 	nextTick() time.Time
@@ -196,6 +209,14 @@ func (c *Counter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.Counter.Count())
 }
 
+// FillPrometheusMetric fills the appropriate metric fields.
+func (g *Counter) FillPrometheusMetric(promMetric *prometheusgo.MetricFamily) {
+	promMetric.Type = prometheusgo.MetricType_COUNTER.Enum()
+	promMetric.Metric = []*prometheusgo.Metric{
+		&prometheusgo.Metric{Counter: &prometheusgo.Counter{Value: proto.Float64(float64(g.Counter.Count()))}},
+	}
+}
+
 // A Gauge atomically stores a single integer value.
 type Gauge struct {
 	metrics.Gauge
@@ -215,6 +236,14 @@ func (g *Gauge) MarshalJSON() ([]byte, error) {
 	return json.Marshal(g.Gauge.Value())
 }
 
+// FillPrometheusMetric fills the appropriate metric fields.
+func (g *Gauge) FillPrometheusMetric(promMetric *prometheusgo.MetricFamily) {
+	promMetric.Type = prometheusgo.MetricType_GAUGE.Enum()
+	promMetric.Metric = []*prometheusgo.Metric{
+		&prometheusgo.Metric{Gauge: &prometheusgo.Gauge{Value: proto.Float64(float64(g.Gauge.Value()))}},
+	}
+}
+
 // A GaugeFloat64 atomically stores a single float64 value.
 type GaugeFloat64 struct {
 	metrics.GaugeFloat64
@@ -232,6 +261,14 @@ func (g *GaugeFloat64) Each(f func(string, interface{})) { f("", g) }
 // MarshalJSON marshals to JSON.
 func (g *GaugeFloat64) MarshalJSON() ([]byte, error) {
 	return json.Marshal(g.GaugeFloat64.Value())
+}
+
+// FillPrometheusMetric fills the appropriate metric fields.
+func (g *GaugeFloat64) FillPrometheusMetric(promMetric *prometheusgo.MetricFamily) {
+	promMetric.Type = prometheusgo.MetricType_GAUGE.Enum()
+	promMetric.Metric = []*prometheusgo.Metric{
+		&prometheusgo.Metric{Gauge: &prometheusgo.Gauge{Value: proto.Float64(g.GaugeFloat64.Value())}},
+	}
 }
 
 // A Rate is a exponential weighted moving average.


### PR DESCRIPTION
A slightly different version of https://github.com/cockroachdb/cockroach/pull/6080

Instead of using the prometheus go library with its own registry and http handler, I'm adding a format option to the existing metrics page. When selecting text (it should probably called prometheus-text, it also has json), it uses the prometheus text formatter to write metrics.

This can then be crawled by setting the following in the prometheus config:

```
scrape_configs:
  - job_name: 'cockroach'
    metrics_path: '/_status/metrics/local'
    params:
        format: [text]
    target_groups:
      - targets: ['localhost:8080']
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6404)

<!-- Reviewable:end -->
