### PR TITLE
sql: use micro instead of nano seconds for timestamps

### DIFF
--- a/acceptance/python_test.go
+++ b/acceptance/python_test.go
@@ -28,10 +28,13 @@ func TestDockerPython(t *testing.T) {
 
 const python = `
 import psycopg2
-import os
 conn = psycopg2.connect('')
 cur = conn.cursor()
 cur.execute("SELECT 1, 2+%v")
 v = cur.fetchall()
 assert v == [(1, 5)]
+# verify #6597 is fixed
+cur = conn.cursor()
+cur.execute("SELECT now()")
+v = cur.fetchall()
 `

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -1072,7 +1072,7 @@ func (gp golangParameters) Arg(name string) (parser.Datum, bool) {
 		return t, true
 	// Time datatypes get special representation in the database.
 	case time.Time:
-		return &parser.DTimestamp{Time: t}, true
+		return parser.MakeDTimestamp(t, time.Microsecond), true
 	case time.Duration:
 		return &parser.DInterval{Duration: duration.Duration{Nanos: t.Nanoseconds()}}, true
 	case *inf.Dec:

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -498,7 +498,7 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{TypeTimestamp},
 			ReturnType: TypeInterval,
 			fn: func(e EvalContext, args DTuple) (Datum, error) {
-				return timestampMinusBinOp.fn(e, e.GetTxnTimestamp(), args[0])
+				return timestampMinusBinOp.fn(e, e.GetTxnTimestamp(time.Microsecond), args[0])
 			},
 		},
 		Builtin{
@@ -515,7 +515,7 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeDate,
 			fn: func(e EvalContext, args DTuple) (Datum, error) {
-				return e.makeDDate(e.GetTxnTimestamp().Time)
+				return e.makeDDate(e.GetTxnTimestamp(time.Microsecond).Time)
 			},
 		},
 	},
@@ -552,7 +552,7 @@ var Builtins = map[string][]Builtin{
 			ReturnType: TypeTimestamp,
 			impure:     true,
 			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				return &DTimestamp{Time: timeutil.Now()}, nil
+				return MakeDTimestamp(timeutil.Now(), time.Microsecond), nil
 			},
 		},
 	},
@@ -618,6 +618,42 @@ var Builtins = map[string][]Builtin{
 				default:
 					return DNull, fmt.Errorf("unsupported timespan: %s", timeSpan)
 				}
+			},
+		},
+	},
+
+	// Nanosecond functions.
+	// These functions are the only ways to create and read nanoseconds in
+	// timestamps. All other functions round to microseconds.
+
+	"parse_timestamp_ns": {
+		Builtin{
+			Types:      ArgTypes{TypeString},
+			ReturnType: TypeTimestamp,
+			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+				return ctx.ParseTimestamp(*args[0].(*DString), time.Nanosecond)
+			},
+		},
+	},
+
+	"format_timestamp_ns": {
+		Builtin{
+			Types:      ArgTypes{TypeTimestamp},
+			ReturnType: TypeString,
+			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+				t := args[0].(*DTimestamp)
+				return NewDString(t.Time.UTC().Format(timestampFormatNS)), nil
+			},
+		},
+	},
+
+	"current_timestamp_ns": {
+		Builtin{
+			Types:      ArgTypes{},
+			ReturnType: TypeTimestamp,
+			impure:     true,
+			fn: func(e EvalContext, args DTuple) (Datum, error) {
+				return e.GetTxnTimestamp(time.Nanosecond), nil
 			},
 		},
 	},
@@ -1141,7 +1177,7 @@ var txnTSImpl = Builtin{
 	ReturnType: TypeTimestamp,
 	impure:     true,
 	fn: func(e EvalContext, args DTuple) (Datum, error) {
-		return e.GetTxnTimestamp(), nil
+		return e.GetTxnTimestamp(time.Microsecond), nil
 	},
 }
 

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -667,6 +667,11 @@ type DTimestamp struct {
 	time.Time
 }
 
