### PR TITLE
sql: support self-ref FKs

### DIFF
--- a/sql/testdata/fk
+++ b/sql/testdata/fk
@@ -236,3 +236,21 @@ DROP INDEX child@child_parent_id_key CASCADE
 
 statement ok
 INSERT INTO grandchild VALUES (1, 1)
+
+statement ok
+CREATE TABLE employees (id INT PRIMARY KEY, manager INT REFERENCES employees, INDEX (manager));
+
+statement ok
+INSERT INTO employees VALUES (1, NULL)
+
+statement ok
+INSERT INTO employees VALUES (2, 1), (3, 1)
+
+statement ok
+INSERT INTO employees VALUES (4, 2), (5, 3);
+
+statement error foreign key violation
+DELETE FROM employees WHERE id = 2
+
+statement error foreign key violation
+DELETE FROM employees WHERE id > 1


### PR DESCRIPTION
A little tricky since table's ID is zero until it is created so it has to be edited immediately after creation to fix the FK pointers. Alternately we could consider just using 0 as a special-case value to mean self and
check that during lookup.

NB (not directly related but encountered in testing this functionality): we currently check FKs row-by-row before flushing the BatchRequest, thus we do NOT see other writes from the same statement when checking FKs. Postgres appears to stage all the writes for a statement before checking FKs, and then there's yet a harder case, DEFERRED, which checks them at txn commit, which we may want to look at later

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7443)

<!-- Reviewable:end -->
