### PR TITLE
storage: Fix a FrozenStatus comment

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -2586,7 +2586,7 @@ func (s *Store) SetRangeRetryOptions(ro retry.Options) {
 }
 
 // FrozenStatus returns all of the Store's Replicas which are frozen (if the
-// parameter is false) or unfrozen (otherwise). It makes no attempt to prevent
+// parameter is true) or unfrozen (otherwise). It makes no attempt to prevent
 // new data being rebalanced to the Store, and thus does not guarantee that the
 // Store remains in the reported state.
 func (s *Store) FrozenStatus(collectFrozen bool) (repDescs []roachpb.ReplicaDescriptor) {


### PR DESCRIPTION
   if the parameter is false
-> if the parameter is true

The parameter is `collectFrozen`, and we have

```
  if r.mu.state.Frozen == collectFrozen {
    repDescs = append(repDescs, repDesc)
  }
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7790)

<!-- Reviewable:end -->
