### PR TITLE
storage: change reservation consts to env variables

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -2418,7 +2418,7 @@ func (s *Store) FrozenStatus(collectFrozen bool) (descs []roachpb.ReplicaDescrip
 // Reserve requests a reservation from the store's bookie.
 func (s *Store) Reserve(req roachpb.ReservationRequest) roachpb.ReservationResponse {
 	if s.metrics.capacity.Value() == 0 {
-		// On startup, it takes some time before compute metrics is run. When
+		// On startup, it takes some time before ComputeMetrics is run. When
 		// this happens, it means the store will reject any incoming
 		// reservations. To avoid this, if there is no capacity information yet
 		// we can force a call to ComputeMetrics.

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -294,7 +294,7 @@ func TestStorePoolGetStoreList(t *testing.T) {
 	// Mark one store dead and one store declined.
 	sp.mu.Lock()
 	sp.mu.stores[deadStore.StoreID].markDead(sp.clock.Now())
-	sp.mu.stores[declinedStore.StoreID].reservationDeclinedOn = sp.clock.Now().GoTime().Add(time.Hour)
+	sp.mu.stores[declinedStore.StoreID].unavailableUntil = sp.clock.Now().GoTime().Add(time.Hour)
 	sp.mu.Unlock()
 
 	if err := verifyStoreList(sp, required, []int{


### PR DESCRIPTION
This will enable quicker iteration testing on reservation timeouts.
Also, this splits the a declined and failed reservation timeouts into two
values. There is a longer delay if the RPC fails and only a small delay if the
reservation is declined.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7255)

<!-- Reviewable:end -->
