### PR TITLE
sql: prototype JOIN and refactor table alias and qargs

### DIFF
--- a/sql/analyze.go
+++ b/sql/analyze.go
@@ -1594,13 +1594,13 @@ func makeIsNotNull(left parser.TypedExpr) parser.TypedExpr {
 // - resolving qnames (optional);
 // - type checking (with optional type enforcement);
 // - normalization.
-// The parameters tables and qvals, if both are non-nil, indicate
+// The parameters sources and qvals, if both are non-nil, indicate
 // qname resolution should be performed. The qvals map will be filled
 // as a result.
 func (p *planner) analyzeExpr(
 	raw parser.Expr,
 	/* arguments for qname resolution */
-	tables []*tableInfo,
+	sources multiSourceInfo,
 	qvals qvalMap,
 	/* arguments for type checking */
 	expectedType parser.Datum,
@@ -1619,10 +1619,10 @@ func (p *planner) analyzeExpr(
 
 	// Perform optional qname resolution.
 	var resolved parser.Expr
-	if tables == nil || qvals == nil {
+	if sources == nil || qvals == nil {
 		resolved = replaced
 	} else {
-		resolved, err = resolveQNames(replaced, tables, qvals, &p.qnameVisitor)
+		resolved, err = resolveQNames(replaced, sources, qvals, &p.qnameVisitor)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/check.go
+++ b/sql/check.go
@@ -34,9 +34,7 @@ func (c *checkHelper) init(p *planner, tableDesc *sqlbase.TableDescriptor) error
 
 	c.qvals = make(qvalMap)
 	c.cols = tableDesc.Columns
-	table := tableInfo{
-		columns: makeResultColumns(tableDesc.Columns),
-	}
+	sourceInfo := newSourceInfoForSingleTable(tableDesc.Name, makeResultColumns(tableDesc.Columns))
 
 	c.exprs = make([]parser.TypedExpr, len(tableDesc.Checks))
 	exprStrings := make([]string, len(tableDesc.Checks))
@@ -49,7 +47,7 @@ func (c *checkHelper) init(p *planner, tableDesc *sqlbase.TableDescriptor) error
 	}
 
 	for i, raw := range exprs {
-		typedExpr, err := p.analyzeExpr(raw, []*tableInfo{&table}, c.qvals,
+		typedExpr, err := p.analyzeExpr(raw, multiSourceInfo{sourceInfo}, c.qvals,
 			parser.TypeBool, false, "")
 		if err != nil {
 			return err

--- a/sql/data_source.go
+++ b/sql/data_source.go
@@ -1,0 +1,481 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package sql
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/pkg/errors"
+)
+
+// To understand dataSourceInfo below it is crucial to understand the
+// meaning of a "data source" and its relationship to qnames/qvalues.
+//
+// A data source is an object that can deliver rows of column data,
+// where each row is implemented in CockroachDB as an array of values.
+// The defining property of a data source is that the columns in its
+// result row arrays are always 0-indexed.
+//
+// From the language perspective, data sources are defined indirectly by:
+// - the FROM clause in a SELECT statement;
+// - JOIN clauses within the FROM clause;
+// - the clause that follows INSERT INTO colName(Cols...);
+// - the clause that follows UPSERT ....;
+// - the invisible data source defined by the original table row during
+//   UPSERT, if it exists.
+//
+// Most expressions (parser.Expr trees) in CockroachDB refer to a
+// single data source. A notable exception is UPSERT, where expressions
+// can refer to two sources: one for the values being inserted, one for
+// the original row data in the table for the conflicting (already
+// existing) rows.
+//
+// Meanwhile, qvalues in CockroachDB provide the interface between
+// symbolic names in expressions (e.g. "f.x", called QualifiedNames,
+// or qnames) and data sources. During evaluation, a qvalue must
+// resolve to a column value. For a given qname there are thus two
+// subsequent questions that must be answered:
+//
+// - which data source is the qname referring to? (when there is more than 1 source)
+// - which 0-indexed column in that data source is the qname referring to?
+//
+// The qvalue must distinguish data sources because the same column index
+// may refer to different columns in different data sources. For
+// example in an UPSERT statement the qvalue for "excluded.x" could refer
+// to column 0 in the (already existing) table row, whereas "src.x" could
+// refer to column 0 in the valueNode that provides values to insert.
+//
+// Within this context, the infrastructure for data sources and qvalues
+// is implemented as follows:
+//
+// - dataSourceInfo provides column metadata for exactly one data source;
+// - the columnRef in qvalues contains a link (pointer) to the
+//   dataSourceInfo for its data source, and the column index;
+// - qvalResolver (select_qvalue.go) is tasked with linking back qvalues with
+//   their data source and column index.
+//
+// This being said, there is a misunderstanding one should be careful
+// to avoid: *there is no direct relationship between data sources and
+// table names* in SQL. In other words:
+//
+// - the same table name can be present in two or more data sources; for example
+//   with:
+//        INSERT INTO excluded VALUES (42) ON CONFLICT (x) DO UPDATE ...
+//   the name "excluded" can refer either to the data source for VALUES(42)
+//   or the implicit data source corresponding to the rows in the original table
+//   that conflict with the new values.
+//
+//   When this happens, a qname of the form "excluded.x" must be
+//   resolved by considering all the data sources; if there is more
+//   than one data source providing the table name "excluded" (as in
+//   this case), the query is rejected with an ambiguity error.
+//
+// - a single data source may provide values for multiple table names; for
+//   example with:
+//         SELECT * FROM (f CROSS JOIN g) WHERE f.x = g.x
+//   there is a single data source corresponding to the results of the
+//   CROSS JOIN, providing a single 0-indexed array of values on each
+//   result row.
+//
+//   (multiple table names for a single data source happen in JOINed sources
+//   and JOINed sources only. Note that a FROM clause with a comma-separated
+//   list of sources is a CROSS JOIN in disguise.)
+//
+//   When this happens, qnames of the form "f.x" in either WHERE,
+//   SELECT renders, or other expressions which can refer to the data
+//   source do not refer to the "internal" data sources of the JOIN;
+//   they always refer to the final result rows of the JOIN source as
+//   a whole.
+//
+//   This implies that a single dataSourceInfo that provides metadata
+//   for a complex JOIN clause must "know" which table name is
+//   associated with each column in its result set.
+//
+
+type dataSourceInfo struct {
+	// sourceColumns match the plan.Columns() 1-to-1. However the column
+	// names might be different if the statement renames them using AS.
+	sourceColumns []ResultColumn
+
+	// sourceAliases indicates to which table alias column ranges
+	// belong.
+	// These often correspond to the original table names for each
+	// column but might be different if the statement renames
+	// them using AS.
+	sourceAliases sourceAliases
+}
+
+// planDataSource contains the data source information for data
+// produced by a planNode.
+type planDataSource struct {
+	// info which describe the columns.
+	info *dataSourceInfo
+
+	// plan which can be used to retrieve the data.
+	plan planNode
+}
+
+// columnRange identifies a non-empty set of columns in a
+// selection. This is used by dataSourceInfo.sourceAliases to map
+// table names to column ranges.
+type columnRange []int
+
+// sourceAliases associates a table name (alias) to a set of columns
+// in the result row of a data source.
+type sourceAliases map[string]columnRange
+
+// fillColumnRange creates a single range that refers to all the
+// columns between firstIdx and lastIdx, inclusive.
+func fillColumnRange(firstIdx, lastIdx int) columnRange {
+	res := make(columnRange, lastIdx-firstIdx+1)
+	for i := range res {
+		res[i] = i + firstIdx
+	}
+	return res
+}
+
+// newSourceInfoForSingleTable creates a simple dataSourceInfo
+// which maps the same tableAlias to all columns.
+func newSourceInfoForSingleTable(tableAlias string, columns []ResultColumn) *dataSourceInfo {
+	norm := sqlbase.NormalizeName(tableAlias)
+	return &dataSourceInfo{
+		sourceColumns: columns,
+		sourceAliases: sourceAliases{norm: fillColumnRange(0, len(columns)-1)},
+	}
+}
+
+// getSources combines zero or more FROM sources into cross-joins.
+func (p *planner) getSources(
+	sources []parser.TableExpr, scanVisibility scanVisibility,
+) (planDataSource, error) {
+	switch len(sources) {
+	case 0:
+		plan := &emptyNode{results: true}
+		return planDataSource{
+			info: newSourceInfoForSingleTable("", plan.Columns()),
+			plan: plan,
+		}, nil
+
+	case 1:
+		return p.getDataSource(sources[0], nil, scanVisibility)
+
+	default:
+		left, err := p.getDataSource(sources[0], nil, scanVisibility)
+		if err != nil {
+			return planDataSource{}, err
+		}
+		right, err := p.getSources(sources[1:], scanVisibility)
+		if err != nil {
+			return planDataSource{}, err
+		}
+		return p.makeJoin("CROSS JOIN", left, right, nil)
+	}
+}
+
+// getDataSource builds a planDataSource from a single data source clause
+// (TableExpr) in a SelectClause.
+func (p *planner) getDataSource(
+	src parser.TableExpr,
+	hints *parser.IndexHints,
+	scanVisibility scanVisibility,
+) (planDataSource, error) {
+	switch t := src.(type) {
+	case *parser.QualifiedName:
+		// Usual case: a table.
+		scan := p.Scan()
+		tableName, err := scan.initTable(p, t, hints, scanVisibility)
+		if err != nil {
+			return planDataSource{}, err
+		}
+
+		return planDataSource{
+			info: newSourceInfoForSingleTable(tableName, scan.Columns()),
+			plan: scan,
+		}, nil
+
+	case *parser.Subquery:
+		// We have a subquery (this includes a simple "VALUES").
+		plan, err := p.newPlan(t.Select, nil, false)
+		if err != nil {
+			return planDataSource{}, err
+		}
+		return planDataSource{
+			info: newSourceInfoForSingleTable("", plan.Columns()),
+			plan: plan,
+		}, nil
+
+	case *parser.JoinTableExpr:
+		// Joins: two sources.
+		left, err := p.getDataSource(t.Left, nil, scanVisibility)
+		if err != nil {
+			return left, err
+		}
+		right, err := p.getDataSource(t.Right, nil, scanVisibility)
+		if err != nil {
+			return right, err
+		}
+		return p.makeJoin(t.Join, left, right, t.Cond)
+
+	case *parser.ParenTableExpr:
+		return p.getDataSource(t.Expr, hints, scanVisibility)
+
+	case *parser.AliasedTableExpr:
+		// AS OF expressions should be handled by the executor.
+		if t.AsOf.Expr != nil && !p.asOf {
+			return planDataSource{}, fmt.Errorf("unexpected AS OF SYSTEM TIME")
+		}
+
+		// Alias clause: source AS alias(cols...)
+		src, err := p.getDataSource(t.Expr, t.Hints, scanVisibility)
+		if err != nil {
+			return src, err
+		}
+
+		var tableAlias string
+		if t.As.Alias != "" {
+			// If an alias was specified, use that.
+			tableAlias = sqlbase.NormalizeName(string(t.As.Alias))
+			src.info.sourceAliases = sourceAliases{
+				tableAlias: fillColumnRange(0, len(src.info.sourceColumns)-1),
+			}
+		}
+		colAlias := t.As.Cols
+
+		if len(colAlias) > 0 {
+			// Make a copy of the slice since we are about to modify the contents.
+			src.info.sourceColumns = append([]ResultColumn(nil), src.info.sourceColumns...)
+
+			// The column aliases can only refer to explicit columns.
+			for colIdx, aliasIdx := 0, 0; aliasIdx < len(colAlias); colIdx++ {
+				if colIdx >= len(src.info.sourceColumns) {
+					return planDataSource{}, errors.Errorf(
+						"table \"%s\" has %d columns available but %d columns specified",
+						tableAlias, aliasIdx, len(colAlias))
+				}
+				if src.info.sourceColumns[colIdx].hidden {
+					continue
+				}
+				src.info.sourceColumns[colIdx].Name = string(colAlias[aliasIdx])
+				aliasIdx++
+			}
+		}
+		return src, nil
+
+	default:
+		return planDataSource{}, errors.Errorf("unsupported FROM type %T", src)
+	}
+}
+
+// expandStar returns the array of column metadata and qname
+// expressions that correspond to the expansion of a qname star.
+func (src *dataSourceInfo) expandStar(
+	qname *parser.QualifiedName, qvals qvalMap,
+) (columns []ResultColumn, exprs []parser.TypedExpr, err error) {
+	if len(src.sourceColumns) == 0 {
+		return nil, nil, fmt.Errorf("cannot use \"%s\" without a FROM clause", qname)
+	}
+
+	colSel := func(idx int) {
+		col := src.sourceColumns[idx]
+		if !col.hidden {
+			qval := qvals.getQVal(columnRef{src, idx})
+			columns = append(columns, ResultColumn{Name: col.Name, Typ: qval.datum})
+			exprs = append(exprs, qval)
+		}
+	}
+
+	tableName := qname.Table()
+	if tableName == "" {
+		for i := 0; i < len(src.sourceColumns); i++ {
+			colSel(i)
+		}
+	} else {
+		norm := sqlbase.NormalizeName(tableName)
+		colRange, ok := src.sourceAliases[norm]
+		if !ok {
+			return nil, nil, fmt.Errorf("table \"%s\" not found", tableName)
+		}
+		for _, i := range colRange {
+			colSel(i)
+		}
+	}
+
+	return columns, exprs, nil
+}
+
+// findUnaliasedColumn looks up the column specified by a qname, not
+// taking column renames into account (but table renames will be taken
+// into account). That is, given a table "blah" with single column "y",
+// findUnaliasedColumn("y") returns a valid index even in the context
+// of:
+//     SELECT * FROM blah as foo(x)
+// If the qname specifies a table name, only columns that have that
+// name as their source alias are considered. If the qname does not
+// specify a table name, all columns in the data source are
+// considered.  If no column is found, invalidColIdx is returned with
+// no error.
+func (p *planDataSource) findUnaliasedColumn(
+	qname *parser.QualifiedName,
+) (colIdx int, err error) {
+	if err := qname.NormalizeColumnName(); err != nil {
+		return invalidColIdx, err
+	}
+
+	colName := sqlbase.NormalizeName(qname.Column())
+	tableName := sqlbase.NormalizeName(qname.Table())
+
+	colIdx = invalidColIdx
+	planColumns := p.plan.Columns()
+
+	selCol := func(colIdx int, idx int) (int, error) {
+		col := planColumns[idx]
+		if sqlbase.NormalizeName(col.Name) == colName {
+			if colIdx != invalidColIdx {
+				return invalidColIdx, fmt.Errorf("column reference \"%s\" is ambiguous", qname)
+			}
+			colIdx = idx
+		}
+		return colIdx, nil
+	}
+
+	if tableName == "" {
+		for idx := 0; idx < len(p.info.sourceColumns); idx++ {
+			colIdx, err = selCol(colIdx, idx)
+			if err != nil {
+				return colIdx, err
+			}
+		}
+	} else {
+		colRange, ok := p.info.sourceAliases[tableName]
+		if !ok {
+			// A table name is specified, but there is no column with this
+			// table name.
+			return invalidColIdx, nil
+		}
+		for _, idx := range colRange {
+			colIdx, err = selCol(colIdx, idx)
+			if err != nil {
+				return colIdx, err
+			}
+		}
+	}
+
+	return colIdx, nil
+}
+
+type multiSourceInfo []*dataSourceInfo
+
+// findColumn looks up the column specified by a qname. The qname
+// will be normalized.
+func (sources multiSourceInfo) findColumn(
+	qname *parser.QualifiedName,
+) (info *dataSourceInfo, colIdx int, err error) {
+	if err := qname.NormalizeColumnName(); err != nil {
+		return nil, invalidColIdx, err
+	}
+
+	// We can't resolve stars to a single column.
+	if qname.IsStar() {
+		panic("star qnames should really not be reaching this point!")
+	}
+
+	colName := sqlbase.NormalizeName(qname.Column())
+	tableName := sqlbase.NormalizeName(qname.Table())
+
+	colIdx = invalidColIdx
+	for _, src := range sources {
+		findCol := func(src, info *dataSourceInfo, colIdx int, idx int) (*dataSourceInfo, int, error) {
+			col := src.sourceColumns[idx]
+			if sqlbase.NormalizeName(col.Name) == colName {
+				if colIdx != invalidColIdx {
+					return nil, invalidColIdx, fmt.Errorf("column reference \"%s\" is ambiguous", qname)
+				}
+				info = src
+				colIdx = idx
+			}
+			return info, colIdx, nil
+		}
+
+		if tableName == "" {
+			for idx := 0; idx < len(src.sourceColumns); idx++ {
+				info, colIdx, err = findCol(src, info, colIdx, idx)
+				if err != nil {
+					return info, colIdx, err
+				}
+			}
+		} else {
+			colRange, ok := src.sourceAliases[tableName]
+			if !ok {
+				// The data source "src" has no column for table tableName.
+				// Try again with the net one.
+				continue
+			}
+			for _, idx := range colRange {
+				info, colIdx, err = findCol(src, info, colIdx, idx)
+				if err != nil {
+					return info, colIdx, err
+				}
+			}
+		}
+	}
+
+	if colIdx == invalidColIdx {
+		return nil, invalidColIdx, fmt.Errorf("qualified name \"%s\" not found", qname)
+	}
+
+	return info, colIdx, nil
+}
+
+// concatDataSourceInfos creates a new dataSourceInfo that represents
+// the side-by-side concatenation of the two data sources described by
+// its arguments.  If it detects that a table alias appears on both
+// sides, an ambiguity is reported.
+func concatDataSourceInfos(left *dataSourceInfo, right *dataSourceInfo) (*dataSourceInfo, error) {
+	aliases := make(sourceAliases)
+	nColsLeft := len(left.sourceColumns)
+	for alias, colRange := range right.sourceAliases {
+		newRange := make(columnRange, len(colRange))
+		for i, idx := range colRange {
+			newRange[i] = idx + nColsLeft
+		}
+		aliases[alias] = newRange
+	}
+	for k, v := range left.sourceAliases {
+		aliases[k] = v
+	}
+
+	columns := make([]ResultColumn, 0, len(left.sourceColumns)+len(right.sourceColumns))
+	columns = append(columns, left.sourceColumns...)
+	columns = append(columns, right.sourceColumns...)
+
+	return &dataSourceInfo{sourceColumns: columns, sourceAliases: aliases}, nil
+}
+
+// findTableAlias returns the first table alias providing the column
+// index given as argument. The index must be valid.
+func (src *dataSourceInfo) findTableAlias(colIdx int) string {
+	for alias, colRange := range src.sourceAliases {
+		for _, idx := range colRange {
+			if colIdx == idx {
+				return alias
+			}
+		}
+	}
+	panic(fmt.Sprintf("no alias for position %d in %q", colIdx, src.sourceAliases))
+}

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -168,26 +168,35 @@ func (e *explainTypesNode) Start() error {
 	return nil
 }
 
+func formatColumns(cols []ResultColumn, printTypes bool) string {
+	var buf bytes.Buffer
+	buf.WriteByte('(')
+	for i, rCol := range cols {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		parser.Name(rCol.Name).Format(&buf, parser.FmtSimple)
+		if rCol.hidden {
+			buf.WriteString("[hidden]")
+		}
+		if printTypes {
+			buf.WriteByte(' ')
+			buf.WriteString(rCol.Typ.Type())
+		}
+	}
+	buf.WriteByte(')')
+	return buf.String()
+}
+
 func populateTypes(v *valuesNode, plan planNode, level int) {
 	name, _, children := plan.ExplainPlan(true)
 
 	// Format the result column types.
-	var colDesc bytes.Buffer
-	colDesc.WriteByte('(')
-	for i, rCol := range plan.Columns() {
-		if i > 0 {
-			colDesc.WriteString(", ")
-		}
-		colDesc.WriteString(parser.Name(rCol.Name).String())
-		colDesc.WriteByte(' ')
-		colDesc.WriteString(rCol.Typ.Type())
-	}
-	colDesc.WriteByte(')')
 	row := parser.DTuple{
 		parser.NewDInt(parser.DInt(level)),
 		parser.NewDString(name),
 		parser.NewDString("result"),
-		parser.NewDString(colDesc.String()),
+		parser.NewDString(formatColumns(plan.Columns(), true)),
 	}
 	v.rows = append(v.rows, row)
 
@@ -230,6 +239,7 @@ func (e *explainPlanNode) expandPlan() error {
 		{Name: "Description", Typ: parser.TypeString},
 	}
 	if e.verbose {
+		columns = append(columns, ResultColumn{Name: "Columns", Typ: parser.TypeString})
 		columns = append(columns, ResultColumn{Name: "Ordering", Typ: parser.TypeString})
 	}
 	e.results = &valuesNode{columns: columns}
@@ -262,6 +272,7 @@ func populateExplain(verbose bool, v *valuesNode, plan planNode, level int) {
 		parser.NewDString(description),
 	}
 	if verbose {
+		row = append(row, parser.NewDString(formatColumns(plan.Columns(), false)))
 		row = append(row, parser.NewDString(plan.Ordering().AsString(plan.Columns())))
 	}
 	v.rows = append(v.rows, row)

--- a/sql/group.go
+++ b/sql/group.go
@@ -52,7 +52,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 		// We do not need to fully analyze the GROUP BY expression here
 		// (as per analyzeExpr) because this is taken care of by addRender
 		// below.
-		resolved, err := resolveQNames(groupBy[i], []*tableInfo{&s.source.info}, s.qvals, &p.qnameVisitor)
+		resolved, err := resolveQNames(groupBy[i], s.sourceInfo, s.qvals, &p.qnameVisitor)
 		if err != nil {
 			return nil, err
 		}
@@ -74,8 +74,8 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 	var typedHaving parser.TypedExpr
 	var err error
 	if n.Having != nil {
-		typedHaving, err = p.analyzeExpr(n.Having.Expr,
-			[]*tableInfo{&s.source.info}, s.qvals, parser.TypeBool, true, "HAVING")
+		typedHaving, err = p.analyzeExpr(n.Having.Expr, s.sourceInfo, s.qvals,
+			parser.TypeBool, true, "HAVING")
 		if err != nil {
 			return nil, err
 		}

--- a/sql/ordering.go
+++ b/sql/ordering.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/encoding"
 )
@@ -75,7 +76,7 @@ func (ord orderingInfo) Format(buf *bytes.Buffer, columns []ResultColumn) {
 		if columns == nil || i >= len(columns) {
 			fmt.Fprintf(buf, "%d", i)
 		} else {
-			buf.WriteString(columns[i].Name)
+			parser.Name(columns[i].Name).Format(buf, parser.FmtSimple)
 		}
 	}
 
@@ -92,7 +93,7 @@ func (ord orderingInfo) Format(buf *bytes.Buffer, columns []ResultColumn) {
 		if columns == nil || o.ColIdx >= len(columns) {
 			fmt.Fprintf(buf, "%d", o.ColIdx)
 		} else {
-			buf.WriteString(columns[o.ColIdx].Name)
+			parser.Name(columns[o.ColIdx].Name).Format(buf, parser.FmtSimple)
 		}
 	}
 

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -2139,3 +2139,13 @@ func anchorPattern(pattern string, caseInsensitive bool) string {
 	}
 	return fmt.Sprintf("^(?:%s)$", pattern)
 }
+
+// FindEqualComparisonFunction looks up an overload of the "=" operator
+// for a given pair of input operand types.
+func FindEqualComparisonFunction(leftType, rightType Datum) (func(*EvalContext, Datum, Datum) (DBool, error), bool) {
+	fn, found := CmpOps[EQ].lookupImpl(leftType, rightType)
+	if found {
+		return fn.fn, true
+	}
+	return nil, false
+}

--- a/sql/parser/format.go
+++ b/sql/parser/format.go
@@ -22,7 +22,8 @@ import (
 )
 
 type fmtFlags struct {
-	showTypes bool
+	showTypes        bool
+	showTableAliases bool
 }
 
 // FmtFlags enables conditional formatting in the pretty-printer.
@@ -32,6 +33,10 @@ type FmtFlags *fmtFlags
 // a straightforward representation, ideally using SQL
 // syntax that makes prettyprint+parse idempotent.
 var FmtSimple FmtFlags = &fmtFlags{showTypes: false}
+
+// FmtQualify instructs the pretty-printer to qualify qnames with the
+// table name.
+var FmtQualify FmtFlags = &fmtFlags{showTableAliases: true}
 
 // FmtShowTypes instructs the pretty-printer to
 // annotate expressions with their resolved types.

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -853,7 +853,7 @@ const sqlEofCode = 1
 const sqlErrCode = 2
 const sqlInitialStackSize = 16
 
-//line sql.y:4569
+//line sql.y:4575
 
 //line yacctab:1
 var sqlExca = [...]int{
@@ -6727,291 +6727,292 @@ sqldefault:
 		}
 	case 393:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2577
-		{ /* SKIP DOC */
+		//line sql.y:2578
+		{
+			sqlVAL.union.val = sqlDollar[1].union.tblExpr()
 		}
 	case 394:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2578
+		//line sql.y:2582
 		{
-			unimplemented()
+			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[2].union.tblExpr(), As: sqlDollar[4].union.aliasClause()}
 		}
 	case 395:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2596
+		//line sql.y:2602
 		{
 			sqlVAL.union.val = &ParenTableExpr{Expr: sqlDollar[2].union.tblExpr()}
 		}
 	case 396:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2600
+		//line sql.y:2606
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astCrossJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr()}
 		}
 	case 397:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2604
+		//line sql.y:2610
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: sqlDollar[2].str, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr(), Cond: sqlDollar[5].union.joinCond()}
 		}
 	case 398:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2608
+		//line sql.y:2614
 		{
 			sqlVAL.union.val = &JoinTableExpr{Join: astJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[3].union.tblExpr(), Cond: sqlDollar[4].union.joinCond()}
 		}
 	case 399:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2612
+		//line sql.y:2618
 		{
-			sqlVAL.union.val = &JoinTableExpr{Join: astNaturalJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[5].union.tblExpr()}
+			sqlVAL.union.val = &JoinTableExpr{Join: sqlDollar[3].str, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[5].union.tblExpr(), Cond: NaturalJoinCond{}}
 		}
 	case 400:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2616
+		//line sql.y:2622
 		{
-			sqlVAL.union.val = &JoinTableExpr{Join: astNaturalJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr()}
+			sqlVAL.union.val = &JoinTableExpr{Join: astJoin, Left: sqlDollar[1].union.tblExpr(), Right: sqlDollar[4].union.tblExpr(), Cond: NaturalJoinCond{}}
 		}
 	case 401:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2622
+		//line sql.y:2628
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[2].str), Cols: NameList(sqlDollar[4].union.strs())}
 		}
 	case 402:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2626
