### PR TITLE
sql: fast path for UPSERT

### DIFF
--- a/sql/tablewriter.go
+++ b/sql/tablewriter.go
@@ -77,7 +77,7 @@ func (ti *tableInserter) init(txn *client.Txn) error {
 }
 
 func (ti *tableInserter) row(values parser.DTuple) (parser.DTuple, error) {
-	return nil, ti.ri.insertRow(ti.b, values)
+	return nil, ti.ri.insertRow(ti.b, values, false)
 }
 
 func (ti *tableInserter) finalize() error {
@@ -137,12 +137,35 @@ func (tu *tableUpdater) finalize() error {
 }
 
 type tableUpsertEvaler interface {
+	// TODO(dan): The tableUpsertEvaler interface separation was an attempt to
+	// keep sql logic out of the mapping between table rows and kv operations.
+	// Unfortunately, it was a misguided effort. tableUpserter's responsibilities
+	// should really be defined as those needed in distributed sql leaf nodes,
+	// which will necessarily include expr evaluation.
+
 	// eval returns the values for the update case of an upsert, given the row
 	// that would have been inserted and the existing (conflicting) values.
 	eval(insertRow parser.DTuple, existingRow parser.DTuple) (parser.DTuple, error)
+
+	isIdentityEvaler() bool
 }
 
 // tableUpserter handles writing kvs and forming table rows for upserts.
+//
+// There are two distinct "modes" that tableUpserter can use, one of which is
+// selected during `init`. In the general mode, rows are batched up from calls
+// to `row` and upserted using `flush`, which uses 1 or 2 `client.Batch`s from
+// the init'd txn to fetch the existing (conflicting) values, followed by one
+// more `client.Batch` with the appropriate inserts and updates. In this case,
+// all necessary `client.Batch`s are created and run within the lifetime of
+// `flush`.
+//
+// The other mode is the fast path. If certain conditions are met (no secondary
+// indexes, all table values being inserted, update expressions of the form `SET
+// a = excluded.a`) then the upsert can be done in one `client.Batch` and using
+// only `Put`s. In this case, the single batch is created during `init`,
+// operated on during `row`, and run during `finalize`. This is the same model
+// as the other `tableFoo`s, which are more simple than upsert.
 type tableUpserter struct {
 	ri            rowInserter
 	conflictIndex sqlbase.IndexDescriptor
@@ -160,6 +183,10 @@ type tableUpserter struct {
 	fetchColIDtoRowIndex  map[sqlbase.ColumnID]int
 	fetcher               sqlbase.RowFetcher
 
+	// Used for the fast path.
+	fastPathBatch *client.Batch
+	fastPathKeys  map[string]struct{}
+
 	// Batched up in run/flush.
 	insertRows []parser.DTuple
 
@@ -169,9 +196,16 @@ type tableUpserter struct {
 
 func (tu *tableUpserter) init(txn *client.Txn) error {
 	tu.txn = txn
-
 	tu.tableDesc = tu.ri.helper.tableDesc
 	tu.indexKeyPrefix = sqlbase.MakeIndexKeyPrefix(tu.tableDesc.ID, tu.tableDesc.PrimaryIndex.ID)
+
+	allColsIdentityExpr := len(tu.ri.insertCols) == len(tu.tableDesc.Columns) &&
+		tu.evaler != nil && tu.evaler.isIdentityEvaler()
+	if len(tu.tableDesc.Indexes) == 0 && allColsIdentityExpr {
+		tu.fastPathBatch = tu.txn.NewBatch()
+		tu.fastPathKeys = make(map[string]struct{})
+		return nil
+	}
 
 	// TODO(dan): This could be made tighter, just the rows needed for the ON
 	// CONFLICT exprs.
@@ -210,12 +244,21 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 }
 
 func (tu *tableUpserter) row(row parser.DTuple) (parser.DTuple, error) {
-	// TODO(dan): If a table has one index and every column is being upserted,
-	// then it can be done entirely with Puts. This would greatly help the
-	// key/value table case.
+	if tu.fastPathBatch != nil {
+		primaryKey, _, err := sqlbase.EncodeIndexKey(
+			&tu.tableDesc.PrimaryIndex, tu.ri.insertColIDtoRowIndex, row, tu.indexKeyPrefix)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := tu.fastPathKeys[string(primaryKey)]; ok {
+			return nil, fmt.Errorf("UPSERT/ON CONFLICT DO UPDATE command cannot affect row a second time")
+		}
+		tu.fastPathKeys[string(primaryKey)] = struct{}{}
+		err = tu.ri.insertRow(tu.fastPathBatch, row, true)
+		return nil, err
+	}
 
 	tu.insertRows = append(tu.insertRows, row)
-
 	// TODO(dan): If len(tu.insertRows) > some threshold, call flush().
 	return nil, nil
 }
@@ -236,7 +279,7 @@ func (tu *tableUpserter) flush() error {
 		existingRow := existingRows[i]
 
 		if existingRow == nil {
-			err := tu.ri.insertRow(b, insertRow)
+			err := tu.ri.insertRow(b, insertRow, false)
 			if err != nil {
 				return err
 			}
@@ -375,6 +418,9 @@ func (tu *tableUpserter) fetchExisting() ([]parser.DTuple, error) {
 }
 
 func (tu *tableUpserter) finalize() error {
+	if tu.fastPathBatch != nil {
+		return tu.txn.Run(tu.fastPathBatch)
+	}
 	return tu.flush()
 }
 


### PR DESCRIPTION
If a table has no secondary indexes and all columns are supplied, an UPSERT can
run without fetching previous values.

```
name                    old time/op    new time/op    delta
Upsert1_Cockroach-8       1.17ms ± 1%    1.00ms ± 0%  -14.64%  (p=0.008 n=5+5)
Upsert10_Cockroach-8      1.75ms ± 0%    1.46ms ± 1%  -16.63%  (p=0.016 n=4+5)
Upsert100_Cockroach-8     7.19ms ± 2%    5.55ms ± 2%  -22.82%  (p=0.008 n=5+5)
Upsert1000_Cockroach-8    71.9ms ± 5%    45.5ms ± 1%  -36.69%  (p=0.008 n=5+5)

name                    old alloc/op   new alloc/op   delta
Upsert1_Cockroach-8       86.2kB ± 0%    73.3kB ± 0%  -15.00%  (p=0.008 n=5+5)
Upsert10_Cockroach-8       169kB ± 0%     146kB ± 0%  -13.35%  (p=0.008 n=5+5)
Upsert100_Cockroach-8     1.07MB ± 0%    0.90MB ± 0%  -15.95%  (p=0.008 n=5+5)
Upsert1000_Cockroach-8    9.34MB ± 0%    7.69MB ± 0%  -17.68%  (p=0.008 n=5+5)

name                    old allocs/op  new allocs/op  delta
Upsert1_Cockroach-8        1.14k ± 0%     0.93k ± 0%  -18.05%  (p=0.029 n=4+4)
Upsert10_Cockroach-8       1.58k ± 0%     1.27k ± 0%  -19.71%  (p=0.016 n=4+5)
Upsert100_Cockroach-8      6.23k ± 0%     4.75k ± 0%  -23.74%  (p=0.008 n=5+5)
Upsert1000_Cockroach-8     52.0k ± 0%     39.3k ± 0%  -24.56%  (p=0.008 n=5+5)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6673)

<!-- Reviewable:end -->
