### PR TITLE
all: gengo/grpc-gateway -> grpc-ecosystem/grpc-gateway

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -2,9 +2,9 @@ cmd github.com/client9/misspell/cmd/misspell
 cmd github.com/cockroachdb/c-protobuf/cmd/protoc
 cmd github.com/cockroachdb/cockroach/cmd/protoc-gen-gogoroach
 cmd github.com/cockroachdb/stress
-cmd github.com/gengo/grpc-gateway/protoc-gen-grpc-gateway
 cmd github.com/golang/lint/golint
 cmd github.com/gordonklaus/ineffassign
+cmd github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 cmd github.com/jteeuwen/go-bindata/go-bindata
 cmd github.com/kisielk/errcheck
 cmd github.com/kkaneda/returncheck
@@ -39,7 +39,6 @@ github.com/docker/go-units f2d77a61e3c169b43402a0a1e84f06daf29b8190
 github.com/dustin/go-humanize fef948f2d241bd1fd0631108ecc2c9553bae60bf
 github.com/elastic/gosigar f720d6786aff82d4dae3d0af8c0ea5a34cd04029
 github.com/elazarl/go-bindata-assetfs 57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2
-github.com/gengo/grpc-gateway faa3576c70e270b37279f045637a7d04f632e353
 github.com/go-sql-driver/mysql 3654d25ec346ee8ce71a68431025458d52a38ac0
 github.com/gogo/protobuf 318371cbef6bab80e8d1c69b470fffa79eebfb54
 github.com/golang/glog 23def4e6c14b4da8ac2ed8007337bc5eb5007998
@@ -47,6 +46,7 @@ github.com/golang/lint c7bacac2b21ca01afa1dee0acf64df3ce047c28f
 github.com/golang/protobuf 3852dcfda249c2097355a6aabb199a28d97b30df
 github.com/google/btree 7d79101e329e5a3adf994758c578dab82b90c017
 github.com/gordonklaus/ineffassign 71e35c2a79cb470e72313ec93d6750089dc95fa3
+github.com/grpc-ecosystem/grpc-gateway f52d055dc48aec25854ed7d31862f78913cf17d1
 github.com/jteeuwen/go-bindata a0ff2567cfb70903282db057e799fd826784d41d
 github.com/julienschmidt/httprouter fb79d6a91d3e4a9ecb6d945b218d78fc0d9b1939
 github.com/kisielk/errcheck aa69c6199800e8aeeedf51950f830458e4cb73e3

--- a/build/protobuf.mk
+++ b/build/protobuf.mk
@@ -39,7 +39,7 @@ CPROTOBUF_PATH  := $(ORG_ROOT)/c-protobuf/internal/src
 
 COREOS_PATH := $(GITHUB_ROOT)/coreos
 
-GRPC_GATEWAY_PACKAGE := github.com/gengo/grpc-gateway
+GRPC_GATEWAY_PACKAGE := github.com/grpc-ecosystem/grpc-gateway
 GRPC_GATEWAY_GOOGLEAPIS_PACKAGE := $(GRPC_GATEWAY_PACKAGE)/third_party/googleapis
 GRPC_GATEWAY_GOOGLEAPIS_PATH := $(GITHUB_ROOT)/../$(GRPC_GATEWAY_GOOGLEAPIS_PACKAGE)
 