+		//line sql.y:2632
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[2].str)}
 		}
 	case 403:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2630
+		//line sql.y:2636
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[1].str), Cols: NameList(sqlDollar[3].union.strs())}
 		}
 	case 404:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2634
+		//line sql.y:2640
 		{
 			sqlVAL.union.val = AliasClause{Alias: Name(sqlDollar[1].str)}
 		}
 	case 406:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2641
+		//line sql.y:2647
 		{
 			sqlVAL.union.val = AliasClause{}
 		}
 	case 407:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2647
+		//line sql.y:2653
 		{
 			sqlVAL.union.val = AsOfClause{Expr: &StrVal{s: sqlDollar[5].str}}
 		}
 	case 408:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2651
+		//line sql.y:2657
 		{
 			sqlVAL.union.val = AsOfClause{}
 		}
 	case 409:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2657
+		//line sql.y:2663
 		{
 			sqlVAL.str = astFullJoin
 		}
 	case 410:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2661
+		//line sql.y:2667
 		{
 			sqlVAL.str = astLeftJoin
 		}
 	case 411:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2665
+		//line sql.y:2671
 		{
 			sqlVAL.str = astRightJoin
 		}
 	case 412:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2669
+		//line sql.y:2675
 		{
 			sqlVAL.str = astInnerJoin
 		}
 	case 413:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2675
+		//line sql.y:2681
 		{
 		}
 	case 414:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2676
+		//line sql.y:2682
 		{
 		}
 	case 415:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2687
+		//line sql.y:2693
 		{
 			sqlVAL.union.val = &UsingJoinCond{Cols: NameList(sqlDollar[3].union.strs())}
 		}
 	case 416:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2691
+		//line sql.y:2697
 		{
 			sqlVAL.union.val = &OnJoinCond{Expr: sqlDollar[2].union.expr()}
 		}
 	case 417:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2697
+		//line sql.y:2703
 		{
 			sqlVAL.union.val = sqlDollar[1].union.qname()
 		}
 	case 418:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2701
+		//line sql.y:2707
 		{
 			sqlVAL.union.val = sqlDollar[1].union.qname()
 		}
 	case 419:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2705
+		//line sql.y:2711
 		{
 			sqlVAL.union.val = sqlDollar[2].union.qname()
 		}
 	case 420:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2709
+		//line sql.y:2715
 		{
 			sqlVAL.union.val = sqlDollar[3].union.qname()
 		}
 	case 421:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2715
+		//line sql.y:2721
 		{
 			sqlVAL.union.val = QualifiedNames{sqlDollar[1].union.qname()}
 		}
 	case 422:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2719
+		//line sql.y:2725
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.qnames(), sqlDollar[3].union.qname())
 		}
 	case 423:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2732
+		//line sql.y:2738
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname()}
 		}
 	case 424:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2736
+		//line sql.y:2742
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname(), As: AliasClause{Alias: Name(sqlDollar[2].str)}}
 		}
 	case 425:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2740
+		//line sql.y:2746
 		{
 			sqlVAL.union.val = &AliasedTableExpr{Expr: sqlDollar[1].union.qname(), As: AliasClause{Alias: Name(sqlDollar[3].str)}}
 		}
 	case 426:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2746
+		//line sql.y:2752
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 427:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2750
+		//line sql.y:2756
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 428:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2762
+		//line sql.y:2768
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 		}
 	case 429:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2766
+		//line sql.y:2772
 		{
 			unimplementedWithIssue(2115)
 		}
 	case 430:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2767
+		//line sql.y:2773
 		{
 			unimplementedWithIssue(2115)
 		}
 	case 431:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2770
+		//line sql.y:2776
 		{
 			unimplementedWithIssue(2115)
 		}
 	case 432:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2771
+		//line sql.y:2777
 		{
 			unimplementedWithIssue(2115)
 		}
 	case 433:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2772
+		//line sql.y:2778
 		{
 		}
 	case 439:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2780
+		//line sql.y:2786
 		{
 			unimplemented()
 		}
 	case 440:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2782
+		//line sql.y:2788
 		{
 			sqlVAL.union.val = bytesColTypeBlob
 		}
 	case 441:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2786
+		//line sql.y:2792
 		{
 			sqlVAL.union.val = bytesColTypeBytes
 		}
 	case 442:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2790
+		//line sql.y:2796
 		{
 			sqlVAL.union.val = bytesColTypeBytea
 		}
 	case 443:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2794
+		//line sql.y:2800
 		{
 			sqlVAL.union.val = stringColTypeText
 		}
 	case 444:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2798
+		//line sql.y:2804
 		{
 			sqlVAL.union.val = intColTypeSerial
 		}
 	case 445:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2802
+		//line sql.y:2808
 		{
 			sqlVAL.union.val = intColTypeSmallSerial
 		}
 	case 446:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2806
+		//line sql.y:2812
 		{
 			sqlVAL.union.val = intColTypeBigSerial
 		}
 	case 451:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2827
