### PR TITLE
Parallelize the stress test.

### DIFF
--- a/cloud/gce/stress/main.tf
+++ b/cloud/gce/stress/main.tf
@@ -20,7 +20,7 @@ output "instance" {
 }
 
 resource "google_compute_instance" "stress" {
-  count = 1
+  count = "${var.shard_count}"
 
   name = "stress-test-${count.index}"
   machine_type = "${var.gce_machine_type}"
@@ -76,6 +76,8 @@ resource "google_compute_instance" "stress" {
       "bash download_binary.sh stress/stress ${var.stress_sha}",
       "tar xfz static-tests.tar.gz",
       "mkdir -p logs",
+      "export SHARD_COUNT=${var.shard_count}",
+      "export SHARD_INDEX=${count.index + 1}",
       "if [ ! -e supervisor.pid ]; then supervisord -c supervisor.conf; fi",
       "supervisorctl -c supervisor.conf start stress",
     ]

--- a/cloud/gce/stress/stress.sh
+++ b/cloud/gce/stress/stress.sh
@@ -31,6 +31,8 @@ function run_one_test {
   popd
 }
 
-for test in $(find cockroach/ -type f -name '*.test' | sort); do
+find cockroach/ -type f -name '*.test' | sort > all_tests
+
+for test in $(split -n "l/${SHARD_INDEX}"/"${SHARD_COUNT}" all_tests); do
   run_one_test ${test}
 done

--- a/cloud/gce/stress/variables.tf
+++ b/cloud/gce/stress/variables.tf
@@ -3,6 +3,10 @@ variable "tests_sha" {
   default = ""
 }
 
+variable "shard_count" {
+  default="5"
+}
+
 # Sha of the stress binary to pull down. If none, the latest is fetched.
 variable "stress_sha" {
   default = ""


### PR DESCRIPTION
This commit updates the stress terraform templates and script to parallelize across n boxes by simply dividing the list of stress tests by n and distributing a slice to each box.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7400)

<!-- Reviewable:end -->
