### PR TITLE
sql: add support for x'val'-style hexadecimal literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.FATAL
 *.FATAL.*
 stderr.*
+npm-debug.log
 
 # Folders
 _obj

--- a/sql/parser/eval_test.go
+++ b/sql/parser/eval_test.go
@@ -69,6 +69,10 @@ func TestEval(t *testing.T) {
 		{`~0 - 1`, `-2`},
 		// Hexadecimal numbers.
 		{`0xa`, `10`},
+		{`0xcafe1111`, `3405648145`},
+		// Hexadecimal string literals.
+		{`x'636174'`, `'cat'`},
+		{`X'636174'`, `'cat'`},
 		// String concatenation.
 		{`'a' || 'b'`, `'ab'`},
 		{`'a' || (1 + 2)::char`, `'a3'`},

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -230,6 +230,7 @@ func TestParse(t *testing.T) {
 		{`SELECT (ROW(1, 2, 3))`},
 		{`SELECT (ROW())`},
 		{`SELECT (TABLE a)`},
+		{`SELECT 0x1`},
 
 		{`SELECT 1 FROM t`},
 		{`SELECT 1, 2 FROM t`},
@@ -526,6 +527,9 @@ func TestParse2(t *testing.T) {
 			`SELECT e'\n\\'`},
 		{`SELECT "a'a" FROM t`,
 			`SELECT "a'a" FROM t`},
+		// Hexadecimal literal strings are turned into regular strings.
+		{`SELECT x'61'`, `SELECT 'a'`},
+		{`SELECT X'61'`, `SELECT 'a'`},
 		// Comments are stripped.
 		{`SELECT 1 FROM t -- hello world`,
 			`SELECT 1 FROM t`},
@@ -780,8 +784,15 @@ SELECT foo''
 `},
 		{
 			`SELECT 0x FROM t`,
-			`invalid hexadecimal literal
+			`invalid hexadecimal numeric literal
 SELECT 0x FROM t
+       ^
+`,
+		},
+		{
+			`SELECT x'fail' FROM t`,
+			`invalid hexadecimal string literal
+SELECT x'fail' FROM t
        ^
 `,
 		},

--- a/sql/parser/scan_test.go
+++ b/sql/parser/scan_test.go
@@ -87,6 +87,9 @@ func TestScanner(t *testing.T) {
 		{`WITH TIME`, []int{WITH_LA, TIME}},
 		{`WITH ORDINALITY`, []int{WITH_LA, ORDINALITY}},
 		{`1`, []int{ICONST}},
+		{`0xa`, []int{ICONST}},
+		{`x'ba'`, []int{SCONST}},
+		{`X'ba'`, []int{SCONST}},
 		{`1.0`, []int{FCONST}},
 		{`1.0e1`, []int{FCONST}},
 		{`1e+1`, []int{FCONST}},
@@ -335,6 +338,8 @@ func TestScanString(t *testing.T) {
 		{`'hello
 world'`, `hello
 world`},
+		{`x'666f6f'`, `foo`},
+		{`X'626172'`, `bar`},
 	}
 	for _, d := range testData {
 		s := makeScanner(d.sql, Traditional)
@@ -390,13 +395,18 @@ func TestScanError(t *testing.T) {
 		{`1e`, "invalid floating point literal"},
 		{`1e-`, "invalid floating point literal"},
 		{`1e+`, "invalid floating point literal"},
-		{`0x`, "invalid hexadecimal literal"},
-		{`1x`, "invalid hexadecimal literal"},
-		{`1.x`, "invalid hexadecimal literal"},
-		{`1.0x`, "invalid hexadecimal literal"},
-		{`0x0x`, "invalid hexadecimal literal"},
-		{`00x0x`, "invalid hexadecimal literal"},
+		{`0x`, "invalid hexadecimal numeric literal"},
+		{`1x`, "invalid hexadecimal numeric literal"},
+		{`1.x`, "invalid hexadecimal numeric literal"},
+		{`1.0x`, "invalid hexadecimal numeric literal"},
+		{`0x0x`, "invalid hexadecimal numeric literal"},
+		{`00x0x`, "invalid hexadecimal numeric literal"},
 		{`08`, "could not make constant int from literal \"08\""},
+		{`x'zzz'`, "invalid hexadecimal string literal"},
+		{`X'zzz'`, "invalid hexadecimal string literal"},
+		{`x'beef\x41'`, "invalid hexadecimal string literal"},
+		{`X'beef\x41\x41'`, "invalid hexadecimal string literal"},
+		{`x'''1'''`, "invalid hexadecimal string literal"},
 		{`$9223372036854775809`, "integer value out of range"},
 	}
 	for _, d := range testData {


### PR DESCRIPTION
Add support for hexadecimal literals of the form `x'val'` and `X'val'`, where val contains hexadecimal digits. [The reference documentation](https://dev.mysql.com/doc/refman/5.7/en/hexadecimal-literals.html) requires that such literals default to string type, but the hex literals that we already support (of form `0xval`) default to integer type. For consistency, the newly-supported `x'val'` style literals also default to integer type.

Resolves #4017.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7138)

<!-- Reviewable:end -->
