### PR TITLE
all: close listeners rather than GracefulStop() on ShouldQuiesce()

### DIFF
--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -104,7 +104,7 @@ func (n *Network) CreateNode() (*Node, error) {
 	}
 	n.Stopper.RunWorker(func() {
 		<-n.Stopper.ShouldQuiesce()
-		server.GracefulStop()
+		netutil.FatalIfUnexpected(ln.Close())
 		<-n.Stopper.ShouldStop()
 		server.Stop()
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -360,7 +360,7 @@ func (s *Server) Start() error {
 
 	s.stopper.RunWorker(func() {
 		<-s.stopper.ShouldQuiesce()
-		s.grpc.GracefulStop()
+		netutil.FatalIfUnexpected(anyL.Close())
 		<-s.stopper.ShouldStop()
 		s.grpc.Stop()
 	})

--- a/util/netutil/net.go
+++ b/util/netutil/net.go
@@ -49,7 +49,7 @@ func ListenAndServeGRPC(
 
 	stopper.RunWorker(func() {
 		<-stopper.ShouldQuiesce()
-		server.GracefulStop()
+		FatalIfUnexpected(ln.Close())
 		<-stopper.ShouldStop()
 		server.Stop()
 	})


### PR DESCRIPTION
Some clients are not properly closing on the stopper, deadlocking
GracefulStop() and causing tests to hang on shutdown.

Ideally GracefulStop() would take a timeout (or a context), but it
doesn't, so we have to kill servers for now.

Fixes #8221.

Also, it was never necessary to call both GracefulStop() and Stop().

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8277)

<!-- Reviewable:end -->
