### PR TITLE
storage: remove empty `else {}` block

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1961,7 +1961,6 @@ func (r *Replica) applyRaftCommand(
 	})
 	if err := batch.Commit(); err != nil {
 		rErr = roachpb.NewError(newReplicaCorruptionError(errors.Errorf("could not commit batch"), err, rErr.GoError()))
-	} else {
 	}
 
 	// On successful write commands handle write-related triggers including


### PR DESCRIPTION
Introduced in https://github.com/cockroachdb/cockroach/commit/d1bdb193d5bf3906096591fd7044956cf0f93c76#diff-a7f2d9c7dc147a31309311a50721ed2bR1871

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7685)

<!-- Reviewable:end -->
