### PR TITLE
kv: Set default SendNextTimeout to a reasonable value

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -41,7 +41,9 @@ import (
 
 // Default constants for timeouts.
 const (
-	defaultSendNextTimeout = 10 * time.Second // for now; see #2500
+	// TODO(bdarnell): make SendNextTimeout configurable.
+	// https://github.com/cockroachdb/cockroach/issues/6719
+	defaultSendNextTimeout = 500 * time.Millisecond
 	defaultClientTimeout   = 10 * time.Second
 
 	// The default maximum number of ranges to return from a range


### PR DESCRIPTION
Reverts #2973, which was a workaround for issues that have been more
cleanly resolved in #6688.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6728)

<!-- Reviewable:end -->
