### PR TITLE
storage: tweak Store.String()

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -917,7 +917,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 
 // String formats a store for debug output.
 func (s *Store) String() string {
-	return fmt.Sprintf("store=%d:%d (%s)", s.Ident.NodeID, s.Ident.StoreID, s.engine)
+	return fmt.Sprintf("store=%d:%d", s.Ident.NodeID, s.Ident.StoreID)
 }
 
 // DrainLeases (when called with 'true') prevents all of the Store's


### PR DESCRIPTION
Don't include Engine.String() in Store.String() as that info isn't
useful in all of the log messages which include Store.String()
transitively via Replica.String().

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8178)

<!-- Reviewable:end -->
