### PR TITLE
storage: when stores are unavailable, don't send the replica to purgatory

### DIFF
--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
@@ -31,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
 var simpleZoneConfig = config.ZoneConfig{
@@ -401,7 +403,7 @@ func TestAllocatorRebalance(t *testing.T) {
 		},
 		{
 			// This store will not be rebalanced to, because it already has more
-			// replias than the mean range count.
+			// replicas than the mean range count.
 			StoreID: 5,
 			Node:    roachpb.NodeDescriptor{NodeID: 5},
 			Capacity: roachpb.StoreCapacity{
@@ -1008,6 +1010,59 @@ func TestAllocatorError(t *testing.T) {
 	}
 }
 
+// TestAllocatorThrottled ensures that when a store is throttled, the replica
+// will not be sent to purgatory.
+func TestAllocatorThrottled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper, g, _, a, _ := createTestAllocator()
+	defer stopper.Stop()
+
+	// First test to make sure we would send the replica to purgatory.
+	_, err := a.AllocateTarget(
+		simpleZoneConfig.ReplicaAttrs[0],
+		[]roachpb.ReplicaDescriptor{},
+		false,
+		nil,
+	)
+	if _, ok := err.(purgatoryError); !ok {
+		t.Fatalf("expected a purgatory error, got: %v", err)
+	}
+
+	// Second, test the normal case in which we can allocate to the store.
+	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
+	result, err := a.AllocateTarget(
+		simpleZoneConfig.ReplicaAttrs[0],
+		[]roachpb.ReplicaDescriptor{},
+		false,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unable to perform allocation: %v", err)
+	}
+	if result.Node.NodeID != 1 || result.StoreID != 1 {
+		t.Errorf("expected NodeID 1 and StoreID 1: %+v", result)
+	}
+
+	// Finally, set that store to be throttled and ensure we don't send the
+	// replica to purgatory.
+	a.storePool.mu.Lock()
+	storeDetail, ok := a.storePool.mu.stores[singleStore[0].StoreID]
+	if !ok {
+		t.Fatalf("store:%d was not found in the store pool", singleStore[0].StoreID)
+	}
+	storeDetail.throttledUntil = timeutil.Now().Add(24 * time.Hour)
+	a.storePool.mu.Unlock()
+	_, err = a.AllocateTarget(
+		simpleZoneConfig.ReplicaAttrs[0],
+		[]roachpb.ReplicaDescriptor{},
+		false,
+		nil,
+	)
+	if _, ok := err.(purgatoryError); ok {
+		t.Fatalf("expected a non purgatory error, got: %v", err)
+	}
+}
+
 type testStore struct {
 	roachpb.StoreDescriptor
 }
@@ -1087,7 +1142,7 @@ func Example_rebalancing() {
 			}
 		}
 
-		// Output store capacities as hexidecimal 2-character values.
+		// Output store capacities as hexadecimal 2-character values.
 		if i%(generations/50) == 0 {
 			var maxBytes int64
 			for j := 0; j < len(testStores); j++ {

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -135,8 +135,7 @@ func (rq *replicateQueue) process(
 			StoreID: newStore.StoreID,
 		}
 		if log.V(1) {
-			log.Infof("adding replica for under-replicated range:%d to node:%d, store:%d",
-				repl.RangeID, newReplica.NodeID, newReplica.StoreID)
+			log.Infof("adding replica for under-replicated RangeID:%d to %+v", repl.RangeID, newReplica)
 		}
 		if err = repl.ChangeReplicas(roachpb.ADD_REPLICA, newReplica, desc); err != nil {
 			return err
@@ -147,8 +146,7 @@ func (rq *replicateQueue) process(
 			return err
 		}
 		if log.V(1) {
-			log.Infof("removing replica for over-replicated range:%d from node:%d, store:%d",
-				repl.RangeID, removeReplica.NodeID, removeReplica.StoreID)
+			log.Infof("removing replica for over-replicated RangeID:%d from %+v", repl.RangeID, removeReplica)
 		}
 		if err = repl.ChangeReplicas(roachpb.REMOVE_REPLICA, removeReplica, desc); err != nil {
 			return err
@@ -165,8 +163,7 @@ func (rq *replicateQueue) process(
 			break
 		}
 		if log.V(1) {
-			log.Infof("removing replica from dead store range:%d from node:%d, store:%d",
-				repl.RangeID, deadReplicas[0].NodeID, deadReplicas[0].StoreID)
+			log.Infof("removing replica from dead store RangeID:%d from %+v", repl.RangeID, deadReplicas[0])
 		}
 		if err = repl.ChangeReplicas(roachpb.REMOVE_REPLICA, deadReplicas[0], desc); err != nil {
 			return err
@@ -177,7 +174,7 @@ func (rq *replicateQueue) process(
 		rebalanceStore := rq.allocator.RebalanceTarget(repl.store.StoreID(), zone.ReplicaAttrs[0], desc.Replicas)
 		if rebalanceStore == nil {
 			if log.V(1) {
-				log.Infof("no suitable rebalance target for range:%d", repl.RangeID)
+				log.Infof("no suitable rebalance target for RangeID:%d", repl.RangeID)
 			}
 			// No action was necessary and no rebalance target was found. Return
 			// without re-queuing this replica.
@@ -188,8 +185,7 @@ func (rq *replicateQueue) process(
 			StoreID: rebalanceStore.StoreID,
 		}
 		if log.V(1) {
-			log.Infof("rebalancing range:%d to node:%d, store:%d", repl.RangeID,
-				rebalanceReplica.NodeID, rebalanceReplica.StoreID)
+			log.Infof("rebalancing RangeID:%d to %+v", repl.RangeID, rebalanceReplica)
 		}
 		if err = repl.ChangeReplicas(roachpb.ADD_REPLICA, rebalanceReplica, desc); err != nil {
 			return err


### PR DESCRIPTION
When a store becomes unavailable due to a declined reservation, we should not
be sending any replicas to purgatory. Purgatory should only be used for when
there are no matching and alive stores.

Fixes #7329

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7332)

<!-- Reviewable:end -->
