### PR TITLE
sql: Next() bool ->  Next() (bool, error)

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -242,13 +242,12 @@ func (n *alterTableNode) Start() error {
 	return nil
 }
 
-func (n *alterTableNode) Next() bool                          { return false }
+func (n *alterTableNode) Next() (bool, error)                 { return false, nil }
 func (n *alterTableNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
 func (n *alterTableNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *alterTableNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *alterTableNode) DebugValues() debugValues            { return debugValues{} }
 func (n *alterTableNode) ExplainTypes(_ func(string, string)) {}
-func (n *alterTableNode) Err() error                          { return nil }
 func (n *alterTableNode) SetLimitHint(_ int64, _ bool)        {}
 func (n *alterTableNode) MarkDebug(mode explainMode)          {}
 func (n *alterTableNode) ExplainPlan(v bool) (string, string, []planNode) {

--- a/sql/create.go
+++ b/sql/create.go
@@ -91,13 +91,12 @@ func (n *createDatabaseNode) Start() error {
 	return nil
 }
 
-func (n *createDatabaseNode) Next() bool                          { return false }
+func (n *createDatabaseNode) Next() (bool, error)                 { return false, nil }
 func (n *createDatabaseNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
 func (n *createDatabaseNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *createDatabaseNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *createDatabaseNode) DebugValues() debugValues            { return debugValues{} }
 func (n *createDatabaseNode) ExplainTypes(_ func(string, string)) {}
-func (n *createDatabaseNode) Err() error                          { return nil }
 func (n *createDatabaseNode) SetLimitHint(_ int64, _ bool)        {}
 func (n *createDatabaseNode) MarkDebug(mode explainMode)          {}
 func (n *createDatabaseNode) ExplainPlan(v bool) (string, string, []planNode) {
@@ -179,13 +178,12 @@ func (n *createIndexNode) Start() error {
 	return nil
 }
 
-func (n *createIndexNode) Next() bool                          { return false }
+func (n *createIndexNode) Next() (bool, error)                 { return false, nil }
 func (n *createIndexNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
 func (n *createIndexNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *createIndexNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *createIndexNode) DebugValues() debugValues            { return debugValues{} }
 func (n *createIndexNode) ExplainTypes(_ func(string, string)) {}
-func (n *createIndexNode) Err() error                          { return nil }
 func (n *createIndexNode) SetLimitHint(_ int64, _ bool)        {}
 func (n *createIndexNode) MarkDebug(mode explainMode)          {}
 func (n *createIndexNode) ExplainPlan(v bool) (string, string, []planNode) {
@@ -313,12 +311,11 @@ func (n *createTableNode) Start() error {
 	return nil
 }
 
-func (n *createTableNode) Next() bool                          { return false }
+func (n *createTableNode) Next() (bool, error)                 { return false, nil }
 func (n *createTableNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
 func (n *createTableNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *createTableNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *createTableNode) DebugValues() debugValues            { return debugValues{} }
-func (n *createTableNode) Err() error                          { return nil }
 func (n *createTableNode) ExplainTypes(_ func(string, string)) {}
 func (n *createTableNode) SetLimitHint(_ int64, _ bool)        {}
 func (n *createTableNode) MarkDebug(mode explainMode)          {}

--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -130,22 +130,27 @@ func (n *distinctNode) DebugValues() debugValues {
 	return n.debugVals
 }
 
-func (n *distinctNode) Next() bool {
+func (n *distinctNode) Next() (bool, error) {
 	if n.err != nil {
-		return false
+		return false, n.err
 	}
-	for n.plan.Next() {
+	for {
+		next, err := n.plan.Next()
+		if !next {
+			n.err = err
+			return false, n.err
+		}
 		if n.explain == explainDebug {
 			n.debugVals = n.plan.DebugValues()
 			if n.debugVals.output != debugValueRow {
 				// Let the non-row debug values pass through.
-				return true
+				return true, nil
 			}
 		}
 		// Detect duplicates
 		prefix, suffix := n.encodeValues(n.Values())
 		if n.err != nil {
-			return false
+			return false, n.err
 		}
 
 		if !bytes.Equal(prefix, n.prefixSeen) {
@@ -158,7 +163,7 @@ func (n *distinctNode) Next() bool {
 			if suffix != nil {
 				n.suffixSeen[string(suffix)] = struct{}{}
 			}
-			return true
+			return true, nil
 		}
 
 		// The prefix of the row is the same as the last row; check
@@ -167,7 +172,7 @@ func (n *distinctNode) Next() bool {
 			sKey := string(suffix)
 			if _, ok := n.suffixSeen[sKey]; !ok {
 				n.suffixSeen[sKey] = struct{}{}
-				return true
+				return true, nil
 			}
 		}
 
@@ -175,15 +180,9 @@ func (n *distinctNode) Next() bool {
 		if n.explain == explainDebug {
 			// Return as a filtered row.
 			n.debugVals.output = debugValueFiltered
-			return true
+			return true, nil
 		}
 	}
-	n.err = n.plan.Err()
-	return false
-}
-
-func (n *distinctNode) Err() error {
-	return n.err
 }
 
 func (n *distinctNode) encodeValues(values parser.DTuple) ([]byte, []byte) {

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -144,13 +144,12 @@ func (n *dropDatabaseNode) Start() error {
 	return nil
 }
 
-func (n *dropDatabaseNode) Next() bool                          { return false }
+func (n *dropDatabaseNode) Next() (bool, error)                 { return false, nil }
 func (n *dropDatabaseNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
 func (n *dropDatabaseNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *dropDatabaseNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *dropDatabaseNode) DebugValues() debugValues            { return debugValues{} }
 func (n *dropDatabaseNode) ExplainTypes(_ func(string, string)) {}
-func (n *dropDatabaseNode) Err() error                          { return nil }
 func (n *dropDatabaseNode) SetLimitHint(_ int64, _ bool)        {}
 func (n *dropDatabaseNode) MarkDebug(mode explainMode)          {}
 func (n *dropDatabaseNode) ExplainPlan(v bool) (string, string, []planNode) {
@@ -257,13 +256,12 @@ func (n *dropIndexNode) Start() error {
 	return nil
 }
 
-func (n *dropIndexNode) Next() bool                          { return false }
+func (n *dropIndexNode) Next() (bool, error)                 { return false, nil }
 func (n *dropIndexNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
 func (n *dropIndexNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *dropIndexNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *dropIndexNode) DebugValues() debugValues            { return debugValues{} }
 func (n *dropIndexNode) ExplainTypes(_ func(string, string)) {}
-func (n *dropIndexNode) Err() error                          { return nil }
 func (n *dropIndexNode) SetLimitHint(_ int64, _ bool)        {}
 func (n *dropIndexNode) MarkDebug(mode explainMode)          {}
 func (n *dropIndexNode) ExplainPlan(v bool) (string, string, []planNode) {
@@ -355,13 +353,12 @@ func (n *dropTableNode) Start() error {
 	return nil
 }
 
-func (n *dropTableNode) Next() bool                          { return false }
+func (n *dropTableNode) Next() (bool, error)                 { return false, nil }
 func (n *dropTableNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
 func (n *dropTableNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *dropTableNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *dropTableNode) ExplainTypes(_ func(string, string)) {}
 func (n *dropTableNode) DebugValues() debugValues            { return debugValues{} }
-func (n *dropTableNode) Err() error                          { return nil }
 func (n *dropTableNode) SetLimitHint(_ int64, _ bool)        {}
 func (n *dropTableNode) MarkDebug(mode explainMode)          {}
 func (n *dropTableNode) ExplainPlan(v bool) (string, string, []planNode) {

--- a/sql/empty.go
+++ b/sql/empty.go
@@ -30,7 +30,6 @@ type emptyNode struct {
 func (*emptyNode) Columns() []ResultColumn             { return nil }
 func (*emptyNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (*emptyNode) Values() parser.DTuple               { return nil }
-func (*emptyNode) Err() error                          { return nil }
 func (*emptyNode) ExplainTypes(_ func(string, string)) {}
 func (*emptyNode) Start() error                        { return nil }
 func (*emptyNode) SetLimitHint(_ int64, _ bool)        {}
@@ -50,8 +49,8 @@ func (e *emptyNode) DebugValues() debugValues {
 	}
 }
 
-func (e *emptyNode) Next() bool {
+func (e *emptyNode) Next() (bool, error) {
 	r := e.results
 	e.results = false
-	return r
+	return r, nil
 }

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -129,12 +129,11 @@ type explainTypesNode struct {
 }
 
 func (e *explainTypesNode) ExplainTypes(fn func(string, string)) {}
-func (e *explainTypesNode) Next() bool                           { return e.results.Next() }
+func (e *explainTypesNode) Next() (bool, error)                  { return e.results.Next() }
 func (e *explainTypesNode) Columns() []ResultColumn              { return e.results.Columns() }
 func (e *explainTypesNode) Ordering() orderingInfo               { return e.results.Ordering() }
 func (e *explainTypesNode) Values() parser.DTuple                { return e.results.Values() }
 func (e *explainTypesNode) DebugValues() debugValues             { return e.results.DebugValues() }
-func (e *explainTypesNode) Err() error                           { return e.results.Err() }
 func (e *explainTypesNode) SetLimitHint(n int64, s bool)         { e.results.SetLimitHint(n, s) }
 func (e *explainTypesNode) MarkDebug(mode explainMode)           { e.results.MarkDebug(mode) }
 func (e *explainTypesNode) ExplainPlan(v bool) (string, string, []planNode) {
@@ -208,12 +207,11 @@ type explainPlanNode struct {
 }
 
 func (e *explainPlanNode) ExplainTypes(fn func(string, string)) {}
-func (e *explainPlanNode) Next() bool                           { return e.results.Next() }
+func (e *explainPlanNode) Next() (bool, error)                  { return e.results.Next() }
 func (e *explainPlanNode) Columns() []ResultColumn              { return e.results.Columns() }
 func (e *explainPlanNode) Ordering() orderingInfo               { return e.results.Ordering() }
 func (e *explainPlanNode) Values() parser.DTuple                { return e.results.Values() }
 func (e *explainPlanNode) DebugValues() debugValues             { return e.results.DebugValues() }
-func (e *explainPlanNode) Err() error                           { return e.results.Err() }
 func (e *explainPlanNode) SetLimitHint(n int64, s bool)         { e.results.SetLimitHint(n, s) }
 func (e *explainPlanNode) MarkDebug(mode explainMode)           { e.results.MarkDebug(mode) }
 func (e *explainPlanNode) expandPlan() error {
@@ -351,7 +349,6 @@ var debugColumns = []ResultColumn{
 func (*explainDebugNode) Columns() []ResultColumn { return debugColumns }
 func (*explainDebugNode) Ordering() orderingInfo  { return orderingInfo{} }
 
-func (n *explainDebugNode) Err() error { return n.plan.Err() }
 func (n *explainDebugNode) expandPlan() error {
 	if err := n.plan.expandPlan(); err != nil {
 		return err
@@ -362,7 +359,7 @@ func (n *explainDebugNode) expandPlan() error {
 
 func (n *explainDebugNode) Start() error { return n.plan.Start() }
 
-func (n *explainDebugNode) Next() bool { return n.plan.Next() }
+func (n *explainDebugNode) Next() (bool, error) { return n.plan.Next() }
 
 func (n *explainDebugNode) ExplainPlan(v bool) (name, description string, children []planNode) {
 	return n.plan.ExplainPlan(v)

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -152,8 +152,9 @@ type planNode interface {
 	// of results each time that Next() returns true.
 	// See executor.go: countRowsAffected() and execStmt() for an example.
 	//
-	// Available after Start().
-	Next() bool
+	// Available after Start(). It is illegal to call Next() after it returns
+	// false.
+	Next() (bool, error)
 
 	// Values returns the values at the current row. The result is only valid
 	// until the next call to Next().
@@ -170,11 +171,6 @@ type planNode interface {
 	// Available after Next() and MarkDebug(explainDebug), see
 	// explain.go.
 	DebugValues() debugValues
-
-	// Err returns the error, if any, encountered during iteration.
-	//
-	// Available after Next().
-	Err() error
 }
 
 // planNodeFastPath is implemented by nodes that can perform all their

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -208,18 +208,19 @@ func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, erro
 	if err := plan.Start(); err != nil {
 		return nil, err
 	}
-	if !plan.Next() {
-		if err := plan.Err(); err != nil {
+	if next, err := plan.Next(); !next {
+		if err != nil {
 			return nil, err
 		}
 		return nil, nil
 	}
 	values := plan.Values()
-	if plan.Next() {
-		return nil, util.Errorf("%s: unexpected multiple results", sql)
-	}
-	if err := plan.Err(); err != nil {
+	next, err := plan.Next()
+	if err != nil {
 		return nil, err
+	}
+	if next {
+		return nil, util.Errorf("%s: unexpected multiple results", sql)
 	}
 	return values, nil
 }
@@ -233,7 +234,7 @@ func (p *planner) exec(sql string, args ...interface{}) (int, error) {
 	if err := plan.Start(); err != nil {
 		return 0, err
 	}
-	return countRowsAffected(plan), plan.Err()
+	return countRowsAffected(plan)
 }
 
 // setTestingVerifyMetadata implements the queryRunner interface.

--- a/sql/select_top.go
+++ b/sql/select_top.go
@@ -159,7 +159,6 @@ func (n *selectTopNode) Ordering() orderingInfo {
 
 func (n *selectTopNode) MarkDebug(mode explainMode) { n.plan.MarkDebug(mode) }
 func (n *selectTopNode) Start() error               { return n.plan.Start() }
-func (n *selectTopNode) Next() bool                 { return n.plan.Next() }
+func (n *selectTopNode) Next() (bool, error)        { return n.plan.Next() }
 func (n *selectTopNode) Values() parser.DTuple      { return n.plan.Values() }
 func (n *selectTopNode) DebugValues() debugValues   { return n.plan.DebugValues() }
-func (n *selectTopNode) Err() error                 { return n.plan.Err() }

--- a/sql/values.go
+++ b/sql/values.go
@@ -179,16 +179,12 @@ func (n *valuesNode) DebugValues() debugValues {
 	}
 }
 
-func (n *valuesNode) Next() bool {
+func (n *valuesNode) Next() (bool, error) {
 	if n.nextRow >= len(n.rows) {
-		return false
+		return false, nil
 	}
 	n.nextRow++
-	return true
-}
-
-func (*valuesNode) Err() error {
-	return nil
+	return true, nil
 }
 
 func (n *valuesNode) Len() int {

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -128,8 +128,13 @@ func TestValues(t *testing.T) {
 				continue
 			}
 			var rows []parser.DTuple
-			for plan.Next() {
+			next, err := plan.Next()
+			for ; next; next, err = plan.Next() {
 				rows = append(rows, plan.Values())
+			}
+			if err != nil {
+				t.Error(err)
+				continue
 			}
 			if !reflect.DeepEqual(rows, tc.rows) {
 				t.Errorf("%d: expected rows:\n%+v\nactual rows:\n%+v", i, tc.rows, rows)


### PR DESCRIPTION
This PR also gets ride of plan.Err(). However each of the plan nodes still retains an error value as part of their struct. I'd have liked to have removed it in this PR, but I was concerned that it could break functionality. I'll follow up this PR with a number of PRs that remove the error stored within plan nodes.
#6921

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6923)

<!-- Reviewable:end -->
