### PR TITLE
sql: Aggregate functions no longer need to define eval functions

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -623,32 +623,21 @@ var Builtins = map[string][]Builtin{
 	},
 
 	// Aggregate functions.
+	// These functions are handled in sql/group.go and are not evaluated normally,
+	// so they do not need to define an fn function.
 
 	"avg": {
 		Builtin{
 			Types:      ArgTypes{DummyInt},
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				if args[0] == DNull {
-					return args[0], nil
-				}
-				// AVG returns a float when given an int argument.
-				return NewDFloat(DFloat(*args[0].(*DInt))), nil
-			},
 		},
 		Builtin{
 			Types:      ArgTypes{DummyFloat},
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				return args[0], nil
-			},
 		},
 		Builtin{
 			Types:      ArgTypes{DummyDecimal},
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				return args[0], nil
-			},
 		},
 	},
 
@@ -662,17 +651,14 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{DummyInt},
 			ReturnType: TypeDecimal,
-			fn:         funcNull,
 		},
 		Builtin{
 			Types:      ArgTypes{DummyDecimal},
 			ReturnType: TypeDecimal,
-			fn:         funcNull,
 		},
 		Builtin{
 			Types:      ArgTypes{DummyFloat},
 			ReturnType: TypeFloat,
-			fn:         funcNull,
 		},
 	},
 
@@ -680,17 +666,14 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{DummyInt},
 			ReturnType: TypeDecimal,
-			fn:         funcNull,
 		},
 		Builtin{
 			Types:      ArgTypes{DummyDecimal},
 			ReturnType: TypeDecimal,
-			fn:         funcNull,
 		},
 		Builtin{
 			Types:      ArgTypes{DummyFloat},
 			ReturnType: TypeFloat,
-			fn:         funcNull,
 		},
 	},
 
@@ -979,10 +962,6 @@ var Builtins = map[string][]Builtin{
 	},
 }
 
-func funcNull(_ EvalContext, _ DTuple) (Datum, error) {
-	return DNull, nil
-}
-
 // The aggregate functions all just return their first argument. We don't
 // perform any type checking here either. The bulk of the aggregate function
 // implementation is performed at a higher level in sql.groupNode.
@@ -992,9 +971,6 @@ func aggregateImpls(types ...Datum) []Builtin {
 		r = append(r, Builtin{
 			Types:      ArgTypes{t},
 			ReturnType: t,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				return args[0], nil
-			},
 		})
 	}
 	return r

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -610,7 +610,7 @@ EXPLAIN (DEBUG) SELECT MIN(z) FROM xyz
 query RRR
 SELECT AVG(1::int), AVG(2::float), AVG(3::decimal)
 ----
-1 2 3
+1 2 3.0000000000000000
 
 query III
 SELECT COUNT(2::int), COUNT(3::float), COUNT(4::decimal)


### PR DESCRIPTION
With recent changes to the typing system, builtin aggregate functions no
longer need to mock out evaluation functions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6477)

<!-- Reviewable:end -->
