### PR TITLE
sql: refactor FK helpers to use passed in tables

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -266,10 +266,16 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		}
 
 		updateCols := append(added, dropped...)
+		fkTables := TablesNeededForFKs(tableDesc, CheckUpdates)
+		for k := range fkTables {
+			if fkTables[k], err = getTableDescFromID(txn, k); err != nil {
+				return err
+			}
+		}
 		// TODO(dan): Tighten up the bound on the requestedCols parameter to
 		// makeRowUpdater.
 		ru, err := makeRowUpdater(
-			txn, tableDesc, updateCols, tableDesc.Columns, rowUpdaterOnlyColumns,
+			txn, tableDesc, fkTables, updateCols, tableDesc.Columns, rowUpdaterOnlyColumns,
 		)
 		if err != nil {
 			return err

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -57,7 +57,11 @@ func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoComm
 		requestedCols = en.tableDesc.Columns
 	}
 
-	rd, err := makeRowDeleter(p.txn, en.tableDesc, requestedCols, checkFKs)
+	fkTables := TablesNeededForFKs(en.tableDesc, CheckDeletes)
+	if err := p.fillFKTableMap(fkTables); err != nil {
+		return nil, err
+	}
+	rd, err := makeRowDeleter(p.txn, en.tableDesc, fkTables, requestedCols, checkFKs)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/tablewriter.go
+++ b/sql/tablewriter.go
@@ -208,6 +208,7 @@ type tableUpserter struct {
 	// Set by init.
 	txn                   *client.Txn
 	tableDesc             *sqlbase.TableDescriptor
+	fkTables              TablesByID // for fk checks in update case
 	ru                    rowUpdater
 	updateColIDtoRowIndex map[sqlbase.ColumnID]int
 	a                     sqlbase.DatumAlloc
@@ -261,7 +262,7 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 		tu.fetchColIDtoRowIndex = colIDtoRowIndexFromCols(requestedCols)
 	} else {
 		tu.ru, err = makeRowUpdater(
-			txn, tu.tableDesc, tu.updateCols, requestedCols, rowUpdaterDefault,
+			txn, tu.tableDesc, tu.fkTables, tu.updateCols, requestedCols, rowUpdaterDefault,
 		)
 		if err != nil {
 			return err

--- a/sql/update.go
+++ b/sql/update.go
@@ -163,7 +163,11 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 		requestedCols = en.tableDesc.Columns
 	}
 
-	ru, err := makeRowUpdater(p.txn, en.tableDesc, updateCols, requestedCols, rowUpdaterDefault)
+	fkTables := TablesNeededForFKs(en.tableDesc, CheckUpdates)
+	if err := p.fillFKTableMap(fkTables); err != nil {
+		return nil, err
+	}
+	ru, err := makeRowUpdater(p.txn, en.tableDesc, fkTables, updateCols, requestedCols, rowUpdaterDefault)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
FK check helpers were looking up their own table descriptors.
Looking up a tableDesc is a relatively high level SQL op:
it should go through the planner's lease cache, the lease
manager, etc.

The various rowwriter helpers where the FK checks are done
are however intended to be much lower level and usable by
distsql.

Precomputing the set of tables that will be needed, fetching
those descriptors and passing them in thus paves the way for
moving the helpers to a lower level package like sqlbase.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7130)

<!-- Reviewable:end -->
