### PR TITLE
cli: Add "debug range-data" command

### DIFF
--- a/keys/constants.go
+++ b/keys/constants.go
@@ -91,21 +91,21 @@ var (
 	// after it's been aborted.
 	LocalAbortCacheSuffix = []byte("abc-")
 	// localRangeFrozenStatusSuffix is the suffix for a frozen status.
-	localRangeFrozenStatusSuffix = []byte("fzn-")
+	LocalRangeFrozenStatusSuffix = []byte("fzn-")
 	// localRangeLastGCSuffix is the suffix for the last GC.
-	localRangeLastGCSuffix = []byte("lgc-")
+	LocalRangeLastGCSuffix = []byte("lgc-")
 	// LocalRaftAppliedIndexSuffix is the suffix for the raft applied index.
 	LocalRaftAppliedIndexSuffix = []byte("rfta")
 	// localRaftTombstoneSuffix is the suffix for the raft tombstone.
-	localRaftTombstoneSuffix = []byte("rftb")
+	LocalRaftTombstoneSuffix = []byte("rftb")
 	// localRaftTruncatedStateSuffix is the suffix for the RaftTruncatedState.
 	LocalRaftTruncatedStateSuffix = []byte("rftt")
 	// localRangeLeaderLeaseSuffix is the suffix for a range leader lease.
-	localRangeLeaderLeaseSuffix = []byte("rll-")
+	LocalRangeLeaderLeaseSuffix = []byte("rll-")
 	// LocalLeaseAppliedIndexSuffix is the suffix for the applied lease index.
 	LocalLeaseAppliedIndexSuffix = []byte("rlla")
 	// localRangeStatsSuffix is the suffix for range statistics.
-	localRangeStatsSuffix = []byte("stat")
+	LocalRangeStatsSuffix = []byte("stat")
 
 	// localRangeIDUnreplicatedInfix is the post-Range ID specifier for all
 	// per-range data that is not fully Raft replicated. By appending this

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -158,7 +158,7 @@ func DecodeAbortCacheKey(key roachpb.Key, dest []byte) (*uuid.UUID, error) {
 
 // RaftTombstoneKey returns a system-local key for a raft tombstone.
 func RaftTombstoneKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, localRaftTombstoneSuffix, nil)
+	return MakeRangeIDReplicatedKey(rangeID, LocalRaftTombstoneSuffix, nil)
 }
 
 // RaftAppliedIndexKey returns a system-local key for a raft applied index.
@@ -178,23 +178,23 @@ func RaftTruncatedStateKey(rangeID roachpb.RangeID) roachpb.Key {
 
 // RangeFrozenStatusKey returns a system-local key for the frozen status.
 func RangeFrozenStatusKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, localRangeFrozenStatusSuffix, nil)
+	return MakeRangeIDReplicatedKey(rangeID, LocalRangeFrozenStatusSuffix, nil)
 }
 
 // RangeLeaderLeaseKey returns a system-local key for a range leader lease.
 func RangeLeaderLeaseKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, localRangeLeaderLeaseSuffix, nil)
+	return MakeRangeIDReplicatedKey(rangeID, LocalRangeLeaderLeaseSuffix, nil)
 }
 
 // RangeStatsKey returns the key for accessing the MVCCStats struct
 // for the specified Range ID.
 func RangeStatsKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, localRangeStatsSuffix, nil)
+	return MakeRangeIDReplicatedKey(rangeID, LocalRangeStatsSuffix, nil)
 }
 
 // RangeLastGCKey returns a system-local key for the last GC.
 func RangeLastGCKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDReplicatedKey(rangeID, localRangeLastGCSuffix, nil)
+	return MakeRangeIDReplicatedKey(rangeID, LocalRangeLastGCSuffix, nil)
 }
 
 // MakeRangeIDUnreplicatedPrefix creates a range-local key prefix from

