### PR TITLE
cli: document `debug sstables` output format

### DIFF
--- a/cli/debug.go
+++ b/cli/debug.go
@@ -714,7 +714,25 @@ var debugSSTablesCmd = &cobra.Command{
 	Use:   "sstables [directory]",
 	Short: "list the sstables in a store",
 	Long: `
-List the sstables in a store.
+
+List the sstables in a store. The output format is 1 or more lines of:
+
+  level [ total size #files ]: file sizes
+
+Only non-empty levels are shown. For levels greater than 0, the files span
+non-overlapping ranges of the key space. Level-0 is special in that sstables
+are created there by flushing the mem-table, thus every level-0 sstable must be
+consulted to see if it contains a particular key. Within a level, the file
+sizes are displayed in decreasing order and bucketed by the number of files of
+that size. The following example shows 3-level output. In Level-3, there are 19
+total files and 14 files that are 129 MiB in size.
+
+  1 [   8M  3 ]: 7M 1M 63K
+  2 [ 110M  7 ]: 31M 30M 13M[2] 10M 8M 5M
+  3 [   2G 19 ]: 129M[14] 122M 93M 24M 18M 9M
+
+The suffixes K, M, G and T are used for terseness to represent KiB, MiB, GiB
+and TiB.
 `,
 	RunE: runDebugSSTables,
 }

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"testing"
 
@@ -373,10 +374,11 @@ func TestSSTableInfosString(t *testing.T) {
 		info(3, 24<<20),
 		info(3, 18<<20),
 	}
-	expected := `1 [   8M]: 7M 1M 63K
-2 [ 110M]: 10M 8M 13M 31M 13M 30M 5M
-3 [   2G]: 129M 129M 129M 9M 129M 129M 129M 93M 129M 129M 122M 129M 129M 129M 129M 129M 129M 24M 18M
+	expected := `1 [   8M  3 ]: 7M 1M 63K
+2 [ 110M  7 ]: 31M 30M 13M[2] 10M 8M 5M
+3 [   2G 19 ]: 129M[14] 122M 93M 24M 18M 9M
 `
+	sort.Sort(tables)
 	s := tables.String()
 	if expected != s {
 		t.Fatalf("expected\n%s\ngot\n%s", expected, s)


### PR DESCRIPTION
Change the format to bucket files by a particular size within a level.

Fixes #7908.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7913)

<!-- Reviewable:end -->
