### PR TITLE
sql: no more pErr in the sql layer

### DIFF
--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -130,12 +130,6 @@ func NewErrorWithTxn(err error, txn *Transaction) *Error {
 	return e
 }
 
-// NewUErrorf creates an Error from the given error message. Used
-// for user-facing errors.
-func NewUErrorf(format string, a ...interface{}) *Error {
-	return NewError(fmt.Errorf(format, a...))
-}
-
 // NewErrorf creates an Error from the given error message. It is a
 // passthrough to fmt.Errorf, with an additional prefix containing the
 // filename and line number.

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -233,8 +233,8 @@ func TestAdminAPIDatabases(t *testing.T) {
 	session := sql.NewSession(sql.SessionArgs{User: security.RootUser}, s.sqlExecutor, nil)
 	query := "CREATE DATABASE " + testdb
 	createRes := s.sqlExecutor.ExecuteStatements(context.Background(), session, query, nil)
-	if createRes.ResultList[0].PErr != nil {
-		t.Fatal(createRes.ResultList[0].PErr)
+	if createRes.ResultList[0].Err != nil {
+		t.Fatal(createRes.ResultList[0].Err)
 	}
 
 	var resp DatabasesResponse
@@ -260,8 +260,8 @@ func TestAdminAPIDatabases(t *testing.T) {
 	testuser := "testuser"
 	grantQuery := "GRANT " + strings.Join(privileges, ", ") + " ON DATABASE " + testdb + " TO " + testuser
 	grantRes := s.sqlExecutor.ExecuteStatements(context.Background(), session, grantQuery, nil)
-	if grantRes.ResultList[0].PErr != nil {
-		t.Fatal(grantRes.ResultList[0].PErr)
+	if grantRes.ResultList[0].Err != nil {
+		t.Fatal(grantRes.ResultList[0].Err)
 	}
 
 	var details DatabaseDetailsResponse
@@ -367,8 +367,8 @@ CREATE TABLE test.tbl (
 
 	for _, q := range setupQueries {
 		res := s.sqlExecutor.ExecuteStatements(context.Background(), session, q, nil)
-		if res.ResultList[0].PErr != nil {
-			t.Fatalf("error executing '%s': %s", q, res.ResultList[0].PErr)
+		if res.ResultList[0].Err != nil {
+			t.Fatalf("error executing '%s': %s", q, res.ResultList[0].Err)
 		}
 	}
 
@@ -450,8 +450,8 @@ VALUES ('admin', 'abc'), ('bob', 'xyz')`
 	res := s.sqlExecutor.ExecuteStatements(context.Background(), session, query, nil)
 	if a, e := len(res.ResultList), 1; a != e {
 		t.Fatalf("len(results) %d != %d", a, e)
-	} else if res.ResultList[0].PErr != nil {
-		t.Fatal(res.ResultList[0].PErr)
+	} else if res.ResultList[0].Err != nil {
+		t.Fatal(res.ResultList[0].Err)
 	}
 
 	// Query the API for users.
@@ -491,8 +491,8 @@ func TestAdminAPIEvents(t *testing.T) {
 	}
 	for _, q := range setupQueries {
 		res := s.sqlExecutor.ExecuteStatements(context.Background(), session, q, nil)
-		if res.ResultList[0].PErr != nil {
-			t.Fatalf("error executing '%s': %s", q, res.ResultList[0].PErr)
+		if res.ResultList[0].Err != nil {
+			t.Fatalf("error executing '%s': %s", q, res.ResultList[0].Err)
 		}
 	}
 

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -500,8 +500,8 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 				}
 			}
 		}
-		if rows.PErr() != nil {
-			return rows.PErr().GoError()
+		if rows.Err() != nil {
+			return rows.Err()
 		}
 		// Write the new index values.
 		if err := txn.Run(b); err != nil {

--- a/sql/internal.go
+++ b/sql/internal.go
@@ -44,8 +44,7 @@ func (ie InternalExecutor) ExecuteStatementInTransaction(
 	p.setTxn(txn)
 	p.session.User = security.RootUser
 	p.leaseMgr = ie.LeaseManager
-	rowsAffected, pErr := p.exec(statement, params...)
-	return rowsAffected, pErr.GoError()
+	return p.exec(statement, params...)
 }
 
 // GetTableSpan gets the key span for a SQL table, including any indices.

--- a/sql/parser/txn.go
+++ b/sql/parser/txn.go
@@ -21,9 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-
-	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/util"
 )
 
 // IsolationLevel holds the isolation level for a transaction.
@@ -117,10 +114,9 @@ const RestartSavepointName string = "COCKROACH_RESTART"
 // value.
 // We accept everything with the desired prefix because at least the C++ libpqxx
 // appends sequence numbers to the savepoint name specified by the user.
-func ValidateRestartCheckpoint(savepoint string) *roachpb.Error {
+func ValidateRestartCheckpoint(savepoint string) error {
 	if !strings.HasPrefix(strings.ToUpper(savepoint), RestartSavepointName) {
-		return roachpb.NewError(util.Errorf(
-			"SAVEPOINT not supported except for %s", RestartSavepointName))
+		return fmt.Errorf("SAVEPOINT not supported except for %s", RestartSavepointName)
 	}
 	return nil
 }

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -186,7 +186,7 @@ func (p *planner) resetTxn() {
 //
 // Note: The autoCommit parameter enables operations to enable the 1PC
 // optimization. This is a bit hackish/preliminary at present.
-func (p *planner) makePlan(stmt parser.Statement, desiredTypes []parser.Datum, autoCommit bool) (planNode, *roachpb.Error) {
+func (p *planner) makePlan(stmt parser.Statement, desiredTypes []parser.Datum, autoCommit bool) (planNode, error) {
 	tracing.AnnotateTrace()
 
 	// This will set the system DB trigger for transactions containing
@@ -200,148 +200,106 @@ func (p *planner) makePlan(stmt parser.Statement, desiredTypes []parser.Datum, a
 
 	switch n := stmt.(type) {
 	case *parser.AlterTable:
-		pNode, err := p.AlterTable(n)
-		return pNode, roachpb.NewError(err)
+		return p.AlterTable(n)
 	case *parser.BeginTransaction:
-		pNode, err := p.BeginTransaction(n)
-		return pNode, roachpb.NewError(err)
+		return p.BeginTransaction(n)
 	case *parser.CreateDatabase:
-		pNode, err := p.CreateDatabase(n)
-		return pNode, roachpb.NewError(err)
+		return p.CreateDatabase(n)
 	case *parser.CreateIndex:
-		pNode, err := p.CreateIndex(n)
-		return pNode, roachpb.NewError(err)
+		return p.CreateIndex(n)
 	case *parser.CreateTable:
-		pNode, err := p.CreateTable(n)
-		return pNode, roachpb.NewError(err)
+		return p.CreateTable(n)
 	case *parser.Delete:
-		pNode, err := p.Delete(n, desiredTypes, autoCommit)
-		return pNode, roachpb.NewError(err)
+		return p.Delete(n, desiredTypes, autoCommit)
 	case *parser.DropDatabase:
-		pNode, err := p.DropDatabase(n)
-		return pNode, roachpb.NewError(err)
+		return p.DropDatabase(n)
 	case *parser.DropIndex:
-		pNode, err := p.DropIndex(n)
-		return pNode, roachpb.NewError(err)
+		return p.DropIndex(n)
 	case *parser.DropTable:
-		pNode, err := p.DropTable(n)
-		return pNode, roachpb.NewError(err)
+		return p.DropTable(n)
 	case *parser.Explain:
 		return p.Explain(n, autoCommit)
 	case *parser.Grant:
-		pNode, err := p.Grant(n)
-		return pNode, roachpb.NewError(err)
+		return p.Grant(n)
 	case *parser.Insert:
 		return p.Insert(n, desiredTypes, autoCommit)
 	case *parser.ParenSelect:
 		return p.makePlan(n.Select, desiredTypes, autoCommit)
 	case *parser.RenameColumn:
-		pNode, err := p.RenameColumn(n)
-		return pNode, roachpb.NewError(err)
+		return p.RenameColumn(n)
 	case *parser.RenameDatabase:
-		pNode, err := p.RenameDatabase(n)
-		return pNode, roachpb.NewError(err)
+		return p.RenameDatabase(n)
 	case *parser.RenameIndex:
-		pNode, err := p.RenameIndex(n)
-		return pNode, roachpb.NewError(err)
+		return p.RenameIndex(n)
 	case *parser.RenameTable:
-		pNode, err := p.RenameTable(n)
-		return pNode, roachpb.NewError(err)
+		return p.RenameTable(n)
 	case *parser.Revoke:
-		pNode, err := p.Revoke(n)
-		return pNode, roachpb.NewError(err)
+		return p.Revoke(n)
 	case *parser.Select:
-		pNode, err := p.Select(n, desiredTypes, autoCommit)
-		return pNode, roachpb.NewError(err)
+		return p.Select(n, desiredTypes, autoCommit)
 	case *parser.SelectClause:
-		pNode, err := p.SelectClause(n, desiredTypes)
-		return pNode, roachpb.NewError(err)
+		return p.SelectClause(n, desiredTypes)
 	case *parser.Set:
-		pNode, err := p.Set(n)
-		return pNode, roachpb.NewError(err)
+		return p.Set(n)
 	case *parser.SetTimeZone:
-		pNode, err := p.SetTimeZone(n)
-		return pNode, roachpb.NewError(err)
+		return p.SetTimeZone(n)
 	case *parser.SetTransaction:
-		pNode, err := p.SetTransaction(n)
-		return pNode, roachpb.NewError(err)
+		return p.SetTransaction(n)
 	case *parser.SetDefaultIsolation:
-		pNode, err := p.SetDefaultIsolation(n)
-		return pNode, roachpb.NewError(err)
+		return p.SetDefaultIsolation(n)
 	case *parser.Show:
-		pNode, err := p.Show(n)
-		return pNode, roachpb.NewError(err)
+		return p.Show(n)
 	case *parser.ShowCreateTable:
-		pNode, err := p.ShowCreateTable(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowCreateTable(n)
 	case *parser.ShowColumns:
-		pNode, err := p.ShowColumns(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowColumns(n)
 	case *parser.ShowDatabases:
-		pNode, err := p.ShowDatabases(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowDatabases(n)
 	case *parser.ShowGrants:
-		pNode, err := p.ShowGrants(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowGrants(n)
 	case *parser.ShowIndex:
-		pNode, err := p.ShowIndex(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowIndex(n)
 	case *parser.ShowTables:
-		pNode, err := p.ShowTables(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowTables(n)
 	case *parser.Truncate:
-		pNode, err := p.Truncate(n)
-		return pNode, roachpb.NewError(err)
+		return p.Truncate(n)
 	case *parser.UnionClause:
 		return p.UnionClause(n, desiredTypes, autoCommit)
 	case *parser.Update:
-		pNode, err := p.Update(n, desiredTypes, autoCommit)
-		return pNode, roachpb.NewError(err)
+		return p.Update(n, desiredTypes, autoCommit)
 	case *parser.ValuesClause:
-		pNode, err := p.ValuesClause(n, desiredTypes)
-		return pNode, roachpb.NewError(err)
+		return p.ValuesClause(n, desiredTypes)
 	default:
-		return nil, roachpb.NewErrorf("unknown statement type: %T", stmt)
+		return nil, util.Errorf("unknown statement type: %T", stmt)
 	}
 }
 
-func (p *planner) prepare(stmt parser.Statement) (planNode, *roachpb.Error) {
+func (p *planner) prepare(stmt parser.Statement) (planNode, error) {
 	switch n := stmt.(type) {
 	case *parser.Delete:
-		pNode, err := p.Delete(n, nil, false)
-		return pNode, roachpb.NewError(err)
+		return p.Delete(n, nil, false)
 	case *parser.Insert:
 		return p.Insert(n, nil, false)
 	case *parser.Select:
-		pNode, err := p.Select(n, nil, false)
-		return pNode, roachpb.NewError(err)
+		return p.Select(n, nil, false)
 	case *parser.SelectClause:
-		pNode, err := p.SelectClause(n, nil)
-		return pNode, roachpb.NewError(err)
+		return p.SelectClause(n, nil)
 	case *parser.Show:
-		pNode, err := p.Show(n)
-		return pNode, roachpb.NewError(err)
+		return p.Show(n)
 	case *parser.ShowCreateTable:
-		pNode, err := p.ShowCreateTable(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowCreateTable(n)
 	case *parser.ShowColumns:
-		pNode, err := p.ShowColumns(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowColumns(n)
 	case *parser.ShowDatabases:
-		pNode, err := p.ShowDatabases(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowDatabases(n)
 	case *parser.ShowGrants:
-		pNode, err := p.ShowGrants(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowGrants(n)
 	case *parser.ShowIndex:
-		pNode, err := p.ShowIndex(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowIndex(n)
 	case *parser.ShowTables:
-		pNode, err := p.ShowTables(n)
-		return pNode, roachpb.NewError(err)
+		return p.ShowTables(n)
 	case *parser.Update:
-		pNode, err := p.Update(n, nil, false)
-		return pNode, roachpb.NewError(err)
+		return p.Update(n, nil, false)
 	default:
 		// Other statement types do not support placeholders so there is no need
 		// for any special handling here.
@@ -349,20 +307,19 @@ func (p *planner) prepare(stmt parser.Statement) (planNode, *roachpb.Error) {
 	}
 }
 
-func (p *planner) query(sql string, args ...interface{}) (planNode, *roachpb.Error) {
+func (p *planner) query(sql string, args ...interface{}) (planNode, error) {
 	stmt, err := parser.ParseOneTraditional(sql)
 	if err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 	stmt, err = parser.FillArgs(stmt, golangParameters(args))
 	if err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, err
 	}
 	return p.makePlan(stmt, nil, false)
 }
 
-// TODO(andrei): change to return error.
-func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, *roachpb.Error) {
+func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, error) {
 	plan, err := p.query(sql, args...)
 	if err != nil {
 		return nil, err
@@ -371,31 +328,30 @@ func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, *roa
 		return nil, err
 	}
 	if !plan.Next() {
-		if pErr := plan.PErr(); pErr != nil {
-			return nil, pErr
+		if err := plan.Err(); err != nil {
+			return nil, err
 		}
 		return nil, nil
 	}
 	values := plan.Values()
 	if plan.Next() {
-		return nil, roachpb.NewErrorf("%s: unexpected multiple results", sql)
+		return nil, util.Errorf("%s: unexpected multiple results", sql)
 	}
-	if pErr := plan.PErr(); pErr != nil {
-		return nil, pErr
+	if err := plan.Err(); err != nil {
+		return nil, err
 	}
 	return values, nil
 }
 
-// TODO(andrei): change to return error.
-func (p *planner) exec(sql string, args ...interface{}) (int, *roachpb.Error) {
-	plan, pErr := p.query(sql, args...)
-	if pErr != nil {
-		return 0, pErr
+func (p *planner) exec(sql string, args ...interface{}) (int, error) {
+	plan, err := p.query(sql, args...)
+	if err != nil {
+		return 0, err
 	}
-	if pErr := plan.Start(); pErr != nil {
-		return 0, pErr
+	if err := plan.Start(); err != nil {
+		return 0, err
 	}
-	return countRowsAffected(plan), plan.PErr()
+	return countRowsAffected(plan), plan.Err()
 }
 
 // getAliasedTableLease looks up the table descriptor for an alias table
@@ -469,7 +425,7 @@ type planNode interface {
 	// plan). Returns an error if initialization fails.
 	// The SQL "prepare" phase should merely build the plan node(s),
 	// and Start/Next should be only called during "execute".
-	Start() *roachpb.Error
+	Start() error
 
 	// Next performs one unit of work, returning false if an error is
 	// encountered or if there is no more work to do. For statements
@@ -478,9 +434,8 @@ type planNode interface {
 	// See executor.go: countRowsAffected() and execStmt() for an example.
 	Next() bool
 
-	// PErr returns the error, if any, encountered during iteration.
-	// TODO(andrei): change to return error
-	PErr() *roachpb.Error
+	// Err returns the error, if any, encountered during iteration.
+	Err() error
 
 	// ExplainPlan returns a name and description and a list of child nodes.
 	ExplainPlan(verbose bool) (name, description string, children []planNode)
@@ -547,7 +502,7 @@ type emptyNode struct {
 func (*emptyNode) Columns() []ResultColumn { return nil }
 func (*emptyNode) Ordering() orderingInfo  { return orderingInfo{} }
 func (*emptyNode) Values() parser.DTuple   { return nil }
-func (*emptyNode) PErr() *roachpb.Error    { return nil }
+func (*emptyNode) Err() error              { return nil }
 
 func (*emptyNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	return "empty", "-", nil
@@ -566,7 +521,7 @@ func (*emptyNode) DebugValues() debugValues {
 	}
 }
 
-func (e *emptyNode) Start() *roachpb.Error {
+func (e *emptyNode) Start() error {
 	return nil
 }
 

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -106,7 +106,7 @@ func (n *scanNode) SetLimitHint(numRows int64, soft bool) {
 	}
 }
 
-func (n *scanNode) Start() *roachpb.Error {
+func (n *scanNode) Start() error {
 	return nil
 }
 
@@ -198,8 +198,8 @@ func (n *scanNode) Next() bool {
 	}
 }
 
-func (n *scanNode) PErr() *roachpb.Error {
-	return roachpb.NewError(n.err)
+func (n *scanNode) Err() error {
+	return n.err
 }
 
 func (n *scanNode) ExplainPlan(_ bool) (name, description string, children []planNode) {

--- a/sql/session.go
+++ b/sql/session.go
@@ -276,7 +276,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 				// statements in the current batch; we can't modify the results of older
 				// statements.
 				if scEntry.epoch == scc.curGroupNum {
-					results[scEntry.idx] = Result{PErr: roachpb.NewError(err)}
+					results[scEntry.idx] = Result{Err: err}
 				}
 				log.Warningf("Error executing schema change: %s", err)
 			}

--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -65,8 +65,8 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 	//     to the TypeCheck() method once the prepare and execute phase are separated
 	//     for select nodes.
 	planMaker := *v.planner
-	plan, pErr := planMaker.makePlan(subquery.Select, nil, false)
-	if pErr != nil {
+	plan, err := planMaker.makePlan(subquery.Select, nil, false)
+	if err != nil {
 		return false, expr
 	}
 
@@ -74,7 +74,7 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 		return false, expr
 	}
 
-	if v.err = plan.Start().GoError(); v.err != nil {
+	if v.err = plan.Start(); v.err != nil {
 		return false, expr
 	}
 
@@ -84,7 +84,7 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 		if plan.Next() {
 			return true, parser.MakeDBool(true)
 		}
-		v.err = plan.PErr().GoError()
+		v.err = plan.Err()
 		if v.err != nil {
 			return false, expr
 		}
@@ -143,7 +143,7 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 		}
 	}
 
-	v.err = plan.PErr().GoError()
+	v.err = plan.Err()
 	if v.err != nil {
 		return false, expr
 	}

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
@@ -50,10 +49,10 @@ var traceColumns = append([]ResultColumn{
 func (*explainTraceNode) Columns() []ResultColumn { return traceColumns }
 func (*explainTraceNode) Ordering() orderingInfo  { return orderingInfo{} }
 
-func (n *explainTraceNode) PErr() *roachpb.Error { return nil }
-func (n *explainTraceNode) Start() *roachpb.Error {
-	if pErr := n.plan.Start(); pErr != nil {
-		return pErr
+func (n *explainTraceNode) Err() error { return nil }
+func (n *explainTraceNode) Start() error {
+	if err := n.plan.Start(); err != nil {
+		return err
 	}
 	n.plan.MarkDebug(explainDebug)
 	return nil
@@ -68,8 +67,8 @@ func (n *explainTraceNode) Next() bool {
 		if !n.plan.Next() {
 			n.exhausted = true
 			sp := opentracing.SpanFromContext(n.txn.Context)
-			if pErr := n.PErr(); pErr != nil {
-				sp.LogEvent(pErr.String())
+			if err := n.Err(); err != nil {
+				sp.LogEvent(err.Error())
 			}
 			sp.LogEvent("tracing completed")
 			sp.Finish()

--- a/sql/values.go
+++ b/sql/values.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util/encoding"
 )
@@ -96,7 +95,7 @@ func (p *planner) ValuesClause(n *parser.ValuesClause, desiredTypes []parser.Dat
 	return v, nil
 }
 
-func (n *valuesNode) Start() *roachpb.Error {
+func (n *valuesNode) Start() error {
 	if n.n == nil {
 		return nil
 	}
@@ -119,7 +118,7 @@ func (n *valuesNode) Start() *roachpb.Error {
 			// TODO(knz): see comment above about expandSubqueries in ValuesClause().
 			expr, err := n.p.expandSubqueries(expr, 1)
 			if err != nil {
-				return roachpb.NewError(err)
+				return err
 			}
 			desired := parser.NoTypePreference
 			if len(n.desiredTypes) > i {
@@ -127,16 +126,16 @@ func (n *valuesNode) Start() *roachpb.Error {
 			}
 			typedExpr, err := parser.TypeCheck(expr, n.p.evalCtx.Args, desired)
 			if err != nil {
-				return roachpb.NewError(err)
+				return err
 			}
 			typedExpr, err = n.p.parser.NormalizeExpr(n.p.evalCtx, typedExpr)
 			if err != nil {
-				return roachpb.NewError(err)
+				return err
 			}
 
 			row[i], err = typedExpr.Eval(n.p.evalCtx)
 			if err != nil {
-				return roachpb.NewError(err)
+				return err
 			}
 		}
 		n.rows = append(n.rows, row)
@@ -175,7 +174,7 @@ func (n *valuesNode) Next() bool {
 	return true
 }
 
-func (*valuesNode) PErr() *roachpb.Error {
+func (*valuesNode) Err() error {
 	return nil
 }
 


### PR DESCRIPTION
Just mechanical changes.

Finished the migration away from pErr by migrating over planner and
Executor and all the node types that were not fully migrated.
The cherry on the cake is that roachpb.NewUError() is going away, since
it's now unused.

Next step is to get rid of the ErrorDetails that are now used as regular
Go types and never written to the proto.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6533)

<!-- Reviewable:end -->
