### PR TITLE
cmd/zerosum: add zerosum tool

### DIFF
--- a/cmd/zerosum/cluster.go
+++ b/cmd/zerosum/cluster.go
@@ -218,7 +218,13 @@ func (c *cluster) transferLease(nodeIdx int, r *rand.Rand, key roachpb.Key) (boo
 		return false, nil
 	}
 
-	target := desc.Replicas[r.Intn(len(desc.Replicas))].StoreID
+	var target roachpb.StoreID
+	for {
+		target = desc.Replicas[r.Intn(len(desc.Replicas))].StoreID
+		if c.nodes[target-1].alive() {
+			break
+		}
+	}
 	if err := c.clients[nodeIdx].AdminTransferLease(key, target); err != nil {
 		return false, errors.Errorf("%s: transfer lease: %s", key, err)
 	}

--- a/cmd/zerosum/cluster.go
+++ b/cmd/zerosum/cluster.go
@@ -1,0 +1,337 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package main
+
+import (
+	"bytes"
+	gosql "database/sql"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+	"time"
+
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/internal/client"
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/rpc"
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/syncutil"
+	"github.com/cockroachdb/cockroach/util/timeutil"
+
+	"github.com/pkg/errors"
+	// Import postgres driver.
+	_ "github.com/cockroachdb/pq"
+	"golang.org/x/net/context"
+)
+
+const basePort = 26257
+const dataDir = "cockroach-data"
+
+var cockroachBin = func() string {
+	bin := "./cockroach"
+	if _, err := os.Stat(bin); err == nil {
+		return bin
+	}
+	return "cockroach"
+}()
+
+type cluster struct {
+	nodes   []*node
+	clients []*client.DB
+	db      []*gosql.DB
+	stopper *stop.Stopper
+	started time.Time
+}
+
+func newCluster(size int) *cluster {
+	return &cluster{
+		nodes:   make([]*node, size),
+		clients: make([]*client.DB, size),
+		db:      make([]*gosql.DB, size),
+		stopper: stop.NewStopper(),
+	}
+}
+
+func (c *cluster) start(db string, args []string) {
+	c.started = timeutil.Now()
+
+	for i := range c.nodes {
+		c.nodes[i] = c.makeNode(i, args)
+		c.clients[i] = c.makeClient(i)
+		c.db[i] = c.makeDB(i, db)
+	}
+
+	log.Infof(context.Background(), "started %.3fs", timeutil.Since(c.started).Seconds())
+}
+
+func (c *cluster) close() {
+	for _, n := range c.nodes {
+		n.kill()
+	}
+	c.stopper.Stop()
+}
+
+func (c *cluster) rpcPort(nodeIdx int) int {
+	return basePort + nodeIdx*2
+}
+
+func (c *cluster) rpcAddr(nodeIdx int) string {
+	return fmt.Sprintf("localhost:%d", c.rpcPort(nodeIdx))
+}
+
+func (c *cluster) httpPort(nodeIdx int) int {
+	return c.rpcPort(nodeIdx) + 1
+}
+
+func (c *cluster) makeNode(nodeIdx int, extraArgs []string) *node {
+	name := fmt.Sprintf("%d", nodeIdx+1)
+	dir := filepath.Join(dataDir, name)
+	logDir := filepath.Join(dir, "logs")
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		log.Fatal(context.Background(), err)
+	}
+
+	args := []string{
+		cockroachBin,
+		"start",
+		"--insecure",
+		fmt.Sprintf("--port=%d", c.rpcPort(nodeIdx)),
+		fmt.Sprintf("--http-port=%d", c.httpPort(nodeIdx)),
+		fmt.Sprintf("--store=%s", dir),
+		fmt.Sprintf("--cache=256MiB"),
+	}
+	if nodeIdx > 0 {
+		args = append(args, fmt.Sprintf("--join=localhost:%d", c.rpcPort(0)))
+	}
+	args = append(args, extraArgs...)
+
+	node := &node{
+		LogDir: logDir,
+		Args:   args,
+	}
+	node.start()
+	return node
+}
+
+func (c *cluster) makeClient(nodeIdx int) *client.DB {
+	ctx := &base.Context{
+		User:     security.NodeUser,
+		Insecure: true,
+	}
+	sender, err := client.NewSender(rpc.NewContext(ctx, nil, c.stopper), c.rpcAddr(nodeIdx))
+	if err != nil {
+		log.Fatalf(context.Background(), "failed to initialize KV client: %s", err)
+	}
+	return client.NewDB(sender)
+}
+
+func (c *cluster) makeDB(nodeIdx int, dbName string) *gosql.DB {
+	url := fmt.Sprintf("postgresql://root@localhost:%d/%s?sslmode=disable",
+		c.rpcPort(nodeIdx), dbName)
+	conn, err := gosql.Open("postgres", url)
+	if err != nil {
+		log.Fatal(context.Background(), err)
+	}
+	return conn
+}
+
+func (c *cluster) waitForFullReplication() {
+	for i := 1; true; i++ {
+		done, detail := c.isReplicated()
+		if (done && i >= 50) || (i%50) == 0 {
+			fmt.Print(detail)
+			log.Infof(context.Background(), "waiting for replication")
+		}
+		if done {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	log.Infof(context.Background(), "replicated %.3fs", timeutil.Since(c.started).Seconds())
+}
+
+func (c *cluster) isReplicated() (bool, string) {
+	db := c.clients[0]
+	rows, err := db.Scan(keys.Meta2Prefix, keys.Meta2Prefix.PrefixEnd(), 100000)
+	if err != nil {
+		log.Fatalf(context.Background(), "scan failed: %s\n", err)
+	}
+
+	var buf bytes.Buffer
+	tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
+
+	done := true
+	for _, row := range rows {
+		desc := &roachpb.RangeDescriptor{}
+		if err := row.ValueProto(desc); err != nil {
+			log.Fatalf(context.Background(), "%s: unable to unmarshal range descriptor\n", row.Key)
+			continue
+		}
+		var storeIDs []roachpb.StoreID
+		for _, replica := range desc.Replicas {
+			storeIDs = append(storeIDs, replica.StoreID)
+		}
+		fmt.Fprintf(tw, "\t%s\t%s\t[%d]\t%d\n",
+			desc.StartKey, desc.EndKey, desc.RangeID, storeIDs)
+		if len(desc.Replicas) != 3 {
+			done = false
+		}
+	}
+	_ = tw.Flush()
+	return done, buf.String()
+}
+
+func (c *cluster) split(nodeIdx int, splitKey roachpb.Key) error {
+	return c.clients[nodeIdx].AdminSplit(splitKey)
+}
+
+func (c *cluster) transferLease(nodeIdx int, r *rand.Rand, key roachpb.Key) (bool, error) {
+	desc, err := c.lookupRange(nodeIdx, key)
+	if err != nil {
+		return false, err
+	}
+	if len(desc.Replicas) <= 1 {
+		return false, nil
+	}
+
+	target := desc.Replicas[r.Intn(len(desc.Replicas))].StoreID
+	if err := c.clients[nodeIdx].AdminTransferLease(key, target); err != nil {
+		return false, errors.Errorf("%s: transfer lease: %s", key, err)
+	}
+	return true, nil
+}
+
+func (c *cluster) lookupRange(nodeIdx int, key roachpb.Key) (*roachpb.RangeDescriptor, error) {
+	req := &roachpb.RangeLookupRequest{
+		Span: roachpb.Span{
+			Key: keys.RangeMetaKey(keys.MustAddr(key)),
+		},
+		MaxRanges:       1,
+		ConsiderIntents: false,
+	}
+	sender := c.clients[nodeIdx].GetSender()
+	resp, pErr := client.SendWrapped(sender, nil, req)
+	if pErr != nil {
+		return nil, errors.Errorf("%s: lookup range: %s", key, pErr)
+	}
+	return &resp.(*roachpb.RangeLookupResponse).Ranges[0], nil
+}
+
+type node struct {
+	syncutil.Mutex
+	LogDir string
+	Args   []string
+	Cmd    *exec.Cmd
+}
+
+func (n *node) start() {
+	n.Lock()
+	defer n.Unlock()
+
+	if n.Cmd != nil {
+		return
+	}
+
+	n.Cmd = exec.Command(n.Args[0], n.Args[1:]...)
+
+	stdoutPath := filepath.Join(n.LogDir, "stdout")
+	stdout, err := os.Create(stdoutPath)
+	if err != nil {
+		log.Fatalf(context.Background(), "unable to open file %s: %s", stdoutPath, err)
+	}
+	n.Cmd.Stdout = stdout
+
+	stderrPath := filepath.Join(n.LogDir, "stderr")
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		log.Fatalf(context.Background(), "unable to open file %s: %s", stderrPath, err)
+	}
+	n.Cmd.Stderr = stderr
+
+	err = n.Cmd.Start()
+	if n.Cmd.Process != nil {
+		log.Infof(context.Background(), "process %d started: %s",
+			n.Cmd.Process.Pid, strings.Join(n.Args, " "))
+	}
+	if err != nil {
+		log.Infof(context.Background(), "%v", err)
+		_ = stdout.Close()
+		_ = stderr.Close()
+		return
+	}
+
+	go func(cmd *exec.Cmd) {
+		if err := cmd.Wait(); err != nil {
+			log.Errorf(context.Background(), "waiting for command: %v", err)
+		}
+		_ = stdout.Close()
+		_ = stderr.Close()
+
+		ps := cmd.ProcessState
+		sy := ps.Sys().(syscall.WaitStatus)
+
+		log.Infof(context.Background(), "Process %d exited with status %d",
+			ps.Pid(), sy.ExitStatus())
+		log.Infof(context.Background(), ps.String())
+
+		n.Lock()
+		n.Cmd = nil
+		n.Unlock()
+	}(n.Cmd)
+}
+
+func (n *node) pause() {
+	n.Lock()
+	defer n.Unlock()
+	if n.Cmd == nil || n.Cmd.Process == nil {
+		return
+	}
+	_ = n.Cmd.Process.Signal(syscall.SIGSTOP)
+}
+
+// TODO(peter): node.pause is currently unused.
+var _ = (*node).pause
+
+func (n *node) resume() {
+	n.Lock()
+	defer n.Unlock()
+	if n.Cmd == nil || n.Cmd.Process == nil {
+		return
+	}
+	_ = n.Cmd.Process.Signal(syscall.SIGCONT)
+}
+
+// TODO(peter): node.resume is currently unused.
+var _ = (*node).resume
+
+func (n *node) kill() {
+	n.Lock()
+	defer n.Unlock()
+	if n.Cmd == nil || n.Cmd.Process == nil {
+		return
+	}
+	_ = n.Cmd.Process.Kill()
+}

--- a/cmd/zerosum/main.go
+++ b/cmd/zerosum/main.go
@@ -1,0 +1,336 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package main
+
+import (
+	gosql "database/sql"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/signal"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/syncutil"
+	"github.com/cockroachdb/cockroach/util/timeutil"
+
+	"golang.org/x/net/context"
+)
+
+var workers = flag.Int("w", 2*runtime.NumCPU(), "number of workers")
+var monkeys = flag.Int("m", 3, "number of monkeys")
+var numNodes = flag.Int("n", 4, "number of nodes")
+var numAccounts = flag.Int("a", 1e5, "number of accounts")
+
+// zeroSum is a bank-like simulation that tests correctness in the face of
+// aggressive splits and lease transfers. A pool of workers chooses two random
+// accounts and increments the balance in one while decrementing the balance in
+// the other (leaving the total balance as zero, hence the name). A pool of
+// monkeys splits ranges and moves leases every second or so. Periodically, we
+// perform full cluster consistency checks as well as verify that the total
+// balance in the accounts table is zero.
+//
+// The account IDs used by workers and chosen as split points are selected from
+// a zipf distribution which tilts towards smaller IDs (and hence more
+// contention).
+type zeroSum struct {
+	*cluster
+	numAccounts int
+	accounts    struct {
+		syncutil.Mutex
+		m map[uint64]struct{}
+	}
+	stats struct {
+		ops       uint64
+		errors    uint64
+		splits    uint64
+		transfers uint64
+	}
+}
+
+func newZeroSum(c *cluster, numAccounts int) *zeroSum {
+	z := &zeroSum{
+		cluster:     c,
+		numAccounts: numAccounts,
+	}
+	z.accounts.m = make(map[uint64]struct{})
+	return z
+}
+
+func (z *zeroSum) run(workers, monkeys int) {
+	tableID := z.setup()
+	for i := 0; i < workers; i++ {
+		go z.worker()
+	}
+	for i := 0; i < monkeys; i++ {
+		go z.monkey(tableID, 2*time.Second)
+	}
+	go z.check(20 * time.Second)
+	go z.verify(10 * time.Second)
+	z.monitor(time.Second)
+}
+
+func (z *zeroSum) setup() uint32 {
+	db := z.db[0]
+	if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS zerosum"); err != nil {
+		log.Fatal(context.Background(), err)
+	}
+
+	accounts := `
+CREATE TABLE IF NOT EXISTS accounts (
+  id INT PRIMARY KEY,
+  balance INT NOT NULL
+)
+`
+	if _, err := db.Exec(accounts); err != nil {
+		log.Fatal(context.Background(), err)
+	}
+
+	tableIDQuery := `
+SELECT tables.id FROM system.namespace tables
+  JOIN system.namespace dbs ON dbs.id = tables.parentid
+  WHERE dbs.name = $1 AND tables.name = $2
+`
+	var tableID uint32
+	if err := db.QueryRow(tableIDQuery, "zerosum", "accounts").Scan(&tableID); err != nil {
+		log.Fatal(context.Background(), err)
+	}
+	return tableID
+}
+
+func (z *zeroSum) accountDistribution(r *rand.Rand) *rand.Zipf {
+	// We use a Zipf distribution for selecting accounts.
+	return rand.NewZipf(r, 1.1, float64(z.numAccounts/10), uint64(z.numAccounts-1))
+}
+
+func (z *zeroSum) accountsLen() int {
+	z.accounts.Lock()
+	defer z.accounts.Unlock()
+	return len(z.accounts.m)
+}
+
+func (z *zeroSum) worker() {
+	r := rand.New(rand.NewSource(int64(timeutil.Now().UnixNano())))
+	zipf := z.accountDistribution(r)
+
+	for {
+		from := zipf.Uint64()
+		to := zipf.Uint64()
+		if from == to {
+			continue
+		}
+
+		db := z.db[r.Intn(len(z.db))]
+		err := crdb.ExecuteTx(db, func(tx *gosql.Tx) error {
+			rows, err := tx.Query(`SELECT id, balance FROM accounts WHERE id IN ($1, $2)`, from, to)
+			if err != nil {
+				return err
+			}
+
+			var fromBalance, toBalance int64
+			for rows.Next() {
+				var id uint64
+				var balance int64
+				if err = rows.Scan(&id, &balance); err != nil {
+					log.Fatal(context.Background(), err)
+				}
+				switch id {
+				case from:
+					fromBalance = balance
+				case to:
+					toBalance = balance
+				default:
+					panic(fmt.Sprintf("got unexpected account %d", id))
+				}
+			}
+
+			upsert := `UPSERT INTO accounts VALUES ($1, $3), ($2, $4)`
+			_, err = tx.Exec(upsert, to, from, toBalance+1, fromBalance-1)
+			return err
+		})
+		if err != nil {
+			log.Error(context.Background(), err)
+			atomic.AddUint64(&z.stats.errors, 1)
+		} else {
+			atomic.AddUint64(&z.stats.ops, 1)
+			z.accounts.Lock()
+			z.accounts.m[from] = struct{}{}
+			z.accounts.m[to] = struct{}{}
+			z.accounts.Unlock()
+		}
+	}
+}
+
+func (z *zeroSum) monkey(tableID uint32, d time.Duration) {
+	r := rand.New(rand.NewSource(int64(timeutil.Now().UnixNano())))
+	zipf := z.accountDistribution(r)
+
+	for {
+		time.Sleep(time.Duration(rand.Float64() * float64(d)))
+
+		key := keys.MakeTablePrefix(tableID)
+		key = encoding.EncodeVarintAscending(key, int64(zipf.Uint64()))
+		key = keys.MakeRowSentinelKey(key)
+
+		switch r.Intn(2) {
+		case 0:
+			if err := z.split(r.Intn(len(z.nodes)), key); err != nil {
+				if strings.Index(err.Error(), "range is already split at key") != -1 ||
+					strings.Index(err.Error(), "conflict updating range descriptors") != -1 {
+					continue
+				}
+				log.Error(context.Background(), err)
+				atomic.AddUint64(&z.stats.errors, 1)
+			} else {
+				atomic.AddUint64(&z.stats.splits, 1)
+			}
+		case 1:
+			if transferred, err := z.transferLease(r.Intn(len(z.nodes)), r, key); err != nil {
+				log.Error(context.Background(), err)
+				atomic.AddUint64(&z.stats.errors, 1)
+			} else if transferred {
+				atomic.AddUint64(&z.stats.transfers, 1)
+			}
+		}
+	}
+}
+
+func (z *zeroSum) check(d time.Duration) {
+	for {
+		time.Sleep(d)
+
+		client := z.clients[rand.Intn(len(z.clients))]
+		if err := client.CheckConsistency(keys.LocalMax, keys.MaxKey, false); err != nil {
+			log.Fatal(context.Background(), err)
+		}
+	}
+}
+
+func (z *zeroSum) verify(d time.Duration) {
+	for {
+		time.Sleep(d)
+
+		// Grab the count of accounts from committed transactions first. The number
+		// of accounts found by the SELECT should be at least this number.
+		committedAccounts := uint64(z.accountsLen())
+
+		q := `SELECT count(*), sum(balance) FROM accounts`
+		var accounts uint64
+		var total int64
+		db := z.db[rand.Intn(len(z.db))]
+		if err := db.QueryRow(q).Scan(&accounts, &total); err != nil {
+			log.Error(context.Background(), err)
+			atomic.AddUint64(&z.stats.errors, 1)
+			continue
+		}
+		if total != 0 {
+			log.Fatalf(context.Background(), "unexpected total balance %d", total)
+		}
+		if accounts < committedAccounts {
+			log.Fatalf(context.Background(), "expected at least %d accounts, but found %d",
+				committedAccounts, accounts)
+		}
+	}
+}
+
+func (z *zeroSum) replicaInfo() (int, string) {
+	replicas := make([]int, len(z.nodes))
+	client := z.clients[rand.Intn(len(z.clients))]
+	rows, err := client.Scan(keys.Meta2Prefix, keys.Meta2KeyMax, 0)
+	if err != nil {
+		log.Error(context.Background(), err)
+		atomic.AddUint64(&z.stats.errors, 1)
+		return -1, ""
+	}
+	for _, row := range rows {
+		desc := &roachpb.RangeDescriptor{}
+		if err := row.ValueProto(desc); err != nil {
+			log.Errorf(context.Background(), "%s: unable to unmarshal range descriptor", row.Key)
+			atomic.AddUint64(&z.stats.errors, 1)
+			continue
+		}
+		for _, replica := range desc.Replicas {
+			replicas[replica.NodeID-1]++
+		}
+	}
+	s := fmt.Sprint(replicas)
+	return len(rows), s[1 : len(s)-1]
+}
+
+func (z *zeroSum) monitor(d time.Duration) {
+	var timer timeutil.Timer
+	defer timer.Stop()
+	timer.Reset(d)
+
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	start := timeutil.Now()
+	lastTime := start
+	var lastOps uint64
+
+	for ticks := 0; true; ticks++ {
+		select {
+		case s := <-signalCh:
+			log.Infof(context.Background(), "signal received: %v", s)
+			return
+		case <-timer.C:
+			if ticks%20 == 0 {
+				fmt.Printf("_elapsed__accounts_________ops__ops/sec___errors___splits____xfers___ranges_____________replicas\n")
+			}
+
+			now := timeutil.Now()
+			elapsed := now.Sub(lastTime).Seconds()
+			ops := atomic.LoadUint64(&z.stats.ops)
+			ranges, replicas := z.replicaInfo()
+
+			fmt.Printf("%8s %9d %11d %8.1f %8d %8d %8d %8d %20s\n",
+				time.Duration(now.Sub(start).Seconds()+0.5)*time.Second,
+				z.accountsLen(), ops, float64(ops-lastOps)/elapsed,
+				atomic.LoadUint64(&z.stats.errors),
+				atomic.LoadUint64(&z.stats.splits),
+				atomic.LoadUint64(&z.stats.transfers),
+				ranges, replicas)
+			lastTime = now
+			lastOps = ops
+
+			timer.Read = true
+			timer.Reset(d)
+		}
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	c := newCluster(*numNodes)
+	defer c.close()
+
+	c.start("zerosum", flag.Args())
+	c.waitForFullReplication()
+
+	z := newZeroSum(c, *numAccounts)
+	z.run(*workers, *monkeys)
+}


### PR DESCRIPTION
ZeroSum is a bank-like simulation that tests correctness in the face of
aggressive splits and lease transfers. Does not use `TestCluster` because I
want to eventually add node outages. Does not use docker because.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8034)

<!-- Reviewable:end -->
