### PR TITLE
sql: properly populate DatabaseDescriptor.Name

### DIFF
--- a/sql/database.go
+++ b/sql/database.go
@@ -71,7 +71,7 @@ func (s *databaseCache) setID(name string, id sqlbase.ID) {
 
 func makeDatabaseDesc(p *parser.CreateDatabase) sqlbase.DatabaseDescriptor {
 	return sqlbase.DatabaseDescriptor{
-		Name:       p.Name.String(),
+		Name:       string(p.Name),
 		Privileges: sqlbase.NewDefaultPrivilegeDescriptor(),
 	}
 }

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 var (
@@ -108,6 +109,10 @@ func (p *planner) createDescriptor(plainKey sqlbase.DescriptorKey, descriptor sq
 	b := client.Batch{}
 	descID := descriptor.GetID()
 	descDesc := sqlbase.WrapDescriptor(descriptor)
+	if log.V(2) {
+		log.Infof("CPut %s -> %d", idKey, descID)
+		log.Infof("CPut %s -> %s", descKey, descDesc)
+	}
 	b.CPut(idKey, descID, nil)
 	b.CPut(descKey, descDesc, nil)
 

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 type dropDatabaseNode struct {
@@ -103,6 +104,11 @@ func (n *dropDatabaseNode) Start() error {
 	zoneKey, nameKey, descKey := getKeysForDatabaseDescriptor(n.dbDesc)
 
 	b := &client.Batch{}
+	if log.V(2) {
+		log.Infof("Del %s", descKey)
+		log.Infof("Del %s", nameKey)
+		log.Infof("Del %s", zoneKey)
+	}
 	b.Del(descKey)
 	b.Del(nameKey)
 	// Delete the zone config entry for this database.

--- a/sql/testdata/drop_database
+++ b/sql/testdata/drop_database
@@ -1,0 +1,37 @@
+statement ok
+CREATE DATABASE "foo-bar"
+
+query T
+SHOW DATABASES
+----
+foo-bar
+system
+test
+
+statement ok
+DROP DATABASE "foo-bar"
+
+query T
+SHOW DATABASES
+----
+system
+test
+
+statement ok
+CREATE DATABASE "foo bar"
+
+query T
+SHOW DATABASES
+----
+foo bar
+system
+test
+
+statement ok
+DROP DATABASE "foo bar"
+
+query T
+SHOW DATABASES
+----
+system
+test


### PR DESCRIPTION
This fixes handling of "quoted" identifiers as database names.

Fixes #6786.
Fixes #6849.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6851)

<!-- Reviewable:end -->
