### PR TITLE
sql: safely process index schema changes that reference mutation columns

### DIFF
--- a/sql/delete.go
+++ b/sql/delete.go
@@ -72,7 +72,7 @@ func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoComm
 		Exprs: sqlbase.ColumnsSelectors(rd.fetchCols),
 		From:  []parser.TableExpr{n.Table},
 		Where: n.Where,
-	}, nil, nil, nil, publicColumns)
+	}, nil, nil, nil, publicAndNonPublicColumns)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/rowwriter.go
+++ b/sql/rowwriter.go
@@ -338,7 +338,7 @@ func makeRowUpdater(
 		deleteOnlyIndex:     deleteOnlyIndex,
 		primaryKeyColChange: primaryKeyColChange,
 		marshalled:          make([]roachpb.Value, len(updateCols)),
-		newValues:           make([]parser.Datum, len(tableDesc.Columns)),
+		newValues:           make([]parser.Datum, len(tableDesc.Columns)+len(tableDesc.Mutations)),
 	}
 
 	if primaryKeyColChange {


### PR DESCRIPTION
#6691

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7075)

<!-- Reviewable:end -->
