### PR TITLE
storage: disable handleRaftReady concurrency

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -19,7 +19,6 @@ package storage
 import (
 	"bytes"
 	"fmt"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -86,7 +85,9 @@ var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeTy
 	roachpb.REMOVE_REPLICA: raftpb.ConfChangeRemoveNode,
 }
 
-var storeReplicaRaftReadyConcurrency = 2 * runtime.NumCPU()
+// TODO(tschottdorf): It's currently unsafe to set this to any other value due
+// to concurrency issues. See #7672 and the discussion within.
+const storeReplicaRaftReadyConcurrency = 1
 
 // TestStoreContext has some fields initialized with values relevant
 // in tests.


### PR DESCRIPTION
We discovered that this exacerbates (and makes harder to fix) problems
discovered in #7600.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7673)

<!-- Reviewable:end -->
