### PR TITLE
rpc: remove timeout from GRPC dial

### DIFF
--- a/rpc/context.go
+++ b/rpc/context.go
@@ -156,8 +156,8 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 		dialOpt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 
-	dialOpts := make([]grpc.DialOption, 0, 2+len(opts))
-	dialOpts = append(dialOpts, dialOpt, grpc.WithTimeout(base.NetworkTimeout))
+	dialOpts := make([]grpc.DialOption, 0, 1+len(opts))
+	dialOpts = append(dialOpts, dialOpt)
 	dialOpts = append(dialOpts, opts...)
 
 	conn, err := grpc.Dial(target, dialOpts...)


### PR DESCRIPTION
The timeout only works if you also specify WithBlock().
See https://godoc.org/google.golang.org/grpc#WithTimeout

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7249)

<!-- Reviewable:end -->
