### PR TITLE
storage: send pre-emptive raft snapshots when up-replicating

### DIFF
--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -22,15 +22,9 @@
 package storage
 
 import (
-	"time"
-
-	"github.com/coreos/etcd/raft"
-	"github.com/coreos/etcd/raft/raftpb"
-
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
-	"github.com/cockroachdb/cockroach/util/retry"
 )
 
 // ComputeMVCCStats immediately computes correct total MVCC usage statistics
@@ -120,39 +114,4 @@ func (r *Replica) GetLastIndex() (uint64, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.LastIndex()
-}
-
-// GetSnapshot wraps Snapshot() but does not require the replica lock
-// to be held and it will block instead of returning
-// ErrSnapshotTemporaryUnavailable.
-func (r *Replica) GetSnapshot() (raftpb.Snapshot, error) {
-	retryOptions := retry.Options{
-		InitialBackoff: 1 * time.Millisecond,
-		MaxBackoff:     50 * time.Millisecond,
-		Multiplier:     2,
-	}
-	for retry := retry.Start(retryOptions); retry.Next(); {
-		r.mu.Lock()
-		snap, err := r.Snapshot()
-		snapshotChan := r.mu.snapshotChan
-		r.mu.Unlock()
-		if err == raft.ErrSnapshotTemporarilyUnavailable {
-			if snapshotChan == nil {
-				// The call to Snapshot() didn't start an async process due to
-				// rate limiting. Try again later.
-				continue
-			}
-			var ok bool
-			snap, ok = <-snapshotChan
-			if ok {
-				return snap, nil
-			}
-			// Each snapshot worker's output can only be consumed once.
-			// We could be racing with raft itself, so if we get a closed
-			// channel loop back and try again.
-		} else {
-			return snap, err
-		}
-	}
-	panic("unreachable") // due to infinite retries
 }

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1382,7 +1382,7 @@ func defaultProposeRaftCommandLocked(r *Replica, p *pendingCmd) error {
 		if crt := etr.InternalCommitTrigger.GetChangeReplicasTrigger(); crt != nil {
 			// EndTransactionRequest with a ChangeReplicasTrigger is special because raft
 			// needs to understand it; it cannot simply be an opaque command.
-			log.Infof("raft: proposing %s %v for range %d", crt.ChangeType, crt.Replica, p.raftCmd.RangeID)
+			log.Infof("raft: proposing %s %+v for range %d", crt.ChangeType, crt.Replica, p.raftCmd.RangeID)
 
 			ctx := ConfChangeContext{
 				CommandID: string(p.idKey),
@@ -1394,12 +1394,11 @@ func defaultProposeRaftCommandLocked(r *Replica, p *pendingCmd) error {
 				return err
 			}
 
-			return r.mu.raftGroup.ProposeConfChange(
-				raftpb.ConfChange{
-					Type:    changeTypeInternalToRaft[crt.ChangeType],
-					NodeID:  uint64(crt.Replica.ReplicaID),
-					Context: encodedCtx,
-				})
+			return r.mu.raftGroup.ProposeConfChange(raftpb.ConfChange{
+				Type:    changeTypeInternalToRaft[crt.ChangeType],
+				NodeID:  uint64(crt.Replica.ReplicaID),
+				Context: encodedCtx,
+			})
 		}
 	}
 	return r.mu.raftGroup.Propose(encodeRaftCommand(string(p.idKey), data))

--- a/storage/store.go
+++ b/storage/store.go
@@ -1572,7 +1572,6 @@ func (s *Store) processRangeDescriptorUpdateLocked(rng *Replica) error {
 
 	// Add the range and its current stats into metrics.
 	s.metrics.replicaCount.Inc(1)
-	s.metrics.addMVCCStats(rng.stats.GetMVCC())
 
 	if s.mu.replicasByKey.Has(rng) {
 		return rangeAlreadyExists{rng}
@@ -1961,7 +1960,7 @@ func (s *Store) handleRaftMessage(req *RaftMessageRequest) error {
 		// or the past?
 		if !found && req.FromReplica.ReplicaID < desc.NextReplicaID {
 			if log.V(2) {
-				log.Infof("range %s: discarding message from replica %v, older than NextReplicaID %v",
+				log.Infof("range %s: discarding message from %+v, older than NextReplicaID %d",
 					req.GroupID, req.FromReplica, desc.NextReplicaID)
 			}
 			return nil
@@ -2000,7 +1999,7 @@ func (s *Store) handleRaftMessage(req *RaftMessageRequest) error {
 		// sender then we could prompt the sender to GC this replica
 		// immediately.
 		if log.V(1) {
-			log.Infof("refusing incoming Raft message %s for group %d from %s to %s: %s",
+			log.Infof("refusing incoming Raft message %s for group %d from %+v to %+v: %s",
 				req.Message.Type, req.GroupID, req.FromReplica, req.ToReplica, err)
 		}
 		return nil


### PR DESCRIPTION
@cockroachdb/core 

Untested, out for early feedback.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6878)

<!-- Reviewable:end -->
