### PR TITLE
storage: eagerly split replicas after replication

### DIFF
--- a/sql/multinode_test.go
+++ b/sql/multinode_test.go
@@ -82,8 +82,6 @@ func TestMultinodeCockroach(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer tracing.Disable()()
 
-	t.Skip("#7689")
-
 	testCluster, conns, stopper := SetupMultinodeTestCluster(t, 3, "Testing")
 	if err := testCluster.WaitForFullReplication(); err != nil {
 		t.Fatal(err)

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2564,13 +2564,10 @@ func (r *Replica) splitTrigger(
 		// If the range was not properly replicated before the split, the replicate
 		// queue may not have picked it up (due to the need for a split). Enqueue
 		// both new halves to speed up a potentially necessary replication. See
-		// #7022.
-		if len(split.UpdatedDesc.Replicas) == 1 {
-			r.store.replicateQueue.MaybeAdd(r, r.store.Clock().Now())
-		}
-		if len(split.NewDesc.Replicas) == 1 {
-			r.store.replicateQueue.MaybeAdd(newRng, r.store.Clock().Now())
-		}
+		// #7022 and #7800.
+		now := r.store.Clock().Now()
+		r.store.replicateQueue.MaybeAdd(r, now)
+		r.store.replicateQueue.MaybeAdd(newRng, now)
 
 		// To avoid leaving the new range unavailable as it waits to elect
 		// its leader, one (and only one) of the nodes should start an
@@ -2837,6 +2834,16 @@ func (r *Replica) changeReplicasTrigger(ctx context.Context, batch engine.Batch,
 				// will be GC'd eventually.
 				log.Errorf("unable to add range %s to GC queue: %s", r, err)
 			}
+		})
+	} else {
+		// After a successful replica addition or removal check to see if the range
+		// needs to be split. Splitting usually takes precedence over replication
+		// via configuration of the split and replicate queues, but if the split
+		// occurs concurrently with the replicas change the split can fail and
+		// won't retry until the next scanner cycle. Re-queuing the replica here
+		// removes that latency.
+		batch.Defer(func() {
+			r.store.splitQueue.MaybeAdd(r, r.store.Clock().Now())
 		})
 	}
 	return nil


### PR DESCRIPTION
And change the criteria for eagerly replicating after splitting.

Fixes #7689.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7800)

<!-- Reviewable:end -->
