### PR TITLE
[DO NOT MERGE] attempts to add multi node testing to benchmark test

### DIFF
--- a/server/testserver.go
+++ b/server/testserver.go
@@ -87,6 +87,15 @@ func StartTestServerJoining(t util.Tester, other TestServer) TestServer {
 	return s
 }
 
+// StartTestServerCluster starts a test server and has n other servers join locally.
+func StartTestServerCluster(t util.Tester, n int) TestServer {
+	s := StartTestServer(t)
+	for i := 0; i < n; i++ {
+		_ = StartTestServerJoining(t, s)
+	}
+	return s
+}
+
 // StartInsecureTestServer starts an insecure in-memory test server.
 func StartInsecureTestServer(t util.Tester) TestServer {
 	ctx := MakeTestContext()

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -36,7 +36,7 @@ import (
 
 func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
 	defer tracing.Disable()()
-	s := server.StartTestServer(b)
+	s := server.StartTestServerCluster(b, 3)
 	defer s.Stop()
 
 	pgURL, cleanupFn := sqlutils.PGUrl(b, s.ServingAddr(), security.RootUser, "benchmarkCockroach")


### PR DESCRIPTION
fixes #6890 

I wanted to see if this seems like the right way to go about adding more nodes to the benchmark tests. If it is, should I duplicate every benchmark test to run twice: once with one node and once with N nodes? If so, what should N be? In this PR I put N=3. 

I ran

```
 make bench PKG=./sql
```

after doing this change and got inconsistent results. Half the time the tests finished in ~50s with lots of fails, and half the time it ended in ~350s with fewer fails (although it spits out so much text that I'm not sure how to evaluate.) Running the benchmarks for SQL with the single node usually finishes in 450s with an output similar to what happens with multiple nodes when it takes 350s.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7063)

<!-- Reviewable:end -->
