### PR TITLE
sql/parser: Clarify the handling of desired types for CastExpr children

### DIFF
--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -209,10 +209,27 @@ func (expr *CaseExpr) TypeCheck(ctx *SemaContext, desired Datum) (TypedExpr, err
 func (expr *CastExpr) TypeCheck(ctx *SemaContext, desired Datum) (TypedExpr, error) {
 	returnDatum, validTypes := expr.castTypeAndValidArgTypes()
 
-	desired = nil
-	if ctx.isUnresolvedArgument(expr.Expr) {
-		desired = TypeString
+	// The desired type provided to a CastExpr is ignored. Instead, NoTypePreference
+	// is passed to the child of the cast. There are two exceptions, described below.
+	desired = NoTypePreference
+	switch t := expr.Expr.(type) {
+	case Constant:
+		if canConstantBecome(t, returnDatum) {
+			// If a Constant is subject to a cast which it can naturally become (which
+			// is in its resolvable type set), we desire the cast's type for the Constant,
+			// which will result in the CastExpr becoming an identity cast.
+			desired = returnDatum
+		}
+	case Placeholder:
+		if ctx.isUnresolvedArgument(t) {
+			// This case will be triggered if ProcessPlaceholderAnnotations found
+			// the same placeholder in another location where it was either not
+			// the child of a cast, or was the child of a cast to a different type.
+			// In this case, we default to inferring a STRING for the placeholder.
+			desired = TypeString
+		}
 	}
+
 	typedSubExpr, err := expr.Expr.TypeCheck(ctx, desired)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change clarifies that no type is desired from `CastExpr` children
during type checking unless:
- The child is a `Constant` with the cast type in its resolvable type set
- The child is an unresolved placeholder

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6928)

<!-- Reviewable:end -->
