### PR TITLE
kv: de-flake TestRangeCacheDetectSplitReverseScan

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -290,10 +290,10 @@ func (n *Node) initNodeID(id roachpb.NodeID) {
 	var err error
 	if id == 0 {
 		id, err = allocateNodeID(n.ctx.DB)
-		log.Infof("new node allocated ID %d", id)
 		if err != nil {
 			log.Fatal(err)
 		}
+		log.Infof("new node allocated ID %d", id)
 		if id == 0 {
 			log.Fatal("new node allocated illegal ID 0")
 		}


### PR DESCRIPTION
The test was occasionally failing with only three out of four expected lookups
in the [a,az) case because certain interleavings of the two parallel lookups
could populate each other's cache, sometimes avoiding one lookup.

Verifying that the number of lookups in that case is either three or four
(instead of requiring four) solves that issue.

Fixes #6783.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6884)

<!-- Reviewable:end -->
