### PR TITLE
cli: add `debug keys --sizes`

### DIFF
--- a/cli/cliflags/names.go
+++ b/cli/cliflags/names.go
@@ -44,6 +44,7 @@ const (
 	FromName              = "from"
 	ToName                = "to"
 	ValuesName            = "values"
+	SizesName             = "sizes"
 	RaftTickIntervalName  = "raft-tick-interval"
 	UndoFreezeClusterName = "undo"
 )

--- a/cli/context.go
+++ b/cli/context.go
@@ -143,4 +143,5 @@ func (k *mvccKey) Type() string {
 type debugContext struct {
 	startKey, endKey engine.MVCCKey
 	values           bool
+	sizes            bool
 }

--- a/cli/debug.go
+++ b/cli/debug.go
@@ -73,16 +73,22 @@ func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (*engine.R
 }
 
 func printKey(kv engine.MVCCKeyValue) (bool, error) {
-	fmt.Printf("%q\n", kv.Key)
-
+	fmt.Printf("%s", kv.Key)
+	if debugCtx.sizes {
+		fmt.Printf(" %d %d", len(kv.Key.Key), len(kv.Value))
+	}
+	fmt.Printf("\n")
 	return false, nil
 }
 
 func printKeyValue(kv engine.MVCCKeyValue) (bool, error) {
 	if kv.Key.Timestamp != hlc.ZeroTimestamp {
-		fmt.Printf("%s %q: ", kv.Key.Timestamp, kv.Key.Key)
+		fmt.Printf("%s %s: ", kv.Key.Timestamp, kv.Key.Key)
 	} else {
-		fmt.Printf("%q: ", kv.Key.Key)
+		fmt.Printf("%s: ", kv.Key.Key)
+	}
+	if debugCtx.sizes {
+		fmt.Printf("%d %d: ", len(kv.Key.Key), len(kv.Value))
 	}
 	decoders := []func(kv engine.MVCCKeyValue) (string, error){
 		tryRaftLogEntry,

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -236,6 +236,9 @@ Exclusive end key and format as [<format>:]<key>. Supported formats:
 	cliflags.ValuesName: wrapText(`
 Print values along with their associated key.`),
 
+	cliflags.SizesName: wrapText(`
+Print key and value sizes along with their associated key.`),
+
 	cliflags.RaftTickIntervalName: wrapText(`
 The resolution of the Raft timer; other raft timeouts are
 defined in terms of multiples of this value.`),
@@ -498,6 +501,7 @@ func init() {
 		f.Var((*mvccKey)(&debugCtx.startKey), cliflags.FromName, usageNoEnv(cliflags.FromName))
 		f.Var((*mvccKey)(&debugCtx.endKey), cliflags.ToName, usageNoEnv(cliflags.ToName))
 		f.BoolVar(&debugCtx.values, cliflags.ValuesName, false, usageNoEnv(cliflags.ValuesName))
+		f.BoolVar(&debugCtx.sizes, cliflags.SizesName, false, usageNoEnv(cliflags.SizesName))
 	}
 
 	{


### PR DESCRIPTION
Add a flag to print the sizes of keys and values.

Remove the unnecessary quoting of the keys.

See #7693.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7696)

<!-- Reviewable:end -->
