### PR TITLE
sql: enable manual control of column families

### DIFF
--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -273,7 +273,7 @@ func testDockerSuccess(t *testing.T, name string, cmd []string) {
 
 const (
 	// NB: postgresTestTag is grepped for in circle-deps.sh, so don't rename it.
-	postgresTestTag = "20160608-1719"
+	postgresTestTag = "20160623-1642"
 	// Iterating against a locally built version of the docker image can be done
 	// by changing postgresTestImage to the hash of the container.
 	postgresTestImage = "cockroachdb/postgres-test:" + postgresTestTag

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -1016,9 +1016,10 @@ func runBenchmarkWideTable(b *testing.B, db *gosql.DB, count int) {
 		b.Fatal(err)
 	}
 	const schema = `CREATE TABLE bench.widetable (
-      f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT, f9 INT, f10 INT,
-      f11 INT, f12 INT, f13 INT, f14 INT, f15 INT, f16 INT, f17 INT, f18 INT, f19 INT, f20 INT,
-    PRIMARY KEY (f1, f2, f3)
+    f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT, f9 INT, f10 INT,
+    f11 INT, f12 INT, f13 INT, f14 INT, f15 INT, f16 INT, f17 INT, f18 INT, f19 INT, f20 INT,
+    PRIMARY KEY (f1, f2, f3),
+    FAMILY (f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20)
   )`
 	if _, err := db.Exec(schema); err != nil {
 		b.Fatal(err)

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -5492,11 +5492,6 @@ sqldefault:
 		{
 			sqlVAL.union.val = sqlDollar[1].union.colDef()
 		}
-	case 192:
-		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
-		//line sql.y:1487
-		{ /* unimplemented */
-		}
 	case 193:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:1489

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -1484,7 +1484,7 @@ table_elem:
     $$.val = $1.colDef()
   }
 | index_def
-| family_def { /* unimplemented */ }
+| family_def
 | table_constraint
   {
     $$.val = $1.constraintDef()

--- a/sql/show.go
+++ b/sql/show.go
@@ -152,6 +152,18 @@ func (p *planner) ShowCreateTable(n *parser.ShowCreateTable) (planNode, error) {
 			storing,
 		)
 	}
+	for _, fam := range desc.Families {
+		activeColumnNames := make([]string, 0, len(fam.ColumnNames))
+		for i, colID := range fam.ColumnIDs {
+			if _, err := desc.FindActiveColumnByID(colID); err == nil {
+				activeColumnNames = append(activeColumnNames, fam.ColumnNames[i])
+			}
+		}
+		fmt.Fprintf(&buf, ",\n\tFAMILY %s (%s)",
+			quoteNames(fam.Name),
+			quoteNames(activeColumnNames...),
+		)
+	}
 
 	for _, e := range desc.Checks {
 		fmt.Fprintf(&buf, ",\n\t")

--- a/sql/show_test.go
+++ b/sql/show_test.go
@@ -54,6 +54,11 @@ func TestShowCreateTable(t *testing.T) {
 	s STRING NULL,
 	v FLOAT NOT NULL,
 	t TIMESTAMP NULL DEFAULT NOW(),
+	FAMILY "primary" (rowid),
+	FAMILY fam_1_i (i),
+	FAMILY fam_2_s (s),
+	FAMILY fam_3_v (v),
+	FAMILY fam_4_t (t),
 	CHECK (i > 0)
 )`,
 		},
@@ -69,6 +74,11 @@ func TestShowCreateTable(t *testing.T) {
 	s STRING NULL,
 	v FLOAT NOT NULL,
 	t TIMESTAMP NULL DEFAULT NOW(),
+	FAMILY "primary" (rowid),
+	FAMILY fam_1_i (i),
+	FAMILY fam_2_s (s),
+	FAMILY fam_3_v (v),
+	FAMILY fam_4_t (t),
 	CHECK (i > 0)
 )`,
 		},
@@ -81,6 +91,9 @@ func TestShowCreateTable(t *testing.T) {
 			expect: `CREATE TABLE %s (
 	i INT NULL,
 	s STRING NULL,
+	FAMILY "primary" (rowid),
+	FAMILY fam_1_i (i),
+	FAMILY fam_2_s (s),
 	CONSTRAINT ck CHECK (i > 0)
 )`,
 		},
@@ -90,7 +103,8 @@ func TestShowCreateTable(t *testing.T) {
 )`,
 			expect: `CREATE TABLE %s (
 	i INT NOT NULL,
-	CONSTRAINT "primary" PRIMARY KEY (i)
+	CONSTRAINT "primary" PRIMARY KEY (i),
+	FAMILY "primary" (i)
 )`,
 		},
 		{
@@ -105,13 +119,19 @@ func TestShowCreateTable(t *testing.T) {
 	s STRING NULL,
 	d DATE NULL,
 	INDEX idx_if (f, i) STORING (s, d),
-	UNIQUE INDEX %[1]s_d_key (d)
+	UNIQUE INDEX %[1]s_d_key (d),
+	FAMILY "primary" (rowid),
+	FAMILY fam_1_i (i),
+	FAMILY fam_2_f (f),
+	FAMILY fam_3_s (s),
+	FAMILY fam_4_d (d)
 )`,
 		},
 		{
 			stmt: `CREATE TABLE %s (
 	"te""st" INT NOT NULL,
-	CONSTRAINT "pri""mary" PRIMARY KEY ("te""st")
+	CONSTRAINT "pri""mary" PRIMARY KEY ("te""st"),
+	FAMILY "primary" ("te""st")
 )`,
 		},
 	}

