### PR TITLE
acceptance: list all containers

### DIFF
--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -326,7 +326,10 @@ func (cli resilientDockerClient) ContainerCreate(
 	response, err := cli.APIClient.ContainerCreate(ctx, config, hostConfig, networkingConfig, containerName)
 	if err != nil && strings.Contains(err.Error(), "already in use") {
 		log.Infof("unable to create container %s: %v", containerName, err)
-		containers, cerr := cli.ContainerList(ctx, types.ContainerListOptions{All: true})
+		containers, cerr := cli.ContainerList(ctx, types.ContainerListOptions{
+			All:   true,
+			Limit: -1, // no limit, see docker/engine-api/client/container_list.go
+		})
 		if cerr != nil {
 			log.Infof("unable to list containers: %v", cerr)
 			return types.ContainerCreateResponse{}, err


### PR DESCRIPTION
It looks like the implementation of ContainerList in docker/engine-api/client
expects -1 to be passed for listing all containers. This could fix #6906.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6946)

<!-- Reviewable:end -->
