### PR TITLE
sqlbase: heuristics for fitting new columns into families

### DIFF
--- a/sql/sqlbase/structured.go
+++ b/sql/sqlbase/structured.go
@@ -725,6 +725,88 @@ func (desc *TableDescriptor) Validate() error {
 	return desc.Privileges.Validate(desc.GetID())
 }
 
+// FamilyHeuristicTargetBytes is the target total byte size of columns that the
+// current heuristic will assign to a family.
+const FamilyHeuristicTargetBytes = 256
+
+// upperBoundColumnValueEncodedSize returns the maximum encoded size of the
+// given column using the "value" encoding. If the size is unbounded, false is returned.
+func upperBoundColumnValueEncodedSize(col ColumnDescriptor) (int, bool) {
+	var typ encoding.Type
+	var size int
+	switch col.Type.Kind {
+	case ColumnType_BOOL:
+		typ = encoding.True
+	case ColumnType_INT, ColumnType_DATE, ColumnType_TIMESTAMP, ColumnType_TIMESTAMPTZ:
+		typ, size = encoding.Int, int(col.Type.Width)
+	case ColumnType_FLOAT:
+		typ = encoding.Float
+	case ColumnType_INTERVAL:
+		typ = encoding.Duration
+	case ColumnType_STRING, ColumnType_BYTES:
+		// STRINGs are counted as runes, so this isn't totally correct, but this
+		// seems better than always assuming the maximum rune width.
+		typ, size = encoding.Bytes, int(col.Type.Width)
+	case ColumnType_DECIMAL:
+		typ, size = encoding.Decimal, int(col.Type.Precision)
+	default:
+		panic(errors.Errorf("unknown column type: %s", col.Type.Kind))
+	}
+	return encoding.UpperBoundValueEncodingSize(uint32(col.ID), typ, size)
+}
+
+// fitColumnToFamily attempts to fit a new column into the existing column
+// families. If the heuristics find a fit, true is returned along with the
+// index of the selected family. Otherwise, false is returned and the column
+// should be put in a new family.
+//
+// Current heuristics:
+// - If the column is unbounded size (bytes, string, decimal) put it in a new
+//   family.
+// - If the column is bounded size (int, float, duration, date, timestamp, bool,
+//   or user bounded string/decimal), find the first family where the storage
+//   size of the existing columns plus the new column is not greater than
+//   FamilyHeuristicTargetBytes. The maximum size of the value encoding is used
+//   as the size of columns.
+// - Otherwise, the column doesn't fit in any existing family, spill it over
+//   into a new family.
+//
+// TODO(dan): Calling this function repeatedly to add columns is N^2. It
+// shouldn't be a problem because the number of columns is small, but if it
+// becomes an issue, make the bookkeeping of the columnSizesByID incremental.
+func fitColumnToFamily(desc TableDescriptor, col ColumnDescriptor) (int, bool) {
+	size, isBounded := upperBoundColumnValueEncodedSize(col)
+	if !isBounded || size > FamilyHeuristicTargetBytes {
+		return 0, false
+	}
+
+	columnSizesByID := make(map[ColumnID]int, len(desc.Columns))
+	for _, c := range desc.Columns {
+		if columnSizesByID[c.ID], isBounded = upperBoundColumnValueEncodedSize(c); !isBounded {
+			// Not bounded in size, so exceed the heuristic max to avoid assigning to
+			// a family that this column is in.
+			columnSizesByID[c.ID] = FamilyHeuristicTargetBytes + 1
+		}
+	}
+
+	// TODO(dan): This naively places columns in the first family they'll fit in,
+	// which is likely to lead to fragmentation. Consider something smarter like
+	// picking the most full family that will fit the column.
+	for i, family := range desc.Families {
+		var familySize int
+		for _, colID := range family.ColumnIDs {
+			familySize += columnSizesByID[colID]
+			if familySize > FamilyHeuristicTargetBytes {
+				break
+			}
+		}
+		if familySize+size <= FamilyHeuristicTargetBytes {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
 // AddColumn adds a column to the table.
 func (desc *TableDescriptor) AddColumn(col ColumnDescriptor) {
 	desc.Columns = append(desc.Columns, col)

--- a/sql/sqlbase/structured_test.go
+++ b/sql/sqlbase/structured_test.go
@@ -622,3 +622,135 @@ func TestColumnTypeSQLString(t *testing.T) {
 		}
 	}
 }
+
+func TestColumnValueEncodedSize(t *testing.T) {
+	tests := []struct {
+		colType ColumnType
+		size    int // -1 means unbounded
+	}{
+		{ColumnType{Kind: ColumnType_BOOL}, 1},
+		{ColumnType{Kind: ColumnType_INT}, 10},
+		{ColumnType{Kind: ColumnType_INT, Width: 2}, 10},
+		{ColumnType{Kind: ColumnType_FLOAT}, 9},
+		{ColumnType{Kind: ColumnType_FLOAT, Precision: 100}, 9},
+		{ColumnType{Kind: ColumnType_DECIMAL}, -1},
+		{ColumnType{Kind: ColumnType_DECIMAL, Precision: 100}, 68},
+		{ColumnType{Kind: ColumnType_DECIMAL, Precision: 100, Width: 100}, 68},
+		{ColumnType{Kind: ColumnType_DATE}, 10},
+		{ColumnType{Kind: ColumnType_TIMESTAMP}, 10},
+		{ColumnType{Kind: ColumnType_INTERVAL}, 28},
+		{ColumnType{Kind: ColumnType_STRING}, -1},
+		{ColumnType{Kind: ColumnType_STRING, Width: 100}, 110},
+		{ColumnType{Kind: ColumnType_BYTES}, -1},
+	}
+	for i, test := range tests {
+		testIsBounded := test.size != -1
+		size, isBounded := upperBoundColumnValueEncodedSize(ColumnDescriptor{
+			Type: test.colType,
+		})
+		if isBounded != testIsBounded {
+			if isBounded {
+				t.Errorf("%d: expected unbounded but got bounded", i)
+			} else {
+				t.Errorf("%d: expected bounded but got unbounded", i)
+			}
+			continue
+		}
+		if isBounded && size != test.size {
+			t.Errorf("%d: got size %d but expected %d", i, size, test.size)
+		}
+	}
+}
+
+func TestFitColumnToFamily(t *testing.T) {
+	intEncodedSize, _ := upperBoundColumnValueEncodedSize(ColumnDescriptor{
+		ID:   8,
+		Type: ColumnType{Kind: ColumnType_INT},
+	})
+
+	makeTestTableDescriptor := func(familyTypes [][]ColumnType) TableDescriptor {
+		nextColumnID := ColumnID(8)
+		var desc TableDescriptor
+		for _, fTypes := range familyTypes {
+			var family ColumnFamilyDescriptor
+			for _, t := range fTypes {
+				desc.Columns = append(desc.Columns, ColumnDescriptor{
+					ID:   nextColumnID,
+					Type: t,
+				})
+				family.ColumnIDs = append(family.ColumnIDs, nextColumnID)
+				nextColumnID++
+			}
+			desc.Families = append(desc.Families, family)
+		}
+		return desc
+	}
+
+	emptyFamily := []ColumnType{}
+	partiallyFullFamily := []ColumnType{
+		{Kind: ColumnType_INT},
+		{Kind: ColumnType_BYTES, Width: 10},
+	}
+	fullFamily := []ColumnType{
+		{Kind: ColumnType_BYTES, Width: FamilyHeuristicTargetBytes + 1},
+	}
+	maxIntsInOneFamily := make([]ColumnType, FamilyHeuristicTargetBytes/intEncodedSize)
+	for i := range maxIntsInOneFamily {
+		maxIntsInOneFamily[i] = ColumnType{Kind: ColumnType_INT}
+	}
+
+	tests := []struct {
+		newCol           ColumnType
+		existingFamilies [][]ColumnType
+		colFits          bool
+		idx              int // not applicable if colFits is false
+	}{
+		// Bounded size column.
+		{colFits: false, idx: -1, newCol: ColumnType{Kind: ColumnType_BOOL},
+			existingFamilies: nil,
+		},
+		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_BOOL},
+			existingFamilies: [][]ColumnType{emptyFamily},
+		},
+		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_BOOL},
+			existingFamilies: [][]ColumnType{partiallyFullFamily},
+		},
+		{colFits: false, idx: -1, newCol: ColumnType{Kind: ColumnType_BOOL},
+			existingFamilies: [][]ColumnType{fullFamily},
+		},
+		{colFits: true, idx: 1, newCol: ColumnType{Kind: ColumnType_BOOL},
+			existingFamilies: [][]ColumnType{fullFamily, emptyFamily},
+		},
+
+		// Unbounded size column.
+		{colFits: false, idx: -1, newCol: ColumnType{Kind: ColumnType_DECIMAL},
+			existingFamilies: [][]ColumnType{emptyFamily},
+		},
+		{colFits: false, idx: -1, newCol: ColumnType{Kind: ColumnType_DECIMAL},
+			existingFamilies: [][]ColumnType{partiallyFullFamily},
+		},
+
+		// Check FamilyHeuristicMaxBytes boundary.
+		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_INT},
+			existingFamilies: [][]ColumnType{maxIntsInOneFamily[1:]},
+		},
+		{colFits: false, idx: -1, newCol: ColumnType{Kind: ColumnType_INT},
+			existingFamilies: [][]ColumnType{maxIntsInOneFamily},
+		},
+	}
+	for i, test := range tests {
+		desc := makeTestTableDescriptor(test.existingFamilies)
+		idx, colFits := fitColumnToFamily(desc, ColumnDescriptor{Type: test.newCol})
+		if colFits != test.colFits {
+			if colFits {
+				t.Errorf("%d: expected no fit for the column but got one", i)
+			} else {
+				t.Errorf("%d: expected fit for the column but didn't get one", i)
+			}
+			continue
+		}
+		if colFits && idx != test.idx {
+			t.Errorf("%d: got a fit in family offset %d but expected offset %d", i, idx, test.idx)
+		}
+	}
+}

