### PR TITLE
Use valid node prefix for terraform_test.

### DIFF
--- a/acceptance/terraform_test.go
+++ b/acceptance/terraform_test.go
@@ -41,7 +41,7 @@ func TestBuildBabyCluster(t *testing.T) {
 // has passed.
 func TestFiveNodesAndWriters(t *testing.T) {
 	deadline := time.After(*flagDuration)
-	f := farmer(t, "5n5w")
+	f := farmer(t, "write-5n5w")
 	defer f.MustDestroy()
 	const size = 5
 	if err := f.Resize(size, size); err != nil {


### PR DESCRIPTION
The farmer random-name change requires that the input name prefixes start with letters. Previously, terraform_test used 5n5w which is invalid.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7569)

<!-- Reviewable:end -->
