### PR TITLE
sql: enable multinode parallel test

### DIFF
--- a/base/constants_race.go
+++ b/base/constants_race.go
@@ -14,7 +14,9 @@
 //
 // Author: Radu Berinde (radu@cockroachlabs.com)
 
-// +build !race
+// +build race
+// Version of constants.go used when the race detector is enabled (with more
+// lenient timeouts).
 
 package base
 
@@ -29,7 +31,7 @@ const (
 	DefaultHeartbeatInterval = 5 * time.Second
 
 	// NetworkTimeout is the timeout used for network operations.
-	NetworkTimeout = 3 * time.Second
+	NetworkTimeout = 10 * time.Second
 
 	// DefaultRaftTickInterval is the default resolution of the Raft timer.
 	DefaultRaftTickInterval = 100 * time.Millisecond

--- a/base/context.go
+++ b/base/context.go
@@ -51,12 +51,6 @@ const (
 	// NB: net.JoinHostPort is not a constant.
 	defaultAddr     = ":" + DefaultPort
 	defaultHTTPAddr = ":" + DefaultHTTPPort
-
-	// NetworkTimeout is the timeout used for network operations.
-	NetworkTimeout = 3 * time.Second
-
-	// DefaultRaftTickInterval is the default resolution of the Raft timer.
-	DefaultRaftTickInterval = 100 * time.Millisecond
 )
 
 type lazyTLSConfig struct {

--- a/sql/partestdata/subquery_retry_multinode/test.yaml
+++ b/sql/partestdata/subquery_retry_multinode/test.yaml
@@ -1,6 +1,3 @@
-# Test is temporarily disabled.
-skip_reason: "#8057"
-
 cluster_size: 5
 
 range_split_size: 32768

--- a/sql/partestdata/subquery_retry_multinode/txn
+++ b/sql/partestdata/subquery_retry_multinode/txn
@@ -5,6 +5,6 @@
 # We insert a large filler string in the second column to generate range splits
 # quicker.
 
-repeat 2
+repeat 50
 statement ok
-INSERT INTO T VALUES ((SELECT MAX(k+1) FROM T), REPEAT('x', 1000))
+INSERT INTO T VALUES ((SELECT MAX(k+1) FROM T), REPEAT('x', 500))


### PR DESCRIPTION
Enable the multinode version of the parallel test, where we have a 5 node
cluster. See #8057.

I will reduce the number of transactions per client to 25 before submitting - I want to do some runs on CircleCI with 150.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8559)

<!-- Reviewable:end -->
