### PR TITLE
storage: De-flake TestChangeReplicasDescriptorInvariant

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -991,17 +991,6 @@ func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 		t.Fatalf("got unexpected error: %v", err)
 	}
 
-	// Both addReplica calls attempted to use origDesc.NextReplicaID.
-	// The failed second call should not have overwritten the cached
-	// replica descriptor from the successful first call.
-	rep, err := mtc.stores[0].GetReplica(origDesc.RangeID)
-	if err != nil {
-		t.Fatalf("failed to look up replica %s: %s", origDesc.RangeID, err)
-	}
-	if a, e := rep.GetLastFromReplicaDesc().StoreID, mtc.stores[1].Ident.StoreID; a != e {
-		t.Fatalf("expected replica %s to point to store %s, but got %s", rep, a, e)
-	}
-
 	// Add to third store with fresh descriptor.
 	if err := addReplica(2, repl.Desc()); err != nil {
 		t.Fatal(err)

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -164,9 +164,3 @@ func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
 	defer r.mu.Unlock()
 	return r.mu.tsCache.lowWater
 }
-
-func (r *Replica) GetLastFromReplicaDesc() roachpb.ReplicaDescriptor {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.mu.lastFromReplica
-}


### PR DESCRIPTION
This test used to verify behavior of the replica descriptor cache,
specifically the way it was updated for outbound raft messages. Since
merging #8125, we no longer save replica descriptors for outgoing
message, only incoming. This test would usually pass due to the incoming
messages, but occasionally those messages would be delayed enough to
make the test fail. Wrapping this part of the test in a SucceedsWithin
would also de-flake it, but this check no longer provides the value
it used to.

Fixes #8273

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8435)

<!-- Reviewable:end -->
