### PR TITLE
sql: simple helper to run SQL in test

### DIFF
--- a/sql/distsql/server_test.go
+++ b/sql/distsql/server_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -39,13 +40,11 @@ func TestServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := sqlDB.Exec(`
-		CREATE DATABASE test;
-		CREATE TABLE test.t (a INT PRIMARY KEY, b INT);
-		INSERT INTO test.t VALUES (1, 10), (2, 20), (3, 30);
-	`); err != nil {
-		t.Fatal(err)
-	}
+	r := sqlutils.MakeSQLRunner(t, sqlDB)
+
+	r.Exec(`CREATE DATABASE test`)
+	r.Exec(`CREATE TABLE test.t (a INT PRIMARY KEY, b INT)`)
+	r.Exec(`INSERT INTO test.t VALUES (1, 10), (2, 20), (3, 30)`)
 
 	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 

--- a/testutils/sqlutils/sql_runner.go
+++ b/testutils/sqlutils/sql_runner.go
@@ -1,0 +1,65 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package sqlutils
+
+import (
+	gosql "database/sql"
+	"testing"
+)
+
+// SQLRunner wraps a testing.TB and *gosql.DB connection and provides
+// convenience functions to run SQL statements and fail the test on any errors.
+type SQLRunner struct {
+	testing.TB
+	DB *gosql.DB
+}
+
+// MakeSQLRunner returns a SQLRunner for the given database connection.
+func MakeSQLRunner(tb testing.TB, db *gosql.DB) *SQLRunner {
+	return &SQLRunner{TB: tb, DB: db}
+}
+
+// Exec is a wrapper around gosql.Exec that kills the test on error.
+func (sr *SQLRunner) Exec(query string, args ...interface{}) gosql.Result {
+	r, err := sr.DB.Exec(query, args...)
+	if err != nil {
+		sr.Fatalf("error executing '%s': %s", query, err)
+	}
+	return r
+}
+
+// ExecRowsAffected executes the statement and verifies that RowsAffected()
+// matches the expected value. It kills the test on errors.
+func (sr *SQLRunner) ExecRowsAffected(expRowsAffected int, query string, args ...interface{}) {
+	r := sr.Exec(query, args...)
+	numRows, err := r.RowsAffected()
+	if err != nil {
+		sr.Fatal(err)
+	}
+	if numRows != int64(expRowsAffected) {
+		sr.Fatalf("expected %d affected rows, got %d on '%s'", expRowsAffected, numRows, query)
+	}
+}
+
+// Query is a wrapper around gosql.Query that kills the test on error.
+func (sr *SQLRunner) Query(query string, args ...interface{}) *gosql.Rows {
+	r, err := sr.DB.Query(query, args...)
+	if err != nil {
+		sr.Fatalf("error executing '%s': %s", query, err)
+	}
+	return r
+}

--- a/testutils/sqlutils/table_gen.go
+++ b/testutils/sqlutils/table_gen.go
@@ -53,11 +53,10 @@ func genValues(w io.Writer, firstRow, lastRow int, fn GenRowFn) {
 func CreateTable(
 	t *testing.T, sqlDB *gosql.DB, tableName, schema string, numRows int, fn GenRowFn,
 ) {
+	r := MakeSQLRunner(t, sqlDB)
 	stmt := `CREATE DATABASE IF NOT EXISTS test;`
 	stmt += fmt.Sprintf(`CREATE TABLE test.%s (%s);`, tableName, schema)
-	if _, err := sqlDB.Exec(stmt); err != nil {
-		t.Fatal(err)
-	}
+	r.Exec(stmt)
 	for i := 1; i <= numRows; {
 		var buf bytes.Buffer
 		fmt.Fprintf(&buf, `INSERT INTO test.%s VALUES `, tableName)
@@ -66,9 +65,7 @@ func CreateTable(
 			batchEnd = numRows
 		}
 		genValues(&buf, i, batchEnd, fn)
-		if _, err := sqlDB.Exec(buf.String()); err != nil {
-			t.Fatal(err)
-		}
+		r.Exec(buf.String())
 		i = batchEnd + 1
 	}
 }


### PR DESCRIPTION
Adding a helper type that wraps sqlgo calls and automatically fails tests on
errors.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7947)

<!-- Reviewable:end -->
