### PR TITLE
sql: Remove TODO that was already addressed

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -827,7 +827,6 @@ var Builtins = map[string][]Builtin{
 		}),
 	},
 
-	// TODO(nvanbenschoten) Add native support for decimal.
 	"exp": {
 		floatBuiltin1(func(x float64) (Datum, error) {
 			return NewDFloat(DFloat(math.Exp(x))), nil


### PR DESCRIPTION
The recent changes in #6170 addressed the TODO to add native DECIMAL
support for exp(decimal), but it missed removing this TODO.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6407)

<!-- Reviewable:end -->
