### PR TITLE
storage/engine: add COCKROACH_ROCKSDB_WAL_TTL env var

### DIFF
--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -151,6 +151,7 @@ func (r *RocksDB) Open() error {
 			cache_size:      C.uint64_t(r.cacheSize),
 			memtable_budget: C.uint64_t(r.memtableBudget),
 			block_size:      C.uint64_t(envutil.EnvOrDefaultBytes("rocksdb_block_size", defaultBlockSize)),
+			wal_ttl_seconds: C.uint64_t(envutil.EnvOrDefaultDuration("rocksdb_wal_ttl", 0).Seconds()),
 			allow_os_buffer: C.bool(true),
 			logging_enabled: C.bool(log.V(3)),
 		})

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1350,6 +1350,7 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
 
   rocksdb::Options options(rocksdb::DBOptions(), cf_options);
   options.allow_os_buffer = db_opts.allow_os_buffer;
+  options.WAL_ttl_seconds = db_opts.wal_ttl_seconds;
   options.comparator = &kComparator;
   options.create_if_missing = true;
   options.info_log.reset(new DBLogger(db_opts.logging_enabled));

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -62,6 +62,7 @@ typedef struct {
   uint64_t cache_size;
   uint64_t memtable_budget;
   uint64_t block_size;
+  uint64_t wal_ttl_seconds;
   bool allow_os_buffer;
   bool logging_enabled;
 } DBOptions;


### PR DESCRIPTION
The obsolete-but-not-yet-deleted WAL files end up in an "archive"
subdirectory of the rocksdb directory. Note that if you run with a
non-zero `COCKROACHDB_ROCKSDB_WAL_TTL`, stop and restart the server with
that env var not set (or set to 0), the "archive" directory will remain
untouched. You have to set the variable to a low value (e.g. `1s`) or
manually remove the "archive" directory in order to delete the archived
WAL files.

See #7257.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7303)

<!-- Reviewable:end -->
