### PR TITLE
sql/parser: make commonNumericConstantType take a []indexedExpr

### DIFF
--- a/sql/parser/constant.go
+++ b/sql/parser/constant.go
@@ -226,13 +226,17 @@ var numValTypePriority = []Datum{DummyInt, DummyFloat, DummyDecimal}
 // commonNumericConstantType returns the best constant type which is shared
 // between a set of provided numeric constants. Here, "best" is defined as
 // the smallest numeric data type which will not lose information.
-func commonNumericConstantType(vals ...*NumVal) Datum {
+//
+// The function takes a slice of indexedExprs, but expects all indexedExprs
+// to wrap a *NumVal. The reason it does no take a slice of *NumVals instead
+// is to avoid forcing callers to allocate separate slices of *NumVals.
+func commonNumericConstantType(vals []indexedExpr) Datum {
 	bestType := 0
 	for _, c := range vals {
 		for {
 			// This will not work if the available types are not strictly
 			// supersets of their previous types in order of preference.
-			if shouldConstantBecome(c, numValTypePriority[bestType]) {
+			if shouldConstantBecome(c.e.(*NumVal), numValTypePriority[bestType]) {
 				break
 			}
 			bestType++

--- a/sql/parser/overload.go
+++ b/sql/parser/overload.go
@@ -347,10 +347,6 @@ func typeCheckOverloadedExprs(
 
 	var bestConstType Datum
 	if len(constExprs) > 0 {
-		numVals := make([]*NumVal, len(constExprs))
-		for i, expr := range constExprs {
-			numVals[i] = expr.e.(*NumVal)
-		}
 		before := overloads
 
 		// The second heuristic is to prefer candidates where all numeric constants can become
@@ -358,8 +354,8 @@ func typeCheckOverloadedExprs(
 		// resolvable expressions were resolved homogeneously up to this point.
 		if homogeneousTyp != nil {
 			all := true
-			for _, constExpr := range numVals {
-				if !canConstantBecome(constExpr, homogeneousTyp) {
+			for _, expr := range constExprs {
+				if !canConstantBecome(expr.e.(*NumVal), homogeneousTyp) {
 					all = false
 					break
 				}
@@ -382,8 +378,8 @@ func typeCheckOverloadedExprs(
 
 		// The third heuristic is to prefer candidates where all numeric constants can become
 		// their "natural"" types.
-		for i, expr := range constExprs {
-			natural := naturalConstantType(numVals[i])
+		for _, expr := range constExprs {
+			natural := naturalConstantType(expr.e.(*NumVal))
 			if natural != nil {
 				filterOverloads(func(o overloadImpl) bool {
 					return o.params().getAt(expr.i).TypeEqual(natural)
@@ -400,7 +396,7 @@ func typeCheckOverloadedExprs(
 
 		// The fourth heuristic is to prefer candidates that accepts the "best" mutual
 		// type in the resolvable type set of all numeric constants.
-		bestConstType = commonNumericConstantType(numVals...)
+		bestConstType = commonNumericConstantType(constExprs)
 		for _, expr := range constExprs {
 			filterOverloads(func(o overloadImpl) bool {
 				return o.params().getAt(expr.i).TypeEqual(bestConstType)

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -763,11 +763,7 @@ func typeCheckSameTypedExprs(args MapArgs, desired Datum, exprs ...Expr) ([]Type
 		}
 
 		// If all consts could not become typ, use their best shared type.
-		numValExprs := make([]*NumVal, len(constExprs))
-		for i, numVal := range constExprs {
-			numValExprs[i] = numVal.e.(*NumVal)
-		}
-		bestType := commonNumericConstantType(numValExprs...)
+		bestType := commonNumericConstantType(constExprs)
 		setTypeForConsts(bestType)
 		return bestType, nil
 	}


### PR DESCRIPTION
We always call this function when we have a slice of `indexedExprs`, so
even though we only need a slice of `*NumVal` in
`commonNumericConstantType`, we take a slice of `indexedExpr` to avoid the
need to allocate and copy.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6546)

<!-- Reviewable:end -->
