### PR TITLE
ui: add graph for RocksDB read amplification

### DIFF
--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -151,6 +151,26 @@ func (s SSTableInfos) String() string {
 	return buf.String()
 }
 
+// ReadAmplification returns RocksDB's read amplification, which is the number
+// of level-0 sstables plus the number of levels, other than level 0, with at
+// least one sstable.
+//
+// This definition comes from here:
+// https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide#level-style-compaction
+func (s SSTableInfos) ReadAmplification() int {
+	var readAmp int
+	seenLevel := make(map[int]bool)
+	for _, t := range s {
+		if t.Level == 0 {
+			readAmp++
+		} else if !seenLevel[t.Level] {
+			readAmp++
+			seenLevel[t.Level] = true
+		}
+	}
+	return readAmp
+}
+
 // RocksDBCache is a wrapper around C.DBCache
 type RocksDBCache struct {
 	cache *C.DBCache

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -350,3 +350,49 @@ func TestSSTableInfosString(t *testing.T) {
 		t.Fatalf("expected\n%s\ngot\n%s", expected, s)
 	}
 }
+
+func TestReadAmplification(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	info := func(level int, size int64) SSTableInfo {
+		return SSTableInfo{
+			Level: level,
+			Size:  size,
+		}
+	}
+
+	tables1 := SSTableInfos{
+		info(0, 0),
+		info(0, 0),
+		info(0, 0),
+		info(1, 0),
+	}
+	if a, e := tables1.ReadAmplification(), 4; a != e {
+		t.Errorf("got %d, expected %d", a, e)
+	}
+
+	tables2 := SSTableInfos{
+		info(0, 0),
+		info(1, 0),
+		info(2, 0),
+		info(3, 0),
+	}
+	if a, e := tables2.ReadAmplification(), 4; a != e {
+		t.Errorf("got %d, expected %d", a, e)
+	}
+
+	tables3 := SSTableInfos{
+		info(1, 0),
+		info(0, 0),
+		info(0, 0),
+		info(0, 0),
+		info(1, 0),
+		info(1, 0),
+		info(2, 0),
+		info(3, 0),
+		info(6, 0),
+	}
+	if a, e := tables3.ReadAmplification(), 7; a != e {
+		t.Errorf("got %d, expected %d", a, e)
+	}
+}

--- a/ui/app/containers/nodeGraphs.tsx
+++ b/ui/app/containers/nodeGraphs.tsx
@@ -203,6 +203,11 @@ export default class extends React.Component<RouteComponentProps<any, any>, {}> 
               </Axis>
             </LineGraph>
 
+            <LineGraph title="Read Amplification" sources={sources}>
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.store.rocksdb.read-amplification" title="Read Amplification" />
+              </Axis>
+            </LineGraph>
           </GraphGroup>
       </div>
     </div>;

--- a/ui/app/containers/nodesGraphs.tsx
+++ b/ui/app/containers/nodesGraphs.tsx
@@ -198,6 +198,12 @@ export default class extends React.Component<{}, {}> {
               </Axis>
             </LineGraph>
 
+            <LineGraph title="Read Amplification">
+              <Axis format={ d3.format(".1") }>
+                <Metric name="cr.store.rocksdb.read-amplification" title="Read Amplification" aggregateMax downsampleMax />
+              </Axis>
+            </LineGraph>
+
           </GraphGroup>
       </div>
     </div>;


### PR DESCRIPTION
Partly addresses #7552 but doesn't include the nice visualization that's
been requested.

<img width="1294" alt="screenshot 2016-07-05 13 00 35" src="https://cloud.githubusercontent.com/assets/1564582/16592962/2ec64d00-42b1-11e6-8da7-5200e7e30d6c.png">

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7620)

<!-- Reviewable:end -->
