### PR TITLE
storage: Add a call to reserve a replica before trying to add a replica

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -56,6 +56,7 @@ const (
 	defaultMetricsSampleInterval    = 10 * time.Second
 	defaultTimeUntilStoreDead       = 5 * time.Minute
 	defaultStorePath                = "cockroach-data"
+	defaultReservationsEnabled      = true
 )
 
 // Context holds parameters needed to setup a server.
@@ -144,6 +145,10 @@ type Context struct {
 	// Environment Variable: COCKROACH_TIME_UNTIL_STORE_DEAD
 	TimeUntilStoreDead time.Duration
 
+	// ReservationsEnabled is a switch used to enable the add replica
+	// reservation system.
+	ReservationsEnabled bool
+
 	// TestingKnobs is used for internal test controls only.
 	TestingKnobs base.TestingKnobs
 }
@@ -211,6 +216,7 @@ func MakeContext() Context {
 		ConsistencyCheckInterval: defaultConsistencyCheckInterval,
 		MetricsSampleInterval:    defaultMetricsSampleInterval,
 		TimeUntilStoreDead:       defaultTimeUntilStoreDead,
+		ReservationsEnabled:      defaultReservationsEnabled,
 		Stores: StoreSpecList{
 			Specs: []StoreSpec{{Path: defaultStorePath}},
 		},
@@ -296,6 +302,9 @@ func (ctx *Context) readEnvironmentVariables() {
 	ctx.ScanMaxIdleTime = envutil.EnvOrDefaultDuration("scan_max_idle_time", ctx.ScanMaxIdleTime)
 	ctx.TimeUntilStoreDead = envutil.EnvOrDefaultDuration("time_until_store_dead", ctx.TimeUntilStoreDead)
 	ctx.ConsistencyCheckInterval = envutil.EnvOrDefaultDuration("consistency_check_interval", ctx.ConsistencyCheckInterval)
+	// TODO(bram): remove ReservationsEnabled once we've completed testing the
+	// feature.
+	ctx.ReservationsEnabled = envutil.EnvOrDefaultBool("reservations_enabled", ctx.ReservationsEnabled)
 }
 
 // parseGossipBootstrapResolvers parses a comma-separated list of

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -110,6 +110,9 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		if err := os.Unsetenv("COCKROACH_CONSISTENCY_CHECK_INTERVAL"); err != nil {
 			t.Fatal(err)
 		}
+		if err := os.Unsetenv("COCKROACH_RESERVATIONS_ENABLED"); err != nil {
+			t.Fatal(err)
+		}
 	}
 	defer resetEnvVar()
 
@@ -161,6 +164,10 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctxExpected.ConsistencyCheckInterval = time.Millisecond * 10
+	if err := os.Setenv("COCKROACH_RESERVATIONS_ENABLED", "false"); err != nil {
+		t.Fatal(err)
+	}
+	ctxExpected.ReservationsEnabled = false
 
 	envutil.ClearEnvCache()
 	ctx.readEnvironmentVariables()
