### PR TITLE
storage: Guard against replica removal in splitTrigger's async campaign

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -970,6 +970,64 @@ func TestReplicateAfterSplit(t *testing.T) {
 	})
 }
 
+// TestReplicaRemovalCampaign verifies that a new replica after a split can be
+// transferred away/replaced without campaigning the old one.
+func TestReplicaRemovalCampaign(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testData := []struct {
+		remove        bool
+		expectAdvance bool
+	}{
+		{ // Replica removed
+			remove:        true,
+			expectAdvance: false,
+		},
+		{ // Default behavior
+			remove:        false,
+			expectAdvance: true,
+		},
+	}
+
+	rangeID := roachpb.RangeID(1)
+	splitKey := roachpb.Key("m")
+	key2 := roachpb.Key("z")
+
+	for i, td := range testData {
+		func() {
+			mtc := startMultiTestContext(t, 2)
+			defer mtc.Stop()
+
+			// Replicate range to enable raft campaigning.
+			mtc.replicateRange(rangeID, 1)
+			store0 := mtc.stores[0]
+
+			// Make the split
+			splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+			if _, err := client.SendWrapped(rg1(store0), nil, &splitArgs); err != nil {
+				t.Fatal(err)
+			}
+
+			replica2 := store0.LookupReplica(roachpb.RKey(key2), nil)
+			if td.remove {
+				// Simulate second replica being transferred by removing it.
+				if err := store0.RemoveReplica(replica2, *replica2.Desc(), true); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			originalTerm := replica2.RaftStatus().Term
+			time.Sleep(100 * time.Millisecond)
+			term := replica2.RaftStatus().Term
+			if td.expectAdvance && term <= originalTerm {
+				t.Errorf("%d. raft term should have advanced", i)
+			} else if !td.expectAdvance && term > originalTerm {
+				t.Errorf("%d. raft term should not have advanced", i)
+			}
+		}()
+	}
+}
+
 // TestRangeDescriptorSnapshotRace calls Snapshot() repeatedly while
 // transactions are performed on the range descriptor.
 func TestRangeDescriptorSnapshotRace(t *testing.T) {

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2194,10 +2194,15 @@ func (r *Replica) splitTrigger(
 			// flaky without a bit of a delay.
 			r.store.stopper.RunAsyncTask(func() {
 				time.Sleep(10 * time.Millisecond)
-				// TODO(bdarnell): make sure newRng hasn't been removed
-				newRng.mu.Lock()
-				_ = newRng.mu.raftGroup.Campaign()
-				newRng.mu.Unlock()
+				// Make sure that newRng hasn't been removed.
+				replica, err := r.store.GetReplica(newRng.RangeID)
+				if err != nil {
+					log.Infof("new replica %d removed before campaigning", r.mu.replicaID)
+					return
+				}
+				replica.mu.Lock()
+				defer replica.mu.Unlock()
+				_ = replica.mu.raftGroup.Campaign()
 			})
 		}
 	})


### PR DESCRIPTION
This adds a check after splitting a range that the replica wasn't transferred/replaced in the short time between it being added and the async campaigning.

See #4475

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6634)

<!-- Reviewable:end -->
