### PR TITLE
storage/engine: reuse iterators for the lifetime of rocksDBBatch

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1393,7 +1393,7 @@ func MVCCDeleteRange(
 	var keys []roachpb.Key
 	num := int64(0)
 	buf := newPutBuffer()
-	iter := engine.NewIterator(false)
+	iter := engine.NewIterator(true)
 	f := func(kv roachpb.KeyValue) (bool, error) {
 		if err := mvccPutInternal(ctx, engine, iter, ms, kv.Key, timestamp, nil, txn, buf, nil); err != nil {
 			return true, err

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -511,10 +511,28 @@ func (r *rocksDBSnapshot) GetStats() (*Stats, error) {
 	return nil, util.Errorf("GetStats is not implemented for %T", r)
 }
 
+// rocksDBBatchIterator wraps rocksDBIterator and allows reuse of an iterator
+// for the lifetime of a batch.
+type rocksDBBatchIterator struct {
+	rocksDBIterator
+	inuse bool
+}
+
+func (r *rocksDBBatchIterator) Close() {
+	// rocksDBBatchIterator.Close() is a no-op. The iterator is left open until
+	// the associated batch is closed.
+	if !r.inuse {
+		panic("closing idle iterator")
+	}
+	r.inuse = false
+}
+
 type rocksDBBatch struct {
-	parent *RocksDB
-	batch  *C.DBEngine
-	defers []func()
+	parent     *RocksDB
+	batch      *C.DBEngine
+	defers     []func()
+	prefixIter rocksDBBatchIterator
+	normalIter rocksDBBatchIterator
 }
 
 func newRocksDBBatch(r *RocksDB) *rocksDBBatch {
@@ -529,6 +547,12 @@ func (r *rocksDBBatch) Open() error {
 }
 
 func (r *rocksDBBatch) Close() {
+	if i := &r.prefixIter.rocksDBIterator; i.iter != nil {
+		i.destroy()
+	}
+	if i := &r.normalIter.rocksDBIterator; i.iter != nil {
+		i.destroy()
+	}
 	if r.batch != nil {
 		C.DBClose(r.batch)
 	}
@@ -586,8 +610,24 @@ func (r *rocksDBBatch) Flush() error {
 	return util.Errorf("cannot flush a batch")
 }
 
+// NewIterator returns an iterator over the batch and underlying engine. Note
+// that the returned iterator is cached and re-used for the lifetime of the
+// batch. A panic will be thrown if multiple prefix or normal (non-prefix)
+// iterators are used simultaneously on the same batch.
 func (r *rocksDBBatch) NewIterator(prefix bool) Iterator {
-	return newRocksDBIterator(r.batch, prefix, r)
+	// Used the cached iterator, creating it on first access.
+	iter := &r.normalIter
+	if prefix {
+		iter = &r.prefixIter
+	}
+	if iter.rocksDBIterator.iter == nil {
+		iter.rocksDBIterator.init(r.batch, prefix, r)
+	}
+	if iter.inuse {
+		panic("iterator already in use")
+	}
+	iter.inuse = true
+	return iter
 }
 
 func (r *rocksDBBatch) NewSnapshot() Engine {
@@ -638,6 +678,8 @@ type rocksDBIterator struct {
 	value  C.DBSlice
 }
 
+// TODO(peter): Is this pool useful now that rocksDBBatch.NewIterator doesn't
+// allocate by returning internal pointers?
 var iterPool = sync.Pool{
 	New: func() interface{} {
 		return &rocksDBIterator{}
@@ -654,9 +696,13 @@ func newRocksDBIterator(rdb *C.DBEngine, prefix bool, engine Engine) Iterator {
 	// options field that should be carried over needs to be set here
 	// as well.
 	r := iterPool.Get().(*rocksDBIterator)
+	r.init(rdb, prefix, engine)
+	return r
+}
+
+func (r *rocksDBIterator) init(rdb *C.DBEngine, prefix bool, engine Engine) {
 	r.iter = C.DBNewIter(rdb, C.bool(prefix))
 	r.engine = engine
-	return r
 }
 
 func (r *rocksDBIterator) checkEngineOpen() {
@@ -665,10 +711,14 @@ func (r *rocksDBIterator) checkEngineOpen() {
 	}
 }
 
-// The following methods implement the Iterator interface.
-func (r *rocksDBIterator) Close() {
+func (r *rocksDBIterator) destroy() {
 	C.DBIterDestroy(r.iter)
 	*r = rocksDBIterator{}
+}
+
+// The following methods implement the Iterator interface.
+func (r *rocksDBIterator) Close() {
+	r.destroy()
 	iterPool.Put(r)
 }
 

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -62,7 +62,10 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	after := b.NewIterator(false)
+	// We use a prefix iterator for after in order to workaround the restriction
+	// on concurrent use of more than 1 prefix or normal (non-prefix) iterator on
+	// a batch.
+	after := b.NewIterator(true /* prefix */)
 	defer after.Close()
 
 	if after.Seek(k); !after.Valid() {


### PR DESCRIPTION
`rocksDBBatch` caches a prefix and normal (non-prefix) iterator upon
first use and reuses them for the lifetime of the batch. This avoids a
cgo call to create an iterator on every request. Note that this change
only affects benchmarks which are doing random inserts and thus not able
to take advantage of the "blind" put optimization.

name                            old time/op    new time/op    delta
TrackChoices1_Cockroach-32         651µs ± 4%     634µs ± 3%  -2.59%  (p=0.000 n=20+20)
TrackChoices10_Cockroach-32        203µs ± 2%     197µs ± 3%  -2.89%  (p=0.000 n=19+20)
TrackChoices100_Cockroach-32       143µs ± 4%     138µs ± 3%  -4.09%  (p=0.000 n=20+20)
TrackChoices1000_Cockroach-32      139µs ± 5%     134µs ± 4%  -3.40%  (p=0.000 n=20+20)
InsertDistinct1_Cockroach-32      2.49ms ± 3%    2.45ms ± 5%  -1.44%  (p=0.028 n=19+20)
InsertDistinct10_Cockroach-32     2.04ms ± 3%    1.96ms ± 2%  -4.03%  (p=0.000 n=20+20)
InsertDistinct100_Cockroach-32    2.41ms ± 3%    2.35ms ± 4%  -2.17%  (p=0.000 n=19+20)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6684)

<!-- Reviewable:end -->
