### PR TITLE
storage: add test to prevent regression of #7600

### DIFF
--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -29,6 +29,11 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
 )
 
+// HandleRaftMessage delegates to handleRaftMessage.
+func (s *Store) HandleRaftMessage(req *RaftMessageRequest) error {
+	return s.handleRaftMessage(req)
+}
+
 // ComputeMVCCStats immediately computes correct total MVCC usage statistics
 // for the store, returning the computed values (but without modifying the
 // store).

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -85,9 +85,9 @@ const (
 // simpler with this being turned off.
 var txnAutoGC = true
 
-// raftInitialLogIndex is the starting point for the raft log. We bootstrap
-// the raft membership by synthesizing a snapshot as if there were some
-// discarded prefix to the log, so we must begin the log at an arbitrary
+// raftInitialLog{Index,Term} are the starting points for the raft log. We
+// bootstrap the raft membership by synthesizing a snapshot as if there were
+// some discarded prefix to the log, so we must begin the log at an arbitrary
 // index greater than 1.
 const (
 	raftInitialLogIndex = 10


### PR DESCRIPTION
This took quite a bit of fiddling, but that version fails both test
and testrace almost instantly (<30iters) when the code added in #7672
is disabled (and even faster with more aggressive Raft tick intervals).
It does not catch the clobbering that could happen if
storeReplicaRaftReadyConcurrency were increased, at least not within 500
iterations.

Closes #7600.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7700)

<!-- Reviewable:end -->
