### PR TITLE
storage: let preemptive snapshots go through Raft

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -266,6 +266,7 @@ func (r *Replica) withRaftGroupLocked(f func(r *raft.RawNode) error) error {
 		// error here as all errors returned from this method are considered fatal.
 		return nil
 	}
+
 	if r.mu.replicaID == 0 {
 		// The replica's raft group has not yet been configured (i.e. the replica
 		// was created from a preemptive snapshot).
@@ -273,18 +274,13 @@ func (r *Replica) withRaftGroupLocked(f func(r *raft.RawNode) error) error {
 	}
 
 	if r.mu.internalRaftGroup == nil {
-		raftGroup, err := raft.NewRawNode(&raft.Config{
-			ID:            uint64(r.mu.replicaID),
-			Applied:       r.mu.state.RaftAppliedIndex,
-			ElectionTick:  r.store.ctx.RaftElectionTimeoutTicks,
-			HeartbeatTick: r.store.ctx.RaftHeartbeatIntervalTicks,
-			Storage:       r,
-			// TODO(bdarnell): make these configurable; evaluate defaults.
-			MaxSizePerMsg:   1024 * 1024,
-			MaxInflightMsgs: 256,
-			CheckQuorum:     true,
-			Logger:          &raftLogger{rangeID: r.RangeID},
-		}, nil)
+		raftGroup, err := raft.NewRawNode(newRaftConfig(
+			raft.Storage(r),
+			uint64(r.mu.replicaID),
+			r.mu.state.RaftAppliedIndex,
+			r.store.ctx,
+			&raftLogger{rangeID: r.RangeID},
+		), nil)
 		if err != nil {
 			return err
 		}
@@ -1465,9 +1461,11 @@ func (r *Replica) handleRaftReady() error {
 	logRaftReady(r.store.StoreID(), r.RangeID, rd)
 
 	if !raft.IsEmptySnap(rd.Snapshot) {
+		if err := r.applySnapshot(rd.Snapshot, rd.HardState); err != nil {
+			return err
+		}
 		var err error
-		lastIndex, err = r.applySnapshot(rd.Snapshot, rd.HardState)
-		if err != nil {
+		if lastIndex, err = loadLastIndex(r.store.Engine(), r.RangeID); err != nil {
 			return err
 		}
 		// TODO(bdarnell): update coalesced heartbeat mapping with snapshot info.

--- a/storage/replica_raftstorage_test.go
+++ b/storage/replica_raftstorage_test.go
@@ -25,67 +25,10 @@ import (
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
-	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/randutil"
 	"github.com/coreos/etcd/raft"
-	"github.com/coreos/etcd/raft/raftpb"
 )
-
-func TestApplySnapshotDenyPreemptive(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	var tc testContext
-	tc.Start(t)
-	defer tc.Stop()
-
-	key := roachpb.RKey("a")
-	realRng := tc.store.LookupReplica(key, nil)
-
-	// Use Raft to get a nontrivial term for our snapshot.
-	if pErr := realRng.redirectOnOrAcquireLease(context.Background()); pErr != nil {
-		t.Fatal(pErr)
-	}
-
-	snap, err := realRng.GetSnapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Make sure that the Term is behind our first range term (raftInitialLogTerm)
-	snap.Metadata.Term--
-
-	// Create an uninitialized version of the first range. This is only ok
-	// because in the case we test, there's an error (and so we don't clobber
-	// our actual first range in the Store). If we want snapshots to apply
-	// successfully during tests, we need to adapt the snapshots to a new
-	// RangeID first and generally do a lot more work.
-	rng, err := NewReplica(&roachpb.RangeDescriptor{RangeID: 1}, tc.store, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := rng.applySnapshot(snap, raftpb.HardState{}); !testutils.IsError(
-		err, "cannot apply preemptive snapshot from past term",
-	) {
-		t.Fatal(err)
-	}
-
-	// Do something that extends the Raft log past what we have in the
-	// snapshot.
-	put := putArgs(roachpb.Key("a"), []byte("foo"))
-	if _, pErr := tc.SendWrapped(&put); pErr != nil {
-		t.Fatal(pErr)
-	}
-	snap.Metadata.Term++ // restore the "real" term of the snapshot
-
-	if _, err := rng.applySnapshot(snap, raftpb.HardState{}); !testutils.IsError(
-		err, "would erase acknowledged log entries",
-	) {
-		t.Fatal(err)
-	}
-
-}
 
 const rangeID = 1
 const keySize = 1 << 7   // 128 B

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -6258,7 +6258,7 @@ func TestReserveAndApplySnapshot(t *testing.T) {
 
 	// Apply a snapshot and check the reservation was filled. Note that this
 	// out-of-band application could be a root cause if this test ever crashes.
-	if _, err := firstRng.applySnapshot(snap, raftpb.HardState{}); err != nil {
+	if err := firstRng.applySnapshot(snap, raftpb.HardState{}); err != nil {
 		t.Fatal(err)
 	}
 	checkReservations(t, 0)

--- a/storage/store.go
+++ b/storage/store.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -64,6 +65,10 @@ const (
 	// ttlStoreGossip is time-to-live for store-related info.
 	ttlStoreGossip = 2 * time.Minute
 
+	// preemptiveSnapshotRaftGroupID is a bogus ID for which a Raft group is
+	// temporarily created during the application of a preemptive snapshot.
+	preemptiveSnapshotRaftGroupID = math.MaxUint64
+
 	// TODO(bdarnell): Determine the right size for this cache. Should
 	// the cache be partitioned so that replica descriptors from the
 	// range descriptors (which are the bulk of the data and can be
@@ -99,6 +104,27 @@ func TestStoreContext() StoreContext {
 		ConsistencyCheckInterval:       10 * time.Minute,
 		ConsistencyCheckPanicOnFailure: true,
 		BlockingSnapshotDuration:       100 * time.Millisecond,
+	}
+}
+
+func newRaftConfig(
+	strg raft.Storage,
+	id uint64,
+	appliedIndex uint64,
+	storeCtx StoreContext,
+	logger raft.Logger,
+) *raft.Config {
+	return &raft.Config{
+		ID:            id,
+		Applied:       appliedIndex,
+		ElectionTick:  storeCtx.RaftElectionTimeoutTicks,
+		HeartbeatTick: storeCtx.RaftHeartbeatIntervalTicks,
+		Storage:       strg,
+		Logger:        logger,
+		CheckQuorum:   true,
+		// TODO(bdarnell): make these configurable; evaluate defaults.
+		MaxSizePerMsg:   1024 * 1024,
+		MaxInflightMsgs: 256,
 	}
 }
 
@@ -2259,12 +2285,93 @@ func (s *Store) handleRaftMessage(req *RaftMessageRequest) error {
 
 	if req.ToReplica.ReplicaID == 0 {
 		if req.Message.Type == raftpb.MsgSnap {
-			// Allow snapshots to be applied to replicas before they are members of
-			// the raft group (i.e. replicas with an ID of 0). This is the only
-			// operation that can be performed on a replica before it is part of the
-			// raft group.
-			_, err := r.applySnapshot(req.Message.Snapshot, raftpb.HardState{})
-			return err
+			// Allow snapshots to be applied to replicas before they are
+			// members of the raft group (i.e. replicas with an ID of 0). This
+			// is the only operation that can be performed before it is part of
+			// the raft group.
+
+			// Requiring that the Term is set in a message makes sure that we
+			// get all of Raft's internal safety checks (it confuses messages
+			// at term zero for internal messages). The sending side uses the
+			// term from the snapshot itself, but we'll just check nonzero.
+			if req.Message.Term == 0 {
+				return errors.Errorf(
+					"preemptive snapshot from term %d received with zero term",
+					req.Message.Snapshot.Metadata.Term,
+				)
+			}
+			// TODO(tschottdorf): A lot of locking of the individual Replica
+			// going on below as well. I think that's more easily refactored
+			// away; what really matters is that the Store doesn't do anything
+			// else with that same Replica (or one that might conflict with us
+			// while we still run). In effect, we'd want something like:
+			//
+			// 1. look up the snapshot's key range
+			// 2. get an exclusive lock for operations on that key range from
+			//    the store (or discard the snapshot)
+			//    (at the time of writing, we have checked the key range in
+			//    canApplySnapshot above, but there are concerns about two
+			//    conflicting operations passing that check simultaneously,
+			//    see #7830)
+			// 3. do everything below (apply the snapshot through temp Raft group)
+			// 4. release the exclusive lock on the snapshot's key range
+			//
+			// There are two future outcomes: Either we begin receiving
+			// legitimate Raft traffic for this Range (hence learning the
+			// ReplicaID and becoming a real Replica), or the Replica GC queue
+			// decides that the ChangeReplicas as a part of which the
+			// preemptive snapshot was sent has likely failed and removes both
+			// in-memory and on-disk state.
+			r.mu.Lock()
+			groupExists := r.mu.internalRaftGroup != nil
+			r.mu.Unlock()
+			if groupExists {
+				return errors.Errorf(
+					"cannot apply preemptive snapshot, Raft group for %d already active",
+					r.RangeID,
+				)
+			}
+			appliedIndex, _, err := loadAppliedIndex(r.store.Engine(), r.RangeID)
+			if err != nil {
+				return err
+			}
+			raftGroup, err := raft.NewRawNode(
+				newRaftConfig(
+					raft.Storage(r),
+					preemptiveSnapshotRaftGroupID,
+					// We pass the "real" applied index here due to subtleties
+					// arising in the case in which Raft discards the snapshot:
+					// It would instruct us to apply entries, which would have
+					// crashing potential for any choice of dummy value below.
+					appliedIndex,
+					r.store.ctx,
+					&raftLogger{rangeID: r.RangeID},
+				), nil)
+			if err != nil {
+				return err
+			}
+			// We have a Raft group; feed it the message.
+			if err := raftGroup.Step(req.Message); err != nil {
+				return errors.Wrap(err, "unable to process preemptive snapshot")
+			}
+			// In the normal case, the group should ask us to apply a snapshot.
+			// If it doesn't, our snapshot was probably stale.
+			var ready raft.Ready
+			if raftGroup.HasReady() {
+				ready = raftGroup.Ready()
+			}
+			if raft.IsEmptySnap(ready.Snapshot) {
+				return errors.Errorf("preemptive snapshot discarded by Raft")
+			}
+			// Apply the snapshot, as Raft told us to.
+			if err := r.applySnapshot(ready.Snapshot, ready.HardState); err != nil {
+				return err
+			}
+			// At this point, the Replica has data but no ReplicaID. We hope
+			// that it turns into a "real" Replica by means of receiving Raft
+			// messages addressed to it with a ReplicaID, but if that doesn't
+			// happen, at some point the Replica GC queue will have to grab it.
+			return nil
 		}
 		// We disallow non-snapshot messages to replica ID 0. Note that
 		// getOrCreateReplicaLocked disallows moving the replica ID backward, so


### PR DESCRIPTION
Change the way in which preemptive snapshots are applied to use
a temporary Raft group. This lets Raft perform the verification
of the snapshot against its on-disk state and allows us to remove
some of the ad-hoc checks we have added recently.

Some fallout from this was making Raft config creation reusable,
trimming down `(*Replica).applySnapshot` and minor improvements
on the sending side.

See #6144.

cc @tamird @bdarnell @petermattis @arjunravinarayan

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7833)

<!-- Reviewable:end -->
