### PR TITLE
storage: simplify Replica.applySnapshot interface

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -6154,14 +6154,8 @@ func TestReserveAndApplySnapshot(t *testing.T) {
 		t.Fatalf("Can't reserve the replica")
 	}
 	checkReservations(t, 1)
-	b := tc.engine.NewBatch()
-	defer b.Close()
-	if err := firstRng.applySnapshot(b, snap); err != nil {
+	if _, err := firstRng.applySnapshot(snap); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Commit(); err != nil {
-		t.Fatal(err)
-	}
-
 	checkReservations(t, 0)
 }


### PR DESCRIPTION
Batch creation is now performed internally. Changed the return values to
match the associated comment (i.e. `applySnapshot` now returns the last
index).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7464)

<!-- Reviewable:end -->
