### PR TITLE
[WIP] (do not merge) sql: refactor the handling of table aliases for qvalues and FROM

### DIFF
--- a/sql/check.go
+++ b/sql/check.go
@@ -35,7 +35,8 @@ func (c *checkHelper) init(p *planner, tableDesc *sqlbase.TableDescriptor) error
 	c.qvals = make(qvalMap)
 	c.cols = tableDesc.Columns
 	table := tableInfo{
-		columns: makeResultColumns(tableDesc.Columns),
+		sourceTables:  fillName(tableDesc.Name, len(tableDesc.Columns)),
+		sourceColumns: makeResultColumns(tableDesc.Columns),
 	}
 
 	c.exprs = make([]parser.TypedExpr, len(tableDesc.Checks))

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -57,8 +57,8 @@ func (p *planner) makeReturningHelper(
 
 	rh.columns = make([]ResultColumn, 0, len(r))
 	rh.table = &tableInfo{
-		columns: makeResultColumns(tablecols),
-		alias:   alias,
+		sourceTables:  fillName(alias, len(tablecols)),
+		sourceColumns: makeResultColumns(tablecols),
 	}
 	rh.qvals = make(qvalMap)
 	rh.exprs = make([]parser.TypedExpr, 0, len(r))

--- a/sql/select_qvalue_test.go
+++ b/sql/select_qvalue_test.go
@@ -32,8 +32,8 @@ func testInitDummySelectNode(desc *sqlbase.TableDescriptor) *selectNode {
 	sel := &selectNode{}
 	sel.qvals = make(qvalMap)
 	sel.source.plan = scan
-	sel.source.info.alias = desc.Name
-	sel.source.info.columns = scan.Columns()
+	sel.source.info.sourceColumns = scan.Columns()
+	sel.source.info.sourceTables = fillName(desc.Name, len(sel.source.info.sourceColumns))
 
 	return sel
 }

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -108,14 +108,13 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, error)
 				if err := qname.NormalizeColumnName(); err != nil {
 					return nil, err
 				}
