### PR TITLE
sql/parser: Return errors on MakeFromLiteral failures in scanner

### DIFF
--- a/sql/parser/scan.go
+++ b/sql/parser/scan.go
@@ -548,7 +548,9 @@ func (s *scanner) scanNumber(lval *sqlSymType, ch int) {
 		lval.id = FCONST
 		floatConst := constant.MakeFromLiteral(lval.str, token.FLOAT, 0)
 		if floatConst.Kind() == constant.Unknown {
-			panic(fmt.Sprintf("could not make constant float from literal %q", lval.str))
+			lval.id = ERROR
+			lval.str = fmt.Sprintf("could not make constant float from literal %q", lval.str)
+			return
 		}
 		lval.union.val = &NumVal{Value: floatConst, OrigString: lval.str}
 	} else {
@@ -561,7 +563,9 @@ func (s *scanner) scanNumber(lval *sqlSymType, ch int) {
 		lval.id = ICONST
 		intConst := constant.MakeFromLiteral(lval.str, token.INT, 0)
 		if intConst.Kind() == constant.Unknown {
-			panic(fmt.Sprintf("could not make constant int from literal %q", lval.str))
+			lval.id = ERROR
+			lval.str = fmt.Sprintf("could not make constant int from literal %q", lval.str)
+			return
 		}
 		lval.union.val = &NumVal{Value: intConst, OrigString: lval.str}
 	}

--- a/sql/parser/scan_test.go
+++ b/sql/parser/scan_test.go
@@ -396,6 +396,7 @@ func TestScanError(t *testing.T) {
 		{`1.0x`, "invalid hexadecimal literal"},
 		{`0x0x`, "invalid hexadecimal literal"},
 		{`00x0x`, "invalid hexadecimal literal"},
+		{`08`, "could not make constant int from literal \"08\""},
 		{`$9223372036854775809`, "integer value out of range"},
 	}
 	for _, d := range testData {


### PR DESCRIPTION
Fixes #7131.

Previously `constant.MakeFromLiteral` would fail on parsing invalid octal
numbers. We didn't think this could fail, so we were panicing. This
changes the panic to an error so that we no longer bring down the server
on a parsing error.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7134)

<!-- Reviewable:end -->
