### PR TITLE
cleanup: replaces context.TODO() in places where a context.Context already exists

### DIFF
--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -373,7 +373,7 @@ func (txn *Txn) CleanupOnError(err error) {
 		panic("no error")
 	}
 	if replyErr := txn.Rollback(); replyErr != nil {
-		log.Errorf(context.TODO(), "failure aborting transaction: %s; abort caused by: %s", replyErr, err)
+		log.Errorf(txn.Context, "failure aborting transaction: %s; abort caused by: %s", replyErr, err)
 	}
 }
 

--- a/kv/db.go
+++ b/kv/db.go
@@ -110,6 +110,9 @@ func (s *DBServer) Batch(
 
 	err = s.stopper.RunTask(func() {
 		var pErr *roachpb.Error
+		// TODO(wiz): This is required to be a different context from the one
+		// provided by grpc since it has to last for the entire transaction and not
+		// just this one RPC call. See comment for (*TxnCoordSender).hearbeatLoop.
 		br, pErr = s.sender.Send(context.TODO(), *args)
 		if pErr != nil {
 			br = &roachpb.BatchResponse{}

--- a/kv/range_cache.go
+++ b/kv/range_cache.go
@@ -317,9 +317,9 @@ func (rdc *rangeDescriptorCache) lookupRangeDescriptorInternal(
 	}
 
 	if log.V(3) {
-		log.Infof(context.TODO(), "lookup range descriptor: key=%s\n%s", key, rdc.stringLocked())
+		log.Infof(ctx, "lookup range descriptor: key=%s\n%s", key, rdc.stringLocked())
 	} else if log.V(2) {
-		log.Infof(context.TODO(), "lookup range descriptor: key=%s", key)
+		log.Infof(ctx, "lookup range descriptor: key=%s", key)
 	}
 
 	var res lookupResult
@@ -384,7 +384,7 @@ func (rdc *rangeDescriptorCache) lookupRangeDescriptorInternal(
 			// append could cause a copy, which would change the address of rs[0]. We insert
 			// the prefetched descriptors first to avoid any unintended overwriting.
 			if err := rdc.insertRangeDescriptorsLocked(preRs...); err != nil {
-				log.Warningf(context.TODO(), "range cache inserting prefetched descriptors failed: %v", err)
+				log.Warningf(ctx, "range cache inserting prefetched descriptors failed: %v", err)
 			}
 			if err := rdc.insertRangeDescriptorsLocked(rs...); err != nil {
 				res = lookupResult{err: err}

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -406,7 +406,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 	if tc.linearizable && sleepNS > 0 {
 		defer func() {
 			if log.V(1) {
-				log.Infof(context.TODO(), "%v: waiting %s on EndTransaction for linearizability", br.Txn.ID.Short(), util.TruncateDuration(sleepNS, time.Millisecond))
+				log.Infof(ctx, "%v: waiting %s on EndTransaction for linearizability", br.Txn.ID.Short(), util.TruncateDuration(sleepNS, time.Millisecond))
 			}
 			time.Sleep(sleepNS)
 		}()
@@ -563,6 +563,7 @@ func (tc *TxnCoordSender) unregisterTxnLocked(txnID uuid.UUID) (
 // own associated lifetime and we're ignoring all but the first. It happens now
 // that we pass the same one in every request, but it's brittle to rely on this
 // forever.
+// TODO(wiz): Update (*DBServer).Batch to not use context.TODO().
 func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context, txnID uuid.UUID) {
 	var tickChan <-chan time.Time
 	{
@@ -688,7 +689,7 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
 	// instead of a timeout.
 	if ctx.Done() == nil && hasAbandoned {
 		if log.V(1) {
-			log.Infof(context.TODO(), "transaction %s abandoned; stopping heartbeat", txnMeta.txn)
+			log.Infof(ctx, "transaction %s abandoned; stopping heartbeat", txnMeta.txn)
 		}
 		tc.tryAsyncAbort(txnID)
 		return false
@@ -712,7 +713,7 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context, txnID uuid.UUID) bool {
 	// transaction record at all, we're going to have to assume we're aborted
 	// as well.
 	if pErr != nil {
-		log.Warningf(context.TODO(), "heartbeat to %s failed: %s", txn, pErr)
+		log.Warningf(ctx, "heartbeat to %s failed: %s", txn, pErr)
 		// We're not going to let the client carry out additional requests, so
 		// try to clean up.
 		tc.tryAsyncAbort(*txn.ID)

--- a/server/node.go
+++ b/server/node.go
@@ -330,8 +330,8 @@ func (n *Node) start(
 			if err != nil {
 				return err
 			}
-			log.Infof(context.TODO(), "**** cluster %s has been created", clusterID)
-			log.Infof(context.TODO(), "**** add additional nodes by specifying --join=%s", addr)
+			log.Infof(ctx, "**** cluster %s has been created", clusterID)
+			log.Infof(ctx, "**** add additional nodes by specifying --join=%s", addr)
 			// After bootstrapping, try again to initialize the stores.
 			if err := n.initStores(ctx, engines, n.stopper); err != nil {
 				return err
@@ -400,7 +400,7 @@ func (n *Node) initStores(
 		// adding the store to the bootstraps list.
 		if err := s.Start(stopper); err != nil {
 			if _, ok := err.(*storage.NotBootstrappedError); ok {
-				log.Infof(context.TODO(), "store %s not bootstrapped", s)
+				log.Infof(ctx, "store %s not bootstrapped", s)
 				bootstraps = append(bootstraps, s)
 				continue
 			}
@@ -413,7 +413,7 @@ func (n *Node) initStores(
 		if err != nil {
 			return errors.Errorf("could not query store capacity: %s", err)
 		}
-		log.Infof(context.TODO(), "initialized store %s: %+v", s, capacity)
+		log.Infof(ctx, "initialized store %s: %+v", s, capacity)
 		n.addStore(s)
 	}
 
@@ -791,7 +791,7 @@ func (n *Node) Batch(
 			if sp, err = tracing.JoinOrNewSnowball(opName, args.Trace, func(rawSpan basictracer.RawSpan) {
 				encSp, err := tracing.EncodeRawSpan(&rawSpan, nil)
 				if err != nil {
-					log.Warning(context.TODO(), err)
+					log.Warning(ctx, err)
 				}
 				br.CollectedSpans = append(br.CollectedSpans, encSp)
 			}); err != nil {

--- a/storage/engine/mvcc.go
+++ b/storage/engine/mvcc.go
@@ -1981,7 +1981,7 @@ func MVCCResolveWriteIntentRangeUsingIter(
 			err = mvccResolveWriteIntent(ctx, engine, iterAndBuf.iter, ms, intent, iterAndBuf.buf)
 		}
 		if err != nil {
-			log.Warningf(context.TODO(), "failed to resolve intent for key %q: %v", key.Key, err)
+			log.Warningf(ctx, "failed to resolve intent for key %q: %v", key.Key, err)
 		} else {
 			num++
 		}
@@ -2122,7 +2122,7 @@ func MVCCFindSplitKey(
 		if debugFn != nil {
 			debugFn(msg, args...)
 		} else if log.V(2) {
-			log.Infof(context.TODO(), "FindSplitKey["+rangeID.String()+"] "+msg, args...)
+			log.Infof(ctx, "FindSplitKey["+rangeID.String()+"] "+msg, args...)
 		}
 	}
 

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -196,7 +196,7 @@ func processTransactionTable(
 				defer infoMu.Lock()
 				if err := resolveIntents(roachpb.AsIntents(txn.Intents, &txn),
 					true /* wait */, false /* !poison */); err != nil {
-					log.Warningf(context.TODO(), "failed to resolve intents of aborted txn on gc: %s", err)
+					log.Warningf(ctx, "failed to resolve intents of aborted txn on gc: %s", err)
 				}
 			}()
 		case roachpb.COMMITTED:
@@ -207,7 +207,7 @@ func processTransactionTable(
 				defer infoMu.Lock()
 				return resolveIntents(roachpb.AsIntents(txn.Intents, &txn), true /* wait */, false /* !poison */)
 			}(); err != nil {
-				log.Warningf(context.TODO(), "unable to resolve intents of committed txn on gc: %s", err)
+				log.Warningf(ctx, "unable to resolve intents of committed txn on gc: %s", err)
 				// Returning the error here would abort the whole GC run, and
 				// we don't want that. Instead, we simply don't GC this entry.
 				return nil
@@ -449,7 +449,7 @@ func RunGC(
 		if len(keys) > 1 {
 			meta := &enginepb.MVCCMetadata{}
 			if err := proto.Unmarshal(vals[0], meta); err != nil {
-				log.Errorf(context.TODO(), "unable to unmarshal MVCC metadata for key %q: %s", keys[0], err)
+				log.Errorf(ctx, "unable to unmarshal MVCC metadata for key %q: %s", keys[0], err)
 			} else {
 				// In the event that there's an active intent, send for
 				// intent resolution if older than the threshold.

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -152,7 +152,7 @@ func (*raftLogQueue) shouldQueue(
 // leader and if the total number of the range's raft log's stale entries
 // exceeds RaftLogQueueStaleThreshold.
 func (rlq *raftLogQueue) process(
-	_ context.Context,
+	ctx context.Context,
 	now hlc.Timestamp,
 	r *Replica,
 	_ config.SystemConfig,
@@ -165,7 +165,7 @@ func (rlq *raftLogQueue) process(
 	// Can and should the raft logs be truncated?
 	if truncatableIndexes >= RaftLogQueueStaleThreshold {
 		if log.V(1) {
-			log.Infof(context.TODO(), "truncating the raft log of range %d to %d", r.RangeID, oldestIndex)
+			log.Infof(ctx, "truncating the raft log of range %d to %d", r.RangeID, oldestIndex)
 		}
 		b := &client.Batch{}
 		b.AddRawRequest(&roachpb.TruncateLogRequest{

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -636,7 +636,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) *roachpb.Error {
 				if (r.mu.pendingLeaseRequest.RequestPending() == nil) &&
 					!timestamp.Less(lease.StartStasis.Add(-int64(r.store.ctx.rangeLeaseRenewalDuration), 0)) {
 					if log.V(2) {
-						log.Warningf(context.TODO(), "%s: extending lease %s at %s", r, lease, timestamp)
+						log.Warningf(ctx, "%s: extending lease %s at %s", r, lease, timestamp)
 					}
 					// We had an active lease to begin with, but we want to trigger
 					// a lease extension. We don't need to wait for that extension
@@ -1030,7 +1030,7 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func
 			case <-ctxDone:
 				err := ctx.Err()
 				errStr := fmt.Sprintf("%s while in command queue: %s", err, ba)
-				log.Warningf(context.TODO(), "%s: error %v", r, errStr)
+				log.Warningf(ctx, "%s: error %v", r, errStr)
 				log.Trace(ctx, errStr)
 				defer log.Trace(ctx, "removed from command queue")
 				// The command is moot, so we don't need to bother executing.
@@ -1406,7 +1406,7 @@ func (r *Replica) addWriteCmd(
 					// which can be interpreted appropriately upstream.
 					pErr = roachpb.NewError(ctx.Err())
 				} else {
-					log.Warningf(context.TODO(), "%s: unable to cancel expired Raft command %s", r, ba)
+					log.Warningf(ctx, "%s: unable to cancel expired Raft command %s", r, ba)
 				}
 			}
 		}
@@ -2093,7 +2093,7 @@ func (r *Replica) applyRaftCommand(
 
 	// TODO(tschottdorf): remove when #7224 is cleared.
 	if ba.Txn != nil && ba.Txn.Name == replicaChangeTxnName {
-		log.Infof(context.TODO(), "%s: applied part of replica change txn: %s, pErr=%v",
+		log.Infof(ctx, "%s: applied part of replica change txn: %s, pErr=%v",
 			r, ba, rErr)
 	}
 
@@ -2230,7 +2230,7 @@ func (r *Replica) checkIfTxnAborted(
 	if aborted {
 		// We hit the cache, so let the transaction restart.
 		if log.V(1) {
-			log.Infof(context.TODO(), "%s: found abort cache entry for %s with priority %d",
+			log.Infof(ctx, "%s: found abort cache entry for %s with priority %d",
 				r, txn.ID.Short(), entry.Priority)
 		}
 		newTxn := txn.Clone()

--- a/storage/replica_consistency_queue.go
+++ b/storage/replica_consistency_queue.go
@@ -54,7 +54,7 @@ func (*replicaConsistencyQueue) shouldQueue(now hlc.Timestamp, rng *Replica,
 
 // process() is called on every range for which this node is a lease holder.
 func (q *replicaConsistencyQueue) process(
-	_ context.Context,
+	ctx context.Context,
 	_ hlc.Timestamp,
 	rng *Replica,
 	_ config.SystemConfig,
@@ -62,7 +62,7 @@ func (q *replicaConsistencyQueue) process(
 	req := roachpb.CheckConsistencyRequest{}
 	_, pErr := rng.CheckConsistency(req, rng.Desc())
 	if pErr != nil {
-		log.Error(context.TODO(), pErr.GoError())
+		log.Error(ctx, pErr.GoError())
 	}
 	return nil
 }

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -167,7 +167,7 @@ func (q *replicaGCQueue) process(
 	if _, currentMember := replyDesc.GetReplicaDescriptor(rng.store.StoreID()); !currentMember {
 		// We are no longer a member of this range; clean up our local data.
 		if log.V(1) {
-			log.Infof(context.TODO(), "destroying local data from range %d", desc.RangeID)
+			log.Infof(ctx, "destroying local data from range %d", desc.RangeID)
 		}
 		log.Trace(ctx, "destroying local data")
 		if err := rng.store.RemoveReplica(rng, replyDesc, true); err != nil {
@@ -179,7 +179,7 @@ func (q *replicaGCQueue) process(
 		// subsuming range. Shut down raft processing for the former range
 		// and delete any remaining metadata, but do not delete the data.
 		if log.V(1) {
-			log.Infof(context.TODO(), "removing merged range %d", desc.RangeID)
+			log.Infof(ctx, "removing merged range %d", desc.RangeID)
 		}
 		log.Trace(ctx, "removing merged range")
 		if err := rng.store.RemoveReplica(rng, replyDesc, false); err != nil {

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -470,7 +470,7 @@ func snapshot(
 		return raftpb.Snapshot{}, errors.Errorf("failed to fetch term of %d: %s", appliedIndex, err)
 	}
 
-	log.Infof(context.TODO(), "generated snapshot for range %s at index %d in %s. encoded size=%d, %d KV pairs, %d log entries",
+	log.Infof(ctx, "generated snapshot for range %s at index %d in %s. encoded size=%d, %d KV pairs, %d log entries",
 		rangeID, appliedIndex, timeutil.Since(start), len(data), len(snapData.KV), len(snapData.LogEntries))
 
 	return raftpb.Snapshot{

--- a/storage/replica_trigger.go
+++ b/storage/replica_trigger.go
@@ -486,11 +486,11 @@ func (r *Replica) handleTrigger(
 	}
 
 	if trigger.computeChecksum != nil {
-		r.computeChecksumTrigger(context.TODO(), *trigger.computeChecksum)
+		r.computeChecksumTrigger(ctx, *trigger.computeChecksum)
 	}
 
 	if trigger.verifyChecksum != nil {
-		r.verifyChecksumTrigger(context.TODO(), *trigger.verifyChecksum)
+		r.verifyChecksumTrigger(ctx, *trigger.verifyChecksum)
 	}
 
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -1608,7 +1608,7 @@ func splitTriggerPostCommit(
 	// to the store's replica map.
 	if err := r.store.SplitRange(r, rightRng); err != nil {
 		// Our in-memory state has diverged from the on-disk state.
-		log.Fatalf(context.TODO(), "%s: failed to update Store after split: %s", r, err)
+		log.Fatalf(ctx, "%s: failed to update Store after split: %s", r, err)
 	}
 
 	// Update store stats with difference in stats before and after split.
@@ -1662,10 +1662,10 @@ func splitTriggerPostCommit(
 			replica, err := r.store.GetReplica(rightRng.RangeID)
 			if err != nil {
 				if _, ok := err.(*roachpb.RangeNotFoundError); ok {
-					log.Infof(context.TODO(), "%s: RHS replica %d removed before campaigning",
+					log.Infof(ctx, "%s: RHS replica %d removed before campaigning",
 						r, r.mu.replicaID)
 				} else {
-					log.Infof(context.TODO(), "%s: RHS replica %d unable to campaign: %s",
+					log.Infof(ctx, "%s: RHS replica %d unable to campaign: %s",
 						r, r.mu.replicaID, err)
 				}
 				return
@@ -1673,14 +1673,14 @@ func splitTriggerPostCommit(
 
 			if err := replica.withRaftGroup(func(raftGroup *raft.RawNode) error {
 				if err := raftGroup.Campaign(); err != nil {
-					log.Warningf(context.TODO(), "%s: error %v", r, err)
+					log.Warningf(ctx, "%s: error %v", r, err)
 				}
 				return nil
 			}); err != nil {
 				panic(err)
 			}
 		}); err != nil {
-			log.Warningf(context.TODO(), "%s: error %v", r, err)
+			log.Warningf(ctx, "%s: error %v", r, err)
 			return
 		}
 	}
@@ -2220,12 +2220,12 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 			if t.Resolved {
 				r.Reset()
 				if log.V(1) {
-					log.Warning(context.TODO(), pErr)
+					log.Warning(ctx, pErr)
 				}
 				continue
 			}
 			if log.V(1) {
-				log.Warning(context.TODO(), pErr)
+				log.Warning(ctx, pErr)
 			}
 			// Update the batch transaction, if applicable, in case it has
 			// been independently pushed and has more recent information.

--- a/storage/verify_queue.go
+++ b/storage/verify_queue.go
@@ -83,7 +83,7 @@ func (*verifyQueue) shouldQueue(now hlc.Timestamp, rng *Replica,
 // act of scanning keys verifies on-disk checksums, as each block
 // checksum is checked on load.
 func (*verifyQueue) process(
-	_ context.Context,
+	ctx context.Context,
 	now hlc.Timestamp,
 	rng *Replica,
 	_ config.SystemConfig,
@@ -103,7 +103,7 @@ func (*verifyQueue) process(
 		// TODO(spencer): do something other than fatal error here. We
 		// want to quarantine this range, make it a non-participating raft
 		// follower until it can be replaced and then destroyed.
-		log.Fatalf(context.TODO(), "unhandled failure when scanning range %s; probable data corruption: %s", rng, iter.Error())
+		log.Fatalf(ctx, "unhandled failure when scanning range %s; probable data corruption: %s", rng, iter.Error())
 	}
 
 	// Store current timestamp as last verification for this range.


### PR DESCRIPTION
Related to https://github.com/cockroachdb/cockroach/issues/1779

Was found using a modification to golint. https://github.com/golang/lint/pull/227

@tamird

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8194)

<!-- Reviewable:end -->
