### PR TITLE
logging: consolidate logging functions to always take a context

### DIFF
--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -171,7 +173,7 @@ func transferMoneyLoop(idx int, state *testState, numAccounts, maxTransfer int) 
 			atomic.AddUint64(&client.count, 1)
 		}
 	}
-	log.Infof("client %d shutting down", idx)
+	log.Infof(context.TODO(), "client %d shutting down", idx)
 	state.errChan <- nil
 }
 
@@ -196,7 +198,7 @@ func chaosMonkey(state *testState, c cluster.Cluster, stopClients bool, pickNode
 				state.clients[i].Lock()
 			}
 		}
-		log.Infof("round %d: restarting nodes %v", curRound, nodes)
+		log.Infof(context.TODO(), "round %d: restarting nodes %v", curRound, nodes)
 		for _, i := range nodes {
 			// Two early exit conditions.
 			select {
@@ -207,7 +209,7 @@ func chaosMonkey(state *testState, c cluster.Cluster, stopClients bool, pickNode
 			if state.done() {
 				break
 			}
-			log.Infof("round %d: restarting %d", curRound, i)
+			log.Infof(context.TODO(), "round %d: restarting %d", curRound, i)
 			if err := c.Kill(i); err != nil {
 				state.t.Error(err)
 			}
@@ -238,13 +240,13 @@ func chaosMonkey(state *testState, c cluster.Cluster, stopClients bool, pickNode
 		}
 
 		// Sleep until at least one client is writing successfully.
-		log.Warningf("round %d: monkey sleeping while cluster recovers...", curRound)
+		log.Warningf(context.TODO(), "round %d: monkey sleeping while cluster recovers...", curRound)
 		for !state.done() && !madeProgress() {
 			time.Sleep(time.Second)
 		}
 		c.Assert(state.t)
 		cluster.Consistent(state.t, c)
-		log.Warningf("round %d: cluster recovered", curRound)
+		log.Warningf(context.TODO(), "round %d: cluster recovered", curRound)
 	}
 }
 
@@ -292,7 +294,7 @@ func waitClientsStop(num int, state *testState, stallDuration time.Duration) {
 			}
 			// This just stops the logs from being a bit too spammy.
 			if newOutput != prevOutput {
-				log.Infof(newOutput)
+				log.Infof(context.TODO(), newOutput)
 				prevOutput = newOutput
 			}
 		}
@@ -335,7 +337,7 @@ func testClusterRecoveryInner(t *testing.T, c cluster.Cluster, cfg cluster.TestC
 
 	// Chaos monkey.
 	rnd, seed := randutil.NewPseudoRand()
-	log.Warningf("monkey starts (seed %d)", seed)
+	log.Warningf(context.TODO(), "monkey starts (seed %d)", seed)
 	pickNodes := func() []int {
 		return rnd.Perm(num)[:rnd.Intn(num)+1]
 	}
@@ -352,7 +354,7 @@ func testClusterRecoveryInner(t *testing.T, c cluster.Cluster, cfg cluster.TestC
 	for _, c := range counts {
 		count += c
 	}
-	log.Infof("%d %.1f/sec", count, float64(count)/elapsed.Seconds())
+	log.Infof(context.TODO(), "%d %.1f/sec", count, float64(count)/elapsed.Seconds())
 }
 
 // TestNodeRestart starts up a cluster with an "accounts" table.
@@ -394,7 +396,7 @@ func testNodeRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfi
 
 	// Chaos monkey.
 	rnd, seed := randutil.NewPseudoRand()
-	log.Warningf("monkey starts (seed %d)", seed)
+	log.Warningf(context.TODO(), "monkey starts (seed %d)", seed)
 	pickNodes := func() []int {
 		return []int{rnd.Intn(num - 1)}
 	}
@@ -407,5 +409,5 @@ func testNodeRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfi
 
 	elapsed := timeutil.Since(start)
 	count := atomic.LoadUint64(&client.count)
-	log.Infof("%d %.1f/sec", count, float64(count)/elapsed.Seconds())
+	log.Infof(context.TODO(), "%d %.1f/sec", count, float64(count)/elapsed.Seconds())
 }

