### PR TITLE
sql/parser: Add support for folding string-like constants

### DIFF
--- a/sql/parser/constant.go
+++ b/sql/parser/constant.go
@@ -274,6 +274,9 @@ func commonNumericConstantType(vals []indexedExpr) Datum {
 
 // StrVal represents a constant string value.
 type StrVal struct {
+	// We could embed a constant.Value here (like NumVal) and use the stringVal implementation,
+	// but that would have extra overhead without much of a benefit. However, it would make
+	// constant folding (below) a little more straightforward.
 	s        string
 	bytesEsc bool
 
@@ -388,11 +391,13 @@ func (constantFolderVisitor) VisitPost(expr Expr) (retExpr Expr) {
 	}()
 	switch t := expr.(type) {
 	case *ParenExpr:
-		if cv, ok := t.Expr.(*NumVal); ok {
+		switch cv := t.Expr.(type) {
+		case *NumVal, *StrVal:
 			return cv
 		}
 	case *UnaryExpr:
-		if cv, ok := t.Expr.(*NumVal); ok {
+		switch cv := t.Expr.(type) {
+		case *NumVal:
 			if token, ok := unaryOpToToken[t.Operator]; ok {
 				return &NumVal{Value: constant.UnaryOp(token, cv.Value, 0)}
 			}
@@ -403,46 +408,78 @@ func (constantFolderVisitor) VisitPost(expr Expr) (retExpr Expr) {
 			}
 		}
 	case *BinaryExpr:
-		l, okL := t.Left.(*NumVal)
-		r, okR := t.Right.(*NumVal)
-		if okL && okR {
-			if token, ok := binaryOpToToken[t.Operator]; ok {
-				return &NumVal{Value: constant.BinaryOp(l.Value, token, r.Value)}
-			}
-			if token, ok := binaryOpToTokenIntOnly[t.Operator]; ok {
-				if lInt, ok := l.asConstantInt(); ok {
-					if rInt, ok := r.asConstantInt(); ok {
-						return &NumVal{Value: constant.BinaryOp(lInt, token, rInt)}
+		switch l := t.Left.(type) {
+		case *NumVal:
+			if r, ok := t.Right.(*NumVal); ok {
+				if token, ok := binaryOpToToken[t.Operator]; ok {
+					return &NumVal{Value: constant.BinaryOp(l.Value, token, r.Value)}
+				}
+				if token, ok := binaryOpToTokenIntOnly[t.Operator]; ok {
+					if lInt, ok := l.asConstantInt(); ok {
+						if rInt, ok := r.asConstantInt(); ok {
+							return &NumVal{Value: constant.BinaryOp(lInt, token, rInt)}
+						}
+					}
+				}
+				if token, ok := binaryShiftOpToToken[t.Operator]; ok {
+					if lInt, ok := l.asConstantInt(); ok {
+						if rInt64, err := r.asInt64(); err == nil && rInt64 >= 0 {
+							return &NumVal{Value: constant.Shift(lInt, token, uint(rInt64))}
+						}
 					}
 				}
 			}
-			if token, ok := binaryShiftOpToToken[t.Operator]; ok {
-				if lInt, ok := l.asConstantInt(); ok {
-					if rInt64, err := r.asInt64(); err == nil && rInt64 >= 0 {
-						return &NumVal{Value: constant.Shift(lInt, token, uint(rInt64))}
-					}
+		case *StrVal:
+			if r, ok := t.Right.(*StrVal); ok {
+				switch t.Operator {
+				case Concat:
+					// When folding string-like constants, if either was byte-escaped,
+					// the result is also considered byte escaped.
+					return &StrVal{s: l.s + r.s, bytesEsc: l.bytesEsc || r.bytesEsc}
 				}
 			}
 		}
 	case *ComparisonExpr:
-		l, okL := t.Left.(*NumVal)
-		r, okR := t.Right.(*NumVal)
-		if okL && okR {
-			if token, ok := comparisonOpToToken[t.Operator]; ok {
-				return MakeDBool(DBool(constant.Compare(l.Value, token, r.Value)))
+		switch l := t.Left.(type) {
+		case *NumVal:
+			if r, ok := t.Right.(*NumVal); ok {
+				if token, ok := comparisonOpToToken[t.Operator]; ok {
+					return MakeDBool(DBool(constant.Compare(l.Value, token, r.Value)))
+				}
+			}
+		case *StrVal:
+			// ComparisonExpr folding for String-like constants is not significantly different
+			// from constant evalutation during normalization (because both should be exact,
+			// unlike numeric comparisons). Still, folding these comparisons when possible here
+			// can reduce the amount of work performed during type checking, can reduce necessary
+			// allocations, and maintains symmetry with numeric constants.
+			if r, ok := t.Right.(*StrVal); ok {
+				switch t.Operator {
+				case EQ:
+					return MakeDBool(DBool(l.s == r.s))
+				case NE:
+					return MakeDBool(DBool(l.s != r.s))
+				case LT:
+					return MakeDBool(DBool(l.s < r.s))
+				case LE:
+					return MakeDBool(DBool(l.s <= r.s))
+				case GT:
+					return MakeDBool(DBool(l.s > r.s))
+				case GE:
+					return MakeDBool(DBool(l.s >= r.s))
+				}
 			}
 		}
 	}
 	return expr
 }
 
-// foldNumericConstants folds all numeric constants using exact arithmetic.
+// foldConstantLiterals folds all constant literals using exact arithmetic.
 //
 // TODO(nvanbenschoten) Can this visitor be preallocated (like normalizeVisitor)?
-// TODO(nvanbenschoten) Do we also want to fold string-like constants?
 // TODO(nvanbenschoten) Investigate normalizing associative operations to group
 //     constants together and permit further numeric constant folding.
-func foldNumericConstants(expr Expr) (Expr, error) {
+func foldConstantLiterals(expr Expr) (Expr, error) {
 	v := constantFolderVisitor{}
 	expr, _ = WalkExpr(v, expr)
 	return expr, nil

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -72,7 +72,7 @@ func TestEval(t *testing.T) {
 		// String concatenation.
 		{`'a' || 'b'`, `'ab'`},
 		{`'a' || (1 + 2)::char`, `'a3'`},
-		{`'hello' || b'world'`, `'helloworld'`},
+		{`b'hello' || 'world'`, `b'helloworld'`},
 		// Bit shift operators.
 		{`1 << 2`, `4`},
 		{`4 >> 2`, `1`},

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -94,7 +94,7 @@ var NoTypePreference = Datum(nil)
 // be used to hint the desired type for the root of the resulting typed expression
 // tree.
 func TypeCheck(expr Expr, ctx *SemaContext, desired Datum) (TypedExpr, error) {
-	expr, err := foldNumericConstants(expr)
+	expr, err := foldConstantLiterals(expr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With direct parallels to numeric constant folding, this commit adds
support for string constant folding. The primary benefit of this is
folding concatenations of `StrVal`s.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6869)

<!-- Reviewable:end -->
