### PR TITLE
sql: move user-facing errors to sqlbase

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -44,7 +44,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, newUndefinedDatabaseError(n.Table.Database())
+		return nil, sqlbase.NewUndefinedDatabaseError(n.Table.Database())
 	}
 
 	tableDesc, err := p.getTableDesc(n.Table)
@@ -55,7 +55,7 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, error) {
 		if n.IfExists {
 			return &emptyNode{}, nil
 		}
-		return nil, newUndefinedTableError(n.Table.String())
+		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
 	}
 
 	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -281,7 +281,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 				// Still processing table.
 				done = false
 				if nonNullableColumn != "" {
-					return newNonNullViolationError(nonNullableColumn)
+					return sqlbase.NewNonNullViolationError(nonNullableColumn)
 				}
 				if sentinelKey == nil || !bytes.HasPrefix(kv.Key, sentinelKey) {
 					// Sentinel keys have a 0 suffix indicating 0 bytes of

--- a/sql/create.go
+++ b/sql/create.go
@@ -120,7 +120,7 @@ func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
 		return nil, err
 	}
 	if tableDesc == nil {
-		return nil, newUndefinedTableError(n.Table.String())
+		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
 	}
 
 	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
@@ -211,7 +211,7 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, newUndefinedDatabaseError(n.Table.Database())
+		return nil, sqlbase.NewUndefinedDatabaseError(n.Table.Database())
 	}
 
 	if err := p.checkPrivilege(dbDesc, privilege.CREATE); err != nil {

--- a/sql/database.go
+++ b/sql/database.go
@@ -172,7 +172,7 @@ func (p *planner) getDatabaseID(name string) (sqlbase.ID, error) {
 			return 0, err
 		}
 		if desc == nil {
-			return 0, newUndefinedDatabaseError(name)
+			return 0, sqlbase.NewUndefinedDatabaseError(name)
 		}
 	}
 

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -173,7 +173,7 @@ func (p *planner) getDescriptorsFromTargetList(targets parser.TargetList) (
 				return nil, err
 			}
 			if descriptor == nil {
-				return nil, newUndefinedDatabaseError(database)
+				return nil, sqlbase.NewUndefinedDatabaseError(database)
 			}
 			descs = append(descs, descriptor)
 		}
@@ -195,7 +195,7 @@ func (p *planner) getDescriptorsFromTargetList(targets parser.TargetList) (
 				return nil, err
 			}
 			if descriptor == nil {
-				return nil, newUndefinedTableError(table.String())
+				return nil, sqlbase.NewUndefinedTableError(table.String())
 			}
 			descs = append(descs, descriptor)
 		}

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -58,7 +58,7 @@ func (p *planner) DropDatabase(n *parser.DropDatabase) (planNode, error) {
 			// Noop.
 			return &emptyNode{}, nil
 		}
-		return nil, newUndefinedDatabaseError(string(n.Name))
+		return nil, sqlbase.NewUndefinedDatabaseError(string(n.Name))
 	}
 
 	if err := p.checkPrivilege(dbDesc, privilege.DROP); err != nil {
@@ -171,7 +171,7 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 			return nil, err
 		}
 		if tableDesc == nil {
-			return nil, newUndefinedTableError(index.Table.String())
+			return nil, sqlbase.NewUndefinedTableError(index.Table.String())
 		}
 
 		if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
@@ -273,7 +273,7 @@ func (p *planner) DropTable(n *parser.DropTable) (planNode, error) {
 				continue
 			}
 			// Table does not exist, but we want it to: error out.
-			return nil, newUndefinedTableError(name.String())
+			return nil, sqlbase.NewUndefinedTableError(name.String())
 		}
 		td = append(td, droppedDesc)
 	}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -664,12 +664,12 @@ func (e *Executor) execStmtInAbortedTxn(
 			// TODO(andrei/cdo): add a counter for user-directed retries.
 			return Result{}, nil
 		}
