### PR TITLE
sql/parser: Remove Row expression type in favor of Tuple

### DIFF
--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -1904,9 +1904,10 @@ func (expr *QualifiedName) Eval(ctx EvalContext) (Datum, error) {
 	return nil, util.Errorf("unhandled type %T", expr)
 }
 
-func evalExprs(ctx EvalContext, exprs []Expr) (Datum, error) {
-	tuple := make(DTuple, 0, len(exprs))
-	for _, v := range exprs {
+// Eval implements the Expr interface.
+func (t *Tuple) Eval(ctx EvalContext) (Datum, error) {
+	tuple := make(DTuple, 0, len(t.Exprs))
+	for _, v := range t.Exprs {
 		d, err := v.(TypedExpr).Eval(ctx)
 		if err != nil {
 			return DNull, err
@@ -1914,16 +1915,6 @@ func evalExprs(ctx EvalContext, exprs []Expr) (Datum, error) {
 		tuple = append(tuple, d)
 	}
 	return &tuple, nil
-}
-
-// Eval implements the Expr interface.
-func (t *Row) Eval(ctx EvalContext) (Datum, error) {
-	return evalExprs(ctx, t.Exprs)
-}
-
-// Eval implements the Expr interface.
-func (t *Tuple) Eval(ctx EvalContext) (Datum, error) {
-	return evalExprs(ctx, t.Exprs)
 }
 
 // Eval implements the Expr interface.

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -756,11 +756,15 @@ func (n TableNameWithIndexList) Format(buf *bytes.Buffer, f FmtFlags) {
 type Tuple struct {
 	Exprs Exprs
 
+	row   bool // indicates whether or not the tuple should be textually represented as a row.
 	types DTuple
 }
 
 // Format implements the NodeFormatter interface.
 func (node *Tuple) Format(buf *bytes.Buffer, f FmtFlags) {
+	if node.row {
+		buf.WriteString("ROW")
+	}
 	buf.WriteByte('(')
 	FormatNode(buf, f, node.Exprs)
 	buf.WriteByte(')')
@@ -768,26 +772,6 @@ func (node *Tuple) Format(buf *bytes.Buffer, f FmtFlags) {
 
 // ReturnType implements the TypedExpr interface.
 func (node *Tuple) ReturnType() Datum {
-	return &node.types
-}
-
-// Row represents a parenthesized list of expressions. Similar to Tuple except
-// in how it is textually represented.
-type Row struct {
-	Exprs Exprs
-
-	types DTuple
-}
-
-// Format implements the NodeFormatter interface.
-func (node *Row) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ROW(")
-	FormatNode(buf, f, node.Exprs)
-	buf.WriteByte(')')
-}
-
-// ReturnType implements the TypedExpr interface.
-func (node *Row) ReturnType() Datum {
 	return &node.types
 }
 
@@ -1101,7 +1085,6 @@ func (node *OverlayExpr) String() string      { return AsString(node) }
 func (node *ParenExpr) String() string        { return AsString(node) }
 func (node *QualifiedName) String() string    { return AsString(node) }
 func (node *RangeCond) String() string        { return AsString(node) }
-func (node *Row) String() string              { return AsString(node) }
 func (node *StrVal) String() string           { return AsString(node) }
 func (node *Subquery) String() string         { return AsString(node) }
 func (node *Tuple) String() string            { return AsString(node) }

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -318,20 +318,12 @@ func (expr *RangeCond) normalize(v *normalizeVisitor) TypedExpr {
 	)
 }
 
-func (expr *Row) normalize(v *normalizeVisitor) TypedExpr {
-	return &Tuple{
-		Exprs: expr.Exprs,
-		types: expr.types,
-	}
-}
-
 // NormalizeExpr normalizes a typed expression, simplifying where possible,
 // but guaranteeing that the result of evaluating the expression is
 // unchanged and that resulting expression tree is still well-typed.
 // Example normalizations:
 //
 //   (a)                   -> a
-//   ROW(a, b, c)          -> (a, b, c)
 //   a = 1 + 1             -> a = 2
 //   a + 1 = 2             -> a = 1
 //   a BETWEEN b AND c     -> (a >= b) AND (a <= c)

--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -25,7 +25,6 @@ func TestNormalizeExpr(t *testing.T) {
 	}{
 		{`(a)`, `a`},
 		{`((((a))))`, `a`},
-		{`ROW(a)`, `(a)`},
 		{`a BETWEEN b AND c`, `(a >= b) AND (a <= c)`},
 		{`a NOT BETWEEN b AND c`, `(a < b) OR (a > c)`},
 		{`1+1`, `2`},

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -7809,13 +7809,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
 		//line sql.y:3477
 		{
-			sqlVAL.union.val = &Row{Exprs: sqlDollar[3].union.exprs()}
+			sqlVAL.union.val = &Tuple{Exprs: sqlDollar[3].union.exprs(), row: true}
 		}
 	case 630:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:3481
 		{
-			sqlVAL.union.val = &Row{Exprs: nil}
+			sqlVAL.union.val = &Tuple{Exprs: nil, row: true}
 		}
 	case 631:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
@@ -7827,13 +7827,13 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
 		//line sql.y:3491
 		{
-			sqlVAL.union.val = &Row{Exprs: sqlDollar[3].union.exprs()}
+			sqlVAL.union.val = &Tuple{Exprs: sqlDollar[3].union.exprs(), row: true}
 		}
 	case 633:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
 		//line sql.y:3495
 		{
-			sqlVAL.union.val = &Row{Exprs: nil}
+			sqlVAL.union.val = &Tuple{Exprs: nil, row: true}
 		}
 	case 634:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -3475,11 +3475,11 @@ frame_bound:
 row:
   ROW '(' expr_list ')'
   {
-    $$.val = &Row{Exprs: $3.exprs()}
+    $$.val = &Tuple{Exprs: $3.exprs(), row: true}
   }
 | ROW '(' ')'
   {
-    $$.val = &Row{Exprs: nil}
+    $$.val = &Tuple{Exprs: nil, row: true}
   }
 | '(' expr_list ',' a_expr ')'
   {
@@ -3489,11 +3489,11 @@ row:
 explicit_row:
   ROW '(' expr_list ')'
   {
-    $$.val = &Row{Exprs: $3.exprs()}
+    $$.val = &Tuple{Exprs: $3.exprs(), row: true}
   }
 | ROW '(' ')'
   {
-    $$.val = &Row{Exprs: nil}
+    $$.val = &Tuple{Exprs: nil, row: true}
   }
 
 implicit_row:

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -338,17 +338,6 @@ func (expr *Array) Walk(v Visitor) Expr {
 }
 
 // Walk implements the Expr interface.
-func (expr *Row) Walk(v Visitor) Expr {
-	exprs, changed := walkExprSlice(v, expr.Exprs)
-	if changed {
-		exprCopy := *expr
-		exprCopy.Exprs = exprs
-		return &exprCopy
-	}
-	return expr
-}
-
-// Walk implements the Expr interface.
 func (expr *Tuple) Walk(v Visitor) Expr {
 	exprs, changed := walkExprSlice(v, expr.Exprs)
 	if changed {


### PR DESCRIPTION
The `Row` type was created exclusively to alter how a `Tuple` is
represented as a string. It makes type-checking, normalization, and
evaluations easier to just add a "row" flag to the `Tuple` struct.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6506)

<!-- Reviewable:end -->
