### PR TITLE
sql: terminate schema change if it violating integrity constraints.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -385,7 +385,11 @@ func (s *Server) Start() error {
 	s.sqlExecutor.SetNodeID(s.node.Descriptor.NodeID)
 	// Create and start the schema change manager only after a NodeID
 	// has been assigned.
-	s.schemaChangeManager = sql.NewSchemaChangeManager(*s.db, s.gossip, s.leaseMgr)
+	sqlTestKnobs := &sql.ExecutorTestingKnobs{}
+	if s.ctx.TestingKnobs.SQLExecutor != nil {
+		sqlTestKnobs = s.ctx.TestingKnobs.SQLExecutor.(*sql.ExecutorTestingKnobs)
+	}
+	s.schemaChangeManager = sql.NewSchemaChangeManager(sqlTestKnobs, *s.db, s.gossip, s.leaseMgr)
 	s.schemaChangeManager.Start(s.stopper)
 
 	s.periodicallyCheckForUpdates()

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -18,7 +18,6 @@ package sql
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -282,9 +281,8 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 				// Still processing table.
 				done = false
 				if nonNullableColumn != "" {
-					return fmt.Errorf("column %s contains null values", nonNullableColumn)
+					return &errNonNullViolation{columnName: nonNullableColumn}
 				}
-
 				if sentinelKey == nil || !bytes.HasPrefix(kv.Key, sentinelKey) {
 					// Sentinel keys have a 0 suffix indicating 0 bytes of
 					// column ID. Strip off that suffix to determine the

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -32,6 +32,8 @@ const (
 	// PG error codes from:
 	// http://www.postgresql.org/docs/9.5/static/errcodes-appendix.html
 
+	// CodeNonNullViolationError represents violation of a non-null constraint.
+	CodeNonNullViolationError string = "23502"
 	// CodeUniquenessConstraintViolationError represents violations of uniqueness
 	// constraints.
 	CodeUniquenessConstraintViolationError string = "23505"
@@ -60,6 +62,7 @@ type ErrorWithPGCode interface {
 	Code() string
 }
 
+var _ ErrorWithPGCode = &errNonNullViolation{}
 var _ ErrorWithPGCode = &errUniquenessConstraintViolation{}
 var _ ErrorWithPGCode = &errTransactionAborted{}
 var _ ErrorWithPGCode = &errTransactionCommitted{}
@@ -112,6 +115,18 @@ func (*errTransactionCommitted) Code() string {
 	return CodeTransactionCommittedError
 }
 
+type errNonNullViolation struct {
+	columnName string
+}
+
+func (e *errNonNullViolation) Error() string {
+	return fmt.Sprintf("null value in column %q violates not-null constraint", e.columnName)
+}
+
+func (*errNonNullViolation) Code() string {
+	return CodeNonNullViolationError
+}
+
 type errUniquenessConstraintViolation struct {
 	index *sqlbase.IndexDescriptor
 	vals  []parser.Datum
@@ -131,6 +146,15 @@ func (e *errUniquenessConstraintViolation) Error() string {
 		strings.Join(e.index.ColumnNames, ","),
 		strings.Join(valStrs, ","),
 		e.index.Name)
+}
+
+func isIntegrityConstraintError(err error) bool {
+	switch err.(type) {
+	case *errNonNullViolation, *errUniquenessConstraintViolation:
+		return true
+	default:
+		return false
+	}
 }
 
 func convertBatchError(tableDesc *sqlbase.TableDescriptor, b *client.Batch) error {

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -213,8 +213,14 @@ type ExecutorTestingKnobs struct {
 	SyncSchemaChangersFilter SyncSchemaChangersFilter
 
 	// SchemaChangersStartBackfillNotification is called before applying the
-	// backfill for a schema change operation.
-	SchemaChangersStartBackfillNotification func()
+	// backfill for a schema change operation. It returns error to stop the
+	// backfill and return an error to the caller of the SchemaChanger.exec().
+	SchemaChangersStartBackfillNotification func() error
+
+	// AsyncSchemaChangersExecNotification is a function called before running
+	// a schema change asynchronously. Returning an error will prevent the
+	// asynchronous execution path from running.
+	AsyncSchemaChangerExecNotification func() error
 }
 
 // NewExecutor creates an Executor and registers a callback on the

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -18,9 +18,11 @@ package sql_test
 
 import (
 	gosql "database/sql"
+	"errors"
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +31,8 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	csql "github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/protoutil"
@@ -293,15 +297,14 @@ func TestAsyncSchemaChanger(t *testing.T) {
 	defer csql.TestDisableTableLeases()()
 	// Disable synchronous schema change execution so the asynchronous schema
 	// changer executes all schema changes.
-	var execKnobs csql.ExecutorTestingKnobs
-	execKnobs.SyncSchemaChangersFilter =
-		func(tscc csql.TestingSchemaChangerCollection) {
-			tscc.ClearSchemaChangers()
-		}
 	defer csql.TestSpeedupAsyncSchemaChanges()()
-
 	ctx, _ := createTestServerContext()
-	ctx.TestingKnobs.SQLExecutor = &execKnobs
+	ctx.TestingKnobs.SQLExecutor = &csql.ExecutorTestingKnobs{
+		SyncSchemaChangersFilter: func(tscc csql.TestingSchemaChangerCollection) {
+			tscc.ClearSchemaChangers()
+		},
+	}
+
 	server, sqlDB, kvDB := setupWithContext(t, ctx)
 	defer cleanup(server, sqlDB)
 
@@ -534,17 +537,17 @@ func TestRaceWithBackfill(t *testing.T) {
 	// Disable asynchronous schema change execution to allow synchronous path
 	// to trigger start of backfill notification.
 	defer csql.TestDisableAsyncSchemaChangeExec()()
-	var execKnobs csql.ExecutorTestingKnobs
 	var backfillNotification chan bool
-	execKnobs.SchemaChangersStartBackfillNotification =
-		func() {
+	ctx, _ := createTestServerContext()
+	ctx.TestingKnobs.SQLExecutor = &csql.ExecutorTestingKnobs{
+		SchemaChangersStartBackfillNotification: func() error {
 			if backfillNotification != nil {
 				// Close channel to notify that the backfill has started.
 				close(backfillNotification)
 			}
-		}
-	ctx, _ := createTestServerContext()
-	ctx.TestingKnobs.SQLExecutor = &execKnobs
+			return nil
+		},
+	}
 	server, sqlDB, kvDB := setupWithContext(t, ctx)
 	defer cleanup(server, sqlDB)
 
@@ -710,5 +713,214 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		t.Fatal(err)
 	} else if len(kvs) != 0 {
 		t.Fatalf("expected %d key value pairs, but got %d", 0, len(kvs))
+	}
+}
+
+// Test schema changes are retried and complete properly
+func TestSchemaChangeRetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Disable asynchronous schema change execution to allow synchronous path
+	// to run schema changes.
+	defer csql.TestDisableAsyncSchemaChangeExec()()
+	attempts := 0
+	ctx, _ := createTestServerContext()
+	ctx.TestingKnobs.SQLExecutor = &csql.ExecutorTestingKnobs{
+		SchemaChangersStartBackfillNotification: func() error {
+			attempts++
+			// Return a deadline exceeded error once.
+			if attempts == 1 {
+				return errors.New("context deadline exceeded")
+			}
+			return nil
+		},
+	}
+	server, sqlDB, _ := setupWithContext(t, ctx)
+	defer cleanup(server, sqlDB)
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bulk insert.
+	maxValue := 10
+	insert := fmt.Sprintf(`INSERT INTO t.test VALUES (%d, %d)`, 0, maxValue)
+	for i := 1; i <= maxValue; i++ {
+		insert += fmt.Sprintf(` ,(%d, %d)`, i, maxValue-i)
+	}
+	if _, err := sqlDB.Exec(insert); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run a schema change.
+	if _, err := sqlDB.Exec("CREATE UNIQUE INDEX foo ON t.test (v)"); err != nil {
+		t.Fatal(err)
+	}
+	// The schema change retried once.
+	if e := 2; attempts != e {
+		t.Fatalf("there were %d instead of %d attempts", attempts, e)
+	}
+
+	// The schema change succeeded. Verify that the index foo over v is
+	// consistent.
+	rows, err := sqlDB.Query(`SELECT v from t.test@foo`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count := 0
+	for ; rows.Next(); count++ {
+		var val int
+		if err := rows.Scan(&val); err != nil {
+			t.Errorf("row %d scan failed: %s", count, err)
+			continue
+		}
+		if count != val {
+			t.Errorf("e = %d, v = %d", count, val)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if eCount := maxValue + 1; eCount != count {
+		t.Fatalf("read the wrong number of rows: e = %d, v = %d", eCount, count)
+	}
+}
+
+// Test schema change purge failure doesn't leave DB in a bad state.
+func TestSchemaChangePurgeFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Speed up evaluation of async schema changes so that it processes a
+	// purged schema change quickly.
+	defer csql.TestSpeedupAsyncSchemaChanges()()
+
+	// Disable the async schema changer.
+	var enableAsyncSchemaChanges uint32
+
+	attempts := 0
+	ctx, _ := createTestServerContext()
+	ctx.TestingKnobs.SQLExecutor = &csql.ExecutorTestingKnobs{
+		SchemaChangersStartBackfillNotification: func() error {
+			attempts++
+			// Return a deadline exceeded error during the second attempt
+			// which attempts to clean up the schema change.
+			if attempts == 2 {
+				return errors.New("context deadline exceeded")
+			}
+			return nil
+		},
+		AsyncSchemaChangerExecNotification: func() error {
+			if enable := atomic.LoadUint32(&enableAsyncSchemaChanges); enable == 0 {
+				return errors.New("async schema changes are disabled")
+			}
+			return nil
+		},
+	}
+	server, sqlDB, kvDB := setupWithContext(t, ctx)
+	defer cleanup(server, sqlDB)
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bulk insert.
+	maxValue := csql.IndexBackfillChunkSize + 1
+	insert := fmt.Sprintf(`INSERT INTO t.test VALUES (%d, %d)`, 0, maxValue)
+	for i := 1; i <= maxValue; i++ {
+		insert += fmt.Sprintf(` ,(%d, %d)`, i, maxValue-i)
+	}
+	if _, err := sqlDB.Exec(insert); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a row with a duplicate value for v
+	if _, err := sqlDB.Exec(
+		`INSERT INTO t.test VALUES ($1, $2)`, maxValue+1, maxValue,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// A schema change that violates integrity constraints.
+	if _, err := sqlDB.Exec(
+		"CREATE UNIQUE INDEX foo ON t.test (v)",
+	); !testutils.IsError(err, "violates unique constraint") {
+		t.Fatal(err)
+	}
+	// The deadline exceeded error in the schema change purge results in no
+	// retry attempts of the purge.
+	if e := 2; attempts != e {
+		t.Fatalf("%d retries, despite allowing only (schema change + reverse) = %d", attempts, e)
+	}
+
+	// The index doesn't exist
+	if _, err := sqlDB.Query(
+		`SELECT v from t.test@foo`,
+	); !testutils.IsError(err, "index .* not found") {
+		t.Fatal(err)
+	}
+
+	// Read table descriptor.
+	nameKey := sqlbase.MakeNameMetadataKey(keys.MaxReservedDescID+1, "test")
+	gr, err := kvDB.Get(nameKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gr.Exists() {
+		t.Fatalf("Name entry %q does not exist", nameKey)
+	}
+	descKey := sqlbase.MakeDescMetadataKey(sqlbase.ID(gr.ValueInt()))
+	desc := &sqlbase.Descriptor{}
+	if err := kvDB.GetProto(descKey, desc); err != nil {
+		t.Fatal(err)
+	}
+	tableDesc := desc.GetTable()
+
+	// There is still a mutation hanging off of it.
+	if e := 1; len(tableDesc.Mutations) != e {
+		t.Fatalf("the table has %d instead of %d mutations", len(tableDesc.Mutations), e)
+	}
+	// The mutation is for a DROP.
+	if tableDesc.Mutations[0].Direction != sqlbase.DescriptorMutation_DROP {
+		t.Fatalf("the table has mutation %v instead of a DROP", tableDesc.Mutations[0])
+	}
+
+	// There is still some garbage index data that needs to be purged. All the
+	// rows from k = 0 to k = maxValue have index values. The k = maxValue + 1
+	// row with the conflict doesn't contain an index value.
+	numGarbageValues := csql.IndexBackfillChunkSize
+	tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
+	tableEnd := tablePrefix.PrefixEnd()
+	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+		t.Fatal(err)
+	} else if e := 2*(maxValue+2) + numGarbageValues; len(kvs) != e {
+		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
+	}
+
+	// Enable async schema change processing to ensure that it cleans up the
+	// above garbage left behind.
+	atomic.StoreUint32(&enableAsyncSchemaChanges, 1)
+
+	util.SucceedsSoon(t, func() error {
+		if err := kvDB.GetProto(descKey, desc); err != nil {
+			t.Fatal(err)
+		}
+		tableDesc := desc.GetTable()
+		if len(tableDesc.Mutations) > 0 {
+			return util.Errorf("%d mutations remaining", len(tableDesc.Mutations))
+		}
+		return nil
+	})
+
+	// No garbage left behind.
+	numGarbageValues = 0
+	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
+		t.Fatal(err)
+	} else if e := 2*(maxValue+2) + numGarbageValues; len(kvs) != e {
+		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
 	}
 }

--- a/sql/session.go
+++ b/sql/session.go
@@ -263,8 +263,8 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 			if err := sc.exec(
 				e.ctx.TestingKnobs.SchemaChangersStartBackfillNotification,
 			); err != nil {
-				if err == errExistingSchemaChangeLease {
-					// Try again.
+				if isSchemaChangeRetryError(err) {
+					// Try again
 					continue
 				}
 				// All other errors can be reported; we report it as the result

--- a/sql/testdata/alter_table
+++ b/sql/testdata/alter_table
@@ -131,7 +131,7 @@ statement ok
 ALTER TABLE t ADD COLUMN y DECIMAL NOT NULL DEFAULT (DECIMAL '1.3')
 
 # Add a non NULL column with no default value
-statement error column q contains null values
+statement error pgcode 23502 null value in column \"q\" violates not-null constraint
 ALTER TABLE t ADD COLUMN q DECIMAL NOT NULL
 
 statement ok


### PR DESCRIPTION
The original code would declare the schema change as unviable
if it hit any error including transient timeouts. This change now
explictly terminates the schema change only if it hits integrity
constraints. Furthermore the schema change is retried for all other
errors with the exception of the "table not found" error.

Whenever an integrity constraint error is hit, the schema change
is first put into reverse, and then backed out. If an error is
seen while backing out, the process is stopped to be continued
later via the asynchronous schema change manager.

fixes #6333 #6432

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6552)

<!-- Reviewable:end -->
