### PR TITLE
scripts: Add wrapper script around pprof and stunnel

### DIFF
--- a/scripts/pprof
+++ b/scripts/pprof
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# This script wraps "go tool pprof" (and stunnel) to work better with
+# HTTPS servers using untrusted certificates (like cockroachdb). "go
+# tool pprof" has no option to ignore certificate errors, so we setup
+# stunnel forwarding to make the server look like unencrypted HTTP.
+
+set -euo pipefail
+
+server=$1
+if [ -z "${server}" ]; then
+  echo "host:port not specified, run with: $0 host:port [profile_type]"
+  exit 1
+fi
+
+profile_type=${2-profile}
+
+port=8089
+
+pidfile=$(mktemp /tmp/pprof.XXXXXX)
+stunnel -fd 0 <<EOF
+pid=${pidfile}
+[http]
+client = yes
+accept = 127.0.0.1:${port}
+connect = $1
+EOF
+
+cleanup() {
+    kill "$(cat ${pidfile})"
+    # stunnel cleans up its own pidfile on exit
+}
+
+trap cleanup EXIT
+
+go tool pprof "http://127.0.0.1:${port}/debug/pprof/${profile_type}"


### PR DESCRIPTION
"go tool pprof" has no option to ignore certificate errors, so we
set up stunnel forwarding to make the server look like unencrypted
HTTP.

This is handy for use with the beta clusters to avoid the need to download profile and binary separately.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8394)

<!-- Reviewable:end -->
