### PR TITLE
kv: ignore stupid grpc error

### DIFF
--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -443,7 +443,7 @@ func TestClientNotReady(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := grpcConn.Close(); err != nil {
+			if err := grpcConn.Close(); err != nil && err != grpc.ErrClientConnClosing {
 				t.Fatal(err)
 			}
 
@@ -477,7 +477,7 @@ func TestClientNotReady(t *testing.T) {
 		_, err := sendBatch(SendOptions{
 			Context: context.Background(),
 		}, addrs, nodeContext)
-		if !testutils.IsError(err, "connection is closing") {
+		if !testutils.IsError(err, "connection is closing|failed fast due to transport failure") {
 			errCh <- errors.Wrap(err, "unexpected error")
 		} else {
 			close(errCh)
@@ -496,7 +496,7 @@ func TestClientNotReady(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := grpcConn.Close(); err != nil {
+	if err := grpcConn.Close(); err != nil && err != grpc.ErrClientConnClosing {
 		t.Fatal(err)
 	}
 	for err := range errCh {


### PR DESCRIPTION
This can happen when a heartbeat fails and closes the connection.

Fixes #8239.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8240)

<!-- Reviewable:end -->
