### PR TITLE
sql/parser: Change EvalContext to be passed by reference

### DIFF
--- a/sql/analyze_test.go
+++ b/sql/analyze_test.go
@@ -71,7 +71,8 @@ func parseAndNormalizeExpr(t *testing.T, sql string) (parser.TypedExpr, qvalMap)
 	if err != nil {
 		t.Fatalf("%s: %v", sql, err)
 	}
-	if typedExpr, err = (parser.EvalContext{}).NormalizeExpr(typedExpr); err != nil {
+	ctx := &parser.EvalContext{}
+	if typedExpr, err = ctx.NormalizeExpr(typedExpr); err != nil {
 		t.Fatalf("%s: %v", sql, err)
 	}
 	return typedExpr, sel.qvals
@@ -91,11 +92,12 @@ func checkEquivExpr(a, b parser.TypedExpr, qvals qvalMap) error {
 		for _, q := range qvals {
 			q.datum = v
 		}
-		da, err := a.Eval(parser.EvalContext{})
+		ctx := &parser.EvalContext{}
+		da, err := a.Eval(ctx)
 		if err != nil {
 			return fmt.Errorf("%s: %v", a, err)
 		}
-		db, err := b.Eval(parser.EvalContext{})
+		db, err := b.Eval(ctx)
 		if err != nil {
 			return fmt.Errorf("%s: %v", b, err)
 		}

--- a/sql/check.go
+++ b/sql/check.go
@@ -56,7 +56,7 @@ func (c *checkHelper) init(p *planner, tableDesc *sqlbase.TableDescriptor) error
 		if err != nil {
 			return err
 		}
-		if typedExpr, err = p.parser.NormalizeExpr(p.evalCtx, typedExpr); err != nil {
+		if typedExpr, err = p.parser.NormalizeExpr(&p.evalCtx, typedExpr); err != nil {
 			return err
 		}
 		c.exprs[i] = typedExpr
@@ -83,7 +83,7 @@ func (c *checkHelper) loadRow(colIdx map[sqlbase.ColumnID]int, row parser.DTuple
 	}
 }
 
-func (c *checkHelper) check(ctx parser.EvalContext) error {
+func (c *checkHelper) check(ctx *parser.EvalContext) error {
 	for _, expr := range c.exprs {
 		if d, err := expr.Eval(ctx); err != nil {
 			return err

--- a/sql/distsql/expr_test.go
+++ b/sql/distsql/expr_test.go
@@ -30,7 +30,7 @@ func (d testVarContainer) IndexedVarReturnType(idx int) parser.Datum {
 	return parser.TypeInt
 }
 
-func (d testVarContainer) IndexedVarEval(idx int, ctx parser.EvalContext) (parser.Datum, error) {
+func (d testVarContainer) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.Datum, error) {
 	return nil, nil
 }
 

--- a/sql/distsql/flow.go
+++ b/sql/distsql/flow.go
@@ -26,7 +26,7 @@ import (
 
 // Flow represents a flow which consists of processors and streams.
 type Flow struct {
-	evalCtx            parser.EvalContext
+	evalCtx            *parser.EvalContext
 	txn                *client.Txn
 	simpleFlowConsumer rowReceiver
 	waitGroup          sync.WaitGroup

--- a/sql/distsql/server.go
+++ b/sql/distsql/server.go
@@ -68,7 +68,7 @@ func (ds *ServerImpl) setupTxn(
 func (ds *ServerImpl) SetupSimpleFlow(
 	ctx context.Context, req *SetupFlowsRequest, output rowReceiver,
 ) (*Flow, error) {
-	f := &Flow{evalCtx: ds.evalCtx}
+	f := &Flow{evalCtx: &ds.evalCtx}
 	f.txn = ds.setupTxn(ctx, &req.Txn)
 	f.simpleFlowConsumer = output
 

--- a/sql/distsql/server.go
+++ b/sql/distsql/server.go
@@ -19,8 +19,6 @@ package distsql
 import (
 	"golang.org/x/net/context"
 
-	"gopkg.in/inf.v0"
-
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -47,7 +45,6 @@ func NewServer(ctx ServerContext) *ServerImpl {
 		ctx: ctx,
 		evalCtx: parser.EvalContext{
 			ReCache: parser.NewRegexpCache(512),
-			TmpDec:  new(inf.Dec),
 		},
 	}
 	return ds

--- a/sql/distsql/tablereader.go
+++ b/sql/distsql/tablereader.go
@@ -42,7 +42,7 @@ type tableReader struct {
 	// values in the row tuple.
 	filterVars parser.IndexedVarHelper
 
-	evalCtx parser.EvalContext
+	evalCtx *parser.EvalContext
 	txn     *client.Txn
 	fetcher sqlbase.RowFetcher
 	// Last row returned by the rowFetcher; it has one entry per table column.
@@ -62,7 +62,7 @@ func (tr *tableReader) IndexedVarReturnType(idx int) parser.Datum {
 }
 
 // IndexedVarEval is part of the parser.IndexedVarContainer interface.
-func (tr *tableReader) IndexedVarEval(idx int, ctx parser.EvalContext) (parser.Datum, error) {
+func (tr *tableReader) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.Datum, error) {
 	err := tr.row[idx].Decode(&tr.datumAlloc)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func (tr *tableReader) IndexedVarString(idx int) string {
 
 // newTableReader creates a tableReader.
 func newTableReader(
-	spec *TableReaderSpec, txn *client.Txn, output rowReceiver, evalCtx parser.EvalContext,
+	spec *TableReaderSpec, txn *client.Txn, output rowReceiver, evalCtx *parser.EvalContext,
 ) (*tableReader, error) {
 	tr := &tableReader{
 		desc:    spec.Table,

--- a/sql/distsql/tablereader_test.go
+++ b/sql/distsql/tablereader_test.go
@@ -81,7 +81,7 @@ func TestTableReader(t *testing.T) {
 	txn := client.NewTxn(context.Background(), *kvDB)
 
 	out := &testingReceiver{}
-	tr, err := newTableReader(&ts, txn, out, parser.EvalContext{})
+	tr, err := newTableReader(&ts, txn, out, &parser.EvalContext{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestTableReader(t *testing.T) {
 		OutputColumns: []uint32{0, 2},               // a, c
 	}
 	out = &testingReceiver{}
-	tr, err = newTableReader(&ts, txn, out, parser.EvalContext{})
+	tr, err = newTableReader(&ts, txn, out, &parser.EvalContext{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/group.go
+++ b/sql/group.go
@@ -79,7 +79,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 			return nil, err
 		}
 
-		norm, err := p.parser.NormalizeExpr(p.evalCtx, typedExpr)
+		norm, err := p.parser.NormalizeExpr(&p.evalCtx, typedExpr)
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +116,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 			return nil, err
 		}
 
-		typedHaving, err = p.parser.NormalizeExpr(p.evalCtx, typedHaving)
+		typedHaving, err = p.parser.NormalizeExpr(&p.evalCtx, typedHaving)
 		if err != nil {
 			return nil, err
 		}
@@ -375,7 +375,7 @@ func (n *groupNode) computeAggregates() error {
 		n.currentBucket = k
 
 		if n.having != nil {
-			res, err := n.having.Eval(n.planner.evalCtx)
+			res, err := n.having.Eval(&n.planner.evalCtx)
 			if err != nil {
 				return err
 			}
@@ -388,7 +388,7 @@ func (n *groupNode) computeAggregates() error {
 
 		row := make(parser.DTuple, 0, len(n.render))
 		for _, r := range n.render {
-			res, err := r.Eval(n.planner.evalCtx)
+			res, err := r.Eval(&n.planner.evalCtx)
 			if err != nil {
 				return err
 			}
@@ -709,7 +709,7 @@ func (a *aggregateFunc) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (
 	return a, nil
 }
 
-func (a *aggregateFunc) Eval(ctx parser.EvalContext) (parser.Datum, error) {
+func (a *aggregateFunc) Eval(ctx *parser.EvalContext) (parser.Datum, error) {
 	// During init of the group buckets, grouped expressions (i.e. wrapped
 	// qvalues) are Eval()'ed to determine the bucket for a row, so pass these
 	// calls through to the underlying `arg` expr Eval until init is done.

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -114,7 +114,7 @@ func (p *planner) Insert(
 		}
 	}
 
-	defaultExprs, err := makeDefaultExprs(cols, &p.parser, p.evalCtx)
+	defaultExprs, err := makeDefaultExprs(cols, &p.parser, &p.evalCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (n *insertNode) Next() (bool, error) {
 			rowVals = append(rowVals, parser.DNull)
 			continue
 		}
-		d, err := n.defaultExprs[i].Eval(n.p.evalCtx)
+		d, err := n.defaultExprs[i].Eval(&n.p.evalCtx)
 		if err != nil {
 			return false, err
 		}
@@ -305,7 +305,7 @@ func (n *insertNode) Next() (bool, error) {
 	}
 
 	n.checkHelper.loadRow(n.insertColIDtoRowIndex, rowVals, false)
-	if err := n.checkHelper.check(n.p.evalCtx); err != nil {
+	if err := n.checkHelper.check(&n.p.evalCtx); err != nil {
 		return false, err
 	}
 
@@ -406,7 +406,7 @@ func (p *planner) fillDefaults(defaultExprs []parser.TypedExpr,
 }
 
 func makeDefaultExprs(
-	cols []sqlbase.ColumnDescriptor, parse *parser.Parser, evalCtx parser.EvalContext,
+	cols []sqlbase.ColumnDescriptor, parse *parser.Parser, evalCtx *parser.EvalContext,
 ) ([]parser.TypedExpr, error) {
 	// Check to see if any of the columns have DEFAULT expressions. If there
 	// are no DEFAULT expressions, we don't bother with constructing the

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -68,7 +68,7 @@ func (p *planner) Limit(n *parser.Limit) (*limitNode, error) {
 			if err != nil {
 				return nil, err
 			}
-			normalized, err := p.parser.NormalizeExpr(p.evalCtx, typedExpr)
+			normalized, err := p.parser.NormalizeExpr(&p.evalCtx, typedExpr)
 			if err != nil {
 				return nil, err
 			}
@@ -165,12 +165,12 @@ func (n *limitNode) evalLimit() error {
 				return err
 			}
 
-			normalized, err := n.p.parser.NormalizeExpr(n.p.evalCtx, datum.src)
+			normalized, err := n.p.parser.NormalizeExpr(&n.p.evalCtx, datum.src)
 			if err != nil {
 				return err
 			}
 
-			dstDatum, err := normalized.Eval(n.p.evalCtx)
+			dstDatum, err := normalized.Eval(&n.p.evalCtx)
 			if err != nil {
 				return err
 			}

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -64,7 +64,7 @@ type Builtin struct {
 	// return the same value in the same statement, but different values
 	// in separate statements, and should not be marked as impure.
 	impure bool
-	fn     func(EvalContext, DTuple) (Datum, error)
+	fn     func(*EvalContext, DTuple) (Datum, error)
 }
 
 func (b Builtin) params() typeList {
@@ -117,7 +117,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      VariadicType{TypeString},
 			ReturnType: TypeString,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				var buffer bytes.Buffer
 				for _, d := range args {
 					if d == DNull {
@@ -134,7 +134,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      VariadicType{TypeString},
 			ReturnType: TypeString,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				dstr, ok := args[0].(*DString)
 				if !ok {
 					return DNull, fmt.Errorf("unknown signature for concat_ws: concat_ws(%s, ...)", args[0].Type())
@@ -156,7 +156,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeString, TypeInt},
 			ReturnType: TypeString,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				text := string(*args[0].(*DString))
 				sep := string(*args[1].(*DString))
 				field := int(*args[2].(*DInt))
@@ -178,7 +178,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeInt},
 			ReturnType: TypeString,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
 				count := int(*args[1].(*DInt))
 				if count < 0 {
@@ -212,7 +212,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeInt},
 			ReturnType: TypeString,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(fmt.Sprintf("%x", int64(*args[0].(*DInt)))), nil
 			},
 		},
@@ -232,7 +232,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeString, TypeInt},
 			ReturnType: TypeString,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
 				to := string(*args[1].(*DString))
 				pos := int(*args[2].(*DInt))
@@ -243,7 +243,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeString, TypeInt, TypeInt},
 			ReturnType: TypeString,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
 				to := string(*args[1].(*DString))
 				pos := int(*args[2].(*DInt))
@@ -325,7 +325,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeString},
 			ReturnType: TypeString,
-			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
 				pattern := string(*args[1].(*DString))
 				return regexpExtract(ctx, s, pattern, `\`)
@@ -337,7 +337,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeString, TypeString},
 			ReturnType: TypeString,
-			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
 				pattern := string(*args[1].(*DString))
 				to := string(*args[2].(*DString))
@@ -347,7 +347,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeString, TypeString, TypeString},
 			ReturnType: TypeString,
-			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
 				pattern := string(*args[1].(*DString))
 				to := string(*args[2].(*DString))
@@ -365,7 +365,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeBytes, TypeInt},
 			ReturnType: TypeBytes,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				bytes := []byte(*args[0].(*DBytes))
 				n := int(*args[1].(*DInt))
 
@@ -382,7 +382,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeInt},
 			ReturnType: TypeString,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				runes := []rune(string(*args[0].(*DString)))
 				n := int(*args[1].(*DInt))
 
@@ -402,7 +402,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeBytes, TypeInt},
 			ReturnType: TypeBytes,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				bytes := []byte(*args[0].(*DBytes))
 				n := int(*args[1].(*DInt))
 
@@ -419,7 +419,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeInt},
 			ReturnType: TypeString,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				runes := []rune(string(*args[0].(*DString)))
 				n := int(*args[1].(*DInt))
 
@@ -440,7 +440,7 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeFloat,
 			impure:     true,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDFloat(DFloat(rand.Float64())), nil
 			},
 		},
@@ -451,7 +451,7 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeBytes,
 			impure:     true,
-			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return NewDBytes(generateUniqueBytes(ctx.NodeID)), nil
 			},
 		},
@@ -462,7 +462,7 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeInt,
 			impure:     true,
-			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return NewDInt(generateUniqueInt(ctx.NodeID)), nil
 			},
 		},
@@ -475,7 +475,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      AnyType{},
 			ReturnType: nil, // No explicit return type because AnyType parameters.
-			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, true /* greatest */, args)
 			},
 		},
@@ -485,7 +485,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      AnyType{},
 			ReturnType: nil, // No explicit return type because AnyType parameters.
-			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, false /* !greatest */, args)
 			},
 		},
@@ -497,15 +497,15 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeTimestamp},
 			ReturnType: TypeInterval,
-			fn: func(e EvalContext, args DTuple) (Datum, error) {
-				return timestampMinusBinOp.fn(e, e.GetTxnTimestamp(time.Microsecond), args[0])
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+				return timestampMinusBinOp.fn(ctx, ctx.GetTxnTimestamp(time.Microsecond), args[0])
 			},
 		},
 		Builtin{
 			Types:      ArgTypes{TypeTimestamp, TypeTimestamp},
 			ReturnType: TypeInterval,
-			fn: func(e EvalContext, args DTuple) (Datum, error) {
-				return timestampMinusBinOp.fn(e, args[0], args[1])
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+				return timestampMinusBinOp.fn(ctx, args[0], args[1])
 			},
 		},
 	},
@@ -514,9 +514,9 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeDate,
-			fn: func(e EvalContext, args DTuple) (Datum, error) {
-				t := e.GetTxnTimestamp(time.Microsecond).Time
-				return NewDDateFromTime(t, e.GetLocation()), nil
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+				t := ctx.GetTxnTimestamp(time.Microsecond).Time
+				return NewDDateFromTime(t, ctx.GetLocation()), nil
 			},
 		},
 	},
@@ -530,8 +530,8 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeTimestamp,
 			impure:     true,
-			fn: func(e EvalContext, args DTuple) (Datum, error) {
-				return e.GetStmtTimestamp(), nil
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+				return ctx.GetStmtTimestamp(), nil
 			},
 		},
 	},
@@ -541,8 +541,8 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeDecimal,
 			impure:     true,
-			fn: func(e EvalContext, args DTuple) (Datum, error) {
-				return e.GetClusterTimestamp(), nil
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+				return ctx.GetClusterTimestamp(), nil
 			},
 		},
 	},
@@ -552,7 +552,7 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeTimestamp,
 			impure:     true,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return MakeDTimestamp(timeutil.Now(), time.Microsecond), nil
 			},
 		},
@@ -562,7 +562,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeTimestamp},
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				// extract timeSpan fromTime.
 				fromTime := *args[1].(*DTimestamp)
 				timeSpan := strings.ToLower(string(*args[0].(*DString)))
@@ -631,7 +631,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString},
 			ReturnType: TypeTimestamp,
-			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
 				return ParseDTimestamp(s, ctx.GetLocation(), time.Nanosecond)
 			},
@@ -642,7 +642,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeTimestamp},
 			ReturnType: TypeString,
-			fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				t := args[0].(*DTimestamp)
 				return NewDString(t.Time.UTC().Format(timestampFormatNS)), nil
 			},
@@ -654,8 +654,8 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeTimestamp,
 			impure:     true,
-			fn: func(e EvalContext, args DTuple) (Datum, error) {
-				return e.GetTxnTimestamp(time.Nanosecond), nil
+			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+				return ctx.GetTxnTimestamp(time.Nanosecond), nil
 			},
 		},
 	},
@@ -675,7 +675,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeInt},
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				dd := &DDecimal{}
 				dd.SetUnscaled(int64(*args[0].(*DInt)))
 				return dd, nil
@@ -782,7 +782,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeInt},
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				x := *args[0].(*DInt)
 				switch {
 				case x == math.MinInt64:
@@ -916,7 +916,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeInt, TypeInt},
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				y := *args[1].(*DInt)
 				if y == 0 {
 					return DNull, errZeroModulus
@@ -931,7 +931,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDFloat(math.Pi), nil
 			},
 		},
@@ -958,14 +958,14 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeFloat, TypeInt},
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return round(float64(*args[0].(*DFloat)), int64(*args[1].(*DInt)))
 			},
 		},
 		Builtin{
 			Types:      ArgTypes{TypeDecimal, TypeInt},
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				dec := &args[0].(*DDecimal).Dec
 				dd := &DDecimal{}
 				dd.Round(dec, inf.Scale(*args[1].(*DInt)), inf.RoundHalfUp)
@@ -996,7 +996,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeInt},
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				x := *args[0].(*DInt)
 				switch {
 				case x < 0:
@@ -1046,7 +1046,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeString,
-			fn: func(_ EvalContext, args DTuple) (Datum, error) {
+			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(build.GetInfo().Short()), nil
 			},
 		},
@@ -1060,7 +1060,7 @@ func init() {
 }
 
 // identityFn returns the first argument provided.
-func identityFn(_ EvalContext, args DTuple) (Datum, error) {
+func identityFn(_ *EvalContext, args DTuple) (Datum, error) {
 	return args[0], nil
 }
 
@@ -1096,7 +1096,7 @@ var substringImpls = []Builtin{
 	{
 		Types:      ArgTypes{TypeString, TypeInt},
 		ReturnType: TypeString,
-		fn: func(_ EvalContext, args DTuple) (Datum, error) {
+		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			runes := []rune(string(*args[0].(*DString)))
 			// SQL strings are 1-indexed.
 			start := int(*args[1].(*DInt)) - 1
@@ -1113,7 +1113,7 @@ var substringImpls = []Builtin{
 	{
 		Types:      ArgTypes{TypeString, TypeInt, TypeInt},
 		ReturnType: TypeString,
-		fn: func(_ EvalContext, args DTuple) (Datum, error) {
+		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			runes := []rune(string(*args[0].(*DString)))
 			// SQL strings are 1-indexed.
 			start := int(*args[1].(*DInt)) - 1
@@ -1142,7 +1142,7 @@ var substringImpls = []Builtin{
 	{
 		Types:      ArgTypes{TypeString, TypeString},
 		ReturnType: TypeString,
-		fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+		fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 			s := string(*args[0].(*DString))
 			pattern := string(*args[1].(*DString))
 			return regexpExtract(ctx, s, pattern, `\`)
@@ -1151,7 +1151,7 @@ var substringImpls = []Builtin{
 	{
 		Types:      ArgTypes{TypeString, TypeString, TypeString},
 		ReturnType: TypeString,
-		fn: func(ctx EvalContext, args DTuple) (Datum, error) {
+		fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 			s := string(*args[0].(*DString))
 			pattern := string(*args[1].(*DString))
 			escape := string(*args[2].(*DString))
@@ -1164,7 +1164,7 @@ var uuidV4Impl = Builtin{
 	Types:      ArgTypes{},
 	ReturnType: TypeBytes,
 	impure:     true,
-	fn: func(_ EvalContext, args DTuple) (Datum, error) {
+	fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 		return NewDBytes(DBytes(uuid.NewV4().GetBytes())), nil
 	},
 }
@@ -1184,8 +1184,8 @@ var txnTSImpl = Builtin{
 	Types:      ArgTypes{},
 	ReturnType: TypeTimestamp,
 	impure:     true,
-	fn: func(e EvalContext, args DTuple) (Datum, error) {
-		return e.GetTxnTimestamp(time.Microsecond), nil
+	fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
+		return ctx.GetTxnTimestamp(time.Microsecond), nil
 	},
 }
 
@@ -1218,7 +1218,7 @@ func floatBuiltin1(f func(float64) (Datum, error)) Builtin {
 	return Builtin{
 		Types:      ArgTypes{TypeFloat},
 		ReturnType: TypeFloat,
-		fn: func(_ EvalContext, args DTuple) (Datum, error) {
+		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(float64(*args[0].(*DFloat)))
 		},
 	}
@@ -1228,7 +1228,7 @@ func floatBuiltin2(f func(float64, float64) (Datum, error)) Builtin {
 	return Builtin{
 		Types:      ArgTypes{TypeFloat, TypeFloat},
 		ReturnType: TypeFloat,
-		fn: func(_ EvalContext, args DTuple) (Datum, error) {
+		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(float64(*args[0].(*DFloat)),
 				float64(*args[1].(*DFloat)))
 		},
@@ -1239,7 +1239,7 @@ func decimalBuiltin1(f func(*inf.Dec) (Datum, error)) Builtin {
 	return Builtin{
 		Types:      ArgTypes{TypeDecimal},
 		ReturnType: TypeDecimal,
-		fn: func(_ EvalContext, args DTuple) (Datum, error) {
+		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			dec := &args[0].(*DDecimal).Dec
 			return f(dec)
 		},
@@ -1250,7 +1250,7 @@ func decimalBuiltin2(f func(*inf.Dec, *inf.Dec) (Datum, error)) Builtin {
 	return Builtin{
 		Types:      ArgTypes{TypeDecimal, TypeDecimal},
 		ReturnType: TypeDecimal,
-		fn: func(_ EvalContext, args DTuple) (Datum, error) {
+		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			dec1 := &args[0].(*DDecimal).Dec
 			dec2 := &args[1].(*DDecimal).Dec
 			return f(dec1, dec2)
@@ -1262,7 +1262,7 @@ func stringBuiltin1(f func(string) (Datum, error), returnType Datum) Builtin {
 	return Builtin{
 		Types:      ArgTypes{TypeString},
 		ReturnType: returnType,
-		fn: func(_ EvalContext, args DTuple) (Datum, error) {
+		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(*args[0].(*DString)))
 		},
 	}
@@ -1272,7 +1272,7 @@ func stringBuiltin2(f func(string, string) (Datum, error), returnType Datum) Bui
 	return Builtin{
 		Types:      ArgTypes{TypeString, TypeString},
 		ReturnType: returnType,
-		fn: func(_ EvalContext, args DTuple) (Datum, error) {
+		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(*args[0].(*DString)), string(*args[1].(*DString)))
 		},
 	}
@@ -1282,7 +1282,7 @@ func stringBuiltin3(f func(string, string, string) (Datum, error), returnType Da
 	return Builtin{
 		Types:      ArgTypes{TypeString, TypeString, TypeString},
 		ReturnType: returnType,
-		fn: func(_ EvalContext, args DTuple) (Datum, error) {
+		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(*args[0].(*DString)), string(*args[1].(*DString)), string(*args[2].(*DString)))
 		},
 	}
@@ -1292,7 +1292,7 @@ func bytesBuiltin1(f func(string) (Datum, error), returnType Datum) Builtin {
 	return Builtin{
 		Types:      ArgTypes{TypeBytes},
 		ReturnType: returnType,
-		fn: func(_ EvalContext, args DTuple) (Datum, error) {
+		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(*args[0].(*DBytes)))
 		},
 	}
@@ -1312,7 +1312,7 @@ func (k regexpEscapeKey) pattern() (string, error) {
 	return pattern, nil
 }
 
-func regexpExtract(ctx EvalContext, s, pattern, escape string) (Datum, error) {
+func regexpExtract(ctx *EvalContext, s, pattern, escape string) (Datum, error) {
 	patternRe, err := ctx.ReCache.GetRegexp(regexpEscapeKey{pattern, escape})
 	if err != nil {
 		return nil, err
@@ -1340,7 +1340,7 @@ func (k regexpFlagKey) pattern() (string, error) {
 
 var replaceSubRe = regexp.MustCompile(`\\[&1-9]`)
 
-func regexpReplace(ctx EvalContext, s, pattern, to, sqlFlags string) (Datum, error) {
+func regexpReplace(ctx *EvalContext, s, pattern, to, sqlFlags string) (Datum, error) {
 	patternRe, err := ctx.ReCache.GetRegexp(regexpFlagKey{pattern, sqlFlags})
 	if err != nil {
 		return nil, err
@@ -1516,7 +1516,7 @@ func round(x float64, n int64) (Datum, error) {
 }
 
 // Pick the greatest (or least value) from a tuple.
-func pickFromTuple(ctx EvalContext, greatest bool, args DTuple) (Datum, error) {
+func pickFromTuple(ctx *EvalContext, greatest bool, args DTuple) (Datum, error) {
 	g := args[0]
 	// Pick a greater (or smaller) value.
 	for _, d := range args[1:] {

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -1399,7 +1399,8 @@ func mixedTypeCompare(l, r Datum) (int, bool) {
 	if !ok {
 		return 0, false
 	}
-	eq, err := eqOp.fn(EvalContext{}, l, r)
+	ctx := &EvalContext{}
+	eq, err := eqOp.fn(ctx, l, r)
 	if err != nil {
 		panic(err)
 	}
@@ -1412,7 +1413,7 @@ func mixedTypeCompare(l, r Datum) (int, bool) {
 	if !ok {
 		return 0, false
 	}
-	lt, err := ltOp.fn(EvalContext{}, l, r)
+	lt, err := ltOp.fn(ctx, l, r)
 	if err != nil {
 		panic(err)
 	}

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -1197,7 +1197,7 @@ type EvalContext struct {
 	Location **time.Location
 
 	ReCache *RegexpCache
-	TmpDec  *inf.Dec
+	tmpDec  inf.Dec
 
 	// TODO(mjibson): remove prepareOnly in favor of a 2-step prepare-exec solution
 	// that is also able to save the plan to skip work during the exec step.
@@ -1276,10 +1276,7 @@ func (ctx *EvalContext) GetLocation() *time.Location {
 }
 
 func (ctx *EvalContext) getTmpDec() *inf.Dec {
-	if ctx.TmpDec != nil {
-		return ctx.TmpDec
-	}
-	return new(inf.Dec)
+	return &ctx.tmpDec
 }
 
 // Eval implements the Expr interface.

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -50,7 +50,7 @@ const secondsInDay = 24 * 60 * 60
 type UnaryOp struct {
 	Typ        Datum
 	ReturnType Datum
-	fn         func(EvalContext, Datum) (Datum, error)
+	fn         func(*EvalContext, Datum) (Datum, error)
 	types      typeList
 }
 
@@ -80,21 +80,21 @@ var UnaryOps = map[UnaryOperator]unaryOpOverload{
 		UnaryOp{
 			Typ:        TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, d Datum) (Datum, error) {
+			fn: func(_ *EvalContext, d Datum) (Datum, error) {
 				return d, nil
 			},
 		},
 		UnaryOp{
 			Typ:        TypeFloat,
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, d Datum) (Datum, error) {
+			fn: func(_ *EvalContext, d Datum) (Datum, error) {
 				return d, nil
 			},
 		},
 		UnaryOp{
 			Typ:        TypeDecimal,
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, d Datum) (Datum, error) {
+			fn: func(_ *EvalContext, d Datum) (Datum, error) {
 				return d, nil
 			},
 		},
@@ -104,21 +104,21 @@ var UnaryOps = map[UnaryOperator]unaryOpOverload{
 		UnaryOp{
 			Typ:        TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, d Datum) (Datum, error) {
+			fn: func(_ *EvalContext, d Datum) (Datum, error) {
 				return NewDInt(-*d.(*DInt)), nil
 			},
 		},
 		UnaryOp{
 			Typ:        TypeFloat,
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, d Datum) (Datum, error) {
+			fn: func(_ *EvalContext, d Datum) (Datum, error) {
 				return NewDFloat(-*d.(*DFloat)), nil
 			},
 		},
 		UnaryOp{
 			Typ:        TypeDecimal,
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, d Datum) (Datum, error) {
+			fn: func(_ *EvalContext, d Datum) (Datum, error) {
 				dec := &d.(*DDecimal).Dec
 				dd := &DDecimal{}
 				dd.Neg(dec)
@@ -131,7 +131,7 @@ var UnaryOps = map[UnaryOperator]unaryOpOverload{
 		UnaryOp{
 			Typ:        TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, d Datum) (Datum, error) {
+			fn: func(_ *EvalContext, d Datum) (Datum, error) {
 				return NewDInt(^*d.(*DInt)), nil
 			},
 		},
@@ -143,7 +143,7 @@ type BinOp struct {
 	LeftType   Datum
 	RightType  Datum
 	ReturnType Datum
-	fn         func(EvalContext, Datum, Datum) (Datum, error)
+	fn         func(*EvalContext, Datum, Datum) (Datum, error)
 	types      typeList
 }
 
@@ -187,7 +187,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDInt(*left.(*DInt) & *right.(*DInt)), nil
 			},
 		},
@@ -198,7 +198,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDInt(*left.(*DInt) | *right.(*DInt)), nil
 			},
 		},
@@ -209,7 +209,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDInt(*left.(*DInt) ^ *right.(*DInt)), nil
 			},
 		},
@@ -222,7 +222,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDInt(*left.(*DInt) + *right.(*DInt)), nil
 			},
 		},
@@ -230,7 +230,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeFloat,
 			RightType:  TypeFloat,
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDFloat(*left.(*DFloat) + *right.(*DFloat)), nil
 			},
 		},
@@ -238,7 +238,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeDecimal,
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Dec
 				r := &right.(*DDecimal).Dec
 				dd := &DDecimal{}
@@ -250,7 +250,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeDate,
 			RightType:  TypeInt,
 			ReturnType: TypeDate,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDDate(*left.(*DDate) + DDate(*right.(*DInt))), nil
 			},
 		},
@@ -258,7 +258,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeDate,
 			ReturnType: TypeDate,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDDate(DDate(*left.(*DInt)) + *right.(*DDate)), nil
 			},
 		},
@@ -266,7 +266,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeTimestamp,
 			RightType:  TypeInterval,
 			ReturnType: TypeTimestamp,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return MakeDTimestamp(duration.Add(left.(*DTimestamp).Time, right.(*DInterval).Duration), time.Microsecond), nil
 			},
 		},
@@ -274,7 +274,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInterval,
 			RightType:  TypeTimestamp,
 			ReturnType: TypeTimestamp,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return MakeDTimestamp(duration.Add(right.(*DTimestamp).Time, left.(*DInterval).Duration), time.Microsecond), nil
 			},
 		},
@@ -282,7 +282,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeTimestampTZ,
 			RightType:  TypeInterval,
 			ReturnType: TypeTimestampTZ,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				t := duration.Add(left.(*DTimestampTZ).Time, right.(*DInterval).Duration)
 				return MakeDTimestampTZ(t, time.Microsecond), nil
 			},
@@ -291,7 +291,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInterval,
 			RightType:  TypeTimestampTZ,
 			ReturnType: TypeTimestampTZ,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				t := duration.Add(right.(*DTimestampTZ).Time, left.(*DInterval).Duration)
 				return MakeDTimestampTZ(t, time.Microsecond), nil
 			},
@@ -300,7 +300,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInterval,
 			RightType:  TypeInterval,
 			ReturnType: TypeInterval,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return &DInterval{Duration: left.(*DInterval).Duration.Add(right.(*DInterval).Duration)}, nil
 			},
 		},
@@ -311,7 +311,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDInt(*left.(*DInt) - *right.(*DInt)), nil
 			},
 		},
@@ -319,7 +319,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeFloat,
 			RightType:  TypeFloat,
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDFloat(*left.(*DFloat) - *right.(*DFloat)), nil
 			},
 		},
@@ -327,7 +327,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeDecimal,
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Dec
 				r := &right.(*DDecimal).Dec
 				dd := &DDecimal{}
@@ -339,7 +339,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeDate,
 			RightType:  TypeInt,
 			ReturnType: TypeDate,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDDate(*left.(*DDate) - DDate(*right.(*DInt))), nil
 			},
 		},
@@ -347,7 +347,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeDate,
 			RightType:  TypeDate,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDInt(DInt(*left.(*DDate) - *right.(*DDate))), nil
 			},
 		},
@@ -355,7 +355,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeTimestamp,
 			RightType:  TypeTimestamp,
 			ReturnType: TypeInterval,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				nanos := left.(*DTimestamp).Sub(right.(*DTimestamp).Time).Nanoseconds()
 				return &DInterval{Duration: duration.Duration{Nanos: nanos}}, nil
 			},
@@ -364,7 +364,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeTimestampTZ,
 			RightType:  TypeTimestampTZ,
 			ReturnType: TypeInterval,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				nanos := left.(*DTimestampTZ).Sub(right.(*DTimestampTZ).Time).Nanoseconds()
 				return &DInterval{Duration: duration.Duration{Nanos: nanos}}, nil
 			},
@@ -373,7 +373,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeTimestamp,
 			RightType:  TypeInterval,
 			ReturnType: TypeTimestamp,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return MakeDTimestamp(duration.Add(left.(*DTimestamp).Time, right.(*DInterval).Duration.Mul(-1)), time.Microsecond), nil
 			},
 		},
@@ -381,7 +381,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeTimestampTZ,
 			RightType:  TypeInterval,
 			ReturnType: TypeTimestampTZ,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				t := duration.Add(left.(*DTimestampTZ).Time, right.(*DInterval).Duration.Mul(-1))
 				return MakeDTimestampTZ(t, time.Microsecond), nil
 			},
@@ -390,7 +390,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInterval,
 			RightType:  TypeInterval,
 			ReturnType: TypeInterval,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return &DInterval{Duration: left.(*DInterval).Duration.Sub(right.(*DInterval).Duration)}, nil
 			},
 		},
@@ -401,7 +401,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDInt(*left.(*DInt) * *right.(*DInt)), nil
 			},
 		},
@@ -409,7 +409,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeFloat,
 			RightType:  TypeFloat,
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDFloat(*left.(*DFloat) * *right.(*DFloat)), nil
 			},
 		},
@@ -419,7 +419,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeDecimal,
 			RightType:  TypeInt,
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Dec
 				r := *right.(*DInt)
 				dd := &DDecimal{}
@@ -432,7 +432,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := *left.(*DInt)
 				r := &right.(*DDecimal).Dec
 				dd := &DDecimal{}
@@ -445,7 +445,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeDecimal,
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Dec
 				r := &right.(*DDecimal).Dec
 				dd := &DDecimal{}
@@ -457,7 +457,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInterval,
 			ReturnType: TypeInterval,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return &DInterval{Duration: right.(*DInterval).Duration.Mul(int64(*left.(*DInt)))}, nil
 			},
 		},
@@ -465,7 +465,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInterval,
 			RightType:  TypeInt,
 			ReturnType: TypeInterval,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return &DInterval{Duration: left.(*DInterval).Duration.Mul(int64(*right.(*DInt)))}, nil
 			},
 		},
@@ -476,7 +476,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeDecimal,
-			fn: func(ctx EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 				rInt := *right.(*DInt)
 				if rInt == 0 {
 					return nil, errDivByZero
@@ -492,7 +492,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeFloat,
 			RightType:  TypeFloat,
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDFloat(*left.(*DFloat) / *right.(*DFloat)), nil
 			},
 		},
@@ -500,7 +500,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeDecimal,
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Dec
 				r := &right.(*DDecimal).Dec
 				if r.Sign() == 0 {
@@ -515,7 +515,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInterval,
 			RightType:  TypeInt,
 			ReturnType: TypeInterval,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				rInt := *right.(*DInt)
 				if rInt == 0 {
 					return nil, errDivByZero
@@ -530,7 +530,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				rInt := *right.(*DInt)
 				if rInt == 0 {
 					return nil, errDivByZero
@@ -542,7 +542,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeFloat,
 			RightType:  TypeFloat,
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := float64(*left.(*DFloat))
 				r := float64(*right.(*DFloat))
 				return NewDFloat(DFloat(math.Trunc(l / r))), nil
@@ -552,7 +552,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeDecimal,
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := left.(*DDecimal).Dec
 				r := right.(*DDecimal).Dec
 				if r.Sign() == 0 {
@@ -570,7 +570,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				r := *right.(*DInt)
 				if r == 0 {
 					return nil, errZeroModulus
@@ -582,7 +582,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeFloat,
 			RightType:  TypeFloat,
 			ReturnType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDFloat(DFloat(math.Mod(float64(*left.(*DFloat)), float64(*right.(*DFloat))))), nil
 			},
 		},
@@ -590,7 +590,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeDecimal,
 			RightType:  TypeDecimal,
 			ReturnType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				l := &left.(*DDecimal).Dec
 				r := &right.(*DDecimal).Dec
 				if r.Sign() == 0 {
@@ -608,7 +608,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeString,
 			RightType:  TypeString,
 			ReturnType: TypeString,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDString(string(*left.(*DString) + *right.(*DString))), nil
 			},
 		},
@@ -616,7 +616,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeBytes,
 			RightType:  TypeBytes,
 			ReturnType: TypeBytes,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDBytes(*left.(*DBytes) + *right.(*DBytes)), nil
 			},
 		},
@@ -628,7 +628,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDInt(*left.(*DInt) << uint(*right.(*DInt))), nil
 			},
 		},
@@ -639,7 +639,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			LeftType:   TypeInt,
 			RightType:  TypeInt,
 			ReturnType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (Datum, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				return NewDInt(*left.(*DInt) >> uint(*right.(*DInt))), nil
 			},
 		},
@@ -656,7 +656,7 @@ func init() {
 type CmpOp struct {
 	LeftType  Datum
 	RightType Datum
-	fn        func(EvalContext, Datum, Datum) (DBool, error)
+	fn        func(*EvalContext, Datum, Datum) (DBool, error)
 	types     typeList
 }
 
@@ -699,7 +699,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeString,
 			RightType: TypeString,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DString) == *right.(*DString)), nil
 			},
 		},
@@ -707,35 +707,35 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			LeftType:  TypeBytes,
 			RightType: TypeBytes,
 
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DBytes) == *right.(*DBytes)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeBool,
 			RightType: TypeBool,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DBool) == *right.(*DBool)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DInt) == *right.(*DInt)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DFloat) == *right.(*DFloat)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) == 0), nil
@@ -744,21 +744,21 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DFloat) == DFloat(*right.(*DInt))), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(DFloat(*left.(*DInt)) == *right.(*DFloat)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeInt,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
 				r := ctx.getTmpDec().SetUnscaled(int64(*right.(*DInt))).SetScale(0)
 				return DBool(l.Cmp(r) == 0), nil
@@ -767,7 +767,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeDecimal,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := ctx.getTmpDec().SetUnscaled(int64(*left.(*DInt))).SetScale(0)
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) == 0), nil
@@ -776,7 +776,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeFloat,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
 				r := decimal.SetFromFloat(ctx.getTmpDec(), float64(*right.(*DFloat)))
 				return DBool(l.Cmp(r) == 0), nil
@@ -785,7 +785,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeDecimal,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := decimal.SetFromFloat(ctx.getTmpDec(), float64(*left.(*DFloat)))
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) == 0), nil
@@ -794,35 +794,35 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDate,
 			RightType: TypeDate,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(left.(*DDate) == right.(*DDate)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeTimestamp,
 			RightType: TypeTimestamp,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(left.(*DTimestamp).Equal(right.(*DTimestamp).Time)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeTimestampTZ,
 			RightType: TypeTimestampTZ,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(left.(*DTimestampTZ).Equal(right.(*DTimestampTZ).Time)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInterval,
 			RightType: TypeInterval,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DInterval) == *right.(*DInterval)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeTuple,
 			RightType: TypeTuple,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				c, err := cmpTuple(left, right)
 				return DBool(c == 0), err
 			},
@@ -833,42 +833,42 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeString,
 			RightType: TypeString,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DString) < *right.(*DString)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeBytes,
 			RightType: TypeBytes,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DBytes) < *right.(*DBytes)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeBool,
 			RightType: TypeBool,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(!*left.(*DBool) && *right.(*DBool)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DInt) < *right.(*DInt)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DFloat) < *right.(*DFloat)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) < 0), nil
@@ -877,21 +877,21 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DFloat) < DFloat(*right.(*DInt))), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(DFloat(*left.(*DInt)) < *right.(*DFloat)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeInt,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
 				r := ctx.getTmpDec().SetUnscaled(int64(*right.(*DInt))).SetScale(0)
 				return DBool(l.Cmp(r) < 0), nil
@@ -900,7 +900,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeDecimal,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := ctx.getTmpDec().SetUnscaled(int64(*left.(*DInt))).SetScale(0)
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) < 0), nil
@@ -909,7 +909,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeFloat,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
 				r := decimal.SetFromFloat(ctx.getTmpDec(), float64(*right.(*DFloat)))
 				return DBool(l.Cmp(r) < 0), nil
@@ -918,7 +918,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeDecimal,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := decimal.SetFromFloat(ctx.getTmpDec(), float64(*left.(*DFloat)))
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) < 0), nil
@@ -927,35 +927,35 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDate,
 			RightType: TypeDate,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DDate) < *right.(*DDate)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeTimestamp,
 			RightType: TypeTimestamp,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(left.(*DTimestamp).Before(right.(*DTimestamp).Time)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeTimestampTZ,
 			RightType: TypeTimestampTZ,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(left.(*DTimestampTZ).Before(right.(*DTimestampTZ).Time)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInterval,
 			RightType: TypeInterval,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(left.(*DInterval).Duration.Compare(right.(*DInterval).Duration) < 0), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeTuple,
 			RightType: TypeTuple,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				c, err := cmpTuple(left, right)
 				return DBool(c < 0), err
 			},
@@ -966,42 +966,42 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeString,
 			RightType: TypeString,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DString) <= *right.(*DString)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeBytes,
 			RightType: TypeBytes,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DBytes) <= *right.(*DBytes)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeBool,
 			RightType: TypeBool,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(!*left.(*DBool) || *right.(*DBool)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DInt) <= *right.(*DInt)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DFloat) <= *right.(*DFloat)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeDecimal,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) <= 0), nil
@@ -1010,21 +1010,21 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeInt,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DFloat) <= DFloat(*right.(*DInt))), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeFloat,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(DFloat(*left.(*DInt)) <= *right.(*DFloat)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeInt,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
 				r := ctx.getTmpDec().SetUnscaled(int64(*right.(*DInt))).SetScale(0)
 				return DBool(l.Cmp(r) <= 0), nil
@@ -1033,7 +1033,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeInt,
 			RightType: TypeDecimal,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := ctx.getTmpDec().SetUnscaled(int64(*left.(*DInt))).SetScale(0)
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) <= 0), nil
@@ -1042,7 +1042,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDecimal,
 			RightType: TypeFloat,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := &left.(*DDecimal).Dec
 				r := decimal.SetFromFloat(ctx.getTmpDec(), float64(*right.(*DFloat)))
 				return DBool(l.Cmp(r) <= 0), nil
@@ -1051,7 +1051,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeFloat,
 			RightType: TypeDecimal,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				l := decimal.SetFromFloat(ctx.getTmpDec(), float64(*left.(*DFloat)))
 				r := &right.(*DDecimal).Dec
 				return DBool(l.Cmp(r) <= 0), nil
@@ -1060,35 +1060,35 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeDate,
 			RightType: TypeDate,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(*left.(*DDate) <= *right.(*DDate)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeTimestamp,
 			RightType: TypeTimestamp,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return !DBool(right.(*DTimestamp).Before(left.(*DTimestamp).Time)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeTimestampTZ,
 			RightType: TypeTimestampTZ,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return !DBool(right.(*DTimestampTZ).Before(left.(*DTimestampTZ).Time)), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeInterval,
 			RightType: TypeInterval,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				return DBool(left.(*DInterval).Duration.Compare(right.(*DInterval).Duration) <= 0), nil
 			},
 		},
 		CmpOp{
 			LeftType:  TypeTuple,
 			RightType: TypeTuple,
-			fn: func(_ EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(_ *EvalContext, left Datum, right Datum) (DBool, error) {
 				c, err := cmpTuple(left, right)
 				return DBool(c <= 0), err
 			},
@@ -1112,7 +1112,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeString,
 			RightType: TypeString,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				pattern := string(*right.(*DString))
 				like := optimizedLikeFunc(pattern)
 				if like == nil {
@@ -1132,7 +1132,7 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 		CmpOp{
 			LeftType:  TypeString,
 			RightType: TypeString,
-			fn: func(ctx EvalContext, left Datum, right Datum) (DBool, error) {
+			fn: func(ctx *EvalContext, left Datum, right Datum) (DBool, error) {
 				key := similarToKey(*right.(*DString))
 				re, err := ctx.ReCache.GetRegexp(key)
 				if err != nil {
@@ -1166,7 +1166,7 @@ func makeEvalTupleIn(d Datum) CmpOp {
 	return CmpOp{
 		LeftType:  d,
 		RightType: TypeTuple,
-		fn: func(_ EvalContext, arg, values Datum) (DBool, error) {
+		fn: func(_ *EvalContext, arg, values Datum) (DBool, error) {
 			if arg == DNull {
 				return DBool(false), nil
 			}
@@ -1178,8 +1178,6 @@ func makeEvalTupleIn(d Datum) CmpOp {
 		},
 	}
 }
-
-var defaultEvalContext = EvalContext{}
 
 // EvalContext defines the context in which to evaluate an expression, allowing
 // the retrieval of state such as the node ID or statement start time.
@@ -1270,14 +1268,14 @@ func (ctx *EvalContext) SetClusterTimestamp(ts roachpb.Timestamp) {
 }
 
 // GetLocation returns the session timezone.
-func (ctx EvalContext) GetLocation() *time.Location {
+func (ctx *EvalContext) GetLocation() *time.Location {
 	if ctx.Location == nil || *ctx.Location == nil {
 		return time.UTC
 	}
 	return *ctx.Location
 }
 
-func (ctx EvalContext) getTmpDec() *inf.Dec {
+func (ctx *EvalContext) getTmpDec() *inf.Dec {
 	if ctx.TmpDec != nil {
 		return ctx.TmpDec
 	}
@@ -1285,7 +1283,7 @@ func (ctx EvalContext) getTmpDec() *inf.Dec {
 }
 
 // Eval implements the Expr interface.
-func (expr *AndExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *AndExpr) Eval(ctx *EvalContext) (Datum, error) {
 	left, err := expr.Left.(TypedExpr).Eval(ctx)
 	if err != nil {
 		return DNull, err
@@ -1313,7 +1311,7 @@ func (expr *AndExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr *BinaryExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *BinaryExpr) Eval(ctx *EvalContext) (Datum, error) {
 	left, err := expr.Left.(TypedExpr).Eval(ctx)
 	if err != nil {
 		return nil, err
@@ -1332,7 +1330,7 @@ func (expr *BinaryExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr *CaseExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *CaseExpr) Eval(ctx *EvalContext) (Datum, error) {
 	if expr.Expr != nil {
 		// CASE <val> WHEN <expr> THEN ...
 		//
@@ -1379,7 +1377,7 @@ func (expr *CaseExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 	d, err := expr.Expr.(TypedExpr).Eval(ctx)
 	if err != nil {
 		return nil, err
@@ -1557,7 +1555,7 @@ func (expr *CastExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr *CoalesceExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *CoalesceExpr) Eval(ctx *EvalContext) (Datum, error) {
 	for _, e := range expr.Exprs {
 		d, err := e.(TypedExpr).Eval(ctx)
 		if err != nil {
@@ -1571,7 +1569,7 @@ func (expr *CoalesceExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr *ComparisonExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *ComparisonExpr) Eval(ctx *EvalContext) (Datum, error) {
 	left, err := expr.Left.(TypedExpr).Eval(ctx)
 	if err != nil {
 		return DNull, err
@@ -1609,13 +1607,13 @@ func (expr *ComparisonExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (t *ExistsExpr) Eval(ctx EvalContext) (Datum, error) {
+func (t *ExistsExpr) Eval(ctx *EvalContext) (Datum, error) {
 	// Exists expressions are handled during subquery expansion.
 	return nil, util.Errorf("unhandled type %T", t)
 }
 
 // Eval implements the Expr interface.
-func (expr *FuncExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *FuncExpr) Eval(ctx *EvalContext) (Datum, error) {
 	args := make(DTuple, 0, len(expr.Exprs))
 	for _, e := range expr.Exprs {
 		arg, err := e.(TypedExpr).Eval(ctx)
@@ -1642,12 +1640,12 @@ func (expr *FuncExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr *OverlayExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *OverlayExpr) Eval(ctx *EvalContext) (Datum, error) {
 	return nil, util.Errorf("unhandled type %T", expr)
 }
 
 // Eval implements the Expr interface.
-func (expr *IfExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *IfExpr) Eval(ctx *EvalContext) (Datum, error) {
 	cond, err := expr.Cond.(TypedExpr).Eval(ctx)
 	if err != nil {
 		return DNull, err
@@ -1659,7 +1657,7 @@ func (expr *IfExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr *IsOfTypeExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *IsOfTypeExpr) Eval(ctx *EvalContext) (Datum, error) {
 	d, err := expr.Expr.(TypedExpr).Eval(ctx)
 	if err != nil {
 		return DNull, err
@@ -1746,7 +1744,7 @@ func (expr *IsOfTypeExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr *NotExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *NotExpr) Eval(ctx *EvalContext) (Datum, error) {
 	d, err := expr.Expr.(TypedExpr).Eval(ctx)
 	if err != nil {
 		return DNull, err
@@ -1762,7 +1760,7 @@ func (expr *NotExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr *NullIfExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *NullIfExpr) Eval(ctx *EvalContext) (Datum, error) {
 	expr1, err := expr.Expr1.(TypedExpr).Eval(ctx)
 	if err != nil {
 		return DNull, err
@@ -1782,7 +1780,7 @@ func (expr *NullIfExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr *OrExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *OrExpr) Eval(ctx *EvalContext) (Datum, error) {
 	left, err := expr.Left.(TypedExpr).Eval(ctx)
 	if err != nil {
 		return DNull, err
@@ -1813,25 +1811,25 @@ func (expr *OrExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr *ParenExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *ParenExpr) Eval(ctx *EvalContext) (Datum, error) {
 	return expr.Expr.(TypedExpr).Eval(ctx)
 }
 
 // Eval implements the Expr interface.
-func (expr *RangeCond) Eval(_ EvalContext) (Datum, error) {
+func (expr *RangeCond) Eval(_ *EvalContext) (Datum, error) {
 	log.Errorf("unhandled type %T passed to Eval", expr)
 	return nil, util.Errorf("unhandled type %T", expr)
 }
 
 // Eval implements the Expr interface.
-func (expr *Subquery) Eval(_ EvalContext) (Datum, error) {
+func (expr *Subquery) Eval(_ *EvalContext) (Datum, error) {
 	// Subquery expressions are handled during subquery expansion.
 	log.Errorf("unhandled type %T passed to Eval", expr)
 	return nil, util.Errorf("unhandled type %T", expr)
 }
 
 // Eval implements the Expr interface.
-func (expr *UnaryExpr) Eval(ctx EvalContext) (Datum, error) {
+func (expr *UnaryExpr) Eval(ctx *EvalContext) (Datum, error) {
 	d, err := expr.Expr.(TypedExpr).Eval(ctx)
 	if err != nil {
 		return nil, err
@@ -1843,19 +1841,19 @@ func (expr *UnaryExpr) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (expr DefaultVal) Eval(_ EvalContext) (Datum, error) {
+func (expr DefaultVal) Eval(_ *EvalContext) (Datum, error) {
 	log.Errorf("unhandled type %T passed to Eval", expr)
 	return nil, util.Errorf("unhandled type %T", expr)
 }
 
 // Eval implements the Expr interface.
-func (expr *QualifiedName) Eval(ctx EvalContext) (Datum, error) {
+func (expr *QualifiedName) Eval(ctx *EvalContext) (Datum, error) {
 	log.Errorf("unhandled type %T passed to Eval", expr)
 	return nil, util.Errorf("unhandled type %T", expr)
 }
 
 // Eval implements the Expr interface.
-func (t *Tuple) Eval(ctx EvalContext) (Datum, error) {
+func (t *Tuple) Eval(ctx *EvalContext) (Datum, error) {
 	tuple := make(DTuple, 0, len(t.Exprs))
 	for _, v := range t.Exprs {
 		d, err := v.(TypedExpr).Eval(ctx)
@@ -1868,71 +1866,71 @@ func (t *Tuple) Eval(ctx EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (t *DBool) Eval(_ EvalContext) (Datum, error) {
+func (t *DBool) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t *DBytes) Eval(_ EvalContext) (Datum, error) {
+func (t *DBytes) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t *DDate) Eval(_ EvalContext) (Datum, error) {
+func (t *DDate) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t *DFloat) Eval(_ EvalContext) (Datum, error) {
+func (t *DFloat) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t *DDecimal) Eval(_ EvalContext) (Datum, error) {
+func (t *DDecimal) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t *DInt) Eval(_ EvalContext) (Datum, error) {
+func (t *DInt) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t *DInterval) Eval(_ EvalContext) (Datum, error) {
+func (t *DInterval) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t dNull) Eval(_ EvalContext) (Datum, error) {
+func (t dNull) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t *DString) Eval(_ EvalContext) (Datum, error) {
+func (t *DString) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t *DTimestamp) Eval(_ EvalContext) (Datum, error) {
+func (t *DTimestamp) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t *DTimestampTZ) Eval(_ EvalContext) (Datum, error) {
+func (t *DTimestampTZ) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t *DTuple) Eval(_ EvalContext) (Datum, error) {
+func (t *DTuple) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
 // Eval implements the Expr interface.
-func (t *DPlaceholder) Eval(_ EvalContext) (Datum, error) {
+func (t *DPlaceholder) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 
-func evalComparison(ctx EvalContext, op ComparisonOperator, left, right Datum) (Datum, error) {
+func evalComparison(ctx *EvalContext, op ComparisonOperator, left, right Datum) (Datum, error) {
 	if left == DNull || right == DNull {
 		return DNull, nil
 	}

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -427,10 +427,11 @@ func TestEval(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		if typedExpr, err = defaultEvalContext.NormalizeExpr(typedExpr); err != nil {
+		ctx := &EvalContext{}
+		if typedExpr, err = ctx.NormalizeExpr(typedExpr); err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		r, err := typedExpr.Eval(defaultEvalContext)
+		r, err := typedExpr.Eval(ctx)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
@@ -477,7 +478,7 @@ func TestEvalError(t *testing.T) {
 		}
 		typedExpr, err := TypeCheck(expr, nil, NoTypePreference)
 		if err == nil {
-			_, err = typedExpr.Eval(defaultEvalContext)
+			_, err = typedExpr.Eval(&EvalContext{})
 		}
 		if !testutils.IsError(err, strings.Replace(regexp.QuoteMeta(d.expected), `\.\*`, `.*`, -1)) {
 			t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)
@@ -507,7 +508,7 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 			Left:     NewDString(d.left),
 			Right:    NewDString(d.right),
 		}
-		ctx := defaultEvalContext
+		ctx := &EvalContext{}
 		ctx.ReCache = NewRegexpCache(8)
 		typedExpr, err := TypeCheck(expr, nil, NoTypePreference)
 		if err != nil {
@@ -561,7 +562,7 @@ func TestClusterTimestampConversion(t *testing.T) {
 		{9223372036854775807, 2147483647, "9223372036854775807.2147483647"},
 	}
 
-	ctx := defaultEvalContext
+	ctx := &EvalContext{}
 	ctx.PrepareOnly = true
 	for _, d := range testData {
 		ts := roachpb.Timestamp{WallTime: d.walltime, Logical: d.logical}
@@ -586,7 +587,7 @@ var benchmarkLikePatterns = []string{
 	`also\%`,
 }
 
-func benchmarkLike(b *testing.B, ctx EvalContext) {
+func benchmarkLike(b *testing.B, ctx *EvalContext) {
 	likeFn, _ := CmpOps[Like].lookupImpl(TypeString, TypeString)
 	iter := func() {
 		for _, p := range benchmarkLikePatterns {
@@ -604,9 +605,9 @@ func benchmarkLike(b *testing.B, ctx EvalContext) {
 }
 
 func BenchmarkLikeWithCache(b *testing.B) {
-	benchmarkLike(b, EvalContext{ReCache: NewRegexpCache(len(benchmarkLikePatterns))})
+	benchmarkLike(b, &EvalContext{ReCache: NewRegexpCache(len(benchmarkLikePatterns))})
 }
 
 func BenchmarkLikeWithoutCache(b *testing.B) {
-	benchmarkLike(b, EvalContext{})
+	benchmarkLike(b, &EvalContext{})
 }

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -52,7 +52,7 @@ type TypedExpr interface {
 	// should be replaced prior to expression evaluation by an appropriate
 	// WalkExpr. For example, Placeholder should be replace by the argument passed from
 	// the client.
-	Eval(EvalContext) (Datum, error)
+	Eval(*EvalContext) (Datum, error)
 	// ReturnType provides the type of the TypedExpr, which is the type of Datum that
 	// the TypedExpr will return when evaluated.
 	ReturnType() Datum

--- a/sql/parser/expr_test.go
+++ b/sql/parser/expr_test.go
@@ -209,11 +209,12 @@ func TestExprString(t *testing.T) {
 			t.Errorf("Print/parse/print cycle changes the string: `%s` vs `%s`", str, str2)
 		}
 		// Compare the normalized expressions.
-		normalized, err := defaultEvalContext.NormalizeExpr(typedExpr)
+		ctx := &EvalContext{}
+		normalized, err := ctx.NormalizeExpr(typedExpr)
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}
-		normalized2, err := defaultEvalContext.NormalizeExpr(typedExpr2)
+		normalized2, err := ctx.NormalizeExpr(typedExpr2)
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}

--- a/sql/parser/indexed_vars.go
+++ b/sql/parser/indexed_vars.go
@@ -24,7 +24,7 @@ import (
 // IndexedVarContainer provides the implementation of TypeCheck, Eval, and
 // String for IndexedVars.
 type IndexedVarContainer interface {
-	IndexedVarEval(idx int, ctx EvalContext) (Datum, error)
+	IndexedVarEval(idx int, ctx *EvalContext) (Datum, error)
 	IndexedVarReturnType(idx int) Datum
 	IndexedVarString(idx int) string
 }
@@ -54,7 +54,7 @@ func (v *IndexedVar) TypeCheck(_ *SemaContext, desired Datum) (TypedExpr, error)
 }
 
 // Eval is part of the TypedExpr interface.
-func (v *IndexedVar) Eval(ctx EvalContext) (Datum, error) {
+func (v *IndexedVar) Eval(ctx *EvalContext) (Datum, error) {
 	return v.container.IndexedVarEval(v.Idx, ctx)
 }
 

--- a/sql/parser/indexed_vars_test.go
+++ b/sql/parser/indexed_vars_test.go
@@ -23,7 +23,7 @@ import (
 
 type testVarContainer []Datum
 
-func (d testVarContainer) IndexedVarEval(idx int, ctx EvalContext) (Datum, error) {
+func (d testVarContainer) IndexedVarEval(idx int, ctx *EvalContext) (Datum, error) {
 	return d[idx].Eval(ctx)
 }
 
@@ -74,7 +74,7 @@ func TestIndexedVars(t *testing.T) {
 	if !d.TypeEqual(TypeInt) {
 		t.Errorf("invalid expression type %s", d.Type())
 	}
-	d, err = typedExpr.Eval(defaultEvalContext)
+	d, err = typedExpr.Eval(&EvalContext{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sql/parser/normalize.go
+++ b/sql/parser/normalize.go
@@ -322,7 +322,7 @@ func (expr *RangeCond) normalize(v *normalizeVisitor) TypedExpr {
 //   a + 1 = 2             -> a = 1
 //   a BETWEEN b AND c     -> (a >= b) AND (a <= c)
 //   a NOT BETWEEN b AND c -> (a < b) OR (a > c)
-func (ctx EvalContext) NormalizeExpr(typedExpr TypedExpr) (TypedExpr, error) {
+func (ctx *EvalContext) NormalizeExpr(typedExpr TypedExpr) (TypedExpr, error) {
 	v := normalizeVisitor{ctx: ctx}
 	expr, _ := WalkExpr(&v, typedExpr)
 	if v.err != nil {
@@ -332,7 +332,7 @@ func (ctx EvalContext) NormalizeExpr(typedExpr TypedExpr) (TypedExpr, error) {
 }
 
 type normalizeVisitor struct {
-	ctx EvalContext
+	ctx *EvalContext
 	err error
 
 	isConstVisitor isConstVisitor

--- a/sql/parser/normalize_test.go
+++ b/sql/parser/normalize_test.go
@@ -93,7 +93,8 @@ func TestNormalizeExpr(t *testing.T) {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		rOrig := typedExpr.String()
-		r, err := defaultEvalContext.NormalizeExpr(typedExpr)
+		ctx := &EvalContext{}
+		r, err := ctx.NormalizeExpr(typedExpr)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
@@ -101,7 +102,7 @@ func TestNormalizeExpr(t *testing.T) {
 			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 		}
 		// Normalizing again should be a no-op.
-		r2, err := defaultEvalContext.NormalizeExpr(r)
+		r2, err := ctx.NormalizeExpr(r)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -119,7 +119,7 @@ func TypeCheckAndRequire(expr Expr, ctx *SemaContext, required Datum, op string)
 
 // NormalizeExpr is wrapper around ctx.NormalizeExpr which avoids allocation of
 // a normalizeVisitor.
-func (p *Parser) NormalizeExpr(ctx EvalContext, typedExpr TypedExpr) (TypedExpr, error) {
+func (p *Parser) NormalizeExpr(ctx *EvalContext, typedExpr TypedExpr) (TypedExpr, error) {
 	p.normalizeVisitor = normalizeVisitor{ctx: ctx}
 	expr, _ := WalkExpr(&p.normalizeVisitor, typedExpr)
 	if err := p.normalizeVisitor.err; err != nil {

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/inf.v0"
-
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -178,7 +176,6 @@ func (p *planner) resetForBatch(e *Executor) {
 	p.evalCtx = parser.EvalContext{
 		NodeID:   e.nodeID,
 		ReCache:  e.reCache,
-		TmpDec:   new(inf.Dec),
 		Location: &p.session.Location,
 	}
 	p.session.TxnState.schemaChangers.curGroupNum++

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -99,7 +99,7 @@ func (rh *returningHelper) cookResultRow(rowVals parser.DTuple) (parser.DTuple, 
 	rh.qvals.populateQVals(rh.table, rowVals)
 	resRow := make(parser.DTuple, len(rh.exprs))
 	for i, e := range rh.exprs {
-		d, err := e.Eval(rh.p.evalCtx)
+		d, err := e.Eval(&rh.p.evalCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -143,7 +143,7 @@ func (rh *returningHelper) TypeCheck() error {
 		if err != nil {
 			return err
 		}
-		typedExpr, err = rh.p.parser.NormalizeExpr(rh.p.evalCtx, typedExpr)
+		typedExpr, err = rh.p.parser.NormalizeExpr(&rh.p.evalCtx, typedExpr)
 		if err != nil {
 			return err
 		}

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -161,7 +161,7 @@ func (n *scanNode) debugNext() (bool, error) {
 	}
 
 	if n.row != nil {
-		passesFilter, err := sqlbase.RunFilter(n.filter, n.p.evalCtx)
+		passesFilter, err := sqlbase.RunFilter(n.filter, &n.p.evalCtx)
 		if err != nil {
 			return false, err
 		}
@@ -196,7 +196,7 @@ func (n *scanNode) Next() (bool, error) {
 		if err != nil || n.row == nil {
 			return false, err
 		}
-		passesFilter, err := sqlbase.RunFilter(n.filter, n.p.evalCtx)
+		passesFilter, err := sqlbase.RunFilter(n.filter, &n.p.evalCtx)
 		if err != nil {
 			return false, err
 		}
@@ -344,7 +344,7 @@ func (n *scanNode) computeOrdering(
 // scanNode implements parser.IndexedVarContainer.
 var _ parser.IndexedVarContainer = &scanNode{}
 
-func (n *scanNode) IndexedVarEval(idx int, ctx parser.EvalContext) (parser.Datum, error) {
+func (n *scanNode) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.Datum, error) {
 	return n.row[idx].Eval(ctx)
 }
 

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -41,6 +42,7 @@ type SchemaChanger struct {
 	nodeID     roachpb.NodeID
 	db         client.DB
 	leaseMgr   *LeaseManager
+	evalCtx    parser.EvalContext
 	// The SchemaChangeManager can attempt to execute this schema
 	// changer after this time.
 	execAfter time.Time

--- a/sql/select.go
+++ b/sql/select.go
@@ -164,7 +164,7 @@ func (s *selectNode) Next() (bool, error) {
 		}
 		row := s.source.plan.Values()
 		s.qvals.populateQVals(&s.source.info, row)
-		passesFilter, err := sqlbase.RunFilter(s.filter, s.planner.evalCtx)
+		passesFilter, err := sqlbase.RunFilter(s.filter, &s.planner.evalCtx)
 		if err != nil {
 			return false, err
 		}
@@ -554,7 +554,7 @@ func (s *selectNode) initWhere(where *parser.Where) error {
 
 	// Normalize the expression (this will also evaluate any branches that are
 	// constant).
-	s.filter, err = s.planner.parser.NormalizeExpr(s.planner.evalCtx, s.filter)
+	s.filter, err = s.planner.parser.NormalizeExpr(&s.planner.evalCtx, s.filter)
 	if err != nil {
 		return err
 	}
@@ -653,7 +653,7 @@ func (s *selectNode) addRender(target parser.SelectExpr, desiredType parser.Datu
 		return err
 	}
 
-	normalized, err := s.planner.parser.NormalizeExpr(s.planner.evalCtx, typedResolved)
+	normalized, err := s.planner.parser.NormalizeExpr(&s.planner.evalCtx, typedResolved)
 	if err != nil {
 		return err
 	}
@@ -679,7 +679,7 @@ func (s *selectNode) renderRow() error {
 	}
 	for i, e := range s.render {
 		var err error
-		s.row[i], err = e.Eval(s.planner.evalCtx)
+		s.row[i], err = e.Eval(&s.planner.evalCtx)
 		if err != nil {
 			return err
 		}

--- a/sql/select_qvalue.go
+++ b/sql/select_qvalue.go
@@ -120,7 +120,7 @@ func (q *qvalue) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.
 }
 
 // Eval implements the TypedExpr interface.
-func (q *qvalue) Eval(ctx parser.EvalContext) (parser.Datum, error) {
+func (q *qvalue) Eval(ctx *parser.EvalContext) (parser.Datum, error) {
 	return q.datum.Eval(ctx)
 }
 
@@ -292,7 +292,7 @@ func (s *starDatum) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (pars
 }
 
 // Eval implements the TypedExpr interface.
-func (*starDatum) Eval(ctx parser.EvalContext) (parser.Datum, error) {
+func (*starDatum) Eval(ctx *parser.EvalContext) (parser.Datum, error) {
 	return parser.TypeInt.Eval(ctx)
 }
 

--- a/sql/set.go
+++ b/sql/set.go
@@ -88,7 +88,7 @@ func (p *planner) getStringVal(name string, values []parser.TypedExpr) (string, 
 	if len(values) != 1 {
 		return "", fmt.Errorf("%s: requires a single string value", name)
 	}
-	val, err := values[0].Eval(p.evalCtx)
+	val, err := values[0].Eval(&p.evalCtx)
 	if err != nil {
 		return "", err
 	}
@@ -117,7 +117,7 @@ func (p *planner) SetTimeZone(n *parser.SetTimeZone) (planNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	d, err := typedValue.Eval(p.evalCtx)
+	d, err := typedValue.Eval(&p.evalCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/sqlbase/expr_filter.go
+++ b/sql/sqlbase/expr_filter.go
@@ -20,7 +20,7 @@ package sqlbase
 import "github.com/cockroachdb/cockroach/sql/parser"
 
 // RunFilter runs a filter expression and returns whether the filter passes.
-func RunFilter(filter parser.TypedExpr, evalCtx parser.EvalContext) (bool, error) {
+func RunFilter(filter parser.TypedExpr, evalCtx *parser.EvalContext) (bool, error) {
 	if filter == nil {
 		return true, nil
 	}

--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -93,7 +93,7 @@ func (s *subquery) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parse
 
 func (s *subquery) ReturnType() parser.Datum { return s.typ }
 
-func (s *subquery) Eval(_ parser.EvalContext) (parser.Datum, error) {
+func (s *subquery) Eval(_ *parser.EvalContext) (parser.Datum, error) {
 	if s.err != nil {
 		return nil, s.err
 	}

--- a/sql/update.go
+++ b/sql/update.go
@@ -145,7 +145,7 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 		return nil, err
 	}
 
-	defaultExprs, err := makeDefaultExprs(updateCols, &p.parser, p.evalCtx)
+	defaultExprs, err := makeDefaultExprs(updateCols, &p.parser, &p.evalCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ func (u *updateNode) Next() (bool, error) {
 
 	u.checkHelper.loadRow(u.tw.ru.fetchColIDtoRowIndex, oldValues, false)
 	u.checkHelper.loadRow(u.updateColsIdx, updateValues, true)
-	if err := u.checkHelper.check(u.p.evalCtx); err != nil {
+	if err := u.checkHelper.check(&u.p.evalCtx); err != nil {
 		return false, err
 	}
 

--- a/sql/upsert.go
+++ b/sql/upsert.go
@@ -47,7 +47,7 @@ func (p *planner) makeUpsertHelper(
 	updateExprs parser.UpdateExprs,
 	upsertConflictIndex *sqlbase.IndexDescriptor,
 ) (*upsertHelper, error) {
-	defaultExprs, err := makeDefaultExprs(updateCols, &p.parser, p.evalCtx)
+	defaultExprs, err := makeDefaultExprs(updateCols, &p.parser, &p.evalCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (p *planner) makeUpsertHelper(
 			return nil, err
 		}
 
-		normExpr, err := p.parser.NormalizeExpr(p.evalCtx, typedExpr)
+		normExpr, err := p.parser.NormalizeExpr(&p.evalCtx, typedExpr)
 		if err != nil {
 			return nil, err
 		}
@@ -160,7 +160,7 @@ func (uh *upsertHelper) eval(
 	var err error
 	ret := make([]parser.Datum, len(uh.evalExprs))
 	for i, evalExpr := range uh.evalExprs {
-		ret[i], err = evalExpr.Eval(uh.p.evalCtx)
+		ret[i], err = evalExpr.Eval(&uh.p.evalCtx)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/values.go
+++ b/sql/values.go
@@ -81,7 +81,7 @@ func (p *planner) ValuesClause(n *parser.ValuesClause, desiredTypes []parser.Dat
 			if err != nil {
 				return nil, err
 			}
-			typedExpr, err = p.parser.NormalizeExpr(p.evalCtx, typedExpr)
+			typedExpr, err = p.parser.NormalizeExpr(&p.evalCtx, typedExpr)
 			if err != nil {
 				return nil, err
 			}
@@ -145,7 +145,7 @@ func (n *valuesNode) Start() error {
 			}
 
 			var err error
-			row[i], err = typedExpr.Eval(n.p.evalCtx)
+			row[i], err = typedExpr.Eval(&n.p.evalCtx)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #6809.

This change switches all occurrences of passing `EvalContext` as a value
with passing it as a reference. This opens up more options around how we
can use the context. It was also such a big struct being passed around,
that passing it as a pointer instead gives a small perf boost.

```
name                    old time/op    new time/op    delta
Select1_Cockroach-4       56.1µs ± 2%    55.1µs ± 3%  -1.85%  (p=0.005 n=10+10)
Select2_Cockroach-4        828µs ± 2%     821µs ± 2%    ~     (p=0.165 n=10+10)
Select3_Cockroach-4       1.11ms ± 1%    1.10ms ± 3%    ~      (p=0.083 n=8+10)
Insert1_Cockroach-4        485µs ± 3%     477µs ± 3%    ~      (p=0.068 n=8+10)
Insert10_Cockroach-4       683µs ± 4%     671µs ± 2%    ~     (p=0.052 n=10+10)
Insert100_Cockroach-4     2.22ms ± 2%    2.19ms ± 3%    ~     (p=0.075 n=10+10)
Insert1000_Cockroach-4    16.5ms ± 2%    16.2ms ± 1%  -1.81%    (p=0.001 n=9+9)
Update1_Cockroach-4        751µs ± 4%     754µs ± 4%    ~      (p=0.780 n=9+10)
Update10_Cockroach-4      1.27ms ± 5%    1.28ms ± 2%    ~     (p=0.684 n=10+10)
Update100_Cockroach-4     5.49ms ± 6%    5.38ms ± 3%    ~      (p=0.182 n=9+10)
Update1000_Cockroach-4    43.3ms ± 5%    42.8ms ± 5%    ~     (p=0.315 n=10+10)
Delete1_Cockroach-4        830µs ± 5%     803µs ± 5%  -3.21%    (p=0.014 n=9+9)
Delete10_Cockroach-4      1.41ms ± 4%    1.38ms ± 3%  -2.60%  (p=0.029 n=10+10)
Delete100_Cockroach-4     6.60ms ± 5%    6.46ms ± 5%    ~     (p=0.247 n=10+10)
Delete1000_Cockroach-4    66.0ms ± 9%    66.5ms ± 5%    ~      (p=0.661 n=10+9)

name                    old alloc/op   new alloc/op   delta
Select1_Cockroach-4       2.80kB ± 0%    2.75kB ± 0%  -1.75%  (p=0.000 n=10+10)
Select2_Cockroach-4       98.6kB ± 0%    98.6kB ± 0%  -0.04%   (p=0.002 n=10+9)
Select3_Cockroach-4        141kB ± 0%     141kB ± 0%  -0.16%   (p=0.000 n=10+9)
Insert1_Cockroach-4       24.8kB ± 0%    24.7kB ± 0%  -0.20%   (p=0.000 n=9+10)
Insert10_Cockroach-4      69.3kB ± 0%    69.2kB ± 0%  -0.08%  (p=0.000 n=10+10)
Insert100_Cockroach-4      462kB ± 0%     462kB ± 0%    ~      (p=0.780 n=9+10)
Insert1000_Cockroach-4    4.05MB ± 0%    4.05MB ± 0%    ~      (p=0.661 n=9+10)
Update1_Cockroach-4       50.6kB ± 0%    50.5kB ± 0%  -0.10%  (p=0.000 n=10+10)
Update10_Cockroach-4       124kB ± 0%     124kB ± 0%  -0.04%    (p=0.000 n=8+9)
Update100_Cockroach-4      817kB ± 0%     817kB ± 0%  -0.01%    (p=0.000 n=9+9)
Update1000_Cockroach-4    6.88MB ± 0%    6.90MB ± 0%    ~      (p=0.274 n=8+10)
Delete1_Cockroach-4       44.0kB ± 0%    44.0kB ± 0%  -0.14%    (p=0.000 n=9+9)
Delete10_Cockroach-4      71.5kB ± 0%    71.5kB ± 0%  -0.06%   (p=0.017 n=9+10)
Delete100_Cockroach-4      336kB ± 0%     336kB ± 0%  -0.07%   (p=0.005 n=10+8)
Delete1000_Cockroach-4    3.55MB ± 2%    3.56MB ± 1%    ~     (p=0.971 n=10+10)

name                    old allocs/op  new allocs/op  delta
Select1_Cockroach-4         52.0 ± 0%      51.0 ± 0%  -1.92%  (p=0.000 n=10+10)
Select2_Cockroach-4        1.42k ± 0%     1.42k ± 0%  -0.07%   (p=0.000 n=10+8)
Select3_Cockroach-4        2.27k ± 0%     2.27k ± 0%  -0.09%   (p=0.000 n=10+9)
Insert1_Cockroach-4          269 ± 0%       267 ± 0%  -0.48%  (p=0.001 n=10+10)
Insert10_Cockroach-4         486 ± 0%       485 ± 0%  -0.21%  (p=0.001 n=10+10)
Insert100_Cockroach-4      2.41k ± 0%     2.41k ± 0%    ~      (p=0.059 n=9+10)
Insert1000_Cockroach-4     21.4k ± 0%     21.4k ± 0%    ~     (p=0.753 n=10+10)
Update1_Cockroach-4          636 ± 0%       635 ± 0%  -0.16%  (p=0.000 n=10+10)
Update10_Cockroach-4       1.02k ± 0%     1.02k ± 0%  -0.09%   (p=0.000 n=8+10)
Update100_Cockroach-4      4.54k ± 0%     4.54k ± 0%  -0.02%    (p=0.000 n=9+9)
Update1000_Cockroach-4     37.4k ± 0%     37.4k ± 0%    ~      (p=0.704 n=8+10)
Delete1_Cockroach-4          518 ± 0%       517 ± 0%  -0.19%    (p=0.000 n=9+9)
Delete10_Cockroach-4         772 ± 0%       771 ± 0%  -0.13%   (p=0.000 n=9+10)
Delete100_Cockroach-4      3.14k ± 0%     3.14k ± 0%  -0.08%   (p=0.000 n=10+9)
Delete1000_Cockroach-4     26.7k ± 1%     26.8k ± 0%    ~     (p=0.912 n=10+10)
```

cc. @seiflotfy

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6931)

<!-- Reviewable:end -->
