### PR TITLE
sql: allow unbounded size columns in empty families

### DIFF
--- a/sql/descriptor_mutation_test.go
+++ b/sql/descriptor_mutation_test.go
@@ -201,9 +201,11 @@ func TestOperationsWithColumnMutation(t *testing.T) {
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer server.Stopper().Stop()
 
+	// Fix the column families so the key counts below don't change if the
+	// family heuristics are updated.
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
-CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR DEFAULT 'i');
+CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR DEFAULT 'i', FAMILY (k), FAMILY (v), FAMILY (i));
 `); err != nil {
 		t.Fatal(err)
 	}
@@ -502,10 +504,12 @@ func TestOperationsWithUniqueColumnMutation(t *testing.T) {
 	server, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer server.Stopper().Stop()
 
-	// Create a table with column i and an index on v and i.
+	// Create a table with column i and an index on v and i. Fix the column
+	// families so the key counts below don't change if the family heuristics
+	// are updated.
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
-CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR, INDEX foo (i, v));
+CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR, INDEX foo (i, v), FAMILY (k), FAMILY (v), FAMILY (i));
 `); err != nil {
 		t.Fatal(err)
 	}

--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -35,9 +35,11 @@ func TestDropDatabase(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
 
+	// Fix the column families so the key counts below don't change if the
+	// family heuristics are updated.
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
-CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR);
+CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR, FAMILY (k), FAMILY (v));
 INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 `); err != nil {
 		t.Fatal(err)
@@ -214,9 +216,11 @@ func TestDropTable(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop()
 
+	// Fix the column families so the key counts below don't change if the
+	// family heuristics are updated.
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
-CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR);
+CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR, FAMILY (k), FAMILY (v));
 INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 `); err != nil {
 		t.Fatal(err)

--- a/sql/sqlbase/structured.go
+++ b/sql/sqlbase/structured.go
@@ -844,13 +844,25 @@ func upperBoundColumnValueEncodedSize(col ColumnDescriptor) (int, bool) {
 // becomes an issue, make the bookkeeping of the columnSizesByID incremental.
 func fitColumnToFamily(desc TableDescriptor, col ColumnDescriptor) (int, bool) {
 	size, isBounded := upperBoundColumnValueEncodedSize(col)
-	if !isBounded || size > FamilyHeuristicTargetBytes {
+	if size > FamilyHeuristicTargetBytes {
 		return 0, false
+	}
+
+	primaryIndexColIDs := make(map[ColumnID]struct{}, len(desc.PrimaryIndex.ColumnIDs))
+	for _, colID := range desc.PrimaryIndex.ColumnIDs {
+		primaryIndexColIDs[colID] = struct{}{}
 	}
 
 	columnSizesByID := make(map[ColumnID]int, len(desc.Columns))
 	for _, c := range desc.Columns {
-		if columnSizesByID[c.ID], isBounded = upperBoundColumnValueEncodedSize(c); !isBounded {
+		if _, ok := primaryIndexColIDs[c.ID]; ok {
+			// Primary key columns are stored in the key, so they don't count
+			// against the heuristic limit.
+			columnSizesByID[c.ID] = 0
+			continue
+		}
+		var bounded bool
+		if columnSizesByID[c.ID], bounded = upperBoundColumnValueEncodedSize(c); !bounded {
 			// Not bounded in size, so exceed the heuristic max to avoid assigning to
 			// a family that this column is in.
 			columnSizesByID[c.ID] = FamilyHeuristicTargetBytes + 1
@@ -868,7 +880,7 @@ func fitColumnToFamily(desc TableDescriptor, col ColumnDescriptor) (int, bool) {
 				break
 			}
 		}
-		if familySize+size <= FamilyHeuristicTargetBytes {
+		if familySize == 0 || (isBounded && familySize+size <= FamilyHeuristicTargetBytes) {
 			return i, true
 		}
 	}

--- a/sql/sqlbase/structured_test.go
+++ b/sql/sqlbase/structured_test.go
@@ -718,7 +718,7 @@ func TestFitColumnToFamily(t *testing.T) {
 		},
 
 		// Unbounded size column.
-		{colFits: false, idx: -1, newCol: ColumnType{Kind: ColumnType_DECIMAL},
+		{colFits: true, idx: 0, newCol: ColumnType{Kind: ColumnType_DECIMAL},
 			existingFamilies: [][]ColumnType{emptyFamily},
 		},
 		{colFits: false, idx: -1, newCol: ColumnType{Kind: ColumnType_DECIMAL},

--- a/sql/testdata/explain_debug
+++ b/sql/testdata/explain_debug
@@ -5,7 +5,9 @@ CREATE TABLE abc (
   c FLOAT,
   PRIMARY KEY (a, b),
   UNIQUE INDEX foo (b),
-  INDEX bar (a)
+  INDEX bar (a),
+  FAMILY (a, b),
+  FAMILY (c)
 )
 
 query ITTT colnames

--- a/sql/testdata/family
+++ b/sql/testdata/family
@@ -21,7 +21,7 @@ abcd  CREATE TABLE abcd (
       CONSTRAINT "primary" PRIMARY KEY (a),
       FAMILY f1 (a, b),
       FAMILY fam_1_c_d (c, d)
-		  )
+      )
 
 statement ok
 INSERT INTO abcd VALUES (1, 2, 3, 4), (5, 6, 7, 8)
@@ -139,6 +139,21 @@ abcd  CREATE TABLE abcd (
       FAMILY fam_2_f (f),
       FAMILY fam_3_g (g)
       )
+
+statement ok
+CREATE TABLE f1 (a INT PRIMARY KEY, b STRING, c STRING)
+
+query TT
+SHOW CREATE TABLE f1
+----
+f1  CREATE TABLE f1 (
+      a INT NOT NULL,
+      b STRING NULL,
+      c STRING NULL,
+      CONSTRAINT "primary" PRIMARY KEY (a),
+      FAMILY "primary" (a, b),
+      FAMILY fam_1_c (c)
+    )
 
 statement ok
 CREATE TABLE assign_at_create (a INT PRIMARY KEY FAMILY pri, b INT FAMILY foo, c INT CREATE FAMILY)

--- a/sql/testdata/insert
+++ b/sql/testdata/insert
@@ -5,7 +5,9 @@ statement ok
 CREATE TABLE kv (
   k CHAR PRIMARY KEY,
   v CHAR,
-  UNIQUE INDEX a (v)
+  UNIQUE INDEX a (v),
+  FAMILY (k),
+  FAMILY (v)
 )
 
 query TT

--- a/sql/testdata/order_by
+++ b/sql/testdata/order_by
@@ -214,7 +214,9 @@ CREATE TABLE abc (
   d CHAR,
   PRIMARY KEY (a, b, c),
   UNIQUE INDEX bc (b, c),
-  INDEX ba (b, a)
+  INDEX ba (b, a),
+  FAMILY (a, b, c),
+  FAMILY (d)
 )
 
 statement ok

--- a/sql/testdata/select_index
+++ b/sql/testdata/select_index
@@ -7,7 +7,10 @@ CREATE TABLE t (
   PRIMARY KEY (a, b),
   INDEX bc (b, c),
   INDEX dc (d, c),
-  INDEX a_desc (a DESC)
+  INDEX a_desc (a DESC),
+  FAMILY (a, b),
+  FAMILY (c),
+  FAMILY (d)
 )
 
 statement ok

--- a/sql/testdata/table
+++ b/sql/testdata/table
@@ -186,10 +186,10 @@ test.users CREATE TABLE "test.users"
   CONSTRAINT "primary" PRIMARY KEY (id),
   INDEX foo (name),
   UNIQUE INDEX bar (id, name),
-  FAMILY "primary" (id, username, email),
-  FAMILY fam_1_name (name),
-  FAMILY fam_2_title (title),
-  FAMILY fam_3_nickname (nickname),
+  FAMILY "primary" (id, name),
+  FAMILY fam_1_title (title),
+  FAMILY fam_2_nickname (nickname),
+  FAMILY fam_3_username_email (username, email),
   CHECK (LENGTH(nickname) < LENGTH(name)),
   CHECK (LENGTH(nickname) < 10)
 )
@@ -223,10 +223,10 @@ test.named_constraints  CREATE TABLE "test.named_constraints" (
                         INDEX foo (name),
                         UNIQUE INDEX uq2 (username),
                         UNIQUE INDEX bar (id, name),
-                        FAMILY "primary" (id, username, email),
-                        FAMILY fam_1_name (name),
-                        FAMILY fam_2_title (title),
-                        FAMILY fam_3_nickname (nickname),
+                        FAMILY "primary" (id, name),
+                        FAMILY fam_1_title (title),
+                        FAMILY fam_2_nickname (nickname),
+                        FAMILY fam_3_username_email (username, email),
                         CONSTRAINT ck2 CHECK (LENGTH(nickname) < LENGTH(name)),
                         CONSTRAINT ck1 CHECK (LENGTH(nickname) < 10)
                         )

--- a/sql/testdata/update
+++ b/sql/testdata/update
@@ -36,7 +36,9 @@ statement ok
 CREATE TABLE kv2 (
   k CHAR PRIMARY KEY,
   v CHAR,
-  UNIQUE INDEX a (v)
+  UNIQUE INDEX a (v),
+  FAMILY (k),
+  FAMILY (v)
 )
 
 statement ok


### PR DESCRIPTION
Bugfix.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7969)

<!-- Reviewable:end -->
