### PR TITLE
Fix the build on FreeBSD.

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -22,7 +22,7 @@ github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/biogo/store 913427a1d5e89604e50ea1db0f28f34966d61602
 github.com/chzyer/readline b411b0f4b22d724d98f4288aebd10cf2ddb42207
 github.com/client9/misspell 6d3ee069a9d5578e7fd6fbf20bf2e62d58b9eacc
-github.com/cockroachdb/c-jemalloc 6362977a9a1989062dccfa5fe314d6c864e7590c
+github.com/cockroachdb/c-jemalloc 9716a86928311cee3633f1773035ce9f0cf9f9e9
 github.com/cockroachdb/c-protobuf 3bef67ea4cc857224fced66f98578362bc892f37
 github.com/cockroachdb/c-rocksdb 9dd1f18d3ab20667957cf240724a5d12e660ad42
 github.com/cockroachdb/c-snappy d4e7b428fe7fc09e93573df3448567a62df8c9fa

--- a/cli/start_jemalloc.go
+++ b/cli/start_jemalloc.go
@@ -19,6 +19,7 @@
 package cli
 
 // #cgo darwin CPPFLAGS: -I../../c-jemalloc/darwin_includes/internal/include
+// #cgo freebsd CPPFLAGS: -I../../c-jemalloc/freebsd_includes/internal/include
 // #cgo linux CPPFLAGS: -I../../c-jemalloc/linux_includes/internal/include
 // #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
 // #cgo linux LDFLAGS: -Wl,-unresolved-symbols=ignore-all

--- a/server/status/runtime_jemalloc.go
+++ b/server/status/runtime_jemalloc.go
@@ -19,6 +19,7 @@
 package status
 
 // #cgo darwin CPPFLAGS: -I../../../c-jemalloc/darwin_includes/internal/include
+// #cgo freebsd CPPFLAGS: -I../../../c-jemalloc/freebsd_includes/internal/include
 // #cgo linux CPPFLAGS: -I../../../c-jemalloc/linux_includes/internal/include
 // #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
 // #cgo linux LDFLAGS: -Wl,-unresolved-symbols=ignore-all


### PR DESCRIPTION
This together with  https://github.com/cockroachdb/c-jemalloc/pull/5 and https://github.com/elastic/gosigar/pull/33 produces a working cockroach binary on FreeBSD 10.3-STABLE.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7376)

<!-- Reviewable:end -->
