### PR TITLE
storage: put the GC queue on speed

### DIFF
--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -35,7 +35,7 @@ const (
 	replicaGCQueueMaxSize = 100
 
 	// replicaGCQueueTimerDuration is the duration between GCs of queued replicas.
-	replicaGCQueueTimerDuration = 10 * time.Second
+	replicaGCQueueTimerDuration = 50 * time.Millisecond
 
 	// ReplicaGCQueueInactivityThreshold is the inactivity duration after which
 	// a range will be considered for garbage collection. Exported for testing.
@@ -43,7 +43,7 @@ const (
 	// ReplicaGCQueueCandidateTimeout is the duration after which a range in
 	// candidate Raft state (which is a typical sign of having been removed
 	// from the group) will be considered for garbage collection.
-	ReplicaGCQueueCandidateTimeout = 10 * time.Second
+	ReplicaGCQueueCandidateTimeout = 1 * time.Second
 )
 
 // replicaGCQueue manages a queue of replicas to be considered for garbage


### PR DESCRIPTION
Running the 1-to-3 rebalance test showed that we are still sometimes
stalling for ~30 seconds; this could be caused by the GC queue taking
a bit to actually GC replicas.

In anticipation of #5789, we should soon be able to make the GC queue
mostly event-driven. In the meantime, aggressive queue timings serve
to rule out this factor when investigating (or having to wait out) upreplication
stalls.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7533)

<!-- Reviewable:end -->
