### PR TITLE
build: make builder.sh work on mac

### DIFF
--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -54,7 +54,7 @@ import (
 
 const (
 	builderImage     = "cockroachdb/builder"
-	builderTag       = "20160802-150300"
+	builderTag       = "20160804-184345"
 	builderImageFull = builderImage + ":" + builderTag
 	networkName      = "cockroachdb_acceptance"
 )

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,6 +1,9 @@
 # Do not add environment-specific entries here (see the top-level .gitignore
 # for reasoning and alternatives).
 
+# builder container's home directory
+/builder_home
+
 # NPM
 node_modules
 npm.installed

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7rc3
+FROM golang:1.7rc4
 
 MAINTAINER Peter Mattis <peter@cockroachlabs.com>
 
@@ -13,5 +13,7 @@ RUN \
  rm -rf /tmp/*
 
 ENV PATH=/opt/backtrace/bin:/third_party/llvm-build/Release+Asserts/bin:$PATH
+
+RUN chmod -R a+w $(go env GOROOT)
 
 CMD ["/bin/bash"]

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -67,10 +67,13 @@ cockroach_toplevel="$(dirname $(cd $(dirname $0); pwd))"
 # container because the container needs a $HOME (without one the default is /)
 # and because various utilities (e.g. bash writing to .bash_history) need to be
 # able to write to there.
-build_home="/root"
-passwd_file="$(mktemp)"
-user_group="$(id -u $USER):$(id -g $USER)"
-echo "$USER:x:$user_group::${build_home}:/bin/bash" > "$passwd_file"
+container_home="/root"
+host_home="${cockroach_toplevel}/build/builder_home"
+passwd_file="${host_home}/passwd"
+username=$(id -un)
+uid_gid="$(id -u):$(id -g)"
+mkdir -p "${host_home}"
+echo "${username}:x:${uid_gid}::${container_home}:/bin/bash" > "${passwd_file}"
 
 # Ensure that all directories to which the container must be able to write are
 # created as the invoking user. Docker would otherwise create them when
@@ -95,23 +98,22 @@ mkdir -p "${HOME}"/.{jspm,npm} "${gopath0}"/pkg/docker_amd64{,_race} "${gopath0}
 #
 # -i causes some commands (including `git diff`) to attempt to use
 # a pager, so we override $PAGER to disable.
-vols="--volume=${gopath0}/src:/go/src"
+vols="--volume=${passwd_file}:/etc/passwd"
+vols="${vols} --volume=${host_home}:${container_home}"
+vols="${vols} --volume=${gopath0}/src:/go/src"
 vols="${vols} --volume=${gopath0}/pkg/docker_amd64:/go/pkg/linux_amd64"
 vols="${vols} --volume=${gopath0}/pkg/docker_amd64_race:/go/pkg/linux_amd64_race"
 vols="${vols} --volume=${gopath0}/pkg/docker_amd64:/usr/local/go/pkg/linux_amd64"
 vols="${vols} --volume=${gopath0}/pkg/docker_amd64_race:/usr/local/go/pkg/linux_amd64_race"
 vols="${vols} --volume=${gopath0}/bin/docker_amd64:/go/bin"
-vols="${vols} --volume=${HOME}/.jspm:${build_home}/.jspm"
-vols="${vols} --volume=${HOME}/.npm:${build_home}/.npm"
+vols="${vols} --volume=${HOME}/.jspm:${container_home}/.jspm"
+vols="${vols} --volume=${HOME}/.npm:${container_home}/.npm"
 vols="${vols} --volume=${cockroach_toplevel}:/go/src/github.com/cockroachdb/cockroach"
-# TODO(jordan/tamird): make this home directory persistent on the host.
-vols="${vols} --volume=$(mktemp -d):${build_home}"
-vols="${vols} --volume=${passwd_file}:/etc/passwd"
 
 backtrace_dir="${cockroach_toplevel}/../../cockroachlabs/backtrace"
 if test -d "${backtrace_dir}"; then
   vols="${vols} --volume=${backtrace_dir}:/opt/backtrace"
-  vols="${vols} --volume=${backtrace_dir}/cockroach.cf:${build_home}/.coroner.cf"
+  vols="${vols} --volume=${backtrace_dir}/cockroach.cf:${container_home}/.coroner.cf"
 fi
 
 # If we're running in an environment that's using git alternates, like TeamCity,
@@ -123,10 +125,9 @@ if test -e "${alternates_file}"; then
 fi
 
 docker run -i ${tty-} ${rm} \
-  -u "${user_group}" \
+  -u "${uid_gid}" \
   ${vols} \
   --workdir="/go/src/github.com/cockroachdb/cockroach" \
-  --env="HOME=${build_home}" \
   --env="PAGER=cat" \
   --env="SKIP_BOOTSTRAP=1" \
   --env="JSPM_GITHUB_AUTH_TOKEN=${JSPM_GITHUB_AUTH_TOKEN-763c42afb2d31eb7bc150da33402a24d0e081aef}" \

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -72,6 +72,12 @@ passwd_file="$(mktemp)"
 user_group="$(id -u $USER):$(id -g $USER)"
 echo "$USER:x:$user_group::${build_home}:/bin/bash" > "$passwd_file"
 
+# Ensure that all directories to which the container must be able to write are
+# created as the invoking user. Docker would otherwise create them when
+# mounting, but that would that deny write access to the invoking user since
+# docker runs as root.
+mkdir -p "${HOME}"/.{jspm,npm} "${gopath0}"/pkg/docker_amd64{,_race} "${gopath0}/bin/docker_amd64"
+
 # Run our build container with a set of volumes mounted that will
 # allow the container to store persistent build data on the host
 # computer.


### PR DESCRIPTION
Docker for mac has a whitelist of things it'll allow you to mount, and
typical output of `mktemp` is not in the default whitelist.

This is currently preventing me from running acceptance tests locally, so I'm going to merge it on green.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8323)

<!-- Reviewable:end -->
