### PR TITLE
storage: make Raft group creation really lazy

### DIFF
--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -140,6 +140,12 @@ func (s *Store) SetReplicaScannerActive(active bool) {
 	s.setScannerActive(active)
 }
 
+// EnqueueRaftUpdateCheck enqueues the replica for a Raft update check, forcing
+// the replica's Raft group into existence.
+func (s *Store) EnqueueRaftUpdateCheck(rangeID roachpb.RangeID) {
+	s.enqueueRaftUpdateCheck(rangeID)
+}
+
 // GetLastIndex is the same function as LastIndex but it does not require
 // that the replica lock is held.
 func (r *Replica) GetLastIndex() (uint64, error) {

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -6111,7 +6111,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		ticks := r.mu.ticks
 		r.mu.Unlock()
 		for ; (ticks % electionTicks) != 0; ticks++ {
-			if err := r.tick(); err != nil {
+			if _, err := r.tick(); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -6141,7 +6141,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		r.mu.Unlock()
 
 		// Tick raft.
-		if err := r.tick(); err != nil {
+		if _, err := r.tick(); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
At startup a store loops over all of the local range descriptors and
creates replicas. These replicas would then be "ticked" by the process
raft goroutine. We attempted to have the raft group lazily created by
making Replica.tick() a no-op if there wasn't a Raft group. But
immediately after the ticking we would add the replica to the set of
pending replicas and on the next iteration would call
Replica.handleRaftReady() which would then create the Raft group.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8592)

<!-- Reviewable:end -->
