### PR TITLE
sql: rewrite backup/restore test and bench

### DIFF
--- a/sql/backup_test.go
+++ b/sql/backup_test.go
@@ -19,7 +19,6 @@ package sql_test
 
 import (
 	"bytes"
-	gosql "database/sql"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -29,71 +28,161 @@ import (
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/internal/client"
+	"github.com/cockroachdb/cockroach/keys"
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/sql"
-	"github.com/cockroachdb/cockroach/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/caller"
 	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/randutil"
+	"github.com/cockroachdb/cockroach/util/tracing"
 )
 
-func setupBackupRestoreDB(t testing.TB, count int) (func(), *gosql.DB, *client.DB, string) {
-	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+const (
+	backupRestoreDefaultRanges  = 10
+	backupRestoreRowPayloadSize = 100
+)
 
-	dir, err := ioutil.TempDir("", "TestBackupRestore")
+func testingTempDir(t testing.TB, depth int) (string, func()) {
+	_, _, name := caller.Lookup(depth)
+	dir, err := ioutil.TempDir("", name)
 	if err != nil {
-		s.Stopper().Stop()
 		t.Fatal(err)
 	}
-	if err := os.RemoveAll(dir); err != nil {
-		s.Stopper().Stop()
-		t.Fatal(err)
-	}
-
-	if _, err := sqlDB.Exec(`CREATE DATABASE d`); err != nil {
-		s.Stopper().Stop()
-		t.Fatal(err)
-	}
-	if _, err := sqlDB.Exec(`CREATE TABLE d.foo (a INT PRIMARY KEY, b STRING, c DECIMAL)`); err != nil {
-		s.Stopper().Stop()
-		t.Fatal(err)
-	}
-	var insert bytes.Buffer
-	insert.WriteString(`INSERT INTO d.foo VALUES `)
-	for i := 0; i < count; i++ {
-		if i != 0 {
-			insert.WriteRune(',')
-		}
-		fmt.Fprintf(&insert, `(%d, '%d', %d)`, i, i, i)
-	}
-	if _, err := sqlDB.Exec(insert.String()); err != nil {
-		s.Stopper().Stop()
-		t.Fatal(err)
-	}
-
-	cleanupFn := func() {
-		s.Stopper().Stop()
+	cleanup := func() {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Error(err)
 		}
 	}
-	return cleanupFn, sqlDB, kvDB, dir
+	return dir, cleanup
 }
 
-func TestBackupRestore(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+// setupBackupRestoreDB creates a table and inserts `count` rows. It then splits
+// the kv ranges for the table as evenly as possible into `rangeCount` ranges.
+func setupBackupRestoreDB(
+	t testing.TB,
+	ctx context.Context,
+	tc *testcluster.TestCluster,
+	count int,
+	rangeCount int,
+) []*roachpb.RangeDescriptor {
+	rng, _ := randutil.NewPseudoRand()
 
-	count := 1000
-	cleanupFn, sqlDB, kvDB, dir := setupBackupRestoreDB(t, count)
+	sqlDB := tc.Conns[0]
+	kvDB := tc.Server(0).KVClient().(*client.DB)
+	if _, err := sqlDB.Exec(`CREATE DATABASE bench`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.Exec(`CREATE TABLE bench.bank (
+		id INT PRIMARY KEY,
+		balance INT,
+		payload STRING,
+		FAMILY (id, balance, payload)
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	var insert bytes.Buffer
+	for i := 0; i < count; i += 1000 {
+		insert.Reset()
+		insert.WriteString(`INSERT INTO bench.bank VALUES `)
+		for j := i; j < i+1000 && j < count; j++ {
+			if j != i {
+				insert.WriteRune(',')
+			}
+			payload := randutil.RandBytes(rng, backupRestoreRowPayloadSize)
+			fmt.Fprintf(&insert, `(%d, %d, '%s')`, j, 0, payload)
+		}
+		if _, err := sqlDB.Exec(insert.String()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if rangeCount > count {
+		t.Fatalf("cannot create %d ranges out of %d rows", rangeCount, count)
+	}
+
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "bench", "bank")
+	tablePrimaryKeyPrefix := sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+	tableColMap := map[sqlbase.ColumnID]int{tableDesc.Columns[0].ID: 0}
+	row := make([]parser.Datum, 1)
+	ranges := make([]*roachpb.RangeDescriptor, rangeCount)
+	for i, incr := 1, count/rangeCount; i < rangeCount; i++ {
+		row[0] = parser.NewDInt(parser.DInt(i * incr))
+		splitKey, _, err := sqlbase.EncodeIndexKey(
+			tableDesc, &tableDesc.PrimaryIndex, tableColMap, row, tablePrimaryKeyPrefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		splitKey = keys.MakeRowSentinelKey(splitKey)
+		util.SucceedsSoon(t, func() error {
+			log.Infof(ctx, "splitting at %x %s", splitKey, roachpb.Key(splitKey))
+			ranges[i-1], ranges[i], err = tc.SplitRange(splitKey)
+			if err != nil {
+				log.Infof(ctx, "error splitting: %s", err)
+			}
+			return err
+		})
+	}
+	return ranges
+}
+
+func setupReplicationAndLeases(
+	t testing.TB,
+	tc *testcluster.TestCluster,
+	ranges []*roachpb.RangeDescriptor,
+	clusterSize int,
+) {
+	targets := make([]testcluster.ReplicationTarget, clusterSize-1)
+	for i := 1; i < clusterSize; i++ {
+		targets[i-1] = tc.Target(i)
+	}
+
+	for _, r := range ranges {
+		if _, err := tc.AddReplicas(r.StartKey.AsRawKey(), targets...); err != nil {
+			t.Fatal(err)
+		}
+		if err := tc.TransferRangeLease(r, tc.Target(int(r.RangeID)%clusterSize)); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestClusterBackupRestore(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	// TODO(dan): Increase this clusterSize to 3. It works if the test timeout
+	// is raised and with a util.SucceedsSoon wrapped around Backup, Restore,
+	// and every sql Exec, but it seems like we should be fixing the underlying
+	// issues.
+	const clusterSize = 1
+	const count = 1000
+
+	tc := testcluster.StartTestCluster(t, clusterSize, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationAuto,
+	})
+	defer tc.Stopper().Stop()
+	sqlDB := tc.Conns[0]
+	kvDB := tc.Server(0).KVClient().(*client.DB)
+
+	_ = setupBackupRestoreDB(t, ctx, tc, count, backupRestoreDefaultRanges)
+	dir, cleanupFn := testingTempDir(t, 2)
 	defer cleanupFn()
 
 	if _, err := sql.Backup(context.Background(), *kvDB, dir); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := sqlDB.Exec(`TRUNCATE d.foo`); err != nil {
+	if _, err := sqlDB.Exec(`TRUNCATE bench.bank`); err != nil {
 		t.Fatal(err)
 	}
 
 	var rowCount int
-	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM d.foo`).Scan(&rowCount); err != nil {
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM bench.bank`).Scan(&rowCount); err != nil {
 		t.Fatal(err)
 	}
 
@@ -102,11 +191,11 @@ func TestBackupRestore(t *testing.T) {
 	}
 
 	// TODO(dan): Shut down the cluster and restore into a fresh one.
-	if err := sql.Restore(context.Background(), *kvDB, dir, "foo", true); err != nil {
+	if err := sql.Restore(ctx, *kvDB, dir, "bank", true); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM d.foo`).Scan(&rowCount); err != nil {
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM bench.bank`).Scan(&rowCount); err != nil {
 		t.Fatal(err)
 	}
 
@@ -115,46 +204,66 @@ func TestBackupRestore(t *testing.T) {
 	}
 }
 
-func runBenchmarkBackup(b *testing.B, count int) {
-	cleanupFn, _, kvDB, dir := setupBackupRestoreDB(b, count)
+// TODO(dan): count=10000 has some issues replicating. Investigate.
+func BenchmarkClusterBackup_10(b *testing.B)   { runBenchmarkClusterBackup(b, 3, 10) }
+func BenchmarkClusterBackup_100(b *testing.B)  { runBenchmarkClusterBackup(b, 3, 100) }
+func BenchmarkClusterBackup_1000(b *testing.B) { runBenchmarkClusterBackup(b, 3, 1000) }
+func runBenchmarkClusterBackup(b *testing.B, clusterSize int, count int) {
+	defer tracing.Disable()()
+	ctx := context.Background()
+
+	tc := testcluster.StartTestCluster(b, clusterSize, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop()
+	kvDB := tc.Server(0).KVClient().(*client.DB)
+
+	ranges := setupBackupRestoreDB(b, ctx, tc, count, backupRestoreDefaultRanges)
+	setupReplicationAndLeases(b, tc, ranges, clusterSize)
+
+	dir, cleanupFn := testingTempDir(b, 2)
 	defer cleanupFn()
 
+	// TODO(dan): Return the actual sizes from Backup.
+	b.SetBytes(int64(count) * backupRestoreRowPayloadSize)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		if err := os.RemoveAll(dir); err != nil {
-			b.Fatal(err)
-		}
-		b.StartTimer()
-		if _, err := sql.Backup(context.Background(), *kvDB, dir); err != nil {
+		if _, err := sql.Backup(ctx, *kvDB, dir); err != nil {
 			b.Fatal(err)
 		}
 	}
 }
 
-func BenchmarkBackup_1(b *testing.B)    { runBenchmarkBackup(b, 1) }
-func BenchmarkBackup_1000(b *testing.B) { runBenchmarkBackup(b, 1000) }
+func BenchmarkClusterRestore_10(b *testing.B)    { runBenchmarkClusterRestore(b, 3, 10) }
+func BenchmarkClusterRestore_100(b *testing.B)   { runBenchmarkClusterRestore(b, 3, 100) }
+func BenchmarkClusterRestore_1000(b *testing.B)  { runBenchmarkClusterRestore(b, 3, 1000) }
+func BenchmarkClusterRestore_10000(b *testing.B) { runBenchmarkClusterRestore(b, 3, 10000) }
+func runBenchmarkClusterRestore(b *testing.B, clusterSize int, count int) {
+	defer tracing.Disable()()
+	ctx := context.Background()
 
-func runBenchmarkRestore(b *testing.B, count int) {
-	cleanupFn, sqlDB, kvDB, dir := setupBackupRestoreDB(b, count)
+	tc := testcluster.StartTestCluster(b, clusterSize, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop()
+	kvDB := tc.Server(0).KVClient().(*client.DB)
+
+	ranges := setupBackupRestoreDB(b, ctx, tc, count, backupRestoreDefaultRanges)
+
+	dir, cleanupFn := testingTempDir(b, 1)
 	defer cleanupFn()
 
-	if _, err := sql.Backup(context.Background(), *kvDB, dir); err != nil {
+	if _, err := sql.Backup(ctx, *kvDB, dir); err != nil {
 		b.Fatal(err)
 	}
 
+	setupReplicationAndLeases(b, tc, ranges, clusterSize)
+
+	b.SetBytes(int64(count) * backupRestoreRowPayloadSize)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		if _, err := sqlDB.Exec(`TRUNCATE d.foo`); err != nil {
-			b.Fatal(err)
-		}
-		b.StartTimer()
-		if err := sql.Restore(context.Background(), *kvDB, dir, "foo", true); err != nil {
+		if err := sql.Restore(ctx, *kvDB, dir, "bank", true); err != nil {
 			b.Fatal(err)
 		}
 	}
 }
-
-func BenchmarkRestore_1(b *testing.B)    { runBenchmarkRestore(b, 1) }
-func BenchmarkRestore_1000(b *testing.B) { runBenchmarkRestore(b, 1000) }


### PR DESCRIPTION
Use testcluster everywhere and do replication and leaseholder selection manually
for greater control. Also create a specific number of splits in the data so we
can see the effects of parallelism.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8597)

<!-- Reviewable:end -->
