### PR TITLE
kv: fix gossip simulation deadlock in tests

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -414,8 +414,12 @@ func (g *Gossip) EnableSimulationCycler(enable bool) {
 	if enable {
 		g.simulationCycler = sync.NewCond(&g.mu)
 	} else {
-		g.simulationCycler.Broadcast()
-		g.simulationCycler = nil
+		// TODO(spencer): remove this nil check when gossip/simulation is no
+		// longer used in kv tests.
+		if g.simulationCycler != nil {
+			g.simulationCycler.Broadcast()
+			g.simulationCycler = nil
+		}
 	}
 }
 

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -112,6 +112,8 @@ func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
 	n := simulation.NewNetwork(1, true)
 	n.Start()
 	g := n.Nodes[0].Gossip
+	// TODO(spencer): remove the use of gossip/simulation here.
+	g.EnableSimulationCycler(false)
 
 	if err := g.AddInfo(gossip.KeySentinel, nil, time.Hour); err != nil {
 		t.Fatal(err)
@@ -794,6 +796,10 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 func TestGetFirstRangeDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	n := simulation.NewNetwork(3, true)
+	for _, node := range n.Nodes {
+		// TODO(spencer): remove the use of gossip/simulation here.
+		node.Gossip.EnableSimulationCycler(false)
+	}
 	n.Start()
 	ds := NewDistSender(nil, n.Nodes[0].Gossip)
 	if _, err := ds.FirstRange(); err == nil {


### PR DESCRIPTION
These tests should really not be using gossip/simulation at all.

Closes #7987.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8284)

<!-- Reviewable:end -->
