### PR TITLE
storage: Define the range lease duration as 3 times the raft election cycle to prevent any issues from occurring when the `--raft-tick-interval` flag is set.

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -1596,7 +1596,7 @@ func TestLeaderRemoveSelf(t *testing.T) {
 	clock := mtc.clocks[0]
 	header := roachpb.Header{}
 	header.Timestamp = clock.Update(clock.Now().Add(
-		storage.LeaderLeaseExpiration(clock), 0))
+		storage.LeaderLeaseExpiration(mtc.stores[0], clock), 0))
 
 	// Expect get a RangeNotFoundError.
 	_, pErr := client.SendWrappedWith(rg1(mtc.stores[0]), nil, header, &getArgs)

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -781,7 +781,7 @@ func (m *multiTestContext) waitForValues(key roachpb.Key, expected []int64) {
 // future that current leader leases are expired. Useful for tests which modify
 // replica sets.
 func (m *multiTestContext) expireLeaderLeases() {
-	m.manualClock.Increment(storage.LeaderLeaseExpiration(m.clock))
+	m.manualClock.Increment(storage.LeaderLeaseExpiration(m.stores[0], m.clock))
 }
 
 // getRaftLeader returns the replica that is the current raft leader for the

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -89,15 +89,6 @@ var txnAutoGC = true
 const (
 	raftInitialLogIndex = 10
 	raftInitialLogTerm  = 5
-
-	// LeaderLeaseActiveDuration is the duration of the active period of leader
-	// leases requested.
-	LeaderLeaseActiveDuration = time.Second
-	// leaderLeaseRenewalDuration specifies a "time" interval at the
-	// end of the active lease interval (i.e. bounded to the right by the
-	// start of the stasis period) during which timestamps will trigger an
-	// asynchronous renewal of the lease.
-	leaderLeaseRenewalDuration = LeaderLeaseActiveDuration / 5
 )
 
 // consultsTimestampCacheMethods specifies the set of methods which
@@ -536,7 +527,7 @@ func (r *Replica) requestLeaderLease(timestamp roachpb.Timestamp) <-chan *roachp
 		pErr := func() *roachpb.Error {
 			// TODO(tschottdorf): get duration from configuration, either as a
 			// config flag or, later, dynamically adjusted.
-			startStasis := timestamp.Add(int64(LeaderLeaseActiveDuration), 0)
+			startStasis := timestamp.Add(int64(r.store.ctx.leaderLeaseActiveDuration), 0)
 			expiration := startStasis.Add(int64(r.store.Clock().MaxOffset()), 0)
 
 			// Prepare a Raft command to get a leader lease for this replica.
@@ -640,7 +631,7 @@ func (r *Replica) redirectOnOrAcquireLeaderLease(ctx context.Context) *roachpb.E
 				return roachpb.NewError(r.newNotLeaderError(lease, r.store.StoreID()))
 			}
 			if !inFlight && !timestamp.Less(lease.StartStasis.Add(
-				-int64(leaderLeaseRenewalDuration), 0)) {
+				-int64(r.store.ctx.leaderLeaseRenewalDuration), 0)) {
 				if log.V(2) {
 					log.Warningf("extending lease %s at %s", lease, timestamp)
 				}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -87,11 +87,11 @@ const (
 
 // LeaderLeaseExpiration returns an int64 to increment a manual clock with to
 // make sure that all active leader leases expire.
-func LeaderLeaseExpiration(clock *hlc.Clock) int64 {
+func LeaderLeaseExpiration(s *Store, clock *hlc.Clock) int64 {
 	// Due to lease extensions, the remaining interval can be longer than just
 	// the sum of the offset (=length of stasis period) and the active
 	// duration, but definitely not by 2x.
-	return 2 * int64(LeaderLeaseActiveDuration+clock.MaxOffset())
+	return 2 * int64(s.ctx.leaderLeaseActiveDuration+clock.MaxOffset())
 }
 
 // leaseExpiry returns a duration in nanos after which any leader lease the


### PR DESCRIPTION
Fixes #6815

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7086)

<!-- Reviewable:end -->
