### PR TITLE
storage: pass/return StoreDescriptor by value

### DIFF
--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -431,7 +431,10 @@ func TestAllocatorRebalance(t *testing.T) {
 	// Verify shouldRebalance results.
 	a.options.Deterministic = true
 	for i, store := range stores {
-		desc := a.storePool.getStoreDescriptor(store.StoreID)
+		desc, ok := a.storePool.getStoreDescriptor(store.StoreID)
+		if !ok {
+			t.Fatalf("%d: unable to get store %d descriptor", i, store.StoreID)
+		}
 		sl, _, _ := a.storePool.getStoreList(roachpb.Attributes{}, true)
 		result := a.shouldRebalance(desc, sl)
 		if expResult := (i >= 2); expResult != result {
@@ -485,7 +488,10 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 	// Verify shouldRebalance results.
 	a.options.Deterministic = true
 	for i, store := range stores {
-		desc := a.storePool.getStoreDescriptor(store.StoreID)
+		desc, ok := a.storePool.getStoreDescriptor(store.StoreID)
+		if !ok {
+			t.Fatalf("%d: unable to get store %d descriptor", i, store.StoreID)
+		}
 		sl, _, _ := a.storePool.getStoreList(roachpb.Attributes{}, true)
 		result := a.shouldRebalance(desc, sl)
 		if expResult := (i < 3); expResult != result {

--- a/storage/balancer.go
+++ b/storage/balancer.go
@@ -33,11 +33,12 @@ type nodeIDSet map[roachpb.NodeID]struct{}
 
 func formatCandidates(
 	selected *roachpb.StoreDescriptor,
-	candidates []*roachpb.StoreDescriptor,
+	candidates []roachpb.StoreDescriptor,
 ) string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("[")
-	for i, candidate := range candidates {
+	for i := range candidates {
+		candidate := &candidates[i]
 		if i > 0 {
 			_, _ = buf.WriteString(" ")
 		}
@@ -58,7 +59,8 @@ type rangeCountBalancer struct {
 
 func (rcb rangeCountBalancer) selectBest(sl StoreList) *roachpb.StoreDescriptor {
 	var best *roachpb.StoreDescriptor
-	for _, candidate := range sl.stores {
+	for i := range sl.stores {
+		candidate := &sl.stores[i]
 		if best == nil {
 			best = candidate
 			continue
@@ -89,7 +91,8 @@ func (rcb rangeCountBalancer) selectGood(
 
 func (rcb rangeCountBalancer) selectBad(sl StoreList) *roachpb.StoreDescriptor {
 	var worst *roachpb.StoreDescriptor
-	for _, candidate := range sl.stores {
+	for i := range sl.stores {
+		candidate := &sl.stores[i]
 		if worst == nil {
 			worst = candidate
 			continue
@@ -142,7 +145,7 @@ func (rcb rangeCountBalancer) improve(
 }
 
 func (rcb rangeCountBalancer) shouldRebalance(
-	store *roachpb.StoreDescriptor, sl StoreList,
+	store roachpb.StoreDescriptor, sl StoreList,
 ) bool {
 	// Moving a replica from the given store makes its range count converge on
 	// the mean range count.
@@ -162,8 +165,8 @@ func (rcb rangeCountBalancer) shouldRebalance(
 // store list, excluding any stores that are too full to accept more replicas.
 func selectRandom(
 	randGen allocatorRand, count int, sl StoreList, excluded nodeIDSet,
-) []*roachpb.StoreDescriptor {
-	var descs []*roachpb.StoreDescriptor
+) []roachpb.StoreDescriptor {
+	var descs []roachpb.StoreDescriptor
 	// Randomly permute available stores matching the required attributes.
 	randGen.Lock()
 	defer randGen.Unlock()
@@ -184,9 +187,6 @@ func selectRandom(
 		if len(descs) >= count {
 			break
 		}
-	}
-	if len(descs) == 0 {
-		return nil
 	}
 	return descs
 }


### PR DESCRIPTION
Changed the StorePool and Allocator code to pass/return StoreDescriptors
by value instead of by pointer to avoid unexpected sharing.

Fixes #8205.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8208)

<!-- Reviewable:end -->
