### PR TITLE
all: Move most non-test retry options to a constant defined in base

### DIFF
--- a/base/context.go
+++ b/base/context.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/cli/cliflags"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/retry"
 )
 
 // Base context defaults.
@@ -176,4 +177,17 @@ func (ctx *Context) GetHTTPClient() (*http.Client, error) {
 	}
 
 	return ctx.httpClient, nil
+}
+
+// DefaultRetryOptions should be used for retrying most
+// network-dependent operations.
+func DefaultRetryOptions() retry.Options {
+	// TODO(bdarnell): This should vary with network latency.
+	// Derive the retry options from a configured or measured
+	// estimate of latency.
+	return retry.Options{
+		InitialBackoff: 50 * time.Millisecond,
+		MaxBackoff:     5 * time.Second,
+		Multiplier:     2,
+	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -97,7 +97,9 @@ func createTestClientForUser(t *testing.T, stopper *stop.Stopper, addr, user str
 func createTestNotifyClient(t *testing.T, stopper *stop.Stopper, addr string, priority roachpb.UserPriority) (*client.DB, *notifyingSender) {
 	db := createTestClient(t, stopper, addr)
 	sender := &notifyingSender{wrapped: db.GetSender()}
-	return client.NewDBWithPriority(sender, priority), sender
+	dbCtx := client.DefaultDBContext()
+	dbCtx.UserPriority = priority
+	return client.NewDBWithContext(sender, dbCtx), sender
 }
 
 // TestClientRetryNonTxn verifies that non-transactional client will

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -75,10 +75,15 @@ func (ss *notifyingSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*
 }
 
 func createTestClient(t *testing.T, stopper *stop.Stopper, addr string) *client.DB {
-	return createTestClientForUser(t, stopper, addr, security.NodeUser)
+	return createTestClientForUser(t, stopper, addr, security.NodeUser, client.DefaultDBContext())
 }
 
-func createTestClientForUser(t *testing.T, stopper *stop.Stopper, addr, user string) *client.DB {
+func createTestClientForUser(
+	t *testing.T,
+	stopper *stop.Stopper,
+	addr, user string,
+	dbCtx client.DBContext,
+) *client.DB {
 	rpcContext := rpc.NewContext(&base.Context{
 		User:       user,
 		SSLCA:      filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert),
@@ -89,7 +94,7 @@ func createTestClientForUser(t *testing.T, stopper *stop.Stopper, addr, user str
 	if err != nil {
 		t.Fatal(err)
 	}
-	return client.NewDB(sender)
+	return client.NewDBWithContext(sender, dbCtx)
 }
 
 // createTestNotifyClient creates a new client which connects using an HTTP
@@ -230,22 +235,15 @@ func TestClientRetryNonTxn(t *testing.T) {
 	}
 }
 
-func setTxnRetryBackoff(backoff time.Duration) func() {
-	savedBackoff := client.DefaultTxnRetryOptions.InitialBackoff
-	client.DefaultTxnRetryOptions.InitialBackoff = backoff
-	return func() {
-		client.DefaultTxnRetryOptions.InitialBackoff = savedBackoff
-	}
-}
-
 // TestClientRunTransaction verifies some simple transaction isolation
 // semantics.
 func TestClientRunTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := server.StartTestServer(t)
 	defer s.Stop()
-	defer setTxnRetryBackoff(1 * time.Millisecond)()
-	db := createTestClient(t, s.Stopper(), s.ServingAddr())
+	dbCtx := client.DefaultDBContext()
+	dbCtx.TxnRetryOptions.InitialBackoff = 1 * time.Millisecond
+	db := createTestClientForUser(t, s.Stopper(), s.ServingAddr(), security.NodeUser, dbCtx)
 
 	for _, commit := range []bool{true, false} {
 		value := []byte("value")
@@ -689,8 +687,10 @@ func TestClientPermissions(t *testing.T) {
 
 	// NodeUser certs are required for all KV operations.
 	// RootUser has no KV privileges whatsoever.
-	nodeClient := createTestClientForUser(t, s.Stopper(), s.ServingAddr(), security.NodeUser)
-	rootClient := createTestClientForUser(t, s.Stopper(), s.ServingAddr(), security.RootUser)
+	nodeClient := createTestClientForUser(t, s.Stopper(), s.ServingAddr(),
+		security.NodeUser, client.DefaultDBContext())
+	rootClient := createTestClientForUser(t, s.Stopper(), s.ServingAddr(),
+		security.RootUser, client.DefaultDBContext())
 
 	testCases := []struct {
 		path    string

--- a/client/db.go
+++ b/client/db.go
@@ -23,6 +23,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
@@ -163,7 +164,7 @@ type DBContext struct {
 func DefaultDBContext() DBContext {
 	return DBContext{
 		UserPriority:    roachpb.NormalUserPriority,
-		TxnRetryOptions: defaultTxnRetryOptions,
+		TxnRetryOptions: base.DefaultRetryOptions(),
 	}
 }
 

--- a/client/db.go
+++ b/client/db.go
@@ -163,7 +163,7 @@ type DBContext struct {
 func DefaultDBContext() DBContext {
 	return DBContext{
 		UserPriority:    roachpb.NormalUserPriority,
-		TxnRetryOptions: DefaultTxnRetryOptions,
+		TxnRetryOptions: defaultTxnRetryOptions,
 	}
 }
 

--- a/client/txn.go
+++ b/client/txn.go
@@ -34,10 +34,9 @@ import (
 	basictracer "github.com/opentracing/basictracer-go"
 )
 
-// DefaultTxnRetryOptions are the standard retry options used
+// defaultTxnRetryOptions are the standard retry options used
 // for transactions.
-// This is exported for testing purposes only.
-var DefaultTxnRetryOptions = retry.Options{
+var defaultTxnRetryOptions = retry.Options{
 	InitialBackoff: 50 * time.Millisecond,
 	MaxBackoff:     5 * time.Second,
 	Multiplier:     2,

--- a/client/txn.go
+++ b/client/txn.go
@@ -19,7 +19,6 @@ package client
 import (
 	"errors"
 	"strconv"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -33,14 +32,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	basictracer "github.com/opentracing/basictracer-go"
 )
-
-// defaultTxnRetryOptions are the standard retry options used
-// for transactions.
-var defaultTxnRetryOptions = retry.Options{
-	InitialBackoff: 50 * time.Millisecond,
-	MaxBackoff:     5 * time.Second,
-	Multiplier:     2,
-}
 
 // txnSender implements the Sender interface and is used to keep the Send
 // method out of the Txn method set.

--- a/client/txn.go
+++ b/client/txn.go
@@ -516,7 +516,7 @@ func (txn *Txn) Exec(
 	}()
 
 	if opt.AutoRetry {
-		retryOptions = txn.db.txnRetryOptions
+		retryOptions = txn.db.ctx.TxnRetryOptions
 	}
 RetryLoop:
 	for r := retry.Start(retryOptions); r.Next(); {

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -52,23 +52,6 @@ const (
 	defaultRangeDescriptorCacheSize = 1 << 20
 )
 
-var defaultRPCRetryOptions = retry.Options{
-	// This is an aggressive initial backoff to support situations where retries
-	// which are expected to succeed in a low number of iterations should occur in
-	// quick succession. An example of this is when the rangeDescriptorCache returns
-	// a lookupMismatchError.
-	InitialBackoff: 100 * time.Microsecond,
-	MaxBackoff:     30 * time.Second,
-	Multiplier:     2,
-}
-
-// GetDefaultDistSenderRetryOptions returns the default retry options for a
-// DistSender. This is helpful for users that want to overwrite a subset of the
-// default options when creating a custom DistSenderContext.
-func GetDefaultDistSenderRetryOptions() retry.Options {
-	return defaultRPCRetryOptions
-}
-
 // A firstRangeMissingError indicates that the first range has not yet
 // been gossiped. This will be the case for a node which hasn't yet
 // joined the gossip network.
@@ -191,7 +174,7 @@ func NewDistSender(ctx *DistSenderContext, gossip *gossip.Gossip) *DistSender {
 	if ctx.TransportFactory != nil {
 		ds.transportFactory = ctx.TransportFactory
 	}
-	ds.rpcRetryOptions = defaultRPCRetryOptions
+	ds.rpcRetryOptions = base.DefaultRetryOptions()
 	if ctx.RPCRetryOptions != nil {
 		ds.rpcRetryOptions = *ctx.RPCRetryOptions
 	}

--- a/kv/local_test_cluster_util.go
+++ b/kv/local_test_cluster_util.go
@@ -21,6 +21,7 @@ import (
 
 	opentracing "github.com/opentracing/opentracing-go"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -56,7 +57,7 @@ func InitSenderForLocalTestCluster(
 	stopper *stop.Stopper,
 	gossip *gossip.Gossip,
 ) client.Sender {
-	retryOpts := GetDefaultDistSenderRetryOptions()
+	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = stopper.ShouldDrain()
 	senderTransportFactory := SenderTransportFactory(tracer, stores)
 	distSender := NewDistSender(&DistSenderContext{

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -917,7 +917,11 @@ func (tc *TxnCoordSender) resendWithTxn(ba roachpb.BatchRequest) (*roachpb.Batch
 	if log.V(1) {
 		log.Infof("%s: auto-wrapping in txn and re-executing: ", ba)
 	}
-	tmpDB := client.NewDBWithPriority(tc, ba.UserPriority)
+	// TODO(bdarnell): need to be able to pass other parts of DBContext
+	// through here.
+	dbCtx := client.DefaultDBContext()
+	dbCtx.UserPriority = ba.UserPriority
+	tmpDB := client.NewDBWithContext(tc, dbCtx)
 	var br *roachpb.BatchResponse
 	err := tmpDB.Txn(func(txn *client.Txn) error {
 		txn.SetDebugName("auto-wrap", 0)

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -70,7 +70,15 @@ func teardownHeartbeats(tc *TxnCoordSender) {
 // createTestDB creates a local test server and starts it. The caller
 // is responsible for stopping the test server.
 func createTestDB(t testing.TB) (*localtestcluster.LocalTestCluster, *TxnCoordSender) {
-	s := &localtestcluster.LocalTestCluster{}
+	return createTestDBWithContext(t, client.DefaultDBContext())
+}
+
+func createTestDBWithContext(
+	t testing.TB, dbCtx client.DBContext,
+) (*localtestcluster.LocalTestCluster, *TxnCoordSender) {
+	s := &localtestcluster.LocalTestCluster{
+		DBContext: &dbCtx,
+	}
 	s.Start(t, testutils.NewNodeTestBaseContext(), InitSenderForLocalTestCluster)
 	return s, s.Sender.(*TxnCoordSender)
 }

--- a/server/admin.go
+++ b/server/admin.go
@@ -810,13 +810,9 @@ func (s *adminServer) waitForStoreFrozen(
 		oks: make(map[roachpb.StoreID]bool),
 	}
 
-	opts := retry.Options{
-		Closer:         s.server.stopper.ShouldDrain(),
-		InitialBackoff: 100 * time.Millisecond,
-		MaxBackoff:     5 * time.Second,
-		Multiplier:     2,
-		MaxRetries:     20,
-	}
+	opts := base.DefaultRetryOptions()
+	opts.Closer = s.server.stopper.ShouldDrain()
+	opts.MaxRetries = 20
 	sem := make(chan struct{}, 256)
 	errChan := make(chan error, 1)
 	sendErr := func(err error) {

--- a/server/node.go
+++ b/server/node.go
@@ -31,6 +31,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
@@ -690,7 +691,9 @@ func (n *Node) recordJoinEvent() {
 	}
 
 	n.stopper.RunWorker(func() {
-		for r := retry.Start(retry.Options{Closer: n.stopper.ShouldStop()}); r.Next(); {
+		retryOpts := base.DefaultRetryOptions()
+		retryOpts.Closer = n.stopper.ShouldStop()
+		for r := retry.Start(retryOpts); r.Next(); {
 			if err := n.ctx.DB.Txn(func(txn *client.Txn) error {
 				return n.eventLogger.InsertEventRecord(txn,
 					logEventType,

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -29,6 +29,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
@@ -83,7 +84,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		g.Start(grpcServer, ln.Addr())
 	}
 	ctx.Gossip = g
-	retryOpts := kv.GetDefaultDistSenderRetryOptions()
+	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = stopper.ShouldDrain()
 	distSender := kv.NewDistSender(&kv.DistSenderContext{
 		Clock:           ctx.Clock,

--- a/server/server.go
+++ b/server/server.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cmux"
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/kv"
@@ -145,7 +146,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	// However, on a single-node setup (such as a test), retries will never
 	// succeed because the only server has been shut down; thus, thus the
 	// DistSender needs to know that it should not retry in this situation.
-	retryOpts := kv.GetDefaultDistSenderRetryOptions()
+	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = stopper.ShouldDrain()
 	s.distSender = kv.NewDistSender(&kv.DistSenderContext{
 		Clock:           s.clock,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"
@@ -227,7 +228,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := StartTestServer(t)
 	defer s.Stop()
-	retryOpts := kv.GetDefaultDistSenderRetryOptions()
+	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = s.stopper.ShouldDrain()
 	ds := kv.NewDistSender(&kv.DistSenderContext{
 		Clock:           s.Clock(),
@@ -323,7 +324,7 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 	for i, tc := range testCases {
 		s := StartTestServer(t)
 		defer s.Stop()
-		retryOpts := kv.GetDefaultDistSenderRetryOptions()
+		retryOpts := base.DefaultRetryOptions()
 		retryOpts.Closer = s.stopper.ShouldDrain()
 		ds := kv.NewDistSender(&kv.DistSenderContext{
 			Clock:           s.Clock(),

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/metric"
-	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
@@ -51,12 +50,6 @@ var errNotRetriable = errors.New("the transaction is not in a retriable state")
 
 const sqlTxnName string = "sql txn"
 const sqlImplicitTxnName string = "sql txn implicit"
-
-var defaultRetryOpt = retry.Options{
-	InitialBackoff: 20 * time.Millisecond,
-	MaxBackoff:     200 * time.Millisecond,
-	Multiplier:     2,
-}
 
 type traceResult struct {
 	tag   string

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -241,18 +241,12 @@ var errDidntUpdateDescriptor = errors.New("didn't update the table descriptor")
 func (s LeaseStore) Publish(
 	tableID sqlbase.ID, update func(*sqlbase.TableDescriptor) error,
 ) (*sqlbase.Descriptor, error) {
-	retryOpts := retry.Options{
-		InitialBackoff: 20 * time.Millisecond,
-		MaxBackoff:     2 * time.Second,
-		Multiplier:     2,
-	}
-
 	errLeaseVersionChanged := errors.New("lease version changed")
 	// Retry while getting errLeaseVersionChanged.
-	for r := retry.Start(retryOpts); r.Next(); {
+	for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 		// Wait until there are no unexpired leases on the previous version
 		// of the table.
-		expectedVersion, err := s.waitForOneVersion(tableID, retryOpts)
+		expectedVersion, err := s.waitForOneVersion(tableID, base.DefaultRetryOptions())
 		if err != nil {
 			return nil, err
 		}

--- a/sql/session.go
+++ b/sql/session.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -249,11 +250,10 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 	}
 	// Execute any schema changes that were scheduled, in the order of the
 	// statements that scheduled them.
-	retryOpt := defaultRetryOpt
 	for _, scEntry := range scc.schemaChangers {
 		sc := &scEntry.sc
 		sc.db = *e.ctx.DB
-		for r := retry.Start(retryOpt); r.Next(); {
+		for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 			if done, err := sc.IsDone(); err != nil {
 				log.Warning(err)
 				break

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -111,7 +111,7 @@ func createTestStoreWithEngine(t testing.TB, eng engine.Engine, clock *hlc.Clock
 		t.Fatal(err)
 	}
 
-	retryOpts := kv.GetDefaultDistSenderRetryOptions()
+	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = stopper.ShouldDrain()
 	distSender := kv.NewDistSender(&kv.DistSenderContext{
 		Clock:             clock,
@@ -512,7 +512,7 @@ func (m *multiTestContext) addStore() {
 		m.storePools = append(m.storePools, storage.NewStorePool(m.gossips[idx], m.clock, m.timeUntilStoreDead, m.clientStopper))
 	}
 	if len(m.dbs) <= idx {
-		retryOpts := kv.GetDefaultDistSenderRetryOptions()
+		retryOpts := base.DefaultRetryOptions()
 		retryOpts.Closer = m.clientStopper.ShouldDrain()
 		m.distSenders = append(m.distSenders,
 			kv.NewDistSender(&kv.DistSenderContext{

--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
@@ -29,14 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
-
-// idAllocationRetryOpts sets the retry options for handling RangeID
-// allocation errors.
-var idAllocationRetryOpts = retry.Options{
-	InitialBackoff: 50 * time.Millisecond,
-	MaxBackoff:     5 * time.Second,
-	Multiplier:     2,
-}
 
 // An idAllocator is used to increment a key in allocation blocks
 // of arbitrary size starting at a minimum ID.
@@ -100,7 +92,7 @@ func (ia *idAllocator) start() {
 					err error
 					res client.KeyValue
 				)
-				for r := retry.Start(idAllocationRetryOpts); r.Next(); {
+				for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 					idKey := ia.idKey.Load().(roachpb.Key)
 					if !ia.stopper.RunTask(func() {
 						res, err = ia.db.Inc(idKey, int64(ia.blockSize))


### PR DESCRIPTION
A notable change in this PR is that backoff times in DistSender have
been reduced to match other comparable retry loops.

This resolves the original motivation for #2500, although that issue has
evolved to encompass other things so I'm leaving it open.

Updates #2500

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6689)

<!-- Reviewable:end -->
