### PR TITLE
kv: get rid of orderingPolicy telling the transport how to order

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -225,9 +225,10 @@ func (ds *DistSender) RangeLookup(
 		Reverse:         useReverseScan,
 	})
 	replicas := newReplicaSlice(ds.gossip, desc)
+	replicas.Shuffle()
 	// TODO(tschottdorf): Ideally we would use the trace of the request which
 	// caused this lookup.
-	br, err := ds.sendRPC(context.Background(), desc.RangeID, replicas, orderRandom, ba)
+	br, err := ds.sendRPC(context.Background(), desc.RangeID, replicas, ba)
 	if err != nil {
 		return nil, nil, roachpb.NewError(err)
 	}
@@ -251,28 +252,33 @@ func (ds *DistSender) FirstRange() (*roachpb.RangeDescriptor, error) {
 	return rangeDesc, nil
 }
 
-func (ds *DistSender) optimizeReplicaOrder(replicas ReplicaSlice) orderingPolicy {
+// optimizeReplicaOrder sorts the replicas in the order in which they are to be
+// used for sending RPCs (meaning in the order in which they'll be probed for
+// leadership). "Closer" replicas (matching in more attributes) are ordered
+// first. Replicas matching in the same number of attributes are shuffled
+// randomly.
+// If the current node is a replica, then it'll be the first one.
+func (ds *DistSender) optimizeReplicaOrder(replicas ReplicaSlice) {
+	// TODO(spencer): going to need to also sort by affinity; closest
+	// ping time should win. Makes sense to have the rpc client/server
+	// heartbeat measure ping times. With a bit of seasoning, each
+	// node will be able to order the healthy replicas based on latency.
+
 	// Unless we know better, send the RPCs randomly.
-	order := orderRandom
 	nodeDesc := ds.getNodeDescriptor()
 	// If we don't know which node we're on, don't optimize anything.
 	if nodeDesc == nil {
-		return order
+		replicas.Shuffle()
+		return
 	}
-	// Sort replicas by attribute affinity, which we treat as a stand-in for
-	// proximity (for now).
-	if replicas.SortByCommonAttributePrefix(nodeDesc.Attrs.Attrs) > 0 {
-		// There's at least some attribute prefix, and we hope that the
-		// replicas that come early in the slice are now located close to
-		// us and hence better candidates.
-		order = orderStable
-	}
+	// Sort replicas by attribute affinity (if any), which we treat as a stand-in
+	// for proximity (for now).
+	replicas.SortByCommonAttributePrefix(nodeDesc.Attrs.Attrs)
+
 	// If there is a replica in local node, move it to the front.
 	if i := replicas.FindReplicaByNodeID(nodeDesc.NodeID); i > 0 {
 		replicas.MoveToFront(i)
-		order = orderStable
 	}
-	return order
 }
 
 // getNodeDescriptor returns ds.nodeDescriptor, but makes an attempt to load
@@ -305,14 +311,17 @@ func (ds *DistSender) getNodeDescriptor() *roachpb.NodeDescriptor {
 }
 
 // sendRPC sends one or more RPCs to replicas from the supplied roachpb.Replica
-// slice. First, replicas which have gossiped addresses are corralled (and
-// rearranged depending on proximity and whether the request needs to go to a
-// leader) and then sent via Send, with requirement that one RPC to a server
-// must succeed. Returns an RPC error if the request could not be sent. Note
+// slice. Returns an RPC error if the request could not be sent. Note
 // that the reply may contain a higher level error and must be checked in
 // addition to the RPC error.
-func (ds *DistSender) sendRPC(ctx context.Context, rangeID roachpb.RangeID, replicas ReplicaSlice,
-	order orderingPolicy, ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
+// The replicas are assume to have been ordered by preference, closer ones (if
+// any) at the front.
+func (ds *DistSender) sendRPC(
+	ctx context.Context,
+	rangeID roachpb.RangeID,
+	replicas ReplicaSlice,
+	ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, error) {
 	if len(replicas) == 0 {
 		return nil, noNodeAddrsAvailError{}
 	}
@@ -324,7 +333,6 @@ func (ds *DistSender) sendRPC(ctx context.Context, rangeID roachpb.RangeID, repl
 
 	// Set RPC opts with stipulation that one of N RPCs must succeed.
 	rpcOpts := SendOptions{
-		Ordering:         order,
 		SendNextTimeout:  ds.sendNextTimeout,
 		Timeout:          base.NetworkTimeout,
 		Context:          ctx,
@@ -434,7 +442,7 @@ func (ds *DistSender) sendSingleRange(
 	// Rearrange the replicas so that those replicas with long common
 	// prefix of attributes end up first. If there's no prefix, this is a
 	// no-op.
-	order := ds.optimizeReplicaOrder(replicas)
+	ds.optimizeReplicaOrder(replicas)
 
 	// If this request needs to go to a leader and we know who that is, move
 	// it to the front.
@@ -442,13 +450,12 @@ func (ds *DistSender) sendSingleRange(
 		if leader := ds.leaderCache.Lookup(roachpb.RangeID(desc.RangeID)); leader.StoreID > 0 {
 			if i := replicas.FindReplica(leader.StoreID); i >= 0 {
 				replicas.MoveToFront(i)
-				order = orderStable
 			}
 		}
 	}
 
 	// TODO(tschottdorf): should serialize the trace here, not higher up.
-	br, err := ds.sendRPC(ctx, desc.RangeID, replicas, order, ba)
+	br, err := ds.sendRPC(ctx, desc.RangeID, replicas, ba)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}

--- a/kv/replica_slice.go
+++ b/kv/replica_slice.go
@@ -137,6 +137,11 @@ func (rs ReplicaSlice) MoveToFront(i int) {
 	rs[0] = front
 }
 
+// Shuffle randomizes the order of the replicas.
+func (rs ReplicaSlice) Shuffle() {
+	rs.randPerm(0, len(rs)-1, rand.Intn)
+}
+
 func (rs ReplicaSlice) randPerm(startIndex int, topIndex int, intnFn func(int) int) {
 	length := topIndex - startIndex + 1
 	for i := 1; i < length; i++ {

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -94,7 +94,6 @@ func TestSendToOneClient(t *testing.T) {
 	roachpb.RegisterInternalServer(s, Node(0))
 
 	opts := SendOptions{
-		Ordering:        orderStable,
 		SendNextTimeout: 1 * time.Second,
 		Timeout:         10 * time.Second,
 		Context:         context.Background(),
@@ -147,7 +146,6 @@ func TestRetryableError(t *testing.T) {
 	waitForConnState(grpc.TransientFailure)
 
 	opts := SendOptions{
-		Ordering:        orderStable,
 		SendNextTimeout: 100 * time.Millisecond,
 		Timeout:         100 * time.Millisecond,
 		Context:         context.Background(),
@@ -199,7 +197,6 @@ func setupSendNextTest(t *testing.T) ([]chan BatchCall, chan BatchCall, *stop.St
 	doneChanChan := make(chan chan BatchCall, len(addrs))
 
 	opts := SendOptions{
-		Ordering:        orderStable,
 		SendNextTimeout: 1 * time.Millisecond,
 		Timeout:         10 * time.Second,
 		Context:         context.Background(),
@@ -422,7 +419,6 @@ func TestClientNotReady(t *testing.T) {
 	defer ln.Close()
 
 	opts := SendOptions{
-		Ordering:        orderStable,
 		SendNextTimeout: 100 * time.Nanosecond,
 		Timeout:         100 * time.Nanosecond,
 		Context:         context.Background(),
@@ -547,7 +543,6 @@ func TestComplexScenarios(t *testing.T) {
 		}
 
 		opts := SendOptions{
-			Ordering:        orderStable,
 			SendNextTimeout: 1 * time.Second,
 			Timeout:         10 * time.Second,
 			Context:         context.Background(),


### PR DESCRIPTION
replicas

It would appear that we were shuffling replicas twice before sending
RPCs to them. Once in distSender.optimizeReplicaOrder, and then again in
grpcTransport. Removed the second one. Also optimizeReplicaOrder was
confusing because it both applied an order, and returned an ordering
policy to the caller. I've removed the ordering policy and commented on
the semantics of optimizeReplicaOrder.

I'm doing this because I want to lift optimizeReplicaOrder and got
confused about the semantics.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6807)

<!-- Reviewable:end -->
