### PR TITLE
sql/parser: correctly escape non-printable bytes

### DIFF
--- a/sql/parser/encode.go
+++ b/sql/parser/encode.go
@@ -100,7 +100,8 @@ func encodeSQLBytes(buf *bytes.Buffer, in string) {
 			buf.WriteByte('\\')
 			buf.WriteByte(encodedChar)
 			start = i + 1
-		} else if ch >= 0x80 {
+		} else if ch < 0x20 || ch >= 0x7F {
+			// Escape non-printable characters.
 			buf.Write(hexMap[ch])
 			start = i + 1
 		}
@@ -111,14 +112,13 @@ func encodeSQLBytes(buf *bytes.Buffer, in string) {
 
 func init() {
 	encodeRef := map[byte]byte{
-		'\x00': '0',
-		'\b':   'b',
-		'\f':   'f',
-		'\n':   'n',
-		'\r':   'r',
-		'\t':   't',
-		'\\':   '\\',
-		'\'':   '\'',
+		'\b': 'b',
+		'\f': 'f',
+		'\n': 'n',
+		'\r': 'r',
+		'\t': 't',
+		'\\': '\\',
+		'\'': '\'',
 	}
 
 	for i := range encodeMap {

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -17,6 +17,8 @@
 package parser
 
 import (
+	"bytes"
+	"fmt"
 	"go/constant"
 	"reflect"
 	"testing"
@@ -1105,6 +1107,24 @@ func BenchmarkParse(b *testing.B) {
 		}
 		if _, ok := st[1].(*Update); !ok {
 			b.Fatalf("unexpected statement type: %T", st[1])
+		}
+	}
+}
+
+func TestEncodeSQLBytes(t *testing.T) {
+	for i := 0; i < 256; i++ {
+		s := string([]byte{byte(i)})
+		var buf bytes.Buffer
+		encodeSQLBytes(&buf, s)
+		sql := fmt.Sprintf("SELECT %s", buf.String())
+		stmts, err := parseTraditional(sql)
+		if err != nil {
+			t.Errorf("%s: expected success, but found %s", sql, err)
+			continue
+		}
+		stmt := stmts.String()
+		if sql != stmt {
+			t.Errorf("expected %s, but found %s", sql, stmt)
 		}
 	}
 }


### PR DESCRIPTION
Fix the output of the 0 byte, which was producing `b'\0'`, which isn't a
valid byte string. Instead output `b'\x00'`.

Change the other non-printable bytes to use escape characters instead of
preserving the byte. Although within cockroach itself, those bytes are
parsed correctly, if they are ever persisted to a file and then read in
via `cockroach sql`, an error would occur because the readline package
interprets those bytes as if a user were typing them, and some of them
are readline commands. Escaping the bytes makes them easy to understand
in a file and doesn't break the readline input.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7294)

<!-- Reviewable:end -->
