### PR TITLE
sql: write non-escaped bytes during byte encoding

### DIFF
--- a/sql/parser/encode.go
+++ b/sql/parser/encode.go
@@ -101,6 +101,7 @@ func encodeSQLBytes(buf *bytes.Buffer, in string) {
 			buf.WriteByte(encodedChar)
 			start = i + 1
 		} else if ch < 0x20 || ch >= 0x7F {
+			buf.WriteString(in[start:i])
 			// Escape non-printable characters.
 			buf.Write(hexMap[ch])
 			start = i + 1


### PR DESCRIPTION
Modify the test to test all combinations of 2 bytes and verify that there
are no duplicates. Duplicate detection is useful because it catches skipped
characters like the above bug.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7338)

<!-- Reviewable:end -->
