### PR TITLE
storage: make replica.GetReplica()s interface more idiot-proof

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -789,11 +789,27 @@ func (r *Replica) setDescWithoutProcessUpdateLocked(desc *roachpb.RangeDescripto
 	r.mu.state.desc = desc
 }
 
+type errReplicaNotInRange struct {
+	StoreID   roachpb.StoreID
+	RangeDesc roachpb.RangeDescriptor
+}
+
+func (e *errReplicaNotInRange) Error() string {
+	return fmt.Sprintf("replica in store %d not found in RangeDescriptor %+v",
+		e.StoreID, e.RangeDesc)
+}
+
 // GetReplica returns the replica for this range from the range descriptor.
-// Returns nil if the replica is not found.
-func (r *Replica) GetReplica() *roachpb.ReplicaDescriptor {
-	_, replica := r.Desc().FindReplica(r.store.StoreID())
-	return replica
+// Returns nil, *errReplicaNotInRange if the replica is not found. No other
+// errors are returned.
+func (r *Replica) GetReplica() (*roachpb.ReplicaDescriptor, error) {
+	rangeDesc := r.Desc()
+	_, replica := rangeDesc.FindReplica(r.store.StoreID())
+	if replica == nil {
+		return nil, &errReplicaNotInRange{
+			StoreID: r.store.StoreID(), RangeDesc: *rangeDesc}
+	}
+	return replica, nil
 }
 
 // ReplicaDescriptor returns information about the given member of

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2612,11 +2612,14 @@ func (r *Replica) ChangeReplicas(
 			return util.Errorf("change replicas of %d failed: %s", rangeID, err)
 		}
 
-		fromReplica := *r.GetReplica()
+		fromReplica, err := r.GetReplica()
+		if err != nil {
+			return err
+		}
 
 		if err := r.store.ctx.Transport.Send(&RaftMessageRequest{
 			GroupID:     r.RangeID,
-			FromReplica: fromReplica,
+			FromReplica: *fromReplica,
 			ToReplica:   replica,
 			Message: raftpb.Message{
 				Type:     raftpb.MsgSnap,

--- a/storage/store.go
+++ b/storage/store.go
@@ -2393,9 +2393,15 @@ func (s *Store) SetRangeRetryOptions(ro retry.Options) {
 // Store remains in the reported state.
 func (s *Store) FrozenStatus(collectFrozen bool) (descs []roachpb.ReplicaDescriptor) {
 	newStoreRangeSet(s).Visit(func(r *Replica) bool {
-		desc := r.GetReplica()
-		if !r.IsInitialized() || desc == nil {
+		if !r.IsInitialized() {
 			return true
+		}
+		desc, err := r.GetReplica()
+		if err != nil {
+			if _, ok := err.(*errReplicaNotInRange); ok {
+				return true
+			}
+			log.Fatalf("unexpected error: %s", err)
 		}
 		r.mu.Lock()
 		if r.mu.state.frozen == collectFrozen {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -101,9 +101,9 @@ func (db *testSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 		return nil, roachpb.NewError(roachpb.NewRangeKeyMismatchError(rs.Key.AsRawKey(), rs.EndKey.AsRawKey(), nil))
 	}
 	ba.RangeID = rng.RangeID
-	replica := rng.GetReplica()
-	if replica == nil {
-		return nil, roachpb.NewErrorf("own replica missing in range")
+	replica, err := rng.GetReplica()
+	if err != nil {
+		return nil, roachpb.NewError(err)
 	}
 	ba.Replica = *replica
 	br, pErr := db.store.Send(ctx, ba)

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -205,7 +205,12 @@ func (ls *Stores) lookupReplica(start, end roachpb.RKey) (rangeID roachpb.RangeI
 		}
 		if replica == nil {
 			rangeID = rng.RangeID
-			replica = rng.GetReplica()
+			replica, err = rng.GetReplica()
+			if err != nil {
+				if _, ok := err.(*errReplicaNotInRange); !ok {
+					return 0, nil, err
+				}
+			}
 			continue
 		}
 		// Should never happen outside of tests.


### PR DESCRIPTION
CC @BramGruneir 

I don't really know what I'm doing. Is the check in `redirectOnOrAcquireLease` a reasonable place to put it?
Also it's unclear to me what goes on / whether anything should be done on the sender side - after a raft request with `REMOVE_REPLICA` is proposed, should the node that's proposing that command not use that replica any more even before the command applies, if it's local?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7148)

<!-- Reviewable:end -->
