### PR TITLE
storage: allow multiple concurrent snapshots

### DIFF
--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2143,7 +2143,9 @@ func TestStoreChangeFrozen(t *testing.T) {
 
 func TestStoreNoConcurrentRaftSnapshots(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	store, _, stopper := createTestStore(t)
+	cfg := TestStoreConfig(nil)
+	cfg.concurrentSnapshotLimit = 1
+	store, stopper := createTestStoreWithConfig(t, &cfg)
 	defer stopper.Stop()
 
 	if !store.AcquireRaftSnapshot() {


### PR DESCRIPTION
@cuongdo this is on top of #7299 - I bet the degradation we saw with this change originally was the result of that issue. Can you test it?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7307)

<!-- Reviewable:end -->
