### PR TITLE
sql: EvalContext.Location references, not copies, the Session.Location

### DIFF
--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -1157,7 +1157,7 @@ type EvalContext struct {
 
 	ReCache  *RegexpCache
 	TmpDec   *inf.Dec
-	Location *time.Location
+	Location **time.Location
 	Args     MapArgs
 
 	// TODO(mjibson): remove prepareOnly in favor of a 2-step prepare-exec solution
@@ -1228,14 +1228,14 @@ func (ctx *EvalContext) SetClusterTimestamp(ts roachpb.Timestamp) {
 	ctx.clusterTimestamp = ts
 }
 
-var defaultContext = EvalContext{Location: time.UTC}
+var defaultContext = EvalContext{}
 
 // GetLocation returns the session timezone.
 func (ctx EvalContext) GetLocation() *time.Location {
-	if ctx.Location == nil {
+	if ctx.Location == nil || *ctx.Location == nil {
 		return time.UTC
 	}
-	return ctx.Location
+	return *ctx.Location
 }
 
 // makeDDate constructs a DDate from a time.Time in the session time zone.

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -173,7 +173,7 @@ func (p *planner) resetForBatch(e *Executor) {
 		NodeID:   e.nodeID,
 		ReCache:  e.reCache,
 		TmpDec:   new(inf.Dec),
-		Location: p.session.Location,
+		Location: &p.session.Location,
 	}
 	p.session.TxnState.schemaChangers.curGroupNum++
 }

--- a/sql/session.go
+++ b/sql/session.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
 )
@@ -64,8 +63,6 @@ func NewSession(args SessionArgs, e *Executor, remote net.Addr) *Session {
 	s.User = args.User
 	cfg, cache := e.getSystemConfig()
 	s.planner = planner{
-		// evalCtx is set in the Executor, for each Prepare or Execute.
-		evalCtx:       parser.EvalContext{Location: s.Location},
 		leaseMgr:      e.ctx.LeaseManager,
 		systemConfig:  cfg,
 		databaseCache: cache,

--- a/sql/set.go
+++ b/sql/set.go
@@ -161,6 +161,5 @@ func (p *planner) SetTimeZone(n *parser.SetTimeZone) (planNode, error) {
 	if offset != 0 {
 		p.session.Location = time.FixedZone("", int(offset))
 	}
-	p.evalCtx.Location = p.session.Location
 	return &emptyNode{}, nil
 }


### PR DESCRIPTION
Previously, the `EvalContext.Location` was set to a copy of the
`Session.Location` value. This meant that we had to be careful about
updating both on every update. With future plans to add an
`AnalyseContext` (or `TypeCheckContext`, input appreciated) which will
also need this location, having both Contexts reference the
`Session.Location` is a lot less error prone and enforces a single
source of truth across a `Session`. As long as multiple `EvalContext`s
for the same session are never used concurrently, this should be safe.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6838)

<!-- Reviewable:end -->
