### PR TITLE
Sample test showing broken PGWire test

### DIFF
--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -501,6 +501,9 @@ func TestPGPreparedQuery(t *testing.T) {
 		"INSERT INTO d.two (a, b) VALUES (~$1, $1 + $2) RETURNING a, b": {
 			base.Params(5, 6).Results(-6, 11),
 		},
+		"UPDATE d.two SET a = 6 WHERE a = -6 AND b = 11 RETURNING a, b": {
+			base.Results(6, 11),
+		},
 		"INSERT INTO d.str (s) VALUES (LEFT($1, 3)) RETURNING s": {
 			base.Params("abcdef").Results("abc"),
 			base.Params("123456").Results("123"),


### PR DESCRIPTION
If you stress this test, it will occasionally fail with

```
--- FAIL: TestPGPreparedQuery (1.15s)
    pgwire_test.go:555: expected row: UPDATE d.two SET a = 6 WHERE a = -6 AND b = 11 RETURNING a, b: []
```

or 

```
--- FAIL: TestPGPreparedQuery (1.12s)
    pgwire_test.go:555: expected row: UPDATE d.two SET a = 6 WHERE a = -6 AND b = 11 RETURNING a, b: []
    pgwire_test.go:596: UPDATE d.two SET a = 6 WHERE a = -6 AND b = 11 RETURNING a, b: unexpected row: [6,11]
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6516)

<!-- Reviewable:end -->
