### PR TITLE
util/encoding: encode nonsorting unsigned varints

### DIFF
--- a/util/encoding/encoding.go
+++ b/util/encoding/encoding.go
@@ -1010,6 +1010,10 @@ func prettyPrintFirstValue(b []byte) ([]byte, string, error) {
 	}
 }
 
+// NonsortingVarintMaxLen is the maximum length of an EncodeNonsortingVarint
+// encoded value.
+const NonsortingVarintMaxLen = binary.MaxVarintLen64
+
 // EncodeNonsortingVarint encodes an int value using encoding/binary, appends it
 // to the supplied buffer, and returns the final buffer.
 func EncodeNonsortingVarint(appendTo []byte, x int64) []byte {
@@ -1020,11 +1024,72 @@ func EncodeNonsortingVarint(appendTo []byte, x int64) []byte {
 }
 
 // DecodeNonsortingVarint decodes a value encoded by EncodeNonsortingVarint. It
-// returns the length and value.
-func DecodeNonsortingVarint(b []byte) ([]byte, int, int64, error) {
-	i, n := binary.Varint(b)
-	if n <= 0 {
-		return nil, 0, 0, fmt.Errorf("int64 varint decoding failed: %d", n)
+// returns the length of the encoded varint and value.
+func DecodeNonsortingVarint(b []byte) (remaining []byte, length int, value int64, err error) {
+	value, length = binary.Varint(b)
+	if length <= 0 {
+		return nil, 0, 0, fmt.Errorf("int64 varint decoding failed: %d", length)
 	}
-	return b[n:], n, i, nil
+	return b[length:], length, value, nil
+}
+
+// NonsortingUvarintMaxLen is the maximum length of an EncodeNonsortingUvarint
+// encoded value.
+const NonsortingUvarintMaxLen = 10
+
+// EncodeNonsortingUvarint encodes a uint64, appends it to the supplied buffer,
+// and returns the final buffer. The encoding used is similar to
+// encoding/binary, but with the most significant bits first:
+// - Unsigned integers are serialized 7 bits at a time, starting with the
+//   most significant bits.
+// - The most significant bit (msb) in each output byte indicates if there
+//   is a continuation byte (msb = 1).
+func EncodeNonsortingUvarint(appendTo []byte, x uint64) []byte {
+	switch {
+	case x < (1 << 7):
+		return append(appendTo, byte(x))
+	case x < (1 << 14):
+		return append(appendTo, 0x80|byte(x>>7), 0x7f&byte(x))
+	case x < (1 << 21):
+		return append(appendTo, 0x80|byte(x>>14), 0x80|byte(x>>7), 0x7f&byte(x))
+	case x < (1 << 28):
+		return append(appendTo, 0x80|byte(x>>21), 0x80|byte(x>>14), 0x80|byte(x>>7), 0x7f&byte(x))
+	case x < (1 << 35):
+		return append(appendTo, 0x80|byte(x>>28), 0x80|byte(x>>21), 0x80|byte(x>>14), 0x80|byte(x>>7), 0x7f&byte(x))
+	case x < (1 << 42):
+		return append(appendTo, 0x80|byte(x>>35), 0x80|byte(x>>28), 0x80|byte(x>>21), 0x80|byte(x>>14), 0x80|byte(x>>7), 0x7f&byte(x))
+	case x < (1 << 49):
+		return append(appendTo, 0x80|byte(x>>42), 0x80|byte(x>>35), 0x80|byte(x>>28), 0x80|byte(x>>21), 0x80|byte(x>>14), 0x80|byte(x>>7), 0x7f&byte(x))
+	case x < (1 << 56):
+		return append(appendTo, 0x80|byte(x>>49), 0x80|byte(x>>42), 0x80|byte(x>>35), 0x80|byte(x>>28), 0x80|byte(x>>21), 0x80|byte(x>>14), 0x80|byte(x>>7), 0x7f&byte(x))
+	case x < (1 << 63):
+		return append(appendTo, 0x80|byte(x>>56), 0x80|byte(x>>49), 0x80|byte(x>>42), 0x80|byte(x>>35), 0x80|byte(x>>28), 0x80|byte(x>>21), 0x80|byte(x>>14), 0x80|byte(x>>7), 0x7f&byte(x))
+	default:
+		return append(appendTo, 0x80|byte(x>>63), 0x80|byte(x>>56), 0x80|byte(x>>49), 0x80|byte(x>>42), 0x80|byte(x>>35), 0x80|byte(x>>28), 0x80|byte(x>>21), 0x80|byte(x>>14), 0x80|byte(x>>7), 0x7f&byte(x))
+	}
+}
+
+// DecodeNonsortingUvarint decodes a value encoded by EncodeNonsortingUvarint. It
+// returns the length of the encoded varint and value.
+func DecodeNonsortingUvarint(buf []byte) (remaining []byte, length int, value uint64, err error) {
+	// TODO(dan): Handle overflow.
+	for i, b := range buf {
+		value <<= 7
+		value += uint64(b & 0x7f)
+		if b < 0x80 {
+			return buf[i+1:], i + 1, value, nil
+		}
+	}
+	return buf, 0, 0, nil
+}
+
+// PeekLengthNonsortingUvarint returns the length of the value that starts at
+// the beginning of buf and was encoded by EncodeNonsortingUvarint.
+func PeekLengthNonsortingUvarint(buf []byte) int {
+	for i, b := range buf {
+		if b&0x80 == 0 {
+			return i + 1
+		}
+	}
+	return 0
 }

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -18,7 +18,6 @@ package encoding
 
 import (
 	"bytes"
-	"encoding/binary"
 	"math"
 	"math/rand"
 	"regexp"
@@ -1236,10 +1235,152 @@ func BenchmarkPeekLengthDuration(b *testing.B) {
 }
 
 func BenchmarkEncodeNonsortingVarint(b *testing.B) {
-	bytes := make([]byte, b.N*binary.MaxVarintLen64)
+	bytes := make([]byte, 0, b.N*NonsortingVarintMaxLen)
 	rng, _ := randutil.NewPseudoRand()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		bytes = EncodeNonsortingVarint(bytes, rng.Int63())
+	}
+}
+
+func BenchmarkDecodeNonsortingVarint(b *testing.B) {
+	buf := make([]byte, 0, b.N*NonsortingVarintMaxLen)
+	rng, _ := randutil.NewPseudoRand()
+	for i := 0; i < b.N; i++ {
+		buf = EncodeNonsortingVarint(buf, rng.Int63())
+	}
+	var err error
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf, _, _, err = DecodeNonsortingVarint(buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// edgeCaseUint64s returns some uint64 edge cases for encodings. Currently:
+// - every power of two
+// - every power of two -1 and +1
+func edgeCaseUint64s() []uint64 {
+	values := []uint64{0, 1, 2}
+	for i := uint(2); i < 64; i++ {
+		x := uint64(1) << i
+		values = append(values, x-1, x, x+1)
+	}
+	values = append(values, math.MaxUint64)
+	return values
+}
+
+// randPowDistributedInt63s returns the requested number of int63s such that the
+// logarithm of the results is evenly distributed.
+func randPowDistributedInt63s(rng *rand.Rand, count int) []int64 {
+	values := make([]int64, count)
+	for i := range values {
+		// 1 << 62 is the largest number that fits in an int63 and 0 digits is
+		// not meaningful.
+		digits := uint(rng.Intn(61)) + 1
+		x := rng.Int63n(int64(1) << digits)
+		for x>>(digits-1) == 0 {
+			// If shifting off digits-1 digits is 0, then we didn't get a big enough
+			// number.
+			x = rng.Int63n(1 << digits)
+		}
+		values[i] = x
+	}
+	return values
+}
+
+func testNonsortingUvarint(t *testing.T, i uint64) {
+	buf := EncodeNonsortingUvarint(nil, i)
+	rem, n, x, err := DecodeNonsortingUvarint(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if x != i {
+		t.Fatalf("expected %d got %d", i, x)
+	}
+	if n != len(buf) {
+		t.Fatalf("expected length %d got %d", len(buf), n)
+	}
+	if len(rem) != 0 {
+		t.Fatalf("expected no remaining bytes got %d", len(rem))
+	}
+}
+
+func TestNonsortingUVarint(t *testing.T) {
+	rng, _ := randutil.NewPseudoRand()
+
+	for _, test := range edgeCaseUint64s() {
+		testNonsortingUvarint(t, test)
+	}
+	for _, test := range randPowDistributedInt63s(rng, 1000) {
+		testNonsortingUvarint(t, uint64(test))
+	}
+}
+
+func TestPeekLengthNonsortingUVarint(t *testing.T) {
+	rng, seed := randutil.NewPseudoRand()
+
+	var buf []byte
+	var lengths []int
+	for _, test := range edgeCaseUint64s() {
+		length := len(buf)
+		buf = EncodeNonsortingUvarint(buf, test)
+		lengths = append(lengths, len(buf)-length)
+	}
+	for _, test := range randPowDistributedInt63s(rng, 1000) {
+		length := len(buf)
+		buf = EncodeNonsortingUvarint(buf, uint64(test))
+		lengths = append(lengths, len(buf)-length)
+	}
+
+	for _, length := range lengths {
+		l := PeekLengthNonsortingUvarint(buf)
+		if l != length {
+			t.Fatalf("seed %d: got %d expected %d: %x", seed, l, length, buf[:length])
+		}
+		buf = buf[l:]
+	}
+	if l := PeekLengthNonsortingUvarint(buf); l != 0 {
+		t.Fatalf("expected 0 for empty buffer got %d", l)
+	}
+}
+
+func BenchmarkEncodeNonsortingUvarint(b *testing.B) {
+	buf := make([]byte, 0, b.N*NonsortingUvarintMaxLen)
+	rng, _ := randutil.NewPseudoRand()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf = EncodeNonsortingUvarint(buf, uint64(rng.Int63()))
+	}
+}
+
+func BenchmarkDecodeNonsortingUvarint(b *testing.B) {
+	buf := make([]byte, 0, b.N*NonsortingUvarintMaxLen)
+	rng, _ := randutil.NewPseudoRand()
+	for i := 0; i < b.N; i++ {
+		buf = EncodeNonsortingUvarint(buf, uint64(rng.Int63()))
+	}
+	var err error
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf, _, _, err = DecodeNonsortingUvarint(buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPeekLengthNonsortingUvarint(b *testing.B) {
+	buf := make([]byte, 0, b.N*NonsortingUvarintMaxLen)
+	rng, _ := randutil.NewPseudoRand()
+	for i := 0; i < b.N; i++ {
+		buf = EncodeNonsortingUvarint(buf, uint64(rng.Int63()))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l := PeekLengthNonsortingUvarint(buf)
+		buf = buf[l:]
 	}
 }


### PR DESCRIPTION
This Uvarint encoding is almost the same as encoding/binary.Uvarint, but it
instead puts the most significant bits first. This lets us do some optimizations
in the upcoming value encoding rewrite.

name                           time/op
EncodeVarint-8                 24.6ns ± 1%
DecodeVarint-8                 30.4ns ± 2%
PeekLengthVarint-8             19.2ns ± 2%
EncodeUvarint-8                21.9ns ± 1%
DecodeUvarint-8                26.3ns ± 1%
PeekLengthUvarint-8            19.3ns ± 4%
EncodeNonsortingVarint-8       37.3ns ± 1%
DecodeNonsortingVarint-8       29.9ns ± 1%
EncodeNonsortingUvarint-8      26.3ns ± 4%
DecodeNonsortingUvarint-8      15.5ns ± 1%
PeekLengthNonsortingUvarint-8  11.3ns ± 2%

name                           alloc/op
EncodeVarint-8                 0.00B ±NaN%
DecodeVarint-8                 0.00B ±NaN%
PeekLengthVarint-8             0.00B ±NaN%
EncodeUvarint-8                0.00B ±NaN%
DecodeUvarint-8                0.00B ±NaN%
PeekLengthUvarint-8            0.00B ±NaN%
EncodeNonsortingVarint-8       0.00B ±NaN%
DecodeNonsortingVarint-8       0.00B ±NaN%
EncodeNonsortingUvarint-8      0.00B ±NaN%
DecodeNonsortingUvarint-8      0.00B ±NaN%
PeekLengthNonsortingUvarint-8  0.00B ±NaN%

name                           allocs/op
EncodeVarint-8                  0.00 ±NaN%
DecodeVarint-8                  0.00 ±NaN%
PeekLengthVarint-8              0.00 ±NaN%
EncodeUvarint-8                 0.00 ±NaN%
DecodeUvarint-8                 0.00 ±NaN%
PeekLengthUvarint-8             0.00 ±NaN%
EncodeNonsortingVarint-8        0.00 ±NaN%
DecodeNonsortingVarint-8        0.00 ±NaN%
EncodeNonsortingUvarint-8       0.00 ±NaN%
DecodeNonsortingUvarint-8       0.00 ±NaN%
PeekLengthNonsortingUvarint-8   0.00 ±NaN%

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7313)

<!-- Reviewable:end -->
