### PR TITLE
Change SetupMultinodeTestCluster so that it waits for at least one of…

### DIFF
--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -540,7 +540,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 		}
 	ctx := server.MakeTestContext()
 	ctx.TestingKnobs.Store = &storeKnobs
-	s := server.StartTestServerWithContext(t, &ctx)
+	s := server.StartTestServerWithContext(t, &ctx, server.StartParams{Nodes: 1})
 	defer s.Stop()
 	db := setupMultipleRanges(t, s, "b")
 

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -114,7 +114,7 @@ func TestIntentResolution(t *testing.T) {
 			ctx := MakeTestContext()
 			ctx.TestingKnobs.Store = &storeKnobs
 
-			s := StartTestServerWithContext(t, &ctx)
+			s := StartTestServerWithContext(t, &ctx, StartParams{Nodes: 1})
 			defer s.Stop()
 			// Split the Range. This should not have any asynchronous intents.
 			if err := s.db.AdminSplit(splitKey); err != nil {

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -55,9 +55,11 @@ const (
 
 // StartTestServerWithContext starts an in-memory test server.
 // ctx can be nil, in which case a default context will be created.
-func StartTestServerWithContext(t util.Tester, ctx *Context) TestServer {
+func StartTestServerWithContext(t util.Tester, ctx *Context, startParams StartParams) TestServer {
 	s := TestServer{Ctx: ctx}
-	if err := s.Start(); err != nil {
+	var err error
+	err = s.StartWithStopper(nil, startParams)
+	if err != nil {
 		if t != nil {
 			t.Fatalf("Could not start server: %v", err)
 		} else {
@@ -69,7 +71,7 @@ func StartTestServerWithContext(t util.Tester, ctx *Context) TestServer {
 
 // StartTestServer starts an in-memory test server.
 func StartTestServer(t util.Tester) TestServer {
-	return StartTestServerWithContext(t, nil)
+	return StartTestServerWithContext(t, nil, StartParams{Nodes: 1})
 }
 
 // StartTestServerJoining starts an in-memory test server that attempts to join `other`.
@@ -152,6 +154,49 @@ type TestServer struct {
 	StoresPerNode int
 }
 
+// StartParams are knobs that determine the properties of a testserver when it
+// initializes.
+type StartParams struct {
+	Nodes int
+}
+
+// A MultinodeTestCluster is an array of in-memory nodes connected to each other.
+type MultinodeTestCluster struct {
+	Servers []TestServer
+}
+
+// WaitForFullReplication waits until all of the nodes in the cluster have the
+// same number of replicas.
+func (tc *MultinodeTestCluster) WaitForFullReplication() error {
+	// TODO (WillHaack): Optimize sleep time.
+	for notReplicated := true; notReplicated; time.Sleep(100 * time.Millisecond) {
+		notReplicated = false
+		var numReplicas int
+		err := tc.Servers[0].Stores().VisitStores(func(s *storage.Store) error {
+			numReplicas = s.ReplicaCount()
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		for _, server := range tc.Servers {
+			err := server.Stores().VisitStores(func(s *storage.Store) error {
+				if numReplicas != s.ReplicaCount() {
+					notReplicated = true
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+			if notReplicated {
+				break
+			}
+		}
+	}
+	return nil
+}
+
 // Stopper returns the embedded server's Stopper.
 func (ts *TestServer) Stopper() *stop.Stopper {
 	return ts.stopper
@@ -203,12 +248,12 @@ func (ts *TestServer) DB() *client.DB {
 // TestServer.ServingAddr() after Start() for client connections. Use Stop()
 // to shutdown the server after the test completes.
 func (ts *TestServer) Start() error {
-	return ts.StartWithStopper(nil)
+	return ts.StartWithStopper(nil, StartParams{Nodes: 1})
 }
 
 // StartWithStopper is the same as Start, but allows passing a stopper
 // explicitly.
-func (ts *TestServer) StartWithStopper(stopper *stop.Stopper) error {
+func (ts *TestServer) StartWithStopper(stopper *stop.Stopper, StartParams StartParams) error {
 	if ts.Ctx == nil {
 		ctx := MakeTestContext()
 		ts.Ctx = &ctx
@@ -221,7 +266,9 @@ func (ts *TestServer) StartWithStopper(stopper *stop.Stopper) error {
 	// Change the replication requirements so we don't get log spam about ranges
 	// not being replicated enough.
 	cfg := config.DefaultZoneConfig()
-	cfg.ReplicaAttrs = []roachpb.Attributes{{}}
+
+	cfg.ReplicaAttrs = make([]roachpb.Attributes, StartParams.Nodes)
+
 	fn := config.TestingSetDefaultZoneConfig(cfg)
 	stopper.AddCloser(stop.CloserFn(fn))
 

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -56,6 +56,16 @@ func benchmarkCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
 	f(b, db)
 }
 
+func benchmarkMultinodeCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
+	defer tracing.Disable()()
+	testCluster, conns, cleanup := SetupMultinodeTestCluster(b, 3, "bench")
+	if err := testCluster.WaitForFullReplication(); err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+	f(b, conns[0])
+}
+
 func benchmarkPostgres(b *testing.B, f func(b *testing.B, db *gosql.DB)) {
 	// Note: the following uses SSL. To run this, make sure your local
 	// Postgres server has SSL enabled. To use Cockroach's checked-in
@@ -122,6 +132,10 @@ func runBenchmarkSelect1(b *testing.B, db *gosql.DB) {
 
 func BenchmarkSelect1_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkSelect1)
+}
+
+func BenchmarkSelect1Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkSelect1)
 }
 
 func BenchmarkSelect1_Postgres(b *testing.B) {
@@ -197,6 +211,10 @@ func BenchmarkSelect2_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkSelect2)
 }
 
+func BenchmarkSelect2Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkSelect2)
+}
+
 func BenchmarkSelect2_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkSelect2)
 }
@@ -216,6 +234,10 @@ func runBenchmarkSelect3(b *testing.B, db *gosql.DB) {
 
 func BenchmarkSelect3_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkSelect3)
+}
+
+func BenchmarkSelect3Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkSelect3)
 }
 
 func BenchmarkSelect3_Postgres(b *testing.B) {
@@ -281,12 +303,20 @@ func BenchmarkInsert1_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkInsert1)
 }
 
+func BenchmarkInsert1Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkInsert1)
+}
+
 func BenchmarkInsert1_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkInsert1)
 }
 
 func BenchmarkInsert10_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkInsert10)
+}
+
+func BenchmarkInsert10Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkInsert10)
 }
 
 func BenchmarkInsert10_Postgres(b *testing.B) {
@@ -297,12 +327,20 @@ func BenchmarkInsert100_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkInsert100)
 }
 
