### PR TITLE
stability: shush senseless log chatter

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -27,6 +27,7 @@ github.com/VividCortex/ewma 8b9f1311551e712ea8a06b494238b8a2351e1c33
 github.com/agtorre/gocolorize f42b554bf7f006936130c9bb4f971afd2d87f671
 github.com/backtrace-labs/go-bcd c5383e2df7004f8b2fb2f10a33167d757bb0fbfb
 github.com/biogo/store 913427a1d5e89604e50ea1db0f28f34966d61602
+github.com/cenk/backoff cdf48bbc1eb78d1349cbda326a4a037f7ba565c6
 github.com/chzyer/logex 96a4d311aa9ba1c5f9f2abda8039671de20f6aa5
 github.com/chzyer/readline c144c8dde4996a05f596bd5acb730d172968e26c
 github.com/chzyer/test bea8f082b6fd8382588bf6fdc6af9217078af151
@@ -50,6 +51,7 @@ github.com/docker/go-units f2d77a61e3c169b43402a0a1e84f06daf29b8190
 github.com/dustin/go-humanize 2fcb5204cdc65b4bec9fd0a87606bb0d0e3c54e8
 github.com/elastic/gosigar 1d5bcdfbb4e5b8b5982f1e87ee6f13a806dd9aa0
 github.com/elazarl/go-bindata-assetfs 57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2
+github.com/facebookgo/clock 600d898af40aa09a7a93ecb9265d87b0504b6f03
 github.com/go-ole/go-ole 7dfdcf409020452e29b4babcbb22f984d2aa308a
 github.com/go-sql-driver/mysql 3654d25ec346ee8ce71a68431025458d52a38ac0
 github.com/gogo/protobuf e33835a643a970c11ac74f6333f5f6866387a101
@@ -81,11 +83,13 @@ github.com/opennota/check 5b00aacd5639507d2b039245a278ec9f5505509f
 github.com/opentracing/basictracer-go a39552bda9584ab9ab465f6462f23f7ed1aa0d15
 github.com/opentracing/opentracing-go ce84834b482d236a829419f99eb78866b58751fd
 github.com/pborman/uuid c55201b036063326c5b1b89ccfe45a184973d073
+github.com/peterbourgon/g2s 5767a0b2078638d14800683fd0fe425604883f63
 github.com/pkg/errors 1d2e60385a13aaa66134984235061c2f9302520e
 github.com/prometheus/client_model fa8ad6fec33561be4280a8f0514318c79d7f6cb6
 github.com/prometheus/common bc0a4460d0fc2693fcdebafafbf07c6d18913b97
 github.com/rcrowley/go-metrics bdb33529eca3e55eac7328e07c57012a797af602
 github.com/robfig/glock c7fb89f56fbead624f7424f81f70af3a742433c5
+github.com/rubyist/circuitbreaker 434e9dfaa002281310291f4042827d0940526785
 github.com/russross/blackfriday 93622da34e54fb6529bfb7c57e710f37a8d9cbd8
 github.com/sasha-s/go-deadlock 09aefc0ac06ad74d91ca31acdb11fc981c159149
 github.com/satori/go.uuid 0aa62d5ddceb50dbcb909d790b5345affd3669b6

--- a/cmd/gossipsim/main.go
+++ b/cmd/gossipsim/main.go
@@ -201,7 +201,7 @@ func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet
 			if otherNode == simNode {
 				continue // skip the node's own info
 			}
