### PR TITLE
Adds the reporting Opt In banner

### DIFF
--- a/ui/next/app/app.tsx
+++ b/ui/next/app/app.tsx
@@ -10,11 +10,9 @@
  *      - Greyed-out display on error
  *    - Cluster health indicator
  * ! Notification Banners
- *    - Help Us
  *    - Cockroach out of date
  * - Node Page
  *    ! Logs Page
- * ! HelpUs Modal
  * - Layout Footer
  * ! HelpUs communication with CRL server
  *

--- a/ui/next/app/containers/banner/bannerContainer.tsx
+++ b/ui/next/app/containers/banner/bannerContainer.tsx
@@ -1,6 +1,7 @@
 /// <reference path="../../../typings/index.d.ts" />
 import * as React from "react";
 import DisconnectedBanner from "./disconnectedBanner";
+import HelpusBanner from "./helpusBanner";
 
 /**
  * This is the outer component for all banners
@@ -9,6 +10,7 @@ export default class extends React.Component<{}, {}> {
   render() {
     return <div id="banner">
       <DisconnectedBanner />
+      <HelpusBanner />
     </div>;
   }
 }

--- a/ui/next/app/containers/banner/helpusBanner.tsx
+++ b/ui/next/app/containers/banner/helpusBanner.tsx
@@ -1,0 +1,97 @@
+/// <reference path="../../../typings/index.d.ts" />
+import * as React from "react";
+import { connect } from "react-redux";
+import { Link } from "react-router";
+import { createSelector } from "reselect";
+import _ = require("lodash");
+
+import Banner from "./banner";
+import { KEY_HELPUS, OptInAttributes, KeyValue, loadUIData, saveUIData } from "../../redux/uiData";
+import { setUISetting } from "../../redux/ui";
+
+export let HELPUS_BANNER_DISMISSED_KEY = "banner/helpusBanner/DISMISSED";
+
+class HelpusBannerProps {
+  attributes: OptInAttributes;
+  attributesLoaded: boolean;
+  dismissed: boolean = false;
+  loadUIData: (...keys: string[]) => void;
+  saveUIData: (...values: KeyValue[]) => void;
+  setUISetting: (key: string, value: any) => void;
+}
+
+class HelpusBanner extends React.Component<HelpusBannerProps, {}> {
+  componentWillMount() {
+    this.props.loadUIData(KEY_HELPUS);
+  }
+
+  dismiss = () => {
+    setUISetting(HELPUS_BANNER_DISMISSED_KEY, true);
+    if (this.props.attributesLoaded) {
+      let attributes = this.props.attributes || new OptInAttributes();
+      attributes.dismissed = attributes.dismissed ? attributes.dismissed + 1 : 1;
+      this.props.saveUIData({
+        key: "helpus",
+        value: attributes,
+      });
+    }
+  }
+
+  render() {
+    /** The banner is only visible when:
+     *   - the banner has not been dismissed in the current UI session AND
+     *   - the optin attributes have loaded AND
+     *   - either the optin attributes don't exist OR
+     *   - the optin attributes do exist, but the user hasn't dismissed or opted in or out
+     */
+    let visible: boolean = this.props.attributesLoaded &&
+      !this.props.dismissed &&
+      (!this.props.attributes ||
+        (!this.props.attributes.dismissed && !_.isBoolean(this.props.attributes.optin)));
+
+    return <Banner className="helpus" visible={visible} onclose={this.dismiss}>
+      <span className="checkmark">✓ </span>
+      Help us improve. Opt in to share usage reporting statistics.
+      <Link to="/help-us/reporting"><button onClick={this.dismiss}>Opt In</button></Link>
+    </Banner>;
+  }
+}
+
+interface UIDataState {
+  data: { [key: string]: any; };
+}
+
+let uiDataState = (state: any): UIDataState => state && state.uiData;
+
+// optinAttributes are the saved attributes that indicate whether the user has
+// opted in to usage reporting
+let optinAttributes = createSelector(
+  uiDataState,
+  (state: UIDataState) => state && state.data[KEY_HELPUS]
+);
+
+// attributesLoaded is a boolean that indicates whether the optinAttributes have been loaded yet
+let attributesLoaded = createSelector(
+  uiDataState,
+  (state: UIDataState) => state && _.has(state.data, KEY_HELPUS)
+);
+
+let helpusBannerDismissed = (state: any): boolean => state.ui[HELPUS_BANNER_DISMISSED_KEY] || false;
+
+// Connect the HelpUsBanner class with our redux store.
+let helpusBannerConnected = connect(
+  (state: any, ownProps: any) => {
+    return {
+      attributes: optinAttributes(state),
+      attributesLoaded: attributesLoaded(state),
+      dismissed: helpusBannerDismissed(state),
+    };
+  },
+  {
+    loadUIData,
+    saveUIData,
+    setUISetting,
+  }
+)(HelpusBanner);
+
+export default helpusBannerConnected;

--- a/ui/next/app/containers/helpus.tsx
+++ b/ui/next/app/containers/helpus.tsx
@@ -3,28 +3,29 @@ import * as React from "react";
 import _ = require("lodash");
 import { connect } from "react-redux";
 import { KEY_HELPUS, OptInAttributes, KeyValue, loadUIData, saveUIData } from "../redux/uiData";