--- a/server/admin.go
+++ b/server/admin.go
@@ -26,8 +26,8 @@ import (
 	"sync"
 	"time"
 
-	gwruntime "github.com/gengo/grpc-gateway/runtime"
 	"github.com/gogo/protobuf/proto"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/elazarl/go-bindata-assetfs"
-	gwruntime "github.com/gengo/grpc-gateway/runtime"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"

--- a/server/serverpb/admin.pb.go
+++ b/server/serverpb/admin.pb.go
@@ -62,7 +62,7 @@ import math "math"
 import cockroach_config "github.com/cockroachdb/cockroach/config"
 
 // skipping weak import gogoproto "github.com/cockroachdb/gogoproto"
-// skipping weak import google_api1 "github.com/gengo/grpc-gateway/third_party/googleapis/google/api"
+// skipping weak import google_api1 "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api"
 
 import (
 	context "golang.org/x/net/context"
@@ -485,8 +485,9 @@ func (*ClusterResponse) Descriptor() ([]byte, []int) { return fileDescriptorAdmi
 // all those in 'on'.
 type DrainRequest struct {
 	// These are actually of type DrainMode, but grpc-gateway does not support
-	// proxying enum fields (yet: https://github.com/gengo/grpc-gateway/issues/5)
-	// and it fails in pretty dramatic ways (panics the server).
+	// proxying enum fields (yet:
+	// https://github.com/grpc-ecosystem/grpc-gateway/issues/5) and it fails in
+	// pretty dramatic ways (panics the server).
 	On  []int32 `protobuf:"varint,1,rep,name=on" json:"on,omitempty"`
 	Off []int32 `protobuf:"varint,2,rep,name=off" json:"off,omitempty"`
 	// When true, terminates the process after the given drain modes have been

--- a/server/serverpb/admin.pb.gw.go
+++ b/server/serverpb/admin.pb.gw.go
@@ -13,9 +13,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/gengo/grpc-gateway/runtime"
-	"github.com/gengo/grpc-gateway/utilities"
 	"github.com/golang/protobuf/proto"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/grpc-ecosystem/grpc-gateway/utilities"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/server/serverpb/admin.proto
+++ b/server/serverpb/admin.proto
@@ -271,8 +271,9 @@ enum DrainMode {
 // all those in 'on'.
 message DrainRequest {
   // These are actually of type DrainMode, but grpc-gateway does not support
-  // proxying enum fields (yet: https://github.com/gengo/grpc-gateway/issues/5)
-  // and it fails in pretty dramatic ways (panics the server).
+  // proxying enum fields (yet: 
+  // https://github.com/grpc-ecosystem/grpc-gateway/issues/5) and it fails in
+  // pretty dramatic ways (panics the server).
   repeated int32 on = 1;
   repeated int32 off = 2;
   // When true, terminates the process after the given drain modes have been

--- a/server/serverpb/status.pb.go
+++ b/server/serverpb/status.pb.go
@@ -14,7 +14,7 @@ import cockroach_storage_storagebase "github.com/cockroachdb/cockroach/storage/s
 import cockroach_util "github.com/cockroachdb/cockroach/util"
 
 // skipping weak import gogoproto "github.com/cockroachdb/gogoproto"
-// skipping weak import google_api1 "github.com/gengo/grpc-gateway/third_party/googleapis/google/api"
+// skipping weak import google_api1 "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api"
 
 import github_com_cockroachdb_cockroach_roachpb "github.com/cockroachdb/cockroach/roachpb"
 

--- a/server/serverpb/status.pb.gw.go
+++ b/server/serverpb/status.pb.gw.go
@@ -13,9 +13,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/gengo/grpc-gateway/runtime"
-	"github.com/gengo/grpc-gateway/utilities"
 	"github.com/golang/protobuf/proto"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/grpc-ecosystem/grpc-gateway/utilities"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/server/status.go
+++ b/server/status.go
@@ -31,7 +31,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	gwruntime "github.com/gengo/grpc-gateway/runtime"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/julienschmidt/httprouter"
 	"github.com/pkg/errors"
 

--- a/ts/server.go
+++ b/ts/server.go
@@ -18,7 +18,7 @@ package ts
 
 import (
 	"github.com/cockroachdb/cockroach/ts/tspb"
-	gwruntime "github.com/gengo/grpc-gateway/runtime"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/ts/tspb/timeseries.pb.go
+++ b/ts/tspb/timeseries.pb.go
@@ -22,7 +22,7 @@ import fmt "fmt"
 import math "math"
 
 // skipping weak import gogoproto "github.com/cockroachdb/gogoproto"
-// skipping weak import google_api1 "github.com/gengo/grpc-gateway/third_party/googleapis/google/api"
+// skipping weak import google_api1 "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api"
 
 import (
 	context "golang.org/x/net/context"

--- a/ts/tspb/timeseries.pb.gw.go
+++ b/ts/tspb/timeseries.pb.gw.go
@@ -13,9 +13,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/gengo/grpc-gateway/runtime"
-	"github.com/gengo/grpc-gateway/utilities"
 	"github.com/golang/protobuf/proto"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/grpc-ecosystem/grpc-gateway/utilities"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/util/http.go
+++ b/util/http.go
@@ -23,9 +23,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 )
 

--- a/util/jsonpb_marshal.go
+++ b/util/jsonpb_marshal.go
@@ -23,9 +23,9 @@ import (
 	"io"
 	"reflect"
 
-	gwruntime "github.com/gengo/grpc-gateway/runtime"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 )
 

--- a/util/proto_marshal.go
+++ b/util/proto_marshal.go
@@ -20,8 +20,8 @@ import (
 	"io"
 	"io/ioutil"
 
-	gwruntime "github.com/gengo/grpc-gateway/runtime"
 	"github.com/gogo/protobuf/proto"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/util/protoutil"


### PR DESCRIPTION
The repo `github.com/gengo/grpc-gateway` has been moved to
`github.com/grpc-ecosystem/grpc-gateway`. Right now, our builds 
only work because of `GLOCKFILE` (and `examples-go` is already broken).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7920)

<!-- Reviewable:end -->
