### PR TITLE
sql: Create placeholderAnnotationVisitor to process placeholder annotations

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -292,6 +292,9 @@ func (e *Executor) Prepare(ctx context.Context, query string, session *Session, 
 	if err != nil {
 		return nil, err
 	}
+	if err = parser.ProcessPlaceholderAnnotations(stmt, args); err != nil {
+		return nil, err
+	}
 
 	session.planner.resetForBatch(e)
 	session.planner.evalCtx.Args = args

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -1079,6 +1079,44 @@ func (node *CastExpr) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteByte(')')
 }
 
+var (
+	boolCastTypes      = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString}
+	intCastTypes       = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString}
+	floatCastTypes     = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString}
+	decimalCastTypes   = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString}
+	stringCastTypes    = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeBytes, TypeTimestamp, TypeTimestampTZ}
+	bytesCastTypes     = []Datum{DNull, TypeString, TypeBytes}
+	dateCastTypes      = []Datum{DNull, TypeString, TypeDate, TypeTimestamp}
+	timestampCastTypes = []Datum{DNull, TypeString, TypeDate, TypeTimestamp, TypeTimestampTZ}
+	intervalCastTypes  = []Datum{DNull, TypeString, TypeInt, TypeInterval}
+)
+
+func (node *CastExpr) castTypeAndValidArgTypes() (Datum, []Datum) {
+	switch node.Type.(type) {
+	case *BoolColType:
+		return TypeBool, boolCastTypes
+	case *IntColType:
+		return TypeInt, intCastTypes
+	case *FloatColType:
+		return TypeFloat, floatCastTypes
+	case *DecimalColType:
+		return TypeDecimal, decimalCastTypes
+	case *StringColType:
+		return TypeString, stringCastTypes
+	case *BytesColType:
+		return TypeBytes, bytesCastTypes
+	case *DateColType:
+		return TypeDate, dateCastTypes
+	case *TimestampColType:
+		return TypeTimestamp, timestampCastTypes
+	case *TimestampTZColType:
+		return TypeTimestampTZ, timestampCastTypes
+	case *IntervalColType:
+		return TypeInterval, intervalCastTypes
+	}
+	return nil, nil
+}
+
 func (node *AliasedTableExpr) String() string { return AsString(node) }
 func (node *ParenTableExpr) String() string   { return AsString(node) }
 func (node *JoinTableExpr) String() string    { return AsString(node) }

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -172,68 +172,13 @@ func (expr *CaseExpr) TypeCheck(args MapArgs, desired Datum) (TypedExpr, error) 
 	return expr, nil
 }
 
