### PR TITLE
sql: encoded datum type

### DIFF
--- a/sql/sqlbase/encoded_datum.go
+++ b/sql/sqlbase/encoded_datum.go
@@ -1,0 +1,139 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sqlbase
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/encoding"
+)
+
+// DatumEncoding identifies the encoding used for an EncDatum.
+type DatumEncoding int32
+
+// Possible encodings.
+const (
+	NoEncoding DatumEncoding = iota
+	AscendingKeyEncoding
+	DescendingKeyEncoding
+	// ValueEncoding to be supported later.
+)
+
+// EncDatum represents a datum that is "backed" by an encoding and/or by a
+// parser.Datum. It allows "passing through" a Datum without decoding and
+// reencoding. TODO(radu): It will also allow comparing encoded datums directly
+// (for certain encodings).
+type EncDatum struct {
+	typ ColumnType_Kind
+
+	// Encoding type. NoEncoding iff encoded is nil.
+	encoding DatumEncoding
+
+	// Encoded datum (according to the encoding field).
+	encoded []byte
+
+	// Decoded datum.
+	Datum parser.Datum
+}
+
+// SetEncoded initializes the EncDatum with the given encoded value. The encoded
+// value is stored as a shallow copy, so the caller must make sure the slice is
+// not modified for the lifetime of the EncDatum.
+func (ed *EncDatum) SetEncoded(typ ColumnType_Kind, enc DatumEncoding, val []byte) {
+	if val == nil {
+		panic("nil encoded value given")
+	}
+	ed.typ = typ
+	ed.encoding = enc
+	ed.encoded = val
+	ed.Datum = nil
+}
+
+// SetDatum initializes the EncDatum with the given Datum.
+func (ed *EncDatum) SetDatum(typ ColumnType_Kind, d parser.Datum) {
+	if d == nil {
+		panic("nil datum given")
+	}
+	if d != parser.DNull && !typ.ToDatumType().TypeEqual(d) {
+		panic(fmt.Sprintf("invalid datum type given: %s, expected %s",
+			d.Type(), typ.ToDatumType().Type()))
+	}
+	ed.typ = typ
+	ed.encoding = NoEncoding
+	ed.encoded = nil
+	ed.Datum = d
+}
+
+// IsUnset returns true if SetEncoded or SetDatum were not called.
+func (ed *EncDatum) IsUnset() bool {
+	return ed.encoded == nil && ed.Datum == nil
+}
+
+// Decode ensures that Datum is set (decoding if necessary).
+func (ed *EncDatum) Decode(a *DatumAlloc) error {
+	if ed.Datum != nil {
+		return nil
+	}
+	datTyp := ed.typ.ToDatumType()
+	var err error
+	var rem []byte
+	switch ed.encoding {
+	case AscendingKeyEncoding:
+		ed.Datum, rem, err = DecodeTableKey(a, datTyp, ed.encoded, encoding.Ascending)
+	case DescendingKeyEncoding:
+		ed.Datum, rem, err = DecodeTableKey(a, datTyp, ed.encoded, encoding.Descending)
+	case NoEncoding:
+		panic("EncDatum without datum or encoding")
+	default:
+		panic(fmt.Sprintf("invalid encoding %d", ed.encoding))
+	}
+	if len(rem) != 0 {
+		return util.Errorf("%d trailing bytes in encoded value", len(rem))
+	}
+	return err
+}
+
+// Encoding returns the encoding that is already available
+// (NoEncoding if none).
+func (ed *EncDatum) Encoding() DatumEncoding {
+	return ed.encoding
+}
+
+// Encode appends the encoded datum to the given slice using the requested
+// encoding.
+func (ed *EncDatum) Encode(a *DatumAlloc, enc DatumEncoding, appendTo []byte) ([]byte, error) {
+	if enc == NoEncoding {
+		panic("NoEncoding requested")
+	}
+	if enc == ed.encoding {
+		// We already have an encoding that matches
+		return append(appendTo, ed.encoded...), nil
+	}
+	if err := ed.Decode(a); err != nil {
+		return nil, err
+	}
+	switch enc {
+	case AscendingKeyEncoding:
+		return EncodeTableKey(appendTo, ed.Datum, encoding.Ascending)
+	case DescendingKeyEncoding:
+		return EncodeTableKey(appendTo, ed.Datum, encoding.Descending)
+	default:
+		panic(fmt.Sprintf("invalid encoding requested %d", enc))
+	}
+}

