### PR TITLE
sql: fix flaky uuid cast logic test (trivial)

### DIFF
--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -112,9 +112,10 @@ SELECT SUBSTR('RoacH', -2, 4)
 ----
 R
 
-# See #6601
+# See #6601 and #8210. We use three arguments to guarantee a very high
+# probability that at least one of the UUIDs is invalid UTF8.
 query error invalid utf8
-select cast(uuid_v4() as string)
+select cast(uuid_v4() as string), cast(uuid_v4() as string), cast(uuid_v4() as string)
 
 query T
 SELECT SUBSTR('12345', 2, 77)


### PR DESCRIPTION
The test fails once every couple thousand times because a random sequence of 16
bytes happens to be valid UTF8. Changing test to use three arguments - the
chance that this happens three times in a row should be on the order of 1e-12.
Ran under stress with two and three arguments and never saw a failure.

Fixes #7763.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8210)

<!-- Reviewable:end -->