+		//line sql.y:2833
 		{
 			prec, err := sqlDollar[2].union.numVal().asInt64()
 			if err != nil {
@@ -7022,7 +7023,7 @@ sqldefault:
 		}
 	case 452:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2836
+		//line sql.y:2842
 		{
 			prec, err := sqlDollar[2].union.numVal().asInt64()
 			if err != nil {
@@ -7038,49 +7039,49 @@ sqldefault:
 		}
 	case 453:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2850
+		//line sql.y:2856
 		{
 			sqlVAL.union.val = nil
 		}
 	case 454:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2857
+		//line sql.y:2863
 		{
 			sqlVAL.union.val = intColTypeInt
 		}
 	case 455:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2861
+		//line sql.y:2867
 		{
 			sqlVAL.union.val = intColTypeInt64
 		}
 	case 456:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2865
+		//line sql.y:2871
 		{
 			sqlVAL.union.val = intColTypeInteger
 		}
 	case 457:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2869
+		//line sql.y:2875
 		{
 			sqlVAL.union.val = intColTypeSmallInt
 		}
 	case 458:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2873
+		//line sql.y:2879
 		{
 			sqlVAL.union.val = intColTypeBigInt
 		}
 	case 459:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2877
+		//line sql.y:2883
 		{
 			sqlVAL.union.val = floatColTypeReal
 		}
 	case 460:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2881
+		//line sql.y:2887
 		{
 			prec, err := sqlDollar[2].union.numVal().asInt64()
 			if err != nil {
@@ -7091,13 +7092,13 @@ sqldefault:
 		}
 	case 461:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2890
+		//line sql.y:2896
 		{
 			sqlVAL.union.val = floatColTypeDouble
 		}
 	case 462:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2894
+		//line sql.y:2900
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			if sqlVAL.union.val == nil {
@@ -7108,7 +7109,7 @@ sqldefault:
 		}
 	case 463:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2903
+		//line sql.y:2909
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			if sqlVAL.union.val == nil {
@@ -7119,7 +7120,7 @@ sqldefault:
 		}
 	case 464:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2912
+		//line sql.y:2918
 		{
 			sqlVAL.union.val = sqlDollar[2].union.colType()
 			if sqlVAL.union.val == nil {
@@ -7130,31 +7131,31 @@ sqldefault:
 		}
 	case 465:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2921
+		//line sql.y:2927
 		{
 			sqlVAL.union.val = boolColTypeBoolean
 		}
 	case 466:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2925
+		//line sql.y:2931
 		{
 			sqlVAL.union.val = boolColTypeBool
 		}
 	case 467:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:2931
+		//line sql.y:2937
 		{
 			sqlVAL.union.val = sqlDollar[2].union.numVal()
 		}
 	case 468:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:2935
+		//line sql.y:2941
 		{
 			sqlVAL.union.val = &NumVal{Value: constant.MakeInt64(0)}
 		}
 	case 473:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:2953
+		//line sql.y:2959
 		{
 			n, err := sqlDollar[4].union.numVal().asInt64()
 			if err != nil {
@@ -7165,13 +7166,13 @@ sqldefault:
 		}
 	case 474:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:2964
+		//line sql.y:2970
 		{
 			sqlVAL.union.val = intColTypeBit
 		}
 	case 479:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:2980
+		//line sql.y:2986
 		{
 			n, err := sqlDollar[3].union.numVal().asInt64()
 			if err != nil {
@@ -7187,1644 +7188,1644 @@ sqldefault:
 		}
 	case 480:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:2996
+		//line sql.y:3002
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colType()
 		}
 	case 481:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3002
+		//line sql.y:3008
 		{
 			sqlVAL.union.val = stringColTypeChar
 		}
 	case 482:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3006
+		//line sql.y:3012
 		{
 			sqlVAL.union.val = stringColTypeChar
 		}
 	case 483:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3010
+		//line sql.y:3016
 		{
 			sqlVAL.union.val = stringColTypeVarChar
 		}
 	case 484:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3014
+		//line sql.y:3020
 		{
 			sqlVAL.union.val = stringColTypeString
 		}
 	case 485:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3019
+		//line sql.y:3025
 		{
 		}
 	case 486:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3020
+		//line sql.y:3026
 		{
 		}
 	case 487:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3025
+		//line sql.y:3031
 		{
 			sqlVAL.union.val = dateColTypeDate
 		}
 	case 488:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3029
+		//line sql.y:3035
 		{
 			sqlVAL.union.val = timestampColTypeTimestamp
 		}
 	case 489:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3033
+		//line sql.y:3039
 		{
 			sqlVAL.union.val = timestampColTypeTimestamp
 		}
 	case 490:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3037
+		//line sql.y:3043
 		{
 			sqlVAL.union.val = timestampTzColTypeTimestampWithTZ
 		}
 	case 491:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3041
+		//line sql.y:3047
 		{
 			sqlVAL.union.val = timestampTzColTypeTimestampWithTZ
 		}
 	case 492:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3046
+		//line sql.y:3052
 		{
 			sqlVAL.union.val = intervalColTypeInterval
 		}
 	case 493:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3051
+		//line sql.y:3057
 		{
 			unimplemented()
 		}
 	case 494:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3052
+		//line sql.y:3058
 		{
 			unimplemented()
 		}
 	case 495:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3053
+		//line sql.y:3059
 		{
 			unimplemented()
 		}
 	case 496:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3054
+		//line sql.y:3060
 		{
 			unimplemented()
 		}
 	case 497:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3055
+		//line sql.y:3061
 		{
 			unimplemented()
 		}
 	case 498:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3056
+		//line sql.y:3062
 		{
 			unimplemented()
 		}
 	case 499:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3057
+		//line sql.y:3063
 		{
 			unimplemented()
 		}
 	case 500:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3058
+		//line sql.y:3064
 		{
 			unimplemented()
 		}
 	case 501:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3059
+		//line sql.y:3065
 		{
 			unimplemented()
 		}
 	case 502:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3060
+		//line sql.y:3066
 		{
 			unimplemented()
 		}
 	case 503:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3061
+		//line sql.y:3067
 		{
 			unimplemented()
 		}
 	case 504:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3062
+		//line sql.y:3068
 		{
 			unimplemented()
 		}
 	case 505:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3063
+		//line sql.y:3069
 		{
 			unimplemented()
 		}
 	case 506:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3064
+		//line sql.y:3070
 		{
 		}
 	case 507:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3067
+		//line sql.y:3073
 		{
 			unimplemented()
 		}
 	case 508:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3068
+		//line sql.y:3074
 		{
 			unimplemented()
 		}
 	case 510:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3092
+		//line sql.y:3098
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
 		}
 	case 511:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3095
+		//line sql.y:3101
 		{
 			unimplemented()
 		}
 	case 512:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3096
+		//line sql.y:3102
 		{
 			unimplemented()
 		}
 	case 513:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3105
+		//line sql.y:3111
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 514:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3109
+		//line sql.y:3115
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 515:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3113
+		//line sql.y:3119
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].union.expr()}
 		}
 	case 516:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3117
+		//line sql.y:3123
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 517:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3121
+		//line sql.y:3127
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 518:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3125
+		//line sql.y:3131
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 519:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3129
+		//line sql.y:3135
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Div, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 520:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3133
+		//line sql.y:3139
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: FloorDiv, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 521:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3137
+		//line sql.y:3143
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 522:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3141
+		//line sql.y:3147
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 523:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3145
+		//line sql.y:3151
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 524:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3149
+		//line sql.y:3155
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 525:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3153
+		//line sql.y:3159
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 526:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3157
+		//line sql.y:3163
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 527:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3161
+		//line sql.y:3167
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 528:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3165
+		//line sql.y:3171
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 529:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3169
+		//line sql.y:3175
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 530:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3173
+		//line sql.y:3179
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 531:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3177
+		//line sql.y:3183
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 532:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3181
+		//line sql.y:3187
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 533:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3185
+		//line sql.y:3191
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 534:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3189
+		//line sql.y:3195
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 535:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3193
+		//line sql.y:3199
 		{
 			sqlVAL.union.val = &AndExpr{Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 536:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3197
+		//line sql.y:3203
 		{
 			sqlVAL.union.val = &OrExpr{Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 537:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3201
+		//line sql.y:3207
 		{
 			sqlVAL.union.val = &NotExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 538:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3205
+		//line sql.y:3211
 		{
 			sqlVAL.union.val = &NotExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 539:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3209
+		//line sql.y:3215
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Like, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 540:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3213
+		//line sql.y:3219
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotLike, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 541:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3217
+		//line sql.y:3223
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: SimilarTo, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 542:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3221
+		//line sql.y:3227
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotSimilarTo, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 543:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3225
+		//line sql.y:3231
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 544:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3229
+		//line sql.y:3235
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 545:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3232
+		//line sql.y:3238
 		{
 			unimplemented()
 		}
 	case 546:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3234
+		//line sql.y:3240
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: MakeDBool(true)}
 		}
 	case 547:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3238
+		//line sql.y:3244
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: MakeDBool(true)}
 		}
 	case 548:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3242
+		//line sql.y:3248
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: MakeDBool(false)}
 		}
 	case 549:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3246
+		//line sql.y:3252
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: MakeDBool(false)}
 		}
 	case 550:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3250
+		//line sql.y:3256
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: Is, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 551:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3254
+		//line sql.y:3260
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNot, Left: sqlDollar[1].union.expr(), Right: DNull}
 		}
 	case 552:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3258
+		//line sql.y:3264
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 553:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3262
+		//line sql.y:3268
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[6].union.expr()}
 		}
 	case 554:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3266
+		//line sql.y:3272
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Expr: sqlDollar[1].union.expr(), Types: sqlDollar[5].union.colTypes()}
 		}
 	case 555:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3270
+		//line sql.y:3276
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].union.expr(), Types: sqlDollar[6].union.colTypes()}
 		}
 	case 556:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3274
+		//line sql.y:3280
 		{
 			sqlVAL.union.val = &RangeCond{Left: sqlDollar[1].union.expr(), From: sqlDollar[4].union.expr(), To: sqlDollar[6].union.expr()}
 		}
 	case 557:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3278
+		//line sql.y:3284
 		{
 			sqlVAL.union.val = &RangeCond{Not: true, Left: sqlDollar[1].union.expr(), From: sqlDollar[5].union.expr(), To: sqlDollar[7].union.expr()}
 		}
 	case 558:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3282
+		//line sql.y:3288
 		{
 			sqlVAL.union.val = &RangeCond{Left: sqlDollar[1].union.expr(), From: sqlDollar[4].union.expr(), To: sqlDollar[6].union.expr()}
 		}
 	case 559:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3286
+		//line sql.y:3292
 		{
 			sqlVAL.union.val = &RangeCond{Not: true, Left: sqlDollar[1].union.expr(), From: sqlDollar[5].union.expr(), To: sqlDollar[7].union.expr()}
 		}
 	case 560:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3290
+		//line sql.y:3296
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: In, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 561:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3294
+		//line sql.y:3300
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NotIn, Left: sqlDollar[1].union.expr(), Right: sqlDollar[4].union.expr()}
 		}
 	case 563:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3311
+		//line sql.y:3317
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[1].union.expr(), Type: sqlDollar[3].union.colType()}
 		}
 	case 564:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3315
+		//line sql.y:3321
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryPlus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 565:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3319
+		//line sql.y:3325
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryMinus, Expr: sqlDollar[2].union.expr()}
 		}
 	case 566:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3323
+		//line sql.y:3329
 		{
 			sqlVAL.union.val = &UnaryExpr{Operator: UnaryComplement, Expr: sqlDollar[2].union.expr()}
 		}
 	case 567:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3327
+		//line sql.y:3333
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Plus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 568:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3331
+		//line sql.y:3337
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Minus, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 569:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3335
+		//line sql.y:3341
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mult, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 570:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3339
+		//line sql.y:3345
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Div, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 571:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3343
+		//line sql.y:3349
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: FloorDiv, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 572:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3347
+		//line sql.y:3353
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Mod, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 573:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3351
+		//line sql.y:3357
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 574:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3355
+		//line sql.y:3361
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitxor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 575:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3359
+		//line sql.y:3365
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitand, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 576:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3363
+		//line sql.y:3369
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Bitor, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 577:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3367
+		//line sql.y:3373
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 578:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3371
+		//line sql.y:3377
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GT, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 579:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3375
+		//line sql.y:3381
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: EQ, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 580:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3379
+		//line sql.y:3385
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: Concat, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 581:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3383
+		//line sql.y:3389
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: LShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 582:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3387
+		//line sql.y:3393
 		{
 			sqlVAL.union.val = &BinaryExpr{Operator: RShift, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 583:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3391
+		//line sql.y:3397
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: LE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 584:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3395
+		//line sql.y:3401
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: GE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 585:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3399
+		//line sql.y:3405
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: NE, Left: sqlDollar[1].union.expr(), Right: sqlDollar[3].union.expr()}
 		}
 	case 586:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3403
+		//line sql.y:3409
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[5].union.expr()}
 		}
 	case 587:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3407
+		//line sql.y:3413
 		{
 			sqlVAL.union.val = &ComparisonExpr{Operator: IsNotDistinctFrom, Left: sqlDollar[1].union.expr(), Right: sqlDollar[6].union.expr()}
 		}
 	case 588:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3411
+		//line sql.y:3417
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Expr: sqlDollar[1].union.expr(), Types: sqlDollar[5].union.colTypes()}
 		}
 	case 589:
 		sqlDollar = sqlS[sqlpt-7 : sqlpt+1]
-		//line sql.y:3415
+		//line sql.y:3421
 		{
 			sqlVAL.union.val = &IsOfTypeExpr{Not: true, Expr: sqlDollar[1].union.expr(), Types: sqlDollar[6].union.colTypes()}
 		}
 	case 590:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3427
+		//line sql.y:3433
 		{
 			sqlVAL.union.val = sqlDollar[1].union.qname()
 		}
 	case 592:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3432
+		//line sql.y:3438
 		{
 			sqlVAL.union.val = Placeholder{Name: sqlDollar[1].str}
 		}
 	case 593:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3436
+		//line sql.y:3442
 		{
 			sqlVAL.union.val = &ParenExpr{Expr: sqlDollar[2].union.expr()}
 		}
 	case 596:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3442
+		//line sql.y:3448
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 597:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3446
+		//line sql.y:3452
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 598:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3450
+		//line sql.y:3456
 		{
 			sqlVAL.union.val = &ExistsExpr{Subquery: &Subquery{Select: sqlDollar[2].union.selectStmt()}}
 		}
 	case 599:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3456
+		//line sql.y:3462
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 600:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3460
+		//line sql.y:3466
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 601:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3464
+		//line sql.y:3470
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 602:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3472
+		//line sql.y:3478
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname()}
 		}
 	case 603:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3476
+		//line sql.y:3482
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 604:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3479
+		//line sql.y:3485
 		{
 			unimplemented()
 		}
 	case 605:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:3480
+		//line sql.y:3486
 		{
 			unimplemented()
 		}
 	case 606:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3482
+		//line sql.y:3488
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Type: All, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 607:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3486
+		//line sql.y:3492
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Type: Distinct, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 608:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3490
+		//line sql.y:3496
 		{
 			sqlVAL.union.val = &FuncExpr{Name: sqlDollar[1].union.qname(), Exprs: Exprs{StarExpr()}}
 		}
 	case 609:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3503
+		//line sql.y:3509
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 610:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3507
+		//line sql.y:3513
 		{
 			sqlVAL.union.val = sqlDollar[1].union.expr()
 		}
 	case 611:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3516
+		//line sql.y:3522
 		{
 			unimplemented()
 		}
 	case 612:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3517
+		//line sql.y:3523
 		{
 			unimplemented()
 		}
 	case 613:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3521
+		//line sql.y:3527
 		{
 			unimplemented()
 		}
 	case 614:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3523
