### PR TITLE
acceptance: use local SSDs for remote tests

### DIFF
--- a/acceptance/allocator_terraform/nodectl
+++ b/acceptance/allocator_terraform/nodectl
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # TODO(cuongdo): add support for multiple stores on the same node
-DATA_DIR="${DATA_DIR:-./data0}"
+DATA_DIR="${DATA_DIR:-/mnt/data0}"
 
 usage() {
     echo "usage: $0 [upload|download] google_cloud_storage_url"
@@ -34,13 +34,15 @@ upload)
     tar zcvf - * --exclude='logs' | gsutil cp - ${store_url}
     ;;
 download)
-    if [ -d ${DATA_DIR} ]; then
-        backup_dir="${DATA_DIR}.$(date +%Y%m%d-%H%M%S)"
-        echo "Backing up ${DATA_DIR} to ${backup_dir}"
-        mv "${DATA_DIR}" "${backup_dir}"
+    if [[ ! -d "${DATA_DIR}" ]]; then
+        echo "${DATA_DIR} doesn't exist"
+        exit 1
+    fi
+    if [[ ! -z $(compgen -G "${DATA_DIR}/*.sst" 2>/dev/null) ]]; then
+        echo "sstables already exist in the destination"
+        exit 1
     fi
     echo "Downloading ${store_url} to store ${DATA_DIR}"
-    mkdir "${DATA_DIR}"
     cd "${DATA_DIR}"
     gsutil cat ${store_url} | tar zxf -
     ;;

--- a/acceptance/allocator_terraform/variables.tf
+++ b/acceptance/allocator_terraform/variables.tf
@@ -85,12 +85,13 @@ variable "cockroach_machine_type" {
   default = "n1-standard-4"
 }
 
-# Size of disk for CockroachDB nodes.
-variable "cockroach_disk_size" {
-  default = "50" # GB
+# Size of root partition for CockroachDB nodes.
+variable "cockroach_root_disk_size" {
+  default = "10" # GB
 }
 
-variable "cockroach_disk_type" {
+# Controls the disk type for the root partition of CockroachDB nodes.
+variable "cockroach_root_disk_type" {
   default = "pd-standard" # can set this to 'pd-ssd' for persistent SSD
 }
 

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -161,9 +161,9 @@ func farmer(t *testing.T, prefix string) *terrafarm.Farmer {
 	if !filepath.IsAbs(logDir) {
 		logDir = filepath.Join(filepath.Clean(os.ExpandEnv("${PWD}")), logDir)
 	}
-	stores := "--store=data0"
+	stores := "--store=/mnt/data0"
 	for j := 1; j < *flagStores; j++ {
-		stores += " --store=data" + strconv.Itoa(j)
+		stores += " --store=/mnt/data" + strconv.Itoa(j)
 	}
 
 	var name string


### PR DESCRIPTION
Persistent disks seem to be throttled, causing intermittent stalls /
failures in our allocator and load tests. This change ensures that all
CockroachDB nodes have a local SSD that is used for the store and logs.

Note that because this change makes snapshot generation much faster,
snapshot-related bugs may become more common. In particular, memory
used by snapshots during our tests seems to have gone up considerably,
causing some out-of-memory errors.

Resolves #8090

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8100)

<!-- Reviewable:end -->
