### PR TITLE
sql: import the go sql library as gosql

### DIFF
--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -18,7 +18,7 @@ package acceptance
 
 import (
 	"bytes"
-	"database/sql"
+	gosql "database/sql"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -43,7 +43,7 @@ var numAccounts = flag.Int("num-accounts", 999, "Number of accounts.")
 
 type testClient struct {
 	sync.RWMutex
-	db    *sql.DB
+	db    *gosql.DB
 	count uint64
 }
 

--- a/acceptance/event_log_test.go
+++ b/acceptance/event_log_test.go
@@ -17,7 +17,7 @@
 package acceptance
 
 import (
-	"database/sql"
+	gosql "database/sql"
 	"encoding/json"
 	"testing"
 
@@ -65,7 +65,7 @@ func testEventLogInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) 
 		var clusterID uuid.UUID
 		for rows.Next() {
 			var targetID int64
-			var infoStr sql.NullString
+			var infoStr gosql.NullString
 			if err := rows.Scan(&targetID, &infoStr); err != nil {
 				t.Fatal(err)
 			}
@@ -135,7 +135,7 @@ func testEventLogInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) 
 		seenCount := 0
 		for rows.Next() {
 			var targetID int64
-			var infoStr sql.NullString
+			var infoStr gosql.NullString
 			if err := rows.Scan(&targetID, &infoStr); err != nil {
 				t.Fatal(err)
 			}

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -19,7 +19,7 @@ package acceptance
 import (
 	"bytes"
 	"crypto/tls"
-	"database/sql"
+	gosql "database/sql"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -219,8 +219,8 @@ func SkipUnlessPrivileged(t *testing.T) {
 	}
 }
 
-func makePGClient(t *testing.T, dest string) *sql.DB {
-	db, err := sql.Open("postgres", dest)
+func makePGClient(t *testing.T, dest string) *gosql.DB {
+	db, err := gosql.Open("postgres", dest)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -72,6 +72,16 @@ TestForbiddenImports() {
   return $ret
 }
 
+TestImportNames() {
+    echo "checking for named imports"
+    if git grep -h '^\(import \|[[:space:]]*\)\(\|[a-z]* \)"database/sql"$' -- '*.go' | grep -v '\<gosql "database/sql"'; then
+        echo "Import 'database/sql' as 'gosql' to avoid confusion with 'cockroach/sql'."
+        return 1
+    fi
+    return 0
+}
+
+
 TestIneffassign() {
   ! ineffassign . | grep -vF '.pb.go' # gogo/protobuf#152
 }

--- a/sql/bank_test.go
+++ b/sql/bank_test.go
@@ -18,7 +18,7 @@ package sql_test
 
 import (
 	"bytes"
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -30,7 +30,7 @@ const maxTransfer = 999
 // runBenchmarkBank mirrors the SQL performed by examples/sql_bank, but
 // structured as a benchmark for easier usage of the Go performance analysis
 // tools like pprof, memprof and trace.
-func runBenchmarkBank(b *testing.B, db *sql.DB, numAccounts int) {
+func runBenchmarkBank(b *testing.B, db *gosql.DB, numAccounts int) {
 	{
 		// Initialize the "bank" table.
 		schema := `
@@ -83,8 +83,8 @@ UPDATE bench.bank
 	b.StopTimer()
 }
 
-func bankRunner(numAccounts int) func(*testing.B, *sql.DB) {
-	return func(b *testing.B, db *sql.DB) {
+func bankRunner(numAccounts int) func(*testing.B, *gosql.DB) {
+	return func(b *testing.B, db *gosql.DB) {
 		runBenchmarkBank(b, db, numAccounts)
 	}
 }

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -18,7 +18,7 @@ package sql_test
 
 import (
 	"bytes"
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -32,7 +32,7 @@ import (
 	_ "github.com/cockroachdb/pq"
 )
 
-func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *sql.DB)) {
+func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
 	defer tracing.Disable()()
 	s := server.StartTestServer(b)
 	defer s.Stop()
@@ -41,7 +41,7 @@ func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *sql.DB)) {
 	pgURL.Path = "bench"
 	defer cleanupFn()
 
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *sql.DB)) {
 	f(b, db)
 }
 
-func benchmarkPostgres(b *testing.B, f func(b *testing.B, db *sql.DB)) {
+func benchmarkPostgres(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
 	// Note: the following uses SSL. To run this, make sure your local
 	// Postgres server has SSL enabled. To use Cockroach's checked-in
 	// testing certificates for Postgres' SSL, first determine the
@@ -79,7 +79,7 @@ func benchmarkPostgres(b *testing.B, f func(b *testing.B, db *sql.DB)) {
 	// is replaced with your local Cockroach source directory.
 	// Be sure to restart Postgres for this to take effect.
 
-	db, err := sql.Open("postgres", "sslmode=require host=localhost port=5432")
+	db, err := gosql.Open("postgres", "sslmode=require host=localhost port=5432")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -92,8 +92,8 @@ func benchmarkPostgres(b *testing.B, f func(b *testing.B, db *sql.DB)) {
 	f(b, db)
 }
 
-func benchmarkMySQL(b *testing.B, f func(b *testing.B, db *sql.DB)) {
-	db, err := sql.Open("mysql", "root@tcp(localhost:3306)/")
+func benchmarkMySQL(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
+	db, err := gosql.Open("mysql", "root@tcp(localhost:3306)/")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func benchmarkMySQL(b *testing.B, f func(b *testing.B, db *sql.DB)) {
 	f(b, db)
 }
 
-func runBenchmarkSelect1(b *testing.B, db *sql.DB) {
+func runBenchmarkSelect1(b *testing.B, db *gosql.DB) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		rows, err := db.Query(`SELECT 1`)
@@ -132,7 +132,7 @@ func BenchmarkSelect1_MySQL(b *testing.B) {
 
 // runBenchmarkSelect2 Runs a SELECT query with non-trivial expressions. The main purpose is to
 // detect major regressions in query expression processing.
-func runBenchmarkSelect2(b *testing.B, db *sql.DB) {
+func runBenchmarkSelect2(b *testing.B, db *gosql.DB) {
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.select`); err != nil {
 		b.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func BenchmarkSelect2_MySQL(b *testing.B) {
 }
 
 // runBenchmarkInsert benchmarks inserting count rows into a table.
-func runBenchmarkInsert(b *testing.B, db *sql.DB, count int) {
+func runBenchmarkInsert(b *testing.B, db *gosql.DB, count int) {
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.insert`); err != nil {
 		b.Fatal(err)
 	}
@@ -229,19 +229,19 @@ func runBenchmarkInsert(b *testing.B, db *sql.DB, count int) {
 
 }
 
-func runBenchmarkInsert1(b *testing.B, db *sql.DB) {
+func runBenchmarkInsert1(b *testing.B, db *gosql.DB) {
 	runBenchmarkInsert(b, db, 1)
 }
 
-func runBenchmarkInsert10(b *testing.B, db *sql.DB) {
+func runBenchmarkInsert10(b *testing.B, db *gosql.DB) {
 	runBenchmarkInsert(b, db, 10)
 }
 
-func runBenchmarkInsert100(b *testing.B, db *sql.DB) {
+func runBenchmarkInsert100(b *testing.B, db *gosql.DB) {
 	runBenchmarkInsert(b, db, 100)
 }
 
-func runBenchmarkInsert1000(b *testing.B, db *sql.DB) {
+func runBenchmarkInsert1000(b *testing.B, db *gosql.DB) {
 	runBenchmarkInsert(b, db, 1000)
 }
 
@@ -278,7 +278,7 @@ func BenchmarkInsert1000_Postgres(b *testing.B) {
 }
 
 // runBenchmarkUpdate benchmarks updating count random rows in a table.
-func runBenchmarkUpdate(b *testing.B, db *sql.DB, count int) {
+func runBenchmarkUpdate(b *testing.B, db *gosql.DB, count int) {
 	rows := 10000
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.update`); err != nil {
 		b.Fatal(err)
@@ -325,19 +325,19 @@ func runBenchmarkUpdate(b *testing.B, db *sql.DB, count int) {
 	b.StopTimer()
 }
 
-func runBenchmarkUpdate1(b *testing.B, db *sql.DB) {
+func runBenchmarkUpdate1(b *testing.B, db *gosql.DB) {
 	runBenchmarkUpdate(b, db, 1)
 }
 
-func runBenchmarkUpdate10(b *testing.B, db *sql.DB) {
+func runBenchmarkUpdate10(b *testing.B, db *gosql.DB) {
 	runBenchmarkUpdate(b, db, 10)
 }
 
-func runBenchmarkUpdate100(b *testing.B, db *sql.DB) {
+func runBenchmarkUpdate100(b *testing.B, db *gosql.DB) {
 	runBenchmarkUpdate(b, db, 100)
 }
 
-func runBenchmarkUpdate1000(b *testing.B, db *sql.DB) {
+func runBenchmarkUpdate1000(b *testing.B, db *gosql.DB) {
 	runBenchmarkUpdate(b, db, 1000)
 }
 
@@ -374,7 +374,7 @@ func BenchmarkUpdate1000_Postgres(b *testing.B) {
 }
 
 // runBenchmarkDelete benchmarks deleting count rows from a table.
-func runBenchmarkDelete(b *testing.B, db *sql.DB, rows int) {
+func runBenchmarkDelete(b *testing.B, db *gosql.DB, rows int) {
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.delete`); err != nil {
 		b.Fatal(err)
 	}
@@ -420,19 +420,19 @@ func runBenchmarkDelete(b *testing.B, db *sql.DB, rows int) {
 	b.StopTimer()
 }
 
-func runBenchmarkDelete1(b *testing.B, db *sql.DB) {
+func runBenchmarkDelete1(b *testing.B, db *gosql.DB) {
 	runBenchmarkDelete(b, db, 1)
 }
 
-func runBenchmarkDelete10(b *testing.B, db *sql.DB) {
+func runBenchmarkDelete10(b *testing.B, db *gosql.DB) {
 	runBenchmarkDelete(b, db, 10)
 }
 
-func runBenchmarkDelete100(b *testing.B, db *sql.DB) {
+func runBenchmarkDelete100(b *testing.B, db *gosql.DB) {
 	runBenchmarkDelete(b, db, 100)
 }
 
-func runBenchmarkDelete1000(b *testing.B, db *sql.DB) {
+func runBenchmarkDelete1000(b *testing.B, db *gosql.DB) {
 	runBenchmarkDelete(b, db, 1000)
 }
 
@@ -469,7 +469,7 @@ func BenchmarkDelete1000_Postgres(b *testing.B) {
 }
 
 // runBenchmarkScan benchmarks scanning a table containing count rows.
-func runBenchmarkScan(b *testing.B, db *sql.DB, count int, limit int) {
+func runBenchmarkScan(b *testing.B, db *gosql.DB, count int, limit int) {
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.scan`); err != nil {
 		b.Fatal(err)
 	}
@@ -524,71 +524,71 @@ func runBenchmarkScan(b *testing.B, db *sql.DB, count int, limit int) {
 }
 
 func BenchmarkScan1_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 1, 0) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1, 0) })
 }
 
 func BenchmarkScan1_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 1, 0) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1, 0) })
 }
 
 func BenchmarkScan10_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 10, 0) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 10, 0) })
 }
 
 func BenchmarkScan10_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 10, 0) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 10, 0) })
 }
 
 func BenchmarkScan100_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 100, 0) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 100, 0) })
 }
 
 func BenchmarkScan100_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 100, 0) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 100, 0) })
 }
 
 func BenchmarkScan1000_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 1000, 0) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 0) })
 }
 
 func BenchmarkScan1000_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 1000, 0) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 0) })
 }
 
 func BenchmarkScan10000_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 10000, 0) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 10000, 0) })
 }
 
 func BenchmarkScan10000_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 10000, 0) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 10000, 0) })
 }
 
 func BenchmarkScan1000Limit1_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 1000, 1) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 1) })
 }
 
 func BenchmarkScan1000Limit1_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 1000, 1) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 1) })
 }
 
 func BenchmarkScan1000Limit10_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 1000, 10) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 10) })
 }
 
 func BenchmarkScan1000Limit10_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 1000, 10) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 10) })
 }
 
 func BenchmarkScan1000Limit100_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 1000, 100) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 100) })
 }
 
 func BenchmarkScan1000Limit100_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkScan(b, db, 1000, 100) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 100) })
 }
 
 // runBenchmarkScanFilter benchmarks scanning (w/filter) from a table containing count1 * count2 rows.
