### PR TITLE
sql: Implement BOOL_AND and BOOL_OR aggregate functions

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -641,6 +641,20 @@ var Builtins = map[string][]Builtin{
 		},
 	},
 
+	"bool_and": {
+		Builtin{
+			Types:      ArgTypes{DummyBool},
+			ReturnType: TypeBool,
+		},
+	},
+
+	"bool_or": {
+		Builtin{
+			Types:      ArgTypes{DummyBool},
+			ReturnType: TypeBool,
+		},
+	},
+
 	"count": countImpls(),
 
 	"max": aggregateImpls(DummyBool, DummyInt, DummyFloat, DummyDecimal, DummyString, DummyBytes, DummyDate, DummyTimestamp, DummyInterval),

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -25,6 +25,8 @@ import (
 
 // TODO(nvanbenschoten) These can be removed and DummyT can be replaced by TypeT.
 var (
+	// TypeBool returns a bool datum.
+	TypeBool = DummyBool
 	// TypeBytes returns a bytes datum.
 	TypeBytes = DummyBytes
 	// TypeDate returns a date datum.

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -637,3 +637,35 @@ query B
 SELECT x > (SELECT avg(0)) FROM xyz LIMIT 1
 ----
 true
+
+statement ok
+CREATE TABLE bools (b BOOL)
+
+query BB
+SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
+----
+NULL NULL
+
+statement OK
+INSERT INTO bools VALUES (true), (true), (true)
+
+query BB
+SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
+----
+true true
+
+statement OK
+INSERT INTO bools VALUES (false), (false)
+
+query BB
+SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
+----
+false true
+
+statement OK
+DELETE FROM bools WHERE b
+
+query BB
+SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
+----
+false false


### PR DESCRIPTION
This change adds support for the aggregate functions
- `BOOL_AND(BOOL) -> BOOL`
- `BOOL_OR(BOOL) -> BOOL`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6535)

<!-- Reviewable:end -->
