### PR TITLE
sql: nits: fix spelling of `constraint` and tidy fk test cases

### DIFF
--- a/sql/drop.go
+++ b/sql/drop.go
@@ -221,9 +221,9 @@ func (n *dropIndexNode) Start() error {
 			// If an index is either end of a FK constraint, it cannot be dropped.
 			if idx.ForeignKey != nil {
 				if n.n.DropBehavior == parser.DropCascade {
-					return fmt.Errorf("CASCADE is not yet supported and index %q is in use as a foreign key contraint", idx.Name)
+					return fmt.Errorf("CASCADE is not yet supported and index %q is in use as a foreign key constraint", idx.Name)
 				}
-				return fmt.Errorf("index %q is in use as a foreign key contraint", idx.Name)
+				return fmt.Errorf("index %q is in use as a foreign key constraint", idx.Name)
 			}
 			if err := checkIndexDependees(idx, "index", idx.Name, n.p.txn, n.n.DropBehavior); err != nil {
 				return err

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -71,7 +71,7 @@ type analyzeOrderingFn func(indexOrdering orderingInfo) (matchingCols, totalCols
 // replacing expressions which are not usable by indexes by "true". The
 // simplified expression is then considered for each index and a set of range
 // constraints is created for the index. The candidate indexes are ranked using
-// these constraints and the best index is selected. The contraints are then
+// these constraints and the best index is selected. The constraints are then
 // transformed into a set of spans to scan within the index.
 //
 // The analyzeOrdering function is used to determine how useful the ordering of
@@ -457,7 +457,7 @@ func (v *indexInfo) makeOrConstraints(orExprs []parser.TypedExprs) error {
 // This method generates one indexConstraint for a prefix of the columns in
 // the index (except for tuple constraints which can account for more than
 // one column). A prefix of the generated constraints has a .start, and
-// similarly a prefix of the contraints has a .end (in other words,
+// similarly a prefix of the constraints has a .end (in other words,
 // once a constraint doesn't have a .start, no further constraints will
 // have one). This is because they wouldn't be useful when generating spans.
 //

--- a/sql/parser/create.go
+++ b/sql/parser/create.go
@@ -377,7 +377,7 @@ func (node *CheckConstraintTableDef) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteByte(')')
 }
 
-// FamilyElem represents a column in a FAMILY contraint.
+// FamilyElem represents a column in a FAMILY constraint.
 type FamilyElem struct {
 	Column Name
 }

--- a/sql/sqlbase/errors.go
+++ b/sql/sqlbase/errors.go
@@ -267,7 +267,7 @@ func (e *ErrUndefinedDatabase) SrcContext() SrcCtx {
 }
 
 // IsIntegrityConstraintError returns true if the error is some kind of SQL
-// contraint violation.
+// constraint violation.
 func IsIntegrityConstraintError(err error) bool {
 	switch err.(type) {
 	case *ErrNonNullViolation, *ErrUniquenessConstraintViolation:

--- a/sql/testdata/fk
+++ b/sql/testdata/fk
@@ -1,58 +1,26 @@
 statement ok
-CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE);
+CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE)
 
 statement ok
-CREATE TABLE products (
-  sku STRING PRIMARY KEY,
-  upc STRING UNIQUE,
-  vendor STRING
-);
+CREATE TABLE products (sku STRING PRIMARY KEY, upc STRING UNIQUE, vendor STRING)
 
 statement error referenced table "productz" not found
-CREATE TABLE orders (
-  id INT PRIMARY KEY,
-  product STRING REFERENCES productz,
-  customer INT REFERENCES customers (id),
-  INDEX (product),
-  INDEX (customer)
-);
+CREATE TABLE missing (product STRING REFERENCES productz)
 
 statement error referenced table "customerz" not found
-CREATE TABLE orders (
-  id INT PRIMARY KEY,
-  product STRING REFERENCES products,
-  customer INT REFERENCES customerz (id),
-  INDEX (product),
-  INDEX (customer)
-);
+CREATE TABLE missing_with_col (customer INT REFERENCES customerz (id))
 
+statement error column "idz" does not exist
+CREATE TABLE missing_col (customer INT REFERENCES customers (idz))
+
+statement error foreign key column "customer" must be the prefix of an index
+CREATE TABLE unindexed (customer INT REFERENCES customers)
 
 statement error foreign key requires a unique index on products.vendor
-CREATE TABLE orders (
-  id INT PRIMARY KEY,
-  product STRING REFERENCES products (vendor),
-  customer INT REFERENCES customers,
-  INDEX (product),
-  INDEX (customer)
-);
-
+CREATE TABLE non_unique (product STRING REFERENCES products (vendor))
 
 statement error type of "customer" \(INT\) does not match foreign key "customers"."email" \(STRING\)
-CREATE TABLE orders (
-  id INT PRIMARY KEY,
-  product STRING REFERENCES products,
-  customer INT REFERENCES customers (email),
-  INDEX (product),
-  INDEX (customer)
-);
-
-statement error foreign key column "product" must be the prefix of an index
-CREATE TABLE orders (
-  id INT PRIMARY KEY,
-  product STRING REFERENCES products,
-  customer INT REFERENCES customers (email),
-  INDEX (customer)
-);
+CREATE TABLE mismatch (customer INT REFERENCES customers (email))
 
 statement ok
 CREATE TABLE orders (
@@ -63,6 +31,8 @@ CREATE TABLE orders (
   INDEX (customer)
 );
 
+# "reviews" makes "products" have multiple inbound references, as well as making
+# "orders" have both directions.
 statement ok
 CREATE TABLE reviews (
   id INT PRIMARY KEY,
@@ -78,7 +48,7 @@ CREATE TABLE reviews (
 statement error "products_upc_key" is referenced by foreign key from table "orders"
 DROP INDEX products@products_upc_key
 
-statement error index "orders_product_idx" is in use as a foreign key contraint
+statement error index "orders_product_idx" is in use as a foreign key constraint
 DROP INDEX orders@orders_product_idx
 
 statement error "products" is referenced by foreign key from table "orders"
@@ -87,7 +57,7 @@ DROP TABLE products
 statement error CASCADE is not yet supported and index "products_upc_key" is referenced by foreign key from table "orders"
 DROP INDEX products@products_upc_key CASCADE
 
-statement error CASCADE is not yet supported and index "orders_product_idx" is in use as a foreign key contraint
+statement error CASCADE is not yet supported and index "orders_product_idx" is in use as a foreign key constraint
 DROP INDEX orders@orders_product_idx CASCADE
 
 statement error CASCADE is not yet supported and table "products" is referenced by foreign key from table "orders"
@@ -96,7 +66,7 @@ DROP TABLE products CASCADE
 statement error "products_upc_key" is referenced by foreign key from table "orders"
 DROP INDEX products@products_upc_key RESTRICT
 
-statement error index "orders_product_idx" is in use as a foreign key contraint
+statement error index "orders_product_idx" is in use as a foreign key constraint
 DROP INDEX orders@orders_product_idx RESTRICT
 
 statement error referenced by foreign key from table "orders"


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6982)

<!-- Reviewable:end -->
