### PR TITLE
stability: better cleanup of old gossip addresses

### DIFF
--- a/gossip/server.go
+++ b/gossip/server.go
@@ -176,8 +176,6 @@ func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) erro
 	for {
 		args := *argsPtr
 		if args.NodeID != 0 {
-			log.Infof(context.TODO(), "node %d: received gossip from node %d",
-				s.is.NodeID, args.NodeID)
 			// Decide whether or not we can accept the incoming connection
 			// as a permanent peer.
 			if args.NodeID == s.is.NodeID {
@@ -274,8 +272,6 @@ func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) erro
 			NodeID:          s.is.NodeID,
 			HighWaterStamps: s.is.getHighWaterStamps(),
 		}
-
-		log.Infof(context.TODO(), "node %d: replying to %d ", s.is.NodeID, args.NodeID)
 
 		s.mu.Unlock()
 		err = senderFn(reply)

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -237,7 +237,7 @@ func (n *Network) RunUntilFullyConnected() int {
 func (n *Network) isNetworkConnected() bool {
 	for _, leftNode := range n.Nodes {
 		for _, rightNode := range n.Nodes {
-			if _, err := leftNode.Gossip.GetInfo(rightNode.Addr().String()); err != nil {
+			if _, err := leftNode.Gossip.GetInfo(gossip.MakeNodeIDKey(rightNode.Gossip.GetNodeID())); err != nil {
 				return false
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -396,6 +396,13 @@ func (s *Server) Start() error {
 		})
 	}
 
+	// Enable the debug endpoints first to provide an earlier window
+	// into what's going on with the node in advance of exporting node
+	// functionality.
+	// TODO(marc): when cookie-based authentication exists,
+	// apply it for all web endpoints.
+	s.mux.HandleFunc(debugEndpoint, http.HandlerFunc(handleDebug))
+
 	s.gossip.Start(unresolvedAddr)
 
 	ctx := context.Background()
@@ -491,7 +498,6 @@ func (s *Server) Start() error {
 
 	// TODO(marc): when cookie-based authentication exists,
 	// apply it for all web endpoints.
-	s.mux.HandleFunc(debugEndpoint, http.HandlerFunc(handleDebug))
 	s.mux.Handle(adminEndpoint, gwMux)
 	s.mux.Handle(ts.URLPrefix, gwMux)
 	s.mux.Handle(statusPrefix, s.status)

--- a/storage/engine/batch.go
+++ b/storage/engine/batch.go
@@ -56,7 +56,7 @@ const (
 // write-ahead-log, the sequence number is 0. The "fixed32" format is little
 // endian.
 //
-// The keys encoded into the batch or MVCC keys: a string key with a timestamp
+// The keys encoded into the batch are MVCC keys: a string key with a timestamp
 // suffix. MVCC keys are encoded as:
 //
 //   <key>[<wall_time>[<logical>]]<#timestamp-bytes>


### PR DESCRIPTION
The previous iteration would only remove gossip addresses which could
not be resolved. This iteration removes all gossip addresses from the
bootstrap info which are no longer being gossiped as of the most recent
occasion where the node was successfully connected to a healthy cluster.

Also, moved debug endpoint registration earlier in the cycle so that we
can access the debug URLs even before the node has successfully connected
to gossip.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8512)

<!-- Reviewable:end -->
