### PR TITLE
sql: Fully support tuples during type checking of ComparisonExprs

### DIFF
--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -594,17 +594,68 @@ func typeCheckAndRequire(args MapArgs, expr Expr, required Datum, op string) (Ty
 	return typedExpr, nil
 }
 
+const (
+	unsupportedCompErrFmtWithTypes = "unsupported comparison operator: <%s> %s <%s>"
+	unsupportedCompErrFmtWithExprs = "unsupported comparison operator: %s %s %s: %v"
+)
+
 func typeCheckComparisonOp(
 	args MapArgs, op ComparisonOperator, left, right Expr,
 ) (TypedExpr, TypedExpr, CmpOp, error) {
 	foldedOp, foldedLeft, foldedRight, switched, _ := foldComparisonExpr(op, left, right)
-
 	ops := CmpOps[foldedOp]
+
+	_, leftIsTuple := foldedLeft.(*Tuple)
+	rightTuple, rightIsTuple := foldedRight.(*Tuple)
+	switch {
+	case foldedOp == In && rightIsTuple:
+		sameTypeExprs := make([]Expr, 0, len(rightTuple.Exprs)+1)
+		sameTypeExprs = append(sameTypeExprs, foldedLeft)
+		sameTypeExprs = append(sameTypeExprs, rightTuple.Exprs...)
+
+		typedSubExprs, retType, err := typeCheckSameTypedExprs(args, nil, sameTypeExprs...)
+		if err != nil {
+			return nil, nil, CmpOp{}, fmt.Errorf(unsupportedCompErrFmtWithExprs,
+				left, op, right, err)
+		}
+
+		fn, ok := ops.lookupImpl(retType, TypeTuple)
+		if !ok {
+			return nil, nil, CmpOp{}, fmt.Errorf(unsupportedCompErrFmtWithTypes,
+				retType.Type(), op, TypeTuple.Type())
+		}
+
+		typedLeft := typedSubExprs[0]
+		typedSubExprs = typedSubExprs[1:]
+
+		rightTuple.Exprs = rightTuple.Exprs[:0]
+		rightTuple.types = make(DTuple, 0, len(typedSubExprs))
+		for _, typedExpr := range typedSubExprs {
+			rightTuple.Exprs = append(rightTuple.Exprs, typedExpr)
+			rightTuple.types = append(rightTuple.types, retType)
+		}
+		if switched {
+			return rightTuple, typedLeft, fn, nil
+		}
+		return typedLeft, rightTuple, fn, nil
+	case leftIsTuple && rightIsTuple:
+		fn, ok := ops.lookupImpl(TypeTuple, TypeTuple)
+		if !ok {
+			return nil, nil, CmpOp{}, fmt.Errorf(unsupportedCompErrFmtWithTypes,
+				TypeTuple.Type(), op, TypeTuple.Type())
+		}
+		// Using non-folded left and right to avoid having to swap later.
+		typedSubExprs, _, err := typeCheckSameTypedTupleExprs(args, nil, left, right)
+		if err != nil {
+			return nil, nil, CmpOp{}, err
+		}
+		return typedSubExprs[0], typedSubExprs[1], fn, nil
+	}
+
 	overloads := make([]overloadImpl, len(ops))
 	for i := range ops {
 		overloads[i] = ops[i]
 	}
-
 	typedSubExprs, fn, err := typeCheckOverloadedExprs(args, nil, overloads, foldedLeft, foldedRight)
 	if err != nil {
 		return nil, nil, CmpOp{}, err
@@ -629,53 +680,10 @@ func typeCheckComparisonOp(
 	}
 
 	if fn == nil {
-		return nil, nil, CmpOp{}, fmt.Errorf("unsupported comparison operator: <%s> %s <%s>",
-			leftReturn.Type(), op, rightReturn.Type())
+		return nil, nil, CmpOp{}, fmt.Errorf(unsupportedCompErrFmtWithTypes, leftReturn.Type(),
+			op, rightReturn.Type())
 	}
-
-	cmpOp := fn.(CmpOp)
-	if op == In && cmpOp.RightType.TypeEqual(TypeTuple) {
-		if err := verifyTupleIN(args, leftReturn, rightReturn); err != nil {
-			return nil, nil, CmpOp{}, err
-		}
-	} else if cmpOp.LeftType.TypeEqual(TypeTuple) && cmpOp.RightType.TypeEqual(TypeTuple) {
-		if err := verifyTupleCmp(args, leftReturn, rightReturn); err != nil {
-			return nil, nil, CmpOp{}, err
-		}
-	}
-
-	return leftExpr, rightExpr, cmpOp, nil
-}
-
-func verifyTupleCmp(args MapArgs, leftTupleType, rightTupleType Datum) error {
-	lTuple := *leftTupleType.(*DTuple)
-	rTuple := *rightTupleType.(*DTuple)
-	if len(lTuple) != len(rTuple) {
-		return fmt.Errorf("unequal number of entries in tuple expressions: %d, %d", len(lTuple), len(rTuple))
-	}
-
-	for i := range lTuple {
-		if _, _, _, err := typeCheckComparisonOp(args, EQ, lTuple[i], rTuple[i]); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func verifyTupleIN(args MapArgs, arg, values Datum) error {
-	if arg == DNull {
-		return nil
-	}
-
-	vtuple := *values.(*DTuple)
-	for _, val := range vtuple {
-		if _, _, _, err := typeCheckComparisonOp(args, EQ, arg, val); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return leftExpr, rightExpr, fn.(CmpOp), nil
 }
 
 type indexedExpr struct {
@@ -900,7 +908,7 @@ func typeCheckSameTypedTupleExprs(args MapArgs, desired Datum, exprs ...Expr) ([
 		}
 		typedSubExprs, resType, err := typeCheckSameTypedExprs(args, desiredElem, sameTypeExprs...)
 		if err != nil {
-			return nil, nil, fmt.Errorf("tuples %s could not be coerced to the same types: %v", Exprs(exprs), err)
+			return nil, nil, fmt.Errorf("tuples %s are not the same type: %v", Exprs(exprs), err)
 		}
 		for j, typedExpr := range typedSubExprs {
 			exprs[j].(*Tuple).Exprs[elemIdx] = typedExpr
@@ -931,7 +939,7 @@ func checkAllTuplesHaveLength(exprs []Expr, expectedLen int) error {
 	for _, expr := range exprs {
 		t := expr.(*Tuple)
 		if len(t.Exprs) != expectedLen {
-			return fmt.Errorf("expected a tuple of length %d for tuple %v", expectedLen, t)
+			return fmt.Errorf("expected tuple %v to have a length of %d", t, expectedLen)
 		}
 	}
 	return nil

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -698,6 +698,11 @@ func typeCheckSameTypedExprs(args MapArgs, desired Datum, exprs ...Expr) ([]Type
 		return []TypedExpr{typedExpr}, typedExpr.ReturnType(), nil
 	}
 
+	// Handle tuples, which will in turn call into this function recursively for each element.
+	if _, ok := exprs[0].(*Tuple); ok {
+		return typeCheckSameTypedTupleExprs(args, desired, exprs...)
+	}
+
 	// Hold the resolved type expressions of the provided exprs, in order.
 	// TODO(nvanbenschoten) Look into reducing allocations here.
 	typedExprs := make([]TypedExpr, len(exprs))
@@ -782,7 +787,7 @@ func typeCheckSameTypedExprs(args MapArgs, desired Datum, exprs ...Expr) ([]Type
 		if err != nil {
 			return nil, nil, err
 		}
-		if len(constExprs) > 0 {
+		if len(valExprs) > 0 {
 			if err := typeCheckSameTypedArgs(typ); err != nil {
 				return nil, nil, err
 			}
@@ -851,4 +856,83 @@ func typeCheckSameTypedExprs(args MapArgs, desired Datum, exprs ...Expr) ([]Type
 		}
 		return typedExprs, firstValidType, nil
 	}
+}
+
+// typeCheckSameTypedTupleExprs type checks a list of expressions, asserting that all
+// are tuples which have the same type. The function expects the first provided expression
+// to be a tuple, and will panic if it is not. However, it does not expect all other
+// expressions are tuples, and will return a sane error if they are not. An optional
+// desired type can be provided, which will hint that type which the expressions should
+// resolve to, if possible.
+func typeCheckSameTypedTupleExprs(args MapArgs, desired Datum, exprs ...Expr) ([]TypedExpr, Datum, error) {
+	// Hold the resolved type expressions of the provided exprs, in order.
+	// TODO(nvanbenschoten) Look into reducing allocations here.
+	typedExprs := make([]TypedExpr, len(exprs))
+
+	// All other exprs must be tuples.
+	first := exprs[0].(*Tuple)
+	if err := checkAllExprsAreTuples(args, exprs[1:]); err != nil {
+		return nil, nil, err
+	}
+
+	// All tuples must have the same length.
+	firstLen := len(first.Exprs)
+	if err := checkAllTuplesHaveLength(exprs[1:], firstLen); err != nil {
+		return nil, nil, err
+	}
+
+	// Pull out desired types.
+	var desiredTuple DTuple
+	if t, ok := desired.(*DTuple); ok {
+		desiredTuple = *t
+	}
+
+	// All expressions at the same indexes must be the same type.
+	resTypes := make(DTuple, firstLen)
+	sameTypeExprs := make([]Expr, len(exprs))
+	for elemIdx := range first.Exprs {
+		for tupleIdx, expr := range exprs {
+			sameTypeExprs[tupleIdx] = expr.(*Tuple).Exprs[elemIdx]
+		}
+		desiredElem := NoTypePreference
+		if len(desiredTuple) > elemIdx {
+			desiredElem = desiredTuple[elemIdx]
+		}
+		typedSubExprs, resType, err := typeCheckSameTypedExprs(args, desiredElem, sameTypeExprs...)
+		if err != nil {
+			return nil, nil, fmt.Errorf("tuples %s could not be coerced to the same types: %v", Exprs(exprs), err)
+		}
+		for j, typedExpr := range typedSubExprs {
+			exprs[j].(*Tuple).Exprs[elemIdx] = typedExpr
+		}
+		resTypes[elemIdx] = resType
+	}
+	for tupleIdx, expr := range exprs {
+		expr.(*Tuple).types = resTypes
+		typedExprs[tupleIdx] = expr.(TypedExpr)
+	}
+	return typedExprs, &resTypes, nil
+}
+
+func checkAllExprsAreTuples(args MapArgs, exprs []Expr) error {
+	for _, expr := range exprs {
+		if _, ok := expr.(*Tuple); !ok {
+			typedExpr, err := expr.TypeCheck(args, NoTypePreference)
+			if err != nil {
+				return err
+			}
+			return unexpectedTypeError{expr, TypeTuple, typedExpr.ReturnType()}
+		}
+	}
+	return nil
+}
+
+func checkAllTuplesHaveLength(exprs []Expr, expectedLen int) error {
+	for _, expr := range exprs {
+		t := expr.(*Tuple)
+		if len(t.Exprs) != expectedLen {
+			return fmt.Errorf("expected a tuple of length %d for tuple %v", expectedLen, t)
+		}
+	}
+	return nil
 }

--- a/sql/parser/type_check_test.go
+++ b/sql/parser/type_check_test.go
@@ -19,6 +19,7 @@ package parser
 import (
 	"go/constant"
 	"go/token"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -127,6 +128,22 @@ func TestTypeCheckError(t *testing.T) {
 	}
 }
 
+func intConst(s string) Expr {
+	return &NumVal{Value: constant.MakeFromLiteral(s, token.INT, 0), OrigString: s}
+}
+
+func floatConst(s string) Expr {
+	return &NumVal{Value: constant.MakeFromLiteral(s, token.FLOAT, 0), OrigString: s}
+}
+
+func cloneMapArgs(args MapArgs) MapArgs {
+	clone := make(MapArgs)
+	for k, v := range args {
+		clone[k] = v
+	}
+	return clone
+}
+
 func forEachPerm(exprs []Expr, i int, fn func([]Expr)) {
 	if i == len(exprs)-1 {
 		fn(exprs)
@@ -139,87 +156,91 @@ func forEachPerm(exprs []Expr, i int, fn func([]Expr)) {
 }
 
 func TestTypeCheckSameTypedExprs(t *testing.T) {
-	intConst := func(s string) Expr {
-		return &NumVal{Value: constant.MakeFromLiteral(s, token.INT, 0), OrigString: s}
-	}
-	floatConst := func(s string) Expr {
-		return &NumVal{Value: constant.MakeFromLiteral(s, token.FLOAT, 0), OrigString: s}
-	}
+	mapArgsInt := MapArgs{"a": TypeInt}
+	mapArgsFloat := MapArgs{"a": TypeFloat}
+	mapArgsIntAndFloat := MapArgs{"a": TypeFloat, "b": TypeFloat}
 
 	testData := []struct {
-		args         MapArgs
-		desired      Datum
-		exprs        []Expr
+		args    MapArgs
+		desired Datum
+		exprs   []Expr
+
 		expectedType Datum
+		expectedArgs MapArgs
 	}{
 		// Constants.
-		{nil, nil, []Expr{intConst("1")}, TypeInt},
-		{nil, nil, []Expr{floatConst("1")}, TypeFloat},
-		{nil, nil, []Expr{intConst("1"), floatConst("1")}, TypeFloat},
+		{nil, nil, []Expr{intConst("1")}, TypeInt, nil},
+		{nil, nil, []Expr{floatConst("1")}, TypeFloat, nil},
+		{nil, nil, []Expr{intConst("1"), floatConst("1")}, TypeFloat, nil},
 		// Resolved exprs.
-		{nil, nil, []Expr{NewDInt(1)}, TypeInt},
-		{nil, nil, []Expr{NewDFloat(1)}, TypeFloat},
+		{nil, nil, []Expr{NewDInt(1)}, TypeInt, nil},
+		{nil, nil, []Expr{NewDFloat(1)}, TypeFloat, nil},
 		// Mixing constants and resolved exprs.
-		{nil, nil, []Expr{NewDInt(1), intConst("1")}, TypeInt},
-		{nil, nil, []Expr{NewDInt(1), floatConst("1")}, TypeInt}, // This is what the AST would look like after folding (0.6 + 0.4).
-		{nil, nil, []Expr{NewDInt(1), NewDInt(1)}, TypeInt},
-		{nil, nil, []Expr{NewDFloat(1), intConst("1")}, TypeFloat},
-		{nil, nil, []Expr{NewDFloat(1), floatConst("1")}, TypeFloat},
-		{nil, nil, []Expr{NewDFloat(1), NewDFloat(1)}, TypeFloat},
+		{nil, nil, []Expr{NewDInt(1), intConst("1")}, TypeInt, nil},
+		{nil, nil, []Expr{NewDInt(1), floatConst("1")}, TypeInt, nil}, // This is what the AST would look like after folding (0.6 + 0.4).
+		{nil, nil, []Expr{NewDInt(1), NewDInt(1)}, TypeInt, nil},
+		{nil, nil, []Expr{NewDFloat(1), intConst("1")}, TypeFloat, nil},
+		{nil, nil, []Expr{NewDFloat(1), floatConst("1")}, TypeFloat, nil},
+		{nil, nil, []Expr{NewDFloat(1), NewDFloat(1)}, TypeFloat, nil},
 		// Mixing resolved constants and resolved exprs with MapArgs.
-		{MapArgs{"a": TypeFloat}, nil, []Expr{NewDFloat(1), ValArg{"a"}}, TypeFloat},
-		{MapArgs{"a": TypeFloat}, nil, []Expr{intConst("1"), ValArg{"a"}}, TypeFloat},
-		{MapArgs{"a": TypeFloat}, nil, []Expr{floatConst("1"), ValArg{"a"}}, TypeFloat},
-		{MapArgs{"a": TypeInt}, nil, []Expr{intConst("1"), ValArg{"a"}}, TypeInt},
-		{MapArgs{"a": TypeInt}, nil, []Expr{floatConst("1"), ValArg{"a"}}, TypeInt},
-		{MapArgs{"a": TypeFloat, "b": TypeFloat}, nil, []Expr{ValArg{"b"}, ValArg{"a"}}, TypeFloat},
+		{mapArgsFloat, nil, []Expr{NewDFloat(1), ValArg{"a"}}, TypeFloat, mapArgsFloat},
+		{mapArgsFloat, nil, []Expr{intConst("1"), ValArg{"a"}}, TypeFloat, mapArgsFloat},
+		{mapArgsFloat, nil, []Expr{floatConst("1"), ValArg{"a"}}, TypeFloat, mapArgsFloat},
+		{mapArgsInt, nil, []Expr{intConst("1"), ValArg{"a"}}, TypeInt, mapArgsInt},
+		{mapArgsInt, nil, []Expr{floatConst("1"), ValArg{"a"}}, TypeInt, mapArgsInt},
+		{mapArgsIntAndFloat, nil, []Expr{ValArg{"b"}, ValArg{"a"}}, TypeFloat, mapArgsIntAndFloat},
 		// Mixing unresolved constants and resolved exprs with MapArgs.
-		{nil, nil, []Expr{NewDFloat(1), ValArg{"a"}}, TypeFloat},
-		{nil, nil, []Expr{intConst("1"), ValArg{"a"}}, TypeInt},
-		{nil, nil, []Expr{floatConst("1"), ValArg{"a"}}, TypeFloat},
+		{nil, nil, []Expr{NewDFloat(1), ValArg{"a"}}, TypeFloat, mapArgsFloat},
+		{nil, nil, []Expr{intConst("1"), ValArg{"a"}}, TypeInt, mapArgsInt},
+		{nil, nil, []Expr{floatConst("1"), ValArg{"a"}}, TypeFloat, mapArgsFloat},
 		// Verify dealing with Null.
-		{nil, nil, []Expr{DNull}, DNull},
-		{nil, nil, []Expr{DNull, DNull}, DNull},
-		{nil, nil, []Expr{DNull, intConst("1")}, TypeInt},
-		{nil, nil, []Expr{DNull, floatConst("1")}, TypeFloat},
-		{nil, nil, []Expr{DNull, NewDInt(1)}, TypeInt},
-		{nil, nil, []Expr{DNull, NewDFloat(1)}, TypeFloat},
-		{nil, nil, []Expr{DNull, NewDFloat(1), intConst("1")}, TypeFloat},
-		{nil, nil, []Expr{DNull, NewDFloat(1), floatConst("1")}, TypeFloat},
-		{nil, nil, []Expr{DNull, NewDFloat(1), floatConst("1")}, TypeFloat},
-		{nil, nil, []Expr{DNull, intConst("1"), floatConst("1")}, TypeFloat},
+		{nil, nil, []Expr{DNull}, DNull, nil},
+		{nil, nil, []Expr{DNull, DNull}, DNull, nil},
+		{nil, nil, []Expr{DNull, intConst("1")}, TypeInt, nil},
+		{nil, nil, []Expr{DNull, floatConst("1")}, TypeFloat, nil},
+		{nil, nil, []Expr{DNull, NewDInt(1)}, TypeInt, nil},
+		{nil, nil, []Expr{DNull, NewDFloat(1)}, TypeFloat, nil},
+		{nil, nil, []Expr{DNull, NewDFloat(1), intConst("1")}, TypeFloat, nil},
+		{nil, nil, []Expr{DNull, NewDFloat(1), floatConst("1")}, TypeFloat, nil},
+		{nil, nil, []Expr{DNull, NewDFloat(1), floatConst("1")}, TypeFloat, nil},
+		{nil, nil, []Expr{DNull, intConst("1"), floatConst("1")}, TypeFloat, nil},
 		// Verify desired type when possible.
-		{nil, TypeInt, []Expr{intConst("1")}, TypeInt},
-		{nil, TypeInt, []Expr{NewDInt(1)}, TypeInt},
-		{nil, TypeInt, []Expr{floatConst("1")}, TypeInt},
-		{nil, TypeInt, []Expr{NewDFloat(1)}, TypeFloat},
-		{nil, TypeFloat, []Expr{intConst("1")}, TypeFloat},
-		{nil, TypeFloat, []Expr{NewDInt(1)}, TypeInt},
-		{nil, TypeInt, []Expr{intConst("1"), floatConst("1")}, TypeInt},
-		{nil, TypeInt, []Expr{intConst("1"), floatConst("1.1")}, TypeFloat},
-		{nil, TypeFloat, []Expr{intConst("1"), floatConst("1")}, TypeFloat},
+		{nil, TypeInt, []Expr{intConst("1")}, TypeInt, nil},
+		{nil, TypeInt, []Expr{NewDInt(1)}, TypeInt, nil},
+		{nil, TypeInt, []Expr{floatConst("1")}, TypeInt, nil},
+		{nil, TypeInt, []Expr{NewDFloat(1)}, TypeFloat, nil},
+		{nil, TypeFloat, []Expr{intConst("1")}, TypeFloat, nil},
+		{nil, TypeFloat, []Expr{NewDInt(1)}, TypeInt, nil},
+		{nil, TypeInt, []Expr{intConst("1"), floatConst("1")}, TypeInt, nil},
+		{nil, TypeInt, []Expr{intConst("1"), floatConst("1.1")}, TypeFloat, nil},
+		{nil, TypeFloat, []Expr{intConst("1"), floatConst("1")}, TypeFloat, nil},
 		// Verify desired type when possible with unresolved constants.
-		{nil, TypeFloat, []Expr{ValArg{"a"}}, TypeFloat},
-		{nil, TypeFloat, []Expr{intConst("1"), ValArg{"a"}}, TypeFloat},
-		{nil, TypeFloat, []Expr{floatConst("1"), ValArg{"a"}}, TypeFloat},
+		{nil, TypeFloat, []Expr{ValArg{"a"}}, TypeFloat, mapArgsFloat},
+		{nil, TypeFloat, []Expr{intConst("1"), ValArg{"a"}}, TypeFloat, mapArgsFloat},
+		{nil, TypeFloat, []Expr{floatConst("1"), ValArg{"a"}}, TypeFloat, mapArgsFloat},
 	}
 	for i, d := range testData {
+		if d.expectedArgs == nil {
+			d.expectedArgs = make(MapArgs)
+		}
 		forEachPerm(d.exprs, 0, func(exprs []Expr) {
-			_, typ, err := typeCheckSameTypedExprs(d.args, d.desired, exprs...)
+			args := cloneMapArgs(d.args)
+			_, typ, err := typeCheckSameTypedExprs(args, d.desired, exprs...)
 			if err != nil {
 				t.Errorf("%d: unexpected error returned from typeCheckSameTypedExprs: %v", i, err)
-			} else if !typ.TypeEqual(d.expectedType) {
-				t.Errorf("%d: expected type %s when type checking %s, found %s", i, d.expectedType.Type(), exprs, typ.Type())
+			} else {
+				if !typ.TypeEqual(d.expectedType) {
+					t.Errorf("%d: expected type %s when type checking %s, found %s", i, d.expectedType.Type(), exprs, typ.Type())
+				}
+				if !reflect.DeepEqual(args, d.expectedArgs) {
+					t.Errorf("%d: expected args %v after typeCheckSameTypedExprs for %v, found %v", i, d.expectedArgs, exprs, args)
+				}
 			}
 		})
 	}
 }
 
 func TestTypeCheckSameTypedExprsError(t *testing.T) {
-	floatConst := func(s string) Expr {
-		return &NumVal{Value: constant.MakeFromLiteral(s, token.FLOAT, 0), OrigString: s}
-	}
-
 	floatIntMismatchErr := `expected .* to be of type (float|int), found type (float|int)`
 	paramErr := `could not determine data type of parameter .*`
 

--- a/sql/parser/type_check_test.go
+++ b/sql/parser/type_check_test.go
@@ -106,10 +106,10 @@ func TestTypeCheckError(t *testing.T) {
 		{`CASE 'one' WHEN 1 THEN 1 WHEN 'two' THEN 2 END`, `incompatible condition type`},
 		{`CASE 1 WHEN 1 THEN 'one' WHEN 2 THEN 2 END`, `incompatible value type`},
 		{`CASE 1 WHEN 1 THEN 'one' ELSE 2 END`, `incompatible value type`},
-		{`(1, 2, 3) = (1, 2)`, `unequal number of entries in tuple expressions`},
-		{`(1, 2) = (1, 'a')`, `unsupported comparison operator`},
-		{`1 IN ('a', 'b')`, `unsupported comparison operator:`},
-		{`1 IN (1, 'a')`, `unsupported comparison operator`},
+		{`(1, 2, 3) = (1, 2)`, `expected tuple (1, 2) to have a length of 3`},
+		{`(1, 2) = (1, 'a')`, `tuples (1, 2), (1, 'a') are not the same type: expected 2 to be of type string, found type int`},
+		{`1 IN ('a', 'b')`, `unsupported comparison operator: 1 IN ('a', 'b'): expected 1 to be of type string, found type int`},
+		{`1 IN (1, 'a')`, `unsupported comparison operator: 1 IN (1, 'a'): expected 1 to be of type string, found type int`},
 		{`1.0 BETWEEN 2 AND '5'`, `expected 1.0 to be of type string, found type float`},
 		{`IF(1, 2, 3)`, `incompatible IF condition type: int`},
 		{`IF(true, 2, '5')`, `incompatible IF expressions: expected 2 to be of type string, found type int`},
@@ -331,9 +331,9 @@ func TestTypeCheckSameTypedTupleExprs(t *testing.T) {
 
 func TestTypeCheckSameTypedExprsError(t *testing.T) {
 	floatIntMismatchErr := `expected .* to be of type (float|int), found type (float|int)`
-	tupleFloatIntMismatchErr := `tuples .* coerced to the same types: ` + floatIntMismatchErr
+	tupleFloatIntMismatchErr := `tuples .* are not the same type: ` + floatIntMismatchErr
 	tupleIntMismatchErr := `expected .* to be of type (tuple|int), found type (tuple|int)`
-	tupleLenErr := `expected a tuple of length .*`
+	tupleLenErr := `expected tuple .* to have a length of .*`
 	paramErr := `could not determine data type of parameter .*`
 
 	testData := []struct {

--- a/sql/parser/type_check_test.go
+++ b/sql/parser/type_check_test.go
@@ -128,23 +128,68 @@ func TestTypeCheckError(t *testing.T) {
 	}
 }
 
-func intConst(s string) Expr {
-	return &NumVal{Value: constant.MakeFromLiteral(s, token.INT, 0), OrigString: s}
-}
+var (
+	mapArgsInt           = MapArgs{"a": TypeInt}
+	mapArgsFloat         = MapArgs{"a": TypeFloat}
+	mapArgsIntAndInt     = MapArgs{"a": TypeInt, "b": TypeInt}
+	mapArgsIntAndFloat   = MapArgs{"a": TypeInt, "b": TypeFloat}
+	mapArgsFloatAndFloat = MapArgs{"a": TypeFloat, "b": TypeFloat}
+)
 
-func floatConst(s string) Expr {
-	return &NumVal{Value: constant.MakeFromLiteral(s, token.FLOAT, 0), OrigString: s}
-}
+// copyableExpr can provide each test permutation with a deep copy of the expression tree.
+type copyableExpr func() Expr
 
-func cloneMapArgs(args MapArgs) MapArgs {
-	clone := make(MapArgs)
-	for k, v := range args {
-		clone[k] = v
+func buildExprs(exprs []copyableExpr) []Expr {
+	freshExprs := make([]Expr, 0, len(exprs))
+	for _, expr := range exprs {
+		freshExprs = append(freshExprs, expr())
 	}
-	return clone
+	return freshExprs
 }
 
-func forEachPerm(exprs []Expr, i int, fn func([]Expr)) {
+var dnull = func() Expr {
+	return DNull
+}
+
+func exprs(fns ...copyableExpr) []copyableExpr {
+	return fns
+}
+func intConst(s string) copyableExpr {
+	return func() Expr {
+		return &NumVal{Value: constant.MakeFromLiteral(s, token.INT, 0), OrigString: s}
+	}
+}
+func floatConst(s string) copyableExpr {
+	return func() Expr {
+		return &NumVal{Value: constant.MakeFromLiteral(s, token.FLOAT, 0), OrigString: s}
+	}
+}
+func dint(i DInt) copyableExpr {
+	return func() Expr {
+		return NewDInt(i)
+	}
+}
+func dfloat(f DFloat) copyableExpr {
+	return func() Expr {
+		return NewDFloat(f)
+	}
+}
+func valArg(name string) copyableExpr {
+	return func() Expr {
+		return ValArg{name}
+	}
+}
+func tuple(exprs ...copyableExpr) copyableExpr {
+	return func() Expr {
+		return &Tuple{Exprs: buildExprs(exprs)}
+	}
+}
+func dtuple(datums ...Datum) *DTuple {
+	dt := DTuple(datums)
+	return &dt
+}
+
+func forEachPerm(exprs []copyableExpr, i int, fn func([]copyableExpr)) {
 	if i == len(exprs)-1 {
 		fn(exprs)
 	}
@@ -155,111 +200,165 @@ func forEachPerm(exprs []Expr, i int, fn func([]Expr)) {
 	}
 }
 
-func TestTypeCheckSameTypedExprs(t *testing.T) {
-	mapArgsInt := MapArgs{"a": TypeInt}
-	mapArgsFloat := MapArgs{"a": TypeFloat}
-	mapArgsIntAndFloat := MapArgs{"a": TypeFloat, "b": TypeFloat}
-
-	testData := []struct {
-		args    MapArgs
-		desired Datum
-		exprs   []Expr
-
-		expectedType Datum
-		expectedArgs MapArgs
-	}{
-		// Constants.
-		{nil, nil, []Expr{intConst("1")}, TypeInt, nil},
-		{nil, nil, []Expr{floatConst("1")}, TypeFloat, nil},
-		{nil, nil, []Expr{intConst("1"), floatConst("1")}, TypeFloat, nil},
-		// Resolved exprs.
-		{nil, nil, []Expr{NewDInt(1)}, TypeInt, nil},
-		{nil, nil, []Expr{NewDFloat(1)}, TypeFloat, nil},
-		// Mixing constants and resolved exprs.
-		{nil, nil, []Expr{NewDInt(1), intConst("1")}, TypeInt, nil},
-		{nil, nil, []Expr{NewDInt(1), floatConst("1")}, TypeInt, nil}, // This is what the AST would look like after folding (0.6 + 0.4).
-		{nil, nil, []Expr{NewDInt(1), NewDInt(1)}, TypeInt, nil},
-		{nil, nil, []Expr{NewDFloat(1), intConst("1")}, TypeFloat, nil},
-		{nil, nil, []Expr{NewDFloat(1), floatConst("1")}, TypeFloat, nil},
-		{nil, nil, []Expr{NewDFloat(1), NewDFloat(1)}, TypeFloat, nil},
-		// Mixing resolved constants and resolved exprs with MapArgs.
-		{mapArgsFloat, nil, []Expr{NewDFloat(1), ValArg{"a"}}, TypeFloat, mapArgsFloat},
-		{mapArgsFloat, nil, []Expr{intConst("1"), ValArg{"a"}}, TypeFloat, mapArgsFloat},
-		{mapArgsFloat, nil, []Expr{floatConst("1"), ValArg{"a"}}, TypeFloat, mapArgsFloat},
-		{mapArgsInt, nil, []Expr{intConst("1"), ValArg{"a"}}, TypeInt, mapArgsInt},
-		{mapArgsInt, nil, []Expr{floatConst("1"), ValArg{"a"}}, TypeInt, mapArgsInt},
-		{mapArgsIntAndFloat, nil, []Expr{ValArg{"b"}, ValArg{"a"}}, TypeFloat, mapArgsIntAndFloat},
-		// Mixing unresolved constants and resolved exprs with MapArgs.
-		{nil, nil, []Expr{NewDFloat(1), ValArg{"a"}}, TypeFloat, mapArgsFloat},
-		{nil, nil, []Expr{intConst("1"), ValArg{"a"}}, TypeInt, mapArgsInt},
-		{nil, nil, []Expr{floatConst("1"), ValArg{"a"}}, TypeFloat, mapArgsFloat},
-		// Verify dealing with Null.
-		{nil, nil, []Expr{DNull}, DNull, nil},
-		{nil, nil, []Expr{DNull, DNull}, DNull, nil},
-		{nil, nil, []Expr{DNull, intConst("1")}, TypeInt, nil},
-		{nil, nil, []Expr{DNull, floatConst("1")}, TypeFloat, nil},
-		{nil, nil, []Expr{DNull, NewDInt(1)}, TypeInt, nil},
-		{nil, nil, []Expr{DNull, NewDFloat(1)}, TypeFloat, nil},
-		{nil, nil, []Expr{DNull, NewDFloat(1), intConst("1")}, TypeFloat, nil},
-		{nil, nil, []Expr{DNull, NewDFloat(1), floatConst("1")}, TypeFloat, nil},
-		{nil, nil, []Expr{DNull, NewDFloat(1), floatConst("1")}, TypeFloat, nil},
-		{nil, nil, []Expr{DNull, intConst("1"), floatConst("1")}, TypeFloat, nil},
-		// Verify desired type when possible.
-		{nil, TypeInt, []Expr{intConst("1")}, TypeInt, nil},
-		{nil, TypeInt, []Expr{NewDInt(1)}, TypeInt, nil},
-		{nil, TypeInt, []Expr{floatConst("1")}, TypeInt, nil},
-		{nil, TypeInt, []Expr{NewDFloat(1)}, TypeFloat, nil},
-		{nil, TypeFloat, []Expr{intConst("1")}, TypeFloat, nil},
-		{nil, TypeFloat, []Expr{NewDInt(1)}, TypeInt, nil},
-		{nil, TypeInt, []Expr{intConst("1"), floatConst("1")}, TypeInt, nil},
-		{nil, TypeInt, []Expr{intConst("1"), floatConst("1.1")}, TypeFloat, nil},
-		{nil, TypeFloat, []Expr{intConst("1"), floatConst("1")}, TypeFloat, nil},
-		// Verify desired type when possible with unresolved constants.
-		{nil, TypeFloat, []Expr{ValArg{"a"}}, TypeFloat, mapArgsFloat},
-		{nil, TypeFloat, []Expr{intConst("1"), ValArg{"a"}}, TypeFloat, mapArgsFloat},
-		{nil, TypeFloat, []Expr{floatConst("1"), ValArg{"a"}}, TypeFloat, mapArgsFloat},
+func cloneMapArgs(args MapArgs) MapArgs {
+	clone := make(MapArgs)
+	for k, v := range args {
+		clone[k] = v
 	}
-	for i, d := range testData {
-		if d.expectedArgs == nil {
-			d.expectedArgs = make(MapArgs)
-		}
-		forEachPerm(d.exprs, 0, func(exprs []Expr) {
-			args := cloneMapArgs(d.args)
-			_, typ, err := typeCheckSameTypedExprs(args, d.desired, exprs...)
-			if err != nil {
-				t.Errorf("%d: unexpected error returned from typeCheckSameTypedExprs: %v", i, err)
-			} else {
-				if !typ.TypeEqual(d.expectedType) {
-					t.Errorf("%d: expected type %s when type checking %s, found %s", i, d.expectedType.Type(), exprs, typ.Type())
-				}
-				if !reflect.DeepEqual(args, d.expectedArgs) {
-					t.Errorf("%d: expected args %v after typeCheckSameTypedExprs for %v, found %v", i, d.expectedArgs, exprs, args)
-				}
+	return clone
+}
+
+type sameTypedExprsTestCase struct {
+	args    MapArgs
+	desired Datum
+	exprs   []copyableExpr
+
+	expectedType Datum
+	expectedArgs MapArgs
+}
+
+func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTestCase) {
+	if test.expectedArgs == nil {
+		test.expectedArgs = make(MapArgs)
+	}
+	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
+		args := cloneMapArgs(test.args)
+		_, typ, err := typeCheckSameTypedExprs(args, test.desired, buildExprs(exprs)...)
+		if err != nil {
+			t.Errorf("%d: unexpected error returned from typeCheckSameTypedExprs: %v", idx, err)
+		} else {
+			if !typ.TypeEqual(test.expectedType) {
+				t.Errorf("%d: expected type %s:%s when type checking %s:%s, found %s", idx, test.expectedType, test.expectedType.Type(), buildExprs(exprs), typ, typ.Type())
 			}
-		})
+			if !reflect.DeepEqual(args, test.expectedArgs) {
+				t.Errorf("%d: expected args %v after typeCheckSameTypedExprs for %v, found %v", idx, test.expectedArgs, buildExprs(exprs), args)
+			}
+		}
+	})
+}
+
+func TestTypeCheckSameTypedExprs(t *testing.T) {
+	for i, d := range []sameTypedExprsTestCase{
+		// Constants.
+		{nil, nil, exprs(intConst("1")), TypeInt, nil},
+		{nil, nil, exprs(floatConst("1.1")), TypeFloat, nil},
+		{nil, nil, exprs(intConst("1"), floatConst("1.0")), TypeFloat, nil},
+		{nil, nil, exprs(intConst("1"), floatConst("1.1")), TypeFloat, nil},
+		// Resolved exprs.
+		{nil, nil, exprs(dint(1)), TypeInt, nil},
+		{nil, nil, exprs(dfloat(1)), TypeFloat, nil},
+		// Mixing constants and resolved exprs.
+		{nil, nil, exprs(dint(1), intConst("1")), TypeInt, nil},
+		{nil, nil, exprs(dint(1), floatConst("1.0")), TypeInt, nil}, // This is what the AST would look like after folding (0.6 + 0.4).
+		{nil, nil, exprs(dint(1), dint(1)), TypeInt, nil},
+		{nil, nil, exprs(dfloat(1), intConst("1")), TypeFloat, nil},
+		{nil, nil, exprs(dfloat(1), floatConst("1.1")), TypeFloat, nil},
+		{nil, nil, exprs(dfloat(1), dfloat(1)), TypeFloat, nil},
+		// Mixing resolved params with constants and resolved exprs.
+		{mapArgsFloat, nil, exprs(dfloat(1), valArg("a")), TypeFloat, mapArgsFloat},
+		{mapArgsFloat, nil, exprs(intConst("1"), valArg("a")), TypeFloat, mapArgsFloat},
+		{mapArgsFloat, nil, exprs(floatConst("1.1"), valArg("a")), TypeFloat, mapArgsFloat},
+		{mapArgsInt, nil, exprs(intConst("1"), valArg("a")), TypeInt, mapArgsInt},
+		{mapArgsInt, nil, exprs(floatConst("1.0"), valArg("a")), TypeInt, mapArgsInt},
+		{mapArgsFloatAndFloat, nil, exprs(valArg("b"), valArg("a")), TypeFloat, mapArgsFloatAndFloat},
+		// Mixing unresolved params with constants and resolved exprs.
+		{nil, nil, exprs(dfloat(1), valArg("a")), TypeFloat, mapArgsFloat},
+		{nil, nil, exprs(intConst("1"), valArg("a")), TypeInt, mapArgsInt},
+		{nil, nil, exprs(floatConst("1.1"), valArg("a")), TypeFloat, mapArgsFloat},
+		// Verify dealing with Null.
+		{nil, nil, exprs(dnull), DNull, nil},
+		{nil, nil, exprs(dnull, dnull), DNull, nil},
+		{nil, nil, exprs(dnull, intConst("1")), TypeInt, nil},
+		{nil, nil, exprs(dnull, floatConst("1.1")), TypeFloat, nil},
+		{nil, nil, exprs(dnull, dint(1)), TypeInt, nil},
+		{nil, nil, exprs(dnull, dfloat(1)), TypeFloat, nil},
+		{nil, nil, exprs(dnull, dfloat(1), intConst("1")), TypeFloat, nil},
+		{nil, nil, exprs(dnull, dfloat(1), floatConst("1.1")), TypeFloat, nil},
+		{nil, nil, exprs(dnull, dfloat(1), floatConst("1.1")), TypeFloat, nil},
+		{nil, nil, exprs(dnull, intConst("1"), floatConst("1.1")), TypeFloat, nil},
+		// Verify desired type when possible.
+		{nil, TypeInt, exprs(intConst("1")), TypeInt, nil},
+		{nil, TypeInt, exprs(dint(1)), TypeInt, nil},
+		{nil, TypeInt, exprs(floatConst("1.0")), TypeInt, nil},
+		{nil, TypeInt, exprs(floatConst("1.1")), TypeFloat, nil},
+		{nil, TypeInt, exprs(dfloat(1)), TypeFloat, nil},
+		{nil, TypeFloat, exprs(intConst("1")), TypeFloat, nil},
+		{nil, TypeFloat, exprs(dint(1)), TypeInt, nil},
+		{nil, TypeInt, exprs(intConst("1"), floatConst("1.0")), TypeInt, nil},
+		{nil, TypeInt, exprs(intConst("1"), floatConst("1.1")), TypeFloat, nil},
+		{nil, TypeFloat, exprs(intConst("1"), floatConst("1.1")), TypeFloat, nil},
+		// Verify desired type when possible with unresolved placeholders.
+		{nil, TypeFloat, exprs(valArg("a")), TypeFloat, mapArgsFloat},
+		{nil, TypeFloat, exprs(intConst("1"), valArg("a")), TypeFloat, mapArgsFloat},
+		{nil, TypeFloat, exprs(floatConst("1.1"), valArg("a")), TypeFloat, mapArgsFloat},
+	} {
+		attemptTypeCheckSameTypedExprs(t, i, d)
+	}
+}
+
+func TestTypeCheckSameTypedTupleExprs(t *testing.T) {
+	for i, d := range []sameTypedExprsTestCase{
+		// // Constants.
+		{nil, nil, exprs(tuple(intConst("1"))), dtuple(TypeInt), nil},
+		{nil, nil, exprs(tuple(intConst("1"), intConst("1"))), dtuple(TypeInt, TypeInt), nil},
+		{nil, nil, exprs(tuple(intConst("1")), tuple(intConst("1"))), dtuple(TypeInt), nil},
+		{nil, nil, exprs(tuple(intConst("1")), tuple(floatConst("1.0"))), dtuple(TypeFloat), nil},
+		{nil, nil, exprs(tuple(intConst("1")), tuple(floatConst("1.1"))), dtuple(TypeFloat), nil},
+		// Resolved exprs.
+		{nil, nil, exprs(tuple(dint(1)), tuple(dint(1))), dtuple(TypeInt), nil},
+		{nil, nil, exprs(tuple(dint(1), dfloat(1)), tuple(dint(1), dfloat(1))), dtuple(TypeInt, TypeFloat), nil},
+		// Mixing constants and resolved exprs.
+		{nil, nil, exprs(tuple(dint(1), floatConst("1.1")), tuple(intConst("1"), dfloat(1))), dtuple(TypeInt, TypeFloat), nil},
+		{nil, nil, exprs(tuple(dint(1), floatConst("1.0")), tuple(intConst("1"), dint(1))), dtuple(TypeInt, TypeInt), nil},
+		// Mixing resolved params with constants and resolved exprs.
+		{mapArgsFloat, nil, exprs(tuple(dfloat(1), intConst("1")), tuple(valArg("a"), valArg("a"))), dtuple(TypeFloat, TypeFloat), mapArgsFloat},
+		{mapArgsFloatAndFloat, nil, exprs(tuple(valArg("b"), intConst("1")), tuple(valArg("a"), valArg("a"))), dtuple(TypeFloat, TypeFloat), mapArgsFloatAndFloat},
+		{mapArgsIntAndFloat, nil, exprs(tuple(intConst("1"), intConst("1")), tuple(valArg("a"), valArg("b"))), dtuple(TypeInt, TypeFloat), mapArgsIntAndFloat},
+		// Mixing unresolved params with constants and resolved exprs.
+		{nil, nil, exprs(tuple(dfloat(1), intConst("1")), tuple(valArg("a"), valArg("a"))), dtuple(TypeFloat, TypeFloat), mapArgsFloat},
+		{nil, nil, exprs(tuple(intConst("1"), intConst("1")), tuple(valArg("a"), valArg("b"))), dtuple(TypeInt, TypeInt), mapArgsIntAndInt},
+		// Verify dealing with Null.
+		{nil, nil, exprs(tuple(intConst("1"), dnull), tuple(dnull, floatConst("1"))), dtuple(TypeInt, TypeFloat), nil},
+		{nil, nil, exprs(tuple(dint(1), dnull), tuple(dnull, dfloat(1))), dtuple(TypeInt, TypeFloat), nil},
+		// Verify desired type when possible.
+		{nil, dtuple(TypeInt, TypeFloat), exprs(tuple(intConst("1"), intConst("1")), tuple(intConst("1"), intConst("1"))), dtuple(TypeInt, TypeFloat), nil},
+		// Verify desired type when possible with unresolved constants.
+		{nil, dtuple(TypeInt, TypeFloat), exprs(tuple(valArg("a"), intConst("1")), tuple(intConst("1"), valArg("b"))), dtuple(TypeInt, TypeFloat), mapArgsIntAndFloat},
+	} {
+		attemptTypeCheckSameTypedExprs(t, i, d)
 	}
 }
 
 func TestTypeCheckSameTypedExprsError(t *testing.T) {
 	floatIntMismatchErr := `expected .* to be of type (float|int), found type (float|int)`
+	tupleFloatIntMismatchErr := `tuples .* coerced to the same types: ` + floatIntMismatchErr
+	tupleIntMismatchErr := `expected .* to be of type (tuple|int), found type (tuple|int)`
+	tupleLenErr := `expected a tuple of length .*`
 	paramErr := `could not determine data type of parameter .*`
 
 	testData := []struct {
-		args        MapArgs
-		desired     Datum
-		exprs       []Expr
+		args    MapArgs
+		desired Datum
+		exprs   []copyableExpr
+
 		expectedErr string
 	}{
-		{nil, nil, []Expr{NewDInt(1), floatConst("1.1")}, floatIntMismatchErr},
-		{nil, nil, []Expr{NewDInt(1), NewDFloat(1)}, floatIntMismatchErr},
-		{MapArgs{"a": TypeInt}, nil, []Expr{NewDFloat(1.1), ValArg{"a"}}, floatIntMismatchErr},
-		{MapArgs{"a": TypeInt}, nil, []Expr{floatConst("1.1"), ValArg{"a"}}, floatIntMismatchErr},
-		{MapArgs{"a": TypeFloat, "b": TypeInt}, nil, []Expr{ValArg{"b"}, ValArg{"a"}}, floatIntMismatchErr},
-		{nil, nil, []Expr{ValArg{"b"}, ValArg{"a"}}, paramErr},
+		// Single type mismatches.
+		{nil, nil, exprs(dint(1), floatConst("1.1")), floatIntMismatchErr},
+		{nil, nil, exprs(dint(1), dfloat(1)), floatIntMismatchErr},
+		{mapArgsInt, nil, exprs(dfloat(1.1), valArg("a")), floatIntMismatchErr},
+		{mapArgsInt, nil, exprs(floatConst("1.1"), valArg("a")), floatIntMismatchErr},
+		{mapArgsIntAndFloat, nil, exprs(valArg("b"), valArg("a")), floatIntMismatchErr},
+		// Tuple type mismatches.
+		{nil, nil, exprs(tuple(dint(1)), tuple(dfloat(1))), tupleFloatIntMismatchErr},
+		{nil, nil, exprs(tuple(dint(1)), dint(1), dint(1)), tupleIntMismatchErr},
+		{nil, nil, exprs(tuple(dint(1)), tuple(dint(1), dint(1))), tupleLenErr},
+		// Parameter ambiguity.
+		{nil, nil, exprs(valArg("b"), valArg("a")), paramErr},
 	}
 	for i, d := range testData {
-		forEachPerm(d.exprs, 0, func(exprs []Expr) {
-			if _, _, err := typeCheckSameTypedExprs(d.args, d.desired, exprs...); !testutils.IsError(err, d.expectedErr) {
+		forEachPerm(d.exprs, 0, func(exprs []copyableExpr) {
+			if _, _, err := typeCheckSameTypedExprs(d.args, d.desired, buildExprs(exprs)...); !testutils.IsError(err, d.expectedErr) {
 				t.Errorf("%d: expected %s, but found %v", i, d.expectedErr, err)
 			}
 		})

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -685,6 +685,12 @@ func TestPGPreparedExec(t *testing.T) {
 			},
 		},
 		{
+			"UPDATE d.t SET i = $1 WHERE (i, s) = ($2, $3)",
+			[]preparedExecTest{
+				base.Params(8, 4, "4").RowsAffected(1),
+			},
+		},
+		{
 			"DELETE FROM d.t WHERE s = $1 and i = $2 and d = 2 + $3",
 			[]preparedExecTest{
 				base.Params(1, 2, 3).RowsAffected(0),

--- a/sql/testdata/select_index
+++ b/sql/testdata/select_index
@@ -286,12 +286,15 @@ EXPLAIN SELECT a FROM t WHERE (b, c) = (5, 1)
 query ITT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.0, 1)
 ----
-0 scan t@bc -
+0 scan t@bc /5/1-/5/2
+
+query error tuples \(b, c\), \(5.1, 1\) are not the same type: expected 5.1 to be of type int, found type float
+EXPLAIN SELECT a FROM t WHERE (b, c) = (5.1, 1)
 
 query ITT
 EXPLAIN SELECT a FROM t WHERE b IN (5.0, 1)
 ----
-0 scan t@b_desc -
+0 scan t@b_desc /-6-/-5 /-2-/-1
 
 statement ok
 CREATE TABLE abcd (

--- a/sql/testdata/tuple
+++ b/sql/testdata/tuple
@@ -91,10 +91,10 @@ SELECT
 ----
 true NULL false NULL
 
-statement error pq: unsupported comparison operator: <string> = <int>
+statement error pq: tuples \(1, 2\), \(1, 'hi'\) are not the same type: expected 2 to be of type string, found type int
 SELECT (1, 2) > (1, 'hi')
 
-statement error pq: unequal number of entries in tuple expressions: 3, 2
+statement error pq: expected tuple \(1, 2, 3\) to have a length of 2
 SELECT (1, 2) > (1, 2, 3)
 
 statement ok

--- a/sql/testdata/tuple
+++ b/sql/testdata/tuple
@@ -115,3 +115,21 @@ SELECT * FROM t WHERE (a, b, c) > (1, 2, 3) ORDER BY a, b, c
 ----
 2 3 1
 3 1 2
+
+query BB
+SELECT ((1, 2), 'equal') = ((1, 2.0), 'equal'), ((1, 2), 'equal') = ((1, 2.0), 'not equal')
+----
+true false
+
+query B
+SELECT ((1, 2), 'equal') = ((1, 2.1), 'equal')
+----
+false
+
+query B
+SELECT (ROW(POW(1, 10.0) + 9), 'a' || 'b') = (ROW(SQRT(100)), 'ab')
+----
+true
+
+query error pq: tuples \(\(1, 2\), 'equal'\), \(\(1, 'huh'\), 'equal'\) are not the same type: tuples \(1, 2\), \(1, 'huh'\) are not the same type: expected 2 to be of type string, found type int
+SELECT ((1, 2), 'equal') = ((1, 'huh'), 'equal')


### PR DESCRIPTION
Fixes #6501.
Fixes #6502.
Fixes #6503.
Fixes #6252.

This change uses the new `typeCheckSameTypedExprs` and
`typeCheckSameTypedTupleExprs` functionality to fully support tuples in
`ComparisonExprs`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6517)

<!-- Reviewable:end -->
