### PR TITLE
remove non-test dependency on testutils

### DIFF
--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -59,6 +59,15 @@ func TestNoLinkForbidden(t *testing.T) {
 			t.Errorf("The cockroach binary includes %s, which is forbidden", forbidden)
 		}
 	}
+	for _, forbiddenPrefix := range []string{
+		"github.com/cockroachdb/cockroach/testutils", // meant for testing code only
+	} {
+		for k := range imports {
+			if strings.HasPrefix(k, forbiddenPrefix) {
+				t.Errorf("The cockroach binary includes %s, which is forbidden", k)
+			}
+		}
+	}
 }
 
 func TestCacheFlagValue(t *testing.T) {

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -511,7 +511,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 
 	ctx := server.NewTestContext()
 	ctx.TestingKnobs.StoreTestingKnobs.TestingCommandFilter =
-		func(fArgs storageutils.FilterArgs) *roachpb.Error {
+		func(fArgs storagebase.FilterArgs) *roachpb.Error {
 			_, ok := fArgs.Req.(*roachpb.ConditionalPutRequest)
 			if ok && fArgs.Req.Header().Key.Equal(targetKey) {
 				if atomic.AddInt32(&numGets, 1) == 1 {

--- a/kv/local_test_cluster.go
+++ b/kv/local_test_cluster.go
@@ -22,13 +22,13 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -41,8 +41,8 @@ import (
 // cockroach node with a single store using a local sender. Example
 // usage of a LocalTestCluster follows:
 //
-//   s := &server.LocalTestCluster{}
-//   s.Start(t)
+//   s := &LocalTestCluster{}
+//   s.Start(t, testutils.NewNodeTestBaseContext())
 //   defer s.Stop()
 //
 // Note that the LocalTestCluster is different from server.TestCluster
@@ -67,14 +67,14 @@ type LocalTestCluster struct {
 // node RPC server and all HTTP endpoints. Use the value of
 // TestServer.Addr after Start() for client connections. Use Stop()
 // to shutdown the server after the test completes.
-func (ltc *LocalTestCluster) Start(t util.Tester) {
+func (ltc *LocalTestCluster) Start(t util.Tester, baseCtx *base.Context) {
 	nodeID := roachpb.NodeID(1)
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: nodeID}
 	ltc.tester = t
 	ltc.Manual = hlc.NewManualClock(0)
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano)
 	ltc.Stopper = stop.NewStopper()
-	rpcContext := rpc.NewContext(testutils.NewNodeTestBaseContext(), ltc.Clock, ltc.Stopper)
+	rpcContext := rpc.NewContext(baseCtx, ltc.Clock, ltc.Stopper)
 	ltc.Gossip = gossip.New(rpcContext, nil, ltc.Stopper)
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20, ltc.Stopper)
 

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -70,7 +70,7 @@ func teardownHeartbeats(tc *TxnCoordSender) {
 // is responsible for stopping the test server.
 func createTestDB(t testing.TB) *LocalTestCluster {
 	s := &LocalTestCluster{}
-	s.Start(t)
+	s.Start(t, testutils.NewNodeTestBaseContext())
 	return s
 }
 

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -106,7 +106,7 @@ func TestTxnDBBasics(t *testing.T) {
 func benchmarkSingleRoundtripWithLatency(b *testing.B, latency time.Duration) {
 	s := &LocalTestCluster{}
 	s.Latency = latency
-	s.Start(b)
+	s.Start(b, testutils.NewNodeTestBaseContext())
 	defer s.Stop()
 	defer b.StopTimer()
 	key := roachpb.Key("key")

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/randutil"
@@ -80,7 +80,7 @@ func TestIntentResolution(t *testing.T) {
 			var done bool
 			ctx := NewTestContext()
 			ctx.TestingKnobs.StoreTestingKnobs.TestingCommandFilter =
-				func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+				func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 					mu.Lock()
 					defer mu.Unlock()
 					header := filterArgs.Req.Header()

--- a/sql/metric_test.go
+++ b/sql/metric_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -105,7 +105,7 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 
 	// Inject errors on the INSERT below.
 	restarted := false
-	cmdFilters.AppendFilter(func(args storageutils.FilterArgs) *roachpb.Error {
+	cmdFilters.AppendFilter(func(args storagebase.FilterArgs) *roachpb.Error {
 		switch req := args.Req.(type) {
 		// SQL INSERT generates ConditionalPuts for unique indexes (such as the PK).
 		case *roachpb.ConditionalPutRequest:

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util/caller"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/uuid"
@@ -241,7 +241,7 @@ CREATE TABLE t.test (k TEXT PRIMARY KEY, v TEXT, t DECIMAL);
 		"hooly":     2,
 	}
 	cleanupFilter := cmdFilters.AppendFilter(
-		func(args storageutils.FilterArgs) *roachpb.Error {
+		func(args storagebase.FilterArgs) *roachpb.Error {
 			if err := injectErrors(args.Req, args.Hdr, magicVals); err != nil {
 				return roachpb.NewErrorWithTxn(err, args.Hdr.Txn)
 			}
@@ -289,7 +289,7 @@ INSERT INTO t.test (k, v, t) VALUES ('k', 'laureal', cluster_logical_timestamp()
 		"hooly": 2,
 	}
 	cleanupFilter = cmdFilters.AppendFilter(
-		func(args storageutils.FilterArgs) *roachpb.Error {
+		func(args storagebase.FilterArgs) *roachpb.Error {
 			if err := injectErrors(args.Req, args.Hdr, magicVals); err != nil {
 				return roachpb.NewErrorWithTxn(err, args.Hdr.Txn)
 			}
@@ -440,7 +440,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 
 	for _, tc := range testCases {
 		cleanupFilter := cmdFilters.AppendFilter(
-			func(args storageutils.FilterArgs) *roachpb.Error {
+			func(args storagebase.FilterArgs) *roachpb.Error {
 				if err := injectErrors(args.Req, args.Hdr, tc.magicVals); err != nil {
 					return roachpb.NewErrorWithTxn(err, args.Hdr.Txn)
 				}
@@ -665,7 +665,7 @@ CREATE TABLE t.test (k TEXT PRIMARY KEY, v TEXT);
 		"boulanger": 1,
 	}
 	cmdFilters.AppendFilter(
-		func(args storageutils.FilterArgs) *roachpb.Error {
+		func(args storagebase.FilterArgs) *roachpb.Error {
 			if err := injectErrors(args.Req, args.Hdr, magicVals); err != nil {
 				return roachpb.NewErrorWithTxn(err, args.Hdr.Txn)
 			}

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils/gossiputil"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -170,7 +170,7 @@ func TestStoreRecoverWithErrors(t *testing.T) {
 		defer stopper.Stop()
 		sCtx := storage.TestStoreContext()
 		sCtx.TestingKnobs.TestingCommandFilter =
-			func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+			func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 				_, ok := filterArgs.Req.(*roachpb.IncrementRequest)
 				if ok && filterArgs.Req.Header().Key.Equal(roachpb.Key("a")) {
 					numIncrements++
@@ -378,7 +378,7 @@ func TestFailedReplicaChange(t *testing.T) {
 	mtc := &multiTestContext{}
 	mtc.storeContext = &ctx
 	mtc.storeContext.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if runFilter.Load().(bool) {
 				if et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest); ok && et.Commit {
 					return roachpb.NewErrorWithTxn(util.Errorf("boom"), filterArgs.Hdr.Txn)

--- a/storage/client_replica_gc_test.go
+++ b/storage/client_replica_gc_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -47,7 +47,7 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 	ctx := storage.TestStoreContext()
 	mtc.storeContext = &ctx
 	mtc.storeContext.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest)
 			if !ok || filterArgs.Sid != 2 {
 				return nil

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -197,7 +197,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 	defer stopper.Stop()
 	ctx := storage.TestStoreContext()
 	ctx.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if _, ok := filterArgs.Req.(*roachpb.GetRequest); ok &&
 				filterArgs.Req.Header().Key.Equal(roachpb.Key(key)) &&
 				filterArgs.Hdr.Txn == nil {

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -36,8 +36,8 @@ import (
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -932,7 +932,7 @@ func TestStoreSplitReadRace(t *testing.T) {
 	var getStarted sync.WaitGroup
 	sCtx := storage.TestStoreContext()
 	sCtx.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest); ok {
 				st := et.InternalCommitTrigger.GetSplitTrigger()
 				if st == nil || !st.UpdatedDesc.EndKey.Equal(splitKey) {

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -407,7 +407,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	tc := testContext{}
 	tsc := TestStoreContext()
 	tsc.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if resArgs, ok := filterArgs.Req.(*roachpb.ResolveIntentRequest); ok {
 				id := string(resArgs.IntentTxn.Key)
 				resolved[id] = append(resolved[id], roachpb.Span{

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/storage/storagebase"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/protoutil"
@@ -67,7 +66,7 @@ func (r *Replica) executeCmd(ctx context.Context, raftCmdID storagebase.CmdIDKey
 
 	// If a unittest filter was installed, check for an injected error; otherwise, continue.
 	if filter := r.store.ctx.TestingKnobs.TestingCommandFilter; filter != nil {
-		filterArgs := storageutils.FilterArgs{Ctx: ctx, CmdID: raftCmdID, Index: index,
+		filterArgs := storagebase.FilterArgs{Ctx: ctx, CmdID: raftCmdID, Index: index,
 			Sid: r.store.StoreID(), Req: args, Hdr: h}
 		if pErr := filter(filterArgs); pErr != nil {
 			log.Infof("test injecting error: %s", pErr)

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -41,8 +41,8 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/caller"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -703,6 +703,17 @@ func TestReplicaNotLeaderError(t *testing.T) {
 // correctly after a lease request.
 func TestReplicaLeaseCounters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	var numProp int64
+	sCtx := TestStoreContext()
+	sCtx.TestingKnobs.TestingCommandFilter = func(
+		args storagebase.FilterArgs,
+	) *roachpb.Error {
+		if args.Req.Method() == roachpb.LeaderLease {
+			atomic.AddInt64(&numProp, 1)
+		}
+		return nil
+	}
 
 	tc := testContext{}
 	tc.Start(t)
@@ -1554,7 +1565,7 @@ func TestReplicaCommandQueue(t *testing.T) {
 	tc := testContext{}
 	tsc := TestStoreContext()
 	tsc.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Hdr.UserPriority == 42 {
 				blockingStart <- struct{}{}
 				<-blockingDone
@@ -1671,7 +1682,7 @@ func TestReplicaCommandQueueInconsistent(t *testing.T) {
 	tc := testContext{}
 	tsc := TestStoreContext()
 	tsc.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if put, ok := filterArgs.Req.(*roachpb.PutRequest); ok {
 				putBytes, err := put.Value.GetBytes()
 				if err != nil {
@@ -2792,7 +2803,7 @@ func TestEndTransactionLocalGC(t *testing.T) {
 	tc := testContext{}
 	tsc := TestStoreContext()
 	tsc.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			// Make sure the direct GC path doesn't interfere with this test.
 			if filterArgs.Req.Method() == roachpb.GC {
 				return roachpb.NewErrorWithTxn(util.Errorf("boom"), filterArgs.Hdr.Txn)
@@ -2896,7 +2907,7 @@ func TestEndTransactionResolveOnlyLocalIntents(t *testing.T) {
 	key := roachpb.Key("a")
 	splitKey := roachpb.RKey(key).Next()
 	tsc.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Req.Method() == roachpb.ResolveIntentRange &&
 				filterArgs.Req.Header().Key.Equal(splitKey.AsRawKey()) {
 				return roachpb.NewErrorWithTxn(util.Errorf("boom"), filterArgs.Hdr.Txn)
@@ -2983,7 +2994,7 @@ func TestEndTransactionDirectGCFailure(t *testing.T) {
 	var count int64
 	tsc := TestStoreContext()
 	tsc.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Req.Method() == roachpb.ResolveIntentRange &&
 				filterArgs.Req.Header().Key.Equal(splitKey.AsRawKey()) {
 				atomic.AddInt64(&count, 1)
@@ -3058,7 +3069,7 @@ func TestReplicaResolveIntentNoWait(t *testing.T) {
 	key := roachpb.Key("zresolveme")
 	tsc := TestStoreContext()
 	tsc.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Req.Method() == roachpb.ResolveIntent &&
 				filterArgs.Req.Header().Key.Equal(key) {
 				atomic.StoreInt32(&seen, 1)
@@ -4112,7 +4123,7 @@ func TestReplicaCorruption(t *testing.T) {
 
 	tsc := TestStoreContext()
 	tsc.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if filterArgs.Req.Header().Key.Equal(roachpb.Key("boom")) {
 				return roachpb.NewError(newReplicaCorruptionError())
 			}
@@ -4961,7 +4972,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 			tsc := TestStoreContext()
 			if !cancelEarly {
 				tsc.TestingKnobs.TestingCommandFilter =
-					func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+					func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 						if !filterArgs.Req.Header().Key.Equal(key) {
 							return nil
 						}

--- a/storage/storagebase/base.go
+++ b/storage/storagebase/base.go
@@ -16,5 +16,33 @@
 
 package storagebase
 
+import (
+	"github.com/cockroachdb/cockroach/roachpb"
+	"golang.org/x/net/context"
+)
+
 // CmdIDKey is a Raft command id.
 type CmdIDKey string
+
+// FilterArgs groups the arguments to a ReplicaCommandFilter.
+type FilterArgs struct {
+	Ctx   context.Context
+	CmdID CmdIDKey
+	Index int
+	Sid   roachpb.StoreID
+	Req   roachpb.Request
+	Hdr   roachpb.Header
+}
+
+// InRaftCmd returns true if the filter is running in the context of a Raft
+// command (it could be running outside of one, for example for a read).
+func (f *FilterArgs) InRaftCmd() bool {
+	return f.CmdID != ""
+}
+
+// ReplicaCommandFilter may be used in tests through the StorageTestingMocker to
+// intercept the handling of commands and artificially generate errors. Return
+// nil to continue with regular processing or non-nil to terminate processing
+// with the returned error. Note that in a multi-replica test this filter will
+// be run once for each replica and must produce consistent results each time.
+type ReplicaCommandFilter func(args FilterArgs) *roachpb.Error

--- a/storage/store.go
+++ b/storage/store.go
@@ -37,7 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/cache"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -407,7 +407,7 @@ type StoreTestingKnobs struct {
 	// A callback to be called when executing every replica command.
 	// If your filter is not idempotent, consider wrapping it in a
 	// ReplayProtectionFilterWrapper.
-	TestingCommandFilter storageutils.ReplicaCommandFilter
+	TestingCommandFilter storagebase.ReplicaCommandFilter
 	// A callback to be called instead of panicking due to a
 	// checksum mismatch in VerifyChecksum()
 	BadChecksumPanic func([]ReplicaSnapshotDiff)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -35,8 +35,8 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils"
-	"github.com/cockroachdb/cockroach/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -616,7 +616,7 @@ func TestStoreObservedTimestamp(t *testing.T) {
 		func() {
 			ctx := TestStoreContext()
 			ctx.TestingKnobs.TestingCommandFilter =
-				func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+				func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 					if bytes.Equal(filterArgs.Req.Header().Key, badKey) {
 						return roachpb.NewError(util.Errorf("boom"))
 					}
@@ -678,7 +678,7 @@ func TestStoreAnnotateNow(t *testing.T) {
 			func() {
 				ctx := TestStoreContext()
 				ctx.TestingKnobs.TestingCommandFilter =
-					func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+					func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 						if bytes.Equal(filterArgs.Req.Header().Key, badKey) {
 							return roachpb.NewErrorWithTxn(util.Errorf("boom"), filterArgs.Hdr.Txn)
 						}
@@ -1084,7 +1084,7 @@ func TestStoreResolveWriteIntent(t *testing.T) {
 	var stopper *stop.Stopper
 	ctx := TestStoreContext()
 	ctx.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			pr, ok := filterArgs.Req.(*roachpb.PushTxnRequest)
 			if !ok || pr.PusherTxn.Name != "test" {
 				return nil
@@ -1556,7 +1556,7 @@ func TestStoreScanIntents(t *testing.T) {
 	countPtr := &count
 
 	ctx.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if _, ok := filterArgs.Req.(*roachpb.ScanRequest); ok {
 				atomic.AddInt32(countPtr, 1)
 			}
@@ -1673,7 +1673,7 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	intercept.Store(true)
 	ctx := TestStoreContext()
 	ctx.TestingKnobs.TestingCommandFilter =
-		func(filterArgs storageutils.FilterArgs) *roachpb.Error {
+		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			_, ok := filterArgs.Req.(*roachpb.ResolveIntentRequest)
 			if ok && intercept.Load().(bool) {
 				return roachpb.NewErrorWithTxn(util.Errorf("boom"), filterArgs.Hdr.Txn)

--- a/testutils/base.go
+++ b/testutils/base.go
@@ -19,15 +19,10 @@ package testutils
 import (
 	"fmt"
 	"path/filepath"
-	"testing"
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/security"
 )
-
-// Force dependency on "testing" to ensure only test code depends
-// on this package.
-var _ testing.T
 
 // NewNodeTestBaseContext creates a base context for testing. This uses
 // embedded certs and the default node user. The default node user has both

--- a/testutils/base.go
+++ b/testutils/base.go
@@ -19,10 +19,15 @@ package testutils
 import (
 	"fmt"
 	"path/filepath"
+	"testing"
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/security"
 )
+
+// Force dependency on "testing" to ensure only test code depends
+// on this package.
+var _ testing.T
 
 // NewNodeTestBaseContext creates a base context for testing. This uses
 // embedded certs and the default node user. The default node user has both

--- a/testutils/buildutil/build.go
+++ b/testutils/buildutil/build.go
@@ -16,14 +16,7 @@
 
 package buildutil
 
-import (
-	"go/build"
-	"testing"
-)
-
-// Force dependency on "testing" to ensure only test code depends
-// on this package.
-var _ testing.T
+import "go/build"
 
 // TransitiveImports returns a set containing all of importpath's
 // transitive dependencies.

--- a/testutils/buildutil/build.go
+++ b/testutils/buildutil/build.go
@@ -16,7 +16,14 @@
 
 package buildutil
 
-import "go/build"
+import (
+	"go/build"
+	"testing"
+)
+
+// Force dependency on "testing" to ensure only test code depends
+// on this package.
+var _ testing.T
 
 // TransitiveImports returns a set containing all of importpath's
 // transitive dependencies.

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/kv"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/gogo/protobuf/proto"
@@ -71,7 +72,7 @@ func newTestModel(t *testing.T) testModel {
 // Start constructs and starts the local test server and creates a
 // time series DB.
 func (tm *testModel) Start() {
-	tm.LocalTestCluster.Start(tm.t)
+	tm.LocalTestCluster.Start(tm.t, testutils.NewNodeTestBaseContext())
 	tm.DB = NewDB(tm.LocalTestCluster.DB)
 }
 


### PR DESCRIPTION
`LocalTestCluster` has a dependency on `testutils` which is easily removed by
having the caller pass a context. This is testing code but is part of the kv
package because it is used from a test in another package. The dependency
blocked the addition of new functionality that involves `testing`.

Adding a dummy dependency on `testing` so this doesn't happen in the future.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6459)

<!-- Reviewable:end -->
