### PR TITLE
Add SortedTable Component

### DIFF
--- a/ui/app/components/sortabletable.spec.tsx
+++ b/ui/app/components/sortabletable.spec.tsx
@@ -27,9 +27,8 @@ function makeTable(count: number, sortSetting?: SortSetting,
                    onChangeSortSetting?: (ss: SortSetting) => void) {
   return shallow(<SortableTable count={count}
                                 sortSetting={sortSetting}
-                                onChangeSortSetting={onChangeSortSetting}>
-                    { columns }
-                 </SortableTable>);
+                                onChangeSortSetting={onChangeSortSetting}
+                                columns={columns}/>);
 }
 
 describe("<SortableTable>", () => {

--- a/ui/app/components/sortabletable.tsx
+++ b/ui/app/components/sortabletable.tsx
@@ -38,6 +38,8 @@ export interface SortSetting {
 interface TableProps {
   // Number of rows in the table.
   count: number;
+  // Array of SortableColumns to render.
+  columns: SortableColumn[];
   // Current sortSetting that was used to sort incoming data.
   sortSetting?: SortSetting;
   // Callback that should be invoked when the user want to change the sort
@@ -53,12 +55,11 @@ interface TableProps {
  * user to indicate how data should be sorted by clicking on column headers.
  * SortableTable can indicate this to higher-level components through the
  * 'onChangeSortSetting' callback property.
- *
- * SortableColumns should be passed to SortableTable as children.
  */
 export class SortableTable extends React.Component<TableProps, {}> {
   static defaultProps: TableProps = {
       count: 0,
+      columns: [],
       sortSetting: {
         sortKey: null,
         ascending: false,
@@ -88,8 +89,7 @@ export class SortableTable extends React.Component<TableProps, {}> {
   }
 
   render() {
-    let columns = this.props.children as SortableColumn[];
-    let { sortSetting } = this.props;
+    let { sortSetting, columns } = this.props;
 
     return <table>
      <thead>
@@ -98,7 +98,7 @@ export class SortableTable extends React.Component<TableProps, {}> {
             let className = "column";
             let onClick: (e: any) => void = undefined;
 
-            if (c.sortKey) {
+            if (!_.isUndefined(c.sortKey)) {
               onClick = () => {
                 this.clickSort(c.sortKey);
               };

--- a/ui/app/components/sortedtable.spec.tsx
+++ b/ui/app/components/sortedtable.spec.tsx
@@ -1,0 +1,89 @@
+/// <reference path="../../typings/index.d.ts" />
+import * as React from "react";
+import _ = require("lodash");
+import { assert } from "chai";
+import { mount } from "enzyme";
+import * as sinon from "sinon";
+
+import { SortedTable, ColumnDescriptor } from "./sortedtable";
+import { SortSetting } from "./sortabletable";
+
+class TestRow {
+  constructor(public name: string, public value: number) { }
+}
+
+const columns: ColumnDescriptor<TestRow>[] = [
+  {
+    title: "first",
+    cell: (tr) => tr.name,
+    sort: (tr) => tr.name,
+  },
+  {
+    title: "second",
+    cell: (tr) => tr.value.toString(),
+    sort: (tr) => tr.value,
+    rollup: (trs) => _.sumBy(trs, (tr) => tr.value),
+  },
+];
+
+// Specialization of generic SortedTable component: 
+//   https://github.com/Microsoft/TypeScript/issues/3960
+//
+// The variable name must start with a capital letter or TSX will not recognize
+// it as a component.
+// tslint:disable-next-line:variable-name
+const TestSortedTable = SortedTable as new () => SortedTable<TestRow>;
+
+function makeTable(
+  data: TestRow[], sortSetting?: SortSetting, onChangeSortSetting?: (ss: SortSetting) => void
+) {
+  return mount(<TestSortedTable data={data}
+                                sortSetting={sortSetting}
+                                onChangeSortSetting={onChangeSortSetting}
+                                columns={columns}/>);
+}
+
+describe("<SortedTable>", function() {
+  it("renders the expected table structure.", function() {
+    let wrapper = makeTable([new TestRow("test", 1)]);
+    assert.lengthOf(wrapper.find("table"), 1, "one table");
+    assert.lengthOf(wrapper.find("thead").find("tr"), 2, "two header rows");
+    assert.lengthOf(wrapper.find("tr.column"), 1, "column header row");
+    assert.lengthOf(wrapper.find("tr.rollup"), 1, "rollup header row");
+    assert.lengthOf(wrapper.find("tbody"), 1, "tbody element");
+  });
+
+  it("correctly uses onChangeSortSetting", function() {
+    let spy = sinon.spy();
+    let wrapper = makeTable([new TestRow("test", 1)], undefined, spy);
+    wrapper.find("th.column").first().simulate("click");
+    assert.isTrue(spy.calledOnce);
+    assert.deepEqual(spy.getCall(0).args[0], {
+      sortKey: 0,
+      ascending: false,
+    } as SortSetting);
+  });
+
+  it("correctly sorts data based on sortSetting", function() {
+    let data = [
+      new TestRow("c", 3),
+      new TestRow("d", 4),
+      new TestRow("a", 1),
+      new TestRow("b", 2),
+    ];
+    let wrapper = makeTable(data, undefined);
+    let assertMatches = (expected: TestRow[]) => {
+      let rows = wrapper.find("tbody");
+      _.each(expected, (rowData, dataIndex) => {
+        let row = rows.childAt(dataIndex);
+        assert.equal(row.childAt(0).text(), rowData.name, "first columns match");
+        assert.equal(row.childAt(1).text(), rowData.value.toString(), "second columns match");
+      });
+    };
+    assertMatches(data);
+    wrapper = makeTable(data, {sortKey: 0, ascending: true});
+    assertMatches(_(data).sortBy((r) => r.name).value());
+    wrapper.setProps({uiSortSetting: {sortKey: 1, ascending: true} as SortSetting});
+    assertMatches(_(data).sortBy((r) => r.value).value());
+  });
+});

--- a/ui/app/components/sortedtable.tsx
+++ b/ui/app/components/sortedtable.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+import _ = require("lodash");
+import { createSelector } from "reselect";
+
+import { SortableTable, SortableColumn, SortSetting } from "../components/sortabletable";
+
+/**
+ * ColumnDescriptor is used to describe metadata about an individual column
+ * in a SortedTable.
+ */
+export interface ColumnDescriptor<T> {
+  // Title string that should appear in the header column.
+  title: string;
+  // Function which generates the contents of an individual cell in this table.
+  cell: (obj: T) => React.ReactNode;
+  // Function which returns a value that can be used to sort the collection of 
+  // objects. This will be used to sort the table according to the data in
+  // this column.
+  sort?: (obj: T) => any;
+  // Function that generates a "rollup" value for this column from all objects
+  // in a collection. This is used to display an appropriate "total" value for
+  // each column.
+  rollup?: (objs: T[]) => React.ReactNode;
+  // className to be applied to the td elements in this column.
+  className?: string;
+}
+
+/**
+ * SortedTableProps describes the properties expected by a SortedTable 
+ * component.
+ */
+interface SortedTableProps<T> {
+  // The data which should be displayed in the table. This data may be sorted
+  // by this component before display.
+  data: T[];
+  // Description of columns to display.
+  columns: ColumnDescriptor<T>[];
+  // sortSetting specifies how data should be sorted in this table, by 
+  // specifying a column id and a direction.
+  sortSetting: SortSetting;
+  // Callback that should be invoked when the user want to change the sort
+  // setting.
+  onChangeSortSetting?: { (ss: SortSetting): void };
+}
+
+/**
+ * SortedTable displays data rows in a table which can be sorted by the values
+ * in a single column. Unsorted row data is passed to SortedTable along with
+ * a SortSetting; SortedTable uses a selector to sort the data for display.
+ *
+ * SortedTable also computes optional "rollup" values for each column; a rollup
+ * is a total value that is computed for a column based on all available rows.
+ * 
+ * SortedTable should be preferred over the lower-level SortableTable when
+ * all data rows to be displayed are available locally on the client side.
+ */
+export class SortedTable<T> extends React.Component<SortedTableProps<T>, {}> {
+  rollups = createSelector(
+    (props: SortedTableProps<T>) => props.data,
+    (props: SortedTableProps<T>) => props.columns,
+    (data: T[], columns: ColumnDescriptor<T>[]) => {
+      return _.map(columns, (c): React.ReactNode => {
+        if (c.rollup) {
+          return c.rollup(data);
+        }
+        return undefined;
+      });
+    }
+  );
+
+  sorted = createSelector(
+    (props: SortedTableProps<T>) => props.data,
+    (props: SortedTableProps<T>) => props.sortSetting,
+    (props: SortedTableProps<T>) => props.columns,
+    (data: T[], sortSetting: SortSetting, columns: ColumnDescriptor<T>[]) => {
+      if (!sortSetting) {
+        return data;
+      }
+      let sortColumn = columns[sortSetting.sortKey];
+      if (!sortColumn || !sortColumn.sort) {
+        return data;
+      }
+      return _.orderBy(data, sortColumn.sort, sortSetting.ascending ? "asc" : "desc");
+    }
+  );
+
+  /**
+   * columns is a selector which computes the input columns to the underlying
+   * sortableTable.
+   */
+  columns = createSelector(
+    this.sorted,
+    this.rollups,
+    (props: SortedTableProps<T>) => props.columns,
+    (sorted: T[], rollups: React.ReactNode[], columns: ColumnDescriptor<T>[]) => {
+      return _.map(columns, (cd, ii): SortableColumn => {
+        return {
+          title: cd.title,
+          cell: (index) => cd.cell(sorted[index]),
+          sortKey: cd.sort ? ii  : undefined,
+          rollup: rollups[ii],
+          className: cd.className,
+        };
+      });
+    });
+
+  render() {
+    let { data, sortSetting, onChangeSortSetting } = this.props;
+    if (data) {
+      return <SortableTable count={data.length}
+                            sortSetting={sortSetting}
+                            onChangeSortSetting={onChangeSortSetting}
+                            columns={this.columns(this.props)}/>;
+    }
+    return <div>No results.</div>;
+  }
+}

--- a/ui/app/containers/databases/databaseDetails.tsx
+++ b/ui/app/containers/databases/databaseDetails.tsx
@@ -27,7 +27,7 @@ class TableInfo {
     public name: string,
     public numColumns: number,
     public numIndices: number,
-    public size: number,
+    public size: number
   ) { };
 }
 
@@ -238,9 +238,8 @@ class DatabaseMain extends React.Component<DatabaseMainProps, {}> {
         </div>
           <SortableTable count={sortedTables.length}
             sortSetting={tablesSortSetting}
-            onChangeSortSetting={(setting) => this.changeTableSortSetting(setting) }>
-            { this.tableColumns(this.props) }
-          </SortableTable>
+            onChangeSortSetting={(setting) => this.changeTableSortSetting(setting) }
+            columns={ this.tableColumns(this.props) }/>
         </div>;
     }
     return <div>No results.</div>;

--- a/ui/app/containers/databases/databaseGrants.tsx
+++ b/ui/app/containers/databases/databaseGrants.tsx
@@ -145,9 +145,8 @@ class DatabaseMain extends React.Component<DatabaseMainProps, {}> {
       return <div className="sql-table">
           <SortableTable count={sortedGrants.length}
             sortSetting={grantsSortSetting}
-            onChangeSortSetting={(setting) => this.changeGrantSortSetting(setting) }>
-            {this.grantColumns(this.props) }
-          </SortableTable>
+            onChangeSortSetting={(setting) => this.changeGrantSortSetting(setting) }
+            columns={this.grantColumns(this.props) }/>
         </div>;
     }
     return <div>No results.</div>;

--- a/ui/app/containers/databases/databaseList.tsx
+++ b/ui/app/containers/databases/databaseList.tsx
@@ -187,9 +187,8 @@ class DatabasesMain extends React.Component<DatabasesMainProps, {}> {
       return <div className="sql-table">
         <SortableTable count={databases.length}
           sortSetting={sortSetting}
-          onChangeSortSetting={(setting) => this.changeSortSetting(setting) }>
-          {this.columns(this.props) }
-        </SortableTable>
+          onChangeSortSetting={(setting) => this.changeSortSetting(setting)}
+          columns={this.columns(this.props) } />
       </div>;
     }
     return <div>No results.</div>;

--- a/ui/app/containers/nodesOverview.tsx
+++ b/ui/app/containers/nodesOverview.tsx
@@ -2,14 +2,14 @@ import * as React from "react";
 import _ = require("lodash");
 import { Link } from "react-router";
 import { connect } from "react-redux";
-import { createSelector } from "reselect";
 import * as d3 from "d3";
 import * as moment from "moment";
 
 import { AdminUIState } from "../redux/state";
 import { refreshNodes } from "../redux/apiReducers";
 import { setUISetting } from "../redux/ui";
-import { SortableTable, SortableColumn, SortSetting } from "../components/sortabletable";
+import { SortSetting } from "../components/sortabletable";
+import { SortedTable } from "../components/sortedtable";
 import { NanoToMilli } from "../util/convert";
 import { BytesToUnitValue } from "../util/format";
 import { NodeStatus, MetricConstants, TotalCpu, BytesUsed } from  "../util/proto";
@@ -17,172 +17,24 @@ import { NodeStatus, MetricConstants, TotalCpu, BytesUsed } from  "../util/proto
 // Constant used to store sort settings in the redux UI store.
 const UI_NODES_SORT_SETTING_KEY = "nodes/sort_setting";
 
-/******************************
- *      COLUMN DEFINITION
- */
-
-/**
- * NodesTableColumn provides an enumeration value for each column in the nodes table.
- */
-enum NodesTableColumn {
-  Health = 1,
-  NodeID,
-  StartedAt,
-  Bytes,
-  Replicas,
-  Connections,
-  CPU,
-  MemUsage,
-  Logs,
-}
-
-/**
- * NodesColumnDescriptor is used to describe metadata about an individual column
- * in the Nodes table.
- */
-interface NodeColumnDescriptor {
-  // Enumeration key to distinguish this column from others.
-  key: NodesTableColumn;
-  // Title string that should appear in the header column.
-  title: string;
-  // Function which generates the contents of an individual cell in this table.
-  cell: (ns: NodeStatus) => React.ReactNode;
-  // Function which returns a value that can be used to sort a collection of
-  // NodeStatus. This will be used to sort the table according to the data in
-  // this column.
-  sort?: (ns: NodeStatus) => any;
-  // Function that generates a "rollup" value for this column from all statuses
-  // in a collection. This is used to display an appropriate "total" value for
-  // each column.
-  rollup?: (ns: NodeStatus[]) => React.ReactNode;
-  // className to be applied to the td elements
-  className?: string;
-}
-
-/**
- * columnDescriptors describes all columns that appear in the nodes table.
- * Columns are displayed in the same order they do in this collection, from left
- * to right.
- */
-let columnDescriptors: NodeColumnDescriptor[] = [
-  // Health column - a simple red/yellow/green status indicator.
-  {
-    key: NodesTableColumn.Health,
-    title: "",
-    cell: (ns) => {
-      let lastUpdate = moment(NanoToMilli(ns.updated_at.toNumber()));
-      let s = staleStatus(lastUpdate);
-      return <div className={"status icon-circle-filled " + s}/>;
-    },
-  },
-  // Node column - displays the node ID, links to the node-specific page for
-  // this node.
-  {
-    key: NodesTableColumn.NodeID,
-    title: "Node",
-    cell: (ns) => <Link to={"/nodes/" + ns.desc.node_id}>{ns.desc.address.address_field}</Link>,
-    sort: (ns) => ns.desc.node_id,
-    rollup: (rows) => {
-      interface StatusTotals {
-        missing?: number;
-        stale?: number;
-        healthy?: number;
-      }
-      let statuses: StatusTotals = _.countBy(rows, (row) => staleStatus(moment(NanoToMilli(row.updated_at.toNumber()))));
-
-      return <div className="node-counts">
-        <span className="healthy">{statuses.healthy || 0}</span>
-        <span>/</span>
-        <span className="stale">{statuses.stale || 0}</span>
-        <span>/</span>
-        <span className="missing">{statuses.missing || 0}</span>
-      </div>;
-    },
-    className: "expand-link",
-  },
-  // Started at - displays the time that the node started.
-  {
-    key: NodesTableColumn.StartedAt,
-    title: "Started",
-    cell: (ns) => {
-      return moment(NanoToMilli(ns.started_at.toNumber())).fromNow();
-    },
-    sort: (ns) => ns.started_at,
-  },
-  // Bytes - displays the total persisted bytes maintained by the node.
-  {
-    key: NodesTableColumn.Bytes,
-    title: "Bytes",
-    cell: (ns) => formatBytes(BytesUsed(ns)),
-    sort: (ns) => BytesUsed(ns),
-    rollup: (rows) => formatBytes(_.sumBy(rows, (row) => BytesUsed(row))),
-  },
-  // Replicas - displays the total number of replicas on the node.
-  {
-    key: NodesTableColumn.Replicas,
-    title: "Replicas",
-    cell: (ns) => ns.metrics.get(MetricConstants.replicas).toString(),
-    sort: (ns) => ns.metrics.get(MetricConstants.replicas),
-    rollup: (rows) => _.sumBy(rows, (row) => row.metrics.get(MetricConstants.replicas)).toString(),
-  },
-  // Connections - the total number of open connections on the node.
-  {
-    key: NodesTableColumn.Connections,
-    title: "Connections",
-    cell: (ns) => ns.metrics.get(MetricConstants.sqlConns).toString(),
-    sort: (ns) => ns.metrics.get(MetricConstants.sqlConns),
-    rollup: (rows) => _.sumBy(rows, (row) => row.metrics.get(MetricConstants.sqlConns)).toString(),
-  },
-  // CPU - total CPU being used on this node.
-  {
-    key: NodesTableColumn.CPU,
-    title: "CPU Usage",
-    cell: (ns) => d3.format(".2%")(TotalCpu(ns)),
-    sort: (ns) => TotalCpu(ns),
-    rollup: (rows) => d3.format(".2%")(_.sumBy(rows, (row) => TotalCpu(row))),
-  },
-  // Mem Usage - total memory being used on this node.
-  {
-    key: NodesTableColumn.MemUsage,
-    title: "Mem Usage",
-    cell: (ns) => formatBytes(ns.metrics.get(MetricConstants.rss)),
-    sort: (ns) => ns.metrics.get(MetricConstants.rss),
-    rollup: (rows) => formatBytes(_.sumBy(rows, (row) => row.metrics.get(MetricConstants.rss))),
-  },
-  // Logs - a link to the logs data for this node.
-  {
-    key: NodesTableColumn.Logs,
-    title: "Logs",
-    cell: (ns) => <Link to={"/nodes/" + ns.desc.node_id + "/logs"}>Logs</Link>,
-    className: "expand-link",
-  },
-];
-
-/**
- * NodeStatusRollups contains rollups for each column in a table, organized by
- * key.
- */
-interface NodeStatusRollups {
-  [key: number]: React.ReactNode;
-}
-
-/******************************
- *   NODES MAIN COMPONENT
- */
+// Specialization of generic SortedTable component: 
+//   https://github.com/Microsoft/TypeScript/issues/3960
+//
+// The variable name must start with a capital letter or TSX will not recognize
+// it as a component.
+// tslint:disable-next-line:variable-name
+const NodeSortedTable = SortedTable as new () => SortedTable<cockroach.server.status.NodeStatus>;
 
 /**
  * NodesMainData are the data properties which should be passed to the NodesMain
  * container.
  */
 interface NodesMainData {
-  // Current sort setting for the table. Incoming rows will already be sorted
-  // according to this setting.
+  // Current sort setting for the table, which is passed on to the sorted table
+  // component.
   sortSetting: SortSetting;
-  // A list of store statuses to display, which are possibly sorted according to
-  // sortSetting.
-  sortedStatuses: NodeStatus[];
-  // Per-column rollups computed for the current statuses.
-  statusRollups: NodeStatusRollups;
+  // A list of store statuses to display.
+  statuses: NodeStatus[];
   // True if current status results are still valid. Needed so that this
   // component refreshes status query when it becomes invalid.
   statusesValid: boolean;
@@ -210,25 +62,6 @@ type NodesMainProps = NodesMainData & NodesMainActions;
  * of all nodes.
  */
 class NodesMain extends React.Component<NodesMainProps, {}> {
-  /**
-   * columns is a selector which computes the input Columns to our data table,
-   * based our columnDescriptors and the current sorted data
-   */
-  columns = createSelector(
-    (props: NodesMainProps) => props.sortedStatuses,
-    (props: NodesMainProps) => props.statusRollups,
-    (statuses: NodeStatus[], rollups: NodeStatusRollups) => {
-      return _.map(columnDescriptors, (cd): SortableColumn => {
-        return {
-          title: cd.title,
-          cell: (index) => cd.cell(statuses[index]),
-          sortKey: cd.sort ? cd.key : undefined,
-          rollup: rollups[cd.key],
-          className: cd.className,
-        };
-      });
-    });
-
   // Callback when the user elects to change the sort setting.
   changeSortSetting(setting: SortSetting) {
     this.props.setUISetting(UI_NODES_SORT_SETTING_KEY, setting);
@@ -246,23 +79,99 @@ class NodesMain extends React.Component<NodesMainProps, {}> {
   }
 
   render() {
-    let { sortedStatuses: statuses, sortSetting } = this.props;
-    let content: React.ReactNode = null;
-
-    if (statuses) {
-      content = <SortableTable count={statuses.length}
-                       sortSetting={sortSetting}
-                       onChangeSortSetting={(setting) => this.changeSortSetting(setting)}>
-        {this.columns(this.props)}
-      </SortableTable>;
-    } else {
-      content = <div>No results.</div>;
-    }
+    let { statuses, sortSetting } = this.props;
 
     return <div className="section table node-overview">
       { this.props.children }
       <div className="stats-table">
-        { content }
+        <NodeSortedTable
+          data={statuses}
+          sortSetting={sortSetting}
+          onChangeSortSetting={(setting) => this.changeSortSetting(setting) }
+          columns={[
+            // Health column - a simple red/yellow/green status indicator.
+            {
+              title: "",
+              cell: (ns) => {
+                let lastUpdate = moment(NanoToMilli(ns.updated_at.toNumber()));
+                let s = staleStatus(lastUpdate);
+                return <div className={"status icon-circle-filled " + s}/>;
+              },
+            },
+            // Node column - displays the node ID, links to the node-specific page for
+            // this node.
+            {
+              title: "Node",
+              cell: (ns) => <Link to={"/nodes/" + ns.desc.node_id}>{ns.desc.address.address_field}</Link>,
+              sort: (ns) => ns.desc.node_id,
+              rollup: (rows) => {
+                interface StatusTotals {
+                  missing?: number;
+                  stale?: number;
+                  healthy?: number;
+                }
+                let healthTotals: StatusTotals = _.countBy(rows, (row) => staleStatus(moment(NanoToMilli(row.updated_at.toNumber()))));
+
+                return <div className="node-counts">
+                  <span className="healthy">{healthTotals.healthy || 0}</span>
+                  <span>/</span>
+                  <span className="stale">{healthTotals.stale || 0}</span>
+                  <span>/</span>
+                  <span className="missing">{healthTotals.missing || 0}</span>
+                </div>;
+              },
+              className: "expand-link",
+            },
+            // Started at - displays the time that the node started.
+            {
+              title: "Started",
+              cell: (ns) => {
+                return moment(NanoToMilli(ns.started_at.toNumber())).fromNow();
+              },
+              sort: (ns) => ns.started_at,
+            },
+            // Bytes - displays the total persisted bytes maintained by the node.
+            {
+              title: "Bytes",
+              cell: (ns) => formatBytes(BytesUsed(ns)),
+              sort: (ns) => BytesUsed(ns),
+              rollup: (rows) => formatBytes(_.sumBy(rows, (row) => BytesUsed(row))),
+            },
+            // Replicas - displays the total number of replicas on the node.
+            {
+              title: "Replicas",
+              cell: (ns) => ns.metrics.get(MetricConstants.replicas).toString(),
+              sort: (ns) => ns.metrics.get(MetricConstants.replicas),
+              rollup: (rows) => _.sumBy(rows, (row) => row.metrics.get(MetricConstants.replicas)).toString(),
+            },
+            // Connections - the total number of open connections on the node.
+            {
+              title: "Connections",
+              cell: (ns) => ns.metrics.get(MetricConstants.sqlConns).toString(),
+              sort: (ns) => ns.metrics.get(MetricConstants.sqlConns),
+              rollup: (rows) => _.sumBy(rows, (row) => row.metrics.get(MetricConstants.sqlConns)).toString(),
+            },
+            // CPU - total CPU being used on this node.
+            {
+              title: "CPU Usage",
+              cell: (ns) => d3.format(".2%")(TotalCpu(ns)),
+              sort: (ns) => TotalCpu(ns),
+              rollup: (rows) => d3.format(".2%")(_.sumBy(rows, (row) => TotalCpu(row))),
+            },
+            // Mem Usage - total memory being used on this node.
+            {
+              title: "Mem Usage",
+              cell: (ns) => formatBytes(ns.metrics.get(MetricConstants.rss)),
+              sort: (ns) => ns.metrics.get(MetricConstants.rss),
+              rollup: (rows) => formatBytes(_.sumBy(rows, (row) => row.metrics.get(MetricConstants.rss))),
+            },
+            // Logs - a link to the logs data for this node.
+            {
+              title: "Logs",
+              cell: (ns) => <Link to={"/nodes/" + ns.desc.node_id + "/logs"}>Logs</Link>,
+              className: "expand-link",
+            },
+          ]}/>
       </div>
     </div>;
   }
@@ -277,56 +186,11 @@ let nodeQueryValid = (state: AdminUIState): boolean => state.cachedData.nodes.va
 let nodeStatuses = (state: AdminUIState): NodeStatus[] => state.cachedData.nodes.data;
 let sortSetting = (state: AdminUIState): SortSetting => state.ui[UI_NODES_SORT_SETTING_KEY] || {};
 
-// Selector which sorts statuses according to current sort setting.
-let sortFunctionLookup = _.reduce(
-  columnDescriptors,
-  (memo, cd) => {
-    if (cd.sort) {
-      memo[cd.key] = cd.sort;
-    }
-    return memo;
-  },
-  {} as {[key: number]: (ns: NodeStatus) => any}
-);
-
-let sortedStatuses = createSelector(
-  nodeStatuses,
-  sortSetting,
-  (statuses, sort) => {
-    if (!sort) {
-      return statuses;
-    }
-    let sortFn = sortFunctionLookup[sort.sortKey];
-    if (!sortFn) {
-      return statuses;
-    }
-    let result = _.chain(statuses);
-    result = result.sortBy(sortFn);
-    if (sort.ascending) {
-      result = result.reverse();
-    }
-    return result.value();
-  });
-
-// Selector which computes status rollups for the current node status set.
-let rollupStatuses = createSelector(
-  nodeStatuses,
-  (statuses) => {
-    let rollups: NodeStatusRollups = {};
-    _.map(columnDescriptors, (c) => {
-      if (c.rollup) {
-        rollups[c.key] = c.rollup(statuses);
-      }
-    });
-    return rollups;
-  });
-
 // Connect the NodesMain class with our redux store.
 let nodesMainConnected = connect(
   (state: AdminUIState) => {
     return {
-      sortedStatuses: sortedStatuses(state),
-      statusRollups: rollupStatuses(state),
+      statuses: nodeStatuses(state),
       sortSetting: sortSetting(state),
       statusesValid: nodeQueryValid(state),
     };


### PR DESCRIPTION
Commit creates SortedTable component, a generic table which accepts unsorted
data and is responsible for computing sort order and per-column rollups.

This is intended to be used by a number of our current UI pages which currently
use the lower-level `SortableTable`, which displays sorted data but is not
actually responsible for sorting data or computing rollups. This will eliminate
a very large amount of boilerplate code which is currently present on pages
displaying tabular data.

In this PR, only the NodesOverview page has been converted to use the new
SortedTable, in order to give a preview of how this will look on all of the
other pages.

Additionally, this PR modifies SortedTable to accept column definitions as an
explicit React property `columns` instead of as child elements; I kept running
into a number of React assertions about "object children", and while I could
eventually get it running without assertions, it is clear that using POJOs as
children is not a desirable pattern in React. This change also gives additional
type safety.

Work towards #8450

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8532)

<!-- Reviewable:end -->
