### PR TITLE
storage: update descriptor after batch commits.

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -786,9 +786,7 @@ func (r *Replica) runCommitTrigger(ctx context.Context, batch engine.Batch, ms *
 			*ms = enginepb.MVCCStats{} // clear stats, as merge recomputed.
 		}
 		if crt := ct.GetChangeReplicasTrigger(); crt != nil {
-			if err := r.changeReplicasTrigger(ctx, batch, crt); err != nil {
-				return err
-			}
+			r.changeReplicasTrigger(ctx, batch, crt)
 		}
 		if ct.GetModifiedSpanTrigger() != nil {
 			if ct.ModifiedSpanTrigger.SystemConfigSpan {
@@ -2827,13 +2825,7 @@ func (r *Replica) mergeTrigger(
 	return nil
 }
 
-func (r *Replica) changeReplicasTrigger(ctx context.Context, batch engine.Batch, change *roachpb.ChangeReplicasTrigger) error {
-	cpy := *r.Desc()
-	cpy.Replicas = change.UpdatedReplicas
-	cpy.NextReplicaID = change.NextReplicaID
-	if err := r.setDesc(&cpy); err != nil {
-		return err
-	}
+func (r *Replica) changeReplicasTrigger(ctx context.Context, batch engine.Batch, change *roachpb.ChangeReplicasTrigger) {
 	// If we're removing the current replica, add it to the range GC queue.
 	if change.ChangeType == roachpb.REMOVE_REPLICA && r.store.StoreID() == change.Replica.StoreID {
 		// Defer this to make it run as late as possible, maximizing the chances
@@ -2858,7 +2850,15 @@ func (r *Replica) changeReplicasTrigger(ctx context.Context, batch engine.Batch,
 			r.store.splitQueue.MaybeAdd(r, r.store.Clock().Now())
 		})
 	}
-	return nil
+	batch.Defer(func() {
+		cpy := *r.Desc()
+		cpy.Replicas = change.UpdatedReplicas
+		cpy.NextReplicaID = change.NextReplicaID
+		if err := r.setDesc(&cpy); err != nil {
+			// Log the error. There's not much we can do because the commit may have already occurred at this point.
+			log.Fatalf("%s: failed to update range descriptor to %+v: %s", r, cpy, err)
+		}
+	})
 }
 
 // ChangeReplicas adds or removes a replica of a range. The change is performed


### PR DESCRIPTION
Fixes #7851.

Defer update of a replica's range descriptor during a change replicas operation until after its batch completes. Previously, if the batch containing a change replicas operation failed, the range  descriptor would be updated regardless, leading to an inconsistent state for the relevant Replica.

The error handling in this patch seems anemic, but I'm not sure what I can do better. If we finish committing the batch but fail to update the range descriptor for some reason, what should happen?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7883)

<!-- Reviewable:end -->
