### PR TITLE
storage: introduce non-temporal commands

### DIFF
--- a/roachpb/api.go
+++ b/roachpb/api.go
@@ -81,6 +81,11 @@ const (
 	isRange                // range commands may span multiple keys
 	isReverse              // reverse commands traverse ranges in descending direction
 	isAlone                // requests which must be alone in a batch
+	// Some commands can skip interacting with the command queue and the timestamp
+	// cache. For example, RequestLeaseRequest is sequenced exclusively by Raft.
+	// These requests still have keys in their header, but those keys are used
+	// exclusively for routing the request to the right range.
+	isNonKV
 )
 
 // GetTxnID returns the transaction ID if the header has a transaction
@@ -806,13 +811,15 @@ func (*ResolveIntentRequest) flags() int      { return isWrite }
 func (*ResolveIntentRangeRequest) flags() int { return isWrite | isRange }
 func (*NoopRequest) flags() int               { return isRead } // slightly special
 func (*MergeRequest) flags() int              { return isWrite }
-func (*TruncateLogRequest) flags() int        { return isWrite }
+func (*TruncateLogRequest) flags() int        { return isWrite | isNonKV }
 
-// TODO(tschottdorf): consider setting isAlone on RequestLeaseRequest and
-// LeaseTransferRequest.
-func (*RequestLeaseRequest) flags() int     { return isWrite }
-func (*TransferLeaseRequest) flags() int    { return isWrite }
-func (*ComputeChecksumRequest) flags() int  { return isWrite }
-func (*VerifyChecksumRequest) flags() int   { return isWrite }
+func (*RequestLeaseRequest) flags() int {
+	return isWrite | isAlone | isNonKV
+}
+func (*TransferLeaseRequest) flags() int {
+	return isWrite | isAlone | isNonKV
+}
+func (*ComputeChecksumRequest) flags() int  { return isWrite | isNonKV }
+func (*VerifyChecksumRequest) flags() int   { return isWrite | isNonKV }
 func (*CheckConsistencyRequest) flags() int { return isAdmin | isRange }
-func (*ChangeFrozenRequest) flags() int     { return isWrite | isRange }
+func (*ChangeFrozenRequest) flags() int     { return isWrite | isRange | isNonKV }

--- a/roachpb/api.go
+++ b/roachpb/api.go
@@ -86,6 +86,9 @@ const (
 	// These requests still have keys in their header, but those keys are used
 	// exclusively for routing the request to the right range.
 	isNonKV
+	// Requests for acquiring a lease skip the (proposal-time) check that the
+	// proposing replica has a valid lease.
+	skipLeaseCheck
 )
 
 // GetTxnID returns the transaction ID if the header has a transaction
