### PR TITLE
storage: improve raft leadership change detection

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -493,7 +493,7 @@ func TestReplicateAfterTruncation(t *testing.T) {
 
 	// Truncate the log at index+1 (log entries < N are removed, so this includes
 	// the increment).
-	truncArgs := truncateLogArgs(index + 1)
+	truncArgs := truncateLogArgs(index+1, 1)
 	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &truncArgs); err != nil {
 		t.Fatal(err)
 	}
@@ -560,6 +560,86 @@ func TestReplicateAfterTruncation(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// Test various mechanism for refreshing pending commands.
+func TestRefreshPendingCommands(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// In this scenario, three different mechanisms detect the need to repropose
+	// commands. Test that each one is sufficient individually. We have this
+	// redundancy because some mechanisms respond with lower latency than others,
+	// but each has some scenarios (not currently tested) in which it is
+	// insufficient on its own. In addition, there is a fourth reproposal
+	// mechanism (reasonNewLeaderOrConfigChange) which is not relevant to this
+	// scenario.
+	testCases := []storage.StoreTestingKnobs{
+		{DisableRefreshReasonNewLeader: true, DisableRefreshReasonTicks: true},
+		{DisableRefreshReasonSnapshotApplied: true, DisableRefreshReasonTicks: true},
+		{DisableRefreshReasonNewLeader: true, DisableRefreshReasonSnapshotApplied: true},
+	}
+	for _, c := range testCases {
+		func() {
+			ctx := storage.TestStoreContext()
+			ctx.TestingKnobs = c
+			mtc := &multiTestContext{storeContext: &ctx}
+			mtc.Start(t, 3)
+			defer mtc.Stop()
+
+			rangeID := roachpb.RangeID(1)
+			mtc.replicateRange(rangeID, 1, 2)
+
+			// Put some data in the range so we'll have something to test for.
+			incArgs := incrementArgs([]byte("a"), 5)
+			if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); err != nil {
+				t.Fatal(err)
+			}
+
+			// Wait for all nodes to catch up.
+			mtc.waitForValues(roachpb.Key("a"), []int64{5, 5, 5})
+
+			// Stop node 2; while it is down write some more data.
+			mtc.stopStore(2)
+
+			if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); err != nil {
+				t.Fatal(err)
+			}
+
+			// Get the last increment's log index.
+			rng, err := mtc.stores[0].GetReplica(1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			index, err := rng.GetLastIndex()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Truncate the log at index+1 (log entries < N are removed, so this includes
+			// the increment).
+			truncArgs := truncateLogArgs(index+1, rangeID)
+			if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &truncArgs); err != nil {
+				t.Fatal(err)
+			}
+
+			// Expire existing leases (i.e. move the clock forward).
+			mtc.expireLeases()
+
+			// Restart node 2 and wait for the snapshot to be applied. Note that
+			// waitForValues reads directly from the engine.
+			mtc.restartStore(2)
+			mtc.waitForValues(roachpb.Key("a"), []int64{10, 10, 10})
+
+			// Send an increment to the restarted node. If we don't refresh pending
+			// commands appropriately, the range lease command will not get
+			// re-proposed when we discover the new leader.
+			if _, err := client.SendWrapped(rg1(mtc.stores[2]), nil, &incArgs); err != nil {
+				t.Fatal(err)
+			}
+
+			mtc.waitForValues(roachpb.Key("a"), []int64{15, 15, 15})
+		}()
+	}
 }
 
 // TestStoreRangeUpReplicate verifies that the replication queue will notice

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -931,10 +931,10 @@ func incrementArgs(key roachpb.Key, inc int64) roachpb.IncrementRequest {
 	}
 }
 
-func truncateLogArgs(index uint64) roachpb.TruncateLogRequest {
+func truncateLogArgs(index uint64, rangeID roachpb.RangeID) roachpb.TruncateLogRequest {
 	return roachpb.TruncateLogRequest{
-		Span:  roachpb.Span{},
-		Index: index,
+		Index:   index,
+		RangeID: rangeID,
 	}
 }
 

--- a/storage/refreshraftreason_string.go
+++ b/storage/refreshraftreason_string.go
@@ -4,9 +4,9 @@ package storage
 
 import "fmt"
 
-const _refreshRaftReason_name = "noReasonreasonNewLeaderOrConfigChangereasonReplicaIDChangedreasonTicks"
+const _refreshRaftReason_name = "noReasonreasonNewLeaderreasonNewLeaderOrConfigChangereasonSnapshotAppliedreasonReplicaIDChangedreasonTicks"
 
-var _refreshRaftReason_index = [...]uint8{0, 8, 37, 59, 70}
+var _refreshRaftReason_index = [...]uint8{0, 8, 23, 52, 73, 95, 106}
 
 func (i refreshRaftReason) String() string {
 	if i < 0 || i >= refreshRaftReason(len(_refreshRaftReason_index)-1) {

--- a/storage/store.go
+++ b/storage/store.go
@@ -556,6 +556,15 @@ type StoreTestingKnobs struct {
 	DisableReplicateQueue bool
 	// DisableScanner disables the replica scanner.
 	DisableScanner bool
+	// DisableRefreshReasonTicks disables refreshing pending commands when a new
+	// leader is discovered.
+	DisableRefreshReasonNewLeader bool
+	// DisableRefreshReasonTicks disables refreshing pending commands when a
+	// snapshot is applied.
+	DisableRefreshReasonSnapshotApplied bool
+	// DisableRefreshReasonTicks disables refreshing pending commands
+	// periodically.
+	DisableRefreshReasonTicks bool
 }
 
 var _ base.ModuleTestingKnobs = &StoreTestingKnobs{}


### PR DESCRIPTION
Watch for changes to Raft leadership via changes to
RaftStatus.SoftState.Lead. Refresh pending commands when the leadership
changes.

See #8344.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8346)

<!-- Reviewable:end -->
