### PR TITLE
sql: vocabulary improvements in the source code

### DIFF
--- a/sql/distsql/data.pb.go
+++ b/sql/distsql/data.pb.go
@@ -69,7 +69,7 @@ func (OutputRouterSpec_Type) EnumDescriptor() ([]byte, []int) { return fileDescr
 type Expression struct {
 	// TODO(radu): TBD how this will be used
 	Version string `protobuf:"bytes,1,opt,name=version" json:"version"`
-	// SQL expressions are passed as a string, with ValArgs ($0, $1, ..) used for
+	// SQL expressions are passed as a string, with Placeholders ($1, $2 ..) used for
 	// "input" variables.
 	Expr string `protobuf:"bytes,2,opt,name=expr" json:"expr"`
 }

--- a/sql/distsql/data.proto
+++ b/sql/distsql/data.proto
@@ -31,7 +31,7 @@ message Expression {
   // TODO(radu): TBD how this will be used
   optional string version = 1 [(gogoproto.nullable) = false];
 
-  // SQL expressions are passed as a string, with ValArgs ($0, $1, ..) used for
+  // SQL expressions are passed as a string, with Placeholders ($1, $2 ..) used for
   // "input" variables.
   optional string expr = 2 [(gogoproto.nullable) = false];
 }

--- a/sql/distsql/expr.go
+++ b/sql/distsql/expr.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 )
 
