### PR TITLE
cli: conditionally output unicode characters in the output of sql -e

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -611,20 +611,34 @@ func Example_sql_escape() {
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.t (s string, d string);"})
 	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'foo', 'printable ASCII')"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'foo\\x0a', 'non-printable ASCII')"})
+	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\"foo', 'printable ASCII with quotes')"})
+	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\\\\foo', 'printable ASCII with backslash')"})
+	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'foo\\x0abar', 'non-printable ASCII')"})
 	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values ('κόσμε', 'printable UTF8')"})
 	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\\xc3\\xb1', 'printable UTF8 using escapes')"})
 	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\\x01', 'non-printable UTF8 string')"})
 	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\\xdc\\x88\\x38\\x35', 'UTF8 string with RTL char')"})
 	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\\xc3\\x28', 'non-UTF8 string')"})
+	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'a\\tb\\tc\\n12\\t123123213\\t12313', 'tabs')"})
 	c.RunWithArgs([]string{"sql", "-e", "select * from t.t"})
+	c.RunWithArgs([]string{"sql", "-e", "create table t.u (\"\"\"foo\" int, \"\\foo\" int, \"foo\nbar\" int, \"κόσμε\" int, \"܈85\" int)"})
+	c.RunWithArgs([]string{"sql", "-e", "insert into t.u values (0, 0, 0, 0, 0)"})
+	c.RunWithArgs([]string{"sql", "-e", "show columns from t.u"})
+	c.RunWithArgs([]string{"sql", "-e", "select * from t.u"})
+	c.RunWithArgs([]string{"sql", "--pretty", "-e", "select * from t.t"})
+	c.RunWithArgs([]string{"sql", "--pretty", "-e", "show columns from t.u"})
+	c.RunWithArgs([]string{"sql", "--pretty", "-e", "select * from t.u"})
 
 	// Output:
 	// sql -e create database t; create table t.t (s string, d string);
 	// CREATE TABLE
 	// sql -e insert into t.t values (e'foo', 'printable ASCII')
 	// INSERT 1
-	// sql -e insert into t.t values (e'foo\x0a', 'non-printable ASCII')
+	// sql -e insert into t.t values (e'"foo', 'printable ASCII with quotes')
+	// INSERT 1
+	// sql -e insert into t.t values (e'\\foo', 'printable ASCII with backslash')
+	// INSERT 1
+	// sql -e insert into t.t values (e'foo\x0abar', 'non-printable ASCII')
 	// INSERT 1
 	// sql -e insert into t.t values ('κόσμε', 'printable UTF8')
 	// INSERT 1
