### PR TITLE
acceptance: replica allocator tests

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -59,6 +59,7 @@ github.com/lightstep/lightstep-tracer-go cab3c65c9d6ca0bda20c2ced3942aded1b6f9b1
 github.com/mattn/go-isatty 56b76bdf51f7708750eac80fa38b952bb9f32639
 github.com/mattn/go-runewidth d6bea18f789704b5f83375793155289da36a3c7f
 github.com/mibk/dupl 415e882ea21ca7012cc49906cb338f34d2d4b4d6
+github.com/montanaflynn/stats 60dcacf48f43d6dd654d0ed94120ff5806c5ca5c
 github.com/olekukonko/tablewriter 8d0265a48283795806b872b4728c67bf5c777f20
 github.com/opencontainers/runc ab10b6068b3f7ec99370eb66bf48592998cc9db1
 github.com/opennota/check 5b00aacd5639507d2b039245a278ec9f5505509f

--- a/acceptance/allocator_terraform/load.tf
+++ b/acceptance/allocator_terraform/load.tf
@@ -1,0 +1,68 @@
+# Load generators that can be used to fill the CockroachDB cluster with data.
+
+variable "example_block_writer_instances" {
+  default = 1
+}
+#output "block_writer_ips" {
+#  value = "${join(",", google_compute_instance.block_writer.*.network_interface.0.access_config.0.assigned_nat_ip)}"
+#}
+output "example_block_writer" {
+  value = "${join(",", google_compute_instance.block_writer.*.name)}"
+}
+
+resource "google_compute_instance" "block_writer" {
+  count = "${var.example_block_writer_instances}"
+
+  name = "${var.prefix}-block-writer-${count.index + 1}"
+  machine_type = "${var.gce_machine_type}"
+  zone = "${var.gce_zone}"
+  tags = ["cockroach"]
+
+  disk {
+    image = "${var.gce_image}"
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+        # Ephemeral
+    }
+  }
+
+  metadata {
+    sshKeys = "ubuntu:${file("~/.ssh/${var.key_name}.pub")}"
+  }
+
+  connection {
+    user = "ubuntu"
+    key_file = "~/.ssh/${var.key_name}"
+  }
+
+  service_account {
+    scopes = ["https://www.googleapis.com/auth/compute.readonly"]
+  }
+
+  provisioner "file" {
+    source = "../../cloud/gce/download_binary.sh"
+    destination = "/home/ubuntu/download_binary.sh"
+  }
+
+  # This writes the filled-in supervisor template. It would be nice if we could
+  # use rendered templates in the file provisioner.
+  provisioner "remote-exec" {
+    inline = <<FILE
+echo '${template_file.supervisor.0.rendered}' > supervisor.conf
+FILE
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo apt-get -qqy update >/dev/null",
+      "sudo apt-get -qqy install supervisor >/dev/null",
+      "sudo service supervisor stop",
+      "bash download_binary.sh examples-go/block_writer ${var.block_writer_sha}",
+      "mkdir -p logs",
+      "if [ ! -e supervisor.pid ]; then supervisord -c supervisor.conf; fi",
+    ]
+  }
+}

