### PR TITLE
storage: set timestamp cache low water based on lease start

### DIFF
--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -554,6 +554,14 @@ func TestRangeTransferLease(t *testing.T) {
 
 	replica1Lease, _ := replica1.GetLease()
 
+	// Verify the timestamp cache low water. Because we executed a transfer lease
+	// request, the low water should be set to the new lease start time which is
+	// less than the previous lease's expiration time.
+	if lowWater := replica1.GetTimestampCacheLowWater(); lowWater != replica1Lease.Start {
+		t.Fatalf("expected timestamp cache low water %s, but found %s",
+			replica1Lease.Start, lowWater)
+	}
+
 	// Make replica1 extend its lease and transfer the lease immediately after
 	// that. Test that the transfer still happens (it'll wait until the extension
 	// is done).

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
 // HandleRaftMessage delegates to handleRaftMessage.
@@ -153,4 +154,11 @@ func (rs *replicaScanner) SetDisabled(disabled bool) {
 // GetLease exposes replica.getLease for tests.
 func (r *Replica) GetLease() (*roachpb.Lease, *roachpb.Lease) {
 	return r.getLease()
+}
+
+// GetTimestampCacheLowWater returns the timestamp cache low water mark.
+func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.tsCache.lowWater
 }

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -1646,9 +1646,16 @@ func (r *Replica) applyNewLeaseLocked(
 			// mark of the timestamp cache. Note that clock offset scenarios are
 			// handled via a stasis period inherent in the lease which is documented
 			// in on the Lease struct.
+			//
+			// The introduction of lease transfers implies that the previous lease
+			// may have been shortened and we are now applying a formally overlapping
+			// lease (since the old lease holder has promised not to serve any more
+			// requests, this is kosher). This means that we don't use the old
+			// lease's expiration but instead use the new lease's start to initialize
+			// the timestamp cache low water.
 			log.Infof("%s: new range lease %s following %s [physicalTime=%s]",
 				r, lease, prevLease, r.store.Clock().PhysicalTime())
-			r.mu.tsCache.SetLowWater(prevLease.Expiration)
+			r.mu.tsCache.SetLowWater(lease.Start)
 		} else if err := r.withRaftGroupLocked(func(raftGroup *raft.RawNode) error {
 			if raftGroup.Status().RaftState == raft.StateLeader {
 				// If this replica is the raft leader but it is not the new lease

--- a/testutils/testcluster/testcluster_test.go
+++ b/testutils/testcluster/testcluster_test.go
@@ -157,20 +157,13 @@ func TestBasicManualReplication(t *testing.T) {
 		t.Fatalf("expected %d replicas, got %+v", expected, desc.Replicas)
 	}
 
-	// TODO(andrei,tobias): Figure out how to fix the test failure:
-	//
-	// testcluster_test.go:169: change replicas of range 1 failed: storage/store.go:1938:
-	//   rejecting command with timestamp in the future: 1468681160641425412 (3.047592914s ahead)
-	//
-	// This is caused by Replica.applyNewLeaseLocked setting the timestamp cache
-	// low water based on the previous lease expiration.
-	// if err := tc.TransferRangeLease(desc, tc.Target(1)); err != nil {
-	// 	t.Fatal(err)
-	// }
+	if err := tc.TransferRangeLease(desc, tc.Target(1)); err != nil {
+		t.Fatal(err)
+	}
 
-	// TODO(peter): Removing the range leader (tc.Target(0)) causes the test to
+	// TODO(peter): Removing the range leader (tc.Target(1)) causes the test to
 	// take ~13s vs ~1.5s for removing a non-leader. Track down that slowness.
-	desc, err = tc.RemoveReplicas(desc.StartKey, tc.Target(1))
+	desc, err = tc.RemoveReplicas(desc.StartKey, tc.Target(0))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #7878.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7885)

<!-- Reviewable:end -->
