### PR TITLE
sql/parser: Address performance concerns with default DECIMAL type

### DIFF
--- a/sql/distsql/server.go
+++ b/sql/distsql/server.go
@@ -19,6 +19,8 @@ package distsql
 import (
 	"golang.org/x/net/context"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -42,8 +44,11 @@ var _ DistSQLServer = &ServerImpl{}
 // NewServer instantiates a DistSQLServer.
 func NewServer(ctx ServerContext) *ServerImpl {
 	ds := &ServerImpl{
-		ctx:     ctx,
-		evalCtx: parser.EvalContext{ReCache: parser.NewRegexpCache(512)},
+		ctx: ctx,
+		evalCtx: parser.EvalContext{
+			ReCache: parser.NewRegexpCache(512),
+			TmpDec:  new(inf.Dec),
+		},
 	}
 	return ds
 }

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -964,9 +964,9 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{TypeDecimal, TypeInt},
 			ReturnType: TypeDecimal,
 			fn: func(_ EvalContext, args DTuple) (Datum, error) {
-				dec := args[0].(*DDecimal)
+				dec := &args[0].(*DDecimal).Dec
 				dd := &DDecimal{}
-				dd.Round(&dec.Dec, inf.Scale(*args[1].(*DInt)), inf.RoundHalfUp)
+				dd.Round(dec, inf.Scale(*args[1].(*DInt)), inf.RoundHalfUp)
 				return dd, nil
 			},
 		},
@@ -1238,8 +1238,8 @@ func decimalBuiltin1(f func(*inf.Dec) (Datum, error)) Builtin {
 		Types:      ArgTypes{TypeDecimal},
 		ReturnType: TypeDecimal,
 		fn: func(_ EvalContext, args DTuple) (Datum, error) {
-			dec := args[0].(*DDecimal)
-			return f(&dec.Dec)
+			dec := &args[0].(*DDecimal).Dec
+			return f(dec)
 		},
 	}
 }
@@ -1249,9 +1249,9 @@ func decimalBuiltin2(f func(*inf.Dec, *inf.Dec) (Datum, error)) Builtin {
 		Types:      ArgTypes{TypeDecimal, TypeDecimal},
 		ReturnType: TypeDecimal,
 		fn: func(_ EvalContext, args DTuple) (Datum, error) {
-			dec1 := args[0].(*DDecimal)
-			dec2 := args[1].(*DDecimal)
-			return f(&dec1.Dec, &dec2.Dec)
+			dec1 := &args[0].(*DDecimal).Dec
+			dec2 := &args[1].(*DDecimal).Dec
+			return f(dec1, dec2)
 		},
 	}
 }

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -120,9 +120,9 @@ var UnaryOps = map[UnaryOperator]unaryOpOverload{
 			Typ:        TypeDecimal,
 			ReturnType: TypeDecimal,
 			fn: func(_ EvalContext, d Datum) (Datum, error) {
-				dec := d.(*DDecimal)
+				dec := &d.(*DDecimal).Dec
 				dd := &DDecimal{}
-				dd.Neg(&dec.Dec)
+				dd.Neg(dec)
 				return dd, nil
 			},
 		},
@@ -240,10 +240,10 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-				l := left.(*DDecimal).Dec
-				r := right.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
+				r := &right.(*DDecimal).Dec
 				dd := &DDecimal{}
-				dd.Add(&l, &r)
+				dd.Add(l, r)
 				return dd, nil
 			},
 		},
@@ -329,10 +329,10 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-				l := left.(*DDecimal).Dec
-				r := right.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
+				r := &right.(*DDecimal).Dec
 				dd := &DDecimal{}
-				dd.Sub(&l, &r)
+				dd.Sub(l, r)
 				return dd, nil
 			},
 		},
@@ -421,11 +421,11 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  TypeInt,
 			ReturnType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-				l := left.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
 				r := *right.(*DInt)
 				dd := &DDecimal{}
 				dd.SetUnscaled(int64(r))
-				dd.Mul(&dd.Dec, &l)
+				dd.Mul(&dd.Dec, l)
 				return dd, nil
 			},
 		},
