### PR TITLE
sql: Add mustGetDatabaseDesc method to DatabaseAccessor

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -39,12 +39,8 @@ func (p *planner) AlterTable(n *parser.AlterTable) (planNode, error) {
 		return nil, err
 	}
 
-	dbDesc, err := p.getDatabaseDesc(n.Table.Database())
-	if err != nil {
+	if _, err := p.mustGetDatabaseDesc(n.Table.Database()); err != nil {
 		return nil, err
-	}
-	if dbDesc == nil {
-		return nil, sqlbase.NewUndefinedDatabaseError(n.Table.Database())
 	}
 
 	tableDesc, err := p.getTableDesc(n.Table)

--- a/sql/create.go
+++ b/sql/create.go
@@ -233,12 +233,9 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 		return nil, err
 	}
 
-	dbDesc, err := p.getDatabaseDesc(n.Table.Database())
+	dbDesc, err := p.mustGetDatabaseDesc(n.Table.Database())
 	if err != nil {
 		return nil, err
-	}
-	if dbDesc == nil {
-		return nil, sqlbase.NewUndefinedDatabaseError(n.Table.Database())
 	}
 
 	if err := p.checkPrivilege(dbDesc, privilege.CREATE); err != nil {

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -178,12 +178,9 @@ func (p *planner) getDescriptorsFromTargetList(targets parser.TargetList) (
 		}
 		descs := make([]sqlbase.DescriptorProto, 0, len(targets.Databases))
 		for _, database := range targets.Databases {
-			descriptor, err := p.getDatabaseDesc(database)
+			descriptor, err := p.mustGetDatabaseDesc(database)
 			if err != nil {
 				return nil, err
-			}
-			if descriptor == nil {
-				return nil, sqlbase.NewUndefinedDatabaseError(database)
 			}
 			descs = append(descs, descriptor)
 		}

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -48,12 +48,9 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
 		return nil, fmt.Errorf("only %s is allowed to rename databases", security.RootUser)
 	}
 
-	dbDesc, err := p.getDatabaseDesc(string(n.Name))
+	dbDesc, err := p.mustGetDatabaseDesc(string(n.Name))
 	if err != nil {
 		return nil, err
-	}
-	if dbDesc == nil {
-		return nil, sqlbase.NewUndefinedDatabaseError(string(n.Name))
 	}
 
 	if n.Name == n.NewName {
@@ -117,12 +114,9 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		return nil, err
 	}
 
-	dbDesc, err := p.getDatabaseDesc(n.Name.Database())
+	dbDesc, err := p.mustGetDatabaseDesc(n.Name.Database())
 	if err != nil {
 		return nil, err
-	}
-	if dbDesc == nil {
-		return nil, sqlbase.NewUndefinedDatabaseError(n.Name.Database())
 	}
 
 	tbKey := tableKey{dbDesc.ID, n.Name.Table()}.Key()
@@ -141,12 +135,9 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		return nil, fmt.Errorf("table %q does not exist", n.Name.Table())
 	}
 
-	targetDbDesc, err := p.getDatabaseDesc(n.NewName.Database())
+	targetDbDesc, err := p.mustGetDatabaseDesc(n.NewName.Database())
 	if err != nil {
 		return nil, err
-	}
-	if targetDbDesc == nil {
-		return nil, sqlbase.NewUndefinedDatabaseError(n.NewName.Database())
 	}
 
 	if err := p.checkPrivilege(targetDbDesc, privilege.CREATE); err != nil {
@@ -299,12 +290,9 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 		return nil, err
 	}
 
-	dbDesc, err := p.getDatabaseDesc(n.Table.Database())
+	dbDesc, err := p.mustGetDatabaseDesc(n.Table.Database())
 	if err != nil {
 		return nil, err
-	}
-	if dbDesc == nil {
-		return nil, sqlbase.NewUndefinedDatabaseError(n.Table.Database())
 	}
 
 	// Check if table exists.

--- a/sql/set.go
+++ b/sql/set.go
@@ -58,12 +58,8 @@ func (p *planner) Set(n *parser.Set) (planNode, error) {
 		}
 		if len(dbName) != 0 {
 			// Verify database descriptor exists.
-			dbDesc, err := p.getDatabaseDesc(dbName)
-			if err != nil {
+			if _, err := p.mustGetDatabaseDesc(dbName); err != nil {
 				return nil, err
-			}
-			if dbDesc == nil {
-				return nil, sqlbase.NewUndefinedDatabaseError(dbName)
 			}
 		}
 		p.session.Database = dbName

--- a/sql/show.go
+++ b/sql/show.go
@@ -448,12 +448,9 @@ func (p *planner) ShowTables(n *parser.ShowTables) (planNode, error) {
 		}
 		name = &parser.QualifiedName{Base: parser.Name(p.session.Database)}
 	}
-	dbDesc, err := p.getDatabaseDesc(string(name.Base))
+	dbDesc, err := p.mustGetDatabaseDesc(string(name.Base))
 	if err != nil {
 		return nil, err
-	}
-	if dbDesc == nil {
-		return nil, sqlbase.NewUndefinedDatabaseError(string(name.Base))
 	}
 
 	tableNames, err := p.getTableNames(dbDesc)

--- a/sql/table.go
+++ b/sql/table.go
@@ -102,7 +102,7 @@ type SchemaAccessor interface {
 	expandTableGlob(expr *parser.QualifiedName) (parser.QualifiedNames, error)
 
 	// getTableDesc returns a table descriptor, or nil if the descriptor
-	// is not found. If you want the not found condition to return an error,
+	// is not found. If you want the "not found" condition to return an error,
 	// use mustGetTableDesc() instead.
 	getTableDesc(qname *parser.QualifiedName) (*sqlbase.TableDescriptor, error)
 
@@ -141,12 +141,9 @@ func (p *planner) getTableDesc(qname *parser.QualifiedName) (*sqlbase.TableDescr
 	if err := qname.NormalizeTableName(p.session.Database); err != nil {
 		return nil, err
 	}
-	dbDesc, err := p.getDatabaseDesc(qname.Database())
+	dbDesc, err := p.mustGetDatabaseDesc(qname.Database())
 	if err != nil {
 		return nil, err
-	}
-	if dbDesc == nil {
-		return nil, sqlbase.NewUndefinedDatabaseError(qname.Database())
 	}
 
 	desc := sqlbase.TableDescriptor{}
@@ -399,12 +396,9 @@ func (p *planner) expandTableGlob(expr *parser.QualifiedName) (
 	case parser.NameIndirection:
 		return parser.QualifiedNames{expr}, nil
 	case parser.StarIndirection:
-		dbDesc, err := p.getDatabaseDesc(string(expr.Base))
+		dbDesc, err := p.mustGetDatabaseDesc(string(expr.Base))
 		if err != nil {
 			return nil, err
-		}
-		if dbDesc == nil {
-			return nil, sqlbase.NewUndefinedDatabaseError(string(expr.Base))
 		}
 		tableNames, err := p.getTableNames(dbDesc)
 		if err != nil {


### PR DESCRIPTION
This method encapsulates the logic of returning an error on
a missing database descriptor. It is the database equivalent of 01ea83d.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7934)

<!-- Reviewable:end -->
