### PR TITLE
storage: avoid periodic reproposal of newly pending commands

### DIFF
--- a/storage/refreshraftreason_string.go
+++ b/storage/refreshraftreason_string.go
@@ -4,9 +4,9 @@ package storage
 
 import "fmt"
 
-const _refreshRaftReason_name = "noReasonreasonEmptyEntryreasonReplicaIDChangedreasonTicks"
+const _refreshRaftReason_name = "noReasonreasonNewLeaderOrConfigChangereasonReplicaIDChangedreasonTicks"
 
-var _refreshRaftReason_index = [...]uint8{0, 8, 24, 46, 57}
+var _refreshRaftReason_index = [...]uint8{0, 8, 37, 59, 70}
 
 func (i refreshRaftReason) String() string {
 	if i < 0 || i >= refreshRaftReason(len(_refreshRaftReason_index)-1) {

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1685,7 +1685,7 @@ func (r *Replica) handleRaftReady() error {
 	}
 	if shouldReproposeCmds {
 		r.mu.Lock()
-		err := r.refreshPendingCmdsLocked(reasonEmptyEntry, 0)
+		err := r.refreshPendingCmdsLocked(reasonNewLeaderOrConfigChange, 0)
 		r.mu.Unlock()
 		if err != nil {
 			return err
@@ -1744,7 +1744,7 @@ type refreshRaftReason int
 
 const (
 	noReason refreshRaftReason = iota
-	reasonEmptyEntry
+	reasonNewLeaderOrConfigChange
 	reasonReplicaIDChanged
 	reasonTicks
 )

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -159,9 +159,10 @@ type pendingCmd struct {
 	// TODO(tschottdorf): idKey is legacy at this point: We could easily key
 	// commands by their MaxLeaseIndex, and doing so should be ok with a stop-
 	// the-world migration. However, requires adapting tryAbandon.
-	idKey   storagebase.CmdIDKey
-	raftCmd roachpb.RaftCommand
-	done    chan roachpb.ResponseWithError // Used to signal waiting RPC handler
+	idKey           storagebase.CmdIDKey
+	proposedAtTicks int
+	raftCmd         roachpb.RaftCommand
+	done            chan roachpb.ResponseWithError // Used to signal waiting RPC handler
 }
 
 type replicaChecksum struct {
@@ -523,7 +524,7 @@ func (r *Replica) setReplicaIDLocked(replicaID roachpb.ReplicaID) error {
 	// this new incarnation.
 	if previousReplicaID != 0 {
 		// propose pending commands under new replicaID
-		if err := r.refreshPendingCmdsLocked(reasonReplicaIDChanged); err != nil {
+		if err := r.refreshPendingCmdsLocked(reasonReplicaIDChanged, 0); err != nil {
 			return err
 		}
 	}
@@ -1428,6 +1429,10 @@ func (r *Replica) prepareRaftCommandLocked(
 	if !ba.IsLease() {
 		r.mu.lastAssignedLeaseIndex++
 	}
+	if log.V(4) {
+		log.Infof(ctx, "%s: prepared command: maxLeaseIndex=%d leaseAppliedIndex=%d",
+			r, r.mu.lastAssignedLeaseIndex, r.mu.state.LeaseAppliedIndex)
+	}
 	return &pendingCmd{
 		ctx:   ctx,
 		idKey: idKey,
@@ -1499,6 +1504,7 @@ func (r *Replica) proposeRaftCommand(
 // proposePendingCmdLocked proposes or re-proposes a command in r.mu.pendingCmds.
 // The replica lock must be held.
 func (r *Replica) proposePendingCmdLocked(p *pendingCmd) error {
+	p.proposedAtTicks = r.mu.ticks
 	if r.mu.proposeRaftCommandFn != nil {
 		return r.mu.proposeRaftCommandFn(p)
 	}
@@ -1679,7 +1685,7 @@ func (r *Replica) handleRaftReady() error {
 	}
 	if shouldReproposeCmds {
 		r.mu.Lock()
-		err := r.refreshPendingCmdsLocked(reasonEmptyEntry)
+		err := r.refreshPendingCmdsLocked(reasonEmptyEntry, 0)
 		r.mu.Unlock()
 		if err != nil {
 			return err
@@ -1708,12 +1714,16 @@ func (r *Replica) tick() error {
 	r.mu.ticks++
 	r.mu.internalRaftGroup.Tick()
 	if r.mu.ticks%r.store.ctx.RaftElectionTimeoutTicks == 0 {
-		// RaftElectionTimeoutTicks is a reasonable approximation of how
-		// long we should wait before deciding that our previous proposal
-		// didn't go through.
+		// RaftElectionTimeoutTicks is a reasonable approximation of how long we
+		// should wait before deciding that our previous proposal didn't go
+		// through. Note that the combination of the above condition and passing
+		// RaftElectionTimeoutTicks to refreshPendingCmdsLocked means that commands
+		// will be refreshed when they have been pending for 1 to 2 electionc
+		// cycles.
 		//
 		// TODO(tamird/bdarnell): Add unit tests.
-		if err := r.refreshPendingCmdsLocked(reasonTicks); err != nil {
+		if err := r.refreshPendingCmdsLocked(
+			reasonTicks, r.store.ctx.RaftElectionTimeoutTicks); err != nil {
 			return err
 		}
 	}
@@ -1739,15 +1749,26 @@ const (
 	reasonTicks
 )
 
-func (r *Replica) refreshPendingCmdsLocked(reason refreshRaftReason) error {
+func (r *Replica) refreshPendingCmdsLocked(reason refreshRaftReason, refreshAtDelta int) error {
+	if len(r.mu.pendingCmds) == 0 {
+		return nil
+	}
+
 	// Note that we can't use the commit index here (which is typically a
 	// little ahead), because a pending command is removed only as it applies.
 	// Thus we'd risk reproposing a command that has been committed but not yet
 	// applied.
 	maxWillRefurbish := r.mu.state.LeaseAppliedIndex // indexes <= will be refurbished
-	origNum := len(r.mu.pendingCmds)
+	refreshAtTicks := r.mu.ticks - refreshAtDelta
+	refurbished := 0
 	var reproposals pendingCmdSlice
 	for idKey, p := range r.mu.pendingCmds {
+		if p.proposedAtTicks > refreshAtTicks {
+			// The command was proposed too recently, don't bother reproprosing or
+			// refurbishing it yet. Note that if refreshAtDelta is 0, refreshAtTicks
+			// will be r.mu.ticks making the above condition impossible.
+			continue
+		}
 		if p.raftCmd.MaxLeaseIndex > maxWillRefurbish {
 			reproposals = append(reproposals, p)
 			continue
@@ -1757,11 +1778,12 @@ func (r *Replica) refreshPendingCmdsLocked(reason refreshRaftReason) error {
 		if pErr := r.refurbishPendingCmdLocked(p); pErr != nil {
 			p.done <- roachpb.ResponseWithError{Err: pErr}
 		}
+		refurbished++
 	}
-	if log.V(1) && origNum > 0 {
-		log.Infof(context.TODO(), "%s: pending commands: refurbished %d, reproposing %d (at %d.%d); %s",
-			r, origNum-len(reproposals),
-			len(reproposals), r.mu.state.RaftAppliedIndex,
+	if log.V(1) && (refurbished > 0 || len(reproposals) > 0) {
+		log.Infof(context.TODO(),
+			"%s: pending commands: refurbished %d, reproposing %d (at %d.%d); %s",
+			r, refurbished, len(reproposals), r.mu.state.RaftAppliedIndex,
 			r.mu.state.LeaseAppliedIndex, reason)
 	}
 
@@ -1877,6 +1899,11 @@ func (r *Replica) processRaftCommand(
 ) *roachpb.Error {
 	if index == 0 {
 		log.Fatalf(context.TODO(), "%s: processRaftCommand requires a non-zero index", r)
+	}
+
+	if log.V(4) {
+		log.Infof(context.TODO(), "%s: processing command: maxLeaseIndex=%d",
+			r, raftCmd.MaxLeaseIndex)
 	}
 
 	r.mu.Lock()

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -6003,6 +6003,7 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 				Key: roachpb.Key(fmt.Sprintf("k%d", i))}})
 			cmd := tc.rng.prepareRaftCommandLocked(ctx, makeIDKey(), repDesc, ba)
 			tc.rng.insertRaftCommandLocked(cmd)
+			chs = append(chs, cmd.done)
 		}
 
 		for _, p := range tc.rng.mu.pendingCmds {

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -5841,7 +5841,7 @@ func runWrongIndexTest(t *testing.T, repropose bool, withErr bool, expProposals 
 		cmd.raftCmd.MaxLeaseIndex = wrongIndex
 		tc.rng.insertRaftCommandLocked(cmd)
 		if repropose {
-			if err := tc.rng.refreshPendingCmdsLocked(noReason); err != nil {
+			if err := tc.rng.refreshPendingCmdsLocked(noReason, 0); err != nil {
 				fatalf("%s", err)
 			}
 		} else if err := tc.rng.proposePendingCmdLocked(cmd); err != nil {
@@ -6017,7 +6017,7 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 			t.Fatalf("wanted required indexes %v, got %v", expIndexes, origIndexes)
 		}
 
-		if err := tc.rng.refreshPendingCmdsLocked(noReason); err != nil {
+		if err := tc.rng.refreshPendingCmdsLocked(noReason, 0); err != nil {
 			t.Fatal(err)
 		}
 		return chs
@@ -6045,6 +6045,76 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 		}
 		return errors.New("still pending commands")
 	})
+}
+
+func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var tc testContext
+	tc.Start(t)
+	defer tc.Stop()
+
+	r := tc.rng
+	repDesc, err := r.GetReplicaDescriptor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pErr := r.redirectOnOrAcquireLease(context.Background()); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	// We tick the replica 2*RaftElectionTimeoutTicks. RaftElectionTimeoutTicks
+	// is special in that it controls how often pending commands are reproposed
+	// or refurbished.
+	electionTicks := tc.store.ctx.RaftElectionTimeoutTicks
+	for i := 0; i < 2*electionTicks; i++ {
+		// Add another pending command on each iteration.
+		r.mu.Lock()
+		id := fmt.Sprintf("%08d", i)
+		var ba roachpb.BatchRequest
+		ba.Timestamp = tc.clock.Now()
+		ba.Add(&roachpb.PutRequest{Span: roachpb.Span{Key: roachpb.Key(id)}})
+		cmd := r.prepareRaftCommandLocked(context.Background(),
+			storagebase.CmdIDKey(id), repDesc, ba)
+		r.insertRaftCommandLocked(cmd)
+		if err := r.proposePendingCmdLocked(cmd); err != nil {
+			t.Fatal(err)
+		}
+		// Build a map from command key to proposed-at-ticks.
+		m := map[storagebase.CmdIDKey]int{}
+		for id, p := range r.mu.pendingCmds {
+			m[id] = p.proposedAtTicks
+		}
+		r.mu.Unlock()
+
+		// Tick raft.
+		if err := r.tick(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Gather up the reproprosed commands.
+		r.mu.Lock()
+		var reproposed []*pendingCmd
+		for id, p := range r.mu.pendingCmds {
+			if m[id] != p.proposedAtTicks {
+				reproposed = append(reproposed, p)
+			}
+		}
+		ticks := r.mu.ticks
+		r.mu.Unlock()
+
+		// Reproposals are only performed every electionTicks. We'll need to fix
+		// this test if that changes.
+		if (ticks % electionTicks) == 0 {
+			if len(reproposed) != i-1 {
+				t.Fatalf("%d: expected %d reproprosed commands, but found %+v", i, i-1, reproposed)
+			}
+		} else {
+			if len(reproposed) != 0 {
+				t.Fatalf("%d: expected no reproprosed commands, but found %+v", i, reproposed)
+			}
+		}
+	}
 }
 
 // TestReplicaDoubleRefurbish exercises a code path in which a command is seen


### PR DESCRIPTION
Replica.tick() was previously reproposing any pending commands every
RaftElectionTimeoutTicks (1.5s). We now keep track of when a Raft
command was proposed and only repropose the command if it is older than
RaftElectionTimeoutTicks. This massively reduces unnecessary
reproposals.

See #8176.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8322)

<!-- Reviewable:end -->
