### PR TITLE
sql: fix bug in CHECK expression column resolution

### DIFF
--- a/sql/insert.go
+++ b/sql/insert.go
@@ -351,7 +351,7 @@ func (n *insertNode) Next() bool {
 		// Populate qvals.
 		for ref, qval := range n.qvals {
 			// The colIdx is 0-based, we need to change it to 1-based.
-			ri, has := n.insertColIDtoRowIndex[sqlbase.ColumnID(ref.colIdx+1)]
+			ri, has := n.insertColIDtoRowIndex[n.tableDesc.Columns[ref.colIdx].ID]
 			if has {
 				qval.datum = rowVals[ri]
 			} else {

--- a/sql/testdata/check_constraints
+++ b/sql/testdata/check_constraints
@@ -1,10 +1,13 @@
 #### column CHECK constraints
 
 statement ok
-CREATE TABLE t1 (a INT CHECK (a > 0), b INT CHECK (b < 0))
+CREATE TABLE t1 (a INT CHECK (a > 0), to_delete INT, b INT CHECK (b < 0))
 
 statement ok
-INSERT INTO t1 VALUES (3, -1)
+INSERT INTO t1 VALUES (3, 0, -1)
+
+statement ok
+ALTER TABLE t1 DROP COLUMN to_delete;
 
 statement ok
 INSERT INTO t1 (a, b) VALUES (4, -2)


### PR DESCRIPTION
previously it was assuming that the column ID and the index in the column slice mapped 1:1,
however (as the added test case shows), this is not true (eg if a column is deleted).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6730)

<!-- Reviewable:end -->
