### PR TITLE
storage: change errors in StorePool to errors.Errorf

### DIFF
--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -18,11 +18,11 @@ package storage
 
 import (
 	"container/heap"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/gossip"
@@ -445,7 +445,7 @@ func (sp *StorePool) reserve(
 	defer sp.mu.Unlock()
 	detail, ok := sp.mu.stores[toStoreID]
 	if !ok {
-		return fmt.Errorf("store does not exist in the store pool")
+		return errors.Errorf("store %d does not exist in the store pool", toStoreID)
 	}
 	conn, err := sp.rpcContext.GRPCDial(detail.desc.Node.Address.String())
 	if err != nil {
@@ -482,7 +482,7 @@ func (sp *StorePool) reserve(
 			log.Infof("reservation failed, store:%s will be throttled for %s until %s",
 				toStoreID, sp.failedReservationsTimeout, detail.throttledUntil)
 		}
-		return fmt.Errorf("reservation failed:%+v due to error:%s", req, err)
+		return errors.Wrapf(err, "reservation failed:%+v", req)
 	}
 	if !resp.Reserved {
 		detail.throttledUntil = sp.clock.Now().GoTime().Add(sp.declinedReservationsTimeout)
@@ -490,7 +490,7 @@ func (sp *StorePool) reserve(
 			log.Infof("reservation failed, store:%s will be throttled for %s until %s",
 				toStoreID, sp.declinedReservationsTimeout, detail.throttledUntil)
 		}
-		return fmt.Errorf("reservation declined:%+v", req)
+		return errors.Errorf("reservation declined:%+v", req)
 	}
 
 	if log.V(2) {

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -525,7 +525,7 @@ func TestStorePoolReserve(t *testing.T) {
 		// The reservation is successful.
 		{fakeResp: true, storeID: 2},
 		// The store is not in the StorePool.
-		{storeID: 3, expErr: "store does not exist in the store pool"},
+		{storeID: 3, expErr: "store 3 does not exist in the store pool"},
 		// The reservation is declined.
 		{fakeResp: false, storeID: 2, expErr: "reservation declined"},
 		// The reservation is with an error.


### PR DESCRIPTION
from fmt.Errorf, because they're not user errors.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7824)

<!-- Reviewable:end -->
