### PR TITLE
sql: selectNode.Next returns false if renderRow errors

### DIFF
--- a/sql/select.go
+++ b/sql/select.go
@@ -132,8 +132,8 @@ func (s *selectNode) Next() bool {
 		}
 
 		if passesFilter {
-			s.renderRow()
-			return true
+			s.err = s.renderRow()
+			return s.err == nil
 		} else if s.explain == explainDebug {
 			// Mark the row as filtered out.
 			s.debugVals.output = debugValueFiltered
@@ -612,19 +612,19 @@ func (s *selectNode) addRender(target parser.SelectExpr, desiredType parser.Datu
 }
 
 // renderRow renders the row by evaluating the render expressions. Assumes the qvals have been
-// populated with the current row. May set n.err if an error occurs during expression evaluation.
-func (s *selectNode) renderRow() {
+// populated with the current row.
+func (s *selectNode) renderRow() error {
 	if s.row == nil {
 		s.row = make([]parser.Datum, len(s.render))
 	}
 	for i, e := range s.render {
 		var err error
 		s.row[i], err = e.Eval(s.planner.evalCtx)
-		s.err = err
-		if s.err != nil {
-			return
+		if err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
 // Searches for a render target that matches the given column reference.

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -112,6 +112,10 @@ SELECT SUBSTR('RoacH', -2, 4)
 ----
 R
 
+# See #6601
+query error invalid utf8
+select cast(uuid_v4() as string)
+
 query T
 SELECT SUBSTR('12345', 2, 77)
 ----


### PR DESCRIPTION
Both Next() and Values() may cause plan.Err() to return non-nil.
It is assumed that on error the result cannot be used, but
failing to check that meant executor was hitting an NPE.

Fixes #6601.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6608)

<!-- Reviewable:end -->
