### PR TITLE
eagerly write Raft state for new Ranges

### DIFF
--- a/storage/below_raft_protos_test.go
+++ b/storage/below_raft_protos_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -65,6 +66,11 @@ type fixture struct {
 }
 
 var belowRaftGoldenProtos = map[reflect.Type]fixture{
+	reflect.TypeOf(&raftpb.HardState{}): {
+		populatedConstructor: func(r *rand.Rand) proto.Message { return &raftpb.HardState{Term: 1, Vote: 2, Commit: 3} },
+		emptySum:             13621293256077144893,
+		populatedSum:         11100902660574274053,
+	},
 	reflect.TypeOf(&enginepb.MVCCMetadata{}): {
 		populatedConstructor: func(r *rand.Rand) proto.Message { return enginepb.NewPopulatedMVCCMetadata(r, false) },
 		emptySum:             7551962144604783939,

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -325,7 +325,7 @@ func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor, clock *hlc.Cloc
 		return err
 	}
 
-	r.mu.lastIndex, err = loadLastIndex(r.store.Engine(), r.RangeID, desc.IsInitialized())
+	r.mu.lastIndex, err = loadLastIndex(r.store.Engine(), r.RangeID)
 	if err != nil {
 		return err
 	}
@@ -1388,7 +1388,7 @@ func (r *Replica) handleRaftReady() error {
 
 	}
 	if !raft.IsEmptyHardState(rd.HardState) {
-		if err := r.setHardState(writer, rd.HardState); err != nil {
+		if err := setHardState(writer, r.RangeID, rd.HardState); err != nil {
 			return err
 		}
 	}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -731,6 +731,21 @@ func (r *Replica) State() storagebase.RangeInfo {
 	return ri
 }
 
+// assertState can be called from the Raft goroutine to check that the in-memory
+// and on-disk states of the Replica are congruent.
+// TODO(tschottdorf): Consider future removal (for example, when #7224 is resolved).
+func (r *Replica) assertState(reader engine.Reader) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	diskState, err := loadState(reader, r.mu.state.Desc)
+	if err != nil {
+		panic(err)
+	}
+	if !reflect.DeepEqual(diskState, r.mu.state) {
+		log.Fatalf("on-disk and in-memory state diverged:\n%+v\n%+v", diskState, r.mu.state)
+	}
+}
+
 // Send adds a command for execution on this range. The command's
 // affected keys are verified to be contained within the range and the
 // range's leadership is confirmed. The command is then dispatched
@@ -1801,6 +1816,9 @@ func (r *Replica) applyRaftCommand(
 
 	if forcedError != nil {
 		batch = r.store.Engine().NewBatch()
+		batch.Defer(func() {
+			r.assertState(r.store.Engine())
+		})
 		br, rErr = nil, forcedError
 	} else {
 		batch, ms, br, intents, rErr = r.applyRaftCommandInBatch(ctx, idKey,
@@ -1813,7 +1831,7 @@ func (r *Replica) applyRaftCommand(
 	// remaining writes are the raft applied index and the updated MVCC stats.
 	writer := batch.Distinct()
 
-	// Advance the last applied index and commit the batch.
+	// Advance the last applied index.
 	if err := setAppliedIndex(writer, &ms, r.RangeID, index, leaseIndex); err != nil {
 		log.Fatalc(ctx, "setting applied index in a batch should never fail: %s", err)
 	}
@@ -1833,9 +1851,13 @@ func (r *Replica) applyRaftCommand(
 	// Update store-level MVCC stats with merged range stats.
 	r.store.metrics.addMVCCStats(ms)
 
-	if err := batch.Commit(); err != nil {
-		rErr = roachpb.NewError(newReplicaCorruptionError(util.Errorf("could not commit batch"), err, rErr.GoError()))
-	} else {
+	// TODO(petermattis): We did not close the writer in an earlier version of
+	// the code, which went undetected even though we used the batch after
+	// (though only to commit it). We should add an assertion to prevent that in
+	// the future.
+	writer.Close()
+
+	batch.Defer(func() {
 		r.mu.Lock()
 		// Update cached appliedIndex if we were able to set the applied index
 		// on disk.
@@ -1843,6 +1865,10 @@ func (r *Replica) applyRaftCommand(
 		r.mu.state.LeaseAppliedIndex = leaseIndex
 		r.mu.state.Stats = newMS
 		r.mu.Unlock()
+	})
+	if err := batch.Commit(); err != nil {
+		rErr = roachpb.NewError(newReplicaCorruptionError(util.Errorf("could not commit batch"), err, rErr.GoError()))
+	} else {
 	}
 
 	// On successful write commands handle write-related triggers including

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -673,6 +673,9 @@ func containsKeyRange(desc roachpb.RangeDescriptor, start, end roachpb.Key) bool
 
 // getLastReplicaGCTimestamp reads the timestamp at which the replica was
 // last checked for garbage collection.
+//
+// TODO(tschottdorf): we may want to phase this out in favor of using
+// gcThreshold.
 func (r *Replica) getLastReplicaGCTimestamp() (hlc.Timestamp, error) {
 	key := keys.RangeLastReplicaGCTimestampKey(r.RangeID)
 	timestamp := hlc.Timestamp{}

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -756,6 +756,12 @@ func (r *Replica) runCommitTrigger(ctx context.Context, batch engine.Batch, ms *
 	args roachpb.EndTransactionRequest, txn *roachpb.Transaction) error {
 	ct := args.InternalCommitTrigger
 	if ct != nil {
+		// Assert that the on-disk state doesn't diverge from the in-memory
+		// state as a result of the commit trigger.
+		batch.Defer(func() {
+			r.assertState(r.store.Engine())
+		})
+
 		// Hold readMu across the application of any commit trigger.
 		// This makes sure that no reads are happening in parallel;
 		// see #3148.

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2250,9 +2250,7 @@ func (r *Replica) splitTrigger(
 	}
 	log.Trace(ctx, fmt.Sprintf("copied abort cache (%d entries)", seqCount))
 
-	// Add the new split replica to the store. This step atomically
-	// updates the EndKey of the updated replica and also adds the
-	// new replica to the store's replica map.
+	// Create the new Replica representing the right side of the split.
 	newRng, err := NewReplica(&split.NewDesc, r.store, 0)
 	if err != nil {
 		return err
@@ -2280,6 +2278,9 @@ func (r *Replica) splitTrigger(
 	// Note: you must not use the trace inside of this defer since it may
 	// run after the trace has already completed.
 	batch.Defer(func() {
+		// Add the new split replica to the store. This step atomically
+		// updates the EndKey of the updated replica and also adds the
+		// new replica to the store's replica map.
 		if err := r.store.SplitRange(r, newRng); err != nil {
 			// Our in-memory state has diverged from the on-disk state.
 			log.Fatalf("failed to update Store after split: %s", err)

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -587,6 +587,9 @@ func (r *Replica) applySnapshot(batch engine.Batch, snap raftpb.Snapshot) error 
 		log.Fatalf("%d: snapshot resulted in appliedIndex=%d, metadataIndex=%d",
 			s.Desc.RangeID, s.RaftAppliedIndex, snap.Metadata.Index)
 	}
+	batch.Defer(func() {
+		r.assertState(r.store.Engine())
+	})
 
 	batch.Defer(func() {
 		r.mu.Lock()

--- a/storage/replica_state.go
+++ b/storage/replica_state.go
@@ -1,0 +1,120 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package storage
+
+import (
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/storage/storagebase"
+	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/protoutil"
+	"golang.org/x/net/context"
+)
+
+// TODO(tschottdorf): unified method to update both in-mem and on-disk
+// state, similar to how loadState unifies restoring from storage.
+func loadState(reader engine.Reader, desc *roachpb.RangeDescriptor) (storagebase.ReplicaState, error) {
+	var s storagebase.ReplicaState
+	// TODO(tschottdorf): figure out whether this is always synchronous with
+	// on-disk state (likely iffy during Split/ChangeReplica triggers).
+	s.Desc = protoutil.Clone(desc).(*roachpb.RangeDescriptor)
+	// Read the leader lease.
+	var err error
+	if s.Lease, err = loadLease(reader, desc.RangeID); err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+
+	if s.Frozen, err = loadFrozenStatus(reader, desc.RangeID); err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+
+	if s.GCThreshold, err = loadGCThreshold(reader, desc.RangeID); err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+
+	if s.RaftAppliedIndex, s.LeaseAppliedIndex, err = loadAppliedIndex(
+		reader,
+		desc.RangeID,
+		desc.IsInitialized(),
+	); err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+
+	if s.Stats, err = loadMVCCStats(reader, desc.RangeID); err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+
+	return s, nil
+}
+
+// TODO(tschottdorf): write and use setLease, too.
+func loadLease(eng engine.Reader, rangeID roachpb.RangeID) (*roachpb.Lease, error) {
+	lease := &roachpb.Lease{}
+	if _, err := engine.MVCCGetProto(context.Background(), eng, keys.RangeLeaderLeaseKey(rangeID), hlc.ZeroTimestamp, true, nil, lease); err != nil {
+		return nil, err
+	}
+	return lease, nil
+}
+
+func setGCThreshold(
+	eng engine.ReadWriter, ms *enginepb.MVCCStats, rangeID roachpb.RangeID, threshold *hlc.Timestamp,
+) error {
+	return engine.MVCCPutProto(context.Background(), eng, ms,
+		keys.RangeLastGCKey(rangeID), hlc.ZeroTimestamp, nil, threshold)
+}
+
+func loadGCThreshold(eng engine.Reader, rangeID roachpb.RangeID) (hlc.Timestamp, error) {
+	var t hlc.Timestamp
+	_, err := engine.MVCCGetProto(context.Background(), eng, keys.RangeLastGCKey(rangeID),
+		hlc.ZeroTimestamp, true, nil, &t)
+	return t, err
+}
+
+func loadMVCCStats(eng engine.Reader, rangeID roachpb.RangeID) (enginepb.MVCCStats, error) {
+	var ms enginepb.MVCCStats
+	if err := engine.MVCCGetRangeStats(context.Background(), eng, rangeID, &ms); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	return ms, nil
+}
+
+func setMVCCStats(eng engine.ReadWriter, rangeID roachpb.RangeID, newMS enginepb.MVCCStats) error {
+	return engine.MVCCSetRangeStats(context.Background(), eng, rangeID, &newMS)
+}
+
+func setFrozenStatus(
+	eng engine.ReadWriter, ms *enginepb.MVCCStats, rangeID roachpb.RangeID, frozen bool,
+) error {
+	var val roachpb.Value
+	val.SetBool(frozen)
+	return engine.MVCCPut(context.Background(), eng, ms,
+		keys.RangeFrozenStatusKey(rangeID), hlc.ZeroTimestamp, val, nil)
+}
+
+func loadFrozenStatus(eng engine.Reader, rangeID roachpb.RangeID) (bool, error) {
+	val, _, err := engine.MVCCGet(context.Background(), eng, keys.RangeFrozenStatusKey(rangeID),
+		hlc.ZeroTimestamp, true, nil)
+	if err != nil {
+		return false, err
+	}
+	if val == nil {
+		return false, nil
+	}
+	return val.GetBool()
+}

--- a/storage/stats_test.go
+++ b/storage/stats_test.go
@@ -27,6 +27,15 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
+// initialStats are the stats for a Replica which has been created through
+// bootstrapRangeOnly. These stats are not empty because we call
+// writeInitialState().
+func initialStats() enginepb.MVCCStats {
+	return enginepb.MVCCStats{
+		SysBytes: 151,
+		SysCount: 5,
+	}
+}
 func TestRangeStatsEmpty(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{
@@ -36,8 +45,8 @@ func TestRangeStatsEmpty(t *testing.T) {
 	defer tc.Stop()
 
 	ms := tc.rng.GetMVCCStats()
-	if !reflect.DeepEqual(ms, enginepb.MVCCStats{}) {
-		t.Errorf("expected empty stats; got %+v", ms)
+	if exp := initialStats(); !reflect.DeepEqual(ms, exp) {
+		t.Errorf("expected stats %+v; got %+v", exp, ms)
 	}
 }
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -1321,9 +1321,12 @@ func (s *Store) BootstrapRange(initialValues []roachpb.KeyValue) error {
 	if err := engine.AccountForSelf(ms, desc.RangeID); err != nil {
 		return err
 	}
-	if err := engine.MVCCSetRangeStats(ctx, batch, desc.RangeID, ms); err != nil {
+
+	updatedMS, err := writeInitialState(batch, *ms, *desc)
+	if err != nil {
 		return err
 	}
+	*ms = updatedMS
 
 	if err := batch.Commit(); err != nil {
 		return err

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -881,6 +881,11 @@ func splitTestRange(store *Store, key, splitKey roachpb.RKey, t *testing.T) *Rep
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Minimal amount of work to keep this deprecated machinery working: Write
+	// some required Raft keys.
+	if _, err := writeInitialState(store.engine, enginepb.MVCCStats{}, *desc); err != nil {
+		t.Fatal(err)
+	}
 	newRng, err := NewReplica(desc, store, 0)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Change the initialization of Raft groups so that whenever we create a Replica
for a "new" Raft group (as opposed to creating a Replica that will receive
a snapshot), we write an initial ReplicaState and associated Raft state.

The WIP part is in the last commit which disables some tests (all of which, I think,
create replicas out-of-band and thus don't properly initialize the state). Some of
them may actually pass, but they shouldn't (I flagged them while I still had an
assertion in there which I'm planning to put in again).

We're still updating in-mem and on-disk state kind of ad-hoc, but that's for a future
PR.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7310)

<!-- Reviewable:end -->