--- a/sql/sqlbase/structured_test.go
+++ b/sql/sqlbase/structured_test.go
@@ -57,7 +57,7 @@ func TestAllocateIDs(t *testing.T) {
 			makeIndexDescriptor("e", []string{"b"}),
 		},
 		Privileges:    NewDefaultPrivilegeDescriptor(),
-		FormatVersion: BaseFormatVersion,
+		FormatVersion: FamilyFormatVersion,
 	}
 	if err := desc.AllocateIDs(); err != nil {
 		t.Fatal(err)
@@ -80,7 +80,7 @@ func TestAllocateIDs(t *testing.T) {
 				ColumnIDs:   []ColumnID{1, 2},
 			},
 			{
-				ID: 3, Name: "fam_c",
+				ID: 3, Name: "fam_3_c",
 				ColumnNames:     []string{"c"},
 				ColumnIDs:       []ColumnID{3},
 				DefaultColumnID: ColumnID(3),
@@ -104,7 +104,7 @@ func TestAllocateIDs(t *testing.T) {
 		NextFamilyID:   4,
 		NextIndexID:    4,
 		NextMutationID: 1,
-		FormatVersion:  BaseFormatVersion,
+		FormatVersion:  FamilyFormatVersion,
 	}
 	if !reflect.DeepEqual(expected, desc) {
 		a, _ := json.MarshalIndent(expected, "", "  ")
@@ -142,14 +142,14 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 			}},
 		{`empty column name`,
 			TableDescriptor{
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 0},
 				},
@@ -160,7 +160,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 0, Name: "bar"},
 				},
@@ -171,7 +171,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -186,7 +186,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 					{ID: 1, Name: "bar"},
@@ -198,7 +198,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 					{ID: 1, Name: "blah"},
@@ -210,7 +210,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -221,7 +221,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -235,7 +235,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -251,7 +251,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -267,7 +267,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -283,7 +283,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -298,7 +298,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -313,7 +313,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -328,7 +328,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -343,7 +343,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -359,7 +359,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -381,7 +381,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -399,7 +399,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -417,7 +417,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -440,7 +440,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -457,7 +457,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 					{ID: 2, Name: "blah"},
@@ -478,7 +478,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -504,7 +504,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -530,7 +530,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -550,7 +550,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},
@@ -570,7 +570,7 @@ func TestValidateTableDesc(t *testing.T) {
 				ID:            2,
 				ParentID:      1,
 				Name:          "foo",
-				FormatVersion: BaseFormatVersion,
+				FormatVersion: FamilyFormatVersion,
 				Columns: []ColumnDescriptor{
 					{ID: 1, Name: "bar"},
 				},

--- a/sql/sqlbase/table.go
+++ b/sql/sqlbase/table.go
@@ -41,7 +41,7 @@ func MakeTableDesc(p *parser.CreateTable, parentID ID) (TableDescriptor, error) 
 	}
 	desc.Name = p.Table.Table()
 	desc.ParentID = parentID
