### PR TITLE
kv: Use the end key of a stale descriptor for a lookup key

### DIFF
--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -157,9 +157,16 @@ type lookupRequestKey struct {
 //           requests to it will evict the descriptor. We set the key to hash to
 //           the start of the stale descriptor for lookup requests to the rebalanced
 //           descriptor so that all requests will be coalesced to the same lookupRequest.
+//
+// Note that the above description assumes that useReverseScan is false for simplicity.
+// If useReverseScan is true, we need to use the end key of the stale descriptor instead.
 func makeLookupRequestKey(key roachpb.RKey, evictToken *evictionToken, considerIntents, useReverseScan bool) lookupRequestKey {
 	if evictToken != nil {
-		key = evictToken.prevDesc.StartKey
+		if useReverseScan {
+			key = evictToken.prevDesc.EndKey
+		} else {
+			key = evictToken.prevDesc.StartKey
+		}
 	}
 	return lookupRequestKey{
 		key:             string(key),


### PR DESCRIPTION
This is another minor bug fix. Suppose that range `["a", b")` is split into `["a", "an")` and `["an", "b")`. When a reverse-scan lookup request for `"az"` is incorrectly sent to `"a"`, we will evict `["a", b")` from the cache and insert `["a", "an")`. Then, the retried lookup request will miss the cache and a new lookup request will be created.

Previously, we used to use `"a"` as the request key since `"a"` is the start key of the stale descriptor `["a", "b")`. However, this can cause a lookup failure if the retried lookup request is coalesced into another lookup request, which will be sent to `[KeyMin, "a")`.

With this change, we will use the end key of the stale descriptor so that the request key is set to `"b"` instead of `"a"`. This probably doesn't matter much in practice, but I think it's still nice to fix.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6662)

<!-- Reviewable:end -->
