### PR TITLE
ui next: Nodes Graphs Tab, StackedAreaChart

### DIFF
--- a/ui/next/app/app.tsx
+++ b/ui/next/app/app.tsx
@@ -8,8 +8,6 @@
  * - Visualization Components
  *    - Graphs
  *      - Greyed-out display on error
- *      - Stacked Line Graph
- *      - Max/Min aggregators
  *    ! Events table
  *    ! Global Timespan Selector
  *      - UI Component
@@ -21,8 +19,6 @@
  *    - Cockroach out of date
  * - Cluster Page
  *    - Events page
- * - Nodes Page
- *    - Graphs tab, with all graphs from existing page
  * - Node Page
  *    - Overview page with table
  *    - Graphs page
@@ -43,6 +39,12 @@
  *
  *  - Create a "NodeStatusProvider" similar to "MetricsDataProvider", allowing
  *  different components to access nodes data.
+ *
+ *  - Commonize code between different graph types (LineGraph and
+ *  StackedAreaGraph). This can likely be done by converting them into stateless
+ *  functions, that return an underlying "Common" graph component. The props of
+ *  the Common graph component would include the part of `initGraph` and
+ *  `drawGraph` that are different for these two chart types.
  *
  */
 

--- a/ui/next/app/components/graphGroup.tsx
+++ b/ui/next/app/components/graphGroup.tsx
@@ -1,0 +1,24 @@
+/// <reference path="../../typings/main.d.ts" />
+import * as React from "react";
+
+import { MetricsDataProvider } from "../containers/metricsDataProvider";
+
+/** 
+ * GraphGroup is a stateless react component that wraps a group of graphs (the
+ * children of this component) in a MetricsDataProvider and some additional tags
+ * relevant to the layout of our graphs pages.
+ */
+export default function(props: { groupId: string, childClassName?: string, children?: any }) {
+  return <div>
+  {
+    React.Children.map(props.children, (child, idx) => {
+      let key = props.groupId + idx.toString();
+      return <div style={{float:"left"}} key={key} className={ props.childClassName || "" }>
+        <MetricsDataProvider id={key}>
+          { child }
+        </MetricsDataProvider>
+      </div>;
+    })
+  }
+  </div>;
+}

