### PR TITLE
Restore change to #6548 which was not committed to branch

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1028,11 +1028,6 @@ func (r *Replica) endCmds(cmd *cmd, ba *roachpb.BatchRequest, br *roachpb.BatchR
 					// DeleteRange adds to the write timestamp cache to prevent
 					// subsequent writes from rewriting history.
 					readTSCache = false
-					// DeleteRange requires that we retry on push to avoid the
-					// lost delete range anomaly.
-					if br.Txn != nil {
-						br.Txn.RetryOnPush = true
-					}
 				case *roachpb.EndTransactionRequest:
 					// EndTransaction adds to the write timestamp cache to ensure
 					// replays create a transaction record with WriteTooOld set.


### PR DESCRIPTION
Move assignment of `RetryOnPush` boolean to execution of `DeleteRange`
instead of having it done outside the Raft execution.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6586)

<!-- Reviewable:end -->
