### PR TITLE
storage: remove zombie test code

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -707,18 +707,6 @@ func TestReplicaNotLeaderError(t *testing.T) {
 // correctly after a lease request.
 func TestReplicaLeaseCounters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	var numProp int64
-	sCtx := TestStoreContext()
-	sCtx.TestingKnobs.TestingCommandFilter = func(
-		args storagebase.FilterArgs,
-	) *roachpb.Error {
-		if args.Req.Method() == roachpb.LeaderLease {
-			atomic.AddInt64(&numProp, 1)
-		}
-		return nil
-	}
-
 	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()


### PR DESCRIPTION
This block seems to have been removed by
https://github.com/cockroachdb/cockroach/commit/9989229810285c693cefc6ca87c85cd370c279a6
and then inadvertently reintroduced in
https://github.com/cockroachdb/cockroach/commit/424dd3b29fde515b539925ba0bebe725267fa11f

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7346)

<!-- Reviewable:end -->
