### PR TITLE
util/leaktest: ignore a go1.7 goroutine created by net.(*netFD).connect

### DIFF
--- a/util/leaktest/leaktest.go
+++ b/util/leaktest/leaktest.go
@@ -39,6 +39,9 @@ func interestingGoroutines() (gs []string) {
 			// timeout properly. See also
 			// https://github.com/cockroachdb/cockroach/issues/7524.
 			strings.Contains(stack, "google.golang.org/grpc.NewConn") ||
+			// Go1.7 added a goroutine to network dialing that doesn't shut down
+			// quickly.
+			strings.Contains(stack, "created by net.(*netFD).connect") ||
 			// Below are the stacks ignored by the upstream leaktest code.
 			strings.Contains(stack, "testing.Main(") ||
 			strings.Contains(stack, "testing.tRunner(") ||


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7745)

<!-- Reviewable:end -->
