### PR TITLE
storage: do not use non-authoritative Desc()

### DIFF
--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -298,7 +298,7 @@ func NewRangeKeyMismatchError(start, end Key, desc *RangeDescriptor) *RangeKeyMi
 	if desc != nil && !desc.IsInitialized() {
 		// We must never send uninitialized ranges back to the client (nil
 		// is fine) guard against regressions of #6027.
-		panic("descriptor is not initialized")
+		panic(fmt.Sprintf("descriptor is not initialized: %+v", desc))
 	}
 	return &RangeKeyMismatchError{
 		RequestStartKey: start,

--- a/storage/storagebase/state.pb.go
+++ b/storage/storagebase/state.pb.go
@@ -49,7 +49,7 @@ type ReplicaState struct {
 	// The pointer may change, but the referenced RangeDescriptor struct itself
 	// must be treated as immutable; it is leaked out of the lock.
 	//
-	// Changes of the descriptor should normally go through one of the
+	// Changes of the descriptor should always go through one of the
 	// (*Replica).setDesc* methods.
 	Desc *cockroach_roachpb.RangeDescriptor `protobuf:"bytes,3,opt,name=desc" json:"desc,omitempty"`
 	// The latest lease, if any.

--- a/storage/storagebase/state.proto
+++ b/storage/storagebase/state.proto
@@ -37,7 +37,7 @@ message ReplicaState {
   // The pointer may change, but the referenced RangeDescriptor struct itself
   // must be treated as immutable; it is leaked out of the lock.
   //
-  // Changes of the descriptor should normally go through one of the
+  // Changes of the descriptor should always go through one of the
   // (*Replica).setDesc* methods.
   roachpb.RangeDescriptor desc = 3;
   // The latest lease, if any.

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1062,28 +1062,28 @@ func TestStoreReplicasByKey(t *testing.T) {
 	r4 := splitTestRange(store, roachpb.RKey("X"), roachpb.RKey("ZZ"), t)
 
 	if r := store.LookupReplica(roachpb.RKey("0"), nil); r != r0 {
-		t.Errorf("mismatched range %+v != %+v", r.Desc(), r0.Desc())
+		t.Errorf("mismatched range %+v != %+v", r.InformalDesc(), r0.InformalDesc())
 	}
 	if r := store.LookupReplica(roachpb.RKey("B"), nil); r != r1 {
-		t.Errorf("mismatched range %+v != %+v", r.Desc(), r1.Desc())
+		t.Errorf("mismatched range %+v != %+v", r.InformalDesc(), r1.InformalDesc())
 	}
 	if r := store.LookupReplica(roachpb.RKey("C"), nil); r != r2 {
-		t.Errorf("mismatched range %+v != %+v", r.Desc(), r2.Desc())
+		t.Errorf("mismatched range %+v != %+v", r.InformalDesc(), r2.InformalDesc())
 	}
 	if r := store.LookupReplica(roachpb.RKey("M"), nil); r != r2 {
-		t.Errorf("mismatched range %+v != %+v", r.Desc(), r2.Desc())
+		t.Errorf("mismatched range %+v != %+v", r.InformalDesc(), r2.InformalDesc())
 	}
 	if r := store.LookupReplica(roachpb.RKey("X"), nil); r != r3 {
-		t.Errorf("mismatched range %+v != %+v", r.Desc(), r3.Desc())
+		t.Errorf("mismatched range %+v != %+v", r.InformalDesc(), r3.InformalDesc())
 	}
 	if r := store.LookupReplica(roachpb.RKey("Z"), nil); r != r3 {
-		t.Errorf("mismatched range %+v != %+v", r.Desc(), r3.Desc())
+		t.Errorf("mismatched range %+v != %+v", r.InformalDesc(), r3.InformalDesc())
 	}
 	if r := store.LookupReplica(roachpb.RKey("ZZ"), nil); r != r4 {
-		t.Errorf("mismatched range %+v != %+v", r.Desc(), r4.Desc())
+		t.Errorf("mismatched range %+v != %+v", r.InformalDesc(), r4.InformalDesc())
 	}
 	if r := store.LookupReplica(roachpb.RKey("\xff\x00"), nil); r != r4 {
-		t.Errorf("mismatched range %+v != %+v", r.Desc(), r4.Desc())
+		t.Errorf("mismatched range %+v != %+v", r.InformalDesc(), r4.InformalDesc())
 	}
 	if store.LookupReplica(roachpb.RKeyMax, nil) != nil {
 		t.Errorf("expected roachpb.KeyMax to not have an associated range")


### PR DESCRIPTION
After ec007326db720f9028f793438ea40a6ce1dc4da1, we were using a denormalized
copy of the descriptor which is not protected by the same mutex in places
where we shouldn't, resulting in subtle races. Change it back to use the
authoritative one almost everywhere, except for informational callsites
(such as stringifying a `Replica`).

Fixes #8086.
Fixes #8157.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8283)

<!-- Reviewable:end -->
