### PR TITLE
acceptance: various allocator test enhancements

### DIFF
--- a/acceptance/allocator_terraform/load.tf
+++ b/acceptance/allocator_terraform/load.tf
@@ -3,11 +3,8 @@
 variable "example_block_writer_instances" {
   default = 1
 }
-#output "block_writer_ips" {
-#  value = "${join(",", google_compute_instance.block_writer.*.network_interface.0.access_config.0.assigned_nat_ip)}"
-#}
 output "example_block_writer" {
-  value = "${join(",", google_compute_instance.block_writer.*.name)}"
+  value = "${join(",", google_compute_instance.block_writer.*.network_interface.0.access_config.0.assigned_nat_ip)}"
 }
 
 resource "google_compute_instance" "block_writer" {

--- a/acceptance/allocator_terraform/main.tf
+++ b/acceptance/allocator_terraform/main.tf
@@ -49,6 +49,7 @@ resource "template_file" "supervisor" {
     # We need to provide one node address for the block writer.
     node_address = "${google_compute_instance.cockroach.0.network_interface.0.access_config.0.assigned_nat_ip}"
     cockroach_flags = "${var.cockroach_flags}"
+    cockroach_env = "${var.cockroach_env}"
   }
 }
 

--- a/acceptance/allocator_terraform/supervisor.conf.tpl
+++ b/acceptance/allocator_terraform/supervisor.conf.tpl
@@ -22,7 +22,7 @@ serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
 
 [program:cockroach]
 directory=%(here)s
-command=%(here)s/cockroach start --alsologtostderr=true ${stores} --insecure --join=${join_address} ${cockroach_flags}
+command=%(here)s/cockroach start --alsologtostderr=true ${stores} --insecure --join=${join_address} --verbosity=1 ${cockroach_flags}
 process_name=%(program_name)s
 numprocs=1
 autostart=false
@@ -32,6 +32,7 @@ startretries=0
 stopwaitsecs=90
 stderr_logfile=%(here)s/logs/%(program_name)s.stderr
 stdout_logfile=%(here)s/logs/%(program_name)s.stdout
+environment=${cockroach_env}
 
 [program:block_writer]
 directory=%(here)s

--- a/acceptance/allocator_terraform/variables.tf
+++ b/acceptance/allocator_terraform/variables.tf
@@ -89,3 +89,15 @@ variable "cockroach_machine_type" {
 variable "cockroach_disk_size" {
   default = "50" # GB
 }
+
+# Environment variables to pass into CockroachDB through the supervisor config.
+# This must be of the following form:
+#
+#   VAR1=value1[,VAR2=value2,...]
+#
+# Relevant supervisor docs:
+#
+#   https://www.terraform.io/docs/configuration/variables.html
+variable "cockroach_env" {
+  default = ""
+}

--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -46,8 +46,9 @@ type Farmer struct {
 	// state.
 	StateFile string
 	// AddVars are additional Terraform variables to be set during calls to Add.
-	AddVars        map[string]string
-	nodes, writers []string
+	AddVars              map[string]string
+	KeepClusterAfterTest bool
+	nodes, writers       []string
 }
 
 func (f *Farmer) refresh() {
@@ -153,6 +154,10 @@ func (f *Farmer) Destroy() error {
 	f.CollectLogs()
 	if f.LogDir != "" {
 		defer f.logf("logs copied to %s", f.AbsLogDir())
+	}
+	if f.KeepClusterAfterTest {
+		f.logf("not destroying cluster")
+		return nil
 	}
 	return f.Resize(0, 0)
 }


### PR DESCRIPTION
- Add date/time prefix to Terraform state files & resource names
- Add ability to pass command-line flags and environment variables to
  `cockroach`
- Add ability to keep cluster after test finishes
- Various fixes suggested by Tobi in review for #7315

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7368)

<!-- Reviewable:end -->
