### PR TITLE
sql: avoid unnecessary allocations during insert/update

### DIFF
--- a/client/util.go
+++ b/client/util.go
@@ -92,6 +92,9 @@ func marshalValue(v interface{}) (roachpb.Value, error) {
 	case proto.Message:
 		err := r.SetProto(t)
 		return r, err
+
+	case roachpb.Value:
+		panic("unexpected type roachpb.Value (use *roachpb.Value)")
 	}
 
 	// Handle all of the Go primitive types besides struct and pointers. This

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -485,8 +485,10 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 			rowVals := rows.Values()
 
 			for _, desc := range added {
-				secondaryIndexEntries, err := sqlbase.EncodeSecondaryIndexes(
-					tableDesc.ID, []sqlbase.IndexDescriptor{desc}, colIDtoRowIndex, rowVals)
+				secondaryIndexEntries := make([]sqlbase.IndexEntry, 1)
+				err := sqlbase.EncodeSecondaryIndexes(
+					tableDesc.ID, []sqlbase.IndexDescriptor{desc}, colIDtoRowIndex,
+					rowVals, secondaryIndexEntries)
 				if err != nil {
 					return err
 				}
@@ -495,7 +497,7 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 						log.Infof("InitPut %s -> %v", secondaryIndexEntry.Key,
 							secondaryIndexEntry.Value)
 					}
-					b.InitPut(secondaryIndexEntry.Key, secondaryIndexEntry.Value)
+					b.InitPut(secondaryIndexEntry.Key, &secondaryIndexEntry.Value)
 				}
 			}
 		}