-func runBenchmarkScanFilter(b *testing.B, db *sql.DB, count1, count2 int, limit int, filter string) {
+func runBenchmarkScanFilter(b *testing.B, db *gosql.DB, count1, count2 int, limit int, filter string) {
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.scan2`); err != nil {
 		b.Fatal(err)
 	}
@@ -637,8 +637,8 @@ func runBenchmarkScanFilter(b *testing.B, db *sql.DB, count1, count2 int, limit 
 	}
 }
 
-func filterLimitBenchFn(limit int) func(*testing.B, *sql.DB) {
-	return func(b *testing.B, db *sql.DB) {
+func filterLimitBenchFn(limit int) func(*testing.B, *gosql.DB) {
+	return func(b *testing.B, db *gosql.DB) {
 		runBenchmarkScanFilter(b, db, 25, 400, limit,
 			`a IN (1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 20, 21, 23) AND b < 10*a`)
 	}
@@ -669,7 +669,7 @@ func BenchmarkScan10000FilterLimit50_Postgres(b *testing.B) {
 }
 
 // runBenchmarkOrderBy benchmarks scanning a table and sorting the results.
-func runBenchmarkOrderBy(b *testing.B, db *sql.DB, count int, limit int, distinct bool) {
+func runBenchmarkOrderBy(b *testing.B, db *gosql.DB, count int, limit int, distinct bool) {
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.sort`); err != nil {
 		b.Fatal(err)
 	}
@@ -728,22 +728,22 @@ func runBenchmarkOrderBy(b *testing.B, db *sql.DB, count int, limit int, distinc
 }
 
 func BenchmarkSort100000Limit10_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, false) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, false) })
 }
 
 func BenchmarkSort100000Limit10_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, false) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, false) })
 }
 
 func BenchmarkSort100000Limit10Distinct_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, true) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, true) })
 }
 
 func BenchmarkSort100000Limit10Distinct_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, true) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, true) })
 }
 
