### PR TITLE
cli: add basic 'help foo' to describe functions

### DIFF
--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -66,6 +66,7 @@ const (
 // Builtin is a built-in function.
 type Builtin struct {
 	Types      typeList
+	ArgNames   []string
 	ReturnType Datum
 	category   string
 	// Set to true when a function potentially returns a different value
@@ -339,7 +340,7 @@ var Builtins = map[string][]Builtin{
 
 	"replace": {stringBuiltin3(func(s, from, to string) (Datum, error) {
 		return NewDString(strings.Replace(s, from, to, -1)), nil
-	}, TypeString)},
+	}, TypeString, []string{"s", "from", "to"})},
 
 	"translate": {stringBuiltin3(func(s, from, to string) (Datum, error) {
 		const deletionRune = utf8.MaxRune + 1
@@ -365,7 +366,7 @@ var Builtins = map[string][]Builtin{
 			}
 		}
 		return NewDString(string(runes)), nil
-	}, TypeString)},
+	}, TypeString, []string{"s", "from", "to"})},
 
 	"regexp_extract": {
 		Builtin{
@@ -1196,13 +1197,18 @@ func stringBuiltin2(f func(string, string) (Datum, error), returnType Datum) Bui
 	}
 }
 
-func stringBuiltin3(f func(string, string, string) (Datum, error), returnType Datum) Builtin {
+func stringBuiltin3(
+	f func(string, string, string) (Datum, error),
+	returnType Datum,
+	names []string,
+) Builtin {
 	return Builtin{
 		Types:      ArgTypes{TypeString, TypeString, TypeString},
 		ReturnType: returnType,
 		fn: func(_ *EvalContext, args DTuple) (Datum, error) {
 			return f(string(*args[0].(*DString)), string(*args[1].(*DString)), string(*args[2].(*DString)))
 		},
+		ArgNames: names,
 	}
 }
 

--- a/sql/parser/overload.go
+++ b/sql/parser/overload.go
@@ -16,7 +16,10 @@
 
 package parser
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+)
 
 // overloadImpl is an implementation of an overloaded function. It provides
 // access to the parameter type list  and the return type of the implementation.
@@ -36,6 +39,8 @@ type typeList interface {
 	// getAt returns the type at the given index in the typeList, or nil if the typeList
 	// cannot have a parameter at index i.
 	getAt(i int) Datum
+
+	String(names []string) string // human readable signature, using `names`` if provided.
 }
 
 var _ typeList = ArgTypes{}
@@ -77,6 +82,24 @@ func (a ArgTypes) getAt(i int) Datum {
 	return a[i]
 }
 
+func (a ArgTypes) String(names []string) string {
+	var s bytes.Buffer
+	first := true
+	for i := range a {
+		if first {
+			first = false
+		} else {
+			s.WriteString(", ")
+		}
+		if len(names) > i {
+			s.WriteString(names[i])
+			s.WriteByte(' ')
+		}
+		s.WriteString(a[i].Type())
+	}
+	return s.String()
+}
+
 // AnyType is a typeList implementation that accepts any arguments.
 type AnyType struct{}
 
@@ -94,6 +117,13 @@ func (AnyType) matchLen(l int) bool {
 
 func (AnyType) getAt(i int) Datum {
 	panic("getAt called on AnyType")
+}
+
+func (AnyType) String(names []string) string {
+	if len(names) > 0 {
+		return fmt.Sprintf("%s *", names[0])
+	}
+	return "*"
 }
 
 // VariadicType is a typeList implementation which accepts any number of
@@ -122,6 +152,13 @@ func (v VariadicType) matchLen(l int) bool {
 
 func (v VariadicType) getAt(i int) Datum {
 	return v.Typ
+}
+
+func (v VariadicType) String(names []string) string {
+	if len(names) > 0 {
+		return fmt.Sprintf("%s %s...", names[0], v.Typ.Type())
+	}
+	return v.Typ.Type() + "..."
 }
 
 // SingleType is a typeList implementation which accepts a single
@@ -154,6 +191,13 @@ func (s SingleType) getAt(i int) Datum {
 		return nil
 	}
 	return s.Typ
+}
+
+func (s SingleType) String(names []string) string {
+	if len(names) > 0 {
+		return fmt.Sprintf("%s %s", names[0], s.Typ.Type())
+	}
+	return s.Typ.Type()
 }
 
 // typeCheckOverloadedExprs determines the correct overload to use for the given set of


### PR DESCRIPTION
Short-hand version, and named arguments in `replace`:

```
root@:26257> \? replace

*** String and Byte Functions ***

replace(s string, from string, to string) -> string

regexp_replace(string, string, string) -> string

regexp_replace(string, string, string, string) -> string

root@:26257>
```

the named arguments will also be good to use in the docs page generator.
a followup will add long-form description text to Builtin as well, which again, will also be useful in the docs generator.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8577)

<!-- Reviewable:end -->
