### PR TITLE
server,ts: Use consistent reads for admin UI

### DIFF
--- a/server/status.go
+++ b/server/status.go
@@ -110,12 +110,6 @@ const (
 // Pattern for local used when determining the node ID.
 var localRE = regexp.MustCompile(`(?i)local`)
 
-func inconsistentBatch() *client.Batch {
-	b := &client.Batch{}
-	b.Header.ReadConsistency = roachpb.INCONSISTENT
-	return b
-}
-
 type metricMarshaler interface {
 	json.Marshaler
 	PrintAsText(io.Writer) error
@@ -484,7 +478,7 @@ func (s *statusServer) Nodes(ctx context.Context, req *serverpb.NodesRequest) (*
 	startKey := keys.StatusNodePrefix
 	endKey := startKey.PrefixEnd()
 
-	b := inconsistentBatch()
+	b := &client.Batch{}
 	b.Scan(startKey, endKey)
 	if err := s.db.Run(b); err != nil {
 		log.Error(ctx, err)
@@ -512,7 +506,7 @@ func (s *statusServer) Node(ctx context.Context, req *serverpb.NodeRequest) (*st
 	}
 
 	key := keys.NodeStatusKey(int32(nodeID))
-	b := inconsistentBatch()
+	b := &client.Batch{}
 	b.Get(key)
 	if err := s.db.Run(b); err != nil {
 		log.Error(ctx, err)

--- a/ts/query.go
+++ b/ts/query.go
@@ -433,7 +433,6 @@ func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) 
 		startKey := MakeDataKey(query.Name, "" /* source */, r, startNanos)
 		endKey := MakeDataKey(query.Name, "" /* source */, r, endNanos).PrefixEnd()
 		b := &client.Batch{}
-		b.Header.ReadConsistency = roachpb.INCONSISTENT
 		b.Scan(startKey, endKey)
 
 		if err := db.db.Run(b); err != nil {
@@ -442,7 +441,6 @@ func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) 
 		rows = b.Results[0].Rows
 	} else {
 		b := &client.Batch{}
-		b.Header.ReadConsistency = roachpb.INCONSISTENT
 		// Iterate over all key timestamps which may contain data for the given
 		// sources, based on the given start/end time and the resolution.
 		kd := r.KeyDuration()


### PR DESCRIPTION
Inconsistent reads don't always work because replicas can be arbitrarily
far behind. Until #8111 is fixed, we're definitely better off
doing consistent reads, and even then it's unclear whether inconsistent
reads are a net win for availability.

Fixes #8092

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8379)

<!-- Reviewable:end -->
