### PR TITLE
cleanup: replace all context.TODO() calls in tests with context.Background()

### DIFF
--- a/acceptance/allocator_test.go
+++ b/acceptance/allocator_test.go
@@ -150,25 +150,25 @@ func (at *allocatorTest) Run(t *testing.T) {
 	}
 	at.f.AddVars["cockroach_disk_type"] = *flagATDiskType
 
-	log.Infof(context.TODO(), "creating cluster with %d node(s)", at.StartNodes)
+	log.Infof(context.Background(), "creating cluster with %d node(s)", at.StartNodes)
 	if err := at.f.Resize(at.StartNodes); err != nil {
 		t.Fatal(err)
 	}
 	checkGossip(t, at.f, longWaitTime, hasPeers(at.StartNodes))
 	at.f.Assert(t)
-	log.Info(context.TODO(), "initial cluster is up")
+	log.Info(context.Background(), "initial cluster is up")
 
 	// We must stop the cluster because a) `nodectl` pokes at the data directory
 	// and, more importantly, b) we don't want the cluster above and the cluster
 	// below to ever talk to each other (see #7224).
-	log.Info(context.TODO(), "stopping cluster")
+	log.Info(context.Background(), "stopping cluster")
 	for i := 0; i < at.f.NumNodes(); i++ {
 		if err := at.f.Kill(i); err != nil {
 			t.Fatalf("error stopping node %d: %s", i, err)
 		}
 	}
 
