### PR TITLE
storage: return identical errors from below Raft

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -5728,8 +5728,16 @@ func runWrongIndexTest(t *testing.T, repropose bool, withErr bool, expProposals 
 		}
 		return cmd.done
 	}()
+
+	var errStr string
+	if repropose {
+		errStr = "boom"
+	} else {
+		errStr = "observed at lease index"
+	}
+
 	if rwe := <-ch; rwe.Err != nil != withErr ||
-		(withErr && !testutils.IsPError(rwe.Err, "boom")) {
+		(withErr && !testutils.IsPError(rwe.Err, errStr)) {
 		fatalf("%s", rwe.Err)
 	}
 	if n := atomic.LoadInt32(&c); n != expProposals {


### PR DESCRIPTION
While the previous code should not have caused Replicas to diverge, it was
confusing.

Fixes #7324.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7353)

<!-- Reviewable:end -->
