### PR TITLE
sql: changes for allowing tests in sql package to set up a server

### DIFF
--- a/base/testing_knobs.go
+++ b/base/testing_knobs.go
@@ -1,0 +1,31 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package base
+
+// ModuleTestingKnobs is an interface for testing knobs for a submodule.
+type ModuleTestingKnobs interface {
+	// ModuleTestingKnobs is a dummy function.
+	ModuleTestingKnobs()
+}
+
+// TestingKnobs contains facilities for controlling various parts of the
+// system for testing.
+type TestingKnobs struct {
+	Store           ModuleTestingKnobs
+	SQLExecutor     ModuleTestingKnobs
+	SQLLeaseManager ModuleTestingKnobs
+}

--- a/cli/sql_util_test.go
+++ b/cli/sql_util_test.go
@@ -32,7 +32,7 @@ func TestRunQuery(t *testing.T) {
 	s := server.StartTestServer(nil)
 	defer s.Stop()
 
-	url, cleanup := sqlutils.PGUrl(t, s, security.RootUser, "TestRunQuery")
+	url, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestRunQuery")
 	defer cleanup()
 
 	conn := makeSQLConn(url.String())

--- a/server/context.go
+++ b/server/context.go
@@ -35,8 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/cli/cliflags"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/sql"
-	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/envutil"
 	"github.com/cockroachdb/cockroach/util/humanizeutil"
@@ -159,15 +157,7 @@ type Context struct {
 	TimeUntilStoreDead time.Duration
 
 	// TestingKnobs is used for internal test controls only.
-	TestingKnobs TestingKnobs
-}
-
-// TestingKnobs contains facilities for controlling various parts of the
-// system for testing.
-type TestingKnobs struct {
-	StoreTestingKnobs        storage.StoreTestingKnobs
-	ExecutorTestingKnobs     sql.ExecutorTestingKnobs
-	LeaseManagerTestingKnobs sql.LeaseManagerTestingKnobs
+	TestingKnobs base.TestingKnobs
 }
 
 // GetTotalMemory returns either the total system memory or if possible the

--- a/server/server.go
+++ b/server/server.go
@@ -166,15 +166,25 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	s.kvDB = kv.NewDBServer(&s.ctx.Context, sender, stopper)
 	roachpb.RegisterExternalServer(s.grpc, s.kvDB)
 
-	s.leaseMgr = sql.NewLeaseManager(
-		0, *s.db, s.clock, ctx.TestingKnobs.LeaseManagerTestingKnobs)
+	// Set up Lease Manager
+	var lmKnobs sql.LeaseManagerTestingKnobs
+	if ctx.TestingKnobs.SQLLeaseManager != nil {
+		lmKnobs = *ctx.TestingKnobs.SQLLeaseManager.(*sql.LeaseManagerTestingKnobs)
+	}
+	s.leaseMgr = sql.NewLeaseManager(0, *s.db, s.clock, lmKnobs)
 	s.leaseMgr.RefreshLeases(s.stopper, s.db, s.gossip)
+
+	// Set up Executor
 	eCtx := sql.ExecutorContext{
 		DB:           s.db,
 		Gossip:       s.gossip,
 		LeaseManager: s.leaseMgr,
 		Clock:        s.clock,
-		TestingKnobs: &ctx.TestingKnobs.ExecutorTestingKnobs,
+	}
+	if ctx.TestingKnobs.SQLExecutor != nil {
+		eCtx.TestingKnobs = ctx.TestingKnobs.SQLExecutor.(*sql.ExecutorTestingKnobs)
+	} else {
+		eCtx.TestingKnobs = &sql.ExecutorTestingKnobs{}
 	}
 
 	sqlRegistry := metric.NewRegistry()
@@ -207,7 +217,9 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 		AllocatorOptions: storage.AllocatorOptions{
 			AllowRebalance: true,
 		},
-		TestingKnobs: ctx.TestingKnobs.StoreTestingKnobs,
+	}
+	if ctx.TestingKnobs.Store != nil {
+		nCtx.TestingKnobs = *ctx.TestingKnobs.Store.(*storage.StoreTestingKnobs)
 	}
 
 	s.recorder = status.NewMetricsRecorder(s.clock)

