### PR TITLE
sql: turn on column family heuristics

### DIFF
--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -322,7 +322,7 @@ func testDockerSuccess(t *testing.T, name string, cmd []string) {
 
 const (
 	// NB: postgresTestTag is grepped for in circle-deps.sh, so don't rename it.
-	postgresTestTag = "20160623-2125"
+	postgresTestTag = "20160705-1326"
 	// Iterating against a locally built version of the docker image can be done
 	// by changing postgresTestImage to the hash of the container.
 	postgresTestImage = "cockroachdb/postgres-test:" + postgresTestTag

--- a/cli/dump_test.go
+++ b/cli/dump_test.go
@@ -95,17 +95,10 @@ CREATE TABLE t (
 	o BOOL NULL,
 	e DECIMAL NULL,
 	tz TIMESTAMP WITH TIME ZONE NULL,
-	FAMILY "primary" (rowid),
-	FAMILY fam_1_i (i),
-	FAMILY fam_2_f (f),
-	FAMILY fam_3_s (s),
-	FAMILY fam_4_b (b),
-	FAMILY fam_5_d (d),
-	FAMILY fam_6_t (t),
-	FAMILY fam_7_n (n),
-	FAMILY fam_8_o (o),
-	FAMILY fam_9_e (e),
-	FAMILY fam_10_tz (tz)
+	FAMILY "primary" (i, f, d, t, n, o, tz, rowid),
+	FAMILY fam_1_s (s),
+	FAMILY fam_2_b (b),
+	FAMILY fam_3_e (e)
 );
 
 INSERT INTO t VALUES

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -1184,8 +1184,7 @@ func runBenchmarkWideTable(b *testing.B, db *gosql.DB, count int) {
 	const schema = `CREATE TABLE bench.widetable (
     f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT, f9 INT, f10 INT,
     f11 INT, f12 INT, f13 INT, f14 INT, f15 INT, f16 INT, f17 INT, f18 INT, f19 INT, f20 INT,
-    PRIMARY KEY (f1, f2, f3),
-    FAMILY (f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20)
+    PRIMARY KEY (f1, f2, f3)
   )`
 	if _, err := db.Exec(schema); err != nil {
 		b.Fatal(err)

--- a/sql/schema_changer_test.go
+++ b/sql/schema_changer_test.go
@@ -555,11 +555,11 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 	tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
 	tableEnd := tablePrefix.PrefixEnd()
-	// number of keys == 4 * number of rows; 3 columns and 1 index entry for
-	// each row.
+	// number of keys == 3 * number of rows; 2 column families and 1 index entry
+	// for each row.
 	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
-	} else if e := 4 * (maxValue + 1); len(kvs) != e {
+	} else if e := 3 * (maxValue + 1); len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
 	}
 
@@ -573,7 +573,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		kvDB,
 		"ALTER TABLE t.test ADD COLUMN x DECIMAL DEFAULT (DECIMAL '1.4')",
 		maxValue,
-		5,
+		4,
 		backfillNotification)
 
 	// Drop column.
@@ -584,7 +584,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		kvDB,
 		"ALTER TABLE t.test DROP pi",
 		maxValue,
-		4,
+		3,
 		backfillNotification)
 
 	// Add index.
@@ -595,7 +595,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		kvDB,
 		"CREATE UNIQUE INDEX foo ON t.test (v)",
 		maxValue,
-		5,
+		4,
 		backfillNotification)
 
 	// Drop index.
@@ -606,7 +606,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		kvDB,
 		"DROP INDEX t.test@vidx",
 		maxValue,
-		4,
+		3,
 		backfillNotification)
 
 	// Verify that the index foo over v is consistent, and that column x has
@@ -858,7 +858,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	tableEnd := tablePrefix.PrefixEnd()
 	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
-	} else if e := 2*(maxValue+2) + numGarbageValues; len(kvs) != e {
+	} else if e := 1*(maxValue+2) + numGarbageValues; len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
 	}
 
@@ -878,7 +878,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	numGarbageValues = 0
 	if kvs, err := kvDB.Scan(tablePrefix, tableEnd, 0); err != nil {
 		t.Fatal(err)
-	} else if e := 2*(maxValue+2) + numGarbageValues; len(kvs) != e {
+	} else if e := 1*(maxValue+2) + numGarbageValues; len(kvs) != e {
 		t.Fatalf("expected %d key value pairs, but got %d", e, len(kvs))
 	}
 }

