### PR TITLE
sql: Add source context to PG errors

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -281,7 +281,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 				// Still processing table.
 				done = false
 				if nonNullableColumn != "" {
-					return &errNonNullViolation{columnName: nonNullableColumn}
+					return newNonNullViolationError(nonNullableColumn)
 				}
 				if sentinelKey == nil || !bytes.HasPrefix(kv.Key, sentinelKey) {
 					// Sentinel keys have a 0 suffix indicating 0 bytes of

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -664,13 +664,12 @@ func (e *Executor) execStmtInAbortedTxn(
 			// TODO(andrei/cdo): add a counter for user-directed retries.
 			return Result{}, nil
 		}
-		err := &errTransactionAborted{
-			CustomMsg: fmt.Sprintf(
-				"SAVEPOINT %s has not been used or a non-retriable error was encountered.",
-				parser.RestartSavepointName)}
+		err := newTransactionAbortedError(fmt.Sprintf(
+			"SAVEPOINT %s has not been used or a non-retriable error was encountered.",
+			parser.RestartSavepointName))
 		return Result{Err: err}, err
 	default:
-		err := &errTransactionAborted{}
+		err := newTransactionAbortedError("")
 		return Result{Err: err}, err
 	}
 }
@@ -692,7 +691,7 @@ func (e *Executor) execStmtInCommitWaitTxn(
 		txnState.resetStateAndTxn(NoTxn)
 		return result, nil
 	default:
-		err := &errTransactionCommitted{}
+		err := newTransactionCommittedError()
 		return Result{Err: err}, err
 	}
 }

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -328,7 +328,7 @@ func (n *insertNode) Next() bool {
 	for _, col := range n.tableDesc.Columns {
 		if !col.Nullable {
 			if i, ok := n.insertColIDtoRowIndex[col.ID]; !ok || rowVals[i] == parser.DNull {
-				n.run.err = fmt.Errorf("null value in column %q violates not-null constraint", col.Name)
+				n.run.err = newNonNullViolationError(col.Name)
 				return false
 			}
 		}

--- a/sql/pgwire/servererrfieldtype_string.go
+++ b/sql/pgwire/servererrfieldtype_string.go
@@ -6,24 +6,30 @@ import "fmt"
 
 const (
 	_serverErrFieldType_name_0 = "serverErrFieldSQLState"
-	_serverErrFieldType_name_1 = "serverErrFieldMsgPrimary"
-	_serverErrFieldType_name_2 = "serverErrFieldSeverity"
+	_serverErrFieldType_name_1 = "serverErrFieldSrcFile"
+	_serverErrFieldType_name_2 = "serverErrFieldSrcLineserverErrFieldMsgPrimary"
+	_serverErrFieldType_name_3 = "serverErrFieldSrcFunctionserverErrFieldSeverity"
 )
 
 var (
 	_serverErrFieldType_index_0 = [...]uint8{0, 22}
-	_serverErrFieldType_index_1 = [...]uint8{0, 24}
-	_serverErrFieldType_index_2 = [...]uint8{0, 22}
+	_serverErrFieldType_index_1 = [...]uint8{0, 21}
+	_serverErrFieldType_index_2 = [...]uint8{0, 21, 45}
+	_serverErrFieldType_index_3 = [...]uint8{0, 25, 47}
 )
 
 func (i serverErrFieldType) String() string {
 	switch {
 	case i == 67:
 		return _serverErrFieldType_name_0
-	case i == 77:
+	case i == 70:
 		return _serverErrFieldType_name_1
-	case i == 83:
-		return _serverErrFieldType_name_2
+	case 76 <= i && i <= 77:
+		i -= 76
+		return _serverErrFieldType_name_2[_serverErrFieldType_index_2[i]:_serverErrFieldType_index_2[i+1]]
+	case 82 <= i && i <= 83:
+		i -= 82
+		return _serverErrFieldType_name_3[_serverErrFieldType_index_3[i]:_serverErrFieldType_index_3[i+1]]
 	default:
 		return fmt.Sprintf("serverErrFieldType(%d)", i)
 	}

--- a/sql/update.go
+++ b/sql/update.go
@@ -322,7 +322,7 @@ func (u *updateNode) Next() bool {
 	for i, col := range u.updateCols {
 		val := updateValues[i]
 		if !col.Nullable && val == parser.DNull {
-			u.run.err = fmt.Errorf("null value in column %q violates not-null constraint", col.Name)
+			u.run.err = newNonNullViolationError(col.Name)
 			return false
 		}
 	}


### PR DESCRIPTION
This will add the file, line, and function fields to PGErrors.

Necessary for https://github.com/sfackler/rust-postgres/issues/171.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6654)

<!-- Reviewable:end -->