-		err := newTransactionAbortedError(fmt.Sprintf(
+		err := sqlbase.NewTransactionAbortedError(fmt.Sprintf(
 			"SAVEPOINT %s has not been used or a non-retriable error was encountered.",
 			parser.RestartSavepointName))
 		return Result{Err: err}, err
 	default:
-		err := newTransactionAbortedError("")
+		err := sqlbase.NewTransactionAbortedError("")
 		return Result{Err: err}, err
 	}
 }
@@ -691,7 +691,7 @@ func (e *Executor) execStmtInCommitWaitTxn(
 		txnState.resetStateAndTxn(NoTxn)
 		return result, nil
 	default:
-		err := newTransactionCommittedError()
+		err := sqlbase.NewTransactionCommittedError()
 		return Result{Err: err}, err
 	}
 }

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -302,7 +302,7 @@ func (n *insertNode) Next() bool {
 	for _, col := range n.tableDesc.Columns {
 		if !col.Nullable {
 			if i, ok := n.insertColIDtoRowIndex[col.ID]; !ok || rowVals[i] == parser.DNull {
-				n.run.err = newNonNullViolationError(col.Name)
+				n.run.err = sqlbase.NewNonNullViolationError(col.Name)
 				return false
 			}
 		}

--- a/sql/internal.go
+++ b/sql/internal.go
@@ -89,7 +89,7 @@ func getTableID(p *planner, qname *parser.QualifiedName) (sqlbase.ID, error) {
 		return 0, err
 	}
 	if !gr.Exists() {
-		return 0, newUndefinedTableError(qname.String())
+		return 0, sqlbase.NewUndefinedTableError(qname.String())
 	}
 	return sqlbase.ID(gr.ValueInt()), nil
 }

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/tracing"
@@ -663,7 +664,7 @@ func (c *v3Conn) sendCommandComplete(tag []byte) error {
 }
 
 func (c *v3Conn) sendError(err error) error {
-	if sqlErr, ok := err.(sql.ErrorWithPGCode); ok {
+	if sqlErr, ok := err.(sqlbase.ErrorWithPGCode); ok {
 		return c.sendErrorWithCode(sqlErr.Code(), sqlErr.SrcContext(), err.Error())
 	}
 	return c.sendInternalError(err.Error())
@@ -672,12 +673,12 @@ func (c *v3Conn) sendError(err error) error {
 // TODO(andrei): Figure out the correct codes to send for all the errors
 // in this file and remove this function.
 func (c *v3Conn) sendInternalError(errToSend string) error {
-	return c.sendErrorWithCode(pgerror.CodeInternalError, sql.SrcCtx{}, errToSend)
+	return c.sendErrorWithCode(pgerror.CodeInternalError, sqlbase.SrcCtx{}, errToSend)
 }
 
 // errCode is a postgres error code, plus our extensions.
 // See http://www.postgresql.org/docs/9.5/static/errcodes-appendix.html
-func (c *v3Conn) sendErrorWithCode(errCode string, errCtx sql.SrcCtx, errToSend string) error {
+func (c *v3Conn) sendErrorWithCode(errCode string, errCtx sqlbase.SrcCtx, errToSend string) error {
 	if c.doingExtendedQueryMessage {
 		c.ignoreTillSync = true
 	}

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -53,7 +53,7 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, newUndefinedDatabaseError(string(n.Name))
+		return nil, sqlbase.NewUndefinedDatabaseError(string(n.Name))
 	}
 
 	if n.Name == n.NewName {
@@ -122,7 +122,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, newUndefinedDatabaseError(n.Name.Database())
+		return nil, sqlbase.NewUndefinedDatabaseError(n.Name.Database())
 	}
 
 	tbKey := tableKey{dbDesc.ID, n.Name.Table()}.Key()
@@ -146,7 +146,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		return nil, err
 	}
 	if targetDbDesc == nil {
-		return nil, newUndefinedDatabaseError(n.NewName.Database())
+		return nil, sqlbase.NewUndefinedDatabaseError(n.NewName.Database())
 	}
 
 	if err := p.checkPrivilege(targetDbDesc, privilege.CREATE); err != nil {
@@ -163,7 +163,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		return nil, err
 	}
 	if tableDesc == nil || tableDesc.State != sqlbase.TableDescriptor_PUBLIC {
-		return nil, newUndefinedTableError(n.Name.String())
+		return nil, sqlbase.NewUndefinedTableError(n.Name.String())
 	}
 
 	if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
@@ -241,7 +241,7 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, error) {
 		return nil, err
 	}
 	if tableDesc == nil {
-		return nil, newUndefinedTableError(n.Index.Table.String())
+		return nil, sqlbase.NewUndefinedTableError(n.Index.Table.String())
 	}
 
 	idxName := string(n.Index.Index)
@@ -307,7 +307,7 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, newUndefinedDatabaseError(n.Table.Database())
+		return nil, sqlbase.NewUndefinedDatabaseError(n.Table.Database())
 	}
 
 	// Check if table exists.
@@ -330,7 +330,7 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 		return nil, err
 	}
 	if tableDesc == nil {
-		return nil, newUndefinedTableError(n.Table.String())
+		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
 	}
 
 	colName := string(n.Name)

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -167,7 +167,7 @@ func isSchemaChangeRetryError(err error) bool {
 	case errDescriptorNotFound:
 		return false
 	default:
-		return !isIntegrityConstraintError(err)
+		return !sqlbase.IsIntegrityConstraintError(err)
 	}
 }
 
