### PR TITLE
sql: Add proper privilege control for information_schema.tables

### DIFF
--- a/sql/information_schema.go
+++ b/sql/information_schema.go
@@ -98,6 +98,9 @@ CREATE TABLE information_schema.tables (
 			sort.Strings(dbTableNames)
 			for _, tableName := range dbTableNames {
 				table := dbTables[tableName]
+				if !userCanSeeTable(table, p.session.User) {
+					continue
+				}
 				tableType := tableTypeBaseTable
 				if isVirtualDescriptor(table) {
 					tableType = tableTypeSystemView
@@ -113,4 +116,9 @@ CREATE TABLE information_schema.tables (
 		}
 		return nil
 	},
+}
+
+func userCanSeeTable(table *sqlbase.TableDescriptor, user string) bool {
+	return table.State == sqlbase.TableDescriptor_PUBLIC &&
+		(table.Privileges.AnyPrivilege(user) || isVirtualDescriptor(table))
 }

--- a/sql/testdata/information_schema
+++ b/sql/testdata/information_schema
@@ -204,5 +204,29 @@ SELECT TABLE_SCHEMA, TABLE_NAME, VERSION FROM information_schema.tables WHERE ve
 TABLE_SCHEMA  TABLE_NAME  VERSION
 other_db      xyz         4
 
+user testuser
+
+query TTTTI colnames
+SELECT * FROM information_schema.tables
+----
+TABLE_CATALOG  TABLE_SCHEMA        TABLE_NAME  TABLE_TYPE   VERSION
+def            information_schema  tables      SYSTEM VIEW  1
+
+user root
+
+statement ok
+GRANT SELECT ON other_db.xyz TO testuser
+
+user testuser
+
+query TTTTI colnames
+SELECT * FROM information_schema.tables
+----
+TABLE_CATALOG  TABLE_SCHEMA        TABLE_NAME  TABLE_TYPE   VERSION
+def            information_schema  tables      SYSTEM VIEW  1
+def            other_db            xyz         BASE TABLE   5
+
+user root
+
 statement ok
 DROP DATABASE other_db


### PR DESCRIPTION
Users of `information_schema` should only be able to see objects which they have privileges on. See [information_schema privileges](https://github.com/cockroachdb/cockroach/blob/f4bc2f692e61df1fbc8a1f8b3c1d5d58ffb808b6/docs/RFCS/information_schema.md#privileges).

This change adds the proper privilege visibility control to the `information_schema.tables` table.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8259)

<!-- Reviewable:end -->
