### PR TITLE
leaktest: ignore goroutine leaks in the stadard library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ testslow:
 .PHONY: testraceslow
 testraceslow: TESTFLAGS += -v
 testraceslow:
-	$(GO) test -v $(GOFLAGS) -i $(PKG)
+	$(GO) test -v $(GOFLAGS) -race -i $(PKG)
 	$(GO) test $(GOFLAGS) -race -run "$(TESTS)" -timeout $(RACETIMEOUT) $(PKG) $(TESTFLAGS) | grep -F ': Test' | sed -E 's/(--- PASS: |\(|\))//g' | awk '{ print $$2, $$1 }' | sort -rn | head -n 10
 
 # "go test -i" builds dependencies and installs them into GOPATH/pkg, but does not run the


### PR DESCRIPTION
See #8136.

To observe the leaks after this change, run:

```
make stress COCKROACH_IGNORESTDLIBLEAKS=0 PKG=./rpc TESTS=TestRemoteOffsetUnhealthy
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8145)

<!-- Reviewable:end -->