+// MakeDTimestamp creates a DTimestamp with specified precision.
+func MakeDTimestamp(t time.Time, precision time.Duration) *DTimestamp {
+	return &DTimestamp{Time: t.Round(precision)}
+}
+
 // ReturnType implements the TypedExpr interface.
 func (*DTimestamp) ReturnType() Datum {
 	return TypeTimestamp
@@ -736,12 +741,17 @@ func (d *DTimestamp) IsMin() bool {
 
 // Format implements the NodeFormatter interface.
 func (d *DTimestamp) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(d.UTC().Format(timestampWithOffsetZoneFormat))
+	buf.WriteString(d.UTC().Format(timestampNodeFormat))
 }
 
 // DTimestampTZ is the timestamp Datum that is rendered with session offset.
 type DTimestampTZ struct {
 	time.Time
+}
+
+// MakeDTimestampTZ creates a DTimestampTZ with specified precision.
+func MakeDTimestampTZ(t time.Time, precision time.Duration) *DTimestampTZ {
+	return &DTimestampTZ{Time: t.Round(precision)}
 }
 
 // ReturnType implements the TypedExpr interface.
@@ -813,7 +823,7 @@ func (d *DTimestampTZ) IsMin() bool {
 
 // Format implements the NodeFormatter interface.
 func (d *DTimestampTZ) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(d.UTC().Format(timestampWithOffsetZoneFormat))
+	buf.WriteString(d.UTC().Format(timestampNodeFormat))
 }
 
 // DInterval is the interval Datum.

--- a/sql/pgwire/types.go
+++ b/sql/pgwire/types.go
@@ -307,8 +307,8 @@ func (b *writeBuffer) writeBinaryDatum(d parser.Datum) {
 	}
 }
 
-const pgTimeStampFormat = "2006-01-02 15:04:05.999999999-07:00"
-const pgTimeStampFormatNoOffset = "2006-01-02 15:04:05.999999999"
+const pgTimeStampFormatNoOffset = "2006-01-02 15:04:05.999999"
+const pgTimeStampFormat = pgTimeStampFormatNoOffset + "-07:00"
 
 // formatTs formats t into a format cockroachdb/pq understands.
 // Mostly cribbed from github.com/cockroachdb/pq.
@@ -606,7 +606,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			if err != nil {
 				return d, util.Errorf("could not parse string %q as timestamp", b)
 			}
-			d = &parser.DTimestamp{Time: ts}
+			d = parser.MakeDTimestamp(ts, time.Microsecond)
 		default:
 			return d, util.Errorf("unsupported timestamp format code: %s", code)
 		}

