### PR TITLE
Test that DEFAULT expressions may not contain variables.

### DIFF
--- a/sql/testdata/alter_table
+++ b/sql/testdata/alter_table
@@ -223,6 +223,9 @@ ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 'foo'
 statement error default expression .* may not contain placeholders
 ALTER TABLE add_default ALTER COLUMN b SET DEFAULT $1
 
+statement error qualified name "c" not found
+ALTER TABLE add_default ALTER COLUMN b SET DEFAULT c
+
 statement error default expression contains a subquery
 ALTER TABLE add_default ALTER COLUMN b SET DEFAULT (SELECT 1)
 

--- a/sql/testdata/default
+++ b/sql/testdata/default
@@ -4,6 +4,9 @@ CREATE TABLE t (a INT PRIMARY KEY DEFAULT false)
 statement error default expression .* may not contain placeholders
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT $1)
 
+statement error qualified name "b" not found
+CREATE TABLE t (a INT PRIMARY KEY DEFAULT b)
+
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY DEFAULT 42,


### PR DESCRIPTION
The changes in 839de99119852476978fa5e0802fbad3bbcb75d2 push the
checks for DEFAULT expressions under responsibility of CREATE and
ALTER TABLE. One of these checks previously performed by the parser
was that the expression may not contain "variables" (non-constant
expressions). The test in the previous patch was only checking that
placeholders are rejected. This patch also checks that identifiers to
other things (dangling names) are also rejected.

Thanks to @tamird for spotting the oversight.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6514)

<!-- Reviewable:end -->
