### PR TITLE
sql: Add PG compatibility for undefined_table error

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -55,7 +55,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, error) {
 		if n.IfExists {
 			return &emptyNode{}, nil
 		}
-		return nil, tableDoesNotExistError(n.Table.String())
+		return nil, newUndefinedTableError(n.Table.String())
 	}
 
 	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {

--- a/sql/create.go
+++ b/sql/create.go
@@ -120,7 +120,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
 		return nil, err
 	}
 	if tableDesc == nil {
-		return nil, tableDoesNotExistError(n.Table.String())
+		return nil, newUndefinedTableError(n.Table.String())
 	}
 
 	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -195,7 +195,7 @@ func (p *planner) getDescriptorsFromTargetList(targets parser.TargetList) (
 				return nil, err
 			}
 			if descriptor == nil {
-				return nil, tableDoesNotExistError(table.String())
+				return nil, newUndefinedTableError(table.String())
 			}
 			descs = append(descs, descriptor)
 		}

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -171,7 +171,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 			return nil, err
 		}
 		if tableDesc == nil {
-			return nil, tableDoesNotExistError(index.Table.String())
+			return nil, newUndefinedTableError(index.Table.String())
 		}
 
 		if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
@@ -273,7 +273,7 @@ func (p *planner) DropTable(n *parser.DropTable) (planNode, error) {
 				continue
 			}
 			// Table does not exist, but we want it to: error out.
-			return nil, tableDoesNotExistError(name.String())
+			return nil, newUndefinedTableError(name.String())
 		}
 		td = append(td, droppedDesc)
 	}

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -163,7 +163,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		return nil, err
 	}
 	if tableDesc == nil {
-		return nil, tableDoesNotExistError(n.Name.String())
+		return nil, newUndefinedTableError(n.Name.String())
 	}
 
 	if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
@@ -227,7 +227,7 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, error) {
 		return nil, err
 	}
 	if tableDesc == nil {
-		return nil, tableDoesNotExistError(n.Index.Table.String())
+		return nil, newUndefinedTableError(n.Index.Table.String())
 	}
 
 	idxName := string(n.Index.Index)
@@ -316,7 +316,7 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 		return nil, err
 	}
 	if tableDesc == nil {
-		return nil, tableDoesNotExistError(n.Table.String())
+		return nil, newUndefinedTableError(n.Table.String())
 	}
 
 	colName := string(n.Name)

--- a/sql/show.go
+++ b/sql/show.go
@@ -65,7 +65,7 @@ func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, error) {
 		return nil, err
 	}
 	if desc == nil {
-		return nil, tableDoesNotExistError(n.Table.String())
+		return nil, newUndefinedTableError(n.Table.String())
 	}
 	v := &valuesNode{
 		columns: []ResultColumn{
@@ -99,7 +99,7 @@ func (p *planner) ShowCreateTable(n *parser.ShowCreateTable) (planNode, error) {
 		return nil, err
 	}
 	if desc == nil {
-		return nil, tableDoesNotExistError(n.Table.String())
+		return nil, newUndefinedTableError(n.Table.String())
 	}
 	v := &valuesNode{
 		columns: []ResultColumn{
@@ -258,7 +258,7 @@ func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, error) {
 		return nil, err
 	}
 	if desc == nil {
-		return nil, tableDoesNotExistError(n.Table.String())
+		return nil, newUndefinedTableError(n.Table.String())
 	}
 
 	v := &valuesNode{

--- a/sql/testdata/errors
+++ b/sql/testdata/errors
@@ -1,0 +1,20 @@
+statement error pgcode 42P01 table "fake1" does not exist
+ALTER TABLE fake1 DROP COLUMN a
+
+statement error pgcode 42P01 table "fake2" does not exist
+CREATE INDEX i ON fake2 (a)
+
+statement error pgcode 42P01 table "fake3" does not exist
+DROP INDEX fake3@i
+
+statement error pgcode 42P01 table "fake4" does not exist
+DROP TABLE fake4
+
+statement error pgcode 42P01 table "fake5" does not exist
+SHOW COLUMNS FROM fake5
+
+statement error pgcode 42P01 table "fake6" does not exist
+INSERT INTO fake6 VALUES (1, 2)
+
+statement error pgcode 42P01 table "fake7" does not exist
+SELECT * FROM fake7


### PR DESCRIPTION
This change converts `tableDoesNotExistError` to a construct its
corresponding `ErrorWithPGCode`.

Necessary for https://github.com/sfackler/rust-postgres/issues/171.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6652)

<!-- Reviewable:end -->
