### PR TITLE
sql: don't skip lower bytes of unicode points

### DIFF
--- a/sql/parser/encode.go
+++ b/sql/parser/encode.go
@@ -93,7 +93,9 @@ func encodeSQLIdent(buf *bytes.Buffer, s string) {
 func encodeSQLBytes(buf *bytes.Buffer, in string) {
 	start := 0
 	buf.WriteString("b'")
-	for i := range in {
+	// Loop over the bytes of the string (i.e., don't use range over unicode
+	// code points).
+	for i, n := 0, len(in); i < n; i++ {
 		ch := in[i]
 		if encodedChar := encodeMap[ch]; encodedChar != dontEscape {
 			buf.WriteString(in[start:i])

--- a/sql/parser/parse_test.go
+++ b/sql/parser/parse_test.go
@@ -1120,6 +1120,12 @@ func TestEncodeSQLBytes(t *testing.T) {
 			var buf bytes.Buffer
 			encodeSQLBytes(&buf, s)
 			sql := fmt.Sprintf("SELECT %s", buf.String())
+			for n := 0; n < len(sql); n++ {
+				ch := sql[n]
+				if ch < 0x20 || ch >= 0x7F {
+					t.Fatalf("unprintable character: %v (%v, %v): %s %v", ch, i, j, sql, []byte(sql))
+				}
+			}
 			stmts, err := parseTraditional(sql)
 			if err != nil {
 				t.Errorf("%s: expected success, but found %s", sql, err)


### PR DESCRIPTION
Iterate over all bytes, not just unicode code points.

This is hopefully the last bug fix for this function. The previous
iteration de-duplicated some things, but still didn't catch the unprintable
characters. Now we have an explicit test to prevent any weird bytes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7350)

<!-- Reviewable:end -->