@@ -435,10 +435,10 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			ReturnType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
 				l := *left.(*DInt)
-				r := right.(*DDecimal).Dec
+				r := &right.(*DDecimal).Dec
 				dd := &DDecimal{}
 				dd.SetUnscaled(int64(l))
-				dd.Mul(&dd.Dec, &r)
+				dd.Mul(&dd.Dec, r)
 				return dd, nil
 			},
 		},
@@ -447,10 +447,10 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-				l := left.(*DDecimal).Dec
-				r := right.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
+				r := &right.(*DDecimal).Dec
 				dd := &DDecimal{}
-				dd.Mul(&l, &r)
+				dd.Mul(l, r)
 				return dd, nil
 			},
 		},
@@ -502,13 +502,13 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-				l := left.(*DDecimal).Dec
-				r := right.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
+				r := &right.(*DDecimal).Dec
 				if r.Sign() == 0 {
 					return nil, errDivByZero
 				}
 				dd := &DDecimal{}
-				dd.QuoRound(&l, &r, decimal.Precision, inf.RoundHalfUp)
+				dd.QuoRound(l, r, decimal.Precision, inf.RoundHalfUp)
 				return dd, nil
 			},
 		},
@@ -552,13 +552,13 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
-				l := left.(*DDecimal).Dec
-				r := right.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
+				r := &right.(*DDecimal).Dec
 				if r.Sign() == 0 {
 					return nil, errZeroModulus
 				}
 				dd := &DDecimal{}
-				decimal.Mod(&dd.Dec, &l, &r)
+				decimal.Mod(&dd.Dec, l, r)
 				return dd, nil
 			},
 		},
@@ -697,9 +697,9 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			LeftType:  TypeDecimal,
 			RightType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := left.(*DDecimal).Dec
-				r := right.(*DDecimal).Dec
-				return DBool(l.Cmp(&r) == 0), nil
+				l := &left.(*DDecimal).Dec
+				r := &right.(*DDecimal).Dec
+				return DBool(l.Cmp(r) == 0), nil
 			},
 		},
 		CmpOp{
@@ -720,7 +720,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			LeftType:  TypeDecimal,
 			RightType: TypeInt,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := left.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
 				r := inf.NewDec(int64(*right.(*DInt)), 0)
 				return DBool(l.Cmp(r) == 0), nil
 			},
@@ -730,15 +730,15 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			RightType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 				l := inf.NewDec(int64(*left.(*DInt)), 0)
-				r := right.(*DDecimal).Dec
-				return DBool(l.Cmp(&r) == 0), nil
+				r := &right.(*DDecimal).Dec
+				return DBool(l.Cmp(r) == 0), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeFloat,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := left.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
 				r := decimal.NewDecFromFloat(float64(*right.(*DFloat)))
 				return DBool(l.Cmp(r) == 0), nil
 			},
@@ -748,8 +748,8 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			RightType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 				l := decimal.NewDecFromFloat(float64(*left.(*DFloat)))
-				r := right.(*DDecimal).Dec
-				return DBool(l.Cmp(&r) == 0), nil
+				r := &right.(*DDecimal).Dec
+				return DBool(l.Cmp(r) == 0), nil
 			},
 		},
 		CmpOp{
@@ -830,9 +830,9 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			LeftType:  TypeDecimal,
 			RightType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := left.(*DDecimal).Dec
-				r := right.(*DDecimal).Dec
-				return DBool(l.Cmp(&r) < 0), nil
+				l := &left.(*DDecimal).Dec
+				r := &right.(*DDecimal).Dec
+				return DBool(l.Cmp(r) < 0), nil
 			},
 		},
 		CmpOp{
@@ -853,7 +853,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			LeftType:  TypeDecimal,
 			RightType: TypeInt,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := left.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
 				r := inf.NewDec(int64(*right.(*DInt)), 0)
 				return DBool(l.Cmp(r) < 0), nil
 			},
