### PR TITLE
rpc: Check stopper.ShouldStop at beginning and end of the loop

### DIFF
--- a/rpc/context.go
+++ b/rpc/context.go
@@ -188,6 +188,14 @@ func (ctx *Context) runHeartbeat(cc *grpc.ClientConn, remoteAddr string) error {
 	var heartbeatTimer timeutil.Timer
 	defer heartbeatTimer.Stop()
 	for {
+		// If we should stop, return immediately. Note that we check this
+		// at the beginning and end of the loop because we may 'continue'
+		// before reaching the end.
+		select {
+		case <-ctx.Stopper.ShouldStop():
+			return nil
+		default:
+		}
 		sendTime := ctx.localClock.PhysicalTime()
 		response, err := ctx.heartbeat(heartbeatClient, request)
 		if err != nil {


### PR DESCRIPTION
If GRPC returns DeadlineExceeded, we continue without checking
ShouldStop, so we could get stuck in this state indefinitely during
shutdown (combined with a listener leak in grpc, fixed by
grpc/grpc-go#684).

Fixes #6593
Fixes #6674
Fixes #6699

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6734)

<!-- Reviewable:end -->
