### PR TITLE
storage: return a resume Span from MVCCScan/ReverseScan/DeleteRange

### DIFF
--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -109,7 +109,7 @@ func TestRangeSplitMeta(t *testing.T) {
 	}
 
 	util.SucceedsSoon(t, func() error {
-		if _, _, err := engine.MVCCScan(context.Background(), s.Eng, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, true, nil); err != nil {
+		if _, _, _, err := engine.MVCCScan(context.Background(), s.Eng, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, true, nil); err != nil {
 			return errors.Errorf("failed to verify no dangling intents: %s", err)
 		}
 		return nil
@@ -211,7 +211,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// for timing of finishing the test writer and a possibly-ongoing
 	// asynchronous split.
 	util.SucceedsSoon(t, func() error {
-		if _, _, err := engine.MVCCScan(context.Background(), s.Eng, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, true, nil); err != nil {
+		if _, _, _, err := engine.MVCCScan(context.Background(), s.Eng, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, true, nil); err != nil {
 			return errors.Errorf("failed to verify no dangling intents: %s", err)
 		}
 		return nil

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -146,7 +146,7 @@ func TestBootstrapCluster(t *testing.T) {
 	}
 
 	// Scan the complete contents of the local database directly from the engine.
-	rows, _, err := engine.MVCCScan(context.Background(), e, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, true, nil)
+	rows, _, _, err := engine.MVCCScan(context.Background(), e, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/addressing_test.go
+++ b/storage/addressing_test.go
@@ -141,7 +141,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Scan meta keys directly from engine.
-		kvs, _, err := engine.MVCCScan(context.Background(), store.Engine(), keys.MetaMin, keys.MetaMax, math.MaxInt64, hlc.MaxTimestamp, true, nil)
+		kvs, _, _, err := engine.MVCCScan(context.Background(), store.Engine(), keys.MetaMin, keys.MetaMax, math.MaxInt64, hlc.MaxTimestamp, true, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/engine/bench_test.go
+++ b/storage/engine/bench_test.go
@@ -175,7 +175,7 @@ func runMVCCScan(emk engineMaker, numRows, numVersions, valueSize int, b *testin
 		startKey := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(keyIdx)))
 		walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 		ts := makeTS(walltime, 0)
-		kvs, _, err := MVCCScan(context.Background(), eng, startKey, keyMax, int64(numRows), ts, true, nil)
+		kvs, _, _, err := MVCCScan(context.Background(), eng, startKey, keyMax, int64(numRows), ts, true, nil)
 		if err != nil {
 			b.Fatalf("failed scan: %s", err)
 		}

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -275,10 +275,10 @@ func TestMVCCEmptyKey(t *testing.T) {
 	if err := MVCCPut(context.Background(), engine, nil, roachpb.Key{}, makeTS(0, 1), value1, nil); err == nil {
 		t.Error("expected empty key error")
 	}
-	if _, _, err := MVCCScan(context.Background(), engine, roachpb.Key{}, testKey1, math.MaxInt64, makeTS(0, 1), true, nil); err != nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, roachpb.Key{}, testKey1, math.MaxInt64, makeTS(0, 1), true, nil); err != nil {
 		t.Errorf("empty key allowed for start key in scan; got %s", err)
 	}
-	if _, _, err := MVCCScan(context.Background(), engine, testKey1, roachpb.Key{}, math.MaxInt64, makeTS(0, 1), true, nil); err == nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, testKey1, roachpb.Key{}, math.MaxInt64, makeTS(0, 1), true, nil); err == nil {
 		t.Error("expected empty key error")
 	}
 	if err := MVCCResolveWriteIntent(context.Background(), engine, nil, roachpb.Intent{}); err == nil {
@@ -649,7 +649,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 	} else if e, ok := err.(*roachpb.ReadWithinUncertaintyIntervalError); !ok {
 		t.Fatalf("wanted a ReadWithinUncertaintyIntervalError, got %+v", e)
 	}
-	if _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey2.PrefixEnd(), 10, makeTS(7, 0), true, txn); err == nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey2.PrefixEnd(), 10, makeTS(7, 0), true, txn); err == nil {
 		t.Fatal("wanted an error")
 	}
 	// Adjust MaxTimestamp and retry.
@@ -657,7 +657,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 	if _, _, err := MVCCGet(context.Background(), engine, testKey2, makeTS(7, 0), true, txn); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey2.PrefixEnd(), 10, makeTS(7, 0), true, txn); err != nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey2.PrefixEnd(), 10, makeTS(7, 0), true, txn); err != nil {
 		t.Fatal(err)
 	}
 
@@ -672,7 +672,7 @@ func TestMVCCGetUncertainty(t *testing.T) {
 	if err := MVCCPut(context.Background(), engine, nil, testKey3, makeTS(99, 0), value2, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := MVCCScan(context.Background(), engine, testKey3, testKey3.PrefixEnd(), 10, makeTS(7, 0), true, txn); err == nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, testKey3, testKey3.PrefixEnd(), 10, makeTS(7, 0), true, txn); err == nil {
 		t.Fatal("wanted an error")
 	}
 	if _, _, err := MVCCGet(context.Background(), engine, testKey3, makeTS(7, 0), true, txn); err == nil {
@@ -960,7 +960,7 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 		if scan.consistent {
 			cStr = "consistent"
 		}
-		kvs, intents, err := MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, makeTS(1, 0), scan.consistent, scan.txn)
+		kvs, _, intents, err := MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, makeTS(1, 0), scan.consistent, scan.txn)
 		wiErr, _ := err.(*roachpb.WriteIntentError)
 		if (err == nil) != (wiErr == nil) {
 			t.Errorf("%s(%d): unexpected error: %s", cStr, i, err)
@@ -1155,7 +1155,7 @@ func TestMVCCScan(t *testing.T) {
 	err = MVCCPut(context.Background(), engine, nil, testKey4, makeTS(1, 0), value4, nil)
 	err = MVCCPut(context.Background(), engine, nil, testKey4, makeTS(5, 0), value1, nil)
 
-	kvs, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1166,8 +1166,11 @@ func TestMVCCScan(t *testing.T) {
 		!bytes.Equal(kvs[1].Value.RawBytes, value3.RawBytes) {
 		t.Fatal("the value should not be empty")
 	}
+	if resumeSpan != nil {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
+	}
 
-	kvs, _, err = MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(4, 0), true, nil)
+	kvs, resumeSpan, _, err = MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(4, 0), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1178,8 +1181,11 @@ func TestMVCCScan(t *testing.T) {
 		!bytes.Equal(kvs[1].Value.RawBytes, value2.RawBytes) {
 		t.Fatal("the value should not be empty")
 	}
+	if resumeSpan != nil {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
+	}
 
-	kvs, _, err = MVCCScan(context.Background(), engine, testKey4, keyMax, math.MaxInt64, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err = MVCCScan(context.Background(), engine, testKey4, keyMax, math.MaxInt64, makeTS(1, 0), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1188,9 +1194,12 @@ func TestMVCCScan(t *testing.T) {
 		!bytes.Equal(kvs[0].Value.RawBytes, value4.RawBytes) {
 		t.Fatal("the value should not be empty")
 	}
+	if resumeSpan != nil {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
+	}
 
 	_, _, err = MVCCGet(context.Background(), engine, testKey1, makeTS(1, 0), true, txn2)
-	kvs, _, err = MVCCScan(context.Background(), engine, keyMin, testKey2, math.MaxInt64, makeTS(1, 0), true, nil)
+	kvs, _, _, err = MVCCScan(context.Background(), engine, keyMin, testKey2, math.MaxInt64, makeTS(1, 0), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1212,7 +1221,7 @@ func TestMVCCScanMaxNum(t *testing.T) {
 	err = MVCCPut(context.Background(), engine, nil, testKey3, makeTS(1, 0), value3, nil)
 	err = MVCCPut(context.Background(), engine, nil, testKey4, makeTS(1, 0), value4, nil)
 
-	kvs, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, 1, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, 1, makeTS(1, 0), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1221,12 +1230,21 @@ func TestMVCCScanMaxNum(t *testing.T) {
 		!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) {
 		t.Fatal("the value should not be empty")
 	}
-	kvs, _, err = MVCCScan(context.Background(), engine, testKey2, testKey4, 0, makeTS(1, 0), true, nil)
+	if !bytes.Equal(resumeSpan.Key, testKey3) ||
+		!bytes.Equal(resumeSpan.EndKey, testKey4) {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
+	}
+
+	kvs, resumeSpan, _, err = MVCCScan(context.Background(), engine, testKey2, testKey4, 0, makeTS(1, 0), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(kvs) != 0 {
 		t.Fatal("the value should be empty")
+	}
+	if !bytes.Equal(resumeSpan.Key, testKey2) ||
+		!bytes.Equal(resumeSpan.EndKey, testKey4) {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
 }
 
@@ -1253,7 +1271,7 @@ func TestMVCCScanWithKeyPrefix(t *testing.T) {
 	err = MVCCPut(context.Background(), engine, nil, roachpb.Key("/aa"), makeTS(3, 0), value3, nil)
 	err = MVCCPut(context.Background(), engine, nil, roachpb.Key("/b"), makeTS(1, 0), value3, nil)
 
-	kvs, _, err := MVCCScan(context.Background(), engine, roachpb.Key("/a"), roachpb.Key("/b"), math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, err := MVCCScan(context.Background(), engine, roachpb.Key("/a"), roachpb.Key("/b"), math.MaxInt64, makeTS(2, 0), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1285,7 +1303,7 @@ func TestMVCCScanInTxn(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	kvs, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, txn1)
+	kvs, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, txn1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1297,7 +1315,7 @@ func TestMVCCScanInTxn(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	if _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, nil); err == nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, nil); err == nil {
 		t.Fatal("expected error on uncommitted write intent")
 	}
 }
@@ -1311,7 +1329,7 @@ func TestMVCCScanInconsistent(t *testing.T) {
 	engine := createTestEngine(stopper)
 
 	// A scan with consistent=false should fail in a txn.
-	if _, _, err := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(1, 0), false, txn1); err == nil {
+	if _, _, _, err := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(1, 0), false, txn1); err == nil {
 		t.Error("expected an error scanning with consistent=false in txn")
 	}
 
@@ -1344,7 +1362,7 @@ func TestMVCCScanInconsistent(t *testing.T) {
 		{Span: roachpb.Span{Key: testKey1}, Txn: txn1.TxnMeta},
 		{Span: roachpb.Span{Key: testKey3}, Txn: txn2.TxnMeta},
 	}
-	kvs, intents, err := MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, makeTS(7, 0), false, nil)
+	kvs, _, intents, err := MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, makeTS(7, 0), false, nil)
 	if !reflect.DeepEqual(intents, expIntents) {
 		t.Fatal(err)
 	}
@@ -1365,7 +1383,7 @@ func TestMVCCScanInconsistent(t *testing.T) {
 
 	// Now try a scan at a historical timestamp.
 	expIntents = expIntents[:1]
-	kvs, intents, err = MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, makeTS(3, 0), false, nil)
+	kvs, _, intents, err = MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, makeTS(3, 0), false, nil)
 	if !reflect.DeepEqual(intents, expIntents) {
 		t.Fatal(err)
 	}
@@ -1392,7 +1410,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 	err = MVCCPut(context.Background(), engine, nil, testKey6, makeTS(1, 0), value6, nil)
 
 	// Attempt to delete two keys.
-	deleted, resumeKey, num, err := MVCCDeleteRange(
+	deleted, resumeSpan, num, err := MVCCDeleteRange(
 		context.Background(), engine, nil, testKey2, testKey6, 2, makeTS(2, 0), nil, false,
 	)
 	if err != nil {
@@ -1404,10 +1422,11 @@ func TestMVCCDeleteRange(t *testing.T) {
 	if num != 2 {
 		t.Fatalf("incorrect number of keys deleted: %d", num)
 	}
-	if expected, actual := testKey4, resumeKey; !expected.Equal(actual) {
-		t.Fatalf("wrong resume key: expected %v found %v", expected, actual)
+	if !bytes.Equal(resumeSpan.Key, testKey4) ||
+		!bytes.Equal(resumeSpan.EndKey, testKey6) {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
-	kvs, _, _ := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
 	if len(kvs) != 4 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[1].Key, testKey4) ||
@@ -1421,7 +1440,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 	}
 
 	// Attempt to delete no keys.
-	deleted, resumeKey, num, err = MVCCDeleteRange(
+	deleted, resumeSpan, num, err = MVCCDeleteRange(
 		context.Background(), engine, nil, testKey2, testKey6, 0, makeTS(2, 0), nil, false,
 	)
 	if err != nil {
@@ -1433,10 +1452,11 @@ func TestMVCCDeleteRange(t *testing.T) {
 	if num != 0 {
 		t.Fatalf("incorrect number of keys deleted: %d", num)
 	}
-	if expected, actual := testKey2, resumeKey; !expected.Equal(actual) {
-		t.Fatalf("wrong resume key: expected %v found %v", expected, actual)
+	if !bytes.Equal(resumeSpan.Key, testKey2) ||
+		!bytes.Equal(resumeSpan.EndKey, testKey6) {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
-	kvs, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
 	if len(kvs) != 4 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[1].Key, testKey4) ||
@@ -1449,7 +1469,7 @@ func TestMVCCDeleteRange(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	deleted, resumeKey, num, err = MVCCDeleteRange(
+	deleted, resumeSpan, num, err = MVCCDeleteRange(
 		context.Background(), engine, nil, testKey4, keyMax, math.MaxInt64, makeTS(2, 0), nil, false,
 	)
 	if err != nil {
@@ -1461,17 +1481,17 @@ func TestMVCCDeleteRange(t *testing.T) {
 	if num != 3 {
 		t.Fatalf("incorrect number of keys deleted: %d", num)
 	}
-	if resumeKey != nil {
-		t.Fatalf("wrong resume key: expected nil, found %v", resumeKey)
+	if resumeSpan != nil {
+		t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 	}
-	kvs, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
 	if len(kvs) != 1 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
 		t.Fatal("the value should not be empty")
 	}
 
-	deleted, resumeKey, num, err = MVCCDeleteRange(
+	deleted, resumeSpan, num, err = MVCCDeleteRange(
 		context.Background(), engine, nil, keyMin, testKey2, math.MaxInt64, makeTS(2, 0), nil, false,
 	)
 	if err != nil {
@@ -1483,10 +1503,10 @@ func TestMVCCDeleteRange(t *testing.T) {
 	if num != 1 {
 		t.Fatalf("incorrect number of keys deleted: %d", num)
 	}
-	if resumeKey != nil {
-		t.Fatalf("wrong resume key: expected nil, found %v", resumeKey)
+	if resumeSpan != nil {
+		t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 	}
-	kvs, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
 	if len(kvs) != 0 {
 		t.Fatal("the value should be empty")
 	}
@@ -1506,7 +1526,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	err = MVCCPut(context.Background(), engine, nil, testKey6, makeTS(1, 0), value6, nil)
 
 	// Attempt to delete two keys.
-	deleted, resumeKey, num, err := MVCCDeleteRange(
+	deleted, resumeSpan, num, err := MVCCDeleteRange(
 		context.Background(), engine, nil, testKey2, testKey6, 2, makeTS(2, 0), nil, true,
 	)
 	if err != nil {
@@ -1524,10 +1544,11 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	if expected, actual := testKey3, deleted[1]; !expected.Equal(actual) {
 		t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
 	}
-	if expected, actual := testKey4, resumeKey; !expected.Equal(actual) {
-		t.Fatalf("wrong resume key: expected %v found %v", expected, actual)
+	if !bytes.Equal(resumeSpan.Key, testKey4) ||
+		!bytes.Equal(resumeSpan.EndKey, testKey6) {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
-	kvs, _, _ := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ := MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
 	if len(kvs) != 4 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[1].Key, testKey4) ||
@@ -1541,7 +1562,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	}
 
 	// Attempt to delete no keys.
-	deleted, resumeKey, num, err = MVCCDeleteRange(
+	deleted, resumeSpan, num, err = MVCCDeleteRange(
 		context.Background(), engine, nil, testKey2, testKey6, 0, makeTS(2, 0), nil, true,
 	)
 	if err != nil {
@@ -1553,10 +1574,11 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	if num != 0 {
 		t.Fatalf("incorrect number of keys deleted: %d", num)
 	}
-	if expected, actual := testKey2, resumeKey; !expected.Equal(actual) {
-		t.Fatalf("wrong resume key: expected %v found %v", expected, actual)
+	if !bytes.Equal(resumeSpan.Key, testKey2) ||
+		!bytes.Equal(resumeSpan.EndKey, testKey6) {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
-	kvs, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
 	if len(kvs) != 4 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[1].Key, testKey4) ||
@@ -1569,7 +1591,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 		t.Fatal("the value should not be empty")
 	}
 
-	deleted, resumeKey, num, err = MVCCDeleteRange(
+	deleted, resumeSpan, num, err = MVCCDeleteRange(
 		context.Background(), engine, nil, testKey4, keyMax, math.MaxInt64, makeTS(2, 0), nil, true,
 	)
 	if err != nil {
@@ -1590,17 +1612,17 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	if expected, actual := testKey6, deleted[2]; !expected.Equal(actual) {
 		t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
 	}
-	if resumeKey != nil {
-		t.Fatalf("wrong resume key: expected nil, found %v", resumeKey)
+	if resumeSpan != nil {
+		t.Fatalf("wrong resume key: expected nil, found %v", resumeSpan)
 	}
-	kvs, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
 	if len(kvs) != 1 ||
 		!bytes.Equal(kvs[0].Key, testKey1) ||
 		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
 		t.Fatal("the value should not be empty")
 	}
 
-	deleted, resumeKey, num, err = MVCCDeleteRange(
+	deleted, resumeSpan, num, err = MVCCDeleteRange(
 		context.Background(), engine, nil, keyMin, testKey2, math.MaxInt64, makeTS(2, 0), nil, true,
 	)
 	if err != nil {
@@ -1615,10 +1637,10 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 	if expected, actual := testKey1, deleted[0]; !expected.Equal(actual) {
 		t.Fatalf("wrong key deleted: expected %v found %v", expected, actual)
 	}
-	if resumeKey != nil {
-		t.Fatalf("wrong resume key: %v", resumeKey)
+	if resumeSpan != nil {
+		t.Fatalf("wrong resume key: %v", resumeSpan)
 	}
-	kvs, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
+	kvs, _, _, _ = MVCCScan(context.Background(), engine, keyMin, keyMax, math.MaxInt64, makeTS(2, 0), true, nil)
 	if len(kvs) != 0 {
 		t.Fatal("the value should be empty")
 	}
@@ -1705,7 +1727,7 @@ func TestMVCCUncommittedDeleteRangeVisible(t *testing.T) {
 	}
 
 	txn.Epoch++
-	kvs, _, _ := MVCCScan(context.Background(), engine, testKey1, testKey4, math.MaxInt64, makeTS(3, 0), true, &txn)
+	kvs, _, _, _ := MVCCScan(context.Background(), engine, testKey1, testKey4, math.MaxInt64, makeTS(3, 0), true, &txn)
 	if e := 2; len(kvs) != e {
 		t.Fatalf("e = %d, got %d", e, len(kvs))
 	}
@@ -2056,7 +2078,7 @@ func TestMVCCReverseScan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	kvs, _, err := MVCCReverseScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err := MVCCReverseScan(context.Background(), engine, testKey2, testKey4, math.MaxInt64, makeTS(1, 0), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2067,8 +2089,11 @@ func TestMVCCReverseScan(t *testing.T) {
 		!bytes.Equal(kvs[1].Value.RawBytes, value3.RawBytes) {
 		t.Errorf("unexpected value: %v", kvs)
 	}
+	if resumeSpan != nil {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
+	}
 
-	kvs, _, err = MVCCReverseScan(context.Background(), engine, testKey2, testKey4, 1, makeTS(1, 0), true, nil)
+	kvs, resumeSpan, _, err = MVCCReverseScan(context.Background(), engine, testKey2, testKey4, 1, makeTS(1, 0), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2077,12 +2102,20 @@ func TestMVCCReverseScan(t *testing.T) {
 		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
 		t.Errorf("unexpected value: %v", kvs)
 	}
-	kvs, _, err = MVCCReverseScan(context.Background(), engine, testKey2, testKey4, 0, makeTS(1, 0), true, nil)
+	if !bytes.Equal(resumeSpan.Key, testKey2) ||
+		!bytes.Equal(resumeSpan.EndKey, testKey2.Next()) {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
+	}
+	kvs, resumeSpan, _, err = MVCCReverseScan(context.Background(), engine, testKey2, testKey4, 0, makeTS(1, 0), true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(kvs) != 0 {
 		t.Errorf("unexpected value: %v", kvs)
+	}
+	if !bytes.Equal(resumeSpan.Key, testKey2) ||
+		!bytes.Equal(resumeSpan.EndKey, testKey4) {
+		t.Fatalf("resumeSpan = %+v", resumeSpan)
 	}
 }
 

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -86,7 +86,7 @@ func (tm *testModel) getActualData() map[string]roachpb.Value {
 	// Scan over all TS Keys stored in the engine
 	startKey := keys.TimeseriesPrefix
 	endKey := startKey.PrefixEnd()
-	keyValues, _, err := engine.MVCCScan(context.Background(), tm.Eng, startKey, endKey, math.MaxInt64, tm.Clock.Now(), true, nil)
+	keyValues, _, _, err := engine.MVCCScan(context.Background(), tm.Eng, startKey, endKey, math.MaxInt64, tm.Clock.Now(), true, nil)
 	if err != nil {
 		tm.t.Fatalf("error scanning TS data from engine: %s", err.Error())
 	}


### PR DESCRIPTION
This change allows these range operations to return a nil ResumeSpan
when they hit the requested key limit after having read all keys
 within the original requested span. As a result the next resumed
operation will skip the read range thereby saving an rpc.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8458)

<!-- Reviewable:end -->
