### PR TITLE
sql: change lease acquisition methods to return error instead of pErr

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -45,9 +45,9 @@ type deleteNode struct {
 //   Notes: postgres requires DELETE. Also requires SELECT for "USING" and "WHERE" with tables.
 //          mysql requires DELETE. Also requires SELECT if a table is used in the "WHERE" clause.
 func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoCommit bool) (planNode, *roachpb.Error) {
-	en, pErr := p.makeEditNode(n.Table, n.Returning, desiredTypes, autoCommit, privilege.DELETE)
-	if pErr != nil {
-		return nil, pErr
+	en, err := p.makeEditNode(n.Table, n.Returning, desiredTypes, autoCommit, privilege.DELETE)
+	if err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	// TODO(knz): Until we split the creation of the node from Start()
@@ -55,7 +55,7 @@ func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoComm
 	// this node's initSelect() method both does type checking and also
 	// performs index selection. We cannot perform index selection
 	// properly until the placeholder values are known.
-	_, pErr = p.SelectClause(&parser.SelectClause{
+	_, pErr := p.SelectClause(&parser.SelectClause{
 		Exprs: en.tableDesc.allColumnsSelector(),
 		From:  []parser.TableExpr{n.Table},
 		Where: n.Where,

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -57,9 +57,9 @@ type insertNode struct {
 func (p *planner) Insert(
 	n *parser.Insert, desiredTypes []parser.Datum, autoCommit bool,
 ) (planNode, *roachpb.Error) {
-	en, pErr := p.makeEditNode(n.Table, n.Returning, desiredTypes, autoCommit, privilege.INSERT)
-	if pErr != nil {
-		return nil, pErr
+	en, err := p.makeEditNode(n.Table, n.Returning, desiredTypes, autoCommit, privilege.INSERT)
+	if err != nil {
+		return nil, roachpb.NewError(err)
 	}
 	if n.OnConflict != nil {
 		if err := p.checkPrivilege(en.tableDesc, privilege.UPDATE); err != nil {

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/tracing"
 )
@@ -390,18 +391,18 @@ func (p *planner) exec(sql string, args ...interface{}) (int, *roachpb.Error) {
 
 // getAliasedTableLease looks up the table descriptor for an alias table
 // expression.
-func (p *planner) getAliasedTableLease(n parser.TableExpr) (*TableDescriptor, *roachpb.Error) {
+func (p *planner) getAliasedTableLease(n parser.TableExpr) (*TableDescriptor, error) {
 	ate, ok := n.(*parser.AliasedTableExpr)
 	if !ok {
-		return nil, roachpb.NewErrorf("TODO(pmattis): unsupported FROM: %s", n)
+		return nil, util.Errorf("TODO(pmattis): unsupported FROM: %s", n)
 	}
 	table, ok := ate.Expr.(*parser.QualifiedName)
 	if !ok {
-		return nil, roachpb.NewErrorf("TODO(pmattis): unsupported FROM: %s", n)
+		return nil, util.Errorf("TODO(pmattis): unsupported FROM: %s", n)
 	}
-	desc, pErr := p.getTableLease(table)
-	if pErr != nil {
-		return nil, pErr
+	desc, err := p.getTableLease(table)
+	if err != nil {
+		return nil, err
 	}
 	return &desc, nil
 }

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -224,7 +224,10 @@ func (n *scanNode) ExplainTypes(regTypes func(string, string)) {
 func (n *scanNode) initTable(
 	p *planner, tableName *parser.QualifiedName, indexHints *parser.IndexHints,
 ) (string, *roachpb.Error) {
-	if n.desc, n.pErr = p.getTableLease(tableName); n.pErr != nil {
+	var err error
+	n.desc, err = p.getTableLease(tableName)
+	if err != nil {
+		n.pErr = roachpb.NewError(err)
 		return "", n.pErr
 	}
 

--- a/sql/truncate.go
+++ b/sql/truncate.go
@@ -31,9 +31,9 @@ import (
 //          mysql requires DROP (for mysql >= 5.1.16, DELETE before that).
 func (p *planner) Truncate(n *parser.Truncate) (planNode, error) {
 	for _, tableQualifiedName := range n.Tables {
-		tableDesc, pErr := p.getTableLease(tableQualifiedName)
-		if pErr != nil {
-			return nil, pErr.GoError()
+		tableDesc, err := p.getTableLease(tableQualifiedName)
+		if err != nil {
+			return nil, err
 		}
 
 		if err := p.checkPrivilege(&tableDesc, privilege.DROP); err != nil {

--- a/sql/update.go
+++ b/sql/update.go
@@ -38,19 +38,19 @@ type editNodeBase struct {
 	autoCommit bool
 }
 
-func (p *planner) makeEditNode(t parser.TableExpr, r parser.ReturningExprs, desiredTypes []parser.Datum, autoCommit bool, priv privilege.Kind) (editNodeBase, *roachpb.Error) {
-	tableDesc, pErr := p.getAliasedTableLease(t)
-	if pErr != nil {
-		return editNodeBase{}, pErr
+func (p *planner) makeEditNode(t parser.TableExpr, r parser.ReturningExprs, desiredTypes []parser.Datum, autoCommit bool, priv privilege.Kind) (editNodeBase, error) {
+	tableDesc, err := p.getAliasedTableLease(t)
+	if err != nil {
+		return editNodeBase{}, err
 	}
 
 	if err := p.checkPrivilege(tableDesc, priv); err != nil {
-		return editNodeBase{}, roachpb.NewError(err)
+		return editNodeBase{}, err
 	}
 
 	rh, err := p.makeReturningHelper(r, desiredTypes, tableDesc.Name, tableDesc.Columns)
 	if err != nil {
-		return editNodeBase{}, roachpb.NewError(err)
+		return editNodeBase{}, err
 	}
 
 	return editNodeBase{
@@ -107,9 +107,9 @@ type updateNode struct {
 func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoCommit bool) (planNode, *roachpb.Error) {
 	tracing.AnnotateTrace()
 
-	en, pErr := p.makeEditNode(n.Table, n.Returning, desiredTypes, autoCommit, privilege.UPDATE)
-	if pErr != nil {
-		return nil, pErr
+	en, err := p.makeEditNode(n.Table, n.Returning, desiredTypes, autoCommit, privilege.UPDATE)
+	if err != nil {
+		return nil, roachpb.NewError(err)
 	}
 
 	exprs := make([]parser.UpdateExpr, len(n.Exprs))


### PR DESCRIPTION
It's a mechanical change. One more step towards de-pErr-ifying sql.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6508)

<!-- Reviewable:end -->