-func runBenchmarkTrackChoices(b *testing.B, db *sql.DB, batchSize int) {
+func runBenchmarkTrackChoices(b *testing.B, db *gosql.DB, batchSize int) {
 	const numOptions = 10000
 
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.track_choices`); err != nil {
@@ -788,33 +788,33 @@ CREATE INDEX track_created_at ON bench.track_choices (track_id, created_at);
 }
 
 func BenchmarkTrackChoices1_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkTrackChoices(b, db, 1) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 1) })
 }
 
 func BenchmarkTrackChoices10_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkTrackChoices(b, db, 10) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 10) })
 }
 
 func BenchmarkTrackChoices100_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkTrackChoices(b, db, 100) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 100) })
 }
 
 func BenchmarkTrackChoices1000_Cockroach(b *testing.B) {
-	benchmarkCockroach(b, func(b *testing.B, db *sql.DB) { runBenchmarkTrackChoices(b, db, 1000) })
+	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 1000) })
 }
 
 func BenchmarkTrackChoices1_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkTrackChoices(b, db, 1) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 1) })
 }
 
 func BenchmarkTrackChoices10_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkTrackChoices(b, db, 10) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 10) })
 }
 
 func BenchmarkTrackChoices100_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkTrackChoices(b, db, 100) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 100) })
 }
 
 func BenchmarkTrackChoices1000_Postgres(b *testing.B) {
-	benchmarkPostgres(b, func(b *testing.B, db *sql.DB) { runBenchmarkTrackChoices(b, db, 1000) })
+	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 1000) })
 }

--- a/sql/descriptor_mutation_test.go
+++ b/sql/descriptor_mutation_test.go
@@ -17,7 +17,7 @@
 package sql_test
 
 import (
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -33,7 +33,7 @@ import (
 type mutationTest struct {
 	*testing.T
 	kvDB    *client.DB
-	sqlDB   *sql.DB
+	sqlDB   *gosql.DB
 	descKey roachpb.Key
 	desc    *csql.Descriptor
 }

--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -17,7 +17,7 @@
 package sql_test
 
 import (
-	dbsql "database/sql"
+	gosql "database/sql"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/config"
@@ -361,7 +361,7 @@ func TestDropAndCreateTable(t *testing.T) {
 	pgURL.Path = "test"
 	defer cleanupFn()
 
-	db, err := dbsql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/kv_test.go
+++ b/sql/kv_test.go
@@ -18,7 +18,7 @@ package sql_test
 
 import (
 	"bytes"
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -163,7 +163,7 @@ func (kv *kvNative) done() {
 
 // kvSQL is a SQL-based implementation of the KV interface.
 type kvSQL struct {
-	db     *sql.DB
+	db     *gosql.DB
 	doneFn func()
 }
 
@@ -172,7 +172,7 @@ func newKVSQL(b *testing.B) kvInterface {
 	s := server.StartTestServer(b)
 	pgURL, cleanupURL := sqlutils.PGUrl(b, s, security.RootUser, "benchmarkCockroach")
 	pgURL.Path = "bench"
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -20,7 +20,7 @@ package sql_test
 
 import (
 	"bytes"
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"sync"
 	"testing"
@@ -39,7 +39,7 @@ import (
 type leaseTest struct {
 	*testing.T
 	server *testServer
-	db     *sql.DB
+	db     *gosql.DB
 	kvDB   *client.DB
 	nodes  map[uint32]*csql.LeaseManager
 }

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -20,7 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/md5"
-	"database/sql"
+	gosql "database/sql"
 	"errors"
 	"flag"
 	"fmt"
@@ -161,10 +161,10 @@ type logicTest struct {
 	srv *testServer
 	// map of built clients. Needs to be persisted so that we can
 	// re-use them and close them all on exit.
-	clients map[string]*sql.DB
+	clients map[string]*gosql.DB
 	// client currently in use.
 	user            string
-	db              *sql.DB
+	db              *gosql.DB
 	progress        int
 	lastProgress    time.Time
 	traceFile       *os.File
@@ -212,7 +212,7 @@ func (t *logicTest) setUser(user string) func() {
 	}
 
 	if t.clients == nil {
-		t.clients = map[string]*sql.DB{}
+		t.clients = map[string]*gosql.DB{}
 	}
 	if db, ok := t.clients[user]; ok {
 		t.db = db
@@ -227,7 +227,7 @@ func (t *logicTest) setUser(user string) func() {
 	}
 
 	pgURL, cleanupFunc := sqlutils.PGUrl(t.T, &t.srv.TestServer, user, "TestLogic")
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -18,7 +18,7 @@ package sql_test
 
 import (
 	"bytes"
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"os"
 	"sync"
@@ -206,16 +206,16 @@ func setupTestServerWithContext(t *testing.T, ctx *server.Context) *testServer {
 	return s
 }
 
-func setup(t *testing.T) (*testServer, *sql.DB, *client.DB) {
+func setup(t *testing.T) (*testServer, *gosql.DB, *client.DB) {
 	return setupWithContext(t, server.NewTestContext())
 }
 
-func setupWithContext(t *testing.T, ctx *server.Context) (*testServer, *sql.DB, *client.DB) {
+func setupWithContext(t *testing.T, ctx *server.Context) (*testServer, *gosql.DB, *client.DB) {
 	s := setupTestServerWithContext(t, ctx)
 
 	// SQL requests use security.RootUser which has ALL permissions on everything.
 	url, cleanupFn := sqlutils.PGUrl(t, &s.TestServer, security.RootUser, "setupWithContext")
-	sqlDB, err := sql.Open("postgres", url.String())
+	sqlDB, err := gosql.Open("postgres", url.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +231,7 @@ func cleanupTestServer(s *testServer) {
 	}
 }
 
-func cleanup(s *testServer, db *sql.DB) {
+func cleanup(s *testServer, db *gosql.DB) {
 	_ = db.Close()
 	cleanupTestServer(s)
 }

--- a/sql/multinode_test.go
+++ b/sql/multinode_test.go
@@ -17,7 +17,7 @@
 package sql_test
 
 import (
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"testing"
 
@@ -29,7 +29,7 @@ import (
 )
 
 // Starts up a cluster made of up `nodes` in-memory testing servers,
-// creates database `name and returns open sql.DB connections to each
+// creates database `name and returns open gosql.DB connections to each
 // node (to the named db), as well as a cleanup func that stops and
 // cleans up all nodes and connections.
 // TODO(davidt): Change zone config to actually add replication.
@@ -38,7 +38,7 @@ import (
 // useful for benchmarking, as without replication overhead it is the same as
 // single-node operation, except without the local-call optimization for the
 // additional nodes.
-func SetupMultinodeTestCluster(t testing.TB, nodes int, name string) ([]*sql.DB, func()) {
+func SetupMultinodeTestCluster(t testing.TB, nodes int, name string) ([]*gosql.DB, func()) {
 	if nodes < 1 {
 		t.Fatal("invalid cluster size: ", nodes)
 	}
@@ -49,14 +49,14 @@ func SetupMultinodeTestCluster(t testing.TB, nodes int, name string) ([]*sql.DB,
 		servers = append(servers, server.StartTestServerJoining(t, first))
 	}
 
-	var conns []*sql.DB
+	var conns []*gosql.DB
 	var closes []func() error
 	var cleanups []func()
 
 	for i, s := range servers {
 		pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, fmt.Sprintf("node%d", i))
 		pgURL.Path = name
-		db, err := sql.Open("postgres", pgURL.String())
+		db, err := gosql.Open("postgres", pgURL.String())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/sql/parallel_test.go
+++ b/sql/parallel_test.go
@@ -29,7 +29,7 @@
 package sql_test
 
 import (
-	"database/sql"
+	gosql "database/sql"
 	"flag"
 	"fmt"
 	"os"
@@ -49,7 +49,7 @@ var (
 )
 
 type testDB struct {
-	db      *sql.DB
+	db      *gosql.DB
 	cleanup func()
 }
 
@@ -73,7 +73,7 @@ func (t *parallelTest) close() {
 
 func (t *parallelTest) addClient(createDB bool) {
 	pgURL, cleanupFunc := sqlutils.PGUrl(t.T, &t.srv.TestServer, security.RootUser, "TestParallel")
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func (t *parallelTest) addClient(createDB bool) {
 	t.clients = append(t.clients, testDB{db: db, cleanup: cleanupFunc})
 }
 
-func (t *parallelTest) processTestFile(path string, db *sql.DB, ch chan bool) {
+func (t *parallelTest) processTestFile(path string, db *gosql.DB, ch chan bool) {
 	if ch != nil {
 		defer func() { ch <- true }()
 	}

--- a/sql/pgbench/cmd/pgbenchsetup/main.go
+++ b/sql/pgbench/cmd/pgbenchsetup/main.go
@@ -17,7 +17,7 @@
 package main
 
 import (
-	"database/sql"
+	gosql "database/sql"
 	"flag"
 	"fmt"
 	"net/url"
@@ -45,7 +45,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	var db *sql.DB
+	var db *gosql.DB
 	var err error
 
 	if *createDb {
@@ -61,7 +61,7 @@ func main() {
 
 		db, err = pgbench.CreateAndConnect(*parsed, name)
 	} else {
-		db, err = sql.Open("postgres", flag.Arg(0))
+		db, err = gosql.Open("postgres", flag.Arg(0))
 	}
 	if err != nil {
 		panic(err)

--- a/sql/pgbench/query.go
+++ b/sql/pgbench/query.go
@@ -17,7 +17,7 @@
 package pgbench
 
 import (
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"math/rand"
 	"net"
@@ -37,7 +37,7 @@ INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES (%[3]d, %[4]d, 
 END;` // vars: 1 delta, 2 aid, 3 tid, 4 bid
 
 // RunOne executes one iteration of the query batch that `pgbench` executes.
-func RunOne(db *sql.DB, r *rand.Rand, accounts int) error {
+func RunOne(db *gosql.DB, r *rand.Rand, accounts int) error {
 	account := r.Intn(accounts)
 	delta := r.Intn(5000)
 	teller := r.Intn(tellers)

--- a/sql/pgbench/setup.go
+++ b/sql/pgbench/setup.go
@@ -18,7 +18,7 @@ package pgbench
 
 import (
 	"bytes"
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"net/url"
 	"os/exec"
@@ -62,10 +62,10 @@ CREATE TABLE pgbench_history (
 
 // CreateAndConnect connects and creates the requested DB (dropping
 // if exists) then returns a new connection to the created DB.
-func CreateAndConnect(pgURL url.URL, name string) (*sql.DB, error) {
+func CreateAndConnect(pgURL url.URL, name string) (*gosql.DB, error) {
 	{
 		pgURL.Path = ""
-		db, err := sql.Open("postgres", pgURL.String())
+		db, err := gosql.Open("postgres", pgURL.String())
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +82,7 @@ func CreateAndConnect(pgURL url.URL, name string) (*sql.DB, error) {
 
 	pgURL.Path = name
 
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func SetupExec(pgURL url.URL, name string, accounts, transactions int) (*exec.Cm
 // not support. The queries this script runs are based on a dump of a db created
 // by `pgbench -i`, but sticking to the compatible subset that both cockroach and
 // postgres support.
-func SetupBenchDB(db *sql.DB, accounts int, quiet bool) error {
+func SetupBenchDB(db *gosql.DB, accounts int, quiet bool) error {
 	if _, err := db.Exec(schema); err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func SetupBenchDB(db *sql.DB, accounts int, quiet bool) error {
 
 const tellers = 10
 
-func populateDB(db *sql.DB, accounts int, quiet bool) error {
+func populateDB(db *gosql.DB, accounts int, quiet bool) error {
 	branches := `INSERT INTO pgbench_branches (bid, bbalance, filler) VALUES (1, 7354, NULL)`
 	if r, err := db.Exec(branches); err != nil {
 		return err

--- a/sql/pgbench_test.go
+++ b/sql/pgbench_test.go
@@ -17,7 +17,7 @@
 package sql_test
 
 import (
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"math/rand"
 	"net/url"
@@ -34,7 +34,7 @@ import (
 
 // Tests a batch of queries very similar to those that that PGBench runs
 // in its TPC-B(ish) mode.
-func runPgbenchQuery(b *testing.B, db *sql.DB) {
+func runPgbenchQuery(b *testing.B, db *gosql.DB) {
 	if err := pgbench.SetupBenchDB(db, 20000, true /*quiet*/); err != nil {
 		b.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func runPgbenchQuery(b *testing.B, db *sql.DB) {
 
 // Tests a batch of queries very similar to those that that PGBench runs
 // in its TPC-B(ish) mode.
-func runPgbenchQueryParallel(b *testing.B, db *sql.DB) {
+func runPgbenchQueryParallel(b *testing.B, db *gosql.DB) {
 	if err := pgbench.SetupBenchDB(db, 20000, true /*quiet*/); err != nil {
 		b.Fatal(err)
 	}

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -17,7 +17,7 @@
 package sql_test
 
 import (
-	"database/sql"
+	gosql "database/sql"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -42,7 +42,7 @@ import (
 )
 
 func trivialQuery(pgURL url.URL) error {
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func TestPGWireDBName(t *testing.T) {
 	pgURL.Path = "foo"
 	defer cleanupFn()
 	{
-		db, err := sql.Open("postgres", pgURL.String())
+		db, err := gosql.Open("postgres", pgURL.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -226,7 +226,7 @@ func TestPGWireDBName(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +246,7 @@ func TestPGPrepareFail(t *testing.T) {
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPGPrepareFail")
 	defer cleanupFn()
 
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -369,7 +369,7 @@ func TestPGPreparedQuery(t *testing.T) {
 		"SELECT CASE WHEN $1 THEN 1-$3 WHEN $2 THEN 1+$3 END": {
 			base.Params(true, false, 2).Results(-1),
 			base.Params(false, true, 3).Results(4),
-			base.Params(false, false, 2).Results(sql.NullBool{}),
+			base.Params(false, false, 2).Results(gosql.NullBool{}),
 		},
 		"SELECT CASE 1 WHEN $1 THEN $2 ELSE 2 END": {
 			base.Params(1, 3).Results(3),
@@ -384,8 +384,8 @@ func TestPGPreparedQuery(t *testing.T) {
 		},
 		"SHOW COLUMNS FROM system.users": {
 			base.
-				Results("username", "STRING", false, sql.NullBool{}).
-				Results("hashedPassword", "BYTES", true, sql.NullBool{}),
+				Results("username", "STRING", false, gosql.NullBool{}).
+				Results("hashedPassword", "BYTES", true, gosql.NullBool{}),
 		},
 		"SHOW DATABASES": {
 			base.Results("d").Results("system"),
@@ -478,13 +478,13 @@ func TestPGPreparedQuery(t *testing.T) {
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPGPreparedQuery")
 	defer cleanupFn()
 
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer db.Close()
 
-	runTests := func(query string, tests []preparedQueryTest, queryFunc func(...interface{}) (*sql.Rows, error)) {
+	runTests := func(query string, tests []preparedQueryTest, queryFunc func(...interface{}) (*gosql.Rows, error)) {
 		for _, test := range tests {
 			if testing.Verbose() || log.V(1) {
 				log.Infof("query: %s", query)
@@ -563,7 +563,7 @@ func TestPGPreparedQuery(t *testing.T) {
 	}
 
 	for query, tests := range queryTests {
-		runTests(query, tests, func(args ...interface{}) (*sql.Rows, error) {
+		runTests(query, tests, func(args ...interface{}) (*gosql.Rows, error) {
 			return db.Query(query, args...)
 		})
 	}
@@ -692,13 +692,13 @@ func TestPGPreparedExec(t *testing.T) {
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPGPreparedExec")
 	defer cleanupFn()
 
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer db.Close()
 
-	runTests := func(query string, tests []preparedExecTest, execFunc func(...interface{}) (sql.Result, error)) {
+	runTests := func(query string, tests []preparedExecTest, execFunc func(...interface{}) (gosql.Result, error)) {
 		for _, test := range tests {
 			if testing.Verbose() || log.V(1) {
 				log.Infof("exec: %s", query)
@@ -720,7 +720,7 @@ func TestPGPreparedExec(t *testing.T) {
 	}
 
 	for _, execTest := range execTests {
-		runTests(execTest.query, execTest.tests, func(args ...interface{}) (sql.Result, error) {
+		runTests(execTest.query, execTest.tests, func(args ...interface{}) (gosql.Result, error) {
 			return db.Exec(execTest.query, args...)
 		})
 	}
@@ -751,7 +751,7 @@ func TestPGPrepareNameQual(t *testing.T) {
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPGPrepareNameQual")
 	defer cleanupFn()
 
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -762,7 +762,7 @@ func TestPGPrepareNameQual(t *testing.T) {
 	}
 
 	pgURL.Path = "/testing"
-	db2, err := sql.Open("postgres", pgURL.String())
+	db2, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -801,16 +801,16 @@ func TestCmdCompleteVsEmptyStatements(t *testing.T) {
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestCmdCompleteVsEmptyStatements")
 	defer cleanupFn()
 
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer db.Close()
 
 	// cockroachdb/pq handles the empty query response by returning a nil driver.Result.
-	// Unfortunately sql.Exec wraps that, nil or not, in a sql.Result which doesn't
+	// Unfortunately gosql.Exec wraps that, nil or not, in a gosql.Result which doesn't
 	// expose the underlying driver.Result.
-	// sql.Result does however have methods which attempt to dereference the underlying
+	// gosql.Result does however have methods which attempt to dereference the underlying
 	// driver.Result and can thus be used to determine if it is nil.
 	// TODO(dt): This would be prettier and generate better failures with testify/assert's helpers.
 
@@ -842,7 +842,7 @@ func TestPGCommandTags(t *testing.T) {
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPGCommandTags")
 	defer cleanupFn()
 
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -997,10 +997,10 @@ func TestSQLNetworkMetrics(t *testing.T) {
 		})
 	}
 
-	var conns [10]*sql.DB
+	var conns [10]*gosql.DB
 	for i := range conns {
 		var err error
-		if conns[i], err = sql.Open("postgres", pgURL.String()); err != nil {
+		if conns[i], err = gosql.Open("postgres", pgURL.String()); err != nil {
 			t.Fatal(err)
 		}
 		defer conns[i].Close()
@@ -1028,7 +1028,7 @@ func TestPrepareSyntax(t *testing.T) {
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPrepareSyntax")
 	defer cleanupFn()
 
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/scan_test.go
+++ b/sql/scan_test.go
@@ -18,7 +18,7 @@ package sql_test
 
 import (
 	"bytes"
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -52,7 +52,7 @@ func genValues(num, valRange int) []int {
 // testScanBatchQuery runs a query of the form
 //  SELECT a,B FROM test.scan WHERE a IN (1,5,3..) AND b >= 5 AND b <= 10
 // numSpans controls the number of possible values for a.
-func testScanBatchQuery(t *testing.T, db *sql.DB, numSpans, numAs, numBs int, reverse bool) {
+func testScanBatchQuery(t *testing.T, db *gosql.DB, numSpans, numAs, numBs int, reverse bool) {
 	// Generate numSpans values for A
 	aVals := genValues(numSpans, numAs)
 
@@ -136,7 +136,7 @@ func TestScanBatches(t *testing.T) {
 	pgURL.Path = "test"
 	defer cleanupFn()
 
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -17,7 +17,7 @@
 package sql_test
 
 import (
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -425,7 +425,7 @@ ALTER INDEX t.test@foo RENAME TO ufo
 // soon as the schema change starts executing its backfill.
 func runSchemaChangeWithOperations(
 	t *testing.T,
-	sqlDB *sql.DB,
+	sqlDB *gosql.DB,
 	kvDB *client.DB,
 	schemaChange string,
 	maxValue int,

--- a/sql/trace_test.go
+++ b/sql/trace_test.go
@@ -18,7 +18,7 @@ package sql_test
 
 import (
 	"bytes"
-	"database/sql"
+	gosql "database/sql"
 	"fmt"
 	"reflect"
 	"sort"
@@ -29,7 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
-func rowsToStrings(rows *sql.Rows) [][]string {
+func rowsToStrings(rows *gosql.Rows) [][]string {
 	cols, err := rows.Columns()
 	if err != nil {
 		panic(err)

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -17,7 +17,7 @@
 package storage_test
 
 import (
-	"database/sql"
+	gosql "database/sql"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -41,7 +41,7 @@ func TestLogSplits(t *testing.T) {
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestLogSplits")
 	defer cleanupFn()
 
-	db, err := sql.Open("postgres", pgURL.String())
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,8 +84,8 @@ func TestLogSplits(t *testing.T) {
 	}
 	for rows.Next() {
 		var rangeID int64
-		var otherRangeID sql.NullInt64
-		var infoStr sql.NullString
+		var otherRangeID gosql.NullInt64
+		var infoStr gosql.NullString
 		if err := rows.Scan(&rangeID, &otherRangeID, &infoStr); err != nil {
 			t.Fatal(err)
 		}
@@ -187,7 +187,7 @@ func TestLogRebalances(t *testing.T) {
 	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestLogRebalances")
 	defer cleanupFn()
 
-	sqlDB, err := sql.Open("postgres", pgURL.String())
+	sqlDB, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func TestLogRebalances(t *testing.T) {
 	for rows.Next() {
 		count++
 		var rangeID int64
-		var infoStr sql.NullString
+		var infoStr gosql.NullString
 		if err := rows.Scan(&rangeID, &infoStr); err != nil {
 			t.Fatal(err)
 		}
@@ -248,7 +248,7 @@ func TestLogRebalances(t *testing.T) {
 	for rows.Next() {
 		count++
 		var rangeID int64
-		var infoStr sql.NullString
+		var infoStr gosql.NullString
 		if err := rows.Scan(&rangeID, &infoStr); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
When browsing code (especially testing code), the use of "sql." for the go
"database/sql" library (as opposed to our sql package) gets confusing. This
change renames all imports of "database/sql" to "gosql".

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6434)

<!-- Reviewable:end -->
