### PR TITLE
sql: fix double import of 'errors' from ships-passing merge

### DIFF
--- a/sql/fk.go
+++ b/sql/fk.go
@@ -15,7 +15,6 @@
 package sql
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/client"


### PR DESCRIPTION
Merge of d62ec23ed768 and af620316176 ended up with a compile error due to double import of 'errors'

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7437)

<!-- Reviewable:end -->
