### PR TITLE
Populate a .mailmap to enhance the output of git blame/shortlog/etc.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,50 @@
+Andrei Matei <andrei@cockroachlabs.com> 
+Andrei Matei <andrei@cockroachlabs.com> <andreimatei1@gmail.com> 
+Ben Darnell <ben@cockroachlabs.com>
+Ben Darnell <ben@cockroachlabs.com> <ben@bendarnell.com>
+Bram Gruneir <bram+code@cockroachlabs.com>
+Bram Gruneir <bram+code@cockroachlabs.com> <bram.gruneir@gmail.com> 
+Bram Gruneir <bram+code@cockroachlabs.com> <BramGruneir@users.noreply.github.com> 
+Bram Gruneir <bram+code@cockroachlabs.com> <bram@squareup.com>
+Bram Gruneir <bram+code@cockroachlabs.com> <MycroftH@users.noreply.github.com> 
+Cuong Do  <cdo@cockroachlabs.com> 
+Cuong Do  <cdo@cockroachlabs.com> <cuongdo@users.noreply.github.com> 
+Dan Harrison <dan@cockroachlabs.com> 
+Dan Harrison <dan@cockroachlabs.com> <daniel.harrison@gmail.com> 
+David Taylor <david@cockroachlabs.com> 
+David Taylor <david@cockroachlabs.com> <tinystatemachine@gmail.com> 
+Jessica Edwards <jessica@cockroachlabs.com>
+Jessica Edwards <jessica@cockroachlabs.com> <jess-edwards@users.noreply.github.com>
+Jesse Seldess <jesse@cockroachlabs.com>
+Raphael 'kena' Poss <knz@cockroachlabs.com>
+Raphael 'kena' Poss <knz@cockroachlabs.com> <knz@thaumogen.net>
+Kenji Kaneda <kenji.kaneda@gmail.com> <kaneda@squareup.com>
+Marc Berhault <marc@cockroachlabs.com> 
+Marc Berhault <marc@cockroachlabs.com> <marc.berhault@gmail.com>
+Matt Jibson <mjibson@cockroachlabs.com>
+Matt Jibson <mjibson@cockroachlabs.com> <matt.jibson@gmail.com>
+Matt Tracy <matt@cockroachlabs.com>
+Matt Tracy <matt@cockroachlabs.com> <matt.r.tracy@gmail.com>
+Matt Tracy <matt@cockroachlabs.com> <mtracy@squareup.com>
+Max Lang <max@cockroachlabs.com>
+Max Lang <max@cockroachlabs.com> <maxwell.g.lang@gmail.com>
+Nathan VanBenschoten <nathan@cockroachlabs.com> 
+Nathan VanBenschoten <nathan@cockroachlabs.com> <nvanbenschoten@gmail.com>
+Peter Mattis <peter@cockroachlabs.com>
+Peter Mattis <peter@cockroachlabs.com> <petermattis@gmail.com>
+Peter Mattis <peter@cockroachlabs.com> <pmattis@squareup.com>
+Radu Berinde <radu@cockroachlabs.com>
+Radu Berinde <radu@cockroachlabs.com> <radu.berinde@gmail.com>
+Spencer Kimball <spencer@cockroachlabs.com>
+Spencer Kimball <spencer@cockroachlabs.com> <spencer@goviewfinder.com>
+Spencer Kimball <spencer@cockroachlabs.com> <spencer.kimball@gmail.com>
+Spencer Kimball <spencer@cockroachlabs.com> <spencerk@squareup.com>
+Tamir Duberstein <tamir@cockroachlabs.com> 
+Tamir Duberstein <tamir@cockroachlabs.com> <tamird@gmail.com>
+Tobias Schottdorf <tobias@cockroachlabs.com> 
+Tobias Schottdorf <tobias@cockroachlabs.com> <tobias.schottdorf@gmail.com>
+Tobias Schottdorf <tobias@cockroachlabs.com> <tobias.schottdorf@hrs.de>
+Vivek Menezes <vivek@cockroachlabs.com>
+Vivek Menezes <vivek@cockroachlabs.com> <vivek1@viveks-MacBook-Pro.local>
+Vivek Menezes <vivek@cockroachlabs.com> <vivek.menezes@gmail.com>
+Vivek Menezes <vivek@cockroachlabs.com> <vivekmenezes@users.noreply.github.com>

--- a/build/authors.sh
+++ b/build/authors.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+# This script produces the list of authors for a given source file,
+# listed in decreasing order of the number of commits by that author
+# that have touched the file.
+
+file=${1:?}
+
+git log --no-merges --format='%aN <%aE>' "$file" \
+    | sort \
+    | uniq -c \
+    | sort -nr \
+    | sed -e 's/^ *//g' \
+    | cut -d' ' -f2- \
+    | sed -e 's,^,// Author: ,g'


### PR DESCRIPTION
Also this patch includes a script build/authors.sh which produces a
summary of the authors that have contributed to a source file, sorted
in inverse order of the number of commits that have touched the file.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6509)

<!-- Reviewable:end -->
