### PR TITLE
sql: use a single column family for the KV* benchmarks

### DIFF
--- a/sql/kv_test.go
+++ b/sql/kv_test.go
@@ -261,7 +261,14 @@ func (kv *kvSQL) prep(rows int, initData bool) error {
 	if _, err := kv.db.Exec(`DROP TABLE IF EXISTS bench.kv`); err != nil {
 		return err
 	}
-	if _, err := kv.db.Exec(`CREATE TABLE IF NOT EXISTS bench.kv (k STRING PRIMARY KEY, v INT)`); err != nil {
+	schema := `
+CREATE TABLE IF NOT EXISTS bench.kv (
+  k STRING PRIMARY KEY,
+  v INT,
+  FAMILY (k, v)
+)
+`
+	if _, err := kv.db.Exec(schema); err != nil {
 		return err
 	}
 	if !initData {


### PR DESCRIPTION
Using a single column family for the `KV*` benchmarks is fair as we're
trying to measure the overhead of using the KV layer directly vs a SQL
"kv" table.

```
name                  old time/op  new time/op  delta
KVInsert1_SQL-32       497µs ± 2%   481µs ± 2%   -3.38%  (p=0.000 n=20+19)
KVInsert10_SQL-32      779µs ± 1%   661µs ± 2%  -15.13%  (p=0.000 n=19+19)
KVInsert100_SQL-32    2.88ms ± 1%  2.03ms ± 1%  -29.62%  (p=0.000 n=20+20)
KVInsert1000_SQL-32   23.0ms ± 4%  14.2ms ± 3%  -38.24%  (p=0.000 n=18+19)
KVInsert10000_SQL-32   261ms ±11%   150ms ± 3%  -42.59%  (p=0.000 n=20+18)
KVUpdate1_SQL-32       710µs ± 5%   700µs ± 5%   -1.40%  (p=0.049 n=20+20)
KVUpdate10_SQL-32     1.15ms ± 1%  1.11ms ± 2%   -3.09%  (p=0.000 n=18+20)
KVUpdate100_SQL-32    4.36ms ± 2%  4.14ms ± 2%   -5.11%  (p=0.000 n=19+18)
KVUpdate1000_SQL-32   35.1ms ± 2%  32.7ms ± 3%   -6.84%  (p=0.000 n=19+19)
KVUpdate10000_SQL-32   403ms ±12%   336ms ± 5%  -16.60%  (p=0.000 n=18+19)
KVDelete1_SQL-32       644µs ± 4%   630µs ± 3%   -2.17%  (p=0.004 n=20+20)
KVDelete10_SQL-32      955µs ± 3%   939µs ± 2%   -1.65%  (p=0.000 n=20+19)
KVDelete100_SQL-32    3.31ms ± 2%  3.32ms ± 4%     ~     (p=0.729 n=17+20)
KVDelete1000_SQL-32   24.9ms ± 4%  24.9ms ± 5%     ~     (p=0.885 n=19+19)
KVDelete10000_SQL-32   262ms ± 4%   266ms ± 6%     ~     (p=0.134 n=19+20)
KVScan1_SQL-32         219µs ± 5%   214µs ± 5%   -2.06%  (p=0.028 n=20+20)
KVScan10_SQL-32        283µs ± 1%   261µs ± 2%   -7.68%  (p=0.000 n=20+20)
KVScan100_SQL-32       766µs ± 1%   585µs ± 1%  -23.62%  (p=0.000 n=20+18)
KVScan1000_SQL-32     4.98ms ± 2%  3.31ms ± 2%  -33.61%  (p=0.000 n=20+19)
KVScan10000_SQL-32    44.5ms ± 3%  29.4ms ± 2%  -34.00%  (p=0.000 n=20+19)
```

And here is how KV vs SQL compare:

```
name              old time/op  new time/op  delta
KVInsert1-32       642µs ± 1%   481µs ± 2%  -25.16%  (p=0.000 n=20+19)
KVInsert10-32      801µs ± 1%   661µs ± 2%  -17.46%  (p=0.000 n=20+19)
KVInsert100-32    2.03ms ± 2%  2.03ms ± 1%     ~     (p=0.602 n=20+20)
KVInsert1000-32   12.0ms ± 2%  14.2ms ± 3%  +18.42%  (p=0.000 n=20+19)
KVInsert10000-32   124ms ± 8%   150ms ± 3%  +20.24%  (p=0.000 n=20+18)
KVUpdate1-32      1.03ms ± 2%  0.70ms ± 5%  -32.32%  (p=0.000 n=19+20)
KVUpdate10-32     1.49ms ± 1%  1.11ms ± 2%  -25.43%  (p=0.000 n=20+20)
KVUpdate100-32    4.69ms ± 2%  4.14ms ± 2%  -11.74%  (p=0.000 n=20+18)
KVUpdate1000-32   30.5ms ± 3%  32.7ms ± 3%   +6.99%  (p=0.000 n=20+19)
KVUpdate10000-32   334ms ±10%   336ms ± 5%     ~     (p=0.053 n=19+19)
KVDelete1-32       639µs ± 3%   630µs ± 3%     ~     (p=0.080 n=17+20)
KVDelete10-32      873µs ± 2%   939µs ± 2%   +7.53%  (p=0.000 n=20+19)
KVDelete100-32    2.53ms ± 1%  3.32ms ± 4%  +31.47%  (p=0.000 n=20+20)
KVDelete1000-32   14.5ms ± 2%  24.9ms ± 5%  +72.38%  (p=0.000 n=20+19)
KVDelete10000-32   151ms ± 6%   266ms ± 6%  +75.92%  (p=0.000 n=20+20)
KVScan1-32         390µs ± 4%   214µs ± 5%  -45.14%  (p=0.000 n=20+20)
KVScan10-32        448µs ± 2%   261µs ± 2%  -41.71%  (p=0.000 n=19+20)
KVScan100-32       713µs ± 1%   585µs ± 1%  -17.87%  (p=0.000 n=20+18)
KVScan1000-32     2.73ms ± 1%  3.31ms ± 2%  +21.38%  (p=0.000 n=18+19)
KVScan10000-32    25.1ms ± 2%  29.4ms ± 2%  +17.12%  (p=0.000 n=20+19)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7471)

<!-- Reviewable:end -->
