### PR TITLE
storage: move rangeDesc out of replica.mu, and use it in Desc()

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -661,9 +661,10 @@ func (r *Replica) setDescWithoutProcessUpdate(desc *roachpb.RangeDescriptor) {
 // setDescWithoutProcessUpdateLocked requires that the replica lock is held.
 func (r *Replica) setDescWithoutProcessUpdateLocked(desc *roachpb.RangeDescriptor) {
 	if desc.RangeID != r.RangeID {
-		panic(fmt.Sprintf("range descriptor ID (%d) does not match replica's range ID (%d)",
-			desc.RangeID, r.RangeID))
+		r.panicf("range descriptor ID (%d) does not match replica's range ID (%d)",
+			desc.RangeID, r.RangeID)
 	}
+
 	r.mu.state.Desc = desc
 	r.mu.rangeDesc.Store(desc)
 }
@@ -808,7 +809,7 @@ func (r *Replica) assertState(reader engine.Reader) {
 func (r *Replica) assertStateLocked(reader engine.Reader) {
 	diskState, err := loadState(reader, r.mu.state.Desc)
 	if err != nil {
-		panic(err)
+		r.panic(err)
 	}
 	if !reflect.DeepEqual(diskState, r.mu.state) {
 		log.Fatalf("%s: on-disk and in-memory state diverged:\n%+v\n%+v", r, diskState, r.mu.state)
@@ -847,9 +848,9 @@ func (r *Replica) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 		// empty batch; shouldn't happen (we could handle it, but it hints
 		// at someone doing weird things, and once we drop the key range
 		// from the header it won't be clear how to route those requests).
-		panic("empty batch")
+		r.panic("empty batch")
 	} else {
-		panic(fmt.Sprintf("don't know how to handle command %s", ba))
+		r.panicf("don't know how to handle command %s", ba)
 	}
 	if _, ok := pErr.GetDetail().(*roachpb.RaftGroupDeletedError); ok {
 		// This error needs to be converted appropriately so that
@@ -1710,7 +1711,7 @@ func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 			raftGroup.ReportUnreachable(msg.To)
 			return nil
 		}); err != nil {
-			panic(err)
+			r.panic(err)
 		}
 	}
 }
@@ -1725,7 +1726,7 @@ func (r *Replica) reportSnapshotStatus(to uint64, snapErr error) {
 		raftGroup.ReportSnapshot(to, snapStatus)
 		return nil
 	}); err != nil {
-		panic(err)
+		r.panic(err)
 	}
 }
 
@@ -2364,7 +2365,8 @@ func (r *Replica) executeBatch(
 			if cReply, ok := reply.(roachpb.Countable); ok {
 				retResults := cReply.Count()
 				if retResults > remScanResults {
-					panic(fmt.Sprintf("received %d results, limit was %d", retResults, remScanResults))
+					r.panicf("received %d results, limit was %d",
+						retResults, remScanResults)
 				}
 				remScanResults -= retResults
 			}
@@ -2644,4 +2646,12 @@ func (r *Replica) maybeAddToRaftLogQueue(appliedIndex uint64) {
 	if appliedIndex%raftLogCheckFrequency == 0 {
 		r.store.raftLogQueue.MaybeAdd(r, r.store.Clock().Now())
 	}
+}
+
+func (r *Replica) panic(s interface{}) {
+	panic(r.String() + ": " + s)
+}
+
+func (r *Replica) panicf(format string, vals ...interface{}) {
+	panic(r.String() + ": " + fmt.Sprintf(format, vals...))
 }

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -366,7 +366,7 @@ func TestReplicaContains(t *testing.T) {
 	// This test really only needs a hollow shell of a Replica.
 	r := &Replica{}
 	r.mu.state.Desc = desc
-	r.mu.rangeDesc.Store(desc)
+	r.rangeDesc.Store(desc)
 
 	if statsKey := keys.RangeStatsKey(desc.RangeID); !r.ContainsKey(statsKey) {
 		t.Errorf("expected range to contain range stats key %q", statsKey)


### PR DESCRIPTION
509c454 made replica.String() readable without locks, and prepended
all logs and errors with it. Prepend panics as well.

In #7871, replica.String() was refactored to use a new atomically
readable copy of the RangeDescriptor. replica.Desc() could use this as
well (so as to not lock replica.mu), but this change was
conservatively deferred. However, with the issue of replica.Desc()
acquiring locks being raised in #7888, and after discussion with
@bdarnell, it should be safe to refactor replica.Desc() as well.

Finally replica.mu.rangeDesc is moved outside mu to replica.rangeDesc
to maintain the semantics of replica.mu

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7904)

<!-- Reviewable:end -->
