### PR TITLE
ui/next: update dependencies

### DIFF
--- a/ui/next/app/app.tsx
+++ b/ui/next/app/app.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../typings/main.d.ts" />
+/// <reference path="../typings/index.d.ts" />
 
 /**
  * UI/NEXT TODO LIST

--- a/ui/next/app/components/graphGroup.tsx
+++ b/ui/next/app/components/graphGroup.tsx
@@ -1,9 +1,9 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 
 import { MetricsDataProvider } from "../containers/metricsDataProvider";
 
-/** 
+/**
  * GraphGroup is a stateless react component that wraps a group of graphs (the
  * children of this component) in a MetricsDataProvider and some additional tags
  * relevant to the layout of our graphs pages.

--- a/ui/next/app/containers/cluster.tsx
+++ b/ui/next/app/containers/cluster.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 
 import { IndexListLink, ListLink } from "../components/listLink.tsx";

--- a/ui/next/app/containers/clusterEvents.tsx
+++ b/ui/next/app/containers/clusterEvents.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 
 /**

--- a/ui/next/app/containers/clusterOverview.tsx
+++ b/ui/next/app/containers/clusterOverview.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 import * as d3 from "d3";
 import _ = require("lodash");

--- a/ui/next/app/containers/databases/databaseDetails.tsx
+++ b/ui/next/app/containers/databases/databaseDetails.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../../typings/main.d.ts" />
+/// <reference path="../../../typings/index.d.ts" />
 import * as React from "react";
 import { Link } from "react-router";
 import * as _ from "lodash";

--- a/ui/next/app/containers/databases/databaseList.tsx
+++ b/ui/next/app/containers/databases/databaseList.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../../typings/main.d.ts" />
+/// <reference path="../../../typings/index.d.ts" />
 import * as React from "react";
 import { Link } from "react-router";
 import * as _ from "lodash";

--- a/ui/next/app/containers/databases/databases.tsx
+++ b/ui/next/app/containers/databases/databases.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../../typings/main.d.ts" />
+/// <reference path="../../../typings/index.d.ts" />
 import * as React from "react";
 
 /**

--- a/ui/next/app/containers/databases/tableDetails.tsx
+++ b/ui/next/app/containers/databases/tableDetails.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../../typings/main.d.ts" />
+/// <reference path="../../../typings/index.d.ts" />
 import * as React from "react";
 import * as _ from "lodash";
 import { connect } from "react-redux";

--- a/ui/next/app/containers/helpus.tsx
+++ b/ui/next/app/containers/helpus.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 
 /**

--- a/ui/next/app/containers/layout.tsx
+++ b/ui/next/app/containers/layout.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 import _ = require("lodash");
 import { RouteComponentProps } from "react-router";

--- a/ui/next/app/containers/metricsDataProvider.tsx
+++ b/ui/next/app/containers/metricsDataProvider.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 
 import * as React from "react";
 import { createSelector } from "reselect";

--- a/ui/next/app/containers/node.tsx
+++ b/ui/next/app/containers/node.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 import { Link, RouteComponentProps } from "react-router";
 

--- a/ui/next/app/containers/nodeGraphs.tsx
+++ b/ui/next/app/containers/nodeGraphs.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 import * as d3 from "d3";
 import { RouteComponentProps } from "react-router";

--- a/ui/next/app/containers/nodeLogs.tsx
+++ b/ui/next/app/containers/nodeLogs.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 
 /**

--- a/ui/next/app/containers/nodeOverview.tsx
+++ b/ui/next/app/containers/nodeOverview.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 
 /**

--- a/ui/next/app/containers/nodes.tsx
+++ b/ui/next/app/containers/nodes.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 
 import { ListLink } from "../components/listLink.tsx";

--- a/ui/next/app/containers/nodesGraphs.tsx
+++ b/ui/next/app/containers/nodesGraphs.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 import * as d3 from "d3";
 

--- a/ui/next/app/containers/nodesOverview.tsx
+++ b/ui/next/app/containers/nodesOverview.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 import _ = require("lodash");
 import { Link } from "react-router";

--- a/ui/next/app/containers/timescale.tsx
+++ b/ui/next/app/containers/timescale.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 
 import * as React from "react";
 import { connect } from "react-redux";

--- a/ui/next/app/containers/timewindow.tsx
+++ b/ui/next/app/containers/timewindow.tsx
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 
 import * as React from "react";
 import { connect } from "react-redux";

--- a/ui/next/app/redux/databaseInfo.spec.ts
+++ b/ui/next/app/redux/databaseInfo.spec.ts
@@ -1,10 +1,11 @@
 import { assert } from "chai";
-import * as databases from "./databaseInfo";
-import * as protos from "../js/protos";
 import * as proxyquire from "proxyquire";
-import { Action } from "../interfaces/action";
 import { Dispatch } from "redux";
 import * as _ from "lodash";
+
+import * as databases from "./databaseInfo";
+import * as protos from "../js/protos";
+import { Action } from "../interfaces/action";
 
 type DatabasesResponse = cockroach.server.DatabasesResponse;
 

--- a/ui/next/app/redux/uiData.ts
+++ b/ui/next/app/redux/uiData.ts
@@ -1,5 +1,4 @@
 import _ = require("lodash");
-
 import { Dispatch } from "redux";
 import ByteBuffer = require("bytebuffer");
 

--- a/ui/next/app/util/api.spec.ts
+++ b/ui/next/app/util/api.spec.ts
@@ -1,9 +1,9 @@
 import { assert } from "chai";
 import _ = require("lodash");
 import * as fetchMock from "fetch-mock";
-import * as protos from "../js/protos";
 import Long = require("long");
 
+import * as protos from "../js/protos";
 import * as api from "./api";
 
 describe("rest api", function() {

--- a/ui/next/app/util/api.ts
+++ b/ui/next/app/util/api.ts
@@ -1,12 +1,13 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 
 /**
  * This module contains all the REST endpoints for communicating with the admin UI.
  */
 
 import "isomorphic-fetch";
