### PR TITLE
storage: combine spans when adding to the timestamp cache

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1016,30 +1016,32 @@ func (r *Replica) endCmds(cmd *cmd, ba *roachpb.BatchRequest, br *roachpb.BatchR
 	// Only update the timestamp cache if the command succeeded and is
 	// marked as affecting the cache. Inconsistent reads are excluded.
 	if pErr == nil && ba.ReadConsistency != roachpb.INCONSISTENT {
-		timestamp := ba.Timestamp
+		cr := cacheRequest{
+			timestamp: ba.Timestamp,
+			txnID:     ba.GetTxnID(),
+		}
+
 		for _, union := range ba.Requests {
 			args := union.GetInner()
 			if updatesTimestampCache(args) {
-				readTSCache := true
-				key := args.Header().Key
-				txnID := ba.GetTxnID()
+				header := args.Header()
 				switch args.(type) {
 				case *roachpb.DeleteRangeRequest:
 					// DeleteRange adds to the write timestamp cache to prevent
 					// subsequent writes from rewriting history.
-					readTSCache = false
+					cr.writes = append(cr.writes, header)
 				case *roachpb.EndTransactionRequest:
-					// EndTransaction adds to the write timestamp cache to ensure
-					// replays create a transaction record with WriteTooOld set.
-					// We set txnID=nil because we want hits for same txn ID.
-					key = keys.TransactionKey(key, txnID)
-					txnID = nil
-					readTSCache = false
+					// EndTransaction adds to the write timestamp cache to ensure replays
+					// create a transaction record with WriteTooOld set.
+					key := keys.TransactionKey(header.Key, cr.txnID)
+					cr.txn = roachpb.Span{Key: key}
+				default:
+					cr.reads = append(cr.reads, header)
 				}
-				header := args.Header()
-				r.mu.tsCache.Add(key, header.EndKey, timestamp, txnID, readTSCache)
 			}
 		}
+
+		r.mu.tsCache.AddRequest(cr)
 	}
 	r.mu.cmdQ.remove(cmd)
 	return pErr
@@ -1065,6 +1067,13 @@ func (r *Replica) endCmds(cmd *cmd, ba *roachpb.BatchRequest, br *roachpb.BatchR
 func (r *Replica) applyTimestampCache(ba *roachpb.BatchRequest) *roachpb.Error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	if ba.Txn != nil {
+		r.mu.tsCache.ExpandRequests(ba.Txn.Timestamp)
+	} else {
+		r.mu.tsCache.ExpandRequests(ba.Timestamp)
+	}
+
 	for _, union := range ba.Requests {
 		args := union.GetInner()
 		if consultsTimestampCache(args) {

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1717,6 +1717,12 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 	// Verify the timestamp cache has rTS=1s and wTS=0s for "a".
 	tc.rng.mu.Lock()
 	defer tc.rng.mu.Unlock()
+	_, rOK := tc.rng.mu.tsCache.GetMaxRead(roachpb.Key("a"), nil, nil)
+	_, wOK := tc.rng.mu.tsCache.GetMaxWrite(roachpb.Key("a"), nil, nil)
+	if rOK || wOK {
+		t.Errorf("expected rOK=false and wOK=false; rOK=%t, wOK=%t", rOK, wOK)
+	}
+	tc.rng.mu.tsCache.ExpandRequests(roachpb.ZeroTimestamp)
 	rTS, rOK := tc.rng.mu.tsCache.GetMaxRead(roachpb.Key("a"), nil, nil)
 	wTS, wOK := tc.rng.mu.tsCache.GetMaxWrite(roachpb.Key("a"), nil, nil)
 	if rTS.WallTime != t0.Nanoseconds() || wTS.WallTime != 0 || !rOK || wOK {

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/interval"
 	"github.com/cockroachdb/cockroach/util/uuid"
+	"github.com/google/btree"
 )
 
 const (
@@ -36,7 +37,50 @@ const (
 	MinTSCacheWindow = 10 * time.Second
 
 	defaultEvictionSizeThreshold = 512
+
+	// Max entries in each btree node.
+	// TODO(peter): Not yet tuned.
+	btreeDegree = 64
 )
+
+// cacheRequest holds the timestamp cache data from a single batch request. The
+// requests are stored in a btree keyed by the timestamp and are "expanded" to
+// populate the read/write interval caches if a potential conflict is detected
+// due to an earlier request (based on timestamp) arriving.
+type cacheRequest struct {
+	reads     []roachpb.Span
+	writes    []roachpb.Span
+	txn       roachpb.Span
+	txnID     *uuid.UUID
+	timestamp roachpb.Timestamp
+	// Used to distinguish requests with identical timestamps. For actual
+	// requests, the uniqueID value is >0. When probing the btree for requests
+	// later than a particular timestamp a value of 0 is used.
+	uniqueID int64
+}
+
+// Less implements the btree.Item interface.
+func (cr *cacheRequest) Less(other btree.Item) bool {
+	otherReq := other.(*cacheRequest)
+	if cr.timestamp.Less(otherReq.timestamp) {
+		return true
+	}
+	if otherReq.timestamp.Less(cr.timestamp) {
+		return false
+	}
+	// Fallback to comparison of the uniqueID as a tie-breaker. This allows
+	// multiple requests with the same timestamp to exist in the requests btree.
+	return cr.uniqueID < otherReq.uniqueID
+}
+
+// numSpans returns the number of spans the request will expand into.
+func (cr *cacheRequest) numSpans() int {
+	n := len(cr.reads) + len(cr.writes)
+	if cr.txn.Key != nil {
+		n++
+	}
+	return n
+}
 
 // A TimestampCache maintains an interval tree FIFO cache of keys or
 // key ranges and the timestamps at which they were most recently read
@@ -51,6 +95,15 @@ const (
 type TimestampCache struct {
 	rCache, wCache   *cache.IntervalCache
 	lowWater, latest roachpb.Timestamp
+
+	// The requests tree contains cacheRequest entries keyed by timestamp. A
+	// request is "expanded" (i.e. the read/write spans are added to the
+	// read/write interval caches) when the timestamp cache is accessed on behalf
+	// of an earlier request.
+	requests   *btree.BTree
+	tmpReq     cacheRequest
+	reqIDAlloc int64
+	reqSpans   int
 
 	// evictionSizeThreshold allows old entries to stay in the TimestampCache
 	// indefinitely as long as the number of intervals in the cache doesn't
@@ -88,6 +141,7 @@ func NewTimestampCache(clock *hlc.Clock) *TimestampCache {
 	tc := &TimestampCache{
 		rCache:                cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}),
 		wCache:                cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}),
+		requests:              btree.New(btreeDegree),
 		evictionSizeThreshold: defaultEvictionSizeThreshold,
 	}
 	tc.Clear(clock)
@@ -111,7 +165,7 @@ func (tc *TimestampCache) Clear(clock *hlc.Clock) {
 // Len returns the total number of read and write intervals in the
 // TimestampCache.
 func (tc *TimestampCache) Len() int {
-	return tc.rCache.Len() + tc.wCache.Len()
+	return tc.rCache.Len() + tc.wCache.Len() + tc.reqSpans
 }
 
 // SetLowWater sets the cache's low water mark, which is the minimum
@@ -133,9 +187,7 @@ func (tc *TimestampCache) Add(start, end roachpb.Key, timestamp roachpb.Timestam
 		end = start.Next()
 		start = end[:len(start)]
 	}
-	if tc.latest.Less(timestamp) {
-		tc.latest = timestamp
-	}
+	tc.latest.Forward(timestamp)
 	// Only add to the cache if the timestamp is more recent than the
 	// low water mark.
 	if tc.lowWater.Less(timestamp) {
@@ -268,6 +320,88 @@ func (tc *TimestampCache) Add(start, end roachpb.Key, timestamp roachpb.Timestam
 	}
 }
 
+// AddRequest adds the specified request to the cache in an unexpanded state.
+func (tc *TimestampCache) AddRequest(req cacheRequest) {
+	if len(req.reads) == 0 && len(req.writes) == 0 && req.txn.Key == nil {
+		// The request didn't contain any spans for the timestamp cache.
+		return
+	}
+
+	if !tc.lowWater.Less(req.timestamp) {
+		// Request too old to be added.
+		return
+	}
+
+	tc.reqIDAlloc++
+	req.uniqueID = tc.reqIDAlloc
+	tc.requests.ReplaceOrInsert(&req)
+	tc.reqSpans += req.numSpans()
+
+	// Bump the latest timestamp and evict any requests that are now too old.
+	tc.latest.Forward(req.timestamp)
+	edge := tc.latest
+	edge.WallTime -= MinTSCacheWindow.Nanoseconds()
+
+	// Evict requests as long as the number of cached spans (both in the requests
+	// queue and the interval caches) is larger than the eviction threshold.
+	for tc.Len() > tc.evictionSizeThreshold {
+		// TODO(peter): It might be more efficient to gather up the requests to
+		// delete using BTree.AscendLessThan rather than calling Min
+		// repeatedly. Maybe.
+		minItem := tc.requests.Min()
+		if minItem == nil {
+			break
+		}
+		minReq := minItem.(*cacheRequest)
+		if edge.Less(minReq.timestamp) {
+			break
+		}
+		tc.lowWater = minReq.timestamp
+		tc.requests.DeleteMin()
+		if tc.reqSpans < minReq.numSpans() {
+			panic(fmt.Sprintf("bad reqSpans: %d < %d", tc.reqSpans, minReq.numSpans()))
+		}
+		tc.reqSpans -= minReq.numSpans()
+	}
+}
+
+// ExpandRequests expands any request that is newer than the specified
+// timestamp.
+func (tc *TimestampCache) ExpandRequests(timestamp roachpb.Timestamp) {
+	// Find all of the requests that have a timestamp greater than or equal to
+	// the specified timestamp. Note that we can't delete the requests during the
+	// btree iteration.
+	var reqs []*cacheRequest
+	tc.tmpReq.timestamp = timestamp
+	tc.requests.AscendGreaterOrEqual(&tc.tmpReq, func(i btree.Item) bool {
+		// TODO(peter): We could be more intelligent about not expanding a request
+		// if there is no possibility of overlap. For example, in workloads where
+		// there are concurrent bulk inserts for completely distinct ranges.
+		reqs = append(reqs, i.(*cacheRequest))
+		return true
+	})
+
+	// Expand the requests, inserting the spans into either the read or write
+	// interval caches.
+	for _, req := range reqs {
+		tc.requests.Delete(req)
+		if tc.reqSpans < req.numSpans() {
+			panic(fmt.Sprintf("bad reqSpans: %d < %d", tc.reqSpans, req.numSpans()))
+		}
+		tc.reqSpans -= req.numSpans()
+		for _, sp := range req.reads {
+			tc.Add(sp.Key, sp.EndKey, req.timestamp, req.txnID, true /* readTSCache */)
+		}
+		for _, sp := range req.writes {
+			tc.Add(sp.Key, sp.EndKey, req.timestamp, req.txnID, false /* !readTSCache */)
+		}
+		if req.txn.Key != nil {
+			// We set txnID=nil because we want hits for same txn ID.
+			tc.Add(req.txn.Key, req.txn.EndKey, req.timestamp, nil, false /* !readTSCache */)
+		}
+	}
+}
+
 // GetMaxRead returns the maximum read timestamp which overlaps the
 // interval spanning from start to end. Cached timestamps matching the
 // specified txnID are not considered. If no part of the specified
@@ -329,6 +463,8 @@ func (tc *TimestampCache) MergeInto(dest *TimestampCache, clear bool) {
 		dest.wCache.Clear()
 		dest.lowWater = tc.lowWater
 		dest.latest = tc.latest
+		dest.requests = btree.New(btreeDegree)
+		dest.reqIDAlloc = 0
 
 		// Because we just cleared the destination cache, we can directly
 		// insert entries from this cache.
@@ -358,6 +494,16 @@ func (tc *TimestampCache) MergeInto(dest *TimestampCache, clear bool) {
 		softMerge(tc.rCache, true)
 		softMerge(tc.wCache, false)
 	}
+
+	// Copy the requests.
+	tc.requests.Ascend(func(i btree.Item) bool {
+		req := *(i.(*cacheRequest))
+		dest.reqIDAlloc++
+		req.uniqueID = dest.reqIDAlloc
+		dest.requests.ReplaceOrInsert(&req)
+		dest.reqSpans += req.numSpans()
+		return true
+	})
 }
 
 // shouldEvict returns true if the cache entry's timestamp is no

--- a/storage/timestamp_cache_test.go
+++ b/storage/timestamp_cache_test.go
@@ -190,13 +190,21 @@ func TestTimestampCacheNoEviction(t *testing.T) {
 	manual.Set(maxClockOffset.Nanoseconds() + 1)
 	aTS := clock.Now()
 	tc.Add(roachpb.Key("a"), nil, aTS, nil, true)
+	tc.AddRequest(cacheRequest{
+		reads:     []roachpb.Span{{Key: roachpb.Key("c")}},
+		timestamp: aTS,
+	})
 
 	// Increment time by the MinTSCacheWindow and add another key.
 	manual.Increment(MinTSCacheWindow.Nanoseconds())
 	tc.Add(roachpb.Key("b"), nil, clock.Now(), nil, true)
+	tc.AddRequest(cacheRequest{
+		reads:     []roachpb.Span{{Key: roachpb.Key("d")}},
+		timestamp: clock.Now(),
+	})
 
-	// Verify that the cache still has 2 entries in it
-	if l, want := tc.Len(), 2; l != want {
+	// Verify that the cache still has 4 entries in it
+	if l, want := tc.Len(), 4; l != want {
 		t.Errorf("expected %d entries to remain, got %d", want, l)
 	}
 }


### PR DESCRIPTION
```
name                  old time/op    new time/op    delta
KVInsert1_SQL-32         504µs ± 2%     508µs ± 2%  +0.94%  (p=0.008 n=19+20)
KVInsert10_SQL-32        956µs ± 2%     934µs ± 2%  -2.34%  (p=0.000 n=20+20)
KVInsert100_SQL-32      5.05ms ± 2%    4.81ms ± 2%  -4.70%  (p=0.000 n=20+18)
KVInsert1000_SQL-32     48.5ms ± 5%    45.0ms ± 3%  -7.09%  (p=0.000 n=19+19)
KVInsert10000_SQL-32     651ms ±10%     647ms ±13%    ~     (p=0.828 n=18+20)

name                  old allocs/op  new allocs/op  delta
KVInsert1_SQL-32           304 ± 0%       302 ± 0%  -0.66%  (p=0.000 n=19+20)
KVInsert10_SQL-32          754 ± 0%       717 ± 0%  -4.96%  (p=0.000 n=19+16)
KVInsert100_SQL-32       5.04k ± 0%     4.65k ± 0%  -7.83%  (p=0.000 n=20+20)
KVInsert1000_SQL-32      48.5k ± 2%     44.4k ± 1%  -8.46%  (p=0.000 n=20+20)
KVInsert10000_SQL-32      565k ± 9%      525k ± 9%  -7.06%  (p=0.002 n=20+20)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6413)

<!-- Reviewable:end -->
