### PR TITLE
sql: tweak COCKROACH_TRACE_SQL env var

### DIFF
--- a/sql/session.go
+++ b/sql/session.go
@@ -37,7 +37,14 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
-var traceSQL = envutil.EnvOrDefaultBool("trace_sql", false)
+// COCKROACH_TRACE_SQL=duration can be used to log SQL transactions that take
+// longer than duration to complete. For example, COCKROACH_TRACE_SQL=1s will
+// log the trace for any transaction that takes 1s or longer. To log traces for
+// all transactions use COCKROACH_TRACE_SQL=1ns. Note that any positive
+// duration will enable tracing and will slow down all execution because traces
+// are gathered for all transactions even if they are not output.
+var traceSQLDuration = envutil.EnvOrDefaultDuration("trace_sql", 0)
+var traceSQL = traceSQLDuration > 0
 
 // Session contains the state of a SQL client connection.
 // Create instances using NewSession().
@@ -223,9 +230,11 @@ func (ts *txnState) resetStateAndTxn(state TxnStateEnum) {
 func (ts *txnState) dumpTrace() {
 	if traceSQL && ts.txn != nil {
 		ts.sp.Finish()
-		dump := tracing.FormatRawSpans(ts.txn.CollectedSpans)
-		if len(dump) > 0 {
-			log.Infof(context.Background(), "%s\n%s", ts.txn.Proto.ID, dump)
+		if time.Since(ts.sqlTimestamp) >= traceSQLDuration {
+			dump := tracing.FormatRawSpans(ts.txn.CollectedSpans)
+			if len(dump) > 0 {
+				log.Infof(context.Background(), "%s\n%s", ts.txn.Proto.ID, dump)
+			}
 		}
 	}
 	ts.sp = nil


### PR DESCRIPTION
The variable now contains a duration instead of a
boolean. COCKROACH_TRACE_SQL=2s will log the trace of any transaction
that takes more than 2 seconds. This reduces log spam when all you want
is traces for long running transactions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8489)

<!-- Reviewable:end -->
