### PR TITLE
sql: SUM and AVG of INTs now return DECIMALs

### DIFF
--- a/sql/group.go
+++ b/sql/group.go
@@ -741,16 +741,12 @@ func (a *avgAggregate) add(datum parser.Datum) error {
 func (a *avgAggregate) result() (parser.Datum, error) {
 	sum, err := a.sumAggregate.result()
 	if err != nil {
-		return parser.DNull, err
+		return nil, err
 	}
 	if sum == parser.DNull {
 		return sum, nil
 	}
 	switch t := sum.(type) {
-	case *parser.DInt:
-		// TODO(nvanbenschoten) decimal: this should be a numeric, once
-		// better type coercion semantics are defined.
-		return parser.NewDFloat(parser.DFloat(*t) / parser.DFloat(a.count)), nil
 	case *parser.DFloat:
 		return parser.NewDFloat(*t / parser.DFloat(a.count)), nil
 	case *parser.DDecimal:
@@ -758,7 +754,7 @@ func (a *avgAggregate) result() (parser.Datum, error) {
 		t.QuoRound(&t.Dec, count, decimal.Precision, inf.RoundHalfUp)
 		return t, nil
 	default:
-		return parser.DNull, util.Errorf("unexpected SUM result type: %s", t.Type())
+		return nil, util.Errorf("unexpected SUM result type: %s", t.Type())
 	}
 }
 
@@ -853,7 +849,10 @@ func (a *minAggregate) result() (parser.Datum, error) {
 }
 
 type sumAggregate struct {
-	sum parser.Datum
+	sumType  parser.Datum
+	sumFloat parser.DFloat
+	sumDec   inf.Dec
+	tmpDec   inf.Dec
 }
 
 func newSumAggregate() aggregateImpl {
@@ -864,53 +863,36 @@ func (a *sumAggregate) add(datum parser.Datum) error {
 	if datum == parser.DNull {
 		return nil
 	}
-	if a.sum == nil {
-		switch t := datum.(type) {
-		case *parser.DDecimal:
-			// Make copy of decimal to allow for modification later.
-			dd := &parser.DDecimal{}
-			dd.Set(&t.Dec)
-			datum = dd
-		}
-		a.sum = datum
-		return nil
-	}
-
 	switch t := datum.(type) {
-	case *parser.DInt:
-		if v, ok := a.sum.(*parser.DInt); ok {
-			a.sum = parser.NewDInt(*v + *t)
-			return nil
-		}
-
 	case *parser.DFloat:
-		if v, ok := a.sum.(*parser.DFloat); ok {
-			a.sum = parser.NewDFloat(*v + *t)
-			return nil
-		}
-
+		a.sumFloat += *t
+	case *parser.DInt:
+		a.tmpDec.SetUnscaled(int64(*t))
+		a.sumDec.Add(&a.sumDec, &a.tmpDec)
 	case *parser.DDecimal:
-		if v, ok := a.sum.(*parser.DDecimal); ok {
-			v.Add(&v.Dec, &t.Dec)
-			a.sum = v
-			return nil
-		}
+		a.sumDec.Add(&a.sumDec, &t.Dec)
+	default:
+		return util.Errorf("unexpected SUM argument type: %s", datum.Type())
 	}
-
-	return util.Errorf("unexpected SUM argument type: %s", datum.Type())
+	if a.sumType == nil {
+		a.sumType = datum
+	}
+	return nil
 }
 
 func (a *sumAggregate) result() (parser.Datum, error) {
-	if a.sum == nil {
+	if a.sumType == nil {
 		return parser.DNull, nil
 	}
-	switch t := a.sum.(type) {
-	case *parser.DDecimal:
+	switch {
+	case a.sumType.TypeEqual(parser.DummyFloat):
+		return parser.NewDFloat(a.sumFloat), nil
+	case a.sumType.TypeEqual(parser.DummyInt), a.sumType.TypeEqual(parser.DummyDecimal):
 		dd := &parser.DDecimal{}
-		dd.Set(&t.Dec)
+		dd.Set(&a.sumDec)
 		return dd, nil
 	default:
-		return a.sum, nil
+		panic("unreachable")
 	}
 }
 

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -629,7 +629,7 @@ var Builtins = map[string][]Builtin{
 	"avg": {
 		Builtin{
 			Types:      ArgTypes{DummyInt},
-			ReturnType: TypeFloat,
+			ReturnType: TypeDecimal,
 		},
 		Builtin{
 			Types:      ArgTypes{DummyFloat},
@@ -645,7 +645,21 @@ var Builtins = map[string][]Builtin{
 
 	"max": aggregateImpls(DummyBool, DummyInt, DummyFloat, DummyDecimal, DummyString, DummyBytes, DummyDate, DummyTimestamp, DummyInterval),
 	"min": aggregateImpls(DummyBool, DummyInt, DummyFloat, DummyDecimal, DummyString, DummyBytes, DummyDate, DummyTimestamp, DummyInterval),
-	"sum": aggregateImpls(DummyInt, DummyFloat, DummyDecimal),
+
+	"sum": {
+		Builtin{
+			Types:      ArgTypes{DummyInt},
+			ReturnType: TypeDecimal,
+		},
+		Builtin{
+			Types:      ArgTypes{DummyFloat},
+			ReturnType: TypeFloat,
+		},
+		Builtin{
+			Types:      ArgTypes{DummyDecimal},
+			ReturnType: TypeDecimal,
+		},
+	},
 
 	"variance": {
 		Builtin{

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -362,25 +362,25 @@ SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv WHERE k > 8
 ----
 NULL NULL NULL NULL
 
-query RRII
+query RRRR
 SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM kv
 ----
-5 2.8 30 14
+5.0000000000000000 2.8000000000000000 30 14
 
 query RRRR
 SELECT AVG(k::decimal), AVG(v::decimal), SUM(k::decimal), SUM(v::decimal) FROM kv
 ----
 5.0000000000000000 2.8000000000000000 30 14
 
-query RRII
+query RRRR
 SELECT AVG(DISTINCT k), AVG(DISTINCT v), SUM(DISTINCT k), SUM(DISTINCT v) FROM kv
 ----
-5 3 30 6
+5.0000000000000000 3.0000000000000000 30 6
 
 query R
-SELECT AVG(k) * 2.0 + MAX(v)::float FROM kv
+SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
 ----
-14
+14.0000000000000000
 
 query ITT
 EXPLAIN SELECT COUNT(k) FROM kv
@@ -610,14 +610,14 @@ EXPLAIN (DEBUG) SELECT MIN(z) FROM xyz
 query RRR
 SELECT AVG(1::int), AVG(2::float), AVG(3::decimal)
 ----
-1 2 3.0000000000000000
+1.0000000000000000 2 3.0000000000000000
 
 query III
 SELECT COUNT(2::int), COUNT(3::float), COUNT(4::decimal)
 ----
 1 1 1
 
-query IRR
+query RRR
 SELECT SUM(1::int), SUM(2::float), SUM(3::decimal)
 ----
 1 2 3


### PR DESCRIPTION
Previously the aggregate function `SUM(INT)` returned an `INT` and the
aggregate function `AVG(INT)` returned a `FLOAT`. This changes both to
return `DECIMAL`s, which is consistent with Postgres.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6532)

<!-- Reviewable:end -->
