### PR TITLE
decimal: Create powers of 10 lookup table for inf.Dec and big.Int

### DIFF
--- a/util/decimal/const.go
+++ b/util/decimal/const.go
@@ -37,8 +37,8 @@ var (
 	decimalCbrtC1    = new(inf.Dec)
 	decimalCbrtC2    = new(inf.Dec)
 	decimalCbrtC3    = new(inf.Dec)
+	decimalE         = new(inf.Dec)
 	// Unused constants for now.
-	// decimalE          = new(inf.Dec)
 	// decimalPi         = new(inf.Dec)
 )
 
@@ -58,9 +58,9 @@ func init() {
 	if _, ok := decimalCbrtC3.SetString(strCbrtC3); !ok {
 		panic("error setting decimalCbrtC3")
 	}
-	// if _, ok := decimalE.SetString(strE); !ok {
-	// 	panic("error setting e")
-	// }
+	if _, ok := decimalE.SetString(strE); !ok {
+		panic("error setting e")
+	}
 	// if _, ok := decimalPi.SetString(strPi); !ok {
 	// 	panic("error setting pi")
 	// }

--- a/util/decimal/decimal.go
+++ b/util/decimal/decimal.go
@@ -25,8 +25,6 @@ import (
 	"gopkg.in/inf.v0"
 )
 
-var e = smallExp(inf.NewDec(1, 0), decimalOne, 1000)
-
 // NewDecFromFloat allocates and returns a new Dec set to the given
 // float64 value. The function will panic if the float is NaN or ±Inf.
 func NewDecFromFloat(f float64) *inf.Dec {
@@ -408,7 +406,7 @@ func Exp(z, n *inf.Dec, s inf.Scale) *inf.Dec {
 		panic("integer out of range")
 	}
 
-	ex := integerPower(z, new(inf.Dec).Set(e), integer, s+2)
+	ex := integerPower(z, new(inf.Dec).Set(decimalE), integer, s+2)
 	return smallExp(ex, y, s-2)
 }
 

--- a/util/decimal/table.go
+++ b/util/decimal/table.go
@@ -1,0 +1,84 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package decimal
+
+import (
+	"fmt"
+	"math/big"
+
+	"gopkg.in/inf.v0"
+)
+
+// tableSize is the magnitude of the maximum power of 10 exponent that is stored
+// in the pow10LookupTable. The table will store both negative and positive powers
+// 10 up to this magnitude. For instance, if the tableSize if 3, then the lookup
+// table will store power of 10 values from 10^-3 to 10^3.
+const tableSize = 32
+
+var pow10LookupTable [2*tableSize + 1]inf.Dec
+
+func init() {
+	tmpInt := new(big.Int)
+	for i := -tableSize; i <= tableSize; i++ {
+		setDecWithPow(&pow10LookupTable[i+tableSize], tmpInt, i)
+	}
+}
+
+// setDecWithPow sets the decimal value to the power of 10 provided. For non-negative values,
+// it guarantees to produce a decimal value with a scale of 0, which means that it's underlying
+// UnscaledBig value will also have a value of 10 to the provided power. A nullable *big.Int can
+// be provided to avoid an allocation during computation.
+func setDecWithPow(dec *inf.Dec, tmpInt *big.Int, pow int) {
+	if pow >= 0 {
+		bi := dec.SetScale(0).UnscaledBig()
+		bi.SetInt64(10)
+		if tmpInt == nil {
+			tmpInt = new(big.Int)
+		}
+		bi.Exp(bi, tmpInt.SetInt64(int64(pow)), nil)
+	} else {
+		dec.SetUnscaled(1).SetScale(inf.Scale(-pow))
+	}
+}
+
+// PowerOfTenDec returns an *inf.Dec with the value 10^pow. It should
+// be treated as immutable.
+//
+// Non-negative powers of 10 will have their value represented in their
+// underlying big.Int with a scale of 0, while negative powers of 10 will
+// have their value represented in their scale with a big.Int value of 1.
+func PowerOfTenDec(pow int) *inf.Dec {
+	if pow >= -tableSize && pow <= tableSize {
+		return &pow10LookupTable[pow+tableSize]
+	}
+	dec := new(inf.Dec)
+	setDecWithPow(dec, nil, pow)
+	return dec
+}
+
+// PowerOfTenInt returns a *big.Int with the value 10^pow. It should
+// be treated as immutable.
+func PowerOfTenInt(pow int) *big.Int {
+	if pow < 0 {
+		panic(fmt.Sprintf("PowerOfTenInt called with negative power: %d", pow))
+	}
+	dec := PowerOfTenDec(pow)
+	if s := dec.Scale(); s != 0 {
+		panic(fmt.Sprintf("PowerOfTenDec(%v) returned decimal with non-zero scale: %d", dec, s))
+	}
+	return dec.UnscaledBig()
+}

--- a/util/decimal/table_test.go
+++ b/util/decimal/table_test.go
@@ -1,0 +1,93 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package decimal
+
+import "testing"
+
+func TestPowerOfTenDec(t *testing.T) {
+	tests := []struct {
+		pow int
+		str string
+	}{
+		{
+			pow: -tableSize - 1,
+			str: "0.000000000000000000000000000000001",
+		},
+		{
+			pow: -5,
+			str: "0.00001",
+		},
+		{
+			pow: -1,
+			str: "0.1",
+		},
+		{
+			pow: 0,
+			str: "1",
+		},
+		{
+			pow: 1,
+			str: "10",
+		},
+		{
+			pow: 5,
+			str: "100000",
+		},
+		{
+			pow: tableSize + 1,
+			str: "1000000000000000000000000000000000",
+		},
+	}
+
+	for i, test := range tests {
+		d := PowerOfTenDec(test.pow)
+		if s := d.String(); s != test.str {
+			t.Errorf("%d: expected PowerOfTenDec(%d) to give %s, got %s", i, test.pow, test.str, s)
+		}
+	}
+}
+
+func TestPowerOfTenInt(t *testing.T) {
+	tests := []struct {
+		pow int
+		str string
+	}{
+		{
+			pow: 0,
+			str: "1",
+		},
+		{
+			pow: 1,
+			str: "10",
+		},
+		{
+			pow: 5,
+			str: "100000",
+		},
+		{
+			pow: tableSize + 1,
+			str: "1000000000000000000000000000000000",
+		},
+	}
+
+	for i, test := range tests {
+		bi := PowerOfTenInt(test.pow)
+		if s := bi.String(); s != test.str {
+			t.Errorf("%d: expected PowerOfTenInt(%d) to give %s, got %s", i, test.pow, test.str, s)
+		}
+	}
+}

--- a/util/encoding/decimal.go
+++ b/util/encoding/decimal.go
@@ -29,12 +29,7 @@ import (
 	"gopkg.in/inf.v0"
 
 	"github.com/cockroachdb/cockroach/util"
-)
-
-var (
-	bigInt10   = big.NewInt(10)
-	bigInt100  = big.NewInt(100)
-	bigInt1000 = big.NewInt(1000)
+	"github.com/cockroachdb/cockroach/util/decimal"
 )
 
 // EncodeDecimalAscending returns the resulting byte slice with the encoded decimal
@@ -595,21 +590,7 @@ func normalizeBigInt(bi *big.Int, copyOnWrite bool, formatted, tmp []byte) *big.
 		if copyOnWrite {
 			bi = new(big.Int)
 		}
-
-		var div *big.Int
-		switch tens {
-		case 1:
-			div = bigInt10
-		case 2:
-			div = bigInt100
-		case 3:
-			div = bigInt1000
-		default:
-			div = big.NewInt(10)
-			pow := big.NewInt(int64(tens))
-			div.Exp(div, pow, nil)
-		}
-		bi.Div(from, div)
+		bi.Div(from, decimal.PowerOfTenInt(tens))
 	}
 	return bi
 }


### PR DESCRIPTION
Fixes #5814.
Closes #5815.

This change creates a powers of 10 lookup table and then uses it where
possible. This allows us to reduce the need to allocate in a few key
places when dealing with decimals.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6716)

<!-- Reviewable:end -->
