### PR TITLE
sql: add EncDatumRow.Compare

### DIFF
--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -74,14 +74,14 @@ func (n *distinctNode) expandPlan() error {
 			n.columnsInOrder[colIdx] = true
 		}
 		for _, c := range ordering.ordering {
-			if c.colIdx >= len(n.columnsInOrder) {
+			if c.ColIdx >= len(n.columnsInOrder) {
 				// Cannot use sort order. This happens when the
 				// columns used for sorting are not part of the output.
 				// e.g. SELECT a FROM t ORDER BY c.
 				n.columnsInOrder = nil
 				break
 			}
-			n.columnsInOrder[c.colIdx] = true
+			n.columnsInOrder[c.ColIdx] = true
 		}
 	}
 	return nil

--- a/sql/group.go
+++ b/sql/group.go
@@ -183,7 +183,7 @@ type groupNode struct {
 	// desiredOrdering is set only if we are aggregating around a single MIN/MAX
 	// function and we can compute the final result using a single row, assuming
 	// a specific ordering of the underlying plan.
-	desiredOrdering columnOrdering
+	desiredOrdering sqlbase.ColumnOrdering
 	needOnlyOneRow  bool
 	gotOneRow       bool
 
@@ -410,7 +410,7 @@ func (n *groupNode) isNotNullFilter(expr parser.TypedExpr) parser.TypedExpr {
 	if len(n.desiredOrdering) != 1 {
 		return expr
 	}
-	i := n.desiredOrdering[0].colIdx
+	i := n.desiredOrdering[0].ColIdx
 	f := n.funcs[i]
 	isNotNull := parser.NewTypedComparisonExpr(
 		parser.IsNot,
@@ -431,7 +431,7 @@ func (n *groupNode) isNotNullFilter(expr parser.TypedExpr) parser.TypedExpr {
 // aggregation. If zero or multiple MIN/MAX aggregations are requested then no
 // ordering will be requested. A negative index indicates a MAX aggregation was
 // requested for the output column.
-func desiredAggregateOrdering(funcs []*aggregateFuncHolder) columnOrdering {
+func desiredAggregateOrdering(funcs []*aggregateFuncHolder) sqlbase.ColumnOrdering {
 	limit := -1
 	direction := encoding.Ascending
 	for i, f := range funcs {
@@ -458,7 +458,7 @@ func desiredAggregateOrdering(funcs []*aggregateFuncHolder) columnOrdering {
 	if limit == -1 {
 		return nil
 	}
-	return columnOrdering{{limit, direction}}
+	return sqlbase.ColumnOrdering{{limit, direction}}
 }
 
 type extractAggregatesVisitor struct {

--- a/sql/group_test.go
+++ b/sql/group_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
@@ -29,11 +30,11 @@ func TestDesiredAggregateOrder(t *testing.T) {
 
 	testData := []struct {
 		expr     string
-		ordering columnOrdering
+		ordering sqlbase.ColumnOrdering
 	}{
 		{`a`, nil},
-		{`MIN(a)`, columnOrdering{{0, encoding.Ascending}}},
-		{`MAX(a)`, columnOrdering{{0, encoding.Descending}}},
+		{`MIN(a)`, sqlbase.ColumnOrdering{{0, encoding.Ascending}}},
+		{`MAX(a)`, sqlbase.ColumnOrdering{{0, encoding.Descending}}},
 		{`(MIN(a), MAX(a))`, nil},
 		{`(MIN(a), AVG(a))`, nil},
 		{`(MIN(a), COUNT(a))`, nil},

--- a/sql/ordering_test.go
+++ b/sql/ordering_test.go
@@ -20,13 +20,14 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
 type desiredCase struct {
 	line            int
-	desired         columnOrdering
+	desired         sqlbase.ColumnOrdering
 	expected        int
 	expectedReverse int
 }
@@ -36,7 +37,7 @@ type computeOrderCase struct {
 	cases    []desiredCase
 }
 
-func defTestCase(expected, expectedReverse int, desired columnOrdering) desiredCase {
+func defTestCase(expected, expectedReverse int, desired sqlbase.ColumnOrdering) desiredCase {
 	// The line number is used to identify testcases in error messages.
 	_, _, line, _ := runtime.Caller(1)
 	return desiredCase{
@@ -62,35 +63,35 @@ func TestComputeOrderingMatch(t *testing.T) {
 				unique:         false,
 			},
 			cases: []desiredCase{
-				defTestCase(0, 0, columnOrdering{{1, desc}, {5, asc}}),
+				defTestCase(0, 0, sqlbase.ColumnOrdering{{1, desc}, {5, asc}}),
 			},
 		},
 		{
 			// Ordering with no exact-match columns.
 			existing: orderingInfo{
 				exactMatchCols: nil,
-				ordering:       []columnOrderInfo{{1, desc}, {2, asc}},
+				ordering:       sqlbase.ColumnOrdering{{1, desc}, {2, asc}},
 				unique:         false,
 			},
 			cases: []desiredCase{
-				defTestCase(1, 0, columnOrdering{{1, desc}, {5, asc}}),
-				defTestCase(0, 1, columnOrdering{{1, asc}, {5, asc}, {2, asc}}),
+				defTestCase(1, 0, sqlbase.ColumnOrdering{{1, desc}, {5, asc}}),
+				defTestCase(0, 1, sqlbase.ColumnOrdering{{1, asc}, {5, asc}, {2, asc}}),
 			},
 		},
 		{
 			// Ordering with no exact-match columns but with distinct.
 			existing: orderingInfo{
 				exactMatchCols: nil,
-				ordering:       []columnOrderInfo{{1, desc}, {2, asc}},
+				ordering:       sqlbase.ColumnOrdering{{1, desc}, {2, asc}},
 				unique:         true,
 			},
 			cases: []desiredCase{
-				defTestCase(1, 0, columnOrdering{{1, desc}, {5, asc}}),
-				defTestCase(3, 0, columnOrdering{{1, desc}, {2, asc}, {5, asc}}),
-				defTestCase(4, 0, columnOrdering{{1, desc}, {2, asc}, {5, asc}, {6, desc}}),
-				defTestCase(0, 1, columnOrdering{{1, asc}, {5, asc}, {2, asc}}),
-				defTestCase(0, 3, columnOrdering{{1, asc}, {2, desc}, {5, asc}}),
-				defTestCase(0, 4, columnOrdering{{1, asc}, {2, desc}, {5, asc}, {6, asc}}),
+				defTestCase(1, 0, sqlbase.ColumnOrdering{{1, desc}, {5, asc}}),
+				defTestCase(3, 0, sqlbase.ColumnOrdering{{1, desc}, {2, asc}, {5, asc}}),
+				defTestCase(4, 0, sqlbase.ColumnOrdering{{1, desc}, {2, asc}, {5, asc}, {6, desc}}),
+				defTestCase(0, 1, sqlbase.ColumnOrdering{{1, asc}, {5, asc}, {2, asc}}),
+				defTestCase(0, 3, sqlbase.ColumnOrdering{{1, asc}, {2, desc}, {5, asc}}),
+				defTestCase(0, 4, sqlbase.ColumnOrdering{{1, asc}, {2, desc}, {5, asc}, {6, asc}}),
 			},
 		},
 		{
@@ -101,43 +102,43 @@ func TestComputeOrderingMatch(t *testing.T) {
 				unique:         false,
 			},
 			cases: []desiredCase{
-				defTestCase(1, 1, columnOrdering{{2, desc}, {5, asc}, {1, asc}}),
-				defTestCase(0, 0, columnOrdering{{5, asc}, {2, asc}}),
+				defTestCase(1, 1, sqlbase.ColumnOrdering{{2, desc}, {5, asc}, {1, asc}}),
+				defTestCase(0, 0, sqlbase.ColumnOrdering{{5, asc}, {2, asc}}),
 			},
 		},
 		{
 			// Ordering with exact-match columns.
 			existing: orderingInfo{
 				exactMatchCols: map[int]struct{}{0: e, 5: e, 6: e},
-				ordering:       []columnOrderInfo{{1, desc}, {2, asc}},
+				ordering:       sqlbase.ColumnOrdering{{1, desc}, {2, asc}},
 				unique:         false,
 			},
 			cases: []desiredCase{
-				defTestCase(2, 0, columnOrdering{{1, desc}, {5, asc}}),
-				defTestCase(2, 1, columnOrdering{{5, asc}, {1, desc}}),
-				defTestCase(2, 2, columnOrdering{{0, desc}, {5, asc}}),
-				defTestCase(1, 0, columnOrdering{{1, desc}, {2, desc}}),
-				defTestCase(5, 2, columnOrdering{{0, asc}, {6, desc}, {1, desc}, {5, desc}, {2, asc}}),
-				defTestCase(2, 2, columnOrdering{{0, asc}, {6, desc}, {2, asc}, {5, desc}, {1, desc}}),
+				defTestCase(2, 0, sqlbase.ColumnOrdering{{1, desc}, {5, asc}}),
+				defTestCase(2, 1, sqlbase.ColumnOrdering{{5, asc}, {1, desc}}),
+				defTestCase(2, 2, sqlbase.ColumnOrdering{{0, desc}, {5, asc}}),
+				defTestCase(1, 0, sqlbase.ColumnOrdering{{1, desc}, {2, desc}}),
+				defTestCase(5, 2, sqlbase.ColumnOrdering{{0, asc}, {6, desc}, {1, desc}, {5, desc}, {2, asc}}),
+				defTestCase(2, 2, sqlbase.ColumnOrdering{{0, asc}, {6, desc}, {2, asc}, {5, desc}, {1, desc}}),
 			},
 		},
 		{
 			// Ordering with exact-match columns and distinct.
 			existing: orderingInfo{
 				exactMatchCols: map[int]struct{}{0: e, 5: e, 6: e},
-				ordering:       []columnOrderInfo{{1, desc}, {2, asc}},
+				ordering:       sqlbase.ColumnOrdering{{1, desc}, {2, asc}},
 				unique:         true,
 			},
 			cases: []desiredCase{
-				defTestCase(2, 0, columnOrdering{{1, desc}, {5, asc}}),
-				defTestCase(2, 1, columnOrdering{{5, asc}, {1, desc}}),
-				defTestCase(4, 0, columnOrdering{{1, desc}, {5, asc}, {2, asc}, {7, desc}}),
-				defTestCase(4, 1, columnOrdering{{5, asc}, {1, desc}, {2, asc}, {7, desc}}),
-				defTestCase(2, 2, columnOrdering{{0, desc}, {5, asc}}),
-				defTestCase(2, 1, columnOrdering{{5, asc}, {1, desc}, {2, desc}}),
-				defTestCase(1, 0, columnOrdering{{1, desc}, {2, desc}}),
-				defTestCase(6, 2, columnOrdering{{0, asc}, {6, desc}, {1, desc}, {5, desc}, {2, asc}, {9, asc}}),
-				defTestCase(2, 2, columnOrdering{{0, asc}, {6, desc}, {2, asc}, {5, desc}, {1, desc}}),
+				defTestCase(2, 0, sqlbase.ColumnOrdering{{1, desc}, {5, asc}}),
+				defTestCase(2, 1, sqlbase.ColumnOrdering{{5, asc}, {1, desc}}),
+				defTestCase(4, 0, sqlbase.ColumnOrdering{{1, desc}, {5, asc}, {2, asc}, {7, desc}}),
+				defTestCase(4, 1, sqlbase.ColumnOrdering{{5, asc}, {1, desc}, {2, asc}, {7, desc}}),
+				defTestCase(2, 2, sqlbase.ColumnOrdering{{0, desc}, {5, asc}}),
+				defTestCase(2, 1, sqlbase.ColumnOrdering{{5, asc}, {1, desc}, {2, desc}}),
+				defTestCase(1, 0, sqlbase.ColumnOrdering{{1, desc}, {2, desc}}),
+				defTestCase(6, 2, sqlbase.ColumnOrdering{{0, asc}, {6, desc}, {1, desc}, {5, desc}, {2, asc}, {9, asc}}),
+				defTestCase(2, 2, sqlbase.ColumnOrdering{{0, asc}, {6, desc}, {2, asc}, {5, desc}, {1, desc}}),
 			},
 		},
 	}

--- a/sql/select.go
+++ b/sql/select.go
@@ -351,7 +351,7 @@ func (p *planner) SelectClause(
 
 func (s *selectNode) expandPlan() error {
 	// Get the ordering for index selection (if any).
-	var ordering columnOrdering
+	var ordering sqlbase.ColumnOrdering
 	var grouping bool
 
 	if s.top.group != nil {
@@ -724,12 +724,12 @@ func (s *selectNode) computeOrdering(fromOrder orderingInfo) orderingInfo {
 	// The rows from the index are ordered by k then by v. We cannot make any use of this
 	// ordering as an ordering on v.
 	for _, colOrder := range fromOrder.ordering {
-		colRef := columnRef{&s.source.info, colOrder.colIdx}
+		colRef := columnRef{&s.source.info, colOrder.ColIdx}
 		renderIdx, ok := s.findRenderIndexForCol(colRef)
 		if !ok {
 			return ordering
 		}
-		ordering.addColumn(renderIdx, colOrder.direction)
+		ordering.addColumn(renderIdx, colOrder.Direction)
 	}
 	// We added all columns in fromOrder; we can copy the distinct flag.
 	ordering.unique = fromOrder.unique

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -35,7 +35,7 @@ import (
 type sortNode struct {
 	plan     planNode
 	columns  []ResultColumn
-	ordering columnOrdering
+	ordering sqlbase.ColumnOrdering
 
 	needSort     bool
 	sortStrategy sortingStrategy
@@ -70,7 +70,7 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, error)
 	if s, ok := n.(*selectNode); ok {
 		numOriginalCols = s.numOriginalCols
 	}
-	var ordering columnOrdering
+	var ordering sqlbase.ColumnOrdering
 
 	for _, o := range orderBy {
 		index := -1
@@ -151,7 +151,7 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, error)
 		if o.Direction == parser.Descending {
 			direction = encoding.Descending
 		}
-		ordering = append(ordering, columnOrderInfo{index, direction})
+		ordering = append(ordering, sqlbase.ColumnOrderInfo{ColIdx: index, Direction: direction})
 	}
 
 	return &sortNode{columns: columns, ordering: ordering}, nil

--- a/sql/sqlbase/encoded_datum.go
+++ b/sql/sqlbase/encoded_datum.go
@@ -218,6 +218,33 @@ func (r EncDatumRow) String() string {
 	return b.String()
 }
 
+// Compare returns the relative ordering of two EncDatumRows according to a
+// ColumnOrdering:
+//   -1 if the receiver comes before the rhs in the ordering,
+//   +1 if the receiver comes after the rhs in the ordering,
+//   0 if the relative order does not matter (i.e. the two rows have the same
+//     values for the columns in the ordering).
+//
+// Note that a return value of 0 does not (in general) imply that the rows are
+// equal; for example, rows [1 1 5] and [1 1 6] when compared against ordering
+// {{0, asc}, {1, asc}} (i.e. ordered by first column and then by second
+// column).
+func (r EncDatumRow) Compare(a *DatumAlloc, ordering ColumnOrdering, rhs EncDatumRow) (int, error) {
+	for _, c := range ordering {
+		cmp, err := r[c.ColIdx].Compare(a, &rhs[c.ColIdx])
+		if err != nil {
+			return 0, err
+		}
+		if cmp != 0 {
+			if c.Direction == encoding.Descending {
+				cmp = -cmp
+			}
+			return cmp, nil
+		}
+	}
+	return 0, nil
+}
+
 // EncDatumRows is a slice of EncDatumRows.
 type EncDatumRows []EncDatumRow
 

--- a/sql/sqlbase/ordering.go
+++ b/sql/sqlbase/ordering.go
@@ -1,0 +1,31 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sqlbase
+
+import "github.com/cockroachdb/cockroach/util/encoding"
+
+// ColumnOrderInfo describes a column (as an index) and a desired order
+// direction.
+type ColumnOrderInfo struct {
+	ColIdx    int
+	Direction encoding.Direction
+}
+
+// ColumnOrdering is used to describe a desired column ordering. For example,
+//     []ColumnOrderInfo{ {3, true}, {1, false} }
+// represents an ordering first by column 3 (descending), then by column 1 (ascending).
+type ColumnOrdering []ColumnOrderInfo

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/client"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
@@ -48,7 +49,7 @@ var traceColumns = append([]ResultColumn{
 	{Name: "Event", Typ: parser.TypeString},
 }, debugColumns...)
 
-var traceOrdering = []columnOrderInfo{
+var traceOrdering = sqlbase.ColumnOrdering{
 	{len(traceColumns), encoding.Ascending}, /* Start time */
 	{2, encoding.Ascending},                 /* Span pos */
 }

--- a/sql/values.go
+++ b/sql/values.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 )
@@ -31,7 +32,7 @@ type valuesNode struct {
 	n        *parser.ValuesClause
 	p        *planner
 	columns  []ResultColumn
-	ordering columnOrdering
+	ordering sqlbase.ColumnOrdering
 	tuples   [][]parser.TypedExpr
 	rows     []parser.DTuple
 
@@ -200,12 +201,12 @@ func (n *valuesNode) Less(i, j int) bool {
 func (n *valuesNode) ValuesLess(ra, rb parser.DTuple) bool {
 	for _, c := range n.ordering {
 		var da, db parser.Datum
-		if c.direction == encoding.Ascending {
-			da = ra[c.colIdx]
-			db = rb[c.colIdx]
+		if c.Direction == encoding.Ascending {
+			da = ra[c.ColIdx]
+			db = rb[c.ColIdx]
 		} else {
-			da = rb[c.colIdx]
-			db = ra[c.colIdx]
+			da = rb[c.ColIdx]
+			db = ra[c.ColIdx]
 		}
 		// TODO(pmattis): This is assuming that the datum types are compatible. I'm
 		// not sure this always holds as `CASE` expressions can return different


### PR DESCRIPTION
Moving columnOrdering to sqlbase (separate commit). Adding function that compares two EncDatumRows according to a ColumnOrdering.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7308)

<!-- Reviewable:end -->
