### PR TITLE
kv: check ctx.Err() in DistSender.sendChunk

### DIFF
--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -597,10 +597,11 @@ func TestTxnCoordSenderCancel(t *testing.T) {
 
 	// Commit the transaction. Note that we cancel the transaction when the
 	// commit is sent which stresses the TxnCoordSender.tryAsyncAbort code
-	// path. We'll either succeed or get a "does not exist" error. Anything else
-	// is unexpected.
+	// path. We'll either succeed, get a "does not exist" error, or get a
+	// context canceled error. Anything else is unexpected.
 	err := txn.CommitOrCleanup()
-	if err != nil && !testutils.IsError(err, "does not exist") {
+	if err != nil && err.Error() != context.Canceled.Error() &&
+		!testutils.IsError(err, "does not exist") {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
I have seen a few instances where the retry loop would take a long time and the
inner operations would keep failing with context canceled or deadline exceeded
errors. Adding a check and exiting the retry loop in this case. This doesn't
address any underlying issue but it should make bugs easier to debug (more
failures, fewer test timeouts).

Related to #8057.
@petermattis @tschottdorf

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8076)

<!-- Reviewable:end -->
