### PR TITLE
sql: Fix the comment on TestTxnDeadline

### DIFF
--- a/client/txn.go
+++ b/client/txn.go
@@ -676,9 +676,9 @@ func (txn *Txn) send(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.
 
 	br, pErr := txn.db.send(ba)
 	if elideEndTxn && pErr == nil {
-		// Check that read only transactions do not violate their deadline. This can happen
-		// when the transaction timestamp is updated by ReadWithinUncertaintyIntervalError
-		// (see TestTxnDeadline).
+		// Check that read only transactions do not violate their deadline. This can NOT
+		// happen since the txn deadline is normally updated when it is about to expire
+		// or expired. We will just keep the code for safety (see TestReacquireLeaseOnRestart).
 		if endTxnRequest.Deadline != nil {
 			if endTxnRequest.Deadline.Less(txn.Proto.Timestamp) {
 				return nil, roachpb.NewErrorWithTxn(roachpb.NewTransactionAbortedError(), &txn.Proto)


### PR DESCRIPTION
Found that we no longer hit the deadline-exceeded error as we re-acquire a lease and extend the deadline on retry..

It seems no read-only txn will hit the deadline-exceeded error, but it would be probably safe to keep the code.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7425)

<!-- Reviewable:end -->
