### PR TITLE
storage: fix preemptive snapshots

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -218,7 +218,11 @@ type Replica struct {
 		// TODO(tschottdorf): evaluate whether this should be a list/slice.
 		pendingCmds       map[storagebase.CmdIDKey]*pendingCmd
 		internalRaftGroup *raft.RawNode
-		replicaID         roachpb.ReplicaID
+		// The ID of the replica within the Raft group. May be 0 if the replica has
+		// been created from a preemptive snapshot (i.e. before being added to the
+		// Raft group). The replica ID will be non-zero whenever the replica is
+		// part of a Raft group.
+		replicaID roachpb.ReplicaID
 		// Most recent timestamps for keys / key ranges.
 		tsCache *timestampCache
 		// proposeRaftCommandFn can be set to mock out the propose operation.
@@ -246,6 +250,11 @@ func (r *Replica) withRaftGroupLocked(f func(r *raft.RawNode) error) error {
 	if r.mu.destroyed != nil {
 		// Silently ignore all operations on destroyed replicas. We can't return an
 		// error here as all errors returned from this method are considered fatal.
+		return nil
+	}
+	if r.mu.replicaID == 0 {
+		// The replica's raft group has not yet been configured (i.e. the replica
+		// was created from a preemptive snapshot).
 		return nil
 	}
 
@@ -351,8 +360,10 @@ func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor, clock *hlc.Cloc
 	if replicaID == 0 {
 		_, repDesc := desc.FindReplica(r.store.StoreID())
 		if repDesc == nil {
-			return errors.Errorf("cannot recreate replica that is not a member of its range (StoreID %s not found in %s)",
-				r.store.StoreID(), desc)
+			// This is intentionally not an error and is the code path exercised
+			// during preemptive snapshots. The replica ID will be sent when the
+			// actual raft replica change occurs.
+			return nil
 		}
 		replicaID = repDesc.ReplicaID
 	}

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -534,10 +534,13 @@ func (r *Replica) applySnapshot(snap raftpb.Snapshot) (uint64, error) {
 	replicaID := r.mu.replicaID
 	r.mu.Unlock()
 
-	log.Infof("replica %d received snapshot for range %d at index %d. encoded size=%d, %d KV pairs, %d log entries",
-		replicaID, desc.RangeID, snap.Metadata.Index, len(snap.Data), len(snapData.KV), len(snapData.LogEntries))
+	log.Infof("replica %d received snapshot for range %d at index %d. "+
+		"encoded size=%d, %d KV pairs, %d log entries",
+		replicaID, desc.RangeID, snap.Metadata.Index,
+		len(snap.Data), len(snapData.KV), len(snapData.LogEntries))
 	defer func(start time.Time) {
-		log.Infof("replica %d applied snapshot for range %d in %s", replicaID, desc.RangeID, timeutil.Since(start))
+		log.Infof("replica %d applied snapshot for range %d in %s",
+			replicaID, desc.RangeID, timeutil.Since(start))
 	}(timeutil.Now())
 
 	// Delete everything in the range and recreate it from the snapshot.
@@ -591,6 +594,15 @@ func (r *Replica) applySnapshot(snap raftpb.Snapshot) (uint64, error) {
 	if s.RaftAppliedIndex != snap.Metadata.Index {
 		log.Fatalf("%d: snapshot resulted in appliedIndex=%d, metadataIndex=%d",
 			s.Desc.RangeID, s.RaftAppliedIndex, snap.Metadata.Index)
+	}
+
+	if replicaID == 0 {
+		// The replica is not part of the Raft group so we need to write the Raft
+		// hard state for the replica in order for the Raft state machine to start
+		// correctly.
+		if err := updateHardState(batch, s); err != nil {
+			return 0, err
+		}
 	}
 
 	if err := batch.Commit(); err != nil {


### PR DESCRIPTION
Allow Replicas to be created which do not have their Raft replica ID
configured. These Replicas only allow snapshots to be applied. When
applying snapshots to these replicas, we initialize the raft group state
similarly to splitting a range.

Fixes #7372.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7468)

<!-- Reviewable:end -->
