### PR TITLE
sql: fix TestRaceWithBackfill

### DIFF
--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/randutil"
@@ -146,7 +147,7 @@ func verifyAccounts(t *testing.T, client *testClient) {
 		client.RLock()
 		defer client.RUnlock()
 		err := client.db.QueryRow("SELECT SUM(balance) FROM bank.accounts").Scan(&sum)
-		if err != nil && !isRetryableError(err) {
+		if err != nil && !testutils.IsSQLRetryError(err) {
 			t.Fatal(err)
 		}
 		return err
@@ -163,7 +164,7 @@ func transferMoneyLoop(idx int, state *testState, numAccounts, maxTransfer int) 
 	for !state.done() {
 		if err := transferMoney(client, numAccounts, maxTransfer); err != nil {
 			// Ignore some errors.
-			if !isRetryableError(err) {
+			if !testutils.IsSQLRetryError(err) {
 				// Report the err and terminate.
 				state.errChan <- err
 				break

--- a/testutils/error.go
+++ b/testutils/error.go
@@ -51,6 +51,13 @@ func IsPError(pErr *roachpb.Error, re string) bool {
 	return matched
 }
 
+// IsSQLRetryError returns true if err is retryable. This is true for errors
+// that show a connection issue or an issue with the node itself. This can
+// occur when a node is restarting or is unstable in some other way.
+func IsSQLRetryError(err error) bool {
+	return IsError(err, "(connection reset by peer|connection refused|failed to send RPC|EOF|context deadline exceeded)")
+}
+
 // Caller returns filename and line number info for the specified stack
 // depths. The info is formated as <file>:<line> and each entry is separated
 // for a space.


### PR DESCRIPTION
This change fixes two bugs:
1. The test would fail when it hit retry errors.
2. panic on closing an already closed channel.

fixes #7628

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7986)

<!-- Reviewable:end -->
