### PR TITLE
sql: avoid deadlock in lease acquisition

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -127,21 +127,21 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 	}
 	s.clock.SetMaxOffset(ctx.MaxOffset)
 
-	s.rpcContext = rpc.NewContext(ctx.Context, s.clock, stopper)
+	s.rpcContext = rpc.NewContext(ctx.Context, s.clock, s.stopper)
 	s.rpcContext.HeartbeatCB = func() {
 		if err := s.rpcContext.RemoteClocks.VerifyClockOffset(); err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	s.gossip = gossip.New(s.rpcContext, s.ctx.GossipBootstrapResolvers, stopper)
+	s.gossip = gossip.New(s.rpcContext, s.ctx.GossipBootstrapResolvers, s.stopper)
 	s.storePool = storage.NewStorePool(
 		s.gossip,
 		s.clock,
 		s.rpcContext,
 		ctx.ReservationsEnabled,
 		ctx.TimeUntilStoreDead,
-		stopper,
+		s.stopper,
 	)
 
 	// A custom RetryOptions is created which uses stopper.ShouldDrain() as
@@ -156,7 +156,7 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 	// succeed because the only server has been shut down; thus, thus the
 	// DistSender needs to know that it should not retry in this situation.
 	retryOpts := base.DefaultRetryOptions()
-	retryOpts.Closer = stopper.ShouldDrain()
+	retryOpts.Closer = s.stopper.ShouldDrain()
 	s.distSender = kv.NewDistSender(&kv.DistSenderContext{
 		Clock:           s.clock,
 		RPCContext:      s.rpcContext,
@@ -171,7 +171,7 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 	s.grpc = rpc.NewServer(s.rpcContext)
 	s.raftTransport = storage.NewRaftTransport(storage.GossipAddressResolver(s.gossip), s.grpc, s.rpcContext)
 
-	s.kvDB = kv.NewDBServer(s.ctx.Context, sender, stopper)
+	s.kvDB = kv.NewDBServer(s.ctx.Context, sender, s.stopper)
 	roachpb.RegisterExternalServer(s.grpc, s.kvDB)
 
 	// Set up Lease Manager
@@ -179,7 +179,7 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 	if ctx.TestingKnobs.SQLLeaseManager != nil {
 		lmKnobs = *ctx.TestingKnobs.SQLLeaseManager.(*sql.LeaseManagerTestingKnobs)
 	}
-	s.leaseMgr = sql.NewLeaseManager(0, *s.db, s.clock, lmKnobs)
+	s.leaseMgr = sql.NewLeaseManager(0, *s.db, s.clock, lmKnobs, s.stopper)
 	s.leaseMgr.RefreshLeases(s.stopper, s.db, s.gossip)
 
 	// Set up the DistSQL server

--- a/sql/helpers_test.go
+++ b/sql/helpers_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Andrei Matei(andreimatei1@gmail.com)
+
+package sql
+
+// LeaseRemovalTracker can be used to wait for a lease to be removed from the
+// store (leases are removed from the store async w.r.t. LeaseManager
+// operations).
+// To use it, its LeaseReleasedNotification method must be hooked up to
+// LeaseStoreTestingKnobs.LeaseReleasedEvent. Then, every time you want to wait
+// for a lease, call PrepareToWait() before calling LeaseManager.Release(), and
+// then call Wait() for the actual blocking.
+type LeaseRemovalTracker struct {
+	waitingFor *LeaseState
+	doneSem    chan error
+}
+
+// PrepareToWait regisers the lease that WaitForRelease() will later be called
+// for. This should be called before triggering the operation that releases
+// (asynchronously) the lease.
+func (w *LeaseRemovalTracker) PrepareToWait(lease *LeaseState) {
+	w.waitingFor = lease
+	w.doneSem = make(chan error, 1)
+}
+
+// WaitForRelease blockes until the lease previously registered with
+// PrepareToWait() has been removed from the store.
+func (w *LeaseRemovalTracker) Wait() error {
+	if w.waitingFor == nil {
+		panic("wasn't told what to wait for")
+	}
+	return <-w.doneSem
+}
+
+// LeaseReleasedNotification has to be called after a lease is removed from the
+// store. This should be hooked up as a callback to
+// LeaseStoreTestingKnobs.LeaseReleasedEvent.
+func (w *LeaseRemovalTracker) LeaseReleasedNotification(
+	lease *LeaseState, err error,
+) {
+	if lease == w.waitingFor {
+		w.doneSem <- err
+	}
+}

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -846,7 +846,11 @@ func (c *tableNameCache) remove(lease *LeaseState) {
 	key := c.makeCacheKey(lease.ParentID, lease.Name)
 	existing, ok := c.tables[key]
 	if !ok {
-		panic(fmt.Sprintf("table for lease not found in table name cache: %s", lease))
+		// Table for lease not found in table name cache. This can happen if we had
+		// a more recent lease on the table in the tableNameCache, then the table
+		// gets deleted, then the more recent lease is remove()d - which clears the
+		// cache.
+		return
 	}
 	// If this was the lease that the cache had for the table name, remove it.
 	// If the cache had some other lease, this remove is a no-op.

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -453,6 +453,7 @@ type tableState struct {
 	id sqlbase.ID
 	// The cache is updated every time we acquire or release a lease.
 	tableNameCache *tableNameCache
+	stopper        *stop.Stopper
 	// Protects both active and acquiring.
 	mu sync.Mutex
 	// The active leases for the table: sorted by their version and expiration
@@ -674,11 +675,14 @@ func (t *tableState) removeLease(lease *LeaseState, store LeaseStore) {
 	t.active.remove(lease)
 	t.tableNameCache.remove(lease)
 	// Release to the store asynchronously, without the tableState lock.
-	go func() {
+	err := t.stopper.RunAsyncTask(func() {
 		if err := store.Release(lease); err != nil {
-			log.Warningf("Error releasing lease %q: %s", lease, err)
+			log.Warningf("error releasing lease %q: %s", lease, err)
 		}
-	}()
+	})
+	if log.V(1) && err != nil {
+		log.Warningf("error removing lease from store: %s", err)
+	}
 }
 
 // purgeOldLeases refreshes the leases on a table. Unused leases older than
@@ -869,17 +873,18 @@ type LeaseManager struct {
 	// Not protected by mu.
 	tableNames   tableNameCache
 	testingKnobs LeaseManagerTestingKnobs
+	stopper      *stop.Stopper
 }
 
 // NewLeaseManager creates a new LeaseManager.
-// Args:
-//  testingLeasesRefreshedEvent: if not nil, a callback called after the leases
-//  are refreshed as a result of a gossip update.
+//
+// stopper is used to run async tasks. Can be nil in tests.
 func NewLeaseManager(
 	nodeID uint32,
 	db client.DB,
 	clock *hlc.Clock,
 	testingKnobs LeaseManagerTestingKnobs,
+	stopper *stop.Stopper,
 ) *LeaseManager {
 	lm := &LeaseManager{
 		LeaseStore: LeaseStore{
@@ -893,6 +898,7 @@ func NewLeaseManager(
 		tableNames: tableNameCache{
 			tables: make(map[tableNameCacheKey]*LeaseState),
 		},
+		stopper: stopper,
 	}
 	return lm
 }
@@ -1004,7 +1010,7 @@ func (m *LeaseManager) resolveName(
 func (m *LeaseManager) Acquire(
 	txn *client.Txn, tableID sqlbase.ID, version sqlbase.DescriptorVersion,
 ) (*LeaseState, error) {
-	t := m.findTableState(tableID, true, &m.tableNames)
+	t := m.findTableState(tableID, true)
 	return t.acquire(txn, version, m.LeaseStore)
 }
 
@@ -1017,7 +1023,7 @@ func (m *LeaseManager) Acquire(
 func (m *LeaseManager) acquireFreshestFromStore(
 	txn *client.Txn, tableID sqlbase.ID,
 ) (*LeaseState, error) {
-	t := m.findTableState(tableID, true, &m.tableNames)
+	t := m.findTableState(tableID, true)
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if err := t.acquireFromStoreLocked(
@@ -1036,7 +1042,7 @@ func (m *LeaseManager) acquireFreshestFromStore(
 
 // Release releases a previously acquired read lease.
 func (m *LeaseManager) Release(lease *LeaseState) error {
-	t := m.findTableState(lease.ID, false, nil)
+	t := m.findTableState(lease.ID, false /* create */)
 	if t == nil {
 		return errors.Errorf("table %d not found", lease.ID)
 	}
@@ -1049,13 +1055,13 @@ func (m *LeaseManager) Release(lease *LeaseState) error {
 	return t.release(lease, m.LeaseStore)
 }
 
-// If create is set, cache needs to be set as well.
-func (m *LeaseManager) findTableState(tableID sqlbase.ID, create bool, cache *tableNameCache) *tableState {
+// If create is set, cache and stopper need to be set as well.
+func (m *LeaseManager) findTableState(tableID sqlbase.ID, create bool) *tableState {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	t := m.tables[tableID]
 	if t == nil && create {
-		t = &tableState{id: tableID, tableNameCache: cache}
+		t = &tableState{id: tableID, tableNameCache: &m.tableNames, stopper: m.stopper}
 		m.tables[tableID] = t
 	}
 	return t
@@ -1103,7 +1109,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gos
 								kv.Key, table.ID, table.Name, table.Version)
 						}
 						// Try to refresh the table lease to one >= this version.
-						if t := m.findTableState(table.ID, false /* create */, nil); t != nil {
+						if t := m.findTableState(table.ID, false /* create */); t != nil {
 							if err := t.purgeOldLeases(
 								db, table.Deleted(), table.Version, m.LeaseStore); err != nil {
 								log.Warningf("error purging leases for table %d(%s): %s",

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -90,6 +90,22 @@ func (s *LeaseState) Refcount() int {
 	return s.refcount
 }
 
+func (s *LeaseState) incRefcount() {
+	s.mu.Lock()
+	s.incRefcountLocked()
+	s.mu.Unlock()
+}
+func (s *LeaseState) incRefcountLocked() {
+	if s.released {
+		panic(fmt.Sprintf("trying to incRefcount on released lease: %+v", s))
+	}
+	s.refcount++
+	if log.V(3) {
+		log.Infof("LeaseState.incRef: descID=%d name=%q version=%d refcount=%d",
+			s.ID, s.Name, s.Version, s.refcount)
+	}
+}
+
 // LeaseStore implements the operations for acquiring and releasing leases and
 // publishing a new version of a descriptor. Exported only for testing.
 type LeaseStore struct {
@@ -521,13 +537,7 @@ func (t *tableState) checkLease(
 	if !skipLifeCheck && !lease.hasSomeLifeLeft(clock) {
 		return nil
 	}
-	lease.mu.Lock()
-	lease.refcount++
-	lease.mu.Unlock()
-	if log.V(3) {
-		log.Infof("acquire: descID=%d name=%q version=%d refcount=%d",
-			lease.ID, lease.Name, lease.Version, lease.refcount)
-	}
+	lease.incRefcount()
 	return lease
 }
 
@@ -638,40 +648,45 @@ func (t *tableState) release(lease *LeaseState, store LeaseStore) error {
 	if s == nil {
 		return errors.Errorf("table %d version %d not found", lease.ID, lease.Version)
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.refcount--
-	if log.V(3) {
-		log.Infof("release: descID=%d name:%q version=%d refcount=%d", s.ID, s.Name, s.Version, s.refcount)
-	}
-	if s.refcount < 0 {
-		panic(fmt.Sprintf("negative ref count: descID=%d(%q) version=%d refcount=%d", s.ID, s.Name, s.Version, s.refcount))
-	}
-	if s.refcount == 0 {
+	// Decrements the refcount and returns true if the lease has to be removed
+	// from the store.
+	decRefcount := func(s *LeaseState) bool {
+		// Figure out if we'd like to remove the lease from the store asap (i.e. when
+		// the refcount drops to 0). If so, we'll need to mark the lease as released.
+		removeOnceDereferenced := false
+		// Release from the store if the table has been deleted; no leases can be
+		// acquired any more.
 		if t.deleted {
-			t.removeLease(s, store)
-			return nil
+			removeOnceDereferenced = true
 		}
-		n := t.active.findNewest(0)
-		if s != n {
-			if s.Version < n.Version {
-				// TODO(pmattis): If an active transaction is releasing the lease for
-				// an older version, hold on to it for a few seconds in anticipation of
-				// another operation being performed within the transaction. If we
-				// release the lease immediately the transaction will necessarily abort
-				// on the next operation due to not being able to get the lease.
-			}
-			t.removeLease(s, store)
-			return nil
+		// Release from the store if the lease is not for the latest version; only
+		// leases for the latest version can be acquired.
+		if s != t.active.findNewest(0) {
+			removeOnceDereferenced = true
 		}
+
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.refcount--
+		if log.V(3) {
+			log.Infof("release: descID=%d name:%q version=%d refcount=%d", s.ID, s.Name, s.Version, s.refcount)
+		}
+		if s.refcount < 0 {
+			panic(fmt.Sprintf("negative ref count: descID=%d(%q) version=%d refcount=%d", s.ID, s.Name, s.Version, s.refcount))
+		}
+		if s.refcount == 0 && removeOnceDereferenced {
+			s.released = true
+		}
+		return s.released
+	}
+	if decRefcount(s) {
+		t.removeLease(s, store)
 	}
 	return nil
 }
 
 // t.mu needs to be locked.
-// lease.mu needs to be locked.
 func (t *tableState) removeLease(lease *LeaseState, store LeaseStore) {
-	lease.released = true
 	t.active.remove(lease)
 	t.tableNameCache.remove(lease)
 	// Release to the store asynchronously, without the tableState lock.
@@ -815,8 +830,7 @@ func (c *tableNameCache) get(dbID sqlbase.ID, tableName string, clock *hlc.Clock
 		// this cache entry soon.
 		return nil
 	}
-	lease.refcount++
-
+	lease.incRefcountLocked()
 	return lease
 }
 
@@ -866,7 +880,11 @@ func (c *tableNameCache) makeCacheKey(dbID sqlbase.ID, tableName string) tableNa
 
 // LeaseManager manages acquiring and releasing per-table leases. It also
 // handles resolving table names to descriptor IDs.
+//
 // Exported only for testing.
+//
+// The locking order is:
+// LeaseManager.mu > tableState.mu > tableNameCache.mu > LeaseState.mu
 type LeaseManager struct {
 	LeaseStore
 	mu     sync.Mutex
@@ -1039,9 +1057,7 @@ func (m *LeaseManager) acquireFreshestFromStore(
 	if lease == nil {
 		panic("no lease in active set after having just acquired one")
 	}
-	lease.mu.Lock()
-	lease.refcount++
-	lease.mu.Unlock()
+	lease.incRefcount()
 	return lease, nil
 }
 
@@ -1110,8 +1126,8 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gos
 							continue
 						}
 						if log.V(2) {
-							log.Infof("%s: refreshing lease table: %d (%s), version: %d",
-								kv.Key, table.ID, table.Name, table.Version)
+							log.Infof("%s: refreshing lease table: %d (%s), version: %d, deleted: %t",
+								kv.Key, table.ID, table.Name, table.Version, table.Deleted())
 						}
 						// Try to refresh the table lease to one >= this version.
 						if t := m.findTableState(table.ID, false /* create */); t != nil {

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -740,6 +740,7 @@ func (t *tableState) purgeOldLeases(
 // LeaseStoreTestingKnobs contains testing knobs.
 type LeaseStoreTestingKnobs struct {
 	// Called after a lease is removed from the store, with any operation error.
+	// See LeaseRemovalTracker.
 	LeaseReleasedEvent func(lease *LeaseState, err error)
 }
 

--- a/sql/lease_internal_test.go
+++ b/sql/lease_internal_test.go
@@ -171,7 +171,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	if err != nil {
 		t.Fatal(err)
 	}
-	ts := leaseManager.findTableState(tableDesc.ID, false, nil)
+	ts := leaseManager.findTableState(tableDesc.ID, false)
 	if numLeases := getNumLeases(ts); numLeases != 3 {
 		t.Fatalf("found %d leases instead of 3", numLeases)
 	}

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -133,14 +133,15 @@ func (t *leaseTest) mustRelease(
 	lease *csql.LeaseState,
 	leaseRemovalTracker *csql.LeaseRemovalTracker,
 ) {
+	var tracker csql.RemovalTracker
 	if leaseRemovalTracker != nil {
-		leaseRemovalTracker.PrepareToWait(lease)
+		tracker = leaseRemovalTracker.TrackRemoval(lease)
 	}
 	if err := t.release(nodeID, lease); err != nil {
 		t.Fatal(err)
 	}
 	if leaseRemovalTracker != nil {
-		if err := leaseRemovalTracker.Wait(); err != nil {
+		if err := tracker.WaitForRemoval(); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -177,11 +178,11 @@ func (t *leaseTest) node(nodeID uint32) *csql.LeaseManager {
 func TestLeaseManager(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
 	ctx := server.MakeTestContext()
-	var releaseTracker csql.LeaseRemovalTracker
+	removalTracker := csql.NewLeaseRemovalTracker()
 	ctx.TestingKnobs = base.TestingKnobs{
 		SQLLeaseManager: &csql.LeaseManagerTestingKnobs{
 			LeaseStoreTestingKnobs: csql.LeaseStoreTestingKnobs{
-				LeaseReleasedEvent: releaseTracker.LeaseReleasedNotification,
+				LeaseReleasedEvent: removalTracker.LeaseRemovedNotification,
 			},
 		},
 	}
@@ -231,7 +232,7 @@ func TestLeaseManager(testingT *testing.T) {
 
 	// When the last local reference on the old version is released the node
 	// lease is also released.
-	t.mustRelease(1, l2, &releaseTracker)
+	t.mustRelease(1, l2, removalTracker)
 	t.expectLeases(descID, "/2/1")
 
 	// It is an error to acquire a lease for an old version once a new version
@@ -261,15 +262,15 @@ func TestLeaseManager(testingT *testing.T) {
 	l8 := t.mustAcquire(2, descID, 3)
 	t.expectLeases(descID, "/2/1 /2/2 /3/1 /3/2")
 
-	t.mustRelease(1, l5, &releaseTracker)
+	t.mustRelease(1, l5, removalTracker)
 	t.expectLeases(descID, "/2/2 /3/1 /3/2")
-	t.mustRelease(2, l6, &releaseTracker)
+	t.mustRelease(2, l6, removalTracker)
 	t.expectLeases(descID, "/3/1 /3/2")
 
 	// Wait for version 4 to be published.
 	wg.Wait()
 	l9 := t.mustAcquire(1, descID, 4)
-	t.mustRelease(1, l7, &releaseTracker)
+	t.mustRelease(1, l7, removalTracker)
 	t.mustRelease(2, l8, nil)
 	t.expectLeases(descID, "/3/2 /4/1")
 	t.mustRelease(1, l9, nil)
@@ -279,11 +280,11 @@ func TestLeaseManager(testingT *testing.T) {
 func TestLeaseManagerReacquire(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
 	ctx := server.MakeTestContext()
-	var releaseTracker csql.LeaseRemovalTracker
+	removalTracker := csql.NewLeaseRemovalTracker()
 	ctx.TestingKnobs = base.TestingKnobs{
 		SQLLeaseManager: &csql.LeaseManagerTestingKnobs{
 			LeaseStoreTestingKnobs: csql.LeaseStoreTestingKnobs{
-				LeaseReleasedEvent: releaseTracker.LeaseReleasedNotification,
+				LeaseReleasedEvent: removalTracker.LeaseRemovedNotification,
 			},
 		},
 	}
@@ -328,7 +329,7 @@ func TestLeaseManagerReacquire(testingT *testing.T) {
 	t.expectLeases(descID, "/1/1 /1/1")
 
 	t.mustRelease(1, l1, nil)
-	t.mustRelease(1, l2, &releaseTracker)
+	t.mustRelease(1, l2, removalTracker)
 	t.mustRelease(1, l3, nil)
 }
 

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -167,6 +167,7 @@ func (t *leaseTest) node(nodeID uint32) *csql.LeaseManager {
 			nodeID, *t.server.DB(),
 			t.server.Clock(),
 			t.leaseManagerTestingKnobs,
+			t.server.Stopper(),
 		)
 		t.nodes[nodeID] = mgr
 	}

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -124,23 +124,23 @@ func (t *leaseTest) release(nodeID uint32, lease *csql.LeaseState) error {
 	return t.node(nodeID).Release(lease)
 }
 
-// If leaseReleaseWaiter is not nil, it will be used to block until the lease is
+// If leaseRemovalTracker is not nil, it will be used to block until the lease is
 // released from the store. If the lease is not supposed to be released from the
 // store (i.e. it's not expired and it's not for an old descriptor version),
 // this shouldn't be set.
 func (t *leaseTest) mustRelease(
 	nodeID uint32,
 	lease *csql.LeaseState,
-	leaseReleaseWaiter *leaseReleaseWaiter,
+	leaseRemovalTracker *csql.LeaseRemovalTracker,
 ) {
-	if leaseReleaseWaiter != nil {
-		leaseReleaseWaiter.PrepareToWait(lease)
+	if leaseRemovalTracker != nil {
+		leaseRemovalTracker.PrepareToWait(lease)
 	}
 	if err := t.release(nodeID, lease); err != nil {
 		t.Fatal(err)
 	}
-	if leaseReleaseWaiter != nil {
-		if err := leaseReleaseWaiter.Wait(); err != nil {
+	if leaseRemovalTracker != nil {
+		if err := leaseRemovalTracker.Wait(); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -174,46 +174,14 @@ func (t *leaseTest) node(nodeID uint32) *csql.LeaseManager {
 	return mgr
 }
 
-// leaseReleaseWaiter can be used to wait for a lease to be removed from the
-// store (leases are removed from the store async w.r.t. LeaseManager
-// operations).
-// To use it, its LeaseReleasedNotification method must be hooked up to
-// LeaseStoreTestingKnobs.LeaseReleasedEvent. Then, every time you want to wait
-// for a lease, call PrepareToWait() before calling LeaseManager.Release(), and
-// then call Wait() for the actual blocking.
-type leaseReleaseWaiter struct {
-	waitingFor *csql.LeaseState
-	doneSem    chan error
-}
-
-func (w *leaseReleaseWaiter) PrepareToWait(lease *csql.LeaseState) {
-	w.waitingFor = lease
-	w.doneSem = make(chan error, 1)
-}
-
-func (w *leaseReleaseWaiter) Wait() error {
-	if w.waitingFor == nil {
-		panic("wasn't told what to wait for")
-	}
-	return <-w.doneSem
-}
-
-func (w *leaseReleaseWaiter) LeaseReleasedNotification(
-	lease *csql.LeaseState, err error,
-) {
-	if lease == w.waitingFor {
-		w.doneSem <- err
-	}
-}
-
 func TestLeaseManager(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
 	ctx := server.MakeTestContext()
-	var releaseWaiter leaseReleaseWaiter
+	var releaseTracker csql.LeaseRemovalTracker
 	ctx.TestingKnobs = base.TestingKnobs{
 		SQLLeaseManager: &csql.LeaseManagerTestingKnobs{
 			LeaseStoreTestingKnobs: csql.LeaseStoreTestingKnobs{
-				LeaseReleasedEvent: releaseWaiter.LeaseReleasedNotification,
+				LeaseReleasedEvent: releaseTracker.LeaseReleasedNotification,
 			},
 		},
 	}
@@ -263,7 +231,7 @@ func TestLeaseManager(testingT *testing.T) {
 
 	// When the last local reference on the old version is released the node
 	// lease is also released.
-	t.mustRelease(1, l2, &releaseWaiter)
+	t.mustRelease(1, l2, &releaseTracker)
 	t.expectLeases(descID, "/2/1")
 
 	// It is an error to acquire a lease for an old version once a new version
@@ -293,15 +261,15 @@ func TestLeaseManager(testingT *testing.T) {
 	l8 := t.mustAcquire(2, descID, 3)
 	t.expectLeases(descID, "/2/1 /2/2 /3/1 /3/2")
 
-	t.mustRelease(1, l5, &releaseWaiter)
+	t.mustRelease(1, l5, &releaseTracker)
 	t.expectLeases(descID, "/2/2 /3/1 /3/2")
-	t.mustRelease(2, l6, &releaseWaiter)
+	t.mustRelease(2, l6, &releaseTracker)
 	t.expectLeases(descID, "/3/1 /3/2")
 
 	// Wait for version 4 to be published.
 	wg.Wait()
 	l9 := t.mustAcquire(1, descID, 4)
-	t.mustRelease(1, l7, &releaseWaiter)
+	t.mustRelease(1, l7, &releaseTracker)
 	t.mustRelease(2, l8, nil)
 	t.expectLeases(descID, "/3/2 /4/1")
 	t.mustRelease(1, l9, nil)
@@ -311,11 +279,11 @@ func TestLeaseManager(testingT *testing.T) {
 func TestLeaseManagerReacquire(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
 	ctx := server.MakeTestContext()
-	var releaseWaiter leaseReleaseWaiter
+	var releaseTracker csql.LeaseRemovalTracker
 	ctx.TestingKnobs = base.TestingKnobs{
 		SQLLeaseManager: &csql.LeaseManagerTestingKnobs{
 			LeaseStoreTestingKnobs: csql.LeaseStoreTestingKnobs{
-				LeaseReleasedEvent: releaseWaiter.LeaseReleasedNotification,
+				LeaseReleasedEvent: releaseTracker.LeaseReleasedNotification,
 			},
 		},
 	}
@@ -360,7 +328,7 @@ func TestLeaseManagerReacquire(testingT *testing.T) {
 	t.expectLeases(descID, "/1/1 /1/1")
 
 	t.mustRelease(1, l1, nil)
-	t.mustRelease(1, l2, &releaseWaiter)
+	t.mustRelease(1, l2, &releaseTracker)
 	t.mustRelease(1, l3, nil)
 }
 

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/protoutil"
 	"github.com/cockroachdb/cockroach/util/retry"
+	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/timeutil"
 	"github.com/pkg/errors"
 )
@@ -141,7 +142,10 @@ func TestSchemaChangeProcess(t *testing.T) {
 	var id = sqlbase.ID(keys.MaxReservedDescID + 2)
 	var node = roachpb.NodeID(2)
 	db := server.DB()
-	leaseMgr := csql.NewLeaseManager(0, *db, hlc.NewClock(hlc.UnixNano), csql.LeaseManagerTestingKnobs{})
+	stopper := stop.NewStopper()
+	leaseMgr := csql.NewLeaseManager(
+		0, *db, hlc.NewClock(hlc.UnixNano), csql.LeaseManagerTestingKnobs{}, stopper)
+	defer stopper.Stop()
 	changer := csql.NewSchemaChangerForTesting(id, 0, node, *db, leaseMgr)
 
 	if _, err := sqlDB.Exec(`

--- a/util/stop/stopper.go
+++ b/util/stop/stopper.go
@@ -99,7 +99,7 @@ func (k taskKey) String() string {
 //
 // Stopping occurs in two phases: the first is the request to stop, which moves
 // the stopper into a draining phase. While draining, calls to RunTask() &
-// RunAsyncTask() don't execute the function passed in and return false.
+// RunAsyncTask() don't execute the function passed in and return errUnavailable.
 // When all outstanding tasks have been completed, the stopper
 // closes its stopper channel, which signals all live workers that it's safe to
 // shut down. When all workers have shutdown, the stopper is complete.


### PR DESCRIPTION
We were locking leaseState, tableNameCache in Release(), but
tableNameCache,LeaseState in AcquireByName.
Refactored Release() to not require both locks at the same time.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7504)

<!-- Reviewable:end -->
