### PR TITLE
sql: split prepare and execute for CREATE, DROP and ALTER TABLE.

### DIFF
--- a/sql/create.go
+++ b/sql/create.go
@@ -17,13 +17,17 @@
 package sql
 
 import (
-	"fmt"
-
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/util"
 )
+
+type createDatabaseNode struct {
+	p *planner
+	n *parser.CreateDatabase
+}
 
 // CreateDatabase creates a database.
 // Privileges: security.RootUser user.
@@ -38,28 +42,50 @@ func (p *planner) CreateDatabase(n *parser.CreateDatabase) (planNode, error) {
 		return nil, util.Errorf("only %s is allowed to create databases", security.RootUser)
 	}
 
-	desc := makeDatabaseDesc(n)
+	return &createDatabaseNode{p: p, n: n}, nil
+}
 
-	created, err := p.createDescriptor(databaseKey{string(n.Name)}, &desc, n.IfNotExists)
+func (n *createDatabaseNode) Start() *roachpb.Error {
+	desc := makeDatabaseDesc(n.n)
+
+	created, err := n.p.createDescriptor(databaseKey{string(n.n.Name)}, &desc, n.n.IfNotExists)
 	if err != nil {
-		return nil, err
+		return roachpb.NewError(err)
 	}
 	if created {
 		// Log Create Database event.
-		if err := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
+		if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(n.p.txn,
 			EventLogCreateDatabase,
 			int32(desc.ID),
-			int32(p.evalCtx.NodeID),
+			int32(n.p.evalCtx.NodeID),
 			struct {
 				DatabaseName string
 				Statement    string
 				User         string
-			}{n.Name.String(), n.String(), p.session.User},
+			}{n.n.Name.String(), n.n.String(), n.p.session.User},
 		); err != nil {
-			return nil, err
+			return roachpb.NewError(err)
 		}
 	}
-	return &emptyNode{}, nil
+	return nil
+}
+
+func (n *createDatabaseNode) Next() bool                   { return false }
+func (n *createDatabaseNode) Columns() []ResultColumn      { return make([]ResultColumn, 0) }
+func (n *createDatabaseNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *createDatabaseNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *createDatabaseNode) DebugValues() debugValues     { return debugValues{} }
+func (n *createDatabaseNode) PErr() *roachpb.Error         { return nil }
+func (n *createDatabaseNode) SetLimitHint(_ int64, _ bool) {}
+func (n *createDatabaseNode) MarkDebug(mode explainMode)   {}
+func (n *createDatabaseNode) ExplainPlan(v bool) (string, string, []planNode) {
+	return "create database", "", nil
+}
+
+type createIndexNode struct {
+	p         *planner
+	n         *parser.CreateIndex
+	tableDesc *TableDescriptor
 }
 
 // CreateIndex creates an index.
@@ -75,51 +101,72 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
 		return nil, tableDoesNotExistError(n.Table.String())
 	}
 
