### PR TITLE
storage/engine: add rocksDBBatchBuilder

### DIFF
--- a/storage/engine/batch.go
+++ b/storage/engine/batch.go
@@ -1,0 +1,203 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package engine
+
+import "github.com/cockroachdb/cockroach/roachpb"
+
+const (
+	batchTypeDeletion byte = 0x0
+	batchTypeValue         = 0x1
+	batchTypeMerge         = 0x2
+
+	// The batch header is composed of an 8-byte sequence number (all zeroes) and
+	// 4-byte count of the number of entries in the batch.
+	headerSize       int = 12
+	initialBatchSize     = 1 << 10
+	maxVarintLen32       = 5
+)
+
+// A rocksDBBatchBuilder constructs a RocksDB batch representation. From the
+// RocksDB code, the representation of a batch is:
+//
+//   WriteBatch::rep_ :=
+//      sequence: fixed64
+//      count: fixed32
+//      data: record[count]
+//   record :=
+//      kTypeValue varstring varstring
+//      kTypeDeletion varstring
+//      kTypeSingleDeletion varstring
+//      kTypeMerge varstring varstring
+//      kTypeColumnFamilyValue varint32 varstring varstring
+//      kTypeColumnFamilyDeletion varint32 varstring varstring
+//      kTypeColumnFamilySingleDeletion varint32 varstring varstring
+//      kTypeColumnFamilyMerge varint32 varstring varstring
+//   varstring :=
+//      len: varint32
+//      data: uint8[len]
+//
+// The rocksDBBatchBuilder code currently only supports kTypeValue
+// (batchTypeValue), kTypeDeletion (batchTypeDeletion)and kTypeMerge
+// (batchTypeMerge) operations. Before a batch is written to the RocksDB
+// write-ahead-log, the sequence number is 0. The "fixed32" format is little
+// endian.
+//
+// The keys encoded into the batch or MVCC keys: a string key with a timestamp
+// suffix. MVCC keys are encoded as:
+//
+//   <key>[<wall_time>[<logical>]]<#timestamp-bytes>
+//
+// The <wall_time> and <logical> portions of the key are encoded as 64 and
+// 32-bit big-endian integers. A custom RocksDB comparator is used to maintain
+// the desired ordering as these keys do not sort lexicographically
+// correctly. Note that the encoding of these keys needs to match up with the
+// encoding in rocksdb/db.cc:EncodeKey().
+type rocksDBBatchBuilder struct {
+	repr  []byte
+	count int
+}
+
+func (b *rocksDBBatchBuilder) maybeInit() {
+	if b.repr == nil {
+		b.repr = make([]byte, headerSize, initialBatchSize)
+	}
+}
+
+// Finish returns the constructed batch representation. After calling Finish,
+// the builder may be used to construct another batch, but the returned []byte
+// is only valid until the next builder method is called.
+func (b *rocksDBBatchBuilder) Finish() []byte {
+	buf := b.repr[8:headerSize]
+	v := uint32(b.count)
+	buf[0] = byte(v)
+	buf[1] = byte(v >> 8)
+	buf[2] = byte(v >> 16)
+	buf[3] = byte(v >> 24)
+	repr := b.repr
+	b.repr = b.repr[:headerSize]
+	b.count = 0
+	return repr
+}
+
+func (b *rocksDBBatchBuilder) grow(n int) {
+	newSize := len(b.repr) + n
+	if newSize > cap(b.repr) {
+		newCap := 2 * cap(b.repr)
+		for newCap < newSize {
+			newCap *= 2
+		}
+		newRepr := make([]byte, len(b.repr), newCap)
+		copy(newRepr, b.repr)
+		b.repr = newRepr
+	}
+	b.repr = b.repr[:newSize]
+}
+
+func putUvarint32(buf []byte, x uint32) int {
+	i := 0
+	for x >= 0x80 {
+		buf[i] = byte(x) | 0x80
+		x >>= 7
+		i++
+	}
+	buf[i] = byte(x)
+	return i + 1
+}
+
+func putUint32(b []byte, v uint32) {
+	b[0] = byte(v >> 24)
+	b[1] = byte(v >> 16)
+	b[2] = byte(v >> 8)
+	b[3] = byte(v)
+}
+
+func putUint64(b []byte, v uint64) {
+	b[0] = byte(v >> 56)
+	b[1] = byte(v >> 48)
+	b[2] = byte(v >> 40)
+	b[3] = byte(v >> 32)
+	b[4] = byte(v >> 24)
+	b[5] = byte(v >> 16)
+	b[6] = byte(v >> 8)
+	b[7] = byte(v)
+}
+
+// encodeKey encodes an MVCC key into the batch, reserving extra bytes in
+// b.repr for use in encoding a value as well. This encoding must match with
+// the encoding in engine/db.cc:EncodeKey().
+func (b *rocksDBBatchBuilder) encodeKey(key MVCCKey, extra int) {
+	length := 1 + len(key.Key)
+	timestampLength := 0
+	if key.Timestamp != roachpb.ZeroTimestamp {
+		timestampLength = 1 + 8
+		if key.Timestamp.Logical != 0 {
+			timestampLength += 4
+		}
+	}
+	length += timestampLength
+
+	pos := 1 + len(b.repr)
+	b.grow(1 + maxVarintLen32 + length + extra)
+	n := putUvarint32(b.repr[pos:], uint32(length))
+	b.repr = b.repr[:len(b.repr)-(maxVarintLen32-n)]
+	pos += n
+	copy(b.repr[pos:], key.Key)
+	if timestampLength > 0 {
+		pos += len(key.Key)
+		b.repr[pos] = 0
+		pos++
+		putUint64(b.repr[pos:], uint64(key.Timestamp.WallTime))
+		if key.Timestamp.Logical != 0 {
+			pos += 8
+			putUint32(b.repr[pos:], uint32(key.Timestamp.Logical))
+		}
+	}
+	b.repr[len(b.repr)-1-extra] = byte(timestampLength)
+}
+
+func (b *rocksDBBatchBuilder) encodeKeyValue(key MVCCKey, value []byte, tag byte) {
+	b.maybeInit()
+	b.count++
+
+	l := uint32(len(value))
+	extra := int(l) + maxVarintLen32
+
+	pos := len(b.repr)
+	b.encodeKey(key, extra)
+	b.repr[pos] = tag
+
+	pos = len(b.repr) - extra
+	n := putUvarint32(b.repr[pos:], l)
+	b.repr = b.repr[:len(b.repr)-(maxVarintLen32-n)]
+	copy(b.repr[pos+n:], value)
+}
+
+func (b *rocksDBBatchBuilder) Put(key MVCCKey, value []byte) {
+	b.encodeKeyValue(key, value, batchTypeValue)
+}
+
+func (b *rocksDBBatchBuilder) Merge(key MVCCKey, value []byte) {
+	b.encodeKeyValue(key, value, batchTypeMerge)
+}
+
+func (b *rocksDBBatchBuilder) Clear(key MVCCKey) {
+	b.maybeInit()
+	b.count++
+	pos := len(b.repr)
+	b.encodeKey(key, 0)
+	b.repr[pos] = batchTypeDeletion
+}

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -150,7 +150,7 @@ type Engine interface {
 	// NewBatch returns a new instance of a batched engine which wraps
 	// this engine. Batched engines accumulate all mutations and apply
 	// them atomically on a call to Commit().
-	NewBatch() Engine
+	NewBatch() Batch
 	// Commit atomically applies any batched updates to the underlying
 	// engine. This is a noop unless the engine was created via NewBatch().
 	Commit() error
@@ -175,6 +175,21 @@ type Engine interface {
 	Closed() bool
 	// GetStats retrieves stats from the engine.
 	GetStats() (*Stats, error)
+}
+
+// Batch is the interface for batch specific operations.
+//
+// TODO(peter): Move various methods of Engine to Batch, such as Commit() and Repr().
+type Batch interface {
+	Engine
+	// Distinct returns a view of the existing batch which passes reads directly
+	// to the underlying engine (the one the batch was created from). That is,
+	// the returned batch will not read its own writes. This is used as an
+	// optimization to avoid flushing mutations buffered by the batch in
+	// situations where we know all of the batched operations are for distinct
+	// keys. Closing/committing the returned engine is equivalent to
+	// closing/committing the original batch.
+	Distinct() Engine
 }
 
 // Stats is a set of RocksDB stats. These are all described in RocksDB

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -347,7 +347,7 @@ func (r *RocksDB) NewSnapshot() Engine {
 }
 
 // NewBatch returns a new batch wrapping this rocksdb engine.
-func (r *RocksDB) NewBatch() Engine {
+func (r *RocksDB) NewBatch() Batch {
 	return newRocksDBBatch(r)
 }
 
@@ -475,7 +475,7 @@ func (r *rocksDBSnapshot) NewSnapshot() Engine {
 }
 
 // NewBatch is illegal for snapshot.
-func (r *rocksDBSnapshot) NewBatch() Engine {
+func (r *rocksDBSnapshot) NewBatch() Batch {
 	panic("cannot create a NewBatch from a snapshot")
 }
 
@@ -499,15 +499,15 @@ func (r *rocksDBSnapshot) GetStats() (*Stats, error) {
 	return nil, util.Errorf("GetStats is not implemented for %T", r)
 }
 
-// rocksDBBatchIterator wraps rocksDBIterator and allows reuse of an iterator
+// reusableIterator wraps rocksDBIterator and allows reuse of an iterator
 // for the lifetime of a batch.
-type rocksDBBatchIterator struct {
+type reusableIterator struct {
 	rocksDBIterator
 	inuse bool
 }
 
-func (r *rocksDBBatchIterator) Close() {
-	// rocksDBBatchIterator.Close() is a no-op. The iterator is left open until
+func (r *reusableIterator) Close() {
+	// reusableIterator.Close() leaves the underlying rocksdb iterator open until
 	// the associated batch is closed.
 	if !r.inuse {
 		panic("closing idle iterator")
@@ -515,19 +515,118 @@ func (r *rocksDBBatchIterator) Close() {
 	r.inuse = false
 }
 
+type distinctBatch struct {
+	*rocksDBBatch
+	prefixIter reusableIterator
+	normalIter reusableIterator
+}
+
+// NewIterator returns an iterator over the batch and underlying engine. Note
+// that the returned iterator is cached and re-used for the lifetime of the
+// batch. A panic will be thrown if multiple prefix or normal (non-prefix)
+// iterators are used simultaneously on the same batch.
+func (r *distinctBatch) NewIterator(prefix bool) Iterator {
+	// Used the cached iterator, creating it on first access.
+	iter := &r.normalIter
+	if prefix {
+		iter = &r.prefixIter
+	}
+	if iter.rocksDBIterator.iter == nil {
+		iter.rocksDBIterator.init(r.parent.rdb, prefix, r)
+	}
+	if iter.inuse {
+		panic("iterator already in use")
+	}
+	iter.inuse = true
+	return iter
+}
+
+func (r *distinctBatch) Get(key MVCCKey) ([]byte, error) {
+	return dbGet(r.parent.rdb, key)
+}
+
+func (r *distinctBatch) GetProto(key MVCCKey, msg proto.Message) (
+	ok bool, keyBytes, valBytes int64, err error) {
+	return dbGetProto(r.parent.rdb, key, msg)
+}
+
+func (r *distinctBatch) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
+	return dbIterate(r.parent.rdb, r, start, end, f)
+}
+
+func (r *distinctBatch) close() {
+	if i := &r.prefixIter.rocksDBIterator; i.iter != nil {
+		i.destroy()
+	}
+	if i := &r.normalIter.rocksDBIterator; i.iter != nil {
+		i.destroy()
+	}
+}
+
+// rocksDBBatchIterator wraps rocksDBIterator and allows reuse of an iterator
+// for the lifetime of a batch.
+type rocksDBBatchIterator struct {
+	rocksDBIterator
+	batch *rocksDBBatch
+}
+
+func (r *rocksDBBatchIterator) Close() {
+	// rocksDBBatchIterator.Close() leaves the underlying rocksdb iterator open
+	// until the associated batch is closed.
+	if r.batch == nil {
+		panic("closing idle iterator")
+	}
+	r.batch = nil
+}
+
+func (r *rocksDBBatchIterator) Seek(key MVCCKey) {
+	r.batch.flushMutations()
+	r.rocksDBIterator.Seek(key)
+}
+
+func (r *rocksDBBatchIterator) SeekReverse(key MVCCKey) {
+	r.batch.flushMutations()
+	r.rocksDBIterator.SeekReverse(key)
+}
+
+func (r *rocksDBBatchIterator) Next() {
+	r.batch.flushMutations()
+	r.rocksDBIterator.Next()
+}
+
+func (r *rocksDBBatchIterator) Prev() {
+	r.batch.flushMutations()
+	r.rocksDBIterator.Prev()
+}
+
+func (r *rocksDBBatchIterator) NextKey() {
+	r.batch.flushMutations()
+	r.rocksDBIterator.NextKey()
+}
+
+func (r *rocksDBBatchIterator) PrevKey() {
+	r.batch.flushMutations()
+	r.rocksDBIterator.PrevKey()
+}
+
 type rocksDBBatch struct {
 	parent     *RocksDB
 	batch      *C.DBEngine
 	defers     []func()
+	flushes    int
 	prefixIter rocksDBBatchIterator
 	normalIter rocksDBBatchIterator
+	builder    rocksDBBatchBuilder
+	distinct   distinctBatch
 }
 
-func newRocksDBBatch(r *RocksDB) *rocksDBBatch {
-	return &rocksDBBatch{
-		parent: r,
-		batch:  C.DBNewBatch(r.rdb),
+func newRocksDBBatch(parent *RocksDB) *rocksDBBatch {
+	r := &rocksDBBatch{
+		parent: parent,
+		batch:  C.DBNewBatch(parent.rdb),
 	}
+	r.distinct.rocksDBBatch = r
+	return r
 }
 
 func (r *rocksDBBatch) Open() error {
@@ -535,6 +634,7 @@ func (r *rocksDBBatch) Open() error {
 }
 
 func (r *rocksDBBatch) Close() {
+	r.distinct.close()
 	if i := &r.prefixIter.rocksDBIterator; i.iter != nil {
 		i.destroy()
 	}
@@ -557,33 +657,40 @@ func (r *rocksDBBatch) Attrs() roachpb.Attributes {
 }
 
 func (r *rocksDBBatch) Put(key MVCCKey, value []byte) error {
-	return dbPut(r.batch, key, value)
+	r.builder.Put(key, value)
+	return nil
 }
 
 func (r *rocksDBBatch) Merge(key MVCCKey, value []byte) error {
-	return dbMerge(r.batch, key, value)
+	r.builder.Merge(key, value)
+	return nil
 }
 
-// ApplyBatchRepr is illegal for a batch and returns an error.
+// ApplyBatchRepr atomically applies a set of batched updates to the current
+// batch (the receiver).
 func (r *rocksDBBatch) ApplyBatchRepr(repr []byte) error {
-	return util.Errorf("cannot ApplyBatchRepr to a batch")
+	return dbApplyBatchRepr(r.batch, repr)
 }
 
 func (r *rocksDBBatch) Get(key MVCCKey) ([]byte, error) {
+	r.flushMutations()
 	return dbGet(r.batch, key)
 }
 
 func (r *rocksDBBatch) GetProto(key MVCCKey, msg proto.Message) (
 	ok bool, keyBytes, valBytes int64, err error) {
+	r.flushMutations()
 	return dbGetProto(r.batch, key, msg)
 }
 
 func (r *rocksDBBatch) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
+	r.flushMutations()
 	return dbIterate(r.batch, r, start, end, f)
 }
 
 func (r *rocksDBBatch) Clear(key MVCCKey) error {
-	return dbClear(r.batch, key)
+	r.builder.Clear(key)
+	return nil
 }
 
 func (r *rocksDBBatch) Capacity() (roachpb.StoreCapacity, error) {
@@ -607,10 +714,10 @@ func (r *rocksDBBatch) NewIterator(prefix bool) Iterator {
 	if iter.rocksDBIterator.iter == nil {
 		iter.rocksDBIterator.init(r.batch, prefix, r)
 	}
-	if iter.inuse {
+	if iter.batch != nil {
 		panic("iterator already in use")
 	}
-	iter.inuse = true
+	iter.batch = r
 	return iter
 }
 
@@ -618,7 +725,7 @@ func (r *rocksDBBatch) NewSnapshot() Engine {
 	panic("cannot create a NewSnapshot from a batch")
 }
 
-func (r *rocksDBBatch) NewBatch() Engine {
+func (r *rocksDBBatch) NewBatch() Batch {
 	return newRocksDBBatch(r.parent)
 }
 
@@ -626,9 +733,22 @@ func (r *rocksDBBatch) Commit() error {
 	if r.batch == nil {
 		panic("this batch was already committed")
 	}
-	if err := statusToError(C.DBCommitBatch(r.batch)); err != nil {
-		return err
+
+	if r.flushes > 0 {
+		// We've previously flushed mutations to the C++ batch, so we have to flush
+		// any remaining mutations as well and then commit the batch.
+		r.flushMutations()
+		if err := statusToError(C.DBCommitBatch(r.batch)); err != nil {
+			return err
+		}
+	} else if r.builder.count > 0 {
+		// Fast-path which avoids flushing mutations to the C++ batch. Instead, we
+		// directly apply the mutations to the database.
+		if err := r.parent.ApplyBatchRepr(r.builder.Finish()); err != nil {
+			return err
+		}
 	}
+
 	C.DBClose(r.batch)
 	r.batch = nil
 
@@ -642,6 +762,7 @@ func (r *rocksDBBatch) Commit() error {
 }
 
 func (r *rocksDBBatch) Repr() []byte {
+	r.flushMutations()
 	return cSliceToGoBytes(C.DBBatchRepr(r.batch))
 }
 
@@ -652,6 +773,20 @@ func (r *rocksDBBatch) Defer(fn func()) {
 // GetStats is not implemented for rocksDBBatch.
 func (r *rocksDBBatch) GetStats() (*Stats, error) {
 	return nil, util.Errorf("GetStats is not implemented for %T", r)
+}
+
+func (r *rocksDBBatch) Distinct() Engine {
+	return &r.distinct
+}
+
+func (r *rocksDBBatch) flushMutations() {
+	if r.builder.count == 0 {
+		return
+	}
+	r.flushes++
+	if err := r.ApplyBatchRepr(r.builder.Finish()); err != nil {
+		panic(err)
+	}
 }
 
 type rocksDBIterator struct {

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -102,8 +102,8 @@ DBStatus DBCommitBatch(DBEngine* db);
 
 // ApplyBatchRepr applies a batch of mutations encoded using that
 // batch representation returned by DBBatchRepr(). It is only valid to
-// call this function on an engine created by DBOpen() (i.e. not a
-// batch or snapshot).
+// call this function on an engine created by DBOpen() or DBNewBatch()
+// (i.e. not a snapshot).
 DBStatus DBApplyBatchRepr(DBEngine* db, DBSlice repr);
 
 // Returns the internal batch representation. The returned value is

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -201,6 +201,11 @@ func (r *Replica) Put(
 	if args.Blind {
 		return reply, engine.MVCCBlindPut(ctx, batch, ms, args.Key, ts, args.Value, h.Txn)
 	}
+	if h.DistinctSpans {
+		if b, ok := batch.(engine.Batch); ok {
+			batch = b.Distinct()
+		}
+	}
 	return reply, engine.MVCCPut(ctx, batch, ms, args.Key, ts, args.Value, h.Txn)
 }
 
@@ -214,6 +219,11 @@ func (r *Replica) ConditionalPut(
 
 	if args.Blind {
 		return reply, engine.MVCCBlindConditionalPut(ctx, batch, ms, args.Key, h.Timestamp, args.Value, args.ExpValue, h.Txn)
+	}
+	if h.DistinctSpans {
+		if b, ok := batch.(engine.Batch); ok {
+			batch = b.Distinct()
+		}
 	}
 	return reply, engine.MVCCConditionalPut(ctx, batch, ms, args.Key, h.Timestamp, args.Value, args.ExpValue, h.Txn)
 }


### PR DESCRIPTION
Building batches in Go is significantly faster than performing a cgo call:
~55ns/op vs ~400ns/op. The Go batches do not support indexing, so flush to
a C++ batch whenever a read of the batch is being performed. I experimented
with adding indexing to the Go side, but all attempts were significantly
slower than flushing to C++.

Added an `engine.Batch` interface with a `FreezeFlushes` method which is
called to avoid flushing a batch in order to write the raft applied index
and mvcc stats.

Fixes #6289.
Fixes #6739.

```
name                            old time/op  new time/op  delta
TrackChoices1_Cockroach-32       597µs ± 5%   577µs ± 3%   -3.37%  (p=0.000 n=19+20)
TrackChoices10_Cockroach-32      153µs ± 5%   138µs ± 4%  -10.02%  (p=0.000 n=20+20)
TrackChoices100_Cockroach-32    96.9µs ± 7%  80.5µs ± 5%  -16.95%  (p=0.000 n=20+19)
TrackChoices1000_Cockroach-32   92.0µs ± 7%  73.7µs ± 6%  -19.94%  (p=0.000 n=20+19)
InsertDistinct1_Cockroach-32    2.04ms ± 9%  1.84ms ± 8%   -9.62%  (p=0.000 n=20+20)
InsertDistinct10_Cockroach-32   1.36ms ± 5%  1.23ms ± 4%  -10.09%  (p=0.000 n=19+20)
InsertDistinct100_Cockroach-32  2.03ms ±15%  1.67ms ± 7%  -17.92%  (p=0.000 n=20+19)
KVInsert1_SQL-32                 519µs ± 4%   528µs ± 5%   +1.88%  (p=0.024 n=20+20)
KVInsert10_SQL-32                926µs ± 6%   906µs ± 3%   -2.13%  (p=0.028 n=20+20)
KVInsert100_SQL-32              3.89ms ± 8%  3.53ms ± 8%   -9.14%  (p=0.000 n=20+19)
KVInsert1000_SQL-32             29.4ms ±11%  27.5ms ± 8%   -6.64%  (p=0.000 n=20+20)
KVInsert10000_SQL-32             356ms ±10%   340ms ±11%   -4.41%  (p=0.013 n=19+19)
KVUpdate1_SQL-32                 757µs ± 9%   742µs ± 9%     ~     (p=0.253 n=20+20)
KVUpdate10_SQL-32               1.31ms ± 7%  1.27ms ± 6%   -2.96%  (p=0.001 n=20+19)
KVUpdate100_SQL-32              5.44ms ± 7%  5.24ms ± 7%   -3.74%  (p=0.006 n=20+20)
KVUpdate1000_SQL-32             43.5ms ± 6%  42.0ms ± 9%   -3.62%  (p=0.007 n=20+20)
KVUpdate10000_SQL-32             508ms ±16%   452ms ±14%  -10.97%  (p=0.000 n=20+18)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6861)

<!-- Reviewable:end -->