--- a/server/testingshim/test_server_shim.go
+++ b/server/testingshim/test_server_shim.go
@@ -1,0 +1,75 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu.berindeg@gmail.com)
+//
+// This file provides generic interfaces that allow tests to set up test servers
+// without importing the server package (avoiding circular dependencies).
+
+package testingshim
+
+import "github.com/cockroachdb/cockroach/base"
+
+// TestServerInterface defines test server functionality that tests need; it is
+// implemented by server.TestServer.
+type TestServerInterface interface {
+	Start() error
+	Stop()
+
+	// ServingAddr returns the server's address.
+	ServingAddr() string
+
+	// ClientDB() returns a *client.DB instance for talking to this server, as
+	// an interface{}.
+	ClientDB() interface{}
+
+	// KVDB() returns the *kv.DB instance as an interface{}.
+	KVDB() interface{}
+}
+
+// TestServerParams contains the parameters we can set when creating a test
+// server.
+type TestServerParams struct {
+	// Knobs for the test server.
+	Knobs base.TestingKnobs
+
+	// JoinAddr (if nonempty) is the address of a node we are joining.
+	JoinAddr string
+}
+
+// TestServerFactory encompasses the actual implementation of the shim
+// service.
+type TestServerFactory interface {
+	// New instantiates a test server instance.
+	New(ctx TestServerParams) TestServerInterface
+}
+
+var serviceImpl TestServerFactory
+
+// InitTestServerFactory should be called once to provide the implementation
+// of the service. It will be called from a xx_test package that can import the
+// server package.
+func InitTestServerFactory(impl TestServerFactory) {
+	serviceImpl = impl
+}
+
+// NewTestServerWithParams creates a new test server with the given parameters.
+func NewTestServerWithParams(params TestServerParams) TestServerInterface {
+	return serviceImpl.New(params)
+}
+
+// NewTestServer creates a new test server with default parameters.
+func NewTestServer() TestServerInterface {
+	return NewTestServerWithParams(TestServerParams{})
+}

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -39,7 +39,7 @@ func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
 	s := server.StartTestServer(b)
 	defer s.Stop()
 
-	pgURL, cleanupFn := sqlutils.PGUrl(b, s, security.RootUser, "benchmarkCockroach")
+	pgURL, cleanupFn := sqlutils.PGUrl(b, s.ServingAddr(), security.RootUser, "benchmarkCockroach")
 	pgURL.Path = "bench"
 	defer cleanupFn()
 

--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -357,7 +357,8 @@ func TestDropAndCreateTable(t *testing.T) {
 	t.Skip(`TODO(andrei, dt): Fails with 'table "foo" does not exist'`)
 	s := server.StartTestServer(t)
 	defer s.Stop()
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestDropAndCreateTable")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(),
+		security.RootUser, "TestDropAndCreateTable")
 	pgURL.Path = "test"
 	defer cleanupFn()
 

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"gopkg.in/inf.v0"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
@@ -161,6 +162,11 @@ type ExecutorContext struct {
 
 	TestingKnobs *ExecutorTestingKnobs
 }
+
+var _ base.ModuleTestingKnobs = &ExecutorTestingKnobs{}
+
+// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
+func (*ExecutorTestingKnobs) ModuleTestingKnobs() {}
 
 // TestingSchemaChangerCollection is an exported (for testing) version of
 // schemaChangerCollection.

--- a/sql/group.go
+++ b/sql/group.go
@@ -329,10 +329,10 @@ func (n *groupNode) computeAggregates() {
 				n.pErr = roachpb.NewError(err)
 				return
 			}
-			if res, err := parser.GetBool(res); err != nil {
+			if val, err := parser.GetBool(res); err != nil {
 				n.pErr = roachpb.NewError(err)
 				return
-			} else if !res {
+			} else if !val {
 				continue
 			}
 		}

