### PR TITLE
storage: A tiny comment fix to Replica.RangeLookup

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -816,7 +816,7 @@ func (r *Replica) RangeLookup(
 			return reply, nil, err
 		}
 	} else {
-		// Use MVCCScan to get first the first range. There are three cases:
+		// Use MVCCScan to get the first range. There are three cases:
 		// 1. args.Key is not an endpoint of the range and
 		// 2a. The args.Key is the start/end key of the range.
 		// 2b. Even worse, the body of args.Key is roachpb.KeyMax.


### PR DESCRIPTION
   get first the first range
-> get the first range

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6749)

<!-- Reviewable:end -->
