### PR TITLE
sql: add random syntax generator tests

### DIFF
--- a/internal/rsg/rsg.go
+++ b/internal/rsg/rsg.go
@@ -1,0 +1,141 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Jibson (mjibson@gmail.com)
+
+package rsg
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/internal/rsg/yacc"
+	"github.com/cockroachdb/cockroach/util/syncutil"
+)
+
+// RSG is a random syntax generator.
+type RSG struct {
+	lock  syncutil.Mutex
+	src   *rand.Rand
+	seen  map[string]bool
+	prods map[string][]*yacc.ExpressionNode
+}
+
+// NewRSG creates a random syntax generator from the given random seed and
+// yacc file.
+func NewRSG(seed int64, y string) (*RSG, error) {
+	tree, err := yacc.Parse("", y)
+	if err != nil {
+		return nil, err
+	}
+	rsg := RSG{
+		src:   rand.New(rand.NewSource(seed)),
+		seen:  make(map[string]bool),
+		prods: make(map[string][]*yacc.ExpressionNode),
+	}
+	for _, prod := range tree.Productions {
+		rsg.prods[prod.Name] = prod.Expressions
+	}
+	return &rsg, nil
+}
+
+// Generate generates a unique random syntax from the root node. At most depth
+// levels of token expansion are performed. An empty string is returned on
+// error or if depth is exceeded. Generate is safe to call from mulitipule
+// goroutines. If Generate is called more times than it can generate unique
+// output, it will block forever.
+func (r *RSG) Generate(root string, depth int) string {
+	for {
+		s := strings.Join(r.generate(root, depth), " ")
+		r.lock.Lock()
+		if !r.seen[s] {
+			r.seen[s] = true
+		} else {
+			s = ""
+		}
+		r.lock.Unlock()
+		if s != "" {
+			s = strings.Replace(s, "_LA", "", -1)
+			s = strings.Replace(s, " AS OF SYSTEM TIME \"string\"", "", -1)
+			return s
+		}
+	}
+}
+
+func (r *RSG) generate(root string, depth int) []string {
+	var ret []string
+	prods := r.prods[root]
+	if len(prods) == 0 {
+		return []string{root}
+	}
+	prod := prods[r.Intn(len(prods))]
+	for _, item := range prod.Items {
+		switch item.Typ {
+		case yacc.TypLiteral:
+			v := item.Value[1 : len(item.Value)-1]
+			ret = append(ret, v)
+		case yacc.TypToken:
+			var v []string
+			switch item.Value {
+			case "IDENT":
+				v = []string{"ident"}
+			case "c_expr":
+				v = r.generate(item.Value, 30)
+			case "SCONST":
+				v = []string{`'string'`}
+			case "ICONST":
+				v = []string{fmt.Sprint(r.Intn(1000) - 500)}
+			case "FCONST":
+				v = []string{fmt.Sprint(r.Float64())}
+			case "BCONST":
+				v = []string{`b'bytes'`}
+			case "substr_from":
+				v = []string{"FROM", `'string'`}
+			case "substr_for":
+				v = []string{"FOR", `'string'`}
+			case "overlay_placing":
+				v = []string{"PLACING", `'string'`}
+			default:
+				if depth == 0 {
+					return nil
+				}
+				v = r.generate(item.Value, depth-1)
+			}
+			if v == nil {
+				return nil
+			}
+			ret = append(ret, v...)
+		default:
+			panic("unknown item type")
+		}
+	}
+	return ret
+}
+
+// Intn returns a random int.
+func (r *RSG) Intn(n int) int {
+	r.lock.Lock()
+	v := r.src.Intn(n)
+	r.lock.Unlock()
+	return v
+}
+
+// Float64 returns a random float.
+func (r *RSG) Float64() float64 {
+	r.lock.Lock()
+	v := r.src.NormFloat64()
+	r.lock.Unlock()
+	return v
+}

