### PR TITLE
kv: Assure that eviction tokens can only evict up to once

### DIFF
--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -173,15 +173,15 @@ func (db *testDescriptorDB) assertLookupCount(t *testing.T, expected int, key st
 	db.lookupCount = 0
 }
 
-func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) (*roachpb.RangeDescriptor, evictionToken) {
-	return doLookupWithToken(t, rc, key, evictionToken{}, false)
+func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) (*roachpb.RangeDescriptor, *evictionToken) {
+	return doLookupWithToken(t, rc, key, nil, false)
 }
 
-func doLookupConsideringIntents(t *testing.T, rc *rangeDescriptorCache, key string) (*roachpb.RangeDescriptor, evictionToken) {
-	return doLookupWithToken(t, rc, key, evictionToken{}, true)
+func doLookupConsideringIntents(t *testing.T, rc *rangeDescriptorCache, key string) (*roachpb.RangeDescriptor, *evictionToken) {
+	return doLookupWithToken(t, rc, key, nil, true)
 }
 
-func doLookupWithToken(t *testing.T, rc *rangeDescriptorCache, key string, evictToken evictionToken, considerIntents bool) (*roachpb.RangeDescriptor, evictionToken) {
+func doLookupWithToken(t *testing.T, rc *rangeDescriptorCache, key string, evictToken *evictionToken, considerIntents bool) (*roachpb.RangeDescriptor, *evictionToken) {
 	r, returnToken, pErr := rc.LookupRangeDescriptor(roachpb.RKey(key), evictToken, considerIntents, false /* useReverseScan */)
 	if pErr != nil {
 		t.Fatalf("Unexpected error from LookupRangeDescriptor: %s", pErr)
@@ -308,7 +308,7 @@ func TestRangeCacheDetectSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	db := initTestDescriptorDB(t)
 
-	pauseLookupResumeAndAssert := func(key string, expected int, evictToken evictionToken) {
+	pauseLookupResumeAndAssert := func(key string, expected int, evictToken *evictionToken) {
 		var wg sync.WaitGroup
 		db.pauseRangeLookups()
 		for i := 0; i < 3; i++ {


### PR DESCRIPTION
Resolves #6415.

Previously, eviction tokens generated from the same `RangeLookup` but
distributed to multiple requesters would allow each requester to evict
their descriptor when they saw an error. This change assures that
`evitionToken`s are now shared, so that at most one of these requests
could have evicted the descriptor.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6425)

<!-- Reviewable:end -->
