### PR TITLE
encoding: Fix Duration benchmarks so they don't fail

### DIFF
--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -1062,14 +1062,16 @@ func BenchmarkEncodeDuration(b *testing.B) {
 
 	vals := make([]duration.Duration, 10000)
 	for i := range vals {
-		vals[i] = duration.Duration{Months: rng.Int63(), Days: rng.Int63(), Nanos: rng.Int63()}
+		vals[i] = duration.Duration{Months: rng.Int63n(1000), Days: rng.Int63n(1000), Nanos: rng.Int63n(1000000)}
 	}
 
 	buf := make([]byte, 0, 1000)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = EncodeDurationAscending(buf, vals[i%len(vals)])
+		if _, err := EncodeDurationAscending(buf, vals[i%len(vals)]); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -1078,12 +1080,17 @@ func BenchmarkDecodeDuration(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		d := duration.Duration{Months: rng.Int63(), Days: rng.Int63(), Nanos: rng.Int63()}
-		vals[i], _ = EncodeDurationAscending(nil, d)
+		d := duration.Duration{Months: rng.Int63n(1000), Days: rng.Int63n(1000), Nanos: rng.Int63n(1000000)}
+		var err error
+		if vals[i], err = EncodeDurationAscending(nil, d); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = DecodeDurationAscending(vals[i%len(vals)])
+		if _, _, err := DecodeDurationAscending(vals[i%len(vals)]); err != nil {
+			b.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
Previously both the duration encoding and decoding benchmark were
failing every time they were run because their encoding's were overflowing.
This change bounds the domains of the randomized duration fields to prevent
this issue and adds checks to prevent it from happening again. The true
benchmark results are:

```
name              time/op
EncodeDuration-4  64.5ns ± 2%
DecodeDuration-4  74.3ns ± 1%

name              alloc/op
EncodeDuration-4  0.00B ±NaN%
DecodeDuration-4  0.00B ±NaN%

name              allocs/op
EncodeDuration-4   0.00 ±NaN%
DecodeDuration-4   0.00 ±NaN%
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6672)

<!-- Reviewable:end -->
