### PR TITLE
Rework metrics

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -118,12 +118,12 @@ const (
 
 // Gossip metrics counter names.
 const (
-	ConnectionsIncomingGaugeName = "connections.incoming"
-	ConnectionsOutgoingGaugeName = "connections.outgoing"
-	InfosSentRatesName           = "infos.sent"
-	InfosReceivedRatesName       = "infos.received"
-	BytesSentRatesName           = "bytes.sent"
-	BytesReceivedRatesName       = "bytes.received"
+	ConnectionsIncomingGaugeName = "gossip.connections.incoming"
+	ConnectionsOutgoingGaugeName = "gossip.connections.outgoing"
+	InfosSentRatesName           = "gossip.infos.sent"
+	InfosReceivedRatesName       = "gossip.infos.received"
+	BytesSentRatesName           = "gossip.bytes.sent"
+	BytesReceivedRatesName       = "gossip.bytes.received"
 )
 
 // Storage is an interface which allows the gossip instance

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -115,24 +115,24 @@ type TxnMetrics struct {
 }
 
 const (
-	abortsPrefix     = "aborts"
-	commitsPrefix    = "commits"
-	commits1PCPrefix = "commits1PC"
-	abandonsPrefix   = "abandons"
-	durationsPrefix  = "durations"
-	restartsKey      = "restarts"
+	abortsPrefix     = "txn.aborts"
+	commitsPrefix    = "txn.commits"
+	commits1PCPrefix = "txn.commits1PC"
+	abandonsPrefix   = "txn.abandons"
+	durationsPrefix  = "txn.durations"
+	restartsKey      = "txn.restarts"
 )
 
 // NewTxnMetrics returns a new instance of txnMetrics that contains metrics which have
 // been registered with the provided Registry.
-func NewTxnMetrics(txnRegistry *metric.Registry) *TxnMetrics {
+func NewTxnMetrics(registry *metric.Registry) *TxnMetrics {
 	return &TxnMetrics{
-		Aborts:     txnRegistry.Rates(abortsPrefix),
-		Commits:    txnRegistry.Rates(commitsPrefix),
-		Commits1PC: txnRegistry.Rates(commits1PCPrefix),
-		Abandons:   txnRegistry.Rates(abandonsPrefix),
-		Durations:  txnRegistry.Latency(durationsPrefix),
-		Restarts:   txnRegistry.Histogram(restartsKey, 60*time.Second, 100, 3),
+		Aborts:     registry.Rates(abortsPrefix),
+		Commits:    registry.Rates(commitsPrefix),
+		Commits1PC: registry.Rates(commits1PCPrefix),
+		Abandons:   registry.Rates(abandonsPrefix),
+		Durations:  registry.Latency(durationsPrefix),
+		Restarts:   registry.Histogram(restartsKey, 60*time.Second, 100, 3),
 	}
 }
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -101,7 +101,7 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	ctx.DB = client.NewDB(sender)
 	ctx.Transport = storage.NewDummyRaftTransport()
 	ctx.Tracer = tracer
-	node := NewNode(ctx, status.NewMetricsRecorder(ctx.Clock), stopper,
+	node := NewNode(ctx, status.NewMetricsRecorder(ctx.Clock), metric.NewRegistry(), stopper,
 		kv.NewTxnMetrics(metric.NewRegistry()), sql.MakeEventLogger(nil))
 	roachpb.RegisterInternalServer(grpcServer, node)
 	return grpcServer, ln.Addr(), ctx.Clock, node, stopper

--- a/server/status/recorder.go
+++ b/server/status/recorder.go
@@ -78,50 +78,48 @@ type storeMetrics interface {
 // store hosted by the node. There are slight differences in the way these are
 // recorded, and they are thus kept separate.
 type MetricsRecorder struct {
-	// nodeRegistry contains, as subregistries, the multiple component-specific
-	// registries which are recorded as "node level" metrics.
-	nodeRegistry *metric.Registry
-
-	// Fields below are locked by this mutex.
 	mu struct {
 		syncutil.Mutex
+		// nodeRegistry contains, as subregistries, the multiple component-specific
+		// registries which are recorded as "node level" metrics.
+		nodeRegistry *metric.Registry
+		desc         roachpb.NodeDescriptor
+		startedAt    int64
+
 		// storeRegistries contains a registry for each store on the node. These
 		// are not stored as subregistries, but rather are treated as wholly
 		// independent.
 		storeRegistries map[roachpb.StoreID]*metric.Registry
-		nodeID          roachpb.NodeID
 		clock           *hlc.Clock
+		stores          map[roachpb.StoreID]storeMetrics
 
 		// Counts to help optimize slice allocation.
 		lastDataCount        int
 		lastSummaryCount     int
 		lastNodeMetricCount  int
 		lastStoreMetricCount int
-
-		startedAt int64
-		desc      roachpb.NodeDescriptor
-		stores    map[roachpb.StoreID]storeMetrics
 	}
 }
 
 // NewMetricsRecorder initializes a new MetricsRecorder object that uses the
 // given clock.
 func NewMetricsRecorder(clock *hlc.Clock) *MetricsRecorder {
-	mr := &MetricsRecorder{
-		nodeRegistry: metric.NewRegistry(),
-	}
+	mr := &MetricsRecorder{}
 	mr.mu.storeRegistries = make(map[roachpb.StoreID]*metric.Registry)
 	mr.mu.stores = make(map[roachpb.StoreID]storeMetrics)
 	mr.mu.clock = clock
 	return mr
 }
 
-// AddNodeRegistry adds a node-level registry to this recorder. Each node-level
-// registry has a 'prefix format' which is used to add a prefix to the name of
-// all metrics in that registry while recording (see the metric.Registry object
-// for more information on prefix format strings).
-func (mr *MetricsRecorder) AddNodeRegistry(prefixFmt string, registry *metric.Registry) {
-	mr.nodeRegistry.MustAdd(prefixFmt, registry)
+// AddNode adds the Registry from an initialized node, along with its descriptor
+// and start time.
+func (mr *MetricsRecorder) AddNode(reg *metric.Registry, desc roachpb.NodeDescriptor,
+	startedAt int64) {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+	mr.mu.nodeRegistry = reg
+	mr.mu.desc = desc
+	mr.mu.startedAt = startedAt
 }
 
 // AddStore adds the Registry from the provided store as a store-level registry
@@ -137,23 +135,12 @@ func (mr *MetricsRecorder) AddStore(store storeMetrics) {
 	mr.mu.stores[storeID] = store
 }
 
-// NodeStarted should be called on the recorder once the associated node has
-// received its Node ID; this indicates that it is appropriate to begin
-// recording statistics for this node.
-func (mr *MetricsRecorder) NodeStarted(desc roachpb.NodeDescriptor, startedAt int64) {
-	mr.mu.Lock()
-	defer mr.mu.Unlock()
-	mr.mu.desc = desc
-	mr.mu.nodeID = desc.NodeID
-	mr.mu.startedAt = startedAt
-}
-
 // MarshalJSON returns an appropriate JSON representation of the current values
 // of the metrics being tracked by this recorder.
 func (mr *MetricsRecorder) MarshalJSON() ([]byte, error) {
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
-	if mr.mu.nodeID == 0 {
+	if mr.mu.nodeRegistry == nil {
 		// We haven't yet processed initialization information; return an empty
 		// JSON object.
 		if log.V(1) {
@@ -162,7 +149,7 @@ func (mr *MetricsRecorder) MarshalJSON() ([]byte, error) {
 		return []byte("{}"), nil
 	}
 	topLevel := map[string]interface{}{
-		fmt.Sprintf("node.%d", mr.mu.nodeID): mr.nodeRegistry,
+		fmt.Sprintf("node.%d", mr.mu.desc.NodeID): mr.mu.nodeRegistry,
 	}
 	// Add collection of stores to top level. JSON requires that keys be strings,
 	// so we must convert the store ID to a string.
@@ -178,7 +165,7 @@ func (mr *MetricsRecorder) MarshalJSON() ([]byte, error) {
 func (mr *MetricsRecorder) PrintAsText(w io.Writer) error {
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
-	if mr.mu.nodeID == 0 {
+	if mr.mu.nodeRegistry == nil {
 		// We haven't yet processed initialization information; output nothing.
 		if log.V(1) {
 			log.Warning(context.TODO(), "MetricsRecorder.MarshalText() called before NodeID allocation")
@@ -186,7 +173,7 @@ func (mr *MetricsRecorder) PrintAsText(w io.Writer) error {
 		return nil
 	}
 
-	if err := mr.nodeRegistry.PrintAsText(w); err != nil {
+	if err := mr.mu.nodeRegistry.PrintAsText(w); err != nil {
 		return err
 	}
 	for _, reg := range mr.mu.storeRegistries {
@@ -203,7 +190,7 @@ func (mr *MetricsRecorder) GetTimeSeriesData() []tspb.TimeSeriesData {
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
 
-	if mr.mu.desc.NodeID == 0 {
+	if mr.mu.nodeRegistry == nil {
 		// We haven't yet processed initialization information; do nothing.
 		if log.V(1) {
 			log.Warning(context.TODO(), "MetricsRecorder.GetTimeSeriesData() called before NodeID allocation")
@@ -216,9 +203,9 @@ func (mr *MetricsRecorder) GetTimeSeriesData() []tspb.TimeSeriesData {
 	// Record time series from node-level registries.
 	now := mr.mu.clock.PhysicalNow()
 	recorder := registryRecorder{
-		registry:       mr.nodeRegistry,
+		registry:       mr.mu.nodeRegistry,
 		format:         nodeTimeSeriesPrefix,
-		source:         strconv.FormatInt(int64(mr.mu.nodeID), 10),
+		source:         strconv.FormatInt(int64(mr.mu.desc.NodeID), 10),
 		timestampNanos: now,
 	}
 	recorder.record(&data)
@@ -244,7 +231,7 @@ func (mr *MetricsRecorder) GetStatusSummary() *NodeStatus {
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
 
-	if mr.mu.nodeID == 0 {
+	if mr.mu.nodeRegistry == nil {
 		// We haven't yet processed initialization information; do nothing.
 		if log.V(1) {
 			log.Warning(context.TODO(), "MetricsRecorder.GetStatusSummary called before NodeID allocation.")
@@ -264,7 +251,7 @@ func (mr *MetricsRecorder) GetStatusSummary() *NodeStatus {
 		Metrics:       make(map[string]float64, mr.mu.lastNodeMetricCount),
 	}
 
-	eachRecordableValue(mr.nodeRegistry, func(name string, val float64) {
+	eachRecordableValue(mr.mu.nodeRegistry, func(name string, val float64) {
 		nodeStat.Metrics[name] = val
 	})
 

--- a/server/status/recorder_test.go
+++ b/server/status/recorder_test.go
@@ -136,7 +136,6 @@ func TestMetricsRecorder(t *testing.T) {
 	// store-level).
 	// ========================================
 	reg1 := metric.NewRegistry()
-	reg2 := metric.NewRegistry()
 	store1 := fakeStore{
 		storeID:  roachpb.StoreID(1),
 		desc:     storeDesc1,
@@ -149,11 +148,9 @@ func TestMetricsRecorder(t *testing.T) {
 	}
 	manual := hlc.NewManualClock(100)
 	recorder := NewMetricsRecorder(hlc.NewClock(manual.UnixNano))
-	recorder.AddNodeRegistry("one.%s", reg1)
-	recorder.AddNodeRegistry("two.%s", reg1)
 	recorder.AddStore(store1)
 	recorder.AddStore(store2)
-	recorder.NodeStarted(nodeDesc, 50)
+	recorder.AddNode(reg1, nodeDesc, 50)
 
 	// Ensure the metric system's view of time does not advance during this test
 	// as the test expects time to not advance too far which would age the actual
@@ -180,7 +177,7 @@ func TestMetricsRecorder(t *testing.T) {
 			isNode: true,
 		},
 		{
-			reg:    reg2,
+			reg:    reg1,
 			prefix: "two.",
 			source: 1,
 			isNode: true,
@@ -260,16 +257,16 @@ func TestMetricsRecorder(t *testing.T) {
 		for _, data := range metricNames {
 			switch data.typ {
 			case "gauge":
-				reg.reg.Gauge(data.name).Update(data.val)
+				reg.reg.Gauge(reg.prefix + data.name).Update(data.val)
 				addExpected(reg.prefix, data.name, reg.source, 100, data.val, reg.isNode)
 			case "floatgauge":
-				reg.reg.GaugeFloat64(data.name).Update(float64(data.val))
+				reg.reg.GaugeFloat64(reg.prefix + data.name).Update(float64(data.val))
 				addExpected(reg.prefix, data.name, reg.source, 100, data.val, reg.isNode)
 			case "counter":
-				reg.reg.Counter(data.name).Inc(data.val)
+				reg.reg.Counter(reg.prefix + data.name).Inc(data.val)
 				addExpected(reg.prefix, data.name, reg.source, 100, data.val, reg.isNode)
 			case "rate":
-				reg.reg.Rates(data.name).Add(data.val)
+				reg.reg.Rates(reg.prefix + data.name).Add(data.val)
 				addExpected(reg.prefix, data.name+"-count", reg.source, 100, data.val, reg.isNode)
 				for _, scale := range metric.DefaultTimeScales {
 					// Rate data is subject to timing errors in tests. Zero out
@@ -277,12 +274,12 @@ func TestMetricsRecorder(t *testing.T) {
 					addExpected(reg.prefix, data.name+sep+scale.Name(), reg.source, 100, 0, reg.isNode)
 				}
 			case "histogram":
-				reg.reg.Histogram(data.name, time.Second, 1000, 2).RecordValue(data.val)
+				reg.reg.Histogram(reg.prefix+data.name, time.Second, 1000, 2).RecordValue(data.val)
 				for _, q := range recordHistogramQuantiles {
 					addExpected(reg.prefix, data.name+q.suffix, reg.source, 100, data.val, reg.isNode)
 				}
 			case "latency":
-				reg.reg.Latency(data.name).RecordValue(data.val)
+				reg.reg.Latency(reg.prefix + data.name).RecordValue(data.val)
 				// Latency is simply three histograms (at different resolution
 				// time scales).
 				for _, scale := range metric.DefaultTimeScales {

--- a/server/status/runtime.go
+++ b/server/status/runtime.go
@@ -32,20 +32,20 @@ import (
 )
 
 const (
-	nameCgoCalls       = "cgocalls"
-	nameGoroutines     = "goroutines"
-	nameGoAllocBytes   = "go.allocbytes"
-	nameGoTotalBytes   = "go.totalbytes"
-	nameCgoAllocBytes  = "cgo.allocbytes"
-	nameCgoTotalBytes  = "cgo.totalbytes"
-	nameGCCount        = "gc.count"
-	nameGCPauseNS      = "gc.pause.ns"
-	nameGCPausePercent = "gc.pause.percent"
-	nameCPUUserNS      = "cpu.user.ns"
-	nameCPUUserPercent = "cpu.user.percent"
-	nameCPUSysNS       = "cpu.sys.ns"
-	nameCPUSysPercent  = "cpu.sys.percent"
-	nameRSS            = "rss"
+	nameCgoCalls       = "sys.cgocalls"
+	nameGoroutines     = "sys.goroutines"
+	nameGoAllocBytes   = "sys.go.allocbytes"
+	nameGoTotalBytes   = "sys.go.totalbytes"
+	nameCgoAllocBytes  = "sys.cgo.allocbytes"
+	nameCgoTotalBytes  = "sys.cgo.totalbytes"
+	nameGCCount        = "sys.gc.count"
+	nameGCPauseNS      = "sys.gc.pause.ns"
+	nameGCPausePercent = "sys.gc.pause.percent"
+	nameCPUUserNS      = "sys.cpu.user.ns"
+	nameCPUUserPercent = "sys.cpu.user.percent"
+	nameCPUSysNS       = "sys.cpu.sys.ns"
+	nameCPUSysPercent  = "sys.cpu.sys.percent"
+	nameRSS            = "sys.rss"
 )
 
 // getCgoMemStats is a function that fetches stats for the C++ portion of the code.
@@ -91,8 +91,7 @@ type RuntimeStatSampler struct {
 }
 
 // MakeRuntimeStatSampler constructs a new RuntimeStatSampler object.
-func MakeRuntimeStatSampler(clock *hlc.Clock) RuntimeStatSampler {
-	reg := metric.NewRegistry()
+func MakeRuntimeStatSampler(clock *hlc.Clock, reg *metric.Registry) RuntimeStatSampler {
 	return RuntimeStatSampler{
 		registry:       reg,
 		clock:          clock,
@@ -111,12 +110,6 @@ func MakeRuntimeStatSampler(clock *hlc.Clock) RuntimeStatSampler {
 		cpuSysPercent:  reg.GaugeFloat64(nameCPUSysPercent),
 		rss:            reg.Gauge(nameRSS),
 	}
-}
-
-// Registry returns the metric.Registry object in which the runtime recorder
-// stores its metric gauges.
-func (rsr RuntimeStatSampler) Registry() *metric.Registry {
-	return rsr.registry
 }
 
 // SampleEnvironment queries the runtime system for various interesting metrics,

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -52,6 +52,22 @@ var errNotRetriable = errors.New("the transaction is not in a retriable state")
 const sqlTxnName string = "sql txn"
 const sqlImplicitTxnName string = "sql txn implicit"
 
+// Fully-qualified names for metrics.
+const (
+	MetricLatencyName     = "sql.latency"
+	MetricTxnBeginName    = "sql.txn.begin.count"
+	MetricTxnCommitName   = "sql.txn.commit.count"
+	MetricTxnAbortName    = "sql.txn.abort.count"
+	MetricTxnRollbackName = "sql.txn.rollback.count"
+	MetricSelectName      = "sql.select.count"
+	MetricUpdateName      = "sql.update.count"
+	MetricInsertName      = "sql.insert.count"
+	MetricDeleteName      = "sql.delete.count"
+	MetricDdlName         = "sql.ddl.count"
+	MetricMiscName        = "sql.misc.count"
+	MetricQueryName       = "sql.query.count"
+)
+
 // TODO(radu): experimental code for testing distSQL flows.
 //    0 : disabled
 //    1 : enabled, sync mode
@@ -234,18 +250,18 @@ func NewExecutor(ctx ExecutorContext, stopper *stop.Stopper, registry *metric.Re
 		reCache: parser.NewRegexpCache(512),
 
 		registry:         registry,
-		latency:          registry.Latency("latency"),
-		txnBeginCount:    registry.Counter("txn.begin.count"),
-		txnCommitCount:   registry.Counter("txn.commit.count"),
-		txnAbortCount:    registry.Counter("txn.abort.count"),
-		txnRollbackCount: registry.Counter("txn.rollback.count"),
-		selectCount:      registry.Counter("select.count"),
-		updateCount:      registry.Counter("update.count"),
-		insertCount:      registry.Counter("insert.count"),
-		deleteCount:      registry.Counter("delete.count"),
-		ddlCount:         registry.Counter("ddl.count"),
-		miscCount:        registry.Counter("misc.count"),
-		queryCount:       registry.Counter("query.count"),
+		latency:          registry.Latency(MetricLatencyName),
+		txnBeginCount:    registry.Counter(MetricTxnBeginName),
+		txnCommitCount:   registry.Counter(MetricTxnCommitName),
+		txnAbortCount:    registry.Counter(MetricTxnAbortName),
+		txnRollbackCount: registry.Counter(MetricTxnRollbackName),
+		selectCount:      registry.Counter(MetricSelectName),
+		updateCount:      registry.Counter(MetricUpdateName),
+		insertCount:      registry.Counter(MetricInsertName),
+		deleteCount:      registry.Counter(MetricDeleteName),
+		ddlCount:         registry.Counter(MetricDdlName),
+		miscCount:        registry.Counter(MetricMiscName),
+		queryCount:       registry.Counter(MetricQueryName),
 	}
 	exec.systemConfigCond = sync.NewCond(exec.systemConfigMu.RLocker())
 

--- a/sql/metric_test.go
+++ b/sql/metric_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils"
 	"github.com/cockroachdb/cockroach/testutils/serverutils"
@@ -73,16 +74,16 @@ func TestQueryCounts(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		checkCounterEQ(t, s, "txn.begin.count", tc.txnBeginCount)
-		checkCounterEQ(t, s, "select.count", tc.selectCount)
-		checkCounterEQ(t, s, "update.count", tc.updateCount)
-		checkCounterEQ(t, s, "insert.count", tc.insertCount)
-		checkCounterEQ(t, s, "delete.count", tc.deleteCount)
-		checkCounterEQ(t, s, "ddl.count", tc.ddlCount)
-		checkCounterEQ(t, s, "misc.count", tc.miscCount)
-		checkCounterEQ(t, s, "txn.commit.count", tc.txnCommitCount)
-		checkCounterEQ(t, s, "txn.rollback.count", tc.txnRollbackCount)
-		checkCounterEQ(t, s, "txn.abort.count", 0)
+		checkCounterEQ(t, s, sql.MetricTxnBeginName, tc.txnBeginCount)
+		checkCounterEQ(t, s, sql.MetricTxnCommitName, tc.txnCommitCount)
+		checkCounterEQ(t, s, sql.MetricTxnRollbackName, tc.txnRollbackCount)
+		checkCounterEQ(t, s, sql.MetricTxnAbortName, 0)
+		checkCounterEQ(t, s, sql.MetricSelectName, tc.selectCount)
+		checkCounterEQ(t, s, sql.MetricUpdateName, tc.updateCount)
+		checkCounterEQ(t, s, sql.MetricInsertName, tc.insertCount)
+		checkCounterEQ(t, s, sql.MetricDeleteName, tc.deleteCount)
+		checkCounterEQ(t, s, sql.MetricDdlName, tc.ddlCount)
+		checkCounterEQ(t, s, sql.MetricMiscName, tc.miscCount)
 
 		// Everything after this query will also fail, so quit now to avoid deluge of errors.
 		if t.Failed() {
@@ -133,11 +134,11 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkCounterEQ(t, s, "txn.abort.count", 1)
-	checkCounterEQ(t, s, "txn.begin.count", 1)
-	checkCounterEQ(t, s, "txn.rollback.count", 0)
-	checkCounterEQ(t, s, "txn.commit.count", 0)
-	checkCounterEQ(t, s, "insert.count", 1)
+	checkCounterEQ(t, s, sql.MetricTxnAbortName, 1)
+	checkCounterEQ(t, s, sql.MetricTxnBeginName, 1)
+	checkCounterEQ(t, s, sql.MetricTxnRollbackName, 0)
+	checkCounterEQ(t, s, sql.MetricTxnCommitName, 0)
+	checkCounterEQ(t, s, sql.MetricInsertName, 1)
 }
 
 // TestErrorDuringTransaction tests that the transaction abort count goes up when a query
@@ -157,7 +158,7 @@ func TestAbortCountErrorDuringTransaction(t *testing.T) {
 		t.Fatal("Expected an error but didn't get one")
 	}
 
-	checkCounterEQ(t, s, "txn.abort.count", 1)
-	checkCounterEQ(t, s, "txn.begin.count", 1)
-	checkCounterEQ(t, s, "select.count", 1)
+	checkCounterEQ(t, s, sql.MetricTxnAbortName, 1)
+	checkCounterEQ(t, s, sql.MetricTxnBeginName, 1)
+	checkCounterEQ(t, s, sql.MetricSelectName, 1)
 }

--- a/sql/pgwire/server.go
+++ b/sql/pgwire/server.go
@@ -42,6 +42,13 @@ const (
 	ErrDraining = "server is not accepting clients"
 )
 
+// Fully-qualified names for metrics.
+const (
+	MetricConnsName    = "sql.conns"
+	MetricBytesInName  = "sql.bytesin"
+	MetricBytesOutName = "sql.bytesout"
+)
+
 const (
 	version30  = 196608
 	versionSSL = 80877103
@@ -76,9 +83,9 @@ type serverMetrics struct {
 
 func newServerMetrics(reg *metric.Registry) *serverMetrics {
 	return &serverMetrics{
-		conns:         reg.Counter("conns"),
-		bytesInCount:  reg.Counter("bytesin"),
-		bytesOutCount: reg.Counter("bytesout"),
+		conns:         reg.Counter(MetricConnsName),
+		bytesInCount:  reg.Counter(MetricBytesInName),
+		bytesOutCount: reg.Counter(MetricBytesOutName),
 	}
 }
 

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -1052,8 +1052,8 @@ func checkSQLNetworkMetrics(
 		return -1, -1, err
 	}
 
-	bytesIn := s.MustGetSQLNetworkCounter("bytesin")
-	bytesOut := s.MustGetSQLNetworkCounter("bytesout")
+	bytesIn := s.MustGetSQLNetworkCounter(pgwire.MetricBytesInName)
+	bytesOut := s.MustGetSQLNetworkCounter(pgwire.MetricBytesOutName)
 	if a, min := bytesIn, minBytesIn; a < min {
 		return bytesIn, bytesOut, errors.Errorf("bytesin %d < expected min %d", a, min)
 	}
@@ -1108,7 +1108,7 @@ func TestSQLNetworkMetrics(t *testing.T) {
 	// Verify connection counter.
 	expectConns := func(n int) {
 		util.SucceedsSoon(t, func() error {
-			if conns := s.MustGetSQLNetworkCounter("conns"); conns != int64(n) {
+			if conns := s.MustGetSQLNetworkCounter(pgwire.MetricConnsName); conns != int64(n) {
 				return errors.Errorf("connections %d != expected %d", conns, n)
 			}
 			return nil

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -485,7 +485,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 			// Also inject an error at RELEASE time, besides the error injected by magicVals.
 			injectReleaseError := true
 
-			commitCount := s.MustGetSQLCounter("txn.commit.count")
+			commitCount := s.MustGetSQLCounter(sql.MetricTxnCommitName)
 			// This is the magic. Run the txn closure until all the retries are exhausted.
 			exec(t, sqlDB, rs, func(tx *gosql.Tx) bool {
 				return runTestTxn(t, tc.magicVals, tc.expectedErr, &injectReleaseError, sqlDB, tx)
@@ -511,7 +511,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 			// Check that the commit counter was incremented. It could have been
 			// incremented by more than 1 because of the transactions we use to force
 			// aborts, plus who knows what else the server is doing in the background.
-			checkCounterGE(t, s, "txn.commit.count", commitCount+1)
+			checkCounterGE(t, s, sql.MetricTxnCommitName, commitCount+1)
 			// Clean up the table for the next test iteration.
 			_, err = sqlDB.Exec("DELETE FROM t.test WHERE true")
 			if err != nil {


### PR DESCRIPTION
- flat registries (registries no longer added to other registries)
- full metric names are specified on individual metrics
- single server.registry passed to all objects with metrics
- add nodeRegistry to recorder only once the node is started (have ID)
- use consts as names (easier for tests)

This makes finding metrics much simpler (the full name is next to the
metric declaration, as opposed to having a prefix in the registry).

Step 2 of this will be to make each metric include its own name, a help string (used in prometheus), and optional label pairs. Registries will also optionally have label pairs (eg: `store: <store ID>`).
This will change the metrics themselves and the way they get created.

Step 3 will be renaming metrics and adding help text. (eg: store metrics need a 'store' prefix in additional to a label pair). This will include updating the admin UI.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8428)

<!-- Reviewable:end -->
