### PR TITLE
sql/parser: Clarify rules about initial arg types in ProcessPlaceholderAnnotations

### DIFF
--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -999,12 +999,16 @@ func (*placeholderAnnotationVisitor) VisitPost(expr Expr) Expr { return expr }
 // situations.
 // - the placeholder is the subject of an explicit type annotation in at least one
 //   of its occurrences. If it is subject to multiple explicit type annotations where
-//   the types are not all in agreement, and error will be thrown.
+//   the types are not all in agreement, or if the placeholder already has an inferred
+//   type in the provided args map which conflicts with the explicit type annotation
+//   type, an error will be thrown.
 // - the placeholder is the subject to an implicit type annotation, meaning that it
 //   is not subject to an explicit type annotation, and that in all occurrences of the
 //   placeholder, it is subject to a cast to the same type. If it is subject to casts
-//   of multiple types, no error will be thrown, but the placeholder will not be
-//   annotated.
+//   of multiple types, no error will be thrown, but the placeholder type will not be
+//   inferred. If a type has already been assigned for the placeholder in the provided
+//   args map, no error will be thrown, and the placeholder will keep it's previously
+//   inferred type.
 //
 // TODO(nvanbenschoten) Add support for explicit placeholder annotations.
 // TODO(nvanbenschoten) Can this visitor and map be preallocated (like normalizeVisitor)?


### PR DESCRIPTION
This commit clarifies the rules on how `ProcessPlaceholderAnnotations`
handles previously inferred placeholder types. It then adds tests to
verify the correct behavior when these interact with `CastExpr`s.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7074)

<!-- Reviewable:end -->
