### PR TITLE
encoding: implement PeekLength

### DIFF
--- a/util/encoding/decimal.go
+++ b/util/encoding/decimal.go
@@ -291,6 +291,32 @@ func decodeDecimal(buf []byte, tmp []byte, invert bool) ([]byte, *inf.Dec, error
 	}
 }
 
+// getDecimalLen returns the length of an encoded decimal.
+func getDecimalLen(buf []byte) (int, error) {
+	m := buf[0]
+	p := 1
+	if m < decimalNaN || m > decimalNaNDesc {
+		panic(fmt.Errorf("invalid tag %d", m))
+	}
+	switch m {
+	case decimalNaN, decimalNegativeInfinity, decimalNaNDesc, decimalInfinity, decimalZero:
+		return 1, nil
+	case decimalNegLarge, decimalNegSmall, decimalPosLarge, decimalPosSmall:
+		// Skip the varint exponent.
+		l, err := getVarintLen(buf[p:])
+		if err != nil {
+			return 0, err
+		}
+		p += l
+	}
+
+	idx, err := findDecimalTerminator(buf[p:])
+	if err != nil {
+		return 0, err
+	}
+	return p + idx + 1, nil
+}
+
 // makeDecimalFromMandE reconstructs the decimal from the mantissa M and
 // exponent E.
 func makeDecimalFromMandE(negative bool, e int, m []byte, tmp []byte) *inf.Dec {
@@ -331,6 +357,19 @@ func makeDecimalFromMandE(negative bool, e int, m []byte, tmp []byte) *inf.Dec {
 	return dec
 }
 
+// findDecimalTerminator finds the decimalTerminator in the given slice.
+func findDecimalTerminator(buf []byte) (int, error) {
+	// TODO(nvanbenschoten): bytes.IndexByte is inefficient for small slices. This is
+	// apparently fixed in go1.7. For now, we manually search for the terminator.
+	// idx := bytes.IndexByte(r, decimalTerminator)
+	for i, b := range buf {
+		if b == decimalTerminator {
+			return i, nil
+		}
+	}
+	return -1, util.Errorf("did not find terminator %#x in buffer %#x", decimalTerminator, buf)
+}
+
 func decodeSmallNumber(negative bool, buf []byte, tmp []byte) (e int, m []byte, rest []byte, newTmp []byte, err error) {
 	var ex uint64
 	var r []byte
@@ -343,18 +382,9 @@ func decodeSmallNumber(negative bool, buf []byte, tmp []byte) (e int, m []byte, 
 		return 0, nil, nil, nil, err
 	}
 
-	// TODO(nvanbenschoten): bytes.IndexByte is inefficient for small slices. This is
-	// apparently fixed in go1.7. For now, we manually search for the terminator.
-	// idx := bytes.IndexByte(r, decimalTerminator)
-	idx := -1
-	for i, b := range r {
-		if b == decimalTerminator {
-			idx = i
-			break
-		}
-	}
-	if idx == -1 {
-		return 0, nil, nil, nil, util.Errorf("did not find terminator %#x in buffer %#x", decimalTerminator, r)
+	idx, err := findDecimalTerminator(r)
+	if err != nil {
+		return 0, nil, nil, nil, err
 	}
 
 	m = r[:idx]
@@ -374,18 +404,9 @@ func decodeSmallNumber(negative bool, buf []byte, tmp []byte) (e int, m []byte, 
 }
 
 func decodeMediumNumber(negative bool, buf []byte, tmp []byte) (e int, m []byte, rest []byte, newTmp []byte, err error) {
-	// TODO(nvanbenschoten): bytes.IndexByte is inefficient for small slices. This is
-	// apparently fixed in go1.7. For now, we manually search for the terminator.
-	// idx := bytes.IndexByte(buf[1:], decimalTerminator)
-	idx := -1
-	for i, b := range buf[1:] {
-		if b == decimalTerminator {
-			idx = i
-			break
-		}
-	}
-	if idx == -1 {
-		return 0, nil, nil, nil, util.Errorf("did not find terminator %#x in buffer %#x", decimalTerminator, buf[1:])
+	idx, err := findDecimalTerminator(buf[1:])
+	if err != nil {
+		return 0, nil, nil, nil, err
 	}
 
 	m = buf[1 : idx+1]
@@ -419,18 +440,9 @@ func decodeLargeNumber(negative bool, buf []byte, tmp []byte) (e int, m []byte, 
 		return 0, nil, nil, nil, err
 	}
 
-	// TODO(nvanbenschoten): bytes.IndexByte is inefficient for small slices. This is
-	// apparently fixed in go1.7. For now, we manually search for the terminator.
-	// idx := bytes.IndexByte(r, decimalTerminator)
-	idx := -1
-	for i, b := range r {
-		if b == decimalTerminator {
-			idx = i
-			break
-		}
-	}
-	if idx == -1 {
-		return 0, nil, nil, nil, util.Errorf("did not find terminator %#x in buffer %#x", decimalTerminator, r)
+	idx, err := findDecimalTerminator(r)
+	if err != nil {
+		return 0, nil, nil, nil, err
 	}
 
 	m = r[:idx]

--- a/util/encoding/decimal_test.go
+++ b/util/encoding/decimal_test.go
@@ -184,6 +184,7 @@ func TestEncodeDecimal(t *testing.T) {
 					t.Error(err)
 					continue
 				}
+				testPeekLength(t, enc)
 				if dec.Cmp(c.Value) != 0 {
 					t.Errorf("%d unexpected mismatch for %v. got %v", i, c.Value, dec)
 				}
@@ -236,6 +237,8 @@ func TestEncodeDecimalRand(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
+
+					testPeekLength(t, enc)
 
 					// Make sure we decode the same value we encoded.
 					if cur.Cmp(res) != 0 {
@@ -442,6 +445,21 @@ func BenchmarkDecodeDecimal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _, _ = DecodeDecimalAscending(vals[i%len(vals)], buf)
+	}
+}
+
+func BenchmarkPeekLengthDecimal(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+
+	vals := make([][]byte, 10000)
+	for i := range vals {
+		d := decimal.NewDecFromFloat(rng.Float64())
+		vals[i] = EncodeDecimalAscending(nil, d)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = PeekLength(vals[i%len(vals)])
 	}
 }
 

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -221,6 +221,28 @@ func EncodeVarintDescending(b []byte, v int64) []byte {
 	return EncodeVarintAscending(b, ^v)
 }
 
+// getVarintLen returns the encoded length of an encoded varint. Assumes the
+// slice has at least one byte.
+func getVarintLen(b []byte) (int, error) {
+	length := int(b[0]) - intZero
+	if length >= 0 {
+		if length <= intSmall {
+			// just the tag
+			return 1, nil
+		}
+		// tag and length-intSmall bytes
+		length = 1 + length - intSmall
+	} else {
+		// tag and -length bytes
+		length = 1 - length
+	}
+
+	if length > len(b) {
+		return 0, util.Errorf("varint length %d exceeds slice length %d", length, len(b))
+	}
+	return length, nil
+}
+
 // DecodeVarintAscending decodes a value encode by EncodeVaringAscending.
 func DecodeVarintAscending(b []byte) ([]byte, int64, error) {
 	if len(b) == 0 {
@@ -471,7 +493,6 @@ func decodeBytesInternal(b []byte, r []byte, e escapes, expectMarker bool) ([]by
 		if i+1 >= len(b) {
 			return nil, nil, util.Errorf("malformed escape in buffer %#x", b)
 		}
-
 		v := b[i+1]
 		if v == e.escapedTerm {
 			if r == nil {
@@ -482,14 +503,32 @@ func decodeBytesInternal(b []byte, r []byte, e escapes, expectMarker bool) ([]by
 			return b[i+2:], r, nil
 		}
 
-		if v == e.escaped00 {
-			r = append(r, b[:i]...)
-			r = append(r, e.escapedFF)
-		} else {
+		if v != e.escaped00 {
 			return nil, nil, util.Errorf("unknown escape sequence: %#x %#x", e.escape, v)
 		}
 
+		r = append(r, b[:i]...)
+		r = append(r, e.escapedFF)
 		b = b[i+2:]
+	}
+}
+
+// getBytesLength finds the length of a bytes encoding.
+func getBytesLength(b []byte, e escapes) (int, error) {
+	// Skip the tag.
+	skipped := 1
+	for {
+		i := bytes.IndexByte(b[skipped:], e.escape)
+		if i == -1 {
+			return 0, util.Errorf("did not find terminator %#x in buffer %#x", e.escape, b)
+		}
+		if i+1 >= len(b) {
+			return 0, util.Errorf("malformed escape in buffer %#x", b)
+		}
+		skipped += i + 2
+		if b[skipped-1] == e.escapedTerm {
+			return skipped, nil
+		}
 	}
 }
 
@@ -801,6 +840,56 @@ func PeekType(b []byte) Type {
 		}
 	}
 	return Unknown
+}
+
+// getMultiVarintLen find the length of <num> encoded varints that follow a
+// 1-byte tag.
+func getMultiVarintLen(b []byte, num int) (int, error) {
+	p := 1
+	for i := 0; i < num && p < len(b); i++ {
+		len, err := getVarintLen(b[p:])
+		if err != nil {
+			return 0, err
+		}
+		p += len
+	}
+	return p, nil
+}
+
+// PeekLength returns the length of the encoded value at the start of b.  Note:
+// if this function succeeds, it's not a guarantee that decoding the value will
+// succeed.
+func PeekLength(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, util.Errorf("empty slice")
+	}
+	m := b[0]
+	switch m {
+	case encodedNull, encodedNullDesc, encodedNotNull, encodedNotNullDesc,
+		floatNaN, floatNaNDesc, floatZero, decimalZero:
+		return 1, nil
+	case bytesMarker:
+		return getBytesLength(b, ascendingEscapes)
+	case bytesDescMarker:
+		return getBytesLength(b, descendingEscapes)
+	case timeMarker:
+		return getMultiVarintLen(b, 2)
+	case durationBigNegMarker, durationMarker, durationBigPosMarker:
+		return getMultiVarintLen(b, 3)
+	case floatNeg, floatPos:
+		// the marker is followed by 8 bytes
+		if len(b) < 9 {
+			return 0, util.Errorf("slice too short for float (%d)", len(b))
+		}
+		return 9, nil
+	}
+	if m >= IntMin && m <= IntMax {
+		return getVarintLen(b)
+	}
+	if m >= decimalNaN && m <= decimalNaNDesc {
+		return getDecimalLen(b)
+	}
+	return 0, util.Errorf("unknown tag %d", m)
 }
 
 // PrettyPrintValue returns the string representation of all contiguous decodable

--- a/util/encoding/float_test.go
+++ b/util/encoding/float_test.go
@@ -113,6 +113,7 @@ func TestEncodeFloat(t *testing.T) {
 			} else if dec != c.Value {
 				t.Errorf("unexpected mismatch for %v. got %v", c.Value, dec)
 			}
+			testPeekLength(t, enc)
 			lastEncoded = enc
 		}
 


### PR DESCRIPTION
Implementing a function that figures out the length of a key-type encoding
without actually decoding the value. This will be used to parse keys and distsql
serialized values into EncDatums (see #6659).

@nvanbenschoten @paperstreet @andreimatei

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6660)

<!-- Reviewable:end -->
