### PR TITLE
cli: add --http-addr flag

### DIFF
--- a/cli/cliflags/names.go
+++ b/cli/cliflags/names.go
@@ -33,6 +33,7 @@ const (
 	PasswordName          = "password"
 	PortName              = "port"
 	HTTPPortName          = "http-port"
+	HTTPAddrName          = "http-addr"
 	CACertName            = "ca-cert"
 	CAKeyName             = "ca-key"
 	CertName              = "cert"


### PR DESCRIPTION
For security, the --http-addr flags makes the Admin UI
bind an IP address that can be private or distinct from
the cluster (such as 127.0.0.1).

Fixes #7474.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7475)

<!-- Reviewable:end -->
