### PR TITLE
util/log: avoid panic in custom flag.Value implementations

### DIFF
--- a/util/log/file.go
+++ b/util/log/file.go
@@ -72,6 +72,9 @@ func (s *stringValue) Type() string {
 }
 
 func (s *stringValue) String() string {
+	if s.val == nil {
+		return ""
+	}
 	return *s.val
 }
 

--- a/util/log/logflags/logflags.go
+++ b/util/log/logflags/logflags.go
@@ -32,6 +32,9 @@ func (ab *atomicBool) IsBoolFlag() bool {
 }
 
 func (ab *atomicBool) String() string {
+	if ab.Locker == nil {
+		return strconv.FormatBool(false)
+	}
 	ab.Lock()
 	defer ab.Unlock()
 	return strconv.FormatBool(*ab.b)


### PR DESCRIPTION
In Go1.7, the `flag` package checks to see if a `flag.Value` is the
"zero-value" by using reflection to create an empty value and then
calling `String()`. This caused a nil-pointer dereference in both
`stringValue.String()` and `atomicBool.String()`. Only affects tools
which use both our `util/log` package and the standard `flag`
package (i.e. `spf13/pflag` is unaffected).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8095)

<!-- Reviewable:end -->
