### PR TITLE
Simple store-level snapshot rate-limited.

### DIFF
--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -381,6 +381,11 @@ func (r *Replica) Snapshot() (raftpb.Snapshot, error) {
 		}
 	}
 
+	// See if there is already a snapshot running for this store.
+	if !r.store.AcquireRaftSnapshot() {
+		return raftpb.Snapshot{}, raft.ErrSnapshotTemporarilyUnavailable
+	}
+
 	// Use an unbuffered channel so the worker stays alive until someone
 	// reads from the channel, and can abandon the snapshot if it gets
 	// stale.
@@ -389,6 +394,7 @@ func (r *Replica) Snapshot() (raftpb.Snapshot, error) {
 		defer close(ch)
 		snap := r.store.NewSnapshot()
 		defer snap.Close()
+		defer r.store.ReleaseRaftSnapshot()
 		// Delegate to a static function to make sure that we do not depend
 		// on any indirect calls to r.store.Engine() (or other in-memory
 		// state of the Replica). Everything must come from the snapshot.
@@ -405,6 +411,8 @@ func (r *Replica) Snapshot() (raftpb.Snapshot, error) {
 		}
 	}) {
 		r.mu.snapshotChan = ch
+	} else {
+		r.store.ReleaseRaftSnapshot()
 	}
 
 	if r.store.ctx.BlockingSnapshotDuration > 0 {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1962,3 +1962,24 @@ func TestStoreChangeFrozen(t *testing.T) {
 		}
 	}
 }
+
+func TestStoreNoConcurrentRaftSnapshots(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	store, _, stopper := createTestStore(t)
+	defer stopper.Stop()
+
+	if !store.AcquireRaftSnapshot() {
+		t.Fatal("expected true")
+	}
+
+	if store.AcquireRaftSnapshot() {
+		t.Fatalf("expected false")
+	}
+
+	store.ReleaseRaftSnapshot()
+
+	if !store.AcquireRaftSnapshot() {
+		t.Fatal("expected true")
+	}
+	store.ReleaseRaftSnapshot()
+}


### PR DESCRIPTION
Limits per-store snapshots to 1 at a time.
This should help with #6589 in the short term.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6632)

<!-- Reviewable:end -->
