### PR TITLE
[wip] storage: gossip store statuses after each range snapshot, split, merge and remove.

### DIFF
--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -720,6 +720,11 @@ func (r *Replica) applySnapshot(batch engine.Engine, snap raftpb.Snapshot) (uint
 			panic(err)
 		}
 	})
+
+	// After applying a snapshot, always have the store gossip its store
+	// descriptor to keep the cluster as up to date as possible.
+	go r.store.GossipStore()
+
 	return snap.Metadata.Index, nil
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -1336,6 +1336,11 @@ func (s *Store) SplitRange(origRng, newRng *Replica) error {
 	}
 
 	s.metrics.replicaCount.Inc(1)
+
+	// After splitting a range, always have the store gossip its store
+	// descriptor to keep the cluster as up to date as possible.
+	go s.GossipStore()
+
 	return s.processRangeDescriptorUpdateLocked(origRng)
 }
 
@@ -1373,6 +1378,10 @@ func (s *Store) MergeRange(subsumingRng *Replica, updatedEndKey roachpb.RKey, su
 	if err := subsumingRng.setDesc(&copy); err != nil {
 		return err
 	}
+
+	// After merging a range, always have the store gossip its store
+	// descriptor to keep the cluster as up to date as possible.
+	go s.GossipStore()
 
 	return nil
 }
@@ -1433,6 +1442,11 @@ func (s *Store) addReplicaToRangeMapLocked(rng *Replica) error {
 func (s *Store) RemoveReplica(rep *Replica, origDesc roachpb.RangeDescriptor, destroy bool) error {
 	s.processRaftMu.Lock()
 	defer s.processRaftMu.Unlock()
+
+	// After removing a replica, always have the store gossip its store
+	// descriptor to keep the cluster as up to date as possible.
+	go s.GossipStore()
+
 	return s.removeReplicaImpl(rep, origDesc, destroy)
 }
 


### PR DESCRIPTION
After each of these events, the storeDescriptor (usually the storeCapacity) will
have changed. So to ensure that the cluster has the most up to date information,
instead of waiting for the minute to expire, gossip the update right away.

This shouldn't be merged until we can test if this improves our rebalancing metrics.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6507)

<!-- Reviewable:end -->
