### PR TITLE
sql/parser: allow builtins to categorize themselves

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -58,6 +58,7 @@ var (
 type Builtin struct {
 	Types      typeList
 	ReturnType Datum
+	category   string
 	// Set to true when a function potentially returns a different value
 	// when called in the same statement with the same parameters.
 	// e.g.: random(), clock_timestamp(). Some functions like now()
@@ -74,6 +75,20 @@ func (b Builtin) params() typeList {
 
 func (b Builtin) returnType() Datum {
 	return b.ReturnType
+}
+
+// Category is used to categorize a function (for documentation purposes).
+func (b Builtin) Category() string {
+	if b.category != "" {
+		return b.category
+	}
+	if types, ok := b.Types.(ArgTypes); ok && len(types) == 1 {
+		return strings.ToUpper(types[0].Type())
+	}
+	if b.ReturnType != nil {
+		return strings.ToUpper(b.ReturnType.Type())
+	}
+	return ""
 }
 
 // Builtins contains the built-in functions indexed by name.
@@ -451,6 +466,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeBytes,
+			category:   "ID Generation",
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return NewDBytes(generateUniqueBytes(ctx.NodeID)), nil
@@ -462,6 +478,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeInt,
+			category:   "ID Generation",
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return NewDInt(generateUniqueInt(ctx.NodeID)), nil
@@ -939,6 +956,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeString,
+			category:   "System Info",
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(build.GetInfo().Short()), nil
 			},
@@ -1023,6 +1041,7 @@ var substringImpls = []Builtin{
 var uuidV4Impl = Builtin{
 	Types:      ArgTypes{},
 	ReturnType: TypeBytes,
+	category:   "ID Generation",
 	impure:     true,
 	fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 		return NewDBytes(DBytes(uuid.NewV4().GetBytes())), nil

--- a/sql/parser/builtins_test.go
+++ b/sql/parser/builtins_test.go
@@ -1,0 +1,32 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package parser
+
+import "testing"
+
+func TestCategory(t *testing.T) {
+	if expected, actual := "STRING", Builtins["lower"][0].Category(); expected != actual {
+		t.Fatalf("bad category: expected %q got %q", expected, actual)
+	}
+	if expected, actual := "STRING", Builtins["length"][0].Category(); expected != actual {
+		t.Fatalf("bad category: expected %q got %q", expected, actual)
+	}
+	if expected, actual := "TIMESTAMP", Builtins["now"][0].Category(); expected != actual {
+		t.Fatalf("bad category: expected %q got %q", expected, actual)
+	}
+	if expected, actual := "System Info", Builtins["version"][0].Category(); expected != actual {
+		t.Fatalf("bad category: expected %q got %q", expected, actual)
+	}
+}


### PR DESCRIPTION
Adding a method that the docs generation code can call to categorize builtin functions,
that will first use a manually assigned category if it is set before falling back to
the type of the argment (for single-argument functions) or return type (for the others).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7248)

<!-- Reviewable:end -->
