### PR TITLE
Makefile: add check dependency on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,10 @@ dupl:
 	       -not -name 'sql.go'      \
 	| dupl -files $(DUPLFLAGS)
 
+# check depends on build because go vet sometimes reports incorrect errors if
+# the build artifacts are stale.
 .PHONY: check
-check:
+check: build
 	@build/check-style.sh
 
 .PHONY: clean


### PR DESCRIPTION
make check (specifically go tool vet) sometimes reports bogus errors if the
build artifacts are stale. Forcing a build with `make check` to avoid that.
@tschottdorf @bdarnell

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6912)

<!-- Reviewable:end -->
