### PR TITLE
cli: force quit when draining fails

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -490,12 +490,19 @@ func runQuit(_ *cobra.Command, _ []string) error {
 		return err
 	}
 	defer stopper.Stop()
-	if _, err := c.Drain(stopperContext(stopper),
-		&serverpb.DrainRequest{
-			On:       onModes,
+
+	ctx := stopperContext(stopper)
+
+	if _, err := c.Drain(ctx, &serverpb.DrainRequest{
+		On:       onModes,
+		Shutdown: true,
+	}); err != nil {
+		fmt.Printf("graceful shutdown failed, proceeding with hard shutdown: %v\n", err)
+		if _, err := c.Drain(ctx, &serverpb.DrainRequest{
 			Shutdown: true,
 		}); err != nil {
-		return err
+			return err
+		}
 	}
 	fmt.Println("ok")
 	return nil

--- a/storage/store.go
+++ b/storage/store.go
@@ -738,8 +738,11 @@ func (s *Store) DrainLeadership(drain bool) error {
 		var err error
 		now := s.Clock().Now()
 		newStoreRangeSet(s).Visit(func(r *Replica) bool {
-			if lease, nextLease := r.getLeaderLease(); (nextLease != nil) ||
-				(lease.OwnedBy(s.StoreID()) && lease.Covers(now)) {
+			lease, nextLease := r.getLeaderLease()
+			// If we own an active lease or we're trying to obtain a lease
+			// (and that request is fresh enough), wait.
+			if (lease.OwnedBy(s.StoreID()) && lease.Covers(now)) ||
+				(nextLease != nil && nextLease.Covers(now)) {
 
 				err = fmt.Errorf("replica %s still has an active lease", r)
 			}


### PR DESCRIPTION
```
$ ./cockroach quit
graceful shutdown failed, proceeding with hard shutdown: rpc error: code = 2 desc = replica range=1 [/Min-/Table/11) still has an active lease
ok
```

Fixes #6963.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7483)

<!-- Reviewable:end -->
