### PR TITLE
Replace replica descriptor cache with last-seen sender and recipient fields.

### DIFF
--- a/roachpb/metadata.go
+++ b/roachpb/metadata.go
@@ -130,6 +130,17 @@ func (r RangeDescriptor) GetReplicaDescriptor(storeID StoreID) (ReplicaDescripto
 	return ReplicaDescriptor{}, false
 }
 
+// GetReplicaDescriptorByID returns the replica which matches the specified store
+// ID.
+func (r RangeDescriptor) GetReplicaDescriptorByID(replicaID ReplicaID) (ReplicaDescriptor, bool) {
+	for _, repDesc := range r.Replicas {
+		if repDesc.ReplicaID == replicaID {
+			return repDesc, true
+		}
+	}
+	return ReplicaDescriptor{}, false
+}
+
 // IsInitialized returns false if this descriptor represents an
 // uninitialized range.
 // TODO(bdarnell): unify this with Validate().

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -733,7 +733,7 @@ func TestStoreRangeDownReplicate(t *testing.T) {
 	mtc.expireLeases()
 }
 
-// TestChangeReplicasDuplicateError tests that a replica change aborts if
+// TestChangeReplicasDescriptorInvariant tests that a replica change aborts if
 // another change has been made to the RangeDescriptor since it was initiated.
 func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -781,10 +781,12 @@ func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 	// Both addReplica calls attempted to use origDesc.NextReplicaID.
 	// The failed second call should not have overwritten the cached
 	// replica descriptor from the successful first call.
