### PR TITLE
sqlbase: allow FamilyFormatVersion in tabledesc validate

### DIFF
--- a/sql/sqlbase/structured.go
+++ b/sql/sqlbase/structured.go
@@ -537,10 +537,13 @@ func (desc *TableDescriptor) Validate() error {
 		return fmt.Errorf("invalid parent ID %d", desc.ParentID)
 	}
 
-	if desc.GetFormatVersion() != BaseFormatVersion {
+	// TODO(dan): Once a beta with this check is released, update the reference
+	// tests with it as the new bidirectional compatibility version. Then remove
+	// support here for BaseFormatVersion.
+	if v := desc.GetFormatVersion(); v != BaseFormatVersion && v != FamilyFormatVersion {
 		return fmt.Errorf(
-			"table %q is encoded using using version %d, but this client only supports version %d",
-			desc.Name, desc.GetFormatVersion(), BaseFormatVersion)
+			"table %q is encoded using using version %d, but this client only supports version %d and %d",
+			desc.Name, desc.GetFormatVersion(), BaseFormatVersion, FamilyFormatVersion)
 	}
 
 	if len(desc.Columns) == 0 {

--- a/sql/sqlbase/structured_test.go
+++ b/sql/sqlbase/structured_test.go
@@ -135,7 +135,7 @@ func TestValidateTableDesc(t *testing.T) {
 			TableDescriptor{ID: 0, Name: "foo"}},
 		{`invalid parent ID 0`,
 			TableDescriptor{ID: 2, Name: "foo"}},
-		{`table "foo" is encoded using using version 0, but this client only supports version 1`,
+		{`table "foo" is encoded using using version 0, but this client only supports version 1 and 2`,
 			TableDescriptor{ID: 2, ParentID: 1, Name: "foo"}},
 		{`table must contain at least 1 column`,
 			TableDescriptor{


### PR DESCRIPTION
The beta containing this commit will start the range of versions that are
bidirectionally compatible with the full implementation of column families
(module tables that use the feature). Every commit before this will be
forward-only compatible.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7119)

<!-- Reviewable:end -->
