### PR TITLE
storage: make baseQueue contain a RangeID instead of a Replica object

### DIFF
--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -95,9 +95,9 @@ type gcQueue struct {
 }
 
 // newGCQueue returns a new instance of gcQueue.
-func newGCQueue(gossip *gossip.Gossip) *gcQueue {
+func newGCQueue(store *Store, gossip *gossip.Gossip) *gcQueue {
 	gcq := &gcQueue{}
-	gcq.baseQueue = makeBaseQueue("gc", gcq, gossip, queueConfig{
+	gcq.baseQueue = makeBaseQueue("gc", gcq, store, gossip, queueConfig{
 		maxSize:              gcQueueMaxSize,
 		needsLease:           true,
 		acceptsUnsplitRanges: false,

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -124,7 +124,7 @@ func TestGCQueueShouldQueue(t *testing.T) {
 		{0, 0, 2, 0, hlc.ZeroTimestamp, true, 1},
 	}
 
-	gcQ := newGCQueue(tc.gossip)
+	gcQ := newGCQueue(tc.store, tc.gossip)
 
 	for i, test := range testCases {
 		// Write gc'able bytes as key bytes; since "live" bytes will be
@@ -272,7 +272,7 @@ func TestGCQueueProcess(t *testing.T) {
 	}
 
 	// Process through a scan queue.
-	gcQ := newGCQueue(tc.gossip)
+	gcQ := newGCQueue(tc.store, tc.gossip)
 	if err := gcQ.process(context.Background(), tc.clock.Now(), tc.rng, cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -488,7 +488,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	}
 
 	// Run GC.
-	gcQ := newGCQueue(tc.gossip)
+	gcQ := newGCQueue(tc.store, tc.gossip)
 	cfg, ok := tc.gossip.GetSystemConfig()
 	if !ok {
 		t.Fatal("config not set")
@@ -591,7 +591,7 @@ func TestGCQueueIntentResolution(t *testing.T) {
 	}
 
 	// Process through a scan queue.
-	gcQ := newGCQueue(tc.gossip)
+	gcQ := newGCQueue(tc.store, tc.gossip)
 	if err := gcQ.process(context.Background(), tc.clock.Now(), tc.rng, cfg); err != nil {
 		t.Fatal(err)
 	}

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -52,7 +52,7 @@ type purgatoryError interface {
 
 // A replicaItem holds a replica and its priority for use with a priority queue.
 type replicaItem struct {
-	value    *Replica
+	value    roachpb.RangeID
 	priority float64
 	// The index is needed by update and is maintained by the heap.Interface methods.
 	index int // The index of the item in the heap.
@@ -185,6 +185,7 @@ type baseQueue struct {
 	// a pointer to a structure which is a copy of the one within which
 	// it is contained. DANGER.
 	impl   queueImpl
+	store  *Store
 	gossip *gossip.Gossip
 	queueConfig
 	incoming chan struct{} // Channel signaled when a new replica is added to the queue.
@@ -210,12 +211,14 @@ type baseQueue struct {
 func makeBaseQueue(
 	name string,
 	impl queueImpl,
+	store *Store,
 	gossip *gossip.Gossip,
 	cfg queueConfig,
 ) baseQueue {
 	bq := baseQueue{
 		name:        name,
 		impl:        impl,
+		store:       store,
 		gossip:      gossip,
 		queueConfig: cfg,
 		incoming:    make(chan struct{}, 1),
@@ -350,7 +353,7 @@ func (bq *baseQueue) addInternal(repl *Replica, should bool, priority float64) e
 	}
 
 	bq.eventLog.VInfof(log.V(3), "%s: adding: priority=%0.3f", repl, priority)
-	item = &replicaItem{value: repl, priority: priority}
+	item = &replicaItem{value: repl.RangeID, priority: priority}
 	heap.Push(&bq.mu.priorityQ, item)
 	bq.mu.replicas[repl.RangeID] = item
 
@@ -410,9 +413,7 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 				}
 			// Process replicas as the timer expires.
 			case <-nextTime:
-				bq.mu.Lock()
 				repl := bq.pop()
-				bq.mu.Unlock()
 				if repl != nil {
 					if stopper.RunTask(func() {
 						if err := bq.processReplica(repl, clock); err != nil {
@@ -502,7 +503,7 @@ func (bq *baseQueue) maybeAddToPurgatory(repl *Replica, err error, clock *hlc.Cl
 
 	bq.eventLog.Error(errors.Wrapf(err, "(purgatory) on %s", repl))
 
-	item := &replicaItem{value: repl}
+	item := &replicaItem{value: repl.RangeID}
 	bq.mu.replicas[repl.RangeID] = item
 
 	// If purgatory already exists, just add to the map and we're done.
@@ -523,14 +524,19 @@ func (bq *baseQueue) maybeAddToPurgatory(repl *Replica, err error, clock *hlc.Cl
 			case <-bq.impl.purgatoryChan():
 				// Remove all items from purgatory into a copied slice.
 				bq.mu.Lock()
-				repls := make([]*Replica, 0, len(bq.mu.purgatory))
+				ranges := make([]roachpb.RangeID, 0, len(bq.mu.purgatory))
 				for rangeID := range bq.mu.purgatory {
 					item := bq.mu.replicas[rangeID]
-					repls = append(repls, item.value)
+					ranges = append(ranges, item.value)
 					bq.remove(item)
 				}
 				bq.mu.Unlock()
-				for _, repl := range repls {
+				for _, id := range ranges {
+					repl, err := bq.store.GetReplica(id)
+					if err != nil {
+						bq.eventLog.Error(errors.Wrapf(err, "range %s no longer exists on store", id))
+						return
+					}
 					if stopper.RunTask(func() {
 						if err := bq.processReplica(repl, clock); err != nil {
 							bq.maybeAddToPurgatory(repl, err, clock, stopper)
@@ -569,38 +575,44 @@ func (bq *baseQueue) maybeAddToPurgatory(repl *Replica, err error, clock *hlc.Cl
 // replica if not empty; otherwise, returns nil. Expects mutex to be
 // locked.
 func (bq *baseQueue) pop() *Replica {
+	bq.mu.Lock()
+
 	if bq.mu.priorityQ.Len() == 0 {
+		bq.mu.Unlock()
 		return nil
 	}
 	item := heap.Pop(&bq.mu.priorityQ).(*replicaItem)
-	delete(bq.mu.replicas, item.value.RangeID)
-	return item.value
+	delete(bq.mu.replicas, item.value)
+	bq.mu.Unlock()
+
+	repl, err := bq.store.GetReplica(item.value)
+	if err != nil {
+		bq.eventLog.Error(errors.Wrapf(err, "range %s no longer exists on store", item.value))
+		return nil
+	}
+	return repl
 }
 
 // remove removes an element from purgatory (if it's experienced an
 // error) or from the priority queue by index. Caller must hold mutex.
 func (bq *baseQueue) remove(item *replicaItem) {
-	if _, ok := bq.mu.purgatory[item.value.RangeID]; ok {
-		delete(bq.mu.purgatory, item.value.RangeID)
+	if _, ok := bq.mu.purgatory[item.value]; ok {
+		delete(bq.mu.purgatory, item.value)
 	} else {
 		heap.Remove(&bq.mu.priorityQ, item.index)
 	}
-	delete(bq.mu.replicas, item.value.RangeID)
+	delete(bq.mu.replicas, item.value)
 }
 
 // DrainQueue locks the queue and processes the remaining queued replicas. It
 // processes the replicas in the order they're queued in, one at a time.
 // Exposed for testing only.
 func (bq *baseQueue) DrainQueue(clock *hlc.Clock) {
-	bq.mu.Lock()
 	repl := bq.pop()
-	bq.mu.Unlock()
 	for repl != nil {
 		if err := bq.processReplica(repl, clock); err != nil {
 			bq.eventLog.Error(errors.Wrapf(err, "failed processing replica %s", repl))
 		}
-		bq.mu.Lock()
 		repl = bq.pop()
-		bq.mu.Unlock()
 	}
 }

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -53,11 +53,11 @@ type raftLogQueue struct {
 }
 
 // newRaftLogQueue returns a new instance of raftLogQueue.
-func newRaftLogQueue(db *client.DB, gossip *gossip.Gossip) *raftLogQueue {
+func newRaftLogQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *raftLogQueue {
 	rlq := &raftLogQueue{
 		db: db,
 	}
-	rlq.baseQueue = makeBaseQueue("raftlog", rlq, gossip, queueConfig{
+	rlq.baseQueue = makeBaseQueue("raftlog", rlq, store, gossip, queueConfig{
 		maxSize:              raftLogQueueMaxSize,
 		needsLease:           false,
 		acceptsUnsplitRanges: true,

--- a/storage/replica_consistency_queue.go
+++ b/storage/replica_consistency_queue.go
@@ -37,9 +37,9 @@ type replicaConsistencyQueue struct {
 }
 
 // newReplicaConsistencyQueue returns a new instance of replicaConsistencyQueue.
-func newReplicaConsistencyQueue(gossip *gossip.Gossip) *replicaConsistencyQueue {
+func newReplicaConsistencyQueue(store *Store, gossip *gossip.Gossip) *replicaConsistencyQueue {
 	rcq := &replicaConsistencyQueue{}
-	rcq.baseQueue = makeBaseQueue("replica consistency checker", rcq, gossip, queueConfig{
+	rcq.baseQueue = makeBaseQueue("replica consistency checker", rcq, store, gossip, queueConfig{
 		maxSize:              replicaConsistencyQueueSize,
 		needsLease:           true,
 		acceptsUnsplitRanges: true,

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -57,11 +57,11 @@ type replicaGCQueue struct {
 }
 
 // newReplicaGCQueue returns a new instance of replicaGCQueue.
-func newReplicaGCQueue(db *client.DB, gossip *gossip.Gossip) *replicaGCQueue {
+func newReplicaGCQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *replicaGCQueue {
 	q := &replicaGCQueue{
 		db: db,
 	}
-	q.baseQueue = makeBaseQueue("replicaGC", q, gossip, queueConfig{
+	q.baseQueue = makeBaseQueue("replicaGC", q, store, gossip, queueConfig{
 		maxSize:              replicaGCQueueMaxSize,
 		needsLease:           false,
 		acceptsUnsplitRanges: true,

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -49,14 +49,14 @@ type replicateQueue struct {
 }
 
 // newReplicateQueue returns a new instance of replicateQueue.
-func newReplicateQueue(g *gossip.Gossip, allocator Allocator, clock *hlc.Clock,
+func newReplicateQueue(store *Store, g *gossip.Gossip, allocator Allocator, clock *hlc.Clock,
 	options AllocatorOptions) *replicateQueue {
 	rq := &replicateQueue{
 		allocator:  allocator,
 		clock:      clock,
 		updateChan: make(chan struct{}, 1),
 	}
-	rq.baseQueue = makeBaseQueue("replicate", rq, g, queueConfig{
+	rq.baseQueue = makeBaseQueue("replicate", rq, store, g, queueConfig{
 		maxSize:              replicateQueueMaxSize,
 		needsLease:           true,
 		acceptsUnsplitRanges: false,

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -46,11 +46,11 @@ type splitQueue struct {
 }
 
 // newSplitQueue returns a new instance of splitQueue.
-func newSplitQueue(db *client.DB, gossip *gossip.Gossip) *splitQueue {
+func newSplitQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *splitQueue {
 	sq := &splitQueue{
 		db: db,
 	}
-	sq.baseQueue = makeBaseQueue("split", sq, gossip, queueConfig{
+	sq.baseQueue = makeBaseQueue("split", sq, store, gossip, queueConfig{
 		maxSize:              splitQueueMaxSize,
 		needsLease:           true,
 		acceptsUnsplitRanges: true,

--- a/storage/split_queue_test.go
+++ b/storage/split_queue_test.go
@@ -72,7 +72,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		{keys.MakeTablePrefix(2001), roachpb.RKeyMax, 32<<20 + 1, true, 1},
 	}
 
-	splitQ := newSplitQueue(nil, tc.gossip)
+	splitQ := newSplitQueue(tc.store, nil, tc.gossip)
 
 	cfg, ok := tc.gossip.GetSystemConfig()
 	if !ok {

--- a/storage/store.go
+++ b/storage/store.go
@@ -859,17 +859,17 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 	if s.ctx.Gossip != nil {
 		// Add range scanner and configure with queues.
 		s.scanner = newReplicaScanner(ctx.ScanInterval, ctx.ScanMaxIdleTime, newStoreRangeSet(s))
-		s.gcQueue = newGCQueue(s.ctx.Gossip)
-		s.splitQueue = newSplitQueue(s.db, s.ctx.Gossip)
-		s.verifyQueue = newVerifyQueue(s.ctx.Gossip, s.ReplicaCount)
-		s.replicateQueue = newReplicateQueue(s.ctx.Gossip, s.allocator, s.ctx.Clock, s.ctx.AllocatorOptions)
-		s.replicaGCQueue = newReplicaGCQueue(s.db, s.ctx.Gossip)
-		s.raftLogQueue = newRaftLogQueue(s.db, s.ctx.Gossip)
+		s.gcQueue = newGCQueue(s, s.ctx.Gossip)
+		s.splitQueue = newSplitQueue(s, s.db, s.ctx.Gossip)
+		s.verifyQueue = newVerifyQueue(s, s.ctx.Gossip, s.ReplicaCount)
+		s.replicateQueue = newReplicateQueue(s, s.ctx.Gossip, s.allocator, s.ctx.Clock, s.ctx.AllocatorOptions)
+		s.replicaGCQueue = newReplicaGCQueue(s, s.db, s.ctx.Gossip)
+		s.raftLogQueue = newRaftLogQueue(s, s.db, s.ctx.Gossip)
 		s.scanner.AddQueues(s.gcQueue, s.splitQueue, s.verifyQueue, s.replicateQueue, s.replicaGCQueue, s.raftLogQueue)
 
 		// Add consistency check scanner.
 		s.consistencyScanner = newReplicaScanner(ctx.ConsistencyCheckInterval, 0, newStoreRangeSet(s))
-		s.replicaConsistencyQueue = newReplicaConsistencyQueue(s.ctx.Gossip)
+		s.replicaConsistencyQueue = newReplicaConsistencyQueue(s, s.ctx.Gossip)
 		s.consistencyScanner.AddQueues(s.replicaConsistencyQueue)
 	}
 

--- a/storage/verify_queue.go
+++ b/storage/verify_queue.go
@@ -48,9 +48,9 @@ type verifyQueue struct {
 }
 
 // newVerifyQueue returns a new instance of verifyQueue.
-func newVerifyQueue(gossip *gossip.Gossip, countFn rangeCountFn) *verifyQueue {
+func newVerifyQueue(store *Store, gossip *gossip.Gossip, countFn rangeCountFn) *verifyQueue {
 	vq := &verifyQueue{countFn: countFn}
-	vq.baseQueue = makeBaseQueue("verify", vq, gossip, queueConfig{
+	vq.baseQueue = makeBaseQueue("verify", vq, store, gossip, queueConfig{
 		maxSize:              verifyQueueMaxSize,
 		needsLease:           false,
 		acceptsUnsplitRanges: true,

--- a/storage/verify_queue_test.go
+++ b/storage/verify_queue_test.go
@@ -55,7 +55,7 @@ func TestVerifyQueueShouldQueue(t *testing.T) {
 		{makeTS(verificationInterval.Nanoseconds()*2, 0), true, 2},
 	}
 
-	verifyQ := newVerifyQueue(tc.gossip, nil)
+	verifyQ := newVerifyQueue(tc.store, tc.gossip, nil)
 	emptyConfig := config.SystemConfig{}
 
 	for i, test := range testCases {


### PR DESCRIPTION
This changes how queues hold information about replicas. Now, instead of storing
a Replica object, a queue stores a roachpb.RangeID and fetches the Replica when
popping from the queue. This prevents issues when replicas are removed due to
change replicas or other reasons but there still is a reference to them in the
queue.

Fixes #7879.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7901)

<!-- Reviewable:end -->
