### PR TITLE
sql: Require DROP privileges to RENAME a database

### DIFF
--- a/sql/rename.go
+++ b/sql/rename.go
@@ -36,7 +36,7 @@ var (
 )
 
 // RenameDatabase renames the database.
-// Privileges: security.RootUser user.
+// Privileges: security.RootUser user, DROP on source database.
 //   Notes: postgres requires superuser, db owner, or "CREATEDB".
 //          mysql >= 5.1.23 does not allow database renames.
 func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
@@ -50,6 +50,10 @@ func (p *planner) RenameDatabase(n *parser.RenameDatabase) (planNode, error) {
 
 	dbDesc, err := p.mustGetDatabaseDesc(string(n.Name))
 	if err != nil {
+		return nil, err
+	}
+
+	if err := p.checkPrivilege(dbDesc, privilege.DROP); err != nil {
 		return nil, err
 	}
 

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -157,6 +157,12 @@ SHOW GRANTS ON system.rangelog
 ----
 rangelog root ALL
 
+statement error user root does not have DROP privilege on database system
+ALTER DATABASE system RENAME TO not_system
+
+statement error user root does not have DROP privilege on database system
+DROP DATABASE system
+
 # Non-root users can have privileges on system objects, but limited to GRANT, SELECT.
 statement error user testuser must not have ALL privileges on system objects
 GRANT ALL ON DATABASE system TO testuser


### PR DESCRIPTION
Previously it was possible to RENAME databases even if the root user did
not have DROP privileges on them. This could result in the `system`
database being renamed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7998)

<!-- Reviewable:end -->
