### PR TITLE
rpc: add circuit breaker to connection dialing

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -918,6 +918,10 @@ func (ds *DistSender) sendToReplicas(opts SendOptions,
 		return nil, err
 	}
 	defer transport.Close()
+	if transport.IsExhausted() {
+		return nil, roachpb.NewSendError(
+			fmt.Sprintf("sending to all %d replicas failed", len(replicas)))
+	}
 
 	// Send the first request.
 	pending := 1

--- a/kv/transport.go
+++ b/kv/transport.go
@@ -29,6 +29,8 @@ import (
 	"github.com/cockroachdb/cockroach/util/envutil"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	"github.com/rubyist/circuitbreaker"
 	"google.golang.org/grpc"
 )
 
@@ -118,6 +120,9 @@ func grpcTransportFactory(
 	for _, replica := range replicas {
 		conn, err := rpcContext.GRPCDial(replica.NodeDesc.Address.String())
 		if err != nil {
+			if errors.Cause(err) == circuit.ErrBreakerOpen {
+				continue
+			}
 			return nil, err
 		}
 		argsCopy := args

--- a/rpc/breaker.go
+++ b/rpc/breaker.go
@@ -1,0 +1,59 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Peter Mattis (peter@cockroachlabs.com)
+
+package rpc
+
+import (
+	"time"
+
+	"github.com/cenk/backoff"
+	circuit "github.com/rubyist/circuitbreaker"
+)
+
+// newBackOff creates a new exponential backoff properly configured for RPC
+// connection backoff.
+func newBackOff() backoff.BackOff {
+	// This exponential backoff limits the circuit breaker to 1 second
+	// intervals between successive attempts to resolve a node address
+	// and connect via GRPC.
+	//
+	// NB (nota Ben): MaxInterval should be less than the Raft election timeout
+	// (1.5s) to avoid disruptions. A newly restarted node will be in follower
+	// mode with no knowledge of the Raft leader. If it doesn't hear from a
+	// leader before the election timeout expires, it will start to campaign,
+	// which can be disruptive. Therefore the leader needs to get in touch (via
+	// Raft heartbeats) with such nodes within one election timeout of their
+	// restart, which won't happen if their backoff is too high.
+	b := &backoff.ExponentialBackOff{
+		InitialInterval:     500 * time.Millisecond,
+		RandomizationFactor: 0.5,
+		Multiplier:          1.5,
+		MaxInterval:         1 * time.Second,
+		MaxElapsedTime:      0,
+		Clock:               backoff.SystemClock,
+	}
+	b.Reset()
+	return b
+}
+
+// NewBreaker creates a new circuit breaker properly configured for RPC
+// connections.
+func NewBreaker() *circuit.Breaker {
+	return circuit.NewBreakerWithOptions(&circuit.Options{
+		BackOff:    newBackOff(),
+		ShouldTrip: circuit.ThresholdTripFunc(1),
+	})
+}

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/syncutil"
 	"github.com/cockroachdb/cockroach/util/timeutil"
+	circuit "github.com/rubyist/circuitbreaker"
 )
 
 const (
@@ -84,7 +85,8 @@ type Context struct {
 
 	conns struct {
 		syncutil.Mutex
-		cache map[string]connMeta
+		cache    map[string]connMeta
+		breakers map[string]*circuit.Breaker
 	}
 }
 
@@ -102,6 +104,8 @@ func NewContext(baseCtx *base.Context, clock *hlc.Clock, stopper *stop.Stopper) 
 	ctx.RemoteClocks = newRemoteClockMonitor(clock, 10*defaultHeartbeatInterval)
 	ctx.HeartbeatInterval = defaultHeartbeatInterval
 	ctx.HeartbeatTimeout = 2 * defaultHeartbeatInterval
+	ctx.conns.cache = make(map[string]connMeta)
+	ctx.conns.breakers = make(map[string]*circuit.Breaker)
 
 	stopper.RunWorker(func() {
 		<-stopper.ShouldQuiesce()
@@ -131,6 +135,9 @@ func (ctx *Context) SetLocalInternalServer(internalServer roachpb.InternalServer
 }
 
 func (ctx *Context) removeConn(key string, conn *grpc.ClientConn) {
+	if log.V(1) {
+		log.Infof(context.TODO(), "closing %s", key)
+	}
 	if err := conn.Close(); err != nil && !grpcutil.IsClosedConnection(err) {
 		if log.V(1) {
 			log.Errorf(context.TODO(), "failed to close client connection: %s", err)
@@ -157,16 +164,26 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 	dialOpts = append(dialOpts, dialOpt)
 	dialOpts = append(dialOpts, opts...)
 
+	breaker, ok := ctx.conns.breakers[target]
+	if !ok {
+		breaker = NewBreaker()
+		ctx.conns.breakers[target] = breaker
+	}
+	if !breaker.Ready() {
+		return nil, circuit.ErrBreakerOpen
+	}
+
+	if log.V(1) {
+		log.Infof(context.TODO(), "dialing %s", target)
+	}
 	conn, err := grpc.Dial(target, dialOpts...)
 	if err == nil {
-		if ctx.conns.cache == nil {
-			ctx.conns.cache = make(map[string]connMeta)
-		}
 		ctx.conns.cache[target] = connMeta{conn: conn}
 
 		if ctx.Stopper.RunTask(func() {
 			ctx.Stopper.RunWorker(func() {
-				if err := ctx.runHeartbeat(conn, target); err != nil && !grpcutil.IsClosedConnection(err) {
+				err := ctx.runHeartbeat(conn, breaker, target)
+				if err != nil && !grpcutil.IsClosedConnection(err) {
 					log.Error(context.TODO(), err)
 				}
 				ctx.conns.Lock()
@@ -217,7 +234,7 @@ func (ctx *Context) IsConnHealthy(remoteAddr string) bool {
 	return ctx.conns.cache[remoteAddr].healthy
 }
 
-func (ctx *Context) runHeartbeat(cc *grpc.ClientConn, remoteAddr string) error {
+func (ctx *Context) runHeartbeat(cc *grpc.ClientConn, breaker *circuit.Breaker, remoteAddr string) error {
 	request := PingRequest{Addr: ctx.Addr}
 	heartbeatClient := NewHeartbeatClient(cc)
 
@@ -239,8 +256,10 @@ func (ctx *Context) runHeartbeat(cc *grpc.ClientConn, remoteAddr string) error {
 			if grpc.Code(err) == codes.DeadlineExceeded {
 				continue
 			}
+			breaker.Fail()
 			return err
 		}
+		breaker.Success()
 		receiveTime := ctx.localClock.PhysicalTime()
 
 		// Only update the clock offset measurement if we actually got a

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/syncutil"
 	"github.com/pkg/errors"
+	circuit "github.com/rubyist/circuitbreaker"
 )
 
 func newTestServer(t *testing.T, ctx *Context, manual bool) (*grpc.Server, net.Listener) {
@@ -387,5 +388,41 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 				t.Logf("max offset: %s - node %d with acceptable clock offset of %s did not return an error, as expected", maxOffset, i, nodeOffset)
 			}
 		}
+	}
+}
+
+func TestCircuitBreaker(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+
+	clock := hlc.NewClock(time.Unix(0, 1).UnixNano)
+	serverCtx := newNodeTestContext(clock, stopper)
+	_, ln := newTestServer(t, serverCtx, true)
+	remoteAddr := ln.Addr().String()
+
+	clientCtx := newNodeTestContext(clock, stopper)
+	// The first dial will succeed because the breaker is closed.
+	if _, err := clientCtx.GRPCDial(remoteAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until the breaker opens. This will occur when the heartbeat fails
+	// (because there is no heartbeat service).
+	util.SucceedsSoon(t, func() error {
+		_, err := clientCtx.GRPCDial(remoteAddr)
+		if err == circuit.ErrBreakerOpen {
+			return nil
+		}
+		return errors.Errorf("breaker not open: %v", err)
+	})
+
+	// Reset the breaker. The next dial will succeed.
+	clientCtx.conns.Lock()
+	clientCtx.conns.breakers[remoteAddr].Reset()
+	clientCtx.conns.Unlock()
+	if _, err := clientCtx.GRPCDial(remoteAddr); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/storage/raft_transport.go
+++ b/storage/raft_transport.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/cenk/backoff"
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -88,9 +87,9 @@ type RaftTransport struct {
 
 	mu struct {
 		syncutil.Mutex
-		handlers     map[roachpb.StoreID]raftMessageHandler
-		queues       map[bool]map[roachpb.ReplicaIdent]chan *RaftMessageRequest
-		connBreakers map[roachpb.NodeID]*circuit.Breaker
+		handlers map[roachpb.StoreID]raftMessageHandler
+		queues   map[bool]map[roachpb.ReplicaIdent]chan *RaftMessageRequest
+		breakers map[roachpb.NodeID]*circuit.Breaker
 	}
 }
 
@@ -110,7 +109,7 @@ func NewRaftTransport(resolver NodeAddressResolver, grpcServer *grpc.Server, rpc
 	}
 	t.mu.handlers = make(map[roachpb.StoreID]raftMessageHandler)
 	t.mu.queues = make(map[bool]map[roachpb.ReplicaIdent]chan *RaftMessageRequest)
-	t.mu.connBreakers = make(map[roachpb.NodeID]*circuit.Breaker)
+	t.mu.breakers = make(map[roachpb.NodeID]*circuit.Breaker)
 
 	if grpcServer != nil {
 		RegisterMultiRaftServer(grpcServer, t)
@@ -181,7 +180,7 @@ func (t *RaftTransport) Stop(storeID roachpb.StoreID) {
 func (t *RaftTransport) GetCircuitBreaker(nodeID roachpb.NodeID) *circuit.Breaker {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return t.mu.connBreakers[nodeID]
+	return t.mu.breakers[nodeID]
 }
 
 // getNodeConn returns a shared instance of a GRPC connection to the
@@ -191,57 +190,48 @@ func (t *RaftTransport) GetCircuitBreaker(nodeID roachpb.NodeID) *circuit.Breake
 // partitioned, etc.).
 func (t *RaftTransport) getNodeConn(nodeID roachpb.NodeID) *grpc.ClientConn {
 	t.mu.Lock()
-	cb, ok := t.mu.connBreakers[nodeID]
+	breaker, ok := t.mu.breakers[nodeID]
 	if !ok {
-		// This exponential backoff limits the circuit breaker to 1 second
-		// intervals between successive attempts to resolve a node address
-		// and connect via GRPC.
-		expBO := backoff.NewExponentialBackOff()
-		expBO.MaxInterval = 1 * time.Second
-		expBO.MaxElapsedTime = 0 * time.Second
-
-		cb = circuit.NewBreakerWithOptions(&circuit.Options{
-			BackOff:    expBO,
-			ShouldTrip: circuit.ThresholdTripFunc(1),
-		})
-		t.mu.connBreakers[nodeID] = cb
+		breaker = rpc.NewBreaker()
+		t.mu.breakers[nodeID] = breaker
 	}
 	t.mu.Unlock()
 
-	// The number of consecutive failures suffered by the circuit breaker
-	// is used to log only state changes in our connection status to the
-	// remote node.
-	consecFailures := cb.ConsecFailures()
-	var conn *grpc.ClientConn
-	if err := cb.Call(func() error {
-		addr, err := t.resolver(nodeID)
-		if err != nil {
-			return err
-		}
-		conn, err = t.rpcContext.GRPCDial(addr.String())
-		if err != nil {
-			return err
-		}
-		if consecFailures > 0 {
-			log.Infof(context.TODO(), "connection succeeded to node %s", nodeID)
-		}
-		return nil
+	// The number of consecutive failures suffered by the circuit breaker is used
+	// to log only state changes in our node address resolution status.
+	consecFailures := breaker.ConsecFailures()
+	var addr net.Addr
+	if err := breaker.Call(func() error {
+		var err error
+		addr, err = t.resolver(nodeID)
+		return err
 	}, 0); err != nil {
 		if consecFailures == 0 {
-			log.Warningf(context.TODO(), "failed to connect to node %s: %s", nodeID, err)
+			log.Warningf(context.TODO(), "failed to resolve node %s: %s", nodeID, err)
+		}
+		return nil
+	}
+	if consecFailures > 0 {
+		log.Infof(context.TODO(), "resolved node %s to %s", nodeID, addr)
+	}
+
+	// GRPC connections are opened asynchronously and internally have a circuit
+	// breaking mechanism based on heartbeat successes and failures.
+	conn, err := t.rpcContext.GRPCDial(addr.String())
+	if err != nil {
+		if errors.Cause(err) != circuit.ErrBreakerOpen {
+			log.Infof(context.TODO(), "failed to connect to %s", addr)
 		}
 		return nil
 	}
 	return conn
 }
 
-// processQueue creates a client and sends messages from its designated queue
-// via that client, exiting when the client fails or when it idles out. All
-// messages remaining in the queue at that point are lost and a new instance of
-// processQueue should be started by the next message to be sent.
-// TODO(tschottdorf) should let raft know if the node is down;
-// need a feedback mechanism for that. Potentially easiest is to arrange for
-// the next call to Send() to fail appropriately.
+// processQueue opens a Raft client stream and sends messages from the
+// designated queue (ch) via that stream, exiting when an error is received or
+// when it idles out. All messages remaining in the queue at that point are
+// lost and a new instance of processQueue will be started by the next message
+// to be sent.
 func (t *RaftTransport) processQueue(ch chan *RaftMessageRequest, conn *grpc.ClientConn) error {
 	client := NewMultiRaftClient(conn)
 	ctx, cancel := context.WithCancel(context.TODO())


### PR DESCRIPTION
The circuit breakers are powered by heartbeat success and failures.

Adjust the RaftTransport circuit breakers to only throttle node address
resolution (which is all they were throttling previously).

Fix kv.grpcTransportFactory to not error when the breaker to one of the
replicas is open.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8292)

<!-- Reviewable:end -->
