### PR TITLE
kv: avoid data race in TxnCoordSender.tryAsyncAbort

### DIFF
--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -626,7 +626,8 @@ func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context, txnID uuid.UUID) {
 func (tc *TxnCoordSender) tryAsyncAbort(txnID uuid.UUID) {
 	tc.Lock()
 	txnMeta := tc.txns[txnID]
-	// Grab the intents and clone the txn to avoid data races.
+	// Clone the intents and the txn to avoid data races.
+	txnMeta.keys = append([]roachpb.Span(nil), txnMeta.keys...)
 	roachpb.MergeSpans(&txnMeta.keys)
 	intentSpans := txnMeta.keys
 	txnMeta.keys = nil


### PR DESCRIPTION
Fixes #7726.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7738)

<!-- Reviewable:end -->
