### PR TITLE
util/leaktest: no-op when called during stack unwinding

### DIFF
--- a/util/leaktest/leaktest.go
+++ b/util/leaktest/leaktest.go
@@ -73,6 +73,9 @@ func AfterTest(t testing.TB) func() {
 		if t.Failed() {
 			return
 		}
+		if r := recover(); r != nil {
+			panic(r)
+		}
 		// Loop, waiting for goroutines to shut down.
 		// Wait up to 5 seconds, but finish as quickly as possible.
 		deadline := timeutil.Now().Add(5 * time.Second)


### PR DESCRIPTION
From the graveyard. I added this since some test I was investigating failed with a panic, but leaktest would still run and clutter the output.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7910)

<!-- Reviewable:end -->
