### PR TITLE
server: set open file descriptors limits to the hard limit each time

### DIFF
--- a/cli/debug.go
+++ b/cli/debug.go
@@ -65,7 +65,15 @@ func parseRangeID(arg string) (roachpb.RangeID, error) {
 func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (*engine.RocksDB, error) {
 	cache := engine.NewRocksDBCache(512 << 20)
 	defer cache.Release()
-	db := engine.NewRocksDB(roachpb.Attributes{}, dir, cache, 10<<20, 0, stopper)
+	db := engine.NewRocksDB(
+		roachpb.Attributes{},
+		dir,
+		cache,
+		10<<20,
+		0,
+		engine.DefaultMaxOpenFiles,
+		stopper,
+	)
 	if err := db.Open(); err != nil {
 		return nil, err
 	}

--- a/storage/engine/bench_rocksdb_test.go
+++ b/storage/engine/bench_rocksdb_test.go
@@ -28,7 +28,15 @@ import (
 func setupMVCCRocksDB(b testing.TB, loc string) (Engine, *stop.Stopper) {
 	const memtableBudget = 512 << 20 // 512 MB
 	stopper := stop.NewStopper()
-	rocksdb := NewRocksDB(roachpb.Attributes{}, loc, RocksDBCache{}, memtableBudget, 0, stopper)
+	rocksdb := NewRocksDB(
+		roachpb.Attributes{},
+		loc,
+		RocksDBCache{},
+		memtableBudget,
+		0,
+		DefaultMaxOpenFiles,
+		stopper,
+	)
 	if err := rocksdb.Open(); err != nil {
 		b.Fatalf("could not create new rocksdb db instance at %s: %v", loc, err)
 	}

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -56,6 +56,13 @@ import "C"
 const (
 	minMemtableBudget = 1 << 20  // 1 MB
 	defaultBlockSize  = 32 << 10 // 32KB (rocksdb default is 4KB)
+
+	// DefaultMaxOpenFiles is the default value for rocksDB's max_open_files
+	// option.
+	DefaultMaxOpenFiles = 5000
+	// MinimumMaxOpenFiles is The minimum value that rocksDB's max_open_files
+	// option can be set to.
+	MinimumMaxOpenFiles = 256
 )
 
 func init() {
@@ -204,6 +211,7 @@ type RocksDB struct {
 	cache          RocksDBCache       // Shared cache.
 	memtableBudget int64              // Memory to use for the memory table.
 	maxSize        int64              // Used for calculating rebalancing and free space.
+	maxOpenFiles   int                // The maximum number of open files this instance will use.
 	stopper        *stop.Stopper
 	deallocated    chan struct{} // Closed when the underlying handle is deallocated.
 }
@@ -216,6 +224,7 @@ func NewRocksDB(
 	dir string,
 	cache RocksDBCache,
 	memtableBudget, maxSize int64,
+	maxOpenFiles int,
 	stopper *stop.Stopper,
 ) *RocksDB {
 	if dir == "" {
@@ -227,6 +236,7 @@ func NewRocksDB(
 		cache:          cache.ref(),
 		memtableBudget: memtableBudget,
 		maxSize:        maxSize,
+		maxOpenFiles:   maxOpenFiles,
 		stopper:        stopper,
 		deallocated:    make(chan struct{}),
 	}
@@ -301,6 +311,7 @@ func (r *RocksDB) Open() error {
 			allow_os_buffer: C.bool(true),
 			logging_enabled: C.bool(log.V(3)),
 			num_cpu:         C.int(runtime.NumCPU()),
+			max_open_files:  C.int(r.maxOpenFiles),
 		})
 	if err := statusToError(status); err != nil {
 		return errors.Errorf("could not open rocksdb instance: %s", err)

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1412,6 +1412,7 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   options.prefix_extractor.reset(new DBPrefixExtractor);
   options.statistics = rocksdb::CreateDBStatistics();
   options.table_factory.reset(rocksdb::NewBlockBasedTableFactory(table_options));
+  options.max_open_files = db_opts.max_open_files;
 
   // Merge two memtables when flushing to L0.
   options.min_write_buffer_number_to_merge = 2;

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -67,6 +67,7 @@ typedef struct {
   bool allow_os_buffer;
   bool logging_enabled;
   int num_cpu;
+  int max_open_files;
 } DBOptions;
 
 // Create a new cache with the specified size.

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -38,7 +38,15 @@ const testCacheSize = 1 << 30 // 1 GB
 func TestMinMemtableBudget(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	rocksdb := NewRocksDB(roachpb.Attributes{}, ".", RocksDBCache{}, 0, 0, stop.NewStopper())
+	rocksdb := NewRocksDB(
+		roachpb.Attributes{},
+		".",
+		RocksDBCache{},
+		0,
+		0,
+		DefaultMaxOpenFiles,
+		stop.NewStopper(),
+	)
 	const expected = "memtable budget must be at least"
 	if err := rocksdb.Open(); !testutils.IsError(err, expected) {
 		t.Fatalf("expected %s, but got %v", expected, err)
@@ -231,7 +239,15 @@ func openRocksDBWithVersion(t *testing.T, hasVersionFile bool, ver Version) erro
 		}
 	}
 
-	rocksdb := NewRocksDB(roachpb.Attributes{}, dir, RocksDBCache{}, minMemtableBudget, 0, stopper)
+	rocksdb := NewRocksDB(
+		roachpb.Attributes{},
+		dir,
+		RocksDBCache{},
+		minMemtableBudget,
+		0,
+		DefaultMaxOpenFiles,
+		stopper,
+	)
 	return rocksdb.Open()
 }
 
@@ -253,7 +269,15 @@ func TestCheckpoint(t *testing.T) {
 		stopper := stop.NewStopper()
 		defer stopper.Stop()
 
-		db := NewRocksDB(roachpb.Attributes{}, dir, RocksDBCache{}, minMemtableBudget, 0, stopper)
+		db := NewRocksDB(
+			roachpb.Attributes{},
+			dir,
+			RocksDBCache{},
+			minMemtableBudget,
+			0,
+			DefaultMaxOpenFiles,
+			stopper,
+		)
 		if err := db.Open(); err != nil {
 			t.Fatal(err)
 		}
@@ -280,7 +304,15 @@ func TestCheckpoint(t *testing.T) {
 		defer stopper.Stop()
 
 		dir = filepath.Join(dir, "checkpoint")
-		db := NewRocksDB(roachpb.Attributes{}, dir, RocksDBCache{}, minMemtableBudget, 0, stopper)
+		db := NewRocksDB(
+			roachpb.Attributes{},
+			dir,
+			RocksDBCache{},
+			minMemtableBudget,
+			0,
+			DefaultMaxOpenFiles,
+			stopper,
+		)
 		if err := db.Open(); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
RocksDB seems to prefer a value of around 5000 open file descriptors per
instance.  This change sets the soft limit to the hard limit.  If the total
is still lower than the recommended settings it will throw an error.

This change also enables us to pass the max_open_files option to rocksdb.

Part of #7562.
See also https://github.com/cockroachdb/docs/issues/436, https://github.com/cockroachdb/docs/issues/53

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7747)

<!-- Reviewable:end -->