+func BenchmarkInsert100Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkInsert100)
+}
+
 func BenchmarkInsert100_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkInsert100)
 }
 
 func BenchmarkInsert1000_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkInsert1000)
+}
+
+func BenchmarkInsert1000Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkInsert1000)
 }
 
 func BenchmarkInsert1000_Postgres(b *testing.B) {
@@ -377,12 +415,20 @@ func BenchmarkUpdate1_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkUpdate1)
 }
 
+func BenchmarkUpdate1Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkUpdate1)
+}
+
 func BenchmarkUpdate1_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkUpdate1)
 }
 
 func BenchmarkUpdate10_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkUpdate10)
+}
+
+func BenchmarkUpdate10Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkUpdate10)
 }
 
 func BenchmarkUpdate10_Postgres(b *testing.B) {
@@ -393,12 +439,20 @@ func BenchmarkUpdate100_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkUpdate100)
 }
 
+func BenchmarkUpdate100Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkUpdate100)
+}
+
 func BenchmarkUpdate100_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkUpdate100)
 }
 
 func BenchmarkUpdate1000_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkUpdate1000)
+}
+
+func BenchmarkUpdate1000Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkUpdate1000)
 }
 
 func BenchmarkUpdate1000_Postgres(b *testing.B) {
@@ -488,6 +542,22 @@ func BenchmarkUpsert1000_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkUpsert1000)
 }
 
