### PR TITLE
storage: De-flake TestReplicaBurstPendingCommandsAndRepropose

### DIFF
--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -5953,7 +5953,13 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var tc testContext
-	tc.Start(t)
+	sc := TestStoreContext()
+	// Ensure that the refresh call in this test is the only reason
+	// commands will get reproposed.
+	// TODO(bdarnell): why is this single-node test seeing a "new
+	// leader" (on rare occasions)? #8422
+	sc.TestingKnobs.DisableRefreshReasonNewLeader = true
+	tc.StartWithStoreContext(t, sc)
 	defer tc.Stop()
 
 	const num = 10


### PR DESCRIPTION
Fixes #8385 

I could reproduce the failure easily at first (and added logging to see the reasons of the two repropsals), but when I added enough logging to see why we might be getting new leaders I was no longer able to reproduce it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8419)

<!-- Reviewable:end -->
