### PR TITLE
util/stop: allow handling of panics

### DIFF
--- a/util/stop/stopper.go
+++ b/util/stop/stopper.go
@@ -108,29 +108,65 @@ func (k taskKey) String() string {
 // be added to the stopper via AddCloser(), to be closed after the
 // stopper has stopped.
 type Stopper struct {
-	drainer  chan struct{}  // Closed when draining
-	stopper  chan struct{}  // Closed when stopping
-	stopped  chan struct{}  // Closed when stopped completely
-	stop     sync.WaitGroup // Incremented for outstanding workers
-	mu       sync.Mutex     // Protects the fields below
-	drain    *sync.Cond     // Conditional variable to wait for outstanding tasks
-	draining bool           // true when Stop() has been called
-	numTasks int            // number of outstanding tasks
+	drainer  chan struct{}     // Closed when draining
+	stopper  chan struct{}     // Closed when stopping
+	stopped  chan struct{}     // Closed when stopped completely
+	onPanic  func(interface{}) // called with recover() on panic on any goroutine
+	stop     sync.WaitGroup    // Incremented for outstanding workers
+	mu       sync.Mutex        // Protects the fields below
+	drain    *sync.Cond        // Conditional variable to wait for outstanding tasks
+	draining bool              // true when Stop() has been called
+	numTasks int               // number of outstanding tasks
 	tasks    map[taskKey]int
 	closers  []Closer
 }
 
+// An Option can be passed to NewStopper.
+type Option interface {
+	apply(*Stopper)
+}
+
+type optionPanicHandler func(interface{})
+
+func (oph optionPanicHandler) apply(stopper *Stopper) {
+	stopper.onPanic = oph
+}
+
+// OnPanic is an option which lets the Stopper recover from all panics using
+// the provided panic handler.
+//
+// When Stop() is invoked during stack unwinding, OnPanic is also invoked, but
+// Stop() may not have carried out its duties.
+func OnPanic(handler func(interface{})) Option {
+	return optionPanicHandler(handler)
+}
+
 // NewStopper returns an instance of Stopper.
-func NewStopper() *Stopper {
+func NewStopper(options ...Option) *Stopper {
 	s := &Stopper{
 		drainer: make(chan struct{}),
 		stopper: make(chan struct{}),
 		stopped: make(chan struct{}),
 		tasks:   map[taskKey]int{},
 	}
+
+	for _, opt := range options {
+		opt.apply(s)
+	}
+
 	s.drain = sync.NewCond(&s.mu)
 	register(s)
 	return s
+}
+
+func (s *Stopper) maybeHandlePanic() {
+	if r := recover(); r != nil {
+		if s.onPanic != nil {
+			s.onPanic(r)
+			return
+		}
+		panic(r)
+	}
 }
 
 // RunWorker runs the supplied function as a "worker" to be stopped
@@ -138,6 +174,7 @@ func NewStopper() *Stopper {
 func (s *Stopper) RunWorker(f func()) {
 	s.stop.Add(1)
 	go func() {
+		defer s.maybeHandlePanic()
 		defer s.stop.Done()
 		f()
 	}()
@@ -165,6 +202,7 @@ func (s *Stopper) RunTask(f func()) error {
 		return errUnavailable
 	}
 	// Call f.
+	defer s.maybeHandlePanic()
 	defer s.runPostlude(key)
 	f()
 	return nil
@@ -180,6 +218,7 @@ func (s *Stopper) RunAsyncTask(f func()) error {
 	}
 	// Call f.
 	go func() {
+		defer s.maybeHandlePanic()
 		defer s.runPostlude(key)
 		f()
 	}()
@@ -216,6 +255,7 @@ func (s *Stopper) RunLimitedAsyncTask(sem chan struct{}, f func()) error {
 		return errUnavailable
 	}
 	go func() {
+		defer s.maybeHandlePanic()
 		defer s.runPostlude(key)
 		defer func() { <-sem }()
 		f()
@@ -285,6 +325,7 @@ func (s *Stopper) runningTasksLocked() TaskMap {
 // Stop signals all live workers to stop and then waits for each to
 // confirm it has stopped.
 func (s *Stopper) Stop() {
+	defer s.maybeHandlePanic()
 	defer unregister(s)
 	// Don't bother doing stuff cleanly if we're panicking, that would likely
 	// block. Instead, best effort only. This cleans up the stack traces,
@@ -344,6 +385,7 @@ func (s *Stopper) IsStopped() <-chan struct{} {
 // Quiesce moves the stopper to state draining and waits until all
 // tasks complete. This is used from Stop() and unittests.
 func (s *Stopper) Quiesce() {
+	defer s.maybeHandlePanic()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.draining {

--- a/util/stop/stopper_test.go
+++ b/util/stop/stopper_test.go
@@ -303,24 +303,40 @@ func TestStopperNumTasks(t *testing.T) {
 	s.Stop()
 }
 
-// TestStopperRunTaskPanic ensures that tasks are not leaked when they panic.
-// RunAsyncTask has a similar bit of logic, but it is not testable because
-// we cannot insert a recover() call in the right place.
+// TestStopperRunTaskPanic ensures that a panic handler can recover panicking
+// tasks, and that no tasks are leaked when they panic.
 func TestStopperRunTaskPanic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s := stop.NewStopper()
+	ch := make(chan interface{})
+	s := stop.NewStopper(stop.OnPanic(func(v interface{}) {
+		ch <- v
+	}))
 	// If RunTask were not panic-safe, Stop() would deadlock.
-	defer s.Stop()
-	func() {
-		defer func() {
-			_ = recover()
-		}()
-		if err := s.RunTask(func() {
-			panic("ouch")
-		}); err != nil {
-			t.Fatal(err)
+	type testFn func()
+	explode := func() { panic(ch) }
+	for i, test := range []testFn{
+		func() {
+			_ = s.RunTask(explode)
+		},
+		func() {
+			_ = s.RunAsyncTask(explode)
+		},
+		func() {
+			_ = s.RunLimitedAsyncTask(
+				make(chan struct{}, 1),
+				explode,
+			)
+		},
+		func() {
+			s.RunWorker(explode)
+		},
+	} {
+		go test()
+		recovered := <-ch
+		if recovered != ch {
+			t.Errorf("%d: unexpected recovered value: %+v", i, recovered)
 		}
-	}()
+	}
 }
 
 func TestStopperShouldDrain(t *testing.T) {


### PR DESCRIPTION
The Stopper is our main source of goroutines, which means that many
panics will pass through it, providing a good opportunity for insertion
of a reporting hook at some point in the future.

This is provided now since we've recently looked at some error reporting
tools, and this will come in handy.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7764)

<!-- Reviewable:end -->
