### PR TITLE
build: avoid boot2docker style initialization

### DIFF
--- a/build/init-docker.sh
+++ b/build/init-docker.sh
@@ -2,15 +2,6 @@
 
 set -eu
 
-if [ "${DOCKER_HOST-}" = "" -a "$(uname)" = "Darwin" ]; then
-  if ! type -P "docker-machine" >& /dev/null; then
-    echo "docker-machine not found!"
-    exit 1
-  fi
-  echo "docker-machine env # initializing DOCKER_* env variables"
-  eval $(docker-machine env default)
-fi
-
 # Verify that Docker is installed.
 DOCKER="docker"
 if [[ ! $(type -P "$DOCKER") ]]; then
@@ -20,7 +11,7 @@ if [[ ! $(type -P "$DOCKER") ]]; then
 fi
 
 # Verify docker is reachable.
-OUT=$(($DOCKER images  > /dev/null) 2>&1) || (
+OUT=$(($DOCKER images > /dev/null) 2>&1) || (
   echo "Docker is not reachable. Is the Docker daemon running?"
   echo "'docker images': $OUT"
   exit 1


### PR DESCRIPTION
This is no longer correct with docker for mac. Folks still using
virtualbox will need to set up their environment by hand.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7820)

<!-- Reviewable:end -->
