### PR TITLE
storage: test that proves that uncommitted DelRange keys are skipped

### DIFF
--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1472,6 +1472,50 @@ func TestMVCCDeleteRangeConcurrentTxn(t *testing.T) {
 	}
 }
 
+// TestMVCCUncommittedDeleteRangeVisible tests that the keys in an uncommitted
+// DeleteRange are visible to the same transaction at a higher epoch.
+func TestMVCCUncommittedDeleteRangeVisible(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	engine := createTestEngine(stopper)
+
+	if err := MVCCPut(
+		context.Background(), engine, nil, testKey1, makeTS(1, 0), value1, nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := MVCCPut(
+		context.Background(), engine, nil, testKey2, makeTS(1, 0), value2, nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := MVCCPut(
+		context.Background(), engine, nil, testKey3, makeTS(1, 0), value3, nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MVCCDelete(
+		context.Background(), engine, nil, testKey2, makeTS(2, 1), nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	txn := txn1.Clone()
+	if _, err := MVCCDeleteRange(
+		context.Background(), engine, nil, testKey1, testKey4, 0, makeTS(2, 0), &txn, false,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	txn.Epoch++
+	kvs, _, _ := MVCCScan(context.Background(), engine, testKey1, testKey4, 0, makeTS(3, 0), true, &txn)
+	if e := 2; len(kvs) != e {
+		t.Fatalf("e = %d, got %d", e, len(kvs))
+	}
+}
+
 func TestMVCCConditionalPut(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()


### PR DESCRIPTION
```
-bash-3.2$ go test ./storage/... -run TestMVCCDeleteRangeSkipTxn -v
I160524 16:41:21.663499 rand.go:76  Random seed: -7817852526782497260
PASS
ok      github.com/cockroachdb/cockroach/storage    0.026s
=== RUN   TestMVCCDeleteRangeSkipTxn
I160524 16:41:11.377584 storage/engine/rocksdb.go:137  opening in memory rocksdb instance
I160524 16:41:11.378767 storage/engine/mvcc.go:797  skip key: "/db1"
I160524 16:41:11.378794 storage/engine/mvcc.go:797  skip key: "/db2"
I160524 16:41:11.378811 storage/engine/mvcc.go:797  skip key: "/db3"
--- PASS: TestMVCCDeleteRangeSkipTxn (0.00s)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6881)

<!-- Reviewable:end -->
