### PR TITLE
testutils/testcluster: wait for all stores to be initialized

### DIFF
--- a/testutils/serverutils/test_server_shim.go
+++ b/testutils/serverutils/test_server_shim.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
@@ -60,6 +61,9 @@ type TestServerInterface interface {
 
 	// LeaseManager() returns the *sql.LeaseManager as an interface{}.
 	LeaseManager() interface{}
+
+	// Gossip returns the gossip used by the TestServer.
+	Gossip() *gossip.Gossip
 
 	// Clock returns the clock used by the TestServer.
 	Clock() *hlc.Clock


### PR DESCRIPTION
`StartTestCluster` now waits for the stores on all servers to be
initialized and gossiped. This gets rid of an issue where a cluster
could be started but we wouldn't be able to replicate to one of the
servers because it didn't have a store ID allocated to its store yet.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7856)

<!-- Reviewable:end -->
