### PR TITLE
Ensure EXPLAIN(TYPES) can show types for placeholders and non-normalized expressions.

### DIFF
--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -1202,6 +1202,11 @@ type EvalContext struct {
 	// TODO(mjibson): remove prepareOnly in favor of a 2-step prepare-exec solution
 	// that is also able to save the plan to skip work during the exec step.
 	PrepareOnly bool
+
+	// SkipNormalize indicates whether expressions should be normalized
+	// (false) or not (true).  It is set to true conditionally by
+	// EXPLAIN(TYPES[, NORMALIZE]).
+	SkipNormalize bool
 }
 
 // GetStmtTimestamp retrieves the current statement timestamp as per

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -120,6 +120,9 @@ func TypeCheckAndRequire(expr Expr, ctx *SemaContext, required Datum, op string)
 // NormalizeExpr is wrapper around ctx.NormalizeExpr which avoids allocation of
 // a normalizeVisitor.
 func (p *Parser) NormalizeExpr(ctx *EvalContext, typedExpr TypedExpr) (TypedExpr, error) {
+	if ctx.SkipNormalize {
+		return typedExpr, nil
+	}
 	p.normalizeVisitor = normalizeVisitor{ctx: ctx}
 	expr, _ := WalkExpr(&p.normalizeVisitor, typedExpr)
 	if err := p.normalizeVisitor.err; err != nil {

--- a/sql/testdata/explain_types
+++ b/sql/testdata/explain_types
@@ -228,3 +228,27 @@ EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10
 1   render/filter   render 0   (x)[int]
 1   render/filter   render 1   (y)[int]
 2   scan            result     (x int, y int, rowid int)
+
+query ITTT
+EXPLAIN (TYPES) SELECT $1 + 2 AS a
+----
+0      select          result     (a int)
+1      render/filter   result     (a int)
+1      render/filter   render 0   (($1)[int] + (2)[int])[int]
+2      empty           result     ()
+
+query ITTT
+EXPLAIN (TYPES) SELECT ABS(2-3) AS a
+----
+0      select          result     (a int)
+1      render/filter   result     (a int)
+1      render/filter   render 0   (ABS((-1)[int]))[int]
+2      empty           result     ()
+
+query ITTT
+EXPLAIN (TYPES, NORMALIZE) SELECT ABS(2-3) AS a
+----
+0      select          result     (a int)
+1      render/filter   result     (a int)
+1      render/filter   render 0   (1)[int]
+2      empty           result     ()


### PR DESCRIPTION
This introduces the EXPLAIN option `NONORMALIZE` to skip normalization if so wished.

Requested by @nvanbenschoten :)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7120)

<!-- Reviewable:end -->
