### PR TITLE
sql/pgwire: Use correct error on session args parse failure

### DIFF
--- a/sql/pgwire/server.go
+++ b/sql/pgwire/server.go
@@ -204,7 +204,7 @@ func (s *Server) ServeConn(conn net.Conn) error {
 		v3conn := makeV3Conn(conn, s.executor, s.metrics, sessionArgs)
 		defer v3conn.finish()
 		if argsErr != nil {
-			return v3conn.sendInternalError(err.Error())
+			return v3conn.sendInternalError(argsErr.Error())
 		}
 		if errSSLRequired {
 			return v3conn.sendInternalError(ErrSSLRequired)


### PR DESCRIPTION
Previously we were using the wrong error here, and would have probably
crashed with a NPE. There's really no test code to stress our Postgres
wire protocol implementation (that I could find), so hacking in a test
for this wont be useful. We might want to consider either building up
tests around `pgwire` or trying to adapt some of PG's.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7231)

<!-- Reviewable:end -->
