### PR TITLE
kv: Consider all errors in getDescriptors retryable

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -635,17 +635,17 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			log.Trace(ctx, "meta descriptor lookup")
 			desc, needAnother, evictToken, pErr = ds.getDescriptors(rs, evictToken, isReverse)
 
-			// getDescriptors may fail retryably if the first range isn't
-			// available via Gossip.
+			// getDescriptors may fail retryably if, for example, the first
+			// range isn't available via Gossip. Assume that all errors at
+			// this level are retryable. Non-retryable errors would be for
+			// things like malformed requests which we should have checked
+			// for before reaching this point.
 			if pErr != nil {
 				log.Trace(ctx, "range descriptor lookup failed: "+pErr.String())
-				if pErr.Retryable {
-					if log.V(1) {
-						log.Warning(pErr)
-					}
-					continue
+				if log.V(1) {
+					log.Warning(pErr)
 				}
-				break
+				continue
 			} else {
 				log.Trace(ctx, "looked up range descriptor")
 			}

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -553,7 +553,7 @@ func TestRetryOnNotLeaderError(t *testing.T) {
 }
 
 // TestRetryOnDescriptorLookupError verifies that the DistSender retries a descriptor
-// lookup on retryable errors.
+// lookup on any error.
 func TestRetryOnDescriptorLookupError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	g, s := makeTestGossip(t)
@@ -565,8 +565,7 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 	}
 
 	pErrs := []*roachpb.Error{
-		roachpb.NewError(errors.New("fatal boom")),
-		roachpb.NewError(&roachpb.RangeKeyMismatchError{}), // retryable
+		roachpb.NewError(errors.New("boom")),
 		nil,
 		nil,
 	}
@@ -588,11 +587,7 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 	}
 	ds := NewDistSender(ctx, g)
 	put := roachpb.NewPut(roachpb.Key("a"), roachpb.MakeValueFromString("value"))
-	// Fatal error on descriptor lookup, propagated to reply.
-	if _, pErr := client.SendWrapped(ds, nil, put); pErr.String() != "fatal boom" {
-		t.Errorf("unexpected error: %s", pErr)
-	}
-	// Retryable error on descriptor lookup, second attempt successful.
+	// Error on descriptor lookup, second attempt successful.
 	if _, pErr := client.SendWrapped(ds, nil, put); pErr != nil {
 		t.Errorf("unexpected error: %s", pErr)
 	}


### PR DESCRIPTION
All errors encountered at this level in our test suite are
retryable (except for one synthesized specifically to test this
feature), and we should generally prefer to catch non-retryable errors
before entering the retry loop.

This is the last place that relies on the generic Retryable interface;
it can be removed after this lands.

Updates #2500

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6727)

<!-- Reviewable:end -->
