### PR TITLE
remove make check from make all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ LDFLAGS += -extldflags "-static-libgcc -static-libstdc++"
 endif
 
 .PHONY: all
-all: build test check
+all: build test
 
 .PHONY: release
 release: build


### PR DESCRIPTION
"make" will run "make build test"

make check is too expensive

fixes #7765

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7769)

<!-- Reviewable:end -->
