### PR TITLE
sqlbase: validate cross-table references

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -113,7 +113,7 @@ func (sc *SchemaChanger) runBackfill(lease *sqlbase.TableDescriptor_SchemaChange
 	var addedColumnDescs []sqlbase.ColumnDescriptor
 	var addedIndexDescs []sqlbase.IndexDescriptor
 	if err := sc.db.Txn(func(txn *client.Txn) error {
-		tableDesc, err := getTableDescFromID(txn, sc.tableID)
+		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {
 			return err
 		}
@@ -176,7 +176,7 @@ func (sc *SchemaChanger) getTableSpan() (sqlbase.Span, error) {
 	var tableDesc *sqlbase.TableDescriptor
 	if err := sc.db.Txn(func(txn *client.Txn) error {
 		var err error
-		tableDesc, err = getTableDescFromID(txn, sc.tableID)
+		tableDesc, err = sqlbase.GetTableDescFromID(txn, sc.tableID)
 		return err
 	}); err != nil {
 		return sqlbase.Span{}, err
@@ -259,7 +259,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 	var curIndexKey roachpb.Key
 	done := false
 	err := sc.db.Txn(func(txn *client.Txn) error {
-		tableDesc, err := getTableDescFromID(txn, sc.tableID)
+		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {
 			return err
 		}
@@ -272,7 +272,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		updateCols := append(added, dropped...)
 		fkTables := TablesNeededForFKs(*tableDesc, CheckUpdates)
 		for k := range fkTables {
-			if fkTables[k], err = getTableDescFromID(txn, k); err != nil {
+			if fkTables[k], err = sqlbase.GetTableDescFromID(txn, k); err != nil {
 				return err
 			}
 		}
@@ -383,7 +383,7 @@ func (sc *SchemaChanger) truncateIndexes(
 		}
 		*lease = l
 		if err := sc.db.Txn(func(txn *client.Txn) error {
-			tableDesc, err := getTableDescFromID(txn, sc.tableID)
+			tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 			if err != nil {
 				return err
 			}
@@ -460,7 +460,7 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 	var nextKey roachpb.Key
 	done := false
 	err := sc.db.Txn(func(txn *client.Txn) error {
-		tableDesc, err := getTableDescFromID(txn, sc.tableID)
+		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {
 			return err
 		}

--- a/sql/create.go
+++ b/sql/create.go
@@ -594,7 +594,7 @@ func (p *planner) finalizeInterleave(
 ) error {
 	// TODO(dan): This is similar to finalizeFKs. Consolidate them.
 	for _, ancestor := range index.Interleave.Ancestors {
-		ancestorTable, err := getTableDescFromID(p.txn, ancestor.TableID)
+		ancestorTable, err := sqlbase.GetTableDescFromID(p.txn, ancestor.TableID)
 		if err != nil {
 			return err
 		}

--- a/sql/create.go
+++ b/sql/create.go
@@ -327,7 +327,9 @@ func (n *createTableNode) Start() error {
 	if desc.ID == 0 {
 		desc.ID = keys.MaxReservedDescID + 1
 	}
-	err = desc.Validate()
+	// Only validate the table because backreferences aren't created yet.
+	// Everything is validated below.
+	err = desc.ValidateTable()
 	desc.ID = savedID
 	if err != nil {
 		return err
@@ -339,19 +341,23 @@ func (n *createTableNode) Start() error {
 		return err
 	}
 
-	if err := n.finalizeFKs(&desc, fkTargets); err != nil {
-		return err
-	}
+	if created {
+		if err := n.finalizeFKs(&desc, fkTargets); err != nil {
+			return err
+		}
 
-	for _, index := range desc.AllNonDropIndexes() {
-		if len(index.Interleave.Ancestors) > 0 {
-			if err := n.p.finalizeInterleave(&desc, index); err != nil {
-				return err
+		for _, index := range desc.AllNonDropIndexes() {
+			if len(index.Interleave.Ancestors) > 0 {
+				if err := n.p.finalizeInterleave(&desc, index); err != nil {
+					return err
+				}
 			}
 		}
-	}
 
-	if created {
+		if err := desc.Validate(n.p.txn); err != nil {
+			return err
+		}
+
 		// Log Create Table event. This is an auditable log event and is
 		// recorded in the same transaction as the table descriptor update.
 		if err := MakeEventLogger(n.p.leaseMgr).InsertEventRecord(n.p.txn,
@@ -487,7 +493,7 @@ func (p *planner) saveNonmutationAndNotify(td *sqlbase.TableDescriptor) error {
 	if err := td.SetUpVersion(); err != nil {
 		return err
 	}
-	if err := td.Validate(); err != nil {
+	if err := td.ValidateTable(); err != nil {
 		return err
 	}
 	if err := p.writeTableDesc(td); err != nil {
@@ -550,6 +556,7 @@ func (p *planner) addInterleave(
 	}
 	index.Interleave = sqlbase.InterleaveDescriptor{Ancestors: append(ancestorPrefix, intl)}
 
+	desc.State = sqlbase.TableDescriptor_ADD
 	return nil
 }
 
@@ -592,23 +599,34 @@ func (n *createTableNode) finalizeFKs(desc *sqlbase.TableDescriptor, fkTargets [
 func (p *planner) finalizeInterleave(
 	desc *sqlbase.TableDescriptor, index sqlbase.IndexDescriptor,
 ) error {
-	// TODO(dan): This is similar to finalizeFKs. Consolidate them.
-	for _, ancestor := range index.Interleave.Ancestors {
-		ancestorTable, err := sqlbase.GetTableDescFromID(p.txn, ancestor.TableID)
-		if err != nil {
-			return err
-		}
-		ancestorIndex, err := ancestorTable.FindIndexByID(ancestor.IndexID)
-		if err != nil {
-			return err
-		}
-		ancestorIndex.InterleavedBy = append(ancestorIndex.InterleavedBy,
-			sqlbase.ForeignKeyReference{Table: desc.ID, Index: index.ID})
+	// TODO(dan): This is similar to finalizeFKs. Consolidate them
+	if len(index.Interleave.Ancestors) == 0 {
+		return nil
+	}
+	// Only the last ancestor needs the backreference.
+	ancestor := index.Interleave.Ancestors[len(index.Interleave.Ancestors)-1]
+	ancestorTable, err := sqlbase.GetTableDescFromID(p.txn, ancestor.TableID)
+	if err != nil {
+		return err
+	}
+	ancestorIndex, err := ancestorTable.FindIndexByID(ancestor.IndexID)
+	if err != nil {
+		return err
+	}
+	ancestorIndex.InterleavedBy = append(ancestorIndex.InterleavedBy,
+		sqlbase.ForeignKeyReference{Table: desc.ID, Index: index.ID})
 
-		// TODO(dan): Only save each referenced table once.
-		if err := p.saveNonmutationAndNotify(ancestorTable); err != nil {
+	if err := p.saveNonmutationAndNotify(ancestorTable); err != nil {
+		return err
+	}
+
+	if desc.State == sqlbase.TableDescriptor_ADD {
+		desc.State = sqlbase.TableDescriptor_PUBLIC
+
+		if err := p.saveNonmutationAndNotify(desc); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -156,17 +156,19 @@ func (p *planner) getDescriptor(plainKey sqlbase.DescriptorKey, descriptor sqlba
 		if table == nil {
 			return false, errors.Errorf("%q is not a table", plainKey.Name())
 		}
+		if err := table.Validate(p.txn); err != nil {
+			return false, err
+		}
 		*t = *table
 	case *sqlbase.DatabaseDescriptor:
 		database := desc.GetDatabase()
 		if database == nil {
 			return false, errors.Errorf("%q is not a database", plainKey.Name())
 		}
+		if err := database.Validate(); err != nil {
+			return false, err
+		}
 		*t = *database
-	}
-
-	if err := descriptor.Validate(); err != nil {
-		return false, err
 	}
 	return true, nil
 }

--- a/sql/descriptor_mutation_test.go
+++ b/sql/descriptor_mutation_test.go
@@ -127,7 +127,7 @@ func (mt mutationTest) makeMutationsActive() {
 		}
 	}
 	mt.tableDesc.Mutations = nil
-	if err := mt.tableDesc.Validate(); err != nil {
+	if err := mt.tableDesc.ValidateTable(); err != nil {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
@@ -177,7 +177,7 @@ func (mt mutationTest) writeMutation(m sqlbase.DescriptorMutation) {
 		}
 	}
 	mt.tableDesc.Mutations = append(mt.tableDesc.Mutations, m)
-	if err := mt.tableDesc.Validate(); err != nil {
+	if err := mt.tableDesc.ValidateTable(); err != nil {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
@@ -336,21 +336,21 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR DEFAULT 'i', FAMILY (k),
 	// Check that a mutation can only be inserted with an explicit mutation state, and direction.
 	tableDesc = mTest.tableDesc
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{}}
-	if err := tableDesc.Validate(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, and no column/index descriptor") {
+	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, and no column/index descriptor") {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{Descriptor_: &sqlbase.DescriptorMutation_Column{Column: &tableDesc.Columns[len(tableDesc.Columns)-1]}}}
 	tableDesc.Columns = tableDesc.Columns[:len(tableDesc.Columns)-1]
-	if err := tableDesc.Validate(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, col i, id 3") {
+	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, col i, id 3") {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = sqlbase.DescriptorMutation_DELETE_ONLY
-	if err := tableDesc.Validate(); !testutils.IsError(err, "mutation in state DELETE_ONLY, direction NONE, col i, id 3") {
+	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state DELETE_ONLY, direction NONE, col i, id 3") {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = sqlbase.DescriptorMutation_UNKNOWN
 	tableDesc.Mutations[0].Direction = sqlbase.DescriptorMutation_DROP
-	if err := tableDesc.Validate(); !testutils.IsError(err, "mutation in state UNKNOWN, direction DROP, col i, id 3") {
+	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction DROP, col i, id 3") {
 		t.Fatal(err)
 	}
 }
@@ -484,7 +484,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo (v));
 	tableDesc = mTest.tableDesc
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{Descriptor_: &sqlbase.DescriptorMutation_Index{Index: &tableDesc.Indexes[len(tableDesc.Indexes)-1]}}}
 	tableDesc.Indexes = tableDesc.Indexes[:len(tableDesc.Indexes)-1]
-	if err := tableDesc.Validate(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, index foo, id 2") {
+	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, index foo, id 2") {
 		t.Fatal(err)
 	}
 }

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -253,7 +253,7 @@ func (n *dropIndexNode) Start() error {
 		if err != nil {
 			return err
 		}
-		if err := tableDesc.Validate(); err != nil {
+		if err := tableDesc.Validate(n.p.txn); err != nil {
 			return err
 		}
 		if err := n.p.writeTableDesc(tableDesc); err != nil {

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -341,7 +341,7 @@ func (n *dropTableNode) expandPlan() error {
 func (p *planner) canRemoveFK(
 	from string, ref *sqlbase.ForeignKeyReference, behavior parser.DropBehavior,
 ) (*sqlbase.TableDescriptor, error) {
-	table, err := getTableDescFromID(p.txn, ref.Table)
+	table, err := sqlbase.GetTableDescFromID(p.txn, ref.Table)
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +357,7 @@ func (p *planner) canRemoveFK(
 func (p *planner) removeFK(ref *sqlbase.ForeignKeyReference, table *sqlbase.TableDescriptor) error {
 	if table == nil {
 		var err error
-		table, err = getTableDescFromID(p.txn, ref.Table)
+		table, err = sqlbase.GetTableDescFromID(p.txn, ref.Table)
 		if err != nil {
 			return err
 		}
@@ -485,7 +485,7 @@ func (p *planner) dropTableImpl(tableDesc *sqlbase.TableDescriptor) error {
 func (p *planner) removeFKBackReference(
 	tableDesc *sqlbase.TableDescriptor, idx sqlbase.IndexDescriptor,
 ) error {
-	t, err := getTableDescFromID(p.txn, idx.ForeignKey.Table)
+	t, err := sqlbase.GetTableDescFromID(p.txn, idx.ForeignKey.Table)
 	if err != nil {
 		return errors.Errorf("error resolving referenced table ID %d: %v", idx.ForeignKey.Table, err)
 	}

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -152,7 +152,7 @@ func (s LeaseStore) Acquire(
 		return nil, err
 	}
 	if values == nil {
-		return nil, errDescriptorNotFound
+		return nil, sqlbase.ErrDescriptorNotFound
 	}
 	desc := &sqlbase.Descriptor{}
 	if err := proto.Unmarshal([]byte(*values[0].(*parser.DBytes)), desc); err != nil {
@@ -1046,14 +1046,14 @@ func (m *LeaseManager) AcquireByName(
 			if err := m.Release(lease); err != nil {
 				log.Warningf(context.TODO(), "error releasing lease: %s", err)
 			}
-			return nil, errDescriptorNotFound
+			return nil, sqlbase.ErrDescriptorNotFound
 		}
 	}
 	return lease, nil
 }
 
 // resolveName resolves a table name to a descriptor ID by looking in the
-// database. If the mapping is not found, errDescriptorNotFound is returned.
+// database. If the mapping is not found, sqlbase.ErrDescriptorNotFound is returned.
 func (m *LeaseManager) resolveName(
 	txn *client.Txn, dbID sqlbase.ID, tableName string,
 ) (sqlbase.ID, error) {
@@ -1064,7 +1064,7 @@ func (m *LeaseManager) resolveName(
 		return 0, err
 	}
 	if !gr.Exists() {
-		return 0, errDescriptorNotFound
+		return 0, sqlbase.ErrDescriptorNotFound
 	}
 	return sqlbase.ID(gr.ValueInt()), nil
 }

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -170,7 +170,9 @@ func (s LeaseStore) Acquire(
 	tableDesc.MaybeUpgradeFormatVersion()
 	lease.TableDescriptor = *tableDesc
 
-	if err := lease.Validate(); err != nil {
+	// ValidateTable instead of Validate, even though we have a txn available,
+	// so we don't block reads waiting for this lease.
+	if err := lease.ValidateTable(); err != nil {
 		return nil, err
 	}
 	if lease.Version < minVersion {
@@ -333,7 +335,7 @@ func (s LeaseStore) Publish(
 				log.Infof(context.TODO(), "publish: descID=%d (%s) version=%d mtime=%s",
 					tableDesc.ID, tableDesc.Name, tableDesc.Version, now.GoTime())
 			}
-			if err := tableDesc.Validate(); err != nil {
+			if err := tableDesc.ValidateTable(); err != nil {
 				return err
 			}
 
@@ -1167,7 +1169,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gos
 					case *sqlbase.Descriptor_Table:
 						table := union.Table
 						table.MaybeUpgradeFormatVersion()
-						if err := table.Validate(); err != nil {
+						if err := table.ValidateTable(); err != nil {
 							log.Errorf(context.TODO(), "%s: received invalid table descriptor: %v", kv.Key, table)
 							continue
 						}

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -167,7 +167,7 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
 	newTbKey := tableKey{targetDbDesc.ID, n.NewName.Table()}.Key()
 
-	if err := tableDesc.Validate(); err != nil {
+	if err := tableDesc.Validate(p.txn); err != nil {
 		return nil, err
 	}
 
@@ -266,7 +266,7 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, error) {
 		return nil, err
 	}
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
-	if err := tableDesc.Validate(); err != nil {
+	if err := tableDesc.Validate(p.txn); err != nil {
 		return nil, err
 	}
 	if err := p.txn.Put(descKey, sqlbase.WrapDescriptor(tableDesc)); err != nil {
@@ -381,7 +381,7 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 	}
 
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
-	if err := tableDesc.Validate(); err != nil {
+	if err := tableDesc.Validate(p.txn); err != nil {
 		return nil, err
 	}
 	if err := p.txn.Put(descKey, sqlbase.WrapDescriptor(tableDesc)); err != nil {

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -101,7 +101,7 @@ func (sc *SchemaChanger) AcquireLease() (sqlbase.TableDescriptor_SchemaChangeLea
 	var lease sqlbase.TableDescriptor_SchemaChangeLease
 	err := sc.db.Txn(func(txn *client.Txn) error {
 		txn.SetSystemConfigTrigger()
-		tableDesc, err := getTableDescFromID(txn, sc.tableID)
+		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {
 			return err
 		}
@@ -129,7 +129,7 @@ func (sc *SchemaChanger) AcquireLease() (sqlbase.TableDescriptor_SchemaChangeLea
 func (sc *SchemaChanger) findTableWithLease(
 	txn *client.Txn, lease sqlbase.TableDescriptor_SchemaChangeLease,
 ) (*sqlbase.TableDescriptor, error) {
-	tableDesc, err := getTableDescFromID(txn, sc.tableID)
+	tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (sc *SchemaChanger) ExtendLease(
 
 func isSchemaChangeRetryError(err error) bool {
 	switch err {
-	case errDescriptorNotFound:
+	case sqlbase.ErrDescriptorNotFound:
 		return false
 	default:
 		return !sqlbase.IsIntegrityConstraintError(err)
@@ -586,7 +586,7 @@ func (sc *SchemaChanger) IsDone() (bool, error) {
 	var done bool
 	err := sc.db.Txn(func(txn *client.Txn) error {
 		done = true
-		tableDesc, err := getTableDescFromID(txn, sc.tableID)
+		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {
 			return err
 		}
@@ -776,7 +776,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 						err := sc.exec(nil, nil)
 						if err != nil {
 							if err == errExistingSchemaChangeLease {
-							} else if err == errDescriptorNotFound {
+							} else if err == sqlbase.ErrDescriptorNotFound {
 								// Someone deleted this table. Don't try to run the schema
 								// changer again. Note that there's no gossip update for the
 								// deletion which would remove this schemaChanger.

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -715,7 +715,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 					case *sqlbase.Descriptor_Table:
 						table := union.Table
 						table.MaybeUpgradeFormatVersion()
-						if err := table.Validate(); err != nil {
+						if err := table.ValidateTable(); err != nil {
 							log.Errorf(context.TODO(), "%s: received invalid table descriptor: %v", kv.Key, table)
 							continue
 						}

--- a/sql/show.go
+++ b/sql/show.go
@@ -96,7 +96,7 @@ func (p *planner) showCreateInterleave(idx *sqlbase.IndexDescriptor) (string, er
 		return "", nil
 	}
 	intl := idx.Interleave
-	parentTable, err := getTableDescFromID(p.txn, intl.Ancestors[len(intl.Ancestors)-1].TableID)
+	parentTable, err := sqlbase.GetTableDescFromID(p.txn, intl.Ancestors[len(intl.Ancestors)-1].TableID)
 	if err != nil {
 		return "", err
 	}

--- a/sql/sqlbase/main_test.go
+++ b/sql/sqlbase/main_test.go
@@ -14,16 +14,22 @@
 //
 // Author: Radu Berinde (radu@cockroachlabs.com)
 
-package sqlbase
+package sqlbase_test
 
 import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/security/securitytest"
+	"github.com/cockroachdb/cockroach/server"
+	"github.com/cockroachdb/cockroach/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
 func TestMain(m *testing.M) {
+	security.SetReadFileFn(securitytest.Asset)
 	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
 	os.Exit(m.Run())
 }

--- a/sql/sqlbase/metadata.go
+++ b/sql/sqlbase/metadata.go
@@ -50,7 +50,6 @@ type DescriptorProto interface {
 	TypeName() string
 	GetName() string
 	SetName(string)
-	Validate() error
 }
 
 // WrapDescriptor fills in a Descriptor.

--- a/sql/sqlbase/structured.go
+++ b/sql/sqlbase/structured.go
@@ -558,16 +558,153 @@ func (desc *TableDescriptor) AllocateIDs() error {
 	if desc.ID == 0 {
 		desc.ID = keys.MaxReservedDescID + 1
 	}
-	err := desc.Validate()
+	err := desc.ValidateTable()
 	desc.ID = savedID
 	return err
 }
 
 // Validate validates that the table descriptor is well formed. Checks include
-// validating the table, column and index names, verifying that column names
-// and index names are unique and verifying that column IDs and index IDs are
-// consistent.
-func (desc *TableDescriptor) Validate() error {
+// both single table and cross table invariants.
+func (desc *TableDescriptor) Validate(txn *client.Txn) error {
+	err := desc.ValidateTable()
+	if err != nil {
+		return err
+	}
+	return desc.validateCrossReferences(txn)
+}
+
+// validateCrossReferences validates that each reference to another table is
+// resolvable and that the necessary back references exist.
+func (desc *TableDescriptor) validateCrossReferences(txn *client.Txn) error {
+	tablesByID := map[ID]*TableDescriptor{desc.ID: desc}
+	getTable := func(id ID) (*TableDescriptor, error) {
+		if table, ok := tablesByID[id]; ok {
+			return table, nil
+		}
+		table, err := GetTableDescFromID(txn, id)
+		if err != nil {
+			return nil, err
+		}
+		tablesByID[id] = table
+		return table, nil
+	}
+
+	findTargetIndex := func(tableID ID, indexID IndexID) (*TableDescriptor, *IndexDescriptor, error) {
+		targetTable, err := getTable(tableID)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "missing table=%d index=%d", tableID, indexID)
+		}
+		targetIndex, err := targetTable.FindIndexByID(indexID)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "missing table=%s index=%d", targetTable.Name, indexID)
+		}
+		return targetTable, targetIndex, nil
+	}
+
+	for _, index := range desc.AllNonDropIndexes() {
+		// Check foreign keys.
+		if index.ForeignKey != nil {
+			targetTable, targetIndex, err := findTargetIndex(
+				index.ForeignKey.Table, index.ForeignKey.Index)
+			if err != nil {
+				return errors.Wrap(err, "invalid foreign key")
+			}
+			found := false
+			for _, backref := range targetIndex.ReferencedBy {
+				if backref.Table == desc.ID && backref.Index == index.ID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return errors.Errorf("missing fk back reference to %s.%s from %s.%s",
+					desc.Name, index.Name, targetTable.Name, targetIndex.Name)
+			}
+		}
+		fkBackrefs := make(map[ForeignKeyReference]struct{})
+		for _, backref := range index.ReferencedBy {
+			if _, ok := fkBackrefs[*backref]; ok {
+				return errors.Errorf("duplicated fk backreference %+v", backref)
+			}
+			fkBackrefs[*backref] = struct{}{}
+			targetTable, err := getTable(backref.Table)
+			if err != nil {
+				return errors.Wrapf(err, "invalid fk backreference table=%d index=%d",
+					backref.Table, backref.Index)
+			}
+			targetIndex, err := targetTable.FindIndexByID(backref.Index)
+			if err != nil {
+				return errors.Wrapf(err, "invalid fk backreference table=%s index=%d",
+					targetTable.Name, backref.Index)
+			}
+			if fk := targetIndex.ForeignKey; fk == nil || fk.Table != desc.ID || fk.Index != index.ID {
+				return errors.Errorf("broken fk backward reference from %s.%s to %s.%s",
+					desc.Name, index.Name, targetTable.Name, targetIndex.Name)
+			}
+		}
+
+		// Check interleaves.
+		if len(index.Interleave.Ancestors) > 0 {
+			// Only check the most recent ancestor, the rest of them don't point
+			// back.
+			ancestor := index.Interleave.Ancestors[len(index.Interleave.Ancestors)-1]
+			targetTable, targetIndex, err := findTargetIndex(ancestor.TableID, ancestor.IndexID)
+			if err != nil {
+				return errors.Wrap(err, "invalid interleave")
+			}
+			found := false
+			for _, backref := range targetIndex.InterleavedBy {
+				if backref.Table == desc.ID && backref.Index == index.ID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return errors.Errorf(
+					"missing interleave back reference to %s.%s from %s.%s",
+					desc.Name, index.Name, targetTable.Name, targetIndex.Name)
+			}
+		}
+		interleaveBackrefs := make(map[ForeignKeyReference]struct{})
+		for _, backref := range index.InterleavedBy {
+			if _, ok := interleaveBackrefs[backref]; ok {
+				return errors.Errorf("duplicated interleave backreference %+v", backref)
+			}
+			interleaveBackrefs[backref] = struct{}{}
+			targetTable, err := getTable(backref.Table)
+			if err != nil {
+				return errors.Wrapf(err, "invalid interleave backreference table=%d index=%d",
+					backref.Table, backref.Index)
+			}
+			targetIndex, err := targetTable.FindIndexByID(backref.Index)
+			if err != nil {
+				return errors.Wrapf(err, "invalid interleave backreference table=%s index=%d",
+					targetTable.Name, backref.Index)
+			}
+			if len(targetIndex.Interleave.Ancestors) == 0 {
+				return errors.Errorf(
+					"broken interleave backward reference from %s.%s to %s.%s",
+					desc.Name, index.Name, targetTable.Name, targetIndex.Name)
+			}
+			// The last ancestor is required to be a backreference.
+			ancestor := targetIndex.Interleave.Ancestors[len(targetIndex.Interleave.Ancestors)-1]
+			if ancestor.TableID != desc.ID || ancestor.IndexID != index.ID {
+				return errors.Errorf(
+					"broken interleave backward reference from %s.%s to %s.%s",
+					desc.Name, index.Name, targetTable.Name, targetIndex.Name)
+			}
+		}
+	}
+	// TODO(dan): Also validate SharedPrefixLen in the interleaves.
+	return nil
+}
+
+// ValidateTable validates that the table descriptor is well formed. Checks
+// include validating the table, column and index names, verifying that column
+// names and index names are unique and verifying that column IDs and index IDs
+// are consistent. Use Validate to validate that cross-table references are
+// correct.
+func (desc *TableDescriptor) ValidateTable() error {
 	if err := validateName(desc.Name, "table"); err != nil {
 		return err
 	}

--- a/sql/sqlbase/structured_test.go
+++ b/sql/sqlbase/structured_test.go
@@ -21,7 +21,13 @@ import (
 	"reflect"
 	"testing"
 
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
@@ -581,10 +587,234 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 	}
 	for i, d := range testData {
-		if err := d.desc.Validate(); err == nil {
+		if err := d.desc.ValidateTable(); err == nil {
 			t.Errorf("%d: expected \"%s\", but found success: %+v", i, d.err, d.desc)
 		} else if d.err != err.Error() {
 			t.Errorf("%d: expected \"%s\", but found \"%s\"", i, d.err, err.Error())
+		}
+	}
+}
+
+func TestValidateCrossTableReferences(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop()
+
+	tests := []struct {
+		err        string
+		desc       TableDescriptor
+		referenced []TableDescriptor
+	}{
+		// Foreign keys
+		{
+			err: `invalid foreign key: missing table=52 index=2: descriptor not found`,
+			desc: TableDescriptor{
+				ID: 51,
+				PrimaryIndex: IndexDescriptor{
+					ID:         1,
+					ForeignKey: &ForeignKeyReference{Table: 52, Index: 2},
+				},
+			},
+			referenced: nil,
+		},
+		{
+			err: `invalid foreign key: missing table=baz index=2: index-id "2" does not exist`,
+			desc: TableDescriptor{
+				ID: 51,
+				PrimaryIndex: IndexDescriptor{
+					ID:         1,
+					ForeignKey: &ForeignKeyReference{Table: 52, Index: 2},
+				},
+			},
+			referenced: []TableDescriptor{{
+				ID:   52,
+				Name: "baz",
+			}},
+		},
+		{
+			err: `missing fk back reference to foo.bar from baz.qux`,
+			desc: TableDescriptor{
+				ID:   51,
+				Name: "foo",
+				PrimaryIndex: IndexDescriptor{
+					ID:         1,
+					Name:       "bar",
+					ForeignKey: &ForeignKeyReference{Table: 52, Index: 2},
+				},
+			},
+			referenced: []TableDescriptor{{
+				ID:   52,
+				Name: "baz",
+				PrimaryIndex: IndexDescriptor{
+					ID:   2,
+					Name: "qux",
+				},
+			}},
+		},
+		{
+			err: `invalid fk backreference table=52 index=2: descriptor not found`,
+			desc: TableDescriptor{
+				ID: 51,
+				PrimaryIndex: IndexDescriptor{
+					ID:           1,
+					ReferencedBy: []*ForeignKeyReference{{Table: 52, Index: 2}},
+				},
+			},
+		},
+		{
+			err: `invalid fk backreference table=baz index=2: index-id "2" does not exist`,
+			desc: TableDescriptor{
+				ID: 51,
+				PrimaryIndex: IndexDescriptor{
+					ID:           1,
+					ReferencedBy: []*ForeignKeyReference{{Table: 52, Index: 2}},
+				},
+			},
+			referenced: []TableDescriptor{{
+				ID:   52,
+				Name: "baz",
+			}},
+		},
+		{
+			err: `broken fk backward reference from foo.bar to baz.qux`,
+			desc: TableDescriptor{
+				ID:   51,
+				Name: "foo",
+				PrimaryIndex: IndexDescriptor{
+					ID:           1,
+					Name:         "bar",
+					ReferencedBy: []*ForeignKeyReference{{Table: 52, Index: 2}},
+				},
+			},
+			referenced: []TableDescriptor{{
+				ID:   52,
+				Name: "baz",
+				PrimaryIndex: IndexDescriptor{
+					ID:   2,
+					Name: "qux",
+				},
+			}},
+		},
+
+		// Interleaves
+		{
+			err: `invalid interleave: missing table=52 index=2: descriptor not found`,
+			desc: TableDescriptor{
+				ID: 51,
+				PrimaryIndex: IndexDescriptor{
+					ID: 1,
+					Interleave: InterleaveDescriptor{Ancestors: []InterleaveDescriptor_Ancestor{
+						{TableID: 52, IndexID: 2},
+					}},
+				},
+			},
+			referenced: nil,
+		},
+		{
+			err: `invalid interleave: missing table=baz index=2: index-id "2" does not exist`,
+			desc: TableDescriptor{
+				ID: 51,
+				PrimaryIndex: IndexDescriptor{
+					ID: 1,
+					Interleave: InterleaveDescriptor{Ancestors: []InterleaveDescriptor_Ancestor{
+						{TableID: 52, IndexID: 2},
+					}},
+				},
+			},
+			referenced: []TableDescriptor{{
+				ID:   52,
+				Name: "baz",
+			}},
+		},
+		{
+			err: `missing interleave back reference to foo.bar from baz.qux`,
+			desc: TableDescriptor{
+				ID:   51,
+				Name: "foo",
+				PrimaryIndex: IndexDescriptor{
+					ID:   1,
+					Name: "bar",
+					Interleave: InterleaveDescriptor{Ancestors: []InterleaveDescriptor_Ancestor{
+						{TableID: 52, IndexID: 2},
+					}},
+				},
+			},
+			referenced: []TableDescriptor{{
+				ID:   52,
+				Name: "baz",
+				PrimaryIndex: IndexDescriptor{
+					ID:   2,
+					Name: "qux",
+				},
+			}},
+		},
+		{
+			err: `invalid interleave backreference table=52 index=2: descriptor not found`,
+			desc: TableDescriptor{
+				ID: 51,
+				PrimaryIndex: IndexDescriptor{
+					ID:            1,
+					InterleavedBy: []ForeignKeyReference{{Table: 52, Index: 2}},
+				},
+			},
+		},
+		{
+			err: `invalid interleave backreference table=baz index=2: index-id "2" does not exist`,
+			desc: TableDescriptor{
+				ID: 51,
+				PrimaryIndex: IndexDescriptor{
+					ID:            1,
+					InterleavedBy: []ForeignKeyReference{{Table: 52, Index: 2}},
+				},
+			},
+			referenced: []TableDescriptor{{
+				ID:   52,
+				Name: "baz",
+			}},
+		},
+		{
+			err: `broken interleave backward reference from foo.bar to baz.qux`,
+			desc: TableDescriptor{
+				ID:   51,
+				Name: "foo",
+				PrimaryIndex: IndexDescriptor{
+					ID:            1,
+					Name:          "bar",
+					InterleavedBy: []ForeignKeyReference{{Table: 52, Index: 2}},
+				},
+			},
+			referenced: []TableDescriptor{{
+				ID:   52,
+				Name: "baz",
+				PrimaryIndex: IndexDescriptor{
+					ID:   2,
+					Name: "qux",
+				},
+			}},
+		},
+	}
+
+	for i, test := range tests {
+		for _, referencedDesc := range test.referenced {
+			var v roachpb.Value
+			desc := &Descriptor{Union: &Descriptor_Table{Table: &referencedDesc}}
+			if err := v.SetProto(desc); err != nil {
+				t.Fatal(err)
+			}
+			if err := kvDB.Put(MakeDescMetadataKey(referencedDesc.ID), &v); err != nil {
+				t.Fatal(err)
+			}
+		}
+		txn := client.NewTxn(context.Background(), *kvDB)
+		if err := test.desc.validateCrossReferences(txn); err == nil {
+			t.Errorf("%d: expected \"%s\", but found success: %+v", i, test.err, test.desc)
+		} else if test.err != err.Error() {
+			t.Errorf("%d: expected \"%s\", but found \"%s\"", i, test.err, err.Error())
+		}
+		for _, referencedDesc := range test.referenced {
+			if err := kvDB.Del(MakeDescMetadataKey(referencedDesc.ID)); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Rename the old (*TableDescriptor).Validate to ValidateTable and make Validate
look up the other tables and check that foreign key and interleaved
backreferences are correct. Most previous uses were migrated to the new
Validate, but a few (leases, schema changes) should only run the single table
tests, so were moved to ValidateTable.

Also fix some bugs it found.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7982)

<!-- Reviewable:end -->