--- a/sql/sqlbase/encoded_datum_test.go
+++ b/sql/sqlbase/encoded_datum_test.go
@@ -1,0 +1,83 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+//
+
+package sqlbase
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+)
+
+func TestEncDatum(t *testing.T) {
+	a := &DatumAlloc{}
+	x := &EncDatum{}
+	if !x.IsUnset() {
+		t.Errorf("empty EncDatum should be unset")
+	}
+	if x.Encoding() != NoEncoding {
+		t.Errorf("invalid encoding %d", x.Encoding())
+	}
+
+	x.SetDatum(ColumnType_INT, parser.NewDInt(5))
+	if x.IsUnset() {
+		t.Errorf("unset after SetDatum()")
+	}
+
+	encoded, err := x.Encode(a, AscendingKeyEncoding, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	y := &EncDatum{}
+	y.SetEncoded(ColumnType_INT, AscendingKeyEncoding, encoded)
+
+	if y.IsUnset() {
+		t.Errorf("unset after SetEncoded()")
+	}
+	if y.Encoding() != AscendingKeyEncoding {
+		t.Errorf("invalid encoding %d", x.Encoding())
+	}
+
+	err = y.Decode(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmp := y.Datum.Compare(x.Datum); cmp != 0 {
+		t.Errorf("Datums should be equal, cmp = %d", cmp)
+	}
+
+	enc2, err := y.Encode(a, DescendingKeyEncoding, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// y's encoding should not change.
+	if y.Encoding() != AscendingKeyEncoding {
+		t.Errorf("invalid encoding %d", x.Encoding())
+	}
+	x.SetEncoded(ColumnType_INT, DescendingKeyEncoding, enc2)
+	if x.Encoding() != DescendingKeyEncoding {
+		t.Errorf("invalid encoding %d", x.Encoding())
+	}
+	err = x.Decode(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmp := y.Datum.Compare(x.Datum); cmp != 0 {
+		t.Errorf("Datums should be equal, cmp = %d", cmp)
+	}
+}

--- a/sql/sqlbase/structured.go
+++ b/sql/sqlbase/structured.go
@@ -729,10 +729,10 @@ func (c *ColumnType) SQLString() string {
 	return c.Kind.String()
 }
 
-// ToDatumType converts the ColumnType to a dummy Datum of the correct type, or
+// ToDatumType converts the ColumnType_Kind to the correct type Datum, or
 // nil if there is no correspondence.
-func (c *ColumnType) ToDatumType() parser.Datum {
-	switch c.Kind {
+func (k ColumnType_Kind) ToDatumType() parser.Datum {
+	switch k {
 	case ColumnType_BOOL:
 		return parser.TypeBool
 	case ColumnType_INT:
@@ -755,6 +755,12 @@ func (c *ColumnType) ToDatumType() parser.Datum {
 		return parser.TypeInterval
 	}
 	return nil
+}
+
+// ToDatumType converts the ColumnType to the correct type Datum, or
+// nil if there is no correspondence.
+func (c *ColumnType) ToDatumType() parser.Datum {
+	return c.Kind.ToDatumType()
 }
 
 // SetID implements the DescriptorProto interface.


### PR DESCRIPTION
EncDatum will allow the distsql layer to avoid decoding and reencoding of datums
in many cases (e.g. reading a datum from a key and then putting it on the wire).

@nvanbenschoten @paperstreet @andreimatei

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6659)

<!-- Reviewable:end -->
