### PR TITLE
cli: Avoid os.Exit in `sql -e`

### DIFF
--- a/cli/sql.go
+++ b/cli/sql.go
@@ -322,8 +322,7 @@ func runStatements(conn *sqlConn, stmts []string) error {
 				if err == pq.ErrNoMoreResults {
 					break
 				}
-				fmt.Fprintln(osStderr, err)
-				os.Exit(1)
+				return err
 			}
 
 			if len(cols) == 0 {


### PR DESCRIPTION
Discovered while writing a test which would have to run a failing
invocation, which before this change would simply quit the process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6781)

<!-- Reviewable:end -->
