### PR TITLE
kv: remove dependency on storage

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -1,0 +1,28 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package base
+
+import "time"
+
+const (
+	// DefaultHeartbeatInterval is how often heartbeats are sent from the
+	// transaction coordinator to a live transaction. These keep it from
+	// being preempted by other transactions writing the same keys. If a
+	// transaction fails to be heartbeat within 2x the heartbeat interval,
+	// it may be aborted by conflicting txns.
+	DefaultHeartbeatInterval = 5 * time.Second
+)

--- a/kv/local_test_cluster_util.go
+++ b/kv/local_test_cluster_util.go
@@ -1,0 +1,83 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package kv
+
+import (
+	"time"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/rpc"
+	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/metric"
+	"github.com/cockroachdb/cockroach/util/stop"
+)
+
+// InitSenderForLocalTestCluster initializes a TxnCoordSender that can be used
+// with LocalTestCluster.
+func InitSenderForLocalTestCluster(
+	nodeDesc *roachpb.NodeDescriptor,
+	tracer opentracing.Tracer,
+	clock *hlc.Clock,
+	latency time.Duration,
+	stores client.Sender,
+	stopper *stop.Stopper,
+	gossip *gossip.Gossip,
+) client.Sender {
+	var rpcSend rpcSendFn = func(_ SendOptions, _ ReplicaSlice,
+		args roachpb.BatchRequest, _ *rpc.Context) (*roachpb.BatchResponse, error) {
+		if latency > 0 {
+			time.Sleep(latency)
+		}
+		sp := tracer.StartSpan("node")
+		defer sp.Finish()
+		ctx := opentracing.ContextWithSpan(context.Background(), sp)
+		log.Trace(ctx, args.String())
+		br, pErr := stores.Send(ctx, args)
+		if br == nil {
+			br = &roachpb.BatchResponse{}
+		}
+		if br.Error != nil {
+			panic(roachpb.ErrorUnexpectedlySet(stores, br))
+		}
+		br.Error = pErr
+		if pErr != nil {
+			log.Trace(ctx, "error: "+pErr.String())
+		}
+		return br, nil
+	}
+	retryOpts := GetDefaultDistSenderRetryOptions()
+	retryOpts.Closer = stopper.ShouldDrain()
+	distSender := NewDistSender(&DistSenderContext{
+		Clock: clock,
+		RangeDescriptorCacheSize: defaultRangeDescriptorCacheSize,
+		RangeLookupMaxRanges:     defaultRangeLookupMaxRanges,
+		LeaderCacheSize:          defaultLeaderCacheSize,
+		RPCRetryOptions:          &retryOpts,
+		nodeDescriptor:           nodeDesc,
+		RPCSend:                  rpcSend,                    // defined above
+		RangeDescriptorDB:        stores.(RangeDescriptorDB), // for descriptor lookup
+	}, gossip)
+
+	return NewTxnCoordSender(distSender, clock, false /* !linearizable */, tracer,
+		stopper, NewTxnMetrics(metric.NewRegistry()))
+}