@@ -863,15 +863,15 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			RightType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 				l := inf.NewDec(int64(*left.(*DInt)), 0)
-				r := right.(*DDecimal).Dec
-				return DBool(l.Cmp(&r) < 0), nil
+				r := &right.(*DDecimal).Dec
+				return DBool(l.Cmp(r) < 0), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeFloat,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := left.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
 				r := decimal.NewDecFromFloat(float64(*right.(*DFloat)))
 				return DBool(l.Cmp(r) < 0), nil
 			},
@@ -881,8 +881,8 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			RightType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 				l := decimal.NewDecFromFloat(float64(*left.(*DFloat)))
-				r := right.(*DDecimal).Dec
-				return DBool(l.Cmp(&r) < 0), nil
+				r := &right.(*DDecimal).Dec
+				return DBool(l.Cmp(r) < 0), nil
 			},
 		},
 		CmpOp{
@@ -963,9 +963,9 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			LeftType:  TypeDecimal,
 			RightType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := left.(*DDecimal).Dec
-				r := right.(*DDecimal).Dec
-				return DBool(l.Cmp(&r) <= 0), nil
+				l := &left.(*DDecimal).Dec
+				r := &right.(*DDecimal).Dec
+				return DBool(l.Cmp(r) <= 0), nil
 			},
 		},
 		CmpOp{
@@ -986,7 +986,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			LeftType:  TypeDecimal,
 			RightType: TypeInt,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := left.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
 				r := inf.NewDec(int64(*right.(*DInt)), 0)
 				return DBool(l.Cmp(r) <= 0), nil
 			},
@@ -996,15 +996,15 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			RightType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 				l := inf.NewDec(int64(*left.(*DInt)), 0)
-				r := right.(*DDecimal).Dec
-				return DBool(l.Cmp(&r) <= 0), nil
+				r := &right.(*DDecimal).Dec
+				return DBool(l.Cmp(r) <= 0), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeFloat,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := left.(*DDecimal).Dec
+				l := &left.(*DDecimal).Dec
 				r := decimal.NewDecFromFloat(float64(*right.(*DFloat)))
 				return DBool(l.Cmp(r) <= 0), nil
 			},
@@ -1014,8 +1014,8 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			RightType: TypeDecimal,
 			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
 				l := decimal.NewDecFromFloat(float64(*left.(*DFloat)))
-				r := right.(*DDecimal).Dec
-				return DBool(l.Cmp(&r) <= 0), nil
+				r := &right.(*DDecimal).Dec
+				return DBool(l.Cmp(r) <= 0), nil
 			},
 		},
 		CmpOp{

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -477,12 +477,12 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(ctx EvalContext, left Datum, right Datum) (Datum, error) {
 				rInt := *right.(*DInt)
 				if rInt == 0 {
 					return nil, errDivByZero
 				}
-				div := inf.NewDec(int64(rInt), 0)
+				div := ctx.getTmpDec().SetUnscaled(int64(rInt)).SetScale(0)
 				dd := &DDecimal{}
 				dd.SetUnscaled(int64(*left.(*DInt)))
 				dd.QuoRound(&dd.Dec, div, decimal.Precision, inf.RoundHalfUp)
@@ -719,17 +719,17 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
-				r := inf.NewDec(int64(*right.(*DInt)), 0)
+				r := ctx.getTmpDec().SetUnscaled(int64(*right.(*DInt))).SetScale(0)
 				return DBool(l.Cmp(r) == 0), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := inf.NewDec(int64(*left.(*DInt)), 0)
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+				l := ctx.getTmpDec().SetUnscaled(int64(*left.(*DInt))).SetScale(0)
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) == 0), nil
 			},
@@ -737,17 +737,17 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
-				r := decimal.NewDecFromFloat(float64(*right.(*DFloat)))
+				r := decimal.SetFromFloat(ctx.getTmpDec(), float64(*right.(*DFloat)))
 				return DBool(l.Cmp(r) == 0), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := decimal.NewDecFromFloat(float64(*left.(*DFloat)))
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+				l := decimal.SetFromFloat(ctx.getTmpDec(), float64(*left.(*DFloat)))
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) == 0), nil
 			},