-	desc.FormatVersion = BaseFormatVersion
+	desc.FormatVersion = FamilyFormatVersion
 	// We don't use version 0.
 	desc.Version = 1
 
@@ -138,6 +138,17 @@ func MakeTableDesc(p *parser.CreateTable, parentID ID) (TableDescriptor, error) 
 				check.Name = string(d.Name)
 			}
 			desc.Checks = append(desc.Checks, check)
+
+		case *parser.FamilyTableDef:
+			names := make([]string, len(d.Columns))
+			for i, col := range d.Columns {
+				names[i] = string(col.Column)
+			}
+			fam := ColumnFamilyDescriptor{
+				Name:        string(d.Name),
+				ColumnNames: names,
+			}
+			desc.AddFamily(fam)
 
 		default:
 			return desc, errors.Errorf("unsupported table def: %T", def)

--- a/sql/testdata/explain_types
+++ b/sql/testdata/explain_types
@@ -120,10 +120,11 @@ query ITTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
 0   update          result     ()
-1   select          result     (k int, "k + 1" int)
-2   render/filter   result     (k int, "k + 1" int)
+1   select          result     (k int, v int, "k + 1" int)
+2   render/filter   result     (k int, v int, "k + 1" int)
 2   render/filter   render 0   (k)[int]
-2   render/filter   render 1   ((k)[int] + (1)[int])[int]
+2   render/filter   render 1   (v)[int]
+2   render/filter   render 2   ((k)[int] + (1)[int])[int]
 3   scan            result     (k int, v int)
 3   scan            filter     ((v)[int] > (123)[int])[bool]
 
@@ -131,11 +132,12 @@ query ITTT
 EXPLAIN (TYPES,NOEXPAND) UPDATE t SET v = k + 1 WHERE v > 123
 ----
 0   update          result     ()
-1   select          result     (k int, "k + 1" int)
-2   render/filter   result     (k int, "k + 1" int)
+1   select          result     (k int, v int, "k + 1" int)
+2   render/filter   result     (k int, v int, "k + 1" int)
 2   render/filter   filter     ((v)[int] > (123)[int])[bool]
 2   render/filter   render 0   (k)[int]
-2   render/filter   render 1   ((k)[int] + (1)[int])[int]
+2   render/filter   render 1   (v)[int]
+2   render/filter   render 2   ((k)[int] + (1)[int])[int]
 3   scan            result     (k int, v int)
 
 query ITTT

--- a/sql/testdata/family
+++ b/sql/testdata/family
@@ -1,7 +1,94 @@
-statement error unsupported table def
-CREATE TABLE abc(
+# a is the primary key so b gets optimized into a one column value. The c, d
+# family has two columns, so it's encoded as a tuple
+statement ok
+CREATE TABLE abcd(
   a INT PRIMARY KEY,
   b INT,
   c INT,
-  FAMILY pri (a, b)
+  d INT,
+  FAMILY f1 (a, b),
+  FAMILY (c, d)
 )
+
+query TT
+SHOW CREATE TABLE abcd
+----
+abcd  CREATE TABLE abcd (
+      a INT NOT NULL,
+      b INT NULL,
+      c INT NULL,
+      d INT NULL,
+      CONSTRAINT "primary" PRIMARY KEY (a),
+      FAMILY f1 (a, b),
+      FAMILY fam_1_c_d (c, d)
+		  )
+
+statement ok
+INSERT INTO abcd VALUES (1, 2, 3, 4), (5, 6, 7, 8)
+
+query IIII
+SELECT * FROM abcd
+----
+1 2 3 4
+5 6 7 8
+
+statement ok
+UPDATE abcd SET b = 9, d = 10, c = NULL where c = 7
+
+query IIII
+SELECT * FROM abcd
+----
+1 2 3    4
+5 9 NULL 10
+
+statement ok
+DELETE FROM abcd where c = 3
+
+query IIII
+SELECT * FROM abcd
+----
+5 9 NULL 10
+
+statement ok
+UPSERT INTO abcd VALUES (1, 2, 3, 4), (5, 6, 7, 8)
+
+query IIII
+SELECT * FROM abcd
+----
+1 2 3 4
+5 6 7 8
+
+statement ok
+UPDATE abcd SET b = NULL, c = NULL, d = NULL WHERE a = 1
+
+query IIII
+SELECT * FROM abcd WHERE a = 1
+----
+1 NULL NULL NULL
+
+# TODO(dan): Specify family f1
+statement ok
+ALTER TABLE abcd ADD e STRING
+
+statement ok
+INSERT INTO abcd VALUES (9, 10, 11, 12, 'foo')
+
+query IIIIT
+SELECT * from abcd WHERE a > 1
+----
+5 6  7  8  NULL
+9 10 11 12 foo
+
+statement ok
+CREATE TABLE unsorted_colids (a INT PRIMARY KEY, b INT NOT NULL, c INT NOT NULL, FAMILY (c, b, a))
+
+statement ok
+INSERT INTO unsorted_colids VALUES (1, 1, 1)
+
+statement ok
+UPDATE unsorted_colids SET b = 2, c = 3 WHERE a = 1
+
+query III
+SELECT * FROM unsorted_colids
+----
+1 2 3

--- a/sql/testdata/table
+++ b/sql/testdata/table
@@ -186,6 +186,12 @@ test.users CREATE TABLE "test.users"
   CONSTRAINT "primary" PRIMARY KEY (id),
   INDEX foo (name),
   UNIQUE INDEX bar (id, name),
+  FAMILY "primary" (id),
+  FAMILY fam_2_name (name),
+  FAMILY fam_3_title (title),
+  FAMILY fam_4_nickname (nickname),
+  FAMILY fam_5_username (username),
+  FAMILY fam_6_email (email),
   CHECK (LENGTH(nickname) < LENGTH(name)),
   CHECK (LENGTH(nickname) < 10)
 )