-	log.Info(context.TODO(), "downloading archived stores from Google Cloud Storage in parallel")
+	log.Info(context.Background(), "downloading archived stores from Google Cloud Storage in parallel")
 	errors := make(chan error, at.f.NumNodes())
 	for i := 0; i < at.f.NumNodes(); i++ {
 		go func(nodeNum int) {
@@ -181,7 +181,7 @@ func (at *allocatorTest) Run(t *testing.T) {
 		}
 	}
 
-	log.Info(context.TODO(), "restarting cluster with archived store(s)")
+	log.Info(context.Background(), "restarting cluster with archived store(s)")
 	for i := 0; i < at.f.NumNodes(); i++ {
 		if err := at.f.Restart(i); err != nil {
 			t.Fatalf("error restarting node %d: %s", i, err)
@@ -189,14 +189,14 @@ func (at *allocatorTest) Run(t *testing.T) {
 	}
 	at.f.Assert(t)
 
-	log.Infof(context.TODO(), "resizing cluster to %d nodes", at.EndNodes)
+	log.Infof(context.Background(), "resizing cluster to %d nodes", at.EndNodes)
 	if err := at.f.Resize(at.EndNodes); err != nil {
 		t.Fatal(err)
 	}
 	checkGossip(t, at.f, longWaitTime, hasPeers(at.EndNodes))
 	at.f.Assert(t)
 
-	log.Info(context.TODO(), "waiting for rebalance to finish")
+	log.Info(context.Background(), "waiting for rebalance to finish")
 	if err := at.WaitForRebalance(t); err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +254,7 @@ func (at *allocatorTest) printRebalanceStats(
 			// This can happen with single-node clusters.
 			rebalanceInterval = time.Duration(0)
 		}
-		log.Infof(context.TODO(), "cluster took %s to rebalance", rebalanceInterval)
+		log.Infof(context.Background(), "cluster took %s to rebalance", rebalanceInterval)
 	}
 
 	// Output # of range events that occurred. All other things being equal,
@@ -265,7 +265,7 @@ func (at *allocatorTest) printRebalanceStats(
 		if err := db.QueryRow(q).Scan(&rangeEvents); err != nil {
 			return err
 		}
-		log.Infof(context.TODO(), "%d range events", rangeEvents)
+		log.Infof(context.Background(), "%d range events", rangeEvents)
 	}
 
 	// Output standard deviation of the replica counts for all stores.
@@ -273,7 +273,7 @@ func (at *allocatorTest) printRebalanceStats(
 	if err != nil {
 		return err
 	}
-	log.Infof(context.TODO(), "stddev(replica count) = %.2f", stdDev)
+	log.Infof(context.Background(), "stddev(replica count) = %.2f", stdDev)
 
 	return nil
 }
@@ -367,10 +367,10 @@ func (at *allocatorTest) WaitForRebalance(t *testing.T) error {
 				return err
 			}
 
-			log.Info(context.TODO(), stats)
+			log.Info(context.Background(), stats)
 			if StableInterval <= stats.ElapsedSinceLastEvent {
 				host := at.f.Nodes()[0]
-				log.Infof(context.TODO(), "replica count = %f, max = %f", stats.ReplicaCountStdDev, *flagATMaxStdDev)
+				log.Infof(context.Background(), "replica count = %f, max = %f", stats.ReplicaCountStdDev, *flagATMaxStdDev)
 				if stats.ReplicaCountStdDev > *flagATMaxStdDev {
 					_ = at.printRebalanceStats(db, host)
 					return errors.Errorf(

--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -174,7 +174,7 @@ func transferMoneyLoop(idx int, state *testState, numAccounts, maxTransfer int) 
 			atomic.AddUint64(&client.count, 1)
 		}
 	}
-	log.Infof(context.TODO(), "client %d shutting down", idx)
+	log.Infof(context.Background(), "client %d shutting down", idx)
 	state.errChan <- nil
 }
 
@@ -199,7 +199,7 @@ func chaosMonkey(state *testState, c cluster.Cluster, stopClients bool, pickNode
 				state.clients[i].Lock()
 			}
 		}
-		log.Infof(context.TODO(), "round %d: restarting nodes %v", curRound, nodes)
+		log.Infof(context.Background(), "round %d: restarting nodes %v", curRound, nodes)
 		for _, i := range nodes {
 			// Two early exit conditions.
 			select {
@@ -210,7 +210,7 @@ func chaosMonkey(state *testState, c cluster.Cluster, stopClients bool, pickNode
 			if state.done() {
 				break
 			}
-			log.Infof(context.TODO(), "round %d: restarting %d", curRound, i)
+			log.Infof(context.Background(), "round %d: restarting %d", curRound, i)
 			if err := c.Kill(i); err != nil {
 				state.t.Error(err)
 			}
@@ -241,13 +241,13 @@ func chaosMonkey(state *testState, c cluster.Cluster, stopClients bool, pickNode
 		}
 
 		// Sleep until at least one client is writing successfully.
-		log.Warningf(context.TODO(), "round %d: monkey sleeping while cluster recovers...", curRound)
+		log.Warningf(context.Background(), "round %d: monkey sleeping while cluster recovers...", curRound)
 		for !state.done() && !madeProgress() {
 			time.Sleep(time.Second)
 		}
 		c.Assert(state.t)
 		cluster.Consistent(state.t, c)
-		log.Warningf(context.TODO(), "round %d: cluster recovered", curRound)
+		log.Warningf(context.Background(), "round %d: cluster recovered", curRound)
 	}
 }
 
@@ -295,7 +295,7 @@ func waitClientsStop(num int, state *testState, stallDuration time.Duration) {
 			}
 			// This just stops the logs from being a bit too spammy.
 			if newOutput != prevOutput {
-				log.Infof(context.TODO(), newOutput)
+				log.Infof(context.Background(), newOutput)
 				prevOutput = newOutput
 			}
 		}
@@ -338,7 +338,7 @@ func testClusterRecoveryInner(t *testing.T, c cluster.Cluster, cfg cluster.TestC
 
 	// Chaos monkey.
 	rnd, seed := randutil.NewPseudoRand()
-	log.Warningf(context.TODO(), "monkey starts (seed %d)", seed)
+	log.Warningf(context.Background(), "monkey starts (seed %d)", seed)
 	pickNodes := func() []int {
 		return rnd.Perm(num)[:rnd.Intn(num)+1]
 	}
@@ -355,7 +355,7 @@ func testClusterRecoveryInner(t *testing.T, c cluster.Cluster, cfg cluster.TestC
 	for _, c := range counts {
 		count += c
 	}
-	log.Infof(context.TODO(), "%d %.1f/sec", count, float64(count)/elapsed.Seconds())
+	log.Infof(context.Background(), "%d %.1f/sec", count, float64(count)/elapsed.Seconds())
 }
 
 // TestNodeRestart starts up a cluster with an "accounts" table.
@@ -397,7 +397,7 @@ func testNodeRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfi
 
 	// Chaos monkey.
 	rnd, seed := randutil.NewPseudoRand()
-	log.Warningf(context.TODO(), "monkey starts (seed %d)", seed)
+	log.Warningf(context.Background(), "monkey starts (seed %d)", seed)
 	pickNodes := func() []int {
 		return []int{rnd.Intn(num - 1)}
 	}
@@ -410,5 +410,5 @@ func testNodeRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfi
 
 	elapsed := timeutil.Since(start)
 	count := atomic.LoadUint64(&client.count)
-	log.Infof(context.TODO(), "%d %.1f/sec", count, float64(count)/elapsed.Seconds())
+	log.Infof(context.Background(), "%d %.1f/sec", count, float64(count)/elapsed.Seconds())
 }

--- a/acceptance/continuous_load_test.go
+++ b/acceptance/continuous_load_test.go
@@ -192,7 +192,7 @@ func (cl continuousLoadTest) shortTestTimeout() string {
 	}
 	timeout, err := time.ParseDuration(fl.Value.String())
 	if err != nil {
-		log.Errorf(context.TODO(), "couldn't parse test timeout %s", fl.Value.String())
+		log.Errorf(context.Background(), "couldn't parse test timeout %s", fl.Value.String())
 		return ""
 	}
 	return regexp.MustCompile(`([a-z])0[0a-z]+`).ReplaceAllString(timeout.String(), `$1`)

--- a/acceptance/freeze_test.go
+++ b/acceptance/freeze_test.go
@@ -46,7 +46,7 @@ func postFreeze(c cluster.Cluster, freeze bool, timeout time.Duration) (serverpb
 	httpClient.Timeout = timeout
 
 	var resp serverpb.ClusterFreezeResponse
-	log.Infof(context.TODO(), "requesting: freeze=%t, timeout=%s", freeze, timeout)
+	log.Infof(context.Background(), "requesting: freeze=%t, timeout=%s", freeze, timeout)
 	cb := func(v proto.Message) {
 		oldNum := resp.RangesAffected
 		resp = *v.(*serverpb.ClusterFreezeResponse)
@@ -54,7 +54,7 @@ func postFreeze(c cluster.Cluster, freeze bool, timeout time.Duration) (serverpb
 			resp.RangesAffected = oldNum
 		}
 		if (resp != serverpb.ClusterFreezeResponse{}) {
-			log.Infof(context.TODO(), "%+v", &resp)
+			log.Infof(context.Background(), "%+v", &resp)
 		}
 	}
 	err := util.StreamJSON(

--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -119,7 +119,7 @@ func testGossipPeeringsInner(t *testing.T, c cluster.Cluster, cfg cluster.TestCo
 		checkGossip(t, c, waitTime, hasPeers(num))
 
 		// Restart the first node.
-		log.Infof(context.TODO(), "restarting node 0")
+		log.Infof(context.Background(), "restarting node 0")
 		if err := c.Restart(0); err != nil {
 			t.Fatal(err)
 		}
@@ -130,7 +130,7 @@ func testGossipPeeringsInner(t *testing.T, c cluster.Cluster, cfg cluster.TestCo
 		if num > 1 {
 			pickedNode = rand.Intn(num-1) + 1
 		}
-		log.Infof(context.TODO(), "restarting node %d", pickedNode)
+		log.Infof(context.Background(), "restarting node %d", pickedNode)
 		if err := c.Restart(pickedNode); err != nil {
 			t.Fatal(err)
 		}
@@ -164,26 +164,26 @@ func testGossipRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestCon
 	}
 
 	for timeutil.Now().Before(deadline) {
-		log.Infof(context.TODO(), "waiting for initial gossip connections")
+		log.Infof(context.Background(), "waiting for initial gossip connections")
 		checkGossip(t, c, waitTime, hasPeers(num))
 		checkGossip(t, c, waitTime, hasClusterID)
 		checkGossip(t, c, waitTime, hasSentinel)
 
-		log.Infof(context.TODO(), "killing all nodes")
+		log.Infof(context.Background(), "killing all nodes")
 		for i := 0; i < num; i++ {
 			if err := c.Kill(i); err != nil {
 				t.Fatal(err)
 			}
 		}
 
-		log.Infof(context.TODO(), "restarting all nodes")
+		log.Infof(context.Background(), "restarting all nodes")
 		for i := 0; i < num; i++ {
 			if err := c.Restart(i); err != nil {
 				t.Fatal(err)
 			}
 		}
 
-		log.Infof(context.TODO(), "waiting for gossip to be connected")
+		log.Infof(context.Background(), "waiting for gossip to be connected")
 		checkGossip(t, c, waitTime, hasPeers(num))
 		checkGossip(t, c, waitTime, hasClusterID)
 		checkGossip(t, c, waitTime, hasSentinel)

--- a/acceptance/main_stub_test.go
+++ b/acceptance/main_stub_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestMain(m *testing.M) {
 	if !*flagRemote {
-		log.Infof(context.TODO(), "not running with `acceptance` build tag or against remote cluster; skipping")
+		log.Infof(context.Background(), "not running with `acceptance` build tag or against remote cluster; skipping")
 		return
 	}
 	runTests(m)

--- a/acceptance/monotonic_insert_test.go
+++ b/acceptance/monotonic_insert_test.go
@@ -99,7 +99,7 @@ INSERT INTO mono.mono VALUES(-1, '0', -1, -1)`); err != nil {
 	invoke := func(client mtClient) {
 		logPrefix := fmt.Sprintf("%03d.%03d: ", atomic.AddUint64(&idGen, 1), client.ID)
 		l := func(msg string, args ...interface{}) {
-			log.Infof(context.TODO(), logPrefix+msg, args...)
+			log.Infof(context.Background(), logPrefix+msg, args...)
 		}
 		l("begin")
 		defer l("done")

--- a/acceptance/partition_test.go
+++ b/acceptance/partition_test.go
@@ -113,13 +113,13 @@ func (b *Bank) Verify() {
 }
 
 func (b *Bank) logFailed(i int, v interface{}) {
-	log.Warningf(context.TODO(), "%d: %v", i, v)
+	log.Warningf(context.Background(), "%d: %v", i, v)
 }
 func (b *Bank) logBegin(i int, from, to, amount int) {
-	log.Warningf(context.TODO(), "%d: %d trying to give $%d to %d", i, from, amount, to)
+	log.Warningf(context.Background(), "%d: %d trying to give $%d to %d", i, from, amount, to)
 }
 func (b *Bank) logSuccess(i int, from, to, amount int) {
-	log.Warningf(context.TODO(), "%d: %d gave $%d to %d", i, from, amount, to)
+	log.Warningf(context.Background(), "%d: %d gave $%d to %d", i, from, amount, to)
 }
 
 // Invoke transfers a random amount of money between random accounts.
@@ -200,7 +200,7 @@ func testBankWithNemesis(nemeses ...NemesisFn) configTestRunner {
 		case <-stopper:
 		case <-time.After(cfg.Duration):
 		}
-		log.Warningf(context.TODO(), "finishing test")
+		log.Warningf(context.Background(), "finishing test")
 		b.Verify()
 	}
 }

--- a/acceptance/put_test.go
+++ b/acceptance/put_test.go
@@ -75,12 +75,12 @@ func testPutInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig) {
 			// Periodically print out progress so that we know the test is still
 			// running.
 			loadedCount := atomic.LoadInt64(&count)
-			log.Infof(context.TODO(), "%d (%d/s)", loadedCount, loadedCount-baseCount)
+			log.Infof(context.Background(), "%d (%d/s)", loadedCount, loadedCount-baseCount)
 			c.Assert(t)
 			cluster.Consistent(t, c)
 		}
 	}
 
 	elapsed := timeutil.Since(start)
-	log.Infof(context.TODO(), "%d %.1f/sec", count, float64(count)/elapsed.Seconds())
+	log.Infof(context.Background(), "%d %.1f/sec", count, float64(count)/elapsed.Seconds())
 }

--- a/acceptance/replication_test.go
+++ b/acceptance/replication_test.go
@@ -55,7 +55,7 @@ func checkRangeReplication(t *testing.T, c cluster.Cluster, d time.Duration) {
 		wantedReplicas = c.NumNodes()
 	}
 
-	log.Infof(context.TODO(), "waiting for first range to have %d replicas", wantedReplicas)
+	log.Infof(context.Background(), "waiting for first range to have %d replicas", wantedReplicas)
 
 	util.SucceedsSoon(t, func() error {
 		select {
@@ -71,7 +71,7 @@ func checkRangeReplication(t *testing.T, c cluster.Cluster, d time.Duration) {
 		}
 
 		if log.V(1) {
-			log.Infof(context.TODO(), "found %d replicas", foundReplicas)
+			log.Infof(context.Background(), "found %d replicas", foundReplicas)
 		}
 		if foundReplicas >= wantedReplicas {
 			return nil
@@ -79,5 +79,5 @@ func checkRangeReplication(t *testing.T, c cluster.Cluster, d time.Duration) {
 		return fmt.Errorf("expected %d replicas, only found %d", wantedReplicas, foundReplicas)
 	})
 
-	log.Infof(context.TODO(), "found %d replicas", wantedReplicas)
+	log.Infof(context.Background(), "found %d replicas", wantedReplicas)
 }

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -114,7 +114,7 @@ func testSingleKeyInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig)
 		case <-time.After(1 * time.Second):
 			// Periodically print out progress so that we know the test is still
 			// running.
-			log.Infof(context.TODO(), "%d", atomic.LoadInt64(&expected))
+			log.Infof(context.Background(), "%d", atomic.LoadInt64(&expected))
 		}
 	}
 
@@ -131,5 +131,5 @@ func testSingleKeyInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig)
 	for _, r := range results {
 		maxLatency = append(maxLatency, r.maxLatency)
 	}
-	log.Infof(context.TODO(), "%d increments: %s", v, maxLatency)
+	log.Infof(context.Background(), "%d increments: %s", v, maxLatency)
 }

--- a/acceptance/status_server_test.go
+++ b/acceptance/status_server_test.go
@@ -48,21 +48,21 @@ func get(t *testing.T, base, rel string) []byte {
 	for r := retry.Start(retryOptions); r.Next(); {
 		resp, err := cluster.HTTPClient.Get(url)
 		if err != nil {
-			log.Infof(context.TODO(), "could not GET %s - %s", url, err)
+			log.Infof(context.Background(), "could not GET %s - %s", url, err)
 			continue
 		}
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			log.Infof(context.TODO(), "could not read body for %s - %s", url, err)
+			log.Infof(context.Background(), "could not read body for %s - %s", url, err)
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
-			log.Infof(context.TODO(), "could not GET %s - statuscode: %d - body: %s", url, resp.StatusCode, body)
+			log.Infof(context.Background(), "could not GET %s - statuscode: %d - body: %s", url, resp.StatusCode, body)
 			continue
 		}
 		if log.V(1) {
-			log.Infof(context.TODO(), "OK response from %s", url)
+			log.Infof(context.Background(), "OK response from %s", url)
 		}
 		return body
 	}

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -225,7 +225,7 @@ func farmer(t *testing.T, prefix string) *terrafarm.Farmer {
 		AddVars:     make(map[string]string),
 		KeepCluster: flagTFKeepCluster.String(),
 	}
-	log.Infof(context.TODO(), "logging to %s", logDir)
+	log.Infof(context.Background(), "logging to %s", logDir)
 	return f
 }
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -69,12 +69,12 @@ func newCLITest() cliTest {
 
 	s, err := serverutils.StartServerRaw(base.TestServerArgs{})
 	if err != nil {
-		log.Fatalf(context.TODO(), "Could not start server: %v", err)
+		log.Fatalf(context.Background(), "Could not start server: %v", err)
 	}
 
 	tempDir, err := ioutil.TempDir("", "cli-test")
 	if err != nil {
-		log.Fatal(context.TODO(), err)
+		log.Fatal(context.Background(), err)
 	}
 
 	// Copy these assets to disk from embedded strings, so this test can
@@ -101,7 +101,7 @@ func newCLITest() cliTest {
 		certsDir:   tempDir,
 		cleanupFunc: func() {
 			if err := os.RemoveAll(tempDir); err != nil {
-				log.Fatal(context.TODO(), err)
+				log.Fatal(context.Background(), err)
 			}
 		},
 	}
@@ -304,7 +304,7 @@ func Example_insecure() {
 	s, err := serverutils.StartServerRaw(
 		base.TestServerArgs{Insecure: true})
 	if err != nil {
-		log.Fatalf(context.TODO(), "Could not start server: %v", err)
+		log.Fatalf(context.Background(), "Could not start server: %v", err)
 	}
 	defer s.Stopper().Stop()
 	c := cliTest{TestServer: s.(*server.TestServer), cleanupFunc: func() {}}
@@ -864,7 +864,7 @@ func Example_node() {
 
 	// Refresh time series data, which is required to retrieve stats.
 	if err := c.TestServer.WriteSummaries(); err != nil {
-		log.Fatalf(context.TODO(), "Couldn't write stats summaries: %s", err)
+		log.Fatalf(context.Background(), "Couldn't write stats summaries: %s", err)
 	}
 
 	c.Run("node ls")

--- a/internal/client/txn_test.go
+++ b/internal/client/txn_test.go
@@ -778,7 +778,7 @@ func TestWrongTxnRetry(t *testing.T) {
 
 	var retries int
 	txnClosure := func(outerTxn *Txn) error {
-		log.Infof(context.TODO(), "outer retry")
+		log.Infof(context.Background(), "outer retry")
 		retries++
 		// Ensure the KV transaction is created.
 		if err := outerTxn.Put("a", "b"); err != nil {

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -73,7 +73,7 @@ func startTestWriter(db *client.DB, i int64, valBytes int32, wg *sync.WaitGroup,
 					key := randutil.RandBytes(src, 10)
 					val := randutil.RandBytes(src, int(src.Int31n(valBytes)))
 					if err := txn.Put(key, val); err != nil {
-						log.Infof(context.TODO(), "experienced an error in routine %d: %s", i, err)
+						log.Infof(context.Background(), "experienced an error in routine %d: %s", i, err)
 						return err
 					}
 				}
@@ -101,11 +101,11 @@ func TestRangeSplitMeta(t *testing.T) {
 
 	// Execute the consecutive splits.
 	for _, splitKey := range splitKeys {
-		log.Infof(context.TODO(), "starting split at key %q...", splitKey)
+		log.Infof(context.Background(), "starting split at key %q...", splitKey)
 		if err := s.DB.AdminSplit(roachpb.Key(splitKey)); err != nil {
 			t.Fatal(err)
 		}
-		log.Infof(context.TODO(), "split at key %q complete", splitKey)
+		log.Infof(context.Background(), "split at key %q complete", splitKey)
 	}
 
 	util.SucceedsSoon(t, func() error {
@@ -146,11 +146,11 @@ func TestRangeSplitsWithConcurrentTxns(t *testing.T) {
 		for i := 0; i < concurrency; i++ {
 			<-txnChannel
 		}
-		log.Infof(context.TODO(), "starting split at key %q...", splitKey)
+		log.Infof(context.Background(), "starting split at key %q...", splitKey)
 		if pErr := s.DB.AdminSplit(splitKey); pErr != nil {
 			t.Error(pErr)
 		}
-		log.Infof(context.TODO(), "split at key %q complete", splitKey)
+		log.Infof(context.Background(), "split at key %q complete", splitKey)
 	}
 
 	close(done)
@@ -226,11 +226,11 @@ func TestRangeSplitsWithSameKeyTwice(t *testing.T) {
 	defer s.Stop()
 
 	splitKey := roachpb.Key("aa")
-	log.Infof(context.TODO(), "starting split at key %q...", splitKey)
+	log.Infof(context.Background(), "starting split at key %q...", splitKey)
 	if err := s.DB.AdminSplit(splitKey); err != nil {
 		t.Fatal(err)
 	}
-	log.Infof(context.TODO(), "split at key %q first time complete", splitKey)
+	log.Infof(context.Background(), "split at key %q first time complete", splitKey)
 	ch := make(chan error)
 	go func() {
 		// should return error other than infinite loop

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -109,14 +109,14 @@ func (c *cmd) clone() *cmd {
 func (c *cmd) execute(txn *client.Txn, t *testing.T) (string, error) {
 	if c.prev != nil {
 		if log.V(2) {
-			log.Infof(context.TODO(), "%s waiting on %s", c, c.prev)
+			log.Infof(context.Background(), "%s waiting on %s", c, c.prev)
 		}
 		if err := <-c.prev.ch; err != nil {
 			return "", err
 		}
 	}
 	if log.V(2) {
-		log.Infof(context.TODO(), "executing %s", c)
+		log.Infof(context.Background(), "executing %s", c)
 	}
 	err := c.fn(c, txn, t)
 	if err == nil {
@@ -552,7 +552,7 @@ func TestEnumerateHistoriesAfterRetry(t *testing.T) {
 	enum := enumerateHistories(txns, false)
 	for i, e := range enum {
 		if log.V(1) {
-			log.Infof(context.TODO(), "enum(%d): %s", i, historyString(e))
+			log.Infof(context.Background(), "enum(%d): %s", i, historyString(e))
 		}
 	}
 	testCases := []struct {
@@ -651,7 +651,7 @@ func newHistoryVerifier(name string, txns []string, verify *verifier, t *testing
 }
 
 func (hv *historyVerifier) run(isolations []enginepb.IsolationType, db *client.DB, t *testing.T) {
-	log.Infof(context.TODO(), "verifying all possible histories for the %q anomaly", hv.name)
+	log.Infof(context.Background(), "verifying all possible histories for the %q anomaly", hv.name)
 	priorities := make([]int32, len(hv.txns))
 	for i := 0; i < len(hv.txns); i++ {
 		priorities[i] = int32(i + 1)
@@ -684,7 +684,7 @@ func (hv *historyVerifier) runHistoryWithRetry(priorities []int32,
 	isolations []enginepb.IsolationType, cmds []*cmd, db *client.DB, t *testing.T) error {
 	if err := hv.runHistory(priorities, isolations, cmds, db, t); err != nil {
 		if log.V(1) {
-			log.Infof(context.TODO(), "got an error running history %s: %s", historyString(cmds), err)
+			log.Infof(context.Background(), "got an error running history %s: %s", historyString(cmds), err)
 		}
 		retry, ok := err.(*retryError)
 		if !ok {
@@ -693,7 +693,7 @@ func (hv *historyVerifier) runHistoryWithRetry(priorities []int32,
 
 		if _, hasRetried := hv.retriedTxns[retry.txnIdx]; hasRetried {
 			if log.V(1) {
-				log.Infof(context.TODO(), "retried txn %d twice; skipping history", retry.txnIdx+1)
+				log.Infof(context.Background(), "retried txn %d twice; skipping history", retry.txnIdx+1)
 			}
 			return nil
 		}
@@ -703,7 +703,7 @@ func (hv *historyVerifier) runHistoryWithRetry(priorities []int32,
 		enumHis := sampleHistories(enumerateHistoriesAfterRetry(retry, cmds), 0.05)
 		for i, h := range enumHis {
 			if log.V(1) {
-				log.Infof(context.TODO(), "after retry, running alternate history %d of %d", i, len(enumHis))
+				log.Infof(context.Background(), "after retry, running alternate history %d of %d", i, len(enumHis))
 			}
 			if err := hv.runHistoryWithRetry(priorities, isolations, h, db, t); err != nil {
 				return err
@@ -728,7 +728,7 @@ func (hv *historyVerifier) runHistory(priorities []int32,
 	}
 	plannedStr := historyString(cmds)
 	if log.V(1) {
-		log.Infof(context.TODO(), "iso=%d pri=%d history=%s", isolations, priorities, plannedStr)
+		log.Infof(context.Background(), "iso=%d pri=%d history=%s", isolations, priorities, plannedStr)
 	}
 
 	hv.mu.actual = []string{}
@@ -778,7 +778,7 @@ func (hv *historyVerifier) runHistory(priorities []int32,
 	err = hv.verify.checkFn(verifyEnv)
 	if err == nil {
 		if log.V(1) {
-			log.Infof(context.TODO(), "PASSED: iso=%d, pri=%d, history=%q", isolations, priorities, actualStr)
+			log.Infof(context.Background(), "PASSED: iso=%d, pri=%d, history=%q", isolations, priorities, actualStr)
 		}
 	}
 	if err != nil {
@@ -841,7 +841,7 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 			_, err := hv.runCmd(txn, txnIdx, retry, cmds[cmdIdx], t)
 			if err != nil {
 				if log.V(1) {
-					log.Infof(context.TODO(), "%s: failed running %s: %s", txnName, cmds[cmdIdx], err)
+					log.Infof(context.Background(), "%s: failed running %s: %s", txnName, cmds[cmdIdx], err)
 				}
 				return err
 			}

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -76,7 +76,7 @@ func TestIntentResolution(t *testing.T) {
 		// Use deterministic randomness to randomly put the writes in separate
 		// batches or commit them with EndTransaction.
 		rnd, seed := randutil.NewPseudoRand()
-		log.Infof(context.TODO(), "%d: using intent test seed %d", i, seed)
+		log.Infof(context.Background(), "%d: using intent test seed %d", i, seed)
 
 		results := map[string]struct{}{}
 		func() {
@@ -105,7 +105,7 @@ func TestIntentResolution(t *testing.T) {
 						}
 					}
 					if entry != "" {
-						log.Infof(context.TODO(), "got %s", entry)
+						log.Infof(context.Background(), "got %s", entry)
 						results[entry] = struct{}{}
 					}
 					if len(results) >= len(tc.exp) && !done {
@@ -132,7 +132,7 @@ func TestIntentResolution(t *testing.T) {
 					// The first write must not go to batch, it anchors the
 					// transaction to the correct range.
 					local := i != 0 && rnd.Intn(2) == 0
-					log.Infof(context.TODO(), "%d: %s: local: %t", i, key, local)
+					log.Infof(context.Background(), "%d: %s: local: %t", i, key, local)
 					if local {
 						b.Put(key, "test")
 					} else if err := txn.Put(key, "test"); err != nil {
@@ -142,7 +142,7 @@ func TestIntentResolution(t *testing.T) {
 
 				for _, kr := range tc.ranges {
 					local := rnd.Intn(2) == 0
-					log.Infof(context.TODO(), "%d: [%s,%s): local: %t", i, kr[0], kr[1], local)
+					log.Infof(context.Background(), "%d: [%s,%s): local: %t", i, kr[0], kr[1], local)
 					if local {
 						b.DelRange(kr[0], kr[1], false)
 					} else if err := txn.DelRange(kr[0], kr[1]); err != nil {

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -172,24 +172,24 @@ func getRequestReader(t *testing.T, ts serverutils.TestServerInterface, path str
 		req.Header.Set(util.AcceptHeader, util.JSONContentType)
 		resp, err := httpClient.Do(req)
 		if err != nil {
-			log.Infof(context.TODO(), "could not GET %s - %s", url, err)
+			log.Infof(context.Background(), "could not GET %s - %s", url, err)
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				log.Infof(context.TODO(), "could not read body for %s - %s", url, err)
+				log.Infof(context.Background(), "could not read body for %s - %s", url, err)
 				continue
 			}
-			log.Infof(context.TODO(), "could not GET %s - statuscode: %d - body: %s", url, resp.StatusCode, body)
+			log.Infof(context.Background(), "could not GET %s - statuscode: %d - body: %s", url, resp.StatusCode, body)
 			continue
 		}
 		returnedContentType := resp.Header.Get(util.ContentTypeHeader)
 		if returnedContentType != util.JSONContentType {
-			log.Infof(context.TODO(), "unexpected content type: %v", returnedContentType)
+			log.Infof(context.Background(), "unexpected content type: %v", returnedContentType)
 			continue
 		}
-		log.Infof(context.TODO(), "OK response from %s", url)
+		log.Infof(context.Background(), "OK response from %s", url)
 		return resp.Body
 	}
 	t.Fatalf("There was an error retrieving %s", url)
@@ -203,7 +203,7 @@ func getRequest(t *testing.T, ts serverutils.TestServerInterface, path string) [
 	defer respBody.Close()
 	body, err := ioutil.ReadAll(respBody)
 	if err != nil {
-		log.Infof(context.TODO(), "could not read body for %s - %s", path, err)
+		log.Infof(context.Background(), "could not read body for %s - %s", path, err)
 		return nil
 	}
 	return body
@@ -268,11 +268,11 @@ func TestStatusLocalLogs(t *testing.T) {
 
 	// Log an error which we expect to show up on every log file.
 	timestamp := timeutil.Now().UnixNano()
-	log.Errorf(context.TODO(), "TestStatusLocalLogFile test message-Error")
+	log.Errorf(context.Background(), "TestStatusLocalLogFile test message-Error")
 	timestampE := timeutil.Now().UnixNano()
-	log.Warningf(context.TODO(), "TestStatusLocalLogFile test message-Warning")
+	log.Warningf(context.Background(), "TestStatusLocalLogFile test message-Warning")
 	timestampEW := timeutil.Now().UnixNano()
-	log.Infof(context.TODO(), "TestStatusLocalLogFile test message-Info")
+	log.Infof(context.Background(), "TestStatusLocalLogFile test message-Info")
 	timestampEWI := timeutil.Now().UnixNano()
 
 	type logsWrapper struct {

--- a/storage/addressing_test.go
+++ b/storage/addressing_test.go
@@ -179,16 +179,16 @@ func TestUpdateRangeAddressing(t *testing.T) {
 
 		if test.split {
 			if log.V(1) {
-				log.Infof(context.TODO(), "test case %d: split %q-%q at %q", i, left.StartKey, right.EndKey, left.EndKey)
+				log.Infof(context.Background(), "test case %d: split %q-%q at %q", i, left.StartKey, right.EndKey, left.EndKey)
 			}
 		} else {
 			if log.V(1) {
-				log.Infof(context.TODO(), "test case %d: merge %q-%q + %q-%q", i, left.StartKey, left.EndKey, left.EndKey, right.EndKey)
+				log.Infof(context.Background(), "test case %d: merge %q-%q + %q-%q", i, left.StartKey, left.EndKey, left.EndKey, right.EndKey)
 			}
 		}
 		for _, meta := range metas {
 			if log.V(1) {
-				log.Infof(context.TODO(), "%q", meta.key)
+				log.Infof(context.Background(), "%q", meta.key)
 			}
 		}
 

--- a/storage/engine/bench_test.go
+++ b/storage/engine/bench_test.go
@@ -88,7 +88,7 @@ func setupMVCCData(emk engineMaker, numVersions, numKeys, valueBytes int, b *tes
 		return eng, loc, stopper
 	}
 
-	log.Infof(context.TODO(), "creating mvcc data: %s", loc)
+	log.Infof(context.Background(), "creating mvcc data: %s", loc)
 
 	// Generate the same data every time.
 	rng := rand.New(rand.NewSource(1449168817))
@@ -119,7 +119,7 @@ func setupMVCCData(emk engineMaker, numVersions, numKeys, valueBytes int, b *tes
 		// optimizations which change the data size result in the same number of
 		// sstables.
 		if scaled := len(order) / 20; i > 0 && (i%scaled) == 0 {
-			log.Infof(context.TODO(), "committing (%d/~%d)", i/scaled, 20)
+			log.Infof(context.Background(), "committing (%d/~%d)", i/scaled, 20)
 			if err := batch.Commit(); err != nil {
 				b.Fatal(err)
 			}
@@ -472,7 +472,7 @@ func runMVCCComputeStats(emk engineMaker, valueBytes int, b *testing.B) {
 	}
 
 	b.StopTimer()
-	log.Infof(context.TODO(), "live_bytes: %d", stats.LiveBytes)
+	log.Infof(context.Background(), "live_bytes: %d", stats.LiveBytes)
 }
 
 func BenchmarkMVCCPutDelete_RocksDB(b *testing.B) {

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -3161,7 +3161,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 func TestMVCCStatsWithRandomRuns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	rng, seed := randutil.NewPseudoRand()
-	log.Infof(context.TODO(), "using pseudo random number generator with seed %d", seed)
+	log.Infof(context.Background(), "using pseudo random number generator with seed %d", seed)
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	engine := createTestEngine(stopper)
@@ -3179,7 +3179,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		lastWT = ts.WallTime
 
 		if log.V(1) {
-			log.Infof(context.TODO(), "*** cycle %d @ %s", i, ts)
+			log.Infof(context.Background(), "*** cycle %d @ %s", i, ts)
 		}
 		// Manually advance aggregate intent age based on one extra second of simulation.
 		// Same for aggregate gc'able bytes age.
@@ -3198,14 +3198,14 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		if i > 0 && isDelete {
 			idx := rng.Int31n(i)
 			if log.V(1) {
-				log.Infof(context.TODO(), "*** DELETE index %d", idx)
+				log.Infof(context.Background(), "*** DELETE index %d", idx)
 			}
 			if err := MVCCDelete(context.Background(), engine, ms, keys[idx], ts, txn); err != nil {
 				// Abort any write intent on an earlier, unresolved txn.
 				if wiErr, ok := err.(*roachpb.WriteIntentError); ok {
 					wiErr.Intents[0].Status = roachpb.ABORTED
 					if log.V(1) {
-						log.Infof(context.TODO(), "*** ABORT index %d", idx)
+						log.Infof(context.Background(), "*** ABORT index %d", idx)
 					}
 					// Note that this already incorporates committing an intent
 					// at a later time (since we use a potentially later ts here
@@ -3215,7 +3215,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 					}
 					// Now, re-delete.
 					if log.V(1) {
-						log.Infof(context.TODO(), "*** RE-DELETE index %d", idx)
+						log.Infof(context.Background(), "*** RE-DELETE index %d", idx)
 					}
 					if err := MVCCDelete(context.Background(), engine, ms, keys[idx], ts, txn); err != nil {
 						t.Fatal(err)
@@ -3227,7 +3227,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 		} else {
 			rngVal := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, int(rng.Int31n(128))))
 			if log.V(1) {
-				log.Infof(context.TODO(), "*** PUT index %d; TXN=%t", i, txn != nil)
+				log.Infof(context.Background(), "*** PUT index %d; TXN=%t", i, txn != nil)
 			}
 			if err := MVCCPut(context.Background(), engine, ms, key, ts, rngVal, txn); err != nil {
 				t.Fatal(err)
@@ -3239,7 +3239,7 @@ func TestMVCCStatsWithRandomRuns(t *testing.T) {
 				txn.Status = roachpb.ABORTED
 			}
 			if log.V(1) {
-				log.Infof(context.TODO(), "*** RESOLVE index %d; COMMIT=%t", i, txn.Status == roachpb.COMMITTED)
+				log.Infof(context.Background(), "*** RESOLVE index %d; COMMIT=%t", i, txn.Status == roachpb.COMMITTED)
 			}
 			if err := MVCCResolveWriteIntent(context.Background(), engine, ms, roachpb.Intent{Span: roachpb.Span{Key: key}, Status: txn.Status, Txn: txn.TxnMeta}); err != nil {
 				t.Fatal(err)
@@ -3323,7 +3323,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 			t.Fatal(err)
 		}
 		for i, kv := range kvsn {
-			log.Infof(context.TODO(), "%d: %s", i, kv.Key)
+			log.Infof(context.Background(), "%d: %s", i, kv.Key)
 		}
 	}
 

--- a/storage/gc_queue_test.go
+++ b/storage/gc_queue_test.go
@@ -64,7 +64,7 @@ func TestGCQueueShouldQueue(t *testing.T) {
 	desc := tc.rng.Desc()
 	zone, err := cfg.GetZoneConfigForKey(desc.StartKey)
 	if err != nil {
-		log.Errorf(context.TODO(), "could not find GC policy for range %s: %s, got zone %+v",
+		log.Errorf(context.Background(), "could not find GC policy for range %s: %s, got zone %+v",
 			tc.rng, err, zone)
 		return
 	}
@@ -312,7 +312,7 @@ func TestGCQueueProcess(t *testing.T) {
 	}
 	for i, kv := range kvs {
 		if log.V(1) {
-			log.Infof(context.TODO(), "%d: %s", i, kv.Key)
+			log.Infof(context.Background(), "%d: %s", i, kv.Key)
 		}
 	}
 	if len(kvs) != len(expKVs) {
@@ -326,7 +326,7 @@ func TestGCQueueProcess(t *testing.T) {
 			t.Errorf("%d: expected ts=%s; got %s", i, expKVs[i].ts, kv.Key.Timestamp)
 		}
 		if log.V(1) {
-			log.Infof(context.TODO(), "%d: %s", i, kv.Key)
+			log.Infof(context.Background(), "%d: %s", i, kv.Key)
 		}
 	}
 

--- a/storage/id_alloc_test.go
+++ b/storage/id_alloc_test.go
@@ -224,7 +224,7 @@ func TestAllocateWithStopper(t *testing.T) {
 	store, _, stopper := createTestStore(t)
 	idAlloc, err := newIDAllocator(keys.RangeIDGenerator, store.ctx.DB, 2, 10, stopper)
 	if err != nil {
-		log.Fatal(context.TODO(), err)
+		log.Fatal(context.Background(), err)
 	}
 
 	stopper.Stop()

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -1628,7 +1628,7 @@ func TestLeaseConcurrent(t *testing.T) {
 					// Morally speaking, this is an error, but reproposals can
 					// happen and so we warn (in case this trips the test up
 					// in more unexpected ways).
-					log.Infof(context.TODO(), "reproposal of %+v", ll)
+					log.Infof(context.Background(), "reproposal of %+v", ll)
 				}
 				go func() {
 					wg.Wait()
@@ -5814,7 +5814,7 @@ func runWrongIndexTest(t *testing.T, repropose bool, withErr bool, expProposals 
 
 	wrongIndex := ai - 1 // will chose this as MaxLeaseIndex
 
-	log.Infof(context.TODO(), "test begins")
+	log.Infof(context.Background(), "test begins")
 
 	var ba roachpb.BatchRequest
 	ba.Timestamp = tc.clock.Now()
@@ -5937,7 +5937,7 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 			// the command and it isn't reproposed due to the
 			// client abandoning it.
 			if rand.Intn(2) == 0 {
-				log.Infof(context.TODO(), "abandoning command %d", i)
+				log.Infof(context.Background(), "abandoning command %d", i)
 				delete(rng.mu.pendingCmds, cmd.idKey)
 			} else if err := rng.proposePendingCmdLocked(cmd); err != nil {
 				t.Fatal(err)

--- a/storage/scanner_test.go
+++ b/storage/scanner_test.go
@@ -255,7 +255,7 @@ func TestScannerTiming(t *testing.T) {
 			stopper.Stop()
 
 			avg := s.avgScan()
-			log.Infof(context.TODO(), "%d: average scan: %s", i, avg)
+			log.Infof(context.Background(), "%d: average scan: %s", i, avg)
 			if avg.Nanoseconds()-duration.Nanoseconds() > maxError.Nanoseconds() ||
 				duration.Nanoseconds()-avg.Nanoseconds() > maxError.Nanoseconds() {
 				return errors.Errorf("expected %s, got %s: exceeds max error of %s", duration, avg, maxError)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -293,7 +293,7 @@ func createRange(s *Store, rangeID roachpb.RangeID, start, end roachpb.RKey) *Re
 	}
 	r, err := NewReplica(desc, s, 0)
 	if err != nil {
-		log.Fatal(context.TODO(), err)
+		log.Fatal(context.Background(), err)
 	}
 	return r
 }
@@ -423,7 +423,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = rng1.proposeRaftCommand(context.TODO(), roachpb.BatchRequest{})
+	_, _, err = rng1.proposeRaftCommand(context.Background(), roachpb.BatchRequest{})
 	expected := "replica .* was garbage collected"
 	if !testutils.IsError(err, expected) {
 		t.Fatalf("expected error %s, but got %v", expected, err)

--- a/testutils/testcluster/testcluster_test.go
+++ b/testutils/testcluster/testcluster_test.go
@@ -70,7 +70,7 @@ func TestManualReplication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Infof(context.TODO(), "After split got ranges: %+v and %+v.", leftRangeDesc, tableRangeDesc)
+	log.Infof(context.Background(), "After split got ranges: %+v and %+v.", leftRangeDesc, tableRangeDesc)
 	if len(tableRangeDesc.Replicas) == 0 {
 		t.Fatalf(
 			"expected replica on node 1, got no replicas: %+v", tableRangeDesc.Replicas)

--- a/util/hlc/hlc_test.go
+++ b/util/hlc/hlc_test.go
@@ -49,15 +49,15 @@ func ExampleNewClock() {
 	// The sanity checks below will usually never be triggered.
 
 	if s.Less(t) || !t.Less(s) {
-		log.Fatalf(context.TODO(), "The later timestamp is smaller than the earlier one")
+		log.Fatalf(context.Background(), "The later timestamp is smaller than the earlier one")
 	}
 
 	if t.WallTime-s.WallTime > 0 {
-		log.Fatalf(context.TODO(), "HLC timestamp %d deviates from physical clock %d", s, t)
+		log.Fatalf(context.Background(), "HLC timestamp %d deviates from physical clock %d", s, t)
 	}
 
 	if s.Logical > 0 {
-		log.Fatalf(context.TODO(), "Trivial timestamp has logical component")
+		log.Fatalf(context.Background(), "Trivial timestamp has logical component")
 	}
 
 	fmt.Printf("The Unix Epoch is now approximately %dns old.\n", t.WallTime)


### PR DESCRIPTION
Found with https://github.com/d4l3k/lint/tree/context-todo.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8314)

<!-- Reviewable:end -->
