### PR TITLE
Log Events for Alter Table, Async Schema Change

### DIFF
--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -187,6 +187,13 @@ func (txn *Txn) InternalSetPriority(priority int32) {
 
 // SetSystemConfigTrigger sets the system db trigger to true on this transaction.
 // This will impact the EndTransactionRequest.
+//
+// NOTE: The system db trigger will only execute correctly if the transaction
+// record is located on the range that contains the system span. If a
+// transaction is created which modifies both system *and* non-system data, it
+// should be ensured that the transaction record itself is on the system span.
+// This can be done by making sure a system key is the first key touched in the
+// transaction.
 func (txn *Txn) SetSystemConfigTrigger() {
 	txn.systemConfigTrigger = true
 }

--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -242,6 +242,22 @@ func (n *alterTableNode) Start() error {
 	if err := n.p.writeTableDesc(n.tableDesc); err != nil {
 		return err
 	}
+
+	// Record this table alteration in the event log.
+	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(n.p.txn,
+		EventLogAlterTable,
+		int32(n.tableDesc.ID),
+		int32(n.p.evalCtx.NodeID),
+		struct {
+			TableName  string
+			Statement  string
+			User       string
+			MutationID uint32
+		}{n.tableDesc.Name, n.n.String(), n.p.session.User, uint32(mutationID)},
+	); err != nil {
+		return err
+	}
+
 	n.p.notifySchemaChange(n.tableDesc.ID, mutationID)
 
 	return nil

--- a/sql/event_log.go
+++ b/sql/event_log.go
@@ -40,6 +40,15 @@ const (
 	EventLogCreateTable EventLogType = "create_table"
 	// EventLogDropTable is recorded when a table is dropped.
 	EventLogDropTable EventLogType = "drop_table"
+	// EventLogAlterTable is recorded when a table is altered.
+	EventLogAlterTable EventLogType = "alter_table"
+	// EventLogReverseSchemaChange is recorded when an in-progress schema change
+	// encounters a problem and is reversed.
+	EventLogReverseSchemaChange EventLogType = "reverse_schema_change"
+	// EventLogFinishSchemaChange is recorded when a previously initiated schema
+	// change has completed.
+	EventLogFinishSchemaChange EventLogType = "finish_schema_change"
+
 	// EventLogNodeJoin is recorded when a node joins the cluster.
 	EventLogNodeJoin EventLogType = "node_join"
 	// EventLogNodeRestart is recorded when an existing node rejoins the cluster

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -148,10 +148,9 @@ func (t *leaseTest) mustRelease(
 }
 
 func (t *leaseTest) publish(nodeID uint32, descID sqlbase.ID) error {
-	_, err := t.node(nodeID).Publish(descID,
-		func(*sqlbase.TableDescriptor) error {
-			return nil
-		})
+	_, err := t.node(nodeID).Publish(descID, func(*sqlbase.TableDescriptor) error {
+		return nil
+	}, nil)
 	return err
 }
 
@@ -369,7 +368,7 @@ func TestLeaseManagerPublishVersionChanged(testingT *testing.T) {
 			// a new version.
 			<-n1update
 			return nil
-		})
+		}, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -382,7 +381,7 @@ func TestLeaseManagerPublishVersionChanged(testingT *testing.T) {
 		<-n2start
 		_, err := n2.Publish(descID, func(*sqlbase.TableDescriptor) error {
 			return nil
-		})
+		}, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -989,7 +989,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 
 		// Ensure that sql is using the correct table lease.
 		if len(cols) != len(expectedCols) {
-			return errors.Errorf("incorrect columns: %v", cols)
+			return errors.Errorf("incorrect columns: %v, expected: %v", cols, expectedCols)
 		}
 		if cols[0] != expectedCols[0] || cols[1] != expectedCols[1] {
 			t.Fatalf("incorrect columns: %v", cols)

--- a/sql/testdata/event_log
+++ b/sql/testdata/event_log
@@ -57,6 +57,74 @@ WHERE eventType = 'create_table'
 ----
 0
 
+# Alter the table. Expect "alter_table" and "finish_schema_change" events.
+##################
+
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'alter_table'
+----
+
+statement ok
+ALTER TABLE test.a ADD val INT
+
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'alter_table'
+----
+51 1
+
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'finish_schema_change'
+----
+51 0
+
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'reverse_schema_change'
+----
+
+# Verify the contents of the 'Info' field of each log message using a LIKE
+# statement.
+##################
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'alter_table'
+  AND info LIKE '%ALTER TABLE test.a%'
+----
+51 1
+
+# Add a UNIQUE constraint to the table in a way that will ensure the schema 
+# change is reversed.
+##################
+
+statement ok
+INSERT INTO test.a VALUES (1, 1), (2, 1)
+
+statement error pq: duplicate key value \(val\)=\(1\) violates unique constraint \"foo\"
+ALTER TABLE test.a ADD CONSTRAINT foo UNIQUE(val)
+
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'alter_table'
+----
+51 1
+51 1
+
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'finish_schema_change'
+----
+51 0
+51 0
+
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'reverse_schema_change'
+----
+51 0
+
 
 # Drop both tables + superfluous "IF EXISTS"
 ##################

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -789,7 +789,20 @@ func (r *Replica) runCommitTrigger(ctx context.Context, batch engine.Batch, ms *
 		if ct.GetModifiedSpanTrigger() != nil {
 			if ct.ModifiedSpanTrigger.SystemConfigSpan {
 				// Check if we need to gossip the system config.
-				batch.Defer(r.maybeGossipSystemConfig)
+				// NOTE: System config gossiping can only execute correctly if
+				// the transaction record is located on the range that contains
+				// the system span. If a transaction is created which modifies
+				// both system *and* non-system data, it should be ensured that
+				// the transaction record itself is on the system span. This can
+				// be done by making sure a system key is the first key touched
+				// in the transaction.
+				if !r.ContainsKey(keys.SystemConfigSpan.Key) {
+					log.Errorc(ctx, "System configuration span was modified, but the "+
+						"modification trigger is executing on a non-system range. Configuration "+
+						"changes will not be gossiped.")
+				} else {
+					batch.Defer(r.maybeGossipSystemConfig)
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
Commit adds three new event log types:
- "Alter Table", logged for every ALTER TABLE DDL statement.
- "Finish Schema Change", logged when an asynchronous schema change is
  completed.
- "Reverse Schema Change", logged when an asynchronous schema change encounters
  an error (such as a constraint violation during backfill) and is rolled back.

This Commit encountered an interesting, perhaps unintended effect with
`SystemConfigTrigger`: in a "mixed" transaction which updates both system and
non-system keys, the system changes will only be gossiped if the transaction
record is located on the system range. In other words, "mixed" transactions will
only work correctly if the system keys are modified first. Issue #7570 had been
logged to track this unexpected behavior; this commit has also added a number of
comments and a logged error to address this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7571)

<!-- Reviewable:end -->
