### PR TITLE
sql: Clean up code surrounding SchemaAccessor.getTable{Desc/Lease}

### DIFF
--- a/sql/create.go
+++ b/sql/create.go
@@ -117,12 +117,9 @@ type createIndexNode struct {
 //   notes: postgres requires CREATE on the table.
 //          mysql requires INDEX on the table.
 func (p *planner) CreateIndex(n *parser.CreateIndex) (planNode, error) {
-	tableDesc, err := p.getTableDesc(n.Table)
+	tableDesc, err := p.mustGetTableDesc(n.Table)
 	if err != nil {
 		return nil, err
-	}
-	if tableDesc == nil {
-		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
 	}
 
 	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -200,12 +200,9 @@ func (p *planner) getDescriptorsFromTargetList(targets parser.TargetList) (
 			return nil, err
 		}
 		for _, table := range tables {
-			descriptor, err := p.getTableDesc(table)
+			descriptor, err := p.mustGetTableDesc(table)
 			if err != nil {
 				return nil, err
-			}
-			if descriptor == nil {
-				return nil, sqlbase.NewUndefinedTableError(table.String())
 			}
 			descs = append(descs, descriptor)
 		}

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -172,12 +172,9 @@ func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 			return nil, err
 		}
 
-		tableDesc, err := p.getTableDesc(index.Table)
+		tableDesc, err := p.mustGetTableDesc(index.Table)
 		if err != nil {
 			return nil, err
-		}
-		if tableDesc == nil {
-			return nil, sqlbase.NewUndefinedTableError(index.Table.String())
 		}
 
 		if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -158,11 +158,11 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		return &emptyNode{}, nil
 	}
 
-	tableDesc, err := p.getTableDesc(n.Name)
+	tableDesc, err := p.mustGetTableDesc(n.Name)
 	if err != nil {
 		return nil, err
 	}
-	if tableDesc == nil || tableDesc.State != sqlbase.TableDescriptor_PUBLIC {
+	if tableDesc.State != sqlbase.TableDescriptor_PUBLIC {
 		return nil, sqlbase.NewUndefinedTableError(n.Name.String())
 	}
 
@@ -236,12 +236,9 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, error) {
 		return nil, err
 	}
 
-	tableDesc, err := p.getTableDesc(n.Index.Table)
+	tableDesc, err := p.mustGetTableDesc(n.Index.Table)
 	if err != nil {
 		return nil, err
-	}
-	if tableDesc == nil {
-		return nil, sqlbase.NewUndefinedTableError(n.Index.Table.String())
 	}
 
 	idxName := string(n.Index.Index)
@@ -325,12 +322,9 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 		return nil, fmt.Errorf("table %q does not exist", n.Table.Table())
 	}
 