--- a/sql/pgwire/types_test.go
+++ b/sql/pgwire/types_test.go
@@ -57,7 +57,7 @@ func TestParseTs(t *testing.T) {
 
 func TestTimestampRoundtrip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ts := time.Date(2006, 7, 8, 0, 0, 0, 123, time.FixedZone("UTC", 0))
+	ts := time.Date(2006, 7, 8, 0, 0, 0, 123000, time.FixedZone("UTC", 0))
 
 	parse := func(encoded []byte) time.Time {
 		decoded, err := parseTs(string(encoded))

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -427,10 +427,10 @@ func TestPGPreparedQuery(t *testing.T) {
 		"SELECT $1::date, $2::timestamp": {
 			base.Params(
 				time.Date(2006, 7, 8, 0, 0, 0, 9, time.FixedZone("", 0)),
-				time.Date(2001, 1, 2, 3, 4, 5, 6, time.FixedZone("", 0)),
+				time.Date(2001, 1, 2, 3, 4, 5, 6000, time.FixedZone("", 0)),
 			).Results(
 				time.Date(2006, 7, 8, 0, 0, 0, 0, time.FixedZone("", 0)),
-				time.Date(2001, 1, 2, 3, 4, 5, 6, time.FixedZone("", 0)),
+				time.Date(2001, 1, 2, 3, 4, 5, 6000, time.FixedZone("", 0)),
 			),
 		},
 		"SELECT (CASE a WHEN 10 THEN 'one' WHEN 11 THEN (CASE 'en' WHEN 'en' THEN $1 END) END) AS ret FROM d.T ORDER BY ret DESC LIMIT 2": {
@@ -454,9 +454,9 @@ func TestPGPreparedQuery(t *testing.T) {
 		},
 		"INSERT INTO d.ts (a) VALUES ($1) RETURNING a": {
 			base.Params(
-				time.Date(2006, 7, 8, 0, 0, 0, 123, time.FixedZone("", 0)),
+				time.Date(2006, 7, 8, 0, 0, 0, 123000, time.FixedZone("", 0)),
 			).Results(
-				time.Date(2006, 7, 8, 0, 0, 0, 123, time.FixedZone("", 0)),
+				time.Date(2006, 7, 8, 0, 0, 0, 123000, time.FixedZone("", 0)),
 			),
 		},
 		"INSERT INTO d.T VALUES ($1) RETURNING 1": {

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -785,12 +785,12 @@ SELECT regexp_replace(E'fooBar\nbaz', 'b(..)$', E'X\\&Y', 'z')
 query T
 SELECT (timestamp '2016-02-10 19:46:33.306157519')::string
 ----
-2016-02-10 19:46:33.306157519+00:00
+2016-02-10 19:46:33.306158+00:00
 
 query T
 SELECT (timestamptz '2016-02-10 19:46:33.306157519')::string
 ----
-2016-02-10 19:46:33.306157519+00:00
+2016-02-10 19:46:33.306158+00:00
 
 query I
 SELECT extract(milliseconds FROM '2016-02-10 19:46:33.306157519'::timestamp)
@@ -805,22 +805,22 @@ SELECT extract(millisecond FROM '2016-02-10 19:46:33.306157519'::timestamp)
 query I
 SELECT extract(microseconds FROM '2016-02-10 19:46:33.306157519'::timestamp)
 ----
-306157
+306158
 
 query I
 SELECT extract(microsecond FROM '2016-02-10 19:46:33.306157519'::timestamp)
 ----
-306157
+306158
 
 query I
 SELECT extract(nanoseconds FROM '2016-02-10 19:46:33.306157519'::timestamp)
 ----
-306157519
+306158000
 
 query I
 SELECT extract(nanosecond FROM '2016-02-10 19:46:33.306157519'::timestamp)
 ----
-306157519
+306158000
 
 query I
 SELECT extract(second FROM '2016-02-10 19:46:33.306157519'::timestamp)

--- a/sql/testdata/datetime
+++ b/sql/testdata/datetime
@@ -370,10 +370,85 @@ SELECT extract(microsecond from timestamp '2001-04-10 12:04:59.34565423')
 ----
 345654
 
+# nanoseconds are truncated to microseconds
 query I
 SELECT extract(nanosecond from timestamp '2001-04-10 12:04:59.34565423')
 ----
-345654230
+345654000
+
+# verify that nanosecond uniqueness is not preserved
+statement error pq: duplicate key value
+INSERT INTO t (a) VALUES ('2001-04-10 12:04:59.000000001'::timestamp), ('2001-04-10 12:04:59.000000002'::timestamp)
+
+# nanosecond uniqueness is preserved with parse_timestamp_ns
+statement ok
+INSERT INTO t (a) VALUES (parse_timestamp_ns('2001-04-10 12:04:59.000000001')), (parse_timestamp_ns('2001-04-10 12:04:59.000000002'))
+
+# parse_timestamp_ns retains nanoseconds
+query I
+SELECT extract(nanosecond from parse_timestamp_ns('2001-04-10 12:04:59.345654423'))
+----
+345654423
+
+# current_timestamp_ns has nanoseconds
+# Since it will produce 0 ns 1 out of 1000 executions,
+# INSERT many and verify that at least one is non-zero.
+
+statement ok
+INSERT INTO t (a) VALUES (current_timestamp_ns())
+
+statement ok
+INSERT INTO t (a) VALUES (current_timestamp_ns())
+
+statement ok
+INSERT INTO t (a) VALUES (current_timestamp_ns())
+
+statement ok
+INSERT INTO t (a) VALUES (current_timestamp_ns())
+
+statement ok
+INSERT INTO t (a) VALUES (current_timestamp_ns())
+
+query B
+SELECT max(extract(nanosecond from a) % 1000) != 0 FROM t
+----
+true
+
+query TT
+SELECT format_timestamp_ns('2001-04-10 12:04:59.345654423'::timestamp), format_timestamp_ns(parse_timestamp_ns('2001-04-10 12:04:59.345654423'))
+----
+2001-04-10 12:04:59.345654 2001-04-10 12:04:59.345654423
+
+# now() should not return any nanoseconds
+query I
+SELECT extract(nanosecond from now()) % 1000
+----
+0
+
+# statement_timestamp() should not return any nanoseconds
+query I
+SELECT extract(nanosecond from statement_timestamp()) % 1000
+----
+0
+
+# clock_timestamp() should not return any nanoseconds
+query I
+SELECT extract(nanosecond from clock_timestamp()) % 1000
+----
+0
+
+# statement_timestamp() should not return any nanoseconds
+query I
+SELECT extract(nanosecond from statement_timestamp()) % 1000
+----
+0
+
+# system.lease should still have nanoseconds
+# Similar to current_timestamp_ns, make sure at least 1 is non-zero.
+query B
+SELECT max(extract(nanosecond from expiration) % 1000) != 0 from system.lease
+----
+true
 
 query error extract: unsupported timespan: nansecond
 SELECT extract(nansecond from timestamp '2001-04-10 12:04:59.34565423')


### PR DESCRIPTION
Matches Postgres.

Fixes #6597

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6604)

<!-- Reviewable:end -->
