### PR TITLE
storage: use quorum-applied-index instead of oldest-index

### DIFF
--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -17,6 +17,7 @@
 package storage
 
 import (
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/client"
@@ -31,6 +32,9 @@ import (
 const (
 	// raftLogQueueMaxSize is the max size of the queue.
 	raftLogQueueMaxSize = 100
+	// raftLogPadding is the number of log entries that should be kept for
+	// lagging replicas.
+	raftLogPadding = 10000
 	// RaftLogQueueTimerDuration is the duration between checking the
 	// raft logs.
 	RaftLogQueueTimerDuration = time.Second
@@ -68,6 +72,8 @@ func (*raftLogQueue) acceptsUnsplitRanges() bool {
 // can be truncated and the oldest index that cannot be pruned.
 func getTruncatableIndexes(r *Replica) (uint64, uint64, error) {
 	rangeID := r.RangeID
+	// TODO(bram): r.store.RaftStatus(rangeID) differs from r.RaftStatus() in
+	// tests, causing TestGetTruncatableIndexes to fail. Figure out why and fix.
 	raftStatus := r.store.RaftStatus(rangeID)
 	if raftStatus == nil {
 		if log.V(1) {
@@ -76,18 +82,14 @@ func getTruncatableIndexes(r *Replica) (uint64, uint64, error) {
 		return 0, 0, nil
 	}
 
-	// Is this the raft leader?
+	// Is this the raft leader? We only perform log truncation on the raft leader
+	// which has the up to date info on followers.
 	if raftStatus.RaftState != raft.StateLeader {
 		return 0, 0, nil
 	}
 
-	// Find the oldest index still in use by the range.
-	oldestIndex := raftStatus.Applied
-	for _, progress := range raftStatus.Progress {
-		if progress.Match < oldestIndex {
-			oldestIndex = progress.Match
-		}
-	}
+	// Calculate the quorum matched index and adjust based on padding.
+	oldestIndex := getQuorumMatchedIndex(raftStatus, raftLogPadding)
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -108,9 +110,9 @@ func getTruncatableIndexes(r *Replica) (uint64, uint64, error) {
 // shouldQueue determines whether a range should be queued for truncating. This
 // is true only if the replica is the raft leader and if the total number of
 // the range's raft log's stale entries exceeds RaftLogQueueStaleThreshold.
-func (*raftLogQueue) shouldQueue(now roachpb.Timestamp, r *Replica, _ config.SystemConfig) (shouldQ bool,
-	priority float64) {
-
+func (*raftLogQueue) shouldQueue(
+	now roachpb.Timestamp, r *Replica, _ config.SystemConfig,
+) (shouldQ bool, priority float64) {
 	truncatableIndexes, _, err := getTruncatableIndexes(r)
 	if err != nil {
 		log.Warning(err)
@@ -124,7 +126,6 @@ func (*raftLogQueue) shouldQueue(now roachpb.Timestamp, r *Replica, _ config.Sys
 // leader and if the total number of the range's raft log's stale entries
 // exceeds RaftLogQueueStaleThreshold.
 func (rlq *raftLogQueue) process(now roachpb.Timestamp, r *Replica, _ config.SystemConfig) error {
-
 	truncatableIndexes, oldestIndex, err := getTruncatableIndexes(r)
 	if err != nil {
 		return err
@@ -154,4 +155,28 @@ func (*raftLogQueue) timer() time.Duration {
 // purgatoryChan returns nil.
 func (*raftLogQueue) purgatoryChan() <-chan struct{} {
 	return nil
+}
+
+// getQuorumMatchedIndex returns the index which a quorum of the nodes have
+// committed. The returned value is adjusted by padding to allow retaining
+// additional entries, but this adjustment is limited so that we won't keep
+// entries which all nodes have matched.
+func getQuorumMatchedIndex(raftStatus *raft.Status, padding uint64) uint64 {
+	index := raftStatus.Commit
+	if index >= padding {
+		index -= padding
+	} else {
+		index = 0
+	}
+
+	smallestMatch := uint64(math.MaxUint64)
+	for _, progress := range raftStatus.Progress {
+		if smallestMatch > progress.Match {
+			smallestMatch = progress.Match
+		}
+	}
+	if index < smallestMatch {
+		index = smallestMatch
+	}
+	return index
 }


### PR DESCRIPTION
When deciding where to truncate the raft log, use the quorum applied
index (minus `raftLogPadding`) instead of the oldest index. The oldest
index can get excessively (and arbitrarily) old if a replica goes down
for a significant period of time.

See #6012.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7040)

<!-- Reviewable:end -->