--- a/acceptance/allocator_terraform/main.tf
+++ b/acceptance/allocator_terraform/main.tf
@@ -1,0 +1,108 @@
+provider "google" {
+  region = "${var.gce_region}"
+}
+
+resource "google_compute_instance" "cockroach" {
+  count = "${var.num_instances}"
+
+  name = "${var.prefix}-cockroach-${count.index + 1}"
+  machine_type = "${var.cockroach_machine_type}"
+  zone = "${var.gce_zone}"
+  tags = ["cockroach"]
+
+  disk {
+    image = "${var.gce_image}"
+    size = "${var.cockroach_disk_size}" # GB
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+        # Ephemeral
+    }
+  }
+
+  metadata {
+    sshKeys = "ubuntu:${file("~/.ssh/${var.key_name}.pub")}"
+  }
+
+  connection {
+    user = "ubuntu"
+    key_file = "~/.ssh/${var.key_name}"
+  }
+
+  service_account {
+    scopes = ["https://www.googleapis.com/auth/compute.readonly", "https://www.googleapis.com/auth/devstorage.read_write"]
+  }
+}
+
+resource "template_file" "supervisor" {
+  count = "${var.num_instances}"
+  template = "${file("supervisor.conf.tpl")}"
+  vars {
+    stores = "${var.stores}"
+    cockroach_port = "${var.sql_port}"
+    # The value of the --join flag must be empty for the first node,
+    # and a running node for all others. We built a list of addresses
+    # shifted by one (first element is empty), then take the value at index "instance.index".
+    join_address = "${element(concat(split(",", ""), google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip), count.index)}"
+    # We need to provide one node address for the block writer.
+    node_address = "${google_compute_instance.cockroach.0.network_interface.0.access_config.0.assigned_nat_ip}"
+    cockroach_flags = "${var.cockroach_flags}"
+  }
+}
+
+resource "null_resource" "cockroach-runner" {
+  count = "${var.num_instances}"
+
+  connection {
+    user = "ubuntu"
+    key_file = "~/.ssh/${var.key_name}"
+    host = "${element(google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip, count.index)}"
+  }
+
+  provisioner "file" {
+    source = "../../cloud/gce/download_binary.sh"
+    destination = "/home/ubuntu/download_binary.sh"
+  }
+
+  provisioner "file" {
+    source = "./nodectl"
+    destination = "/home/ubuntu/nodectl"
+  }
+
+  # This writes the filled-in supervisor template. It would be nice if we could
+  # use rendered templates in the file provisioner.
+  provisioner "remote-exec" {
+    inline = <<FILE
+echo '${element(template_file.supervisor.*.rendered, count.index)}' > supervisor.conf
+FILE
+  }
+
+  provisioner "file" {
+    # If no binary is specified, we'll copy /dev/null (always 0 bytes) to the
+    # instance. The "remote-exec" block will then overwrite that. There's no
+    # such thing as conditional file copying in Terraform, so we fake it.
+    source = "${coalesce(var.cockroach_binary, "/dev/null")}"
+    destination = "/home/ubuntu/cockroach"
+  }
+
+  # Launch CockroachDB.
+  provisioner "remote-exec" {
+    inline = [
+      "sudo apt-get -qqy update >/dev/null",
+      "sudo apt-get -qqy install supervisor nethogs pv >/dev/null",
+      "sudo service supervisor stop",
+      "export CLOUD_SDK_REPO=\"cloud-sdk-$(lsb_release -c -s)\"",
+      "echo \"deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main\" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list",
+      "curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -",
+      "sudo apt-get -qqy update >/dev/null",
+      "sudo apt-get -qqy install google-cloud-sdk >/dev/null",
+      "mkdir -p logs",
+      "chmod 755 cockroach nodectl",
+      "[ $(stat --format=%s cockroach) -ne 0 ] || bash download_binary.sh cockroach/cockroach ${var.cockroach_sha}",
+      "if [ ! -e supervisor.pid ]; then supervisord -c supervisor.conf; fi",
+      "supervisorctl -c supervisor.conf start cockroach",
+    ]
+  }
+}

--- a/acceptance/allocator_terraform/network.tf
+++ b/acceptance/allocator_terraform/network.tf
@@ -1,0 +1,13 @@
+resource "google_compute_firewall" "default" {
+  name = "${var.prefix}-cockroach-firewall"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports = ["${var.sql_port}", "${var.http_port}", 9001 ]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags = ["cockroach"]
+}
+

