### PR TITLE
Makefile: error out if bash is not available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ export PATH := $(GOPATH)/bin:$(PATH)
 # is one way to do this globally.
 # http://stackoverflow.com/questions/8941110/how-i-could-add-dir-to-path-in-makefile/13468229#13468229
 SHELL := $(shell which bash)
+ifeq ($(SHELL),)
+$(error bash is required)
+endif
 export GIT_PAGER :=
 
 # Note: We pass `-v` to `go build` and `go test -i` so that warnings


### PR DESCRIPTION
If bash is not installed, SHELL will be empty. Error out to avoid a cryptic
error.

Fixes #7698.

Tested by temporarily changing `bash` to something else in `SHELL := $(shell which bash)`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7707)

<!-- Reviewable:end -->
