### PR TITLE
kv,storage: clarify range/group terminology

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -99,8 +99,7 @@ type DistSender struct {
 	// rangeCache caches replica metadata for key ranges.
 	rangeCache           *rangeDescriptorCache
 	rangeLookupMaxRanges int32
-	// leaderCache caches the last known leader replica for range
-	// consensus groups.
+	// leaderCache caches range leaders by range ID.
 	leaderCache      *leaderCache
 	transportFactory TransportFactory
 	rpcContext       *rpc.Context
@@ -449,7 +448,7 @@ func (ds *DistSender) sendSingleRange(
 	// If this request needs to go to a leader and we know who that is, move
 	// it to the front.
 	if !(ba.IsReadOnly() && ba.ReadConsistency == roachpb.INCONSISTENT) {
-		if leader := ds.leaderCache.Lookup(roachpb.RangeID(desc.RangeID)); leader.StoreID > 0 {
+		if leader, ok := ds.leaderCache.Lookup(roachpb.RangeID(desc.RangeID)); ok {
 			if i := replicas.FindReplica(leader.StoreID); i >= 0 {
 				replicas.MoveToFront(i)
 			}
@@ -1038,14 +1037,21 @@ func (ds *DistSender) handlePerReplicaError(rangeID roachpb.RangeID, pErr *roach
 	return false
 }
 
-// updateLeaderCache updates the cached leader for the given range,
-// evicting any previous value in the process.
-func (ds *DistSender) updateLeaderCache(rid roachpb.RangeID, leader roachpb.ReplicaDescriptor) {
-	oldLeader := ds.leaderCache.Lookup(rid)
-	if leader.StoreID != oldLeader.StoreID {
-		if log.V(1) {
-			log.Infof("range %d: new cached leader store %d (old: %d)", rid, leader.StoreID, oldLeader.StoreID)
+// updateLeaderCache updates the cached leader for the given range.
+func (ds *DistSender) updateLeaderCache(
+	rangeID roachpb.RangeID,
+	newLeader roachpb.ReplicaDescriptor,
+) {
+	if log.V(1) {
+		if oldLeader, ok := ds.leaderCache.Lookup(rangeID); ok {
+			if (newLeader == roachpb.ReplicaDescriptor{}) {
+				log.Infof("range %d: evicting cached leader %+v", rangeID, oldLeader)
+			} else if newLeader != oldLeader {
+				log.Infof("range %d: replacing cached leader %+v with %+v", rangeID, oldLeader, newLeader)
+			}
+		} else {
+			log.Infof("range %d: caching new leader %+v", rangeID, newLeader)
 		}
-		ds.leaderCache.Update(rid, leader)
 	}
+	ds.leaderCache.Update(rangeID, newLeader)
 }

--- a/storage/raft.go
+++ b/storage/raft.go
@@ -28,7 +28,7 @@ import (
 )
 
 // init installs an adapter to use clog for log messages from raft which
-// don't belong to any raft group.
+// don't belong to any range.
 func init() {
 	raft.SetLogger(&raftLogger{})
 }
@@ -45,15 +45,15 @@ func init() {
 // This file is named raft.go instead of something like logger.go because this
 // file's name is used to determine the vmodule parameter: --vmodule=raft=1
 type raftLogger struct {
-	group uint64
+	rangeID roachpb.RangeID
 }
 
 // logPrefix returns a string that will prefix logs emitted by
 // raftLogger. Bad things will happen if this method returns a string
 // containing unescaped '%' characters.
 func (r *raftLogger) logPrefix() string {
-	if r.group != 0 {
-		return fmt.Sprintf("[group %d] ", r.group)
+	if r.rangeID != 0 {
+		return fmt.Sprintf("[range %d] ", r.rangeID)
 	}
 	return ""
 }
@@ -124,7 +124,7 @@ func logRaftReady(storeID roachpb.StoreID, rangeID roachpb.RangeID, ready raft.R
 		// Globally synchronize to avoid interleaving different sets of logs in tests.
 		logRaftReadyMu.Lock()
 		defer logRaftReadyMu.Unlock()
-		log.Infof("store %s: group %s raft ready", storeID, rangeID)
+		log.Infof("store %d: range %d raft ready", storeID, rangeID)
 		if ready.SoftState != nil {
 			log.Infof("SoftState updated: %+v", *ready.SoftState)
 		}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -269,7 +269,7 @@ func (r *Replica) withRaftGroupLocked(f func(r *raft.RawNode) error) error {
 			MaxSizePerMsg:   1024 * 1024,
 			MaxInflightMsgs: 256,
 			CheckQuorum:     true,
-			Logger:          &raftLogger{group: uint64(r.RangeID)},
+			Logger:          &raftLogger{rangeID: r.RangeID},
 		}, nil)
 		if err != nil {
 			return err
@@ -1645,11 +1645,11 @@ func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 	r.store.mu.Unlock()
 
 	if toErr != nil {
-		log.Warningf("failed to lookup recipient replica %d in group %s: %s", msg.To, rangeID, toErr)
+		log.Warningf("failed to look up recipient replica %d in range %d: %s", msg.To, rangeID, toErr)
 		return
 	}
 	if fromErr != nil {
-		log.Warningf("failed to lookup sender replica %d in group %s: %s", msg.From, rangeID, fromErr)
+		log.Warningf("failed to look up sender replica %d in range %d: %s", msg.From, rangeID, fromErr)
 		return
 	}
 	if !r.raftSender.SendAsync(&RaftMessageRequest{

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -180,7 +180,7 @@ func (q *replicaGCQueue) process(now hlc.Timestamp, rng *Replica, _ config.Syste
 		// TODO(bdarnell): remove raft logs and other metadata (while leaving a
 		// tombstone). Add tests for GC of merged ranges.
 	} else {
-		// This range is a current member of the raft group. Set the last replica
+		// This replica is a current member of the raft group. Set the last replica
 		// GC check time to avoid re-processing for another check interval.
 		if err := rng.setLastReplicaGCTimestamp(now); err != nil {
 			return err


### PR DESCRIPTION
Snuck in some drive-by cleanups as well, mostly comments.

cc @cockroachdb/core

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7617)

<!-- Reviewable:end -->