--- a/util/encoding/decimal.go
+++ b/util/encoding/decimal.go
@@ -22,6 +22,7 @@ package encoding
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"strconv"
 	"unsafe"
@@ -714,6 +715,23 @@ func UpperBoundNonsortingDecimalSize(d *inf.Dec) int {
 	// - maxVarintSize for the exponent
 	// - wordLen for the big.Int bytes
 	return 1 + maxVarintSize + wordLen(d.UnscaledBig().Bits())
+}
+
+// upperBoundNonsortingDecimalUnscaledSize is the same as
+// UpperBoundNonsortingDecimalSize but for a decimal with the given unscaled
+// length. The upper bound here may not be as tight as the one returned by
+// UpperBoundNonsortingDecimalSize.
+func upperBoundNonsortingDecimalUnscaledSize(unscaledLen int) int {
+	// The number of digits needed to represent a base 10 number of length
+	// unscaledLen in base 2.
+	unscaledLenBase2 := float64(unscaledLen) * math.Log2(10)
+	unscaledLenBase2Words := math.Ceil(unscaledLenBase2 / 8 / float64(bigWordSize))
+	unscaledLenWordRounded := int(unscaledLenBase2Words) * bigWordSize
+	// Makeup of upper bound size:
+	// - 1 byte for the prefix
+	// - maxVarintSize for the exponent
+	// - unscaledLenWordRounded for the big.Int bytes
+	return 1 + maxVarintSize + unscaledLenWordRounded
 }
 
 // Taken from math/big/arith.go.

