### PR TITLE
gossip: fix race and update locking

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -239,7 +239,7 @@ func (c *client) gossip(ctx context.Context, g *Gossip, gossipClient GossipClien
 		return err
 	}
 
-	if err := c.requestGossip(g, addr, stream); err != nil {
+	if err := c.requestGossip(g, *addr, stream); err != nil {
 		return err
 	}
 
@@ -279,7 +279,7 @@ func (c *client) gossip(ctx context.Context, g *Gossip, gossipClient GossipClien
 		case err := <-errCh:
 			return err
 		case <-sendGossipChan:
-			if err := c.sendGossip(g, addr, stream); err != nil {
+			if err := c.sendGossip(g, *addr, stream); err != nil {
 				return err
 			}
 		}

--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -135,7 +135,7 @@ func gossipSucceedsSoon(t *testing.T, stopper *stop.Stopper, disconnected chan *
 		select {
 		case client := <-disconnected:
 			// If the client wasn't able to connect, restart it.
-			client.start(gossip[client], disconnected, rpcContext, stopper)
+			client.start(gossip[client], disconnected, rpcContext, stopper, gossip[client].GetNodeID())
 		default:
 		}
 
@@ -150,7 +150,8 @@ func TestClientGossip(t *testing.T) {
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 	remote := startGossip(2, stopper, t, metric.NewRegistry())
 	disconnected := make(chan *client, 1)
-	c := newClient(&remote.is.NodeAddr, makeMetrics())
+	remoteAddr := remote.GetNodeAddr()
+	c := newClient(&remoteAddr, makeMetrics())
 
 	defer func() {
 		stopper.Stop()
@@ -185,13 +186,15 @@ func TestClientGossipMetrics(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	local := startGossip(1, stopper, t, metric.NewRegistry())
+	localAddr := local.GetNodeAddr()
 	remote := startGossip(2, stopper, t, metric.NewRegistry())
+	remoteAddr := remote.GetNodeAddr()
 
 	gossipSucceedsSoon(
 		t, stopper, make(chan *client, 2),
 		map[*client]*Gossip{
-			newClient(&local.is.NodeAddr, makeMetrics()):  remote,
-			newClient(&remote.is.NodeAddr, makeMetrics()): local,
+			newClient(&localAddr, makeMetrics()):  remote,
+			newClient(&remoteAddr, makeMetrics()): local,
 		},
 		func() error {
 			if err := local.AddInfo("local-key", nil, time.Hour); err != nil {
@@ -219,7 +222,9 @@ func TestClientGossipMetrics(t *testing.T) {
 			// Since there are two gossip nodes, there should be at least one incoming
 			// and outgoing connection.
 			for i, s := range []*server{local.server, remote.server} {
-				gauge := s.incoming.gauge
+				s.mu.Lock()
+				gauge := s.mu.incoming.gauge
+				s.mu.Unlock()
 				if gauge == nil {
 					return errors.Errorf("%d: missing gauge \"incoming\"", i)
 				}
@@ -265,7 +270,7 @@ func TestClientNodeID(t *testing.T) {
 			return
 		case <-disconnected:
 			// The client hasn't been started or failed to start, loop and try again.
-			c.start(local, disconnected, rpcContext, stopper)
+			c.start(local, disconnected, rpcContext, stopper, local.GetNodeID())
 		}
 	}
 }
@@ -273,7 +278,7 @@ func TestClientNodeID(t *testing.T) {
 func verifyServerMaps(g *Gossip, expCount int) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return len(g.nodeMap) == expCount
+	return len(g.mu.nodeMap) == expCount
 }
 
 // TestClientDisconnectLoopback verifies that the gossip server
@@ -286,8 +291,8 @@ func TestClientDisconnectLoopback(t *testing.T) {
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 	// startClient requires locks are held, so acquire here.
 	local.mu.Lock()
-	lAddr := local.is.NodeAddr
-	local.startClient(&lAddr)
+	lAddr := local.mu.is.NodeAddr
+	local.startClient(&lAddr, local.mu.is.NodeID)
 	local.mu.Unlock()
 	local.manage()
 	util.SucceedsSoon(t, func() error {
@@ -311,11 +316,10 @@ func TestClientDisconnectRedundant(t *testing.T) {
 	// startClient requires locks are held, so acquire here.
 	local.mu.Lock()
 	remote.mu.Lock()
-
-	rAddr := remote.is.NodeAddr
-	lAddr := local.is.NodeAddr
-	local.startClient(&rAddr)
-	remote.startClient(&lAddr)
+	rAddr := remote.mu.is.NodeAddr
+	lAddr := local.mu.is.NodeAddr
+	local.startClient(&rAddr, remote.mu.is.NodeID)
+	remote.startClient(&lAddr, local.mu.is.NodeID)
 	local.mu.Unlock()
 	remote.mu.Unlock()
 	local.manage()
@@ -349,12 +353,12 @@ func TestClientDisallowMultipleConns(t *testing.T) {
 	remote := startGossip(2, stopper, t, metric.NewRegistry())
 	local.mu.Lock()
 	remote.mu.Lock()
-	rAddr := remote.is.NodeAddr
+	rAddr := remote.mu.is.NodeAddr
 	// Start two clients from local to remote. RPC client cache is
 	// disabled via the context, so we'll start two different outgoing
 	// connections.
-	local.startClient(&rAddr)
-	local.startClient(&rAddr)
+	local.startClient(&rAddr, remote.mu.is.NodeID)
+	local.startClient(&rAddr, remote.mu.is.NodeID)
 	local.mu.Unlock()
 	remote.mu.Unlock()
 	local.manage()
@@ -366,7 +370,7 @@ func TestClientDisallowMultipleConns(t *testing.T) {
 		local.mu.Lock()
 		remote.mu.Lock()
 		outgoing := local.outgoing.len()
-		incoming := remote.incoming.len()
+		incoming := remote.mu.incoming.len()
 		local.mu.Unlock()
 		remote.mu.Unlock()
 		if outgoing == 1 && incoming == 1 && verifyServerMaps(local, 0) && verifyServerMaps(remote, 1) {
@@ -417,8 +421,8 @@ func TestClientRegisterWithInitNodeID(t *testing.T) {
 		// in nodeMap if these three gossip nodes registered success.
 		g[0].mu.Lock()
 		defer g[0].mu.Unlock()
-		if a, e := len(g[0].nodeMap), 2; a != e {
-			return errors.Errorf("expected %s to contain %d nodes, got %d", g[0].nodeMap, e, a)
+		if a, e := len(g[0].mu.nodeMap), 2; a != e {
+			return errors.Errorf("expected %s to contain %d nodes, got %d", g[0].mu.nodeMap, e, a)
 		}
 		return nil
 	})
@@ -453,9 +457,7 @@ func TestClientRetryBootstrap(t *testing.T) {
 	defer stopper.Stop()
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 	remote := startGossip(2, stopper, t, metric.NewRegistry())
-	remote.mu.Lock()
-	rAddr := remote.is.NodeAddr
-	remote.mu.Unlock()
+	rAddr := remote.GetNodeAddr()
 
 	if err := local.AddInfo("local-key", []byte("hello"), 0*time.Second); err != nil {
 		t.Fatal(err)
@@ -482,9 +484,7 @@ func TestClientForwardUnresolved(t *testing.T) {
 	defer stopper.Stop()
 	const nodeID = 1
 	local := startGossip(nodeID, stopper, t, metric.NewRegistry())
-	local.mu.Lock()
-	addr := local.is.NodeAddr
-	local.mu.Unlock()
+	addr := local.GetNodeAddr()
 
 	client := newClient(&addr, makeMetrics()) // never started
 

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -164,8 +164,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 	}
 
 	for _, peer := range peers {
-		localAddr := local.GetNodeAddr()
-		c := newClient(&localAddr, makeMetrics())
+		c := newClient(local.GetNodeAddr(), makeMetrics())
 
 		util.SucceedsSoon(t, func() error {
 			conn, err := peer.rpcContext.GRPCDial(c.addr.String(), grpc.WithBlock())
@@ -178,8 +177,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 				return err
 			}
 
-			peerAddr := peer.GetNodeAddr()
-			if err := c.requestGossip(peer, peerAddr, stream); err != nil {
+			if err := c.requestGossip(peer, *peer.GetNodeAddr(), stream); err != nil {
 				return err
 			}
 
@@ -202,7 +200,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 
 		for {
 			localAddr := local.GetNodeAddr()
-			c := newClient(&localAddr, makeMetrics())
+			c := newClient(localAddr, makeMetrics())
 			c.start(peer, disconnectedCh, peer.rpcContext, stopper, peer.GetNodeID())
 
 			disconnectedClient := <-disconnectedCh
@@ -213,7 +211,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 				// unrelated to the test, so we need to permit some.
 				t.Logf("node #%d: got nil forwarding address", peer.GetNodeID())
 				continue
-			} else if *c.forwardAddr == localAddr {
+			} else if *c.forwardAddr == *localAddr {
 				t.Errorf("node #%d: got local's forwarding address", peer.GetNodeID())
 			}
 			break
@@ -234,8 +232,7 @@ func TestGossipCullNetwork(t *testing.T) {
 	local.mu.Lock()
 	for i := 0; i < minPeers; i++ {
 		peer := startGossip(roachpb.NodeID(i+2), stopper, t, metric.NewRegistry())
-		peerAddr := peer.GetNodeAddr()
-		local.startClient(&peerAddr, peer.GetNodeID())
+		local.startClient(peer.GetNodeAddr(), peer.GetNodeID())
 	}
 	local.mu.Unlock()
 

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -46,12 +46,14 @@ type serverInfo struct {
 type server struct {
 	stopper *stop.Stopper
 
-	mu       syncutil.Mutex                     // Protects the fields below
-	is       *infoStore                         // The backing infostore
-	incoming nodeSet                            // Incoming client node IDs
-	nodeMap  map[util.UnresolvedAddr]serverInfo // Incoming client's local address -> serverInfo
-	tighten  chan roachpb.NodeID                // Channel of too-distant node IDs
-	ready    chan struct{}                      // Broadcasts wakeup to waiting gossip requests
+	mu struct {
+		syncutil.Mutex
+		is       *infoStore                         // The backing infostore
+		incoming nodeSet                            // Incoming client node IDs
+		nodeMap  map[util.UnresolvedAddr]serverInfo // Incoming client's local address -> serverInfo
+		ready    chan struct{}                      // Broadcasts wakeup to waiting gossip requests
+	}
+	tighten chan roachpb.NodeID // Channel of too-distant node IDs
 
 	nodeMetrics   Metrics
 	serverMetrics Metrics
@@ -62,17 +64,20 @@ type server struct {
 // newServer creates and returns a server struct.
 func newServer(stopper *stop.Stopper, registry *metric.Registry) *server {
 	s := &server{
-		stopper:       stopper,
-		is:            newInfoStore(0, util.UnresolvedAddr{}, stopper),
-		incoming:      makeNodeSet(minPeers, metric.NewGauge(MetaConnectionsIncomingGauge)),
-		nodeMap:       make(map[util.UnresolvedAddr]serverInfo),
-		tighten:       make(chan roachpb.NodeID, 1),
-		ready:         make(chan struct{}),
+		stopper: stopper,
+
+		tighten: make(chan roachpb.NodeID, 1),
+
 		nodeMetrics:   makeMetrics(),
 		serverMetrics: makeMetrics(),
 	}
 
-	registry.AddMetric(s.incoming.gauge)
+	s.mu.is = newInfoStore(0, util.UnresolvedAddr{}, stopper)
+	s.mu.incoming = makeNodeSet(minPeers, metric.NewGauge(MetaConnectionsIncomingGauge))
+	s.mu.nodeMap = make(map[util.UnresolvedAddr]serverInfo)
+	s.mu.ready = make(chan struct{})
+
+	registry.AddMetric(s.mu.incoming.gauge)
 	registry.AddMetricStruct(s.nodeMetrics)
 
 	return s
@@ -119,7 +124,7 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 	// node. This can happen when bootstrap connections are initiated through
 	// a load balancer.
 	s.mu.Lock()
-	_, ok := s.nodeMap[args.Addr]
+	_, ok := s.mu.nodeMap[args.Addr]
 	s.mu.Unlock()
 	if ok {
 		return errors.Errorf("duplicate connection from node at %s", args.Addr)
@@ -143,18 +148,18 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 		// Store the old ready so that if it gets replaced with a new one
 		// (once the lock is released) and is closed, we still trigger the
 		// select below.
-		ready := s.ready
-		delta := s.is.delta(args.HighWaterStamps)
+		ready := s.mu.ready
+		delta := s.mu.is.delta(args.HighWaterStamps)
 
 		if infoCount := len(delta); infoCount > 0 {
 			if log.V(1) {
 				log.Infof(context.TODO(), "node %d: returning %d info(s) to node %d: %s",
-					s.is.NodeID, infoCount, args.NodeID, extractKeys(delta))
+					s.mu.is.NodeID, infoCount, args.NodeID, extractKeys(delta))
 			}
 
 			*reply = Response{
-				NodeID:          s.is.NodeID,
-				HighWaterStamps: s.is.getHighWaterStamps(),
+				NodeID:          s.mu.is.NodeID,
+				HighWaterStamps: s.mu.is.getHighWaterStamps(),
 				Delta:           delta,
 			}
 
@@ -190,27 +195,27 @@ func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) erro
 		if args.NodeID != 0 {
 			// Decide whether or not we can accept the incoming connection
 			// as a permanent peer.
-			if args.NodeID == s.is.NodeID {
+			if args.NodeID == s.mu.is.NodeID {
 				// This is an incoming loopback connection which should be closed by
 				// the client.
 				if log.V(2) {
 					log.Infof(context.TODO(), "node %d: ignoring gossip from node %d (loopback)",
-						s.is.NodeID, args.NodeID)
+						s.mu.is.NodeID, args.NodeID)
 				}
-			} else if s.incoming.hasNode(args.NodeID) {
+			} else if s.mu.incoming.hasNode(args.NodeID) {
 				// Do nothing.
 				if log.V(2) {
 					log.Infof(context.TODO(), "node %d: ignoring gossip from node %d (already in incoming set)",
-						s.is.NodeID, args.NodeID)
+						s.mu.is.NodeID, args.NodeID)
 				}
-			} else if s.incoming.hasSpace() {
+			} else if s.mu.incoming.hasSpace() {
 				if log.V(2) {
 					log.Infof(context.TODO(), "node %d: adding node %d to incoming set",
-						s.is.NodeID, args.NodeID)
+						s.mu.is.NodeID, args.NodeID)
 				}
 
-				s.incoming.addNode(args.NodeID)
-				s.nodeMap[args.Addr] = serverInfo{
+				s.mu.incoming.addNode(args.NodeID)
+				s.mu.nodeMap[args.Addr] = serverInfo{
 					peerID:    args.NodeID,
 					createdAt: timeutil.Now(),
 				}
@@ -218,18 +223,18 @@ func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) erro
 				defer func(nodeID roachpb.NodeID, addr util.UnresolvedAddr) {
 					if log.V(2) {
 						log.Infof(context.TODO(), "node %d: removing node %d from incoming set",
-							s.is.NodeID, args.NodeID)
+							s.mu.is.NodeID, args.NodeID)
 					}
 
-					s.incoming.removeNode(nodeID)
-					delete(s.nodeMap, addr)
+					s.mu.incoming.removeNode(nodeID)
+					delete(s.mu.nodeMap, addr)
 				}(args.NodeID, args.Addr)
 			} else {
 				var alternateAddr util.UnresolvedAddr
 				var alternateNodeID roachpb.NodeID
 				// Choose a random peer for forwarding.
-				altIdx := rand.Intn(len(s.nodeMap))
-				for addr, info := range s.nodeMap {
+				altIdx := rand.Intn(len(s.mu.nodeMap))
+				for addr, info := range s.mu.nodeMap {
 					if altIdx == 0 {
 						alternateAddr = addr
 						alternateNodeID = info.peerID
@@ -239,10 +244,10 @@ func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) erro
 				}
 
 				log.Infof(context.TODO(), "node %d: refusing gossip from node %d (max %d conns); forwarding to %d (%s)",
-					s.is.NodeID, args.NodeID, s.incoming.maxSize, alternateNodeID, alternateAddr)
+					s.mu.is.NodeID, args.NodeID, s.mu.incoming.maxSize, alternateNodeID, alternateAddr)
 
 				*reply = Response{
-					NodeID:          s.is.NodeID,
+					NodeID:          s.mu.is.NodeID,
 					AlternateAddr:   &alternateAddr,
 					AlternateNodeID: alternateNodeID,
 				}
@@ -261,7 +266,7 @@ func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) erro
 				}
 			}
 		} else {
-			log.Infof(context.TODO(), "node %d: received gossip from unknown node", s.is.NodeID)
+			log.Infof(context.TODO(), "node %d: received gossip from unknown node", s.mu.is.NodeID)
 		}
 
 		bytesReceived := int64(args.Size())
@@ -271,18 +276,18 @@ func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) erro
 		s.serverMetrics.BytesReceived.Add(bytesReceived)
 		s.serverMetrics.InfosReceived.Add(infosReceived)
 
-		freshCount, err := s.is.combine(args.Delta, args.NodeID)
+		freshCount, err := s.mu.is.combine(args.Delta, args.NodeID)
 		if err != nil {
-			log.Warningf(context.TODO(), "node %d: failed to fully combine gossip delta from node %d: %s", s.is.NodeID, args.NodeID, err)
+			log.Warningf(context.TODO(), "node %d: failed to fully combine gossip delta from node %d: %s", s.mu.is.NodeID, args.NodeID, err)
 		}
 		if log.V(1) {
-			log.Infof(context.TODO(), "node %d: received %s from node %d (%d fresh)", s.is.NodeID, extractKeys(args.Delta), args.NodeID, freshCount)
+			log.Infof(context.TODO(), "node %d: received %s from node %d (%d fresh)", s.mu.is.NodeID, extractKeys(args.Delta), args.NodeID, freshCount)
 		}
-		s.maybeTighten()
+		s.maybeTightenLocked()
 
 		*reply = Response{
-			NodeID:          s.is.NodeID,
-			HighWaterStamps: s.is.getHighWaterStamps(),
+			NodeID:          s.mu.is.NodeID,
+			HighWaterStamps: s.mu.is.getHighWaterStamps(),
 		}
 
 		s.mu.Unlock()
@@ -311,20 +316,21 @@ func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) erro
 	}
 }
 
-// maybeTighten examines the infostore for the most distant node and
+// maybeTightenLocked examines the infostore for the most distant node and
 // if more distant than MaxHops, sends on the tightenNetwork channel
-// to start a new client connection.
-func (s *server) maybeTighten() {
-	distantNodeID, distantHops := s.is.mostDistant()
+// to start a new client connection. The mutex must be held by the caller.
+func (s *server) maybeTightenLocked() {
+	distantNodeID, distantHops := s.mu.is.mostDistant()
 	if log.V(2) {
-		log.Infof(context.TODO(), "node %d: distantHops: %d from %d", s.is.NodeID, distantHops, distantNodeID)
+		log.Infof(context.TODO(), "node %d: distantHops: %d from %d",
+			s.mu.is.NodeID, distantHops, distantNodeID)
 	}
 	if distantHops > MaxHops {
 		select {
 		case s.tighten <- distantNodeID:
 			if log.V(1) {
 				log.Infof(context.TODO(), "node %d: if possible, tightening network to node %d (%d > %d)",
-					s.is.NodeID, distantNodeID, distantHops, MaxHops)
+					s.mu.is.NodeID, distantNodeID, distantHops, MaxHops)
 			}
 		default:
 			// Do nothing.
@@ -338,18 +344,18 @@ func (s *server) maybeTighten() {
 // the next round of gossip are awoken via the conditional variable.
 func (s *server) start(addr net.Addr) {
 	s.mu.Lock()
-	s.is.NodeAddr = util.MakeUnresolvedAddr(addr.Network(), addr.String())
-	s.mu.Unlock()
+	defer s.mu.Unlock()
+	s.mu.is.NodeAddr = util.MakeUnresolvedAddr(addr.Network(), addr.String())
 
 	broadcast := func() {
-		ready := make(chan struct{})
-
 		s.mu.Lock()
-		close(s.ready)
-		s.ready = ready
-		s.mu.Unlock()
+		defer s.mu.Unlock()
+		ready := make(chan struct{})
+		close(s.mu.ready)
+		s.mu.ready = ready
 	}
-	unregister := s.is.registerCallback(".*", func(_ string, _ roachpb.Value) {
+
+	unregister := s.mu.is.registerCallback(".*", func(_ string, _ roachpb.Value) {
 		broadcast()
 	})
 
@@ -369,8 +375,8 @@ func (s *server) status() string {
 	defer s.mu.Unlock()
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "gossip server (%d/%d cur/max conns, %s)\n",
-		s.incoming.gauge.Value(), s.incoming.maxSize, s.serverMetrics)
-	for addr, info := range s.nodeMap {
+		s.mu.incoming.gauge.Value(), s.mu.incoming.maxSize, s.serverMetrics)
+	for addr, info := range s.mu.nodeMap {
 		// TODO(peter): Report per connection sent/received statistics. The
 		// structure of server.Gossip and server.gossipReceiver makes this
 		// irritating to track.
@@ -382,4 +388,11 @@ func (s *server) status() string {
 
 func roundSecs(d time.Duration) time.Duration {
 	return time.Duration(d.Seconds()+0.5) * time.Second
+}
+
+// GetNodeAddr returns the node's address stored in the Infostore.
+func (s *server) GetNodeAddr() util.UnresolvedAddr {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mu.is.NodeAddr
 }

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -384,8 +384,8 @@ func roundSecs(d time.Duration) time.Duration {
 }
 
 // GetNodeAddr returns the node's address stored in the Infostore.
-func (s *server) GetNodeAddr() util.UnresolvedAddr {
+func (s *server) GetNodeAddr() *util.UnresolvedAddr {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.mu.is.NodeAddr
+	return &s.mu.is.NodeAddr
 }

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -51,9 +51,9 @@ type server struct {
 		is       *infoStore                         // The backing infostore
 		incoming nodeSet                            // Incoming client node IDs
 		nodeMap  map[util.UnresolvedAddr]serverInfo // Incoming client's local address -> serverInfo
-		ready    chan struct{}                      // Broadcasts wakeup to waiting gossip requests
 	}
 	tighten chan roachpb.NodeID // Channel of too-distant node IDs
+	ready   chan struct{}       // Broadcasts wakeup to waiting gossip requests
 
 	nodeMetrics   Metrics
 	serverMetrics Metrics
@@ -64,10 +64,9 @@ type server struct {
 // newServer creates and returns a server struct.
 func newServer(stopper *stop.Stopper, registry *metric.Registry) *server {
 	s := &server{
-		stopper: stopper,
-
-		tighten: make(chan roachpb.NodeID, 1),
-
+		stopper:       stopper,
+		tighten:       make(chan roachpb.NodeID, 1),
+		ready:         make(chan struct{}, 1),
 		nodeMetrics:   makeMetrics(),
 		serverMetrics: makeMetrics(),
 	}
@@ -75,7 +74,6 @@ func newServer(stopper *stop.Stopper, registry *metric.Registry) *server {
 	s.mu.is = newInfoStore(0, util.UnresolvedAddr{}, stopper)
 	s.mu.incoming = makeNodeSet(minPeers, metric.NewGauge(MetaConnectionsIncomingGauge))
 	s.mu.nodeMap = make(map[util.UnresolvedAddr]serverInfo)
-	s.mu.ready = make(chan struct{})
 
 	registry.AddMetric(s.mu.incoming.gauge)
 	registry.AddMetricStruct(s.nodeMetrics)
@@ -145,10 +143,6 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 
 	for {
 		s.mu.Lock()
-		// Store the old ready so that if it gets replaced with a new one
-		// (once the lock is released) and is closed, we still trigger the
-		// select below.
-		ready := s.mu.ready
 		delta := s.mu.is.delta(args.HighWaterStamps)
 
 		if infoCount := len(delta); infoCount > 0 {
@@ -177,7 +171,7 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 			return nil
 		case err := <-errCh:
 			return err
-		case <-ready:
+		case <-s.ready:
 		}
 	}
 }
@@ -348,11 +342,10 @@ func (s *server) start(addr net.Addr) {
 	s.mu.is.NodeAddr = util.MakeUnresolvedAddr(addr.Network(), addr.String())
 
 	broadcast := func() {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		ready := make(chan struct{})
-		close(s.mu.ready)
-		s.mu.ready = ready
+		select {
+		case s.ready <- struct{}{}:
+		default:
+		}
 	}
 
 	unregister := s.mu.is.registerCallback(".*", func(_ string, _ roachpb.Value) {

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -140,7 +140,10 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 
 	for {
 		s.mu.Lock()
-
+		// Store the old ready so that if it gets replaced with a new one
+		// (once the lock is released) and is closed, we still trigger the
+		// select below.
+		ready := s.ready
 		delta := s.is.delta(args.HighWaterStamps)
 
 		if infoCount := len(delta); infoCount > 0 {
@@ -162,7 +165,6 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 			s.mu.Lock()
 		}
 
-		ready := s.ready
 		s.mu.Unlock()
 
 		select {


### PR DESCRIPTION
2 commits:
- gossip: fix race in which we may not trigger a gossip
  When a new gossip comes in, we replace the ready channel with a new one. If we
  don't hold the old ready channel, we may miss the callback if there was a reply
  already in progress.  The solution is to just store the ready channel before
  we release the lock.
- gossip: move lock to anonymous struct
  This brings gossip's server locking in line with our current style.

The outgoing nodeSet seems like it requires the server lock as well.  I'd like to move it into the struct as well.

This is part of work towards #8263.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8539)

<!-- Reviewable:end -->
