### PR TITLE
ui: fix incorrect protobuf handling in /raft/ranges

### DIFF
--- a/ui/app/containers/raftRanges.tsx
+++ b/ui/app/containers/raftRanges.tsx
@@ -175,7 +175,7 @@ class RangesMain extends React.Component<RangesMainProps, RangesMainState> {
               <div>Replica On: {replicaNodeIDs.join(", ")}</div>
               <div>Next Replica ID: {nodeRange.state.state.desc.next_replica_id}</div>
             </div> : ""}
-            {(this.state.showPending) ? <div>Pending Command Count: {nodeRange.state.num_pending || 0}</div> : ""}
+            {(this.state.showPending) ? <div>Pending Command Count: {(nodeRange.state.num_pending || 0).toString()}</div> : ""}
           </td>;
           row[index] = cell;
         });


### PR DESCRIPTION
Error occurred at  https://github.com/cockroachdb/cockroach/commit/13282c0ac408cb9ee0b38813e58f6417d5046665#diff-418156c82b28786067251a8ecd887768L175 when the type was changed from `int32` to `uint64`.

React throws an error since `Long` isn't a basic data type or part of React.

@tschottdorf @maxlang @bdarnell

Fixes #7891.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7894)

<!-- Reviewable:end -->
