### PR TITLE
sql/parser: Demonstrate StrVal type inference in overload resolution

### DIFF
--- a/sql/parser/overload.go
+++ b/sql/parser/overload.go
@@ -182,6 +182,10 @@ func typeCheckOverloadedExprs(
 	// Hold the resolved type expressions of the provided exprs, in order.
 	typedExprs := make([]TypedExpr, len(exprs))
 
+	// Split provided expressions into three groups:
+	// - Arguments
+	// - Numeric constants
+	// - All other Exprs
 	var resolvableExprs, constExprs, valExprs []indexedExpr
 	for i, expr := range exprs {
 		idxExpr := indexedExpr{e: expr, i: i}
@@ -250,7 +254,7 @@ func typeCheckOverloadedExprs(
 
 	// Filter out overloads which constants cannot become.
 	for _, expr := range constExprs {
-		constExpr := expr.e.(*NumVal)
+		constExpr := expr.e.(Constant)
 		filterOverloads(func(o overloadImpl) bool {
 			return canConstantBecome(constExpr, o.params().getAt(expr.i))
 		})
@@ -355,7 +359,7 @@ func typeCheckOverloadedExprs(
 		if homogeneousTyp != nil {
 			all := true
 			for _, expr := range constExprs {
-				if !canConstantBecome(expr.e.(*NumVal), homogeneousTyp) {
+				if !canConstantBecome(expr.e.(Constant), homogeneousTyp) {
 					all = false
 					break
 				}
@@ -379,7 +383,7 @@ func typeCheckOverloadedExprs(
 		// The third heuristic is to prefer candidates where all numeric constants can become
 		// their "natural"" types.
 		for _, expr := range constExprs {
-			natural := naturalConstantType(expr.e.(*NumVal))
+			natural := naturalConstantType(expr.e.(Constant))
 			if natural != nil {
 				filterOverloads(func(o overloadImpl) bool {
 					return o.params().getAt(expr.i).TypeEqual(natural)

--- a/sql/testdata/datetime
+++ b/sql/testdata/datetime
@@ -84,12 +84,12 @@ true true
 # TIMESTAMP/DATE builtins.
 
 query T
-SELECT age(timestamp '2001-04-10 22:06:45', timestamp '1957-06-13')
+SELECT age('2001-04-10 22:06:45', '1957-06-13')
 ----
 384190h6m45s
 
 query B
-SELECT age(timestamp '1957-06-13') - age(now(), timestamp '1957-06-13') = interval '0s'
+SELECT age('1957-06-13') - age(now(), '1957-06-13') = interval '0s'
 ----
 true
 
@@ -294,83 +294,83 @@ SELECT k FROM kv ORDER BY v
 
 
 query I
-SELECT extract(year from timestamp '2001-04-10 12:04:59')
+SELECT extract(year from '2001-04-10 12:04:59')
 ----
 2001
 
 query I
-SELECT extract(quarter from timestamp '2001-04-10 12:04:59')
+SELECT extract(quarter from '2001-04-10 12:04:59')
 ----
 2
 
 query I
-SELECT extract(month from timestamp '2001-04-10 12:04:59')
+SELECT extract(month from '2001-04-10 12:04:59')
 ----
 4
 
 query I
-SELECT extract(week from timestamp '2001-04-10 12:04:59')
+SELECT extract(week from '2001-04-10 12:04:59')
 ----
 15
 
 query I
-SELECT extract(day from timestamp '2001-04-10 12:04:59')
+SELECT extract(day from '2001-04-10 12:04:59')
 ----
 10
 
 query I
-SELECT extract(dayofweek from timestamp '2001-04-10 12:04:59')
+SELECT extract(dayofweek from '2001-04-10 12:04:59')
 ----
 2
 
 query I
-SELECT extract(dow from timestamp '2001-04-12 12:04:59')
+SELECT extract(dow from '2001-04-12 12:04:59')
 ----
 4
 
 query I
-SELECT extract(dayofyear from timestamp '2001-04-10 12:04:59')
+SELECT extract(dayofyear from '2001-04-10 12:04:59')
 ----
 100
 
 query I
-SELECT extract(doy from timestamp '2001-04-12 12:04:59')
+SELECT extract(doy from '2001-04-12 12:04:59')
 ----
 102
 
 query I
-SELECT extract(epoch from timestamp '2001-04-10 12:04:59')
+SELECT extract(epoch from '2001-04-10 12:04:59')
 ----
 986904299
 
 query I
-SELECT extract(hour from timestamp '2001-04-10 12:04:59')
+SELECT extract(hour from '2001-04-10 12:04:59')
 ----
 12
 
 query I
-SELECT extract(minute from timestamp '2001-04-10 12:04:59')
+SELECT extract(minute from '2001-04-10 12:04:59')
 ----
 4
 
 query I
-SELECT extract(second from timestamp '2001-04-10 12:04:59.234')
+SELECT extract(second from '2001-04-10 12:04:59.234')
 ----
 59
 
 query I
-SELECT extract(millisecond from timestamp '2001-04-10 12:04:59.234567')
+SELECT extract(millisecond from '2001-04-10 12:04:59.234567')
 ----
 234
 
 query I
-SELECT extract(microsecond from timestamp '2001-04-10 12:04:59.34565423')
+SELECT extract(microsecond from '2001-04-10 12:04:59.34565423')
 ----
 345654
 
 # nanoseconds are truncated to microseconds
 query I
-SELECT extract(nanosecond from timestamp '2001-04-10 12:04:59.34565423')
+SELECT extract(nanosecond from '2001-04-10 12:04:59.34565423')
 ----
 345654000
 
@@ -413,7 +413,7 @@ SELECT max(extract(nanosecond from a) % 1000) != 0 FROM t
 true
 
 query TT
-SELECT format_timestamp_ns('2001-04-10 12:04:59.345654423'::timestamp), format_timestamp_ns(parse_timestamp_ns('2001-04-10 12:04:59.345654423'))
+SELECT format_timestamp_ns('2001-04-10 12:04:59.345654423'), format_timestamp_ns(parse_timestamp_ns('2001-04-10 12:04:59.345654423'))
 ----
 2001-04-10 12:04:59.345654 2001-04-10 12:04:59.345654423
 
@@ -449,7 +449,7 @@ SELECT max(extract(nanosecond from expiration) % 1000) != 0 from system.lease
 true
 
 query error extract: unsupported timespan: nansecond
-SELECT extract(nansecond from timestamp '2001-04-10 12:04:59.34565423')
+SELECT extract(nansecond from '2001-04-10 12:04:59.34565423')
 
 # Test SET TIME ZONE
 


### PR DESCRIPTION
This change adds/changes a few tests to demonstrate that limited type
inference with string constants is possible during overload resolution.
The inference is only possible if the overload is limited to a single
implementation when type checking resolvable expressions. This is
because we treat string literals different than numeric literals in
overload resolution (see Typing RFC).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7098)

<!-- Reviewable:end -->
