### PR TITLE
storage: skip flaky TestReservationQueue

### DIFF
--- a/storage/reservation_test.go
+++ b/storage/reservation_test.go
@@ -278,6 +278,7 @@ func expireNextReservation(t *testing.T, mc *hlc.ManualClock, b *bookie, expireC
 // correctly expiring any unfilled reservations in a number of different cases.
 func TestReservationQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#7373")
 	// This test loads up 7 reservations at once, so set the queue higher to
 	// accommodate them.
 	stopper, mc, b := createTestBookie(time.Microsecond, 20, defaultMaxReservedBytes)


### PR DESCRIPTION
See #7373. Repros locally with

`make stress PKG=./storage TESTS=TestReservationQueue`

in about 2000 iterations.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7381)

<!-- Reviewable:end -->
