### PR TITLE
cli: separate client/server contexts

### DIFF
--- a/cli/cert.go
+++ b/cli/cert.go
@@ -43,11 +43,11 @@ Generates CA certificate and key, writing them to --ca-cert and --ca-key.
 // runCreateCACert generates key pair and CA certificate and writes them
 // to their corresponding files.
 func runCreateCACert(cmd *cobra.Command, args []string) error {
-	if len(cliContext.SSLCA) == 0 || len(cliContext.SSLCAKey) == 0 {
+	if len(baseCtx.SSLCA) == 0 || len(baseCtx.SSLCAKey) == 0 {
 		mustUsage(cmd)
 		return errMissingParams
 	}
-	if err := security.RunCreateCACert(cliContext.SSLCA, cliContext.SSLCAKey, keySize); err != nil {
+	if err := security.RunCreateCACert(baseCtx.SSLCA, baseCtx.SSLCAKey, keySize); err != nil {
 		return fmt.Errorf("failed to generate CA certificate: %s", err)
 	}
 	return nil
@@ -70,13 +70,13 @@ At least one host should be passed in (either IP address or dns name).
 // runCreateNodeCert generates key pair and CA certificate and writes them
 // to their corresponding files.
 func runCreateNodeCert(cmd *cobra.Command, args []string) error {
-	if len(cliContext.SSLCA) == 0 || len(cliContext.SSLCAKey) == 0 ||
-		len(cliContext.SSLCert) == 0 || len(cliContext.SSLCertKey) == 0 {
+	if len(baseCtx.SSLCA) == 0 || len(baseCtx.SSLCAKey) == 0 ||
+		len(baseCtx.SSLCert) == 0 || len(baseCtx.SSLCertKey) == 0 {
 		mustUsage(cmd)
 		return errMissingParams
 	}
-	if err := security.RunCreateNodeCert(cliContext.SSLCA, cliContext.SSLCAKey,
-		cliContext.SSLCert, cliContext.SSLCertKey, keySize, args); err != nil {
+	if err := security.RunCreateNodeCert(baseCtx.SSLCA, baseCtx.SSLCAKey,
+		baseCtx.SSLCert, baseCtx.SSLCertKey, keySize, args); err != nil {
 		return fmt.Errorf("failed to generate node certificate: %s", err)
 	}
 	return nil
@@ -103,14 +103,14 @@ func runCreateClientCert(cmd *cobra.Command, args []string) error {
 		mustUsage(cmd)
 		return errMissingParams
 	}
-	if len(cliContext.SSLCA) == 0 || len(cliContext.SSLCAKey) == 0 ||
-		len(cliContext.SSLCert) == 0 || len(cliContext.SSLCertKey) == 0 {
+	if len(baseCtx.SSLCA) == 0 || len(baseCtx.SSLCAKey) == 0 ||
+		len(baseCtx.SSLCert) == 0 || len(baseCtx.SSLCertKey) == 0 {
 		mustUsage(cmd)
 		return errMissingParams
 	}
 
-	if err := security.RunCreateClientCert(cliContext.SSLCA, cliContext.SSLCAKey,
-		cliContext.SSLCert, cliContext.SSLCertKey, keySize, args[0]); err != nil {
+	if err := security.RunCreateClientCert(baseCtx.SSLCA, baseCtx.SSLCAKey,
+		baseCtx.SSLCert, baseCtx.SSLCertKey, keySize, args[0]); err != nil {
 		return fmt.Errorf("failed to generate clent certificate: %s", err)
 	}
 	return nil

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 type cliTest struct {
-	*server.TestServer
+	server.TestServer
 	certsDir    string
 	cleanupFunc func()
 }
@@ -57,11 +57,11 @@ func newCLITest() cliTest {
 	// Reset the client context for each test. We don't reset the
 	// pointer (because they are tied into the flags), but instead
 	// overwrite the existing struct's values.
-	cliContext.InitDefaults()
+	baseCtx.InitDefaults()
 
 	osStderr = os.Stdout
 
-	s := &server.TestServer{}
+	var s server.TestServer
 	if err := s.Start(); err != nil {
 		log.Fatalf("Could not start server: %v", err)
 	}
@@ -152,7 +152,7 @@ func (c cliTest) RunWithCapture(line string) (out string, err error) {
 }
 
 func (c cliTest) RunWithArgs(a []string) {
-	cliContext.execStmts = nil
+	sqlCtx.execStmts = nil
 
 	var args []string
 	args = append(args, a[0])
@@ -288,9 +288,9 @@ func Example_quoted() {
 
 func Example_insecure() {
 	c := cliTest{cleanupFunc: func() {}}
-	c.TestServer = &server.TestServer{}
-	c.Ctx = server.NewTestContext()
-	c.Ctx.Insecure = true
+	ctx := server.MakeTestContext()
+	ctx.Insecure = true
+	c.TestServer.Ctx = &ctx
 	if err := c.Start(); err != nil {
 		log.Fatalf("Could not start server: %v", err)
 	}

--- a/cli/context.go
+++ b/cli/context.go
@@ -19,7 +19,7 @@ package cli
 import (
 	"strings"
 
-	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/base"
 )
 
 // statementsValue is an implementation of pflag.Value that appends any
@@ -39,31 +39,16 @@ func (s *statementsValue) Set(value string) error {
 	return nil
 }
 
+type sqlContext struct {
+	// Embed the base context.
+	*base.Context
+
+	// execStmts is a list of statements to execute.
+	execStmts statementsValue
+}
+
 type debugContext struct {
 	startKey, endKey string
 	raw              bool
 	values           bool
-}
-
-// Context contains global settings for the command-line client.
-type Context struct {
-	// Embed the server context.
-	server.Context
-
-	// execStmts is a list of statements to execute.
-	execStmts statementsValue
-	// debugContext holds values used by debug cli commands.
-	debug debugContext
-}
-
-// NewContext returns a Context with default values.
-func NewContext() *Context {
-	ctx := &Context{}
-	ctx.InitDefaults()
-	return ctx
-}
-
-// InitDefaults sets up the default values for a Context.
-func (ctx *Context) InitDefaults() {
-	ctx.Context.InitDefaults()
 }

--- a/cli/debug.go
+++ b/cli/debug.go
@@ -61,10 +61,7 @@ func parseRangeID(arg string) (roachpb.RangeID, error) {
 }
 
 func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (engine.Engine, error) {
-	setDefaultCacheSize(&cliContext.Context)
-
-	db := engine.NewRocksDB(roachpb.Attributes{}, dir,
-		cliContext.CacheSize, cliContext.MemtableBudget, 0, stopper)
+	db := engine.NewRocksDB(roachpb.Attributes{}, dir, 512<<20, 10<<20, 0, stopper)
 	if err := db.Open(); err != nil {
 		return nil, err
 	}
@@ -109,27 +106,25 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	d := cliContext.debug
-
 	from := engine.NilKey
 	to := engine.MVCCKeyMax
-	if d.raw {
-		if len(d.startKey) > 0 {
-			from = engine.MakeMVCCMetadataKey(roachpb.Key(d.startKey))
+	if debugCtx.raw {
+		if len(debugCtx.startKey) > 0 {
+			from = engine.MakeMVCCMetadataKey(roachpb.Key(debugCtx.startKey))
 		}
-		if len(d.endKey) > 0 {
-			to = engine.MakeMVCCMetadataKey(roachpb.Key(d.endKey))
+		if len(debugCtx.endKey) > 0 {
+			to = engine.MakeMVCCMetadataKey(roachpb.Key(debugCtx.endKey))
 		}
 	} else {
-		if len(d.startKey) > 0 {
-			startKey, err := keys.UglyPrint(d.startKey)
+		if len(debugCtx.startKey) > 0 {
+			startKey, err := keys.UglyPrint(debugCtx.startKey)
 			if err != nil {
 				return err
 			}
 			from = engine.MakeMVCCMetadataKey(startKey)
 		}
-		if len(d.endKey) > 0 {
-			endKey, err := keys.UglyPrint(d.endKey)
+		if len(debugCtx.endKey) > 0 {
+			endKey, err := keys.UglyPrint(debugCtx.endKey)
 			if err != nil {
 				return err
 			}
@@ -138,7 +133,7 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 	}
 
 	printer := printKey
-	if d.values {
+	if debugCtx.values {
 		printer = printKeyValue
 	}
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/cli/cliflags"
 	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/util/envutil"
 	"github.com/cockroachdb/cockroach/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/util/log/logflags"
@@ -42,8 +43,11 @@ var connUser, connHost, connPort, httpPort, connDBName string
 var startBackground bool
 var undoFreezeCluster bool
 
-// cliContext is the CLI Context used for the command-line client.
-var cliContext = NewContext()
+var serverCtx = server.MakeContext()
+var baseCtx = serverCtx.Context
+var sqlCtx = sqlContext{Context: baseCtx}
+var debugCtx debugContext
+
 var cacheSize *bytesValue
 var insecure *insecureValue
 
@@ -324,10 +328,10 @@ func (b *insecureValue) Set(s string) error {
 		// If --insecure is specified, clear any of the existing security flags if
 		// they were set. This allows composition of command lines where a later
 		// specification of --insecure clears an earlier security specification.
-		cliContext.SSLCA = ""
-		cliContext.SSLCAKey = ""
-		cliContext.SSLCert = ""
-		cliContext.SSLCertKey = ""
+		baseCtx.SSLCA = ""
+		baseCtx.SSLCAKey = ""
+		baseCtx.SSLCert = ""
+		baseCtx.SSLCertKey = ""
 	}
 	return nil
 }
@@ -340,10 +344,7 @@ func (b *insecureValue) String() string {
 	return fmt.Sprint(*b.val)
 }
 
-// initFlags sets the cli.Context values to flag values.
-// Keep in sync with "server/context.go". Values in Context should be
-// settable here.
-func initFlags(ctx *Context) {
+func init() {
 	// Change the logging defaults for the main cockroach binary.
 	if err := flag.Lookup(logflags.LogToStderrName).Value.Set("false"); err != nil {
 		panic(err)
@@ -369,44 +370,44 @@ func initFlags(ctx *Context) {
 		f.StringVar(&connHost, cliflags.HostName, "", usageNoEnv(forServer(cliflags.HostName)))
 		f.StringVarP(&connPort, cliflags.PortName, "p", base.DefaultPort, usageNoEnv(forServer(cliflags.PortName)))
 		f.StringVar(&httpPort, cliflags.HTTPPortName, base.DefaultHTTPPort, usageNoEnv(forServer(cliflags.HTTPPortName)))
-		f.StringVar(&ctx.Attrs, cliflags.AttrsName, ctx.Attrs, usageNoEnv(cliflags.AttrsName))
-		f.VarP(&ctx.Stores, cliflags.StoreName, "s", usageNoEnv(cliflags.StoreName))
-		f.DurationVar(&ctx.RaftTickInterval, cliflags.RaftTickIntervalName, base.DefaultRaftTickInterval, usageNoEnv(cliflags.RaftTickIntervalName))
+		f.StringVar(&serverCtx.Attrs, cliflags.AttrsName, serverCtx.Attrs, usageNoEnv(cliflags.AttrsName))
+		f.VarP(&serverCtx.Stores, cliflags.StoreName, "s", usageNoEnv(cliflags.StoreName))
+		f.DurationVar(&serverCtx.RaftTickInterval, cliflags.RaftTickIntervalName, base.DefaultRaftTickInterval, usageNoEnv(cliflags.RaftTickIntervalName))
 		f.BoolVar(&startBackground, cliflags.BackgroundName, false, usageNoEnv(cliflags.BackgroundName))
 
 		// Usage for the unix socket is odd as we use a real file, whereas
 		// postgresql and clients consider it a directory and build a filename
 		// inside it using the port.
 		// Thus, we keep it hidden and use it for testing only.
-		f.StringVar(&ctx.SocketFile, cliflags.SocketName, "", usageEnv(cliflags.SocketName))
+		f.StringVar(&serverCtx.SocketFile, cliflags.SocketName, "", usageEnv(cliflags.SocketName))
 		_ = f.MarkHidden(cliflags.SocketName)
 
 		// Security flags.
-		ctx.Insecure = true
-		insecure = newInsecureValue(&ctx.Insecure)
+		baseCtx.Insecure = true
+		insecure = newInsecureValue(&baseCtx.Insecure)
 		insecureF := f.VarPF(insecure, cliflags.InsecureName, "", usageNoEnv(cliflags.InsecureName))
 		insecureF.NoOptDefVal = "true"
 		// Certificates.
-		f.StringVar(&ctx.SSLCA, cliflags.CACertName, ctx.SSLCA, usageNoEnv(cliflags.CACertName))
-		f.StringVar(&ctx.SSLCert, cliflags.CertName, ctx.SSLCert, usageNoEnv(cliflags.CertName))
-		f.StringVar(&ctx.SSLCertKey, cliflags.KeyName, ctx.SSLCertKey, usageNoEnv(cliflags.KeyName))
+		f.StringVar(&baseCtx.SSLCA, cliflags.CACertName, baseCtx.SSLCA, usageNoEnv(cliflags.CACertName))
+		f.StringVar(&baseCtx.SSLCert, cliflags.CertName, baseCtx.SSLCert, usageNoEnv(cliflags.CertName))
+		f.StringVar(&baseCtx.SSLCertKey, cliflags.KeyName, baseCtx.SSLCertKey, usageNoEnv(cliflags.KeyName))
 
 		// Cluster joining flags.
-		f.StringVar(&ctx.JoinUsing, cliflags.JoinName, ctx.JoinUsing, usageNoEnv(cliflags.JoinName))
+		f.StringVar(&serverCtx.JoinUsing, cliflags.JoinName, serverCtx.JoinUsing, usageNoEnv(cliflags.JoinName))
 
 		// Engine flags.
-		setDefaultCacheSize(&ctx.Context)
-		cacheSize = newBytesValue(&ctx.CacheSize)
+		setDefaultCacheSize(&serverCtx)
+		cacheSize = newBytesValue(&serverCtx.CacheSize)
 		f.Var(cacheSize, cliflags.CacheName, usageNoEnv(cliflags.CacheName))
 	}
 
 	for _, cmd := range certCmds {
 		f := cmd.Flags()
 		// Certificate flags.
-		f.StringVar(&ctx.SSLCA, cliflags.CACertName, ctx.SSLCA, usageNoEnv(cliflags.CACertName))
-		f.StringVar(&ctx.SSLCAKey, cliflags.CAKeyName, ctx.SSLCAKey, usageNoEnv(cliflags.CAKeyName))
-		f.StringVar(&ctx.SSLCert, cliflags.CertName, ctx.SSLCert, usageNoEnv(cliflags.CertName))
-		f.StringVar(&ctx.SSLCertKey, cliflags.KeyName, ctx.SSLCertKey, usageNoEnv(cliflags.KeyName))
+		f.StringVar(&baseCtx.SSLCA, cliflags.CACertName, baseCtx.SSLCA, usageNoEnv(cliflags.CACertName))
+		f.StringVar(&baseCtx.SSLCAKey, cliflags.CAKeyName, baseCtx.SSLCAKey, usageNoEnv(cliflags.CAKeyName))
+		f.StringVar(&baseCtx.SSLCert, cliflags.CertName, baseCtx.SSLCert, usageNoEnv(cliflags.CertName))
+		f.StringVar(&baseCtx.SSLCertKey, cliflags.KeyName, baseCtx.SSLCertKey, usageNoEnv(cliflags.KeyName))
 		f.IntVar(&keySize, cliflags.KeySizeName, defaultKeySize, usageNoEnv(cliflags.KeySizeName))
 	}
 
@@ -427,14 +428,14 @@ func initFlags(ctx *Context) {
 		f.StringVar(&connHost, cliflags.HostName, envutil.EnvOrDefaultString(cliflags.HostName, ""), usageEnv(forClient(cliflags.HostName)))
 
 		// Certificate flags.
-		f.StringVar(&ctx.SSLCA, cliflags.CACertName, envutil.EnvOrDefaultString(cliflags.CACertName, ctx.SSLCA), usageEnv(cliflags.CACertName))
-		f.StringVar(&ctx.SSLCert, cliflags.CertName, envutil.EnvOrDefaultString(cliflags.CertName, ctx.SSLCert), usageEnv(cliflags.CertName))
-		f.StringVar(&ctx.SSLCertKey, cliflags.KeyName, envutil.EnvOrDefaultString(cliflags.KeyName, ctx.SSLCertKey), usageEnv(cliflags.KeyName))
+		f.StringVar(&baseCtx.SSLCA, cliflags.CACertName, envutil.EnvOrDefaultString(cliflags.CACertName, baseCtx.SSLCA), usageEnv(cliflags.CACertName))
+		f.StringVar(&baseCtx.SSLCert, cliflags.CertName, envutil.EnvOrDefaultString(cliflags.CertName, baseCtx.SSLCert), usageEnv(cliflags.CertName))
+		f.StringVar(&baseCtx.SSLCertKey, cliflags.KeyName, envutil.EnvOrDefaultString(cliflags.KeyName, baseCtx.SSLCertKey), usageEnv(cliflags.KeyName))
 	}
 
 	{
 		f := sqlShellCmd.Flags()
-		f.VarP(&ctx.execStmts, cliflags.ExecuteName, "e", usageNoEnv(cliflags.ExecuteName))
+		f.VarP(&sqlCtx.execStmts, cliflags.ExecuteName, "e", usageNoEnv(cliflags.ExecuteName))
 	}
 	{
 		f := freezeClusterCmd.PersistentFlags()
@@ -473,31 +474,27 @@ func initFlags(ctx *Context) {
 	// Debug commands.
 	{
 		f := debugKeysCmd.Flags()
-		f.StringVar(&cliContext.debug.startKey, cliflags.FromName, "", usageNoEnv(cliflags.FromName))
-		f.StringVar(&cliContext.debug.endKey, cliflags.ToName, "", usageNoEnv(cliflags.ToName))
-		f.BoolVar(&cliContext.debug.raw, cliflags.RawName, false, usageNoEnv(cliflags.RawName))
-		f.BoolVar(&cliContext.debug.values, cliflags.ValuesName, false, usageNoEnv(cliflags.ValuesName))
+		f.StringVar(&debugCtx.startKey, cliflags.FromName, "", usageNoEnv(cliflags.FromName))
+		f.StringVar(&debugCtx.endKey, cliflags.ToName, "", usageNoEnv(cliflags.ToName))
+		f.BoolVar(&debugCtx.raw, cliflags.RawName, false, usageNoEnv(cliflags.RawName))
+		f.BoolVar(&debugCtx.values, cliflags.ValuesName, false, usageNoEnv(cliflags.ValuesName))
 	}
 
 	{
 		f := versionCmd.Flags()
 		f.BoolVar(&versionIncludesDeps, cliflags.DepsName, false, usageNoEnv(cliflags.DepsName))
 	}
-}
-
-func init() {
-	initFlags(cliContext)
 
 	cobra.OnInitialize(func() {
 		// If any of the security flags have been set, clear the insecure
 		// setting. Note that we do the inverse when the --insecure flag is
 		// set. See insecureValue.Set().
-		if cliContext.SSLCA != "" || cliContext.SSLCAKey != "" ||
-			cliContext.SSLCert != "" || cliContext.SSLCertKey != "" {
-			cliContext.Insecure = false
+		if baseCtx.SSLCA != "" || baseCtx.SSLCAKey != "" ||
+			baseCtx.SSLCert != "" || baseCtx.SSLCertKey != "" {
+			baseCtx.Insecure = false
 		}
 
-		cliContext.Addr = net.JoinHostPort(connHost, connPort)
-		cliContext.HTTPAddr = net.JoinHostPort(connHost, httpPort)
+		serverCtx.Addr = net.JoinHostPort(connHost, connPort)
+		serverCtx.HTTPAddr = net.JoinHostPort(connHost, httpPort)
 	})
 }

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -64,10 +64,9 @@ func TestCacheFlagValue(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := cliContext
 	const expectedCacheSize = 100 * 1000 * 1000
-	if expectedCacheSize != ctx.CacheSize {
-		t.Errorf("expected %d, but got %d", expectedCacheSize, ctx.CacheSize)
+	if expectedCacheSize != serverCtx.CacheSize {
+		t.Errorf("expected %d, but got %d", expectedCacheSize, serverCtx.CacheSize)
 	}
 }
 
@@ -82,13 +81,13 @@ func TestRaftTickIntervalFlagValue(t *testing.T) {
 		{nil, base.DefaultRaftTickInterval},
 		{[]string{"--raft-tick-interval", "200ms"}, 200 * time.Millisecond},
 	}
-	ctx := cliContext
+
 	for i, td := range testData {
 		if err := f.Parse(td.args); err != nil {
 			t.Fatal(err)
 		}
-		if td.expected != ctx.RaftTickInterval {
-			t.Errorf("%d. RaftTickInterval expected %d, but got %d", i, td.expected, ctx.RaftTickInterval)
+		if td.expected != serverCtx.RaftTickInterval {
+			t.Errorf("%d. RaftTickInterval expected %d, but got %d", i, td.expected, serverCtx.RaftTickInterval)
 		}
 	}
 }

--- a/cli/kv.go
+++ b/cli/kv.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/keys"
@@ -29,20 +31,18 @@ import (
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util/stop"
-
-	"github.com/spf13/cobra"
 )
 
 func makeDBClient() (*client.DB, *stop.Stopper) {
 	stopper := stop.NewStopper()
 	context := &base.Context{
 		User:       security.NodeUser,
-		SSLCA:      cliContext.SSLCA,
-		SSLCert:    cliContext.SSLCert,
-		SSLCertKey: cliContext.SSLCertKey,
-		Insecure:   cliContext.Insecure,
+		SSLCA:      baseCtx.SSLCA,
+		SSLCert:    baseCtx.SSLCert,
+		SSLCertKey: baseCtx.SSLCertKey,
+		Insecure:   baseCtx.Insecure,
 	}
-	sender, err := client.NewSender(rpc.NewContext(context, nil, stopper), cliContext.Addr)
+	sender, err := client.NewSender(rpc.NewContext(context, nil, stopper), baseCtx.Addr)
 	if err != nil {
 		stopper.Stop()
 		panicf("failed to initialize KV client: %s", err)

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -357,9 +357,9 @@ func runTerm(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 
-	if len(cliContext.execStmts) > 0 {
+	if len(sqlCtx.execStmts) > 0 {
 		// Single-line sql; run as simple as possible, without noise on stdout.
-		return runStatements(conn, cliContext.execStmts)
+		return runStatements(conn, sqlCtx.execStmts)
 	}
 	return runInteractive(conn)
 }

--- a/cli/sql_util.go
+++ b/cli/sql_util.go
@@ -145,7 +145,7 @@ func makeSQLConn(url string) *sqlConn {
 func makeSQLClient() (*sqlConn, error) {
 	sqlURL := connURL
 	if len(connURL) == 0 {
-		u, err := cliContext.PGURL(connUser)
+		u, err := sqlCtx.PGURL(connUser)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/start_test.go
+++ b/cli/start_test.go
@@ -27,7 +27,7 @@ func TestInitInsecure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	f := startCmd.Flags()
-	ctx := cliContext
+	ctx := serverCtx
 
 	testCases := []struct {
 		args     []string

--- a/client/db_test.go
+++ b/client/db_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-func setup() (*server.TestServer, *client.DB) {
+func setup() (server.TestServer, *client.DB) {
 	s := server.StartTestServer(nil)
 	return s, s.DB()
 }
@@ -282,9 +282,11 @@ func ExampleTxn_Commit() {
 }
 
 func ExampleDB_Put_insecure() {
-	s := &server.TestServer{}
-	s.Ctx = server.NewTestContext()
-	s.Ctx.Insecure = true
+	ctx := server.MakeTestContext()
+	ctx.Insecure = true
+	s := server.TestServer{
+		Ctx: &ctx,
+	}
 	if err := s.Start(); err != nil {
 		log.Fatalf("Could not start server: %v", err)
 	}

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -80,7 +80,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 // key range at the given keys. Returns the test server and client.
 // The caller is responsible for stopping the server and
 // closing the client.
-func setupMultipleRanges(t *testing.T, ts *server.TestServer, splitAt ...string) *client.DB {
+func setupMultipleRanges(t *testing.T, ts server.TestServer, splitAt ...string) *client.DB {
 	db := createTestClient(t, ts.Stopper(), ts.ServingAddr())
 
 	// Split the keyspace at the given keys.
@@ -319,7 +319,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 	}
 }
 
-func initReverseScanTestEnv(s *server.TestServer, t *testing.T) *client.DB {
+func initReverseScanTestEnv(s server.TestServer, t *testing.T) *client.DB {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
 	// Set up multiple ranges:
@@ -521,9 +521,9 @@ func TestPropagateTxnOnError(t *testing.T) {
 			}
 			return nil
 		}
-	ctx := server.NewTestContext()
+	ctx := server.MakeTestContext()
 	ctx.TestingKnobs.Store = &storeKnobs
-	s := server.StartTestServerWithContext(t, ctx)
+	s := server.StartTestServerWithContext(t, &ctx)
 	defer s.Stop()
 	db := setupMultipleRanges(t, s, "b")
 
@@ -586,10 +586,8 @@ func assertTransactionPushErrorWithTxnIDSet(t *testing.T, e error) *uuid.UUID {
 				t.Fatalf("txn ID is not set unexpectedly: %s", retErr)
 			}
 			return retErr.TxnID
-		} else {
-			t.Fatalf("expected a TransactionPushError, but got %s (%T)",
-				retErr.Cause, retErr.Cause)
 		}
+		t.Fatalf("expected a TransactionPushError, but got %s (%T)", retErr.Cause, retErr.Cause)
 	} else {
 		t.Fatalf("expected a retryable error, but got %s (%T)", e, e)
 	}

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -78,7 +78,6 @@ type Context struct {
 	HeartbeatCB       func()
 
 	localInternalServer roachpb.InternalServer
-	localAddr           string
 
 	conns struct {
 		sync.Mutex
@@ -117,16 +116,15 @@ func NewContext(baseCtx *base.Context, clock *hlc.Clock, stopper *stop.Stopper) 
 // GetLocalInternalServerForAddr returns the context's internal batch server
 // for addr, if it exists.
 func (ctx *Context) GetLocalInternalServerForAddr(addr string) roachpb.InternalServer {
-	if addr == ctx.localAddr {
+	if addr == ctx.Addr {
 		return ctx.localInternalServer
 	}
 	return nil
 }
 
 // SetLocalInternalServer sets the context's local internal batch server.
-func (ctx *Context) SetLocalInternalServer(internalServer roachpb.InternalServer, addr string) {
+func (ctx *Context) SetLocalInternalServer(internalServer roachpb.InternalServer) {
 	ctx.localInternalServer = internalServer
-	ctx.localAddr = addr
 }
 
 func (ctx *Context) removeConn(key string, conn *grpc.ClientConn) {
@@ -182,7 +180,7 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 }
 
 func (ctx *Context) runHeartbeat(cc *grpc.ClientConn, remoteAddr string) error {
-	request := PingRequest{Addr: ctx.localAddr}
+	request := PingRequest{Addr: ctx.Addr}
 	heartbeatClient := NewHeartbeatClient(cc)
 
 	var heartbeatTimer timeutil.Timer

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -260,7 +260,7 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 			clock:              clock,
 			remoteClockMonitor: nodeCtxs[i].ctx.RemoteClocks,
 		})
-		nodeCtxs[i].ctx.localAddr = ln.Addr().String()
+		nodeCtxs[i].ctx.Addr = ln.Addr().String()
 	}
 
 	// Fully connect the nodes.
@@ -269,7 +269,7 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 			if i == j {
 				continue
 			}
-			if _, err := clientNodeContext.ctx.GRPCDial(serverNodeContext.ctx.localAddr); err != nil {
+			if _, err := clientNodeContext.ctx.GRPCDial(serverNodeContext.ctx.Addr); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/security/certs_test.go
+++ b/security/certs_test.go
@@ -137,15 +137,15 @@ func TestUseCerts(t *testing.T) {
 
 	// Start a test server and override certs.
 	// We use a real context since we want generated certs.
-	testCtx := server.NewContext()
-	testCtx.Insecure = false
-	testCtx.SSLCA = filepath.Join(certsDir, security.EmbeddedCACert)
-	testCtx.SSLCert = filepath.Join(certsDir, security.EmbeddedNodeCert)
-	testCtx.SSLCertKey = filepath.Join(certsDir, security.EmbeddedNodeKey)
-	testCtx.User = security.NodeUser
-	testCtx.Addr = "127.0.0.1:0"
-	testCtx.HTTPAddr = "127.0.0.1:0"
-	s := &server.TestServer{Ctx: testCtx}
+	ctx := server.MakeContext()
+	ctx.Insecure = false
+	ctx.SSLCA = filepath.Join(certsDir, security.EmbeddedCACert)
+	ctx.SSLCert = filepath.Join(certsDir, security.EmbeddedNodeCert)
+	ctx.SSLCertKey = filepath.Join(certsDir, security.EmbeddedNodeKey)
+	ctx.User = security.NodeUser
+	ctx.Addr = "127.0.0.1:0"
+	ctx.HTTPAddr = "127.0.0.1:0"
+	s := server.TestServer{Ctx: &ctx}
 	if err := s.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestUseCerts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req, err := http.NewRequest("GET", testCtx.AdminURL()+"/_admin/v1/health", nil)
+	req, err := http.NewRequest("GET", s.Ctx.AdminURL()+"/_admin/v1/health", nil)
 	if err != nil {
 		t.Fatalf("could not create request: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestUseCerts(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Endpoint that does not enforce client auth (see: server/authentication_test.go)
-	req, err = http.NewRequest("GET", testCtx.AdminURL()+"/_admin/v1/health", nil)
+	req, err = http.NewRequest("GET", s.Ctx.AdminURL()+"/_admin/v1/health", nil)
 	if err != nil {
 		t.Fatalf("could not create request: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestUseCerts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected success, got %v", err)
 	}
-	req, err = http.NewRequest("GET", testCtx.AdminURL()+"/_admin/v1/health", nil)
+	req, err = http.NewRequest("GET", s.Ctx.AdminURL()+"/_admin/v1/health", nil)
 	if err != nil {
 		t.Fatalf("could not create request: %v", err)
 	}

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -74,7 +74,7 @@ func getJSON(url string) (interface{}, error) {
 }
 
 // debugURL returns the root debug URL.
-func debugURL(s *TestServer) string {
+func debugURL(s TestServer) string {
 	return s.Ctx.AdminURL() + debugEndpoint
 }
 
@@ -203,7 +203,7 @@ func TestAdminDebugRedirect(t *testing.T) {
 
 // apiGet issues a GET to the provided server using the given API path and marshals the result
 // into the v parameter.
-func apiGet(s *TestServer, path string, v interface{}) error {
+func apiGet(s TestServer, path string, v interface{}) error {
 	apiPath := apiEndpoint + path
 	client, err := s.Ctx.GetHTTPClient()
 	if err != nil {
@@ -214,7 +214,7 @@ func apiGet(s *TestServer, path string, v interface{}) error {
 
 // apiPost issues a POST to the provided server using the given API path and
 // request body, marshalling the result into the v parameter.
-func apiPost(s *TestServer, path, body string, v interface{}) error {
+func apiPost(s TestServer, path, body string, v interface{}) error {
 	apiPath := apiEndpoint + path
 	client, err := s.Ctx.GetHTTPClient()
 	if err != nil {

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestParseInitNodeAttributes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ctx := NewContext()
+	ctx := MakeContext()
 	ctx.Attrs = "attr1=val1::attr2=val2"
 	ctx.Stores = StoreSpecList{Specs: []StoreSpec{{InMemory: true, SizeInBytes: minimumStoreSize * 100}}}
 	stopper := stop.NewStopper()
@@ -51,7 +51,7 @@ func TestParseInitNodeAttributes(t *testing.T) {
 // correctly.
 func TestParseJoinUsingAddrs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ctx := NewContext()
+	ctx := MakeContext()
 	ctx.JoinUsing = "localhost:12345,,localhost:23456"
 	ctx.Stores = StoreSpecList{Specs: []StoreSpec{{InMemory: true, SizeInBytes: minimumStoreSize * 100}}}
 	stopper := stop.NewStopper()
@@ -62,11 +62,11 @@ func TestParseJoinUsingAddrs(t *testing.T) {
 	if err := ctx.InitNode(); err != nil {
 		t.Fatalf("Failed to initialize node: %s", err)
 	}
-	r1, err := resolver.NewResolver(&ctx.Context, "localhost:12345")
+	r1, err := resolver.NewResolver(ctx.Context, "localhost:12345")
 	if err != nil {
 		t.Fatal(err)
 	}
-	r2, err := resolver.NewResolver(&ctx.Context, "localhost:23456")
+	r2, err := resolver.NewResolver(ctx.Context, "localhost:23456")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,8 +114,8 @@ func TestReadEnvironmentVariables(t *testing.T) {
 	defer resetEnvVar()
 
 	// Makes sure no values are set when no environment variables are set.
-	ctx := NewContext()
-	ctxExpected := NewContext()
+	ctx := MakeContext()
+	ctxExpected := MakeContext()
 
 	resetEnvVar()
 	ctx.readEnvironmentVariables()
@@ -170,8 +170,8 @@ func TestReadEnvironmentVariables(t *testing.T) {
 
 	// Set all the environment variables to invalid values and test that the
 	// defaults are still set.
-	ctx = NewContext()
-	ctxExpected = NewContext()
+	ctx = MakeContext()
+	ctxExpected = MakeContext()
 
 	if err := os.Setenv("COCKROACH_LINEARIZABLE", "abcd"); err != nil {
 		t.Fatal(err)

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -111,10 +111,10 @@ func TestIntentResolution(t *testing.T) {
 					return nil
 				}
 
-			ctx := NewTestContext()
+			ctx := MakeTestContext()
 			ctx.TestingKnobs.Store = &storeKnobs
 
-			s := StartTestServerWithContext(t, ctx)
+			s := StartTestServerWithContext(t, &ctx)
 			defer s.Stop()
 			// Split the Range. This should not have any asynchronous intents.
 			if err := s.db.AdminSplit(splitKey); err != nil {

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -69,7 +69,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	if err != nil {
 		t.Fatal(err)
 	}
-	serverCtx := NewTestContext()
+	serverCtx := MakeTestContext()
 	g := gossip.New(nodeRPCContext, serverCtx.GossipBootstrapResolvers, stopper)
 	if gossipBS != nil {
 		// Handle possibility of a :0 port specification.
@@ -317,7 +317,7 @@ func TestCorruptedClusterID(t *testing.T) {
 // the bytes and counts for Live, Key and Val are at least the expected value.
 // And that UpdatedAt has increased.
 // The latest actual stats are returned.
-func compareNodeStatus(t *testing.T, ts *TestServer, expectedNodeStatus *status.NodeStatus, testNumber int) *status.NodeStatus {
+func compareNodeStatus(t *testing.T, ts TestServer, expectedNodeStatus *status.NodeStatus, testNumber int) *status.NodeStatus {
 	// ========================================
 	// Read NodeStatus from server and validate top-level fields.
 	// ========================================
@@ -437,9 +437,11 @@ func TestStatusSummaries(t *testing.T) {
 	// ========================================
 	// Start test server and wait for full initialization.
 	// ========================================
-	ts := &TestServer{}
-	ts.Ctx = NewTestContext()
-	ts.StoresPerNode = 3
+	ctx := MakeTestContext()
+	ts := TestServer{
+		Ctx:           &ctx,
+		StoresPerNode: 3,
+	}
 	if err := ts.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -71,7 +71,7 @@ var (
 // Server is the cockroach server node.
 type Server struct {
 	Tracer              opentracing.Tracer
-	ctx                 *Context
+	ctx                 Context
 	mux                 *http.ServeMux
 	clock               *hlc.Clock
 	rpcContext          *rpc.Context
@@ -100,11 +100,7 @@ type Server struct {
 }
 
 // NewServer creates a Server from a server.Context.
-func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
-	if ctx == nil {
-		return nil, util.Errorf("ctx must not be null")
-	}
-
+func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 	if _, err := net.ResolveTCPAddr("tcp", ctx.Addr); err != nil {
 		return nil, util.Errorf("unable to resolve RPC address %q: %v", ctx.Addr, err)
 	}
@@ -129,7 +125,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	}
 	s.clock.SetMaxOffset(ctx.MaxOffset)
 
-	s.rpcContext = rpc.NewContext(&ctx.Context, s.clock, stopper)
+	s.rpcContext = rpc.NewContext(ctx.Context, s.clock, stopper)
 	s.rpcContext.HeartbeatCB = func() {
 		if err := s.rpcContext.RemoteClocks.VerifyClockOffset(); err != nil {
 			log.Fatal(err)
@@ -166,7 +162,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	s.grpc = rpc.NewServer(s.rpcContext)
 	s.raftTransport = storage.NewRaftTransport(storage.GossipAddressResolver(s.gossip), s.grpc, s.rpcContext)
 
-	s.kvDB = kv.NewDBServer(&s.ctx.Context, sender, stopper)
+	s.kvDB = kv.NewDBServer(s.ctx.Context, sender, stopper)
 	roachpb.RegisterExternalServer(s.grpc, s.kvDB)
 
 	// Set up Lease Manager
@@ -193,7 +189,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	sqlRegistry := metric.NewRegistry()
 	s.sqlExecutor = sql.NewExecutor(eCtx, s.stopper, sqlRegistry)
 
-	s.pgServer = pgwire.MakeServer(&s.ctx.Context, s.sqlExecutor, sqlRegistry)
+	s.pgServer = pgwire.MakeServer(s.ctx.Context, s.sqlExecutor, sqlRegistry)
 
 	distSQLCtx := distsql.ServerContext{
 		DB: s.db,
@@ -241,7 +237,7 @@ func NewServer(ctx *Context, stopper *stop.Stopper) (*Server, error) {
 	s.tsServer = ts.NewServer(s.tsDB)
 
 	s.admin = newAdminServer(s)
-	s.status = newStatusServer(s.db, s.gossip, s.recorder, s.ctx, s.rpcContext, s.node.stores)
+	s.status = newStatusServer(s.db, s.gossip, s.recorder, s.ctx.Context, s.rpcContext, s.node.stores)
 	for _, gw := range []grpcGatewayServer{s.admin, s.status} {
 		gw.RegisterService(s.grpc)
 	}
@@ -307,7 +303,7 @@ func (s *Server) Start() error {
 		return err
 	}
 	s.ctx.Addr = unresolvedAddr.String()
-	s.rpcContext.SetLocalInternalServer(s.node, s.ctx.Addr)
+	s.rpcContext.SetLocalInternalServer(s.node)
 
 	s.stopper.RunWorker(func() {
 		<-s.stopper.ShouldDrain()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -80,11 +80,11 @@ func TestHealth(t *testing.T) {
 func TestPlainHTTPServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Create a custom context. The default one uses embedded certs.
-	ctx := NewContext()
+	ctx := MakeContext()
 	ctx.Addr = "127.0.0.1:0"
 	ctx.HTTPAddr = "127.0.0.1:0"
 	ctx.Insecure = true
-	s := TestServer{Ctx: ctx}
+	s := TestServer{Ctx: &ctx}
 	if err := s.Start(); err != nil {
 		t.Fatalf("could not start plain http server: %v", err)
 	}

--- a/server/status.go
+++ b/server/status.go
@@ -114,9 +114,8 @@ type statusServer struct {
 	gossip       *gossip.Gossip
 	metricSource json.Marshaler
 	router       *httprouter.Router
-	ctx          *Context
 	rpcCtx       *rpc.Context
-	proxyClient  *http.Client
+	proxyClient  http.Client
 	stores       *storage.Stores
 }
 
@@ -125,19 +124,15 @@ func newStatusServer(
 	db *client.DB,
 	gossip *gossip.Gossip,
 	metricSource json.Marshaler,
-	ctx *Context,
+	ctx *base.Context,
 	rpcCtx *rpc.Context,
 	stores *storage.Stores,
 ) *statusServer {
 	// Create an http client with a timeout
-	tlsConfig, err := ctx.GetClientTLSConfig()
+	httpClient, err := ctx.GetHTTPClient()
 	if err != nil {
 		log.Error(err)
 		return nil
-	}
-	httpClient := &http.Client{
-		Transport: &http.Transport{TLSClientConfig: tlsConfig},
-		Timeout:   base.NetworkTimeout,
 	}
 
 	server := &statusServer{
@@ -145,7 +140,6 @@ func newStatusServer(
 		gossip:       gossip,
 		metricSource: metricSource,
 		router:       httprouter.New(),
-		ctx:          ctx,
 		rpcCtx:       rpcCtx,
 		proxyClient:  httpClient,
 		stores:       stores,

--- a/server/updates_test.go
+++ b/server/updates_test.go
@@ -91,9 +91,11 @@ func TestReportUsage(t *testing.T) {
 		}
 	}))
 
-	var s TestServer
-	s.Ctx = NewTestContext()
-	s.StoresPerNode = 2
+	ctx := MakeTestContext()
+	s := TestServer{
+		Ctx:           &ctx,
+		StoresPerNode: 2,
+	}
 	if err := s.Start(); err != nil {
 		t.Fatalf("failed to start test server: %s", err)
 	}

--- a/sql/descriptor_mutation_test.go
+++ b/sql/descriptor_mutation_test.go
@@ -195,7 +195,7 @@ func TestOperationsWithColumnMutation(t *testing.T) {
 	ctx.TestingKnobs.SQLSchemaChangeManager = &csql.SchemaChangeManagerTestingKnobs{
 		AsyncSchemaChangerExecNotification: schemaChangeManagerDisabled,
 	}
-	server, sqlDB, kvDB := setupWithContext(t, ctx)
+	server, sqlDB, kvDB := setupWithContext(t, &ctx)
 	defer cleanup(server, sqlDB)
 
 	if _, err := sqlDB.Exec(`
@@ -386,7 +386,7 @@ func TestOperationsWithIndexMutation(t *testing.T) {
 	ctx.TestingKnobs.SQLSchemaChangeManager = &csql.SchemaChangeManagerTestingKnobs{
 		AsyncSchemaChangerExecNotification: schemaChangeManagerDisabled,
 	}
-	server, sqlDB, kvDB := setupWithContext(t, ctx)
+	server, sqlDB, kvDB := setupWithContext(t, &ctx)
 	defer cleanup(server, sqlDB)
 
 	if _, err := sqlDB.Exec(`
@@ -522,7 +522,7 @@ func TestOperationsWithUniqueColumnMutation(t *testing.T) {
 	ctx.TestingKnobs.SQLSchemaChangeManager = &csql.SchemaChangeManagerTestingKnobs{
 		AsyncSchemaChangerExecNotification: schemaChangeManagerDisabled,
 	}
-	server, sqlDB, kvDB := setupWithContext(t, ctx)
+	server, sqlDB, kvDB := setupWithContext(t, &ctx)
 	defer cleanup(server, sqlDB)
 
 	// Create a table with column i and an index on v and i.
@@ -661,7 +661,7 @@ func TestCommandsWithPendingMutations(t *testing.T) {
 	ctx.TestingKnobs.SQLSchemaChangeManager = &csql.SchemaChangeManagerTestingKnobs{
 		AsyncSchemaChangerExecNotification: schemaChangeManagerDisabled,
 	}
-	server, sqlDB, kvDB := setupWithContext(t, ctx)
+	server, sqlDB, kvDB := setupWithContext(t, &ctx)
 	defer cleanup(server, sqlDB)
 
 	if _, err := sqlDB.Exec(`

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -150,7 +150,8 @@ func (t *leaseTest) node(nodeID uint32) *csql.LeaseManager {
 
 func TestLeaseManager(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
-	t := newLeaseTest(testingT, server.NewTestContext())
+	ctx := server.MakeTestContext()
+	t := newLeaseTest(testingT, &ctx)
 	defer t.cleanup()
 
 	const descID = keys.LeaseTableID
@@ -243,7 +244,8 @@ func TestLeaseManager(testingT *testing.T) {
 
 func TestLeaseManagerReacquire(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
-	t := newLeaseTest(testingT, server.NewTestContext())
+	ctx := server.MakeTestContext()
+	t := newLeaseTest(testingT, &ctx)
 	defer t.cleanup()
 
 	const descID = keys.LeaseTableID
@@ -290,7 +292,8 @@ func TestLeaseManagerReacquire(testingT *testing.T) {
 
 func TestLeaseManagerPublishVersionChanged(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
-	t := newLeaseTest(testingT, server.NewTestContext())
+	ctx := server.MakeTestContext()
+	t := newLeaseTest(testingT, &ctx)
 	defer t.cleanup()
 
 	const descID = keys.LeaseTableID
@@ -373,7 +376,7 @@ func TestCantLeaseDeletedTable(testingT *testing.T) {
 		},
 	}
 
-	t := newLeaseTest(testingT, ctx)
+	t := newLeaseTest(testingT, &ctx)
 	defer t.cleanup()
 
 	sql := `
@@ -470,7 +473,7 @@ func TestLeasesOnDeletedTableAreReleasedImmediately(t *testing.T) {
 			AsyncSchemaChangerExecNotification: schemaChangeManagerDisabled,
 		},
 	}
-	s, db, kvDB := setupWithContext(t, ctx)
+	s, db, kvDB := setupWithContext(t, &ctx)
 	defer cleanup(s, db)
 
 	sql := `

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -249,13 +249,13 @@ func (t *logicTest) run(path string) {
 func (t *logicTest) setup() {
 	// TODO(pmattis): Add a flag to make it easy to run the tests against a local
 	// MySQL or Postgres instance.
-	ctx := server.NewTestContext()
+	ctx := server.MakeTestContext()
 	ctx.MaxOffset = logicMaxOffset
 	ctx.TestingKnobs.SQLExecutor = &sql.ExecutorTestingKnobs{
 		WaitForGossipUpdate:   true,
 		CheckStmtStringChange: true,
 	}
-	t.srv = setupTestServerWithContext(t.T, ctx)
+	t.srv = setupTestServerWithContext(t.T, &ctx)
 
 	// db may change over the lifetime of this function, with intermediate
 	// values cached in t.clients and finally closed in t.close().

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -61,15 +61,13 @@ type CommandFilters struct {
 // runFilters executes the registered filters, stopping at the first one
 // that returns an error.
 func (c *CommandFilters) runFilters(args storagebase.FilterArgs) *roachpb.Error {
-
 	c.RLock()
 	defer c.RUnlock()
 
 	if c.replayProtection != nil {
 		return c.replayProtection(args)
-	} else {
-		return c.runFiltersInternal(args)
 	}
+	return c.runFiltersInternal(args)
 }
 
 func (c *CommandFilters) runFiltersInternal(args storagebase.FilterArgs) *roachpb.Error {
@@ -184,8 +182,8 @@ type testServer struct {
 	cleanupFns []func()
 }
 
-func createTestServerContext() (*server.Context, *CommandFilters) {
-	ctx := server.NewTestContext()
+func createTestServerContext() (server.Context, *CommandFilters) {
+	ctx := server.MakeTestContext()
 	var cmdFilters CommandFilters
 	cmdFilters.AppendFilter(checkEndTransactionTrigger, true)
 	ctx.TestingKnobs.Store = &storage.StoreTestingKnobs{
@@ -204,7 +202,8 @@ func setupTestServerWithContext(t *testing.T, ctx *server.Context) *testServer {
 }
 
 func setup(t *testing.T) (*testServer, *gosql.DB, *client.DB) {
-	return setupWithContext(t, server.NewTestContext())
+	ctx := server.MakeTestContext()
+	return setupWithContext(t, &ctx)
 }
 
 func setupWithContext(t *testing.T, ctx *server.Context) (*testServer, *gosql.DB, *client.DB) {

--- a/sql/metric_test.go
+++ b/sql/metric_test.go
@@ -93,7 +93,7 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx, cmdFilters := createTestServerContext()
-	s, sqlDB, _ := setupWithContext(t, ctx)
+	s, sqlDB, _ := setupWithContext(t, &ctx)
 	defer cleanup(s, sqlDB)
 
 	if _, err := sqlDB.Exec("CREATE DATABASE db"); err != nil {

--- a/sql/multinode_test.go
+++ b/sql/multinode_test.go
@@ -42,7 +42,7 @@ func SetupMultinodeTestCluster(t testing.TB, nodes int, name string) ([]*gosql.D
 	if nodes < 1 {
 		t.Fatal("invalid cluster size: ", nodes)
 	}
-	var servers []*server.TestServer
+	var servers []server.TestServer
 	first := server.StartTestServer(t)
 	servers = append(servers, first)
 	for i := 1; i < nodes; i++ {

--- a/sql/parallel_test.go
+++ b/sql/parallel_test.go
@@ -154,13 +154,13 @@ func (t *parallelTest) run(dir string) {
 }
 
 func (t *parallelTest) setup() {
-	ctx := server.NewTestContext()
+	ctx := server.MakeTestContext()
 	ctx.MaxOffset = logicMaxOffset
 	ctx.TestingKnobs.SQLExecutor = &sql.ExecutorTestingKnobs{
 		WaitForGossipUpdate:   true,
 		CheckStmtStringChange: true,
 	}
-	t.srv = setupTestServerWithContext(t.T, ctx)
+	t.srv = setupTestServerWithContext(t.T, &ctx)
 }
 
 func TestParallel(t *testing.T) {

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -136,7 +136,7 @@ func TestSchemaChangeProcess(t *testing.T) {
 	ctx.TestingKnobs.SQLSchemaChangeManager = &csql.SchemaChangeManagerTestingKnobs{
 		AsyncSchemaChangerExecNotification: schemaChangeManagerDisabled,
 	}
-	server, sqlDB, kvDB := setupWithContext(t, ctx)
+	server, sqlDB, kvDB := setupWithContext(t, &ctx)
 	defer cleanup(server, sqlDB)
 	var id = sqlbase.ID(keys.MaxReservedDescID + 2)
 	var node = roachpb.NodeID(2)
@@ -319,7 +319,7 @@ func TestAsyncSchemaChanger(t *testing.T) {
 		},
 	}
 
-	server, sqlDB, kvDB := setupWithContext(t, ctx)
+	server, sqlDB, kvDB := setupWithContext(t, &ctx)
 	defer cleanup(server, sqlDB)
 
 	if _, err := sqlDB.Exec(`
@@ -566,7 +566,7 @@ func TestRaceWithBackfill(t *testing.T) {
 			AsyncSchemaChangerExecNotification: schemaChangeManagerDisabled,
 		},
 	}
-	server, sqlDB, kvDB := setupWithContext(t, ctx)
+	server, sqlDB, kvDB := setupWithContext(t, &ctx)
 	defer cleanup(server, sqlDB)
 
 	if _, err := sqlDB.Exec(`
@@ -757,7 +757,7 @@ func TestSchemaChangeRetry(t *testing.T) {
 			AsyncSchemaChangerExecNotification: schemaChangeManagerDisabled,
 		},
 	}
-	server, sqlDB, _ := setupWithContext(t, ctx)
+	server, sqlDB, _ := setupWithContext(t, &ctx)
 	defer cleanup(server, sqlDB)
 
 	if _, err := sqlDB.Exec(`
@@ -845,7 +845,7 @@ func TestSchemaChangePurgeFailure(t *testing.T) {
 			AsyncSchemaChangerExecQuickly: true,
 		},
 	}
-	server, sqlDB, kvDB := setupWithContext(t, ctx)
+	server, sqlDB, kvDB := setupWithContext(t, &ctx)
 	defer cleanup(server, sqlDB)
 
 	if _, err := sqlDB.Exec(`

--- a/sql/show_test.go
+++ b/sql/show_test.go
@@ -27,7 +27,7 @@ func TestShowCreateTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx, _ := createTestServerContext()
-	server, sqlDB, _ := setupWithContext(t, ctx)
+	server, sqlDB, _ := setupWithContext(t, &ctx)
 	defer cleanup(server, sqlDB)
 
 	if _, err := sqlDB.Exec(`

--- a/sql/split_test.go
+++ b/sql/split_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 // getFastScanContext returns a test context with fast scan.
-func getFastScanContext() *server.Context {
-	c := server.NewTestContext()
+func getFastScanContext() server.Context {
+	c := server.MakeTestContext()
 	c.ScanInterval = time.Millisecond
 	c.ScanMaxIdleTime = time.Millisecond
 	return c
@@ -74,7 +74,8 @@ func rangesMatchSplits(ranges []roachpb.Key, splits []roachpb.RKey) bool {
 // as new tables get created.
 func TestSplitOnTableBoundaries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s, sqlDB, kvDB := setupWithContext(t, getFastScanContext())
+	ctx := getFastScanContext()
+	s, sqlDB, kvDB := setupWithContext(t, &ctx)
 	defer cleanup(s, sqlDB)
 
 	expectedInitialRanges := server.ExpectedInitialRangeCount()


### PR DESCRIPTION
This also changes cli.Context and server.Context to embed base.Context
by reference so that a single base.Context can be shared in the cli
package.

Almost all uses of cli.Context and server.Context have been converted
from pointers to values now that these structures are safe to copy.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6909)

<!-- Reviewable:end -->