+		//line sql.y:3529
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 615:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3527
+		//line sql.y:3533
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 616:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3531
+		//line sql.y:3537
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 617:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3535
+		//line sql.y:3541
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}}
 		}
 	case 618:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3538
+		//line sql.y:3544
 		{
 			unimplemented()
 		}
 	case 619:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3539
+		//line sql.y:3545
 		{
 			unimplemented()
 		}
 	case 620:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3540
+		//line sql.y:3546
 		{
 			unimplemented()
 		}
 	case 621:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3541
+		//line sql.y:3547
 		{
 			unimplemented()
 		}
 	case 622:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3543
+		//line sql.y:3549
 		{
 			sqlVAL.union.val = &CastExpr{Expr: sqlDollar[3].union.expr(), Type: sqlDollar[5].union.colType()}
 		}
 	case 623:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3547
+		//line sql.y:3553
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 624:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3551
+		//line sql.y:3557
 		{
 			sqlVAL.union.val = &OverlayExpr{FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}}
 		}
 	case 625:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3555
+		//line sql.y:3561
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "STRPOS"}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 626:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3559
+		//line sql.y:3565
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 627:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3562
+		//line sql.y:3568
 		{
 			unimplemented()
 		}
 	case 628:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3564
+		//line sql.y:3570
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "BTRIM"}, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 629:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3568
+		//line sql.y:3574
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "LTRIM"}, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 630:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3572
+		//line sql.y:3578
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "RTRIM"}, Exprs: sqlDollar[4].union.exprs()}
 		}
 	case 631:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3576
+		//line sql.y:3582
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: "BTRIM"}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 632:
 		sqlDollar = sqlS[sqlpt-8 : sqlpt+1]
-		//line sql.y:3580
+		//line sql.y:3586
 		{
 			sqlVAL.union.val = &IfExpr{Cond: sqlDollar[3].union.expr(), True: sqlDollar[5].union.expr(), Else: sqlDollar[7].union.expr()}
 		}
 	case 633:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3584
+		//line sql.y:3590
 		{
 			sqlVAL.union.val = &NullIfExpr{Expr1: sqlDollar[3].union.expr(), Expr2: sqlDollar[5].union.expr()}
 		}
 	case 634:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3588
+		//line sql.y:3594
 		{
 			sqlVAL.union.val = &CoalesceExpr{Name: "IFNULL", Exprs: Exprs{sqlDollar[3].union.expr(), sqlDollar[5].union.expr()}}
 		}
 	case 635:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3592
+		//line sql.y:3598
 		{
 			sqlVAL.union.val = &CoalesceExpr{Name: "COALESCE", Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 636:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3596
+		//line sql.y:3602
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 637:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3600
+		//line sql.y:3606
 		{
 			sqlVAL.union.val = &FuncExpr{Name: &QualifiedName{Base: Name(sqlDollar[1].str)}, Exprs: sqlDollar[3].union.exprs()}
 		}
 	case 638:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3606
+		//line sql.y:3612
 		{
 			unimplemented()
 		}
 	case 639:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3607
+		//line sql.y:3613
 		{
 		}
 	case 640:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3610
+		//line sql.y:3616
 		{
 			unimplemented()
 		}
 	case 641:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3611
+		//line sql.y:3617
 		{
 		}
 	case 642:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3615
+		//line sql.y:3621
 		{
 			unimplemented()
 		}
 	case 643:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3616
+		//line sql.y:3622
 		{
 		}
 	case 644:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3619
+		//line sql.y:3625
 		{
 			unimplemented()
 		}
 	case 645:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3620
+		//line sql.y:3626
 		{
 			unimplemented()
 		}
 	case 646:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3623
+		//line sql.y:3629
 		{
 			unimplemented()
 		}
 	case 647:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3626
+		//line sql.y:3632
 		{
 			unimplemented()
 		}
 	case 648:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3627
+		//line sql.y:3633
 		{
 			unimplemented()
 		}
 	case 649:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3628
+		//line sql.y:3634
 		{
 		}
 	case 650:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:3632
+		//line sql.y:3638
 		{
 			unimplemented()
 		}
 	case 651:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3643
+		//line sql.y:3649
 		{
 			unimplemented()
 		}
 	case 652:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3644
+		//line sql.y:3650
 		{
 		}
 	case 653:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3647
+		//line sql.y:3653
 		{
 			unimplemented()
 		}
 	case 654:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3648
+		//line sql.y:3654
 		{
 		}
 	case 655:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3656
+		//line sql.y:3662
 		{
 			unimplemented()
 		}
 	case 656:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3657
+		//line sql.y:3663
 		{
 			unimplemented()
 		}
 	case 657:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3658
+		//line sql.y:3664
 		{
 		}
 	case 658:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3661
+		//line sql.y:3667
 		{
 			unimplemented()
 		}
 	case 659:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3662
+		//line sql.y:3668
 		{
 			unimplemented()
 		}
 	case 660:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3668
+		//line sql.y:3674
 		{
 			unimplemented()
 		}
 	case 661:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3669
+		//line sql.y:3675
 		{
 			unimplemented()
 		}
 	case 662:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3670
+		//line sql.y:3676
 		{
 			unimplemented()
 		}
 	case 663:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3671
+		//line sql.y:3677
 		{
 			unimplemented()
 		}
 	case 664:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3672
+		//line sql.y:3678
 		{
 			unimplemented()
 		}
 	case 665:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3683
+		//line sql.y:3689
 		{
 			sqlVAL.union.val = &Tuple{Exprs: sqlDollar[3].union.exprs(), row: true}
 		}
 	case 666:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3687
+		//line sql.y:3693
 		{
 			sqlVAL.union.val = &Tuple{Exprs: nil, row: true}
 		}
 	case 667:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3691
+		//line sql.y:3697
 		{
 			sqlVAL.union.val = &Tuple{Exprs: append(sqlDollar[2].union.exprs(), sqlDollar[4].union.expr())}
 		}
 	case 668:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3697
+		//line sql.y:3703
 		{
 			sqlVAL.union.val = &Tuple{Exprs: sqlDollar[3].union.exprs(), row: true}
 		}
 	case 669:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3701
+		//line sql.y:3707
 		{
 			sqlVAL.union.val = &Tuple{Exprs: nil, row: true}
 		}
 	case 670:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3707
+		//line sql.y:3713
 		{
 			sqlVAL.union.val = &Tuple{Exprs: append(sqlDollar[2].union.exprs(), sqlDollar[4].union.expr())}
 		}
 	case 671:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3748
+		//line sql.y:3754
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 672:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3752
+		//line sql.y:3758
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 673:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3758
+		//line sql.y:3764
 		{
 			sqlVAL.union.val = []ColumnType{sqlDollar[1].union.colType()}
 		}
 	case 674:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3762
+		//line sql.y:3768
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.colTypes(), sqlDollar[3].union.colType())
 		}
 	case 675:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3768
+		//line sql.y:3774
 		{
 			sqlVAL.union.val = &Array{sqlDollar[2].union.exprs()}
 		}
 	case 676:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3772
+		//line sql.y:3778
 		{
 			sqlVAL.union.val = &Array{sqlDollar[2].union.exprs()}
 		}
 	case 677:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3776
+		//line sql.y:3782
 		{
 			sqlVAL.union.val = &Array{nil}
 		}
 	case 678:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3782
+		//line sql.y:3788
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 679:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3786
+		//line sql.y:3792
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 680:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3792
+		//line sql.y:3798
 		{
 			sqlVAL.union.val = Exprs{&StrVal{s: sqlDollar[1].str}, sqlDollar[3].union.expr()}
 		}
 	case 688:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3814
+		//line sql.y:3820
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr(), sqlDollar[4].union.expr()}
 		}
 	case 689:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3818
+		//line sql.y:3824
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr()}
 		}
 	case 690:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3824
+		//line sql.y:3830
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 691:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3831
+		//line sql.y:3837
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[3].union.expr(), sqlDollar[1].union.expr()}
 		}
 	case 692:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3835
+		//line sql.y:3841
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 693:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3852
+		//line sql.y:3858
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr(), sqlDollar[3].union.expr()}
 		}
 	case 694:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3856
+		//line sql.y:3862
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[3].union.expr(), sqlDollar[2].union.expr()}
 		}
 	case 695:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3860
+		//line sql.y:3866
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), sqlDollar[2].union.expr()}
 		}
 	case 696:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3864
+		//line sql.y:3870
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr(), NewDInt(1), sqlDollar[2].union.expr()}
 		}
 	case 697:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3868
+		//line sql.y:3874
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 698:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3872
+		//line sql.y:3878
 		{
 			sqlVAL.union.val = Exprs(nil)
 		}
 	case 699:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3878
+		//line sql.y:3884
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 700:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3884
+		//line sql.y:3890
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 701:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3890
+		//line sql.y:3896
 		{
 			sqlVAL.union.val = append(sqlDollar[3].union.exprs(), sqlDollar[1].union.expr())
 		}
 	case 702:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3894
+		//line sql.y:3900
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 703:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3898
+		//line sql.y:3904
 		{
 			sqlVAL.union.val = sqlDollar[1].union.exprs()
 		}
 	case 704:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3904
+		//line sql.y:3910
 		{
 			sqlVAL.union.val = &Subquery{Select: sqlDollar[1].union.selectStmt()}
 		}
 	case 705:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3908
+		//line sql.y:3914
 		{
 			sqlVAL.union.val = &Tuple{Exprs: sqlDollar[2].union.exprs()}
 		}
 	case 706:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3919
+		//line sql.y:3925
 		{
 			sqlVAL.union.val = &CaseExpr{Expr: sqlDollar[2].union.expr(), Whens: sqlDollar[3].union.whens(), Else: sqlDollar[4].union.expr()}
 		}
 	case 707:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3926
+		//line sql.y:3932
 		{
 			sqlVAL.union.val = []*When{sqlDollar[1].union.when()}
 		}
 	case 708:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3930
+		//line sql.y:3936
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.whens(), sqlDollar[2].union.when())
 		}
 	case 709:
 		sqlDollar = sqlS[sqlpt-4 : sqlpt+1]
-		//line sql.y:3936
+		//line sql.y:3942
 		{
 			sqlVAL.union.val = &When{Cond: sqlDollar[2].union.expr(), Val: sqlDollar[4].union.expr()}
 		}
 	case 710:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3942
+		//line sql.y:3948
 		{
 			sqlVAL.union.val = sqlDollar[2].union.expr()
 		}
 	case 711:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3946
+		//line sql.y:3952
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 713:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3953
+		//line sql.y:3959
 		{
 			sqlVAL.union.val = Expr(nil)
 		}
 	case 714:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3959
+		//line sql.y:3965
 		{
 			sqlVAL.union.val = sqlDollar[1].union.indirectElem()
 		}
 	case 715:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3963
+		//line sql.y:3969
 		{
 			sqlVAL.union.val = sqlDollar[1].union.indirectElem()
 		}
 	case 716:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:3967
+		//line sql.y:3973
 		{
 			sqlVAL.union.val = &ArrayIndirection{Begin: sqlDollar[2].union.expr()}
 		}
 	case 717:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:3971
+		//line sql.y:3977
 		{
 			sqlVAL.union.val = &ArrayIndirection{Begin: sqlDollar[2].union.expr(), End: sqlDollar[4].union.expr()}
 		}
 	case 718:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3977
+		//line sql.y:3983
 		{
 			sqlVAL.union.val = NameIndirection(sqlDollar[2].str)
 		}
 	case 719:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3983
+		//line sql.y:3989
 		{
 			sqlVAL.union.val = qualifiedStar
 		}
 	case 720:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3989
+		//line sql.y:3995
 		{
 			sqlVAL.union.val = Indirection{sqlDollar[1].union.indirectElem()}
 		}
 	case 721:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:3993
+		//line sql.y:3999
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.indirect(), sqlDollar[2].union.indirectElem())
 		}
 	case 722:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:3998
+		//line sql.y:4004
 		{
 		}
 	case 723:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:3999
+		//line sql.y:4005
 		{
 		}
 	case 725:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4008
+		//line sql.y:4014
 		{
 			sqlVAL.union.val = DefaultVal{}
 		}
 	case 726:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4014
+		//line sql.y:4020
 		{
 			sqlVAL.union.val = Exprs{sqlDollar[1].union.expr()}
 		}
 	case 727:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4018
+		//line sql.y:4024
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.exprs(), sqlDollar[3].union.expr())
 		}
 	case 728:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4027
+		//line sql.y:4033
 		{
 			sqlVAL.union.val = sqlDollar[2].union.exprs()
 		}
 	case 729:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4033
+		//line sql.y:4039
 		{
 			sqlVAL.union.val = SelectExprs{sqlDollar[1].union.selExpr()}
 		}
 	case 730:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4037
+		//line sql.y:4043
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.selExprs(), sqlDollar[3].union.selExpr())
 		}
 	case 731:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4043
+		//line sql.y:4049
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr(), As: Name(sqlDollar[3].str)}
 		}
 	case 732:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4052
+		//line sql.y:4058
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr(), As: Name(sqlDollar[2].str)}
 		}
 	case 733:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4056
+		//line sql.y:4062
 		{
 			sqlVAL.union.val = SelectExpr{Expr: sqlDollar[1].union.expr()}
 		}
 	case 734:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4060
+		//line sql.y:4066
 		{
 			sqlVAL.union.val = starSelectExpr()
 		}
 	case 735:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4068
+		//line sql.y:4074
 		{
 			sqlVAL.union.val = QualifiedNames{sqlDollar[1].union.qname()}
 		}
 	case 736:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4072
+		//line sql.y:4078
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.qnames(), sqlDollar[3].union.qname())
 		}
 	case 737:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4078
+		//line sql.y:4084
 		{
 			sqlVAL.union.val = TableNameWithIndexList{sqlDollar[1].union.tableWithIdx()}
 		}
 	case 738:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4082
+		//line sql.y:4088
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.tableWithIdxList(), sqlDollar[3].union.tableWithIdx())
 		}
 	case 739:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4088
+		//line sql.y:4094
 		{
 			sqlVAL.union.val = QualifiedNames{sqlDollar[1].union.qname()}
 		}
 	case 740:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4092
+		//line sql.y:4098
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.qnames(), sqlDollar[3].union.qname())
 		}
 	case 741:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4103
+		//line sql.y:4109
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 742:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4107
+		//line sql.y:4113
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: sqlDollar[2].union.indirect()}
 		}
 	case 743:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4113
+		//line sql.y:4119
 		{
 			sqlVAL.union.val = &TableNameWithIndex{Table: sqlDollar[1].union.qname(), Index: Name(sqlDollar[3].str)}
 		}
 	case 744:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4124
+		//line sql.y:4130
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 745:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4128
+		//line sql.y:4134
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: Indirection{sqlDollar[2].union.indirectElem()}}
 		}
 	case 746:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4132
+		//line sql.y:4138
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: Indirection{sqlDollar[2].union.indirectElem()}}
 		}
 	case 747:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4136
+		//line sql.y:4142
 		{
 			sqlVAL.union.val = &QualifiedName{Indirect: Indirection{unqualifiedStar}}
 		}
 	case 748:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4142
+		//line sql.y:4148
 		{
 			sqlVAL.union.val = []string{sqlDollar[1].str}
 		}
 	case 749:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4146
+		//line sql.y:4152
 		{
 			sqlVAL.union.val = append(sqlDollar[1].union.strs(), sqlDollar[3].str)
 		}
 	case 750:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4152
+		//line sql.y:4158
 		{
 			sqlVAL.union.val = sqlDollar[2].union.strs()
 		}
 	case 751:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4155
+		//line sql.y:4161
 		{
 		}
 	case 752:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4165
+		//line sql.y:4171
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str)}
 		}
 	case 753:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4169
+		//line sql.y:4175
 		{
 			sqlVAL.union.val = &QualifiedName{Base: Name(sqlDollar[1].str), Indirect: sqlDollar[2].union.indirect()}
 		}
 	case 754:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4176
