### PR TITLE
storage: deflake TestReplicaDestroy

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -4953,7 +4953,6 @@ func TestReplicaLoadSystemConfigSpanIntent(t *testing.T) {
 
 func TestReplicaDestroy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#7457")
 	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -404,8 +404,15 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	}
 
 	// Verify that removal of a replica marks it as destroyed so that future raft
-	// commands on the Replica structure will fail.
-	err = rng1.withRaftGroup(func(r *raft.RawNode) error { return nil })
+	// commands on the Replica will silently be dropped.
+	err = rng1.withRaftGroup(func(r *raft.RawNode) error {
+		return errors.Errorf("unexpectedly created a raft group")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = rng1.proposeRaftCommand(context.TODO(), roachpb.BatchRequest{})
 	expected := "replica .* was garbage collected"
 	if !testutils.IsError(err, expected) {
 		t.Fatalf("expected error %s, but got %v", expected, err)


### PR DESCRIPTION
Don't return an error from `Replica.withRaftGroupLocked` when a
`Replica` has been destroyed. Instead, silently ignore operations.

Fixes #7457.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7463)

<!-- Reviewable:end -->