+import { setUISetting } from "../redux/ui";
+import { HELPUS_BANNER_DISMISSED_KEY } from "./banner/helpusBanner";
 
 export interface HelpUsProps {
   optInAttributes: OptInAttributes;
   loadUIData: (...keys: string[]) => void;
   saveUIData: (...values: KeyValue[]) => void;
+  setUISetting: (key: string, value: any) => void;
 }
 
 /**
  * Renders the main content of the help us page.
  */
 export class HelpUs extends React.Component<HelpUsProps, OptInAttributes> {
+  state = new OptInAttributes();
+
   static title() {
     return <h2>Help Cockroach Labs</h2>;
   }
 
-  constructor(props: any) {
-    super(props);
-    this.state = new OptInAttributes();
-  }
-
   componentWillMount() {
     this.props.loadUIData(KEY_HELPUS);
+    this.props.setUISetting(HELPUS_BANNER_DISMISSED_KEY, true);
   }
 
   componentWillReceiveProps(props: HelpUsProps) {
@@ -97,8 +98,8 @@ export class HelpUs extends React.Component<HelpUsProps, OptInAttributes> {
 
 let optinAttributes = (state: any): OptInAttributes => state && state.uiData && state.uiData.data && state.uiData.data[KEY_HELPUS];
 
-// Connect the EventsList class with our redux store.
-let eventsConnected = connect(
+// Connect the HelpUs class with our redux store.
+let helpusConnected = connect(
   (state, ownProps) => {
     return {
       optInAttributes: optinAttributes(state),
@@ -107,7 +108,8 @@ let eventsConnected = connect(
   {
     loadUIData,
     saveUIData,
+    setUISetting,
   }
 )(HelpUs);
 
-export default eventsConnected;
+export default helpusConnected;

--- a/ui/next/app/redux/uiData.spec.ts
+++ b/ui/next/app/redux/uiData.spec.ts
@@ -223,5 +223,32 @@ describe("UIData reducer", function() {
         assert.equal(state.inFlight, 0);
       });
     });
+
+    it("handles missing keys", function () {
+      let missingKey = "missingKey";
+
+      let expectedURL = `/_admin/v1/uidata?keys=${missingKey}`;
+
+      fetchMock.mock(expectedURL, "get", function() {
+        assert.equal(state.inFlight, 1);
+
+        let response = new protos.cockroach.server.serverpb.GetUIDataResponse();
+
+        return {
+          sendAsJson: false,
+          body: response.toArrayBuffer(),
+        };
+      });
+
+      let p = loadUIData(missingKey);
+
+      return p.then(() => {
+        assert.lengthOf(fetchMock.calls(expectedURL), 1);
+        assert.lengthOf(_.keys(state.data), 1);
+        assert.deepEqual(state.data[missingKey], undefined);
+        assert.isNull(state.error);
+        assert.equal(state.inFlight, 0);
+      });
+    });
   });
 });

--- a/ui/next/app/redux/uiData.ts
+++ b/ui/next/app/redux/uiData.ts
@@ -153,16 +153,18 @@ export function loadUIData(...keys: string[]) {
     dispatch(fetchUIData());
 
     return getUIData({ keys }).then((response) => {
-      response.getKeyValues().forEach((val, key) => {
+      let keyValues = response.getKeyValues();
+
+      _.each(keys, (key) => {
         // Responses from the server return values as ByteBuffer objects, which
         // represent stringified JSON objects.
-        let decoded: Object;
-        let bb = val.getValue();
-        let str = bb.readString(bb.limit - bb.offset);
+        let bb = keyValues.has(key) && keyValues.get(key).getValue();
+        let str = bb && bb.readString(bb.limit - bb.offset);
         if (str) {
-          decoded = JSON.parse(str);
+          dispatch(setUIDataKey(key, JSON.parse(str)));
+        } else {
+          dispatch(setUIDataKey(key, undefined));
         }
-        dispatch(setUIDataKey(key, decoded));
       });
     }).catch((error) => {
       dispatch(errorUIData(error));

--- a/ui/styl/partials/layout.styl
+++ b/ui/styl/partials/layout.styl
@@ -321,6 +321,9 @@ a.toggle
       &:first-child
         padding-top 0
 
+#banner
+  max-height 73px
+
 .banner
   width 100%
   background-color $secondary-blue
@@ -340,12 +343,6 @@ a.toggle
 
   &.disconnected
     background-color $secondary-salmon
-
-  // only show the first .banner
-  // any .banner with a previous .banner as a sibling is hidden
-  & ~ &
-    height 0
-    opacity 0
 
   button
     margin-left 15px


### PR DESCRIPTION
The helpus banner no longer triggers a modal. Clicking "Opt In"
directs you to the "Help Us" page. When on the "Help Us" page
the banner is dismissed for the session. Interacting with the
banner in any way dismisses the banner permanently.

Other notes:
- changes the uiData reducer to create entries for missing keys
- slightly changes the banner styles (tested in old UI)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7180)

<!-- Reviewable:end -->
