### PR TITLE
sql: Move remaining handling of DatabaseDescriptors into DatabaseAccessor

### DIFF
--- a/sql/create.go
+++ b/sql/create.go
@@ -71,7 +71,7 @@ func (n *createDatabaseNode) expandPlan() error {
 func (n *createDatabaseNode) Start() error {
 	desc := makeDatabaseDesc(n.n)
 
-	created, err := n.p.createDescriptor(databaseKey{string(n.n.Name)}, &desc, n.n.IfNotExists)
+	created, err := n.p.createDatabase(&desc, n.n.IfNotExists)
 	if err != nil {
 		return err
 	}

--- a/sql/database.go
+++ b/sql/database.go
@@ -108,6 +108,12 @@ type DatabaseAccessor interface {
 	// uses the descriptor cache if possible, otherwise falls back to KV
 	// operations.
 	getDatabaseID(name string) (sqlbase.ID, error)
+
+	// createDatabase attempts to create a database with the provided DatabaseDescriptor.
+	// Returns true if the database is actually created, false if it already existed,
+	// or an error if one was encountered. The ifNotExists flag is used to declare
+	// if the "already existed" state should be an error (false) or a no-op (true).
+	createDatabase(desc *sqlbase.DatabaseDescriptor, ifNotExists bool) (bool, error)
 }
 
 var _ DatabaseAccessor = &planner{}
@@ -193,4 +199,9 @@ func (p *planner) getDatabaseID(name string) (sqlbase.ID, error) {
 
 	p.databaseCache.setID(name, desc.ID)
 	return desc.ID, nil
+}
+
+// createDatabase implements the DatabaseAccessor interface.
+func (p *planner) createDatabase(desc *sqlbase.DatabaseDescriptor, ifNotExists bool) (bool, error) {
+	return p.createDescriptor(databaseKey{desc.Name}, desc, ifNotExists)
 }

--- a/sql/database.go
+++ b/sql/database.go
@@ -21,6 +21,8 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/config"
+	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -114,6 +116,11 @@ type DatabaseAccessor interface {
 	// or an error if one was encountered. The ifNotExists flag is used to declare
 	// if the "already existed" state should be an error (false) or a no-op (true).
 	createDatabase(desc *sqlbase.DatabaseDescriptor, ifNotExists bool) (bool, error)
+
+	// renameDatabase attempts to rename the database with the provided DatabaseDescriptor
+	// to a new name. The method will mutate the provided DatabaseDescriptor, updating its
+	// name with the new name.
+	renameDatabase(oldDesc *sqlbase.DatabaseDescriptor, newName string) error
 }
 
 var _ DatabaseAccessor = &planner{}
@@ -204,4 +211,42 @@ func (p *planner) getDatabaseID(name string) (sqlbase.ID, error) {
 // createDatabase implements the DatabaseAccessor interface.
 func (p *planner) createDatabase(desc *sqlbase.DatabaseDescriptor, ifNotExists bool) (bool, error) {
 	return p.createDescriptor(databaseKey{desc.Name}, desc, ifNotExists)
+}
+
+// renameDatabase implements the DatabaseAccessor interface.
+func (p *planner) renameDatabase(oldDesc *sqlbase.DatabaseDescriptor, newName string) error {
+	oldName := oldDesc.Name
+	oldDesc.SetName(newName)
+	if err := oldDesc.Validate(); err != nil {
+		return err
+	}
+
+	oldKey := databaseKey{oldName}.Key()
+	newKey := databaseKey{newName}.Key()
+	descID := oldDesc.GetID()
+	descKey := sqlbase.MakeDescMetadataKey(descID)
+	descDesc := sqlbase.WrapDescriptor(oldDesc)
+
+	b := client.Batch{}
+	b.CPut(newKey, descID, nil)
+	b.Put(descKey, descDesc)
+	b.Del(oldKey)
+
+	if err := p.txn.Run(&b); err != nil {
+		if _, ok := err.(*roachpb.ConditionFailedError); ok {
+			return fmt.Errorf("the new database name %q already exists", newName)
+		}
+		return err
+	}
+
+	p.setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
+		if err := expectDescriptorID(systemConfig, newKey, descID); err != nil {
+			return err
+		}
+		if err := expectDescriptor(systemConfig, descKey, descDesc); err != nil {
+			return err
+		}
+		return expectDeleted(systemConfig, oldKey)
+	})
+	return nil
 }

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -45,7 +45,9 @@ type DescriptorAccessor interface {
 
 	// createDescriptor takes a Table or Database descriptor and creates it if
 	// needed, incrementing the descriptor counter. Returns true if the descriptor
-	// is actually created, false if it already existed.
+	// is actually created, false if it already existed, or an error if one was encountered.
+	// The ifNotExists flag is used to declare if the "already existed" state should be an
+	// error (false) or a no-op (true).
 	createDescriptor(plainKey sqlbase.DescriptorKey, descriptor sqlbase.DescriptorProto, ifNotExists bool) (bool, error)
 
 	// getDescriptor looks up the descriptor for `plainKey`, validates it,


### PR DESCRIPTION
This change add the following methods to the `DatabaseAccessor` interface:
- `createDatabase`
- `renameDatabase`

The change is needed because #7965 necessitates mocking out certain `DatabaseDescriptor` accesses. Moving all of these accesses into the `DatabaseAccessor` interface allows the changes needed for #7965 to be much more localized.

A good sign that this is the correct boundary of abstraction is that `databaseKey` is now only used within the `DatabaseAccessor` implementation.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8037)

<!-- Reviewable:end -->
