### PR TITLE
encoding: fix decimal encoding bug

### DIFF
--- a/util/encoding/decimal_test.go
+++ b/util/encoding/decimal_test.go
@@ -91,7 +91,7 @@ func TestDecimalMandE(t *testing.T) {
 			d.SetScale(d.Scale() - inf.Scale(scale))
 		}
 
-		if e, m := decimalMandE(d, nil); e != c.E || !bytes.Equal(m, c.M) {
+		if e, m := decimalEandM(d, nil); e != c.E || !bytes.Equal(m, c.M) {
 			t.Errorf("unexpected mismatch in E/M for %v. expected E=%v | M=[% x], got E=%v | M=[% x]",
 				c.Value, c.E, c.M, e, m)
 		}
@@ -104,6 +104,34 @@ func mustDecimal(s string) *inf.Dec {
 		panic(fmt.Sprintf("could not set string %q on decimal", s))
 	}
 	return d
+}
+
+func randBuf(rng *rand.Rand, maxLen int) []byte {
+	buf := make([]byte, rng.Intn(maxLen+1))
+	_, _ = rng.Read(buf)
+	return buf
+}
+
+func encodeDecimalWithDir(dir Direction, buf []byte, d *inf.Dec) []byte {
+	if dir == Ascending {
+		return EncodeDecimalAscending(buf, d)
+	}
+	return EncodeDecimalDescending(buf, d)
+}
+
+func decodeDecimalWithDir(t *testing.T, dir Direction, buf []byte, tmp []byte) ([]byte, *inf.Dec) {
+	var err error
+	var resBuf []byte
+	var res *inf.Dec
+	if dir == Ascending {
+		resBuf, res, err = DecodeDecimalAscending(buf, tmp)
+	} else {
+		resBuf, res, err = DecodeDecimalDescending(buf, tmp)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resBuf, res
 }
 
 func TestEncodeDecimal(t *testing.T) {
@@ -155,20 +183,14 @@ func TestEncodeDecimal(t *testing.T) {
 		{inf.NewDec(99122839898321208, -99999), []byte{0x34, 0xf7, 0xc3, 0x58, 0xc7, 0x19, 0x39, 0x4f, 0xb3, 0xa7, 0x2b, 0x29, 0xa0, 0x00}},
 	}
 
+	rng, _ := randutil.NewPseudoRand()
+
 	var lastEncoded []byte
 	for _, dir := range []Direction{Ascending, Descending} {
 		for _, tmp := range [][]byte{nil, make([]byte, 0, 100)} {
 			for i, c := range testCases {
-				var enc []byte
-				var err error
-				var dec *inf.Dec
-				if dir == Ascending {
-					enc = EncodeDecimalAscending(nil, c.Value)
-					_, dec, err = DecodeDecimalAscending(enc, tmp)
-				} else {
-					enc = EncodeDecimalDescending(nil, c.Value)
-					_, dec, err = DecodeDecimalDescending(enc, tmp)
-				}
+				enc := encodeDecimalWithDir(dir, nil, c.Value)
+				_, dec := decodeDecimalWithDir(t, dir, enc, tmp)
 				if dir == Ascending && !bytes.Equal(enc, c.Encoding) {
 					t.Errorf("unexpected mismatch for %s. expected [% x], got [% x]",
 						c.Value, c.Encoding, enc)
@@ -180,88 +202,102 @@ func TestEncodeDecimal(t *testing.T) {
 							c.Value, testCases[i-1].Encoding, enc)
 					}
 				}
-				if err != nil {
-					t.Error(err)
-					continue
-				}
 				testPeekLength(t, enc)
 				if dec.Cmp(c.Value) != 0 {
 					t.Errorf("%d unexpected mismatch for %v. got %v", i, c.Value, dec)
 				}
 				lastEncoded = enc
-			}
 
-			// Test that appending the decimal to an existing buffer works.
-			var enc []byte
-			var dec *inf.Dec
-			other := inf.NewDec(123, 2)
-			if dir == Ascending {
-				enc = EncodeDecimalAscending([]byte("hello"), other)
-				_, dec, _ = DecodeDecimalAscending(enc[5:], tmp)
-			} else {
-				enc = EncodeDecimalDescending([]byte("hello"), other)
-				_, dec, _ = DecodeDecimalDescending(enc[5:], tmp)
-			}
-			if dec.Cmp(other) != 0 {
-				t.Errorf("unexpected mismatch for %v. got %v", 1.23, other)
+				// Test that appending the decimal to an existing buffer works. It
+				// is important to test with various values, slice lengths, and
+				// capacities because the various encoding paths try to use any
+				// spare capacity to avoid allocations.
+				for trials := 0; trials < 5; trials++ {
+					orig := randBuf(rng, 30)
+					origLen := len(orig)
+
+					bufCap := origLen + rng.Intn(30)
+					buf := make([]byte, origLen, bufCap)
+					copy(buf, orig)
+
+					enc := encodeDecimalWithDir(dir, buf, c.Value)
+					// Append some random bytes
+					enc = append(enc, randBuf(rng, 20)...)
+					_, dec := decodeDecimalWithDir(t, dir, enc[origLen:], tmp)
+
+					if dec.Cmp(c.Value) != 0 {
+						t.Errorf("unexpected mismatch for %v. got %v", c.Value, dec)
+					}
+					// Verify the existing values weren't modified.
+					for i := range orig {
+						if enc[i] != orig[i] {
+							t.Errorf("existing byte %d changed after encoding (from %d to %d)",
+								i, orig[i], enc[i])
+						}
+					}
+				}
 			}
 		}
 	}
 }
 
 func TestEncodeDecimalRand(t *testing.T) {
+	rng, _ := randutil.NewPseudoRand()
 	// Test both directions.
 	for _, dir := range []Direction{Ascending, Descending} {
 		var prev *inf.Dec
 		var prevEnc []byte
-		// Test with and without tmp buffer.
-		for _, tmp := range [][]byte{nil, make([]byte, 0, 100)} {
-			// Test with and without appending buffer.
-			for _, append := range [][]byte{nil, []byte("hello")} {
-				const randomTrials = 50000
-				for i := 0; i < randomTrials; i++ {
-					cur := decimal.NewDecFromFloat(rand.Float64())
+		const randomTrials = 100000
+		for i := 0; i < randomTrials; i++ {
+			cur := randDecimal(rng, -20, 20)
+			var tmp, appendTo []byte
+			// Test with and without appending.
+			if rng.Intn(2) == 1 {
+				appendTo = randBuf(rng, 30)
+				appendTo = appendTo[:rng.Intn(len(appendTo)+1)]
+			}
+			// Test with and without tmp buffer.
+			if rng.Intn(2) == 1 {
+				tmp = randBuf(rng, 100)
+			}
+			var enc []byte
+			var res *inf.Dec
+			var err error
+			if dir == Ascending {
+				enc = EncodeDecimalAscending(appendTo, cur)
+				enc = enc[len(appendTo):]
+				_, res, err = DecodeDecimalAscending(enc, tmp)
+			} else {
+				enc = EncodeDecimalDescending(appendTo, cur)
+				enc = enc[len(appendTo):]
+				_, res, err = DecodeDecimalDescending(enc, tmp)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
 
-					var enc []byte
-					var res *inf.Dec
-					var err error
-					if dir == Ascending {
-						enc = EncodeDecimalAscending(append, cur)
-						enc = enc[len(append):]
-						_, res, err = DecodeDecimalAscending(enc, tmp)
-					} else {
-						enc = EncodeDecimalDescending(append, cur)
-						enc = enc[len(append):]
-						_, res, err = DecodeDecimalDescending(enc, tmp)
-					}
-					if err != nil {
-						t.Fatal(err)
-					}
+			testPeekLength(t, enc)
 
-					testPeekLength(t, enc)
+			// Make sure we decode the same value we encoded.
+			if cur.Cmp(res) != 0 {
+				t.Fatalf("unexpected mismatch for %v, got %v", cur, res)
+			}
 
-					// Make sure we decode the same value we encoded.
-					if cur.Cmp(res) != 0 {
-						t.Fatalf("unexpected mismatch for %v, got %v", cur, res)
-					}
-
-					// Make sure lexicographical sorting is consistent.
-					if prev != nil {
-						bytesCmp := bytes.Compare(prevEnc, enc)
-						cmpType := "same"
-						if dir == Descending {
-							bytesCmp *= -1
-							cmpType = "inverse"
-						}
-						if decCmp := prev.Cmp(cur); decCmp != bytesCmp {
-							t.Fatalf("expected [% x] to compare to [% x] the %s way that %v compares to %v",
-								prevEnc, enc, cmpType, prev, cur)
-						}
-					}
-					prev = cur
-					prevEnc = enc
+			// Make sure lexicographical sorting is consistent.
+			if prev != nil {
+				bytesCmp := bytes.Compare(prevEnc, enc)
+				cmpType := "same"
+				if dir == Descending {
+					bytesCmp *= -1
+					cmpType = "inverse"
+				}
+				if decCmp := prev.Cmp(cur); decCmp != bytesCmp {
+					t.Fatalf("expected [% x] to compare to [% x] the %s way that %v compares to %v",
+						prevEnc, enc, cmpType, prev, cur)
 				}
 			}
+			prev = cur
+			prevEnc = enc
 		}
 	}
 }
@@ -310,6 +346,8 @@ func TestNonsortingEncodeDecimal(t *testing.T) {
 		{inf.NewDec(99122839898321208, -99999), []byte{0x34, 0xf8, 0x01, 0x86, 0xb0, 0x01, 0x60, 0x27, 0xb2, 0x9d, 0x44, 0x71, 0x38}},
 	}
 
+	rng, _ := randutil.NewPseudoRand()
+
 	for _, tmp := range [][]byte{nil, make([]byte, 0, 100)} {
 		for i, c := range testCases {
 			enc := EncodeNonsortingDecimal(nil, c.Value)
@@ -325,48 +363,70 @@ func TestNonsortingEncodeDecimal(t *testing.T) {
 			if dec.Cmp(c.Value) != 0 {
 				t.Errorf("%d unexpected mismatch for %v. got %v", i, c.Value, dec)
 			}
-		}
+			// Test that appending the decimal to an existing buffer works. It
+			// is important to test with various values, slice lengths, and
+			// capacities because the various encoding paths try to use any
+			// spare capacity to avoid allocations.
+			for trials := 0; trials < 5; trials++ {
+				orig := randBuf(rng, 30)
+				origLen := len(orig)
 
-		// Test that appending the decimal to an existing buffer works.
-		other := inf.NewDec(123, 2)
-		enc := EncodeNonsortingDecimal([]byte("hello"), other)
-		dec, err := DecodeNonsortingDecimal(enc[5:], tmp)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-		if dec.Cmp(other) != 0 {
-			t.Errorf("unexpected mismatch for %v. got %v", 1.23, other)
+				bufCap := origLen + rng.Intn(30)
+				buf := make([]byte, origLen, bufCap)
+				copy(buf, orig)
+
+				enc := EncodeNonsortingDecimal(buf, c.Value)
+				dec, err := DecodeNonsortingDecimal(enc[origLen:], tmp)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if dec.Cmp(c.Value) != 0 {
+					t.Errorf("unexpected mismatch for %v. got %v", c.Value, dec)
+				}
+				// Verify the existing values weren't modified.
+				for i := range orig {
+					if enc[i] != orig[i] {
+						t.Errorf("existing byte %d changed after encoding (from %d to %d)",
+							i, orig[i], enc[i])
+					}
+				}
+			}
 		}
 	}
 }
 
 func TestNonsortingEncodeDecimalRand(t *testing.T) {
-	// Test with and without tmp buffer.
-	for _, tmp := range [][]byte{nil, make([]byte, 0, 100)} {
-		// Test with and without appending buffer.
-		for _, append := range [][]byte{nil, []byte("hello")} {
-			const randomTrials = 200000
-			for i := 0; i < randomTrials; i++ {
-				cur := decimal.NewDecFromFloat(rand.Float64())
+	rng, _ := randutil.NewPseudoRand()
+	const randomTrials = 200000
+	for i := 0; i < randomTrials; i++ {
+		var tmp, appendTo []byte
+		// Test with and without appending.
+		if rng.Intn(2) == 1 {
+			appendTo = randBuf(rng, 30)
+			appendTo = appendTo[:rng.Intn(len(appendTo)+1)]
+		}
+		// Test with and without tmp buffer.
+		if rng.Intn(2) == 1 {
+			tmp = randBuf(rng, 100)
+		}
+		cur := randDecimal(rng, -20, 20)
 
-				enc := EncodeNonsortingDecimal(append, cur)
-				enc = enc[len(append):]
-				res, err := DecodeNonsortingDecimal(enc, tmp)
-				if err != nil {
-					t.Fatal(err)
-				}
+		enc := EncodeNonsortingDecimal(appendTo, cur)
+		enc = enc[len(appendTo):]
+		res, err := DecodeNonsortingDecimal(enc, tmp)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-				// Make sure we decode the same value we encoded.
-				if cur.Cmp(res) != 0 {
-					t.Fatalf("unexpected mismatch for %v, got %v", cur, res)
-				}
+		// Make sure we decode the same value we encoded.
+		if cur.Cmp(res) != 0 {
+			t.Fatalf("unexpected mismatch for %v, got %v", cur, res)
+		}
 
-				// Make sure we would have overestimated the value.
-				if est := UpperBoundNonsortingDecimalSize(cur); est < len(enc) {
-					t.Fatalf("expected estimate of %d for %v to be greater than or equal to the encoded length, found [% x]", est, cur, enc)
-				}
-			}
+		// Make sure we would have overestimated the value.
+		if est := UpperBoundNonsortingDecimalSize(cur); est < len(enc) {
+			t.Fatalf("expected estimate of %d for %v to be greater than or equal to the encoded length, found [% x]", est, cur, enc)
 		}
 	}
 }
@@ -426,7 +486,6 @@ func randDecimal(rng *rand.Rand, minExp, maxExp int) *inf.Dec {
 
 // makeDecimalVals creates decimal values with exponents in
 // the range [minExp, maxExp].
-// range.
 func makeDecimalVals(minExp, maxExp int) []*inf.Dec {
 	rng, _ := randutil.NewPseudoRand()
 	vals := make([]*inf.Dec, 10000)

--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -351,6 +351,41 @@ func EncodeUvarintDescending(b []byte, v uint64) []byte {
 	}
 }
 
+// highestByteIndex returns the index (0 to 7) of the highest nonzero byte in v.
+func highestByteIndex(v uint64) int {
+	l := 0
+	if v > 0xffffffff {
+		v >>= 32
+		l += 4
+	}
+	if v > 0xffff {
+		v >>= 16
+		l += 2
+	}
+	if v > 0xff {
+		l++
+	}
+	return l
+}
+
+// EncLenUvarintAscending returns the encoding length for EncodeUvarintAscending
+// without actually encoding.
+func EncLenUvarintAscending(v uint64) int {
+	if v <= intSmall {
+		return 1
+	}
+	return 2 + highestByteIndex(v)
+}
+
+// EncLenUvarintDescending returns the encoding length for
+// EncodeUvarintDescending without actually encoding.
+func EncLenUvarintDescending(v uint64) int {
+	if v == 0 {
+		return 1
+	}
+	return 2 + highestByteIndex(v)
+}
+
 // DecodeUvarintAscending decodes a varint encoded uint64 from the input
 // buffer. The remainder of the input buffer and the decoded uint64
 // are returned.

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -105,7 +105,7 @@ func TestEncodeDecodeUint32Descending(t *testing.T) {
 func testBasicEncodeDecodeUint64(
 	encFunc func([]byte, uint64) []byte,
 	decFunc func([]byte) ([]byte, uint64, error),
-	descending, testPeekLen bool,
+	descending, testPeekLen, testUvarintEncLen bool,
 	t *testing.T,
 ) {
 	testCases := []uint64{
@@ -142,6 +142,18 @@ func testBasicEncodeDecodeUint64(
 		}
 		if testPeekLen {
 			testPeekLength(t, enc)
+		}
+		if testUvarintEncLen {
+			var encLen int
+			if descending {
+				encLen = EncLenUvarintDescending(v)
+			} else {
+				encLen = EncLenUvarintAscending(v)
+			}
+			if encLen != len(enc) {
+				t.Errorf("EncLenUvarint for %d returned incorrect length %d, should be %d",
+					v, encLen, len(enc))
+			}
 		}
 		lastEnc = enc
 	}
@@ -231,7 +243,7 @@ func testCustomEncodeUint64(testCases []testCaseUint64,
 }
 
 func TestEncodeDecodeUint64(t *testing.T) {
-	testBasicEncodeDecodeUint64(EncodeUint64Ascending, DecodeUint64Ascending, false, false, t)
+	testBasicEncodeDecodeUint64(EncodeUint64Ascending, DecodeUint64Ascending, false, false, false, t)
 	testCases := []testCaseUint64{
 		{0, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
 		{1, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}},
@@ -242,7 +254,7 @@ func TestEncodeDecodeUint64(t *testing.T) {
 }
 
 func TestEncodeDecodeUint64Descending(t *testing.T) {
-	testBasicEncodeDecodeUint64(EncodeUint64Descending, DecodeUint64Descending, true, false, t)
+	testBasicEncodeDecodeUint64(EncodeUint64Descending, DecodeUint64Descending, true, false, false, t)
 	testCases := []testCaseUint64{
 		{0, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
 		{1, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe}},
@@ -286,7 +298,7 @@ func TestEncodeDecodeVarintDescending(t *testing.T) {
 }
 
 func TestEncodeDecodeUvarint(t *testing.T) {
-	testBasicEncodeDecodeUint64(EncodeUvarintAscending, DecodeUvarintAscending, false, true, t)
+	testBasicEncodeDecodeUint64(EncodeUvarintAscending, DecodeUvarintAscending, false, true, true, t)
 	testCases := []testCaseUint64{
 		{0, []byte{0x88}},
 		{1, []byte{0x89}},
@@ -299,7 +311,7 @@ func TestEncodeDecodeUvarint(t *testing.T) {
 }
 
 func TestEncodeDecodeUvarintDescending(t *testing.T) {
-	testBasicEncodeDecodeUint64(EncodeUvarintDescending, DecodeUvarintDescending, true, true, t)
+	testBasicEncodeDecodeUint64(EncodeUvarintDescending, DecodeUvarintDescending, true, true, true, t)
 	testCases := []testCaseUint64{
 		{0, []byte{0x88}},
 		{1, []byte{0x87, 0xfe}},


### PR DESCRIPTION
While working on EncDatums I discovered an encoding bug that only shows up if
the buffer we are appending to has enough extra capacity. We use the extra
capacity in various ways to avoid allocations during encoding. The problem was
that when we encoded a variable exponent into the buffer, we were potentially
overwriting part of the mantissa which lived in the same buffer.

Fixing by adding functions that tell us the Uvarint encoded length without
actually encoding. Cleaning up the encoding code and adding comments explaining
all this. Adding tests that trigger this problem.

No regression observed.

```
name                       old time/op  new time/op  delta
EncodeDecimalSmall-4        480ns ± 3%   468ns ± 3%   ~     (p=0.667 n=2+2)
DecodeDecimalSmall-4        552ns ± 2%   646ns ±11%   ~     (p=0.333 n=2+2)
EncodeDecimalMedium-4       459ns ± 2%   472ns ± 5%   ~     (p=1.000 n=2+2)
DecodeDecimalMedium-4       558ns ± 5%   758ns ±28%   ~     (p=0.667 n=2+2)
EncodeDecimalLarge-4        463ns ± 2%   463ns ± 3%   ~     (p=1.000 n=2+2)
DecodeDecimalLarge-4       1.03µs ±45%  0.57µs ± 1%   ~     (p=1.000 n=2+2)
PeekLengthDecimal-4        46.6ns ± 2%  45.8ns ± 0%   ~     (p=0.333 n=2+2)
NonsortingEncodeDecimal-4   222ns ± 0%   219ns ± 1%   ~     (p=0.333 n=2+2)
NonsortingDecodeDecimal-4   270ns ± 6%   264ns ± 3%   ~     (p=1.000 n=2+2)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6802)

<!-- Reviewable:end -->
