### PR TITLE
Clean up runtime metrics

### DIFF
--- a/util/metric/registry.go
+++ b/util/metric/registry.go
@@ -41,14 +41,14 @@ const sep = "-"
 type Registry struct {
 	syncutil.Mutex
 	labels  []*prometheusgo.LabelPair
-	tracked map[string]Iterable
+	tracked []Iterable
 }
 
 // NewRegistry creates a new Registry.
 func NewRegistry() *Registry {
 	return &Registry{
 		labels:  []*prometheusgo.LabelPair{},
-		tracked: map[string]Iterable{},
+		tracked: []Iterable{},
 	}
 }
 
@@ -73,7 +73,7 @@ func (r *Registry) getLabels() []*prometheusgo.LabelPair {
 func (r *Registry) AddMetric(metric Iterable) {
 	r.Lock()
 	defer r.Unlock()
-	r.tracked[metric.GetName()] = metric
+	r.tracked = append(r.tracked, metric)
 	if log.V(2) {
 		log.Infof(context.TODO(), "Added metric: %s (%T)", metric.GetName(), metric)
 	}
@@ -85,7 +85,7 @@ func (r *Registry) AddMetricGroup(group metricGroup) {
 	r.Lock()
 	defer r.Unlock()
 	group.iterate(func(metric Iterable) {
-		r.tracked[metric.GetName()] = metric
+		r.tracked = append(r.tracked, metric)
 		if log.V(2) {
 			log.Infof(context.TODO(), "Added metric: %s (%T)", metric.GetName(), metric)
 		}

--- a/util/metric/registry_test.go
+++ b/util/metric/registry_test.go
@@ -21,14 +21,23 @@ import (
 	"time"
 )
 
+func (r *Registry) findMetricByName(name string) Iterable {
+	for _, metric := range r.tracked {
+		if metric.GetName() == name {
+			return metric
+		}
+	}
+	return nil
+}
+
 // getCounter returns the Counter in this registry with the given name. If a
 // Counter with this name is not present (including if a non-Counter Iterable is
 // registered with the name), nil is returned.
 func (r *Registry) getCounter(name string) *Counter {
 	r.Lock()
 	defer r.Unlock()
-	iterable, ok := r.tracked[name]
-	if !ok {
+	iterable := r.findMetricByName(name)
+	if iterable == nil {
 		return nil
 	}
 	counter, ok := iterable.(*Counter)
@@ -44,8 +53,8 @@ func (r *Registry) getCounter(name string) *Counter {
 func (r *Registry) getGauge(name string) *Gauge {
 	r.Lock()
 	defer r.Unlock()
-	iterable, ok := r.tracked[name]
-	if !ok {
+	iterable := r.findMetricByName(name)
+	if iterable == nil {
 		return nil
 	}
 	gauge, ok := iterable.(*Gauge)
@@ -61,8 +70,8 @@ func (r *Registry) getGauge(name string) *Gauge {
 func (r *Registry) getRate(name string) *Rate {
 	r.Lock()
 	defer r.Unlock()
-	iterable, ok := r.tracked[name]
-	if !ok {
+	iterable := r.findMetricByName(name)
+	if iterable == nil {
 		return nil
 	}
 	rate, ok := iterable.(*Rate)


### PR DESCRIPTION
- add help strings to all `runtime` metrics
- add `sys.uptime` metric (in seconds)

Slight change to the registry: we no longer use a map of metrics but a
slice. This means that we can easily refresh `/_status/vars` and stay in
one place (makes my life much simpler). The only code left that indexes
directly into the map is in `registry_test`, so they now loop over the
slice.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8555)

<!-- Reviewable:end -->
