### PR TITLE
gossip: added basic metrics and refactored existing metrics

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -72,6 +72,7 @@ import (
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/protoutil"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/timeutil"
@@ -109,6 +110,16 @@ const (
 	// DefaultGossipStoresInterval is the default interval for gossiping storage-
 	// related info.
 	DefaultGossipStoresInterval = 1 * time.Minute
+)
+
+// Gossip metrics counter names.
+const (
+	ConnectionsIncomingGaugeName = "connections.incoming"
+	ConnectionsOutgoingGaugeName = "connections.outgoing"
+	InfosSentRatesName           = "infos.sent"
+	InfosReceivedRatesName       = "infos.received"
+	BytesSentRatesName           = "bytes.sent"
+	BytesReceivedRatesName       = "bytes.received"
 )
 
 // Storage is an interface which allows the gossip instance
@@ -174,12 +185,12 @@ type Gossip struct {
 }
 
 // New creates an instance of a gossip node.
-func New(rpcContext *rpc.Context, resolvers []resolver.Resolver, stopper *stop.Stopper) *Gossip {
+func New(rpcContext *rpc.Context, resolvers []resolver.Resolver, stopper *stop.Stopper, registry *metric.Registry) *Gossip {
 	g := &Gossip{
 		Connected:         make(chan struct{}),
 		rpcContext:        rpcContext,
-		server:            newServer(stopper),
-		outgoing:          makeNodeSet(minPeers),
+		server:            newServer(stopper, registry),
+		outgoing:          makeNodeSet(minPeers, registry.Gauge(ConnectionsOutgoingGaugeName)),
 		bootstrapping:     map[string]struct{}{},
 		disconnected:      make(chan *client, 10),
 		stalled:           make(chan struct{}, 1),
@@ -373,8 +384,8 @@ func (g *Gossip) clientStatus() string {
 
 	fmt.Fprintf(&buf, "gossip client (%d/%d cur/max conns)\n", len(g.clientsMu.clients), g.outgoing.maxSize)
 	for _, c := range g.clientsMu.clients {
-		fmt.Fprintf(&buf, "  %d: %s (%s: %d/%d sent/received)\n",
-			c.peerID, c.addr, roundSecs(timeutil.Since(c.createdAt)), c.sent, c.received)
+		fmt.Fprintf(&buf, "  %d: %s (%s: %s)\n",
+			c.peerID, c.addr, roundSecs(timeutil.Since(c.createdAt)), c.clientMetrics)
 	}
 	return buf.String()
 }
@@ -960,7 +971,7 @@ func (g *Gossip) checkHasConnected() {
 // The client is added to the outgoing address set and launched in
 // a goroutine.
 func (g *Gossip) startClient(addr net.Addr) {
-	c := newClient(addr)
+	c := newClient(addr, g.serverMetrics)
 	g.clientsMu.Lock()
 	g.clientsMu.clients = append(g.clientsMu.clients, c)
 	g.clientsMu.Unlock()
@@ -999,4 +1010,27 @@ var _ security.RequestWithUser = &Request{}
 // Gossip messages are always sent by the node user.
 func (*Request) GetUser() string {
 	return security.NodeUser
+}
+
+type metrics struct {
+	bytesReceived metric.Rates
+	bytesSent     metric.Rates
+	infosReceived metric.Rates
+	infosSent     metric.Rates
+}
+
+func (m metrics) String() string {
+	return fmt.Sprintf("infos %d/%d sent/received, bytes %dB/%dB sent/received",
+		m.infosSent.Count(), m.infosReceived.Count(), m.bytesSent.Count(), m.bytesReceived.Count())
+}
+
+// makeMetrics makes a new metrics object with rates set on the provided
+// registry.
+func makeMetrics(registry *metric.Registry) metrics {
+	return metrics{
+		bytesReceived: registry.Rates(BytesReceivedRatesName),
+		bytesSent:     registry.Rates(BytesSentRatesName),
+		infosReceived: registry.Rates(InfosReceivedRatesName),
+		infosSent:     registry.Rates(InfosSentRatesName),
+	}
 }

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
@@ -41,7 +42,7 @@ func TestGossipInfoStore(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	rpcContext := rpc.NewContext(nil, nil, stopper)
-	g := New(rpcContext, nil, stopper)
+	g := New(rpcContext, nil, stopper, metric.NewRegistry())
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	slice := []byte("b")
@@ -75,7 +76,7 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 	if len(resolvers) != 3 {
 		t.Errorf("expected 3 resolvers; got %d", len(resolvers))
 	}
-	g := New(nil, resolvers, nil)
+	g := New(nil, resolvers, nil, metric.NewRegistry())
 
 	// Using specified resolvers, fetch bootstrap addresses 3 times
 	// and verify the results match expected addresses.
@@ -98,10 +99,10 @@ func TestGossipRaceLogStatus(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	local := startGossip(1, stopper, t)
+	local := startGossip(1, stopper, t, metric.NewRegistry())
 
 	local.mu.Lock()
-	peer := startGossip(2, stopper, t)
+	peer := startGossip(2, stopper, t, metric.NewRegistry())
 	local.startClient(&peer.is.NodeAddr)
 	local.mu.Unlock()
 
@@ -144,7 +145,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	local := startGossip(1, stopper, t)
+	local := startGossip(1, stopper, t, metric.NewRegistry())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -153,11 +154,11 @@ func TestGossipNoForwardSelf(t *testing.T) {
 	// incoming clients.
 	peers := []*Gossip{local}
 	for i := 0; i < local.server.incoming.maxSize; i++ {
-		peers = append(peers, startGossip(roachpb.NodeID(i+2), stopper, t))
+		peers = append(peers, startGossip(roachpb.NodeID(i+2), stopper, t, metric.NewRegistry()))
 	}
 
 	for _, peer := range peers {
-		c := newClient(&local.is.NodeAddr)
+		c := newClient(&local.is.NodeAddr, makeMetrics(metric.NewRegistry()))
 
 		util.SucceedsSoon(t, func() error {
 			conn, err := peer.rpcContext.GRPCDial(c.addr.String(), grpc.WithBlock())
@@ -186,10 +187,10 @@ func TestGossipNoForwardSelf(t *testing.T) {
 	// Start a few overflow peers and assert that they don't get forwarded to us
 	// again.
 	for i := 0; i < numClients; i++ {
-		peer := startGossip(roachpb.NodeID(i+local.server.incoming.maxSize+2), stopper, t)
+		peer := startGossip(roachpb.NodeID(i+local.server.incoming.maxSize+2), stopper, t, metric.NewRegistry())
 
 		for {
-			c := newClient(&local.is.NodeAddr)
+			c := newClient(&local.is.NodeAddr, makeMetrics(metric.NewRegistry()))
 			c.start(peer, disconnectedCh, peer.rpcContext, stopper)
 
 			disconnectedClient := <-disconnectedCh
@@ -215,12 +216,12 @@ func TestGossipCullNetwork(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	local := startGossip(1, stopper, t)
+	local := startGossip(1, stopper, t, metric.NewRegistry())
 	local.SetCullInterval(5 * time.Millisecond)
 
 	local.mu.Lock()
 	for i := 0; i < minPeers; i++ {
-		peer := startGossip(roachpb.NodeID(i+2), stopper, t)
+		peer := startGossip(roachpb.NodeID(i+2), stopper, t, metric.NewRegistry())
 		local.startClient(&peer.is.NodeAddr)
 	}
 	local.mu.Unlock()

--- a/gossip/infostore_test.go
+++ b/gossip/infostore_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/gogo/protobuf/proto"
 )
@@ -294,7 +295,7 @@ func TestLeastUseful(t *testing.T) {
 	defer stopper.Stop()
 	is := newInfoStore(1, emptyAddr, stopper)
 
-	set := makeNodeSet(3)
+	set := makeNodeSet(3, metric.NewGauge())
 	if is.leastUseful(set) != 0 {
 		t.Error("not expecting a node from an empty set")
 	}

--- a/gossip/node_set_test.go
+++ b/gossip/node_set_test.go
@@ -21,11 +21,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/metric"
 )
 
 func TestNodeSetMaxSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	nodes := makeNodeSet(1)
+	nodes := makeNodeSet(1, metric.NewGauge())
 	if !nodes.hasSpace() {
 		t.Error("set should have space")
 	}
@@ -37,7 +38,7 @@ func TestNodeSetMaxSize(t *testing.T) {
 
 func TestNodeSetHasNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	nodes := makeNodeSet(2)
+	nodes := makeNodeSet(2, metric.NewGauge())
 	node := roachpb.NodeID(1)
 	if nodes.hasNode(node) {
 		t.Error("node wasn't added and should not be valid")
@@ -51,7 +52,7 @@ func TestNodeSetHasNode(t *testing.T) {
 
 func TestNodeSetAddAndRemoveNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	nodes := makeNodeSet(2)
+	nodes := makeNodeSet(2, metric.NewGauge())
 	node0 := roachpb.NodeID(1)
 	node1 := roachpb.NodeID(2)
 	nodes.addNode(node0)
@@ -71,13 +72,13 @@ func TestNodeSetAddAndRemoveNode(t *testing.T) {
 
 func TestNodeSetFilter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	nodes1 := makeNodeSet(2)
+	nodes1 := makeNodeSet(2, metric.NewGauge())
 	node0 := roachpb.NodeID(1)
 	node1 := roachpb.NodeID(2)
 	nodes1.addNode(node0)
 	nodes1.addNode(node1)
 
-	nodes2 := makeNodeSet(1)
+	nodes2 := makeNodeSet(1, metric.NewGauge())
 	nodes2.addNode(node1)
 
 	filtered := nodes1.filter(func(a roachpb.NodeID) bool {
@@ -90,7 +91,7 @@ func TestNodeSetFilter(t *testing.T) {
 
 func TestNodeSetAsSlice(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	nodes := makeNodeSet(2)
+	nodes := makeNodeSet(2, metric.NewGauge())
 	node0 := roachpb.NodeID(1)
 	node1 := roachpb.NodeID(2)
 	nodes.addNode(node0)

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/netutil"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
@@ -39,9 +40,10 @@ import (
 // about the node's gossip instance, network address, and underlying
 // server.
 type Node struct {
-	Gossip *gossip.Gossip
-	Server *grpc.Server
-	Addr   net.Addr
+	Gossip   *gossip.Gossip
+	Server   *grpc.Server
+	Addr     net.Addr
+	Registry *metric.Registry
 }
 
 // Network provides access to a test gossip network of nodes.
@@ -93,8 +95,8 @@ func (n *Network) CreateNode() (*Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	node := &Node{Server: server, Addr: ln.Addr()}
-	node.Gossip = gossip.New(n.rpcContext, nil, n.Stopper)
+	node := &Node{Server: server, Addr: ln.Addr(), Registry: metric.NewRegistry()}
+	node.Gossip = gossip.New(n.rpcContext, nil, n.Stopper, node.Registry)
 	n.Nodes = append(n.Nodes, node)
 	return node, nil
 }
@@ -209,19 +211,19 @@ func (n *Network) isNetworkConnected() bool {
 // infosSent returns the total count of infos sent from all nodes in
 // the network.
 func (n *Network) infosSent() int {
-	var count int
+	var count int64
 	for _, node := range n.Nodes {
-		count += node.Gossip.InfosSent()
+		count += node.Registry.GetCounter(gossip.InfosSentRatesName + "-count").Count()
 	}
-	return count
+	return int(count)
 }
 
 // infosReceived returns the total count of infos received from all
 // nodes in the network.
 func (n *Network) infosReceived() int {
-	var count int
+	var count int64
 	for _, node := range n.Nodes {
-		count += node.Gossip.InfosReceived()
+		count += node.Registry.GetCounter(gossip.InfosReceivedRatesName + "-count").Count()
 	}
-	return count
+	return int(count)
 }

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -73,7 +73,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		t.Fatal(err)
 	}
 	serverCtx := makeTestContext()
-	g := gossip.New(nodeRPCContext, serverCtx.GossipBootstrapResolvers, stopper)
+	g := gossip.New(nodeRPCContext, serverCtx.GossipBootstrapResolvers, stopper, metric.NewRegistry())
 	if gossipBS != nil {
 		// Handle possibility of a :0 port specification.
 		if gossipBS.Network() == addr.Network() && gossipBS.String() == addr.String() {

--- a/server/server.go
+++ b/server/server.go
@@ -134,7 +134,8 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 		}
 	}
 
-	s.gossip = gossip.New(s.rpcContext, s.ctx.GossipBootstrapResolvers, s.stopper)
+	gossipRegistry := metric.NewRegistry()
+	s.gossip = gossip.New(s.rpcContext, s.ctx.GossipBootstrapResolvers, s.stopper, gossipRegistry)
 	s.storePool = storage.NewStorePool(
 		s.gossip,
 		s.clock,
@@ -237,6 +238,7 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 	s.recorder.AddNodeRegistry("sql.%s", sqlRegistry)
 	s.recorder.AddNodeRegistry("txn.%s", txnRegistry)
 	s.recorder.AddNodeRegistry("clock-offset.%s", s.rpcContext.RemoteClocks.Registry())
+	s.recorder.AddNodeRegistry("gossip.%s", gossipRegistry)
 
 	s.runtime = status.MakeRuntimeStatSampler(s.clock)
 	s.recorder.AddNodeRegistry("sys.%s", s.runtime.Registry())

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/timeutil"
 )
@@ -168,7 +169,7 @@ func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator
 	manualClock := hlc.NewManualClock(hlc.UnixNano())
 	clock := hlc.NewClock(manualClock.UnixNano)
 	rpcContext := rpc.NewContext(nil, clock, stopper)
-	g := gossip.New(rpcContext, nil, stopper)
+	g := gossip.New(rpcContext, nil, stopper, metric.NewRegistry())
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	storePool := NewStorePool(
@@ -1088,7 +1089,7 @@ func Example_rebalancing() {
 
 	// Model a set of stores in a cluster,
 	// randomly adding / removing stores and adding bytes.
-	g := gossip.New(nil, nil, stopper)
+	g := gossip.New(nil, nil, stopper, metric.NewRegistry())
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	sp := NewStorePool(

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -103,7 +103,7 @@ func createTestStoreWithEngine(t testing.TB, eng engine.Engine, clock *hlc.Clock
 	bootstrap bool, sCtx storage.StoreContext, stopper *stop.Stopper) *storage.Store {
 	rpcContext := rpc.NewContext(nil, clock, stopper)
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
-	sCtx.Gossip = gossip.New(rpcContext, nil, stopper)
+	sCtx.Gossip = gossip.New(rpcContext, nil, stopper, metric.NewRegistry())
 	sCtx.Gossip.SetNodeID(nodeDesc.NodeID)
 	sCtx.ScanMaxIdleTime = 1 * time.Second
 	sCtx.Tracer = tracing.NewTracer()
@@ -553,7 +553,7 @@ func (m *multiTestContext) addStore(idx int) {
 			resolvers = append(resolvers, r)
 		}
 	}()
-	m.gossips[idx] = gossip.New(m.rpcContext, resolvers, m.transportStopper)
+	m.gossips[idx] = gossip.New(m.rpcContext, resolvers, m.transportStopper, metric.NewRegistry())
 	m.gossips[idx].SetNodeID(roachpb.NodeID(idx + 1))
 	if m.timeUntilStoreDead == 0 {
 		m.timeUntilStoreDead = storage.TestTimeUntilStoreDeadOff

--- a/storage/raft_transport_test.go
+++ b/storage/raft_transport_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/grpcutil"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/netutil"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
@@ -64,7 +65,7 @@ func TestSendAndReceive(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	nodeRPCContext := rpc.NewContext(testutils.NewNodeTestBaseContext(), nil, stopper)
-	g := gossip.New(nodeRPCContext, nil, stopper)
+	g := gossip.New(nodeRPCContext, nil, stopper, metric.NewRegistry())
 	g.SetNodeID(roachpb.NodeID(1))
 
 	// Create several servers, each of which has two stores (A raft
@@ -279,7 +280,7 @@ func TestInOrderDelivery(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	nodeRPCContext := rpc.NewContext(testutils.NewNodeTestBaseContext(), nil, stopper)
-	g := gossip.New(nodeRPCContext, nil, stopper)
+	g := gossip.New(nodeRPCContext, nil, stopper, metric.NewRegistry())
 
 	grpcServer := rpc.NewServer(nodeRPCContext)
 	ln, err := netutil.ListenAndServeGRPC(stopper, grpcServer, util.TestAddr)

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/protoutil"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/uuid"
@@ -152,7 +153,7 @@ func (tc *testContext) StartWithStoreContext(t testing.TB, ctx StoreContext) {
 	config.TestingSetupZoneConfigHook(tc.stopper)
 	if tc.gossip == nil {
 		rpcContext := rpc.NewContext(nil, nil, tc.stopper)
-		tc.gossip = gossip.New(rpcContext, nil, tc.stopper)
+		tc.gossip = gossip.New(rpcContext, nil, tc.stopper, metric.NewRegistry())
 		tc.gossip.SetNodeID(1)
 	}
 	if tc.manualClock == nil {

--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage"
 	"github.com/cockroachdb/cockroach/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 )
 
@@ -74,7 +75,7 @@ func createCluster(
 ) *Cluster {
 	clock := hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(nil, clock, stopper)
-	g := gossip.New(rpcContext, nil, stopper)
+	g := gossip.New(rpcContext, nil, stopper, metric.NewRegistry())
 	// NodeID is required for Gossip, so set it to -1 for the cluster Gossip
 	// instance to prevent conflicts with real NodeIDs.
 	g.SetNodeID(-1)

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/netutil"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/timeutil"
@@ -60,7 +61,7 @@ func createTestStorePool(timeUntilStoreDead time.Duration) (*stop.Stopper, *goss
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
 	rpcContext := rpc.NewContext(nil, clock, stopper)
-	g := gossip.New(rpcContext, nil, stopper)
+	g := gossip.New(rpcContext, nil, stopper, metric.NewRegistry())
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	storePool := NewStorePool(
@@ -488,7 +489,7 @@ func TestStorePoolReserve(t *testing.T) {
 	// Create a fake store pool.
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
-	g := gossip.New(ctx, nil, stopper)
+	g := gossip.New(ctx, nil, stopper, metric.NewRegistry())
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	storePool := NewStorePool(

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/protoutil"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -130,7 +131,7 @@ func createTestStoreWithoutStart(t testing.TB, ctx *StoreContext) (*Store, *hlc.
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
 	rpcContext := rpc.NewContext(nil, nil, stopper)
-	ctx.Gossip = gossip.New(rpcContext, nil, stopper)
+	ctx.Gossip = gossip.New(rpcContext, nil, stopper, metric.NewRegistry())
 	ctx.Gossip.SetNodeID(1)
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)

--- a/testutils/localtestcluster/local_test_cluster.go
+++ b/testutils/localtestcluster/local_test_cluster.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
+	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/tracing"
@@ -87,7 +88,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester, baseCtx *base.Context, initSen
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano)
 	ltc.Stopper = stop.NewStopper()
 	rpcContext := rpc.NewContext(baseCtx, ltc.Clock, ltc.Stopper)
-	ltc.Gossip = gossip.New(rpcContext, nil, ltc.Stopper)
+	ltc.Gossip = gossip.New(rpcContext, nil, ltc.Stopper, metric.NewRegistry())
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20, ltc.Stopper)
 
 	ltc.Stores = storage.NewStores(ltc.Clock)


### PR DESCRIPTION
This adds basic rates and counters or the number of infos/bytes sent/received as
well as the number of ingoing and outgoing connections.

All metrics:
- gossip.connections.incoming
- gossip.connections.outgoing
- gossip.bytes.received-10m
- gossip.bytes.received-1h
- gossip.bytes.received-1m
- gossip.bytes.received-count
- gossip.bytes.sent-10m
- gossip.bytes.sent-1h
- gossip.bytes.sent-1m
- gossip.bytes.sent-count
- gossip.infos.received-10m
- gossip.infos.received-1h
- gossip.infos.received-1m
- gossip.infos.received-count
- gossip.infos.sent-10m
- gossip.infos.sent-1h
- gossip.infos.sent-1m
- gossip.infos.sent-count

See #7719.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7839)

<!-- Reviewable:end -->
