### PR TITLE
sql: Create IsUnresolvedArgument method on MapArgs

### DIFF
--- a/sql/parser/overload.go
+++ b/sql/parser/overload.go
@@ -188,7 +188,7 @@ func typeCheckOverloadedExprs(
 		switch {
 		case isNumericConstant(expr):
 			constExprs = append(constExprs, idxExpr)
-		case isUnresolvedVariable(args, expr):
+		case args.IsUnresolvedArgument(expr):
 			valExprs = append(valExprs, idxExpr)
 		default:
 			resolvableExprs = append(resolvableExprs, idxExpr)

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -224,7 +224,7 @@ func (expr *CastExpr) TypeCheck(args MapArgs, desired Datum) (TypedExpr, error) 
 		validTypes = intervalCastTypes
 	}
 
-	if isUnresolvedArgument(args, expr.Expr) {
+	if args.IsUnresolvedArgument(expr.Expr) {
 		desired = DummyString
 	} else if desired != nil && desired.TypeEqual(returnDatum) {
 		desired = nil
@@ -684,27 +684,6 @@ func verifyTupleIN(args MapArgs, arg, values Datum) error {
 	return nil
 }
 
-func isUnresolvedArgument(args MapArgs, expr Expr) bool {
-	if t, ok := expr.(ValArg); ok {
-		if _, ok := args[t.Name]; !ok {
-			return true
-		}
-	}
-	return false
-}
-
-func isUnresolvedVariable(args MapArgs, expr Expr) bool {
-	// TODO(nvanbenschoten) move to expr.go
-	if t, ok := expr.(ValArg); ok {
-		_, ok := args[t.Name]
-		return !ok
-	}
-	if _, ok := expr.(*QualifiedName); ok {
-		return true
-	}
-	return false
-}
-
 type indexedExpr struct {
 	e Expr
 	i int
@@ -736,7 +715,7 @@ func typeCheckSameTypedExprs(args MapArgs, desired Datum, exprs ...Expr) ([]Type
 		switch {
 		case isNumericConstant(expr):
 			constExprs = append(constExprs, idxExpr)
-		case isUnresolvedVariable(args, expr):
+		case args.IsUnresolvedArgument(expr):
 			valExprs = append(valExprs, idxExpr)
 		default:
 			resolvableExprs = append(resolvableExprs, idxExpr)

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -800,6 +800,18 @@ func (m MapArgs) SetInferredType(d, typ Datum) (set Datum, err error) {
 	return typ, nil
 }
 
+// IsUnresolvedArgument returns whether expr is an unresolved var argument. In
+// other words, it returns whether the provided expression is an argument, and
+// if so, whether the variable's type remains unset or not.
+func (m MapArgs) IsUnresolvedArgument(expr Expr) bool {
+	if t, ok := expr.(ValArg); ok {
+		if _, ok := m[t.Name]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
 type argVisitor struct {
 	args Args
 	err  error


### PR DESCRIPTION
The new `IsUnresolvedArgument` determines if a provided expression is a
`ValArg` whose inferred type remains unset.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6499)

<!-- Reviewable:end -->
