### PR TITLE
storage: improve message for raft proxying error

### DIFF
--- a/storage/raft_transport.go
+++ b/storage/raft_transport.go
@@ -133,7 +133,9 @@ func (t *RaftTransport) RaftMessage(stream MultiRaft_RaftMessageServer) (err err
 					t.mu.Unlock()
 
 					if !ok {
-						return errors.Errorf("Unable to proxy message to node: %d", req.Message.To)
+						return errors.Errorf(
+							"unable to accept Raft message from %+v: no store registered for %+v",
+							req.ToReplica, req.FromReplica)
 					}
 
 					if err := handler(req); err != nil {


### PR DESCRIPTION
Saw this a bunch while debugging a test failure and found it lacking descriptiveness.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7797)

<!-- Reviewable:end -->
