### PR TITLE
sql: prevent truncating a table if referenced by a non-empty table

### DIFF
--- a/sql/sqlbase/kvfetcher.go
+++ b/sql/sqlbase/kvfetcher.go
@@ -151,6 +151,15 @@ func (f *kvFetcher) getBatchSize() int64 {
 	}
 }
 
+// NonEmpty checks if spans are non-empty and returns first match if not.
+func NonEmpty(txn *client.Txn, spans Spans) (bool, client.KeyValue, error) {
+	if len(spans) == 0 {
+		return false, client.KeyValue{}, nil
+	}
+	fetcher := makeKVFetcher(txn, spans, false, 1)
+	return fetcher.nextKV()
+}
+
 // makeKVFetcher initializes a kvFetcher for the given spans. If non-zero, firstBatchLimit limits
 // the size of the first batch (subsequent batches use the default size).
 func makeKVFetcher(txn *client.Txn, spans Spans, reverse bool, firstBatchLimit int64) kvFetcher {

--- a/sql/sqlbase/structured.go
+++ b/sql/sqlbase/structured.go
@@ -836,3 +836,8 @@ func (desc *Descriptor) GetName() string {
 		return ""
 	}
 }
+
+// IndexKeyPrefix returns the prefix for the table-index reference.
+func (t TableAndIndexID) IndexKeyPrefix() []byte {
+	return MakeIndexKeyPrefix(t.Table, t.Index)
+}

--- a/sql/testdata/fk
+++ b/sql/testdata/fk
@@ -2,11 +2,17 @@ statement ok
 CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE);
 
 statement ok
+INSERT INTO customers VALUES (1, 'a@'), (2, 'b@');
+
+statement ok
 CREATE TABLE products (
   sku STRING PRIMARY KEY,
   upc STRING UNIQUE,
   vendor STRING
 );
+
+statement ok
+INSERT INTO products VALUES ('VP-W9QH-W44L', '867072000006', 'Dave'), ('780', '885155001450', 'iRobot');
 
 statement error referenced table "productz" not found
 CREATE TABLE orders (
@@ -62,3 +68,18 @@ CREATE TABLE orders (
   INDEX (product),
   INDEX (customer)
 );
+
+statement ok
+TRUNCATE TABLE products
+
+statement ok
+INSERT INTO products VALUES ('VP-W9QH-W44L', '867072000006', 'Dave'), ('780', '885155001450', 'iRobot')
+
+statement ok
+INSERT INTO orders VALUES (1, '780', 1)
+
+statement error cannot trucate because a non-empty table somewhere has an FK
+TRUNCATE TABLE products
+
+statement ok
+TRUNCATE TABLE orders, products


### PR DESCRIPTION
rough draft of the absolute simplest FK enforcement case (truncate): I'm not actually sure I like this approach -- I'm thinking I might actually want to fire up a rowreader instead to make it easier to get meaningful errors and insulate against eg col groups to some extent.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6871)

<!-- Reviewable:end -->
