### PR TITLE
[WIP] COCKROACH_TRACE_SQL

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -744,10 +744,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 				break
 			}
 
-			if log.V(1) {
-				log.Warningf(ctx, "failed to invoke %s: %s", ba, pErr)
-			}
-			log.Tracef(ctx, "reply error: %s", pErr)
+			log.VTracef(1, ctx, "reply error %s: %s", ba, pErr)
 
 			// Error handling: If the error indicates that our range
 			// descriptor is out of date, evict it from the cache and try

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -747,7 +747,7 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 			if log.V(1) {
 				log.Warningf(ctx, "failed to invoke %s: %s", ba, pErr)
 			}
-			log.Trace(ctx, fmt.Sprintf("reply error: %s", pErr))
+			log.Tracef(ctx, "reply error: %s", pErr)
 
 			// Error handling: If the error indicates that our range
 			// descriptor is out of date, evict it from the cache and try
@@ -971,7 +971,7 @@ func (ds *DistSender) sendToReplicas(opts SendOptions,
 
 			// Send to additional replicas if available.
 			if !transport.IsExhausted() {
-				log.Trace(opts.Context, fmt.Sprintf("error, trying next peer: %s", err))
+				log.Tracef(opts.Context, "error, trying next peer: %s", err)
 				pending++
 				transport.SendNext(done)
 			}

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -246,8 +246,7 @@ func (et *evictionToken) EvictAndReplace(ctx context.Context, newDescs ...roachp
 		if err == nil {
 			if len(newDescs) > 0 {
 				err = et.doReplace(newDescs...)
-				log.Trace(ctx, fmt.Sprintf("evicting cached range descriptor with %d replacements",
-					len(newDescs)))
+				log.Tracef(ctx, "evicting cached range descriptor with %d replacements", len(newDescs))
 			} else {
 				log.Trace(ctx, "evicting cached range descriptor")
 			}

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -360,8 +360,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 
 		if hasET && log.V(1) {
 			for _, intent := range et.IntentSpans {
-				log.Trace(ctx, fmt.Sprintf("intent: [%s,%s)",
-					intent.Key, intent.EndKey))
+				log.Tracef(ctx, "intent: [%s,%s)", intent.Key, intent.EndKey)
 			}
 		}
 	}
@@ -379,7 +378,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 		}
 
 		if pErr = tc.updateState(startNS, ctx, ba, br, pErr); pErr != nil {
-			log.Trace(ctx, fmt.Sprintf("error: %s", pErr))
+			log.Tracef(ctx, "error: %s", pErr)
 			return nil, pErr
 		}
 	}

