### PR TITLE
ui next: Time Scale Selector

### DIFF
--- a/ui/next/app/app.tsx
+++ b/ui/next/app/app.tsx
@@ -9,7 +9,6 @@
  *    - Graphs
  *      - Greyed-out display on error
  *    ! Events table
- *    - Global Timespan UI Component
  *    - Cluster health indicator
  * ! Notification Banners
  *    - Help Us
@@ -43,6 +42,13 @@
  *  functions, that return an underlying "Common" graph component. The props of
  *  the Common graph component would include the part of `initGraph` and
  *  `drawGraph` that are different for these two chart types.
+ *
+ *  - It is possible to create race conditions using the time scale selector.
+ *  The issue: a user selects a new time scale, which immediately initiates a
+ *  server query. Before that query completes, change the time scale again,
+ *  initiating another query to the server. The order in which these queries
+ *  complete is indeterminate, and could result in the charts displaying data
+ *  for the wrong time scale.
  *
  */
 

--- a/ui/next/app/containers/cluster.tsx
+++ b/ui/next/app/containers/cluster.tsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 
 import { IndexListLink, ListLink } from "../components/listLink.tsx";
+import TimeScaleSelector from "./timescale";
 
 /**
  * ClusterMain renders the main content of the cluster page.
@@ -12,12 +13,17 @@ export default class extends React.Component<{}, {}> {
   }
 
   render() {
+    // Determine whether or not the time scale options should be displayed.
+    let child = React.Children.only(this.props.children);
+    let displayTimescale = (child as any).type.displayTimeScale === true;
+
     // TODO: The first div seems superfluous, remove after switch to ui/next.
     return <div>
       <div className="nav-container">
         <ul className="nav">
           <IndexListLink to="/cluster">Overview</IndexListLink>
           <ListLink to="/cluster/events">Events</ListLink>
+          { displayTimescale ? <TimeScaleSelector/> : null }
         </ul>
       </div>
       { this.props.children }

--- a/ui/next/app/containers/clusterOverview.tsx
+++ b/ui/next/app/containers/clusterOverview.tsx
@@ -27,6 +27,8 @@ interface ClusterMainProps {
  * ClusterMain renders the main content of the cluster page.
  */
 class ClusterMain extends React.Component<ClusterMainProps, {}> {
+  static displayTimeScale = true;
+
   static title() {
     return <h2>Cluster</h2>;
   }

--- a/ui/next/app/containers/nodes.tsx
+++ b/ui/next/app/containers/nodes.tsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 
 import { ListLink } from "../components/listLink.tsx";
+import TimeScaleSelector from "./timescale";
 
 /**
  * Renders the layout of the nodes page.
@@ -12,12 +13,17 @@ export default class Layout extends React.Component<{}, {}> {
   }
 
   render() {
+    // Determine whether or not the time scale options should be displayed.
+    let child = React.Children.only(this.props.children);
+    let displayTimescale = (child as any).type.displayTimeScale === true;
+
     // TODO: The first div seems superfluous, remove after switch to ui/next.
     return <div>
       <div className="nav-container">
         <ul className="nav">
           <ListLink to="/nodes/overview">Overview</ListLink>
           <ListLink to="/nodes/graphs">Graphs</ListLink>
+          { displayTimescale ? <TimeScaleSelector/> : null }
         </ul>
       </div>
       { this.props.children }

--- a/ui/next/app/containers/nodesGraphs.tsx
+++ b/ui/next/app/containers/nodesGraphs.tsx
@@ -12,6 +12,8 @@ import { NanoToMilli } from "../util/convert";
  * Renders the graphs tab of the nodes page.
  */
 export default class extends React.Component<{}, {}> {
+  static displayTimeScale = true;
+
   render() {
     return <div className="section nodes">
       <div className="charts">

--- a/ui/next/app/containers/timescale.tsx
+++ b/ui/next/app/containers/timescale.tsx
@@ -1,0 +1,78 @@
+/// <reference path="../../typings/main.d.ts" />
+
+import * as React from "react";
+import { connect } from "react-redux";
+import classNames = require("classnames");
+import _ = require("lodash");
+
+import * as timewindow from "../redux/timewindow";
+
+interface TimeScaleSelectorProps {
+  currentScale: timewindow.TimeScale;
+  availableScales: timewindow.TimeScaleCollection;
+  setTimeScale: (ts: timewindow.TimeScale) => void;
+}
+
+interface TimeScaleSelectorState {
+  // This setting should not persist if the current route is changed, and thus
+  // it is not stored in the redux state.
+  controlsVisible: boolean;
+}
+
+class TimeScaleSelector extends React.Component<TimeScaleSelectorProps, TimeScaleSelectorState> {
+  constructor() {
+    super();
+    this.state = {
+      controlsVisible: false,
+    };
+  }
+
+  toggleControls = () => {
+    this.setState({
+      controlsVisible: !this.state.controlsVisible,
+    });
+  };
+
+  changeSettings(newSettings: timewindow.TimeScale) {
+    this.props.setTimeScale(newSettings);
+  }
+
+  isSelected(scale: timewindow.TimeScale) {
+    return scale === this.props.currentScale;
+  }
+
+  render() {
+    let selectorClass = classNames({
+      "timescale-selector": true,
+      "show": this.state.controlsVisible,
+    });
+    return <div className="timescale-selector-container">
+      <button className="timescale" onClick={this.toggleControls}>Select Timescale</button>
+      <div className={selectorClass}>
+        <div className="text">View Last: </div>
+        {
+          _.map(this.props.availableScales, (scale, key) => {
+            let theseSettings = scale;
+            return <button key={key}
+                           className={classNames({selected: this.isSelected(scale)})}
+                           onClick={() => this.changeSettings(theseSettings)}>
+                           { key }
+            </button>;
+          })
+        }
+      </div>
+    </div>;
+  }
+}
+
+export default connect(
+  (state) => {
+    return {
+      currentScale: (state.timewindow as timewindow.TimeWindowState).scale,
+      availableScales: timewindow.availableTimeScales,
+    };
+  },
+  {
+    setTimeScale : timewindow.setTimeScale,
+  }
+)(TimeScaleSelector);

--- a/ui/next/app/containers/timewindow.spec.tsx
+++ b/ui/next/app/containers/timewindow.spec.tsx
@@ -26,30 +26,46 @@ describe("<TimeWindowManager>", function() {
     getManager();
     assert.isTrue(spy.calledOnce);
     assert.deepEqual(spy.firstCall.args[0], {
-      start: now().subtract(state.settings.windowSize),
+      start: now().subtract(state.scale.windowSize),
       end: now(),
     });
   });
 
   it("resets time window immediately if expired", function() {
     state.currentWindow = {
-      start: now().subtract(state.settings.windowSize),
-      end: now().subtract(state.settings.windowValid).subtract(1),
+      start: now().subtract(state.scale.windowSize),
+      end: now().subtract(state.scale.windowValid).subtract(1),
     };
 
     getManager();
     assert.isTrue(spy.calledOnce);
     assert.deepEqual(spy.firstCall.args[0], {
-      start: now().subtract(state.settings.windowSize),
+      start: now().subtract(state.scale.windowSize),
+      end: now(),
+    });
+  });
+
+  it("resets time window immediately if scale has changed", function() {
+    // valid window.
+    state.currentWindow = {
+      start: now().subtract(state.scale.windowSize),
+      end: now(),
+    };
+    state.scaleChanged = true;
+
+    getManager();
+    assert.isTrue(spy.calledOnce);
+    assert.deepEqual(spy.firstCall.args[0], {
+      start: now().subtract(state.scale.windowSize),
       end: now(),
     });
   });
 
   it("resets time window later if current window is valid", function() {
     state.currentWindow = {
-      start: now().subtract(state.settings.windowSize),
+      start: now().subtract(state.scale.windowSize),
       // 5 milliseconds until expiration.
-      end: now().subtract(state.settings.windowValid.asMilliseconds() - 5),
+      end: now().subtract(state.scale.windowValid.asMilliseconds() - 5),
     };
 
     getManager();
@@ -61,7 +77,7 @@ describe("<TimeWindowManager>", function() {
         () => {
           assert.isTrue(spy.calledOnce);
           assert.deepEqual(spy.firstCall.args[0], {
-            start: now().subtract(state.settings.windowSize),
+            start: now().subtract(state.scale.windowSize),
             end: now(),
           });
           resolve();
@@ -72,9 +88,9 @@ describe("<TimeWindowManager>", function() {
 
   it("has only a single timeout at a time.", function() {
     state.currentWindow = {
-      start: now().subtract(state.settings.windowSize),
+      start: now().subtract(state.scale.windowSize),
       // 5 milliseconds until expiration.
-      end: now().subtract(state.settings.windowValid.asMilliseconds() - 5),
+      end: now().subtract(state.scale.windowValid.asMilliseconds() - 5),
     };
 
     let manager = getManager();
@@ -82,9 +98,9 @@ describe("<TimeWindowManager>", function() {
 
     // Set new props on currentWindow. The previous timeout should be abandoned.
     state.currentWindow = {
-      start: now().subtract(state.settings.windowSize),
+      start: now().subtract(state.scale.windowSize),
       // 10 milliseconds until expiration.
-      end: now().subtract(state.settings.windowValid.asMilliseconds() - 10),
+      end: now().subtract(state.scale.windowValid.asMilliseconds() - 10),
     };
     manager.setProps({
       timeWindow: state,
@@ -97,7 +113,7 @@ describe("<TimeWindowManager>", function() {
         () => {
           assert.isTrue(spy.calledOnce);
           assert.deepEqual(spy.firstCall.args[0], {
-            start: now().subtract(state.settings.windowSize),
+            start: now().subtract(state.scale.windowSize),
             end: now(),
           });
           resolve();

--- a/ui/next/app/redux/timewindow.spec.ts
+++ b/ui/next/app/redux/timewindow.spec.ts
@@ -23,14 +23,14 @@ describe("time window reducer", function() {
       let windowSize = moment.duration(10, "s");
       let windowValid = moment.duration(10, "s");
       const expectedSetting = {
-        type: timewindow.SET_SETTINGS,
+        type: timewindow.SET_SCALE,
         payload: {
           windowSize,
           windowValid,
         },
       };
       assert.deepEqual(
-        timewindow.setTimeWindowSettings({ windowSize, windowValid }),
+        timewindow.setTimeScale({ windowSize, windowValid }),
         expectedSetting);
     });
   });
@@ -42,7 +42,7 @@ describe("time window reducer", function() {
         new timewindow.TimeWindowState()
       );
       assert.deepEqual(
-        (new timewindow.TimeWindowState()).settings,
+        (new timewindow.TimeWindowState()).scale,
         {
           windowSize: moment.duration(10, "m"),
           windowValid: moment.duration(10, "s"),
@@ -59,6 +59,7 @@ describe("time window reducer", function() {
           start,
           end,
         };
+        expected.scaleChanged = false;
         assert.deepEqual(
           reducer(undefined, timewindow.setTimeWindow({ start, end })),
           expected
@@ -71,12 +72,13 @@ describe("time window reducer", function() {
       let newValid = moment.duration(1, "m");
       it("should correctly overwrite previous value", () => {
         let expected = new timewindow.TimeWindowState();
-        expected.settings = {
+        expected.scale = {
           windowSize: newSize,
           windowValid: newValid,
         };
+        expected.scaleChanged = true;
         assert.deepEqual(
-          reducer(undefined, timewindow.setTimeWindowSettings({
+          reducer(undefined, timewindow.setTimeScale({
             windowSize: newSize,
             windowValid: newValid,
           })),


### PR DESCRIPTION
Implements the visual component that allows users to select a different global
time scale for graphs.
- TimeWindowSettings renamed to TimeScale.
- A static list of TimeScales is defined in the timewindow redux module.
- TimeWindowManager now immediately resets window if selected TimeScale changes.
- TimeScaleSelector is displayed on Cluster Overview and Nodes Graph pages.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6813)

<!-- Reviewable:end -->
