### PR TITLE
sql: Improve error message for PREPARE/EXECUTE stmts

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/distsql"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/duration"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -887,6 +888,16 @@ func (e *Executor) execStmtInOpenTxn(
 			// txn in a different state.
 			err = errNotRetriable
 		}
+		txnState.updateStateAndCleanupOnErr(err, e)
+		return Result{Err: err}, err
+	case *parser.Prepare:
+		err := util.UnimplementedWithIssueErrorf(7568,
+			"Prepared statements are supported only via the Postgres wire protocol")
+		txnState.updateStateAndCleanupOnErr(err, e)
+		return Result{Err: err}, err
+	case *parser.Execute:
+		err := util.UnimplementedWithIssueErrorf(7568,
+			"Executing prepared statements is supported only via the Postgres wire protocol")
 		txnState.updateStateAndCleanupOnErr(err, e)
 		return Result{Err: err}, err
 	case *parser.Deallocate:

--- a/sql/testdata/prepare
+++ b/sql/testdata/prepare
@@ -1,7 +1,7 @@
-statement error unknown statement type: \*parser.Prepare
+statement error unimplemented: Prepared statements are supported only via the Postgres wire protocol \(see issue https://github.com/cockroachdb/cockroach/issues/7568\)
 PREPARE a AS SELECT 1
 
-statement error unknown statement type: \*parser.Execute
+statement error unimplemented: Executing prepared statements is supported only via the Postgres wire protocol \(see issue https://github.com/cockroachdb/cockroach/issues/7568\)
 EXECUTE a
 
 # TODO(nvanbenschoten) This deserves more robust testing, but that is hard


### PR DESCRIPTION
This links the error messages back to the open issue.

Requested by @jseldess

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7667)

<!-- Reviewable:end -->
