### PR TITLE
kv: Refactor mocking in DistSender

### DIFF
--- a/kv/send.go
+++ b/kv/send.go
@@ -168,7 +168,7 @@ func send(opts SendOptions, replicas ReplicaSlice,
 			}
 			if pending == 0 {
 				return nil, roachpb.NewSendError(
-					fmt.Sprintf("failed to send to any of %d replicas failed: %v",
+					fmt.Sprintf("sending to all %d replicas failed; last error: %v",
 						len(replicas), err), true)
 			}
 		}

--- a/kv/send.go
+++ b/kv/send.go
@@ -111,6 +111,7 @@ func send(opts SendOptions, replicas ReplicaSlice,
 	if err != nil {
 		return nil, err
 	}
+	defer transport.Close()
 
 	// Send the first request.
 	pending := 1

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -179,6 +179,9 @@ func (c *channelSaveTransport) SendNext(done chan BatchCall) {
 	c.ch <- done
 }
 
+func (*channelSaveTransport) Close() {
+}
+
 // setupSendNextTest sets up a situation in which SendNextTimeout has
 // caused RPCs to be sent to all three replicas simultaneously. The
 // caller may then cause those RPCs to finish by writing to one of the
@@ -518,6 +521,9 @@ func (f *firstNErrorTransport) SendNext(done chan BatchCall) {
 	}
 	f.numSent++
 	done <- call
+}
+
+func (*firstNErrorTransport) Close() {
 }
 
 // TestComplexScenarios verifies various complex success/failure scenarios by

--- a/kv/transport.go
+++ b/kv/transport.go
@@ -51,12 +51,16 @@ type TransportFactory func(
 ) (Transport, error)
 
 // Transport objects can send RPCs to one or more replicas of a range.
+// All calls to Transport methods are made from a single thread, so
+// Transports are not required to be thread-safe.
 type Transport interface {
 	// IsExhausted returns true if there are no more replicas to try.
 	IsExhausted() bool
 
 	// SendNext sends the rpc (captured at creation time) to the next
-	// replica. May panic if the transport is exhausted.
+	// replica. May panic if the transport is exhausted. Should not
+	// block; the transport is responsible for starting other goroutines
+	// as needed.
 	SendNext(chan BatchCall)
 
 	// Close is called when the transport is no longer needed. It may

--- a/kv/transport.go
+++ b/kv/transport.go
@@ -1,0 +1,115 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+package kv
+
+import (
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/rpc"
+)
+
+// TransportFactory encapsulates all interaction with the RPC
+// subsystem, allowing it to be mocked out for testing. The factory
+// function returns a Transport object which is used to send the given
+// arguments to one or more replicas in the slice.
+//
+// In addition to actually sending RPCs, the transport is responsible
+// for ordering replicas in accordance with SendOptions.Ordering and
+// transport-specific knowledge such as connection health or latency.
+//
+// TODO(bdarnell): clean up this crufty interface; it was extracted
+// verbatim from the non-abstracted code.
+type TransportFactory func(
+	SendOptions, *rpc.Context, ReplicaSlice, roachpb.BatchRequest,
+) (Transport, error)
+
+// Transport objects can send RPCs to one or more replicas of a range.
+type Transport interface {
+	// IsExhausted returns true if there are no more replicas to try.
+	IsExhausted() bool
+
+	// SendNext sends the rpc (captured at creation time) to the next
+	// replica. May panic if the transport is exhausted.
+	SendNext(chan batchCall)
+}
+
+// grpcTransportFactory is the default TransportFactory, using GRPC.
+func grpcTransportFactory(
+	opts SendOptions,
+	rpcContext *rpc.Context,
+	replicas ReplicaSlice,
+	args roachpb.BatchRequest,
+) (Transport, error) {
+	clients := make([]batchClient, 0, len(replicas))
+	for _, replica := range replicas {
+		conn, err := rpcContext.GRPCDial(replica.NodeDesc.Address.String())
+		if err != nil {
+			return nil, err
+		}
+		argsCopy := args
+		argsCopy.Replica = replica.ReplicaDescriptor
+		clients = append(clients, batchClient{
+			remoteAddr: replica.NodeDesc.Address.String(),
+			conn:       conn,
+			client:     roachpb.NewInternalClient(conn),
+			args:       argsCopy,
+		})
+	}
+
+	// Put known-unhealthy clients last.
+	nHealthy, err := splitHealthy(clients)
+	if err != nil {
+		return nil, err
+	}
+
+	var orderedClients []batchClient
+	switch opts.Ordering {
+	case orderStable:
+		orderedClients = clients
+	case orderRandom:
+		// Randomly permute order, but keep known-unhealthy clients last.
+		shuffleClients(clients[:nHealthy])
+		shuffleClients(clients[nHealthy:])
+
+		orderedClients = clients
+	}
+	// TODO(spencer): going to need to also sort by affinity; closest
+	// ping time should win. Makes sense to have the rpc client/server
+	// heartbeat measure ping times. With a bit of seasoning, each
+	// node will be able to order the healthy replicas based on latency.
+
+	return &grpcTransport{
+		opts:           opts,
+		rpcContext:     rpcContext,
+		orderedClients: orderedClients,
+	}, nil
+}
+
+type grpcTransport struct {
+	opts           SendOptions
+	rpcContext     *rpc.Context
+	orderedClients []batchClient
+}
+
+func (gt *grpcTransport) IsExhausted() bool {
+	return len(gt.orderedClients) == 0
+}
+
+func (gt *grpcTransport) SendNext(done chan batchCall) {
+	sendOneFn(gt.opts, gt.rpcContext, gt.orderedClients[0], done)
+	gt.orderedClients = gt.orderedClients[1:]
+}


### PR DESCRIPTION
DistSender has two hooks for mocking out the RPC mechanism: `sendOneFn` (which is used too late in the process and doesn't completely hide the use of GRPC) and `DistSenderContext.RPCSend` (which is used too early and requires the mock to reimplement retry logic found in `kv.send`).  This PR replaces both hooks with a new `Transport` abstraction that more precisely targets the RPC-specific parts of `DistSender`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6627)

<!-- Reviewable:end -->
