### PR TITLE
acceptance: no Docker for remote tests

### DIFF
--- a/acceptance/allocator_test.go
+++ b/acceptance/allocator_test.go
@@ -30,10 +30,11 @@ package acceptance
 //
 // Example use:
 //
-// make acceptance \
-//   TESTFLAGS="-v --remote -key-name google_compute_engine -cwd=allocator_terraform" \
-//   TESTS="TestUpreplicate_1To3Small" \
-//   TESTTIMEOUT="24h"
+// make test \
+//	 TESTTIMEOUT=48h \
+//	 PKG=./acceptance \
+//	 TESTS=Rebalance_3To5Small \
+//	 TESTFLAGS='-v -remote -key-name google_compute_engine -cwd allocator_terraform -tf.keep-cluster-fail' \
 //
 // Things to note:
 // - Your SSH key (-key-name) for Google Cloud Platform must be in

--- a/acceptance/main_stub_test.go
+++ b/acceptance/main_stub_test.go
@@ -27,14 +27,12 @@
 package acceptance
 
 import (
-	"flag"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
 func TestMain(m *testing.M) {
-	flag.Parse()
 	if !*flagRemote {
 		log.Infof("not running with `acceptance` build tag or against remote cluster; skipping")
 		return

--- a/acceptance/main_stub_test.go
+++ b/acceptance/main_stub_test.go
@@ -16,18 +16,28 @@
 
 // +build !acceptance
 
-// Acceptance tests are comparatively slow to run, so we use the above build
-// tag to separate invocations of `go test` which are intended to run the
-// acceptance tests from those which are not. The corollary file to this one
-// is main_test.go
+// Our Docker-based acceptance tests are comparatively slow to run, so we use
+// the above build tag to separate invocations of `go test` which are intended
+// to run the acceptance tests from those which are not. The corollary file to
+// this one is main_test.go. Acceptance tests against remote clusters (which
+// aren't run unless `-remote` is passed explicitly) are run through this file
+// via the standard facilities (i.e. `make test` and without `acceptance` build
+// tag).
 
 package acceptance
 
 import (
-	"os"
+	"flag"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 func TestMain(m *testing.M) {
-	os.Exit(0)
+	flag.Parse()
+	if !*flagRemote {
+		log.Infof("not running with `acceptance` build tag or against remote cluster; skipping")
+		return
+	}
+	runTests(m)
 }

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -23,8 +23,17 @@
 
 package acceptance
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"testing"
+)
 
 func TestMain(m *testing.M) {
+	if *flagRemote {
+		fmt.Fprintln(os.Stderr, "use `make test [...]` instead of `make acceptance [...]` when running remote cluster")
+		os.Exit(1)
+	}
+
 	runTests(m)
 }

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -23,27 +23,8 @@
 
 package acceptance
 
-import (
-	"os"
-	"os/signal"
-	"testing"
-
-	"github.com/cockroachdb/cockroach/util/randutil"
-)
+import "testing"
 
 func TestMain(m *testing.M) {
-	randutil.SeedForTests()
-	go func() {
-		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, os.Interrupt)
-		<-sig
-		select {
-		case <-stopper:
-		default:
-			// There is a very tiny race here: the cluster might be closing
-			// the stopper simultaneously.
-			close(stopper)
-		}
-	}()
-	os.Exit(m.Run())
+	runTests(m)
 }

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -42,6 +42,10 @@ import (
 	_ "github.com/cockroachdb/pq"
 )
 
+func init() {
+	flag.Parse()
+}
+
 var flagDuration = flag.Duration("d", cluster.DefaultDuration, "duration to run the test")
 var flagNodes = flag.Int("nodes", 3, "number of nodes")
 var flagStores = flag.Int("stores", 1, "number of stores to use for each node")


### PR DESCRIPTION
Avoid having to go through `make acceptance` for tests which run against
a remote cluster. Instead, use the usual `make test` invocation (or, if
preferred, `go test` directly.
Triggered by the `-remote` flag. Without that flag, running `./acceptance`
is still a no-op, preserving the desired previous behaviour.

cc @jordanlewis for possible existing test invocations elsewhere that should adapt.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7560)

<!-- Reviewable:end -->
