### PR TITLE
sql: clean up error messages in join checks

### DIFF
--- a/sql/data_source.go
+++ b/sql/data_source.go
@@ -330,7 +330,7 @@ func (src *dataSourceInfo) expandStar(
 	v parser.VarName, qvals qvalMap,
 ) (columns []ResultColumn, exprs []parser.TypedExpr, err error) {
 	if len(src.sourceColumns) == 0 {
-		return nil, nil, fmt.Errorf("cannot use \"%s\" without a FROM clause", v)
+		return nil, nil, fmt.Errorf("cannot use %q without a FROM clause", v)
 	}
 
 	colSel := func(idx int) {
@@ -402,7 +402,7 @@ func (p *planDataSource) findUnaliasedColumn(
 		col := planColumns[idx]
 		if sqlbase.ReNormalizeName(col.Name) == colName {
 			if colIdx != invalidColIdx {
-				return invalidColIdx, fmt.Errorf("column reference \"%s\" is ambiguous", parser.AsString(c))
+				return invalidColIdx, fmt.Errorf("column reference %q is ambiguous", c)
 			}
 			colIdx = idx
 		}

--- a/sql/table_join.go
+++ b/sql/table_join.go
@@ -331,7 +331,7 @@ func (p *planner) makeUsingPredicate(
 
 		// Check for USING(x,x)
 		if _, ok := seenNames[colName]; ok {
-			return nil, nil, fmt.Errorf("column \"%s\" appears more than once in USING clause", colName)
+			return nil, nil, fmt.Errorf("column %q appears more than once in USING clause", colName)
 		}
 		seenNames[colName] = struct{}{}
 
@@ -468,7 +468,11 @@ func (p *planner) makeJoin(
 	// Check that the same table name is not used on both sides.
 	for alias := range right.info.sourceAliases {
 		if _, ok := left.info.sourceAliases[alias]; ok {
-			return planDataSource{}, fmt.Errorf("table name \"%s\" specified more than once", alias)
+			t := alias.Table()
+			if t == "" {
+				return planDataSource{}, errors.New("cannot join columns from multiple anonymous sources (missing AS clause)")
+			}
+			return planDataSource{}, fmt.Errorf("cannot join columns from the same source name %q (missing AS clause)", t)
 		}
 	}
 

--- a/sql/testdata/join
+++ b/sql/testdata/join
@@ -317,10 +317,10 @@ x    x    x    y  y  y
 44   44   44   51 51 51
 42   42   42   53 53 53
 
-query error column.*in USING clause does not exist
+query error column "y" specified in USING clause does not exist
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(y))
 
-query error column.*appears more than once in USING clause
+query error column "x" appears more than once in USING clause
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(x, x))
 
 statement ok
@@ -329,14 +329,17 @@ CREATE TABLE othertype (x TEXT);
 query error JOIN/USING types.*cannot be matched
 SELECT * FROM (onecolumn AS a JOIN othertype AS b USING(x))
 
-query error table name.*specified more than once
+query error cannot join columns from the same source name "onecolumn"
 SELECT * FROM (onecolumn JOIN onecolumn USING(x))
 
-query error table name.*specified more than once
+query error cannot join columns from the same source name "onecolumn"
 SELECT * FROM (onecolumn JOIN twocolumn USING(x) JOIN onecolumn USING(x))
 
-query error column reference.*is ambiguous
+query error cannot join columns from multiple anonymous sources
+SELECT * FROM (SELECT * FROM onecolumn), (SELECT * FROM onecolumn)
+
+query error column reference "x" is ambiguous
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b ON x > 32)
 
-query error column name.*not found
+query error column name "a\.y" not found
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b ON a.y > y)


### PR DESCRIPTION
Prior to this patch a join on two anonymous sources would fail
with an ugly message:

```
pq: table name "{"" "" %!s(bool=false)}" specified more than once
```

This was not caught previously because the tests had a wildcard
pattern on the generated table name in the error message. This patch
addresses this and a couple related error messages.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8580)

<!-- Reviewable:end -->