--- a/sql/show_test.go
+++ b/sql/show_test.go
@@ -54,11 +54,8 @@ func TestShowCreateTable(t *testing.T) {
 	s STRING NULL,
 	v FLOAT NOT NULL,
 	t TIMESTAMP NULL DEFAULT NOW(),
-	FAMILY "primary" (rowid),
-	FAMILY fam_1_i (i),
-	FAMILY fam_2_s (s),
-	FAMILY fam_3_v (v),
-	FAMILY fam_4_t (t),
+	FAMILY "primary" (i, v, t, rowid),
+	FAMILY fam_1_s (s),
 	CHECK (i > 0)
 )`,
 		},
@@ -74,11 +71,8 @@ func TestShowCreateTable(t *testing.T) {
 	s STRING NULL,
 	v FLOAT NOT NULL,
 	t TIMESTAMP NULL DEFAULT NOW(),
-	FAMILY "primary" (rowid),
-	FAMILY fam_1_i (i),
-	FAMILY fam_2_s (s),
-	FAMILY fam_3_v (v),
-	FAMILY fam_4_t (t),
+	FAMILY "primary" (i, v, t, rowid),
+	FAMILY fam_1_s (s),
 	CHECK (i > 0)
 )`,
 		},
@@ -91,9 +85,8 @@ func TestShowCreateTable(t *testing.T) {
 			expect: `CREATE TABLE %s (
 	i INT NULL,
 	s STRING NULL,
-	FAMILY "primary" (rowid),
-	FAMILY fam_1_i (i),
-	FAMILY fam_2_s (s),
+	FAMILY "primary" (i, rowid),
+	FAMILY fam_1_s (s),
 	CONSTRAINT ck CHECK (i > 0)
 )`,
 		},
