### PR TITLE
acceptance/allocatortest_terraform: misc fixes

### DIFF
--- a/acceptance/allocator_terraform/load.tf
+++ b/acceptance/allocator_terraform/load.tf
@@ -3,6 +3,11 @@
 variable "example_block_writer_instances" {
   default = 1
 }
+
+# Despite its name, example_block_writer actually has `photos` too. We're
+# sticking to this name for compatibility with Terrafarm. Since our load
+# generators are rarely CPU-bound, it's fine to have them on a single GCE
+# instance.
 output "example_block_writer" {
   value = "${join(",", google_compute_instance.block_writer.*.network_interface.0.access_config.0.assigned_nat_ip)}"
 }
@@ -58,6 +63,7 @@ FILE
       "sudo apt-get -qqy install supervisor >/dev/null",
       "sudo service supervisor stop",
       "bash download_binary.sh examples-go/block_writer ${var.block_writer_sha}",
+      "bash download_binary.sh examples-go/photos ${var.block_writer_sha}",
       "mkdir -p logs",
       "if [ ! -e supervisor.pid ]; then supervisord -c supervisor.conf; fi",
     ]

--- a/acceptance/allocator_terraform/nodectl
+++ b/acceptance/allocator_terraform/nodectl
@@ -31,7 +31,7 @@ case $action in
 upload)
     echo "Uploading store ${DATA_DIR} to ${store_url}"
     cd "${DATA_DIR}"
-    tar zcvf - * | gsutil cp - ${store_url}
+    tar zcvf - * --exclude='logs' | gsutil cp - ${store_url}
     ;;
 download)
     if [ -d ${DATA_DIR} ]; then


### PR DESCRIPTION
**acceptance: add download of photos app** 

Add photos to `example_block_writer` nodes. Yes, this is
counterintuitive, but there are different pieces of code that assume the
`example_block_writer` name, such as Terrafarm.

**acceptance: exclude logs from store upload** 
When uploading stores to create the test data set for allocator test,
exclude logs from the resulting archives.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7393)

<!-- Reviewable:end -->
