### PR TITLE
Revert "kv: Set default SendNextTimeout to a reasonable value"

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -43,7 +43,10 @@ import (
 const (
 	// TODO(bdarnell): make SendNextTimeout configurable.
 	// https://github.com/cockroachdb/cockroach/issues/6719
-	defaultSendNextTimeout = 500 * time.Millisecond
+	//
+	// Temporarily increased from 500ms to 10s; see
+	// https://github.com/cockroachdb/cockroach/issues/6750
+	defaultSendNextTimeout = 10 * time.Second
 	defaultClientTimeout   = 10 * time.Second
 
 	// The default maximum number of ranges to return from a range


### PR DESCRIPTION
This reverts commit f0be19ff11b87ff86f0d1e5cb33c4d1e20d608ef.

I think this change was responsible for the race seen in #6750,
but I haven't been able to reproduce it in a test yet.

@mberhault Let's see if this stabilizes things for the beta clusters.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6767)

<!-- Reviewable:end -->
