### PR TITLE
storage: [Tiny fix] Remove the consistent argument from MVCCGetAsTxn

### DIFF
--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -649,7 +649,6 @@ func MVCCGetAsTxn(
 	engine Engine,
 	key roachpb.Key,
 	timestamp roachpb.Timestamp,
-	consistent bool,
 	txnMeta roachpb.TxnMeta,
 ) (*roachpb.Value, []roachpb.Intent, error) {
 	txn := &roachpb.Transaction{
@@ -659,7 +658,7 @@ func MVCCGetAsTxn(
 		OrigTimestamp: txnMeta.Timestamp,
 		MaxTimestamp:  txnMeta.Timestamp,
 	}
-	return MVCCGet(ctx, engine, key, timestamp, consistent, txn)
+	return MVCCGet(ctx, engine, key, timestamp, true /* consistent */, txn)
 }
 
 // mvccGetMetadata returns or reconstructs the meta key for the given key.

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -921,7 +921,7 @@ func (r *Replica) RangeLookup(
 		// observed intents could be returned when MaxRanges is set to 1 and
 		// the ConsiderIntents flag is set.
 		for _, intent := range intents {
-			val, _, err := engine.MVCCGetAsTxn(ctx, batch, intent.Key, intent.Txn.Timestamp, true, intent.Txn)
+			val, _, err := engine.MVCCGetAsTxn(ctx, batch, intent.Key, intent.Txn.Timestamp, intent.Txn)
 			if err != nil {
 				return reply, nil, err
 			}


### PR DESCRIPTION
`consistent1 must be always true since`mvccGetInternal` does not allow inconsistent reads within a transaction.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6887)

<!-- Reviewable:end -->
