### PR TITLE
kv: Don't panic if a retryable error reaches TxnCoordSender

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -791,16 +791,16 @@ func (tc *TxnCoordSender) updateState(
 	case nil:
 		// Nothing to do here, avoid the default case.
 	default:
-		if pErr.GetTxn() != nil {
-			if pErr.CanRetry() {
-				log.Fatalf("retryable internal error must not happen at this level: %s", pErr)
-			} else {
-				// Do not clean up the transaction here since the client might still
-				// want to continue the transaction. For example, a client might
-				// continue its transaction after receiving ConditionFailedError, which
-				// can come from a unique index violation.
-			}
-		}
+		// Do not clean up the transaction here since the client might still
+		// want to continue the transaction. For example, a client might
+		// continue its transaction after receiving ConditionFailedError, which
+		// can come from a unique index violation.
+		//
+		// TODO(bdarnell): Is this valid? Unless there is a single CPut in
+		// the batch, it is difficult to be able to continue after a
+		// ConditionFailedError because it is unclear which parts of the
+		// batch had succeeded on other ranges before one range hit the
+		// failed condition. It may be better to clean up the transaction here.
 	}
 
 	txnID := *newTxn.ID


### PR DESCRIPTION
The concept of Retryable errors is going away as a part of #2500, and
it's normal for Retryable NotLeaderErrors to reach this level during
shutdown (as happens occasionally in many tests, as well as in
real-world deployments: #5722). The asynchronous operation (in tests,
it's a split or event log) won't succeed after the error is returned,
but that's not a problem.

Closes #5722
Closes #6431
Closes #6436
Closes #6446
Closes #6461
Closes #6554
Closes #6581
Closes #6600
Closes #6607
Closes #6664

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6677)

<!-- Reviewable:end -->
