### PR TITLE
storage: touch up TestRequestLeaderEncounterGroupDeleteError

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -4758,9 +4758,7 @@ func TestReplicaLookup(t *testing.T) {
 // RaftGroupDeletedError is converted to a RangeNotFoundError in the Store.
 func TestRequestLeaderEncounterGroupDeleteError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	tc := testContext{
-		rng: &Replica{},
-	}
+	tc := testContext{}
 	tc.Start(t)
 	defer tc.Stop()
 
@@ -4768,18 +4766,12 @@ func TestRequestLeaderEncounterGroupDeleteError(t *testing.T) {
 	proposeRaftCommandFn := func(*pendingCmd) error {
 		return &roachpb.RaftGroupDeletedError{}
 	}
-	rng, err := NewReplica(testRangeDescriptor(), tc.store, 0)
+
+	rng := tc.rng
 
 	rng.mu.Lock()
 	rng.mu.proposeRaftCommandFn = proposeRaftCommandFn
 	rng.mu.Unlock()
-
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := tc.store.AddReplicaTest(rng); err != nil {
-		t.Fatal(err)
-	}
 
 	gArgs := getArgs(roachpb.Key("a"))
 	// Force the read command request a new lease.


### PR DESCRIPTION
It was using a bare bones range for no good reason.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7828)

<!-- Reviewable:end -->
