### PR TITLE
sql: Define NoTypePreference to act as a sentinel value for type checking

### DIFF
--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -66,7 +66,7 @@ func parseAndNormalizeExpr(t *testing.T, sql string) (parser.TypedExpr, qvalMap)
 	if expr, err = sel.resolveQNames(expr); err != nil {
 		t.Fatalf("%s: %v", sql, err)
 	}
-	typedExpr, err := parser.TypeCheck(expr, nil, nil)
+	typedExpr, err := parser.TypeCheck(expr, nil, parser.NoTypePreference)
 	if err != nil {
 		t.Fatalf("%s: %v", sql, err)
 	}

--- a/sql/group.go
+++ b/sql/group.go
@@ -66,7 +66,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, *r
 
 		// We could potentially skip this, since it will be checked in addRender,
 		// but checking now allows early err return.
-		typedExpr, err := parser.TypeCheck(resolved, p.evalCtx.Args, nil /* no preference */)
+		typedExpr, err := parser.TypeCheck(resolved, p.evalCtx.Args, parser.NoTypePreference)
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -409,7 +409,7 @@ func TestEval(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		typedExpr, err := TypeCheck(expr, nil, nil)
+		typedExpr, err := TypeCheck(expr, nil, NoTypePreference)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
@@ -449,7 +449,7 @@ func TestEvalError(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		typedExpr, err := TypeCheck(expr, nil, nil)
+		typedExpr, err := TypeCheck(expr, nil, NoTypePreference)
 		if err == nil {
 			_, err = typedExpr.Eval(defaultContext)
 		}
@@ -483,7 +483,7 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 		}
 		ctx := defaultContext
 		ctx.ReCache = NewRegexpCache(8)
-		typedExpr, err := TypeCheck(expr, nil, nil)
+		typedExpr, err := TypeCheck(expr, nil, NoTypePreference)
 		if err != nil {
 			t.Fatalf("%v: %v", d, err)
 		}

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -81,6 +81,10 @@ func (p *Parser) Parse(sql string, syntax Syntax) (stmts StatementList, err erro
 	return p.scanner.stmts, nil
 }
 
+// NoTypePreference can be provided to TypeCheck's desired type parameter to indicate that
+// the caller of the function has no preference on the type of the resulting TypedExpr.
+var NoTypePreference = Datum(nil)
+
 // TypeCheck performs type checking on the provided expression tree, returning
 // the new typed expression tree, which additionally permits evaluation and type
 // introspection globally and on each sub-tree.

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -4912,7 +4912,7 @@ sqldefault:
 		//line sql.y:1202
 		{
 			expr := &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType()}
-			typedExpr, err := TypeCheck(expr, nil, nil)
+			typedExpr, err := TypeCheck(expr, nil, NoTypePreference)
 			if err != nil {
 				sqllex.Error("cannot type check interval type: " + err.Error())
 				return 1

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -1201,7 +1201,7 @@ zone_value:
 | const_interval SCONST opt_interval
   {
     expr := &CastExpr{Expr: &StrVal{s: $2}, Type: $1.colType()}
-    typedExpr, err := TypeCheck(expr, nil, nil)
+    typedExpr, err := TypeCheck(expr, nil, NoTypePreference)
     if err != nil {
       sqllex.Error("cannot type check interval type: " + err.Error())
       return 1

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -272,7 +272,7 @@ func (expr *ComparisonExpr) TypeCheck(args MapArgs, desired Datum) (TypedExpr, e
 
 // TypeCheck implements the Expr interface.
 func (expr *ExistsExpr) TypeCheck(args MapArgs, desired Datum) (TypedExpr, error) {
-	subqueryTyped, err := expr.Subquery.TypeCheck(args, nil /* no preference */)
+	subqueryTyped, err := expr.Subquery.TypeCheck(args, NoTypePreference)
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +348,7 @@ func (expr *IfExpr) TypeCheck(args MapArgs, desired Datum) (TypedExpr, error) {
 
 // TypeCheck implements the Expr interface.
 func (expr *IsOfTypeExpr) TypeCheck(args MapArgs, desired Datum) (TypedExpr, error) {
-	exprTyped, err := expr.Expr.TypeCheck(args, nil /* no preference */)
+	exprTyped, err := expr.Expr.TypeCheck(args, NoTypePreference)
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +523,7 @@ func (expr ValArg) TypeCheck(args MapArgs, desired Datum) (TypedExpr, error) {
 		dVal.typeAnnotation.typ = v
 		return dVal, nil
 	}
-	if desired == nil || desired == DNull {
+	if desired == NoTypePreference || desired == DNull {
 		return nil, parameterTypeAmbiguityError{expr}
 	}
 	if _, err := args.SetInferredType(dVal, desired); err != nil {
@@ -776,7 +776,7 @@ func typeCheckSameTypedExprs(args MapArgs, desired Datum, exprs ...Expr) ([]Type
 			for _, numVal := range constExprs {
 				if !canConstantBecome(numVal.e.(*NumVal), typ) {
 					if required {
-						typedExpr, err := numVal.e.TypeCheck(args, nil)
+						typedExpr, err := numVal.e.TypeCheck(args, NoTypePreference)
 						if err != nil {
 							return nil, err
 						}

--- a/sql/parser/type_check_test.go
+++ b/sql/parser/type_check_test.go
@@ -75,7 +75,7 @@ func TestTypeCheck(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d, err)
 		}
-		if _, err := TypeCheck(expr, nil, nil); err != nil {
+		if _, err := TypeCheck(expr, nil, NoTypePreference); err != nil {
 			t.Errorf("%s: unexpected error %s", d, err)
 		}
 	}
@@ -121,7 +121,7 @@ func TestTypeCheckError(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		if _, err := TypeCheck(expr, nil, nil); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
+		if _, err := TypeCheck(expr, nil, NoTypePreference); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
 			t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)
 		}
 	}

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -110,7 +110,7 @@ func (rh *returningHelper) cookResultRow(rowVals parser.DTuple) (parser.DTuple, 
 // ought to be split into two phases.
 func (rh *returningHelper) TypeCheck() *roachpb.Error {
 	for i, expr := range rh.untypedExprs {
-		var desired parser.Datum
+		desired := parser.NoTypePreference
 		if len(rh.desiredTypes) > i {
 			desired = rh.desiredTypes[i]
 		}

--- a/sql/values.go
+++ b/sql/values.go
@@ -69,7 +69,7 @@ func (p *planner) ValuesClause(n *parser.ValuesClause, desiredTypes []parser.Dat
 			if pErr != nil {
 				return nil, pErr
 			}
-			var desired parser.Datum
+			desired := parser.NoTypePreference
 			if len(desiredTypes) > i {
 				desired = desiredTypes[i]
 			}
@@ -121,7 +121,7 @@ func (n *valuesNode) Start() *roachpb.Error {
 			if pErr != nil {
 				return pErr
 			}
-			var desired parser.Datum
+			desired := parser.NoTypePreference
 			if len(n.desiredTypes) > i {
 				desired = n.desiredTypes[i]
 			}


### PR DESCRIPTION
Instead of passing around `nil` whenever we don't want to specify a
desired type when type checking, it's more expressive to use a sentinel
`NoTypePreference` value.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6475)

<!-- Reviewable:end -->