+		//line sql.y:4182
 		{
 			sqlVAL.union.val = sqlDollar[1].union.numVal()
 		}
 	case 755:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4180
+		//line sql.y:4186
 		{
 			sqlVAL.union.val = sqlDollar[1].union.numVal()
 		}
 	case 756:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4184
+		//line sql.y:4190
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str}
 		}
 	case 757:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4188
+		//line sql.y:4194
 		{
 			sqlVAL.union.val = &StrVal{s: sqlDollar[1].str, bytesEsc: true}
 		}
 	case 758:
 		sqlDollar = sqlS[sqlpt-6 : sqlpt+1]
-		//line sql.y:4191
+		//line sql.y:4197
 		{
 			unimplemented()
 		}
 	case 759:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4193
+		//line sql.y:4199
 		{
 			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType()}
 		}
 	case 760:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4197
+		//line sql.y:4203
 		{
 			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[2].str}, Type: sqlDollar[1].union.colType()}
 		}
 	case 761:
 		sqlDollar = sqlS[sqlpt-5 : sqlpt+1]
-		//line sql.y:4201
+		//line sql.y:4207
 		{
 			sqlVAL.union.val = &CastExpr{Expr: &StrVal{s: sqlDollar[5].str}, Type: sqlDollar[1].union.colType()}
 		}
 	case 762:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4205
+		//line sql.y:4211
 		{
 			sqlVAL.union.val = MakeDBool(true)
 		}
 	case 763:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4209
+		//line sql.y:4215
 		{
 			sqlVAL.union.val = MakeDBool(false)
 		}
 	case 764:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:4213
+		//line sql.y:4219
 		{
 			sqlVAL.union.val = DNull
 		}
 	case 766:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4220
+		//line sql.y:4226
 		{
 			sqlVAL.union.val = sqlDollar[2].union.numVal()
 		}
 	case 767:
 		sqlDollar = sqlS[sqlpt-2 : sqlpt+1]
-		//line sql.y:4224
+		//line sql.y:4230
 		{
 			sqlVAL.union.val = &NumVal{Value: constant.UnaryOp(token.SUB, sqlDollar[2].union.numVal().Value, 0)}
 		}
 	case 772:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4246
+		//line sql.y:4252
 		{
 			sqlVAL.str = ""
 		}
 	case 773:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]
-		//line sql.y:4252
+		//line sql.y:4258
 		{
 			sqlVAL.str = sqlDollar[2].str
 		}
 	case 774:
 		sqlDollar = sqlS[sqlpt-0 : sqlpt+1]
-		//line sql.y:4256
+		//line sql.y:4262
 		{
 			sqlVAL.str = ""
 		}

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -2574,8 +2574,14 @@ table_ref:
   {
     $$.val = &AliasedTableExpr{Expr: &Subquery{Select: $1.selectStmt()}, As: $2.aliasClause()}
   }
-| joined_table { /* SKIP DOC */ }
-| '(' joined_table ')' alias_clause { unimplemented() }
+| joined_table
+  {
+    $$.val = $1.tblExpr()
+  }
+| '(' joined_table ')' alias_clause
+  {
+   $$.val = &AliasedTableExpr{Expr: $2.tblExpr(), As: $4.aliasClause()}
+  }
 
 // It may seem silly to separate joined_table from table_ref, but there is
 // method in SQL's madness: if you don't do it this way you get reduce- reduce
@@ -2610,11 +2616,11 @@ joined_table:
   }
 | table_ref NATURAL join_type JOIN table_ref
   {
-    $$.val = &JoinTableExpr{Join: astNaturalJoin, Left: $1.tblExpr(), Right: $5.tblExpr()}
+    $$.val = &JoinTableExpr{Join: $3, Left: $1.tblExpr(), Right: $5.tblExpr(), Cond: NaturalJoinCond{}}
   }
 | table_ref NATURAL JOIN table_ref
   {
-    $$.val = &JoinTableExpr{Join: astNaturalJoin, Left: $1.tblExpr(), Right: $4.tblExpr()}
+    $$.val = &JoinTableExpr{Join: astJoin, Left: $1.tblExpr(), Right: $4.tblExpr(), Cond: NaturalJoinCond{}}
   }
 
 alias_clause:

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -205,6 +205,7 @@ var _ planNode = &dropDatabaseNode{}
 var _ planNode = &dropTableNode{}
 var _ planNode = &dropIndexNode{}
 var _ planNode = &alterTableNode{}