--- a/server/node.go
+++ b/server/node.go
@@ -794,7 +794,7 @@ func (n *Node) Batch(
 		br, pErr = n.stores.Send(traceCtx, *args)
 		if pErr != nil {
 			br = &roachpb.BatchResponse{}
-			log.Trace(traceCtx, fmt.Sprintf("error: %T", pErr.GetDetail()))
+			log.Tracef(traceCtx, "error: %T", pErr.GetDetail())
 		}
 		if br.Error != nil {
 			panic(roachpb.ErrorUnexpectedlySet(n.stores, br))

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -302,9 +302,8 @@ func (e *Executor) Prepare(
 	pinfo parser.PlaceholderTypes,
 ) ([]ResultColumn, error) {
 	if log.V(2) {
-		log.Infof(context.TODO(), "preparing: %s", query)
-	}
-	if traceSQL {
+		log.Infof(session.Context(), "preparing: %s", query)
+	} else if traceSQL {
 		log.Tracef(session.Context(), "preparing: %s", query)
 	}
 	stmt, err := parser.ParseOne(query, parser.Syntax(session.Syntax))
@@ -658,11 +657,11 @@ func (e *Executor) execStmtsInCurrentTxn(
 	}
 
 	for i, stmt := range stmts {
+		ctx := planMaker.session.Context()
 		if log.V(2) {
-			log.Infof(context.TODO(), "about to execute sql statement (%d/%d): %s", i+1, len(stmts), stmt)
-		}
-		if traceSQL && txnState.txn != nil {
-			log.Tracef(txnState.txn.Context, "executing %d/%d: %s", i+1, len(stmts), stmt)
+			log.Infof(ctx, "executing %d/%d: %s", i+1, len(stmts), stmt)
+		} else if traceSQL {
+			log.Tracef(ctx, "executing %d/%d: %s", i+1, len(stmts), stmt)
 		}
 		txnState.schemaChangers.curStatementIdx = i
 

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -305,7 +305,7 @@ func (e *Executor) Prepare(
 		log.Infof(context.TODO(), "preparing: %s", query)
 	}
 	if traceSQL {
-		log.Trace(session.Context(), fmt.Sprintf("preparing: %s", query))
+		log.Tracef(session.Context(), "preparing: %s", query)
 	}
 	stmt, err := parser.ParseOne(query, parser.Syntax(session.Syntax))
 	if err != nil {
@@ -662,7 +662,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 			log.Infof(context.TODO(), "about to execute sql statement (%d/%d): %s", i+1, len(stmts), stmt)
 		}
 		if traceSQL && txnState.txn != nil {
-			log.Trace(txnState.txn.Context, fmt.Sprintf("executing %d/%d: %s", i+1, len(stmts), stmt))
+			log.Tracef(txnState.txn.Context, "executing %d/%d: %s", i+1, len(stmts), stmt)
 		}
 		txnState.schemaChangers.curStatementIdx = i
 
@@ -934,7 +934,7 @@ func (e *Executor) execStmtInOpenTxn(
 	result, err := e.execStmt(stmt, planMaker, implicitTxn /* autoCommit */)
 	if err != nil {
 		if traceSQL {
-			log.Trace(txnState.txn.Context, fmt.Sprintf("ERROR: %v", err))
+			log.Tracef(txnState.txn.Context, "ERROR: %v", err)
 		}
 		if txnState.tr != nil {
 			txnState.tr.LazyPrintf("ERROR: %v", err)
@@ -951,7 +951,7 @@ func (e *Executor) execStmtInOpenTxn(
 		}
 		txnState.tr.LazyLog(tResult, false)
 		if traceSQL {
-			log.Trace(txnState.txn.Context, fmt.Sprintf("%s done", tResult.String()))
+			log.Tracef(txnState.txn.Context, "%s done", tResult)
 		}
 	}
 	return result, err

--- a/sql/lease.go
+++ b/sql/lease.go
@@ -191,7 +191,9 @@ func (s LeaseStore) Acquire(
 	// there is no harm in that as no other transaction will be attempting to
 	// modify the descriptor and even if the descriptor is never created we'll
 	// just have a dangling lease entry which will eventually get GC'd.
+	ctx := txn.Context // propagate context/trace to new transaction
 	err = s.db.Txn(func(txn *client.Txn) error {
+		txn.Context = ctx
 		p := makeInternalPlanner(txn, security.RootUser)
 		const insertLease = `INSERT INTO system.lease (descID, version, nodeID, expiration) ` +
 			`VALUES ($1, $2, $3, $4)`

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -189,8 +189,7 @@ var statusReportParams = map[string]string{
 }
 
 func (c *v3Conn) serve(authenticationHook func(string, bool) error) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := c.session.Context()
 
 	if authenticationHook != nil {
 		if err := authenticationHook(c.session.User, true /* public */); err != nil {

--- a/sql/session.go
+++ b/sql/session.go
@@ -29,9 +29,15 @@ import (
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/util/envutil"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/retry"
+	"github.com/cockroachdb/cockroach/util/tracing"
+	basictracer "github.com/opentracing/basictracer-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
+
+var traceSQL = envutil.EnvOrDefaultBool("trace_sql", false)
 
 // Session contains the state of a SQL client connection.
 // Create instances using NewSession().
@@ -50,6 +56,8 @@ type Session struct {
 	Location              *time.Location
 	DefaultIsolationLevel enginepb.IsolationType
 	Trace                 trace.Trace
+	context               context.Context
+	cancel                context.CancelFunc
 }
 
 // SessionArgs contains arguments for creating a new Session with NewSession().
@@ -82,6 +90,7 @@ func NewSession(args SessionArgs, e *Executor, remote net.Addr) *Session {
 	}
 	s.Trace = trace.New("sql."+args.User, remoteStr)
 	s.Trace.SetMaxEvents(100)
+	s.context, s.cancel = context.WithCancel(context.Background())
 	return s
 }
 
@@ -95,6 +104,17 @@ func (s *Session) Finish() {
 		s.Trace.Finish()
 		s.Trace = nil
 	}
+	s.cancel()
+}
+
+// Context returns the current context for the session. If there is an active
+// transaction it returns the transaction context, otherwise it returns the
+// session context.
+func (s *Session) Context() context.Context {
+	if s.TxnState.txn != nil {
+		return s.TxnState.txn.Context
+	}
+	return s.context
 }
 
 // TxnStateEnum represents the state of a SQL txn.
@@ -150,6 +170,7 @@ type txnState struct {
 	// TODO(andrei): this is the same as Session.Trace. Consider removing this and
 	// passing the Session along everywhere the trace is needed.
 	tr trace.Trace
+	sp opentracing.Span
 
 	// The timestamp to report for current_timestamp(), now() etc.
 	// This must be constant for the lifetime of a SQL transaction.
@@ -160,10 +181,23 @@ type txnState struct {
 func (ts *txnState) reset(ctx context.Context, e *Executor, s *Session) {
 	*ts = txnState{}
 	ts.txn = client.NewTxn(ctx, *e.ctx.DB)
+	ts.txn.Context = s.context
 	ts.txn.Proto.Isolation = s.DefaultIsolationLevel
 	ts.tr = s.Trace
 	// Discard the old schemaChangers, if any.
 	ts.schemaChangers = schemaChangerCollection{}
+
+	if traceSQL {
+		sp, err := tracing.JoinOrNewSnowball("coordinator", nil, func(sp basictracer.RawSpan) {
+			ts.txn.CollectedSpans = append(ts.txn.CollectedSpans, sp)
+		})
+		if err != nil {
+			log.Warningf(ctx, "unable to create snowball tracer: %s", err)
+			return
+		}
+		ts.txn.Context = opentracing.ContextWithSpan(ts.txn.Context, sp)
+		ts.sp = sp
+	}
 }
 
 func (ts *txnState) willBeRetried() bool {
@@ -180,8 +214,20 @@ func (ts *txnState) resetStateAndTxn(state TxnStateEnum) {
 				"(finalized: %t)", state, ts.txn.Proto.Status, ts.txn.IsFinalized()))
 	}
 
+	ts.dumpTrace()
 	ts.State = state
 	ts.txn = nil
+}
+
+func (ts *txnState) dumpTrace() {
+	if traceSQL && ts.txn != nil {
+		ts.sp.Finish()
+		dump := tracing.FormatRawSpans(ts.txn.CollectedSpans)
+		if len(dump) > 0 {
+			log.Infof(context.Background(), "%s\n%s", ts.txn.Proto.ID, dump)
+		}
+	}
+	ts.sp = nil
 }
 
 // updateStateAndCleanupOnErr updates txnState based on the type of error that we

--- a/storage/intent_resolver.go
+++ b/storage/intent_resolver.go
@@ -18,7 +18,6 @@
 package storage
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/base"
@@ -374,7 +373,7 @@ func (ir *intentResolver) resolveIntents(ctx context.Context, r *Replica,
 	// We're doing async stuff below; those need new traces.
 	ctx, cleanup := tracing.EnsureContext(ctx, ir.store.Tracer())
 	defer cleanup()
-	log.Trace(ctx, fmt.Sprintf("resolving intents [wait=%t]", wait))
+	log.Tracef(ctx, "resolving intents [wait=%t]", wait)
 
 	var reqsRemote []roachpb.Request
 	baLocal := roachpb.BatchRequest{}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -632,7 +632,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) *roachpb.Error {
 				// Return a nil chan to signal that we have a valid lease.
 				return nil, nil
 			}
-			log.Trace(ctx, fmt.Sprintf("request range lease (attempt #%d)", attempt))
+			log.Tracef(ctx, "request range lease (attempt #%d)", attempt)
 
 			// No active lease: Request renewal if a renewal is not already pending.
 			return r.requestLeaseLocked(timestamp), nil
@@ -924,7 +924,7 @@ func (r *Replica) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 		pErr = roachpb.NewError(roachpb.NewRangeNotFoundError(r.RangeID))
 	}
 	if pErr != nil {
-		log.Trace(ctx, fmt.Sprintf("error: %s", pErr))
+		log.Tracef(ctx, "error: %s", pErr)
 	}
 	return br, pErr
 }

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2569,7 +2569,7 @@ func (r *Replica) splitTrigger(
 		// TODO(tschottdorf): ReplicaCorruptionError.
 		return enginepb.MVCCStats{}, nil, errors.Wrap(err, "unable to copy abort cache to RHS split range")
 	}
-	log.Trace(ctx, fmt.Sprintf("copied abort cache (%d entries)", seqCount))
+	log.Tracef(ctx, "copied abort cache (%d entries)", seqCount)
 
 	// Initialize the right-hand lease to be the same as the left-hand lease.
 	// This looks like an innocuous performance improvement, but it's more than

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -352,7 +352,7 @@ func (r *Replica) GetSnapshot(ctx context.Context) (raftpb.Snapshot, error) {
 		Closer:         r.store.Stopper().ShouldQuiesce(),
 	}
 	for retry := retry.Start(retryOptions); retry.Next(); {
-		log.Trace(ctx, fmt.Sprintf("snapshot retry loop pass %d", retry.CurrentAttempt()))
+		log.Tracef(ctx, "snapshot retry loop pass %d", retry.CurrentAttempt())
 		r.mu.Lock()
 		snap, err := r.SnapshotWithContext(ctx)
 		snapshotChan := r.mu.snapshotChan

--- a/storage/replica_range_lease.go
+++ b/storage/replica_range_lease.go
@@ -139,7 +139,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 			case c := <-ch:
 				if c.Err != nil {
 					if log.V(1) {
-						log.Infof(context.TODO(), "failed to acquire lease for replica %s: %s", replica.store, c.Err)
+						log.Infof(context.TODO(), "failed to acquire lease for replica %s: %s", replica, c.Err)
 					}
 					execPErr = c.Err
 				}

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -149,10 +149,7 @@ func (rq *replicateQueue) process(
 			StoreID: newStore.StoreID,
 		}
 
-		if log.V(1) {
-			log.Infof(ctx, "%s: adding replica to %+v due to under-replication", repl, newReplica)
-		}
-		log.Tracef(ctx, "adding replica to %+v due to under-replication", newReplica)
+		log.VTracef(1, ctx, "%s: adding replica to %+v due to under-replication", repl, newReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, newReplica, desc); err != nil {
 			return err
 		}
@@ -164,10 +161,7 @@ func (rq *replicateQueue) process(
 		if err != nil {
 			return err
 		}
-		if log.V(1) {
-			log.Infof(ctx, "%s: removing replica %+v due to over-replication", repl, removeReplica)
-		}
-		log.Tracef(ctx, "removing replica %+v due to over-replication", removeReplica)
+		log.VTracef(1, ctx, "%s: removing replica %+v due to over-replication", repl, removeReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, removeReplica, desc); err != nil {
 			return err
 		}
@@ -184,10 +178,7 @@ func (rq *replicateQueue) process(
 			break
 		}
 		deadReplica := deadReplicas[0]
-		if log.V(1) {
-			log.Infof(ctx, "%s: removing replica %+v from dead store", repl, deadReplica)
-		}
-		log.Tracef(ctx, "removing replica %+v from dead store", deadReplica)
+		log.VTracef(1, ctx, "%s: removing replica %+v from dead store", repl, deadReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, deadReplica, desc); err != nil {
 			return err
 		}
@@ -201,10 +192,7 @@ func (rq *replicateQueue) process(
 		rebalanceStore := rq.allocator.RebalanceTarget(
 			zone.ReplicaAttrs[0], desc.Replicas, repl.store.StoreID())
 		if rebalanceStore == nil {
-			if log.V(1) {
-				log.Infof(ctx, "%s: no suitable rebalance target", repl)
-			}
-			log.Trace(ctx, "no suitable rebalance target")
+			log.VTracef(1, ctx, "%s: no suitable rebalance target", repl)
 			// No action was necessary and no rebalance target was found. Return
 			// without re-queuing this replica.
 			return nil
@@ -213,10 +201,7 @@ func (rq *replicateQueue) process(
 			NodeID:  rebalanceStore.Node.NodeID,
 			StoreID: rebalanceStore.StoreID,
 		}
-		if log.V(1) {
-			log.Infof(ctx, "%s: rebalancing to %+v", repl, rebalanceReplica)
-		}
-		log.Tracef(ctx, "rebalancing to %+v", rebalanceReplica)
+		log.VTracef(1, ctx, "%s: rebalancing to %+v", repl, rebalanceReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, rebalanceReplica, desc); err != nil {
 			return err
 		}

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -153,7 +152,7 @@ func (rq *replicateQueue) process(
 		if log.V(1) {
 			log.Infof(ctx, "%s: adding replica to %+v due to under-replication", repl, newReplica)
 		}
-		log.Trace(ctx, fmt.Sprintf("adding replica to %+v due to under-replication", newReplica))
+		log.Tracef(ctx, "adding replica to %+v due to under-replication", newReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, newReplica, desc); err != nil {
 			return err
 		}
@@ -168,7 +167,7 @@ func (rq *replicateQueue) process(
 		if log.V(1) {
 			log.Infof(ctx, "%s: removing replica %+v due to over-replication", repl, removeReplica)
 		}
-		log.Trace(ctx, fmt.Sprintf("removing replica %+v due to over-replication", removeReplica))
+		log.Tracef(ctx, "removing replica %+v due to over-replication", removeReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, removeReplica, desc); err != nil {
 			return err
 		}
@@ -188,7 +187,7 @@ func (rq *replicateQueue) process(
 		if log.V(1) {
 			log.Infof(ctx, "%s: removing replica %+v from dead store", repl, deadReplica)
 		}
-		log.Trace(ctx, fmt.Sprintf("removing replica %+v from dead store", deadReplica))
+		log.Tracef(ctx, "removing replica %+v from dead store", deadReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, deadReplica, desc); err != nil {
 			return err
 		}
@@ -217,7 +216,7 @@ func (rq *replicateQueue) process(
 		if log.V(1) {
 			log.Infof(ctx, "%s: rebalancing to %+v", repl, rebalanceReplica)
 		}
-		log.Trace(ctx, fmt.Sprintf("rebalancing to %+v", rebalanceReplica))
+		log.Tracef(ctx, "rebalancing to %+v", rebalanceReplica)
 		if err = repl.ChangeReplicas(ctx, roachpb.ADD_REPLICA, rebalanceReplica, desc); err != nil {
 			return err
 		}

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -96,8 +96,7 @@ func (sq *splitQueue) process(
 	desc := rng.Desc()
 	splitKeys := sysCfg.ComputeSplitKeys(desc.StartKey, desc.EndKey)
 	if len(splitKeys) > 0 {
-		log.Infof(context.TODO(), "splitting %s at keys %v", rng, splitKeys)
-		log.Tracef(ctx, "splitting at keys %v", splitKeys)
+		log.Infof(ctx, "splitting %s at keys %v", rng, splitKeys)
 		for _, splitKey := range splitKeys {
 			if err := sq.db.AdminSplit(splitKey.AsRawKey()); err != nil {
 				return errors.Errorf("unable to split %s at key %q: %s", rng, splitKey, err)
@@ -114,8 +113,7 @@ func (sq *splitQueue) process(
 	size := rng.GetMVCCStats().Total()
 	// FIXME: why is this implementation not the same as the one above?
 	if float64(size)/float64(zone.RangeMaxBytes) > 1 {
-		log.Infof(context.TODO(), "splitting %s size=%d max=%d", rng, size, zone.RangeMaxBytes)
-		log.Tracef(ctx, "splitting size=%d max=%d", size, zone.RangeMaxBytes)
+		log.Infof(ctx, "splitting %s size=%d max=%d", rng, size, zone.RangeMaxBytes)
 		if _, pErr := client.SendWrappedWith(rng, ctx, roachpb.Header{
 			Timestamp: now,
 		}, &roachpb.AdminSplitRequest{

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -98,7 +97,7 @@ func (sq *splitQueue) process(
 	splitKeys := sysCfg.ComputeSplitKeys(desc.StartKey, desc.EndKey)
 	if len(splitKeys) > 0 {
 		log.Infof(context.TODO(), "splitting %s at keys %v", rng, splitKeys)
-		log.Trace(ctx, fmt.Sprintf("splitting at keys %v", splitKeys))
+		log.Tracef(ctx, "splitting at keys %v", splitKeys)
 		for _, splitKey := range splitKeys {
 			if err := sq.db.AdminSplit(splitKey.AsRawKey()); err != nil {
 				return errors.Errorf("unable to split %s at key %q: %s", rng, splitKey, err)
@@ -116,7 +115,7 @@ func (sq *splitQueue) process(
 	// FIXME: why is this implementation not the same as the one above?
 	if float64(size)/float64(zone.RangeMaxBytes) > 1 {
 		log.Infof(context.TODO(), "splitting %s size=%d max=%d", rng, size, zone.RangeMaxBytes)
-		log.Trace(ctx, fmt.Sprintf("splitting size=%d max=%d", size, zone.RangeMaxBytes))
+		log.Tracef(ctx, "splitting size=%d max=%d", size, zone.RangeMaxBytes)
 		if _, pErr := client.SendWrappedWith(rng, ctx, roachpb.Header{
 			Timestamp: now,
 		}, &roachpb.AdminSplitRequest{

--- a/storage/store.go
+++ b/storage/store.go
@@ -2100,9 +2100,9 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 	}
 
 	if log.V(1) {
-		log.Trace(ctx, fmt.Sprintf("executing %s", ba))
+		log.Tracef(ctx, "executing %s", ba)
 	} else {
-		log.Trace(ctx, fmt.Sprintf("executing %d requests", len(ba.Requests)))
+		log.Tracef(ctx, "executing %d requests", len(ba.Requests))
 	}
 	// Backoff and retry loop for handling errors. Backoff times are measured
 	// in the Trace.
@@ -2175,7 +2175,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 			pErr.Index = index
 		}
 
-		log.Trace(ctx, fmt.Sprintf("error: %T", pErr.GetDetail()))
+		log.Tracef(ctx, "error: %T", pErr.GetDetail())
 		switch t := pErr.GetDetail().(type) {
 		case *roachpb.WriteIntentError:
 			// If write intent error is resolved, exit retry/backoff loop to

--- a/util/log/trace.go
+++ b/util/log/trace.go
@@ -42,3 +42,27 @@ func Tracef(ctx context.Context, format string, args ...interface{}) {
 		sp.LogEvent(fmt.Sprintf(format, args...))
 	}
 }
+
+// VTrace either logs a message to the log files (which also outputs to the
+// active trace) or logs to the trace alone depending on whether the specified
+// verbosity level is active.
+func VTrace(level level, ctx context.Context, msg string) {
+	if V(level) {
+		Info(ctx, msg)
+	} else {
+		Trace(ctx, msg)
+	}
+}
+
+var _ = VTrace // TODO(peter): silence unused error, remove when used
+
+// VTracef either logs a message to the log files (which also outputs to the
+// active trace) or logs to the trace alone depending on whether the specified
+// verbosity level is active.
+func VTracef(level level, ctx context.Context, format string, args ...interface{}) {
+	if V(level) {
+		Infof(ctx, format, args...)
+	} else {
+		Tracef(ctx, format, args...)
+	}
+}

--- a/util/log/trace.go
+++ b/util/log/trace.go
@@ -17,15 +17,28 @@
 package log
 
 import (
+	"fmt"
+
 	opentracing "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 )
+
+var noopTracer opentracing.NoopTracer
 
 // Trace looks for an opentracing.Trace in the context and logs the given
 // message to it on success.
 func Trace(ctx context.Context, msg string) {
 	sp := opentracing.SpanFromContext(ctx)
-	if sp != nil {
+	if sp != nil && sp.Tracer() != noopTracer {
 		sp.LogEvent(msg)
+	}
+}
+
+// Tracef looks for an opentracing.Trace in the context and formats and logs
+// the given message to it on success.
+func Tracef(ctx context.Context, format string, args ...interface{}) {
+	sp := opentracing.SpanFromContext(ctx)
+	if sp != nil && sp.Tracer() != noopTracer {
+		sp.LogEvent(fmt.Sprintf(format, args...))
 	}
 }

--- a/util/tracing/format.go
+++ b/util/tracing/format.go
@@ -1,0 +1,94 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package tracing
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	basictracer "github.com/opentracing/basictracer-go"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+type traceLogData struct {
+	opentracing.LogData
+	depth int
+}
+
+type traceLogs []traceLogData
+
+func (l traceLogs) Len() int {
+	return len(l)
+}
+
+func (l traceLogs) Less(i, j int) bool {
+	return l[i].Timestamp.Before(l[j].Timestamp)
+}
+
+func (l traceLogs) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
+// FormatRawSpans formats the given spans for human consumption, showing the
+// relationship using nesting and times as both relative to the previous event
+// and cumulative.
+func FormatRawSpans(spans []basictracer.RawSpan) string {
+	m := make(map[uint64]*basictracer.RawSpan)
+	for i, sp := range spans {
+		m[sp.SpanID] = &spans[i]
+	}
+
+	var depth func(uint64) int
+	depth = func(parentID uint64) int {
+		p := m[parentID]
+		if p == nil {
+			return 0
+		}
+		return depth(p.ParentSpanID) + 1
+	}
+
+	var logs traceLogs
+	var start time.Time
+	for _, sp := range spans {
+		if sp.ParentSpanID == 0 {
+			start = sp.Start
+		}
+		d := depth(sp.ParentSpanID)
+		for _, e := range sp.Logs {
+			logs = append(logs, traceLogData{LogData: e, depth: d})
+		}
+	}
+	sort.Sort(logs)
+
+	var buf bytes.Buffer
+	var last time.Time
+	if len(logs) > 0 {
+		last = logs[0].Timestamp
+	}
+	for _, entry := range logs {
+		fmt.Fprintf(&buf, "% 10.3fms % 10.3fms%s%s\n",
+			1000*entry.Timestamp.Sub(start).Seconds(),
+			1000*entry.Timestamp.Sub(last).Seconds(),
+			strings.Repeat("    ", entry.depth+1),
+			entry.Event)
+		last = entry.Timestamp
+	}
+	return buf.String()
+}


### PR DESCRIPTION
Add support tracing all SQL statements via the COCKROACH_TRACE_SQL env
variable. When the transaction associated with the statement commits or
aborts the trace is output to the log file.

In the logs this looks like:

```
I160731 21:57:58.740716 sql/session.go:227  b85d7043-27e9-47df-8813-6f1d775be699
     0.021ms      0.000ms    executing 1/1: BEGIN TRANSACTION
     0.027ms      0.006ms    BEGIN done
     0.300ms      0.273ms    executing 1/1: SAVEPOINT cockroach_restart
     0.447ms      0.147ms    preparing: SELECT id, balance FROM accounts WHERE id IN ($1, $2)
     0.777ms      0.330ms    executing 1/1: SELECT id, balance FROM accounts WHERE id IN ($1, $2)
     0.877ms      0.100ms    meta descriptor lookup
     0.881ms      0.005ms    looked up range descriptor from cache
     0.894ms      0.012ms    sending RPC to [/Table/50, /Max)
     1.104ms      0.211ms    reply error: key range /Table/51/1/526-/Table/51/1/527 outside of bounds of range /Table/50-/Table/51
     1.130ms      0.025ms    evicting cached range descriptor with 2 replacements
     1.132ms      0.003ms    meta descriptor lookup
     1.135ms      0.003ms    looked up range descriptor from cache
     1.145ms      0.010ms    sending RPC to [/Table/51, /Max)
     1.228ms      0.083ms        node 1
     1.232ms      0.003ms        read has no clock uncertainty
     1.238ms      0.006ms        executing 2 requests
     1.245ms      0.007ms        read-only path
     1.247ms      0.002ms        command queue
     1.485ms      0.239ms    SELECT 0 done
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8166)

<!-- Reviewable:end -->
