### PR TITLE
kv: deflake TestClientNotReady

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ install:
 # PKG is expanded and all packages are built and moved to their directory.
 # If STATIC=1, tests are statically linked.
 # eg: to statically build the sql tests, run:
-#   make testbuild PKG=./sql STATIC=1
+#   make STATIC=1 testbuild PKG=./sql
 .PHONY: testbuild
 testbuild: GOFLAGS += -c
 testbuild:

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -126,21 +126,21 @@ func TestRetryableError(t *testing.T) {
 	s, ln := newTestServer(t, serverContext)
 	roachpb.RegisterInternalServer(s, Node(0))
 
-	conn, err := clientContext.GRPCDial(ln.Addr().String())
+	grpcConn, err := clientContext.GRPCDial(ln.Addr().String())
 	if err != nil {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
 	waitForConnState := func(desiredState grpc.ConnectivityState) {
-		clientState, err := conn.State()
+		clientState, err := grpcConn.State()
 		for clientState != desiredState {
 			if err != nil {
 				t.Fatal(err)
 			}
 			if clientState == grpc.Shutdown {
-				t.Fatalf("%v has unexpectedly shut down", conn)
+				t.Fatalf("%v has unexpectedly shut down", grpcConn)
 			}
-			clientState, err = conn.WaitForStateChange(ctx, clientState)
+			clientState, err = grpcConn.WaitForStateChange(ctx, clientState)
 		}
 	}
 	// Wait until the client becomes healthy and shut down the server.
@@ -414,70 +414,93 @@ func TestClientNotReady(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 
-	// Construct a server that listens but doesn't do anything. Notice that we
-	// never start accepting connections on the listener.
+	// Construct a server that listens but doesn't do anything. Note that we
+	// don't accept any connections on the listener.
 	ln, err := net.Listen(util.TestAddr.Network(), util.TestAddr.String())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer ln.Close()
+	addr := ln.Addr()
+	addrs := []net.Addr{addr}
 
-	opts := SendOptions{
-		SendNextTimeout: 100 * time.Nanosecond,
-		Timeout:         100 * time.Nanosecond,
-		Context:         context.Background(),
-	}
+	{
+		// Send RPC to an address where no server is running.
+		nodeContext := newNodeTestContext(nil, stopper)
+		if _, err := sendBatch(SendOptions{
+			SendNextTimeout: 100 * time.Nanosecond,
+			Timeout:         100 * time.Nanosecond,
+			Context:         context.Background(),
+		}, addrs, nodeContext); !testutils.IsError(err, "context deadline exceeded") {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
-	// Send RPC to an address where no server is running.
-	nodeContext := newNodeTestContext(nil, stopper)
-	if _, err := sendBatch(opts, []net.Addr{ln.Addr()}, nodeContext); err == nil {
-		t.Fatalf("Unexpected success")
-	}
-
-	// Send the RPC again with no timeout. We create a new node context to ensure
-	// there is a new connection.
-	nodeContext = newNodeTestContext(nil, stopper)
-	opts.SendNextTimeout = 0
-	opts.Timeout = 0
-	c := make(chan error)
-	sent := make(chan struct{})
-
-	// Start a goroutine to accept the connection from the client. We'll close
-	// the sent channel after receiving the connection, thus ensuring that the
-	// RPC was sent before we closed the connection. We intentionally do not
-	// close the server connection as doing so triggers other gRPC code paths.
-	go func() {
-		_, err := ln.Accept()
-		if err != nil {
-			c <- err
+		// Do a dance to convince GRPC to close the connection.
+		if conn, err := ln.Accept(); err != nil {
+			t.Fatal(err)
 		} else {
-			close(sent)
+			// The connection is cached in the RPC context.
+			grpcConn, err := nodeContext.GRPCDial(addr.String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := grpcConn.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			// Just in case, close it from the server as well.
+			if err := conn.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	errCh := make(chan error)
+	connected := make(chan struct{})
+
+	// Accept a single connection from the client.
+	go func() {
+		if _, err := ln.Accept(); err != nil {
+			errCh <- err
+		} else {
+			close(connected)
 		}
 	}()
+
+	// Send the RPC again with no timeout. We create a new node context to ensure
+	// there is a new connection; we could reuse the the old connection by not
+	// closing it, but by the time we reach this point in the test, GRPC may have
+	// attempted to reconnect enough times to make the backoff long enough to
+	// time out the test.
+	nodeContext := newNodeTestContext(nil, stopper)
+
 	go func() {
-		_, err := sendBatch(opts, []net.Addr{ln.Addr()}, nodeContext)
+		_, err := sendBatch(SendOptions{
+			Context: context.Background(),
+		}, addrs, nodeContext)
 		if !testutils.IsError(err, "failed as client connection was closed") {
-			c <- util.Errorf("unexpected error: %v", err)
+			errCh <- util.Errorf("unexpected error: %v", err)
+		} else {
+			close(errCh)
 		}
-		close(c)
 	}()
 
 	select {
-	case err := <-c:
-		t.Fatalf("Unexpected end of rpc call: %v", err)
-	case <-sent:
+	case err := <-errCh:
+		t.Fatalf("unexpected error: %v", err)
+	case <-connected:
 	}
 
-	// Grab the client for our invalid address and close it. This will cause the
-	// blocked ping RPC to finish.
-	conn, err := nodeContext.GRPCDial(ln.Addr().String())
+	// Grab the cached connection and close it. This will cause the blocked RPC
+	// to finish.
+	grpcConn, err := nodeContext.GRPCDial(addr.String())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := conn.Close(); err != nil {
+	if err := grpcConn.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := <-c; err != nil {
+	for err := range errCh {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This test became flaky in 44cab7c, where the connection timeout was
removed. Despite what's stated in the gRPC docs, the timeout does
indeed have an effect even in the absence of WithBlock().

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7293)

<!-- Reviewable:end -->
