### PR TITLE
status: skip store when descriptor not obtained

### DIFF
--- a/server/status/recorder.go
+++ b/server/status/recorder.go
@@ -253,6 +253,7 @@ func (mr *MetricsRecorder) GetStatusSummary() *NodeStatus {
 		descriptor, err := mr.mu.stores[storeID].Descriptor()
 		if err != nil {
 			log.Errorf("Could not record status summaries: Store %d could not return descriptor, error: %s", storeID, err)
+			continue
 		}
 
 		nodeStat.StoreStatuses = append(nodeStat.StoreStatuses, StoreStatus{


### PR DESCRIPTION
Previous code would simply panic (as I found out when I removed
a running node's data directory by accident).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7244)

<!-- Reviewable:end -->
