### PR TITLE
gossip: de-flake TestGossipCullNetwork

### DIFF
--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -18,7 +18,6 @@ package gossip
 
 import (
 	"bytes"
-	"errors"
 	"testing"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/pkg/errors"
 )
 
 // TestGossipInfoStore verifies operation of gossip instance infostore.
@@ -202,11 +202,14 @@ func TestGossipCullNetwork(t *testing.T) {
 
 	local.manage()
 
+	expectedNum := minPeers - 1
 	util.SucceedsSoon(t, func() error {
 		// Verify that a client is closed within the cull interval.
-		if len(local.Outgoing()) == minPeers-1 {
+		actualNum := len(local.Outgoing())
+		if actualNum <= expectedNum {
 			return nil
 		}
-		return errors.New("no network culling occurred")
+		return errors.Errorf("no network culling occurred (have %d, want %d)",
+			actualNum, expectedNum)
 	})
 }


### PR DESCRIPTION
Previously failed after <15k iters because when it was looking for two clients,
it had only one left (so perhaps there is a situation during which two clients
can get disconnected when only one must, but I haven't investigated further).

```
$ make stress PKG=./gossip TESTS=TestGossipCullNetwork
138253 runs so far, 0 failures, over 5m5s
```

Fixes #7791.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7792)

<!-- Reviewable:end -->
