### PR TITLE
sql: use rowUpdater for schema change backfills

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -17,11 +17,9 @@
 package sql
 
 import (
-	"bytes"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/client"
-	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -202,16 +200,17 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 		return err
 	}
 
-	// Remember any new non nullable column with no default value.
-	nonNullableColumn := ""
+	// Note if there is a new non nullable column with no default value.
+	addingNonNullableColumn := false
 	for _, columnDesc := range added {
 		if columnDesc.DefaultExpr == nil && !columnDesc.Nullable {
-			nonNullableColumn = columnDesc.Name
+			addingNonNullableColumn = true
+			break
 		}
 	}
 
 	// Add or Drop a column.
-	if len(dropped) > 0 || nonNullableColumn != "" || len(defaultExprs) > 0 {
+	if len(dropped) > 0 || addingNonNullableColumn || len(defaultExprs) > 0 {
 		// Initialize start and end to represent a span of keys.
 		sp, err := sc.getTableSpan()
 		if err != nil {
@@ -229,7 +228,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 
 			// Add and delete columns for a chunk of the key space.
 			sp.Start, done, err = sc.truncateAndBackfillColumnsChunk(
-				added, dropped, nonNullableColumn, defaultExprs, &sc.evalCtx, sp,
+				added, dropped, defaultExprs, &sc.evalCtx, sp,
 			)
 			if err != nil {
 				return err
@@ -242,12 +241,11 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 	added []sqlbase.ColumnDescriptor,
 	dropped []sqlbase.ColumnDescriptor,
-	nonNullableColumn string,
 	defaultExprs []parser.TypedExpr,
 	evalCtx *parser.EvalContext,
 	sp sqlbase.Span,
 ) (roachpb.Key, bool, error) {
-	var curSentinel roachpb.Key
+	var curIndexKey roachpb.Key
 	done := false
 	err := sc.db.Txn(func(txn *client.Txn) error {
 		tableDesc, err := getTableDescFromID(txn, sc.tableID)
@@ -260,92 +258,89 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 			return nil
 		}
 
+		updateCols := append(added, dropped...)
+		// TODO(dan): Tighten up the bound on the requestedCols parameter to
+		// makeRowUpdater.
+		ru, err := makeRowUpdater(tableDesc, updateCols, tableDesc.Columns)
+		if err != nil {
+			return err
+		}
+
+		// TODO(dan): This check is an unfortunate bleeding of the internals of
+		// rowUpdater. Extract the sql row to k/v mapping logic out into something
+		// usable here.
+		if !ru.isColumnOnlyUpdate() {
+			panic("only column data should be modified, but the rowUpdater is configured otherwise")
+		}
+
 		// Run a scan across the table using the primary key. Running
 		// the scan and applying the changes in many transactions is
 		// fine because the schema change is in the correct state to
 		// handle intermediate OLTP commands which delete and add
 		// values during the scan.
-		b := &client.Batch{}
-		b.Scan(sp.Start, sp.End, ColumnTruncateAndBackfillChunkSize)
-		if err := txn.Run(b); err != nil {
+		var rf sqlbase.RowFetcher
+		colIDtoRowIndex := colIDtoRowIndexFromCols(tableDesc.Columns)
+		valNeededForCol := make([]bool, len(tableDesc.Columns))
+		for i := range valNeededForCol {
+			_, valNeededForCol[i] = ru.fetchColIDtoRowIndex[tableDesc.Columns[i].ID]
+		}
+		err = rf.Init(tableDesc, colIDtoRowIndex, &tableDesc.PrimaryIndex, false, false, valNeededForCol)
+		if err != nil {
+			return err
+		}
+		// StartScan uses 0 as a sentinal for the default limit of entries scanned.
+		if err := rf.StartScan(txn, sqlbase.Spans{sp}, 0); err != nil {
 			return err
 		}
 
-		// Use a different batch to truncate/backfill columns.
+		indexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc.ID, tableDesc.PrimaryIndex.ID)
+		updateValues := make(parser.DTuple, len(updateCols))
+
 		writeBatch := &client.Batch{}
-		marshalled := make([]roachpb.Value, len(defaultExprs))
-		done = true
-		for _, result := range b.Results {
-			var sentinelKey roachpb.Key
-			for _, kv := range result.Rows {
-				// Still processing table.
-				done = false
-				if nonNullableColumn != "" {
-					return sqlbase.NewNonNullViolationError(nonNullableColumn)
+		var i int
+		for ; i < ColumnTruncateAndBackfillChunkSize; i++ {
+			row, err := rf.NextRow()
+			if err != nil {
+				return err
+			}
+			if row == nil {
+				break // Done
+			}
+
+			curIndexKey, _, err = sqlbase.EncodeIndexKey(
+				&tableDesc.PrimaryIndex, colIDtoRowIndex, row, indexKeyPrefix)
+
+			for i, col := range added {
+				if defaultExprs == nil || defaultExprs[i] == nil {
+					updateValues[i] = parser.DNull
+				} else {
+					updateValues[i], err = defaultExprs[i].Eval(evalCtx)
+					if err != nil {
+						return err
+					}
 				}
-				if sentinelKey == nil || !bytes.HasPrefix(kv.Key, sentinelKey) {
-					// Sentinel keys have a 0 suffix indicating 0 bytes of
-					// column ID. Strip off that suffix to determine the
-					// prefix shared with the other keys for the row.
-					sentinelKey = sqlbase.StripColumnIDLength(kv.Key)
-					// Store away key for the next table row as the point from
-					// which to start from.
-					curSentinel = sentinelKey
-
-					// Delete the entire dropped columns. This used to use SQL
-					// UPDATE in the past to update the dropped column to
-					// NULL; but a column in the process of being dropped is
-					// placed in the table descriptor mutations, and a SQL
-					// UPDATE of a column in mutations will fail.
-					for _, columnDesc := range dropped {
-						// Delete the dropped column.
-						colKey := keys.MakeColumnKey(sentinelKey, uint32(columnDesc.ID))
-						if log.V(2) {
-							log.Infof("Del %s", colKey)
-						}
-						writeBatch.Del(colKey)
-					}
-
-					// Add the new columns and backfill the values.
-					for i, expr := range defaultExprs {
-						if expr == nil {
-							continue
-						}
-						col := added[i]
-						colKey := keys.MakeColumnKey(sentinelKey, uint32(col.ID))
-						d, err := expr.Eval(evalCtx)
-						if err != nil {
-							return err
-						}
-						marshalled[i], err = sqlbase.MarshalColumnValue(col, d)
-						if err != nil {
-							return err
-						}
-
-						if log.V(2) {
-							log.Infof("Put %s -> %v", colKey, d)
-						}
-						// Insert default value into the column. If this row
-						// was recently added the default value might have
-						// already been populated, because the
-						// ColumnDescriptor is in the WRITE_ONLY state.
-						// Reinserting the default value is not a big deal.
-						//
-						// Note: a column in the WRITE_ONLY state cannot be
-						// populated directly through SQL. A SQL INSERT cannot
-						// directly reference the column, and the INSERT
-						// populates the column with the default value.
-						writeBatch.Put(colKey, &marshalled[i])
-					}
+				if !col.Nullable && updateValues[i].Compare(parser.DNull) == 0 {
+					return sqlbase.NewNonNullViolationError(col.Name)
 				}
 			}
+			for i := range dropped {
+				updateValues[i+len(added)] = parser.DNull
+			}
+
+			if _, err := ru.updateRow(writeBatch, row, updateValues); err != nil {
+				return err
+			}
 		}
+		if i < ColumnTruncateAndBackfillChunkSize {
+			done = true
+		}
+
 		if err := txn.Run(writeBatch); err != nil {
 			return convertBackfillError(tableDesc, writeBatch)
 		}
 		return nil
 	})
-	return curSentinel.PrefixEnd(), done, err
+	return curIndexKey.PrefixEnd(), done, err
 }
 
 func (sc *SchemaChanger) truncateIndexes(

--- a/sql/rowwriter.go
+++ b/sql/rowwriter.go
@@ -472,6 +472,18 @@ func (ru *rowUpdater) updateRow(
 	return ru.newValues, nil
 }
 
+// isColumnOnlyUpdate returns true if this rowUpdater is only updating column
+// data (in contrast to updating the primary key or other indexes).
+func (ru *rowUpdater) isColumnOnlyUpdate() bool {
+	// TODO(dan): This is used in the schema change backfill to assert that it was
+	// configured correctly and will not be doing things it shouldn't. This is an
+	// unfortunate bleeding of responsibility and indicates the abstraction could
+	// be improved. Specifically, rowUpdater currently has two responsibilities
+	// (computing which indexes need to be updated and mapping sql rows to k/v
+	// operations) and these should be split.
+	return !ru.primaryKeyColChange && len(ru.deleteOnlyIndex) == 0 && len(ru.helper.indexes) == 0
+}
+
 // rowDeleter abstracts the key/value operations for deleting table rows.
 type rowDeleter struct {
 	helper               rowHelper

--- a/sql/sqlbase/keys.go
+++ b/sql/sqlbase/keys.go
@@ -115,11 +115,3 @@ func MakeIndexKeyPrefix(tableID ID, indexID IndexID) []byte {
 	key = encoding.EncodeUvarintAscending(key, uint64(indexID))
 	return key
 }
-
-// StripColumnIDLength strips off a one byte suffix from the key.
-func StripColumnIDLength(key roachpb.Key) roachpb.Key {
-	if n := len(key); n > 0 {
-		return key[:n-1]
-	}
-	return key
-}

--- a/sql/testdata/alter_table
+++ b/sql/testdata/alter_table
@@ -286,6 +286,26 @@ SELECT a,b FROM add_default WHERE e > d AND e - d < interval '10s'
 3 10
 5 NULL
 
+# Multiple columns can be added at once with heterogeneous DEFAULT usage
+statement ok
+CREATE TABLE d (a INT PRIMARY KEY)
+
+statement ok
+INSERT INTO d VALUES (1), (2)
+
+statement ok
+ALTER TABLE d ADD COLUMN c INT, ADD COLUMN b INT DEFAULT 7
+
+statement ok
+INSERT INTO d (a, c) VALUES (3, 4)
+
+query III
+SELECT * FROM d
+----
+1 NULL 7
+2 NULL 7
+3 4    7
+
 # Test privileges.
 
 statement ok


### PR DESCRIPTION
The existing code makes assumptions about the layout of the sql to k/v mapping
that will no longer be true with column families.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6970)

<!-- Reviewable:end -->
