### PR TITLE
storage: better gossiping of first range on lease acquisition

### DIFF
--- a/storage/gossip_test.go
+++ b/storage/gossip_test.go
@@ -1,0 +1,122 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package storage_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/gossip"
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func TestGossipFirstRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tc := testcluster.StartTestCluster(t, 3,
+		testcluster.ClusterArgs{
+			ReplicationMode: testcluster.ReplicationManual,
+		})
+	defer tc.Stopper().Stop()
+
+	errors := make(chan error)
+	descs := make(chan *roachpb.RangeDescriptor)
+	tc.Servers[0].Gossip().RegisterCallback(gossip.KeyFirstRangeDescriptor,
+		func(_ string, content roachpb.Value) {
+			var desc roachpb.RangeDescriptor
+			if err := content.GetProto(&desc); err != nil {
+				errors <- err
+			} else {
+				descs <- &desc
+			}
+		})
+
+	// Expect an initial callback of the first range descriptor.
+	select {
+	case err := <-errors:
+		t.Fatal(err)
+	case _ = <-descs:
+	}
+
+	// Add two replicas. The first range descriptor should be gossiped after each
+	// addition.
+	var desc *roachpb.RangeDescriptor
+	firstRangeKey := roachpb.RKey(keys.MinKey)
+	for i := 1; i <= 2; i++ {
+		var err error
+		if desc, err = tc.AddReplicas(firstRangeKey, tc.Target(i)); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case err := <-errors:
+			t.Fatal(err)
+		case gossiped := <-descs:
+			if !reflect.DeepEqual(desc, gossiped) {
+				t.Fatalf("expected\n%+v\nbut found\n%+v", desc, gossiped)
+			}
+		}
+	}
+
+	// Transfer the lease to a new node. This should cause the first range to be
+	// gossiped again.
+	if err := tc.TransferRangeLease(desc, tc.Target(1)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-errors:
+		t.Fatal(err)
+	case gossiped := <-descs:
+		if !reflect.DeepEqual(desc, gossiped) {
+			t.Fatalf("expected\n%+v\nbut found\n%+v", desc, gossiped)
+		}
+	}
+
+	// Remove a non-lease holder replica.
+	desc, err := tc.RemoveReplicas(firstRangeKey, tc.Target(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-errors:
+		t.Fatal(err)
+	case gossiped := <-descs:
+		if !reflect.DeepEqual(desc, gossiped) {
+			t.Fatalf("expected\n%+v\nbut found\n%+v", desc, gossiped)
+		}
+	}
+
+	// TODO(peter): Re-enable or remove when we've resolved the discussion
+	// about removing the lease-holder replica. See #7872.
+
+	// // Remove the lease holder replica.
+	// leaseHolder, err := tc.FindRangeLeaseHolder(desc, nil)
+	// desc, err = tc.RemoveReplicas(firstRangeKey, leaseHolder)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+	// select {
+	// case err := <-errors:
+	// 	t.Fatal(err)
+	// case gossiped := <-descs:
+	// 	if !reflect.DeepEqual(desc, gossiped) {
+	// 		t.Fatalf("expected\n%+v\nbut found\n%+v", desc, gossiped)
+	// 	}
+	// }
+}


### PR DESCRIPTION
Only gossip the first range when the lease holder changes. Also gossip
the first range after a change replicas in case the lease holder is not
changing.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7823)

<!-- Reviewable:end -->
