### PR TITLE
sql: removed redundant error stored in plan nodes

### DIFF
--- a/sql/scan.go
+++ b/sql/scan.go
@@ -56,7 +56,6 @@ type scanNode struct {
 	isSecondaryIndex bool
 	reverse          bool
 	ordering         orderingInfo
-	err              error
 
 	explain   explainMode
 	rowIndex  int // the index of the current row
@@ -128,10 +127,8 @@ func (n *scanNode) Start() error {
 	return n.p.startSubqueryPlans(n.filter)
 }
 
-// initScan sets up the rowFetcher and starts a scan. On error, sets n.err and
-// returns false.
-func (n *scanNode) initScan() (success bool) {
-
+// initScan sets up the rowFetcher and starts a scan.
+func (n *scanNode) initScan() (err error) {
 	if len(n.spans) == 0 {
 		// If no spans were specified retrieve all of the keys that start with our
 		// index key prefix. This isn't needed for the fetcher, but it is for
@@ -145,28 +142,28 @@ func (n *scanNode) initScan() (success bool) {
 		// Read a multiple of the limit if the limit is "soft".
 		limitHint *= 2
 	}
-	n.err = n.fetcher.StartScan(n.p.txn, n.spans, limitHint)
-	if n.err != nil {
-		return false
+
+	if err := n.fetcher.StartScan(n.p.txn, n.spans, limitHint); err != nil {
+		return err
 	}
 	n.scanInitialized = true
-	return true
+	return nil
 }
 
 // debugNext is a helper function used by Next() when in explainDebug mode.
 func (n *scanNode) debugNext() (bool, error) {
 	// In debug mode, we output a set of debug values for each key.
 	n.debugVals.rowIdx = n.rowIndex
-	n.debugVals.key, n.debugVals.value, n.row, n.err = n.fetcher.NextKeyDebug()
-	if n.err != nil || n.debugVals.key == "" {
-		return false, n.err
+	var err error
+	n.debugVals.key, n.debugVals.value, n.row, err = n.fetcher.NextKeyDebug()
+	if err != nil || n.debugVals.key == "" {
+		return false, err
 	}
 
 	if n.row != nil {
 		passesFilter, err := sqlbase.RunFilter(n.filter, n.p.evalCtx)
 		if err != nil {
-			n.err = err
-			return false, n.err
+			return false, err
 		}
 		if passesFilter {
 			n.debugVals.output = debugValueRow
@@ -182,14 +179,10 @@ func (n *scanNode) debugNext() (bool, error) {
 
 func (n *scanNode) Next() (bool, error) {
 	tracing.AnnotateTrace()
-
-	if n.err != nil {
-		return false, n.err
-	}
-
-	if !n.scanInitialized && !n.initScan() {
-		// Hit error during initScan
-		return false, nil
+	if !n.scanInitialized {
+		if err := n.initScan(); err != nil {
+			return false, nil
+		}
 	}
 
 	if n.explain == explainDebug {
@@ -198,14 +191,14 @@ func (n *scanNode) Next() (bool, error) {
 
 	// We fetch one row at a time until we find one that passes the filter.
 	for {
-		n.row, n.err = n.fetcher.NextRow()
-		if n.err != nil || n.row == nil {
-			return false, n.err
+		var err error
+		n.row, err = n.fetcher.NextRow()
+		if err != nil || n.row == nil {
+			return false, err
 		}
 		passesFilter, err := sqlbase.RunFilter(n.filter, n.p.evalCtx)
 		if err != nil {
-			n.err = err
-			return false, n.err
+			return false, err
 		}
 		if passesFilter {
 			return true, nil
@@ -252,8 +245,7 @@ func (n *scanNode) initTable(
 	var err error
 	n.desc, err = p.getTableLease(tableName)
 	if err != nil {
-		n.err = err
-		return "", n.err
+		return "", err
 	}
 
 	if err := p.checkPrivilege(&n.desc, privilege.SELECT); err != nil {
@@ -274,8 +266,7 @@ func (n *scanNode) initTable(
 				}
 			}
 			if n.specifiedIndex == nil {
-				n.err = fmt.Errorf("index \"%s\" not found", indexName)
-				return "", n.err
+				return "", fmt.Errorf("index \"%s\" not found", indexName)
 			}
 		}
 	}

--- a/sql/union.go
+++ b/sql/union.go
@@ -80,7 +80,6 @@ func (p *planner) UnionClause(n *parser.UnionClause, desiredTypes []parser.Datum
 	}
 
 	node := &unionNode{
-		err:       nil,
 		right:     right,
 		left:      left,
 		rightDone: false,
@@ -127,7 +126,6 @@ func (p *planner) UnionClause(n *parser.UnionClause, desiredTypes []parser.Datum
 //    decrement the entry. Otherwise, the row was on the right, but we've
 //    already emitted as many as were on the right, don't emit.
 type unionNode struct {
-	err         error
 	right, left planNode
 	rightDone   bool
 	leftDone    bool
@@ -190,8 +188,8 @@ func (n *unionNode) readRight() (bool, error) {
 			return true, nil
 		}
 		n.scratch = n.scratch[:0]
-		if n.scratch, n.err = sqlbase.EncodeDTuple(n.scratch, n.right.Values()); n.err != nil {
-			return false, n.err
+		if n.scratch, err = sqlbase.EncodeDTuple(n.scratch, n.right.Values()); err != nil {
+			return false, err
 		}
 		// TODO(dan): Sending the entire encodeDTuple to be stored in the map would
 		// use a lot of memory for big rows or big resultsets. Consider using a hash
@@ -205,7 +203,7 @@ func (n *unionNode) readRight() (bool, error) {
 			return true, nil
 		}
 	}
-	if n.err = err; err != nil {
+	if err != nil {
 		return false, err
 	}
 
@@ -228,8 +226,8 @@ func (n *unionNode) readLeft() (bool, error) {
 			return true, nil
 		}
 		n.scratch = n.scratch[:0]
-		if n.scratch, n.err = sqlbase.EncodeDTuple(n.scratch, n.left.Values()); n.err != nil {
-			return false, n.err
+		if n.scratch, err = sqlbase.EncodeDTuple(n.scratch, n.left.Values()); err != nil {
+			return false, err
 		}
 		if n.emit.emitLeft(n.scratch) {
 			return true, nil
@@ -240,7 +238,7 @@ func (n *unionNode) readLeft() (bool, error) {
 			return true, nil
 		}
 	}
-	if n.err = err; err != nil {
+	if err != nil {
 		return false, err
 	}
 	n.leftDone = true


### PR DESCRIPTION
Also removed done boolean from editNodeRun

the error boolean is still in group.go and subquery.go . I'll see what I can do with those later.
#6921

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6934)

<!-- Reviewable:end -->
