### PR TITLE
storage: only add a single span to the command queue per batch

### DIFF
--- a/storage/command_queue.go
+++ b/storage/command_queue.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/util/cache"
 	"github.com/cockroachdb/cockroach/util/interval"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 // A CommandQueue maintains an interval tree of keys or key ranges for
@@ -50,48 +50,44 @@ import (
 //
 // CommandQueue is not thread safe.
 type CommandQueue struct {
-	// TODO(peter): Use an interval.Tree directly. There is no need for keeping
-	// the LRU list used by the cache.
-	cache     *cache.IntervalCache
+	tree      interval.Tree
 	idAlloc   int64
-	wRg, rwRg interval.RangeGroup // avoids allocating in GetWait.
-	oHeap     overlapHeap         // avoids allocating in GetWait.
+	wRg, rwRg interval.RangeGroup // avoids allocating in GetWait
+	oHeap     overlapHeap         // avoids allocating in GetWait
+	overlaps  []*cmd              // avoids allocating in getOverlaps
 }
 
 type cmd struct {
-	ID       int64
+	id       int64
+	key      interval.Range
 	readOnly bool
 	expanded bool              // have the children been added
-	pending  []*sync.WaitGroup // pending commands gated on cmd.
-	children []cmdEntry
+	pending  []*sync.WaitGroup // pending commands gated on cmd
+	children []cmd
 }
 
-type cmdEntry struct {
-	key   cache.IntervalKey
-	value cmd
-	entry cache.Entry
+// ID implements interval.Interface.
+func (c *cmd) ID() uintptr {
+	return uintptr(c.id)
+}
+
+// Range implements interval.Interface.
+func (c *cmd) Range() interval.Range {
+	return c.key
 }
 
 // NewCommandQueue returns a new command queue.
 func NewCommandQueue() *CommandQueue {
 	cq := &CommandQueue{
-		cache: cache.NewIntervalCache(cache.Config{Policy: cache.CacheNone}),
-		wRg:   interval.NewRangeTree(),
-		rwRg:  interval.NewRangeTree(),
+		tree: interval.Tree{Overlapper: interval.Range.OverlapExclusive},
+		wRg:  interval.NewRangeTree(),
+		rwRg: interval.NewRangeTree(),
 	}
-	cq.cache.OnEvicted = cq.onEvicted
 	return cq
 }
 
-// onEvicted is called when any entry is removed from the interval
-// tree. This happens on calls to Remove() and to Clear().
-func (cq *CommandQueue) onEvicted(key, value interface{}) {
-	c := value.(*cmd)
-	for _, wg := range c.pending {
-		wg.Done()
-	}
-}
-
+// prepareSpans ensures the spans all have an end key. Note that this function
+// mutates its arguments.
 func prepareSpans(spans ...roachpb.Span) {
 	for i, span := range spans {
 		// This gives us a memory-efficient end key if end is empty.
@@ -122,7 +118,7 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 			Start: interval.Comparable(start),
 			End:   interval.Comparable(end),
 		}
-		overlaps := cq.cache.GetOverlaps(newCmdRange.Start, newCmdRange.End)
+		overlaps := cq.getOverlaps(newCmdRange.Start, newCmdRange.End)
 		if readOnly {
 			// If both commands are read-only, there are no dependencies between them,
 			// so these can be filtered out of the overlapping commands.
@@ -133,16 +129,19 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 		// entries. If we encounter a covering entry, we remove it from the
 		// interval tree and add all of its children.
 		restart := false
-		for _, o := range overlaps {
-			cmd := o.Value.(*cmd)
+		for _, cmd := range overlaps {
 			if !cmd.expanded && len(cmd.children) != 0 {
 				restart = true
 				cmd.expanded = true
+				if err := cq.tree.Delete(cmd, false /* !fast */); err != nil {
+					log.Error(err)
+				}
 				for i := range cmd.children {
 					child := &cmd.children[i]
-					cq.cache.AddEntry(&child.entry)
+					if err := cq.tree.Insert(child, false /* !fast */); err != nil {
+						log.Error(err)
+					}
 				}
-				cq.cache.Del(o.Key)
 			}
 		}
 		if restart {
@@ -207,8 +206,8 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 		//
 		cq.oHeap.Init(overlaps)
 		for enclosed := false; cq.oHeap.Len() > 0 && !enclosed; {
-			o := cq.oHeap.PopOverlap()
-			keyRange, cmd := o.Key.Range, o.Value.(*cmd)
+			cmd := cq.oHeap.PopOverlap()
+			keyRange := cmd.key
 			if cmd.readOnly {
 				// If the current overlap is a read (meaning we're a write because other reads will
 				// be filtered out if we're a read as well), we only need to wait if the write RangeGroup
@@ -277,11 +276,30 @@ func (cq *CommandQueue) GetWait(readOnly bool, wg *sync.WaitGroup, spans ...roac
 	}
 }
 
+// getOverlaps returns a slice of values which overlap the specified
+// interval. The slice is only valid until the next call to GetOverlaps.
+func (cq *CommandQueue) getOverlaps(start, end []byte) []*cmd {
+	rng := interval.Range{
+		Start: interval.Comparable(start),
+		End:   interval.Comparable(end),
+	}
+	cq.tree.DoMatching(cq.doOverlaps, rng)
+	overlaps := cq.overlaps
+	cq.overlaps = cq.overlaps[:0]
+	return overlaps
+}
+
+func (cq *CommandQueue) doOverlaps(i interval.Interface) bool {
+	c := i.(*cmd)
+	cq.overlaps = append(cq.overlaps, c)
+	return false
+}
+
 // filterReadWrite filters out the read-only commands from the provided slice.
-func filterReadWrite(cmds []cache.Overlap) []cache.Overlap {
+func filterReadWrite(cmds []*cmd) []*cmd {
 	rwIdx := len(cmds)
 	for i := 0; i < rwIdx; {
-		c := cmds[i].Value.(*cmd)
+		c := cmds[i]
 		if !c.readOnly {
 			i++
 		} else {
@@ -293,12 +311,12 @@ func filterReadWrite(cmds []cache.Overlap) []cache.Overlap {
 }
 
 // overlapHeap is a max-heap of cache.Overlaps, sorting the elements
-// in decreasing Value.(*cmd).ID order.
-type overlapHeap []cache.Overlap
+// in decreasing Value.(*cmd).id order.
+type overlapHeap []*cmd
 
 func (o overlapHeap) Len() int { return len(o) }
 func (o overlapHeap) Less(i, j int) bool {
-	return o[i].Value.(*cmd).ID > o[j].Value.(*cmd).ID
+	return o[i].id > o[j].id
 }
 func (o overlapHeap) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
 
@@ -308,15 +326,12 @@ func (o *overlapHeap) Push(x interface{}) {
 
 func (o *overlapHeap) Pop() interface{} {
 	n := len(*o) - 1
-	// Returning a pointer to avoid an allocation when storing the cache.Overlap in an interface{}.
-	// A *cache.Overlap stored in an interface{} won't allocate, but the value pointed to may
-	// change if the heap is later modified, so the pointer should be dereferenced immediately.
-	x := &(*o)[n]
+	x := (*o)[n]
 	*o = (*o)[:n]
 	return x
 }
 
-func (o *overlapHeap) Init(overlaps []cache.Overlap) {
+func (o *overlapHeap) Init(overlaps []*cmd) {
 	*o = overlaps
 	heap.Init(o)
 }
@@ -325,9 +340,9 @@ func (o *overlapHeap) Clear() {
 	*o = nil
 }
 
-func (o *overlapHeap) PopOverlap() cache.Overlap {
+func (o *overlapHeap) PopOverlap() *cmd {
 	x := heap.Pop(o)
-	return *x.(*cache.Overlap)
+	return x.(*cmd)
 }
 
 // Add adds commands to the queue which affect the specified key ranges. Ranges
@@ -352,41 +367,41 @@ func (cq *CommandQueue) Add(readOnly bool, spans ...roachpb.Span) interface{} {
 		}
 	}
 
-	numEntries := 1
+	numCmds := 1
 	if len(spans) > 1 {
-		numEntries += len(spans)
+		numCmds += len(spans)
 	}
-	entries := make([]cmdEntry, numEntries)
+	cmds := make([]cmd, numCmds)
 
 	// Create the covering entry.
-	entry := &entries[0]
-	entry.key = cq.cache.MakeKey(minKey, maxKey)
-	entry.value = cmd{
-		ID:       cq.nextID(),
-		readOnly: readOnly,
-		expanded: false,
+	cmd := &cmds[0]
+	cmd.id = cq.nextID()
+	cmd.key = interval.Range{
+		Start: interval.Comparable(minKey),
+		End:   interval.Comparable(maxKey),
 	}
-	entry.entry.Key = &entry.key
-	entry.entry.Value = &entry.value
+	cmd.readOnly = readOnly
+	cmd.expanded = false
 
 	if len(spans) > 1 {
 		// Populate the covering entry's children.
-		entry.value.children = entries[1:]
+		cmd.children = cmds[1:]
 		for i, span := range spans {
-			child := &entry.value.children[i]
-			child.key = cq.cache.MakeKey(span.Key, span.EndKey)
-			child.value = cmd{
-				ID:       cq.nextID(),
-				readOnly: readOnly,
-				expanded: true,
+			child := &cmd.children[i]
+			child.id = cq.nextID()
+			child.key = interval.Range{
+				Start: interval.Comparable(span.Key),
+				End:   interval.Comparable(span.EndKey),
 			}
-			child.entry.Key = &child.key
-			child.entry.Value = &child.value
+			child.readOnly = readOnly
+			child.expanded = true
 		}
 	}
 
-	cq.cache.AddEntry(&entry.entry)
-	return entry
+	if err := cq.tree.Insert(cmd, false /* !fast */); err != nil {
+		log.Error(err)
+	}
+	return cmd
 }
 
 // Remove is invoked to signal that the command associated with the
@@ -403,19 +418,24 @@ func (cq *CommandQueue) Remove(key interface{}) {
 		return
 	}
 
-	entry := key.(*cmdEntry)
-	if !entry.value.expanded {
-		cq.cache.Del(&entry.key)
+	cmd := key.(*cmd)
+	if !cmd.expanded {
+		if err := cq.tree.Delete(cmd, false /* !fast */); err != nil {
+			log.Error(err)
+		}
+		for _, wg := range cmd.pending {
+			wg.Done()
+		}
 	} else {
-		for _, child := range entry.value.children {
-			cq.cache.Del(&child.key)
+		for _, child := range cmd.children {
+			if err := cq.tree.Delete(&child, false /* !fast */); err != nil {
+				log.Error(err)
+			}
+			for _, wg := range child.pending {
+				wg.Done()
+			}
 		}
 	}
-}
-
-// Clear removes all executing commands, signaling any waiting commands.
-func (cq *CommandQueue) Clear() {
-	cq.cache.Clear()
 }
 
 func (cq *CommandQueue) nextID() int64 {

--- a/storage/command_queue_test.go
+++ b/storage/command_queue_test.go
@@ -31,7 +31,7 @@ func getWait(cq *CommandQueue, from, to roachpb.Key, readOnly bool, wg *sync.Wai
 }
 
 func add(cq *CommandQueue, from, to roachpb.Key, readOnly bool) interface{} {
-	return cq.Add(readOnly, roachpb.Span{Key: from, EndKey: to})[0]
+	return cq.Add(readOnly, roachpb.Span{Key: from, EndKey: to})
 }
 
 func getWaitAndAdd(cq *CommandQueue, from, to roachpb.Key, readOnly bool, wg *sync.WaitGroup) interface{} {
@@ -81,7 +81,7 @@ func TestCommandQueue(t *testing.T) {
 	if testCmdDone(cmdDone, 1*time.Millisecond) {
 		t.Fatal("command should not finish with command outstanding")
 	}
-	cq.Remove([]interface{}{wk})
+	cq.Remove(wk)
 	if !testCmdDone(cmdDone, 5*time.Millisecond) {
 		t.Fatal("command should finish with no commands outstanding")
 	}
@@ -125,13 +125,13 @@ func TestCommandQueueWriteWaitForNonAdjacentRead(t *testing.T) {
 	assert(true)
 
 	// The second read returns, but the first one remains.
-	cq.Remove([]interface{}{wk2})
+	cq.Remove(wk2)
 
 	// Should still block. This being broken is why this test exists.
 	assert(true)
 
 	// First read returns.
-	cq.Remove([]interface{}{wk1})
+	cq.Remove(wk1)
 
 	// Now it goes through.
 	assert(false)
@@ -152,7 +152,7 @@ func TestCommandQueueNoWaitOnReadOnly(t *testing.T) {
 	if testCmdDone(cmdDone, 1*time.Millisecond) {
 		t.Fatal("command should not finish with command outstanding")
 	}
-	cq.Remove([]interface{}{wk})
+	cq.Remove(wk)
 	if !testCmdDone(cmdDone, 5*time.Millisecond) {
 		t.Fatal("command should finish with no commands outstanding")
 	}
@@ -169,15 +169,15 @@ func TestCommandQueueMultipleExecutingCommands(t *testing.T) {
 	wk3 := add(cq, roachpb.Key("0"), roachpb.Key("d"), false)
 	getWait(cq, roachpb.Key("a"), roachpb.Key("cc"), false, &wg)
 	cmdDone := waitForCmd(&wg)
-	cq.Remove([]interface{}{wk1})
+	cq.Remove(wk1)
 	if testCmdDone(cmdDone, 1*time.Millisecond) {
 		t.Fatal("command should not finish with two commands outstanding")
 	}
-	cq.Remove([]interface{}{wk2})
+	cq.Remove(wk2)
 	if testCmdDone(cmdDone, 1*time.Millisecond) {
 		t.Fatal("command should not finish with one command outstanding")
 	}
-	cq.Remove([]interface{}{wk3})
+	cq.Remove(wk3)
 	if !testCmdDone(cmdDone, 5*time.Millisecond) {
 		t.Fatal("command should finish with no commands outstanding")
 	}
@@ -204,7 +204,7 @@ func TestCommandQueueMultiplePendingCommands(t *testing.T) {
 		testCmdDone(cmdDone3, 1*time.Millisecond) {
 		t.Fatal("no commands should finish with command outstanding")
 	}
-	cq.Remove([]interface{}{wk0})
+	cq.Remove(wk0)
 	if !testCmdDone(cmdDone1, 5*time.Millisecond) ||
 		!testCmdDone(cmdDone3, 5*time.Millisecond) {
 		t.Fatal("command 1 and 3 should finish")
@@ -212,7 +212,7 @@ func TestCommandQueueMultiplePendingCommands(t *testing.T) {
 	if testCmdDone(cmdDone2, 5*time.Millisecond) {
 		t.Fatal("command 2 should remain outstanding")
 	}
-	cq.Remove([]interface{}{wk1})
+	cq.Remove(wk1)
 	if !testCmdDone(cmdDone2, 5*time.Millisecond) {
 		t.Fatal("command 2 should finish with no commands outstanding")
 	}
@@ -268,6 +268,33 @@ func TestCommandQueueSelfOverlap(t *testing.T) {
 	k := add(cq, a, roachpb.Key("b"), false)
 	var wg sync.WaitGroup
 	cq.GetWait(false, &wg, []roachpb.Span{{Key: a}, {Key: a}, {Key: a}}...)
-	cq.Remove([]interface{}{k})
+	cq.Remove(k)
 	wg.Wait()
+}
+
+func TestCommandQueueCovering(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	cq := NewCommandQueue()
+
+	a := roachpb.Span{Key: roachpb.Key("a")}
+	b := roachpb.Span{Key: roachpb.Key("b")}
+	c := roachpb.Span{Key: roachpb.Key("c")}
+
+	{
+		// Test adding a covering entry and then not expanding it.
+		wk := cq.Add(false, a, b)
+		var wg sync.WaitGroup
+		cq.GetWait(false, &wg, c)
+		wg.Wait()
+		cq.Remove(wk)
+	}
+
+	{
+		// Test adding a covering entry and expanding it.
+		wk := cq.Add(false, a, b)
+		var wg sync.WaitGroup
+		cq.GetWait(false, &wg, a)
+		cq.Remove(wk)
+		wg.Wait()
+	}
 }

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -876,10 +876,10 @@ func (r *Replica) checkBatchRequest(ba roachpb.BatchRequest) error {
 // already in the queue. Returns a cleanup function to be called when the
 // commands are done and can be removed from the queue.
 func (r *Replica) beginCmds(ba *roachpb.BatchRequest) func(*roachpb.BatchResponse, *roachpb.Error) {
-	var cmdKeys []interface{}
+	var cmdEntry interface{}
 	// Don't use the command queue for inconsistent reads.
 	if ba.ReadConsistency != roachpb.INCONSISTENT {
-		var spans []roachpb.Span
+		spans := make([]roachpb.Span, 0, len(ba.Requests))
 		readOnly := ba.IsReadOnly()
 		for _, union := range ba.Requests {
 			h := union.GetInner().Header()
@@ -888,7 +888,7 @@ func (r *Replica) beginCmds(ba *roachpb.BatchRequest) func(*roachpb.BatchRespons
 		var wg sync.WaitGroup
 		r.mu.Lock()
 		r.mu.cmdQ.GetWait(readOnly, &wg, spans...)
-		cmdKeys = append(cmdKeys, r.mu.cmdQ.Add(readOnly, spans...)...)
+		cmdEntry = r.mu.cmdQ.Add(readOnly, spans...)
 		r.mu.Unlock()
 		wg.Wait()
 	}
@@ -911,13 +911,13 @@ func (r *Replica) beginCmds(ba *roachpb.BatchRequest) func(*roachpb.BatchRespons
 	}
 
 	return func(br *roachpb.BatchResponse, pErr *roachpb.Error) {
-		r.endCmds(cmdKeys, ba, br, pErr)
+		r.endCmds(cmdEntry, ba, br, pErr)
 	}
 }
 
 // endCmds removes pending commands from the command queue and updates
 // the timestamp cache using the final timestamp of each command.
-func (r *Replica) endCmds(cmdKeys []interface{}, ba *roachpb.BatchRequest, br *roachpb.BatchResponse, pErr *roachpb.Error) {
+func (r *Replica) endCmds(cmdEntry interface{}, ba *roachpb.BatchRequest, br *roachpb.BatchResponse, pErr *roachpb.Error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// Only update the timestamp cache if the command succeeded and is
@@ -948,7 +948,7 @@ func (r *Replica) endCmds(cmdKeys []interface{}, ba *roachpb.BatchRequest, br *r
 			}
 		}
 	}
-	r.mu.cmdQ.Remove(cmdKeys)
+	r.mu.cmdQ.Remove(cmdEntry)
 }
 
 // applyTimestampCache moves the batch timestamp forward depending on


### PR DESCRIPTION
Previously, the CommandQueue was fine-grained. This switches to a
coarse-grained approach were a single span is computed for a batch that
covers all of the keys used by the individual KV ops. This reduces
parallelism at the range level, but dramatically reduces the
CommandQueue overhead for bulk operations.

```
name                  old time/op    new time/op    delta
KVInsert1_SQL-32         492µs ± 2%     489µs ± 3%     ~     (p=0.072 n=20+20)
KVInsert10_SQL-32        935µs ± 2%     901µs ± 1%   -3.59%  (p=0.000 n=19+19)
KVInsert100_SQL-32      5.09ms ± 2%    4.61ms ± 4%   -9.39%  (p=0.000 n=20+20)
KVInsert1000_SQL-32     49.9ms ± 6%    42.0ms ± 5%  -15.97%  (p=0.000 n=19+20)
KVInsert10000_SQL-32     659ms ±12%     470ms ±10%  -28.63%  (p=0.000 n=19+18)

name                  old allocs/op  new allocs/op  delta
KVInsert1_SQL-32           304 ± 0%       298 ± 0%   -1.97%  (p=0.000 n=16+19)
KVInsert10_SQL-32          754 ± 0%       712 ± 0%   -5.57%  (p=0.000 n=17+17)
KVInsert100_SQL-32       5.04k ± 0%     4.64k ± 0%   -8.00%  (p=0.000 n=19+20)
KVInsert1000_SQL-32      48.7k ± 2%     44.0k ± 1%   -9.69%  (p=0.000 n=20+20)
KVInsert10000_SQL-32      570k ±15%      477k ± 8%  -16.32%  (p=0.000 n=20+20)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6412)

<!-- Reviewable:end -->
