### PR TITLE
storage: Increase replica descriptor cache size

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1683,11 +1683,11 @@ func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 	r.store.mu.Unlock()
 
 	if toErr != nil {
-		log.Warningf(context.TODO(), "failed to look up recipient replica %d in range %d: %s", msg.To, rangeID, toErr)
+		log.Warningf(context.TODO(), "failed to look up recipient replica %d in range %d while sending %s: %s", msg.To, rangeID, msg.Type, toErr)
 		return
 	}
 	if fromErr != nil {
-		log.Warningf(context.TODO(), "failed to look up sender replica %d in range %d: %s", msg.From, rangeID, fromErr)
+		log.Warningf(context.TODO(), "failed to look up sender replica %d in range %d while sending %s: %s", msg.From, rangeID, msg.Type, fromErr)
 		return
 	}
 	if !r.raftSender.SendAsync(&RaftMessageRequest{

--- a/storage/store.go
+++ b/storage/store.go
@@ -76,7 +76,7 @@ const (
 	// reloaded from disk as needed) don't crowd out the
 	// message/snapshot descriptors (whose necessity is short-lived but
 	// cannot be recovered through other means if evicted)?
-	maxReplicaDescCacheSize = 1000
+	maxReplicaDescCacheSize = 10000
 
 	// rangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the leader
 	// lease active duration should be of the raft election timeout.


### PR DESCRIPTION
Improve logging for replica descriptor cache misses.

This is a quick fix for #8056

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8094)

<!-- Reviewable:end -->
