### PR TITLE
sql: fix sub-query plan expansion for queries with indexed joins.

### DIFF
--- a/sql/Makefile
+++ b/sql/Makefile
@@ -1,3 +1,3 @@
 .PHONY: bigtest
 bigtest:
-	go test -bigtest -timeout 24h -run '^TestLogic$$'
+	go test -bigtest -timeout 24h $(TESTFLAGS) -run '^TestLogic$$'

--- a/sql/select.go
+++ b/sql/select.go
@@ -338,16 +338,6 @@ func (p *planner) SelectClause(parsed *parser.SelectClause, orderBy parser.Order
 }
 
 func (s *selectNode) expandPlan() error {
-	// Expand the sub-query plans in the sub-expressions, if any.
-	if err := s.planner.expandSubqueryPlans(s.filter); err != nil {
-		return err
-	}
-	for _, e := range s.render {
-		if err := s.planner.expandSubqueryPlans(e); err != nil {
-			return err
-		}
-	}
-
 	// Get the ordering for index selection (if any).
 	var ordering columnOrdering
 	var grouping bool
@@ -418,20 +408,23 @@ func (s *selectNode) expandPlan() error {
 		s.source.plan = plan
 	}
 
-	// If the source node is not a scanNode, expand its plan.
-	// (If it is a scanNode, it is already "expanded" and
-	// we do not want to expand the sub-queries in its filters
-	// here because they are shared with the selectNode and the selectNode
-	// already cares of expanding the sub-queries.)
-	if _, isScan := s.source.plan.(*scanNode); !isScan {
-		if err := s.source.plan.expandPlan(); err != nil {
+	s.ordering = s.computeOrdering(s.source.plan.Ordering())
+
+	// Expand the sub-query plans in the local sub-expressions, if any.
+	// This must be done for filters after index selection and splitting
+	// the filter, since part of the filter may have landed in the source
+	// scanNode and will be expanded there.
+	if err := s.planner.expandSubqueryPlans(s.filter); err != nil {
+		return err
+	}
+	for _, e := range s.render {
+		if err := s.planner.expandSubqueryPlans(e); err != nil {
 			return err
 		}
 	}
 
-	s.ordering = s.computeOrdering(s.source.plan.Ordering())
-
-	return nil
+	// Expand the source node.
+	return s.source.plan.expandPlan()
 }
 
 // initFrom initializes the table node, given the parsed select expression

--- a/sql/testdata/subquery
+++ b/sql/testdata/subquery
@@ -305,3 +305,14 @@ query B
 INSERT INTO xyz (x, y, z) VALUES (13, 11, 12) RETURNING (y IN (SELECT y FROM xyz))
 ----
 true
+
+# check that residual filters are not expanded twice
+query ITTT
+EXPLAIN(VERBOSE) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
+----
+0 select                          +x,unique
+1 render/filter  (x)@xyz          +x,unique
+2 scan           xyz@primary  -   +x,unique
+3 select                          +x,unique
+4 render/filter  (x)@xyz          +x,unique
+5 scan           xyz@primary      +x,unique


### PR DESCRIPTION
Found in #6986: the selectNode expanded the sub-queries in its filter
expression, then splits the filter for an indexed join, then the
indexJoinNode re-expands the sub-queries in its children node
including the scanNode with the remainder of the filter
expression. The double expansion was invalid.

This patch fixes the issue by delaying expansion of filter sub-queries
in the selectNode until after the index node has been
initialized. This ensure that it only expands the part of the filter
split away from the scanNode under responsibility of the
indexJoinNode.

Fixes #6986.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/6994)

<!-- Reviewable:end -->
