### PR TITLE
Enable grpc tracing. Goes into /debug/requests automatically

### DIFF
--- a/rpc/context.go
+++ b/rpc/context.go
@@ -34,10 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
-func init() {
-	grpc.EnableTracing = false
-}
-
 const (
 	defaultHeartbeatInterval = 3 * time.Second
 	// The coefficient by which the maximum offset is multiplied to determine the


### PR DESCRIPTION
The default is `true`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8069)

<!-- Reviewable:end -->
