### PR TITLE
sql: fix FK bugs using PK vs secondary

### DIFF
--- a/sql/sqlbase/structured.go
+++ b/sql/sqlbase/structured.go
@@ -602,12 +602,15 @@ func (desc *TableDescriptor) FindIndexByName(name string) (DescriptorStatus, int
 }
 
 // FindIndexByID finds an index (active or inactive) with the specified ID.
+// Must return a pointer to the IndexDescriptor in the TableDescriptor, so that
+// callers can use returned values to modify the TableDesc.
 func (desc *TableDescriptor) FindIndexByID(id IndexID) (*IndexDescriptor, error) {
-	indexes := append(desc.Indexes, desc.PrimaryIndex)
-
-	for i, c := range indexes {
+	if desc.PrimaryIndex.ID == id {
+		return &desc.PrimaryIndex, nil
+	}
+	for i, c := range desc.Indexes {
 		if c.ID == id {
-			return &indexes[i], nil
+			return &desc.Indexes[i], nil
 		}
 	}
 	for _, m := range desc.Mutations {

--- a/sql/testdata/fk
+++ b/sql/testdata/fk
@@ -45,32 +45,41 @@ CREATE TABLE reviews (
   INDEX ("order")
 )
 
-statement error "products_upc_key" is referenced by foreign key from table "orders"
+statement ok
+CREATE TABLE scans (ts TIMESTAMP, upc STRING REFERENCES products (upc), INDEX (upc))
+
+statement error "products_upc_key" is referenced by foreign key from table "scans"
+DROP INDEX products@products_upc_key
+
+statement error "products_upc_key" is referenced by foreign key from table "scans"
+DROP INDEX products@products_upc_key RESTRICT
+
+statement error CASCADE is not yet supported and index "products_upc_key" is referenced by foreign key from table "scans"
+DROP INDEX products@products_upc_key CASCADE
+
+statement ok
+DROP TABLE scans
+
+statement ok
 DROP INDEX products@products_upc_key
 
 statement error index "orders_product_idx" is in use as a foreign key constraint
 DROP INDEX orders@orders_product_idx
 
-statement error "products" is referenced by foreign key from table "orders"
-DROP TABLE products
-
-statement error CASCADE is not yet supported and index "products_upc_key" is referenced by foreign key from table "orders"
-DROP INDEX products@products_upc_key CASCADE
+statement error index "orders_product_idx" is in use as a foreign key constraint
+DROP INDEX orders@orders_product_idx RESTRICT
 
 statement error CASCADE is not yet supported and index "orders_product_idx" is in use as a foreign key constraint
 DROP INDEX orders@orders_product_idx CASCADE
 
-statement error CASCADE is not yet supported and table "products" is referenced by foreign key from table "orders"
-DROP TABLE products CASCADE
-
-statement error "products_upc_key" is referenced by foreign key from table "orders"
-DROP INDEX products@products_upc_key RESTRICT
-
-statement error index "orders_product_idx" is in use as a foreign key constraint
-DROP INDEX orders@orders_product_idx RESTRICT
+statement error "products" is referenced by foreign key from table "orders"
+DROP TABLE products
 
 statement error referenced by foreign key from table "orders"
 DROP TABLE products RESTRICT
+
+statement error CASCADE is not yet supported and table "products" is referenced by foreign key from table "orders"
+DROP TABLE products CASCADE
 
 statement error referenced by foreign key from table "reviews"
 DROP TABLE orders


### PR DESCRIPTION
The first impl mistakenly only searched table.Indexes in some places, missing FK references
on the primary key (which is not in table.Indexes) and then also used AllNonDropIndexes in
places where only public indexes should have been usable.

This _is_ covered by the logic tests, I just asserted the wrong index names in the errors
Still TODO is moving some of this to schema-changes, but this change is just about
correctness of the existing index selection, not when or where it is done.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6989)

<!-- Reviewable:end -->
