### PR TITLE
sql/parser: avoid name normalization in FuncExpr.TypeCheck

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -1051,6 +1051,12 @@ var Builtins = map[string][]Builtin{
 	},
 }
 
+func init() {
+	for k, v := range Builtins {
+		Builtins[strings.ToUpper(k)] = v
+	}
+}
+
 // identityFn returns the first argument provided.
 func identityFn(_ EvalContext, args DTuple) (Datum, error) {
 	return args[0], nil

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -242,9 +242,15 @@ func (expr *FuncExpr) TypeCheck(args MapArgs, desired Datum) (TypedExpr, error) 
 	}
 
 	name := string(expr.Name.Base)
-	candidates, ok := Builtins[strings.ToLower(name)]
+	// Optimize for the case where name is already normalized to upper/lower
+	// case. Note that the Builtins map contains duplicate entries for
+	// upper/lower case names.
+	candidates, ok := Builtins[name]
 	if !ok {
-		return nil, fmt.Errorf("unknown function: %s", name)
+		candidates, ok = Builtins[strings.ToLower(name)]
+		if !ok {
+			return nil, fmt.Errorf("unknown function: %s", name)
+		}
 	}
 
 	overloads := make([]overloadImpl, len(candidates))


### PR DESCRIPTION
Instead of normalizing function names to lower case for lookups, we add
both upper and lower case variants and only normalize to lower case if the
initial lookup fails. This saves an allocation per lookup and the time
spent adjust the casing.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6759)

<!-- Reviewable:end -->
