### PR TITLE
sql: properly handle column names in INSERT and UPDATE

### DIFF
--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -443,3 +443,15 @@ CREATE TABLE nocols()
 
 statement error INSERT error: table nocols has \d+ columns but \d+ values were supplied
 INSERT INTO nocols VALUES (true, default)
+
+statement error column "kv" does not exist
+INSERT INTO kv (kv.k) VALUES ('hello')
+
+statement error column name "k\.\*" cannot be assigned to
+INSERT INTO kv (k.*) VALUES ('hello')
+
+statement error column name "k\[0\]" cannot be assigned to
+INSERT INTO kv (k[0]) VALUES ('hello')
+
+statement error column name "k\.v" cannot be assigned to
+INSERT INTO kv (k.v) VALUES ('hello')

--- a/sql/testdata/update
+++ b/sql/testdata/update
@@ -32,6 +32,18 @@ SELECT * FROM kv
 statement error column "m" does not exist
 UPDATE kv SET m = 9 WHERE k IN (1, 3)
 
+statement error column "kv" does not exist
+UPDATE kv SET kv.k = 9
+
+statement error column name "k\.\*" cannot be assigned to
+UPDATE kv SET k.* = 9
+
+statement error column name "k\[0\]" cannot be assigned to
+UPDATE kv SET k[0] = 9
+
+statement error column name "k\.v" cannot be assigned to
+UPDATE kv SET k.v = 9
+
 statement ok
 CREATE TABLE kv2 (
   k CHAR PRIMARY KEY,


### PR DESCRIPTION
Prior to this patch the code assumed that the names in the INSERT
column list (`INSERT foo( <here> )`) and the LHS of UPDATE set
expressions (`UPDATE foo SET <here> = ...`) are qualified in the same
way as in other places, i.e. "X.Y" means "X" is a table name. This is
wrong and is now fixed.

Fixes #7873.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7911)

<!-- Reviewable:end -->
