### PR TITLE
acceptance: extend remote Cluster implementation

### DIFF
--- a/acceptance/allocator_terraform/main.tf
+++ b/acceptance/allocator_terraform/main.tf
@@ -99,7 +99,7 @@ FILE
       "sudo service supervisor stop",
       "export CLOUD_SDK_REPO=\"cloud-sdk-$(lsb_release -c -s)\"",
       "echo \"deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main\" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list",
-      "curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -",
+      "curl -sS https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -",
       "sudo apt-get -qqy update >/dev/null",
       "sudo apt-get -qqy install google-cloud-sdk >/dev/null",
       "mkdir -p logs",

--- a/acceptance/allocator_test.go
+++ b/acceptance/allocator_test.go
@@ -83,6 +83,13 @@ const (
 	StableInterval   = 3 * time.Minute
 )
 
+const (
+	urlStore1s = archivedStoreURL + "/1node-10g-262ranges"
+	urlStore1m = archivedStoreURL + "/1node-2065replicas-108G"
+	urlStore3s = archivedStoreURL + "/3nodes-10g-262ranges"
+	urlStore6m = archivedStoreURL + "/6nodes-1038replicas-56G"
+)
+
 type allocatorTest struct {
 	// StartNodes is the starting number of nodes this cluster will have.
 	StartNodes int
@@ -336,7 +343,7 @@ func TestUpreplicate_1To3Small(t *testing.T) {
 	at := allocatorTest{
 		StartNodes: 1,
 		EndNodes:   3,
-		StoreURL:   archivedStoreURL + "/1node-10g-262ranges",
+		StoreURL:   urlStore1s,
 		Prefix:     "uprep-1to3s",
 	}
 	at.Run(t)
@@ -348,7 +355,7 @@ func TestRebalance_3To5Small(t *testing.T) {
 	at := allocatorTest{
 		StartNodes: 3,
 		EndNodes:   5,
-		StoreURL:   archivedStoreURL + "/3nodes-10g-262ranges",
+		StoreURL:   urlStore3s,
 		Prefix:     "rebal-3to5s",
 	}
 	at.Run(t)
@@ -360,7 +367,7 @@ func TestUpreplicate_1To3Medium(t *testing.T) {
 	at := allocatorTest{
 		StartNodes:          1,
 		EndNodes:            3,
-		StoreURL:            archivedStoreURL + "/1node-2065replicas-108G",
+		StoreURL:            urlStore1m,
 		Prefix:              "uprep-1to3m",
 		CockroachDiskSizeGB: 250, // GB
 	}
@@ -371,7 +378,7 @@ func TestUpreplicate_1To6Medium(t *testing.T) {
 	at := allocatorTest{
 		StartNodes:          1,
 		EndNodes:            6,
-		StoreURL:            archivedStoreURL + "/1node-2065replicas-108G",
+		StoreURL:            urlStore1m,
 		Prefix:              "uprep-1to6m",
 		CockroachDiskSizeGB: 250, // GB
 	}
@@ -386,7 +393,7 @@ func TestSteady_6Medium(t *testing.T) {
 	at := allocatorTest{
 		StartNodes:          6,
 		EndNodes:            6,
-		StoreURL:            archivedStoreURL + "/6nodes-1038replicas-56G",
+		StoreURL:            urlStore6m,
 		Prefix:              "steady-6m",
 		CockroachDiskSizeGB: 250, // GB
 	}

--- a/acceptance/allocator_test.go
+++ b/acceptance/allocator_test.go
@@ -60,7 +60,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -110,17 +109,17 @@ type allocatorTest struct {
 	f *terrafarm.Farmer
 }
 
+func (at *allocatorTest) Cleanup(t *testing.T) {
+	if r := recover(); r != nil {
+		t.Errorf("recovered from panic to destroy cluster: %v", r)
+	}
+	if at.f != nil {
+		at.f.MustDestroy(t)
+	}
+}
+
 func (at *allocatorTest) Run(t *testing.T) {
 	at.f = farmer(t, at.Prefix)
-	if e := "GOOGLE_PROJECT"; os.Getenv(e) == "" {
-		t.Fatalf("%s environment variable must be set for Terraform", e)
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("recovered from panic to destroy cluster: %v", r)
-		}
-		at.f.MustDestroy(t)
-	}()
 
 	// Pass on overrides to Terraform input variables.
 	if *flagATCockroachBinary != "" {
@@ -187,8 +186,12 @@ func (at *allocatorTest) Run(t *testing.T) {
 	if err := at.WaitForRebalance(t); err != nil {
 		t.Fatal(err)
 	}
-
 	at.f.Assert(t)
+}
+
+func (at *allocatorTest) RunAndCleanup(t *testing.T) {
+	defer at.Cleanup(t)
+	at.Run(t)
 }
 
 // printStats prints the time it took for rebalancing to finish and the final
@@ -296,7 +299,7 @@ func (at *allocatorTest) checkAllocatorStable(db *gosql.DB) (bool, error) {
 // This method is crude but necessary. If we were to wait until range counts
 // were just about even, we'd miss potential post-rebalance thrashing.
 func (at *allocatorTest) WaitForRebalance(t *testing.T) error {
-	db, err := gosql.Open("postgres", at.f.PGUrl(1))
+	db, err := gosql.Open("postgres", at.f.PGUrl(0))
 	if err != nil {
 		return err
 	}
@@ -346,7 +349,7 @@ func TestUpreplicate_1To3Small(t *testing.T) {
 		StoreURL:   urlStore1s,
 		Prefix:     "uprep-1to3s",
 	}
-	at.Run(t)
+	at.RunAndCleanup(t)
 }
 
 // TestRebalance3to5Small tests rebalancing, starting with 3 nodes (each
@@ -358,7 +361,7 @@ func TestRebalance_3To5Small(t *testing.T) {
 		StoreURL:   urlStore3s,
 		Prefix:     "rebal-3to5s",
 	}
-	at.Run(t)
+	at.RunAndCleanup(t)
 }
 
 // TestUpreplicate_1To3Medium tests up-replication, starting with 1 node
@@ -371,9 +374,12 @@ func TestUpreplicate_1To3Medium(t *testing.T) {
 		Prefix:              "uprep-1to3m",
 		CockroachDiskSizeGB: 250, // GB
 	}
-	at.Run(t)
+	at.RunAndCleanup(t)
 }
 
+// TestUpreplicate_1To6Medium tests up-replication (and, to a lesser extent,
+// rebalancing), starting with 1 node containing 108 GiB of data and growing to
+// 6 nodes.
 func TestUpreplicate_1To6Medium(t *testing.T) {
 	at := allocatorTest{
 		StartNodes:          1,
@@ -382,7 +388,7 @@ func TestUpreplicate_1To6Medium(t *testing.T) {
 		Prefix:              "uprep-1to6m",
 		CockroachDiskSizeGB: 250, // GB
 	}
-	at.Run(t)
+	at.RunAndCleanup(t)
 }
 
 // TestSteady_6Medium is useful for creating a medium-size balanced cluster
@@ -397,5 +403,5 @@ func TestSteady_6Medium(t *testing.T) {
 		Prefix:              "steady-6m",
 		CockroachDiskSizeGB: 250, // GB
 	}
-	at.Run(t)
+	at.RunAndCleanup(t)
 }

--- a/acceptance/cluster/cluster.go
+++ b/acceptance/cluster/cluster.go
@@ -56,7 +56,7 @@ type Cluster interface {
 	// URL returns the HTTP(s) endpoint.
 	URL(int) string
 	// Addr returns the host and port from the node in the format HOST:PORT.
-	Addr(int) string
+	Addr(i int, port string) string
 }
 
 // Consistent performs a replication consistency check on all the ranges

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -794,8 +794,8 @@ func (l *LocalCluster) URL(i int) string {
 }
 
 // Addr returns the host and port from the node in the format HOST:PORT.
-func (l *LocalCluster) Addr(i int) string {
-	return l.Nodes[i].Addr(defaultHTTP).String()
+func (l *LocalCluster) Addr(i int, port string) string {
+	return l.Nodes[i].Addr(nat.Port(port + "/tcp")).String()
 }
 
 // ExecRoot runs a command as root.

--- a/acceptance/cluster/stdcopy_test.go
+++ b/acceptance/cluster/stdcopy_test.go
@@ -105,22 +105,22 @@ func TestWriteDoesNotReturnNegativeWrittenBytes(t *testing.T) {
 	}
 }
 
-func getSrcBuffer(stdOutBytes, stdErrBytes []byte) (buffer *bytes.Buffer, err error) {
+func getSrcBuffer(stdoutBytes, stderrBytes []byte) (buffer *bytes.Buffer, err error) {
 	buffer = new(bytes.Buffer)
 	dstOut := NewStdWriter(buffer, Stdout)
-	_, err = dstOut.Write(stdOutBytes)
+	_, err = dstOut.Write(stdoutBytes)
 	if err != nil {
 		return
 	}
 	dstErr := NewStdWriter(buffer, Stderr)
-	_, err = dstErr.Write(stdErrBytes)
+	_, err = dstErr.Write(stderrBytes)
 	return
 }
 
 func TestStdCopyWriteAndRead(t *testing.T) {
-	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
-	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
-	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	stdoutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stderrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdoutBytes, stderrBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestStdCopyWriteAndRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedTotalWritten := len(stdOutBytes) + len(stdErrBytes)
+	expectedTotalWritten := len(stdoutBytes) + len(stderrBytes)
 	if written != int64(expectedTotalWritten) {
 		t.Fatalf("Expected to have total of %d bytes written, got %d", expectedTotalWritten, written)
 	}
@@ -165,9 +165,9 @@ func TestStdCopyReturnsErrorReadingHeader(t *testing.T) {
 
 func TestStdCopyReturnsErrorReadingFrame(t *testing.T) {
 	expectedError := errors.New("error")
-	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
-	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
-	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	stdoutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stderrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdoutBytes, stderrBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,9 +186,9 @@ func TestStdCopyReturnsErrorReadingFrame(t *testing.T) {
 }
 
 func TestStdCopyDetectsCorruptedFrame(t *testing.T) {
-	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
-	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
-	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	stdoutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stderrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdoutBytes, stderrBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,9 +229,9 @@ func TestStdCopyWithCorruptedPrefix(t *testing.T) {
 }
 
 func TestStdCopyReturnsWriteErrors(t *testing.T) {
-	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
-	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
-	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	stdoutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stderrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdoutBytes, stderrBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,9 +249,9 @@ func TestStdCopyReturnsWriteErrors(t *testing.T) {
 }
 
 func TestStdCopyDetectsNotFullyWrittenFrames(t *testing.T) {
-	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
-	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
-	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	stdoutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stderrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdoutBytes, stderrBytes)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/acceptance/continuous_load_test.go
+++ b/acceptance/continuous_load_test.go
@@ -16,7 +16,6 @@ package acceptance
 
 import (
 	"flag"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -72,9 +71,6 @@ func (cl continuousLoadTest) Run(t *testing.T) {
 	ctx, err := WithClusterTimeout(context.Background())
 	if err != nil {
 		t.Fatal(err)
-	}
-	if e := "GOOGLE_PROJECT"; os.Getenv(e) == "" {
-		t.Fatalf("%s environment variable must be set for Terraform", e)
 	}
 	if deadline, ok := ctx.Deadline(); ok {
 		log.Infof(ctx, "load test will end at %s", deadline)

--- a/acceptance/dynamic_client.go
+++ b/acceptance/dynamic_client.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -60,7 +61,7 @@ func (dc *dynamicClient) Close() {
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 	for i, client := range dc.mu.clients {
-		log.Infof(context.TODO(), "closing connection to %s", dc.cluster.Addr(i))
+		log.Infof(context.TODO(), "closing connection to %s", dc.cluster.Addr(i, base.DefaultPort))
 		client.Close()
 		delete(dc.mu.clients, i)
 	}
@@ -113,10 +114,11 @@ func (dc *dynamicClient) getClient() (*gosql.DB, error) {
 		}
 		client, err := gosql.Open("postgres", dc.cluster.PGUrl(index))
 		if err != nil {
-			log.Infof(context.TODO(), "could not establish connection to %s: %s", dc.cluster.Addr(index), err)
+			log.Infof(context.TODO(), "could not establish connection to %s: %s", dc.cluster.Addr(index, base.DefaultPort), err)
 			continue
 		}
-		log.Infof(context.TODO(), "connection established to %s", dc.cluster.Addr(index))
+		log.Infof(context.TODO(), "connection established to %s",
+			dc.cluster.Addr(index, base.DefaultPort))
 		dc.mu.clients[index] = client
 		return client, nil
 	}

--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/internal/client"
+	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util/retry"
 	"github.com/cockroachdb/cockroach/util/stop"
@@ -204,18 +205,40 @@ func (f *Farmer) Exec(i int, cmd string) error {
 
 // NewClient implements the Cluster interface.
 func (f *Farmer) NewClient(t *testing.T, i int) (*client.DB, *stop.Stopper) {
-	panic("unimplemented")
+	stopper := stop.NewStopper()
+	rpcContext := rpc.NewContext(&base.Context{
+		Insecure: true,
+		User:     security.NodeUser,
+	}, nil, stopper)
+	sender, err := client.NewSender(rpcContext, f.Addr(i, base.DefaultPort))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client.NewDB(sender), stopper
 }
 
 // PGUrl returns a URL string for the given node postgres server.
 func (f *Farmer) PGUrl(i int) string {
-	host := f.Nodes()[i-1]
+	host := f.Nodes()[i]
 	return fmt.Sprintf("postgresql://%s@%s:26257/system?sslmode=disable", security.RootUser, host)
 }
 
 // InternalIP returns the address used for inter-node communication.
 func (f *Farmer) InternalIP(i int) net.IP {
-	panic("unimplemented")
+	// TODO(tschottdorf): This is specific to GCE. On AWS, the following
+	// might do it: `curl -sS http://instance-data/latest/meta-data/public-ipv4`.
+	// See https://flummox-engineering.blogspot.com/2014/01/get-ip-address-of-google-compute-engine.html
+	cmd := `curl -sS "http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip" -H "X-Google-Metadata-Request: True"`
+	stdout, stderr, err := f.ssh(f.Nodes()[i], f.defaultKeyFile(), cmd)
+	if err != nil {
+		panic(errors.Wrapf(err, stderr+"\n"+stdout))
+	}
+	stdout = strings.TrimSpace(stdout)
+	ip := net.ParseIP(stdout)
+	if ip == nil {
+		panic(fmt.Sprintf("'%s' did not parse to an IP", stdout))
+	}
+	return ip
 }
 
 // WaitReady waits until the infrastructure is in a state that *should* allow
@@ -279,9 +302,9 @@ func (f *Farmer) AssertAndStop(t *testing.T) {
 
 // ExecRoot executes the given command with super-user privileges.
 func (f *Farmer) ExecRoot(i int, cmd []string) error {
-	// We have `f.Exec(i, strings.Join(" ", cmd))`, so this should be
-	// easy to implement once we need it.
-	panic("unimplemented")
+	// TODO(tschottdorf): This doesn't handle escapes properly. May it never
+	// have to.
+	return f.Exec(i, "sudo "+strings.Join(cmd, " "))
 }
 
 // Kill terminates the cockroach process running on the given node number.
@@ -320,8 +343,8 @@ func (f *Farmer) URL(i int) string {
 }
 
 // Addr returns the host and port from the node in the format HOST:PORT.
-func (f *Farmer) Addr(i int) string {
-	return net.JoinHostPort(f.Nodes()[i], base.DefaultHTTPPort)
+func (f *Farmer) Addr(i int, port string) string {
+	return net.JoinHostPort(f.Nodes()[i], port)
 }
 
 func (f *Farmer) logf(format string, args ...interface{}) {

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -140,12 +140,16 @@ func runTests(m *testing.M) {
 var prefixRE = regexp.MustCompile("^(?:[a-z](?:[-a-z0-9]{0,45}[a-z0-9])?)$")
 
 func farmer(t *testing.T, prefix string) *terrafarm.Farmer {
-	if !*flagRemote {
-		t.Skip("running in docker mode")
-	}
+	SkipUnlessRemote(t)
+
 	if *flagKeyName == "" {
 		t.Fatal("-key-name is required") // saves a lot of trouble
 	}
+
+	if e := "GOOGLE_PROJECT"; os.Getenv(e) == "" {
+		t.Fatalf("%s environment variable must be set for Terraform", e)
+	}
+
 	logDir := *flagLogDir
 	if logDir == "" {
 		var err error
@@ -329,6 +333,13 @@ func StartCluster(t *testing.T, cfg cluster.TestConfig) (c cluster.Cluster) {
 func SkipUnlessLocal(t *testing.T) {
 	if *flagRemote {
 		t.Skip("skipping since not run against local cluster")
+	}
+}
+
+// SkipUnlessRemote calls t.Skip if not running against a remote cluster.
+func SkipUnlessRemote(t *testing.T) {
+	if !*flagRemote {
+		t.Skip("skipping since not run against remote cluster")
 	}
 }
 

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -174,7 +174,7 @@ func farmer(t *testing.T, prefix string) *terrafarm.Farmer {
 			name += "-"
 		}
 
-		name += "-" + getRandomName()
+		name += getRandomName()
 
 		// Rudimentary collision control.
 		for i := 0; ; i++ {


### PR DESCRIPTION
Implemented `NewClient`, `ExecRoot`, `InternalIP` and verified that
`TestPartitionBank` works (though it will likely exhibit the same
timeouts for which the test is already skipped). Minor edits to the
`iptables` partitioner to be able to run against a steady cluster even
when crashing half-way through.
`checkRangeReplication` also works against remote clusters now.
Fixed an off-by-one in remote cluster's PGUrl (we start at zero, not one).

From here on, should be easy to add additional nemeses which periodically
kill nodes or perform other shenanigans.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8091)

<!-- Reviewable:end -->
