### PR TITLE
Fix check-style.sh when running using parallel.

### DIFF
--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-PKG=${PKG:-./...}
+export PKG=${PKG:-./...}
 
 TestCopyrightHeaders() {
   echo "checking for missing license headers"


### PR DESCRIPTION
Parallel launches separate processes and does not grab global variables.
Export `PKG` instead to make sure it gets picked up.

This was causing my `make check` to skip most checks (but still return
success) since all my machines have `parallel` installed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8547)

<!-- Reviewable:end -->