@@ -852,17 +852,17 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
-				r := inf.NewDec(int64(*right.(*DInt)), 0)
+				r := ctx.getTmpDec().SetUnscaled(int64(*right.(*DInt))).SetScale(0)
 				return DBool(l.Cmp(r) < 0), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := inf.NewDec(int64(*left.(*DInt)), 0)
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+				l := ctx.getTmpDec().SetUnscaled(int64(*left.(*DInt))).SetScale(0)
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) < 0), nil
 			},
@@ -870,17 +870,17 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
-				r := decimal.NewDecFromFloat(float64(*right.(*DFloat)))
+				r := decimal.SetFromFloat(ctx.getTmpDec(), float64(*right.(*DFloat)))
 				return DBool(l.Cmp(r) < 0), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := decimal.NewDecFromFloat(float64(*left.(*DFloat)))
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+				l := decimal.SetFromFloat(ctx.getTmpDec(), float64(*left.(*DFloat)))
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) < 0), nil
 			},
@@ -985,17 +985,17 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
-				r := inf.NewDec(int64(*right.(*DInt)), 0)
+				r := ctx.getTmpDec().SetUnscaled(int64(*right.(*DInt))).SetScale(0)
 				return DBool(l.Cmp(r) <= 0), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := inf.NewDec(int64(*left.(*DInt)), 0)
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+				l := ctx.getTmpDec().SetUnscaled(int64(*left.(*DInt))).SetScale(0)
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) <= 0), nil
 			},
@@ -1003,17 +1003,17 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
-				r := decimal.NewDecFromFloat(float64(*right.(*DFloat)))
+				r := decimal.SetFromFloat(ctx.getTmpDec(), float64(*right.(*DFloat)))
 				return DBool(l.Cmp(r) <= 0), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
-				l := decimal.NewDecFromFloat(float64(*left.(*DFloat)))
+			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+				l := decimal.SetFromFloat(ctx.getTmpDec(), float64(*left.(*DFloat)))
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) <= 0), nil
 			},
@@ -1156,6 +1156,7 @@ type EvalContext struct {
 	clusterTimestamp roachpb.Timestamp
 
 	ReCache  *RegexpCache
+	TmpDec   *inf.Dec
 	Location *time.Location
 	Args     MapArgs
 
@@ -1242,6 +1243,13 @@ func (ctx EvalContext) makeDDate(t time.Time) (*DDate, error) {
 	year, month, day := t.In(ctx.GetLocation()).Date()
 	secs := time.Date(year, month, day, 0, 0, 0, 0, time.UTC).Unix()
 	return NewDDate(DDate(secs / secondsInDay)), nil
+}
+
+func (ctx EvalContext) getTmpDec() *inf.Dec {
+	if ctx.TmpDec != nil {
+		return ctx.TmpDec
+	}
+	return new(inf.Dec)
 }
 
 // Eval implements the Expr interface.

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"gopkg.in/inf.v0"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -170,6 +172,7 @@ func (p *planner) resetForBatch(e *Executor) {
 	p.evalCtx = parser.EvalContext{
 		NodeID:   e.nodeID,
 		ReCache:  e.reCache,
+		TmpDec:   new(inf.Dec),
 		Location: p.session.Location,
 	}
 	p.session.TxnState.schemaChangers.curGroupNum++


### PR DESCRIPTION
Addresses performance concerns brought up in https://github.com/cockroachdb/cockroach/pull/6752.
#### Changes:
- make sure decimal references do not allocate on evaluation
- add a temporary working decimal to `EvalContext`
  
  _(this could be a lot cleaner if we passed around a pointer to `EvalContext`)_
- return statically allocated errors from `asInt64`
#### Perf impact:

```
name                 old time/op    new time/op    delta
Select3_Cockroach-4    1.33ms ± 4%    1.08ms ± 3%  -18.41%  (p=0.000 n=20+19)

name                 old alloc/op   new alloc/op   delta
Select3_Cockroach-4     182kB ± 0%     139kB ± 0%  -23.70%  (p=0.000 n=18+20)

name                 old allocs/op  new allocs/op  delta
Select3_Cockroach-4     3.19k ± 0%     2.26k ± 0%  -28.90%  (p=0.000 n=17+20)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6787)

<!-- Reviewable:end -->
