### PR TITLE
gossip: ensure grpc initialization occurs before start 

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -61,11 +61,12 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"golang.org/x/net/context"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
-	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
@@ -190,7 +191,7 @@ type Gossip struct {
 }
 
 // New creates an instance of a gossip node.
-func New(rpcContext *rpc.Context, resolvers []resolver.Resolver, stopper *stop.Stopper, registry *metric.Registry) *Gossip {
+func New(rpcContext *rpc.Context, grpcServer *grpc.Server, resolvers []resolver.Resolver, stopper *stop.Stopper, registry *metric.Registry) *Gossip {
 	g := &Gossip{
 		Connected:         make(chan struct{}),
 		rpcContext:        rpcContext,
@@ -212,6 +213,8 @@ func New(rpcContext *rpc.Context, resolvers []resolver.Resolver, stopper *stop.S
 	g.is.registerCallback(KeySystemConfig, g.updateSystemConfig)
 	// Add ourselves as a node descriptor watcher.
 	g.is.registerCallback(MakePrefixPattern(KeyNodeIDPrefix), g.updateNodeAddress)
+
+	RegisterGossipServer(grpcServer, g.server)
 
 	return g
 }
@@ -765,10 +768,10 @@ func (g *Gossip) MaxHops() uint32 {
 //
 // This method starts bootstrap loop, gossip server, and client
 // management in separate goroutines and returns.
-func (g *Gossip) Start(grpcServer *grpc.Server, addr net.Addr) {
-	g.server.start(grpcServer, addr) // serve gossip protocol
-	g.bootstrap()                    // bootstrap gossip client
-	g.manage()                       // manage gossip clients
+func (g *Gossip) Start(addr net.Addr) {
+	g.server.start(addr) // serve gossip protocol
+	g.bootstrap()        // bootstrap gossip client
+	g.manage()           // manage gossip clients
 }
 
 // hasIncoming returns whether the server has an incoming gossip

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -41,8 +41,8 @@ func TestGossipInfoStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	rpcContext := rpc.NewContext(nil, nil, stopper)
-	g := New(rpcContext, nil, stopper, metric.NewRegistry())
+	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
+	g := New(rpcContext, rpc.NewServer(rpcContext), nil, stopper, metric.NewRegistry())
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	slice := []byte("b")
@@ -59,6 +59,8 @@ func TestGossipInfoStore(t *testing.T) {
 
 func TestGossipGetNextBootstrapAddress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
 
 	resolverSpecs := []string{
 		"127.0.0.1:9000",
@@ -76,7 +78,8 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 	if len(resolvers) != 3 {
 		t.Errorf("expected 3 resolvers; got %d", len(resolvers))
 	}
-	g := New(nil, resolvers, nil, metric.NewRegistry())
+	server := rpc.NewServer(rpc.NewContext(&base.Context{Insecure: true}, nil, stopper))
+	g := New(nil, server, resolvers, nil, metric.NewRegistry())
 
 	// Using specified resolvers, fetch bootstrap addresses 3 times
 	// and verify the results match expected addresses.

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
@@ -303,11 +302,10 @@ func (s *server) maybeTighten() {
 // then begins processing connecting clients in an infinite select
 // loop via goroutine. Periodically, clients connected and awaiting
 // the next round of gossip are awoken via the conditional variable.
-func (s *server) start(grpcServer *grpc.Server, addr net.Addr) {
+func (s *server) start(addr net.Addr) {
 	s.mu.Lock()
 	s.is.NodeAddr = util.MakeUnresolvedAddr(addr.Network(), addr.String())
 	s.mu.Unlock()
-	RegisterGossipServer(grpcServer, s)
 
 	broadcast := func() {
 		ready := make(chan struct{})

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -109,7 +109,7 @@ func (n *Network) CreateNode() (*Node, error) {
 		server.Stop()
 	})
 	node := &Node{Server: server, Listener: ln, Registry: metric.NewRegistry()}
-	node.Gossip = gossip.New(n.rpcContext, nil, n.Stopper, node.Registry)
+	node.Gossip = gossip.New(n.rpcContext, server, nil, n.Stopper, node.Registry)
 	n.Nodes = append(n.Nodes, node)
 	return node, nil
 }
@@ -117,7 +117,7 @@ func (n *Network) CreateNode() (*Node, error) {
 // StartNode initializes a gossip instance for the simulation node and
 // starts it.
 func (n *Network) StartNode(node *Node) error {
-	node.Gossip.Start(node.Server, node.Addr())
+	node.Gossip.Start(node.Addr())
 	node.Gossip.EnableSimulationCycler(true)
 	n.nodeIDAllocator++
 	node.Gossip.SetNodeID(n.nodeIDAllocator)

--- a/storage/raft_transport_test.go
+++ b/storage/raft_transport_test.go
@@ -88,7 +88,8 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 		transports: map[roachpb.NodeID]*storage.RaftTransport{},
 	}
 	rttc.nodeRPCContext = rpc.NewContext(testutils.NewNodeTestBaseContext(), nil, rttc.stopper)
-	rttc.gossip = gossip.New(rttc.nodeRPCContext, nil, rttc.stopper, metric.NewRegistry())
+	server := rpc.NewServer(rttc.nodeRPCContext) // never started
+	rttc.gossip = gossip.New(rttc.nodeRPCContext, server, nil, rttc.stopper, metric.NewRegistry())
 	rttc.gossip.SetNodeID(1)
 	return rttc
 }

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -152,8 +152,9 @@ func (tc *testContext) StartWithStoreContext(t testing.TB, ctx StoreContext) {
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(tc.stopper)
 	if tc.gossip == nil {
-		rpcContext := rpc.NewContext(nil, nil, tc.stopper)
-		tc.gossip = gossip.New(rpcContext, nil, tc.stopper, metric.NewRegistry())
+		rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, tc.stopper)
+		server := rpc.NewServer(rpcContext) // never started
+		tc.gossip = gossip.New(rpcContext, server, nil, tc.stopper, metric.NewRegistry())
 		tc.gossip.SetNodeID(1)
 	}
 	if tc.manualClock == nil {

--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"text/tabwriter"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
@@ -74,8 +75,9 @@ func createCluster(
 	rand *rand.Rand,
 ) *Cluster {
 	clock := hlc.NewClock(hlc.UnixNano)
-	rpcContext := rpc.NewContext(nil, clock, stopper)
-	g := gossip.New(rpcContext, nil, stopper, metric.NewRegistry())
+	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, clock, stopper)
+	server := rpc.NewServer(rpcContext)
+	g := gossip.New(rpcContext, server, nil, stopper, metric.NewRegistry())
 	// NodeID is required for Gossip, so set it to -1 for the cluster Gossip
 	// instance to prevent conflicts with real NodeIDs.
 	g.SetNodeID(-1)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -28,6 +28,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/build"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
@@ -130,8 +131,9 @@ func createTestStoreWithoutStart(t testing.TB, ctx *StoreContext) (*Store, *hlc.
 	stopper := stop.NewStopper()
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
-	rpcContext := rpc.NewContext(nil, nil, stopper)
-	ctx.Gossip = gossip.New(rpcContext, nil, stopper, metric.NewRegistry())
+	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
+	server := rpc.NewServer(rpcContext) // never started
+	ctx.Gossip = gossip.New(rpcContext, server, nil, stopper, metric.NewRegistry())
 	ctx.Gossip.SetNodeID(1)
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)

--- a/testutils/localtestcluster/local_test_cluster.go
+++ b/testutils/localtestcluster/local_test_cluster.go
@@ -88,7 +88,8 @@ func (ltc *LocalTestCluster) Start(t util.Tester, baseCtx *base.Context, initSen
 	ltc.Clock = hlc.NewClock(ltc.Manual.UnixNano)
 	ltc.Stopper = stop.NewStopper()
 	rpcContext := rpc.NewContext(baseCtx, ltc.Clock, ltc.Stopper)
-	ltc.Gossip = gossip.New(rpcContext, nil, ltc.Stopper, metric.NewRegistry())
+	server := rpc.NewServer(rpcContext) // never started
+	ltc.Gossip = gossip.New(rpcContext, server, nil, ltc.Stopper, metric.NewRegistry())
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20, ltc.Stopper)
 
 	ltc.Stores = storage.NewStores(ltc.Clock)


### PR DESCRIPTION
There was previously a race condition here where the grpc server could
receive an RPC before or while services were being registered on it.

Fixes #8169.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8282)

<!-- Reviewable:end -->
