### PR TITLE
storage: don't handle already-handled error

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -2560,10 +2560,6 @@ func (r *Replica) getLeaseForGossip(ctx context.Context) (bool, *roachpb.Error) 
 				if e.LeaseHolder != nil {
 					pErr = nil
 				}
-			case *roachpb.LeaseRejectedError:
-				// leaseRejectedError means we tried to get one but someone
-				// beat us to it.
-				pErr = nil
 			case *roachpb.RangeFrozenError:
 				storeID := r.store.StoreID()
 				// Let the replica with the smallest StoreID gossip.


### PR DESCRIPTION
LeaseRejectedError is translated to a NotLeaseHolderError by
redirectOnOrAcquireLease.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8294)

<!-- Reviewable:end -->