--- a/sql/kv_test.go
+++ b/sql/kv_test.go
@@ -174,7 +174,7 @@ type kvSQL struct {
 func newKVSQL(b *testing.B) kvInterface {
 	enableTracing := tracing.Disable()
 	s := server.StartTestServer(b)
-	pgURL, cleanupURL := sqlutils.PGUrl(b, s, security.RootUser, "benchmarkCockroach")
+	pgURL, cleanupURL := sqlutils.PGUrl(b, s.ServingAddr(), security.RootUser, "benchmarkCockroach")
 	pgURL.Path = "bench"
 	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
@@ -640,6 +641,11 @@ type LeaseManagerTestingKnobs struct {
 	// A callback called after the leases are refreshed as a result of a gossip update.
 	TestingLeasesRefreshedEvent func(config.SystemConfig)
 }
+
+var _ base.ModuleTestingKnobs = &LeaseManagerTestingKnobs{}
+
+// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
+func (*LeaseManagerTestingKnobs) ModuleTestingKnobs() {}
 
 // LeaseManager manages acquiring and releasing per-table leases. Exported only
 // for testing.

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -227,7 +227,7 @@ func (t *logicTest) setUser(user string) func() {
 		return func() {}
 	}
 
-	pgURL, cleanupFunc := sqlutils.PGUrl(t.T, &t.srv.TestServer, user, "TestLogic")
+	pgURL, cleanupFunc := sqlutils.PGUrl(t.T, t.srv.TestServer.ServingAddr(), user, "TestLogic")
 	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -211,7 +211,8 @@ func setupWithContext(t *testing.T, ctx *server.Context) (*testServer, *gosql.DB
 	s := setupTestServerWithContext(t, ctx)
 
 	// SQL requests use security.RootUser which has ALL permissions on everything.
-	url, cleanupFn := sqlutils.PGUrl(t, &s.TestServer, security.RootUser, "setupWithContext")
+	url, cleanupFn := sqlutils.PGUrl(t, s.TestServer.ServingAddr(), security.RootUser,
+		"setupWithContext")
 	sqlDB, err := gosql.Open("postgres", url.String())
 	if err != nil {
 		t.Fatal(err)

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/security/securitytest"
 	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/testutils/storageutils"
@@ -190,7 +191,9 @@ func createTestServerContext() (*server.Context, *CommandFilters) {
 	ctx := server.NewTestContext()
 	var cmdFilters CommandFilters
 	cmdFilters.AppendFilter(checkEndTransactionTrigger, true)
-	ctx.TestingKnobs.StoreTestingKnobs.TestingCommandFilter = cmdFilters.runFilters
+	ctx.TestingKnobs.Store = &storage.StoreTestingKnobs{
+		TestingCommandFilter: cmdFilters.runFilters,
+	}
 	return ctx, &cmdFilters
 }
 

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/security/securitytest"
 	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/server/testingshim"
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
@@ -39,10 +40,6 @@ import (
 )
 
 //go:generate ../util/leaktest/add-leaktest.sh *_test.go
-
-func init() {
-	security.SetReadFileFn(securitytest.Asset)
-}
 
 // CommandFilters provides facilities for registering "TestingCommandFilters"
 // (i.e. functions to be run on every replica command).
@@ -237,6 +234,8 @@ func cleanup(s *testServer, db *gosql.DB) {
 }
 
 func TestMain(m *testing.M) {
+	security.SetReadFileFn(securitytest.Asset)
 	randutil.SeedForTests()
+	testingshim.InitTestServerFactory(server.TestServerFactory)
 	os.Exit(m.Run())
 }

--- a/sql/multinode_test.go
+++ b/sql/multinode_test.go
@@ -54,7 +54,8 @@ func SetupMultinodeTestCluster(t testing.TB, nodes int, name string) ([]*gosql.D
 	var cleanups []func()
 
 	for i, s := range servers {
-		pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, fmt.Sprintf("node%d", i))
+		pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser,
+			fmt.Sprintf("node%d", i))
 		pgURL.Path = name
 		db, err := gosql.Open("postgres", pgURL.String())
 		if err != nil {

--- a/sql/parallel_test.go
+++ b/sql/parallel_test.go
@@ -73,7 +73,8 @@ func (t *parallelTest) close() {
 }
 
 func (t *parallelTest) addClient(createDB bool) {
-	pgURL, cleanupFunc := sqlutils.PGUrl(t.T, &t.srv.TestServer, security.RootUser, "TestParallel")
+	pgURL, cleanupFunc := sqlutils.PGUrl(t.T, t.srv.TestServer.ServingAddr(), security.RootUser,
+		"TestParallel")
 	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)

--- a/sql/parallel_test.go
+++ b/sql/parallel_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -154,8 +155,10 @@ func (t *parallelTest) run(dir string) {
 func (t *parallelTest) setup() {
 	ctx := server.NewTestContext()
 	ctx.MaxOffset = logicMaxOffset
-	ctx.TestingKnobs.ExecutorTestingKnobs.WaitForGossipUpdate = true
-	ctx.TestingKnobs.ExecutorTestingKnobs.CheckStmtStringChange = true
+	ctx.TestingKnobs.SQLExecutor = &sql.ExecutorTestingKnobs{
+		WaitForGossipUpdate:   true,
+		CheckStmtStringChange: true,
+	}
 	t.srv = setupTestServerWithContext(t.T, ctx)
 }
 

--- a/sql/pgbench_test.go
+++ b/sql/pgbench_test.go
@@ -105,7 +105,7 @@ func BenchmarkPgbenchExec_Cockroach(b *testing.B) {
 	s := server.StartInsecureTestServer(b)
 	defer s.Stop()
 
-	pgUrl, cleanupFn := sqlutils.PGUrl(b, s, security.RootUser, "benchmarkCockroach")
+	pgUrl, cleanupFn := sqlutils.PGUrl(b, s.ServingAddr(), security.RootUser, "benchmarkCockroach")
 	pgUrl.RawQuery = "sslmode=disable"
 	defer cleanupFn()
 

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -208,7 +208,7 @@ func TestPGWireDBName(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPGWireDBName")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestPGWireDBName")
 	pgURL.Path = "foo"
 	defer cleanupFn()
 	{
@@ -243,7 +243,7 @@ func TestPGPrepareFail(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPGPrepareFail")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestPGPrepareFail")
 	defer cleanupFn()
 
 	db, err := gosql.Open("postgres", pgURL.String())
@@ -478,7 +478,7 @@ func TestPGPreparedQuery(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPGPreparedQuery")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestPGPreparedQuery")
 	defer cleanupFn()
 
 	db, err := gosql.Open("postgres", pgURL.String())
@@ -698,7 +698,7 @@ func TestPGPreparedExec(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPGPreparedExec")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestPGPreparedExec")
 	defer cleanupFn()
 
 	db, err := gosql.Open("postgres", pgURL.String())
@@ -757,7 +757,7 @@ func TestPGPrepareNameQual(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPGPrepareNameQual")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestPGPrepareNameQual")
 	defer cleanupFn()
 
 	db, err := gosql.Open("postgres", pgURL.String())
@@ -807,7 +807,8 @@ func TestCmdCompleteVsEmptyStatements(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestCmdCompleteVsEmptyStatements")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser,
+		"TestCmdCompleteVsEmptyStatements")
 	defer cleanupFn()
 
 	db, err := gosql.Open("postgres", pgURL.String())
@@ -848,7 +849,7 @@ func TestPGCommandTags(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPGCommandTags")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestPGCommandTags")
 	defer cleanupFn()
 
 	db, err := gosql.Open("postgres", pgURL.String())
@@ -968,7 +969,8 @@ func TestSQLNetworkMetrics(t *testing.T) {
 	defer s.Stop()
 
 	// Setup pgwire client.
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestSQLNetworkMetrics")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser,
+		"TestSQLNetworkMetrics")
 	defer cleanupFn()
 
 	const minbytes = 20
@@ -1034,7 +1036,7 @@ func TestPrepareSyntax(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestPrepareSyntax")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestPrepareSyntax")
 	defer cleanupFn()
 
 	db, err := gosql.Open("postgres", pgURL.String())

--- a/sql/poc_test.go
+++ b/sql/poc_test.go
@@ -1,0 +1,50 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/server/testingshim"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+// Temporary proof-of-concept test that uses the testingshim to set up a test
+// server from the sql package.
+func TestPOC(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s := testingshim.NewTestServer()
+	if err := s.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	kvClient := s.ClientDB().(*client.DB)
+	err := kvClient.Put("testkey", "testval")
+	if err != nil {
+		t.Fatal(err)
+	}
+	kv, err := kvClient.Get("testkey")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kv.PrettyValue() != `"testval"` {
+		t.Errorf(`Invalid Get result: %s, expected "testval"`, kv.PrettyValue())
+	}
+}

--- a/sql/scan_test.go
+++ b/sql/scan_test.go
@@ -132,7 +132,7 @@ func TestScanBatches(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "scanTestCockroach")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "scanTestCockroach")
 	pgURL.Path = "test"
 	defer cleanupFn()
 

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -294,13 +294,15 @@ func TestAsyncSchemaChanger(t *testing.T) {
 	defer csql.TestDisableTableLeases()()
 	// Disable synchronous schema change execution so the asynchronous schema
 	// changer executes all schema changes.
-	ctx, _ := createTestServerContext()
-	ctx.TestingKnobs.ExecutorTestingKnobs.SyncSchemaChangersFilter =
+	var execKnobs csql.ExecutorTestingKnobs
+	execKnobs.SyncSchemaChangersFilter =
 		func(tscc csql.TestingSchemaChangerCollection) {
 			tscc.ClearSchemaChangers()
 		}
 	defer csql.TestSpeedupAsyncSchemaChanges()()
 
+	ctx, _ := createTestServerContext()
+	ctx.TestingKnobs.SQLExecutor = &execKnobs
 	server, sqlDB, kvDB := setupWithContext(t, ctx)
 	defer cleanup(server, sqlDB)
 
@@ -533,15 +535,17 @@ func TestRaceWithBackfill(t *testing.T) {
 	// Disable asynchronous schema change execution to allow synchronous path
 	// to trigger start of backfill notification.
 	defer csql.TestDisableAsyncSchemaChangeExec()()
-	ctx, _ := createTestServerContext()
+	var execKnobs csql.ExecutorTestingKnobs
 	var backfillNotification chan bool
-	ctx.TestingKnobs.ExecutorTestingKnobs.SchemaChangersStartBackfillNotification =
+	execKnobs.SchemaChangersStartBackfillNotification =
 		func() {
 			if backfillNotification != nil {
 				// Close channel to notify that the backfill has started.
 				close(backfillNotification)
 			}
 		}
+	ctx, _ := createTestServerContext()
+	ctx.TestingKnobs.SQLExecutor = &execKnobs
 	server, sqlDB, kvDB := setupWithContext(t, ctx)
 	defer cleanup(server, sqlDB)
 

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/caller"
@@ -202,7 +204,7 @@ func TestTxnRestart(t *testing.T) {
 
 	ctx, cmdFilters := createTestServerContext()
 	// Disable one phase commits because they cannot be restarted.
-	ctx.TestingKnobs.StoreTestingKnobs.DisableOnePhaseCommits = true
+	ctx.TestingKnobs.Store.(*storage.StoreTestingKnobs).DisableOnePhaseCommits = true
 	server, sqlDB, _ := setupWithContext(t, ctx)
 	defer cleanup(server, sqlDB)
 
@@ -410,7 +412,7 @@ func TestTxnUserRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx, cmdFilters := createTestServerContext()
-	ctx.TestingKnobs.ExecutorTestingKnobs.FixTxnPriority = true
+	ctx.TestingKnobs.SQLExecutor = &sql.ExecutorTestingKnobs{FixTxnPriority: true}
 	server, sqlDB, _ := setupWithContext(t, ctx)
 	defer cleanup(server, sqlDB)
 
@@ -527,7 +529,7 @@ func TestErrorOnCommit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := server.NewTestContext()
-	ctx.TestingKnobs.ExecutorTestingKnobs.FixTxnPriority = true
+	ctx.TestingKnobs.SQLExecutor = &sql.ExecutorTestingKnobs{FixTxnPriority: true}
 	server, sqlDB, _ := setupWithContext(t, ctx)
 	defer cleanup(server, sqlDB)
 	if _, err := sqlDB.Exec(`

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -38,7 +38,7 @@ func TestLogSplits(t *testing.T) {
 	s := server.StartTestServer(t)
 	defer s.Stop()
 
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestLogSplits")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestLogSplits")
 	defer cleanupFn()
 
 	db, err := gosql.Open("postgres", pgURL.String())
@@ -184,7 +184,7 @@ func TestLogRebalances(t *testing.T) {
 	checkMetrics(2 /*adds*/, 1 /*remove*/)
 
 	// Open a SQL connection to verify that the events have been logged.
-	pgURL, cleanupFn := sqlutils.PGUrl(t, s, security.RootUser, "TestLogRebalances")
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestLogRebalances")
 	defer cleanupFn()
 
 	sqlDB, err := gosql.Open("postgres", pgURL.String())

--- a/storage/store.go
+++ b/storage/store.go
@@ -30,6 +30,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
@@ -414,6 +415,11 @@ type StoreTestingKnobs struct {
 	// Disables the use of one phase commits.
 	DisableOnePhaseCommits bool
 }
+
+var _ base.ModuleTestingKnobs = &StoreTestingKnobs{}
+
+// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
+func (*StoreTestingKnobs) ModuleTestingKnobs() {}
 
 type storeMetrics struct {
 	registry *metric.Registry

--- a/testutils/sqlutils/pg_url.go
+++ b/testutils/sqlutils/pg_url.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/security/securitytest"
-	"github.com/cockroachdb/cockroach/server"
 )
 
 // PGUrl returns a postgres connection url which connects to this server with the given user, and a
@@ -42,8 +41,8 @@ import (
 //
 // Args:
 //  prefix: A prefix to be prepended to the temp file names generated, for debugging.
-func PGUrl(t testing.TB, ts *server.TestServer, user, prefix string) (url.URL, func()) {
-	host, port, err := net.SplitHostPort(ts.ServingAddr())
+func PGUrl(t testing.TB, servingAddr, user, prefix string) (url.URL, func()) {
+	host, port, err := net.SplitHostPort(servingAddr)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We currently run most sql tests from the `sql_test` package to avoid a circular dependency on `server`. This means that everything the tests need must be exported from `sql`. The distributed sql package will have the same problem.

The commits in this PR provide a solution to this problem, with a "sample" proof-of-concept test. This test will be removed when we add a real test that uses this infrastructure, or we move over (some of) the existing tests to `sql`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6473)

<!-- Reviewable:end -->