-	if rd, err := mtc.stores[0].ReplicaDescriptor(origDesc.RangeID, origDesc.NextReplicaID); err != nil {
-		t.Fatalf("failed to look up replica %s", origDesc.NextReplicaID)
-	} else if a, e := rd.StoreID, mtc.stores[1].Ident.StoreID; a != e {
-		t.Fatalf("expected replica %s to point to store %s, but got %s", origDesc.NextReplicaID, a, e)
+	rep, err := mtc.stores[0].GetReplica(origDesc.RangeID)
+	if err != nil {
+		t.Fatalf("failed to look up replica %s: %s", origDesc.RangeID, err)
+	}
+	if a, e := rep.GetLastFromReplicaDesc().StoreID, mtc.stores[1].Ident.StoreID; a != e {
+		t.Fatalf("expected replica %s to point to store %s, but got %s", rep, a, e)
 	}
 
 	// Add to third store with fresh descriptor.

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -130,7 +130,11 @@ func (s *Store) SetSplitQueueActive(active bool) {
 // SetReplicaScannerDisabled turns replica scanning off or on as directed. Note
 // that while disabled, removals are still processed.
 func (s *Store) SetReplicaScannerDisabled(disabled bool) {
-	s.scanner.SetDisabled(disabled)
+	if disabled {
+		atomic.StoreInt32(&s.scanner.disabled, 1)
+	} else {
+		atomic.StoreInt32(&s.scanner.disabled, 0)
+	}
 }
 
 // GetLastIndex is the same function as LastIndex but it does not require
@@ -139,16 +143,6 @@ func (r *Replica) GetLastIndex() (uint64, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.LastIndex()
-}
-
-// SetDisabled turns replica scanning off or on as directed. Note that while
-// disabled, removals are still processed.
-func (rs *replicaScanner) SetDisabled(disabled bool) {
-	if disabled {
-		atomic.StoreInt32(&rs.disabled, 1)
-	} else {
-		atomic.StoreInt32(&rs.disabled, 0)
-	}
 }
 
 // GetLease exposes replica.getLease for tests.

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -156,3 +156,9 @@ func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
 	defer r.mu.Unlock()
 	return r.mu.tsCache.lowWater
 }
+
+func (r *Replica) GetLastFromReplicaDesc() roachpb.ReplicaDescriptor {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.lastFromReplica
+}

--- a/storage/raft_log_queue_test.go
+++ b/storage/raft_log_queue_test.go
@@ -204,7 +204,7 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	defer stopper.Stop()
 
-	store.scanner.SetDisabled(true)
+	store.SetReplicaScannerDisabled(true)
 
 	r, err := store.GetReplica(1)
 	if err != nil {

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -238,6 +238,48 @@ type Replica struct {
 		// Raft group). The replica ID will be non-zero whenever the replica is
 		// part of a Raft group.
 		replicaID roachpb.ReplicaID
+
+		// The last seen replica descriptors from incoming Raft messages. These are
+		// stored so that the replica still knows the replica descriptors for itself
+		// and for its message recipients in the circumstances when its RangeDescriptor
+		// is out of date.
+		//
+		// Normally, a replica knows about the other replica descriptors for a
+		// range via the RangeDescriptor stored in Replica.mu.state.Desc. But that
+		// descriptor is only updated during a Split or ChangeReplicas operation.
+		// There are periods during a Replica's lifetime when that information is
+		// out of date:
+		//
+		// 1. When a replica is being newly created as the result of an incoming
+		// Raft message for it. This is the common case for ChangeReplicas and an
+		// uncommon case for Splits. The leader will be sending the replica
+		// messages and the replica needs to be able to respond before it can
+		// receive an updated range descriptor (via a snapshot,
+		// changeReplicasTrigger, or splitTrigger).
+		//
+		// 2. If the node containing a replica is partitioned or down while the
+		// replicas for the range are updated. When the node comes back up, other
+		// replicas may begin communicating with it and it needs to be able to
+		// respond. Unlike 1 where there is no range descriptor, in this situation
+		// the replica has a range descriptor but it is out of date. Note that a
+		// replica being removed from a node and then quickly re-added before the
+		// replica has been GC'd will also use the last seen descriptors. In
+		// effect, this is another path for which the replica's local range
+		// descriptor is out of date.
+		//
+		// The last seen replica descriptors are updated on receipt of every raft
+		// message via Replica.setLastReplicaDescriptors (see
+		// Store.handleRaftMessage). These last seen descriptors are used when
+		// the replica's RangeDescriptor contains missing or out of date descriptors
+		// for a replica (see Replica.sendRaftMessage).
+		//
+		// Removing a replica from Store.mu.replicas is not a problem because
+		// when a replica is completely removed, it won't be recreated until
+		// there is another event that will repopulate the replicas map in the
+		// range descriptor. When it is temporarily dropped and recreated, the
+		// newly recreated replica will have a complete range descriptor.
+		lastToReplica, lastFromReplica roachpb.ReplicaDescriptor
+
 		// Most recent timestamps for keys / key ranges.
 		tsCache *timestampCache
 		// proposeRaftCommandFn can be set to mock out the propose operation.
@@ -672,6 +714,15 @@ func (r *Replica) getReplicaDescriptorLocked() (roachpb.ReplicaDescriptor, error
 		return repDesc, nil
 	}
 	return roachpb.ReplicaDescriptor{}, roachpb.NewRangeNotFoundError(r.RangeID)
+}
+
+// setLastReplicaDescriptors sets the the most recently seen replica descriptors to those
+// contained in the *RaftMessageRequest, acquiring r.mu to do so.
+func (r *Replica) setLastReplicaDescriptors(req *RaftMessageRequest) {
+	r.mu.Lock()
+	r.mu.lastFromReplica = req.FromReplica
+	r.mu.lastToReplica = req.ToReplica
+	r.mu.Unlock()
 }
 
 // GetMVCCStats returns a copy of the MVCC stats object for this range.
@@ -1674,22 +1725,39 @@ func (r *Replica) refreshPendingCmdsLocked(reason refreshRaftReason) error {
 	return nil
 }
 
+func (r *Replica) getReplicaDescriptorByIDLocked(
+	replicaID roachpb.ReplicaID,
+	fallback roachpb.ReplicaDescriptor,
+) (roachpb.ReplicaDescriptor, error) {
+	if repDesc, ok := r.mu.state.Desc.GetReplicaDescriptorByID(replicaID); ok {
+		return repDesc, nil
+	}
+	if fallback.ReplicaID == replicaID {
+		return fallback, nil
+	}
+	return roachpb.ReplicaDescriptor{},
+		errors.Errorf("replica %d not present in %v, %v", replicaID, fallback, r.mu.state.Desc.Replicas)
+}
+
 func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 	rangeID := r.RangeID
 
-	r.store.mu.Lock()
-	toReplica, toErr := r.store.replicaDescriptorLocked(rangeID, roachpb.ReplicaID(msg.To))
-	fromReplica, fromErr := r.store.replicaDescriptorLocked(rangeID, roachpb.ReplicaID(msg.From))
-	r.store.mu.Unlock()
+	r.mu.Lock()
+	fromReplica, fromErr := r.getReplicaDescriptorByIDLocked(roachpb.ReplicaID(msg.From), r.mu.lastToReplica)
+	toReplica, toErr := r.getReplicaDescriptorByIDLocked(roachpb.ReplicaID(msg.To), r.mu.lastFromReplica)
+	r.mu.Unlock()
 
-	if toErr != nil {
-		log.Warningf(context.TODO(), "failed to look up recipient replica %d in range %d while sending %s: %s", msg.To, rangeID, msg.Type, toErr)
-		return
-	}
 	if fromErr != nil {
-		log.Warningf(context.TODO(), "failed to look up sender replica %d in range %d while sending %s: %s", msg.From, rangeID, msg.Type, fromErr)
+		log.Warningf(context.TODO(),
+			"failed to look up sender replica %d in range %d while sending %s: %s", msg.From, rangeID, msg.Type, fromErr)
 		return
 	}
+	if toErr != nil {
+		log.Warningf(context.TODO(),
+			"failed to look up recipient replica %d in range %d while sending %s: %s", msg.To, rangeID, msg.Type, toErr)
+		return
+	}
+
 	if !r.raftSender.SendAsync(&RaftMessageRequest{
 		RangeID:     rangeID,
 		ToReplica:   toReplica,


### PR DESCRIPTION
Replace the replica descriptor cache that used to live on Store with a
pair of fields on Replica that keep track of the most recently seen
sender and recipient replica descriptors from Raft.

This change is possible because the cache was only necessary in the
situations when the replica is trying to send a Raft-initiated message
and its Range does not have an accurate or present replica descriptor
for either the sender (itself) or the recipient - but in all of these
situations, the recipient and sender replica descriptors are guaranteed
to be the same as the sender and recipient (respectively) of the
Replica's most recently recieved Raft message. So, we can simply store
those 2 replica descriptors on the replica, updating them every time we
get a Raft message, and use them when sending Raft messages when the
Replica's Range doesn't have present or accurate descriptors for the
sender or recipient.

The comments for the replica descriptor cache have been moved to the new
fields in Replica, and contain further justification for why this change
works.

Resolves #7694.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8125)

<!-- Reviewable:end -->