-	tableDesc, err := p.getTableDesc(n.Table)
+	tableDesc, err := p.mustGetTableDesc(n.Table)
 	if err != nil {
 		return nil, err
-	}
-	if tableDesc == nil {
-		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
 	}
 
 	colName := string(n.Name)

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -248,8 +248,6 @@ func (n *scanNode) initTable(
 	indexHints *parser.IndexHints,
 	scanVisibility scanVisibility,
 ) (string, error) {
-	var err error
-
 	// AS OF SYSTEM TIME queries need to fetch the table descriptor at the
 	// specified time, and never lease anything. The proto transaction already
 	// has its timestamps set correctly so getTableDesc will fetch with the
@@ -261,10 +259,11 @@ func (n *scanNode) initTable(
 		}
 		n.desc = *desc
 	} else {
-		n.desc, err = p.getTableLease(tableName)
-	}
-	if err != nil {
-		return "", err
+		desc, err := p.getTableLease(tableName)
+		if err != nil {
+			return "", err
+		}
+		n.desc = *desc
 	}
 
 	if err := p.checkPrivilege(&n.desc, privilege.SELECT); err != nil {

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -248,23 +248,19 @@ func (n *scanNode) initTable(
 	indexHints *parser.IndexHints,
 	scanVisibility scanVisibility,
 ) (string, error) {
-	// AS OF SYSTEM TIME queries need to fetch the table descriptor at the
-	// specified time, and never lease anything. The proto transaction already
-	// has its timestamps set correctly so getTableDesc will fetch with the
-	// correct timestamp.
+	descFunc := p.getTableLease
 	if p.asOf {
-		desc, err := p.mustGetTableDesc(tableName)
-		if err != nil {
-			return "", err
-		}
-		n.desc = *desc
-	} else {
-		desc, err := p.getTableLease(tableName)
-		if err != nil {
-			return "", err
-		}
-		n.desc = *desc
+		// AS OF SYSTEM TIME queries need to fetch the table descriptor at the
+		// specified time, and never lease anything. The proto transaction already
+		// has its timestamps set correctly so mustGetTableDesc will fetch with the
+		// correct timestamp.
+		descFunc = p.mustGetTableDesc
 	}
+	desc, err := descFunc(tableName)
+	if err != nil {
+		return "", err
+	}
+	n.desc = *desc
 
 	if err := p.checkPrivilege(&n.desc, privilege.SELECT); err != nil {
 		return "", err

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -255,12 +255,9 @@ func (n *scanNode) initTable(
 	// has its timestamps set correctly so getTableDesc will fetch with the
 	// correct timestamp.
 	if p.asOf {
-		desc, err := p.getTableDesc(tableName)
+		desc, err := p.mustGetTableDesc(tableName)
 		if err != nil {
 			return "", err
-		}
-		if desc == nil {
-			return "", sqlbase.NewUndefinedTableError(tableName.String())
 		}
 		n.desc = *desc
 	} else {

--- a/sql/show.go
+++ b/sql/show.go
@@ -60,13 +60,11 @@ func (p *planner) Show(n *parser.Show) (planNode, error) {
 //   Notes: postgres does not have a SHOW COLUMNS statement.
 //          mysql only returns columns you have privileges on.
 func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, error) {
-	desc, err := p.getTableDesc(n.Table)
+	desc, err := p.mustGetTableDesc(n.Table)
 	if err != nil {
 		return nil, err
 	}
-	if desc == nil {
-		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
-	}
+
 	v := &valuesNode{
 		columns: []ResultColumn{
 			{Name: "Field", Typ: parser.TypeString},
@@ -75,6 +73,7 @@ func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, error) {
 			{Name: "Default", Typ: parser.TypeString},
 		},
 	}
+
 	for i, col := range desc.Columns {
 		defaultExpr := parser.Datum(parser.DNull)
 		if e := desc.Columns[i].DefaultExpr; e != nil {
@@ -94,13 +93,11 @@ func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, error) {
 // Traditional syntax.
 // Privileges: None.
 func (p *planner) ShowCreateTable(n *parser.ShowCreateTable) (planNode, error) {
-	desc, err := p.getTableDesc(n.Table)
+	desc, err := p.mustGetTableDesc(n.Table)
 	if err != nil {
 		return nil, err
 	}
-	if desc == nil {
-		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
-	}
+
 	v := &valuesNode{
 		columns: []ResultColumn{
 			{Name: "Table", Typ: parser.TypeString},
@@ -271,12 +268,9 @@ func (p *planner) ShowGrants(n *parser.ShowGrants) (planNode, error) {
 //   Notes: postgres does not have a SHOW INDEXES statement.
 //          mysql requires some privilege for any column.
 func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, error) {
-	desc, err := p.getTableDesc(n.Table)
+	desc, err := p.mustGetTableDesc(n.Table)
 	if err != nil {
 		return nil, err
-	}
-	if desc == nil {
-		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
 	}
 
 	v := &valuesNode{
@@ -303,6 +297,7 @@ func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, error) {
 			parser.MakeDBool(parser.DBool(isStored)),
 		})
 	}
+
 	for _, index := range append([]sqlbase.IndexDescriptor{desc.PrimaryIndex}, desc.Indexes...) {
 		sequence := 1
 		for i, col := range index.ColumnNames {
@@ -322,12 +317,9 @@ func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, error) {
 //   Notes: postgres does not have a SHOW CONSTRAINTS statement.
 //          mysql requires some privilege for any column.
 func (p *planner) ShowConstraints(n *parser.ShowConstraints) (planNode, error) {
-	desc, err := p.getTableDesc(n.Table)
+	desc, err := p.mustGetTableDesc(n.Table)
 	if err != nil {
 		return nil, err
-	}
-	if desc == nil {
-		return nil, sqlbase.NewUndefinedTableError(n.Table.String())
 	}
 
 	v := &valuesNode{

--- a/sql/truncate.go
+++ b/sql/truncate.go
@@ -37,20 +37,20 @@ func (p *planner) Truncate(n *parser.Truncate) (planNode, error) {
 			return nil, err
 		}
 
-		if err := p.checkPrivilege(&tableDesc, privilege.DROP); err != nil {
+		if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
 			return nil, err
 		}
 
-		if err := truncateTable(&tableDesc, p.txn); err != nil {
+		if err := truncateTable(tableDesc, p.txn); err != nil {
 			return nil, err
 		}
 
-		fkTables := TablesNeededForFKs(tableDesc, CheckDeletes)
+		fkTables := TablesNeededForFKs(*tableDesc, CheckDeletes)
 		if err := p.fillFKTableMap(fkTables); err != nil {
 			return nil, err
 		}
 		colMap := colIDtoRowIndexFromCols(tableDesc.Columns)
-		if helper, err := makeFKDeleteHelper(p.txn, tableDesc, fkTables, colMap); err != nil {
+		if helper, err := makeFKDeleteHelper(p.txn, *tableDesc, fkTables, colMap); err != nil {
 			return nil, err
 		} else if err = helper.checkAll(nil); err != nil {
 			return nil, err


### PR DESCRIPTION
This change:
- Adds `mustGetTableDesc` method to `SchemaAccessor`
- Returns a `*TableDescriptor` from `SchemaAccessor.getTableLease`
- Simplifies logic for getting a `TableDescriptor` in `scanNode.initTable`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7799)

<!-- Reviewable:end -->
