### PR TITLE
sql: plumb contexts to logs

### DIFF
--- a/server/admin.go
+++ b/server/admin.go
@@ -163,9 +163,12 @@ func (s *adminServer) firstNotFoundError(results []sql.Result) error {
 }
 
 // Databases is an endpoint that returns a list of databases.
-func (s *adminServer) Databases(ctx context.Context, req *serverpb.DatabasesRequest) (*serverpb.DatabasesResponse, error) {
-	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.server.sqlExecutor, nil)
-	r := s.server.sqlExecutor.ExecuteStatements(ctx, session, "SHOW DATABASES;", nil)
+func (s *adminServer) Databases(
+	ctx context.Context, req *serverpb.DatabasesRequest,
+) (*serverpb.DatabasesResponse, error) {
+	args := sql.SessionArgs{User: s.getUser(req)}
+	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
+	r := s.server.sqlExecutor.ExecuteStatements(session, "SHOW DATABASES;", nil)
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, s.serverError(err)
 	}
@@ -184,8 +187,11 @@ func (s *adminServer) Databases(ctx context.Context, req *serverpb.DatabasesRequ
 
 // DatabaseDetails is an endpoint that returns grants and a list of table names
 // for the specified database.
-func (s *adminServer) DatabaseDetails(ctx context.Context, req *serverpb.DatabaseDetailsRequest) (*serverpb.DatabaseDetailsResponse, error) {
-	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.server.sqlExecutor, nil)
+func (s *adminServer) DatabaseDetails(
+	ctx context.Context, req *serverpb.DatabaseDetailsRequest,
+) (*serverpb.DatabaseDetailsResponse, error) {
+	args := sql.SessionArgs{User: s.getUser(req)}
+	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
 
 	// Placeholders don't work with SHOW statements, so we need to manually
 	// escape the database name.
@@ -193,7 +199,7 @@ func (s *adminServer) DatabaseDetails(ctx context.Context, req *serverpb.Databas
 	// TODO(cdo): Use placeholders when they're supported by SHOW.
 	escDBName := parser.Name(req.Database).String()
 	query := fmt.Sprintf("SHOW GRANTS ON DATABASE %s; SHOW TABLES FROM %s;", escDBName, escDBName)
-	r := s.server.sqlExecutor.ExecuteStatements(ctx, session, query, nil)
+	r := s.server.sqlExecutor.ExecuteStatements(session, query, nil)
 	if err := s.firstNotFoundError(r.ResultList); err != nil {
 		return nil, grpc.Errorf(codes.NotFound, "%s", err)
 	}
@@ -246,9 +252,11 @@ func (s *adminServer) DatabaseDetails(ctx context.Context, req *serverpb.Databas
 
 // TableDetails is an endpoint that returns columns, indices, and other
 // relevant details for the specified table.
-func (s *adminServer) TableDetails(ctx context.Context, req *serverpb.TableDetailsRequest) (
-	*serverpb.TableDetailsResponse, error) {
-	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.server.sqlExecutor, nil)
+func (s *adminServer) TableDetails(
+	ctx context.Context, req *serverpb.TableDetailsRequest,
+) (*serverpb.TableDetailsResponse, error) {
+	args := sql.SessionArgs{User: s.getUser(req)}
+	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
 
 	// TODO(cdo): Use real placeholders for the table and database names when we've extended our SQL
 	// grammar to allow that.
@@ -257,7 +265,7 @@ func (s *adminServer) TableDetails(ctx context.Context, req *serverpb.TableDetai
 	escQualTable := fmt.Sprintf("%s.%s", escDbName, escTableName)
 	query := fmt.Sprintf("SHOW COLUMNS FROM %s; SHOW INDEX FROM %s; SHOW GRANTS ON TABLE %s; SHOW CREATE TABLE %s;",
 		escQualTable, escQualTable, escQualTable, escQualTable)
-	r := s.server.sqlExecutor.ExecuteStatements(ctx, session, query, nil)
+	r := s.server.sqlExecutor.ExecuteStatements(session, query, nil)
 	if err := s.firstNotFoundError(r.ResultList); err != nil {
 		return nil, grpc.Errorf(codes.NotFound, "%s", err)
 	}
@@ -411,12 +419,12 @@ func (s *adminServer) TableDetails(ctx context.Context, req *serverpb.TableDetai
 
 	// Query the zone configuration for this table.
 	{
-		path, err := s.queryDescriptorIDPath(ctx, session, []string{escDbName, escTableName})
+		path, err := s.queryDescriptorIDPath(session, []string{escDbName, escTableName})
 		if err != nil {
 			return nil, s.serverError(err)
 		}
 
-		id, zone, zoneExists, err := s.queryZonePath(ctx, session, path)
+		id, zone, zoneExists, err := s.queryZonePath(session, path)
 		if err != nil {
 			return nil, s.serverError(err)
 		}
@@ -441,9 +449,10 @@ func (s *adminServer) TableDetails(ctx context.Context, req *serverpb.TableDetai
 
 // Users returns a list of users, stripped of any passwords.
 func (s *adminServer) Users(ctx context.Context, req *serverpb.UsersRequest) (*serverpb.UsersResponse, error) {
-	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.server.sqlExecutor, nil)
+	args := sql.SessionArgs{User: s.getUser(req)}
+	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
 	query := "SELECT username FROM system.users"
-	r := s.server.sqlExecutor.ExecuteStatements(ctx, session, query, nil)
+	r := s.server.sqlExecutor.ExecuteStatements(session, query, nil)
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, s.serverError(err)
 	}
@@ -461,7 +470,8 @@ func (s *adminServer) Users(ctx context.Context, req *serverpb.UsersRequest) (*s
 // type=STRING  returns events with this type (e.g. "create_table")
 // targetID=INT returns events for that have this targetID
 func (s *adminServer) Events(ctx context.Context, req *serverpb.EventsRequest) (*serverpb.EventsResponse, error) {
-	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.server.sqlExecutor, nil)
+	args := sql.SessionArgs{User: s.getUser(req)}
+	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
 
 	// Execute the query.
 	q := makeSQLQuery()
@@ -479,7 +489,7 @@ func (s *adminServer) Events(ctx context.Context, req *serverpb.EventsRequest) (
 	if len(q.Errors()) > 0 {
 		return nil, s.serverErrors(q.Errors())
 	}
-	r := s.server.sqlExecutor.ExecuteStatements(ctx, session, q.String(), q.QueryArguments())
+	r := s.server.sqlExecutor.ExecuteStatements(session, q.String(), q.QueryArguments())
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, s.serverError(err)
 	}
@@ -535,8 +545,7 @@ func (s *adminServer) getUIData(session *sql.Session, user string, keys []string
 	if err := query.Errors(); err != nil {
 		return nil, s.serverErrorf("error constructing query: %v", err)
 	}
-	r := s.server.sqlExecutor.ExecuteStatements(context.Background(),
-		session, query.String(), query.QueryArguments())
+	r := s.server.sqlExecutor.ExecuteStatements(session, query.String(), query.QueryArguments())
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, s.serverError(err)
 	}
@@ -572,12 +581,13 @@ func (s *adminServer) SetUIData(ctx context.Context, req *serverpb.SetUIDataRequ
 		return nil, grpc.Errorf(codes.InvalidArgument, "KeyValues cannot be empty")
 	}
 
-	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.server.sqlExecutor, nil)
+	args := sql.SessionArgs{User: s.getUser(req)}
+	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
 
 	for key, val := range req.KeyValues {
 		// Do an upsert of the key. We update each key in a separate transaction to
 		// avoid long-running transactions and possible deadlocks.
-		br := s.server.sqlExecutor.ExecuteStatements(ctx, session, "BEGIN;", nil)
+		br := s.server.sqlExecutor.ExecuteStatements(session, "BEGIN;", nil)
 		if err := s.checkQueryResults(br.ResultList, 1); err != nil {
 			return nil, s.serverError(err)
 		}
@@ -595,7 +605,7 @@ func (s *adminServer) SetUIData(ctx context.Context, req *serverpb.SetUIDataRequ
 			qargs := parser.NewPlaceholderInfo()
 			qargs.SetValue(`1`, parser.NewDString(string(val)))
 			qargs.SetValue(`2`, parser.NewDString(key))
-			r := s.server.sqlExecutor.ExecuteStatements(ctx, session, query, qargs)
+			r := s.server.sqlExecutor.ExecuteStatements(session, query, qargs)
 			if err := s.checkQueryResults(r.ResultList, 2); err != nil {
 				return nil, s.serverError(err)
 			}
@@ -607,7 +617,7 @@ func (s *adminServer) SetUIData(ctx context.Context, req *serverpb.SetUIDataRequ
 			qargs := parser.NewPlaceholderInfo()
 			qargs.SetValue(`1`, parser.NewDString(key))
 			qargs.SetValue(`2`, parser.NewDBytes(parser.DBytes(val)))
-			r := s.server.sqlExecutor.ExecuteStatements(ctx, session, query, qargs)
+			r := s.server.sqlExecutor.ExecuteStatements(session, query, qargs)
 			if err := s.checkQueryResults(r.ResultList, 2); err != nil {
 				return nil, s.serverError(err)
 			}
@@ -626,8 +636,9 @@ func (s *adminServer) SetUIData(ctx context.Context, req *serverpb.SetUIDataRequ
 // The stored values are meant to be opaque to the server. In the rare case that
 // the server code needs to call this method, it should only read from keys that
 // have the prefix `serverUIDataKeyPrefix`.
-func (s *adminServer) GetUIData(_ context.Context, req *serverpb.GetUIDataRequest) (*serverpb.GetUIDataResponse, error) {
-	session := sql.NewSession(sql.SessionArgs{User: s.getUser(req)}, s.server.sqlExecutor, nil)
+func (s *adminServer) GetUIData(ctx context.Context, req *serverpb.GetUIDataRequest) (*serverpb.GetUIDataResponse, error) {
+	args := sql.SessionArgs{User: s.getUser(req)}
+	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
 
 	if len(req.Keys) == 0 {
 		return nil, grpc.Errorf(codes.InvalidArgument, "keys cannot be empty")
@@ -1091,12 +1102,12 @@ func (rs resultScanner) Scan(row sql.ResultRow, colName string, dst interface{})
 // queryZone retrieves the specific ZoneConfig associated with the supplied ID,
 // if it exists.
 func (s *adminServer) queryZone(
-	ctx context.Context, session *sql.Session, id sqlbase.ID,
+	session *sql.Session, id sqlbase.ID,
 ) (config.ZoneConfig, bool, error) {
 	const query = `SELECT config FROM system.zones WHERE id = $1`
 	params := parser.NewPlaceholderInfo()
 	params.SetValue(`1`, parser.NewDInt(parser.DInt(id)))
-	r := s.server.sqlExecutor.ExecuteStatements(ctx, session, query, params)
+	r := s.server.sqlExecutor.ExecuteStatements(session, query, params)
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return config.ZoneConfig{}, false, err
 	}
@@ -1124,10 +1135,10 @@ func (s *adminServer) queryZone(
 // queryDescriptorIDPath(), for a ZoneConfig. It returns the most specific
 // ZoneConfig specified for the object IDs in the path.
 func (s *adminServer) queryZonePath(
-	ctx context.Context, session *sql.Session, path []sqlbase.ID,
+	session *sql.Session, path []sqlbase.ID,
 ) (sqlbase.ID, config.ZoneConfig, bool, error) {
 	for i := len(path) - 1; i >= 0; i-- {
-		zone, zoneExists, err := s.queryZone(ctx, session, path[i])
+		zone, zoneExists, err := s.queryZone(session, path[i])
 		if err != nil || zoneExists {
 			return path[i], zone, true, err
 		}
@@ -1138,13 +1149,13 @@ func (s *adminServer) queryZonePath(
 // queryNamespaceID queries for the ID of the namespace with the given name and
 // parent ID.
 func (s *adminServer) queryNamespaceID(
-	ctx context.Context, session *sql.Session, parentID sqlbase.ID, name string,
+	session *sql.Session, parentID sqlbase.ID, name string,
 ) (sqlbase.ID, error) {
 	const query = `SELECT id FROM system.namespace WHERE parentID = $1 AND name = $2`
 	params := parser.NewPlaceholderInfo()
 	params.SetValue(`1`, parser.NewDInt(parser.DInt(parentID)))
 	params.SetValue(`2`, parser.NewDString(name))
-	r := s.server.sqlExecutor.ExecuteStatements(ctx, session, query, params)
+	r := s.server.sqlExecutor.ExecuteStatements(session, query, params)
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return 0, err
 	}
@@ -1169,11 +1180,11 @@ func (s *adminServer) queryNamespaceID(
 // it will return a list of IDs consisting of the root namespace ID, the
 // databases ID, and the table ID (in that order).
 func (s *adminServer) queryDescriptorIDPath(
-	ctx context.Context, session *sql.Session, names []string,
+	session *sql.Session, names []string,
 ) ([]sqlbase.ID, error) {
 	path := []sqlbase.ID{keys.RootNamespaceID}
 	for _, name := range names {
-		id, err := s.queryNamespaceID(ctx, session, path[len(path)-1], name)
+		id, err := s.queryNamespaceID(session, path[len(path)-1], name)
 		if err != nil {
 			return nil, err
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -192,6 +192,7 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 
 	// Set up Executor
 	eCtx := sql.ExecutorContext{
+		Context:      context.Background(),
 		DB:           s.db,
 		Gossip:       s.gossip,
 		LeaseManager: s.leaseMgr,

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -248,6 +248,9 @@ func startServer(t *testing.T) serverutils.TestServerInterface {
 // correctly.
 func TestStatusLocalLogs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	if log.V(3) {
+		t.Skip("Test only works with low verbosity levels")
+	}
 	dir, err := ioutil.TempDir("", "local_log_test")
 	if err != nil {
 		t.Fatal(err)

--- a/sql/database.go
+++ b/sql/database.go
@@ -19,8 +19,6 @@ package sql
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
@@ -203,7 +201,7 @@ func (p *planner) getDatabaseID(name string) (sqlbase.ID, error) {
 	desc, err := p.getCachedDatabaseDesc(name)
 	if err != nil {
 		if log.V(3) {
-			log.Infof(context.TODO(), "%v", err)
+			log.Infof(p.ctx(), "%v", err)
 		}
 		var err error
 		desc, err = p.mustGetDatabaseDesc(name)

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -19,8 +19,6 @@ package sql
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
@@ -137,8 +135,8 @@ func (p *planner) createDescriptor(plainKey sqlbase.DescriptorKey, descriptor sq
 	descID := descriptor.GetID()
 	descDesc := sqlbase.WrapDescriptor(descriptor)
 	if log.V(2) {
-		log.Infof(context.TODO(), "CPut %s -> %d", idKey, descID)
-		log.Infof(context.TODO(), "CPut %s -> %s", descKey, descDesc)
+		log.Infof(p.ctx(), "CPut %s -> %d", idKey, descID)
+		log.Infof(p.ctx(), "CPut %s -> %s", descKey, descDesc)
 	}
 	b.CPut(idKey, descID, nil)
 	b.CPut(descKey, descDesc, nil)

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -19,8 +19,6 @@ package sql
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -108,9 +106,9 @@ func (n *dropDatabaseNode) Start() error {
 
 	b := &client.Batch{}
 	if log.V(2) {
-		log.Infof(context.TODO(), "Del %s", descKey)
-		log.Infof(context.TODO(), "Del %s", nameKey)
-		log.Infof(context.TODO(), "Del %s", zoneKey)
+		log.Infof(n.p.ctx(), "Del %s", descKey)
+		log.Infof(n.p.ctx(), "Del %s", nameKey)
+		log.Infof(n.p.ctx(), "Del %s", zoneKey)
 	}
 	b.Del(descKey)
 	b.Del(nameKey)

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -156,6 +156,7 @@ type Executor struct {
 // All fields holding a pointer or an interface are required to create
 // a Executor; the rest will have sane defaults set if omitted.
 type ExecutorContext struct {
+	Context      context.Context
 	DB           *client.DB
 	Gossip       *gossip.Gossip
 	LeaseManager *LeaseManager
@@ -264,6 +265,16 @@ func NewExecutor(ctx ExecutorContext, stopper *stop.Stopper, registry *metric.Re
 	return exec
 }
 
+// NewDummyExecutor creates an empty Executor that is used for certain tests.
+func NewDummyExecutor() *Executor {
+	return &Executor{ctx: ExecutorContext{Context: context.Background()}}
+}
+
+// Ctx returns the Context associated with this Executor.
+func (e *Executor) Ctx() context.Context {
+	return e.ctx.Context
+}
+
 // SetNodeID sets the node ID for the SQL server. This method must be called
 // before actually using the Executor.
 func (e *Executor) SetNodeID(nodeID roachpb.NodeID) {
@@ -296,15 +307,14 @@ func (e *Executor) getSystemConfig() (config.SystemConfig, *databaseCache) {
 // populate the missing types. The column result types are returned (or
 // nil if there are no results).
 func (e *Executor) Prepare(
-	ctx context.Context,
 	query string,
 	session *Session,
 	pinfo parser.PlaceholderTypes,
 ) ([]ResultColumn, error) {
 	if log.V(2) {
-		log.Infof(session.Context(), "preparing: %s", query)
+		log.Infof(session.Ctx(), "preparing: %s", query)
 	} else if traceSQL {
-		log.Tracef(session.Context(), "preparing: %s", query)
+		log.Tracef(session.Ctx(), "preparing: %s", query)
 	}
 	stmt, err := parser.ParseOne(query, parser.Syntax(session.Syntax))
 	if err != nil {
@@ -324,7 +334,7 @@ func (e *Executor) Prepare(
 
 	// Prepare needs a transaction because it needs to retrieve db/table
 	// descriptors for type checking.
-	txn := client.NewTxn(session.Context(), *e.ctx.DB)
+	txn := client.NewTxn(session.Ctx(), *e.ctx.DB)
 	txn.Proto.Isolation = session.DefaultIsolationLevel
 	session.planner.setTxn(txn)
 	defer session.planner.setTxn(nil)
@@ -356,7 +366,7 @@ func (e *Executor) Prepare(
 
 // ExecuteStatements executes the given statement(s) and returns a response.
 func (e *Executor) ExecuteStatements(
-	ctx context.Context, session *Session, stmts string, pinfo *parser.PlaceholderInfo,
+	session *Session, stmts string, pinfo *parser.PlaceholderInfo,
 ) StatementResults {
 
 	session.planner.resetForBatch(e)
@@ -364,7 +374,7 @@ func (e *Executor) ExecuteStatements(
 
 	// Send the Request for SQL execution and set the application-level error
 	// for each result in the reply.
-	return e.execRequest(ctx, session, stmts)
+	return e.execRequest(session, stmts)
 }
 
 // blockConfigUpdates blocks any gossip updates to the system config
@@ -399,7 +409,7 @@ func (e *Executor) waitForConfigUpdate() {
 // Args:
 //  txnState: State about about ongoing transaction (if any). The state will be
 //   updated.
-func (e *Executor) execRequest(ctx context.Context, session *Session, sql string) StatementResults {
+func (e *Executor) execRequest(session *Session, sql string) StatementResults {
 	var res StatementResults
 	txnState := &session.TxnState
 	planMaker := &session.planner
@@ -457,7 +467,7 @@ func (e *Executor) execRequest(ctx context.Context, session *Session, sql string
 					}()
 				}
 			}
-			txnState.reset(ctx, e, session)
+			txnState.reset(session.Ctx(), e, session)
 			txnState.State = Open
 			txnState.autoRetry = true
 			txnState.sqlTimestamp = e.ctx.Clock.PhysicalTime()
@@ -505,14 +515,18 @@ func (e *Executor) execRequest(ctx context.Context, session *Session, sql string
 			if aErr, ok := err.(*client.AutoCommitError); ok {
 				// Until #7881 fixed.
 				if txn == nil {
-					log.Errorf(context.TODO(), "AutoCommitError on nil txn: %+v, txnState %+v, execOpt %+v, stmts %+v, remaining %+v", err, txnState, execOpt, stmts, remainingStmts)
+					log.Errorf(session.Ctx(), "AutoCommitError on nil txn: %+v, "+
+						"txnState %+v, execOpt %+v, stmts %+v, remaining %+v",
+						err, txnState, execOpt, stmts, remainingStmts)
 				}
 				lastResult.Err = aErr
 				e.txnAbortCount.Inc(1)
 				txn.CleanupOnError(err)
 			}
 			if lastResult.Err == nil {
-				log.Fatalf(context.TODO(), "error (%s) was returned, but it was not set in the last result (%v)", err, lastResult)
+				log.Fatalf(session.Ctx(),
+					"error (%s) was returned, but it was not set in the last result (%v)",
+					err, lastResult)
 			}
 		}
 
@@ -657,7 +671,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 	}
 
 	for i, stmt := range stmts {
-		ctx := planMaker.session.Context()
+		ctx := planMaker.session.Ctx()
 		if log.V(2) {
 			log.Infof(ctx, "executing %d/%d: %s", i+1, len(stmts), stmt)
 		} else if traceSQL {
@@ -976,7 +990,7 @@ func rollbackSQLTransaction(txnState *txnState, p *planner) Result {
 	err := p.txn.Rollback()
 	result := Result{PGTag: (*parser.RollbackTransaction)(nil).StatementTag()}
 	if err != nil {
-		log.Warningf(context.TODO(), "txn rollback failed. The error was swallowed: %s", err)
+		log.Warningf(p.ctx(), "txn rollback failed. The error was swallowed: %s", err)
 		result.Err = err
 	}
 	// We're done with this txn.

--- a/sql/group.go
+++ b/sql/group.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/encoding"
@@ -138,7 +136,7 @@ func (p *planner) groupBy(n *parser.SelectClause, s *selectNode) (*groupNode, er
 		for _, f := range group.funcs {
 			strs = append(strs, f.String())
 		}
-		log.Infof(context.TODO(), "Group: %s", strings.Join(strs, ", "))
+		log.Infof(p.ctx(), "Group: %s", strings.Join(strs, ", "))
 	}
 
 	// Replace the render expressions in the scanNode with expressions that

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -22,8 +22,6 @@ import (
 	"reflect"
 	"sort"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -120,7 +118,7 @@ func selectIndex(
 		// possibly overlapping ranges.
 		exprs, equivalent := analyzeExpr(s.filter)
 		if log.V(2) {
-			log.Infof(context.TODO(), "analyzeExpr: %s -> %s [equivalent=%v]", s.filter, exprs, equivalent)
+			log.Infof(s.p.ctx(), "analyzeExpr: %s -> %s [equivalent=%v]", s.filter, exprs, equivalent)
 		}
 
 		// Check to see if the filter simplified to a constant.
@@ -190,7 +188,7 @@ func selectIndex(
 
 	if log.V(2) {
 		for i, c := range candidates {
-			log.Infof(context.TODO(), "%d: selectIndex(%s): cost=%v constraints=%s reverse=%t",
+			log.Infof(s.p.ctx(), "%d: selectIndex(%s): cost=%v constraints=%s reverse=%t",
 				i, c.index.Name, c.cost, c.constraints, c.reverse)
 		}
 	}
@@ -220,9 +218,9 @@ func selectIndex(
 	}
 
 	if log.V(3) {
-		log.Infof(context.TODO(), "%s: filter=%v", c.index.Name, s.filter)
+		log.Infof(s.p.ctx(), "%s: filter=%v", c.index.Name, s.filter)
 		for i, span := range s.spans {
-			log.Infof(context.TODO(), "%s/%d: %s", c.index.Name, i, sqlbase.PrettySpan(span, 2))
+			log.Infof(s.p.ctx(), "%s/%d: %s", c.index.Name, i, sqlbase.PrettySpan(span, 2))
 		}
 	}
 
@@ -404,7 +402,7 @@ func (v *indexInfo) analyzeOrdering(scan *scanNode, analyzeOrdering analyzeOrder
 	}
 
 	if log.V(2) {
-		log.Infof(context.TODO(), "%s: analyzeOrdering: weight=%0.2f reverse=%v match=%d",
+		log.Infof(scan.p.ctx(), "%s: analyzeOrdering: weight=%0.2f reverse=%v match=%d",
 			v.index.Name, weight, v.reverse, match)
 	}
 }

--- a/sql/join.go
+++ b/sql/join.go
@@ -19,8 +19,6 @@ package sql
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -230,7 +228,7 @@ func (n *indexJoinNode) Next() (bool, error) {
 		}
 
 		if log.V(3) {
-			log.Infof(context.TODO(), "table scan: %s", sqlbase.PrettySpans(n.table.spans, 0))
+			log.Infof(n.index.p.ctx(), "table scan: %s", sqlbase.PrettySpans(n.table.spans, 0))
 		}
 	}
 	return false, nil

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -124,8 +124,8 @@ type v3Conn struct {
 }
 
 func makeV3Conn(
-	conn net.Conn, executor *sql.Executor,
-	metrics *serverMetrics, sessionArgs sql.SessionArgs) v3Conn {
+	conn net.Conn, executor *sql.Executor, metrics *serverMetrics, sessionArgs sql.SessionArgs,
+) v3Conn {
 	return v3Conn{
 		conn:     conn,
 		rd:       bufio.NewReader(conn),
@@ -133,7 +133,7 @@ func makeV3Conn(
 		executor: executor,
 		writeBuf: writeBuffer{bytecount: metrics.bytesOutCount},
 		metrics:  metrics,
-		session:  sql.NewSession(sessionArgs, executor, conn.RemoteAddr()),
+		session:  sql.NewSession(executor.Ctx(), sessionArgs, executor, conn.RemoteAddr()),
 	}
 }
 
@@ -189,7 +189,7 @@ var statusReportParams = map[string]string{
 }
 
 func (c *v3Conn) serve(authenticationHook func(string, bool) error) error {
-	ctx := c.session.Context()
+	ctx := c.session.Ctx()
 
 	if authenticationHook != nil {
 		if err := authenticationHook(c.session.User, true /* public */); err != nil {
@@ -636,7 +636,7 @@ func (c *v3Conn) executeStatements(
 	limit int,
 ) error {
 	tracing.AnnotateTrace()
-	results := c.executor.ExecuteStatements(ctx, c.session, stmts, pinfo)
+	results := c.executor.ExecuteStatements(c.session, stmts, pinfo)
 
 	tracing.AnnotateTrace()
 	if results.Empty {

--- a/sql/pgwire/v3_test.go
+++ b/sql/pgwire/v3_test.go
@@ -29,7 +29,7 @@ import (
 
 func makeTestV3Conn(c net.Conn) v3Conn {
 	return makeV3Conn(c,
-		&sql.Executor{},
+		sql.NewDummyExecutor(),
 		newServerMetrics(metric.NewRegistry()),
 		sql.SessionArgs{},
 	)

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -558,7 +558,7 @@ func TestPGPreparedQuery(t *testing.T) {
 	runTests := func(query string, tests []preparedQueryTest, queryFunc func(...interface{}) (*gosql.Rows, error)) {
 		for _, test := range tests {
 			if testing.Verbose() || log.V(1) {
-				log.Infof(context.TODO(), "query: %s", query)
+				log.Infof(context.Background(), "query: %s", query)
 			}
 			rows, err := queryFunc(test.qargs...)
 			if err != nil {
@@ -814,7 +814,7 @@ func TestPGPreparedExec(t *testing.T) {
 	runTests := func(query string, tests []preparedExecTest, execFunc func(...interface{}) (gosql.Result, error)) {
 		for _, test := range tests {
 			if testing.Verbose() || log.V(1) {
-				log.Infof(context.TODO(), "exec: %s", query)
+				log.Infof(context.Background(), "exec: %s", query)
 			}
 			if result, err := execFunc(test.qargs...); err != nil {
 				if test.error == "" {
@@ -840,7 +840,7 @@ func TestPGPreparedExec(t *testing.T) {
 
 	for _, execTest := range execTests {
 		if testing.Verbose() || log.V(1) {
-			log.Infof(context.TODO(), "prepare: %s", execTest.query)
+			log.Infof(context.Background(), "prepare: %s", execTest.query)
 		}
 		if stmt, err := db.Prepare(execTest.query); err != nil {
 			t.Errorf("%s: prepare error: %s", execTest.query, err)

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/sql/parser"
@@ -142,6 +144,11 @@ type queryRunner interface {
 }
 
 var _ queryRunner = &planner{}
+
+// ctx returns the current session context (suitable for logging/tracing).
+func (p *planner) ctx() context.Context {
+	return p.session.Ctx()
+}
 
 // setTxn implements the queryRunner interface.
 func (p *planner) setTxn(txn *client.Txn) {

--- a/sql/prepare.go
+++ b/sql/prepare.go
@@ -69,7 +69,7 @@ func (ps PreparedStatements) New(
 	placeholderHints parser.PlaceholderTypes,
 ) (*PreparedStatement, error) {
 	// Prepare the query. This completes the typing of placeholders.
-	cols, err := e.Prepare(ctx, query, ps.session, placeholderHints)
+	cols, err := e.Prepare(query, ps.session, placeholderHints)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -117,7 +117,7 @@ func (sc *SchemaChanger) AcquireLease() (sqlbase.TableDescriptor_SchemaChangeLea
 			if time.Unix(0, tableDesc.Lease.ExpirationTime).Add(expirationTimeUncertainty).After(timeutil.Now()) {
 				return errExistingSchemaChangeLease
 			}
-			log.Infof(context.TODO(), "Overriding existing expired lease %v", tableDesc.Lease)
+			log.Infof(txn.Context, "Overriding existing expired lease %v", tableDesc.Lease)
 		}
 		lease = sc.createSchemaChangeLease()
 		tableDesc.Lease = &lease

--- a/sql/show.go
+++ b/sql/show.go
@@ -433,6 +433,7 @@ func (p *planner) ShowConstraints(n *parser.ShowConstraints) (planNode, error) {
 
 	// Sort the results by constraint name.
 	sort := &sortNode{
+		ctx: p.ctx(),
 		ordering: sqlbase.ColumnOrdering{
 			{ColIdx: 0, Direction: encoding.Ascending},
 			{ColIdx: 1, Direction: encoding.Ascending},

--- a/sql/sort.go
+++ b/sql/sort.go
@@ -35,6 +35,7 @@ import (
 // sortNode represents a node that sorts the rows returned by its
 // sub-node.
 type sortNode struct {
+	ctx      context.Context
 	plan     planNode
 	columns  []ResultColumn
 	ordering sqlbase.ColumnOrdering
@@ -149,7 +150,7 @@ func (p *planner) orderBy(orderBy parser.OrderBy, n planNode) (*sortNode, error)
 		ordering = append(ordering, sqlbase.ColumnOrderInfo{ColIdx: index, Direction: direction})
 	}
 
-	return &sortNode{columns: columns, ordering: ordering}, nil
+	return &sortNode{ctx: p.ctx(), columns: columns, ordering: ordering}, nil
 }
 
 // colIndex takes an expression that refers to a column using an integer, verifies it refers to a
@@ -264,7 +265,7 @@ func (n *sortNode) wrap(plan planNode) (bool, planNode) {
 		// ordering.
 		existingOrdering := plan.Ordering()
 		if log.V(2) {
-			log.Infof(context.TODO(), "Sort: existing=%+v desired=%+v", existingOrdering, n.ordering)
+			log.Infof(n.ctx, "Sort: existing=%+v desired=%+v", existingOrdering, n.ordering)
 		}
 		match := computeOrderingMatch(n.ordering, existingOrdering, false)
 		if match < len(n.ordering) {
@@ -281,7 +282,7 @@ func (n *sortNode) wrap(plan planNode) (bool, planNode) {
 		}
 
 		if log.V(2) {
-			log.Infof(context.TODO(), "Sort: no sorting required")
+			log.Infof(n.ctx, "Sort: no sorting required")
 		}
 	}
 

--- a/sql/table.go
+++ b/sql/table.go
@@ -21,8 +21,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -160,7 +158,7 @@ func (p *planner) mustGetTableDesc(qname *parser.QualifiedName) (*sqlbase.TableD
 // getTableLease implements the SchemaAccessor interface.
 func (p *planner) getTableLease(qname *parser.QualifiedName) (*sqlbase.TableDescriptor, error) {
 	if log.V(2) {
-		log.Infof(context.TODO(), "planner acquiring lease on table %q", qname)
+		log.Infof(p.ctx(), "planner acquiring lease on table %q", qname)
 	}
 	if err := qname.NormalizeTableName(p.session.Database); err != nil {
 		return nil, err
@@ -195,7 +193,7 @@ func (p *planner) getTableLease(qname *parser.QualifiedName) (*sqlbase.TableDesc
 			l.ParentID == dbID {
 			lease = l
 			if log.V(2) {
-				log.Infof(context.TODO(), "found lease in planner cache for table %q", qname)
+				log.Infof(p.ctx(), "found lease in planner cache for table %q", qname)
 			}
 			break
 		}
@@ -224,7 +222,7 @@ func (p *planner) getTableLease(qname *parser.QualifiedName) (*sqlbase.TableDesc
 // getTableLeaseByID is a by-ID variant of getTableLease (i.e. uses same cache).
 func (p *planner) getTableLeaseByID(tableID sqlbase.ID) (*sqlbase.TableDescriptor, error) {
 	if log.V(2) {
-		log.Infof(context.TODO(), "planner acquiring lease on table ID %d", tableID)
+		log.Infof(p.ctx(), "planner acquiring lease on table ID %d", tableID)
 	}
 
 	// First, look to see if we already have a lease for this table -- including
@@ -234,7 +232,7 @@ func (p *planner) getTableLeaseByID(tableID sqlbase.ID) (*sqlbase.TableDescripto
 		if l.ID == tableID {
 			lease = l
 			if log.V(2) {
-				log.Infof(context.TODO(), "found lease in planner cache for table %d", tableID)
+				log.Infof(p.ctx(), "found lease in planner cache for table %d", tableID)
 			}
 			break
 		}
@@ -276,7 +274,7 @@ func (p *planner) removeLeaseIfExpiring(lease *LeaseState) bool {
 		}
 	}
 	if idx == -1 {
-		log.Warningf(context.TODO(), "lease (%s) not found", lease)
+		log.Warningf(p.ctx(), "lease (%s) not found", lease)
 		return false
 	}
 	p.leases[idx] = p.leases[len(p.leases)-1]
@@ -284,7 +282,7 @@ func (p *planner) removeLeaseIfExpiring(lease *LeaseState) bool {
 	p.leases = p.leases[:len(p.leases)-1]
 
 	if err := p.leaseMgr.Release(lease); err != nil {
-		log.Warning(context.TODO(), err)
+		log.Warning(p.ctx(), err)
 	}
 
 	// Reset the deadline so that a new deadline will be set after the lease is acquired.
@@ -354,12 +352,12 @@ func (p *planner) notifySchemaChange(id sqlbase.ID, mutationID sqlbase.MutationI
 // releaseLeases implements the SchemaAccessor interface.
 func (p *planner) releaseLeases() {
 	if log.V(2) {
-		log.Infof(context.TODO(), "planner releasing leases")
+		log.Infof(p.ctx(), "planner releasing leases")
 	}
 	if p.leases != nil {
 		for _, lease := range p.leases {
 			if err := p.leaseMgr.Release(lease); err != nil {
-				log.Warning(context.TODO(), err)
+				log.Warning(p.ctx(), err)
 			}
 		}
 		p.leases = nil

--- a/sql/table_test.go
+++ b/sql/table_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -252,11 +254,11 @@ func TestPrimaryKeyUnspecified(t *testing.T) {
 func TestRemoveLeaseIfExpiring(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	p := planner{}
+	p := planner{session: &Session{context: context.Background()}}
 	mc := hlc.NewManualClock(0)
 	p.leaseMgr = &LeaseManager{LeaseStore: LeaseStore{clock: hlc.NewClock(mc.UnixNano)}}
 	p.leases = make([]*LeaseState, 0)
-	txn := client.Txn{}
+	txn := client.Txn{Context: context.Background()}
 	p.setTxn(&txn)
 
 	if p.removeLeaseIfExpiring(nil) {

--- a/sql/trace.go
+++ b/sql/trace.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -61,6 +63,10 @@ func makeTraceNode(plan planNode, txn *client.Txn) planNode {
 			txn:  txn,
 		},
 		sort: &sortNode{
+			// Don't use the planner context: this sort node is sorting the
+			// trace events themselves; we don't want any events from this sort
+			// node to show up in the EXPLAIN TRACE output.
+			ctx:      context.Background(),
 			ordering: traceOrdering,
 			columns:  traceColumns,
 		},

--- a/sql/update.go
+++ b/sql/update.go
@@ -20,8 +20,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
@@ -282,12 +280,11 @@ func (u *updateNode) Start() error {
 }
 
 func (u *updateNode) Next() (bool, error) {
-	ctx := context.TODO()
 	next, err := u.run.rows.Next()
 	if !next {
 		if err == nil {
 			// We're done. Finish the batch.
-			err = u.tw.finalize(ctx)
+			err = u.tw.finalize(u.p.ctx())
 		}
 		return false, err
 	}
@@ -326,7 +323,7 @@ func (u *updateNode) Next() (bool, error) {
 		}
 	}
 
-	newValues, err := u.tw.row(ctx, append(oldValues, updateValues...))
+	newValues, err := u.tw.row(u.p.ctx(), append(oldValues, updateValues...))
 	if err != nil {
 		return false, err
 	}

--- a/sql/virtual_schema.go
+++ b/sql/virtual_schema.go
@@ -151,7 +151,7 @@ func initVirtualTableDesc(t virtualSchemaTable) *sqlbase.TableDescriptor {
 	if err != nil {
 		panic(err)
 	}
-	desc, err := sqlbase.MakeTableDesc(stmt.(*parser.CreateTable), 0)
+	desc, err := MakeTableDesc(stmt.(*parser.CreateTable), 0)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes context for log callsites in `sql/*.go`, with the exception of schema
changer and leases.

Part of #7992.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8147)

<!-- Reviewable:end -->
