### PR TITLE
Reduce log spam on gossip and raft transport

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -109,7 +109,7 @@ golang.org/x/sys a646d33e2ee3172a661fc09bca23bb4889a41bc8
 golang.org/x/text 2910a502d2bf9e43193af9d68ca516529614eed3
 golang.org/x/tools 0e9f43fcb67267967af8c15d7dc54b373e341d20
 google.golang.org/appengine e951d3868b377b14f4e60efa3a301532ee3c1ebf
-google.golang.org/grpc c2c110d5cf950aef5e2af86b2f5d0a53400ff90b
+google.golang.org/grpc 8a81ddda27e5fdd3b56f3ce841b37dbf7387dd26
 gopkg.in/check.v1 4f90aeace3a26ad7021961c297b22c42160c7b25
 gopkg.in/inf.v0 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 gopkg.in/yaml.v1 9f9df34309c04878acc86042b16630b0f696e1de

--- a/gossip/client.go
+++ b/gossip/client.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	circuit "github.com/rubyist/circuitbreaker"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -69,27 +70,46 @@ func newClient(addr net.Addr, nodeMetrics Metrics) *client {
 // start dials the remote addr and commences gossip once connected. Upon exit,
 // the client is sent on the disconnected channel. This method starts client
 // processing in a goroutine and returns immediately.
-func (c *client) start(g *Gossip, disconnected chan *client, rpcCtx *rpc.Context, stopper *stop.Stopper, nodeID roachpb.NodeID) {
-	ctx := context.TODO()
-	log.Infof(ctx, "node %d: starting client to %s", nodeID, c.addr)
-
+func (c *client) start(
+	g *Gossip,
+	disconnected chan *client,
+	rpcCtx *rpc.Context,
+	stopper *stop.Stopper,
+	nodeID roachpb.NodeID,
+	breaker *circuit.Breaker,
+) {
 	stopper.RunWorker(func() {
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
 		defer func() {
 			disconnected <- c
 		}()
 
-		// Note: avoid using `grpc.WithBlock` here. This code is already
-		// asynchronous from the caller's perspective, so the only effect of
-		// `WithBlock` here is blocking shutdown - at the time of this writing,
-		// that ends ups up making `kv` tests take twice as long.
-		conn, err := rpcCtx.GRPCDial(c.addr.String())
-		if err != nil {
-			log.Errorf(ctx, "node %d: failed to dial: %s", nodeID, err)
+		consecFailures := breaker.ConsecFailures()
+		var stream Gossip_GossipClient
+		if err := breaker.Call(func() error {
+			// Note: avoid using `grpc.WithBlock` here. This code is already
+			// asynchronous from the caller's perspective, so the only effect of
+			// `WithBlock` here is blocking shutdown - at the time of this writing,
+			// that ends ups up making `kv` tests take twice as long.
+			conn, err := rpcCtx.GRPCDial(c.addr.String())
+			if err != nil {
+				return err
+			}
+			if stream, err = NewGossipClient(conn).Gossip(ctx); err != nil {
+				return err
+			}
+			return c.requestGossip(g, stream)
+		}, 0); err != nil {
+			if consecFailures == 0 {
+				log.Warningf(ctx, "node %d: failed to start gossip client: %s", nodeID, err)
+			}
 			return
 		}
 
 		// Start gossiping.
-		if err := c.gossip(ctx, g, NewGossipClient(conn), stopper); err != nil {
+		log.Infof(ctx, "node %d: started gossip client to %s", nodeID, c.addr)
+		if err := c.gossip(ctx, g, stream, stopper); err != nil {
 			if !grpcutil.IsClosedConnection(err) {
 				g.mu.Lock()
 				peerID := c.peerID
@@ -116,11 +136,11 @@ func (c *client) close() {
 // requestGossip requests the latest gossip from the remote server by
 // supplying a map of this node's knowledge of other nodes' high water
 // timestamps.
-func (c *client) requestGossip(g *Gossip, addr util.UnresolvedAddr, stream Gossip_GossipClient) error {
+func (c *client) requestGossip(g *Gossip, stream Gossip_GossipClient) error {
 	g.mu.Lock()
 	args := &Request{
 		NodeID:          g.mu.is.NodeID,
-		Addr:            addr,
+		Addr:            g.mu.is.NodeAddr,
 		HighWaterStamps: g.mu.is.getHighWaterStamps(),
 	}
 	g.mu.Unlock()
@@ -134,12 +154,12 @@ func (c *client) requestGossip(g *Gossip, addr util.UnresolvedAddr, stream Gossi
 
 // sendGossip sends the latest gossip to the remote server, based on
 // the remote server's notion of other nodes' high water timestamps.
-func (c *client) sendGossip(g *Gossip, addr util.UnresolvedAddr, stream Gossip_GossipClient) error {
+func (c *client) sendGossip(g *Gossip, stream Gossip_GossipClient) error {
 	g.mu.Lock()
 	if delta := g.mu.is.delta(c.remoteHighWaterStamps); len(delta) > 0 {
 		args := Request{
 			NodeID:          g.mu.is.NodeID,
-			Addr:            addr,
+			Addr:            g.mu.is.NodeAddr,
 			Delta:           delta,
 			HighWaterStamps: g.mu.is.getHighWaterStamps(),
 		}
@@ -228,21 +248,7 @@ func (c *client) handleResponse(g *Gossip, reply *Response) error {
 // gossip loops, sending deltas of the infostore and receiving deltas
 // in turn. If an alternate is proposed on response, the client addr
 // is modified and method returns for forwarding by caller.
-func (c *client) gossip(ctx context.Context, g *Gossip, gossipClient GossipClient, stopper *stop.Stopper) error {
-	// For un-bootstrapped node, g.is.NodeID is 0 when client start gossip,
-	// so it's better to get nodeID from g.is every time.
-	addr := g.GetNodeAddr()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	stream, err := gossipClient.Gossip(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := c.requestGossip(g, *addr, stream); err != nil {
-		return err
-	}
-
+func (c *client) gossip(ctx context.Context, g *Gossip, stream Gossip_GossipClient, stopper *stop.Stopper) error {
 	sendGossipChan := make(chan struct{}, 1)
 
 	// Register a callback for gossip updates.
@@ -279,7 +285,7 @@ func (c *client) gossip(ctx context.Context, g *Gossip, gossipClient GossipClien
 		case err := <-errCh:
 			return err
 		case <-sendGossipChan:
-			if err := c.sendGossip(g, *addr, stream); err != nil {
+			if err := c.sendGossip(g, stream); err != nil {
 				return err
 			}
 		}

--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -135,7 +135,7 @@ func gossipSucceedsSoon(t *testing.T, stopper *stop.Stopper, disconnected chan *
 		select {
 		case client := <-disconnected:
 			// If the client wasn't able to connect, restart it.
-			client.start(gossip[client], disconnected, rpcContext, stopper, gossip[client].GetNodeID())
+			client.start(gossip[client], disconnected, rpcContext, stopper, gossip[client].GetNodeID(), rpcContext.NewBreaker())
 		default:
 		}
 
@@ -267,7 +267,7 @@ func TestClientNodeID(t *testing.T) {
 			return
 		case <-disconnected:
 			// The client hasn't been started or failed to start, loop and try again.
-			c.start(local, disconnected, rpcContext, stopper, local.GetNodeID())
+			c.start(local, disconnected, rpcContext, stopper, local.GetNodeID(), rpcContext.NewBreaker())
 		}
 	}
 }

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -177,7 +177,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 				return err
 			}
 
-			if err := c.requestGossip(peer, *peer.GetNodeAddr(), stream); err != nil {
+			if err := c.requestGossip(peer, stream); err != nil {
 				return err
 			}
 
@@ -201,7 +201,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 		for {
 			localAddr := local.GetNodeAddr()
 			c := newClient(localAddr, makeMetrics())
-			c.start(peer, disconnectedCh, peer.rpcContext, stopper, peer.GetNodeID())
+			c.start(peer, disconnectedCh, peer.rpcContext, stopper, peer.GetNodeID(), peer.rpcContext.NewBreaker())
 
 			disconnectedClient := <-disconnectedCh
 			if disconnectedClient != c {

--- a/internal/client/sender.go
+++ b/internal/client/sender.go
@@ -62,9 +62,9 @@ func SendWrappedWith(
 	return unwrappedReply, nil
 }
 
-// SendWrapped is identical to SendWrappedAt with a zero header.
-// TODO(tschottdorf): should move this to testutils and merge with other helpers
-// which are used, for example, in `storage`.
+// SendWrapped is identical to SendWrappedWith with a zero header.
+// TODO(tschottdorf): should move this to testutils and merge with
+// other helpers which are used, for example, in `storage`.
 func SendWrapped(sender Sender, ctx context.Context, args roachpb.Request) (roachpb.Response, *roachpb.Error) {
 	return SendWrappedWith(sender, ctx, roachpb.Header{}, args)
 }

--- a/kv/transport.go
+++ b/kv/transport.go
@@ -29,8 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/envutil"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
-	"github.com/rubyist/circuitbreaker"
 	"google.golang.org/grpc"
 )
 
@@ -120,9 +118,6 @@ func grpcTransportFactory(
 	for _, replica := range replicas {
 		conn, err := rpcContext.GRPCDial(replica.NodeDesc.Address.String())
 		if err != nil {
-			if errors.Cause(err) == circuit.ErrBreakerOpen {
-				continue
-			}
 			return nil, err
 		}
 		argsCopy := args

--- a/server/node.go
+++ b/server/node.go
@@ -617,12 +617,11 @@ func (n *Node) startComputePeriodicMetrics(stopper *stop.Stopper) {
 		// Publish status at the same frequency as metrics are collected.
 		ticker := time.NewTicker(publishStatusInterval)
 		defer ticker.Stop()
-		for {
+		for tick := 0; ; tick++ {
 			select {
 			case <-ticker.C:
-				err := n.computePeriodicMetrics()
-				if err != nil {
-					log.Error(context.TODO(), err)
+				if err := n.computePeriodicMetrics(tick); err != nil {
+					log.Errorf(context.TODO(), "failed computing periodic metrics: %s", err)
 				}
 			case <-stopper.ShouldStop():
 				return
@@ -633,9 +632,12 @@ func (n *Node) startComputePeriodicMetrics(stopper *stop.Stopper) {
 
 // computePeriodicMetrics instructs each store to compute the value of
 // complicated metrics.
-func (n *Node) computePeriodicMetrics() error {
+func (n *Node) computePeriodicMetrics(tick int) error {
 	return n.stores.VisitStores(func(store *storage.Store) error {
-		return store.ComputeMetrics()
+		if err := store.ComputeMetrics(tick); err != nil {
+			log.Warningf(context.TODO(), "%s: unable to compute metrics: %s", store, err)
+		}
+		return nil
 	})
 }
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -521,7 +521,7 @@ func TestStatusSummaries(t *testing.T) {
 	// were multiple replicas, more care would need to be taken in the initial
 	// syncFeed().
 	forceWriteStatus := func() {
-		if err := ts.node.computePeriodicMetrics(); err != nil {
+		if err := ts.node.computePeriodicMetrics(0); err != nil {
 			t.Fatalf("error publishing store statuses: %s", err)
 		}
 

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -233,7 +233,7 @@ func startServer(t *testing.T) serverutils.TestServerInterface {
 	// Make sure the node status is available. This is done by forcing stores to
 	// publish their status, synchronizing to the event feed with a canary
 	// event, and then forcing the server to write summaries immediately.
-	if err := ts.(*TestServer).node.computePeriodicMetrics(); err != nil {
+	if err := ts.(*TestServer).node.computePeriodicMetrics(0); err != nil {
 		t.Fatalf("error publishing store statuses: %s", err)
 	}
 

--- a/storage/client_metrics_test.go
+++ b/storage/client_metrics_test.go
@@ -123,7 +123,7 @@ func verifyStats(t *testing.T, mtc *multiTestContext, storeIdxSlice ...int) {
 }
 
 func verifyRocksDBStats(t *testing.T, s *storage.Store) {
-	if err := s.ComputeMetrics(); err != nil {
+	if err := s.ComputeMetrics(0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -34,9 +34,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cenk/backoff"
 	"github.com/coreos/etcd/raft"
+	"github.com/facebookgo/clock"
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
+	circuit "github.com/rubyist/circuitbreaker"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -265,8 +268,25 @@ func (m *multiTestContext) Start(t *testing.T, numStores int) {
 	}
 	if m.rpcContext == nil {
 		m.rpcContext = rpc.NewContext(&base.Context{Insecure: true}, m.clock, m.transportStopper)
+		// Create breaker options which retry very quickly and use a "real"
+		// clock so breakers retry without requiring the manual clock to be
+		// incremented manually to untrip breaker.
+		m.rpcContext.BreakerFactory = func() *circuit.Breaker {
+			b := &backoff.ExponentialBackOff{
+				InitialInterval:     1 * time.Millisecond,
+				RandomizationFactor: 0.25,
+				Multiplier:          2,
+				MaxInterval:         20 * time.Millisecond,
+				MaxElapsedTime:      0,
+				Clock:               clock.New(),
+			}
+			b.Reset()
+			return circuit.NewBreakerWithOptions(&circuit.Options{
+				BackOff:    b,
+				ShouldTrip: circuit.ThresholdTripFunc(1),
+			})
+		}
 	}
-
 	for idx := 0; idx < numStores; idx++ {
 		m.addStore(idx)
 	}

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -237,8 +237,12 @@ func TestBaseQueueAdd(t *testing.T) {
 	if bq.Length() != 0 {
 		t.Fatalf("expected length 0; got %d", bq.Length())
 	}
-	if err := bq.Add(r, 1.0); err != nil {
-		t.Fatalf("expected Add to succeed: %s", err)
+	if added, err := bq.Add(r, 1.0); err != nil || !added {
+		t.Fatalf("expected Add to succeed: %t, %s", added, err)
+	}
+	// Add again and verify it's not actually added (it's already there).
+	if added, err := bq.Add(r, 1.0); err != nil || added {
+		t.Fatalf("expected Add to succeed: %t, %s", added, err)
 	}
 	if bq.Length() != 1 {
 		t.Fatalf("expected length 1; got %d", bq.Length())

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -72,7 +72,7 @@ func getTruncatableIndexes(r *Replica) (uint64, uint64, error) {
 	rangeID := r.RangeID
 	raftStatus := r.RaftStatus()
 	if raftStatus == nil {
-		if log.V(1) {
+		if log.V(6) {
 			log.Infof(context.TODO(), "the raft group doesn't exist for range %d", rangeID)
 		}
 		return 0, 0, nil

--- a/storage/raft_transport.go
+++ b/storage/raft_transport.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
-	"github.com/cockroachdb/cockroach/util/grpcutil"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/syncutil"
 	"github.com/cockroachdb/cockroach/util/timeutil"
@@ -200,55 +199,44 @@ func (t *RaftTransport) Stop(storeID roachpb.StoreID) {
 
 // GetCircuitBreaker returns the circuit breaker controlling
 // connection attempts to the specified node.
-// NOTE: For unittesting.
 func (t *RaftTransport) GetCircuitBreaker(nodeID roachpb.NodeID) *circuit.Breaker {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return t.mu.breakers[nodeID]
-}
-
-// getNodeConn returns a shared instance of a GRPC connection to the
-// node specified by nodeID. Returns null if the remote node is not
-// available (e.g. because the node ID can't be resolved or the remote
-// node is not responding or is timing out, or the network is
-// partitioned, etc.).
-func (t *RaftTransport) getNodeConn(nodeID roachpb.NodeID) *grpc.ClientConn {
-	t.mu.Lock()
 	breaker, ok := t.mu.breakers[nodeID]
 	if !ok {
 		breaker = t.rpcContext.NewBreaker()
 		t.mu.breakers[nodeID] = breaker
 	}
-	t.mu.Unlock()
+	return breaker
+}
 
-	// The number of consecutive failures suffered by the circuit breaker is used
-	// to log only state changes in our node address resolution status.
+// connectAndProcess connects to the node and then processes the
+// provided channel containing a queue of raft messages until there is
+// an unrecoverable error with the underlying connection. A circuit
+// breaker is used to allow fast failures in SendAsync which will drop
+// incoming raft messages and report unreachable status to the raft group.
+func (t *RaftTransport) connectAndProcess(nodeID roachpb.NodeID, ch chan *RaftMessageRequest) {
+	breaker := t.GetCircuitBreaker(nodeID)
 	consecFailures := breaker.ConsecFailures()
-	var addr net.Addr
 	if err := breaker.Call(func() error {
-		var err error
-		addr, err = t.resolver(nodeID)
-		return err
+		addr, err := t.resolver(nodeID)
+		if err != nil {
+			return err
+		}
+		conn, err := t.rpcContext.GRPCDial(addr.String(), grpc.WithBlock())
+		if err != nil {
+			return err
+		}
+		return t.processQueue(nodeID, ch, conn)
 	}, 0); err != nil {
 		if consecFailures == 0 {
-			log.Warningf(context.TODO(), "failed to resolve node %s: %s", nodeID, err)
+			log.Warningf(context.TODO(), "raft transport stream to node %d failed: %s", nodeID, err)
 		}
-		return nil
+		return
 	}
 	if consecFailures > 0 {
-		log.Infof(context.TODO(), "resolved node %s to %s", nodeID, addr)
+		log.Infof(context.TODO(), "raft transport stream to node %d established", nodeID)
 	}
-
-	// GRPC connections are opened asynchronously and internally have a circuit
-	// breaking mechanism based on heartbeat successes and failures.
-	conn, err := t.rpcContext.GRPCDial(addr.String())
-	if err != nil {
-		if errors.Cause(err) != circuit.ErrBreakerOpen {
-			log.Infof(context.TODO(), "failed to connect to %s", addr)
-		}
-		return nil
-	}
-	return conn
 }
 
 // processQueue opens a Raft client stream and sends messages from the
@@ -256,7 +244,7 @@ func (t *RaftTransport) getNodeConn(nodeID roachpb.NodeID) *grpc.ClientConn {
 // when it idles out. All messages remaining in the queue at that point are
 // lost and a new instance of processQueue will be started by the next message
 // to be sent.
-func (t *RaftTransport) processQueue(ch chan *RaftMessageRequest, conn *grpc.ClientConn) error {
+func (t *RaftTransport) processQueue(nodeID roachpb.NodeID, ch chan *RaftMessageRequest, conn *grpc.ClientConn) error {
 	client := NewMultiRaftClient(conn)
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -335,6 +323,14 @@ func (t *RaftTransport) SendAsync(req *RaftMessageRequest) bool {
 	isSnap := req.Message.Type == raftpb.MsgSnap
 	toNodeID := req.ToReplica.NodeID
 
+	// First, check the circuit breaker for connections to the outgoing
+	// node. We fail fast if the breaker is open to drop the raft
+	// message and have the caller mark the raft group as unreachable.
+	breaker := t.GetCircuitBreaker(toNodeID)
+	if !breaker.Ready() {
+		return false
+	}
+
 	t.mu.Lock()
 	// We use two queues; one will be used for snapshots, the other for all other
 	// traffic. This is done to prevent snapshots from blocking other traffic.
@@ -351,25 +347,10 @@ func (t *RaftTransport) SendAsync(req *RaftMessageRequest) bool {
 	t.mu.Unlock()
 
 	if !ok {
-		// Get a connection to the node specified by the replica's node
-		// ID. If no connection can be made, return false to indicate caller
-		// should drop the Raft message.
-		conn := t.getNodeConn(toNodeID)
-		if conn == nil {
-			t.mu.Lock()
-			delete(queues, toNodeID)
-			t.mu.Unlock()
-			return false
-		}
-
 		// Starting workers in a task prevents data races during shutdown.
 		if err := t.rpcContext.Stopper.RunTask(func() {
 			t.rpcContext.Stopper.RunWorker(func() {
-				if err := t.processQueue(ch, conn); err != nil && !grpcutil.IsClosedConnection(err) {
-					log.Warningf(context.TODO(),
-						"range=%s: outgoing raft transport stream to %s closed by the remote: %s",
-						req.RangeID, toNodeID, err)
-				}
+				t.connectAndProcess(toNodeID, ch)
 				t.mu.Lock()
 				delete(queues, toNodeID)
 				t.mu.Unlock()

--- a/storage/raft_transport_test.go
+++ b/storage/raft_transport_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -412,8 +413,9 @@ func TestRaftTransportCircuitBreaker(t *testing.T) {
 	}
 	clientTransport := rttc.AddNode(clientReplica.NodeID)
 
-	if rttc.Send(clientReplica, serverReplica, 1, raftpb.Message{Commit: 1}) {
-		t.Errorf("succeeded in sending when message should be dropped")
+	// The transport is set up asynchronously, so we expect Send to return true here.
+	if !rttc.Send(clientReplica, serverReplica, 1, raftpb.Message{Commit: 1}) {
+		t.Errorf("unexpectedly failed sending while connection is being asynchronously established")
 	}
 
 	// None should go through as the receiving node's address has not been gossiped.
@@ -423,10 +425,20 @@ func TestRaftTransportCircuitBreaker(t *testing.T) {
 	default:
 	}
 
+	// However, sending repeated messages should begin dropping once
+	// the circuit breaker does trip.
+	util.SucceedsSoon(t, func() error {
+		if rttc.Send(clientReplica, serverReplica, 1, raftpb.Message{Commit: 1}) {
+			return errors.Errorf("expected circuit breaker to trip")
+		}
+		return nil
+	})
+
 	// Now, gossip address of server.
 	rttc.GossipNode(serverReplica.NodeID, serverAddr)
 
-	// Message was dropped, not queued, so still shouldn't just appear.
+	// When the circuit breaker tripped, the queue would have been deleted.
+	// So gossiping the server address won't magically make the request appear.
 	select {
 	case req := <-serverChannel.ch:
 		t.Fatalf("should not have received any Raft messages from client: %s", req)
@@ -435,13 +447,13 @@ func TestRaftTransportCircuitBreaker(t *testing.T) {
 
 	// Reset the circuit breaker & resend and verify message arrives at server.
 	clientTransport.GetCircuitBreaker(serverReplica.NodeID).Reset()
-	if !rttc.Send(clientReplica, serverReplica, 1, raftpb.Message{Commit: 1}) {
+	if !rttc.Send(clientReplica, serverReplica, 1, raftpb.Message{Commit: 2}) {
 		t.Errorf("sent raft message was unexpectedly dropped")
 	}
 
 	req := <-serverChannel.ch
-	if req.Message.Commit != 1 {
-		t.Errorf("expected message 1; got %s", req)
+	if req.Message.Commit != 2 {
+		t.Errorf("expected message 2; got %s", req)
 	}
 }
 

--- a/storage/replica_trigger.go
+++ b/storage/replica_trigger.go
@@ -458,7 +458,7 @@ func (r *Replica) handleTrigger(
 	}
 
 	if trigger.addToReplicaGCQueue {
-		if err := r.store.replicaGCQueue.Add(r, 1.0); err != nil {
+		if _, err := r.store.replicaGCQueue.Add(r, 1.0); err != nil {
 			// Log the error; the range should still be GC'd eventually.
 			log.Errorf(ctx, "%s: unable to add to GC queue: %s", r, err)
 		}

--- a/storage/store.go
+++ b/storage/store.go
@@ -907,7 +907,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 				}
 				ba.Add(&fReq)
 				if _, pErr := r.Send(ctx, ba); pErr != nil {
-					log.Errorf(ctx, "could not unfreeze Range %s on startup: %s", r, pErr)
+					log.Errorf(ctx, "%s: could not unfreeze Range %s on startup: %s", s, r, pErr)
 				} else {
 					// We don't use the returned RangesAffected (0 or 1) for
 					// counting. One of the other Replicas may have beaten us
@@ -923,7 +923,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 		})
 		wg.Wait()
 		if unfrozen > 0 {
-			log.Infof(context.TODO(), "reactivated %d frozen Ranges", unfrozen)
+			log.Infof(ctx, "%s: reactivated %d frozen Ranges", s, unfrozen)
 		}
 	}) != nil {
 		close(doneUnfreezing)
@@ -985,8 +985,8 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 		})
 
 		// Run metrics computation up front to populate initial statistics.
-		if err := s.ComputeMetrics(); err != nil {
-			return err
+		if err = s.ComputeMetrics(-1); err != nil {
+			log.Infof(ctx, "%s: failed initial metrics computation: %s", s, err)
 		}
 	}
 
@@ -2173,8 +2173,7 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 
 	s.mu.Lock()
 	// Lazily create the replica.
-	r, err := s.getOrCreateReplicaLocked(req.RangeID, req.ToReplica.ReplicaID,
-		req.FromReplica)
+	r, err := s.getOrCreateReplicaLocked(req.RangeID, req.ToReplica.ReplicaID, req.FromReplica)
 	// TODO(bdarnell): is it safe to release the store lock here?
 	// It deadlocks to hold s.Mutex while calling raftGroup.Step.
 	s.mu.Unlock()
@@ -2311,10 +2310,10 @@ func (s *Store) HandleRaftResponse(ctx context.Context, resp *RaftMessageRespons
 				rep, ok := s.mu.replicas[resp.RangeID]
 				s.mu.Unlock()
 				if ok {
-					log.Infof(ctx, "%s: replica %s too old, adding to replica GC queue", rep, resp.ToReplica)
-
-					if err := s.replicaGCQueue.Add(rep, 1.0); err != nil {
+					if added, err := s.replicaGCQueue.Add(rep, 1.0); err != nil {
 						log.Errorf(ctx, "%s: unable to add replica %d to GC queue: %s", rep, resp.ToReplica, err)
+					} else if added {
+						log.Infof(ctx, "%s: replica %s too old, added to replica GC queue", rep, resp.ToReplica)
 					}
 				}
 			}); err != nil {
@@ -2322,11 +2321,11 @@ func (s *Store) HandleRaftResponse(ctx context.Context, resp *RaftMessageRespons
 			}
 
 		default:
-			log.Warningf(ctx, "%s: got unknown raft error: %s", s, val)
+			log.Warningf(ctx, "%s: got error from replica %s: %s", s, resp.FromReplica, val)
 		}
 
 	default:
-		log.Infof(ctx, "%s: got unknown raft response type %T: %s", s, val, val)
+		log.Infof(ctx, "%s: got unknown raft response type %T from replica %s: %s", s, val, resp.FromReplica, val)
 	}
 }
 
@@ -2559,11 +2558,11 @@ func raftEntryFormatter(data []byte) string {
 // scanning ranges. An ideal solution would be to create incremental events
 // whenever availability changes.
 func (s *Store) computeReplicationStatus(now int64) (
-	leaderRangeCount, replicatedRangeCount, replicationPendingRangeCount, availableRangeCount int64) {
+	leaderRangeCount, replicatedRangeCount, replicationPendingRangeCount, availableRangeCount int64, err error) {
 	// Load the system config.
 	cfg, ok := s.Gossip().GetSystemConfig()
 	if !ok {
-		log.Infof(context.TODO(), "%s: system config not yet available", s)
+		err = errors.Errorf("%s: system config not yet available", s)
 		return
 	}
 
@@ -2618,18 +2617,21 @@ func (s *Store) computeReplicationStatus(now int64) (
 // ComputeMetrics immediately computes the current value of store metrics which
 // cannot be computed incrementally. This method should be invoked periodically
 // by a higher-level system which records store metrics.
-func (s *Store) ComputeMetrics() error {
-	// broadcast store descriptor.
+func (s *Store) ComputeMetrics(tick int) error {
+	// Broadcast store descriptor.
 	desc, err := s.Descriptor()
 	if err != nil {
 		return err
 	}
 	s.metrics.updateCapacityGauges(desc.Capacity)
 
-	// broadcast replication status.
+	// Broadcast replication status.
 	now := s.ctx.Clock.Now().WallTime
-	leaderRangeCount, replicatedRangeCount, replicationPendingRangeCount, availableRangeCount :=
+	leaderRangeCount, replicatedRangeCount, replicationPendingRangeCount, availableRangeCount, err :=
 		s.computeReplicationStatus(now)
+	if err != nil {
+		return err
+	}
 	s.metrics.updateReplicationGauges(
 		leaderRangeCount, replicatedRangeCount, replicationPendingRangeCount, availableRangeCount)
 
@@ -2644,8 +2646,11 @@ func (s *Store) ComputeMetrics() error {
 	if rocksdb, ok := s.engine.(*engine.RocksDB); ok {
 		sstables := rocksdb.GetSSTables()
 		readAmp := sstables.ReadAmplification()
-		log.Infof(context.TODO(), "store %d sstables (read amplification = %d):\n%s", s.StoreID(), readAmp, sstables)
 		s.metrics.RdbReadAmplification.Update(int64(readAmp))
+		// Log this metric infrequently.
+		if tick%100 == 0 {
+			log.Infof(context.TODO(), "store %d sstables (read amplification = %d):\n%s", s.StoreID(), readAmp, sstables)
+		}
 	}
 	return nil
 }

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -476,7 +476,7 @@ func (tc *TestCluster) WaitForFullReplication() error {
 		notReplicated = false
 		for _, s := range tc.Servers {
 			err := s.Stores().VisitStores(func(s *storage.Store) error {
-				if err := s.ComputeMetrics(); err != nil {
+				if err := s.ComputeMetrics(0); err != nil {
 					return err
 				}
 				if s.Metrics().ReplicationPendingRangeCount.Value() > 0 {

--- a/util/grpcutil/grpc_util.go
+++ b/util/grpcutil/grpc_util.go
@@ -32,8 +32,10 @@ import (
 func IsClosedConnection(err error) bool {
 	if err == context.Canceled ||
 		grpc.Code(err) == codes.Canceled ||
+		grpc.Code(err) == codes.Unavailable ||
 		grpc.ErrorDesc(err) == grpc.ErrClientConnClosing.Error() ||
-		strings.Contains(err.Error(), "is closing") {
+		strings.Contains(err.Error(), "is closing") ||
+		strings.Contains(err.Error(), "node unavailable") {
 		return true
 	}
 	if streamErr, ok := err.(transport.StreamError); ok && streamErr.Code == codes.Canceled {


### PR DESCRIPTION
This is necessary to avoid lots of spurious RPC errors on node startup
caused by the connection believing itself to be unhealthy and failing
everything fast. With thousands of ranges, this was quite confusing.

Remove spammy logging via use of circuit breakers to measure state
changes. In particular with gossip and raft transport.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8529)

<!-- Reviewable:end -->
