### PR TITLE
storage: set Closer in GetSnapshot retry

### DIFF
--- a/sql/parallel_test.go
+++ b/sql/parallel_test.go
@@ -70,7 +70,13 @@ func (t *parallelTest) processTestFile(path string, nodeIdx int, db *gosql.DB, c
 	}
 
 	// Set up a dummy logicTest structure to use that code.
-	l := &logicTest{T: t.T, srv: t.cluster.Server(nodeIdx), db: db, user: security.RootUser}
+	l := &logicTest{
+		T:       t.T,
+		srv:     t.cluster.Server(nodeIdx),
+		db:      db,
+		user:    security.RootUser,
+		verbose: testing.Verbose() || log.V(1),
+	}
 	if err := l.processTestFile(path); err != nil {
 		t.Error(err)
 	}

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -349,6 +349,7 @@ func (r *Replica) GetSnapshot(ctx context.Context) (raftpb.Snapshot, error) {
 		InitialBackoff: 1 * time.Millisecond,
 		MaxBackoff:     50 * time.Millisecond,
 		Multiplier:     2,
+		Closer:         r.store.Stopper().ShouldQuiesce(),
 	}
 	for retry := retry.Start(retryOptions); retry.Next(); {
 		log.Trace(ctx, fmt.Sprintf("snapshot retry loop pass %d", retry.CurrentAttempt()))


### PR DESCRIPTION
Fix subquery_retry_multinode test timeout caused by retry loop in
GetSnapshot. Part of #8057.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8058)

<!-- Reviewable:end -->
