### PR TITLE
sql: new syntax "skipif/onlyif cockroachdb" for logic bigtest

### DIFF
--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -468,7 +468,7 @@ func (t *logicTest) processTestFile(path string) error {
 			case "":
 				return errors.New("skipif command requires a non-blank argument")
 			case "mysql":
-			case "postgresql":
+			case "postgresql", "cockroachdb":
 				s.skip = true
 				continue
 			default:
@@ -482,6 +482,7 @@ func (t *logicTest) processTestFile(path string) error {
 			switch fields[1] {
 			case "":
 				return errors.New("onlyif command requires a non-blank argument")
+			case "cockroachdb":
 			case "mysql":
 				s.skip = true
 				continue


### PR DESCRIPTION
The LogicTest input syntax is defined by the input format of sqllite's
"SQL logic tests", of which we have a copy in
https://github.com/cockroachdb/sqllogictest. It defines the syntax
`skipif` and `onlyif` to conditionally skip a test based on database
compatibility.

Prior to this patch CockroachDB supported only `skipif/onlyif
mysql/postgresql`. `onlyif mysql` and `skipif postgresql` tests would
be ignored.

Meanwhile the SQL logic tests also contain tests for which CockroachDB
is not compatible with PostgreSQL, namely where it pertains to integer
division (CockroachDB does it like MySQL). However we cannot blindly
run all MySQL tests either due to incompatibilities in other areas.

To solve this, this patch introduces support for `cockroachdb` as an
argument for `skipif/only`, to be used accordingly in our custom fork
of the SQL logic tests.

Found while investigating #7351.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7352)

<!-- Reviewable:end -->