--- a/internal/rsg/yacc/lex.go
+++ b/internal/rsg/yacc/lex.go
@@ -1,0 +1,303 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copied from Go's text/template/parse package and modified for yacc.
+
+package yacc
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// item represents a token or text string returned from the scanner.
+type item struct {
+	typ itemType // The type of this item.
+	pos Pos      // The starting position, in bytes, of this item in the input string.
+	val string   // The value of this item.
+}
+
+func (i item) String() string {
+	switch {
+	case i.typ == itemEOF:
+		return "EOF"
+	case i.typ == itemError:
+		return i.val
+	case len(i.val) > 10:
+		return fmt.Sprintf("%.10q...", i.val)
+	}
+	return fmt.Sprintf("%q", i.val)
+}
+
+// itemType identifies the type of lex items.
+type itemType int
+
+const (
+	itemError itemType = iota // error occurred; value is text of error
+	itemEOF
+	itemComment
+	itemPct
+	itemDoublePct
+	itemIdent
+	itemColon
+	itemLiteral
+	itemExpr
+	itemPipe
+	itemNL
+)
+
+const eof = -1
+
+// stateFn represents the state of the scanner as a function that returns the next state.
+type stateFn func(*lexer) stateFn
+
+// lexer holds the state of the scanner.
+type lexer struct {
+	name    string    // the name of the input; used only for error reports
+	input   string    // the string being scanned
+	state   stateFn   // the next lexing function to enter
+	pos     Pos       // current position in the input
+	start   Pos       // start position of this item
+	width   Pos       // width of last rune read from input
+	lastPos Pos       // position of most recent item returned by nextItem
+	items   chan item // channel of scanned items
+}
+
+// next returns the next rune in the input.
+func (l *lexer) next() rune {
+	if int(l.pos) >= len(l.input) {
+		l.width = 0
+		return eof
+	}
+	r, w := utf8.DecodeRuneInString(l.input[l.pos:])
+	l.width = Pos(w)
+	l.pos += l.width
+	return r
+}
+
+// peek returns but does not consume the next rune in the input.
+func (l *lexer) peek() rune {
+	r := l.next()
+	l.backup()
+	return r
+}
+
+// backup steps back one rune. Can only be called once per call of next.
+func (l *lexer) backup() {
+	l.pos -= l.width
+}
+
+// emit passes an item back to the client.
+func (l *lexer) emit(t itemType) {
+	l.items <- item{t, l.start, l.input[l.start:l.pos]}
+	l.start = l.pos
+}
+
+// ignore skips over the pending input before this point.
+func (l *lexer) ignore() {
+	l.start = l.pos
+}
+
+// lineNumber reports which line we're on, based on the position of
+// the previous item returned by nextItem. Doing it this way
+// means we don't have to worry about peek double counting.
+func (l *lexer) lineNumber() int {
+	return 1 + strings.Count(l.input[:l.lastPos], "\n")
+}
+
+// errorf returns an error token and terminates the scan by passing
+// back a nil pointer that will be the next state, terminating l.nextItem.
+func (l *lexer) errorf(format string, args ...interface{}) stateFn {
+	l.items <- item{itemError, l.start, fmt.Sprintf(format, args...)}
+	return nil
+}
+
+// nextItem returns the next item from the input.
+func (l *lexer) nextItem() item {
+	i := <-l.items
+	l.lastPos = i.pos
+	return i
+}
+
+// lex creates a new scanner for the input string.
+func lex(name, input string) *lexer {
+	l := &lexer{
+		name:  name,
+		input: input,
+		items: make(chan item),
+	}
+	go l.run()
+	return l
+}
+
+// run runs the state machine for the lexer.
+func (l *lexer) run() {
+	for l.state = lexStart; l.state != nil; {
+		l.state = l.state(l)
+	}
+}
+
+// state functions
+
+func lexStart(l *lexer) stateFn {
+Loop:
+	for {
+		switch r := l.next(); {
+		case r == '/':
+			return lexComment
+		case r == '%':
+			return lexPct
+		case r == '\n':
+			l.emit(itemNL)
+		case r == ':':
+			l.emit(itemColon)
+		case r == '|':
+			l.emit(itemPipe)
+		case r == '{':
+			return lexExpr
+		case isSpace(r):
+			l.ignore()
+		case isIdent(r):
+			return lexIdent
+		case r == '\'':
+			return lexLiteral
+		case r == eof:
+			l.emit(itemEOF)
+			break Loop
+		default:
+			return l.errorf("invalid character: %v", string(r))
+		}
+	}
+	return nil
+}
+
+func lexLiteral(l *lexer) stateFn {
+	for {
+		switch l.next() {
+		case '\'':
+			l.emit(itemLiteral)
+			return lexStart
+		}
+	}
+}
+
+func lexExpr(l *lexer) stateFn {
+	ct := 1
+	for {
+		switch l.next() {
+		case '{':
+			ct++
+		case '}':
+			ct--
+			if ct == 0 {
+				l.emit(itemExpr)
+				return lexStart
+			}
+		}
+	}
+}
+
+func lexComment(l *lexer) stateFn {
+	switch r := l.next(); r {
+	case '/':
+		for {
+			switch l.next() {
+			case '\n':
+				l.backup()
+				l.emit(itemComment)
+				return lexStart
+			}
+		}
+	case '*':
+		for {
+			switch l.next() {
+			case '*':
+				if l.peek() == '/' {
+					l.next()
+					l.emit(itemComment)
+					return lexStart
+				}
+			}
+		}
+	default:
+		return l.errorf("expected comment: %c", r)
+	}
+}
+
+func lexPct(l *lexer) stateFn {
+	switch l.next() {
+	case '%':
+		l.emit(itemDoublePct)
+		return lexStart
+	case '{':
+		for {
+			switch l.next() {
+			case '%':
+				if l.peek() == '}' {
+					l.next()
+					l.emit(itemPct)
+					return lexStart
+				}
+			}
+		}
+	case 'p':
+		if l.next() != 'r' || l.next() != 'e' || l.next() != 'c' || l.next() != ' ' {
+			l.errorf("expected %%prec")
+		}
+		for {
+			switch r := l.next(); {
+			case isIdent(r):
+				// absorb
+			default:
+				l.backup()
+				l.emit(itemPct)
+				return lexStart
+			}
+		}
+	default:
+		ct := 0
+		for {
+			switch l.next() {
+			case ' ':
+			case '{':
+				ct++
+			case '}':
+				ct--
+				if ct == 0 {
+					l.emit(itemPct)
+					return lexStart
+				}
+			case '\n':
+				if ct == 0 {
+					l.backup()
+					l.emit(itemPct)
+					return lexStart
+				}
+			}
+		}
+	}
+}
+
+func lexIdent(l *lexer) stateFn {
+	for {
+		switch r := l.next(); {
+		case isIdent(r):
+			// absorb
+		default:
+			l.backup()
+			l.emit(itemIdent)
+			return lexStart
+		}
+	}
+}
+
+func isSpace(r rune) bool {
+	return r == ' ' || r == '\t'
+}
+
+func isIdent(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}