+var _ planNode = &joinNode{}
 
 // makePlan implements the Planner interface.
 func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, error) {

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -33,7 +33,7 @@ type returningHelper struct {
 	exprs    []parser.TypedExpr
 	qvals    qvalMap
 	rowCount int
-	table    *tableInfo
+	source   *dataSourceInfo
 }
 
 func (p *planner) makeReturningHelper(
@@ -56,14 +56,11 @@ func (p *planner) makeReturningHelper(
 	}
 
 	rh.columns = make([]ResultColumn, 0, len(r))
-	rh.table = &tableInfo{
-		columns: makeResultColumns(tablecols),
-		alias:   alias,
-	}
+	rh.source = newSourceInfoForSingleTable(alias, makeResultColumns(tablecols))
 	rh.qvals = make(qvalMap)
 	rh.exprs = make([]parser.TypedExpr, 0, len(r))
 	for i, target := range r {
-		if isStar, cols, typedExprs, err := checkRenderStar(target, rh.table, rh.qvals); err != nil {
+		if isStar, cols, typedExprs, err := checkRenderStar(target, rh.source, rh.qvals); err != nil {
 			return returningHelper{}, err
 		} else if isStar {
 			rh.exprs = append(rh.exprs, typedExprs...)
@@ -81,7 +78,7 @@ func (p *planner) makeReturningHelper(
 			desired = desiredTypes[i]
 		}
 
-		typedExpr, err := rh.p.analyzeExpr(target.Expr, []*tableInfo{rh.table}, rh.qvals, desired, false, "")
+		typedExpr, err := rh.p.analyzeExpr(target.Expr, multiSourceInfo{rh.source}, rh.qvals, desired, false, "")
 		if err != nil {
 			return returningHelper{}, err
 		}
@@ -98,7 +95,7 @@ func (rh *returningHelper) cookResultRow(rowVals parser.DTuple) (parser.DTuple, 
 		rh.rowCount++
 		return rowVals, nil
 	}
-	rh.qvals.populateQVals(rh.table, rowVals)
+	rh.qvals.populateQVals(rh.source, rowVals)
 	resRow := make(parser.DTuple, len(rh.exprs))
 	for i, e := range rh.exprs {
 		d, err := e.Eval(&rh.p.evalCtx)

--- a/sql/select.go
+++ b/sql/select.go
@@ -22,31 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/util"
-	"github.com/pkg/errors"
 )
-
-// tableInfo contains the information for table used by a select statement. It can be an actual
-// table, or a "virtual table" which is the result of a subquery.
-type tableInfo struct {
-	// alias (if no alias is given and the source is a table, this is the table name)
-	alias string
-
-	// resultColumns which match the node.Columns() 1-to-1. However the column names might be
-	// different if the statement renames them using AS.
-	columns []ResultColumn
-}
-
-// tableSource contains the tableInfo and planNode for a data source
-// for selectNode.
-type tableSource struct {
-	// info containing the result columns and the table alias for qname resolution.
-	info tableInfo
-
-	// plan which can be used to retrieve the data (normally a scanNode). For performance purposes,
-	// this node can be aware of the filters, grouping etc.
-	plan planNode
-}
 
 // selectNode encapsulates the core logic of a select statement: retrieving filtered results from
 // the sources. Grouping, sorting, distinct and limits are implemented on top of this node (as
@@ -61,7 +37,13 @@ type selectNode struct {
 	// source describes where the data is coming from.
 	// populated initially by initFrom().
 	// potentially modified by index selection.
-	source tableSource
+	source planDataSource
+
+	// sourceInfo contains the reference to the dataSourceInfo in the
+	// source planDataSource that is needed for qname resolution.
+	// We keep one instance of multiSourceInfo cached here so as to avoid
+	// re-creating it every time analyzeExpr() is called in addRender().
+	sourceInfo multiSourceInfo
 
 	// Map of qvalues encountered in expressions.
 	// populated by addRender() / checkRenderStar()
@@ -164,7 +146,7 @@ func (s *selectNode) Next() (bool, error) {
 			}
 		}
 		row := s.source.plan.Values()
-		s.qvals.populateQVals(&s.source.info, row)
+		s.qvals.populateQVals(s.source.info, row)
 		passesFilter, err := sqlbase.RunFilter(s.filter, &s.planner.evalCtx)
 		if err != nil {
 			return false, err
@@ -205,14 +187,20 @@ func (s *selectNode) ExplainPlan(v bool) (name, description string, children []p
 	}
 
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "(")
-	for i, col := range s.columns {
+
+	buf.WriteString("from (")
+	for i, col := range s.source.info.sourceColumns {
 		if i > 0 {
-			fmt.Fprintf(&buf, ", ")
+			buf.WriteString(", ")
 		}
-		fmt.Fprintf(&buf, "%s", col.Name)
+		if col.hidden {
+			buf.WriteByte('*')
+		}
+		parser.Name(s.source.info.findTableAlias(i)).Format(&buf, parser.FmtSimple)
+		buf.WriteByte('.')
+		parser.Name(col.Name).Format(&buf, parser.FmtSimple)
 	}
-	fmt.Fprintf(&buf, ")@%s", s.source.info.alias)
+	buf.WriteByte(')')
 
 	name = "render/filter"
 	if s.explain != explainNone {
@@ -303,7 +291,7 @@ func (p *planner) SelectClause(
 
 	s.qvals = make(qvalMap)
 
-	if err := s.initFrom(p, parsed, scanVisibility); err != nil {
+	if err := s.initFrom(parsed, scanVisibility); err != nil {
 		return nil, err
 	}
 
@@ -371,9 +359,9 @@ func (s *selectNode) expandPlan() error {
 		// Find the set of columns that we actually need values for. This is an
 		// optimization to avoid unmarshaling unnecessary values and is also
 		// used for index selection.
-		neededCols := make([]bool, len(s.source.info.columns))
+		neededCols := make([]bool, len(s.source.info.sourceColumns))
 		for i := range neededCols {
-			_, ok := s.qvals[columnRef{&s.source.info, i}]
+			_, ok := s.qvals[columnRef{s.source.info, i}]
 			neededCols[i] = ok
 		}
 		scan.setNeededColumns(neededCols)
@@ -381,7 +369,7 @@ func (s *selectNode) expandPlan() error {
 		// Compute a filter expression for the scan node.
 		convFunc := func(expr parser.VariableExpr) (bool, parser.VariableExpr) {
 			qval := expr.(*qvalue)
-			if qval.colRef.table != &s.source.info {
+			if qval.colRef.source != s.source.info {
 				// TODO(radu): when we will support multiple tables, this
 				// will be a valid case.
 				panic("scan qvalue refers to unknown table")
@@ -441,80 +429,13 @@ func (s *selectNode) expandPlan() error {
 }
 
 // initFrom initializes the table node, given the parsed select expression
-func (s *selectNode) initFrom(
-	p *planner, parsed *parser.SelectClause, scanVisibility scanVisibility,
-) error {
-	from := parsed.From
-	var colAlias parser.NameList
-	var err error
-	switch len(from) {
-	case 0:
-		s.source.plan = &emptyNode{results: true}
-
-	case 1:
-		ate, ok := from[0].(*parser.AliasedTableExpr)
-		if !ok {
-			return util.UnimplementedWithIssueErrorf(2970, "unsupported FROM type %T", from[0])
-		}
-		// AS OF expressions should be handled by the executor.
-		if ate.AsOf.Expr != nil && !p.asOf {
-			return fmt.Errorf("unexpected AS OF SYSTEM TIME")
-		}
-
-		switch expr := ate.Expr.(type) {
-		case *parser.QualifiedName:
-			// Usual case: a table.
-			scan := p.Scan()
-			s.source.info.alias, err = scan.initTable(p, expr, ate.Hints, scanVisibility)
-			if err != nil {
-				return err
-			}
-			s.source.plan = scan
-
-		case *parser.Subquery:
-			// We have a subquery (this includes a simple "VALUES").
-			if ate.As.Alias == "" {
-				return fmt.Errorf("subquery in FROM must have an alias")
-			}
-
-			s.source.plan, err = p.newPlan(expr.Select, nil, false)
-			if err != nil {
-				return err
-			}
-
-		default:
-			panic(fmt.Sprintf("unexpected SimpleTableExpr type: %T", expr))
-		}
-
-		if ate.As.Alias != "" {
-			// If an alias was specified, use that.
-			s.source.info.alias = string(ate.As.Alias)
-		}
-		colAlias = ate.As.Cols
-	default:
-		return util.UnimplementedWithIssueErrorf(2970, "JOINs and SELECTs from multiple tables "+
-			"are not yet supported: %s", from)
+func (s *selectNode) initFrom(parsed *parser.SelectClause, scanVisibility scanVisibility) error {
+	src, err := s.planner.getSources(parsed.From, scanVisibility)
+	if err != nil {
+		return err
 	}
-
-	s.source.info.columns = s.source.plan.Columns()
-	if len(colAlias) > 0 {
-		// Make a copy of the slice since we are about to modify the contents.
-		s.source.info.columns = append([]ResultColumn(nil), s.source.info.columns...)
-
-		// The column aliases can only refer to explicit columns.
-		for colIdx, aliasIdx := 0, 0; aliasIdx < len(colAlias); colIdx++ {
-			if colIdx >= len(s.source.info.columns) {
-				return errors.Errorf(
-					"table \"%s\" has %d columns available but %d columns specified",
-					s.source.info.alias, aliasIdx, len(colAlias))
-			}
-			if s.source.info.columns[colIdx].hidden {
-				continue
-			}
-			s.source.info.columns[colIdx].Name = string(colAlias[aliasIdx])
-			aliasIdx++
-		}
-	}
+	s.source = src
+	s.sourceInfo = multiSourceInfo{s.source.info}
 	return nil
 }
 
@@ -547,7 +468,7 @@ func (s *selectNode) initWhere(where *parser.Where) error {
 	}
 
 	var err error
-	s.filter, err = s.planner.analyzeExpr(where.Expr, []*tableInfo{&s.source.info}, s.qvals,
+	s.filter, err = s.planner.analyzeExpr(where.Expr, s.sourceInfo, s.qvals,
 		parser.TypeBool, true, "WHERE")
 	if err != nil {
 		return err
@@ -567,7 +488,7 @@ func (s *selectNode) initWhere(where *parser.Where) error {
 // "*" into a list of columns. The qvalMap is updated to include all the relevant columns. A
 // ResultColumns and Expr pair is returned for each column.
 func checkRenderStar(
-	target parser.SelectExpr, table *tableInfo, qvals qvalMap,
+	target parser.SelectExpr, src *dataSourceInfo, qvals qvalMap,
 ) (isStar bool, columns []ResultColumn, exprs []parser.TypedExpr, err error) {
 	qname, ok := target.Expr.(*parser.QualifiedName)
 	if !ok {
@@ -580,27 +501,12 @@ func checkRenderStar(
 		return false, nil, nil, nil
 	}
 
-	if table.alias == "" {
-		return false, nil, nil, fmt.Errorf("\"%s\" with no tables specified is not valid", qname)
-	}
 	if target.As != "" {
 		return false, nil, nil, fmt.Errorf("\"%s\" cannot be aliased", qname)
 	}
 
-	// TODO(radu): support multiple FROMs, consolidate with logic in findColumn
-	if tableName := qname.Table(); tableName != "" && !sqlbase.EqualName(table.alias, tableName) {
-		return false, nil, nil, fmt.Errorf("table \"%s\" not found", tableName)
-	}
-
-	for idx, col := range table.columns {
-		if col.hidden {
-			continue
-		}
-		qval := qvals.getQVal(columnRef{table, idx})
-		columns = append(columns, ResultColumn{Name: col.Name, Typ: qval.datum})
-		exprs = append(exprs, qval)
-	}
-	return true, columns, exprs, nil
+	columns, exprs, err = src.expandStar(qname, qvals)
+	return true, columns, exprs, err
 }
 
 // getRenderColName returns the output column name for a render expression.
@@ -619,7 +525,7 @@ func (s *selectNode) addRender(target parser.SelectExpr, desiredType parser.Datu
 	// outputName will be empty if the target is not aliased.
 	outputName := string(target.As)
 
-	if isStar, cols, typedExprs, err := checkRenderStar(target, &s.source.info, s.qvals); err != nil {
+	if isStar, cols, typedExprs, err := checkRenderStar(target, s.source.info, s.qvals); err != nil {
 		return err
 	} else if isStar {
 		s.columns = append(s.columns, cols...)
@@ -632,8 +538,7 @@ func (s *selectNode) addRender(target parser.SelectExpr, desiredType parser.Datu
 	// manipulations to the expression.
 	outputName = getRenderColName(target)
 
-	normalized, err := s.planner.analyzeExpr(target.Expr,
-		[]*tableInfo{&s.source.info}, s.qvals, desiredType, false, "")
+	normalized, err := s.planner.analyzeExpr(target.Expr, s.sourceInfo, s.qvals, desiredType, false, "")
 	if err != nil {
 		return err
 	}
@@ -710,7 +615,7 @@ func (s *selectNode) computeOrdering(fromOrder orderingInfo) orderingInfo {
 	// The rows from the index are ordered by k then by v, but since k is an exact match
 	// column the results are also ordered just by v.
 	for colIdx := range fromOrder.exactMatchCols {
-		colRef := columnRef{&s.source.info, colIdx}
+		colRef := columnRef{s.source.info, colIdx}
 		if renderIdx, ok := s.findRenderIndexForCol(colRef); ok {
 			ordering.addExactMatchColumn(renderIdx)
 		}
@@ -725,7 +630,7 @@ func (s *selectNode) computeOrdering(fromOrder orderingInfo) orderingInfo {
 	// The rows from the index are ordered by k then by v. We cannot make any use of this
 	// ordering as an ordering on v.
 	for _, colOrder := range fromOrder.ordering {
-		colRef := columnRef{&s.source.info, colOrder.ColIdx}
+		colRef := columnRef{s.source.info, colOrder.ColIdx}
 		renderIdx, ok := s.findRenderIndexForCol(colRef)
 		if !ok {
 			return ordering

--- a/sql/select_qvalue_test.go
+++ b/sql/select_qvalue_test.go
@@ -32,8 +32,8 @@ func testInitDummySelectNode(desc *sqlbase.TableDescriptor) *selectNode {
 	sel := &selectNode{}
 	sel.qvals = make(qvalMap)
 	sel.source.plan = scan
-	sel.source.info.alias = desc.Name
-	sel.source.info.columns = scan.Columns()
+	sel.source.info = newSourceInfoForSingleTable(desc.Name, scan.Columns())
+	sel.sourceInfo = multiSourceInfo{sel.source.info}
 
 	return sel
 }
@@ -62,7 +62,7 @@ func TestRetryResolveQNames(t *testing.T) {
 		if len(s.qvals) != 1 {
 			t.Fatalf("%d: expected 1 qvalue, but found %d", i, len(s.qvals))
 		}
-		if _, ok := s.qvals[columnRef{&s.source.info, 0}]; !ok {
+		if _, ok := s.qvals[columnRef{s.source.info, 0}]; !ok {
 			t.Fatalf("%d: unable to find qvalue for column 0 (a)", i)
 		}
 	}

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -105,14 +105,14 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, error)
 				// render target that matches the column name. This handles cases like:
 				//
 				//   SELECT a AS b FROM t ORDER BY a
-				if err := qname.NormalizeColumnName(); err != nil {
+				colIdx, err := s.source.findUnaliasedColumn(qname)
+				if err != nil {
 					return nil, err
 				}
-				if qname.Table() == "" || sqlbase.EqualName(s.source.info.alias, qname.Table()) {
-					qnameCol := sqlbase.NormalizeName(qname.Column())
+				if colIdx != invalidColIdx {
 					for j, r := range s.render {
 						if qval, ok := r.(*qvalue); ok {
-							if sqlbase.NormalizeName(qval.colRef.get().Name) == qnameCol {
+							if qval.colRef.source == s.source.info && qval.colRef.colIdx == colIdx {
 								index = j
 								break
 							}

--- a/sql/table_join.go
+++ b/sql/table_join.go
@@ -1,0 +1,739 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package sql
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/pkg/errors"
+)
+
+type joinType int
+
+const (
+	joinTypeInner joinType = iota
+	joinTypeOuterLeft
+	joinTypeOuterFull
+)
+
+// joinNode is a planNode whose rows are the result of an inner or
+// left/right outer join.
+type joinNode struct {
+	joinType joinType
+
+	// The data sources.
+	left    planNode
+	right   planNode
+	swapped bool
+
+	// pred represents the join predicate.
+	pred joinPredicate
+
+	// columns contains the metadata for the results of this node.
+	columns []ResultColumn
+
+	// output contains the last generated row of results from this node.
+	output parser.DTuple
+
+	// rightRows contains a copy of all rows from the data source on the
+	// right of the join.
+	rightRows *valuesNode
+	// rightMatched remembers which of the right rows have matched in a
+	// full outer join.
+	rightMatched []bool
+
+	// rightIdx indicates the current right row.
+	// In a full outer join, the value becomes negative during
+	// the last pass searching for unmatched right rows.
+	rightIdx int
+
+	// passedFilter turns to true when the current left row has matched
+	// at least one right row.
+	passedFilter bool
+
+	// emptyRight contain tuples of NULL values to use on the
+	// right for outer joins when the filter fails.
+	emptyRight parser.DTuple
+
+	// emptyLeft contains tuples of NULL values to use
+	// on the left for full outer joins when the filter fails.
+	emptyLeft parser.DTuple
+}
+
+type joinPredicate interface {
+	// eval tests whether the current combination of rows passes the
+	// predicate.
+	eval(leftRow parser.DTuple, rightRow parser.DTuple) (bool, error)
+
+	// prepareRow prepares the output row by combining values from the
+	// input data sources.
+	prepareRow(result parser.DTuple, leftRow parser.DTuple, rightRow parser.DTuple)
+
+	// expand and start propagate to embedded sub-queries.
+	expand() error
+	start() error
+
+	// format pretty-prints the predicate for EXPLAIN.
+	format(buf *bytes.Buffer)
+	// explainTypes registers the expression types for EXPLAIN.
+	explainTypes(f func(string, string))
+}
+
+var _ joinPredicate = &onPredicate{}
+var _ joinPredicate = &crossPredicate{}
+var _ joinPredicate = &usingPredicate{}
+
+// prepareRowConcat implement the simple case of CROSS JOIN or JOIN
+// with an ON clause, where the rows of the two inputs are simply
+// concatenated.
+func prepareRowConcat(result parser.DTuple, leftRow parser.DTuple, rightRow parser.DTuple) {
+	copy(result, leftRow)
+	copy(result[len(leftRow):], rightRow)
+}
+
+// crossPredicate implements the predicate logic for CROSS JOIN.  The
+// predicate is always true, the work done here is thus minimal.
+type crossPredicate struct{}
+
+func (p *crossPredicate) eval(_, _ parser.DTuple) (bool, error) {
+	return true, nil
+}
+func (p *crossPredicate) prepareRow(result parser.DTuple, leftRow parser.DTuple, rightRow parser.DTuple) {
+	prepareRowConcat(result, leftRow, rightRow)
+}
+func (p *crossPredicate) start() error                        { return nil }
+func (p *crossPredicate) expand() error                       { return nil }
+func (p *crossPredicate) format(_ *bytes.Buffer)              {}
+func (p *crossPredicate) explainTypes(_ func(string, string)) {}
+
+// onPredicate implements the predicate logic for joins with an ON clause.
+type onPredicate struct {
+	p *planner
+
+	// leftInfo/rightInfo contain the column metadata for the left and
+	// right data sources.
+	leftInfo  *dataSourceInfo
+	rightInfo *dataSourceInfo
+
+	// qvals is needed to resolve qvalues in the filter expression.
+	// TODO(knz) perhaps this is not needed if this node ends up
+	// using IndexedVar (like scanNode) instead of qvalues.
+	qvals  qvalMap
+	filter parser.TypedExpr
+}
+
+// eval for onPredicate uses an arbitrary SQL expression to determine
+// whether the left and right input row can join.
+func (p *onPredicate) eval(leftRow parser.DTuple, rightRow parser.DTuple) (bool, error) {
+	p.qvals.populateQVals(p.leftInfo, leftRow)
+	p.qvals.populateQVals(p.rightInfo, rightRow)
+	return sqlbase.RunFilter(p.filter, &p.p.evalCtx)
+}
+
+func (p *onPredicate) prepareRow(result parser.DTuple, leftRow parser.DTuple, rightRow parser.DTuple) {
+	prepareRowConcat(result, leftRow, rightRow)
+}
+
+func (p *onPredicate) expand() error {
+	return p.p.expandSubqueryPlans(p.filter)
+}
+
+func (p *onPredicate) start() error {
+	return p.p.startSubqueryPlans(p.filter)
+}
+
+func (p *onPredicate) format(buf *bytes.Buffer) {
+	buf.WriteString(" ON ")
+	p.filter.Format(buf, parser.FmtQualify)
+}
+
+func (p *onPredicate) explainTypes(regTypes func(string, string)) {
+	if p.filter != nil {
+		regTypes("filter", parser.AsStringWithFlags(p.filter, parser.FmtShowTypes))
+	}
+}
+
+// makeOnPredicate constructs a joinPredicate object for joins with a
+// ON clause.
+func (p *planner) makeOnPredicate(
+	left, right *dataSourceInfo, expr parser.Expr,
+) (joinPredicate, *dataSourceInfo, error) {
+	// Output rows are the concatenation of input rows.
+	info, err := concatDataSourceInfos(left, right)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Determine the filter expression.
+	qvals := make(qvalMap)
+	colInfo := multiSourceInfo{left, right}
+	filter, err := p.analyzeExpr(expr, colInfo, qvals, parser.TypeBool, true, "ON")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &onPredicate{
+		p:         p,
+		leftInfo:  left,
+		rightInfo: right,
+		qvals:     qvals,
+		filter:    filter,
+	}, info, nil
+}
+
+// usingPredicate implements the predicate logic for joins with a USING clause.
+type usingPredicate struct {
+	// The list of column names given to USING.
+	colNames parser.NameList
+
+	// The comparison function to use for each column. We need
+	// different functions because each USING column may have a different
+	// type (and they may be heterogeneous between left and right).
+	usingCmp []func(*parser.EvalContext, parser.Datum, parser.Datum) (parser.DBool, error)
+	// evalCtx is needed to evaluate the functions in usingCmp.
+	evalCtx *parser.EvalContext
+
+	// left/rightUsingIndices give the position of USING columns
+	// on the left and right input row arrays, respectively.
+	leftUsingIndices  []int
+	rightUsingIndices []int
+
+	// left/rightUsingIndices give the position of non-USING columns on
+	// the left and right input row arrays, respectively.
+	leftRestIndices  []int
+	rightRestIndices []int
+}
+
+func (p *usingPredicate) format(buf *bytes.Buffer) {
+	buf.WriteString(" USING(")
+	p.colNames.Format(buf, parser.FmtSimple)
+	buf.WriteByte(')')
+}
+func (p *usingPredicate) start() error                        { return nil }
+func (p *usingPredicate) expand() error                       { return nil }
+func (p *usingPredicate) explainTypes(_ func(string, string)) {}
+
+// eval for usingPredicate compares the USING columns, returning true
+// if and only if all USING columns are equal on both sides.
+func (p *usingPredicate) eval(leftRow parser.DTuple, rightRow parser.DTuple) (bool, error) {
+	eq := true
+	for i := range p.colNames {
+		leftVal := leftRow[p.leftUsingIndices[i]]
+		rightVal := rightRow[p.rightUsingIndices[i]]
+		if leftVal == parser.DNull || rightVal == parser.DNull {
+			eq = false
+			break
+		}
+		res, err := p.usingCmp[i](p.evalCtx, leftVal, rightVal)
+		if err != nil {
+			return false, err
+		}
+		if res != parser.DBool(true) {
+			eq = false
+			break
+		}
+	}
+	return eq, nil
+}
+
+// prepareRow for usingPredicate has more work to do than for ON
+// clauses and CROSS JOIN: a result row contains first the values for
+// the USING columns; then the non-USING values from the left input
+// row, then the non-USING values from the right input row.
+func (p *usingPredicate) prepareRow(result parser.DTuple, leftRow parser.DTuple, rightRow parser.DTuple) {
+	d := 0
+	for k, j := range p.leftUsingIndices {
+		// The result for USING columns must be computed as per COALESCE().
+		if leftRow[j] != parser.DNull {
+			result[d] = leftRow[j]
+		} else {
+			result[d] = rightRow[p.rightUsingIndices[k]]
+		}
+		d++
+	}
+	for _, j := range p.leftRestIndices {
+		result[d] = leftRow[j]
+		d++
+	}
+	for _, j := range p.rightRestIndices {
+		result[d] = rightRow[j]
+		d++
+	}
+}
+
+// pickUsingColumn searches for a column whose name matches colName.
+// The column index and type are returned if found, otherwise an error
+// is reported.
+func pickUsingColumn(cols []ResultColumn, colName string, context string) (int, parser.Datum, error) {
+	idx := invalidColIdx
+	for j, col := range cols {
+		if col.hidden {
+			continue
+		}
+		if sqlbase.NormalizeName(col.Name) == colName {
+			idx = j
+		}
+	}
+	if idx == invalidColIdx {
+		return idx, nil, fmt.Errorf("column \"%s\" specified in USING clause does not exist in %s table", colName, context)
+	}
+	return idx, cols[idx].Typ, nil
+}
+
+// makeUsingPredicate constructs a joinPredicate object for joins with
+// a USING clause.
+func (p *planner) makeUsingPredicate(
+	left *dataSourceInfo, right *dataSourceInfo, colNames parser.NameList,
+) (joinPredicate, *dataSourceInfo, error) {
+	cmpOps := make([]func(*parser.EvalContext, parser.Datum, parser.Datum) (parser.DBool, error), len(colNames))
+	leftUsingIndices := make([]int, len(colNames))
+	rightUsingIndices := make([]int, len(colNames))
+	usedLeft := make([]int, len(left.sourceColumns))
+	for i := range usedLeft {
+		usedLeft[i] = invalidColIdx
+	}
+	usedRight := make([]int, len(right.sourceColumns))
+	for i := range usedRight {
+		usedRight[i] = invalidColIdx
+	}
+	seenNames := make(map[string]struct{})
+	columns := make([]ResultColumn, 0, len(left.sourceColumns)+len(right.sourceColumns)-len(colNames))
+
+	// Find out which columns are involved in the USING clause.
+	for i, colName := range colNames {
+		colName = sqlbase.NormalizeName(colName)
+
+		// Check for USING(x,x)
+		if _, ok := seenNames[colName]; ok {
+			return nil, nil, fmt.Errorf("column \"%s\" appears more than once in USING clause", colName)
+		}
+		seenNames[colName] = struct{}{}
+
+		// Find the column name on the left.
+		leftIdx, leftType, err := pickUsingColumn(left.sourceColumns, colName, "left")
+		if err != nil {
+			return nil, nil, err
+		}
+		usedLeft[leftIdx] = i
+
+		// Find the column name on the right.
+		rightIdx, rightType, err := pickUsingColumn(right.sourceColumns, colName, "right")
+		if err != nil {
+			return nil, nil, err
+		}
+		usedRight[rightIdx] = i
+
+		// Remember the indices.
+		leftUsingIndices[i] = leftIdx
+		rightUsingIndices[i] = rightIdx
+
+		// Memoize the comparison function.
+		fn, found := parser.FindEqualComparisonFunction(leftType, rightType)
+		if !found {
+			return nil, nil, fmt.Errorf("JOIN/USING types %s and %s for column %s cannot be matched", leftType.Type(), rightType.Type(), colName)
+		}
+		cmpOps[i] = fn
+
+		// Prepare the output column for USING.
+		columns = append(columns, left.sourceColumns[leftIdx])
+	}
+
+	// Find out which columns are not involved in the USING clause.
+	leftRestIndices := make([]int, 0, len(left.sourceColumns)-1)
+	for i := range left.sourceColumns {
+		if usedLeft[i] == invalidColIdx {
+			leftRestIndices = append(leftRestIndices, i)
+			usedLeft[i] = len(columns)
+			columns = append(columns, left.sourceColumns[i])
+		}
+	}
+	rightRestIndices := make([]int, 0, len(right.sourceColumns)-1)
+	for i := range right.sourceColumns {
+		if usedRight[i] == invalidColIdx {
+			rightRestIndices = append(rightRestIndices, i)
+			usedRight[i] = len(columns)
+			columns = append(columns, right.sourceColumns[i])
+		}
+	}
+
+	// Merge the mappings from table aliases to column sets from both
+	// sides into a new alias-columnset mapping for the result rows.
+	aliases := make(sourceAliases)
+	for alias, colRange := range left.sourceAliases {
+		newRange := make([]int, len(colRange))
+		for i, colIdx := range colRange {
+			newRange[i] = usedLeft[colIdx]
+		}
+		aliases[alias] = newRange
+	}
+	for alias, colRange := range right.sourceAliases {
+		newRange := make([]int, len(colRange))
+		for i, colIdx := range colRange {
+			newRange[i] = usedRight[colIdx]
+		}
+		aliases[alias] = newRange
+	}
+
+	info := &dataSourceInfo{
+		sourceColumns: columns,
+		sourceAliases: aliases,
+	}
+
+	return &usingPredicate{
+		evalCtx:           &p.evalCtx,
+		colNames:          colNames,
+		usingCmp:          cmpOps,
+		leftUsingIndices:  leftUsingIndices,
+		rightUsingIndices: rightUsingIndices,
+		leftRestIndices:   leftRestIndices,
+		rightRestIndices:  rightRestIndices,
+	}, info, nil
+}
+
+// commonColumns returns the names of columns common on the
+// right and left sides, for use by NATURAL JOIN.
+func commonColumns(left, right *dataSourceInfo) []string {
+	var res []string
+	for _, cLeft := range left.sourceColumns {
+		if cLeft.hidden {
+			continue
+		}
+		for _, cRight := range right.sourceColumns {
+			if cRight.hidden {
+				continue
+			}
+
+			lName := sqlbase.NormalizeName(cLeft.Name)
+			if lName == sqlbase.NormalizeName(cRight.Name) {
+				res = append(res, lName)
+			}
+		}
+	}
+	return res
+}
+
+// makeJoin constructs a planDataSource for a JOIN node.
+// The tableInfo field from the left node is taken over (overwritten)
+// by the new node.
+func (p *planner) makeJoin(
+	astJoinType string,
+	left planDataSource,
+	right planDataSource,
+	cond parser.JoinCond,
+) (planDataSource, error) {
+	leftInfo, rightInfo := left.info, right.info
+
+	swapped := false
+	var typ joinType
+	switch astJoinType {
+	case "JOIN", "INNER JOIN", "CROSS JOIN":
+		typ = joinTypeInner
+	case "LEFT JOIN":
+		typ = joinTypeOuterLeft
+	case "RIGHT JOIN":
+		left, right = right, left // swap
+		typ = joinTypeOuterLeft
+		swapped = true
+	case "FULL JOIN":
+		typ = joinTypeOuterFull
+	default:
+		return planDataSource{}, errors.Errorf("unsupported JOIN type %T", astJoinType)
+	}
+
+	// Check that the same table name is not used on both sides.
+	for alias := range right.info.sourceAliases {
+		if _, ok := left.info.sourceAliases[alias]; ok {
+			return planDataSource{}, fmt.Errorf("table name \"%s\" specified more than once", alias)
+		}
+	}
+
+	var info *dataSourceInfo
+	var pred joinPredicate
+	var err error
+	if cond == nil {
+		pred = &crossPredicate{}
+		info, err = concatDataSourceInfos(leftInfo, rightInfo)
+	} else {
+		switch t := cond.(type) {
+		case *parser.OnJoinCond:
+			pred, info, err = p.makeOnPredicate(leftInfo, rightInfo, t.Expr)
+		case parser.NaturalJoinCond:
+			cols := commonColumns(leftInfo, rightInfo)
+			pred, info, err = p.makeUsingPredicate(leftInfo, rightInfo, cols)
+		case *parser.UsingJoinCond:
+			pred, info, err = p.makeUsingPredicate(leftInfo, rightInfo, t.Cols)
+		default:
+			err = util.UnimplementedWithIssueErrorf(2970, "unsupported JOIN predicate: %T", cond)
+		}
+	}
+	if err != nil {
+		return planDataSource{}, err
+	}
+
+	return planDataSource{
+		info: info,
+		plan: &joinNode{
+			joinType: typ,
+			left:     left.plan,
+			right:    right.plan,
+			pred:     pred,
+			columns:  info.sourceColumns,
+			swapped:  swapped,
+		},
+	}, nil
+}
+
+// ExplainTypes implements the planNode interface.
+func (n *joinNode) ExplainTypes(regTypes func(string, string)) {
+	n.pred.explainTypes(regTypes)
+}
+
+// SetLimitHint implements the planNode interface.
+func (n *joinNode) SetLimitHint(numRows int64, soft bool) {
+	n.left.SetLimitHint(numRows, soft)
+}
+
+// expandPlan implements the planNode interface.
+func (n *joinNode) expandPlan() error {
+	if err := n.pred.expand(); err != nil {
+		return err
+	}
+	if err := n.left.expandPlan(); err != nil {
+		return err
+	}
+	return n.right.expandPlan()
+}
+
+// ExplainPlan implements the planNode interface.
+func (n *joinNode) ExplainPlan(v bool) (name, description string, children []planNode) {
+	var buf bytes.Buffer
+	switch n.joinType {
+	case joinTypeInner:
+		jType := "INNER"
+		if _, ok := n.pred.(*crossPredicate); ok {
+			jType = "CROSS"
+		}
+		buf.WriteString(jType)
+	case joinTypeOuterLeft:
+		if !n.swapped {
+			buf.WriteString("LEFT OUTER")
+		} else {
+			buf.WriteString("RIGHT OUTER")
+		}
+	case joinTypeOuterFull:
+		buf.WriteString("FULL OUTER")
+	}
+
+	n.pred.format(&buf)
+
+	subplans := []planNode{n.left, n.right}
+	if n.swapped {
+		subplans[0], subplans[1] = subplans[1], subplans[0]
+	}
+	if p, ok := n.pred.(*onPredicate); ok {
+		subplans = p.p.collectSubqueryPlans(p.filter, subplans)
+	}
+
+	return "join", buf.String(), subplans
+}
+
+// Columns implements the planNode interface.
+func (n *joinNode) Columns() []ResultColumn { return n.columns }
+
+// Ordering implements the planNode interface.
+func (n *joinNode) Ordering() orderingInfo { return n.left.Ordering() }
+
+// MarkDebug implements the planNode interface.
+func (n *joinNode) MarkDebug(mode explainMode) {
+	n.left.MarkDebug(mode)
+	n.right.MarkDebug(mode)
+}
+
+// Start implements the planNode interface.
+func (n *joinNode) Start() error {
+	if err := n.pred.start(); err != nil {
+		return err
+	}
+
+	if err := n.left.Start(); err != nil {
+		return err
+	}
+	if err := n.right.Start(); err != nil {
+		return err
+	}
+
+	// Load all the rows from the right side in memory.
+	v := &valuesNode{}
+	for {
+		hasRow, err := n.right.Next()
+		if err != nil {
+			return err
+		}
+		if !hasRow {
+			break
+		}
+		row := n.right.Values()
+		newRow := make([]parser.Datum, len(row))
+		copy(newRow, row)
+		v.rows = append(v.rows, newRow)
+	}
+	if len(v.rows) > 0 {
+		n.rightRows = v
+	}
+
+	// Pre-allocate the space for output rows.
+	n.output = make(parser.DTuple, len(n.columns))
+
+	// If needed, pre-allocate a left row of NULL tuples for when the
+	// join predicate fails to match.
+	if n.joinType == joinTypeOuterLeft || n.joinType == joinTypeOuterFull {
+		n.emptyRight = make(parser.DTuple, len(n.right.Columns()))
+		for i := range n.emptyRight {
+			n.emptyRight[i] = parser.DNull
+		}
+	}
+	// If needed, allocate an array of booleans to remember which
+	// right rows have matched.
+	if n.joinType == joinTypeOuterFull && n.rightRows != nil {
+		n.rightMatched = make([]bool, len(n.rightRows.rows))
+		n.emptyLeft = make(parser.DTuple, len(n.left.Columns()))
+		for i := range n.emptyLeft {
+			n.emptyLeft[i] = parser.DNull
+		}
+	}
+
+	return nil
+}
+
+// Next implements the planNode interface.
+func (n *joinNode) Next() (bool, error) {
+	var leftRow, rightRow parser.DTuple
+	var nRightRows int
+
+	if n.rightRows == nil {
+		if n.joinType != joinTypeOuterLeft && n.joinType != joinTypeOuterFull {
+			// No rows on right; don't even try.
+			return false, nil
+		}
+		nRightRows = 0
+	} else {
+		nRightRows = len(n.rightRows.rows)
+	}
+
+	// We fetch one row at a time until we find one that passes the filter.
+	for {
+		curRightIdx := n.rightIdx
+
+		if curRightIdx < 0 {
+			// Going through the remaining right row of a full outer join.
+			curRightIdx = (-curRightIdx) - 1
+			n.rightIdx--
+			if curRightIdx < nRightRows {
+				if n.rightMatched[curRightIdx] {
+					continue
+				}
+				leftRow = n.emptyLeft
+				rightRow = n.rightRows.rows[curRightIdx]
+				break
+			} else {
+				// Both right and left exhausted.
+				return false, nil
+			}
+		}
+
+		if curRightIdx == 0 {
+			leftHasRow, err := n.left.Next()
+			if err != nil {
+				return false, err
+			}
+
+			if !leftHasRow && n.rightMatched != nil {
+				// Go through the remaining right rows.
+				n.rightIdx = -1
+				continue
+			}
+
+			if !leftHasRow {
+				// Both left and right are exhausted; done.
+				return false, nil
+			}
+		}
+
+		leftRow = n.left.Values()
+
+		if curRightIdx >= nRightRows {
+			n.rightIdx = 0
+			if (n.joinType == joinTypeOuterLeft || n.joinType == joinTypeOuterFull) && !n.passedFilter {
+				// If nothing was emitted in the previous batch of right rows,
+				// insert a tuple of NULLs on the right.
+				rightRow = n.emptyRight
+				if n.swapped {
+					leftRow, rightRow = rightRow, leftRow
+				}
+				break
+			}
+			n.passedFilter = false
+			continue
+		}
+
+		emptyRight := false
+		if nRightRows > 0 {
+			rightRow = n.rightRows.rows[curRightIdx]
+			n.rightIdx = curRightIdx + 1
+		} else {
+			emptyRight = true
+			rightRow = n.emptyRight
+		}
+
+		if n.swapped {
+			leftRow, rightRow = rightRow, leftRow
+		}
+		passesFilter, err := n.pred.eval(leftRow, rightRow)
+		if err != nil {
+			return false, err
+		}
+
+		if passesFilter {
+			n.passedFilter = true
+			if n.rightMatched != nil && !emptyRight {
+				// FULL OUTER JOIN, mark the rows as matched.
+				n.rightMatched[curRightIdx] = true
+			}
+			break
+		}
+	}
+
+	// Got a row from both right and left; prepareRow the result.
+	n.pred.prepareRow(n.output, leftRow, rightRow)
+	return true, nil
+}
+
+// Values implements the planNode interface.
+func (n *joinNode) Values() parser.DTuple {
+	return n.output
+}
+
+// DebugValues implements the planNode interface.
+func (n *joinNode) DebugValues() debugValues {
+	// TODO(knz): not so clear yet how to report DebugValues()
+	// for JOIN.
+	return debugValues{}
+}

--- a/sql/testdata/distinct
+++ b/sql/testdata/distinct
@@ -99,7 +99,7 @@ EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 ----
 Level  Type     Description
 0      distinct
-1      sort     +y + z
+1      sort     +"y + z"
 2      scan     xyz@foo -
 
 query I

--- a/sql/testdata/explain
+++ b/sql/testdata/explain
@@ -4,21 +4,21 @@ EXPLAIN (PLAN) SELECT 1
 Level  Type  Description
 0      empty -
 
-query ITTT colnames
+query ITTTT colnames
 EXPLAIN (PLAN, VERBOSE) SELECT 1
 ----
-Level  Type           Description Ordering
-0      select
-1      render/filter  (1)@
-2      empty           -
+Level  Type           Description    Columns Ordering
+0      select                        ("1")
+1      render/filter  from ()        ("1")
+2      empty          -              ()
 
-query ITTT colnames
+query ITTTT colnames
 EXPLAIN (VERBOSE, PLAN) SELECT 1
 ----
-Level  Type           Description Ordering
-0      select
-1      render/filter  (1)@
-2      empty           -
+Level  Type           Description Columns Ordering
+0      select                     ("1")
+1      render/filter  from ()     ("1")
+2      empty          -           ()
 
 query ITTT colnames
 EXPLAIN (DEBUG) SELECT 1
@@ -61,16 +61,16 @@ statement error unsupported EXPLAIN option
 EXPLAIN (TRACE, UNKNOWN) SELECT 1
 
 # Ensure that tracing results are sorted after gathering
-query ITTT colnames
+query ITTTT colnames
 EXPLAIN(VERBOSE) EXPLAIN(TRACE) SELECT 1
 ----
-Level  Type                  Description   Ordering
-0      select                              +9,+Span Pos
-1      sort                  +9,+Span Pos  +9,+Span Pos
-2      explain               trace
-3      select
-4      render/filter(debug)  (1)@
-5      empty                 -
+Level  Type                  Description    Columns                                                                                      Ordering
+0      select                               ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition) +9,+"Span Pos"
+1      sort                  +9,+"Span Pos" ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition) +9,+"Span Pos"
+2      explain               trace          ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)
+3      select                               (RowIdx, Key, Value, Disposition)
+4      render/filter(debug)  from ()        (RowIdx, Key, Value, Disposition)
+5      empty                 -              ()
 
 # Ensure that all relevant statement types can be explained
 query ITT

--- a/sql/testdata/explain_plan
+++ b/sql/testdata/explain_plan
@@ -20,13 +20,13 @@ EXPLAIN SELECT * FROM t
 Level  Type  Description
 0      scan  t@primary
 
-query ITTT colnames
+query ITTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t
 ----
-Level  Type   Description Ordering
-0      select                    +k,unique
-1      render/filter (k, v)@t    +k,unique
-2      scan          t@primary   +k,unique
+Level  Type          Description      Columns Ordering
+0      select                         (k, v)  +k,unique
+1      render/filter from (t.k, t.v)  (k, v)  +k,unique
+2      scan          t@primary        (k, v)  +k,unique
 
 query ITT colnames
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
@@ -71,13 +71,13 @@ Level  Type     Description
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))
 
-query ITTT colnames
+query ITTTT colnames
 EXPLAIN(VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-Level Type          Description   Ordering
-0     select                      +b
-1     sort          +b            +b
-2     render/filter (a, b)@tc     =a
-3     index-join                  =a,+rowid,unique
-4     scan          tc@c /10-/11  =a,+rowid,unique
-4     scan          tc@primary    +rowid,unique
+Level Type          Description                   Columns               Ordering
+0     select                                      (a, b)                +b
+1     sort          +b                            (a, b)                +b
+2     render/filter from (tc.a, tc.b, *tc.rowid)  (a, b)                =a
+3     index-join                                  (a, b, rowid[hidden]) =a,+rowid,unique
+4     scan          tc@c /10-/11                  (a, b, rowid[hidden]) =a,+rowid,unique
+4     scan          tc@primary                    (a, b, rowid[hidden]) +rowid,unique

--- a/sql/testdata/explain_types
+++ b/sql/testdata/explain_types
@@ -215,10 +215,10 @@ EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 1   render/filter   result     (x int, y int)
 1   render/filter   render 0   (x)[int]
 1   render/filter   render 1   (y)[int]
-2   index-join      result     (x int, y int, rowid int)
-3   scan            result     (x int, y int, rowid int)
+2   index-join      result     (x int, y int, rowid[hidden] int)
+3   scan            result     (x int, y int, rowid[hidden] int)
 3   scan            filter     ((x)[int] < (10)[int])[bool]
-3   scan            result     (x int, y int, rowid int)
+3   scan            result     (x int, y int, rowid[hidden] int)
 3   scan            filter     ((y)[int] > (10)[int])[bool]
 
 query ITTT
@@ -229,7 +229,7 @@ EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10
 1   render/filter   filter     ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]
 1   render/filter   render 0   (x)[int]
 1   render/filter   render 1   (y)[int]
-2   scan            result     (x int, y int, rowid int)
+2   scan            result     (x int, y int, rowid[hidden] int)
 
 query ITTT
 EXPLAIN (TYPES) SELECT $1 + 2 AS a

--- a/sql/testdata/join
+++ b/sql/testdata/join
@@ -1,0 +1,334 @@
+# The join condition logic is tricky to get right with NULL
+# values. Simple implementations can deal well with NULLs on the first
+# or last row but fail to handle them in the middle. So the test table
+# must contain at least 3 rows with a null in the middle. This test
+# table also contains the pair 44/42 so that a test with a non-trivial
+# ON condition can be written.
+statement ok
+CREATE TABLE onecolumn (x INT); INSERT INTO onecolumn(x) VALUES (44), (NULL), (42)
+
+query II colnames
+SELECT * FROM onecolumn AS a(x) CROSS JOIN onecolumn AS b(y)
+----
+   x     y
+  44    44
+  44  NULL
+  44    42
+NULL    44
+NULL  NULL
+NULL    42
+  42    44
+  42  NULL
+  42    42
+
+query II colnames
+SELECT * FROM onecolumn AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
+----
+ x  y
+44 44
+42 42
+
+query I colnames
+SELECT * FROM onecolumn AS a JOIN onecolumn as b USING(x)
+----
+ x
+44
+42
+
+query I colnames
+SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn as b
+----
+ x
+44
+42
+
+query II colnames
+SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+----
+   x     y
+  44    44
+NULL  NULL
+  42    42
+
+query I colnames
+SELECT * FROM onecolumn AS a LEFT OUTER JOIN onecolumn AS b USING(x)
+----
+   x
+  44
+NULL
+  42
+
+query I colnames
+SELECT * FROM onecolumn AS a NATURAL LEFT OUTER JOIN onecolumn AS b
+----
+   x
+  44
+NULL
+  42
+
+query II colnames
+SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+----
+   x     y
+  44    44
+NULL  NULL
+  42    42
+
+query I colnames
+SELECT * FROM onecolumn AS a RIGHT OUTER JOIN onecolumn AS b USING(x)
+----
+   x
+  44
+NULL
+  42
+
+query I colnames
+SELECT * FROM onecolumn AS a NATURAL RIGHT OUTER JOIN onecolumn AS b
+----
+   x
+  44
+NULL
+  42
+
+statement ok
+CREATE TABLE onecolumn_w(w INT); INSERT INTO onecolumn_w(w) VALUES (42),(43)
+
+query II colnames
+SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn_w as b
+----
+   x  w
+  44  42
+  44  43
+NULL  42
+NULL  43
+  42  42
+  42  43
+
+statement ok
+CREATE TABLE othercolumn (x INT); INSERT INTO othercolumn(x) VALUES (43),(42),(16)
+
+query II colnames
+SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b ON a.x = b.x ORDER BY a.x,b.x
+----
+x    x
+NULL NULL
+NULL 16
+NULL 43
+42   42
+44   NULL
+
+query I colnames
+SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b USING(x) ORDER BY x
+----
+x
+NULL
+16
+42
+43
+44
+
+query I colnames
+SELECT * FROM onecolumn AS a NATURAL FULL OUTER JOIN othercolumn AS b ORDER BY x
+----
+x
+NULL
+16
+42
+43
+44
+
+statement ok
+CREATE TABLE empty (x INT)
+
+query II
+SELECT * FROM onecolumn AS a(x) CROSS JOIN empty AS b(y)
+----
+
+query II
+SELECT * FROM empty AS a CROSS JOIN onecolumn AS b
+----
+
+query II
+SELECT * FROM onecolumn AS a(x) JOIN empty AS b(y) ON a.x = b.y
+----
+
+query I
+SELECT * FROM onecolumn AS a JOIN empty AS b USING(x)
+----
+
+query II
+SELECT * FROM empty AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
+----
+
+query I
+SELECT * FROM empty AS a JOIN onecolumn AS b USING(x)
+----
+
+query II colnames
+SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN empty AS b(y) ON a.x = b.y
+----
+x    y
+44   NULL
+NULL NULL
+42   NULL
+
+query I colnames
+SELECT * FROM onecolumn AS a LEFT OUTER JOIN empty AS b USING(x)
+----
+x
+44
+NULL
+42
+
+query II
+SELECT * FROM empty AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+----
+
+query I
+SELECT * FROM empty AS a LEFT OUTER JOIN onecolumn AS b USING(x)
+----
+
+query II
+SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN empty AS b(y) ON a.x = b.y
+----
+
+query I
+SELECT * FROM onecolumn AS a RIGHT OUTER JOIN empty AS b USING(x)
+----
+
+query II colnames
+SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+----
+x    y
+NULL 44
+NULL NULL
+NULL 42
+
+query I colnames
+SELECT * FROM empty AS a FULL OUTER JOIN onecolumn AS b USING(x)
+----
+x
+44
+NULL
+42
+
+query II colnames
+SELECT * FROM onecolumn AS a(x) FULL OUTER JOIN empty AS b(y) ON a.x = b.y
+----
+x    y
+44   NULL
+NULL NULL
+42   NULL
+
+query I colnames
+SELECT * FROM onecolumn AS a FULL OUTER JOIN empty AS b USING(x)
+----
+x
+44
+NULL
+42
+
+query II colnames
+SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+----
+x    y
+NULL 44
+NULL NULL
+NULL 42
+
+query I colnames
+SELECT * FROM empty AS a FULL OUTER JOIN onecolumn AS b USING(x)
+----
+x
+44
+NULL
+42
+
+statement ok
+CREATE TABLE twocolumn (x INT, y INT); INSERT INTO twocolumn(x, y) VALUES (44,51), (NULL,52), (42,53)
+
+# Natural joins with partial match
+query II colnames
+SELECT * FROM onecolumn NATURAL JOIN twocolumn;
+----
+x    y
+44   51
+42   53
+
+# Check column orders and names.
+query IIIIII colnames
+SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
+----
+x  x  y  b  d  e
+44 44 51 44 44 51
+
+# Check EXPLAIN.
+query ITT
+EXPLAIN SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
+----
+0  limit  count: 1
+1  join   INNER ON (a.b = c.d) AND (c.d = onecolumn.x)
+2  join   INNER ON a.b = twocolumn.x
+3  join   CROSS
+4  scan   onecolumn@primary (max 1 row)
+4  scan   twocolumn@primary
+3  scan   onecolumn@primary
+2  scan   twocolumn@primary
+
+# Check sub-queries in ON conditions.
+query III colnames
+SELECT * FROM onecolumn JOIN twocolumn ON twocolumn.x = onecolumn.x AND onecolumn.x IN (SELECT x FROM twocolumn WHERE y >= 52)
+----
+x    x    y
+42   42   53
+
+# Check sub-queries as data sources.
+query I colnames
+SELECT * FROM onecolumn JOIN (VALUES (41),(42),(43)) AS a(x) USING(x)
+----
+x
+42
+
+query I colnames
+SELECT * FROM onecolumn JOIN (SELECT x + 2 AS x FROM onecolumn) USING(x)
+----
+x
+44
+
+# Check that a single column can have multiple table aliases.
+query IIII colnames
+SELECT * FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x)) LIMIT 1
+----
+x  y  y  y
+44 51 51 51
+
+query IIIIII colnames
+SELECT a.x, b.x, c.x, a.y, b.y, c.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x))
+----
+x    x    x    y  y  y
+44   44   44   51 51 51
+42   42   42   53 53 53
+
+query error column.*in USING clause does not exist
+SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(y))
+
+query error column.*appears more than once in USING clause
+SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(x, x))
+
+statement ok
+CREATE TABLE othertype (x TEXT);
+
+query error JOIN/USING types.*cannot be matched
+SELECT * FROM (onecolumn AS a JOIN othertype AS b USING(x))
+
+query error table name.*specified more than once
+SELECT * FROM (onecolumn JOIN onecolumn USING(x))
+
+query error table name.*specified more than once
+SELECT * FROM (onecolumn JOIN twocolumn USING(x) JOIN onecolumn USING(x))
+
+query error column reference.*is ambiguous
+SELECT * FROM (onecolumn AS a JOIN onecolumn AS b ON x > 32)
+
+query error qualified name.*not found
+SELECT * FROM (onecolumn AS a JOIN onecolumn AS b ON a.y > y)

--- a/sql/testdata/select
+++ b/sql/testdata/select
@@ -119,8 +119,16 @@ a NULL
 query error table "foo" not found
 SELECT foo.* FROM kv
 
-query error "*" with no tables specified is not valid
+query error cannot use "\*" without a FROM clause
 SELECT *
+
+# "*" must expand to zero columns if there are zero columns to select.
+statement ok
+CREATE TABLE nocols(x INT); ALTER TABLE nocols DROP COLUMN x
+
+query I
+SELECT 1, * FROM nocols
+----
 
 query error "kv.*" cannot be aliased
 SELECT kv.* AS foo FROM kv

--- a/sql/testdata/subquery
+++ b/sql/testdata/subquery
@@ -173,8 +173,11 @@ SELECT * FROM (VALUES (1, 2)) AS foo
 column1 column2
 1 2
 
-query error subquery in FROM must have an alias
+query II colnames
 SELECT * FROM (VALUES (1, 2))
+----
+column1 column2
+1 2
 
 query IT colnames
 SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS foo
@@ -307,15 +310,15 @@ INSERT INTO xyz (x, y, z) VALUES (13, 11, 12) RETURNING (y IN (SELECT y FROM xyz
 true
 
 # check that residual filters are not expanded twice
-query ITTT
+query ITTTT
 EXPLAIN(VERBOSE) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz);
 ----
-0 select                          +x,unique
-1 render/filter  (x)@xyz          +x,unique
-2 scan           xyz@primary  -   +x,unique
-3 select                          +x,unique
-4 render/filter  (x)@xyz          +x,unique
-5 scan           xyz@primary      +x,unique
+0 select                                    (x)        +x,unique
+1 render/filter  from (xyz.x, xyz.y, xyz.z) (x)        +x,unique
+2 scan           xyz@primary  -             (x, y, z)  +x,unique
+3 select                                    (x)        +x,unique
+4 render/filter  from (xyz.x, xyz.y, xyz.z) (x)        +x,unique
+5 scan           xyz@primary                (x, y, z)  +x,unique
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not

--- a/sql/upsert.go
+++ b/sql/upsert.go
@@ -33,8 +33,8 @@ type upsertHelper struct {
 	p                  *planner
 	qvals              qvalMap
 	evalExprs          []parser.TypedExpr
-	table              *tableInfo
-	excludedAliasTable *tableInfo
+	sourceInfo         *dataSourceInfo
+	excludedSourceInfo *dataSourceInfo
 	allExprsIdentity   bool
 }
 
@@ -88,31 +88,29 @@ func (p *planner) makeUpsertHelper(
 		}
 	}
 
-	table := &tableInfo{alias: tableDesc.Name, columns: makeResultColumns(tableDesc.Columns)}
-	excludedAliasTable := &tableInfo{
-		alias:   upsertExcludedTable,
-		columns: makeResultColumns(insertCols),
-	}
-	tables := []*tableInfo{table, excludedAliasTable}
+	sourceInfo := newSourceInfoForSingleTable(tableDesc.Name, makeResultColumns(tableDesc.Columns))
+	excludedSourceInfo := newSourceInfoForSingleTable(upsertExcludedTable, makeResultColumns(insertCols))
 
-	var normExprs []parser.TypedExpr
+	var evalExprs []parser.TypedExpr
 	qvals := make(qvalMap)
+	sources := multiSourceInfo{sourceInfo, excludedSourceInfo}
 	for _, expr := range untupledExprs {
-		normExpr, err := p.analyzeExpr(expr, tables, qvals, parser.NoTypePreference, false, "")
+		normExpr, err := p.analyzeExpr(expr, sources, qvals, parser.NoTypePreference, false, "")
 		if err != nil {
 			return nil, err
 		}
-		normExprs = append(normExprs, normExpr)
+		evalExprs = append(evalExprs, normExpr)
 	}
 
 	helper := &upsertHelper{
 		p:                  p,
 		qvals:              qvals,
-		evalExprs:          normExprs,
-		table:              table,
-		excludedAliasTable: excludedAliasTable,
+		evalExprs:          evalExprs,
+		sourceInfo:         sourceInfo,
+		excludedSourceInfo: excludedSourceInfo,
 		allExprsIdentity:   allExprsIdentity,
 	}
+
 	return helper, nil
 }
 
@@ -139,8 +137,8 @@ func (uh *upsertHelper) start() error {
 func (uh *upsertHelper) eval(
 	insertRow parser.DTuple, existingRow parser.DTuple,
 ) (parser.DTuple, error) {
-	uh.qvals.populateQVals(uh.table, existingRow)
-	uh.qvals.populateQVals(uh.excludedAliasTable, insertRow)
+	uh.qvals.populateQVals(uh.sourceInfo, existingRow)
+	uh.qvals.populateQVals(uh.excludedSourceInfo, insertRow)
 
 	var err error
 	ret := make([]parser.Datum, len(uh.evalExprs))


### PR DESCRIPTION
This patch provides a first implementation of JOIN.

Summary:
- `CROSS JOIN`, `INNER JOIN`, `JOIN`, and `LEFT/FULL/RIGHT OUTER JOIN`
  as well as implicit cross joins in FROM clauses
  (`FROM x, y`) should report correct results.
- this introduces a new `joinNode` in charge of joins. Although all
  joins are not supported yet, the various forms of JOIN are now
  recognized and expanded as a `planNode`, so they can be `EXPLAIN`ed
  too.
- this patch largely refactors `selectNode.initFrom`, by cristallizing
  the notion of "data source" which was previously only implicit. See
  the comments at the start of the (new) `sql/data_source.go` for an
  overview.
- the qname resolution logic and qvalue handling is adjusted accordingly.
- `EXPLAIN(VERBOSE)` is extended to account for multiple input table
  aliases in a JOIN clause (or multiple FROM).

See #2970 for some background.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7202)

<!-- Reviewable:end -->
