### PR TITLE
storage: remove incorrect panic(unreachable)

### DIFF
--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -375,7 +375,7 @@ func (r *Replica) GetSnapshot(ctx context.Context) (raftpb.Snapshot, error) {
 			return snap, err
 		}
 	}
-	panic("unreachable") // due to infinite retries
+	return raftpb.Snapshot{}, &roachpb.NodeUnavailableError{}
 }
 
 func snapshot(


### PR DESCRIPTION
This can be reached when the stopper quiesces.

Fixes #8118.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8181)

<!-- Reviewable:end -->