@@ -120,11 +113,8 @@ func TestShowCreateTable(t *testing.T) {
 	d DATE NULL,
 	INDEX idx_if (f, i) STORING (s, d),
 	UNIQUE INDEX %[1]s_d_key (d),
-	FAMILY "primary" (rowid),
-	FAMILY fam_1_i (i),
-	FAMILY fam_2_f (f),
-	FAMILY fam_3_s (s),
-	FAMILY fam_4_d (d)
+	FAMILY "primary" (i, f, d, rowid),
+	FAMILY fam_1_s (s)
 )`,
 		},
 		{

--- a/sql/sqlbase/structured_test.go
+++ b/sql/sqlbase/structured_test.go
@@ -76,14 +76,9 @@ func TestAllocateIDs(t *testing.T) {
 		Families: []ColumnFamilyDescriptor{
 			{
 				ID: 0, Name: "primary",
-				ColumnNames: []string{"a", "b"},
-				ColumnIDs:   []ColumnID{1, 2},
-			},
-			{
-				ID: 3, Name: "fam_3_c",
-				ColumnNames:     []string{"c"},
-				ColumnIDs:       []ColumnID{3},
-				DefaultColumnID: ColumnID(3),
+				ColumnNames:     []string{"a", "b", "c"},
+				ColumnIDs:       []ColumnID{1, 2, 3},
+				DefaultColumnID: 3,
 			},
 		},
 		PrimaryIndex: IndexDescriptor{
@@ -101,7 +96,7 @@ func TestAllocateIDs(t *testing.T) {
 		},
 		Privileges:     NewDefaultPrivilegeDescriptor(),
 		NextColumnID:   4,
-		NextFamilyID:   4,
+		NextFamilyID:   1,
 		NextIndexID:    4,
 		NextMutationID: 1,
 		FormatVersion:  FamilyFormatVersion,

--- a/sql/testdata/aggregate
+++ b/sql/testdata/aggregate
@@ -476,7 +476,10 @@ CREATE TABLE xyz (
   y INT,
   z FLOAT,
   INDEX xy (x, y),
-  INDEX zyx (z, y, x)
+  INDEX zyx (z, y, x),
+  FAMILY (x),
+  FAMILY (y),
+  FAMILY (z)
 )
 
 statement ok
@@ -705,7 +708,9 @@ false false
 statement OK
 CREATE TABLE ab (
   a INT PRIMARY KEY,
-  b INT
+  b INT,
+  FAMILY (a),
+  FAMILY (b)
 )
 
 statement OK

--- a/sql/testdata/alter_table
+++ b/sql/testdata/alter_table
@@ -94,13 +94,9 @@ query ITTT colnames
 EXPLAIN (DEBUG) SELECT * FROM t
 ----
 RowIdx  Key             Value  Disposition
-0       /t/primary/1    NULL   ROW
-1       /t/primary/2    NULL   PARTIAL
-1       /t/primary/2/b  1      PARTIAL
-1       /t/primary/2/c  1      ROW
-2       /t/primary/3    NULL   PARTIAL
-2       /t/primary/3/b  2      PARTIAL
-2       /t/primary/3/c  1      ROW
+0       /t/primary/1      NULL   ROW
+1       /t/primary/2/b/c  /1/1   ROW
+2       /t/primary/3/b/c  /2/1   ROW
 
 statement ok
 ALTER TABLE t DROP b, DROP c

--- a/sql/testdata/create_index
+++ b/sql/testdata/create_index
@@ -1,7 +1,9 @@
 statement ok
 CREATE TABLE t (
   a INT PRIMARY KEY,
-  b INT
+  b INT,
+  FAMILY (a),
+  FAMILY (b)
 )
 
 statement ok

--- a/sql/testdata/datetime
+++ b/sql/testdata/datetime
@@ -4,7 +4,10 @@ CREATE TABLE t (
   b DATE,
   c INTERVAL,
   UNIQUE (b),
-  UNIQUE (c)
+  UNIQUE (c),
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c)
 )
 
 statement ok

--- a/sql/testdata/family
+++ b/sql/testdata/family
@@ -80,7 +80,7 @@ SELECT * from abcd WHERE a > 1
 
 # Check the descriptor bookkeeping
 statement ok
-ALTER TABLE abcd ADD COLUMN f INT
+ALTER TABLE abcd ADD COLUMN f DECIMAL
 
 query TT
 SHOW CREATE TABLE abcd
@@ -91,11 +91,11 @@ abcd  CREATE TABLE abcd (
       c INT NULL,
       d INT NULL,
       e STRING NULL,
-      f INT NULL,
+      f DECIMAL NULL,
       CONSTRAINT "primary" PRIMARY KEY (a),
       FAMILY f1 (a, b, e),
       FAMILY fam_1_c_d (c, d),
-      FAMILY fam_6_f (f)
+      FAMILY fam_2_f (f)
       )
 
 statement ok
@@ -107,10 +107,10 @@ SHOW CREATE TABLE abcd
 abcd  CREATE TABLE abcd (
       a INT NOT NULL,
       b INT NULL,
-      f INT NULL,
+      f DECIMAL NULL,
       CONSTRAINT "primary" PRIMARY KEY (a),
       FAMILY f1 (a, b),
-      FAMILY fam_6_f (f)
+      FAMILY fam_2_f (f)
       )
 
 statement error unknown family \"foo\"

--- a/sql/testdata/select_non_covering_index
+++ b/sql/testdata/select_non_covering_index
@@ -5,7 +5,11 @@ CREATE TABLE t (
   c INT,
   d INT,
   INDEX b (b),
-  UNIQUE INDEX c (c)
+  UNIQUE INDEX c (c),
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c),
+  FAMILY (d)
 )
 
 statement ok

--- a/sql/testdata/select_non_covering_index_filtering
+++ b/sql/testdata/select_non_covering_index_filtering
@@ -8,7 +8,11 @@ CREATE TABLE t (
   b INT,
   c INT,
   s STRING,
-  INDEX bc (b, c)
+  INDEX bc (b, c),
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c),
+  FAMILY (s)
 )
 
 statement ok

--- a/sql/testdata/table
+++ b/sql/testdata/table
@@ -186,12 +186,10 @@ test.users CREATE TABLE "test.users"
   CONSTRAINT "primary" PRIMARY KEY (id),
   INDEX foo (name),
   UNIQUE INDEX bar (id, name),
-  FAMILY "primary" (id),
-  FAMILY fam_2_name (name),
-  FAMILY fam_3_title (title),
-  FAMILY fam_4_nickname (nickname),
-  FAMILY fam_5_username (username),
-  FAMILY fam_6_email (email),
+  FAMILY "primary" (id, username, email),
+  FAMILY fam_1_name (name),
+  FAMILY fam_2_title (title),
+  FAMILY fam_3_nickname (nickname),
   CHECK (LENGTH(nickname) < LENGTH(name)),
   CHECK (LENGTH(nickname) < 10)
 )
@@ -225,12 +223,10 @@ test.named_constraints  CREATE TABLE "test.named_constraints" (
                         INDEX foo (name),
                         UNIQUE INDEX uq2 (username),
                         UNIQUE INDEX bar (id, name),
-                        FAMILY "primary" (id),
-                        FAMILY fam_2_name (name),
-                        FAMILY fam_3_title (title),
-                        FAMILY fam_4_nickname (nickname),
-                        FAMILY fam_5_username (username),
-                        FAMILY fam_6_email (email),
+                        FAMILY "primary" (id, username, email),
+                        FAMILY fam_1_name (name),
+                        FAMILY fam_2_title (title),
+                        FAMILY fam_3_nickname (nickname),
                         CONSTRAINT ck2 CHECK (LENGTH(nickname) < LENGTH(name)),
                         CONSTRAINT ck1 CHECK (LENGTH(nickname) < 10)
                         )

--- a/sql/testdata/update
+++ b/sql/testdata/update
@@ -248,7 +248,9 @@ CREATE TABLE pks (
   k2 INT,
   v INT,
   PRIMARY KEY (k1, k2),
-  UNIQUE INDEX i (k2, v)
+  UNIQUE INDEX i (k2, v),
+  FAMILY (k1, k2),
+  FAMILY (v)
 )
 
 statement ok


### PR DESCRIPTION
```
name                                    old time/op    new time/op    delta
Bank2_Cockroach-32                        12.2ms ± 6%    14.3ms ±29%     ~             (p=0.690 n=5+5)
Bank4_Cockroach-32                        8.78ms ±25%    9.02ms ±26%     ~             (p=1.000 n=5+5)
Bank8_Cockroach-32                        4.74ms ±25%    4.40ms ±25%     ~             (p=0.548 n=5+5)
Bank16_Cockroach-32                       3.00ms ±47%    3.33ms ±20%     ~             (p=0.310 n=5+5)
Bank32_Cockroach-32                       2.26ms ±20%    1.98ms ±18%     ~             (p=0.310 n=5+5)
Bank64_Cockroach-32                       1.40ms ±23%    1.66ms ±40%     ~             (p=0.222 n=5+5)
Select1_Cockroach-32                      61.7µs ± 1%    64.1µs ± 1%   +3.91%          (p=0.008 n=5+5)
Select2_Cockroach-32                       801µs ± 1%     674µs ± 1%  -15.88%          (p=0.008 n=5+5)
Select3_Cockroach-32                      1.07ms ± 1%    0.94ms ± 1%  -12.33%          (p=0.008 n=5+5)
Insert1_Cockroach-32                       513µs ± 1%     521µs ± 3%     ~             (p=0.056 n=5+5)
Insert10_Cockroach-32                      671µs ± 2%     675µs ± 1%     ~             (p=0.690 n=5+5)
Insert100_Cockroach-32                    1.82ms ± 1%    1.81ms ± 2%     ~             (p=0.222 n=5+5)
Insert1000_Cockroach-32                   12.1ms ± 5%    12.0ms ± 4%     ~             (p=0.421 n=5+5)
Update1_Cockroach-32                       715µs ± 2%     720µs ± 0%     ~             (p=0.095 n=5+5)
Update10_Cockroach-32                     1.14ms ± 2%    1.13ms ± 2%     ~             (p=0.421 n=5+5)
Update100_Cockroach-32                    4.53ms ± 1%    4.33ms ± 2%   -4.46%          (p=0.008 n=5+5)
Update1000_Cockroach-32                   34.5ms ± 1%    33.3ms ± 2%   -3.66%          (p=0.008 n=5+5)
Upsert1_Cockroach-32                      1.75ms ± 1%    1.68ms ± 1%   -4.01%          (p=0.008 n=5+5)
Upsert10_Cockroach-32                     2.20ms ± 2%    1.93ms ± 3%  -12.24%          (p=0.008 n=5+5)
Upsert100_Cockroach-32                    7.24ms ± 3%    4.73ms ± 3%  -34.72%          (p=0.008 n=5+5)
Upsert1000_Cockroach-32                   55.5ms ± 3%    30.4ms ± 3%  -45.30%          (p=0.008 n=5+5)
Delete1_Cockroach-32                       733µs ± 1%     693µs ± 2%   -5.45%          (p=0.008 n=5+5)
Delete10_Cockroach-32                     1.25ms ± 2%    0.85ms ± 2%  -31.91%          (p=0.008 n=5+5)
Delete100_Cockroach-32                    6.33ms ± 0%    2.35ms ± 2%  -62.82%          (p=0.008 n=5+5)
Delete1000_Cockroach-32                   63.4ms ± 3%    17.9ms ± 2%  -71.80%          (p=0.008 n=5+5)
Scan1_Cockroach-32                         182µs ± 2%     185µs ± 1%     ~             (p=0.095 n=5+5)
Scan10_Cockroach-32                        210µs ± 2%     214µs ± 2%     ~             (p=0.151 n=5+5)
Scan100_Cockroach-32                       479µs ± 1%     488µs ± 1%   +1.68%          (p=0.008 n=5+5)
Scan1000_Cockroach-32                     2.68ms ± 2%    2.74ms ± 2%     ~             (p=0.095 n=5+5)
Scan10000_Cockroach-32                    23.9ms ± 1%    24.3ms ± 4%     ~             (p=0.151 n=5+5)
Scan1000Limit1_Cockroach-32                192µs ± 1%     195µs ± 2%     ~             (p=0.095 n=5+5)
Scan1000Limit10_Cockroach-32               223µs ± 2%     227µs ± 2%     ~             (p=0.095 n=5+5)
Scan1000Limit100_Cockroach-32              477µs ± 1%     484µs ± 3%     ~             (p=0.095 n=5+5)
Scan10000FilterLimit1_Cockroach-32         379µs ± 1%     384µs ± 2%     ~             (p=0.056 n=5+5)
Scan10000FilterLimit10_Cockroach-32        427µs ± 1%     429µs ± 4%     ~             (p=1.000 n=5+5)
Scan10000FilterLimit50_Cockroach-32       2.49ms ± 2%    2.47ms ± 1%     ~             (p=0.690 n=5+5)
Sort100000Limit10_Cockroach-32             483ms ± 1%     220ms ± 5%  -54.45%          (p=0.008 n=5+5)
Sort100000Limit10Distinct_Cockroach-32     498ms ± 2%     239ms ± 2%  -52.09%          (p=0.008 n=5+5)
TrackChoices1_Cockroach-32                 582µs ± 2%     574µs ± 2%     ~             (p=0.222 n=5+5)
TrackChoices10_Cockroach-32                117µs ± 3%     110µs ± 5%   -5.64%          (p=0.016 n=5+5)
TrackChoices100_Cockroach-32              66.1µs ± 2%    61.5µs ± 4%   -6.95%          (p=0.008 n=5+5)
TrackChoices1000_Cockroach-32             62.7µs ± 4%    54.2µs ± 3%  -13.62%          (p=0.008 n=5+5)
InsertDistinct1_Cockroach-32              1.56ms ± 2%    1.59ms ± 2%     ~             (p=0.151 n=5+5)
InsertDistinct10_Cockroach-32             1.09ms ± 2%    1.19ms ± 7%   +9.64%          (p=0.032 n=5+5)
InsertDistinct100_Cockroach-32            1.34ms ± 2%    1.80ms ±15%  +34.41%          (p=0.008 n=5+5)
WideTable1_Cockroach-32                   2.19ms ± 1%    2.31ms ± 2%   +5.44%          (p=0.008 n=5+5)
WideTable10_Cockroach-32                  3.42ms ± 1%    3.68ms ± 2%   +7.43%          (p=0.008 n=5+5)
WideTable100_Cockroach-32                 15.2ms ± 2%    16.0ms ± 1%   +4.99%          (p=0.008 n=5+5)
WideTable1000_Cockroach-32                 132ms ± 2%     136ms ± 2%   +2.83%          (p=0.016 n=5+5)
PgbenchQuery_Cockroach-32                 3.21ms ± 2%    3.08ms ± 2%   -4.07%          (p=0.016 n=5+5)
ParallelPgbenchQuery_Cockroach-32        32.7ms ±114%    25.7ms ±47%     ~             (p=0.421 n=5+5)

