### PR TITLE
sql: Introduce VirtualSchema infrastructure

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -595,8 +595,9 @@ func Example_sql() {
 	// x	y
 	// 42	69
 	// sql --execute=show databases
-	// 2 rows
+	// 3 rows
 	// Database
+	// information_schema
 	// system
 	// t
 	// sql -e explain select 3

--- a/keys/constants.go
+++ b/keys/constants.go
@@ -222,6 +222,9 @@ const (
 	// cockroach.
 	MaxReservedDescID = 49
 
+	// VirtualDescriptorID is the ID used by all virtual descriptors.
+	VirtualDescriptorID = math.MaxUint32
+
 	// RootNamespaceID is the ID of the root namespace.
 	RootNamespaceID = 0
 

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -250,17 +250,19 @@ func TestAdminAPIDatabases(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// We should have the system database and the newly created test database.
-	if a, e := len(resp.Databases), 2; a != e {
+	// We should have three databases:
+	// - system database
+	// - information_schema
+	// - newly created test database
+	if a, e := len(resp.Databases), 3; a != e {
 		t.Fatalf("length of result %d != expected %d", a, e)
 	}
 
 	sort.Strings(resp.Databases)
-	if a, e := resp.Databases[0], "system"; a != e {
-		t.Fatalf("database name %s != expected %s", a, e)
-	}
-	if a, e := resp.Databases[1], testdb; a != e {
-		t.Fatalf("database name %s != expected %s", a, e)
+	for i, e := range []string{"information_schema", "system", testdb} {
+		if a := resp.Databases[i]; a != e {
+			t.Fatalf("database name %s != expected %s", a, e)
+		}
 	}
 
 	// Test database details endpoint.

--- a/sql/database.go
+++ b/sql/database.go
@@ -128,7 +128,7 @@ var _ DatabaseAccessor = &planner{}
 
 // getDatabaseDesc implements the DatabaseAccessor interface.
 func (p *planner) getDatabaseDesc(name string) (*sqlbase.DatabaseDescriptor, error) {
-	if virtual := checkVirtualDatabaseDesc(name); virtual != nil {
+	if virtual := getVirtualDatabaseDesc(name); virtual != nil {
 		return virtual, nil
 	}
 	desc := &sqlbase.DatabaseDescriptor{}
@@ -189,8 +189,8 @@ func (p *planner) getCachedDatabaseDesc(name string) (*sqlbase.DatabaseDescripto
 
 // getDatabaseID implements the DatabaseAccessor interface.
 func (p *planner) getDatabaseID(name string) (sqlbase.ID, error) {
-	if virtual := checkVirtualDatabaseDesc(name); virtual != nil {
-		return 0, errors.Errorf("virtual databases (%s) do not have IDs", name)
+	if virtual := getVirtualDatabaseDesc(name); virtual != nil {
+		return virtual.GetID(), nil
 	}
 
 	if id := p.databaseCache.getID(name); id != 0 {

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -85,6 +85,15 @@ func (p *planner) anyPrivilege(descriptor sqlbase.DescriptorProto) error {
 		p.session.User, descriptor.TypeName(), descriptor.GetName())
 }
 
+type descriptorAlreadyExistsErr struct {
+	desc sqlbase.DescriptorProto
+	name string
+}
+
+func (d descriptorAlreadyExistsErr) Error() string {
+	return fmt.Sprintf("%s %q already exists", d.desc.TypeName(), d.name)
+}
+
 // createDescriptor implements the DescriptorAccessor interface.
 func (p *planner) createDescriptor(plainKey sqlbase.DescriptorKey, descriptor sqlbase.DescriptorProto, ifNotExists bool) (bool, error) {
 	idKey := plainKey.Key()
@@ -100,7 +109,7 @@ func (p *planner) createDescriptor(plainKey sqlbase.DescriptorKey, descriptor sq
 			return false, nil
 		}
 		// Key exists, but we don't want it to: error out.
-		return false, fmt.Errorf("%s %q already exists", descriptor.TypeName(), plainKey.Name())
+		return false, descriptorAlreadyExistsErr{descriptor, plainKey.Name()}
 	}
 
 	// Increment unique descriptor counter.

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -78,7 +78,7 @@ func (p *planner) checkPrivilege(descriptor sqlbase.DescriptorProto, privilege p
 
 // anyPrivilege implements the DescriptorAccessor interface.
 func (p *planner) anyPrivilege(descriptor sqlbase.DescriptorProto) error {
-	if descriptor.GetPrivileges().AnyPrivilege(p.session.User) {
+	if descriptor.GetPrivileges().AnyPrivilege(p.session.User) || isVirtualDescriptor(descriptor) {
 		return nil
 	}
 	return fmt.Errorf("user %s has no privileges on %s %s",

--- a/sql/information_schema.go
+++ b/sql/information_schema.go
@@ -16,6 +16,8 @@
 
 package sql
 
+import "github.com/cockroachdb/cockroach/sql/parser"
+
 var informationSchema = virtualSchema{
 	name: "information_schema",
 	tables: []virtualSchemaTable{
@@ -48,4 +50,46 @@ CREATE TABLE information_schema.tables (
   CREATE_OPTIONS STRING,
   TABLE_COMMENT STRING NOT NULL DEFAULT ''
 );`,
+	populate: func(p *planner, addRow func(...parser.Datum)) error {
+		// TODO(nvanbenschoten) This isn't actually the correct implementation
+		// for this table. Fixing this will come later.
+		if p.session.Database == "" {
+			return errNoDatabase
+		}
+		dbDesc, err := p.mustGetDatabaseDesc(p.session.Database)
+		if err != nil {
+			return err
+		}
+
+		tableNames, err := p.getTableNames(dbDesc)
+		if err != nil {
+			return err
+		}
+		for _, name := range tableNames {
+			addRow(
+				parser.DNull,
+				parser.DNull,
+				parser.NewDString(name.Table()),
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+				parser.DNull,
+			)
+		}
+		return nil
+	},
 }

--- a/sql/information_schema.go
+++ b/sql/information_schema.go
@@ -17,6 +17,35 @@
 package sql
 
 var informationSchema = virtualSchema{
-	name:   "information_schema",
-	tables: []virtualSchemaTable{},
+	name: "information_schema",
+	tables: []virtualSchemaTable{
+		informationSchemaTablesTable,
+	},
+}
+
+var informationSchemaTablesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE information_schema.tables (
+  TABLE_CATALOG STRING NOT NULL DEFAULT '',
+  TABLE_SCHEMA STRING NOT NULL DEFAULT '',
+  TABLE_NAME STRING NOT NULL DEFAULT '',
+  TABLE_TYPE STRING NOT NULL DEFAULT '',
+  ENGINE STRING,
+  VERSION INT,
+  ROW_FORMAT STRING,
+  TABLE_ROWS INT,
+  AVG_ROW_LENGTH INT,
+  DATA_LENGTH INT,
+  MAX_DATA_LENGTH INT,
+  INDEX_LENGTH INT,
+  DATA_FREE INT,
+  AUTO_INCREMENT INT,
+  CREATE_TIME TIMESTAMP,
+  UPDATE_TIME TIMESTAMP,
+  CHECK_TIME TIMESTAMP,
+  TABLE_COLLATION STRING,
+  CHECKSUM INT,
+  CREATE_OPTIONS STRING,
+  TABLE_COMMENT STRING NOT NULL DEFAULT ''
+);`,
 }

--- a/sql/information_schema.go
+++ b/sql/information_schema.go
@@ -1,0 +1,22 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package sql
+
+var informationSchema = virtualSchema{
+	name:   "information_schema",
+	tables: []virtualSchemaTable{},
+}

--- a/sql/information_schema.go
+++ b/sql/information_schema.go
@@ -16,7 +16,13 @@
 
 package sql
 
-import "github.com/cockroachdb/cockroach/sql/parser"
+import (
+	"sort"
+
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/pkg/errors"
+)
 
 var informationSchema = virtualSchema{
 	name: "information_schema",
@@ -25,6 +31,16 @@ var informationSchema = virtualSchema{
 	},
 }
 
+// defString is used as the value for columns included in the sql standard
+// of information_schema that don't make sense for CockroachDB. This is
+// identical to the behavior of MySQL.
+var defString = parser.NewDString("def")
+
+var (
+	tableTypeSystemView = parser.NewDString("SYSTEM VIEW")
+	tableTypeBaseTable  = parser.NewDString("BASE TABLE")
+)
+
 var informationSchemaTablesTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.tables (
@@ -32,63 +48,68 @@ CREATE TABLE information_schema.tables (
   TABLE_SCHEMA STRING NOT NULL DEFAULT '',
   TABLE_NAME STRING NOT NULL DEFAULT '',
   TABLE_TYPE STRING NOT NULL DEFAULT '',
-  ENGINE STRING,
-  VERSION INT,
-  ROW_FORMAT STRING,
-  TABLE_ROWS INT,
-  AVG_ROW_LENGTH INT,
-  DATA_LENGTH INT,
-  MAX_DATA_LENGTH INT,
-  INDEX_LENGTH INT,
-  DATA_FREE INT,
-  AUTO_INCREMENT INT,
-  CREATE_TIME TIMESTAMP,
-  UPDATE_TIME TIMESTAMP,
-  CHECK_TIME TIMESTAMP,
-  TABLE_COLLATION STRING,
-  CHECKSUM INT,
-  CREATE_OPTIONS STRING,
-  TABLE_COMMENT STRING NOT NULL DEFAULT ''
+  VERSION INT
 );`,
 	populate: func(p *planner, addRow func(...parser.Datum)) error {
-		// TODO(nvanbenschoten) This isn't actually the correct implementation
-		// for this table. Fixing this will come later.
-		if p.session.Database == "" {
-			return errNoDatabase
-		}
-		dbDesc, err := p.mustGetDatabaseDesc(p.session.Database)
-		if err != nil {
-			return err
+		var dbNames []string
+		dbNamesToTables := make(map[string]map[string]*sqlbase.TableDescriptor)
+
+		// Handle virtual schemas.
+		for dbName, schema := range virtualSchemaMap {
+			dbNames = append(dbNames, dbName)
+			dbTables := make(map[string]*sqlbase.TableDescriptor)
+			for tableName, entry := range schema.tables {
+				dbTables[tableName] = entry.desc
+			}
+			dbNamesToTables[dbName] = dbTables
 		}
 
-		tableNames, err := p.getTableNames(dbDesc)
+		// Handle real schemas.
+		descs, err := p.getAllDescriptors()
 		if err != nil {
 			return err
 		}
-		for _, name := range tableNames {
-			addRow(
-				parser.DNull,
-				parser.DNull,
-				parser.NewDString(name.Table()),
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-				parser.DNull,
-			)
+		dbIDsToName := make(map[sqlbase.ID]string)
+		for _, desc := range descs {
+			if db, ok := desc.(*sqlbase.DatabaseDescriptor); ok {
+				dbNames = append(dbNames, db.GetName())
+				dbIDsToName[db.GetID()] = db.GetName()
+				dbNamesToTables[db.GetName()] = make(map[string]*sqlbase.TableDescriptor)
+			}
+		}
+		for _, desc := range descs {
+			if table, ok := desc.(*sqlbase.TableDescriptor); ok {
+				dbName, ok := dbIDsToName[table.GetParentID()]
+				if !ok {
+					return errors.Errorf("no database with ID %d found", table.GetParentID())
+				}
+				dbTables := dbNamesToTables[dbName]
+				dbTables[table.GetName()] = table
+			}
+		}
+
+		sort.Strings(dbNames)
+		for _, dbName := range dbNames {
+			var dbTableNames []string
+			dbTables := dbNamesToTables[dbName]
+			for tableName := range dbTables {
+				dbTableNames = append(dbTableNames, tableName)
+			}
+			sort.Strings(dbTableNames)
+			for _, tableName := range dbTableNames {
+				table := dbTables[tableName]
+				tableType := tableTypeBaseTable
+				if isVirtualDescriptor(table) {
+					tableType = tableTypeSystemView
+				}
+				addRow(
+					defString,
+					parser.NewDString(dbName),
+					parser.NewDString(tableName),
+					tableType,
+					parser.NewDInt(parser.DInt(table.GetVersion())),
+				)
+			}
 		}
 		return nil
 	},

--- a/sql/internal.go
+++ b/sql/internal.go
@@ -73,12 +73,12 @@ func getTableID(p *planner, qname *parser.QualifiedName) (sqlbase.ID, error) {
 		return 0, err
 	}
 
-	virtual, foundDB := checkVirtualTableDesc(qname)
+	virtual, err := getVirtualTableDesc(qname)
+	if err != nil {
+		return 0, err
+	}
 	if virtual != nil {
 		return virtual.GetID(), nil
-	}
-	if foundDB {
-		return 0, sqlbase.NewUndefinedTableError(qname.String())
 	}
 
 	dbID, err := p.getDatabaseID(qname.Database())

--- a/sql/internal.go
+++ b/sql/internal.go
@@ -73,6 +73,14 @@ func getTableID(p *planner, qname *parser.QualifiedName) (sqlbase.ID, error) {
 		return 0, err
 	}
 
+	virtual, foundDB := checkVirtualTableDesc(qname)
+	if virtual != nil {
+		return virtual.GetID(), nil
+	}
+	if foundDB {
+		return 0, sqlbase.NewUndefinedTableError(qname.String())
+	}
+
 	dbID, err := p.getDatabaseID(qname.Database())
 	if err != nil {
 		return 0, err

--- a/sql/parser/expr.go
+++ b/sql/parser/expr.go
@@ -579,6 +579,19 @@ type QualifiedName struct {
 	origString string
 }
 
+// NewQualifiedNameFromDBAndTable creates a new QualifiedName object from the
+// provided database and table name.
+func NewQualifiedNameFromDBAndTable(db, table string) (*QualifiedName, error) {
+	qname := &QualifiedName{
+		Base:     Name(db),
+		Indirect: Indirection{NameIndirection(table)},
+	}
+	if err := qname.NormalizeTableName(""); err != nil {
+		return nil, err
+	}
+	return qname, nil
+}
+
 // ReturnType implements the TypedExpr interface.
 func (node *QualifiedName) ReturnType() Datum {
 	if qualifiedNameTypes == nil {

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -404,7 +404,7 @@ func TestPGPreparedQuery(t *testing.T) {
 				Results("hashedPassword", "BYTES", true, gosql.NullBool{}),
 		},
 		"SHOW DATABASES": {
-			baseTest.Results("d").Results("system"),
+			baseTest.Results("information_schema").Results("d").Results("system"),
 		},
 		"SHOW GRANTS ON system.users": {
 			baseTest.Results("users", security.RootUser, "DELETE,GRANT,INSERT,SELECT,UPDATE"),

--- a/sql/privilege/privilege.go
+++ b/sql/privilege/privilege.go
@@ -46,7 +46,6 @@ const (
 var (
 	ReadData      = List{GRANT, SELECT}
 	ReadWriteData = List{GRANT, SELECT, INSERT, DELETE, UPDATE}
-	VirtualData   = List{SELECT}
 )
 
 // Mask returns the bitmask for a given privilege.

--- a/sql/privilege/privilege.go
+++ b/sql/privilege/privilege.go
@@ -46,6 +46,7 @@ const (
 var (
 	ReadData      = List{GRANT, SELECT}
 	ReadWriteData = List{GRANT, SELECT, INSERT, DELETE, UPDATE}
+	VirtualData   = List{SELECT}
 )
 
 // Mask returns the bitmask for a given privilege.

--- a/sql/show.go
+++ b/sql/show.go
@@ -237,7 +237,7 @@ func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, error) {
 		return nil, err
 	}
 	v := &valuesNode{columns: []ResultColumn{{Name: "Database", Typ: parser.TypeString}}}
-	for db := range virtualDatabaseDescs {
+	for db := range virtualSchemaMap {
 		v.rows = append(v.rows, []parser.Datum{parser.NewDString(db)})
 	}
 	for _, row := range sr {

--- a/sql/show.go
+++ b/sql/show.go
@@ -154,7 +154,7 @@ func (p *planner) ShowCreateTable(n *parser.ShowCreateTable) (planNode, error) {
 			}
 			fmt.Fprintf(&buf, " DEFAULT %s", *col.DefaultExpr)
 		}
-		if desc.PrimaryIndex.ColumnIDs[0] == col.ID {
+		if len(desc.PrimaryIndex.ColumnIDs) > 0 && desc.PrimaryIndex.ColumnIDs[0] == col.ID {
 			// Only set primary if the primary key is on a visible column (not rowid).
 			primary = fmt.Sprintf(",\n\tCONSTRAINT %s PRIMARY KEY (%s)",
 				quoteNames(desc.PrimaryIndex.Name),

--- a/sql/show.go
+++ b/sql/show.go
@@ -237,6 +237,9 @@ func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, error) {
 		return nil, err
 	}
 	v := &valuesNode{columns: []ResultColumn{{Name: "Database", Typ: parser.TypeString}}}
+	for db := range virtualDatabaseDescs {
+		v.rows = append(v.rows, []parser.Datum{parser.NewDString(db)})
+	}
 	for _, row := range sr {
 		_, name, err := encoding.DecodeUnsafeStringAscending(
 			bytes.TrimPrefix(row.Key, prefix), nil)

--- a/sql/sqlbase/keys.go
+++ b/sql/sqlbase/keys.go
@@ -93,10 +93,15 @@ func MakeNameMetadataKey(parentID ID, name string) roachpb.Key {
 	return k
 }
 
+// MakeAllDescsMetadataKey returns the key for all descriptors.
+func MakeAllDescsMetadataKey() roachpb.Key {
+	k := keys.MakeTablePrefix(uint32(DescriptorTable.ID))
+	return encoding.EncodeUvarintAscending(k, uint64(DescriptorTable.PrimaryIndex.ID))
+}
+
 // MakeDescMetadataKey returns the key for the descriptor.
 func MakeDescMetadataKey(descID ID) roachpb.Key {
-	k := keys.MakeTablePrefix(uint32(DescriptorTable.ID))
-	k = encoding.EncodeUvarintAscending(k, uint64(DescriptorTable.PrimaryIndex.ID))
+	k := MakeAllDescsMetadataKey()
 	k = encoding.EncodeUvarintAscending(k, uint64(descID))
 	return keys.MakeFamilyKey(k, uint32(DescriptorTable.Columns[1].ID))
 }

--- a/sql/table.go
+++ b/sql/table.go
@@ -124,14 +124,9 @@ func (p *planner) getTableDesc(qname *parser.QualifiedName) (*sqlbase.TableDescr
 		return nil, err
 	}
 
-	virtual, foundDB := checkVirtualTableDesc(qname)
-	if virtual != nil {
-		return virtual, nil
-	}
-	if foundDB {
-		// The database referenced was a virtual database, but it does not
-		// contain the desired table.
-		return nil, nil
+	virtual, err := getVirtualTableDesc(qname)
+	if err != nil || virtual != nil {
+		return virtual, err
 	}
 
 	dbDesc, err := p.mustGetDatabaseDesc(qname.Database())

--- a/sql/table.go
+++ b/sql/table.go
@@ -123,6 +123,17 @@ func (p *planner) getTableDesc(qname *parser.QualifiedName) (*sqlbase.TableDescr
 	if err := qname.NormalizeTableName(p.session.Database); err != nil {
 		return nil, err
 	}
+
+	virtual, foundDB := checkVirtualTableDesc(qname)
+	if virtual != nil {
+		return virtual, nil
+	}
+	if foundDB {
+		// The database referenced was a virtual database, but it does not
+		// contain the desired table.
+		return nil, nil
+	}
+
 	dbDesc, err := p.mustGetDatabaseDesc(qname.Database())
 	if err != nil {
 		return nil, err
@@ -160,11 +171,17 @@ func (p *planner) getTableLease(qname *parser.QualifiedName) (*sqlbase.TableDesc
 		return nil, err
 	}
 
-	if qname.Database() == sqlbase.SystemDB.Name || testDisableTableLeases {
-		// We don't go through the normal lease mechanism for system tables. The
-		// system.lease and system.descriptor table, in particular, are problematic
-		// because they are used for acquiring leases itself, creating a
-		// chicken&egg problem.
+	isSystemDB := qname.Database() == sqlbase.SystemDB.Name
+	isVirtualDB := isVirtualDatabase(qname.Database())
+	if isSystemDB || isVirtualDB || testDisableTableLeases {
+		// We don't go through the normal lease mechanism for:
+		// - system tables. The system.lease and system.descriptor table, in
+		//   particular, are problematic because they are used for acquiring
+		//   leases itself, creating a chicken&egg problem.
+		// - virtual tables. These tables' descriptors are not persisted,
+		//   so they cannot be leased. Instead, we simply return the static
+		//   descriptor and rely on the immutability privileges set on the
+		//   descriptors to cause upper layers to reject mutations statements.
 		return p.mustGetTableDesc(qname)
 	}
 
@@ -285,6 +302,10 @@ func (p *planner) removeLeaseIfExpiring(lease *LeaseState) bool {
 
 // getTableNames implements the SchemaAccessor interface.
 func (p *planner) getTableNames(dbDesc *sqlbase.DatabaseDescriptor) (parser.QualifiedNames, error) {
+	if e, ok := getVirtualSchemaEntry(dbDesc.Name); ok {
+		return e.tableNames()
+	}
+
 	prefix := sqlbase.MakeNameMetadataKey(dbDesc.ID, "")
 	sr, err := p.txn.Scan(prefix, prefix.PrefixEnd(), 0)
 	if err != nil {
@@ -298,11 +319,8 @@ func (p *planner) getTableNames(dbDesc *sqlbase.DatabaseDescriptor) (parser.Qual
 		if err != nil {
 			return nil, err
 		}
-		qname := &parser.QualifiedName{
-			Base:     parser.Name(dbDesc.Name),
-			Indirect: parser.Indirection{parser.NameIndirection(tableName)},
-		}
-		if err := qname.NormalizeTableName(""); err != nil {
+		qname, err := parser.NewQualifiedNameFromDBAndTable(dbDesc.Name, tableName)
+		if err != nil {
 			return nil, err
 		}
 		qualifiedNames = append(qualifiedNames, qname)
@@ -355,6 +373,9 @@ func (p *planner) releaseLeases() {
 
 // writeTableDesc implements the SchemaAccessor interface.
 func (p *planner) writeTableDesc(tableDesc *sqlbase.TableDescriptor) error {
+	if isVirtualDescriptor(tableDesc) {
+		panic(fmt.Sprintf("Virtual Descriptors cannot be stored, found: %v", tableDesc))
+	}
 	return p.txn.Put(sqlbase.MakeDescMetadataKey(tableDesc.GetID()),
 		sqlbase.WrapDescriptor(tableDesc))
 }

--- a/sql/testdata/database
+++ b/sql/testdata/database
@@ -14,6 +14,7 @@ query T colnames
 SHOW DATABASES
 ----
 Database
+information_schema
 a
 system
 test
@@ -33,6 +34,7 @@ CREATE DATABASE c
 query T
 SHOW DATABASES
 ----
+information_schema
 a
 b
 c
@@ -71,6 +73,7 @@ query T colnames
 SHOW DATABASES
 ----
 Database
+information_schema
 a
 c
 system

--- a/sql/testdata/drop_database
+++ b/sql/testdata/drop_database
@@ -4,6 +4,7 @@ CREATE DATABASE "foo-bar"
 query T
 SHOW DATABASES
 ----
+information_schema
 foo-bar
 system
 test
@@ -14,6 +15,7 @@ DROP DATABASE "foo-bar"
 query T
 SHOW DATABASES
 ----
+information_schema
 system
 test
 
@@ -23,6 +25,7 @@ CREATE DATABASE "foo bar"
 query T
 SHOW DATABASES
 ----
+information_schema
 foo bar
 system
 test
@@ -33,5 +36,6 @@ DROP DATABASE "foo bar"
 query T
 SHOW DATABASES
 ----
+information_schema
 system
 test

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -115,23 +115,7 @@ information_schema.tables  CREATE TABLE "information_schema.tables" (
                                TABLE_SCHEMA STRING NOT NULL DEFAULT '',
                                TABLE_NAME STRING NOT NULL DEFAULT '',
                                TABLE_TYPE STRING NOT NULL DEFAULT '',
-                               ENGINE STRING NULL,
-                               VERSION INT NULL,
-                               ROW_FORMAT STRING NULL,
-                               TABLE_ROWS INT NULL,
-                               AVG_ROW_LENGTH INT NULL,
-                               DATA_LENGTH INT NULL,
-                               MAX_DATA_LENGTH INT NULL,
-                               INDEX_LENGTH INT NULL,
-                               DATA_FREE INT NULL,
-                               AUTO_INCREMENT INT NULL,
-                               CREATE_TIME TIMESTAMP NULL,
-                               UPDATE_TIME TIMESTAMP NULL,
-                               CHECK_TIME TIMESTAMP NULL,
-                               TABLE_COLLATION STRING NULL,
-                               CHECKSUM INT NULL,
-                               CREATE_OPTIONS STRING NULL,
-                               TABLE_COMMENT STRING NOT NULL DEFAULT ''
+                               VERSION INT NULL
                            )
 
 query TTBT colnames
@@ -142,23 +126,7 @@ TABLE_CATALOG    STRING     false  ''
 TABLE_SCHEMA     STRING     false  ''
 TABLE_NAME       STRING     false  ''
 TABLE_TYPE       STRING     false  ''
-ENGINE           STRING     true   NULL
 VERSION          INT        true   NULL
-ROW_FORMAT       STRING     true   NULL
-TABLE_ROWS       INT        true   NULL
-AVG_ROW_LENGTH   INT        true   NULL
-DATA_LENGTH      INT        true   NULL
-MAX_DATA_LENGTH  INT        true   NULL
-INDEX_LENGTH     INT        true   NULL
-DATA_FREE        INT        true   NULL
-AUTO_INCREMENT   INT        true   NULL
-CREATE_TIME      TIMESTAMP  true   NULL
-UPDATE_TIME      TIMESTAMP  true   NULL
-CHECK_TIME       TIMESTAMP  true   NULL
-TABLE_COLLATION  STRING     true   NULL
-CHECKSUM         INT        true   NULL
-CREATE_OPTIONS   STRING     true   NULL
-TABLE_COMMENT    STRING     false  ''
 
 query TTTTTTT colnames
 SHOW INDEXES FROM information_schema.tables
@@ -179,12 +147,19 @@ Table  User  Privileges
 
 # Verify selecting from information_schema.
 
+## information_schema.tables
+
 statement ok
-SET DATABASE = system
+CREATE DATABASE other_db
+
+statement ok
+CREATE TABLE other_db.xyz (i INT)
 
 query T
-SELECT table_name FROM information_schema.tables;
+SELECT table_name FROM information_schema.tables
 ----
+tables
+xyz
 descriptor
 eventlog
 lease
@@ -195,10 +170,39 @@ users
 zones
 
 query T
-SELECT table_name FROM information_schema.tables WHERE table_name > 'n' ORDER BY 1 DESC;
+SELECT table_name FROM information_schema.tables WHERE table_name > 'n' ORDER BY 1 DESC
 ----
 zones
+xyz
 users
 ui
+tables
 rangelog
 namespace
+
+query TTTTI colnames
+SELECT * FROM information_schema.tables
+----
+TABLE_CATALOG  TABLE_SCHEMA        TABLE_NAME  TABLE_TYPE   VERSION
+def            information_schema  tables      SYSTEM VIEW  1
+def            other_db            xyz         BASE TABLE   1
+def            system              descriptor  BASE TABLE   1
+def            system              eventlog    BASE TABLE   1
+def            system              lease       BASE TABLE   1
+def            system              namespace   BASE TABLE   1
+def            system              rangelog    BASE TABLE   1
+def            system              ui          BASE TABLE   1
+def            system              users       BASE TABLE   1
+def            system              zones       BASE TABLE   1
+
+statement ok
+ALTER TABLE other_db.xyz ADD COLUMN j INT
+
+query TTI colnames
+SELECT TABLE_SCHEMA, TABLE_NAME, VERSION FROM information_schema.tables WHERE version > 1
+----
+TABLE_SCHEMA  TABLE_NAME  VERSION
+other_db      xyz         4
+
+statement ok
+DROP DATABASE other_db

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -1,0 +1,24 @@
+# TODO(nvanbenschoten)
+#query error dsaodjassjdoiasjdio
+#ALTER DATABASE information_schema RENAME TO not_information_schema
+
+statement ok
+CREATE DATABASE other_db
+
+statement error the new database name "information_schema" already exists
+ALTER DATABASE other_db RENAME TO information_schema
+
+statement error database "information_schema" already exists
+CREATE DATABASE information_schema
+
+statement error user root does not have CREATE privilege on database information_schema
+CREATE TABLE information_schema.t (x INT)
+
+query error user root does not have DROP privilege on database information_schema
+DROP DATABASE information_schema
+
+#statement ok
+#GRANT CREATE ON information_schema.tables TO root
+
+statement ok
+SET DATABASE = information_schema

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -175,3 +175,30 @@ query TTT colnames
 SHOW GRANTS ON information_schema.tables
 ----
 Table  User  Privileges
+
+
+# Verify selecting from information_schema.
+
+statement ok
+SET DATABASE = system
+
+query T
+SELECT table_name FROM information_schema.tables;
+----
+descriptor
+eventlog
+lease
+namespace
+rangelog
+ui
+users
+zones
+
+query T
+SELECT table_name FROM information_schema.tables WHERE table_name > 'n' ORDER BY 1 DESC;
+----
+zones
+users
+ui
+rangelog
+namespace

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -22,6 +22,9 @@ ALTER DATABASE other_db RENAME TO information_schema
 statement error database "information_schema" already exists
 CREATE DATABASE information_schema
 
+statement ok
+DROP DATABASE other_db
+
 
 # Verify information_schema tables handle mutation statements correctly.
 
@@ -92,6 +95,83 @@ SET DATABASE = ''
 # Verify information_schema handles reflection correctly.
 
 query T
-SHOW TABLES FROM information_schema;
+SHOW DATABASES
+----
+information_schema
+system
+test
+
+query T
+SHOW TABLES FROM information_schema
 ----
 tables
+
+query TT colnames
+SHOW CREATE TABLE information_schema.tables
+----
+Table                      CreateTable
+information_schema.tables  CREATE TABLE "information_schema.tables" (
+                               TABLE_CATALOG STRING NOT NULL DEFAULT '',
+                               TABLE_SCHEMA STRING NOT NULL DEFAULT '',
+                               TABLE_NAME STRING NOT NULL DEFAULT '',
+                               TABLE_TYPE STRING NOT NULL DEFAULT '',
+                               ENGINE STRING NULL,
+                               VERSION INT NULL,
+                               ROW_FORMAT STRING NULL,
+                               TABLE_ROWS INT NULL,
+                               AVG_ROW_LENGTH INT NULL,
+                               DATA_LENGTH INT NULL,
+                               MAX_DATA_LENGTH INT NULL,
+                               INDEX_LENGTH INT NULL,
+                               DATA_FREE INT NULL,
+                               AUTO_INCREMENT INT NULL,
+                               CREATE_TIME TIMESTAMP NULL,
+                               UPDATE_TIME TIMESTAMP NULL,
+                               CHECK_TIME TIMESTAMP NULL,
+                               TABLE_COLLATION STRING NULL,
+                               CHECKSUM INT NULL,
+                               CREATE_OPTIONS STRING NULL,
+                               TABLE_COMMENT STRING NOT NULL DEFAULT ''
+                           )
+
+query TTBT colnames
+SHOW COLUMNS FROM information_schema.tables
+----
+Field            Type       Null   Default
+TABLE_CATALOG    STRING     false  ''
+TABLE_SCHEMA     STRING     false  ''
+TABLE_NAME       STRING     false  ''
+TABLE_TYPE       STRING     false  ''
+ENGINE           STRING     true   NULL
+VERSION          INT        true   NULL
+ROW_FORMAT       STRING     true   NULL
+TABLE_ROWS       INT        true   NULL
+AVG_ROW_LENGTH   INT        true   NULL
+DATA_LENGTH      INT        true   NULL
+MAX_DATA_LENGTH  INT        true   NULL
+INDEX_LENGTH     INT        true   NULL
+DATA_FREE        INT        true   NULL
+AUTO_INCREMENT   INT        true   NULL
+CREATE_TIME      TIMESTAMP  true   NULL
+UPDATE_TIME      TIMESTAMP  true   NULL
+CHECK_TIME       TIMESTAMP  true   NULL
+TABLE_COLLATION  STRING     true   NULL
+CHECKSUM         INT        true   NULL
+CREATE_OPTIONS   STRING     true   NULL
+TABLE_COMMENT    STRING     false  ''
+
+query TTTTTTT colnames
+SHOW INDEXES FROM information_schema.tables
+----
+Table  Name  Unique  Seq  Column  Direction  Storing
+
+query TTTTT colnames
+SHOW CONSTRAINTS FROM information_schema.tables
+----
+Table   Name     Type  Column(s)  Details
+tables  PRIMARY  KEY   []         NULL
+
+query TTT colnames
+SHOW GRANTS ON information_schema.tables
+----
+Table  User  Privileges

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -1,6 +1,17 @@
-# TODO(nvanbenschoten)
+# Verify information_schema database handles mutation statements correctly.
+
+# TODO(nvanbenschoten) Blocked on #7998.
 #query error dsaodjassjdoiasjdio
 #ALTER DATABASE information_schema RENAME TO not_information_schema
+
+statement error user root does not have CREATE privilege on database information_schema
+CREATE TABLE information_schema.t (x INT)
+
+query error user root does not have DROP privilege on database information_schema
+DROP DATABASE information_schema
+
+
+# Verify other databases cant be called "information_schema".
 
 statement ok
 CREATE DATABASE other_db
@@ -11,14 +22,76 @@ ALTER DATABASE other_db RENAME TO information_schema
 statement error database "information_schema" already exists
 CREATE DATABASE information_schema
 
-statement error user root does not have CREATE privilege on database information_schema
-CREATE TABLE information_schema.t (x INT)
 
-query error user root does not have DROP privilege on database information_schema
-DROP DATABASE information_schema
+# Verify information_schema tables handle mutation statements correctly.
 
-#statement ok
-#GRANT CREATE ON information_schema.tables TO root
+statement error user root does not have DROP privilege on table tables
+ALTER TABLE information_schema.tables RENAME TO information_schema.bad
+
+statement error user root does not have CREATE privilege on table tables
+ALTER TABLE information_schema.tables RENAME COLUMN x TO y
+
+statement error user root does not have CREATE privilege on table tables
+ALTER TABLE information_schema.tables ADD COLUMN x DECIMAL
+
+statement error user root does not have CREATE privilege on table tables
+ALTER TABLE information_schema.tables DROP COLUMN x
+
+statement error user root does not have CREATE privilege on table tables
+ALTER TABLE information_schema.tables ADD CONSTRAINT foo UNIQUE (b)
+
+statement error user root does not have CREATE privilege on table tables
+ALTER TABLE information_schema.tables DROP CONSTRAINT bar
+
+statement error user root does not have CREATE privilege on table tables
+ALTER TABLE information_schema.tables ALTER COLUMN x SET DEFAULT 'foo'
+
+statement error user root does not have CREATE privilege on table tables
+ALTER TABLE information_schema.tables ALTER x DROP NOT NULL
+
+statement error user root does not have CREATE privilege on table tables
+CREATE INDEX i on information_schema.tables (x)
+
+statement error user root does not have DROP privilege on table tables
+DROP TABLE information_schema.tables
+
+statement error user root does not have CREATE privilege on table tables
+DROP INDEX information_schema.tables@i
+
+statement error user root does not have GRANT privilege on table tables
+GRANT CREATE ON information_schema.tables TO root
+
+statement error user root does not have GRANT privilege on table tables
+REVOKE CREATE ON information_schema.tables FROM root
+
+
+# Verify information_schema tables handles read-only property correctly.
+
+query error user root does not have DELETE privilege on table tables
+DELETE FROM information_schema.tables
+
+query error user root does not have INSERT privilege on table tables
+INSERT INTO information_schema.tables VALUES ('abc')
+
+statement error user root does not have UPDATE privilege on table tables
+UPDATE information_schema.tables SET a = 'abc'
+
+statement error user root does not have DROP privilege on table tables
+TRUNCATE TABLE information_schema.tables
+
+
+# Verify information_schema can be used like a normal database.
 
 statement ok
 SET DATABASE = information_schema
+
+statement ok
+SET DATABASE = ''
+
+
+# Verify information_schema handles reflection correctly.
+
+query T
+SHOW TABLES FROM information_schema;
+----
+tables

--- a/sql/testdata/rename_database
+++ b/sql/testdata/rename_database
@@ -1,6 +1,7 @@
 query T
 SHOW DATABASES
 ----
+information_schema
 system
 test
 
@@ -39,6 +40,7 @@ SHOW GRANTS ON DATABASE test
 query T
 SHOW DATABASES
 ----
+information_schema
 system
 u
 
@@ -85,6 +87,7 @@ ALTER DATABASE t RENAME TO v
 query T
 SHOW DATABASES
 ----
+information_schema
 system
 t
 u

--- a/sql/testdata/system
+++ b/sql/testdata/system
@@ -1,6 +1,7 @@
 query T
 SHOW DATABASES
 ----
+information_schema
 system
 test
 

--- a/sql/virtual_schema.go
+++ b/sql/virtual_schema.go
@@ -1,0 +1,105 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nathan VanBenschoten (nvanbenschoten@gmail.com)
+
+package sql
+
+import (
+	"github.com/cockroachdb/cockroach/security"
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/privilege"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
+)
+
+// virtualSchema represents a database with a set of virtual tables. Virtual
+// tables differ from standard tables in that they are not persisted to storage,
+// and instead their contents are populated whenever they are queried.
+//
+// The virtual database and its virtual tables also differ from standard databases
+// and tables in that their descriptors are not distributed, but instead live statically
+// in code. This means that they are accessed separately from standard descriptors.
+type virtualSchema struct {
+	name   string
+	tables []virtualSchemaTable
+}
+
+// virtualSchemaTable represents a table within a virtualSchema.
+type virtualSchemaTable struct {
+	schema   string
+	populate func(*planner) planNode
+}
+
+// virtualSchemas holds a slice of statically registered virtualSchema objects.
+//
+// When adding a new virtualSchema, define a virtualSchema in a separate file, and
+// add that object to this slice.
+var virtualSchemas = []virtualSchema{
+	informationSchema,
+}
+
+// Statically populated maps which are used to provide access to virtual
+// database and table descriptors.
+var virtualDatabaseDescs map[string]*sqlbase.DatabaseDescriptor
+var virtualTableDescs map[string]map[string]*sqlbase.TableDescriptor
+
+func init() {
+	virtualDatabaseDescs = make(map[string]*sqlbase.DatabaseDescriptor)
+	virtualTableDescs = make(map[string]map[string]*sqlbase.TableDescriptor)
+	for _, schema := range virtualSchemas {
+		dbName := schema.name
+		virtualDatabaseDescs[dbName] = initVirtualDatabaseDesc(dbName)
+		virtualTableDescMap := make(map[string]*sqlbase.TableDescriptor)
+		for _, table := range schema.tables {
+			tableDesc := initVirtualTableDesc(table)
+			virtualTableDescMap[tableDesc.Name] = tableDesc
+		}
+		virtualTableDescs[dbName] = virtualTableDescMap
+	}
+}
+
+func initVirtualDatabaseDesc(name string) *sqlbase.DatabaseDescriptor {
+	return &sqlbase.DatabaseDescriptor{
+		Name: name,
+		// TODO(nvanbenschoten) All users should have Read-only access to virtual databases.
+		// Access control will be provided by the population routines.
+		Privileges: sqlbase.NewPrivilegeDescriptor(security.RootUser, privilege.VirtualData),
+	}
+}
+
+func initVirtualTableDesc(t virtualSchemaTable) *sqlbase.TableDescriptor {
+	stmt, err := parser.ParseOneTraditional(t.schema)
+	if err != nil {
+		panic(err)
+	}
+	desc, err := sqlbase.MakeTableDesc(stmt.(*parser.CreateTable), 0)
+	if err != nil {
+		panic(err)
+	}
+	// TODO(nvanbenschoten) All users should have Read-only access to virtual tables.
+	// Access control will be provided by the population routines.
+	desc.Privileges = sqlbase.NewPrivilegeDescriptor(security.RootUser, privilege.VirtualData)
+	return &desc
+}
+
+// checkVirtualDatabaseDesc checks if the provided name matches a virtual database,
+// and if so, returns that database's descriptor.
+func checkVirtualDatabaseDesc(name string) *sqlbase.DatabaseDescriptor {
+	return virtualDatabaseDescs[name]
+}
+
+// isVirtualDatabase checks if the provided name corresponds to a virtual database.
+func isVirtualDatabase(name string) bool {
+	return checkVirtualDatabaseDesc(name) != nil
+}


### PR DESCRIPTION
Related to #7965.

This PR introduces the `VirtualSchema` infrastructure into the SQL layer. This new structure allows static virtual descriptors to be used for non-distributed read-only SQL relations, and provides a means to mock out the results of selecting from tables within these schemas.

This is the initial step towards supporting `information_schema` and `pg_catalog`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8119)

<!-- Reviewable:end -->
