### PR TITLE
storage/command_queue: use a channel-based API

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -898,13 +898,18 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func
 			select {
 			case <-ch:
 			case <-ctxDone:
+				err := ctx.Err()
+				errStr := fmt.Sprintf("%s while in command queue: %s", err, ba)
+				log.Warning(errStr)
+				log.Trace(ctx, errStr)
+				defer log.Trace(ctx, "removed from command queue")
 				// The command is moot, so we don't need to bother executing.
 				// However, the command queue assumes that commands don't drop
 				// out before their prerequisites, so we still have to wait it
 				// out.
 				//
 				// TODO(tamird): this can be done asynchronously, allowing the
-				// caller to return immediatelly. For now, we're keeping it
+				// caller to return immediately. For now, we're keeping it
 				// simple to avoid unexpected surprises.
 				for _, ch := range chans[i:] {
 					<-ch
@@ -912,7 +917,7 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func
 				r.mu.Lock()
 				r.mu.cmdQ.remove(cmd)
 				r.mu.Unlock()
-				return nil, ctx.Err()
+				return nil, err
 			}
 		}
 	}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -879,7 +879,7 @@ func (r *Replica) checkBatchRequest(ba roachpb.BatchRequest) error {
 // already in the queue. Returns a cleanup function to be called when the
 // commands are done and can be removed from the queue, and whose returned
 // error is to be used in place of the supplied error.
-func (r *Replica) beginCmds(ba *roachpb.BatchRequest) func(*roachpb.BatchResponse, *roachpb.Error) *roachpb.Error {
+func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func(*roachpb.BatchResponse, *roachpb.Error) *roachpb.Error, error) {
 	var cmd *cmd
 	// Don't use the command queue for inconsistent reads.
 	if ba.ReadConsistency != roachpb.INCONSISTENT {
@@ -888,12 +888,33 @@ func (r *Replica) beginCmds(ba *roachpb.BatchRequest) func(*roachpb.BatchRespons
 		for i, union := range ba.Requests {
 			spans[i] = union.GetInner().Header()
 		}
-		var wg sync.WaitGroup
 		r.mu.Lock()
-		r.mu.cmdQ.getWait(readOnly, &wg, spans...)
+		chans := r.mu.cmdQ.getWait(readOnly, spans...)
 		cmd = r.mu.cmdQ.add(readOnly, spans...)
 		r.mu.Unlock()
-		wg.Wait()
+
+		ctxDone := ctx.Done()
+		for i, ch := range chans {
+			select {
+			case <-ch:
+			case <-ctxDone:
+				// The command is moot, so we don't need to bother executing.
+				// However, the command queue assumes that commands don't drop
+				// out before their prerequisites, so we still have to wait it
+				// out.
+				//
+				// TODO(tamird): this can be done asynchronously, allowing the
+				// caller to return immediatelly. For now, we're keeping it
+				// simple to avoid unexpected surprises.
+				for _, ch := range chans[i:] {
+					<-ch
+				}
+				r.mu.Lock()
+				r.mu.cmdQ.remove(cmd)
+				r.mu.Unlock()
+				return nil, ctx.Err()
+			}
+		}
 	}
 
 	// Update the incoming timestamp if unset. Wait until after any
@@ -915,7 +936,7 @@ func (r *Replica) beginCmds(ba *roachpb.BatchRequest) func(*roachpb.BatchRespons
 
 	return func(br *roachpb.BatchResponse, pErr *roachpb.Error) *roachpb.Error {
 		return r.endCmds(cmd, ba, br, pErr)
-	}
+	}, nil
 }
 
 // endCmds removes pending commands from the command queue and updates
@@ -1104,7 +1125,10 @@ func (r *Replica) addReadOnlyCmd(ctx context.Context, ba roachpb.BatchRequest) (
 	// Add the read to the command queue to gate subsequent
 	// overlapping commands until this command completes.
 	log.Trace(ctx, "command queue")
-	endCmdsFunc := r.beginCmds(&ba)
+	endCmdsFunc, err := r.beginCmds(ctx, &ba)
+	if err != nil {
+		return nil, roachpb.NewError(err)
+	}
 
 	r.readOnlyCmdMu.RLock()
 	defer r.readOnlyCmdMu.RUnlock()
@@ -1171,7 +1195,10 @@ func (r *Replica) addWriteCmd(
 	// timestamp cache is only updated after preceding commands have
 	// been run to successful completion.
 	log.Trace(ctx, "command queue")
-	endCmdsFunc := r.beginCmds(&ba)
+	endCmdsFunc, err := r.beginCmds(ctx, &ba)
+	if err != nil {
+		return nil, roachpb.NewError(err)
+	}
 
 	// Guarantee we remove the commands from the command queue. This is
 	// wrapped to delay pErr evaluation to its value when returning.

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -883,11 +883,10 @@ func (r *Replica) beginCmds(ba *roachpb.BatchRequest) func(*roachpb.BatchRespons
 	var cmd *cmd
 	// Don't use the command queue for inconsistent reads.
 	if ba.ReadConsistency != roachpb.INCONSISTENT {
-		spans := make([]roachpb.Span, 0, len(ba.Requests))
 		readOnly := ba.IsReadOnly()
-		for _, union := range ba.Requests {
-			h := union.GetInner().Header()
-			spans = append(spans, roachpb.Span{Key: h.Key, EndKey: h.EndKey})
+		spans := make([]roachpb.Span, len(ba.Requests))
+		for i, union := range ba.Requests {
+			spans[i] = union.GetInner().Header()
 		}
 		var wg sync.WaitGroup
 		r.mu.Lock()


### PR DESCRIPTION
storage/command_queue: use a channel-based API

This permits us to compose waiting for the command queue with a
context cancellation channel, which is also done here.

By lazily creating channels, performance remains unchanged.

```
name                            old time/op    new time/op    delta
InsertDistinct1_Cockroach-24      1.61ms ± 1%    1.64ms ± 4%  +1.79%        (p=0.007 n=10+10)
InsertDistinct10_Cockroach-24     1.14ms ± 2%    1.17ms ± 3%  +2.54%        (p=0.000 n=10+10)
InsertDistinct100_Cockroach-24    1.47ms ± 1%    1.51ms ± 3%  +2.53%         (p=0.003 n=8+10)
KVInsert1_Native-24                663µs ± 1%     664µs ± 2%    ~           (p=1.000 n=10+10)
KVInsert1_SQL-24                   502µs ± 3%     503µs ± 1%    ~            (p=0.360 n=10+8)
KVInsert10_Native-24               820µs ± 1%     820µs ± 1%    ~           (p=0.853 n=10+10)
KVInsert10_SQL-24                  687µs ± 2%     686µs ± 2%    ~           (p=0.971 n=10+10)
KVInsert100_Native-24             1.97ms ± 1%    1.94ms ± 1%  -1.22%         (p=0.004 n=10+8)
KVInsert100_SQL-24                2.02ms ± 2%    2.01ms ± 1%    ~           (p=0.190 n=10+10)
KVInsert1000_Native-24            11.8ms ± 4%    11.5ms ± 3%    ~           (p=0.063 n=10+10)
KVInsert1000_SQL-24               14.3ms ± 5%    14.0ms ± 3%    ~           (p=0.063 n=10+10)
KVInsert10000_Native-24            119ms ± 5%     120ms ± 5%    ~            (p=0.549 n=9+10)
KVInsert10000_SQL-24               147ms ± 6%     149ms ± 3%    ~           (p=0.280 n=10+10)

name                            old alloc/op   new alloc/op   delta
InsertDistinct1_Cockroach-24       304kB ± 0%     303kB ± 0%  -0.33%        (p=0.000 n=10+10)
InsertDistinct10_Cockroach-24      316kB ± 0%     318kB ± 2%    ~            (p=0.173 n=8+10)
InsertDistinct100_Cockroach-24     474kB ± 0%     472kB ± 0%  -0.33%         (p=0.000 n=10+9)
KVInsert1_Native-24               37.1kB ± 0%    37.0kB ± 0%  -0.22%         (p=0.000 n=10+9)
KVInsert1_SQL-24                  30.7kB ± 0%    30.6kB ± 0%  -0.24%         (p=0.000 n=10+9)
KVInsert10_Native-24              93.2kB ± 0%    93.0kB ± 0%  -0.28%        (p=0.000 n=10+10)
KVInsert10_SQL-24                 79.3kB ± 0%    79.1kB ± 0%  -0.33%        (p=0.000 n=10+10)
KVInsert100_Native-24              607kB ± 0%     605kB ± 0%  -0.29%         (p=0.000 n=9+10)
KVInsert100_SQL-24                 527kB ± 0%     525kB ± 0%  -0.35%         (p=0.000 n=10+9)
KVInsert1000_Native-24            5.14MB ± 0%    5.13MB ± 0%  -0.31%         (p=0.000 n=10+7)
KVInsert1000_SQL-24               4.58MB ± 0%    4.57MB ± 0%  -0.35%         (p=0.000 n=9+10)
KVInsert10000_Native-24           79.1MB ± 0%    79.0MB ± 0%  -0.20%        (p=0.000 n=10+10)
KVInsert10000_SQL-24              66.3MB ± 0%    66.1MB ± 0%  -0.26%         (p=0.000 n=9+10)

name                            old allocs/op  new allocs/op  delta
InsertDistinct1_Cockroach-24       1.91k ± 0%     1.91k ± 0%    ~            (p=0.507 n=9+10)
InsertDistinct10_Cockroach-24      1.98k ± 0%     2.00k ± 3%    ~            (p=0.214 n=8+10)
InsertDistinct100_Cockroach-24     3.32k ± 0%     3.32k ± 0%  -0.07%         (p=0.047 n=10+9)
KVInsert1_Native-24                  364 ± 0%       364 ± 0%    ~           (p=0.087 n=10+10)
KVInsert1_SQL-24                     314 ± 0%       314 ± 0%    ~     (all samples are equal)
KVInsert10_Native-24                 596 ± 0%       596 ± 0%    ~     (all samples are equal)
KVInsert10_SQL-24                    586 ± 0%       586 ± 0%    ~     (all samples are equal)
KVInsert100_Native-24              2.71k ± 0%     2.71k ± 0%  -0.01%         (p=0.029 n=10+7)
KVInsert100_SQL-24                 3.05k ± 0%     3.05k ± 0%    ~            (p=0.674 n=10+9)
KVInsert1000_Native-24             23.6k ± 0%     23.6k ± 0%    ~            (p=0.160 n=10+8)
KVInsert1000_SQL-24                27.5k ± 0%     27.5k ± 0%    ~             (p=0.610 n=8+9)
KVInsert10000_Native-24             232k ± 0%      232k ± 0%    ~           (p=0.541 n=10+10)
KVInsert10000_SQL-24                275k ± 0%      275k ± 0%    ~            (p=0.435 n=9+10)
```

Fixes #3299.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7605)

<!-- Reviewable:end -->
