### PR TITLE
gossip: properly close clients during culling

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -94,7 +94,11 @@ func (c *client) start(g *Gossip, disconnected chan *client, ctx *rpc.Context, s
 
 // close stops the client gossip loop and returns immediately.
 func (c *client) close() {
-	close(c.closer)
+	select {
+	case <-c.closer:
+	default:
+		close(c.closer)
+	}
 }
 
 // requestGossip requests the latest gossip from the remote server by
@@ -237,6 +241,8 @@ func (c *client) gossip(g *Gossip, gossipClient GossipClient, stopper *stop.Stop
 
 	for {
 		select {
+		case <-c.closer:
+			return nil
 		case <-stopper.ShouldStop():
 			return nil
 		case err := <-errCh:

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -937,25 +937,17 @@ func (g *Gossip) closeClient(nodeID roachpb.NodeID) {
 
 // removeClient removes the specified client. Called when a client
 // disconnects.
-func (g *Gossip) removeClient(c *client) {
-	g.removeMatchingClient(func(match *client) bool { return c == match })
-}
-
-// removeMatchingClient finds and removes a client which matches the
-// provided match function from the clients slice. Returns the client
-// if found and removed.
-func (g *Gossip) removeMatchingClient(match func(*client) bool) *client {
+func (g *Gossip) removeClient(target *client) {
 	g.clientsMu.Lock()
 	defer g.clientsMu.Unlock()
-	for i, c := range g.clients {
-		if match(c) {
+	for i, candidate := range g.clients {
+		if candidate == target {
 			g.clients = append(g.clients[:i], g.clients[i+1:]...)
-			delete(g.bootstrapping, c.addr.String())
-			g.outgoing.removeNode(c.peerID)
-			return c
+			delete(g.bootstrapping, candidate.addr.String())
+			g.outgoing.removeNode(candidate.peerID)
+			break
 		}
 	}
-	return nil
 }
 
 func (g *Gossip) findClient(match func(*client) bool) *client {

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -928,10 +928,9 @@ func (g *Gossip) startClient(addr net.Addr, stopper *stop.Stopper) {
 	c.start(g, g.disconnected, g.rpcContext, stopper)
 }
 
-// closeClient finds and removes a client from the clients slice.
+// closeClient finds and closes a client.
 func (g *Gossip) closeClient(nodeID roachpb.NodeID) {
-	c := g.removeMatchingClient(func(c *client) bool { return c.peerID == nodeID })
-	if c != nil {
+	if c := g.findClient(func(c *client) bool { return c.peerID == nodeID }); c != nil {
 		c.close()
 	}
 }

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -177,6 +177,14 @@ func TestGossipCullNetwork(t *testing.T) {
 		local.startClient(&peer.is.NodeAddr, stopper)
 	}
 	local.mu.Unlock()
+
+	util.SucceedsSoon(t, func() error {
+		if len(local.Outgoing()) == minPeers {
+			return nil
+		}
+		return errors.New("some peers not yet connected")
+	})
+
 	local.manage()
 
 	util.SucceedsSoon(t, func() error {


### PR DESCRIPTION
This was lost in the move to gRPC (bc9aa42).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7330)

<!-- Reviewable:end -->
