### PR TITLE
cli: remove `exterminate`

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -400,11 +400,6 @@ func initFlags(ctx *Context) {
 		f.Var(cacheSize, cliflags.CacheName, usageNoEnv(cliflags.CacheName))
 	}
 
-	{
-		f := exterminateCmd.Flags()
-		f.Var(&ctx.Stores, cliflags.StoreName, usageNoEnv(cliflags.StoreName))
-	}
-
 	for _, cmd := range certCmds {
 		f := cmd.Flags()
 		// Certificate flags.
@@ -418,7 +413,7 @@ func initFlags(ctx *Context) {
 	setUserCmd.Flags().StringVar(&password, cliflags.PasswordName, envutil.EnvOrDefaultString(cliflags.PasswordName, ""), usageEnv(cliflags.PasswordName))
 
 	clientCmds := []*cobra.Command{
-		sqlShellCmd, exterminateCmd, quitCmd, freezeClusterCmd, /* startCmd is covered above */
+		sqlShellCmd, quitCmd, freezeClusterCmd, /* startCmd is covered above */
 	}
 	clientCmds = append(clientCmds, kvCmds...)
 	clientCmds = append(clientCmds, rangeCmds...)
@@ -447,7 +442,7 @@ func initFlags(ctx *Context) {
 	}
 
 	// Commands that need the cockroach port.
-	simpleCmds := []*cobra.Command{exterminateCmd, freezeClusterCmd}
+	simpleCmds := []*cobra.Command{freezeClusterCmd}
 	simpleCmds = append(simpleCmds, kvCmds...)
 	simpleCmds = append(simpleCmds, rangeCmds...)
 	for _, cmd := range simpleCmds {


### PR DESCRIPTION
Whether we ultimately want a command like that is not determined (see #6197),
but the code isn't currently working correctly (#6196) and it's set up in the
legacy way, which hinders the upcoming migration of the `quit` command.
A re-implementation of the code would likely want to erase the data on the
server side (and not from the cli).

cc @BramGruneir
cc @jseldess for documentation

Closes #6197, closes #6198.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6780)

<!-- Reviewable:end -->