--- a/sql/sqlbase/table.go
+++ b/sql/sqlbase/table.go
@@ -262,22 +262,24 @@ func MakeColumnDefDescs(d *parser.ColumnTableDef) (*ColumnDescriptor, *IndexDesc
 // a full index key.
 func EncodeIndexKey(index *IndexDescriptor, colMap map[ColumnID]int,
 	values []parser.Datum, indexKey []byte) ([]byte, bool, error) {
-	dirs := make([]encoding.Direction, 0, len(index.ColumnIDs))
-	for _, dir := range index.ColumnDirections {
-		convertedDir, err := dir.ToEncodingDirection()
-		if err != nil {
-			return nil, false, err
-		}
-		dirs = append(dirs, convertedDir)
+	return EncodeColumns(index.ColumnIDs, directions(index.ColumnDirections),
+		colMap, values, indexKey)
+}
+
+type directions []IndexDescriptor_Direction
+
+func (d directions) get(i int) (encoding.Direction, error) {
+	if i < len(d) {
+		return d[i].ToEncodingDirection()
 	}
-	return EncodeColumns(index.ColumnIDs, dirs, colMap, values, indexKey)
+	return encoding.Ascending, nil
 }
 
 // EncodeColumns is a version of EncodeIndexKey that takes ColumnIDs and
 // directions explicitly.
 func EncodeColumns(
 	columnIDs []ColumnID,
-	directions []encoding.Direction,
+	directions directions,
 	colMap map[ColumnID]int,
 	values []parser.Datum,
 	indexKey []byte,
@@ -300,8 +302,12 @@ func EncodeColumns(
 			containsNull = true
 		}
 
-		var err error
-		if key, err = EncodeTableKey(key, val, directions[colIdx]); err != nil {
+		dir, err := directions.get(colIdx)
+		if err != nil {
+			return nil, containsNull, err
+		}
+
+		if key, err = EncodeTableKey(key, val, dir); err != nil {
 			return nil, containsNull, err
 		}
 	}
@@ -910,30 +916,27 @@ func DecodeTableValue(a *DatumAlloc, valType parser.Datum, b []byte) (parser.Dat
 // IndexEntry represents an encoded key/value for an index entry.
 type IndexEntry struct {
 	Key   roachpb.Key
-	Value []byte
+	Value roachpb.Value
 }
 
 // EncodeSecondaryIndex encodes key/values for a secondary index. colMap maps
 // ColumnIDs to indices in `values`.
 func EncodeSecondaryIndex(
 	tableID ID,
-	secondaryIndex IndexDescriptor,
+	secondaryIndex *IndexDescriptor,
 	colMap map[ColumnID]int,
 	values []parser.Datum,
 ) (IndexEntry, error) {
 	secondaryIndexKeyPrefix := MakeIndexKeyPrefix(tableID, secondaryIndex.ID)
 	secondaryIndexKey, containsNull, err := EncodeIndexKey(
-		&secondaryIndex, colMap, values, secondaryIndexKeyPrefix)
+		secondaryIndex, colMap, values, secondaryIndexKeyPrefix)
 	if err != nil {
 		return IndexEntry{}, err
 	}
 
-	// Add the implicit columns - they are encoded ascendingly.
-	implicitDirs := make([]encoding.Direction, 0, len(secondaryIndex.ImplicitColumnIDs))
-	for range secondaryIndex.ImplicitColumnIDs {
-		implicitDirs = append(implicitDirs, encoding.Ascending)
-	}
-	extraKey, _, err := EncodeColumns(secondaryIndex.ImplicitColumnIDs, implicitDirs,
+	// Add the implicit columns - they are encoded ascendingly which is done by
+	// passing nil for the encoding directions.
+	extraKey, _, err := EncodeColumns(secondaryIndex.ImplicitColumnIDs, nil,
 		colMap, values, nil)
 	if err != nil {
 		return IndexEntry{}, err
@@ -958,29 +961,34 @@ func EncodeSecondaryIndex(
 		// unique. We could potentially get rid of the duplication here but at
 		// the expense of complicating scanNode when dealing with unique
 		// secondary indexes.
-		entry.Value = extraKey
+		entry.Value.SetBytes(extraKey)
+	} else {
+		// The zero value for an index-key is a 0-length bytes value.
+		entry.Value.SetBytes([]byte{})
 	}
 
 	return entry, nil
 }
 
 // EncodeSecondaryIndexes encodes key/values for the secondary indexes. colMap
-// maps ColumnIDs to indices in `values`.
+// maps ColumnIDs to indices in `values`. secondaryIndexEntries is the return
+// value (passed as a parameter so the caller can reuse between rows) and is
+// expected to be the same length as indexes.
 func EncodeSecondaryIndexes(
 	tableID ID,
 	indexes []IndexDescriptor,
 	colMap map[ColumnID]int,
 	values []parser.Datum,
-) ([]IndexEntry, error) {
-	var secondaryIndexEntries []IndexEntry
-	for _, secondaryIndex := range indexes {
-		entry, err := EncodeSecondaryIndex(tableID, secondaryIndex, colMap, values)
+	secondaryIndexEntries []IndexEntry,
+) error {
+	for i := range indexes {
+		var err error
+		secondaryIndexEntries[i], err = EncodeSecondaryIndex(tableID, &indexes[i], colMap, values)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		secondaryIndexEntries = append(secondaryIndexEntries, entry)
 	}
-	return secondaryIndexEntries, nil
+	return nil
 }
 
 // CheckColumnType verifies that a given value is compatible

--- a/sql/tablewriter.go
+++ b/sql/tablewriter.go
@@ -377,7 +377,7 @@ func (tu *tableUpserter) upsertRowPKs() ([]roachpb.Key, error) {
 	b := tu.txn.NewBatch()
 	for _, insertRow := range tu.insertRows {
 		entry, err := sqlbase.EncodeSecondaryIndex(
-			tu.tableDesc.ID, tu.conflictIndex, tu.ri.insertColIDtoRowIndex, insertRow)
+			tu.tableDesc.ID, &tu.conflictIndex, tu.ri.insertColIDtoRowIndex, insertRow)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Primarily affects benchmarks with secondary indexes.

```
name                          old time/op    new time/op    delta
TrackChoices1_Cockroach-8        272µs ± 4%     270µs ± 2%     ~     (p=0.481 n=10+10)
TrackChoices10_Cockroach-8      72.6µs ± 2%    71.0µs ± 2%   -2.23%  (p=0.000 n=10+10)
TrackChoices100_Cockroach-8     44.8µs ± 1%    42.9µs ± 1%   -4.21%  (p=0.000 n=10+10)
TrackChoices1000_Cockroach-8    42.3µs ± 1%    41.6µs ± 3%   -1.55%   (p=0.028 n=9+10)

name                          old allocs/op  new allocs/op  delta
TrackChoices1_Cockroach-8          388 ± 0%       378 ± 0%   -2.58%  (p=0.000 n=10+10)
TrackChoices10_Cockroach-8         134 ± 0%       123 ± 0%   -8.21%  (p=0.000 n=10+10)
TrackChoices100_Cockroach-8        105 ± 0%        94 ± 0%  -10.48%  (p=0.000 n=10+10)
TrackChoices1000_Cockroach-8       102 ± 0%        91 ± 0%  -10.78%  (p=0.000 n=10+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7011)

<!-- Reviewable:end -->
