### PR TITLE
sqlbase: Add unit tests for PrivilegeDescriptor.{CheckPrivilege|AnyPrivilege}

### DIFF
--- a/sql/sqlbase/privilege_test.go
+++ b/sql/sqlbase/privilege_test.go
@@ -87,6 +87,49 @@ func TestPrivilege(t *testing.T) {
 	}
 }
 
+func TestCheckPrivilege(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		pd   *PrivilegeDescriptor
+		user string
+		priv privilege.Kind
+		exp  bool
+	}{
+		{NewPrivilegeDescriptor("foo", privilege.List{privilege.CREATE}),
+			"foo", privilege.CREATE, true},
+		{NewPrivilegeDescriptor("foo", privilege.List{privilege.CREATE}),
+			"bar", privilege.CREATE, false},
+		{NewPrivilegeDescriptor("foo", privilege.List{privilege.CREATE}),
+			"bar", privilege.DROP, false},
+		{NewPrivilegeDescriptor("foo", privilege.List{privilege.CREATE}),
+			"foo", privilege.DROP, false},
+		{NewPrivilegeDescriptor("foo", privilege.List{privilege.ALL}),
+			"foo", privilege.CREATE, true},
+		{NewPrivilegeDescriptor("foo", privilege.List{privilege.CREATE}),
+			"foo", privilege.ALL, false},
+		{NewPrivilegeDescriptor("foo", privilege.List{privilege.ALL}),
+			"foo", privilege.ALL, true},
+		{NewPrivilegeDescriptor("foo", privilege.List{}),
+			"foo", privilege.ALL, false},
+		{NewPrivilegeDescriptor("foo", privilege.List{}),
+			"foo", privilege.CREATE, false},
+		{NewPrivilegeDescriptor("foo", privilege.List{privilege.CREATE, privilege.DROP}),
+			"foo", privilege.UPDATE, false},
+		{NewPrivilegeDescriptor("foo", privilege.List{privilege.CREATE, privilege.DROP}),
+			"foo", privilege.DROP, true},
+		{NewPrivilegeDescriptor("foo", privilege.List{privilege.CREATE, privilege.ALL}),
+			"foo", privilege.DROP, true},
+	}
+
+	for tcNum, tc := range testCases {
+		if found := tc.pd.CheckPrivilege(tc.user, tc.priv); found != tc.exp {
+			t.Errorf("#%d: CheckPrivilege(%s, %v) for descriptor %+v = %t, expected %t",
+				tcNum, tc.user, tc.priv, tc.pd, found, tc.exp)
+		}
+	}
+}
+
 // TestPrivilegeValidate exercises validation for non-system descriptors.
 func TestPrivilegeValidate(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
After hitting a merge conflict on another branch, I realized I had added exactly what @mjibson added in b72c441d53bb5b08b9d52db78c6b74c9b3d741c2. This was because `information_schema` also needed a notion of `AnyPrivilege`.

I was happily able to remove my duplicate implementation, but figured I'd push the tests I had included along the way.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8212)

<!-- Reviewable:end -->
