### PR TITLE
sql: unexport distsql internals

### DIFF
--- a/sql/distsql/server.go
+++ b/sql/distsql/server.go
@@ -64,11 +64,11 @@ func (ds *ServerImpl) SetupFlows(ctx context.Context, req *SetupFlowsRequest) (
 ) {
 	txn := ds.setupTxn(ctx, &req.Txn)
 	for _, f := range req.Flows {
-		reader, err := NewTableReader(f.Reader, txn, ds.evalCtx)
+		reader, err := newTableReader(f.Reader, txn, ds.evalCtx)
 		if err != nil {
 			return nil, err
 		}
-		if err := reader.Run(); err != nil {
+		if err := reader.run(); err != nil {
 			fmt.Println(err)
 		}
 	}

--- a/sql/distsql/tablereader.go
+++ b/sql/distsql/tablereader.go
@@ -26,11 +26,11 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-// TableReader is the start of a computation flow; it performs KV operations to
+// tableReader is the start of a computation flow; it performs KV operations to
 // retrieve rows for a table and outputs the desired columns of the rows that
 // pass a filter expression.
 // See docs/RFCS/distributed_sql.md
-type TableReader struct {
+type tableReader struct {
 	desc       sqlbase.TableDescriptor
 	spans      sqlbase.Spans
 	outputCols []int
@@ -47,29 +47,29 @@ type TableReader struct {
 	row parser.DTuple
 }
 
-// TableReader implements parser.IndexedVarContainer.
-var _ parser.IndexedVarContainer = &TableReader{}
+// tableReader implements parser.IndexedVarContainer.
+var _ parser.IndexedVarContainer = &tableReader{}
 
 // IndexedVarReturnType is part of the parser.IndexedVarContaine interface.
-func (tr *TableReader) IndexedVarReturnType(idx int) parser.Datum {
+func (tr *tableReader) IndexedVarReturnType(idx int) parser.Datum {
 	return tr.desc.Columns[idx].Type.ToDatumType()
 }
 
 // IndexedVarEval is part of the parser.IndexedVarContaine interface.
-func (tr *TableReader) IndexedVarEval(idx int, ctx parser.EvalContext) (parser.Datum, error) {
+func (tr *tableReader) IndexedVarEval(idx int, ctx parser.EvalContext) (parser.Datum, error) {
 	return tr.row[idx].Eval(ctx)
 }
 
 // IndexedVarString is part of the parser.IndexedVarContaine interface.
-func (tr *TableReader) IndexedVarString(idx int) string {
+func (tr *tableReader) IndexedVarString(idx int) string {
 	return string(tr.desc.Columns[idx].Name)
 }
 
-// NewTableReader creates a TableReader. Exported for testing purposes.
-func NewTableReader(spec *TableReaderSpec, txn *client.Txn, evalCtx parser.EvalContext) (
-	*TableReader, error,
+// newTableReader creates a tableReader. Exported for testing purposes.
+func newTableReader(spec *TableReaderSpec, txn *client.Txn, evalCtx parser.EvalContext) (
+	*tableReader, error,
 ) {
-	tr := &TableReader{
+	tr := &tableReader{
 		desc:    spec.Table,
 		txn:     txn,
 		evalCtx: evalCtx,
@@ -132,8 +132,8 @@ func NewTableReader(spec *TableReaderSpec, txn *client.Txn, evalCtx parser.EvalC
 	return tr, nil
 }
 
-// Run is the "main loop".
-func (tr *TableReader) Run() error {
+// run is the "main loop".
+func (tr *tableReader) run() error {
 	if log.V(1) {
 		log.Infof("TableReader filter: %s\n", tr.filter)
 	}

--- a/sql/distsql/tablereader_test.go
+++ b/sql/distsql/tablereader_test.go
@@ -58,11 +58,11 @@ func TestTableReader(t *testing.T) {
 
 	txn := client.NewTxn(context.Background(), *kvDB)
 
-	tr, err := NewTableReader(&ts, txn, parser.EvalContext{})
+	tr, err := newTableReader(&ts, txn, parser.EvalContext{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := tr.Run(); err != nil {
+	if err := tr.run(); err != nil {
 		t.Fatal(err)
 	}
 	// TODO(radu): currently the table reader just prints out stuff; when it
@@ -87,11 +87,11 @@ func TestTableReader(t *testing.T) {
 		Filter:        Expression{Expr: "$1 != 30"}, // b != 30
 		OutputColumns: []uint32{0, 1},               // a, c
 	}
-	tr, err = NewTableReader(&ts, txn, parser.EvalContext{})
+	tr, err = newTableReader(&ts, txn, parser.EvalContext{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tr.Run()
+	err = tr.run()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Now that the tests live in the same package, we can unexport table reader
internals.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6571)

<!-- Reviewable:end -->
