### PR TITLE
sql: add dump subcommand

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -79,6 +79,7 @@ func init() {
 		userCmd,
 		zoneCmd,
 		nodeCmd,
+		dumpCmd,
 
 		// Miscellaneous commands.
 		// TODO(pmattis): stats

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -836,6 +836,7 @@ Available Commands:
   user           get, set, list and remove users
   zone           get, set, list and remove zones
   node           list nodes and show their status
+  dump           dump sql tables
 
   gen            generate manpages and bash completion file
   version        output version information
@@ -843,6 +844,7 @@ Available Commands:
 
 Flags:
       --alsologtostderr value[=INFO]   logs at or above this threshold go to stderr (default NONE)
+      --duration-random value          duration for randomized dump test to run (default 1s)
       --log-backtrace-at value         when logging hits line file:N, emit a stack trace (default :0)
       --log-dir value                  if non-empty, write log files in this directory
       --logtostderr                    log to standard error instead of files

--- a/cli/dump.go
+++ b/cli/dump.go
@@ -1,0 +1,261 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Jibson (mjibson@cockroachlabs.com)
+
+package cli
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// dumpCmd dumps SQL tables.
+var dumpCmd = &cobra.Command{
+	Use:   "dump [options] <database> <table>",
+	Short: "dump sql tables\n",
+	Long: `
+Dump SQL tables of a cockroach database.
+`,
+	RunE:         runDump,
+	SilenceUsage: true,
+}
+
+func runDump(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		mustUsage(cmd)
+		return errMissingParams
+	}
+
+	conn, err := makeSQLClient()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	return dumpTable(os.Stdout, conn, args[0], args[1])
+}
+
+func dumpTable(w io.Writer, conn *sqlConn, origDBName, origTableName string) error {
+	const limit = 100
+
+	// Escape names since they can't be used in placeholders.
+	dbname := parser.Name(origDBName).String()
+	tablename := parser.Name(origTableName).String()
+
+	if err := conn.Exec(fmt.Sprintf("SET DATABASE = %s", dbname), nil); err != nil {
+		return err
+	}
+
+	// Fetch all table metadata in a transaction and its time to guarantee it
+	// doesn't change between the various SHOW statements.
+	if err := conn.Exec("BEGIN", nil); err != nil {
+		return err
+	}
+
+	vals, err := conn.QueryRow("SELECT cluster_logical_timestamp()::int", nil)
+	if err != nil {
+		return err
+	}
+	clusterTSStart := vals[0].(int64)
+	clusterTS := time.Unix(0, clusterTSStart).Format(time.RFC3339Nano)
+
+	// Fetch table descriptor.
+	vals, err = conn.QueryRow(`
+		SELECT descriptor
+		FROM system.descriptor
+		JOIN system.namespace tables
+			ON tables.id = descriptor.id
+		JOIN system.namespace dbs
+			ON dbs.id = tables.parentid
+		WHERE tables.name = $1 AND dbs.name = $2`,
+		[]driver.Value{origTableName, origDBName})
+	if err == io.EOF {
+		return errors.Errorf("unknown database or table %s.%s", origTableName, origDBName)
+	} else if err != nil {
+		return err
+	}
+	b := vals[0].([]byte)
+	var desc sqlbase.Descriptor
+	if err := proto.Unmarshal(b, &desc); err != nil {
+		return err
+	}
+	table := desc.GetTable()
+	if table == nil {
+		return errors.New("internal error: expected table descriptor")
+	}
+
+	coltypes := make(map[string]string)
+	for _, c := range table.Columns {
+		coltypes[c.Name] = c.Type.SQLString()
+	}
+
+	primaryIndex := table.PrimaryIndex.Name
+	index := table.PrimaryIndex.ColumnNames
+	indexes := strings.Join(index, ", ")
+
+	// Build the SELECT query.
+	var sbuf bytes.Buffer
+	fmt.Fprintf(&sbuf, "SELECT %s, * FROM %s@%s AS OF SYSTEM TIME '%s'", indexes, tablename, primaryIndex, clusterTS)
+
+	var wbuf bytes.Buffer
+	fmt.Fprintf(&wbuf, " WHERE ROW (%s) > ROW (", indexes)
+	for i := range index {
+		if i > 0 {
+			wbuf.WriteString(", ")
+		}
+		fmt.Fprintf(&wbuf, "$%d", i+1)
+	}
+	wbuf.WriteString(")")
+	// No WHERE clause first time, so add a place to inject it.
+	fmt.Fprintf(&sbuf, "%%s ORDER BY %s LIMIT %d", indexes, limit)
+	bs := sbuf.String()
+
+	vals, err = conn.QueryRow(fmt.Sprintf("SHOW CREATE TABLE %s", tablename), nil)
+	if err != nil {
+		return err
+	}
+	create := vals[1].([]byte)
+	if _, err := w.Write(create); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte(";\n")); err != nil {
+		return err
+	}
+
+	if err := conn.Exec("COMMIT", nil); err != nil {
+		return err
+	}
+
+	// pk holds the last values of the fetched primary keys
+	var pk []driver.Value
+	q := fmt.Sprintf(bs, "")
+	for {
+		rows, err := conn.Query(q, pk)
+		if err != nil {
+			return err
+		}
+		cols := rows.Columns()
+		pkcols := cols[:len(index)]
+		cols = cols[len(index):]
+		inserts := make([][]string, 0, limit)
+		i := 0
+		for i < limit {
+			vals := make([]driver.Value, len(cols)+len(pkcols))
+			if err := rows.Next(vals); err == io.EOF {
+				break
+			} else if err != nil {
+				return err
+			}
+			if pk == nil {
+				q = fmt.Sprintf(bs, wbuf.String())
+			}
+			pk = vals[:len(index)]
+			vals = vals[len(index):]
+			ivals := make([]string, len(vals))
+			// Values need to be correctly encoded for INSERT statements in a text file.
+			for si, sv := range vals {
+				switch t := sv.(type) {
+				case nil:
+					ivals[si] = "NULL"
+				case bool:
+					ivals[si] = parser.MakeDBool(parser.DBool(t)).String()
+				case int64:
+					ivals[si] = parser.NewDInt(parser.DInt(t)).String()
+				case float64:
+					ivals[si] = parser.NewDFloat(parser.DFloat(t)).String()
+				case []byte:
+					switch ct := coltypes[cols[si]]; ct {
+					case "INTERVAL":
+						ivals[si] = fmt.Sprintf("'%s'", t)
+					case "DECIMAL":
+						ivals[si] = fmt.Sprintf("%s", t)
+					default:
+						// STRING and BYTES types can have optional length suffixes, so only examine
+						// the prefix of the type.
+						if strings.HasPrefix(coltypes[cols[si]], "STRING") {
+							ivals[si] = parser.NewDString(string(t)).String()
+						} else if strings.HasPrefix(coltypes[cols[si]], "BYTES") {
+							ivals[si] = parser.NewDBytes(parser.DBytes(t)).String()
+						} else {
+							panic(errors.Errorf("unknown []byte type: %s, %v: %s", t, cols[si], coltypes[cols[si]]))
+						}
+					}
+				case time.Time:
+					var d parser.Datum
+					ct := coltypes[cols[si]]
+					switch ct {
+					case "DATE":
+						d = parser.NewDDateFromTime(t, time.UTC)
+					case "TIMESTAMP":
+						d = parser.MakeDTimestamp(t, time.Nanosecond)
+					case "TIMESTAMP WITH TIME ZONE":
+						d = parser.MakeDTimestampTZ(t, time.Nanosecond)
+					default:
+						panic(errors.Errorf("unknown timestamp type: %s, %v: %s", t, cols[si], coltypes[cols[si]]))
+					}
+					ivals[si] = fmt.Sprintf("'%s'", d)
+				default:
+					panic(errors.Errorf("unknown field type: %T (%s)", t, cols[si]))
+				}
+			}
+			inserts = append(inserts, ivals)
+			i++
+		}
+		for si, sv := range pk {
+			b, ok := sv.([]byte)
+			if ok && strings.HasPrefix(coltypes[pkcols[si]], "STRING") {
+				// Primary key strings need to be converted to a go string, but not SQL
+				// encoded since they aren't being written to a text file.
+				pk[si] = string(b)
+			}
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		if i == 0 {
+			break
+		}
+		fmt.Fprintf(w, "\nINSERT INTO %s VALUES", tablename)
+		for idx, values := range inserts {
+			if idx > 0 {
+				fmt.Fprint(w, ",")
+			}
+			fmt.Fprint(w, "\n\t(")
+			for vi, v := range values {
+				if vi > 0 {
+					fmt.Fprint(w, ", ")
+				}
+				fmt.Fprint(w, v)
+			}
+			fmt.Fprint(w, ")")
+		}
+		fmt.Fprintln(w, ";")
+		if i < limit {
+			break
+		}
+	}
+	return nil
+}

