### PR TITLE
acceptance: download reference binaries

### DIFF
--- a/acceptance/.gitignore
+++ b/acceptance/.gitignore
@@ -4,3 +4,4 @@
 .cluster.certs.*
 *.backup
 *.tfstate
+.reference-binary-cache

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -194,10 +194,15 @@ func (l *LocalCluster) expectEvent(c *Container, msgs ...string) {
 	}
 }
 
-// OneShot runs a container, expecting it to successfully run to completion
-// and die, after which it is removed. Not goroutine safe: only one OneShot
-// can be running at once.
-// Adds the same binds as the cluster containers (certs, binary, etc).
+// OneShot runs a container, expecting it to successfully run to completion and
+// die, after which it is removed. Not goroutine safe: only one OneShot can be
+// running at once. Adds the same binds as the cluster containers (certs,
+// binary, etc).
+//
+// TODO(tamird): This should only need the certs bind. Decoupling that will
+// require changing `l.vols` to a slice, so that we can have a volume container
+// for the certs and another for everything else needed to run a cluster node
+// (logs, binary).
 func (l *LocalCluster) OneShot(
 	ref string,
 	ipo types.ImagePullOptions,
@@ -310,6 +315,7 @@ func (l *LocalCluster) initCluster() {
 	binds := []string{
 		l.CertsDir + ":/certs",
 		filepath.Join(pwd, "..") + ":/go/src/github.com/cockroachdb/cockroach",
+		filepath.Join(pwd, ".reference-binary-cache") + ":/.reference-binary-cache",
 	}
 
 	if l.logDir != "" {

--- a/acceptance/util_test.go
+++ b/acceptance/util_test.go
@@ -398,7 +398,7 @@ func testDockerSuccess(t *testing.T, name string, cmd []string) {
 
 const (
 	// NB: postgresTestTag is grepped for in circle-deps.sh, so don't rename it.
-	postgresTestTag = "20160705-1326"
+	postgresTestTag = "20160810-1626"
 	// Iterating against a locally built version of the docker image can be done
 	// by changing postgresTestImage to the hash of the container.
 	postgresTestImage = "cockroachdb/postgres-test:" + postgresTestTag

--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,7 @@ dependencies:
     - ~/.jspm
     - ~/.npm
     - ~/builder
+    - ~/cockroach/acceptance/.reference-binary-cache
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,8 @@ checkout:
     - mkdir -p       "${GOPATH%%:*}/src/github.com/cockroachdb/"
     - mv ~/cockroach "${GOPATH%%:*}/src/github.com/cockroachdb/"
     - ln -s          "${GOPATH%%:*}/src/github.com/cockroachdb/cockroach" ~/cockroach
+    - mkdir -p ~/.reference-binary-cache
+    - ln -s ~/.reference-binary-cache ~/cockroach/acceptance/.reference-binary-cache
 
 dependencies:
   override:
@@ -33,7 +35,6 @@ dependencies:
     - ~/.jspm
     - ~/.npm
     - ~/builder
-    - ~/cockroach/acceptance/.reference-binary-cache
 
 test:
   override:


### PR DESCRIPTION
instead of getting them from docker. The versions really should be bumped in the
same commit that needs the bump. Right now, they are in a separate repo
(https://github.com/cockroachdb/postgres-test).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8453)

<!-- Reviewable:end -->
