### PR TITLE
storage: Fix more sharing of *roachpb.Error

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1460,7 +1460,12 @@ func TestLeaderLeaseConcurrent(t *testing.T) {
 				tc.stopper.RunAsyncTask(func() {
 					leaseCh := tc.rng.requestLeaderLease(ts)
 					wg.Done()
-					pErrCh <- (<-leaseCh)
+					pErr := <-leaseCh
+					// Mutate the errors as we receive them to expose races.
+					if pErr != nil {
+						pErr.OriginNode = 0
+					}
+					pErrCh <- pErr
 				})
 			}
 


### PR DESCRIPTION
Sending the original error to the channel and then cloning it doesn't
fix the race; we have to send the original error last.

Fixes #6442

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6464)

<!-- Reviewable:end -->
