### PR TITLE
Fix timeouts with BenchmarkMVCCDeleteRange1VersionNBytes_RocksDB tests

### DIFF
--- a/storage/engine/bench_test.go
+++ b/storage/engine/bench_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -439,7 +440,9 @@ func runMVCCDeleteRange(emk engineMaker, valueBytes int, b *testing.B) {
 		dupEng, stopper := emk(b, locDirty)
 
 		b.StartTimer()
-		_, _, _, err := MVCCDeleteRange(context.Background(), dupEng, &enginepb.MVCCStats{}, roachpb.KeyMin, roachpb.KeyMax, 0, hlc.MaxTimestamp, nil, false)
+		_, _, _, err := MVCCDeleteRange(context.Background(), dupEng,
+			&enginepb.MVCCStats{}, roachpb.KeyMin, roachpb.KeyMax, math.MaxInt64,
+			hlc.MaxTimestamp, nil, false)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
The Go benchmark tool allows you to time a portion of your code and then
adjusts the value b.N until the portion that is timed is equal to 1 second.
Thus, it is standard to put the portion of your code in a for loop that looks
like:

for (i := 0; i < b.N i++) { code_to_benchmark() }

However, if you stop the timer in your for loop and to run untracked setup
code in the same loop (as was done before this commit in storage/engine)
then you can run into an issue where N \* setup_code >> 1 second. In this
case N was being set to roughly ~500,000 causing our benchmark tests to run
forever.

This commit fixes this issue by multiplying the time code_to_benchmark()
takes by 100, thus reducing b.N by a factor of 100, thus making our test
run in a reasonable amount of time.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8558)

<!-- Reviewable:end -->
