### PR TITLE
sql: simple backup/restore commands

### DIFF
--- a/cli/backup.go
+++ b/cli/backup.go
@@ -1,0 +1,25 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Daniel Harrison (daniel.harrison@gmail.com)
+
+// +build !experimental
+
+package cli
+
+import "github.com/spf13/cobra"
+
+// Backup is an experimental feature, this file is just a stub.
+var backupCmds []*cobra.Command

--- a/cli/backup_experimental.go
+++ b/cli/backup_experimental.go
@@ -1,0 +1,96 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Daniel Harrison (daniel.harrison@gmail.com)
+
+// +build experimental
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/sql"
+)
+
+type backupContext struct {
+	table     string
+	overwrite bool
+}
+
+var backupCtx backupContext
+
+func init() {
+	f := restoreCmd.Flags()
+	f.StringVar(&backupCtx.table, "table", "", "table or restore (or empty for all user tables)")
+	f.BoolVar(&backupCtx.overwrite, "overwrite", false, "true to overwrite existing tables")
+}
+
+func runBackup(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("output basepath argument is required")
+	}
+	base := args[0]
+
+	ctx := context.Background()
+	kvDB, stopper := makeDBClient()
+	defer stopper.Stop()
+
+	if err := sql.Backup(ctx, *kvDB, base); err != nil {
+		return err
+	}
+
+	fmt.Printf("Backed up to %s\n", base)
+	return nil
+}
+
+var backupCmd = &cobra.Command{
+	Use:   "backup [options] <basepath>",
+	Short: "backup all SQL tables",
+	Long:  "Exports a consistent snapshot of all SQL tables to storage.",
+	RunE:  runBackup,
+}
+
+func runRestore(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("input basepath argument is required")
+	}
+	base := args[0]
+
+	ctx := context.Background()
+	kvDB, stopper := makeDBClient()
+	defer stopper.Stop()
+
+	if err := sql.Restore(ctx, *kvDB, base, backupCtx.table, backupCtx.overwrite); err != nil {
+		return err
+	}
+
+	fmt.Printf("Restored from %s\n", base)
+	return nil
+}
+
+var restoreCmd = &cobra.Command{
+	Use:   "restore [options] <basepath>",
+	Short: "restore SQL tables from a backup",
+	Long:  "Imports one or all SQL tables, restoring them to a previously snapshotted state.",
+	RunE:  runRestore,
+}
+
+var backupCmds = []*cobra.Command{backupCmd, restoreCmd}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -87,6 +87,7 @@ func init() {
 		versionCmd,
 		debugCmd,
 	)
