### PR TITLE
storage: cleanup queueImpl interface

### DIFF
--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -96,18 +96,12 @@ type gcQueue struct {
 // newGCQueue returns a new instance of gcQueue.
 func newGCQueue(gossip *gossip.Gossip) *gcQueue {
 	gcq := &gcQueue{}
-	gcq.baseQueue = makeBaseQueue("gc", gcq, gossip, gcQueueMaxSize)
+	gcq.baseQueue = makeBaseQueue("gc", gcq, gossip, queueConfig{
+		maxSize:              gcQueueMaxSize,
+		needsLeaderLease:     true,
+		acceptsUnsplitRanges: false,
+	})
 	return gcq
-}
-
-func (*gcQueue) needsLeaderLease() bool {
-	return true
-}
-
-// acceptsUnsplitRanges is false because the proper GC
-// policy cannot be determined for ranges that span zone configs.
-func (*gcQueue) acceptsUnsplitRanges() bool {
-	return false
 }
 
 type pushFunc func(roachpb.Timestamp, *roachpb.Transaction, roachpb.PushTxnType)

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -56,16 +56,12 @@ func newRaftLogQueue(db *client.DB, gossip *gossip.Gossip) *raftLogQueue {
 	rlq := &raftLogQueue{
 		db: db,
 	}
-	rlq.baseQueue = makeBaseQueue("raftlog", rlq, gossip, raftLogQueueMaxSize)
+	rlq.baseQueue = makeBaseQueue("raftlog", rlq, gossip, queueConfig{
+		maxSize:              raftLogQueueMaxSize,
+		needsLeaderLease:     false,
+		acceptsUnsplitRanges: true,
+	})
 	return rlq
-}
-
-func (*raftLogQueue) needsLeaderLease() bool {
-	return false
-}
-
-func (*raftLogQueue) acceptsUnsplitRanges() bool {
-	return true
 }
 
 // getTruncatableIndexes returns the total number of stale raft log entries that

--- a/storage/replica_consistency_queue.go
+++ b/storage/replica_consistency_queue.go
@@ -36,16 +36,12 @@ type replicaConsistencyQueue struct {
 // newReplicaConsistencyQueue returns a new instance of replicaConsistencyQueue.
 func newReplicaConsistencyQueue(gossip *gossip.Gossip) *replicaConsistencyQueue {
 	rcq := &replicaConsistencyQueue{}
-	rcq.baseQueue = makeBaseQueue("replica consistency checker", rcq, gossip, replicaConsistencyQueueSize)
+	rcq.baseQueue = makeBaseQueue("replica consistency checker", rcq, gossip, queueConfig{
+		maxSize:              replicaConsistencyQueueSize,
+		needsLeaderLease:     true,
+		acceptsUnsplitRanges: true,
+	})
 	return rcq
-}
-
-func (*replicaConsistencyQueue) needsLeaderLease() bool {
-	return true
-}
-
-func (*replicaConsistencyQueue) acceptsUnsplitRanges() bool {
-	return true
 }
 
 func (*replicaConsistencyQueue) shouldQueue(now roachpb.Timestamp, rng *Replica,

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -53,16 +53,12 @@ func newReplicaGCQueue(db *client.DB, gossip *gossip.Gossip) *replicaGCQueue {
 	q := &replicaGCQueue{
 		db: db,
 	}
-	q.baseQueue = makeBaseQueue("replicaGC", q, gossip, replicaGCQueueMaxSize)
+	q.baseQueue = makeBaseQueue("replicaGC", q, gossip, queueConfig{
+		maxSize:              replicaGCQueueMaxSize,
+		needsLeaderLease:     false,
+		acceptsUnsplitRanges: true,
+	})
 	return q
-}
-
-func (*replicaGCQueue) needsLeaderLease() bool {
-	return false
-}
-
-func (*replicaGCQueue) acceptsUnsplitRanges() bool {
-	return true
 }
 
 // shouldQueue determines whether a replica should be queued for GC,

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -48,16 +48,12 @@ func newSplitQueue(db *client.DB, gossip *gossip.Gossip) *splitQueue {
 	sq := &splitQueue{
 		db: db,
 	}
-	sq.baseQueue = makeBaseQueue("split", sq, gossip, splitQueueMaxSize)
+	sq.baseQueue = makeBaseQueue("split", sq, gossip, queueConfig{
+		maxSize:              splitQueueMaxSize,
+		needsLeaderLease:     true,
+		acceptsUnsplitRanges: true,
+	})
 	return sq
-}
-
-func (*splitQueue) needsLeaderLease() bool {
-	return true
-}
-
-func (*splitQueue) acceptsUnsplitRanges() bool {
-	return true
 }
 
 // shouldQueue determines whether a range should be queued for

--- a/storage/verify_queue.go
+++ b/storage/verify_queue.go
@@ -48,16 +48,12 @@ type verifyQueue struct {
 // newVerifyQueue returns a new instance of verifyQueue.
 func newVerifyQueue(gossip *gossip.Gossip, countFn rangeCountFn) *verifyQueue {
 	vq := &verifyQueue{countFn: countFn}
-	vq.baseQueue = makeBaseQueue("verify", vq, gossip, verifyQueueMaxSize)
+	vq.baseQueue = makeBaseQueue("verify", vq, gossip, queueConfig{
+		maxSize:              verifyQueueMaxSize,
+		needsLeaderLease:     false,
+		acceptsUnsplitRanges: true,
+	})
 	return vq
-}
-
-func (*verifyQueue) needsLeaderLease() bool {
-	return false
-}
-
-func (*verifyQueue) acceptsUnsplitRanges() bool {
-	return true
 }
 
 // shouldQueue determines whether a range should be queued for


### PR DESCRIPTION
Replace `queueImpl.{needsLeaderLease,acceptsUnsplitRanges}` with
configuration on the `baseQueue`. These methods were always returning
constants.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7129)

<!-- Reviewable:end -->
