### PR TITLE
sql/parser: Avoid Datum allocations during Constant type resolution

### DIFF
--- a/sql/parser/constant_test.go
+++ b/sql/parser/constant_test.go
@@ -139,9 +139,9 @@ func TestStringConstantAvailableTypes(t *testing.T) {
 		c     *StrVal
 		avail []Datum
 	}{
-		{&StrVal{"abc 世界", false}, wantStringButCanBeBytes},
-		{&StrVal{"abc 世界", true}, wantBytesButCanBeString},
-		{&StrVal{string([]byte{0xff, 0xfe, 0xfd}), true}, wantBytes},
+		{&StrVal{s: "abc 世界", bytesEsc: false}, wantStringButCanBeBytes},
+		{&StrVal{s: "abc 世界", bytesEsc: true}, wantBytesButCanBeString},
+		{&StrVal{s: string([]byte{0xff, 0xfe, 0xfd}), bytesEsc: true}, wantBytes},
 	}
 
 	for i, test := range testCases {


### PR DESCRIPTION
This change embeds `Datum` value types in `Constant` structs to avoid allocating
the `Datum` when the `Constants` are resolved.

```
name                    old time/op    new time/op    delta
Select1_Cockroach-4       61.9µs ± 8%    58.1µs ± 5%   -6.09%   (p=0.003 n=10+9)
Select2_Cockroach-4        921µs ± 4%     937µs ± 7%     ~     (p=0.579 n=10+10)
Insert1_Cockroach-4        547µs ± 7%     554µs ± 4%     ~     (p=0.912 n=10+10)
Insert10_Cockroach-4       913µs ± 5%     878µs ± 5%   -3.91%   (p=0.013 n=10+9)
Insert100_Cockroach-4     3.64ms ± 7%    3.58ms ± 5%     ~     (p=0.315 n=10+10)
Insert1000_Cockroach-4    28.2ms ± 7%    27.3ms ±12%     ~     (p=0.353 n=10+10)
Update1_Cockroach-4        897µs ± 1%     887µs ± 4%     ~       (p=0.093 n=8+9)
Update10_Cockroach-4      1.66ms ± 7%    1.67ms ± 5%     ~     (p=0.853 n=10+10)
Update100_Cockroach-4     8.18ms ± 5%    7.35ms ±16%  -10.23%   (p=0.006 n=9+10)
Update1000_Cockroach-4    58.4ms ± 7%    54.9ms ±10%   -6.03%  (p=0.009 n=10+10)
Delete1_Cockroach-4        917µs ± 6%     924µs ± 5%     ~     (p=0.631 n=10+10)
Delete10_Cockroach-4      1.89ms ± 4%    1.84ms ± 9%     ~     (p=0.481 n=10+10)
Delete100_Cockroach-4     10.8ms ± 6%    10.4ms ± 9%     ~      (p=0.079 n=9+10)
Delete1000_Cockroach-4     103ms ±19%      95ms ±13%     ~     (p=0.052 n=10+10)

name                    old alloc/op   new alloc/op   delta
Select1_Cockroach-4       2.69kB ± 0%    2.75kB ± 0%   +2.00%  (p=0.000 n=10+10)
Select2_Cockroach-4       96.0kB ± 0%    96.6kB ± 0%   +0.56%  (p=0.000 n=10+10)
Insert1_Cockroach-4       23.8kB ± 0%    23.8kB ± 0%     ~       (p=0.748 n=9+9)
Insert10_Cockroach-4      73.7kB ± 0%    74.0kB ± 0%   +0.41%    (p=0.000 n=9+9)
Insert100_Cockroach-4      511kB ± 0%     514kB ± 0%   +0.59%   (p=0.000 n=10+8)
Insert1000_Cockroach-4    4.59MB ± 0%    4.62MB ± 0%   +0.70%   (p=0.000 n=10+8)
Update1_Cockroach-4       47.7kB ± 0%    47.8kB ± 0%   +0.25%   (p=0.000 n=10+9)
Update10_Cockroach-4       130kB ± 0%     130kB ± 0%   +0.46%    (p=0.000 n=9+9)
Update100_Cockroach-4      872kB ± 0%     877kB ± 0%   +0.64%    (p=0.000 n=8+8)
Update1000_Cockroach-4    7.40MB ± 0%    7.44MB ± 0%   +0.55%    (p=0.000 n=9+9)
Delete1_Cockroach-4       44.7kB ± 0%    44.8kB ± 0%   +0.12%   (p=0.000 n=9+10)
Delete10_Cockroach-4      71.8kB ± 0%    72.4kB ± 0%   +0.79%  (p=0.000 n=10+10)
Delete100_Cockroach-4      332kB ± 0%     337kB ± 0%   +1.56%  (p=0.000 n=10+10)
Delete1000_Cockroach-4    3.48MB ± 0%    3.54MB ± 0%   +1.60%   (p=0.000 n=10+9)

name                    old allocs/op  new allocs/op  delta
Select1_Cockroach-4         51.0 ± 0%      50.0 ± 0%   -1.96%  (p=0.000 n=10+10)
Select2_Cockroach-4        1.42k ± 0%     1.41k ± 0%   -0.70%    (p=0.000 n=9+9)
Insert1_Cockroach-4          285 ± 1%       281 ± 0%   -1.61%  (p=0.000 n=10+10)
Insert10_Cockroach-4         580 ± 0%       540 ± 0%   -6.90%   (p=0.000 n=9+10)
Insert100_Cockroach-4      3.40k ± 0%     3.00k ± 0%  -11.80%   (p=0.000 n=10+8)
Insert1000_Cockroach-4     31.5k ± 0%     27.5k ± 0%  -12.71%   (p=0.000 n=10+9)
Update1_Cockroach-4          666 ± 0%       663 ± 0%   -0.45%  (p=0.000 n=10+10)
Update10_Cockroach-4       1.10k ± 0%     1.09k ± 0%   -1.09%  (p=0.000 n=10+10)
Update100_Cockroach-4      5.16k ± 0%     5.06k ± 0%   -1.99%    (p=0.000 n=8+8)
Update1000_Cockroach-4     43.4k ± 1%     42.3k ± 1%   -2.53%  (p=0.000 n=10+10)
Delete1_Cockroach-4          593 ± 0%       592 ± 0%   -0.17%  (p=0.000 n=10+10)
Delete10_Cockroach-4         856 ± 0%       846 ± 0%   -1.12%   (p=0.000 n=8+10)
Delete100_Cockroach-4      3.32k ± 0%     3.22k ± 0%   -3.09%  (p=0.000 n=10+10)
Delete1000_Cockroach-4     27.7k ± 0%     26.7k ± 0%   -3.61%   (p=0.000 n=10+9)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6592)

<!-- Reviewable:end -->
