### PR TITLE
roachpb: Introduce Value.(Get|Set)Bool methods

### DIFF
--- a/client/util.go
+++ b/client/util.go
@@ -58,11 +58,7 @@ func marshalValue(v interface{}) (roachpb.Value, error) {
 		return r, nil
 
 	case bool:
-		i := int64(0)
-		if t {
-			i = 1
-		}
-		r.SetInt(i)
+		r.SetBool(t)
 		return r, nil
 
 	case string:
@@ -102,11 +98,7 @@ func marshalValue(v interface{}) (roachpb.Value, error) {
 	// int").
 	switch v := reflect.ValueOf(v); v.Kind() {
 	case reflect.Bool:
-		i := int64(0)
-		if v.Bool() {
-			i = 1
-		}
-		r.SetInt(i)
+		r.SetBool(v.Bool())
 		return r, nil
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -566,6 +566,18 @@ func (v *Value) SetFloat(f float64) {
 	v.RawBytes = EncodeFloatValue(v.RawBytes, f)
 }
 
+// SetBool encodes the specified bool value into the bytes field of the
+// receiver, sets the tag and clears the checksum.
+func (v *Value) SetBool(b bool) {
+	// 0 or 1 will always encode to a 1-byte long varint.
+	v.RawBytes = make([]byte, checksumSize, headerSize+1)
+	i := int64(0)
+	if b {
+		i = 1
+	}
+	v.RawBytes = EncodeIntValue(v.RawBytes, i)
+}
+
 // SetInt encodes the specified int64 value into the bytes field of the
 // receiver, sets the tag and clears the checksum.
 func (v *Value) SetInt(i int64) {
@@ -642,6 +654,17 @@ func (v Value) GetBytes() ([]byte, error) {
 func (v Value) GetFloat() (float64, error) {
 	_, f, err := DecodeFloatValue(v.RawBytes[checksumSize:])
 	return f, err
+}
+
+// GetBool decodes a bool value from the bytes field of the receiver. If the
+// tag is not INT (the tag used for bool values) or the value cannot be decoded
+// an error will be returned.
+func (v Value) GetBool() (bool, error) {
+	_, i, err := DecodeIntValue(v.RawBytes[checksumSize:])
+	if err != nil {
+		return false, err
+	}
+	return i != 0, nil
 }
 
 // GetInt decodes an int64 value from the bytes field of the receiver. If the

--- a/roachpb/data_test.go
+++ b/roachpb/data_test.go
@@ -335,6 +335,14 @@ func TestSetGetChecked(t *testing.T) {
 		t.Errorf("set %f on a value and extracted it, expected %f back, but got %f", f, f, r)
 	}
 
+	b := true
+	v.SetBool(b)
+	if r, err := v.GetBool(); err != nil {
+		t.Fatal(err)
+	} else if b != r {
+		t.Errorf("set %t on a value and extracted it, expected %t back, but got %t", b, b, r)
+	}
+
 	i := int64(1)
 	v.SetInt(i)
 	if r, err := v.GetInt(); err != nil {
@@ -885,6 +893,15 @@ func BenchmarkValueSetFloat(b *testing.B) {
 	}
 }
 
+func BenchmarkValueSetBool(b *testing.B) {
+	v := Value{}
+	bo := true
+
+	for i := 0; i < b.N; i++ {
+		v.SetBool(bo)
+	}
+}
+
 func BenchmarkValueSetInt(b *testing.B) {
 	v := Value{}
 	in := int64(1)
@@ -953,6 +970,18 @@ func BenchmarkValueGetFloat(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		if _, err := v.GetFloat(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValueGetBool(b *testing.B) {
+	v := Value{}
+	bo := true
+	v.SetBool(bo)
+
+	for i := 0; i < b.N; i++ {
+		if _, err := v.GetBool(); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/sql/sqlbase/table.go
+++ b/sql/sqlbase/table.go
@@ -1117,11 +1117,7 @@ func MarshalColumnValue(col ColumnDescriptor, val parser.Datum) (roachpb.Value, 
 	switch col.Type.Kind {
 	case ColumnType_BOOL:
 		if v, ok := val.(*parser.DBool); ok {
-			if *v {
-				r.SetInt(1)
-			} else {
-				r.SetInt(0)
-			}
+			r.SetBool(bool(*v))
 			return r, nil
 		}
 	case ColumnType_INT:
@@ -1192,11 +1188,11 @@ func UnmarshalColumnValue(
 
 	switch kind {
 	case ColumnType_BOOL:
-		v, err := value.GetInt()
+		v, err := value.GetBool()
 		if err != nil {
 			return nil, err
 		}
-		return parser.MakeDBool(parser.DBool(v != 0)), nil
+		return parser.MakeDBool(parser.DBool(v)), nil
 	case ColumnType_INT:
 		v, err := value.GetInt()
 		if err != nil {

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -469,12 +469,8 @@ func (r *Replica) IsFirstRange() bool {
 func setFrozenStatus(
 	eng engine.ReadWriter, ms *engine.MVCCStats, rangeID roachpb.RangeID, frozen bool,
 ) error {
-	var status int64
-	if frozen {
-		status = 1
-	}
 	var val roachpb.Value
-	val.SetInt(status)
+	val.SetBool(frozen)
 	return engine.MVCCPut(context.Background(), eng, ms,
 		keys.RangeFrozenStatusKey(rangeID), roachpb.ZeroTimestamp, val, nil)
 }
@@ -488,11 +484,7 @@ func loadFrozenStatus(eng engine.Reader, rangeID roachpb.RangeID) (bool, error) 
 	if val == nil {
 		return false, nil
 	}
-	s, err := val.GetInt()
-	if err != nil {
-		return false, err
-	}
-	return s != 0, nil
+	return val.GetBool()
 }
 
 func loadLeaderLease(eng engine.Reader, rangeID roachpb.RangeID) (*roachpb.Lease, error) {


### PR DESCRIPTION
This change adds new boolean accessors to the `roachpb.Value` type. The
change was made because it allows us to avoid an extra 8 bytes of
preallocated space for each boolean during encoding (because we know `0`
and `1` will both result in 1-byte varints). It also encapsulates the
boolean -> int logic (false = 0, true = 1), which previously was spread
out throughout our code.

The new methods' benchmarks can be compared against their INT
counterparts', which conveniently use a value of `1` as well.

```
name            time/op
ValueSetBool-4  71.2ns ± 3%
ValueSetInt-4   78.2ns ± 3%
ValueGetBool-4  22.6ns ± 1%
ValueGetInt-4   22.9ns ± 2%

name            alloc/op
ValueSetBool-4   8.00B ± 0%
ValueSetInt-4    16.0B ± 0%
ValueGetBool-4  0.00B ±NaN%
ValueGetInt-4   0.00B ±NaN%

name            allocs/op
ValueSetBool-4    1.00 ± 0%
ValueSetInt-4     1.00 ± 0%
ValueGetBool-4   0.00 ±NaN%
ValueGetInt-4    0.00 ±NaN%
```

This **DOES NOT** change the on-disk format of booleans, so it does not
require any migration path

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7171)

<!-- Reviewable:end -->
