### PR TITLE
Update CONTRIBUTING.md builder.sh cmdline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,8 @@ regenerate the associated `.pb.{go,cc,h}` or `.js` files using `go generate
 
 We advise to run `go generate` using our embedded Docker setup.
 `build/builder.sh` is a wrapper script designed to make this convenient. You can
-run `build/builder.sh go generate ./...` from the repository root to get the
-intended result.
+run `build/builder.sh env SKIP_BOOTSTRAP=0 go generate ./...` from the repository
+root to get the intended result.
 
 If you want to run it outside of Docker, `go generate` requires a collection of
 Node.js modules which are installed via npm.


### PR DESCRIPTION
Updating the command line to include `env SKIP_BOOTSTRAP=0`.

Without this the command errors out because it cannot find various binaries.
Note that this is only required once - the binaries live on in
`$GOPATH/bin/linux_amd64`

Fixes #7513.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7517)

<!-- Reviewable:end -->