--- a/util/encoding/decimal_test.go
+++ b/util/encoding/decimal_test.go
@@ -475,6 +475,21 @@ func TestDigitsLookupTable(t *testing.T) {
 	}
 }
 
+func TestUpperBoundNonsortingDecimalUnscaledSize(t *testing.T) {
+	x := make([]byte, 100)
+	u := new(big.Int)
+	for i := 0; i < len(x); i++ {
+		u.SetString(string(x[:i]), 10)
+		d := inf.NewDecBig(u, 0)
+		reference := UpperBoundNonsortingDecimalSize(d)
+		bound := upperBoundNonsortingDecimalUnscaledSize(i)
+		if bound < reference || bound > reference+bigWordSize {
+			t.Errorf("%d: got a bound of %d but expected between %d and %d", i, bound, reference, reference+bigWordSize)
+		}
+		x[i] = '1'
+	}
+}
+
 // randDecimal generates a random decimal with exponent in the
 // range [minExp, maxExp].
 func randDecimal(rng *rand.Rand, minExp, maxExp int) *inf.Dec {

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -1731,6 +1731,45 @@ func TestValueEncodingRand(t *testing.T) {
 	}
 }
 
+func TestUpperBoundValueEncodingSize(t *testing.T) {
+	tests := []struct {
+		colID uint32
+		typ   Type
+		width int
+		size  int // -1 means unbounded
+	}{
+		{colID: 0, typ: Null, size: 1},
+		{colID: 0, typ: True, size: 1},
+		{colID: 0, typ: False, size: 1},
+		{colID: 0, typ: Int, size: 10},
+		{colID: 0, typ: Int, width: 100, size: 10},
+		{colID: 0, typ: Float, size: 9},
+		{colID: 0, typ: Decimal, size: -1},
+		{colID: 0, typ: Decimal, width: 100, size: 68},
+		{colID: 0, typ: Time, size: 19},
+		{colID: 0, typ: Duration, size: 28},
+		{colID: 0, typ: Bytes, size: -1},
+		{colID: 0, typ: Bytes, width: 100, size: 110},
+
+		{colID: 8, typ: True, size: 2},
+	}
+	for i, test := range tests {
+		testIsBounded := test.size != -1
+		size, isBounded := UpperBoundValueEncodingSize(test.colID, test.typ, test.width)
+		if isBounded != testIsBounded {
+			if isBounded {
+				t.Errorf("%d: expected unbounded but got bounded", i)
+			} else {
+				t.Errorf("%d: expected bounded but got unbounded", i)
+			}
+			continue
+		}
+		if isBounded && size != test.size {
+			t.Errorf("%d: got size %d but expected %d", i, size, test.size)
+		}
+	}
+}
+
 func TestPrettyPrintValueEncoded(t *testing.T) {
 	tests := []struct {
 		buf      []byte


### PR DESCRIPTION
The logic for fitting these is added here, but not yet used.

Implements the heuristics described in https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/sql_column_families.md#heuristics-for-fitting-columns-into-families

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7491)

<!-- Reviewable:end -->
