### PR TITLE
Event Logs for CREATE/DROP INDEX

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -243,7 +243,9 @@ func (n *alterTableNode) Start() error {
 		return err
 	}
 
-	// Record this table alteration in the event log.
+	// Record this table alteration in the event log. This is an auditable log
+	// event and is recorded in the same transaction as the table descriptor
+	// update.
 	if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(n.p.txn,
 		EventLogAlterTable,
 		int32(n.tableDesc.ID),

--- a/sql/event_log.go
+++ b/sql/event_log.go
@@ -41,8 +41,13 @@ const (
 	EventLogCreateTable EventLogType = "create_table"
 	// EventLogDropTable is recorded when a table is dropped.
 	EventLogDropTable EventLogType = "drop_table"
+
 	// EventLogAlterTable is recorded when a table is altered.
 	EventLogAlterTable EventLogType = "alter_table"
+	// EventLogCreateIndex is recorded when an index is created.
+	EventLogCreateIndex EventLogType = "create_index"
+	// EventLogDropIndex is recorded when an index is created.
+	EventLogDropIndex EventLogType = "drop_index"
 	// EventLogReverseSchemaChange is recorded when an in-progress schema change
 	// encounters a problem and is reversed.
 	EventLogReverseSchemaChange EventLogType = "reverse_schema_change"

--- a/sql/testdata/event_log
+++ b/sql/testdata/event_log
@@ -125,6 +125,48 @@ WHERE eventType = 'reverse_schema_change'
 ----
 51 0
 
+# Create an Index on the table
+#################
+
+statement ok
+CREATE INDEX a_foo ON test.a (val)
+
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'create_index'
+  AND info LIKE '%a_foo%'
+----
+51 1
+
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'finish_schema_change'
+----
+51 0
+51 0
+51 0
+
+# Drop the index
+#################
+
+statement ok
+DROP INDEX test.a@a_foo
+
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'drop_index'
+  AND info LIKE '%a_foo%'
+----
+51 1
+
+query II
+SELECT targetID, reportingID FROM system.eventlog
+WHERE eventType = 'finish_schema_change'
+----
+51 0
+51 0
+51 0
+51 0
 
 # Drop both tables + superfluous "IF EXISTS"
 ##################


### PR DESCRIPTION
Adds event log entries for CREATE/DROP INDEX. Both of these operations are
asynchronous schema changes, and will result in a "finish_schema_change" event
being logged at the completion of the change.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7748)

<!-- Reviewable:end -->
