### PR TITLE
sql: various cleanups preliminary to a major select refactoring

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -457,12 +457,11 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 		// because the schema change is in the correct state to handle
 		// intermediate OLTP commands which delete and add values during the
 		// scan.
-		scan := &scanNode{
-			planner: makePlanner(),
-			txn:     txn,
-			desc:    *tableDesc,
-			spans:   []sqlbase.Span{sp},
-		}
+		planner := makePlanner()
+		planner.setTxn(txn)
+		scan := planner.Scan()
+		scan.desc = *tableDesc
+		scan.spans = []sqlbase.Span{sp}
 		scan.initDescDefaults()
 		rows, err := selectIndex(scan, nil, false)
 		if err != nil {

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -467,6 +467,11 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 		if err != nil {
 			return err
 		}
+
+		if err := rows.Start(); err != nil {
+			return err
+		}
+
 		// Construct a map from column ID to the index the value appears at
 		// within a row.
 		colIDtoRowIndex, err := makeColIDtoRowIndex(rows, tableDesc)

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -72,7 +72,7 @@ func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoComm
 		Exprs: sqlbase.ColumnsSelectors(rd.fetchCols),
 		From:  []parser.TableExpr{n.Table},
 		Where: n.Where,
-	}, nil)
+	}, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (d *deleteNode) expandPlan() error {
 		Exprs: sqlbase.ColumnsSelectors(d.tw.rd.fetchCols),
 		From:  []parser.TableExpr{d.n.Table},
 		Where: d.n.Where,
-	}, nil)
+	}, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -1131,3 +1131,19 @@ func checkResultDatum(datum parser.Datum) error {
 	}
 	return nil
 }
