### PR TITLE
gossip: don't add self resolver to gossip during bootstrapping

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -333,7 +333,7 @@ func (g *Gossip) SetStorage(storage Storage) error {
 		if log.V(1) {
 			log.Infof(context.TODO(), "found new resolvers from storage; signalling bootstrap")
 		}
-		g.signalStalled()
+		g.signalStalledLocked()
 	}
 	return nil
 }
@@ -983,13 +983,15 @@ func (g *Gossip) maybeSignalStalledLocked() {
 		g.stalled = true
 		g.warnAboutStall()
 	}
-	g.signalStalled()
+	g.signalStalledLocked()
 }
 
-func (g *Gossip) signalStalled() {
-	select {
-	case g.stalledCh <- struct{}{}:
-	default:
+func (g *Gossip) signalStalledLocked() {
+	if len(g.resolvers) > 0 {
+		select {
+		case g.stalledCh <- struct{}{}:
+		default:
+		}
 	}
 }
 

--- a/server/node.go
+++ b/server/node.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip"
-	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
 	"github.com/cockroachdb/cockroach/kv"
@@ -322,12 +321,6 @@ func (n *Node) start(addr net.Addr, engines []engine.Engine, attrs roachpb.Attri
 			}
 			log.Infof(context.TODO(), "**** cluster %s has been created", clusterID)
 			log.Infof(context.TODO(), "**** add additional nodes by specifying --join=%s", addr)
-			// Make sure we add the node as a resolver.
-			selfResolver, err := resolver.NewResolverFromAddress(addr)
-			if err != nil {
-				return err
-			}
-			n.ctx.Gossip.SetResolvers([]resolver.Resolver{selfResolver})
 			// After bootstrapping, try again to initialize the stores.
 			if err := n.initStores(engines, n.stopper); err != nil {
 				return err


### PR DESCRIPTION
It's not clear from the code why we added a self resolver during
bootstrapping. It doesn't appear to be necessary and doing so created a
discrepancy between starting a node and going through bootstrapping and
restarting an existing single node cluster. In the latter case we
wouldn't have a self resolver while in the former we would.

Don't signal the stalled channel if there are no resolvers as is the
case in a single node cluster.

See #8129

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8226)

<!-- Reviewable:end -->
