### PR TITLE
build: fix go1.7 vet issues

### DIFF
--- a/sql/distsql/input_sync_test.go
+++ b/sql/distsql/input_sync_test.go
@@ -54,7 +54,10 @@ func TestOrderedSync(t *testing.T) {
 					{v[4], v[4], v[4]},
 				},
 			},
-			ordering: sqlbase.ColumnOrdering{{0, asc}, {1, asc}},
+			ordering: sqlbase.ColumnOrdering{
+				{ColIdx: 0, Direction: asc},
+				{ColIdx: 1, Direction: asc},
+			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], v[0], v[0]},
 				{v[0], v[1], v[4]},
@@ -82,7 +85,11 @@ func TestOrderedSync(t *testing.T) {
 					{v[0], v[0], v[0]},
 				},
 			},
-			ordering: sqlbase.ColumnOrdering{{1, desc}, {0, asc}, {2, asc}},
+			ordering: sqlbase.ColumnOrdering{
+				{ColIdx: 1, Direction: desc},
+				{ColIdx: 0, Direction: asc},
+				{ColIdx: 2, Direction: asc},
+			},
 			expected: sqlbase.EncDatumRows{
 				{v[3], v[4], v[1]},
 				{v[4], v[4], v[4]},

--- a/sql/group.go
+++ b/sql/group.go
@@ -458,7 +458,7 @@ func desiredAggregateOrdering(funcs []*aggregateFuncHolder) sqlbase.ColumnOrderi
 	if limit == -1 {
 		return nil
 	}
-	return sqlbase.ColumnOrdering{{limit, direction}}
+	return sqlbase.ColumnOrdering{{ColIdx: limit, Direction: direction}}
 }
 
 type extractAggregatesVisitor struct {

--- a/sql/group_test.go
+++ b/sql/group_test.go
@@ -33,8 +33,8 @@ func TestDesiredAggregateOrder(t *testing.T) {
 		ordering sqlbase.ColumnOrdering
 	}{
 		{`a`, nil},
-		{`MIN(a)`, sqlbase.ColumnOrdering{{0, encoding.Ascending}}},
-		{`MAX(a)`, sqlbase.ColumnOrdering{{0, encoding.Descending}}},
+		{`MIN(a)`, sqlbase.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}},
+		{`MAX(a)`, sqlbase.ColumnOrdering{{ColIdx: 0, Direction: encoding.Descending}}},
 		{`(MIN(a), MAX(a))`, nil},
 		{`(MIN(a), AVG(a))`, nil},
 		{`(MIN(a), COUNT(a))`, nil},

--- a/sql/show.go
+++ b/sql/show.go
@@ -398,8 +398,11 @@ func (p *planner) ShowConstraints(n *parser.ShowConstraints) (planNode, error) {
 
 	// Sort the results by constraint name.
 	sort := &sortNode{
-		ordering: sqlbase.ColumnOrdering{{0, encoding.Ascending}, {1, encoding.Ascending}},
-		columns:  v.columns,
+		ordering: sqlbase.ColumnOrdering{
+			{ColIdx: 0, Direction: encoding.Ascending},
+			{ColIdx: 1, Direction: encoding.Ascending},
+		},
+		columns: v.columns,
 	}
 	return &selectTopNode{source: v, sort: sort}, nil
 }

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -50,8 +50,8 @@ var traceColumns = append([]ResultColumn{
 }, debugColumns...)
 
 var traceOrdering = sqlbase.ColumnOrdering{
-	{len(traceColumns), encoding.Ascending}, /* Start time */
-	{2, encoding.Ascending},                 /* Span pos */
+	{ColIdx: len(traceColumns), Direction: encoding.Ascending}, /* Start time */
+	{ColIdx: 2, Direction: encoding.Ascending},                 /* Span pos */
 }
 
 func makeTraceNode(plan planNode, txn *client.Txn) planNode {

--- a/util/duration/duration.go
+++ b/util/duration/duration.go
@@ -180,7 +180,7 @@ func (d Duration) normalize() Duration {
 }
 
 func (d Duration) shiftPosDaysToMonths() Duration {
-	var maxMonths int64 = math.MaxInt64
+	var maxMonths = int64(math.MaxInt64)
 	if d.Months > 0 {
 		// If d.Months < 0, then this would overflow, but because of the exchange
 		// rate, we can never transfer more than math.MaxInt64 anyway.
@@ -193,7 +193,7 @@ func (d Duration) shiftPosDaysToMonths() Duration {
 }
 
 func (d Duration) shiftPosNanosToDays() Duration {
-	var maxDays int64 = math.MaxInt64
+	var maxDays = int64(math.MaxInt64)
 	if d.Days > 0 {
 		// If d.Days < 0, then this would overflow, but because of the exchange
 		// rate, we can never transfer more than math.MaxInt64 anyway.
@@ -206,7 +206,7 @@ func (d Duration) shiftPosNanosToDays() Duration {
 }
 
 func (d Duration) shiftNegDaysToMonths() Duration {
-	var minMonths int64 = math.MinInt64
+	var minMonths = int64(math.MinInt64)
 	if d.Months < 0 {
 		// If d.Months > 0, then this would overflow, but because of the exchange
 		// rate, we can never transfer more than math.MaxInt64 anyway.
@@ -219,7 +219,7 @@ func (d Duration) shiftNegDaysToMonths() Duration {
 }
 
 func (d Duration) shiftNegNanosToDays() Duration {
-	var minDays int64 = math.MinInt64
+	var minDays = int64(math.MinInt64)
 	if d.Days < 0 {
 		// If d.Days > 0, then this would overflow, but because of the exchange
 		// rate, we can never transfer more than math.MaxInt64 anyway.


### PR DESCRIPTION
Primarily issues with unkeyed literals for sqlbase.ColumnOrderInfo.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7740)

<!-- Reviewable:end -->