-	status, i, err := tableDesc.FindIndexByName(string(n.Name))
+	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
+		return nil, err
+	}
+
+	return &createIndexNode{p: p, tableDesc: tableDesc, n: n}, nil
+}
+
+func (n *createIndexNode) Start() *roachpb.Error {
+	status, i, err := n.tableDesc.FindIndexByName(string(n.n.Name))
 	if err == nil {
 		if status == DescriptorIncomplete {
-			switch tableDesc.Mutations[i].Direction {
+			switch n.tableDesc.Mutations[i].Direction {
 			case DescriptorMutation_DROP:
-				return nil, fmt.Errorf("index %q being dropped, try again later", string(n.Name))
+				return roachpb.NewErrorf("index %q being dropped, try again later", string(n.n.Name))
 
 			case DescriptorMutation_ADD:
 				// Noop, will fail in AllocateIDs below.
 			}
 		}
-		if n.IfNotExists {
-			// Noop.
-			return &emptyNode{}, nil
+		if n.n.IfNotExists {
+			return nil
 		}
 	}
 
-	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
-		return nil, err
-	}
-
 	indexDesc := IndexDescriptor{
-		Name:             string(n.Name),
-		Unique:           n.Unique,
-		StoreColumnNames: n.Storing,
+		Name:             string(n.n.Name),
+		Unique:           n.n.Unique,
+		StoreColumnNames: n.n.Storing,
 	}
-	if err := indexDesc.fillColumns(n.Columns); err != nil {
-		return nil, err
+	if err := indexDesc.fillColumns(n.n.Columns); err != nil {
+		return roachpb.NewError(err)
 	}
 
-	tableDesc.addIndexMutation(indexDesc, DescriptorMutation_ADD)
-	mutationID, err := tableDesc.finalizeMutation()
+	n.tableDesc.addIndexMutation(indexDesc, DescriptorMutation_ADD)
+	mutationID, err := n.tableDesc.finalizeMutation()
 	if err != nil {
-		return nil, err
+		return roachpb.NewError(err)
 	}
-	if err := tableDesc.AllocateIDs(); err != nil {
-		return nil, err
+	if err := n.tableDesc.AllocateIDs(); err != nil {
+		return roachpb.NewError(err)
 	}
 
-	if err := p.txn.Put(MakeDescMetadataKey(tableDesc.GetID()), wrapDescriptor(tableDesc)); err != nil {
-		return nil, err
+	if err := n.p.txn.Put(MakeDescMetadataKey(n.tableDesc.GetID()), wrapDescriptor(n.tableDesc)); err != nil {
+		return roachpb.NewError(err)
 	}
-	p.notifySchemaChange(tableDesc.ID, mutationID)
+	n.p.notifySchemaChange(n.tableDesc.ID, mutationID)
 
-	return &emptyNode{}, nil
+	return nil
+}
+
+func (n *createIndexNode) Next() bool                   { return false }
+func (n *createIndexNode) Columns() []ResultColumn      { return make([]ResultColumn, 0) }
+func (n *createIndexNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *createIndexNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *createIndexNode) DebugValues() debugValues     { return debugValues{} }
+func (n *createIndexNode) PErr() *roachpb.Error         { return nil }
+func (n *createIndexNode) SetLimitHint(_ int64, _ bool) {}
+func (n *createIndexNode) MarkDebug(mode explainMode)   {}
+func (n *createIndexNode) ExplainPlan(v bool) (string, string, []planNode) {
+	return "create index", "", nil
+}
+
+type createTableNode struct {
+	p      *planner
+	n      *parser.CreateTable
+	dbDesc *DatabaseDescriptor
 }
 
 // CreateTable creates a table.
@@ -142,12 +189,16 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 		return nil, err
 	}
 
-	desc, err := makeTableDesc(n, dbDesc.ID)
+	return &createTableNode{p: p, n: n, dbDesc: dbDesc}, nil
+}
+
+func (n *createTableNode) Start() *roachpb.Error {
+	desc, err := makeTableDesc(n.n, n.dbDesc.ID)
 	if err != nil {
-		return nil, err
+		return roachpb.NewError(err)
 	}
 	// Inherit permissions from the database descriptor.
-	desc.Privileges = dbDesc.GetPrivileges()
+	desc.Privileges = n.dbDesc.GetPrivileges()
 
 	if len(desc.PrimaryIndex.ColumnNames) == 0 {
 		// Ensure a Primary Key exists.
@@ -168,34 +219,46 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 			ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 		}
 		if err := desc.AddIndex(idx, true); err != nil {
-			return nil, err
+			return roachpb.NewError(err)
 		}
 	}
 
 	if err := desc.AllocateIDs(); err != nil {
-		return nil, err
+		return roachpb.NewError(err)
 	}
 
-	created, err := p.createDescriptor(tableKey{dbDesc.ID, n.Table.Table()}, &desc, n.IfNotExists)
+	created, err := n.p.createDescriptor(tableKey{n.dbDesc.ID, n.n.Table.Table()}, &desc, n.n.IfNotExists)
 	if err != nil {
-		return nil, err
+		return roachpb.NewError(err)
 	}
 
 	if created {
 		// Log Create Table event.
-		if err := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
+		if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(n.p.txn,
 			EventLogCreateTable,
 			int32(desc.ID),
-			int32(p.evalCtx.NodeID),
+			int32(n.p.evalCtx.NodeID),
 			struct {
 				TableName string
 				Statement string
 				User      string
-			}{n.Table.String(), n.String(), p.session.User},
+			}{n.n.Table.String(), n.n.String(), n.p.session.User},
 		); err != nil {
-			return nil, err
+			return roachpb.NewError(err)
 		}
 	}
 
-	return &emptyNode{}, nil
+	return nil
+}
+
+func (n *createTableNode) Next() bool                   { return false }
+func (n *createTableNode) Columns() []ResultColumn      { return make([]ResultColumn, 0) }
+func (n *createTableNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *createTableNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *createTableNode) DebugValues() debugValues     { return debugValues{} }
+func (n *createTableNode) PErr() *roachpb.Error         { return nil }
+func (n *createTableNode) SetLimitHint(_ int64, _ bool) {}
+func (n *createTableNode) MarkDebug(mode explainMode)   {}
+func (n *createTableNode) ExplainPlan(v bool) (string, string, []planNode) {
+	return "create table", "", nil
 }

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -27,6 +27,13 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 )
 
+type dropDatabaseNode struct {
+	p      *planner
+	n      *parser.DropDatabase
+	dbDesc *DatabaseDescriptor
+	td     []*TableDescriptor
+}
+
 // DropDatabase drops a database.
 // Privileges: DROP on database.
 //   Notes: postgres allows only the database owner to DROP a database.
@@ -62,21 +69,33 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, error) {
 		return nil, err
 	}
 