@@ -286,7 +286,7 @@ func (sc SchemaChanger) exec(
 	// Purge the mutations if the application of the mutations failed due to
 	// an integrity constraint violation. All other errors are transient
 	// errors that are resolved by retrying the backfill.
-	if isIntegrityConstraintError(err) {
+	if sqlbase.IsIntegrityConstraintError(err) {
 		log.Warningf("reversing schema change due to irrecoverable error: %s", err)
 		if errReverse := sc.reverseMutations(); errReverse != nil {
 			// Although the backfill did hit an integrity constraint violation

--- a/sql/set.go
+++ b/sql/set.go
@@ -56,7 +56,7 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 				return nil, err
 			}
 			if dbDesc == nil {
-				return nil, newUndefinedDatabaseError(dbName)
+				return nil, sqlbase.NewUndefinedDatabaseError(dbName)
 			}
 		}
 		p.session.Database = dbName

--- a/sql/show.go
+++ b/sql/show.go
@@ -65,7 +65,7 @@ func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, error) {
 		return nil, err
 	}
 	if desc == nil {
-		return nil, newUndefinedTableError(n.Table.String())
+		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
 	}
 	v := &valuesNode{
 		columns: []ResultColumn{
@@ -99,7 +99,7 @@ func (p *planner) ShowCreateTable(n *parser.ShowCreateTable) (planNode, error) {
 		return nil, err
 	}
 	if desc == nil {
-		return nil, newUndefinedTableError(n.Table.String())
+		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
 	}
 	v := &valuesNode{
 		columns: []ResultColumn{
@@ -258,7 +258,7 @@ func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, error) {
 		return nil, err
 	}
 	if desc == nil {
-		return nil, newUndefinedTableError(n.Table.String())
+		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
 	}
 
 	v := &valuesNode{
@@ -322,7 +322,7 @@ func (p *planner) ShowTables(n *parser.ShowTables) (planNode, error) {
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, newUndefinedDatabaseError(string(name.Base))
+		return nil, sqlbase.NewUndefinedDatabaseError(string(name.Base))
 	}
 
 	tableNames, err := p.getTableNames(dbDesc)

--- a/sql/sqlbase/errors.go
+++ b/sql/sqlbase/errors.go
@@ -1,0 +1,286 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tamir Duberstein (tamird@gmail.com)
+// Author: Andrei Matei (andreimatei1@gmail.com)
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package sqlbase
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/util/caller"
+)
+
+// Cockroach error extensions:
+const (
+	// CodeRetriableError signals to the user that the SQL txn entered the
+	// RESTART_WAIT state and that a RESTART statement should be issued.
+	CodeRetriableError string = "CR000"
+	// CodeTransactionCommittedError signals that the SQL txn is in the
+	// COMMIT_WAIT state and a COMMIT statement should be issued.
+	CodeTransactionCommittedError string = "CR001"
+)
+
+// SrcCtx contains contextual information about the source of an error.
+type SrcCtx struct {
+	File     string
+	Line     int
+	Function string
+}
+
+func makeSrcCtx(depth int) SrcCtx {
+	f, l, fun := caller.Lookup(depth + 1)
+	return SrcCtx{File: f, Line: l, Function: fun}
+}
+
+// ErrorWithPGCode represents errors that carries an error code to the user.
+// pgwire recognizes this interfaces and extracts the code.
+type ErrorWithPGCode interface {
+	error
+	Code() string
+	SrcContext() SrcCtx
+}
+
+var _ ErrorWithPGCode = &ErrNonNullViolation{}
+var _ ErrorWithPGCode = &ErrUniquenessConstraintViolation{}
+var _ ErrorWithPGCode = &ErrTransactionAborted{}
+var _ ErrorWithPGCode = &ErrTransactionCommitted{}
+var _ ErrorWithPGCode = &ErrUndefinedDatabase{}
+var _ ErrorWithPGCode = &ErrUndefinedTable{}
+var _ ErrorWithPGCode = &ErrRetry{}
+
+const (
+	txnAbortedMsg = "current transaction is aborted, commands ignored " +
+		"until end of transaction block"
+	txnCommittedMsg = "current transaction is committed, commands ignored " +
+		"until end of transaction block"
+	txnRetryMsgPrefix = "restart transaction:"
+)
+
+// NewRetryError creates a ErrRetry.
+func NewRetryError(cause error) error {
+	return &ErrRetry{ctx: makeSrcCtx(1), msg: fmt.Sprintf("%s %v", txnRetryMsgPrefix, cause)}
+}
+
+// ErrRetry means that the transaction can be retried.
+type ErrRetry struct {
+	ctx SrcCtx
+	msg string
+}
+
+func (e *ErrRetry) Error() string {
+	return e.msg
+}
+
+// Code implements the ErrorWithPGCode interface.
+func (*ErrRetry) Code() string {
+	return CodeRetriableError
+}
+
+// SrcContext implements the ErrorWithPGCode interface.
+func (e *ErrRetry) SrcContext() SrcCtx {
+	return e.ctx
+}
+
+// NewTransactionAbortedError creates a new ErrTransactionAborted.
+func NewTransactionAbortedError(customMsg string) error {
+	return &ErrTransactionAborted{ctx: makeSrcCtx(1), CustomMsg: customMsg}
+}
+
+// ErrTransactionAborted represents an error for trying to run a command in the
+// context of transaction that's already aborted.
+type ErrTransactionAborted struct {
+	ctx       SrcCtx
+	CustomMsg string
+}
+
+func (e *ErrTransactionAborted) Error() string {
+	msg := txnAbortedMsg
+	if e.CustomMsg != "" {
+		msg += "; " + e.CustomMsg
+	}
+	return msg
+}
+
+// Code implements the ErrorWithPGCode interface.
+func (*ErrTransactionAborted) Code() string {
+	return pgerror.CodeInFailedSQLTransactionError
+}
+
+// SrcContext implements the ErrorWithPGCode interface.
+func (e *ErrTransactionAborted) SrcContext() SrcCtx {
+	return e.ctx
+}
+
+// NewTransactionCommittedError creates a new ErrTransactionCommitted.
+func NewTransactionCommittedError() error {
+	return &ErrTransactionCommitted{ctx: makeSrcCtx(1)}
+}
+
+// ErrTransactionCommitted represents an error for trying to run a command in the
+// context of transaction that's already committed.
+type ErrTransactionCommitted struct {
+	ctx SrcCtx
+}
+
+func (*ErrTransactionCommitted) Error() string {
+	return txnCommittedMsg
+}
+
+// Code implements the ErrorWithPGCode interface.
+func (*ErrTransactionCommitted) Code() string {
+	return CodeTransactionCommittedError
+}
+
+// SrcContext implements the ErrorWithPGCode interface.
+func (e *ErrTransactionCommitted) SrcContext() SrcCtx {
+	return e.ctx
+}
+
+// NewNonNullViolationError creates a new ErrNonNullViolation.
+func NewNonNullViolationError(columnName string) error {
+	return &ErrNonNullViolation{ctx: makeSrcCtx(1), columnName: columnName}
+}
+
+// ErrNonNullViolation represents a violation of a non-NULL constraint.
+type ErrNonNullViolation struct {
+	ctx        SrcCtx
+	columnName string
+}
+
+func (e *ErrNonNullViolation) Error() string {
+	return fmt.Sprintf("null value in column %q violates not-null constraint", e.columnName)
+}
+
+// Code implements the ErrorWithPGCode interface.
+func (*ErrNonNullViolation) Code() string {
+	return pgerror.CodeNotNullViolationError
+}
+
+// SrcContext implements the ErrorWithPGCode interface.
+func (e *ErrNonNullViolation) SrcContext() SrcCtx {
+	return e.ctx
+}
+
+// NewUniquenessConstraintViolationError creates a new
+// ErrUniquenessConstrainViolation.
+func NewUniquenessConstraintViolationError(
+	index *IndexDescriptor, vals []parser.Datum,
+) error {
+	return &ErrUniquenessConstraintViolation{
+		ctx:   makeSrcCtx(1),
+		index: index,
+		vals:  vals,
+	}
+}
+
+// ErrUniquenessConstraintViolation represents a violation of a UNIQUE constraint.
+type ErrUniquenessConstraintViolation struct {
+	ctx   SrcCtx
+	index *IndexDescriptor
+	vals  []parser.Datum
+}
+
+// Code implements the ErrorWithPGCode interface.
+func (*ErrUniquenessConstraintViolation) Code() string {
+	return pgerror.CodeUniqueViolationError
+}
+
+func (e *ErrUniquenessConstraintViolation) Error() string {
+	valStrs := make([]string, 0, len(e.vals))
+	for _, val := range e.vals {
+		valStrs = append(valStrs, val.String())
+	}
+
+	return fmt.Sprintf("duplicate key value (%s)=(%s) violates unique constraint %q",
+		strings.Join(e.index.ColumnNames, ","),
+		strings.Join(valStrs, ","),
+		e.index.Name)
+}
+
+// SrcContext implements the ErrorWithPGCode interface.
+func (e *ErrUniquenessConstraintViolation) SrcContext() SrcCtx {
+	return e.ctx
+}
+
+// NewUndefinedTableError creates a new ErrUndefinedTable.
+func NewUndefinedTableError(name string) error {
+	return &ErrUndefinedTable{ctx: makeSrcCtx(1), name: name}
+}
+
+// ErrUndefinedTable represents a missing database table.
+type ErrUndefinedTable struct {
+	ctx  SrcCtx
+	name string
+}
+
+func (e *ErrUndefinedTable) Error() string {
+	return fmt.Sprintf("table %q does not exist", e.name)
+}
+
+// Code implements the ErrorWithPGCode interface.
+func (*ErrUndefinedTable) Code() string {
+	return pgerror.CodeUndefinedTableError
+}
+
+// SrcContext implements the ErrorWithPGCode interface.
+func (e *ErrUndefinedTable) SrcContext() SrcCtx {
+	return e.ctx
+}
+
+// NewUndefinedDatabaseError creates a new ErrUndefinedDatabase.
+func NewUndefinedDatabaseError(name string) error {
+	return &ErrUndefinedDatabase{ctx: makeSrcCtx(1), name: name}
+}
+
+// ErrUndefinedDatabase represents a missing database error.
+type ErrUndefinedDatabase struct {
+	ctx  SrcCtx
+	name string
+}
+
+func (e *ErrUndefinedDatabase) Error() string {
+	return fmt.Sprintf("database %q does not exist", e.name)
+}
+
+// Code implements the ErrorWithPGCode interface.
+func (*ErrUndefinedDatabase) Code() string {
+	// Postgres will return an UndefinedTable error on queries that go to a "relation"
+	// that does not exist (a query to a non-existent table or database), but will
+	// return an InvalidCatalogName error when connecting to a database that does
+	// not exist. We've chosen to return this code for all cases where the error cause
+	// is a missing database.
+	return pgerror.CodeInvalidCatalogNameError
+}
+
+// SrcContext implements the ErrorWithPGCode interface.
+func (e *ErrUndefinedDatabase) SrcContext() SrcCtx {
+	return e.ctx
+}
+
+// IsIntegrityConstraintError returns true if the error is some kind of SQL
+// contraint violation.
+func IsIntegrityConstraintError(err error) bool {
+	switch err.(type) {
+	case *ErrNonNullViolation, *ErrUniquenessConstraintViolation:
+		return true
+	default:
+		return false
+	}
+}

--- a/sql/table.go
+++ b/sql/table.go
@@ -144,7 +144,7 @@ func (p *planner) getTableDesc(qname *parser.QualifiedName) (*sqlbase.TableDescr
 		return nil, err
 	}
 	if dbDesc == nil {
-		return nil, newUndefinedDatabaseError(qname.Database())
+		return nil, sqlbase.NewUndefinedDatabaseError(qname.Database())
 	}
 
 	desc := sqlbase.TableDescriptor{}
@@ -177,7 +177,7 @@ func (p *planner) getTableLease(qname *parser.QualifiedName) (sqlbase.TableDescr
 			return sqlbase.TableDescriptor{}, err
 		}
 		if desc == nil {
-			return sqlbase.TableDescriptor{}, newUndefinedTableError(qname.String())
+			return sqlbase.TableDescriptor{}, sqlbase.NewUndefinedTableError(qname.String())
 		}
 		return *desc, nil
 	}
@@ -215,7 +215,7 @@ func (p *planner) getTableLease(qname *parser.QualifiedName) (sqlbase.TableDescr
 			if err == errDescriptorNotFound {
 				// Transform the descriptor error into an error that references the
 				// table's name.
-				return sqlbase.TableDescriptor{}, newUndefinedTableError(qname.String())
+				return sqlbase.TableDescriptor{}, sqlbase.NewUndefinedTableError(qname.String())
 			}
 			return sqlbase.TableDescriptor{}, err
 		}
@@ -324,7 +324,7 @@ func (p *planner) expandTableGlob(expr *parser.QualifiedName) (
 			return nil, err
 		}
 		if dbDesc == nil {
-			return nil, newUndefinedDatabaseError(string(expr.Base))
+			return nil, sqlbase.NewUndefinedDatabaseError(string(expr.Base))
 		}
 		tableNames, err := p.getTableNames(dbDesc)
 		if err != nil {

--- a/sql/update.go
+++ b/sql/update.go
@@ -345,7 +345,7 @@ func (u *updateNode) Next() bool {
 	for i, col := range u.updateCols {
 		val := updateValues[i]
 		if !col.Nullable && val == parser.DNull {
-			u.run.err = newNonNullViolationError(col.Name)
+			u.run.err = sqlbase.NewNonNullViolationError(col.Name)
 			return false
 		}
 	}


### PR DESCRIPTION
In anticipation of errors needed in the distsql package, which I'd like
to keep together with the rest of the sql errors. Also, I think it's
likely distsql is gonna start generating some of the already-existing
errors.

Mechanic change.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6817)

<!-- Reviewable:end -->