@@ -198,6 +205,9 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.Setenv("COCKROACH_CONSISTENCY_CHECK_INTERVAL", "abcd"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("COCKROACH_RESERVATIONS_ENABLED", "abcd"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -135,7 +135,14 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	s.gossip = gossip.New(s.rpcContext, s.ctx.GossipBootstrapResolvers, stopper)
-	s.storePool = storage.NewStorePool(s.gossip, s.clock, ctx.TimeUntilStoreDead, stopper)
+	s.storePool = storage.NewStorePool(
+		s.gossip,
+		s.clock,
+		s.rpcContext,
+		ctx.ReservationsEnabled,
+		ctx.TimeUntilStoreDead,
+		stopper,
+	)
 
 	// A custom RetryOptions is created which uses stopper.ShouldDrain() as
 	// the Closer. This prevents infinite retry loops from occurring during

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -169,7 +169,14 @@ func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator
 	g := gossip.New(rpcContext, nil, stopper)
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
-	storePool := NewStorePool(g, clock, TestTimeUntilStoreDeadOff, stopper)
+	storePool := NewStorePool(
+		g,
+		clock,
+		rpcContext,
+		/* reservationsEnabled */ true,
+		TestTimeUntilStoreDeadOff,
+		stopper,
+	)
 	a := MakeAllocator(storePool, AllocatorOptions{AllowRebalance: true})
 	return stopper, g, storePool, a, manualClock
 }
@@ -1029,7 +1036,14 @@ func Example_rebalancing() {
 	g := gossip.New(nil, nil, stopper)
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
-	sp := NewStorePool(g, hlc.NewClock(hlc.UnixNano), TestTimeUntilStoreDeadOff, stopper)
+	sp := NewStorePool(
+		g,
+		hlc.NewClock(hlc.UnixNano),
+		nil,
+		/* reservationsEnabled */ true,
+		TestTimeUntilStoreDeadOff,
+		stopper,
+	)
 	alloc := MakeAllocator(sp, AllocatorOptions{AllowRebalance: true, Deterministic: true})
 
 	var wg sync.WaitGroup

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -125,7 +125,14 @@ func createTestStoreWithEngine(t testing.TB, eng engine.Engine, clock *hlc.Clock
 		kv.NewTxnMetrics(metric.NewRegistry()))
 	sCtx.Clock = clock
 	sCtx.DB = client.NewDB(sender)
-	sCtx.StorePool = storage.NewStorePool(sCtx.Gossip, clock, storage.TestTimeUntilStoreDeadOff, stopper)
+	sCtx.StorePool = storage.NewStorePool(
+		sCtx.Gossip,
+		clock,
+		rpcContext,
+		/* reservationsEnabled */ true,
+		storage.TestTimeUntilStoreDeadOff,
+		stopper,
+	)
 	sCtx.Transport = storage.NewDummyRaftTransport()
 	// TODO(bdarnell): arrange to have the transport closed.
 	store := storage.NewStore(*sCtx, eng, nodeDesc)
@@ -510,7 +517,17 @@ func (m *multiTestContext) addStore() {
 		if m.timeUntilStoreDead == 0 {
 			m.timeUntilStoreDead = storage.TestTimeUntilStoreDeadOff
 		}
-		m.storePools = append(m.storePools, storage.NewStorePool(m.gossips[idx], m.clock, m.timeUntilStoreDead, m.clientStopper))
+		m.storePools = append(
+			m.storePools,
+			storage.NewStorePool(
+				m.gossips[idx],
+				m.clock,
+				m.rpcContext,
+				/* reservationsEnabled */ false,
+				m.timeUntilStoreDead,
+				m.clientStopper,
+			),
+		)
 	}
 	if len(m.dbs) <= idx {
 		retryOpts := base.DefaultRetryOptions()

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -175,7 +175,6 @@ func (rq *replicateQueue) process(
 		if err = repl.ChangeReplicas(roachpb.ADD_REPLICA, rebalanceReplica, desc); err != nil {
 			return err
 		}
-		rq.allocator.UpdateNextRebalance()
 	}
 
 	// Enqueue this replica again to see if there are more changes to be made.

--- a/storage/reservation_test.go
+++ b/storage/reservation_test.go
@@ -57,10 +57,10 @@ func verifyBookie(t *testing.T, b *bookie, reservations, queueLen int, reservedB
 	}
 }
 
-// TestReserve ensures that you can never have more than one reservation for a
-// specific rangeID at a time, and that both `Reserve` and `Fill` function
+// TestBookieReserve ensures that you can never have more than one reservation
+// for a specific rangeID at a time, and that both `Reserve` and `Fill` function
 // correctly.
-func TestReserve(t *testing.T) {
+func TestBookieReserve(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, _, b := createTestBookie(time.Hour, 20, 20*maxReservedBytes)
 	defer stopper.Stop()

--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -78,7 +78,14 @@ func createCluster(
 	// NodeID is required for Gossip, so set it to -1 for the cluster Gossip
 	// instance to prevent conflicts with real NodeIDs.
 	g.SetNodeID(-1)
-	storePool := storage.NewStorePool(g, clock, storage.TestTimeUntilStoreDeadOff, stopper)
+	storePool := storage.NewStorePool(
+		g,
+		clock,
+		rpcContext,
+		/* reservationsEnabled */ true,
+		storage.TestTimeUntilStoreDeadOff,
+		stopper,
+	)
 	c := &Cluster{
 		stopper:   stopper,
 		clock:     clock,

--- a/storage/store.go
+++ b/storage/store.go
@@ -2417,5 +2417,14 @@ func (s *Store) FrozenStatus(collectFrozen bool) (descs []roachpb.ReplicaDescrip
 
 // Reserve requests a reservation from the store's bookie.
 func (s *Store) Reserve(req roachpb.ReservationRequest) roachpb.ReservationResponse {
+	if s.metrics.capacity.Value() == 0 {
+		// On startup, it takes some time before compute metrics is run. When
+		// this happens, it means the store will reject any incoming
+		// reservations. To avoid this, if there is no capacity information yet
+		// we can force a call to ComputeMetrics.
+		if err := s.ComputeMetrics(); err != nil {
+			log.Error(err)
+		}
+	}
 	return s.bookie.Reserve(req)
 }

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -18,7 +18,6 @@ package storage
 
 import (
 	"container/heap"
-	"math"
 	"sort"
 	"sync"
 	"time"
@@ -167,11 +166,6 @@ func NewStorePool(g *gossip.Gossip, clock *hlc.Clock, timeUntilStoreDead time.Du
 	return sp
 }
 
-// Clock returns the storepool's clock.
-func (sp *StorePool) Clock() *hlc.Clock {
-	return sp.clock
-}
-
 // storeGossipUpdate is the gossip callback used to keep the StorePool up to date.
 func (sp *StorePool) storeGossipUpdate(_ string, content roachpb.Value) {
 	var storeDesc roachpb.StoreDescriptor
@@ -297,11 +291,6 @@ func (s *stat) update(x float64) {
 	// Update variable used to calculate running standard deviation. See: Knuth
 	// TAOCP, vol 2, 3rd ed, page 232.
 	s.s = s.s + (x-oldMean)*(x-s.mean)
-}
-
-// stddev returns the running standard deviation.
-func (s *stat) stddev() float64 {
-	return math.Sqrt(s.s / (s.n - 1))
 }
 
 // StoreList holds a list of store descriptors and associated count and used

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -18,12 +18,16 @@ package storage
 
 import (
 	"container/heap"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -38,15 +42,24 @@ const (
 	// TestTimeUntilStoreDeadOff is the test value for TimeUntilStoreDead that
 	// prevents the store pool from marking stores as dead.
 	TestTimeUntilStoreDeadOff = 24 * time.Hour
+
+	// timeoutForDeclinedReservations is the amount of time to not consider the
+	// store available for up-replication after a reservation was declined.
+	timeoutForDeclinedReservations = 10 * time.Second
+
+	// rpcTimeout is used for the rpc calls to Reserve on other nodes. It is
+	// set quite small as this may block calls to ChangeReplicas.
+	rpcTimeout = 1 * time.Second
 )
 
 type storeDetail struct {
-	desc            *roachpb.StoreDescriptor
-	dead            bool
-	timesDied       int
-	foundDeadOn     hlc.Timestamp
-	lastUpdatedTime hlc.Timestamp // This is also the priority for the queue.
-	index           int           // index of the item in the heap, required for heap.Interface
+	desc                  *roachpb.StoreDescriptor
+	dead                  bool
+	timesDied             int
+	foundDeadOn           hlc.Timestamp
+	reservationDeclinedOn time.Time     // The last time a reservation was declined.
+	lastUpdatedTime       hlc.Timestamp // This is also the priority for the queue.
+	index                 int           // index of the item in the heap, required for heap.Interface
 }
 
 // markDead sets the storeDetail to dead(inactive).
@@ -67,6 +80,33 @@ func (sd *storeDetail) markAlive(foundAliveOn hlc.Timestamp, storeDesc *roachpb.
 	sd.desc = storeDesc
 	sd.dead = false
 	sd.lastUpdatedTime = foundAliveOn
+}
+
+// storeMatch is the return value for match().
+type storeMatch int
+
+// These are the possible values for a storeMatch.
+const (
+	storeMatchDead    storeMatch = iota // The store is not yet available or has been timed out.
+	storeMatchAlive                     // The store is alive, but its attributes didn't match the required ones.
+	storeMatchMatched                   // The store is alive and its attributes matched.
+)
+
+// match returns if the store is alive, and if the store is available and it's
+// attributes contain the required ones respectively.
+func (sd *storeDetail) match(now time.Time, required roachpb.Attributes) storeMatch {
+	// The store must be alive and it must have a descriptor to be considered
+	// alive.
+	if sd.dead || sd.desc == nil {
+		return storeMatchDead
+	}
+	// The store must not have a recent declined reservation to be considered
+	// available for matching.
+	if sd.reservationDeclinedOn.Add(timeoutForDeclinedReservations).After(now) ||
+		!required.IsSubset(*sd.desc.CombinedAttrs()) {
+		return storeMatchAlive
+	}
+	return storeMatchMatched
 }
 
 // storePoolPQ implements the heap.Interface (which includes sort.Interface)
@@ -136,10 +176,11 @@ func (pq *storePoolPQ) dequeue() *storeDetail {
 // StorePool maintains a list of all known stores in the cluster and
 // information on their health.
 type StorePool struct {
-	clock              *hlc.Clock
-	timeUntilStoreDead time.Duration
-
-	mu struct {
+	clock               *hlc.Clock
+	timeUntilStoreDead  time.Duration
+	rpcContext          *rpc.Context
+	reservationsEnabled bool
+	mu                  struct {
 		sync.RWMutex
 		// Each storeDetail is contained in both a map and a priorityQueue;
 		// pointers are used so that data can be kept in sync.
@@ -150,10 +191,19 @@ type StorePool struct {
 
 // NewStorePool creates a StorePool and registers the store updating callback
 // with gossip.
-func NewStorePool(g *gossip.Gossip, clock *hlc.Clock, timeUntilStoreDead time.Duration, stopper *stop.Stopper) *StorePool {
+func NewStorePool(
+	g *gossip.Gossip,
+	clock *hlc.Clock,
+	rpcContext *rpc.Context,
+	reservationsEnabled bool,
+	timeUntilStoreDead time.Duration,
+	stopper *stop.Stopper,
+) *StorePool {
 	sp := &StorePool{
-		clock:              clock,
-		timeUntilStoreDead: timeUntilStoreDead,
+		clock:               clock,
+		timeUntilStoreDead:  timeUntilStoreDead,
+		rpcContext:          rpcContext,
+		reservationsEnabled: reservationsEnabled,
 	}
 	sp.mu.stores = make(map[roachpb.StoreID]*storeDetail)
 	heap.Init(&sp.mu.queue)
@@ -335,16 +385,78 @@ func (sp *StorePool) getStoreList(required roachpb.Attributes, deterministic boo
 	if deterministic {
 		sort.Sort(storeIDs)
 	}
+	now := sp.clock.Now().GoTime()
 	sl := StoreList{}
 	var aliveStoreCount int
 	for _, storeID := range storeIDs {
 		detail := sp.mu.stores[roachpb.StoreID(storeID)]
-		if !detail.dead && detail.desc != nil {
+		matched := detail.match(now, required)
+		if matched >= storeMatchAlive {
 			aliveStoreCount++
-			if required.IsSubset(*detail.desc.CombinedAttrs()) {
-				sl.add(detail.desc)
-			}
+		}
+		if matched == storeMatchMatched {
+			sl.add(detail.desc)
 		}
 	}
 	return sl, aliveStoreCount
+}
+
+// reserve send a reservation request rpc to the node and store
+// based on the toStoreID. It returns an error if the reservation was not
+// successfully booked. When unsuccessful, the store is marked as having a
+// declined reservation so it will not be considered for up-replication or
+// rebalancing until after timeoutForDeclinedReservations has passed.
+// TODO(bram): consider moving the nodeID to the store pool during
+// NewStorePool.
+func (sp *StorePool) reserve(
+	curIdent roachpb.StoreIdent,
+	toStoreID roachpb.StoreID,
+	rangeID roachpb.RangeID,
+	rangeSize int64,
+) error {
+	if !sp.reservationsEnabled {
+		return nil
+	}
+	// We don't want to hold the lock for the rpc call, so make copies of all
+	// needed values to avoid the chance of any funny business.
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	detail, ok := sp.mu.stores[toStoreID]
+	if !ok {
+		return fmt.Errorf("store does not exist in the store pool")
+	}
+	conn, err := sp.rpcContext.GRPCDial(detail.desc.Node.Address.String())
+	if err != nil {
+		return err
+	}
+
+	client := roachpb.NewInternalClient(conn)
+	req := &roachpb.ReservationRequest{
+		StoreRequestHeader: roachpb.StoreRequestHeader{
+			NodeID:  detail.desc.Node.NodeID,
+			StoreID: toStoreID,
+		},
+		FromNodeID:  curIdent.NodeID,
+		FromStoreID: curIdent.StoreID,
+		RangeSize:   rangeSize,
+		RangeID:     rangeID,
+	}
+
+	ctxWithTimeout, cancel := context.WithTimeout(context.TODO(), rpcTimeout)
+	defer cancel()
+	resp, err := client.Reserve(ctxWithTimeout, req)
+
+	// If a reservation is declined, be it due to an error or because it was
+	// rejected, we mark the store detail as having been rejected so it won't
+	// be considered for other checks until after timeoutForDeclinedReservations
+	// has expired.
+	if err != nil {
+		detail.reservationDeclinedOn = sp.clock.Now().GoTime()
+		return fmt.Errorf("reservation failed:%+v due to error:%s", req, err)
+	}
+	if !resp.Reserved {
+		detail.reservationDeclinedOn = sp.clock.Now().GoTime()
+		return fmt.Errorf("reservation declined:%+v", req)
+	}
+	return nil
 }

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -24,9 +24,12 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
@@ -60,7 +63,14 @@ func createTestStorePool(timeUntilStoreDead time.Duration) (*stop.Stopper, *goss
 	g := gossip.New(rpcContext, nil, stopper)
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
-	storePool := NewStorePool(g, clock, timeUntilStoreDead, stopper)
+	storePool := NewStorePool(
+		g,
+		clock,
+		rpcContext,
+		/* reservationsEnabled */ true,
+		timeUntilStoreDead,
+		stopper,
+	)
 	return stopper, g, mc, storePool
 }
 
@@ -256,6 +266,11 @@ func TestStorePoolGetStoreList(t *testing.T) {
 		Node:    roachpb.NodeDescriptor{NodeID: 1},
 		Attrs:   roachpb.Attributes{Attrs: required},
 	}
+	declinedStore := roachpb.StoreDescriptor{
+		StoreID: 6,
+		Node:    roachpb.NodeDescriptor{NodeID: 1},
+		Attrs:   roachpb.Attributes{Attrs: required},
+	}
 
 	// Mark all alive initially.
 	sg.GossipStores([]*roachpb.StoreDescriptor{
@@ -264,25 +279,28 @@ func TestStorePoolGetStoreList(t *testing.T) {
 		&unmatchingStore,
 		&emptyStore,
 		&deadStore,
+		&declinedStore,
 	}, t)
 
 	if err := verifyStoreList(sp, required, []int{
 		int(matchingStore.StoreID),
 		int(supersetStore.StoreID),
 		int(deadStore.StoreID),
-	}, 5); err != nil {
+		int(declinedStore.StoreID),
+	}, 6); err != nil {
 		t.Error(err)
 	}
 
-	// Mark one store dead.
+	// Mark one store dead and one store declined.
 	sp.mu.Lock()
 	sp.mu.stores[deadStore.StoreID].markDead(sp.clock.Now())
+	sp.mu.stores[declinedStore.StoreID].reservationDeclinedOn = sp.clock.Now().GoTime().Add(time.Hour)
 	sp.mu.Unlock()
 
 	if err := verifyStoreList(sp, required, []int{
 		int(matchingStore.StoreID),
 		int(supersetStore.StoreID),
-	}, 4); err != nil {
+	}, 5); err != nil {
 		t.Error(err)
 	}
 }
@@ -398,5 +416,131 @@ func TestStorePoolDefaultState(t *testing.T) {
 
 	if sl, c := sp.getStoreList(roachpb.Attributes{}, true); len(sl.stores) > 0 || c != 0 {
 		t.Errorf("expected 0 live stores; got list %v and total count %d", sl, c)
+	}
+}
+
+// fakeNodeServer implements the InternalServer interface. Specifically, this
+// is used for testing the Reserve() RPC.
+type fakeNodeServer struct {
+	reservationResponse bool
+	reservationErr      error
+}
+
+func (f *fakeNodeServer) Batch(ctx context.Context, args *roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
+	panic("unimplemented")
+}
+
+func (f *fakeNodeServer) PollFrozen(_ context.Context, _ *roachpb.PollFrozenRequest) (*roachpb.PollFrozenResponse, error) {
+	panic("unimplemented")
+}
+
+func (f *fakeNodeServer) Reserve(_ context.Context, _ *roachpb.ReservationRequest) (*roachpb.ReservationResponse, error) {
+	return &roachpb.ReservationResponse{Reserved: f.reservationResponse}, f.reservationErr
+}
+
+// newFakeNodeServer returns a fakeNodeServer designed to handle internal
+// node server RPCs, an rpc context used for the server and the fake server's
+// address.
+func newFakeNodeServer(stopper *stop.Stopper) (*fakeNodeServer, *rpc.Context, string, error) {
+	ctx := rpc.NewContext(testutils.NewNodeTestBaseContext(), nil, stopper)
+	s := rpc.NewServer(ctx)
+	ln, err := util.ListenAndServeGRPC(ctx.Stopper, s, util.TestAddr)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	stopper.AddCloser(stop.CloserFn(func() { _ = ln.Close() }))
+	f := &fakeNodeServer{}
+	roachpb.RegisterInternalServer(s, f)
+	return f, ctx, ln.Addr().String(), nil
+}
+
+// TestStorePoolReserve tests that requestReservation performs correctly
+// when reservations are accepted, declined and when the Reserve RPC encounters
+// an error.
+func TestStorePoolReserve(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+
+	// Create a fake node server to generate responses for calls to Reserve.
+	f, ctx, address, err := newFakeNodeServer(stopper)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a fake store pool.
+	mc := hlc.NewManualClock(0)
+	clock := hlc.NewClock(mc.UnixNano)
+	g := gossip.New(ctx, nil, stopper)
+	// Have to call g.SetNodeID before call g.AddInfo
+	g.SetNodeID(roachpb.NodeID(1))
+	storePool := NewStorePool(
+		g,
+		clock,
+		ctx,
+		/* reservationsEnabled */ true,
+		TestTimeUntilStoreDeadOff,
+		stopper,
+	)
+	sg := gossiputil.NewStoreGossiper(g)
+
+	// Gossip a fake store descriptor into the store pool so we can redirect
+	// the Reserve call to our fake server.
+	stores := []*roachpb.StoreDescriptor{
+		{
+			StoreID: 2,
+			Node: roachpb.NodeDescriptor{
+				NodeID: 2,
+				Address: util.UnresolvedAddr{
+					AddressField: address,
+				},
+			},
+		},
+	}
+	sg.GossipStores(stores, t)
+
+	testCases := []struct {
+		fakeResp bool
+		fakeErr  string
+		storeID  int
+		expErr   string
+	}{
+		// The reservation is successful.
+		{fakeResp: true, storeID: 2},
+		// The store is not in the StorePool.
+		{storeID: 3, expErr: "store does not exist in the store pool"},
+		// The reservation is declined.
+		{fakeResp: false, storeID: 2, expErr: "reservation declined"},
+		// The reservation is with an error.
+		{fakeResp: false, fakeErr: "abcd", storeID: 2, expErr: "abcd"},
+	}
+
+	for i, testCase := range testCases {
+		f.reservationResponse = testCase.fakeResp
+		if len(testCase.fakeErr) != 0 {
+			f.reservationErr = fmt.Errorf("%s", testCase.fakeErr)
+		} else {
+			f.reservationErr = nil
+		}
+		err := storePool.reserve(
+			roachpb.StoreIdent{
+				NodeID:  roachpb.NodeID(1),
+				StoreID: roachpb.StoreID(1),
+			},
+			roachpb.StoreID(testCase.storeID),
+			roachpb.RangeID(2),
+			100000,
+		)
+		if len(testCase.expErr) == 0 {
+			if err != nil {
+				t.Errorf("%d: expected no error, got %s", i, err)
+			}
+			continue
+		}
+		if err == nil {
+			t.Errorf("%d: expected an error:%s, got none", i, testCase.expErr)
+		} else if !testutils.IsError(err, testCase.expErr) {
+			t.Errorf("%d: expected error:%s, actual:%s", i, testCase.expErr, err)
+		}
 	}
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -131,7 +131,14 @@ func createTestStoreWithoutStart(t *testing.T, ctx *StoreContext) (*Store, *hlc.
 	ctx.Gossip.SetNodeID(1)
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)
-	ctx.StorePool = NewStorePool(ctx.Gossip, ctx.Clock, TestTimeUntilStoreDeadOff, stopper)
+	ctx.StorePool = NewStorePool(
+		ctx.Gossip,
+		ctx.Clock,
+		rpcContext,
+		/* reservationsEnabled */ true,
+		TestTimeUntilStoreDeadOff,
+		stopper,
+	)
 	eng := engine.NewInMem(roachpb.Attributes{}, 10<<20, stopper)
 	ctx.Transport = NewDummyRaftTransport()
 	sender := &testSender{}


### PR DESCRIPTION
- storage: remove timeout between rebalance attempts
  This is no longer needed since we have a combination of both preemptive
  snapshots and the reservation system.
- storage: add Reserve RPCs to replica's ChangeReplicas
  This also adds functionality to the store pool to stop repeated attempts to
  reserve a replica on a store if one is declined.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7147)

<!-- Reviewable:end -->
