### PR TITLE
kv: reimplement TxnCoordSender.keys as a set of sorted spans

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
-	"github.com/cockroachdb/cockroach/util/interval"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -61,7 +60,7 @@ type txnMetadata struct {
 	// keys stores key ranges affected by this transaction through this
 	// coordinator. By keeping this record, the coordinator will be able
 	// to update the write intent when the transaction is committed.
-	keys interval.RangeGroup
+	keys []roachpb.Span
 
 	// lastUpdateNanos is the latest wall time in nanos the client sent
 	// transaction operations to this coordinator. Accessed and updated
@@ -82,26 +81,6 @@ type txnMetadata struct {
 	txnEnd chan struct{}
 }
 
-// addKeyRange adds the specified key range to the range group,
-// taking care not to add this range if existing entries already
-// completely cover the range.
-func addKeyRange(keys interval.RangeGroup, start, end roachpb.Key) {
-	// This gives us a memory-efficient end key if end is empty.
-	// The most common case for keys in the intents interval map
-	// is for single keys. However, the range group requires
-	// a non-empty interval, so we create two key slices which
-	// share the same underlying byte array.
-	if len(end) == 0 {
-		end = start.Next()
-		start = end[:len(start)]
-	}
-	keyR := interval.Range{
-		Start: interval.Comparable(start),
-		End:   interval.Comparable(end),
-	}
-	keys.Add(keyR)
-}
-
 // setLastUpdate updates the wall time (in nanoseconds) since the most
 // recent client operation for this transaction through the coordinator.
 func (tm *txnMetadata) setLastUpdate(nowNanos int64) {
@@ -120,26 +99,6 @@ func (tm *txnMetadata) getLastUpdate() int64 {
 func (tm *txnMetadata) hasClientAbandonedCoord(nowNanos int64) bool {
 	timeout := nowNanos - tm.timeoutDuration.Nanoseconds()
 	return tm.getLastUpdate() < timeout
-}
-
-// collectIntentSpans collects the spans of the intents to be resolved for the
-// transaction. It does not create copies, so the caller must not alter the
-// returned data. Usually called with txnMeta.keys.
-func collectIntentSpans(keys interval.RangeGroup) []roachpb.Span {
-	intents := make([]roachpb.Span, 0, keys.Len())
-	if err := keys.ForEach(func(r interval.Range) error {
-		sp := roachpb.Span{
-			Key: roachpb.Key(r.Start),
-		}
-		if endKey := roachpb.Key(r.End); !sp.Key.IsPrev(endKey) {
-			sp.EndKey = endKey
-		}
-		intents = append(intents, sp)
-		return nil
-	}); err != nil {
-		panic(err)
-	}
-	return intents
 }
 
 // TxnMetrics holds all metrics relating to KV transactions.
@@ -366,21 +325,25 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 
 			// Populate et.IntentSpans, taking into account both any existing
 			// and new writes, and taking care to perform proper deduplication.
-			var keys interval.RangeGroup
-			if txnMeta, metaOK := tc.txns[*ba.Txn.ID]; metaOK {
-				keys = txnMeta.keys
-			} else {
-				keys = interval.NewRangeTree()
+			txnMeta := tc.txns[*ba.Txn.ID]
+			if txnMeta != nil {
+				et.IntentSpans = txnMeta.keys
 			}
 			ba.IntentSpanIterate(func(key, endKey roachpb.Key) {
-				addKeyRange(keys, key, endKey)
+				et.IntentSpans = append(et.IntentSpans, roachpb.Span{
+					Key:    key,
+					EndKey: endKey,
+				})
 			})
-			et.IntentSpans = collectIntentSpans(keys)
+			roachpb.MergeSpans(&et.IntentSpans)
 			if len(et.IntentSpans) == 0 {
 				// If there aren't any intents, then there's factually no
 				// transaction to end. Read-only txns have all of their state
 				// in the client.
 				return roachpb.NewErrorf("cannot commit a read-only transaction")
+			}
+			if txnMeta != nil {
+				txnMeta.keys = et.IntentSpans
 			}
 			return nil
 		}(); pErr != nil {
@@ -576,7 +539,7 @@ func (tc *TxnCoordSender) unregisterTxnLocked(txnID uuid.UUID) (
 	restarts = int64(txnMeta.txn.Epoch)
 	status = txnMeta.txn.Status
 
-	txnMeta.keys.Clear()
+	txnMeta.keys = nil
 
 	delete(tc.txns, txnID)
 
@@ -656,8 +619,9 @@ func (tc *TxnCoordSender) tryAsyncAbort(txnID uuid.UUID) {
 	tc.Lock()
 	txnMeta := tc.txns[txnID]
 	// Grab the intents and clone the txn to avoid data races.
-	intentSpans := collectIntentSpans(txnMeta.keys)
-	txnMeta.keys.Clear()
+	roachpb.MergeSpans(&txnMeta.keys)
+	intentSpans := txnMeta.keys
+	txnMeta.keys = nil
 	txn := txnMeta.txn.Clone()
 	tc.Unlock()
 
@@ -854,21 +818,24 @@ func (tc *TxnCoordSender) updateState(
 	// unless it is tracking it (on top of it making sense to track it;
 	// after all, it **has** laid down intents and only the coordinator
 	// can augment a potential EndTransaction call). See #3303.
-	var intentGroup interval.RangeGroup
-	if txnMeta != nil {
-		intentGroup = txnMeta.keys
-	} else if pErr == nil || newTxn.Writing {
-		intentGroup = interval.NewRangeTree()
-	}
-	if intentGroup != nil {
+	if txnMeta != nil || pErr == nil || newTxn.Writing {
 		// Adding the intents even on error reduces the likelihood of dangling
 		// intents blocking concurrent writers for extended periods of time.
 		// See #3346.
+		var keys []roachpb.Span
+		if txnMeta != nil {
+			keys = txnMeta.keys
+		}
 		ba.IntentSpanIterate(func(key, endKey roachpb.Key) {
-			addKeyRange(intentGroup, key, endKey)
+			keys = append(keys, roachpb.Span{
+				Key:    key,
+				EndKey: endKey,
+			})
 		})
 
-		if txnMeta == nil && intentGroup.Len() > 0 {
+		if txnMeta != nil {
+			txnMeta.keys = keys
+		} else if len(keys) > 0 {
 			if !newTxn.Writing {
 				panic("txn with intents marked as non-writing")
 			}
@@ -882,7 +849,7 @@ func (tc *TxnCoordSender) updateState(
 				log.Trace(ctx, "coordinator spawns")
 				txnMeta = &txnMetadata{
 					txn:              newTxn,
-					keys:             intentGroup,
+					keys:             keys,
 					firstUpdateNanos: startNS,
 					lastUpdateNanos:  tc.clock.PhysicalNow(),
 					timeoutDuration:  tc.clientTimeout,

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -251,8 +251,10 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected a transaction to be created on coordinator")
 	}
-	if txnMeta.keys.Len() != 2 {
-		t.Errorf("expected 2 entries in keys range group; got %v", txnMeta.keys)
+	roachpb.MergeSpans(&txnMeta.keys)
+	keys := txnMeta.keys
+	if len(keys) != 2 {
+		t.Errorf("expected 2 entries in keys range group; got %v", keys)
 	}
 }
 
@@ -481,7 +483,8 @@ func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 	}
 	sender.Lock()
 	txnID := *txn.Proto.ID
-	intentSpans := collectIntentSpans(sender.txns[txnID].keys)
+	roachpb.MergeSpans(&sender.txns[txnID].keys)
+	intentSpans := sender.txns[txnID].keys
 	expSpans := []roachpb.Span{{Key: key, EndKey: []byte("")}}
 	equal := !reflect.DeepEqual(intentSpans, expSpans)
 	sender.Unlock()

--- a/roachpb/merge_spans.go
+++ b/roachpb/merge_spans.go
@@ -1,0 +1,94 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package roachpb
+
+import "sort"
+
+type sortedSpans []Span
+
+func (s sortedSpans) Less(i, j int) bool {
+	// Sort first on the start key and second on the end key. Note that we're
+	// relying on EndKey = nil (and len(EndKey) == 0) sorting before other
+	// EndKeys.
+	c := s[i].Key.Compare(s[j].Key)
+	if c != 0 {
+		return c < 0
+	}
+	return s[i].EndKey.Compare(s[j].EndKey) < 0
+}
+
+func (s sortedSpans) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s sortedSpans) Len() int {
+	return len(s)
+}
+
+// MergeSpans sorts the incoming spans and merges overlapping spans.
+func MergeSpans(spans *[]Span) {
+	if len(*spans) == 0 {
+		return
+	}
+
+	sort.Sort(sortedSpans(*spans))
+
+	// We build up the resulting slice of merged spans in place. This is safe
+	// because "r" grows by at most 1 element on each iteration, staying abreast
+	// or behind the iteration over "spans".
+	r := (*spans)[:1]
+	for _, cur := range (*spans)[1:] {
+		prev := &r[len(r)-1]
+		if len(cur.EndKey) == 0 && len(prev.EndKey) == 0 {
+			if cur.Key.Compare(prev.Key) != 0 {
+				// [a, nil] merge [b, nil]
+				r = append(r, cur)
+			} else {
+				// [a, nil] merge [a, nil]
+			}
+			continue
+		}
+		if len(prev.EndKey) == 0 {
+			if cur.Key.Compare(prev.Key) == 0 {
+				// [a, nil] merge [a, b]
+				prev.EndKey = cur.EndKey
+			} else {
+				// [a, nil] merge [b, c]
+				r = append(r, cur)
+			}
+			continue
+		}
+		if c := prev.EndKey.Compare(cur.Key); c >= 0 {
+			if cur.EndKey != nil {
+				if prev.EndKey.Compare(cur.EndKey) < 0 {
+					// [a, c] merge [b, d]
+					prev.EndKey = cur.EndKey
+				} else {
+					// [a, c] merge [b, c]
+				}
+			} else if c == 0 {
+				// [a, b] merge [b, nil]
+				prev.EndKey = cur.Key.Next()
+			} else {
+				// [a, c] merge [b, nil]
+			}
+			continue
+		}
+		r = append(r, cur)
+	}
+	*spans = r
+}

--- a/roachpb/merge_spans_test.go
+++ b/roachpb/merge_spans_test.go
@@ -1,0 +1,70 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package roachpb
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestMergeSpans(t *testing.T) {
+	makeSpan := func(s string) Span {
+		parts := strings.Split(s, "-")
+		if len(parts) == 2 {
+			return Span{Key: Key(parts[0]), EndKey: Key(parts[1])}
+		}
+		return Span{Key: Key(s)}
+	}
+	makeSpans := func(s string) []Span {
+		var spans []Span
+		if len(s) > 0 {
+			for _, p := range strings.Split(s, ",") {
+				spans = append(spans, makeSpan(p))
+			}
+		}
+		return spans
+	}
+
+	testCases := []struct {
+		spans    string
+		expected string
+	}{
+		{"", ""},
+		{"a", "a"},
+		{"a,b", "a,b"},
+		{"b,a", "a,b"},
+		{"a,a", "a"},
+		{"a-b", "a-b"},
+		{"a-b,b-c", "a-c"},
+		{"a-c,a-b", "a-c"},
+		{"a,b-c", "a,b-c"},
+		{"a,a-c", "a-c"},
+		{"a-c,b", "a-c"},
+		{"a-c,c", "a-c\x00"},
+		{"a-c,b-bb", "a-c"},
+		{"a-c,b-c", "a-c"},
+	}
+	for i, c := range testCases {
+		spans := makeSpans(c.spans)
+		MergeSpans(&spans)
+		expected := makeSpans(c.expected)
+		if !reflect.DeepEqual(expected, spans) {
+			t.Fatalf("%d: expected\n%s\n, but found:\n%s", i, expected, spans)
+		}
+	}
+}


### PR DESCRIPTION
Added roachpb.MergeSpans which sorts and merges overlapping spans. This
produces identical results to using an `interval.RangeGroup` to keep
track of intents, but is both faster and performs fewer allocations
during bulk operations involving lots of non-overlapping
spans (e.g. bulk inserts).

```
name                  old time/op    new time/op    delta
KVInsert1_SQL-32         503µs ± 2%     498µs ± 2%   -0.98%  (p=0.040 n=20+20)
KVInsert10_SQL-32       1.00ms ± 3%    0.97ms ± 3%   -2.89%  (p=0.000 n=19+20)
KVInsert100_SQL-32      5.28ms ± 3%    4.98ms ± 3%   -5.67%  (p=0.000 n=19+20)
KVInsert1000_SQL-32     48.0ms ± 6%    44.3ms ± 8%   -7.66%  (p=0.000 n=20+19)
KVInsert10000_SQL-32     585ms ±15%     525ms ± 7%  -10.23%  (p=0.000 n=20+19)

name                  old allocs/op  new allocs/op  delta
KVInsert1_SQL-32           296 ± 0%       288 ± 0%   -2.70%  (p=0.000 n=19+20)
KVInsert10_SQL-32          786 ± 0%       714 ± 0%   -9.16%  (p=0.000 n=17+17)
KVInsert100_SQL-32       5.51k ± 0%     4.73k ± 0%  -14.29%  (p=0.000 n=20+20)
KVInsert1000_SQL-32      52.8k ± 0%     44.8k ± 0%  -15.11%  (p=0.000 n=19+20)
KVInsert10000_SQL-32      563k ± 0%      483k ± 0%  -14.20%  (p=0.000 n=20+19)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6611)

<!-- Reviewable:end -->
