### PR TITLE
storage/engine: fix defaultBlockSize value to match comment

### DIFF
--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -52,8 +52,8 @@ import (
 import "C"
 
 const (
-	minMemtableBudget = 1 << 20 // 1 MB
-	defaultBlockSize  = 2 << 10 // 32KB (rocksdb default is 4KB)
+	minMemtableBudget = 1 << 20  // 1 MB
+	defaultBlockSize  = 32 << 10 // 32KB (rocksdb default is 4KB)
 )
 
 func init() {

--- a/storage/engine/rocksdb/eventlistener.cc
+++ b/storage/engine/rocksdb/eventlistener.cc
@@ -14,7 +14,10 @@
 //
 // Author: Cuong Do <cdo@cockroachlabs.com>
 
+#include <rocksdb/table_properties.h>
 #include "eventlistener.h"
+
+static const bool kDebug = false;
 
 DBEventListener::DBEventListener()
   : flushes_(0),
@@ -23,10 +26,29 @@ DBEventListener::DBEventListener()
 
 void DBEventListener::OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobInfo& flush_job_info) {
   ++flushes_;
+
+  if (kDebug) {
+    const rocksdb::TableProperties &p = flush_job_info.table_properties;
+    fprintf(stderr, "OnFlushCompleted:\n  %40s:  index=%.1f  filter=%.1f\n",
+            flush_job_info.file_path.c_str(),
+            p.index_size / float(p.num_entries),
+            p.filter_size / float(p.num_entries));
+  }
 }
 
 void DBEventListener::OnCompactionCompleted(rocksdb::DB* db, const rocksdb::CompactionJobInfo& ci) {
   ++compactions_;
+
+  if (kDebug) {
+    fprintf(stderr, "OnCompactionCompleted:\n");
+    for (auto iter = ci.table_properties.begin(); iter != ci.table_properties.end(); ++iter) {
+      const rocksdb::TableProperties &p = *iter->second;
+      fprintf(stderr, "  %40s: index=%.1f  filter=%.1f\n",
+              iter->first.c_str(),
+              p.index_size / float(p.num_entries),
+              p.filter_size / float(p.num_entries));
+    }
+  }
 }
 
 uint64_t DBEventListener::GetFlushes() const {
@@ -36,4 +58,3 @@ uint64_t DBEventListener::GetFlushes() const {
 uint64_t DBEventListener::GetCompactions() const {
   return compactions_.load();
 }
-


### PR DESCRIPTION
For the block_writer workload a 2KB block-size results in ~15 bytes of
index data per key. A 32KB block-size results in ~1 byte of index data
per key. The filter-bytes per key is independent of the block-size and
comes in at ~2 bytes per key.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7276)

<!-- Reviewable:end -->
