### PR TITLE
sql/pgwire: Support TimestampTZ in decodeOidDatum

### DIFF
--- a/sql/pgwire/types.go
+++ b/sql/pgwire/types.go
@@ -600,7 +600,7 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 		default:
 			return d, errors.Errorf("unsupported bytea format code: %s", code)
 		}
-	case oid.T_timestamp, oid.T_timestamptz:
+	case oid.T_timestamp:
 		switch code {
 		case formatText:
 			ts, err := parseTs(string(b))
@@ -610,6 +610,17 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 			d = parser.MakeDTimestamp(ts, time.Microsecond)
 		default:
 			return d, errors.Errorf("unsupported timestamp format code: %s", code)
+		}
+	case oid.T_timestamptz:
+		switch code {
+		case formatText:
+			ts, err := parseTs(string(b))
+			if err != nil {
+				return d, errors.Errorf("could not parse string %q as timestamp", b)
+			}
+			d = parser.MakeDTimestampTZ(ts, time.Microsecond)
+		default:
+			return d, errors.Errorf("unsupported timestamptz format code: %s", code)
 		}
 	case oid.T_date:
 		switch code {

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -771,8 +771,7 @@ func TestPGPreparedExec(t *testing.T) {
 			},
 		},
 		{
-			// TODO(dt, nvanbenschoten): can we avoid this cast? #7647
-			"INSERT INTO d.types VALUES ($1, $2, $3, $4, $5, $6, $7::timestamptz, $8, $9, $10)",
+			"INSERT INTO d.types VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
 			[]preparedExecTest{
 				base.RowsAffected(1).SetArgs(
 					int64(0),


### PR DESCRIPTION
Fixes #7647.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7664)

<!-- Reviewable:end -->