name                                    old alloc/op   new alloc/op   delta
Bank2_Cockroach-32                        1.08MB ±24%    1.16MB ± 7%     ~             (p=0.548 n=5+5)
Bank4_Cockroach-32                         862kB ±34%     828kB ±27%     ~             (p=0.690 n=5+5)
Bank8_Cockroach-32                         558kB ±12%     580kB ±17%     ~             (p=0.548 n=5+5)
Bank16_Cockroach-32                        429kB ± 4%     444kB ±14%     ~             (p=0.690 n=5+5)
Bank32_Cockroach-32                        345kB ±12%     329kB ±10%     ~             (p=0.548 n=5+5)
Bank64_Cockroach-32                        256kB ± 4%     263kB ± 1%     ~             (p=0.056 n=5+5)
Select1_Cockroach-32                      3.73kB ± 0%    3.73kB ± 0%     ~             (p=0.063 n=5+5)
Select2_Cockroach-32                      91.8kB ± 0%    71.4kB ± 0%  -22.25%          (p=0.008 n=5+5)
Select3_Cockroach-32                       136kB ± 0%     116kB ± 0%  -15.00%          (p=0.008 n=5+5)
Insert1_Cockroach-32                      29.8kB ± 0%    29.8kB ± 0%     ~             (p=0.421 n=5+5)
Insert10_Cockroach-32                     74.9kB ± 0%    74.9kB ± 0%     ~             (p=0.333 n=5+5)
Insert100_Cockroach-32                     488kB ± 0%     488kB ± 0%     ~             (p=0.841 n=5+5)
Insert1000_Cockroach-32                   4.18MB ± 0%    4.18MB ± 0%     ~             (p=0.841 n=5+5)
Update1_Cockroach-32                      51.7kB ± 0%    51.6kB ± 0%   -0.14%          (p=0.008 n=5+5)
Update10_Cockroach-32                      122kB ± 0%     120kB ± 0%   -1.57%          (p=0.016 n=4+5)
Update100_Cockroach-32                     795kB ± 0%     774kB ± 0%   -2.68%          (p=0.016 n=4+5)
Update1000_Cockroach-32                   6.59MB ± 0%    6.39MB ± 0%   -3.01%          (p=0.029 n=4+4)
Upsert1_Cockroach-32                       104kB ± 0%      98kB ± 0%   -6.01%          (p=0.008 n=5+5)
Upsert10_Cockroach-32                      172kB ± 0%     129kB ± 0%  -25.06%          (p=0.008 n=5+5)
Upsert100_Cockroach-32                     942kB ± 0%     554kB ± 0%  -41.22%          (p=0.008 n=5+5)
Upsert1000_Cockroach-32                   7.87MB ± 1%    4.48MB ± 0%  -43.10%          (p=0.008 n=5+5)
Delete1_Cockroach-32                      45.3kB ± 0%    44.0kB ± 0%   -2.87%          (p=0.008 n=5+5)
Delete10_Cockroach-32                     70.3kB ± 0%    54.1kB ± 0%  -23.06%          (p=0.008 n=5+5)
Delete100_Cockroach-32                     307kB ± 0%     155kB ± 0%  -49.35%          (p=0.008 n=5+5)
Delete1000_Cockroach-32                   3.19MB ± 0%    1.07MB ± 0%  -66.46%          (p=0.016 n=4+5)
Scan1_Cockroach-32                        16.0kB ± 0%    16.0kB ± 0%     ~             (p=0.365 n=5+5)
Scan10_Cockroach-32                       19.5kB ± 0%    19.5kB ± 0%     ~             (p=0.968 n=5+5)
Scan100_Cockroach-32                      50.5kB ± 0%    50.5kB ± 0%     ~             (p=0.730 n=5+5)
Scan1000_Cockroach-32                      318kB ± 0%     318kB ± 0%     ~             (p=1.000 n=5+5)
Scan10000_Cockroach-32                    5.54MB ± 0%    5.54MB ± 0%     ~             (p=0.841 n=5+5)
Scan1000Limit1_Cockroach-32               16.6kB ± 0%    16.6kB ± 0%     ~             (p=0.952 n=5+5)
Scan1000Limit10_Cockroach-32              19.9kB ± 0%    19.9kB ± 0%     ~             (p=0.667 n=5+5)
Scan1000Limit100_Cockroach-32             50.8kB ± 0%    50.8kB ± 0%     ~             (p=0.992 n=5+5)
Scan10000FilterLimit1_Cockroach-32        48.6kB ± 0%    48.6kB ± 0%     ~             (p=0.421 n=5+5)
Scan10000FilterLimit10_Cockroach-32       54.8kB ± 0%    54.8kB ± 0%     ~             (p=1.000 n=5+5)
Scan10000FilterLimit50_Cockroach-32        462kB ± 0%     462kB ± 0%     ~             (p=0.952 n=5+5)
Sort100000Limit10_Cockroach-32             118MB ± 0%      42MB ± 0%  -64.13%          (p=0.029 n=4+4)
Sort100000Limit10Distinct_Cockroach-32     136MB ± 0%      60MB ± 0%  -55.87%          (p=0.008 n=5+5)
TrackChoices1_Cockroach-32                46.6kB ± 0%    44.0kB ± 0%   -5.68%          (p=0.008 n=5+5)
TrackChoices10_Cockroach-32               23.5kB ± 0%    16.5kB ± 0%  -29.72%          (p=0.008 n=5+5)
TrackChoices100_Cockroach-32              20.0kB ± 0%    16.0kB ± 0%  -19.99%          (p=0.008 n=5+5)
TrackChoices1000_Cockroach-32             22.7kB ± 0%    17.8kB ± 0%  -21.70%          (p=0.016 n=4+5)
InsertDistinct1_Cockroach-32               303kB ± 0%     303kB ± 0%     ~             (p=0.635 n=5+5)
InsertDistinct10_Cockroach-32              316kB ± 0%     323kB ± 2%   +2.41%          (p=0.008 n=5+5)
InsertDistinct100_Cockroach-32             473kB ± 0%     540kB ±19%  +14.19%          (p=0.032 n=5+5)
WideTable1_Cockroach-32                    170kB ± 0%     170kB ± 0%   +0.52%          (p=0.016 n=5+4)
WideTable10_Cockroach-32                   373kB ± 0%     374kB ± 0%   +0.36%          (p=0.008 n=5+5)
WideTable100_Cockroach-32                 2.36MB ± 0%    2.36MB ± 0%   +0.15%          (p=0.008 n=5+5)
WideTable1000_Cockroach-32                21.2MB ± 0%    21.2MB ± 0%     ~             (p=0.056 n=5+5)
PgbenchQuery_Cockroach-32                  277kB ± 0%     247kB ± 0%  -10.68%          (p=0.029 n=4+4)
ParallelPgbenchQuery_Cockroach-32         1.41MB ± 4%    1.33MB ± 6%     ~             (p=0.056 n=5+5)

