### PR TITLE
sql/parser: Clean up memoized function handling for TypedExprs

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -623,21 +623,35 @@ var Builtins = map[string][]Builtin{
 	},
 
 	// Aggregate functions.
-	// These functions are handled in sql/group.go and are not evaluated normally,
-	// so they do not need to define an fn function.
+	// These functions are handled in sql/group.go and are not evaluated normally.
+	//
+	// The functions are split into two groups when it comes to handling constant
+	// literal arguments. If the result of the aggregate function with constant
+	// arguments is dependent on the number of rows it is run across (eg. SUM(1)),
+	// it should be marked as impure. If the result of the aggregate function with
+	// constant arguments is independent on the number of rows it is run across
+	// (eg. BOOL_AND(true)), it should provide an fn implementation that handles this
+	// constant argument case.
 
 	"avg": {
 		Builtin{
 			Types:      ArgTypes{TypeInt},
 			ReturnType: TypeDecimal,
+			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+				dd := &DDecimal{}
+				dd.SetUnscaled(int64(*args[0].(*DInt)))
+				return dd, nil
+			},
 		},
 		Builtin{
 			Types:      ArgTypes{TypeFloat},
 			ReturnType: TypeFloat,
+			fn:         identityFn,
 		},
 		Builtin{
 			Types:      ArgTypes{TypeDecimal},
 			ReturnType: TypeDecimal,
+			fn:         identityFn,
 		},
 	},
 
@@ -645,6 +659,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeBool},
 			ReturnType: TypeBool,
+			fn:         identityFn,
 		},
 	},
 
@@ -652,6 +667,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeBool},
 			ReturnType: TypeBool,
+			fn:         identityFn,
 		},
 	},
 
@@ -662,14 +678,17 @@ var Builtins = map[string][]Builtin{
 
 	"sum": {
 		Builtin{
+			impure:     true,
 			Types:      ArgTypes{TypeInt},
 			ReturnType: TypeDecimal,
 		},
 		Builtin{
+			impure:     true,
 			Types:      ArgTypes{TypeFloat},
 			ReturnType: TypeFloat,
 		},
 		Builtin{
+			impure:     true,
 			Types:      ArgTypes{TypeDecimal},
 			ReturnType: TypeDecimal,
 		},
@@ -677,14 +696,17 @@ var Builtins = map[string][]Builtin{
 
 	"variance": {
 		Builtin{
+			impure:     true,
 			Types:      ArgTypes{TypeInt},
 			ReturnType: TypeDecimal,
 		},
 		Builtin{
+			impure:     true,
 			Types:      ArgTypes{TypeDecimal},
 			ReturnType: TypeDecimal,
 		},
 		Builtin{
+			impure:     true,
 			Types:      ArgTypes{TypeFloat},
 			ReturnType: TypeFloat,
 		},
@@ -692,14 +714,17 @@ var Builtins = map[string][]Builtin{
 
 	"stddev": {
 		Builtin{
+			impure:     true,
 			Types:      ArgTypes{TypeInt},
 			ReturnType: TypeDecimal,
 		},
 		Builtin{
+			impure:     true,
 			Types:      ArgTypes{TypeDecimal},
 			ReturnType: TypeDecimal,
 		},
 		Builtin{
+			impure:     true,
 			Types:      ArgTypes{TypeFloat},
 			ReturnType: TypeFloat,
 		},
@@ -990,8 +1015,13 @@ var Builtins = map[string][]Builtin{
 	},
 }
 
-// The aggregate functions all just return their first argument. We don't
-// perform any type checking here either. The bulk of the aggregate function
+// identityFn returns the first argument provided.
+func identityFn(_ EvalContext, args DTuple) (Datum, error) {
+	return args[0], nil
+}
+
+// The aggregate functions all just return their first argument if given a
+// constant argument. The bulk of the aggregate function
 // implementation is performed at a higher level in sql.groupNode.
 func aggregateImpls(types ...Datum) []Builtin {
 	var r []Builtin
@@ -999,6 +1029,7 @@ func aggregateImpls(types ...Datum) []Builtin {
 		r = append(r, Builtin{
 			Types:      ArgTypes{t},
 			ReturnType: t,
+			fn:         identityFn,
 		})
 	}
 	return r

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -434,7 +434,7 @@ func (v *isConstVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 			v.isConst = false
 			return false, expr
 		case *FuncExpr:
-			if t.fn.fn == nil || t.fn.impure {
+			if t.fn.impure {
 				v.isConst = false
 				return false, expr
 			}

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -16,10 +16,7 @@
 
 package parser
 
-import (
-	"fmt"
-	"strings"
-)
+import "fmt"
 
 type normalizableExpr interface {
 	Expr
@@ -440,21 +437,6 @@ func (v *isConstVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 			v.isConst = false
 			return false, expr
 		case *FuncExpr:
-			// TODO(nvanbenschoten) This could be cleaned up a bit.
-			if t.fn.fn == nil {
-				name := string(t.Name.Base)
-				candidates, _ := Builtins[strings.ToLower(name)]
-				args := make(DTuple, 0, len(t.Exprs))
-				for _, e := range t.Exprs {
-					args = append(args, e.(TypedExpr).ReturnType())
-				}
-				for _, fn := range candidates {
-					if fn.Types.match(ArgTypes(args)) {
-						t.fn = fn
-						break
-					}
-				}
-			}
 			if t.fn.fn == nil || t.fn.impure {
 				v.isConst = false
 				return false, expr

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -415,9 +415,24 @@ func (expr *ParenExpr) TypeCheck(args MapArgs, desired Datum) (TypedExpr, error)
 	return expr, nil
 }
 
+// qualifiedNameTypes is a mapping of qualified names to types that can be mocked out
+// for tests to allow the qualified names to be type checked without throwing an error.
+var qualifiedNameTypes map[string]Datum
+
+func mockQualifiedNameTypes(types map[string]Datum) func() {
+	qualifiedNameTypes = types
+	return func() {
+		qualifiedNameTypes = nil
+	}
+}
+
 // TypeCheck implements the Expr interface.
 func (expr *QualifiedName) TypeCheck(args MapArgs, desired Datum) (TypedExpr, error) {
-	return nil, fmt.Errorf("qualified name \"%s\" not found", expr)
+	name := expr.String()
+	if _, ok := qualifiedNameTypes[name]; ok {
+		return expr, nil
+	}
+	return nil, fmt.Errorf("qualified name \"%s\" not found", name)
 }
 
 // TypeCheck implements the Expr interface.

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -610,7 +610,7 @@ EXPLAIN (DEBUG) SELECT MIN(z) FROM xyz
 query RRR
 SELECT AVG(1::int), AVG(2::float), AVG(3::decimal)
 ----
-1.0000000000000000 2 3.0000000000000000
+1 2 3
 
 query III
 SELECT COUNT(2::int), COUNT(3::float), COUNT(4::decimal)


### PR DESCRIPTION
This change simplifies how memoized functions are handled for `UnaryExprs`, `BinaryExprs`,
`ComparisonExprs`, and `FuncExprs`. We now maintain the memoized function throughout normilization and analysis so that we can make the guarantee that once an expression is type checked, it will always hold onto its function reference.

The change also cleans up some of the aggregate function semantics dealing with constant literal arguments.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6588)

<!-- Reviewable:end -->
