### PR TITLE
Allow TestCluster to stop an individual Server.

### DIFF
--- a/base/test_server_args.go
+++ b/base/test_server_args.go
@@ -74,9 +74,6 @@ type TestClusterArgs struct {
 	ServerArgs TestServerArgs
 	// ReplicationMode controls how replication is to be done in the cluster.
 	ReplicationMode TestClusterReplicationMode
-	// Stopper can be used to stop the cluster. If not set, a stopper will be
-	// constructed and it can be gotten through TestCluster.Stopper().
-	Stopper *stop.Stopper
 }
 
 // TestClusterReplicationMode represents the replication settings for a TestCluster.

--- a/testutils/serverutils/test_cluster_shim.go
+++ b/testutils/serverutils/test_cluster_shim.go
@@ -42,9 +42,14 @@ type TestClusterInterface interface {
 	// ServerConn returns a gosql.DB connection to a specific node.
 	ServerConn(idx int) *gosql.DB
 
-	Stopper() *stop.Stopper
-
 	WaitForFullReplication() error
+
+	// StopServer stops a single server.
+	StopServer(idx int)
+
+	// Stopper retrieves the stopper for this test cluster. Tests should call or
+	// defer the Stop() method on this stopper after starting a test cluster.
+	Stopper() *stop.Stopper
 }
 
 // TestClusterFactory encompasses the actual implementation of the shim

--- a/testutils/testcluster/testcluster_test.go
+++ b/testutils/testcluster/testcluster_test.go
@@ -19,13 +19,18 @@ package testcluster
 
 import (
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/rpc"
+	"github.com/cockroachdb/cockroach/server/serverpb"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
 )
@@ -171,5 +176,70 @@ func TestWaitForFullReplication(t *testing.T) {
 	defer tc.Stopper().Stop()
 	if err := tc.WaitForFullReplication(); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestStopServer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tc := StartTestCluster(t, 3, base.TestClusterArgs{ReplicationMode: base.ReplicationAuto})
+	defer tc.Stopper().Stop()
+	if err := tc.WaitForFullReplication(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Connect to server 1, ensure it is answering requests over HTTP and GRPC.
+	server1 := tc.Server(1)
+	var response serverpb.HealthResponse
+
+	httpClient1, err := server1.GetHTTPClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	url := server1.AdminURL() + "/_admin/v1/health"
+	if err := util.GetJSON(httpClient1, url, &response); err != nil {
+		t.Fatal(err)
+	}
+
+	rpcContext := rpc.NewContext(
+		tc.Server(1).RPCContext().Context, tc.Server(1).Clock(), tc.Stopper(),
+	)
+	conn, err := rpcContext.GRPCDial(server1.ServingAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	adminClient1 := serverpb.NewAdminClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := adminClient1.Health(ctx, &serverpb.HealthRequest{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stop server 1.
+	tc.StopServer(1)
+
+	// Verify HTTP and GRPC requests to server now fail.
+	httpErrorText := "connection refused"
+	if err := util.GetJSON(httpClient1, url, &response); err == nil {
+		t.Fatal("Expected HTTP Request to fail after server stopped")
+	} else if !testutils.IsError(err, httpErrorText) {
+		t.Fatalf("Expected error from server with text %q, got error with text %q", httpErrorText, err.Error())
+	}
+
+	grpcErrorText := "rpc error"
+	if _, err := adminClient1.Health(ctx, &serverpb.HealthRequest{}); err == nil {
+		t.Fatal("Expected GRPC Request to fail after server stopped")
+	} else if !testutils.IsError(err, grpcErrorText) {
+		t.Fatalf("Expected error from GRPC with text %q, got error with text %q", grpcErrorText, err.Error())
+	}
+
+	// Verify that request to Server 0 still works.
+	httpClient1, err = tc.Server(0).GetHTTPClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	url = tc.Server(0).AdminURL() + "/_admin/v1/health"
+	if err := util.GetJSON(httpClient1, url, &response); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Adds "StopServer" method to TestCluster, allowing individual TestServers
in a TestCluster to be stopped independently.

This commit primarily changes the "stopper" behavior in TestCluster. Previously,
one stopper was shared between all TestServers. Now, each server is given its
own stopper; the cluster creates a Worker task that waits until the cluster's
Stopper is Stop()ed, and then closes the individual stoppers of the servers.

Added a test to verify that a single server is stopped.

Commit additionally fixes a bug where open GRPC connections to a TestServer
would still function after it had been stopped.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8075)

<!-- Reviewable:end -->
