### PR TITLE
cli: add COCKROACH_CHECKPOINT_INTERVAL env var

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/server"
 	"github.com/cockroachdb/cockroach/server/serverpb"
+	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/envutil"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -138,7 +139,7 @@ func initMemProfile(dir string) {
 		return
 	}
 	if min := time.Second; memProfileInterval < min {
-		log.Infof("fixing excessively small memory profiling interval: %s -> %s",
+		log.Infof("fixing excessively short memory profiling interval: %s -> %s",
 			memProfileInterval, min)
 		memProfileInterval = min
 	}
@@ -192,7 +193,7 @@ func initCPUProfile(dir string) {
 		return
 	}
 	if min := time.Second; cpuProfileInterval < min {
-		log.Infof("fixing excessively small cpu profiling interval: %s -> %s",
+		log.Infof("fixing excessively short cpu profiling interval: %s -> %s",
 			cpuProfileInterval, min)
 		cpuProfileInterval = min
 	}
@@ -236,6 +237,39 @@ func initCPUProfile(dir string) {
 			}()
 
 			<-t.C
+		}
+	}()
+}
+
+func initCheckpointing(engines []engine.Engine) {
+	checkpointInterval := envutil.EnvOrDefaultDuration("checkpoint_interval", -1)
+	if checkpointInterval < 0 {
+		return
+	}
+	if min := 10 * time.Second; checkpointInterval < min {
+		log.Infof("fixing excessively short checkpointing interval: %s -> %s",
+			checkpointInterval, min)
+		checkpointInterval = min
+	}
+
+	go func() {
+		t := time.NewTicker(checkpointInterval)
+		defer t.Stop()
+
+		for {
+			<-t.C
+
+			const format = "2006-01-02T15_04_05"
+			dir := timeutil.Now().Format(format)
+			start := timeutil.Now()
+			for _, e := range engines {
+				// Note that when dir is relative (as it is here) it is appended to the
+				// engine's data directory.
+				if err := e.Checkpoint(dir); err != nil {
+					log.Warning(err)
+				}
+			}
+			log.Infof("created checkpoint %s: %.1fms", dir, timeutil.Since(start).Seconds()*1000)
 		}
 	}()
 }
@@ -311,6 +345,8 @@ func runStart(_ *cobra.Command, args []string) error {
 	if err := s.Start(); err != nil {
 		return fmt.Errorf("cockroach server exited with error: %s", err)
 	}
+
+	initCheckpointing(serverCtx.Engines)
 
 	pgURL, err := serverCtx.PGURL(connUser)
 	if err != nil {

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -160,6 +160,10 @@ type Engine interface {
 	ReadWriter
 	// Attrs returns the engine/store attributes.
 	Attrs() roachpb.Attributes
+	// Checkpoint creates a point-in-time snapshot of the on-disk state of the
+	// key/value store, hard-linking and copying files into the specified
+	// directory.
+	Checkpoint(dir string) error
 	// Capacity returns capacity details for the engine's available storage.
 	Capacity() (roachpb.StoreCapacity, error)
 	// Flush causes the engine to write all in-memory data to disk

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -336,6 +336,20 @@ func (r *RocksDB) Flush() error {
 	return statusToError(C.DBFlush(r.rdb))
 }
 
+// Checkpoint creates a point-in-time snapshot of the on-disk state.
+func (r *RocksDB) Checkpoint(dir string) error {
+	if len(r.dir) == 0 {
+		return util.Errorf("unable to checkpoint in-memory rocksdb instance")
+	}
+	if len(dir) == 0 {
+		return util.Errorf("empty checkpoint directory")
+	}
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(r.dir, dir)
+	}
+	return statusToError(C.DBCheckpoint(r.rdb, goToCSlice([]byte(dir))))
+}
+
 // NewIterator returns an iterator over this rocksdb engine.
 func (r *RocksDB) NewIterator(prefix bool) Iterator {
 	return newRocksDBIterator(r.rdb, prefix, r)

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -84,6 +84,11 @@ DBStatus DBFlush(DBEngine* db);
 // Forces an immediate compaction over all keys.
 DBStatus DBCompact(DBEngine* db);
 
+// Checkpoint creates a point-in-time snapshot of the database,
+// hard-linking sstable files and copying the manifest and other
+// files.
+DBStatus DBCheckpoint(DBEngine* db, DBSlice dir);
+
 // Sets the database entry for "key" to "value".
 DBStatus DBPut(DBEngine* db, DBKey key, DBSlice value);
 


### PR DESCRIPTION
Add support for taking periodic checkpoints. Checkpoints are
point-in-time snapshots of the RocksDB disk state. They are extremely
quick to create (10s of milliseconds) because the snapshots use
hard-links for the sstables.

See #7257.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7281)

<!-- Reviewable:end -->
