### PR TITLE
ui next: Single Node Overview Page

### DIFF
--- a/ui/next/app/app.tsx
+++ b/ui/next/app/app.tsx
@@ -17,8 +17,6 @@
  * - Cluster Page
  *    - Events page
  * - Node Page
- *    - Overview page with table
- *    - Graphs page
  *    ! Logs Page
  * ! HelpUs Page
  *    - Forms

--- a/ui/next/app/containers/clusterOverview.tsx
+++ b/ui/next/app/containers/clusterOverview.tsx
@@ -164,7 +164,7 @@ let clusterMainConnected = connect(
     };
   },
   {
-      refreshNodes: refreshNodes,
+      refreshNodes,
   }
 )(ClusterMain);
 

--- a/ui/next/app/containers/nodeOverview.tsx
+++ b/ui/next/app/containers/nodeOverview.tsx
@@ -1,13 +1,139 @@
 /// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
+import { connect } from "react-redux";
+import { createSelector } from "reselect";
+import { RouteComponentProps } from "react-router";
+import _ = require("lodash");
+
+import { refreshNodes } from "../redux/nodes";
+import { NodeStatus, MetricConstants } from  "../util/proto";
+import { Bytes, Percentage } from "../util/format";
+
+interface NodeOverviewProps extends RouteComponentProps<any, any> {
+  node: NodeStatus;
+  refreshNodes(): void;
+}
 
 /**
- * Renders the main content of the help us page.
+ * Renders the Node Overview page.
  */
-export default class extends React.Component<{}, {}> {
+class NodeOverview extends React.Component<NodeOverviewProps, {}> {
+  componentWillMount() {
+    // Refresh nodes status query when mounting.
+    this.props.refreshNodes();
+  }
+
+  componentWillReceiveProps(props: NodeOverviewProps) {
+    // Refresh nodes status query when props are received; this will immediately
+    // trigger a new request if previous results are invalidated.
+    props.refreshNodes();
+  }
+
   render() {
-    return <div className="section">
-      <h1>Node Overview</h1>
-    </div>;
+    let node = this.props.node;
+    if (!node) {
+      return <div className="section">
+        <h1>Loading cluster status...</h1>
+      </div>;
+    }
+
+    return <div className="section table">
+        <div className="stats-table">
+          <table>
+            <thead>
+              <tr>
+                <th className="title" />
+                <th className="value">{`Node ${node.desc.node_id}`}</th>
+                {
+                  _.map(node.store_statuses, (ss) => {
+                    let storeId = ss.desc.store_id;
+                    return <th key={storeId} className="value">{`Store ${storeId}`}</th>;
+                  })
+                }
+              </tr>
+            </thead>
+            <tbody>
+              <TableRow data={node}
+                        title="Live Bytes"
+                        valueFn={(metrics) => Bytes(metrics.get(MetricConstants.liveBytes))} />
+              <TableRow data={node}
+                        title="Key Bytes"
+                        valueFn={(metrics) => Bytes(metrics.get(MetricConstants.keyBytes))} />
+              <TableRow data={node}
+                        title="Value Bytes"
+                        valueFn={(metrics) => Bytes(metrics.get(MetricConstants.valBytes))} />
+              <TableRow data={node}
+                        title="Intent Bytes"
+                        valueFn={(metrics) => Bytes(metrics.get(MetricConstants.intentBytes))} />
+              <TableRow data={node}
+                        title="Sys Bytes"
+                        valueFn={(metrics) => Bytes(metrics.get(MetricConstants.sysBytes))} />
+              <TableRow data={node}
+                        title="GC Bytes Age"
+                        valueFn={(metrics) => metrics.get(MetricConstants.gcBytesAge).toString()} />
+              <TableRow data={node}
+                        title="Total Replicas"
+                        valueFn={(metrics) => metrics.get(MetricConstants.replicas).toString()} />
+              <TableRow data={node}
+                        title="Leader Ranges"
+                        valueFn={(metrics) => metrics.get(MetricConstants.leaderRanges).toString()} />
+              <TableRow data={node}
+                        title="Available"
+                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.availableRanges), metrics.get(MetricConstants.leaderRanges))} />
+              <TableRow data={node}
+                        title="Fully Replicated"
+                        valueFn={(metrics) => Percentage(metrics.get(MetricConstants.replicatedRanges), metrics.get(MetricConstants.leaderRanges))} />
+              <TableRow data={node}
+                        title="Available Capacity"
+                        valueFn={(metrics) => Bytes(metrics.get(MetricConstants.availableCapacity))} />
+              <TableRow data={node}
+                        title="Total Capacity"
+                        valueFn={(metrics) => Bytes(metrics.get(MetricConstants.capacity))} />
+            </tbody>
+          </table>
+        </div>
+        <div className="section info">
+          <div className="info">{ `Build: ${node.build_info.tag}` }</div>
+        </div>
+      </div>;
   }
 }
+
+/**
+ * TableRow is a small stateless component that renders a single row in the node
+ * overview table. Each row renders a store metrics value, comparing the value
+ * across the different stores on the node (along with a total value for the
+ * node itself).
+ */
+function TableRow(props: { data: NodeStatus, title: string, valueFn: (s: cockroach.ProtoBufMap<string, number>) => React.ReactNode }) {
+  return <tr>
+    <td className="title">{ props.title }</td>
+    <td className="value">{ props.valueFn(props.data.metrics) }</td>
+    {
+      _.map(props.data.store_statuses,
+            (ss) => <td key={ss.desc.store_id} className="value">{ props.valueFn(ss.metrics) }</td>
+           )
+    }
+  </tr>;
+}
+
+let currentNode = createSelector(
+  (state: any, props: RouteComponentProps<any, any>): NodeStatus[] => state.nodes.statuses,
+  (state: any, props: RouteComponentProps<any, any>): number => parseInt(props.params.node_id, 10),
+  (nodes, id) => {
+    if (!nodes || !id) {
+      return undefined;
+    }
+    return _.find(nodes, (ns) => ns.desc.node_id === id);
+  });
+
+export default connect(
+  (state: any, ownProps: RouteComponentProps<any, any>) => {
+    return {
+      node: currentNode(state, ownProps),
+    };
+  },
+  {
+    refreshNodes,
+  }
+)(NodeOverview);

--- a/ui/next/app/util/format.ts
+++ b/ui/next/app/util/format.ts
@@ -33,3 +33,13 @@ export function Bytes(bytes: number): string {
   let unitVal: UnitValue = BytesToUnitValue(bytes);
   return unitVal.value.toFixed(1) + " " + unitVal.units;
 }
+
+/**
+ * Percentage creates a string representation of a fraction as a percentage.
+ */
+export function Percentage(numerator: number, denominator: number): string {
+  if (denominator === 0) {
+    return "100%";
+  }
+  return Math.floor(numerator / denominator * 100).toString() + "%";
+}


### PR DESCRIPTION
The single-node overview page is now rendered in ui next. The page contains a
table comparing metric values across the different stores on the node; it also
displays the current build for the node.

The table is not sortable and requires no rollup computations, so it is easily
rendered directly without using a table component.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6903)

<!-- Reviewable:end -->