-				if qname.Table() == "" || sqlbase.EqualName(s.source.info.alias, qname.Table()) {
-					qnameCol := sqlbase.NormalizeName(qname.Column())
-					for j, r := range s.render {
-						if qval, ok := r.(*qvalue); ok {
-							if sqlbase.NormalizeName(qval.colRef.get().Name) == qnameCol {
-								index = j
-								break
-							}
+				qnameCol := sqlbase.NormalizeName(qname.Column())
+				for j, r := range s.render {
+					if qval, ok := r.(*qvalue); ok {
+						if (qname.Table() == "" || sqlbase.EqualName(s.source.info.sourceTables[j], qname.Table())) &&
+							sqlbase.NormalizeName(qval.colRef.get().Name) == qnameCol {
+							index = j
+							break
 						}
 					}
 				}

--- a/sql/table.go
+++ b/sql/table.go
@@ -370,3 +370,11 @@ func (p *planner) expandTableGlob(expr *parser.QualifiedName) (
 		return nil, fmt.Errorf("invalid table glob: %s", expr)
 	}
 }
+
+func fillName(name string, n int) []string {
+	ret := make([]string, n)
+	for i := 0; i < n; i++ {
+		ret[i] = name
+	}
+	return ret
+}

--- a/sql/testdata/explain
+++ b/sql/testdata/explain
@@ -9,7 +9,7 @@ EXPLAIN (PLAN, VERBOSE) SELECT 1
 ----
 Level  Type           Description Ordering
 0      select
-1      render/filter  (1)@
+1      render/filter  ("1") from ()
 2      empty           -
 
 query ITTT colnames
@@ -17,7 +17,7 @@ EXPLAIN (VERBOSE, PLAN) SELECT 1
 ----
 Level  Type           Description Ordering
 0      select
-1      render/filter  (1)@
+1      render/filter  ("1") from ()
 2      empty           -
 
 query ITTT colnames
@@ -69,5 +69,5 @@ Level  Type                  Description   Ordering
 1      sort                  +9,+Span Pos  +9,+Span Pos
 2      explain               trace
 3      select
-4      render/filter(debug)  (1)@
+4      render/filter(debug)  ("1") from ()
 5      empty                 -

--- a/sql/testdata/explain_plan
+++ b/sql/testdata/explain_plan
@@ -24,9 +24,9 @@ query ITTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t
 ----
 Level  Type   Description Ordering
-0      select                    +k,unique
-1      render/filter (k, v)@t    +k,unique
-2      scan          t@primary   +k,unique
+0      select                                +k,unique
+1      render/filter (k, v) from (t.k, t.v)  +k,unique
+2      scan          t@primary               +k,unique
 
 query ITT colnames
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
@@ -74,10 +74,10 @@ CREATE TABLE tc (a INT, b INT, INDEX c(a))
 query ITTT colnames
 EXPLAIN(VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-Level Type          Description   Ordering
-0     select                      +b
-1     sort          +b            +b
-2     render/filter (a, b)@tc     =a
-3     index-join                  =a,+rowid,unique
-4     scan          tc@c /10-/11  =a,+rowid,unique
-4     scan          tc@primary    +rowid,unique
+Level Type          Description                          Ordering
+0     select                                             +b
+1     sort          +b                                   +b
+2     render/filter (a, b) from (tc.a, tc.b, *tc.rowid)  =a
+3     index-join                                         =a,+rowid,unique
+4     scan          tc@c /10-/11                         =a,+rowid,unique
+4     scan          tc@primary                           +rowid,unique

--- a/sql/testdata/subquery
+++ b/sql/testdata/subquery
@@ -310,12 +310,12 @@ true
 query ITTT
 EXPLAIN(VERBOSE) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
 ----
-0 select                          +x,unique
-1 render/filter  (x)@xyz          +x,unique
-2 scan           xyz@primary  -   +x,unique
-3 select                          +x,unique
-4 render/filter  (x)@xyz          +x,unique
-5 scan           xyz@primary      +x,unique
+0 select                                        +x,unique
+1 render/filter  (x) from (xyz.x, xyz.y, xyz.z) +x,unique
+2 scan           xyz@primary  -                 +x,unique
+3 select                                        +x,unique
+4 render/filter  (x) from (xyz.x, xyz.y, xyz.z) +x,unique
+5 scan           xyz@primary                    +x,unique
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not

--- a/sql/upsert.go
+++ b/sql/upsert.go
@@ -88,10 +88,13 @@ func (p *planner) makeUpsertHelper(
 		}
 	}
 
-	table := &tableInfo{alias: tableDesc.Name, columns: makeResultColumns(tableDesc.Columns)}
+	table := &tableInfo{
+		sourceTables:  fillName(tableDesc.Name, len(tableDesc.Columns)),
+		sourceColumns: makeResultColumns(tableDesc.Columns),
+	}
 	excludedAliasTable := &tableInfo{
-		alias:   upsertExcludedTable,
-		columns: makeResultColumns(insertCols),
+		sourceTables:  fillName(upsertExcludedTable, len(insertCols)),
+		sourceColumns: makeResultColumns(insertCols),
 	}
 	tables := []*tableInfo{table, excludedAliasTable}
 


### PR DESCRIPTION
Prior to this patch the assumption was that all columns in a given
FROM clause were originating from the same "table", identified by its
(possibly empty) alias. From there, the `tableInfo` struct held a single
alias string and the source column information; then qname resolution
would scan one or more tableInfo assuming that each tableInfo
corresponds to a single table alias (or none).

To support multiple source tables in FROM, including JOIN clauses,
this assumption must be dropped. When multiple tables are selected,
the same set of source columns can "belong" to more than one table
alias. Actually there can be as many tables as columns selected, for
example `FROM f as f(x), g as g(x), h as h(x)`.

To accommodate this new situation, this patch extends the `tableInfo`
to hold table aliases for each column.

The field `tableInfo.columns` is also renamed to `sourceColumns` to
distinguish them from the diverse uses of `.columns` in `planNode`.

`EXPLAIN(VERBOSE)` is extended to account for multiple input table aliases.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7190)

<!-- Reviewable:end -->
