### PR TITLE
storage: remove the 2 remaining Batch.Defer calls

### DIFF
--- a/storage/engine/batch_test.go
+++ b/storage/engine/batch_test.go
@@ -574,35 +574,6 @@ func TestBatchConcurrency(t *testing.T) {
 	}
 }
 
-func TestBatchDefer(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	stopper := stop.NewStopper()
-	defer stopper.Stop()
-	e := NewInMem(roachpb.Attributes{}, 1<<20, stopper)
-
-	b := e.NewBatch()
-	defer b.Close()
-
-	list := []string{}
-
-	b.Defer(func() {
-		list = append(list, "one")
-	})
-	b.Defer(func() {
-		list = append(list, "two")
-	})
-
-	if err := b.Commit(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Order was reversed when the defers were run.
-	if !reflect.DeepEqual(list, []string{"two", "one"}) {
-		t.Errorf("expected [two, one]; got %v", list)
-	}
-}
-
 func TestBatchBuilder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/storage/engine/engine.go
+++ b/storage/engine/engine.go
@@ -191,10 +191,6 @@ type Batch interface {
 	// Commit atomically applies any batched updates to the underlying
 	// engine. This is a noop unless the engine was created via NewBatch().
 	Commit() error
-	// Defer adds a callback to be run after the batch commits successfully. If
-	// Commit() fails deferred callbacks are not called. As with the defer
-	// statement, the last callback to be deferred is the first to be executed.
-	Defer(fn func())
 	// Distinct returns a view of the existing batch which only sees writes that
 	// were performed before the Distinct batch was created. That is, the
 	// returned batch will not read its own writes, but it will read writes to


### PR DESCRIPTION
And remove the Batch.Defer() mechanism so that we don't introduce new
ones.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8307)

<!-- Reviewable:end -->
