### PR TITLE
cli: properly handle EOF on non-empty lines when reading from stdin

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -20,7 +20,7 @@ github.com/Sirupsen/logrus f3cfb454f4c209e6668c95216c4744b8fddb2356
 github.com/VividCortex/ewma c34099b489e4ac33ca8d8c5f9d29d6eeaf69f2ed
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store 913427a1d5e89604e50ea1db0f28f34966d61602
-github.com/chzyer/readline 03625fbce39089d52a89922753e80125430d0d62
+github.com/chzyer/readline b411b0f4b22d724d98f4288aebd10cf2ddb42207
 github.com/client9/misspell 6c4f82f46611bc5054b80ff8c792131ce74702e7
 github.com/cockroachdb/c-jemalloc 6362977a9a1989062dccfa5fe314d6c864e7590c
 github.com/cockroachdb/c-protobuf 3bef67ea4cc857224fced66f98578362bc892f37

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -286,6 +286,14 @@ func runInteractive(conn *sqlConn) (exitErr error) {
 		// statement.
 		fullStmt := strings.Join(stmt, "\n")
 
+		// Ensure the statement is terminated with a semicolon. This
+		// catches cases where the last line before EOF was not terminated
+		// properly.
+		if len(fullStmt) > 0 && !strings.HasSuffix(fullStmt, ";") {
+			fmt.Fprintf(osStderr, "no semicolon at end of statement; statement ignored\n")
+			continue
+		}
+
 		if isInteractive {
 			// We save the history between each statement, This enables
 			// reusing history in another SQL shell without closing the


### PR DESCRIPTION
Prior to this patch EOF on the last line would cause the line to be
silently ignored. This patch ensures that a valid statement followed
by a semicolon and EOF is properly executed; whereas a warning is
reported when the line is non-empty and EOF is encountered.

This requires an upgrade to the upstream library chzier/readline.

Fixes #7286.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7328)

<!-- Reviewable:end -->
