### PR TITLE
storage: update Replica.truncatedState in a defer

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1705,11 +1705,6 @@ func (r *Replica) applyRaftCommand(idKey storagebase.CmdIDKey, ctx context.Conte
 		// Update cached appliedIndex if we were able to set the applied index
 		// on disk.
 		r.mu.appliedIndex = index
-		// Invalidate the cache and let raftTruncatedStateLocked() read the
-		// value the next time it's required.
-		if _, ok := ba.GetArg(roachpb.TruncateLog); ok {
-			r.mu.truncatedState = nil
-		}
 		r.mu.Unlock()
 	}
 


### PR DESCRIPTION
Instead of clearing the cached `Replica.truncatedState` after committing
a batch which contains a `TruncateLogRequest`, we now update the cached
data based on what was written to disk use a `Batch.Defer`. This follows
the pattern used for `ChangeFrozenRequest` and `GCRequest`.

See #6012.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7053)

<!-- Reviewable:end -->
