### PR TITLE
sql: document primary key violation anomaly

### DIFF
--- a/sql/testdata/violate_pk
+++ b/sql/testdata/violate_pk
@@ -1,0 +1,31 @@
+# Document an anomaly which reports success when inserting two conflicting rows,
+# with only the second row actually written.
+
+statement ok
+CREATE TABLE accounts (
+  pk1 INT,
+  pk2 INT,
+  random_id INT,
+  PRIMARY KEY (pk1, pk2),
+  UNIQUE (pk1, random_id)
+);
+
+# To trigger the anomaly below, it doesn't matter what index we create here,
+# but without one, things behave correctly.
+statement ok
+CREATE INDEX ON accounts(random_id);
+
+statement ok
+CREATE INDEX ON accounts (pk2);
+
+# Violate the primary key constraint (pk1, pk2). This *should* give
+#   statement error violates unique constraint "primary"
+# but it goes through!
+statement ok
+INSERT INTO accounts (pk1, pk2, random_id) values(123, 2, 2), (123, 2, 3);
+
+# It has overwritten the first insert.
+query III
+SELECT * FROM accounts;
+----
+123 2 3

--- a/sql/testdata/wrong_index_error
+++ b/sql/testdata/wrong_index_error
@@ -1,0 +1,31 @@
+# Document an anomaly in which the wrong index is blamed for a constraint
+# violation.
+
+statement ok
+CREATE TABLE accounts (
+  pk1 VARCHAR,
+  pk2 BIGINT NOT NULL,
+  causality_id BIGINT NOT NULL,
+  transaction_id VARCHAR,
+  PRIMARY KEY (pk1, pk2),
+  UNIQUE (pk1, causality_id)
+);
+
+# This seemingly bogus index triggers a bug.
+statement ok
+CREATE INDEX ON accounts(transaction_id);
+
+# And this one is needed too. God knows what's going on under the hood.
+statement ok
+CREATE INDEX ON accounts (pk2);
+
+# Need to insert something or the bug won't fire.
+statement ok
+INSERT INTO accounts (pk1, pk2, causality_id) values('A', 1, 1)
+
+# Violate the primary key constraint (pk1, pk2) in a single insert.
+# Should give:
+#   statement error violates unique constraint "primary"
+# but doesn't. Omitting causality_id fixes it.
+statement error violates unique constraint "accounts_transaction_id_idx"
+INSERT INTO accounts (pk1, pk2, causality_id) values('A', 2, 2), ('A', 2, 3);


### PR DESCRIPTION
During https://github.com/cockroachdb/examples-go/pull/63, I encountered
unexpected constraint violations (violations were expected, but not for
the index named in the error, which was not UNIQUE). Upon reproducing
this in a logic test, realized that I was able to insert two rows with
conflicting primary keys successfully (but only the second row would survive).

Documented both in logic tests (which are currently set up to pass but
obviously should be changed along with a fix).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6487)

<!-- Reviewable:end -->