-	tbNameStrings := make([]string, len(tbNames))
+	td := make([]*TableDescriptor, len(tbNames))
 	for i, tbName := range tbNames {
-		tbDesc, err := p.dropTableImpl(tbName)
-		if err != nil {
-			return nil, err
+		tbDesc, pErr := p.dropTablePrepare(tbName)
+		if pErr != nil {
+			return nil, pErr
 		}
 		if tbDesc == nil {
 			// Database claims to have this table, but it does not exist.
 			return nil, util.Errorf("table %q was described by database %q, but does not exist",
 				tbName.String(), n.Name)
 		}
+		td[i] = tbDesc
+	}
+
+	return &dropDatabaseNode{n: n, p: p, dbDesc: dbDesc, td: td}, nil
+}
+
+func (n *dropDatabaseNode) Start() *roachpb.Error {
+	tbNameStrings := make([]string, len(n.td))
+	for i, tbDesc := range n.td {
+		if err := n.p.dropTableImpl(tbDesc); err != nil {
+			return roachpb.NewError(err)
+		}
 		tbNameStrings[i] = tbDesc.Name
 	}
 
-	zoneKey, nameKey, descKey := getKeysForDatabaseDescriptor(dbDesc)
+	zoneKey, nameKey, descKey := getKeysForDatabaseDescriptor(n.dbDesc)
 
 	b := &client.Batch{}
 	b.Del(descKey)
@@ -84,7 +103,7 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, error) {
 	// Delete the zone config entry for this database.
 	b.Del(zoneKey)
 
-	p.setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
+	n.p.setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
 		for _, key := range [...]roachpb.Key{descKey, nameKey, zoneKey} {
 			if err := expectDeleted(systemConfig, key); err != nil {
 				return err
@@ -93,25 +112,42 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, error) {
 		return nil
 	})
 
-	if err := p.txn.Run(b); err != nil {
-		return nil, err
+	if err := n.p.txn.Run(b); err != nil {
+		return roachpb.NewError(err)
 	}
 
 	// Log Drop Database event.
-	if err := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
+	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(n.p.txn,
 		EventLogDropDatabase,
-		int32(dbDesc.ID),
-		int32(p.evalCtx.NodeID),
+		int32(n.dbDesc.ID),
+		int32(n.p.evalCtx.NodeID),
 		struct {
 			DatabaseName  string
 			Statement     string
 			User          string
 			DroppedTables []string
-		}{n.Name.String(), n.String(), p.session.User, tbNameStrings},
+		}{n.n.Name.String(), n.n.String(), n.p.session.User, tbNameStrings},
 	); err != nil {
-		return nil, err
+		return roachpb.NewError(err)
 	}
-	return &emptyNode{}, nil
+	return nil
+}
+
+func (n *dropDatabaseNode) Next() bool                   { return false }
+func (n *dropDatabaseNode) Columns() []ResultColumn      { return make([]ResultColumn, 0) }
+func (n *dropDatabaseNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *dropDatabaseNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *dropDatabaseNode) DebugValues() debugValues     { return debugValues{} }
+func (n *dropDatabaseNode) PErr() *roachpb.Error         { return nil }
+func (n *dropDatabaseNode) SetLimitHint(_ int64, _ bool) {}
+func (n *dropDatabaseNode) MarkDebug(mode explainMode)   {}
+func (n *dropDatabaseNode) ExplainPlan(v bool) (string, string, []planNode) {
+	return "drop database", "", nil
+}
+
+type dropIndexNode struct {
+	p *planner
+	n *parser.DropIndex
 }
 
 // DropIndex drops an index.
@@ -135,15 +171,32 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 		if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
 			return nil, err
 		}
