### PR TITLE
distsql: set NodeID and FlowID in logging contexts

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -185,7 +185,6 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 
 	// Set up the DistSQL server
 	distSQLCtx := distsql.ServerContext{
-		// TODO(radu): set node ID in the context.
 		Context:    context.Background(),
 		DB:         s.db,
 		RPCContext: s.rpcContext,
@@ -421,6 +420,7 @@ func (s *Server) Start() error {
 	s.node.startWriteSummaries(s.ctx.MetricsSampleInterval)
 
 	s.sqlExecutor.SetNodeID(s.node.Descriptor.NodeID)
+	s.distSQLServer.SetNodeID(s.node.Descriptor.NodeID)
 
 	// Create and start the schema change manager only after a NodeID
 	// has been assigned.

--- a/sql/distsql/flow.go
+++ b/sql/distsql/flow.go
@@ -45,7 +45,7 @@ type FlowID struct {
 
 // FlowCtx encompasses the contexts needed for various flow components.
 type FlowCtx struct {
-	context.Context
+	Context context.Context
 	id      FlowID
 	evalCtx *parser.EvalContext
 	rpcCtx  *rpc.Context
@@ -84,7 +84,7 @@ func newFlow(
 	flowReg *flowRegistry,
 	simpleFlowConsumer RowReceiver,
 ) *Flow {
-	// TODO(radu): add Flow ID to flowCtx.Context.
+	flowCtx.Context = log.WithLogTagStr(flowCtx.Context, "flow", flowCtx.id.Short())
 	return &Flow{
 		FlowCtx:            flowCtx,
 		flowRegistry:       flowReg,
@@ -108,7 +108,7 @@ func (f *Flow) setupInboundStream(spec StreamEndpointSpec, rowChan *RowChannel) 
 			f.inboundStreams = make(map[StreamID]RowReceiver)
 		}
 		if log.V(2) {
-			log.Infof(f.FlowCtx, "Set up inbound stream %d", sid)
+			log.Infof(f.FlowCtx.Context, "Set up inbound stream %d", sid)
 		}
 		f.inboundStreams[sid] = rowChan
 		return nil

--- a/sql/distsql/inbound.go
+++ b/sql/distsql/inbound.go
@@ -27,8 +27,9 @@ import (
 // already received (because the first message contains the flow and stream IDs,
 // it needs to be received before we can get here).
 func ProcessInboundStream(
-	ctx *FlowCtx, stream DistSQL_FlowStreamServer, firstMsg *StreamMessage, dst RowReceiver,
+	flowCtx *FlowCtx, stream DistSQL_FlowStreamServer, firstMsg *StreamMessage, dst RowReceiver,
 ) error {
+	ctx := flowCtx.Context
 	// Function which we call when we are done.
 	finish := func(err error) error {
 		dst.Close(err)

--- a/sql/distsql/server.go
+++ b/sql/distsql/server.go
@@ -33,7 +33,7 @@ import (
 // ServerContext encompasses the configuration required to create a
 // DistSQLServer.
 type ServerContext struct {
-	context.Context
+	Context    context.Context
 	DB         *client.DB
 	RPCContext *rpc.Context
 }
@@ -63,6 +63,11 @@ func NewServer(ctx ServerContext) *ServerImpl {
 	return ds
 }
 
+// SetNodeID sets the NodeID for the server.
+func (ds *ServerImpl) SetNodeID(nodeID roachpb.NodeID) {
+	ds.ServerContext.Context = log.WithLogTagInt(ds.ServerContext.Context, "node", int(nodeID))
+}
+
 func (ds *ServerImpl) setupTxn(
 	ctx context.Context,
 	txnProto *roachpb.Transaction,
@@ -79,7 +84,6 @@ func (ds *ServerImpl) SetupSimpleFlow(
 	ctx context.Context, req *SetupFlowRequest, output RowReceiver,
 ) (*Flow, error) {
 	txn := ds.setupTxn(ctx, &req.Txn)
-	// TODO(radu): "merge" information from ctx and the server context.
 	flowCtx := FlowCtx{
 		Context: ds.ServerContext.Context,
 		id:      req.Flow.FlowID,
@@ -91,7 +95,7 @@ func (ds *ServerImpl) SetupSimpleFlow(
 	f := newFlow(flowCtx, ds.flowRegistry, output)
 	err := f.setupFlow(&req.Flow)
 	if err != nil {
-		log.Errorf(ds, err.Error(), "", err)
+		log.Errorf(ds.Context, err.Error(), "", err)
 		return nil, err
 	}
 	return f, nil
@@ -101,16 +105,17 @@ func (ds *ServerImpl) SetupSimpleFlow(
 func (ds *ServerImpl) RunSimpleFlow(
 	req *SetupFlowRequest, stream DistSQL_RunSimpleFlowServer,
 ) error {
-	// TODO(radu): merge context with server context.
+	ctx := ds.ServerContext.Context
 
 	// Set up the outgoing mailbox for the stream.
-	mbox := newOutboxSimpleFlowStream(stream.Context(), stream)
+	mbox := newOutboxSimpleFlowStream(stream)
 
-	f, err := ds.SetupSimpleFlow(stream.Context(), req, mbox)
+	f, err := ds.SetupSimpleFlow(ctx, req, mbox)
 	if err != nil {
-		log.Errorf(ds, err.Error(), "", err)
+		log.Errorf(ds.Context, err.Error(), "", err)
 		return err
 	}
+	mbox.setFlowCtx(&f.FlowCtx)
 
 	// TODO(radu): this stuff should probably be run through a stopper.
 	mbox.start(&f.waitGroup)
@@ -127,7 +132,6 @@ func (ds *ServerImpl) SetupFlow(ctx context.Context, req *SetupFlowRequest) (
 	// Note: ctx will be canceled when the RPC completes, so we can't associate
 	// it with the transaction.
 
-	// TODO(radu): "merge" information from ctx and the server context.
 	txn := ds.setupTxn(ds.ServerContext.Context, &req.Txn)
 	flowCtx := FlowCtx{
 		Context: ds.ServerContext.Context,
@@ -139,7 +143,7 @@ func (ds *ServerImpl) SetupFlow(ctx context.Context, req *SetupFlowRequest) (
 	f := newFlow(flowCtx, ds.flowRegistry, nil)
 	err := f.setupFlow(&req.Flow)
 	if err != nil {
-		log.Errorf(ds, err.Error(), "", err)
+		log.Errorf(ds.Context, err.Error(), "", err)
 		return nil, err
 	}
 	f.Start()
@@ -180,7 +184,7 @@ func (ds *ServerImpl) flowStreamInt(stream DistSQL_FlowStreamServer) error {
 func (ds *ServerImpl) FlowStream(stream DistSQL_FlowStreamServer) error {
 	err := ds.flowStreamInt(stream)
 	if err != nil {
-		log.Errorf(ds, err.Error(), "", err)
+		log.Errorf(ds.Context, err.Error(), "", err)
 	}
 	return err
 }

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -73,7 +73,7 @@ type planner struct {
 func makePlanner() *planner {
 	// init with an empty session. We can't leave this nil because too much code
 	// looks in the session for the current database.
-	return &planner{session: &Session{Location: time.UTC}}
+	return &planner{session: &Session{Location: time.UTC, context: context.Background()}}
 }
 
 // queryRunner abstracts the services provided by a planner object

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -54,6 +54,9 @@ func makeMessage(ctx context.Context, format string, args []interface{}) string 
 // addStructured creates a structured log entry to be written to the
 // specified facility of the logger.
 func addStructured(ctx context.Context, s Severity, depth int, format string, args []interface{}) {
+	if ctx == nil {
+		panic("nil context")
+	}
 	file, line, _ := caller.Lookup(depth + 1)
 	msg := makeMessage(ctx, format, args)
 	Trace(ctx, msg)


### PR DESCRIPTION
Please ignore the first commit (r1), it is a separate PR.

Sample log output:

```
I160727 14:38:38.212306 sql/distsql/tablereader.go:233  [node: 2] [flow: 4fa99b27-9834-47e3-b58e-cfeb005b0f5b] [TableReader: 51] pushing row [83 11]
I160727 14:38:38.212335 sql/distsql/tablereader.go:233  [node: 2] [flow: 4fa99b27-9834-47e3-b58e-cfeb005b0f5b] [TableReader: 51] pushing row [92 11]
I160727 14:38:38.212345 sql/distsql/outbox.go:101  [node: 2] [flow: 4fa99b27-9834-47e3-b58e-cfeb005b0f5b] flushing outbox
I160727 14:38:38.212364 sql/distsql/outbox.go:114  [node: 2] [flow: 4fa99b27-9834-47e3-b58e-cfeb005b0f5b] outbox flushed
I160727 14:38:38.212377 sql/distsql/inbound.go:80  [node: 3] [flow: 4fa99b27-9834-47e3-b58e-cfeb005b0f5b] inbound stream pushing row [81 9]
```

@tschottdorf @jordanlewis

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8066)

<!-- Reviewable:end -->
