### PR TITLE
sql: factor expression semantic analysis.

### DIFF
--- a/sql/check.go
+++ b/sql/check.go
@@ -44,19 +44,9 @@ func (c *checkHelper) init(p *planner, tableDesc *sqlbase.TableDescriptor) error
 		if err != nil {
 			return err
 		}
-		replaced, err := p.replaceSubqueries(raw, 1)
+		typedExpr, err := p.analyzeExpr(raw, []*tableInfo{&table}, c.qvals,
+			parser.TypeBool, false, "")
 		if err != nil {
-			return nil
-		}
-		resolved, err := resolveQNames(replaced, []*tableInfo{&table}, c.qvals, &p.qnameVisitor)
-		if err != nil {
-			return err
-		}
-		typedExpr, err := parser.TypeCheck(resolved, nil, parser.TypeBool)
-		if err != nil {
-			return err
-		}
-		if typedExpr, err = p.parser.NormalizeExpr(&p.evalCtx, typedExpr); err != nil {
 			return err
 		}
 		c.exprs[i] = typedExpr

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -45,13 +45,13 @@ type deleteNode struct {
 //   Notes: postgres requires DELETE. Also requires SELECT for "USING" and "WHERE" with tables.
 //          mysql requires DELETE. Also requires SELECT if a table is used in the "WHERE" clause.
 func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoCommit bool) (planNode, error) {
-	en, err := p.makeEditNode(n.Table, n.Returning, desiredTypes, autoCommit, privilege.DELETE)
+	en, err := p.makeEditNode(n.Table, autoCommit, privilege.DELETE)
 	if err != nil {
 		return nil, err
 	}
 
 	var requestedCols []sqlbase.ColumnDescriptor
-	if len(en.rh.exprs) > 0 {
+	if len(n.Returning) > 0 {
 		// TODO(dan): This could be made tighter, just the rows needed for RETURNING
 		// exprs.
 		requestedCols = en.tableDesc.Columns
@@ -77,23 +77,20 @@ func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoComm
 		return nil, err
 	}
 
-	if err := en.rh.TypeCheck(); err != nil {
-		return nil, err
-	}
-
 	dn := &deleteNode{
 		n:            n,
 		editNodeBase: en,
 		tw:           tw,
 	}
-	dn.run.initEditNode(rows)
+
+	if err := dn.run.initEditNode(&dn.editNodeBase, rows, n.Returning, desiredTypes); err != nil {
+		return nil, err
+	}
+
 	return dn, nil
 }
 
 func (d *deleteNode) expandPlan() error {
-	if err := d.rh.expandPlans(); err != nil {
-		return err
-	}
 	return d.run.expandEditNodePlan(&d.editNodeBase, &d.tw)
 }
 

--- a/sql/upsert.go
+++ b/sql/upsert.go
@@ -98,22 +98,7 @@ func (p *planner) makeUpsertHelper(
 	var normExprs []parser.TypedExpr
 	qvals := make(qvalMap)
 	for _, expr := range untupledExprs {
-		expandedExpr, err := p.replaceSubqueries(expr, 1)
-		if err != nil {
-			return nil, err
-		}
-
-		resolvedExpr, err := resolveQNames(expandedExpr, tables, qvals, &p.qnameVisitor)
-		if err != nil {
-			return nil, err
-		}
-
-		typedExpr, err := parser.TypeCheck(resolvedExpr, &p.semaCtx, parser.NoTypePreference)
-		if err != nil {
-			return nil, err
-		}
-
-		normExpr, err := p.parser.NormalizeExpr(&p.evalCtx, typedExpr)
+		normExpr, err := p.analyzeExpr(expr, tables, qvals, parser.NoTypePreference, false, "")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This patch introduces `planner.analyzeExpr` which groups sequences of
calls to `replaceSuqueries`, `resolveQNames`, `TypeCheck` and
`NormalizeExpr`.

Fixes #6860.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7049)

<!-- Reviewable:end -->
