### PR TITLE
acceptance: skip flaky TestClusterRecovery.

### DIFF
--- a/acceptance/chaos_test.go
+++ b/acceptance/chaos_test.go
@@ -309,6 +309,7 @@ func waitClientsStop(num int, state *testState, stallDuration time.Duration) {
 // being killed and restarted continuously. The test doesn't measure write
 // performance, but cluster recovery.
 func TestClusterRecovery(t *testing.T) {
+	t.Skip("Skipped due to flakiness until we can investigate #8538 further.")
 	runTestOnConfigs(t, testClusterRecoveryInner)
 }
 


### PR DESCRIPTION
This test fails about half the time on TeamCity. See #8538 for more details. Let's skip this for now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8575)

<!-- Reviewable:end -->
