### PR TITLE
Proposal for opaque log tags

### DIFF
--- a/util/log/log_context.go
+++ b/util/log/log_context.go
@@ -1,0 +1,102 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde
+
+package log
+
+import "golang.org/x/net/context"
+
+type valueType int
+
+const (
+	genericType valueType = iota
+	int64Type
+	stringType
+)
+
+type logTag struct {
+	name string
+
+	valType    valueType
+	intVal     int64
+	strVal     string
+	genericVal interface{}
+
+	prev *logTag
+}
+
+func (t *logTag) value() interface{} {
+	switch t.valType {
+	case int64Type:
+		return t.intVal
+	case stringType:
+		return t.strVal
+	default:
+		return t.genericVal
+	}
+}
+
+// contextTagKeyType is an empty type for the handle associated with the
+// logTag value (see context.Value).
+type contextTagKeyType struct{}
+
+func contextLastTag(ctx context.Context) *logTag {
+	val := ctx.Value(contextTagKeyType{})
+	if val == nil {
+		return nil
+	}
+	return val.(*logTag)
+}
+
+func contextLogTags(ctx context.Context) []logTag {
+	var tags []logTag
+	for t := contextLastTag(ctx); t != nil; t = t.prev {
+		tags = append(tags, *t)
+	}
+	for i, j := 0, len(tags)-1; i < j; i, j = i+1, j-1 {
+		tags[i], tags[j] = tags[j], tags[i]
+	}
+	return tags
+}
+
+func withLogTag(ctx context.Context, newTag *logTag) context.Context {
+	newTag.prev = contextLastTag(ctx)
+	return context.WithValue(ctx, contextTagKeyType{}, newTag)
+}
+
+// WithLogTag returns a context (derived from the given context) which when used
+// with a logging function results in the given name and value being printed in
+// the message. If the value is nil, just the name shows up.
+func WithLogTag(ctx context.Context, name string, value interface{}) context.Context {
+	return withLogTag(ctx, &logTag{name: name, valType: genericType, genericVal: value})
+}
+
+// WithLogTagInt is a variant of WithLogTag that avoids the allocation
+// associated with boxing the value in an interface{}.
+func WithLogTagInt(ctx context.Context, name string, value int) context.Context {
+	return withLogTag(ctx, &logTag{name: name, valType: int64Type, intVal: int64(value)})
+}
+
+// WithLogTagInt64 is a variant of WithLogTag that avoids the allocation
+// associated with boxing the value in an interface{}.
+func WithLogTagInt64(ctx context.Context, name string, value int64) context.Context {
+	return withLogTag(ctx, &logTag{name: name, valType: int64Type, intVal: value})
+}
+
+// WithLogTagStr is a variant of WithLogTag that avoids the allocation
+// associated with boxing the value in an interface{}.
+func WithLogTagStr(ctx context.Context, name string, value string) context.Context {
+	return withLogTag(ctx, &logTag{name: name, valType: stringType, strVal: value})
+}

--- a/util/log/log_context_test.go
+++ b/util/log/log_context_test.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde
+
+package log
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestLogContext(t *testing.T) {
+	ctx := context.Background()
+	ctxA := WithLogTagInt(ctx, "NodeID", 5)
+	ctxB := WithLogTagInt64(ctxA, "ReqID", 123)
+	ctxC := WithLogTag(ctxB, "aborted", nil)
+	ctxD := WithLogTag(ctxC, "slice", []int{1, 2, 3})
+
+	ctxB1 := WithLogTagStr(ctxA, "branch", "meh")
+
+	testCases := []struct{ value, expected string }{
+		{
+			value:    makeMessage(ctx, "test", nil),
+			expected: "test",
+		},
+		{
+			value:    makeMessage(ctxA, "test", nil),
+			expected: "[NodeID: 5] test",
+		},
+		{
+			value:    makeMessage(ctxB, "test", nil),
+			expected: "[NodeID: 5] [ReqID: 123] test",
+		},
+		{
+			value:    makeMessage(ctxC, "test", nil),
+			expected: "[NodeID: 5] [ReqID: 123] [aborted] test",
+		},
+		{
+			value:    makeMessage(ctxD, "test", nil),
+			expected: "[NodeID: 5] [ReqID: 123] [aborted] [slice: [1 2 3]] test",
+		},
+		{
+			value:    makeMessage(ctxB1, "test", nil),
+			expected: "[NodeID: 5] [branch: meh] test",
+		},
+	}
+
+	for i, tc := range testCases {
+		if tc.value != tc.expected {
+			t.Errorf("Test case %d failed: expected '%s', got '%s'", i, tc.expected, tc.value)
+		}
+	}
+}

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -26,8 +26,18 @@ import (
 )
 
 // makeMessage creates a structured log entry.
-func makeMessage(format string, args []interface{}) string {
+func makeMessage(ctx context.Context, format string, args []interface{}) string {
 	var buf bytes.Buffer
+	tags := contextLogTags(ctx)
+	for _, t := range tags {
+		buf.WriteString("[")
+		buf.WriteString(t.name)
+		if value := t.value(); value != nil {
+			buf.WriteString(": ")
+			fmt.Fprint(&buf, value)
+		}
+		buf.WriteString("] ")
+	}
 	if len(format) == 0 {
 		fmt.Fprint(&buf, args...)
 	} else {
@@ -40,7 +50,7 @@ func makeMessage(format string, args []interface{}) string {
 // specified facility of the logger.
 func addStructured(ctx context.Context, s Severity, depth int, format string, args []interface{}) {
 	file, line, _ := caller.Lookup(depth + 1)
-	msg := makeMessage(format, args)
+	msg := makeMessage(ctx, format, args)
 	Trace(ctx, msg)
 	logging.outputLogEntry(s, file, line, msg)
 }


### PR DESCRIPTION
This is a proposal for adding opaque "tags" to contexts that show up in log
messages.

See log_context_test for an example.

@tschottdorf @jordanlewis

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7966)

<!-- Reviewable:end -->
