### PR TITLE
sql: support mutation columns in SelectClause

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -34,11 +34,18 @@ func makeColIDtoRowIndex(row planNode, desc *sqlbase.TableDescriptor) (
 	columns := row.Columns()
 	colIDtoRowIndex := make(map[sqlbase.ColumnID]int, len(columns))
 	for i, column := range columns {
-		col, err := desc.FindActiveColumnByName(column.Name)
+		s, idx, err := desc.FindColumnByName(column.Name)
 		if err != nil {
 			return nil, err
 		}
-		colIDtoRowIndex[col.ID] = i
+		switch s {
+		case sqlbase.DescriptorActive:
+			colIDtoRowIndex[desc.Columns[idx].ID] = i
+		case sqlbase.DescriptorIncomplete:
+			colIDtoRowIndex[desc.Mutations[idx].GetColumn().ID] = i
+		default:
+			panic("unreachable")
+		}
 	}
 	return colIDtoRowIndex, nil
 }
@@ -284,7 +291,8 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		for i := range valNeededForCol {
 			_, valNeededForCol[i] = ru.fetchColIDtoRowIndex[tableDesc.Columns[i].ID]
 		}
-		err = rf.Init(tableDesc, colIDtoRowIndex, &tableDesc.PrimaryIndex, false, false, valNeededForCol)
+		err = rf.Init(tableDesc, colIDtoRowIndex, &tableDesc.PrimaryIndex, false, false,
+			tableDesc.Columns, valNeededForCol)
 		if err != nil {
 			return err
 		}
@@ -457,7 +465,7 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 		scan := planner.Scan()
 		scan.desc = *tableDesc
 		scan.spans = []sqlbase.Span{sp}
-		scan.initDescDefaults()
+		scan.initDescDefaults(publicAndNonPublicColumns)
 		rows, err := selectIndex(scan, nil, false)
 		if err != nil {
 			return err

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -72,7 +72,7 @@ func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoComm
 		Exprs: sqlbase.ColumnsSelectors(rd.fetchCols),
 		From:  []parser.TableExpr{n.Table},
 		Where: n.Where,
-	}, nil, nil, nil)
+	}, nil, nil, nil, publicColumns)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/distsql/tablereader.go
+++ b/sql/distsql/tablereader.go
@@ -140,7 +140,7 @@ func newTableReader(
 		colIdxMap[c.ID] = i
 	}
 	err := tr.fetcher.Init(&tr.desc, colIdxMap, index, spec.Reverse, isSecondaryIndex,
-		valNeededForCol)
+		tr.desc.Columns, valNeededForCol)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/fk.go
+++ b/sql/fk.go
@@ -128,7 +128,8 @@ func makeBaseFKHelepr(
 		needed[ids[i]] = true
 	}
 	isSecondary := searchTable.PrimaryIndex.ID != searchIdx.ID
