### PR TITLE
acceptance: add monotonic inserts test

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -29,6 +29,7 @@ github.com/cockroachdb/c-protobuf 3bef67ea4cc857224fced66f98578362bc892f37
 github.com/cockroachdb/c-rocksdb ab57b321a358f4c93fb639331ac3e10911649492
 github.com/cockroachdb/c-snappy d4e7b428fe7fc09e93573df3448567a62df8c9fa
 github.com/cockroachdb/cmux bf6fecde181ec0604ff3265fde91123c9395fa1f
+github.com/cockroachdb/cockroach-go 2e4a60d41697eebb308b1def89f0abaf1c056137
 github.com/cockroachdb/pq 40c6b2414c76cdb84aacc955f79dc844e48ad0c0
 github.com/cockroachdb/stress aa7690c22fd0abd6168ed0e6c361e4f4c5f7ab25
 github.com/codahale/hdrhistogram f8ad88b59a584afeee9d334eff879b104439117b
@@ -65,7 +66,6 @@ github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0e
 github.com/mibk/dupl 415e882ea21ca7012cc49906cb338f34d2d4b4d6
 github.com/montanaflynn/stats 60dcacf48f43d6dd654d0ed94120ff5806c5ca5c
 github.com/olekukonko/tablewriter daf2955e742cf123959884fdff4685aa79b63135
-github.com/opencontainers/runc 4eb8c2fb1dcb10fa3bf9bd7031f3a25a8ce2fef6
 github.com/opennota/check 5b00aacd5639507d2b039245a278ec9f5505509f
 github.com/opentracing/basictracer-go 8d298b35c67ed83c7565d36bd2928b7be8c06ba8
 github.com/opentracing/opentracing-go 74bcbcefb667969189ea542337a94d99c9c0e088

