### PR TITLE
Log cluster events to local log

### DIFF
--- a/sql/event_log.go
+++ b/sql/event_log.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/pkg/errors"
 )
 
@@ -90,6 +91,12 @@ func MakeEventLogger(leaseMgr *LeaseManager) EventLogger {
 // InsertEventRecord inserts a single event into the event log as part of the
 // provided transaction.
 func (ev EventLogger) InsertEventRecord(txn *client.Txn, eventType EventLogType, targetID, reportingID int32, info interface{}) error {
+	// Record event record insertion in local log output.
+	log.Infoc(txn.Context, "Event: %q, target: %d, info: %+v",
+		eventType,
+		targetID,
+		info)
+
 	const insertEventTableStmt = `
 INSERT INTO system.eventlog (
   timestamp, eventType, targetID, reportingID, info

--- a/storage/log.go
+++ b/storage/log.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/pkg/errors"
 )
 
@@ -72,6 +73,16 @@ type rangeLogEvent struct {
 }
 
 func (s *Store) insertRangeLogEvent(txn *client.Txn, event rangeLogEvent) error {
+	// Record range log event to console log.
+	var info string
+	if event.info != nil {
+		info = *event.info
+	}
+	log.Infoc(txn.Context, "Range Event: %q, range: %d, info: %s",
+		event.eventType,
+		event.rangeID,
+		info)
+
 	const insertEventTableStmt = `
 INSERT INTO system.rangelog (
   timestamp, rangeID, storeID, eventType, otherRangeID, info


### PR DESCRIPTION
All events recorded to the event log or range event log now result in a console
log message. This is a suggested fix for #5306.

Resolves #5306

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7681)

<!-- Reviewable:end -->
