### PR TITLE
util/tracing: use lightstep if COCKROACH_LIGHTSTEP_TOKEN is set

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -54,6 +54,7 @@ github.com/kkaneda/returncheck bf081fa7155e3a27df1f056a49d50685edfa5b1b
 github.com/kr/pretty add1dbc86daf0f983cd4a48ceb39deb95c729b67
 github.com/kr/text 7cafcd837844e784b526369c9bce262804aebc60
 github.com/lib/pq ee1442bda7bd1b6a84e913bdb421cb1874ec629d
+github.com/lightstep/lightstep-tracer-go cab3c65c9d6ca0bda20c2ced3942aded1b6f9b17
 github.com/mattn/go-isatty 56b76bdf51f7708750eac80fa38b952bb9f32639
 github.com/mattn/go-runewidth d6bea18f789704b5f83375793155289da36a3c7f
 github.com/mibk/dupl 415e882ea21ca7012cc49906cb338f34d2d4b4d6

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -354,7 +354,12 @@ func init() {
 	// top-level cockroach command.
 	pf := cockroachCmd.PersistentFlags()
 	flag.VisitAll(func(f *flag.Flag) {
-		pf.AddFlag(pflag.PFlagFromGoFlag(f))
+		flag := pflag.PFlagFromGoFlag(f)
+		// TODO(peter): Decide if we want to make the lightstep flags visible.
+		if strings.HasPrefix(flag.Name, "lightstep_") {
+			flag.Hidden = true
+		}
+		pf.AddFlag(flag)
 	})
 
 	// The --log-dir default changes depending on the command. Avoid confusion by

--- a/util/tracing/tracer.go
+++ b/util/tracing/tracer.go
@@ -23,6 +23,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/util/caller"
+	"github.com/cockroachdb/cockroach/util/envutil"
+	"github.com/lightstep/lightstep-tracer-go"
 	basictracer "github.com/opentracing/basictracer-go"
 	"github.com/opentracing/basictracer-go/events"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -82,8 +84,15 @@ func defaultOptions(recorder func(basictracer.RawSpan)) basictracer.Options {
 	return opts
 }
 
+var lightstepToken = envutil.EnvOrDefaultString("lightstep_token", "")
+
 // newTracer implements NewTracer and allows that function to be mocked out via Disable().
 var newTracer = func() opentracing.Tracer {
+	if lightstepToken != "" {
+		return lightstep.NewTracer(lightstep.Options{
+			AccessToken: lightstepToken,
+		})
+	}
 	return basictracer.NewWithOptions(defaultOptions(func(_ basictracer.RawSpan) {}))
 }
 


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6922)

<!-- Reviewable:end -->
