### PR TITLE
storage: Give up lease acquisition when draining

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -558,7 +558,7 @@ func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) <-chan *roachp
 					}
 				}
 				return c.Err
-			case <-r.store.Stopper().ShouldStop():
+			case <-r.store.Stopper().ShouldDrain():
 				return roachpb.NewError(r.newNotLeaderError(nil, r.store.StoreID()))
 			}
 		}()


### PR DESCRIPTION
This establishes parity with the other case (in which the task does not even
get started) and should address a relatively common reason for an invocation
of `./cockroach quit` to run into the hard limit.

cc @jseldess

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6777)

<!-- Reviewable:end -->
