### PR TITLE
client: Update zero txn timestamp when processing an elided end txn

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -666,7 +666,12 @@ func (txn *Txn) send(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.
 	if elideEndTxn && pErr == nil {
 		// Check that read only transactions do not violate their deadline.
 		if endTxnRequest.Deadline != nil {
-			if endTxnRequest.Deadline.Less(txn.Proto.Timestamp) {
+			t := txn.Proto.Timestamp
+			if t.Equal(roachpb.ZeroTimestamp) {
+				// Update the timstamp as BatchRequest.SetActiveTimestamp does.
+				t = txn.Proto.OrigTimestamp
+			}
+			if endTxnRequest.Deadline.Less(t) {
 				return nil, roachpb.NewErrorf(
 					"read-only txn timestamp violates deadline: %s < %s",
 					endTxnRequest.Deadline,


### PR DESCRIPTION
Not sure this makes sense (or matters in practice), but noticed while debugging.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7239)

<!-- Reviewable:end -->
