### PR TITLE
acceptance: terrafarm cleanups

### DIFF
--- a/acceptance/allocator_test.go
+++ b/acceptance/allocator_test.go
@@ -135,20 +135,9 @@ func (at *allocatorTest) Cleanup(t *testing.T) {
 func (at *allocatorTest) Run(t *testing.T) {
 	at.f = farmer(t, at.Prefix)
 
-	// Pass on overrides to Terraform input variables.
-	if *flagATCockroachBinary != "" {
-		at.f.AddVars["cockroach_binary"] = *flagATCockroachBinary
-	}
-	if *flagATCockroachFlags != "" {
-		at.f.AddVars["cockroach_flags"] = *flagATCockroachFlags
-	}
-	if *flagATCockroachEnv != "" {
-		at.f.AddVars["cockroach_env"] = *flagATCockroachEnv
-	}
 	if at.CockroachDiskSizeGB != 0 {
 		at.f.AddVars["cockroach_disk_size"] = strconv.Itoa(at.CockroachDiskSizeGB)
 	}
-	at.f.AddVars["cockroach_disk_type"] = *flagATDiskType
 
 	log.Infof(context.Background(), "creating cluster with %d node(s)", at.StartNodes)
 	if err := at.f.Resize(at.StartNodes); err != nil {

--- a/acceptance/terraform/supervisor.conf.tpl
+++ b/acceptance/terraform/supervisor.conf.tpl
@@ -22,7 +22,7 @@ serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
 
 [program:cockroach]
 directory=%(here)s
-command=%(here)s/cockroach start --alsologtostderr=true ${stores} --insecure --join=${join_address} --verbosity=1 ${cockroach_flags}
+command=%(here)s/cockroach start --logtostderr=true ${stores} --insecure --join=${join_address} --cache=2GiB ${cockroach_flags}
 process_name=%(program_name)s
 numprocs=1
 autostart=false
@@ -36,7 +36,7 @@ environment=${cockroach_env}
 
 [program:block_writer]
 directory=%(here)s
-command=%(here)s/block_writer -concurrency 10 -min-block-bytes=16384 -max-block-bytes=65535 --tolerate-errors -benchmark-name ${benchmark_name} 'postgres://root@$localhost:${cockroach_port}/?sslmode=disable'
+command=%(here)s/block_writer --concurrency 5 --tolerate-errors -benchmark-name ${benchmark_name} 'postgres://root@$localhost:${cockroach_port}/?sslmode=disable'
 process_name=%(program_name)s
 numprocs=1
 autostart=false
@@ -48,7 +48,7 @@ stdout_logfile=%(here)s/logs/%(program_name)s.stdout
 
 [program:photos]
 directory=%(here)s
-command=%(here)s/photos --users 3 --benchmark-name ${benchmark_name} --db postgres://root@localhost:${cockroach_port}/photos?sslmode=disable
+command=%(here)s/photos --users 1 --benchmark-name ${benchmark_name} --db postgres://root@localhost:${cockroach_port}/photos?sslmode=disable
 process_name=%(program_name)s
 numprocs=1
 autostart=false

--- a/acceptance/terraform/supervisor.conf.tpl
+++ b/acceptance/terraform/supervisor.conf.tpl
@@ -36,7 +36,7 @@ environment=${cockroach_env}
 
 [program:block_writer]
 directory=%(here)s
-command=%(here)s/block_writer --concurrency 5 --tolerate-errors -benchmark-name ${benchmark_name} 'postgres://root@$localhost:${cockroach_port}/?sslmode=disable'
+command=%(here)s/block_writer --concurrency 5 --tolerate-errors --benchmark-name ${benchmark_name} 'postgres://root@$localhost:${cockroach_port}/?sslmode=disable'
 process_name=%(program_name)s
 numprocs=1
 autostart=false


### PR DESCRIPTION
**acceptance/terraform: sync with beta cluster cfg**
This brings the terrafarm clusters to  the beta cluster config for both
CockroachDB (notably 2 GiB cache size) and block_writer / photos
parameters.

**acceptance: clean up allocator vs. terrafarm flags**
Originally, the allocator tests were using a different Terraform config
than the other remote acceptance tests. This required unnaturally
putting certain flags (e.g. the one that lets you pass in a custom
`cockroach` binary) as allocator test flags.

This change allows any remote test using a `terrafarm.Farmer` to 
use these useful flags -- particularly our continuous load tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8472)

<!-- Reviewable:end -->
