### PR TITLE
tracing: support storing Tracer in Context

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -160,6 +160,10 @@ type Context struct {
 
 	// TestingKnobs is used for internal test controls only.
 	TestingKnobs base.TestingKnobs
+
+	// Ctx is the base context.Context for the server. If nil,
+	// context.Background() will be used.
+	Ctx context.Context
 }
 
 // GetTotalMemory returns either the total system memory or if possible the

--- a/server/server.go
+++ b/server/server.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/elazarl/go-bindata-assetfs"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
@@ -74,7 +73,6 @@ var (
 
 // Server is the cockroach server node.
 type Server struct {
-	Tracer        opentracing.Tracer
 	ctx           Context
 	mux           *http.ServeMux
 	clock         *hlc.Clock
@@ -102,35 +100,49 @@ type Server struct {
 }
 
 // NewServer creates a Server from a server.Context.
-func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
-	if _, err := net.ResolveTCPAddr("tcp", ctx.Addr); err != nil {
-		return nil, errors.Errorf("unable to resolve RPC address %q: %v", ctx.Addr, err)
+func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
+	if _, err := net.ResolveTCPAddr("tcp", srvCtx.Addr); err != nil {
+		return nil, errors.Errorf("unable to resolve RPC address %q: %v", srvCtx.Addr, err)
 	}
 
-	if ctx.Insecure {
-		log.Warning(context.TODO(), "running in insecure mode, this is strongly discouraged. See --insecure.")
+	if srvCtx.Ctx == nil {
+		srvCtx.Ctx = context.Background()
+	}
+	if srvCtx.Ctx.Done() != nil {
+		panic("context with cancel or deadline")
+	}
+	tracer := tracing.TracerFromCtx(srvCtx.Ctx)
+	if tracer == nil {
+		tracer = tracing.NewTracer()
+		// TODO(radu): instead of modifying srvCtx.Ctx, we should have a separate
+		// context.Context inside Server. We will need to rename server.Context
+		// though.
+		srvCtx.Ctx = tracing.WithTracer(srvCtx.Ctx, tracer)
+	}
+
+	if srvCtx.Insecure {
+		log.Warning(srvCtx.Ctx, "running in insecure mode, this is strongly discouraged. See --insecure.")
 	}
 	// Try loading the TLS configs before anything else.
-	if _, err := ctx.GetServerTLSConfig(); err != nil {
+	if _, err := srvCtx.GetServerTLSConfig(); err != nil {
 		return nil, err
 	}
-	if _, err := ctx.GetClientTLSConfig(); err != nil {
+	if _, err := srvCtx.GetClientTLSConfig(); err != nil {
 		return nil, err
 	}
 
 	s := &Server{
-		Tracer:  tracing.NewTracer(),
-		ctx:     ctx,
+		ctx:     srvCtx,
 		mux:     http.NewServeMux(),
 		clock:   hlc.NewClock(hlc.UnixNano),
 		stopper: stopper,
 	}
-	s.clock.SetMaxOffset(ctx.MaxOffset)
+	s.clock.SetMaxOffset(srvCtx.MaxOffset)
 
-	s.rpcContext = rpc.NewContext(ctx.Context, s.clock, s.stopper)
+	s.rpcContext = rpc.NewContext(srvCtx.Context, s.clock, s.stopper)
 	s.rpcContext.HeartbeatCB = func() {
 		if err := s.rpcContext.RemoteClocks.VerifyClockOffset(); err != nil {
-			log.Fatal(context.TODO(), err)
+			log.Fatal(s.Ctx(), err)
 		}
 	}
 	s.grpc = rpc.NewServer(s.rpcContext)
@@ -141,8 +153,8 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 		s.gossip,
 		s.clock,
 		s.rpcContext,
-		ctx.ReservationsEnabled,
-		ctx.TimeUntilStoreDead,
+		srvCtx.ReservationsEnabled,
+		srvCtx.TimeUntilStoreDead,
 		s.stopper,
 	)
 
@@ -166,7 +178,7 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 	}, s.gossip)
 	txnMetrics := kv.MakeTxnMetrics()
 	s.registry.AddMetricStruct(txnMetrics)
-	sender := kv.NewTxnCoordSender(s.distSender, s.clock, ctx.Linearizable, s.Tracer,
+	sender := kv.NewTxnCoordSender(s.distSender, s.clock, srvCtx.Linearizable, tracer,
 		s.stopper, txnMetrics)
 	s.db = client.NewDB(sender)
 
@@ -177,15 +189,15 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 
 	// Set up Lease Manager
 	var lmKnobs sql.LeaseManagerTestingKnobs
-	if ctx.TestingKnobs.SQLLeaseManager != nil {
-		lmKnobs = *ctx.TestingKnobs.SQLLeaseManager.(*sql.LeaseManagerTestingKnobs)
+	if srvCtx.TestingKnobs.SQLLeaseManager != nil {
+		lmKnobs = *srvCtx.TestingKnobs.SQLLeaseManager.(*sql.LeaseManagerTestingKnobs)
 	}
 	s.leaseMgr = sql.NewLeaseManager(0, *s.db, s.clock, lmKnobs, s.stopper)
 	s.leaseMgr.RefreshLeases(s.stopper, s.db, s.gossip)
 
 	// Set up the DistSQL server
 	distSQLCfg := distsql.ServerConfig{
-		Context:    context.Background(),
+		Context:    s.Ctx(),
 		DB:         s.db,
 		RPCContext: s.rpcContext,
 	}
@@ -194,15 +206,15 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 
 	// Set up Executor
 	execCfg := sql.ExecutorConfig{
-		Context:      context.Background(),
+		Context:      s.Ctx(),
 		DB:           s.db,
 		Gossip:       s.gossip,
 		LeaseManager: s.leaseMgr,
 		Clock:        s.clock,
 		DistSQLSrv:   s.distSQLServer,
 	}
-	if ctx.TestingKnobs.SQLExecutor != nil {
-		execCfg.TestingKnobs = ctx.TestingKnobs.SQLExecutor.(*sql.ExecutorTestingKnobs)
+	if srvCtx.TestingKnobs.SQLExecutor != nil {
+		execCfg.TestingKnobs = srvCtx.TestingKnobs.SQLExecutor.(*sql.ExecutorTestingKnobs)
 	} else {
 		execCfg.TestingKnobs = &sql.ExecutorTestingKnobs{}
 	}
@@ -224,7 +236,7 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 		ScanMaxIdleTime:                s.ctx.ScanMaxIdleTime,
 		ConsistencyCheckInterval:       s.ctx.ConsistencyCheckInterval,
 		ConsistencyCheckPanicOnFailure: s.ctx.ConsistencyCheckPanicOnFailure,
-		Tracer:    s.Tracer,
+		Tracer:    tracer,
 		StorePool: s.storePool,
 		SQLExecutor: sql.InternalExecutor{
 			LeaseManager: s.leaseMgr,
@@ -234,8 +246,8 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 			AllowRebalance: true,
 		},
 	}
-	if ctx.TestingKnobs.Store != nil {
-		nCtx.TestingKnobs = *ctx.TestingKnobs.Store.(*storage.StoreTestingKnobs)
+	if srvCtx.TestingKnobs.Store != nil {
+		nCtx.TestingKnobs = *srvCtx.TestingKnobs.Store.(*storage.StoreTestingKnobs)
 	}
 
 	s.recorder = status.NewMetricsRecorder(s.clock)
@@ -258,6 +270,11 @@ func NewServer(ctx Context, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	return s, nil
+}
+
+// Ctx returns the base context for the server.
+func (s *Server) Ctx() context.Context {
+	return s.ctx.Ctx
 }
 
 // grpcGatewayServer represents a grpc service with HTTP endpoints through GRPC
@@ -334,7 +351,7 @@ func (s *Server) Start() error {
 	s.stopper.RunWorker(func() {
 		<-s.stopper.ShouldQuiesce()
 		if err := httpLn.Close(); err != nil {
-			log.Fatal(context.TODO(), err)
+			log.Fatal(s.Ctx(), err)
 		}
 	})
 
@@ -372,7 +389,7 @@ func (s *Server) Start() error {
 	s.stopper.RunWorker(func() {
 		netutil.FatalIfUnexpected(httpServer.ServeWith(s.stopper, pgL, func(conn net.Conn) {
 			if err := s.pgServer.ServeConn(conn); err != nil && !netutil.IsClosedConnection(err) {
-				log.Error(context.TODO(), err)
+				log.Error(s.Ctx(), err)
 			}
 		}))
 	})
@@ -387,7 +404,7 @@ func (s *Server) Start() error {
 		s.stopper.RunWorker(func() {
 			<-s.stopper.ShouldQuiesce()
 			if err := unixLn.Close(); err != nil {
-				log.Fatal(context.TODO(), err)
+				log.Fatal(s.Ctx(), err)
 			}
 		})
 
@@ -395,7 +412,7 @@ func (s *Server) Start() error {
 			netutil.FatalIfUnexpected(httpServer.ServeWith(s.stopper, unixLn, func(conn net.Conn) {
 				if err := s.pgServer.ServeConn(conn); err != nil &&
 					!netutil.IsClosedConnection(err) {
-					log.Error(context.TODO(), err)
+					log.Error(s.Ctx(), err)
 				}
 			}))
 		})
@@ -403,8 +420,7 @@ func (s *Server) Start() error {
 
 	s.gossip.Start(unresolvedAddr)
 
-	ctx := context.Background()
-	if err := s.node.start(ctx, unresolvedAddr, s.ctx.Engines, s.ctx.NodeAttributes); err != nil {
+	if err := s.node.start(s.Ctx(), unresolvedAddr, s.ctx.Engines, s.ctx.NodeAttributes); err != nil {
 		return err
 	}
 
@@ -431,10 +447,10 @@ func (s *Server) Start() error {
 	}
 	sql.NewSchemaChangeManager(testingKnobs, *s.db, s.gossip, s.leaseMgr).Start(s.stopper)
 
-	log.Infof(context.TODO(), "starting %s server at %s", s.ctx.HTTPRequestScheme(), unresolvedHTTPAddr)
-	log.Infof(context.TODO(), "starting grpc/postgres server at %s", unresolvedAddr)
+	log.Infof(s.Ctx(), "starting %s server at %s", s.ctx.HTTPRequestScheme(), unresolvedHTTPAddr)
+	log.Infof(s.Ctx(), "starting grpc/postgres server at %s", unresolvedAddr)
 	if len(s.ctx.SocketFile) != 0 {
-		log.Infof(context.TODO(), "starting postgres server at unix:%s", s.ctx.SocketFile)
+		log.Infof(s.Ctx(), "starting postgres server at unix:%s", s.ctx.SocketFile)
 	}
 
 	s.stopper.RunWorker(func() {
@@ -455,7 +471,7 @@ func (s *Server) Start() error {
 		gwruntime.WithMarshalerOption(util.ProtoContentType, protopb),
 		gwruntime.WithMarshalerOption(util.AltProtoContentType, protopb),
 	)
-	gwCtx, gwCancel := context.WithCancel(ctx)
+	gwCtx, gwCancel := context.WithCancel(s.Ctx())
 	s.stopper.AddCloser(stop.CloserFn(gwCancel))
 
 	// Setup HTTP<->gRPC handlers.
@@ -503,7 +519,7 @@ func (s *Server) Start() error {
 	s.mux.Handle(healthEndpoint, s.status)
 
 	if err := sdnotify.Ready(); err != nil {
-		log.Errorf(context.TODO(), "failed to signal readiness using systemd protocol: %s", err)
+		log.Errorf(s.Ctx(), "failed to signal readiness using systemd protocol: %s", err)
 	}
 
 	return nil

--- a/util/tracing/tracer.go
+++ b/util/tracing/tracer.go
@@ -141,3 +141,22 @@ func EncodeRawSpan(rawSpan *basictracer.RawSpan, dest []byte) ([]byte, error) {
 func DecodeRawSpan(enc []byte, dest *basictracer.RawSpan) error {
 	return gob.NewDecoder(bytes.NewBuffer(enc)).Decode(dest)
 }
+
+// contextTracerKeyType is an empty type for the handle associated with the
+// tracer value (see context.Value).
+type contextTracerKeyType struct{}
+
+// WithTracer returns a context derived from the given context, for which
+// TracerFromCtx returns the given tracer.
+func WithTracer(ctx context.Context, tracer opentracing.Tracer) context.Context {
+	return context.WithValue(ctx, contextTracerKeyType{}, tracer)
+}
+
+// TracerFromCtx returns the tracer set on the context (or a parent context) via
+// WithTracer.
+func TracerFromCtx(ctx context.Context) opentracing.Tracer {
+	if tracerVal := ctx.Value(contextTracerKeyType{}); tracerVal != nil {
+		return tracerVal.(opentracing.Tracer)
+	}
+	return nil
+}


### PR DESCRIPTION
Allowing NewServer to be passed a context that can have a Tracer already set.
This would (for example) allow disabling tracing for this server without using
the global Disable().

The intention is that we will remove the Tracer fields from various contexts and
instead plumb Contexts.

@andreimatei @petermattis

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8467)

<!-- Reviewable:end -->
