### PR TITLE
sql: code for decoding buffers of encoded datums

### DIFF
--- a/sql/sqlbase/main_test.go
+++ b/sql/sqlbase/main_test.go
@@ -1,0 +1,29 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sqlbase
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+	os.Exit(m.Run())
+}

--- a/sql/sqlbase/util.go
+++ b/sql/sqlbase/util.go
@@ -1,0 +1,81 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sqlbase
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/duration"
+	"gopkg.in/inf.v0"
+)
+
+// RandDatum generates a random Datum of the given type.
+// If null is true, the datum can be DNull.
+func RandDatum(rng *rand.Rand, typ ColumnType_Kind, null bool) parser.Datum {
+	if null && rng.Intn(10) == 0 {
+		return parser.DNull
+	}
+	switch typ {
+	case ColumnType_BOOL:
+		return parser.MakeDBool(rng.Intn(2) == 1)
+	case ColumnType_INT:
+		return parser.NewDInt(parser.DInt(rng.Int63()))
+	case ColumnType_FLOAT:
+		return parser.NewDFloat(parser.DFloat(rng.NormFloat64()))
+	case ColumnType_DECIMAL:
+		d := &parser.DDecimal{}
+		d.Dec.SetScale(inf.Scale(rng.Intn(40) - 20))
+		d.Dec.SetUnscaled(rng.Int63())
+		return d
+	case ColumnType_DATE:
+		return parser.NewDDate(parser.DDate(rng.Intn(10000)))
+	case ColumnType_TIMESTAMP:
+		return &parser.DTimestamp{Time: time.Unix(rng.Int63n(1000000), rng.Int63n(1000000))}
+	case ColumnType_INTERVAL:
+		return &parser.DInterval{Duration: duration.Duration{Months: rng.Int63n(1000),
+			Days:  rng.Int63n(1000),
+			Nanos: rng.Int63n(1000000),
+		}}
+	case ColumnType_STRING:
+		// Generate a random ASCII string.
+		p := make([]byte, rng.Intn(10))
+		for i := range p {
+			p[i] = byte(1 + rng.Intn(127))
+		}
+		return parser.NewDString(string(p))
+	case ColumnType_BYTES:
+		p := make([]byte, rng.Intn(10))
+		_, _ = rng.Read(p)
+		return parser.NewDBytes(parser.DBytes(p))
+	case ColumnType_TIMESTAMPTZ:
+		return &parser.DTimestampTZ{Time: time.Unix(rng.Int63n(1000000), rng.Int63n(1000000))}
+	default:
+		panic(fmt.Sprintf("invalid type %s", typ))
+	}
+}
+
+// RandEncDatum generates a random EncDatum (of a random type).
+func RandEncDatum(rng *rand.Rand) EncDatum {
+	typ := ColumnType_Kind(rng.Intn(len(ColumnType_Kind_value)))
+	datum := RandDatum(rng, typ, true)
+	var ed EncDatum
+	ed.SetDatum(typ, datum)
+	return ed
+}


### PR DESCRIPTION
We can now create EncDatums based on pieces of a bigger buffer. Adding tests
where we encode random datums in a buffer and then decode them.
@nvanbenschoten, @paperstreet

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6812)

<!-- Reviewable:end -->
