### PR TITLE
acceptance: add QPS checking & photos load test

### DIFF
--- a/acceptance/allocator_terraform/supervisor.conf.tpl
+++ b/acceptance/allocator_terraform/supervisor.conf.tpl
@@ -48,7 +48,7 @@ stdout_logfile=%(here)s/logs/%(program_name)s.stdout
 
 [program:photos]
 directory=%(here)s
-command=%(here)s/photos --users 3 --db postgres://root@${node_address}:${cockroach_port}/photos?sslmode=disable
+command=%(here)s/photos --users 3 --benchmark-name ${benchmark_name} --db postgres://root@${node_address}:${cockroach_port}/photos?sslmode=disable
 process_name=%(program_name)s
 numprocs=1
 autostart=false


### PR DESCRIPTION
While we're testing whether the various processes were alive, we weren't
testing whether queries were being processed. Now, we ensure that
QPS is non-zero. This would've caught #8192 automatically (I just
happened to notice the 0 QPS manually).

Also added a load test for photos.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8211)

<!-- Reviewable:end -->