-			infoKey := otherNode.Addr.String()
+			infoKey := otherNode.Addr().String()
 			// GetInfo returns an error if the info is missing.
 			if info, err := node.GetInfo(infoKey); err != nil {
 				missing = append(missing, otherNode.Gossip.GetNodeID())
@@ -303,7 +303,7 @@ func main() {
 
 	edgeSet := make(map[string]edge)
 
-	n := simulation.NewNetwork(nodeCount)
+	n := simulation.NewNetwork(nodeCount, true)
 	n.SimulateNetwork(
 		func(cycle int, network *simulation.Network) bool {
 			// Output dot graph.

--- a/gossip/convergence_test.go
+++ b/gossip/convergence_test.go
@@ -29,7 +29,7 @@ import (
 // verifyConvergence verifies that info from each node is visible from
 // every node in the network within numCycles cycles of the gossip protocol.
 func verifyConvergence(numNodes, maxCycles int, _ *testing.T) {
-	network := simulation.NewNetwork(numNodes)
+	network := simulation.NewNetwork(numNodes, true)
 
 	if connectedCycle := network.RunUntilFullyConnected(); connectedCycle > maxCycles {
 		log.Warningf(context.TODO(), "expected a fully-connected network within %d cycles; took %d",

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -44,8 +44,13 @@ import (
 type Node struct {
 	Gossip   *gossip.Gossip
 	Server   *grpc.Server
-	Addr     net.Addr
+	Listener net.Listener
 	Registry *metric.Registry
+}
+
+// Addr returns the address of the connected listener.
+func (n *Node) Addr() net.Addr {
+	return n.Listener.Addr()
 }
 
 // Network provides access to a test gossip network of nodes.
@@ -55,10 +60,11 @@ type Network struct {
 	nodeIDAllocator roachpb.NodeID // provides unique node IDs
 	rpcContext      *rpc.Context
 	tlsConfig       *tls.Config
+	started         bool
 }
 
 // NewNetwork creates nodeCount gossip nodes.
-func NewNetwork(nodeCount int) *Network {
+func NewNetwork(nodeCount int, createResolvers bool) *Network {
 	log.Infof(context.TODO(), "simulating gossip network with %d nodes", nodeCount)
 
 	n := &Network{
@@ -78,13 +84,12 @@ func NewNetwork(nodeCount int) *Network {
 			log.Fatal(context.TODO(), err)
 		}
 		// Build a resolver for each instance or we'll get data races.
-		r, err := resolver.NewResolverFromAddress(n.Nodes[0].Addr)
-		if err != nil {
-			log.Fatalf(context.TODO(), "bad gossip address %s: %s", n.Nodes[0].Addr, err)
-		}
-		node.Gossip.SetResolvers([]resolver.Resolver{r})
-		if err := n.StartNode(node); err != nil {
-			log.Fatal(context.TODO(), err)
+		if createResolvers {
+			r, err := resolver.NewResolverFromAddress(n.Nodes[0].Addr())
+			if err != nil {
+				log.Fatalf(context.TODO(), "bad gossip address %s: %s", n.Nodes[0].Addr(), err)
+			}
+			node.Gossip.SetResolvers([]resolver.Resolver{r})
 		}
 	}
 	return n
@@ -93,11 +98,17 @@ func NewNetwork(nodeCount int) *Network {
 // CreateNode creates a simulation node and starts an RPC server for it.
 func (n *Network) CreateNode() (*Node, error) {
 	server := rpc.NewServer(n.rpcContext)
-	ln, err := netutil.ListenAndServeGRPC(n.Stopper, server, util.TestAddr)
+	ln, err := net.Listen(util.TestAddr.Network(), util.TestAddr.String())
 	if err != nil {
 		return nil, err
 	}
-	node := &Node{Server: server, Addr: ln.Addr(), Registry: metric.NewRegistry()}
+	n.Stopper.RunWorker(func() {
+		<-n.Stopper.ShouldQuiesce()
+		server.GracefulStop()
+		<-n.Stopper.ShouldStop()
+		server.Stop()
+	})
+	node := &Node{Server: server, Listener: ln, Registry: metric.NewRegistry()}
 	node.Gossip = gossip.New(n.rpcContext, nil, n.Stopper, node.Registry)
 	n.Nodes = append(n.Nodes, node)
 	return node, nil
@@ -106,20 +117,23 @@ func (n *Network) CreateNode() (*Node, error) {
 // StartNode initializes a gossip instance for the simulation node and
 // starts it.
 func (n *Network) StartNode(node *Node) error {
-	node.Gossip.Start(node.Server, node.Addr)
+	node.Gossip.Start(node.Server, node.Addr())
 	node.Gossip.EnableSimulationCycler(true)
 	n.nodeIDAllocator++
 	node.Gossip.SetNodeID(n.nodeIDAllocator)
 	if err := node.Gossip.SetNodeDescriptor(&roachpb.NodeDescriptor{
 		NodeID:  node.Gossip.GetNodeID(),
-		Address: util.MakeUnresolvedAddr(node.Addr.Network(), node.Addr.String()),
+		Address: util.MakeUnresolvedAddr(node.Addr().Network(), node.Addr().String()),
 	}); err != nil {
 		return err
 	}
-	if err := node.Gossip.AddInfo(node.Addr.String(),
+	if err := node.Gossip.AddInfo(node.Addr().String(),
 		encoding.EncodeUint64Ascending(nil, 0), time.Hour); err != nil {
 		return err
 	}
+	n.Stopper.RunWorker(func() {
+		netutil.FatalIfUnexpected(node.Server.Serve(node.Listener))
+	})
 	return nil
 }
 
@@ -145,6 +159,7 @@ func (n *Network) GetNodeFromID(nodeID roachpb.NodeID) (*Node, bool) {
 //
 // The simulation callback receives the cycle and the network as arguments.
 func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) bool) {
+	n.Start()
 	nodes := n.Nodes
 	for cycle := 1; simCallback(cycle, n); cycle++ {
 		// Node 0 gossips sentinel & cluster ID every cycle.
@@ -165,7 +180,7 @@ func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) 
 		// Every node gossips every cycle.
 		for _, node := range nodes {
 			if err := node.Gossip.AddInfo(
-				node.Addr.String(),
+				node.Addr().String(),
 				encoding.EncodeUint64Ascending(nil, uint64(cycle)),
 				time.Hour,
 			); err != nil {
@@ -176,6 +191,21 @@ func (n *Network) SimulateNetwork(simCallback func(cycle int, network *Network) 
 		time.Sleep(5 * time.Millisecond)
 	}
 	log.Infof(context.TODO(), "gossip network simulation: total infos sent=%d, received=%d", n.infosSent(), n.infosReceived())
+}
+
+// Start starts all gossip nodes.
+// TODO(spencer): make all methods in Network return errors instead of
+// fatal logging.
+func (n *Network) Start() {
+	if n.started {
+		return
+	}
+	n.started = true
+	for _, node := range n.Nodes {
+		if err := n.StartNode(node); err != nil {
+			log.Fatal(context.TODO(), err)
+		}
+	}
 }
 
 // Stop stops all servers and gossip nodes.
@@ -207,7 +237,7 @@ func (n *Network) RunUntilFullyConnected() int {
 func (n *Network) isNetworkConnected() bool {
 	for _, leftNode := range n.Nodes {
 		for _, rightNode := range n.Nodes {
-			if _, err := leftNode.Gossip.GetInfo(rightNode.Addr.String()); err != nil {
+			if _, err := leftNode.Gossip.GetInfo(rightNode.Addr().String()); err != nil {
 				return false
 			}
 		}

--- a/gossip/storage_test.go
+++ b/gossip/storage_test.go
@@ -98,14 +98,14 @@ func (s unresolvedAddrSlice) Swap(i, j int) {
 func TestGossipStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	network := simulation.NewNetwork(3)
+	network := simulation.NewNetwork(3, true)
 	defer network.Stop()
 
 	// Set storage for each of the nodes.
 	addresses := make(unresolvedAddrSlice, len(network.Nodes))
 	stores := make([]testStorage, len(network.Nodes))
 	for i, n := range network.Nodes {
-		addresses[i] = util.MakeUnresolvedAddr(n.Addr.Network(), n.Addr.String())
+		addresses[i] = util.MakeUnresolvedAddr(n.Addr().Network(), n.Addr().String())
 		if err := n.Gossip.SetStorage(&stores[i]); err != nil {
 			t.Fatal(err)
 		}
@@ -162,7 +162,7 @@ func TestGossipStorage(t *testing.T) {
 	}
 	node.Gossip.SetBootstrapInterval(1 * time.Millisecond)
 
-	r, err := resolver.NewResolverFromAddress(node.Addr)
+	r, err := resolver.NewResolverFromAddress(node.Addr())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,6 +204,58 @@ func TestGossipStorage(t *testing.T) {
 	util.SucceedsSoon(t, func() error {
 		if expected, actual := len(network.Nodes)-1 /* -1 is ourself */, ts2.Len(); expected != actual {
 			return errors.Errorf("expected %v, got %v (info: %#v)", expected, actual, ts2.Info().Addresses)
+		}
+		return nil
+	})
+}
+
+// TestGossipStorageCleanup verifies that bad resolvers are purged
+// from the bootstrap info after gossip has successfully connected.
+func TestGossipStorageCleanup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const numNodes = 3
+	network := simulation.NewNetwork(numNodes, false)
+	defer network.Stop()
+
+	const invalidAddr = "10.10.10.10.10:3333333"
+	// Set storage for each of the nodes.
+	addresses := make(unresolvedAddrSlice, len(network.Nodes))
+	stores := make([]testStorage, len(network.Nodes))
+	for i, n := range network.Nodes {
+		addresses[i] = util.MakeUnresolvedAddr(n.Addr().Network(), n.Addr().String())
+		// Pre-add an invalid address to each gossip storage.
+		if err := stores[i].WriteBootstrapInfo(&gossip.BootstrapInfo{
+			Addresses: []util.UnresolvedAddr{
+				util.MakeUnresolvedAddr("tcp", network.Nodes[(i+1)%numNodes].Addr().String()), // node i+1 address
+				util.MakeUnresolvedAddr("tcp", invalidAddr),                                   // invalid address
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := n.Gossip.SetStorage(&stores[i]); err != nil {
+			t.Fatal(err)
+		}
+		n.Gossip.SetStallInterval(1 * time.Millisecond)
+		n.Gossip.SetBootstrapInterval(1 * time.Millisecond)
+	}
+
+	// Wait for the gossip network to connect.
+	network.RunUntilFullyConnected()
+
+	// Wait long enough for storage to get the expected number of
+	// addresses and no pending cleanups.
+	util.SucceedsSoon(t, func() error {
+		for i := range stores {
+			p := &stores[i]
+			if expected, actual := len(network.Nodes)-1 /* -1 is ourself */, p.Len(); expected != actual {
+				return errors.Errorf("expected %v, got %v (info: %#v)", expected, actual, p.Info().Addresses)
+			}
+			for _, addr := range p.Info().Addresses {
+				if addr.String() == invalidAddr {
+					return errors.Errorf("node %d still needs bootstrap cleanup", i)
+				}
+			}
 		}
 		return nil
 	})

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -109,7 +109,8 @@ func (*legacyTransportAdapter) Close() {
 }
 
 func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
-	n := simulation.NewNetwork(1)
+	n := simulation.NewNetwork(1, true)
+	n.Start()
 	g := n.Nodes[0].Gossip
 
 	if err := g.AddInfo(gossip.KeySentinel, nil, time.Hour); err != nil {
@@ -792,7 +793,8 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 
 func TestGetFirstRangeDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	n := simulation.NewNetwork(3)
+	n := simulation.NewNetwork(3, true)
+	n.Start()
 	ds := NewDistSender(nil, n.Nodes[0].Gossip)
 	if _, err := ds.FirstRange(); err == nil {
 		t.Errorf("expected not to find first range descriptor")

--- a/storage/raft_transport_test.go
+++ b/storage/raft_transport_test.go
@@ -273,6 +273,36 @@ func TestSendAndReceive(t *testing.T) {
 	}
 }
 
+func sendRaftMessage(t *testing.T,
+	fromNID roachpb.NodeID, fromSID roachpb.StoreID, fromRID roachpb.ReplicaID,
+	toNID roachpb.NodeID, toSID roachpb.StoreID, toRID roachpb.ReplicaID,
+	idx int, client *storage.RaftTransport) bool {
+	req := &storage.RaftMessageRequest{
+		RangeID: 1,
+		Message: raftpb.Message{
+			To:     uint64(toNID),
+			From:   uint64(fromNID),
+			Commit: uint64(idx),
+		},
+		ToReplica: roachpb.ReplicaDescriptor{
+			NodeID:    toNID,
+			StoreID:   toSID,
+			ReplicaID: toRID,
+		},
+		FromReplica: roachpb.ReplicaDescriptor{
+			NodeID:    fromNID,
+			StoreID:   fromSID,
+			ReplicaID: fromRID,
+		},
+	}
+	sender := client.MakeSender(func(err error, _ roachpb.ReplicaDescriptor) {
+		if err != nil && !grpcutil.IsClosedConnection(err) {
+			t.Fatal(err)
+		}
+	})
+	return sender.SendAsync(req)
+}
+
 // TestInOrderDelivery verifies that for a given pair of nodes, raft
 // messages are delivered in order.
 func TestInOrderDelivery(t *testing.T) {
@@ -307,30 +337,12 @@ func TestInOrderDelivery(t *testing.T) {
 	clientNodeID := roachpb.NodeID(2)
 	clientTransport := storage.NewRaftTransport(storage.GossipAddressResolver(g), nil, nodeRPCContext)
 
+	fromSID := roachpb.StoreID(1)
+	fromRID := roachpb.ReplicaID(1)
+	toSID := roachpb.StoreID(2)
+	toRID := roachpb.ReplicaID(2)
 	for i := 0; i < numMessages; i++ {
-		req := &storage.RaftMessageRequest{
-			RangeID: 1,
-			Message: raftpb.Message{
-				To:     uint64(nodeID),
-				From:   uint64(clientNodeID),
-				Commit: uint64(i),
-			},
-			ToReplica: roachpb.ReplicaDescriptor{
-				NodeID:    nodeID,
-				StoreID:   roachpb.StoreID(nodeID),
-				ReplicaID: roachpb.ReplicaID(nodeID),
-			},
-			FromReplica: roachpb.ReplicaDescriptor{
-				NodeID:    clientNodeID,
-				StoreID:   roachpb.StoreID(clientNodeID),
-				ReplicaID: roachpb.ReplicaID(clientNodeID),
-			},
-		}
-		if !clientTransport.MakeSender(func(err error, _ roachpb.ReplicaDescriptor) {
-			if err != nil && !grpcutil.IsClosedConnection(err) {
-				panic(err)
-			}
-		}).SendAsync(req) {
+		if !sendRaftMessage(t, clientNodeID, fromSID, fromRID, nodeID, toSID, toRID, i, clientTransport) {
 			t.Errorf("failed to send message %d", i)
 		}
 	}
@@ -340,5 +352,73 @@ func TestInOrderDelivery(t *testing.T) {
 		if req.Message.Commit != uint64(i) {
 			t.Errorf("messages out of order: got %d while expecting %d", req.Message.Commit, i)
 		}
+	}
+}
+
+// TestRaftTransportCircuitBreaker verifies that messages will be
+// dropped waiting for raft node connection to be established.
+func TestRaftTransportCircuitBreaker(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+	nodeRPCContext := rpc.NewContext(testutils.NewNodeTestBaseContext(), nil, stopper)
+	g := gossip.New(nodeRPCContext, nil, stopper, metric.NewRegistry())
+
+	grpcServer := rpc.NewServer(nodeRPCContext)
+	ln, err := netutil.ListenAndServeGRPC(stopper, grpcServer, util.TestAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nodeID := roachpb.NodeID(roachpb.NodeID(2))
+	serverTransport := storage.NewRaftTransport(storage.GossipAddressResolver(g), grpcServer, nodeRPCContext)
+	serverChannel := newChannelServer(10, 10*time.Millisecond)
+	serverTransport.Listen(roachpb.StoreID(nodeID), serverChannel.RaftMessage)
+
+	clientNodeID := roachpb.NodeID(2)
+	clientTransport := storage.NewRaftTransport(storage.GossipAddressResolver(g), nil, nodeRPCContext)
+
+	fromSID := roachpb.StoreID(1)
+	fromRID := roachpb.ReplicaID(1)
+	toSID := roachpb.StoreID(2)
+	toRID := roachpb.ReplicaID(2)
+	if sendRaftMessage(t, clientNodeID, fromSID, fromRID, nodeID, toSID, toRID, 1, clientTransport) {
+		t.Errorf("succeeded in sending when message should be dropped")
+	}
+
+	// None should go through as the receiving node's address has not been gossiped.
+	select {
+	case req := <-serverChannel.ch:
+		t.Fatalf("should not have received any Raft messages from client: %s", req)
+	default:
+	}
+
+	// Now, gossip address of server.
+	addr := ln.Addr()
+	g.SetNodeID(nodeID)
+	if err := g.AddInfoProto(gossip.MakeNodeIDKey(nodeID),
+		&roachpb.NodeDescriptor{
+			Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),
+		},
+		time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	// Message was dropped, not queued, so still shouldn't just appear.
+	select {
+	case req := <-serverChannel.ch:
+		t.Fatalf("should not have received any Raft messages from client: %s", req)
+	default:
+	}
+
+	// Reset the circuit breaker & resend and verify message arrives at server.
+	clientTransport.GetCircuitBreaker(nodeID).Reset()
+	if !sendRaftMessage(t, clientNodeID, fromSID, fromRID, nodeID, toSID, toRID, 1, clientTransport) {
+		t.Errorf("sent raft message was unexpectedly dropped")
+	}
+
+	req := <-serverChannel.ch
+	if req.Message.Commit != 1 {
+		t.Errorf("expected message 1; got %s", req)
 	}
 }


### PR DESCRIPTION
Changed Raft transport to avoid busy logging when node addresses aren't
available via gossip. It now retries with an exponential backoff and
only logs during availability state changes.

Similarly removed endless repetition of gossip logging in the event
that bootstrap hosts don't resolve (happens when you migrate data dirs).

Cleaned up a TODO to purge old, invalid hosts from the bootstrap info
host addresses.

No more repeated warnings on stalled gossip. We now just log the
state transitions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8021)

<!-- Reviewable:end -->
