### PR TITLE
storage: add fix and regression test for #7899

### DIFF
--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -299,7 +299,8 @@ func (txn *Txn) scan(begin, end interface{}, maxRows int64, isReverse bool) ([]K
 // Scan retrieves the rows between begin (inclusive) and end (exclusive) in
 // ascending order.
 //
-// The returned []KeyValue will contain up to maxRows elements.
+// The returned []KeyValue will contain up to maxRows elements (or all results
+// when zero is supplied).
 //
 // key can be either a byte slice or a string.
 func (txn *Txn) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {
@@ -309,7 +310,8 @@ func (txn *Txn) Scan(begin, end interface{}, maxRows int64) ([]KeyValue, error) 
 // ReverseScan retrieves the rows between begin (inclusive) and end (exclusive)
 // in descending order.
 //
-// The returned []KeyValue will contain up to maxRows elements.
+// The returned []KeyValue will contain up to maxRows elements (or all results
+// when zero is supplied).
 //
 // key can be either a byte slice or a string.
 func (txn *Txn) ReverseScan(begin, end interface{}, maxRows int64) ([]KeyValue, error) {

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -358,10 +358,11 @@ func Addr(k roachpb.Key) (roachpb.RKey, error) {
 	return roachpb.RKey(k), nil
 }
 
-func mustAddr(k roachpb.Key) roachpb.RKey {
+// MustAddr calls Addr and panics on errors.
+func MustAddr(k roachpb.Key) roachpb.RKey {
 	rk, err := Addr(k)
 	if err != nil {
-		panic(err)
+		panic(errors.Wrapf(err, "could not take address of '%s'", k))
 	}
 	return rk
 }

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -283,7 +283,7 @@ func TestMetaReverseScanBounds(t *testing.T) {
 			expError: "",
 		},
 		{
-			key:      mustAddr(Meta2Prefix),
+			key:      MustAddr(Meta2Prefix),
 			expStart: Meta1Prefix,
 			expEnd:   Meta2Prefix.Next(),
 			expError: "",

--- a/keys/printer.go
+++ b/keys/printer.go
@@ -84,7 +84,7 @@ var (
 					if len(unq) == 0 {
 						return "", Meta1Prefix
 					}
-					return "", RangeMetaKey(mustAddr(RangeMetaKey(mustAddr(
+					return "", RangeMetaKey(MustAddr(RangeMetaKey(MustAddr(
 						roachpb.Key(unq)))))
 				},
 			}},
@@ -100,7 +100,7 @@ var (
 					if len(unq) == 0 {
 						return "", Meta2Prefix
 					}
-					return "", RangeMetaKey(mustAddr(roachpb.Key(unq)))
+					return "", RangeMetaKey(MustAddr(roachpb.Key(unq)))
 				},
 			}},
 		},

--- a/roachpb/api.pb.go
+++ b/roachpb/api.pb.go
@@ -428,7 +428,8 @@ func (*DeleteResponse) ProtoMessage()               {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []int{12} }
 
 // A DeleteRangeRequest is the argument to the DeleteRange() method. It
-// specifies the range of keys to delete.
+// specifies the range of keys to delete and a maximum number of key-value
+// pairs to delete (zero for unlimited).
 type DeleteRangeRequest struct {
 	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	// If 0, *all* entries between key (inclusive) and end_key
@@ -457,7 +458,7 @@ func (*DeleteRangeResponse) Descriptor() ([]byte, []int) { return fileDescriptor
 
 // A ScanRequest is the argument to the Scan() method. It specifies the
 // start and end keys for an ascending scan of [start,end) and the maximum
-// number of results.
+// number of results (unbounded if zero).
 type ScanRequest struct {
 	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	// If 0, there is no limit on the number of retrieved entries. Must be >= 0.
@@ -483,7 +484,7 @@ func (*ScanResponse) Descriptor() ([]byte, []int) { return fileDescriptorApi, []
 
 // A ReverseScanRequest is the argument to the ReverseScan() method. It specifies the
 // start and end keys for a descending scan of [start,end) and the maximum
-// number of results.
+// number of results (unbounded if zero).
 type ReverseScanRequest struct {
 	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	// If 0, there is no limit on the number of retrieved entries. Must be >= 0.

--- a/roachpb/api.proto
+++ b/roachpb/api.proto
@@ -155,7 +155,8 @@ message DeleteResponse {
 }
 
 // A DeleteRangeRequest is the argument to the DeleteRange() method. It
-// specifies the range of keys to delete.
+// specifies the range of keys to delete and a maximum number of key-value
+// pairs to delete (zero for unlimited).
 message DeleteRangeRequest {
   optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // If 0, *all* entries between key (inclusive) and end_key
@@ -174,7 +175,7 @@ message DeleteRangeResponse {
 
 // A ScanRequest is the argument to the Scan() method. It specifies the
 // start and end keys for an ascending scan of [start,end) and the maximum
-// number of results.
+// number of results (unbounded if zero).
 message ScanRequest {
   optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // If 0, there is no limit on the number of retrieved entries. Must be >= 0.
@@ -190,7 +191,7 @@ message ScanResponse {
 
 // A ReverseScanRequest is the argument to the ReverseScan() method. It specifies the
 // start and end keys for a descending scan of [start,end) and the maximum
-// number of results.
+// number of results (unbounded if zero).
 message ReverseScanRequest {
   optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // If 0, there is no limit on the number of retrieved entries. Must be >= 0.

--- a/server/status.go
+++ b/server/status.go
@@ -674,6 +674,8 @@ func (s *statusServer) Ranges(ctx context.Context, req *serverpb.RangesRequest) 
 					// because it contains a map with integer keys. Just extract
 					// the most interesting bit for now.
 					raftState = status.RaftState.String()
+				} else {
+					raftState = "StateDormant"
 				}
 				state := rep.State()
 				output.Ranges = append(output.Ranges, serverpb.RangeInfo{

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -504,8 +504,8 @@ func TestRangesResponse(t *testing.T) {
 	for _, ri := range response.Ranges {
 		// Do some simple validation based on the fact that this is a
 		// single-node cluster.
-		if ri.RaftState != "StateLeader" {
-			t.Errorf("expected to be raft leader but was %s", ri.RaftState)
+		if ri.RaftState != "StateLeader" && ri.RaftState != "StateDormant" {
+			t.Errorf("expected to be Raft leader or dormant, but was '%s'", ri.RaftState)
 		}
 		expReplica := roachpb.ReplicaDescriptor{
 			NodeID:    1,

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -1052,13 +1052,13 @@ func TestSplitSnapshotRace_SnapshotWins(t *testing.T) {
 	mtc.waitForValues(rightKey, []int64{0, 0, 0, 225, 225, 225})
 }
 
-// TestStoreSplitReadRace prevents regression of #3148. It begins a couple of
-// read requests and lets them complete while a split is happening; the reads
-// hit the second half of the split. If the split happens non-atomically with
-// respect to the reads (and in particular their update of the timestamp
-// cache), then some of them may not be reflected in the timestamp cache of the
-// new range, in which case this test would fail.
-func TestStoreSplitReadRace(t *testing.T) {
+// TestStoreSplitTimestampCacheReadRace prevents regression of #3148. It begins
+// a couple of read requests and lets them complete while a split is happening;
+// the reads hit the right half of the split. If the split happens
+// non-atomically with respect to the reads (and in particular their update of
+// the timestamp cache), then some of them may not be reflected in the
+// timestamp cache of the new range, in which case this test would fail.
+func TestStoreSplitTimestampCacheReadRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	splitKey := roachpb.Key("a")
 	key := func(i int) roachpb.Key {

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -28,6 +28,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/internal/client"
@@ -39,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils"
+	"github.com/cockroachdb/cockroach/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/ts"
 	"github.com/cockroachdb/cockroach/ts/tspb"
 	"github.com/cockroachdb/cockroach/util"
@@ -1140,6 +1142,154 @@ func TestStoreSplitTimestampCacheReadRace(t *testing.T) {
 		if respH.Timestamp.Less(ts(i)) {
 			t.Fatalf("%d: expected Put to be forced higher than %s by timestamp caches, but wrote at %s", i, ts(i), respH.Timestamp)
 		}
+	}
+}
+
+// TestStoreSplitTimestampCacheDifferentLeaseHolder prevents regression of
+// #7899. When the first lease holder of the right-hand side of a Split was
+// not equal to the left-hand side lease holder (at the time of the split),
+// its timestamp cache would not be properly initialized, which would allow
+// for writes which invalidated reads previously served by the pre-split lease.
+func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	leftKey := roachpb.Key("a")
+	splitKey := roachpb.Key("b")
+	rightKey := roachpb.Key("c")
+
+	// This filter is better understood when reading the meat of the test
+	// below first.
+	var noLeaseForDesc atomic.Value
+	var numLeases int32
+	filter := func(args storagebase.FilterArgs) *roachpb.Error {
+		leaseReq, argOK := args.Req.(*roachpb.RequestLeaseRequest)
+		forbiddenDesc, descOK := noLeaseForDesc.Load().(*roachpb.ReplicaDescriptor)
+		if !argOK || !descOK || !bytes.Equal(leaseReq.Key, splitKey) {
+			return nil
+		}
+		atomic.AddInt32(&numLeases, 1)
+		if !reflect.DeepEqual(*forbiddenDesc, leaseReq.Lease.Replica) {
+			return nil
+		}
+		log.Infof("refusing %+v because %+v held lease for LHS of split",
+			leaseReq, forbiddenDesc)
+		return roachpb.NewError(&roachpb.NotLeaseHolderError{RangeID: args.Hdr.RangeID})
+	}
+
+	var args base.TestClusterArgs
+	args.ReplicationMode = base.ReplicationManual
+	args.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{
+		TestingCommandFilter: filter,
+	}
+
+	tc := testcluster.StartTestCluster(t, 2, args)
+	defer tc.Stopper().Stop()
+
+	// Split the data range, mainly to avoid other splits getting in our way.
+	for _, k := range []roachpb.Key{leftKey, rightKey} {
+		if _, _, err := tc.SplitRange(k); err != nil {
+			t.Fatal(errors.Wrapf(err, "split at %s", k))
+		}
+	}
+	if _, err := tc.AddReplicas(leftKey, tc.Target(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	db := tc.Servers[0].DB() // irrelevant which one we use
+
+	// Make a context tied to the Stopper. The test works without, but this
+	// is cleaner since we won't properly terminate the transaction below.
+	ctx := tc.Stopper().WithCancel(context.Background())
+
+	// This transaction will try to write "under" a served read.
+	txnOld := client.NewTxn(ctx, *db)
+
+	// Do something with txnOld so that its timestamp gets set.
+	if _, err := txnOld.Scan("a", "b", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Another client comes along at a higher timestamp, touching everything on
+	// the right of the (soon-to-be) split key.
+	if _, err := db.Scan(splitKey, rightKey, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// This block makes sure that from now on, we don't allow the current
+	// lease holder of our range to extend. Any attempt of doing so will
+	// catch a NotLeaseHolderError, which means a retry by DistSender (until
+	// the other node gets to be the lease holder instead).
+	//
+	// This makes sure that once we split, we'll be in the situation described
+	// in #7899 (before the fix): The first lease holder of the right hand side
+	// of the Split will not be that of the pre-split Range.
+	// With the fix, the right-hand lease is initialized from the left-hand
+	// lease, so the lease holders are the same, and there will never be a
+	// lease request for the right-hand side in this test.
+	leaseHolder := func(k roachpb.Key) roachpb.ReplicaDescriptor {
+		desc, err := tc.LookupRange(k)
+		if err != nil {
+			t.Fatal(err)
+		}
+		leaseHolder, err := tc.FindRangeLeaseHolder(&desc, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		replica, found := desc.GetReplicaDescriptor(leaseHolder.StoreID)
+		if !found {
+			t.Fatalf("no replica on store %d found in %+v", leaseHolder.StoreID, desc)
+		}
+		return replica
+	}
+	blacklistedLeaseHolder := leaseHolder(leftKey)
+	noLeaseForDesc.Store(&blacklistedLeaseHolder)
+
+	// Pull the trigger. This actually also reads the RHS descriptor after the
+	// split, so when this returns, we've got the leases set up already.
+	//
+	// There's a slight race here: Just above, we've settled on who must not
+	// be the future lease holder. But between then and now, that lease could
+	// have expired and the other Replica could have obtained it. This would
+	// have given it a proper initialization of the timestamp cache, and so
+	// the split trigger would populate the right hand side with a timestamp
+	// cache which does not exhibit the anomaly.
+	//
+	// In practice, this should only be possible if second-long delays occur
+	// just above this comment, and we assert against it below.
+	if _, _, err := tc.SplitRange(splitKey); err != nil {
+		t.Fatal(err)
+	}
+
+	if currentLHSLeaseHolder := leaseHolder(leftKey); !reflect.DeepEqual(
+		currentLHSLeaseHolder, blacklistedLeaseHolder) {
+		t.Fatalf("lease holder changed from %+v to %+v, should de-flake this test",
+			blacklistedLeaseHolder, currentLHSLeaseHolder)
+	}
+
+	// This write (to the right-hand side of the split) should hit the
+	// timestamp cache and flag the txn for a restart when we try to commit it
+	// below. With the bug in #7899, the RHS of the split had an empty
+	// timestamp cache and would simply let us write behind the previous read.
+	if err := txnOld.Put("bb", "bump"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := txnOld.Commit(); !testutils.IsError(err, "retry txn") {
+		t.Fatalf("expected txn retry, got %v", err)
+	}
+
+	// As outlined above, the anomaly was fixed by giving the right-hand side
+	// of the split the same lease as the left-hand side of the Split. Check
+	// that that's what's happened (we actually test a little more, namely
+	// that it's the same ReplicaID, which is not required but should always
+	// hold).
+	if rhsLease := leaseHolder(rightKey); !reflect.DeepEqual(
+		rhsLease, blacklistedLeaseHolder,
+	) {
+		t.Errorf("expected LHS and RHS to have same lease holder")
+	}
+	if num := atomic.LoadInt32(&numLeases); num > 0 {
+		t.Errorf("expected to see no lease requests for the right-hand side")
 	}
 }
 

--- a/storage/gossip_test.go
+++ b/storage/gossip_test.go
@@ -77,7 +77,7 @@ func TestGossipFirstRange(t *testing.T) {
 	// Add two replicas. The first range descriptor should be gossiped after each
 	// addition.
 	var desc *roachpb.RangeDescriptor
-	firstRangeKey := roachpb.RKey(keys.MinKey)
+	firstRangeKey := keys.MinKey
 	for i := 1; i <= 2; i++ {
 		var err error
 		if desc, err = tc.AddReplicas(firstRangeKey, tc.Target(i)); err != nil {

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2497,6 +2497,44 @@ func (r *Replica) splitTrigger(
 		return errors.Wrap(err, "unable to write initial state")
 	}
 
+	// Initialize the right-hand lease to be the same as the left-hand lease.
+	// This looks like an innocuous performance improvement, but it's more than
+	// that - it ensures that we properly initialize the timestamp cache, which
+	// is only populated on the lease holder, from that of the original Range.
+	// We found out about a regression here the hard way in #7899. Prior to
+	// this block, the following could happen:
+	// - a client reads key 'd', leaving an entry in the timestamp cache on the
+	//   lease holder of [a,e) at the time, node one.
+	// - the range [a,e) splits at key 'c'. [c,e) starts out without a lease.
+	// - the replicas of [a,e) on nodes one and two both process the split
+	//   trigger and thus copy their timestamp caches to the new right-hand side
+	//   Replica. However, only node one's timestamp cache contains information
+	//   about the read of key 'd' in the first place.
+	// - node two becomes the lease holder for [c,e). Its timestamp cache does
+	//   know about the read at 'd' which happened at the beginning.
+	// - node two can illegaly propose a write to 'd' at a lower timestamp.
+	{
+		leftLease, err := loadLease(r.store.Engine(), r.RangeID)
+		if err != nil {
+			return errors.Wrap(err, "unable to load lease")
+		}
+
+		replica, found := split.RightDesc.GetReplicaDescriptor(leftLease.Replica.StoreID)
+		if !found {
+			return errors.Errorf(
+				"pre-split lease holder %+v not found in post-split descriptor %+v",
+				leftLease.Replica, split.RightDesc,
+			)
+		}
+		rightLease := leftLease
+		rightLease.Replica = replica
+		if err := setLease(
+			batch, &deltaMS, split.RightDesc.RangeID, rightLease,
+		); err != nil {
+			return errors.Wrap(err, "unable to seed right-hand side lease")
+		}
+	}
+
 	// Compute stats for new range.
 	var rightMS enginepb.MVCCStats
 	if origStats.ContainsEstimates || deltaMS.ContainsEstimates {

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -4709,14 +4709,6 @@ func TestReplicaLookup(t *testing.T) {
 	tc.Start(t)
 	defer tc.Stop()
 
-	mustAddr := func(k roachpb.Key) roachpb.RKey {
-		rk, err := keys.Addr(k)
-		if err != nil {
-			panic(err)
-		}
-		return rk
-	}
-
 	expected := []roachpb.RangeDescriptor{*tc.rng.Desc()}
 	testCases := []struct {
 		key      roachpb.RKey
@@ -4731,10 +4723,10 @@ func TestReplicaLookup(t *testing.T) {
 		{key: roachpb.RKeyMin, reverse: false, expected: expected},
 		// Test with the last key in a meta prefix. This is an edge case in the
 		// implementation.
-		{key: mustAddr(keys.Meta1KeyMax), reverse: false, expected: expected},
-		{key: mustAddr(keys.Meta2KeyMax), reverse: false, expected: nil},
-		{key: mustAddr(keys.Meta1KeyMax), reverse: true, expected: expected},
-		{key: mustAddr(keys.Meta2KeyMax), reverse: true, expected: expected},
+		{key: keys.MustAddr(keys.Meta1KeyMax), reverse: false, expected: expected},
+		{key: keys.MustAddr(keys.Meta2KeyMax), reverse: false, expected: nil},
+		{key: keys.MustAddr(keys.Meta1KeyMax), reverse: true, expected: expected},
+		{key: keys.MustAddr(keys.Meta2KeyMax), reverse: true, expected: expected},
 	}
 
 	for _, c := range testCases {

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -213,7 +213,7 @@ func (tc *TestCluster) SplitRange(
 	rightRangeDesc := new(roachpb.RangeDescriptor)
 	if err := tc.Servers[0].DB().GetProto(
 		keys.RangeDescriptorKey(origRangeDesc.StartKey), leftRangeDesc); err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "could not look up left-hand side descriptor")
 	}
 	// The split point might not be exactly the one we requested (it can be
 	// adjusted slightly so we don't split in the middle of SQL rows). Update it
@@ -221,7 +221,7 @@ func (tc *TestCluster) SplitRange(
 	splitRKey = leftRangeDesc.EndKey
 	if err := tc.Servers[0].DB().GetProto(
 		keys.RangeDescriptorKey(splitRKey), rightRangeDesc); err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "could not look up right-hand side descriptor")
 	}
 	return leftRangeDesc, rightRangeDesc, nil
 }

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -158,8 +158,8 @@ func (tc *TestCluster) Stopper() *stop.Stopper {
 	return tc.Servers[0].Stopper()
 }
 
-// lookupRange returns the descriptor of the range containing key.
-func (tc *TestCluster) lookupRange(key roachpb.RKey) (roachpb.RangeDescriptor, error) {
+// LookupRange returns the descriptor of the range containing key.
+func (tc *TestCluster) LookupRange(key roachpb.RKey) (roachpb.RangeDescriptor, error) {
 	rangeLookupReq := roachpb.RangeLookupRequest{
 		Span: roachpb.Span{
 			Key: keys.RangeMetaKey(key),
@@ -189,7 +189,7 @@ func (tc *TestCluster) SplitRange(
 	if err != nil {
 		return nil, nil, err
 	}
-	origRangeDesc, err := tc.lookupRange(splitRKey)
+	origRangeDesc, err := tc.LookupRange(splitRKey)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/testutils/testcluster/testcluster_test.go
+++ b/testutils/testcluster/testcluster_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/keys"
-	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -75,7 +74,9 @@ func TestManualReplication(t *testing.T) {
 	}
 
 	// Replicate the table's range to all the nodes.
-	tableRangeDesc, err = tc.AddReplicas(tableRangeDesc.StartKey, tc.Target(1), tc.Target(2))
+	tableRangeDesc, err = tc.AddReplicas(
+		tableRangeDesc.StartKey.AsRawKey(), tc.Target(1), tc.Target(2),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +139,7 @@ func TestBasicManualReplication(t *testing.T) {
 	tc := StartTestCluster(t, 3, base.TestClusterArgs{ReplicationMode: base.ReplicationManual})
 	defer tc.Stopper().Stop()
 
-	desc, err := tc.AddReplicas(roachpb.RKey(keys.MinKey), tc.Target(1), tc.Target(2))
+	desc, err := tc.AddReplicas(keys.MinKey, tc.Target(1), tc.Target(2))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +153,7 @@ func TestBasicManualReplication(t *testing.T) {
 
 	// TODO(peter): Removing the range leader (tc.Target(1)) causes the test to
 	// take ~13s vs ~1.5s for removing a non-leader. Track down that slowness.
-	desc, err = tc.RemoveReplicas(desc.StartKey, tc.Target(0))
+	desc, err = tc.RemoveReplicas(desc.StartKey.AsRawKey(), tc.Target(0))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/util/stop/stopper_test.go
+++ b/util/stop/stopper_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -336,6 +338,16 @@ func TestStopperRunTaskPanic(t *testing.T) {
 		if recovered != ch {
 			t.Errorf("%d: unexpected recovered value: %+v", i, recovered)
 		}
+	}
+}
+
+func TestStopperWithCancel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s := stop.NewStopper()
+	ctx := s.WithCancel(context.Background())
+	s.Stop()
+	if err := ctx.Err(); err != context.Canceled {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Fixes #7899 by preventing timestamp cache information loss when
the right hand side lease holder was not equal to that of the
left hand side.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7955)

<!-- Reviewable:end -->