--- a/ui/next/app/containers/metricsDataProvider.tsx
+++ b/ui/next/app/containers/metricsDataProvider.tsx
@@ -65,12 +65,27 @@ const enum TimeSeriesQueryDerivative {
  * structure based on a MetricProps object.
  */
 function queryFromProps(props: MetricProps): TSQueryMessage {
+    let derivative = TimeSeriesQueryDerivative.NONE;
+    let sourceAggregator = TimeSeriesQueryAggregator.SUM;
+    let downsampler = TimeSeriesQueryAggregator.AVG;
+
     // Compute derivative function.
-    let derivative: TimeSeriesQueryDerivative = TimeSeriesQueryDerivative.NONE;
     if (props.rate) {
       derivative = TimeSeriesQueryDerivative.DERIVATIVE;
     } else if (props.nonNegativeRate) {
       derivative = TimeSeriesQueryDerivative.NON_NEGATIVE_DERIVATIVE;
+    }
+    // Compute downsample function.
+    if (props.downsampleMax) {
+      downsampler = TimeSeriesQueryAggregator.MAX;
+    } else if (props.downsampleMin) {
+      downsampler = TimeSeriesQueryAggregator.MIN;
+    }
+    // Compute aggregation function.
+    if (props.aggregateMax) {
+      sourceAggregator = TimeSeriesQueryAggregator.MAX;
+    } else if (props.aggregateMin) {
+      sourceAggregator = TimeSeriesQueryAggregator.MIN;
     }
 
     return new protos.cockroach.ts.Query({
@@ -84,8 +99,8 @@ function queryFromProps(props: MetricProps): TSQueryMessage {
        * not available in the SystemJS compiler. Values are cast *through*
        * number, as apparently direct casts between enumerations are forbidden.
        */
-      downsampler: TimeSeriesQueryAggregator.AVG as number as cockroach.ts.TimeSeriesQueryAggregator,
-      source_aggregator: TimeSeriesQueryAggregator.SUM as number as cockroach.ts.TimeSeriesQueryAggregator,
+      downsampler: downsampler as number as cockroach.ts.TimeSeriesQueryAggregator,
+      source_aggregator: sourceAggregator as number as cockroach.ts.TimeSeriesQueryAggregator,
       derivative: derivative as number as cockroach.ts.TimeSeriesQueryDerivative,
     });
 }

--- a/ui/next/app/containers/nodesGraphs.tsx
+++ b/ui/next/app/containers/nodesGraphs.tsx
@@ -1,13 +1,201 @@
 /// <reference path="../../typings/main.d.ts" />
 import * as React from "react";
+import * as d3 from "d3";
+
+import GraphGroup from "../components/graphGroup";
+import { LineGraph, Axis, Metric } from "../components/linegraph";
+import { StackedAreaGraph } from "../components/stackedgraph";
+import { Bytes } from "../util/format";
+import { NanoToMilli } from "../util/convert";
 
 /**
  * Renders the graphs tab of the nodes page.
  */
 export default class extends React.Component<{}, {}> {
   render() {
-    return <div className="section">
-      <h1>Nodes Graphs Page</h1>
+    return <div className="section nodes">
+      <div className="charts">
+        <h2>Activity</h2>
+          <GraphGroup groupId="nodes.activity">
+
+            <LineGraph title="SQL Connections">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.conns" title="Client Connections" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="SQL Traffic">
+              <Axis format={ Bytes }>
+                <Metric name="cr.node.sql.bytesin" title="Bytes In" nonNegativeRate />
+                <Metric name="cr.node.sql.bytesout" title="Bytes Out" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Queries Per Second">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.query.count" title="Queries/Sec" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Live Bytes">
+              <Axis format={ Bytes }>
+                <Metric name="cr.store.livebytes" title="Live Bytes" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Query Time"
+                       subtitle="(Max Per Percentile)"
+                       tooltip={`The latency between query requests and responses over a 1 minute period.
+                                 Percentiles are first calculated on each node.
+                                 For Each percentile, the maximum latency across all nodes is then shown.`}>
+              <Axis format={ (n: number) => d3.format(".1f")(NanoToMilli(n)) } label="Milliseconds">
+                <Metric name="cr.node.exec.latency-1m-max" title="Max Latency"
+                        aggregateMax downsampleMax />
+                <Metric name="cr.node.exec.latency-1m-p99" title="99th percentile latency"
+                        aggregateMax downsampleMax />
+                <Metric name="cr.node.exec.latency-1m-p90" title="90th percentile latency"
+                        aggregateMax downsampleMax />
+                <Metric name="cr.node.exec.latency-1m-p50" title="50th percentile latency"
+                        aggregateMax downsampleMax />
+              </Axis>
+            </LineGraph>
+
+          </GraphGroup>
+        <h2>SQL Queries</h2>
+          <GraphGroup groupId="nodes.queries">
+
+            <LineGraph title="Reads">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.select.count" title="Selects" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Writes">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.update.count" title="Updates" nonNegativeRate />
+                <Metric name="cr.node.sql.insert.count" title="Inserts" nonNegativeRate />
+                <Metric name="cr.node.sql.delete.count" title="Deletes" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Transactions">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.txn.commit.count" title="Commits" nonNegativeRate />
+                <Metric name="cr.node.sql.txn.rollback.count" title="Rollbacks" nonNegativeRate />
+                <Metric name="cr.node.sql.txn.abort.count" title="Aborts" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Schema Changes">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.ddl.count" title="DDL Statements" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+          </GraphGroup>
+        <h2>System Resources</h2>
+          <GraphGroup groupId="nodes.resources">
+
+            <StackedAreaGraph title="CPU Usage">
+              <Axis format={ d3.format(".2%") }>
+                <Metric name="cr.node.sys.cpu.user.percent" title="CPU User %"/>
+                <Metric name="cr.node.sys.cpu.sys.percent" title="CPU Sys %"/>
+              </Axis>
+            </StackedAreaGraph>
+
+            <LineGraph title="Memory Usage">
+              <Axis format={ Bytes }>
+                <Metric name="cr.node.sys.allocbytes" title="Go In Use" />
+                <Metric name="cr.node.sys.sysbytes" title="Go Sys" />
+                <Metric name="cr.node.sys.rss" title="RSS" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Goroutine Count">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sys.goroutines" title="Goroutine Count" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="CGo Calls">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sys.cgocalls" title="CGo Calls" />
+              </Axis>
+            </LineGraph>
+
+          </GraphGroup>
+        <h2>Internals</h2>
+          <GraphGroup groupId="nodes.internals">
+
+            <StackedAreaGraph title="Key/Value Transactions">
+              <Axis label="transactions/sec" format={ d3.format(".1f") }>
+                <Metric name="cr.node.txn.commits-count" title="Commits" nonNegativeRate />
+                <Metric name="cr.node.txn.commits1PC-count" title="Fast 1PC" nonNegativeRate />
+                <Metric name="cr.node.txn.aborts-count" title="Aborts" nonNegativeRate />
+                <Metric name="cr.node.txn.abandons-count" title="Abandons" nonNegativeRate />
+              </Axis>
+            </StackedAreaGraph>
+
+            <LineGraph title="Engine Memory Usage">
+              <Axis format={ Bytes }>
+                <Metric name="cr.store.rocksdb.block.cache.usage" title="Block Cache" />
+                <Metric name="cr.store.rocksdb.block.cache.pinned-usage" title="Iterators" />
+                <Metric name="cr.store.rocksdb.memtable.total-size" title="Memtable" />
+              </Axis>
+            </LineGraph>
+
+            <StackedAreaGraph title="Block Cache Hits/Misses">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.store.rocksdb.block.cache.hits"
+                        title="Cache Hits"
+                        nonNegativeRate />
+                <Metric name="cr.store.rocksdb.block.cache.misses"
+                        title="Cache Missses"
+                        nonNegativeRate />
+              </Axis>
+            </StackedAreaGraph>
+
+            <StackedAreaGraph title="Range Events">
+              <Axis format={ d3.format(".1f") }>
+                <Metric name="cr.store.range.splits" title="Splits" nonNegativeRate />
+                <Metric name="cr.store.range.adds" title="Adds" nonNegativeRate />
+                <Metric name="cr.store.range.removes" title="Removes" nonNegativeRate />
+              </Axis>
+            </StackedAreaGraph>
+
+            <LineGraph title="Flushes and Compactions">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.store.rocksdb.flushes" title="Flushes" nonNegativeRate />
+                <Metric name="cr.store.rocksdb.compactions" title="Compactions" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Bloom Filter Prefix">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.store.rocksdb.bloom.filter.prefix.checked"
+                        title="Checked"
+                        nonNegativeRate />
+                <Metric name="cr.store.rocksdb.bloom.filter.prefix.useful"
+                        title="Useful"
+                        nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Clock Offset">
+              <Axis label="Milliseconds" format={ (n) => d3.format(".1f")(NanoToMilli(n)) }>
+                <Metric name="cr.node.clock-offset.upper-bound-nanos" title="Upper Bound" />
+                <Metric name="cr.node.clock-offset.lower-bound-nanos" title="Lower Bound" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="GC Pause Time">
+              <Axis label="Milliseconds" format={ (n) => d3.format(".1f")(NanoToMilli(n)) }>
+                <Metric name="cr.node.sys.gc.pause.ns" title="Time" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+          </GraphGroup>
+      </div>
     </div>;
   }
 }

--- a/ui/next/package.json
+++ b/ui/next/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "chai": "^3.5.0",
+    "d3": "^3.5.17",
     "enzyme": "^2.2.0",
     "fetch-mock": "^4.4.0",
     "isomorphic-fetch": "^2.2.1",


### PR DESCRIPTION
Convert existing graphs from nodes graphs page.

`GraphGroup` has been promoted to its own component, shared by any page which
displays multiple graphs.

`Metric` can now specify max/min for both downsampler and source aggregator.

Commit also creates `StackedAreaGraph`, an alternative to `LineGraph` which was
indicated in the previous UI by a `.stacked()` option on the normal LineGraph.
There is some apparent code duplication, but due to the lack of a common
interface between NVD3's LineChart and StackedAreaChart components, some of this
duplication is inevitable. A suggestion has been logged in the app.tsx

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6760)

<!-- Reviewable:end -->
