### PR TITLE
UI: Fixes some issues with the help-us page

### DIFF
--- a/ui/ts/components/health.ts
+++ b/ui/ts/components/health.ts
@@ -16,6 +16,10 @@ module Components {
     import Health = Models.Health;
 
     export function controller(): any {
+      Health.startRefresh();
+      return {
+        onunload: (): void => Health.endRefresh(),
+      };
     }
 
     export function view(ctrl: any): _mithril.MithrilVirtualElement {

--- a/ui/ts/models/cockroachlabs.ts
+++ b/ui/ts/models/cockroachlabs.ts
@@ -49,6 +49,7 @@ module Models {
       last_name: string;
       company: string;
       email: string;
+      product_updates: boolean;
     }
 
     export class CockroachLabs {
@@ -181,6 +182,7 @@ module Models {
             last_name: data.lastname,
             company: data.company,
             email: data.email,
+            product_updates: data.updates,
           });
         } else {
           p = this.unregister();

--- a/ui/ts/models/health.ts
+++ b/ui/ts/models/health.ts
@@ -29,17 +29,15 @@ module Models {
       });
     };
 
-    function endRefresh(): void {
+    export function endRefresh(): void {
       if (interval) {
         clearInterval(interval);
       }
     }
 
-    function startRefresh(): void {
+    export function startRefresh(): void {
       endRefresh();
       interval = setInterval(getHealth, 2000);
     }
-
-    startRefresh();
   }
 }


### PR DESCRIPTION
- Stops the health widget from running on the HelpUs page. This
  was causing form fields to clear content.
- Sends whether they have opted-in to product updates or not.
  This data is used by hubspot.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6769)

<!-- Reviewable:end -->
