### PR TITLE
cli: Reduce block profile rate

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -253,7 +253,7 @@ func initBlockProfile() {
 	// The block profile can be viewed with `go tool pprof
 	// http://HOST:PORT/debug/pprof/block`
 	d := envutil.EnvOrDefaultInt64("block_profile_rate",
-		1000000 /* 1 sample per millisecond spent blocking */)
+		10000000 /* 1 sample per 10 milliseconds spent blocking */)
 	runtime.SetBlockProfileRate(int(d))
 }
 


### PR DESCRIPTION
The beta cluster is spending 6% of its CPU generating stack traces for
blocking events.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8384)

<!-- Reviewable:end -->
