### PR TITLE
sql/parser: Construct Context for Semantic Analysis

### DIFF
--- a/sql/distsql/expr.go
+++ b/sql/distsql/expr.go
@@ -61,7 +61,7 @@ func processExpression(exprSpec Expression, h *parser.IndexedVarHelper) (parser.
 	}
 
 	// Convert to a fully typed expression.
-	typedExpr, err := parser.TypeCheck(expr, nil, nil)
+	typedExpr, err := parser.TypeCheck(expr, nil, parser.NoTypePreference)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -297,7 +297,7 @@ func (e *Executor) Prepare(ctx context.Context, query string, session *Session, 
 	}
 
 	session.planner.resetForBatch(e)
-	session.planner.evalCtx.Args = args
+	session.planner.semaCtx.Args = args
 	session.planner.evalCtx.PrepareOnly = true
 
 	// Prepare needs a transaction because it needs to retrieve db/table

--- a/sql/group.go
+++ b/sql/group.go
@@ -74,7 +74,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 
 		// We could potentially skip this, since it will be checked in addRender,
 		// but checking now allows early err return.
-		typedExpr, err := parser.TypeCheck(resolved, p.evalCtx.Args, parser.NoTypePreference)
+		typedExpr, err := parser.TypeCheck(resolved, &p.semaCtx, parser.NoTypePreference)
 		if err != nil {
 			return nil, err
 		}
@@ -110,7 +110,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 			return nil, err
 		}
 
