### PR TITLE
Txn correctness test waits on remainder of history in event of retry

### DIFF
--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -86,18 +86,20 @@ type cmd struct {
 }
 
 func (c *cmd) init(prevCmd *cmd) {
+	c.ch = nil
 	if prevCmd != nil {
+		prevCmd.ch = make(chan struct{}) // unbuffered to force synchronous handoff
 		c.prev = prevCmd.ch
 	} else {
 		c.prev = nil
 	}
-	c.ch = make(chan struct{}, 1)
 	c.debug = ""
 }
 
 func (c *cmd) execute(txn *client.Txn, t *testing.T) (string, error) {
 	if c.prev != nil {
 		<-c.prev
+		c.prev = nil
 	}
 	if log.V(2) {
 		log.Infof("executing %s", c)
@@ -105,6 +107,7 @@ func (c *cmd) execute(txn *client.Txn, t *testing.T) (string, error) {
 	err := c.fn(c, txn, t)
 	if c.ch != nil {
 		c.ch <- struct{}{}
+		c.ch = nil
 	}
 	if len(c.key) > 0 && len(c.endKey) > 0 {
 		return fmt.Sprintf("%s%%d.%%d(%s-%s)%s", c.name, c.key, c.endKey, c.debug), err
@@ -116,9 +119,14 @@ func (c *cmd) execute(txn *client.Txn, t *testing.T) (string, error) {
 }
 
 func (c *cmd) done() {
-	close(c.ch)
-	c.ch = nil
-	c.prev = nil
+	if c.prev != nil {
+		<-c.prev
+		c.prev = nil
+	}
+	if c.ch != nil {
+		c.ch <- struct{}{}
+		c.ch = nil
+	}
 	c.debug = ""
 }
 
@@ -139,12 +147,12 @@ func (c *cmd) getEndKey() []byte {
 
 func (c *cmd) String() string {
 	if len(c.key) > 0 && len(c.endKey) > 0 {
-		return fmt.Sprintf("%s%d(%s-%s)", c.name, c.txnIdx, c.key, c.endKey)
+		return fmt.Sprintf("%s%d(%s-%s)", c.name, c.txnIdx+1, c.key, c.endKey)
 	}
 	if len(c.key) > 0 {
-		return fmt.Sprintf("%s%d(%s)", c.name, c.txnIdx, c.key)
+		return fmt.Sprintf("%s%d(%s)", c.name, c.txnIdx+1, c.key)
 	}
-	return fmt.Sprintf("%s%d", c.name, c.txnIdx)
+	return fmt.Sprintf("%s%d", c.name, c.txnIdx+1)
 }
 
 // readCmd reads a value from the db and stores it in the env.
@@ -313,7 +321,7 @@ func parseHistory(txnIdx int, history string, t *testing.T) []*cmd {
 func parseHistories(histories []string, t *testing.T) [][]*cmd {
 	var results [][]*cmd
 	for i, history := range histories {
-		results = append(results, parseHistory(i+1, history, t))
+		results = append(results, parseHistory(i, history, t))
 	}
 	return results
 }
@@ -535,7 +543,7 @@ func (hv *historyVerifier) run(isolations []roachpb.IsolationType, db *client.DB
 		for _, i := range enumIso {
 			for _, h := range enumHis {
 				if err := hv.runHistory(historyIdx, p, i, h, db, t); err != nil {
-					t.Errorf("expected success, experienced %v", err)
+					t.Errorf("expected success, experienced %s", err)
 					return
 				}
 				historyIdx++
@@ -558,7 +566,7 @@ func (hv *historyVerifier) runHistory(historyIdx int, priorities []int32,
 	}
 	plannedStr := historyString(cmds)
 	if log.V(1) {
-		log.Infof("attempting iso=%v pri=%v history=%s", isolations, priorities, plannedStr)
+		log.Infof("attempting history %d: iso=%v pri=%v history=%s", historyIdx, isolations, priorities, plannedStr)
 	}
 
 	hv.actual = []string{}
@@ -568,13 +576,19 @@ func (hv *historyVerifier) runHistory(historyIdx int, priorities []int32,
 	for _, c := range cmds {
 		c.historyIdx = historyIdx
 		txnMap[c.txnIdx] = append(txnMap[c.txnIdx], c)
+		// Because the command channels are unbuffered, don't wait if the
+		// previous command is from the same transaction (and thus will be
+		// executed in a single goroutine).
+		if prev != nil && c.txnIdx == prev.txnIdx {
+			prev = nil
+		}
 		c.init(prev)
 		prev = c
 	}
 	for i, txnCmds := range txnMap {
 		go func(i int, txnCmds []*cmd) {
-			if err := hv.runTxn(i, priorities[i-1], isolations[i-1], txnCmds, db, t); err != nil {
-				t.Errorf("(%s): unexpected failure running %s: %v", cmds, cmds[i], err)
+			if err := hv.runTxn(i, priorities[i], isolations[i], txnCmds, db, t); err != nil {
+				t.Errorf("(%s): unexpected failure running %s: %s", cmds, cmds[i], err)
 			}
 		}(i, txnCmds)
 	}
@@ -653,6 +667,9 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 		for i := range cmds {
 			cmds[i].env = env
 			if err := hv.runCmd(txn, txnIdx, retry, i, cmds, t); err != nil {
+				if log.V(1) {
+					log.Infof("%s encountered error: %s", cmds[i], err)
+				}
 				return err
 			}
 		}


### PR DESCRIPTION
By changing the wait channel to be unbuffered, and receiving on the
"prev" channel when calling `done()` on all remaining commands after
a txn history experiences retry, we now force the non-failing txn(s)
in the history to finish before the retry is attempted.

Also renumbered the indexes for txns (cosmetic).

Fixes #6965, #6953, #6916, #6915, #6865, #6855, #6746

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7004)

<!-- Reviewable:end -->
