### PR TITLE
util/encoding: fix BenchmarkPeekLengthDuration

### DIFF
--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -1174,7 +1174,11 @@ func BenchmarkEncodeDuration(b *testing.B) {
 
 	vals := make([]duration.Duration, 10000)
 	for i := range vals {
-		vals[i] = duration.Duration{Months: rng.Int63n(1000), Days: rng.Int63n(1000), Nanos: rng.Int63n(1000000)}
+		vals[i] = duration.Duration{
+			Months: rng.Int63n(1000),
+			Days:   rng.Int63n(1000),
+			Nanos:  rng.Int63n(1000000),
+		}
 	}
 
 	buf := make([]byte, 0, 1000)
@@ -1212,8 +1216,16 @@ func BenchmarkPeekLengthDuration(b *testing.B) {
 
 	vals := make([][]byte, 10000)
 	for i := range vals {
-		d := duration.Duration{Months: rng.Int63(), Days: rng.Int63(), Nanos: rng.Int63()}
-		vals[i], _ = EncodeDurationAscending(nil, d)
+		d := duration.Duration{
+			Months: rng.Int63n(1000),
+			Days:   rng.Int63n(1000),
+			Nanos:  rng.Int63n(1000000),
+		}
+		var err error
+		vals[i], err = EncodeDurationAscending(nil, d)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	b.ResetTimer()


### PR DESCRIPTION
The random durations being created had overflow causing encoding to
fail, but we were ignoring the error. Subsequent calls to PeekLength
were benchmarking returning an error.

```
name                  old time/op  new time/op  delta
PeekLengthDuration-8  2.26µs ± 2%  0.04µs ± 2%  -98.42%  (p=0.008 n=5+5)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7007)

<!-- Reviewable:end -->
