### PR TITLE
sql: allow multiple subquery traversals on the same expression.

### DIFF
--- a/sql/testdata/subquery
+++ b/sql/testdata/subquery
@@ -316,3 +316,28 @@ EXPLAIN(VERBOSE) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
 3 select                          +x,unique
 4 render/filter  (x)@xyz          +x,unique
 5 scan           xyz@primary      +x,unique
+
+# This test checks that the double sub-query plan expansion caused by a
+# sub-expression being shared by two or more plan nodes does not
+# panic.
+statement ok
+CREATE TABLE tab4(col0 INTEGER, col1 FLOAT, col3 INTEGER, col4 FLOAT)
+
+statement ok
+INSERT INTO tab4 VALUES (1,1,1,1);
+
+statement ok
+CREATE INDEX idx_tab4_0 ON tab4 (col4,col0);
+
+query I
+SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
+----
+
+query ITT
+EXPLAIN SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
+----
+0  index-join
+1  scan        tab4@idx_tab4_0 /#-/5.38/1
+2  scan        tab4@primary    -
+1  scan        tab4@primary
+2  scan        tab4@primary    -


### PR DESCRIPTION
The introduction of the sql.subquery Expr node in
4acdc8a77e8554180ca0fbda8b3d14dc7ad35482 assumed that each expression
object was referred to a single location and thus would only be
expanded/started/evaluated once. A violation of this assumption was
reported as a panic to encourage further investigation into possible
inefficiencies.

However the assumption was wrong, because when a query is replaced to
use an index join, the same sub-expression can be shared in both the
index filter and table filter. For example an expression of the form

E = (leftRes OR leftRem) AND (rightRes OR rightRem)

gets replaced to

E1 = (leftRes AND rightRes)
E2 = E

So both leftRes and rightRes become shared.
This is a valid case and thus the panic incorrectly reported the
processing of valid queries as programmer error.

This patch addresses this issue by acknowledging this possible sharing,
detecting and ignoring double traversals of sql.subquery nodes.

Fixes #6986.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7146)

<!-- Reviewable:end -->
