### PR TITLE
roachpb: Define ContainsExclusiveEndKey and use it in DistSender

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -690,8 +690,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			// We evict and retry in such a case.
 			includesFrontOfCurSpan := func(rd *roachpb.RangeDescriptor) bool {
 				if isReverse {
-					// This approach is needed because rs.EndKey is exclusive.
-					return desc.ContainsKeyRange(desc.StartKey, rs.EndKey)
+					return desc.ContainsExclusiveEndKey(rs.EndKey)
 				}
 				return desc.ContainsKey(rs.Key)
 			}

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -941,6 +941,12 @@ func (rs RSpan) ContainsKey(key RKey) bool {
 	return bytes.Compare(key, rs.Key) >= 0 && bytes.Compare(key, rs.EndKey) < 0
 }
 
+// ContainsExclusiveEndKey returns whether this span contains the specified (exclusive) end key
+// (e.g., span ["a", b") contains "b" as exclusive end key).
+func (rs RSpan) ContainsExclusiveEndKey(key RKey) bool {
+	return bytes.Compare(key, rs.Key) > 0 && bytes.Compare(key, rs.EndKey) <= 0
+}
+
 // ContainsKeyRange returns whether this span contains the specified
 // key range from start (inclusive) to end (exclusive).
 // If end is empty, returns ContainsKey(start).

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -741,6 +741,29 @@ func TestRSpanContains(t *testing.T) {
 	}
 }
 
+// TestRSpanContainsExclusiveEndKey verifies ContainsExclusiveEndKey to check whether a key
+// or key range is contained within the span.
+func TestRSpanContainsExclusiveEndKey(t *testing.T) {
+	rs := RSpan{Key: []byte("b"), EndKey: []byte("c")}
+
+	testData := []struct {
+		key      RKey
+		contains bool
+	}{
+		// Single keys.
+		{RKey("a"), false},
+		{RKey("b"), false},
+		{RKey("bb"), true},
+		{RKey("c"), true},
+		{RKey("c").Next(), false},
+	}
+	for i, test := range testData {
+		if rs.ContainsExclusiveEndKey(test.key) != test.contains {
+			t.Errorf("%d: expected key %q within range", i, test.key)
+		}
+	}
+}
+
 // TestRSpanIntersect verifies rSpan.intersect.
 func TestRSpanIntersect(t *testing.T) {
 	rs := RSpan{Key: RKey("b"), EndKey: RKey("e")}

--- a/roachpb/metadata.go
+++ b/roachpb/metadata.go
@@ -107,6 +107,11 @@ func (r RangeDescriptor) ContainsKey(key RKey) bool {
 	return r.RSpan().ContainsKey(key)
 }
 
+// ContainsExclusiveEndKey returns whether this RangeDescriptor contains the specified end key.
+func (r RangeDescriptor) ContainsExclusiveEndKey(key RKey) bool {
+	return r.RSpan().ContainsExclusiveEndKey(key)
+}
+
 // ContainsKeyRange returns whether this RangeDescriptor contains the specified
 // key range from start (inclusive) to end (exclusive).
 // If end is empty, returns ContainsKey(start).


### PR DESCRIPTION
`ContainsKeyRange(s, e)` returns true when `s == e`, so `includesFrontOfCurSpan` returns true if the key is `'a'`, the descriptor range is `['a', b')`, and `isReverse` is `true`. This is not expected
since `'a'` is exclusive in the context and we want to a descriptor `[..., 'a')`.

We can also change `ContainsKeyRange(s,e)` to stop returning true when `s == e`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6558)

<!-- Reviewable:end -->