--- a/acceptance/monotonic_insert_test.go
+++ b/acceptance/monotonic_insert_test.go
@@ -1,0 +1,213 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tobias Schottdorf (tobias.schottdorf@gmail.com)
+
+package acceptance
+
+import (
+	"bytes"
+	gosql "database/sql"
+	"fmt"
+	"math/rand"
+	"sort"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/cockroachdb/cockroach/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/util/log"
+)
+
+// TestMonotonicInserts replicates the 'monotonic' test from the Jepsen
+// CockroachDB test suite (https://github.com/cockroachdb/jepsen).
+func TestMonotonicInserts(t *testing.T) {
+	runTestOnConfigs(t, testMonotonicInsertsInner)
+}
+
+type mtRow struct {
+	val      int64
+	sts      string
+	node, tb int64
+}
+
+type mtRows []mtRow
+
+func (r mtRows) Len() int {
+	return len(r)
+}
+
+func (r mtRows) Less(i, j int) bool {
+	if r[i].val == r[j].val {
+		return r[i].sts < r[j].sts
+	}
+	return r[i].val < r[j].val
+}
+
+func (r mtRows) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+func (r mtRows) String() string {
+	var buf bytes.Buffer
+	for i, row := range r {
+		prefix := "ok"
+		if ok := i == 0 || r.Less(i-1, i); !ok {
+			prefix = "!!"
+		}
+		_, _ = buf.WriteString(fmt.Sprintf("%s %+v\n", prefix, row))
+	}
+	return buf.String()
+}
+
+type mtClient struct {
+	*gosql.DB
+	ID int
+}
+
+func testMonotonicInsertsInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
+	var clients []mtClient
+	for i := 0; i < c.NumNodes(); i++ {
+		clients = append(clients, mtClient{ID: i, DB: makePGClient(t, c.PGUrl(i))})
+	}
+	// We will insert into this table by selecting MAX(val) and increasing by
+	// one and expect that val and sts (the commit timestamp) are both
+	// simultaneously increasing.
+	if _, err := clients[0].Exec(`
+CREATE DATABASE mono;
+CREATE TABLE IF NOT EXISTS mono.mono (val INT, sts STRING, node INT, tb INT);
+INSERT INTO mono.mono VALUES(-1, '0', -1, -1)`); err != nil {
+		t.Fatal(err)
+	}
+
+	var idGen uint64
+
+	invoke := func(client mtClient) {
+		logPrefix := fmt.Sprintf("%03d.%03d: ", atomic.AddUint64(&idGen, 1), client.ID)
+		l := func(msg string, args ...interface{}) {
+			log.Infof(logPrefix+msg, args...)
+		}
+		l("begin")
+		defer l("done")
+
+		var exRow, insRow mtRow
+		var attempt int
+		if err := crdb.ExecuteTx(client.DB, func(tx *gosql.Tx) error {
+			attempt++
+			l("attempt %d", attempt)
+			if err := tx.QueryRow(`SELECT cluster_logical_timestamp()`).Scan(
+				&insRow.sts,
+			); err != nil {
+				l(err.Error())
+				return err
+			}
+
+			l("read max val")
+			if err := tx.QueryRow(`SELECT MAX(val) AS m FROM mono.mono`).Scan(
+				&exRow.val,
+			); err != nil {
+				l(err.Error())
+				return err
+			}
+
+			l("read max row for val=%d", exRow.val)
+			if err := tx.QueryRow(`SELECT sts, node, tb FROM mono.mono WHERE val = $1`,
+				exRow.val,
+			).Scan(
+				&exRow.sts, &exRow.node, &exRow.tb,
+			); err != nil {
+				l(err.Error())
+				return err
+			}
+
+			l("insert")
+			if err := tx.QueryRow(`
+INSERT INTO mono.mono (val, sts, node, tb) VALUES($1, $2, $3, $4)
+RETURNING val, sts, node, tb`,
+				exRow.val+1, insRow.sts, client.ID, 0,
+			).Scan(
+				&insRow.val, &insRow.sts, &insRow.node, &insRow.tb,
+			); err != nil {
+				l(err.Error())
+				return err
+			}
+			l("commit")
+			return nil
+		}); err != nil {
+			t.Errorf("%T: %v", err, err)
+		}
+	}
+
+	verify := func() {
+		client := clients[0]
+		var numDistinct int
+		if err := client.QueryRow("SELECT COUNT(DISTINCT(val)) FROM mono.mono").Scan(
+			&numDistinct,
+		); err != nil {
+			t.Fatal(err)
+		}
+		rows, err := client.Query("SELECT val, sts, node, tb FROM mono.mono ORDER BY val ASC, sts ASC")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var results mtRows
+		for rows.Next() {
+			var row mtRow
+			if err := rows.Scan(&row.val, &row.sts, &row.node, &row.tb); err != nil {
+				t.Fatal(err)
+			}
+			results = append(results, row)
+		}
+
+		if !sort.IsSorted(results) {
+			t.Error("results are not sorted")
+		}
+
+		if numDistinct != len(results) {
+			t.Errorf("'val' column is not unique: %d results, but %d distinct",
+				len(results), numDistinct)
+		}
+
+		fmt.Println(results)
+	}
+
+	concurrency := 2 * c.NumNodes()
+
+	sem := make(chan struct{}, concurrency)
+	timer := time.After(cfg.Duration)
+
+	defer verify()
+	defer func() {
+		// Now that consuming has stopped, fill up the semaphore (i.e. wait for
+		// still-running goroutines to stop)
+		for i := 0; i < concurrency; i++ {
+			sem <- struct{}{}
+		}
+	}()
+
+	for {
+		select {
+		case sem <- struct{}{}:
+		case <-stopper:
+			return
+		case <-timer:
+			return
+		}
+		go func(client mtClient) {
+			invoke(client)
+			<-sem
+		}(clients[rand.Intn(c.NumNodes())])
+	}
+}


### PR DESCRIPTION
This test loosely mirrors the `monotonic` test from
cockroachdb/jepsen, which has seen a regression in #7899.

Unfortunately, at the time of writing, TestMonotonicIncrements
has not failed, after repeated invocations of

`make acceptance TESTS=Monotonic TESTFLAGS='-v -d 3s -count 10 -nodes=5`.

The bug in #7899 has since been discovered and is covered by a high-level
test which sets up exactly the situation Jepsen has tickled, so it's not
worth optimizing this test to reproduce that exact but any more. See #7955.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7941)

<!-- Reviewable:end -->