@@ -814,10 +817,18 @@ func (*MergeRequest) flags() int              { return isWrite }
 func (*TruncateLogRequest) flags() int        { return isWrite | isNonKV }
 
 func (*RequestLeaseRequest) flags() int {
-	return isWrite | isAlone | isNonKV
+	return isWrite | isAlone | isNonKV | skipLeaseCheck
 }
 func (*TransferLeaseRequest) flags() int {
-	return isWrite | isAlone | isNonKV
+	// TransferLeaseRequest requires the lease, which is checked in
+	// `AdminTransferLease()` at proposal time and in the usual way for write
+	// commands at apply time.
+	// But it can't be checked at propose time through the
+	// `redirectOnOrAcquireLease` call because, by the time that call is made, the
+	// replica has registered that a transfer is in progress and
+	// `redirectOrAcquire` already tentatively redirects to the future lease
+	// holder.
+	return isWrite | isAlone | isNonKV | skipLeaseCheck
 }
 func (*ComputeChecksumRequest) flags() int  { return isWrite | isNonKV }
 func (*VerifyChecksumRequest) flags() int   { return isWrite | isNonKV }

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -47,16 +47,19 @@ func (ba *BatchRequest) SetActiveTimestamp(nowFn func() hlc.Timestamp) error {
 
 // IsFreeze returns whether the batch consists of a single ChangeFrozen request.
 func (ba *BatchRequest) IsFreeze() bool {
-	if len(ba.Requests) != 1 {
+	if !ba.IsSingleRequest() {
 		return false
 	}
 	_, ok := ba.GetArg(ChangeFrozen)
 	return ok
 }
 
-// IsLease returns whether the batch consists of a single RequestLease request.
-func (ba *BatchRequest) IsLease() bool {
-	if len(ba.Requests) != 1 {
+// IsLeaseRequest returns whether the batch consists of a single RequestLease
+// request. Note that TransferLease requests return false.
+// RequestLease requests are special because they're the only type of requests a
+// non-lease-holder can propose.
+func (ba *BatchRequest) IsLeaseRequest() bool {
+	if !ba.IsSingleRequest() {
 		return false
 	}
 	_, ok := ba.GetArg(RequestLease)
@@ -92,6 +95,17 @@ func (ba *BatchRequest) IsPossibleTransaction() bool {
 // IsTransactionWrite returns true iff the BatchRequest contains a txn write.
 func (ba *BatchRequest) IsTransactionWrite() bool {
 	return ba.hasFlag(isTxnWrite)
+}
+
+// IsSingleRequest returns true iff the BatchRequest contains a single request.
+func (ba *BatchRequest) IsSingleRequest() bool {
+	return len(ba.Requests) == 1
+}
+
+// IsSingleNonKVRequest returns true iff the batch contains a single
+// request, and that request has the non-KV flag set.
+func (ba *BatchRequest) IsSingleNonKVRequest() bool {
+	return ba.IsSingleRequest() && ba.hasFlag(isNonKV)
 }
 
 // hasFlag returns true iff one of the requests within the batch contains the

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -108,6 +108,12 @@ func (ba *BatchRequest) IsSingleNonKVRequest() bool {
 	return ba.IsSingleRequest() && ba.hasFlag(isNonKV)
 }
 
+// IsSingleSkipLeaseCheckRequest returns true iff the batch contains a single
+// request, and that request has the skipLeaseCheck flag set.
+func (ba *BatchRequest) IsSingleSkipLeaseCheckRequest() bool {
+	return ba.IsSingleRequest() && ba.hasFlag(skipLeaseCheck)
+}
+
 // hasFlag returns true iff one of the requests within the batch contains the
 // specified flag.
 func (ba *BatchRequest) hasFlag(flag int) bool {

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -659,8 +659,11 @@ func TestRangeTransferLease(t *testing.T) {
 
 // Test that a lease extension (a RequestLeaseRequest that doesn't change the
 // lease holder) is not blocked by ongoing reads.
-// Note that lease transfers are blocked by reads through their
+// The test relies on two things:
+// 1) Lease extensions, unlike lease transfers, are not blocked by reads through their
 // PostCommitTrigger.noConcurrentReads.
+// 2) Requests with the non-KV flag, such as RequestLeaseRequest, do not
+// go through the command queue.
 func TestLeaseExtensionNotBlockedByRead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	readBlocked := make(chan struct{})
@@ -705,12 +708,7 @@ func TestLeaseExtensionNotBlockedByRead(t *testing.T) {
 		t.Fatal(err)
 	case <-readBlocked:
 		// Send the lease request.
-		// We change the key slightly, otherwise the lease request will be blocked
-		// by the read through the command queue.
-		// TODO(andrei): don't change the key anymore once lease requests don't go
-		// through the command queue any more.
-		leaseHdrKey := roachpb.Key(append(key, 0x00))
-		rKey, err := keys.Addr(leaseHdrKey)
+		rKey, err := keys.Addr(key)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -720,7 +718,7 @@ func TestLeaseExtensionNotBlockedByRead(t *testing.T) {
 		}
 		leaseReq := roachpb.RequestLeaseRequest{
 			Span: roachpb.Span{
-				Key: leaseHdrKey,
+				Key: key,
 			},
 			Lease: roachpb.Lease{
 				Start:       s.Clock().Now(),

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -958,8 +958,8 @@ func putArgs(key roachpb.Key, value []byte) roachpb.PutRequest {
 	}
 }
 
-// incrementArgs returns an IncrementRequest and IncrementResponse pair
-// addressed to the default replica for the specified key / value.
+// incrementArgs returns an IncrementRequest addressed to the default replica
+// for the specified key.
 func incrementArgs(key roachpb.Key, inc int64) roachpb.IncrementRequest {
 	return roachpb.IncrementRequest{
 		Span: roachpb.Span{

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1342,18 +1342,20 @@ func (r *Replica) addWriteCmd(
 		}()
 	}
 
-	// This replica must have range lease to process a write, except when it's
-	// an attempt to unfreeze the Range. These are a special case in which any
-	// replica will propose it to get back to an active state.
-	if pErr = r.redirectOnOrAcquireLease(ctx); pErr != nil {
-		if _, frozen := pErr.GetDetail().(*roachpb.RangeFrozenError); !frozen {
-			return nil, pErr
+	if !ba.IsSingleSkipLeaseCheckRequest() {
+		// This replica must have range lease to process a write, except when it's
+		// an attempt to unfreeze the Range. These are a special case in which any
+		// replica will propose it to get back to an active state.
+		if pErr = r.redirectOnOrAcquireLease(ctx); pErr != nil {
+			if _, frozen := pErr.GetDetail().(*roachpb.RangeFrozenError); !frozen {
+				return nil, pErr
+			}
+			// Only continue if the batch appears freezing-related.
+			if !ba.IsFreeze() {
+				return nil, pErr
+			}
+			pErr = nil
 		}
-		// Only continue if the batch appears freezing-related.
-		if !ba.IsFreeze() {
-			return nil, pErr
-		}
-		pErr = nil
 	}
 
 	if !isNonKV {

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1256,12 +1256,22 @@ func (r *Replica) addReadOnlyCmd(ctx context.Context, ba roachpb.BatchRequest) (
 		}
 	}
 
-	// Add the read to the command queue to gate subsequent
-	// overlapping commands until this command completes.
-	log.Trace(ctx, "command queue")
-	endCmdsFunc, err := r.beginCmds(ctx, &ba)
-	if err != nil {
-		return nil, roachpb.NewError(err)
+	var endCmdsFunc func(*roachpb.BatchResponse, *roachpb.Error) *roachpb.Error
+	if !ba.IsSingleNonKVRequest() {
+		// Add the read to the command queue to gate subsequent
+		// overlapping commands until this command completes.
+		log.Trace(ctx, "command queue")
+		var err error
+		endCmdsFunc, err = r.beginCmds(ctx, &ba)
+		if err != nil {
+			return nil, roachpb.NewError(err)
+		}
+	} else {
+		endCmdsFunc = func(
+			*roachpb.BatchResponse, *roachpb.Error,
+		) *roachpb.Error {
+			return nil
+		}
 	}
 
 	r.readOnlyCmdMu.RLock()
@@ -1312,22 +1322,25 @@ func (r *Replica) assert5725(ba roachpb.BatchRequest) {
 func (r *Replica) addWriteCmd(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (br *roachpb.BatchResponse, pErr *roachpb.Error) {
-	// Add the write to the command queue to gate subsequent overlapping
-	// commands until this command completes. Note that this must be
-	// done before getting the max timestamp for the key(s), as
-	// timestamp cache is only updated after preceding commands have
-	// been run to successful completion.
-	log.Trace(ctx, "command queue")
-	endCmdsFunc, err := r.beginCmds(ctx, &ba)
-	if err != nil {
-		return nil, roachpb.NewError(err)
-	}
+	isNonKV := ba.IsSingleNonKVRequest()
+	if !isNonKV {
+		// Add the write to the command queue to gate subsequent overlapping
+		// commands until this command completes. Note that this must be
+		// done before getting the max timestamp for the key(s), as
+		// timestamp cache is only updated after preceding commands have
+		// been run to successful completion.
+		log.Trace(ctx, "command queue")
+		endCmdsFunc, err := r.beginCmds(ctx, &ba)
+		if err != nil {
+			return nil, roachpb.NewError(err)
+		}
 
-	// Guarantee we remove the commands from the command queue. This is
-	// wrapped to delay pErr evaluation to its value when returning.
-	defer func() {
-		pErr = endCmdsFunc(br, pErr)
-	}()
+		// Guarantee we remove the commands from the command queue. This is
+		// wrapped to delay pErr evaluation to its value when returning.
+		defer func() {
+			pErr = endCmdsFunc(br, pErr)
+		}()
+	}
 
 	// This replica must have range lease to process a write, except when it's
 	// an attempt to unfreeze the Range. These are a special case in which any
@@ -1343,12 +1356,14 @@ func (r *Replica) addWriteCmd(
 		pErr = nil
 	}
 
-	// Examine the read and write timestamp caches for preceding
-	// commands which require this command to move its timestamp
-	// forward. Or, in the case of a transactional write, the txn
-	// timestamp and possible write-too-old bool.
-	if pErr := r.applyTimestampCache(&ba); pErr != nil {
-		return nil, pErr
+	if !isNonKV {
+		// Examine the read and write timestamp caches for preceding
+		// commands which require this command to move its timestamp
+		// forward. Or, in the case of a transactional write, the txn
+		// timestamp and possible write-too-old bool.
+		if pErr := r.applyTimestampCache(&ba); pErr != nil {
+			return nil, pErr
+		}
 	}
 
 	log.Trace(ctx, "raft")
@@ -1399,7 +1414,7 @@ func (r *Replica) prepareRaftCommandLocked(
 	if r.mu.lastAssignedLeaseIndex < r.mu.state.LeaseAppliedIndex {
 		r.mu.lastAssignedLeaseIndex = r.mu.state.LeaseAppliedIndex
 	}
-	if !ba.IsLease() {
+	if !ba.IsLeaseRequest() {
 		r.mu.lastAssignedLeaseIndex++
 	}
 	if log.V(4) {
@@ -1945,11 +1960,11 @@ func (r *Replica) processRaftCommand(
 
 	isLeaseError := func() bool {
 		l, ba, origin := r.mu.state.Lease, raftCmd.Cmd, raftCmd.OriginReplica
-		if l.Replica != origin && !ba.IsLease() {
+		if l.Replica != origin && !ba.IsLeaseRequest() {
 			return true
 		}
 		notCovered := !l.OwnedBy(origin.StoreID) || !l.Covers(ba.Timestamp)
-		if notCovered && !ba.IsFreeze() && !ba.IsLease() {
+		if notCovered && !ba.IsFreeze() && !ba.IsLeaseRequest() {
 			// Verify the range lease is held, unless this command is trying
 			// to obtain it or is a freeze change (which can be proposed by any
 			// Replica). Any other Raft command has had the range lease held
@@ -1991,7 +2006,7 @@ func (r *Replica) processRaftCommand(
 		}
 		forcedErr = roachpb.NewError(newNotLeaseHolderError(
 			r.mu.state.Lease, raftCmd.OriginReplica.StoreID, r.mu.state.Desc))
-	} else if raftCmd.Cmd.IsLease() {
+	} else if raftCmd.Cmd.IsLeaseRequest() {
 		// Lease commands are ignored by the counter (and their MaxLeaseIndex
 		// is ignored). This makes sense since lease commands are proposed by
 		// anyone, so we can't expect a coherent MaxLeaseIndex. Also, lease


### PR DESCRIPTION
Introduce a new flag for requests - isNonTemporal. This is set by the lease
requests to specify that they don't need to be serialized through the
command queue (they were using the range's first key, which is a bogus
thing to sync on).

Also sets the isAlone flag on LeaseRequest and LeaseTransfer requests.

cc @tschottdorf

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8310)

<!-- Reviewable:end -->
