### PR TITLE
storage: de-flake TestComputeVerifyChecksum

### DIFF
--- a/storage/replica_state.go
+++ b/storage/replica_state.go
@@ -138,6 +138,7 @@ func setLease(
 		hlc.ZeroTimestamp, nil, lease)
 }
 
+// loadAppliedIndex returns the Raft applied index and the lease applied index.
 func loadAppliedIndex(reader engine.Reader, rangeID roachpb.RangeID) (uint64, uint64, error) {
 	var appliedIndex uint64
 	v, _, err := engine.MVCCGet(context.Background(), reader, keys.RaftAppliedIndexKey(rangeID),

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -5306,7 +5306,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 	}
 }
 
-// verify the checksum for the range and returrn it.
+// verify the checksum for the range and return it.
 func verifyChecksum(t *testing.T, rng *Replica) []byte {
 	id := uuid.MakeV4()
 	args := roachpb.ComputeChecksumRequest{
@@ -5347,25 +5347,54 @@ func TestComputeVerifyChecksum(t *testing.T) {
 	if _, err := tc.SendWrapped(&incArgs); err != nil {
 		t.Fatal(err)
 	}
-	initialChecksum := verifyChecksum(t, rng)
 
-	// Getting a value will not affect the snapshot checksum
-	gArgs := getArgs(roachpb.Key("a"))
-	if _, err := tc.SendWrapped(&gArgs); err != nil {
-		t.Fatal(err)
-	}
-	checksum := verifyChecksum(t, rng)
+	// We use this helper below to gauge whether another Raft command possibly
+	// snuck in (in which case we recompute). We can't use the in-memory state
+	// because it's not updated atomically with the batch and because this
+	// test doesn't respect Raft ordering.
+	getAppliedIndex := func() uint64 {
+		rng.mu.Lock()
+		defer rng.mu.Unlock()
 
-	if !bytes.Equal(initialChecksum, checksum) {
-		t.Fatalf("changed checksum: e = %v, c = %v", initialChecksum, checksum)
+		appliedIndex, _, err := loadAppliedIndex(rng.store.Engine(), rng.RangeID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return appliedIndex
 	}
+
+	var initialChecksum []byte
+	// The following part of the test is inherently racy if other Raft commands
+	// get processed (which could happen due to reproposals). The loop makes
+	// sure that we catch this.
+	util.SucceedsSoon(t, func() error {
+		oldAppliedIndex := getAppliedIndex()
+		initialChecksum = verifyChecksum(t, rng)
+
+		// Getting a value will not affect the snapshot checksum.
+		gArgs := getArgs(roachpb.Key("a"))
+		if _, err := tc.SendWrapped(&gArgs); err != nil {
+			t.Fatal(err)
+		}
+		checksum := verifyChecksum(t, rng)
+
+		if !bytes.Equal(initialChecksum, checksum) {
+			appliedIndex := getAppliedIndex()
+			if appliedIndex != oldAppliedIndex {
+				return errors.Errorf("applied index changed from %d to %d",
+					oldAppliedIndex, appliedIndex)
+			}
+			t.Fatalf("changed checksum: e = %v, c = %v", initialChecksum, checksum)
+		}
+		return nil
+	})
 
 	// Modifying the range will change the checksum.
 	incArgs = incrementArgs([]byte("a"), 5)
 	if _, err := tc.SendWrapped(&incArgs); err != nil {
 		t.Fatal(err)
 	}
-	checksum = verifyChecksum(t, rng)
+	checksum := verifyChecksum(t, rng)
 	if bytes.Equal(initialChecksum, checksum) {
 		t.Fatalf("same checksum: e = %v, c = %v", initialChecksum, checksum)
 	}


### PR DESCRIPTION
``````
The test was assuming that the Replica had no other moving parts.

Before this fix, failed in the low hundreds before on GCE (never on laptop) due
to a Raft reproposal (which was caught but still updates the applied index).
```
$ git checkout tschottdorf/fix-checksum-test && make stressrace PKG=./storage TESTS=TestComputeVerifyChecksum STRESSFLAGS='-p 128 -stderr -maxfails 1 -maxruns 15000'
[...]
15000 runs completed, 0 failures, over 2m18s
SUCCESS
```

Fixes #7360.
``````

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7782)

<!-- Reviewable:end -->
