### PR TITLE
storage: use a "distinct" batch in Replica.handleRaftReady()

### DIFF
--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -89,7 +89,10 @@ type Iterator interface {
 
 // Reader is the read interface to an engine's data.
 type Reader interface {
-	// Close closes the reader, freeing up any outstanding resources.
+	// Close closes the reader, freeing up any outstanding resources. Note that
+	// various implementations have slightly different behaviors. In particular,
+	// Distinct() batches release their parent batch for future use while
+	// Engines, Snapshots and Batches free the associated C++ resources.
 	Close()
 	// closed returns true if the reader has been closed or is not usable.
 	// Objects backed by this reader (e.g. Iterators) can check this to ensure
@@ -187,13 +190,14 @@ type Batch interface {
 	// Commit() fails deferred callbacks are not called. As with the defer
 	// statement, the last callback to be deferred is the first to be executed.
 	Defer(fn func())
-	// Distinct returns a view of the existing batch which passes reads directly
-	// to the underlying engine (the one the batch was created from). That is,
-	// the returned batch will not read its own writes. This is used as an
-	// optimization to avoid flushing mutations buffered by the batch in
+	// Distinct returns a view of the existing batch which only sees writes that
+	// were performed before the Distinct batch was created. That is, the
+	// returned batch will not read its own writes, but it will read writes to
+	// the parent batch performed before the call to Distinct(). The returned
+	// batch needs to be closed before using the parent patch again. This is used
+	// as an optimization to avoid flushing mutations buffered by the batch in
 	// situations where we know all of the batched operations are for distinct
-	// keys. Closing/committing the returned engine is equivalent to
-	// closing/committing the original batch.
+	// keys.
 	Distinct() ReadWriter
 	// Repr returns the underlying representation of the batch and can be used to
 	// reconstitute the batch on a remote node using Writer.ApplyBatchRepr().

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1421,8 +1421,6 @@ func (r *Replica) handleRaftReady() error {
 	batch := r.store.Engine().NewBatch()
 	defer batch.Close()
 	if !raft.IsEmptySnap(rd.Snapshot) {
-		// TODO(peter): Could use a "distinct" batch within applySnapshot, but we
-		// also need the Batch.Defer mechanism.
 		var err error
 		if lastIndex, err = r.applySnapshot(batch, rd.Snapshot); err != nil {
 			return err


### PR DESCRIPTION
A minor optimization that affects small transactions.

Fixes #6949.

```
name                       old time/op    new time/op    delta
Insert1_Cockroach-8           212µs ± 2%     204µs ± 1%  -3.55%        (p=0.000 n=10+10)
Update1_Cockroach-8           356µs ± 2%     343µs ± 1%  -3.49%         (p=0.000 n=10+9)
Delete1_Cockroach-8           390µs ± 2%     389µs ± 2%    ~           (p=0.529 n=10+10)
TrackChoices1_Cockroach-8     280µs ± 1%     269µs ± 1%  -3.61%        (p=0.000 n=10+10)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7015)

<!-- Reviewable:end -->
