### PR TITLE
Revert "Enable grpc tracing. Goes into /debug/requests automatically"

### DIFF
--- a/rpc/context.go
+++ b/rpc/context.go
@@ -36,6 +36,10 @@ import (
 	circuit "github.com/rubyist/circuitbreaker"
 )
 
+func init() {
+	grpc.EnableTracing = false
+}
+
 const (
 	defaultHeartbeatInterval = 3 * time.Second
 	// The coefficient by which the maximum offset is multiplied to determine the


### PR DESCRIPTION
This reverts commit 44695cf55f7d00cf5abadfa486b54fee81c9e210.

GRPC tracing leaks memory; see #8340

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8341)

<!-- Reviewable:end -->
