### PR TITLE
sql/parser: IsUnresolvedPlaceholder checks for nested parens

### DIFF
--- a/sql/parser/constant.go
+++ b/sql/parser/constant.go
@@ -48,6 +48,11 @@ type Constant interface {
 var _ Constant = &NumVal{}
 var _ Constant = &StrVal{}
 
+func isConstant(expr Expr) bool {
+	_, ok := expr.(Constant)
+	return ok
+}
+
 func isNumericConstant(expr Expr) bool {
 	_, ok := expr.(*NumVal)
 	return ok

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -230,6 +230,18 @@ func (node *ParenExpr) TypedInnerExpr() TypedExpr {
 	return node.Expr.(TypedExpr)
 }
 
+// StripParens strips any parentheses surrounding an expression and
+// returns the inner expression. For instance:
+//   1   -> 1
+//  (1)  -> 1
+// ((1)) -> 1
+func StripParens(expr Expr) Expr {
+	if p, ok := expr.(*ParenExpr); ok {
+		return StripParens(p.Expr)
+	}
+	return expr
+}
+
 // ComparisonOperator represents a binary operator.
 type ComparisonOperator int
 

--- a/sql/parser/expr_test.go
+++ b/sql/parser/expr_test.go
@@ -232,6 +232,28 @@ func TestExprString(t *testing.T) {
 	}
 }
 
+func TestStripParens(t *testing.T) {
+	testExprs := []struct {
+		in, out string
+	}{
+		{`1`, `1`},
+		{`(1)`, `1`},
+		{`((1))`, `1`},
+		{`(1) + (2)`, `(1) + (2)`},
+		{`((1) + (2))`, `(1) + (2)`},
+	}
+	for i, test := range testExprs {
+		expr, err := ParseExprTraditional(test.in)
+		if err != nil {
+			t.Fatalf("%d: %v", i, err)
+		}
+		stripped := StripParens(expr)
+		if str := stripped.String(); str != test.out {
+			t.Fatalf("%d: expected StripParens(%s) = %s, but found %s", i, test.in, test.out, str)
+		}
+	}
+}
+
 type stripFuncsVisitor struct{}
 
 func (v stripFuncsVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {

--- a/sql/parser/overload.go
+++ b/sql/parser/overload.go
@@ -211,11 +211,14 @@ func typeCheckOverloadedExprs(
 		}
 		for _, expr := range placeholderExprs {
 			if errorOnPlaceholders {
-				_, err := expr.e.(Placeholder).TypeCheck(ctx, nil)
+				_, err := expr.e.TypeCheck(ctx, nil)
 				return err
 			}
 			// If we dont want to error on args, avoid type checking them without a desired type.
-			typedExprs[expr.i] = &DPlaceholder{name: expr.e.(Placeholder).Name, pmap: ctx.Placeholders}
+			typedExprs[expr.i] = &DPlaceholder{
+				name: StripParens(expr.e).(Placeholder).Name,
+				pmap: ctx.Placeholders,
+			}
 		}
 		return nil
 	}

--- a/sql/parser/placeholders.go
+++ b/sql/parser/placeholders.go
@@ -109,13 +109,13 @@ func (p *PlaceholderInfo) SetTypes(src PlaceholderTypes) {
 }
 
 // IsUnresolvedPlaceholder returns whether expr is an unresolved placeholder. In
-// other words, it returns whether the provided expression is a placeholder, and
-// if so, whether the placeholder's type remains unset or not.
+// other words, it returns whether the provided expression is a placeholder
+// expression or a placeholder expression within nested parentheses, and if so,
+// whether the placeholder's type remains unset in the PlaceholderInfo.
 func (p *PlaceholderInfo) IsUnresolvedPlaceholder(expr Expr) bool {
-	if pl, ok := expr.(Placeholder); ok {
-		if _, ok := p.Types[pl.Name]; !ok {
-			return true
-		}
+	if t, ok := StripParens(expr).(Placeholder); ok {
+		_, res := p.Types[t.Name]
+		return !res
 	}
 	return false
 }

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -214,22 +214,20 @@ func (expr *CastExpr) TypeCheck(ctx *SemaContext, desired Datum) (TypedExpr, err
 	// The desired type provided to a CastExpr is ignored. Instead, NoTypePreference
 	// is passed to the child of the cast. There are two exceptions, described below.
 	desired = NoTypePreference
-	switch t := expr.Expr.(type) {
-	case Constant:
-		if canConstantBecome(t, returnDatum) {
+	switch {
+	case isConstant(expr.Expr):
+		if canConstantBecome(expr.Expr.(Constant), returnDatum) {
 			// If a Constant is subject to a cast which it can naturally become (which
 			// is in its resolvable type set), we desire the cast's type for the Constant,
 			// which will result in the CastExpr becoming an identity cast.
 			desired = returnDatum
 		}
-	case Placeholder:
-		if ctx.isUnresolvedPlaceholder(t) {
-			// This case will be triggered if ProcessPlaceholderAnnotations found
-			// the same placeholder in another location where it was either not
-			// the child of a cast, or was the child of a cast to a different type.
-			// In this case, we default to inferring a STRING for the placeholder.
-			desired = TypeString
-		}
+	case ctx.isUnresolvedPlaceholder(expr.Expr):
+		// This case will be triggered if ProcessPlaceholderAnnotations found
+		// the same placeholder in another location where it was either not
+		// the child of a cast, or was the child of a cast to a different type.
+		// In this case, we default to inferring a STRING for the placeholder.
+		desired = TypeString
 	}
 
 	typedSubExpr, err := expr.Expr.TypeCheck(ctx, desired)

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -326,6 +326,14 @@ func TestPGPreparedQuery(t *testing.T) {
 			base.SetArgs("1.0").Error(`pq: error in argument for $1: strconv.ParseInt: parsing "1.0": invalid syntax`),
 			base.SetArgs(true).Error(`pq: error in argument for $1: strconv.ParseInt: parsing "true": invalid syntax`),
 		},
+		"SELECT ($1) > 0": {
+			base.SetArgs(1).Results(true),
+			base.SetArgs(-1).Results(false),
+		},
+		"SELECT ((($1))) > 0": {
+			base.SetArgs(1).Results(true),
+			base.SetArgs(-1).Results(false),
+		},
 		"SELECT TRUE AND $1": {
 			base.SetArgs(true).Results(true),
 			base.SetArgs(false).Results(false),

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -76,14 +76,7 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, error)
 		index := -1
 
 		// Unwrap parenthesized expressions like "((a))" to "a".
-		expr := o.Expr
-		for {
-			if paren, ok := expr.(*parser.ParenExpr); ok {
-				expr = paren.Expr
-			} else {
-				break
-			}
-		}
+		expr := parser.StripParens(o.Expr)
 
 		if qname, ok := expr.(*parser.QualifiedName); ok {
 			if len(qname.Indirect) == 0 {


### PR DESCRIPTION
Fixes #7331.

We now look for nested parentheses when checking if an `Expr`
is an unresolved placeholder. This fixes type checking of queries
like:

```
SELECT a FROM d.t WHERE a > ($1);
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7440)

<!-- Reviewable:end -->
