### PR TITLE
cli: lex sql input

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -113,6 +113,14 @@ func (c cliTest) Run(line string) {
 // errors in executing c, because those will be caught when the test verifies
 // the output of c.
 func (c cliTest) RunWithCapture(line string) (out string, err error) {
+	return captureOutput(func() {
+		c.Run(line)
+	})
+}
+
+// captureOutput runs f and returns a string containing the output and any
+// error that may have occurred capturing the output.
+func captureOutput(f func()) (out string, err error) {
 	// Heavily inspired by Go's testing/example.go:runExample().
 
 	// Funnel stdout into a pipe.
@@ -149,7 +157,7 @@ func (c cliTest) RunWithCapture(line string) (out string, err error) {
 	}()
 
 	// Run the command. The output will be returned in the defer block.
-	c.Run(line)
+	f()
 	return
 }
 

--- a/cli/sql_test.go
+++ b/cli/sql_test.go
@@ -1,0 +1,167 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Jibson (mjibson@cockroachlabs.com)
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chzyer/readline"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+// TestSQLLex tests the usage of the lexer in the sql subcommand.
+func TestSQLLex(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s := server.StartInsecureTestServer(t)
+	defer s.Stop()
+
+	pgurl, err := s.Ctx.PGURL("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn := makeSQLConn(pgurl.String())
+	defer conn.Close()
+
+	tests := []struct {
+		in     string
+		expect string
+	}{
+		{
+			in: `
+select '
+\?
+;
+';
+`,
+			expect: `+---------------+
+| e'\n\\?\n;\n' |
++---------------+
+| ␤             |
+| \?␤           |
+| ;␤            |
++---------------+
+(1 row)
+`,
+		},
+		{
+			in: `
+select ''''
+;
+
+set syntax = modern;
+
+select ''''
+;
+''';
+`,
+			expect: `+-------+
+| e'\'' |
++-------+
+| '     |
++-------+
+(1 row)
+SET
++------------+
+| e'\'\n;\n' |
++------------+
+| '␤         |
+| ;␤         |
++------------+
+(1 row)
+`,
+		},
+	}
+
+	conf := readline.Config{
+		DisableAutoSaveHistory: true,
+		FuncOnWidthChanged:     func(func()) {},
+	}
+
+	for _, test := range tests {
+		conf.Stdin = strings.NewReader(test.in)
+		out, err := captureOutput(func() {
+			err := runInteractive(conn, &conf)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out != test.expect {
+			t.Fatalf("%s:\nexpected: %s\ngot: %s", test.in, test.expect, out)
+		}
+	}
+}
+
+func TestIsEndOfStatement(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		syntax parser.Syntax
+		in     string
+		isEnd  bool
+		hasSet bool
+	}{
+		{
+			in:    ";",
+			isEnd: true,
+		},
+		{
+			in:    "; /* comment */",
+			isEnd: true,
+		},
+		{
+			in: "; SELECT",
+		},
+		{
+			in: "SELECT",
+		},
+		{
+			in:     "SET; SELECT 1;",
+			isEnd:  true,
+			hasSet: true,
+		},
+		{
+			in:     "SELECT ''''; SET;",
+			isEnd:  true,
+			hasSet: true,
+		},
+		{
+			in:     "SELECT ''''; SET;",
+			syntax: parser.Modern,
+		},
+	}
+
+	for _, test := range tests {
+		syntax := test.syntax
+		if syntax == 0 {
+			syntax = parser.Traditional
+		}
+		isEnd, hasSet := isEndOfStatement(syntax, &[]string{test.in})
+		if isEnd != test.isEnd {
+			t.Errorf("%q: isEnd expected %v, got %v", test.in, test.isEnd, isEnd)
+		}
+		if hasSet != test.hasSet {
+			t.Errorf("%q: hasSet expected %v, got %v", test.in, test.hasSet, hasSet)
+		}
+	}
+}

--- a/sql/parser/parse.go
+++ b/sql/parser/parse.go
@@ -59,7 +59,7 @@ const (
 // Parser wraps a scanner, parser and other utilities present in the parser
 // package.
 type Parser struct {
-	scanner            scanner
+	scanner            Scanner
 	parserImpl         sqlParserImpl
 	normalizeVisitor   normalizeVisitor
 	isAggregateVisitor IsAggregateVisitor

--- a/sql/parser/scan.go
+++ b/sql/parser/scan.go
@@ -32,7 +32,8 @@ const errUnterminated = "unterminated string"
 const errInvalidHexNumeric = "invalid hexadecimal numeric literal"
 const singleQuote = '\''
 
-type scanner struct {
+// Scanner lexes SQL statements.
+type Scanner struct {
 	in          string
 	pos         int
 	tokBuf      sqlSymType
@@ -47,13 +48,14 @@ type scanner struct {
 	initialized bool
 }
 
-func makeScanner(str string, syntax Syntax) scanner {
-	var s scanner
+// MakeScanner makes a Scanner from str.
+func MakeScanner(str string, syntax Syntax) Scanner {
+	var s Scanner
 	s.init(str, syntax)
 	return s
 }
 
-func (s *scanner) init(str string, syntax Syntax) {
+func (s *Scanner) init(str string, syntax Syntax) {
 	if s.initialized {
 		panic("scanner already initialized; a scanner cannot be reused.")
 	}
@@ -69,7 +71,19 @@ func (s *scanner) init(str string, syntax Syntax) {
 	}
 }
 
-func (s *scanner) Lex(lval *sqlSymType) int {
+// Tokens calls f on all tokens of the input until an EOF is encountered.
+func (s *Scanner) Tokens(f func(token int)) {
+	for {
+		t := s.Lex(&s.tokBuf)
+		if t == 0 {
+			return
+		}
+		f(t)
+	}
+}
+
+// Lex lexes a token from input.
+func (s *Scanner) Lex(lval *sqlSymType) int {
 	// The core lexing takes place in scan(). Here we do a small bit of post
 	// processing of the lexical tokens so that the grammar only requires
 	// one-token lookahead despite SQL requiring multi-token lookahead in some
@@ -116,7 +130,7 @@ func (s *scanner) Lex(lval *sqlSymType) int {
 	return lval.id
 }
 
-func (s *scanner) Error(e string) {
+func (s *Scanner) Error(e string) {
 	var buf bytes.Buffer
 	if s.lastTok.id == ERROR {
 		fmt.Fprintf(&buf, "%s", s.lastTok.str)
@@ -142,7 +156,7 @@ func (s *scanner) Error(e string) {
 	s.lastError = buf.String()
 }
 
-func (s *scanner) scan(lval *sqlSymType) {
+func (s *Scanner) scan(lval *sqlSymType) {
 	lval.id = 0
 	lval.pos = s.pos
 	lval.str = "EOF"
@@ -378,14 +392,14 @@ func (s *scanner) scan(lval *sqlSymType) {
 	// lval for above.
 }
 
-func (s *scanner) peek() int {
+func (s *Scanner) peek() int {
 	if s.pos >= len(s.in) {
 		return eof
 	}
 	return int(s.in[s.pos])
 }
 
-func (s *scanner) peekN(n int) int {
+func (s *Scanner) peekN(n int) int {
 	pos := s.pos + n
 	if pos >= len(s.in) {
 		return eof
@@ -393,7 +407,7 @@ func (s *scanner) peekN(n int) int {
 	return int(s.in[pos])
 }
 
-func (s *scanner) next() int {
+func (s *Scanner) next() int {
 	ch := s.peek()
 	if ch != eof {
 		s.pos++
@@ -401,7 +415,7 @@ func (s *scanner) next() int {
 	return ch
 }
 
-func (s *scanner) skipWhitespace(lval *sqlSymType, allowComments bool) (newline, ok bool) {
+func (s *Scanner) skipWhitespace(lval *sqlSymType, allowComments bool) (newline, ok bool) {
 	newline = false
 	for {
 		ch := s.peek()
@@ -426,7 +440,7 @@ func (s *scanner) skipWhitespace(lval *sqlSymType, allowComments bool) (newline,
 	return newline, true
 }
 
-func (s *scanner) scanComment(lval *sqlSymType) (present, ok bool) {
+func (s *Scanner) scanComment(lval *sqlSymType) (present, ok bool) {
 	start := s.pos
 	ch := s.peek()
 
@@ -493,7 +507,7 @@ func (s *scanner) scanComment(lval *sqlSymType) (present, ok bool) {
 	return false, true
 }
 
-func (s *scanner) scanIdent(lval *sqlSymType, ch int) {
+func (s *Scanner) scanIdent(lval *sqlSymType, ch int) {
 	start := s.pos - 1
 	for {
 		ch := s.peek()
@@ -512,7 +526,7 @@ func (s *scanner) scanIdent(lval *sqlSymType, ch int) {
 	lval.id = IDENT
 }
 
-func (s *scanner) scanNumber(lval *sqlSymType, ch int) {
+func (s *Scanner) scanNumber(lval *sqlSymType, ch int) {
 	start := s.pos - 1
 	isHex := false
 	hasDecimal := ch == '.'
@@ -600,7 +614,7 @@ func (s *scanner) scanNumber(lval *sqlSymType, ch int) {
 	}
 }
 
-func (s *scanner) scanPlaceholder(lval *sqlSymType) {
+func (s *Scanner) scanPlaceholder(lval *sqlSymType) {
 	start := s.pos
 	for isDigit(s.peek()) {
 		s.pos++
@@ -623,7 +637,7 @@ func (s *scanner) scanPlaceholder(lval *sqlSymType) {
 	lval.id = PLACEHOLDER
 }
 
-func (s *scanner) scanString(lval *sqlSymType, ch int, allowEscapes bool) bool {
+func (s *Scanner) scanString(lval *sqlSymType, ch int, allowEscapes bool) bool {
 	var buf []byte
 	var runeTmp [utf8.UTFMax]byte
 	start := s.pos

--- a/sql/parser/scan_test.go
+++ b/sql/parser/scan_test.go
@@ -96,7 +96,7 @@ func TestScanner(t *testing.T) {
 		{`1e-1`, []int{FCONST}},
 	}
 	for i, d := range testData {
-		s := makeScanner(d.sql, Traditional)
+		s := MakeScanner(d.sql, Traditional)
 		var tokens []int
 		for {
 			var lval sqlSymType
@@ -132,7 +132,7 @@ func TestScannerModern(t *testing.T) {
 		{`$1 $foo $select`, []int{PLACEHOLDER, PLACEHOLDER, PLACEHOLDER}},
 	}
 	for i, d := range testData {
-		s := makeScanner(d.sql, Modern)
+		s := MakeScanner(d.sql, Modern)
 		var tokens []int
 		for {
 			var lval sqlSymType
@@ -169,7 +169,7 @@ foo`, "", "foo"},
 		{`/* /* */`, "unterminated comment", ""},
 	}
 	for i, d := range testData {
-		s := makeScanner(d.sql, Traditional)
+		s := MakeScanner(d.sql, Traditional)
 		var lval sqlSymType
 		present, ok := s.scanComment(&lval)
 		if d.err == "" && (!present || !ok) {
@@ -193,7 +193,7 @@ func TestScanCommentModern(t *testing.T) {
 foo`, "", "foo"},
 	}
 	for i, d := range testData {
-		s := makeScanner(d.sql, Modern)
+		s := MakeScanner(d.sql, Modern)
 		var lval sqlSymType
 		present, ok := s.scanComment(&lval)
 		if d.err == "" && (!present || !ok) {
@@ -209,7 +209,7 @@ foo`, "", "foo"},
 
 func TestScanKeyword(t *testing.T) {
 	for kwName, kwID := range keywords {
-		s := makeScanner(kwName, Traditional)
+		s := MakeScanner(kwName, Traditional)
 		var lval sqlSymType
 		id := s.Lex(&lval)
 		if kwID != id {
@@ -245,7 +245,7 @@ func TestScanNumber(t *testing.T) {
 		{`9223372036854775809`, `9223372036854775809`, ICONST},
 	}
 	for _, d := range testData {
-		s := makeScanner(d.sql, Traditional)
+		s := MakeScanner(d.sql, Traditional)
 		var lval sqlSymType
 		id := s.Lex(&lval)
 		if d.id != id {
@@ -267,7 +267,7 @@ func TestScanPlaceholder(t *testing.T) {
 		{`$123`, 123},
 	}
 	for _, d := range testData {
-		s := makeScanner(d.sql, Traditional)
+		s := MakeScanner(d.sql, Traditional)
 		var lval sqlSymType
 		id := s.Lex(&lval)
 		if id != PLACEHOLDER {
@@ -342,7 +342,7 @@ world`},
 		{`X'626172'`, `bar`},
 	}
 	for _, d := range testData {
-		s := makeScanner(d.sql, Traditional)
+		s := MakeScanner(d.sql, Traditional)
 		var lval sqlSymType
 		_ = s.Lex(&lval)
 		if d.expected != lval.str {
@@ -378,7 +378,7 @@ world`},
 world'`, `invalid syntax: embedded newline`},
 	}
 	for _, d := range testData {
-		s := makeScanner(d.sql, Modern)
+		s := MakeScanner(d.sql, Modern)
 		var lval sqlSymType
 		_ = s.Lex(&lval)
 		if d.expected != lval.str {
@@ -410,7 +410,7 @@ func TestScanError(t *testing.T) {
 		{`$9223372036854775809`, "integer value out of range"},
 	}
 	for _, d := range testData {
-		s := makeScanner(d.sql, Traditional)
+		s := MakeScanner(d.sql, Traditional)
 		var lval sqlSymType
 		id := s.Lex(&lval)
 		if id != ERROR {

--- a/sql/parser/sql.go
+++ b/sql/parser/sql.go
@@ -4556,7 +4556,7 @@ sqldefault:
 		sqlDollar = sqlS[sqlpt-1 : sqlpt+1]
 		//line sql.y:691
 		{
-			sqllex.(*scanner).stmts = sqlDollar[1].union.stmts()
+			sqllex.(*Scanner).stmts = sqlDollar[1].union.stmts()
 		}
 	case 2:
 		sqlDollar = sqlS[sqlpt-3 : sqlpt+1]

--- a/sql/parser/sql.y
+++ b/sql/parser/sql.y
@@ -689,7 +689,7 @@ func (u *sqlSymUnion) dropBehavior() DropBehavior {
 stmt_block:
   stmt_list
   {
-    sqllex.(*scanner).stmts = $1.stmts()
+    sqllex.(*Scanner).stmts = $1.stmts()
   }
 
 stmt_list:


### PR DESCRIPTION
Change the sql subcommand to lex the input so it can recognize semicolons
and \ commands only where expected.

Commands can now only be specified when there is not an active statement
being completed.

This requires tracking the current syntax mode. This is done by examining
the lex input for a SET token. If one is set, then the syntax is fetched
from the server after running the current group of statements.

Export sql/parser.scanner and add a helpful wrapper function to do the
lexing (since sqlSymType is still unexported).

The tests added are a very rudimentary start to #7334.

Fixes #4233

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7510)

<!-- Reviewable:end -->