--- a/acceptance/allocator_terraform/nodectl
+++ b/acceptance/allocator_terraform/nodectl
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# TODO(cuongdo): add support for multiple stores on the same node
+DATA_DIR="${DATA_DIR:-./data0}"
+
+usage() {
+    echo "usage: $0 [upload|download] google_cloud_storage_url"
+    echo
+    echo "google_cloud_storage_url is a gs:// URL to a directory where archived"
+    echo "stores will be stored to and retrieved from."
+    exit 1
+}
+
+if [ $# -ne 2 ]; then
+    echo "expected 2 parameters"
+    echo ""
+    usage
+fi
+
+# CockroachDB nodes are named blah-cockroach-[0-9]*, so extract the final
+# numeric part.
+gcs_url="$2"
+hostname="$(hostname)"
+node_index="${hostname##*-}" # remove everything through the final '-' in the hostname
+store_url="${gcs_url}/store${node_index}.tgz"
+
+action=$1
+case $action in
+upload)
+    echo "Uploading store ${DATA_DIR} to ${store_url}"
+    cd "${DATA_DIR}"
+    tar zcvf - * | gsutil cp - ${store_url}
+    ;;
+download)
+    if [ -d ${DATA_DIR} ]; then
+        backup_dir="${DATA_DIR}.$(date +%Y%m%d-%H%M%S)"
+        echo "Backing up ${DATA_DIR} to ${backup_dir}"
+        mv "${DATA_DIR}" "${backup_dir}"
+    fi
+    echo "Downloading ${store_url} to store ${DATA_DIR}"
+    mkdir "${DATA_DIR}"
+    cd "${DATA_DIR}"
+    gsutil cat ${store_url} | tar zxf -
+    ;;
+*)
+    echo "Unknown action '${action}'"
+    echo
+    usage
+esac

--- a/acceptance/allocator_terraform/output.tf
+++ b/acceptance/allocator_terraform/output.tf
@@ -1,0 +1,3 @@
+output "instances" {
+  value = "${join(",", google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip)}"
+}

--- a/acceptance/allocator_terraform/supervisor.conf.tpl
+++ b/acceptance/allocator_terraform/supervisor.conf.tpl
@@ -1,0 +1,58 @@
+; This is the cockroach supervisor config template.
+; It is first rendered by terraform, filling in stores, join_address, node_address,
+; and cockroach_port.
+
+[inet_http_server]
+port=*:9001
+
+[supervisord]
+logfile=%(here)s/logs/supervisor.log
+pidfile=%(here)s/supervisor.pid
+childlogdir=%(here)s/logs
+directory=%(here)s
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
+
+[program:cockroach]
+directory=%(here)s
+command=%(here)s/cockroach start --alsologtostderr=true ${stores} --insecure --join=${join_address} ${cockroach_flags}
+process_name=%(program_name)s
+numprocs=1
+autostart=false
+autorestart=false
+startsecs=2
+startretries=0
+stopwaitsecs=90
+stderr_logfile=%(here)s/logs/%(program_name)s.stderr
+stdout_logfile=%(here)s/logs/%(program_name)s.stdout
+
+[program:block_writer]
+directory=%(here)s
+command=%(here)s/block_writer -concurrency 10 -min-block-bytes=16384 -max-block-bytes=65535 --tolerate-errors 'postgres://root@${node_address}:${cockroach_port}/?sslmode=disable'
+process_name=%(program_name)s
+numprocs=1
+autostart=false
+autorestart=false
+startsecs=2
+startretries=0
+stderr_logfile=%(here)s/logs/%(program_name)s.stderr
+stdout_logfile=%(here)s/logs/%(program_name)s.stdout
+
+[program:photos]
+directory=%(here)s
+command=%(here)s/photos --users 3 --db postgres://root@${node_address}:${cockroach_port}/photos?sslmode=disable
+process_name=%(program_name)s
+numprocs=1
+autostart=false
+autorestart=false
+startsecs=2
+startretries=0
+stderr_logfile=%(here)s/logs/%(program_name)s.stderr
+stdout_logfile=%(here)s/logs/%(program_name)s.stdout