-	if err := b.rf.Init(searchTable, ids, searchIdx, false, isSecondary, needed); err != nil {
+	err = b.rf.Init(searchTable, ids, searchIdx, false, isSecondary, searchTable.Columns, needed)
+	if err != nil {
 		return b, err
 	}
 

--- a/sql/join.go
+++ b/sql/join.go
@@ -55,7 +55,7 @@ func (p *planner) makeIndexJoin(origScan *scanNode, exactPrefix int) (resultPlan
 	// Create a new table scan node with the primary index.
 	table := p.Scan()
 	table.desc = origScan.desc
-	table.initDescDefaults()
+	table.initDescDefaults(publicColumns)
 	table.initOrdering(0)
 
 	colIDtoRowIndex := map[sqlbase.ColumnID]int{}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -272,7 +272,7 @@ func (p *planner) newPlan(stmt parser.Statement, desiredTypes []parser.Datum, au
 	case *parser.Select:
 		return p.Select(n, desiredTypes, autoCommit)
 	case *parser.SelectClause:
-		return p.SelectClause(n, nil, nil, desiredTypes)
+		return p.SelectClause(n, nil, nil, desiredTypes, publicColumns)
 	case *parser.Set:
 		return p.Set(n)
 	case *parser.SetTimeZone:
@@ -317,7 +317,7 @@ func (p *planner) prepare(stmt parser.Statement) (planNode, error) {
 	case *parser.Select:
 		return p.Select(n, nil, false)
 	case *parser.SelectClause:
-		return p.SelectClause(n, nil, nil, nil)
+		return p.SelectClause(n, nil, nil, nil, publicColumns)
 	case *parser.Show:
 		return p.Show(n)
 	case *parser.ShowCreateTable:

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -40,7 +40,9 @@ type scanNode struct {
 	// Set if the NO_INDEX_JOIN hint was given.
 	noIndexJoin bool
 
-	// There is a 1-1 correspondence between desc.Columns and resultColumns.
+	// The table columns, possibly including ones currently in schema changes.
+	cols []sqlbase.ColumnDescriptor
+	// There is a 1-1 correspondence between cols and resultColumns.
 	resultColumns []ResultColumn
 	// Contains values for the current row. There is a 1-1 correspondence
 	// between resultColumns and values in row.
@@ -49,7 +51,7 @@ type scanNode struct {
 	// as an optimization when the upper layer doesn't need all values).
 	valNeededForCol []bool
 
-	// Map used to get the index for columns in desc.Columns.
+	// Map used to get the index for columns in cols.
 	colIdxMap map[sqlbase.ColumnID]int
 
 	spans            []sqlbase.Span
@@ -119,8 +121,9 @@ func (n *scanNode) expandPlan() error {
 }
 
 func (n *scanNode) Start() error {
-	if err := n.fetcher.Init(&n.desc, n.colIdxMap, n.index, n.reverse,
-		n.isSecondaryIndex, n.valNeededForCol); err != nil {
+	err := n.fetcher.Init(&n.desc, n.colIdxMap, n.index, n.reverse, n.isSecondaryIndex, n.cols,
+		n.valNeededForCol)
+	if err != nil {
 		return err
 	}
 
@@ -240,7 +243,10 @@ func (n *scanNode) ExplainTypes(regTypes func(string, string)) {
 // Initializes a scanNode with a tableName. Returns the table or index name that can be used for
 // fully-qualified columns if an alias is not specified.
 func (n *scanNode) initTable(
-	p *planner, tableName *parser.QualifiedName, indexHints *parser.IndexHints,
+	p *planner,
+	tableName *parser.QualifiedName,
+	indexHints *parser.IndexHints,
+	scanVisibility scanVisibility,
 ) (string, error) {
 	var err error
 	n.desc, err = p.getTableLease(tableName)
@@ -271,7 +277,7 @@ func (n *scanNode) initTable(
 		}
 	}
 	n.noIndexJoin = (indexHints != nil && indexHints.NoIndexJoin)
-	n.initDescDefaults()
+	n.initDescDefaults(scanVisibility)
 	return alias, nil
 }
 
@@ -285,20 +291,31 @@ func (n *scanNode) setNeededColumns(needed []bool) {
 }
 
 // Initializes the column structures.
-func (n *scanNode) initDescDefaults() {
+func (n *scanNode) initDescDefaults(scanVisibility scanVisibility) {
 	n.index = &n.desc.PrimaryIndex
-	cols := n.desc.Columns
-	n.resultColumns = makeResultColumns(cols)
-	n.colIdxMap = make(map[sqlbase.ColumnID]int, len(cols))
-	for i, c := range cols {
+	n.cols = make([]sqlbase.ColumnDescriptor, 0, len(n.desc.Columns)+len(n.desc.Mutations))
+	switch scanVisibility {
+	case publicColumns:
+		n.cols = append(n.cols, n.desc.Columns...)
+	case publicAndNonPublicColumns:
+		n.cols = append(n.cols, n.desc.Columns...)
+		for _, mutation := range n.desc.Mutations {
+			if c := mutation.GetColumn(); c != nil {
+				n.cols = append(n.cols, *c)
+			}
+		}
+	}
+	n.resultColumns = makeResultColumns(n.cols)
+	n.colIdxMap = make(map[sqlbase.ColumnID]int, len(n.cols))
+	for i, c := range n.cols {
 		n.colIdxMap[c.ID] = i
 	}
-	n.valNeededForCol = make([]bool, len(cols))
-	for i := range cols {
+	n.valNeededForCol = make([]bool, len(n.cols))
+	for i := range n.cols {
 		n.valNeededForCol[i] = true
 	}
-	n.row = make([]parser.Datum, len(cols))
-	n.filterVars = parser.MakeIndexedVarHelper(n, len(cols))
+	n.row = make([]parser.Datum, len(n.cols))
+	n.filterVars = parser.MakeIndexedVarHelper(n, len(n.cols))
 }
 
 // initOrdering initializes the ordering info using the selected index. This
@@ -355,3 +372,11 @@ func (n *scanNode) IndexedVarReturnType(idx int) parser.Datum {
 func (n *scanNode) IndexedVarString(idx int) string {
 	return string(n.resultColumns[idx].Name)
 }
+
+// scanVisibility represents which table columns should be included in a scan.
+type scanVisibility int
+
+const (
+	publicColumns             scanVisibility = 0
+	publicAndNonPublicColumns scanVisibility = 1
+)

--- a/sql/select_qvalue_test.go
+++ b/sql/select_qvalue_test.go
@@ -27,7 +27,7 @@ import (
 func testInitDummySelectNode(desc *sqlbase.TableDescriptor) *selectNode {
 	scan := &scanNode{}
 	scan.desc = *desc
-	scan.initDescDefaults()
+	scan.initDescDefaults(publicColumns)
 
 	sel := &selectNode{}
 	sel.qvals = make(qvalMap)

--- a/sql/tablewriter.go
+++ b/sql/tablewriter.go
@@ -280,7 +280,7 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 	}
 	err = tu.fetcher.Init(
 		tu.tableDesc, tu.fetchColIDtoRowIndex, &tu.tableDesc.PrimaryIndex, false, false,
-		valNeededForCol)
+		tu.tableDesc.Columns, valNeededForCol)
 	if err != nil {
 		return err
 	}

--- a/sql/update.go
+++ b/sql/update.go
@@ -203,7 +203,7 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 		Exprs: targets,
 		From:  []parser.TableExpr{n.Table},
 		Where: n.Where,
-	}, nil, nil, desiredTypesFromSelect)
+	}, nil, nil, desiredTypesFromSelect, publicAndNonPublicColumns)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is required for upcoming column family work. If a backfill is running for a
schema change that adds a column with a default value to an existing family,
then any updates to that family need to fetch whatever has been backfilled so
far.

It may also help with https://github.com/cockroachdb/cockroach/pull/6757 (see
the discussion).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7019)

<!-- Reviewable:end -->
