### PR TITLE
sql: switch table reader test to use the new testingshim

### DIFF
--- a/server/testingshim/test_server_shim.go
+++ b/server/testingshim/test_server_shim.go
@@ -30,9 +30,9 @@ type TestServerInterface interface {
 	// ServingAddr returns the server's address.
 	ServingAddr() string
 
-	// ClientDB() returns a *client.DB instance for talking to this server, as
-	// an interface{}.
-	ClientDB() interface{}
+	// KVClient() returns a *client.DB instance for talking to this KV server,
+	// as an interface{}.
+	KVClient() interface{}
 
 	// KVDB() returns the *kv.DB instance as an interface{}.
 	KVDB() interface{}
@@ -64,12 +64,7 @@ func InitTestServerFactory(impl TestServerFactory) {
 	serviceImpl = impl
 }
 
-// NewTestServerWithParams creates a new test server with the given parameters.
-func NewTestServerWithParams(params TestServerParams) TestServerInterface {
+// NewTestServer creates a new test server with the given parameters.
+func NewTestServer(params TestServerParams) TestServerInterface {
 	return serviceImpl.New(params)
-}
-
-// NewTestServer creates a new test server with default parameters.
-func NewTestServer() TestServerInterface {
-	return NewTestServerWithParams(TestServerParams{})
 }

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -384,8 +384,8 @@ func (ts *TestServer) MustGetSQLNetworkCounter(name string) int64 {
 
 var _ testingshim.TestServerInterface = &TestServer{}
 
-// ClientDB is part of TestServerInterface.
-func (ts *TestServer) ClientDB() interface{} { return ts.db }
+// KVClient is part of TestServerInterface.
+func (ts *TestServer) KVClient() interface{} { return ts.db }
 
 // KVDB is part of TestServerInterface.
 func (ts *TestServer) KVDB() interface{} { return ts.kvDB }

--- a/sql/poc_test.go
+++ b/sql/poc_test.go
@@ -19,8 +19,7 @@ package sql
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/server/testingshim"
+	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -29,13 +28,9 @@ import (
 func TestPOC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	s := testingshim.NewTestServer()
-	if err := s.Start(); err != nil {
-		t.Fatal(err)
-	}
-	defer s.Stop()
+	_, _, kvClient, cleanup := sqlutils.SetupServer(t)
+	defer cleanup()
 
-	kvClient := s.ClientDB().(*client.DB)
 	err := kvClient.Put("testkey", "testval")
 	if err != nil {
 		t.Fatal(err)

--- a/sql/sqlbase/testutils.go
+++ b/sql/sqlbase/testutils.go
@@ -1,0 +1,54 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Andrei Matei (andreimatei1@gmail.com)
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sqlbase
+
+import (
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
+)
+
+// This file contains utility functions for tests (in other packages).
+
+// GetTableDescriptor retrieves a table descriptor directly from the KV layer.
+func GetTableDescriptor(kvDB *client.DB, database string, table string) *TableDescriptor {
+	dbNameKey := MakeNameMetadataKey(keys.RootNamespaceID, database)
+	gr, err := kvDB.Get(dbNameKey)
+	if err != nil {
+		panic(err)
+	}
+	if !gr.Exists() {
+		panic("database missing")
+	}
+	dbDescID := ID(gr.ValueInt())
+
+	tableNameKey := MakeNameMetadataKey(dbDescID, table)
+	gr, err = kvDB.Get(tableNameKey)
+	if err != nil {
+		panic(err)
+	}
+	if !gr.Exists() {
+		panic("table missing")
+	}
+
+	descKey := MakeDescMetadataKey(ID(gr.ValueInt()))
+	desc := &Descriptor{}
+	if err := kvDB.GetProto(descKey, desc); err != nil {
+		panic("proto missing")
+	}
+	return desc.GetTable()
+}

--- a/testutils/sqlutils/test_server.go
+++ b/testutils/sqlutils/test_server.go
@@ -1,0 +1,60 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sqlutils
+
+import (
+	gosql "database/sql"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/server/testingshim"
+)
+
+// SetupServerWithParams creates a test server with the given params and sets up
+// a gosql DB connection.
+func SetupServerWithParams(t *testing.T, params testingshim.TestServerParams) (
+	server testingshim.TestServerInterface, goDB *gosql.DB, kvClient *client.DB, cleanupFn func(),
+) {
+	server = testingshim.NewTestServer(params)
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	kvClient = server.KVClient().(*client.DB)
+	url, cleanupGoDB := PGUrl(t, server.ServingAddr(), security.RootUser, "SetupServer")
+	goDB, err := gosql.Open("postgres", url.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cleanupFn = func() {
+		_ = goDB.Close()
+		cleanupGoDB()
+		server.Stop()
+	}
+	return server, goDB, kvClient, cleanupFn
+}
+
+// SetupServer creates a test server with default parameters and sets up a gosql
+// DB connection.
+func SetupServer(t *testing.T) (
+	server testingshim.TestServerInterface, goDB *gosql.DB, kvClient *client.DB, cleanupFn func(),
+) {
+	return SetupServerWithParams(t, testingshim.TestServerParams{})
+}


### PR DESCRIPTION
Adding utility functions that parallel the existing ones in sql_test, but which
use the testingshim. Switching the table reader test to use it; this is a
prequel to moving the dist_sql stuff to a separate package.

Also moved getTableLease to sqlbase; this will need to happen for any
functionality that is used for both sql and dis_sql tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6560)

<!-- Reviewable:end -->
