### PR TITLE
roachpb: micro optimization to BatchRequest.Is{Admin,Write,ReadOnly,...}

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -840,15 +840,15 @@ func (r *Replica) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 
 	// Differentiate between admin, read-only and write.
 	var pErr *roachpb.Error
-	if ba.IsAdmin() {
-		log.Trace(ctx, "admin path")
-		br, pErr = r.addAdminCmd(ctx, ba)
+	if ba.IsWrite() {
+		log.Trace(ctx, "read-write path")
+		br, pErr = r.addWriteCmd(ctx, ba, nil)
 	} else if ba.IsReadOnly() {
 		log.Trace(ctx, "read-only path")
 		br, pErr = r.addReadOnlyCmd(ctx, ba)
-	} else if ba.IsWrite() {
-		log.Trace(ctx, "read-write path")
-		br, pErr = r.addWriteCmd(ctx, ba, nil)
+	} else if ba.IsAdmin() {
+		log.Trace(ctx, "admin path")
+		br, pErr = r.addAdminCmd(ctx, ba)
 	} else if len(ba.Requests) == 0 {
 		// empty batch; shouldn't happen (we could handle it, but it hints
 		// at someone doing weird things, and once we drop the key range


### PR DESCRIPTION
Replaced `BatchRequest.flags()` with `BatchRequest.hasFlag` which can
early exit when a flag is found. Surprisingly, this actually shows up in
bulk insert benchmarks.

```
name                          old time/op  new time/op  delta
TrackChoices1_Cockroach-8      300µs ± 1%   299µs ± 1%    ~     (p=0.548 n=5+5)
TrackChoices10_Cockroach-8    85.4µs ± 1%  84.1µs ± 1%  -1.50%  (p=0.008 n=5+5)
TrackChoices100_Cockroach-8   56.0µs ± 1%  55.0µs ± 1%  -1.84%  (p=0.008 n=5+5)
TrackChoices1000_Cockroach-8  57.1µs ± 1%  55.6µs ± 2%  -2.55%  (p=0.008 n=5+5)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6892)

<!-- Reviewable:end -->
