### PR TITLE
sql: check FKs if PK referenced

### DIFF
--- a/sql/tablewriter.go
+++ b/sql/tablewriter.go
@@ -527,6 +527,12 @@ func (td *tableDeleter) fastPathAvailable(ctx context.Context) bool {
 		}
 		return false
 	}
+	if len(td.rd.helper.tableDesc.PrimaryIndex.ReferencedBy) > 0 {
+		if log.V(2) {
+			log.Info(ctx, "delete forced to scan: table is referenced by foreign keys")
+		}
+		return false
+	}
 	return true
 }
 

--- a/sql/testdata/fk
+++ b/sql/testdata/fk
@@ -314,3 +314,19 @@ UPDATE pairs SET dest = 'too' WHERE id = 2
 
 statement error foreign key violation: value\(s\) \[200 'two'\] in columns \[src dest\] referenced in table "refpairs"
 DELETE FROM pairs WHERE id = 2
+
+# since PKs are handled differently than other indexes, check pk<->pk ref with no other indexes in play.
+statement ok
+CREATE TABLE foo (id INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE bar (id INT PRIMARY KEY REFERENCES foo)
+
+statement ok
+INSERT INTO foo VALUES (2)
+
+statement ok
+INSERT INTO bar VALUES (2)
+
+statement error foreign key violation: value\(s\) \[2] in columns \[id\] referenced in table "bar"
+DELETE FROM foo


### PR DESCRIPTION
even if no secondary indexes exist, if the pk is referenced, the fast-path is unsafe.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8410)

<!-- Reviewable:end -->