-		typedHaving, err = parser.TypeCheckAndRequire(having, p.evalCtx.Args,
+		typedHaving, err = parser.TypeCheckAndRequire(having, &p.semaCtx,
 			parser.TypeBool, "HAVING")
 		if err != nil {
 			return nil, err
@@ -694,7 +694,7 @@ func (a *aggregateFunc) String() string { return parser.AsString(a) }
 
 func (a *aggregateFunc) Walk(v parser.Visitor) parser.Expr { return a }
 
-func (a *aggregateFunc) TypeCheck(args parser.MapArgs, desired parser.Datum) (parser.TypedExpr, error) {
+func (a *aggregateFunc) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.TypedExpr, error) {
 	return a, nil
 }
 

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -146,11 +146,11 @@ func (p *planner) Insert(
 				if _, ok := val.(parser.DefaultVal); ok {
 					continue
 				}
-				typedExpr, err := parser.TypeCheck(val, p.evalCtx.Args, desiredTypesFromSelect[eIdx])
+				typedExpr, err := parser.TypeCheck(val, &p.semaCtx, desiredTypesFromSelect[eIdx])
 				if err != nil {
 					return nil, err
 				}
-				err = sqlbase.CheckColumnType(cols[eIdx], typedExpr.ReturnType(), p.evalCtx.Args)
+				err = sqlbase.CheckColumnType(cols[eIdx], typedExpr.ReturnType(), p.semaCtx.Args)
 				if err != nil {
 					return nil, err
 				}

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -63,7 +63,7 @@ func (p *planner) Limit(n *parser.Limit) (*limitNode, error) {
 			if err != nil {
 				return nil, err
 			}
-			typedExpr, err := parser.TypeCheckAndRequire(replaced, p.evalCtx.Args,
+			typedExpr, err := parser.TypeCheckAndRequire(replaced, &p.semaCtx,
 				parser.TypeInt, datum.name)
 			if err != nil {
 				return nil, err

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -1139,6 +1139,8 @@ func makeEvalTupleIn(d Datum) CmpOp {
 	}
 }
 
+var defaultEvalContext = EvalContext{}
+
 // EvalContext defines the context in which to evaluate an expression, allowing
 // the retrieval of state such as the node ID or statement start time.
 type EvalContext struct {
@@ -1153,11 +1155,11 @@ type EvalContext struct {
 	// The cluster timestamp. Needs to be stable for the lifetime of the
 	// transaction. Used for cluster_logical_timestamp().
 	clusterTimestamp roachpb.Timestamp
-
-	ReCache  *RegexpCache
-	TmpDec   *inf.Dec
+	// Location references the *Location on the current Session.
 	Location **time.Location
-	Args     MapArgs
+
+	ReCache *RegexpCache
+	TmpDec  *inf.Dec
 
 	// TODO(mjibson): remove prepareOnly in favor of a 2-step prepare-exec solution
 	// that is also able to save the plan to skip work during the exec step.
@@ -1226,8 +1228,6 @@ func (ctx *EvalContext) SetStmtTimestamp(ts time.Time) {
 func (ctx *EvalContext) SetClusterTimestamp(ts roachpb.Timestamp) {
 	ctx.clusterTimestamp = ts
 }
-
-var defaultContext = EvalContext{}
 
 // GetLocation returns the session timezone.
 func (ctx EvalContext) GetLocation() *time.Location {

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -419,10 +419,10 @@ func TestEval(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		if typedExpr, err = defaultContext.NormalizeExpr(typedExpr); err != nil {
+		if typedExpr, err = defaultEvalContext.NormalizeExpr(typedExpr); err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		r, err := typedExpr.Eval(defaultContext)
+		r, err := typedExpr.Eval(defaultEvalContext)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
@@ -468,7 +468,7 @@ func TestEvalError(t *testing.T) {
 		}
 		typedExpr, err := TypeCheck(expr, nil, NoTypePreference)
 		if err == nil {
-			_, err = typedExpr.Eval(defaultContext)
+			_, err = typedExpr.Eval(defaultEvalContext)
 		}
 		if !testutils.IsError(err, strings.Replace(regexp.QuoteMeta(d.expected), `\.\*`, `.*`, -1)) {
 			t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)
@@ -498,7 +498,7 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 			Left:     NewDString(d.left),
 			Right:    NewDString(d.right),
 		}
-		ctx := defaultContext
+		ctx := defaultEvalContext
 		ctx.ReCache = NewRegexpCache(8)
 		typedExpr, err := TypeCheck(expr, nil, NoTypePreference)
 		if err != nil {
@@ -552,7 +552,7 @@ func TestClusterTimestampConversion(t *testing.T) {
 		{9223372036854775807, 2147483647, "9223372036854775807.2147483647"},
 	}
 
-	ctx := defaultContext
+	ctx := defaultEvalContext
 	ctx.PrepareOnly = true
 	for _, d := range testData {
 		ts := roachpb.Timestamp{WallTime: d.walltime, Logical: d.logical}

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -35,10 +35,10 @@ type Expr interface {
 	// sub-expressions will be guaranteed to be well-typed, meaning that the method effectively
 	// maps the Expr tree into a TypedExpr tree.
 	//
-	// The args parameter maps ValArg names to types inferred while type-checking.
+	// The ctx parameter defines the context in which to perform type checking.
 	// The desired parameter hints the desired type that the method's caller wants from
 	// the resulting TypedExpr.
-	TypeCheck(args MapArgs, desired Datum) (TypedExpr, error)
+	TypeCheck(ctx *SemaContext, desired Datum) (TypedExpr, error)
 }
 
 // TypedExpr represents a well-typed expression.

--- a/sql/parser/expr_test.go
+++ b/sql/parser/expr_test.go
@@ -188,7 +188,7 @@ func TestExprString(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}
-		typedExpr, err := TypeCheck(expr, nil, nil)
+		typedExpr, err := TypeCheck(expr, nil, NoTypePreference)
 		if err != nil {
 			t.Fatalf("%s: %v", expr, err)
 		}
@@ -198,7 +198,7 @@ func TestExprString(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}
-		typedExpr2, err := TypeCheck(expr2, nil, nil)
+		typedExpr2, err := TypeCheck(expr2, nil, NoTypePreference)
 		if err != nil {
 			t.Fatalf("%s: %v", expr2, err)
 		}
@@ -209,11 +209,11 @@ func TestExprString(t *testing.T) {
 			t.Errorf("Print/parse/print cycle changes the string: `%s` vs `%s`", str, str2)
 		}
 		// Compare the normalized expressions.
-		normalized, err := defaultContext.NormalizeExpr(typedExpr)
+		normalized, err := defaultEvalContext.NormalizeExpr(typedExpr)
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}
-		normalized2, err := defaultContext.NormalizeExpr(typedExpr2)
+		normalized2, err := defaultEvalContext.NormalizeExpr(typedExpr2)
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}

--- a/sql/parser/indexed_vars.go
+++ b/sql/parser/indexed_vars.go
@@ -49,7 +49,7 @@ func (v *IndexedVar) Walk(_ Visitor) Expr {
 }
 
 // TypeCheck is part of the Expr interface.
-func (v *IndexedVar) TypeCheck(args MapArgs, desired Datum) (TypedExpr, error) {
+func (v *IndexedVar) TypeCheck(_ *SemaContext, desired Datum) (TypedExpr, error) {
 	return v, nil
 }
 

--- a/sql/parser/indexed_vars_test.go
+++ b/sql/parser/indexed_vars_test.go
@@ -74,7 +74,7 @@ func TestIndexedVars(t *testing.T) {
 	if !d.TypeEqual(TypeInt) {
 		t.Errorf("invalid expression type %s", d.Type())
 	}
-	d, err = typedExpr.Eval(defaultContext)
+	d, err = typedExpr.Eval(defaultEvalContext)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -88,12 +88,12 @@ func TestNormalizeExpr(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		typedExpr, err := expr.TypeCheck(nil, nil)
+		typedExpr, err := expr.TypeCheck(nil, NoTypePreference)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		rOrig := typedExpr.String()
-		r, err := defaultContext.NormalizeExpr(typedExpr)
+		r, err := defaultEvalContext.NormalizeExpr(typedExpr)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
@@ -101,7 +101,7 @@ func TestNormalizeExpr(t *testing.T) {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 		}
 		// Normalizing again should be a no-op.
-		r2, err := defaultContext.NormalizeExpr(r)
+		r2, err := defaultEvalContext.NormalizeExpr(r)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}

--- a/sql/parser/overload_test.go
+++ b/sql/parser/overload_test.go
@@ -139,7 +139,8 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, TypeDate, []Expr{decConst("1.0"), ValArg{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn},
 	}
 	for i, d := range testData {
-		_, fn, err := typeCheckOverloadedExprs(d.args, d.desired, d.overloads, d.exprs...)
+		ctx := SemaContext{Args: d.args}
+		_, fn, err := typeCheckOverloadedExprs(&ctx, d.desired, d.overloads, d.exprs...)
 		if d.expectedOverload != nil {
 			if err != nil {
 				t.Errorf("%d: unexpected error returned from typeCheckOverloadedExprs: %v", i, err)

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -90,23 +90,23 @@ var NoTypePreference = Datum(nil)
 // introspection globally and on each sub-tree.
 //
 // While doing so, it will fold numeric constants and bind var argument names to
-// their inferred types in the args parameter. The optional desired parameter can
+// their inferred types in the provided context. The optional desired parameter can
 // be used to hint the desired type for the root of the resulting typed expression
 // tree.
-func TypeCheck(expr Expr, args MapArgs, desired Datum) (TypedExpr, error) {
+func TypeCheck(expr Expr, ctx *SemaContext, desired Datum) (TypedExpr, error) {
 	expr, err := foldNumericConstants(expr)
 	if err != nil {
 		return nil, err
 	}
-	return expr.TypeCheck(args, desired)
+	return expr.TypeCheck(ctx, desired)
 }
 
 // TypeCheckAndRequire performs type checking on the provided expression tree in
 // an identical manner to TypeCheck. It then asserts that the resulting TypedExpr
 // has the provided return type, returning both the typed expression and an error
 // if it does not.
-func TypeCheckAndRequire(expr Expr, args MapArgs, required Datum, op string) (TypedExpr, error) {
-	typedExpr, err := TypeCheck(expr, args, required)
+func TypeCheckAndRequire(expr Expr, ctx *SemaContext, required Datum, op string) (TypedExpr, error) {
+	typedExpr, err := TypeCheck(expr, ctx, required)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/parser/type_check_test.go
+++ b/sql/parser/type_check_test.go
@@ -225,16 +225,16 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 		test.expectedArgs = make(MapArgs)
 	}
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
-		args := cloneMapArgs(test.args)
-		_, typ, err := typeCheckSameTypedExprs(args, test.desired, buildExprs(exprs)...)
+		ctx := SemaContext{Args: cloneMapArgs(test.args)}
+		_, typ, err := typeCheckSameTypedExprs(&ctx, test.desired, buildExprs(exprs)...)
 		if err != nil {
 			t.Errorf("%d: unexpected error returned from typeCheckSameTypedExprs: %v", idx, err)
 		} else {
 			if !typ.TypeEqual(test.expectedType) {
 				t.Errorf("%d: expected type %s:%s when type checking %s:%s, found %s", idx, test.expectedType, test.expectedType.Type(), buildExprs(exprs), typ, typ.Type())
 			}
-			if !reflect.DeepEqual(args, test.expectedArgs) {
-				t.Errorf("%d: expected args %v after typeCheckSameTypedExprs for %v, found %v", idx, test.expectedArgs, buildExprs(exprs), args)
+			if !reflect.DeepEqual(ctx.Args, test.expectedArgs) {
+				t.Errorf("%d: expected args %v after typeCheckSameTypedExprs for %v, found %v", idx, test.expectedArgs, buildExprs(exprs), ctx.Args)
 			}
 		}
 	})
@@ -360,8 +360,9 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 		{nil, nil, exprs(valArg("b"), valArg("a")), paramErr},
 	}
 	for i, d := range testData {
+		ctx := SemaContext{Args: d.args}
 		forEachPerm(d.exprs, 0, func(exprs []copyableExpr) {
-			if _, _, err := typeCheckSameTypedExprs(d.args, d.desired, buildExprs(exprs)...); !testutils.IsError(err, d.expectedErr) {
+			if _, _, err := typeCheckSameTypedExprs(&ctx, d.desired, buildExprs(exprs)...); !testutils.IsError(err, d.expectedErr) {
 				t.Errorf("%d: expected %s, but found %v", i, d.expectedErr, err)
 			}
 		})

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -39,6 +39,7 @@ type planner struct {
 	// TODO(andrei): see if the circular dependency between planner and Session
 	// can be broken if we move the User and Database here from the Session.
 	session  *Session
+	semaCtx  parser.SemaContext
 	evalCtx  parser.EvalContext
 	leases   []*LeaseState
 	leaseMgr *LeaseManager
@@ -171,6 +172,9 @@ func (p *planner) resetForBatch(e *Executor) {
 	// The parser cannot be reused between batches.
 	p.parser = parser.Parser{}
 
+	p.semaCtx = parser.SemaContext{
+		Location: &p.session.Location,
+	}
 	p.evalCtx = parser.EvalContext{
 		NodeID:   e.nodeID,
 		ReCache:  e.reCache,

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -139,7 +139,7 @@ func (rh *returningHelper) TypeCheck() error {
 		if len(rh.desiredTypes) > i {
 			desired = rh.desiredTypes[i]
 		}
-		typedExpr, err := parser.TypeCheck(baseExpr, rh.p.evalCtx.Args, desired)
+		typedExpr, err := parser.TypeCheck(baseExpr, &rh.p.semaCtx, desired)
 		if err != nil {
 			return err
 		}

--- a/sql/select.go
+++ b/sql/select.go
@@ -565,7 +565,7 @@ func (s *selectNode) initWhere(where *parser.Where) error {
 		return err
 	}
 
-	s.filter, err = parser.TypeCheckAndRequire(untypedFilter, s.planner.evalCtx.Args,
+	s.filter, err = parser.TypeCheckAndRequire(untypedFilter, &s.planner.semaCtx,
 		parser.TypeBool, "WHERE")
 	if err != nil {
 		return err
@@ -667,7 +667,7 @@ func (s *selectNode) addRender(target parser.SelectExpr, desiredType parser.Datu
 	if err != nil {
 		return err
 	}
-	typedResolved, err := parser.TypeCheck(resolved, s.planner.evalCtx.Args, desiredType)
+	typedResolved, err := parser.TypeCheck(resolved, &s.planner.semaCtx, desiredType)
 	if err != nil {
 		return err
 	}

--- a/sql/select_qvalue.go
+++ b/sql/select_qvalue.go
@@ -115,7 +115,7 @@ func (q *qvalue) Walk(v parser.Visitor) parser.Expr {
 }
 
 // TypeCheck implements the Expr interface.
-func (q *qvalue) TypeCheck(args parser.MapArgs, desired parser.Datum) (parser.TypedExpr, error) {
+func (q *qvalue) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.TypedExpr, error) {
 	return q, nil
 }
 
@@ -287,7 +287,7 @@ func (s *starDatum) String() string { return parser.AsString(s) }
 func (s *starDatum) Walk(v parser.Visitor) parser.Expr { return s }
 
 // TypeCheck implements the Expr interface.
-func (s *starDatum) TypeCheck(args parser.MapArgs, desired parser.Datum) (parser.TypedExpr, error) {
+func (s *starDatum) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.TypedExpr, error) {
 	return s, nil
 }
 

--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -79,7 +79,7 @@ func (s *subquery) Walk(v parser.Visitor) parser.Expr {
 
 func (s *subquery) Variable() {}
 
-func (s *subquery) TypeCheck(args parser.MapArgs, desired parser.Datum) (parser.TypedExpr, error) {
+func (s *subquery) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.TypedExpr, error) {
 	// TODO(knz): if/when type checking can be extracted from the
 	// newPlan recursion, we can propagate the desired type to the
 	// sub-query. For now, the type is simply derived during the subquery node

--- a/sql/update.go
+++ b/sql/update.go
@@ -222,11 +222,11 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 			continue
 		}
 		// TODO(nvanbenschoten) isn't this TypeCheck redundant with the call to SelectClause?
-		typedTarget, err := parser.TypeCheck(target, p.evalCtx.Args, updateCols[i].Type.ToDatumType())
+		typedTarget, err := parser.TypeCheck(target, &p.semaCtx, updateCols[i].Type.ToDatumType())
 		if err != nil {
 			return nil, err
 		}
-		err = sqlbase.CheckColumnType(updateCols[i], typedTarget.ReturnType(), p.evalCtx.Args)
+		err = sqlbase.CheckColumnType(updateCols[i], typedTarget.ReturnType(), p.semaCtx.Args)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/upsert.go
+++ b/sql/upsert.go
@@ -108,7 +108,7 @@ func (p *planner) makeUpsertHelper(
 			return nil, err
 		}
 
-		typedExpr, err := parser.TypeCheck(resolvedExpr, p.evalCtx.Args, parser.NoTypePreference)
+		typedExpr, err := parser.TypeCheck(resolvedExpr, &p.semaCtx, parser.NoTypePreference)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/values.go
+++ b/sql/values.go
@@ -77,7 +77,7 @@ func (p *planner) ValuesClause(n *parser.ValuesClause, desiredTypes []parser.Dat
 			if len(desiredTypes) > i {
 				desired = desiredTypes[i]
 			}
-			typedExpr, err := parser.TypeCheck(expr, p.evalCtx.Args, desired)
+			typedExpr, err := parser.TypeCheck(expr, &p.semaCtx, desired)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This change creates a new `SemaContext` struct that is passed around
during semantic analysis. It currently wraps a `MapArgs` and a
`Location` reference. The context is passed as a pointer, which is the
plan for `EvalContext` soon (see #6809).

This can wait on #6735, because it will be much easier for me to rebase than
for @knz.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6897)

<!-- Reviewable:end -->
