### PR TITLE
ui next: Cluster Overview Visualizations

### DIFF
--- a/ui/next/app/app.tsx
+++ b/ui/next/app/app.tsx
@@ -9,7 +9,7 @@
  *    - Graphs
  *      - Greyed-out display on error
  *      - Stacked Line Graph
- *    - "Big number" visualization
+ *      - Max/Min aggregators
  *    ! Events table
  *    ! Global Timespan Selector
  *      - UI Component
@@ -20,8 +20,6 @@
  *    - Cluster Unreachable
  *    - Cockroach out of date
  * - Cluster Page
- *    - Finish converting all existing graphs onto Cluster page
- *    - "Big Number" Visualizations
  *    - Events page
  * - Nodes Page
  *    - Graphs tab, with all graphs from existing page
@@ -39,7 +37,16 @@
  * ! HelpUs Modal
  * ! Persistent Settings Reducer
  * - Layout Footer
- * 
+ *
+ *
+ * NICE TO HAVE:
+ *  - "generateCacheReducer()" method; most of our data reducers are extremely
+ *  similar (storing read-only, cachable data queried from the server), we could
+ *  cut down on a lot of boilerplate and testing by creating such a function.
+ *  
+ *  - Create a "NodeStatusProvider" similar to "MetricsDataProvider", allowing
+ *  different components to access nodes data.
+ *
  */
 
 import * as React from "react";

--- a/ui/next/app/components/linegraph.tsx
+++ b/ui/next/app/components/linegraph.tsx
@@ -17,6 +17,7 @@ const MAX_LEGEND_SERIES: number = 3;
 
 interface LineGraphProps extends MetricsDataComponentProps {
   title?: string;
+  subtitle?: string;
   legend?: boolean;
   xAxis?: boolean;
   tooltip?: string;
@@ -178,8 +179,8 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
   }
 
   render() {
-    let { title, tooltip } = this.props;
-    return <Visualization title={title} tooltip={tooltip}>
+    let { title, subtitle, tooltip } = this.props;
+    return <Visualization title={title} subtitle={subtitle} tooltip={tooltip}>
       <div className="linegraph">
         <svg className="graph" ref={(svg) => this.svgEl = svg}/>
       </div>

--- a/ui/next/app/components/visualization.tsx
+++ b/ui/next/app/components/visualization.tsx
@@ -23,6 +23,7 @@ class ToolTip extends React.Component<ToolTipProps, {}> {
 
 interface VisualizationProps {
   title: string;
+  subtitle?: string;
   tooltip?: string;
   stale?: boolean;
 }
@@ -57,7 +58,10 @@ export default class extends React.Component<VisualizationProps, {}> {
       </div>
         { this.props.children }
       <div className="viz-bottom">
-        <div className="viz-title">{this.props.title}</div>
+        <div className="viz-title">
+          <div>{this.props.title}</div>
+          { this.props.subtitle ? <div className="small">{this.props.subtitle}</div> : null }
+        </div>
       </div>
     </div>;
   }

--- a/ui/next/app/containers/nodesOverview.tsx
+++ b/ui/next/app/containers/nodesOverview.tsx
@@ -12,7 +12,7 @@ import { setUISetting } from "../redux/ui";
 import { SortableTable, SortableColumn, SortSetting } from "../components/sortabletable";
 import { NanoToMilli } from "../util/convert";
 import { BytesToUnitValue } from "../util/format";
-import { NodeStatus, MetricConstants } from  "../util/proto";
+import { NodeStatus, MetricConstants, TotalCpu, BytesUsed } from  "../util/proto";
 
 // Constant used to store sort settings in the redux UI store.
 const UI_NODES_SORT_SETTING_KEY = "nodes/sort_setting";
@@ -110,9 +110,9 @@ let columnDescriptors: NodeColumnDescriptor[] = [
   {
     key: NodesTableColumn.Bytes,
     title: "Bytes",
-    cell: (ns) => formatBytes(byteSum(ns)),
-    sort: (ns) => byteSum(ns),
-    rollup: (rows) => formatBytes(_.sumBy(rows, (row) => byteSum(row))),
+    cell: (ns) => formatBytes(BytesUsed(ns)),
+    sort: (ns) => BytesUsed(ns),
+    rollup: (rows) => formatBytes(_.sumBy(rows, (row) => BytesUsed(row))),
   },
   // Replicas - displays the total number of replicas on the node.
   {
@@ -134,9 +134,9 @@ let columnDescriptors: NodeColumnDescriptor[] = [
   {
     key: NodesTableColumn.CPU,
     title: "CPU Usage",
-    cell: (ns) => d3.format(".2%")(totalCpu(ns)),
-    sort: (ns) => totalCpu(ns),
-    rollup: (rows) => d3.format(".2%")(_.sumBy(rows, (row) => totalCpu(row))),
+    cell: (ns) => d3.format(".2%")(TotalCpu(ns)),
+    sort: (ns) => TotalCpu(ns),
+    rollup: (rows) => d3.format(".2%")(_.sumBy(rows, (row) => TotalCpu(row))),
   },
   // Mem Usage - total memory being used on this node.
   {
@@ -368,26 +368,3 @@ function formatBytes(bytes: number): React.ReactNode {
     <span className="units">{b.units}</span>
   </div>;
 }
-
-/**
- * totalCpu computes the total CPU usage accounted for in a NodeStatus.
- */
-function totalCpu(status: NodeStatus): number {
-  let metrics = status.metrics;
-  return metrics.get(MetricConstants.sysCPUPercent) + metrics.get(MetricConstants.userCPUPercent);
-}
-
-/**
- * byteSum computes the total byte usage accounted for in a NodeStatus.
- */
-let aggregateByteKeys = [
-  MetricConstants.liveBytes,
-  MetricConstants.intentBytes,
-  MetricConstants.sysBytes,
-];
-
-function byteSum(s: NodeStatus): number {
-  return _.sumBy(aggregateByteKeys, (key: string) => {
-    return s.metrics.get(key);
-  });
-};

--- a/ui/next/app/util/proto.ts
+++ b/ui/next/app/util/proto.ts
@@ -66,4 +66,27 @@ export namespace MetricConstants {
   export var rss: string = "sys.rss";
 }
 
+/**
+ * TotalCPU computes the total CPU usage accounted for in a NodeStatus.
+ */
+export function TotalCpu(status: NodeStatus): number {
+  let metrics = status.metrics;
+  return metrics.get(MetricConstants.sysCPUPercent) + metrics.get(MetricConstants.userCPUPercent);
+}
+
+/**
+ * BytesUsed computes the total byte usage accounted for in a NodeStatus.
+ */
+let aggregateByteKeys = [
+  MetricConstants.liveBytes,
+  MetricConstants.intentBytes,
+  MetricConstants.sysBytes,
+];
+
+export function BytesUsed(s: NodeStatus): number {
+  return _.sumBy(aggregateByteKeys, (key: string) => {
+    return s.metrics.get(key);
+  });
+};
+
 export { NodeStatus };


### PR DESCRIPTION
Adds "large number" visualizations to the Cluster Overview page, along with the
remaining missing graphs.

Because there are only two "large number" visualizations present in the entire
code base, the code has not been extracted into a common component; large
numbers are already expressed quite succinctly using the `Visualization`
component directly.

Commit also moves a few data aggregation functions from `containers/nodes.tsx`
to an appropriate common home in `util/proto.ts`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6741)

<!-- Reviewable:end -->
