### PR TITLE
cli: allow specifying `--join` multiple times

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -109,15 +109,25 @@ with a non-zero status code and further statements are not executed. The
 results of each SQL statement are printed on the standard output.`),
 
 	cliflags.PrettyName: wrapText(`
-Causes table rows to be formatted as tables using ASCII art. 
+Causes table rows to be formatted as tables using ASCII art.
 When not specified, table rows are printed as tab-separated values (TSV).`),
 
 	cliflags.JoinName: wrapText(`
-A comma-separated list of addresses to use when a new node is joining
-an existing cluster. For the first node in a cluster, --join should
-NOT be specified. Each address in the list has an optional type:
-[type=]<address>. An unspecified type means ip address or dns. Type
-is one of:`) + `
+The address of node which acts as bootstrap when a new node is
+joining an existing cluster. This flag can be specified
+separately for each address, for example:`) + `
+
+  --join=localhost:1234 --join=localhost:2345
+
+` + wrapText(`
+Or can be specified as a comma separated list in single flag,
+or both forms can be used together, for example:`) + `
+
+  --join=localhost:1234,localhost:2345 --join=localhost:3456
+
+` + wrapText(`
+Each address in the list has an optional type: [type=]<address>.
+An unspecified type means ip address or dns. Type is one of:`) + `
 
   - tcp: (default if type is omitted): plain ip address or hostname.
   - http-lb: HTTP load balancer: we query
@@ -418,7 +428,7 @@ func init() {
 		f.StringVar(&baseCtx.SSLCertKey, cliflags.KeyName, baseCtx.SSLCertKey, usageNoEnv(cliflags.KeyName))
 
 		// Cluster joining flags.
-		f.StringVar(&serverCtx.JoinUsing, cliflags.JoinName, serverCtx.JoinUsing, usageNoEnv(cliflags.JoinName))
+		f.VarP(&serverCtx.JoinList, cliflags.JoinName, "j", usageNoEnv(cliflags.JoinName))
 
 		// Engine flags.
 		setDefaultCacheSize(&serverCtx)

--- a/cli/start.go
+++ b/cli/start.go
@@ -366,6 +366,9 @@ func runStart(_ *cobra.Command, args []string) error {
 	for i, spec := range serverCtx.Stores.Specs {
 		fmt.Fprintf(tw, "store[%d]:\t%s\n", i, spec)
 	}
+	for i, address := range serverCtx.JoinList {
+		fmt.Fprintf(tw, "join[%d]:\t%s\n", i, address)
+	}
 	if err := tw.Flush(); err != nil {
 		return err
 	}

--- a/server/context_test.go
+++ b/server/context_test.go
@@ -47,12 +47,12 @@ func TestParseInitNodeAttributes(t *testing.T) {
 	}
 }
 
-// TestParseJoinUsingAddrs verifies that JoinUsing is parsed
+// TestParseJoinUsingAddrs verifies that JoinList is parsed
 // correctly.
 func TestParseJoinUsingAddrs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := MakeContext()
-	ctx.JoinUsing = "localhost:12345,,localhost:23456"
+	ctx.JoinList = []string{"localhost:12345,,localhost:23456", "localhost:34567"}
 	ctx.Stores = StoreSpecList{Specs: []StoreSpec{{InMemory: true, SizeInBytes: minimumStoreSize * 100}}}
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
@@ -70,7 +70,11 @@ func TestParseJoinUsingAddrs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := []resolver.Resolver{r1, r2}
+	r3, err := resolver.NewResolver(ctx.Context, "localhost:34567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []resolver.Resolver{r1, r2, r3}
 	if !reflect.DeepEqual(ctx.GossipBootstrapResolvers, expected) {
 		t.Fatalf("Unexpected bootstrap addresses: %v, expected: %v", ctx.GossipBootstrapResolvers, expected)
 	}

--- a/server/store_spec.go
+++ b/server/store_spec.go
@@ -31,6 +31,9 @@ import (
 	"github.com/cockroachdb/cockroach/util/humanizeutil"
 )
 
+// This file implements method receivers for members of server.Context struct
+// -- 'Stores' and 'JoinList', which satisfies pflag's value interface
+
 var minimumStoreSize = 10 * int64(config.DefaultZoneConfig().RangeMaxBytes)
 
 // StoreSpec contains the details that can be specified in the cli pertaining
@@ -248,5 +251,36 @@ func (ssl *StoreSpecList) Set(value string) error {
 	} else {
 		ssl.Specs = append(ssl.Specs, spec)
 	}
+	return nil
+}
+
+// JoinListType is a slice of strings that implements pflag's value
+// interface.
+type JoinListType []string
+
+// String returns a string representation of all the JoinListType. This is part
+// of pflag's value interface.
+func (jls JoinListType) String() string {
+	var buffer bytes.Buffer
+	for _, jl := range jls {
+		fmt.Fprintf(&buffer, "--join=%s ", jl)
+	}
+	// Trim the extra space from the end if it exists.
+	if l := buffer.Len(); l > 0 {
+		buffer.Truncate(l - 1)
+	}
+	return buffer.String()
+}
+
+// Type returns the underlying type in string form. This is part of pflag's
+// value interface.
+func (jls *JoinListType) Type() string {
+	return "string"
+}
+
+// Set adds a new value to the JoinListType. It is the important part of
+// pflag's value interface.
+func (jls *JoinListType) Set(value string) error {
+	*jls = append(*jls, value)
 	return nil
 }

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -93,7 +93,7 @@ func makeTestContextFromParams(params base.TestServerArgs) Context {
 	ctx := makeTestContext()
 	ctx.TestingKnobs = params.Knobs
 	if params.JoinAddr != "" {
-		ctx.JoinUsing = params.JoinAddr
+		ctx.JoinList = []string{params.JoinAddr}
 	}
 	ctx.Insecure = params.Insecure
 	ctx.SocketFile = params.SocketFile
@@ -118,7 +118,7 @@ func makeTestContextFromParams(params base.TestServerArgs) Context {
 	if params.SSLCertKey != "" {
 		ctx.SSLCertKey = params.SSLCertKey
 	}
-	ctx.JoinUsing = params.JoinAddr
+	ctx.JoinList = []string{params.JoinAddr}
 	return ctx
 }
 


### PR DESCRIPTION
Fixes #7610
CockroachDB supported specifying addresses of bootstrap nodes as a
comma-separated list:

  cockroach start --join=address1,address2 [...]

But it makes automation slightly difficult. This patch changes the
behavior. Now one needs to specify multiple --join flags to achieve the
same:

  cockroach start --join=address1 --join=address2 [...]

A short flag '-j' is also added corresponding to '--join' long flag.

Implementation detail: In the Context struct, we were storing bootstrap
node addresses as a comma-concatenated string of addresses, in JoinUsing
string variable. The variable name is now changed to JoinList whose type
is JoinListType which is nothing but a string slice. On JoinListType
struct, we added three methods: String(), Type() and Set() to adhere to
pflag's value interface.

This is a backwards-incompatible change. Comma-separated values to
--join won't work any more, but only single address specified to --join
flag will.

Documentation need to be updated to reflect this changed behavior of
--join flag, and also the new '-j' short flag

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7876)

<!-- Reviewable:end -->