+	cockroachCmd.AddCommand(backupCmds...)
 }
 
 // Run ...

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -459,6 +459,7 @@ func init() {
 	clientCmds = append(clientCmds, userCmds...)
 	clientCmds = append(clientCmds, zoneCmds...)
 	clientCmds = append(clientCmds, nodeCmds...)
+	clientCmds = append(clientCmds, backupCmds...)
 	for _, cmd := range clientCmds {
 		f := cmd.PersistentFlags()
 		f.StringVar(&connHost, cliflags.HostName, envutil.EnvOrDefaultString(cliflags.HostName, ""), usageEnv(forClient(cliflags.HostName)))

--- a/sql/backup.go
+++ b/sql/backup.go
@@ -1,0 +1,266 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Daniel Harrison (daniel.harrison@gmail.com)
+
+package sql
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/internal/client"
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/storage/engine"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/pkg/errors"
+)
+
+const (
+	dataSSTableName = "data.sst"
+)
+
+func allRangeDescriptors(txn *client.Txn) ([]roachpb.RangeDescriptor, error) {
+	// TODO(dan): Iterate with some batch size.
+	rows, err := txn.Scan(keys.MetaMin, keys.MetaMax, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "scan failed")
+	}
+
+	rangeDescs := make([]roachpb.RangeDescriptor, len(rows))
+	for i, row := range rows {
+		if err := row.ValueProto(&rangeDescs[i]); err != nil {
+			return nil, errors.Wrapf(err, "%s: unable to unmarshal range descriptor", row.Key)
+		}
+	}
+	return rangeDescs, nil
+}
+
+// Backup exports a snapshot of every kv entry into ranged sstables.
+//
+// The output is an sstable per range with files in the following locations:
+// - /<base>/<node_id>/<key_range>/data.sst
+// - <base> is given by the user and is expected to eventually be cloud storage
+// - The <key_range>s are non-overlapping.
+//
+// TODO(dan): Bikeshed this directory structure and naming.
+func Backup(ctx context.Context, db client.DB, base string) (retErr error) {
+	// TODO(dan): Optionally take a start time for an incremental backup.
+	// TODO(dan): Take a uri for the path prefix and support various cloud storages.
+	// TODO(dan): Figure out how permissions should work. #6713 is tracking this
+	// for grpc.
+
+	// TODO(dan): Pick an appropriate end time and set it in the txn.
+	txn := client.NewTxn(ctx, db)
+
+	rangeDescs, err := allRangeDescriptors(txn)
+	if err != nil {
+		return err
+	}
+
+	for _, rangeDesc := range rangeDescs {
+		nodeID := 0
+		dir := filepath.Join(base, fmt.Sprintf("%03d", nodeID))
+		dir = filepath.Join(dir, fmt.Sprintf("%x-%x", rangeDesc.StartKey, rangeDesc.EndKey))
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return err
+		}
+
+		dataStartKey := rangeDesc.StartKey.AsRawKey()
+		dataEndKey := rangeDesc.EndKey.AsRawKey()
+		if dataStartKey.Compare(keys.LocalMax) < 0 {
+			dataStartKey = keys.LocalMax
+		}
+
+		// TODO(dan): Iterate with some batch size.
+		kvs, err := txn.Scan(dataStartKey, dataEndKey, 0)
+		if err != nil {
+			return err
+		}
+		if len(kvs) == 0 {
+			log.Infof(ctx, "skipping backup of empty range %x-%x", dataStartKey, dataEndKey)
+			continue
+		}
+
+		sst := engine.MakeRocksDBSstFileWriter()
+		sstPath := filepath.Join(dir, dataSSTableName)
+		if err := sst.Open(sstPath); err != nil {
+			return err
+		}
+		defer func() {
+			if err := sst.Close(); err != nil && retErr == nil {
+				retErr = err
+			}
+		}()
+		// TODO(dan): Move all this iteration into cpp to avoid the cgo calls.
+		for _, kv := range kvs {
+			mvccKV := engine.MVCCKeyValue{
+				Key:   engine.MVCCKey{Key: kv.Key, Timestamp: kv.Value.Timestamp},
+				Value: kv.Value.RawBytes,
+			}
+			if err := sst.Add(mvccKV); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func getDescriptors(sst engine.RocksDBSstFileReader) ([]sqlbase.Descriptor, error) {
+	// TODO(dan): These descriptors should really be coming from some backup
+	// metadata sidechannel instead.
+
+	startKey := engine.MVCCKey{Key: roachpb.Key(keys.MakeTablePrefix(keys.DescriptorTableID))}
+	endKey := engine.MVCCKey{Key: startKey.Key.PrefixEnd()}
+
+	var desc sqlbase.Descriptor
+	var v roachpb.Value
+
+	var descs []sqlbase.Descriptor
+	return descs, sst.Iterate(startKey, endKey, func(kv engine.MVCCKeyValue) (bool, error) {
+		// TODO(dan): Only keep the latest.
+		v = roachpb.Value{RawBytes: kv.Value}
+		if err := v.GetProto(&desc); err != nil {
+			return true, err
+		}
+		descs = append(descs, desc)
+		return false, nil
+	})
+}
+
+// Import loads some data in sstables into the database. Only the keys between
+// startKey and endKey are loaded.
+func Import(
+	ctx context.Context,
+	sst engine.RocksDBSstFileReader,
+	txn *client.Txn,
+	startKey, endKey engine.MVCCKey,
+) error {
+	var v roachpb.Value
+	importFunc := func(kv engine.MVCCKeyValue) (bool, error) {
+		v = roachpb.Value{RawBytes: kv.Value}
+		v.ClearChecksum()
+		if log.V(3) {
+			log.Infof(ctx, "Put %s %s\n", kv.Key.Key, v.PrettyPrint())
+		}
+		if err := txn.Put(kv.Key.Key, &v); err != nil {
+			return true, err
+		}
+		return false, nil
+	}
+	return sst.Iterate(startKey, endKey, importFunc)
+}
+
+func restoreTable(
+	ctx context.Context,
+	sst engine.RocksDBSstFileReader,
+	txn *client.Txn,
+	table *sqlbase.TableDescriptor,
+	overwrite bool,
+) error {
+	log.Infof(ctx, "Restoring Table %q", table.Name)
+
+	tableStartKey := roachpb.Key(sqlbase.MakeIndexKeyPrefix(table, table.PrimaryIndex.ID))
+	tableEndKey := tableStartKey.PrefixEnd()
+
+	existingDesc, err := txn.Get(sqlbase.MakeDescMetadataKey(table.GetID()))
+	if err != nil {
+		return err
+	}
+	existingData, err := txn.Scan(tableStartKey, tableEndKey, 1)
+	if err != nil {
+		return err
+	}
+	if existingDesc.Value != nil || len(existingData) > 0 {
+		if overwrite {
+			// We're about to Put the descriptor, so don't bother deleting it.
+			if err := txn.DelRange(tableStartKey, tableEndKey); err != nil {
+				return err
+			}
+		} else {
+			return errors.Errorf("table %q already exists", table.Name)
+		}
+	}
+	tableDescKey := sqlbase.MakeDescMetadataKey(table.GetID())
+	if err := txn.Put(tableDescKey, sqlbase.WrapDescriptor(table)); err != nil {
+		return err
+	}
+
+	return Import(ctx, sst, txn, engine.MVCCKey{Key: tableStartKey}, engine.MVCCKey{Key: tableEndKey})
+}
+
+// Restore imports a SQL table (or all user SQL tables) from a set of
+// non-overlapping sstable files.
+func Restore(ctx context.Context, db client.DB, base string, table string, overwrite bool) error {
+	sst, err := engine.MakeRocksDBSstFileReader()
+	if err != nil {
+		return err
+	}
+	defer sst.Close()
+
+	// TODO(dan): Once metadata is output from Backup, use that to discover the
+	// files to import instead of walking the filesystem.
+	walkFn := func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Base(filePath) == dataSSTableName {
+			return sst.AddFile(filePath)
+		}
+		return nil
+	}
+	if err := filepath.Walk(base, walkFn); err != nil {
+		return err
+	}
+
+	descs, err := getDescriptors(sst)
+	if err != nil {
+		return err
+	}
+
+	// TODO(dan): This uses one giant transaction for the entire restore, which
+	// works for small datasets, but not for big ones.
+	txn := client.NewTxn(ctx, db)
+	if len(table) > 0 {
+		found := false
+		for _, desc := range descs {
+			if t := desc.GetTable(); t != nil && t.Name == table {
+				if err := restoreTable(ctx, sst, txn, t, overwrite); err != nil {
+					return err
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			return errors.Errorf("table not found: %s", table)
+		}
+	} else {
+		for _, desc := range descs {
+			if t := desc.GetTable(); t != nil && t.ParentID != keys.SystemDatabaseID {
+				if err := restoreTable(ctx, sst, txn, t, overwrite); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return txn.Commit()
+}

--- a/sql/backup_test.go
+++ b/sql/backup_test.go
@@ -1,0 +1,160 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Daniel Harrison (daniel.harrison@gmail.com)
+
+package sql_test
+
+import (
+	"bytes"
+	gosql "database/sql"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/internal/client"
+	"github.com/cockroachdb/cockroach/sql"
+	"github.com/cockroachdb/cockroach/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+)
+
+func setupBackupRestoreDB(t testing.TB, count int) (func(), *gosql.DB, *client.DB, string) {
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+
+	dir, err := ioutil.TempDir("", "TestBackupRestore")
+	if err != nil {
+		s.Stopper().Stop()
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		s.Stopper().Stop()
+		t.Fatal(err)
+	}
+
+	if _, err := sqlDB.Exec(`CREATE DATABASE d`); err != nil {
+		s.Stopper().Stop()
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`CREATE TABLE d.foo (a INT PRIMARY KEY, b STRING, c DECIMAL)`); err != nil {
+		s.Stopper().Stop()
+		t.Fatal(err)
+	}
+	var insert bytes.Buffer
+	insert.WriteString(`INSERT INTO d.foo VALUES `)
+	for i := 0; i < count; i++ {
+		if i != 0 {
+			insert.WriteRune(',')
+		}
+		fmt.Fprintf(&insert, `(%d, '%d', %d)`, i, i, i)
+	}
+	if _, err := sqlDB.Exec(insert.String()); err != nil {
+		s.Stopper().Stop()
+		t.Fatal(err)
+	}
+
+	cleanupFn := func() {
+		s.Stopper().Stop()
+		if err := os.RemoveAll(dir); err != nil {
+			t.Error(err)
+		}
+	}
+	return cleanupFn, sqlDB, kvDB, dir
+}
+
+func TestBackupRestore(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	count := 1000
+	cleanupFn, sqlDB, kvDB, dir := setupBackupRestoreDB(t, count)
+	defer cleanupFn()
+
+	if err := sql.Backup(context.Background(), *kvDB, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqlDB.Exec(`TRUNCATE d.foo`); err != nil {
+		t.Fatal(err)
+	}
+
+	var rowCount int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM d.foo`).Scan(&rowCount); err != nil {
+		t.Fatal(err)
+	}
+
+	if rowCount != 0 {
+		t.Fatalf("expected 0 rows but found %d", rowCount)
+	}
+
+	// TODO(dan): Shut down the cluster and restore into a fresh one.
+	if err := sql.Restore(context.Background(), *kvDB, dir, "foo", true); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM d.foo`).Scan(&rowCount); err != nil {
+		t.Fatal(err)
+	}
+
+	if rowCount != count {
+		t.Fatalf("expected %d rows but found %d", count, rowCount)
+	}
+}
+
+func runBenchmarkBackup(b *testing.B, count int) {
+	cleanupFn, _, kvDB, dir := setupBackupRestoreDB(b, count)
+	defer cleanupFn()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		if err := os.RemoveAll(dir); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		if err := sql.Backup(context.Background(), *kvDB, dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBackup_1(b *testing.B)    { runBenchmarkBackup(b, 1) }
+func BenchmarkBackup_1000(b *testing.B) { runBenchmarkBackup(b, 1000) }
+
+func runBenchmarkRestore(b *testing.B, count int) {
+	cleanupFn, sqlDB, kvDB, dir := setupBackupRestoreDB(b, count)
+	defer cleanupFn()
+
+	if err := sql.Backup(context.Background(), *kvDB, dir); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		if _, err := sqlDB.Exec(`TRUNCATE d.foo`); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		if err := sql.Restore(context.Background(), *kvDB, dir, "foo", true); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRestore_1(b *testing.B)    { runBenchmarkRestore(b, 1) }
+func BenchmarkRestore_1000(b *testing.B) { runBenchmarkRestore(b, 1000) }

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -22,6 +22,7 @@ package engine
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -1422,4 +1423,109 @@ func dbIterate(rdb *C.DBEngine, engine Reader, start, end MVCCKey,
 	}
 	// Check for any errors during iteration.
 	return it.Error()
+}
+
+// RocksDBSstFileReader allows iteration over a number of non-overlapping
+// sstables exported by `RocksDBSstFileWriter`.
+type RocksDBSstFileReader struct {
+	// TODO(dan): This currently works by creating a RocksDB instance in a
+	// temporary directory that's cleaned up on `Close`. It doesn't appear that
+	// we can use an in-memory RocksDB with this, because AddFile doesn't then
+	// work with files on disk. This should also work with overlapping files.
+
+	dir     string
+	rocksDB *RocksDB
+}
+
+// MakeRocksDBSstFileReader creates a RocksDBSstFileReader that uses a scrach
+// directory which is cleaned up by `Close`.
+func MakeRocksDBSstFileReader() (RocksDBSstFileReader, error) {
+	stopper := stop.NewStopper()
+
+	dir, err := ioutil.TempDir("", "RocksDBSstFileReader")
+	if err != nil {
+		return RocksDBSstFileReader{}, err
+	}
+
+	// TODO(dan): I pulled all these magic numbers out of nowhere. Make them
+	// less magic.
+	cache := NewRocksDBCache(1 << 20)
+	rocksDB := NewRocksDB(
+		roachpb.Attributes{}, dir, cache, 512<<20, 512<<20, DefaultMaxOpenFiles, stopper)
+	if err := rocksDB.Open(); err != nil {
+		return RocksDBSstFileReader{}, err
+	}
+	return RocksDBSstFileReader{dir, rocksDB}, nil
+}
+
+// AddFile links the file at the given path into a database. See the RocksDB
+// documentation on `AddFile` for the various restrictions on what can be added.
+func (fr *RocksDBSstFileReader) AddFile(path string) error {
+	if fr.rocksDB == nil {
+		return errors.New("cannot call AddFile on a closed reader")
+	}
+	return statusToError(C.DBEngineAddFile(fr.rocksDB.rdb, goToCSlice([]byte(path))))
+}
+
+// Iterate iterates over the keys between start inclusive and end
+// exclusive, invoking f() on each key/value pair.
+func (fr *RocksDBSstFileReader) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
+	if fr.rocksDB == nil {
+		return errors.New("cannot call Iterate on a closed reader")
+	}
+	return fr.rocksDB.Iterate(start, end, f)
+}
+
+// Close finishes the reader.
+func (fr *RocksDBSstFileReader) Close() {
+	if fr.rocksDB == nil {
+		return
+	}
+	fr.rocksDB.Close()
+	fr.rocksDB = nil
+	if err := os.RemoveAll(fr.dir); err != nil {
+		log.Warningf(context.TODO(), "error removing temp rocksdb directory %q: %s", fr.dir, err)
+	}
+}
+
+// RocksDBSstFileWriter creates a file suitable for importing with
+// RocksDBSstFileReader.
+type RocksDBSstFileWriter struct {
+	fw *C.DBSstFileWriter
+}
+
+// MakeRocksDBSstFileWriter creates a new RocksDBSstFileWriter with the default
+// configuration.
+func MakeRocksDBSstFileWriter() RocksDBSstFileWriter {
+	return RocksDBSstFileWriter{C.DBSstFileWriterNew()}
+}
+
+// Open creates a file at the given path for output of an sstable.
+func (fw *RocksDBSstFileWriter) Open(path string) error {
+	if fw == nil {
+		return errors.New("cannot call Open on a closed writer")
+	}
+	return statusToError(C.DBSstFileWriterOpen(fw.fw, goToCSlice([]byte(path))))
+}
+
+// Add puts a kv entry into the sstable being built. An error is returned if it
+// is not greater than any previously added entry (according to the comparator
+// configured during writer creation). `Open` must have been called. `Close`
+// cannot have been called.
+func (fw *RocksDBSstFileWriter) Add(kv MVCCKeyValue) error {
+	if fw == nil {
+		return errors.New("cannot call Open on a closed writer")
+	}
+	return statusToError(C.DBSstFileWriterAdd(fw.fw, goToCKey(kv.Key), goToCSlice(kv.Value)))
+}
+
+// Close finishes the writer, flushing any remaining writes to disk. At least
+// one kv entry must have been added.
+func (fw *RocksDBSstFileWriter) Close() error {
+	if fw.fw == nil {
+		return errors.New("writer is already closed")
+	}
+	err := statusToError(C.DBSstFileWriterClose(fw.fw))
+	fw.fw = nil
+	return err
 }

--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -29,6 +29,7 @@
 #include "rocksdb/options.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/statistics.h"
+#include "rocksdb/sst_file_writer.h"
 #include "rocksdb/table.h"
 #include "rocksdb/utilities/checkpoint.h"
 #include "rocksdb/utilities/write_batch_with_index.h"
@@ -38,6 +39,8 @@
 #include "db.h"
 #include "encoding.h"
 #include "eventlistener.h"
+
+#include <iostream>
 
 extern "C" {
 #include "_cgo_export.h"
@@ -1969,4 +1972,56 @@ DBStatus DBGetStats(DBEngine* db, DBStatsResult* stats) {
 
 DBSSTable* DBGetSSTables(DBEngine* db, int* n) {
   return db->GetSSTables(n);
+}
+
+DBStatus DBEngineAddFile(DBEngine* db, DBSlice path) {
+  rocksdb::Status status = db->rep->AddFile(ToString(path));
+  if (!status.ok()) {
+    return ToDBStatus(status);
+  }
+  return kSuccess;
+}
+
+struct DBSstFileWriter {
+  std::unique_ptr<rocksdb::Options> options;
+  rocksdb::ImmutableCFOptions ioptions;
+  rocksdb::SstFileWriter rep;
+
+  DBSstFileWriter(rocksdb::Options* o)
+      : options(o),
+        ioptions(*o),
+        rep(rocksdb::EnvOptions(), ioptions, o->comparator) {
+  }
+  virtual ~DBSstFileWriter() { }
+};
+
+DBSstFileWriter* DBSstFileWriterNew() {
+  rocksdb::Options* options = new rocksdb::Options();
+  options->comparator = &kComparator;
+  return new DBSstFileWriter(options);
+}
+
+DBStatus DBSstFileWriterOpen(DBSstFileWriter* fw, DBSlice path) {
+  rocksdb::Status status = fw->rep.Open(ToString(path));
+  if (!status.ok()) {
+    return ToDBStatus(status);
+  }
+  return kSuccess;
+}
+
+DBStatus DBSstFileWriterAdd(DBSstFileWriter* fw, DBKey key, DBSlice val) {
+  rocksdb::Status status = fw->rep.Add(EncodeKey(key), ToSlice(val));
+  if (!status.ok()) {
+    return ToDBStatus(status);
+  }
+  return kSuccess;
+}
+
+DBStatus DBSstFileWriterClose(DBSstFileWriter* fw) {
+  rocksdb::Status status = fw->rep.Finish();
+  delete fw;
+  if (!status.ok()) {
+    return ToDBStatus(status);
+  }
+  return kSuccess;
 }

--- a/storage/engine/rocksdb/db.h
+++ b/storage/engine/rocksdb/db.h
@@ -233,6 +233,28 @@ typedef struct {
 // table.
 DBSSTable* DBGetSSTables(DBEngine* db, int* n);
 
+// Bulk adds the file at the given path to a database. See the RocksDB
+// documentation on `AddFile` for the various restrictions on what can be added.
+DBStatus DBEngineAddFile(DBEngine* db, DBSlice path);
+
+typedef struct DBSstFileWriter DBSstFileWriter;
+
+// Creates a new SstFileWriter with the default configuration.
+DBSstFileWriter* DBSstFileWriterNew();
+
+// Opens a file at the given path for output of an sstable.
+DBStatus DBSstFileWriterOpen(DBSstFileWriter* fw, DBSlice path);
+
+// Adds a kv entry to the sstable being built. An error is returned if it is
+// not greater than any previously added entry (according to the comparator
+// configured during writer creation). `Open` must have been called. `Close`
+// cannot have been called.
+DBStatus DBSstFileWriterAdd(DBSstFileWriter* fw, DBKey key, DBSlice val);
+
+// Closes the writer, flushing any remaining writes to disk and freeing
+// memory and other resources. At least one kv entry must have been added.
+DBStatus DBSstFileWriterClose(DBSstFileWriter* fw);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif


### PR DESCRIPTION
As an aide for further investigations, this implements backup to and restore
from the file format that's expected to be used in the final version:
- /<base>/<timestamp>/<node_id>/<key_range>/data.sst
- <base> is given by the user and is expected to eventually be cloud storage
- The <key_range>s are non-overlapping.
- Metadata (including checksums and a mapping between key ranges and full
  paths) will be added at the same level as <node_id>.

This implementation is slow but correct (or mostly correct). Most future work
will focus on speed, but there is some additional correctness work:
- Support incremental backup/restore
- Support various cloud storages
- Resolve intents during backup
- Tighter bound on the end timestamp
- Support time travel queries on restored data
- Etc.

Initial results of the benchmarks on my laptop:

name            time/op
Backup_1-8      4.95ms ± 1%
Backup_1000-8   8.48ms ± 3%
Restore_1-8     8.62ms ±34%
Restore_1000-8   455ms ± 1%

name            alloc/op
Backup_1-8       275kB ± 0%
Backup_1000-8    847kB ± 0%
Restore_1-8      287kB ± 0%
Restore_1000-8  44.2MB ± 0%

name            allocs/op
Backup_1-8       2.07k ± 0%
Backup_1000-8    2.09k ± 0%
Restore_1-8      2.84k ± 0%
Restore_1000-8    491k ± 0%

For #8191.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8443)

<!-- Reviewable:end -->