--- a/acceptance/allocator_terraform/variables.tf
+++ b/acceptance/allocator_terraform/variables.tf
@@ -1,0 +1,91 @@
+# Number of CockroachDB instances. This is overridden by terrafarm.
+variable "num_instances" {
+  default = "0"
+}
+
+# Port used for the load balancer and backends.
+variable "sql_port" {
+  default = "26257"
+}
+
+variable "http_port" {
+  default = "8080"
+}
+
+# List of stores each with its own --store flag. (--store flags from the cockroach binary).
+variable "stores" {
+  default = "--store=data"
+}
+
+# GCE region to use.
+variable "gce_region" {
+  default = "us-east1"
+}
+
+# GCE zone to use.
+variable "gce_zone" {
+  default = "us-east1-c"
+}
+
+# GCE image name.
+variable "gce_image" {
+  default = "ubuntu-os-cloud/ubuntu-1510-wily-v20151021"
+}
+
+# Machine type for non-DB nodes (e.g. load generators).
+variable "gce_machine_type" {
+  default = "n1-standard-4"
+}
+
+# Path to the cockroach binary. An empty value results in the latest official
+# binary being used.
+variable "cockroach_binary" {
+  default = ""
+}
+
+# Name of the ssh key pair to use for GCE instances.
+# The public key will be passed at instance creation, and the private
+# key will be used by the local ssh client.
+#
+# The path is expanded to: ~/.ssh/<key_name>.pub
+#
+# If you use `gcloud compute ssh` or `gcloud compute copy-files`, you may want
+# to leave this as "google_compute_engine" for convenience.
+variable "key_name" {
+  default = "google_compute_engine"
+}
+
+# SHA of the cockroach binary to pull down. If none, the latest is fetched.
+variable "cockroach_sha" {
+  default = ""
+}
+
+# SHA of the block_writer binary to pull down. If none, the latest is fetched.
+variable "block_writer_sha" {
+  default = ""
+}
+
+# SHA of the photos binary to pull down. If none, the latest is fetched.
+variable "photos_sha" {
+  default = ""
+}
+
+# Prefix to prepend to all GC resource names.
+variable "prefix" {
+  default = "alloctest"
+}
+
+# Additional command-line flags to pass into `cockroach start`.
+variable "cockroach_flags" {
+  default  = ""
+}
+
+# Machine type for CockroachDB nodes.
+variable "cockroach_machine_type" {
+  default = "n1-standard-4"
+}
+
+# Size of disk for CockroachDB nodes.
+variable "cockroach_disk_size" {
+  default = "50" # GB
+}