@@ -219,6 +225,12 @@ test.named_constraints  CREATE TABLE "test.named_constraints" (
                         INDEX foo (name),
                         UNIQUE INDEX uq2 (username),
                         UNIQUE INDEX bar (id, name),
+                        FAMILY "primary" (id),
+                        FAMILY fam_2_name (name),
+                        FAMILY fam_3_title (title),
+                        FAMILY fam_4_nickname (nickname),
+                        FAMILY fam_5_username (username),
+                        FAMILY fam_6_email (email),
                         CONSTRAINT ck2 CHECK (LENGTH(nickname) < LENGTH(name)),
                         CONSTRAINT ck1 CHECK (LENGTH(nickname) < 10)
                         )


### PR DESCRIPTION
- Switch to the new FormatVersion
- Hook up the sql syntax in CREATE TABLE
- Update SHOW CREATE TABLE
- Update the WideTable benchmark to take advantage of column families

name                       old time/op    new time/op    delta
WideTable1_Cockroach-8       1.88ms ± 1%    1.50ms ± 0%  -20.08%  (p=0.008 n=5+5)
WideTable10_Cockroach-8      5.86ms ± 1%    2.59ms ± 1%  -55.77%  (p=0.016 n=4+5)
WideTable100_Cockroach-8     49.1ms ± 5%    13.2ms ± 5%  -73.07%  (p=0.008 n=5+5)
WideTable1000_Cockroach-8     570ms ± 5%     120ms ± 3%  -79.00%  (p=0.008 n=5+5)

name                       old alloc/op   new alloc/op   delta
WideTable1_Cockroach-8        265kB ± 0%     163kB ± 0%  -38.55%  (p=0.008 n=5+5)
WideTable10_Cockroach-8      1.43MB ± 0%    0.37MB ± 0%  -74.27%  (p=0.008 n=5+5)
WideTable100_Cockroach-8     13.2MB ± 0%     2.4MB ± 0%  -82.00%  (p=0.016 n=4+5)
WideTable1000_Cockroach-8     175MB ± 0%      21MB ± 0%  -87.76%  (p=0.008 n=5+5)

name                       old allocs/op  new allocs/op  delta
WideTable1_Cockroach-8        2.19k ± 0%     1.91k ± 0%  -12.88%  (p=0.008 n=5+5)
WideTable10_Cockroach-8       6.59k ± 0%     3.96k ± 0%  -39.83%  (p=0.008 n=5+5)
WideTable100_Cockroach-8      50.2k ± 0%     23.9k ± 0%  -52.40%  (p=0.008 n=5+5)
WideTable1000_Cockroach-8      546k ± 0%      223k ± 0%  -59.09%  (p=0.008 n=5+5)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7408)

<!-- Reviewable:end -->
