### PR TITLE
storage: deflake TestReservationQueue

### DIFF
--- a/storage/reservation.go
+++ b/storage/reservation.go
@@ -91,11 +91,12 @@ func newBookie(
 	clock *hlc.Clock,
 	stopper *stop.Stopper,
 	metrics *storeMetrics,
+	reservationTimeout time.Duration,
 ) *bookie {
 	b := &bookie{
 		clock:              clock,
 		metrics:            metrics,
-		reservationTimeout: envutil.EnvOrDefaultDuration("reservation_timeout", ttlStoreGossip),
+		reservationTimeout: reservationTimeout,
 		maxReservations:    envutil.EnvOrDefaultInt("max_reservations", defaultMaxReservations),
 		maxReservedBytes:   envutil.EnvOrDefaultBytes("max_reserved_bytes", defaultMaxReservedBytes),
 	}

--- a/storage/store.go
+++ b/storage/store.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/cache"
+	"github.com/cockroachdb/cockroach/util/envutil"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/metric"
@@ -861,7 +862,12 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 	}))
 
 	// Add the bookie to the store.
-	s.bookie = newBookie(s.ctx.Clock, s.stopper, s.metrics)
+	s.bookie = newBookie(
+		s.ctx.Clock,
+		s.stopper,
+		s.metrics,
+		envutil.EnvOrDefaultDuration("reservation_timeout", ttlStoreGossip),
+	)
 
 	if s.Ident.NodeID == 0 {
 		// Open engine (i.e. initialize RocksDB database). "NodeID != 0"


### PR DESCRIPTION
There was a small race between setting the reservationTimeout and the bookie
starting and using the default value.  When the default value is used, it sets
a 2 minute timeout which causes the test to fail as the loop in bookie.start
won't make any forward progress until after that timeout.

Fixes #7373

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7493)

<!-- Reviewable:end -->
