### PR TITLE
[WIP] cli: backtrace integration

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -21,6 +21,7 @@ cmd honnef.co/go/unused/cmd/unused
 github.com/Sirupsen/logrus f3cfb454f4c209e6668c95216c4744b8fddb2356
 github.com/VividCortex/ewma 8b9f1311551e712ea8a06b494238b8a2351e1c33
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
+github.com/backtrace-labs/go-bcd 334e611401c4abc065e77ceaa6904f6de17278c7
 github.com/biogo/store 913427a1d5e89604e50ea1db0f28f34966d61602
 github.com/chzyer/readline 683bf8ff7cd77265a852553c3c3e37a464339049
 github.com/client9/misspell 940f19ff686fdd0ee8395209994d4e243cb81e37
@@ -85,6 +86,7 @@ github.com/termie/go-shutil bcacb06fecaeec8dc42af03c87c6949f4a05c74c
 github.com/wadey/gocovmerge b5bfa59ec0adc420475f97f89b58045c721d761c
 golang.org/x/crypto 2c99acdd1e9b90d779ca23f632aad86af9909c62
 golang.org/x/net f841c39de738b1d0df95b5a7187744f0e03d8112
+golang.org/x/sys a646d33e2ee3172a661fc09bca23bb4889a41bc8
 golang.org/x/text d5d7737684e596dbabf914ecf946d2783f35bdc2
 golang.org/x/tools d4a8e583a10c1e702d1accc9e66c104f992115c8
 google.golang.org/grpc aecdccadd24d03e42d00ec82f6774a428fc63c30

--- a/cli/backtrace.go
+++ b/cli/backtrace.go
@@ -1,0 +1,109 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+// +build linux freebsd
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/cockroachdb/cockroach/build"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/stop"
+
+	"github.com/backtrace-labs/go-bcd"
+)
+
+func initBacktrace(logDir string) *stop.Stopper {
+	const ptracePath = "/opt/backtrace/bin/ptrace"
+	if _, err := os.Stat(ptracePath); err != nil {
+		log.Infof("backtrace disabled: %s", err)
+		return stop.NewStopper()
+	}
+
+	if err := bcd.EnableTracing(); err != nil {
+		log.Infof("unable to enable backtrace: %s", err)
+		return stop.NewStopper()
+	}
+
+	bcd.UpdateConfig(&bcd.GlobalConfig{
+		PanicOnKillFailure: true,
+		ResendSignal:       true,
+		RateLimit:          time.Second * 3,
+		SynchronousPut:     true,
+	})
+
+	// Use the default tracer implementation.
+	// false: Exclude system goroutines.
+	tracer := bcd.New(false)
+
+	// Enable WARNING log output from the tracer.
+	tracer.AddOptions(nil, "-L", "WARNING")
+
+	info := build.GetInfo()
+	tracer.AddKV(nil, "cgo-compiler", info.CgoCompiler)
+	tracer.AddKV(nil, "go-version", info.GoVersion)
+	tracer.AddKV(nil, "platform", info.Platform)
+	tracer.AddKV(nil, "tag", info.Tag)
+	tracer.AddKV(nil, "time", info.Time)
+
+	// Register for traces on signal reception.
+	tracer.SetSigset(
+		[]os.Signal{
+			syscall.SIGABRT,
+			syscall.SIGFPE,
+			syscall.SIGSEGV,
+			syscall.SIGILL,
+			syscall.SIGBUS}...)
+	bcd.Register(tracer)
+
+	// Hook log.Fatal*.
+	log.SetExitFunc(func(code int) {
+		_ = bcd.Trace(tracer, fmt.Errorf("exit %d", code), nil)
+		os.Exit(code)
+	})
+
+	stopper := stop.NewStopper(stop.OnPanic(func(val interface{}) {
+		err, ok := val.(error)
+		if !ok {
+			err = fmt.Errorf("%v", val)
+		}
+		_ = bcd.Trace(tracer, err, nil)
+		panic(val)
+	}))
+
+	// Internally, backtrace uses an external program (/opt/backtrace/bin/ptrace)
+	// to generate traces. We direct the stdout for this program to a file for
+	// debugging our usage of backtrace.
+	if f, err := os.OpenFile(filepath.Join(logDir, "backtrace.out"),
+		os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666); err != nil {
+		log.Infof("unable to open: %s", err)
+	} else {
+		stopper.AddCloser(stop.CloserFn(func() {
+			f.Close()
+		}))
+		tracer.SetPipes(nil, f)
+	}
+
+	tracer.SetLogLevel(bcd.LogMax)
+	log.Infof("backtrace enabled")
+	return stopper
+}