-var (
-	boolCastTypes      = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString}
-	intCastTypes       = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString}
-	floatCastTypes     = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString}
-	decimalCastTypes   = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString}
-	stringCastTypes    = []Datum{DNull, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeBytes, TypeTimestamp, TypeTimestampTZ}
-	bytesCastTypes     = []Datum{DNull, TypeBytes, TypeString}
-	dateCastTypes      = []Datum{DNull, TypeString, TypeDate, TypeTimestamp}
-	timestampCastTypes = []Datum{DNull, TypeString, TypeDate, TypeTimestamp, TypeTimestampTZ}
-	intervalCastTypes  = []Datum{DNull, TypeString, TypeInt, TypeInterval}
-)
-
 // TypeCheck implements the Expr interface.
 func (expr *CastExpr) TypeCheck(args MapArgs, desired Datum) (TypedExpr, error) {
-	var returnDatum Datum
-	var validTypes []Datum
-	switch expr.Type.(type) {
-	case *BoolColType:
-		returnDatum = TypeBool
-		validTypes = boolCastTypes
+	returnDatum, validTypes := expr.castTypeAndValidArgTypes()
 
-	case *IntColType:
-		returnDatum = TypeInt
-		validTypes = intCastTypes
-
-	case *FloatColType:
-		returnDatum = TypeFloat
-		validTypes = floatCastTypes
-
-	case *DecimalColType:
-		returnDatum = TypeDecimal
-		validTypes = decimalCastTypes
-
-	case *StringColType:
-		returnDatum = TypeString
-		validTypes = stringCastTypes
-
-	case *BytesColType:
-		returnDatum = TypeBytes
-		validTypes = bytesCastTypes
-
-	case *DateColType:
-		returnDatum = TypeDate
-		validTypes = dateCastTypes
-
-	case *TimestampColType:
-		returnDatum = TypeTimestamp
-		validTypes = timestampCastTypes
-
-	case *TimestampTZColType:
-		returnDatum = TypeTimestampTZ
-		validTypes = timestampCastTypes
-
-	case *IntervalColType:
-		returnDatum = TypeInterval
-		validTypes = intervalCastTypes
-	}
-
+	desired = nil
 	if args.IsUnresolvedArgument(expr.Expr) {
 		desired = TypeString
-	} else if desired != nil && desired.TypeEqual(returnDatum) {
-		desired = nil
 	}
 	typedSubExpr, err := expr.Expr.TypeCheck(args, desired)
 	if err != nil {
@@ -951,6 +896,68 @@ func checkAllTuplesHaveLength(exprs []Expr, expectedLen int) error {
 		t := expr.(*Tuple)
 		if len(t.Exprs) != expectedLen {
 			return fmt.Errorf("expected tuple %v to have a length of %d", t, expectedLen)
+		}
+	}
+	return nil
+}
+
+type placeholderAnnotationVisitor struct {
+	placeholders map[string]annotationState
+}
+
+type annotationState struct {
+	every bool
+	typ   Datum
+}
+
+func (v *placeholderAnnotationVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
+	switch t := expr.(type) {
+	// TODO(nvanbenschoten) Add support for explicit type annotations.
+	// case *TypeAnnotationExpr:
+	case *CastExpr:
+		if arg, ok := t.Expr.(ValArg); ok {
+			castType, _ := t.castTypeAndValidArgTypes()
+			if state, ok := v.placeholders[arg.Name]; ok {
+				if state.every && !castType.TypeEqual(state.typ) {
+					state.every = false
+					v.placeholders[arg.Name] = state
+				}
+			} else {
+				v.placeholders[arg.Name] = annotationState{
+					every: true,
+					typ:   castType,
+				}
+			}
+			return false, expr
+		}
+	case ValArg:
+		v.placeholders[t.Name] = annotationState{every: false}
+	}
+	return true, expr
+}
+
+func (*placeholderAnnotationVisitor) VisitPost(expr Expr) Expr { return expr }
+
+// ProcessPlaceholderAnnotations performs an order-independent global traversal of the
+// provided Statement, annotating all placeholders with a type in either of the following
+// situations.
+// - the placeholder is the subject of an explicit type annotation in at least one
+//   of its occurrences. If it is subject to multiple explicit type annotations where
+//   the types are not all in agreement, and error will be thrown.
+// - the placeholder is the subject to an implicit type annotation, meaning that it
+//   is not subject to an explicit type annotation, and that in all occurrences of the
+//   placeholder, it is subject to a cast to the same type. If it is subject to casts
+//   of multiple types, no error will be thrown, but the placeholder will not be
+//   annotated.
+//
+// TODO(nvanbenschoten) Add support for explicit placeholder annotations.
+// TODO(nvanbenschoten) Can this visitor and map be preallocated (like normalizeVisitor)?
+func ProcessPlaceholderAnnotations(stmt Statement, args MapArgs) error {
+	v := placeholderAnnotationVisitor{make(map[string]annotationState)}
+	WalkStmt(&v, stmt)
+	for placeholder, state := range v.placeholders {
+		if _, ok := args[placeholder]; !ok && state.every {
+			args[placeholder] = state.typ
 		}
 	}
 	return nil

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -337,16 +337,17 @@ func TestPGPreparedQuery(t *testing.T) {
 			base.Params("true").Results(true),
 			base.Params("false").Results(false),
 			base.Params("1").Results(true),
-			base.Params(2).Error(`pq: strconv.ParseBool: parsing "2": invalid syntax`),
-			base.Params(3.1).Error(`pq: strconv.ParseBool: parsing "3.1": invalid syntax`),
-			base.Params("").Error(`pq: strconv.ParseBool: parsing "": invalid syntax`),
+			base.Params(2).Error(`pq: param $1: strconv.ParseBool: parsing "2": invalid syntax`),
+			base.Params(3.1).Error(`pq: param $1: strconv.ParseBool: parsing "3.1": invalid syntax`),
+			base.Params("").Error(`pq: param $1: strconv.ParseBool: parsing "": invalid syntax`),
 		},
 		"SELECT $1::int > $2::float": {
+			base.Params(2, 1).Results(true),
 			base.Params("2", 1).Results(true),
 			base.Params(1, "2").Results(false),
 			base.Params("2", "1.0").Results(true),
-			base.Params("2.0", "1").Error(`pq: strconv.ParseInt: parsing "2.0": invalid syntax`),
-			base.Params(2.1, 1).Error(`pq: strconv.ParseInt: parsing "2.1": invalid syntax`),
+			base.Params("2.0", "1").Error(`pq: param $1: strconv.ParseInt: parsing "2.0": invalid syntax`),
+			base.Params(2.1, 1).Error(`pq: param $1: strconv.ParseInt: parsing "2.1": invalid syntax`),
 		},
 		"SELECT GREATEST($1, 0, $2), $2": {
 			base.Params(1, -1).Results(1, -1),
@@ -355,6 +356,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			base.Params(1, 2.1).Error(`pq: param $2: strconv.ParseInt: parsing "2.1": invalid syntax`),
 		},
 		"SELECT $1::int, $1::float": {
+			base.Params(1).Results(1, 1.0),
 			base.Params("1").Results(1, 1.0),
 		},
 		"SELECT 3 + $1, $1 + $2": {
@@ -489,6 +491,9 @@ func TestPGPreparedQuery(t *testing.T) {
 		},
 		"SELECT TO_HEX(~(~$1))": {
 			base.Params(12).Results("c"),
+		},
+		"SELECT $1::INT": {
+			base.Params(12).Results(12),
 		},
 		"INSERT INTO d.T VALUES ($1 + 1) RETURNING a": {
 			base.Params(1).Results(2),


### PR DESCRIPTION
This visitor performs an order-independent global traversal of the provided
Statement, annotating all placeholders with a type in either of the
following situations.
- the placeholder is the subject of an explicit type annotation in at least one
  of its occurrences. If it is subject to multiple explicit type annotations where
  the types are not all in agreement, and error will be thrown. _(not implemented yet)_
- the placeholder is the subject to an implicit type annotation, meaning that it
  is not subject to an explicit type annotation, and that in all occurrences of the
  placeholder, it is subject to a cast to the same type. If it is subject to casts
  of multiple types, no error will be thrown, but the placeholder will not be
  annotated.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6504)

<!-- Reviewable:end -->
