### PR TITLE
sql: refactor selectNode to separate initialization from plan expansion and execution

### DIFF
--- a/sql/check.go
+++ b/sql/check.go
@@ -44,7 +44,11 @@ func (c *checkHelper) init(p *planner, tableDesc *sqlbase.TableDescriptor) error
 		if err != nil {
 			return err
 		}
-		resolved, err := resolveQNames(raw, []*tableInfo{&table}, c.qvals, &p.qnameVisitor)
+		replaced, err := p.replaceSubqueries(raw, 1)
+		if err != nil {
+			return nil
+		}
+		resolved, err := resolveQNames(replaced, []*tableInfo{&table}, c.qvals, &p.qnameVisitor)
 		if err != nil {
 			return err
 		}

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -68,7 +68,7 @@ func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoComm
 	// this node's initSelect() method both does type checking and also
 	// performs index selection. We cannot perform index selection
 	// properly until the placeholder values are known.
-	_, err = p.SelectClause(&parser.SelectClause{
+	rows, err := p.SelectClause(&parser.SelectClause{
 		Exprs: sqlbase.ColumnsSelectors(rd.fetchCols),
 		From:  []parser.TableExpr{n.Table},
 		Where: n.Where,
@@ -86,30 +86,19 @@ func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoComm
 		editNodeBase: en,
 		tw:           tw,
 	}
+	dn.run.initEditNode(rows)
 	return dn, nil
 }
 
 func (d *deleteNode) expandPlan() error {
-	// TODO(knz): See the comment above in Delete().
-	rows, err := d.p.SelectClause(&parser.SelectClause{
-		Exprs: sqlbase.ColumnsSelectors(d.tw.rd.fetchCols),
-		From:  []parser.TableExpr{d.n.Table},
-		Where: d.n.Where,
-	}, nil, nil, nil)
-	if err != nil {
+	if err := d.rh.expandPlans(); err != nil {
 		return err
 	}
-
-	if err := rows.expandPlan(); err != nil {
-		return err
-	}
-
-	d.run.buildEditNodePlan(&d.editNodeBase, rows, &d.tw)
-	return nil
+	return d.run.expandEditNodePlan(&d.editNodeBase, &d.tw)
 }
 
 func (d *deleteNode) Start() error {
-	if err := d.run.rows.Start(); err != nil {
+	if err := d.run.startEditNode(); err != nil {
 		return err
 	}
 
@@ -117,12 +106,16 @@ func (d *deleteNode) Start() error {
 	// "fast-path" skip to deleting the key ranges without reading them first.
 	// TODO(dt): We could probably be smarter when presented with an index-join,
 	// but this goes away anyway once we push-down more of SQL.
-	sel := d.run.rows.(*selectNode)
-	if scan, ok := sel.table.node.(*scanNode); ok && canDeleteWithoutScan(d.n, scan, &d.tw) {
+	sel := d.run.rows.(*selectTopNode).source.(*selectNode)
+	if scan, ok := sel.source.plan.(*scanNode); ok && canDeleteWithoutScan(d.n, scan, &d.tw) {
 		d.run.fastPath = true
-		d.run.err = d.fastDelete()
+		d.run.err = d.fastDelete(scan)
 		d.run.done = true
 		return d.run.err
+	}
+
+	if err := d.rh.startPlans(); err != nil {
+		return err
 	}
 
 	return d.run.tw.init(d.p.txn)
@@ -190,8 +183,7 @@ func canDeleteWithoutScan(n *parser.Delete, scan *scanNode, td *tableDeleter) bo
 // `fastDelete` skips the scan of rows and just deletes the ranges that
 // `rows` would scan. Should only be used if `canDeleteWithoutScan` indicates
 // that it is safe to do so.
-func (d *deleteNode) fastDelete() error {
-	scan := d.run.rows.(*selectNode).table.node.(*scanNode)
+func (d *deleteNode) fastDelete(scan *scanNode) error {
 	if !scan.initScan() {
 		return scan.err
 	}
@@ -243,7 +235,13 @@ func (d *deleteNode) ExplainPlan(v bool) (name, description string, children []p
 		}
 		fmt.Fprintf(&buf, ")")
 	}
-	return "delete", buf.String(), []planNode{d.run.rows}
+
+	subplans := []planNode{d.run.rows}
+	for _, e := range d.rh.exprs {
+		subplans = d.p.collectSubqueryPlans(e, subplans)
+	}
+
+	return "delete", buf.String(), subplans
 }
 
 func (d *deleteNode) ExplainTypes(regTypes func(string, string)) {

--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -25,48 +25,16 @@ import (
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 )
 
-// distinct constructs a distinctNode.
-func (*planner) distinct(n *parser.SelectClause, p planNode) planNode {
-	if !n.Distinct {
-		return p
-	}
-	d := &distinctNode{
-		plan:       p,
-		suffixSeen: make(map[string]struct{}),
-	}
-	ordering := p.Ordering()
-	if !ordering.isEmpty() {
-		d.columnsInOrder = make([]bool, len(p.Columns()))
-		for colIdx := range ordering.exactMatchCols {
-			if colIdx >= len(d.columnsInOrder) {
-				// If the exact-match column is not part of the output, we can safely ignore it.
-				continue
-			}
-			d.columnsInOrder[colIdx] = true
-		}
-		for _, c := range ordering.ordering {
-			if c.colIdx >= len(d.columnsInOrder) {
-				// Cannot use sort order. This happens when the
-				// columns used for sorting are not part of the output.
-				// e.g. SELECT a FROM t ORDER BY c.
-				d.columnsInOrder = nil
-				break
-			}
-			d.columnsInOrder[c.colIdx] = true
-		}
-	}
-	return d
-}
-
-// distinctNode de-duplicates row returned by a wrapped planNode.
+// distinctNode de-duplicates rows returned by a wrapped planNode.
 type distinctNode struct {
 	plan planNode
+	top  *selectTopNode
 	// All the columns that are part of the Sort. Set to nil if no-sort, or
 	// sort used an expression that was not part of the requested column set.
 	columnsInOrder []bool
-	// encoding of the columnsInOrder columns for the previous row.
+	// Encoding of the columnsInOrder columns for the previous row.
 	prefixSeen []byte
-	// encoding of the non-columnInOrder columns for rows sharing the same
+	// Encoding of the non-columnInOrder columns for rows sharing the same
 	// prefixSeen value.
 	suffixSeen map[string]struct{}
 	err        error
@@ -74,11 +42,78 @@ type distinctNode struct {
 	debugVals  debugValues
 }
 
-func (n *distinctNode) expandPlan() error       { return n.plan.expandPlan() }
-func (n *distinctNode) Start() error            { return n.plan.Start() }
-func (n *distinctNode) Columns() []ResultColumn { return n.plan.Columns() }
-func (n *distinctNode) Values() parser.DTuple   { return n.plan.Values() }
-func (n *distinctNode) Ordering() orderingInfo  { return n.plan.Ordering() }
+// distinct constructs a distinctNode.
+func (*planner) Distinct(n *parser.SelectClause) *distinctNode {
+	if !n.Distinct {
+		return nil
+	}
+	return &distinctNode{}
+}
+
+// wrap connects the distinctNode to its source planNode.
+// invoked by selectTopNode.expandPlan() prior
+// to invoking distinctNode.expandPlan() below.
+func (n *distinctNode) wrap(plan planNode) planNode {
+	if n == nil {
+		return plan
+	}
+	n.plan = plan
+	return n
+}
+
+func (n *distinctNode) expandPlan() error {
+	// At this point the selectTopNode has already expanded the plans
+	// upstream of distinctNode.
+	ordering := n.plan.Ordering()
+	if !ordering.isEmpty() {
+		n.columnsInOrder = make([]bool, len(n.plan.Columns()))
+		for colIdx := range ordering.exactMatchCols {
+			if colIdx >= len(n.columnsInOrder) {
+				// If the exact-match column is not part of the output, we can safely ignore it.
+				continue
+			}
+			n.columnsInOrder[colIdx] = true
+		}
+		for _, c := range ordering.ordering {
+			if c.colIdx >= len(n.columnsInOrder) {
+				// Cannot use sort order. This happens when the
+				// columns used for sorting are not part of the output.
+				// e.g. SELECT a FROM t ORDER BY c.
+				n.columnsInOrder = nil
+				break
+			}
+			n.columnsInOrder[c.colIdx] = true
+		}
+	}
+	return nil
+}
+
+func (n *distinctNode) Start() error {
+	n.suffixSeen = make(map[string]struct{})
+	return n.plan.Start()
+}
+
+// setTop connects the distinctNode back to the selectTopNode that
+// caused its existence. This is needed because the distinctNode needs
+// to refer to other nodes in the selectTopNode before its
+// expandPlan() method has ran and its child plan is known and
+// connected.
+func (n *distinctNode) setTop(top *selectTopNode) {
+	if n != nil {
+		n.top = top
+	}
+}
+
+func (n *distinctNode) Columns() []ResultColumn {
+	if n.plan != nil {
+		return n.plan.Columns()
+	}
+	// Pre-prepare: not connected yet. Ask the top select node.
+	return n.top.Columns()
+}
+
+func (n *distinctNode) Values() parser.DTuple  { return n.plan.Values() }
+func (n *distinctNode) Ordering() orderingInfo { return n.plan.Ordering() }
 
 func (n *distinctNode) MarkDebug(mode explainMode) {
 	if mode != explainDebug {

--- a/sql/expr_filter.go
+++ b/sql/expr_filter.go
@@ -76,6 +76,10 @@ func (v *varConvertVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pa
 		if _, isValArg := expr.(parser.ValArg); isValArg {
 			return false, expr
 		}
+		// Ignore sub-queries
+		if _, isSubquery := expr.(*subquery); isSubquery {
+			return false, expr
+		}
 
 		ok, converted := v.conv(varExpr)
 		if !ok {

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -34,8 +34,6 @@ type insertNode struct {
 	insertRows   parser.SelectStatement
 	checkHelper  checkHelper
 
-	desiredTypes []parser.Datum // This will go away when we only type check once.
-
 	insertCols            []sqlbase.ColumnDescriptor
 	insertColIDtoRowIndex map[sqlbase.ColumnID]int
 	tw                    tableWriter
@@ -209,29 +207,20 @@ func (p *planner) Insert(
 		insertRows:            insertRows,
 		insertCols:            ri.insertCols,
 		insertColIDtoRowIndex: ri.insertColIDtoRowIndex,
-		desiredTypes:          desiredTypesFromSelect,
-		tw:                    tw,
+		tw: tw,
 	}
+
 	if err := in.checkHelper.init(p, en.tableDesc); err != nil {
 		return nil, err
 	}
+
+	in.run.initEditNode(rows)
+
 	return in, nil
 }
 
 func (n *insertNode) expandPlan() error {
-	// TODO(knz): We need to re-run makePlan here again
-	// because that's when we can expand sub-queries.
-	// This goes away when sub-query expansion is moved
-	// to the Start() method of the insertRows object.
-
-	// Transform the values into a rows object. This expands SELECT statements or
-	// generates rows from the values contained within the query.
-	rows, err := n.p.newPlan(n.insertRows, n.desiredTypes, false)
-	if err != nil {
-		return err
-	}
-
-	if err := rows.expandPlan(); err != nil {
+	if err := n.rh.expandPlans(); err != nil {
 		return err
 	}
 
@@ -258,12 +247,15 @@ func (n *insertNode) expandPlan() error {
 		}
 	}
 
-	n.run.buildEditNodePlan(&n.editNodeBase, rows, n.tw)
-	return nil
+	return n.run.expandEditNodePlan(&n.editNodeBase, n.tw)
 }
 
 func (n *insertNode) Start() error {
-	if err := n.run.rows.Start(); err != nil {
+	if err := n.rh.startPlans(); err != nil {
+		return err
+	}
+
+	if err := n.run.startEditNode(); err != nil {
 		return err
 	}
 
@@ -508,7 +500,18 @@ func (n *insertNode) ExplainPlan(v bool) (name, description string, children []p
 		}
 		fmt.Fprintf(&buf, ")")
 	}
-	return "insert", buf.String(), []planNode{n.run.rows}
+
+	subplans := []planNode{n.run.rows}
+	for _, e := range n.defaultExprs {
+		subplans = n.p.collectSubqueryPlans(e, subplans)
+	}
+	for _, e := range n.checkHelper.exprs {
+		subplans = n.p.collectSubqueryPlans(e, subplans)
+	}
+	for _, e := range n.rh.exprs {
+		subplans = n.p.collectSubqueryPlans(e, subplans)
+	}
+	return "insert", buf.String(), subplans
 }
 
 func (n *insertNode) ExplainTypes(regTypes func(string, string)) {

--- a/sql/join.go
+++ b/sql/join.go
@@ -148,7 +148,9 @@ func (n *indexJoinNode) DebugValues() debugValues {
 }
 
 func (n *indexJoinNode) expandPlan() error {
-	// TODO(knz): Some code from makeIndexJoin() above really belongs here.
+	// If we arrive here, selectNode's expandPlan has run already and
+	// created the indexJoinNode by means of makeIndexJoin() above.
+	// We thus now need to expand the sub-nodes.
 	if err := n.table.expandPlan(); err != nil {
 		return err
 	}

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -17,52 +17,162 @@
 package sql
 
 import (
+	"bytes"
 	"fmt"
 	"math"
-	"strconv"
 
 	"github.com/cockroachdb/cockroach/sql/parser"
 )
 
-// evalLimit evaluates the Count and Offset fields. If Count is missing, the
-// value is MaxInt64. If Offset is missing, the value is 0
-func (p *planner) evalLimit(limit *parser.Limit) (count, offset int64, err error) {
-	count = math.MaxInt64
-	offset = 0
+// limitNode represents a node that limits the number of rows
+// returned or only return them past a given number (offset).
+type limitNode struct {
+	p          *planner
+	top        *selectTopNode
+	plan       planNode
+	countExpr  parser.TypedExpr
+	offsetExpr parser.TypedExpr
+	count      int64
+	offset     int64
+	rowIndex   int64
+	explain    explainMode
+	debugVals  debugValues
+}
 
-	if limit == nil {
-		return count, offset, nil
+// limit constructs a limitNode based on the LIMIT and OFFSET clauses.
+func (p *planner) Limit(n *parser.Limit) (*limitNode, error) {
+	if n == nil || (n.Count == nil && n.Offset == nil) {
+		// No LIMIT nor OFFSET; there is nothing special to do.
+		return nil, nil
 	}
+
+	res := limitNode{p: p}
 
 	data := []struct {
 		name string
 		src  parser.Expr
-		dst  *int64
+		dst  *parser.TypedExpr
 	}{
-		{"LIMIT", limit.Count, &count},
-		{"OFFSET", limit.Offset, &offset},
+		{"LIMIT", n.Count, &res.countExpr},
+		{"OFFSET", n.Offset, &res.offsetExpr},
 	}
 
 	for _, datum := range data {
 		if datum.src != nil {
-			typedSrc, err := parser.TypeCheckAndRequire(datum.src, p.evalCtx.Args,
+			replaced, err := p.replaceSubqueries(datum.src, 1)
+			if err != nil {
+				return nil, err
+			}
+			typedExpr, err := parser.TypeCheckAndRequire(replaced, p.evalCtx.Args,
 				parser.TypeInt, datum.name)
 			if err != nil {
-				return 0, 0, err
+				return nil, err
 			}
-
-			normalized, err := p.parser.NormalizeExpr(p.evalCtx, typedSrc)
+			normalized, err := p.parser.NormalizeExpr(p.evalCtx, typedExpr)
 			if err != nil {
-				return 0, 0, err
+				return nil, err
+			}
+			*datum.dst = normalized
+		}
+	}
+	return &res, nil
+}
+
+func (n *limitNode) wrap(plan planNode) planNode {
+	if n == nil {
+		return plan
+	}
+	n.plan = plan
+	return n
+}
+
+func (n *limitNode) expandPlan() error {
+	// We do not need to recurse into the child node here; selectTopNode
+	// does this for us.
+
+	if err := n.p.expandSubqueryPlans(n.countExpr); err != nil {
+		return err
+	}
+	return n.p.expandSubqueryPlans(n.offsetExpr)
+}
+
+func (n *limitNode) Start() error {
+	if err := n.plan.Start(); err != nil {
+		return err
+	}
+
+	if err := n.evalLimit(); err != nil {
+		return err
+	}
+
+	// Propagate the local limit upstream.
+	// Note that this must be called *after* all upstream nodes have been started.
+	n.plan.SetLimitHint(getLimit(n.count, n.offset), false /* hard */)
+
+	return nil
+}
+
+// estimateLimit returns the Count and Offset fields if they are constants,
+// otherwise MaxInt64, 0. Used by index selection.
+// This must be called after type checking and constant folding.
+func (n *limitNode) estimateLimit() (count, offset int64) {
+	if n == nil {
+		return math.MaxInt64, 0
+	}
+
+	n.count = math.MaxInt64
+	n.offset = 0
+
+	data := []struct {
+		src parser.TypedExpr
+		dst *int64
+	}{
+		{n.countExpr, &n.count},
+		{n.offsetExpr, &n.offset},
+	}
+	for _, datum := range data {
+		if datum.src != nil {
+			// Use simple integer datum if available.
+			// The limit can be a simple DInt here either because it was
+			// entered as such in the query, or as a result of constant
+			// folding prior to type checking.
+			if d, ok := datum.src.(*parser.DInt); ok {
+				*datum.dst = int64(*d)
+			}
+		}
+	}
+	return n.count, n.offset
+}
+
+// evalLimit evaluates the Count and Offset fields. If Count is missing, the
+// value is MaxInt64. If Offset is missing, the value is 0
+func (n *limitNode) evalLimit() error {
+	n.count = math.MaxInt64
+	n.offset = 0
+
+	data := []struct {
+		name string
+		src  parser.TypedExpr
+		dst  *int64
+	}{
+		{"LIMIT", n.countExpr, &n.count},
+		{"OFFSET", n.offsetExpr, &n.offset},
+	}
+
+	for _, datum := range data {
+		if datum.src != nil {
+			if err := n.p.startSubqueryPlans(datum.src); err != nil {
+				return err
 			}
 
-			if p.evalCtx.PrepareOnly {
-				continue
-			}
-
-			dstDatum, err := normalized.Eval(p.evalCtx)
+			normalized, err := n.p.parser.NormalizeExpr(n.p.evalCtx, datum.src)
 			if err != nil {
-				return 0, 0, err
+				return err
+			}
+
+			dstDatum, err := normalized.Eval(n.p.evalCtx)
+			if err != nil {
+				return err
 			}
 
 			if dstDatum == parser.DNull {
@@ -73,43 +183,44 @@ func (p *planner) evalLimit(limit *parser.Limit) (count, offset int64, err error
 			dstDInt := *dstDatum.(*parser.DInt)
 			val := int64(dstDInt)
 			if val < 0 {
-				return 0, 0, fmt.Errorf("negative value for %s", datum.name)
+				return fmt.Errorf("negative value for %s", datum.name)
 			}
 			*datum.dst = val
 		}
 	}
-	return count, offset, nil
+	return nil
 }
 
-// limit constructs a limitNode based on the LIMIT and OFFSET clauses.
-func (p *planner) limit(count, offset int64, plan planNode) planNode {
-	if count == math.MaxInt64 && offset == 0 {
-		return plan
+func (n *limitNode) ExplainTypes(regTypes func(string, string)) {
+	if n.countExpr != nil {
+		regTypes("count", parser.AsStringWithFlags(n.countExpr, parser.FmtShowTypes))
 	}
-
-	if count != math.MaxInt64 {
-		plan.SetLimitHint(offset+count, false /* hard */)
+	if n.offsetExpr != nil {
+		regTypes("offset", parser.AsStringWithFlags(n.offsetExpr, parser.FmtShowTypes))
 	}
-
-	return &limitNode{plan: plan, count: count, offset: offset}
 }
 
-type limitNode struct {
-	plan      planNode
-	count     int64
-	offset    int64
-	rowIndex  int64
-	explain   explainMode
-	debugVals debugValues
+// setTop connects the limitNode back to the selectTopNode that caused
+// its existence. This is needed because the limitNode needs to refer
+// to other nodes in the selectTopNode before its expandPlan() method
+// has ran and its child plan is known and connected.
+func (n *limitNode) setTop(top *selectTopNode) {
+	if n != nil {
+		n.top = top
+	}
 }
 
-func (n *limitNode) ExplainTypes(f func(string, string)) { n.plan.ExplainTypes(f) }
-func (n *limitNode) expandPlan() error                   { return n.plan.expandPlan() }
-func (n *limitNode) Err() error                          { return n.plan.Err() }
-func (n *limitNode) Start() error                        { return n.plan.Start() }
-func (n *limitNode) Columns() []ResultColumn             { return n.plan.Columns() }
-func (n *limitNode) Values() parser.DTuple               { return n.plan.Values() }
-func (n *limitNode) Ordering() orderingInfo              { return n.plan.Ordering() }
+func (n *limitNode) Columns() []ResultColumn {
+	if n.plan != nil {
+		return n.plan.Columns()
+	}
+	// Pre-prepare: not connected yet. Ask the top select node.
+	return n.top.Columns()
+}
+
+func (n *limitNode) Err() error             { return n.plan.Err() }
+func (n *limitNode) Values() parser.DTuple  { return n.plan.Values() }
+func (n *limitNode) Ordering() orderingInfo { return n.plan.Ordering() }
 
 func (n *limitNode) MarkDebug(mode explainMode) {
 	if mode != explainDebug {
@@ -162,14 +273,46 @@ func (n *limitNode) Next() bool {
 }
 
 func (n *limitNode) ExplainPlan(_ bool) (string, string, []planNode) {
-	var count string
-	if n.count == math.MaxInt64 {
-		count = "ALL"
-	} else {
-		count = strconv.FormatInt(n.count, 10)
+	var buf bytes.Buffer
+	subplans := []planNode{n.plan}
+	prefix := ""
+	if n.countExpr != nil {
+		buf.WriteString("count: ")
+		n.countExpr.Format(&buf, parser.FmtSimple)
+		subplans = n.p.collectSubqueryPlans(n.countExpr, subplans)
+		prefix = ", "
 	}
-
-	return "limit", fmt.Sprintf("count: %s, offset: %d", count, n.offset), []planNode{n.plan}
+	if n.offsetExpr != nil {
+		buf.WriteString(prefix)
+		buf.WriteString("offset: ")
+		n.offsetExpr.Format(&buf, parser.FmtSimple)
+		subplans = n.p.collectSubqueryPlans(n.offsetExpr, subplans)
+	}
+	return "limit", buf.String(), subplans
 }
 
-func (*limitNode) SetLimitHint(_ int64, _ bool) {}
+// getLimit computes the actual number of rows to request from the
+// data source to honour both the required count and offset together.
+// This also ensures that the resulting number of rows does not
+// overflow.
+func getLimit(count, offset int64) int64 {
+	if offset > math.MaxInt64-count {
+		count = math.MaxInt64 - offset
+	}
+	return count + offset
+}
+
+func (n *limitNode) SetLimitHint(count int64, soft bool) {
+	// A higher-level limitNode or EXPLAIN is pushing a limit down onto
+	// this node. Accept it unless the local limit is definitely
+	// smaller, in which case we propagate that as a hard limit instead.
+	// TODO(radu): we may get a smaller "soft" limit from the upper node
+	// and we may have a larger "hard" limit locally. In general, it's
+	// not clear which of those results in less work.
+	hintCount := count
+	if hintCount > n.count {
+		hintCount = n.count
+		soft = false
+	}
+	n.plan.SetLimitHint(getLimit(hintCount, n.offset), soft)
+}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -78,14 +78,26 @@ type planNode interface {
 	// SetLimitHint tells this node to optimize things under the assumption that
 	// we will only need the first `numRows` rows.
 	//
+	// The special value math.MaxInt64 indicates "no limit".
+	//
 	// If soft is true, this is a "soft" limit and is only a hint; the node must
 	// still be able to produce all results if requested.
 	//
 	// If soft is false, this is a "hard" limit and is a promise that Next will
 	// never be called more than numRows times.
 	//
+	// The action of calling this method triggers limit-based query plan
+	// optimizations, e.g. in selectNode.expandPlan(). The primary user
+	// is limitNode.Start() after it has fully evaluated the limit and
+	// offset expressions. EXPLAIN also does this, see
+	// explainTypesNode.expandPlan() and explainPlanNode.expandPlan().
+	//
+	// TODO(radu) Arguably, this interface has room for improvement.  A
+	// limitNode may have a hard limit locally which is larger than the
+	// soft limit propagated up by nodes downstream. We may want to
+	// improve this API to pass both the soft and hard limit.
+	//
 	// Available during/after newPlan().
-	// TODO(knz) This should only be used during expandPlan().
 	SetLimitHint(numRows int64, soft bool)
 
 	// expandPlan finalizes type checking of placeholders and expands
@@ -181,6 +193,7 @@ var _ planNode = &limitNode{}
 var _ planNode = &scanNode{}
 var _ planNode = &sortNode{}
 var _ planNode = &valuesNode{}
+var _ planNode = &selectTopNode{}
 var _ planNode = &selectNode{}
 var _ planNode = &unionNode{}
 var _ planNode = &emptyNode{}

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -55,9 +55,11 @@ type planner struct {
 	params parameters
 
 	// Avoid allocations by embedding commonly used visitors.
-	isAggregateVisitor isAggregateVisitor
-	subqueryVisitor    subqueryVisitor
-	qnameVisitor       qnameVisitor
+	isAggregateVisitor          isAggregateVisitor
+	subqueryVisitor             subqueryVisitor
+	subqueryPlanVisitor         subqueryPlanVisitor
+	collectSubqueryPlansVisitor collectSubqueryPlansVisitor
+	qnameVisitor                qnameVisitor
 
 	execCtx *ExecutorContext
 }

--- a/sql/select.go
+++ b/sql/select.go
@@ -28,16 +28,23 @@ import (
 // tableInfo contains the information for table used by a select statement. It can be an actual
 // table, or a "virtual table" which is the result of a subquery.
 type tableInfo struct {
-	// node which can be used to retrieve the data (normally a scanNode). For performance purposes,
-	// this node can be aware of the filters, grouping etc.
-	node planNode
-
 	// alias (if no alias is given and the source is a table, this is the table name)
 	alias string
 
 	// resultColumns which match the node.Columns() 1-to-1. However the column names might be
 	// different if the statement renames them using AS.
 	columns []ResultColumn
+}
+
+// tableSource contains the tableInfo and planNode for a data source
+// for selectNode.
+type tableSource struct {
+	// info containing the result columns and the table alias for qname resolution.
+	info tableInfo
+
+	// plan which can be used to retrieve the data (normally a scanNode). For performance purposes,
+	// this node can be aware of the filters, grouping etc.
+	plan planNode
 }
 
 // selectNode encapsulates the core logic of a select statement: retrieving filtered results from
@@ -47,32 +54,58 @@ type tableInfo struct {
 type selectNode struct {
 	planner *planner
 
-	table tableInfo
+	// top refers to the surrounding selectTopNode.
+	top *selectTopNode
+
+	// source describes where the data is coming from.
+	// populated initially by initFrom().
+	// potentially modified by index selection.
+	source tableSource
 
 	// Map of qvalues encountered in expressions.
+	// populated by addRender() / checkRenderStar()
+	// as invoked initially by initTargets() and initWhere()
+	// then extended by the groupNode and sortNode.
 	qvals qvalMap
 
-	err error
-
 	// Rendering expressions for rows and corresponding output columns.
+	// populated by addRender()
+	// as invoked initially by initTargets() and initWhere().
+	// sortNode peeks into the render array defined by initTargets() as an optimization.
+	// sortNode adds extra selectNode renders for sort columns not requested as select targets.
+	// groupNode copies/extends the render array defined by initTargets()
+	// will add extra selectNode renders for the aggregation sources.
 	render  []parser.TypedExpr
 	columns []ResultColumn
 
-	// The rendered row, with one value for each render expression.
-	row parser.DTuple
-
-	// Filtering expression for rows.
-	filter parser.TypedExpr
-
-	// The number of initial columns - before adding any internal render targets for grouping or
-	// ordering. The original columns are columns[:numOriginalCols], the internally added ones are
+	// The number of initial columns - before adding any internal render
+	// targets for grouping, filtering or ordering. The original columns
+	// are columns[:numOriginalCols], the internally added ones are
 	// columns[numOriginalCols:].
+	// populated by initTargets(), which thus must be obviously vcalled before initWhere()
+	// and the other initializations that may add render columns.
 	numOriginalCols int
 
+	// Filtering expression for rows.
+	// populated initially by initWhere().
+	// modified by index selection (split between scan filter and post-indexjoin filter).
+	filter parser.TypedExpr
+
+	// ordering indicates the order of returned rows.
+	// initially suggested by the GROUP BY and ORDER BY clauses;
+	// modified by index selection.
+	ordering orderingInfo
+
+	// support attributes for EXPLAIN(DEBUG)
 	explain   explainMode
 	debugVals debugValues
 
-	ordering orderingInfo
+	// The rendered row, with one value for each render expression.
+	// populated by Next().
+	row parser.DTuple
+
+	// Last error encountered during Next().
+	err error
 }
 
 func (s *selectNode) Columns() []ResultColumn {
@@ -95,7 +128,7 @@ func (s *selectNode) MarkDebug(mode explainMode) {
 		panic(fmt.Sprintf("unknown debug mode %d", mode))
 	}
 	s.explain = mode
-	s.table.node.MarkDebug(mode)
+	s.source.plan.MarkDebug(mode)
 }
 
 func (s *selectNode) DebugValues() debugValues {
@@ -105,32 +138,36 @@ func (s *selectNode) DebugValues() debugValues {
 	return s.debugVals
 }
 
-func (s *selectNode) expandPlan() error {
-	// TODO(knz) Some code from the constructor in Select() and initSelect() really
-	// belongs here.
-	return s.table.node.expandPlan()
-}
-
 func (s *selectNode) Start() error {
-	return s.table.node.Start()
+	if err := s.source.plan.Start(); err != nil {
+		return err
+	}
+
+	for _, e := range s.render {
+		if err := s.planner.startSubqueryPlans(e); err != nil {
+			return err
+		}
+	}
+	return s.planner.startSubqueryPlans(s.filter)
 }
 
 func (s *selectNode) Next() bool {
 	for {
-		if !s.table.node.Next() {
+		if !s.source.plan.Next() {
+			s.err = s.source.plan.Err()
 			return false
 		}
 
 		if s.explain == explainDebug {
-			s.debugVals = s.table.node.DebugValues()
+			s.debugVals = s.source.plan.DebugValues()
 
 			if s.debugVals.output != debugValueRow {
 				// Let the debug values pass through.
 				return true
 			}
 		}
-		row := s.table.node.Values()
-		s.qvals.populateQVals(&s.table, row)
+		row := s.source.plan.Values()
+		s.qvals.populateQVals(&s.source.info, row)
 		passesFilter, err := sqlbase.RunFilter(s.filter, s.planner.evalCtx)
 		if err != nil {
 			s.err = err
@@ -150,10 +187,7 @@ func (s *selectNode) Next() bool {
 }
 
 func (s *selectNode) Err() error {
-	if s.err != nil {
-		return s.err
-	}
-	return s.table.node.Err()
+	return s.err
 }
 
 func (s *selectNode) ExplainTypes(regTypes func(string, string)) {
@@ -166,8 +200,16 @@ func (s *selectNode) ExplainTypes(regTypes func(string, string)) {
 }
 
 func (s *selectNode) ExplainPlan(v bool) (name, description string, children []planNode) {
-	if !v {
-		return s.table.node.ExplainPlan(v)
+	subplans := []planNode{s.source.plan}
+
+	subplans = s.planner.collectSubqueryPlans(s.filter, subplans)
+
+	for _, e := range s.render {
+		subplans = s.planner.collectSubqueryPlans(e, subplans)
+	}
+
+	if len(subplans) == 1 && !v {
+		return s.source.plan.ExplainPlan(v)
 	}
 
 	var buf bytes.Buffer
@@ -178,12 +220,13 @@ func (s *selectNode) ExplainPlan(v bool) (name, description string, children []p
 		}
 		fmt.Fprintf(&buf, "%s", col.Name)
 	}
-	fmt.Fprintf(&buf, ")@%s", s.table.alias)
-	return "select", buf.String(), []planNode{s.table.node}
+	fmt.Fprintf(&buf, ")@%s", s.source.info.alias)
+
+	return "render/filter", buf.String(), subplans
 }
 
 func (s *selectNode) SetLimitHint(numRows int64, soft bool) {
-	s.table.node.SetLimitHint(numRows, soft || s.filter != nil)
+	s.source.plan.SetLimitHint(numRows, soft || s.filter != nil)
 }
 
 // Select selects rows from a SELECT/UNION/VALUES, ordering and/or limiting them.
@@ -213,6 +256,7 @@ func (p *planner) Select(n *parser.Select, desiredTypes []parser.Datum, autoComm
 		// Select can potentially optimize index selection if it's being ordered,
 		// so we allow it to do its own sorting.
 		return p.SelectClause(s, orderBy, limit, desiredTypes)
+
 	// TODO(dan): Union can also do optimizations when it has an ORDER BY, but
 	// currently expects the ordering to be done externally, so we let it fall
 	// through. Instead of continuing this special casing, it may be worth
@@ -227,11 +271,13 @@ func (p *planner) Select(n *parser.Select, desiredTypes []parser.Datum, autoComm
 		if err != nil {
 			return nil, err
 		}
-		count, offset, err := p.evalLimit(limit)
+		limit, err := p.Limit(limit)
 		if err != nil {
 			return nil, err
 		}
-		return p.limit(count, offset, sort.wrap(plan)), nil
+		result := &selectTopNode{source: plan, sort: sort, limit: limit}
+		limit.setTop(result)
+		return result, nil
 	}
 }
 
@@ -280,53 +326,80 @@ func (p *planner) SelectClause(parsed *parser.SelectClause, orderBy parser.Order
 		s.filter = group.isNotNullFilter(s.filter)
 	}
 
+	limitPlan, err := p.Limit(limit)
+	if err != nil {
+		return nil, err
+	}
+	distinctPlan := p.Distinct(parsed)
+
+	result := &selectTopNode{
+		source:   s,
+		group:    group,
+		sort:     sort,
+		distinct: distinctPlan,
+		limit:    limitPlan,
+	}
+	s.top = result
+	limitPlan.setTop(result)
+	distinctPlan.setTop(result)
+
+	return result, nil
+}
+
+func (s *selectNode) expandPlan() error {
+	// Expand the sub-query plans in the sub-expressions, if any.
+	if err := s.planner.expandSubqueryPlans(s.filter); err != nil {
+		return err
+	}
+	for _, e := range s.render {
+		if err := s.planner.expandSubqueryPlans(e); err != nil {
+			return err
+		}
+	}
+
 	// Get the ordering for index selection (if any).
 	var ordering columnOrdering
 	var grouping bool
 
-	if group != nil {
-		ordering = group.desiredOrdering
+	if s.top.group != nil {
+		ordering = s.top.group.desiredOrdering
 		grouping = true
-	} else if sort != nil {
-		ordering = sort.Ordering().ordering
+	} else if s.top.sort != nil {
+		ordering = s.top.sort.Ordering().ordering
 	}
 
-	limitCount, limitOffset, err := p.evalLimit(limit)
-	if err != nil {
-		return nil, err
-	}
+	// Estimate the limit parameters. We can't full eval them just yet,
+	// because evaluation requires running potential sub-queries, which
+	// cannot occur during expandPlan.
+	limitCount, limitOffset := s.top.limit.estimateLimit()
 
-	if scan, ok := s.table.node.(*scanNode); ok {
+	if scan, ok := s.source.plan.(*scanNode); ok {
 		// Find the set of columns that we actually need values for. This is an
 		// optimization to avoid unmarshaling unnecessary values and is also
 		// used for index selection.
-		neededCols := make([]bool, len(s.table.columns))
+		neededCols := make([]bool, len(s.source.info.columns))
 		for i := range neededCols {
-			_, ok := s.qvals[columnRef{&s.table, i}]
+			_, ok := s.qvals[columnRef{&s.source.info, i}]
 			neededCols[i] = ok
 		}
 		scan.setNeededColumns(neededCols)
 
-		// If we are only preparing, the filter expression can contain
-		// unexpanded subqueries which are not supported by splitFilter.
-		if !p.evalCtx.PrepareOnly {
-			// Compute a filter expression for the scan node.
-			convFunc := func(expr parser.VariableExpr) (bool, parser.VariableExpr) {
-				qval := expr.(*qvalue)
-				if qval.colRef.table != &s.table {
-					// TODO(radu): when we will support multiple tables, this
-					// will be a valid case.
-					panic("scan qvalue refers to unknown table")
-				}
-				return true, scan.filterVars.IndexedVar(qval.colRef.colIdx)
+		// Compute a filter expression for the scan node.
+		convFunc := func(expr parser.VariableExpr) (bool, parser.VariableExpr) {
+			qval := expr.(*qvalue)
+			if qval.colRef.table != &s.source.info {
+				// TODO(radu): when we will support multiple tables, this
+				// will be a valid case.
+				panic("scan qvalue refers to unknown table")
 			}
+			return true, scan.filterVars.IndexedVar(qval.colRef.colIdx)
+		}
 
-			scan.filter, s.filter = splitFilter(s.filter, convFunc)
-			if s.filter != nil {
-				// Right now we support only one table, so the entire expression
-				// should be converted.
-				panic(fmt.Sprintf("residual filter `%s` (scan filter `%s`)", s.filter, scan.filter))
-			}
+		scan.filter, s.filter = splitFilter(s.filter, convFunc)
+		if s.filter != nil {
+			// Right now we support only one table, so the entire expression
+			// should be converted.
+			panic(fmt.Sprintf("residual filter `%s` (scan filter `%s`)", s.filter, scan.filter))
 		}
 
 		var analyzeOrdering analyzeOrderingFn
@@ -357,26 +430,37 @@ func (p *planner) SelectClause(parsed *parser.SelectClause, orderBy parser.Order
 
 		plan, err := selectIndex(scan, analyzeOrdering, preferOrderMatchingIndex)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		// Update s.table with the new plan.
-		s.table.node = plan
+		// Update s.source.info with the new plan.
+		s.source.plan = plan
 	}
 
-	s.ordering = s.computeOrdering(s.table.node.Ordering())
+	// If the source node is not a scanNode, expand its plan.
+	// (If it is a scanNode, it is already "expanded" and
+	// we do not want to expand the sub-queries in its filters
+	// here because they are shared with the selectNode and the selectNode
+	// already cares of expanding the sub-queries.)
+	if _, isScan := s.source.plan.(*scanNode); !isScan {
+		if err := s.source.plan.expandPlan(); err != nil {
+			return err
+		}
+	}
 
-	// Wrap this node as necessary.
-	return p.limit(limitCount, limitOffset, p.distinct(parsed, sort.wrap(group.wrap(s)))), nil
+	s.ordering = s.computeOrdering(s.source.plan.Ordering())
+
+	return nil
 }
 
 // initFrom initializes the table node, given the parsed select expression
 func (s *selectNode) initFrom(p *planner, parsed *parser.SelectClause) error {
 	from := parsed.From
 	var colAlias parser.NameList
+	var err error
 	switch len(from) {
 	case 0:
-		s.table.node = &emptyNode{results: true}
+		s.source.plan = &emptyNode{results: true}
 
 	case 1:
 		ate, ok := from[0].(*parser.AliasedTableExpr)
@@ -388,11 +472,11 @@ func (s *selectNode) initFrom(p *planner, parsed *parser.SelectClause) error {
 		case *parser.QualifiedName:
 			// Usual case: a table.
 			scan := p.Scan()
-			s.table.alias, s.err = scan.initTable(p, expr, ate.Hints)
-			if s.err != nil {
-				return s.err
+			s.source.info.alias, err = scan.initTable(p, expr, ate.Hints)
+			if err != nil {
+				return err
 			}
-			s.table.node = scan
+			s.source.plan = scan
 
 		case *parser.Subquery:
 			// We have a subquery (this includes a simple "VALUES").
@@ -400,9 +484,9 @@ func (s *selectNode) initFrom(p *planner, parsed *parser.SelectClause) error {
 				return fmt.Errorf("subquery in FROM must have an alias")
 			}
 
-			s.table.node, s.err = p.newPlan(expr.Select, nil, false)
-			if s.err != nil {
-				return s.err
+			s.source.plan, err = p.newPlan(expr.Select, nil, false)
+			if err != nil {
+				return err
 			}
 
 		default:
@@ -411,31 +495,30 @@ func (s *selectNode) initFrom(p *planner, parsed *parser.SelectClause) error {
 
 		if ate.As.Alias != "" {
 			// If an alias was specified, use that.
-			s.table.alias = string(ate.As.Alias)
+			s.source.info.alias = string(ate.As.Alias)
 		}
 		colAlias = ate.As.Cols
 	default:
-		s.err = util.UnimplementedWithIssueErrorf(2970, "JOINs and SELECTs from multiple tables "+
+		return util.UnimplementedWithIssueErrorf(2970, "JOINs and SELECTs from multiple tables "+
 			"are not yet supported: %s", from)
-		return s.err
 	}
 
-	s.table.columns = s.table.node.Columns()
+	s.source.info.columns = s.source.plan.Columns()
 	if len(colAlias) > 0 {
 		// Make a copy of the slice since we are about to modify the contents.
-		s.table.columns = append([]ResultColumn(nil), s.table.columns...)
+		s.source.info.columns = append([]ResultColumn(nil), s.source.info.columns...)
 
 		// The column aliases can only refer to explicit columns.
 		for colIdx, aliasIdx := 0, 0; aliasIdx < len(colAlias); colIdx++ {
-			if colIdx >= len(s.table.columns) {
+			if colIdx >= len(s.source.info.columns) {
 				return util.Errorf(
 					"table \"%s\" has %d columns available but %d columns specified",
-					s.table.alias, aliasIdx, len(colAlias))
+					s.source.info.alias, aliasIdx, len(colAlias))
 			}
-			if s.table.columns[colIdx].hidden {
+			if s.source.info.columns[colIdx].hidden {
 				continue
 			}
-			s.table.columns[colIdx].Name = string(colAlias[aliasIdx])
+			s.source.info.columns[colIdx].Name = string(colAlias[aliasIdx])
 			aliasIdx++
 		}
 	}
@@ -451,8 +534,8 @@ func (s *selectNode) initTargets(targets parser.SelectExprs, desiredTypes []pars
 		if len(desiredTypes) > i {
 			desiredType = desiredTypes[i]
 		}
-		if s.err = s.addRender(target, desiredType); s.err != nil {
-			return s.err
+		if err := s.addRender(target, desiredType); err != nil {
+			return err
 		}
 	}
 	// `groupBy` or `orderBy` may internally add additional columns which we
@@ -471,34 +554,34 @@ func (s *selectNode) initWhere(where *parser.Where) error {
 	}
 
 	var untypedFilter parser.Expr
-	untypedFilter, s.err = s.planner.expandSubqueries(where.Expr, 1)
-	if s.err != nil {
-		return s.err
+	var err error
+	untypedFilter, err = s.planner.replaceSubqueries(where.Expr, 1)
+	if err != nil {
+		return err
 	}
 
-	untypedFilter, s.err = s.resolveQNames(untypedFilter)
-	if s.err != nil {
-		return s.err
+	untypedFilter, err = s.resolveQNames(untypedFilter)
+	if err != nil {
+		return err
 	}
 
-	s.filter, s.err = parser.TypeCheckAndRequire(untypedFilter, s.planner.evalCtx.Args,
+	s.filter, err = parser.TypeCheckAndRequire(untypedFilter, s.planner.evalCtx.Args,
 		parser.TypeBool, "WHERE")
-	if s.err != nil {
-		return s.err
+	if err != nil {
+		return err
 	}
 
 	// Normalize the expression (this will also evaluate any branches that are
 	// constant).
-	s.filter, s.err = s.planner.parser.NormalizeExpr(s.planner.evalCtx, s.filter)
-	if s.err != nil {
-		return s.err
+	s.filter, err = s.planner.parser.NormalizeExpr(s.planner.evalCtx, s.filter)
+	if err != nil {
+		return err
 	}
 
 	// Make sure there are no aggregation functions in the filter (after subqueries have been
 	// expanded).
 	if s.planner.aggregateInExpr(s.filter) {
-		s.err = fmt.Errorf("aggregate functions are not allowed in WHERE")
-		return s.err
+		return fmt.Errorf("aggregate functions are not allowed in WHERE")
 	}
 
 	return nil
@@ -561,9 +644,8 @@ func (s *selectNode) addRender(target parser.SelectExpr, desiredType parser.Datu
 	// outputName will be empty if the target is not aliased.
 	outputName := string(target.As)
 
-	if isStar, cols, typedExprs, err := checkRenderStar(target, &s.table, s.qvals); err != nil {
-		s.err = err
-		return s.err
+	if isStar, cols, typedExprs, err := checkRenderStar(target, &s.source.info, s.qvals); err != nil {
+		return err
 	} else if isStar {
 		s.columns = append(s.columns, cols...)
 		s.render = append(s.render, typedExprs...)
@@ -577,25 +659,22 @@ func (s *selectNode) addRender(target parser.SelectExpr, desiredType parser.Datu
 
 	// Resolve qualified names. This has the side-effect of normalizing any
 	// qualified name found.
-	var resolved parser.Expr
-	var err error
-	if resolved, s.err = s.resolveQNames(target.Expr); s.err != nil {
-		return s.err
+	replaced, err := s.planner.replaceSubqueries(target.Expr, 1)
+	if err != nil {
+		return err
 	}
-	if resolved, s.err = s.planner.expandSubqueries(resolved, 1); s.err != nil {
-		return s.err
+	resolved, err := s.resolveQNames(replaced)
+	if err != nil {
+		return err
 	}
-
 	typedResolved, err := parser.TypeCheck(resolved, s.planner.evalCtx.Args, desiredType)
 	if err != nil {
-		s.err = err
-		return s.err
+		return err
 	}
 
 	normalized, err := s.planner.parser.NormalizeExpr(s.planner.evalCtx, typedResolved)
 	if err != nil {
-		s.err = err
-		return s.err
+		return err
 	}
 	s.render = append(s.render, normalized)
 
@@ -670,7 +749,7 @@ func (s *selectNode) computeOrdering(fromOrder orderingInfo) orderingInfo {
 	// The rows from the index are ordered by k then by v, but since k is an exact match
 	// column the results are also ordered just by v.
 	for colIdx := range fromOrder.exactMatchCols {
-		colRef := columnRef{&s.table, colIdx}
+		colRef := columnRef{&s.source.info, colIdx}
 		if renderIdx, ok := s.findRenderIndexForCol(colRef); ok {
 			ordering.addExactMatchColumn(renderIdx)
 		}
@@ -685,7 +764,7 @@ func (s *selectNode) computeOrdering(fromOrder orderingInfo) orderingInfo {
 	// The rows from the index are ordered by k then by v. We cannot make any use of this
 	// ordering as an ordering on v.
 	for _, colOrder := range fromOrder.ordering {
-		colRef := columnRef{&s.table, colOrder.colIdx}
+		colRef := columnRef{&s.source.info, colOrder.colIdx}
 		renderIdx, ok := s.findRenderIndexForCol(colRef)
 		if !ok {
 			return ordering

--- a/sql/select_qvalue.go
+++ b/sql/select_qvalue.go
@@ -225,7 +225,7 @@ func (s *selectNode) resolveQNames(expr parser.Expr) (parser.Expr, error) {
 	if s.planner != nil {
 		v = &s.planner.qnameVisitor
 	}
-	return resolveQNames(expr, []*tableInfo{&s.table}, s.qvals, v)
+	return resolveQNames(expr, []*tableInfo{&s.source.info}, s.qvals, v)
 }
 
 // resolveQNames walks the provided expression and resolves all qualified

--- a/sql/select_qvalue_test.go
+++ b/sql/select_qvalue_test.go
@@ -31,9 +31,9 @@ func testInitDummySelectNode(desc *sqlbase.TableDescriptor) *selectNode {
 
 	sel := &selectNode{}
 	sel.qvals = make(qvalMap)
-	sel.table.node = scan
-	sel.table.alias = desc.Name
-	sel.table.columns = scan.Columns()
+	sel.source.plan = scan
+	sel.source.info.alias = desc.Name
+	sel.source.info.columns = scan.Columns()
 
 	return sel
 }
@@ -62,7 +62,7 @@ func TestRetryResolveQNames(t *testing.T) {
 		if len(s.qvals) != 1 {
 			t.Fatalf("%d: expected 1 qvalue, but found %d", i, len(s.qvals))
 		}
-		if _, ok := s.qvals[columnRef{&s.table, 0}]; !ok {
+		if _, ok := s.qvals[columnRef{&s.source.info, 0}]; !ok {
 			t.Fatalf("%d: unable to find qvalue for column 0 (a)", i)
 		}
 	}

--- a/sql/select_top.go
+++ b/sql/select_top.go
@@ -1,0 +1,165 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package sql
+
+import "github.com/cockroachdb/cockroach/sql/parser"
+
+// selectTopNode encapsulate the whole logic of a select statement.
+// This exposes the selectNode, groupNode, sortNode, distinctNode and limitNode
+// side-by-side so that they can "see" each other during query optimization.
+type selectTopNode struct {
+	// The various nodes involved in obtaining the results.
+	source   planNode
+	group    *groupNode
+	sort     *sortNode
+	distinct *distinctNode
+	limit    *limitNode
+	// The result node that actually runs the query.
+	// Populated during expandPlan() by connecting the nodes above
+	// together.
+	plan planNode
+}
+
+func (n *selectTopNode) ExplainTypes(f func(string, string)) {
+	if n.plan == nil {
+		// The sub-nodes are not connected yet.
+		// Ask them for typing individually.
+		if n.limit != nil {
+			n.limit.ExplainTypes(f)
+		}
+		if n.distinct != nil {
+			n.distinct.ExplainTypes(f)
+		}
+		if n.sort != nil {
+			n.sort.ExplainTypes(f)
+		}
+		if n.group != nil {
+			n.group.ExplainTypes(f)
+		}
+
+		// The source is always reported as sub-plan by ExplainPlan,
+		// so it will explain its own types.
+	}
+}
+
+func (n *selectTopNode) SetLimitHint(numRows int64, soft bool) {
+	n.plan.SetLimitHint(numRows, soft)
+}
+
+func (n *selectTopNode) expandPlan() error {
+	if n.plan != nil {
+		panic("can't expandPlan twice!")
+	}
+
+	var squash bool
+
+	n.plan = n.source
+	if err := n.source.expandPlan(); err != nil {
+		return err
+	}
+
+	n.plan = n.group.wrap(n.plan)
+	if n.group != nil {
+		if err := n.group.expandPlan(); err != nil {
+			return err
+		}
+	}
+
+	squash, n.plan = n.sort.wrap(n.plan)
+	if squash {
+		n.sort = nil
+	}
+	if n.sort != nil {
+		if err := n.sort.expandPlan(); err != nil {
+			return err
+		}
+	}
+
+	n.plan = n.distinct.wrap(n.plan)
+	if n.distinct != nil {
+		if err := n.distinct.expandPlan(); err != nil {
+			return err
+		}
+	}
+
+	n.plan = n.limit.wrap(n.plan)
+	if n.limit != nil {
+		if err := n.limit.expandPlan(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (n *selectTopNode) ExplainPlan(v bool) (name, description string, subplans []planNode) {
+	if !v {
+		return n.plan.ExplainPlan(v)
+	}
+
+	if n.plan != nil {
+		subplans = []planNode{n.plan}
+	} else {
+		// We are not connected yet, but we may still be interested in the
+		// sub-query plans. Get them.
+		subplans = []planNode{}
+		if n.limit != nil {
+			_, _, plans := n.limit.ExplainPlan(false)
+			subplans = append(subplans, plans[1:]...)
+		}
+		if n.distinct != nil {
+			_, _, plans := n.distinct.ExplainPlan(false)
+			subplans = append(subplans, plans[1:]...)
+		}
+		if n.sort != nil {
+			_, _, plans := n.sort.ExplainPlan(false)
+			subplans = append(subplans, plans[1:]...)
+		}
+		if n.group != nil {
+			_, _, plans := n.group.ExplainPlan(false)
+			subplans = append(subplans, plans[1:]...)
+		}
+		subplans = append(subplans, n.source)
+	}
+	return "select", "", subplans
+}
+
+func (n *selectTopNode) Columns() []ResultColumn {
+	// sort, group and source may have different ideas about the
+	// result columns. Ask them in turn.
+	// (We cannot ask n.plan because it may not be connected yet.)
+	if n.sort != nil {
+		return n.sort.Columns()
+	}
+	if n.group != nil {
+		return n.group.Columns()
+	}
+	return n.source.Columns()
+}
+
+func (n *selectTopNode) Ordering() orderingInfo {
+	if n.plan == nil {
+		return n.source.Ordering()
+	}
+	return n.plan.Ordering()
+}
+
+func (n *selectTopNode) MarkDebug(mode explainMode) { n.plan.MarkDebug(mode) }
+func (n *selectTopNode) Start() error               { return n.plan.Start() }
+func (n *selectTopNode) Next() bool                 { return n.plan.Next() }
+func (n *selectTopNode) Values() parser.DTuple      { return n.plan.Values() }
+func (n *selectTopNode) DebugValues() debugValues   { return n.plan.DebugValues() }
+func (n *selectTopNode) Err() error                 { return n.plan.Err() }

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"container/heap"
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -28,6 +29,22 @@ import (
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 )
+
+// sortNode represents a node that sorts the rows returned by its
+// sub-node.
+type sortNode struct {
+	plan     planNode
+	columns  []ResultColumn
+	ordering columnOrdering
+	err      error
+
+	needSort     bool
+	sortStrategy sortingStrategy
+	valueIter    valueIterator
+
+	explain   explainMode
+	debugVals debugValues
+}
 
 // orderBy constructs a sortNode based on the ORDER BY clause.
 //
@@ -92,7 +109,7 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, error)
 				if err := qname.NormalizeColumnName(); err != nil {
 					return nil, err
 				}
-				if qname.Table() == "" || sqlbase.EqualName(s.table.alias, qname.Table()) {
+				if qname.Table() == "" || sqlbase.EqualName(s.source.info.alias, qname.Table()) {
 					qnameCol := sqlbase.NormalizeName(qname.Column())
 					for j, r := range s.render {
 						if qval, ok := r.(*qvalue); ok {
@@ -123,7 +140,7 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, error)
 				//
 				//   SELECT a FROM t ORDER by b
 				//   SELECT a, b FROM t ORDER by a+b
-				if err := s.addRender(parser.SelectExpr{Expr: expr}, parser.TypeInt); err != nil {
+				if err := s.addRender(parser.SelectExpr{Expr: expr}, nil); err != nil {
 					return nil, err
 				}
 				index = len(s.columns) - 1
@@ -166,20 +183,6 @@ func colIndex(numOriginalCols int, expr parser.Expr) (int, error) {
 		// expr doesn't look like a col index (i.e. not a constant).
 		return -1, nil
 	}
-}
-
-type sortNode struct {
-	plan     planNode
-	columns  []ResultColumn
-	ordering columnOrdering
-	err      error
-
-	needSort     bool
-	sortStrategy sortingStrategy
-	valueIter    valueIterator
-
-	explain   explainMode
-	debugVals debugValues
 }
 
 func (n *sortNode) Columns() []ResultColumn {
@@ -226,7 +229,10 @@ func (n *sortNode) ExplainPlan(_ bool) (name, description string, children []pla
 	}
 
 	var buf bytes.Buffer
-	columns := n.plan.Columns()
+	var columns []ResultColumn
+	if n.plan != nil {
+		columns = n.plan.Columns()
+	}
 	n.Ordering().Format(&buf, columns)
 
 	switch ss := n.sortStrategy.(type) {
@@ -247,17 +253,22 @@ func (n *sortNode) SetLimitHint(numRows int64, soft bool) {
 		// The limit is only useful to the wrapped node if we don't need to sort.
 		n.plan.SetLimitHint(numRows, soft)
 	} else {
-		v := &valuesNode{ordering: n.ordering}
-		if soft {
-			n.sortStrategy = newIterativeSortStrategy(v)
-		} else {
-			n.sortStrategy = newSortTopKStrategy(v, numRows)
+		// The special value math.MaxInt64 means "no limit".
+		if numRows != math.MaxInt64 {
+			v := &valuesNode{ordering: n.ordering}
+			if soft {
+				n.sortStrategy = newIterativeSortStrategy(v)
+			} else {
+				n.sortStrategy = newSortTopKStrategy(v, numRows)
+			}
 		}
 	}
 }
 
 // wrap the supplied planNode with the sortNode if sorting is required.
-func (n *sortNode) wrap(plan planNode) planNode {
+// The first returned value is "true" if the sort node can be squashed
+// in the selectTopNode (sorting unneeded).
+func (n *sortNode) wrap(plan planNode) (bool, planNode) {
 	if n != nil {
 		// Check to see if the requested ordering is compatible with the existing
 		// ordering.
@@ -269,26 +280,28 @@ func (n *sortNode) wrap(plan planNode) planNode {
 		if match < len(n.ordering) {
 			n.plan = plan
 			n.needSort = true
-			return n
+			return false, n
 		}
 
 		if len(n.columns) < len(plan.Columns()) {
 			// No sorting required, but we have to strip off the extra render
 			// expressions we added.
 			n.plan = plan
-			return n
+			return false, n
+		}
+
+		if log.V(2) {
+			log.Infof("Sort: no sorting required")
 		}
 	}
 
-	if log.V(2) {
-		log.Infof("Sort: no sorting required")
-	}
-	return plan
+	return true, plan
 }
 
 func (n *sortNode) expandPlan() error {
-	// TODO(knz) Some code from orderBy() above really belongs here.
-	return n.plan.expandPlan()
+	// We do not need to recurse into the child node here; selectTopNode
+	// does this for us.
+	return nil
 }
 
 func (n *sortNode) Start() error {

--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -17,100 +17,109 @@
 package sql
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/sql/parser"
 )
 
-func (p *planner) expandSubqueries(expr parser.Expr, columns int) (parser.Expr, error) {
-	p.subqueryVisitor = subqueryVisitor{planner: p, columns: columns}
-	p.subqueryVisitor.path = p.subqueryVisitor.pathBuf[:0]
-	expr, _ = parser.WalkExpr(&p.subqueryVisitor, expr)
-	return expr, p.subqueryVisitor.err
+// subquery represents a subquery expression in an expression tree
+// after it has been converted to a query plan. It is carried
+// in the expression tree from the point type checking occurs to
+// the point the query starts execution / evaluation.
+type subquery struct {
+	typ            parser.Datum
+	subquery       *parser.Subquery
+	execMode       subqueryExecMode
+	wantNormalized bool
+	plan           planNode
+	result         parser.Datum
+	err            error
 }
 
-type subqueryVisitor struct {
-	*planner
-	columns int
-	path    []parser.Expr // parent expressions
-	pathBuf [4]parser.Expr
-	err     error
+type subqueryExecMode int
+
+const (
+	// Sub-query is argument to EXISTS. Only 0 or 1 row is expected.
+	// Result type is Bool.
+	execModeExists subqueryExecMode = iota
+	// Sub-query is argument to IN. Any number of rows expected. Result
+	// type is tuple of rows. As a special case, if there is only one
+	// column selected, the result is a tuple of the selected values
+	// (instead of a tuple of 1-tuples).
+	execModeAllRows
+	// Sub-query is argument to another function. Exactly 1 row
+	// expected. Result type is tuple of columns, unless there is
+	// exactly 1 column in which case the result type is that column's
+	// type.
+	execModeOneRow
+)
+
+var _ parser.TypedExpr = &subquery{}
+var _ parser.VariableExpr = &subquery{}
+
+func (s *subquery) Format(buf *bytes.Buffer, f parser.FmtFlags) {
+	if s.execMode == execModeExists {
+		buf.WriteString("EXISTS ")
+	}
+	if f == parser.FmtShowTypes {
+		// TODO(knz/nvanbenschoten) It is not possible to extract types
+		// from the subquery using Format, because type checking does not
+		// replace the sub-expressions of a SelectClause node in-place.
+		f = parser.FmtSimple
+	}
+	s.subquery.Format(buf, f)
 }
 
-var _ parser.Visitor = &subqueryVisitor{}
+func (s *subquery) String() string { return parser.AsString(s) }
 
-func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
-	if v.err != nil {
-		return false, expr
-	}
-	v.path = append(v.path, expr)
+func (s *subquery) Walk(v parser.Visitor) parser.Expr {
+	return s
+}
 
-	var exists *parser.ExistsExpr
-	subquery, ok := expr.(*parser.Subquery)
-	if !ok {
-		exists, ok = expr.(*parser.ExistsExpr)
-		if !ok {
-			return true, expr
-		}
-		subquery, ok = exists.Subquery.(*parser.Subquery)
-		if !ok {
-			return true, expr
-		}
-	}
+func (s *subquery) Variable() {}
 
-	// Calling newPlan() might recursively invoke expandSubqueries, so we need a
-	// copy of the planner in order for there to have a separate subqueryVisitor.
-	// TODO(nvanbenschoten) We should propagate a desired type here.
-	// TODO(knz) the instantiation of the subquery's select node should be moved
-	//     to the TypeCheck() method once the prepare and execute phase are separated
-	//     for select nodes.
-	planMaker := *v.planner
-	plan, err := planMaker.newPlan(subquery.Select, nil, false)
-	if err != nil {
-		return false, expr
-	}
+func (s *subquery) TypeCheck(args parser.MapArgs, desired parser.Datum) (parser.TypedExpr, error) {
+	// TODO(knz): if/when type checking can be extracted from the
+	// newPlan recursion, we can propagate the desired type to the
+	// sub-query. For now, the type is simply derived during the subquery node
+	// creation by looking at the result column types.
 
-	if v.evalCtx.PrepareOnly {
-		return false, expr
-	}
+	// TODO(nvanbenschoten) Type checking for the comparison operator(s)
+	// should take this new node into account. In particular it should
+	// check that the tuple types match pairwise.
+	return s, nil
+}
 
-	// TODO(knz) This is really not the right place to do this.
-	if v.err = plan.expandPlan(); v.err != nil {
-		return false, expr
-	}
-	if v.err = plan.Start(); v.err != nil {
-		return false, expr
-	}
+func (s *subquery) ReturnType() parser.Datum { return s.typ }
 
-	if exists != nil {
+func (s *subquery) Eval(_ parser.EvalContext) (parser.Datum, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.result == nil {
+		panic("subquery was not pre-evaluated properly")
+	}
+	return s.result, s.err
+}
+
+func (s *subquery) doEval() (parser.Datum, error) {
+	var result parser.Datum
+	switch s.execMode {
+	case execModeExists:
 		// For EXISTS expressions, all we want to know is if there is at least one
 		// result.
-		if plan.Next() {
-			return true, parser.MakeDBool(true)
+		if s.plan.Next() {
+			result = parser.MakeDBool(true)
 		}
-		v.err = plan.Err()
-		if v.err != nil {
-			return false, expr
+		if result == nil {
+			result = parser.MakeDBool(false)
 		}
-		return true, parser.MakeDBool(false)
-	}
 
-	columns, multipleRows := v.getSubqueryContext()
-	if n := len(plan.Columns()); columns != n {
-		switch columns {
-		case 1:
-			v.err = fmt.Errorf("subquery must return only one column, found %d", n)
-		default:
-			v.err = fmt.Errorf("subquery must return %d columns, found %d", columns, n)
-		}
-		return true, expr
-	}
-
-	var result parser.Expr
-	if multipleRows {
+	case execModeAllRows:
 		var rows parser.DTuple
-		for plan.Next() {
-			values := plan.Values()
+		for s.plan.Next() {
+			values := s.plan.Values()
 			switch len(values) {
 			case 1:
 				// This seems hokey, but if we don't do this then the subquery expands
@@ -126,12 +135,15 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 				rows = append(rows, &valuesCopy)
 			}
 		}
-		rows.Normalize()
+		if s.wantNormalized {
+			rows.Normalize()
+		}
 		result = &rows
-	} else {
+
+	case execModeOneRow:
 		result = parser.DNull
-		for plan.Next() {
-			values := plan.Values()
+		for s.plan.Next() {
+			values := s.plan.Values()
 			switch len(values) {
 			case 1:
 				result = values[0]
@@ -140,18 +152,199 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 				copy(valuesCopy, values)
 				result = &valuesCopy
 			}
-			if plan.Next() {
-				v.err = fmt.Errorf("more than one row returned by a subquery used as an expression")
-				return false, expr
+			if s.plan.Next() {
+				return nil, fmt.Errorf("more than one row returned by a subquery used as an expression")
 			}
 		}
 	}
 
-	v.err = plan.Err()
+	if err := s.plan.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// subqueryPlanVisitor is responsible for acting on the query plan
+// that implements the sub-query, after it has been populated by
+// subqueryVisitor.  This visitor supports both expanding, starting
+// and evaluating the sub-plans in one recursion.
+type subqueryPlanVisitor struct {
+	doExpand bool
+	doStart  bool
+	doEval   bool
+	err      error
+}
+
+var _ parser.Visitor = &subqueryPlanVisitor{}
+
+func (v *subqueryPlanVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
 	if v.err != nil {
 		return false, expr
 	}
-	return true, result
+	if sq, ok := expr.(*subquery); ok {
+		if v.doExpand {
+			v.err = sq.plan.expandPlan()
+		}
+		if v.err == nil && v.doStart {
+			v.err = sq.plan.Start()
+		}
+		if v.err == nil && v.doEval {
+			sq.result, sq.err = sq.doEval()
+			if sq.err != nil {
+				v.err = sq.err
+			}
+		}
+		return false, expr
+	}
+	return true, expr
+}
+
+func (v *subqueryPlanVisitor) VisitPost(expr parser.Expr) parser.Expr { return expr }
+
+func (p *planner) expandSubqueryPlans(expr parser.Expr) error {
+	if expr == nil {
+		return nil
+	}
+	p.subqueryPlanVisitor = subqueryPlanVisitor{doExpand: true}
+	_, _ = parser.WalkExpr(&p.subqueryPlanVisitor, expr)
+	return p.subqueryPlanVisitor.err
+}
+
+func (p *planner) startSubqueryPlans(expr parser.Expr) error {
+	if expr == nil {
+		return nil
+	}
+	// We also run and pre-evaluate the subqueries during start,
+	// so as to avoid re-running the sub-query for every row
+	// in the results of the surrounding planNode.
+	p.subqueryPlanVisitor = subqueryPlanVisitor{doStart: true, doEval: true}
+	_, _ = parser.WalkExpr(&p.subqueryPlanVisitor, expr)
+	return p.subqueryPlanVisitor.err
+}
+
+// collectSubqueryPlansVisitor gathers all the planNodes implementing
+// sub-queries in a given expression. This is used by EXPLAIN to show
+// the sub-plans.
+type collectSubqueryPlansVisitor struct {
+	plans []planNode
+}
+
+var _ parser.Visitor = &collectSubqueryPlansVisitor{}
+
+func (v *collectSubqueryPlansVisitor) VisitPre(expr parser.Expr) (
+	recurse bool, newExpr parser.Expr) {
+	if sq, ok := expr.(*subquery); ok {
+		if sq.plan == nil {
+			panic("cannot collect the sub-plans before they were expanded")
+		}
+		v.plans = append(v.plans, sq.plan)
+		return false, expr
+	}
+	return true, expr
+}
+
+func (v *collectSubqueryPlansVisitor) VisitPost(expr parser.Expr) parser.Expr { return expr }
+
+func (p *planner) collectSubqueryPlans(expr parser.Expr, result []planNode) []planNode {
+	if expr == nil {
+		return result
+	}
+	p.collectSubqueryPlansVisitor = collectSubqueryPlansVisitor{plans: result}
+	_, _ = parser.WalkExpr(&p.collectSubqueryPlansVisitor, expr)
+	return p.collectSubqueryPlansVisitor.plans
+}
+
+// subqueryVisitor replaces parser.Subquery syntax nodes by a
+// sql.subquery node and an initial query plan for running the
+// sub-query.
+type subqueryVisitor struct {
+	*planner
+	columns int
+	path    []parser.Expr // parent expressions
+	pathBuf [4]parser.Expr
+	err     error
+}
+
+var _ parser.Visitor = &subqueryVisitor{}
+
+func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
+	if v.err != nil {
+		return false, expr
+	}
+
+	if _, ok := expr.(*subquery); ok {
+		// We already replaced this one; do nothing.
+		return false, expr
+	}
+
+	v.path = append(v.path, expr)
+
+	var exists *parser.ExistsExpr
+	sq, ok := expr.(*parser.Subquery)
+	if !ok {
+		exists, ok = expr.(*parser.ExistsExpr)
+		if !ok {
+			return true, expr
+		}
+		sq, ok = exists.Subquery.(*parser.Subquery)
+		if !ok {
+			return true, expr
+		}
+	}
+
+	planMaker := *v.planner
+	plan, err := planMaker.newPlan(sq.Select, nil, false)
+	if err != nil {
+		v.err = err
+		return false, expr
+	}
+
+	result := &subquery{subquery: sq, plan: plan}
+
+	if exists != nil {
+		result.execMode = execModeExists
+		result.typ = parser.TypeBool
+	} else {
+		wantedNumColumns, ctxIsInExpr := v.getSubqueryContext()
+
+		// First check that the number of columns match.
+		cols := plan.Columns()
+		if numColumns := len(cols); wantedNumColumns != numColumns {
+			switch wantedNumColumns {
+			case 1:
+				v.err = fmt.Errorf("subquery must return only one column, found %d",
+					numColumns)
+			default:
+				v.err = fmt.Errorf("subquery must return %d columns, found %d",
+					wantedNumColumns, numColumns)
+			}
+			return false, expr
+		}
+
+		// Decide how the sub-query will be evaluated.
+		if ctxIsInExpr {
+			result.execMode = execModeAllRows
+			result.wantNormalized = true
+		} else {
+			result.execMode = execModeOneRow
+		}
+
+		if wantedNumColumns == 1 && !ctxIsInExpr {
+			// This seems hokey, but if we don't do this then the subquery expands
+			// to a tuple of tuples instead of a tuple of values and an expression
+			// like "k IN (SELECT foo FROM bar)" will fail because we're comparing
+			// a single value against a tuple.
+			result.typ = cols[0].Typ
+		} else {
+			colTypes := make(parser.DTuple, wantedNumColumns)
+			for i, col := range cols {
+				colTypes[i] = col.Typ
+			}
+			result.typ = &colTypes
+		}
+	}
+
+	return false, result
 }
 
 func (v *subqueryVisitor) VisitPost(expr parser.Expr) parser.Expr {
@@ -161,11 +354,26 @@ func (v *subqueryVisitor) VisitPost(expr parser.Expr) parser.Expr {
 	return expr
 }
 
-// getSubqueryContext returns the number of columns and rows the subquery is
-// allowed to have.
-func (v *subqueryVisitor) getSubqueryContext() (columns int, multipleRows bool) {
+func (p *planner) replaceSubqueries(expr parser.Expr, columns int) (parser.Expr, error) {
+	p.subqueryVisitor = subqueryVisitor{planner: p, columns: columns}
+	p.subqueryVisitor.path = p.subqueryVisitor.pathBuf[:0]
+	expr, _ = parser.WalkExpr(&p.subqueryVisitor, expr)
+	return expr, p.subqueryVisitor.err
+}
+
+// getSubqueryContext returns:
+// - the desired number of columns;
+// - whether the sub-query is operand of a IN/NOT IN expression.
+func (v *subqueryVisitor) getSubqueryContext() (columns int, ctxIsInExpr bool) {
 	for i := len(v.path) - 1; i >= 0; i-- {
 		switch e := v.path[i].(type) {
+		case *parser.ExistsExpr:
+			continue
+		case *parser.Subquery:
+			continue
+		case *parser.ParenExpr:
+			continue
+
 		case *parser.ComparisonExpr:
 			// The subquery must occur on the right hand side of the comparison.
 			//
@@ -181,14 +389,23 @@ func (v *subqueryVisitor) getSubqueryContext() (columns int, multipleRows bool) 
 				columns = len(*t)
 			}
 
-			multipleRows = false
+			ctxIsInExpr = false
 			switch e.Operator {
 			case parser.In, parser.NotIn:
-				multipleRows = true
+				ctxIsInExpr = true
 			}
 
-			return columns, multipleRows
+			return columns, ctxIsInExpr
+
+		default:
+			// Any other expr that has this sub-query as operand
+			// is expecting a single value.
+			return 1, false
 		}
 	}
+
+	// We have not encountered any non-paren, non-IN expression so far,
+	// so the outer context is informing us of the desired number of
+	// columns.
 	return v.columns, false
 }

--- a/sql/testdata/explain
+++ b/sql/testdata/explain
@@ -7,16 +7,18 @@ Level  Type  Description
 query ITTT colnames
 EXPLAIN (PLAN, VERBOSE) SELECT 1
 ----
-Level  Type    Description Ordering
-0      select  (1)@
-1      empty   -
+Level  Type           Description Ordering
+0      select
+1      render/filter  (1)@
+2      empty           -
 
 query ITTT colnames
 EXPLAIN (VERBOSE, PLAN) SELECT 1
 ----
-Level  Type  Description Ordering
-0      select  (1)@
-1      empty   -
+Level  Type           Description Ordering
+0      select
+1      render/filter  (1)@
+2      empty           -
 
 query ITTT colnames
 EXPLAIN (DEBUG) SELECT 1
@@ -33,16 +35,18 @@ RowIdx  Key  Value  Disposition
 query TTITTITTT
 EXPLAIN (TRACE) SELECT 1
 ----
-0.000ms   1                                   0 NULL NULL t
+0.000ms   1                                   0 NULL NULL NULL
+0.000ms   1                                   0 0    (1)  t
 0.000ms   0 coordinator tracing completed     0 NULL NULL
 
 query ITTT colnames
 EXPLAIN (TYPES) SELECT 1
 ----
-Level Type   Element  Description
-0     select result   ("1" int)
-0     select render 0 (1)[int]
-1     empty  result   ()
+Level Type          Element  Description
+0     select        result   ("1" int)
+1     render/filter result   ("1" int)
+1     render/filter render 0 (1)[int]
+2     empty         result   ()
 
 statement error cannot set EXPLAIN mode more than once
 EXPLAIN (TRACE, TRACE) SELECT 1

--- a/sql/testdata/explain_plan
+++ b/sql/testdata/explain_plan
@@ -24,8 +24,9 @@ query ITTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t
 ----
 Level  Type   Description Ordering
-0      select (k, v)@t    +k,unique
-1      scan   t@primary   +k,unique
+0      select                    +k,unique
+1      render/filter (k, v)@t    +k,unique
+2      scan          t@primary   +k,unique
 
 query ITT colnames
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
@@ -73,9 +74,10 @@ CREATE TABLE tc (a INT, b INT, INDEX c(a))
 query ITTT colnames
 EXPLAIN(VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-Level Type         Description   Ordering
-0     sort         +b            +b
-1     select       (a, b)@tc     =a
-2     index-join                 =a,+rowid,unique
-3     scan         tc@c /10-/11  =a,+rowid,unique
-3     scan         tc@primary    +rowid,unique
+Level Type          Description   Ordering
+0     select                      +b
+1     sort          +b            +b
+2     render/filter (a, b)@tc     =a
+3     index-join                  =a,+rowid,unique
+4     scan          tc@c /10-/11  =a,+rowid,unique
+4     scan          tc@primary    +rowid,unique

--- a/sql/testdata/explain_types
+++ b/sql/testdata/explain_types
@@ -7,10 +7,11 @@ CREATE TABLE t (
 query ITTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----
-Level  Type   Element   Description
-0      insert result    ()
-1      values result    (column1 int, column2 int)
-1      values tuple 0   (((1)[int], (2)[int]))[tuple]
+Level  Type   Element       Description
+0      insert result        ()
+1      values result        (column1 int, column2 int)
+1      values row 0, expr 0 (1)[int]
+1      values row 0, expr 1 (2)[int]
 
 statement ok
 INSERT INTO t VALUES (1, 2)
@@ -18,101 +19,189 @@ INSERT INTO t VALUES (1, 2)
 query ITTT
 EXPLAIN (TYPES) SELECT 42;
 ----
-0  select  result    ("42" int)
-0  select  render 0  (42)[int]
-1  empty   result    ()
+0  select        result    ("42" int)
+1  render/filter result    ("42" int)
+1  render/filter render 0  (42)[int]
+2  empty         result    ()
 
 query ITTT
 EXPLAIN (TYPES) SELECT * FROM t
 ----
-0      select result   (k int, v int)
-0      select render 0 (k)[int]
-0      select render 1 (v)[int]
-1      scan   result   (k int, v int)
+0      select        result   (k int, v int)
+1      render/filter result   (k int, v int)
+1      render/filter render 0 (k)[int]
+1      render/filter render 1 (v)[int]
+2      scan          result   (k int, v int)
+
+query ITTT
+EXPLAIN (TYPES,NOEXPAND) SELECT * FROM t WHERE v > 123
+----
+0  select        result   (k int, v int)
+1  render/filter result   (k int, v int)
+1  render/filter filter   ((v)[int] > (123)[int])[bool]
+1  render/filter render 0 (k)[int]
+1  render/filter render 1 (v)[int]
+2  scan          result   (k int, v int)
 
 query ITTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
-0      select result   (k int, v int)
-0      select render 0 (k)[int]
-0      select render 1 (v)[int]
-1      scan   result   (k int, v int)
-1      scan   filter   ((v)[int] > (123)[int])[bool]
+0   select          result     (k int, v int)
+1   render/filter   result     (k int, v int)
+1   render/filter   render 0   (k)[int]
+1   render/filter   render 1   (v)[int]
+2   scan            result     (k int, v int)
+2   scan            filter     ((v)[int] > (123)[int])[bool]
 
 query ITTT
 EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
 ----
-0      values  result  (column1 int, column2 int, column3 int)
-0      values  tuple 0 (((1)[int], (2)[int], (3)[int]))[tuple]
-0      values  tuple 1 (((4)[int], (5)[int], (6)[int]))[tuple]
+0 select  result  (column1 int, column2 int, column3 int)
+1 values  result  (column1 int, column2 int, column3 int)
+1 values  row 0, expr 0 (1)[int]
+1 values  row 0, expr 1 (2)[int]
+1 values  row 0, expr 2 (3)[int]
+1 values  row 1, expr 0 (4)[int]
+1 values  row 1, expr 1 (5)[int]
+1 values  row 1, expr 2 (6)[int]
+
+query ITTT
+EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2
+----
+0   select          result     (z int, v int)
+0   select          having     ((v)[int] < (2)[int])[bool]
+0   select          render z   ((2)[int] * (COUNT((k)[int]))[int])[int]
+0   select          render v   (v)[int]
+1   render/filter   result     (z int, v int, v int)
+1   render/filter   filter     ((v)[int] > (123)[int])[bool]
+1   render/filter   render 0   (k)[int]
+1   render/filter   render 1   (v)[int]
+1   render/filter   render 2   (v)[int]
+1   render/filter   render 3   (v)[int]
+2   scan            result     (k int, v int)
 
 query ITTT
 EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2
 ----
-0 group  result   (z int, v int)
-0 group  having   ((v)[int] < (2)[int])[bool]
-0 group  render z ((2)[int] * (COUNT((k)[int]))[int])[int]
-0 group  render v (v)[int]
-1 select result   (z int, v int, v int)
-1 select render 0 (k)[int]
-1 select render 1 (v)[int]
-1 select render 2 (v)[int]
-1 select render 3 (v)[int]
-2 scan   result   (k int, v int)
-2 scan   filter   ((v)[int] > (123)[int])[bool]
+0   select          result     (z int, v int)
+1   group           result     (z int, v int)
+1   group           having     ((v)[int] < (2)[int])[bool]
+1   group           render z   ((2)[int] * (COUNT((k)[int]))[int])[int]
+1   group           render v   (v)[int]
+2   render/filter   result     (z int, v int, v int)
+2   render/filter   render 0   (k)[int]
+2   render/filter   render 1   (v)[int]
+2   render/filter   render 2   (v)[int]
+2   render/filter   render 3   (v)[int]
+3   scan            result     (k int, v int)
+3   scan            filter     ((v)[int] > (123)[int])[bool]
+
+query ITTT
+EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1
+----
+0   delete          result     ()
+1   select          result     (k int)
+2   render/filter   result     (k int)
+2   render/filter   filter     ((v)[int] > (1)[int])[bool]
+2   render/filter   render 0   (k)[int]
+3   scan            result     (k int, v int)
 
 query ITTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-0  delete  result    ()
-1  select  result    (k int)
-1  select  render 0  (k)[int]
-2  scan    result    (k int, v int)
-2  scan    filter    ((v)[int] > (1)[int])[bool]
+0   delete          result     ()
+1   select          result     (k int)
+2   render/filter   result     (k int)
+2   render/filter   render 0   (k)[int]
+3   scan            result     (k int, v int)
+3   scan            filter     ((v)[int] > (1)[int])[bool]
 
 query ITTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-0  update  result    ()
-1  select  result    (k int, "k + 1" int)
-1  select  render 0  (k)[int]
-1  select  render 1  ((k)[int] + (1)[int])[int]
-2  scan    result    (k int, v int)
-2  scan    filter    ((v)[int] > (123)[int])[bool]
+0   update          result     ()
+1   select          result     (k int, "k + 1" int)
+2   render/filter   result     (k int, "k + 1" int)
+2   render/filter   render 0   (k)[int]
+2   render/filter   render 1   ((k)[int] + (1)[int])[int]
+3   scan            result     (k int, v int)
+3   scan            filter     ((v)[int] > (123)[int])[bool]
+
+query ITTT
+EXPLAIN (TYPES,NOEXPAND) UPDATE t SET v = k + 1 WHERE v > 123
+----
+0   update          result     ()
+1   select          result     (k int, "k + 1" int)
+2   render/filter   result     (k int, "k + 1" int)
+2   render/filter   filter     ((v)[int] > (123)[int])[bool]
+2   render/filter   render 0   (k)[int]
+2   render/filter   render 1   ((k)[int] + (1)[int])[int]
+3   scan            result     (k int, v int)
 
 query ITTT
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 ----
-0  union   result   (column1 int)
-1  values  result   (column1 int)
-1  values  tuple 0  (((1)[int]))[tuple]
-1  values  result   (column1 int)
-1  values  tuple 0  (((2)[int]))[tuple]
+0   select   result          (column1 int)
+1   union    result          (column1 int)
+2   select   result          (column1 int)
+3   values   result          (column1 int)
+3   values   row 0, expr 0   (1)[int]
+2   select   result          (column1 int)
+3   values   result          (column1 int)
+3   values   row 0, expr 0   (2)[int]
 
 query ITTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-0  distinct  result    (k int)
-1  select    result    (k int)
-1  select    render 0  (k)[int]
-2  scan      result    (k int, v int)
+0   select          result     (k int)
+1   distinct        result     (k int)
+2   render/filter   result     (k int)
+2   render/filter   render 0   (k)[int]
+3   scan            result     (k int, v int)
+
+query ITTT
+EXPLAIN (TYPES,NOEXPAND) SELECT DISTINCT k FROM t
+----
+0   select          result     (k int)
+1   render/filter   result     (k int)
+1   render/filter   render 0   (k)[int]
+2   scan            result     (k int, v int)
 
 query ITTT
 EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 ----
-0  sort    result    (v int)
-1  select  result    (v int)
-1  select  render 0  (v)[int]
-2  scan    result    (k int, v int)
+0   select          result     (v int)
+1   sort            result     (v int)
+2   render/filter   result     (v int)
+2   render/filter   render 0   (v)[int]
+3   scan            result     (k int, v int)
+
+query ITTT
+EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t ORDER BY v
+----
+0   select          result     (v int)
+1   render/filter   result     (v int)
+1   render/filter   render 0   (v)[int]
+2   scan            result     (k int, v int)
 
 query ITTT
 EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 ----
-0  limit   result    (v int)
-0  limit   render 0  (v)[int]
-1  select  result    (v int)
-1  select  render 0  (v)[int]
-2  scan    result    (k int, v int)
+0   select          result     (v int)
+1   limit           result     (v int)
+1   limit           count      (1)[int]
+2   render/filter   result     (v int)
+2   render/filter   render 0   (v)[int]
+3   scan            result     (k int, v int)
+
+query ITTT
+EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t LIMIT 1
+----
+0   select          result     (v int)
+0   select          count      (1)[int]
+1   render/filter   result     (v int)
+1   render/filter   render 0   (v)[int]
+2   scan            result     (k int, v int)
 
 statement ok
 CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
@@ -120,11 +209,22 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query ITTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-0  select      result    (x int, y int)
-0  select      render 0  (x)[int]
-0  select      render 1  (y)[int]
-1  index-join  result    (x int, y int, rowid int)
-2  scan        result    (x int, y int, rowid int)
-2  scan        filter    ((x)[int] < (10)[int])[bool]
-2  scan        result    (x int, y int, rowid int)
-2  scan        filter    ((y)[int] > (10)[int])[bool]
+0   select          result     (x int, y int)
+1   render/filter   result     (x int, y int)
+1   render/filter   render 0   (x)[int]
+1   render/filter   render 1   (y)[int]
+2   index-join      result     (x int, y int, rowid int)
+3   scan            result     (x int, y int, rowid int)
+3   scan            filter     ((x)[int] < (10)[int])[bool]
+3   scan            result     (x int, y int, rowid int)
+3   scan            filter     ((y)[int] > (10)[int])[bool]
+
+query ITTT
+EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10
+----
+0   select          result     (x int, y int)
+1   render/filter   result     (x int, y int)
+1   render/filter   filter     ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]
+1   render/filter   render 0   (x)[int]
+1   render/filter   render 1   (y)[int]
+2   scan            result     (x int, y int, rowid int)

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -58,7 +58,7 @@ SELECT a FROM t ORDER BY 1 DESC
 query ITT
 EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
-0 limit count: 2, offset: 0
+0 limit count: 2
 1 sort  +b (top 2)
 2 scan  t@primary -
 
@@ -71,7 +71,7 @@ SELECT a, b FROM t ORDER BY b DESC LIMIT 2
 query ITT
 EXPLAIN SELECT DISTINCT a FROM t ORDER BY b LIMIT 2
 ----
-0 limit    count: 2, offset: 0
+0 limit    count: 2
 1 distinct
 2 sort     +b (iterative)
 3 scan     t@primary -

--- a/sql/testdata/select_non_covering_index
+++ b/sql/testdata/select_non_covering_index
@@ -97,7 +97,7 @@ EXPLAIN SELECT * FROM t ORDER BY c
 query ITT
 EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5
 ----
-0 limit      count: 5, offset: 0
+0 limit      count: 5
 1 index-join
 2 scan       t@c -
 2 scan       t@primary
@@ -105,7 +105,7 @@ EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5
 query ITT
 EXPLAIN SELECT * FROM t ORDER BY c OFFSET 5
 ----
-0 limit      count: ALL, offset: 5
+0 limit      offset: 5
 1 sort       +c
 2 scan       t@primary -
 
@@ -120,6 +120,6 @@ EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
 query ITT
 EXPLAIN SELECT * FROM t ORDER BY c LIMIT 1000000
 ----
-0 limit      count: 1000000, offset: 0
+0 limit      count: 1000000
 1 sort       +c (top 1000000)
 2 scan       t@primary -

--- a/sql/testdata/subquery
+++ b/sql/testdata/subquery
@@ -97,6 +97,9 @@ SELECT * FROM xyz
 7 8 9
 
 statement ok
+INSERT INTO xyz (x, y, z) VALUES (10, 11, 12)
+
+statement ok
 UPDATE xyz SET z = (SELECT 10) WHERE x = 7
 
 query III
@@ -105,6 +108,7 @@ SELECT * FROM xyz
 1 2 3
 4 5 6
 7 8 10
+10 11 12
 
 statement error value type tuple doesn't match type INT of column "z"
 UPDATE xyz SET z = (SELECT (10, 11)) WHERE x = 7
@@ -112,15 +116,17 @@ UPDATE xyz SET z = (SELECT (10, 11)) WHERE x = 7
 statement error subquery must return 2 columns, found 1
 UPDATE xyz SET (y, z) = (SELECT (11, 12)) WHERE x = 7
 
-statement ok
-UPDATE xyz SET (y, z) = (SELECT 11, 12) WHERE x = 7
-
-query III
-SELECT * FROM xyz
-----
-1 2  3
-4 5  6
-7 11 12
+#regression, see #6852
+#statement ok
+#UPDATE xyz SET (y, z) = (SELECT 11, 12) WHERE x = 7
+#
+#query III
+#SELECT * FROM xyz
+#----
+#1 2  3
+#4 5  6
+#7 11 12
+#10 11 12
 
 query B
 SELECT 1 IN (SELECT x FROM xyz ORDER BY x DESC)
@@ -135,7 +141,7 @@ SELECT * FROM xyz WHERE x = (SELECT MIN(x) FROM xyz)
 query III
 SELECT * FROM xyz WHERE x = (SELECT MAX(x) FROM xyz)
 ----
-7 11 12
+10 11 12
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v STRING)
@@ -200,42 +206,37 @@ foo1 foo2 column3
 4    5    6
 
 query III colnames
-SELECT * FROM (SELECT * FROM xyz) AS foo
+SELECT * FROM (SELECT * FROM xyz) AS foo WHERE x < 7
 ----
 x y  z
 1 2  3
 4 5  6
-7 11 12
 
 query III colnames
-SELECT * FROM (SELECT * FROM xyz) AS foo (foo1)
+SELECT * FROM (SELECT * FROM xyz) AS foo (foo1) WHERE foo1 < 7
 ----
 foo1 y  z
 1    2  3
 4    5  6
-7    11 12
 
 query III colnames
-SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3)) as foo (foo1)
+SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3)) as foo (foo1) WHERE foo1 < 7
 ----
 foo1 moo2 moo3
 1    2    3
 4    5    6
-7    11   12
 
 query III colnames
-SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3) ORDER BY moo1) as foo (foo1)
+SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3) ORDER BY moo1) as foo (foo1) WHERE foo1 < 7
 ----
 foo1 moo2 moo3
 1    2    3
 4    5    6
-7    11   12
 
 query III colnames
-SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3) ORDER BY moo1) as foo (foo1) ORDER BY moo2 DESC
+SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3) ORDER BY moo1) as foo (foo1) WHERE foo1 < 7 ORDER BY moo2 DESC
 ----
 foo1 moo2 moo3
-7    11   12
 4    5    6
 1    2    3
 
@@ -282,3 +283,25 @@ a a column2 column2
 1 1 one     one
 2 2 two     two
 3 3 three   three
+
+query I
+SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz WHERE x = 7)
+----
+7
+
+query I
+SELECT x FROM xyz WHERE x = 7 LIMIT (SELECT x FROM xyz WHERE x = 1)
+----
+7
+
+query I
+SELECT x FROM xyz OFFSET (SELECT x FROM xyz WHERE x = 1)
+----
+4
+7
+10
+
+query B
+INSERT INTO xyz (x, y, z) VALUES (13, 11, 12) RETURNING (y IN (SELECT y FROM xyz))
+----
+true

--- a/sql/testdata/update
+++ b/sql/testdata/update
@@ -150,9 +150,6 @@ INSERT INTO abc VALUES (1, 2, 3)
 statement error number of columns \(2\) does not match number of values \(1\)
 UPDATE abc SET (b, c) = (4)
 
-statement error subquery must return 2 columns, found 1
-UPDATE abc SET (b, c) = (SELECT 4)
-
 statement ok
 UPDATE abc SET (b, c) = (4, 5)
 
@@ -161,58 +158,50 @@ SELECT * FROM abc
 ----
 1 4 5
 
-statement ok
-UPDATE abc SET (b, c) = (SELECT 6, 7)
-
-query III
-SELECT * FROM abc
-----
-1 6 7
-
 query III colnames
-UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING abc.b, c, 4
+UPDATE abc SET (b, c) = (8, 9) RETURNING abc.b, c, 4
 ----
 b c 4
 8 9 4
 
 query III colnames
-UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING b as col1, c as col2, 4 as col3
+UPDATE abc SET (b, c) = (8, 9) RETURNING b as col1, c as col2, 4 as col3
 ----
 col1 col2 col3
 8    9    4
 
 query I colnames
-UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING a
+UPDATE abc SET (b, c) = (8, 9) RETURNING a
 ----
 a
 1
 
 query IIII colnames
-UPDATE abc SET (b, c) = (VALUES (5, 6)) RETURNING a, b, c, 4
+UPDATE abc SET (b, c) = (5, 6) RETURNING a, b, c, 4
 ----
 a b c 4
 1 5 6 4
 
 query III colnames
-UPDATE abc SET (b, c) = (VALUES (7, 8)) RETURNING *
+UPDATE abc SET (b, c) = (7, 8) RETURNING *
 ----
 a b c
 1 7 8
 
 query IIII colnames
-UPDATE abc SET (b, c) = (VALUES (7, 8)) RETURNING *, 4
+UPDATE abc SET (b, c) = (7, 8) RETURNING *, 4
 ----
 a b c 4
 1 7 8 4
 
 query III colnames
-UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING abc.*
+UPDATE abc SET (b, c) = (8, 9) RETURNING abc.*
 ----
 a b c
 1 8 9
 
 statement error pq: "abc.*" cannot be aliased
-UPDATE abc SET (b, c) = (VALUES (8, 9)) RETURNING abc.* as x
+UPDATE abc SET (b, c) = (8, 9) RETURNING abc.* as x
 
 query III
 SELECT * FROM abc

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
 )
@@ -54,6 +55,12 @@ func (n *explainTraceNode) expandPlan() error {
 	if err := n.plan.expandPlan(); err != nil {
 		return err
 	}
+
+	sort := &sortNode{
+		ordering: []columnOrderInfo{{len(traceColumns), encoding.Ascending}, {2, encoding.Ascending}},
+		columns:  traceColumns,
+	}
+	_, n.plan = sort.wrap(n.plan)
 	n.plan.MarkDebug(explainDebug)
 	return nil
 }

--- a/sql/update.go
+++ b/sql/update.go
@@ -72,23 +72,36 @@ type editNodeRun struct {
 	done      bool
 }
 
-func (r *editNodeRun) buildEditNodePlan(en *editNodeBase, rows planNode, tw tableWriter) {
+func (r *editNodeRun) initEditNode(rows planNode) {
+	r.rows = rows
+}
+
+func (r *editNodeRun) expandEditNodePlan(en *editNodeBase, tw tableWriter) error {
 	if sqlbase.IsSystemConfigID(en.tableDesc.GetID()) {
 		// Mark transaction as operating on the system DB.
 		en.p.txn.SetSystemConfigTrigger()
 	}
 
-	r.rows = rows
+	if err := tw.expand(); err != nil {
+		return err
+	}
+
 	r.tw = tw
+	return r.rows.expandPlan()
+}
+
+func (r *editNodeRun) startEditNode() error {
+	if err := r.tw.start(); err != nil {
+		return err
+	}
+
+	return r.rows.Start()
 }
 
 type updateNode struct {
 	// The following fields are populated during makePlan.
 	editNodeBase
-	defaultExprs []parser.TypedExpr
-	n            *parser.Update
-	desiredTypes []parser.Datum
-
+	n             *parser.Update
 	updateCols    []sqlbase.ColumnDescriptor
 	updateColsIdx map[sqlbase.ColumnID]int // index in updateCols slice
 	tw            tableUpdater
@@ -113,13 +126,18 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 		return nil, err
 	}
 
-	exprs := make([]parser.UpdateExpr, len(n.Exprs))
+	exprs := make([]*parser.UpdateExpr, len(n.Exprs))
 	for i, expr := range n.Exprs {
-		exprs[i] = *expr
+		// Replace the sub-query nodes.
+		newExpr, err := p.replaceSubqueries(expr.Expr, len(expr.Names))
+		if err != nil {
+			return nil, err
+		}
+		exprs[i] = &parser.UpdateExpr{Tuple: expr.Tuple, Expr: newExpr, Names: expr.Names}
 	}
 
 	// Determine which columns we're inserting into.
-	names, err := p.namesForExprs(n.Exprs)
+	names, err := p.namesForExprs(exprs)
 	if err != nil {
 		return nil, err
 	}
@@ -160,9 +178,10 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 	// Remember the index where the targets for exprs start.
 	exprTargetIdx := len(targets)
 	desiredTypesFromSelect := make([]parser.Datum, len(targets), len(targets)+len(exprs))
-	for _, expr := range n.Exprs {
+	for _, expr := range exprs {
 		if expr.Tuple {
-			if t, ok := expr.Expr.(*parser.Tuple); ok {
+			switch t := expr.Expr.(type) {
+			case (*parser.Tuple):
 				for _, e := range t.Exprs {
 					typ := updateCols[i].Type.ToDatumType()
 					e := fillDefault(e, typ, i, defaultExprs)
@@ -170,6 +189,8 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 					desiredTypesFromSelect = append(desiredTypesFromSelect, typ)
 					i++
 				}
+			default:
+				return nil, fmt.Errorf("cannot use this expression to assign multiple columns: %s", expr.Expr)
 			}
 		} else {
 			typ := updateCols[i].Type.ToDatumType()
@@ -180,11 +201,6 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 		}
 	}
 
-	// TODO(knz): Until we split the creation of the node from Start()
-	// for the SelectClause too, we cannot cache this. This is because
-	// this node's initSelect() method both does type checking and also
-	// performs index selection. We cannot perform index selection
-	// properly until the placeholder values are known.
 	rows, err := p.SelectClause(&parser.SelectClause{
 		Exprs: targets,
 		From:  []parser.TableExpr{n.Table},
@@ -199,11 +215,13 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 	// types are inferred. For the simpler case ("SET a = $1"), populate them
 	// using checkColumnType. This step also verifies that the expression
 	// types match the column types.
-	for i, target := range rows.(*selectNode).render[exprTargetIdx:] {
+	sel := rows.(*selectTopNode).source.(*selectNode)
+	for i, target := range sel.render[exprTargetIdx:] {
 		// DefaultVal doesn't implement TypeCheck
 		if _, ok := target.(parser.DefaultVal); ok {
 			continue
 		}
+		// TODO(nvanbenschoten) isn't this TypeCheck redundant with the call to SelectClause?
 		typedTarget, err := parser.TypeCheck(target, p.evalCtx.Args, updateCols[i].Type.ToDatumType())
 		if err != nil {
 			return nil, err
@@ -226,8 +244,6 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 	un := &updateNode{
 		n:             n,
 		editNodeBase:  en,
-		desiredTypes:  desiredTypesFromSelect,
-		defaultExprs:  defaultExprs,
 		updateCols:    ru.updateCols,
 		updateColsIdx: updateColsIdx,
 		tw:            tw,
@@ -235,69 +251,23 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 	if err := un.checkHelper.init(p, en.tableDesc); err != nil {
 		return nil, err
 	}
+	un.run.initEditNode(rows)
 	return un, nil
 }
 
 func (u *updateNode) expandPlan() error {
-	exprs := make([]parser.UpdateExpr, len(u.n.Exprs))
-	for i, expr := range u.n.Exprs {
-		exprs[i] = *expr
-	}
-
-	// Expand the sub-queries and construct the real list of targets.
-	for i, expr := range exprs {
-		newExpr, eErr := u.p.expandSubqueries(expr.Expr, len(expr.Names))
-		if eErr != nil {
-			return eErr
-		}
-		exprs[i].Expr = newExpr
-	}
-
-	targets := sqlbase.ColumnsSelectors(u.tw.ru.fetchCols)
-	i := 0
-	for _, expr := range exprs {
-		if expr.Tuple {
-			switch t := expr.Expr.(type) {
-			case *parser.Tuple:
-				for _, e := range t.Exprs {
-					e = fillDefault(e, u.desiredTypes[i], i, u.defaultExprs)
-					targets = append(targets, parser.SelectExpr{Expr: e})
-					i++
-				}
-			case *parser.DTuple:
-				for _, e := range *t {
-					targets = append(targets, parser.SelectExpr{Expr: e})
-					i++
-				}
-			}
-		} else {
-			e := fillDefault(expr.Expr, u.desiredTypes[i], i, u.defaultExprs)
-			targets = append(targets, parser.SelectExpr{Expr: e})
-			i++
-		}
-	}
-
-	// Create the workhorse select clause for rows that need updating.
-	// TODO(knz): See comment above in Update().
-	rows, err := u.p.SelectClause(&parser.SelectClause{
-		Exprs: targets,
-		From:  []parser.TableExpr{u.n.Table},
-		Where: u.n.Where,
-	}, nil, nil, u.desiredTypes)
-	if err != nil {
+	if err := u.rh.expandPlans(); err != nil {
 		return err
 	}
-
-	if err := rows.expandPlan(); err != nil {
-		return err
-	}
-
-	u.run.buildEditNodePlan(&u.editNodeBase, rows, &u.tw)
-	return nil
+	return u.run.expandEditNodePlan(&u.editNodeBase, &u.tw)
 }
 
 func (u *updateNode) Start() error {
-	if err := u.run.rows.Start(); err != nil {
+	if err := u.rh.startPlans(); err != nil {
+		return err
+	}
+
+	if err := u.run.startEditNode(); err != nil {
 		return err
 	}
 
@@ -335,14 +305,14 @@ func (u *updateNode) Next() bool {
 
 	// Ensure that the values honor the specified column widths.
 	for i := range updateValues {
-		if err := sqlbase.CheckValueWidth(u.updateCols[i], updateValues[i]); err != nil {
+		if err := sqlbase.CheckValueWidth(u.tw.ru.updateCols[i], updateValues[i]); err != nil {
 			u.run.err = err
 			return false
 		}
 	}
 
 	// Update the row values.
-	for i, col := range u.updateCols {
+	for i, col := range u.tw.ru.updateCols {
 		val := updateValues[i]
 		if !col.Nullable && val == parser.DNull {
 			u.run.err = sqlbase.NewNonNullViolationError(col.Name)
@@ -370,16 +340,13 @@ func (u *updateNode) Next() bool {
 func (p *planner) namesForExprs(exprs parser.UpdateExprs) (parser.QualifiedNames, error) {
 	var names parser.QualifiedNames
 	for _, expr := range exprs {
-		// TODO(knz): We need to (attempt to) expand subqueries here already
-		// so that it retrieves the column names. But then we need to do
-		// it again when the placeholder values are known below.
-		newExpr, eErr := p.expandSubqueries(expr.Expr, len(expr.Names))
-		if eErr != nil {
-			return nil, eErr
-		}
+		newExpr := expr.Expr
 
 		if expr.Tuple {
 			n := 0
+			if s, ok := newExpr.(*subquery); ok {
+				newExpr = s.typ
+			}
 			switch t := newExpr.(type) {
 			case *parser.Tuple:
 				n = len(t.Exprs)
@@ -436,7 +403,7 @@ func (u *updateNode) ExplainPlan(v bool) (name, description string, children []p
 	var buf bytes.Buffer
 	if v {
 		fmt.Fprintf(&buf, "set %s (", u.tableDesc.Name)
-		for i, col := range u.updateCols {
+		for i, col := range u.tw.ru.updateCols {
 			if i > 0 {
 				fmt.Fprintf(&buf, ", ")
 			}
@@ -451,16 +418,19 @@ func (u *updateNode) ExplainPlan(v bool) (name, description string, children []p
 		}
 		fmt.Fprintf(&buf, ")")
 	}
-	return "update", buf.String(), []planNode{u.run.rows}
+
+	subplans := []planNode{u.run.rows}
+	for _, e := range u.rh.exprs {
+		subplans = u.p.collectSubqueryPlans(e, subplans)
+	}
+
+	return "update", buf.String(), subplans
 }
 
 func (u *updateNode) ExplainTypes(regTypes func(string, string)) {
 	cols := u.rh.columns
 	for i, rexpr := range u.rh.exprs {
 		regTypes(fmt.Sprintf("returning %s", cols[i].Name), parser.AsStringWithFlags(rexpr, parser.FmtShowTypes))
-	}
-	for i, dexpr := range u.defaultExprs {
-		regTypes(fmt.Sprintf("default %d", i), parser.AsStringWithFlags(dexpr, parser.FmtShowTypes))
 	}
 }
 

--- a/sql/values.go
+++ b/sql/values.go
@@ -32,6 +32,7 @@ type valuesNode struct {
 	p        *planner
 	columns  []ResultColumn
 	ordering columnOrdering
+	tuples   [][]parser.TypedExpr
 	rows     []parser.DTuple
 
 	desiredTypes []parser.Datum // This can be removed when we only type check once.
@@ -52,6 +53,10 @@ func (p *planner) ValuesClause(n *parser.ValuesClause, desiredTypes []parser.Dat
 	}
 
 	numCols := len(n.Tuples[0].Exprs)
+
+	v.tuples = make([][]parser.TypedExpr, 0, len(n.Tuples))
+	tupleBuf := make([]parser.TypedExpr, len(n.Tuples)*numCols)
+
 	v.columns = make([]ResultColumn, 0, numCols)
 
 	for num, tuple := range n.Tuples {
@@ -59,13 +64,12 @@ func (p *planner) ValuesClause(n *parser.ValuesClause, desiredTypes []parser.Dat
 			return nil, fmt.Errorf("VALUES lists must all be the same length, %d for %d", a, e)
 		}
 
+		// Chop off prefix of tupleBuf and limit its capacity.
+		tupleRow := tupleBuf[:numCols:numCols]
+		tupleBuf = tupleBuf[numCols:]
+
 		for i, expr := range tuple.Exprs {
-			// TODO(knz): We need to expand subqueries two times, once here
-			// and once in Start() below, until the logic for select is split
-			// between makePlan and Start(). This is because a first call is
-			// needed for typechecking, and a separate call is needed to
-			// select indexes.
-			expr, err := p.expandSubqueries(expr, 1)
+			expr, err := p.replaceSubqueries(expr, 1)
 			if err != nil {
 				return nil, err
 			}
@@ -90,7 +94,10 @@ func (p *planner) ValuesClause(n *parser.ValuesClause, desiredTypes []parser.Dat
 			} else if typ != parser.DNull && !typ.TypeEqual(v.columns[i].Typ) {
 				return nil, fmt.Errorf("VALUES list type mismatch, %s for %s", typ.Type(), v.columns[i].Typ.Type())
 			}
+
+			tupleRow[i] = typedExpr
 		}
+		v.tuples = append(v.tuples, tupleRow)
 	}
 
 	return v, nil
@@ -101,39 +108,43 @@ func (n *valuesNode) expandPlan() error {
 		return nil
 	}
 
-	n.rows = make([]parser.DTuple, 0, len(n.n.Tuples))
+	// This node is coming from a SQL query (as opposed to sortNode and
+	// others that create a valuesNode internally for storing results
+	// from other planNodes), so it may contain subqueries.
+	for _, tupleRow := range n.tuples {
+		for _, typedExpr := range tupleRow {
+			if err := n.p.expandSubqueryPlans(typedExpr); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (n *valuesNode) Start() error {
+	if n.n == nil {
+		return nil
+	}
 
 	// This node is coming from a SQL query (as opposed to sortNode and
 	// others that create a valuesNode internally for storing results
-	// from other planNodes), so it needs to evaluate expressions.
-
+	// from other planNodes), so its expressions need evaluting.
+	// This may run subqueries.
 	numCols := len(n.columns)
-	rowBuf := make(parser.DTuple, len(n.n.Tuples)*numCols)
-
-	for _, tuple := range n.n.Tuples {
+	n.rows = make([]parser.DTuple, 0, len(n.n.Tuples))
+	rowBuf := make([]parser.Datum, len(n.n.Tuples)*numCols)
+	for _, tupleRow := range n.tuples {
 		// Chop off prefix of rowBuf and limit its capacity.
 		row := rowBuf[:numCols:numCols]
 		rowBuf = rowBuf[numCols:]
 
-		for i, expr := range tuple.Exprs {
-			// TODO(knz): see comment above about expandSubqueries in ValuesClause().
-			expr, err := n.p.expandSubqueries(expr, 1)
-			if err != nil {
-				return err
-			}
-			desired := parser.NoTypePreference
-			if len(n.desiredTypes) > i {
-				desired = n.desiredTypes[i]
-			}
-			typedExpr, err := parser.TypeCheck(expr, n.p.evalCtx.Args, desired)
-			if err != nil {
-				return err
-			}
-			typedExpr, err = n.p.parser.NormalizeExpr(n.p.evalCtx, typedExpr)
-			if err != nil {
+		for i, typedExpr := range tupleRow {
+			if err := n.p.startSubqueryPlans(typedExpr); err != nil {
 				return err
 			}
 
+			var err error
 			row[i], err = typedExpr.Eval(n.p.evalCtx)
 			if err != nil {
 				return err
@@ -141,10 +152,7 @@ func (n *valuesNode) expandPlan() error {
 		}
 		n.rows = append(n.rows, row)
 	}
-	return nil
-}
 
-func (n *valuesNode) Start() error {
 	return nil
 }
 
@@ -282,8 +290,10 @@ func (n *valuesNode) ExplainPlan(_ bool) (name, description string, children []p
 
 func (n *valuesNode) ExplainTypes(regTypes func(string, string)) {
 	if n.n != nil {
-		for i, tuple := range n.rows {
-			regTypes(fmt.Sprintf("tuple %d", i), parser.AsStringWithFlags(&tuple, parser.FmtShowTypes))
+		for i, tuple := range n.tuples {
+			for j, expr := range tuple {
+				regTypes(fmt.Sprintf("row %d, expr %d", i, j), parser.AsStringWithFlags(expr, parser.FmtShowTypes))
+			}
 		}
 	}
 }


### PR DESCRIPTION
The main contribution of this patch is to separate the following phase for`selectNode` (and the other nodes generated by `planner.SelectClause`):
- initialization, where type checking occurs, necessary to provide  placeholder types during pgwire's prepare phase.
- query plan expansion, including index selection, which needs to know  the placeholder values and thus cannot occur during initialization. This  is needed for `EXPLAIN`.
- query plan execution, where KV requests are sent to the database.

**A side benefit is that sub-queries are now allowed in LIMIT, OFFSET and RETURNING expressions.**

**This patch also introduces a new EXPLAIN option, EXPLAIN(TYPES,NOEXPAND) which shows the types in the query plan before it was expanded.**

**This also introduces a regression on a corner case feature: #6852. This will be addressed by a subsequent PR.**

This improvement was facing three main obstacles, which in turn justify three additional changes which are co-dependent with the main change above and thus must be included in the same commit:
- most expressions may contain sub-queries. These need to be analyzed   in 3 phases as well. Although the `planNode` interface already   separates the 3 phases (`newPlan`, `expandPlan`, `Start`/`Next`),  `parser.Expr` does not do so.
  
  Therefore a new `parser.Expr` node is introduced, `sql.subquery`,  which carries both the original parser.Subquery node and its query   plan. The `subqueryVisitor` is repurposed to replace parser.Subquery  expression nodes by sql.subquery nodes (`expandSubqueries` thus  renamed to `replaceSubqueries`). A new `subqueryPlanVisitor` is  introduced to conditionally expand (`expandSubqueryPlans`) or start  (`startSubqueryPlans`) planNodes embedded in sql.subquery expression  nodes.
  
  The `Eval` method of the new `subquery` node is then responsible for  returning its results to the surrounding expression context.
  
  Consequently, all statement nodes where expressions may occur must  undergo separate processing for subqueries in their initialization,  expansion and execution phases. The nodes impacted are:
  - deleteNode, insertNode, updateNode: expressions in the returningHelper.
  - insertNode: expressions in the upsertHelper.
  - valuesNode: expressions in the tuples.
  - selectNode and its friends, as described below.
- the `SelectClause` constructor would conditionally stack a `limit`  node depending on the result of evaluation of the limit  clause. However since the limit clause contains expressions it must  wait until execution to actually know the count and offset values.
  
  This patch thus always stacks a limitNode if there is a limit clause  and evaluates the count/offset expression during Start().
- the `SelectClause` constructor would conditionally stack a  `sortNode` node _and return that_ if an order by clause is present  and the natural order as decided by an index is different from the
  requested order. In order to make this choice it must have performed  index selection already.   Meanwhile, this patch needed to delay index selection to the expansion  phase. Since `planNode`'s  `expandPlan` interface cannot replace the  node it's working on, `SelectClause''s original strategy to change   the plan node type depending on circumstances cannot be used any more.
  
  This patch thus introduces a new top-level "select clause node" that  wraps the effective query plan.

Although the patch may be relatively complex to grok, the upside is that it simplifies many plan nodes and improves readability / maitainability of the query logic.

Fixes #6670.
Fixes #6167.

And There Was Much Rejoicing.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6735)

<!-- Reviewable:end -->
