### PR TITLE
sql/pgwire: Avoid uint{16, 32} -> int{16, 32} overflows, which could cause panics

### DIFF
--- a/sql/pgwire/encoding.go
+++ b/sql/pgwire/encoding.go
@@ -138,11 +138,11 @@ func (b *readBuffer) getUint16() (uint16, error) {
 	return v, nil
 }
 
-func (b *readBuffer) getInt32() (int32, error) {
+func (b *readBuffer) getUint32() (uint32, error) {
 	if len(b.msg) < 4 {
 		return 0, errors.Errorf("insufficient data: %d", len(b.msg))
 	}
-	v := int32(binary.BigEndian.Uint32(b.msg[:4]))
+	v := binary.BigEndian.Uint32(b.msg[:4])
 	b.msg = b.msg[4:]
 	return v, nil
 }

--- a/sql/pgwire/encoding.go
+++ b/sql/pgwire/encoding.go
@@ -129,11 +129,11 @@ func (b *readBuffer) getBytes(n int) ([]byte, error) {
 	return v, nil
 }
 
-func (b *readBuffer) getInt16() (int16, error) {
+func (b *readBuffer) getUint16() (uint16, error) {
 	if len(b.msg) < 2 {
 		return 0, errors.Errorf("insufficient data: %d", len(b.msg))
 	}
-	v := int16(binary.BigEndian.Uint16(b.msg[:2]))
+	v := binary.BigEndian.Uint16(b.msg[:2])
 	b.msg = b.msg[2:]
 	return v, nil
 }

--- a/sql/pgwire/formatcode_string.go
+++ b/sql/pgwire/formatcode_string.go
@@ -9,7 +9,7 @@ const _formatCode_name = "formatTextformatBinary"
 var _formatCode_index = [...]uint8{0, 10, 22}
 
 func (i formatCode) String() string {
-	if i < 0 || i >= formatCode(len(_formatCode_index)-1) {
+	if i >= formatCode(len(_formatCode_index)-1) {
 		return fmt.Sprintf("formatCode(%d)", i)
 	}
 	return _formatCode_name[_formatCode_index[i]:_formatCode_index[i+1]]

--- a/sql/pgwire/server.go
+++ b/sql/pgwire/server.go
@@ -99,7 +99,7 @@ func Match(rd io.Reader) bool {
 	if err != nil {
 		return false
 	}
-	version, err := buf.getInt32()
+	version, err := buf.getUint32()
 	if err != nil {
 		return false
 	}
@@ -163,7 +163,7 @@ func (s *Server) ServeConn(conn net.Conn) error {
 		return err
 	}
 	s.metrics.bytesInCount.Inc(int64(n))
-	version, err := buf.getInt32()
+	version, err := buf.getUint32()
 	if err != nil {
 		return err
 	}
@@ -193,7 +193,7 @@ func (s *Server) ServeConn(conn net.Conn) error {
 			return err
 		}
 		s.metrics.bytesInCount.Inc(int64(n))
-		version, err = buf.getInt32()
+		version, err = buf.getUint32()
 		if err != nil {
 			return err
 		}

--- a/sql/pgwire/types.go
+++ b/sql/pgwire/types.go
@@ -37,7 +37,7 @@ import (
 )
 
 //go:generate stringer -type=formatCode
-type formatCode int16
+type formatCode uint16
 
 const (
 	formatText   formatCode = 0

--- a/sql/pgwire/types_test.go
+++ b/sql/pgwire/types_test.go
@@ -110,7 +110,7 @@ func BenchmarkDecodeBinaryDecimal(b *testing.B) {
 
 	rbuf := readBuffer{msg: wbuf.wrapped.Bytes()}
 
-	plen, err := rbuf.getInt32()
+	plen, err := rbuf.getUint32()
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -337,7 +337,7 @@ func (c *v3Conn) handleParse(ctx context.Context, buf *readBuffer) error {
 	}
 	// The client may provide type information for (some of) the
 	// placeholders. Read this first.
-	numQArgTypes, err := buf.getInt16()
+	numQArgTypes, err := buf.getUint16()
 	if err != nil {
 		return err
 	}
@@ -491,7 +491,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 	}
 
 	stmtMeta := stmt.ProtocolMeta.(preparedStatementMeta)
-	numQArgs := int16(len(stmtMeta.inTypes))
+	numQArgs := uint16(len(stmtMeta.inTypes))
 	qArgFormatCodes := make([]formatCode, numQArgs)
 	// From the docs on number of argument format codes to bind:
 	// This can be zero to indicate that there are no arguments or that the
@@ -499,7 +499,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 	// specified format code is applied to all arguments; or it can equal the
 	// actual number of arguments.
 	// http://www.postgresql.org/docs/current/static/protocol-message-formats.html
-	numQArgFormatCodes, err := buf.getInt16()
+	numQArgFormatCodes, err := buf.getUint16()
 	if err != nil {
 		return err
 	}
@@ -507,7 +507,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 	case 0:
 	case 1:
 		// `1` means read one code and apply it to every argument.
-		c, err := buf.getInt16()
+		c, err := buf.getUint16()
 		if err != nil {
 			return err
 		}
@@ -518,7 +518,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 	case numQArgs:
 		// Read one format code for each argument and apply it to that argument.
 		for i := range qArgFormatCodes {
-			c, err := buf.getInt16()
+			c, err := buf.getUint16()
 			if err != nil {
 				return err
 			}
@@ -528,7 +528,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 		return c.sendInternalError(fmt.Sprintf("wrong number of format codes specified: %d for %d arguments", numQArgFormatCodes, numQArgs))
 	}
 
-	numValues, err := buf.getInt16()
+	numValues, err := buf.getUint16()
 	if err != nil {
 		return err
 	}
@@ -558,7 +558,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 		qargs[k] = d
 	}
 
-	numColumns := int16(len(stmt.Columns))
+	numColumns := uint16(len(stmt.Columns))
 	columnFormatCodes := make([]formatCode, numColumns)
 
 	// From the docs on number of result-column format codes to bind:
@@ -568,7 +568,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 	// (if any); or it can equal the actual number of result columns of the
 	// query.
 	// http://www.postgresql.org/docs/current/static/protocol-message-formats.html
-	numColumnFormatCodes, err := buf.getInt16()
+	numColumnFormatCodes, err := buf.getUint16()
 	if err != nil {
 		return err
 	}
@@ -576,7 +576,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 	case 0:
 	case 1:
 		// Read one code and apply it to every column.
-		c, err := buf.getInt16()
+		c, err := buf.getUint16()
 		if err != nil {
 			return err
 		}
@@ -587,7 +587,7 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 	case numColumns:
 		// Read one format code for each column and apply it to that column.
 		for i := range columnFormatCodes {
-			c, err := buf.getInt16()
+			c, err := buf.getUint16()
 			if err != nil {
 				return err
 			}

--- a/sql/pgwire/v3_test.go
+++ b/sql/pgwire/v3_test.go
@@ -50,6 +50,9 @@ func TestMaliciousInputs(t *testing.T) {
 		// This byte string exploited the same bug using a clientMsgDescribe
 		// message type.
 		{byte(clientMsgDescribe), 0x00, 0x00, 0x00, 0x04},
+		// This would cause readBuffer.getInt16 to overflow, resulting in a
+		// negative value being used for an allocation size.
+		{byte(clientMsgParse), 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0xff, 0xff},
 	} {
 		testMaliciousInput(t, data)
 	}


### PR DESCRIPTION
This was found using https://github.com/cockroachdb/go-fuzz/pull/4.

Fuzz testing revealed that it was possible for a `uint16` overflow when a
client-provided `uint16` value was cast to an `int16` and for a `uint32` overflow when a
client-provided `uint32` value was cast to an `int32`. These could both be exploited to
result in server panics, due to a negative allocation size in `handleParse` for the former 
and a negative slice index in `handleBind->getBytes` for the latter.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7434)

<!-- Reviewable:end -->
