### PR TITLE
sql: fix an error in the handling of LIMIT on JOINs.

### DIFF
--- a/sql/table_join.go
+++ b/sql/table_join.go
@@ -507,9 +507,7 @@ func (n *joinNode) ExplainTypes(regTypes func(string, string)) {
 }
 
 // SetLimitHint implements the planNode interface.
-func (n *joinNode) SetLimitHint(numRows int64, soft bool) {
-	n.left.SetLimitHint(numRows, soft)
-}
+func (n *joinNode) SetLimitHint(numRows int64, soft bool) {}
 
 // expandPlan implements the planNode interface.
 func (n *joinNode) expandPlan() error {

--- a/sql/testdata/join
+++ b/sql/testdata/join
@@ -137,6 +137,14 @@ NULL
 43
 44
 
+# Check that a limit on the JOIN's result do not cause rows from the
+# JOIN operands to become invisible to the JOIN.
+query I colnames
+SELECT * FROM (SELECT x FROM onecolumn ORDER BY x DESC) NATURAL JOIN (VALUES (42)) AS v(x) LIMIT 1
+----
+x
+42
+
 statement ok
 CREATE TABLE empty (x INT)
 
@@ -270,7 +278,7 @@ EXPLAIN SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON 
 1  join   INNER ON (a.b = c.d) AND (c.d = onecolumn.x)
 2  join   INNER ON a.b = twocolumn.x
 3  join   CROSS
-4  scan   onecolumn@primary (max 1 row)
+4  scan   onecolumn@primary
 4  scan   twocolumn@primary
 3  scan   onecolumn@primary
 2  scan   twocolumn@primary


### PR DESCRIPTION
Prior to this patch the outer LIMIT would propagate to the inner left
data source. This is incorrect, because the JOIN logic may skip
unmatched rows from the left data source to produce its output.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7546)

<!-- Reviewable:end -->