-// valArgsConvert is a parser.Visitor that converts ValArgs ($0, $1, etc.) to
+// valArgsConvert is a parser.Visitor that converts Placeholders ($0, $1, etc.) to
 // IndexedVars.
 type valArgsConvert struct {
 	h   *parser.IndexedVarHelper
@@ -31,7 +31,7 @@ type valArgsConvert struct {
 }
 
 func (v *valArgsConvert) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
-	if val, ok := expr.(parser.ValArg); ok {
+	if val, ok := expr.(parser.Placeholder); ok {
 		idx, err := strconv.Atoi(val.Name)
 		if err != nil || idx < 0 || idx >= v.h.NumVars() {
 			v.err = util.Errorf("invalid variable index %s", val.Name)
@@ -53,7 +53,7 @@ func processExpression(exprSpec Expression, h *parser.IndexedVarHelper) (parser.
 		return nil, err
 	}
 
-	// Convert ValArgs to IndexedVars
+	// Convert Placeholders to IndexedVars
 	v := valArgsConvert{h: h, err: nil}
 	expr, _ = parser.WalkExpr(&v, expr)
 	if v.err != nil {

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -1132,7 +1132,7 @@ func checkResultDatum(datum parser.Datum) error {
 	case *parser.DTimestamp:
 	case *parser.DTimestampTZ:
 	case *parser.DInterval:
-	case *parser.DValArg:
+	case *parser.DPlaceholder:
 		return fmt.Errorf("could not determine data type of %s %s", datum.Type(), datum)
 	default:
 		return util.Errorf("unsupported result type: %s", datum.Type())

--- a/sql/expr_filter.go
+++ b/sql/expr_filter.go
@@ -72,8 +72,8 @@ func (v *varConvertVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pa
 	}
 
 	if varExpr, ok := expr.(parser.VariableExpr); ok {
-		// Ignore ValArgs
-		if _, isValArg := expr.(parser.ValArg); isValArg {
+		// Ignore Placeholders
+		if _, isPlaceholder := expr.(parser.Placeholder); isPlaceholder {
 			return false, expr
 		}
 		// Ignore sub-queries

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -150,7 +150,7 @@ func (p *planner) Insert(
 				if err != nil {
 					return nil, err
 				}
-				err = sqlbase.CheckColumnType(cols[eIdx], typedExpr.ReturnType(), p.semaCtx.Args)
+				err = sqlbase.CheckColumnType(cols[eIdx], typedExpr.ReturnType(), p.semaCtx.PlaceholderTypes)
 				if err != nil {
 					return nil, err
 				}

--- a/sql/internal.go
+++ b/sql/internal.go
@@ -39,13 +39,13 @@ var _ sqlutil.InternalExecutor = InternalExecutor{}
 // ExecuteStatementInTransaction executes the supplied SQL statement as part of
 // the supplied transaction. Statements are currently executed as the root user.
 func (ie InternalExecutor) ExecuteStatementInTransaction(
-	txn *client.Txn, statement string, params ...interface{},
+	txn *client.Txn, statement string, qargs ...interface{},
 ) (int, error) {
 	p := makePlanner()
 	p.setTxn(txn)
 	p.session.User = security.RootUser
 	p.leaseMgr = ie.LeaseManager
-	return p.exec(statement, params...)
+	return p.exec(statement, qargs...)
 }
 
 // GetTableSpan gets the key span for a SQL table, including any indices.

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -1319,16 +1319,16 @@ func (dNull) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("NULL")
 }
 
-var _ VariableExpr = &DValArg{}
+var _ VariableExpr = &DPlaceholder{}
 
-// DValArg is the named bind var argument Datum.
-type DValArg struct {
+// DPlaceholder is the named bind var argument Datum.
+type DPlaceholder struct {
 	name string
 	typeAnnotation
 }
 
 // ReturnType implements the TypedExpr interface.
-func (d *DValArg) ReturnType() Datum {
+func (d *DPlaceholder) ReturnType() Datum {
 	if d.typeAnnotation.typ != nil {
 		return d.typeAnnotation.typ
 	}
@@ -1336,56 +1336,56 @@ func (d *DValArg) ReturnType() Datum {
 }
 
 // Variable implements the VariableExpr interface.
-func (*DValArg) Variable() {}
+func (*DPlaceholder) Variable() {}
 
 // Type implements the Datum interface.
-func (*DValArg) Type() string {
+func (*DPlaceholder) Type() string {
 	return "parameter"
 }
 
 // TypeEqual implements the Datum interface.
-func (d *DValArg) TypeEqual(other Datum) bool {
-	_, ok := other.(*DValArg)
+func (d *DPlaceholder) TypeEqual(other Datum) bool {
+	_, ok := other.(*DPlaceholder)
 	return ok
 }
 
 // Compare implements the Datum interface.
-func (d *DValArg) Compare(other Datum) int {
+func (d *DPlaceholder) Compare(other Datum) int {
 	panic(d.Type() + ".Compare not supported")
 }
 
 // HasPrev implements the Datum interface.
-func (*DValArg) HasPrev() bool {
+func (*DPlaceholder) HasPrev() bool {
 	return false
 }
 
 // Prev implements the Datum interface.
-func (d *DValArg) Prev() Datum {
+func (d *DPlaceholder) Prev() Datum {
 	panic(d.Type() + ".Prev not supported")
 }
 
 // HasNext implements the Datum interface.
-func (*DValArg) HasNext() bool {
+func (*DPlaceholder) HasNext() bool {
 	return false
 }
 
 // Next implements the Datum interface.
-func (d *DValArg) Next() Datum {
+func (d *DPlaceholder) Next() Datum {
 	panic(d.Type() + ".Next not supported")
 }
 
 // IsMax implements the Datum interface.
-func (*DValArg) IsMax() bool {
+func (*DPlaceholder) IsMax() bool {
 	return true
 }
 
 // IsMin implements the Datum interface.
-func (*DValArg) IsMin() bool {
+func (*DPlaceholder) IsMin() bool {
 	return true
 }
 
 // Format implements the NodeFormatter interface.
-func (d *DValArg) Format(buf *bytes.Buffer, f FmtFlags) {
+func (d *DPlaceholder) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteByte('$')
 	buf.WriteString(d.name)
 }

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -1340,7 +1340,7 @@ func (*DPlaceholder) Variable() {}
 
 // Type implements the Datum interface.
 func (*DPlaceholder) Type() string {
-	return "parameter"
+	return "placeholder"
 }
 
 // TypeEqual implements the Datum interface.

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -1928,7 +1928,7 @@ func (t *DTuple) Eval(_ EvalContext) (Datum, error) {
 }
 
 // Eval implements the Expr interface.
-func (t *DValArg) Eval(_ EvalContext) (Datum, error) {
+func (t *DPlaceholder) Eval(_ EvalContext) (Datum, error) {
 	return t, nil
 }
 

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -48,9 +48,9 @@ type TypedExpr interface {
 	// straightforward walk over the parse tree. The only significant complexity is
 	// the handling of types and implicit conversions. See binOps and cmpOps for
 	// more details. Note that expression evaluation returns an error if certain
-	// node types are encountered: ValArg, QualifiedName or Subquery. These nodes
+	// node types are encountered: Placeholder, QualifiedName or Subquery. These nodes
 	// should be replaced prior to expression evaluation by an appropriate
-	// WalkExpr. For example, ValArg should be replace by the argument passed from
+	// WalkExpr. For example, Placeholder should be replace by the argument passed from
 	// the client.
 	Eval(EvalContext) (Datum, error)
 	// ReturnType provides the type of the TypedExpr, which is the type of Datum that
@@ -499,18 +499,18 @@ func (node DefaultVal) Format(buf *bytes.Buffer, f FmtFlags) {
 // ReturnType implements the TypedExpr interface.
 func (DefaultVal) ReturnType() Datum { return nil }
 
-var _ VariableExpr = ValArg{}
+var _ VariableExpr = Placeholder{}
 
-// ValArg represents a named bind var argument.
-type ValArg struct {
+// Placeholder represents a named bind var argument.
+type Placeholder struct {
 	Name string
 }
 
 // Variable implements the VariableExpr interface.
-func (ValArg) Variable() {}
+func (Placeholder) Variable() {}
 
 // Format implements the NodeFormatter interface.
-func (node ValArg) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node Placeholder) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteByte('$')
 	buf.WriteString(node.Name)
 }
@@ -1169,7 +1169,7 @@ func (node *DString) String() string          { return AsString(node) }
 func (node *DTimestamp) String() string       { return AsString(node) }
 func (node *DTimestampTZ) String() string     { return AsString(node) }
 func (node *DTuple) String() string           { return AsString(node) }
-func (node *DValArg) String() string          { return AsString(node) }
+func (node *DPlaceholder) String() string     { return AsString(node) }
 func (node *ExistsExpr) String() string       { return AsString(node) }
 func (node Exprs) String() string             { return AsString(node) }
 func (node *FuncExpr) String() string         { return AsString(node) }
@@ -1190,6 +1190,6 @@ func (node *Subquery) String() string         { return AsString(node) }
 func (node *Tuple) String() string            { return AsString(node) }
 func (node *UnaryExpr) String() string        { return AsString(node) }
 func (node DefaultVal) String() string        { return AsString(node) }
-func (node ValArg) String() string            { return AsString(node) }
+func (node Placeholder) String() string       { return AsString(node) }
 func (node dNull) String() string             { return AsString(node) }
 func (list NameList) String() string          { return AsString(list) }

--- a/sql/parser/overload.go
+++ b/sql/parser/overload.go
@@ -195,7 +195,7 @@ func typeCheckOverloadedExprs(
 		}
 	}
 
-	// defaultTypeCheck type checks the constant and valArg expressions without a preference
+	// defaultTypeCheck type checks the constant and placeholder expressions without a preference
 	// and adds them to the type checked slice.
 	defaultTypeCheck := func(errorOnArgs bool) error {
 		for _, expr := range constExprs {

--- a/sql/parser/overload.go
+++ b/sql/parser/overload.go
@@ -207,11 +207,11 @@ func typeCheckOverloadedExprs(
 		}
 		for _, expr := range valExprs {
 			if errorOnArgs {
-				_, err := expr.e.(ValArg).TypeCheck(ctx, nil)
+				_, err := expr.e.(Placeholder).TypeCheck(ctx, nil)
 				return err
 			}
 			// If we dont want to error on args, avoid type checking them without a desired type.
-			typedExprs[expr.i] = &DValArg{name: expr.e.(ValArg).Name}
+			typedExprs[expr.i] = &DPlaceholder{name: expr.e.(Placeholder).Name}
 		}
 		return nil
 	}

--- a/sql/parser/overload_test.go
+++ b/sql/parser/overload_test.go
@@ -76,7 +76,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	binaryIntDateFn := makeTestOverload(TypeDate, TypeInt, TypeDate)
 
 	testData := []struct {
-		args             MapArgs
+		ptypes           MapPlaceholderTypes
 		desired          Datum
 		exprs            []Expr
 		overloads        []overloadImpl
@@ -139,7 +139,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, TypeDate, []Expr{decConst("1.0"), Placeholder{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn},
 	}
 	for i, d := range testData {
-		ctx := SemaContext{Args: d.args}
+		ctx := SemaContext{PlaceholderTypes: d.ptypes}
 		_, fn, err := typeCheckOverloadedExprs(&ctx, d.desired, d.overloads, d.exprs...)
 		if d.expectedOverload != nil {
 			if err != nil {

--- a/sql/parser/overload_test.go
+++ b/sql/parser/overload_test.go
@@ -89,9 +89,9 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, nil, []Expr{intConst("1")}, []overloadImpl{unaryIntFn, binaryIntFn}, unaryIntFn},
 		{nil, nil, []Expr{intConst("1")}, []overloadImpl{unaryFloatFn, unaryStringFn}, unaryFloatFn},
 		{nil, nil, []Expr{intConst("1")}, []overloadImpl{unaryStringFn, binaryIntFn}, nil},
-		// Unary unresolved ValArgs.
-		{nil, nil, []Expr{ValArg{"a"}}, []overloadImpl{unaryStringFn, unaryIntFn}, nil},
-		{nil, nil, []Expr{ValArg{"a"}}, []overloadImpl{unaryStringFn, binaryIntFn}, unaryStringFn},
+		// Unary unresolved Placeholders.
+		{nil, nil, []Expr{Placeholder{"a"}}, []overloadImpl{unaryStringFn, unaryIntFn}, nil},
+		{nil, nil, []Expr{Placeholder{"a"}}, []overloadImpl{unaryStringFn, binaryIntFn}, unaryStringFn},
 		// Unary values (not constants).
 		{nil, nil, []Expr{NewDInt(1)}, []overloadImpl{unaryIntFn, unaryFloatFn}, unaryIntFn},
 		{nil, nil, []Expr{NewDFloat(1)}, []overloadImpl{unaryIntFn, unaryFloatFn}, unaryFloatFn},
@@ -102,12 +102,12 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		// Binary constants.
 		{nil, nil, []Expr{intConst("1"), intConst("1")}, []overloadImpl{binaryIntFn, binaryFloatFn, unaryIntFn}, binaryIntFn},
 		{nil, nil, []Expr{intConst("1"), decConst("1.0")}, []overloadImpl{binaryIntFn, binaryDecimalFn, unaryDecimalFn}, binaryDecimalFn},
-		// Binary unresolved ValArgs.
-		{nil, nil, []Expr{ValArg{"a"}, ValArg{"b"}}, []overloadImpl{binaryIntFn, binaryFloatFn}, nil},
-		{nil, nil, []Expr{ValArg{"a"}, ValArg{"b"}}, []overloadImpl{binaryIntFn, unaryStringFn}, binaryIntFn},
-		{nil, nil, []Expr{ValArg{"a"}, NewDString("a")}, []overloadImpl{binaryIntFn, binaryStringFn}, binaryStringFn},
-		{nil, nil, []Expr{ValArg{"a"}, intConst("1")}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryIntFn},
-		{nil, nil, []Expr{ValArg{"a"}, intConst("1")}, []overloadImpl{binaryStringFn, binaryFloatFn}, binaryFloatFn},
+		// Binary unresolved Placeholders.
+		{nil, nil, []Expr{Placeholder{"a"}, Placeholder{"b"}}, []overloadImpl{binaryIntFn, binaryFloatFn}, nil},
+		{nil, nil, []Expr{Placeholder{"a"}, Placeholder{"b"}}, []overloadImpl{binaryIntFn, unaryStringFn}, binaryIntFn},
+		{nil, nil, []Expr{Placeholder{"a"}, NewDString("a")}, []overloadImpl{binaryIntFn, binaryStringFn}, binaryStringFn},
+		{nil, nil, []Expr{Placeholder{"a"}, intConst("1")}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryIntFn},
+		{nil, nil, []Expr{Placeholder{"a"}, intConst("1")}, []overloadImpl{binaryStringFn, binaryFloatFn}, binaryFloatFn},
 		// Binary values.
 		{nil, nil, []Expr{NewDString("a"), NewDString("b")}, []overloadImpl{binaryStringFn, binaryFloatFn, unaryFloatFn}, binaryStringFn},
 		{nil, nil, []Expr{NewDString("a"), intConst("1")}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1}, binaryStringFloatFn1},
@@ -121,7 +121,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, TypeInt, []Expr{intConst("1"), NewDFloat(1)}, []overloadImpl{binaryIntFn, binaryFloatFn, unaryFloatFn}, binaryFloatFn},
 		{nil, TypeInt, []Expr{NewDString("a"), NewDFloat(1)}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1, binaryStringFloatFn2}, binaryStringFloatFn1},
 		{nil, TypeFloat, []Expr{NewDString("a"), NewDFloat(1)}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1, binaryStringFloatFn2}, binaryStringFloatFn2},
-		{nil, TypeFloat, []Expr{ValArg{"a"}, ValArg{"b"}}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryFloatFn},
+		{nil, TypeFloat, []Expr{Placeholder{"a"}, Placeholder{"b"}}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryFloatFn},
 		// Sub-expressions.
 		{nil, nil, []Expr{decConst("1.0"), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, binaryIntFn},
 		{nil, nil, []Expr{decConst("1.1"), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, binaryDecimalFn},
@@ -129,14 +129,14 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, nil, []Expr{plus(intConst("1"), intConst("2")), plus(decConst("1.1"), decConst("2.2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, nil}, // Limitation.
 		{nil, nil, []Expr{plus(decConst("1.1"), decConst("2.2")), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, binaryDecimalFn},
 		// Homogenous preference.
-		{nil, nil, []Expr{NewDInt(1), ValArg{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn},
-		{nil, nil, []Expr{NewDFloat(1), ValArg{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, nil},
-		{nil, nil, []Expr{intConst("1"), ValArg{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn},
-		{nil, nil, []Expr{decConst("1.0"), ValArg{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, nil}, // Limitation.
-		{nil, TypeDate, []Expr{NewDInt(1), ValArg{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn},
-		{nil, TypeDate, []Expr{NewDFloat(1), ValArg{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, nil},
-		{nil, TypeDate, []Expr{intConst("1"), ValArg{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn},
-		{nil, TypeDate, []Expr{decConst("1.0"), ValArg{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn},
+		{nil, nil, []Expr{NewDInt(1), Placeholder{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn},
+		{nil, nil, []Expr{NewDFloat(1), Placeholder{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, nil},
+		{nil, nil, []Expr{intConst("1"), Placeholder{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn},
+		{nil, nil, []Expr{decConst("1.0"), Placeholder{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, nil}, // Limitation.
+		{nil, TypeDate, []Expr{NewDInt(1), Placeholder{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn},
+		{nil, TypeDate, []Expr{NewDFloat(1), Placeholder{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, nil},
+		{nil, TypeDate, []Expr{intConst("1"), Placeholder{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn},
+		{nil, TypeDate, []Expr{decConst("1.0"), Placeholder{"b"}}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn},
 	}
 	for i, d := range testData {
 		ctx := SemaContext{Args: d.args}

--- a/sql/parser/scan.go
+++ b/sql/parser/scan.go
@@ -156,19 +156,19 @@ func (s *scanner) scan(lval *sqlSymType) {
 
 	switch ch {
 	case '$':
-		// param? $[0-9]+
+		// placeholder? $[0-9]+
 		if isDigit(s.peek()) {
-			s.scanParam(lval)
+			s.scanPlaceholder(lval)
 			return
 		} else if s.syntax == Modern {
 			// TODO(pmattis): This should really be prefixed with '@', but that
 			// conflicts with using '@' for index indirection in qualified names.
 			//
-			// param? $<ident>
+			// placeholder? $<ident>
 			if t := s.peek(); isIdentStart(t) {
 				s.pos++
 				s.scanIdent(lval, t)
-				lval.id = PARAM
+				lval.id = PLACEHOLDER
 				return
 			}
 		}
@@ -567,7 +567,7 @@ func (s *scanner) scanNumber(lval *sqlSymType, ch int) {
 	}
 }
 
-func (s *scanner) scanParam(lval *sqlSymType) {
+func (s *scanner) scanPlaceholder(lval *sqlSymType) {
 	start := s.pos
 	for isDigit(s.peek()) {
 		s.pos++
@@ -587,7 +587,7 @@ func (s *scanner) scanParam(lval *sqlSymType) {
 	// uval is now in the range [0, 1<<63]. Casting to an int64 leaves the range
 	// [0, 1<<63 - 1] intact and moves 1<<63 to -1<<63 (a.k.a. math.MinInt64).
 	lval.union.val = &NumVal{Value: constant.MakeUint64(uval)}
-	lval.id = PARAM
+	lval.id = PLACEHOLDER
 }
 
 func (s *scanner) scanString(lval *sqlSymType, ch int, allowEscapes bool) bool {

--- a/sql/parser/scan_test.go
+++ b/sql/parser/scan_test.go
@@ -67,7 +67,7 @@ func TestScanner(t *testing.T) {
 		{`||`, []int{CONCAT}},
 		{`#`, []int{'#'}},
 		{`~`, []int{'~'}},
-		{`$1`, []int{PARAM}},
+		{`$1`, []int{PLACEHOLDER}},
 		{`$a`, []int{'$', IDENT}},
 		{`a`, []int{IDENT}},
 		{`foo + bar`, []int{IDENT, '+', IDENT}},
@@ -126,7 +126,7 @@ func TestScannerModern(t *testing.T) {
 		{`E'a' E"a"`, []int{SCONST, SCONST}},
 		{`r'a' r"a"`, []int{SCONST, SCONST}},
 		{`R'a' R"a"`, []int{SCONST, SCONST}},
-		{`$1 $foo $select`, []int{PARAM, PARAM, PARAM}},
+		{`$1 $foo $select`, []int{PLACEHOLDER, PLACEHOLDER, PLACEHOLDER}},
 	}
 	for i, d := range testData {
 		s := makeScanner(d.sql, Modern)
@@ -254,7 +254,7 @@ func TestScanNumber(t *testing.T) {
 	}
 }
 
-func TestScanParam(t *testing.T) {
+func TestScanPlaceholder(t *testing.T) {
 	testData := []struct {
 		sql      string
 		expected int64
@@ -267,8 +267,8 @@ func TestScanParam(t *testing.T) {
 		s := makeScanner(d.sql, Traditional)
 		var lval sqlSymType
 		id := s.Lex(&lval)
-		if id != PARAM {
-			t.Errorf("%s: expected %d, but found %d", d.sql, PARAM, id)
+		if id != PLACEHOLDER {
+			t.Errorf("%s: expected %d, but found %d", d.sql, PLACEHOLDER, id)
 		}
 		if i, err := lval.union.numVal().asInt64(); err != nil {
 			t.Errorf("%s: expected success, but found %v", d.sql, err)

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -4957,7 +4957,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1155
 		{
-			sqlVAL.union.val = ValArg{Name: sqlDollar[1].str}
+			sqlVAL.union.val = Placeholder{Name: sqlDollar[1].str}
 		}
 	case 118:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
@@ -7569,7 +7569,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:3318
 		{
-			sqlVAL.union.val = ValArg{Name: sqlDollar[1].str}
+			sqlVAL.union.val = Placeholder{Name: sqlDollar[1].str}
 		}
 	case 570:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -278,7 +278,7 @@ const SCONST = 57347
 const BCONST = 57348
 const ICONST = 57349
 const FCONST = 57350
-const PARAM = 57351
+const PLACEHOLDER = 57351
 const TYPECAST = 57352
 const DOT_DOT = 57353
 const LESS_EQUALS = 57354
@@ -543,7 +543,7 @@ var sqlToknames = [...]string{
 	"BCONST",
 	"ICONST",
 	"FCONST",
-	"PARAM",
+	"PLACEHOLDER",
 	"TYPECAST",
 	"DOT_DOT",
 	"LESS_EQUALS",

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -1153,7 +1153,7 @@ var_value:
 | numeric_only
 | PARAM
   {
-    $$.val = ValArg{Name: $1}
+    $$.val = Placeholder{Name: $1}
   }
 
 iso_level:
@@ -3316,7 +3316,7 @@ c_expr:
 | a_expr_const
 | PARAM
   {
-    $$.val = ValArg{Name: $1}
+    $$.val = Placeholder{Name: $1}
   }
 | '(' a_expr ')'
   {

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -505,7 +505,7 @@ func (u *sqlSymUnion) dropBehavior() DropBehavior {
 // errors. It is needed by PL/pgsql.
 %token <str>   IDENT SCONST BCONST
 %token <*NumVal> ICONST FCONST
-%token <str>   PARAM
+%token <str>   PLACEHOLDER
 %token <str>   TYPECAST DOT_DOT
 %token <str>   LESS_EQUALS GREATER_EQUALS NOT_EQUALS
 %token <str>   ERROR
@@ -1151,7 +1151,7 @@ var_list:
 var_value:
   opt_boolean_or_string
 | numeric_only
-| PARAM
+| PLACEHOLDER
   {
     $$.val = Placeholder{Name: $1}
   }
@@ -3314,7 +3314,7 @@ c_expr:
     $$.val = $1.qname()
   }
 | a_expr_const
-| PARAM
+| PLACEHOLDER
   {
     $$.val = Placeholder{Name: $1}
   }

--- a/sql/parser/type_check_test.go
+++ b/sql/parser/type_check_test.go
@@ -179,7 +179,7 @@ func ddecimal(f float64) copyableExpr {
 }
 func valArg(name string) copyableExpr {
 	return func() Expr {
-		return ValArg{name}
+		return Placeholder{name}
 	}
 }
 func tuple(exprs ...copyableExpr) copyableExpr {
@@ -377,38 +377,38 @@ func TestProcessPlaceholderAnnotations(t *testing.T) {
 		stmtExprs []Expr
 		desired   MapArgs
 	}{
-		{[]Expr{ValArg{"a"}}, MapArgs{}},
-		{[]Expr{ValArg{"a"}, ValArg{"b"}}, MapArgs{}},
+		{[]Expr{Placeholder{"a"}}, MapArgs{}},
+		{[]Expr{Placeholder{"a"}, Placeholder{"b"}}, MapArgs{}},
 		{[]Expr{
-			&CastExpr{Expr: ValArg{"a"}, Type: intType},
-			&CastExpr{Expr: ValArg{"a"}, Type: boolType},
+			&CastExpr{Expr: Placeholder{"a"}, Type: intType},
+			&CastExpr{Expr: Placeholder{"a"}, Type: boolType},
 		}, MapArgs{}},
 		{[]Expr{
-			&CastExpr{Expr: ValArg{"a"}, Type: intType},
-			&CastExpr{Expr: ValArg{"b"}, Type: boolType},
+			&CastExpr{Expr: Placeholder{"a"}, Type: intType},
+			&CastExpr{Expr: Placeholder{"b"}, Type: boolType},
 		}, MapArgs{
 			"a": TypeInt,
 			"b": TypeBool,
 		}},
 		{[]Expr{
-			&CastExpr{Expr: ValArg{"a"}, Type: intType},
-			&CastExpr{Expr: ValArg{"b"}, Type: boolType},
-			&CastExpr{Expr: ValArg{"a"}, Type: intType},
-			&CastExpr{Expr: ValArg{"b"}, Type: intType},
+			&CastExpr{Expr: Placeholder{"a"}, Type: intType},
+			&CastExpr{Expr: Placeholder{"b"}, Type: boolType},
+			&CastExpr{Expr: Placeholder{"a"}, Type: intType},
+			&CastExpr{Expr: Placeholder{"b"}, Type: intType},
 		}, MapArgs{
 			"a": TypeInt,
 		}},
 		{[]Expr{
-			&CastExpr{Expr: ValArg{"a"}, Type: intType},
-			&CastExpr{Expr: ValArg{"b"}, Type: boolType},
-			ValArg{"a"},
+			&CastExpr{Expr: Placeholder{"a"}, Type: intType},
+			&CastExpr{Expr: Placeholder{"b"}, Type: boolType},
+			Placeholder{"a"},
 		}, MapArgs{
 			"b": TypeBool,
 		}},
 		{[]Expr{
-			ValArg{"a"},
-			&CastExpr{Expr: ValArg{"a"}, Type: intType},
-			&CastExpr{Expr: ValArg{"b"}, Type: boolType},
+			Placeholder{"a"},
+			&CastExpr{Expr: Placeholder{"a"}, Type: intType},
+			&CastExpr{Expr: Placeholder{"b"}, Type: boolType},
 		}, MapArgs{
 			"b": TypeBool,
 		}},

--- a/sql/parser/type_check_test.go
+++ b/sql/parser/type_check_test.go
@@ -130,11 +130,11 @@ func TestTypeCheckError(t *testing.T) {
 }
 
 var (
-	mapArgsInt               = MapArgs{"a": TypeInt}
-	mapArgsDecimal           = MapArgs{"a": TypeDecimal}
-	mapArgsIntAndInt         = MapArgs{"a": TypeInt, "b": TypeInt}
-	mapArgsIntAndDecimal     = MapArgs{"a": TypeInt, "b": TypeDecimal}
-	mapArgsDecimalAndDecimal = MapArgs{"a": TypeDecimal, "b": TypeDecimal}
+	mapPTypesInt               = MapPlaceholderTypes{"a": TypeInt}
+	mapPTypesDecimal           = MapPlaceholderTypes{"a": TypeDecimal}
+	mapPTypesIntAndInt         = MapPlaceholderTypes{"a": TypeInt, "b": TypeInt}
+	mapPTypesIntAndDecimal     = MapPlaceholderTypes{"a": TypeInt, "b": TypeDecimal}
+	mapPTypesDecimalAndDecimal = MapPlaceholderTypes{"a": TypeDecimal, "b": TypeDecimal}
 )
 
 // copyableExpr can provide each test permutation with a deep copy of the expression tree.
@@ -177,7 +177,7 @@ func ddecimal(f float64) copyableExpr {
 		return dd
 	}
 }
-func valArg(name string) copyableExpr {
+func placeholder(name string) copyableExpr {
 	return func() Expr {
 		return Placeholder{name}
 	}
@@ -203,8 +203,8 @@ func forEachPerm(exprs []copyableExpr, i int, fn func([]copyableExpr)) {
 	}
 }
 
-func cloneMapArgs(args MapArgs) MapArgs {
-	clone := make(MapArgs)
+func cloneMapPlaceholderTypes(args MapPlaceholderTypes) MapPlaceholderTypes {
+	clone := make(MapPlaceholderTypes)
 	for k, v := range args {
 		clone[k] = v
 	}
@@ -212,20 +212,20 @@ func cloneMapArgs(args MapArgs) MapArgs {
 }
 
 type sameTypedExprsTestCase struct {
-	args    MapArgs
+	ptypes  MapPlaceholderTypes
 	desired Datum
 	exprs   []copyableExpr
 
-	expectedType Datum
-	expectedArgs MapArgs
+	expectedType   Datum
+	expectedPTypes MapPlaceholderTypes
 }
 
 func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTestCase) {
-	if test.expectedArgs == nil {
-		test.expectedArgs = make(MapArgs)
+	if test.expectedPTypes == nil {
+		test.expectedPTypes = make(MapPlaceholderTypes)
 	}
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
-		ctx := SemaContext{Args: cloneMapArgs(test.args)}
+		ctx := SemaContext{PlaceholderTypes: cloneMapPlaceholderTypes(test.ptypes)}
 		_, typ, err := typeCheckSameTypedExprs(&ctx, test.desired, buildExprs(exprs)...)
 		if err != nil {
 			t.Errorf("%d: unexpected error returned from typeCheckSameTypedExprs: %v", idx, err)
@@ -233,8 +233,8 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 			if !typ.TypeEqual(test.expectedType) {
 				t.Errorf("%d: expected type %s:%s when type checking %s:%s, found %s", idx, test.expectedType, test.expectedType.Type(), buildExprs(exprs), typ, typ.Type())
 			}
-			if !reflect.DeepEqual(ctx.Args, test.expectedArgs) {
-				t.Errorf("%d: expected args %v after typeCheckSameTypedExprs for %v, found %v", idx, test.expectedArgs, buildExprs(exprs), ctx.Args)
+			if !reflect.DeepEqual(ctx.PlaceholderTypes, test.expectedPTypes) {
+				t.Errorf("%d: expected plaecholder types %v after typeCheckSameTypedExprs for %v, found %v", idx, test.expectedPTypes, buildExprs(exprs), ctx.PlaceholderTypes)
 			}
 		}
 	})
@@ -257,17 +257,17 @@ func TestTypeCheckSameTypedExprs(t *testing.T) {
 		{nil, nil, exprs(ddecimal(1), intConst("1")), TypeDecimal, nil},
 		{nil, nil, exprs(ddecimal(1), decConst("1.1")), TypeDecimal, nil},
 		{nil, nil, exprs(ddecimal(1), ddecimal(1)), TypeDecimal, nil},
-		// Mixing resolved params with constants and resolved exprs.
-		{mapArgsDecimal, nil, exprs(ddecimal(1), valArg("a")), TypeDecimal, mapArgsDecimal},
-		{mapArgsDecimal, nil, exprs(intConst("1"), valArg("a")), TypeDecimal, mapArgsDecimal},
-		{mapArgsDecimal, nil, exprs(decConst("1.1"), valArg("a")), TypeDecimal, mapArgsDecimal},
-		{mapArgsInt, nil, exprs(intConst("1"), valArg("a")), TypeInt, mapArgsInt},
-		{mapArgsInt, nil, exprs(decConst("1.0"), valArg("a")), TypeInt, mapArgsInt},
-		{mapArgsDecimalAndDecimal, nil, exprs(valArg("b"), valArg("a")), TypeDecimal, mapArgsDecimalAndDecimal},
-		// Mixing unresolved params with constants and resolved exprs.
-		{nil, nil, exprs(ddecimal(1), valArg("a")), TypeDecimal, mapArgsDecimal},
-		{nil, nil, exprs(intConst("1"), valArg("a")), TypeInt, mapArgsInt},
-		{nil, nil, exprs(decConst("1.1"), valArg("a")), TypeDecimal, mapArgsDecimal},
+		// Mixing resolved placeholders with constants and resolved exprs.
+		{mapPTypesDecimal, nil, exprs(ddecimal(1), placeholder("a")), TypeDecimal, mapPTypesDecimal},
+		{mapPTypesDecimal, nil, exprs(intConst("1"), placeholder("a")), TypeDecimal, mapPTypesDecimal},
+		{mapPTypesDecimal, nil, exprs(decConst("1.1"), placeholder("a")), TypeDecimal, mapPTypesDecimal},
+		{mapPTypesInt, nil, exprs(intConst("1"), placeholder("a")), TypeInt, mapPTypesInt},
+		{mapPTypesInt, nil, exprs(decConst("1.0"), placeholder("a")), TypeInt, mapPTypesInt},
+		{mapPTypesDecimalAndDecimal, nil, exprs(placeholder("b"), placeholder("a")), TypeDecimal, mapPTypesDecimalAndDecimal},
+		// Mixing unresolved placeholders with constants and resolved exprs.
+		{nil, nil, exprs(ddecimal(1), placeholder("a")), TypeDecimal, mapPTypesDecimal},
+		{nil, nil, exprs(intConst("1"), placeholder("a")), TypeInt, mapPTypesInt},
+		{nil, nil, exprs(decConst("1.1"), placeholder("a")), TypeDecimal, mapPTypesDecimal},
 		// Verify dealing with Null.
 		{nil, nil, exprs(dnull), DNull, nil},
 		{nil, nil, exprs(dnull, dnull), DNull, nil},
@@ -291,9 +291,9 @@ func TestTypeCheckSameTypedExprs(t *testing.T) {
 		{nil, TypeInt, exprs(intConst("1"), decConst("1.1")), TypeDecimal, nil},
 		{nil, TypeDecimal, exprs(intConst("1"), decConst("1.1")), TypeDecimal, nil},
 		// Verify desired type when possible with unresolved placeholders.
-		{nil, TypeDecimal, exprs(valArg("a")), TypeDecimal, mapArgsDecimal},
-		{nil, TypeDecimal, exprs(intConst("1"), valArg("a")), TypeDecimal, mapArgsDecimal},
-		{nil, TypeDecimal, exprs(decConst("1.1"), valArg("a")), TypeDecimal, mapArgsDecimal},
+		{nil, TypeDecimal, exprs(placeholder("a")), TypeDecimal, mapPTypesDecimal},
+		{nil, TypeDecimal, exprs(intConst("1"), placeholder("a")), TypeDecimal, mapPTypesDecimal},
+		{nil, TypeDecimal, exprs(decConst("1.1"), placeholder("a")), TypeDecimal, mapPTypesDecimal},
 	} {
 		attemptTypeCheckSameTypedExprs(t, i, d)
 	}
@@ -313,20 +313,20 @@ func TestTypeCheckSameTypedTupleExprs(t *testing.T) {
 		// Mixing constants and resolved exprs.
 		{nil, nil, exprs(tuple(dint(1), decConst("1.1")), tuple(intConst("1"), ddecimal(1))), dtuple(TypeInt, TypeDecimal), nil},
 		{nil, nil, exprs(tuple(dint(1), decConst("1.0")), tuple(intConst("1"), dint(1))), dtuple(TypeInt, TypeInt), nil},
-		// Mixing resolved params with constants and resolved exprs.
-		{mapArgsDecimal, nil, exprs(tuple(ddecimal(1), intConst("1")), tuple(valArg("a"), valArg("a"))), dtuple(TypeDecimal, TypeDecimal), mapArgsDecimal},
-		{mapArgsDecimalAndDecimal, nil, exprs(tuple(valArg("b"), intConst("1")), tuple(valArg("a"), valArg("a"))), dtuple(TypeDecimal, TypeDecimal), mapArgsDecimalAndDecimal},
-		{mapArgsIntAndDecimal, nil, exprs(tuple(intConst("1"), intConst("1")), tuple(valArg("a"), valArg("b"))), dtuple(TypeInt, TypeDecimal), mapArgsIntAndDecimal},
-		// Mixing unresolved params with constants and resolved exprs.
-		{nil, nil, exprs(tuple(ddecimal(1), intConst("1")), tuple(valArg("a"), valArg("a"))), dtuple(TypeDecimal, TypeDecimal), mapArgsDecimal},
-		{nil, nil, exprs(tuple(intConst("1"), intConst("1")), tuple(valArg("a"), valArg("b"))), dtuple(TypeInt, TypeInt), mapArgsIntAndInt},
+		// Mixing resolved placeholders with constants and resolved exprs.
+		{mapPTypesDecimal, nil, exprs(tuple(ddecimal(1), intConst("1")), tuple(placeholder("a"), placeholder("a"))), dtuple(TypeDecimal, TypeDecimal), mapPTypesDecimal},
+		{mapPTypesDecimalAndDecimal, nil, exprs(tuple(placeholder("b"), intConst("1")), tuple(placeholder("a"), placeholder("a"))), dtuple(TypeDecimal, TypeDecimal), mapPTypesDecimalAndDecimal},
+		{mapPTypesIntAndDecimal, nil, exprs(tuple(intConst("1"), intConst("1")), tuple(placeholder("a"), placeholder("b"))), dtuple(TypeInt, TypeDecimal), mapPTypesIntAndDecimal},
+		// Mixing unresolved placeholders with constants and resolved exprs.
+		{nil, nil, exprs(tuple(ddecimal(1), intConst("1")), tuple(placeholder("a"), placeholder("a"))), dtuple(TypeDecimal, TypeDecimal), mapPTypesDecimal},
+		{nil, nil, exprs(tuple(intConst("1"), intConst("1")), tuple(placeholder("a"), placeholder("b"))), dtuple(TypeInt, TypeInt), mapPTypesIntAndInt},
 		// Verify dealing with Null.
 		{nil, nil, exprs(tuple(intConst("1"), dnull), tuple(dnull, decConst("1"))), dtuple(TypeInt, TypeDecimal), nil},
 		{nil, nil, exprs(tuple(dint(1), dnull), tuple(dnull, ddecimal(1))), dtuple(TypeInt, TypeDecimal), nil},
 		// Verify desired type when possible.
 		{nil, dtuple(TypeInt, TypeDecimal), exprs(tuple(intConst("1"), intConst("1")), tuple(intConst("1"), intConst("1"))), dtuple(TypeInt, TypeDecimal), nil},
 		// Verify desired type when possible with unresolved constants.
-		{nil, dtuple(TypeInt, TypeDecimal), exprs(tuple(valArg("a"), intConst("1")), tuple(intConst("1"), valArg("b"))), dtuple(TypeInt, TypeDecimal), mapArgsIntAndDecimal},
+		{nil, dtuple(TypeInt, TypeDecimal), exprs(tuple(placeholder("a"), intConst("1")), tuple(intConst("1"), placeholder("b"))), dtuple(TypeInt, TypeDecimal), mapPTypesIntAndDecimal},
 	} {
 		attemptTypeCheckSameTypedExprs(t, i, d)
 	}
@@ -337,10 +337,10 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 	tupleFloatIntMismatchErr := `tuples .* are not the same type: ` + decimalIntMismatchErr
 	tupleIntMismatchErr := `expected .* to be of type (tuple|int), found type (tuple|int)`
 	tupleLenErr := `expected tuple .* to have a length of .*`
-	paramErr := `could not determine data type of parameter .*`
+	placeholderErr := `could not determine data type of placeholder .*`
 
 	testData := []struct {
-		args    MapArgs
+		ptypes  MapPlaceholderTypes
 		desired Datum
 		exprs   []copyableExpr
 
@@ -349,18 +349,18 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 		// Single type mismatches.
 		{nil, nil, exprs(dint(1), decConst("1.1")), decimalIntMismatchErr},
 		{nil, nil, exprs(dint(1), ddecimal(1)), decimalIntMismatchErr},
-		{mapArgsInt, nil, exprs(ddecimal(1.1), valArg("a")), decimalIntMismatchErr},
-		{mapArgsInt, nil, exprs(decConst("1.1"), valArg("a")), decimalIntMismatchErr},
-		{mapArgsIntAndDecimal, nil, exprs(valArg("b"), valArg("a")), decimalIntMismatchErr},
+		{mapPTypesInt, nil, exprs(ddecimal(1.1), placeholder("a")), decimalIntMismatchErr},
+		{mapPTypesInt, nil, exprs(decConst("1.1"), placeholder("a")), decimalIntMismatchErr},
+		{mapPTypesIntAndDecimal, nil, exprs(placeholder("b"), placeholder("a")), decimalIntMismatchErr},
 		// Tuple type mismatches.
 		{nil, nil, exprs(tuple(dint(1)), tuple(ddecimal(1))), tupleFloatIntMismatchErr},
 		{nil, nil, exprs(tuple(dint(1)), dint(1), dint(1)), tupleIntMismatchErr},
 		{nil, nil, exprs(tuple(dint(1)), tuple(dint(1), dint(1))), tupleLenErr},
-		// Parameter ambiguity.
-		{nil, nil, exprs(valArg("b"), valArg("a")), paramErr},
+		// Placeholder ambiguity.
+		{nil, nil, exprs(placeholder("b"), placeholder("a")), placeholderErr},
 	}
 	for i, d := range testData {
-		ctx := SemaContext{Args: d.args}
+		ctx := SemaContext{PlaceholderTypes: d.ptypes}
 		forEachPerm(d.exprs, 0, func(exprs []copyableExpr) {
 			if _, _, err := typeCheckSameTypedExprs(&ctx, d.desired, buildExprs(exprs)...); !testutils.IsError(err, d.expectedErr) {
 				t.Errorf("%d: expected %s, but found %v", i, d.expectedErr, err)
@@ -375,18 +375,18 @@ func TestProcessPlaceholderAnnotations(t *testing.T) {
 
 	testData := []struct {
 		stmtExprs []Expr
-		desired   MapArgs
+		desired   MapPlaceholderTypes
 	}{
-		{[]Expr{Placeholder{"a"}}, MapArgs{}},
-		{[]Expr{Placeholder{"a"}, Placeholder{"b"}}, MapArgs{}},
+		{[]Expr{Placeholder{"a"}}, MapPlaceholderTypes{}},
+		{[]Expr{Placeholder{"a"}, Placeholder{"b"}}, MapPlaceholderTypes{}},
 		{[]Expr{
 			&CastExpr{Expr: Placeholder{"a"}, Type: intType},
 			&CastExpr{Expr: Placeholder{"a"}, Type: boolType},
-		}, MapArgs{}},
+		}, MapPlaceholderTypes{}},
 		{[]Expr{
 			&CastExpr{Expr: Placeholder{"a"}, Type: intType},
 			&CastExpr{Expr: Placeholder{"b"}, Type: boolType},
-		}, MapArgs{
+		}, MapPlaceholderTypes{
 			"a": TypeInt,
 			"b": TypeBool,
 		}},
@@ -395,26 +395,26 @@ func TestProcessPlaceholderAnnotations(t *testing.T) {
 			&CastExpr{Expr: Placeholder{"b"}, Type: boolType},
 			&CastExpr{Expr: Placeholder{"a"}, Type: intType},
 			&CastExpr{Expr: Placeholder{"b"}, Type: intType},
-		}, MapArgs{
+		}, MapPlaceholderTypes{
 			"a": TypeInt,
 		}},
 		{[]Expr{
 			&CastExpr{Expr: Placeholder{"a"}, Type: intType},
 			&CastExpr{Expr: Placeholder{"b"}, Type: boolType},
 			Placeholder{"a"},
-		}, MapArgs{
+		}, MapPlaceholderTypes{
 			"b": TypeBool,
 		}},
 		{[]Expr{
 			Placeholder{"a"},
 			&CastExpr{Expr: Placeholder{"a"}, Type: intType},
 			&CastExpr{Expr: Placeholder{"b"}, Type: boolType},
-		}, MapArgs{
+		}, MapPlaceholderTypes{
 			"b": TypeBool,
 		}},
 	}
 	for i, d := range testData {
-		args := make(MapArgs)
+		args := make(MapPlaceholderTypes)
 		stmt := &ValuesClause{Tuples: []*Tuple{{Exprs: d.stmtExprs}}}
 		if err := ProcessPlaceholderAnnotations(stmt, args); err != nil {
 			t.Errorf("%d: unexpected error returned from ProcessPlaceholderAnnotations: %v", i, err)

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -751,30 +751,17 @@ func WalkStmt(v Visitor, stmt Statement) (newStmt Statement, changed bool) {
 	return newStmt, (stmt != newStmt)
 }
 
-// Args defines the interface for retrieving arguments. Return false for the
-// second return value if the argument cannot be found.
-type Args interface {
-	Arg(name string) (Datum, bool)
-}
-
-var _ Args = MapArgs{}
-
-// MapArgs is an Args implementation which is used for the type
-// inference necessary to support the postgres wire protocol.
-// See various TypeCheck() implementations for details.
-type MapArgs map[string]Datum
-
-// Arg implements the Args interface.
-func (m MapArgs) Arg(name string) (Datum, bool) {
-	d, ok := m[name]
-	return d, ok
-}
+// MapPlaceholderTypes maps placeholder names (without leading "$") to
+// their type. This is populated by the type inference necessary to
+// support the postgres wire protocol.  See various TypeCheck()
+// implementations for details.
+type MapPlaceholderTypes map[string]Datum
 
 // SetInferredType sets the bind var argument d to the type typ in m. If m is
 // nil or d is not a DPlaceholder, nil is returned. If the bind var argument is set,
 // typ is returned. An error is returned if typ cannot be set because a
 // different type is already present.
-func (m MapArgs) SetInferredType(d, typ Datum) (set Datum, err error) {
+func (m MapPlaceholderTypes) SetInferredType(d, typ Datum) (set Datum, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -783,7 +770,7 @@ func (m MapArgs) SetInferredType(d, typ Datum) (set Datum, err error) {
 		return nil, nil
 	}
 	if t, ok := m[v.name]; ok && !typ.TypeEqual(t) {
-		return nil, fmt.Errorf("parameter %s has multiple types: %s, %s", v, typ.Type(), t.Type())
+		return nil, fmt.Errorf("placeholder %s has multiple types: %s, %s", v, typ.Type(), t.Type())
 	}
 	m[v.name] = typ
 	return typ, nil
@@ -792,13 +779,20 @@ func (m MapArgs) SetInferredType(d, typ Datum) (set Datum, err error) {
 // IsUnresolvedArgument returns whether expr is an unresolved var argument. In
 // other words, it returns whether the provided expression is an argument, and
 // if so, whether the variable's type remains unset or not.
-func (m MapArgs) IsUnresolvedArgument(expr Expr) bool {
+func (m MapPlaceholderTypes) IsUnresolvedArgument(expr Expr) bool {
 	if t, ok := expr.(Placeholder); ok {
 		if _, ok := m[t.Name]; !ok {
 			return true
 		}
 	}
 	return false
+}
+
+// Args defines the interface for retrieving the value provided as
+// argument by the client for a placeholder. Return false for the
+// second return value if no argument was provided for the placeholder.
+type Args interface {
+	Arg(name string) (Datum, bool)
 }
 
 type argVisitor struct {
@@ -829,9 +823,9 @@ func (v *argVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 
 func (v *argVisitor) VisitPost(expr Expr) Expr { return expr }
 
-// FillArgs replaces any placeholder nodes in the expression with arguments
+// FillQueryArgs replaces any placeholder nodes in the expression with arguments
 // supplied with the query.
-func FillArgs(stmt Statement, args Args) (Statement, error) {
+func FillQueryArgs(stmt Statement, args Args) (Statement, error) {
 	v := argVisitor{args: args}
 	stmt, _ = WalkStmt(&v, stmt)
 	return stmt, v.err

--- a/sql/parser/walk.go
+++ b/sql/parser/walk.go
@@ -361,7 +361,7 @@ func (expr *NumVal) Walk(_ Visitor) Expr { return expr }
 func (expr *StrVal) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr ValArg) Walk(_ Visitor) Expr { return expr }
+func (expr Placeholder) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
 func (expr *DBool) Walk(_ Visitor) Expr { return expr }
@@ -400,7 +400,7 @@ func (expr *DTimestampTZ) Walk(_ Visitor) Expr { return expr }
 func (expr *DTuple) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr *DValArg) Walk(_ Visitor) Expr { return expr }
+func (expr *DPlaceholder) Walk(_ Visitor) Expr { return expr }
 
 // WalkExpr traverses the nodes in an expression.
 func WalkExpr(v Visitor, expr Expr) (newExpr Expr, changed bool) {
@@ -771,14 +771,14 @@ func (m MapArgs) Arg(name string) (Datum, bool) {
 }
 
 // SetInferredType sets the bind var argument d to the type typ in m. If m is
-// nil or d is not a DValArg, nil is returned. If the bind var argument is set,
+// nil or d is not a DPlaceholder, nil is returned. If the bind var argument is set,
 // typ is returned. An error is returned if typ cannot be set because a
 // different type is already present.
 func (m MapArgs) SetInferredType(d, typ Datum) (set Datum, err error) {
 	if m == nil {
 		return nil, nil
 	}
-	v, ok := d.(*DValArg)
+	v, ok := d.(*DPlaceholder)
 	if !ok {
 		return nil, nil
 	}
@@ -793,7 +793,7 @@ func (m MapArgs) SetInferredType(d, typ Datum) (set Datum, err error) {
 // other words, it returns whether the provided expression is an argument, and
 // if so, whether the variable's type remains unset or not.
 func (m MapArgs) IsUnresolvedArgument(expr Expr) bool {
-	if t, ok := expr.(ValArg); ok {
+	if t, ok := expr.(Placeholder); ok {
 		if _, ok := m[t.Name]; !ok {
 			return true
 		}
@@ -812,7 +812,7 @@ func (v *argVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	if v.err != nil {
 		return false, expr
 	}
-	placeholder, ok := expr.(ValArg)
+	placeholder, ok := expr.(Placeholder)
 	if !ok {
 		return true, expr
 	}

--- a/sql/parser/walk_test.go
+++ b/sql/parser/walk_test.go
@@ -22,6 +22,15 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
+// MapArgs maps a placeholder to a query argument (value)
+type MapArgs map[string]Datum
+
+// Arg implements the Args interface.
+func (m MapArgs) Arg(name string) (Datum, bool) {
+	d, ok := m[name]
+	return d, ok
+}
+
 // TestFillArgs tests both FillArgs and WalkExpr.
 func TestFillArgs(t *testing.T) {
 	dstring := NewDString
@@ -87,7 +96,7 @@ func TestFillArgs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		q, err = FillArgs(q, d.args)
+		q, err = FillQueryArgs(q, d.args)
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
@@ -111,7 +120,7 @@ func TestFillArgsError(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		if _, err := FillArgs(q, d.args); err == nil {
+		if _, err := FillQueryArgs(q, d.args); err == nil {
 			t.Fatalf("%s: expected failure, but found success", d.expr)
 		} else if d.expected != err.Error() {
 			t.Fatalf("%s: expected %s, but found %v", d.expr, d.expected, err)
@@ -153,7 +162,7 @@ func TestWalkStmt(t *testing.T) {
 		qOrig := q
 		qOrigStr := q.String()
 		// FillArgs is where the walk happens, using argVisitor.
-		q, err = FillArgs(q, d.args)
+		q, err = FillQueryArgs(q, d.args)
 		if err != nil {
 			t.Fatalf("%s: %v", d.sql, err)
 		}

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -102,11 +102,11 @@ type preparedStatement struct {
 	portalNames map[string]struct{}
 }
 
-// preparedPortal is a preparedStatement that has been bound with parameters.
+// preparedPortal is a preparedStatement that has been bound with query arguments.
 type preparedPortal struct {
 	stmt       preparedStatement
 	stmtName   string
-	params     []parser.Datum
+	qargs      []parser.Datum
 	outFormats []formatCode
 }
 
@@ -340,12 +340,12 @@ func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 	if err != nil {
 		return err
 	}
-	numParamTypes, err := buf.getInt16()
+	numQArgTypes, err := buf.getInt16()
 	if err != nil {
 		return err
 	}
 
-	inTypeHints := make([]oid.Oid, numParamTypes)
+	inTypeHints := make([]oid.Oid, numQArgTypes)
 	for i := range inTypeHints {
 		typ, err := buf.getInt32()
 		if err != nil {
@@ -353,7 +353,7 @@ func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 		}
 		inTypeHints[i] = oid.Oid(typ)
 	}
-	args := make(parser.MapArgs)
+	ptypes := make(parser.MapPlaceholderTypes)
 	for i, t := range inTypeHints {
 		if t == 0 {
 			continue
@@ -362,27 +362,27 @@ func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 		if !ok {
 			return c.sendInternalError(fmt.Sprintf("unknown oid type: %v", t))
 		}
-		args[fmt.Sprint(i+1)] = v
+		ptypes[fmt.Sprint(i+1)] = v
 	}
-	cols, err := c.executor.Prepare(ctx, query, c.session, args)
+	cols, err := c.executor.Prepare(ctx, query, c.session, ptypes)
 	if err != nil {
 		return c.sendError(err)
 	}
 	pq := preparedStatement{
 		query:       query,
-		inTypes:     make([]oid.Oid, 0, len(args)),
+		inTypes:     make([]oid.Oid, 0, len(ptypes)),
 		portalNames: make(map[string]struct{}),
 		columns:     cols,
 	}
-	for k, v := range args {
+	for k, v := range ptypes {
 		i, err := strconv.Atoi(k)
 		if err != nil {
-			return c.sendInternalError(fmt.Sprintf("non-integer parameter: %s", k))
+			return c.sendInternalError(fmt.Sprintf("non-integer placholder name: %s", k))
 		}
 		// Placeholders are 1-indexed, pq.inTypes are 0-indexed.
 		i--
 		if i < 0 {
-			return c.sendInternalError(fmt.Sprintf("there is no parameter $%s", k))
+			return c.sendInternalError(fmt.Sprintf("invalid placeholder name $%s", k))
 		}
 		// Grow pq.inTypes to be at least as large as i.
 		for j := len(pq.inTypes); j <= i; j++ {
@@ -405,7 +405,7 @@ func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 	for i := range pq.inTypes {
 		if pq.inTypes[i] == 0 {
 			return c.sendInternalError(
-				fmt.Sprintf("could not determine data type of parameter $%d", i+1))
+				fmt.Sprintf("could not determine data type of placeholder $%d", i+1))
 		}
 	}
 	c.preparedStatements[name] = pq
@@ -504,70 +504,70 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 		return c.sendInternalError(fmt.Sprintf("unknown prepared statement %q", statementName))
 	}
 
-	numParams := int16(len(stmt.inTypes))
-	paramFormatCodes := make([]formatCode, numParams)
+	numQArgs := int16(len(stmt.inTypes))
+	qArgFormatCodes := make([]formatCode, numQArgs)
 
-	// From the docs on number of parameter format codes to bind:
-	// This can be zero to indicate that there are no parameters or that the
-	// parameters all use the default format (text); or one, in which case the
-	// specified format code is applied to all parameters; or it can equal the
-	// actual number of parameters.
+	// From the docs on number of argument format codes to bind:
+	// This can be zero to indicate that there are no arguments or that the
+	// arguments all use the default format (text); or one, in which case the
+	// specified format code is applied to all arguments; or it can equal the
+	// actual number of arguments.
 	// http://www.postgresql.org/docs/current/static/protocol-message-formats.html
-	numParamFormatCodes, err := buf.getInt16()
+	numQArgFormatCodes, err := buf.getInt16()
 	if err != nil {
 		return err
 	}
-	switch numParamFormatCodes {
+	switch numQArgFormatCodes {
 	case 0:
 	case 1:
-		// `1` means read one code and apply it to every param.
+		// `1` means read one code and apply it to every argument.
 		c, err := buf.getInt16()
 		if err != nil {
 			return err
 		}
 		fmtCode := formatCode(c)
-		for i := range paramFormatCodes {
-			paramFormatCodes[i] = fmtCode
+		for i := range qArgFormatCodes {
+			qArgFormatCodes[i] = fmtCode
 		}
-	case numParams:
-		// Read one format code for each param and apply it to that param.
-		for i := range paramFormatCodes {
+	case numQArgs:
+		// Read one format code for each argument and apply it to that argument.
+		for i := range qArgFormatCodes {
 			c, err := buf.getInt16()
 			if err != nil {
 				return err
 			}
-			paramFormatCodes[i] = formatCode(c)
+			qArgFormatCodes[i] = formatCode(c)
 		}
 	default:
-		return c.sendInternalError(fmt.Sprintf("wrong number of format codes specified: %d for %d paramaters", numParamFormatCodes, numParams))
+		return c.sendInternalError(fmt.Sprintf("wrong number of format codes specified: %d for %d arguments", numQArgFormatCodes, numQArgs))
 	}
 
 	numValues, err := buf.getInt16()
 	if err != nil {
 		return err
 	}
-	if numValues != numParams {
-		return c.sendInternalError(fmt.Sprintf("expected %d parameters, got %d", numParams, numValues))
+	if numValues != numQArgs {
+		return c.sendInternalError(fmt.Sprintf("expected %d arguments, got %d", numQArgs, numValues))
 	}
-	params := make([]parser.Datum, numParams)
+	qargs := make([]parser.Datum, numQArgs)
 	for i, t := range stmt.inTypes {
 		plen, err := buf.getInt32()
 		if err != nil {
 			return err
 		}
 		if plen == -1 {
-			// TODO(mjibson): a NULL parameter, figure out what this should do
+			// TODO(mjibson): a NULL argument, figure out what this should do
 			continue
 		}
 		b, err := buf.getBytes(int(plen))
 		if err != nil {
 			return err
 		}
-		d, err := decodeOidDatum(t, paramFormatCodes[i], b)
+		d, err := decodeOidDatum(t, qArgFormatCodes[i], b)
 		if err != nil {
-			return c.sendInternalError(fmt.Sprintf("param $%d: %s", i+1, err))
+			return c.sendInternalError(fmt.Sprintf("error in argument for $%d: %s", i+1, err))
 		}
-		params[i] = d
+		qargs[i] = d
 	}
 
 	numColumns := int16(len(stmt.columns))
@@ -612,7 +612,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 	c.preparedPortals[portalName] = preparedPortal{
 		stmt:       stmt,
 		stmtName:   statementName,
-		params:     params,
+		qargs:      qargs,
 		outFormats: columnFormatCodes,
 	}
 	c.writeBuf.initMsg(serverMsgBindComplete)
@@ -633,19 +633,19 @@ func (c *v3Conn) handleExecute(ctx context.Context, buf *readBuffer) error {
 		return err
 	}
 
-	return c.executeStatements(ctx, portal.stmt.query, portal.params, portal.outFormats, false, limit)
+	return c.executeStatements(ctx, portal.stmt.query, portal.qargs, portal.outFormats, false, limit)
 }
 
 func (c *v3Conn) executeStatements(
 	ctx context.Context,
 	stmts string,
-	params []parser.Datum,
+	qargs []parser.Datum,
 	formatCodes []formatCode,
 	sendDescription bool,
 	limit int32,
 ) error {
 	tracing.AnnotateTrace()
-	results := c.executor.ExecuteStatements(ctx, c.session, stmts, params)
+	results := c.executor.ExecuteStatements(ctx, c.session, stmts, qargs)
 
 	tracing.AnnotateTrace()
 	if results.Empty {

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -379,7 +379,7 @@ func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 		if err != nil {
 			return c.sendInternalError(fmt.Sprintf("non-integer parameter: %s", k))
 		}
-		// ValArgs are 1-indexed, pq.inTypes are 0-indexed.
+		// Placeholders are 1-indexed, pq.inTypes are 0-indexed.
 		i--
 		if i < 0 {
 			return c.sendInternalError(fmt.Sprintf("there is no parameter $%s", k))

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -53,7 +53,7 @@ type planner struct {
 	verifyFnCheckedOnce     bool
 
 	parser parser.Parser
-	params parameters
+	qargs  queryArguments
 
 	// Avoid allocations by embedding commonly used visitors.
 	isAggregateVisitor          isAggregateVisitor
@@ -167,7 +167,7 @@ func (p *planner) resetForBatch(e *Executor) {
 	p.systemConfig = cfg
 	p.databaseCache = cache
 
-	p.params = parameters{}
+	p.qargs = queryArguments{}
 
 	// The parser cannot be reused between batches.
 	p.parser = parser.Parser{}
@@ -192,7 +192,7 @@ func (p *planner) query(sql string, args ...interface{}) (planNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	stmt, err = parser.FillArgs(stmt, golangParameters(args))
+	stmt, err = parser.FillQueryArgs(stmt, golangQueryArguments(args))
 	if err != nil {
 		return nil, err
 	}

--- a/sql/sqlbase/table.go
+++ b/sql/sqlbase/table.go
@@ -986,7 +986,7 @@ func EncodeSecondaryIndexes(
 // CheckColumnType verifies that a given value is compatible
 // with the type requested by the column. If the value is a
 // placeholder, the type of the placeholder gets populated.
-func CheckColumnType(col ColumnDescriptor, val parser.Datum, args parser.MapArgs) error {
+func CheckColumnType(col ColumnDescriptor, val parser.Datum, args parser.MapPlaceholderTypes) error {
 	if val == parser.DNull {
 		return nil
 	}

--- a/sql/update.go
+++ b/sql/update.go
@@ -208,7 +208,7 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 		return nil, err
 	}
 
-	// ValArgs have their types populated in the above Select if they are part
+	// Placeholders have their types populated in the above Select if they are part
 	// of an expression ("SET a = 2 + $1") in the type check step where those
 	// types are inferred. For the simpler case ("SET a = $1"), populate them
 	// using checkColumnType. This step also verifies that the expression

--- a/sql/update.go
+++ b/sql/update.go
@@ -224,7 +224,7 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 		if err != nil {
 			return nil, err
 		}
-		err = sqlbase.CheckColumnType(updateCols[i], typedTarget.ReturnType(), p.semaCtx.Args)
+		err = sqlbase.CheckColumnType(updateCols[i], typedTarget.ReturnType(), p.semaCtx.PlaceholderTypes)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -147,7 +147,7 @@ type floatAlias float32
 type boolAlias bool
 type stringAlias string
 
-func TestGolangParams(t *testing.T) {
+func TestGolangQueryArgs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Each test case pairs an arbitrary value and parser.Datum which has the same
 	// type
@@ -203,8 +203,8 @@ func TestGolangParams(t *testing.T) {
 	}
 
 	for i, tcase := range testCases {
-		params := golangParameters([]interface{}{tcase.value})
-		output, valid := params.Arg("1")
+		qargs := golangQueryArguments([]interface{}{tcase.value})
+		output, valid := qargs.Arg("1")
 		if !valid {
 			t.Errorf("case %d failed: argument was invalid", i)
 			continue


### PR DESCRIPTION
Summary:

```
- the things that are declared between parentheses for a builtin SQL
  functions: *parameters* (as before)

- the values that are given between parentheses for a call to a SQL
  builtin function: *arguments* (as before)

- the thing that is written as a hole ("$N") in a SQL query:
  *placeholder* (previously inconsistently called either "parameter" or
  "argument" in different places)

- the client-supplied values during the BIND phase of the pgwire
  protocol to fill the placeholders: *query arguments* (previously
  inconsistently called either "parameters" or "arguments" in
  different places)

- the type of the dictionary of placeholder names to placeholder
  types: *MapPlaceholderTypes* (previously called "MapArgs")

- the dictionary of placeholder names to placeholder types: *ptypes*
  (previously called "args")
```

See separate commits in PR for details.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6944)

<!-- Reviewable:end -->
