### PR TITLE
util/interval: fix interval.Tree.Insert

### DIFF
--- a/util/interval/interval.go
+++ b/util/interval/interval.go
@@ -317,13 +317,13 @@ func (n *Node) insert(e Interface, min Comparable, id uintptr, fast bool) (root 
 
 	switch c := min.Compare(n.Elem.Range().Start); {
 	case c == 0:
-		switch cid := id - n.Elem.ID(); {
-		case cid == 0:
+		switch {
+		case id == n.Elem.ID():
 			n.Elem = e
 			if !fast {
 				n.Range.End = e.Range().End
 			}
-		case cid < 0:
+		case id < n.Elem.ID():
 			n.Left, d = n.Left.insert(e, min, id, fast)
 		default:
 			n.Right, d = n.Right.insert(e, min, id, fast)
@@ -525,10 +525,10 @@ func (n *Node) floor(m Comparable, id uintptr) *Node {
 	}
 	switch c := m.Compare(n.Elem.Range().Start); {
 	case c == 0:
-		switch cid := id - n.Elem.ID(); {
-		case cid == 0:
+		switch {
+		case id == n.Elem.ID():
 			return n
-		case cid < 0:
+		case id < n.Elem.ID():
 			return n.Left.floor(m, id)
 		default:
 			if r := n.Right.floor(m, id); r != nil {
@@ -564,10 +564,10 @@ func (n *Node) ceil(m Comparable, id uintptr) *Node {
 	}
 	switch c := m.Compare(n.Elem.Range().Start); {
 	case c == 0:
-		switch cid := id - n.Elem.ID(); {
-		case cid == 0:
+		switch {
+		case id == n.Elem.ID():
 			return n
-		case cid > 0:
+		case id > n.Elem.ID():
 			return n.Right.ceil(m, id)
 		default:
 			if l := n.Left.ceil(m, id); l != nil {


### PR DESCRIPTION
`interval.Tree.Insert` was not properly inserting entries when the
`ID()` field was smaller than an existing entry due to an invalid
comparison of an unsigned integer less than 0. The `ID()` field is used
to uniquely identify an entry and the `interval.Tree` uses it as a tie
breaker in cases where the start key of the range is identical. But due
to the invalid comparison, entries were being inserted into the wrong
branch of the tree which made the `Delete()` logic unable to find the
entry. This, in turn, caused commands to be left in the `CommandQueue`
after they had been removed. If a subsequent command then depended on
this zombie command it would never run.

Added sanity checking code to `CommandQueue.Remove` the deletion from
the `interval.Tree` actually deletes an entry.

Fixes #6495.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6515)

<!-- Reviewable:end -->
