### PR TITLE
storage: tweak raft log truncation heuristics

### DIFF
--- a/storage/raft_log_queue_test.go
+++ b/storage/raft_log_queue_test.go
@@ -78,9 +78,8 @@ func TestComputeTruncatableIndex(t *testing.T) {
 		{[]uint64{1, 2}, 1, 100, 1, 1},
 		{[]uint64{1, 2, 3, 4}, 3, 100, 1, 1},
 		{[]uint64{1, 2, 3, 4}, 3, 100, 2, 2},
-		// If over targetSize, should truncate to next behind replica, or quorum
-		// committed index.
-		{[]uint64{1, 2, 3, 4}, 3, 2000, 1, 2},
+		// If over targetSize, should truncate to quorum committed index.
+		{[]uint64{1, 2, 3, 4}, 3, 2000, 1, 3},
 		{[]uint64{1, 2, 3, 4}, 3, 2000, 2, 3},
 		{[]uint64{1, 2, 3, 4}, 3, 2000, 3, 3},
 		// Never truncate past raftStatus.Commit.

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -679,6 +679,9 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) *roachpb.Error {
 			}
 			continue
 		case <-ctx.Done():
+			if log.V(2) {
+				log.Infof(ctx, "%s: lease acquisition failed: %v", r, ctx.Err())
+			}
 		case <-r.store.Stopper().ShouldStop():
 		}
 		return roachpb.NewError(newNotLeaseHolderError(nil, r.store.StoreID(), r.Desc()))


### PR DESCRIPTION
Previously we targeted the range max-bytes (64 MB) as the maximum size
for the Raft log. But the Raft log can easily be significantly larger
than the range itself and applying Raft log entries is (experimentally)
more expensive than applying a snapshot. Now we target the range size
for the Raft log size.

Changed computeTruncatableIndexes to always truncate to the quorum
committed index if the Raft log is larger than the target size. The
previous logic was trying to be too clever and could get into situations
where the Raft log was larger than the target size but we wouldn't
truncate it because the behind index was not equal to the first index.

Fixes #8176. Well, not quite, but this fixes the most significant
problem there. I'll start up a new issue and investigation on the next
anomaly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8343)

<!-- Reviewable:end -->