--- a/cli/dump_test.go
+++ b/cli/dump_test.go
@@ -1,0 +1,314 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Jibson (mjibson@cockroachlabs.com)
+
+package cli
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"flag"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/inf.v0"
+
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/randutil"
+	"github.com/cockroachdb/cockroach/util/timeutil"
+)
+
+func TestDumpRow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c := newCLITest()
+	defer c.stop()
+
+	const create = `
+	CREATE DATABASE d;
+	CREATE TABLE d.t (
+		i int,
+		f float,
+		s string,
+		b bytes,
+		d date,
+		t timestamp,
+		n interval,
+		o bool,
+		e decimal,
+		tz timestamptz
+	);
+	INSERT INTO d.t VALUES (
+		1,
+		2.3,
+		'striiing',
+		b'\141\061\142\062\143\063', '2016-03-26', '2016-01-25 10:10:10' ,
+		'2h30m30s',
+		true,
+		1.2345,
+		'2016-01-25 10:10:10'
+	);
+	INSERT INTO d.t VALUES (DEFAULT);
+	INSERT INTO d.t (f) VALUES (
+		CAST('+Inf' AS FLOAT)
+	), (
+		CAST('-Inf' AS FLOAT)
+	), (
+		CAST('NaN' AS FLOAT)
+	);
+`
+
+	c.RunWithArgs([]string{"sql", "-e", create})
+
+	out, err := c.RunWithCapture("dump d t")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const expect = `dump d t
+CREATE TABLE t (
+	i INT NULL,
+	f FLOAT NULL,
+	s STRING NULL,
+	b BYTES NULL,
+	d DATE NULL,
+	t TIMESTAMP NULL,
+	n INTERVAL NULL,
+	o BOOL NULL,
+	e DECIMAL NULL,
+	tz TIMESTAMP WITH TIME ZONE NULL,
+	FAMILY "primary" (rowid),
+	FAMILY fam_1_i (i),
+	FAMILY fam_2_f (f),
+	FAMILY fam_3_s (s),
+	FAMILY fam_4_b (b),
+	FAMILY fam_5_d (d),
+	FAMILY fam_6_t (t),
+	FAMILY fam_7_n (n),
+	FAMILY fam_8_o (o),
+	FAMILY fam_9_e (e),
+	FAMILY fam_10_tz (tz)
+);
+
+INSERT INTO t VALUES
+	(1, 2.3, 'striiing', b'a1b2c3', '2016-03-26', '2016-01-25 10:10:10+00:00', '2h30m30s', true, 1.2345, '2016-01-25 10:10:10+00:00'),
+	(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, +Inf, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, -Inf, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, NaN, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+`
+
+	if string(out) != expect {
+		t.Fatalf("expected: %s\ngot: %s", expect, out)
+	}
+}
+
+func TestDumpBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s := server.StartTestServer(t)
+	defer s.Stop()
+
+	url, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestDumpBytes")
+	defer cleanup()
+
+	conn := makeSQLConn(url.String())
+	defer conn.Close()
+
+	if err := conn.Exec(`
+		CREATE DATABASE d;
+		SET DATABASE = d;
+		CREATE TABLE t (b BYTES PRIMARY KEY);
+	`, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := int64(0); i < 256; i++ {
+		if err := conn.Exec("INSERT INTO t VALUES ($1)", []driver.Value{[]byte{byte(i)}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var b bytes.Buffer
+	if err := dumpTable(&b, conn, "d", "t"); err != nil {
+		t.Fatal(err)
+	}
+	dump := b.String()
+	b.Reset()
+
+	if err := conn.Exec(`
+		CREATE DATABASE o;
+		SET DATABASE = o;
+	`, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.Exec(dump, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := dumpTable(&b, conn, "o", "t"); err != nil {
+		t.Fatal(err)
+	}
+	dump2 := b.String()
+	if dump != dump2 {
+		t.Fatalf("unmatching dumps:\n%s\n%s", dump, dump2)
+	}
+}
+
+var randomTestTime = flag.Duration("duration-random", time.Second, "duration for randomized dump test to run")
+
+// TestDumpRandom generates a random number of random rows with all data
+// types. This data is dumped, inserted, and dumped again. The two dumps
+// are compared for exactness. The data from the inserted dump is then
+// SELECT'd and compared to the original generated data to ensure it is
+// round-trippable.
+func TestDumpRandom(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s := server.StartTestServer(t)
+	defer s.Stop()
+
+	url, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), security.RootUser, "TestDumpRandom")
+	defer cleanup()
+
+	conn := makeSQLConn(url.String())
+	defer conn.Close()
+
+	if err := conn.Exec(`
+		CREATE DATABASE d;
+		CREATE DATABASE o;
+		CREATE TABLE d.t (
+			rowid int,
+			i int,
+			f float,
+			d date,
+			m timestamp,
+			n interval,
+			o bool,
+			e decimal,
+			s string,
+			b bytes,
+			PRIMARY KEY (rowid, i, f, d, m, n, o, e, s, b)
+		);
+	`, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	rnd, seed := randutil.NewPseudoRand()
+	t.Logf("random seed: %v", seed)
+
+	start := timeutil.Now()
+
+	for iteration := 0; timeutil.Since(start) < *randomTestTime; iteration++ {
+		if err := conn.Exec(`DELETE FROM d.t`, nil); err != nil {
+			t.Fatal(err)
+		}
+		var generatedRows [][]driver.Value
+		count := rnd.Int63n(500)
+		t.Logf("random iteration %v: %v rows", iteration, count)
+		for _i := int64(0); _i < count; _i++ {
+			// Generate a random number of random inserts.
+			i := rnd.Int63()
+			f := rnd.Float64()
+			d := time.Unix(0, rnd.Int63()).Round(time.Hour * 24).UTC()
+			m := time.Unix(0, rnd.Int63()).Round(time.Microsecond).UTC()
+			n := time.Duration(rnd.Int63()).String()
+			o := rnd.Intn(2) == 1
+			e := strings.TrimRight(inf.NewDec(rnd.Int63(), inf.Scale(rnd.Int31n(20)-10)).String(), ".0")
+			s := make([]byte, rnd.Intn(500))
+			if _, err := rnd.Read(s); err != nil {
+				t.Fatal(err)
+			}
+			b := make([]byte, rnd.Intn(500))
+			if _, err := rnd.Read(b); err != nil {
+				t.Fatal(err)
+			}
+
+			vals := []driver.Value{_i, i, f, d, m, n, o, e, s, b}
+			if err := conn.Exec("INSERT INTO d.t VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)", vals); err != nil {
+				t.Fatal(err)
+			}
+			generatedRows = append(generatedRows, vals[1:])
+		}
+
+		check := func(table string) {
+			q := fmt.Sprintf("SELECT i, f, d, m, n, o, e, s, b FROM %s ORDER BY rowid", table)
+			nrows, err := conn.Query(q, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := nrows.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}()
+			for gi, generatedRow := range generatedRows {
+				fetched := make([]driver.Value, len(nrows.Columns()))
+				if err := nrows.Next(fetched); err != nil {
+					t.Fatal(err)
+				}
+
+				for i, fetchedVal := range fetched {
+					generatedVal := generatedRow[i]
+					switch t := fetchedVal.(type) {
+					case time.Time:
+						fetchedVal = t.UTC()
+					case []uint8:
+						if _, ok := generatedVal.(string); ok {
+							fetchedVal = string(t)
+						}
+					}
+					if !reflect.DeepEqual(fetchedVal, generatedVal) {
+						t.Fatalf("NOT EQUAL: table %s, row %d, col %d\ngenerated: %#v (%T): %v\nselected: %#v (%T): %v\n", table, gi, i, generatedVal, generatedVal, generatedVal, fetchedVal, fetchedVal, fetchedVal)
+					}
+				}
+			}
+		}
+
+		check("d.t")
+
+		var buf bytes.Buffer
+		if err := dumpTable(&buf, conn, "d", "t"); err != nil {
+			t.Fatal(err)
+		}
+		dump := buf.String()
+		buf.Reset()
+
+		if err := conn.Exec(`
+			SET DATABASE = o;
+			DROP TABLE IF EXISTS t;
+		`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := conn.Exec(dump, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		check("o.t")
+
+		if err := dumpTable(&buf, conn, "o", "t"); err != nil {
+			t.Fatal(err)
+		}
+		dump2 := buf.String()
+		if dump != dump2 {
+			t.Fatalf("unmatching dumps:\nFIRST:\n%s\n\nSECOND:\n%s", dump, dump2)
+		}
+	}
+}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -429,7 +429,7 @@ func init() {
 	setUserCmd.Flags().StringVar(&password, cliflags.PasswordName, envutil.EnvOrDefaultString(cliflags.PasswordName, ""), usageEnv(cliflags.PasswordName))
 
 	clientCmds := []*cobra.Command{
-		sqlShellCmd, quitCmd, freezeClusterCmd, /* startCmd is covered above */
+		sqlShellCmd, quitCmd, freezeClusterCmd, dumpCmd, /* startCmd is covered above */
 	}
 	clientCmds = append(clientCmds, kvCmds...)
 	clientCmds = append(clientCmds, rangeCmds...)
@@ -474,7 +474,7 @@ func init() {
 	}
 
 	// Commands that establish a SQL connection.
-	sqlCmds := []*cobra.Command{sqlShellCmd}
+	sqlCmds := []*cobra.Command{sqlShellCmd, dumpCmd}
 	sqlCmds = append(sqlCmds, zoneCmds...)
 	sqlCmds = append(sqlCmds, userCmds...)
 	for _, cmd := range sqlCmds {

--- a/cli/node.go
+++ b/cli/node.go
@@ -192,7 +192,7 @@ var nodeCmds = []*cobra.Command{
 
 var nodeCmd = &cobra.Command{
 	Use:   "node [command]",
-	Short: "list nodes and show their status\n",
+	Short: "list nodes and show their status",
 	Long:  "List nodes and show their status.",
 	Run: func(cmd *cobra.Command, args []string) {
 		mustUsage(cmd)

--- a/cli/sql_test.go
+++ b/cli/sql_test.go
@@ -95,6 +95,9 @@ SET
 		FuncOnWidthChanged:     func(func()) {},
 	}
 
+	// Some other tests (TestDumpRow) mess with this, so make sure it's set.
+	cliCtx.prettyFmt = true
+
 	for _, test := range tests {
 		conf.Stdin = strings.NewReader(test.in)
 		out, err := captureOutput(func() {


### PR DESCRIPTION
Introspect over a specified table to determine its structure. Iteratively
select all rows from the table in pages using time travel queries to
guarantee they don't change.

TestDumpRandom was run for 20 minutes and didn't report any unexpected
values, so I have fairly high confidence that the bytes a user has stored
will correctly be inserted if the dump file is piped into the sql subcommand.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7511)

<!-- Reviewable:end -->
