### PR TITLE
distsql: add infrastructure for running simple flows without goroutines

### DIFF
--- a/sql/dist_sql_node.go
+++ b/sql/dist_sql_node.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/sql/distsql"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/util"
 )
 
 // distSQLNode is a planNode that receives results from a distsql flow (through
@@ -34,11 +33,20 @@ type distSQLNode struct {
 	columns  []ResultColumn
 	ordering orderingInfo
 
+	// syncMode indicates the mode in which we run the associated flow. If true,
+	// we run in a mode used for small queries (when the number of table rows
+	// needed is known). In this mode we run the processors serially and
+	// accumulate the output of each processor in memory.
+	syncMode bool
+
+	// flowResult is used to access the results of the flow. It can be a
+	// RowChannel or a RowBuffer (depending on syncMode).
+	flowResult distsql.RowSource
+
 	// colMapping maps columns in the RowChannel stream to result columns.
 	colMapping []uint32
 
 	flow *distsql.Flow
-	c    distsql.RowChannel
 
 	values parser.DTuple
 	alloc  sqlbase.DatumAlloc
@@ -71,40 +79,60 @@ func newDistSQLNode(
 	columns []ResultColumn,
 	colMapping []uint32,
 	ordering orderingInfo,
-) *distSQLNode {
+	srv *distsql.ServerImpl,
+	flowReq *distsql.SetupFlowsRequest,
+	syncMode bool,
+) (*distSQLNode, error) {
 	n := &distSQLNode{
+		syncMode:   syncMode,
 		columns:    columns,
 		ordering:   ordering,
 		colMapping: colMapping,
 		values:     make(parser.DTuple, len(columns)),
 	}
-	n.c.Init()
-	return n
+	var recv distsql.RowReceiver
+	if syncMode {
+		rb := new(distsql.RowBuffer)
+		n.flowResult = rb
+		recv = rb
+	} else {
+		rc := new(distsql.RowChannel)
+		rc.Init()
+		n.flowResult = rc
+		recv = rc
+	}
+
+	flow, err := srv.SetupSimpleFlow(context.Background(), flowReq, recv)
+	if err != nil {
+		return nil, err
+	}
+	n.flow = flow
+	return n, nil
 }
 
 func (n *distSQLNode) Next() (bool, error) {
 	if !n.flowStarted {
-		n.flow.Start()
+		if n.syncMode {
+			n.flow.RunSync()
+		} else {
+			n.flow.Start()
+		}
 		n.flowStarted = true
 	}
-	d, ok := <-n.c.C
-	if !ok {
-		// No more data
+	row, err := n.flowResult.NextRow()
+	if err != nil {
+		return false, err
+	}
+	if row == nil {
 		return false, nil
 	}
-	if d.Err != nil {
-		return false, d.Err
-	}
-	if len(d.Row) != len(n.colMapping) {
-		return false, util.Errorf("row length %d, expected %d", len(d.Row), len(n.colMapping))
-	}
-	for i := range d.Row {
+	for i := range row {
 		col := n.colMapping[i]
-		err := d.Row[i].Decode(&n.alloc)
+		err := row[i].Decode(&n.alloc)
 		if err != nil {
 			return false, err
 		}
-		n.values[col] = d.Row[i].Datum
+		n.values[col] = row[i].Datum
 	}
 	return true, nil
 }
@@ -170,8 +198,10 @@ func scanNodeToTableReaderSpec(n *scanNode) *distsql.TableReaderSpec {
 
 // scanNodeToDistSQL creates a flow and distSQLNode that correspond to a
 // scanNode.
-func scanNodeToDistSQL(n *scanNode) (*distSQLNode, error) {
-	req := &distsql.SetupFlowsRequest{Txn: n.p.txn.Proto}
+// If syncMode is true, the plan does not instantiate any goroutines
+// internally.
+func scanNodeToDistSQL(n *scanNode, syncMode bool) (*distSQLNode, error) {
+	req := distsql.SetupFlowsRequest{Txn: n.p.txn.Proto}
 	tr := scanNodeToTableReaderSpec(n)
 	req.Flows = []distsql.FlowSpec{{
 		Processors: []distsql.ProcessorSpec{{
@@ -185,26 +215,21 @@ func scanNodeToDistSQL(n *scanNode) (*distSQLNode, error) {
 		}},
 	}}
 
-	dn := newDistSQLNode(n.resultColumns, tr.OutputColumns, n.ordering)
-
-	srv := n.p.execCtx.DistSQLSrv
-	flow, err := srv.SetupSimpleFlow(context.Background(), req, &dn.c)
-	if err != nil {
-		return nil, err
-	}
-	dn.flow = flow
-	return dn, nil
+	return newDistSQLNode(
+		n.resultColumns, tr.OutputColumns, n.ordering, n.p.execCtx.DistSQLSrv, &req, syncMode)
 }
 
 // hackPlanToUseDistSQL goes through a planNode tree and replaces each scanNode with
 // a distSQLNode and a corresponding flow.
-func hackPlanToUseDistSQL(plan planNode) error {
+// If syncMode is true, the plan does not instantiate any goroutines
+// internally.
+func hackPlanToUseDistSQL(plan planNode, syncMode bool) error {
 	// Trigger limit propagation.
 	plan.SetLimitHint(math.MaxInt64, true)
 
 	if sel, ok := plan.(*selectNode); ok {
 		if scan, ok := sel.source.plan.(*scanNode); ok {
-			distNode, err := scanNodeToDistSQL(scan)
+			distNode, err := scanNodeToDistSQL(scan, syncMode)
 			if err != nil {
 				return err
 			}
@@ -214,7 +239,7 @@ func hackPlanToUseDistSQL(plan planNode) error {
 
 	_, _, children := plan.ExplainPlan(true)
 	for _, c := range children {
-		if err := hackPlanToUseDistSQL(c); err != nil {
+		if err := hackPlanToUseDistSQL(c, syncMode); err != nil {
 			return err
 		}
 	}

--- a/sql/distsql/base.go
+++ b/sql/distsql/base.go
@@ -25,18 +25,26 @@ import (
 
 const rowChannelBufSize = 16
 
-// rowReceiver is any component of a flow that receives rows from another
+// RowReceiver is any component of a flow that receives rows from another
 // component. It can be an input synchronizer, a router, or a mailbox.
-type rowReceiver interface {
+type RowReceiver interface {
 	// PushRow sends a row to this receiver. May block.
 	// Returns true if the row was sent, or false if the receiver does not need
 	// any more rows. In all cases, Close() still needs to be called.
 	// The sender must not use the row anymore after calling this function.
 	PushRow(row sqlbase.EncDatumRow) bool
-	// Close is called when we have no more rows; it causes the rowReceiver to
+	// Close is called when we have no more rows; it causes the RowReceiver to
 	// process all rows and clean up. If err is not null, the error is sent to
 	// the receiver (and the function may block).
 	Close(err error)
+}
+
+// RowSource is any component of a flow that produces rows that cam be consumed
+// by another component.
+type RowSource interface {
+	// NextRow retrieves the next row. Returns a nil row if there are no more
+	// rows. Depending on the implementation, it may block.
+	NextRow() (sqlbase.EncDatumRow, error)
 }
 
 // processor is a common interface implemented by all processors, used by the
@@ -69,7 +77,8 @@ type RowChannel struct {
 	noMoreRows uint32
 }
 
-var _ rowReceiver = &RowChannel{}
+var _ RowReceiver = &RowChannel{}
+var _ RowSource = &RowChannel{}
 
 // InitWithBufSize initializes the RowChannel with a given buffer size.
 func (rc *RowChannel) InitWithBufSize(chanBufSize int) {
@@ -83,7 +92,7 @@ func (rc *RowChannel) Init() {
 	rc.InitWithBufSize(rowChannelBufSize)
 }
 
-// PushRow is part of the rowReceiver interface.
+// PushRow is part of the RowReceiver interface.
 func (rc *RowChannel) PushRow(row sqlbase.EncDatumRow) bool {
 	if atomic.LoadUint32(&rc.noMoreRows) == 1 {
 		return false
@@ -93,7 +102,7 @@ func (rc *RowChannel) PushRow(row sqlbase.EncDatumRow) bool {
 	return true
 }
 
-// Close is part of the rowReceiver interface.
+// Close is part of the RowReceiver interface.
 func (rc *RowChannel) Close(err error) {
 	if err != nil {
 		rc.dataChan <- StreamMsg{Row: nil, Err: err}
@@ -101,8 +110,66 @@ func (rc *RowChannel) Close(err error) {
 	close(rc.dataChan)
 }
 
+// NextRow is part of the RowSource interface.
+func (rc *RowChannel) NextRow() (sqlbase.EncDatumRow, error) {
+	d, ok := <-rc.C
+	if !ok {
+		// No more rows.
+		return nil, nil
+	}
+	if d.Err != nil {
+		return nil, d.Err
+	}
+	return d.Row, nil
+}
+
 // NoMoreRows causes future PushRow calls to return false. The caller should
 // still drain the channel to make sure the sender is not blocked.
 func (rc *RowChannel) NoMoreRows() {
 	atomic.StoreUint32(&rc.noMoreRows, 1)
+}
+
+// RowBuffer is an implementation of RowReceiver that buffers (accumulates)
+// results in memory, as well as an implementation of rowSender that returns
+// rows from a row buffer.
+type RowBuffer struct {
+	rows sqlbase.EncDatumRows
+	err  error
+
+	// closed is used when the RowBuffer is used as a RowReceiver; it is set to
+	// true when the sender calls Close.
+	closed bool
+
+	// done is used when the RowBuffer is used as a RowSource; it is set to true
+	// when the receiver read all the rows.
+	done bool
+}
+
+var _ RowReceiver = &RowBuffer{}
+
+// PushRow is part of the RowReceiver interface.
+func (rb *RowBuffer) PushRow(row sqlbase.EncDatumRow) bool {
+	rowCopy := append(sqlbase.EncDatumRow(nil), row...)
+	rb.rows = append(rb.rows, rowCopy)
+	return true
+}
+
+// Close is part of the RowReceiver interface.
+func (rb *RowBuffer) Close(err error) {
+	rb.err = err
+	rb.closed = true
+}
+
+// NextRow is part of the RowSource interface.
+func (rb *RowBuffer) NextRow() (sqlbase.EncDatumRow, error) {
+	if rb.err != nil {
+		return nil, rb.err
+	}
+	if len(rb.rows) == 0 {
+		rb.done = true
+		return nil, nil
+	}
+	row := rb.rows[0]
+	rb.rows = rb.rows[1:]
+	return row, nil
 }

--- a/sql/distsql/joinreader.go
+++ b/sql/distsql/joinreader.go
@@ -33,22 +33,24 @@ import (
 const joinReaderBatchSize = 100
 
 type joinReader struct {
-	// RowChannel implements the rowReceiver interface.
-	// We use the incoming rows to generate keys for row lookups, and produce
-	// the corresponding results to the output in order.
-	RowChannel
+	input RowSource
 
 	readerBase
 
-	output rowReceiver
+	output RowReceiver
 }
 
 var _ processor = &joinReader{}
 
 func newJoinReader(
-	spec *JoinReaderSpec, txn *client.Txn, output rowReceiver, evalCtx *parser.EvalContext,
+	spec *JoinReaderSpec,
+	txn *client.Txn,
+	input RowSource,
+	output RowReceiver,
+	evalCtx *parser.EvalContext,
 ) (*joinReader, error) {
 	jr := &joinReader{
+		input:  input,
 		output: output,
 	}
 
@@ -62,9 +64,6 @@ func newJoinReader(
 	if err != nil {
 		return nil, err
 	}
-
-	// Allow the input channel to buffer an entire batch.
-	jr.RowChannel.InitWithBufSize(joinReaderBatchSize)
 
 	return jr, nil
 }
@@ -104,18 +103,17 @@ func (jr *joinReader) mainLoop() error {
 		// a soft limit (perhaps send the batch out if we don't get a result
 		// within a certain amount of time).
 		for spans = spans[:0]; len(spans) < joinReaderBatchSize; {
-			d, ok := <-jr.RowChannel.C
-			if !ok {
+			row, err := jr.input.NextRow()
+			if err != nil {
+				return err
+			}
+			if row == nil {
 				if len(spans) == 0 {
 					return nil
 				}
 				break
 			}
-			if d.Err != nil {
-				return d.Err
-			}
-
-			key, err := jr.generateKey(d.Row, &alloc, primaryKeyPrefix)
+			key, err := jr.generateKey(row, &alloc, primaryKeyPrefix)
 			if err != nil {
 				return err
 			}
@@ -143,7 +141,7 @@ func (jr *joinReader) mainLoop() error {
 				// Done.
 				break
 			}
-			// Push the row to the output rowReceiver; stop if they don't need more
+			// Push the row to the output RowReceiver; stop if they don't need more
 			// rows.
 			if !jr.output.PushRow(outRow) {
 				return nil

--- a/sql/distsql/outbox.go
+++ b/sql/distsql/outbox.go
@@ -39,12 +39,12 @@ type outboxStream interface {
 	Send(*StreamMessage) error
 }
 
-// outbox implements an outgoing mailbox as a rowReceiver that receives rows and
+// outbox implements an outgoing mailbox as a RowReceiver that receives rows and
 // sends them to a gRPC stream. Its core logic runs in a goroutine. We send rows
 // when we accumulate outboxBufRows or every outboxFlushPeriod (whichever comes
 // first).
 type outbox struct {
-	// RowChannel implements the rowReceiver interface.
+	// RowChannel implements the RowReceiver interface.
 	RowChannel
 
 	outStream outboxStream
@@ -59,7 +59,7 @@ type outbox struct {
 	wg  *sync.WaitGroup
 }
 
-var _ rowReceiver = &outbox{}
+var _ RowReceiver = &outbox{}
 
 func newOutbox(stream outboxStream) *outbox {
 	return &outbox{outStream: stream}

--- a/sql/distsql/routers.go
+++ b/sql/distsql/routers.go
@@ -18,8 +18,8 @@ package distsql
 
 import "github.com/cockroachdb/cockroach/util"
 
-func makeRouter(typ OutputRouterSpec_Type, streams []rowReceiver) (
-	rowReceiver, error,
+func makeRouter(typ OutputRouterSpec_Type, streams []RowReceiver) (
+	RowReceiver, error,
 ) {
 	if len(streams) == 0 {
 		panic("no streams")

--- a/sql/distsql/server.go
+++ b/sql/distsql/server.go
@@ -61,9 +61,9 @@ func (ds *ServerImpl) setupTxn(
 }
 
 // SetupSimpleFlow sets up a simple flow, connecting the simple response output
-// stream to the given rowReceiver. The flow is not started.
+// stream to the given RowReceiver. The flow is not started.
 func (ds *ServerImpl) SetupSimpleFlow(
-	ctx context.Context, req *SetupFlowsRequest, output rowReceiver,
+	ctx context.Context, req *SetupFlowsRequest, output RowReceiver,
 ) (*Flow, error) {
 	f := &Flow{evalCtx: &ds.evalCtx}
 	f.txn = ds.setupTxn(ctx, &req.Txn)

--- a/sql/distsql/tablereader.go
+++ b/sql/distsql/tablereader.go
@@ -150,7 +150,7 @@ func (rb *readerBase) nextRow() (sqlbase.EncDatumRow, error) {
 
 // tableReader is the start of a computation flow; it performs KV operations to
 // retrieve rows for a table, runs a filter expression, and passes rows with the
-// desired column values to an output rowReceiver.
+// desired column values to an output RowReceiver.
 // See docs/RFCS/distributed_sql.md
 type tableReader struct {
 	readerBase
@@ -158,14 +158,14 @@ type tableReader struct {
 	spans                sqlbase.Spans
 	hardLimit, softLimit int64
 
-	output rowReceiver
+	output RowReceiver
 }
 
 var _ processor = &tableReader{}
 
 // newTableReader creates a tableReader.
 func newTableReader(
-	spec *TableReaderSpec, txn *client.Txn, output rowReceiver, evalCtx *parser.EvalContext,
+	spec *TableReaderSpec, txn *client.Txn, output RowReceiver, evalCtx *parser.EvalContext,
 ) (*tableReader, error) {
 	tr := &tableReader{
 		output:    output,
@@ -230,7 +230,7 @@ func (tr *tableReader) Run(wg *sync.WaitGroup) {
 			tr.output.Close(err)
 			return
 		}
-		// Push the row to the output rowReceiver; stop if they don't need more
+		// Push the row to the output RowReceiver; stop if they don't need more
 		// rows.
 		if !tr.output.PushRow(outRow) {
 			tr.output.Close(nil)

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -52,7 +52,10 @@ const sqlTxnName string = "sql txn"
 const sqlImplicitTxnName string = "sql txn implicit"
 
 // TODO(radu): experimental code for testing distSQL flows.
-const testDistSQL bool = false
+//    0 : disabled
+//    1 : enabled, sync mode
+//    2 : enabled, async mode
+const testDistSQL int = 0
 
 type traceResult struct {
 	tag   string
@@ -996,8 +999,8 @@ func (e *Executor) execStmt(
 		return result, err
 	}
 
-	if testDistSQL {
-		if err := hackPlanToUseDistSQL(plan); err != nil {
+	if testDistSQL != 0 {
+		if err := hackPlanToUseDistSQL(plan, testDistSQL == 1); err != nil {
 			return result, err
 		}
 	}


### PR DESCRIPTION
We can run certain simple local flows in "serial" mode, where each processor
dumps its output into a row buffer. This will be used for very small queries
(the kind where we know exactly how many rows we are going to read).

Introducing a rowSource interface and changing joinReader to use that as input.

Benchmarks (after is with the test flag enabled):

```
Scan1_Cockroach-4                    140µs ± 5%    162µs ±23%    +15.64%    (p=0.002 n=9+9)
Scan10_Cockroach-4                   169µs ± 2%    191µs ±28%    +13.07%   (p=0.004 n=8+10)
Scan100_Cockroach-4                  390µs ± 9%    438µs ±15%    +12.36%    (p=0.000 n=9+9)
Scan1000_Cockroach-4                2.42ms ± 7%   2.60ms ± 7%     +7.34%   (p=0.016 n=10+8)
Scan10000_Cockroach-4               21.8ms ± 3%   24.4ms ± 4%    +11.81%  (p=0.000 n=10+10)
Scan1000Limit1_Cockroach-4           154µs ±12%    154µs ± 6%       ~     (p=0.971 n=10+10)
Scan1000Limit10_Cockroach-4          171µs ± 4%    177µs ± 1%     +3.84%   (p=0.001 n=10+8)
Scan1000Limit100_Cockroach-4         389µs ± 7%    417µs ± 8%     +7.25%   (p=0.008 n=9+10)
```

(I'm not including the FilterLimit benchmarks - those are not the kind of queries that
will be run in this mode, as we don't know how many rows we need to read).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7300)

<!-- Reviewable:end -->
