### PR TITLE
ui: fix "connection lost" banner

### DIFF
--- a/ui/ts/models/health.ts
+++ b/ui/ts/models/health.ts
@@ -18,14 +18,13 @@ module Models {
       m.redraw();
       return m.request({
         url: "/_admin/v1/health",
-        deserialize: (d: any): any => { return d; },
         config: Utils.Http.XHRConfig,
       })
       .then((r: any): void => {
-        healthy = _.startsWith(r.toString(), "ok");
+        healthy = true;
       })
       .catch((r: any): void => {
-        healthy = _.startsWith(r.toString(), "ok");
+        healthy = false;
       });
     };
 


### PR DESCRIPTION
The semantics of this endpoint changed in 7e52483; it now returns a
serialized proto, which is an empty message. If the request succeeds,
the node is up; otherwise, it is down.

Fixes #6867.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6872)

<!-- Reviewable:end -->