--- a/internal/rsg/yacc/node.go
+++ b/internal/rsg/yacc/node.go
@@ -1,0 +1,53 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copied from Go's text/template/parse package and modified for yacc.
+
+// Parse nodes.
+
+package yacc
+
+// Pos represents a byte position in the original input text from which
+// this template was parsed.
+type Pos int
+
+// Nodes.
+
+// ProductionNode holds is a named production of multiple expressions.
+type ProductionNode struct {
+	Pos
+	Name        string
+	Expressions []*ExpressionNode
+}
+
+func newProduction(pos Pos, name string) *ProductionNode {
+	return &ProductionNode{Pos: pos, Name: name}
+}
+
+// ExpressionNode hold a single expression.
+type ExpressionNode struct {
+	Pos
+	Items   []Item
+	Command string
+}
+
+func newExpression(pos Pos) *ExpressionNode {
+	return &ExpressionNode{Pos: pos}
+}
+
+// Item hold an item.
+type Item struct {
+	Value string
+	Typ   ItemTyp
+}
+
+// ItemTyp is the item type.
+type ItemTyp int
+
+const (
+	// TypToken is the token type.
+	TypToken ItemTyp = iota
+	// TypLiteral is the literal type.
+	TypLiteral
+)

--- a/internal/rsg/yacc/parse.go
+++ b/internal/rsg/yacc/parse.go
@@ -1,0 +1,195 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copied from Go's text/template/parse package and modified for yacc.
+
+// Package yacc parses .y files.
+package yacc
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Tree is the representation of a single parsed file.
+type Tree struct {
+	Name        string // name of the template represented by the tree.
+	Productions []*ProductionNode
+	text        string // text parsed to create the template (or its parent)
+	// Parsing only; cleared after parse.
+	lex       *lexer
+	token     [2]item // two-token lookahead for parser.
+	peekCount int
+}
+
+// Parse parses the yacc file text with optional name.
+func Parse(name, text string) (t *Tree, err error) {
+	t = New(name)
+	t.text = text
+	err = t.Parse(text)
+	return
+}
+
+// next returns the next token.
+func (t *Tree) next() item {
+	if t.peekCount > 0 {
+		t.peekCount--
+	} else {
+		t.token[0] = t.lex.nextItem()
+	}
+	return t.token[t.peekCount]
+}
+
+// backup backs the input stream up one token.
+func (t *Tree) backup() {
+	t.peekCount++
+}
+
+// peek returns but does not consume the next token.
+func (t *Tree) peek() item {
+	if t.peekCount > 0 {
+		return t.token[t.peekCount-1]
+	}
+	t.peekCount = 1
+	t.token[0] = t.lex.nextItem()
+	return t.token[0]
+}
+
+// Parsing.
+
+// New allocates a new parse tree with the given name.
+func New(name string) *Tree {
+	return &Tree{
+		Name: name,
+	}
+}
+
+// errorf formats the error and terminates processing.
+func (t *Tree) errorf(format string, args ...interface{}) {
+	format = fmt.Sprintf("parse: %s:%d: %s", t.Name, t.lex.lineNumber(), format)
+	panic(fmt.Errorf(format, args...))
+}
+
+// expect consumes the next token and guarantees it has the required type.
+func (t *Tree) expect(expected itemType, context string) item {
+	token := t.next()
+	if token.typ != expected {
+		t.unexpected(token, context)
+	}
+	return token
+}
+
+// unexpected complains about the token and terminates processing.
+func (t *Tree) unexpected(token item, context string) {
+	t.errorf("unexpected %s in %s", token, context)
+}
+
+// recover is the handler that turns panics into returns from the top level of Parse.
+func (t *Tree) recover(errp *error) {
+	e := recover()
+	if e != nil {
+		if _, ok := e.(runtime.Error); ok {
+			panic(e)
+		}
+		if t != nil {
+			t.stopParse()
+		}
+		*errp = e.(error)
+	}
+	return
+}
+
+// startParse initializes the parser, using the lexer.
+func (t *Tree) startParse(lex *lexer) {
+	t.lex = lex
+}
+
+// stopParse terminates parsing.
+func (t *Tree) stopParse() {
+	t.lex = nil
+}
+
+// Parse parses the yacc string to construct a representation of
+// the file for analysis.
+func (t *Tree) Parse(text string) (err error) {
+	defer t.recover(&err)
+	t.startParse(lex(t.Name, text))
+	t.text = text
+	t.parse()
+	t.stopParse()
+	return nil
+}
+
+// parse is the top-level parser for a file.
+// It runs to EOF.
+func (t *Tree) parse() {
+	for {
+		switch token := t.next(); token.typ {
+		case itemIdent:
+			p := newProduction(token.pos, token.val)
+			t.parseProduction(p)
+			t.Productions = append(t.Productions, p)
+		case itemEOF:
+			return
+		}
+	}
+}
+
+func (t *Tree) parseProduction(p *ProductionNode) {
+	const context = "production"
+	t.expect(itemColon, context)
+	t.expect(itemNL, context)
+	expectExpr := true
+	for {
+		switch token := t.next(); token.typ {
+		case itemComment:
+			if t.peek().typ == itemNL {
+				t.next()
+			}
+		case itemNL:
+			if !expectExpr {
+				return
+			}
+		case itemPipe:
+			if expectExpr {
+				t.unexpected(token, context)
+			}
+			expectExpr = true
+		default:
+			if !expectExpr {
+				t.unexpected(token, context)
+			}
+			t.backup()
+			e := newExpression(token.pos)
+			t.parseExpression(e)
+			p.Expressions = append(p.Expressions, e)
+			expectExpr = false
+		}
+	}
+}
+
+func (t *Tree) parseExpression(e *ExpressionNode) {
+	const context = "expression"
+	for {
+		switch token := t.next(); token.typ {
+		case itemNL:
+			peek := t.peek().typ
+			if peek == itemPipe || peek == itemNL {
+				return
+			}
+		case itemIdent:
+			e.Items = append(e.Items, Item{token.val, TypToken})
+		case itemLiteral:
+			e.Items = append(e.Items, Item{token.val, TypLiteral})
+		case itemExpr:
+			e.Command = token.val
+			t.expect(itemNL, context)
+			return
+		case itemPct, itemComment:
+			// ignore
+		default:
+			t.unexpected(token, context)
+		}
+	}
+}

