### PR TITLE
cli: allow rangeID as delimiter in `debug keys`

### DIFF
--- a/cli/cliflags/names.go
+++ b/cli/cliflags/names.go
@@ -43,7 +43,7 @@ const (
 	UserName              = "user"
 	FromName              = "from"
 	ToName                = "to"
-	RawName               = "raw"
+	TypeName              = "type"
 	ValuesName            = "values"
 	RaftTickIntervalName  = "raft-tick-interval"
 	UndoFreezeClusterName = "undo"

--- a/cli/context.go
+++ b/cli/context.go
@@ -62,6 +62,6 @@ type sqlContext struct {
 
 type debugContext struct {
 	startKey, endKey string
-	raw              bool
+	typ              string
 	values           bool
 }

--- a/cli/debug.go
+++ b/cli/debug.go
@@ -273,14 +273,14 @@ func tryRangeIDKey(kv engine.MVCCKeyValue) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("%d", i), nil
+		return strconv.FormatInt(i, 10), nil
 
 	case bytes.Equal(suffix, keys.LocalRangeFrozenStatusSuffix):
 		b, err := value.GetBool()
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("%t", b), nil
+		return strconv.FormatBool(b), nil
 
 	case bytes.Equal(suffix, keys.LocalAbortCacheSuffix):
 		msg = &roachpb.AbortCacheEntry{}
@@ -299,6 +299,22 @@ func tryRangeIDKey(kv engine.MVCCKeyValue) (string, error) {
 
 	case bytes.Equal(suffix, keys.LocalRangeStatsSuffix):
 		msg = &enginepb.MVCCStats{}
+
+	case bytes.Equal(suffix, keys.LocalRaftHardStateSuffix):
+		msg = &raftpb.HardState{}
+
+	case bytes.Equal(suffix, keys.LocalRaftLastIndexSuffix):
+		i, err := value.GetInt()
+		if err != nil {
+			return "", err
+		}
+		return strconv.FormatInt(i, 10), nil
+
+	case bytes.Equal(suffix, keys.LocalRangeLastVerificationTimestampSuffix):
+		msg = &hlc.Timestamp{}
+
+	case bytes.Equal(suffix, keys.LocalRangeLastReplicaGCTimestampSuffix):
+		msg = &hlc.Timestamp{}
 
 	default:
 		return "", fmt.Errorf("unknown raft id key %s", suffix)

--- a/cli/debug.go
+++ b/cli/debug.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"golang.org/x/net/context"
 
@@ -117,14 +118,35 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 
 	from := engine.NilKey
 	to := engine.MVCCKeyMax
-	if debugCtx.raw {
+
+	switch strings.ToLower(debugCtx.typ) {
+	case "rangeid":
+		var fromID, toID roachpb.RangeID
+		var err error
+		if len(debugCtx.startKey) > 0 {
+			fromID, err = parseRangeID(debugCtx.startKey)
+			if err != nil {
+				return err
+			}
+			from = engine.MakeMVCCMetadataKey(keys.MakeRangeIDPrefix(fromID))
+		}
+		if len(debugCtx.endKey) > 0 {
+			toID, err = parseRangeID(debugCtx.endKey)
+			if err != nil {
+				return err
+			}
+			to = engine.MakeMVCCMetadataKey(keys.MakeRangeIDPrefix(toID))
+		} else {
+			to = engine.MakeMVCCMetadataKey(keys.MakeRangeIDPrefix(fromID + 1))
+		}
+	case "raw":
 		if len(debugCtx.startKey) > 0 {
 			from = engine.MakeMVCCMetadataKey(roachpb.Key(debugCtx.startKey))
 		}
 		if len(debugCtx.endKey) > 0 {
 			to = engine.MakeMVCCMetadataKey(roachpb.Key(debugCtx.endKey))
 		}
-	} else {
+	case "pretty":
 		if len(debugCtx.startKey) > 0 {
 			startKey, err := keys.UglyPrint(debugCtx.startKey)
 			if err != nil {
@@ -139,6 +161,8 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 			}
 			to = engine.MakeMVCCMetadataKey(endKey)
 		}
+	default:
+		return fmt.Errorf("invalid input key type '%s'", debugCtx.typ)
 	}
 
 	printer := printKey

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -227,8 +227,9 @@ Start key in pretty-printed format. See also --raw.`),
 	cliflags.ToName: wrapText(`
 Exclusive end key in pretty-printed format. See also --raw.`),
 
-	cliflags.RawName: wrapText(`
-Interpret keys as raw bytes.`),
+	cliflags.TypeName: wrapText(`
+Interpret the arguments to --from and --to as raw bytes ('raw'),
+rangeIDs ('rangeID') or pretty-printed keys ('pretty').`),
 
 	cliflags.ValuesName: wrapText(`
 Print values along with their associated key.`),
@@ -491,7 +492,8 @@ func init() {
 		f := debugKeysCmd.Flags()
 		f.StringVar(&debugCtx.startKey, cliflags.FromName, "", usageNoEnv(cliflags.FromName))
 		f.StringVar(&debugCtx.endKey, cliflags.ToName, "", usageNoEnv(cliflags.ToName))
-		f.BoolVar(&debugCtx.raw, cliflags.RawName, false, usageNoEnv(cliflags.RawName))
+		// TODO(tamird): should technically be an enum, but there's no good flag support for them.
+		f.StringVar(&debugCtx.typ, cliflags.TypeName, "raw", usageNoEnv(cliflags.TypeName))
 		f.BoolVar(&debugCtx.values, cliflags.ValuesName, false, usageNoEnv(cliflags.ValuesName))
 	}
 

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -114,17 +114,17 @@ var (
 	// together or individually in a single scan.
 	localRangeIDUnreplicatedInfix = []byte("u")
 	// localRaftHardStateSuffix is the Suffix for the raft HardState.
-	localRaftHardStateSuffix = []byte("rfth")
+	LocalRaftHardStateSuffix = []byte("rfth")
 	// localRaftLastIndexSuffix is the suffix for raft's last index.
-	localRaftLastIndexSuffix = []byte("rfti")
+	LocalRaftLastIndexSuffix = []byte("rfti")
 	// LocalRaftLogSuffix is the suffix for the raft log.
 	LocalRaftLogSuffix = []byte("rftl")
 	// localRangeLastReplicaGCTimestampSuffix is the suffix for a range's
 	// last replica GC timestamp (for GC of old replicas).
-	localRangeLastReplicaGCTimestampSuffix = []byte("rlrt")
+	LocalRangeLastReplicaGCTimestampSuffix = []byte("rlrt")
 	// localRangeLastVerificationTimestampSuffix is the suffix for a range's
 	// last verification timestamp (for checking integrity of on-disk data).
-	localRangeLastVerificationTimestampSuffix = []byte("rlvt")
+	LocalRangeLastVerificationTimestampSuffix = []byte("rlvt")
 
 	// LocalRangePrefix is the prefix identifying per-range data indexed
 	// by range key (either start key, or some key in the range). The

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -218,13 +218,13 @@ func MakeRangeIDUnreplicatedKey(rangeID roachpb.RangeID, suffix roachpb.RKey, de
 
 // RaftHardStateKey returns a system-local key for a Raft HardState.
 func RaftHardStateKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDUnreplicatedKey(rangeID, localRaftHardStateSuffix, nil)
+	return MakeRangeIDUnreplicatedKey(rangeID, LocalRaftHardStateSuffix, nil)
 }
 
 // RaftLastIndexKey returns a system-local key for the last index of the
 // Raft log.
 func RaftLastIndexKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDUnreplicatedKey(rangeID, localRaftLastIndexSuffix, nil)
+	return MakeRangeIDUnreplicatedKey(rangeID, LocalRaftLastIndexSuffix, nil)
 }
 
 // RaftLogPrefix returns the system-local prefix shared by all entries
@@ -243,13 +243,13 @@ func RaftLogKey(rangeID roachpb.RangeID, logIndex uint64) roachpb.Key {
 // RangeLastReplicaGCTimestampKey returns a range-local key for
 // the range's last replica GC timestamp.
 func RangeLastReplicaGCTimestampKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDUnreplicatedKey(rangeID, localRangeLastReplicaGCTimestampSuffix, nil)
+	return MakeRangeIDUnreplicatedKey(rangeID, LocalRangeLastReplicaGCTimestampSuffix, nil)
 }
 
 // RangeLastVerificationTimestampKey returns a range-local key for
 // the range's last verification timestamp.
 func RangeLastVerificationTimestampKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDUnreplicatedKey(rangeID, localRangeLastVerificationTimestampSuffix, nil)
+	return MakeRangeIDUnreplicatedKey(rangeID, LocalRangeLastVerificationTimestampSuffix, nil)
 }
 
 // MakeRangeKey creates a range-local key based on the range

--- a/keys/printer.go
+++ b/keys/printer.go
@@ -130,7 +130,7 @@ var (
 	}{
 		{name: "AbortCache", suffix: LocalAbortCacheSuffix, ppFunc: abortCacheKeyPrint, psFunc: abortCacheKeyParse},
 		{name: "RaftTombstone", suffix: LocalRaftTombstoneSuffix},
-		{name: "RaftHardState", suffix: localRaftHardStateSuffix},
+		{name: "RaftHardState", suffix: LocalRaftHardStateSuffix},
 		{name: "RaftAppliedIndex", suffix: LocalRaftAppliedIndexSuffix},
 		{name: "LeaseAppliedIndex", suffix: LocalLeaseAppliedIndexSuffix},
 		{name: "RaftLog", suffix: LocalRaftLogSuffix,
@@ -138,9 +138,9 @@ var (
 			psFunc: raftLogKeyParse,
 		},
 		{name: "RaftTruncatedState", suffix: LocalRaftTruncatedStateSuffix},
-		{name: "RaftLastIndex", suffix: localRaftLastIndexSuffix},
-		{name: "RangeLastReplicaGCTimestamp", suffix: localRangeLastReplicaGCTimestampSuffix},
-		{name: "RangeLastVerificationTimestamp", suffix: localRangeLastVerificationTimestampSuffix},
+		{name: "RaftLastIndex", suffix: LocalRaftLastIndexSuffix},
+		{name: "RangeLastReplicaGCTimestamp", suffix: LocalRangeLastReplicaGCTimestampSuffix},
+		{name: "RangeLastVerificationTimestamp", suffix: LocalRangeLastVerificationTimestampSuffix},
 		{name: "RangeLeaderLease", suffix: LocalRangeLeaderLeaseSuffix},
 		{name: "RangeStats", suffix: LocalRangeStatsSuffix},
 	}


### PR DESCRIPTION
Some fallout from looking at #7389. Trying to get these in in time for test running the migration for said issue.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7427)

<!-- Reviewable:end -->