-import * as protos from "../js/protos";
 import * as _ from "lodash";
+
+import * as protos from "../js/protos";
 
 let server = protos.cockroach.server;
 let ts = protos.cockroach.ts;

--- a/ui/next/app/util/find.ts
+++ b/ui/next/app/util/find.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import * as React from "react";
 
 /**

--- a/ui/next/app/util/proto.ts
+++ b/ui/next/app/util/proto.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../typings/main.d.ts" />
+/// <reference path="../../typings/index.d.ts" />
 import _ = require("lodash");
 
 type NodeStatus = cockroach.server.status.NodeStatus;

--- a/ui/next/config.js
+++ b/ui/next/config.js
@@ -55,34 +55,40 @@ System.config({
     }
   },
 
+  meta: {
+    "reselect": {
+      "typings": "src/reselect.d.ts"
+    }
+  },
+
   map: {
     "classnames": "npm:classnames@2.2.5",
     "d3": "npm:d3@3.5.17",
-    "es6-promise": "npm:es6-promise@3.1.2",
+    "es6-promise": "npm:es6-promise@3.2.1",
     "isomorphic-fetch": "npm:isomorphic-fetch@2.2.1",
-    "lodash": "npm:lodash@4.11.2",
+    "lodash": "npm:lodash@4.13.1",
     "long": "npm:long@3.1.0",
     "moment": "npm:moment@2.13.0",
     "nvd3": "npm:nvd3@1.8.3",
     "object-assign": "npm:object-assign@4.1.0",
     "protobufjs": "npm:protobufjs@5.0.1",
-    "react": "npm:react@15.0.2",
-    "react-dom": "npm:react-dom@15.0.2",
+    "react": "npm:react@15.1.0",
+    "react-dom": "npm:react-dom@15.1.0",
     "react-redux": "npm:react-redux@4.4.5",
-    "react-router": "npm:react-router@2.4.0",
+    "react-router": "npm:react-router@2.4.1",
     "react-router-redux": "npm:react-router-redux@4.0.4",
     "redux": "npm:redux@3.5.2",
-    "redux-thunk": "npm:redux-thunk@2.0.1",
+    "redux-thunk": "npm:redux-thunk@2.1.0",
     "reselect": "npm:reselect@2.5.1",
-    "ts": "github:frankwallis/plugin-typescript@4.0.9",
-    "ts-runtime": "npm:babel-runtime@6.6.1",
+    "ts": "github:frankwallis/plugin-typescript@4.0.16",
+    "ts-runtime": "npm:babel-runtime@6.9.1",
     "typescript": "npm:typescript@1.8.10",
     "whatwg-fetch": "npm:whatwg-fetch@0.11.0",
-    "github:frankwallis/plugin-typescript@4.0.9": {
+    "github:frankwallis/plugin-typescript@4.0.16": {
       "typescript": "npm:typescript@1.8.10"
     },
     "github:jspm/nodelibs-assert@0.1.0": {
-      "assert": "npm:assert@1.3.0"
+      "assert": "npm:assert@1.4.0"
     },
     "github:jspm/nodelibs-buffer@0.1.0": {
       "buffer": "npm:buffer@3.6.0"
@@ -111,7 +117,7 @@ System.config({
       "path-browserify": "npm:path-browserify@0.0.0"
     },
     "github:jspm/nodelibs-process@0.1.2": {
-      "process": "npm:process@0.11.2"
+      "process": "npm:process@0.11.3"
     },
     "github:jspm/nodelibs-stream@0.1.0": {
       "stream-browserify": "npm:stream-browserify@1.0.0"
@@ -131,7 +137,7 @@ System.config({
     "github:jspm/nodelibs-zlib@0.1.0": {
       "browserify-zlib": "npm:browserify-zlib@0.1.4"
     },
-    "npm:asap@2.0.3": {
+    "npm:asap@2.0.4": {
       "domain": "github:jspm/nodelibs-domain@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
@@ -142,15 +148,15 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2",
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
-    "npm:assert@1.3.0": {
+    "npm:assert@1.4.0": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer-shims": "npm:buffer-shims@1.0.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "util": "npm:util@0.10.3"
     },
-    "npm:babel-plugin-syntax-flow@6.8.0": {
-      "babel-runtime": "npm:babel-runtime@6.6.1"
-    },
-    "npm:babel-runtime@6.6.1": {
-      "core-js": "npm:core-js@2.3.0",
-      "process": "github:jspm/nodelibs-process@0.1.2"
+    "npm:babel-runtime@6.9.1": {
+      "core-js": "npm:core-js@2.4.0"
     },
     "npm:brace-expansion@1.1.4": {
       "balanced-match": "npm:balanced-match@0.4.1",
@@ -161,8 +167,11 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "pako": "npm:pako@0.2.8",
       "process": "github:jspm/nodelibs-process@0.1.2",
-      "readable-stream": "npm:readable-stream@2.1.2",
+      "readable-stream": "npm:readable-stream@2.1.4",
       "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:buffer-shims@1.0.0": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0"
     },
     "npm:buffer@3.6.0": {
       "base64-js": "npm:base64-js@0.0.8",
@@ -194,7 +203,7 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
-    "npm:core-js@2.3.0": {
+    "npm:core-js@2.4.0": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
@@ -210,14 +219,15 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "iconv-lite": "npm:iconv-lite@0.4.13"
     },
-    "npm:es6-promise@3.1.2": {
+    "npm:es6-promise@3.2.1": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:fbjs@0.8.1": {
-      "babel-plugin-syntax-flow": "npm:babel-plugin-syntax-flow@6.8.0",
+    "npm:fbjs@0.8.3": {
       "core-js": "npm:core-js@1.2.6",
+      "immutable": "npm:immutable@3.8.1",
       "isomorphic-fetch": "npm:isomorphic-fetch@2.2.1",
-      "loose-envify": "npm:loose-envify@1.1.0",
+      "loose-envify": "npm:loose-envify@1.2.0",
+      "object-assign": "npm:object-assign@4.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
       "promise": "npm:promise@7.1.1",
       "ua-parser-js": "npm:ua-parser-js@0.7.10"
@@ -226,7 +236,7 @@ System.config({
       "assert": "github:jspm/nodelibs-assert@0.1.0",
       "events": "github:jspm/nodelibs-events@0.1.1",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "inflight": "npm:inflight@1.0.4",
+      "inflight": "npm:inflight@1.0.5",
       "inherits": "npm:inherits@2.0.1",
       "minimatch": "npm:minimatch@3.0.0",
       "once": "npm:once@1.3.3",
@@ -235,7 +245,7 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2",
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
-    "npm:history@2.1.1": {
+    "npm:history@2.1.2": {
       "deep-equal": "npm:deep-equal@1.0.1",
       "invariant": "npm:invariant@2.2.1",
       "process": "github:jspm/nodelibs-process@0.1.2",
@@ -252,30 +262,30 @@ System.config({
       "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0",
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
-    "npm:inflight@1.0.4": {
+    "npm:inflight@1.0.5": {
       "once": "npm:once@1.3.3",
       "process": "github:jspm/nodelibs-process@0.1.2",
-      "wrappy": "npm:wrappy@1.0.1"
+      "wrappy": "npm:wrappy@1.0.2"
     },
     "npm:inherits@2.0.1": {
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:invariant@2.2.1": {
-      "loose-envify": "npm:loose-envify@1.1.0",
+      "loose-envify": "npm:loose-envify@1.2.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:is-fullwidth-code-point@1.0.0": {
       "number-is-nan": "npm:number-is-nan@1.0.0"
     },
     "npm:isomorphic-fetch@2.2.1": {
-      "node-fetch": "npm:node-fetch@1.5.1",
+      "node-fetch": "npm:node-fetch@1.5.3",
       "whatwg-fetch": "npm:whatwg-fetch@1.0.0"
     },
     "npm:lcid@1.0.0": {
       "invert-kv": "npm:invert-kv@1.0.0",
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
-    "npm:lodash@4.11.2": {
+    "npm:lodash@4.13.1": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
@@ -284,7 +294,8 @@ System.config({
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:loose-envify@1.1.0": {
+    "npm:loose-envify@1.2.0": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
       "js-tokens": "npm:js-tokens@1.0.3",
       "process": "github:jspm/nodelibs-process@0.1.2",
       "stream": "github:jspm/nodelibs-stream@0.1.0",
@@ -294,7 +305,7 @@ System.config({
       "brace-expansion": "npm:brace-expansion@1.1.4",
       "path": "github:jspm/nodelibs-path@0.1.0"
     },
-    "npm:node-fetch@1.5.1": {
+    "npm:node-fetch@1.5.3": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "encoding": "npm:encoding@0.1.12",
       "http": "github:jspm/nodelibs-http@1.7.1",
@@ -309,7 +320,7 @@ System.config({
       "d3": "npm:d3@3.5.17"
     },
     "npm:once@1.3.3": {
-      "wrappy": "npm:wrappy@1.0.1"
+      "wrappy": "npm:wrappy@1.0.2"
     },
     "npm:optjs@3.2.2": {
       "process": "github:jspm/nodelibs-process@0.1.2"
@@ -335,11 +346,11 @@ System.config({
     "npm:process-nextick-args@1.0.7": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:process@0.11.2": {
+    "npm:process@0.11.3": {
       "assert": "github:jspm/nodelibs-assert@0.1.0"
     },
     "npm:promise@7.1.1": {
-      "asap": "npm:asap@2.0.3",
+      "asap": "npm:asap@2.0.4",
       "fs": "github:jspm/nodelibs-fs@0.1.2"
     },
     "npm:protobufjs@5.0.1": {
@@ -359,29 +370,29 @@ System.config({
     "npm:query-string@3.0.3": {
       "strict-uri-encode": "npm:strict-uri-encode@1.1.0"
     },
-    "npm:react-dom@15.0.2": {
-      "react": "npm:react@15.0.2"
+    "npm:react-dom@15.1.0": {
+      "react": "npm:react@15.1.0"
     },
     "npm:react-redux@4.4.5": {
-      "hoist-non-react-statics": "npm:hoist-non-react-statics@1.0.5",
+      "hoist-non-react-statics": "npm:hoist-non-react-statics@1.0.6",
       "invariant": "npm:invariant@2.2.1",
-      "lodash": "npm:lodash@4.11.2",
-      "loose-envify": "npm:loose-envify@1.1.0",
+      "lodash": "npm:lodash@4.13.1",
+      "loose-envify": "npm:loose-envify@1.2.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
-      "react": "npm:react@15.0.2",
+      "react": "npm:react@15.1.0",
       "redux": "npm:redux@3.5.2"
     },
-    "npm:react-router@2.4.0": {
-      "history": "npm:history@2.1.1",
-      "hoist-non-react-statics": "npm:hoist-non-react-statics@1.0.5",
+    "npm:react-router@2.4.1": {
+      "history": "npm:history@2.1.2",
+      "hoist-non-react-statics": "npm:hoist-non-react-statics@1.0.6",
       "invariant": "npm:invariant@2.2.1",
       "process": "github:jspm/nodelibs-process@0.1.2",
-      "react": "npm:react@15.0.2",
+      "react": "npm:react@15.1.0",
       "warning": "npm:warning@2.1.0"
     },
-    "npm:react@15.0.2": {
-      "fbjs": "npm:fbjs@0.8.1",
-      "loose-envify": "npm:loose-envify@1.1.0",
+    "npm:react@15.1.0": {
+      "fbjs": "npm:fbjs@0.8.3",
+      "loose-envify": "npm:loose-envify@1.2.0",
       "object-assign": "npm:object-assign@4.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
@@ -395,8 +406,9 @@ System.config({
       "stream-browserify": "npm:stream-browserify@1.0.0",
       "string_decoder": "npm:string_decoder@0.10.31"
     },
-    "npm:readable-stream@2.1.2": {
+    "npm:readable-stream@2.1.4": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "buffer-shims": "npm:buffer-shims@1.0.0",
       "core-util-is": "npm:core-util-is@1.0.2",
       "events": "github:jspm/nodelibs-events@0.1.1",
       "inherits": "npm:inherits@2.0.1",
@@ -407,9 +419,9 @@ System.config({
       "util-deprecate": "npm:util-deprecate@1.0.2"
     },
     "npm:redux@3.5.2": {
-      "lodash": "npm:lodash@4.11.2",
-      "lodash-es": "npm:lodash-es@4.11.2",
-      "loose-envify": "npm:loose-envify@1.1.0",
+      "lodash": "npm:lodash@4.13.1",
+      "lodash-es": "npm:lodash-es@4.13.1",
+      "loose-envify": "npm:loose-envify@1.2.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
       "symbol-observable": "npm:symbol-observable@0.2.4"
     },
@@ -449,7 +461,7 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:warning@2.1.0": {
-      "loose-envify": "npm:loose-envify@1.1.0",
+      "loose-envify": "npm:loose-envify@1.2.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:window-size@0.1.4": {

--- a/ui/next/npm-shrinkwrap.json
+++ b/ui/next/npm-shrinkwrap.json
@@ -26,6 +26,9 @@
     "amdefine": {
       "version": "1.0.0"
     },
+    "ansi-align": {
+      "version": "1.0.0"
+    },
     "ansi-regex": {
       "version": "2.0.0"
     },
@@ -33,7 +36,7 @@
       "version": "2.2.1"
     },
     "any-promise": {
-      "version": "1.2.0"
+      "version": "1.3.0"
     },
     "anymatch": {
       "version": "1.3.0"
@@ -57,7 +60,7 @@
       "version": "1.0.1"
     },
     "asap": {
-      "version": "2.0.3"
+      "version": "2.0.4"
     },
     "ascli": {
       "version": "1.0.0"
@@ -81,17 +84,14 @@
       "version": "0.6.0"
     },
     "aws4": {
-      "version": "1.3.2"
+      "version": "1.4.1"
     },
     "babel-code-frame": {
       "version": "6.8.0"
     },
     "babel-core": {
-      "version": "6.8.0",
+      "version": "6.9.1",
       "dependencies": {
-        "lodash": {
-          "version": "3.10.1"
-        },
         "minimatch": {
           "version": "2.0.10"
         },
@@ -101,11 +101,8 @@
       }
     },
     "babel-generator": {
-      "version": "6.8.0",
+      "version": "6.9.0",
       "dependencies": {
-        "lodash": {
-          "version": "3.10.1"
-        },
         "source-map": {
           "version": "0.5.6"
         }
@@ -120,57 +117,33 @@
     "babel-messages": {
       "version": "6.8.0"
     },
-    "babel-plugin-syntax-flow": {
-      "version": "6.8.0"
-    },
     "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.8.0"
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.8.0"
+      "version": "6.9.0"
     },
     "babel-register": {
-      "version": "6.8.0",
+      "version": "6.9.0",
       "dependencies": {
         "core-js": {
-          "version": "2.3.0"
-        },
-        "lodash": {
-          "version": "3.10.1"
+          "version": "2.4.0"
         }
       }
     },
     "babel-runtime": {
-      "version": "6.6.1",
+      "version": "6.9.1",
       "dependencies": {
         "core-js": {
-          "version": "2.3.0"
+          "version": "2.4.0"
         }
       }
     },
     "babel-template": {
-      "version": "6.8.0",
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1"
-        }
-      }
+      "version": "6.9.0"
     },
     "babel-traverse": {
-      "version": "6.8.0",
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1"
-        }
-      }
+      "version": "6.9.0"
     },
     "babel-types": {
-      "version": "6.8.1",
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1"
-        }
-      }
+      "version": "6.9.1"
     },
     "babylon": {
       "version": "6.8.0"
@@ -179,7 +152,7 @@
       "version": "0.4.1"
     },
     "binary-extensions": {
-      "version": "1.4.0"
+      "version": "1.4.1"
     },
     "bl": {
       "version": "1.1.2",
@@ -205,8 +178,11 @@
       "version": "2.10.1"
     },
     "boxen": {
-      "version": "0.3.1",
+      "version": "0.5.1",
       "dependencies": {
+        "camelcase": {
+          "version": "2.1.1"
+        },
         "repeating": {
           "version": "2.0.1"
         }
@@ -216,7 +192,10 @@
       "version": "1.1.4"
     },
     "braces": {
-      "version": "1.8.4"
+      "version": "1.8.5"
+    },
+    "buffer-shims": {
+      "version": "1.0.0"
     },
     "bytebuffer": {
       "version": "5.0.1"
@@ -233,6 +212,9 @@
     "center-align": {
       "version": "0.1.3"
     },
+    "chai": {
+      "version": "3.5.0"
+    },
     "chalk": {
       "version": "1.1.3"
     },
@@ -248,13 +230,13 @@
         "glob": {
           "version": "3.2.11"
         },
-        "lru-cache": {
-          "version": "2.7.3"
-        },
         "minimatch": {
           "version": "0.3.0"
         }
       }
+    },
+    "cli-boxes": {
+      "version": "1.0.0"
     },
     "cliui": {
       "version": "2.1.0",
@@ -327,13 +309,16 @@
       "version": "0.3.1"
     },
     "cssstyle": {
-      "version": "0.2.34"
+      "version": "0.2.36"
     },
     "ctype": {
       "version": "0.5.3"
     },
     "d": {
       "version": "0.1.1"
+    },
+    "d3": {
+      "version": "3.5.17"
     },
     "dashdash": {
       "version": "1.13.1",
@@ -342,6 +327,9 @@
           "version": "1.0.0"
         }
       }
+    },
+    "data-uri-to-buffer": {
+      "version": "0.0.4"
     },
     "debug": {
       "version": "2.2.0"
@@ -410,7 +398,7 @@
           "version": "1.0.0"
         },
         "readable-stream": {
-          "version": "2.1.2"
+          "version": "2.1.4"
         }
       }
     },
@@ -428,6 +416,9 @@
     },
     "entities": {
       "version": "1.1.1"
+    },
+    "enzyme": {
+      "version": "2.3.0"
     },
     "err-code": {
       "version": "1.1.1"
@@ -478,7 +469,7 @@
       "version": "0.1.5"
     },
     "expand-range": {
-      "version": "1.8.1"
+      "version": "1.8.2"
     },
     "expand-tilde": {
       "version": "1.2.1"
@@ -496,13 +487,19 @@
       "version": "1.1.3"
     },
     "fbjs": {
-      "version": "0.8.1"
+      "version": "0.8.3"
     },
     "fd-slicer": {
       "version": "1.0.1"
     },
+    "fetch-mock": {
+      "version": "4.5.0"
+    },
     "filename-regex": {
       "version": "2.0.0"
+    },
+    "fill-keys": {
+      "version": "1.0.2"
     },
     "fill-range": {
       "version": "2.2.3"
@@ -543,7 +540,7 @@
       "version": "0.3.8"
     },
     "fstream": {
-      "version": "1.0.8"
+      "version": "1.0.9"
     },
     "function-bind": {
       "version": "1.1.0"
@@ -597,18 +594,18 @@
           "version": "1.0.0"
         },
         "readable-stream": {
-          "version": "2.1.2"
+          "version": "2.1.4"
         }
       }
     },
     "graceful-fs": {
-      "version": "4.1.3"
+      "version": "4.1.4"
     },
     "graceful-readlink": {
       "version": "1.0.1"
     },
     "growl": {
-      "version": "1.8.1"
+      "version": "1.9.2"
     },
     "har-validator": {
       "version": "2.0.6"
@@ -624,6 +621,9 @@
     },
     "hoek": {
       "version": "2.16.3"
+    },
+    "hoist-non-react-statics": {
+      "version": "1.0.6"
     },
     "home-or-tmp": {
       "version": "1.0.0"
@@ -648,11 +648,14 @@
     "iconv-lite": {
       "version": "0.4.13"
     },
+    "immutable": {
+      "version": "3.8.1"
+    },
     "imurmurhash": {
       "version": "0.1.4"
     },
     "inflight": {
-      "version": "1.0.4"
+      "version": "1.0.5"
     },
     "inherits": {
       "version": "2.0.1"
@@ -667,7 +670,7 @@
       "version": "0.2.7"
     },
     "is-absolute": {
-      "version": "0.1.7"
+      "version": "0.2.5"
     },
     "is-arrayish": {
       "version": "0.2.1"
@@ -705,9 +708,6 @@
     "is-glob": {
       "version": "1.1.3"
     },
-    "is-integer": {
-      "version": "1.0.6"
-    },
     "is-my-json-valid": {
       "version": "2.13.1"
     },
@@ -718,6 +718,9 @@
       "version": "2.1.0"
     },
     "is-obj": {
+      "version": "1.0.1"
+    },
+    "is-object": {
       "version": "1.0.1"
     },
     "is-plain-obj": {
@@ -739,7 +742,7 @@
       "version": "1.0.3"
     },
     "is-relative": {
-      "version": "0.1.3"
+      "version": "0.2.1"
     },
     "is-retry-allowed": {
       "version": "1.0.0"
@@ -820,8 +823,11 @@
     "jsonpointer": {
       "version": "2.0.0"
     },
+    "jspm": {
+      "version": "0.16.35"
+    },
     "jspm-github": {
-      "version": "0.13.12",
+      "version": "0.13.13",
       "dependencies": {
         "asn1": {
           "version": "0.1.11"
@@ -979,7 +985,10 @@
       "version": "1.0.1"
     },
     "lodash": {
-      "version": "4.11.2"
+      "version": "4.13.1"
+    },
+    "lodash-es": {
+      "version": "4.13.1"
     },
     "lolex": {
       "version": "1.3.2"
@@ -991,13 +1000,13 @@
       "version": "1.0.1"
     },
     "loose-envify": {
-      "version": "1.1.0"
+      "version": "1.2.0"
     },
     "lowercase-keys": {
       "version": "1.0.0"
     },
     "lru-cache": {
-      "version": "4.0.1"
+      "version": "2.7.3"
     },
     "make-error": {
       "version": "1.1.1"
@@ -1005,8 +1014,8 @@
     "make-error-cause": {
       "version": "1.1.0"
     },
-    "methods": {
-      "version": "1.1.2"
+    "merge-descriptors": {
+      "version": "1.0.1"
     },
     "micromatch": {
       "version": "2.3.8",
@@ -1031,6 +1040,29 @@
     "mkdirp": {
       "version": "0.5.1"
     },
+    "mocha": {
+      "version": "2.5.3",
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2"
+        },
+        "glob": {
+          "version": "3.2.11"
+        },
+        "minimatch": {
+          "version": "0.3.0"
+        },
+        "supports-color": {
+          "version": "1.2.0"
+        }
+      }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1"
+    },
     "ms": {
       "version": "0.7.1"
     },
@@ -1044,7 +1076,7 @@
       "version": "0.1.4"
     },
     "node-fetch": {
-      "version": "1.5.1"
+      "version": "1.5.3"
     },
     "node-status-codes": {
       "version": "1.0.0"
@@ -1079,10 +1111,13 @@
       "version": "1.3.7"
     },
     "oauth-sign": {
-      "version": "0.8.1"
+      "version": "0.8.2"
     },
     "object-assign": {
       "version": "4.1.0"
+    },
+    "object-is": {
+      "version": "1.0.1"
     },
     "object-keys": {
       "version": "1.0.9"
@@ -1158,7 +1193,7 @@
       "version": "2.0.1"
     },
     "popsicle": {
-      "version": "5.0.1",
+      "version": "6.2.0",
       "dependencies": {
         "async": {
           "version": "0.9.2"
@@ -1181,19 +1216,19 @@
       }
     },
     "popsicle-proxy-agent": {
-      "version": "1.0.0"
+      "version": "2.0.1"
     },
     "popsicle-retry": {
-      "version": "2.0.0"
+      "version": "3.1.0"
     },
     "popsicle-status": {
-      "version": "1.0.2"
+      "version": "2.0.0"
     },
     "prelude-ls": {
       "version": "1.1.2"
     },
     "prepend-http": {
-      "version": "1.0.3"
+      "version": "1.0.4"
     },
     "preserve": {
       "version": "0.2.0"
@@ -1202,19 +1237,32 @@
       "version": "0.1.6"
     },
     "process-nextick-args": {
-      "version": "1.0.6"
+      "version": "1.0.7"
     },
     "promise": {
       "version": "7.1.1"
     },
     "promise-finally": {
-      "version": "2.1.0"
+      "version": "2.2.0"
     },
     "proper-lockfile": {
       "version": "1.1.2"
     },
-    "pseudomap": {
-      "version": "1.0.2"
+    "proto2ts": {
+      "version": "1.0.0",
+      "from": "sintef-9012/Proto2TypeScript",
+      "resolved": "git://github.com/sintef-9012/Proto2TypeScript.git#cac85819caf88028fe85fad5748c12e8743ac173"
+    },
+    "protobufjs": {
+      "version": "5.0.1",
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15"
+        }
+      }
+    },
+    "proxyquire": {
+      "version": "1.7.9"
     },
     "qs": {
       "version": "6.1.0"
@@ -1230,6 +1278,18 @@
         }
       }
     },
+    "react": {
+      "version": "15.1.0"
+    },
+    "react-addons-test-utils": {
+      "version": "15.1.0"
+    },
+    "react-dom": {
+      "version": "15.1.0"
+    },
+    "react-redux": {
+      "version": "4.4.5"
+    },
     "read-all-stream": {
       "version": "3.1.0",
       "dependencies": {
@@ -1237,7 +1297,7 @@
           "version": "1.0.0"
         },
         "readable-stream": {
-          "version": "2.1.2"
+          "version": "2.1.4"
         }
       }
     },
@@ -1247,9 +1307,6 @@
     "readdirp": {
       "version": "1.4.0",
       "dependencies": {
-        "lru-cache": {
-          "version": "2.7.3"
-        },
         "minimatch": {
           "version": "0.2.14"
         },
@@ -1260,6 +1317,9 @@
     },
     "rechoir": {
       "version": "0.6.2"
+    },
+    "redux": {
+      "version": "3.5.2"
     },
     "regex-cache": {
       "version": "0.4.3"
@@ -1278,6 +1338,9 @@
     },
     "request": {
       "version": "2.72.0"
+    },
+    "reselect": {
+      "version": "2.5.1"
     },
     "resolve": {
       "version": "1.1.7"
@@ -1331,8 +1394,14 @@
     "shebang-regex": {
       "version": "1.0.0"
     },
+    "shonkwrap": {
+      "version": "1.3.0"
+    },
     "sigmund": {
       "version": "1.0.1"
+    },
+    "sinon": {
+      "version": "1.17.4"
     },
     "slash": {
       "version": "1.0.0"
@@ -1344,7 +1413,7 @@
       "version": "1.0.9"
     },
     "sort-keys": {
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     "source-map": {
       "version": "0.2.0"
@@ -1356,6 +1425,12 @@
           "version": "0.1.32"
         }
       }
+    },
+    "source-map-url": {
+      "version": "0.4.0"
+    },
+    "sprintf-js": {
+      "version": "1.0.3"
     },
     "sshpk": {
       "version": "1.8.3",
@@ -1389,17 +1464,20 @@
     "supports-color": {
       "version": "2.0.0"
     },
+    "symbol-observable": {
+      "version": "0.2.4"
+    },
     "symbol-tree": {
       "version": "3.1.4"
     },
     "systemjs": {
-      "version": "0.19.27"
+      "version": "0.19.29"
     },
     "systemjs-builder": {
-      "version": "0.15.16",
+      "version": "0.15.17",
       "dependencies": {
         "bluebird": {
-          "version": "3.3.5"
+          "version": "3.4.0"
         },
         "glob": {
           "version": "7.0.3"
@@ -1418,11 +1496,17 @@
     "throat": {
       "version": "2.0.2"
     },
+    "throwback": {
+      "version": "1.1.0"
+    },
     "timed-out": {
       "version": "2.0.0"
     },
     "to-fast-properties": {
       "version": "1.0.2"
+    },
+    "to-iso-string": {
+      "version": "0.0.2"
     },
     "touch": {
       "version": "1.0.0"
@@ -1444,11 +1528,36 @@
         }
       }
     },
-    "trim-right": {
-      "version": "1.0.1"
+    "ts-node": {
+      "version": "0.7.3",
+      "dependencies": {
+        "diff": {
+          "version": "2.2.2"
+        },
+        "minimist": {
+          "version": "1.2.0"
+        },
+        "source-map": {
+          "version": "0.1.32"
+        },
+        "source-map-support": {
+          "version": "0.4.0"
+        }
+      }
+    },
+    "tslint": {
+      "version": "3.10.2",
+      "dependencies": {
+        "diff": {
+          "version": "2.2.2"
+        },
+        "glob": {
+          "version": "7.0.3"
+        }
+      }
     },
     "tunnel-agent": {
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     "tweetnacl": {
       "version": "0.13.3"
@@ -1465,20 +1574,28 @@
     "typescript": {
       "version": "1.8.10"
     },
+    "typings": {
+      "version": "1.0.4",
+      "dependencies": {
+        "bluebird": {
+          "version": "3.4.0"
+        },
+        "minimist": {
+          "version": "1.2.0"
+        }
+      }
+    },
     "typings-core": {
-      "version": "0.3.1",
+      "version": "1.0.1",
       "dependencies": {
         "detect-indent": {
           "version": "4.0.0"
         },
-        "is-absolute": {
-          "version": "0.2.5"
-        },
-        "is-relative": {
-          "version": "0.2.1"
-        },
         "repeating": {
           "version": "2.0.1"
+        },
+        "typescript": {
+          "version": "1.8.7"
         }
       }
     },
@@ -1503,13 +1620,13 @@
       "version": "0.1.2"
     },
     "underscore.string": {
-      "version": "3.1.1"
+      "version": "3.3.4"
     },
     "unzip-response": {
       "version": "1.0.0"
     },
     "update-notifier": {
-      "version": "0.6.3"
+      "version": "0.7.0"
     },
     "url-parse-lax": {
       "version": "1.0.0"
@@ -1545,7 +1662,7 @@
       "version": "3.7.7"
     },
     "which": {
-      "version": "1.2.4"
+      "version": "1.2.9"
     },
     "widest-line": {
       "version": "1.0.0"
@@ -1557,7 +1674,7 @@
       "version": "1.0.0"
     },
     "wrappy": {
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "write-file-atomic": {
       "version": "1.1.4"
@@ -1571,14 +1688,11 @@
     "xtend": {
       "version": "4.0.1"
     },
-    "yallist": {
-      "version": "2.0.0"
-    },
     "yargs": {
       "version": "3.10.0"
     },
     "yauzl": {
-      "version": "2.4.1"
+      "version": "2.4.2"
     },
     "zip-object": {
       "version": "0.1.0"

--- a/ui/next/package.json
+++ b/ui/next/package.json
@@ -1,5 +1,5 @@
 {
-  "devDependencies": {
+  "dependencies": {
     "chai": "^3.5.0",
     "d3": "^3.5.17",
     "enzyme": "^2.2.0",
@@ -22,7 +22,7 @@
     "ts-node": "^0.7.2",
     "tslint": "^3.8.1",
     "typescript": "^1.8.10",
-    "typings": "^0.8.1"
+    "typings": "^1.0.4"
   },
   "jspm": {
     "dependencies": {

--- a/ui/next/typings.json
+++ b/ui/next/typings.json
@@ -1,32 +1,31 @@
 {
-  "ambientDependencies": {
+  "globalDependencies": {
     "bytebuffer": "file:local_typings/bytebuffer/bytebuffer.d.ts",
-    "chai": "registry:dt/chai#3.4.0+20160317120654",
     "classnames": "registry:dt/classnames#0.0.0+20160316155526",
     "cockroach-protos": "file:generated/protos.d.ts",
-    "es6-promise": "registry:dt/es6-promise#0.0.0+20160317120654",
-    "isomorphic-fetch": "registry:dt/isomorphic-fetch#0.0.0+20160316155526",
+    "es6-promise": "registry:dt/es6-promise#0.0.0+20160423074304",
+    "isomorphic-fetch": "registry:dt/isomorphic-fetch#0.0.0+20160524142046",
     "long": "file:local_typings/long/long.d.ts",
     "mocha": "registry:dt/mocha#2.2.5+20160317120654",
-    "object-assign": "registry:dt/object-assign#4.0.1+20160316155526",
-    "proxyquire": "registry:dt/proxyquire#1.3.0+20160316155526",
-    "react": "registry:dt/react#0.14.0+20160319053454",
-    "react-dom": "registry:dt/react-dom#0.14.0+20160316155526",
-    "react-redux": "registry:dt/react-redux#4.4.0+20160406115600",
-    "react-router": "registry:dt/react-router#2.0.0+20160423062133",
+    "react": "registry:dt/react#0.14.0+20160526134601",
+    "react-dom": "registry:dt/react-dom#0.14.0+20160412154040",
+    "react-redux": "registry:dt/react-redux#4.4.0+20160501125835",
+    "react-router": "registry:dt/react-router#2.0.0+20160501155536",
     "react-router-redux": "registry:dt/react-router-redux#4.0.0+20160316155526",
     "react-router/history": "registry:dt/react-router/history#2.0.0+20160316155526",
     "redux": "registry:dt/redux#3.3.1+20160326112656",
     "redux-thunk": "registry:dt/redux-thunk#2.0.1+20160317120654"
   },
   "dependencies": {
+    "chai": "registry:npm/chai#3.5.0+20160415060238",
     "d3": "registry:npm/d3#3.0.0+20160211003958",
     "enzyme": "registry:npm/enzyme#2.2.0+20160322031343",
     "fetch-mock": "registry:npm/fetch-mock#4.1.1+20160310030142",
     "lodash": "registry:npm/lodash#4.0.0+20160416211519",
     "moment": "registry:npm/moment#2.10.5+20160211003958",
     "nvd3": "registry:npm/nvd3#1.8.3+20160501004949",
-    "reselect": "github:reactjs/reselect/src/reselect.d.ts#v2.5.1",
-    "sinon": "registry:npm/sinon#1.16.0+20160309002336"
+    "object-assign": "registry:npm/object-assign#4.0.1+20160301180549",
+    "proxyquire": "registry:npm/proxyquire#1.0.0+20160211003958",
+    "sinon": "registry:npm/sinon#1.16.0+20160427193336"
   }
 }


### PR DESCRIPTION
Notably includes typings 1.0.0.

NB: There are external definitions available for es6-promise, but
isomorphic-fetch's definitions depend on es6-promise's ambient
definitions.

Also note that redux ships with external definitions, but none of the
react packages do, and the react packages' global definitions have not
been updated for use with the new external redux definitions.

Finally, a manual override was necessary to make reselect's external
typings load via plugin-typescript. This appears to be a bug, since
this exact information is present in reselect's package.json.
Discussion is ongoing in https://github.com/frankwallis/plugin-typescript/issues/102.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6962)

<!-- Reviewable:end -->
