### PR TITLE
storage/engine: add Engine.{WriteBatch,BatchRepr} methods

### DIFF
--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"reflect"
 	"testing"
@@ -45,10 +46,7 @@ func mvccKey(k interface{}) MVCCKey {
 	}
 }
 
-// TestBatchBasics verifies that all commands work in a batch, aren't
-// visible until commit, and then are all visible after commit.
-func TestBatchBasics(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+func testBatchBasics(t *testing.T, commit func(e, b Engine) error) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
@@ -103,7 +101,7 @@ func TestBatchBasics(t *testing.T) {
 	}
 
 	// Commit batch and verify direct engine scan yields correct values.
-	if err := b.Commit(); err != nil {
+	if err := commit(e, b); err != nil {
 		t.Fatal(err)
 	}
 	kvs, err = Scan(e, mvccKey(roachpb.RKeyMin), mvccKey(roachpb.RKeyMax), 0)
@@ -113,6 +111,117 @@ func TestBatchBasics(t *testing.T) {
 	if !reflect.DeepEqual(expValues, kvs) {
 		t.Errorf("%v != %v", kvs, expValues)
 	}
+}
+
+// TestBatchBasics verifies that all commands work in a batch, aren't
+// visible until commit, and then are all visible after commit.
+func TestBatchBasics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testBatchBasics(t, func(e, b Engine) error {
+		return b.Commit()
+	})
+}
+
+func TestBatchRepr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testBatchBasics(t, func(e, b Engine) error {
+		repr := b.Repr()
+
+		// Simple sanity checks about the format of the batch representation. This
+		// is inefficient decoding code. Do not move outside of test code.
+		buf := bytes.NewReader(repr)
+		var seq uint64
+		var count uint32
+		if err := binary.Read(buf, binary.LittleEndian, &seq); err != nil {
+			t.Fatal(err)
+		}
+		if seq != 0 {
+			// The sequence number is set when the batch is written.
+			t.Fatalf("bad sequence: expected 0, but found %d", seq)
+		}
+		if err := binary.Read(buf, binary.LittleEndian, &count); err != nil {
+			t.Fatal(err)
+		}
+		if expected := uint32(3); expected != count {
+			t.Fatalf("bad count: expected %d, but found %d", expected, count)
+		}
+
+		const (
+			// These constants come from rocksdb/db/dbformat.h.
+			TypeDeletion = 0x0
+			TypeValue    = 0x1
+			TypeMerge    = 0x2
+			// TypeLogData                    = 0x3
+			// TypeColumnFamilyDeletion       = 0x4
+			// TypeColumnFamilyValue          = 0x5
+			// TypeColumnFamilyMerge          = 0x6
+			// TypeSingleDeletion             = 0x7
+			// TypeColumnFamilySingleDeletion = 0x8
+		)
+
+		varstring := func(buf *bytes.Reader) (string, error) {
+			n, err := binary.ReadUvarint(buf)
+			if err != nil {
+				return "", err
+			}
+			s := make([]byte, n)
+			c, err := buf.Read(s)
+			if err != nil {
+				return "", err
+			}
+			if c != int(n) {
+				return "", fmt.Errorf("expected %d, but found %d", n, c)
+			}
+			return string(s), nil
+		}
+
+		var ops []string
+		for i := uint32(0); i < count; i++ {
+			typ, err := buf.ReadByte()
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch typ {
+			case TypeDeletion:
+				k, err := varstring(buf)
+				if err != nil {
+					t.Fatal(err)
+				}
+				ops = append(ops, fmt.Sprintf("delete(%s)", k))
+			case TypeValue:
+				k, err := varstring(buf)
+				if err != nil {
+					t.Fatal(err)
+				}
+				v, err := varstring(buf)
+				if err != nil {
+					t.Fatal(err)
+				}
+				ops = append(ops, fmt.Sprintf("put(%s,%s)", k, v))
+			case TypeMerge:
+				k, err := varstring(buf)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// The merge value is a protobuf and not easily displayable.
+				if _, err = varstring(buf); err != nil {
+					t.Fatal(err)
+				}
+				ops = append(ops, fmt.Sprintf("merge(%s)", k))
+			default:
+				t.Fatalf("%d: unexpected type %d", i, typ)
+			}
+		}
+
+		// The keys in the batch have the internal MVCC encoding applied which for
+		// this test implies an appended 0 byte.
+		expOps := []string{"put(a\x00,value)", "delete(b\x00)", "merge(c\x00)"}
+		if !reflect.DeepEqual(expOps, ops) {
+			t.Fatalf("expected %v, but found %v", expOps, ops)
+		}
+
+		return e.ApplyBatchRepr(repr)
+	})
 }
 
 func TestBatchGet(t *testing.T) {

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -157,6 +157,15 @@ type Engine interface {
 	// Commit atomically applies any batched updates to the underlying
 	// engine. This is a noop unless the engine was created via NewBatch().
 	Commit() error
+	// ApplyBatchRepr atomically applies a set of batched updates. Created by
+	// calling Repr() on a batch. Using this method is equivalent to constructing
+	// and committing a batch whose Repr() equals repr.
+	ApplyBatchRepr(repr []byte) error
+	// Repr returns the underlying representation of the batch and can be used to
+	// reconstitute the batch on a remote node using
+	// Engine.NewBatchFromRepr(). This method is only valid on engines created
+	// via NewBatch().
+	Repr() []byte
 	// Defer adds a callback to be run after the batch commits
 	// successfully.  If Commit() fails (or if this engine was not
 	// created via NewBatch()), deferred callbacks are not called. As

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -220,6 +220,13 @@ func (r *RocksDB) Merge(key MVCCKey, value []byte) error {
 	return dbMerge(r.rdb, key, value)
 }
 
+// ApplyBatchRepr atomically applies a set of batched updates. Created by
+// calling Repr() on a batch. Using this method is equivalent to constructing
+// and committing a batch whose Repr() equals repr.
+func (r *RocksDB) ApplyBatchRepr(repr []byte) error {
+	return dbApplyBatchRepr(r.rdb, repr)
+}
+
 // Get returns the value for the given key.
 func (r *RocksDB) Get(key MVCCKey) ([]byte, error) {
 	return dbGet(r.rdb, key)
@@ -355,6 +362,11 @@ func (r *RocksDB) Commit() error {
 	return nil
 }
 
+// Repr is not implemented for RocksDB engine.
+func (r *RocksDB) Repr() []byte {
+	panic("only implemented for rocksDBBatch")
+}
+
 // Defer is not implemented for RocksDB engine.
 func (r *RocksDB) Defer(func()) {
 	panic("only implemented for rocksDBBatch")
@@ -442,6 +454,11 @@ func (r *rocksDBSnapshot) Merge(key MVCCKey, value []byte) error {
 	return util.Errorf("cannot Merge to a snapshot")
 }
 
+// ApplyBatchRepr is illegal for snapshot and returns an error.
+func (r *rocksDBSnapshot) ApplyBatchRepr(repr []byte) error {
+	return util.Errorf("cannot ApplyBatchRepr to a snapshot")
+}
+
 // Capacity returns capacity details for the engine's available storage.
 func (r *rocksDBSnapshot) Capacity() (roachpb.StoreCapacity, error) {
 	return r.parent.Capacity()
@@ -477,6 +494,11 @@ func (r *rocksDBSnapshot) NewBatch() Engine {
 // Commit is illegal for snapshot and returns an error.
 func (r *rocksDBSnapshot) Commit() error {
 	return util.Errorf("cannot Commit to a snapshot")
+}
+
+// Repr is not implemented for rocksDBSnapshot.
+func (r *rocksDBSnapshot) Repr() []byte {
+	panic("only implemented for rocksDBBatch")
 }
 
 // Defer is not implemented for rocksDBSnapshot.
@@ -530,6 +552,11 @@ func (r *rocksDBBatch) Merge(key MVCCKey, value []byte) error {
 	return dbMerge(r.batch, key, value)
 }
 
+// ApplyBatchRepr is illegal for a batch and returns an error.
+func (r *rocksDBBatch) ApplyBatchRepr(repr []byte) error {
+	return util.Errorf("cannot ApplyBatchRepr to a batch")
+}
+
 func (r *rocksDBBatch) Get(key MVCCKey) ([]byte, error) {
 	return dbGet(r.batch, key)
 }
@@ -575,7 +602,7 @@ func (r *rocksDBBatch) Commit() error {
 	if r.batch == nil {
 		panic("this batch was already committed")
 	}
-	if err := statusToError(C.DBWriteBatch(r.batch)); err != nil {
+	if err := statusToError(C.DBCommitBatch(r.batch)); err != nil {
 		return err
 	}
 	C.DBClose(r.batch)
@@ -588,6 +615,10 @@ func (r *rocksDBBatch) Commit() error {
 	r.defers = nil
 
 	return nil
+}
+
+func (r *rocksDBBatch) Repr() []byte {
+	return cSliceToGoBytes(C.DBBatchRepr(r.batch))
 }
 
 func (r *rocksDBBatch) Defer(fn func()) {
@@ -900,6 +931,10 @@ func dbMerge(rdb *C.DBEngine, key MVCCKey, value []byte) error {
 	// when called, so we do not need to worry about these byte slices being
 	// reclaimed by the GC.
 	return statusToError(C.DBMerge(rdb, goToCKey(key), goToCSlice(value)))
+}
+
+func dbApplyBatchRepr(rdb *C.DBEngine, repr []byte) error {
+	return statusToError(C.DBApplyBatchRepr(rdb, goToCSlice(repr)))
 }
 
 // dbGet returns the value for the given key.

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -52,7 +52,9 @@ struct DBEngine {
   virtual DBStatus Put(DBKey key, DBSlice value) = 0;
   virtual DBStatus Merge(DBKey key, DBSlice value) = 0;
   virtual DBStatus Delete(DBKey key) = 0;
-  virtual DBStatus WriteBatch() = 0;
+  virtual DBStatus CommitBatch() = 0;
+  virtual DBStatus ApplyBatchRepr(DBSlice repr) = 0;
+  virtual DBSlice BatchRepr() = 0;
   virtual DBStatus Get(DBKey key, DBString* value) = 0;
   virtual DBIterator* NewIter(bool prefix) = 0;
   virtual DBStatus GetStats(DBStatsResult* stats) = 0;
@@ -87,7 +89,9 @@ struct DBImpl : public DBEngine {
   virtual DBStatus Put(DBKey key, DBSlice value);
   virtual DBStatus Merge(DBKey key, DBSlice value);
   virtual DBStatus Delete(DBKey key);
-  virtual DBStatus WriteBatch();
+  virtual DBStatus CommitBatch();
+  virtual DBStatus ApplyBatchRepr(DBSlice repr);
+  virtual DBSlice BatchRepr();
   virtual DBStatus Get(DBKey key, DBString* value);
   virtual DBIterator* NewIter(bool prefix);
   virtual DBStatus GetStats(DBStatsResult* stats);
@@ -105,7 +109,9 @@ struct DBBatch : public DBEngine {
   virtual DBStatus Put(DBKey key, DBSlice value);
   virtual DBStatus Merge(DBKey key, DBSlice value);
   virtual DBStatus Delete(DBKey key);
-  virtual DBStatus WriteBatch();
+  virtual DBStatus CommitBatch();
+  virtual DBStatus ApplyBatchRepr(DBSlice repr);
+  virtual DBSlice BatchRepr();
   virtual DBStatus Get(DBKey key, DBString* value);
   virtual DBIterator* NewIter(bool prefix);
   virtual DBStatus GetStats(DBStatsResult* stats);
@@ -127,7 +133,9 @@ struct DBSnapshot : public DBEngine {
   virtual DBStatus Put(DBKey key, DBSlice value);
   virtual DBStatus Merge(DBKey key, DBSlice value);
   virtual DBStatus Delete(DBKey key);
-  virtual DBStatus WriteBatch();
+  virtual DBStatus CommitBatch();
+  virtual DBStatus ApplyBatchRepr(DBSlice repr);
+  virtual DBSlice BatchRepr();
   virtual DBStatus Get(DBKey key, DBString* value);
   virtual DBIterator* NewIter(bool prefix);
   virtual DBStatus GetStats(DBStatsResult* stats);
@@ -1451,11 +1459,11 @@ DBStatus DBDelete(DBEngine *db, DBKey key) {
   return db->Delete(key);
 }
 
-DBStatus DBImpl::WriteBatch() {
+DBStatus DBImpl::CommitBatch() {
   return FmtStatus("unsupported");
 }
 
-DBStatus DBBatch::WriteBatch() {
+DBStatus DBBatch::CommitBatch() {
   if (updates == 0) {
     return kSuccess;
   }
@@ -1463,12 +1471,49 @@ DBStatus DBBatch::WriteBatch() {
   return ToDBStatus(rep->Write(options, batch.GetWriteBatch()));
 }
 
-DBStatus DBSnapshot::WriteBatch() {
+DBStatus DBSnapshot::CommitBatch() {
   return FmtStatus("unsupported");
 }
 
-DBStatus DBWriteBatch(DBEngine* db) {
-  return db->WriteBatch();
+DBStatus DBCommitBatch(DBEngine* db) {
+  return db->CommitBatch();
+}
+
+DBStatus DBImpl::ApplyBatchRepr(DBSlice repr) {
+  rocksdb::WriteBatch batch(ToString(repr));
+  rocksdb::WriteOptions options;
+  return ToDBStatus(rep->Write(options, &batch));
+}
+
+DBStatus DBBatch::ApplyBatchRepr(DBSlice repr) {
+  // TODO(peter): If needed, we could support applying a batch to
+  // another batch. We would have to iterate over the batch contents
+  // and perform the associated Put/Delete/Merge operations.
+  return FmtStatus("unsupported");
+}
+
+DBStatus DBSnapshot::ApplyBatchRepr(DBSlice repr) {
+  return FmtStatus("unsupported");
+}
+
+DBStatus DBApplyBatchRepr(DBEngine* db, DBSlice repr) {
+  return db->ApplyBatchRepr(repr);
+}
+
+DBSlice DBImpl::BatchRepr() {
+  return ToDBSlice("unsupported");
+}
+
+DBSlice DBBatch::BatchRepr() {
+  return ToDBSlice(batch.GetWriteBatch()->Data());
+}
+
+DBSlice DBSnapshot::BatchRepr() {
+  return ToDBSlice("unsupported");
+}
+
+DBSlice DBBatchRepr(DBEngine *db) {
+  return db->BatchRepr();
 }
 
 DBEngine* DBNewSnapshot(DBEngine* db)  {

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -102,17 +102,29 @@ DBStatus DBDelete(DBEngine* db, DBKey key);
 // Applies a batch of operations (puts, merges and deletes) to the
 // database atomically. It is only valid to call this function on an
 // engine created by DBNewBatch.
-DBStatus DBWriteBatch(DBEngine* db);
+DBStatus DBCommitBatch(DBEngine* db);
+
+// ApplyBatchRepr applies a batch of mutations encoded using that
+// batch representation returned by DBBatchRepr(). It is only valid to
+// call this function on an engine created by DBOpen() (i.e. not a
+// batch or snapshot).
+DBStatus DBApplyBatchRepr(DBEngine* db, DBSlice repr);
+
+// Returns the internal batch representation. The returned value is
+// only valid until the next call to a method using the DBEngine and
+// should thus be copied immediately. It is only valid to call this
+// function on an engine created by DBNewBatch.
+DBSlice DBBatchRepr(DBEngine *db);
 
 // Creates a new snapshot of the database for use in DBGet() and
 // DBNewIter(). It is the caller's responsibility to call DBClose().
 DBEngine* DBNewSnapshot(DBEngine* db);
 
 // Creates a new batch for performing a series of operations
-// atomically. Use DBWriteBatch() on the returned engine to apply the
+// atomically. Use DBCommitBatch() on the returned engine to apply the
 // batch to the database. It is the caller's responsibility to call
 // DBClose().
-DBEngine* DBNewBatch(DBEngine *db);
+DBEngine* DBNewBatch(DBEngine* db);
 
 // Creates a new database iterator. When prefix is true, Seek will use
 // the user-key prefix of the key supplied to DBIterSeek() to restrict


### PR DESCRIPTION
`Engine.BatchRepr` can be used to retrieve the underlying representation
of a batch so that it can be transferred to a remote
node. `Engine.WriteBatch` can then be used to apply the batch. Doing so
is equivalent to calling `Engine.Commit` on the original batch.

Fixes #6288.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6629)

<!-- Reviewable:end -->
