### PR TITLE
sql: refactor the statement pretty-printer and implement EXPLAIN(TYPES)

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -235,4 +235,11 @@ func (d *deleteNode) ExplainPlan(v bool) (name, description string, children []p
 	return "delete", buf.String(), []planNode{d.run.rows}
 }
 
+func (d *deleteNode) ExplainTypes(regTypes func(string, string)) {
+	cols := d.rh.columns
+	for i, rexpr := range d.rh.exprs {
+		regTypes(fmt.Sprintf("returning %s", cols[i].Name), parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
+	}
+}
+
 func (d *deleteNode) SetLimitHint(numRows int64, soft bool) {}

--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -184,6 +184,8 @@ func (n *distinctNode) ExplainPlan(_ bool) (string, string, []planNode) {
 	return "distinct", description, []planNode{n.planNode}
 }
 
+func (n *distinctNode) ExplainTypes(_ func(string, string)) {}
+
 func (n *distinctNode) SetLimitHint(numRows int64, soft bool) {
 	// Any limit becomes a "soft" limit underneath.
 	n.planNode.SetLimitHint(numRows, true)

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -17,6 +17,7 @@
 package sql
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -35,6 +36,7 @@ const (
 	explainDebug
 	explainPlan
 	explainTrace
+	explainTypes
 )
 
 // Explain executes the explain statement, providing debugging and analysis
@@ -52,6 +54,8 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, *roachp
 			newMode = explainTrace
 		} else if strings.EqualFold(opt, "PLAN") {
 			newMode = explainPlan
+		} else if strings.EqualFold(opt, "TYPES") {
+			newMode = explainTypes
 		} else if strings.EqualFold(opt, "VERBOSE") {
 			verbose = true
 		} else {
@@ -84,18 +88,35 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, *roachp
 	}
 	switch mode {
 	case explainDebug:
-		// Wrap the plan in an explainDebugNode.
 		return &explainDebugNode{plan}, nil
 
-	case explainPlan:
-		v := &valuesNode{}
-		v.columns = []ResultColumn{
-			{Name: "Level", Typ: parser.DummyInt},
-			{Name: "Type", Typ: parser.DummyString},
-			{Name: "Description", Typ: parser.DummyString},
+	case explainTypes:
+		node := &explainTypesNode{
+			plan: plan,
+			results: &valuesNode{
+				columns: []ResultColumn{
+					{Name: "Level", Typ: parser.DummyInt},
+					{Name: "Type", Typ: parser.DummyString},
+					{Name: "Element", Typ: parser.DummyString},
+					{Name: "Description", Typ: parser.DummyString},
+				},
+			},
 		}
-		populateExplain(verbose, v, plan, 0)
-		return v, nil
+		return node, nil
+
+	case explainPlan:
+		node := &explainPlanNode{
+			verbose: verbose,
+			plan:    plan,
+			results: &valuesNode{
+				columns: []ResultColumn{
+					{Name: "Level", Typ: parser.DummyInt},
+					{Name: "Type", Typ: parser.DummyString},
+					{Name: "Description", Typ: parser.DummyString},
+				},
+			},
+		}
+		return node, nil
 
 	case explainTrace:
 		return (&sortNode{
@@ -106,6 +127,100 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, *roachp
 	default:
 		return nil, roachpb.NewUErrorf("unsupported EXPLAIN mode: %d", mode)
 	}
+}
+
+type explainTypesNode struct {
+	plan    planNode
+	results *valuesNode
+}
+
+func (e *explainTypesNode) ExplainTypes(fn func(string, string)) {}
+func (e *explainTypesNode) Next() bool                           { return e.results.Next() }
+func (e *explainTypesNode) Columns() []ResultColumn              { return e.results.Columns() }
+func (e *explainTypesNode) Ordering() orderingInfo               { return e.results.Ordering() }
+func (e *explainTypesNode) Values() parser.DTuple                { return e.results.Values() }
+func (e *explainTypesNode) DebugValues() debugValues             { return e.results.DebugValues() }
+func (e *explainTypesNode) PErr() *roachpb.Error                 { return e.results.PErr() }
+func (e *explainTypesNode) SetLimitHint(n int64, s bool)         { e.results.SetLimitHint(n, s) }
+func (e *explainTypesNode) MarkDebug(mode explainMode)           { e.results.MarkDebug(mode) }
+func (e *explainTypesNode) ExplainPlan(v bool) (string, string, []planNode) {
+	return e.plan.ExplainPlan(v)
+}
+
+func (e *explainTypesNode) Start() *roachpb.Error {
+	if pErr := e.plan.Start(); pErr != nil {
+		return pErr
+	}
+	populateTypes(e.results, e.plan, 0)
+	return nil
+}
+
+func populateTypes(v *valuesNode, plan planNode, level int) {
+	name, _, children := plan.ExplainPlan(true)
+
+	// Format the result column types.
+	var colDesc bytes.Buffer
+	colDesc.WriteByte('(')
+	for i, rCol := range plan.Columns() {
+		if i > 0 {
+			colDesc.WriteString(", ")
+		}
+		colDesc.WriteString(parser.Name(rCol.Name).String())
+		colDesc.WriteByte(' ')
+		colDesc.WriteString(rCol.Typ.Type())
+	}
+	colDesc.WriteByte(')')
+	row := parser.DTuple{
+		parser.NewDInt(parser.DInt(level)),
+		parser.NewDString(name),
+		parser.NewDString("result"),
+		parser.NewDString(colDesc.String()),
+	}
+	v.rows = append(v.rows, row)
+
+	// Format the node's typing details.
+	regType := func(elt string, desc string) {
+		row := parser.DTuple{
+			parser.NewDInt(parser.DInt(level)),
+			parser.NewDString(name),
+			parser.NewDString(elt),
+			parser.NewDString(desc),
+		}
+		v.rows = append(v.rows, row)
+	}
+	plan.ExplainTypes(regType)
+
+	// Recurse into sub-nodes.
+	for _, child := range children {
+		populateTypes(v, child, level+1)
+	}
+}
+
+type explainPlanNode struct {
+	verbose bool
+	plan    planNode
+	results *valuesNode
+}
+
+func (e *explainPlanNode) ExplainTypes(fn func(string, string)) {}
+func (e *explainPlanNode) Next() bool                           { return e.results.Next() }
+func (e *explainPlanNode) Columns() []ResultColumn              { return e.results.Columns() }
+func (e *explainPlanNode) Ordering() orderingInfo               { return e.results.Ordering() }
+func (e *explainPlanNode) Values() parser.DTuple                { return e.results.Values() }
+func (e *explainPlanNode) DebugValues() debugValues             { return e.results.DebugValues() }
+func (e *explainPlanNode) PErr() *roachpb.Error                 { return e.results.PErr() }
+func (e *explainPlanNode) SetLimitHint(n int64, s bool)         { e.results.SetLimitHint(n, s) }
+func (e *explainPlanNode) MarkDebug(mode explainMode)           { e.results.MarkDebug(mode) }
+func (e *explainPlanNode) ExplainPlan(v bool) (string, string, []planNode) {
+	return e.plan.ExplainPlan(v)
+}
+
+func (e *explainPlanNode) Start() *roachpb.Error {
+	if pErr := e.plan.Start(); pErr != nil {
+		return pErr
+	}
+	populateExplain(e.verbose, e.results, e.plan, 0)
+	return nil
 }
 
 func populateExplain(verbose bool, v *valuesNode, plan planNode, level int) {
@@ -223,6 +338,10 @@ func (n *explainDebugNode) Next() bool { return n.plan.Next() }
 
 func (n *explainDebugNode) ExplainPlan(v bool) (name, description string, children []planNode) {
 	return n.plan.ExplainPlan(v)
+}
+
+func (n *explainDebugNode) ExplainTypes(fn func(string, string)) {
+	n.plan.ExplainTypes(fn)
 }
 
 func (n *explainDebugNode) Values() parser.DTuple {

--- a/sql/group.go
+++ b/sql/group.go
@@ -17,6 +17,7 @@
 package sql
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"strings"
@@ -629,9 +630,10 @@ func (a *aggregateFunc) add(bucket []byte, d parser.Datum) error {
 
 func (*aggregateFunc) Variable() {}
 
-func (a *aggregateFunc) String() string {
-	return a.expr.String()
+func (a *aggregateFunc) Format(buf *bytes.Buffer, f parser.FmtFlags) {
+	a.expr.Format(buf, f)
 }
+func (a *aggregateFunc) String() string { return parser.AsString(a) }
 
 func (a *aggregateFunc) Walk(v parser.Visitor) parser.Expr { return a }
 

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -584,4 +584,17 @@ func (n *insertNode) ExplainPlan(v bool) (name, description string, children []p
 	return "insert", buf.String(), []planNode{n.run.rows}
 }
 
+func (n *insertNode) ExplainTypes(regTypes func(string, string)) {
+	for i, dexpr := range n.defaultExprs {
+		regTypes(fmt.Sprintf("default %d", i), parser.AsStringWithFlags(dexpr, parser.FmtShowTypes))
+	}
+	for i, cexpr := range n.checkExprs {
+		regTypes(fmt.Sprintf("check %d", i), parser.AsStringWithFlags(cexpr, parser.FmtShowTypes))
+	}
+	cols := n.rh.columns
+	for i, rexpr := range n.rh.exprs {
+		regTypes(fmt.Sprintf("returning %s", cols[i].Name), parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
+	}
+}
+
 func (n *insertNode) SetLimitHint(numRows int64, soft bool) {}

--- a/sql/join.go
+++ b/sql/join.go
@@ -220,6 +220,8 @@ func (n *indexJoinNode) ExplainPlan(_ bool) (name, description string, children 
 	return "index-join", "", []planNode{n.index, n.table}
 }
 
+func (n *indexJoinNode) ExplainTypes(_ func(string, string)) {}
+
 func (n *indexJoinNode) SetLimitHint(numRows int64, soft bool) {
 	if numRows < joinBatchSize {
 		numRows = joinBatchSize

--- a/sql/parser/constant.go
+++ b/sql/parser/constant.go
@@ -17,6 +17,7 @@
 package parser
 
 import (
+	"bytes"
 	"fmt"
 	"go/constant"
 	"go/token"
@@ -102,11 +103,13 @@ type NumVal struct {
 	OrigString string
 }
 
-func (expr *NumVal) String() string {
-	if expr.OrigString != "" {
-		return expr.OrigString
+// Format implements the NodeFormatter interface.
+func (expr *NumVal) Format(buf *bytes.Buffer, f FmtFlags) {
+	s := expr.OrigString
+	if s == "" {
+		s = expr.Value.String()
 	}
-	return expr.Value.String()
+	buf.WriteString(s)
 }
 
 // canBeInt64 checks if it's possible for the value to become an int64:
@@ -265,11 +268,13 @@ type StrVal struct {
 	bytesEsc bool
 }
 
-func (expr *StrVal) String() string {
+// Format implements the NodeFormatter interface.
+func (expr *StrVal) Format(buf *bytes.Buffer, f FmtFlags) {
 	if expr.bytesEsc {
-		return encodeSQLBytes(expr.s)
+		encodeSQLBytes(buf, expr.s)
+	} else {
+		encodeSQLString(buf, expr.s)
 	}
-	return encodeSQLString(expr.s)
 }
 
 var strValAvailStringBytes = []Datum{DummyString, DummyBytes}

--- a/sql/parser/create.go
+++ b/sql/parser/create.go
@@ -25,7 +25,6 @@ package parser
 import (
 	"bytes"
 	"fmt"
-	"strings"
 )
 
 // CreateDatabase represents a CREATE DATABASE statement.
@@ -34,14 +33,13 @@ type CreateDatabase struct {
 	Name        Name
 }
 
-func (node *CreateDatabase) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *CreateDatabase) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("CREATE DATABASE ")
 	if node.IfNotExists {
 		buf.WriteString("IF NOT EXISTS ")
 	}
-	buf.WriteString(node.Name.String())
-	return buf.String()
+	FormatNode(buf, f, node.Name)
 }
 
 // IndexElem represents a column with a direction in a CREATE INDEX statement.
@@ -50,23 +48,27 @@ type IndexElem struct {
 	Direction Direction
 }
 
-func (node IndexElem) String() string {
-	if node.Direction == DefaultDirection {
-		return node.Column.String()
+// Format implements the NodeFormatter interface.
+func (node IndexElem) Format(buf *bytes.Buffer, f FmtFlags) {
+	FormatNode(buf, f, node.Column)
+	if node.Direction != DefaultDirection {
+		buf.WriteByte(' ')
+		buf.WriteString(node.Direction.String())
 	}
-	return fmt.Sprintf("%s %s", node.Column, node.Direction)
 }
 
 // IndexElemList is list of IndexElem.
 type IndexElemList []IndexElem
 
-// String formats the contained names as a comma-separated, escaped string.
-func (l IndexElemList) String() string {
-	colStrs := make([]string, 0, len(l))
-	for _, indexElem := range l {
-		colStrs = append(colStrs, indexElem.String())
+// Format pretty-prints the contained names separated by commas.
+// Format implements the NodeFormatter interface.
+func (l IndexElemList) Format(buf *bytes.Buffer, f FmtFlags) {
+	for i, indexElem := range l {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		FormatNode(buf, f, indexElem)
 	}
-	return strings.Join(colStrs, ", ")
 }
 
 // CreateIndex represents a CREATE INDEX statement.
@@ -81,8 +83,8 @@ type CreateIndex struct {
 	Storing NameList
 }
 
-func (node *CreateIndex) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *CreateIndex) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("CREATE ")
 	if node.Unique {
 		buf.WriteString("UNIQUE ")
@@ -92,18 +94,20 @@ func (node *CreateIndex) String() string {
 		buf.WriteString("IF NOT EXISTS ")
 	}
 	if node.Name != "" {
-		fmt.Fprintf(&buf, "%s ", node.Name)
+		fmt.Fprintf(buf, "%s ", node.Name)
 	}
-	fmt.Fprintf(&buf, "ON %s (%s)", node.Table, node.Columns)
+	fmt.Fprintf(buf, "ON %s (", node.Table)
+	FormatNode(buf, f, node.Columns)
+	buf.WriteByte(')')
 	if node.Storing != nil {
-		fmt.Fprintf(&buf, " STORING (%s)", node.Storing)
+		fmt.Fprintf(buf, " STORING (%s)", node.Storing)
 	}
-	return buf.String()
 }
 
 // TableDef represents a column or index definition within a CREATE TABLE
 // statement.
 type TableDef interface {
+	NodeFormatter
 	// Placeholder function to ensure that only desired types (*TableDef) conform
 	// to the TableDef interface.
 	tableDef()
@@ -116,14 +120,14 @@ func (*IndexTableDef) tableDef()  {}
 // TableDefs represents a list of table definitions.
 type TableDefs []TableDef
 
-func (node TableDefs) String() string {
-	var prefix string
-	var buf bytes.Buffer
-	for _, n := range node {
-		fmt.Fprintf(&buf, "%s%s", prefix, n)
-		prefix = ", "
+// Format implements the NodeFormatter interface.
+func (node TableDefs) Format(buf *bytes.Buffer, f FmtFlags) {
+	for i, n := range node {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		FormatNode(buf, f, n)
 	}
-	return buf.String()
 }
 
 // Nullability represents either NULL, NOT NULL or an unspecified value (silent
@@ -181,9 +185,10 @@ func (node *ColumnTableDef) setName(name Name) {
 	node.Name = name
 }
 
-func (node *ColumnTableDef) String() string {
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%s %s", node.Name, node.Type)
+// Format implements the NodeFormatter interface.
+func (node *ColumnTableDef) Format(buf *bytes.Buffer, f FmtFlags) {
+	fmt.Fprintf(buf, "%s ", node.Name)
+	FormatNode(buf, f, node.Type)
 	switch node.Nullable {
 	case Null:
 		buf.WriteString(" NULL")
@@ -196,12 +201,14 @@ func (node *ColumnTableDef) String() string {
 		buf.WriteString(" UNIQUE")
 	}
 	if node.DefaultExpr != nil {
-		fmt.Fprintf(&buf, " DEFAULT %s", node.DefaultExpr)
+		buf.WriteString(" DEFAULT ")
+		FormatNode(buf, f, node.DefaultExpr)
 	}
 	if node.CheckExpr != nil {
-		fmt.Fprintf(&buf, " CHECK (%s)", node.CheckExpr)
+		buf.WriteString(" CHECK (")
+		FormatNode(buf, f, node.CheckExpr)
+		buf.WriteByte(')')
 	}
-	return buf.String()
 }
 
 // ColumnQualification represents a constraint on a column.
@@ -260,17 +267,21 @@ func (node *IndexTableDef) setName(name Name) {
 	node.Name = name
 }
 
-func (node *IndexTableDef) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *IndexTableDef) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("INDEX ")
 	if node.Name != "" {
-		fmt.Fprintf(&buf, "%s ", node.Name)
+		FormatNode(buf, f, node.Name)
+		buf.WriteByte(' ')
 	}
-	fmt.Fprintf(&buf, "(%s)", node.Columns)
+	buf.WriteByte('(')
+	FormatNode(buf, f, node.Columns)
+	buf.WriteByte(')')
 	if node.Storing != nil {
-		fmt.Fprintf(&buf, " STORING (%s)", node.Storing)
+		buf.WriteString(" STORING (")
+		FormatNode(buf, f, node.Storing)
+		buf.WriteByte(')')
 	}
-	return buf.String()
 }
 
 // ConstraintTableDef represents a constraint definition within a CREATE TABLE
@@ -291,21 +302,24 @@ type UniqueConstraintTableDef struct {
 	PrimaryKey bool
 }
 
-func (node *UniqueConstraintTableDef) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *UniqueConstraintTableDef) Format(buf *bytes.Buffer, f FmtFlags) {
 	if node.Name != "" {
-		fmt.Fprintf(&buf, "CONSTRAINT %s ", node.Name)
+		fmt.Fprintf(buf, "CONSTRAINT %s ", node.Name)
 	}
 	if node.PrimaryKey {
 		buf.WriteString("PRIMARY KEY ")
 	} else {
 		buf.WriteString("UNIQUE ")
 	}
-	fmt.Fprintf(&buf, "(%s)", node.Columns)
+	buf.WriteByte('(')
+	FormatNode(buf, f, node.Columns)
+	buf.WriteByte(')')
 	if node.Storing != nil {
-		fmt.Fprintf(&buf, " STORING (%s)", node.Storing)
+		buf.WriteString(" STORING (")
+		FormatNode(buf, f, node.Storing)
+		buf.WriteByte(')')
 	}
-	return buf.String()
 }
 
 // CreateTable represents a CREATE TABLE statement.
@@ -315,12 +329,14 @@ type CreateTable struct {
 	Defs        TableDefs
 }
 
-func (node *CreateTable) String() string {
-	var buf bytes.Buffer
-	buf.WriteString("CREATE TABLE")
+// Format implements the NodeFormatter interface.
+func (node *CreateTable) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("CREATE TABLE ")
 	if node.IfNotExists {
-		buf.WriteString(" IF NOT EXISTS")
+		buf.WriteString("IF NOT EXISTS ")
 	}
-	fmt.Fprintf(&buf, " %s (%s)", node.Table, node.Defs)
-	return buf.String()
+	FormatNode(buf, f, node.Table)
+	buf.WriteString(" (")
+	FormatNode(buf, f, node.Defs)
+	buf.WriteByte(')')
 }

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -193,8 +193,9 @@ func (d *DBool) IsMin() bool {
 	return *d == false
 }
 
-func (d *DBool) String() string {
-	return strconv.FormatBool(bool(*d))
+// Format implements the NodeFormatter interface.
+func (d *DBool) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(strconv.FormatBool(bool(*d)))
 }
 
 // DInt is the int Datum.
@@ -274,8 +275,9 @@ func (d *DInt) IsMin() bool {
 	return *d == math.MinInt64
 }
 
-func (d *DInt) String() string {
-	return strconv.FormatInt(int64(*d), 10)
+// Format implements the NodeFormatter interface.
+func (d *DInt) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(strconv.FormatInt(int64(*d), 10))
 }
 
 // DFloat is the float Datum.
@@ -358,22 +360,15 @@ func (d *DFloat) IsMin() bool {
 	return *d <= -math.MaxFloat64
 }
 
-func (d *DFloat) String() string {
-	fmt := byte('g')
-	prec := -1
-	if _, frac := math.Modf(float64(*d)); frac == 0 {
-		// d is a whole number.
-		if -1000000 < *d && *d < 1000000 {
-			// Small whole numbers are printed without exponents, and with one
-			// digit of decimal precision to ensure they will parse as floats.
-			fmt = 'f'
-			prec = 1
-		} else {
-			// Large whole numbers are printed with exponents.
-			fmt = 'e'
-		}
+// Format implements the NodeFormatter interface.
+func (d *DFloat) Format(buf *bytes.Buffer, f FmtFlags) {
+	fl := float64(*d)
+	if _, frac := math.Modf(fl); frac == 0 && -1000000 < *d && *d < 1000000 {
+		// d is a small whole number. Ensure it is printed using a decimal point.
+		fmt.Fprintf(buf, "%.1f", fl)
+	} else {
+		fmt.Fprintf(buf, "%g", fl)
 	}
-	return strconv.FormatFloat(float64(*d), fmt, prec, 64)
 }
 
 // DDecimal is the decimal Datum.
@@ -444,8 +439,9 @@ func (*DDecimal) IsMin() bool {
 	return false
 }
 
-func (d *DDecimal) String() string {
-	return d.Dec.String()
+// Format implements the NodeFormatter interface.
+func (d *DDecimal) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(d.Dec.String())
 }
 
 // DString is the string Datum.
@@ -523,8 +519,9 @@ func (d *DString) IsMin() bool {
 	return len(*d) == 0
 }
 
-func (d *DString) String() string {
-	return encodeSQLString(string(*d))
+// Format implements the NodeFormatter interface.
+func (d *DString) Format(buf *bytes.Buffer, f FmtFlags) {
+	encodeSQLString(buf, string(*d))
 }
 
 // DBytes is the bytes Datum. The underlying type is a string because we want
@@ -602,8 +599,9 @@ func (d *DBytes) IsMin() bool {
 	return len(*d) == 0
 }
 
-func (d *DBytes) String() string {
-	return encodeSQLBytes(string(*d))
+// Format implements the NodeFormatter interface.
+func (d *DBytes) Format(buf *bytes.Buffer, f FmtFlags) {
+	encodeSQLBytes(buf, string(*d))
 }
 
 // DDate is the date Datum represented as the number of days after
@@ -681,8 +679,9 @@ func (d *DDate) IsMin() bool {
 	return *d == math.MinInt64
 }
 
-func (d *DDate) String() string {
-	return time.Unix(int64(*d)*secondsInDay, 0).UTC().Format(dateFormat)
+// Format implements the NodeFormatter interface.
+func (d *DDate) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(time.Unix(int64(*d)*secondsInDay, 0).UTC().Format(dateFormat))
 }
 
 // DTimestamp is the timestamp Datum.
@@ -757,8 +756,9 @@ func (d *DTimestamp) IsMin() bool {
 	return d.Before(d.Add(-1))
 }
 
-func (d *DTimestamp) String() string {
-	return d.UTC().Format(timestampWithOffsetZoneFormat)
+// Format implements the NodeFormatter interface.
+func (d *DTimestamp) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(d.UTC().Format(timestampWithOffsetZoneFormat))
 }
 
 // DTimestampTZ is the timestamp Datum that is rendered with session offset.
@@ -833,8 +833,9 @@ func (d *DTimestampTZ) IsMin() bool {
 	return d.Before(d.Add(-1))
 }
 
-func (d *DTimestampTZ) String() string {
-	return d.UTC().Format(timestampWithOffsetZoneFormat)
+// Format implements the NodeFormatter interface.
+func (d *DTimestampTZ) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(d.UTC().Format(timestampWithOffsetZoneFormat))
 }
 
 // DInterval is the interval Datum.
@@ -901,12 +902,13 @@ func (d *DInterval) IsMin() bool {
 	return d.Months == math.MinInt64 && d.Days == math.MinInt64 && d.Nanos == math.MinInt64
 }
 
-// String implements the Datum interface.
-func (d *DInterval) String() string {
+// Format implements the NodeFormatter interface.
+func (d *DInterval) Format(buf *bytes.Buffer, f FmtFlags) {
 	if d.Months != 0 || d.Days != 0 {
-		return d.Duration.String()
+		buf.WriteString(d.Duration.String())
+	} else {
+		buf.WriteString((time.Duration(d.Duration.Nanos) * time.Nanosecond).String())
 	}
-	return (time.Duration(d.Duration.Nanos) * time.Nanosecond).String()
 }
 
 // DTuple is the tuple Datum.
@@ -1030,17 +1032,16 @@ func (*DTuple) IsMin() bool {
 	return false
 }
 
-func (d *DTuple) String() string {
-	var buf bytes.Buffer
-	_ = buf.WriteByte('(')
+// Format implements the NodeFormatter interface.
+func (d *DTuple) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteByte('(')
 	for i, v := range *d {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		buf.WriteString(v.String())
+		FormatNode(buf, f, v)
 	}
-	_ = buf.WriteByte(')')
-	return buf.String()
+	buf.WriteByte(')')
 }
 
 func (d *DTuple) Len() int {
@@ -1131,8 +1132,9 @@ func (dNull) IsMin() bool {
 	return true
 }
 
-func (dNull) String() string {
-	return "NULL"
+// Format implements the NodeFormatter interface.
+func (dNull) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("NULL")
 }
 
 var _ VariableExpr = &DValArg{}
@@ -1200,8 +1202,10 @@ func (*DValArg) IsMin() bool {
 	return true
 }
 
-func (d *DValArg) String() string {
-	return "$" + d.name
+// Format implements the NodeFormatter interface.
+func (d *DValArg) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteByte('$')
+	buf.WriteString(d.name)
 }
 
 // Temporary workaround for #3633, allowing comparisons between

--- a/sql/parser/delete.go
+++ b/sql/parser/delete.go
@@ -22,7 +22,7 @@
 
 package parser
 
-import "fmt"
+import "bytes"
 
 // Delete represents a DELETE statement.
 type Delete struct {
@@ -31,7 +31,10 @@ type Delete struct {
 	Returning ReturningExprs
 }
 
-func (node *Delete) String() string {
-	return fmt.Sprintf("DELETE FROM %s%s%s",
-		node.Table, node.Where, node.Returning)
+// Format implements the NodeFormatter interface.
+func (node *Delete) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("DELETE FROM ")
+	FormatNode(buf, f, node.Table)
+	FormatNode(buf, f, node.Where)
+	FormatNode(buf, f, node.Returning)
 }

--- a/sql/parser/drop.go
+++ b/sql/parser/drop.go
@@ -22,10 +22,7 @@
 
 package parser
 
-import (
-	"bytes"
-	"fmt"
-)
+import "bytes"
 
 // DropBehavior represents options for dropping schema elements.
 type DropBehavior int
@@ -53,14 +50,13 @@ type DropDatabase struct {
 	IfExists bool
 }
 
-func (node *DropDatabase) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *DropDatabase) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("DROP DATABASE ")
 	if node.IfExists {
 		buf.WriteString("IF EXISTS ")
 	}
-	buf.WriteString(node.Name.String())
-	return buf.String()
+	FormatNode(buf, f, node.Name)
 }
 
 // DropIndex represents a DROP INDEX statement.
@@ -70,17 +66,17 @@ type DropIndex struct {
 	DropBehavior DropBehavior
 }
 
-func (node *DropIndex) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *DropIndex) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("DROP INDEX ")
 	if node.IfExists {
 		buf.WriteString("IF EXISTS ")
 	}
-	buf.WriteString(node.IndexList.String())
+	FormatNode(buf, f, node.IndexList)
 	if node.DropBehavior != DropDefault {
-		fmt.Fprintf(&buf, " %s", node.DropBehavior)
+		buf.WriteByte(' ')
+		buf.WriteString(node.DropBehavior.String())
 	}
-	return buf.String()
 }
 
 // DropTable represents a DROP TABLE statement.
@@ -89,12 +85,11 @@ type DropTable struct {
 	IfExists bool
 }
 
-func (node *DropTable) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *DropTable) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("DROP TABLE ")
 	if node.IfExists {
 		buf.WriteString("IF EXISTS ")
 	}
-	buf.WriteString(node.Names.String())
-	return buf.String()
+	FormatNode(buf, f, node.Names)
 }

--- a/sql/parser/encode.go
+++ b/sql/parser/encode.go
@@ -23,6 +23,7 @@
 package parser
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 )
@@ -34,77 +35,78 @@ var (
 	hexMap    [256][]byte
 )
 
-func encodeSQLString(in string) string {
+func encodeSQLString(buf *bytes.Buffer, in string) {
 	// See http://www.postgresql.org/docs/9.4/static/sql-syntax-lexical.html
 	start := 0
-	buf := make([]byte, 0, len(in)+3)
 	for i := range in {
 		ch := in[i]
 		if encodedChar := encodeMap[ch]; encodedChar != dontEscape {
 			if start == 0 {
-				buf = append(buf, 'e', '\'') // begin e'xxx' string
+				buf.WriteString("e'") // begin e'xxx' string
 			}
-			buf = append(buf, in[start:i]...)
-			buf = append(buf, '\\', encodedChar)
+			buf.WriteString(in[start:i])
+			buf.WriteByte('\\')
+			buf.WriteByte(encodedChar)
 			start = i + 1
 		}
 	}
 	if start == 0 {
-		buf = append(buf, '\'') // begin 'xxx' string if nothing was escaped
+		buf.WriteByte('\'') // begin 'xxx' string if nothing was escaped
 	}
-	buf = append(buf, in[start:]...)
-	buf = append(buf, '\'')
-	return string(buf)
+	buf.WriteString(in[start:])
+	buf.WriteByte('\'')
 }
 
-func encodeSQLIdent(s string) string {
+func encodeSQLIdent(buf *bytes.Buffer, s string) {
 	if _, ok := reservedKeywords[strings.ToUpper(s)]; ok {
-		return fmt.Sprintf("\"%s\"", s)
+		buf.WriteString(`"`)
+		buf.WriteString(s)
+		buf.WriteString(`"`)
+		return
 	}
 	// The string needs quoting if it does not match the ident format.
 	if isIdent(s) {
-		return s
+		buf.WriteString(s)
+		return
 	}
 
 	// The only character that requires escaping is a double quote.
-	buf := make([]byte, 0, len(s)+2)
-	buf = append(buf, '"')
+	buf.WriteString(`"`)
 	start := 0
 	for i, n := 0, len(s); i < n; i++ {
 		ch := s[i]
 		if ch == '"' {
 			if start != i {
-				buf = append(buf, s[start:i]...)
+				buf.WriteString(s[start:i])
 			}
 			start = i + 1
-			buf = append(buf, ch, ch) // add extra copy of ch
+			buf.WriteByte(ch)
+			buf.WriteByte(ch) // add extra copy of ch
 		}
 	}
 	if start < len(s) {
-		buf = append(buf, s[start:]...)
+		buf.WriteString(s[start:])
 	}
-	buf = append(buf, '"')
-	return string(buf)
+	buf.WriteString(`"`)
 }
 
-func encodeSQLBytes(in string) string {
+func encodeSQLBytes(buf *bytes.Buffer, in string) {
 	start := 0
-	buf := make([]byte, 0, len(in)+3)
-	buf = append(buf, "b'"...)
+	buf.WriteString("b'")
 	for i := range in {
 		ch := in[i]
 		if encodedChar := encodeMap[ch]; encodedChar != dontEscape {
-			buf = append(buf, in[start:i]...)
-			buf = append(buf, '\\', encodedChar)
+			buf.WriteString(in[start:i])
+			buf.WriteByte('\\')
+			buf.WriteByte(encodedChar)
 			start = i + 1
 		} else if ch >= 0x80 {
-			buf = append(buf, hexMap[ch]...)
+			buf.Write(hexMap[ch])
 			start = i + 1
 		}
 	}
-	buf = append(buf, in[start:]...)
-	buf = append(buf, '\'')
-	return string(buf)
+	buf.WriteString(in[start:])
+	buf.WriteByte('\'')
 }
 
 func init() {

--- a/sql/parser/explain.go
+++ b/sql/parser/explain.go
@@ -16,10 +16,7 @@
 
 package parser
 
-import (
-	"fmt"
-	"strings"
-)
+import "bytes"
 
 // Explain represents an EXPLAIN statement.
 type Explain struct {
@@ -27,10 +24,18 @@ type Explain struct {
 	Statement Statement
 }
 
-func (node *Explain) String() string {
+// Format implements the NodeFormatter interface.
+func (node *Explain) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("EXPLAIN ")
 	if len(node.Options) > 0 {
-		return fmt.Sprintf("EXPLAIN (%s) %s",
-			strings.Join(node.Options, ", "), node.Statement)
+		buf.WriteByte('(')
+		for i, opt := range node.Options {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(opt)
+		}
+		buf.WriteString(") ")
 	}
-	return fmt.Sprintf("EXPLAIN %s", node.Statement)
+	FormatNode(buf, f, node.Statement)
 }

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -24,6 +24,7 @@ import (
 // Expr represents an expression.
 type Expr interface {
 	fmt.Stringer
+	NodeFormatter
 	// Walk recursively walks all children using WalkExpr. If any children are changed, it returns a
 	// copy of this node updated to point to the new children. Otherwise the receiver is returned.
 	// For childless (leaf) Exprs, its implementation is empty.
@@ -81,15 +82,18 @@ var _ operatorExpr = &ComparisonExpr{}
 var _ operatorExpr = &RangeCond{}
 var _ operatorExpr = &IsOfTypeExpr{}
 
-// exprStrWithParen is a variant of e.String() which adds a set of outer parens
+// exprFmtWithParen is a variant of Format() which adds a set of outer parens
 // if the expression involves an operator. It is used internally when the
 // expression is part of another expression and we know it is preceded or
 // followed by an operator.
-func exprStrWithParen(e Expr) string {
+func exprFmtWithParen(buf *bytes.Buffer, f FmtFlags, e Expr) {
 	if _, ok := e.(operatorExpr); ok {
-		return fmt.Sprintf("(%s)", e)
+		buf.WriteByte('(')
+		FormatNode(buf, f, e)
+		buf.WriteByte(')')
+	} else {
+		FormatNode(buf, f, e)
 	}
-	return e.String()
 }
 
 // typeAnnotation is an embeddable struct to provide a TypedExpr with a dynamic
@@ -119,8 +123,17 @@ type AndExpr struct {
 
 func (*AndExpr) operatorExpr() {}
 
-func (node *AndExpr) String() string {
-	return fmt.Sprintf("%s AND %s", exprStrWithParen(node.Left), exprStrWithParen(node.Right))
+func binExprFmtWithParen(buf *bytes.Buffer, f FmtFlags, e1 Expr, op string, e2 Expr) {
+	exprFmtWithParen(buf, f, e1)
+	buf.WriteByte(' ')
+	buf.WriteString(op)
+	buf.WriteByte(' ')
+	exprFmtWithParen(buf, f, e2)
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AndExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	binExprFmtWithParen(buf, f, node.Left, "AND", node.Right)
 }
 
 // NewTypedAndExpr returns a new AndExpr that is verified to be well-typed.
@@ -149,8 +162,9 @@ type OrExpr struct {
 
 func (*OrExpr) operatorExpr() {}
 
-func (node *OrExpr) String() string {
-	return fmt.Sprintf("%s OR %s", exprStrWithParen(node.Left), exprStrWithParen(node.Right))
+// Format implements the NodeFormatter interface.
+func (node *OrExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	binExprFmtWithParen(buf, f, node.Left, "OR", node.Right)
 }
 
 // NewTypedOrExpr returns a new OrExpr that is verified to be well-typed.
@@ -179,8 +193,10 @@ type NotExpr struct {
 
 func (*NotExpr) operatorExpr() {}
 
-func (node *NotExpr) String() string {
-	return fmt.Sprintf("NOT %s", exprStrWithParen(node.Expr))
+// Format implements the NodeFormatter interface.
+func (node *NotExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("NOT ")
+	exprFmtWithParen(buf, f, node.Expr)
 }
 
 // NewTypedNotExpr returns a new NotExpr that is verified to be well-typed.
@@ -202,8 +218,11 @@ type ParenExpr struct {
 	typeAnnotation
 }
 
-func (node *ParenExpr) String() string {
-	return fmt.Sprintf("(%s)", node.Expr)
+// Format implements the NodeFormatter interface.
+func (node *ParenExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteByte('(')
+	FormatNode(buf, f, node.Expr)
+	buf.WriteByte(')')
 }
 
 // TypedInnerExpr returns the ParenExpr's inner expression as a TypedExpr.
@@ -271,9 +290,9 @@ type ComparisonExpr struct {
 
 func (*ComparisonExpr) operatorExpr() {}
 
-func (node *ComparisonExpr) String() string {
-	return fmt.Sprintf("%s %s %s", exprStrWithParen(node.Left), node.Operator,
-		exprStrWithParen(node.Right))
+// Format implements the NodeFormatter interface.
+func (node *ComparisonExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	binExprFmtWithParen(buf, f, node.Left, node.Operator.String(), node.Right)
 }
 
 // NewTypedComparisonExpr returns a new ComparisonExpr that is verified to be well-typed.
@@ -304,13 +323,15 @@ type RangeCond struct {
 
 func (*RangeCond) operatorExpr() {}
 
-func (node *RangeCond) String() string {
-	notStr := ""
+// Format implements the NodeFormatter interface.
+func (node *RangeCond) Format(buf *bytes.Buffer, f FmtFlags) {
+	notStr := " BETWEEN "
 	if node.Not {
-		notStr = "NOT "
+		notStr = " NOT BETWEEN "
 	}
-	return fmt.Sprintf("%s %sBETWEEN %s AND %s", exprStrWithParen(node.Left), notStr,
-		exprStrWithParen(node.From), exprStrWithParen(node.To))
+	exprFmtWithParen(buf, f, node.Left)
+	buf.WriteString(notStr)
+	binExprFmtWithParen(buf, f, node.From, "AND", node.To)
 }
 
 // TypedLeft returns the RangeCond's left expression as a TypedExpr.
@@ -339,9 +360,9 @@ type IsOfTypeExpr struct {
 
 func (*IsOfTypeExpr) operatorExpr() {}
 
-func (node *IsOfTypeExpr) String() string {
-	var buf bytes.Buffer
-	buf.WriteString(node.Expr.String())
+// Format implements the NodeFormatter interface.
+func (node *IsOfTypeExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	FormatNode(buf, f, node.Expr)
 	buf.WriteString(" IS")
 	if node.Not {
 		buf.WriteString(" NOT")
@@ -351,10 +372,9 @@ func (node *IsOfTypeExpr) String() string {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		buf.WriteString(t.String())
+		FormatNode(buf, f, t)
 	}
-	buf.WriteString(")")
-	return buf.String()
+	buf.WriteByte(')')
 }
 
 // ExistsExpr represents an EXISTS expression.
@@ -364,8 +384,10 @@ type ExistsExpr struct {
 	typeAnnotation
 }
 
-func (node *ExistsExpr) String() string {
-	return fmt.Sprintf("EXISTS %s", exprStrWithParen(node.Subquery))
+// Format implements the NodeFormatter interface.
+func (node *ExistsExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("EXISTS ")
+	exprFmtWithParen(buf, f, node.Subquery)
 }
 
 // IfExpr represents an IF expression.
@@ -377,8 +399,15 @@ type IfExpr struct {
 	typeAnnotation
 }
 
-func (node *IfExpr) String() string {
-	return fmt.Sprintf("IF(%s, %s, %s)", node.Cond, node.True, node.Else)
+// Format implements the NodeFormatter interface.
+func (node *IfExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("IF(")
+	FormatNode(buf, f, node.Cond)
+	buf.WriteString(", ")
+	FormatNode(buf, f, node.True)
+	buf.WriteString(", ")
+	FormatNode(buf, f, node.Else)
+	buf.WriteByte(')')
 }
 
 // NullIfExpr represents a NULLIF expression.
@@ -389,8 +418,13 @@ type NullIfExpr struct {
 	typeAnnotation
 }
 
-func (node *NullIfExpr) String() string {
-	return fmt.Sprintf("NULLIF(%s, %s)", node.Expr1, node.Expr2)
+// Format implements the NodeFormatter interface.
+func (node *NullIfExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("NULLIF(")
+	FormatNode(buf, f, node.Expr1)
+	buf.WriteString(", ")
+	FormatNode(buf, f, node.Expr2)
+	buf.WriteByte(')')
 }
 
 // CoalesceExpr represents a COALESCE or IFNULL expression.
@@ -401,15 +435,20 @@ type CoalesceExpr struct {
 	typeAnnotation
 }
 
-func (node *CoalesceExpr) String() string {
-	return fmt.Sprintf("%s(%s)", node.Name, node.Exprs)
+// Format implements the NodeFormatter interface.
+func (node *CoalesceExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(node.Name)
+	buf.WriteByte('(')
+	FormatNode(buf, f, node.Exprs)
+	buf.WriteByte(')')
 }
 
 // DefaultVal represents the DEFAULT expression.
 type DefaultVal struct{}
 
-func (node DefaultVal) String() string {
-	return "DEFAULT"
+// Format implements the NodeFormatter interface.
+func (node DefaultVal) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("DEFAULT")
 }
 
 // ReturnType implements the TypedExpr interface.
@@ -425,8 +464,10 @@ type ValArg struct {
 // Variable implements the VariableExpr interface.
 func (ValArg) Variable() {}
 
-func (node ValArg) String() string {
-	return fmt.Sprintf("$%s", node.Name)
+// Format implements the NodeFormatter interface.
+func (node ValArg) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteByte('$')
+	buf.WriteString(node.Name)
 }
 
 type nameType int
@@ -473,21 +514,21 @@ func StarExpr() *QualifiedName {
 // On successful normalization, the qualified name will have the form:
 //
 //   database.table@index
-func (n *QualifiedName) NormalizeTableName(database string) error {
-	if n == nil || n.Base == "" {
-		return fmt.Errorf("empty table name: %s", n)
+func (node *QualifiedName) NormalizeTableName(database string) error {
+	if node == nil || node.Base == "" {
+		return fmt.Errorf("empty table name: %s", node)
 	}
-	if n.normalized == columnName {
-		return fmt.Errorf("already normalized as a column name: %s", n)
+	if node.normalized == columnName {
+		return fmt.Errorf("already normalized as a column name: %s", node)
 	}
-	if err := n.QualifyWithDatabase(database); err != nil {
+	if err := node.QualifyWithDatabase(database); err != nil {
 		return err
 	}
 
-	if len(n.Indirect) > 1 {
-		return fmt.Errorf("invalid table name: %s", n)
+	if len(node.Indirect) > 1 {
+		return fmt.Errorf("invalid table name: %s", node)
 	}
-	n.normalized = tableName
+	node.normalized = tableName
 	return nil
 }
 
@@ -496,37 +537,37 @@ func (n *QualifiedName) NormalizeTableName(database string) error {
 // table       -> database.table
 // table@index -> database.table@index
 // *           -> database.*
-func (n *QualifiedName) QualifyWithDatabase(database string) error {
-	n.setString()
-	if len(n.Indirect) == 0 {
+func (node *QualifiedName) QualifyWithDatabase(database string) error {
+	node.setString()
+	if len(node.Indirect) == 0 {
 		if database == "" {
-			return fmt.Errorf("no database specified: %s", n)
+			return fmt.Errorf("no database specified: %s", node)
 		}
 		// table -> database.table
 		if database == "" {
-			return fmt.Errorf("no database specified: %s", n)
+			return fmt.Errorf("no database specified: %s", node)
 		}
-		n.Indirect = append(n.Indirect, NameIndirection(n.Base))
-		n.Base = Name(database)
-		n.normalized = tableName
+		node.Indirect = append(node.Indirect, NameIndirection(node.Base))
+		node.Base = Name(database)
+		node.normalized = tableName
 		return nil
 	}
-	switch n.Indirect[0].(type) {
+	switch node.Indirect[0].(type) {
 	case NameIndirection:
 		// Nothing to do.
 	case StarIndirection:
 		// * -> database.*
-		if n.Base != "" {
+		if node.Base != "" {
 			// nothing to do
 			return nil
 		}
-		if n.Base != "" {
-			n.Indirect = append(Indirection{NameIndirection(n.Base)}, n.Indirect...)
+		if node.Base != "" {
+			node.Indirect = append(Indirection{NameIndirection(node.Base)}, node.Indirect...)
 		}
 		if database == "" {
-			return fmt.Errorf("no database specified: %s", n)
+			return fmt.Errorf("no database specified: %s", node)
 		}
-		n.Base = Name(database)
+		node.Base = Name(database)
 	}
 	return nil
 }
@@ -551,93 +592,93 @@ func (n *QualifiedName) QualifyWithDatabase(database string) error {
 //   table.*
 //   table.column
 //   table.column[array-indirection]
-func (n *QualifiedName) NormalizeColumnName() error {
-	if n == nil {
-		return fmt.Errorf("empty column name: %s", n)
+func (node *QualifiedName) NormalizeColumnName() error {
+	if node == nil {
+		return fmt.Errorf("empty column name: %s", node)
 	}
-	if n.normalized == tableName {
-		return fmt.Errorf("already normalized as a table name: %s", n)
+	if node.normalized == tableName {
+		return fmt.Errorf("already normalized as a table name: %s", node)
 	}
-	n.setString()
-	if len(n.Indirect) == 0 {
+	node.setString()
+	if len(node.Indirect) == 0 {
 		// column -> table.column
-		if n.Base == "" {
-			return fmt.Errorf("empty column name: %s", n)
+		if node.Base == "" {
+			return fmt.Errorf("empty column name: %s", node)
 		}
-		n.Indirect = append(n.Indirect, NameIndirection(n.Base))
-		n.Base = ""
-		n.normalized = columnName
+		node.Indirect = append(node.Indirect, NameIndirection(node.Base))
+		node.Base = ""
+		node.normalized = columnName
 		return nil
 	}
-	if len(n.Indirect) > 2 {
-		return fmt.Errorf("invalid column name: %s", n)
+	if len(node.Indirect) > 2 {
+		return fmt.Errorf("invalid column name: %s", node)
 	}
 	// Either table.column, table.*, column[array-indirection] or
 	// table.column[array-indirection].
-	switch n.Indirect[0].(type) {
+	switch node.Indirect[0].(type) {
 	case NameIndirection:
 		// Nothing to do.
 	case StarIndirection:
-		n.Indirect[0] = qualifiedStar
+		node.Indirect[0] = qualifiedStar
 	case *ArrayIndirection:
 		// column[array-indirection] -> "".column[array-indirection]
 		//
-		// Accomplished by prepending n.Base to the existing indirection and then
-		// clearing n.Base.
-		n.Indirect = append(Indirection{NameIndirection(n.Base)}, n.Indirect...)
-		n.Base = ""
+		// Accomplished by prepending node.Base to the existing indirection and then
+		// clearing node.Base.
+		node.Indirect = append(Indirection{NameIndirection(node.Base)}, node.Indirect...)
+		node.Base = ""
 	default:
-		return fmt.Errorf("invalid column name: %s", n)
+		return fmt.Errorf("invalid column name: %s", node)
 	}
-	if len(n.Indirect) == 2 {
-		if _, ok := n.Indirect[1].(*ArrayIndirection); !ok {
-			return fmt.Errorf("invalid column name: %s", n)
+	if len(node.Indirect) == 2 {
+		if _, ok := node.Indirect[1].(*ArrayIndirection); !ok {
+			return fmt.Errorf("invalid column name: %s", node)
 		}
 	}
-	n.normalized = columnName
+	node.normalized = columnName
 	return nil
 }
 
 // Database returns the database portion of the name. Note that the returned
 // string is not quoted even if the name is a keyword.
-func (n *QualifiedName) Database() string {
-	if n.normalized != tableName {
-		panic(fmt.Sprintf("%s is not a table name", n))
+func (node *QualifiedName) Database() string {
+	if node.normalized != tableName {
+		panic(fmt.Sprintf("%s is not a table name", node))
 	}
 	// The database portion of the name is n.Base.
-	return string(n.Base)
+	return string(node.Base)
 }
 
 // Table returns the table portion of the name. Note that the returned string
 // is not quoted even if the name is a keyword.
-func (n *QualifiedName) Table() string {
-	if n.normalized != tableName && n.normalized != columnName {
-		panic(fmt.Sprintf("%s is not a table or column name", n))
+func (node *QualifiedName) Table() string {
+	if node.normalized != tableName && node.normalized != columnName {
+		panic(fmt.Sprintf("%s is not a table or column name", node))
 	}
-	if n.normalized == tableName {
-		return string(n.Indirect[0].(NameIndirection))
+	if node.normalized == tableName {
+		return string(node.Indirect[0].(NameIndirection))
 	}
-	return string(n.Base)
+	return string(node.Base)
 }
 
 // Column returns the column portion of the name. Note that the returned string
 // is not quoted even if the name is a keyword.
-func (n *QualifiedName) Column() string {
-	if n.normalized != columnName {
-		panic(fmt.Sprintf("%s is not a column name", n))
+func (node *QualifiedName) Column() string {
+	if node.normalized != columnName {
+		panic(fmt.Sprintf("%s is not a column name", node))
 	}
-	return string(n.Indirect[0].(NameIndirection))
+	return string(node.Indirect[0].(NameIndirection))
 }
 
 // IsStar returns true iff the qualified name contains matches "".* or table.*.
-func (n *QualifiedName) IsStar() bool {
-	if n.normalized != columnName {
-		panic(fmt.Sprintf("%s is not a column name", n))
+func (node *QualifiedName) IsStar() bool {
+	if node.normalized != columnName {
+		panic(fmt.Sprintf("%s is not a column name", node))
 	}
-	if len(n.Indirect) != 1 {
+	if len(node.Indirect) != 1 {
 		return false
 	}
-	if _, ok := n.Indirect[0].(StarIndirection); !ok {
+	if _, ok := node.Indirect[0].(StarIndirection); !ok {
 		return false
 	}
 	return true
@@ -645,40 +686,43 @@ func (n *QualifiedName) IsStar() bool {
 
 // ClearString causes String to return the current (possibly normalized) name instead of the
 // original name (used for testing).
-func (n *QualifiedName) ClearString() {
-	n.origString = ""
+func (node *QualifiedName) ClearString() {
+	node.origString = ""
 }
 
-func (n *QualifiedName) setString() {
+func (node *QualifiedName) setString() {
 	// We preserve the representation pre-normalization.
-	if n.origString != "" {
+	if node.origString != "" {
 		return
 	}
-	if n.Base == "" && len(n.Indirect) == 1 && n.Indirect[0] == unqualifiedStar {
-		n.origString = n.Indirect[0].String()
+	var buf bytes.Buffer
+	if node.Base == "" && len(node.Indirect) == 1 && node.Indirect[0] == unqualifiedStar {
+		FormatNode(&buf, FmtSimple, node.Indirect[0])
 	} else {
-		n.origString = fmt.Sprintf("%s%s", n.Base, n.Indirect)
+		FormatNode(&buf, FmtSimple, node.Base)
+		FormatNode(&buf, FmtSimple, node.Indirect)
 	}
+	node.origString = buf.String()
 }
 
-func (n *QualifiedName) String() string {
-	n.setString()
-	return n.origString
+// Format implements the NodeFormatter interface.
+func (node *QualifiedName) Format(buf *bytes.Buffer, f FmtFlags) {
+	node.setString()
+	buf.WriteString(node.origString)
 }
 
 // QualifiedNames represents a command separated list (see the String method)
 // of qualified names.
 type QualifiedNames []*QualifiedName
 
-func (n QualifiedNames) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (n QualifiedNames) Format(buf *bytes.Buffer, f FmtFlags) {
 	for i, e := range n {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		buf.WriteString(e.String())
+		FormatNode(buf, f, e)
 	}
-	return buf.String()
 }
 
 // TableNameWithIndex represents a "table@index", used in statements that
@@ -688,22 +732,24 @@ type TableNameWithIndex struct {
 	Index Name
 }
 
-func (n *TableNameWithIndex) String() string {
-	return fmt.Sprintf("%s@%s", n.Table, n.Index)
+// Format implements the NodeFormatter interface.
+func (n *TableNameWithIndex) Format(buf *bytes.Buffer, f FmtFlags) {
+	FormatNode(buf, f, n.Table)
+	buf.WriteByte('@')
+	FormatNode(buf, f, n.Index)
 }
 
 // TableNameWithIndexList is a list of indexes.
 type TableNameWithIndexList []*TableNameWithIndex
 
-func (n TableNameWithIndexList) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (n TableNameWithIndexList) Format(buf *bytes.Buffer, f FmtFlags) {
 	for i, e := range n {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		buf.WriteString(e.String())
+		FormatNode(buf, f, e)
 	}
-	return buf.String()
 }
 
 // Tuple represents a parenthesized list of expressions.
@@ -713,8 +759,11 @@ type Tuple struct {
 	types DTuple
 }
 
-func (node *Tuple) String() string {
-	return fmt.Sprintf("(%s)", node.Exprs)
+// Format implements the NodeFormatter interface.
+func (node *Tuple) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteByte('(')
+	FormatNode(buf, f, node.Exprs)
+	buf.WriteByte(')')
 }
 
 // ReturnType implements the TypedExpr interface.
@@ -730,8 +779,11 @@ type Row struct {
 	types DTuple
 }
 
-func (node *Row) String() string {
-	return fmt.Sprintf("ROW(%s)", node.Exprs)
+// Format implements the NodeFormatter interface.
+func (node *Row) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("ROW(")
+	FormatNode(buf, f, node.Exprs)
+	buf.WriteByte(')')
 }
 
 // ReturnType implements the TypedExpr interface.
@@ -744,22 +796,25 @@ type Array struct {
 	Exprs Exprs
 }
 
-func (node *Array) String() string {
-	return fmt.Sprintf("ARRAY[%s]", node.Exprs)
+// Format implements the NodeFormatter interface.
+func (node *Array) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("ARRAY[")
+	FormatNode(buf, f, node.Exprs)
+	buf.WriteByte(']')
 }
 
 // Exprs represents a list of value expressions. It's not a valid expression
 // because it's not parenthesized.
 type Exprs []Expr
 
-func (node Exprs) String() string {
-	var prefix string
-	var buf bytes.Buffer
-	for _, n := range node {
-		fmt.Fprintf(&buf, "%s%s", prefix, n)
-		prefix = ", "
+// Format implements the NodeFormatter interface.
+func (node Exprs) Format(buf *bytes.Buffer, f FmtFlags) {
+	for i, n := range node {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		FormatNode(buf, f, n)
 	}
-	return buf.String()
 }
 
 // TypedExprs represents a list of well-typed value expressions. It's not a valid expression
@@ -781,8 +836,9 @@ type Subquery struct {
 	Select SelectStatement
 }
 
-func (node *Subquery) String() string {
-	return node.Select.String()
+// Format implements the NodeFormatter interface.
+func (node *Subquery) Format(buf *bytes.Buffer, f FmtFlags) {
+	FormatNode(buf, f, node.Select)
 }
 
 // ReturnType implements the TypedExpr interface.
@@ -840,9 +896,9 @@ type BinaryExpr struct {
 
 func (*BinaryExpr) operatorExpr() {}
 
-func (node *BinaryExpr) String() string {
-	return fmt.Sprintf("%s %s %s", exprStrWithParen(node.Left), node.Operator,
-		exprStrWithParen(node.Right))
+// Format implements the NodeFormatter interface.
+func (node *BinaryExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	binExprFmtWithParen(buf, f, node.Left, node.Operator.String(), node.Right)
 }
 
 // UnaryOperator represents a unary operator.
@@ -879,8 +935,11 @@ type UnaryExpr struct {
 
 func (*UnaryExpr) operatorExpr() {}
 
-func (node *UnaryExpr) String() string {
-	return fmt.Sprintf("%s %s", node.Operator, exprStrWithParen(node.Expr))
+// Format implements the NodeFormatter interface.
+func (node *UnaryExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(node.Operator.String())
+	buf.WriteByte(' ')
+	exprFmtWithParen(buf, f, node.Expr)
 }
 
 // FuncExpr represents a function call.
@@ -907,12 +966,17 @@ var funcTypeName = [...]string{
 	All:      "ALL",
 }
 
-func (node *FuncExpr) String() string {
+// Format implements the NodeFormatter interface.
+func (node *FuncExpr) Format(buf *bytes.Buffer, f FmtFlags) {
 	var typ string
 	if node.Type != 0 {
 		typ = funcTypeName[node.Type] + " "
 	}
-	return fmt.Sprintf("%s(%s%s)", node.Name, typ, node.Exprs)
+	FormatNode(buf, f, node.Name)
+	buf.WriteByte('(')
+	buf.WriteString(typ)
+	FormatNode(buf, f, node.Exprs)
+	buf.WriteByte(')')
 }
 
 // OverlayExpr represents an overlay function call.
@@ -920,12 +984,20 @@ type OverlayExpr struct {
 	FuncExpr
 }
 
-func (node *OverlayExpr) String() string {
-	var f string
+// Format implements the NodeFormatter interface.
+func (node *OverlayExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	FormatNode(buf, f, node.Name)
+	buf.WriteByte('(')
+	FormatNode(buf, f, node.Exprs[0])
+	buf.WriteString(" PLACING ")
+	FormatNode(buf, f, node.Exprs[1])
+	buf.WriteString(" FROM ")
+	FormatNode(buf, f, node.Exprs[2])
 	if len(node.Exprs) == 4 {
-		f = fmt.Sprintf(" FOR %s", node.Exprs[3])
+		buf.WriteString(" FOR ")
+		FormatNode(buf, f, node.Exprs[3])
 	}
-	return fmt.Sprintf("%s(%s PLACING %s FROM %s%s)", node.Name, node.Exprs[0], node.Exprs[1], node.Exprs[2], f)
+	buf.WriteByte(')')
 }
 
 // CaseExpr represents a CASE expression.
@@ -937,20 +1009,23 @@ type CaseExpr struct {
 	typeAnnotation
 }
 
-func (node *CaseExpr) String() string {
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "CASE ")
+// Format implements the NodeFormatter interface.
+func (node *CaseExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("CASE ")
 	if node.Expr != nil {
-		fmt.Fprintf(&buf, "%s ", node.Expr)
+		FormatNode(buf, f, node.Expr)
+		buf.WriteByte(' ')
 	}
 	for _, when := range node.Whens {
-		fmt.Fprintf(&buf, "%s ", when)
+		FormatNode(buf, f, when)
+		buf.WriteByte(' ')
 	}
 	if node.Else != nil {
-		fmt.Fprintf(&buf, "ELSE %s ", node.Else)
+		buf.WriteString("ELSE ")
+		FormatNode(buf, f, node.Else)
+		buf.WriteByte(' ')
 	}
-	fmt.Fprintf(&buf, "END")
-	return buf.String()
+	buf.WriteString("END")
 }
 
 // When represents a WHEN sub-expression.
@@ -959,8 +1034,12 @@ type When struct {
 	Val  Expr
 }
 
-func (node *When) String() string {
-	return fmt.Sprintf("WHEN %s THEN %s", node.Cond, node.Val)
+// Format implements the NodeFormatter interface.
+func (node *When) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("WHEN ")
+	FormatNode(buf, f, node.Cond)
+	buf.WriteString(" THEN ")
+	FormatNode(buf, f, node.Val)
 }
 
 // CastExpr represents a CAST(expr AS type) expression.
@@ -971,6 +1050,58 @@ type CastExpr struct {
 	typeAnnotation
 }
 
-func (n *CastExpr) String() string {
-	return fmt.Sprintf("CAST(%s AS %s)", n.Expr, n.Type)
+// Format implements the NodeFormatter interface.
+func (node *CastExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("CAST(")
+	FormatNode(buf, f, node.Expr)
+	buf.WriteString(" AS ")
+	FormatNode(buf, f, node.Type)
+	buf.WriteByte(')')
 }
+
+func (node *AliasedTableExpr) String() string { return AsString(node) }
+func (node *ParenTableExpr) String() string   { return AsString(node) }
+func (node *JoinTableExpr) String() string    { return AsString(node) }
+func (node *AndExpr) String() string          { return AsString(node) }
+func (node *Array) String() string            { return AsString(node) }
+func (node *BinaryExpr) String() string       { return AsString(node) }
+func (node *CaseExpr) String() string         { return AsString(node) }
+func (node *CastExpr) String() string         { return AsString(node) }
+func (node *CoalesceExpr) String() string     { return AsString(node) }
+func (node *ComparisonExpr) String() string   { return AsString(node) }
+func (node *DBool) String() string            { return AsString(node) }
+func (node *DBytes) String() string           { return AsString(node) }
+func (node *DDate) String() string            { return AsString(node) }
+func (node *DDecimal) String() string         { return AsString(node) }
+func (node *DFloat) String() string           { return AsString(node) }
+func (node *DInt) String() string             { return AsString(node) }
+func (node *DInterval) String() string        { return AsString(node) }
+func (node *DString) String() string          { return AsString(node) }
+func (node *DTimestamp) String() string       { return AsString(node) }
+func (node *DTimestampTZ) String() string     { return AsString(node) }
+func (node *DTuple) String() string           { return AsString(node) }
+func (node *DValArg) String() string          { return AsString(node) }
+func (node *ExistsExpr) String() string       { return AsString(node) }
+func (node Exprs) String() string             { return AsString(node) }
+func (node *FuncExpr) String() string         { return AsString(node) }
+func (node *IfExpr) String() string           { return AsString(node) }
+func (node *IndexedVar) String() string       { return AsString(node) }
+func (node *IsOfTypeExpr) String() string     { return AsString(node) }
+func (node Name) String() string              { return AsString(node) }
+func (node *NotExpr) String() string          { return AsString(node) }
+func (node *NullIfExpr) String() string       { return AsString(node) }
+func (node *NumVal) String() string           { return AsString(node) }
+func (node *OrExpr) String() string           { return AsString(node) }
+func (node *OverlayExpr) String() string      { return AsString(node) }
+func (node *ParenExpr) String() string        { return AsString(node) }
+func (node *QualifiedName) String() string    { return AsString(node) }
+func (node *RangeCond) String() string        { return AsString(node) }
+func (node *Row) String() string              { return AsString(node) }
+func (node *StrVal) String() string           { return AsString(node) }
+func (node *Subquery) String() string         { return AsString(node) }
+func (node *Tuple) String() string            { return AsString(node) }
+func (node *UnaryExpr) String() string        { return AsString(node) }
+func (node DefaultVal) String() string        { return AsString(node) }
+func (node ValArg) String() string            { return AsString(node) }
+func (node dNull) String() string             { return AsString(node) }
+func (list NameList) String() string          { return AsString(list) }

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -972,7 +972,12 @@ func (node *FuncExpr) Format(buf *bytes.Buffer, f FmtFlags) {
 	if node.Type != 0 {
 		typ = funcTypeName[node.Type] + " "
 	}
-	FormatNode(buf, f, node.Name)
+	// TODO(nvanbenschoten) We should probably either remove
+	// *QualifiedName as a TypedExpr or special case it in
+	// FormatNode. The reason it's a TypedExpr in the first place is for
+	// testing (I believe), but this doesn't seem like a good enough
+	// reason to justify the strangeness.
+	buf.WriteString(node.Name.String())
 	buf.WriteByte('(')
 	buf.WriteString(typ)
 	FormatNode(buf, f, node.Exprs)

--- a/sql/parser/format.go
+++ b/sql/parser/format.go
@@ -1,0 +1,54 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package parser
+
+import "bytes"
+
+type fmtFlags struct{}
+
+// FmtFlags enables conditional formatting in the pretty-printer.
+type FmtFlags *fmtFlags
+
+// FmtSimple instructs the pretty-printer to produce
+// a straightforward representation, ideally using SQL
+// syntax that makes prettyprint+parse idempotent.
+var FmtSimple = &fmtFlags{}
+
+// NodeFormatter is implemented by nodes that can be pretty-printed.
+type NodeFormatter interface {
+	// Format performs pretty-printing towards a bytes buffer. The
+	// flags argument influences the results.
+	Format(buf *bytes.Buffer, flags FmtFlags)
+}
+
+// FormatNode recurses into a node for pretty-printing.
+// Flag-driven special cases can hook into this.
+func FormatNode(buf *bytes.Buffer, f FmtFlags, n NodeFormatter) {
+	n.Format(buf, f)
+}
+
+// AsStringWithFlags pretty prints a node to a string given specific flags.
+func AsStringWithFlags(n NodeFormatter, f FmtFlags) string {
+	var buf bytes.Buffer
+	FormatNode(&buf, f, n)
+	return buf.String()
+}
+
+// AsString pretty prints a node to a string.
+func AsString(n NodeFormatter) string {
+	return AsStringWithFlags(n, FmtSimple)
+}

--- a/sql/parser/grant.go
+++ b/sql/parser/grant.go
@@ -23,7 +23,7 @@
 package parser
 
 import (
-	"fmt"
+	"bytes"
 
 	"github.com/cockroachdb/cockroach/sql/privilege"
 )
@@ -60,16 +60,22 @@ type TargetList struct {
 	Tables    QualifiedNames
 }
 
-func (tl TargetList) String() string {
+// Format implements the NodeFormatter interface.
+func (tl TargetList) Format(buf *bytes.Buffer, f FmtFlags) {
 	if tl.Databases != nil {
-		return fmt.Sprintf("DATABASE %s", tl.Databases)
+		buf.WriteString("DATABASE ")
+		FormatNode(buf, f, tl.Databases)
+	} else {
+		FormatNode(buf, f, tl.Tables)
 	}
-	return fmt.Sprintf("%s", tl.Tables)
 }
 
-func (node *Grant) String() string {
-	return fmt.Sprintf("GRANT %s ON %s TO %v",
-		node.Privileges,
-		node.Targets,
-		node.Grantees)
+// Format implements the NodeFormatter interface.
+func (node *Grant) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("GRANT ")
+	node.Privileges.Format(buf)
+	buf.WriteString(" ON ")
+	FormatNode(buf, f, node.Targets)
+	buf.WriteString(" TO ")
+	FormatNode(buf, f, node.Grantees)
 }

--- a/sql/parser/indexed_vars.go
+++ b/sql/parser/indexed_vars.go
@@ -16,7 +16,10 @@
 
 package parser
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+)
 
 // IndexedVarContainer provides the implementation of TypeCheck, Eval, and
 // String for IndexedVars.
@@ -60,8 +63,9 @@ func (v *IndexedVar) ReturnType() Datum {
 	return v.container.IndexedVarReturnType(v.Idx)
 }
 
-func (v *IndexedVar) String() string {
-	return v.container.IndexedVarString(v.Idx)
+// Format implements the NodeFormatter interface.
+func (v *IndexedVar) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(v.container.IndexedVarString(v.Idx))
 }
 
 // IndexedVarHelper is a structure that helps with initialization of IndexVars.

--- a/sql/parser/indirection.go
+++ b/sql/parser/indirection.go
@@ -16,15 +16,12 @@
 
 package parser
 
-import (
-	"bytes"
-	"fmt"
-)
+import "bytes"
 
 // IndirectionElem is a single element in an indirection expression.
 type IndirectionElem interface {
+	NodeFormatter
 	indirectionElem()
-	String() string
 }
 
 func (NameIndirection) indirectionElem()   {}
@@ -35,19 +32,20 @@ func (*ArrayIndirection) indirectionElem() {}
 // indirection elements.
 type Indirection []IndirectionElem
 
-func (i Indirection) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (i Indirection) Format(buf *bytes.Buffer, f FmtFlags) {
 	for _, e := range i {
-		buf.WriteString(e.String())
+		FormatNode(buf, f, e)
 	}
-	return buf.String()
 }
 
 // NameIndirection represents ".<name>" in an indirection expression.
 type NameIndirection Name
 
-func (n NameIndirection) String() string {
-	return fmt.Sprintf(".%s", Name(n))
+// Format implements the NodeFormatter interface.
+func (n NameIndirection) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteByte('.')
+	FormatNode(buf, f, Name(n))
 }
 
 // StarIndirection represents ".*" in an indirection expression.
@@ -58,8 +56,9 @@ const (
 	unqualifiedStar StarIndirection = "*"
 )
 
-func (s StarIndirection) String() string {
-	return string(s)
+// Format implements the NodeFormatter interface.
+func (s StarIndirection) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(string(s))
 }
 
 // ArrayIndirection represents "[<begin>:<end>]" in an indirection expression.
@@ -68,14 +67,13 @@ type ArrayIndirection struct {
 	End   Expr
 }
 
-func (a *ArrayIndirection) String() string {
-	var buf bytes.Buffer
-	buf.WriteString("[")
-	buf.WriteString(a.Begin.String())
+// Format implements the NodeFormatter interface.
+func (a *ArrayIndirection) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteByte('[')
+	FormatNode(buf, f, a.Begin)
 	if a.End != nil {
-		buf.WriteString(":")
-		buf.WriteString(a.End.String())
+		buf.WriteByte(':')
+		FormatNode(buf, f, a.End)
 	}
-	buf.WriteString("]")
-	return buf.String()
+	buf.WriteByte(']')
 }

--- a/sql/parser/insert.go
+++ b/sql/parser/insert.go
@@ -22,10 +22,7 @@
 
 package parser
 
-import (
-	"bytes"
-	"fmt"
-)
+import "bytes"
 
 // Insert represents an INSERT statement.
 type Insert struct {
@@ -36,24 +33,27 @@ type Insert struct {
 	OnConflict *OnConflict
 }
 
-func (node *Insert) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *Insert) Format(buf *bytes.Buffer, f FmtFlags) {
 	if node.OnConflict != nil {
 		buf.WriteString("UPSERT")
 	} else {
 		buf.WriteString("INSERT")
 	}
-	fmt.Fprintf(&buf, " INTO %s", node.Table)
+	buf.WriteString(" INTO ")
+	FormatNode(buf, f, node.Table)
 	if node.Columns != nil {
-		fmt.Fprintf(&buf, "(%s)", node.Columns)
+		buf.WriteByte('(')
+		FormatNode(buf, f, node.Columns)
+		buf.WriteByte(')')
 	}
 	if node.DefaultValues() {
 		buf.WriteString(" DEFAULT VALUES")
 	} else {
-		fmt.Fprintf(&buf, " %s", node.Rows)
+		buf.WriteByte(' ')
+		FormatNode(buf, f, node.Rows)
 	}
-	buf.WriteString(node.Returning.String())
-	return buf.String()
+	FormatNode(buf, f, node.Returning)
 }
 
 // DefaultValues returns true iff only default values are being inserted.

--- a/sql/parser/name.go
+++ b/sql/parser/name.go
@@ -27,9 +27,9 @@ import "bytes"
 // A Name is an SQL identifier.
 type Name string
 
-// String formats an SQL identifier, applying proper escaping rules.
-func (n Name) String() string {
-	return encodeSQLIdent(string(n))
+// Format implements the NodeFormatter interface.
+func (n Name) Format(buf *bytes.Buffer, f FmtFlags) {
+	encodeSQLIdent(buf, string(n))
 }
 
 // A NameList is a list of identifier.
@@ -37,14 +37,12 @@ func (n Name) String() string {
 // to introduce new types to the grammar, NameList([]string{...}) needs to work.
 type NameList []string
 
-// String formats the contained names as a comma-separated, escaped string.
-func (l NameList) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (l NameList) Format(buf *bytes.Buffer, f FmtFlags) {
 	for i, n := range l {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		buf.WriteString(Name(n).String())
+		FormatNode(buf, f, Name(n))
 	}
-	return buf.String()
 }

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -35,15 +35,14 @@ import (
 // StatementList is a list of statements.
 type StatementList []Statement
 
-func (l StatementList) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (l StatementList) Format(buf *bytes.Buffer, f FmtFlags) {
 	for i, s := range l {
 		if i > 0 {
 			buf.WriteString("; ")
 		}
-		buf.WriteString(s.String())
+		FormatNode(buf, f, s)
 	}
-	return buf.String()
 }
 
 // Syntax is an enum of the various syntax types.

--- a/sql/parser/rename.go
+++ b/sql/parser/rename.go
@@ -22,10 +22,7 @@
 
 package parser
 
-import (
-	"bytes"
-	"fmt"
-)
+import "bytes"
 
 // RenameDatabase represents a RENAME DATABASE statement.
 type RenameDatabase struct {
@@ -33,8 +30,12 @@ type RenameDatabase struct {
 	NewName Name
 }
 
-func (node *RenameDatabase) String() string {
-	return fmt.Sprintf("ALTER DATABASE %s RENAME TO %s", node.Name, node.NewName)
+// Format implements the NodeFormatter interface.
+func (node *RenameDatabase) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("ALTER DATABASE ")
+	FormatNode(buf, f, node.Name)
+	buf.WriteString(" RENAME TO ")
+	FormatNode(buf, f, node.NewName)
 }
 
 // RenameTable represents a RENAME TABLE statement.
@@ -44,14 +45,15 @@ type RenameTable struct {
 	IfExists bool
 }
 
-func (node *RenameTable) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *RenameTable) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("ALTER TABLE ")
 	if node.IfExists {
 		buf.WriteString("IF EXISTS ")
 	}
-	fmt.Fprintf(&buf, "%s RENAME TO %s", node.Name, node.NewName)
-	return buf.String()
+	FormatNode(buf, f, node.Name)
+	buf.WriteString(" RENAME TO ")
+	FormatNode(buf, f, node.NewName)
 }
 
 // RenameIndex represents a RENAME INDEX statement.
@@ -61,14 +63,15 @@ type RenameIndex struct {
 	IfExists bool
 }
 
-func (node *RenameIndex) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *RenameIndex) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("ALTER INDEX ")
 	if node.IfExists {
 		buf.WriteString("IF EXISTS ")
 	}
-	fmt.Fprintf(&buf, "%s RENAME TO %s", node.Index, node.NewName)
-	return buf.String()
+	FormatNode(buf, f, node.Index)
+	buf.WriteString(" RENAME TO ")
+	FormatNode(buf, f, node.NewName)
 }
 
 // RenameColumn represents a RENAME COLUMN statement.
@@ -80,12 +83,16 @@ type RenameColumn struct {
 	IfExists bool
 }
 
-func (node *RenameColumn) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *RenameColumn) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("ALTER TABLE ")
 	if node.IfExists {
 		buf.WriteString("IF EXISTS ")
+
 	}
-	fmt.Fprintf(&buf, "%s RENAME COLUMN %s TO %s", node.Table, node.Name, node.NewName)
-	return buf.String()
+	FormatNode(buf, f, node.Table)
+	buf.WriteString(" RENAME COLUMN ")
+	FormatNode(buf, f, node.Name)
+	buf.WriteString(" TO ")
+	FormatNode(buf, f, node.NewName)
 }

--- a/sql/parser/returning.go
+++ b/sql/parser/returning.go
@@ -16,16 +16,17 @@
 
 package parser
 
-import "fmt"
+import "bytes"
 
 // ReturningExprs represents RETURNING expressions.
 type ReturningExprs SelectExprs
 
-func (r ReturningExprs) String() string {
-	if len(r) == 0 {
-		return ""
+// Format implements the NodeFormatter interface.
+func (r ReturningExprs) Format(buf *bytes.Buffer, f FmtFlags) {
+	if len(r) != 0 {
+		buf.WriteString(" RETURNING ")
+		FormatNode(buf, f, SelectExprs(r))
 	}
-	return fmt.Sprintf(" RETURNING%s", SelectExprs(r))
 }
 
 // StatementType implements the Statement interface.

--- a/sql/parser/revoke.go
+++ b/sql/parser/revoke.go
@@ -23,7 +23,7 @@
 package parser
 
 import (
-	"fmt"
+	"bytes"
 
 	"github.com/cockroachdb/cockroach/sql/privilege"
 )
@@ -36,9 +36,12 @@ type Revoke struct {
 	Grantees   NameList
 }
 
-func (node *Revoke) String() string {
-	return fmt.Sprintf("REVOKE %s ON %s FROM %v",
-		node.Privileges,
-		node.Targets,
-		node.Grantees)
+// Format implements the NodeFormatter interface.
+func (node *Revoke) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("REVOKE ")
+	node.Privileges.Format(buf)
+	buf.WriteString(" ON ")
+	FormatNode(buf, f, node.Targets)
+	buf.WriteString(" FROM ")
+	FormatNode(buf, f, node.Grantees)
 }

--- a/sql/parser/set.go
+++ b/sql/parser/set.go
@@ -22,10 +22,7 @@
 
 package parser
 
-import (
-	"bytes"
-	"fmt"
-)
+import "bytes"
 
 // Set represents a SET statement.
 type Set struct {
@@ -33,11 +30,16 @@ type Set struct {
 	Values Exprs
 }
 
-func (node *Set) String() string {
+// Format implements the NodeFormatter interface.
+func (node *Set) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("SET ")
+	FormatNode(buf, f, node.Name)
+	buf.WriteString(" = ")
 	if node.Values == nil {
-		return fmt.Sprintf("SET %s = DEFAULT", node.Name)
+		buf.WriteString("DEFAULT")
+	} else {
+		FormatNode(buf, f, node.Values)
 	}
-	return fmt.Sprintf("SET %s = %v", node.Name, node.Values)
 }
 
 // SetTransaction represents a SET TRANSACTION statement.
@@ -46,18 +48,20 @@ type SetTransaction struct {
 	UserPriority UserPriority
 }
 
-func (node *SetTransaction) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *SetTransaction) Format(buf *bytes.Buffer, f FmtFlags) {
 	var sep string
 	buf.WriteString("SET TRANSACTION")
 	if node.Isolation != UnspecifiedIsolation {
-		fmt.Fprintf(&buf, " ISOLATION LEVEL %s", node.Isolation)
+		buf.WriteString(" ISOLATION LEVEL ")
+		buf.WriteString(node.Isolation.String())
 		sep = ","
 	}
 	if node.UserPriority != UnspecifiedUserPriority {
-		fmt.Fprintf(&buf, "%s PRIORITY %s", sep, node.UserPriority)
+		buf.WriteString(sep)
+		buf.WriteString(" PRIORITY ")
+		buf.WriteString(node.UserPriority.String())
 	}
-	return buf.String()
 }
 
 // SetTimeZone represents a SET TIME ZONE statement.
@@ -65,30 +69,28 @@ type SetTimeZone struct {
 	Value Expr
 }
 
-func (node *SetTimeZone) String() string {
-	// TODO(knz) clean up this when refactoring the pretty-printer.
-	prefix := "SET TIME ZONE"
-	onZoneStr := func(zone string) (string, bool) {
-		if zone == "DEFAULT" || zone == "LOCAL" {
-			return fmt.Sprintf("%s %s", prefix, zone), true
-		}
-		return "", false
-	}
-	switch v := node.Value.(type) {
+// Format implements the NodeFormatter interface.
+func (node *SetTimeZone) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("SET TIME ZONE ")
+	switch node.Value.(type) {
 	case *DInterval:
-		return fmt.Sprintf("%s INTERVAL '%s'", prefix, v)
-
-	case *StrVal:
-		if s, ok := onZoneStr(v.s); ok {
-			return s
+		buf.WriteString("INTERVAL '")
+		FormatNode(buf, f, node.Value)
+		buf.WriteByte('\'')
+	default:
+		var s string
+		switch v := node.Value.(type) {
+		case *DString:
+			s = string(*v)
+		case *StrVal:
+			s = v.s
 		}
-
-	case *DString:
-		if s, ok := onZoneStr(string(*v)); ok {
-			return s
+		if s == "DEFAULT" || s == "LOCAL" {
+			buf.WriteString(s)
+		} else {
+			FormatNode(buf, f, node.Value)
 		}
 	}
-	return fmt.Sprintf("%s %s", prefix, node.Value)
 }
 
 // SetDefaultIsolation represents a SET SESSION CHARACTERISTICS AS TRANSACTION statement.
@@ -96,11 +98,11 @@ type SetDefaultIsolation struct {
 	Isolation IsolationLevel
 }
 
-func (node *SetDefaultIsolation) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *SetDefaultIsolation) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL")
 	if node.Isolation != UnspecifiedIsolation {
-		fmt.Fprintf(&buf, " %s", node.Isolation)
+		buf.WriteByte(' ')
+		buf.WriteString(node.Isolation.String())
 	}
-	return buf.String()
 }

--- a/sql/parser/show.go
+++ b/sql/parser/show.go
@@ -22,18 +22,17 @@
 
 package parser
 
-import (
-	"bytes"
-	"fmt"
-)
+import "bytes"
 
 // Show represents a SHOW statement.
 type Show struct {
 	Name string
 }
 
-func (node *Show) String() string {
-	return fmt.Sprintf("SHOW %s", node.Name)
+// Format implements the NodeFormatter interface.
+func (node *Show) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("SHOW ")
+	buf.WriteString(node.Name)
 }
 
 // ShowColumns represents a SHOW COLUMNS statement.
@@ -41,19 +40,19 @@ type ShowColumns struct {
 	Table *QualifiedName
 }
 
-func (node *ShowColumns) String() string {
-	var buf bytes.Buffer
-	buf.WriteString("SHOW ")
-	fmt.Fprintf(&buf, "COLUMNS FROM %s", node.Table)
-	return buf.String()
+// Format implements the NodeFormatter interface.
+func (node *ShowColumns) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("SHOW COLUMNS FROM ")
+	FormatNode(buf, f, node.Table)
 }
 
 // ShowDatabases represents a SHOW DATABASES statement.
 type ShowDatabases struct {
 }
 
-func (node *ShowDatabases) String() string {
-	return "SHOW DATABASES"
+// Format implements the NodeFormatter interface.
+func (node *ShowDatabases) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("SHOW DATABASES")
 }
 
 // ShowIndex represents a SHOW INDEX statement.
@@ -61,8 +60,10 @@ type ShowIndex struct {
 	Table *QualifiedName
 }
 
-func (node *ShowIndex) String() string {
-	return fmt.Sprintf("SHOW INDEXES FROM %s", node.Table)
+// Format implements the NodeFormatter interface.
+func (node *ShowIndex) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("SHOW INDEXES FROM ")
+	FormatNode(buf, f, node.Table)
 }
 
 // ShowTables represents a SHOW TABLES statement.
@@ -70,13 +71,13 @@ type ShowTables struct {
 	Name *QualifiedName
 }
 
-func (node *ShowTables) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *ShowTables) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("SHOW TABLES")
 	if node.Name != nil {
-		fmt.Fprintf(&buf, " FROM %s", node.Name)
+		buf.WriteString(" FROM ")
+		FormatNode(buf, f, node.Name)
 	}
-	return buf.String()
 }
 
 // ShowGrants represents a SHOW GRANTS statement.
@@ -86,16 +87,17 @@ type ShowGrants struct {
 	Grantees NameList
 }
 
-func (node *ShowGrants) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *ShowGrants) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("SHOW GRANTS")
 	if node.Targets != nil {
-		fmt.Fprintf(&buf, " ON %s", *node.Targets)
+		buf.WriteString(" ON ")
+		FormatNode(buf, f, node.Targets)
 	}
 	if node.Grantees != nil {
-		fmt.Fprintf(&buf, " FOR %s", node.Grantees)
+		buf.WriteString(" FOR ")
+		FormatNode(buf, f, node.Grantees)
 	}
-	return buf.String()
 }
 
 // ShowCreateTable represents a SHOW CREATE TABLE statement.
@@ -103,6 +105,8 @@ type ShowCreateTable struct {
 	Table *QualifiedName
 }
 
-func (node *ShowCreateTable) String() string {
-	return fmt.Sprintf("SHOW CREATE TABLE %s", node.Table)
+// Format implements the NodeFormatter interface.
+func (node *ShowCreateTable) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("SHOW CREATE TABLE ")
+	FormatNode(buf, f, node.Table)
 }

--- a/sql/parser/stmt.go
+++ b/sql/parser/stmt.go
@@ -54,6 +54,7 @@ const (
 // Statement represents a statement.
 type Statement interface {
 	fmt.Stringer
+	NodeFormatter
 	StatementType() StatementType
 	// StatementTag is a short string identifying the type of statement
 	// (usually a single verb). This is different than the Stringer output,
@@ -302,3 +303,52 @@ func (ValuesClause) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (ValuesClause) StatementTag() string { return "VALUES" }
+
+func (n *AlterTable) String() string               { return AsString(n) }
+func (n AlterTableCmds) String() string            { return AsString(n) }
+func (n *AlterTableAddColumn) String() string      { return AsString(n) }
+func (n *AlterTableAddConstraint) String() string  { return AsString(n) }
+func (n *AlterTableDropColumn) String() string     { return AsString(n) }
+func (n *AlterTableDropConstraint) String() string { return AsString(n) }
+func (n *AlterTableDropNotNull) String() string    { return AsString(n) }
+func (n *AlterTableSetDefault) String() string     { return AsString(n) }
+func (n *BeginTransaction) String() string         { return AsString(n) }
+func (n *CommitTransaction) String() string        { return AsString(n) }
+func (n *CreateDatabase) String() string           { return AsString(n) }
+func (n *CreateIndex) String() string              { return AsString(n) }
+func (n *CreateTable) String() string              { return AsString(n) }
+func (n *Delete) String() string                   { return AsString(n) }
+func (n *DropDatabase) String() string             { return AsString(n) }
+func (n *DropIndex) String() string                { return AsString(n) }
+func (n *DropTable) String() string                { return AsString(n) }
+func (n *Explain) String() string                  { return AsString(n) }
+func (n *Grant) String() string                    { return AsString(n) }
+func (n *Insert) String() string                   { return AsString(n) }
+func (n *ParenSelect) String() string              { return AsString(n) }
+func (n *ReleaseSavepoint) String() string         { return AsString(n) }
+func (n *RenameColumn) String() string             { return AsString(n) }
+func (n *RenameDatabase) String() string           { return AsString(n) }
+func (n *RenameIndex) String() string              { return AsString(n) }
+func (n *RenameTable) String() string              { return AsString(n) }
+func (n *Revoke) String() string                   { return AsString(n) }
+func (n *RollbackToSavepoint) String() string      { return AsString(n) }
+func (n *RollbackTransaction) String() string      { return AsString(n) }
+func (n *Savepoint) String() string                { return AsString(n) }
+func (n *Select) String() string                   { return AsString(n) }
+func (n *SelectClause) String() string             { return AsString(n) }
+func (n *Set) String() string                      { return AsString(n) }
+func (n *SetDefaultIsolation) String() string      { return AsString(n) }
+func (n *SetTimeZone) String() string              { return AsString(n) }
+func (n *SetTransaction) String() string           { return AsString(n) }
+func (n *Show) String() string                     { return AsString(n) }
+func (n *ShowColumns) String() string              { return AsString(n) }
+func (n *ShowCreateTable) String() string          { return AsString(n) }
+func (n *ShowDatabases) String() string            { return AsString(n) }
+func (n *ShowGrants) String() string               { return AsString(n) }
+func (n *ShowIndex) String() string                { return AsString(n) }
+func (n *ShowTables) String() string               { return AsString(n) }
+func (l StatementList) String() string             { return AsString(l) }
+func (n *Truncate) String() string                 { return AsString(n) }
+func (n *UnionClause) String() string              { return AsString(n) }
+func (n *Update) String() string                   { return AsString(n) }
+func (n *ValuesClause) String() string             { return AsString(n) }

--- a/sql/parser/truncate.go
+++ b/sql/parser/truncate.go
@@ -22,10 +22,7 @@
 
 package parser
 
-import (
-	"bytes"
-	"fmt"
-)
+import "bytes"
 
 // Truncate represents a TRUNCATE statement.
 type Truncate struct {
@@ -33,17 +30,17 @@ type Truncate struct {
 	DropBehavior DropBehavior
 }
 
-func (node *Truncate) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *Truncate) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("TRUNCATE TABLE ")
 	for i, n := range node.Tables {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		buf.WriteString(n.String())
+		FormatNode(buf, f, n)
 	}
 	if node.DropBehavior != DropDefault {
-		fmt.Fprintf(&buf, " %s", node.DropBehavior)
+		buf.WriteByte(' ')
+		buf.WriteString(node.DropBehavior.String())
 	}
-	return buf.String()
 }

--- a/sql/parser/txn.go
+++ b/sql/parser/txn.go
@@ -80,32 +80,33 @@ type BeginTransaction struct {
 	UserPriority UserPriority
 }
 
-func (node *BeginTransaction) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *BeginTransaction) Format(buf *bytes.Buffer, f FmtFlags) {
 	var sep string
 	buf.WriteString("BEGIN TRANSACTION")
 	if node.Isolation != UnspecifiedIsolation {
-		fmt.Fprintf(&buf, " ISOLATION LEVEL %s", node.Isolation)
+		fmt.Fprintf(buf, " ISOLATION LEVEL %s", node.Isolation)
 		sep = ","
 	}
 	if node.UserPriority != UnspecifiedUserPriority {
-		fmt.Fprintf(&buf, "%s PRIORITY %s", sep, node.UserPriority)
+		fmt.Fprintf(buf, "%s PRIORITY %s", sep, node.UserPriority)
 	}
-	return buf.String()
 }
 
 // CommitTransaction represents a COMMIT statement.
 type CommitTransaction struct{}
 
-func (node *CommitTransaction) String() string {
-	return "COMMIT TRANSACTION"
+// Format implements the NodeFormatter interface.
+func (node *CommitTransaction) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("COMMIT TRANSACTION")
 }
 
 // RollbackTransaction represents a ROLLBACK statement.
 type RollbackTransaction struct{}
 
-func (node *RollbackTransaction) String() string {
-	return "ROLLBACK TRANSACTION"
+// Format implements the NodeFormatter interface.
+func (node *RollbackTransaction) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("ROLLBACK TRANSACTION")
 }
 
 // RestartSavepointName is the only savepoint name that we accept, modulo
@@ -129,8 +130,10 @@ type Savepoint struct {
 	Name string
 }
 
-func (node *Savepoint) String() string {
-	return "SAVEPOINT " + node.Name
+// Format implements the NodeFormatter interface.
+func (node *Savepoint) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("SAVEPOINT ")
+	buf.WriteString(node.Name)
 }
 
 // ReleaseSavepoint represents a RELEASE SAVEPOINT <name> statement.
@@ -138,8 +141,10 @@ type ReleaseSavepoint struct {
 	Savepoint string
 }
 
-func (node *ReleaseSavepoint) String() string {
-	return "RELEASE SAVEPOINT " + node.Savepoint
+// Format implements the NodeFormatter interface.
+func (node *ReleaseSavepoint) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("RELEASE SAVEPOINT ")
+	buf.WriteString(node.Savepoint)
 }
 
 // RollbackToSavepoint represents a ROLLBACK TO SAVEPOINT <name> statement.
@@ -147,6 +152,8 @@ type RollbackToSavepoint struct {
 	Savepoint string
 }
 
-func (node *RollbackToSavepoint) String() string {
-	return "ROLLBACK TRANSACTION TO SAVEPOINT " + node.Savepoint
+// Format implements the NodeFormatter interface.
+func (node *RollbackToSavepoint) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("ROLLBACK TRANSACTION TO SAVEPOINT ")
+	buf.WriteString(node.Savepoint)
 }

--- a/sql/parser/types.go
+++ b/sql/parser/types.go
@@ -24,6 +24,7 @@ import (
 // ColumnType represents a type in a column definition.
 type ColumnType interface {
 	fmt.Stringer
+	NodeFormatter
 	columnType()
 }
 
@@ -49,8 +50,9 @@ type BoolType struct {
 	Name string
 }
 
-func (node *BoolType) String() string {
-	return node.Name
+// Format implements the NodeFormatter interface.
+func (node *BoolType) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(node.Name)
 }
 
 // Pre-allocated immutable integer column types.
@@ -76,13 +78,12 @@ type IntType struct {
 	N    int
 }
 
-func (node *IntType) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *IntType) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(node.Name)
 	if node.N > 0 {
-		fmt.Fprintf(&buf, "(%d)", node.N)
+		fmt.Fprintf(buf, "(%d)", node.N)
 	}
-	return buf.String()
 }
 
 // Pre-allocated immutable float column types.
@@ -105,13 +106,12 @@ func newFloatType(prec int) *FloatType {
 	return &FloatType{Name: "FLOAT", Prec: prec}
 }
 
-func (node *FloatType) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *FloatType) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(node.Name)
 	if node.Prec > 0 {
-		fmt.Fprintf(&buf, "(%d)", node.Prec)
+		fmt.Fprintf(buf, "(%d)", node.Prec)
 	}
-	return buf.String()
 }
 
 // Pre-allocated immutable decimal column types.
@@ -128,17 +128,16 @@ type DecimalType struct {
 	Scale int
 }
 
-func (node *DecimalType) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *DecimalType) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(node.Name)
 	if node.Prec > 0 {
-		fmt.Fprintf(&buf, "(%d", node.Prec)
+		fmt.Fprintf(buf, "(%d", node.Prec)
 		if node.Scale > 0 {
-			fmt.Fprintf(&buf, ",%d", node.Scale)
+			fmt.Fprintf(buf, ",%d", node.Scale)
 		}
-		buf.WriteString(")")
+		buf.WriteByte(')')
 	}
-	return buf.String()
 }
 
 // Pre-allocated immutable date column type.
@@ -148,8 +147,9 @@ var dateTypeDate = &DateType{}
 type DateType struct {
 }
 
-func (node *DateType) String() string {
-	return "DATE"
+// Format implements the NodeFormatter interface.
+func (node *DateType) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("DATE")
 }
 
 // Pre-allocated immutable timestamp column type.
@@ -159,8 +159,9 @@ var timestampTypeTimestamp = &TimestampType{}
 type TimestampType struct {
 }
 
-func (node *TimestampType) String() string {
-	return "TIMESTAMP"
+// Format implements the NodeFormatter interface.
+func (node *TimestampType) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("TIMESTAMP")
 }
 
 // Pre-allocated immutable timestamp with time zone column type.
@@ -170,8 +171,9 @@ var timestampTzTypeTimestampWithTZ = &TimestampTZType{}
 type TimestampTZType struct {
 }
 
-func (node *TimestampTZType) String() string {
-	return "TIMESTAMP WITH TIME ZONE"
+// Format implements the NodeFormatter interface.
+func (node *TimestampTZType) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("TIMESTAMP WITH TIME ZONE")
 }
 
 // Pre-allocated immutable interval column type.
@@ -181,8 +183,9 @@ var intervalTypeInterval = &IntervalType{}
 type IntervalType struct {
 }
 
-func (node *IntervalType) String() string {
-	return "INTERVAL"
+// Format implements the NodeFormatter interface.
+func (node *IntervalType) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("INTERVAL")
 }
 
 // Pre-allocated immutable string column types.
@@ -199,13 +202,12 @@ type StringType struct {
 	N    int
 }
 
-func (node *StringType) String() string {
-	var buf bytes.Buffer
+// Format implements the NodeFormatter interface.
+func (node *StringType) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(node.Name)
 	if node.N > 0 {
-		fmt.Fprintf(&buf, "(%d)", node.N)
+		fmt.Fprintf(buf, "(%d)", node.N)
 	}
-	return buf.String()
 }
 
 // Pre-allocated immutable bytes column types.
@@ -220,6 +222,18 @@ type BytesType struct {
 	Name string
 }
 
-func (node *BytesType) String() string {
-	return node.Name
+// Format implements the NodeFormatter interface.
+func (node *BytesType) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString(node.Name)
 }
+
+func (node *BoolType) String() string        { return AsString(node) }
+func (node *IntType) String() string         { return AsString(node) }
+func (node *FloatType) String() string       { return AsString(node) }
+func (node *DecimalType) String() string     { return AsString(node) }
+func (node *DateType) String() string        { return AsString(node) }
+func (node *TimestampType) String() string   { return AsString(node) }
+func (node *TimestampTZType) String() string { return AsString(node) }
+func (node *IntervalType) String() string    { return AsString(node) }
+func (node *StringType) String() string      { return AsString(node) }
+func (node *BytesType) String() string       { return AsString(node) }

--- a/sql/parser/union.go
+++ b/sql/parser/union.go
@@ -22,7 +22,10 @@
 
 package parser
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+)
 
 // UnionClause represents a UNION statement.
 type UnionClause struct {
@@ -54,10 +57,14 @@ func (i UnionType) String() string {
 	return unionTypeName[i]
 }
 
-func (node *UnionClause) String() string {
-	all := ""
+// Format implements the NodeFormatter interface.
+func (node *UnionClause) Format(buf *bytes.Buffer, f FmtFlags) {
+	FormatNode(buf, f, node.Left)
+	buf.WriteByte(' ')
+	buf.WriteString(node.Type.String())
 	if node.All {
-		all = " ALL"
+		buf.WriteString(" ALL")
 	}
-	return fmt.Sprintf("%s %s%s %s", node.Left, node.Type, all, node.Right)
+	buf.WriteByte(' ')
+	FormatNode(buf, f, node.Right)
 }

--- a/sql/parser/update.go
+++ b/sql/parser/update.go
@@ -22,10 +22,7 @@
 
 package parser
 
-import (
-	"bytes"
-	"fmt"
-)
+import "bytes"
 
 // Update represents an UPDATE statement.
 type Update struct {
@@ -35,22 +32,27 @@ type Update struct {
 	Returning ReturningExprs
 }
 
-func (node *Update) String() string {
-	return fmt.Sprintf("UPDATE %s SET %s%s%s",
-		node.Table, node.Exprs, node.Where, node.Returning)
+// Format implements the NodeFormatter interface.
+func (node *Update) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("UPDATE ")
+	FormatNode(buf, f, node.Table)
+	buf.WriteString(" SET ")
+	FormatNode(buf, f, node.Exprs)
+	FormatNode(buf, f, node.Where)
+	FormatNode(buf, f, node.Returning)
 }
 
 // UpdateExprs represents a list of update expressions.
 type UpdateExprs []*UpdateExpr
 
-func (node UpdateExprs) String() string {
-	var prefix string
-	var buf bytes.Buffer
-	for _, n := range node {
-		fmt.Fprintf(&buf, "%s%s", prefix, n)
-		prefix = ", "
+// Format implements the NodeFormatter interface.
+func (node UpdateExprs) Format(buf *bytes.Buffer, f FmtFlags) {
+	for i, n := range node {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		FormatNode(buf, f, n)
 	}
-	return buf.String()
 }
 
 // UpdateExpr represents an update expression.
@@ -60,10 +62,15 @@ type UpdateExpr struct {
 	Expr  Expr
 }
 
-func (node *UpdateExpr) String() string {
+// Format implements the NodeFormatter interface.
+func (node *UpdateExpr) Format(buf *bytes.Buffer, f FmtFlags) {
 	open, close := "", ""
 	if node.Tuple {
 		open, close = "(", ")"
 	}
-	return fmt.Sprintf("%s%s%s = %s", open, node.Names, close, node.Expr)
+	buf.WriteString(open)
+	FormatNode(buf, f, node.Names)
+	buf.WriteString(close)
+	buf.WriteString(" = ")
+	FormatNode(buf, f, node.Expr)
 }

--- a/sql/parser/values.go
+++ b/sql/parser/values.go
@@ -22,17 +22,20 @@
 
 package parser
 
-import "strings"
+import "bytes"
 
 // ValuesClause represents a VALUES clause.
 type ValuesClause struct {
 	Tuples []*Tuple
 }
 
-func (node *ValuesClause) String() string {
-	strs := make([]string, 0, len(node.Tuples))
-	for _, n := range node.Tuples {
-		strs = append(strs, n.String())
+// Format implements the NodeFormatter interface.
+func (node *ValuesClause) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("VALUES ")
+	for i, n := range node.Tuples {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		FormatNode(buf, f, n)
 	}
-	return "VALUES " + strings.Join(strs, ", ")
 }

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -475,6 +475,10 @@ type planNode interface {
 	// ExplainPlan returns a name and description and a list of child nodes.
 	ExplainPlan(verbose bool) (name, description string, children []planNode)
 
+	// ExplainTypes reports the data types involved in the node, excluding
+	// the result column types.
+	ExplainTypes(explainFn func(elem string, desc string))
+
 	// SetLimitHint tells this node to optimize things under the assumption that
 	// we will only need the first `numRows` rows.
 	//
@@ -528,6 +532,8 @@ func (*emptyNode) PErr() *roachpb.Error    { return nil }
 func (*emptyNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	return "empty", "-", nil
 }
+
+func (e *emptyNode) ExplainTypes(_ func(string, string)) {}
 
 func (*emptyNode) MarkDebug(_ explainMode) {}
 

--- a/sql/privilege/privilege.go
+++ b/sql/privilege/privilege.go
@@ -17,6 +17,7 @@
 package privilege
 
 import (
+	"bytes"
 	"sort"
 	"strings"
 )
@@ -81,6 +82,17 @@ func (pl List) names() []string {
 		ret[i] = p.String()
 	}
 	return ret
+}
+
+// Format prints out the list in a buffer.
+// This keeps the existing order and uses ", " as separator.
+func (pl List) Format(buf *bytes.Buffer) {
+	for i, p := range pl {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(p.String())
+	}
 }
 
 // String implements the Stringer interface.

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -213,6 +213,12 @@ func (n *scanNode) ExplainPlan(_ bool) (name, description string, children []pla
 	return name, description, nil
 }
 
+func (n *scanNode) ExplainTypes(regTypes func(string, string)) {
+	if n.filter != nil {
+		regTypes("filter", parser.AsStringWithFlags(n.filter, parser.FmtShowTypes))
+	}
+}
+
 // Initializes a scanNode with a tableName. Returns the table or index name that can be used for
 // fully-qualified columns if an alias is not specified.
 func (n *scanNode) initTable(

--- a/sql/select.go
+++ b/sql/select.go
@@ -149,6 +149,15 @@ func (s *selectNode) PErr() *roachpb.Error {
 	return s.table.node.PErr()
 }
 
+func (s *selectNode) ExplainTypes(regTypes func(string, string)) {
+	if s.filter != nil {
+		regTypes("filter", parser.AsStringWithFlags(s.filter, parser.FmtShowTypes))
+	}
+	for i, rexpr := range s.render {
+		regTypes(fmt.Sprintf("render %d", i), parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
+	}
+}
+
 func (s *selectNode) ExplainPlan(v bool) (name, description string, children []planNode) {
 	if !v {
 		return s.table.node.ExplainPlan(v)

--- a/sql/select_qvalue.go
+++ b/sql/select_qvalue.go
@@ -20,6 +20,7 @@
 package sql
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -96,9 +97,10 @@ var _ parser.VariableExpr = &qvalue{}
 // Variable implements the VariableExpr interface.
 func (*qvalue) Variable() {}
 
-func (q *qvalue) String() string {
-	return q.colRef.get().Name
+func (q *qvalue) Format(buf *bytes.Buffer, f parser.FmtFlags) {
+	buf.WriteString(q.colRef.get().Name)
 }
+func (q *qvalue) String() string { return parser.AsString(q) }
 
 // Walk implements the Expr interface.
 func (q *qvalue) Walk(v parser.Visitor) parser.Expr {
@@ -270,16 +272,17 @@ var _ parser.VariableExpr = starDatumInstance
 // Variable implements the VariableExpr interface.
 func (*starDatum) Variable() {}
 
-func (*starDatum) String() string {
-	return "*"
+func (*starDatum) Format(buf *bytes.Buffer, f parser.FmtFlags) {
+	buf.WriteByte('*')
 }
+func (s *starDatum) String() string { return parser.AsString(s) }
 
 // Walk implements the Expr interface.
-func (e *starDatum) Walk(v parser.Visitor) parser.Expr { return e }
+func (s *starDatum) Walk(v parser.Visitor) parser.Expr { return s }
 
 // TypeCheck implements the Expr interface.
-func (e *starDatum) TypeCheck(args parser.MapArgs, desired parser.Datum) (parser.TypedExpr, error) {
-	return e, nil
+func (s *starDatum) TypeCheck(args parser.MapArgs, desired parser.Datum) (parser.TypedExpr, error) {
+	return s, nil
 }
 
 // Eval implements the TypedExpr interface.

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -245,6 +245,8 @@ func (n *sortNode) ExplainPlan(_ bool) (name, description string, children []pla
 	return name, description, []planNode{n.plan}
 }
 
+func (n *sortNode) ExplainTypes(_ func(string, string)) {}
+
 func (n *sortNode) SetLimitHint(numRows int64, soft bool) {
 	if !n.needSort {
 		// The limit is only useful to the wrapped node if we don't need to sort.

--- a/sql/testdata/explain
+++ b/sql/testdata/explain
@@ -36,6 +36,14 @@ EXPLAIN (TRACE) SELECT 1
 0.000ms   1                                   0 NULL NULL t
 0.000ms   0 coordinator tracing completed     0 NULL NULL
 
+query ITTT colnames
+EXPLAIN (TYPES) SELECT 1
+----
+Level Type   Element  Description
+0     select result   ("1" int)
+0     select render 0 (1)[int]
+1     empty  result   ()
+
 statement error cannot set EXPLAIN mode more than once
 EXPLAIN (TRACE, TRACE) SELECT 1
 

--- a/sql/testdata/explain_plan
+++ b/sql/testdata/explain_plan
@@ -4,6 +4,13 @@ CREATE TABLE t (
   v INT
 )
 
+query ITT colnames
+EXPLAIN INSERT INTO t VALUES (1, 2)
+----
+Level  Type   Description
+0      insert
+1      values 2 columns
+
 statement ok
 INSERT INTO t VALUES (1, 2)
 
@@ -19,7 +26,6 @@ EXPLAIN (VERBOSE) SELECT * FROM t
 Level  Type   Description
 0      select (k, v)@t 
 1      scan   t@primary
-
 
 query ITT colnames
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3

--- a/sql/testdata/explain_types
+++ b/sql/testdata/explain_types
@@ -1,0 +1,132 @@
+statement ok
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  v INT
+)
+
+query ITTT colnames
+EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
+----
+Level  Type   Element   Description
+0      insert result    ()
+1      values result    (column1 int, column2 int)
+1      values tuple 0   (((1)[int], (2)[int]))[tuple]
+
+statement ok
+INSERT INTO t VALUES (1, 2)
+
+query ITTT
+EXPLAIN (TYPES) SELECT 42;
+----
+0  select  result    ("42" int)
+0  select  render 0  (42)[int]
+1  empty   result    ()
+
+query ITTT
+EXPLAIN (TYPES) SELECT * FROM t
+----
+0      select result   (k int, v int)
+0      select render 0 (k)[int]
+0      select render 1 (v)[int]
+1      scan   result   (k int, v int)
+
+query ITTT
+EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
+----
+0      select result   (k int, v int)
+0      select render 0 (k)[int]
+0      select render 1 (v)[int]
+1      scan   result   (k int, v int)
+1      scan   filter   ((v)[int] > (123)[int])[bool]
+
+query ITTT
+EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
+----
+0      values  result  (column1 int, column2 int, column3 int)
+0      values  tuple 0 (((1)[int], (2)[int], (3)[int]))[tuple]
+0      values  tuple 1 (((4)[int], (5)[int], (6)[int]))[tuple]
+
+query ITTT
+EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2
+----
+0 group  result   (z int, v int)
+0 group  having   ((v)[int] < (2)[int])[bool]
+0 group  render z ((2)[int] * (COUNT((k)[int]))[int])[int]
+0 group  render v (v)[int]
+1 select result   (z int, v int, v int)
+1 select render 0 (k)[int]
+1 select render 1 (v)[int]
+1 select render 2 (v)[int]
+1 select render 3 (v)[int]
+2 scan   result   (k int, v int)
+2 scan   filter   ((v)[int] > (123)[int])[bool]
+
+query ITTT
+EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
+----
+0  delete  result    ()
+1  select  result    (k int, v int)
+1  select  render 0  (k)[int]
+1  select  render 1  (v)[int]
+2  scan    result    (k int, v int)
+2  scan    filter    ((v)[int] > (1)[int])[bool]
+
+query ITTT
+EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
+----
+0  update  result    ()
+1  select  result    (k int, v int, "k + 1" int)
+1  select  render 0  (k)[int]
+1  select  render 1  (v)[int]
+1  select  render 2  ((k)[int] + (1)[int])[int]
+2  scan    result    (k int, v int)
+2  scan    filter    ((v)[int] > (123)[int])[bool]
+
+query ITTT
+EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
+----
+0  union   result   (column1 int)
+1  values  result   (column1 int)
+1  values  tuple 0  (((1)[int]))[tuple]
+1  values  result   (column1 int)
+1  values  tuple 0  (((2)[int]))[tuple]
+
+query ITTT
+EXPLAIN (TYPES) SELECT DISTINCT k FROM t
+----
+0  distinct  result    (k int)
+1  select    result    (k int)
+1  select    render 0  (k)[int]
+2  scan      result    (k int, v int)
+
+query ITTT
+EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
+----
+0  sort    result    (v int)
+1  select  result    (v int)
+1  select  render 0  (v)[int]
+2  scan    result    (k int, v int)
+
+query ITTT
+EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
+----
+0  limit   result    (v int)
+0  limit   render 0  (v)[int]
+1  select  result    (v int)
+1  select  render 0  (v)[int]
+2  scan    result    (k int, v int)
+
+statement ok
+CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
+
+query ITTT
+EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
+----
+0  select      result    (x int, y int)
+0  select      render 0  (x)[int]
+0  select      render 1  (y)[int]
+1  index-join  result    (x int, y int, rowid int)
+2  scan        result    (x int, y int, rowid int)
+2  scan        filter    ((x)[int] < (10)[int])[bool]
+2  scan        result    (x int, y int, rowid int)
+2  scan        filter    ((y)[int] > (10)[int])[bool]

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -136,6 +136,10 @@ func (n *explainTraceNode) ExplainPlan(v bool) (name, description string, childr
 	return n.plan.ExplainPlan(v)
 }
 
+func (n *explainTraceNode) ExplainTypes(fn func(string, string)) {
+	n.plan.ExplainTypes(fn)
+}
+
 func (n *explainTraceNode) Values() parser.DTuple {
 	return n.rows[0]
 }

--- a/sql/union.go
+++ b/sql/union.go
@@ -167,6 +167,8 @@ func (n *unionNode) ExplainPlan(_ bool) (name, description string, children []pl
 	return "union", "-", []planNode{n.left, n.right}
 }
 
+func (n *unionNode) ExplainTypes(_ func(string, string)) {}
+
 func (n *unionNode) MarkDebug(mode explainMode) {
 	if mode != explainDebug {
 		panic(fmt.Sprintf("unknown debug mode %d", mode))

--- a/sql/update.go
+++ b/sql/update.go
@@ -421,4 +421,14 @@ func (u *updateNode) ExplainPlan(v bool) (name, description string, children []p
 	return "update", buf.String(), []planNode{u.run.rows}
 }
 
+func (u *updateNode) ExplainTypes(regTypes func(string, string)) {
+	cols := u.rh.columns
+	for i, rexpr := range u.rh.exprs {
+		regTypes(fmt.Sprintf("returning %s", cols[i].Name), parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
+	}
+	for i, dexpr := range u.defaultExprs {
+		regTypes(fmt.Sprintf("default %d", i), parser.AsStringWithFlags(dexpr, parser.FmtShowTypes))
+	}
+}
+
 func (u *updateNode) SetLimitHint(numRows int64, soft bool) {}

--- a/sql/values.go
+++ b/sql/values.go
@@ -282,4 +282,12 @@ func (n *valuesNode) ExplainPlan(_ bool) (name, description string, children []p
 	return name, description, nil
 }
 
+func (n *valuesNode) ExplainTypes(regTypes func(string, string)) {
+	if n.n != nil {
+		for i, tuple := range n.rows {
+			regTypes(fmt.Sprintf("tuple %d", i), parser.AsStringWithFlags(&tuple, parser.FmtShowTypes))
+		}
+	}
+}
+
 func (*valuesNode) SetLimitHint(_ int64, _ bool) {}


### PR DESCRIPTION
The first part of this patch replaces the pretty-printing using a tree of String() calls
by a NodeFormatter interface common to all syntax object. This interface
allows caller code to pass formatting flags throughout the pretty
printing. This can be used later to implement conditional
printing of node details (e.g. typing information).

A side effect is a performance improvement: prior to this patch String
and bytes.Buffer objects would be created and destroyed throughout the
recursion, causing pressure on memory allocation. With this patch a
single Buffer object is used per top-level request to the
pretty-printer.

The second part of this patch introduces a new features: the statement EXPLAIN (TYPES)
to inspect the types of intermediate results in a query plan.

Known limitation: EXPLAIN(TYPES) cannot be applied on statements
containing placeholders ($xxx). This will be worked on in a later phase.

As a side effect this patch also fixes a bug, where EXPLAIN(PLAN)
would cause a panic when invoked on an INSERT statement.

Replaces #6424.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6482)

<!-- Reviewable:end -->
