### PR TITLE
cli: print visual Unicode characters as-is.

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -640,11 +640,12 @@ func Example_sql_escape() {
 	// 7 rows
 	// s	d
 	// foo	printable ASCII
-	// "foo\n"	non-printable ASCII
-	// "\u03ba\u1f79\u03c3\u03bc\u03b5"	printable UTF8
-	// "\u00f1"	printable UTF8 using escapes
+	// foo
+	// 	non-printable ASCII
+	// κόσμε	printable UTF8
+	// ñ	printable UTF8 using escapes
 	// "\x01"	non-printable UTF8 string
-	// "\u070885"	UTF8 string with RTL char
+	// ܈85	UTF8 string with RTL char
 	// "\xc3("	non-UTF8 string
 }
 


### PR DESCRIPTION
This patch ensures that Unicode characters that have a visual
representation (unicode.IsGraphic), as well as newlines and tabs, are
printed out un-escaped.  This brings two benefits:
- multi-line strings are now formatted properly. For example:
  
  ```
  root@:26257> show create table foo;
  +-------+--------------------------------+
  | Table |          CreateTable           |
  +-------+--------------------------------+
  | foo   | CREATE TABLE foo (             |
  |       |     x FLOAT NULL,              |
  |       |     INDEX blah (x)             |
  |       | )                              |
  +-------+--------------------------------+
  ```
- special characters that have a proper width are now rendered on the
  terminal. For example:
  
  ```
  root@:26257> select '😉';
  +-----+
  | '😉' |
  +-----+
  | 😉   |
  +-----+
  root@:26257> create table "éa"(x int);
  OK
  root@:26257> show tables;
  +---------+
  |  Table  |
  +---------+
  | éa      |
  +---------+
  ```

Meanwhile the issue highlighted in #4315 is still managed:

```
root@:26257> select '\x01' as a;
+------+
|  a   |
+------+
| \x01 |
+------+
```

Fixes  #6926.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7045)

<!-- Reviewable:end -->