+	}
+	return &dropIndexNode{n: n, p: p}, nil
+}
+
+func (n *dropIndexNode) Start() *roachpb.Error {
+	for _, index := range n.n.IndexList {
+		// Need to retrieve the descriptor again for each index name in
+		// the list: when two or more index names refer to the same table,
+		// the mutation list and new version number created by the first
+		// drop need to be visible to the second drop.
+		tableDesc, pErr := n.p.getTableDesc(index.Table)
+		if pErr != nil || tableDesc == nil {
+			// makePlan() and Start() ultimately run within the same
+			// transaction. If we got a descriptor during makePlan(), we
+			// must have it here too.
+			panic(fmt.Sprintf("table descriptor for %s became unavailable within same txn", index.Table))
+		}
 		idxName := string(index.Index)
 		status, i, err := tableDesc.FindIndexByName(idxName)
 		if err != nil {
-			if n.IfExists {
+			if n.n.IfExists {
 				// Noop.
-				return &emptyNode{}, nil
+				continue
 			}
 			// Index does not exist, but we want it to: error out.
-			return nil, err
+			return roachpb.NewError(err)
 		}
 		// Queue the mutation.
 		switch status {
@@ -154,25 +207,43 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 		case DescriptorIncomplete:
 			switch tableDesc.Mutations[i].Direction {
 			case DescriptorMutation_ADD:
-				return nil, fmt.Errorf("index %q in the middle of being added, try again later", idxName)
+				return roachpb.NewUErrorf("index %q in the middle of being added, try again later", idxName)
 
 			case DescriptorMutation_DROP:
-				return &emptyNode{}, nil
+				continue
 			}
 		}
 		mutationID, err := tableDesc.finalizeMutation()
 		if err != nil {
-			return nil, err
+			return roachpb.NewError(err)
 		}
 		if err := tableDesc.Validate(); err != nil {
-			return nil, err
+			return roachpb.NewError(err)
 		}
-		if err := p.writeTableDesc(tableDesc); err != nil {
-			return nil, err
+		if err := n.p.writeTableDesc(tableDesc); err != nil {
+			return roachpb.NewError(err)
 		}
-		p.notifySchemaChange(tableDesc.ID, mutationID)
+		n.p.notifySchemaChange(tableDesc.ID, mutationID)
 	}
-	return &emptyNode{}, nil
+	return nil
+}
+
+func (n *dropIndexNode) Next() bool                   { return false }
+func (n *dropIndexNode) Columns() []ResultColumn      { return make([]ResultColumn, 0) }
+func (n *dropIndexNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *dropIndexNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *dropIndexNode) DebugValues() debugValues     { return debugValues{} }
+func (n *dropIndexNode) PErr() *roachpb.Error         { return nil }
+func (n *dropIndexNode) SetLimitHint(_ int64, _ bool) {}
+func (n *dropIndexNode) MarkDebug(mode explainMode)   {}
+func (n *dropIndexNode) ExplainPlan(v bool) (string, string, []planNode) {
+	return "drop index", "", nil
+}
+
+type dropTableNode struct {
+	p  *planner
+	n  *parser.DropTable
+	td []*TableDescriptor
 }
 
 // DropTable drops a table.
@@ -180,8 +251,9 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 //   Notes: postgres allows only the table owner to DROP a table.
 //          mysql requires the DROP privilege on the table.
 func (p *planner) DropTable(n *parser.DropTable) (planNode, error) {
-	for i := range n.Names {
-		droppedDesc, err := p.dropTableImpl(n.Names[i])
+	td := make([]*TableDescriptor, 0, len(n.Names))
+	for _, name := range n.Names {
+		droppedDesc, err := p.dropTablePrepare(name)
 		if err != nil {
 			return nil, err
 		}
@@ -190,37 +262,66 @@ func (p *planner) DropTable(n *parser.DropTable) (planNode, error) {
 				continue
 			}
 			// Table does not exist, but we want it to: error out.
-			return nil, tableDoesNotExistError(n.Names[i].String())
+			return nil, tableDoesNotExistError(name.String())
+		}
+		td = append(td, droppedDesc)
+	}
+	if len(td) == 0 {
+		return &emptyNode{}, nil
+	}
+	return &dropTableNode{p: p, n: n, td: td}, nil
+}
+
+func (n *dropTableNode) Start() *roachpb.Error {
+	for _, droppedDesc := range n.td {
+		if droppedDesc == nil {
+			continue
+		}
+		if err := n.p.dropTableImpl(droppedDesc); err != nil {
+			return roachpb.NewError(err)
 		}
 		// Log a Drop Table event for this table.
-		if err := MakeEventLogger(p.leaseMgr).InsertEventRecord(p.txn,
+		if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(n.p.txn,
 			EventLogDropTable,
 			int32(droppedDesc.ID),
-			int32(p.evalCtx.NodeID),
+			int32(n.p.evalCtx.NodeID),
 			struct {
 				TableName string
 				Statement string
 				User      string
-			}{droppedDesc.Name, n.String(), p.session.User},
+			}{droppedDesc.Name, n.n.String(), n.p.session.User},
 		); err != nil {
-			return nil, err
+			return roachpb.NewError(err)
 		}
 	}
-	return &emptyNode{}, nil
+	return nil
 }
 
-// dropTableImpl is used to drop a single table by name, which can result from
-// either a DROP TABLE or DROP DATABASE statement. This method returns the
-// dropped table descriptor, to be used for the purpose of logging the event.
-// The table is not actually truncated or deleted synchronously. Instead, it is
-// marked as deleted (meaning up_version is set and deleted is set) and the
-// actual deletion happens async in a schema changer. Note that, courtesy of
-// up_version, the actual truncation and dropping will only happen once every
-// node ACKs the version of the descriptor with the deleted bit set, meaning the
-// lease manager will not hand out new leases for it and existing leases are
-// released).
+func (n *dropTableNode) Next() bool                   { return false }
+func (n *dropTableNode) Columns() []ResultColumn      { return make([]ResultColumn, 0) }
+func (n *dropTableNode) Ordering() orderingInfo       { return orderingInfo{} }
+func (n *dropTableNode) Values() parser.DTuple        { return parser.DTuple{} }
+func (n *dropTableNode) DebugValues() debugValues     { return debugValues{} }
+func (n *dropTableNode) PErr() *roachpb.Error         { return nil }
+func (n *dropTableNode) SetLimitHint(_ int64, _ bool) {}
+func (n *dropTableNode) MarkDebug(mode explainMode)   {}
+func (n *dropTableNode) ExplainPlan(v bool) (string, string, []planNode) {
+	return "drop table", "", nil
+}
+
+// dropTablePrepare/dropTableImpl is used to drop a single table by
+// name, which can result from either a DROP TABLE or DROP DATABASE
+// statement. This method returns the dropped table descriptor, to be
+// used for the purpose of logging the event.  The table is not
+// actually truncated or deleted synchronously. Instead, it is marked
+// as deleted (meaning up_version is set and deleted is set) and the
+// actual deletion happens async in a schema changer. Note that,
+// courtesy of up_version, the actual truncation and dropping will
+// only happen once every node ACKs the version of the descriptor with
+// the deleted bit set, meaning the lease manager will not hand out
+// new leases for it and existing leases are released).
 // If the table does not exist, this function returns a nil descriptor.
-func (p *planner) dropTableImpl(name *parser.QualifiedName,
+func (p *planner) dropTablePrepare(name *parser.QualifiedName,
 ) (*TableDescriptor, error) {
 	tableDesc, err := p.getTableDesc(name)
 	if err != nil {
@@ -233,13 +334,16 @@ func (p *planner) dropTableImpl(name *parser.QualifiedName,
 	if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
 		return nil, err
 	}
+	return tableDesc, nil
+}
 
+func (p *planner) dropTableImpl(tableDesc *TableDescriptor) error {
 	if err := tableDesc.setUpVersion(); err != nil {
-		return nil, err
+		return err
 	}
 	tableDesc.Deleted = true
-	if err = p.writeTableDesc(tableDesc); err != nil {
-		return nil, err
+	if err := p.writeTableDesc(tableDesc); err != nil {
+		return err
 	}
 	p.notifySchemaChange(tableDesc.ID, invalidMutationID)
 
@@ -260,7 +364,7 @@ func (p *planner) dropTableImpl(name *parser.QualifiedName,
 		return verifyMetadataCallback(systemConfig, tableDesc.ID)
 	})
 
-	return tableDesc, nil
+	return nil
 }
 
 // truncateAndDropTable batches all the commands required for truncating and deleting the

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -757,13 +757,6 @@ SELECT 0x FROM t
 `,
 		},
 		{
-			`CREATE TABLE a (b INT DEFAULT c)`,
-			`default expression contains a variable at or near ")"
-CREATE TABLE a (b INT DEFAULT c)
-                               ^
-`,
-		},
-		{
 			`CREATE TABLE a (b INT DEFAULT (SELECT 1))`,
 			`default expression contains a subquery at or near ")"
 CREATE TABLE a (b INT DEFAULT (SELECT 1))

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -4459,75 +4459,79 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:800
 		{
+			if containsSubquery(sqlDollar[3].union.expr()) {
+				sqllex.Error("default expression contains a subquery")
+				return 1
+			}
 			sqlVAL.union.val = sqlDollar[3].union.expr()
 		}
 	case 42:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:804
+		//line sql.y:808
 		{
 			sqlVAL.union.val = nil
 		}
 	case 43:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:810
+		//line sql.y:814
 		{
 			sqlVAL.union.val = DropCascade
 		}
 	case 44:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:814
+		//line sql.y:818
 		{
 			sqlVAL.union.val = DropRestrict
 		}
 	case 45:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:818
+		//line sql.y:822
 		{
 			sqlVAL.union.val = DropDefault
 		}
 	case 46:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:823
+		//line sql.y:827
 		{
 			unimplemented()
 		}
 	case 47:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:824
+		//line sql.y:828
 		{
 		}
 	case 48:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:827
+		//line sql.y:831
 		{
 			unimplemented()
 		}
 	case 49:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:828
+		//line sql.y:832
 		{
 		}
 	case 53:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:839
+		//line sql.y:843
 		{
 			sqlVAL.union.val = &Delete{Table: sqlDollar[4].union.tblExpr(), Where: newWhere(astWhere, sqlDollar[5].union.expr()), Returning: sqlDollar[6].union.retExprs()}
 		}
 	case 54:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:846
+		//line sql.y:850
 		{
 			sqlVAL.union.val = &DropDatabase{Name: Name(sqlDollar[3].str), IfExists: false}
 		}
 	case 55:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:850
+		//line sql.y:854
 		{
 			sqlVAL.union.val = &DropDatabase{Name: Name(sqlDollar[5].str), IfExists: true}
 		}
 	case 56:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:854
+		//line sql.y:858
 		{
 			sqlVAL.union.val = &DropIndex{
 				IndexList:    sqlDollar[3].union.tableWithIdxList(),
@@ -4537,7 +4541,7 @@ sqldefault:
 		}
 	case 57:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:862
+		//line sql.y:866
 		{
 			sqlVAL.union.val = &DropIndex{
 				IndexList:    sqlDollar[5].union.tableWithIdxList(),
@@ -4547,390 +4551,390 @@ sqldefault:
 		}
 	case 58:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:870
+		//line sql.y:874
 		{
 			sqlVAL.union.val = &DropTable{Names: sqlDollar[3].union.qnames(), IfExists: false}
 		}
 	case 59:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:874
+		//line sql.y:878
 		{
 			sqlVAL.union.val = &DropTable{Names: sqlDollar[5].union.qnames(), IfExists: true}
 		}
 	case 60:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:880
+		//line sql.y:884
 		{
 			sqlVAL.union.val = QualifiedNames{sqlDollar[1].union.qname()}
 		}
 	case 61:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:884
+		//line sql.y:888
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.qnames(), sqlDollar[3].union.qname())
 		}
 	case 62:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:890
+		//line sql.y:894
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 63:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:894
+		//line sql.y:898
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: sqlDollar[2].union.indirect()}
 		}
 	case 64:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:900
+		//line sql.y:904
 		{
 			sqlVAL.union.val = Indirection{NameIndirection(sqlDollar[2].str)}
 		}
 	case 65:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:904
+		//line sql.y:908
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.indirect(), NameIndirection(sqlDollar[3].str))
 		}
 	case 66:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:911
