### PR TITLE
ui next: Node Page, Node Page Graphs

### DIFF
--- a/ui/next/app/app.tsx
+++ b/ui/next/app/app.tsx
@@ -76,6 +76,9 @@ import Nodes from "./containers/nodes";
 import NodesOverview from "./containers/nodesOverview";
 import NodesGraphs from "./containers/nodesGraphs";
 import Node from "./containers/node";
+import NodeOverview from "./containers/nodeOverview";
+import NodeGraphs from "./containers/nodeGraphs";
+import NodeLogs from "./containers/nodeLogs";
 
 // TODO(mrtracy): Redux now provides official typings, and their Store
 // definition is generic. That would let us enforce that the store actually has
@@ -120,7 +123,11 @@ ReactDOM.render(
           // This path has to match the "nodes" route for the purpose of
           // highlighting links, but the page does not render as a child of the
           // Nodes component.
-          <Route path=":node_id" component={ Node } />
+          <Route path=":node_id" component={ Node }>
+            <IndexRoute component={ NodeOverview } />
+            <Route path="graphs" component={ NodeGraphs } />
+            <Route path="logs" component={ NodeLogs } />
+          </Route>
         </Route>
         <Route path="databases" component={ Databases } />
         <Route path="help-us/reporting" component={ HelpUs } />

--- a/ui/next/app/components/graphs.tsx
+++ b/ui/next/app/components/graphs.tsx
@@ -138,6 +138,10 @@ export function ProcessDataPoints(metrics: React.ReactElement<MetricProps>[],
 // MetricsDataProvider to pass query data to its contained component.
 export interface MetricsDataComponentProps {
   data?: TSResponseMessage;
+  // Allow graphs to declare a single source for all metrics. This is a
+  // convenient syntax for a common use case where all metrics on a graph are
+  // are from the same source set.
+  sources?: string[];
 }
 
 // TextGraph is a proof-of-concept component used to demonstrate that

--- a/ui/next/app/containers/node.tsx
+++ b/ui/next/app/containers/node.tsx
@@ -1,12 +1,14 @@
 /// <reference path="../../typings/main.d.ts" />
 import * as React from "react";
-
 import { Link, RouteComponentProps } from "react-router";
+
+import { IndexListLink, ListLink } from "../components/listLink.tsx";
+import TimeScaleSelector from "./timescale";
 
 /**
  * Renders teh main content of the single node page.
  */
-export default class extends React.Component<{}, {}> {
+export default class extends React.Component<RouteComponentProps<any, any>, {}> {
   static title(routes: RouteComponentProps<any, any>) {
     return <h2>
       <Link to="/nodes">Nodes</Link>: Node { routes.params.node_id }
@@ -14,8 +16,23 @@ export default class extends React.Component<{}, {}> {
   }
 
   render() {
-    return <div className="section">
-      <h1>Single Node Page</h1>
+    // Determine whether or not the time scale options should be displayed.
+    let child = React.Children.only(this.props.children);
+    let displayTimescale = (child as any).type.displayTimeScale === true;
+
+    let baseRoute = `/nodes/${this.props.params.node_id}`;
+
+    // TODO: The first div seems superfluous, remove after switch to ui/next.
+    return <div>
+      <div className="nav-container">
+        <ul className="nav">
+          <IndexListLink to={baseRoute}>Overview</IndexListLink>
+          <ListLink to={baseRoute + "/graphs"}>Graphs</ListLink>
+          <ListLink to={baseRoute + "/logs"}>Logs</ListLink>
+          { displayTimescale ? <TimeScaleSelector/> : null }
+        </ul>
+      </div>
+      { this.props.children }
     </div>;
   }
 }

--- a/ui/next/app/containers/nodeGraphs.tsx
+++ b/ui/next/app/containers/nodeGraphs.tsx
@@ -1,0 +1,208 @@
+/// <reference path="../../typings/main.d.ts" />
+import * as React from "react";
+import * as d3 from "d3";
+import { RouteComponentProps } from "react-router";
+
+import GraphGroup from "../components/graphGroup";
+import { LineGraph, Axis, Metric } from "../components/linegraph";
+import { StackedAreaGraph } from "../components/stackedgraph";
+import { Bytes } from "../util/format";
+import { NanoToMilli } from "../util/convert";
+
+/**
+ * Renders the main content of the help us page.
+ */
+export default class extends React.Component<RouteComponentProps<any, any>, {}> {
+  static displayTimeScale = true;
+
+  render() {
+    let { node_id : nodeId } = this.props.params;
+    let sources = [nodeId];
+
+    return <div className="section node">
+      <div className="charts">
+        <h2>Activity</h2>
+          <GraphGroup groupId="node.activity">
+
+            <LineGraph title="SQL Connections" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.conns" title="Client Connections" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="SQL Traffic" sources={sources}>
+              <Axis format={ Bytes }>
+                <Metric name="cr.node.sql.bytesin" title="Bytes In" nonNegativeRate />
+                <Metric name="cr.node.sql.bytesout" title="Bytes Out" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Queries Per Second" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.query.count" title="Queries/Sec" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Live Bytes" sources={sources}>
+              <Axis format={ Bytes }>
+                <Metric name="cr.store.livebytes" title="Live Bytes" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Query Time"
+                       subtitle="(Max Per Percentile)"
+                       tooltip={`The latency between query requests and responses over a 1 minute period.
+                                 Percentiles are first calculated on each node.
+                                 For Each percentile, the maximum latency across all nodes is then shown.`}
+                       sources={sources}>
+              <Axis format={ (n: number) => d3.format(".1f")(NanoToMilli(n)) } label="Milliseconds">
+                <Metric name="cr.node.exec.latency-1m-max" title="Max Latency"
+                        aggregateMax downsampleMax />
+                <Metric name="cr.node.exec.latency-1m-p99" title="99th percentile latency"
+                        aggregateMax downsampleMax />
+                <Metric name="cr.node.exec.latency-1m-p90" title="90th percentile latency"
+                        aggregateMax downsampleMax />
+                <Metric name="cr.node.exec.latency-1m-p50" title="50th percentile latency"
+                        aggregateMax downsampleMax />
+              </Axis>
+            </LineGraph>
+
+          </GraphGroup>
+        <h2>SQL Queries</h2>
+          <GraphGroup groupId="node.queries">
+
+            <LineGraph title="Reads" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.select.count" title="Selects" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Writes" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.update.count" title="Updates" nonNegativeRate />
+                <Metric name="cr.node.sql.insert.count" title="Inserts" nonNegativeRate />
+                <Metric name="cr.node.sql.delete.count" title="Deletes" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Transactions" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.txn.commit.count" title="Commits" nonNegativeRate />
+                <Metric name="cr.node.sql.txn.rollback.count" title="Rollbacks" nonNegativeRate />
+                <Metric name="cr.node.sql.txn.abort.count" title="Aborts" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Schema Changes" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sql.ddl.count" title="DDL Statements" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+          </GraphGroup>
+        <h2>System Resources</h2>
+          <GraphGroup groupId="node.resources">
+
+            <StackedAreaGraph title="CPU Usage" sources={sources}>
+              <Axis format={ d3.format(".2%") }>
+                <Metric name="cr.node.sys.cpu.user.percent" title="CPU User %"/>
+                <Metric name="cr.node.sys.cpu.sys.percent" title="CPU Sys %"/>
+              </Axis>
+            </StackedAreaGraph>
+
+            <LineGraph title="Memory Usage" sources={sources}>
+              <Axis format={ Bytes }>
+                <Metric name="cr.node.sys.allocbytes" title="Go In Use" />
+                <Metric name="cr.node.sys.sysbytes" title="Go Sys" />
+                <Metric name="cr.node.sys.rss" title="RSS" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Goroutine Count" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sys.goroutines" title="Goroutine Count" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="CGo Calls" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.node.sys.cgocalls" title="CGo Calls" />
+              </Axis>
+            </LineGraph>
+
+          </GraphGroup>
+        <h2>Internals</h2>
+          <GraphGroup groupId="node.internals">
+
+            <StackedAreaGraph title="Key/Value Transactions" sources={sources}>
+              <Axis label="transactions/sec" format={ d3.format(".1f") }>
+                <Metric name="cr.node.txn.commits-count" title="Commits" nonNegativeRate />
+                <Metric name="cr.node.txn.commits1PC-count" title="Fast 1PC" nonNegativeRate />
+                <Metric name="cr.node.txn.aborts-count" title="Aborts" nonNegativeRate />
+                <Metric name="cr.node.txn.abandons-count" title="Abandons" nonNegativeRate />
+              </Axis>
+            </StackedAreaGraph>
+
+            <LineGraph title="Engine Memory Usage" sources={sources}>
+              <Axis format={ Bytes }>
+                <Metric name="cr.store.rocksdb.block.cache.usage" title="Block Cache" />
+                <Metric name="cr.store.rocksdb.block.cache.pinned-usage" title="Iterators" />
+                <Metric name="cr.store.rocksdb.memtable.total-size" title="Memtable" />
+              </Axis>
+            </LineGraph>
+
+            <StackedAreaGraph title="Block Cache Hits/Misses" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.store.rocksdb.block.cache.hits"
+                        title="Cache Hits"
+                        nonNegativeRate />
+                <Metric name="cr.store.rocksdb.block.cache.misses"
+                        title="Cache Missses"
+                        nonNegativeRate />
+              </Axis>
+            </StackedAreaGraph>
+
+            <StackedAreaGraph title="Range Events" sources={sources}>
+              <Axis format={ d3.format(".1f") }>
+                <Metric name="cr.store.range.splits" title="Splits" nonNegativeRate />
+                <Metric name="cr.store.range.adds" title="Adds" nonNegativeRate />
+                <Metric name="cr.store.range.removes" title="Removes" nonNegativeRate />
+              </Axis>
+            </StackedAreaGraph>
+
+            <LineGraph title="Flushes and Compactions" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.store.rocksdb.flushes" title="Flushes" nonNegativeRate />
+                <Metric name="cr.store.rocksdb.compactions" title="Compactions" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Bloom Filter Prefix" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.store.rocksdb.bloom.filter.prefix.checked"
+                        title="Checked"
+                        nonNegativeRate />
+                <Metric name="cr.store.rocksdb.bloom.filter.prefix.useful"
+                        title="Useful"
+                        nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Clock Offset" sources={sources}>
+              <Axis label="Milliseconds" format={ (n) => d3.format(".1f")(NanoToMilli(n)) }>
+                <Metric name="cr.node.clock-offset.upper-bound-nanos" title="Upper Bound" />
+                <Metric name="cr.node.clock-offset.lower-bound-nanos" title="Lower Bound" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="GC Pause Time" sources={sources}>
+              <Axis label="Milliseconds" format={ (n) => d3.format(".1f")(NanoToMilli(n)) }>
+                <Metric name="cr.node.sys.gc.pause.ns" title="Time" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
+          </GraphGroup>
+      </div>
+    </div>;
+  }
+}

--- a/ui/next/app/containers/nodeLogs.tsx
+++ b/ui/next/app/containers/nodeLogs.tsx
@@ -1,0 +1,13 @@
+/// <reference path="../../typings/main.d.ts" />
+import * as React from "react";
+
+/**
+ * Renders the main content of the help us page.
+ */
+export default class extends React.Component<{}, {}> {
+  render() {
+    return <div className="section">
+      <h1>Node Logs</h1>
+    </div>;
+  }
+}

--- a/ui/next/app/containers/nodeOverview.tsx
+++ b/ui/next/app/containers/nodeOverview.tsx
@@ -1,0 +1,13 @@
+/// <reference path="../../typings/main.d.ts" />
+import * as React from "react";
+
+/**
+ * Renders the main content of the help us page.
+ */
+export default class extends React.Component<{}, {}> {
+  render() {
+    return <div className="section">
+      <h1>Node Overview</h1>
+    </div>;
+  }
+}

--- a/ui/next/app/redux/metrics.ts
+++ b/ui/next/app/redux/metrics.ts
@@ -30,6 +30,14 @@ interface WithID<T> {
   data: T;
 }
 
+/** 
+ * A request/response pair.
+ */
+interface RequestWithResponse {
+  request: TSRequestMessage;
+  response: TSResponseMessage;
+}
+
 /**
  * MetricsQuery maintains the cached data for a single component.
  */
@@ -38,14 +46,17 @@ export class MetricsQuery {
   id: string;
   // The currently cached response data for this component.
   data: TSResponseMessage;
-  // The current request used to retrieve data from the server for this
-  // component. This may represent a currently in-flight query, and thus is not
-  // necessarily the request used to retrieve the current value of "data".
-  request: TSRequestMessage;
   // If the immediately previous request attempt returned an error, rather than
   // a response, it is maintained here. Null if the previous request was
   // successful.
   error: Error;
+  // The previous request, which will have resulted in either "data" or "error"
+  // being populated.
+  request: TSRequestMessage;
+  // A possibly outstanding request used to retrieve data from the server for this
+  // component. This may represent a currently in-flight query, and thus is not
+  // necessarily the request used to retrieve the current value of "data".
+  nextRequest: TSRequestMessage;
 
   constructor(id: string) {
     this.id = id;
@@ -62,14 +73,15 @@ function metricsQueryReducer(state: MetricsQuery, action: Action) {
     case REQUEST:
       let { payload: request } = action as PayloadAction<WithID<TSRequestMessage>>;
       state = _.clone(state);
-      state.request = request.data;
+      state.nextRequest = request.data;
       return state;
 
     // Results for a previous request have been received from the server.
     case RECEIVE:
-      let { payload: response } = action as PayloadAction<WithID<TSResponseMessage>>;
+      let { payload: response } = action as PayloadAction<WithID<RequestWithResponse>>;
       state = _.clone(state);
-      state.data = response.data;
+      state.data = response.data.response;
+      state.request = response.data.request;
       state.error = undefined;
       return state;
 
@@ -170,12 +182,16 @@ export function requestMetrics(id: string, request: TSRequestMessage): PayloadAc
  * receiveMetrics indicates that a previous request from this component has been
  * fulfilled by the server.
  */
-export function receiveMetrics(id: string, response: TSResponseMessage): PayloadAction<WithID<TSResponseMessage>> {
+export function receiveMetrics(id: string, request: TSRequestMessage,
+                               response: TSResponseMessage): PayloadAction<WithID<RequestWithResponse>> {
   return {
     type: RECEIVE,
     payload: {
       id: id,
-      data: response,
+      data: {
+        request: request,
+        response: response,
+      },
     },
   };
 }
@@ -299,7 +315,8 @@ export function queryMetrics(id: string, query: TSRequestMessage) {
             // query. Each request may have sent multiple queries in the batch.
             _.each(batch, (request) => {
               let numQueries = request.data.queries.length;
-              dispatch(receiveMetrics(request.id, new protos.cockroach.ts.TimeSeriesQueryResponse({
+              dispatch(receiveMetrics(request.id, request.data,
+                                      new protos.cockroach.ts.TimeSeriesQueryResponse({
                 results: results.splice(0, numQueries),
               })));
             });


### PR DESCRIPTION
Commit implements single node page skeleton, along with node page graphs tab. A
few supporting changes are included to facilitate the usage of metrics 'sources'
by the single node graphs.

Supporting changes :
- MetricDataComponentProps now includes and optional `sources` field, allowing
  any graph to specify a sources set (rather than specifying sources on each
  metric).  This is convenient for all current use cases.
- Metrics reducer now maintains separate `request` and `nextRequest` fields,
  allowing us to tell which request was actually associated with the current data
  for a chart. This is necessary to avoid flashing invalid data when viewing the
  single nodes graph page for two different nodes in succession (data for the
  first node would be briefly displayed when the second node page was pulled
  up).
- Enhanced logic for MetricsDataProvider to support the above scenario.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6870)

<!-- Reviewable:end -->