+func BenchmarkUpsert1Multinode_ockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkUpsert1)
+}
+
+func BenchmarkUpsert10Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkUpsert10)
+}
+
+func BenchmarkUpsert100Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkUpsert100)
+}
+
+func BenchmarkUpsert1000Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkUpsert1000)
+}
+
 // runBenchmarkDelete benchmarks deleting count rows from a table.
 func runBenchmarkDelete(b *testing.B, db *gosql.DB, rows int) {
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.delete`); err != nil {
@@ -555,12 +625,20 @@ func BenchmarkDelete1_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkDelete1)
 }
 
+func BenchmarkDelete1Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkDelete1)
+}
+
 func BenchmarkDelete1_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkDelete1)
 }
 
 func BenchmarkDelete10_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkDelete10)
+}
+
+func BenchmarkDelete10Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkDelete10)
 }
 
 func BenchmarkDelete10_Postgres(b *testing.B) {
@@ -571,12 +649,20 @@ func BenchmarkDelete100_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkDelete100)
 }
 
+func BenchmarkDelete100Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkDelete100)
+}
+
 func BenchmarkDelete100_Postgres(b *testing.B) {
 	benchmarkPostgres(b, runBenchmarkDelete100)
 }
 
 func BenchmarkDelete1000_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, runBenchmarkDelete1000)
+}
+
+func BenchmarkDelete1000Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, runBenchmarkDelete1000)
 }
 
 func BenchmarkDelete1000_Postgres(b *testing.B) {
@@ -642,12 +728,20 @@ func BenchmarkScan1_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1, 0) })
 }
 
+func BenchmarkScan1Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1, 0) })
+}
+
 func BenchmarkScan1_Postgres(b *testing.B) {
 	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1, 0) })
 }
 
 func BenchmarkScan10_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 10, 0) })
+}
+
+func BenchmarkScan10Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 10, 0) })
 }
 
 func BenchmarkScan10_Postgres(b *testing.B) {
@@ -658,12 +752,20 @@ func BenchmarkScan100_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 100, 0) })
 }
 
+func BenchmarkScan100Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 100, 0) })
+}
+
 func BenchmarkScan100_Postgres(b *testing.B) {
 	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 100, 0) })
 }
 
 func BenchmarkScan1000_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 0) })
+}
+
+func BenchmarkScan1000Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 0) })
 }
 
 func BenchmarkScan1000_Postgres(b *testing.B) {
@@ -674,12 +776,20 @@ func BenchmarkScan10000_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 10000, 0) })
 }
 
+func BenchmarkScan10000Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 10000, 0) })
+}
+
 func BenchmarkScan10000_Postgres(b *testing.B) {
 	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 10000, 0) })
 }
 
 func BenchmarkScan1000Limit1_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 1) })
+}
+
+func BenchmarkScan1000Limit1Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 1) })
 }
 
 func BenchmarkScan1000Limit1_Postgres(b *testing.B) {
@@ -690,12 +800,20 @@ func BenchmarkScan1000Limit10_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 10) })
 }
 
+func BenchmarkScan1000Limit10Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 10) })
+}
+
 func BenchmarkScan1000Limit10_Postgres(b *testing.B) {
 	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 10) })
 }
 
 func BenchmarkScan1000Limit100_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 100) })
+}
+
+func BenchmarkScan1000Limit100Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkScan(b, db, 1000, 100) })
 }
 
 func BenchmarkScan1000Limit100_Postgres(b *testing.B) {
@@ -763,6 +881,10 @@ func BenchmarkScan10000FilterLimit1_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, filterLimitBenchFn(1))
 }
 
+func BenchmarkScan10000FilterLimit1Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, filterLimitBenchFn(1))
+}
+
 func BenchmarkScan10000FilterLimit1_Postgres(b *testing.B) {
 	benchmarkPostgres(b, filterLimitBenchFn(1))
 }
@@ -771,12 +893,20 @@ func BenchmarkScan10000FilterLimit10_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, filterLimitBenchFn(10))
 }
 
+func BenchmarkScan10000FilterLimit10Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, filterLimitBenchFn(10))
+}
+
 func BenchmarkScan10000FilterLimit10_Postgres(b *testing.B) {
 	benchmarkPostgres(b, filterLimitBenchFn(10))
 }
 
 func BenchmarkScan10000FilterLimit50_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, filterLimitBenchFn(50))
+}
+
+func BenchmarkScan10000FilterLimit50Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, filterLimitBenchFn(50))
 }
 
 func BenchmarkScan10000FilterLimit50_Postgres(b *testing.B) {
@@ -846,12 +976,20 @@ func BenchmarkSort100000Limit10_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, false) })
 }
 
+func BenchmarkSort100000Limit10Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, false) })
+}
+
 func BenchmarkSort100000Limit10_Postgres(b *testing.B) {
 	benchmarkPostgres(b, func(b *testing.B, db *gosql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, false) })
 }
 
 func BenchmarkSort100000Limit10Distinct_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, true) })
+}
+
+func BenchmarkSort100000Limit10DistinctMultinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkOrderBy(b, db, 100000, 10, true) })
 }
 
 func BenchmarkSort100000Limit10Distinct_Postgres(b *testing.B) {
@@ -916,6 +1054,22 @@ func BenchmarkTrackChoices100_Cockroach(b *testing.B) {
 
 func BenchmarkTrackChoices1000_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 1000) })
+}
+
+func BenchmarkTrackChoices1Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 1) })
+}
+
+func BenchmarkTrackChoices10Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 10) })
+}
+
+func BenchmarkTrackChoices100Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 100) })
+}
+
+func BenchmarkTrackChoices1000Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkTrackChoices(b, db, 1000) })
 }
 
 func BenchmarkTrackChoices1_Postgres(b *testing.B) {
@@ -1007,6 +1161,18 @@ func BenchmarkInsertDistinct10_Cockroach(b *testing.B) {
 
 func BenchmarkInsertDistinct100_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkInsertDistinct(b, db, 100) })
+}
+
+func BenchmarkInsertDistinct1Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkInsertDistinct(b, db, 1) })
+}
+
+func BenchmarkInsertDistinct10Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkInsertDistinct(b, db, 10) })
+}
+
+func BenchmarkInsertDistinct100Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkInsertDistinct(b, db, 100) })
 }
 
 // runBenchmarkWideTable measures performance on a table with a large number of
@@ -1102,4 +1268,20 @@ func BenchmarkWideTable100_Cockroach(b *testing.B) {
 
 func BenchmarkWideTable1000_Cockroach(b *testing.B) {
 	benchmarkCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 1000) })
+}
+
+func BenchmarkWideTable1Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 1) })
+}
+
+func BenchmarkWideTable10Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 10) })
+}
+
+func BenchmarkWideTable100Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 100) })
+}
+
+func BenchmarkWideTable1000Multinode_Cockroach(b *testing.B) {
+	benchmarkMultinodeCockroach(b, func(b *testing.B, db *gosql.DB) { runBenchmarkWideTable(b, db, 1000) })
 }

--- a/sql/multinode_test.go
+++ b/sql/multinode_test.go
@@ -13,6 +13,7 @@
 // permissions and limitations under the License.
 //
 // Author: David Taylor (david@cockroachlabs.com)
+// Author: William Haack (will@cockroachlabs.com)
 
 package sql_test
 
@@ -32,23 +33,17 @@ import (
 // creates database `name and returns open gosql.DB connections to each
 // node (to the named db), as well as a cleanup func that stops and
 // cleans up all nodes and connections.
-// TODO(davidt): Change zone config to actually add replication.
-// TODO(davidt): Ensure that ranges are actually replicated before returning.
-// Until these TODOs are resolved, the cluster returned is not particularly
-// useful for benchmarking, as without replication overhead it is the same as
-// single-node operation, except without the local-call optimization for the
-// additional nodes.
-func SetupMultinodeTestCluster(t testing.TB, nodes int, name string) ([]*gosql.DB, func()) {
+func SetupMultinodeTestCluster(t testing.TB, nodes int, name string) (server.MultinodeTestCluster, []*gosql.DB, func()) {
 	if nodes < 1 {
 		t.Fatal("invalid cluster size: ", nodes)
 	}
-	var servers []server.TestServer
-	first := server.StartTestServer(t)
-	servers = append(servers, first)
-	for i := 1; i < nodes; i++ {
-		servers = append(servers, server.StartTestServerJoining(t, first))
-	}
 
+	servers := make([]server.TestServer, nodes)
+	servers[0] = server.StartTestServerWithContext(t, nil, server.StartParams{Nodes: nodes})
+	for i := range servers[1:] {
+		servers[i+1] = server.StartTestServerJoining(t, servers[0])
+	}
+	testCluster := server.MultinodeTestCluster{Servers: servers}
 	var conns []*gosql.DB
 	var closes []func() error
 	var cleanups []func()
@@ -82,19 +77,17 @@ func SetupMultinodeTestCluster(t testing.TB, nodes int, name string) ([]*gosql.D
 		}
 	}
 
-	return conns, f
+	return testCluster, conns, f
 }
 
-// NB(davidt): until `SetupMultinodeTestCluster` actually returns a cluster
-// with replication configured, this is only testing adding nodes to a cluster
-// and then their ability to serve SQL by talking to a remote, single-node KV.
 func TestMultinodeCockroach(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer tracing.Disable()()
 
-	t.Skip("#7450")
-
-	conns, cleanup := SetupMultinodeTestCluster(t, 3, "Testing")
+	testCluster, conns, cleanup := SetupMultinodeTestCluster(t, 3, "Testing")
+	if err := testCluster.WaitForFullReplication(); err != nil {
+		t.Fatal(err)
+	}
 	defer cleanup()
 
 	if _, err := conns[0].Exec(`CREATE TABLE testing (k INT PRIMARY KEY, v INT)`); err != nil {


### PR DESCRIPTION
… the joining nodes to receive a replication before returning the set of clusters in order to make the multinode test more meaningful. In addition, every SQL benchmark test was given a corresponding multinode test. Addresses https://github.com/cockroachdb/cockroach/issues/6890

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7312)

<!-- Reviewable:end -->
