### PR TITLE
acceptance/cluster: fix local acceptance tests

### DIFF
--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -78,7 +78,7 @@ func defaultBinary() string {
 	if len(gopath) == 0 {
 		return ""
 	}
-	return gopath[0] + "/bin/linux_amd64/cockroach"
+	return gopath[0] + "/bin/docker_amd64/cockroach"
 }
 
 func exists(path string) bool {


### PR DESCRIPTION
Broken by the switch from linux_amd64 to docker_amd64.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7651)

<!-- Reviewable:end -->
