### PR TITLE
storage/engine: tweak RocksDB options

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -44,12 +44,12 @@ const (
 	defaultMaxOffset     = 250 * time.Millisecond
 	defaultCacheSize     = 512 << 20 // 512 MB
 	// defaultMemtableBudget controls how much memory can be used for memory
-	// tables. The way we initialize RocksDB, 150% (24 MB) of this setting can be
-	// used for memory tables and each memory table will be 25% of the size (4
+	// tables. The way we initialize RocksDB, 100% (32 MB) of this setting can be
+	// used for memory tables and each memory table will be 25% of the size (8
 	// MB). This corresponds to the default RocksDB memtable size. Note that
 	// larger values do not necessarily improve performance, so benchmark any
 	// changes to this value.
-	defaultMemtableBudget           = 16 << 20 // 16 MB
+	defaultMemtableBudget           = 32 << 20 // 32 MB
 	defaultScanInterval             = 10 * time.Minute
 	defaultConsistencyCheckInterval = 24 * time.Hour
 	defaultScanMaxIdleTime          = 5 * time.Second

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"unsafe"
 
@@ -188,6 +189,7 @@ func (r *RocksDB) Open() error {
 			wal_ttl_seconds: C.uint64_t(envutil.EnvOrDefaultDuration("rocksdb_wal_ttl", 0).Seconds()),
 			allow_os_buffer: C.bool(true),
 			logging_enabled: C.bool(log.V(3)),
+			num_cpu:         C.int(runtime.NumCPU()),
 		})
 	if err := statusToError(status); err != nil {
 		return errors.Errorf("could not open rocksdb instance: %s", err)

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1355,6 +1355,7 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
 
   rocksdb::Options options(rocksdb::GetOptions(db_opts.memtable_budget));
   options.IncreaseParallelism(db_opts.num_cpu);
+  options.max_subcompactions = std::max<int>(db_opts.num_cpu / 2, 1);
   options.allow_os_buffer = db_opts.allow_os_buffer;
   options.WAL_ttl_seconds = db_opts.wal_ttl_seconds;
   options.comparator = &kComparator;

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1353,9 +1353,16 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   // increased read amplification.
   table_options.block_size = db_opts.block_size;
 
+  // Use the rocksdb options builder to configure the base options
+  // using our memtable budget.
   rocksdb::Options options(rocksdb::GetOptions(db_opts.memtable_budget));
+  // Increase parallelism for compactions based on the number of
+  // cpus. This will use 1 high priority thread for flushes and
+  // num_cpu-1 low priority threads for compactions.
   options.IncreaseParallelism(db_opts.num_cpu);
-  options.max_subcompactions = std::max<int>(db_opts.num_cpu / 2, 1);
+  // Enable subcompactions which will use multiple threads to speed up
+  // a single compaction. The value of num_cpu/2 has not been tuned.
+  options.max_subcompactions = std::max(db_opts.num_cpu / 2, 1);
   options.allow_os_buffer = db_opts.allow_os_buffer;
   options.WAL_ttl_seconds = db_opts.wal_ttl_seconds;
   options.comparator = &kComparator;
@@ -1366,15 +1373,23 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   options.statistics = rocksdb::CreateDBStatistics();
   options.table_factory.reset(rocksdb::NewBlockBasedTableFactory(table_options));
 
-  // File size settings: TODO(marc): investigate and determine better long-term settings:
-  // https://github.com/cockroachdb/cockroach/issues/5852
-  options.level_compaction_dynamic_level_bytes = true;
-  options.target_file_size_base = 64 << 20;
-  options.target_file_size_multiplier = 8;
-  options.max_bytes_for_level_base = 512 << 20;
-  options.max_bytes_for_level_multiplier = 8;
   // Merge two memtables when flushing to L0.
   options.min_write_buffer_number_to_merge = 2;
+  // Enable dynamic level sizing which reduces both size and write
+  // amplification. This causes RocksDB to pick the target size of
+  // each level dynamically.
+  options.level_compaction_dynamic_level_bytes = true;
+  // TODO(peter): The target_file_size_* settings diverge from the
+  // RocksDB recommendation of max_bytes_for_level_base/10. But using
+  // that recommendation appears to lower performance in block_writer
+  // benchmarks. Need to figure out why.
+  options.target_file_size_base = 64 << 20;
+  options.target_file_size_multiplier = 8;
+  // Follow the RocksDB recommendation to configure the size of L1 to
+  // be the same as the estimated size of L0.
+  options.max_bytes_for_level_base = options.write_buffer_size *
+      options.min_write_buffer_number_to_merge * options.level0_file_num_compaction_trigger;
+  options.max_bytes_for_level_multiplier = 8;
 
   // Register listener for tracking RocksDB stats.
   std::shared_ptr<DBEventListener> event_listener(new DBEventListener);

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -66,6 +66,7 @@ typedef struct {
   uint64_t wal_ttl_seconds;
   bool allow_os_buffer;
   bool logging_enabled;
+  int num_cpu;
 } DBOptions;
 
 // Create a new cache with the specified size.


### PR DESCRIPTION
Together these tweaks reduce the time for `block_writer` to insert 1m
rows from 250s to 225s (-10%).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7532)

<!-- Reviewable:end -->
