### PR TITLE
storage: fix deadlock in multiTestContext

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -651,23 +651,24 @@ func (m *multiTestContext) gossipNodeDesc(g *gossip.Gossip, nodeID roachpb.NodeI
 // StopStore stops a store but leaves the engine intact.
 // All stopped stores must be restarted before multiTestContext.Stop is called.
 func (m *multiTestContext) stopStore(i int) {
-	m.mu.Lock()
+	// If we acquired a write lock here, we could already deadlock. #8170.
+	m.mu.RLock()
 	// Stopping with multiple stoppers (which are not aware of each other) is
 	// messy.
 	// multiTestContextKVTransport needs a read lock to access its stopper and
 	// it's already in a task, so if we simply grabbed a write lock here while
 	// stopping we could deadlock (see #7678).
-	// So we initiate quiescing under a write lock, and then release the lock
+	// So we initiate quiescing under a read lock, and then release the lock
 	// during stopping.
 	stopper := m.stoppers[i]
-	m.stoppers[i] = nil
 	go stopper.Quiesce()
 	<-stopper.ShouldQuiesce()
-	m.mu.Unlock()
+	m.mu.RUnlock()
 	stopper.Stop()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.stoppers[i] = nil
 	m.senders[i].RemoveStore(m.stores[i])
 	m.stores[i] = nil
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -2541,11 +2541,11 @@ func (s *Store) processRaft() {
 			for _, r := range initReplicas {
 				sem.acquire()
 				go func(r *Replica) {
+					defer sem.release()
+					defer wg.Done()
 					if err := r.handleRaftReady(); err != nil {
 						panic(err) // TODO(bdarnell)
 					}
-					wg.Done()
-					sem.release()
 				}(r)
 			}
 			wg.Wait()


### PR DESCRIPTION
See #7488 and #8170. Attempting to acquire a write lock early in `stopStore`
could lead to situations in which an outstanding Raft proposal never returned
(due to address resolution calling back into `multiTestContext` with a RLock),
but at the same time that write lock being stuck on a read lock held in
`SendNext` which in turn waited on Raft:

SendNext[hold RLock] -> Raft[want RLock]
            ʌ               /
              \            v
            stopStore[want Lock]

The solution (which I wasn't able to test, for the flakiness doesn't easily
reproduce on my laptop and that's all I have available at the moment) is to
acquire first a read lock to quiesce the stopper, which should tell everything
downstream to let go of what they're trying to accomplish before the
opportunity for deadlock presents itself.
I'm sure there will be another one, though.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8286)

<!-- Reviewable:end -->