name                                    old allocs/op  new allocs/op  delta
Bank2_Cockroach-32                         11.6k ±20%     12.5k ± 8%     ~             (p=0.421 n=5+5)
Bank4_Cockroach-32                         9.56k ±30%     9.20k ±21%     ~             (p=0.841 n=5+5)
Bank8_Cockroach-32                         6.45k ±10%     6.64k ±15%     ~             (p=0.548 n=5+5)
Bank16_Cockroach-32                        5.00k ± 4%     5.10k ±12%     ~             (p=0.690 n=5+5)
Bank32_Cockroach-32                        4.03k ±10%     3.89k ± 7%     ~             (p=0.690 n=5+5)
Bank64_Cockroach-32                        3.03k ± 4%     3.14k ± 1%     ~             (p=0.056 n=5+5)
Select1_Cockroach-32                        58.0 ± 0%      58.0 ± 0%     ~     (all samples are equal)
Select2_Cockroach-32                       1.20k ± 0%     1.19k ± 0%   -0.72%          (p=0.000 n=5+4)
Select3_Cockroach-32                       2.06k ± 0%     2.05k ± 0%     ~             (p=0.079 n=4+5)
Insert1_Cockroach-32                         300 ± 0%       300 ± 0%     ~     (all samples are equal)
Insert10_Cockroach-32                        508 ± 0%       508 ± 0%     ~     (all samples are equal)
Insert100_Cockroach-32                     2.35k ± 0%     2.35k ± 0%     ~             (p=1.000 n=5+5)
Insert1000_Cockroach-32                    20.5k ± 0%     20.5k ± 0%     ~             (p=0.524 n=5+5)
Update1_Cockroach-32                         575 ± 0%       580 ± 0%   +0.87%          (p=0.008 n=5+5)
Update10_Cockroach-32                        887 ± 0%       884 ± 0%     ~             (p=0.079 n=4+5)
Update100_Cockroach-32                     3.68k ± 0%     3.59k ± 0%   -2.43%          (p=0.000 n=5+4)
Update1000_Cockroach-32                    29.7k ± 0%     28.8k ± 0%   -2.88%          (p=0.029 n=4+4)
Upsert1_Cockroach-32                       1.15k ± 0%     1.12k ± 0%   -2.79%          (p=0.008 n=5+5)
Upsert10_Cockroach-32                      1.54k ± 0%     1.40k ± 0%   -9.36%          (p=0.008 n=5+5)
Upsert100_Cockroach-32                     5.70k ± 0%     4.36k ± 0%  -23.46%          (p=0.008 n=5+5)
Upsert1000_Cockroach-32                    46.8k ± 0%     33.4k ± 0%  -28.55%          (p=0.008 n=5+5)
Delete1_Cockroach-32                         479 ± 0%       466 ± 0%   -2.71%          (p=0.029 n=4+4)
Delete10_Cockroach-32                        684 ± 0%       591 ± 0%  -13.71%          (p=0.008 n=5+5)
Delete100_Cockroach-32                     2.60k ± 0%     1.69k ± 0%  -34.87%          (p=0.008 n=5+5)
Delete1000_Cockroach-32                    21.6k ± 0%     12.6k ± 0%  -41.81%          (p=0.016 n=4+5)
Scan1_Cockroach-32                           200 ± 0%       200 ± 0%     ~     (all samples are equal)
Scan10_Cockroach-32                          227 ± 0%       227 ± 0%     ~     (all samples are equal)
Scan100_Cockroach-32                         425 ± 0%       425 ± 0%     ~     (all samples are equal)
Scan1000_Cockroach-32                      2.31k ± 0%     2.31k ± 0%     ~             (p=0.873 n=5+5)
Scan10000_Cockroach-32                     21.2k ± 0%     21.2k ± 0%     ~             (p=1.000 n=5+5)
Scan1000Limit1_Cockroach-32                  207 ± 0%       207 ± 0%     ~     (all samples are equal)
Scan1000Limit10_Cockroach-32                 233 ± 0%       233 ± 0%     ~     (all samples are equal)
Scan1000Limit100_Cockroach-32                430 ± 0%       430 ± 0%     ~     (all samples are equal)
Scan10000FilterLimit1_Cockroach-32           509 ± 0%       509 ± 0%     ~     (all samples are equal)
Scan10000FilterLimit10_Cockroach-32          563 ± 0%       563 ± 0%     ~     (all samples are equal)
Scan10000FilterLimit50_Cockroach-32        1.80k ± 0%     1.80k ± 0%     ~             (p=0.167 n=5+5)
Sort100000Limit10_Cockroach-32             75.1k ± 0%     60.3k ± 0%  -19.74%          (p=0.029 n=4+4)
Sort100000Limit10Distinct_Cockroach-32      135k ± 0%      120k ± 0%  -10.93%          (p=0.008 n=5+5)
TrackChoices1_Cockroach-32                   397 ± 0%       387 ± 0%   -2.52%          (p=0.008 n=5+5)
TrackChoices10_Cockroach-32                  117 ± 0%       107 ± 0%   -8.55%          (p=0.008 n=5+5)
TrackChoices100_Cockroach-32                86.0 ± 0%      77.0 ± 0%  -10.47%          (p=0.000 n=5+4)
TrackChoices1000_Cockroach-32               83.0 ± 0%      73.0 ± 0%     ~             (p=0.079 n=4+5)
InsertDistinct1_Cockroach-32               1.90k ± 0%     1.90k ± 0%     ~             (p=0.079 n=5+5)
InsertDistinct10_Cockroach-32              1.97k ± 0%     2.06k ± 0%   +4.62%          (p=0.016 n=5+4)
InsertDistinct100_Cockroach-32             3.32k ± 0%     3.90k ±22%  +17.51%          (p=0.032 n=5+5)
WideTable1_Cockroach-32                    1.96k ± 0%     1.96k ± 0%   +0.41%          (p=0.016 n=5+4)
WideTable10_Cockroach-32                   4.01k ± 0%     4.02k ± 0%   +0.27%          (p=0.008 n=5+5)
WideTable100_Cockroach-32                  24.0k ± 0%     24.0k ± 0%   +0.13%          (p=0.008 n=5+5)
WideTable1000_Cockroach-32                  223k ± 0%      224k ± 0%     ~             (p=0.690 n=5+5)
PgbenchQuery_Cockroach-32                  2.89k ± 0%     2.85k ± 0%   -1.28%          (p=0.029 n=4+4)
ParallelPgbenchQuery_Cockroach-32          13.9k ± 4%     13.8k ± 7%     ~             (p=0.841 n=5+5)
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7623)

<!-- Reviewable:end -->
