### PR TITLE
storage: fix blocked async snapshot task

### DIFF
--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -299,6 +299,7 @@ func (r *Replica) Snapshot() (raftpb.Snapshot, error) {
 			case <-time.After(r.store.ctx.AsyncSnapshotMaxAge):
 				// If raft decides it doesn't need this snapshot any more (or
 				// just takes too long to use it), abandon it to save memory.
+			case <-r.store.Stopper().ShouldDrain():
 			}
 		}
 	}) == nil {


### PR DESCRIPTION
If an async snapshot task is in progress when the stopper is stopped we
need to watch for notification on the Stopper.ShouldDrain(), otherwise
the async task will block trying to send the snapshot data to a channel
that will never be read from.

See #7689.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7770)

<!-- Reviewable:end -->
