### PR TITLE
storage,acceptance: skip flaky tests

### DIFF
--- a/acceptance/partition_test.go
+++ b/acceptance/partition_test.go
@@ -47,6 +47,7 @@ func TestPartitionNemesis(t *testing.T) {
 }
 
 func TestPartitionBank(t *testing.T) {
+	t.Skip("#7978")
 	SkipUnlessPrivileged(t)
 	runTestOnConfigs(t, testBankWithNemesis(BidirectionalPartitionNemesis))
 }

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -356,6 +356,7 @@ func TestBaseQueueAddRemove(t *testing.T) {
 // rejected when the queue has 'acceptsUnsplitRanges = false'.
 func TestAcceptsUnsplitRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#8001")
 	s, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 


### PR DESCRIPTION
See #8001, #7978

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8022)

<!-- Reviewable:end -->
