### PR TITLE
server: Verify status code on update check

### DIFF
--- a/server/updates.go
+++ b/server/updates.go
@@ -273,10 +273,17 @@ func (s *Server) reportUsage() {
 	q.Set("uuid", s.node.ClusterID.String())
 	reportingURL.RawQuery = q.Encode()
 
-	_, err := http.Post(reportingURL.String(), "application/json", b)
+	res, err := http.Post(reportingURL.String(), "application/json", b)
 	if err != nil && log.V(2) {
 		// This is probably going to be relatively common in production
 		// environments where network access is usually curtailed.
-		log.Warning("Error checking reporting node usage metrics: ", err)
+		log.Warning("Failed to report node usage metrics: ", err)
+		return
+	}
+
+	if res.StatusCode != http.StatusOK {
+		b, err := ioutil.ReadAll(res.Body)
+		log.Warningf("Failed to report node usage metrics: status: %s, body: %s, "+
+			"error: %v", res.Status, b, err)
 	}
 }

--- a/server/updates.go
+++ b/server/updates.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -176,11 +177,18 @@ func (s *Server) checkForUpdates() {
 		// This is probably going to be relatively common in production
 		// environments where network access is usually curtailed.
 		if log.V(2) {
-			log.Warning("Error checking for updates: ", err)
+			log.Warning("Failed to check for updates: ", err)
 		}
 		return
 	}
 	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		b, err := ioutil.ReadAll(res.Body)
+		log.Warningf("Failed to check for updates: status: %s, body: %s, error: %v",
+			res.Status, b, err)
+		return
+	}
 
 	decoder := json.NewDecoder(res.Body)
 	r := struct {


### PR DESCRIPTION
Closes #6687.

Previously we would try to JSON decode a response body without checking
its status code. This led to log errors like:

```
Error decoding updates info: invalid character 'h' looking for beginning
of value
```

Now we get something like:

```
Error checking for updates: 500 Internal Server Error: http.go:96:
failed to fetch updates for UUID c4e50fd6-02cf-4605-8b61-49410c0ace11:
dial tcp 127.0.0.1:26257: socket: too many open files
```

Related to https://github.com/cockroachlabs/registration/issues/25.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7543)

<!-- Reviewable:end -->
