### PR TITLE
storage: queue replicas for raft log truncation after write ops

### DIFF
--- a/storage/client_metrics_test.go
+++ b/storage/client_metrics_test.go
@@ -150,6 +150,11 @@ func TestStoreMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Disable the raft log truncation which confuses this test.
+	for _, s := range mtc.stores {
+		s.DisableRaftLogQueue(true)
+	}
+
 	// Perform a split, which has special metrics handling.
 	splitArgs := adminSplitArgs(roachpb.KeyMin, roachpb.Key("m"))
 	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &splitArgs); err != nil {

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -22,6 +22,8 @@
 package storage
 
 import (
+	"sync/atomic"
+
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
@@ -114,4 +116,14 @@ func (r *Replica) GetLastIndex() (uint64, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.LastIndex()
+}
+
+// SetDisabled turns replica scanning off or on as directed. Note that while
+// disabled, removals are still processed.
+func (rs *replicaScanner) SetDisabled(disabled bool) {
+	if disabled {
+		atomic.StoreInt32(&rs.disabled, 1)
+	} else {
+		atomic.StoreInt32(&rs.disabled, 0)
+	}
 }

--- a/storage/raft_log_queue_test.go
+++ b/storage/raft_log_queue_test.go
@@ -77,7 +77,7 @@ func TestGetTruncatableIndexes(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 	if _, err := store.GetReplica(0); err == nil {
-		t.Error("expected GetRange to fail on missing range")
+		t.Fatal("expected GetRange to fail on missing range")
 	}
 
 	store.DisableRaftLogQueue(true)
@@ -97,18 +97,18 @@ func TestGetTruncatableIndexes(t *testing.T) {
 
 	r, err := store.GetReplica(1)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	r.mu.Lock()
 	firstIndex, err := r.FirstIndex()
 	r.mu.Unlock()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// Write a few keys to the range.
-	for i := 0; i < 10; i++ {
+	for i := 0; i < RaftLogQueueStaleThreshold+1; i++ {
 		key := roachpb.Key(fmt.Sprintf("key%02d", i))
 		args := putArgs(key, []byte(fmt.Sprintf("value%02d", i)))
 		if _, err := client.SendWrapped(store.testSender(), nil, &args); err != nil {
@@ -164,4 +164,52 @@ func TestGetTruncatableIndexes(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestProactiveRaftLogTruncate verifies that we proactively truncate the raft
+// log even when replica scanning is disabled.
+func TestProactiveRaftLogTruncate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	store, _, stopper := createTestStore(t)
+	defer stopper.Stop()
+
+	store.scanner.SetDisabled(true)
+
+	r, err := store.GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r.mu.Lock()
+	oldFirstIndex, err := r.FirstIndex()
+	r.mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a few keys to the range. While writing these keys, the raft log
+	// should be proactively truncated even though replica scanning is disabled.
+	for i := 0; i < 2*RaftLogQueueStaleThreshold; i++ {
+		key := roachpb.Key(fmt.Sprintf("key%02d", i))
+		args := putArgs(key, []byte(fmt.Sprintf("value%02d", i)))
+		if _, err := client.SendWrapped(store.testSender(), nil, &args); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Wait for tasks to finish, in case the processLoop grabbed the event
+	// before ForceRaftLogScanAndProcess but is still working on it.
+	stopper.Quiesce()
+
+	r.mu.Lock()
+	newFirstIndex, err := r.FirstIndex()
+	r.mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if newFirstIndex <= oldFirstIndex {
+		t.Errorf("log was not correctly truncated, old first index:%d, current first index:%d",
+			oldFirstIndex, newFirstIndex)
+	}
 }

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1975,10 +1975,10 @@ func (r *Replica) applyRaftCommand(
 	}
 
 	// On successful write commands handle write-related triggers including
-	// splitting.
+	// splitting and raft log truncation.
 	if rErr == nil && ba.IsWrite() {
-		// If the commit succeeded, potentially add range to split queue.
 		r.maybeAddToSplitQueue()
+		r.maybeAddToRaftLogQueue(index)
 	}
 
 	// On the replica on which this command originated, resolve skipped intents
@@ -2588,6 +2588,15 @@ func (r *Replica) needsSplitBySize() bool {
 func (r *Replica) maybeAddToSplitQueue() {
 	if r.needsSplitBySize() {
 		r.store.splitQueue.MaybeAdd(r, r.store.Clock().Now())
+	}
+}
+
+// maybeAddToRaftLogQueue checks whether the raft log is a candidate for
+// truncation. If yes, the range is added to the raft log queue.
+func (r *Replica) maybeAddToRaftLogQueue(appliedIndex uint64) {
+	const raftLogCheckFrequency = 1 + RaftLogQueueStaleThreshold/4
+	if appliedIndex%raftLogCheckFrequency == 0 {
+		r.store.raftLogQueue.MaybeAdd(r, r.store.Clock().Now())
 	}
 }
 

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -865,6 +865,8 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 	tc.clock.SetMaxOffset(maxClockOffset)
+	// Disable raft log truncation which confuses this test.
+	tc.store.DisableRaftLogQueue(true)
 
 	// Modify range descriptor to include a second replica; leader lease can
 	// only be obtained by Replicas which are part of the range descriptor. This

--- a/storage/scanner.go
+++ b/storage/scanner.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -73,6 +74,8 @@ type replicaScanner struct {
 	completedScan *sync.Cond
 	count         int64
 	total         time.Duration
+	// Some tests in this package disable scanning.
+	disabled int32 // updated atomically
 }
 
 // newReplicaScanner creates a new replica scanner with the provided loop intervals,
@@ -164,6 +167,9 @@ func (rs *replicaScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stop
 			if repl == nil {
 				return false
 			}
+			if atomic.LoadInt32(&rs.disabled) == 1 {
+				return false
+			}
 
 			return !stopper.RunTask(func() {
 				// Try adding replica to all queues.
@@ -172,7 +178,8 @@ func (rs *replicaScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stop
 				}
 			})
 		case repl := <-rs.removed:
-			// Remove replica from all queues as applicable.
+			// Remove replica from all queues as applicable. Note that we still
+			// process removals while disabled.
 			for _, q := range rs.queues {
 				q.MaybeRemove(repl)
 			}


### PR DESCRIPTION
Fixes #6012.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7125)

<!-- Reviewable:end -->