+		//line sql.y:915
 		{
 			sqlVAL.union.val = &Explain{Statement: sqlDollar[2].union.stmt()}
 		}
 	case 67:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:915
+		//line sql.y:919
 		{
 			sqlVAL.union.val = &Explain{Options: sqlDollar[3].union.strs(), Statement: sqlDollar[5].union.stmt()}
 		}
 	case 68:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:921
+		//line sql.y:925
 		{
 			sqlVAL.union.val = sqlDollar[1].union.slct()
 		}
 	case 72:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:930
+		//line sql.y:934
 		{
 			sqlVAL.union.val = []string{sqlDollar[1].str}
 		}
 	case 73:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:934
+		//line sql.y:938
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.strs(), sqlDollar[3].str)
 		}
 	case 75:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:944
+		//line sql.y:948
 		{
 			sqlVAL.union.val = &Grant{Privileges: sqlDollar[2].union.privilegeList(), Grantees: NameList(sqlDollar[6].union.strs()), Targets: sqlDollar[4].union.targetList()}
 		}
 	case 76:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:951
+		//line sql.y:955
 		{
 			sqlVAL.union.val = &Revoke{Privileges: sqlDollar[2].union.privilegeList(), Grantees: NameList(sqlDollar[6].union.strs()), Targets: sqlDollar[4].union.targetList()}
 		}
 	case 77:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:958
+		//line sql.y:962
 		{
 			sqlVAL.union.val = TargetList{Tables: QualifiedNames(sqlDollar[1].union.qnames())}
 		}
 	case 78:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:962
+		//line sql.y:966
 		{
 			sqlVAL.union.val = TargetList{Tables: QualifiedNames(sqlDollar[2].union.qnames())}
 		}
 	case 79:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:966