--- a/internal/rsg/yacc/parse_test.go
+++ b/internal/rsg/yacc/parse_test.go
@@ -1,0 +1,62 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Jibson (mjibson@cockroachlabs.com)
+
+package yacc
+
+import (
+	"io/ioutil"
+	"testing"
+
+	// Needed for the -verbosity flag on circleci tests.
+	_ "github.com/cockroachdb/cockroach/util/log"
+)
+
+// TODO(mjibson): unskip these tests when we move to TeamCity (they fail on CircleCI)
+
+const sqlYPath = "../../../sql/parser/sql.y"
+
+func TestLex(t *testing.T) {
+	t.Skip("broken on CircleCI")
+
+	b, err := ioutil.ReadFile(sqlYPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l := lex(sqlYPath, string(b))
+Loop:
+	for {
+		item := l.nextItem()
+		switch item.typ {
+		case itemEOF:
+			break Loop
+		case itemError:
+			t.Fatalf("%s:%d: %s", sqlYPath, l.lineNumber(), item)
+		}
+	}
+}
+
+func TestParse(t *testing.T) {
+	t.Skip("broken on CircleCI")
+
+	b, err := ioutil.ReadFile(sqlYPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Parse(sqlYPath, string(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/sql/rsg_test.go
+++ b/sql/rsg_test.go
@@ -1,0 +1,286 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Matt Jibson (mjibson@cockroachlabs.com)
+
+package sql_test
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"math/rand"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/internal/rsg"
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/timeutil"
+)
+
+var (
+	flagRSGTime       = flag.Duration("rsg", 0, "random syntax generator test duration")
+	flagRSGGoRoutines = flag.Int("rsg-routines", 1, "number of Go routines executing random statements in each RSG test")
+)
+
+func TestRandomSyntaxGeneration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const rootStmt = "target_list"
+
+	if *flagRSGTime == 0 {
+		t.Skip("enable with '-rsg <duration>'")
+	}
+
+	params, _ := createTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop()
+
+	y, err := ioutil.ReadFile(filepath.Join("parser", "sql.y"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := rsg.NewRSG(timeutil.Now().UnixNano(), string(y))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Broadcast channel for all workers.
+	done := make(chan bool)
+	var wg sync.WaitGroup
+	worker := func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			s := r.Generate(rootStmt, 20)
+			if strings.HasPrefix(s, "REVOKE") || strings.HasPrefix(s, "GRANT") {
+				continue
+			}
+			_, _ = db.Exec(`ROLLBACK`)
+			_, _ = db.Exec(`CREATE DATABASE IF NOT EXISTS name; SET DATABASE name;`)
+			_, _ = db.Exec(s)
+		}
+	}
+	for i := 0; i < *flagRSGGoRoutines; i++ {
+		go worker()
+		wg.Add(1)
+	}
+	time.Sleep(*flagRSGTime)
+	close(done)
+	wg.Wait()
+}
+
+func TestRandomSyntaxSelect(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const rootStmt = "stmt"
+
+	if *flagRSGTime == 0 {
+		t.Skip("enable with '-rsg <duration>'")
+	}
+
+	params, _ := createTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop()
+
+	y, err := ioutil.ReadFile(filepath.Join("parser", "sql.y"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := rsg.NewRSG(timeutil.Now().UnixNano(), string(y))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS ident; CREATE TABLE IF NOT EXISTS ident.ident (ident decimal);`); err != nil {
+		panic(err)
+	}
+	// Broadcast channel for all workers.
+	done := make(chan bool)
+	var wg sync.WaitGroup
+	worker := func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			targets := r.Generate(rootStmt, 30)
+			var where, from string
+			// Only generate complex clauses half the time.
+			if rand.Intn(2) == 0 {
+				where = r.Generate("where_clause", 30)
+				from = r.Generate("from_clause", 30)
+			} else {
+				from = "FROM ident"
+			}
+			s := fmt.Sprintf("SELECT %s %s %s", targets, from, where)
+			_, _ = db.Exec(`ROLLBACK`)
+			_, _ = db.Exec(`SET DATABASE = ident`)
+			_, _ = db.Exec(s)
+		}
+	}
+	for i := 0; i < *flagRSGGoRoutines; i++ {
+		go worker()
+		wg.Add(1)
+	}
+	time.Sleep(*flagRSGTime)
+	close(done)
+	wg.Wait()
+}
+
+func TestRandomSyntaxFunctions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	if *flagRSGTime == 0 {
+		t.Skip("enable with '-rsg <duration>'")
+	}
+
+	params, _ := createTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop()
+
+	y, err := ioutil.ReadFile(filepath.Join("parser", "sql.y"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := rsg.NewRSG(timeutil.Now().UnixNano(), string(y))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var names []string
+	for b := range parser.Builtins {
+		names = append(names, b)
+	}
+
+	// Broadcast channel for all workers.
+	done := make(chan bool)
+	var wg sync.WaitGroup
+	worker := func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			name := names[r.Intn(len(names))]
+			variations := parser.Builtins[name]
+			fn := variations[r.Intn(len(variations))]
+			var args []string
+			switch ft := fn.Types.(type) {
+			case parser.ArgTypes:
+				for _, typ := range ft {
+					var v interface{}
+					switch typ.(type) {
+					case *parser.DInt:
+						i := r.Intn(math.MaxInt64)
+						i -= r.Intn(math.MaxInt64)
+						v = i
+					case *parser.DFloat, *parser.DDecimal:
+						v = r.Float64()
+					case *parser.DString:
+						v = `'string'`
+					case *parser.DBytes:
+						v = `b'bytes'`
+					case *parser.DTimestamp:
+						t := time.Unix(0, int64(r.Intn(math.MaxInt64)))
+						v = fmt.Sprintf(`'%s'`, t.Format(time.RFC3339Nano))
+					default:
+						panic(fmt.Errorf("unknown arg type: %T", typ))
+					}
+					args = append(args, fmt.Sprint(v))
+				}
+			default:
+				continue
+			}
+			s := fmt.Sprintf("SELECT %s(%s)", name, strings.Join(args, ", "))
+			_, _ = db.Exec("ROLLBACK")
+			funcdone := make(chan bool, 1)
+			go func() {
+				_, _ = db.Exec(s)
+				funcdone <- true
+			}()
+			select {
+			case <-funcdone:
+			case <-time.After(time.Second * 5):
+				panic(fmt.Errorf("func exec timeout: %s", s))
+			}
+		}
+	}
+	for i := 0; i < *flagRSGGoRoutines; i++ {
+		go worker()
+		wg.Add(1)
+	}
+	time.Sleep(*flagRSGTime)
+	close(done)
+	wg.Wait()
+}
+
+func TestRandomSyntaxFuncCommon(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const rootStmt = "func_expr_common_subexpr"
+
+	if *flagRSGTime == 0 {
+		t.Skip("enable with '-rsg <duration>'")
+	}
+
+	params, _ := createTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop()
+
+	y, err := ioutil.ReadFile(filepath.Join("parser", "sql.y"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := rsg.NewRSG(timeutil.Now().UnixNano(), string(y))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Broadcast channel for all workers.
+	done := make(chan bool)
+	var wg sync.WaitGroup
+	worker := func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			expr := r.Generate(rootStmt, 30)
+			s := fmt.Sprintf("SELECT %s", expr)
+			_, _ = db.Exec(`ROLLBACK`)
+			_, _ = db.Exec(s)
+		}
+	}
+	for i := 0; i < *flagRSGGoRoutines; i++ {
+		go worker()
+		wg.Add(1)
+	}
+	time.Sleep(*flagRSGTime)
+	close(done)
+	wg.Wait()
+}


### PR DESCRIPTION
This test is designed to be run from a nightly job for some longish time
(~1h). Its goal is to find panics introduced in our implementation. Since
the executor is not the same go routine as the test, the executor has
been changed to include a panic handler that prepends the failed SQL
statement in a panic.

This uses the yacc package from the docs repo that generates the SQL
diagrams. It and the rsg package are included in internal because they
are not needed for the operation of the database, only for a test.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7970)

<!-- Reviewable:end -->
