### PR TITLE
sql: read backward-comptatible data using colfamilies

### DIFF
--- a/sql/sqlbase/rowfetcher.go
+++ b/sql/sqlbase/rowfetcher.go
@@ -20,8 +20,10 @@ package sqlbase
 import (
 	"bytes"
 	"fmt"
+	"math"
 
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util"
@@ -78,6 +80,7 @@ type RowFetcher struct {
 	implicitVals     []parser.Datum // the implicit values for unique indexes
 	indexKey         []byte         // the index key of the current row
 	row              parser.DTuple
+	prettyValueBuf   bytes.Buffer
 
 	// The current key/value, unless kvEnd is true.
 	kv    client.KeyValue
@@ -270,35 +273,24 @@ func (rf *RowFetcher) ProcessKV(kv client.KeyValue, debugStrings bool) (
 	}
 
 	if !rf.isSecondaryIndex && len(remaining) > 0 {
-		_, colID, err := encoding.DecodeUvarintAscending(remaining)
+		_, familyID, err := encoding.DecodeUvarintAscending(remaining)
 		if err != nil {
 			return "", "", err
 		}
 
-		idx, ok := rf.colIdxMap[ColumnID(colID)]
-		if ok && (debugStrings || rf.valNeededForCol[idx]) {
-			if debugStrings {
-				prettyKey = fmt.Sprintf("%s/%s", prettyKey, rf.cols[idx].Name)
-			}
-			kind := rf.cols[idx].Type.Kind
-			value, err := UnmarshalColumnValue(&rf.alloc, kind, kv.Value)
-			if err != nil {
-				return "", "", err
-			}
-			prettyValue = value.String()
-			if rf.row[idx] != nil {
-				panic(fmt.Sprintf("duplicate value for column %d", idx))
-			}
-			rf.row[idx] = value
-			if log.V(3) {
-				log.Infof("Scan %s -> %v", kv.Key, value)
-			}
-		} else {
-			// No need to unmarshal the column value. Either the column was part of
-			// the index key or it isn't needed.
-			if log.V(3) {
-				log.Infof("Scan %s -> [%d] (skipped)", kv.Key, colID)
-			}
+		family, err := rf.desc.FindFamilyByID(FamilyID(familyID))
+		if err != nil {
+			return "", "", err
+		}
+
+		switch kv.Value.GetTag() {
+		case roachpb.ValueType_TUPLE:
+			prettyKey, prettyValue, err = rf.processValueTuple(family, kv, debugStrings, prettyKey)
+		default:
+			prettyKey, prettyValue, err = rf.processValueSingle(family, kv, debugStrings, prettyKey)
+		}
+		if err != nil {
+			return "", "", err
 		}
 	} else {
 		if rf.implicitVals != nil {
@@ -332,6 +324,128 @@ func (rf *RowFetcher) ProcessKV(kv client.KeyValue, debugStrings bool) (
 		prettyValue = parser.DNull.String()
 	}
 
+	return prettyKey, prettyValue, nil
+}
+
+// processValueSingle processes the given value (of column
+// family.DefaultColumnID), setting values in the rf.row accordingly. The key is
+// only used for logging.
+func (rf *RowFetcher) processValueSingle(
+	family *ColumnFamilyDescriptor, kv client.KeyValue, debugStrings bool, prettyKeyPrefix string,
+) (prettyKey string, prettyValue string, err error) {
+	prettyKey = prettyKeyPrefix
+
+	colID := family.DefaultColumnID
+	if colID == 0 {
+		// If this is the sentinel family, a value is not expected, so we're done.
+		// Otherwise, this means something went wrong in the TableDescriptor
+		// bookkeeping.
+		if family.ID == keys.SentinelFamilyID {
+			return "", "", nil
+		}
+		return "", "", util.Errorf("single entry value with no default column id")
+	}
+
+	idx, ok := rf.colIdxMap[colID]
+	if ok && (debugStrings || rf.valNeededForCol[idx]) {
+		if debugStrings {
+			prettyKey = fmt.Sprintf("%s/%s", prettyKey, rf.desc.Columns[idx].Name)
+		}
+		kind := rf.cols[idx].Type.Kind
+		// TODO(dan): Once we decide if we're changing the tuple encoding, see if we
+		// can get rid of UnmarshalColumnValue in favor of DecodeTableValue.
+		value, err := UnmarshalColumnValue(&rf.alloc, kind, kv.Value)
+		if err != nil {
+			return "", "", err
+		}
+		if debugStrings {
+			prettyValue = value.String()
+		}
+		if rf.row[idx] != nil {
+			panic(fmt.Sprintf("duplicate value for column %d", idx))
+		}
+		rf.row[idx] = value
+		if log.V(3) {
+			log.Infof("Scan %s -> %v", kv.Key, value)
+		}
+	} else {
+		// No need to unmarshal the column value. Either the column was part of
+		// the index key or it isn't needed.
+		if log.V(3) {
+			log.Infof("Scan %s -> [%d] (skipped)", kv.Key, colID)
+		}
+	}
+
+	return prettyKey, prettyValue, nil
+}
+
+// processValueTuple processes the given values (of columns family.ColumnIDs),
+// setting values in the rf.row accordingly. The key is only used for logging.
+func (rf *RowFetcher) processValueTuple(
+	family *ColumnFamilyDescriptor, kv client.KeyValue, debugStrings bool, prettyKeyPrefix string,
+) (prettyKey string, prettyValue string, err error) {
+	prettyKey = prettyKeyPrefix
+	if debugStrings {
+		rf.prettyValueBuf.Reset()
+	}
+
+	tupleBytes, err := kv.Value.GetTuple()
+	if err != nil {
+		return "", "", err
+	}
+
+	var colIDRaw int64
+	var value parser.Datum
+	for len(tupleBytes) > 0 {
+		tupleBytes, _, colIDRaw, err = encoding.DecodeNonsortingVarint(tupleBytes)
+		if err != nil {
+			return "", "", err
+		}
+		if colIDRaw < 0 || colIDRaw > math.MaxUint32 {
+			return "", "", util.Errorf("invalid column-id: %d", colIDRaw)
+		}
+		idx, ok := rf.colIdxMap[ColumnID(colIDRaw)]
+		// TODO(dan): Ideally rowFetcher would generate EncDatums instead of Datums
+		// and that would make the logic simpler. We won't need valNeededForCol at
+		// all, it would be up to the user of the class to decide if they want to
+		// decode them or not.
+		if !ok || !rf.valNeededForCol[idx] {
+			// This column wasn't requested, so read its length and skip it.
+			i, err := roachpb.PeekValueLength(tupleBytes)
+			if err != nil {
+				return "", "", err
+			}
+			tupleBytes = tupleBytes[i:]
+			if log.V(3) {
+				log.Infof("Scan %s -> [%d] (skipped)", kv.Key, colIDRaw)
+			}
+			continue
+		}
+
+		if debugStrings {
+			prettyKey = fmt.Sprintf("%s/%s", prettyKey, rf.desc.Columns[idx].Name)
+		}
+
+		kind := rf.cols[idx].Type.Kind.ToDatumType()
+		value, tupleBytes, err = DecodeTableValue(&rf.alloc, kind, tupleBytes)
+		if err != nil {
+			return "", "", err
+		}
+		if debugStrings {
+			fmt.Fprintf(&rf.prettyValueBuf, "/%v", value)
+		}
+		if rf.row[idx] != nil {
+			panic(fmt.Sprintf("duplicate value for column %d", idx))
+		}
+		rf.row[idx] = value
+		if log.V(3) {
+			log.Infof("Scan %d -> %v", idx, value)
+		}
+	}
+
+	if debugStrings {
+		prettyValue = rf.prettyValueBuf.String()
+	}
 	return prettyKey, prettyValue, nil
 }
 

--- a/sql/sqlbase/structured.go
+++ b/sql/sqlbase/structured.go
@@ -851,6 +851,16 @@ func (desc *TableDescriptor) FindActiveColumnByID(id ColumnID) (*ColumnDescripto
 	return nil, fmt.Errorf("column-id \"%d\" does not exist", id)
 }
 
+// FindFamilyByID finds the family with specified ID.
+func (desc *TableDescriptor) FindFamilyByID(id FamilyID) (*ColumnFamilyDescriptor, error) {
+	for i, f := range desc.Families {
+		if f.ID == id {
+			return &desc.Families[i], nil
+		}
+	}
+	return nil, fmt.Errorf("family-id \"%d\" does not exist", id)
+}
+
 // FindIndexByName finds the index with the specified name. It returns
 // DescriptorStatus for the index, and an index into either the indexes
 // (status == DescriptorActive) or mutations (status == DescriptorIncomplete).


### PR DESCRIPTION
The family descriptors are still being generated only in a way that creates backwards compatible data in kv.

Benchmarks are flat

name                                old time/op    new time/op    delta
Select1_Cockroach-8                   66.6µs ± 8%    65.7µs ± 1%     ~             (p=0.841 n=5+5)
Select2_Cockroach-8                    705µs ± 1%     708µs ± 3%     ~             (p=0.841 n=5+5)
Select3_Cockroach-8                    993µs ± 3%    1010µs ± 3%     ~             (p=0.151 n=5+5)
Insert1_Cockroach-8                    303µs ± 2%     303µs ± 1%     ~             (p=0.841 n=5+5)
Insert10_Cockroach-8                   444µs ± 2%     442µs ± 2%     ~             (p=0.841 n=5+5)
Insert100_Cockroach-8                 1.37ms ± 3%    1.38ms ± 5%     ~             (p=0.548 n=5+5)
Insert1000_Cockroach-8                10.2ms ± 4%    10.1ms ± 2%     ~             (p=0.841 n=5+5)
Update1_Cockroach-8                    505µs ± 1%     497µs ± 2%     ~             (p=0.190 n=4+5)
Update10_Cockroach-8                   855µs ± 1%     850µs ± 2%     ~             (p=0.421 n=5+5)
Update100_Cockroach-8                 3.66ms ± 1%    3.64ms ± 4%     ~             (p=0.222 n=5+5)
Update1000_Cockroach-8                30.3ms ± 6%    29.9ms ± 3%     ~             (p=0.690 n=5+5)
Delete1_Cockroach-8                    550µs ± 2%     530µs ± 4%     ~             (p=0.095 n=5+5)
Delete10_Cockroach-8                   975µs ± 2%     981µs ± 2%     ~             (p=0.548 n=5+5)
Delete100_Cockroach-8                 4.83ms ± 1%    5.05ms ± 4%   +4.56%          (p=0.008 n=5+5)
Delete1000_Cockroach-8                49.4ms ± 2%    51.4ms ± 3%   +3.96%          (p=0.016 n=5+5)
Scan1_Cockroach-8                      192µs ± 6%     184µs ± 2%   -3.74%          (p=0.016 n=5+5)
Scan10_Cockroach-8                     222µs ± 2%     226µs ± 7%     ~             (p=0.690 n=5+5)
Scan100_Cockroach-8                    469µs ± 4%     467µs ± 1%     ~             (p=0.841 n=5+5)
Scan1000_Cockroach-8                  2.31ms ± 9%    2.36ms ± 1%     ~             (p=0.151 n=5+5)
Scan10000_Cockroach-8                 21.2ms ± 4%    22.0ms ± 3%     ~             (p=0.056 n=5+5)
Scan1000Limit1_Cockroach-8             209µs ± 4%     201µs ± 1%     ~             (p=0.095 n=5+5)
Scan1000Limit10_Cockroach-8            239µs ± 3%     241µs ± 4%     ~             (p=0.690 n=5+5)
Scan1000Limit100_Cockroach-8           474µs ± 5%     474µs ± 2%     ~             (p=0.421 n=5+5)
Scan10000FilterLimit1_Cockroach-8      380µs ± 3%     387µs ± 1%     ~             (p=0.095 n=5+5)
Scan10000FilterLimit10_Cockroach-8     422µs ± 1%     426µs ± 2%     ~             (p=0.056 n=5+5)
Scan10000FilterLimit50_Cockroach-8    2.16ms ± 5%    2.28ms ± 1%   +5.79%          (p=0.016 n=5+5)
WideTable1_Cockroach-8                1.82ms ± 1%    1.86ms ± 8%     ~             (p=0.548 n=5+5)
WideTable10_Cockroach-8               5.77ms ± 4%    5.91ms ± 8%     ~             (p=0.095 n=5+5)
WideTable100_Cockroach-8              45.4ms ± 9%    44.8ms ± 2%     ~             (p=0.690 n=5+5)
WideTable1000_Cockroach-8              515ms ± 2%     542ms ± 9%   +5.14%          (p=0.016 n=5+5)

name                                old alloc/op   new alloc/op   delta
Select1_Cockroach-8                   3.30kB ± 0%    3.30kB ± 0%     ~             (p=0.921 n=5+5)
Select2_Cockroach-8                    100kB ± 0%      90kB ± 0%   -9.18%          (p=0.008 n=5+5)
Select3_Cockroach-8                    143kB ± 0%     134kB ± 0%   -6.31%          (p=0.029 n=4+4)
Insert1_Cockroach-8                   29.0kB ± 0%    29.0kB ± 0%     ~             (p=0.667 n=5+5)
Insert10_Cockroach-8                  73.9kB ± 0%    73.9kB ± 0%     ~             (p=0.730 n=5+5)
Insert100_Cockroach-8                  486kB ± 0%     486kB ± 0%     ~             (p=0.841 n=5+5)
Insert1000_Cockroach-8                4.19MB ± 0%    4.17MB ± 0%     ~             (p=0.056 n=5+5)
Update1_Cockroach-8                   49.6kB ± 0%    49.6kB ± 0%   +0.03%          (p=0.008 n=5+5)
Update10_Cockroach-8                   121kB ± 0%     120kB ± 0%   -0.88%          (p=0.008 n=5+5)
Update100_Cockroach-8                  802kB ± 0%     790kB ± 0%   -1.48%          (p=0.029 n=4+4)
Update1000_Cockroach-8                6.69MB ± 0%    6.57MB ± 0%   -1.77%          (p=0.008 n=5+5)
Delete1_Cockroach-8                   44.2kB ± 0%    44.4kB ± 0%   +0.31%          (p=0.008 n=5+5)
Delete10_Cockroach-8                  69.2kB ± 0%    69.4kB ± 0%   +0.29%          (p=0.008 n=5+5)
Delete100_Cockroach-8                  306kB ± 0%     307kB ± 0%     ~             (p=0.063 n=5+4)
Delete1000_Cockroach-8                3.19MB ± 0%    3.19MB ± 0%     ~             (p=0.886 n=4+4)
Scan1_Cockroach-8                     15.3kB ± 0%    15.4kB ± 0%   +0.83%          (p=0.029 n=4+4)
Scan10_Cockroach-8                    18.8kB ± 0%    19.0kB ± 0%   +0.66%          (p=0.008 n=5+5)
Scan100_Cockroach-8                   49.7kB ± 0%    49.8kB ± 0%   +0.26%          (p=0.008 n=5+5)
Scan1000_Cockroach-8                   317kB ± 0%     317kB ± 0%     ~             (p=0.063 n=5+5)
Scan10000_Cockroach-8                 5.53MB ± 0%    5.53MB ± 0%     ~             (p=1.000 n=5+5)
Scan1000Limit1_Cockroach-8            15.9kB ± 0%    16.0kB ± 0%   +0.80%          (p=0.008 n=5+5)
Scan1000Limit10_Cockroach-8           19.3kB ± 0%    19.4kB ± 0%   +0.66%          (p=0.008 n=5+5)
Scan1000Limit100_Cockroach-8          50.0kB ± 0%    50.1kB ± 0%   +0.25%          (p=0.008 n=5+5)
Scan10000FilterLimit1_Cockroach-8     47.8kB ± 0%    47.9kB ± 0%   +0.27%          (p=0.008 n=5+5)
Scan10000FilterLimit10_Cockroach-8    54.0kB ± 0%    54.2kB ± 0%   +0.25%          (p=0.008 n=5+5)
Scan10000FilterLimit50_Cockroach-8     461kB ± 0%     461kB ± 0%   +0.03%          (p=0.008 n=5+5)
WideTable1_Cockroach-8                 266kB ± 0%     264kB ± 0%   -0.75%          (p=0.008 n=5+5)
WideTable10_Cockroach-8               1.45MB ± 0%    1.43MB ± 0%   -1.39%          (p=0.008 n=5+5)
WideTable100_Cockroach-8              13.4MB ± 0%    13.2MB ± 0%   -1.49%          (p=0.008 n=5+5)
WideTable1000_Cockroach-8              177MB ± 0%     176MB ± 0%   -1.10%          (p=0.008 n=5+5)

name                                old allocs/op  new allocs/op  delta
Select1_Cockroach-8                     55.0 ± 0%      55.0 ± 0%     ~     (all samples are equal)
Select2_Cockroach-8                    1.42k ± 0%     1.18k ± 0%  -17.09%          (p=0.008 n=5+5)
Select3_Cockroach-8                    2.28k ± 0%     2.03k ± 0%  -10.67%          (p=0.029 n=4+4)
Insert1_Cockroach-8                      290 ± 0%       290 ± 0%     ~     (all samples are equal)
Insert10_Cockroach-8                     497 ± 0%       497 ± 0%     ~             (p=1.000 n=5+5)
Insert100_Cockroach-8                  2.33k ± 0%     2.33k ± 0%     ~             (p=0.881 n=5+5)
Insert1000_Cockroach-8                 20.4k ± 0%     20.5k ± 0%   +0.14%          (p=0.008 n=5+5)
Update1_Cockroach-8                      555 ± 0%       552 ± 0%   -0.54%          (p=0.008 n=5+5)
Update10_Cockroach-8                     894 ± 0%       864 ± 0%   -3.36%          (p=0.008 n=5+5)
Update100_Cockroach-8                  3.93k ± 0%     3.63k ± 0%   -7.58%          (p=0.029 n=4+4)
Update1000_Cockroach-8                 32.4k ± 0%     29.5k ± 0%   -8.91%          (p=0.008 n=5+5)
Delete1_Cockroach-8                      469 ± 0%       469 ± 0%     ~     (all samples are equal)
Delete10_Cockroach-8                     674 ± 0%       674 ± 0%     ~     (all samples are equal)
Delete100_Cockroach-8                  2.59k ± 0%     2.59k ± 0%     ~             (p=0.079 n=4+5)
Delete1000_Cockroach-8                 21.6k ± 0%     21.6k ± 0%     ~             (p=0.629 n=4+4)
Scan1_Cockroach-8                        194 ± 0%       194 ± 0%     ~     (all samples are equal)
Scan10_Cockroach-8                       221 ± 0%       221 ± 0%     ~     (all samples are equal)
Scan100_Cockroach-8                      417 ± 0%       417 ± 0%     ~     (all samples are equal)
Scan1000_Cockroach-8                   2.30k ± 0%     2.30k ± 0%     ~             (p=1.000 n=5+5)
Scan10000_Cockroach-8                  21.1k ± 0%     21.1k ± 0%     ~             (p=0.952 n=5+5)
Scan1000Limit1_Cockroach-8               201 ± 0%       201 ± 0%     ~     (all samples are equal)
Scan1000Limit10_Cockroach-8              227 ± 0%       227 ± 0%     ~     (all samples are equal)
Scan1000Limit100_Cockroach-8             423 ± 0%       423 ± 0%     ~     (all samples are equal)
Scan10000FilterLimit1_Cockroach-8        501 ± 0%       501 ± 0%     ~     (all samples are equal)
Scan10000FilterLimit10_Cockroach-8       555 ± 0%       555 ± 0%     ~     (all samples are equal)
Scan10000FilterLimit50_Cockroach-8     1.79k ± 0%     1.79k ± 0%     ~             (p=0.556 n=4+5)
WideTable1_Cockroach-8                 2.24k ± 0%     2.19k ± 0%   -2.34%          (p=0.008 n=5+5)
WideTable10_Cockroach-8                7.09k ± 0%     6.58k ± 0%   -7.19%          (p=0.008 n=5+5)
WideTable100_Cockroach-8               55.3k ± 0%     50.2k ± 0%   -9.18%          (p=0.008 n=5+5)
WideTable1000_Cockroach-8               597k ± 0%      547k ± 0%   -8.42%          (p=0.008 n=5+5)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7243)

<!-- Reviewable:end -->
