### PR TITLE
acceptance: set high timeout for HTTP client

### DIFF
--- a/acceptance/update_test.go
+++ b/acceptance/update_test.go
@@ -37,7 +37,7 @@ func TestRaftUpdate(t *testing.T) {
 
 func postFreeze(c cluster.Cluster, freeze bool) (server.ClusterFreezeResponse, error) {
 	httpClient := cluster.HTTPClient()
-	httpClient.Timeout = 10 * time.Second
+	httpClient.Timeout = time.Minute
 
 	var resp server.ClusterFreezeResponse
 	err := postJSON(httpClient, c.URL(0), "/_admin/v1/cluster/freeze",


### PR DESCRIPTION
```
update_test.go:54: acceptance/update_test.go:63:
Post https://127.0.0.1:33065/_admin/v1/cluster/freeze:
net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6707)

<!-- Reviewable:end -->
