### PR TITLE
sql: fix a correctness bug in upsert

### DIFF
--- a/sql/tablewriter.go
+++ b/sql/tablewriter.go
@@ -412,7 +412,11 @@ func (tu *tableUpserter) fetchExisting() ([]parser.DTuple, error) {
 			return nil, err
 		}
 
-		rows[rowIdxForPrimaryKey[string(rowPrimaryKey)]] = row
+		// The rows returned by rowFetcher are invalidated after the call to
+		// NextRow, so we have to copy them to save them.
+		rowCopy := make(parser.DTuple, len(row))
+		copy(rowCopy, row)
+		rows[rowIdxForPrimaryKey[string(rowPrimaryKey)]] = rowCopy
 	}
 	return rows, nil
 }

--- a/sql/testdata/upsert
+++ b/sql/testdata/upsert
@@ -123,3 +123,19 @@ INSERT INTO excluded VALUES (1, 1) ON CONFLICT (a) DO UPDATE SET b = excluded.b
 
 statement error column reference "excluded.b" is ambiguous
 UPSERT INTO excluded VALUES (1, 1)
+
+# For #6710. Add an unused column to disable the fast path which doesn't have this bug.
+statement ok
+CREATE TABLE issue_6710 (a INT PRIMARY KEY, b STRING, c INT)
+
+statement ok
+INSERT INTO issue_6710 (a, b) VALUES (1, 'foo'), (2, 'bar')
+
+statement ok
+UPSERT INTO issue_6710 (a, b) VALUES (1, 'test1'), (2, 'test2')
+
+query IT
+SELECT a, b from issue_6710;
+----
+1 test1
+2 test2


### PR DESCRIPTION
The rows returned by rowFetcher are invalidated after the call to NextRow, so we
have to copy them to save them.

Closes #6710.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6714)

<!-- Reviewable:end -->
