### PR TITLE
storage: add Replica state assertions

### DIFF
--- a/acceptance/reference_test.go
+++ b/acceptance/reference_test.go
@@ -44,12 +44,19 @@ set -xe
 mkdir /old
 cd /old
 
+function finish() {
+  touch oldout newout
+  cat oldout newout
+}
+
+trap finish EXIT
+
 export PGHOST=localhost
 export PGPORT=""
 
 bin=/%s/cockroach
 # TODO(bdarnell): when --background is in referenceBinPath, use it here and below.
-$bin start &
+$bin start --alsologtostderr & &> oldout
 sleep 1
 
 echo "Use the reference binary to write a couple rows, then render its output to a file and shut down."
@@ -61,7 +68,7 @@ $bin sql -d old -e "SELECT i, b, s, d, f, v, extract(epoch FROM t) FROM testing_
 $bin quit && wait # wait will block until all background jobs finish.
 
 bin=/cockroach
-$bin start --background
+$bin start --background --alsologtostderr &> newout
 echo "Read data written by reference version using new binary"
 $bin sql -d old -e "SELECT i, b, s, d, f, v, extract(epoch FROM t) FROM testing_old" > new.everything
 # diff returns non-zero if different. With set -e above, that would exit here.
@@ -102,7 +109,13 @@ $bin quit && wait
 
 func TestDockerReadWriteForwardReferenceVersion(t *testing.T) {
 	backwardReferenceTest := `
-$bin start &
+function finish() {
+  touch out
+  cat out
+}
+trap finish EXIT
+
+$bin start & &> out
 sleep 1
 # grep returns non-zero if it didn't match anything. With set -e above, that would exit here.
 $bin sql -d old -e "SELECT i, b, s, d, f, v, extract(epoch FROM t) FROM testing_new" 2>&1 | grep "is encoded using using version 2, but this client only supports version 1"

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -384,10 +384,10 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	var msA, msB enginepb.MVCCStats
 	snap := store.Engine().NewSnapshot()
 	defer snap.Close()
-	if err := engine.MVCCGetRangeStats(context.Background(), snap, aDesc.RangeID, &msA); err != nil {
+	if _, err := engine.MVCCGetRangeStats(context.Background(), snap, aDesc.RangeID, &msA); err != nil {
 		t.Fatal(err)
 	}
-	if err := engine.MVCCGetRangeStats(context.Background(), snap, bDesc.RangeID, &msB); err != nil {
+	if _, err := engine.MVCCGetRangeStats(context.Background(), snap, bDesc.RangeID, &msB); err != nil {
 		t.Fatal(err)
 	}
 
@@ -412,7 +412,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	snap = store.Engine().NewSnapshot()
 	defer snap.Close()
 	var msMerged enginepb.MVCCStats
-	if err := engine.MVCCGetRangeStats(context.Background(), snap, rngMerged.RangeID, &msMerged); err != nil {
+	if _, err := engine.MVCCGetRangeStats(context.Background(), snap, rngMerged.RangeID, &msMerged); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -299,7 +299,7 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 
 	// Get the original stats for key and value bytes.
 	var ms enginepb.MVCCStats
-	if err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), rangeID, &ms); err != nil {
+	if _, err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), rangeID, &ms); err != nil {
 		t.Fatal(err)
 	}
 	keyBytes, valBytes := ms.KeyBytes, ms.ValBytes
@@ -374,11 +374,11 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 	// Compare stats of split ranges to ensure they are non zero and
 	// exceed the original range when summed.
 	var left, right enginepb.MVCCStats
-	if err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), rangeID, &left); err != nil {
+	if _, err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), rangeID, &left); err != nil {
 		t.Fatal(err)
 	}
 	lKeyBytes, lValBytes := left.KeyBytes, left.ValBytes
-	if err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), newRng.RangeID, &right); err != nil {
+	if _, err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), newRng.RangeID, &right); err != nil {
 		t.Fatal(err)
 	}
 	rKeyBytes, rValBytes := right.KeyBytes, right.ValBytes
@@ -430,7 +430,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	snap := store.Engine().NewSnapshot()
 	defer snap.Close()
 	var ms enginepb.MVCCStats
-	if err := engine.MVCCGetRangeStats(context.Background(), snap, rng.RangeID, &ms); err != nil {
+	if _, err := engine.MVCCGetRangeStats(context.Background(), snap, rng.RangeID, &ms); err != nil {
 		t.Fatal(err)
 	}
 	if err := verifyRecomputedStats(snap, rng.Desc(), ms, manual.UnixNano()); err != nil {
@@ -456,11 +456,11 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	snap = store.Engine().NewSnapshot()
 	defer snap.Close()
 	var msLeft, msRight enginepb.MVCCStats
-	if err := engine.MVCCGetRangeStats(context.Background(), snap, rng.RangeID, &msLeft); err != nil {
+	if _, err := engine.MVCCGetRangeStats(context.Background(), snap, rng.RangeID, &msLeft); err != nil {
 		t.Fatal(err)
 	}
 	rngRight := store.LookupReplica(midKey, nil)
-	if err := engine.MVCCGetRangeStats(context.Background(), snap, rngRight.RangeID, &msRight); err != nil {
+	if _, err := engine.MVCCGetRangeStats(context.Background(), snap, rngRight.RangeID, &msRight); err != nil {
 		t.Fatal(err)
 	}
 
@@ -505,7 +505,7 @@ func fillRange(store *storage.Store, rangeID roachpb.RangeID, prefix roachpb.Key
 	src := rand.New(rand.NewSource(0))
 	for {
 		var ms enginepb.MVCCStats
-		if err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), rangeID, &ms); err != nil {
+		if _, err := engine.MVCCGetRangeStats(context.Background(), store.Engine(), rangeID, &ms); err != nil {
 			t.Fatal(err)
 		}
 		keyBytes, valBytes := ms.KeyBytes, ms.ValBytes

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -942,7 +942,7 @@ func TestSortRangeDescByAge(t *testing.T) {
 
 func verifyRangeStats(eng engine.Reader, rangeID roachpb.RangeID, expMS enginepb.MVCCStats) error {
 	var ms enginepb.MVCCStats
-	if err := engine.MVCCGetRangeStats(context.Background(), eng, rangeID, &ms); err != nil {
+	if _, err := engine.MVCCGetRangeStats(context.Background(), eng, rangeID, &ms); err != nil {
 		return err
 	}
 	// Clear system counts as these are expected to vary.

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -411,8 +411,6 @@ func updateStatsOnGC(
 
 // MVCCGetRangeStats reads stat counters for the specified range and
 // sets the values in the enginepb.MVCCStats struct.
-//
-// TODO(tschottdorf): see whether keeping this method around makes sense.
 func MVCCGetRangeStats(
 	ctx context.Context,
 	engine Reader,

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -411,14 +411,15 @@ func updateStatsOnGC(
 
 // MVCCGetRangeStats reads stat counters for the specified range and
 // sets the values in the enginepb.MVCCStats struct.
+//
+// TODO(tschottdorf): see whether keeping this method around makes sense.
 func MVCCGetRangeStats(
 	ctx context.Context,
 	engine Reader,
 	rangeID roachpb.RangeID,
 	ms *enginepb.MVCCStats,
-) error {
-	_, err := MVCCGetProto(ctx, engine, keys.RangeStatsKey(rangeID), hlc.ZeroTimestamp, true, nil, ms)
-	return err
+) (bool, error) {
+	return MVCCGetProto(ctx, engine, keys.RangeStatsKey(rangeID), hlc.ZeroTimestamp, true, nil, ms)
 }
 
 // MVCCSetRangeStats sets stat counters for specified range.
@@ -2120,7 +2121,7 @@ func MVCCFindSplitKey(
 
 	// Get range size from stats.
 	var ms enginepb.MVCCStats
-	if err := MVCCGetRangeStats(ctx, engine, rangeID, &ms); err != nil {
+	if _, err := MVCCGetRangeStats(ctx, engine, rangeID, &ms); err != nil {
 		return nil, err
 	}
 

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -332,7 +332,7 @@ func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor, clock *hlc.Cloc
 		return err
 	}
 
-	r.mu.lastIndex, err = loadLastIndex(r.store.Engine(), r.RangeID)
+	_, r.mu.lastIndex, err = loadLastIndex(r.store.Engine(), r.RangeID)
 	if err != nil {
 		return err
 	}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -328,7 +328,7 @@ func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor, clock *hlc.Cloc
 
 	var err error
 
-	if r.mu.state, err = loadState(r.store.Engine(), desc); err != nil {
+	if r.mu.state, err = loadState(r.store.Engine(), desc, true /* assert */); err != nil {
 		return err
 	}
 
@@ -753,7 +753,7 @@ func (r *Replica) assertState(reader engine.Reader) {
 //
 // TODO(tschottdorf): Consider future removal (for example, when #7224 is resolved).
 func (r *Replica) assertStateLocked(reader engine.Reader) {
-	diskState, err := loadState(reader, r.mu.state.Desc)
+	diskState, err := loadState(reader, r.mu.state.Desc, true /* assert */)
 	if err != nil {
 		panic(err)
 	}

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1907,7 +1907,7 @@ func (r *Replica) ChangeFrozen(
 
 	desc := r.Desc()
 
-	frozen, err := loadFrozenStatus(batch, desc.RangeID)
+	_, frozen, err := loadFrozenStatus(batch, desc.RangeID)
 	if err != nil || frozen == args.Frozen {
 		// Something went wrong or we're already in the right frozen state. In
 		// the latter case, we avoid writing the "same thing" because "we"
@@ -2515,7 +2515,7 @@ func (r *Replica) mergeTrigger(
 	// Add in stats for right half of merge, excluding system-local stats, which
 	// will need to be recomputed.
 	var rightMS enginepb.MVCCStats
-	if err := engine.MVCCGetRangeStats(ctx, batch, subsumedRangeID, &rightMS); err != nil {
+	if _, err := engine.MVCCGetRangeStats(ctx, batch, subsumedRangeID, &rightMS); err != nil {
 		return err
 	}
 	rightMS.SysBytes, rightMS.SysCount = 0, 0

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -54,7 +54,7 @@ var _ raft.Storage = (*Replica)(nil)
 // InitialState implements the raft.Storage interface.
 // InitialState requires that the replica lock be held.
 func (r *Replica) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
-	hs, err := loadHardState(r.store.Engine(), r.RangeID)
+	_, hs, err := loadHardState(r.store.Engine(), r.RangeID)
 	// For uninitialized ranges, membership is unknown at this point.
 	if raft.IsEmptyHardState(hs) || err != nil {
 		return raftpb.HardState{}, raftpb.ConfState{}, err
@@ -131,7 +131,7 @@ func entries(
 		}
 
 		// Was the missing index after the last index?
-		lastIndex, err := loadLastIndex(e, rangeID)
+		_, lastIndex, err := loadLastIndex(e, rangeID)
 		if err != nil {
 			return nil, err
 		}
@@ -144,7 +144,7 @@ func entries(
 	}
 
 	// No results, was it due to unavailability or truncation?
-	ts, err := raftTruncatedState(e, rangeID)
+	_, ts, err := loadTruncatedState(e, rangeID)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (r *Replica) Term(i uint64) (uint64, error) {
 func term(eng engine.Reader, rangeID roachpb.RangeID, i uint64) (uint64, error) {
 	ents, err := entries(eng, rangeID, i, i+1, 0)
 	if err == raft.ErrCompacted {
-		ts, err := raftTruncatedState(eng, rangeID)
+		_, ts, err := loadTruncatedState(eng, rangeID)
 		if err != nil {
 			return 0, err
 		}
@@ -214,7 +214,7 @@ func (r *Replica) raftTruncatedStateLocked() (roachpb.RaftTruncatedState, error)
 	if r.mu.state.TruncatedState != nil {
 		return *r.mu.state.TruncatedState, nil
 	}
-	ts, err := raftTruncatedState(r.store.Engine(), r.RangeID)
+	_, ts, err := loadTruncatedState(r.store.Engine(), r.RangeID)
 	if err != nil {
 		return ts, err
 	}
@@ -222,15 +222,6 @@ func (r *Replica) raftTruncatedStateLocked() (roachpb.RaftTruncatedState, error)
 		r.mu.state.TruncatedState = &ts
 	}
 	return ts, nil
-}
-
-func raftTruncatedState(
-	eng engine.Reader, rangeID roachpb.RangeID,
-) (roachpb.RaftTruncatedState, error) {
-	ts := roachpb.RaftTruncatedState{}
-	_, err := engine.MVCCGetProto(context.Background(), eng, keys.RaftTruncatedStateKey(rangeID),
-		hlc.ZeroTimestamp, true, nil, &ts)
-	return ts /* zero if not found */, err
 }
 
 // FirstIndex implements the raft.Storage interface.
@@ -360,7 +351,7 @@ func snapshot(
 	start := timeutil.Now()
 	var snapData roachpb.RaftSnapshotData
 
-	truncState, err := raftTruncatedState(snap, rangeID)
+	_, truncState, err := loadTruncatedState(snap, rangeID)
 	if err != nil {
 		return raftpb.Snapshot{}, err
 	}
@@ -368,7 +359,7 @@ func snapshot(
 
 	// Read the range metadata from the snapshot instead of the members
 	// of the Range struct because they might be changed concurrently.
-	appliedIndex, _, err := loadAppliedIndex(snap, rangeID)
+	_, appliedIndex, err := loadAppliedIndex(snap, rangeID)
 	if err != nil {
 		return raftpb.Snapshot{}, err
 	}

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -54,14 +54,20 @@ var _ raft.Storage = (*Replica)(nil)
 // InitialState implements the raft.Storage interface.
 // InitialState requires that the replica lock be held.
 func (r *Replica) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
-	_, hs, err := loadHardState(r.store.Engine(), r.RangeID)
+	found, hs, err := loadHardState(r.store.Engine(), r.RangeID)
 	// For uninitialized ranges, membership is unknown at this point.
-	if raft.IsEmptyHardState(hs) || err != nil {
+	if err != nil {
 		return raftpb.HardState{}, raftpb.ConfState{}, err
 	}
 	var cs raftpb.ConfState
 	for _, rep := range r.mu.state.Desc.Replicas {
 		cs.Nodes = append(cs.Nodes, uint64(rep.ReplicaID))
+	}
+
+	if found == (raft.IsEmptyHardState(hs) || len(cs.Nodes) == 0) {
+		return raftpb.HardState{}, raftpb.ConfState{}, errors.Errorf(
+			"inconsistent HardState: %v (found=%t) for %v", hs, found,
+			r.mu.state.Desc.Replicas)
 	}
 
 	return hs, cs, nil
@@ -572,7 +578,7 @@ func (r *Replica) applySnapshot(snap raftpb.Snapshot) (uint64, error) {
 		return 0, err
 	}
 
-	s, err := loadState(batch, &desc)
+	s, err := loadState(batch, &desc, true /* assert */)
 	if err != nil {
 		return 0, err
 	}

--- a/storage/replica_state.go
+++ b/storage/replica_state.go
@@ -42,32 +42,39 @@ func loadState(
 	s.Desc = protoutil.Clone(desc).(*roachpb.RangeDescriptor)
 	// Read the leader lease.
 	var err error
-	if s.Lease, err = loadLease(reader, desc.RangeID); err != nil {
+	if _, s.Lease, err = loadLease(reader, desc.RangeID); err != nil {
 		return storagebase.ReplicaState{}, err
 	}
 
-	if s.Frozen, err = loadFrozenStatus(reader, desc.RangeID); err != nil {
+	if _, s.Frozen, err = loadFrozenStatus(reader, desc.RangeID); err != nil {
 		return storagebase.ReplicaState{}, err
 	}
 
-	if s.GCThreshold, err = loadGCThreshold(reader, desc.RangeID); err != nil {
+	if _, s.GCThreshold, err = loadGCThreshold(reader, desc.RangeID); err != nil {
 		return storagebase.ReplicaState{}, err
 	}
 
-	if s.RaftAppliedIndex, s.LeaseAppliedIndex, err = loadAppliedIndex(
+	if _, s.RaftAppliedIndex, err = loadAppliedIndex(
 		reader,
 		desc.RangeID,
 	); err != nil {
 		return storagebase.ReplicaState{}, err
 	}
 
-	if s.Stats, err = loadMVCCStats(reader, desc.RangeID); err != nil {
+	if _, s.LeaseAppliedIndex, err = loadLeaseAppliedIndex(
+		reader,
+		desc.RangeID,
+	); err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+
+	if _, s.Stats, err = loadMVCCStats(reader, desc.RangeID); err != nil {
 		return storagebase.ReplicaState{}, err
 	}
 
 	// The truncated state should not be optional (i.e. the pointer is
 	// pointless), but it is and the migration is not worth it.
-	truncState, err := loadTruncatedState(reader, desc.RangeID)
+	_, truncState, err := loadTruncatedState(reader, desc.RangeID)
 	if err != nil {
 		return storagebase.ReplicaState{}, err
 	}
@@ -112,15 +119,15 @@ func saveState(
 	return state.Stats, nil
 }
 
-func loadLease(reader engine.Reader, rangeID roachpb.RangeID) (*roachpb.Lease, error) {
+func loadLease(reader engine.Reader, rangeID roachpb.RangeID) (bool, *roachpb.Lease, error) {
 	lease := &roachpb.Lease{}
-	_, err := engine.MVCCGetProto(context.Background(), reader,
+	found, err := engine.MVCCGetProto(context.Background(), reader,
 		keys.RangeLeaderLeaseKey(rangeID), hlc.ZeroTimestamp,
 		true, nil, lease)
 	if err != nil {
-		return nil, err
+		return false, nil, err
 	}
-	return lease, nil
+	return found, lease, nil
 }
 
 func setLease(
@@ -138,36 +145,39 @@ func setLease(
 		hlc.ZeroTimestamp, nil, lease)
 }
 
-func loadAppliedIndex(reader engine.Reader, rangeID roachpb.RangeID) (uint64, uint64, error) {
+func loadAppliedIndex(reader engine.Reader, rangeID roachpb.RangeID) (bool, uint64, error) {
 	var appliedIndex uint64
 	v, _, err := engine.MVCCGet(context.Background(), reader, keys.RaftAppliedIndexKey(rangeID),
 		hlc.ZeroTimestamp, true, nil)
 	if err != nil {
-		return 0, 0, err
+		return false, 0, err
 	}
 	if v != nil {
 		int64AppliedIndex, err := v.GetInt()
 		if err != nil {
-			return 0, 0, err
+			return false, 0, err
 		}
 		appliedIndex = uint64(int64AppliedIndex)
 	}
-	// TODO(tschottdorf): code duplication.
+	return v != nil, appliedIndex, nil
+}
+
+func loadLeaseAppliedIndex(reader engine.Reader, rangeID roachpb.RangeID) (bool, uint64, error) {
 	var leaseAppliedIndex uint64
-	v, _, err = engine.MVCCGet(context.Background(), reader, keys.LeaseAppliedIndexKey(rangeID),
+	v, _, err := engine.MVCCGet(context.Background(), reader, keys.LeaseAppliedIndexKey(rangeID),
 		hlc.ZeroTimestamp, true, nil)
 	if err != nil {
-		return 0, 0, err
+		return false, 0, err
 	}
 	if v != nil {
 		int64LeaseAppliedIndex, err := v.GetInt()
 		if err != nil {
-			return 0, 0, err
+			return false, 0, err
 		}
 		leaseAppliedIndex = uint64(int64LeaseAppliedIndex)
 	}
 
-	return appliedIndex, leaseAppliedIndex, nil
+	return v != nil, leaseAppliedIndex, nil
 }
 
 func setAppliedIndex(eng engine.ReadWriter, ms *enginepb.MVCCStats, rangeID roachpb.RangeID, appliedIndex, leaseAppliedIndex uint64) error {
@@ -191,14 +201,15 @@ func setAppliedIndex(eng engine.ReadWriter, ms *enginepb.MVCCStats, rangeID roac
 
 func loadTruncatedState(
 	reader engine.Reader, rangeID roachpb.RangeID,
-) (roachpb.RaftTruncatedState, error) {
+) (bool, roachpb.RaftTruncatedState, error) {
 	var truncState roachpb.RaftTruncatedState
-	if _, err := engine.MVCCGetProto(context.Background(), reader,
+	found, err := engine.MVCCGetProto(context.Background(), reader,
 		keys.RaftTruncatedStateKey(rangeID), hlc.ZeroTimestamp, true,
-		nil, &truncState); err != nil {
-		return roachpb.RaftTruncatedState{}, err
+		nil, &truncState)
+	if err != nil {
+		return false, roachpb.RaftTruncatedState{}, err
 	}
-	return truncState, nil
+	return found, truncState, nil
 }
 
 func setTruncatedState(
@@ -211,11 +222,14 @@ func setTruncatedState(
 		keys.RaftTruncatedStateKey(rangeID), hlc.ZeroTimestamp, nil, &truncState)
 }
 
-func loadGCThreshold(reader engine.Reader, rangeID roachpb.RangeID) (hlc.Timestamp, error) {
+func loadGCThreshold(reader engine.Reader, rangeID roachpb.RangeID) (bool, hlc.Timestamp, error) {
 	var t hlc.Timestamp
-	_, err := engine.MVCCGetProto(context.Background(), reader, keys.RangeLastGCKey(rangeID),
+	found, err := engine.MVCCGetProto(context.Background(), reader, keys.RangeLastGCKey(rangeID),
 		hlc.ZeroTimestamp, true, nil, &t)
-	return t, err
+	if err != nil {
+		return false, hlc.ZeroTimestamp, err
+	}
+	return found, t, err
 }
 
 func setGCThreshold(
@@ -225,12 +239,13 @@ func setGCThreshold(
 		keys.RangeLastGCKey(rangeID), hlc.ZeroTimestamp, nil, threshold)
 }
 
-func loadMVCCStats(reader engine.Reader, rangeID roachpb.RangeID) (enginepb.MVCCStats, error) {
+func loadMVCCStats(reader engine.Reader, rangeID roachpb.RangeID) (bool, enginepb.MVCCStats, error) {
 	var ms enginepb.MVCCStats
-	if err := engine.MVCCGetRangeStats(context.Background(), reader, rangeID, &ms); err != nil {
-		return enginepb.MVCCStats{}, err
+	found, err := engine.MVCCGetRangeStats(context.Background(), reader, rangeID, &ms)
+	if err != nil {
+		return false, enginepb.MVCCStats{}, err
 	}
-	return ms, nil
+	return found, ms, nil
 }
 
 func setMVCCStats(eng engine.ReadWriter, rangeID roachpb.RangeID, newMS enginepb.MVCCStats) error {
@@ -246,16 +261,20 @@ func setFrozenStatus(
 		keys.RangeFrozenStatusKey(rangeID), hlc.ZeroTimestamp, val, nil)
 }
 
-func loadFrozenStatus(reader engine.Reader, rangeID roachpb.RangeID) (bool, error) {
+func loadFrozenStatus(reader engine.Reader, rangeID roachpb.RangeID) (bool, bool, error) {
 	val, _, err := engine.MVCCGet(context.Background(), reader, keys.RangeFrozenStatusKey(rangeID),
 		hlc.ZeroTimestamp, true, nil)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	if val == nil {
-		return false, nil
+		return false, false, nil
 	}
-	return val.GetBool()
+	frozen, err := val.GetBool()
+	if err != nil {
+		return false, false, err
+	}
+	return true, frozen, err
 }
 
 // The rest is not technically part of ReplicaState.
@@ -264,30 +283,30 @@ func loadFrozenStatus(reader engine.Reader, rangeID roachpb.RangeID) (bool, erro
 // with its TruncatedState) but are different in that they are not consistently
 // updated through Raft.
 
-func loadLastIndex(reader engine.Reader, rangeID roachpb.RangeID) (uint64, error) {
+func loadLastIndex(reader engine.Reader, rangeID roachpb.RangeID) (bool, uint64, error) {
 	lastIndex := uint64(0)
 	v, _, err := engine.MVCCGet(context.Background(), reader,
 		keys.RaftLastIndexKey(rangeID),
 		hlc.ZeroTimestamp, true /* consistent */, nil)
 	if err != nil {
-		return 0, err
+		return false, 0, err
 	}
 	if v != nil {
 		int64LastIndex, err := v.GetInt()
 		if err != nil {
-			return 0, err
+			return false, 0, err
 		}
 		lastIndex = uint64(int64LastIndex)
 	} else {
 		// The log is empty, which means we are either starting from scratch
 		// or the entire log has been truncated away.
-		lastEnt, err := raftTruncatedState(reader, rangeID)
+		_, lastEnt, err := loadTruncatedState(reader, rangeID)
 		if err != nil {
-			return 0, err
+			return false, 0, err
 		}
 		lastIndex = lastEnt.Index
 	}
-	return lastIndex, nil
+	return v != nil, lastIndex, nil
 }
 
 func setLastIndex(eng engine.ReadWriter, rangeID roachpb.RangeID, lastIndex uint64) error {
@@ -302,15 +321,15 @@ func setLastIndex(eng engine.ReadWriter, rangeID roachpb.RangeID, lastIndex uint
 
 func loadHardState(
 	reader engine.Reader, rangeID roachpb.RangeID,
-) (raftpb.HardState, error) {
+) (bool, raftpb.HardState, error) {
 	var hs raftpb.HardState
 	found, err := engine.MVCCGetProto(context.Background(), reader,
 		keys.RaftHardStateKey(rangeID), hlc.ZeroTimestamp, true, nil, &hs)
 
-	if !found || err != nil {
-		return raftpb.HardState{}, err
+	if err != nil {
+		return false, raftpb.HardState{}, err
 	}
-	return hs, nil
+	return found, hs, nil
 }
 
 func setHardState(
@@ -353,7 +372,7 @@ func writeInitialState(
 	// information about cast votes. For example, during a Split for which
 	// another node's new right-hand side has contacted us before our left-hand
 	// side called in here to create the group.
-	oldHS, err := loadHardState(eng, rangeID)
+	_, oldHS, err := loadHardState(eng, rangeID)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -4750,13 +4750,12 @@ func TestReplicaLookup(t *testing.T) {
 	}
 }
 
-// TestRequestLeaderEncounterGroupDeleteError verifies that a request leader proposal which fails with
-// RaftGroupDeletedError is converted to a RangeNotFoundError in the Store.
+// TestRequestLeaderEncounterGroupDeleteError verifies that a request leader
+// proposal which fails with RaftGroupDeletedError is converted to
+// a RangeNotFoundError in the Store.
 func TestRequestLeaderEncounterGroupDeleteError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	tc := testContext{
-		rng: &Replica{},
-	}
+	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()
 
@@ -4764,18 +4763,10 @@ func TestRequestLeaderEncounterGroupDeleteError(t *testing.T) {
 	proposeRaftCommandFn := func(*pendingCmd) error {
 		return &roachpb.RaftGroupDeletedError{}
 	}
-	rng, err := NewReplica(testRangeDescriptor(), tc.store, 0)
-
+	rng := tc.rng
 	rng.mu.Lock()
 	rng.mu.proposeRaftCommandFn = proposeRaftCommandFn
 	rng.mu.Unlock()
-
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := tc.store.AddReplicaTest(rng); err != nil {
-		t.Fatal(err)
-	}
 
 	gArgs := getArgs(roachpb.Key("a"))
 	// Force the read command request a new lease.

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -4015,7 +4015,7 @@ func TestReplicaResolveIntentRange(t *testing.T) {
 
 func verifyRangeStats(eng engine.Engine, rangeID roachpb.RangeID, expMS enginepb.MVCCStats, t *testing.T) {
 	var ms enginepb.MVCCStats
-	if err := engine.MVCCGetRangeStats(context.Background(), eng, rangeID, &ms); err != nil {
+	if _, err := engine.MVCCGetRangeStats(context.Background(), eng, rangeID, &ms); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(expMS, ms) {

--- a/storage/stats_test.go
+++ b/storage/stats_test.go
@@ -71,7 +71,7 @@ func TestRangeStatsInit(t *testing.T) {
 	if err := engine.MVCCSetRangeStats(context.Background(), tc.engine, 1, &ms); err != nil {
 		t.Fatal(err)
 	}
-	loadMS, err := loadMVCCStats(tc.engine, tc.rng.RangeID)
+	_, loadMS, err := loadMVCCStats(tc.engine, tc.rng.RangeID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -812,7 +812,10 @@ func (s *Store) migrate7310(desc roachpb.RangeDescriptor) {
 		log.Fatalf("found uninitialized descriptor on range: %+v", desc)
 	}
 	batch := s.engine.NewBatch()
-	state, err := loadState(batch, &desc)
+	// Load the state without asserting: we're currently migrating, and the
+	// assertions could fail since old versions were more lenient about their
+	// on-disk state.
+	state, err := loadState(batch, &desc, false /* !assert */)
 	if err != nil {
 		log.Fatalf("could not migrate truncated state: %s", err)
 	}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1907,7 +1907,7 @@ func TestStoreChangeFrozen(t *testing.T) {
 		repl.mu.Lock()
 		frozen := repl.mu.state.Frozen
 		repl.mu.Unlock()
-		pFrozen, err := loadFrozenStatus(store.Engine(), 1)
+		_, pFrozen, err := loadFrozenStatus(store.Engine(), 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2046,7 +2046,7 @@ func TestStoreGCThreshold(t *testing.T) {
 		repl.mu.Lock()
 		gcThreshold := repl.mu.state.GCThreshold
 		repl.mu.Unlock()
-		pgcThreshold, err := loadGCThreshold(store.Engine(), 1)
+		_, pgcThreshold, err := loadGCThreshold(store.Engine(), 1)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -287,6 +287,10 @@ func createRange(s *Store, rangeID roachpb.RangeID, start, end roachpb.RKey) *Re
 		}},
 		NextReplicaID: 2,
 	}
+	if _, err := writeInitialState(s.Engine(), enginepb.MVCCStats{}, *desc); err != nil {
+		log.Fatal(err)
+	}
+
 	r, err := NewReplica(desc, s, 0)
 	if err != nil {
 		log.Fatal(err)

--- a/storage/stores_test.go
+++ b/storage/stores_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -153,6 +154,9 @@ func TestStoresLookupReplica(t *testing.T) {
 			StartKey: rng.start,
 			EndKey:   rng.end,
 			Replicas: []roachpb.ReplicaDescriptor{{StoreID: rng.storeID}},
+		}
+		if _, err := writeInitialState(e[i], enginepb.MVCCStats{}, *d[i]); err != nil {
+			t.Fatal(err)
 		}
 		newRng, err := NewReplica(d[i], s[i], 0)
 		if err != nil {


### PR DESCRIPTION
In particular, we check that an initialized Replica always has a complete
state, and that no empty HardState is persisted.

I don't think we're going to find much real-world use for these assertions,
but they did help clean up some tests and establish clarity about when what
state is persisted in reality.

Removed `raftTruncatedState` (which had been superseded by `loadTruncatedState`
but was still used).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7379)

<!-- Reviewable:end -->