+
+// makeResultColumns converts sqlbase.ColumnDescriptors to ResultColumns.
+func makeResultColumns(colDescs []sqlbase.ColumnDescriptor) []ResultColumn {
+	cols := make([]ResultColumn, 0, len(colDescs))
+	for _, colDesc := range colDescs {
+		// Convert the sqlbase.ColumnDescriptor to ResultColumn.
+		typ := colDesc.Type.ToDatumType()
+		if typ == nil {
+			panic(fmt.Sprintf("unsupported column type: %s", colDesc.Type.Kind))
+		}
+
+		hidden := colDesc.Hidden
+		cols = append(cols, ResultColumn{Name: colDesc.Name, Typ: typ, hidden: hidden})
+	}
+	return cols
+}

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -704,12 +704,12 @@ func (v *indexInfo) makeIndexConstraints(andExprs parser.TypedExprs) (indexConst
 				// we can not include it in the index constraints because the index
 				// encoding would be incorrect. See #4313.
 				if preStart != *startExpr {
-					if isMixedTypeComparison(*startExpr) {
+					if (*startExpr).IsMixedTypeComparison() {
 						*startExpr = nil
 					}
 				}
 				if preEnd != *endExpr {
-					if isMixedTypeComparison(*endExpr) {
+					if (*endExpr).IsMixedTypeComparison() {
 						*endExpr = nil
 					}
 				}
@@ -775,33 +775,6 @@ func (v *indexInfo) isCoveringIndex(scan *scanNode) bool {
 		}
 	}
 	return true
-}
-
-func isMixedTypeComparison(c *parser.ComparisonExpr) bool {
-	switch c.Operator {
-	case parser.In, parser.NotIn:
-		tuple := *c.Right.(*parser.DTuple)
-		for _, expr := range tuple {
-			if !sameTypeExprs(c.TypedLeft(), expr.(parser.TypedExpr)) {
-				return true
-			}
-		}
-		return false
-	default:
-		return !sameTypeExprs(c.TypedLeft(), c.TypedRight())
-	}
-}
-
-func sameTypeExprs(left, right parser.TypedExpr) bool {
-	leftType := left.ReturnType()
-	if leftType == parser.DNull {
-		return true
-	}
-	rightType := right.ReturnType()
-	if rightType == parser.DNull {
-		return true
-	}
-	return leftType.TypeEqual(rightType)
 }
 
 type indexInfoByCost []*indexInfo

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -1461,7 +1461,7 @@ func (v *applyConstraintsVisitor) VisitPre(expr parser.Expr) (recurse bool, newE
 				if reflect.TypeOf(datum) != reflect.TypeOf(cdatum) {
 					return true, expr
 				}
-				diff := diffSorted(*datum.(*parser.DTuple), *cdatum.(*parser.DTuple))
+				diff := datum.(*parser.DTuple).SortedDifference(cdatum.(*parser.DTuple))
 				if len(*diff) == 0 {
 					return false, parser.DBoolTrue
 				}
@@ -1498,21 +1498,4 @@ func (v *applyConstraintsVisitor) VisitPost(expr parser.Expr) parser.Expr {
 	}
 
 	return expr
-}
-
-func diffSorted(a, b parser.DTuple) *parser.DTuple {
-	var r parser.DTuple
-	for len(a) > 0 && len(b) > 0 {
-		switch a[0].Compare(b[0]) {
-		case -1:
-			r = append(r, a[0])
-			a = a[1:]
-		case 0:
-			a = a[1:]
-			b = b[1:]
-		case 1:
-			b = b[1:]
-		}
-	}
-	return &r
 }

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -206,7 +206,7 @@ func selectIndex(
 		// There are no spans to scan.
 		return &emptyNode{}, nil
 	}
-	s.filter = applyConstraints(s.filter, c.constraints)
+	s.filter = applyIndexConstraints(s.filter, c.constraints)
 	noFilter := (s.filter == nil)
 	s.reverse = c.reverse
 
@@ -1353,7 +1353,7 @@ func (oic orIndexConstraints) exactPrefix() int {
 // constraint is "a = 1", the expression is simplified to "b > 2".
 //
 // Note that applyConstraints currently only handles simple cases.
-func applyConstraints(typedExpr parser.TypedExpr, constraints orIndexConstraints) parser.TypedExpr {
+func applyIndexConstraints(typedExpr parser.TypedExpr, constraints orIndexConstraints) parser.TypedExpr {
 	if len(constraints) != 1 {
 		// We only support simplifying the expressions if there aren't multiple
 		// disjunctions (top-level OR branches).

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -421,6 +421,10 @@ func (v *indexInfo) analyzeOrdering(scan *scanNode, analyzeOrdering analyzeOrder
 	}
 }
 
+// getQValColIdx detects whether an expression is a straightforward
+// reference to a column or index variable. In this case it returns
+// the index of that column's in the descriptor's []Column array.
+// Used by indexInfo.makeIndexConstraints().
 func getQValColIdx(expr parser.Expr) (ok bool, colIdx int) {
 	switch q := expr.(type) {
 	case *qvalue:

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -215,8 +215,10 @@ func selectIndex(
 		s.initOrdering(c.exactPrefix)
 		plan = s
 	} else {
-		// Note: makeIndexJoin can modify s.filter.
-		plan = s.p.makeIndexJoin(s, c.exactPrefix)
+		// Note: makeIndexJoin destroys s and returns a new index scan
+		// node. The filter in that node may be different from the
+		// original table filter.
+		plan, s = s.p.makeIndexJoin(s, c.exactPrefix)
 	}
 
 	// If we have no filter, we can request a single key in some cases.

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -216,7 +216,7 @@ func selectIndex(
 		plan = s
 	} else {
 		// Note: makeIndexJoin can modify s.filter.
-		plan = makeIndexJoin(s, c.exactPrefix)
+		plan = s.p.makeIndexJoin(s, c.exactPrefix)
 	}
 
 	// If we have no filter, we can request a single key in some cases.

--- a/sql/index_selection_test.go
+++ b/sql/index_selection_test.go
@@ -652,7 +652,7 @@ func TestApplyConstraints(t *testing.T) {
 	for _, d := range testData {
 		desc, index := makeTestIndexFromStr(t, d.columns)
 		constraints, expr := makeConstraints(t, d.expr, desc, index)
-		expr2 := applyConstraints(expr, constraints)
+		expr2 := applyIndexConstraints(expr, constraints)
 		if s := fmt.Sprint(expr2); d.expected != s {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 		}

--- a/sql/join.go
+++ b/sql/join.go
@@ -44,7 +44,7 @@ type indexJoinNode struct {
 
 func makeIndexJoin(indexScan *scanNode, exactPrefix int) *indexJoinNode {
 	// Create a new table scan node with the primary index.
-	table := &scanNode{planner: indexScan.planner, txn: indexScan.txn}
+	table := indexScan.p.Scan()
 	table.desc = indexScan.desc
 	table.initDescDefaults()
 	table.initOrdering(0)

--- a/sql/join.go
+++ b/sql/join.go
@@ -42,9 +42,9 @@ type indexJoinNode struct {
 	debugVals        debugValues
 }
 
-func makeIndexJoin(indexScan *scanNode, exactPrefix int) *indexJoinNode {
+func (p *planner) makeIndexJoin(indexScan *scanNode, exactPrefix int) *indexJoinNode {
 	// Create a new table scan node with the primary index.
-	table := indexScan.p.Scan()
+	table := p.Scan()
 	table.desc = indexScan.desc
 	table.initDescDefaults()
 	table.initOrdering(0)

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -1054,6 +1054,27 @@ func (d *DTuple) makeUnique() {
 	*d = (*d)[:n]
 }
 
+// SortedDifference finds the elements of d which are not in other,
+// assuming that d and other are already sorted.
+func (d *DTuple) SortedDifference(other *DTuple) *DTuple {
+	var r DTuple
+	a := *d
+	b := *other
+	for len(a) > 0 && len(b) > 0 {
+		switch a[0].Compare(b[0]) {
+		case -1:
+			r = append(r, a[0])
+			a = a[1:]
+		case 0:
+			a = a[1:]
+			b = b[1:]
+		case 1:
+			b = b[1:]
+		}
+	}
+	return &r
+}
+
 type dNull struct{}
 
 // ReturnType implements the TypedExpr interface.

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -328,6 +328,35 @@ func (node *ComparisonExpr) TypedRight() TypedExpr {
 	return node.Right.(TypedExpr)
 }
 
+// IsMixedTypeComparison returns true when the two sides of
+// a comparison operator have different types.
+func (node *ComparisonExpr) IsMixedTypeComparison() bool {
+	switch node.Operator {
+	case In, NotIn:
+		tuple := *node.Right.(*DTuple)
+		for _, expr := range tuple {
+			if !sameTypeExprs(node.TypedLeft(), expr.(TypedExpr)) {
+				return true
+			}
+		}
+		return false
+	default:
+		return !sameTypeExprs(node.TypedLeft(), node.TypedRight())
+	}
+}
+
+func sameTypeExprs(left, right TypedExpr) bool {
+	leftType := left.ReturnType()
+	if leftType == DNull {
+		return true
+	}
+	rightType := right.ReturnType()
+	if rightType == DNull {
+		return true
+	}
+	return leftType.TypeEqual(rightType)
+}
+
 // RangeCond represents a BETWEEN or a NOT BETWEEN expression.
 type RangeCond struct {
 	Not      bool

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -260,7 +260,7 @@ func (p *planner) newPlan(stmt parser.Statement, desiredTypes []parser.Datum, au
 	case *parser.Select:
 		return p.Select(n, desiredTypes, autoCommit)
 	case *parser.SelectClause:
-		return p.SelectClause(n, desiredTypes)
+		return p.SelectClause(n, nil, nil, desiredTypes)
 	case *parser.Set:
 		return p.Set(n)
 	case *parser.SetTimeZone:
@@ -305,7 +305,7 @@ func (p *planner) prepare(stmt parser.Statement) (planNode, error) {
 	case *parser.Select:
 		return p.Select(n, nil, false)
 	case *parser.SelectClause:
-		return p.SelectClause(n, nil)
+		return p.SelectClause(n, nil, nil, nil)
 	case *parser.Show:
 		return p.Show(n)
 	case *parser.ShowCreateTable:

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -165,6 +165,9 @@ type planNode interface {
 	Err() error
 }
 
+// planNodeFastPath is implemented by nodes that can perform all their
+// work during Start(), possibly affecting even multiple rows. For
+// example, DELETE can do this.
 type planNodeFastPath interface {
 	// FastPathResults returns the affected row count and true if the
 	// node has no result set and has already executed when Start() completes.

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -114,20 +114,17 @@ func (n *scanNode) expandPlan() error {
 }
 
 func (n *scanNode) Start() error {
+	if err := n.fetcher.Init(&n.desc, n.colIdxMap, n.index, n.reverse,
+		n.isSecondaryIndex, n.valNeededForCol); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // initScan sets up the rowFetcher and starts a scan. On error, sets n.err and
 // returns false.
 func (n *scanNode) initScan() (success bool) {
-	// TODO(radu): we could call init() just once, after the index and
-	// valNeededForCol are set.
-	err := n.fetcher.Init(&n.desc, n.colIdxMap, n.index, n.reverse, n.isSecondaryIndex,
-		n.valNeededForCol)
-	if err != nil {
-		n.err = err
-		return false
-	}
 
 	if len(n.spans) == 0 {
 		// If no spans were specified retrieve all of the keys that start with our

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -263,22 +263,6 @@ func (n *scanNode) initTable(
 	return alias, nil
 }
 
-// makeResultColumns converts sqlbase.ColumnDescriptors to ResultColumns.
-func makeResultColumns(colDescs []sqlbase.ColumnDescriptor) []ResultColumn {
-	cols := make([]ResultColumn, 0, len(colDescs))
-	for _, colDesc := range colDescs {
-		// Convert the sqlbase.ColumnDescriptor to ResultColumn.
-		typ := colDesc.Type.ToDatumType()
-		if typ == nil {
-			panic(fmt.Sprintf("unsupported column type: %s", colDesc.Type.Kind))
-		}
-
-		hidden := colDesc.Hidden
-		cols = append(cols, ResultColumn{Name: colDesc.Name, Typ: typ, hidden: hidden})
-	}
-	return cols
-}
-
 // setNeededColumns sets the flags indicating which columns are needed by the upper layer.
 func (n *scanNode) setNeededColumns(needed []bool) {
 	if len(needed) != len(n.valNeededForCol) {

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -19,7 +19,6 @@ package sql
 import (
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
@@ -30,10 +29,9 @@ import (
 // A scanNode handles scanning over the key/value pairs for a table and
 // reconstructing them into rows.
 type scanNode struct {
-	planner *planner
-	txn     *client.Txn
-	desc    sqlbase.TableDescriptor
-	index   *sqlbase.IndexDescriptor
+	p     *planner
+	desc  sqlbase.TableDescriptor
+	index *sqlbase.IndexDescriptor
 
 	// Set if an index was explicitly specified.
 	specifiedIndex *sqlbase.IndexDescriptor
@@ -71,6 +69,10 @@ type scanNode struct {
 	fetcher         sqlbase.RowFetcher
 
 	limitHint int64
+}
+
+func (p *planner) Scan() *scanNode {
+	return &scanNode{p: p}
 }
 
 func (n *scanNode) Columns() []ResultColumn {
@@ -135,7 +137,7 @@ func (n *scanNode) initScan() (success bool) {
 		n.spans = append(n.spans, sqlbase.Span{Start: start, End: start.PrefixEnd()})
 	}
 
-	n.err = n.fetcher.StartScan(n.txn, n.spans, n.limitHint)
+	n.err = n.fetcher.StartScan(n.p.txn, n.spans, n.limitHint)
 	if n.err != nil {
 		return false
 	}
@@ -153,7 +155,7 @@ func (n *scanNode) debugNext() bool {
 	}
 
 	if n.row != nil {
-		passesFilter, err := sqlbase.RunFilter(n.filter, n.planner.evalCtx)
+		passesFilter, err := sqlbase.RunFilter(n.filter, n.p.evalCtx)
 		if err != nil {
 			n.err = err
 			return false
@@ -192,7 +194,7 @@ func (n *scanNode) Next() bool {
 		if n.err != nil || n.row == nil {
 			return false
 		}
-		passesFilter, err := sqlbase.RunFilter(n.filter, n.planner.evalCtx)
+		passesFilter, err := sqlbase.RunFilter(n.filter, n.p.evalCtx)
 		if err != nil {
 			n.err = err
 			return false

--- a/sql/select.go
+++ b/sql/select.go
@@ -387,7 +387,7 @@ func (s *selectNode) initFrom(p *planner, parsed *parser.SelectClause) error {
 		switch expr := ate.Expr.(type) {
 		case *parser.QualifiedName:
 			// Usual case: a table.
-			scan := &scanNode{planner: p, txn: p.txn}
+			scan := p.Scan()
 			s.table.alias, s.err = scan.initTable(p, expr, ate.Hints)
 			if s.err != nil {
 				return s.err

--- a/sql/select.go
+++ b/sql/select.go
@@ -212,8 +212,7 @@ func (p *planner) Select(n *parser.Select, desiredTypes []parser.Datum, autoComm
 	case *parser.SelectClause:
 		// Select can potentially optimize index selection if it's being ordered,
 		// so we allow it to do its own sorting.
-		node := &selectNode{planner: p}
-		return p.initSelect(node, s, orderBy, limit, desiredTypes)
+		return p.SelectClause(s, orderBy, limit, desiredTypes)
 	// TODO(dan): Union can also do optimizations when it has an ORDER BY, but
 	// currently expects the ordering to be done externally, so we let it fall
 	// through. Instead of continuing this special casing, it may be worth
@@ -249,14 +248,8 @@ func (p *planner) Select(n *parser.Select, desiredTypes []parser.Datum, autoComm
 // Privileges: SELECT on table
 //   Notes: postgres requires SELECT. Also requires UPDATE on "FOR UPDATE".
 //          mysql requires SELECT.
-func (p *planner) SelectClause(parsed *parser.SelectClause, desiredTypes []parser.Datum) (planNode, error) {
-	node := &selectNode{planner: p}
-	return p.initSelect(node, parsed, nil, nil, desiredTypes)
-}
-
-func (p *planner) initSelect(
-	s *selectNode, parsed *parser.SelectClause, orderBy parser.OrderBy, limit *parser.Limit, desiredTypes []parser.Datum,
-) (planNode, error) {
+func (p *planner) SelectClause(parsed *parser.SelectClause, orderBy parser.OrderBy, limit *parser.Limit, desiredTypes []parser.Datum) (planNode, error) {
+	s := &selectNode{planner: p}
 
 	s.qvals = make(qvalMap)
 

--- a/sql/select_qvalue.go
+++ b/sql/select_qvalue.go
@@ -108,11 +108,9 @@ func (q *qvalue) String() string { return parser.AsString(q) }
 
 // Walk implements the Expr interface.
 func (q *qvalue) Walk(v parser.Visitor) parser.Expr {
-	e, _ := parser.WalkExpr(v, q.datum)
-	// Typically Walk implementations are not supposed to modify nodes in-place, in order to
-	// preserve the original transaction statement and expressions. However, `qvalue` is our type
-	// (which we have "stiched" into an expression) so we aren't modifying an original expression.
-	q.datum = e.(parser.Datum)
+	if e, changed := parser.WalkExpr(v, q.datum); changed {
+		return &qvalue{datum: e.(parser.Datum), colRef: q.colRef}
+	}
 	return q
 }
 

--- a/sql/sqlbase/rowfetcher.go
+++ b/sql/sqlbase/rowfetcher.go
@@ -32,12 +32,12 @@ import (
 // RowFetcher handles fetching kvs and forming table rows.
 // Usage:
 //   var rf RowFetcher
-//   err := rf.init(..)
+//   err := rf.Init(..)
 //   // Handle err
-//   err := rf.startScan(..)
+//   err := rf.StartScan(..)
 //   // Handle err
 //   for {
-//      row, err := rf.nextRow()
+//      row, err := rf.NextRow()
 //      // Handle err
 //      if row == nil {
 //         // Done

--- a/sql/update.go
+++ b/sql/update.go
@@ -187,7 +187,7 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 		Exprs: targets,
 		From:  []parser.TableExpr{n.Table},
 		Where: n.Where,
-	}, desiredTypesFromSelect)
+	}, nil, nil, desiredTypesFromSelect)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +272,7 @@ func (u *updateNode) expandPlan() error {
 		Exprs: targets,
 		From:  []parser.TableExpr{u.n.Table},
 		Where: u.n.Where,
-	}, u.desiredTypes)
+	}, nil, nil, u.desiredTypes)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is splitting the preliminary cleanup commits from PR #6594, which was getting unyieldy.

Commits are independent, should be reviewed separately. No user-visible change.

cc @tamird @RaduBerinde.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6681)

<!-- Reviewable:end -->
