### PR TITLE
build: Correctly detect failures in check-style.sh

### DIFF
--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -153,9 +153,10 @@ runcheck() {
   echo "=== RUN $name"
   start=$(date +%s)
   output=$(eval "$name")
+  status=$?
   end=$(date +%s)
   runtime=$((end-start))
-  if [ $? -eq 0 ]; then
+  if [ $status -eq 0 ]; then
     echo "--- PASS: $name ($runtime.00s)"
   else
     echo "--- FAIL: $name ($runtime.00s)"

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -880,8 +880,6 @@ func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*
 
 		log.Trace(ctx, "querying next range")
 	}
-
-	return br, nil, false
 }
 
 // fillSkippedResponses after meeting the batch key max limit for range

--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -577,7 +577,7 @@ func (buf *buffer) someDigits(i, d int) int {
 }
 
 func formatLogEntry(entry Entry, stacks []byte, colors *colorProfile) *buffer {
-	buf := formatHeader(Severity(entry.Severity), time.Unix(0, entry.Time),
+	buf := formatHeader(entry.Severity, time.Unix(0, entry.Time),
 		entry.File, int(entry.Line), colors)
 	_, _ = buf.WriteString(entry.Message)
 	if buf.Bytes()[buf.Len()-1] != '\n' {


### PR DESCRIPTION
Since #8424, `check-style.sh` has been looking at the result of `date`
instead of the exit status of the checker, so it would always pass.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8490)

<!-- Reviewable:end -->
