### PR TITLE
sql: Add PG compatibility for invalid_catalog_name error

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -44,7 +44,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, databaseDoesNotExistError(n.Table.Database())
+		return nil, newUndefinedDatabaseError(n.Table.Database())
 	}
 
 	tableDesc, err := p.getTableDesc(n.Table)

--- a/sql/create.go
+++ b/sql/create.go
@@ -211,7 +211,7 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, databaseDoesNotExistError(n.Table.Database())
+		return nil, newUndefinedDatabaseError(n.Table.Database())
 	}
 
 	if err := p.checkPrivilege(dbDesc, privilege.CREATE); err != nil {

--- a/sql/database.go
+++ b/sql/database.go
@@ -28,10 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-func databaseDoesNotExistError(name string) error {
-	return fmt.Errorf("database %q does not exist", name)
-}
-
 // databaseKey implements sqlbase.DescriptorKey.
 type databaseKey struct {
 	name string
@@ -95,7 +91,7 @@ func getKeysForDatabaseDescriptor(
 type DatabaseAccessor interface {
 	// getDatabaseDesc looks up the database descriptor given its name.
 	// Returns nil if the descriptor is not found. If you want to turn the "not
-	// found" condition into an error, use databaseDoesNotExistError().
+	// found" condition into an error, use newUndefinedDatabaseError().
 	getDatabaseDesc(name string) (*sqlbase.DatabaseDescriptor, error)
 
 	// getCachedDatabaseDesc looks up the database descriptor from
@@ -176,7 +172,7 @@ func (p *planner) getDatabaseID(name string) (sqlbase.ID, error) {
 			return 0, err
 		}
 		if desc == nil {
-			return 0, databaseDoesNotExistError(name)
+			return 0, newUndefinedDatabaseError(name)
 		}
 	}
 

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -173,7 +173,7 @@ func (p *planner) getDescriptorsFromTargetList(targets parser.TargetList) (
 				return nil, err
 			}
 			if descriptor == nil {
-				return nil, databaseDoesNotExistError(database)
+				return nil, newUndefinedDatabaseError(database)
 			}
 			descs = append(descs, descriptor)
 		}

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -58,7 +58,7 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, error) {
 			// Noop.
 			return &emptyNode{}, nil
 		}
-		return nil, databaseDoesNotExistError(string(n.Name))
+		return nil, newUndefinedDatabaseError(string(n.Name))
 	}
 
 	if err := p.checkPrivilege(dbDesc, privilege.DROP); err != nil {

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -53,7 +53,7 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, databaseDoesNotExistError(string(n.Name))
+		return nil, newUndefinedDatabaseError(string(n.Name))
 	}
 
 	if n.Name == n.NewName {
@@ -122,7 +122,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, databaseDoesNotExistError(n.Name.Database())
+		return nil, newUndefinedDatabaseError(n.Name.Database())
 	}
 
 	tbKey := tableKey{dbDesc.ID, n.Name.Table()}.Key()
@@ -146,7 +146,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		return nil, err
 	}
 	if targetDbDesc == nil {
-		return nil, databaseDoesNotExistError(n.NewName.Database())
+		return nil, newUndefinedDatabaseError(n.NewName.Database())
 	}
 
 	if err := p.checkPrivilege(targetDbDesc, privilege.CREATE); err != nil {
@@ -307,7 +307,7 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, databaseDoesNotExistError(n.Table.Database())
+		return nil, newUndefinedDatabaseError(n.Table.Database())
 	}
 
 	// Check if table exists.

--- a/sql/set.go
+++ b/sql/set.go
@@ -56,7 +56,7 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 				return nil, err
 			}
 			if dbDesc == nil {
-				return nil, databaseDoesNotExistError(dbName)
+				return nil, newUndefinedDatabaseError(dbName)
 			}
 		}
 		p.session.Database = dbName

--- a/sql/show.go
+++ b/sql/show.go
@@ -322,7 +322,7 @@ func (p *planner) ShowTables(n *parser.ShowTables) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, databaseDoesNotExistError(string(name.Base))
+		return nil, newUndefinedDatabaseError(string(name.Base))
 	}
 
 	tableNames, err := p.getTableNames(dbDesc)

--- a/sql/table.go
+++ b/sql/table.go
@@ -144,7 +144,7 @@ func (p *planner) getTableDesc(qname *parser.QualifiedName) (*sqlbase.TableDescr
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, databaseDoesNotExistError(qname.Database())
+		return nil, newUndefinedDatabaseError(qname.Database())
 	}
 
 	desc := sqlbase.TableDescriptor{}
@@ -324,7 +324,7 @@ func (p *planner) expandTableGlob(expr *parser.QualifiedName) (
 			return nil, err
 		}
 		if dbDesc == nil {
-			return nil, databaseDoesNotExistError(string(expr.Base))
+			return nil, newUndefinedDatabaseError(string(expr.Base))
 		}
 		tableNames, err := p.getTableNames(dbDesc)
 		if err != nil {


### PR DESCRIPTION
This change replaces `databaseDoesNotExistError` with its corresponding
PG compliant error code.

Necessary for sfackler/rust-postgres#171.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6680)

<!-- Reviewable:end -->
