### PR TITLE
kv: set called in senderTransport

### DIFF
--- a/kv/transport.go
+++ b/kv/transport.go
@@ -283,6 +283,10 @@ func (s *senderTransport) IsExhausted() bool {
 }
 
 func (s *senderTransport) SendNext(done chan BatchCall) {
+	if s.called {
+		panic("called an exhausted transport")
+	}
+	s.called = true
 	sp := s.tracer.StartSpan("node")
 	defer sp.Finish()
 	ctx := opentracing.ContextWithSpan(context.Background(), sp)


### PR DESCRIPTION
Fixes a simple buglet which caused infinite loops during shutdown due to
the transport never being exhausted.

Fixes #6736

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6804)

<!-- Reviewable:end -->