--- a/acceptance/dynamic_client.go
+++ b/acceptance/dynamic_client.go
@@ -21,6 +21,8 @@ import (
 	"math/rand"
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -58,7 +60,7 @@ func (dc *dynamicClient) Close() {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 	for i, client := range dc.mu.clients {
-		log.Infof("closing connection to %s", dc.cluster.Addr(i))
+		log.Infof(context.TODO(), "closing connection to %s", dc.cluster.Addr(i))
 		client.Close()
 		delete(dc.mu.clients, i)
 	}
@@ -114,10 +116,10 @@ func (dc *dynamicClient) getClient() (*gosql.DB, error) {
 		}
 		client, err := gosql.Open("postgres", dc.cluster.PGUrl(index))
 		if err != nil {
-			log.Infof("could not establish connection to %s: %s", dc.cluster.Addr(index), err)
+			log.Infof(context.TODO(), "could not establish connection to %s: %s", dc.cluster.Addr(index), err)
 			continue
 		}
-		log.Infof("connection established to %s", dc.cluster.Addr(index))
+		log.Infof(context.TODO(), "connection established to %s", dc.cluster.Addr(index))
 		dc.mu.clients[index] = client
 		return client, nil
 	}

--- a/acceptance/freeze_test.go
+++ b/acceptance/freeze_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 
@@ -43,7 +45,7 @@ func postFreeze(c cluster.Cluster, freeze bool, timeout time.Duration) (serverpb
 	httpClient.Timeout = timeout
 
 	var resp serverpb.ClusterFreezeResponse
-	log.Infof("requesting: freeze=%t, timeout=%s", freeze, timeout)
+	log.Infof(context.TODO(), "requesting: freeze=%t, timeout=%s", freeze, timeout)
 	cb := func(v proto.Message) {
 		oldNum := resp.RangesAffected
 		resp = *v.(*serverpb.ClusterFreezeResponse)
@@ -51,7 +53,7 @@ func postFreeze(c cluster.Cluster, freeze bool, timeout time.Duration) (serverpb
 			resp.RangesAffected = oldNum
 		}
 		if (resp != serverpb.ClusterFreezeResponse{}) {
-			log.Infof("%+v", &resp)
+			log.Infof(context.TODO(), "%+v", &resp)
 		}
 	}
 	err := util.StreamJSON(

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
@@ -117,7 +119,7 @@ func testGossipPeeringsInner(t *testing.T, c cluster.Cluster, cfg cluster.TestCo
 		checkGossip(t, c, waitTime, hasPeers(num))
 
 		// Restart the first node.
-		log.Infof("restarting node 0")
+		log.Infof(context.TODO(), "restarting node 0")
 		if err := c.Restart(0); err != nil {
 			t.Fatal(err)
 		}
@@ -128,7 +130,7 @@ func testGossipPeeringsInner(t *testing.T, c cluster.Cluster, cfg cluster.TestCo
 		if num > 1 {
 			pickedNode = rand.Intn(num-1) + 1
 		}
-		log.Infof("restarting node %d", pickedNode)
+		log.Infof(context.TODO(), "restarting node %d", pickedNode)
 		if err := c.Restart(pickedNode); err != nil {
 			t.Fatal(err)
 		}
@@ -162,26 +164,26 @@ func testGossipRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestCon
 	}
 
 	for timeutil.Now().Before(deadline) {
-		log.Infof("waiting for initial gossip connections")
+		log.Infof(context.TODO(), "waiting for initial gossip connections")
 		checkGossip(t, c, waitTime, hasPeers(num))
 		checkGossip(t, c, waitTime, hasClusterID)
 		checkGossip(t, c, waitTime, hasSentinel)
 
-		log.Infof("killing all nodes")
+		log.Infof(context.TODO(), "killing all nodes")
 		for i := 0; i < num; i++ {
 			if err := c.Kill(i); err != nil {
 				t.Fatal(err)
 			}
 		}
 
-		log.Infof("restarting all nodes")
+		log.Infof(context.TODO(), "restarting all nodes")
 		for i := 0; i < num; i++ {
 			if err := c.Restart(i); err != nil {
 				t.Fatal(err)
 			}
 		}
 
-		log.Infof("waiting for gossip to be connected")
+		log.Infof(context.TODO(), "waiting for gossip to be connected")
 		checkGossip(t, c, waitTime, hasPeers(num))
 		checkGossip(t, c, waitTime, hasClusterID)
 		checkGossip(t, c, waitTime, hasSentinel)

--- a/acceptance/load.go
+++ b/acceptance/load.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/timeutil"
 )
@@ -78,7 +80,7 @@ CREATE TABLE %s (
 		}
 
 		if timeutil.Now().After(nextUpdate) {
-			log.Infof("Insert %d: inserted and checked %d values", ID, valueInsert)
+			log.Infof(context.TODO(), "Insert %d: inserted and checked %d values", ID, valueInsert)
 			nextUpdate = timeutil.Now().Add(time.Second)
 		}
 	}

--- a/acceptance/main_stub_test.go
+++ b/acceptance/main_stub_test.go
@@ -29,12 +29,14 @@ package acceptance
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
 func TestMain(m *testing.M) {
 	if !*flagRemote {
-		log.Infof("not running with `acceptance` build tag or against remote cluster; skipping")
+		log.Infof(context.TODO(), "not running with `acceptance` build tag or against remote cluster; skipping")
 		return
 	}
 	runTests(m)

--- a/acceptance/monotonic_insert_test.go
+++ b/acceptance/monotonic_insert_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -97,7 +99,7 @@ INSERT INTO mono.mono VALUES(-1, '0', -1, -1)`); err != nil {
 	invoke := func(client mtClient) {
 		logPrefix := fmt.Sprintf("%03d.%03d: ", atomic.AddUint64(&idGen, 1), client.ID)
 		l := func(msg string, args ...interface{}) {
-			log.Infof(logPrefix+msg, args...)
+			log.Infof(context.TODO(), logPrefix+msg, args...)
 		}
 		l("begin")
 		defer l("done")

--- a/acceptance/partition.go
+++ b/acceptance/partition.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/acceptance/iptables"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -87,7 +89,7 @@ func cutNetwork(t *testing.T, c cluster.Cluster, closer <-chan struct{}, partiti
 		}
 		ipPartitions = append(ipPartitions, ipPartition)
 	}
-	log.Warningf("partitioning: %v (%v)", partitions, ipPartitions)
+	log.Warningf(context.TODO(), "partitioning: %v (%v)", partitions, ipPartitions)
 	for host, cmds := range iptables.Rules(iptables.Bidirectional(ipPartitions...)) {
 		for _, cmd := range cmds {
 			if err := c.ExecRoot(addrsToNode[host], cmd); err != nil {
@@ -103,5 +105,5 @@ func cutNetwork(t *testing.T, c cluster.Cluster, closer <-chan struct{}, partiti
 			}
 		}
 	}
-	log.Warningf("resolved all partitions")
+	log.Warningf(context.TODO(), "resolved all partitions")
 }

--- a/acceptance/partition_test.go
+++ b/acceptance/partition_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -107,13 +109,13 @@ func (b *Bank) Verify() {
 }
 
 func (b *Bank) logFailed(i int, v interface{}) {
-	log.Warningf("%d: %v", i, v)
+	log.Warningf(context.TODO(), "%d: %v", i, v)
 }
 func (b *Bank) logBegin(i int, from, to, amount int) {
-	log.Warningf("%d: %d trying to give $%d to %d", i, from, amount, to)
+	log.Warningf(context.TODO(), "%d: %d trying to give $%d to %d", i, from, amount, to)
 }
 func (b *Bank) logSuccess(i int, from, to, amount int) {
-	log.Warningf("%d: %d gave $%d to %d", i, from, amount, to)
+	log.Warningf(context.TODO(), "%d: %d gave $%d to %d", i, from, amount, to)
 }
 
 // Invoke transfers a random amount of money between random accounts.
@@ -194,7 +196,7 @@ func testBankWithNemesis(nemeses ...NemesisFn) configTestRunner {
 		case <-stopper:
 		case <-time.After(cfg.Duration):
 		}
-		log.Warningf("finishing test")
+		log.Warningf(context.TODO(), "finishing test")
 		b.Verify()
 	}
 }

--- a/acceptance/put_test.go
+++ b/acceptance/put_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/randutil"
@@ -73,12 +75,12 @@ func testPutInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
 			// Periodically print out progress so that we know the test is still
 			// running.
 			loadedCount := atomic.LoadInt64(&count)
-			log.Infof("%d (%d/s)", loadedCount, loadedCount-baseCount)
+			log.Infof(context.TODO(), "%d (%d/s)", loadedCount, loadedCount-baseCount)
 			c.Assert(t)
 			cluster.Consistent(t, c)
 		}
 	}
 
 	elapsed := timeutil.Since(start)
-	log.Infof("%d %.1f/sec", count, float64(count)/elapsed.Seconds())
+	log.Infof(context.TODO(), "%d %.1f/sec", count, float64(count)/elapsed.Seconds())
 }

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
@@ -53,7 +55,7 @@ func checkRangeReplication(t *testing.T, c cluster.Cluster, d time.Duration) {
 		wantedReplicas = c.NumNodes()
 	}
 
-	log.Infof("waiting for first range to have %d replicas", wantedReplicas)
+	log.Infof(context.TODO(), "waiting for first range to have %d replicas", wantedReplicas)
 
 	util.SucceedsSoon(t, func() error {
 		select {
@@ -69,7 +71,7 @@ func checkRangeReplication(t *testing.T, c cluster.Cluster, d time.Duration) {
 		}
 
 		if log.V(1) {
-			log.Infof("found %d replicas", foundReplicas)
+			log.Infof(context.TODO(), "found %d replicas", foundReplicas)
 		}
 		if foundReplicas >= wantedReplicas {
 			return nil
@@ -77,5 +79,5 @@ func checkRangeReplication(t *testing.T, c cluster.Cluster, d time.Duration) {
 		return fmt.Errorf("expected %d replicas, only found %d", wantedReplicas, foundReplicas)
 	})
 
-	log.Infof("found %d replicas", wantedReplicas)
+	log.Infof(context.TODO(), "found %d replicas", wantedReplicas)
 }

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
@@ -112,7 +114,7 @@ func testSingleKeyInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig)
 		case <-time.After(1 * time.Second):
 			// Periodically print out progress so that we know the test is still
 			// running.
-			log.Infof("%d", atomic.LoadInt64(&expected))
+			log.Infof(context.TODO(), "%d", atomic.LoadInt64(&expected))
 		}
 	}
 
@@ -129,5 +131,5 @@ func testSingleKeyInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig)
 	for _, r := range results {
 		maxLatency = append(maxLatency, r.maxLatency)
 	}
-	log.Infof("%d increments: %s", v, maxLatency)
+	log.Infof(context.TODO(), "%d increments: %s", v, maxLatency)
 }

--- a/acceptance/status_server_test.go
+++ b/acceptance/status_server_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
@@ -46,21 +48,21 @@ func get(t *testing.T, base, rel string) []byte {
 	for r := retry.Start(retryOptions); r.Next(); {
 		resp, err := cluster.HTTPClient.Get(url)
 		if err != nil {
-			log.Infof("could not GET %s - %s", url, err)
+			log.Infof(context.TODO(), "could not GET %s - %s", url, err)
 			continue
 		}
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			log.Infof("could not read body for %s - %s", url, err)
+			log.Infof(context.TODO(), "could not read body for %s - %s", url, err)
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
-			log.Infof("could not GET %s - statuscode: %d - body: %s", url, resp.StatusCode, body)
+			log.Infof(context.TODO(), "could not GET %s - statuscode: %d - body: %s", url, resp.StatusCode, body)
 			continue
 		}
 		if log.V(1) {
-			log.Infof("OK response from %s", url)
+			log.Infof(context.TODO(), "OK response from %s", url)
 		}
 		return body
 	}

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -31,6 +31,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 
@@ -188,7 +190,7 @@ func farmer(t *testing.T, prefix string) *terrafarm.Farmer {
 		AddVars:     make(map[string]string),
 		KeepCluster: flagTFKeepCluster.String(),
 	}
-	log.Infof("logging to %s", logDir)
+	log.Infof(context.TODO(), "logging to %s", logDir)
 	return f
 }
 

--- a/cli/backtrace.go
+++ b/cli/backtrace.go
@@ -25,6 +25,8 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/build"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -35,12 +37,12 @@ import (
 func initBacktrace(logDir string) *stop.Stopper {
 	const ptracePath = "/opt/backtrace/bin/ptrace"
 	if _, err := os.Stat(ptracePath); err != nil {
-		log.Infof("backtrace disabled: %s", err)
+		log.Infof(context.TODO(), "backtrace disabled: %s", err)
 		return stop.NewStopper()
 	}
 
 	if err := bcd.EnableTracing(); err != nil {
-		log.Infof("unable to enable backtrace: %s", err)
+		log.Infof(context.TODO(), "unable to enable backtrace: %s", err)
 		return stop.NewStopper()
 	}
 
@@ -95,7 +97,7 @@ func initBacktrace(logDir string) *stop.Stopper {
 	// debugging our usage of backtrace.
 	if f, err := os.OpenFile(filepath.Join(logDir, "backtrace.out"),
 		os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666); err != nil {
-		log.Infof("unable to open: %s", err)
+		log.Infof(context.TODO(), "unable to open: %s", err)
 	} else {
 		stopper.AddCloser(stop.CloserFn(func() {
 			f.Close()
@@ -104,6 +106,6 @@ func initBacktrace(logDir string) *stop.Stopper {
 	}
 
 	tracer.SetLogLevel(bcd.LogMax)
-	log.Infof("backtrace enabled")
+	log.Infof(context.TODO(), "backtrace enabled")
 	return stopper
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -31,6 +31,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/base"
@@ -67,12 +69,12 @@ func newCLITest() cliTest {
 
 	s, err := serverutils.StartServerRaw(base.TestServerArgs{})
 	if err != nil {
-		log.Fatalf("Could not start server: %v", err)
+		log.Fatalf(context.TODO(), "Could not start server: %v", err)
 	}
 
 	tempDir, err := ioutil.TempDir("", "cli-test")
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(context.TODO(), err)
 	}
 
 	// Copy these assets to disk from embedded strings, so this test can
@@ -99,7 +101,7 @@ func newCLITest() cliTest {
 		certsDir:   tempDir,
 		cleanupFunc: func() {
 			if err := os.RemoveAll(tempDir); err != nil {
-				log.Fatal(err)
+				log.Fatal(context.TODO(), err)
 			}
 		},
 	}
@@ -302,7 +304,7 @@ func Example_insecure() {
 	s, err := serverutils.StartServerRaw(
 		base.TestServerArgs{Insecure: true})
 	if err != nil {
-		log.Fatalf("Could not start server: %v", err)
+		log.Fatalf(context.TODO(), "Could not start server: %v", err)
 	}
 	defer s.Stopper().Stop()
 	c := cliTest{TestServer: s.(*server.TestServer), cleanupFunc: func() {}}
@@ -867,7 +869,7 @@ func Example_node() {
 
 	// Refresh time series data, which is required to retrieve stats.
 	if err := c.TestServer.WriteSummaries(); err != nil {
-		log.Fatalf("Couldn't write stats summaries: %s", err)
+		log.Fatalf(context.TODO(), "Couldn't write stats summaries: %s", err)
 	}
 
 	c.Run("node ls")

--- a/cli/sql.go
+++ b/cli/sql.go
@@ -27,6 +27,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/chzyer/readline"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/util/envutil"
@@ -79,8 +81,8 @@ func addHistory(ins *readline.Instance, line string) {
 	// persist to disk (if ins's config.HistoryFile is set).  err can
 	// be not nil only if it got a IO error while trying to persist.
 	if err := ins.SaveHistory(line); err != nil {
-		log.Warningf("cannot save command-line history: %s", err)
-		log.Info("command-line history will not be saved in this session")
+		log.Warningf(context.TODO(), "cannot save command-line history: %s", err)
+		log.Info(context.TODO(), "command-line history will not be saved in this session")
 		cfg := ins.Config.Clone()
 		cfg.HistoryFile = ""
 		ins.SetConfig(cfg)
@@ -251,8 +253,8 @@ func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
 		userAcct, err := user.Current()
 		if err != nil {
 			if log.V(2) {
-				log.Warningf("cannot retrieve user information: %s", err)
-				log.Info("cannot load or save the command-line history")
+				log.Warningf(context.TODO(), "cannot retrieve user information: %s", err)
+				log.Info(context.TODO(), "cannot load or save the command-line history")
 			}
 		} else {
 			histFile := filepath.Join(userAcct.HomeDir, ".cockroachdb_history")

--- a/cli/sql_util.go
+++ b/cli/sql_util.go
@@ -26,6 +26,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"golang.org/x/net/context"
+
 	"github.com/olekukonko/tablewriter"
 
 	"github.com/cockroachdb/cockroach/util"
@@ -107,7 +109,7 @@ func (c *sqlConn) Close() {
 	if c.conn != nil {
 		err := c.conn.Close()
 		if err != nil && err != driver.ErrBadConn {
-			log.Info(err)
+			log.Info(context.TODO(), err)
 		}
 		c.conn = nil
 	}

--- a/cmd/gossipsim/main.go
+++ b/cmd/gossipsim/main.go
@@ -68,6 +68,8 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/simulation"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -145,7 +147,7 @@ func (em edgeMap) addEdge(nodeID roachpb.NodeID, e edge) {
 func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet map[string]edge) (string, bool) {
 	f, err := os.Create(dotFN)
 	if err != nil {
-		log.Fatalf("unable to create temp file: %s", err)
+		log.Fatalf(context.TODO(), "unable to create temp file: %s", err)
 	}
 	defer f.Close()
 
@@ -183,7 +185,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 		quiescent = false
 		nodeID, err := strconv.Atoi(strings.Split(key, ":")[0])
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal(context.TODO(), err)
 		}
 		outgoingMap.addEdge(roachpb.NodeID(nodeID), e)
 		delete(edgeSet, key)
@@ -207,21 +209,21 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 			} else {
 				_, val, err := encoding.DecodeUint64Ascending(info)
 				if err != nil {
-					log.Fatalf("bad decode of node info cycle: %s", err)
+					log.Fatalf(context.TODO(), "bad decode of node info cycle: %s", err)
 				}
 				totalAge += int64(cycle) - int64(val)
 			}
 		}
-		log.Infof("node %d: missing infos for nodes %s", node.GetNodeID(), missing)
+		log.Infof(context.TODO(), "node %d: missing infos for nodes %s", node.GetNodeID(), missing)
 
 		var sentinelAge int64
 		// GetInfo returns an error if the info is missing.
 		if info, err := node.GetInfo(gossip.KeySentinel); err != nil {
-			log.Infof("error getting info for sentinel gossip key %q: %s", gossip.KeySentinel, err)
+			log.Infof(context.TODO(), "error getting info for sentinel gossip key %q: %s", gossip.KeySentinel, err)
 		} else {
 			_, val, err := encoding.DecodeUint64Ascending(info)
 			if err != nil {
-				log.Fatalf("bad decode of sentinel cycle: %s", err)
+				log.Fatalf(context.TODO(), "bad decode of sentinel cycle: %s", err)
 			}
 			sentinelAge = int64(cycle) - int64(val)
 		}
@@ -275,7 +277,7 @@ func main() {
 
 	dirName, err := ioutil.TempDir("", "gossip-simulation-")
 	if err != nil {
-		log.Fatalf("could not create temporary directory for gossip simulation output: %s", err)
+		log.Fatalf(context.TODO(), "could not create temporary directory for gossip simulation output: %s", err)
 	}
 
 	// Simulation callbacks to run the simulation for cycleCount
@@ -296,7 +298,7 @@ func main() {
 	case "ginormous":
 		nodeCount = 250
 	default:
-		log.Fatalf("unknown simulation size: %s", *size)
+		log.Fatalf(context.TODO(), "unknown simulation size: %s", *size)
 	}
 
 	edgeSet := make(map[string]edge)

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"sort"
 
+	"golang.org/x/net/context"
+
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/keys"
@@ -347,7 +349,7 @@ func (s SystemConfig) ComputeSplitKeys(startKey, endKey roachpb.RKey) []roachpb.
 	if startID <= keys.MaxReservedDescID {
 		endID, err := s.GetLargestObjectID(keys.MaxReservedDescID)
 		if err != nil {
-			log.Errorf("unable to determine largest reserved object ID from system config: %s", err)
+			log.Errorf(context.TODO(), "unable to determine largest reserved object ID from system config: %s", err)
 			return nil
 		}
 		appendSplitKeys(startID, endID)
@@ -357,7 +359,7 @@ func (s SystemConfig) ComputeSplitKeys(startKey, endKey roachpb.RKey) []roachpb.
 	// Append keys in the user space.
 	endID, err := s.GetLargestObjectID(0)
 	if err != nil {
-		log.Errorf("unable to determine largest object ID from system config: %s", err)
+		log.Errorf(context.TODO(), "unable to determine largest object ID from system config: %s", err)
 		return nil
 	}
 	appendSplitKeys(startID, endID)

--- a/gossip/client.go
+++ b/gossip/client.go
@@ -68,7 +68,7 @@ func newClient(addr net.Addr) *client {
 // the client is sent on the disconnected channel. This method starts client
 // processing in a goroutine and returns immediately.
 func (c *client) start(g *Gossip, disconnected chan *client, ctx *rpc.Context, stopper *stop.Stopper) {
-	log.Infof("starting client to %s", c.addr)
+	log.Infof(context.TODO(), "starting client to %s", c.addr)
 
 	stopper.RunWorker(func() {
 		defer func() {
@@ -81,7 +81,7 @@ func (c *client) start(g *Gossip, disconnected chan *client, ctx *rpc.Context, s
 		// that ends ups up making `kv` tests take twice as long.
 		conn, err := ctx.GRPCDial(c.addr.String())
 		if err != nil {
-			log.Errorf("failed to dial: %v", err)
+			log.Errorf(context.TODO(), "failed to dial: %v", err)
 			return
 		}
 
@@ -92,9 +92,9 @@ func (c *client) start(g *Gossip, disconnected chan *client, ctx *rpc.Context, s
 				peerID := c.peerID
 				g.mu.Unlock()
 				if peerID != 0 {
-					log.Infof("closing client to node %d (%s): %s", peerID, c.addr, err)
+					log.Infof(context.TODO(), "closing client to node %d (%s): %s", peerID, c.addr, err)
 				} else {
-					log.Infof("closing client to %s: %s", c.addr, err)
+					log.Infof(context.TODO(), "closing client to %s: %s", c.addr, err)
 				}
 			}
 		}
@@ -156,11 +156,11 @@ func (c *client) handleResponse(g *Gossip, reply *Response) error {
 		c.received += len(reply.Delta)
 		freshCount, err := g.is.combine(reply.Delta, reply.NodeID)
 		if err != nil {
-			log.Warningf("node %d failed to fully combine delta from node %d: %s", g.is.NodeID, reply.NodeID, err)
+			log.Warningf(context.TODO(), "node %d failed to fully combine delta from node %d: %s", g.is.NodeID, reply.NodeID, err)
 		}
 		if infoCount := len(reply.Delta); infoCount > 0 {
 			if log.V(1) {
-				log.Infof("node %d received %s from node %d (%d fresh)", g.is.NodeID, extractKeys(reply.Delta), reply.NodeID, freshCount)
+				log.Infof(context.TODO(), "node %d received %s from node %d (%d fresh)", g.is.NodeID, extractKeys(reply.Delta), reply.NodeID, freshCount)
 			}
 		}
 		g.maybeTighten()

--- a/gossip/convergence_test.go
+++ b/gossip/convergence_test.go
@@ -19,6 +19,8 @@ package gossip_test
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/gossip/simulation"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -30,7 +32,7 @@ func verifyConvergence(numNodes, maxCycles int, _ *testing.T) {
 	network := simulation.NewNetwork(numNodes)
 
 	if connectedCycle := network.RunUntilFullyConnected(); connectedCycle > maxCycles {
-		log.Warningf("expected a fully-connected network within %d cycles; took %d",
+		log.Warningf(context.TODO(), "expected a fully-connected network within %d cycles; took %d",
 			maxCycles, connectedCycle)
 	}
 	network.Stop()

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -115,7 +117,7 @@ func (is *infoStore) String() string {
 		prepend = ", "
 		return nil
 	}); err != nil {
-		log.Errorf("failed to properly construct string representation of infoStore: %s", err)
+		log.Errorf(context.TODO(), "failed to properly construct string representation of infoStore: %s", err)
 	}
 	return buf.String()
 }
@@ -286,7 +288,7 @@ func (is *infoStore) runCallbacks(key string, content roachpb.Value, callbacks .
 			w()
 		}
 	}); err != nil {
-		log.Warning(err)
+		log.Warning(context.TODO(), err)
 	}
 }
 

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -123,7 +123,7 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 
 		if infoCount := len(delta); infoCount > 0 {
 			if log.V(1) {
-				log.Infof("node %d returned %d info(s) to node %d", s.is.NodeID, infoCount, args.NodeID)
+				log.Infof(context.TODO(), "node %d returned %d info(s) to node %d", s.is.NodeID, infoCount, args.NodeID)
 			}
 
 			*reply = Response{
@@ -196,7 +196,7 @@ func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) erro
 					altIdx--
 				}
 
-				log.Infof("refusing gossip from node %d (max %d conns); forwarding to %d (%s)",
+				log.Infof(context.TODO(), "refusing gossip from node %d (max %d conns); forwarding to %d (%s)",
 					args.NodeID, s.incoming.maxSize, alternateNodeID, alternateAddr)
 
 				*reply = Response{
@@ -215,10 +215,10 @@ func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) erro
 		s.received += len(args.Delta)
 		freshCount, err := s.is.combine(args.Delta, args.NodeID)
 		if err != nil {
-			log.Warningf("node %d failed to fully combine gossip delta from node %d: %s", s.is.NodeID, args.NodeID, err)
+			log.Warningf(context.TODO(), "node %d failed to fully combine gossip delta from node %d: %s", s.is.NodeID, args.NodeID, err)
 		}
 		if log.V(1) {
-			log.Infof("node %d received %s from node %d (%d fresh)", s.is.NodeID, extractKeys(args.Delta), args.NodeID, freshCount)
+			log.Infof(context.TODO(), "node %d received %s from node %d (%d fresh)", s.is.NodeID, extractKeys(args.Delta), args.NodeID, freshCount)
 		}
 		s.maybeTighten()
 
@@ -273,13 +273,13 @@ func (s *server) InfosReceived() int {
 func (s *server) maybeTighten() {
 	distantNodeID, distantHops := s.is.mostDistant()
 	if log.V(2) {
-		log.Infof("@%d: distantHops: %d from %d", s.is.NodeID, distantHops, distantNodeID)
+		log.Infof(context.TODO(), "@%d: distantHops: %d from %d", s.is.NodeID, distantHops, distantNodeID)
 	}
 	if distantHops > MaxHops {
 		select {
 		case s.tighten <- distantNodeID:
 			if log.V(1) {
-				log.Infof("if possible, tightening network to node %d (%d > %d)", distantNodeID, distantHops, MaxHops)
+				log.Infof(context.TODO(), "if possible, tightening network to node %d (%d > %d)", distantNodeID, distantHops, MaxHops)
 			}
 		default:
 			// Do nothing.

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -21,6 +21,8 @@ import (
 	"net"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/base"
@@ -55,7 +57,7 @@ type Network struct {
 
 // NewNetwork creates nodeCount gossip nodes.
 func NewNetwork(nodeCount int) *Network {
-	log.Infof("simulating gossip network with %d nodes", nodeCount)
+	log.Infof(context.TODO(), "simulating gossip network with %d nodes", nodeCount)
 
 	n := &Network{
 		Nodes:   []*Node{},
@@ -65,22 +67,22 @@ func NewNetwork(nodeCount int) *Network {
 	var err error
 	n.tlsConfig, err = n.rpcContext.GetServerTLSConfig()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(context.TODO(), err)
 	}
 
 	for i := 0; i < nodeCount; i++ {
 		node, err := n.CreateNode()
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal(context.TODO(), err)
 		}
 		// Build a resolver for each instance or we'll get data races.
 		r, err := resolver.NewResolverFromAddress(n.Nodes[0].Addr)
 		if err != nil {
-			log.Fatalf("bad gossip address %s: %s", n.Nodes[0].Addr, err)
+			log.Fatalf(context.TODO(), "bad gossip address %s: %s", n.Nodes[0].Addr, err)
 		}
 		node.Gossip.SetResolvers([]resolver.Resolver{r})
 		if err := n.StartNode(node); err != nil {
-			log.Fatal(err)
+			log.Fatal(context.TODO(), err)
 		}
 	}
 	return n
@@ -148,11 +150,11 @@ func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) 
 			gossip.KeySentinel,
 			encoding.EncodeUint64Ascending(nil, uint64(cycle)),
 			time.Hour); err != nil {
-			log.Fatal(err)
+			log.Fatal(context.TODO(), err)
 		}
 		if err := nodes[0].Gossip.AddInfo(gossip.KeyClusterID,
 			encoding.EncodeUint64Ascending(nil, uint64(cycle)), 0*time.Second); err != nil {
-			log.Fatal(err)
+			log.Fatal(context.TODO(), err)
 		}
 		// Every node gossips cycle.
 		for _, node := range nodes {
@@ -160,13 +162,13 @@ func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) 
 				node.Addr.String(),
 				encoding.EncodeUint64Ascending(nil, uint64(cycle)),
 				time.Hour); err != nil {
-				log.Fatal(err)
+				log.Fatal(context.TODO(), err)
 			}
 			node.Gossip.SimulationCycle()
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	log.Infof("gossip network simulation: total infos sent=%d, received=%d", n.infosSent(), n.infosReceived())
+	log.Infof(context.TODO(), "gossip network simulation: total infos sent=%d, received=%d", n.infosSent(), n.infosReceived())
 }
 
 // Stop stops all servers and gossip nodes.

--- a/internal/client/db.go
+++ b/internal/client/db.go
@@ -471,7 +471,7 @@ func (db *DB) send(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Er
 	br, pErr := db.sender.Send(context.TODO(), ba)
 	if pErr != nil {
 		if log.V(1) {
-			log.Infof("failed batch: %s", pErr)
+			log.Infof(context.TODO(), "failed batch: %s", pErr)
 		}
 		return nil, pErr
 	}

--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -370,7 +370,7 @@ func (txn *Txn) CleanupOnError(err error) {
 		panic("no error")
 	}
 	if replyErr := txn.Rollback(); replyErr != nil {
-		log.Errorf("failure aborting transaction: %s; abort caused by: %s", replyErr, err)
+		log.Errorf(context.TODO(), "failure aborting transaction: %s; abort caused by: %s", replyErr, err)
 	}
 }
 
@@ -583,7 +583,7 @@ func (txn *Txn) Exec(
 			}
 		}
 		if log.V(2) {
-			log.Infof("automatically retrying transaction: %s because of error: %s",
+			log.Infof(context.TODO(), "automatically retrying transaction: %s because of error: %s",
 				txn.DebugName(), err)
 		}
 	}

--- a/internal/client/txn_test.go
+++ b/internal/client/txn_test.go
@@ -778,7 +778,7 @@ func TestWrongTxnRetry(t *testing.T) {
 
 	var retries int
 	txnClosure := func(outerTxn *Txn) error {
-		log.Infof("outer retry")
+		log.Infof(context.TODO(), "outer retry")
 		retries++
 		// Ensure the KV transaction is created.
 		if err := outerTxn.Put("a", "b"); err != nil {

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -306,7 +306,7 @@ func (ds *DistSender) getNodeDescriptor() *roachpb.NodeDescriptor {
 			return nodeDesc
 		}
 	}
-	log.Infof("unable to determine this node's attributes for replica " +
+	log.Infof(context.TODO(), "unable to determine this node's attributes for replica "+
 		"selection; node is most likely bootstrapping")
 	return nil
 }
@@ -653,7 +653,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			if err != nil {
 				log.Trace(ctx, "range descriptor lookup failed: "+err.Error())
 				if log.V(1) {
-					log.Warning(err)
+					log.Warning(context.TODO(), err)
 				}
 				pErr = roachpb.NewError(err)
 				continue
@@ -726,7 +726,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			}
 
 			if log.V(1) {
-				log.Warningf("failed to invoke %s: %s", ba, pErr)
+				log.Warningf(context.TODO(), "failed to invoke %s: %s", ba, pErr)
 			}
 			log.Trace(ctx, fmt.Sprintf("reply error: %s", pErr))
 
@@ -773,7 +773,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 				// On addressing errors, don't backoff; retry immediately.
 				r.Reset()
 				if log.V(1) {
-					log.Warning(tErr)
+					log.Warning(context.TODO(), tErr)
 				}
 				continue
 			}
@@ -788,7 +788,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			case <-ds.rpcRetryOptions.Closer:
 				return nil, roachpb.NewError(&roachpb.NodeUnavailableError{}), false
 			default:
-				log.Fatal("exited retry loop with nil error but finished=false")
+				log.Fatal(context.TODO(), "exited retry loop with nil error but finished=false")
 			}
 		}
 
@@ -990,9 +990,9 @@ func (ds *DistSender) sendToReplicas(opts SendOptions,
 			err := call.Err
 			if err == nil {
 				if log.V(2) {
-					log.Infof("RPC reply: %+v", call.Reply)
+					log.Infof(context.TODO(), "RPC reply: %+v", call.Reply)
 				} else if log.V(1) && call.Reply.Error != nil {
-					log.Infof("application error: %s", call.Reply.Error)
+					log.Infof(context.TODO(), "application error: %s", call.Reply.Error)
 				}
 
 				if !ds.handlePerReplicaError(rangeID, call.Reply.Error) {
@@ -1008,7 +1008,7 @@ func (ds *DistSender) sendToReplicas(opts SendOptions,
 				// information than a RangeNotFound).
 				err = call.Reply.Error.GoError()
 			} else if log.V(1) {
-				log.Warningf("RPC error: %s", err)
+				log.Warningf(context.TODO(), "RPC error: %s", err)
 			}
 
 			// Send to additional replicas if available.
@@ -1058,12 +1058,12 @@ func (ds *DistSender) updateLeaseHolderCache(
 	if log.V(1) {
 		if oldLeaseHolder, ok := ds.leaseHolderCache.Lookup(rangeID); ok {
 			if (newLeaseHolder == roachpb.ReplicaDescriptor{}) {
-				log.Infof("range %d: evicting cached lease holder %+v", rangeID, oldLeaseHolder)
+				log.Infof(context.TODO(), "range %d: evicting cached lease holder %+v", rangeID, oldLeaseHolder)
 			} else if newLeaseHolder != oldLeaseHolder {
-				log.Infof("range %d: replacing cached lease holder %+v with %+v", rangeID, oldLeaseHolder, newLeaseHolder)
+				log.Infof(context.TODO(), "range %d: replacing cached lease holder %+v with %+v", rangeID, oldLeaseHolder, newLeaseHolder)
 			}
 		} else {
-			log.Infof("range %d: caching new lease holder %+v", rangeID, newLeaseHolder)
+			log.Infof(context.TODO(), "range %d: caching new lease holder %+v", rangeID, newLeaseHolder)
 		}
 	}
 	ds.leaseHolderCache.Update(rangeID, newLeaseHolder)

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -328,7 +328,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 			t.Fatal(err)
 		}
 		ts[i] = s.Clock().Now()
-		log.Infof("%d: %s %d", i, key, ts[i])
+		log.Infof(context.TODO(), "%d: %s %d", i, key, ts[i])
 		if i == 0 {
 			util.SucceedsSoon(t, func() error {
 				// Enforce that when we write the second key, it's written
@@ -677,14 +677,14 @@ func TestPropagateTxnOnPushError(t *testing.T) {
 		if err := db.Txn(func(txn *client.Txn) error {
 			// Set high priority so that the intent will not be pushed.
 			txn.InternalSetPriority(highPriority)
-			log.Infof("Creating a write intent with high priority")
+			log.Infof(context.TODO(), "Creating a write intent with high priority")
 			if err := txn.Put(key, "val"); err != nil {
 				return err
 			}
 			close(waitForWriteIntent)
 			// Wait until another txn in this test is
 			// restarted by a push txn error.
-			log.Infof("Waiting for the txn restart")
+			log.Infof(context.TODO(), "Waiting for the txn restart")
 			<-waitForTxnRestart
 			return txn.CommitInBatch(txn.NewBatch())
 		}); err != nil {
@@ -694,7 +694,7 @@ func TestPropagateTxnOnPushError(t *testing.T) {
 	}()
 
 	// Wait until a write intent is created by the above goroutine.
-	log.Infof("Waiting for the write intent creation")
+	log.Infof(context.TODO(), "Waiting for the write intent creation")
 	<-waitForWriteIntent
 
 	// The transaction below is restarted exactly once. The restart is
@@ -712,7 +712,7 @@ func TestPropagateTxnOnPushError(t *testing.T) {
 		if epoch == 2 {
 			close(waitForTxnRestart)
 			// Wait until the txn created by the goroutine is committed.
-			log.Infof("Waiting for the txn commit")
+			log.Infof(context.TODO(), "Waiting for the txn commit")
 			<-waitForTxnCommit
 			if !roachpb.TxnIDEqual(txn.Proto.ID, txnID) {
 				t.Errorf("txn ID is not propagated; got %s", txn.Proto.ID)
@@ -735,7 +735,7 @@ func TestPropagateTxnOnPushError(t *testing.T) {
 		if epoch == 1 {
 			// Wait for the completion of the goroutine to see if it successfully commits the txn.
 			close(waitForTxnRestart)
-			log.Infof("Waiting for the txn commit")
+			log.Infof(context.TODO(), "Waiting for the txn commit")
 			<-waitForTxnCommit
 		}
 	}

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -317,9 +317,9 @@ func (rdc *rangeDescriptorCache) lookupRangeDescriptorInternal(
 	}
 
 	if log.V(3) {
-		log.Infof("lookup range descriptor: key=%s\n%s", key, rdc.stringLocked())
+		log.Infof(context.TODO(), "lookup range descriptor: key=%s\n%s", key, rdc.stringLocked())
 	} else if log.V(2) {
-		log.Infof("lookup range descriptor: key=%s", key)
+		log.Infof(context.TODO(), "lookup range descriptor: key=%s", key)
 	}
 
 	var res lookupResult
@@ -384,7 +384,7 @@ func (rdc *rangeDescriptorCache) lookupRangeDescriptorInternal(
 			// append could cause a copy, which would change the address of rs[0]. We insert
 			// the prefetched descriptors first to avoid any unintended overwriting.
 			if err := rdc.insertRangeDescriptorsLocked(preRs...); err != nil {
-				log.Warningf("range cache inserting prefetched descriptors failed: %v", err)
+				log.Warningf(context.TODO(), "range cache inserting prefetched descriptors failed: %v", err)
 			}
 			if err := rdc.insertRangeDescriptorsLocked(rs...); err != nil {
 				res = lookupResult{err: err}
@@ -475,7 +475,7 @@ func (rdc *rangeDescriptorCache) EvictCachedRangeDescriptor(descKey roachpb.RKey
 
 func (rdc *rangeDescriptorCache) evictCachedRangeDescriptorLocked(descKey roachpb.RKey, seenDesc *roachpb.RangeDescriptor, inclusive bool) error {
 	if seenDesc == nil {
-		log.Warningf("compare-and-evict for key %s with nil descriptor; clearing unconditionally", descKey)
+		log.Warningf(context.TODO(), "compare-and-evict for key %s with nil descriptor; clearing unconditionally", descKey)
 	}
 
 	rngKey, cachedDesc, err := rdc.getCachedRangeDescriptorLocked(descKey, inclusive)
@@ -493,9 +493,9 @@ func (rdc *rangeDescriptorCache) evictCachedRangeDescriptorLocked(descKey roachp
 
 	for {
 		if log.V(3) {
-			log.Infof("evict cached descriptor: key=%s desc=%s\n%s", descKey, cachedDesc, rdc.stringLocked())
+			log.Infof(context.TODO(), "evict cached descriptor: key=%s desc=%s\n%s", descKey, cachedDesc, rdc.stringLocked())
 		} else if log.V(2) {
-			log.Infof("evict cached descriptor: key=%s desc=%s", descKey, cachedDesc)
+			log.Infof(context.TODO(), "evict cached descriptor: key=%s desc=%s", descKey, cachedDesc)
 		}
 		rdc.rangeCache.cache.Del(rngKey)
 
@@ -585,7 +585,7 @@ func (rdc *rangeDescriptorCache) insertRangeDescriptorsLocked(rs ...roachpb.Rang
 			return err
 		}
 		if log.V(2) {
-			log.Infof("adding descriptor: key=%s desc=%s", rangeKey, &rs[i])
+			log.Infof(context.TODO(), "adding descriptor: key=%s desc=%s", rangeKey, &rs[i])
 		}
 		rdc.rangeCache.cache.Add(rangeCacheKey(rangeKey), &rs[i])
 	}
@@ -609,7 +609,7 @@ func (rdc *rangeDescriptorCache) clearOverlappingCachedRangeDescriptors(desc *ro
 		descriptor := v.(*roachpb.RangeDescriptor)
 		if descriptor.StartKey.Less(key) && !descriptor.EndKey.Less(key) {
 			if log.V(2) {
-				log.Infof("clearing overlapping descriptor: key=%s desc=%s", k, descriptor)
+				log.Infof(context.TODO(), "clearing overlapping descriptor: key=%s desc=%s", k, descriptor)
 			}
 			rdc.rangeCache.cache.Del(k.(rangeCacheKey))
 		}
@@ -630,7 +630,7 @@ func (rdc *rangeDescriptorCache) clearOverlappingCachedRangeDescriptors(desc *ro
 	// after RangeMetaKey(desc.StartKey) to the range meta key for desc.EndKey.
 	rdc.rangeCache.cache.DoRange(func(k, v interface{}) bool {
 		if log.V(2) {
-			log.Infof("clearing subsumed descriptor: key=%s desc=%s", k, v.(*roachpb.RangeDescriptor))
+			log.Infof(context.TODO(), "clearing subsumed descriptor: key=%s desc=%s", k, v.(*roachpb.RangeDescriptor))
 		}
 		rdc.rangeCache.cache.Del(k.(rangeCacheKey))
 

--- a/kv/replica_slice.go
+++ b/kv/replica_slice.go
@@ -20,6 +20,8 @@ package kv
 import (
 	"math/rand"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -51,7 +53,7 @@ func newReplicaSlice(gossip *gossip.Gossip, desc *roachpb.RangeDescriptor) Repli
 		nd, err := gossip.GetNodeDescriptor(r.NodeID)
 		if err != nil {
 			if log.V(1) {
-				log.Infof("node %d is not gossiped: %v", r.NodeID, err)
+				log.Infof(context.TODO(), "node %d is not gossiped: %v", r.NodeID, err)
 			}
 			continue
 		}

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -72,7 +72,7 @@ func startTestWriter(db *client.DB, i int64, valBytes int32, wg *sync.WaitGroup,
 					key := randutil.RandBytes(src, 10)
 					val := randutil.RandBytes(src, int(src.Int31n(valBytes)))
 					if err := txn.Put(key, val); err != nil {
-						log.Infof("experienced an error in routine %d: %s", i, err)
+						log.Infof(context.TODO(), "experienced an error in routine %d: %s", i, err)
 						return err
 					}
 				}
@@ -100,11 +100,11 @@ func TestRangeSplitMeta(t *testing.T) {
 
 	// Execute the consecutive splits.
 	for _, splitKey := range splitKeys {
-		log.Infof("starting split at key %q...", splitKey)
+		log.Infof(context.TODO(), "starting split at key %q...", splitKey)
 		if err := s.DB.AdminSplit(roachpb.Key(splitKey)); err != nil {
 			t.Fatal(err)
 		}
-		log.Infof("split at key %q complete", splitKey)
+		log.Infof(context.TODO(), "split at key %q complete", splitKey)
 	}
 
 	util.SucceedsSoon(t, func() error {
@@ -145,11 +145,11 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 		for i := 0; i < concurrency; i++ {
 			<-txnChannel
 		}
-		log.Infof("starting split at key %q...", splitKey)
+		log.Infof(context.TODO(), "starting split at key %q...", splitKey)
 		if pErr := s.DB.AdminSplit(splitKey); pErr != nil {
 			t.Error(pErr)
 		}
-		log.Infof("split at key %q complete", splitKey)
+		log.Infof(context.TODO(), "split at key %q complete", splitKey)
 	}
 
 	close(done)
@@ -225,11 +225,11 @@ func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 	defer s.Stop()
 
 	splitKey := roachpb.Key("aa")
-	log.Infof("starting split at key %q...", splitKey)
+	log.Infof(context.TODO(), "starting split at key %q...", splitKey)
 	if err := s.DB.AdminSplit(splitKey); err != nil {
 		t.Fatal(err)
 	}
-	log.Infof("split at key %q first time complete", splitKey)
+	log.Infof(context.TODO(), "split at key %q first time complete", splitKey)
 	ch := make(chan error)
 	go func() {
 		// should return error other than infinite loop

--- a/kv/transport.go
+++ b/kv/transport.go
@@ -162,7 +162,7 @@ func (gt *grpcTransport) SendNext(done chan BatchCall) {
 
 	addr := client.remoteAddr
 	if log.V(2) {
-		log.Infof("sending request to %s: %+v", addr, client.args)
+		log.Infof(context.TODO(), "sending request to %s: %+v", addr, client.args)
 	}
 
 	if localServer := gt.rpcContext.GetLocalInternalServerForAddr(addr); enableLocalCalls && localServer != nil {
@@ -194,7 +194,7 @@ func (gt *grpcTransport) SendNext(done chan BatchCall) {
 		if reply != nil {
 			for i := range reply.Responses {
 				if err := reply.Responses[i].GetInner().Verify(client.args.Requests[i].GetInner()); err != nil {
-					log.Error(err)
+					log.Error(context.TODO(), err)
 				}
 			}
 		}

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -236,7 +236,7 @@ func (tc *TxnCoordSender) startStats() {
 			rMax := restarts.Max()
 			num := durations.TotalCount()
 
-			log.Infof(
+			log.Infof(context.TODO(),
 				"txn coordinator: %.2f txn/sec, %.2f/%.2f/%.2f/%.2f %%cmmt/cmmt1pc/abrt/abnd, %s/%s/%s avg/σ/max duration, %.1f/%.1f/%d avg/σ/max restarts (%d samples)",
 				totalRate, pCommitted, pCommitted1PC, pAborted, pAbandoned,
 				util.TruncateDuration(time.Duration(dMean), res),
@@ -407,7 +407,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 	if tc.linearizable && sleepNS > 0 {
 		defer func() {
 			if log.V(1) {
-				log.Infof("%v: waiting %s on EndTransaction for linearizability", br.Txn.ID.Short(), util.TruncateDuration(sleepNS, time.Millisecond))
+				log.Infof(context.TODO(), "%v: waiting %s on EndTransaction for linearizability", br.Txn.ID.Short(), util.TruncateDuration(sleepNS, time.Millisecond))
 			}
 			time.Sleep(sleepNS)
 		}()
@@ -660,11 +660,11 @@ func (tc *TxnCoordSender) tryAsyncAbort(txnID uuid.UUID) {
 		// before the goroutine.
 		if _, pErr := tc.wrapped.Send(context.Background(), ba); pErr != nil {
 			if log.V(1) {
-				log.Warningf("abort due to inactivity failed for %s: %s ", txn, pErr)
+				log.Warningf(context.TODO(), "abort due to inactivity failed for %s: %s ", txn, pErr)
 			}
 		}
 	}); err != nil {
-		log.Warning(err)
+		log.Warning(context.TODO(), err)
 	}
 }
 
@@ -689,7 +689,7 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
 	// instead of a timeout.
 	if ctx.Done() == nil && hasAbandoned {
 		if log.V(1) {
-			log.Infof("transaction %s abandoned; stopping heartbeat", txnMeta.txn)
+			log.Infof(context.TODO(), "transaction %s abandoned; stopping heartbeat", txnMeta.txn)
 		}
 		tc.tryAsyncAbort(txnID)
 		return false
@@ -713,7 +713,7 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
 	// transaction record at all, we're going to have to assume we're aborted
 	// as well.
 	if pErr != nil {
-		log.Warningf("heartbeat to %s failed: %s", txn, pErr)
+		log.Warningf(context.TODO(), "heartbeat to %s failed: %s", txn, pErr)
 		// We're not going to let the client carry out additional requests, so
 		// try to clean up.
 		tc.tryAsyncAbort(*txn.ID)
@@ -925,7 +925,7 @@ func (tc *TxnCoordSender) updateState(
 func (tc *TxnCoordSender) resendWithTxn(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 	// Run a one-off transaction with that single command.
 	if log.V(1) {
-		log.Infof("%s: auto-wrapping in txn and re-executing: ", ba)
+		log.Infof(context.TODO(), "%s: auto-wrapping in txn and re-executing: ", ba)
 	}
 	// TODO(bdarnell): need to be able to pass other parts of DBContext
 	// through here.

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/testutils"
@@ -106,14 +108,14 @@ func (c *cmd) clone() *cmd {
 func (c *cmd) execute(txn *client.Txn, t *testing.T) (string, error) {
 	if c.prev != nil {
 		if log.V(2) {
-			log.Infof("%s waiting on %s", c, c.prev)
+			log.Infof(context.TODO(), "%s waiting on %s", c, c.prev)
 		}
 		if err := <-c.prev.ch; err != nil {
 			return "", err
 		}
 	}
 	if log.V(2) {
-		log.Infof("executing %s", c)
+		log.Infof(context.TODO(), "executing %s", c)
 	}
 	err := c.fn(c, txn, t)
 	if err == nil {
@@ -549,7 +551,7 @@ func TestEnumerateHistoriesAfterRetry(t *testing.T) {
 	enum := enumerateHistories(txns, false)
 	for i, e := range enum {
 		if log.V(1) {
-			log.Infof("enum(%d): %s", i, historyString(e))
+			log.Infof(context.TODO(), "enum(%d): %s", i, historyString(e))
 		}
 	}
 	testCases := []struct {
@@ -648,7 +650,7 @@ func newHistoryVerifier(name string, txns []string, verify *verifier, t *testing
 }
 
 func (hv *historyVerifier) run(isolations []enginepb.IsolationType, db *client.DB, t *testing.T) {
-	log.Infof("verifying all possible histories for the %q anomaly", hv.name)
+	log.Infof(context.TODO(), "verifying all possible histories for the %q anomaly", hv.name)
 	priorities := make([]int32, len(hv.txns))
 	for i := 0; i < len(hv.txns); i++ {
 		priorities[i] = int32(i + 1)
@@ -681,7 +683,7 @@ func (hv *historyVerifier) runHistoryWithRetry(priorities []int32,
 	isolations []enginepb.IsolationType, cmds []*cmd, db *client.DB, t *testing.T) error {
 	if err := hv.runHistory(priorities, isolations, cmds, db, t); err != nil {
 		if log.V(1) {
-			log.Infof("got an error running history %s: %s", historyString(cmds), err)
+			log.Infof(context.TODO(), "got an error running history %s: %s", historyString(cmds), err)
 		}
 		retry, ok := err.(*retryError)
 		if !ok {
@@ -690,7 +692,7 @@ func (hv *historyVerifier) runHistoryWithRetry(priorities []int32,
 
 		if _, hasRetried := hv.retriedTxns[retry.txnIdx]; hasRetried {
 			if log.V(1) {
-				log.Infof("retried txn %d twice; skipping history", retry.txnIdx+1)
+				log.Infof(context.TODO(), "retried txn %d twice; skipping history", retry.txnIdx+1)
 			}
 			return nil
 		}
@@ -700,7 +702,7 @@ func (hv *historyVerifier) runHistoryWithRetry(priorities []int32,
 		enumHis := sampleHistories(enumerateHistoriesAfterRetry(retry, cmds), 0.05)
 		for i, h := range enumHis {
 			if log.V(1) {
-				log.Infof("after retry, running alternate history %d of %d", i, len(enumHis))
+				log.Infof(context.TODO(), "after retry, running alternate history %d of %d", i, len(enumHis))
 			}
 			if err := hv.runHistoryWithRetry(priorities, isolations, h, db, t); err != nil {
 				return err
@@ -725,7 +727,7 @@ func (hv *historyVerifier) runHistory(priorities []int32,
 	}
 	plannedStr := historyString(cmds)
 	if log.V(1) {
-		log.Infof("iso=%d pri=%d history=%s", isolations, priorities, plannedStr)
+		log.Infof(context.TODO(), "iso=%d pri=%d history=%s", isolations, priorities, plannedStr)
 	}
 
 	hv.mu.actual = []string{}
@@ -775,7 +777,7 @@ func (hv *historyVerifier) runHistory(priorities []int32,
 	err = hv.verify.checkFn(verifyEnv)
 	if err == nil {
 		if log.V(1) {
-			log.Infof("PASSED: iso=%d, pri=%d, history=%q", isolations, priorities, actualStr)
+			log.Infof(context.TODO(), "PASSED: iso=%d, pri=%d, history=%q", isolations, priorities, actualStr)
 		}
 	}
 	if err != nil {
@@ -838,7 +840,7 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 			_, err := hv.runCmd(txn, txnIdx, retry, cmds[cmdIdx], t)
 			if err != nil {
 				if log.V(1) {
-					log.Infof("%s: failed running %s: %s", txnName, cmds[cmdIdx], err)
+					log.Infof(context.TODO(), "%s: failed running %s: %s", txnName, cmds[cmdIdx], err)
 				}
 				return err
 			}

--- a/rpc/clock_offset.go
+++ b/rpc/clock_offset.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/metric"
@@ -97,7 +99,7 @@ func (r *RemoteClockMonitor) UpdateOffset(addr string, offset RemoteOffset) {
 	}
 
 	if log.V(2) {
-		log.Infof("update offset: %s %v", addr, r.mu.offsets[addr])
+		log.Infof(context.TODO(), "update offset: %s %v", addr, r.mu.offsets[addr])
 	}
 }
 
@@ -132,7 +134,7 @@ func (r *RemoteClockMonitor) VerifyClockOffset() error {
 			return errors.Errorf("fewer than half the known nodes are within the maximum offset of %s (%d of %d)", maxOffset, healthyOffsetCount, numClocks)
 		}
 		if log.V(1) {
-			log.Infof("%d of %d nodes are within the maximum offset of %s", healthyOffsetCount, numClocks, maxOffset)
+			log.Infof(context.TODO(), "%d of %d nodes are within the maximum offset of %s", healthyOffsetCount, numClocks, maxOffset)
 		}
 	}
 
@@ -161,7 +163,7 @@ func (r RemoteOffset) isHealthy(maxOffset time.Duration) bool {
 		// health is ambiguous. For now, we err on the side of not spuriously
 		// killing nodes.
 		if log.V(1) {
-			log.Infof("uncertain remote offset %s for maximum offset %s, treating as healthy", r, maxOffset)
+			log.Infof(context.TODO(), "uncertain remote offset %s for maximum offset %s, treating as healthy", r, maxOffset)
 		}
 		return true
 	}

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -135,7 +135,7 @@ func (ctx *Context) SetLocalInternalServer(internalServer roachpb.InternalServer
 func (ctx *Context) removeConn(key string, conn *grpc.ClientConn) {
 	if err := conn.Close(); err != nil && !grpcutil.IsClosedConnection(err) {
 		if log.V(1) {
-			log.Errorf("failed to close client connection: %s", err)
+			log.Errorf(context.TODO(), "failed to close client connection: %s", err)
 		}
 	}
 	delete(ctx.conns.cache, key)
@@ -175,7 +175,7 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 		if ctx.Stopper.RunTask(func() {
 			ctx.Stopper.RunWorker(func() {
 				if err := ctx.runHeartbeat(conn, target); err != nil && !grpcutil.IsClosedConnection(err) {
-					log.Error(err)
+					log.Error(context.TODO(), err)
 				}
 				ctx.conns.Lock()
 				ctx.removeConn(target, conn)

--- a/security/securitytest/securitytest.go
+++ b/security/securitytest/securitytest.go
@@ -20,6 +20,7 @@ package securitytest
 import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/log"
+	"golang.org/x/net/context"
 )
 
 //go:generate go-bindata -pkg securitytest -mode 0644 -modtime 1400000000 -o ./embedded.go -ignore README.md -prefix ../../resource ../../resource/test_certs/...
@@ -37,7 +38,7 @@ func RestrictedCopy(t util.Tester, path, tempdir, name string) string {
 	contents, err := Asset(path)
 	if err != nil {
 		if t == nil {
-			log.Fatal(err)
+			log.Fatal(context.TODO(), err)
 		} else {
 			t.Fatal(err)
 		}

--- a/server/admin.go
+++ b/server/admin.go
@@ -114,21 +114,21 @@ func (s *adminServer) getUser(_ proto.Message) string {
 // serverError logs the provided error and returns an error that should be returned by
 // the RPC endpoint method.
 func (s *adminServer) serverError(err error) error {
-	log.ErrorfDepth(1, "%s", err)
+	log.ErrorfDepth(context.TODO(), 1, "%s", err)
 	return errAdminAPIError
 }
 
 // serverErrorf logs the provided error and returns an error that should be returned by
 // the RPC endpoint method.
 func (s *adminServer) serverErrorf(format string, args ...interface{}) error {
-	log.ErrorfDepth(1, format, args...)
+	log.ErrorfDepth(context.TODO(), 1, format, args...)
 	return errAdminAPIError
 }
 
 // serverErrors logs the provided errors and returns an error that should be returned by
 // the RPC endpoint method.
 func (s *adminServer) serverErrors(errors []error) error {
-	log.ErrorfDepth(1, "%v", errors)
+	log.ErrorfDepth(context.TODO(), 1, "%v", errors)
 	return errAdminAPIError
 }
 

--- a/server/context.go
+++ b/server/context.go
@@ -26,6 +26,8 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/dustin/go-humanize"
 	"github.com/elastic/gosigar"
 
@@ -177,7 +179,7 @@ func GetTotalMemory() (int64, error) {
 		var buf []byte
 		if buf, err = ioutil.ReadFile(defaultCGroupMemPath); err != nil {
 			if log.V(1) {
-				log.Infof("can't read available memory from cgroups (%s), using system memory %s instead", err,
+				log.Infof(context.TODO(), "can't read available memory from cgroups (%s), using system memory %s instead", err,
 					humanizeutil.IBytes(totalMem))
 			}
 			return totalMem, nil
@@ -185,14 +187,14 @@ func GetTotalMemory() (int64, error) {
 		var cgAvlMem uint64
 		if cgAvlMem, err = strconv.ParseUint(strings.TrimSpace(string(buf)), 10, 64); err != nil {
 			if log.V(1) {
-				log.Infof("can't parse available memory from cgroups (%s), using system memory %s instead", err,
+				log.Infof(context.TODO(), "can't parse available memory from cgroups (%s), using system memory %s instead", err,
 					humanizeutil.IBytes(totalMem))
 			}
 			return totalMem, nil
 		}
 		if cgAvlMem > math.MaxInt64 {
 			if log.V(1) {
-				log.Infof("available memory from cgroups is too large and unsupported %s using system memory %s instead",
+				log.Infof(context.TODO(), "available memory from cgroups is too large and unsupported %s using system memory %s instead",
 					humanize.IBytes(cgAvlMem), humanizeutil.IBytes(totalMem))
 
 			}
@@ -200,7 +202,7 @@ func GetTotalMemory() (int64, error) {
 		}
 		if cgAvlMem > mem.Total {
 			if log.V(1) {
-				log.Infof("available memory from cgroups %s exceeds system memory %s, using system memory",
+				log.Infof(context.TODO(), "available memory from cgroups %s exceeds system memory %s, using system memory",
 					humanize.IBytes(cgAvlMem), humanizeutil.IBytes(totalMem))
 			}
 			return totalMem, nil
@@ -228,7 +230,7 @@ func setOpenFileLimit(physicalStoreCount int) (int, error) {
 	var rLimit syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {
 		if log.V(1) {
-			log.Infof("could not get rlimit; setting maxOpenFiles to the default value %d - %s", engine.DefaultMaxOpenFiles, err)
+			log.Infof(context.TODO(), "could not get rlimit; setting maxOpenFiles to the default value %d - %s", engine.DefaultMaxOpenFiles, err)
 		}
 		return engine.DefaultMaxOpenFiles, nil
 	}
@@ -257,7 +259,7 @@ func setOpenFileLimit(physicalStoreCount int) (int, error) {
 	}
 	if rLimit.Cur < newCurrent {
 		if log.V(1) {
-			log.Infof("setting the soft limit for open file descriptors from %d to %d",
+			log.Infof(context.TODO(), "setting the soft limit for open file descriptors from %d to %d",
 				rLimit.Cur, newCurrent)
 		}
 		rLimit.Cur = newCurrent
@@ -270,7 +272,7 @@ func setOpenFileLimit(physicalStoreCount int) (int, error) {
 			return 0, err
 		}
 		if log.V(1) {
-			log.Infof("soft open file descriptor limit is now %d", rLimit.Cur)
+			log.Infof(context.TODO(), "soft open file descriptor limit is now %d", rLimit.Cur)
 		}
 	}
 
@@ -289,7 +291,7 @@ func setOpenFileLimit(physicalStoreCount int) (int, error) {
 
 	// We're still below the recommended amount, we should always show a
 	// warning.
-	log.Warningf("soft open file descriptor limit %d is under the recommended limit %d; this may decrease performance\n%s",
+	log.Warningf(context.TODO(), "soft open file descriptor limit %d is under the recommended limit %d; this may decrease performance\n%s",
 		rLimit.Cur,
 		recommendedOpenFileLimit,
 		productionSettingsWebpage)
@@ -391,9 +393,9 @@ func (ctx *Context) InitStores(stopper *stop.Stopper) error {
 	}
 
 	if len(ctx.Engines) == 1 {
-		log.Infof("1 storage engine initialized")
+		log.Infof(context.TODO(), "1 storage engine initialized")
 	} else {
-		log.Infof("%d storage engines initialized", len(ctx.Engines))
+		log.Infof(context.TODO(), "%d storage engines initialized", len(ctx.Engines))
 	}
 	return nil
 }

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -74,7 +76,7 @@ func TestIntentResolution(t *testing.T) {
 		// Use deterministic randomness to randomly put the writes in separate
 		// batches or commit them with EndTransaction.
 		rnd, seed := randutil.NewPseudoRand()
-		log.Infof("%d: using intent test seed %d", i, seed)
+		log.Infof(context.TODO(), "%d: using intent test seed %d", i, seed)
 
 		results := map[string]struct{}{}
 		func() {
@@ -103,7 +105,7 @@ func TestIntentResolution(t *testing.T) {
 						}
 					}
 					if entry != "" {
-						log.Infof("got %s", entry)
+						log.Infof(context.TODO(), "got %s", entry)
 						results[entry] = struct{}{}
 					}
 					if len(results) >= len(tc.exp) && !done {
@@ -130,7 +132,7 @@ func TestIntentResolution(t *testing.T) {
 					// The first write must not go to batch, it anchors the
 					// transaction to the correct range.
 					local := i != 0 && rnd.Intn(2) == 0
-					log.Infof("%d: %s: local: %t", i, key, local)
+					log.Infof(context.TODO(), "%d: %s: local: %t", i, key, local)
 					if local {
 						b.Put(key, "test")
 					} else if err := txn.Put(key, "test"); err != nil {
@@ -140,7 +142,7 @@ func TestIntentResolution(t *testing.T) {
 
 				for _, kr := range tc.ranges {
 					local := rnd.Intn(2) == 0
-					log.Infof("%d: [%s,%s): local: %t", i, kr[0], kr[1], local)
+					log.Infof(context.TODO(), "%d: [%s,%s): local: %t", i, kr[0], kr[1], local)
 					if local {
 						b.DelRange(kr[0], kr[1], false)
 					} else if err := txn.DelRange(kr[0], kr[1]); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -108,7 +108,7 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	if ctx.Insecure {
-		log.Warning("running in insecure mode, this is strongly discouraged. See --insecure.")
+		log.Warning(context.TODO(), "running in insecure mode, this is strongly discouraged. See --insecure.")
 	}
 	// Try loading the TLS configs before anything else.
 	if _, err := ctx.GetServerTLSConfig(); err != nil {
@@ -130,7 +130,7 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 	s.rpcContext = rpc.NewContext(ctx.Context, s.clock, s.stopper)
 	s.rpcContext.HeartbeatCB = func() {
 		if err := s.rpcContext.RemoteClocks.VerifyClockOffset(); err != nil {
-			log.Fatal(err)
+			log.Fatal(context.TODO(), err)
 		}
 	}
 
@@ -316,7 +316,7 @@ func (s *Server) Start() error {
 	s.stopper.RunWorker(func() {
 		<-s.stopper.ShouldQuiesce()
 		if err := ln.Close(); err != nil {
-			log.Fatal(err)
+			log.Fatal(context.TODO(), err)
 		}
 	})
 
@@ -337,7 +337,7 @@ func (s *Server) Start() error {
 	s.stopper.RunWorker(func() {
 		<-s.stopper.ShouldQuiesce()
 		if err := httpLn.Close(); err != nil {
-			log.Fatal(err)
+			log.Fatal(context.TODO(), err)
 		}
 	})
 
@@ -368,7 +368,7 @@ func (s *Server) Start() error {
 	s.stopper.RunWorker(func() {
 		netutil.FatalIfUnexpected(httpServer.ServeWith(s.stopper, pgL, func(conn net.Conn) {
 			if err := s.pgServer.ServeConn(conn); err != nil && !netutil.IsClosedConnection(err) {
-				log.Error(err)
+				log.Error(context.TODO(), err)
 			}
 		}))
 	})
@@ -383,7 +383,7 @@ func (s *Server) Start() error {
 		s.stopper.RunWorker(func() {
 			<-s.stopper.ShouldQuiesce()
 			if err := unixLn.Close(); err != nil {
-				log.Fatal(err)
+				log.Fatal(context.TODO(), err)
 			}
 		})
 
@@ -391,7 +391,7 @@ func (s *Server) Start() error {
 			netutil.FatalIfUnexpected(httpServer.ServeWith(s.stopper, unixLn, func(conn net.Conn) {
 				if err := s.pgServer.ServeConn(conn); err != nil &&
 					!netutil.IsClosedConnection(err) {
-					log.Error(err)
+					log.Error(context.TODO(), err)
 				}
 			}))
 		})
@@ -422,10 +422,10 @@ func (s *Server) Start() error {
 	}
 	sql.NewSchemaChangeManager(testingKnobs, *s.db, s.gossip, s.leaseMgr).Start(s.stopper)
 
-	log.Infof("starting %s server at %s", s.ctx.HTTPRequestScheme(), unresolvedHTTPAddr)
-	log.Infof("starting grpc/postgres server at %s", unresolvedAddr)
+	log.Infof(context.TODO(), "starting %s server at %s", s.ctx.HTTPRequestScheme(), unresolvedHTTPAddr)
+	log.Infof(context.TODO(), "starting grpc/postgres server at %s", unresolvedAddr)
 	if len(s.ctx.SocketFile) != 0 {
-		log.Infof("starting postgres server at unix:%s", s.ctx.SocketFile)
+		log.Infof(context.TODO(), "starting postgres server at unix:%s", s.ctx.SocketFile)
 	}
 
 	s.stopper.RunWorker(func() {
@@ -513,7 +513,7 @@ func (s *Server) Start() error {
 	s.mux.Handle(healthEndpoint, s.status)
 
 	if err := sdnotify.Ready(); err != nil {
-		log.Errorf("failed to signal readiness using systemd protocol: %s", err)
+		log.Errorf(context.TODO(), "failed to signal readiness using systemd protocol: %s", err)
 	}
 
 	return nil

--- a/server/status.go
+++ b/server/status.go
@@ -144,7 +144,7 @@ func newStatusServer(
 	// Create an http client with a timeout
 	httpClient, err := ctx.GetHTTPClient()
 	if err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		return nil
 	}
 
@@ -285,7 +285,7 @@ func (s *statusServer) LogFilesList(ctx context.Context, req *serverpb.LogFilesL
 func (s *statusServer) handleLogFilesList(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	resp, err := s.LogFilesList(context.TODO(), &serverpb.LogFilesListRequest{NodeId: ps.ByName("node_id")})
 	if err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -337,7 +337,7 @@ func (s *statusServer) handleLogFile(w http.ResponseWriter, r *http.Request, ps 
 	}
 	resp, err := s.LogFile(context.TODO(), &req)
 	if err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -438,7 +438,7 @@ func (s *statusServer) handleLogs(w http.ResponseWriter, r *http.Request, ps htt
 	}
 	resp, err := s.Logs(context.TODO(), &req)
 	if err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -496,7 +496,7 @@ func (s *statusServer) Nodes(_ context.Context, req *serverpb.NodesRequest) (*se
 	b := inconsistentBatch()
 	b.Scan(startKey, endKey, 0)
 	if err := s.db.Run(b); err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 	rows := b.Results[0].Rows
@@ -506,7 +506,7 @@ func (s *statusServer) Nodes(_ context.Context, req *serverpb.NodesRequest) (*se
 	}
 	for i, row := range rows {
 		if err := row.ValueProto(&resp.Nodes[i]); err != nil {
-			log.Error(err)
+			log.Error(context.TODO(), err)
 			return nil, grpc.Errorf(codes.Internal, err.Error())
 		}
 	}
@@ -524,14 +524,14 @@ func (s *statusServer) Node(ctx context.Context, req *serverpb.NodeRequest) (*st
 	b := inconsistentBatch()
 	b.Get(key)
 	if err := s.db.Run(b); err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 
 	var nodeStatus status.NodeStatus
 	if err := b.Results[0].Rows[0].ValueProto(&nodeStatus); err != nil {
 		err = errors.Errorf("could not unmarshal NodeStatus from %s: %s", key, err)
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 	return &nodeStatus, nil
@@ -557,7 +557,7 @@ func (s *statusServer) Metrics(ctx context.Context, req *serverpb.MetricsRequest
 func (s *statusServer) handleMetrics(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	resp, err := s.Metrics(context.TODO(), &serverpb.MetricsRequest{NodeId: ps.ByName("node_id")})
 	if err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -579,7 +579,7 @@ func (s *statusServer) RaftDebug(ctx context.Context, _ *serverpb.RaftDebugReque
 		nodeID := node.Desc.NodeID
 		ranges, err := s.Ranges(ctx, &serverpb.RangesRequest{NodeId: nodeID.String()})
 		if err != nil {
-			log.Infof("Failed to get ranges from %d: %q", node.Desc.NodeID, err)
+			log.Infof(context.TODO(), "Failed to get ranges from %d: %q", node.Desc.NodeID, err)
 			continue
 		}
 		for _, rng := range ranges.Ranges {
@@ -635,7 +635,7 @@ func (s *statusServer) handleVars(w http.ResponseWriter, r *http.Request, ps htt
 	w.Header().Set(util.ContentTypeHeader, util.PlaintextContentType)
 	err := s.metricSource.PrintAsText(w)
 	if err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/server/status/recorder.go
+++ b/server/status/recorder.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/build"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
@@ -155,7 +157,7 @@ func (mr *MetricsRecorder) MarshalJSON() ([]byte, error) {
 		// We haven't yet processed initialization information; return an empty
 		// JSON object.
 		if log.V(1) {
-			log.Warning("MetricsRecorder.MarshalJSON() called before NodeID allocation")
+			log.Warning(context.TODO(), "MetricsRecorder.MarshalJSON() called before NodeID allocation")
 		}
 		return []byte("{}"), nil
 	}
@@ -179,7 +181,7 @@ func (mr *MetricsRecorder) PrintAsText(w io.Writer) error {
 	if mr.mu.nodeID == 0 {
 		// We haven't yet processed initialization information; output nothing.
 		if log.V(1) {
-			log.Warning("MetricsRecorder.MarshalText() called before NodeID allocation")
+			log.Warning(context.TODO(), "MetricsRecorder.MarshalText() called before NodeID allocation")
 		}
 		return nil
 	}
@@ -204,7 +206,7 @@ func (mr *MetricsRecorder) GetTimeSeriesData() []tspb.TimeSeriesData {
 	if mr.mu.desc.NodeID == 0 {
 		// We haven't yet processed initialization information; do nothing.
 		if log.V(1) {
-			log.Warning("MetricsRecorder.GetTimeSeriesData() called before NodeID allocation")
+			log.Warning(context.TODO(), "MetricsRecorder.GetTimeSeriesData() called before NodeID allocation")
 		}
 		return nil
 	}
@@ -245,7 +247,7 @@ func (mr *MetricsRecorder) GetStatusSummary() *NodeStatus {
 	if mr.mu.nodeID == 0 {
 		// We haven't yet processed initialization information; do nothing.
 		if log.V(1) {
-			log.Warning("MetricsRecorder.GetStatusSummary called before NodeID allocation.")
+			log.Warning(context.TODO(), "MetricsRecorder.GetStatusSummary called before NodeID allocation.")
 		}
 		return nil
 	}
@@ -276,7 +278,7 @@ func (mr *MetricsRecorder) GetStatusSummary() *NodeStatus {
 		// Gather descriptor from store.
 		descriptor, err := mr.mu.stores[storeID].Descriptor()
 		if err != nil {
-			log.Errorf("Could not record status summaries: Store %d could not return descriptor, error: %s", storeID, err)
+			log.Errorf(context.TODO(), "Could not record status summaries: Store %d could not return descriptor, error: %s", storeID, err)
 			continue
 		}
 
@@ -335,7 +337,7 @@ func eachRecordableValue(reg *metric.Registry, fn func(string, float64)) {
 		} else {
 			val, err := extractValue(mtr)
 			if err != nil {
-				log.Warning(err)
+				log.Warning(context.TODO(), err)
 				return
 			}
 			fn(name, val)

--- a/server/status/runtime.go
+++ b/server/status/runtime.go
@@ -21,6 +21,8 @@ import (
 	"runtime"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/metric"
@@ -143,11 +145,11 @@ func (rsr *RuntimeStatSampler) SampleEnvironment() {
 	pid := os.Getpid()
 	mem := gosigar.ProcMem{}
 	if err := mem.Get(pid); err != nil {
-		log.Errorf("unable to get mem usage: %v", err)
+		log.Errorf(context.TODO(), "unable to get mem usage: %v", err)
 	}
 	cpu := gosigar.ProcTime{}
 	if err := cpu.Get(pid); err != nil {
-		log.Errorf("unable to get cpu usage: %v", err)
+		log.Errorf(context.TODO(), "unable to get cpu usage: %v", err)
 	}
 
 	// Time statistics can be compared to the total elapsed time to create a
@@ -171,7 +173,7 @@ func (rsr *RuntimeStatSampler) SampleEnvironment() {
 		var err error
 		cgoAllocated, cgoTotal, err = getCgoMemStats()
 		if err != nil {
-			log.Warningf("problem fetching CGO memory stats: %s, CGO stats will be empty.", err)
+			log.Warningf(context.TODO(), "problem fetching CGO memory stats: %s, CGO stats will be empty.", err)
 		}
 	}
 
@@ -180,13 +182,13 @@ func (rsr *RuntimeStatSampler) SampleEnvironment() {
 
 	// Log summary of statistics to console.
 	cgoRate := float64((numCgoCall-rsr.lastCgoCall)*int64(time.Second)) / dur
-	log.Infof("runtime stats: %s RSS, %d goroutines, %s/%s/%s GO alloc/idle/total, %s/%s CGO alloc/total, %.2fcgo/sec, %.2f/%.2f %%(u/s)time, %.2f %%gc (%dx)",
+	log.Infof(context.TODO(), "runtime stats: %s RSS, %d goroutines, %s/%s/%s GO alloc/idle/total, %s/%s CGO alloc/total, %.2fcgo/sec, %.2f/%.2f %%(u/s)time, %.2f %%gc (%dx)",
 		humanize.IBytes(mem.Resident), numGoroutine,
 		humanize.IBytes(goAllocated), humanize.IBytes(ms.HeapIdle-ms.HeapReleased), humanize.IBytes(goTotal),
 		humanize.IBytes(cgoAllocated), humanize.IBytes(cgoTotal),
 		cgoRate, uPerc, sPerc, pausePerc, ms.NumGC-rsr.lastNumGC)
 	if log.V(2) {
-		log.Infof("memstats: %+v", ms)
+		log.Infof(context.TODO(), "memstats: %+v", ms)
 	}
 	rsr.lastCgoCall = numCgoCall
 	rsr.lastNumGC = ms.NumGC

--- a/server/status/runtime_jemalloc.go
+++ b/server/status/runtime_jemalloc.go
@@ -73,6 +73,8 @@ import "C"
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	// This is explicit because this Go library does not export any Go symbols.
 	_ "github.com/cockroachdb/c-jemalloc"
 
@@ -97,7 +99,7 @@ func getJemallocStats() (uint64, uint64, error) {
 
 	if log.V(2) {
 		// Summary of jemalloc stats:
-		log.Infof("jemalloc stats: allocated: %s, active: %s, metadata: %s, resident: %s, mapped: %s",
+		log.Infof(context.TODO(), "jemalloc stats: allocated: %s, active: %s, metadata: %s, resident: %s, mapped: %s",
 			humanize.IBytes(uint64(js.allocated)), humanize.IBytes(uint64(js.active)),
 			humanize.IBytes(uint64(js.metadata)), humanize.IBytes(uint64(js.resident)),
 			humanize.IBytes(uint64(js.mapped)))

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -32,6 +32,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/build"
 	"github.com/cockroachdb/cockroach/gossip"
@@ -170,24 +172,24 @@ func getRequestReader(t *testing.T, ts serverutils.TestServerInterface, path str
 		req.Header.Set(util.AcceptHeader, util.JSONContentType)
 		resp, err := httpClient.Do(req)
 		if err != nil {
-			log.Infof("could not GET %s - %s", url, err)
+			log.Infof(context.TODO(), "could not GET %s - %s", url, err)
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				log.Infof("could not read body for %s - %s", url, err)
+				log.Infof(context.TODO(), "could not read body for %s - %s", url, err)
 				continue
 			}
-			log.Infof("could not GET %s - statuscode: %d - body: %s", url, resp.StatusCode, body)
+			log.Infof(context.TODO(), "could not GET %s - statuscode: %d - body: %s", url, resp.StatusCode, body)
 			continue
 		}
 		returnedContentType := resp.Header.Get(util.ContentTypeHeader)
 		if returnedContentType != util.JSONContentType {
-			log.Infof("unexpected content type: %v", returnedContentType)
+			log.Infof(context.TODO(), "unexpected content type: %v", returnedContentType)
 			continue
 		}
-		log.Infof("OK response from %s", url)
+		log.Infof(context.TODO(), "OK response from %s", url)
 		return resp.Body
 	}
 	t.Fatalf("There was an error retrieving %s", url)
@@ -201,7 +203,7 @@ func getRequest(t *testing.T, ts serverutils.TestServerInterface, path string) [
 	defer respBody.Close()
 	body, err := ioutil.ReadAll(respBody)
 	if err != nil {
-		log.Infof("could not read body for %s - %s", path, err)
+		log.Infof(context.TODO(), "could not read body for %s - %s", path, err)
 		return nil
 	}
 	return body
@@ -263,11 +265,11 @@ func TestStatusLocalLogs(t *testing.T) {
 
 	// Log an error which we expect to show up on every log file.
 	timestamp := timeutil.Now().UnixNano()
-	log.Errorf("TestStatusLocalLogFile test message-Error")
+	log.Errorf(context.TODO(), "TestStatusLocalLogFile test message-Error")
 	timestampE := timeutil.Now().UnixNano()
-	log.Warningf("TestStatusLocalLogFile test message-Warning")
+	log.Warningf(context.TODO(), "TestStatusLocalLogFile test message-Warning")
 	timestampEW := timeutil.Now().UnixNano()
-	log.Infof("TestStatusLocalLogFile test message-Info")
+	log.Infof(context.TODO(), "TestStatusLocalLogFile test message-Info")
 	timestampEWI := timeutil.Now().UnixNano()
 
 	type logsWrapper struct {

--- a/server/updates.go
+++ b/server/updates.go
@@ -123,7 +123,7 @@ func (s *Server) maybeCheckForUpdates() time.Duration {
 func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) time.Duration {
 	resp, err := s.db.Get(key)
 	if err != nil {
-		log.Infof("Error reading %s time: %v", op, err)
+		log.Infof(context.TODO(), "Error reading %s time: %v", op, err)
 		return updateCheckRetryFrequency
 	}
 
@@ -133,7 +133,7 @@ func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) tim
 	if resp.Exists() {
 		whenToCheck, pErr := resp.Value.GetTime()
 		if pErr != nil {
-			log.Warningf("Error decoding %s time: %v", op, err)
+			log.Warningf(context.TODO(), "Error decoding %s time: %v", op, err)
 			return updateCheckRetryFrequency
 		} else if delay := whenToCheck.Sub(timeutil.Now()); delay > 0 {
 			return delay
@@ -142,17 +142,17 @@ func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) tim
 		nextRetry := whenToCheck.Add(updateCheckRetryFrequency)
 		if err := s.db.CPut(key, nextRetry, whenToCheck); err != nil {
 			if log.V(2) {
-				log.Infof("Could not set next version check time (maybe another node checked?): %v", err)
+				log.Infof(context.TODO(), "Could not set next version check time (maybe another node checked?): %v", err)
 			}
 			return updateCheckRetryFrequency
 		}
 	} else {
-		log.Infof("No previous %s time.", op)
+		log.Infof(context.TODO(), "No previous %s time.", op)
 		nextRetry := timeutil.Now().Add(updateCheckRetryFrequency)
 		// CPut with `nil` prev value to assert that no other node has checked.
 		if err := s.db.CPut(key, nextRetry, nil); err != nil {
 			if log.V(2) {
-				log.Infof("Could not set %s time (maybe another node checked?): %v", op, err)
+				log.Infof(context.TODO(), "Could not set %s time (maybe another node checked?): %v", op, err)
 			}
 			return updateCheckRetryFrequency
 		}
@@ -161,7 +161,7 @@ func (s *Server) maybeRunPeriodicCheck(op string, key roachpb.Key, f func()) tim
 	f()
 
 	if err := s.db.Put(key, timeutil.Now().Add(updateCheckFrequency)); err != nil {
-		log.Infof("Error updating %s time: %v", op, err)
+		log.Infof(context.TODO(), "Error updating %s time: %v", op, err)
 	}
 	return updateCheckFrequency
 }
@@ -177,7 +177,7 @@ func (s *Server) checkForUpdates() {
 		// This is probably going to be relatively common in production
 		// environments where network access is usually curtailed.
 		if log.V(2) {
-			log.Warning("Failed to check for updates: ", err)
+			log.Warning(context.TODO(), "Failed to check for updates: ", err)
 		}
 		return
 	}
@@ -185,7 +185,7 @@ func (s *Server) checkForUpdates() {
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
-		log.Warningf("Failed to check for updates: status: %s, body: %s, error: %v",
+		log.Warningf(context.TODO(), "Failed to check for updates: status: %s, body: %s, error: %v",
 			res.Status, b, err)
 		return
 	}
@@ -197,12 +197,12 @@ func (s *Server) checkForUpdates() {
 
 	err = decoder.Decode(&r)
 	if err != nil && err != io.EOF {
-		log.Warning("Error decoding updates info: ", err)
+		log.Warning(context.TODO(), "Error decoding updates info: ", err)
 		return
 	}
 
 	for _, v := range r.Details {
-		log.Infof("A new version is available: %s, details: %s", v.Version, v.Details)
+		log.Infof(context.TODO(), "A new version is available: %s, details: %s", v.Version, v.Details)
 	}
 }
 
@@ -212,7 +212,7 @@ func (s *Server) usageReportingEnabled() bool {
 	req := &serverpb.GetUIDataRequest{Keys: []string{optinKey}}
 	resp, err := s.admin.GetUIData(ctx, req)
 	if err != nil {
-		log.Warning(err)
+		log.Warning(context.TODO(), err)
 		return false
 	}
 
@@ -223,7 +223,7 @@ func (s *Server) usageReportingEnabled() bool {
 	}
 	optin, err := strconv.ParseBool(string(val.Value))
 	if err != nil {
-		log.Warningf("could not parse optin value (%q): %v", val.Value, err)
+		log.Warningf(context.TODO(), "could not parse optin value (%q): %v", val.Value, err)
 		return false
 	}
 	return optin
@@ -264,7 +264,7 @@ func (s *Server) getReportingInfo() reportingInfo {
 func (s *Server) reportUsage() {
 	b := new(bytes.Buffer)
 	if err := json.NewEncoder(b).Encode(s.getReportingInfo()); err != nil {
-		log.Warning(err)
+		log.Warning(context.TODO(), err)
 		return
 	}
 
@@ -277,13 +277,13 @@ func (s *Server) reportUsage() {
 	if err != nil && log.V(2) {
 		// This is probably going to be relatively common in production
 		// environments where network access is usually curtailed.
-		log.Warning("Failed to report node usage metrics: ", err)
+		log.Warning(context.TODO(), "Failed to report node usage metrics: ", err)
 		return
 	}
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
-		log.Warningf("Failed to report node usage metrics: status: %s, body: %s, "+
+		log.Warningf(context.TODO(), "Failed to report node usage metrics: status: %s, body: %s, "+
 			"error: %v", res.Status, b, err)
 	}
 }

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"sort"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -396,7 +398,7 @@ func (sc *SchemaChanger) truncateIndexes(
 			indexStartKey := roachpb.Key(indexPrefix)
 			indexEndKey := indexStartKey.PrefixEnd()
 			if log.V(2) {
-				log.Infof("DelRange %s - %s", indexStartKey, indexEndKey)
+				log.Infof(context.TODO(), "DelRange %s - %s", indexStartKey, indexEndKey)
 			}
 			b := &client.Batch{}
 			b.DelRange(indexStartKey, indexEndKey, false)
@@ -520,7 +522,7 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 				}
 				for _, secondaryIndexEntry := range secondaryIndexEntries {
 					if log.V(2) {
-						log.Infof("InitPut %s -> %v", secondaryIndexEntry.Key,
+						log.Infof(context.TODO(), "InitPut %s -> %v", secondaryIndexEntry.Key,
 							secondaryIndexEntry.Value)
 					}
 					b.InitPut(secondaryIndexEntry.Key, &secondaryIndexEntry.Value)

--- a/sql/database.go
+++ b/sql/database.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -180,7 +182,7 @@ func (p *planner) getDatabaseID(name string) (sqlbase.ID, error) {
 	desc, err := p.getCachedDatabaseDesc(name)
 	if err != nil {
 		if log.V(3) {
-			log.Infof("%v", err)
+			log.Infof(context.TODO(), "%v", err)
 		}
 		var err error
 		desc, err = p.mustGetDatabaseDesc(name)

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -172,13 +174,13 @@ func canDeleteWithoutScan(n *parser.Delete, scan *scanNode, td *tableDeleter) bo
 	}
 	if n.Returning != nil {
 		if log.V(2) {
-			log.Infof("delete forced to scan: values required for RETURNING")
+			log.Infof(context.TODO(), "delete forced to scan: values required for RETURNING")
 		}
 		return false
 	}
 	if scan.filter != nil {
 		if log.V(2) {
-			log.Infof("delete forced to scan: values required for filter (%s)", scan.filter)
+			log.Infof(context.TODO(), "delete forced to scan: values required for filter (%s)", scan.filter)
 		}
 		return false
 	}

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
@@ -109,8 +111,8 @@ func (p *planner) createDescriptor(plainKey sqlbase.DescriptorKey, descriptor sq
 	descID := descriptor.GetID()
 	descDesc := sqlbase.WrapDescriptor(descriptor)
 	if log.V(2) {
-		log.Infof("CPut %s -> %d", idKey, descID)
-		log.Infof("CPut %s -> %s", descKey, descDesc)
+		log.Infof(context.TODO(), "CPut %s -> %d", idKey, descID)
+		log.Infof(context.TODO(), "CPut %s -> %s", descKey, descDesc)
 	}
 	b.CPut(idKey, descID, nil)
 	b.CPut(descKey, descDesc, nil)

--- a/sql/distsql/joinreader.go
+++ b/sql/distsql/joinreader.go
@@ -19,6 +19,8 @@ package distsql
 import (
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -158,7 +160,7 @@ func (jr *joinReader) mainLoop() error {
 // Run is part of the processor interface.
 func (jr *joinReader) Run(wg *sync.WaitGroup) {
 	if log.V(2) {
-		log.Infof("JoinReader filter: %s\n", jr.filter.expr)
+		log.Infof(context.TODO(), "JoinReader filter: %s\n", jr.filter.expr)
 	}
 	err := jr.mainLoop()
 	jr.output.Close(err)

--- a/sql/distsql/tablereader.go
+++ b/sql/distsql/tablereader.go
@@ -19,6 +19,8 @@ package distsql
 import (
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -216,7 +218,7 @@ func (tr *tableReader) Run(wg *sync.WaitGroup) {
 		defer wg.Done()
 	}
 	if log.V(2) {
-		log.Infof("TableReader filter: %s\n", tr.filter.expr)
+		log.Infof(context.TODO(), "TableReader filter: %s\n", tr.filter.expr)
 	}
 
 	if err := tr.fetcher.StartScan(tr.txn, tr.spans, tr.getLimitHint()); err != nil {

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -105,9 +107,9 @@ func (n *dropDatabaseNode) Start() error {
 
 	b := &client.Batch{}
 	if log.V(2) {
-		log.Infof("Del %s", descKey)
-		log.Infof("Del %s", nameKey)
-		log.Infof("Del %s", zoneKey)
+		log.Infof(context.TODO(), "Del %s", descKey)
+		log.Infof(context.TODO(), "Del %s", nameKey)
+		log.Infof(context.TODO(), "Del %s", zoneKey)
 	}
 	b.Del(descKey)
 	b.Del(nameKey)

--- a/sql/event_log.go
+++ b/sql/event_log.go
@@ -97,7 +97,7 @@ func MakeEventLogger(leaseMgr *LeaseManager) EventLogger {
 // provided transaction.
 func (ev EventLogger) InsertEventRecord(txn *client.Txn, eventType EventLogType, targetID, reportingID int32, info interface{}) error {
 	// Record event record insertion in local log output.
-	log.Infoc(txn.Context, "Event: %q, target: %d, info: %+v",
+	log.Infof(txn.Context, "Event: %q, target: %d, info: %+v",
 		eventType,
 		targetID,
 		info)

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -301,7 +301,7 @@ func (e *Executor) Prepare(
 	pinfo parser.PlaceholderTypes,
 ) ([]ResultColumn, error) {
 	if log.V(2) {
-		log.Infof("preparing statement: %s", query)
+		log.Infof(context.TODO(), "preparing statement: %s", query)
 	}
 	stmt, err := parser.ParseOne(query, parser.Syntax(session.Syntax))
 	if err != nil {
@@ -496,7 +496,7 @@ func (e *Executor) execRequest(ctx context.Context, session *Session, sql string
 
 		// Until #7881 fixed.
 		if txnState.State != NoTxn && txnState.txn == nil {
-			log.Errorf("txnState not cleared while txn == nil: %+v, execOpt %+v, stmts %+v, remaining %+v", txnState, execOpt, stmts, remainingStmts)
+			log.Errorf(context.TODO(), "txnState not cleared while txn == nil: %+v, execOpt %+v, stmts %+v, remaining %+v", txnState, execOpt, stmts, remainingStmts)
 		}
 
 		// Update the Err field of the last result if the error was coming from
@@ -507,14 +507,14 @@ func (e *Executor) execRequest(ctx context.Context, session *Session, sql string
 			if aErr, ok := err.(*client.AutoCommitError); ok {
 				// Until #7881 fixed.
 				if txnState.txn == nil {
-					log.Errorf("AutoCommitError on nil txn: %+v, txnState %+v, execOpt %+v, stmts %+v, remaining %+v", err, txnState, execOpt, stmts, remainingStmts)
+					log.Errorf(context.TODO(), "AutoCommitError on nil txn: %+v, txnState %+v, execOpt %+v, stmts %+v, remaining %+v", err, txnState, execOpt, stmts, remainingStmts)
 				}
 				lastResult.Err = aErr
 				e.txnAbortCount.Inc(1)
 				txnState.txn.CleanupOnError(err)
 			}
 			if lastResult.Err == nil {
-				log.Fatalf("error (%s) was returned, but it was not set in the last result (%v)", err, lastResult)
+				log.Fatalf(context.TODO(), "error (%s) was returned, but it was not set in the last result (%v)", err, lastResult)
 			}
 		}
 
@@ -660,7 +660,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 
 	for i, stmt := range stmts {
 		if log.V(2) {
-			log.Infof("about to execute sql statement (%d/%d): %s", i+1, len(stmts), stmt)
+			log.Infof(context.TODO(), "about to execute sql statement (%d/%d): %s", i+1, len(stmts), stmt)
 		}
 		txnState.schemaChangers.curStatementIdx = i
 
@@ -968,7 +968,7 @@ func rollbackSQLTransaction(txnState *txnState, p *planner) Result {
 	err := p.txn.Rollback()
 	result := Result{PGTag: (*parser.RollbackTransaction)(nil).StatementTag()}
 	if err != nil {
-		log.Warningf("txn rollback failed. The error was swallowed: %s", err)
+		log.Warningf(context.TODO(), "txn rollback failed. The error was swallowed: %s", err)
 		result.Err = err
 	}
 	// We're done with this txn.

--- a/sql/group.go
+++ b/sql/group.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/encoding"
@@ -136,7 +138,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 		for _, f := range group.funcs {
 			strs = append(strs, f.String())
 		}
-		log.Infof("Group: %s", strings.Join(strs, ", "))
+		log.Infof(context.TODO(), "Group: %s", strings.Join(strs, ", "))
 	}
 
 	// Replace the render expressions in the scanNode with expressions that

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"sort"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -118,7 +120,7 @@ func selectIndex(
 		// possibly overlapping ranges.
 		exprs, equivalent := analyzeExpr(s.filter)
 		if log.V(2) {
-			log.Infof("analyzeExpr: %s -> %s [equivalent=%v]", s.filter, exprs, equivalent)
+			log.Infof(context.TODO(), "analyzeExpr: %s -> %s [equivalent=%v]", s.filter, exprs, equivalent)
 		}
 
 		// Check to see if the filter simplified to a constant.
@@ -188,7 +190,7 @@ func selectIndex(
 
 	if log.V(2) {
 		for i, c := range candidates {
-			log.Infof("%d: selectIndex(%s): cost=%v constraints=%s reverse=%t",
+			log.Infof(context.TODO(), "%d: selectIndex(%s): cost=%v constraints=%s reverse=%t",
 				i, c.index.Name, c.cost, c.constraints, c.reverse)
 		}
 	}
@@ -218,9 +220,9 @@ func selectIndex(
 	}
 
 	if log.V(3) {
-		log.Infof("%s: filter=%v", c.index.Name, s.filter)
+		log.Infof(context.TODO(), "%s: filter=%v", c.index.Name, s.filter)
 		for i, span := range s.spans {
-			log.Infof("%s/%d: %s", c.index.Name, i, sqlbase.PrettySpan(span, 2))
+			log.Infof(context.TODO(), "%s/%d: %s", c.index.Name, i, sqlbase.PrettySpan(span, 2))
 		}
 	}
 
@@ -402,7 +404,7 @@ func (v *indexInfo) analyzeOrdering(scan *scanNode, analyzeOrdering analyzeOrder
 	}
 
 	if log.V(2) {
-		log.Infof("%s: analyzeOrdering: weight=%0.2f reverse=%v match=%d",
+		log.Infof(context.TODO(), "%s: analyzeOrdering: weight=%0.2f reverse=%v match=%d",
 			v.index.Name, weight, v.reverse, match)
 	}
 }

--- a/sql/join.go
+++ b/sql/join.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -228,7 +230,7 @@ func (n *indexJoinNode) Next() (bool, error) {
 		}
 
 		if log.V(3) {
-			log.Infof("table scan: %s", sqlbase.PrettySpans(n.table.spans, 0))
+			log.Infof(context.TODO(), "table scan: %s", sqlbase.PrettySpans(n.table.spans, 0))
 		}
 	}
 	return false, nil

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -26,6 +26,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"golang.org/x/net/context"
+
 	"gopkg.in/inf.v0"
 
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -1865,14 +1867,14 @@ func (expr *ParenExpr) Eval(ctx *EvalContext) (Datum, error) {
 
 // Eval implements the TypedExpr interface.
 func (expr *RangeCond) Eval(_ *EvalContext) (Datum, error) {
-	log.Errorf("unhandled type %T passed to Eval", expr)
+	log.Errorf(context.TODO(), "unhandled type %T passed to Eval", expr)
 	return nil, errors.Errorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
 func (expr *Subquery) Eval(_ *EvalContext) (Datum, error) {
 	// Subquery expressions are handled during subquery expansion.
-	log.Errorf("unhandled type %T passed to Eval", expr)
+	log.Errorf(context.TODO(), "unhandled type %T passed to Eval", expr)
 	return nil, errors.Errorf("unhandled type %T", expr)
 }
 
@@ -1890,13 +1892,13 @@ func (expr *UnaryExpr) Eval(ctx *EvalContext) (Datum, error) {
 
 // Eval implements the TypedExpr interface.
 func (expr DefaultVal) Eval(_ *EvalContext) (Datum, error) {
-	log.Errorf("unhandled type %T passed to Eval", expr)
+	log.Errorf(context.TODO(), "unhandled type %T passed to Eval", expr)
 	return nil, errors.Errorf("unhandled type %T", expr)
 }
 
 // Eval implements the TypedExpr interface.
 func (expr *QualifiedName) Eval(ctx *EvalContext) (Datum, error) {
-	log.Errorf("unhandled type %T passed to Eval", expr)
+	log.Errorf(context.TODO(), "unhandled type %T passed to Eval", expr)
 	return nil, errors.Errorf("unhandled type %T", expr)
 }
 

--- a/sql/pgwire/types.go
+++ b/sql/pgwire/types.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"gopkg.in/inf.v0"
 
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -120,7 +122,7 @@ const secondsInDay = 24 * 60 * 60
 
 func (b *writeBuffer) writeTextDatum(d parser.Datum, sessionLoc *time.Location) {
 	if log.V(2) {
-		log.Infof("pgwire writing TEXT datum of type: %T, %#v", d, d)
+		log.Infof(context.TODO(), "pgwire writing TEXT datum of type: %T, %#v", d, d)
 	}
 	if d == parser.DNull {
 		// NULL is encoded as -1; all other values have a length prefix.
@@ -192,7 +194,7 @@ func (b *writeBuffer) writeTextDatum(d parser.Datum, sessionLoc *time.Location) 
 
 func (b *writeBuffer) writeBinaryDatum(d parser.Datum) {
 	if log.V(2) {
-		log.Infof("pgwire writing BINARY datum of type: %T, %#v", d, d)
+		log.Infof(context.TODO(), "pgwire writing BINARY datum of type: %T, %#v", d, d)
 	}
 	if d == parser.DNull {
 		// NULL is encoded as -1; all other values have a length prefix.

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -140,7 +140,7 @@ func makeV3Conn(
 func (c *v3Conn) finish() {
 	// This is better than always flushing on error.
 	if err := c.wr.Flush(); err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 	}
 	_ = c.conn.Close()
 	c.session.Finish()
@@ -168,7 +168,7 @@ func parseOptions(data []byte) (sql.SessionArgs, error) {
 			args.User = value
 		default:
 			if log.V(1) {
-				log.Warningf("unrecognized configuration parameter %q", key)
+				log.Warningf(context.TODO(), "unrecognized configuration parameter %q", key)
 			}
 		}
 	}
@@ -236,7 +236,7 @@ func (c *v3Conn) serve(authenticationHook func(string, bool) error) error {
 			}
 
 			if log.V(2) {
-				log.Infof("pgwire: %s: %q", serverMsgReady, txnStatus)
+				log.Infof(context.TODO(), "pgwire: %s: %q", serverMsgReady, txnStatus)
 			}
 			c.writeBuf.writeByte(txnStatus)
 			if err := c.writeBuf.finishMsg(c.wr); err != nil {
@@ -258,12 +258,12 @@ func (c *v3Conn) serve(authenticationHook func(string, bool) error) error {
 		// any messages until we get a sync.
 		if c.ignoreTillSync && typ != clientMsgSync {
 			if log.V(2) {
-				log.Infof("pgwire: ignoring %s till sync", typ)
+				log.Infof(context.TODO(), "pgwire: ignoring %s till sync", typ)
 			}
 			continue
 		}
 		if log.V(2) {
-			log.Infof("pgwire: processing %s", typ)
+			log.Infof(context.TODO(), "pgwire: processing %s", typ)
 		}
 		switch typ {
 		case clientMsgSync:
@@ -803,7 +803,7 @@ func (c *v3Conn) sendRowDescription(columns []sql.ResultColumn, formatCodes []fo
 	c.writeBuf.putInt16(int16(len(columns)))
 	for i, column := range columns {
 		if log.V(2) {
-			log.Infof("pgwire writing column %s of type: %T", column.Name, column.Typ)
+			log.Infof(context.TODO(), "pgwire writing column %s of type: %T", column.Name, column.Typ)
 		}
 		c.writeBuf.writeTerminatedString(column.Name)
 

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/security/securitytest"
@@ -556,7 +558,7 @@ func TestPGPreparedQuery(t *testing.T) {
 	runTests := func(query string, tests []preparedQueryTest, queryFunc func(...interface{}) (*gosql.Rows, error)) {
 		for _, test := range tests {
 			if testing.Verbose() || log.V(1) {
-				log.Infof("query: %s", query)
+				log.Infof(context.TODO(), "query: %s", query)
 			}
 			rows, err := queryFunc(test.qargs...)
 			if err != nil {
@@ -812,7 +814,7 @@ func TestPGPreparedExec(t *testing.T) {
 	runTests := func(query string, tests []preparedExecTest, execFunc func(...interface{}) (gosql.Result, error)) {
 		for _, test := range tests {
 			if testing.Verbose() || log.V(1) {
-				log.Infof("exec: %s", query)
+				log.Infof(context.TODO(), "exec: %s", query)
 			}
 			if result, err := execFunc(test.qargs...); err != nil {
 				if test.error == "" {
@@ -838,7 +840,7 @@ func TestPGPreparedExec(t *testing.T) {
 
 	for _, execTest := range execTests {
 		if testing.Verbose() || log.V(1) {
-			log.Infof("prepare: %s", execTest.query)
+			log.Infof(context.TODO(), "prepare: %s", execTest.query)
 		}
 		if stmt, err := db.Prepare(execTest.query); err != nil {
 			t.Errorf("%s: prepare error: %s", execTest.query, err)

--- a/sql/rowwriter.go
+++ b/sql/rowwriter.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"sort"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/util/encoding"
 
 	"github.com/cockroachdb/cockroach/internal/client"
@@ -190,7 +192,7 @@ func insertCPutFn(b *client.Batch, key *roachpb.Key, value *roachpb.Value) {
 	// TODO(dan): We want do this V(2) log everywhere in sql. Consider making a
 	// client.Batch wrapper instead of inlining it everywhere.
 	if log.V(2) {
-		log.InfofDepth(1, "CPut %s -> %s", *key, value.PrettyPrint())
+		log.InfofDepth(context.TODO(), 1, "CPut %s -> %s", *key, value.PrettyPrint())
 	}
 	b.CPut(key, value, nil)
 }
@@ -199,7 +201,7 @@ func insertCPutFn(b *client.Batch, key *roachpb.Key, value *roachpb.Value) {
 // logValue is used for pretty printing.
 func insertPutFn(b *client.Batch, key *roachpb.Key, value *roachpb.Value) {
 	if log.V(2) {
-		log.InfofDepth(1, "Put %s -> %s", *key, value.PrettyPrint())
+		log.InfofDepth(context.TODO(), 1, "Put %s -> %s", *key, value.PrettyPrint())
 	}
 	b.Put(key, value)
 }
@@ -626,7 +628,7 @@ func (ru *rowUpdater) updateRow(
 
 			ru.key = keys.MakeFamilyKey(primaryIndexKey, uint32(family.ID))
 			if log.V(2) {
-				log.Infof("Put %s -> %v", ru.key, ru.marshalled[idx].PrettyPrint())
+				log.Infof(context.TODO(), "Put %s -> %v", ru.key, ru.marshalled[idx].PrettyPrint())
 			}
 			b.Put(&ru.key, &ru.marshalled[idx])
 			ru.key = nil
@@ -677,14 +679,14 @@ func (ru *rowUpdater) updateRow(
 			// The family might have already existed but every column in it is being
 			// set to NULL, so delete it.
 			if log.V(2) {
-				log.Infof("Del %s", ru.key)
+				log.Infof(context.TODO(), "Del %s", ru.key)
 			}
 
 			b.Del(&ru.key)
 		} else {
 			ru.value.SetTuple(ru.valueBuf)
 			if log.V(2) {
-				log.Infof("Put %s -> %v", ru.key, ru.value.PrettyPrint())
+				log.Infof(context.TODO(), "Put %s -> %v", ru.key, ru.value.PrettyPrint())
 			}
 			b.Put(&ru.key, &ru.value)
 		}
@@ -702,13 +704,13 @@ func (ru *rowUpdater) updateRow(
 			}
 
 			if log.V(2) {
-				log.Infof("Del %s", secondaryIndexEntry.Key)
+				log.Infof(context.TODO(), "Del %s", secondaryIndexEntry.Key)
 			}
 			b.Del(secondaryIndexEntry.Key)
 			// Do not update Indexes in the DELETE_ONLY state.
 			if _, ok := ru.deleteOnlyIndex[i]; !ok {
 				if log.V(2) {
-					log.Infof("CPut %s -> %v", newSecondaryIndexEntry.Key, newSecondaryIndexEntry.Value.PrettyPrint())
+					log.Infof(context.TODO(), "CPut %s -> %v", newSecondaryIndexEntry.Key, newSecondaryIndexEntry.Value.PrettyPrint())
 				}
 				b.CPut(newSecondaryIndexEntry.Key, &newSecondaryIndexEntry.Value, nil)
 			}
@@ -816,7 +818,7 @@ func (rd *rowDeleter) deleteRow(b *client.Batch, values []parser.Datum) error {
 
 	for _, secondaryIndexEntry := range secondaryIndexEntries {
 		if log.V(2) {
-			log.Infof("Del %s", secondaryIndexEntry.Key)
+			log.Infof(context.TODO(), "Del %s", secondaryIndexEntry.Key)
 		}
 		b.Del(secondaryIndexEntry.Key)
 	}
@@ -825,7 +827,7 @@ func (rd *rowDeleter) deleteRow(b *client.Batch, values []parser.Datum) error {
 	rd.startKey = roachpb.Key(primaryIndexKey)
 	rd.endKey = roachpb.Key(encoding.EncodeNotNullDescending(primaryIndexKey))
 	if log.V(2) {
-		log.Infof("DelRange %s - %s", rd.startKey, rd.endKey)
+		log.Infof(context.TODO(), "DelRange %s - %s", rd.startKey, rd.endKey)
 	}
 	b.DelRange(&rd.startKey, &rd.endKey, false)
 	rd.startKey, rd.endKey = nil, nil

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -22,6 +22,8 @@ import (
 	"math"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
@@ -115,7 +117,7 @@ func (sc *SchemaChanger) AcquireLease() (sqlbase.TableDescriptor_SchemaChangeLea
 			if time.Unix(0, tableDesc.Lease.ExpirationTime).Add(expirationTimeUncertainty).After(timeutil.Now()) {
 				return errExistingSchemaChangeLease
 			}
-			log.Infof("Overriding existing expired lease %v", tableDesc.Lease)
+			log.Infof(context.TODO(), "Overriding existing expired lease %v", tableDesc.Lease)
 		}
 		lease = sc.createSchemaChangeLease()
 		tableDesc.Lease = &lease
@@ -211,7 +213,7 @@ func (sc SchemaChanger) exec(
 			return
 		}
 		if err := sc.ReleaseLease(*l); err != nil {
-			log.Warning(err)
+			log.Warning(context.TODO(), err)
 		}
 	}(&lease)
 
@@ -288,7 +290,7 @@ func (sc SchemaChanger) exec(
 	// correctness but is done to make the UI experience/tests predictable.
 	defer func() {
 		if err := sc.waitToUpdateLeases(); err != nil {
-			log.Warning(err)
+			log.Warning(context.TODO(), err)
 		}
 	}()
 
@@ -307,7 +309,7 @@ func (sc SchemaChanger) exec(
 	// an integrity constraint violation. All other errors are transient
 	// errors that are resolved by retrying the backfill.
 	if sqlbase.IsIntegrityConstraintError(err) {
-		log.Warningf("reversing schema change due to irrecoverable error: %s", err)
+		log.Warningf(context.TODO(), "reversing schema change due to irrecoverable error: %s", err)
 		if errReverse := sc.reverseMutations(err); errReverse != nil {
 			// Although the backfill did hit an integrity constraint violation
 			// and made a decision to reverse the mutations,
@@ -325,7 +327,7 @@ func (sc SchemaChanger) exec(
 			// that an integrity constraint was violated with the original
 			// schema change. The reversed schema change will be
 			// retried via the async schema change manager.
-			log.Warningf("error purging mutation: %s, after error: %s", errPurge, err)
+			log.Warningf(context.TODO(), "error purging mutation: %s, after error: %s", errPurge, err)
 		}
 	}
 
@@ -412,11 +414,11 @@ func (sc *SchemaChanger) waitToUpdateLeases() error {
 		Multiplier:     2,
 	}
 	if log.V(2) {
-		log.Infof("waiting for a single version of table %d...", sc.tableID)
+		log.Infof(context.TODO(), "waiting for a single version of table %d...", sc.tableID)
 	}
 	_, err := sc.leaseMgr.waitForOneVersion(sc.tableID, retryOpts)
 	if log.V(2) {
-		log.Infof("waiting for a single version of table %d... done", sc.tableID)
+		log.Infof(context.TODO(), "waiting for a single version of table %d... done", sc.tableID)
 	}
 	return err
 }
@@ -503,7 +505,7 @@ func (sc *SchemaChanger) reverseMutations(causingError error) error {
 				// mutation ID we're looking for.
 				break
 			}
-			log.Warningf("reverse schema change mutation: %+v", mutation)
+			log.Warningf(context.TODO(), "reverse schema change mutation: %+v", mutation)
 			switch mutation.Direction {
 			case sqlbase.DescriptorMutation_ADD:
 				desc.Mutations[i].Direction = sqlbase.DescriptorMutation_DROP
@@ -563,7 +565,7 @@ func (sc *SchemaChanger) deleteIndexMutationsWithReversedColumns(
 							mutation.State != sqlbase.DescriptorMutation_DELETE_ONLY {
 							panic(fmt.Sprintf("mutation in bad state: %+v", mutation))
 						}
-						log.Warningf("delete schema change mutation: %+v", mutation)
+						log.Warningf(context.TODO(), "delete schema change mutation: %+v", mutation)
 						deleteMutation = true
 						break
 					}
@@ -686,7 +688,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 				cfg, _ := s.gossip.GetSystemConfig()
 				// Read all tables and their versions
 				if log.V(2) {
-					log.Info("received a new config")
+					log.Info(context.TODO(), "received a new config")
 				}
 				schemaChanger := SchemaChanger{
 					nodeID:   roachpb.NodeID(s.leaseMgr.nodeID),
@@ -707,7 +709,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 					// Attempt to unmarshal config into a table/database descriptor.
 					var descriptor sqlbase.Descriptor
 					if err := kv.Value.GetProto(&descriptor); err != nil {
-						log.Warningf("%s: unable to unmarshal descriptor %v", kv.Key, kv.Value)
+						log.Warningf(context.TODO(), "%s: unable to unmarshal descriptor %v", kv.Key, kv.Value)
 						continue
 					}
 					switch union := descriptor.Union.(type) {
@@ -715,7 +717,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 						table := union.Table
 						table.MaybeUpgradeFormatVersion()
 						if err := table.Validate(); err != nil {
-							log.Errorf("%s: received invalid table descriptor: %v", kv.Key, table)
+							log.Errorf(context.TODO(), "%s: received invalid table descriptor: %v", kv.Key, table)
 							continue
 						}
 
@@ -728,7 +730,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 						if table.UpVersion || table.Deleted() ||
 							table.Renamed() || len(table.Mutations) > 0 {
 							if log.V(2) {
-								log.Infof("%s: queue up pending schema change; table: %d, version: %d",
+								log.Infof(context.TODO(), "%s: queue up pending schema change; table: %d, version: %d",
 									kv.Key, table.ID, table.Version)
 							}
 
@@ -785,7 +787,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 								// constraints violations because exec()
 								// purges mutations that violate integrity
 								// constraints.
-								log.Warningf("Error executing schema change: %s", err)
+								log.Warningf(context.TODO(), "Error executing schema change: %s", err)
 							}
 						}
 						// Advance the execAfter time so that this schema

--- a/sql/session.go
+++ b/sql/session.go
@@ -263,7 +263,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 		sc.db = *e.ctx.DB
 		for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 			if done, err := sc.IsDone(); err != nil {
-				log.Warning(err)
+				log.Warning(context.TODO(), err)
 				break
 			} else if done {
 				break
@@ -287,7 +287,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 				if scEntry.epoch == scc.curGroupNum {
 					results[scEntry.idx] = Result{Err: err}
 				}
-				log.Warningf("Error executing schema change: %s", err)
+				log.Warningf(context.TODO(), "Error executing schema change: %s", err)
 			}
 			break
 		}

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -23,6 +23,8 @@ import (
 	"math"
 	"strconv"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/encoding"
@@ -262,7 +264,7 @@ func (n *sortNode) wrap(plan planNode) (bool, planNode) {
 		// ordering.
 		existingOrdering := plan.Ordering()
 		if log.V(2) {
-			log.Infof("Sort: existing=%+v desired=%+v", existingOrdering, n.ordering)
+			log.Infof(context.TODO(), "Sort: existing=%+v desired=%+v", existingOrdering, n.ordering)
 		}
 		match := computeOrderingMatch(n.ordering, existingOrdering, false)
 		if match < len(n.ordering) {
@@ -279,7 +281,7 @@ func (n *sortNode) wrap(plan planNode) (bool, planNode) {
 		}
 
 		if log.V(2) {
-			log.Infof("Sort: no sorting required")
+			log.Infof(context.TODO(), "Sort: no sorting required")
 		}
 	}
 

--- a/sql/sqlbase/metadata.go
+++ b/sql/sqlbase/metadata.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"sort"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -168,7 +170,7 @@ func (ms MetadataSchema) GetInitialValues() []roachpb.KeyValue {
 		value = roachpb.Value{}
 		wrappedDesc := WrapDescriptor(desc)
 		if err := value.SetProto(wrappedDesc); err != nil {
-			log.Fatalf("could not marshal %v", desc)
+			log.Fatalf(context.TODO(), "could not marshal %v", desc)
 		}
 		ret = append(ret, roachpb.KeyValue{
 			Key:   MakeDescMetadataKey(desc.GetID()),

--- a/sql/sqlbase/rowfetcher.go
+++ b/sql/sqlbase/rowfetcher.go
@@ -21,6 +21,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -311,9 +313,9 @@ func (rf *RowFetcher) ProcessKV(kv client.KeyValue, debugStrings bool) (
 
 		if log.V(2) {
 			if rf.implicitVals != nil {
-				log.Infof("Scan %s -> %s", kv.Key, prettyDatums(rf.implicitVals))
+				log.Infof(context.TODO(), "Scan %s -> %s", kv.Key, prettyDatums(rf.implicitVals))
 			} else {
-				log.Infof("Scan %s", kv.Key)
+				log.Infof(context.TODO(), "Scan %s", kv.Key)
 			}
 		}
 	}
@@ -364,13 +366,13 @@ func (rf *RowFetcher) processValueSingle(
 		}
 		rf.row[idx] = value
 		if log.V(3) {
-			log.Infof("Scan %s -> %v", kv.Key, value)
+			log.Infof(context.TODO(), "Scan %s -> %v", kv.Key, value)
 		}
 	} else {
 		// No need to unmarshal the column value. Either the column was part of
 		// the index key or it isn't needed.
 		if log.V(3) {
-			log.Infof("Scan %s -> [%d] (skipped)", kv.Key, colID)
+			log.Infof(context.TODO(), "Scan %s -> [%d] (skipped)", kv.Key, colID)
 		}
 	}
 
@@ -415,7 +417,7 @@ func (rf *RowFetcher) processValueTuple(
 			}
 			tupleBytes = tupleBytes[i:]
 			if log.V(3) {
-				log.Infof("Scan %s -> [%d] (skipped)", kv.Key, colID)
+				log.Infof(context.TODO(), "Scan %s -> [%d] (skipped)", kv.Key, colID)
 			}
 			continue
 		}
@@ -437,7 +439,7 @@ func (rf *RowFetcher) processValueTuple(
 		}
 		rf.row[idx] = value
 		if log.V(3) {
-			log.Infof("Scan %d -> %v", idx, value)
+			log.Infof(context.TODO(), "Scan %d -> %v", idx, value)
 		}
 	}
 

--- a/sql/sqlbase/system.go
+++ b/sql/sqlbase/system.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/util/log"
+	"golang.org/x/net/context"
 )
 
 const (
@@ -127,19 +128,19 @@ func createSystemConfigTable(id ID, schema string) TableDescriptor {
 func createTableDescriptor(id, parentID ID, schema string, privileges *PrivilegeDescriptor) TableDescriptor {
 	stmt, err := parser.ParseOneTraditional(schema)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(context.TODO(), err)
 	}
 
 	desc, err := MakeTableDesc(stmt.(*parser.CreateTable), parentID)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(context.TODO(), err)
 	}
 
 	desc.Privileges = privileges
 
 	desc.ID = id
 	if err := desc.AllocateIDs(); err != nil {
-		log.Fatalf("%s: %v", desc.Name, err)
+		log.Fatalf(context.TODO(), "%s: %v", desc.Name, err)
 	}
 
 	return desc
@@ -151,7 +152,7 @@ func createDefaultZoneConfig() []roachpb.KeyValue {
 	value := roachpb.Value{}
 	desc := config.DefaultZoneConfig()
 	if err := value.SetProto(&desc); err != nil {
-		log.Fatalf("could not marshal %v", desc)
+		log.Fatalf(context.TODO(), "could not marshal %v", desc)
 	}
 	ret = append(ret, roachpb.KeyValue{
 		Key:   MakeZoneKey(keys.RootNamespaceID),

--- a/sql/table.go
+++ b/sql/table.go
@@ -21,6 +21,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -172,7 +174,7 @@ func (p *planner) mustGetTableDesc(qname *parser.QualifiedName) (*sqlbase.TableD
 // getTableLease implements the SchemaAccessor interface.
 func (p *planner) getTableLease(qname *parser.QualifiedName) (*sqlbase.TableDescriptor, error) {
 	if log.V(2) {
-		log.Infof("planner acquiring lease on table %q", qname)
+		log.Infof(context.TODO(), "planner acquiring lease on table %q", qname)
 	}
 	if err := qname.NormalizeTableName(p.session.Database); err != nil {
 		return nil, err
@@ -201,7 +203,7 @@ func (p *planner) getTableLease(qname *parser.QualifiedName) (*sqlbase.TableDesc
 			l.ParentID == dbID {
 			lease = l
 			if log.V(2) {
-				log.Infof("found lease in planner cache for table %q", qname)
+				log.Infof(context.TODO(), "found lease in planner cache for table %q", qname)
 			}
 			break
 		}
@@ -230,7 +232,7 @@ func (p *planner) getTableLease(qname *parser.QualifiedName) (*sqlbase.TableDesc
 // getTableLeaseByID is a by-ID variant of getTableLease (i.e. uses same cache).
 func (p *planner) getTableLeaseByID(tableID sqlbase.ID) (*sqlbase.TableDescriptor, error) {
 	if log.V(2) {
-		log.Infof("planner acquiring lease on table ID %d", tableID)
+		log.Infof(context.TODO(), "planner acquiring lease on table ID %d", tableID)
 	}
 
 	// First, look to see if we already have a lease for this table -- including
@@ -240,7 +242,7 @@ func (p *planner) getTableLeaseByID(tableID sqlbase.ID) (*sqlbase.TableDescripto
 		if l.ID == tableID {
 			lease = l
 			if log.V(2) {
-				log.Infof("found lease in planner cache for table %d", tableID)
+				log.Infof(context.TODO(), "found lease in planner cache for table %d", tableID)
 			}
 			break
 		}
@@ -282,7 +284,7 @@ func (p *planner) removeLeaseIfExpiring(lease *LeaseState) bool {
 		}
 	}
 	if idx == -1 {
-		log.Warningf("lease (%s) not found", lease)
+		log.Warningf(context.TODO(), "lease (%s) not found", lease)
 		return false
 	}
 	p.leases[idx] = p.leases[len(p.leases)-1]
@@ -290,7 +292,7 @@ func (p *planner) removeLeaseIfExpiring(lease *LeaseState) bool {
 	p.leases = p.leases[:len(p.leases)-1]
 
 	if err := p.leaseMgr.Release(lease); err != nil {
-		log.Warning(err)
+		log.Warning(context.TODO(), err)
 	}
 
 	// Reset the deadline so that a new deadline will be set after the lease is acquired.
@@ -359,12 +361,12 @@ func (p *planner) notifySchemaChange(id sqlbase.ID, mutationID sqlbase.MutationI
 // releaseLeases implements the SchemaAccessor interface.
 func (p *planner) releaseLeases() {
 	if log.V(2) {
-		log.Infof("planner releasing leases")
+		log.Infof(context.TODO(), "planner releasing leases")
 	}
 	if p.leases != nil {
 		for _, lease := range p.leases {
 			if err := p.leaseMgr.Release(lease); err != nil {
-				log.Warning(err)
+				log.Warning(context.TODO(), err)
 			}
 		}
 		p.leases = nil

--- a/sql/tablewriter.go
+++ b/sql/tablewriter.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -386,7 +388,7 @@ func (tu *tableUpserter) upsertRowPKs() ([]roachpb.Key, error) {
 			return nil, err
 		}
 		if log.V(2) {
-			log.Infof("Get %s\n", entry.Key)
+			log.Infof(context.TODO(), "Get %s\n", entry.Key)
 		}
 		b.Get(entry.Key)
 	}
@@ -519,13 +521,13 @@ func (td *tableDeleter) finalize() error {
 func (td *tableDeleter) fastPathAvailable() bool {
 	if len(td.rd.helper.indexes) != 0 {
 		if log.V(2) {
-			log.Infof("delete forced to scan: values required to update %d secondary indexes", len(td.rd.helper.indexes))
+			log.Infof(context.TODO(), "delete forced to scan: values required to update %d secondary indexes", len(td.rd.helper.indexes))
 		}
 		return false
 	}
 	if td.rd.helper.tableDesc.IsInterleaved() {
 		if log.V(2) {
-			log.Info("delete forced to scan: table is interleaved")
+			log.Info(context.TODO(), "delete forced to scan: table is interleaved")
 		}
 		return false
 	}
@@ -540,7 +542,7 @@ func (td *tableDeleter) fastDelete(
 ) (rowCount int, err error) {
 	for _, span := range scan.spans {
 		if log.V(2) {
-			log.Infof("Skipping scan and just deleting %s - %s", span.Start, span.End)
+			log.Infof(context.TODO(), "Skipping scan and just deleting %s - %s", span.Start, span.End)
 		}
 		td.b.DelRange(span.Start, span.End, true)
 	}

--- a/sql/truncate.go
+++ b/sql/truncate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/log"
+	"golang.org/x/net/context"
 )
 
 // Truncate deletes all rows from a table.
@@ -70,7 +71,7 @@ func truncateTable(tableDesc *sqlbase.TableDescriptor, txn *client.Txn) error {
 	tableStartKey := roachpb.Key(tablePrefix)
 	tableEndKey := tableStartKey.PrefixEnd()
 	if log.V(2) {
-		log.Infof("DelRange %s - %s", tableStartKey, tableEndKey)
+		log.Infof(context.TODO(), "DelRange %s - %s", tableStartKey, tableEndKey)
 	}
 	b := client.Batch{}
 	b.DelRange(tableStartKey, tableEndKey, false)

--- a/storage/addressing_test.go
+++ b/storage/addressing_test.go
@@ -178,16 +178,16 @@ func TestUpdateRangeAddressing(t *testing.T) {
 
 		if test.split {
 			if log.V(1) {
-				log.Infof("test case %d: split %q-%q at %q", i, left.StartKey, right.EndKey, left.EndKey)
+				log.Infof(context.TODO(), "test case %d: split %q-%q at %q", i, left.StartKey, right.EndKey, left.EndKey)
 			}
 		} else {
 			if log.V(1) {
-				log.Infof("test case %d: merge %q-%q + %q-%q", i, left.StartKey, left.EndKey, left.EndKey, right.EndKey)
+				log.Infof(context.TODO(), "test case %d: merge %q-%q + %q-%q", i, left.StartKey, left.EndKey, left.EndKey, right.EndKey)
 			}
 		}
 		for _, meta := range metas {
 			if log.V(1) {
-				log.Infof("%q", meta.key)
+				log.Infof(context.TODO(), "%q", meta.key)
 			}
 		}
 

--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -23,6 +23,8 @@ import (
 	"math/rand"
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
@@ -302,12 +304,12 @@ func (a *Allocator) ShouldRebalance(storeID roachpb.StoreID) bool {
 		return false
 	}
 	if log.V(2) {
-		log.Infof("ShouldRebalance from store %d", storeID)
+		log.Infof(context.TODO(), "ShouldRebalance from store %d", storeID)
 	}
 	storeDesc := a.storePool.getStoreDescriptor(storeID)
 	if storeDesc == nil {
 		if log.V(2) {
-			log.Warningf(
+			log.Warningf(context.TODO(),
 				"ShouldRebalance couldn't find store with id %d in StorePool",
 				storeID)
 		}

--- a/storage/balancer.go
+++ b/storage/balancer.go
@@ -19,6 +19,8 @@ package storage
 import (
 	"math"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -83,7 +85,7 @@ func (rcb rangeCountBalancer) improve(
 		(math.Abs(float64(store.Capacity.RangeCount-1)-sl.candidateCount.mean) >
 			math.Abs(float64(store.Capacity.RangeCount)-sl.candidateCount.mean)) {
 		if log.V(2) {
-			log.Infof("not rebalancing: source store %d wouldn't converge on the mean",
+			log.Infof(context.TODO(), "not rebalancing: source store %d wouldn't converge on the mean",
 				store.StoreID)
 		}
 		return nil
@@ -93,7 +95,7 @@ func (rcb rangeCountBalancer) improve(
 	candidate := rcb.selectGood(sl, excluded)
 	if candidate == nil {
 		if log.V(2) {
-			log.Infof("not rebalancing: no candidate targets (all stores nearly full?)")
+			log.Infof(context.TODO(), "not rebalancing: no candidate targets (all stores nearly full?)")
 		}
 		return nil
 	}
@@ -103,14 +105,14 @@ func (rcb rangeCountBalancer) improve(
 	if math.Abs(float64(candidate.Capacity.RangeCount+1)-sl.candidateCount.mean) >=
 		math.Abs(float64(candidate.Capacity.RangeCount)-sl.candidateCount.mean) {
 		if log.V(2) {
-			log.Infof("not rebalancing: candidate store %d wouldn't converge on the mean",
+			log.Infof(context.TODO(), "not rebalancing: candidate store %d wouldn't converge on the mean",
 				candidate.StoreID)
 		}
 		return nil
 	}
 
 	if log.V(2) {
-		log.Infof("found candidate store %d", candidate.StoreID)
+		log.Infof(context.TODO(), "found candidate store %d", candidate.StoreID)
 	}
 
 	return candidate

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -56,7 +56,7 @@ func createSplitRanges(store *storage.Store) (*roachpb.RangeDescriptor, *roachpb
 	rangeBDesc := store.LookupReplica([]byte("c"), nil).Desc()
 
 	if bytes.Equal(rangeADesc.StartKey, rangeBDesc.StartKey) {
-		log.Errorf("split ranges keys are equal %q!=%q", rangeADesc.StartKey, rangeBDesc.StartKey)
+		log.Errorf(context.TODO(), "split ranges keys are equal %q!=%q", rangeADesc.StartKey, rangeBDesc.StartKey)
 	}
 
 	return rangeADesc, rangeBDesc, nil
@@ -341,13 +341,13 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 	rangeCDesc := rangeC.Desc()
 
 	if bytes.Equal(rangeADesc.StartKey, rangeBDesc.StartKey) {
-		log.Errorf("split ranges keys are equal %q!=%q", rangeADesc.StartKey, rangeBDesc.StartKey)
+		log.Errorf(context.TODO(), "split ranges keys are equal %q!=%q", rangeADesc.StartKey, rangeBDesc.StartKey)
 	}
 	if bytes.Equal(rangeBDesc.StartKey, rangeCDesc.StartKey) {
-		log.Errorf("split ranges keys are equal %q!=%q", rangeBDesc.StartKey, rangeCDesc.StartKey)
+		log.Errorf(context.TODO(), "split ranges keys are equal %q!=%q", rangeBDesc.StartKey, rangeCDesc.StartKey)
 	}
 	if bytes.Equal(rangeADesc.StartKey, rangeCDesc.StartKey) {
-		log.Errorf("split ranges keys are equal %q!=%q", rangeADesc.StartKey, rangeCDesc.StartKey)
+		log.Errorf(context.TODO(), "split ranges keys are equal %q!=%q", rangeADesc.StartKey, rangeCDesc.StartKey)
 	}
 
 	// Replicate the ranges to different sets of stores. Ranges A and C

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -781,7 +781,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 			}
 			bytes, err := kv.Value.GetBytes()
 			if err != nil {
-				log.Info(err)
+				log.Info(context.TODO(), err)
 				continue
 			}
 			if err := txn.Put(kv.Key, bytes); err != nil {
@@ -1171,7 +1171,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 		if !reflect.DeepEqual(*forbiddenDesc, leaseReq.Lease.Replica) {
 			return nil
 		}
-		log.Infof("refusing %+v because %+v held lease for LHS of split",
+		log.Infof(context.TODO(), "refusing %+v because %+v held lease for LHS of split",
 			leaseReq, forbiddenDesc)
 		return roachpb.NewError(&roachpb.NotLeaseHolderError{RangeID: args.Hdr.RangeID})
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -812,13 +812,13 @@ func (m *multiTestContext) readIntFromEngines(key roachpb.Key) []int64 {
 	for i, eng := range m.engines {
 		val, _, err := engine.MVCCGet(context.Background(), eng, key, m.clock.Now(), true, nil)
 		if err != nil {
-			log.Errorf("engine %d: error reading from key %s: %s", i, key, err)
+			log.Errorf(context.TODO(), "engine %d: error reading from key %s: %s", i, key, err)
 		} else if val == nil {
-			log.Errorf("engine %d: missing key %s", i, key)
+			log.Errorf(context.TODO(), "engine %d: missing key %s", i, key)
 		} else {
 			results[i], err = val.GetInt()
 			if err != nil {
-				log.Errorf("engine %d: error decoding %s from key %s: %s", i, val, key, err)
+				log.Errorf(context.TODO(), "engine %d: error decoding %s from key %s: %s", i, val, key, err)
 			}
 		}
 	}

--- a/storage/engine/bench_test.go
+++ b/storage/engine/bench_test.go
@@ -88,7 +88,7 @@ func setupMVCCData(emk engineMaker, numVersions, numKeys, valueBytes int, b *tes
 		return eng, loc, stopper
 	}
 
-	log.Infof("creating mvcc data: %s", loc)
+	log.Infof(context.TODO(), "creating mvcc data: %s", loc)
 
 	// Generate the same data every time.
 	rng := rand.New(rand.NewSource(1449168817))
@@ -119,7 +119,7 @@ func setupMVCCData(emk engineMaker, numVersions, numKeys, valueBytes int, b *tes
 		// optimizations which change the data size result in the same number of
 		// sstables.
 		if scaled := len(order) / 20; i > 0 && (i%scaled) == 0 {
-			log.Infof("committing (%d/~%d)", i/scaled, 20)
+			log.Infof(context.TODO(), "committing (%d/~%d)", i/scaled, 20)
 			if err := batch.Commit(); err != nil {
 				b.Fatal(err)
 			}
@@ -472,7 +472,7 @@ func runMVCCComputeStats(emk engineMaker, valueBytes int, b *testing.B) {
 	}
 
 	b.StopTimer()
-	log.Infof("live_bytes: %d", stats.LiveBytes)
+	log.Infof(context.TODO(), "live_bytes: %d", stats.LiveBytes)
 }
 
 func BenchmarkMVCCPutDelete_RocksDB(b *testing.B) {

--- a/storage/engine/gc.go
+++ b/storage/engine/gc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
+	"golang.org/x/net/context"
 )
 
 // GarbageCollector GCs MVCC key/values using a zone-specific GC
@@ -70,7 +71,7 @@ func (gc GarbageCollector) Filter(keys []MVCCKey, values [][]byte) hlc.Timestamp
 	delTS := hlc.ZeroTimestamp
 	for i, key = range keys {
 		if !key.IsValue() {
-			log.Errorf("unexpected MVCC metadata encountered: %q", key)
+			log.Errorf(context.TODO(), "unexpected MVCC metadata encountered: %q", key)
 			return hlc.ZeroTimestamp
 		}
 		if gc.Threshold.Less(key.Timestamp) {

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1966,7 +1966,7 @@ func MVCCResolveWriteIntentRangeUsingIter(
 			err = mvccResolveWriteIntent(ctx, engine, iterAndBuf.iter, ms, intent, iterAndBuf.buf)
 		}
 		if err != nil {
-			log.Warningf("failed to resolve intent for key %q: %v", key.Key, err)
+			log.Warningf(context.TODO(), "failed to resolve intent for key %q: %v", key.Key, err)
 		} else {
 			num++
 			if max != 0 && max == num {
@@ -2110,7 +2110,7 @@ func MVCCFindSplitKey(
 		if debugFn != nil {
 			debugFn(msg, args...)
 		} else if log.V(2) {
-			log.Infof("FindSplitKey["+rangeID.String()+"] "+msg, args...)
+			log.Infof(context.TODO(), "FindSplitKey["+rangeID.String()+"] "+msg, args...)
 		}
 	}
 

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -3140,7 +3140,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 func TestMVCCStatsWithRandomRuns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	rng, seed := randutil.NewPseudoRand()
-	log.Infof("using pseudo random number generator with seed %d", seed)
+	log.Infof(context.TODO(), "using pseudo random number generator with seed %d", seed)
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
@@ -3158,7 +3158,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		lastWT = ts.WallTime
 
 		if log.V(1) {
-			log.Infof("*** cycle %d @ %s", i, ts)
+			log.Infof(context.TODO(), "*** cycle %d @ %s", i, ts)
 		}
 		// Manually advance aggregate intent age based on one extra second of simulation.
 		// Same for aggregate gc'able bytes age.
@@ -3177,14 +3177,14 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		if i > 0 && isDelete {
 			idx := rng.Int31n(i)
 			if log.V(1) {
-				log.Infof("*** DELETE index %d", idx)
+				log.Infof(context.TODO(), "*** DELETE index %d", idx)
 			}
 			if err := MVCCDelete(context.Background(), engine, ms, keys[idx], ts, txn); err != nil {
 				// Abort any write intent on an earlier, unresolved txn.
 				if wiErr, ok := err.(*roachpb.WriteIntentError); ok {
 					wiErr.Intents[0].Status = roachpb.ABORTED
 					if log.V(1) {
-						log.Infof("*** ABORT index %d", idx)
+						log.Infof(context.TODO(), "*** ABORT index %d", idx)
 					}
 					// Note that this already incorporates committing an intent
 					// at a later time (since we use a potentially later ts here
@@ -3194,7 +3194,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 					}
 					// Now, re-delete.
 					if log.V(1) {
-						log.Infof("*** RE-DELETE index %d", idx)
+						log.Infof(context.TODO(), "*** RE-DELETE index %d", idx)
 					}
 					if err := MVCCDelete(context.Background(), engine, ms, keys[idx], ts, txn); err != nil {
 						t.Fatal(err)
@@ -3206,7 +3206,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		} else {
 			rngVal := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, int(rng.Int31n(128))))
 			if log.V(1) {
-				log.Infof("*** PUT index %d; TXN=%t", i, txn != nil)
+				log.Infof(context.TODO(), "*** PUT index %d; TXN=%t", i, txn != nil)
 			}
 			if err := MVCCPut(context.Background(), engine, ms, key, ts, rngVal, txn); err != nil {
 				t.Fatal(err)
@@ -3218,7 +3218,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 				txn.Status = roachpb.ABORTED
 			}
 			if log.V(1) {
-				log.Infof("*** RESOLVE index %d; COMMIT=%t", i, txn.Status == roachpb.COMMITTED)
+				log.Infof(context.TODO(), "*** RESOLVE index %d; COMMIT=%t", i, txn.Status == roachpb.COMMITTED)
 			}
 			if err := MVCCResolveWriteIntent(context.Background(), engine, ms, roachpb.Intent{Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta}); err != nil {
 				t.Fatal(err)
@@ -3302,7 +3302,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 			t.Fatal(err)
 		}
 		for i, kv := range kvsn {
-			log.Infof("%d: %s", i, kv.Key)
+			log.Infof(context.TODO(), "%d: %s", i, kv.Key)
 		}
 	}
 

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -30,6 +30,8 @@ import (
 	"sync"
 	"unsafe"
 
+	"golang.org/x/net/context"
+
 	"github.com/dustin/go-humanize"
 	"github.com/elastic/gosigar"
 	"github.com/gogo/protobuf/proto"
@@ -66,7 +68,7 @@ const (
 )
 
 func init() {
-	rocksdb.Logger = log.Infof
+	rocksdb.Logger = func(format string, args ...interface{}) { log.Infof(context.TODO(), format, args...) }
 }
 
 // SSTableInfo contains metadata about a single RocksDB sstable. This mirrors
@@ -330,7 +332,7 @@ func (r *RocksDB) Open() error {
 
 	var ver storageVersion
 	if len(r.dir) != 0 {
-		log.Infof("opening rocksdb instance at %q", r.dir)
+		log.Infof(context.TODO(), "opening rocksdb instance at %q", r.dir)
 
 		// Check the version number.
 		var err error
@@ -344,7 +346,7 @@ func (r *RocksDB) Open() error {
 				versionCurrent, ver, versionMinimum)
 		}
 	} else {
-		log.Infof("opening in memory rocksdb instance")
+		log.Infof(context.TODO(), "opening in memory rocksdb instance")
 
 		// In memory dbs are always current.
 		ver = versionCurrent
@@ -384,15 +386,15 @@ func (r *RocksDB) Open() error {
 // Close closes the database by deallocating the underlying handle.
 func (r *RocksDB) Close() {
 	if r.rdb == nil {
-		log.Errorf("closing unopened rocksdb instance")
+		log.Errorf(context.TODO(), "closing unopened rocksdb instance")
 		return
 	}
 	if len(r.dir) == 0 {
 		if log.V(1) {
-			log.Infof("closing in-memory rocksdb instance")
+			log.Infof(context.TODO(), "closing in-memory rocksdb instance")
 		}
 	} else {
-		log.Infof("closing rocksdb instance at %q", r.dir)
+		log.Infof(context.TODO(), "closing rocksdb instance at %q", r.dir)
 	}
 	if r.rdb != nil {
 		C.DBClose(r.rdb)

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -117,7 +117,7 @@ func (*gcQueue) shouldQueue(now hlc.Timestamp, repl *Replica,
 	desc := repl.Desc()
 	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
 	if err != nil {
-		log.Errorf("could not find zone config for range %s: %s", repl, err)
+		log.Errorf(context.TODO(), "could not find zone config for range %s: %s", repl, err)
 		return
 	}
 
@@ -195,7 +195,7 @@ func processTransactionTable(
 				defer infoMu.Lock()
 				if err := resolveIntents(roachpb.AsIntents(txn.Intents, &txn),
 					true /* wait */, false /* !poison */); err != nil {
-					log.Warningf("failed to resolve intents of aborted txn on gc: %s", err)
+					log.Warningf(context.TODO(), "failed to resolve intents of aborted txn on gc: %s", err)
 				}
 			}()
 		case roachpb.COMMITTED:
@@ -206,7 +206,7 @@ func processTransactionTable(
 				defer infoMu.Lock()
 				return resolveIntents(roachpb.AsIntents(txn.Intents, &txn), true /* wait */, false /* !poison */)
 			}(); err != nil {
-				log.Warningf("unable to resolve intents of committed txn on gc: %s", err)
+				log.Warningf(context.TODO(), "unable to resolve intents of committed txn on gc: %s", err)
 				// Returning the error here would abort the whole GC run, and
 				// we don't want that. Instead, we simply don't GC this entry.
 				return nil
@@ -448,7 +448,7 @@ func RunGC(
 		if len(keys) > 1 {
 			meta := &enginepb.MVCCMetadata{}
 			if err := proto.Unmarshal(vals[0], meta); err != nil {
-				log.Errorf("unable to unmarshal MVCC metadata for key %q: %s", keys[0], err)
+				log.Errorf(context.TODO(), "unable to unmarshal MVCC metadata for key %q: %s", keys[0], err)
 			} else {
 				// In the event that there's an active intent, send for
 				// intent resolution if older than the threshold.
@@ -592,7 +592,7 @@ func pushTxn(repl *Replica, now hlc.Timestamp, txn *roachpb.Transaction,
 	b := &client.Batch{}
 	b.AddRawRequest(pushArgs)
 	if err := repl.store.DB().Run(b); err != nil {
-		log.Warningf("push of txn %s failed: %s", txn, err)
+		log.Warningf(context.TODO(), "push of txn %s failed: %s", txn, err)
 		return
 	}
 	br := b.RawResponse()

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -64,7 +64,7 @@ func TestGCQueueShouldQueue(t *testing.T) {
 	desc := tc.rng.Desc()
 	zone, err := cfg.GetZoneConfigForKey(desc.StartKey)
 	if err != nil {
-		log.Errorf("could not find GC policy for range %s: %s, got zone %+v",
+		log.Errorf(context.TODO(), "could not find GC policy for range %s: %s, got zone %+v",
 			tc.rng, err, zone)
 		return
 	}
@@ -312,7 +312,7 @@ func TestGCQueueProcess(t *testing.T) {
 	}
 	for i, kv := range kvs {
 		if log.V(1) {
-			log.Infof("%d: %s", i, kv.Key)
+			log.Infof(context.TODO(), "%d: %s", i, kv.Key)
 		}
 	}
 	if len(kvs) != len(expKVs) {
@@ -326,7 +326,7 @@ func TestGCQueueProcess(t *testing.T) {
 			t.Errorf("%d: expected ts=%s; got %s", i, expKVs[i].ts, kv.Key.Timestamp)
 		}
 		if log.V(1) {
-			log.Infof("%d: %s", i, kv.Key)
+			log.Infof(context.TODO(), "%d: %s", i, kv.Key)
 		}
 	}
 

--- a/storage/gossip_test.go
+++ b/storage/gossip_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/keys"
@@ -62,7 +64,7 @@ func TestGossipFirstRange(t *testing.T) {
 				if reflect.DeepEqual(desc, gossiped) {
 					return
 				}
-				log.Infof("expected\n%+v\nbut found\n%+v", desc, gossiped)
+				log.Infof(context.TODO(), "expected\n%+v\nbut found\n%+v", desc, gossiped)
 			}
 		}
 	}

--- a/storage/id_alloc.go
+++ b/storage/id_alloc.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -95,7 +97,7 @@ func (ia *idAllocator) start() {
 					if err := ia.stopper.RunTask(func() {
 						res, err = ia.db.Inc(idKey, int64(ia.blockSize))
 					}); err != nil {
-						log.Warning(err)
+						log.Warning(context.TODO(), err)
 						return
 					}
 					if err == nil {
@@ -103,7 +105,7 @@ func (ia *idAllocator) start() {
 						break
 					}
 
-					log.Warningf("unable to allocate %d ids from %s: %s", ia.blockSize, idKey, err)
+					log.Warningf(context.TODO(), "unable to allocate %d ids from %s: %s", ia.blockSize, idKey, err)
 				}
 				if err != nil {
 					panic(fmt.Sprintf("unexpectedly exited id allocation retry loop: %s", err))

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -224,7 +224,7 @@ func TestAllocateWithStopper(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	idAlloc, err := newIDAllocator(keys.RangeIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(context.TODO(), err)
 	}
 
 	stopper.Stop()

--- a/storage/intent_resolver.go
+++ b/storage/intent_resolver.go
@@ -83,7 +83,7 @@ func (ir *intentResolver) processWriteIntentError(ctx context.Context,
 	}
 
 	if log.V(6) {
-		log.Infoc(ctx, "resolving write intent %s", wiErr)
+		log.Infof(ctx, "resolving write intent %s", wiErr)
 	}
 
 	method := args.Method()
@@ -97,12 +97,12 @@ func (ir *intentResolver) processWriteIntentError(ctx context.Context,
 		// usually be returned here, although there are some cases
 		// when they may be (especially when a test cluster is in
 		// the process of shutting down).
-		log.Warningf("asynchronous resolveIntents failed: %s", resErr)
+		log.Warningf(context.TODO(), "asynchronous resolveIntents failed: %s", resErr)
 	}
 
 	if pushErr != nil {
 		if log.V(1) {
-			log.Infoc(ctx, "on %s: %s", method, pushErr)
+			log.Infof(ctx, "on %s: %s", method, pushErr)
 		}
 
 		if _, isExpected := pushErr.GetDetail().(*roachpb.TransactionPushError); !isExpected {
@@ -194,7 +194,7 @@ func (ir *intentResolver) maybePushTransactions(
 			// Another goroutine is working on this transaction so we can
 			// skip it.
 			if log.V(1) {
-				log.Infof("skipping PushTxn for %s; attempt already in flight", intent.Txn.ID)
+				log.Infof(context.TODO(), "skipping PushTxn for %s; attempt already in flight", intent.Txn.ID)
 			}
 			continue
 		} else {
@@ -299,15 +299,15 @@ func (ir *intentResolver) processIntentsAsync(r *Replica, intents []intentsWithA
 				// poison.
 				if err := ir.resolveIntents(ctxWithTimeout, r, resolveIntents,
 					true /* wait */, true /* poison */); err != nil {
-					log.Warningf("%s: failed to resolve intents: %s", r, err)
+					log.Warningf(context.TODO(), "%s: failed to resolve intents: %s", r, err)
 					return
 				}
 				if pushErr != nil {
-					log.Warningf("%s: failed to push during intent resolution: %s", r, pushErr)
+					log.Warningf(context.TODO(), "%s: failed to push during intent resolution: %s", r, pushErr)
 					return
 				}
 			}); err != nil {
-				log.Warningf("failed to resolve intents: %s", err)
+				log.Warningf(context.TODO(), "failed to resolve intents: %s", err)
 				return
 			}
 		} else { // EndTransaction
@@ -325,7 +325,7 @@ func (ir *intentResolver) processIntentsAsync(r *Replica, intents []intentsWithA
 				// not make it back to the client.
 				if err := ir.resolveIntents(ctxWithTimeout, r, item.intents,
 					true /* wait */, false /* !poison */); err != nil {
-					log.Warningf("%s: failed to resolve intents: %s", r, err)
+					log.Warningf(context.TODO(), "%s: failed to resolve intents: %s", r, err)
 					return
 				}
 
@@ -346,10 +346,10 @@ func (ir *intentResolver) processIntentsAsync(r *Replica, intents []intentsWithA
 				})
 				ba.Add(&gcArgs)
 				if _, pErr := r.addWriteCmd(ctxWithTimeout, ba, nil /* nil */); pErr != nil {
-					log.Warningf("could not GC completed transaction: %s", pErr)
+					log.Warningf(context.TODO(), "could not GC completed transaction: %s", pErr)
 				}
 			}); err != nil {
-				log.Warningf("failed to resolve intents: %s", err)
+				log.Warningf(context.TODO(), "failed to resolve intents: %s", err)
 				return
 			}
 		}
@@ -431,7 +431,7 @@ func (ir *intentResolver) resolveIntents(ctx context.Context, r *Replica,
 		wg.Add(1)
 		if wait || r.store.Stopper().RunLimitedAsyncTask(ir.sem, func() {
 			if err := action(); err != nil {
-				log.Warningf("unable to resolve local intents; %s", err)
+				log.Warningf(context.TODO(), "unable to resolve local intents; %s", err)
 			}
 		}) != nil {
 			// Still run the task when draining. Our caller already has a task and
@@ -455,7 +455,7 @@ func (ir *intentResolver) resolveIntents(ctx context.Context, r *Replica,
 		}
 		if wait || r.store.Stopper().RunLimitedAsyncTask(ir.sem, func() {
 			if err := action(); err != nil {
-				log.Warningf("unable to resolve external intents: %s", err)
+				log.Warningf(context.TODO(), "unable to resolve external intents: %s", err)
 			}
 		}) != nil {
 			// As with local intents, try async to not keep the caller waiting, but

--- a/storage/log.go
+++ b/storage/log.go
@@ -78,7 +78,7 @@ func (s *Store) insertRangeLogEvent(txn *client.Txn, event rangeLogEvent) error 
 	if event.info != nil {
 		info = *event.info
 	}
-	log.Infoc(txn.Context, "Range Event: %q, range: %d, info: %s",
+	log.Infof(txn.Context, "Range Event: %q, range: %d, info: %s",
 		event.eventType,
 		event.rangeID,
 		info)

--- a/storage/migration.go
+++ b/storage/migration.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 // MIGRATION(tschottdorf): As of #7310, we make sure that a Replica always has
@@ -50,7 +51,7 @@ func migrate7310And6991(batch engine.ReadWriter, desc roachpb.RangeDescriptor) e
 		if _, err := saveState(batch, state); err != nil {
 			return errors.Wrapf(err, "could not migrate TruncatedState to %+v", &state.TruncatedState)
 		}
-		log.Warningf("migration: synthesized TruncatedState for %+v", desc)
+		log.Warningf(context.TODO(), "migration: synthesized TruncatedState for %+v", desc)
 	}
 
 	hs, err := loadHardState(batch, desc.RangeID)

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -132,14 +132,14 @@ type queueLog struct {
 
 func (l queueLog) VInfof(logv bool, format string, a ...interface{}) {
 	if logv {
-		log.InfofDepth(1, l.prefix+format, a...)
+		log.InfofDepth(context.TODO(), 1, l.prefix+format, a...)
 	}
 	l.traceLog.Printf(format, a...)
 }
 
 func (l queueLog) Error(err error) {
 	const format = "%s"
-	log.ErrorfDepth(1, l.prefix+format, err)
+	log.ErrorfDepth(context.TODO(), 1, l.prefix+format, err)
 	l.traceLog.Errorf(format, err)
 }
 

--- a/storage/raft.go
+++ b/storage/raft.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util/log"
@@ -60,60 +62,60 @@ func (r *raftLogger) logPrefix() string {
 
 func (r *raftLogger) Debug(v ...interface{}) {
 	if log.V(3) {
-		log.InfofDepth(1, r.logPrefix(), v...)
+		log.InfofDepth(context.TODO(), 1, r.logPrefix(), v...)
 	}
 }
 
 func (r *raftLogger) Debugf(format string, v ...interface{}) {
 	if log.V(3) {
-		log.InfofDepth(1, r.logPrefix()+format, v...)
+		log.InfofDepth(context.TODO(), 1, r.logPrefix()+format, v...)
 	}
 }
 
 func (r *raftLogger) Info(v ...interface{}) {
 	if log.V(2) {
-		log.InfofDepth(1, r.logPrefix(), v...)
+		log.InfofDepth(context.TODO(), 1, r.logPrefix(), v...)
 	}
 }
 
 func (r *raftLogger) Infof(format string, v ...interface{}) {
 	if log.V(2) {
-		log.InfofDepth(1, r.logPrefix()+format, v...)
+		log.InfofDepth(context.TODO(), 1, r.logPrefix()+format, v...)
 	}
 }
 
 func (r *raftLogger) Warning(v ...interface{}) {
-	log.WarningfDepth(1, r.logPrefix(), v...)
+	log.WarningfDepth(context.TODO(), 1, r.logPrefix(), v...)
 }
 
 func (r *raftLogger) Warningf(format string, v ...interface{}) {
-	log.WarningfDepth(1, r.logPrefix()+format, v...)
+	log.WarningfDepth(context.TODO(), 1, r.logPrefix()+format, v...)
 }
 
 func (r *raftLogger) Error(v ...interface{}) {
-	log.ErrorfDepth(1, r.logPrefix(), v...)
+	log.ErrorfDepth(context.TODO(), 1, r.logPrefix(), v...)
 }
 
 func (r *raftLogger) Errorf(format string, v ...interface{}) {
-	log.ErrorfDepth(1, r.logPrefix()+format, v...)
+	log.ErrorfDepth(context.TODO(), 1, r.logPrefix()+format, v...)
 }
 
 func (r *raftLogger) Fatal(v ...interface{}) {
-	log.FatalfDepth(1, r.logPrefix(), v...)
+	log.FatalfDepth(context.TODO(), 1, r.logPrefix(), v...)
 }
 
 func (r *raftLogger) Fatalf(format string, v ...interface{}) {
-	log.FatalfDepth(1, r.logPrefix()+format, v...)
+	log.FatalfDepth(context.TODO(), 1, r.logPrefix()+format, v...)
 }
 
 func (r *raftLogger) Panic(v ...interface{}) {
 	s := fmt.Sprint(v...)
-	log.ErrorfDepth(1, s)
+	log.ErrorfDepth(context.TODO(), 1, s)
 	panic(s)
 }
 
 func (r *raftLogger) Panicf(format string, v ...interface{}) {
-	log.ErrorfDepth(1, r.logPrefix()+format, v...)
+	log.ErrorfDepth(context.TODO(), 1, r.logPrefix()+format, v...)
 	panic(fmt.Sprintf(r.logPrefix()+format, v...))
 }
 
@@ -124,24 +126,24 @@ func logRaftReady(storeID roachpb.StoreID, rangeID roachpb.RangeID, ready raft.R
 		// Globally synchronize to avoid interleaving different sets of logs in tests.
 		logRaftReadyMu.Lock()
 		defer logRaftReadyMu.Unlock()
-		log.Infof("store %d: range %d raft ready", storeID, rangeID)
+		log.Infof(context.TODO(), "store %d: range %d raft ready", storeID, rangeID)
 		if ready.SoftState != nil {
-			log.Infof("SoftState updated: %+v", *ready.SoftState)
+			log.Infof(context.TODO(), "SoftState updated: %+v", *ready.SoftState)
 		}
 		if !raft.IsEmptyHardState(ready.HardState) {
-			log.Infof("HardState updated: %+v", ready.HardState)
+			log.Infof(context.TODO(), "HardState updated: %+v", ready.HardState)
 		}
 		for i, e := range ready.Entries {
-			log.Infof("New Entry[%d]: %.200s", i, raft.DescribeEntry(e, raftEntryFormatter))
+			log.Infof(context.TODO(), "New Entry[%d]: %.200s", i, raft.DescribeEntry(e, raftEntryFormatter))
 		}
 		for i, e := range ready.CommittedEntries {
-			log.Infof("Committed Entry[%d]: %.200s", i, raft.DescribeEntry(e, raftEntryFormatter))
+			log.Infof(context.TODO(), "Committed Entry[%d]: %.200s", i, raft.DescribeEntry(e, raftEntryFormatter))
 		}
 		if !raft.IsEmptySnap(ready.Snapshot) {
-			log.Infof("Snapshot updated: %.200s", ready.Snapshot.String())
+			log.Infof(context.TODO(), "Snapshot updated: %.200s", ready.Snapshot.String())
 		}
 		for i, m := range ready.Messages {
-			log.Infof("Outgoing Message[%d]: %.200s", i, raft.DescribeMessage(m, raftEntryFormatter))
+			log.Infof(context.TODO(), "Outgoing Message[%d]: %.200s", i, raft.DescribeMessage(m, raftEntryFormatter))
 		}
 	}
 }

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -73,7 +73,7 @@ func getTruncatableIndexes(r *Replica) (uint64, uint64, error) {
 	raftStatus := r.RaftStatus()
 	if raftStatus == nil {
 		if log.V(1) {
-			log.Infof("the raft group doesn't exist for range %d", rangeID)
+			log.Infof(context.TODO(), "the raft group doesn't exist for range %d", rangeID)
 		}
 		return 0, 0, nil
 	}
@@ -141,7 +141,7 @@ func (*raftLogQueue) shouldQueue(
 ) (shouldQ bool, priority float64) {
 	truncatableIndexes, _, err := getTruncatableIndexes(r)
 	if err != nil {
-		log.Warning(err)
+		log.Warning(context.TODO(), err)
 		return false, 0
 	}
 
@@ -165,7 +165,7 @@ func (rlq *raftLogQueue) process(
 	// Can and should the raft logs be truncated?
 	if truncatableIndexes >= RaftLogQueueStaleThreshold {
 		if log.V(1) {
-			log.Infof("truncating the raft log of range %d to %d", r.RangeID, oldestIndex)
+			log.Infof(context.TODO(), "truncating the raft log of range %d to %d", r.RangeID, oldestIndex)
 		}
 		b := &client.Batch{}
 		b.AddRawRequest(&roachpb.TruncateLogRequest{

--- a/storage/replica_consistency_queue.go
+++ b/storage/replica_consistency_queue.go
@@ -62,7 +62,7 @@ func (q *replicaConsistencyQueue) process(
 	req := roachpb.CheckConsistencyRequest{}
 	_, pErr := rng.CheckConsistency(req, rng.Desc())
 	if pErr != nil {
-		log.Error(pErr.GoError())
+		log.Error(context.TODO(), pErr.GoError())
 	}
 	return nil
 }

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -78,7 +78,7 @@ func newReplicaGCQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *repl
 func (*replicaGCQueue) shouldQueue(now hlc.Timestamp, rng *Replica, _ config.SystemConfig) (bool, float64) {
 	lastCheck, err := rng.getLastReplicaGCTimestamp()
 	if err != nil {
-		log.Errorf("could not read last replica GC timestamp: %s", err)
+		log.Errorf(context.TODO(), "could not read last replica GC timestamp: %s", err)
 		return false, 0
 	}
 
@@ -167,7 +167,7 @@ func (q *replicaGCQueue) process(
 	if _, currentMember := replyDesc.GetReplicaDescriptor(rng.store.StoreID()); !currentMember {
 		// We are no longer a member of this range; clean up our local data.
 		if log.V(1) {
-			log.Infof("destroying local data from range %d", desc.RangeID)
+			log.Infof(context.TODO(), "destroying local data from range %d", desc.RangeID)
 		}
 		log.Trace(ctx, "destroying local data")
 		if err := rng.store.RemoveReplica(rng, replyDesc, true); err != nil {
@@ -179,7 +179,7 @@ func (q *replicaGCQueue) process(
 		// subsuming range. Shut down raft processing for the former range
 		// and delete any remaining metadata, but do not delete the data.
 		if log.V(1) {
-			log.Infof("removing merged range %d", desc.RangeID)
+			log.Infof(context.TODO(), "removing merged range %d", desc.RangeID)
 		}
 		log.Trace(ctx, "removing merged range")
 		if err := rng.store.RemoveReplica(rng, replyDesc, false); err != nil {

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -287,7 +287,7 @@ func (r *Replica) Snapshot() (raftpb.Snapshot, error) {
 		// state of the Replica). Everything must come from the snapshot.
 		snapData, err := snapshot(snap, rangeID, r.mu.state.Desc.StartKey)
 		if err != nil {
-			log.Errorf("%s: error generating snapshot: %s", r, err)
+			log.Errorf(context.TODO(), "%s: error generating snapshot: %s", r, err)
 		} else {
 			r.store.metrics.rangeSnapshotsGenerated.Inc(1)
 			select {
@@ -436,7 +436,7 @@ func snapshot(
 		return raftpb.Snapshot{}, errors.Errorf("failed to fetch term of %d: %s", appliedIndex, err)
 	}
 
-	log.Infof("generated snapshot for range %s at index %d in %s. encoded size=%d, %d KV pairs, %d log entries",
+	log.Infof(context.TODO(), "generated snapshot for range %s at index %d in %s. encoded size=%d, %d KV pairs, %d log entries",
 		rangeID, appliedIndex, timeutil.Since(start), len(data), len(snapData.KV), len(snapData.LogEntries))
 
 	return raftpb.Snapshot{
@@ -500,7 +500,7 @@ func (r *Replica) updateRangeInfo(desc *roachpb.RangeDescriptor) error {
 	if !ok {
 		// This could be before the system config was ever gossiped,
 		// or it expired. Let the gossip callback set the info.
-		log.Warningf("%s: no system config available, cannot determine range MaxBytes", r)
+		log.Warningf(context.TODO(), "%s: no system config available, cannot determine range MaxBytes", r)
 		return nil
 	}
 
@@ -563,12 +563,12 @@ func (r *Replica) applySnapshot(
 		snapType = "Raft"
 	}
 
-	log.Infof("%s: with replicaID %s, applying %s snapshot for range %d at index %d "+
+	log.Infof(context.TODO(), "%s: with replicaID %s, applying %s snapshot for range %d at index %d "+
 		"(encoded size=%d, %d KV pairs, %d log entries)",
 		r, replicaIDStr, snapType, desc.RangeID, snap.Metadata.Index,
 		len(snap.Data), len(snapData.KV), len(snapData.LogEntries))
 	defer func(start time.Time) {
-		log.Infof("%s: with replicaID %s, applied %s snapshot for range %d in %s",
+		log.Infof(context.TODO(), "%s: with replicaID %s, applied %s snapshot for range %d in %s",
 			r, replicaIDStr, snapType, desc.RangeID, timeutil.Since(start))
 	}(timeutil.Now())
 
@@ -635,7 +635,7 @@ func (r *Replica) applySnapshot(
 	// As outlined above, last and applied index are the same after applying
 	// the snapshot (i.e. the snapshot has no uncommitted tail).
 	if s.RaftAppliedIndex != snap.Metadata.Index {
-		log.Fatalf("%s with state loaded from %d: snapshot resulted in appliedIndex=%d, metadataIndex=%d",
+		log.Fatalf(context.TODO(), "%s with state loaded from %d: snapshot resulted in appliedIndex=%d, metadataIndex=%d",
 			r, s.Desc.RangeID, s.RaftAppliedIndex, snap.Metadata.Index)
 	}
 
@@ -729,7 +729,7 @@ const (
 
 func encodeRaftCommand(commandID string, command []byte) []byte {
 	if len(commandID) != raftCommandIDLen {
-		log.Fatalf("invalid command ID length; %d != %d", len(commandID), raftCommandIDLen)
+		log.Fatalf(context.TODO(), "invalid command ID length; %d != %d", len(commandID), raftCommandIDLen)
 	}
 	x := make([]byte, 1, 1+raftCommandIDLen+len(command))
 	x[0] = raftCommandEncodingVersion
@@ -745,7 +745,7 @@ func encodeRaftCommand(commandID string, command []byte) []byte {
 // but is exported for use by debugging tools.
 func DecodeRaftCommand(data []byte) (commandID string, command []byte) {
 	if data[0] != raftCommandEncodingVersion {
-		log.Fatalf("unknown command encoding version %v", data[0])
+		log.Fatalf(context.TODO(), "unknown command encoding version %v", data[0])
 	}
 	return string(data[1 : 1+raftCommandIDLen]), data[1+raftCommandIDLen:]
 }

--- a/storage/replica_range_lease.go
+++ b/storage/replica_range_lease.go
@@ -138,7 +138,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 			case c := <-ch:
 				if c.Err != nil {
 					if log.V(1) {
-						log.Infof("failed to acquire lease for replica %s: %s", replica.store, c.Err)
+						log.Infof(context.TODO(), "failed to acquire lease for replica %s: %s", replica.store, c.Err)
 					}
 					execPErr = c.Err
 				}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1625,7 +1625,7 @@ func TestLeaseConcurrent(t *testing.T) {
 					// Morally speaking, this is an error, but reproposals can
 					// happen and so we warn (in case this trips the test up
 					// in more unexpected ways).
-					log.Infof("reproposal of %+v", ll)
+					log.Infof(context.TODO(), "reproposal of %+v", ll)
 				}
 				go func() {
 					wg.Wait()
@@ -5828,7 +5828,7 @@ func runWrongIndexTest(t *testing.T, repropose bool, withErr bool, expProposals 
 
 	wrongIndex := ai - 1 // will chose this as MaxLeaseIndex
 
-	log.Infof("test begins")
+	log.Infof(context.TODO(), "test begins")
 
 	var ba roachpb.BatchRequest
 	ba.Timestamp = tc.clock.Now()
@@ -5951,7 +5951,7 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 			// the command and it isn't reproposed due to the
 			// client abandoning it.
 			if rand.Intn(2) == 0 {
-				log.Infof("abandoning command %d", i)
+				log.Infof(context.TODO(), "abandoning command %d", i)
 				delete(rng.mu.pendingCmds, cmd.idKey)
 			} else if err := rng.proposePendingCmdLocked(cmd); err != nil {
 				t.Fatal(err)

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -97,7 +97,7 @@ func (rq *replicateQueue) shouldQueue(
 	desc := repl.Desc()
 	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
 	if err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		return
 	}
 
@@ -146,7 +146,7 @@ func (rq *replicateQueue) process(
 		}
 
 		if log.V(1) {
-			log.Infof("%s: adding replica to %+v due to under-replication", repl, newReplica)
+			log.Infof(context.TODO(), "%s: adding replica to %+v due to under-replication", repl, newReplica)
 		}
 		log.Trace(ctx, fmt.Sprintf("adding replica to %+v due to under-replication", newReplica))
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, newReplica, desc); err != nil {
@@ -164,7 +164,7 @@ func (rq *replicateQueue) process(
 			return err
 		}
 		if log.V(1) {
-			log.Infof("%s: removing replica %+v due to over-replication", repl, removeReplica)
+			log.Infof(context.TODO(), "%s: removing replica %+v due to over-replication", repl, removeReplica)
 		}
 		log.Trace(ctx, fmt.Sprintf("removing replica %+v due to over-replication", removeReplica))
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, removeReplica, desc); err != nil {
@@ -178,13 +178,13 @@ func (rq *replicateQueue) process(
 		log.Trace(ctx, "removing a dead replica")
 		if len(deadReplicas) == 0 {
 			if log.V(1) {
-				log.Warningf("Range of replica %s was identified as having dead replicas, but no dead replicas were found.", repl)
+				log.Warningf(context.TODO(), "Range of replica %s was identified as having dead replicas, but no dead replicas were found.", repl)
 			}
 			break
 		}
 		deadReplica := deadReplicas[0]
 		if log.V(1) {
-			log.Infof("%s: removing replica %+v from dead store", repl, deadReplica)
+			log.Infof(context.TODO(), "%s: removing replica %+v from dead store", repl, deadReplica)
 		}
 		log.Trace(ctx, fmt.Sprintf("removing replica %+v from dead store", deadReplica))
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, deadReplica, desc); err != nil {
@@ -197,7 +197,7 @@ func (rq *replicateQueue) process(
 		rebalanceStore := rq.allocator.RebalanceTarget(repl.store.StoreID(), zone.ReplicaAttrs[0], desc.Replicas)
 		if rebalanceStore == nil {
 			if log.V(1) {
-				log.Infof("%s: no suitable rebalance target", repl)
+				log.Infof(context.TODO(), "%s: no suitable rebalance target", repl)
 			}
 			log.Trace(ctx, "no suitable rebalance target")
 			// No action was necessary and no rebalance target was found. Return
@@ -209,7 +209,7 @@ func (rq *replicateQueue) process(
 			StoreID: rebalanceStore.StoreID,
 		}
 		if log.V(1) {
-			log.Infof("%s: rebalancing to %+v", repl, rebalanceReplica)
+			log.Infof(context.TODO(), "%s: rebalancing to %+v", repl, rebalanceReplica)
 		}
 		log.Trace(ctx, fmt.Sprintf("rebalancing to %+v", rebalanceReplica))
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, rebalanceReplica, desc); err != nil {

--- a/storage/scanner.go
+++ b/storage/scanner.go
@@ -21,6 +21,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -82,7 +84,7 @@ type replicaScanner struct {
 // loop that function will be called.
 func newReplicaScanner(targetInterval, maxIdleTime time.Duration, replicas replicaSet) *replicaScanner {
 	if targetInterval <= 0 {
-		log.Fatalf("scanner interval must be greater than zero")
+		log.Fatalf(context.TODO(), "scanner interval must be greater than zero")
 	}
 	return &replicaScanner{
 		targetInterval: targetInterval,
@@ -157,7 +159,7 @@ func (rs *replicaScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stop
 	waitInterval := rs.paceInterval(start, timeutil.Now())
 	rs.waitTimer.Reset(waitInterval)
 	if log.V(6) {
-		log.Infof("Wait time interval set to %s", waitInterval)
+		log.Infof(context.TODO(), "Wait time interval set to %s", waitInterval)
 	}
 	for {
 		select {
@@ -184,7 +186,7 @@ func (rs *replicaScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stop
 				q.MaybeRemove(repl)
 			}
 			if log.V(6) {
-				log.Infof("removed replica %s", repl)
+				log.Infof(context.TODO(), "removed replica %s", repl)
 			}
 
 		case <-stopper.ShouldStop():
@@ -224,7 +226,7 @@ func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 				rs.completedScan.Broadcast()
 				rs.completedScan.L.Unlock()
 				if log.V(6) {
-					log.Infof("reset replica scan iteration")
+					log.Infof(context.TODO(), "reset replica scan iteration")
 				}
 
 				// Reset iteration and start time.

--- a/storage/scanner_test.go
+++ b/storage/scanner_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/google/btree"
 	"github.com/pkg/errors"
 
@@ -253,7 +255,7 @@ func TestScannerTiming(t *testing.T) {
 			stopper.Stop()
 
 			avg := s.avgScan()
-			log.Infof("%d: average scan: %s", i, avg)
+			log.Infof(context.TODO(), "%d: average scan: %s", i, avg)
 			if avg.Nanoseconds()-duration.Nanoseconds() > maxError.Nanoseconds() ||
 				duration.Nanoseconds()-avg.Nanoseconds() > maxError.Nanoseconds() {
 				return errors.Errorf("expected %s, got %s: exceeds max error of %s", duration, avg, maxError)

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -75,7 +75,7 @@ func (*splitQueue) shouldQueue(now hlc.Timestamp, rng *Replica,
 	// size for the zone it's in.
 	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
 	if err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		return
 	}
 
@@ -97,7 +97,7 @@ func (sq *splitQueue) process(
 	desc := rng.Desc()
 	splitKeys := sysCfg.ComputeSplitKeys(desc.StartKey, desc.EndKey)
 	if len(splitKeys) > 0 {
-		log.Infof("splitting %s at keys %v", rng, splitKeys)
+		log.Infof(context.TODO(), "splitting %s at keys %v", rng, splitKeys)
 		log.Trace(ctx, fmt.Sprintf("splitting at keys %v", splitKeys))
 		for _, splitKey := range splitKeys {
 			if err := sq.db.AdminSplit(splitKey.AsRawKey()); err != nil {
@@ -115,7 +115,7 @@ func (sq *splitQueue) process(
 	size := rng.GetMVCCStats().Total()
 	// FIXME: why is this implementation not the same as the one above?
 	if float64(size)/float64(zone.RangeMaxBytes) > 1 {
-		log.Infof("splitting %s size=%d max=%d", rng, size, zone.RangeMaxBytes)
+		log.Infof(context.TODO(), "splitting %s size=%d max=%d", rng, size, zone.RangeMaxBytes)
 		log.Trace(ctx, fmt.Sprintf("splitting size=%d max=%d", size, zone.RangeMaxBytes))
 		if _, pErr := client.SendWrappedWith(rng, ctx, roachpb.Header{
 			Timestamp: now,

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -77,7 +77,7 @@ func (sd *storeDetail) markDead(foundDeadOn hlc.Timestamp) {
 	if sd.desc != nil {
 		// sd.desc can still be nil if it was markedAlive and enqueued in getStoreDetailLocked
 		// and never markedAlive again.
-		log.Warningf("store %s on node %s is now considered offline", sd.desc.StoreID, sd.desc.Node.NodeID)
+		log.Warningf(context.TODO(), "store %s on node %s is now considered offline", sd.desc.StoreID, sd.desc.Node.NodeID)
 	}
 }
 
@@ -239,7 +239,7 @@ func NewStorePool(
 func (sp *StorePool) storeGossipUpdate(_ string, content roachpb.Value) {
 	var storeDesc roachpb.StoreDescriptor
 	if err := content.GetProto(&storeDesc); err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 		return
 	}
 
@@ -465,7 +465,7 @@ func (sp *StorePool) reserve(
 	}
 
 	if log.V(2) {
-		log.Infof("proposing new reservation:%+v", req)
+		log.Infof(context.TODO(), "proposing new reservation:%+v", req)
 	}
 
 	ctxWithTimeout, cancel := context.WithTimeout(context.TODO(), sp.reserveRPCTimeout)
@@ -479,7 +479,7 @@ func (sp *StorePool) reserve(
 	if err != nil {
 		detail.throttledUntil = sp.clock.Now().GoTime().Add(sp.failedReservationsTimeout)
 		if log.V(2) {
-			log.Infof("reservation failed, store:%s will be throttled for %s until %s",
+			log.Infof(context.TODO(), "reservation failed, store:%s will be throttled for %s until %s",
 				toStoreID, sp.failedReservationsTimeout, detail.throttledUntil)
 		}
 		return errors.Wrapf(err, "reservation failed:%+v", req)
@@ -487,14 +487,14 @@ func (sp *StorePool) reserve(
 	if !resp.Reserved {
 		detail.throttledUntil = sp.clock.Now().GoTime().Add(sp.declinedReservationsTimeout)
 		if log.V(2) {
-			log.Infof("reservation failed, store:%s will be throttled for %s until %s",
+			log.Infof(context.TODO(), "reservation failed, store:%s will be throttled for %s until %s",
 				toStoreID, sp.declinedReservationsTimeout, detail.throttledUntil)
 		}
 		return errors.Errorf("reservation declined:%+v", req)
 	}
 
 	if log.V(2) {
-		log.Infof("reservation was approved:%+v", req)
+		log.Infof(context.TODO(), "reservation was approved:%+v", req)
 	}
 	return nil
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -290,7 +290,7 @@ func createRange(s *Store, rangeID roachpb.RangeID, start, end roachpb.RKey) *Re
 	}
 	r, err := NewReplica(desc, s, 0)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(context.TODO(), err)
 	}
 	return r
 }

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -99,7 +99,7 @@ func (ls *Stores) AddStore(s *Store) {
 	// all stores have the most recent values.
 	if !ls.biLatestTS.Equal(hlc.ZeroTimestamp) {
 		if err := ls.updateBootstrapInfo(ls.latestBI); err != nil {
-			log.Errorf("failed to update bootstrap info on newly added store: %s", err)
+			log.Errorf(context.TODO(), "failed to update bootstrap info on newly added store: %s", err)
 		}
 	}
 }
@@ -195,7 +195,7 @@ func (ls *Stores) LookupReplica(start, end roachpb.RKey) (rangeID roachpb.RangeI
 		rng = store.LookupReplica(start, end)
 		if rng == nil {
 			if tmpRng := store.LookupReplica(start, nil); tmpRng != nil {
-				log.Warningf("range not contained in one range: [%s,%s), but have [%s,%s)",
+				log.Warningf(context.TODO(), "range not contained in one range: [%s,%s), but have [%s,%s)",
 					start, end, tmpRng.Desc().StartKey, tmpRng.Desc().EndKey)
 				partialDesc = tmpRng.Desc()
 				break
@@ -292,7 +292,7 @@ func (ls *Stores) ReadBootstrapInfo(bi *gossip.BootstrapInfo) error {
 			*bi = storeBI
 		}
 	}
-	log.Infof("read %d node addresses from persistent storage", len(bi.Addresses))
+	log.Infof(context.TODO(), "read %d node addresses from persistent storage", len(bi.Addresses))
 	return ls.updateBootstrapInfo(bi)
 }
 
@@ -307,7 +307,7 @@ func (ls *Stores) WriteBootstrapInfo(bi *gossip.BootstrapInfo) error {
 	if err := ls.updateBootstrapInfo(bi); err != nil {
 		return err
 	}
-	log.Infof("wrote %d node addresses to persistent storage", len(bi.Addresses))
+	log.Infof(context.TODO(), "wrote %d node addresses to persistent storage", len(bi.Addresses))
 	return nil
 }
 

--- a/storage/verify_queue.go
+++ b/storage/verify_queue.go
@@ -68,7 +68,7 @@ func (*verifyQueue) shouldQueue(now hlc.Timestamp, rng *Replica,
 	// Get last verification timestamp.
 	lastVerify, err := rng.getLastVerificationTimestamp()
 	if err != nil {
-		log.Errorf("unable to fetch last verification timestamp: %s", err)
+		log.Errorf(context.TODO(), "unable to fetch last verification timestamp: %s", err)
 		return
 	}
 	verifyScore := float64(now.WallTime-lastVerify.WallTime) / float64(verificationInterval.Nanoseconds())
@@ -103,7 +103,7 @@ func (*verifyQueue) process(
 		// TODO(spencer): do something other than fatal error here. We
 		// want to quarantine this range, make it a non-participating raft
 		// follower until it can be replaced and then destroyed.
-		log.Fatalf("unhandled failure when scanning range %s; probable data corruption: %s", rng, iter.Error())
+		log.Fatalf(context.TODO(), "unhandled failure when scanning range %s; probable data corruption: %s", rng, iter.Error())
 	}
 
 	// Store current timestamp as last verification for this range.

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -309,7 +309,7 @@ func (tc *TestCluster) AddReplicas(
 			// snapshot has been transferred and the descriptor initialized.
 			store, err := tc.findMemberStore(target.StoreID)
 			if err != nil {
-				log.Errorf("unexpected error: %s", err)
+				log.Errorf(context.TODO(), "unexpected error: %s", err)
 				return err
 			}
 			if store.LookupReplica(rKey, nil) == nil {
@@ -338,7 +338,7 @@ func (tc *TestCluster) TransferRangeLease(
 ) error {
 	destReplicaDesc, ok := rangeDesc.GetReplicaDescriptor(dest.StoreID)
 	if !ok {
-		log.Fatalf("Couldn't find store %d in range %+v", dest.StoreID, rangeDesc)
+		log.Fatalf(context.TODO(), "Couldn't find store %d in range %+v", dest.StoreID, rangeDesc)
 	}
 
 	leaseHolderDesc, err := tc.FindRangeLeaseHolder(rangeDesc,

--- a/testutils/testcluster/testcluster_test.go
+++ b/testutils/testcluster/testcluster_test.go
@@ -20,6 +20,8 @@ package testcluster
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -63,7 +65,7 @@ func TestManualReplication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Infof("After split got ranges: %+v and %+v.", leftRangeDesc, tableRangeDesc)
+	log.Infof(context.TODO(), "After split got ranges: %+v and %+v.", leftRangeDesc, tableRangeDesc)
 	if len(tableRangeDesc.Replicas) == 0 {
 		t.Fatalf(
 			"expected replica on node 1, got no replicas: %+v", tableRangeDesc.Replicas)

--- a/ts/db.go
+++ b/ts/db.go
@@ -19,6 +19,8 @@ package ts
 import (
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/ts/tspb"
@@ -96,10 +98,10 @@ func (p *poller) poll() {
 		}
 
 		if err := p.db.StoreData(p.r, data); err != nil {
-			log.Warningf("error writing time series data: %s", err)
+			log.Warningf(context.TODO(), "error writing time series data: %s", err)
 		}
 	}); err != nil {
-		log.Warning(err)
+		log.Warning(context.TODO(), err)
 	}
 }
 

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"golang.org/x/net/context"
+
 	"github.com/biogo/store/llrb"
 
 	"github.com/cockroachdb/cockroach/util/interval"
@@ -514,14 +516,14 @@ func (ic *IntervalCache) doGet(i interval.Interface) bool {
 
 func (ic *IntervalCache) add(e *Entry) {
 	if err := ic.tree.Insert(e, false); err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 	}
 }
 
 func (ic *IntervalCache) del(key interface{}) {
 	ic.tmpEntry.Key = key
 	if err := ic.tree.Delete(&ic.tmpEntry, false); err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 	}
 }
 

--- a/util/envutil/env.go
+++ b/util/envutil/env.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -132,7 +134,7 @@ func EnvOrDefaultBool(name string, value bool) bool {
 	if str, present := getEnv(name); present {
 		v, err := strconv.ParseBool(str)
 		if err != nil {
-			log.Errorf("error parsing %s: %s", VarName(name), err)
+			log.Errorf(context.TODO(), "error parsing %s: %s", VarName(name), err)
 			return value
 		}
 		return v
@@ -146,7 +148,7 @@ func EnvOrDefaultInt(name string, value int) int {
 	if str, present := getEnv(name); present {
 		v, err := strconv.ParseInt(str, 0, 0)
 		if err != nil {
-			log.Errorf("error parsing %s: %s", VarName(name), err)
+			log.Errorf(context.TODO(), "error parsing %s: %s", VarName(name), err)
 			return value
 		}
 		return int(v)
@@ -160,7 +162,7 @@ func EnvOrDefaultInt64(name string, value int64) int64 {
 	if str, present := getEnv(name); present {
 		v, err := strconv.ParseInt(str, 0, 64)
 		if err != nil {
-			log.Errorf("error parsing %s: %s", VarName(name), err)
+			log.Errorf(context.TODO(), "error parsing %s: %s", VarName(name), err)
 			return value
 		}
 		return v
@@ -174,7 +176,7 @@ func EnvOrDefaultBytes(name string, value int64) int64 {
 	if str, present := getEnv(name); present {
 		v, err := humanizeutil.ParseBytes(str)
 		if err != nil {
-			log.Errorf("error parsing %s: %s", VarName(name), err)
+			log.Errorf(context.TODO(), "error parsing %s: %s", VarName(name), err)
 			return value
 		}
 		return v
@@ -188,7 +190,7 @@ func EnvOrDefaultDuration(name string, value time.Duration) time.Duration {
 	if str, present := getEnv(name); present {
 		v, err := time.ParseDuration(str)
 		if err != nil {
-			log.Errorf("error parsing %s: %s", VarName(name), err)
+			log.Errorf(context.TODO(), "error parsing %s: %s", VarName(name), err)
 			return value
 		}
 		return v

--- a/util/grpcutil/log.go
+++ b/util/grpcutil/log.go
@@ -18,6 +18,7 @@
 package grpcutil
 
 import (
+	"golang.org/x/net/context"
 	"google.golang.org/grpc/grpclog"
 
 	"github.com/cockroachdb/cockroach/util/log"
@@ -40,25 +41,25 @@ var _ grpclog.Logger = (*logger)(nil)
 type logger struct{}
 
 func (*logger) Fatal(args ...interface{}) {
-	log.FatalfDepth(2, "", args...)
+	log.FatalfDepth(context.TODO(), 2, "", args...)
 }
 
 func (*logger) Fatalf(format string, args ...interface{}) {
-	log.FatalfDepth(2, format, args...)
+	log.FatalfDepth(context.TODO(), 2, format, args...)
 }
 
 func (*logger) Fatalln(args ...interface{}) {
-	log.FatalfDepth(2, "", args...)
+	log.FatalfDepth(context.TODO(), 2, "", args...)
 }
 
 func (*logger) Print(args ...interface{}) {
-	log.InfofDepth(2, "", args...)
+	log.InfofDepth(context.TODO(), 2, "", args...)
 }
 
 func (*logger) Printf(format string, args ...interface{}) {
-	log.InfofDepth(2, format, args...)
+	log.InfofDepth(context.TODO(), 2, format, args...)
 }
 
 func (*logger) Println(args ...interface{}) {
-	log.InfofDepth(2, "", args...)
+	log.InfofDepth(context.TODO(), 2, "", args...)
 }

--- a/util/hlc/hlc.go
+++ b/util/hlc/hlc.go
@@ -25,6 +25,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/timeutil"
 )
@@ -162,7 +164,7 @@ func (c *Clock) getPhysicalClock() int64 {
 		interval := c.lastPhysicalTime - newTime
 		if interval > int64(c.maxOffset/10) {
 			c.monotonicityErrorsCount++
-			log.Warningf("backward time jump detected (%f seconds)", float64(newTime-c.lastPhysicalTime)/1e9)
+			log.Warningf(context.TODO(), "backward time jump detected (%f seconds)", float64(newTime-c.lastPhysicalTime)/1e9)
 		}
 	}
 
@@ -233,7 +235,7 @@ func (c *Clock) Update(rt Timestamp) Timestamp {
 	if rt.WallTime > c.state.WallTime {
 		offset := time.Duration(rt.WallTime-physicalClock) * time.Nanosecond
 		if c.maxOffset > 0 && offset > c.maxOffset {
-			log.Warningf("remote wall time is too far ahead (%s) to be trustworthy - updating anyway", offset)
+			log.Warningf(context.TODO(), "remote wall time is too far ahead (%s) to be trustworthy - updating anyway", offset)
 		}
 		// The remote clock is ahead of ours, and we update
 		// our own logical clock with theirs.

--- a/util/hlc/hlc_test.go
+++ b/util/hlc/hlc_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
@@ -47,15 +49,15 @@ func ExampleNewClock() {
 	// The sanity checks below will usually never be triggered.
 
 	if s.Less(t) || !t.Less(s) {
-		log.Fatalf("The later timestamp is smaller than the earlier one")
+		log.Fatalf(context.TODO(), "The later timestamp is smaller than the earlier one")
 	}
 
 	if t.WallTime-s.WallTime > 0 {
-		log.Fatalf("HLC timestamp %d deviates from physical clock %d", s, t)
+		log.Fatalf(context.TODO(), "HLC timestamp %d deviates from physical clock %d", s, t)
 	}
 
 	if s.Logical > 0 {
-		log.Fatalf("Trivial timestamp has logical component")
+		log.Fatalf(context.TODO(), "Trivial timestamp has logical component")
 	}
 
 	fmt.Printf("The Unix Epoch is now approximately %dns old.\n", t.WallTime)

--- a/util/log/clog_test.go
+++ b/util/log/clog_test.go
@@ -101,7 +101,7 @@ func setFlags() {
 func TestInfo(t *testing.T) {
 	setFlags()
 	defer logging.swap(logging.newBuffers())
-	Info("test")
+	Info(context.Background(), "test")
 	if !contains(InfoLog, "I", t) {
 		t.Errorf("Info has wrong character: %q", contents(InfoLog))
 	}
@@ -217,7 +217,7 @@ func TestEntryDecoder(t *testing.T) {
 func TestError(t *testing.T) {
 	setFlags()
 	defer logging.swap(logging.newBuffers())
-	Error("test")
+	Error(context.Background(), "test")
 	if !contains(ErrorLog, "E", t) {
 		t.Errorf("Error has wrong character: %q", contents(ErrorLog))
 	}
@@ -239,7 +239,7 @@ func TestError(t *testing.T) {
 func TestWarning(t *testing.T) {
 	setFlags()
 	defer logging.swap(logging.newBuffers())
-	Warning("test")
+	Warning(context.Background(), "test")
 	if !contains(WarningLog, "W", t) {
 		t.Errorf("Warning has wrong character: %q", contents(WarningLog))
 	}
@@ -353,8 +353,8 @@ func TestVmoduleGlob(t *testing.T) {
 func TestListLogFiles(t *testing.T) {
 	setFlags()
 
-	Info("x")    // Be sure we have a file.
-	Warning("x") // Be sure we have a file.
+	Info(context.Background(), "x")    // Be sure we have a file.
+	Warning(context.Background(), "x") // Be sure we have a file.
 	var info, warn *syncBuffer
 	var ok bool
 	info, ok = logging.file[InfoLog].(*syncBuffer)
@@ -388,7 +388,7 @@ func TestListLogFiles(t *testing.T) {
 
 func TestGetLogReader(t *testing.T) {
 	setFlags()
-	Warning("x")
+	Warning(context.Background(), "x")
 	warn, ok := logging.file[WarningLog].(*syncBuffer)
 	if !ok {
 		t.Fatal("warning wasn't created")
@@ -473,7 +473,7 @@ func TestRollover(t *testing.T) {
 	defer func(previous uint64) { MaxSize = previous }(MaxSize)
 	MaxSize = 1024
 
-	Info("x") // Be sure we have a file.
+	Info(context.Background(), "x") // Be sure we have a file.
 	info, ok := logging.file[InfoLog].(*syncBuffer)
 	if !ok {
 		t.Fatal("info wasn't created")
@@ -482,7 +482,7 @@ func TestRollover(t *testing.T) {
 		t.Fatalf("info has initial error: %v", err)
 	}
 	fname0 := info.file.Name()
-	Info(strings.Repeat("x", int(MaxSize))) // force a rollover
+	Info(context.Background(), strings.Repeat("x", int(MaxSize))) // force a rollover
 	if err != nil {
 		t.Fatalf("info has error after big write: %v", err)
 	}
@@ -495,7 +495,7 @@ func TestRollover(t *testing.T) {
 	// handle Daylight Savings Time properly).
 	time.Sleep(1 * time.Second)
 
-	Info("x") // create a new file
+	Info(context.Background(), "x") // create a new file
 	if err != nil {
 		t.Fatalf("error after rotation: %v", err)
 	}
@@ -526,7 +526,7 @@ func TestLogBacktraceAt(t *testing.T) {
 		// Start of tracing block. These lines know about each other's relative position.
 		file, line, _ := caller.Lookup(0)
 		setTraceLocation(file, line, +2) // Two lines between Caller and Info calls.
-		Info("we want a stack trace here")
+		Info(context.Background(), "we want a stack trace here")
 		if err := logging.traceLocation.Set(""); err != nil {
 			t.Fatal(err)
 		}
@@ -561,7 +561,7 @@ func TestFatalStacktraceStderr(t *testing.T) {
 
 	for _, level := range []int{tracebackNone, tracebackSingle, tracebackAll} {
 		traceback = level
-		Fatalf("cinap")
+		Fatalf(context.Background(), "cinap")
 		cont := contents(FatalLog)
 		if !strings.Contains(cont, " cinap") {
 			t.Fatalf("panic output does not contain cinap:\n%s", cont)

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -39,7 +39,7 @@ func init() {
 // panics and ignoring them.
 func FatalOnPanic() {
 	if r := recover(); r != nil {
-		Fatalf("unexpected panic: %s", r)
+		Fatalf(context.Background(), "unexpected panic: %s", r)
 	}
 }
 
@@ -81,118 +81,107 @@ func logDepth(ctx context.Context, depth int, sev Severity, format string, args 
 	addStructured(ctx, sev, depth+1, format, args)
 }
 
-// Infoc logs to the WARNING and INFO logs. It extracts values from the context
-// using the Field keys specified in this package and logs them along with the
-// given message and any additional pairs specified as consecutive elements in
-// kvs.
-func Infoc(ctx context.Context, format string, args ...interface{}) {
+// Infof logs to the INFO log.
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Printf; a newline is
+// appended.
+func Infof(ctx context.Context, format string, args ...interface{}) {
 	logDepth(ctx, 1, InfoLog, format, args)
 }
 
 // Info logs to the INFO log.
-// Arguments are handled in the manner of fmt.Print; a newline is appended.
-func Info(args ...interface{}) {
-	logDepth(context.Background(), 1, InfoLog, "", args)
-}
-
-// Infof logs to the INFO log. Don't use it; use Info or Infoc instead.
-// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
-func Infof(format string, args ...interface{}) {
-	logDepth(context.Background(), 1, InfoLog, format, args)
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Print; a newline is
+// appended.
+func Info(ctx context.Context, args ...interface{}) {
+	logDepth(ctx, 1, InfoLog, "", args)
 }
 
 // InfofDepth logs to the INFO log, offsetting the caller's stack frame by
-// 'depth'. Passing an empty string for `format` causes this method to
-// naturally format `args`.
-func InfofDepth(depth int, format string, args ...interface{}) {
-	logDepth(context.Background(), depth+1, InfoLog, format, args)
+// 'depth'.
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Printf; a newline is
+// appended.
+func InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
+	logDepth(ctx, depth+1, InfoLog, format, args)
 }
 
-// Warningc logs to the WARNING and INFO logs. It extracts values from the
-// context using the Field keys specified in this package and logs them along
-// with the given message and any additional pairs specified as consecutive
-// elements in kvs.
-func Warningc(ctx context.Context, format string, args ...interface{}) {
+// Warningf logs to the WARNING and INFO logs.
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Printf; a newline is
+// appended.
+func Warningf(ctx context.Context, format string, args ...interface{}) {
 	logDepth(ctx, 1, WarningLog, format, args)
 }
 
 // Warning logs to the WARNING and INFO logs.
-// Warningf logs to the WARNING and INFO logs. Don't use it; use Warning or
-// Arguments are handled in the manner of fmt.Print; a newline is appended.
-func Warning(args ...interface{}) {
-	logDepth(context.Background(), 1, WarningLog, "", args)
-}
-
-// Warningf logs to the WARNING and INFO logs. Don't use it; use Warning or
-// Warningc instead. Arguments are handled in the manner of fmt.Printf; a
-// newline is appended if missing.
-func Warningf(format string, args ...interface{}) {
-	logDepth(context.Background(), 1, WarningLog, format, args)
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Print; a newline is
+// appended.
+func Warning(ctx context.Context, args ...interface{}) {
+	logDepth(ctx, 1, WarningLog, "", args)
 }
 
 // WarningfDepth logs to the WARNING and INFO logs, offsetting the caller's
-// stack frame by 'depth'. Passing an empty string for `format` causes this
-// method to naturally format `args`.
-func WarningfDepth(depth int, format string, args ...interface{}) {
-	logDepth(context.Background(), depth+1, WarningLog, format, args)
+// stack frame by 'depth'.
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Printf; a newline is
+// appended.
+func WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
+	logDepth(ctx, depth+1, WarningLog, format, args)
 }
 
-// Errorc logs to the ERROR, WARNING, and INFO logs. It extracts values from
-// Field keys specified in this package and logs them along with the given
-// message and any additional pairs specified as consecutive elements in kvs.
-func Errorc(ctx context.Context, format string, args ...interface{}) {
+// Errorf logs to the ERROR, WARNING, and INFO logs.
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Printf; a newline is
+// appended.
+func Errorf(ctx context.Context, format string, args ...interface{}) {
 	logDepth(ctx, 1, ErrorLog, format, args)
 }
 
 // Error logs to the ERROR, WARNING, and INFO logs.
-// Arguments are handled in the manner of fmt.Print; a newline is appended.
-func Error(args ...interface{}) {
-	logDepth(context.Background(), 1, ErrorLog, "", args)
-}
-
-// Errorf logs to the ERROR, WARNING, and INFO logs. Don't use it; use Error
-// Info or Errorc instead. Arguments are handled in the manner of fmt.Printf;
-// a newline is appended if missing.
-func Errorf(format string, args ...interface{}) {
-	logDepth(context.Background(), 1, ErrorLog, format, args)
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Print; a newline is
+// appended.
+func Error(ctx context.Context, args ...interface{}) {
+	logDepth(ctx, 1, ErrorLog, "", args)
 }
 
 // ErrorfDepth logs to the ERROR, WARNING, and INFO logs, offsetting the
-// caller's stack frame by 'depth'. Passing an empty string for `format` causes
-// this method to naturally format `args`.
-func ErrorfDepth(depth int, format string, args ...interface{}) {
-	logDepth(context.Background(), depth+1, ErrorLog, format, args)
+// caller's stack frame by 'depth'.
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Printf; a newline is
+// appended.
+func ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
+	logDepth(ctx, depth+1, ErrorLog, format, args)
 }
 
-// Fatalc logs to the INFO, WARNING, ERROR, and FATAL logs, including a stack
-// trace of all running goroutines, then calls os.Exit(255). It extracts values
-// from the context using the Field keys specified in this package and logs
-// them along with the given message and any additional pairs specified as
-// consecutive elements in kvs.
-func Fatalc(ctx context.Context, format string, args ...interface{}) {
+// Fatalf logs to the INFO, WARNING, ERROR, and FATAL logs, including a stack
+// trace of all running goroutines, then calls os.Exit(255).
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Printf; a newline is
+// appended.
+func Fatalf(ctx context.Context, format string, args ...interface{}) {
 	logDepth(ctx, 1, FatalLog, format, args)
 }
 
-// Fatal logs to the INFO, WARNING, ERROR, and FATAL logs,
-// including a stack trace of all running goroutines, then calls os.Exit(255).
-// Arguments are handled in the manner of fmt.Print; a newline is appended.
-func Fatal(args ...interface{}) {
-	logDepth(context.Background(), 1, FatalLog, "", args)
+// Fatal logs to the INFO, WARNING, ERROR, and FATAL logs, including a stack
+// trace of all running goroutines, then calls os.Exit(255).
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Print; a newline is
+// appended.
+func Fatal(ctx context.Context, args ...interface{}) {
+	logDepth(ctx, 1, FatalLog, "", args)
 }
 
-// Fatalf logs to the INFO, WARNING, ERROR, and FATAL logs,
-// including a stack trace of all running goroutines, then calls os.Exit(255).
-// Arguments are handled in the manner of fmt.Printf; a newline is appended.
-func Fatalf(format string, args ...interface{}) {
-	logDepth(context.Background(), 1, FatalLog, format, args)
-}
-
-// FatalfDepth logs to the INFO, WARNING, ERROR, and FATAL logs,
-// including a stack trace of all running goroutines, then calls os.Exit(255),
-// offsetting the caller's stack frame by 'depth'. Passing an empty string for
-// `format` causes this method to naturally format `args`.
-func FatalfDepth(depth int, format string, args ...interface{}) {
-	logDepth(context.Background(), depth+1, FatalLog, format, args)
+// FatalfDepth logs to the INFO, WARNING, ERROR, and FATAL logs (offsetting the
+// caller's stack frame by 'depth'), including a stack trace of all running
+// goroutines, then calls os.Exit(255).
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Printf; a newline is
+// appended.
+func FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
+	logDepth(ctx, depth+1, FatalLog, format, args)
 }
 
 // V returns true if the logging verbosity is set to the specified level or

--- a/util/log/log_test.go
+++ b/util/log/log_test.go
@@ -28,5 +28,5 @@ func TestLogNilArg(t *testing.T) {
 			t.Fatalf("test panicked")
 		}
 	}()
-	Warningc(context.Background(), "test", nil)
+	Warningf(context.Background(), "test", nil)
 }

--- a/util/log/main_test.go
+++ b/util/log/main_test.go
@@ -20,16 +20,18 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestMain(m *testing.M) {
 	tmpDir, err := ioutil.TempDir("", "logtest")
 	if err != nil {
-		Fatalf("could not create temporary directory: %s", err)
+		Fatalf(context.Background(), "could not create temporary directory: %s", err)
 	}
 	defer func() {
 		if err := os.RemoveAll(tmpDir); err != nil {
-			Errorf("failed to clean up temp directory: %s", err)
+			Errorf(context.Background(), "failed to clean up temp directory: %s", err)
 		}
 	}()
 	logDir = tmpDir

--- a/util/netutil/net.go
+++ b/util/netutil/net.go
@@ -27,6 +27,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
 
 	"github.com/cockroachdb/cmux"
@@ -87,7 +88,7 @@ func MakeServer(stopper *stop.Stopper, tlsConfig *tls.Config, handler http.Handl
 	// net/http.(*Server).Serve/http2.ConfigureServer are not thread safe with
 	// respect to net/http.(*Server).TLSConfig, so we call it synchronously here.
 	if err := http2.ConfigureServer(server.Server, nil); err != nil {
-		log.Fatal(err)
+		log.Fatal(context.TODO(), err)
 	}
 
 	stopper.RunWorker(func() {
@@ -148,6 +149,6 @@ func IsClosedConnection(err error) bool {
 // cmux.ErrListenerClosed, or the net package's errClosed.
 func FatalIfUnexpected(err error) {
 	if err != nil && !IsClosedConnection(err) {
-		log.Fatal(err)
+		log.Fatal(context.TODO(), err)
 	}
 }

--- a/util/testing.go
+++ b/util/testing.go
@@ -24,6 +24,8 @@ import (
 	"reflect"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/timeutil"
 )
@@ -82,7 +84,7 @@ func CreateRestrictedFile(t Tester, contents []byte, tempdir, name string) strin
 	tempPath := filepath.Join(tempdir, name)
 	if err := ioutil.WriteFile(tempPath, contents, 0600); err != nil {
 		if t == nil {
-			log.Fatal(err)
+			log.Fatal(context.TODO(), err)
 		} else {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Mostly mechanical change to require a context on all logging functions.

I will file issues against various components for auditing the call sites to
replace `context.TODO()` with a real context.

Part of #1779.

 @tschottdorf @petermattis The only thing to look at is `util/log/log.go`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7990)

<!-- Reviewable:end -->
