### PR TITLE
sql: avoid copying mutex

### DIFF
--- a/sql/pgwire_internal_test.go
+++ b/sql/pgwire_internal_test.go
@@ -82,11 +82,11 @@ func TestPGWireConnectionCloseReleasesLeases(t *testing.T) {
 	// Wait for the lease to be released.
 	util.SucceedsSoon(t, func() error {
 		ts.mu.Lock()
-		lease := *(ts.active.data[0])
+		refcount := ts.active.data[0].refcount
 		ts.mu.Unlock()
-		if lease.refcount != 0 {
+		if refcount != 0 {
 			return errors.Errorf(
-				"expected lease to be unused, found refcount: %d", lease.refcount)
+				"expected lease to be unused, found refcount: %d", refcount)
 		}
 		return nil
 	})


### PR DESCRIPTION
go1.7 vet complains about:

  sql/pgwire_internal_test.go:85: assignment copies lock value to lease:
  sql.LeaseState contains sync.Mutex

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7767)

<!-- Reviewable:end -->
