### PR TITLE
sql: Propagate parser.TypedExpr throughout sql analysis

### DIFF
--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -250,7 +250,7 @@ func TestSimplifyExpr(t *testing.T) {
 	}
 	for _, d := range testData {
 		expr, _ := parseAndNormalizeExpr(t, d.expr)
-		expr, equiv := simplifyTypedExpr(expr)
+		expr, equiv := simplifyExpr(expr)
 		if s := expr.String(); d.expected != s {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 		}
@@ -286,7 +286,7 @@ func TestSimplifyNotExpr(t *testing.T) {
 	}
 	for _, d := range testData {
 		expr1, qvals := parseAndNormalizeExpr(t, d.expr)
-		expr2, equiv := simplifyTypedExpr(expr1)
+		expr2, equiv := simplifyExpr(expr1)
 		if s := expr2.String(); d.expected != s {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 		}
@@ -519,7 +519,7 @@ func TestSimplifyAndExprCheck(t *testing.T) {
 	}
 	for _, d := range testData {
 		expr1, qvals := parseAndNormalizeExpr(t, d.expr)
-		expr2, equiv := simplifyTypedExpr(expr1)
+		expr2, equiv := simplifyExpr(expr1)
 		if s := expr2.String(); d.expected != s {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 		}
@@ -736,7 +736,7 @@ func TestSimplifyOrExprCheck(t *testing.T) {
 	}
 	for _, d := range testData {
 		expr1, qvals := parseAndNormalizeExpr(t, d.expr)
-		expr2, equiv := simplifyTypedExpr(expr1)
+		expr2, equiv := simplifyExpr(expr1)
 		if s := expr2.String(); d.expected != s {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 		}

--- a/sql/group.go
+++ b/sql/group.go
@@ -381,24 +381,24 @@ func (n *groupNode) wrap(plan planNode) planNode {
 // the groupNode has a desired ordering on col (see
 // desiredAggregateOrdering). A desired ordering will only be present if there
 // is a single MIN/MAX aggregation function.
-func (n *groupNode) isNotNullFilter(expr parser.Expr) parser.Expr {
+func (n *groupNode) isNotNullFilter(expr parser.TypedExpr) parser.TypedExpr {
 	if len(n.desiredOrdering) != 1 {
 		return expr
 	}
 	i := n.desiredOrdering[0].colIdx
 	f := n.funcs[i]
-	isNotNull := &parser.ComparisonExpr{
-		Operator: parser.IsNot,
-		Left:     f.arg,
-		Right:    parser.DNull,
-	}
+	isNotNull := parser.NewTypedComparisonExpr(
+		parser.IsNot,
+		f.arg,
+		parser.DNull,
+	)
 	if expr == nil {
 		return isNotNull
 	}
-	return &parser.AndExpr{
-		Left:  expr,
-		Right: isNotNull,
-	}
+	return parser.NewTypedAndExpr(
+		expr,
+		isNotNull,
+	)
 }
 
 // desiredAggregateOrdering computes the desired output ordering from the

--- a/sql/index_selection_test.go
+++ b/sql/index_selection_test.go
@@ -170,7 +170,7 @@ func makeConstraints(t *testing.T, sql string, desc *TableDescriptor,
 	}
 	c.analyzeExprs(exprs)
 	if equiv && len(exprs) == 1 {
-		expr = joinAndExprs(exprs[0]).(parser.TypedExpr)
+		expr = joinAndExprs(exprs[0])
 	}
 	return c.constraints, expr
 }

--- a/sql/join.go
+++ b/sql/join.go
@@ -81,7 +81,7 @@ func makeIndexJoin(indexScan *scanNode, exactPrefix int) *indexJoinNode {
 			iv := expr.(*parser.IndexedVar)
 			return true, table.filterVars.IndexedVar(iv.Idx)
 		}
-		table.filter = exprConvertVars(indexScan.filter, convFunc).(parser.TypedExpr)
+		table.filter = exprConvertVars(indexScan.filter, convFunc)
 
 		// Now we split the filter by extracting the part that can be evaluated using just the index
 		// columns.

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -132,6 +132,21 @@ func (node *AndExpr) String() string {
 	return fmt.Sprintf("%s AND %s", exprStrWithParen(node.Left), exprStrWithParen(node.Right))
 }
 
+// NewTypedAndExpr returns a new AndExpr that is verified to be well-typed.
+func NewTypedAndExpr(left, right TypedExpr) *AndExpr {
+	return &AndExpr{Left: left, Right: right}
+}
+
+// TypedLeft returns the AndExpr's left expression as a TypedExpr.
+func (node *AndExpr) TypedLeft() TypedExpr {
+	return node.Left.(TypedExpr)
+}
+
+// TypedRight returns the AndExpr's right expression as a TypedExpr.
+func (node *AndExpr) TypedRight() TypedExpr {
+	return node.Right.(TypedExpr)
+}
+
 // OrExpr represents an OR expression.
 type OrExpr struct {
 	Left, Right Expr
@@ -143,6 +158,21 @@ func (*OrExpr) operatorExpr() {}
 
 func (node *OrExpr) String() string {
 	return fmt.Sprintf("%s OR %s", exprStrWithParen(node.Left), exprStrWithParen(node.Right))
+}
+
+// NewTypedOrExpr returns a new OrExpr that is verified to be well-typed.
+func NewTypedOrExpr(left, right TypedExpr) *OrExpr {
+	return &OrExpr{Left: left, Right: right}
+}
+
+// TypedLeft returns the OrExpr's left expression as a TypedExpr.
+func (node *OrExpr) TypedLeft() TypedExpr {
+	return node.Left.(TypedExpr)
+}
+
+// TypedRight returns the OrExpr's right expression as a TypedExpr.
+func (node *OrExpr) TypedRight() TypedExpr {
+	return node.Right.(TypedExpr)
 }
 
 // NotExpr represents a NOT expression.
@@ -158,6 +188,16 @@ func (node *NotExpr) String() string {
 	return fmt.Sprintf("NOT %s", exprStrWithParen(node.Expr))
 }
 
+// NewTypedNotExpr returns a new NotExpr that is verified to be well-typed.
+func NewTypedNotExpr(expr TypedExpr) *NotExpr {
+	return &NotExpr{Expr: expr}
+}
+
+// TypedInnerExpr returns the NotExpr's inner expression as a TypedExpr.
+func (node *NotExpr) TypedInnerExpr() TypedExpr {
+	return node.Expr.(TypedExpr)
+}
+
 // ParenExpr represents a parenthesized expression.
 type ParenExpr struct {
 	Expr Expr
@@ -167,6 +207,11 @@ type ParenExpr struct {
 
 func (node *ParenExpr) String() string {
 	return fmt.Sprintf("(%s)", node.Expr)
+}
+
+// TypedInnerExpr returns the ParenExpr's inner expression as a TypedExpr.
+func (node *ParenExpr) TypedInnerExpr() TypedExpr {
+	return node.Expr.(TypedExpr)
 }
 
 // ComparisonOperator represents a binary operator.
@@ -232,6 +277,21 @@ func (*ComparisonExpr) operatorExpr() {}
 func (node *ComparisonExpr) String() string {
 	return fmt.Sprintf("%s %s %s", exprStrWithParen(node.Left), node.Operator,
 		exprStrWithParen(node.Right))
+}
+
+// NewTypedComparisonExpr returns a new ComparisonExpr that is verified to be well-typed.
+func NewTypedComparisonExpr(op ComparisonOperator, left, right TypedExpr) *ComparisonExpr {
+	return &ComparisonExpr{Operator: op, Left: left, Right: right}
+}
+
+// TypedLeft returns the ComparisonExpr's left expression as a TypedExpr.
+func (node *ComparisonExpr) TypedLeft() TypedExpr {
+	return node.Left.(TypedExpr)
+}
+
+// TypedRight returns the ComparisonExpr's right expression as a TypedExpr.
+func (node *ComparisonExpr) TypedRight() TypedExpr {
+	return node.Right.(TypedExpr)
 }
 
 // RangeCond represents a BETWEEN or a NOT BETWEEN expression.
@@ -679,6 +739,20 @@ func (node *Array) String() string {
 type Exprs []Expr
 
 func (node Exprs) String() string {
+	var prefix string
+	var buf bytes.Buffer
+	for _, n := range node {
+		fmt.Fprintf(&buf, "%s%s", prefix, n)
+		prefix = ", "
+	}
+	return buf.String()
+}
+
+// TypedExprs represents a list of well-typed value expressions. It's not a valid expression
+// because it's not parenthesized.
+type TypedExprs []TypedExpr
+
+func (node TypedExprs) String() string {
 	var prefix string
 	var buf bytes.Buffer
 	for _, n := range node {

--- a/sql/select.go
+++ b/sql/select.go
@@ -268,7 +268,7 @@ func (p *planner) initSelect(
 
 	if s.filter != nil && group != nil {
 		// Allow the group-by to add an implicit "IS NOT NULL" filter.
-		s.filter = group.isNotNullFilter(s.filter).(parser.TypedExpr)
+		s.filter = group.isNotNullFilter(s.filter)
 	}
 
 	// Get the ordering for index selection (if any).


### PR DESCRIPTION
All sql analysis should be working on well-typed expressions. This
commit uses the `parser.TypedExpr` interface to assert that that is
true.

This change also creates "typed" expression constructors within the
`sql/parser` package, which are intended to:
- hide the understanding that `Typed<X implements Expr>` types are
  implemented by the same struct types as their corresponding `X
  implements Expr` types.
- Allow a follow-on PR to assure that during these constructors type
  annotations are set for the constructed `TypedExpr`s. The plan is to
  pull out boolTypeAnnotion and force the explicit assignment for all
  `TypedExpr`s so we can use the annotation as a sanity check against
  improper `Expr -> TypedExpr` type assertions.

This should greatly improve the type safety provided by `parser.TypedExpr`
because it removes almost all need for assertions from `Expr` -> `TypedExpr` outside
of the `sql/parser` package.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6478)

<!-- Reviewable:end -->
