### PR TITLE
storage: fix excessive time spent raft logging

### DIFF
--- a/storage/raft.go
+++ b/storage/raft.go
@@ -23,9 +23,12 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/security"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/coreos/etcd/raft"
+	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/gogo/protobuf/proto"
 )
 
 // init installs an adapter to use clog for log messages from raft which
@@ -136,14 +139,71 @@ func logRaftReady(ctx context.Context, prefix fmt.Stringer, ready raft.Ready) {
 				i, raft.DescribeEntry(e, raftEntryFormatter))
 		}
 		if !raft.IsEmptySnap(ready.Snapshot) {
-			fmt.Fprintf(&buf, "  Snapshot updated: %.200s\n", ready.Snapshot.String())
+			snap := ready.Snapshot
+			snap.Data = nil
+			fmt.Fprintf(&buf, "  Snapshot updated: %v\n", snap)
 		}
 		for i, m := range ready.Messages {
 			fmt.Fprintf(&buf, "  Outgoing Message[%d]: %.200s\n",
-				i, raft.DescribeMessage(m, raftEntryFormatter))
+				i, raftDescribeMessage(m, raftEntryFormatter))
 		}
 		log.Infof(ctx, "%s raft ready\n%s", prefix, buf.String())
 	}
+}
+
+// This is a fork of raft.DescribeMessage with a tweak to avoid logging
+// snapshot data.
+func raftDescribeMessage(m raftpb.Message, f raft.EntryFormatter) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%x->%x %v Term:%d Log:%d/%d", m.From, m.To, m.Type, m.Term, m.LogTerm, m.Index)
+	if m.Reject {
+		fmt.Fprintf(&buf, " Rejected")
+		if m.RejectHint != 0 {
+			fmt.Fprintf(&buf, "(Hint:%d)", m.RejectHint)
+		}
+	}
+	if m.Commit != 0 {
+		fmt.Fprintf(&buf, " Commit:%d", m.Commit)
+	}
+	if len(m.Entries) > 0 {
+		fmt.Fprintf(&buf, " Entries:[")
+		for i, e := range m.Entries {
+			if i != 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(raft.DescribeEntry(e, f))
+		}
+		fmt.Fprintf(&buf, "]")
+	}
+	if !raft.IsEmptySnap(m.Snapshot) {
+		snap := m.Snapshot
+		snap.Data = nil
+		fmt.Fprintf(&buf, " Snapshot:%v", snap)
+	}
+	return buf.String()
+}
+
+func raftEntryFormatter(data []byte) string {
+	if len(data) == 0 {
+		return "[empty]"
+	}
+	if len(data) >= 1024 {
+		// Don't try to unmarshal and stringify the command if it is large. Doing
+		// so is super expensive (multiple seconds for the call to String()) for
+		// large snapshot entries.
+		return fmt.Sprintf("[%d]", len(data))
+	}
+	_, encodedCmd := DecodeRaftCommand(data)
+	var cmd roachpb.RaftCommand
+	if err := proto.Unmarshal(encodedCmd, &cmd); err != nil {
+		return fmt.Sprintf("[error parsing entry: %s]", err)
+	}
+	s := cmd.Cmd.String()
+	maxLen := 300
+	if len(s) > maxLen {
+		s = s[:maxLen]
+	}
+	return s
 }
 
 var _ security.RequestWithUser = &RaftMessageRequest{}

--- a/storage/store.go
+++ b/storage/store.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
-	"github.com/gogo/protobuf/proto"
 	"github.com/google/btree"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -2434,6 +2433,7 @@ func (s *Store) processRaft() {
 		}()
 
 		var pendingReplicas []roachpb.RangeID
+		var warnDuration = 10 * s.ctx.RaftTickInterval
 
 		for {
 			workingStart := timeutil.Now()
@@ -2495,6 +2495,13 @@ func (s *Store) processRaft() {
 			s.processRaftMu.Unlock()
 			s.metrics.RaftWorkingDurationNanos.Inc(timeutil.Since(workingStart).Nanoseconds())
 
+			// If Raft ready processing took longer than a second something bad is
+			// going on. Such long processing time means we'll have starved local
+			// replicas of ticks and remote replicas will likely start campaigning.
+			if elapsed := timeutil.Since(workingStart); elapsed >= warnDuration {
+				log.Warningf(context.TODO(), "%s: raft ready processing: %.1fs", s, elapsed.Seconds())
+			}
+
 			selectStart := timeutil.Now()
 
 			select {
@@ -2537,6 +2544,13 @@ func (s *Store) processRaft() {
 				s.pendingRaftGroups.Unlock()
 				s.processRaftMu.Unlock()
 				s.metrics.RaftTickingDurationNanos.Inc(timeutil.Since(tickerStart).Nanoseconds())
+
+				// If Raft ticking took longer than a second something bad is going
+				// on. Such long processing time means we'll have starved local
+				// replicas of ticks and remote replicas will likely start campaigning.
+				if elapsed := timeutil.Since(tickerStart); elapsed >= warnDuration {
+					log.Warningf(context.TODO(), "%s: raft ticking: %.1fs", s, elapsed.Seconds())
+				}
 
 			case <-s.stopper.ShouldStop():
 				s.metrics.RaftSelectDurationNanos.Inc(timeutil.Since(selectStart).Nanoseconds())
@@ -2635,23 +2649,6 @@ func (s *Store) canApplySnapshotLocked(rangeID roachpb.RangeID, snap raftpb.Snap
 		rangeDesc: parsedSnap.RangeDescriptor,
 	}
 	return placeholder, nil
-}
-
-func raftEntryFormatter(data []byte) string {
-	if len(data) == 0 {
-		return "[empty]"
-	}
-	_, encodedCmd := DecodeRaftCommand(data)
-	var cmd roachpb.RaftCommand
-	if err := proto.Unmarshal(encodedCmd, &cmd); err != nil {
-		return fmt.Sprintf("[error parsing entry: %s]", err)
-	}
-	s := cmd.Cmd.String()
-	maxLen := 300
-	if len(s) > maxLen {
-		s = s[:maxLen]
-	}
-	return s
 }
 
 // computeReplicationStatus counts a number of simple replication statistics for


### PR DESCRIPTION
Raft ready logging (enabled via -vmodule=raft=5) is extraordinarily
expensive when logging a large snapshot. In particular, if an outgoing
message contained a snapshot or raft.Ready.Snapshot was non-empty we
would see multiple seconds being spent formatting the log message only
for most of it to be thrown away. These delays horked up the raft
processing goroutine

Added warning logs when raft ready processing and raft ticking take
longer than a second. When that happens something bad is usually going
on elsehwere.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8612)

<!-- Reviewable:end -->
