### PR TITLE
storage: fix intent resolution edge case, document write timestamps

### DIFF
--- a/roachpb/data.pb.go
+++ b/roachpb/data.pb.go
@@ -377,6 +377,36 @@ type Transaction struct {
 	// The original timestamp at which the transaction started. For serializable
 	// transactions, if the timestamp drifts from the original timestamp, the
 	// transaction will retry.
+	//
+	// This timestamp is the one at which all transactions will read. It is also,
+	// surprisingly, the timestamp at which transactions will _write_. This is
+	// ultimately because of correctness concerns around SNAPSHOT transactions.
+	// Note first that for SERIALIZABLE transactions, the original and commit
+	// timestamps must not diverge, and so an intent which may be committed is
+	// always written when both timestamps coincide.
+	//
+	// For a SNAPSHOT transaction however, this is not the case. Intuitively,
+	// one could think that the timestamp at which intents should be written
+	// should be the provisional commit timestamp, and while this is morally
+	// true, consider the following scenario, where txn1 is a SNAPSHOT txn:
+	//
+	// - txn1 at orig_timestamp=5 reads key1: {Amount: 1, Price: 10}
+	// - txn1 writes elsewhere, has its commit timestamp increased to 20.
+	// - txn2 at orig_timestamp=10 reads key1: {Amount: 1, Price: 10}
+	// - txn2 increases Price by 5: {Amount: 1, Price: 15} and commits
+	// - txn1 increases Amount by 1: {Amount: 2, Price: 10}, attempts commit
+	//
+	// If txn1 uses its orig_timestamp for updating key1 (as it does), it
+	// conflicts with txn2's committed value (which is at timestamp 10, in the
+	// future of 5), and restarts.
+	// Using instead its candidate commit timestamp, it wouldn't see a conflict
+	// and commit, but this is not the expected outcome {Amount: 2, Price: 15}
+	// and we are experiencing the Lost Update Anomaly.
+	//
+	// Note that in practice, before restarting, txn1 would still lay down an
+	// intent (just above the committed value) not with the intent to commit it,
+	// but to avoid being starved by short-lived transactions on that key which
+	// would otherwise not have to go through conflict resolution with txn1.
 	OrigTimestamp cockroach_util_hlc.Timestamp `protobuf:"bytes,6,opt,name=orig_timestamp,json=origTimestamp" json:"orig_timestamp"`
 	// Initial Timestamp + clock skew. Reads which encounter values with
 	// timestamps between timestamp and max_timestamp trigger a txn

--- a/roachpb/data.proto
+++ b/roachpb/data.proto
@@ -219,6 +219,36 @@ message Transaction {
   // The original timestamp at which the transaction started. For serializable
   // transactions, if the timestamp drifts from the original timestamp, the
   // transaction will retry.
+  //
+  // This timestamp is the one at which all transactions will read. It is also,
+  // surprisingly, the timestamp at which transactions will _write_. This is
+  // ultimately because of correctness concerns around SNAPSHOT transactions.
+  // Note first that for SERIALIZABLE transactions, the original and commit
+  // timestamps must not diverge, and so an intent which may be committed is
+  // always written when both timestamps coincide.
+  //
+  // For a SNAPSHOT transaction however, this is not the case. Intuitively,
+  // one could think that the timestamp at which intents should be written
+  // should be the provisional commit timestamp, and while this is morally
+  // true, consider the following scenario, where txn1 is a SNAPSHOT txn:
+  //
+  // - txn1 at orig_timestamp=5 reads key1: {Amount: 1, Price: 10}
+  // - txn1 writes elsewhere, has its commit timestamp increased to 20.
+  // - txn2 at orig_timestamp=10 reads key1: {Amount: 1, Price: 10}
+  // - txn2 increases Price by 5: {Amount: 1, Price: 15} and commits
+  // - txn1 increases Amount by 1: {Amount: 2, Price: 10}, attempts commit
+  //
+  // If txn1 uses its orig_timestamp for updating key1 (as it does), it
+  // conflicts with txn2's committed value (which is at timestamp 10, in the
+  // future of 5), and restarts.
+  // Using instead its candidate commit timestamp, it wouldn't see a conflict
+  // and commit, but this is not the expected outcome {Amount: 2, Price: 15}
+  // and we are experiencing the Lost Update Anomaly.
+  //
+  // Note that in practice, before restarting, txn1 would still lay down an
+  // intent (just above the committed value) not with the intent to commit it,
+  // but to avoid being starved by short-lived transactions on that key which
+  // would otherwise not have to go through conflict resolution with txn1.
   optional util.hlc.Timestamp orig_timestamp = 6 [(gogoproto.nullable) = false];
   // Initial Timestamp + clock skew. Reads which encounter values with
   // timestamps between timestamp and max_timestamp trigger a txn

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1768,7 +1768,7 @@ func mvccResolveWriteIntent(
 	// TODO(tschottdorf): various epoch-related scenarios here deserve more
 	// testing.
 	pushed := intent.Status == roachpb.PENDING &&
-		meta.Txn.Timestamp.Less(intent.Txn.Timestamp) &&
+		meta.Timestamp.Less(intent.Txn.Timestamp) &&
 		meta.Txn.Epoch >= intent.Txn.Epoch
 
 	// If we're committing, or if the commit timestamp of the intent has

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -1946,6 +1946,59 @@ func TestMVCCResolveNewerIntent(t *testing.T) {
 	}
 }
 
+func TestMVCCResolveIntentTxnTimestampMismatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	engine := createTestEngine(stopper)
+
+	txn := txn1.Clone()
+	tsEarly := txn.Timestamp
+	txn.TxnMeta.Timestamp.Forward(tsEarly.Add(10, 0))
+
+	// Write an intent which has txn.Timestamp > meta.timestamp.
+	if err := MVCCPut(
+		context.Background(), engine, nil, testKey1, tsEarly, value1, &txn,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	intent := roachpb.Intent{
+		Span:   roachpb.Span{Key: testKey1},
+		Status: roachpb.PENDING,
+		// The Timestamp within is equal to that of txn.Meta even though
+		// the intent sits at tsEarly. The bug was looking at the former
+		// instead of the latter (and so we could also tickle it with
+		// smaller timestamps in Txn).
+		Txn: txn.TxnMeta,
+	}
+
+	// A bug (see #7654) caused intents to just stay where they were instead
+	// of being moved forward in the situation set up above.
+	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, intent); err != nil {
+		t.Fatal(err)
+	}
+
+	for i, test := range []struct {
+		hlc.Timestamp
+		found bool
+	}{
+		// Check that the intent has indeed moved to where we pushed it.
+		{tsEarly, false},
+		{intent.Txn.Timestamp.Prev(), false},
+		{intent.Txn.Timestamp, true},
+		{hlc.MaxTimestamp, true},
+	} {
+		_, _, err := MVCCGet(
+			context.Background(), engine, testKey1, test.Timestamp, true, nil,
+		)
+
+		if _, ok := err.(*roachpb.WriteIntentError); ok != test.found {
+			t.Fatalf("%d: expected write intent error: %t, got %v", i, test.found, err)
+		}
+	}
+}
+
 // TestMVCCConditionalPutOldTimestamp tests a case where a conditional
 // put with an older timestamp happens after a put with a newer timestamp.
 //

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -951,7 +951,6 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func
 	//   directly into the local range they're servicing.
 	if ba.Timestamp.Equal(hlc.ZeroTimestamp) {
 		if ba.Txn != nil {
-			// TODO(tschottdorf): see if this is already done somewhere else.
 			ba.Timestamp = ba.Txn.OrigTimestamp
 		} else {
 			ba.Timestamp = r.store.Clock().Now()
@@ -1021,6 +1020,14 @@ func (r *Replica) endCmds(cmd *cmd, ba *roachpb.BatchRequest, br *roachpb.BatchR
 //
 // TODO(tschottdorf): find a way not to update the batch txn
 //   which should be immutable.
+// TODO(tschottdorf): Things look fishy here. We're updating txn.Timestamp in
+// multiple places, but there's apparently nothing that forces the remainder of
+// request processing to return that updated transaction with a response. In
+// effect, we're running in danger of writing at higher timestamps than the
+// client (and thus the commit!) are aware of. If there's coverage of these
+// code paths, I wonder how it works if not for data races or some brittle
+// code path a stack frame higher up. Should really address that previous
+// TODO.
 func (r *Replica) applyTimestampCache(ba *roachpb.BatchRequest) *roachpb.Error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -2239,6 +2246,7 @@ func optimizePuts(batch engine.ReadWriter, reqs []roachpb.RequestUnion, distinct
 	}
 }
 
+// TODO(tschottdorf): Reliance on mutating `ba.Txn` should be dealt with.
 func (r *Replica) executeBatch(
 	ctx context.Context, idKey storagebase.CmdIDKey,
 	batch engine.ReadWriter, ms *enginepb.MVCCStats, ba roachpb.BatchRequest) (

--- a/storage/store.go
+++ b/storage/store.go
@@ -1825,9 +1825,13 @@ func (s *Store) ReplicaCount() int {
 // specified through the incoming BatchRequest, and it is not guaranteed that
 // all operations are written at the same timestamp. If it is transactional, a
 // timestamp must not be set - it is deduced automatically from the
-// transaction. Should a transactional operation be forced to a higher
-// timestamp (for instance due to the timestamp cache), the response will have
-// a transaction set which should be used to update the client transaction.
+// transaction. In particular, the read (original) timestamp will be used for
+// all reads _and writes_ (see the TxnMeta.OrigTimestamp for details).
+//
+// Should a transactional operation be forced to a higher timestamp (for
+// instance due to the timestamp cache or finding a committed value in the path
+// of one of its writes), the response will have a transaction set which should
+// be used to update the client transaction.
 func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.BatchResponse, pErr *roachpb.Error) {
 	ctx = s.context(ctx)
 


### PR DESCRIPTION
Went with @petermattis' fix from #7680 and added a test plus commentary along the way. Let me know if there are any additional comments that I can add.

Closes #7680.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7744)

<!-- Reviewable:end -->
