### PR TITLE
storage: don't down-replicate the range holding range lease

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -689,12 +689,12 @@ func TestStoreRangeDownReplicate(t *testing.T) {
 
 	maxTimeout := time.After(10 * time.Second)
 	succeeded := false
+	i := 0
 	for !succeeded {
 		select {
 		case <-maxTimeout:
 			t.Fatalf("Failed to achieve proper replication within 10 seconds")
 		case <-time.After(10 * time.Millisecond):
-			mtc.expireLeases()
 			rangeDesc := getRangeMetadata(rightKeyAddr, mtc, t)
 			if count := len(rangeDesc.Replicas); count < 3 {
 				t.Fatalf("Removed too many replicas; expected at least 3 replicas, found %d", count)
@@ -703,12 +703,26 @@ func TestStoreRangeDownReplicate(t *testing.T) {
 				break
 			}
 
-			// Run replication scans on every store; only the store with the
-			// range lease will actually do anything. If we did not wait
-			// for the scan to complete here it could be interrupted by the
-			// next call to expireLeases.
-			for _, store := range mtc.stores {
-				store.ForceReplicationScanAndProcess()
+			// Cycle the lease to the next replica (on the next store) if that
+			// replica still exists. This avoids the condition in which we try
+			// to continuously remove the replica on a store when
+			// down-replicating while it also still holds the lease.
+			for {
+				i++
+				if i >= len(mtc.stores) {
+					i = 0
+				}
+				rep := mtc.stores[i].LookupReplica(rightKeyAddr, nil)
+				if rep != nil {
+					mtc.expireLeases()
+					// Force the read command request a new lease.
+					getArgs := getArgs(rightKey)
+					if _, err := client.SendWrapped(mtc.distSenders[i], nil, &getArgs); err != nil {
+						t.Fatal(err)
+					}
+					mtc.stores[i].ForceReplicationScanAndProcess()
+					break
+				}
 			}
 		}
 	}

--- a/storage/replica_range_lease.go
+++ b/storage/replica_range_lease.go
@@ -272,7 +272,7 @@ func (r *Replica) AdminTransferLease(nextLeader roachpb.ReplicaDescriptor) error
 		defer r.mu.Unlock()
 		lease := r.mu.state.Lease
 		if !lease.OwnedBy(r.store.StoreID()) {
-			return nil, nil, r.newNotLeaseHolderError(lease, r.store.StoreID(), r.Desc())
+			return nil, nil, r.newNotLeaseHolderError(lease, r.store.StoreID(), r.mu.state.Desc)
 		}
 		nextLease := r.mu.pendingLeaseRequest.RequestPending()
 		if nextLease != nil && nextLease.Replica != nextLeader {

--- a/storage/simulation/range.go
+++ b/storage/simulation/range.go
@@ -124,7 +124,9 @@ func (r *Range) getAllocateTarget() (roachpb.StoreID, error) {
 // getRemoveTarget queries the allocator for the store that contains a replica
 // that can be removed.
 func (r *Range) getRemoveTarget() (roachpb.StoreID, error) {
-	removeStore, err := r.allocator.RemoveTarget(r.desc.Replicas)
+	// Pass in an invalid store ID since we don't consider range leases as part
+	// of the simulator.
+	removeStore, err := r.allocator.RemoveTarget(r.desc.Replicas, roachpb.StoreID(-1))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This is the preventative measure for stopping a down-replication of the range
lease holder's replica.  RemoveTarget will pick the worst replica from the list
that does not contain the lease holder's replica.
Part of #5737

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7918)

<!-- Reviewable:end -->
