### PR TITLE
build: fix infinite loop in upload-coverage when package doesn't depend on itself

### DIFF
--- a/build/upload-coverage.sh
+++ b/build/upload-coverage.sh
@@ -30,9 +30,10 @@ iterative_coverpkg() {
   old_line_count="-1"
   while [ "$old_line_count" != "$line_count" ]; do
     old_line_count=$line_count
-    imports=$(go list  -f '{{join .Imports "\n"}}
+    imports+=$'\n'$(go list  -f '{{join .Imports "\n"}}
 {{join .TestImports "\n"}}
-{{join .XTestImports "\n"}}' $imports | grep $main_package | sort | uniq)
+{{join .XTestImports "\n"}}' $imports | grep $main_package)
+    imports=$(echo "$imports" | sort | uniq)
     line_count=$(echo $imports | wc -w)
   done
   coverpkg=$(echo $imports | sed 's/ /,/g')
@@ -43,6 +44,7 @@ mkdir -p "$coverage_dir"
 
 # Run "make coverage" on each package.
 for pkg in $(go list ./...); do
+  echo "Processing $pkg..."
   # Verify package has test files.
   if [ -z "$(go list -f '{{join .TestGoFiles ""}}{{join .XTestGoFiles ""}}' $pkg)" ]; then
     echo "$pkg: Skipping due to no test files."


### PR DESCRIPTION
This should stop hanging coverage builds in teamcity.

Test run 
https://teamcity.cockroachdb.com/viewLog.html?buildTypeId=Cockroach_Coverage_Coverage&buildId=4175

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8005)

<!-- Reviewable:end -->
