### PR TITLE
kv: deflake TestClientNotReady

### DIFF
--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -477,7 +478,12 @@ func TestClientNotReady(t *testing.T) {
 		_, err := sendBatch(SendOptions{
 			Context: context.Background(),
 		}, addrs, nodeContext)
-		if !testutils.IsError(err, "connection is closing|failed fast due to transport failure") {
+		expected := strings.Join([]string{
+			"context canceled",
+			"connection is closing",
+			"failed fast due to transport failure",
+		}, "|")
+		if !testutils.IsError(err, expected) {
 			errCh <- errors.Wrap(err, "unexpected error")
 		} else {
 			close(errCh)


### PR DESCRIPTION
Upstream grpc change added a new "expected" error for an RPC when the
connection is closed.

Fixes #8367.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8432)

<!-- Reviewable:end -->
