### PR TITLE
sql: Clean up misuses of code surrounding table and db descriptors

### DIFF
--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -35,14 +35,6 @@ type alterTableNode struct {
 //   notes: postgres requires CREATE on the table.
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) AlterTable(n *parser.AlterTable) (planNode, error) {
-	if err := n.Table.NormalizeTableName(p.session.Database); err != nil {
-		return nil, err
-	}
-
-	if _, err := p.mustGetDatabaseDesc(n.Table.Database()); err != nil {
-		return nil, err
-	}
-
 	tableDesc, err := p.getTableDesc(n.Table)
 	if err != nil {
 		return nil, err

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -170,10 +170,6 @@ type dropIndexNode struct {
 //          mysql requires the INDEX privilege on the table.
 func (p *planner) DropIndex(n *parser.DropIndex) (planNode, error) {
 	for _, index := range n.IndexList {
-		if err := index.Table.NormalizeTableName(p.session.Database); err != nil {
-			return nil, err
-		}
-
 		tableDesc, err := p.mustGetTableDesc(index.Table)
 		if err != nil {
 			return nil, err

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -217,10 +217,6 @@ func (p *planner) RenameIndex(n *parser.RenameIndex) (planNode, error) {
 		return nil, errEmptyIndexName
 	}
 
-	if err := n.Index.Table.NormalizeTableName(p.session.Database); err != nil {
-		return nil, err
-	}
-
 	tableDesc, err := p.mustGetTableDesc(n.Index.Table)
 	if err != nil {
 		return nil, err
@@ -280,14 +276,6 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 		return nil, errEmptyColumnName
 	}
 
-	if err := n.Table.NormalizeTableName(p.session.Database); err != nil {
-		return nil, err
-	}
-
-	_, err := p.mustGetDatabaseDesc(n.Table.Database())
-	if err != nil {
-		return nil, err
-	}
 	// Check if table exists.
 	tableDesc, err := p.getTableDesc(n.Table)
 	if err != nil {

--- a/sql/rename.go
+++ b/sql/rename.go
@@ -119,14 +119,12 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		return nil, err
 	}
 
-	tbKey := tableKey{dbDesc.ID, n.Name.Table()}.Key()
-
-	// Check if table exists.
-	gr, err := p.txn.Get(tbKey)
+	// Check if source table exists.
+	tableDesc, err := p.getTableDesc(n.Name)
 	if err != nil {
 		return nil, err
 	}
-	if !gr.Exists() {
+	if tableDesc == nil {
 		if n.IfExists {
 			// Noop.
 			return &emptyNode{}, nil
@@ -134,7 +132,15 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 		// Key does not exist, but we want it to: error out.
 		return nil, fmt.Errorf("table %q does not exist", n.Name.Table())
 	}
+	if tableDesc.State != sqlbase.TableDescriptor_PUBLIC {
+		return nil, sqlbase.NewUndefinedTableError(n.Name.String())
+	}
 
+	if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
+		return nil, err
+	}
+
+	// Check if target database exists.
 	targetDbDesc, err := p.mustGetDatabaseDesc(n.NewName.Database())
 	if err != nil {
 		return nil, err
@@ -147,18 +153,6 @@ func (p *planner) RenameTable(n *parser.RenameTable) (planNode, error) {
 	if n.Name.Database() == n.NewName.Database() && n.Name.Table() == n.NewName.Table() {
 		// Noop.
 		return &emptyNode{}, nil
-	}
-
-	tableDesc, err := p.mustGetTableDesc(n.Name)
-	if err != nil {
-		return nil, err
-	}
-	if tableDesc.State != sqlbase.TableDescriptor_PUBLIC {
-		return nil, sqlbase.NewUndefinedTableError(n.Name.String())
-	}
-
-	if err := p.checkPrivilege(tableDesc, privilege.DROP); err != nil {
-		return nil, err
 	}
 
 	tableDesc.SetName(n.NewName.Table())
@@ -290,18 +284,16 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 		return nil, err
 	}
 
-	dbDesc, err := p.mustGetDatabaseDesc(n.Table.Database())
+	_, err := p.mustGetDatabaseDesc(n.Table.Database())
 	if err != nil {
 		return nil, err
 	}
-
 	// Check if table exists.
-	tbKey := tableKey{dbDesc.ID, n.Table.Table()}.Key()
-	gr, err := p.txn.Get(tbKey)
+	tableDesc, err := p.getTableDesc(n.Table)
 	if err != nil {
 		return nil, err
 	}
-	if !gr.Exists() {
+	if tableDesc == nil {
 		if n.IfExists {
 			// Noop.
 			return &emptyNode{}, nil
@@ -310,8 +302,7 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 		return nil, fmt.Errorf("table %q does not exist", n.Table.Table())
 	}
 
-	tableDesc, err := p.mustGetTableDesc(n.Table)
-	if err != nil {
+	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
 		return nil, err
 	}
 
@@ -326,10 +317,6 @@ func (p *planner) RenameColumn(n *parser.RenameColumn) (planNode, error) {
 		column = &tableDesc.Columns[i]
 	} else {
 		column = tableDesc.Mutations[i].GetColumn()
-	}
-
-	if err := p.checkPrivilege(tableDesc, privilege.CREATE); err != nil {
-		return nil, err
 	}
 
 	if sqlbase.EqualName(colName, newColName) {

--- a/sql/testdata/rename_table
+++ b/sql/testdata/rename_table
@@ -70,19 +70,6 @@ ALTER TABLE t RENAME TO new_kv
 
 user testuser
 
-statement error user testuser does not have CREATE privilege on database test
-ALTER TABLE test.t RENAME TO t2
-
-user root
-
-statement ok
-GRANT CREATE ON DATABASE test TO testuser
-
-statement ok
-create database test2
-
-user testuser
-
 statement error user testuser does not have DROP privilege on table t
 ALTER TABLE test.t RENAME TO t2
 
@@ -90,6 +77,19 @@ user root
 
 statement ok
 GRANT DROP ON TABLE test.t TO testuser
+
+statement ok
+create database test2
+
+user testuser
+
+statement error user testuser does not have CREATE privilege on database test
+ALTER TABLE test.t RENAME TO t2
+
+user root
+
+statement ok
+GRANT CREATE ON DATABASE test TO testuser
 
 statement ok
 ALTER TABLE test.t RENAME TO t2


### PR DESCRIPTION
The three related misuses are that:
- Two rename routines used both `tableKey` and `planner.getTableDesc` to
  check first check for the existence of a `TableDescriptor` and then fetch
  the `TableDescriptor`.
- `planner.{get|mustGet}TableDesc` already normalizes table names, so
  calling `NormalizeTableName` on the provided `QualifiedName` beforehand
  is unnecessary.
- `planner.{get|mustGet}TableDesc` internally retrieves a `DatabaseDescriptor`, so calling
  `planner.{get|mustGet}DatabaseDesc` is unnecessary if the resulting
  descriptor is not actually used.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/7999)

<!-- Reviewable:end -->