+		//line sql.y:970
 		{
 			sqlVAL.union.val = TargetList{Databases: NameList(sqlDollar[2].union.strs())}
 		}
 	case 80:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:973
+		//line sql.y:977
 		{
 			sqlVAL.union.val = privilege.List{privilege.ALL}
 		}
 	case 81:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:976
+		//line sql.y:980
 		{
 		}
 	case 82:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:980
+		//line sql.y:984
 		{
 			sqlVAL.union.val = privilege.List{sqlDollar[1].union.privilegeType()}
 		}
 	case 83:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:984
+		//line sql.y:988
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.privilegeList(), sqlDollar[3].union.privilegeType())
 		}
 	case 84:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:991
+		//line sql.y:995
 		{
 			sqlVAL.union.val = privilege.CREATE
 		}
 	case 85:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:995
+		//line sql.y:999
 		{
 			sqlVAL.union.val = privilege.DROP
 		}
 	case 86:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:999
+		//line sql.y:1003
 		{
 			sqlVAL.union.val = privilege.GRANT
 		}
 	case 87:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1003
+		//line sql.y:1007
 		{
 			sqlVAL.union.val = privilege.SELECT
 		}
 	case 88:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1007
+		//line sql.y:1011
 		{
 			sqlVAL.union.val = privilege.INSERT
 		}
 	case 89:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1011
+		//line sql.y:1015
 		{
 			sqlVAL.union.val = privilege.DELETE
 		}
 	case 90:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1015
+		//line sql.y:1019
 		{
 			sqlVAL.union.val = privilege.UPDATE
 		}
 	case 91:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1023
+		//line sql.y:1027
 		{
 			sqlVAL.union.val = []string{sqlDollar[1].str}
 		}
 	case 92:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1027
+		//line sql.y:1031
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.strs(), sqlDollar[3].str)
 		}
 	case 93:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1035
+		//line sql.y:1039
 		{
 			sqlVAL.union.val = sqlDollar[2].union.stmt()
 		}
 	case 94:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1039
+		//line sql.y:1043
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 95:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1043
+		//line sql.y:1047
 		{
 			sqlVAL.union.val = &SetDefaultIsolation{Isolation: sqlDollar[6].union.isoLevel()}
 		}
 	case 96:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1047
+		//line sql.y:1051
 		{
 			sqlVAL.union.val = sqlDollar[3].union.stmt()
 		}
 	case 97:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1053
+		//line sql.y:1057
 		{
 			sqlVAL.union.val = sqlDollar[2].union.stmt()
 		}
 	case 99:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1060
+		//line sql.y:1064
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: UnspecifiedUserPriority}
 		}
 	case 100:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1064
+		//line sql.y:1068
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: UnspecifiedIsolation, UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 101:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1068
+		//line sql.y:1072
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[1].union.isoLevel(), UserPriority: sqlDollar[3].union.userPriority()}
 		}
 	case 102:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1072
+		//line sql.y:1076
 		{
 			sqlVAL.union.val = &SetTransaction{Isolation: sqlDollar[3].union.isoLevel(), UserPriority: sqlDollar[1].union.userPriority()}
 		}
 	case 103:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1079
+		//line sql.y:1083
 		{
 			sqlVAL.union.val = sqlDollar[2].union.userPriority()
 		}
 	case 104:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1085
+		//line sql.y:1089
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.qname(), Values: sqlDollar[3].union.exprs()}
 		}
 	case 105:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1089
+		//line sql.y:1093
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.qname(), Values: sqlDollar[3].union.exprs()}
 		}
 	case 106:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1093
+		//line sql.y:1097
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.qname()}
 		}
 	case 107:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1097
+		//line sql.y:1101
 		{
 			sqlVAL.union.val = &Set{Name: sqlDollar[1].union.qname()}
 		}
 	case 109:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1104
+		//line sql.y:1108
 		{
 			unimplemented()
 		}
 	case 110:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1107
+		//line sql.y:1111
 		{
 			sqlVAL.union.val = &SetTimeZone{Value: sqlDollar[3].union.expr()}
 		}
 	case 111:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1110
+		//line sql.y:1114
 		{
 			unimplemented()
 		}
 	case 113:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1117
+		//line sql.y:1121
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 114:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1121
+		//line sql.y:1125
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 117:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1129
+		//line sql.y:1133
 		{
 			sqlVAL.union.val = ValArg{Name: sqlDollar[1].str}
 		}
 	case 118:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1135
+		//line sql.y:1139
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 119:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1139
+		//line sql.y:1143
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 120:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1143
+		//line sql.y:1147
 		{
 			sqlVAL.union.val = SnapshotIsolation
 		}
 	case 121:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1147
+		//line sql.y:1151
 		{
 			sqlVAL.union.val = SerializableIsolation
 		}
 	case 122:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1151
+		//line sql.y:1155
 		{
 			sqlVAL.union.val = SerializableIsolation
 		}
 	case 123:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1157
+		//line sql.y:1161
 		{
 			sqlVAL.union.val = Low
 		}
 	case 124:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1161
+		//line sql.y:1165
 		{
 			sqlVAL.union.val = Normal
 		}
 	case 125:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1165
+		//line sql.y:1169
 		{
 			sqlVAL.union.val = High
 		}
 	case 126:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1171
+		//line sql.y:1175
 		{
 			sqlVAL.union.val = MakeDBool(true)
 		}
 	case 127:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1175
+		//line sql.y:1179
 		{
 			sqlVAL.union.val = MakeDBool(false)
 		}
 	case 128:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1179
