### PR TITLE
build: fix builder.sh for TeamCity.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,6 +14,4 @@ RUN \
 
 ENV PATH=/opt/backtrace/bin:/third_party/llvm-build/Release+Asserts/bin:$PATH
 
-ENV SKIP_BOOTSTRAP=1
-
 CMD ["/bin/bash"]

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -92,10 +92,19 @@ if test -d "${backtrace_dir}"; then
   vols="${vols} --volume=${backtrace_dir}/cockroach.cf:/root/.coroner.cf"
 fi
 
+# If we're running in an environment that's using git alternates, like TeamCity,
+# we must mount the path to the real git objects for git to work in the container.
+alternates_file="${cockroach_toplevel}/.git/objects/info/alternates"
+if test -e "${alternates_file}"; then
+  alternates_path=$(cat "${alternates_file}")
+  vols="${vols} --volume=${alternates_path}:${alternates_path}"
+fi
+
 docker run -i ${tty-} ${rm} \
   ${vols} \
   --workdir="/go/src/github.com/cockroachdb/cockroach" \
   --env="PAGER=cat" \
+  --env="SKIP_BOOTSTRAP=1" \
   --env="JSPM_GITHUB_AUTH_TOKEN=${JSPM_GITHUB_AUTH_TOKEN-763c42afb2d31eb7bc150da33402a24d0e081aef}" \
   --env="CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX-0}" \
   --env="CIRCLE_NODE_TOTAL=${CIRCLE_NODE_TOTAL-1}" \


### PR DESCRIPTION
TeamCity uses git alternates to avoid having many copies of source on
disk. The builder wasn't aware of this, so git didn't work inside the
container. Now, if we're using git alternates, we mount the alternates
path for the docker container.

Also, add SKIP_BOOTSTRAP=1 to the container environment explicitly so
it's easier to understand how make works from within the container. The
Dockerfile already does this, so it's redundant but serving as useful
documentation.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8295)

<!-- Reviewable:end -->
