### PR TITLE
Add Context arg to db.Txn()

### DIFF
--- a/acceptance/gossip_peerings_test.go
+++ b/acceptance/gossip_peerings_test.go
@@ -196,7 +196,7 @@ func testGossipRestartInner(t *testing.T, c cluster.Cluster, cfg cluster.TestCon
 				}
 			}
 			var kv client.KeyValue
-			if err := db.Txn(func(txn *client.Txn) error {
+			if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 				var err error
 				kv, err = txn.Inc("count", 1)
 				return err

--- a/acceptance/single_key_test.go
+++ b/acceptance/single_key_test.go
@@ -68,7 +68,7 @@ func testSingleKeyInner(t *testing.T, c cluster.Cluster, cfg cluster.TestConfig)
 			var r result
 			for timeutil.Now().Before(deadline) {
 				start := timeutil.Now()
-				err := db.Txn(func(txn *client.Txn) error {
+				err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 					minExp := atomic.LoadInt64(&expected)
 					r, err := txn.Get(key)
 					if err != nil {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -220,7 +220,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 		// doneCall signals when the non-txn read or write has completed.
 		doneCall := make(chan error)
 		count := 0 // keeps track of retries
-		err := db.Txn(func(txn *client.Txn) error {
+		err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 			if test.isolation == enginepb.SNAPSHOT {
 				if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 					return err
@@ -315,7 +315,7 @@ func TestClientRunTransaction(t *testing.T) {
 		key := []byte(fmt.Sprintf("%s/key-%t", testUser, commit))
 
 		// Use snapshot isolation so non-transactional read can always push.
-		err := db.Txn(func(txn *client.Txn) error {
+		err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 			if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 				return err
 			}
@@ -635,7 +635,7 @@ func TestClientBatch(t *testing.T) {
 
 		b := &client.Batch{}
 		b.CPut(key, "goodbyte", nil) // should fail
-		if err := db.Txn(func(txn *client.Txn) error {
+		if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 			return txn.Run(b)
 		}); err == nil {
 			t.Error("unexpected success")
@@ -675,7 +675,7 @@ func concurrentIncrements(db *client.DB, t *testing.T) {
 			// Wait until the other goroutines are running.
 			wgStart.Wait()
 
-			if err := db.Txn(func(txn *client.Txn) error {
+			if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 				txn.SetDebugName(fmt.Sprintf("test-%d", i), 0)
 
 				// Retrieve the other key.
@@ -888,7 +888,7 @@ func TestTxn_ReverseScan(t *testing.T) {
 		t.Error(err)
 	}
 
-	err := db.Txn(func(txn *client.Txn) error {
+	err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		// Try reverse scans for all keys.
 		{
 			rows, err := txn.ReverseScan(testUser+"/key/00", testUser+"/key/10", 100)

--- a/internal/client/db.go
+++ b/internal/client/db.go
@@ -442,10 +442,12 @@ func (db *DB) Run(b *Batch) error {
 // cause problems in the event it must be run more than once.
 //
 // If you need more control over how the txn is executed, check out txn.Exec().
-func (db *DB) Txn(retryable func(txn *Txn) error) error {
+func (db *DB) Txn(ctx context.Context, retryable func(txn *Txn) error) error {
+	// TODO(radu): we should open a tracing Span here (we need to figure out how
+	// to use the correct tracer).
 	// TODO(dan): This context should, at longest, live for the lifetime of this
 	// method. Add a defered cancel.
-	txn := NewTxn(context.TODO(), *db)
+	txn := NewTxn(ctx, *db)
 	txn.SetDebugName("", 1)
 	err := txn.Exec(TxnExecOptions{AutoRetry: true, AutoCommit: true},
 		func(txn *Txn, _ *TxnExecOptions) error {

--- a/internal/client/db_test.go
+++ b/internal/client/db_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/testutils/serverutils"
@@ -283,7 +285,7 @@ func TestTxn_Commit(t *testing.T) {
 	s, db := setup(t)
 	defer s.Stopper().Stop()
 
-	err := db.Txn(func(txn *client.Txn) error {
+	err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		b := txn.NewBatch()
 		b.Put("aa", "1")
 		b.Put("ab", "2")
@@ -327,7 +329,7 @@ func TestDebugName(t *testing.T) {
 	defer s.Stopper().Stop()
 
 	file, _, _ := caller.Lookup(0)
-	if err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		if !strings.HasPrefix(txn.DebugName(), file+":") {
 			t.Fatalf("expected \"%s\" to have the prefix \"%s:\"", txn.DebugName(), file)
 		}

--- a/internal/client/txn_test.go
+++ b/internal/client/txn_test.go
@@ -196,7 +196,7 @@ func TestTransactionConfig(t *testing.T) {
 	dbCtx := DefaultDBContext()
 	dbCtx.UserPriority = 101
 	db := NewDBWithContext(newTestSender(nil, nil), dbCtx)
-	if err := db.Txn(func(txn *Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *Txn) error {
 		if txn.db.ctx.UserPriority != db.ctx.UserPriority {
 			t.Errorf("expected txn user priority %f; got %f",
 				db.ctx.UserPriority, txn.db.ctx.UserPriority)
@@ -217,7 +217,7 @@ func TestCommitReadOnlyTransaction(t *testing.T) {
 		calls = append(calls, ba.Methods()...)
 		return ba.CreateReply(), nil
 	}, nil))
-	if err := db.Txn(func(txn *Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *Txn) error {
 		_, err := txn.Get("a")
 		return err
 	}); err != nil {
@@ -240,7 +240,7 @@ func TestCommitReadOnlyTransactionExplicit(t *testing.T) {
 			calls = append(calls, ba.Methods()...)
 			return ba.CreateReply(), nil
 		}, nil))
-		if err := db.Txn(func(txn *Txn) error {
+		if err := db.Txn(context.TODO(), func(txn *Txn) error {
 			b := txn.NewBatch()
 			if withGet {
 				b.Get("foo")
@@ -292,7 +292,7 @@ func TestCommitMutatingTransaction(t *testing.T) {
 	}
 	for i, test := range testArgs {
 		calls = []roachpb.Method{}
-		if err := db.Txn(func(txn *Txn) error {
+		if err := db.Txn(context.TODO(), func(txn *Txn) error {
 			return test.f(txn)
 		}); err != nil {
 			t.Errorf("%d: unexpected error on commit: %s", i, err)
@@ -313,7 +313,7 @@ func TestTxnInsertBeginTransaction(t *testing.T) {
 		calls = append(calls, ba.Methods()...)
 		return ba.CreateReply(), nil
 	}, nil))
-	if err := db.Txn(func(txn *Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *Txn) error {
 		if _, err := txn.Get("foo"); err != nil {
 			return err
 		}
@@ -336,7 +336,7 @@ func TestBeginTransactionErrorIndex(t *testing.T) {
 		pErr.SetErrorIndex(0)
 		return nil, pErr
 	}, nil))
-	_ = db.Txn(func(txn *Txn) error {
+	_ = db.Txn(context.TODO(), func(txn *Txn) error {
 		b := txn.NewBatch()
 		b.Put("a", "b")
 		_, err := runOneResult(txn, b)
@@ -362,7 +362,7 @@ func TestCommitTransactionOnce(t *testing.T) {
 		count++
 		return ba.CreateReply(), nil
 	}, nil))
-	if err := db.Txn(func(txn *Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *Txn) error {
 		b := txn.NewBatch()
 		b.Put("z", "adding a write exposed a bug in #1882")
 		return txn.CommitInBatch(b)
@@ -384,7 +384,7 @@ func TestAbortReadOnlyTransaction(t *testing.T) {
 		}
 		return ba.CreateReply(), nil
 	}, nil))
-	if err := db.Txn(func(txn *Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *Txn) error {
 		return errors.New("foo")
 	}); err == nil {
 		t.Error("expected error on abort")
@@ -406,7 +406,7 @@ func TestEndWriteRestartReadOnlyTransaction(t *testing.T) {
 			return ba.CreateReply(), nil
 		}, nil))
 		ok := false
-		if err := db.Txn(func(txn *Txn) error {
+		if err := db.Txn(context.TODO(), func(txn *Txn) error {
 			if !ok {
 				if err := txn.Put("consider", "phlebas"); err != nil {
 					t.Fatal(err)
@@ -458,7 +458,7 @@ func TestTransactionKeyNotChangedInRestart(t *testing.T) {
 		return ba.CreateReply(), nil
 	}))
 
-	if err := db.Txn(func(txn *Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *Txn) error {
 		tries++
 		b := txn.NewBatch()
 		b.Put("a", "b")
@@ -491,7 +491,7 @@ func TestAbortMutatingTransaction(t *testing.T) {
 		return ba.CreateReply(), nil
 	}, nil))
 
-	if err := db.Txn(func(txn *Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *Txn) error {
 		if err := txn.Put("a", "b"); err != nil {
 			return err
 		}
@@ -538,7 +538,7 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 				}
 				return ba.CreateReply(), nil
 			}, nil), dbCtx)
-		err := db.Txn(func(txn *Txn) error {
+		err := db.Txn(context.TODO(), func(txn *Txn) error {
 			return txn.Put("a", "b")
 		})
 		if test.retry {
@@ -799,7 +799,7 @@ func TestWrongTxnRetry(t *testing.T) {
 		return err
 	}
 
-	if err := db.Txn(txnClosure); !testutils.IsError(err, "failed to push") {
+	if err := db.Txn(context.TODO(), txnClosure); !testutils.IsError(err, "failed to push") {
 		t.Fatal(err)
 	}
 	if retries != 1 {

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -213,7 +215,7 @@ func TestKVDBTransaction(t *testing.T) {
 
 	key := roachpb.Key("db-txn-test")
 	value := []byte("value")
-	err := db.Txn(func(txn *client.Txn) error {
+	err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		// Use snapshot isolation so non-transactional read can always push.
 		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 			return err

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -624,7 +624,7 @@ func TestMultiRangeEmptyAfterTruncate(t *testing.T) {
 
 	// Delete the keys within a transaction. The range [c,d) doesn't have
 	// any active requests.
-	if err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		b := txn.NewBatch()
 		b.DelRange("a", "b", false)
 		b.DelRange("e", "f", false)
@@ -681,7 +681,7 @@ func TestMultiRangeScanReverseScanDeleteResolve(t *testing.T) {
 
 	// Delete the keys within a transaction. Implicitly, the intents are
 	// resolved via ResolveIntentRange upon completion.
-	if err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		b := txn.NewBatch()
 		b.DelRange("a", "d", false)
 		return txn.CommitInBatch(b)
@@ -952,7 +952,7 @@ func TestNoSequenceCachePutOnRangeMismatchError(t *testing.T) {
 	//    same replica.
 	// 5) The command succeeds since the sequence cache has not yet been updated.
 	epoch := 0
-	if err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		epoch++
 		b := txn.NewBatch()
 		b.Put("a", "val")
@@ -1008,7 +1008,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 	// get a ReadWithinUncertaintyIntervalError and the txn will be
 	// retried.
 	epoch := 0
-	if err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		epoch++
 		if epoch >= 2 {
 			// Writing must be true since we ran the BeginTransaction command.
@@ -1082,7 +1082,7 @@ func TestPropagateTxnOnPushError(t *testing.T) {
 	// Create a goroutine that creates a write intent and waits until
 	// another txn created in this test is restarted.
 	go func() {
-		if err := db.Txn(func(txn *client.Txn) error {
+		if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 			// Set high priority so that the intent will not be pushed.
 			txn.InternalSetPriority(highPriority)
 			log.Infof(context.TODO(), "Creating a write intent with high priority")
@@ -1111,7 +1111,7 @@ func TestPropagateTxnOnPushError(t *testing.T) {
 	// iteration.
 	epoch := 0
 	var txnID *uuid.UUID
-	if err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		// Set low priority so that a write from this txn will not push others.
 		txn.InternalSetPriority(lowPriority)
 

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -59,7 +59,7 @@ func startTestWriter(db *client.DB, i int64, valBytes int32, wg *sync.WaitGroup,
 			return
 		default:
 			first := true
-			err := db.Txn(func(txn *client.Txn) error {
+			err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 				if first && txnChannel != nil {
 					select {
 					case txnChannel <- struct{}{}:

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -933,7 +933,7 @@ func (tc *TxnCoordSender) resendWithTxn(ba roachpb.BatchRequest) (*roachpb.Batch
 	dbCtx.UserPriority = ba.UserPriority
 	tmpDB := client.NewDBWithContext(tc, dbCtx)
 	var br *roachpb.BatchResponse
-	err := tmpDB.Txn(func(txn *client.Txn) error {
+	err := tmpDB.Txn(context.TODO(), func(txn *client.Txn) error {
 		txn.SetDebugName("auto-wrap", 0)
 		b := txn.NewBatch()
 		b.Header = ba.Header

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -1170,7 +1170,7 @@ func TestTxnCommit(t *testing.T) {
 	db := client.NewDB(sender)
 
 	// Test normal commit.
-	if err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		key := []byte("key-commit")
 
 		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
@@ -1201,7 +1201,7 @@ func TestTxnOnePhaseCommit(t *testing.T) {
 	value := []byte("value")
 	db := client.NewDB(sender)
 
-	if err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		key := []byte("key-commit")
 		b := txn.NewBatch()
 		b.Put(key, value)
@@ -1225,7 +1225,7 @@ func TestTxnAbandonCount(t *testing.T) {
 	// abandoned transactions.
 	sender.heartbeatInterval = 2 * time.Millisecond
 	sender.clientTimeout = 1 * time.Millisecond
-	if err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		key := []byte("key-abandon")
 
 		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
@@ -1262,7 +1262,7 @@ func TestTxnReadAfterAbandon(t *testing.T) {
 	sender.heartbeatInterval = 2 * time.Millisecond
 	sender.clientTimeout = 1 * time.Millisecond
 
-	err := db.Txn(func(txn *client.Txn) error {
+	err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		key := []byte("key-abandon")
 
 		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
@@ -1301,7 +1301,7 @@ func TestTxnAbortCount(t *testing.T) {
 
 	intentionalErrText := "intentional error to cause abort"
 	// Test aborted transaction.
-	if err := db.Txn(func(txn *client.Txn) error {
+	if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		key := []byte("key-abort")
 
 		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
@@ -1368,7 +1368,7 @@ func TestTxnDurations(t *testing.T) {
 	const incr int64 = 1000
 	for i := 0; i < puts; i++ {
 		key := roachpb.Key(fmt.Sprintf("key-txn-durations-%d", i))
-		if err := db.Txn(func(txn *client.Txn) error {
+		if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 			if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 				return err
 			}

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -791,7 +791,7 @@ func (hv *historyVerifier) runHistory(priorities []int32,
 func (hv *historyVerifier) runCmds(cmds []*cmd, db *client.DB, t *testing.T) (string, map[string]int64, error) {
 	var strs []string
 	env := map[string]int64{}
-	err := db.Txn(func(txn *client.Txn) error {
+	err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		for _, c := range cmds {
 			c.historyIdx = hv.idx
 			c.env = env
@@ -813,7 +813,7 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 	txnName := fmt.Sprintf("txn %d", txnIdx+1)
 	cmdIdx := -1
 
-	err := db.Txn(func(txn *client.Txn) error {
+	err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 		// If this is 2nd attempt, and a retry wasn't expected, return a
 		// retry error which results in further histories being enumerated.
 		if retry++; retry > 1 {

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -52,7 +52,7 @@ func TestTxnDBBasics(t *testing.T) {
 	for _, commit := range []bool{true, false} {
 		key := []byte(fmt.Sprintf("key-%t", commit))
 
-		err := s.DB.Txn(func(txn *client.Txn) error {
+		err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 			// Use snapshot isolation so non-transactional read can always push.
 			if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 				return err
@@ -115,7 +115,7 @@ func benchmarkSingleRoundtripWithLatency(b *testing.B, latency time.Duration) {
 	key := roachpb.Key("key")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if tErr := s.DB.Txn(func(txn *client.Txn) error {
+		if tErr := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 			b := txn.NewBatch()
 			b.Put(key, fmt.Sprintf("value-%d", i))
 			return txn.CommitInBatch(b)
@@ -149,7 +149,7 @@ func TestSnapshotIsolationIncrement(t *testing.T) {
 
 	go func() {
 		<-start
-		done <- s.DB.Txn(func(txn *client.Txn) error {
+		done <- s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 			if _, err := txn.Inc(key, 1); err != nil {
 				return err
 			}
@@ -160,7 +160,7 @@ func TestSnapshotIsolationIncrement(t *testing.T) {
 		})
 	}()
 
-	if err := s.DB.Txn(func(txn *client.Txn) error {
+	if err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 			t.Fatal(err)
 		}
@@ -227,12 +227,12 @@ func TestSnapshotIsolationLostUpdate(t *testing.T) {
 	start := make(chan struct{})
 	go func() {
 		<-start
-		done <- s.DB.Txn(func(txn *client.Txn) error {
+		done <- s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 			return txn.Put(key, "hi")
 		})
 	}()
 
-	if err := s.DB.Txn(func(txn *client.Txn) error {
+	if err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 			t.Fatal(err)
 		}
@@ -295,7 +295,7 @@ func TestPriorityRatchetOnAbortOrPush(t *testing.T) {
 	const pusherPri = 10 // pusher will win
 
 	pushByReading := func(key roachpb.Key) {
-		if err := s.DB.Txn(func(txn *client.Txn) error {
+		if err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 			txn.InternalSetPriority(pusherPri)
 			_, err := txn.Get(key)
 			return err
@@ -304,7 +304,7 @@ func TestPriorityRatchetOnAbortOrPush(t *testing.T) {
 		}
 	}
 	abortByWriting := func(key roachpb.Key) {
-		if err := s.DB.Txn(func(txn *client.Txn) error {
+		if err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 			txn.InternalSetPriority(pusherPri)
 			return txn.Put(key, "foo")
 		}); err != nil {
@@ -316,7 +316,7 @@ func TestPriorityRatchetOnAbortOrPush(t *testing.T) {
 	for _, read := range []bool{true, false} {
 		for _, iso := range []enginepb.IsolationType{enginepb.SNAPSHOT, enginepb.SERIALIZABLE} {
 			var iteration int
-			if err := s.DB.Txn(func(txn *client.Txn) error {
+			if err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 				defer func() { iteration++ }()
 				key := roachpb.Key(fmt.Sprintf("read=%t, iso=%s", read, iso))
 
@@ -402,14 +402,14 @@ func TestUncertaintyRestart(t *testing.T) {
 	go func() {
 		defer close(done)
 		<-start
-		if err := s.DB.Txn(func(txn *client.Txn) error {
+		if err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 			return txn.Put(key, "hi")
 		}); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	if err := s.DB.Txn(func(txn *client.Txn) error {
+	if err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 		if txn.Proto.Epoch > 2 {
 			t.Fatal("expected only one restart")
 		}
@@ -466,7 +466,7 @@ func TestUncertaintyMaxTimestampForwarding(t *testing.T) {
 	}
 
 	i := 0
-	if tErr := s.DB.Txn(func(txn *client.Txn) error {
+	if tErr := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 		i++
 		// The first command serves to start a Txn, fixing the timestamps.
 		// There will be a restart, but this is idempotent.
@@ -520,7 +520,7 @@ func TestTxnTimestampRegression(t *testing.T) {
 
 	keyA := "a"
 	keyB := "b"
-	err := s.DB.Txn(func(txn *client.Txn) error {
+	err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 		// Use snapshot isolation so non-transactional read can always push.
 		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 			return err
@@ -564,7 +564,7 @@ func TestTxnLongDelayBetweenWritesWithConcurrentRead(t *testing.T) {
 	keyB := roachpb.Key("b")
 	ch := make(chan struct{})
 	go func() {
-		err := s.DB.Txn(func(txn *client.Txn) error {
+		err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 			// Use snapshot isolation.
 			if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 				return err
@@ -591,7 +591,7 @@ func TestTxnLongDelayBetweenWritesWithConcurrentRead(t *testing.T) {
 	<-ch
 	// Delay for longer than the cache window.
 	s.Manual.Set((storage.MinTSCacheWindow + time.Second).Nanoseconds())
-	err := s.DB.Txn(func(txn *client.Txn) error {
+	err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 		// Use snapshot isolation.
 		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 			return err
@@ -637,7 +637,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 	splitKey := roachpb.Key("b")
 	ch := make(chan struct{})
 	go func() {
-		err := s.DB.Txn(func(txn *client.Txn) error {
+		err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 			// Use snapshot isolation.
 			if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 				return err
@@ -663,7 +663,7 @@ func TestTxnRepeatGetWithRangeSplit(t *testing.T) {
 	// Wait till txnA finish put(a).
 	<-ch
 
-	err := s.DB.Txn(func(txn *client.Txn) error {
+	err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 		// Use snapshot isolation.
 		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 			return err
@@ -725,7 +725,7 @@ func TestTxnRestartedSerializableTimestampRegression(t *testing.T) {
 	ch := make(chan struct{})
 	var count int
 	go func() {
-		err := s.DB.Txn(func(txn *client.Txn) error {
+		err := s.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 			count++
 			// Use a low priority for the transaction so that it can be pushed.
 			txn.InternalSetPriority(1)

--- a/server/admin.go
+++ b/server/admin.go
@@ -393,7 +393,7 @@ func (s *adminServer) TableDetails(
 	{
 		var iexecutor sql.InternalExecutor
 		var tableSpan roachpb.Span
-		if err := s.server.db.Txn(func(txn *client.Txn) error {
+		if err := s.server.db.Txn(context.TODO(), func(txn *client.Txn) error {
 			var err error
 			tableSpan, err = iexecutor.GetTableSpan(s.getUser(req), txn, escDBName, escTableName)
 			return err
@@ -455,7 +455,7 @@ func (s *adminServer) TableStats(ctx context.Context, req *serverpb.TableStatsRe
 	// Get table span.
 	var tableSpan roachpb.Span
 	var iexecutor sql.InternalExecutor
-	if err := s.server.db.Txn(func(txn *client.Txn) error {
+	if err := s.server.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		var err error
 		tableSpan, err = iexecutor.GetTableSpan(s.getUser(req), txn, req.Database, req.Table)
 		return err

--- a/server/intent_test.go
+++ b/server/intent_test.go
@@ -123,7 +123,7 @@ func TestIntentResolution(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := kvDB.Txn(func(txn *client.Txn) error {
+			if err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 				b := txn.NewBatch()
 				if tc.keys[0] >= string(splitKey) {
 					t.Fatalf("first key %s must be < split key %s", tc.keys[0], splitKey)

--- a/server/node.go
+++ b/server/node.go
@@ -711,7 +711,7 @@ func (n *Node) recordJoinEvent() {
 		retryOpts := base.DefaultRetryOptions()
 		retryOpts.Closer = n.stopper.ShouldStop()
 		for r := retry.Start(retryOpts); r.Next(); {
-			if err := n.ctx.DB.Txn(func(txn *client.Txn) error {
+			if err := n.ctx.DB.Txn(context.TODO(), func(txn *client.Txn) error {
 				return n.eventLogger.InsertEventRecord(txn,
 					logEventType,
 					int32(n.Descriptor.NodeID),

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/gogo/protobuf/jsonpb"
 
 	"github.com/cockroachdb/cockroach/base"
@@ -392,7 +394,7 @@ func TestSystemConfigGossip(t *testing.T) {
 	}
 
 	// Now do it as part of a transaction, but without the trigger set.
-	if err := kvDB.Txn(func(txn *client.Txn) error {
+	if err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 		return txn.Put(key, valAt(1))
 	}); err != nil {
 		t.Fatal(err)
@@ -413,7 +415,7 @@ func TestSystemConfigGossip(t *testing.T) {
 	}
 
 	// This time mark the transaction as having a Gossip trigger.
-	if err := kvDB.Txn(func(txn *client.Txn) error {
+	if err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 		txn.SetSystemConfigTrigger()
 		return txn.Put(key, valAt(2))
 	}); err != nil {

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -112,7 +112,7 @@ func (sc *SchemaChanger) runBackfill(lease *sqlbase.TableDescriptor_SchemaChange
 	var droppedIndexDescs []sqlbase.IndexDescriptor
 	var addedColumnDescs []sqlbase.ColumnDescriptor
 	var addedIndexDescs []sqlbase.IndexDescriptor
-	if err := sc.db.Txn(func(txn *client.Txn) error {
+	if err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {
 			return err
@@ -174,7 +174,7 @@ func (sc *SchemaChanger) runBackfill(lease *sqlbase.TableDescriptor_SchemaChange
 // getTableSpan returns a span containing the start and end key for a table.
 func (sc *SchemaChanger) getTableSpan() (sqlbase.Span, error) {
 	var tableDesc *sqlbase.TableDescriptor
-	if err := sc.db.Txn(func(txn *client.Txn) error {
+	if err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		var err error
 		tableDesc, err = sqlbase.GetTableDescFromID(txn, sc.tableID)
 		return err
@@ -258,7 +258,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 ) (roachpb.Key, bool, error) {
 	var curIndexKey roachpb.Key
 	done := false
-	err := sc.db.Txn(func(txn *client.Txn) error {
+	err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {
 			return err
@@ -384,7 +384,7 @@ func (sc *SchemaChanger) truncateIndexes(
 			return err
 		}
 		*lease = l
-		if err := sc.db.Txn(func(txn *client.Txn) error {
+		if err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 			tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 			if err != nil {
 				return err
@@ -455,7 +455,7 @@ func (sc *SchemaChanger) backfillIndexesChunk(
 ) (roachpb.Key, bool, error) {
 	var nextKey roachpb.Key
 	done := false
-	err := sc.db.Txn(func(txn *client.Txn) error {
+	err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {
 			return err

--- a/sql/config_test.go
+++ b/sql/config_test.go
@@ -19,6 +19,8 @@ package sql_test
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
@@ -52,7 +54,7 @@ func forceNewConfig(t *testing.T, s *server.TestServer) config.SystemConfig {
 	}
 
 	// This needs to be done in a transaction with the system trigger set.
-	if err := s.DB().Txn(func(txn *client.Txn) error {
+	if err := s.DB().Txn(context.TODO(), func(txn *client.Txn) error {
 		txn.SetSystemConfigTrigger()
 		return txn.Put(configDescKey, configDesc)
 	}); err != nil {

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -19,6 +19,8 @@ package sql
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -597,7 +599,7 @@ func (p *planner) removeInterleaveBackReference(
 // table descriptor.
 // It is called from a mutation, async wrt the DROP statement.
 func truncateAndDropTable(tableDesc *sqlbase.TableDescriptor, db *client.DB) error {
-	return db.Txn(func(txn *client.Txn) error {
+	return db.Txn(context.TODO(), func(txn *client.Txn) error {
 		if err := truncateTable(tableDesc, txn); err != nil {
 			return err
 		}

--- a/sql/kv_test.go
+++ b/sql/kv_test.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/rpc"
@@ -82,7 +84,7 @@ func newKVNative(b *testing.B) kvInterface {
 func (kv *kvNative) insert(rows, run int) error {
 	firstRow := rows * run
 	lastRow := rows * (run + 1)
-	err := kv.db.Txn(func(txn *client.Txn) error {
+	err := kv.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		b := txn.NewBatch()
 		for i := firstRow; i < lastRow; i++ {
 			b.Put(fmt.Sprintf("%s%06d", kv.prefix, i), i)
@@ -94,7 +96,7 @@ func (kv *kvNative) insert(rows, run int) error {
 
 func (kv *kvNative) update(rows, run int) error {
 	perm := rand.Perm(rows)
-	err := kv.db.Txn(func(txn *client.Txn) error {
+	err := kv.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		// Read all values in a batch.
 		b := txn.NewBatch()
 		for i := 0; i < rows; i++ {
@@ -117,7 +119,7 @@ func (kv *kvNative) update(rows, run int) error {
 func (kv *kvNative) del(rows, run int) error {
 	firstRow := rows * run
 	lastRow := rows * (run + 1)
-	err := kv.db.Txn(func(txn *client.Txn) error {
+	err := kv.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		b := txn.NewBatch()
 		for i := firstRow; i < lastRow; i++ {
 			b.Del(fmt.Sprintf("%s%06d", kv.prefix, i))
@@ -129,7 +131,7 @@ func (kv *kvNative) del(rows, run int) error {
 
 func (kv *kvNative) scan(rows, run int) error {
 	var kvs []client.KeyValue
-	err := kv.db.Txn(func(txn *client.Txn) error {
+	err := kv.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		var err error
 		kvs, err = txn.Scan(fmt.Sprintf("%s%06d", kv.prefix, 0), fmt.Sprintf("%s%06d", kv.prefix, rows), int64(rows))
 		return err
@@ -146,7 +148,7 @@ func (kv *kvNative) prep(rows int, initData bool) error {
 	if !initData {
 		return nil
 	}
-	err := kv.db.Txn(func(txn *client.Txn) error {
+	err := kv.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		b := txn.NewBatch()
 		for i := 0; i < rows; i++ {
 			b.Put(fmt.Sprintf("%s%06d", kv.prefix, i), i)

--- a/sql/lease_internal_test.go
+++ b/sql/lease_internal_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
@@ -155,7 +157,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 
 	var leases []*LeaseState
-	err := kvDB.Txn(func(txn *client.Txn) error {
+	err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 		for i := 0; i < 3; i++ {
 			lease, err := leaseManager.acquireFreshestFromStore(txn, tableDesc.ID)
 			if err != nil {
@@ -365,7 +367,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 	// Populate the name cache.
 	var lease *LeaseState
-	if err := kvDB.Txn(func(txn *client.Txn) error {
+	if err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 		var err error
 		lease, err = leaseManager.AcquireByName(txn, tableDesc.ParentID, "test")
 		return err
@@ -396,7 +398,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 	for i := 0; i < 50; i++ {
 		var leaseByName *LeaseState
-		if err := kvDB.Txn(func(txn *client.Txn) error {
+		if err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 			var err error
 			lease, err := leaseManager.AcquireByName(txn, tableDesc.ParentID, "test")
 			if err != nil {
@@ -479,7 +481,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	for i := 0; i < numRoutines; i++ {
 		go func() {
 			defer wg.Done()
-			err := kvDB.Txn(func(txn *client.Txn) error {
+			err := kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 				lease, err := leaseManager.acquireFreshestFromStore(txn, tableDesc.ID)
 				if err != nil {
 					return err

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
@@ -106,7 +108,7 @@ func (t *leaseTest) expectLeases(descID sqlbase.ID, expected string) {
 
 func (t *leaseTest) acquire(nodeID uint32, descID sqlbase.ID, version sqlbase.DescriptorVersion) (*csql.LeaseState, error) {
 	var lease *csql.LeaseState
-	err := t.kvDB.Txn(func(txn *client.Txn) error {
+	err := t.kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 		var err error
 		lease, err = t.node(nodeID).Acquire(txn, descID, version)
 		return err
@@ -470,7 +472,7 @@ func isDeleted(tableID sqlbase.ID, cfg config.SystemConfig) bool {
 
 func acquire(s *server.TestServer, descID sqlbase.ID, version sqlbase.DescriptorVersion) (*csql.LeaseState, error) {
 	var lease *csql.LeaseState
-	err := s.DB().Txn(func(txn *client.Txn) error {
+	err := s.DB().Txn(context.TODO(), func(txn *client.Txn) error {
 		var err error
 		lease, err = s.LeaseManager().(*csql.LeaseManager).Acquire(txn, descID, version)
 		return err

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -99,7 +99,7 @@ var errExistingSchemaChangeLease = errors.New(
 // an unexpired lease doesn't exist. It returns the lease.
 func (sc *SchemaChanger) AcquireLease() (sqlbase.TableDescriptor_SchemaChangeLease, error) {
 	var lease sqlbase.TableDescriptor_SchemaChangeLease
-	err := sc.db.Txn(func(txn *client.Txn) error {
+	err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		txn.SetSystemConfigTrigger()
 		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {
@@ -145,7 +145,7 @@ func (sc *SchemaChanger) findTableWithLease(
 // ReleaseLease the table lease if it is the one registered with
 // the table descriptor.
 func (sc *SchemaChanger) ReleaseLease(lease sqlbase.TableDescriptor_SchemaChangeLease) error {
-	err := sc.db.Txn(func(txn *client.Txn) error {
+	err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		tableDesc, err := sc.findTableWithLease(txn, lease)
 		if err != nil {
 			return err
@@ -170,7 +170,7 @@ func (sc *SchemaChanger) ExtendLease(
 	}
 	// Update lease.
 	var lease sqlbase.TableDescriptor_SchemaChangeLease
-	err := sc.db.Txn(func(txn *client.Txn) error {
+	err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		tableDesc, err := sc.findTableWithLease(txn, existingLease)
 		if err != nil {
 			return err
@@ -281,7 +281,7 @@ func (sc SchemaChanger) exec(
 			oldNameNotInUseNotification()
 		}
 		// Free up the old name(s).
-		err := sc.db.Txn(func(txn *client.Txn) error {
+		err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 			b := txn.NewBatch()
 			for _, renameDetails := range table.Renames {
 				tbKey := tableKey{renameDetails.OldParentID, renameDetails.OldName}.Key()
@@ -603,7 +603,7 @@ func (sc *SchemaChanger) deleteIndexMutationsWithReversedColumns(
 // is complete.
 func (sc *SchemaChanger) IsDone() (bool, error) {
 	var done bool
-	err := sc.db.Txn(func(txn *client.Txn) error {
+	err := sc.db.Txn(context.TODO(), func(txn *client.Txn) error {
 		done = true
 		tableDesc, err := sqlbase.GetTableDescFromID(txn, sc.tableID)
 		if err != nil {

--- a/storage/client_metrics_test.go
+++ b/storage/client_metrics_test.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage"
@@ -214,7 +216,7 @@ func TestStoreMetrics(t *testing.T) {
 
 	// Create a transaction statement that fails, but will add an entry to the
 	// sequence cache. Regression test for #4969.
-	if err := mtc.dbs[0].Txn(func(txn *client.Txn) error {
+	if err := mtc.dbs[0].Txn(context.TODO(), func(txn *client.Txn) error {
 		b := txn.NewBatch()
 		b.CPut(dataKey, 7, 6)
 		return txn.Run(b)

--- a/storage/client_replica_test.go
+++ b/storage/client_replica_test.go
@@ -243,7 +243,7 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 		// Start a txn that does read-after-write.
 		// The txn will be restarted twice, and the out-of-order put
 		// will happen in the second epoch.
-		if err := store.DB().Txn(func(txn *client.Txn) error {
+		if err := store.DB().Txn(context.TODO(), func(txn *client.Txn) error {
 			epoch++
 
 			if epoch == 1 {

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -110,7 +110,7 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 	}
 
 	// Update SystemConfig to trigger gossip.
-	if err := store.DB().Txn(func(txn *client.Txn) error {
+	if err := store.DB().Txn(context.TODO(), func(txn *client.Txn) error {
 		txn.SetSystemConfigTrigger()
 		// We don't care about the values, just the keys.
 		k := sqlbase.MakeDescMetadataKey(sqlbase.ID(keys.MaxReservedDescID + 1))
@@ -788,7 +788,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 	// - descriptor IDs are used to determine split keys
 	// - the write triggers a SystemConfig update and gossip.
 	// We should end up with splits at each user table prefix.
-	if err := store.DB().Txn(func(txn *client.Txn) error {
+	if err := store.DB().Txn(context.TODO(), func(txn *client.Txn) error {
 		prefix := keys.MakeTablePrefix(keys.DescriptorTableID)
 		txn.SetSystemConfigTrigger()
 		for i, kv := range initialSystemValues {
@@ -861,7 +861,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 	numTotalValues := keys.MaxSystemConfigDescID + server.ExpectedInitialRangeCount()
 
 	// Write another, disjoint descriptor for a user table.
-	if err := store.DB().Txn(func(txn *client.Txn) error {
+	if err := store.DB().Txn(context.TODO(), func(txn *client.Txn) error {
 		txn.SetSystemConfigTrigger()
 		// This time, only write the last table descriptor. Splits
 		// still occur for every intervening ID.

--- a/storage/log_test.go
+++ b/storage/log_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/keys"
@@ -152,7 +154,7 @@ func TestLogRebalances(t *testing.T) {
 
 	// Log several fake events using the store.
 	logEvent := func(changeType roachpb.ReplicaChangeType) {
-		if err := db.Txn(func(txn *client.Txn) error {
+		if err := db.Txn(context.TODO(), func(txn *client.Txn) error {
 			return store.LogReplicaChangeTest(txn, changeType, desc.Replicas[0], *desc)
 		}); err != nil {
 			t.Fatal(err)

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -2215,7 +2215,7 @@ func (r *Replica) AdminSplit(
 
 	log.Infof(ctx, "%s: initiating a split of this range at key %s", r, splitKey)
 
-	if err := r.store.DB().Txn(func(txn *client.Txn) error {
+	if err := r.store.DB().Txn(context.TODO(), func(txn *client.Txn) error {
 		log.Trace(ctx, "split closure begins")
 		defer log.Trace(ctx, "split closure ends")
 		// Update existing range descriptor for left hand side of
@@ -2652,7 +2652,7 @@ func (r *Replica) AdminMerge(
 		log.Infof(ctx, "%s: initiating a merge of %s into this range", r, rightRng)
 	}
 
-	if err := r.store.DB().Txn(func(txn *client.Txn) error {
+	if err := r.store.DB().Txn(context.TODO(), func(txn *client.Txn) error {
 		log.Trace(ctx, "merge closure begins")
 		// Update the range descriptor for the receiving range.
 		{
@@ -3044,7 +3044,7 @@ func (r *Replica) ChangeReplicas(
 
 	descKey := keys.RangeDescriptorKey(desc.StartKey)
 
-	if err := r.store.DB().Txn(func(txn *client.Txn) error {
+	if err := r.store.DB().Txn(context.TODO(), func(txn *client.Txn) error {
 		log.Trace(ctx, "attempting txn")
 		txn.Proto.Name = replicaChangeTxnName
 		// TODO(tschottdorf): oldDesc is used for sanity checks related to #7224.


### PR DESCRIPTION
Mechanic change to add a Context argument to db.Txn(); for now context.TODO() is
used in all call sites.

@andreimatei

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8459)

<!-- Reviewable:end -->
