### PR TITLE
stability: raft entry log cache to avoid busy waiting fetching last t…

### DIFF
--- a/server/debug.go
+++ b/server/debug.go
@@ -112,10 +112,12 @@ table tr td {
 <td>pprof</td>
 <td>
 <!-- cribbed from the /debug/pprof endpoint -->
-<a href="./pprof/block?debug=1">block</a><br />
-<a href="./pprof/goroutine?debug=1">goroutine</a> (<a href="./pprof/goroutine?debug=2">all</a>)<br />
 <a href="./pprof/heap?debug=1">heap</a><br />
+<a href="./pprof/profile?debug=1">profile</a><br />
+<a href="./pprof/block?debug=1">block</a><br />
+<a href="./pprof/trace?debug=1">heap</a><br />
 <a href="./pprof/threadcreate?debug=1">threadcreate</a><br />
+<a href="./pprof/goroutine?debug=1">goroutine</a> (<a href="./pprof/goroutine?debug=2">all</a>)<br />
 </td>
 </tr>
 </table>

--- a/storage/entry_cache.go
+++ b/storage/entry_cache.go
@@ -1,0 +1,159 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Spencer Kimball (spencer@cockroachlabs.com)
+
+package storage
+
+import (
+	"github.com/biogo/store/llrb"
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util/cache"
+	"github.com/cockroachdb/cockroach/util/syncutil"
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+type entryCacheKey struct {
+	RangeID roachpb.RangeID
+	Index   uint64
+}
+
+// Compare implements the llrb.Comparable interface for entryCacheKey, so that
+// it can be used as a key for util.OrderedCache.
+func (a entryCacheKey) Compare(b llrb.Comparable) int {
+	bk := b.(entryCacheKey)
+	switch {
+	case a.RangeID < bk.RangeID:
+		return -1
+	case a.RangeID > bk.RangeID:
+		return 1
+	case a.Index < bk.Index:
+		return -1
+	case a.Index > bk.Index:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// A raftEntryCache maintains a global cache of Raft group log
+// entries. The cache mostly prevents unnecessary reads from disk of
+// recently-written log entries between log append and application
+// to the FSM.
+type raftEntryCache struct {
+	syncutil.RWMutex                     // protects Cache for concurrent access.
+	bytes            uint64              // total size of the cache in bytes
+	cache            *cache.OrderedCache // LRU cache of log entries, keyed by rangeID / log index
+}
+
+// newRaftEntryCache returns a new RaftEntryCache with the given
+// maximum size in bytes.
+func newRaftEntryCache(maxBytes uint64) *raftEntryCache {
+	rec := &raftEntryCache{
+		cache: cache.NewOrderedCache(cache.Config{Policy: cache.CacheLRU}),
+	}
+	// The raft entry cache mutex will be held when the ShouldEvict
+	// and OnEvicted callbacks are invoked.
+	//
+	// On ShouldEvict, compare the total size of the cache in bytes to the
+	// configured maxBytes. We also insist that at least one entry remains
+	// in the cache to prevent the case where a very large entry isn't able
+	// to be cached at all.
+	rec.cache.Config.ShouldEvict = func(n int, k, v interface{}) bool {
+		return rec.bytes > maxBytes && n >= 1
+	}
+	rec.cache.Config.OnEvicted = func(k, v interface{}) {
+		ent := v.(raftpb.Entry)
+		rec.bytes -= uint64(ent.Size())
+	}
+
+	return rec
+}
+
+// addEntries adds the slice of raft entries, using the range ID and the
+// entry indexes as each cached entry's key.
+func (rec *raftEntryCache) addEntries(rangeID roachpb.RangeID, ents []raftpb.Entry) {
+	if len(ents) == 0 {
+		return
+	}
+	rec.Lock()
+	defer rec.Unlock()
+
+	for _, e := range ents {
+		rec.bytes += uint64(e.Size())
+		rec.cache.Add(entryCacheKey{RangeID: rangeID, Index: e.Index}, e)
+	}
+}
+
+// getEntries returns entries between [lo, hi) for specified range.
+// If any entries are returned for the specified indexes, they will
+// start with index lo and proceed sequentially without gaps until
+// 1) all entries exclusive of hi are fetched, 2) > maxBytes of
+// entries data is fetched, or 3) a cache miss occurs.
+func (rec *raftEntryCache) getEntries(rangeID roachpb.RangeID, lo, hi, maxBytes uint64) (
+	[]raftpb.Entry, uint64 /* size in bytes */, uint64 /* next log index */) {
+	rec.Lock()
+	defer rec.Unlock()
+	var ents []raftpb.Entry
+	var ent raftpb.Entry
+	var bytes uint64
+	nextIndex := lo
+
+	fromKey := entryCacheKey{RangeID: rangeID, Index: lo}
+	toKey := entryCacheKey{RangeID: rangeID, Index: hi}
+	rec.cache.DoRange(func(k, v interface{}) bool {
+		ecKey := k.(entryCacheKey)
+		if ecKey.Index != nextIndex {
+			return true
+		}
+		ent = v.(raftpb.Entry)
+		ents = append(ents, ent)
+		bytes += uint64(ent.Size())
+		nextIndex++
+		if maxBytes > 0 && bytes > maxBytes {
+			return true
+		}
+		return false
+	}, fromKey, toKey)
+
+	return ents, bytes, nextIndex
+}
+
+// delEntries deletes entries between [lo, hi) for specified range.
+func (rec *raftEntryCache) delEntries(rangeID roachpb.RangeID, lo, hi uint64) {
+	rec.Lock()
+	defer rec.Unlock()
+	if lo >= hi {
+		return
+	}
+	var keys []entryCacheKey
+	fromKey := entryCacheKey{RangeID: rangeID, Index: lo}
+	toKey := entryCacheKey{RangeID: rangeID, Index: hi}
+	rec.cache.DoRange(func(k, v interface{}) bool {
+		keys = append(keys, k.(entryCacheKey))
+		return false
+	}, fromKey, toKey)
+
+	for _, k := range keys {
+		rec.cache.Del(k)
+	}
+	return
+}
+
+// clearTo clears the entries in the cache for specified range up to,
+// but not including the specified index.
+func (rec *raftEntryCache) clearTo(rangeID roachpb.RangeID, index uint64) {
+	rec.delEntries(rangeID, 0, index)
+}

--- a/storage/entry_cache_test.go
+++ b/storage/entry_cache_test.go
@@ -1,0 +1,120 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Spencer Kimball (spencer.kimball@gmail.com)
+
+package storage
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+func newEntry(index, size uint64) raftpb.Entry {
+	return raftpb.Entry{
+		Index: index,
+		Data:  make([]byte, size, size),
+	}
+}
+
+func addEntries(rec *raftEntryCache, rangeID roachpb.RangeID, lo, hi uint64) []raftpb.Entry {
+	ents := []raftpb.Entry{}
+	for i := lo; i < hi; i++ {
+		ents = append(ents, newEntry(i, 1))
+	}
+	rec.addEntries(rangeID, ents)
+	return ents
+}
+
+func verifyGet(t *testing.T, rec *raftEntryCache, rangeID roachpb.RangeID, lo, hi uint64, expEnts []raftpb.Entry, expNextIndex uint64) {
+	ents, _, nextIndex := rec.getEntries(rangeID, lo, hi, 0)
+	if !(len(expEnts) == 0 && len(ents) == 0) && !reflect.DeepEqual(expEnts, ents) {
+		t.Fatalf("expected entries %+v; got %+v", expEnts, ents)
+	}
+	if nextIndex != expNextIndex {
+		t.Fatalf("expected next index %d; got %d", nextIndex, expNextIndex)
+	}
+}
+
+func TestEntryCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	rec := newRaftEntryCache(100)
+	rangeID := roachpb.RangeID(2)
+	// Add entries for range 1, indexes (1-10).
+	ents := addEntries(rec, rangeID, 1, 11)
+	// Fetch all data with an exact match.
+	verifyGet(t, rec, rangeID, 1, 11, ents, 11)
+	// Fetch point entry.
+	verifyGet(t, rec, rangeID, 1, 2, ents[0:1], 2)
+	// Fetch overlapping first half.
+	verifyGet(t, rec, rangeID, 0, 5, []raftpb.Entry{}, 0)
+	// Fetch overlapping second half.
+	verifyGet(t, rec, rangeID, 9, 12, ents[8:], 11)
+	// Fetch data from earlier range.
+	verifyGet(t, rec, roachpb.RangeID(1), 1, 11, []raftpb.Entry{}, 1)
+	// Fetch data from later range.
+	verifyGet(t, rec, roachpb.RangeID(3), 1, 11, []raftpb.Entry{}, 1)
+	// Create a gap in the entries.
+	rec.delEntries(rangeID, 4, 8)
+	// Fetch all data; verify we get only first three.
+	verifyGet(t, rec, rangeID, 1, 11, ents[0:3], 4)
+	// Try to fetch from within the gap; expect no entries.
+	verifyGet(t, rec, rangeID, 5, 11, []raftpb.Entry{}, 5)
+	// Fetch after the gap.
+	verifyGet(t, rec, rangeID, 8, 11, ents[7:], 11)
+	// Delete the prefix of entries.
+	rec.delEntries(rangeID, 1, 3)
+	// Verify entries are gone.
+	verifyGet(t, rec, rangeID, 1, 5, []raftpb.Entry{}, 1)
+	// Delete the suffix of entries.
+	rec.delEntries(rangeID, 10, 11)
+	// Verify get of entries at end of range.
+	verifyGet(t, rec, rangeID, 8, 11, ents[7:9], 10)
+}
+
+func TestEntryCacheClearTo(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	rangeID := roachpb.RangeID(1)
+	rec := newRaftEntryCache(100)
+	rec.addEntries(rangeID, []raftpb.Entry{newEntry(2, 1)})
+	rec.addEntries(rangeID, []raftpb.Entry{newEntry(20, 1), newEntry(21, 1)})
+	rec.clearTo(rangeID, 21)
+	if ents, _, _ := rec.getEntries(rangeID, 2, 21, 0); len(ents) != 0 {
+		t.Errorf("expected no entries after clearTo")
+	}
+	if ents, _, _ := rec.getEntries(rangeID, 21, 22, 0); len(ents) != 1 {
+		t.Errorf("expected entry 22 to remain in the cache clearTo")
+	}
+}
+
+func TestEntryCacheEviction(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	rangeID := roachpb.RangeID(1)
+	rec := newRaftEntryCache(100)
+	rec.addEntries(rangeID, []raftpb.Entry{newEntry(1, 40), newEntry(2, 40)})
+	ents, _, hi := rec.getEntries(rangeID, 1, 3, 0)
+	if len(ents) != 2 {
+		t.Errorf("expected both entries; got %+v", ents)
+	}
+	// Add another entry to evict first.
+	rec.addEntries(rangeID, []raftpb.Entry{newEntry(3, 40)})
+	ents, _, hi = rec.getEntries(rangeID, 2, 4, 0)
+	if len(ents) != 2 || hi != 4 {
+		t.Errorf("expected only two entries; got %+v, %d", ents, hi)
+	}
+}

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -1600,8 +1600,11 @@ func (r *Replica) handleRaftReady() error {
 		return err
 	}
 
-	// Update protected state (last index, raft log size and raft leader ID).
+	// Update protected state (last index, raft log size and raft leader
+	// ID) and set raft log entry cache. We clear any older, uncommitted
+	// log entries and cache the latest ones.
 	r.mu.Lock()
+	r.store.raftEntryCache.addEntries(r.RangeID, rd.Entries)
 	r.mu.lastIndex = lastIndex
 	r.mu.raftLogSize = raftLogSize
 	r.mu.leaderID = leaderID

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -74,19 +74,18 @@ func (r *Replica) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 // Entries implements the raft.Storage interface. Note that maxBytes is advisory
 // and this method will always return at least one entry even if it exceeds
 // maxBytes. Passing maxBytes equal to zero disables size checking.
-// TODO(bdarnell): consider caching for recent entries, if rocksdb's built in
-// caching is insufficient.
 // Entries requires that the replica lock is held.
 func (r *Replica) Entries(lo, hi, maxBytes uint64) ([]raftpb.Entry, error) {
 	snap := r.store.NewSnapshot()
 	defer snap.Close()
-	return entries(context.Background(), snap, r.RangeID, lo, hi, maxBytes)
+	return entries(context.Background(), snap, r.RangeID, r.store.raftEntryCache, lo, hi, maxBytes)
 }
 
 func entries(
 	ctx context.Context,
 	e engine.Reader,
 	rangeID roachpb.RangeID,
+	eCache *raftEntryCache,
 	lo, hi, maxBytes uint64,
 ) ([]raftpb.Entry, error) {
 	if lo > hi {
@@ -96,8 +95,19 @@ func entries(
 	// stopping once we have enough.
 	ents := make([]raftpb.Entry, 0, hi-lo)
 	size := uint64(0)
+
+	hitEnts, hitSize, hitIndex := eCache.getEntries(rangeID, lo, hi, maxBytes)
+	// Return results if the correct number of results came back or if
+	// we ran into the max bytes limit.
+	if uint64(len(hitEnts)) == hi-lo || (maxBytes > 0 && hitSize > maxBytes) {
+		return hitEnts, nil
+	}
+
+	ents = append(ents, hitEnts...)
+	size += hitSize
+	expectedIndex := hitIndex
+
 	var ent raftpb.Entry
-	expectedIndex := lo
 	exceededMaxBytes := false
 	scanFunc := func(kv roachpb.KeyValue) (bool, error) {
 		if err := kv.Value.GetProto(&ent); err != nil {
@@ -114,9 +124,11 @@ func entries(
 		return exceededMaxBytes, nil
 	}
 
-	if err := iterateEntries(ctx, e, rangeID, lo, hi, scanFunc); err != nil {
+	if err := iterateEntries(ctx, e, rangeID, expectedIndex, hi, scanFunc); err != nil {
 		return nil, err
 	}
+	// Cache the fetched entries.
+	eCache.addEntries(rangeID, ents)
 
 	// Did the correct number of results come back? If so, we're all good.
 	if uint64(len(ents)) == hi-lo {
@@ -187,11 +199,17 @@ func iterateEntries(
 func (r *Replica) Term(i uint64) (uint64, error) {
 	snap := r.store.NewSnapshot()
 	defer snap.Close()
-	return term(context.Background(), snap, r.RangeID, i)
+	return term(context.Background(), snap, r.RangeID, r.store.raftEntryCache, i)
 }
 
-func term(ctx context.Context, eng engine.Reader, rangeID roachpb.RangeID, i uint64) (uint64, error) {
-	ents, err := entries(ctx, eng, rangeID, i, i+1, 0)
+func term(
+	ctx context.Context,
+	eng engine.Reader,
+	rangeID roachpb.RangeID,
+	eCache *raftEntryCache,
+	i uint64,
+) (uint64, error) {
+	ents, err := entries(ctx, eng, rangeID, eCache, i, i+1, 0)
 	if err == raft.ErrCompacted {
 		ts, err := loadTruncatedState(ctx, eng, rangeID)
 		if err != nil {
@@ -312,7 +330,7 @@ func (r *Replica) SnapshotWithContext(ctx context.Context) (raftpb.Snapshot, err
 		// Delegate to a static function to make sure that we do not depend
 		// on any indirect calls to r.store.Engine() (or other in-memory
 		// state of the Replica). Everything must come from the snapshot.
-		snapData, err := snapshot(context.Background(), snap, rangeID, startKey)
+		snapData, err := snapshot(context.Background(), snap, rangeID, r.store.raftEntryCache, startKey)
 		if err != nil {
 			log.Errorf(ctxInner, "%s: error generating snapshot: %s", r, err)
 		} else {
@@ -388,6 +406,7 @@ func snapshot(
 	ctx context.Context,
 	snap engine.Reader,
 	rangeID roachpb.RangeID,
+	eCache *raftEntryCache,
 	startKey roachpb.RKey,
 ) (raftpb.Snapshot, error) {
 	start := timeutil.Now()
@@ -465,7 +484,7 @@ func snapshot(
 		cs.Nodes = append(cs.Nodes, uint64(rep.ReplicaID))
 	}
 
-	term, err := term(ctx, snap, rangeID, appliedIndex)
+	term, err := term(ctx, snap, rangeID, eCache, appliedIndex)
 	if err != nil {
 		return raftpb.Snapshot{}, errors.Errorf("failed to fetch term of %d: %s", appliedIndex, err)
 	}

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -5002,71 +5002,113 @@ func TestEntries(t *testing.T) {
 	defer tc.Stop()
 	tc.rng.store.SetRaftLogQueueActive(false)
 
-	// Populate the log with 10 entries. Save the LastIndex after each write.
-	var indexes []uint64
-	for i := 0; i < 10; i++ {
-		args := incrementArgs([]byte("a"), int64(i))
-
-		if _, pErr := tc.SendWrapped(&args); pErr != nil {
-			t.Fatal(pErr)
-		}
-		idx, err := tc.rng.GetLastIndex()
-		if err != nil {
-			t.Fatal(err)
-		}
-		indexes = append(indexes, idx)
-	}
-
 	rng := tc.rng
 	rangeID := rng.RangeID
+	var indexes []uint64
 
-	// Discard the first half of the log.
-	truncateArgs := truncateLogArgs(indexes[5], rangeID)
-	if _, pErr := tc.SendWrapped(&truncateArgs); pErr != nil {
-		t.Fatal(pErr)
+	populateLogs := func(from, to int) []uint64 {
+		var newIndexes []uint64
+		for i := from; i < to; i++ {
+			args := incrementArgs([]byte("a"), int64(i))
+			if _, pErr := tc.SendWrapped(&args); pErr != nil {
+				t.Fatal(pErr)
+			}
+			idx, err := rng.GetLastIndex()
+			if err != nil {
+				t.Fatal(err)
+			}
+			newIndexes = append(newIndexes, idx)
+		}
+		return newIndexes
 	}
+
+	truncateLogs := func(index int) {
+		truncateArgs := truncateLogArgs(indexes[index], rangeID)
+		if _, err := client.SendWrapped(tc.Sender(), context.Background(), &truncateArgs); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Populate the log with 10 entries. Save the LastIndex after each write.
+	indexes = append(indexes, populateLogs(0, 10)...)
 
 	for i, tc := range []struct {
 		lo             uint64
 		hi             uint64
 		maxBytes       uint64
 		expResultCount int
+		expCacheCount  int
 		expError       error
+		// Setup, if not nil, is called before running the test case.
+		setup func()
 	}{
-		// Case 0: Just most of the entries.
-		{lo: indexes[5], hi: indexes[9], expResultCount: 4},
-		// Case 1: Get a single entry.
-		{lo: indexes[5], hi: indexes[6], expResultCount: 1},
-		// Case 2: Use MaxUint64 instead of 0 for maxBytes.
-		{lo: indexes[5], hi: indexes[9], maxBytes: math.MaxUint64, expResultCount: 4},
-		// Case 3: maxBytes is set low so only a single value should be
+		// Case 0: All of the entries from cache.
+		{lo: indexes[0], hi: indexes[9] + 1, expResultCount: 10, expCacheCount: 10, setup: nil},
+		// Case 1: Get the first entry from cache.
+		{lo: indexes[0], hi: indexes[1], expResultCount: 1, expCacheCount: 1, setup: nil},
+		// Case 2: Get the last entry from cache.
+		{lo: indexes[9], hi: indexes[9] + 1, expResultCount: 1, expCacheCount: 1, setup: nil},
+		// Case 3: lo is available, but hi is not, cache miss.
+		{lo: indexes[9], hi: indexes[9] + 2, expCacheCount: 1, expError: raft.ErrUnavailable, setup: nil},
+
+		// Case 4: Just most of the entries from cache.
+		{lo: indexes[5], hi: indexes[9], expResultCount: 4, expCacheCount: 4, setup: func() {
+			// Discard the first half of the log.
+			truncateLogs(5)
+		}},
+		// Case 5: Get a single entry from cache.
+		{lo: indexes[5], hi: indexes[6], expResultCount: 1, expCacheCount: 1, setup: nil},
+		// Case 6: Use MaxUint64 instead of 0 for maxBytes.
+		{lo: indexes[5], hi: indexes[9], maxBytes: math.MaxUint64, expResultCount: 4, expCacheCount: 4, setup: nil},
+		// Case 7: maxBytes is set low so only a single value should be
 		// returned.
-		{lo: indexes[5], hi: indexes[9], maxBytes: 1, expResultCount: 1},
-		// Case 4: hi value is past the last index, should return all available
-		// entries
-		{lo: indexes[5], hi: indexes[9] + 1, expResultCount: 5},
-		// Case 5: all values have been truncated.
-		{lo: indexes[1], hi: indexes[2], expError: raft.ErrCompacted},
-		// Case 6: hi has just been truncated.
-		{lo: indexes[1], hi: indexes[4], expError: raft.ErrCompacted},
-		// Case 7: another case where hi has just been truncated.
-		{lo: indexes[3], hi: indexes[4], expError: raft.ErrCompacted},
-		// Case 8: lo has been truncated and hi is the truncation point.
-		{lo: indexes[4], hi: indexes[5], expError: raft.ErrCompacted},
-		// Case 9: lo has been truncated but hi is available.
-		{lo: indexes[4], hi: indexes[9], expError: raft.ErrCompacted},
-		// Case 10: lo has been truncated and hi is not available.
-		{lo: indexes[4], hi: indexes[9] + 100, expError: raft.ErrCompacted},
-		// Case 11: lo has been truncated but hi is available, and maxBytes is
+		{lo: indexes[5], hi: indexes[9], maxBytes: 1, expResultCount: 1, expCacheCount: 1, setup: nil},
+		// Case 8: hi value is just past the last index, should return all
+		// available entries.
+		{lo: indexes[5], hi: indexes[9] + 1, expResultCount: 5, expCacheCount: 5, setup: nil},
+		// Case 9: all values have been truncated from cache and storage.
+		{lo: indexes[1], hi: indexes[2], expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
+		// Case 10: hi has just been truncated from cache and storage.
+		{lo: indexes[1], hi: indexes[4], expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
+		// Case 11: another case where hi has just been truncated from
+		// cache and storage.
+		{lo: indexes[3], hi: indexes[4], expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
+		// Case 12: lo has been truncated and hi is the truncation point.
+		{lo: indexes[4], hi: indexes[5], expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
+		// Case 13: lo has been truncated but hi is available.
+		{lo: indexes[4], hi: indexes[9], expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
+		// Case 14: lo has been truncated and hi is not available.
+		{lo: indexes[4], hi: indexes[9] + 100, expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
+		// Case 15: lo has been truncated but hi is available, and maxBytes is
 		// set low.
-		{lo: indexes[4], hi: indexes[9], maxBytes: 1, expError: raft.ErrCompacted},
-		// Case 12: lo is available but hi isn't.
-		{lo: indexes[5], hi: indexes[9] + 100, expError: raft.ErrUnavailable},
-		// Case 13: both lo and hi are not available.
-		{lo: indexes[9] + 100, hi: indexes[9] + 1000, expError: raft.ErrUnavailable},
-		// Case 14: lo is available, hi is not, but it was cut off by maxBytes.
-		{lo: indexes[5], hi: indexes[9] + 1000, maxBytes: 1, expResultCount: 1},
+		{lo: indexes[4], hi: indexes[9], maxBytes: 1, expCacheCount: 0, expError: raft.ErrCompacted, setup: nil},
+		// Case 16: lo is available but hi is not.
+		{lo: indexes[5], hi: indexes[9] + 100, expCacheCount: 6, expError: raft.ErrUnavailable, setup: nil},
+		// Case 17: both lo and hi are not available, cache miss.
+		{lo: indexes[9] + 100, hi: indexes[9] + 1000, expCacheCount: 0, expError: raft.ErrUnavailable, setup: nil},
+		// Case 18: lo is available, hi is not, but it was cut off by maxBytes.
+		{lo: indexes[5], hi: indexes[9] + 1000, maxBytes: 1, expResultCount: 1, expCacheCount: 1, setup: nil},
+
+		// Case 19: lo and hi are available, but entry cache evicted.
+		{lo: indexes[5], hi: indexes[9], expResultCount: 4, expCacheCount: 0, setup: func() {
+			// Manually evict cache for the first 10 log entries.
+			rng.store.raftEntryCache.delEntries(rangeID, indexes[0], indexes[9]+1)
+			indexes = append(indexes, populateLogs(10, 40)...)
+		}},
+		// Case 20: lo and hi are available, entry cache evicted and hi available in cache.
+		{lo: indexes[5], hi: indexes[9] + 5, expResultCount: 9, expCacheCount: 4, setup: nil},
+		// Case 21: lo and hi are available and in entry cache.
+		{lo: indexes[9] + 2, hi: indexes[9] + 32, expResultCount: 30, expCacheCount: 30, setup: nil},
+		// Case 22: lo is available and hi is not.
+		{lo: indexes[9] + 2, hi: indexes[9] + 33, expCacheCount: 30, expError: raft.ErrUnavailable, setup: nil},
 	} {
+		if tc.setup != nil {
+			tc.setup()
+		}
+		cacheEntries, _, _ := rng.store.raftEntryCache.getEntries(rangeID, tc.lo, tc.hi, tc.maxBytes)
+		if len(cacheEntries) != tc.expCacheCount {
+			t.Errorf("%d: expected cache count %d, got %d", i, tc.expCacheCount, len(cacheEntries))
+		}
 		rng.mu.Lock()
 		ents, err := rng.Entries(tc.lo, tc.hi, tc.maxBytes)
 		rng.mu.Unlock()
@@ -5082,37 +5124,37 @@ func TestEntries(t *testing.T) {
 		}
 	}
 
-	// Case 15: Lo must be less than or equal to hi.
+	// Case 23: Lo must be less than or equal to hi.
 	rng.mu.Lock()
 	if _, err := rng.Entries(indexes[9], indexes[5], 0); err == nil {
-		t.Errorf("15: error expected, got none")
+		t.Errorf("23: error expected, got none")
 	}
 	rng.mu.Unlock()
 
-	// Case 16: add a gap to the indexes.
-	if err := engine.MVCCDelete(context.Background(), tc.store.Engine(), nil, keys.RaftLogKey(rangeID, indexes[6]), hlc.ZeroTimestamp,
-		nil); err != nil {
+	// Case 24: add a gap to the indexes.
+	if err := engine.MVCCDelete(context.Background(), tc.store.Engine(), nil, keys.RaftLogKey(rangeID, indexes[6]), hlc.ZeroTimestamp, nil); err != nil {
 		t.Fatal(err)
 	}
+	rng.store.raftEntryCache.delEntries(rangeID, indexes[6], indexes[6]+1)
 
 	rng.mu.Lock()
 	defer rng.mu.Unlock()
 	if _, err := rng.Entries(indexes[5], indexes[9], 0); err == nil {
-		t.Errorf("16: error expected, got none")
+		t.Errorf("24: error expected, got none")
 	}
 
-	// Case 17: don't hit the gap due to maxBytes.
+	// Case 25: don't hit the gap due to maxBytes.
 	ents, err := rng.Entries(indexes[5], indexes[9], 1)
 	if err != nil {
-		t.Errorf("17: expected no error, got %s", err)
+		t.Errorf("25: expected no error, got %s", err)
 	}
 	if len(ents) != 1 {
-		t.Errorf("17: expected 1 entry, got %d", len(ents))
+		t.Errorf("25: expected 1 entry, got %d", len(ents))
 	}
 
-	// Case 18: don't hit the gap due to truncation.
+	// Case 26: don't hit the gap due to truncation.
 	if _, err := rng.Entries(indexes[4], indexes[9], 0); err != raft.ErrCompacted {
-		t.Errorf("18: expected error %s , got %s", raft.ErrCompacted, err)
+		t.Errorf("26: expected error %s , got %s", raft.ErrCompacted, err)
 	}
 }
 

--- a/storage/replica_trigger.go
+++ b/storage/replica_trigger.go
@@ -402,6 +402,9 @@ func (r *Replica) handleTrigger(
 		r.mu.Lock()
 		r.mu.state.TruncatedState = trigger.truncatedState
 		r.mu.Unlock()
+		// Clear any entries in the Raft log entry cache for this range up
+		// to and including the most recently truncated index.
+		r.store.raftEntryCache.clearTo(r.RangeID, trigger.truncatedState.Index+1)
 	}
 	if trigger.raftLogSize != nil {
 		r.mu.Lock()

--- a/storage/store.go
+++ b/storage/store.go
@@ -70,6 +70,10 @@ const (
 	// temporarily created during the application of a preemptive snapshot.
 	preemptiveSnapshotRaftGroupID = math.MaxUint64
 
+	// defaultRaftEntryCacheSize is the default size in bytes for a
+	// store's Raft log entry cache.
+	defaultRaftEntryCacheSize = 1 << 24 // 16M
+
 	// rangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the leader
 	// lease active duration should be of the raft election timeout.
 	rangeLeaseRaftElectionTimeoutMultiplier = 3
@@ -309,6 +313,7 @@ type Store struct {
 	consistencyScanner      *replicaScanner          // Consistency checker scanner
 	metrics                 *StoreMetrics
 	intentResolver          *intentResolver
+	raftEntryCache          *raftEntryCache
 	wakeRaftLoop            chan struct{}
 	// 1 if the store was started, 0 if it wasn't. To be accessed using atomic
 	// ops.
@@ -518,6 +523,10 @@ type StoreContext struct {
 	// it up (counted from when the snapshot generation is completed).
 	AsyncSnapshotMaxAge time.Duration
 
+	// RaftEntryCacheSize is the size in bytes of the Raft log entry cache
+	// shared by all Raft groups managed by the store.
+	RaftEntryCacheSize uint64
+
 	TestingKnobs StoreTestingKnobs
 
 	// rangeLeaseActiveDuration is the duration of the active period of leader
@@ -604,6 +613,9 @@ func (sc *StoreContext) setDefaults() {
 	if sc.AsyncSnapshotMaxAge == 0 {
 		sc.AsyncSnapshotMaxAge = defaultAsyncSnapshotMaxAge
 	}
+	if sc.RaftEntryCacheSize == 0 {
+		sc.RaftEntryCacheSize = defaultRaftEntryCacheSize
+	}
 
 	raftElectionTimeout := time.Duration(sc.RaftElectionTimeoutTicks) * sc.RaftTickInterval
 	sc.rangeLeaseActiveDuration = rangeLeaseRaftElectionTimeoutMultiplier * raftElectionTimeout
@@ -629,6 +641,7 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 		metrics:      newStoreMetrics(),
 	}
 	s.intentResolver = newIntentResolver(s)
+	s.raftEntryCache = newRaftEntryCache(ctx.RaftEntryCacheSize)
 	s.drainLeases.Store(false)
 
 	s.mu.Lock()
@@ -636,7 +649,6 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 	s.mu.replicasByKey = btree.New(64 /* degree */)
 	s.mu.uninitReplicas = map[roachpb.RangeID]*Replica{}
 	s.pendingRaftGroups.value = map[roachpb.RangeID]struct{}{}
-
 	s.mu.Unlock()
 
 	if s.ctx.Gossip != nil {

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -419,6 +419,9 @@ func (oc *OrderedCache) Do(f func(k, v interface{})) {
 }
 
 // DoRange invokes f on all cache entries in the range of from -> to.
+// f returns a boolean indicating the traversal is done. If f returns
+// true, the DoRange loop will exit; false, it will continue. DoRange
+// returns whether the iteration exited early.
 func (oc *OrderedCache) DoRange(f func(k, v interface{}) bool, from, to interface{}) bool {
 	return oc.llrb.DoRange(func(e llrb.Comparable) bool {
 		return f(e.(*Entry).Key, e.(*Entry).Value)


### PR DESCRIPTION
…erms

Resurrection of #3189 to avoid busy-looping fetching last terms when
a node comes up alone in what used to be a multi-node cluster. The
original PR used a cache per Raft group. This one uses a single cache
and evicts based on total bytes stored. This change also stores newly-
fetched entries in the cache instead of only when they're appended to
the log.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8494)

<!-- Reviewable:end -->