--- a/keys/printer.go
+++ b/keys/printer.go
@@ -129,9 +129,10 @@ var (
 		psFunc func(rangeID roachpb.RangeID, input string) (string, roachpb.Key)
 	}{
 		{name: "AbortCache", suffix: LocalAbortCacheSuffix, ppFunc: abortCacheKeyPrint, psFunc: abortCacheKeyParse},
-		{name: "RaftTombstone", suffix: localRaftTombstoneSuffix},
+		{name: "RaftTombstone", suffix: LocalRaftTombstoneSuffix},
 		{name: "RaftHardState", suffix: localRaftHardStateSuffix},
 		{name: "RaftAppliedIndex", suffix: LocalRaftAppliedIndexSuffix},
+		{name: "LeaseAppliedIndex", suffix: LocalLeaseAppliedIndexSuffix},
 		{name: "RaftLog", suffix: LocalRaftLogSuffix,
 			ppFunc: raftLogKeyPrint,
 			psFunc: raftLogKeyParse,
@@ -140,8 +141,8 @@ var (
 		{name: "RaftLastIndex", suffix: localRaftLastIndexSuffix},
 		{name: "RangeLastReplicaGCTimestamp", suffix: localRangeLastReplicaGCTimestampSuffix},
 		{name: "RangeLastVerificationTimestamp", suffix: localRangeLastVerificationTimestampSuffix},
-		{name: "RangeLeaderLease", suffix: localRangeLeaderLeaseSuffix},
-		{name: "RangeStats", suffix: localRangeStatsSuffix},
+		{name: "RangeLeaderLease", suffix: LocalRangeLeaderLeaseSuffix},
+		{name: "RangeStats", suffix: LocalRangeStatsSuffix},
 	}
 
 	rangeSuffixDict = []struct {

--- a/keys/printer_test.go
+++ b/keys/printer_test.go
@@ -53,6 +53,7 @@ func TestPrettyPrint(t *testing.T) {
 		{AbortCacheKey(roachpb.RangeID(1000001), txnID), fmt.Sprintf(`/Local/RangeID/1000001/r/AbortCache/%q`, txnID)},
 		{RaftTombstoneKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RaftTombstone"},
 		{RaftAppliedIndexKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RaftAppliedIndex"},
+		{LeaseAppliedIndexKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/LeaseAppliedIndex"},
 		{RaftTruncatedStateKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RaftTruncatedState"},
 		{RangeLeaderLeaseKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeLeaderLease"},
 		{RangeStatsKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RangeStats"},

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -390,7 +390,7 @@ func RunGC(
 	resolveIntents resolveFunc,
 ) ([]roachpb.GCRequest_GCKey, GCInfo, error) {
 
-	iter := newReplicaDataIterator(desc, snap, true /* replicatedOnly */)
+	iter := NewReplicaDataIterator(desc, snap, true /* replicatedOnly */)
 	defer iter.Close()
 
 	var infoMu = lockableGCInfo{}

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1768,7 +1768,7 @@ func (r *Replica) sha512(
 ) ([]byte, error) {
 	hasher := sha512.New()
 	// Iterate over all the data in the range.
-	iter := newReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
+	iter := NewReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		key := iter.Key()

--- a/storage/replica_data_iter.go
+++ b/storage/replica_data_iter.go
@@ -87,24 +87,18 @@ func newReplicaDataIterator(
 		ranges:   rangeFunc(d),
 		iterator: e.NewIterator(false),
 	}
-	ri.Seek(ri.ranges[ri.curIndex].start)
+	ri.iterator.Seek(ri.ranges[ri.curIndex].start)
+	ri.advance()
 	return ri
 }
 
-// Close closes the underlying iterator.
+// Close the underlying iterator.
 func (ri *replicaDataIterator) Close() {
 	ri.curIndex = len(ri.ranges)
 	ri.iterator.Close()
 }
 
-// Seek seeks to the specified key.
-func (ri *replicaDataIterator) Seek(key engine.MVCCKey) {
-	ri.iterator.Seek(key)
-	ri.advance()
-}
-
-// Next returns the next raw key value in the iteration, or nil if
-// iteration is done.
+// Next advances to the next key in the iteration.
 func (ri *replicaDataIterator) Next() {
 	ri.iterator.Next()
 	ri.advance()

--- a/storage/replica_data_iter.go
+++ b/storage/replica_data_iter.go
@@ -144,9 +144,9 @@ func (ri *ReplicaDataIterator) Error() error {
 	return ri.iterator.Error()
 }
 
-// AllocIterKeyValue returns ri.Key() and ri.Value() with the underlying
+// allocIterKeyValue returns ri.Key() and ri.Value() with the underlying
 // storage allocated from the passed ByteAllocator.
-func (ri *ReplicaDataIterator) AllocIterKeyValue(
+func (ri *ReplicaDataIterator) allocIterKeyValue(
 	a bufalloc.ByteAllocator,
 ) (bufalloc.ByteAllocator, engine.MVCCKey, []byte) {
 	return engine.AllocIterKeyValue(a, ri.iterator)

--- a/storage/replica_data_iter_test.go
+++ b/storage/replica_data_iter_test.go
@@ -119,7 +119,7 @@ func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	iter := newReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), false /* !replicatedOnly */)
+	iter := NewReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), false /* !replicatedOnly */)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		t.Error("expected empty iteration")
@@ -163,7 +163,7 @@ func TestReplicaDataIterator(t *testing.T) {
 	postKeys := createRangeData(t, postRng)
 
 	// Verify the contents of the "b"-"c" range.
-	iter := newReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), false /* !replicatedOnly */)
+	iter := NewReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), false /* !replicatedOnly */)
 	defer iter.Close()
 	i := 0
 	for ; iter.Valid(); iter.Next() {
@@ -186,7 +186,7 @@ func TestReplicaDataIterator(t *testing.T) {
 
 	// Verify that the replicated-only iterator ignores unreplicated keys.
 	unreplicatedPrefix := keys.MakeRangeIDUnreplicatedPrefix(tc.rng.RangeID)
-	iter = newReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), true /* replicatedOnly */)
+	iter = NewReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), true /* replicatedOnly */)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		if err := iter.Error(); err != nil {
@@ -201,7 +201,7 @@ func TestReplicaDataIterator(t *testing.T) {
 	if err := tc.rng.Destroy(*tc.rng.Desc()); err != nil {
 		t.Fatal(err)
 	}
-	iter = newReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), false /* !replicatedOnly */)
+	iter = NewReplicaDataIterator(tc.rng.Desc(), tc.rng.store.Engine(), false /* !replicatedOnly */)
 	defer iter.Close()
 	if iter.Valid() {
 		// If the range is destroyed, only a tombstone key should be there.
@@ -225,7 +225,7 @@ func TestReplicaDataIterator(t *testing.T) {
 		{preRng, preKeys},
 		{postRng, postKeys},
 	} {
-		iter = newReplicaDataIterator(test.r.Desc(), test.r.store.Engine(), false /* !replicatedOnly */)
+		iter = NewReplicaDataIterator(test.r.Desc(), test.r.store.Engine(), false /* !replicatedOnly */)
 		defer iter.Close()
 		i = 0
 		for ; iter.Valid(); iter.Next() {

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -538,7 +538,7 @@ func snapshot(
 	for ; iter.Valid(); iter.Next() {
 		var key engine.MVCCKey
 		var value []byte
-		alloc, key, value = engine.AllocIterKeyValue(alloc, iter.Iterator)
+		alloc, key, value = iter.AllocIterKeyValue(alloc)
 		snapData.KV = append(snapData.KV,
 			roachpb.RaftSnapshotData_KeyValue{
 				Key:       key.Key,

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -532,7 +532,7 @@ func snapshot(
 
 	// Iterate over all the data in the range, including local-only data like
 	// the sequence cache.
-	iter := newReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
+	iter := NewReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
 	defer iter.Close()
 	var alloc bufalloc.ByteAllocator
 	for ; iter.Valid(); iter.Next() {
@@ -679,7 +679,7 @@ func (r *Replica) applySnapshot(batch engine.Batch, snap raftpb.Snapshot) error 
 	// Delete everything in the range and recreate it from the snapshot.
 	// We need to delete any old Raft log entries here because any log entries
 	// that predate the snapshot will be orphaned and never truncated or GC'd.
-	iter := newReplicaDataIterator(&desc, batch, false /* !replicatedOnly */)
+	iter := NewReplicaDataIterator(&desc, batch, false /* !replicatedOnly */)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		if err := batch.Clear(iter.Key()); err != nil {

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -538,7 +538,7 @@ func snapshot(
 	for ; iter.Valid(); iter.Next() {
 		var key engine.MVCCKey
 		var value []byte
-		alloc, key, value = iter.AllocIterKeyValue(alloc)
+		alloc, key, value = iter.allocIterKeyValue(alloc)
 		snapData.KV = append(snapData.KV,
 			roachpb.RaftSnapshotData_KeyValue{
 				Key:       key.Key,

--- a/storage/store.go
+++ b/storage/store.go
@@ -1579,7 +1579,7 @@ func (s *Store) removeReplicaImpl(rep *Replica, origDesc roachpb.RangeDescriptor
 // destroyReplicaData deletes all data associated with a replica, leaving a tombstone.
 // If a Replica object exists, use Replica.Destroy instead of this method.
 func (s *Store) destroyReplicaData(desc *roachpb.RangeDescriptor) error {
-	iter := newReplicaDataIterator(desc, s.Engine(), false /* !replicatedOnly */)
+	iter := NewReplicaDataIterator(desc, s.Engine(), false /* !replicatedOnly */)
 	defer iter.Close()
 	batch := s.Engine().NewBatch()
 	defer batch.Close()

--- a/storage/verify_queue.go
+++ b/storage/verify_queue.go
@@ -84,7 +84,7 @@ func (*verifyQueue) process(now hlc.Timestamp, rng *Replica,
 	_ config.SystemConfig) error {
 
 	snap := rng.store.Engine().NewSnapshot()
-	iter := newReplicaDataIterator(rng.Desc(), snap, false /* !replicatedOnly */)
+	iter := NewReplicaDataIterator(rng.Desc(), snap, false /* !replicatedOnly */)
 	defer iter.Close()
 	defer snap.Close()
 


### PR DESCRIPTION
"debug range-data" prints the contents of a range using `ReplicaDataIterator` (which is exported and cleaned up as a part of this PR), so it sees the same things that the consistency checker sees.

Improved coverage of the pretty-printer.

This PR was used in my last message on #7224.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7321)

<!-- Reviewable:end -->
