### PR TITLE
storage/engine: split up Engine interface

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -920,7 +920,7 @@ func TestSortRangeDescByAge(t *testing.T) {
 	}
 }
 
-func verifyRangeStats(eng engine.Engine, rangeID roachpb.RangeID, expMS engine.MVCCStats) error {
+func verifyRangeStats(eng engine.Reader, rangeID roachpb.RangeID, expMS engine.MVCCStats) error {
 	var ms engine.MVCCStats
 	if err := engine.MVCCGetRangeStats(context.Background(), eng, rangeID, &ms); err != nil {
 		return err
@@ -933,7 +933,9 @@ func verifyRangeStats(eng engine.Engine, rangeID roachpb.RangeID, expMS engine.M
 	return nil
 }
 
-func verifyRecomputedStats(eng engine.Engine, d *roachpb.RangeDescriptor, expMS engine.MVCCStats, nowNanos int64) error {
+func verifyRecomputedStats(
+	eng engine.Reader, d *roachpb.RangeDescriptor, expMS engine.MVCCStats, nowNanos int64,
+) error {
 	if ms, err := storage.ComputeStatsForRange(d, eng, nowNanos); err != nil {
 		return err
 	} else if expMS != ms {

--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -47,7 +47,7 @@ func mvccKey(k interface{}) MVCCKey {
 	}
 }
 
-func testBatchBasics(t *testing.T, commit func(e, b Engine) error) {
+func testBatchBasics(t *testing.T, commit func(e Engine, b Batch) error) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
@@ -118,14 +118,14 @@ func testBatchBasics(t *testing.T, commit func(e, b Engine) error) {
 // visible until commit, and then are all visible after commit.
 func TestBatchBasics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	testBatchBasics(t, func(e, b Engine) error {
+	testBatchBasics(t, func(e Engine, b Batch) error {
 		return b.Commit()
 	})
 }
 
 func TestBatchRepr(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	testBatchBasics(t, func(e, b Engine) error {
+	testBatchBasics(t, func(e Engine, b Batch) error {
 		repr := b.Repr()
 
 		// Simple sanity checks about the format of the batch representation. This

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -87,17 +87,14 @@ type Iterator interface {
 	ComputeStats(start, end MVCCKey, nowNanos int64) (MVCCStats, error)
 }
 
-// Engine is the interface that wraps the core operations of a
-// key/value store.
-type Engine interface {
-	// Open initializes the engine.
-	Open() error
-	// Close closes the engine, freeing up any outstanding resources.
+// Reader is the read interface to an engine's data.
+type Reader interface {
+	// Close closes the reader, freeing up any outstanding resources.
 	Close()
-	// Attrs returns the engine/store attributes.
-	Attrs() roachpb.Attributes
-	// Put sets the given key to the value provided.
-	Put(key MVCCKey, value []byte) error
+	// closed returns true if the reader has been closed or is not usable.
+	// Objects backed by this reader (e.g. Iterators) can check this to ensure
+	// that they are not using a closed engine.
+	closed() bool
 	// Get returns the value for the given key, nil otherwise.
 	Get(key MVCCKey) ([]byte, error)
 	// GetProto fetches the value at the specified key and unmarshals it
@@ -111,6 +108,21 @@ type Engine interface {
 	// an error, the iteration will stop and return the error.
 	// If the first result of f is true, the iteration stops.
 	Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error
+	// NewIterator returns a new instance of an Iterator over this engine. When
+	// prefix is true, Seek will use the user-key prefix of the supplied MVCC key
+	// to restrict which sstables are searched, but iteration (using Next) over
+	// keys without the same user-key prefix will not work correctly (keys may be
+	// skipped). The caller must invoke Iterator.Close() when finished with the
+	// iterator to free resources.
+	NewIterator(prefix bool) Iterator
+}
+
+// Writer is the write interface to an engine's data.
+type Writer interface {
+	// ApplyBatchRepr atomically applies a set of batched updates. Created by
+	// calling Repr() on a batch. Using this method is equivalent to constructing
+	// and committing a batch whose Repr() equals repr.
+	ApplyBatchRepr(repr []byte) error
 	// Clear removes the item from the db with the given key.
 	// Note that clear actually removes entries from the storage
 	// engine, rather than inserting tombstones.
@@ -129,59 +141,52 @@ type Engine interface {
 	//
 	// The logic for merges is written in db.cc in order to be compatible with RocksDB.
 	Merge(key MVCCKey, value []byte) error
+	// Put sets the given key to the value provided.
+	Put(key MVCCKey, value []byte) error
+}
+
+// ReadWriter is the read/write interface to an engine's data.
+type ReadWriter interface {
+	Reader
+	Writer
+}
+
+// Engine is the interface that wraps the core operations of a key/value store.
+type Engine interface {
+	ReadWriter
+	// Attrs returns the engine/store attributes.
+	Attrs() roachpb.Attributes
 	// Capacity returns capacity details for the engine's available storage.
 	Capacity() (roachpb.StoreCapacity, error)
 	// Flush causes the engine to write all in-memory data to disk
 	// immediately.
 	Flush() error
-	// NewIterator returns a new instance of an Iterator over this engine. When
-	// prefix is true, Seek will use the user-key prefix of the supplied MVCC key
-	// to restrict which sstables are searched, but iteration (using Next) over
-	// keys without the same user-key prefix will not work correctly (keys may be
-	// skipped). The caller must invoke Iterator.Close() when finished with the
-	// iterator to free resources.
-	NewIterator(prefix bool) Iterator
+	// GetStats retrieves stats from the engine.
+	GetStats() (*Stats, error)
+	// NewBatch returns a new instance of a batched engine which wraps
+	// this engine. Batched engines accumulate all mutations and apply
+	// them atomically on a call to Commit().
+	NewBatch() Batch
 	// NewSnapshot returns a new instance of a read-only snapshot
 	// engine. Snapshots are instantaneous and, as long as they're
 	// released relatively quickly, inexpensive. Snapshots are released
 	// by invoking Close(). Note that snapshots must not be used after the
 	// original engine has been stopped.
-	NewSnapshot() Engine
-	// NewBatch returns a new instance of a batched engine which wraps
-	// this engine. Batched engines accumulate all mutations and apply
-	// them atomically on a call to Commit().
-	NewBatch() Batch
-	// Commit atomically applies any batched updates to the underlying
-	// engine. This is a noop unless the engine was created via NewBatch().
-	Commit() error
-	// ApplyBatchRepr atomically applies a set of batched updates. Created by
-	// calling Repr() on a batch. Using this method is equivalent to constructing
-	// and committing a batch whose Repr() equals repr.
-	ApplyBatchRepr(repr []byte) error
-	// Repr returns the underlying representation of the batch and can be used to
-	// reconstitute the batch on a remote node using
-	// Engine.NewBatchFromRepr(). This method is only valid on engines created
-	// via NewBatch().
-	Repr() []byte
-	// Defer adds a callback to be run after the batch commits
-	// successfully.  If Commit() fails (or if this engine was not
-	// created via NewBatch()), deferred callbacks are not called. As
-	// with the defer statement, the last callback to be deferred is the
-	// first to be executed.
-	Defer(fn func())
-	// Closed returns true if the engine has been close or not usable.
-	// Objects backed by this engine (e.g. Iterators) can check this to ensure
-	// that they are not using an closed engine.
-	Closed() bool
-	// GetStats retrieves stats from the engine.
-	GetStats() (*Stats, error)
+	NewSnapshot() Reader
+	// Open initializes the engine.
+	Open() error
 }
 
 // Batch is the interface for batch specific operations.
-//
-// TODO(peter): Move various methods of Engine to Batch, such as Commit() and Repr().
 type Batch interface {
-	Engine
+	ReadWriter
+	// Commit atomically applies any batched updates to the underlying
+	// engine. This is a noop unless the engine was created via NewBatch().
+	Commit() error
+	// Defer adds a callback to be run after the batch commits successfully. If
+	// Commit() fails deferred callbacks are not called. As with the defer
+	// statement, the last callback to be deferred is the first to be executed.
+	Defer(fn func())
 	// Distinct returns a view of the existing batch which passes reads directly
 	// to the underlying engine (the one the batch was created from). That is,
 	// the returned batch will not read its own writes. This is used as an
@@ -189,7 +194,10 @@ type Batch interface {
 	// situations where we know all of the batched operations are for distinct
 	// keys. Closing/committing the returned engine is equivalent to
 	// closing/committing the original batch.
-	Distinct() Engine
+	Distinct() ReadWriter
+	// Repr returns the underlying representation of the batch and can be used to
+	// reconstitute the batch on a remote node using Writer.ApplyBatchRepr().
+	Repr() []byte
 }
 
 // Stats is a set of RocksDB stats. These are all described in RocksDB
@@ -220,7 +228,7 @@ type Stats struct {
 // PutProto sets the given key to the protobuf-serialized byte string
 // of msg and the provided timestamp. Returns the length in bytes of
 // key and the value.
-func PutProto(engine Engine, key MVCCKey, msg proto.Message) (keyBytes, valBytes int64, err error) {
+func PutProto(engine Writer, key MVCCKey, msg proto.Message) (keyBytes, valBytes int64, err error) {
 	bytes, err := protoutil.Marshal(msg)
 	if err != nil {
 		return 0, 0, err
@@ -236,7 +244,7 @@ func PutProto(engine Engine, key MVCCKey, msg proto.Message) (keyBytes, valBytes
 // Scan returns up to max key/value objects starting from
 // start (inclusive) and ending at end (non-inclusive).
 // Specify max=0 for unbounded scans.
-func Scan(engine Engine, start, end MVCCKey, max int64) ([]MVCCKeyValue, error) {
+func Scan(engine Reader, start, end MVCCKey, max int64) ([]MVCCKeyValue, error) {
 	var kvs []MVCCKeyValue
 	err := engine.Iterate(start, end, func(kv MVCCKeyValue) (bool, error) {
 		if max != 0 && int64(len(kvs)) >= max {
@@ -254,12 +262,10 @@ func Scan(engine Engine, start, end MVCCKey, max int64) ([]MVCCKeyValue, error) 
 // none, and an error will be returned. Note that this function
 // actually removes entries from the storage engine, rather than
 // inserting tombstones, as with deletion through the MVCC.
-func ClearRange(engine Engine, start, end MVCCKey) (int, error) {
-	b := engine.NewBatch()
-	defer b.Close()
+func ClearRange(engine ReadWriter, start, end MVCCKey) (int, error) {
 	count := 0
 	if err := engine.Iterate(start, end, func(kv MVCCKeyValue) (bool, error) {
-		if err := b.Clear(kv.Key); err != nil {
+		if err := engine.Clear(kv.Key); err != nil {
 			return false, err
 		}
 		count++
@@ -267,5 +273,5 @@ func ClearRange(engine Engine, start, end MVCCKey) (int, error) {
 	}); err != nil {
 		return 0, err
 	}
-	return count, b.Commit()
+	return count, nil
 }

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1964,9 +1964,6 @@ func TestMVCCAbortTxn(t *testing.T) {
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Txn: txn1AbortWithTS.TxnMeta, Status: txn1AbortWithTS.Status}); err != nil {
 		t.Fatal(err)
 	}
-	if err := engine.Commit(); err != nil {
-		t.Fatal(err)
-	}
 
 	if value, _, err := MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, nil); err != nil {
 		t.Fatal(err)
@@ -2000,9 +1997,6 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 	txn1AbortWithTS.Timestamp = makeTS(2, 0)
 
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{Span: roachpb.Span{Key: testKey1}, Status: txn1AbortWithTS.Status, Txn: txn1AbortWithTS.TxnMeta}); err != nil {
-		t.Fatal(err)
-	}
-	if err := engine.Commit(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -103,8 +103,8 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 		t.Fatalf(`Seek on batch-backed iter after batched closed should panic.
 			iter.engine: %T, iter.engine.Closed: %v, batch.Closed %v`,
 			after.(*rocksDBIterator).engine,
-			after.(*rocksDBIterator).engine.Closed(),
-			b.Closed(),
+			after.(*rocksDBIterator).engine.closed(),
+			b.closed(),
 		)
 	}()
 }

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -152,7 +152,7 @@ func (*gcQueue) shouldQueue(now roachpb.Timestamp, repl *Replica,
 // returned separately and are not added to txnMap nor intentSpanMap.
 func processTransactionTable(
 	ctx context.Context,
-	snap engine.Engine,
+	snap engine.Reader,
 	desc *roachpb.RangeDescriptor,
 	txnMap map[uuid.UUID]*roachpb.Transaction,
 	cutoff roachpb.Timestamp,
@@ -245,7 +245,7 @@ func processTransactionTable(
 // all of the keys over the wire).
 func processAbortCache(
 	ctx context.Context,
-	snap engine.Engine,
+	snap engine.Reader,
 	rangeID roachpb.RangeID,
 	now roachpb.Timestamp,
 	minAge time.Duration,
@@ -383,8 +383,15 @@ type lockableGCInfo struct {
 // resolveIntents to clarify the true status of and clean up after encountered
 // transactions. It returns a slice of gc'able keys from the data, transaction,
 // and abort spans.
-func RunGC(ctx context.Context, desc *roachpb.RangeDescriptor, snap engine.Engine, now roachpb.Timestamp, policy config.GCPolicy,
-	pushTxn pushFunc, resolveIntents resolveFunc) ([]roachpb.GCRequest_GCKey, GCInfo, error) {
+func RunGC(
+	ctx context.Context,
+	desc *roachpb.RangeDescriptor,
+	snap engine.Reader,
+	now roachpb.Timestamp,
+	policy config.GCPolicy,
+	pushTxn pushFunc,
+	resolveIntents resolveFunc,
+) ([]roachpb.GCRequest_GCKey, GCInfo, error) {
 
 	iter := newReplicaDataIterator(desc, snap, true /* replicatedOnly */)
 	defer iter.Close()

--- a/storage/range_tree.go
+++ b/storage/range_tree.go
@@ -43,7 +43,10 @@ type treeContext struct {
 // SetupRangeTree creates a new RangeTree. This should only be called as part
 // of store.BootstrapRange.
 // TODO(tschottdorf): other RangeTree operations should also propagate a Context.
-func SetupRangeTree(ctx context.Context, batch engine.Engine, ms *engine.MVCCStats, timestamp roachpb.Timestamp, startKey roachpb.RKey) error {
+func SetupRangeTree(
+	ctx context.Context, batch engine.Batch, ms *engine.MVCCStats,
+	timestamp roachpb.Timestamp, startKey roachpb.RKey,
+) error {
 	tree := &RangeTree{
 		RootKey: startKey,
 	}

--- a/storage/replica_data_iter.go
+++ b/storage/replica_data_iter.go
@@ -76,7 +76,9 @@ func makeReplicaKeyRanges(d *roachpb.RangeDescriptor, metaFunc func(roachpb.Rang
 	}
 }
 
-func newReplicaDataIterator(d *roachpb.RangeDescriptor, e engine.Engine, replicatedOnly bool) *replicaDataIterator {
+func newReplicaDataIterator(
+	d *roachpb.RangeDescriptor, e engine.Reader, replicatedOnly bool,
+) *replicaDataIterator {
 	rangeFunc := makeAllKeyRanges
 	if replicatedOnly {
 		rangeFunc = makeReplicatedKeyRanges

--- a/storage/store.go
+++ b/storage/store.go
@@ -733,7 +733,9 @@ func (s *Store) IsStarted() bool {
 // IterateRangeDescriptors calls the provided function with each descriptor
 // from the provided Engine. The return values of this method and fn have
 // semantics similar to engine.MVCCIterate.
-func IterateRangeDescriptors(eng engine.Engine, fn func(desc roachpb.RangeDescriptor) (bool, error)) error {
+func IterateRangeDescriptors(
+	eng engine.Reader, fn func(desc roachpb.RangeDescriptor) (bool, error),
+) error {
 	// Iterator over all range-local key-based data.
 	start := keys.RangeDescriptorKey(roachpb.RKeyMin)
 	end := keys.RangeDescriptorKey(roachpb.RKeyMax)
@@ -1583,7 +1585,7 @@ func (s *Store) processRangeDescriptorUpdateLocked(rng *Replica) error {
 }
 
 // NewSnapshot creates a new snapshot engine.
-func (s *Store) NewSnapshot() engine.Engine {
+func (s *Store) NewSnapshot() engine.Reader {
 	return s.engine.NewSnapshot()
 }
 


### PR DESCRIPTION
Split the Engine interface into Reader, Writer, ReadWriter, Engine and
Batch. Use narrower interfaces where possible in various methods. For
example, the `MVCC*` functions now take either a `Reader` or
`ReadWriter`, but never an `Engine` or `Batch`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6972)

<!-- Reviewable:end -->
