### PR TITLE
sql: Introduce TypeCheckAndRequire function

### DIFF
--- a/sql/group.go
+++ b/sql/group.go
@@ -97,13 +97,10 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, *r
 			return nil, roachpb.NewError(err)
 		}
 
-		typedHaving, err = parser.TypeCheck(having, p.evalCtx.Args, parser.DummyBool)
+		typedHaving, err = parser.TypeCheckAndRequire(having, p.evalCtx.Args,
+			parser.DummyBool, "HAVING")
 		if err != nil {
 			return nil, roachpb.NewError(err)
-		}
-		if typ := typedHaving.ReturnType(); !(typ.TypeEqual(parser.DummyBool) || typ == parser.DNull) {
-			return nil, roachpb.NewUErrorf("argument of HAVING must be type %s, not type %s",
-				parser.DummyBool.Type(), typ.Type())
 		}
 
 		typedHaving, err = p.parser.NormalizeExpr(p.evalCtx, typedHaving)

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -45,7 +45,8 @@ func (p *planner) evalLimit(limit *parser.Limit) (count, offset int64, err error
 
 	for _, datum := range data {
 		if datum.src != nil {
-			typedSrc, err := parser.TypeCheck(datum.src, p.evalCtx.Args, parser.DummyInt)
+			typedSrc, err := parser.TypeCheckAndRequire(datum.src, p.evalCtx.Args,
+				parser.DummyInt, datum.name)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -53,11 +54,6 @@ func (p *planner) evalLimit(limit *parser.Limit) (count, offset int64, err error
 			normalized, err := p.parser.NormalizeExpr(p.evalCtx, typedSrc)
 			if err != nil {
 				return 0, 0, err
-			}
-
-			if typ := normalized.ReturnType(); !(typ.TypeEqual(parser.DummyInt) || typ == parser.DNull) {
-				return 0, 0, fmt.Errorf("argument of %s must be type %s, not type %s",
-					datum.name, parser.DummyInt.Type(), typ.Type())
 			}
 
 			if p.evalCtx.PrepareOnly {

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -25,6 +25,7 @@ package parser
 import (
 	"bytes"
 	"errors"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/util"
 )
@@ -95,6 +96,22 @@ func TypeCheck(expr Expr, args MapArgs, desired Datum) (TypedExpr, error) {
 		return nil, err
 	}
 	return expr.TypeCheck(args, desired)
+}
+
+// TypeCheckAndRequire performs type checking on the provided expression tree in
+// an identical manner to TypeCheck. It then asserts that the resulting TypedExpr
+// has the provided return type, returning both the typed expression and an error
+// if it does not.
+func TypeCheckAndRequire(expr Expr, args MapArgs, required Datum, op string) (TypedExpr, error) {
+	typedExpr, err := TypeCheck(expr, args, required)
+	if err != nil {
+		return nil, err
+	}
+	if typ := typedExpr.ReturnType(); !(typ.TypeEqual(required) || typ == DNull) {
+		return typedExpr, fmt.Errorf("argument of %s must be type %s, not type %s",
+			op, required.Type(), typ.Type())
+	}
+	return typedExpr, nil
 }
 
 // NormalizeExpr is wrapper around ctx.NormalizeExpr which avoids allocation of

--- a/sql/select.go
+++ b/sql/select.go
@@ -472,14 +472,10 @@ func (s *selectNode) initWhere(where *parser.Where) *roachpb.Error {
 		return s.pErr
 	}
 
-	s.filter, err = parser.TypeCheck(untypedFilter, s.planner.evalCtx.Args, parser.DummyBool)
+	s.filter, err = parser.TypeCheckAndRequire(untypedFilter, s.planner.evalCtx.Args,
+		parser.DummyBool, "WHERE")
 	if err != nil {
 		s.pErr = roachpb.NewError(err)
-		return s.pErr
-	}
-	if whereType := s.filter.ReturnType(); !(whereType.TypeEqual(parser.DummyBool) || whereType == parser.DNull) {
-		s.pErr = roachpb.NewUErrorf("argument of WHERE must be type %s, not type %s",
-			parser.DummyBool.Type(), whereType.Type())
 		return s.pErr
 	}
 


### PR DESCRIPTION
This commit introduces a new `TypeCheckAndRequire` function which type
checks the provided expression and asserts that it is equal to the
provided type.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6479)

<!-- Reviewable:end -->
