### PR TITLE
sql: move the aggfuncs to parser/builtins

### DIFF
--- a/sql/group.go
+++ b/sql/group.go
@@ -19,30 +19,13 @@ package sql
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"strings"
-
-	"gopkg.in/inf.v0"
 
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/util"
-	"github.com/cockroachdb/cockroach/util/decimal"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 )
-
-var aggregates = map[string]func() aggregateImpl{
-	"avg":      newAvgAggregate,
-	"bool_and": newBoolAndAggregate,
-	"bool_or":  newBoolOrAggregate,
-	"count":    newCountAggregate,
-	"max":      newMaxAggregate,
-	"min":      newMinAggregate,
-	"sum":      newSumAggregate,
-	"stddev":   newStddevAggregate,
-	"variance": newVarianceAggregate,
-}
 
 // groupBy constructs a groupNode according to grouping functions or clauses. This may adjust the
 // render targets in the selectNode as necessary.
@@ -75,9 +58,9 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 		}
 
 		// If a col index is specified, replace it with that expression first.
-		// NB: This is not a deep copy, and thus when extractAggregateFuncs runs
+		// NB: This is not a deep copy, and thus when extractAggregatesVisitor runs
 		// on s.render, the GroupBy expressions can contain wrapped qvalues.
-		// aggregateFunc's Eval() method handles being called during grouping.
+		// aggregateFuncHolder's Eval() method handles being called during grouping.
 		if col, err := colIndex(s.numOriginalCols, resolved); err != nil {
 			return nil, err
 		} else if col >= 0 {
@@ -124,7 +107,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 	// Loop over the render expressions and extract any aggregate functions --
 	// qvalues are also replaced (with identAggregates, which just return the last
 	// value added to them for a bucket) to provide grouped-by values for each bucket.
-	// After extraction, group.render will be entirely rendered from aggregateFuncs,
+	// After extraction, group.render will be entirely rendered from aggregateFuncHolders,
 	// and group.funcs will contain all the functions which need to be fed values.
 	for i := range group.render {
 		typedExpr, err := visitor.extract(group.render[i])
@@ -185,7 +168,7 @@ type groupNode struct {
 	render []parser.TypedExpr
 	having parser.TypedExpr
 
-	funcs []*aggregateFunc
+	funcs []*aggregateFuncHolder
 	// The set of bucket keys.
 	buckets map[string]struct{}
 
@@ -194,7 +177,7 @@ type groupNode struct {
 	values    valuesNode
 	populated bool
 
-	// During rendering, aggregateFuncs compute their result for group.currentBucket.
+	// During rendering, aggregateFuncHolders compute their result for group.currentBucket.
 	currentBucket string
 
 	// desiredOrdering is set only if we are aggregating around a single MIN/MAX
@@ -318,7 +301,7 @@ func (n *groupNode) Next() (bool, error) {
 
 		n.buckets[string(encoded)] = struct{}{}
 
-		// Feed the aggregateFuncs for this bucket the non-grouped values.
+		// Feed the aggregateFuncHolders for this bucket the non-grouped values.
 		for i, value := range aggregatedValues {
 			if err := n.funcs[i].add(encoded, value); err != nil {
 				return false, err
@@ -342,7 +325,7 @@ func (n *groupNode) computeAggregates() error {
 		n.buckets[""] = struct{}{}
 	}
 
-	// Since this controls Eval behavior of aggregateFunc, it is not set until init is complete.
+	// Since this controls Eval behavior of aggregateFuncHolder, it is not set until init is complete.
 	n.populated = true
 
 	// Render the results.
@@ -448,20 +431,20 @@ func (n *groupNode) isNotNullFilter(expr parser.TypedExpr) parser.TypedExpr {
 // aggregation. If zero or multiple MIN/MAX aggregations are requested then no
 // ordering will be requested. A negative index indicates a MAX aggregation was
 // requested for the output column.
-func desiredAggregateOrdering(funcs []*aggregateFunc) columnOrdering {
+func desiredAggregateOrdering(funcs []*aggregateFuncHolder) columnOrdering {
 	limit := -1
 	direction := encoding.Ascending
 	for i, f := range funcs {
 		impl := f.create()
 		switch impl.(type) {
-		case *maxAggregate, *minAggregate:
+		case *parser.MaxAggregate, *parser.MinAggregate:
 			if limit != -1 || f.arg == nil {
 				return nil
 			}
 			switch f.arg.(type) {
 			case *qvalue:
 				limit = i
-				if _, ok := impl.(*maxAggregate); ok {
+				if _, ok := impl.(*parser.MaxAggregate); ok {
 					direction = encoding.Descending
 				}
 			default:
@@ -507,7 +490,7 @@ func (v *extractAggregatesVisitor) VisitPre(expr parser.Expr) (recurse bool, new
 		if len(t.Name.Indirect) > 0 {
 			break
 		}
-		if impl, ok := aggregates[strings.ToLower(string(t.Name.Base))]; ok {
+		if impl, ok := parser.Aggregates[strings.ToLower(string(t.Name.Base))]; ok {
 			if len(t.Exprs) != 1 {
 				// Type checking has already run on these expressions thus
 				// if an aggregate function of the wrong arity gets here,
@@ -522,12 +505,12 @@ func (v *extractAggregatesVisitor) VisitPre(expr parser.Expr) (recurse bool, new
 				return false, expr
 			}
 
-			f := &aggregateFunc{
+			f := &aggregateFuncHolder{
 				expr:    t,
 				arg:     t.Exprs[0].(parser.TypedExpr),
-				create:  impl,
+				create:  impl[0].AggregateFunc,
 				group:   v.n,
-				buckets: make(map[string]aggregateImpl),
+				buckets: make(map[string]parser.AggregateFunc),
 			}
 			if t.Type == parser.Distinct {
 				f.seen = make(map[string]struct{})
@@ -541,12 +524,12 @@ func (v *extractAggregatesVisitor) VisitPre(expr parser.Expr) (recurse bool, new
 				t.colRef.get().Name)
 			return true, expr
 		}
-		f := &aggregateFunc{
+		f := &aggregateFuncHolder{
 			expr:    t,
 			arg:     t,
-			create:  newIdentAggregate,
+			create:  parser.NewIdentAggregate,
 			group:   v.n,
-			buckets: make(map[string]aggregateImpl),
+			buckets: make(map[string]parser.AggregateFunc),
 		}
 		v.n.funcs = append(v.n.funcs, f)
 		return false, f
@@ -556,7 +539,7 @@ func (v *extractAggregatesVisitor) VisitPre(expr parser.Expr) (recurse bool, new
 
 func (*extractAggregatesVisitor) VisitPost(expr parser.Expr) parser.Expr { return expr }
 
-// Extract aggregateFuncs from exprs that use aggregation and check if they are valid.
+// Extract aggregateFuncHolders from exprs that use aggregation and check if they are valid.
 // An expression is valid if:
 // - it is an aggregate expression, or
 // - it appears verbatim in groupBy, or
@@ -592,7 +575,7 @@ type isAggregateVisitor struct {
 func (v *isAggregateVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr parser.Expr) {
 	switch t := expr.(type) {
 	case *parser.FuncExpr:
-		if _, ok := aggregates[strings.ToLower(string(t.Name.Base))]; ok {
+		if _, ok := parser.Aggregates[strings.ToLower(string(t.Name.Base))]; ok {
 			v.aggregated = true
 			return false, expr
 		}
@@ -635,19 +618,19 @@ func (p *planner) isAggregate(n *parser.SelectClause) bool {
 	return false
 }
 
-var _ parser.TypedExpr = &aggregateFunc{}
-var _ parser.VariableExpr = &aggregateFunc{}
+var _ parser.TypedExpr = &aggregateFuncHolder{}
+var _ parser.VariableExpr = &aggregateFuncHolder{}
 
-type aggregateFunc struct {
+type aggregateFuncHolder struct {
 	expr    parser.TypedExpr
 	arg     parser.TypedExpr
-	create  func() aggregateImpl
+	create  func() parser.AggregateFunc
 	group   *groupNode
-	buckets map[string]aggregateImpl
+	buckets map[string]parser.AggregateFunc
 	seen    map[string]struct{}
 }
 
-func (a *aggregateFunc) add(bucket []byte, d parser.Datum) error {
+func (a *aggregateFuncHolder) add(bucket []byte, d parser.Datum) error {
 	// NB: the compiler *should* optimize `myMap[string(myBytes)]`. See:
 	// https://github.com/golang/go/commit/f5f5a8b6209f84961687d993b93ea0d397f5d5bf
 
@@ -669,23 +652,23 @@ func (a *aggregateFunc) add(bucket []byte, d parser.Datum) error {
 		a.buckets[string(bucket)] = impl
 	}
 
-	return impl.add(d)
+	return impl.Add(d)
 }
 
-func (*aggregateFunc) Variable() {}
+func (*aggregateFuncHolder) Variable() {}
 
-func (a *aggregateFunc) Format(buf *bytes.Buffer, f parser.FmtFlags) {
+func (a *aggregateFuncHolder) Format(buf *bytes.Buffer, f parser.FmtFlags) {
 	a.expr.Format(buf, f)
 }
-func (a *aggregateFunc) String() string { return parser.AsString(a) }
+func (a *aggregateFuncHolder) String() string { return parser.AsString(a) }
 
-func (a *aggregateFunc) Walk(v parser.Visitor) parser.Expr { return a }
+func (a *aggregateFuncHolder) Walk(v parser.Visitor) parser.Expr { return a }
 
-func (a *aggregateFunc) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.TypedExpr, error) {
+func (a *aggregateFuncHolder) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.TypedExpr, error) {
 	return a, nil
 }
 
-func (a *aggregateFunc) Eval(ctx *parser.EvalContext) (parser.Datum, error) {
+func (a *aggregateFuncHolder) Eval(ctx *parser.EvalContext) (parser.Datum, error) {
 	// During init of the group buckets, grouped expressions (i.e. wrapped
 	// qvalues) are Eval()'ed to determine the bucket for a row, so pass these
 	// calls through to the underlying `arg` expr Eval until init is done.
@@ -698,7 +681,7 @@ func (a *aggregateFunc) Eval(ctx *parser.EvalContext) (parser.Datum, error) {
 		found = a.create()
 	}
 
-	datum, err := found.result()
+	datum, err := found.Result()
 	if err != nil {
 		return nil, err
 	}
@@ -707,449 +690,6 @@ func (a *aggregateFunc) Eval(ctx *parser.EvalContext) (parser.Datum, error) {
 	return datum.Eval(ctx)
 }
 
-func (a *aggregateFunc) ReturnType() parser.Datum {
+func (a *aggregateFuncHolder) ReturnType() parser.Datum {
 	return a.expr.ReturnType()
-}
-
-type aggregateImpl interface {
-	add(parser.Datum) error
-	result() (parser.Datum, error)
-}
-
-var _ aggregateImpl = &avgAggregate{}
-var _ aggregateImpl = &countAggregate{}
-var _ aggregateImpl = &maxAggregate{}
-var _ aggregateImpl = &minAggregate{}
-var _ aggregateImpl = &sumAggregate{}
-var _ aggregateImpl = &stddevAggregate{}
-var _ aggregateImpl = &varianceAggregate{}
-var _ aggregateImpl = &floatVarianceAggregate{}
-var _ aggregateImpl = &decimalVarianceAggregate{}
-var _ aggregateImpl = &identAggregate{}
-
-// In order to render the unaggregated (i.e. grouped) fields, during aggregation,
-// the values for those fields have to be stored for each bucket.
-// The `identAggregate` provides an "aggregate" function that actually
-// just returns the last value passed to `add`, unchanged. For accumulating
-// and rendering though it behaves like the other aggregate functions,
-// allowing both those steps to avoid special-casing grouped vs aggregated fields.
-type identAggregate struct {
-	val parser.Datum
-}
-
-func newIdentAggregate() aggregateImpl {
-	return &identAggregate{}
-}
-
-func (a *identAggregate) add(datum parser.Datum) error {
-	a.val = datum
-	return nil
-}
-
-func (a *identAggregate) result() (parser.Datum, error) {
-	return a.val, nil
-}
-
-type avgAggregate struct {
-	sumAggregate
-	count int
-}
-
-func newAvgAggregate() aggregateImpl {
-	return &avgAggregate{}
-}
-
-func (a *avgAggregate) add(datum parser.Datum) error {
-	if datum == parser.DNull {
-		return nil
-	}
-	if err := a.sumAggregate.add(datum); err != nil {
-		return err
-	}
-	a.count++
-	return nil
-}
-
-func (a *avgAggregate) result() (parser.Datum, error) {
-	sum, err := a.sumAggregate.result()
-	if err != nil {
-		return nil, err
-	}
-	if sum == parser.DNull {
-		return sum, nil
-	}
-	switch t := sum.(type) {
-	case *parser.DFloat:
-		return parser.NewDFloat(*t / parser.DFloat(a.count)), nil
-	case *parser.DDecimal:
-		count := inf.NewDec(int64(a.count), 0)
-		t.QuoRound(&t.Dec, count, decimal.Precision, inf.RoundHalfUp)
-		return t, nil
-	default:
-		return nil, util.Errorf("unexpected SUM result type: %s", t.Type())
-	}
-}
-
-type boolAndAggregate struct {
-	sawNonNull bool
-	sawFalse   bool
-}
-
-func newBoolAndAggregate() aggregateImpl {
-	return &boolAndAggregate{}
-}
-
-func (a *boolAndAggregate) add(datum parser.Datum) error {
-	if datum == parser.DNull {
-		return nil
-	}
-	a.sawNonNull = true
-	switch t := datum.(type) {
-	case *parser.DBool:
-		if !a.sawFalse {
-			a.sawFalse = !bool(*t)
-		}
-		return nil
-	default:
-		return util.Errorf("unexpected BOOL_AND argument type: %s", t.Type())
-	}
-}
-
-func (a *boolAndAggregate) result() (parser.Datum, error) {
-	if !a.sawNonNull {
-		return parser.DNull, nil
-	}
-	return parser.MakeDBool(parser.DBool(!a.sawFalse)), nil
-}
-
-type boolOrAggregate struct {
-	sawNonNull bool
-	sawTrue    bool
-}
-
-func newBoolOrAggregate() aggregateImpl {
-	return &boolOrAggregate{}
-}
-
-func (a *boolOrAggregate) add(datum parser.Datum) error {
-	if datum == parser.DNull {
-		return nil
-	}
-	a.sawNonNull = true
-	switch t := datum.(type) {
-	case *parser.DBool:
-		if !a.sawTrue {
-			a.sawTrue = bool(*t)
-		}
-		return nil
-	default:
-		return util.Errorf("unexpected BOOL_OR argument type: %s", t.Type())
-	}
-}
-
-func (a *boolOrAggregate) result() (parser.Datum, error) {
-	if !a.sawNonNull {
-		return parser.DNull, nil
-	}
-	return parser.MakeDBool(parser.DBool(a.sawTrue)), nil
-}
-
-type countAggregate struct {
-	count int
-}
-
-func newCountAggregate() aggregateImpl {
-	return &countAggregate{}
-}
-
-func (a *countAggregate) add(datum parser.Datum) error {
-	if datum == parser.DNull {
-		return nil
-	}
-	switch t := datum.(type) {
-	case *parser.DTuple:
-		for _, d := range *t {
-			if d != parser.DNull {
-				a.count++
-				break
-			}
-		}
-	default:
-		a.count++
-	}
-	return nil
-}
-
-func (a *countAggregate) result() (parser.Datum, error) {
-	return parser.NewDInt(parser.DInt(a.count)), nil
-}
-
-type maxAggregate struct {
-	max parser.Datum
-}
-
-func newMaxAggregate() aggregateImpl {
-	return &maxAggregate{}
-}
-
-func (a *maxAggregate) add(datum parser.Datum) error {
-	if datum == parser.DNull {
-		return nil
-	}
-	if a.max == nil {
-		a.max = datum
-		return nil
-	}
-	c := a.max.Compare(datum)
-	if c < 0 {
-		a.max = datum
-	}
-	return nil
-}
-
-func (a *maxAggregate) result() (parser.Datum, error) {
-	if a.max == nil {
-		return parser.DNull, nil
-	}
-	return a.max, nil
-}
-
-type minAggregate struct {
-	min parser.Datum
-}
-
-func newMinAggregate() aggregateImpl {
-	return &minAggregate{}
-}
-
-func (a *minAggregate) add(datum parser.Datum) error {
-	if datum == parser.DNull {
-		return nil
-	}
-	if a.min == nil {
-		a.min = datum
-		return nil
-	}
-	c := a.min.Compare(datum)
-	if c > 0 {
-		a.min = datum
-	}
-	return nil
-}
-
-func (a *minAggregate) result() (parser.Datum, error) {
-	if a.min == nil {
-		return parser.DNull, nil
-	}
-	return a.min, nil
-}
-
-type sumAggregate struct {
-	sumType  parser.Datum
-	sumFloat parser.DFloat
-	sumDec   inf.Dec
-	tmpDec   inf.Dec
-}
-
-func newSumAggregate() aggregateImpl {
-	return &sumAggregate{}
-}
-
-func (a *sumAggregate) add(datum parser.Datum) error {
-	if datum == parser.DNull {
-		return nil
-	}
-	switch t := datum.(type) {
-	case *parser.DFloat:
-		a.sumFloat += *t
-	case *parser.DInt:
-		a.tmpDec.SetUnscaled(int64(*t))
-		a.sumDec.Add(&a.sumDec, &a.tmpDec)
-	case *parser.DDecimal:
-		a.sumDec.Add(&a.sumDec, &t.Dec)
-	default:
-		return util.Errorf("unexpected SUM argument type: %s", datum.Type())
-	}
-	if a.sumType == nil {
-		a.sumType = datum
-	}
-	return nil
-}
-
-func (a *sumAggregate) result() (parser.Datum, error) {
-	if a.sumType == nil {
-		return parser.DNull, nil
-	}
-	switch {
-	case a.sumType.TypeEqual(parser.TypeFloat):
-		return parser.NewDFloat(a.sumFloat), nil
-	case a.sumType.TypeEqual(parser.TypeInt), a.sumType.TypeEqual(parser.TypeDecimal):
-		dd := &parser.DDecimal{}
-		dd.Set(&a.sumDec)
-		return dd, nil
-	default:
-		panic("unreachable")
-	}
-}
-
-type varianceAggregate struct {
-	typedAggregate aggregateImpl
-	// Used for passing int64s as *inf.Dec values.
-	tmpDec parser.DDecimal
-}
-
-func newVarianceAggregate() aggregateImpl {
-	return &varianceAggregate{}
-}
-
-func (a *varianceAggregate) add(datum parser.Datum) error {
-	if datum == parser.DNull {
-		return nil
-	}
-
-	const unexpectedErrFormat = "unexpected VARIANCE argument type: %s"
-	switch t := datum.(type) {
-	case *parser.DFloat:
-		if a.typedAggregate == nil {
-			a.typedAggregate = newFloatVarianceAggregate()
-		} else {
-			switch a.typedAggregate.(type) {
-			case *floatVarianceAggregate:
-			default:
-				return util.Errorf(unexpectedErrFormat, datum.Type())
-			}
-		}
-		return a.typedAggregate.add(t)
-	case *parser.DInt:
-		if a.typedAggregate == nil {
-			a.typedAggregate = newDecimalVarianceAggregate()
-		} else {
-			switch a.typedAggregate.(type) {
-			case *decimalVarianceAggregate:
-			default:
-				return util.Errorf(unexpectedErrFormat, datum.Type())
-			}
-		}
-		a.tmpDec.SetUnscaled(int64(*t))
-		return a.typedAggregate.add(&a.tmpDec)
-	case *parser.DDecimal:
-		if a.typedAggregate == nil {
-			a.typedAggregate = newDecimalVarianceAggregate()
-		} else {
-			switch a.typedAggregate.(type) {
-			case *decimalVarianceAggregate:
-			default:
-				return util.Errorf(unexpectedErrFormat, datum.Type())
-			}
-		}
-		return a.typedAggregate.add(t)
-	default:
-		return util.Errorf(unexpectedErrFormat, datum.Type())
-	}
-}
-
-func (a *varianceAggregate) result() (parser.Datum, error) {
-	if a.typedAggregate == nil {
-		return parser.DNull, nil
-	}
-	return a.typedAggregate.result()
-}
-
-type floatVarianceAggregate struct {
-	count   int
-	mean    float64
-	sqrDiff float64
-}
-
-func newFloatVarianceAggregate() aggregateImpl {
-	return &floatVarianceAggregate{}
-}
-
-func (a *floatVarianceAggregate) add(datum parser.Datum) error {
-	f := float64(*datum.(*parser.DFloat))
-
-	// Uses the Knuth/Welford method for accurately computing variance online in a
-	// single pass. See http://www.johndcook.com/blog/standard_deviation/ and
-	// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm.
-	a.count++
-	delta := f - a.mean
-	a.mean += delta / float64(a.count)
-	a.sqrDiff += delta * (f - a.mean)
-	return nil
-}
-
-func (a *floatVarianceAggregate) result() (parser.Datum, error) {
-	if a.count < 2 {
-		return parser.DNull, nil
-	}
-	return parser.NewDFloat(parser.DFloat(a.sqrDiff / (float64(a.count) - 1))), nil
-}
-
-type decimalVarianceAggregate struct {
-	// Variables used across iterations.
-	count   inf.Dec
-	mean    inf.Dec
-	sqrDiff inf.Dec
-
-	// Variables used as scratch space within iterations.
-	delta inf.Dec
-	tmp   inf.Dec
-}
-
-func newDecimalVarianceAggregate() aggregateImpl {
-	return &decimalVarianceAggregate{}
-}
-
-// Read-only constants used for compuation.
-var (
-	decimalOne = inf.NewDec(1, 0)
-	decimalTwo = inf.NewDec(2, 0)
-)
-
-func (a *decimalVarianceAggregate) add(datum parser.Datum) error {
-	d := datum.(*parser.DDecimal).Dec
-
-	// Uses the Knuth/Welford method for accurately computing variance online in a
-	// single pass. See http://www.johndcook.com/blog/standard_deviation/ and
-	// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm.
-	a.count.Add(&a.count, decimalOne)
-	a.delta.Sub(&d, &a.mean)
-	a.tmp.QuoRound(&a.delta, &a.count, decimal.Precision, inf.RoundHalfUp)
-	a.mean.Add(&a.mean, &a.tmp)
-	a.tmp.Sub(&d, &a.mean)
-	a.sqrDiff.Add(&a.sqrDiff, a.delta.Mul(&a.delta, &a.tmp))
-	return nil
-}
-
-func (a *decimalVarianceAggregate) result() (parser.Datum, error) {
-	if a.count.Cmp(decimalTwo) < 0 {
-		return parser.DNull, nil
-	}
-	a.tmp.Sub(&a.count, decimalOne)
-	dd := &parser.DDecimal{}
-	dd.QuoRound(&a.sqrDiff, &a.tmp, decimal.Precision, inf.RoundHalfUp)
-	return dd, nil
-}
-
-type stddevAggregate struct {
-	varianceAggregate
-}
-
-func newStddevAggregate() aggregateImpl {
-	return &stddevAggregate{varianceAggregate: *newVarianceAggregate().(*varianceAggregate)}
-}
-
-func (a *stddevAggregate) result() (parser.Datum, error) {
-	variance, err := a.varianceAggregate.result()
-	if err != nil || variance == parser.DNull {
-		return variance, err
-	}
-	switch t := variance.(type) {
-	case *parser.DFloat:
-		return parser.NewDFloat(parser.DFloat(math.Sqrt(float64(*t)))), nil
-	case *parser.DDecimal:
-		decimal.Sqrt(&t.Dec, &t.Dec, decimal.Precision)
-		return t, nil
-	}
-	return nil, util.Errorf("unexpected variance result type: %s", variance.Type())
 }

--- a/sql/group_test.go
+++ b/sql/group_test.go
@@ -20,11 +20,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/sql/parser"
-	"github.com/cockroachdb/cockroach/util/decimal"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/leaktest"
-	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
 func TestDesiredAggregateOrder(t *testing.T) {
@@ -60,127 +57,4 @@ func TestDesiredAggregateOrder(t *testing.T) {
 			t.Fatalf("%s: expected %v, but found %v", d.expr, d.ordering, ordering)
 		}
 	}
-}
-
-func makeIntTestDatum(count int) []parser.Datum {
-	rng, _ := randutil.NewPseudoRand()
-
-	vals := make([]parser.Datum, count)
-	for i := range vals {
-		vals[i] = parser.NewDInt(parser.DInt(rng.Int63()))
-	}
-	return vals
-}
-
-func makeFloatTestDatum(count int) []parser.Datum {
-	rng, _ := randutil.NewPseudoRand()
-
-	vals := make([]parser.Datum, count)
-	for i := range vals {
-		vals[i] = parser.NewDFloat(parser.DFloat(rng.Float64()))
-	}
-	return vals
-}
-
-func makeDecimalTestDatum(count int) []parser.Datum {
-	rng, _ := randutil.NewPseudoRand()
-
-	vals := make([]parser.Datum, count)
-	for i := range vals {
-		dd := &parser.DDecimal{}
-		decimal.SetFromFloat(&dd.Dec, rng.Float64())
-		vals[i] = dd
-	}
-	return vals
-}
-
-func runBenchmarkAggregate(b *testing.B, aggFunc func() aggregateImpl, vals []parser.Datum) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		aggImpl := aggFunc()
-		for i := range vals {
-			if err := aggImpl.add(vals[i]); err != nil {
-				b.Errorf("adding value to aggregate implementation %T failed: %v", aggImpl, err)
-			}
-		}
-		if _, err := aggImpl.result(); err != nil {
-			b.Errorf("taking result of aggregate implementation %T failed: %v", aggImpl, err)
-		}
-	}
-}
-
-func BenchmarkAvgAggregateInt1K(b *testing.B) {
-	runBenchmarkAggregate(b, newAvgAggregate, makeIntTestDatum(1000))
-}
-
-func BenchmarkAvgAggregateFloat1K(b *testing.B) {
-	runBenchmarkAggregate(b, newAvgAggregate, makeFloatTestDatum(1000))
-}
-
-func BenchmarkAvgAggregateDecimal1K(b *testing.B) {
-	runBenchmarkAggregate(b, newAvgAggregate, makeDecimalTestDatum(1000))
-}
-
-func BenchmarkCountAggregate1K(b *testing.B) {
-	runBenchmarkAggregate(b, newCountAggregate, makeIntTestDatum(1000))
-}
-
-func BenchmarkSumAggregateInt1K(b *testing.B) {
-	runBenchmarkAggregate(b, newSumAggregate, makeIntTestDatum(1000))
-}
-
-func BenchmarkSumAggregateFloat1K(b *testing.B) {
-	runBenchmarkAggregate(b, newSumAggregate, makeFloatTestDatum(1000))
-}
-
-func BenchmarkSumAggregateDecimal1K(b *testing.B) {
-	runBenchmarkAggregate(b, newSumAggregate, makeDecimalTestDatum(1000))
-}
-
-func BenchmarkMaxAggregateInt1K(b *testing.B) {
-	runBenchmarkAggregate(b, newMaxAggregate, makeIntTestDatum(1000))
-}
-
-func BenchmarkMaxAggregateFloat1K(b *testing.B) {
-	runBenchmarkAggregate(b, newMaxAggregate, makeFloatTestDatum(1000))
-}
-
-func BenchmarkMaxAggregateDecimal1K(b *testing.B) {
-	runBenchmarkAggregate(b, newMaxAggregate, makeDecimalTestDatum(1000))
-}
-
-func BenchmarkMinAggregateInt1K(b *testing.B) {
-	runBenchmarkAggregate(b, newMinAggregate, makeIntTestDatum(1000))
-}
-
-func BenchmarkMinAggregateFloat1K(b *testing.B) {
-	runBenchmarkAggregate(b, newMinAggregate, makeFloatTestDatum(1000))
-}
-
-func BenchmarkMinAggregateDecimal1K(b *testing.B) {
-	runBenchmarkAggregate(b, newMinAggregate, makeDecimalTestDatum(1000))
-}
-
-func BenchmarkVarianceAggregateInt1K(b *testing.B) {
-	runBenchmarkAggregate(b, newVarianceAggregate, makeIntTestDatum(1000))
-}
-
-func BenchmarkVarianceAggregateFloat1K(b *testing.B) {
-	runBenchmarkAggregate(b, newVarianceAggregate, makeFloatTestDatum(1000))
-}
-
-func BenchmarkVarianceAggregateDecimal1K(b *testing.B) {
-	runBenchmarkAggregate(b, newVarianceAggregate, makeDecimalTestDatum(1000))
-}
-
-func BenchmarkStddevAggregateInt1K(b *testing.B) {
-	runBenchmarkAggregate(b, newStddevAggregate, makeIntTestDatum(1000))
-}
-
-func BenchmarkStddevAggregateFloat1K(b *testing.B) {
-	runBenchmarkAggregate(b, newStddevAggregate, makeFloatTestDatum(1000))
-}
-
-func BenchmarkStddevAggregateDecimal1K(b *testing.B) {
-	runBenchmarkAggregate(b, newStddevAggregate, makeDecimalTestDatum(1000))
 }

--- a/sql/parser/aggregate_builtins.go
+++ b/sql/parser/aggregate_builtins.go
@@ -1,0 +1,567 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package parser
+
+import (
+	"math"
+	"strings"
+
+	"gopkg.in/inf.v0"
+
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/decimal"
+)
+
+func init() {
+	for k, v := range Aggregates {
+		for i := range v {
+			v[i].impure = true
+		}
+		Aggregates[strings.ToUpper(k)] = v
+	}
+}
+
+// AggregateFunc accumulates the result of a some function of a Datum.
+type AggregateFunc interface {
+	Add(Datum) error
+	Result() (Datum, error)
+}
+
+// Aggregates are a special class of builtin functions that are wrapped
+// at execution in a bucketing layer to combine (aggregate) the result
+// of the function being run over many rows.
+// See `aggregateFuncHolder` in the sql
+// In particular they must not be simplified during normalization
+// (and thus must be marked as impure), even when they are given a
+// constant argument (e.g. SUM(1)). This is because aggregate
+// functions must return NULL when they are no rows in the source
+// table, so their evaluation must always be delayed until query
+// execution.
+var Aggregates = map[string][]Builtin{
+	"avg": {
+		makeAggBuiltin(TypeInt, TypeDecimal, newAvgAggregate),
+		makeAggBuiltin(TypeFloat, TypeFloat, newAvgAggregate),
+		makeAggBuiltin(TypeDecimal, TypeDecimal, newAvgAggregate),
+	},
+
+	"bool_and": {
+		makeAggBuiltin(TypeBool, TypeBool, newBoolAndAggregate),
+	},
+
+	"bool_or": {
+		makeAggBuiltin(TypeBool, TypeBool, newBoolOrAggregate),
+	},
+
+	"count": countImpls(),
+
+	"max": makeAggBuiltins(newMaxAggregate, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeBytes, TypeDate, TypeTimestamp, TypeInterval),
+	"min": makeAggBuiltins(newMinAggregate, TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeBytes, TypeDate, TypeTimestamp, TypeInterval),
+
+	"sum": {
+		makeAggBuiltin(TypeInt, TypeDecimal, newSumAggregate),
+		makeAggBuiltin(TypeFloat, TypeFloat, newSumAggregate),
+		makeAggBuiltin(TypeDecimal, TypeDecimal, newSumAggregate),
+	},
+
+	"variance": {
+		makeAggBuiltin(TypeInt, TypeDecimal, newVarianceAggregate),
+		makeAggBuiltin(TypeDecimal, TypeDecimal, newVarianceAggregate),
+		makeAggBuiltin(TypeFloat, TypeFloat, newVarianceAggregate),
+	},
+
+	"stddev": {
+		makeAggBuiltin(TypeInt, TypeDecimal, newStddevAggregate),
+		makeAggBuiltin(TypeDecimal, TypeDecimal, newStddevAggregate),
+		makeAggBuiltin(TypeFloat, TypeFloat, newStddevAggregate),
+	},
+}
+
+func makeAggBuiltin(in, ret Datum, f func() AggregateFunc) Builtin {
+	return Builtin{
+		// See the comment about aggregate functions in the definitions
+		// of the Builtins array above.
+		impure:        true,
+		Types:         ArgTypes{in},
+		ReturnType:    ret,
+		AggregateFunc: f,
+	}
+}
+func makeAggBuiltins(f func() AggregateFunc, types ...Datum) []Builtin {
+	ret := make([]Builtin, len(types))
+	for i := range types {
+		ret[i] = makeAggBuiltin(types[i], types[i], f)
+	}
+	return ret
+}
+
+func countImpls() []Builtin {
+	types := ArgTypes{TypeBool, TypeInt, TypeFloat, TypeDecimal, TypeString, TypeBytes, TypeDate, TypeTimestamp, TypeInterval, TypeTuple}
+	r := make([]Builtin, len(types))
+	for i := range types {
+		r[i] = makeAggBuiltin(types[i], TypeInt, newCountAggregate)
+	}
+	return r
+}
+
+var _ AggregateFunc = &avgAggregate{}
+var _ AggregateFunc = &countAggregate{}
+var _ AggregateFunc = &MaxAggregate{}
+var _ AggregateFunc = &MinAggregate{}
+var _ AggregateFunc = &sumAggregate{}
+var _ AggregateFunc = &stddevAggregate{}
+var _ AggregateFunc = &varianceAggregate{}
+var _ AggregateFunc = &floatVarianceAggregate{}
+var _ AggregateFunc = &decimalVarianceAggregate{}
+var _ AggregateFunc = &identAggregate{}
+
+// In order to render the unaggregated (i.e. grouped) fields, during aggregation,
+// the values for those fields have to be stored for each bucket.
+// The `identAggregate` provides an "aggregate" function that actually
+// just returns the last value passed to `add`, unchanged. For accumulating
+// and rendering though it behaves like the other aggregate functions,
+// allowing both those steps to avoid special-casing grouped vs aggregated fields.
+type identAggregate struct {
+	val Datum
+}
+
+// NewIdentAggregate returns an identAggregate (see comment on struct).
+func NewIdentAggregate() AggregateFunc {
+	return &identAggregate{}
+}
+
+// Add sets the value to the passed datum.
+func (a *identAggregate) Add(datum Datum) error {
+	a.val = datum
+	return nil
+}
+
+// Result returns the value most recently passed to Add.
+func (a *identAggregate) Result() (Datum, error) {
+	return a.val, nil
+}
+
+type avgAggregate struct {
+	sumAggregate
+	count int
+}
+
+func newAvgAggregate() AggregateFunc {
+	return &avgAggregate{}
+}
+
+// Add accumulates the passed datum into the average.
+func (a *avgAggregate) Add(datum Datum) error {
+	if datum == DNull {
+		return nil
+	}
+	if err := a.sumAggregate.Add(datum); err != nil {
+		return err
+	}
+	a.count++
+	return nil
+}
+
+// Result returns the average of all datums passed to Add.
+func (a *avgAggregate) Result() (Datum, error) {
+	sum, err := a.sumAggregate.Result()
+	if err != nil {
+		return nil, err
+	}
+	if sum == DNull {
+		return sum, nil
+	}
+	switch t := sum.(type) {
+	case *DFloat:
+		return NewDFloat(*t / DFloat(a.count)), nil
+	case *DDecimal:
+		count := inf.NewDec(int64(a.count), 0)
+		t.QuoRound(&t.Dec, count, decimal.Precision, inf.RoundHalfUp)
+		return t, nil
+	default:
+		return nil, util.Errorf("unexpected SUM result type: %s", t.Type())
+	}
+}
+
+type boolAndAggregate struct {
+	sawNonNull bool
+	sawFalse   bool
+}
+
+func newBoolAndAggregate() AggregateFunc {
+	return &boolAndAggregate{}
+}
+
+func (a *boolAndAggregate) Add(datum Datum) error {
+	if datum == DNull {
+		return nil
+	}
+	a.sawNonNull = true
+	switch t := datum.(type) {
+	case *DBool:
+		if !a.sawFalse {
+			a.sawFalse = !bool(*t)
+		}
+		return nil
+	default:
+		return util.Errorf("unexpected BOOL_AND argument type: %s", t.Type())
+	}
+}
+
+func (a *boolAndAggregate) Result() (Datum, error) {
+	if !a.sawNonNull {
+		return DNull, nil
+	}
+	return MakeDBool(DBool(!a.sawFalse)), nil
+}
+
+type boolOrAggregate struct {
+	sawNonNull bool
+	sawTrue    bool
+}
+
+func newBoolOrAggregate() AggregateFunc {
+	return &boolOrAggregate{}
+}
+
+func (a *boolOrAggregate) Add(datum Datum) error {
+	if datum == DNull {
+		return nil
+	}
+	a.sawNonNull = true
+	switch t := datum.(type) {
+	case *DBool:
+		if !a.sawTrue {
+			a.sawTrue = bool(*t)
+		}
+		return nil
+	default:
+		return util.Errorf("unexpected BOOL_OR argument type: %s", t.Type())
+	}
+}
+
+func (a *boolOrAggregate) Result() (Datum, error) {
+	if !a.sawNonNull {
+		return DNull, nil
+	}
+	return MakeDBool(DBool(a.sawTrue)), nil
+}
+
+type countAggregate struct {
+	count int
+}
+
+func newCountAggregate() AggregateFunc {
+	return &countAggregate{}
+}
+
+func (a *countAggregate) Add(datum Datum) error {
+	if datum == DNull {
+		return nil
+	}
+	switch t := datum.(type) {
+	case *DTuple:
+		for _, d := range *t {
+			if d != DNull {
+				a.count++
+				break
+			}
+		}
+	default:
+		a.count++
+	}
+	return nil
+}
+
+func (a *countAggregate) Result() (Datum, error) {
+	return NewDInt(DInt(a.count)), nil
+}
+
+// MaxAggregate keeps track of the largest value passed to Add.
+type MaxAggregate struct {
+	max Datum
+}
+
+func newMaxAggregate() AggregateFunc {
+	return &MaxAggregate{}
+}
+
+// Add sets the max to the larger of the current max or the passed datum.
+func (a *MaxAggregate) Add(datum Datum) error {
+	if datum == DNull {
+		return nil
+	}
+	if a.max == nil {
+		a.max = datum
+		return nil
+	}
+	c := a.max.Compare(datum)
+	if c < 0 {
+		a.max = datum
+	}
+	return nil
+}
+
+// Result returns the largest value passed to Add.
+func (a *MaxAggregate) Result() (Datum, error) {
+	if a.max == nil {
+		return DNull, nil
+	}
+	return a.max, nil
+}
+
+// MinAggregate keeps track of the smallest value passed to Add.
+type MinAggregate struct {
+	min Datum
+}
+
+func newMinAggregate() AggregateFunc {
+	return &MinAggregate{}
+}
+
+// Add sets the min to the smaller of the current min or the passed datum.
+func (a *MinAggregate) Add(datum Datum) error {
+	if datum == DNull {
+		return nil
+	}
+	if a.min == nil {
+		a.min = datum
+		return nil
+	}
+	c := a.min.Compare(datum)
+	if c > 0 {
+		a.min = datum
+	}
+	return nil
+}
+
+// Result returns the smallest value passed to Add.
+func (a *MinAggregate) Result() (Datum, error) {
+	if a.min == nil {
+		return DNull, nil
+	}
+	return a.min, nil
+}
+
+type sumAggregate struct {
+	sumType  Datum
+	sumFloat DFloat
+	sumDec   inf.Dec
+	tmpDec   inf.Dec
+}
+
+func newSumAggregate() AggregateFunc {
+	return &sumAggregate{}
+}
+
+// Add adds the value of the passed datum to the sum.
+func (a *sumAggregate) Add(datum Datum) error {
+	if datum == DNull {
+		return nil
+	}
+	switch t := datum.(type) {
+	case *DFloat:
+		a.sumFloat += *t
+	case *DInt:
+		a.tmpDec.SetUnscaled(int64(*t))
+		a.sumDec.Add(&a.sumDec, &a.tmpDec)
+	case *DDecimal:
+		a.sumDec.Add(&a.sumDec, &t.Dec)
+	default:
+		return util.Errorf("unexpected SUM argument type: %s", datum.Type())
+	}
+	if a.sumType == nil {
+		a.sumType = datum
+	}
+	return nil
+}
+
+// Result returns the sum.
+func (a *sumAggregate) Result() (Datum, error) {
+	if a.sumType == nil {
+		return DNull, nil
+	}
+	switch {
+	case a.sumType.TypeEqual(TypeFloat):
+		return NewDFloat(a.sumFloat), nil
+	case a.sumType.TypeEqual(TypeInt), a.sumType.TypeEqual(TypeDecimal):
+		dd := &DDecimal{}
+		dd.Set(&a.sumDec)
+		return dd, nil
+	default:
+		panic("unreachable")
+	}
+}
+
+type varianceAggregate struct {
+	typedAggregate AggregateFunc
+	// Used for passing int64s as *inf.Dec values.
+	tmpDec DDecimal
+}
+
+func newVarianceAggregate() AggregateFunc {
+	return &varianceAggregate{}
+}
+
+func (a *varianceAggregate) Add(datum Datum) error {
+	if datum == DNull {
+		return nil
+	}
+
+	const unexpectedErrFormat = "unexpected VARIANCE argument type: %s"
+	switch t := datum.(type) {
+	case *DFloat:
+		if a.typedAggregate == nil {
+			a.typedAggregate = newFloatVarianceAggregate()
+		} else {
+			switch a.typedAggregate.(type) {
+			case *floatVarianceAggregate:
+			default:
+				return util.Errorf(unexpectedErrFormat, datum.Type())
+			}
+		}
+		return a.typedAggregate.Add(t)
+	case *DInt:
+		if a.typedAggregate == nil {
+			a.typedAggregate = newDecimalVarianceAggregate()
+		} else {
+			switch a.typedAggregate.(type) {
+			case *decimalVarianceAggregate:
+			default:
+				return util.Errorf(unexpectedErrFormat, datum.Type())
+			}
+		}
+		a.tmpDec.SetUnscaled(int64(*t))
+		return a.typedAggregate.Add(&a.tmpDec)
+	case *DDecimal:
+		if a.typedAggregate == nil {
+			a.typedAggregate = newDecimalVarianceAggregate()
+		} else {
+			switch a.typedAggregate.(type) {
+			case *decimalVarianceAggregate:
+			default:
+				return util.Errorf(unexpectedErrFormat, datum.Type())
+			}
+		}
+		return a.typedAggregate.Add(t)
+	default:
+		return util.Errorf(unexpectedErrFormat, datum.Type())
+	}
+}
+
+func (a *varianceAggregate) Result() (Datum, error) {
+	if a.typedAggregate == nil {
+		return DNull, nil
+	}
+	return a.typedAggregate.Result()
+}
+
+type floatVarianceAggregate struct {
+	count   int
+	mean    float64
+	sqrDiff float64
+}
+
+func newFloatVarianceAggregate() AggregateFunc {
+	return &floatVarianceAggregate{}
+}
+
+func (a *floatVarianceAggregate) Add(datum Datum) error {
+	f := float64(*datum.(*DFloat))
+
+	// Uses the Knuth/Welford method for accurately computing variance online in a
+	// single pass. See http://www.johndcook.com/blog/standard_deviation/ and
+	// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm.
+	a.count++
+	delta := f - a.mean
+	a.mean += delta / float64(a.count)
+	a.sqrDiff += delta * (f - a.mean)
+	return nil
+}
+
+func (a *floatVarianceAggregate) Result() (Datum, error) {
+	if a.count < 2 {
+		return DNull, nil
+	}
+	return NewDFloat(DFloat(a.sqrDiff / (float64(a.count) - 1))), nil
+}
+
+type decimalVarianceAggregate struct {
+	// Variables used across iterations.
+	count   inf.Dec
+	mean    inf.Dec
+	sqrDiff inf.Dec
+
+	// Variables used as scratch space within iterations.
+	delta inf.Dec
+	tmp   inf.Dec
+}
+
+func newDecimalVarianceAggregate() AggregateFunc {
+	return &decimalVarianceAggregate{}
+}
+
+// Read-only constants used for compuation.
+var (
+	decimalOne = inf.NewDec(1, 0)
+	decimalTwo = inf.NewDec(2, 0)
+)
+
+func (a *decimalVarianceAggregate) Add(datum Datum) error {
+	d := datum.(*DDecimal).Dec
+
+	// Uses the Knuth/Welford method for accurately computing variance online in a
+	// single pass. See http://www.johndcook.com/blog/standard_deviation/ and
+	// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm.
+	a.count.Add(&a.count, decimalOne)
+	a.delta.Sub(&d, &a.mean)
+	a.tmp.QuoRound(&a.delta, &a.count, decimal.Precision, inf.RoundHalfUp)
+	a.mean.Add(&a.mean, &a.tmp)
+	a.tmp.Sub(&d, &a.mean)
+	a.sqrDiff.Add(&a.sqrDiff, a.delta.Mul(&a.delta, &a.tmp))
+	return nil
+}
+
+func (a *decimalVarianceAggregate) Result() (Datum, error) {
+	if a.count.Cmp(decimalTwo) < 0 {
+		return DNull, nil
+	}
+	a.tmp.Sub(&a.count, decimalOne)
+	dd := &DDecimal{}
+	dd.QuoRound(&a.sqrDiff, &a.tmp, decimal.Precision, inf.RoundHalfUp)
+	return dd, nil
+}
+
+type stddevAggregate struct {
+	varianceAggregate
+}
+
+func newStddevAggregate() AggregateFunc {
+	return &stddevAggregate{varianceAggregate: *newVarianceAggregate().(*varianceAggregate)}
+}
+
+func (a *stddevAggregate) Result() (Datum, error) {
+	variance, err := a.varianceAggregate.Result()
+	if err != nil || variance == DNull {
+		return variance, err
+	}
+	switch t := variance.(type) {
+	case *DFloat:
+		return NewDFloat(DFloat(math.Sqrt(float64(*t)))), nil
+	case *DDecimal:
+		decimal.Sqrt(&t.Dec, &t.Dec, decimal.Precision)
+		return t, nil
+	}
+	return nil, util.Errorf("unexpected variance result type: %s", variance.Type())
+}

--- a/sql/parser/aggregate_builtins_test.go
+++ b/sql/parser/aggregate_builtins_test.go
@@ -1,0 +1,145 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util/decimal"
+	"github.com/cockroachdb/cockroach/util/randutil"
+)
+
+func makeIntTestDatum(count int) []Datum {
+	rng, _ := randutil.NewPseudoRand()
+
+	vals := make([]Datum, count)
+	for i := range vals {
+		vals[i] = NewDInt(DInt(rng.Int63()))
+	}
+	return vals
+}
+
+func makeFloatTestDatum(count int) []Datum {
+	rng, _ := randutil.NewPseudoRand()
+
+	vals := make([]Datum, count)
+	for i := range vals {
+		vals[i] = NewDFloat(DFloat(rng.Float64()))
+	}
+	return vals
+}
+
+func makeDecimalTestDatum(count int) []Datum {
+	rng, _ := randutil.NewPseudoRand()
+
+	vals := make([]Datum, count)
+	for i := range vals {
+		dd := &DDecimal{}
+		decimal.SetFromFloat(&dd.Dec, rng.Float64())
+		vals[i] = dd
+	}
+	return vals
+}
+
+func runBenchmarkAggregate(b *testing.B, aggFunc func() AggregateFunc, vals []Datum) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		aggImpl := aggFunc()
+		for i := range vals {
+			if err := aggImpl.Add(vals[i]); err != nil {
+				b.Errorf("adding value to aggregate implementation %T failed: %v", aggImpl, err)
+			}
+		}
+		if _, err := aggImpl.Result(); err != nil {
+			b.Errorf("taking result of aggregate implementation %T failed: %v", aggImpl, err)
+		}
+	}
+}
+
+func BenchmarkAvgAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newAvgAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkAvgAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newAvgAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkAvgAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newAvgAggregate, makeDecimalTestDatum(1000))
+}
+
+func BenchmarkCountAggregate1K(b *testing.B) {
+	runBenchmarkAggregate(b, newCountAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkSumAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newSumAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkSumAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newSumAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkSumAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newSumAggregate, makeDecimalTestDatum(1000))
+}
+
+func BenchmarkMaxAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMaxAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkMaxAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMaxAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkMaxAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMaxAggregate, makeDecimalTestDatum(1000))
+}
+
+func BenchmarkMinAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMinAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkMinAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMinAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkMinAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newMinAggregate, makeDecimalTestDatum(1000))
+}
+
+func BenchmarkVarianceAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newVarianceAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkVarianceAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newVarianceAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkVarianceAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newVarianceAggregate, makeDecimalTestDatum(1000))
+}
+
+func BenchmarkStddevAggregateInt1K(b *testing.B) {
+	runBenchmarkAggregate(b, newStddevAggregate, makeIntTestDatum(1000))
+}
+
+func BenchmarkStddevAggregateFloat1K(b *testing.B) {
+	runBenchmarkAggregate(b, newStddevAggregate, makeFloatTestDatum(1000))
+}
+
+func BenchmarkStddevAggregateDecimal1K(b *testing.B) {
+	runBenchmarkAggregate(b, newStddevAggregate, makeDecimalTestDatum(1000))
+}

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -299,10 +299,17 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired Datum) (TypedExpr, err
 	// upper/lower case names.
 	candidates, ok := Builtins[name]
 	if !ok {
-		candidates, ok = Builtins[strings.ToLower(name)]
+		candidates, ok = Aggregates[name]
+	}
+	if !ok {
+		lowerName := strings.ToLower(name)
+		candidates, ok = Builtins[lowerName]
 		if !ok {
-			return nil, fmt.Errorf("unknown function: %s", name)
+			candidates, ok = Aggregates[lowerName]
 		}
+	}
+	if !ok {
+		return nil, fmt.Errorf("unknown function: %s", name)
 	}
 
 	overloads := make([]overloadImpl, len(candidates))


### PR DESCRIPTION
[playing with an idea @knz and I talked about, just wanted concrete code and PR mechanics to discuss]

The various aggregate func implementations (like sum or count) were in sql/group before but all other builtin functions that just operate on datums were in sql/parser/builtins. This also meant that the mapping
of function names to function info was split between two maps (one in Builtins and the other, used by
the agg visitors, in sql/group) containing the same keys (though this wasn't checked anywhere).

This moves the individual built-in agg funcs to builtins with the other aggfuncs, and removes the duplicate
declaration of function-name-to-info by removing them from Builtins and extending FuncExpr's typecheck
to also search the map of Aggregates, which is shared between function resolution and the aggregate visitors.

Note that the higher-level logic for actually doing aggregation (handling rows, bucketing, plans, ordering, etc) all still stays in sql/group.go -- this is only moving the simpler functions that operate on an individual datum, akin to the other builtin functions.

A followup change will also move the isAggregate visitor from the planner to the parser, since it doesn't actually need anything about the planner, and the visitors could use the `Agg` function pointer in the FuncExpr rather than going back to the map at all.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7116)

<!-- Reviewable:end -->
