### PR TITLE
storage: make TestGossipFirstRange more robust to extra gossiping

### DIFF
--- a/storage/gossip_test.go
+++ b/storage/gossip_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/log"
 )
 
 func TestGossipFirstRange(t *testing.T) {
@@ -48,6 +49,23 @@ func TestGossipFirstRange(t *testing.T) {
 			}
 		})
 
+	// Wait for the specified descriptor to be gossiped for the first range. We
+	// loop because the timing of replica addition and lease transfer can cause
+	// extra gossiping of the first range.
+	waitForGossip := func(desc *roachpb.RangeDescriptor) {
+		for {
+			select {
+			case err := <-errors:
+				t.Fatal(err)
+			case gossiped := <-descs:
+				if reflect.DeepEqual(desc, gossiped) {
+					return
+				}
+				log.Infof("expected\n%+v\nbut found\n%+v", desc, gossiped)
+			}
+		}
+	}
+
 	// Expect an initial callback of the first range descriptor.
 	select {
 	case err := <-errors:
@@ -64,14 +82,7 @@ func TestGossipFirstRange(t *testing.T) {
 		if desc, err = tc.AddReplicas(firstRangeKey, tc.Target(i)); err != nil {
 			t.Fatal(err)
 		}
-		select {
-		case err := <-errors:
-			t.Fatal(err)
-		case gossiped := <-descs:
-			if !reflect.DeepEqual(desc, gossiped) {
-				t.Fatalf("expected\n%+v\nbut found\n%+v", desc, gossiped)
-			}
-		}
+		waitForGossip(desc)
 	}
 
 	// Transfer the lease to a new node. This should cause the first range to be
@@ -79,28 +90,14 @@ func TestGossipFirstRange(t *testing.T) {
 	if err := tc.TransferRangeLease(desc, tc.Target(1)); err != nil {
 		t.Fatal(err)
 	}
-	select {
-	case err := <-errors:
-		t.Fatal(err)
-	case gossiped := <-descs:
-		if !reflect.DeepEqual(desc, gossiped) {
-			t.Fatalf("expected\n%+v\nbut found\n%+v", desc, gossiped)
-		}
-	}
+	waitForGossip(desc)
 
 	// Remove a non-lease holder replica.
 	desc, err := tc.RemoveReplicas(firstRangeKey, tc.Target(0))
 	if err != nil {
 		t.Fatal(err)
 	}
-	select {
-	case err := <-errors:
-		t.Fatal(err)
-	case gossiped := <-descs:
-		if !reflect.DeepEqual(desc, gossiped) {
-			t.Fatalf("expected\n%+v\nbut found\n%+v", desc, gossiped)
-		}
-	}
+	waitForGossip(desc)
 
 	// TODO(peter): Re-enable or remove when we've resolved the discussion
 	// about removing the lease-holder replica. See #7872.


### PR DESCRIPTION
Fixes a test failure seen in #7833.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7946)

<!-- Reviewable:end -->
