### PR TITLE
ui/next: use an unprivileged token

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ machine:
     # Matches the docker daemon version in use.
     # See https://docs.docker.com/engine/reference/api/docker_remote_api/
     DOCKER_API_VERSION: v1.22
+    JSPM_GITHUB_AUTH_TOKEN: 763c42afb2d31eb7bc150da33402a24d0e081aef
 
   services:
     - docker

--- a/ui/next/npm-shrinkwrap.json
+++ b/ui/next/npm-shrinkwrap.json
@@ -1240,6 +1240,7 @@
     },
     "jspm-github": {
       "version": "0.13.13",
+      "resolved": "git://github.com/tamird/github.git#769d6632131b0a2abd236031708e7352cac0417a",
       "dependencies": {
         "glob": {
           "version": "4.5.3"


### PR DESCRIPTION
Requires a fork of jspm-github until upstream is fixed, see
https://github.com/jspm/github/issues/89.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7194)

<!-- Reviewable:end -->
