### PR TITLE
acceptance: add six node cluster in steady state

### DIFF
--- a/acceptance/allocator_terraform/main.tf
+++ b/acceptance/allocator_terraform/main.tf
@@ -1,5 +1,6 @@
 provider "google" {
   region = "${var.gce_region}"
+  credentials = ""
 }
 
 resource "google_compute_instance" "cockroach" {

--- a/acceptance/allocator_test.go
+++ b/acceptance/allocator_test.go
@@ -390,3 +390,18 @@ func TestUpreplicate_1To6Medium(t *testing.T) {
 	}
 	at.Run(t)
 }
+
+// TestSteady_6Medium is useful for creating a medium-size balanced cluster
+// (when used with the -tf.keep-cluster flag).
+// TODO(tschottdorf): use for tests which run schema changes or drop large
+// amounts of data.
+func TestSteady_6Medium(t *testing.T) {
+	at := allocatorTest{
+		StartNodes:          6,
+		EndNodes:            6,
+		StoreURL:            archivedStoreURL + "/6nodes-1038replicas-56G",
+		Prefix:              "steady-6m",
+		CockroachDiskSizeGB: 250, // GB
+	}
+	at.Run(t)
+}

--- a/acceptance/allocator_test.go
+++ b/acceptance/allocator_test.go
@@ -114,7 +114,7 @@ func (at *allocatorTest) Run(t *testing.T) {
 		}
 		baseDir := filepath.Join(wd, at.f.Cwd)
 		if t.Failed() && at.f.KeepClusterAfterFail {
-			t.Logf("test has failed, not destroying; run:\n(cd %s && terraform destroy -state %s)",
+			t.Logf("test has failed, not destroying; run:\n(cd %s && terraform destroy -force -state %s)",
 				baseDir, at.f.StateFile)
 			return
 		}

--- a/acceptance/terraform_test.go
+++ b/acceptance/terraform_test.go
@@ -42,7 +42,7 @@ func TestBuildBabyCluster(t *testing.T) {
 func TestFiveNodesAndWriters(t *testing.T) {
 	deadline := time.After(*flagDuration)
 	f := farmer(t, "write-5n5w")
-	defer f.MustDestroy()
+	defer f.MustDestroy(t)
 	const size = 5
 	if err := f.Resize(size, size); err != nil {
 		t.Fatal(err)

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -297,7 +297,9 @@ func StartCluster(t *testing.T, cfg cluster.TestConfig) (c cluster.Cluster) {
 		t.Fatal(err)
 	}
 	if err := f.WaitReady(5 * time.Minute); err != nil {
-		_ = f.Destroy(t)
+		if destroyErr := f.Destroy(t); destroyErr != nil {
+			t.Fatalf("could not destroy cluster after error %v: %v", err, destroyErr)
+		}
 		t.Fatalf("cluster not ready in time: %v", err)
 	}
 	checkRangeReplication(t, f, 20*time.Second)

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -19,6 +19,7 @@ package acceptance
 import (
 	gosql "database/sql"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -42,7 +43,26 @@ import (
 	_ "github.com/cockroachdb/pq"
 )
 
+type keepClusterVar string
+
+func (kcv *keepClusterVar) String() string {
+	return string(*kcv)
+}
+
+func (kcv *keepClusterVar) Set(val string) error {
+	if val != terrafarm.KeepClusterAlways &&
+		val != terrafarm.KeepClusterFailed &&
+		val != terrafarm.KeepClusterNever {
+		return errors.New("invalid value")
+	}
+	*kcv = keepClusterVar(val)
+	return nil
+}
+
 func init() {
+	flag.Var(&flagTFKeepCluster, "tf.keep-cluster",
+		"keep the cluster after the test, either 'always', 'never', or 'failed'")
+
 	flag.Parse()
 }
 
@@ -60,8 +80,8 @@ var flagConfig = flag.String("config", "", "a json TestConfig proto, see testcon
 
 var flagPrivileged = flag.Bool("privileged", os.Getenv("CIRCLECI") != "true",
 	"run containers in privileged mode (required for nemesis tests")
-var flagTFKeepCluster = flag.Bool("tf.keep-cluster", false, "do not destroy Terraform cluster after test finishes, has precedence over tf.keep-cluster-fail")
-var flagTFKeepClusterFail = flag.Bool("tf.keep-cluster-fail", false, "do not destroy Terraform cluster after test finishes only if the test has failed")
+
+var flagTFKeepCluster = keepClusterVar(terrafarm.KeepClusterNever) // see init()
 
 // TODO(cuongdo): These should be refactored so that they're not allocator
 // test-specific when we have more than one kind of system test that uses these
@@ -158,16 +178,15 @@ func farmer(t *testing.T, prefix string) *terrafarm.Farmer {
 		t.Fatalf("generated farmer prefix '%s' must match regex %s", prefix, prefixRE)
 	}
 	f := &terrafarm.Farmer{
-		Output:               os.Stderr,
-		Cwd:                  *flagCwd,
-		LogDir:               logDir,
-		KeyName:              *flagKeyName,
-		Stores:               stores,
-		Prefix:               prefix,
-		StateFile:            prefix + ".tfstate",
-		AddVars:              make(map[string]string),
-		KeepClusterAfterTest: *flagTFKeepCluster,
-		KeepClusterAfterFail: *flagTFKeepClusterFail,
+		Output:      os.Stderr,
+		Cwd:         *flagCwd,
+		LogDir:      logDir,
+		KeyName:     *flagKeyName,
+		Stores:      stores,
+		Prefix:      prefix,
+		StateFile:   prefix + ".tfstate",
+		AddVars:     make(map[string]string),
+		KeepCluster: flagTFKeepCluster.String(),
 	}
 	log.Infof("logging to %s", logDir)
 	return f
@@ -278,7 +297,7 @@ func StartCluster(t *testing.T, cfg cluster.TestConfig) (c cluster.Cluster) {
 		t.Fatal(err)
 	}
 	if err := f.WaitReady(5 * time.Minute); err != nil {
-		_ = f.Destroy()
+		_ = f.Destroy(t)
 		t.Fatalf("cluster not ready in time: %v", err)
 	}
 	checkRangeReplication(t, f, 20*time.Second)


### PR DESCRIPTION
This steady-state six node cluster is a good starting point for tests
which downreplicate or attempt to delete large amounts of data. The
relevant contribution here is having created the data file.

Note that 1038 is the number of Replicas per Store taken from the
admin UI. 56GB is the size of the data directory, though the first
node clocks in at 112GB, which is a bit suspicious and might warrant
an investigation (a GCed replica should have its on-disk state removed;
perhaps RocksDB compactions can take care of the rest? cc @petermattis).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7944)

<!-- Reviewable:end -->
