### PR TITLE
sql: write backward-comptatible data using colfamilies

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -507,9 +507,9 @@ func DecodeTablePrefix(key roachpb.Key) ([]byte, uint64, error) {
 	return encoding.DecodeUvarintAscending(key)
 }
 
-// MakeFamilyKey returns the key for the family in the given row.
-func MakeFamilyKey(rowKey []byte, famID uint32) []byte {
-	key := append([]byte(nil), rowKey...)
+// MakeFamilyKey returns the key for the family in the given row by appending to
+// the passed key.
+func MakeFamilyKey(key []byte, famID uint32) []byte {
 	if famID == 0 {
 		return encoding.EncodeUvarintAscending(key, 0)
 	}

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -507,11 +507,14 @@ func DecodeTablePrefix(key roachpb.Key) ([]byte, uint64, error) {
 	return encoding.DecodeUvarintAscending(key)
 }
 
-// MakeColumnKey returns the key for the column in the given row.
-func MakeColumnKey(rowKey []byte, colID uint32) []byte {
+// MakeFamilyKey returns the key for the family in the given row.
+func MakeFamilyKey(rowKey []byte, famID uint32) []byte {
 	key := append([]byte(nil), rowKey...)
+	if famID == 0 {
+		return encoding.EncodeUvarintAscending(key, 0)
+	}
 	size := len(key)
-	key = encoding.EncodeUvarintAscending(key, uint64(colID))
+	key = encoding.EncodeUvarintAscending(key, uint64(famID))
 	// Note that we assume that `len(key)-size` will always be encoded to a
 	// single byte by EncodeUvarint. This is currently always true because the
 	// varint encoding will encode 1-9 bytes.
@@ -520,6 +523,8 @@ func MakeColumnKey(rowKey []byte, colID uint32) []byte {
 
 // MakeNonColumnKey creates a non-column key for a row by appending a 0 column
 // ID suffix size to rowKey.
+// TODO(dan): Delete this in favor of MakeFamilyKey(0) once the allocation
+// differences are addressed.
 func MakeNonColumnKey(rowKey []byte) []byte {
 	return encoding.EncodeUvarintAscending(rowKey, 0)
 }

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -434,9 +434,9 @@ func TestBatchError(t *testing.T) {
 	}
 }
 
-func TestMakeColumnKey(t *testing.T) {
-	const maxColID = math.MaxUint32
-	key := MakeColumnKey(nil, maxColID)
+func TestMakeFamilyKey(t *testing.T) {
+	const maxFamID = math.MaxUint32
+	key := MakeFamilyKey(nil, maxFamID)
 	if expected, n := 6, len(key); expected != n {
 		t.Errorf("expected %d bytes, but got %d: [% x]", expected, n, []byte(key))
 	}

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -276,8 +276,11 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		}
 		// TODO(dan): Tighten up the bound on the requestedCols parameter to
 		// makeRowUpdater.
+		requestedCols := make([]sqlbase.ColumnDescriptor, 0, len(tableDesc.Columns)+len(added))
+		requestedCols = append(requestedCols, tableDesc.Columns...)
+		requestedCols = append(requestedCols, added...)
 		ru, err := makeRowUpdater(
-			txn, tableDesc, fkTables, updateCols, tableDesc.Columns, rowUpdaterOnlyColumns,
+			txn, tableDesc, fkTables, updateCols, requestedCols, rowUpdaterOnlyColumns,
 		)
 		if err != nil {
 			return err
@@ -312,6 +315,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		}
 
 		indexKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc.ID, tableDesc.PrimaryIndex.ID)
+		oldValues := make(parser.DTuple, len(ru.fetchCols))
 		updateValues := make(parser.DTuple, len(updateCols))
 
 		writeBatch := &client.Batch{}
@@ -345,7 +349,11 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 				updateValues[i+len(added)] = parser.DNull
 			}
 
-			if _, err := ru.updateRow(writeBatch, row, updateValues); err != nil {
+			copy(oldValues, row)
+			for j := len(row); j < len(oldValues); j++ {
+				oldValues[j] = parser.DNull
+			}
+			if _, err := ru.updateRow(writeBatch, oldValues, updateValues); err != nil {
 				return err
 			}
 		}

--- a/sql/rowwriter.go
+++ b/sql/rowwriter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -113,9 +114,10 @@ type rowInserter struct {
 	fks                   fkInsertHelper
 
 	// For allocation avoidance.
-	marshalled    []roachpb.Value
-	key           roachpb.Key
-	sentinelValue roachpb.Value
+	marshalled []roachpb.Value
+	key        roachpb.Key
+	valueBuf   []byte
+	value      roachpb.Value
 }
 
 // makeRowInserter creates a rowInserter for the given table.
@@ -209,42 +211,86 @@ func (ri *rowInserter) insertRow(b *client.Batch, values []parser.Datum, ignoreC
 	if err != nil {
 		return err
 	}
-	// Write the row sentinel. We want to write the sentinel first in case
-	// we are trying to insert a duplicate primary key: if we write the
-	// secondary indexes first, we may get an error that looks like a
-	// uniqueness violation on a non-unique index.
-	ri.key = keys.MakeNonColumnKey(primaryIndexKey)
-	// Each sentinel value needs a distinct RawBytes field as the computed
-	// checksum includes the key the value is associated with.
-	ri.sentinelValue.SetBytes([]byte{})
-	putFn(b, &ri.key, &ri.sentinelValue, &ri.sentinelValue)
-	ri.key = nil
+
+	// Add the new values.
+	// TODO(dan): This has gotten very similar to the loop in updateRow, see if
+	// they can be DRY'd. Ideally, this would also work for
+	// truncateAndBackfillColumnsChunk, which is currently abusing rowUdpdater.
+	for _, family := range ri.helper.tableDesc.Families {
+		if len(family.ColumnIDs) == 1 && family.ColumnIDs[0] == family.DefaultColumnID {
+			// Storage optimization to store DefaultColumnID directly as a value. Also
+			// backwards compatible with the original BaseFormatVersion.
+			if family.ID == 0 {
+				// TODO(dan): Delete this once column families can be created that are
+				// not backward compatible with the old format.
+				return util.Errorf("family is not backward compatible: %v", family)
+			}
+
+			idx, ok := ri.insertColIDtoRowIndex[family.DefaultColumnID]
+			if !ok {
+				continue
+			}
+
+			if ri.marshalled[idx].RawBytes != nil {
+				// We only output non-NULL values. Non-existent column keys are
+				// considered NULL during scanning and the row sentinel ensures we know
+				// the row exists.
+
+				ri.key = keys.MakeFamilyKey(primaryIndexKey, uint32(family.ID))
+				putFn(b, &ri.key, &ri.marshalled[idx], values[idx])
+				ri.key = nil
+			}
+
+			continue
+		}
+
+		ri.key = keys.MakeFamilyKey(primaryIndexKey, uint32(family.ID))
+		ri.valueBuf = ri.valueBuf[:0]
+
+		for _, colID := range family.ColumnIDs {
+			if ri.helper.columnInPK(colID) {
+				if family.ID != 0 {
+					return util.Errorf("primary index column %d must be in family 0, was %d", colID, family.ID)
+				}
+				// Skip primary key columns as their values are encoded in the key of
+				// each family. Family 0 is guaranteed to exist and acts as a sentinel.
+				continue
+			}
+
+			idx, ok := ri.insertColIDtoRowIndex[colID]
+			if !ok {
+				// Column not being inserted.
+				continue
+			}
+			col := ri.insertCols[idx]
+
+			if values[idx].Compare(parser.DNull) == 0 {
+				continue
+			}
+
+			ri.valueBuf = encoding.EncodeNonsortingVarint(ri.valueBuf, int64(col.ID))
+			ri.valueBuf, err = sqlbase.EncodeTableValue(ri.valueBuf, values[idx])
+			if err != nil {
+				return err
+			}
+		}
+
+		if family.ID == 0 || len(ri.valueBuf) > 0 {
+			// TODO(dan): Delete this check once column families can be created that
+			// are not backward compatible with the old format.
+			if family.ID == 0 && len(ri.valueBuf) > 0 {
+				return util.Errorf("family is not backward compatible: %v", family)
+			}
+			ri.value.SetTuple(ri.valueBuf)
+			putFn(b, &ri.key, &ri.value, &ri.value)
+		}
+
+		ri.key = nil
+	}
 
 	for i := range secondaryIndexEntries {
 		e := &secondaryIndexEntries[i]
 		putFn(b, &e.Key, &e.Value, &e.Value)
-	}
-
-	// Write the row columns.
-	for i, val := range values {
-		col := ri.insertCols[i]
-
-		if ri.helper.columnInPK(col.ID) {
-			// Skip primary key columns as their values are encoded in the row
-			// sentinel key which is guaranteed to exist for as long as the row
-			// exists.
-			continue
-		}
-
-		if ri.marshalled[i].RawBytes != nil {
-			// We only output non-NULL values. Non-existent column keys are
-			// considered NULL during scanning and the row sentinel ensures we know
-			// the row exists.
-
-			ri.key = keys.MakeColumnKey(primaryIndexKey, uint32(col.ID))
-			putFn(b, &ri.key, &ri.marshalled[i], val)
-			ri.key = nil
-		}
 	}
 
 	return nil
@@ -252,12 +298,13 @@ func (ri *rowInserter) insertRow(b *client.Batch, values []parser.Datum, ignoreC
 
 // rowUpdater abstracts the key/value operations for updating table rows.
 type rowUpdater struct {
-	helper               rowHelper
-	fetchCols            []sqlbase.ColumnDescriptor
-	fetchColIDtoRowIndex map[sqlbase.ColumnID]int
-	updateCols           []sqlbase.ColumnDescriptor
-	deleteOnlyIndex      map[int]struct{}
-	primaryKeyColChange  bool
+	helper                rowHelper
+	fetchCols             []sqlbase.ColumnDescriptor
+	fetchColIDtoRowIndex  map[sqlbase.ColumnID]int
+	updateCols            []sqlbase.ColumnDescriptor
+	updateColIDtoRowIndex map[sqlbase.ColumnID]int
+	deleteOnlyIndex       map[int]struct{}
+	primaryKeyColChange   bool
 
 	rd rowDeleter
 	ri rowInserter
@@ -269,6 +316,8 @@ type rowUpdater struct {
 	newValues       []parser.Datum
 	key             roachpb.Key
 	indexEntriesBuf []sqlbase.IndexEntry
+	valueBuf        []byte
+	value           roachpb.Value
 }
 
 type rowUpdaterType int
@@ -355,12 +404,13 @@ func makeRowUpdater(
 	}
 
 	ru := rowUpdater{
-		helper:              rowHelper{tableDesc: tableDesc, indexes: indexes},
-		updateCols:          updateCols,
-		deleteOnlyIndex:     deleteOnlyIndex,
-		primaryKeyColChange: primaryKeyColChange,
-		marshalled:          make([]roachpb.Value, len(updateCols)),
-		newValues:           make([]parser.Datum, len(tableDesc.Columns)+len(tableDesc.Mutations)),
+		helper:                rowHelper{tableDesc: tableDesc, indexes: indexes},
+		updateCols:            updateCols,
+		updateColIDtoRowIndex: updateColIDtoRowIndex,
+		deleteOnlyIndex:       deleteOnlyIndex,
+		primaryKeyColChange:   primaryKeyColChange,
+		marshalled:            make([]roachpb.Value, len(updateCols)),
+		newValues:             make([]parser.Datum, len(tableDesc.Columns)+len(tableDesc.Mutations)),
 	}
 
 	if primaryKeyColChange {
@@ -457,10 +507,10 @@ func (ru *rowUpdater) updateRow(
 		ru.newValues[ru.fetchColIDtoRowIndex[updateCol.ID]] = updateValues[i]
 	}
 
-	newPrimaryIndexKey := primaryIndexKey
 	rowPrimaryKeyChanged := false
 	var newSecondaryIndexEntries []sqlbase.IndexEntry
 	if ru.primaryKeyColChange {
+		var newPrimaryIndexKey []byte
 		newPrimaryIndexKey, newSecondaryIndexEntries, err =
 			ru.helper.encodeIndexes(ru.fetchColIDtoRowIndex, ru.newValues)
 		if err != nil {
@@ -475,35 +525,18 @@ func (ru *rowUpdater) updateRow(
 		}
 	}
 
-	// Update secondary indexes.
-	for i, newSecondaryIndexEntry := range newSecondaryIndexEntries {
-		secondaryIndexEntry := secondaryIndexEntries[i]
-		secondaryKeyChanged := !bytes.Equal(newSecondaryIndexEntry.Key, secondaryIndexEntry.Key)
-		if secondaryKeyChanged {
-			if err := ru.fks.checkIdx(ru.helper.indexes[i].ID, oldValues, ru.newValues); err != nil {
-				return nil, err
-			}
-
-			if !rowPrimaryKeyChanged {
-				if log.V(2) {
-					log.Infof("Del %s", secondaryIndexEntry.Key)
-				}
-				b.Del(secondaryIndexEntry.Key)
-				// Do not update Indexes in the DELETE_ONLY state.
-				if _, ok := ru.deleteOnlyIndex[i]; !ok {
-					if log.V(2) {
-						log.Infof("CPut %s -> %v", newSecondaryIndexEntry.Key, newSecondaryIndexEntry.Value)
-					}
-					b.CPut(newSecondaryIndexEntry.Key, &newSecondaryIndexEntry.Value, nil)
-				}
-			}
-		}
-	}
-
 	if rowPrimaryKeyChanged {
 		if err := ru.fks.checkIdx(ru.helper.tableDesc.PrimaryIndex.ID, oldValues, ru.newValues); err != nil {
 			return nil, err
 		}
+		for i := range newSecondaryIndexEntries {
+			if !bytes.Equal(newSecondaryIndexEntries[i].Key, secondaryIndexEntries[i].Key) {
+				if err := ru.fks.checkIdx(ru.helper.indexes[i].ID, oldValues, ru.newValues); err != nil {
+					return nil, err
+				}
+			}
+		}
+
 		if err := ru.rd.deleteRow(b, oldValues); err != nil {
 			return nil, err
 		}
@@ -514,36 +547,120 @@ func (ru *rowUpdater) updateRow(
 	}
 
 	// Add the new values.
-	for i, val := range updateValues {
-		col := ru.updateCols[i]
-
-		if ru.helper.columnInPK(col.ID) {
-			// Skip primary key columns as their values are encoded in the row
-			// sentinel key which is guaranteed to exist for as long as the row
-			// exists.
+	// TODO(dan): This has gotten very similar to the loop in insertRow, see if
+	// they can be DRY'd. Ideally, this would also work for
+	// truncateAndBackfillColumnsChunk, which is currently abusing rowUdpdater.
+	for _, family := range ru.helper.tableDesc.Families {
+		update := false
+		for _, colID := range family.ColumnIDs {
+			if _, ok := ru.updateColIDtoRowIndex[colID]; ok {
+				update = true
+				break
+			}
+		}
+		if !update {
 			continue
 		}
 
-		ru.key = keys.MakeColumnKey(newPrimaryIndexKey, uint32(col.ID))
-		if ru.marshalled[i].RawBytes != nil {
-			// We only output non-NULL values. Non-existent column keys are
-			// considered NULL during scanning and the row sentinel ensures we know
-			// the row exists.
-			if log.V(2) {
-				log.Infof("Put %s -> %v", ru.key, val)
+		if len(family.ColumnIDs) == 1 && family.ColumnIDs[0] == family.DefaultColumnID {
+			// Storage optimization to store DefaultColumnID directly as a value. Also
+			// backwards compatible with the original BaseFormatVersion.
+			if family.ID == 0 {
+				// TODO(dan): Delete this once column families can be created that are
+				// not backward compatible with the old format.
+				return nil, util.Errorf("family is not backward compatible: %v", family)
 			}
 
-			b.Put(&ru.key, &ru.marshalled[i])
-		} else {
-			// The column might have already existed but is being set to NULL, so
-			// delete it.
+			idx, ok := ru.updateColIDtoRowIndex[family.DefaultColumnID]
+			if !ok {
+				continue
+			}
+
+			ru.key = keys.MakeFamilyKey(primaryIndexKey, uint32(family.ID))
+			if log.V(2) {
+				log.Infof("Put %s -> %v", ru.key, updateValues[idx])
+			}
+			b.Put(&ru.key, &ru.marshalled[idx])
+			ru.key = nil
+
+			continue
+		}
+
+		ru.key = keys.MakeFamilyKey(primaryIndexKey, uint32(family.ID))
+		ru.valueBuf = ru.valueBuf[:0]
+
+		for _, colID := range family.ColumnIDs {
+			if ru.helper.columnInPK(colID) {
+				if family.ID != 0 {
+					return nil, util.Errorf("primary index column %d must be in family 0, was %d", colID, family.ID)
+				}
+				// Skip primary key columns as their values are encoded in the key of
+				// each family. Family 0 is guaranteed to exist and acts as a sentinel.
+				continue
+			}
+
+			idx, ok := ru.fetchColIDtoRowIndex[colID]
+			if !ok {
+				return nil, util.Errorf("column %d was expected to be fetched, but wasn't", colID)
+			}
+			col := ru.fetchCols[idx]
+
+			if ru.newValues[idx].Compare(parser.DNull) == 0 {
+				continue
+			}
+
+			ru.valueBuf = encoding.EncodeNonsortingVarint(ru.valueBuf, int64(col.ID))
+			ru.valueBuf, err = sqlbase.EncodeTableValue(ru.valueBuf, ru.newValues[idx])
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if family.ID != 0 && len(ru.valueBuf) == 0 {
+			// The family might have already existed but every column in it is being
+			// set to NULL, so delete it.
 			if log.V(2) {
 				log.Infof("Del %s", ru.key)
 			}
 
 			b.Del(&ru.key)
+		} else {
+			// TODO(dan): Delete this check once column families can be created that
+			// are not backward compatible with the old format.
+			if family.ID == 0 && len(ru.valueBuf) > 0 {
+				return nil, util.Errorf("family is not backward compatible: %v", family)
+			}
+			ru.value.SetTuple(ru.valueBuf)
+			if log.V(2) {
+				log.Infof("Put %s -> %v", ru.key, &ru.value)
+			}
+			b.Put(&ru.key, &ru.value)
 		}
+
 		ru.key = nil
+	}
+
+	// Update secondary indexes.
+	for i, newSecondaryIndexEntry := range newSecondaryIndexEntries {
+		secondaryIndexEntry := secondaryIndexEntries[i]
+		secondaryKeyChanged := !bytes.Equal(newSecondaryIndexEntry.Key, secondaryIndexEntry.Key)
+		if secondaryKeyChanged {
+			if err := ru.fks.checkIdx(ru.helper.indexes[i].ID, oldValues, ru.newValues); err != nil {
+				return nil, err
+			}
+
+			if log.V(2) {
+				log.Infof("Del %s", secondaryIndexEntry.Key)
+			}
+			b.Del(secondaryIndexEntry.Key)
+			// Do not update Indexes in the DELETE_ONLY state.
+			if _, ok := ru.deleteOnlyIndex[i]; !ok {
+				if log.V(2) {
+					log.Infof("CPut %s -> %v", newSecondaryIndexEntry.Key, newSecondaryIndexEntry.Value)
+				}
+				b.CPut(newSecondaryIndexEntry.Key, &newSecondaryIndexEntry.Value, nil)
+			}
+		}
 	}
 
 	return ru.newValues, nil

--- a/sql/sqlbase/keys.go
+++ b/sql/sqlbase/keys.go
@@ -88,7 +88,7 @@ func MakeNameMetadataKey(parentID ID, name string) roachpb.Key {
 	k = encoding.EncodeUvarintAscending(k, uint64(parentID))
 	if name != "" {
 		k = encoding.EncodeBytesAscending(k, []byte(name))
-		k = keys.MakeColumnKey(k, uint32(namespaceTable.Columns[2].ID))
+		k = keys.MakeFamilyKey(k, uint32(namespaceTable.Columns[2].ID))
 	}
 	return k
 }
@@ -98,7 +98,7 @@ func MakeDescMetadataKey(descID ID) roachpb.Key {
 	k := keys.MakeTablePrefix(uint32(DescriptorTable.ID))
 	k = encoding.EncodeUvarintAscending(k, uint64(DescriptorTable.PrimaryIndex.ID))
 	k = encoding.EncodeUvarintAscending(k, uint64(descID))
-	return keys.MakeColumnKey(k, uint32(DescriptorTable.Columns[1].ID))
+	return keys.MakeFamilyKey(k, uint32(DescriptorTable.Columns[1].ID))
 }
 
 // MakeZoneKey returns the key for 'id's entry in the system.zones table.
@@ -106,7 +106,7 @@ func MakeZoneKey(id ID) roachpb.Key {
 	k := keys.MakeTablePrefix(uint32(zonesTable.ID))
 	k = encoding.EncodeUvarintAscending(k, uint64(zonesTable.PrimaryIndex.ID))
 	k = encoding.EncodeUvarintAscending(k, uint64(id))
-	return keys.MakeColumnKey(k, uint32(zonesTable.Columns[1].ID))
+	return keys.MakeFamilyKey(k, uint32(zonesTable.Columns[1].ID))
 }
 
 // MakeIndexKeyPrefix returns the key prefix used for the index's data.

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -143,8 +143,8 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 	tableKey := keys.MakeTablePrefix(keys.MaxReservedDescID + 1)
 	rowKey := roachpb.Key(encoding.EncodeVarintAscending(append([]byte(nil), tableKey...), 1))
 	rowKey = encoding.EncodeStringAscending(encoding.EncodeVarintAscending(rowKey, 1), "a")
-	col1Key := keys.MakeColumnKey(append([]byte(nil), rowKey...), 1)
-	col2Key := keys.MakeColumnKey(append([]byte(nil), rowKey...), 2)
+	col1Key := keys.MakeFamilyKey(append([]byte(nil), rowKey...), 1)
+	col2Key := keys.MakeFamilyKey(append([]byte(nil), rowKey...), 2)
 
 	// We don't care about the value, so just store any old thing.
 	if err := store.DB().Put(col1Key, "column 1"); err != nil {


### PR DESCRIPTION
This commit replaces the column-based kv writing code with the family-based
version. No reading code is changed, but the tests and reading code are left
unchanged to verify backward compatibility of the new code and the way
MaybeUpgradeFormatVersion configures the ColumnFamilyDescriptors.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7122)

<!-- Reviewable:end -->
