### PR TITLE
sql: create tables with foreign keys via schema changes

### DIFF
--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -270,11 +270,13 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 		}
 
 		updateCols := append(added, dropped...)
-		fkTables := TablesNeededForFKs(*tableDesc, CheckUpdates)
+		fkTables := tablesNeededForFKs(*tableDesc, CheckUpdates)
 		for k := range fkTables {
-			if fkTables[k], err = sqlbase.GetTableDescFromID(txn, k); err != nil {
+			table, err := sqlbase.GetTableDescFromID(txn, k)
+			if err != nil {
 				return err
 			}
+			fkTables[k] = tableLookup{table: table}
 		}
 		// TODO(dan): Tighten up the bound on the requestedCols parameter to
 		// makeRowUpdater.

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -64,7 +64,7 @@ func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoComm
 		requestedCols = en.tableDesc.Columns
 	}
 
-	fkTables := TablesNeededForFKs(*en.tableDesc, CheckDeletes)
+	fkTables := tablesNeededForFKs(*en.tableDesc, CheckDeletes)
 	if err := p.fillFKTableMap(fkTables); err != nil {
 		return nil, err
 	}

--- a/sql/fk.go
+++ b/sql/fk.go
@@ -24,8 +24,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-// TablesByID maps table IDs to looked up descriptors.
-type TablesByID map[sqlbase.ID]*sqlbase.TableDescriptor
+// tableLookupsByID maps table IDs to looked up descriptors or, for tables that
+// exist but are not yet public/leasable, entries with just the isAdding flag.
+type tableLookupsByID map[sqlbase.ID]tableLookup
+type tableLookup struct {
+	table    *sqlbase.TableDescriptor
+	isAdding bool
+}
 
 // FKCheck indicates a kind of FK check (delete, insert, or both).
 type FKCheck int
@@ -39,29 +44,29 @@ const (
 	CheckUpdates
 )
 
-// TablesNeededForFKs calculates the IDs of the additional TableDescriptors that
+// tablesNeededForFKs calculates the IDs of the additional TableDescriptors that
 // will be needed for FK checking delete and/or insert operations on `table`.
 //
 // NB: the returned map's values are *not* set -- higher level calling code, eg
 // in planner, should fill the map's values by acquiring leases. This function
 // is essentially just returning a slice of IDs, but the empty map can be filled
 // in place and reused, avoiding a second allocation.
