### PR TITLE
build: use a tmp file for forbidden.log

### DIFF
--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -174,7 +174,7 @@ tests=$(declare -F|cut -d' ' -f3|grep '^Test'|grep "${TESTS-.}")
 export -f runcheck
 export -f $tests
 if hash parallel 2>/dev/null; then
-  parallel runcheck {} ::: $tests || exit_status=$?
+  parallel -j4 runcheck {} ::: $tests || exit_status=$?
 else
   for i in $tests; do
     check_status=0


### PR DESCRIPTION
This avoids placing a file temporarily in the user's source directory
which can confuse other checks when run concurrently.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8513)

<!-- Reviewable:end -->
