### PR TITLE
all: fix various badness when resuscitating a node

### DIFF
--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -475,10 +475,6 @@ func (rdc *rangeDescriptorCache) EvictCachedRangeDescriptor(descKey roachpb.RKey
 }
 
 func (rdc *rangeDescriptorCache) evictCachedRangeDescriptorLocked(descKey roachpb.RKey, seenDesc *roachpb.RangeDescriptor, inclusive bool) error {
-	if seenDesc == nil {
-		log.Warningf(context.TODO(), "compare-and-evict for key %s with nil descriptor; clearing unconditionally", descKey)
-	}
-
 	rngKey, cachedDesc, err := rdc.getCachedRangeDescriptorLocked(descKey, inclusive)
 	if err != nil {
 		return err


### PR DESCRIPTION
Prior to this PR, `zerosum` would experience a significant hiccup when
restarting a node:

```
chaos: starting node 1
     35s      9425       26203    789.3       15        0        0        6              2 6 5 5
     36s      9430       26319    115.4       42        0        0        6              2 6 5 5
     37s      9430       26319      0.0       42        0        0        6              2 6 5 5
     38s      9430       26319      0.0       42        0        0        6              2 6 5 5
     39s      9430       26319      0.0       43        0        0       -1              0 0 0 0
     40s      9430       26319      0.0       43        0        0        6              2 6 5 5
     41s      9430       26319      0.0       43        0        0        6              2 6 5 5
     42s      9430       26319      0.0       43        0        0        6              2 6 5 5
     43s      9430       26319      0.0       43        0        0        6              2 6 5 5
     44s      9430       26319      0.0       43        0        0        6              2 6 5 5
     45s      9444       26528    208.7       43        0        0        6              2 6 5 5
     46s      9480       27312    783.9       43        0        0        6              2 6 5 5
```

And now:

```
chaos: starting node 1
     35s      9399       24615    873.5        6        0        0        6              4 5 5 4
     36s      9399       24663     47.8        6        0        0        6              4 5 5 4
     37s      9399       24663      0.0        6        0        0        6              4 5 5 4
     38s      9425       25124    460.9        7        0        0       -1              0 0 0 0
     39s      9463       25890    765.9        7        0        0        6              4 5 5 4
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8163)

<!-- Reviewable:end -->