-func TablesNeededForFKs(table sqlbase.TableDescriptor, usage FKCheck) TablesByID {
-	var ret TablesByID
+func tablesNeededForFKs(table sqlbase.TableDescriptor, usage FKCheck) tableLookupsByID {
+	var ret tableLookupsByID
 	for _, idx := range table.AllNonDropIndexes() {
 		if usage != CheckDeletes && idx.ForeignKey.IsSet() {
 			if ret == nil {
-				ret = make(TablesByID)
+				ret = make(tableLookupsByID)
 			}
-			ret[idx.ForeignKey.Table] = nil
+			ret[idx.ForeignKey.Table] = tableLookup{}
 		}
 		if usage != CheckInserts {
 			for _, idx := range table.AllNonDropIndexes() {
 				for _, ref := range idx.ReferencedBy {
 					if ret == nil {
-						ret = make(TablesByID)
+						ret = make(tableLookupsByID)
 					}
-					ret[ref.Table] = nil
+					ret[ref.Table] = tableLookup{}
 				}
 			}
 		}
@@ -74,7 +79,7 @@ type fkInsertHelper map[sqlbase.IndexID][]baseFKHelper
 var errSkipUnsedFK = errors.New("no columns involved in FK included in writer")
 
 func makeFKInsertHelper(
-	txn *client.Txn, table sqlbase.TableDescriptor, otherTables TablesByID, colMap map[sqlbase.ColumnID]int,
+	txn *client.Txn, table sqlbase.TableDescriptor, otherTables tableLookupsByID, colMap map[sqlbase.ColumnID]int,
 ) (fkInsertHelper, error) {
 	var fks fkInsertHelper
 	for _, idx := range table.AllNonDropIndexes() {
@@ -136,11 +141,16 @@ func (fks fkInsertHelper) checkIdx(idx sqlbase.IndexID, row parser.DTuple) error
 type fkDeleteHelper map[sqlbase.IndexID][]baseFKHelper
 
 func makeFKDeleteHelper(
-	txn *client.Txn, table sqlbase.TableDescriptor, otherTables TablesByID, colMap map[sqlbase.ColumnID]int,
+	txn *client.Txn, table sqlbase.TableDescriptor, otherTables tableLookupsByID, colMap map[sqlbase.ColumnID]int,
 ) (fkDeleteHelper, error) {
 	var fks fkDeleteHelper
 	for _, idx := range table.AllNonDropIndexes() {
 		for _, ref := range idx.ReferencedBy {
+			if otherTables[ref.Table].isAdding {
+				// We can assume that a table being added but not yet public is empty,
+				// and thus does not need to be checked for FK violations.
+				continue
+			}
 			fk, err := makeBaseFKHelper(txn, otherTables, idx, ref, colMap)
 			if err == errSkipUnsedFK {
 				continue
@@ -195,7 +205,7 @@ type fkUpdateHelper struct {
 }
 
 func makeFKUpdateHelper(
-	txn *client.Txn, table sqlbase.TableDescriptor, otherTables TablesByID, colMap map[sqlbase.ColumnID]int,
+	txn *client.Txn, table sqlbase.TableDescriptor, otherTables tableLookupsByID, colMap map[sqlbase.ColumnID]int,
 ) (fkUpdateHelper, error) {
 	ret := fkUpdateHelper{}
 	var err error
@@ -226,19 +236,17 @@ type baseFKHelper struct {
 
 func makeBaseFKHelper(
 	txn *client.Txn,
-	otherTables TablesByID,
+	otherTables tableLookupsByID,
 	writeIdx sqlbase.IndexDescriptor,
 	ref sqlbase.ForeignKeyReference,
 	colMap map[sqlbase.ColumnID]int, // col ids (for idx being written) to row offset.
 ) (baseFKHelper, error) {
-	b := baseFKHelper{txn: txn, writeIdx: writeIdx}
-	searchTable, ok := otherTables[ref.Table]
-	if !ok {
+	b := baseFKHelper{txn: txn, writeIdx: writeIdx, searchTable: otherTables[ref.Table].table}
+	if b.searchTable == nil {
 		return b, errors.Errorf("referenced table %d not in provided table map %+v", ref.Table, otherTables)
 	}
-	b.searchTable = searchTable
 	b.searchPrefix = sqlbase.MakeIndexKeyPrefix(b.searchTable, ref.Index)
-	searchIdx, err := searchTable.FindIndexByID(ref.Index)
+	searchIdx, err := b.searchTable.FindIndexByID(ref.Index)
 	if err != nil {
 		return b, err
 	}
@@ -247,13 +255,13 @@ func makeBaseFKHelper(
 		b.prefixLen = len(writeIdx.ColumnIDs)
 	}
 	b.searchIdx = searchIdx
-	ids := colIDtoRowIndexFromCols(searchTable.Columns)
+	ids := colIDtoRowIndexFromCols(b.searchTable.Columns)
 	needed := make([]bool, len(ids))
 	for _, i := range searchIdx.ColumnIDs {
 		needed[ids[i]] = true
 	}
-	isSecondary := searchTable.PrimaryIndex.ID != searchIdx.ID
-	err = b.rf.Init(searchTable, ids, searchIdx, false, isSecondary, searchTable.Columns, needed)
+	isSecondary := b.searchTable.PrimaryIndex.ID != searchIdx.ID
+	err = b.rf.Init(b.searchTable, ids, searchIdx, false, isSecondary, b.searchTable.Columns, needed)
 	if err != nil {
 		return b, err
 	}

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -150,7 +150,7 @@ func (p *planner) Insert(
 		return nil, fmt.Errorf("INSERT error: table %s has %d columns but %d values were supplied", n.Table, numInputColumns, expressions)
 	}
 
-	fkTables := TablesNeededForFKs(*en.tableDesc, CheckInserts)
+	fkTables := tablesNeededForFKs(*en.tableDesc, CheckInserts)
 	if err := p.fillFKTableMap(fkTables); err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (p *planner) Insert(
 				return nil, err
 			}
 
-			fkTables := TablesNeededForFKs(*en.tableDesc, CheckUpdates)
+			fkTables := tablesNeededForFKs(*en.tableDesc, CheckUpdates)
 			if err := p.fillFKTableMap(fkTables); err != nil {
 				return nil, err
 			}

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -300,12 +300,17 @@ func (p *planner) checkTestingVerifyMetadataOrDie(
 	p.testingVerifyMetadataFn = nil
 }
 
-func (p *planner) fillFKTableMap(m TablesByID) error {
-	var err error
+func (p *planner) fillFKTableMap(m tableLookupsByID) error {
 	for tableID := range m {
-		if m[tableID], err = p.getTableLeaseByID(tableID); err != nil {
+		table, err := p.getTableLeaseByID(tableID)
+		if err == errTableAdding {
+			m[tableID] = tableLookup{isAdding: true}
+			continue
+		}
+		if err != nil {
 			return err
 		}
+		m[tableID] = tableLookup{table: table}
 	}
 	return nil
 }

--- a/sql/rowwriter.go
+++ b/sql/rowwriter.go
@@ -150,7 +150,7 @@ type rowInserter struct {
 func makeRowInserter(
 	txn *client.Txn,
 	tableDesc *sqlbase.TableDescriptor,
-	fkTables TablesByID,
+	fkTables tableLookupsByID,
 	insertCols []sqlbase.ColumnDescriptor,
 	checkFKs bool,
 ) (rowInserter, error) {
@@ -372,7 +372,7 @@ const (
 func makeRowUpdater(
 	txn *client.Txn,
 	tableDesc *sqlbase.TableDescriptor,
-	fkTables TablesByID,
+	fkTables tableLookupsByID,
 	updateCols []sqlbase.ColumnDescriptor,
 	requestedCols []sqlbase.ColumnDescriptor,
 	updateType rowUpdaterType,
@@ -754,7 +754,7 @@ type rowDeleter struct {
 func makeRowDeleter(
 	txn *client.Txn,
 	tableDesc *sqlbase.TableDescriptor,
-	fkTables TablesByID,
+	fkTables tableLookupsByID,
 	requestedCols []sqlbase.ColumnDescriptor,
 	checkFKs bool,
 ) (rowDeleter, error) {
@@ -800,7 +800,7 @@ func makeRowDeleter(
 	if checkFKs {
 		var err error
 		if rd.fks, err = makeFKDeleteHelper(txn, *tableDesc, fkTables, fetchColIDtoRowIndex); err != nil {
-			return rowDeleter{}, nil
+			return rowDeleter{}, err
 		}
 	}
 

--- a/sql/sqlbase/structured.go
+++ b/sql/sqlbase/structured.go
@@ -1366,6 +1366,11 @@ func (desc *TableDescriptor) Deleted() bool {
 	return desc.State == TableDescriptor_DROP
 }
 
+// Adding returns true if the table is being added.
+func (desc *TableDescriptor) Adding() bool {
+	return desc.State == TableDescriptor_ADD
+}
+
 // Renamed returns true if the table is being renamed.
 func (desc *TableDescriptor) Renamed() bool {
 	return len(desc.Renames) > 0

--- a/sql/table.go
+++ b/sql/table.go
@@ -146,13 +146,15 @@ func (p *planner) mustGetTableDesc(tn *parser.TableName) (*sqlbase.TableDescript
 }
 
 var errTableDeleted = errors.New("table is being deleted")
+var errTableAdding = errors.New("table is being added")
 
 func filterTableState(tableDesc *sqlbase.TableDescriptor) error {
-	if tableDesc.Deleted() {
+	switch {
+	case tableDesc.Deleted():
 		return errTableDeleted
-	}
-
-	if tableDesc.State != sqlbase.TableDescriptor_PUBLIC {
+	case tableDesc.Adding():
+		return errTableAdding
+	case tableDesc.State != sqlbase.TableDescriptor_PUBLIC:
 		return errors.Errorf("table in unknown state: %s", tableDesc.State.String())
 	}
 	return nil

--- a/sql/table.go
+++ b/sql/table.go
@@ -139,7 +139,23 @@ func (p *planner) mustGetTableDesc(tn *parser.TableName) (*sqlbase.TableDescript
 	if desc == nil {
 		return nil, sqlbase.NewUndefinedTableError(tn.String())
 	}
+	if err := filterTableState(desc); err != nil {
+		return nil, err
+	}
 	return desc, nil
+}
+
+var errTableDeleted = errors.New("table is being deleted")
+
+func filterTableState(tableDesc *sqlbase.TableDescriptor) error {
+	if tableDesc.Deleted() {
+		return errTableDeleted
+	}
+
+	if tableDesc.State != sqlbase.TableDescriptor_PUBLIC {
+		return errors.Errorf("table in unknown state: %s", tableDesc.State.String())
+	}
+	return nil
 }
 
 // getTableLease implements the SchemaAccessor interface.
@@ -159,7 +175,14 @@ func (p *planner) getTableLease(tn *parser.TableName) (*sqlbase.TableDescriptor,
 		//   so they cannot be leased. Instead, we simply return the static
 		//   descriptor and rely on the immutability privileges set on the
 		//   descriptors to cause upper layers to reject mutations statements.
-		return p.mustGetTableDesc(tn)
+		tbl, err := p.mustGetTableDesc(tn)
+		if err != nil {
+			return nil, err
+		}
+		if err := filterTableState(tbl); err != nil {
+			return nil, err
+		}
+		return tbl, nil
 	}
 
 	dbID, err := p.getDatabaseID(tn.Database())
@@ -207,6 +230,17 @@ func (p *planner) getTableLease(tn *parser.TableName) (*sqlbase.TableDescriptor,
 func (p *planner) getTableLeaseByID(tableID sqlbase.ID) (*sqlbase.TableDescriptor, error) {
 	if log.V(2) {
 		log.Infof(p.ctx(), "planner acquiring lease on table ID %d", tableID)
+	}
+
+	if testDisableTableLeases {
+		table, err := sqlbase.GetTableDescFromID(p.txn, tableID)
+		if err != nil {
+			return nil, err
+		}
+		if err := filterTableState(table); err != nil {
+			return nil, err
+		}
+		return table, nil
 	}
 
 	// First, look to see if we already have a lease for this table -- including

--- a/sql/tablewriter.go
+++ b/sql/tablewriter.go
@@ -212,7 +212,7 @@ type tableUpserter struct {
 	// Set by init.
 	txn                   *client.Txn
 	tableDesc             *sqlbase.TableDescriptor
-	fkTables              TablesByID // for fk checks in update case
+	fkTables              tableLookupsByID // for fk checks in update case
 	ru                    rowUpdater
 	updateColIDtoRowIndex map[sqlbase.ColumnID]int
 	a                     sqlbase.DatumAlloc

--- a/sql/tablewriter.go
+++ b/sql/tablewriter.go
@@ -527,6 +527,12 @@ func (td *tableDeleter) fastPathAvailable(ctx context.Context) bool {
 		}
 		return false
 	}
+	if len(td.rd.helper.tableDesc.PrimaryIndex.ReferencedBy) > 0 {
+		if log.V(2) {
+			log.Info(ctx, "delete forced to scan: table is referenced by foreign keys")
+		}
+		return false
+	}
 	return true
 }
 

--- a/sql/testdata/fk
+++ b/sql/testdata/fk
@@ -327,3 +327,20 @@ DELETE FROM pairs WHERE id = 2
 #
 # statement error foreign key violation: value \[2\] not found in other@primary \[x\]
 # INSERT INTO crossdb(y) VALUES (2)
+
+
+# since PKs are handled differently than other indexes, check pk<->pk ref with no other indexes in play.
+statement ok
+CREATE TABLE foo (id INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE bar (id INT PRIMARY KEY REFERENCES foo)
+
+statement ok
+INSERT INTO foo VALUES (2)
+
+statement ok
+INSERT INTO bar VALUES (2)
+
+statement error foreign key violation: value\(s\) \[2] in columns \[id\] referenced in table "bar"
+DELETE FROM foo

--- a/sql/testdata/fk
+++ b/sql/testdata/fk
@@ -66,6 +66,9 @@ CREATE TABLE reviews (
 statement ok
 INSERT INTO orders VALUES (1, '780', 2);
 
+statement error foreign key violation: value\(s\) \['780'\] in columns \[sku\] referenced in table "orders"
+DELETE FROM products
+
 statement ok
 INSERT INTO reviews VALUES (1, '780', 2, 1, NULL)
 
@@ -315,20 +318,6 @@ UPDATE pairs SET dest = 'too' WHERE id = 2
 statement error foreign key violation: value\(s\) \[200 'two'\] in columns \[src dest\] referenced in table "refpairs"
 DELETE FROM pairs WHERE id = 2
 
-# Disabled due to issue #8392.
-# statement ok
-# CREATE DATABASE test2
-#
-# statement ok
-# CREATE TABLE test2.other(x INT PRIMARY KEY)
-#
-# statement ok
-# CREATE TABLE crossdb (y INT PRIMARY KEY, FOREIGN KEY (y) REFERENCES test2.other(x))
-#
-# statement error foreign key violation: value \[2\] not found in other@primary \[x\]
-# INSERT INTO crossdb(y) VALUES (2)
-
-
 # since PKs are handled differently than other indexes, check pk<->pk ref with no other indexes in play.
 statement ok
 CREATE TABLE foo (id INT PRIMARY KEY)
@@ -344,3 +333,24 @@ INSERT INTO bar VALUES (2)
 
 statement error foreign key violation: value\(s\) \[2] in columns \[id\] referenced in table "bar"
 DELETE FROM foo
+
+statement ok
+CREATE DATABASE otherdb
+
+statement ok
+CREATE TABLE otherdb.othertable (id INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE crossdb (id INT PRIMARY KEY, FOREIGN KEY (id) REFERENCES otherdb.othertable)
+
+statement error foreign key violation: value \[2\] not found in othertable@primary \[id\]
+INSERT INTO crossdb VALUES (2)
+
+statement ok
+INSERT INTO otherdb.othertable VALUES (1), (2)
+
+statement ok
+INSERT INTO crossdb VALUES (2)
+
+statement error foreign key violation: value\(s\) \[2] in columns \[id\] referenced in table "crossdb"
+DELETE FROM otherdb.othertable WHERE id = 2

--- a/sql/truncate.go
+++ b/sql/truncate.go
@@ -51,7 +51,7 @@ func (p *planner) Truncate(n *parser.Truncate) (planNode, error) {
 			return nil, err
 		}
 
-		fkTables := TablesNeededForFKs(*tableDesc, CheckDeletes)
+		fkTables := tablesNeededForFKs(*tableDesc, CheckDeletes)
 		if err := p.fillFKTableMap(fkTables); err != nil {
 			return nil, err
 		}

--- a/sql/update.go
+++ b/sql/update.go
@@ -170,7 +170,7 @@ func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoComm
 		requestedCols = en.tableDesc.Columns
 	}
 
-	fkTables := TablesNeededForFKs(*en.tableDesc, CheckUpdates)
+	fkTables := tablesNeededForFKs(*en.tableDesc, CheckUpdates)
 	if err := p.fillFKTableMap(fkTables); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
also a fix a bug that let fast-deletes of tables with no non-pk indexes skip FK checks (if the PK was referenced), makes `leaseByID` obey the `testDisableTableLeases` flag.

Fixes #8392.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8399)

<!-- Reviewable:end -->