--- a/acceptance/allocator_test.go
+++ b/acceptance/allocator_test.go
@@ -1,0 +1,344 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package acceptance
+
+// All tests in this file are remote tests that use Terrafarm to manage
+// and run tests against dedicated test clusters.
+//
+// Required setup:
+// 1. Have a GCE account.
+// 2. Have someone grant permissions (for new *and* existing objects) for the
+//    GCS bucket referenced in `archivedStoreURL`. You'll want permissions
+//    granted to the following email addresses:
+//      a. The email address you use to log into Google Cloud Console.
+//      b. Your default Google Compute Engine service account (it'll look like
+//         111111111111-compute@developer.gserviceaccount.com)
+// 3. Set the environment variable GOOGLE_PROJECT to the name of the Google
+//    Project you want Terraform to use.
+//
+// Example use:
+//
+// make acceptance \
+//   TESTFLAGS="-v --remote -key-name google_compute_engine -cwd=allocator_terraform" \
+//   TESTS="TestUpreplicate1To3Small" \
+//   TESTTIMEOUT="24h"
+//
+// Things to note:
+// - Your SSH key (-key-name) for Google Cloud Platform must be in
+//    ~/.ssh/google_compute_engine
+// - These tests rely on a specific Terraform config that's specified using the
+//   -cwd test flag.
+// - You *must* set the TESTTIMEOUT high enough for any of these tests to
+//   finish. To be safe, specify a timeout of at least 24 hours.
+// - The Google credentials you're using for Terraform must have access to the
+//   Google Cloud Storage bucket referenced by archivedStoreURL.
+// - Your Google Cloud credentials must be accessible by Terraform, as described
+//   here:
+//   https://www.terraform.io/docs/providers/google/
+// - Add "-cockroach-binary" to TESTFLAGS to specify a custom Linux CockroachDB
+//   binary. If omitted, your test will use the latest CircleCI Linux build.
+
+import (
+	gosql "database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/montanaflynn/stats"
+
+	"github.com/cockroachdb/cockroach/acceptance/terrafarm"
+	"github.com/cockroachdb/cockroach/server/serverpb"
+	"github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/storage"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/timeutil"
+)
+
+const (
+	archivedStoreURL = "gs://cockroach-test/allocatortest"
+	StableInterval   = 3 * time.Minute
+)
+
+type allocatorTest struct {
+	// StartNodes is the starting number of nodes this cluster will have.
+	StartNodes int
+	// EndNodes is the final number of nodes this cluster will have.
+	EndNodes int
+	// StoreURL is the Google Cloud Storage URL from which the test will download
+	// stores.
+	StoreURL string
+	// Prefix is the prefix that will be prepended to all resources created by
+	// Terraform.
+	Prefix string
+	// RebalanceTimeout is the max time we'll wait for the cluster to finish
+	// rebalancing.
+	RebalanceTimeout time.Duration
+	// CockroachDiskSizeGB is the size, in gigabytes, of the disks allocated
+	// for CockroachDB nodes. Leaving this as 0 accepts the default in the
+	// Terraform configs. This must be in GB, because Terraform only accepts
+	// disk size for GCE in GB.
+	CockroachDiskSizeGB int
+
+	f *terrafarm.Farmer
+}
+
+func (at *allocatorTest) Run(t *testing.T) {
+	at.f = farmer(t, at.Prefix)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("recovered from panic to destroy cluster")
+		}
+		at.f.MustDestroy()
+	}()
+
+	if e := "GOOGLE_PROJECT"; os.Getenv(e) == "" {
+		t.Fatalf("%s environment variable must be set for Terraform", e)
+	}
+
+	// Pass on overrides to Terraform input variables.
+	if *flagCockroachBinary != "" {
+		at.f.AddVars["cockroach_binary"] = *flagCockroachBinary
+	}
+	if at.CockroachDiskSizeGB != 0 {
+		at.f.AddVars["cockroach_disk_size"] = strconv.Itoa(at.CockroachDiskSizeGB)
+	}
+
+	log.Infof("creating cluster with %d node(s)", at.StartNodes)
+	if err := at.f.Resize(at.StartNodes, 0 /*writers*/); err != nil {
+		t.Fatal(err)
+	}
+	checkGossip(t, at.f, longWaitTime, hasPeers(at.StartNodes))
+	at.f.Assert(t)
+	log.Info("initial cluster is up")
+
+	log.Info("downloading archived stores from Google Cloud Storage in parallel")
+	var wg sync.WaitGroup
+	errors := make(chan error, at.f.NumNodes())
+	for i := 0; i < at.f.NumNodes(); i++ {
+		wg.Add(1)
+		go func(nodeNum int) {
+			defer wg.Done()
+			if err := at.f.Exec(nodeNum, "./nodectl download "+at.StoreURL); err != nil {
+				errors <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	log.Info("restarting cluster with archived store(s)")
+	for i := 0; i < at.f.NumNodes(); i++ {
+		if err := at.f.Restart(i); err != nil {
+			t.Fatalf("error restarting node %d: %s", i, err)
+		}
+	}
+	at.f.Assert(t)
+
+	log.Infof("resizing cluster to %d nodes", at.EndNodes)
+	if err := at.f.Resize(at.EndNodes, 0 /*writers*/); err != nil {
+		t.Fatal(err)
+	}
+	checkGossip(t, at.f, longWaitTime, hasPeers(at.EndNodes))
+	at.f.Assert(t)
+
+	log.Info("waiting for rebalance to finish")
+	if err := at.WaitForRebalance(); err != nil {
+		t.Fatal(err)
+	}
+
+	at.f.Assert(t)
+}
+
+// printStats prints the time it took for rebalancing to finish and the final
+// standard deviation of replica counts across stores.
+func (at *allocatorTest) printRebalanceStats(db *gosql.DB, host string, adminPort int) error {
+	// TODO(cuongdo): Output these in a machine-friendly way and graph.
+
+	// Output time it took to rebalance.
+	{
+		var rebalanceIntervalStr string
+		var rebalanceInterval time.Duration
+		q := `SELECT (SELECT MAX(timestamp) FROM rangelog) - ` +
+			`(select MAX(timestamp) FROM eventlog WHERE eventType='` + string(sql.EventLogNodeJoin) + `')`
+		if err := db.QueryRow(q).Scan(&rebalanceIntervalStr); err != nil {
+			return err
+		}
+		rebalanceInterval, err := time.ParseDuration(rebalanceIntervalStr)
+		if err != nil {
+			return err
+		}
+		if rebalanceInterval < 0 {
+			// This can happen with single-node clusters.
+			rebalanceInterval = time.Duration(0)
+		}
+		log.Infof("cluster took %s to rebalance", rebalanceInterval)
+	}
+
+	// Output # of range events that occurred. All other things being equal,
+	// larger numbers are worse and potentially indicate thrashing.
+	{
+		var rangeEvents int64
+		q := `SELECT COUNT(*) from rangelog`
+		if err := db.QueryRow(q).Scan(&rangeEvents); err != nil {
+			return err
+		}
+		log.Infof("%d range events", rangeEvents)
+	}
+
+	// Output standard deviation of the replica counts for all stores.
+	{
+		var client http.Client
+		var nodesResp serverpb.NodesResponse
+		url := fmt.Sprintf("http://%s:%d/_status/nodes", host, adminPort)
+		if err := util.GetJSON(client, url, &nodesResp); err != nil {
+			return err
+		}
+		var replicaCounts stats.Float64Data
+		for _, node := range nodesResp.Nodes {
+			for _, ss := range node.StoreStatuses {
+				replicaCounts = append(replicaCounts, float64(ss.Metrics["replicas"]))
+			}
+		}
+		stddev, err := stats.StdDevP(replicaCounts)
+		if err != nil {
+			return err
+		}
+		log.Infof("stddev(replica count) = %.2f", stddev)
+	}
+
+	return nil
+}
+
+// checkAllocatorStable returns whether the replica distribution within the cluster has
+// been stable for at least `StableInterval`.
+func (at *allocatorTest) checkAllocatorStable(db *gosql.DB) (bool, error) {
+	q := `SELECT NOW() - MAX(timestamp) FROM rangelog WHERE eventType IN ($1, $2, $3)`
+	eventTypes := []interface{}{
+		string(storage.RangeEventLogSplit),
+		string(storage.RangeEventLogAdd),
+		string(storage.RangeEventLogRemove),
+	}
+	var elapsedStr string
+	if err := db.QueryRow(q, eventTypes...).Scan(&elapsedStr); err != nil {
+		// Log but don't return errors, to increase resilience against transient
+		// errors.
+		log.Errorf("error checking rebalancer: %s", err)
+		return false, nil
+	}
+	elapsedSinceLastRangeEvent, err := time.ParseDuration(elapsedStr)
+	if err != nil {
+		return false, err
+	}
+
+	var status string
+	stable := elapsedSinceLastRangeEvent >= StableInterval
+	if stable {
+		status = fmt.Sprintf("allocator is stable (idle for %s)", StableInterval)
+	} else {
+		status = "waiting for idle allocator"
+	}
+	log.Infof("last range event was %s ago: %s", elapsedSinceLastRangeEvent, status)
+	return stable, nil
+}
+
+// WaitForRebalance waits until there's been no recent range adds, removes, and
+// splits. We wait until the cluster is balanced or until `StableInterval`
+// elapses, whichever comes first. Then, it prints stats about the rebalancing
+// process.
+//
+// This method is crude but necessary. If we were to wait until range counts
+// were just about even, we'd miss potential post-rebalance thrashing.
+func (at *allocatorTest) WaitForRebalance() error {
+	db, err := gosql.Open("postgres", at.f.PGUrl(1))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	timeoutTimer := time.After(at.RebalanceTimeout)
+	var timer timeutil.Timer
+	defer timer.Stop()
+	timer.Reset(0)
+	for {
+		select {
+		case <-timer.C:
+			timer.Read = true
+			stable, err := at.checkAllocatorStable(db)
+			if err != nil {
+				return err
+			}
+			if stable {
+				host := at.f.Nodes()[0]
+				if err := at.printRebalanceStats(db, host, 8080); err != nil {
+					return err
+				}
+				return nil
+			}
+		case <-timeoutTimer:
+			return errors.New("timeout expired")
+		case <-stopper:
+			return errors.New("interrupted")
+		}
+
+		timer.Reset(10 * time.Second)
+	}
+}
+
+// TestUpreplicate1To3Small tests up-replication, starting with 1 node
+// containing 10 GiB of data and growing to 3 nodes.
+func TestUpreplicate1To3Small(t *testing.T) {
+	at := allocatorTest{
+		StartNodes:       1,
+		EndNodes:         3,
+		StoreURL:         archivedStoreURL + "/1node-10g-262ranges",
+		Prefix:           "uprep-1to3-small",
+		RebalanceTimeout: time.Hour,
+	}
+	at.Run(t)
+}
+
+// TestRebalance3to5Small tests rebalancing, starting with 3 nodes (each
+// containing 10 GiB of data) and growing to 5 nodes.
+func TestRebalance3to5Small(t *testing.T) {
+	at := allocatorTest{
+		StartNodes:       3,
+		EndNodes:         5,
+		StoreURL:         archivedStoreURL + "/3nodes-10g-262ranges",
+		Prefix:           "rebal-3to5-small",
+		RebalanceTimeout: time.Hour,
+	}
+	at.Run(t)
+}
+
+// TestUpreplicate1To3Medium tests up-replication, starting with 1 node
+// containing 108 GiB of data and growing to 3 nodes.
+func TestUpreplicate1To3Medium(t *testing.T) {
+	at := allocatorTest{
+		StartNodes:          1,
+		EndNodes:            3,
+		StoreURL:            archivedStoreURL + "/1node-2065replicas-108G",
+		Prefix:              "uprep-1to3-med",
+		RebalanceTimeout:    4 * time.Hour,
+		CockroachDiskSizeGB: 250, // GB
+	}
+	at.Run(t)
+}

--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -29,16 +29,24 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/client"
+	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
 // A Farmer sets up and manipulates a test cluster via terraform.
 type Farmer struct {
-	Output         io.Writer
-	Cwd, LogDir    string
-	KeyName        string
-	Stores         string
+	Output      io.Writer
+	Cwd, LogDir string
+	KeyName     string
+	Stores      string
+	// Prefix will be prepended all names of resources created by Terraform.
+	Prefix string
+	// StateFile is the file (under `Cwd`) in which Terraform will stores its
+	// state.
+	StateFile string
+	// AddVars are additional Terraform variables to be set during calls to Add.
+	AddVars        map[string]string
 	nodes, writers []string
 }
 
@@ -85,9 +93,12 @@ func (f *Farmer) NumWriters() int {
 func (f *Farmer) Add(nodes, writers int) error {
 	nodes += f.NumNodes()
 	writers += f.NumWriters()
-	args := []string{fmt.Sprintf("--var=num_instances=%d", nodes),
-		fmt.Sprintf("--var=stores=%s", f.Stores),
-		fmt.Sprintf("--var=example_block_writer_instances=%d", writers)}
+	args := []string{fmt.Sprintf("-var=num_instances=%d", nodes),
+		fmt.Sprintf("-var=stores=%s", f.Stores),
+		fmt.Sprintf("-var=example_block_writer_instances=%d", writers)}
+	for v, val := range f.AddVars {
+		args = append(args, fmt.Sprintf("-var=%s=%s", v, val))
+	}
 
 	if nodes == 0 && writers == 0 {
 		return f.runErr("terraform", f.appendDefaults(append([]string{"destroy", "--force"}, args...))...)
@@ -170,7 +181,8 @@ func (f *Farmer) NewClient(t *testing.T, i int) (*client.DB, *stop.Stopper) {
 
 // PGUrl returns a URL string for the given node postgres server.
 func (f *Farmer) PGUrl(i int) string {
-	panic("unimplemented")
+	host := f.Nodes()[i-1]
+	return fmt.Sprintf("postgresql://%s@%s:26257/system?sslmode=disable", security.RootUser, host)
 }
 
 // InternalIP returns the address used for inter-node communication.

--- a/acceptance/terraform_test.go
+++ b/acceptance/terraform_test.go
@@ -28,7 +28,7 @@ import (
 // useful for testing code changes in the `terrafarm` package.
 func TestBuildBabyCluster(t *testing.T) {
 	t.Skip("only enabled during testing")
-	f := farmer(t)
+	f := farmer(t, "baby-cluster")
 	defer f.CollectLogs()
 	if err := f.Resize(1, 1); err != nil {
 		t.Fatal(err)
@@ -41,7 +41,7 @@ func TestBuildBabyCluster(t *testing.T) {
 // has passed.
 func TestFiveNodesAndWriters(t *testing.T) {
 	deadline := time.After(*flagDuration)
-	f := farmer(t)
+	f := farmer(t, "five-nodes-and-writers")
 	defer f.MustDestroy()
 	const size = 5
 	if err := f.Resize(size, size); err != nil {

--- a/cloud/gce/download_binary.sh
+++ b/cloud/gce/download_binary.sh
@@ -44,7 +44,7 @@ sha=$2
 if [ -z "${sha}" ]; then
   echo "Looking for latest sha for ${binary_path}"
   latest_url="https://s3.amazonaws.com/${BUCKET_NAME}/${binary_path}${LATEST_SUFFIX}"
-  sha=$(curl ${latest_url})
+  sha=$(curl --silent --show-error ${latest_url})
   if [ -z "${sha}" ]; then
     echo "Could not fetch latest binary: ${latest_url}"
     exit 1
@@ -53,7 +53,7 @@ fi
 
 # Fetch binary and symlink.
 binary_url="https://s3.amazonaws.com/${BUCKET_NAME}/${binary_path}.${sha}"
-time curl -O ${binary_url}
+time curl -O --silent --show-error ${binary_url}
 
 # Chmod and symlink.
 binary_name=$(basename ${binary_path})


### PR DESCRIPTION
Adds these tests:
- Up-replication of 10 GiB from 1 to 3 nodes
- Rebalancing of 10 GiB unique data from 3 to 5 nodes
- Up-replication of 108 GiB from 1 to 3 nodes

These are all necessarily remote tests that use `terrafarm`. Current
limitations include:
1. SSH operations are all done in serial, including downloading of
   archived store data and copying of custom `cockroach` binaries.
2. Lacks ability to interrupt test at precise points in time, which is
   helpful for debugging and extending tests.
3. Doesn't provide conveniences for manually intervening in a test
   cluster (e.g. pushing new binaries mid-test, stopping/starting
   cluster, SSH'ing into individual machines, opening admin UI).
4. No automated way to archive stores to Google Cloud Storage.
5. Control-C behavior is a little weird. Pressing Control-C seems to
   abort just the current part of the test, not the whole test.

These will be fixed in later PRs.

cc @tschottdorf (Terrafarm)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7315)

<!-- Reviewable:end -->
