### PR TITLE
storage: get rid of TestingTableSplitsDisabled

### DIFF
--- a/server/testserver.go
+++ b/server/testserver.go
@@ -240,9 +240,6 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 	// If enabled, wait for initial splits to complete before returning control.
 	// If initial splits do not complete, the server is stopped before
 	// returning.
-	if config.TestingTableSplitsDisabled() {
-		return nil
-	}
 	if stk, ok := ts.ctx.TestingKnobs.Store.(*storage.StoreTestingKnobs); ok &&
 		stk.DisableSplitQueue {
 		return nil

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -25,7 +25,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -67,8 +66,9 @@ func createSplitRanges(store *storage.Store) (*roachpb.RangeDescriptor, *roachpb
 // together.
 func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer config.TestingDisableTableSplits()()
-	store, stopper, _ := createTestStore(t)
+	sCtx := storage.TestStoreContext()
+	sCtx.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithContext(t, sCtx)
 	defer stopper.Stop()
 
 	if _, _, err := createSplitRanges(store); err != nil {
@@ -95,8 +95,9 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 // subsumed range is cleaned up on merge.
 func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer config.TestingDisableTableSplits()()
-	store, stopper, _ := createTestStore(t)
+	sCtx := storage.TestStoreContext()
+	sCtx.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithContext(t, sCtx)
 	defer stopper.Stop()
 
 	scan := func(f func(roachpb.KeyValue) (bool, error)) {
@@ -173,8 +174,9 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 // each containing data.
 func TestStoreRangeMergeWithData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer config.TestingDisableTableSplits()()
-	store, stopper, _ := createTestStore(t)
+	sCtx := storage.TestStoreContext()
+	sCtx.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithContext(t, sCtx)
 	defer stopper.Stop()
 
 	content := roachpb.Key("testing!")
@@ -300,8 +302,9 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 // fails.
 func TestStoreRangeMergeLastRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer config.TestingDisableTableSplits()()
-	store, stopper, _ := createTestStore(t)
+	sCtx := storage.TestStoreContext()
+	sCtx.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithContext(t, sCtx)
 	defer stopper.Stop()
 
 	// Merge last range.
@@ -366,8 +369,9 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 // range has stats consistent with recomputations.
 func TestStoreRangeMergeStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer config.TestingDisableTableSplits()()
-	store, stopper, manual := createTestStore(t)
+	sCtx := storage.TestStoreContext()
+	sCtx.TestingKnobs.DisableSplitQueue = true
+	store, stopper, manual := createTestStoreWithContext(t, sCtx)
 	defer stopper.Stop()
 
 	// Split the range.
@@ -424,8 +428,9 @@ func TestStoreRangeMergeStats(t *testing.T) {
 
 func BenchmarkStoreRangeMerge(b *testing.B) {
 	defer tracing.Disable()()
-	defer config.TestingDisableTableSplits()()
-	store, stopper, _ := createTestStore(b)
+	sCtx := storage.TestStoreContext()
+	sCtx.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithContext(b, sCtx)
 	defer stopper.Stop()
 
 	// Perform initial split of ranges.

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -27,7 +27,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -217,7 +216,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		engine.NewInMem(roachpb.Attributes{}, 10<<20, stopper),
 		clock,
 		true,
-		&ctx,
+		ctx,
 		stopper)
 
 	// Put an initial value.
@@ -327,8 +326,9 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 // are correct when scanning in reverse order.
 func TestRangeLookupUseReverse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer config.TestingDisableTableSplits()()
-	store, stopper, _ := createTestStore(t)
+	sCtx := storage.TestStoreContext()
+	sCtx.TestingKnobs.DisableSplitQueue = true
+	store, stopper, _ := createTestStoreWithContext(t, sCtx)
 	defer stopper.Stop()
 
 	// Init test ranges:

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -156,6 +156,10 @@ type queueConfig struct {
 	// acceptsUnsplitRanges controls whether this queue can process ranges that
 	// need to be split due to zone config settings. Ranges are checked before
 	// calling queueImpl.shouldQueue and queueImpl.process.
+	// This is to avoid giving the queue a replica that spans multiple config
+	// zones (which might make the action of the queue ambiguous - e.g. we don't
+	// want to try to replicate a range until we know which zone it is in and
+	// therefore how many replicas are required).
 	acceptsUnsplitRanges bool
 }
 
@@ -248,6 +252,11 @@ func (bq *baseQueue) SetDisabled(disabled bool) {
 	}
 }
 
+// Disabled returns true is the queue is currently disabled.
+func (bq *baseQueue) Disabled() bool {
+	return atomic.LoadInt32(&bq.disabled) == 1
+}
+
 func (bq *baseQueue) Close() {
 	bq.eventLog.Finish()
 }
@@ -283,11 +292,14 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now hlc.Timestamp) {
 	}
 
 	desc := repl.Desc()
-	if !bq.acceptsUnsplitRanges && cfg.NeedsSplit(desc.StartKey, desc.EndKey) {
-		// Range needs to be split due to zone configs, but queue does
-		// not accept unsplit ranges.
-		bq.eventLog.VInfof(log.V(1), "%s: split needed; not adding", repl)
-		return
+	if !bq.acceptsUnsplitRanges {
+		// If the split queue is disabled (i.e. in some tests), ignore this condition.
+		if !splittingDisabledForTest(repl.store) && cfg.NeedsSplit(desc.StartKey, desc.EndKey) {
+			// Range needs to be split due to zone configs, but queue does
+			// not accept unsplit ranges.
+			bq.eventLog.VInfof(log.V(1), "%s: split needed; not adding", repl)
+			return
+		}
 	}
 
 	bq.mu.Lock()
@@ -296,6 +308,16 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now hlc.Timestamp) {
 	if err := bq.addInternal(repl, should, priority); !isExpectedQueueError(err) {
 		bq.eventLog.Error(errors.Wrapf(err, "unable to add %s", repl))
 	}
+}
+
+// splittingDisabledForTest returns true if a store's split queue has been
+// disabled. This only happens in tests.
+func splittingDisabledForTest(store *Store) bool {
+	if store == nil {
+		// Some tests hack half-initialized replicas.
+		return true
+	}
+	return store.splitQueue.Disabled()
 }
 
 // addInternal adds the replica the queue with specified priority. If the
@@ -426,11 +448,13 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 	}
 
 	desc := repl.Desc()
-	if !bq.acceptsUnsplitRanges && cfg.NeedsSplit(desc.StartKey, desc.EndKey) {
-		// Range needs to be split due to zone configs, but queue does
-		// not accept unsplit ranges.
-		bq.eventLog.VInfof(log.V(3), "%s: split needed; skipping", repl)
-		return nil
+	if !bq.acceptsUnsplitRanges {
+		if !splittingDisabledForTest(repl.store) && cfg.NeedsSplit(desc.StartKey, desc.EndKey) {
+			// Range needs to be split due to zone configs, but queue does
+			// not accept unsplit ranges.
+			bq.eventLog.VInfof(log.V(3), "%s: split needed; skipping", repl)
+			return nil
+		}
 	}
 
 	sp := repl.store.Tracer().StartSpan(fmt.Sprintf("%s:%d", bq.name, repl.RangeID))

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -78,8 +78,7 @@ func newReplicateQueue(g *gossip.Gossip, allocator Allocator, clock *hlc.Clock,
 
 func (rq *replicateQueue) shouldQueue(now hlc.Timestamp, repl *Replica,
 	sysCfg config.SystemConfig) (shouldQ bool, priority float64) {
-
-	if repl.needsSplitBySize() {
+	if !splittingDisabledForTest(repl.store) && repl.needsSplitBySize() {
 		// If the range exceeds the split threshold, let that finish
 		// first. Ranges must fit in memory on both sender and receiver
 		// nodes while being replicated. This supplements the check


### PR DESCRIPTION
Replace it with disabling the split queue, which we have from
https://reviewable.io/reviews/cockroachdb/cockroach/7448

The changes that are not mechanic stem from the fact that
TestingTableSplitsDisabled made cfg.NeedsSplit() return false. Now, that
function just runs normally, is not "mocked" any more. This means that
the ReplicationQueue needs to explicitly check if the split queue has
been disabled in some places, and some tests need a Store with an
enabled split queue, where before they didn't.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7789)

<!-- Reviewable:end -->
