### PR TITLE
storage: Reject all messages from removed replicas

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -1855,6 +1855,31 @@ func (s *Store) enqueueRaftMessage(req *RaftMessageRequest) error {
 // Replica. It requires that processRaftMu is held and that s.mu is
 // not held.
 func (s *Store) handleRaftMessage(req *RaftMessageRequest) error {
+	// Drop messages that come from a node that we believe was once
+	// a member of the group but has been removed.
+	s.mu.Lock()
+	r, ok := s.mu.replicas[req.GroupID]
+	s.mu.Unlock()
+	if ok {
+		found := false
+		desc := r.Desc()
+		for _, rep := range desc.Replicas {
+			if rep.ReplicaID == req.FromReplica.ReplicaID {
+				found = true
+				break
+			}
+		}
+		// It's not a current member of the group. Is it from the future
+		// or the past?
+		if !found && req.FromReplica.ReplicaID < desc.NextReplicaID {
+			if log.V(2) {
+				log.Infof("range %s: discarding message from replica %v, older than NextReplicaID %v",
+					req.GroupID, req.FromReplica, desc.NextReplicaID)
+			}
+			return nil
+		}
+	}
+
 	switch req.Message.Type {
 	case raftpb.MsgSnap:
 		if !s.canApplySnapshot(req.GroupID, req.Message.Snapshot) {
@@ -1864,26 +1889,8 @@ func (s *Store) handleRaftMessage(req *RaftMessageRequest) error {
 			return nil
 		}
 
-	// TODO(bdarnell): handle coalesced heartbeats
 	case raftpb.MsgHeartbeat:
-		// A subset of coalesced heartbeats: drop heartbeats (but not
-		// other messages!) that come from a node that we don't believe to
-		// be a current member of the group.
-		s.mu.Lock()
-		r, ok := s.mu.replicas[req.GroupID]
-		s.mu.Unlock()
-		if ok {
-			found := false
-			for _, rep := range r.Desc().Replicas {
-				if rep.ReplicaID == req.FromReplica.ReplicaID {
-					found = true
-					break
-				}
-			}
-			if !found && req.FromReplica.ReplicaID < r.Desc().NextReplicaID {
-				return nil
-			}
-		}
+		// TODO(bdarnell): handle coalesced heartbeats.
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
Previously, we would drop heartbeat messages but no others. This
distinction predated the introduction of NextReplicaID; now that we have
that to allow us to distinguish messages from the future from those from
the past, it is safe to apply this filter to all messages.

Removed replicas couldn't do much harm (e.g. they couldn't get elected
leader), but they could be disruptive by triggering unnecessary
elections.

Fixes #6118

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6423)

<!-- Reviewable:end -->