@@ -636,17 +650,74 @@ func Example_sql_escape() {
 	// INSERT 1
 	// sql -e insert into t.t values (e'\xc3\x28', 'non-UTF8 string')
 	// INSERT 1
+	// sql -e insert into t.t values (e'a\tb\tc\n12\t123123213\t12313', 'tabs')
+	// INSERT 1
 	// sql -e select * from t.t
-	// 7 rows
+	// 10 rows
 	// s	d
 	// foo	printable ASCII
-	// foo
-	// 	non-printable ASCII
-	// κόσμε	printable UTF8
-	// ñ	printable UTF8 using escapes
+	// "\"foo"	printable ASCII with quotes
+	// "\\foo"	printable ASCII with backslash
+	// "foo\nbar"	non-printable ASCII
+	// "\u03ba\u1f79\u03c3\u03bc\u03b5"	printable UTF8
+	// "\u00f1"	printable UTF8 using escapes
 	// "\x01"	non-printable UTF8 string
-	// ܈85	UTF8 string with RTL char
+	// "\u070885"	UTF8 string with RTL char
 	// "\xc3("	non-UTF8 string
+	// "a\tb\tc\n12\t123123213\t12313"	tabs
+	// sql -e create table t.u ("""foo" int, "\foo" int, "foo
+	// bar" int, "κόσμε" int, "܈85" int)
+	// CREATE TABLE
+	// sql -e insert into t.u values (0, 0, 0, 0, 0)
+	// INSERT 1
+	// sql -e show columns from t.u
+	// 6 rows
+	// Field	Type	Null	Default
+	// "\"foo"	INT	true	NULL
+	// "\\foo"	INT	true	NULL
+	// "foo\nbar"	INT	true	NULL
+	// "\u03ba\u1f79\u03c3\u03bc\u03b5"	INT	true	NULL
+	// "\u070885"	INT	true	NULL
+	// rowid	INT	false	unique_rowid()
+	// sql -e select * from t.u
+	// 1 row
+	// "\"foo"	"\\foo"	"foo\nbar"	"\u03ba\u1f79\u03c3\u03bc\u03b5"	"\u070885"
+	// 0	0	0	0	0
+	// sql --pretty -e select * from t.t
+	// +--------------------------------+--------------------------------+
+	// |               s                |               d                |
+	// +--------------------------------+--------------------------------+
+	// | foo                            | printable ASCII                |
+	// | "foo                           | printable ASCII with quotes    |
+	// | \foo                           | printable ASCII with backslash |
+	// | foo␤                           | non-printable ASCII            |
+	// | bar                            |                                |
+	// | κόσμε                          | printable UTF8                 |
+	// | ñ                              | printable UTF8 using escapes   |
+	// | "\x01"                         | non-printable UTF8 string      |
+	// | ܈85                            | UTF8 string with RTL char      |
+	// | "\xc3("                        | non-UTF8 string                |
+	// | a   b         c␤               | tabs                           |
+	// | 12  123123213 12313            |                                |
+	// +--------------------------------+--------------------------------+
+	// sql --pretty -e show columns from t.u
+	// +----------+------+-------+----------------+
+	// |  Field   | Type | Null  |    Default     |
+	// +----------+------+-------+----------------+
+	// | "foo     | INT  | true  | NULL           |
+	// | \foo     | INT  | true  | NULL           |
+	// | foo␤     | INT  | true  | NULL           |
+	// | bar      |      |       |                |
+	// | κόσμε    | INT  | true  | NULL           |
+	// | ܈85      | INT  | true  | NULL           |
+	// | rowid    | INT  | false | unique_rowid() |
+	// +----------+------+-------+----------------+
+	// sql --pretty -e select * from t.u
+	// +------+------+------------+-------+-----+
+	// | "foo | \foo | "foo\nbar" | κόσμε | ܈85 |
+	// +------+------+------------+-------+-----+
+	// |    0 |    0 |          0 |     0 |   0 |
+	// +------+------+------------+-------+-----+
 }
 
 func Example_user() {

--- a/cli/cliflags/names.go
+++ b/cli/cliflags/names.go
@@ -24,6 +24,7 @@ const (
 	DatabaseName          = "database"
 	DepsName              = "deps"
 	ExecuteName           = "execute"
+	PrettyName            = "pretty"
 	JoinName              = "join"
 	HostName              = "host"
 	InsecureName          = "insecure"

--- a/cli/context.go
+++ b/cli/context.go
@@ -45,6 +45,10 @@ type sqlContext struct {
 
 	// execStmts is a list of statements to execute.
 	execStmts statementsValue
+
+	// prettyFmt indicates whether tables should be pretty-formatted in
+	// the output during non-interactive execution.
+	prettyFmt bool
 }
 
 type debugContext struct {

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -100,6 +100,10 @@ separated statements. If an error occurs in any statement, the command exits
 with a non-zero status code and further statements are not executed. The
 results of each SQL statement are printed on the standard output.`),
 
+	cliflags.PrettyName: wrapText(`
+Causes table rows to be formatted as tables using ASCII art. 
+When not specified, table rows are printed as tab-separated values (TSV).`),
+
 	cliflags.JoinName: wrapText(`
 A comma-separated list of addresses to use when a new node is joining
 an existing cluster. For the first node in a cluster, --join should
@@ -441,6 +445,7 @@ func init() {
 	{
 		f := sqlShellCmd.Flags()
 		f.VarP(&sqlCtx.execStmts, cliflags.ExecuteName, "e", usageNoEnv(cliflags.ExecuteName))
+		f.BoolVar(&sqlCtx.prettyFmt, cliflags.PrettyName, false, usageNoEnv(cliflags.PrettyName))
 	}
 	{
 		f := freezeClusterCmd.PersistentFlags()

--- a/cli/node.go
+++ b/cli/node.go
@@ -72,7 +72,7 @@ func runLsNodes(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	printQueryOutput(os.Stdout, lsNodesColumnHeaders, rows, "")
+	printQueryOutput(os.Stdout, lsNodesColumnHeaders, rows, "", true)
 	return nil
 }
 
@@ -141,7 +141,7 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 		return util.Errorf("expected no arguments or a single node ID")
 	}
 
-	printQueryOutput(os.Stdout, nodesColumnHeaders, nodeStatusesToRows(nodeStatuses), "")
+	printQueryOutput(os.Stdout, nodesColumnHeaders, nodeStatusesToRows(nodeStatuses), "", true)
 	return nil
 }
 

--- a/cli/sql_util.go
+++ b/cli/sql_util.go
@@ -22,11 +22,13 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"text/tabwriter"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/olekukonko/tablewriter"
 
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/pq"
 )
@@ -107,20 +109,12 @@ type sqlRowsI interface {
 }
 
 type sqlRows struct {
-	rows    sqlRowsI
-	conn    *sqlConn
-	columns []string
+	rows sqlRowsI
+	conn *sqlConn
 }
 
 func (r *sqlRows) Columns() []string {
-	if r.columns == nil {
-		srcCols := r.rows.Columns()
-		r.columns = make([]string, len(srcCols))
-		for i, c := range srcCols {
-			r.columns[i] = escapeString(c)
-		}
-	}
-	return r.columns
+	return r.rows.Columns()
 }
 
 func (r *sqlRows) Result() driver.Result {
@@ -193,28 +187,30 @@ func makeQuery(query string, parameters ...driver.Value) queryFunc {
 
 // runQuery takes a 'query' with optional 'parameters'.
 // It runs the sql query and returns a list of columns names and a list of rows.
-func runQuery(conn *sqlConn, fn queryFunc) ([]string, [][]string, string, error) {
+func runQuery(conn *sqlConn, fn queryFunc, pretty bool) ([]string, [][]string, string, error) {
 	rows, err := fn(conn)
 	if err != nil {
 		return nil, nil, "", err
 	}
 
 	defer func() { _ = rows.Close() }()
-	return sqlRowsToStrings(rows)
+	return sqlRowsToStrings(rows, pretty)
 }
 
-// runPrettyQuery takes a 'query' with optional 'parameters'.
-// It runs the sql query and writes pretty output to 'w'.
-func runPrettyQuery(conn *sqlConn, w io.Writer, fn queryFunc) error {
+// runQueryAndFormatResults takes a 'query' with optional 'parameters'.
+// It runs the sql query and writes output to 'w'.
+func runQueryAndFormatResults(
+	conn *sqlConn, w io.Writer, fn queryFunc, pretty bool,
+) error {
 	for {
-		cols, allRows, result, err := runQuery(conn, fn)
+		cols, allRows, result, err := runQuery(conn, fn, pretty)
 		if err != nil {
 			if err == pq.ErrNoMoreResults {
 				return nil
 			}
 			return err
 		}
-		printQueryOutput(w, cols, allRows, result)
+		printQueryOutput(w, cols, allRows, result, pretty)
 		fn = nextResult
 	}
 }
@@ -225,8 +221,13 @@ func runPrettyQuery(conn *sqlConn, w io.Writer, fn queryFunc) error {
 // It returns the header row followed by all data rows.
 // If both the header row and list of rows are empty, it means no row
 // information was returned (eg: statement was not a query).
-func sqlRowsToStrings(rows *sqlRows) ([]string, [][]string, string, error) {
-	cols := rows.Columns()
+// If pretty is true, then more characters are not escaped.
+func sqlRowsToStrings(rows *sqlRows, pretty bool) ([]string, [][]string, string, error) {
+	srcCols := rows.Columns()
+	cols := make([]string, len(srcCols))
+	for i, c := range srcCols {
+		cols[i] = formatVal(c, pretty, false)
+	}
 
 	var allRows [][]string
 	var vals []driver.Value
@@ -244,7 +245,7 @@ func sqlRowsToStrings(rows *sqlRows) ([]string, [][]string, string, error) {
 		}
 		rowStrings := make([]string, len(cols))
 		for i, v := range vals {
-			rowStrings[i] = formatVal(v)
+			rowStrings[i] = formatVal(v, pretty, pretty)
 		}
 		allRows = append(allRows, rowStrings)
 	}
@@ -263,48 +264,106 @@ func sqlRowsToStrings(rows *sqlRows) ([]string, [][]string, string, error) {
 	return cols, allRows, tag, nil
 }
 
+// expandTabsAndNewLines ensures that multi-line row strings that may
+// contain tabs are properly formatted: tabs are expanded to spaces,
+// and newline characters are marked visually. Marking newline
+// characters is especially important in single-column results where
+// the underlying TableWriter would not otherwise show the difference
+// between one multi-line row and two one-line rows.
+func expandTabsAndNewLines(s string) string {
+	var buf bytes.Buffer
+	// 4-wide columns, 1 character minimum width.
+	w := tabwriter.NewWriter(&buf, 4, 0, 1, ' ', 0)
+	fmt.Fprint(w, strings.Replace(s, "\n", "␤\n", -1))
+	_ = w.Flush()
+	return buf.String()
+}
+
 // printQueryOutput takes a list of column names and a list of row contents
 // writes a pretty table to 'w', or "OK" if empty.
-func printQueryOutput(w io.Writer, cols []string, allRows [][]string, tag string) {
+func printQueryOutput(
+	w io.Writer, cols []string, allRows [][]string, tag string, pretty bool,
+) {
 	if len(cols) == 0 {
 		// This operation did not return rows, just show the tag.
 		fmt.Fprintln(w, tag)
 		return
 	}
 
-	// Initialize tablewriter and set column names as the header row.
-	table := tablewriter.NewWriter(w)
-	table.SetAutoFormatHeaders(false)
-	table.SetAutoWrapText(false)
-	table.SetHeader(cols)
+	if pretty {
+		// Initialize tablewriter and set column names as the header row.
+		table := tablewriter.NewWriter(w)
+		table.SetAutoFormatHeaders(false)
+		table.SetAutoWrapText(false)
+		table.SetHeader(cols)
+		for _, row := range allRows {
+			for i, r := range row {
+				row[i] = expandTabsAndNewLines(r)
+			}
+			table.Append(row)
+		}
+		table.Render()
+	} else {
+		if len(cols) == 0 {
+			// No result selected, inform the user.
+			fmt.Fprintln(w, tag)
+		} else {
+			// Some results selected, inform the user about how much data to expect.
+			fmt.Fprintf(w, "%d row%s\n", len(allRows),
+				util.Pluralize(int64(len(allRows))))
 
-	for _, row := range allRows {
-		table.Append(row)
+			// Then print the results themselves.
+			fmt.Fprintln(w, strings.Join(cols, "\t"))
+			for _, row := range allRows {
+				fmt.Fprintln(w, strings.Join(row, "\t"))
+			}
+		}
 	}
-
-	table.Render()
 }
 
-func formatVal(val driver.Value) string {
+func isNotPrintableASCII(r rune) bool { return r < 0x20 || r > 0x7e || r == '"' || r == '\\' }
+func isNotGraphicUnicode(r rune) bool { return !unicode.IsGraphic(r) }
+func isNotGraphicUnicodeOrTabOrNewline(r rune) bool {
+	return r != '\t' && r != '\n' && !unicode.IsGraphic(r)
+}
+
+func formatVal(
+	val driver.Value, showPrintableUnicode bool, showNewLinesAndTabs bool,
+) string {
 	switch t := val.(type) {
 	case nil:
 		return "NULL"
-	case []byte:
-		// We don't escape valid strings that contain only printable characters.
-		if utf8.Valid(t) && bytes.IndexFunc(t, func(r rune) bool { return r != '\t' && r != '\n' && !unicode.IsGraphic(r) }) == -1 {
-			return strings.Replace(string(t), "\t", "    ", -1)
+	case string:
+		if showPrintableUnicode {
+			pred := isNotGraphicUnicode
+			if showNewLinesAndTabs {
+				pred = isNotGraphicUnicodeOrTabOrNewline
+			}
+			if utf8.ValidString(t) && strings.IndexFunc(t, pred) == -1 {
+				return t
+			}
+		} else {
+			if strings.IndexFunc(t, isNotPrintableASCII) == -1 {
+				return t
+			}
 		}
-		// We use %+q to ensure the output contains only ASCII (see issue #4315).
+		return fmt.Sprintf("%+q", t)
+
+	case []byte:
+		if showPrintableUnicode {
+			pred := isNotGraphicUnicode
+			if showNewLinesAndTabs {
+				pred = isNotGraphicUnicodeOrTabOrNewline
+			}
+			if utf8.Valid(t) && bytes.IndexFunc(t, pred) == -1 {
+				return string(t)
+			}
+		} else {
+			if bytes.IndexFunc(t, isNotPrintableASCII) == -1 {
+				return string(t)
+			}
+		}
 		return fmt.Sprintf("%+q", t)
 	}
 	return fmt.Sprint(val)
-}
-
-func escapeString(t string) string {
-	// We don't escape strings that contain only printable characters.
-	if utf8.ValidString(t) && strings.IndexFunc(t, func(r rune) bool { return !unicode.IsGraphic(r) }) == -1 {
-		return t
-	}
-	// We use %+q to ensure the output contains only ASCII (see issue #4315).
-	return fmt.Sprintf("%+q", t)
 }

--- a/cli/sql_util_test.go
+++ b/cli/sql_util_test.go
@@ -42,7 +42,7 @@ func TestRunQuery(t *testing.T) {
 	var b bytes.Buffer
 
 	// Non-query statement.
-	if err := runPrettyQuery(conn, &b, makeQuery(`SET DATABASE=system`)); err != nil {
+	if err := runQueryAndFormatResults(conn, &b, makeQuery(`SET DATABASE=system`), true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -55,7 +55,7 @@ SET
 	b.Reset()
 
 	// Use system database for sample query/output as they are fairly fixed.
-	cols, rows, _, err := runQuery(conn, makeQuery(`SHOW COLUMNS FROM system.namespace`))
+	cols, rows, _, err := runQuery(conn, makeQuery(`SHOW COLUMNS FROM system.namespace`), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,8 +74,8 @@ SET
 		t.Fatalf("expected:\n%v\ngot:\n%v", expectedRows, rows)
 	}
 
-	if err := runPrettyQuery(conn, &b,
-		makeQuery(`SHOW COLUMNS FROM system.namespace`)); err != nil {
+	if err := runQueryAndFormatResults(conn, &b,
+		makeQuery(`SHOW COLUMNS FROM system.namespace`), true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -95,8 +95,8 @@ SET
 	b.Reset()
 
 	// Test placeholders.
-	if err := runPrettyQuery(conn, &b,
-		makeQuery(`SELECT * FROM system.namespace WHERE name=$1`, "descriptor")); err != nil {
+	if err := runQueryAndFormatResults(conn, &b,
+		makeQuery(`SELECT * FROM system.namespace WHERE name=$1`, "descriptor"), true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -113,8 +113,8 @@ SET
 	b.Reset()
 
 	// Test multiple results.
-	if err := runPrettyQuery(conn, &b,
-		makeQuery(`SELECT 1; SELECT 2, 3; SELECT 'hello'`)); err != nil {
+	if err := runQueryAndFormatResults(conn, &b,
+		makeQuery(`SELECT 1; SELECT 2, 3; SELECT 'hello'`), true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cli/user.go
+++ b/cli/user.go
@@ -48,8 +48,8 @@ func runGetUser(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 	defer conn.Close()
-	err = runPrettyQuery(conn, os.Stdout,
-		makeQuery(`SELECT * FROM system.users WHERE username=$1`, args[0]))
+	err = runQueryAndFormatResults(conn, os.Stdout,
+		makeQuery(`SELECT * FROM system.users WHERE username=$1`, args[0]), true)
 	if err != nil {
 		panic(err)
 	}
@@ -76,8 +76,8 @@ func runLsUsers(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 	defer conn.Close()
-	err = runPrettyQuery(conn, os.Stdout,
-		makeQuery(`SELECT username FROM system.users`))
+	err = runQueryAndFormatResults(conn, os.Stdout,
+		makeQuery(`SELECT username FROM system.users`), true)
 	if err != nil {
 		panic(err)
 	}
@@ -104,8 +104,8 @@ func runRmUser(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 	defer conn.Close()
-	err = runPrettyQuery(conn, os.Stdout,
-		makeQuery(`DELETE FROM system.users WHERE username=$1`, args[0]))
+	err = runQueryAndFormatResults(conn, os.Stdout,
+		makeQuery(`DELETE FROM system.users WHERE username=$1`, args[0]), true)
 	if err != nil {
 		panic(err)
 	}
@@ -176,8 +176,8 @@ func runSetUser(cmd *cobra.Command, args []string) {
 	}
 	defer conn.Close()
 	// TODO(marc): switch to UPSERT.
-	err = runPrettyQuery(conn, os.Stdout,
-		makeQuery(`INSERT INTO system.users VALUES ($1, $2)`, args[0], hashed))
+	err = runQueryAndFormatResults(conn, os.Stdout,
+		makeQuery(`INSERT INTO system.users VALUES ($1, $2)`, args[0], hashed), true)
 	if err != nil {
 		panic(err)
 	}

--- a/cli/zone.go
+++ b/cli/zone.go
@@ -387,8 +387,8 @@ func runRmZone(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to remove %s", args[0])
 	}
 
-	if err := runPrettyQuery(conn, os.Stdout,
-		makeQuery(`DELETE FROM system.zones WHERE id=$1`, id)); err != nil {
+	if err := runQueryAndFormatResults(conn, os.Stdout,
+		makeQuery(`DELETE FROM system.zones WHERE id=$1`, id), true); err != nil {
 		return err
 	}
 	return conn.Exec(`COMMIT`, nil)
@@ -485,11 +485,11 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 
 	id := path[len(path)-1]
 	if id == zoneID {
-		err = runPrettyQuery(conn, os.Stdout,
-			makeQuery(`UPDATE system.zones SET config = $2 WHERE id = $1`, id, buf))
+		err = runQueryAndFormatResults(conn, os.Stdout,
+			makeQuery(`UPDATE system.zones SET config = $2 WHERE id = $1`, id, buf), true)
 	} else {
-		err = runPrettyQuery(conn, os.Stdout,
-			makeQuery(`INSERT INTO system.zones VALUES ($1, $2)`, id, buf))
+		err = runQueryAndFormatResults(conn, os.Stdout,
+			makeQuery(`INSERT INTO system.zones VALUES ($1, $2)`, id, buf), true)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Summary:
- by default, `sql -e` always escapes strings that contain special
  characters. It also forcefully escapes strings containing double
  quotes and backslashes, so as to ease automated processing by other
  languages (ie. a string starting with a doublequote character in the
  output will always be the start of an escaped string.). This
  way issue #4315 is still addressed adequately.
- a new flag `--pretty` is added to the `sql` sub-command, to print
  row data as pretty-formatted ASCII art tables.
- when results are pretty-formatted (either in the interactive shell
  or with `sql --pretty -e`), graphic unicode and newline characters
  are printed without escaping. This keeps the fix to #6926.
- new tests are added in `cli_test.go` (`Example_sql_escape`) to test
  escaped and non-escaped output when table and column names contain
  special characters.
- the `cli` API renames `runPrettyQuery` to
  `runQueryAndFormatResults`, and extends it with an extra argument to
  specify pretty-printing.

(See issues/PRs #7045, #6926, #4354 and #4315 for background discussion.)

cc @bdarnell @mjibson @dt

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7048)

<!-- Reviewable:end -->
