### PR TITLE
kv, rpc: make grpcTransportFactory use heartbeat information for replica priority

### DIFF
--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -19,6 +19,7 @@ package kv
 import (
 	"errors"
 	"net"
+	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -598,6 +599,69 @@ func TestComplexScenarios(t *testing.T) {
 			if err == nil {
 				t.Errorf("%d: unexpected success", i)
 			}
+		}
+	}
+}
+
+// TestSplitHealthy tests that the splitHealthy helper function sorts healthy
+// nodes before unhealthy nodes.
+func TestSplitHealthy(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testData := []struct {
+		in       []batchClient
+		out      []batchClient
+		nHealthy int
+	}{
+		{nil, nil, 0},
+		{
+			[]batchClient{
+				{remoteAddr: "1", healthy: false},
+				{remoteAddr: "2", healthy: false},
+				{remoteAddr: "3", healthy: true},
+			},
+			[]batchClient{
+				{remoteAddr: "3", healthy: true},
+				{remoteAddr: "1", healthy: false},
+				{remoteAddr: "2", healthy: false},
+			},
+			1,
+		},
+		{
+			[]batchClient{
+				{remoteAddr: "1", healthy: true},
+				{remoteAddr: "2", healthy: false},
+				{remoteAddr: "3", healthy: true},
+			},
+			[]batchClient{
+				{remoteAddr: "1", healthy: true},
+				{remoteAddr: "3", healthy: true},
+				{remoteAddr: "2", healthy: false},
+			},
+			2,
+		},
+		{
+			[]batchClient{
+				{remoteAddr: "1", healthy: true},
+				{remoteAddr: "2", healthy: true},
+				{remoteAddr: "3", healthy: true},
+			},
+			[]batchClient{
+				{remoteAddr: "1", healthy: true},
+				{remoteAddr: "2", healthy: true},
+				{remoteAddr: "3", healthy: true},
+			},
+			3,
+		},
+	}
+
+	for i, td := range testData {
+		nHealthy := splitHealthy(td.in)
+		if nHealthy != td.nHealthy {
+			t.Errorf("%d. splitHealthy(%+v) = %d; not %d", i, td.in, nHealthy, td.nHealthy)
+		}
+		if !reflect.DeepEqual(td.in, td.out) {
+			t.Errorf("%d. splitHealthy(...)\n  = %+v;\nnot %+v", i, td.in, td.out)
 		}
 	}
 }


### PR DESCRIPTION
This adds health information based on whether the last heartbeat to a server
failed to the rpc context. We then use it in kv.grpcTransportFactory to lower
the priority of nodes that have recently failed a heartbeat.

This fixes #7108 along with other potential performance issues. This stops write
delays when RangeLookup tries to fetch information from a down node and has a 3s
blocking timeout.

This also makes splitHealthy actually do stable sorting (+ tests).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7399)

<!-- Reviewable:end -->
