### PR TITLE
server: wait for initial splits in node_test.go

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -829,7 +829,7 @@ func (tc *TxnCoordSender) updateState(
 	default:
 		if pErr.GetTxn() != nil {
 			if pErr.CanRetry() {
-				panic("Retryable internal error must not happen at this level")
+				log.Fatalf("retryable internal error must not happen at this level: %s", pErr)
 			} else {
 				// Do not clean up the transaction here since the client might still
 				// want to continue the transaction. For example, a client might

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -109,6 +109,9 @@ func createAndStartTestNode(addr net.Addr, engines []engine.Engine, gossipBS net
 	if err := node.start(addr, engines, roachpb.Attributes{}); err != nil {
 		t.Fatal(err)
 	}
+	if err := waitForInitialSplits(node.ctx.DB); err != nil {
+		t.Fatal(err)
+	}
 	return grpcServer, addr, node, stopper
 }
 

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -274,10 +274,14 @@ func ExpectedInitialRangeCount() int {
 // splits at startup. If the expected range count is not reached within a
 // configured timeout, an error is returned.
 func (ts *TestServer) WaitForInitialSplits() error {
+	return waitForInitialSplits(ts.DB())
+}
+
+func waitForInitialSplits(db *client.DB) error {
 	expectedRanges := ExpectedInitialRangeCount()
 	return util.RetryForDuration(initialSplitsTimeout, func() error {
 		// Scan all keys in the Meta2Prefix; we only need a count.
-		rows, pErr := ts.DB().Scan(keys.Meta2Prefix, keys.MetaMax, 0)
+		rows, pErr := db.Scan(keys.Meta2Prefix, keys.MetaMax, 0)
 		if pErr != nil {
 			return pErr.GoError()
 		}


### PR DESCRIPTION
I was unable to reproduce or diagnose the underlying errors, but this works around the problem. #6436 filed to look closer at this some day.

De-flakes TestBootstrapNewStore and TestNodeJoin.

Fixes #6116
Fixes #6431

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6437)

<!-- Reviewable:end -->
