### PR TITLE
sql: only process one row when aggregating with MIN/MAX and the order…

### DIFF
--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -669,3 +669,47 @@ query BB
 SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
 ----
 false false
+
+# Tests for the single-row optimization.
+statement OK
+CREATE TABLE ab (
+  a INT PRIMARY KEY,
+  b INT
+)
+
+statement OK
+INSERT INTO ab VALUES
+  (1, 10),
+  (2, 20),
+  (3, 30),
+  (4, 40),
+  (5, 50)
+
+query ITT
+EXPLAIN SELECT MIN(a) FROM abc
+----
+0 group MIN(a)
+1 scan  abc@primary -
+
+# Verify we only buffer one row.
+query ITTT
+EXPLAIN (DEBUG) SELECT MIN(a) FROM ab
+----
+0 /ab/primary/1   NULL PARTIAL
+0 /ab/primary/1/b 10   BUFFERED
+0 0               (1)  ROW
+
+query ITT
+EXPLAIN SELECT MAX(a) FROM abc
+----
+0 group   MAX(a)
+1 revscan abc@primary -
+
+# Verify we only buffer one row.
+query ITTT
+EXPLAIN (DEBUG) SELECT MAX(a) FROM ab
+----
+0 /ab/primary/5/b 50   PARTIAL
+0 /ab/primary/5   NULL BUFFERED
+0 0               (5)  ROW
+


### PR DESCRIPTION
… matches

When we are grouping for MIN/MAX, we try to get the underlying plan's ordering
to match the function (i.e. increasing for MIN, decreasing for MAX). If the
ordering does match, we only need to read the first row.

We currently use this fact only in the specific case of using an index and no
filters (the index selection code has a special case that limits the span counts
to 1). But we can apply this optimization in general: we can set a hard limit of
1 in the plan, and only read one row.

Adding a test that uses EXPLAIN (DEBUG) to verify we don't buffer more than one
row.

This generalized path will cover the index case as well and we will remove the
special optimization in a separate commit.

@knz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6891)

<!-- Reviewable:end -->
