### PR TITLE
storage: Remove direct access to addWriteCmd from intentResolver

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -3332,7 +3332,7 @@ func TestReplicaResolveIntentNoWait(t *testing.T) {
 	setupResolutionTest(t, tc, roachpb.Key("a") /* irrelevant */, splitKey, true /* commit */)
 	txn := newTransaction("name", key, 1, enginepb.SERIALIZABLE, tc.clock)
 	txn.Status = roachpb.COMMITTED
-	if pErr := tc.store.intentResolver.resolveIntents(context.Background(), tc.rng,
+	if pErr := tc.store.intentResolver.resolveIntents(context.Background(),
 		[]roachpb.Intent{{
 			Span:   roachpb.Span{Key: key},
 			Txn:    txn.TxnMeta,
@@ -5305,7 +5305,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 			if err := ba.SetActiveTimestamp(tc.clock.Now); err != nil {
 				t.Fatal(err)
 			}
-			br, pErr := tc.rng.addWriteCmd(ctx, ba, nil /* wg */)
+			br, pErr := tc.rng.addWriteCmd(ctx, ba)
 			if pErr == nil {
 				if !cancelEarly {
 					// We cancelled the context while the command was already

--- a/storage/store.go
+++ b/storage/store.go
@@ -2207,7 +2207,7 @@ func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.
 			// after our operation started. This allows us to not have to
 			// restart for uncertainty as we come back and read.
 			h.Timestamp.Forward(now)
-			pErr = s.intentResolver.processWriteIntentError(ctx, pErr, rng, args, h, pushType)
+			pErr = s.intentResolver.processWriteIntentError(ctx, pErr, args, h, pushType)
 			// Preserve the error index.
 			pErr.Index = index
 		}


### PR DESCRIPTION
This change sends everything through the DistSender instead of accessing Replica internals (without synchronizing with the Store). This removes an optimization that improved latency under contention, but it is part of a broader effort to clean up and simplify the relationship between Store and Replica. 

Fixes #7933

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8362)

<!-- Reviewable:end -->