+		//line sql.y:1183
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 130:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1194
+		//line sql.y:1198
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 131:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1198
+		//line sql.y:1202
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 132:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1202
+		//line sql.y:1206
 		{
 			expr := &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType()}
 			typedExpr, err := TypeCheck(expr, nil, NoTypePreference)
@@ -4951,276 +4955,272 @@ sqldefault:
 		}
 	case 134:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1222
+		//line sql.y:1226
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 135:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1226
+		//line sql.y:1230
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 136:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1231
+		//line sql.y:1235
 		{
 			unimplemented()
 		}
 	case 137:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1232
+		//line sql.y:1236
 		{
 			unimplemented()
 		}
 	case 138:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1233
+		//line sql.y:1237
 		{
 		}
 	case 139:
-		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1237
-		{
-			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
-		}
-	case 140:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1241
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
-	case 141:
-		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1247
+	case 140:
+		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
+		//line sql.y:1245
 		{
-			sqlVAL.union.val = &Show{Name: sqlDollar[2].str}
+			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
-	case 142:
+	case 141:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
 		//line sql.y:1251
 		{
 			sqlVAL.union.val = &Show{Name: sqlDollar[2].str}
 		}
+	case 142:
+		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
+		//line sql.y:1255
+		{
+			sqlVAL.union.val = &Show{Name: sqlDollar[2].str}
+		}
 	case 143:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1255
+		//line sql.y:1259
 		{
 			sqlVAL.union.val = &ShowColumns{Table: sqlDollar[4].union.qname()}
 		}
 	case 144:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1259
+		//line sql.y:1263
 		{
 			sqlVAL.union.val = &ShowDatabases{}
 		}
 	case 145:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1263
+		//line sql.y:1267
 		{
 			sqlVAL.union.val = &ShowGrants{Targets: sqlDollar[3].union.targetListPtr(), Grantees: sqlDollar[4].union.strs()}
 		}
 	case 146:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1267
+		//line sql.y:1271
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.qname()}
 		}
 	case 147:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1271
+		//line sql.y:1275
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.qname()}
 		}
 	case 148:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1275
+		//line sql.y:1279
 		{
 			sqlVAL.union.val = &ShowIndex{Table: sqlDollar[4].union.qname()}
 		}
 	case 149:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1279
+		//line sql.y:1283
 		{
 			sqlVAL.union.val = &ShowTables{Name: sqlDollar[3].union.qname()}
 		}
 	case 150:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1283
+		//line sql.y:1287
 		{
 			sqlVAL.union.val = &Show{Name: "TIME ZONE"}
 		}
 	case 151:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1287
+		//line sql.y:1291
 		{
 			sqlVAL.union.val = &Show{Name: "TRANSACTION ISOLATION LEVEL"}
 		}
 	case 152:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1291
+		//line sql.y:1295
 		{
 			sqlVAL.union.val = &Show{Name: "TRANSACTION PRIORITY"}
 		}
 	case 153:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1295
+		//line sql.y:1299
 		{
 			sqlVAL.union.val = Statement(nil)
 		}
 	case 154:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1299
+		//line sql.y:1303
 		{
 			sqlVAL.union.val = &ShowCreateTable{Table: sqlDollar[4].union.qname()}
 		}
 	case 155:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1305
+		//line sql.y:1309
 		{
 			sqlVAL.union.val = sqlDollar[2].union.qname()
 		}
 	case 156:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1309
+		//line sql.y:1313
 		{
 			sqlVAL.union.val = (*QualifiedName)(nil)
 		}
 	case 157:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1315
+		//line sql.y:1319
 		{
 			tmp := sqlDollar[2].union.targetList()
 			sqlVAL.union.val = &tmp
 		}
 	case 158:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1320
+		//line sql.y:1324
 		{
 			sqlVAL.union.val = (*TargetList)(nil)
 		}
 	case 159:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1326
+		//line sql.y:1330
 		{
 			sqlVAL.union.val = sqlDollar[2].union.strs()
 		}
 	case 160:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1330
+		//line sql.y:1334
 		{
 			sqlVAL.union.val = []string(nil)
 		}
 	case 161:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:1337
+		//line sql.y:1341
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[3].union.qname(), IfNotExists: false, Defs: sqlDollar[5].union.tblDefs()}
 		}
 	case 162:
 		sqlDollar = sqlS[sqlpt-9 : sqlpt+1]
-		//line sql.y:1341
+		//line sql.y:1345
 		{
 			sqlVAL.union.val = &CreateTable{Table: sqlDollar[6].union.qname(), IfNotExists: true, Defs: sqlDollar[8].union.tblDefs()}
 		}
 	case 164:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1348
+		//line sql.y:1352
 		{
 			sqlVAL.union.val = TableDefs(nil)
 		}
 	case 165:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1354
+		//line sql.y:1358
 		{
 			sqlVAL.union.val = TableDefs{sqlDollar[1].union.tblDef()}
 		}
 	case 166:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1358
+		//line sql.y:1362
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tblDefs(), sqlDollar[3].union.tblDef())
 		}
 	case 167:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1364
+		//line sql.y:1368
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colDef()
 		}
 	case 169:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1369
+		//line sql.y:1373
 		{
 			sqlVAL.union.val = sqlDollar[1].union.constraintDef()
 		}
 	case 170:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1375
+		//line sql.y:1379
 		{
 			sqlVAL.union.val = newColumnTableDef(Name(sqlDollar[1].str), sqlDollar[2].union.colType(), sqlDollar[3].union.colQuals())
 		}
 	case 171:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1381
