### PR TITLE
Fix dubious implementation of `TestCluster.WaitForFullReplication`

### DIFF
--- a/base/test_server_args.go
+++ b/base/test_server_args.go
@@ -83,16 +83,12 @@ type TestClusterArgs struct {
 type TestClusterReplicationMode int
 
 const (
-	// ReplicationFull means that each range is to be replicated everywhere. This
-	// will be done by overriding the default zone config. The replication will be
-	// performed as in production, by the replication queue.
-	// TestCluster.WaitForFullReplication() can be used to wait for replication to
-	// be stable at any point in a test.
-	// TODO(andrei): ReplicationFull should not be an option, or at least not the
-	// default option. Instead, the production default replication should be the
-	// default for TestCluster too. But I'm not sure how to implement
-	// `WaitForFullReplication` for that.
-	ReplicationFull TestClusterReplicationMode = iota
+	// ReplicationAuto means that ranges are replicated according to the
+	// production default zone config. Replication is performed as in
+	// production, by the replication queue.
+	// TestCluster.WaitForFullReplication() can be used to wait for
+	// replication to be stable at any point in a test.
+	ReplicationAuto TestClusterReplicationMode = iota
 	// ReplicationManual means that the split and replication queues of all
 	// servers are stopped, and the test must manually control splitting and
 	// replication through the TestServer.

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -51,7 +51,7 @@ func benchmarkMultinodeCockroach(b *testing.B, f func(b *testing.B, db *gosql.DB
 	defer tracing.Disable()()
 	tc := testcluster.StartTestCluster(b, 3,
 		base.TestClusterArgs{
-			ReplicationMode: base.ReplicationFull,
+			ReplicationMode: base.ReplicationAuto,
 			ServerArgs: base.TestServerArgs{
 				UseDatabase: "bench",
 			},

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/pkg/errors"
 )
@@ -90,11 +91,8 @@ func StartTestCluster(t testing.TB, nodes int, args base.TestClusterArgs) *TestC
 	}
 
 	switch args.ReplicationMode {
-	case base.ReplicationFull:
-		// Force all ranges to be replicated everywhere.
-		cfg := config.DefaultZoneConfig()
-		cfg.ReplicaAttrs = make([]roachpb.Attributes, nodes)
-		fn := config.TestingSetDefaultZoneConfig(cfg)
+	case base.ReplicationAuto:
+		fn := config.TestingSetDefaultZoneConfig(config.DefaultZoneConfig())
 		args.Stopper.AddCloser(stop.CloserFn(fn))
 	case base.ReplicationManual:
 		if args.ServerArgs.Knobs.Store == nil {
@@ -446,23 +444,24 @@ func (tc *TestCluster) findMemberStore(
 	return nil, errors.Errorf("store not found")
 }
 
-// WaitForFullReplication waits until all of the nodes in the cluster have the
-// same number of replicas.
+// WaitForFullReplication waits until all stores in the cluster
+// have no ranges with replication pending.
 func (tc *TestCluster) WaitForFullReplication() error {
-	// TODO (WillHaack): Optimize sleep time.
-	for notReplicated := true; notReplicated; time.Sleep(100 * time.Millisecond) {
+	opts := retry.Options{
+		InitialBackoff: time.Millisecond * 10,
+		MaxBackoff:     time.Millisecond * 100,
+		Multiplier:     2,
+	}
+
+	notReplicated := true
+	for r := retry.Start(opts); r.Next() && notReplicated; {
 		notReplicated = false
-		var numReplicas int
-		err := tc.Servers[0].Stores().VisitStores(func(s *storage.Store) error {
-			numReplicas = s.ReplicaCount()
-			return nil
-		})
-		if err != nil {
-			return err
-		}
 		for _, s := range tc.Servers {
 			err := s.Stores().VisitStores(func(s *storage.Store) error {
-				if numReplicas != s.ReplicaCount() {
+				if err := s.ComputeMetrics(); err != nil {
+					return err
+				}
+				if s.Registry().GetGauge("ranges.replication-pending").Value() > 0 {
 					notReplicated = true
 				}
 				return nil

--- a/testutils/testcluster/testcluster_test.go
+++ b/testutils/testcluster/testcluster_test.go
@@ -175,9 +175,9 @@ func TestBasicManualReplication(t *testing.T) {
 func TestWaitForFullReplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	tc := StartTestCluster(t, 3, base.TestClusterArgs{ReplicationMode: base.ReplicationFull})
+	tc := StartTestCluster(t, 3, base.TestClusterArgs{ReplicationMode: base.ReplicationAuto})
 	defer tc.Stopper().Stop()
 	if err := tc.WaitForFullReplication(); err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
Removed TODO for better wait timing by using a retry loop. Now we check
store metrics for the number of replicas belonging to ranges with pending
replication work. This metric was added to store. Previously, it was just
verifying that all stores had the exact same number of replicas, which
only works if the replication factor is equal to the number of stores.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7951)

<!-- Reviewable:end -->