--- a/kv/main_test.go
+++ b/kv/main_test.go
@@ -17,12 +17,27 @@
 package kv_test
 
 import (
+	"testing"
+
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/security/securitytest"
+	"github.com/cockroachdb/cockroach/testutils/buildutil"
+	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
 //go:generate ../util/leaktest/add-leaktest.sh *_test.go
 
 func init() {
 	security.SetReadFileFn(securitytest.Asset)
+}
+
+func TestForbiddenDeps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Verify kv does not depend on storage (or any of its subpackages).
+	buildutil.VerifyNoImports(t,
+		"github.com/cockroachdb/cockroach/kv", true,
+		[]string{},
+		[]string{
+			"github.com/cockroachdb/cockroach/storage",
+		})
 }

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -103,7 +103,7 @@ func startTestWriter(db *client.DB, i int64, valBytes int32, wg *sync.WaitGroup,
 // which are resolved synchronously with EndTransaction and via RPC.
 func TestRangeSplitMeta(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, _ := createTestDB(t)
 	defer s.Stop()
 
 	splitKeys := []roachpb.RKey{roachpb.RKey("G"), mustMeta(roachpb.RKey("F")),
@@ -131,7 +131,7 @@ func TestRangeSplitMeta(t *testing.T) {
 // composed of a random mix of puts.
 func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, _ := createTestDB(t)
 	defer s.Stop()
 
 	// This channel shuts the whole apparatus down.
@@ -181,7 +181,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	cfg.RangeMaxBytes = 1 << 18
 	defer config.TestingSetDefaultZoneConfig(cfg)()
 
-	s := createTestDB(t)
+	s, _ := createTestDB(t)
 	// This is purely to silence log spam.
 	config.TestingSetupZoneConfigHook(s.Stopper)
 	defer s.Stop()
@@ -227,7 +227,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 // on the same splitKey should not cause infinite retry loop.
 func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, _ := createTestDB(t)
 	defer s.Stop()
 
 	splitKey := roachpb.Key("aa")

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -28,9 +28,9 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/interval"
@@ -216,7 +216,7 @@ func NewTxnCoordSender(
 	tc := &TxnCoordSender{
 		wrapped:           wrapped,
 		clock:             clock,
-		heartbeatInterval: storage.DefaultHeartbeatInterval,
+		heartbeatInterval: base.DefaultHeartbeatInterval,
 		clientTimeout:     defaultClientTimeout,
 		txns:              map[uuid.UUID]*txnMetadata{},
 		linearizable:      linearizable,

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/testutils/localtestcluster"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -68,10 +69,10 @@ func teardownHeartbeats(tc *TxnCoordSender) {
 
 // createTestDB creates a local test server and starts it. The caller
 // is responsible for stopping the test server.
-func createTestDB(t testing.TB) *LocalTestCluster {
-	s := &LocalTestCluster{}
-	s.Start(t, testutils.NewNodeTestBaseContext())
-	return s
+func createTestDB(t testing.TB) (*localtestcluster.LocalTestCluster, *TxnCoordSender) {
+	s := &localtestcluster.LocalTestCluster{}
+	s.Start(t, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
+	return s, s.Sender.(*TxnCoordSender)
 }
 
 // makeTS creates a new timestamp.
@@ -87,9 +88,9 @@ func makeTS(walltime int64, logical int32) roachpb.Timestamp {
 // transaction ID updates the last update timestamp.
 func TestTxnCoordSenderAddRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
-	defer teardownHeartbeats(s.Sender)
+	defer teardownHeartbeats(sender)
 
 	txn := client.NewTxn(context.Background(), *s.DB)
 
@@ -98,7 +99,7 @@ func TestTxnCoordSenderAddRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	txnID := *txn.Proto.ID
-	txnMeta, ok := s.Sender.txns[txnID]
+	txnMeta, ok := sender.txns[txnID]
 	if !ok {
 		t.Fatal("expected a transaction to be created on coordinator")
 	}
@@ -109,16 +110,16 @@ func TestTxnCoordSenderAddRequest(t *testing.T) {
 
 	// Advance time and send another put request. Lock the coordinator
 	// to prevent a data race.
-	s.Sender.Lock()
+	sender.Lock()
 	s.Manual.Set(1)
-	s.Sender.Unlock()
+	sender.Unlock()
 	if err := txn.Put(roachpb.Key("a"), []byte("value")); err != nil {
 		t.Fatal(err)
 	}
-	if len(s.Sender.txns) != 1 {
-		t.Errorf("expected length of transactions map to be 1; got %d", len(s.Sender.txns))
+	if len(sender.txns) != 1 {
+		t.Errorf("expected length of transactions map to be 1; got %d", len(sender.txns))
 	}
-	txnMeta = s.Sender.txns[txnID]
+	txnMeta = sender.txns[txnID]
 	if lu := atomic.LoadInt64(&txnMeta.lastUpdateNanos); ts >= lu || lu != s.Manual.UnixNano() {
 		t.Errorf("expected last update time to advance; got %d", lu)
 	}
@@ -128,9 +129,9 @@ func TestTxnCoordSenderAddRequest(t *testing.T) {
 // not-nil Txn with empty ID gets a new transaction initialized.
 func TestTxnCoordSenderBeginTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
-	defer teardownHeartbeats(s.Sender)
+	defer teardownHeartbeats(sender)
 
 	txn := client.NewTxn(context.Background(), *s.DB)
 
@@ -160,9 +161,9 @@ func TestTxnCoordSenderBeginTransaction(t *testing.T) {
 // before the Txn is created is honored.
 func TestTxnInitialTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
-	defer teardownHeartbeats(s.Sender)
+	defer teardownHeartbeats(sender)
 
 	txn := client.NewTxn(context.Background(), *s.DB)
 
@@ -190,9 +191,9 @@ func TestTxnInitialTimestamp(t *testing.T) {
 // a new transaction, a non-zero priority is treated as a minimum value.
 func TestTxnCoordSenderBeginTransactionMinPriority(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
-	defer teardownHeartbeats(s.Sender)
+	defer teardownHeartbeats(sender)
 
 	txn := client.NewTxn(context.Background(), *s.DB)
 
@@ -225,9 +226,9 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 		{roachpb.Key("b"), roachpb.Key("c")},
 	}
 
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
-	defer teardownHeartbeats(s.Sender)
+	defer teardownHeartbeats(sender)
 
 	txn := client.NewTxn(context.Background(), *s.DB)
 	for _, rng := range ranges {
@@ -246,7 +247,7 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 
 	// Verify that the transaction metadata contains only two entries
 	// in its "keys" range group. "a" and range "aa"-"c".
-	txnMeta, ok := s.Sender.txns[txnID]
+	txnMeta, ok := sender.txns[txnID]
 	if !ok {
 		t.Fatalf("expected a transaction to be created on coordinator")
 	}
@@ -259,9 +260,9 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 // multiple outstanding transactions.
 func TestTxnCoordSenderMultipleTxns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
-	defer teardownHeartbeats(s.Sender)
+	defer teardownHeartbeats(sender)
 
 	txn1 := client.NewTxn(context.Background(), *s.DB)
 	txn2 := client.NewTxn(context.Background(), *s.DB)
@@ -273,8 +274,8 @@ func TestTxnCoordSenderMultipleTxns(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(s.Sender.txns) != 2 {
-		t.Errorf("expected length of transactions map to be 2; got %d", len(s.Sender.txns))
+	if len(sender.txns) != 2 {
+		t.Errorf("expected length of transactions map to be 2; got %d", len(sender.txns))
 	}
 }
 
@@ -282,12 +283,12 @@ func TestTxnCoordSenderMultipleTxns(t *testing.T) {
 // transaction record.
 func TestTxnCoordSenderHeartbeat(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
-	defer teardownHeartbeats(s.Sender)
+	defer teardownHeartbeats(sender)
 
 	// Set heartbeat interval to 1ms for testing.
-	s.Sender.heartbeatInterval = 1 * time.Millisecond
+	sender.heartbeatInterval = 1 * time.Millisecond
 
 	initialTxn := client.NewTxn(context.Background(), *s.DB)
 	if err := initialTxn.Put(roachpb.Key("a"), []byte("value")); err != nil {
@@ -298,15 +299,15 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 	var heartbeatTS roachpb.Timestamp
 	for i := 0; i < 3; i++ {
 		util.SucceedsSoon(t, func() error {
-			ok, txn, pErr := getTxn(s.Sender, &initialTxn.Proto)
+			ok, txn, pErr := getTxn(sender, &initialTxn.Proto)
 			if !ok || pErr != nil {
 				t.Fatalf("got txn: %t: %s", ok, pErr)
 			}
 			// Advance clock by 1ns.
 			// Locking the TxnCoordSender to prevent a data race.
-			s.Sender.Lock()
+			sender.Lock()
 			s.Manual.Increment(1)
-			s.Sender.Unlock()
+			sender.Unlock()
 			if txn.LastHeartbeat != nil && heartbeatTS.Less(*txn.LastHeartbeat) {
 				heartbeatTS = *txn.LastHeartbeat
 				return nil
@@ -323,15 +324,15 @@ func TestTxnCoordSenderHeartbeat(t *testing.T) {
 			Span:   roachpb.Span{Key: initialTxn.Proto.Key},
 		})
 		ba.Txn = &initialTxn.Proto
-		if _, pErr := s.distSender.Send(context.Background(), ba); pErr != nil {
+		if _, pErr := sender.wrapped.Send(context.Background(), ba); pErr != nil {
 			t.Fatal(pErr)
 		}
 	}
 
 	util.SucceedsSoon(t, func() error {
-		s.Sender.Lock()
-		defer s.Sender.Unlock()
-		if txnMeta, ok := s.Sender.txns[*initialTxn.Proto.ID]; !ok {
+		sender.Lock()
+		defer sender.Unlock()
+		if txnMeta, ok := sender.txns[*initialTxn.Proto.ID]; !ok {
 			t.Fatal("transaction unregistered prematurely")
 		} else if txnMeta.txn.Status != roachpb.ABORTED {
 			return fmt.Errorf("transaction is not aborted")
@@ -387,7 +388,7 @@ func verifyCleanup(key roachpb.Key, coord *TxnCoordSender, eng engine.Engine, t 
 // from the txns map.
 func TestTxnCoordSenderEndTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
 
 	// 4 cases: no deadline, past deadline, equal deadline, future deadline.
@@ -439,7 +440,7 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 				}
 			}
 		}
-		verifyCleanup(key, s.Sender, s.Eng, t)
+		verifyCleanup(key, sender, s.Eng, t)
 	}
 }
 
@@ -447,7 +448,7 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 // the transaction is, even on error.
 func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
 
 	// Create a transaction with intent at "a".
@@ -461,12 +462,12 @@ func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 	if !ok {
 		t.Fatal(err)
 	}
-	s.Sender.Lock()
+	sender.Lock()
 	txnID := *txn.Proto.ID
-	intentSpans := collectIntentSpans(s.Sender.txns[txnID].keys)
+	intentSpans := collectIntentSpans(sender.txns[txnID].keys)
 	expSpans := []roachpb.Span{{Key: key, EndKey: []byte("")}}
 	equal := !reflect.DeepEqual(intentSpans, expSpans)
-	s.Sender.Unlock()
+	sender.Unlock()
 	if pErr := txn.Rollback(); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -479,7 +480,7 @@ func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 // TransactionAbortedError, the coordinator cleans up the transaction.
 func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
 
 	// Create a transaction with intent at "a".
@@ -509,18 +510,18 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 	if pErr := txn2.CommitOrCleanup(); pErr != nil {
 		t.Fatal(pErr)
 	}
-	verifyCleanup(key, s.Sender, s.Eng, t)
+	verifyCleanup(key, sender, s.Eng, t)
 }
 
 // TestTxnCoordSenderGCTimeout verifies that the coordinator cleans up extant
 // transactions and intents after the lastUpdateNanos exceeds the timeout.
 func TestTxnCoordSenderGCTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
 
 	// Set heartbeat interval to 1ms for testing.
-	s.Sender.heartbeatInterval = 1 * time.Millisecond
+	sender.heartbeatInterval = 1 * time.Millisecond
 
 	txn := client.NewTxn(context.Background(), *s.DB)
 	key := roachpb.Key("a")
@@ -530,35 +531,35 @@ func TestTxnCoordSenderGCTimeout(t *testing.T) {
 
 	// Now, advance clock past the default client timeout.
 	// Locking the TxnCoordSender to prevent a data race.
-	s.Sender.Lock()
+	sender.Lock()
 	s.Manual.Set(defaultClientTimeout.Nanoseconds() + 1)
-	s.Sender.Unlock()
+	sender.Unlock()
 
 	txnID := *txn.Proto.ID
 
 	util.SucceedsSoon(t, func() error {
 		// Locking the TxnCoordSender to prevent a data race.
-		s.Sender.Lock()
-		_, ok := s.Sender.txns[txnID]
-		s.Sender.Unlock()
+		sender.Lock()
+		_, ok := sender.txns[txnID]
+		sender.Unlock()
 		if ok {
 			return util.Errorf("expected garbage collection")
 		}
 		return nil
 	})
 
-	verifyCleanup(key, s.Sender, s.Eng, t)
+	verifyCleanup(key, sender, s.Eng, t)
 }
 
 // TestTxnCoordSenderGCWithCancel verifies that the coordinator cleans up extant
 // transactions and intents after transaction context is cancelled.
 func TestTxnCoordSenderGCWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
 
 	// Set heartbeat interval to 1ms for testing.
-	s.Sender.heartbeatInterval = 1 * time.Millisecond
+	sender.heartbeatInterval = 1 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
 	txn := client.NewTxn(ctx, *s.DB)
@@ -569,9 +570,9 @@ func TestTxnCoordSenderGCWithCancel(t *testing.T) {
 
 	// Now, advance clock past the default client timeout.
 	// Locking the TxnCoordSender to prevent a data race.
-	s.Sender.Lock()
+	sender.Lock()
 	s.Manual.Set(defaultClientTimeout.Nanoseconds() + 1)
-	s.Sender.Unlock()
+	sender.Unlock()
 
 	txnID := *txn.Proto.ID
 
@@ -581,9 +582,9 @@ func TestTxnCoordSenderGCWithCancel(t *testing.T) {
 	// TODO(dan): Figure out how to run the heartbeat manually instead of this.
 	if err := util.RetryForDuration(1*time.Second, func() error {
 		// Locking the TxnCoordSender to prevent a data race.
-		s.Sender.Lock()
-		_, ok := s.Sender.txns[txnID]
-		s.Sender.Unlock()
+		sender.Lock()
+		_, ok := sender.txns[txnID]
+		sender.Unlock()
 		if !ok {
 			return nil
 		}
@@ -604,16 +605,16 @@ func TestTxnCoordSenderGCWithCancel(t *testing.T) {
 	cancel()
 	util.SucceedsSoon(t, func() error {
 		// Locking the TxnCoordSender to prevent a data race.
-		s.Sender.Lock()
-		_, ok := s.Sender.txns[txnID]
-		s.Sender.Unlock()
+		sender.Lock()
+		_, ok := sender.txns[txnID]
+		sender.Unlock()
 		if ok {
 			return util.Errorf("expected garbage collection")
 		}
 		return nil
 	})
 
-	verifyCleanup(key, s.Sender, s.Eng, t)
+	verifyCleanup(key, sender, s.Eng, t)
 }
 
 // TestTxnCoordSenderTxnUpdatedOnError verifies that errors adjust the
@@ -745,9 +746,9 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 // TestTxnCoordIdempotentCleanup verifies that cleanupTxnLocked is idempotent.
 func TestTxnCoordIdempotentCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
-	defer teardownHeartbeats(s.Sender)
+	defer teardownHeartbeats(sender)
 
 	txn := client.NewTxn(context.Background(), *s.DB)
 	ba := txn.NewBatch()
@@ -756,11 +757,11 @@ func TestTxnCoordIdempotentCleanup(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	s.Sender.Lock()
+	sender.Lock()
 	// Clean up twice successively.
-	s.Sender.cleanupTxnLocked(context.Background(), txn.Proto)
-	s.Sender.cleanupTxnLocked(context.Background(), txn.Proto)
-	s.Sender.Unlock()
+	sender.cleanupTxnLocked(context.Background(), txn.Proto)
+	sender.cleanupTxnLocked(context.Background(), txn.Proto)
+	sender.Unlock()
 
 	// For good measure, try to commit (which cleans up once more if it
 	// succeeds, which it may not if the previous cleanup has already
@@ -777,7 +778,7 @@ func TestTxnCoordIdempotentCleanup(t *testing.T) {
 // enforce that only one coordinator can be used for transactional writes.
 func TestTxnMultipleCoord(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
 
 	testCases := []struct {
@@ -795,7 +796,7 @@ func TestTxnMultipleCoord(t *testing.T) {
 		txn := roachpb.NewTransaction("test", roachpb.Key("a"), 1, roachpb.SERIALIZABLE,
 			s.Clock.Now(), s.Clock.MaxOffset().Nanoseconds())
 		txn.Writing = tc.writing
-		reply, pErr := client.SendWrappedWith(s.Sender, nil, roachpb.Header{
+		reply, pErr := client.SendWrappedWith(sender, nil, roachpb.Header{
 			Txn: txn,
 		}, tc.args)
 		if pErr == nil != tc.ok {
@@ -817,7 +818,7 @@ func TestTxnMultipleCoord(t *testing.T) {
 			continue
 		}
 		// Abort for clean shutdown.
-		if _, pErr := client.SendWrappedWith(s.Sender, nil, roachpb.Header{
+		if _, pErr := client.SendWrappedWith(sender, nil, roachpb.Header{
 			Txn: txn,
 		}, &roachpb.EndTransactionRequest{
 			Commit: false,
@@ -920,9 +921,9 @@ func TestTxnCoordSenderErrorWithIntent(t *testing.T) {
 // txnMetadata after the txn has committed successfully.
 func TestTxnCoordSenderReleaseTxnMeta(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
+	s, sender := createTestDB(t)
 	defer s.Stop()
-	defer teardownHeartbeats(s.Sender)
+	defer teardownHeartbeats(sender)
 
 	txn := client.NewTxn(context.Background(), *s.DB)
 	ba := txn.NewBatch()
@@ -934,7 +935,7 @@ func TestTxnCoordSenderReleaseTxnMeta(t *testing.T) {
 
 	txnID := *txn.Proto.ID
 
-	if _, ok := s.Sender.txns[txnID]; ok {
+	if _, ok := sender.txns[txnID]; ok {
 		t.Fatal("expected TxnCoordSender has released the txn")
 	}
 }
@@ -1056,10 +1057,10 @@ func checkTxnMetrics(t *testing.T, sender *TxnCoordSender, name string,
 // LocalTestCluster. Also returns a cleanup function to be executed at the end of the
 // test.
 func setupMetricsTest(t *testing.T) (*hlc.ManualClock, *TxnCoordSender, func()) {
-	s := createTestDB(t)
+	s, testSender := createTestDB(t)
 	reg := metric.NewRegistry()
 	txnMetrics := NewTxnMetrics(reg)
-	sender := NewTxnCoordSender(s.distSender, s.Clock, false, tracing.NewTracer(), s.Stopper, txnMetrics)
+	sender := NewTxnCoordSender(testSender.wrapped, s.Clock, false, tracing.NewTracer(), s.Stopper, txnMetrics)
 
 	return s.Manual, sender, func() {
 		teardownHeartbeats(sender)

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -678,9 +678,9 @@ func (hv *historyVerifier) runCmd(txn *client.Txn, txnIdx, retry, cmdIdx int, cm
 func checkConcurrency(name string, isolations []roachpb.IsolationType, txns []string,
 	verify *verifier, expSuccess bool, t *testing.T) {
 	verifier := newHistoryVerifier(name, txns, verify, expSuccess, t)
-	s := createTestDB(t)
+	s, _ := createTestDB(t)
 	defer s.Stop()
-	defer setCorrectnessRetryOptions(s.stores)()
+	defer setCorrectnessRetryOptions(s.Stores)()
 	verifier.run(isolations, s.DB, t)
 }
 

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -28,6 +28,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
@@ -416,7 +417,7 @@ func TestFailedReplicaChange(t *testing.T) {
 
 	// The first failed replica change has laid down intents. Make sure those
 	// are pushable by making the transaction abandoned.
-	mtc.manualClock.Increment(10 * storage.DefaultHeartbeatInterval.Nanoseconds())
+	mtc.manualClock.Increment(10 * base.DefaultHeartbeatInterval.Nanoseconds())
 
 	err = rng.ChangeReplicas(roachpb.ADD_REPLICA,
 		roachpb.ReplicaDescriptor{

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
@@ -64,7 +65,7 @@ const (
 	// interval used by transaction coordinators throughout the cluster to make
 	// sure that no coordinator can run with a transaction which has been
 	// aborted and whose abort cache entry is being deleted.
-	abortCacheAgeThreshold = 5 * DefaultHeartbeatInterval
+	abortCacheAgeThreshold = 5 * base.DefaultHeartbeatInterval
 
 	// considerThreshold is used in shouldQueue. Only an a normalized GC bytes
 	// or intent byte age larger than the threshold queues the replica for GC.

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -52,13 +52,6 @@ import (
 )
 
 const (
-	// DefaultHeartbeatInterval is how often heartbeats are sent from the
-	// transaction coordinator to a live transaction. These keep it from
-	// being preempted by other transactions writing the same keys. If a
-	// transaction fails to be heartbeat within 2x the heartbeat interval,
-	// it may be aborted by conflicting txns.
-	DefaultHeartbeatInterval = 5 * time.Second
-
 	// sentinelGossipTTL is time-to-live for the gossip sentinel. The
 	// sentinel informs a node whether or not it's connected to the
 	// primary gossip network and not just a partition. As such it must

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -30,6 +30,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -1140,7 +1141,7 @@ func (r *Replica) PushTxn(
 	var reason string
 
 	switch {
-	case reply.PusheeTxn.LastActive().Less(args.Now.Add(-2*DefaultHeartbeatInterval.Nanoseconds(), 0)):
+	case reply.PusheeTxn.LastActive().Less(args.Now.Add(-2*base.DefaultHeartbeatInterval.Nanoseconds(), 0)):
 		reason = "pushee is expired"
 		// When cleaning up, actually clean up (as opposed to simply pushing
 		// the garbage in the path of future writers).

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/coreos/etcd/raft"
 	"github.com/gogo/protobuf/proto"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
@@ -3524,7 +3525,7 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 	defer tc.Stop()
 
 	ts := roachpb.Timestamp{WallTime: 1}
-	ns := DefaultHeartbeatInterval.Nanoseconds()
+	ns := base.DefaultHeartbeatInterval.Nanoseconds()
 	testCases := []struct {
 		heartbeat   roachpb.Timestamp // zero value indicates no heartbeat
 		currentTime int64             // nanoseconds

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/testutils/localtestcluster"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/gogo/protobuf/proto"
@@ -54,7 +55,7 @@ type testModel struct {
 	t           testing.TB
 	modelData   map[string]roachpb.Value
 	seenSources map[string]struct{}
-	*kv.LocalTestCluster
+	*localtestcluster.LocalTestCluster
 	DB *DB
 }
 
@@ -65,14 +66,15 @@ func newTestModel(t *testing.T) testModel {
 		t:                t,
 		modelData:        make(map[string]roachpb.Value),
 		seenSources:      make(map[string]struct{}),
-		LocalTestCluster: &kv.LocalTestCluster{},
+		LocalTestCluster: &localtestcluster.LocalTestCluster{},
 	}
 }
 
 // Start constructs and starts the local test server and creates a
 // time series DB.
 func (tm *testModel) Start() {
-	tm.LocalTestCluster.Start(tm.t, testutils.NewNodeTestBaseContext())
+	tm.LocalTestCluster.Start(tm.t, testutils.NewNodeTestBaseContext(),
+		kv.InitSenderForLocalTestCluster)
 	tm.DB = NewDB(tm.LocalTestCluster.DB)
 }
 


### PR DESCRIPTION
Removing the kv dependency on storage by moving most of LocalTestCluster to a
`testutils` package. The kv-specific part stays behind as a callback.

Also had to make a kv copy of DefaultHeartbeatInterval; added a test to verify
the value is the same.

Fixes #6246.

Second commit is a test for the dependency.

Current dependency graph (excluding util,keys,rpc,cliflags,base,security,roachpb): http://postimg.org/image/o9tbeg5y9/

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6466)

<!-- Reviewable:end -->
