### PR TITLE
util/log: change format of tag output

### DIFF
--- a/util/log/log_context_test.go
+++ b/util/log/log_context_test.go
@@ -38,23 +38,23 @@ func TestLogContext(t *testing.T) {
 		},
 		{
 			value:    makeMessage(ctxA, "test", nil),
-			expected: "[NodeID: 5] test",
+			expected: "[NodeID=5] test",
 		},
 		{
 			value:    makeMessage(ctxB, "test", nil),
-			expected: "[NodeID: 5] [ReqID: 123] test",
+			expected: "[NodeID=5,ReqID=123] test",
 		},
 		{
 			value:    makeMessage(ctxC, "test", nil),
-			expected: "[NodeID: 5] [ReqID: 123] [aborted] test",
+			expected: "[NodeID=5,ReqID=123,aborted] test",
 		},
 		{
 			value:    makeMessage(ctxD, "test", nil),
-			expected: "[NodeID: 5] [ReqID: 123] [aborted] [slice: [1 2 3]] test",
+			expected: "[NodeID=5,ReqID=123,aborted,slice=[1 2 3]] test",
 		},
 		{
 			value:    makeMessage(ctxB1, "test", nil),
-			expected: "[NodeID: 5] [branch: meh] test",
+			expected: "[NodeID=5,branch=meh] test",
 		},
 	}
 

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -29,12 +29,17 @@ import (
 func makeMessage(ctx context.Context, format string, args []interface{}) string {
 	var buf bytes.Buffer
 	tags := contextLogTags(ctx)
-	for _, t := range tags {
+	if len(tags) > 0 {
 		buf.WriteString("[")
-		buf.WriteString(t.name)
-		if value := t.value(); value != nil {
-			buf.WriteString(": ")
-			fmt.Fprint(&buf, value)
+		for i, t := range tags {
+			if i > 0 {
+				buf.WriteString(",")
+			}
+			buf.WriteString(t.name)
+			if value := t.value(); value != nil {
+				buf.WriteString("=")
+				fmt.Fprint(&buf, value)
+			}
 		}
 		buf.WriteString("] ")
 	}


### PR DESCRIPTION
Changed the format of tag output from:

  `[tag1: value1] [tag2: value2] ...`

to:

  `[tag1=value1,tag2=value2,...]`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8148)

<!-- Reviewable:end -->