+		//line sql.y:1385
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.colQuals(), sqlDollar[2].union.colQual())
 		}
 	case 172:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:1385
+		//line sql.y:1389
 		{
 			sqlVAL.union.val = []ColumnQualification(nil)
 		}
 	case 173:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:1391
+		//line sql.y:1395
 		{
 			sqlVAL.union.val = sqlDollar[3].union.colQual()
 		}
 	case 175:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1395
+		//line sql.y:1399
 		{
 			unimplemented()
 		}
 	case 176:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1411
+		//line sql.y:1415
 		{
 			sqlVAL.union.val = NotNullConstraint{}
 		}
 	case 177:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1415
+		//line sql.y:1419
 		{
 			sqlVAL.union.val = NullConstraint{}
 		}
 	case 178:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1419
+		//line sql.y:1423
 		{
 			sqlVAL.union.val = UniqueConstraint{}
 		}
 	case 179:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1423
+		//line sql.y:1427
 		{
 			sqlVAL.union.val = PrimaryKeyConstraint{}
 		}
 	case 180:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:1427
+		//line sql.y:1431
 		{
 			sqlVAL.union.val = &ColumnCheckConstraint{Expr: sqlDollar[3].union.expr()}
 		}
 	case 181:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:1431
+		//line sql.y:1435
 		{
-			if ContainsVars(sqlDollar[2].union.expr()) {
-				sqllex.Error("default expression contains a variable")
-				return 1
-			}
 			if containsSubquery(sqlDollar[2].union.expr()) {
 				sqllex.Error("default expression contains a subquery")
 				return 1

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -798,6 +798,10 @@ alter_table_cmd:
 alter_column_default:
   SET DEFAULT a_expr
   {
+    if containsSubquery($3.expr()) {
+      sqllex.Error("default expression contains a subquery")
+      return 1
+    }
     $$.val = $3.expr()
   }
 | DROP DEFAULT
@@ -1429,10 +1433,6 @@ col_qualification_elem:
   }
 | DEFAULT b_expr
   {
-    if ContainsVars($2.expr()) {
-      sqllex.Error("default expression contains a variable")
-      return 1
-    }
     if containsSubquery($2.expr()) {
       sqllex.Error("default expression contains a subquery")
       return 1

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -510,6 +510,16 @@ var _ planNode = &unionNode{}
 var _ planNode = &emptyNode{}
 var _ planNode = &explainDebugNode{}
 var _ planNode = &explainTraceNode{}
+var _ planNode = &insertNode{}
+var _ planNode = &updateNode{}
+var _ planNode = &deleteNode{}
+var _ planNode = &createDatabaseNode{}
+var _ planNode = &createTableNode{}
+var _ planNode = &createIndexNode{}
+var _ planNode = &dropDatabaseNode{}
+var _ planNode = &dropTableNode{}
+var _ planNode = &dropIndexNode{}
+var _ planNode = &alterTableNode{}
 
 // emptyNode is a planNode with no columns and either no rows (default) or a single row with empty
 // results (if results is initialized to true). The former is used for nodes that have no results

--- a/sql/testdata/alter_table
+++ b/sql/testdata/alter_table
@@ -217,6 +217,15 @@ ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 10
 statement ok
 INSERT INTO add_default (a) VALUES (3)
 
+statement error incompatible column type
+ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 'foo'
+
+statement error default expression .* may not contain placeholders
+ALTER TABLE add_default ALTER COLUMN b SET DEFAULT $1
+
+statement error default expression contains a subquery
+ALTER TABLE add_default ALTER COLUMN b SET DEFAULT (SELECT 1)
+
 statement ok
 ALTER TABLE add_default ALTER COLUMN b DROP DEFAULT
 

--- a/sql/testdata/default
+++ b/sql/testdata/default
@@ -1,5 +1,8 @@
-statement error incompatible column type and default expression: INT vs bool
+statement error incompatible column type and default expression: int vs bool
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT false)
+
+statement error default expression .* may not contain placeholders
+CREATE TABLE t (a INT PRIMARY KEY DEFAULT $1)
 
 statement ok
 CREATE TABLE t (

--- a/sql/testdata/drop_index
+++ b/sql/testdata/drop_index
@@ -80,6 +80,12 @@ CREATE INDEX foo ON users (name)
 statement ok
 CREATE INDEX bar ON users (title)
 
+statement ok
+CREATE INDEX baz ON users (name, title)
+
+statement ok
+DROP INDEX IF EXISTS users@invalid, users@baz
+
 query TTBITTB colnames
 SHOW INDEXES FROM users
 ----


### PR DESCRIPTION
This patch furthers the agenda introduced in
e2838ca2d68ec9682df77c308dbe9aa4a9d7634a to minimize the amount of
logic run during a SQL prepare phase, for the various CREATE, DROP and
ALTER TABLE statements.

In doing so this patch also addresses a few other issues:
- DROP INDEX did not validate its table descriptors properly. This is
  now fixed.
- DROP INDEX IF EXISTS with two or more index names would fail to
  delete the 2nd or later indices if the  1st index does
  not exist. This is now fixed.
- ALTER TABLE did not check type compatibility between a new DEFAULT
  expression and its column type. This is now fixed.
- CREATE TABLE and ALTER TABLE did not check for the presence
  of placeholders ($xx) in DEFAULT expressions, deferring this check
  to INSERT or UPDATE. This patch now performs the check in CREATE
  and ALTER TABLE instead.
- ALTER TABLE now avoids querying the database two times to obtain a table descriptor.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6492)

<!-- Reviewable:end -->
