### PR TITLE
sql/parser: more builtin categorization

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -54,6 +54,15 @@ var (
 	errLogOfZero         = errors.New("cannot take logarithm of zero")
 )
 
+const (
+	categoryIDGeneration = "ID Generation"
+	categorySystemInfo   = "System Info"
+	categoryDateAndTime  = "Date and Time"
+	categoryString       = "String and Byte"
+	categoryMath         = "Math and Numeric"
+	categoryComparison   = "Comparison"
+)
+
 // Builtin is a built-in function.
 type Builtin struct {
 	Types      typeList
@@ -77,16 +86,29 @@ func (b Builtin) returnType() Datum {
 	return b.ReturnType
 }
 
+func categoryizeType(t Datum) string {
+	switch t {
+	case TypeDate, TypeInterval, TypeTimestamp, TypeTimestampTZ:
+		return categoryDateAndTime
+	case TypeInt, TypeDecimal, TypeFloat:
+		return categoryMath
+	case TypeString, TypeBytes:
+		return categoryString
+	default:
+		return strings.ToUpper(t.Type())
+	}
+}
+
 // Category is used to categorize a function (for documentation purposes).
 func (b Builtin) Category() string {
 	if b.category != "" {
 		return b.category
 	}
 	if types, ok := b.Types.(ArgTypes); ok && len(types) == 1 {
-		return strings.ToUpper(types[0].Type())
+		return categoryizeType(types[0])
 	}
 	if b.ReturnType != nil {
-		return strings.ToUpper(b.ReturnType.Type())
+		return categoryizeType(b.ReturnType)
 	}
 	return ""
 }
@@ -466,7 +488,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeBytes,
-			category:   "ID Generation",
+			category:   categoryIDGeneration,
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return NewDBytes(generateUniqueBytes(ctx.NodeID)), nil
@@ -478,7 +500,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeInt,
-			category:   "ID Generation",
+			category:   categoryIDGeneration,
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return NewDInt(generateUniqueInt(ctx.NodeID)), nil
@@ -493,6 +515,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      AnyType{},
 			ReturnType: nil, // No explicit return type because AnyType parameters.
+			category:   categoryComparison,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, true /* greatest */, args)
 			},
@@ -503,6 +526,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      AnyType{},
 			ReturnType: nil, // No explicit return type because AnyType parameters.
+			category:   categoryComparison,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return pickFromTuple(ctx, false /* !greatest */, args)
 			},
@@ -558,6 +582,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeDecimal,
+			category:   categorySystemInfo,
 			impure:     true,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				return ctx.GetClusterTimestamp(), nil
@@ -580,6 +605,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString, TypeTimestamp},
 			ReturnType: TypeInt,
+			category:   categoryDateAndTime,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				// extract timeSpan fromTime.
 				fromTime := *args[1].(*DTimestamp)
@@ -649,6 +675,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{TypeString},
 			ReturnType: TypeTimestamp,
+			category:   categoryDateAndTime,
 			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
 				s := string(*args[0].(*DString))
 				return ParseDTimestamp(s, ctx.GetLocation(), time.Nanosecond)
@@ -956,7 +983,7 @@ var Builtins = map[string][]Builtin{
 		Builtin{
 			Types:      ArgTypes{},
 			ReturnType: TypeString,
-			category:   "System Info",
+			category:   categorySystemInfo,
 			fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 				return NewDString(build.GetInfo().Short()), nil
 			},
@@ -1041,7 +1068,7 @@ var substringImpls = []Builtin{
 var uuidV4Impl = Builtin{
 	Types:      ArgTypes{},
 	ReturnType: TypeBytes,
-	category:   "ID Generation",
+	category:   categoryIDGeneration,
 	impure:     true,
 	fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 		return NewDBytes(DBytes(uuid.NewV4().GetBytes())), nil
@@ -1151,6 +1178,7 @@ func stringBuiltin2(f func(string, string) (Datum, error), returnType Datum) Bui
 	return Builtin{
 		Types:      ArgTypes{TypeString, TypeString},
 		ReturnType: returnType,
+		category:   categoryizeType(TypeString),
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(*args[0].(*DString)), string(*args[1].(*DString)))
 		},

--- a/sql/parser/builtins_test.go
+++ b/sql/parser/builtins_test.go
@@ -17,16 +17,16 @@ package parser
 import "testing"
 
 func TestCategory(t *testing.T) {
-	if expected, actual := "STRING", Builtins["lower"][0].Category(); expected != actual {
+	if expected, actual := categoryString, Builtins["lower"][0].Category(); expected != actual {
 		t.Fatalf("bad category: expected %q got %q", expected, actual)
 	}
-	if expected, actual := "STRING", Builtins["length"][0].Category(); expected != actual {
+	if expected, actual := categoryString, Builtins["length"][0].Category(); expected != actual {
 		t.Fatalf("bad category: expected %q got %q", expected, actual)
 	}
-	if expected, actual := "TIMESTAMP", Builtins["now"][0].Category(); expected != actual {
+	if expected, actual := categoryDateAndTime, Builtins["now"][0].Category(); expected != actual {
 		t.Fatalf("bad category: expected %q got %q", expected, actual)
 	}
-	if expected, actual := "System Info", Builtins["version"][0].Category(); expected != actual {
+	if expected, actual := categorySystemInfo, Builtins["version"][0].Category(); expected != actual {
 		t.Fatalf("bad category: expected %q got %q", expected, actual)
 	}
 }


### PR DESCRIPTION
use constants for repeated category names and combine date and timestamp into single category.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7292)

<!-- Reviewable:end -->
