### PR TITLE
kv: ShouldDrain() at the start of a select to exit quickly

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -599,6 +599,8 @@ func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context, txnID uuid.UUID) {
 	// Loop with ticker for periodic heartbeats.
 	for {
 		select {
+		case <-tc.stopper.ShouldDrain():
+			return
 		case <-tickChan:
 			if !tc.heartbeat(ctx, txnID) {
 				return
@@ -613,8 +615,6 @@ func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context, txnID uuid.UUID) {
 			// then heartbeat loop ignores the timeout check and this case is
 			// responsible for client timeouts.
 			tc.tryAsyncAbort(txnID)
-			return
-		case <-tc.stopper.ShouldDrain():
 			return
 		}
 	}


### PR DESCRIPTION
This allows the heartbeatLoop to exit before the next heartbeat is sent. In the event heartbeats are delayed beyond the 5 second interval, heartbeatLoop can loop forever.

fixes #7168  #7183 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7203)

<!-- Reviewable:end -->
