### PR TITLE
storage: ensure nonoverlapping ranges

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -1811,16 +1811,17 @@ func (s *Store) processRangeDescriptorUpdateLocked(rng *Replica) error {
 	}
 	delete(s.mu.uninitReplicas, rangeID)
 
-	// Add the range and its current stats into metrics.
-	s.metrics.replicaCount.Inc(1)
-
-	if s.mu.replicasByKey.Has(rng) {
+	if s.hasOverlappingReplicaLocked(rng.Desc()) {
 		return rangeAlreadyExists{rng}
 	}
 	if exRngItem := s.mu.replicasByKey.ReplaceOrInsert(rng); exRngItem != nil {
 		return errors.Errorf("range for key %v already exists in replicasByKey btree",
 			(exRngItem.(*Replica)).getKey())
 	}
+
+	// Add the range and its current stats into metrics.
+	s.metrics.replicaCount.Inc(1)
+
 	return nil
 }
 

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -587,6 +587,71 @@ func TestHasOverlappingReplica(t *testing.T) {
 	}
 }
 
+func TestProcessRangeDescriptorUpdate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	store, _, stopper := createTestStore(t)
+	defer stopper.Stop()
+
+	// Clobber the existing range so we can test overlaps that aren't KeyMin or KeyMax.
+	rng1, err := store.GetReplica(1)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := store.RemoveReplica(rng1, *rng1.Desc(), true); err != nil {
+		t.Error(err)
+	}
+
+	rng := createRange(store, roachpb.RangeID(2), roachpb.RKey("a"), roachpb.RKey("c"))
+	if err := store.AddReplicaTest(rng); err != nil {
+		t.Fatal(err)
+	}
+
+	newRangeID := roachpb.RangeID(3)
+	desc := &roachpb.RangeDescriptor{
+		RangeID: newRangeID,
+		Replicas: []roachpb.ReplicaDescriptor{{
+			NodeID:    1,
+			StoreID:   1,
+			ReplicaID: 1,
+		}},
+		NextReplicaID: 2,
+	}
+
+	r := &Replica{
+		RangeID:    desc.RangeID,
+		store:      store,
+		abortCache: NewAbortCache(desc.RangeID),
+		raftSender: store.ctx.Transport.MakeSender(func(err error, toReplica roachpb.ReplicaDescriptor) {}),
+	}
+	if err := r.newReplicaInner(desc, store.Clock(), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedResult := "attempted to process uninitialized range.*"
+	if err := store.processRangeDescriptorUpdate(r); !testutils.IsError(err, expectedResult) {
+		t.Errorf("expected processRangeDescriptorUpdate with uninitialized replica to fail, got %v", err)
+	}
+
+	// Initialize the range with start and end keys.
+	r.mu.Lock()
+	r.mu.state.Desc.StartKey = roachpb.RKey("b")
+	r.mu.state.Desc.EndKey = roachpb.RKey("d")
+	r.mu.Unlock()
+
+	if err := store.processRangeDescriptorUpdateLocked(r); err != nil {
+		t.Errorf("expected processRangeDescriptorUpdate on a replica that's not in the uninit map to silently succeed, got %v", err)
+	}
+
+	store.mu.Lock()
+	store.mu.uninitReplicas[newRangeID] = r
+	store.mu.Unlock()
+
+	expectedResult = rangeAlreadyExists{r}.Error()
+	if err := store.processRangeDescriptorUpdate(r); !testutils.IsError(err, expectedResult) {
+		t.Errorf("expected processRangeDescriptorUpdate with overlapping keys to fail, got %v", err)
+	}
+}
+
 // TestStoreSend verifies straightforward command execution
 // of both a read-only and a read-write command.
 func TestStoreSend(t *testing.T) {


### PR DESCRIPTION
processRangeDescriptorUpdateLocked checks to see if there is an
existing range before adding a Replica. We should widen the check to
look for any overlapping ranges. This addresses one of the cases in #7830.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7905)

<!-- Reviewable:end -->
