### PR TITLE
acceptance: misc fixes

### DIFF
--- a/acceptance/allocator_test.go
+++ b/acceptance/allocator_test.go
@@ -104,6 +104,10 @@ func (at *allocatorTest) Run(t *testing.T) {
 		if r := recover(); r != nil {
 			t.Errorf("recovered from panic to destroy cluster: %v", r)
 		}
+		if t.Failed() && at.f.KeepClusterAfterFail {
+			t.Log("test has failed, not destroying")
+			return
+		}
 		at.f.MustDestroy()
 	}()
 

--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -48,6 +48,7 @@ type Farmer struct {
 	// AddVars are additional Terraform variables to be set during calls to Add.
 	AddVars              map[string]string
 	KeepClusterAfterTest bool
+	KeepClusterAfterFail bool
 	nodes, writers       []string
 }
 

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -109,7 +109,7 @@ func farmer(t *testing.T, prefix string) *terrafarm.Farmer {
 	if !prefixRE.MatchString(prefix) {
 		t.Fatalf("farmer prefix must match regex %s", prefixRE)
 	}
-	dt := timeutil.Now().Format("20060102-1504")
+	dt := timeutil.Now().Format("20060102-150405")
 	f := &terrafarm.Farmer{
 		Output:  os.Stderr,
 		Cwd:     *flagCwd,

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -55,7 +55,8 @@ var flagConfig = flag.String("config", "", "a json TestConfig proto, see testcon
 
 var flagPrivileged = flag.Bool("privileged", os.Getenv("CIRCLECI") != "true",
 	"run containers in privileged mode (required for nemesis tests")
-var flagTFKeepCluster = flag.Bool("tf.keep-cluster", false, "do not destroy Terraform cluster after test finishes")
+var flagTFKeepCluster = flag.Bool("tf.keep-cluster", false, "do not destroy Terraform cluster after test finishes, has precedence over tf.keep-cluster-fail")
+var flagTFKeepClusterFail = flag.Bool("tf.keep-cluster-fail", false, "do not destroy Terraform cluster after test finishes only if the test has failed")
 
 // TODO(cuongdo): These should be refactored so that they're not allocator
 // test-specific when we have more than one kind of system test that uses these
@@ -124,6 +125,7 @@ func farmer(t *testing.T, prefix string) *terrafarm.Farmer {
 		StateFile:            prefix + "-" + dt + ".tfstate",
 		AddVars:              make(map[string]string),
 		KeepClusterAfterTest: *flagTFKeepCluster,
+		KeepClusterAfterFail: *flagTFKeepClusterFail,
 	}
 	log.Infof("logging to %s", logDir)
 	return f


### PR DESCRIPTION
1 - change the allocator test's prefix to include seconds so more can be launched in quicker succession
2 - add a flag to keep the cluster around if the test fails - a good follow up to this will be instead copying the data off to storage somewhere and then dumping it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7523)

<!-- Reviewable:end -->
