### PR TITLE
sql: Parse "e" case-insensitively in numeric constants

### DIFF
--- a/sql/parser/constant.go
+++ b/sql/parser/constant.go
@@ -234,7 +234,7 @@ func (expr *NumVal) ResolveAsType(typ Datum) (Datum, error) {
 			// TODO(nvanbenschoten) Handling e will not be necessary once the TODO about the
 			// OrigString workaround from above is addressed.
 			eScale := inf.Scale(0)
-			if eIdx := strings.IndexRune(s, 'e'); eIdx != -1 {
+			if eIdx := strings.IndexAny(s, "eE"); eIdx != -1 {
 				eInt, err := strconv.ParseInt(s[eIdx+1:], 10, 32)
 				if err != nil {
 					return nil, fmt.Errorf("could not evaluate %v as Datum type DDecimal from "+

--- a/sql/parser/constant_test.go
+++ b/sql/parser/constant_test.go
@@ -65,7 +65,7 @@ func TestNumericConstantAvailableTypes(t *testing.T) {
 		}
 
 		// Check available types.
-		c := &NumVal{Value: val}
+		c := &NumVal{Value: val, OrigString: test.str}
 		avail := c.AvailableTypes()
 		if !reflect.DeepEqual(avail, test.avail) {
 			t.Errorf("%d: expected the available type set %v for %v, found %v",


### PR DESCRIPTION
The tests didn't reach this case because they followed a slightly
different code path that normalized the constants through the constant
package.

This makes us pass sqlalchemy's decimal tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6864)

<!-- Reviewable:end -->