--- a/cli/backtrace_unsupported.go
+++ b/cli/backtrace_unsupported.go
@@ -1,0 +1,25 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+// +build !linux,!freebsd
+
+package cli
+
+import "github.com/cockroachdb/cockroach/util/stop"
+
+func initBacktrace(logDir string) *stop.Stopper {
+	return stop.NewStopper()
+}

--- a/cli/start.go
+++ b/cli/start.go
@@ -308,7 +308,8 @@ func runStart(_ *cobra.Command, args []string) error {
 	}
 
 	// Make sure the path exists.
-	if err := os.MkdirAll(f.Value.String(), 0755); err != nil {
+	logDir := f.Value.String()
+	if err := os.MkdirAll(logDir, 0755); err != nil {
 		return err
 	}
 
@@ -323,7 +324,7 @@ func runStart(_ *cobra.Command, args []string) error {
 	// Default user for servers.
 	serverCtx.User = security.NodeUser
 
-	stopper := stop.NewStopper()
+	stopper := initBacktrace(logDir)
 	if err := serverCtx.InitStores(stopper); err != nil {
 		return fmt.Errorf("failed to initialize stores: %s", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -366,7 +366,7 @@ func (s *Server) Start() error {
 	})
 
 	s.stopper.RunWorker(func() {
-		netutil.FatalIfUnexpected(httpServer.ServeWith(pgL, func(conn net.Conn) {
+		netutil.FatalIfUnexpected(httpServer.ServeWith(s.stopper, pgL, func(conn net.Conn) {
 			if err := s.pgServer.ServeConn(conn); err != nil && !netutil.IsClosedConnection(err) {
 				log.Error(err)
 			}
@@ -388,7 +388,7 @@ func (s *Server) Start() error {
 		})
 
 		s.stopper.RunWorker(func() {
-			netutil.FatalIfUnexpected(httpServer.ServeWith(unixLn, func(conn net.Conn) {
+			netutil.FatalIfUnexpected(httpServer.ServeWith(s.stopper, unixLn, func(conn net.Conn) {
 				if err := s.pgServer.ServeConn(conn); err != nil &&
 					!netutil.IsClosedConnection(err) {
 					log.Error(err)

--- a/util/log/clog_test.go
+++ b/util/log/clog_test.go
@@ -89,10 +89,10 @@ func contains(s Severity, str string, t *testing.T) bool {
 	return strings.Contains(c, str)
 }
 
-// setFlags configures the logging flags and osExitFunc how the test expects
+// setFlags configures the logging flags and exitFunc how the test expects
 // them.
 func setFlags() {
-	osExitFunc = os.Exit
+	SetExitFunc(os.Exit)
 	logging.stderrThreshold = ErrorLog
 	logging.toStderr = false
 }
@@ -554,7 +554,7 @@ func TestFatalStacktraceStderr(t *testing.T) {
 	setFlags()
 	logging.stderrThreshold = NumSeverity
 	logging.toStderr = false
-	osExitFunc = func(int) {}
+	SetExitFunc(func(int) {})
 
 	defer setFlags()
 	defer logging.swap(logging.newBuffers())

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -65,6 +65,14 @@ func DisableLogFileOutput() {
 	logging.stderrThreshold = NumSeverity
 }
 
+// SetExitFunc allows setting a function that will be called to exit the
+// process when a Fatal message is generated.
+func SetExitFunc(f func(int)) {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+	logging.exitFunc = f
+}
+
 // logDepth uses the PrintWith to format the output string and
 // formulate the context information into the machine-readable
 // dictionary for separate binary-log output.

--- a/util/netutil/net.go
+++ b/util/netutil/net.go
@@ -104,7 +104,7 @@ func MakeServer(stopper *stop.Stopper, tlsConfig *tls.Config, handler http.Handl
 }
 
 // ServeWith accepts connections on ln and serves them using serveConn.
-func (s *Server) ServeWith(l net.Listener, serveConn func(net.Conn)) error {
+func (s *Server) ServeWith(stopper *stop.Stopper, l net.Listener, serveConn func(net.Conn)) error {
 	// Inspired by net/http.(*Server).Serve
 	var tempDelay time.Duration // how long to sleep on accept failure
 	for {
@@ -127,6 +127,7 @@ func (s *Server) ServeWith(l net.Listener, serveConn func(net.Conn)) error {
 		}
 		tempDelay = 0
 		go func() {
+			defer stopper.Recover()
 			s.Server.ConnState(rw, http.StateNew) // before Serve can return
 			serveConn(rw)
 			s.Server.ConnState(rw, http.StateClosed)


### PR DESCRIPTION
Initialize backtrace if available.

Use `stopper.Recover` in the connection handling goroutines.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7980)

<!-- Reviewable:end -->
