### PR TITLE
docs: small getting-started docs improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,9 @@
 3.  Run `make build`, `make test`, or anything else our Makefile offers. Note
 that at least 4GB of RAM is required to build from source and run tests. Also,
 the first time you run `make`, it can take some time to download and install
-various dependencies.
+various dependencies. After running `make build`, the `cockroach` executable
+will be in your current directory and can be run as shown in the
+[README](README.md).
 
 Note that if you edit a `.proto` or `.ts` file, you will need to manually
 regenerate the associated `.pb.{go,cc,h}` or `.js` files using `go generate

--- a/docs/design.md
+++ b/docs/design.md
@@ -405,7 +405,7 @@ Please see [roachpb/data.proto](https://github.com/cockroachdb/cockroach/blob/ma
 **Cons**
 
 - Reads from non-lease holder replicas still require a ping to the lease holder
-  update *read timestamp cache*.
+  to update the *read timestamp cache*.
 - Abandoned transactions may block contending writers for up to the
   heartbeat interval, though average wait is likely to be
   considerably shorter (see [graph in link](https://docs.google.com/document/d/1kBCu4sdGAnvLqpT-_2vaTbomNmX3_saayWEGYu1j7mQ/edit?usp=sharing)).

--- a/util/metric/doc.go
+++ b/util/metric/doc.go
@@ -74,7 +74,7 @@ Additionally, you can manually verify that your metric is updating by using the
 metrics endpoint.  For example, if you're running the Cockroach DB server with
 the "--insecure" flag, you can use access the endpoint as follows:
 
-	$ curl http://localhost:26257/_status/metrics/1
+	$ curl http://localhost:8080/_status/nodes/1
 
 	(some other output)
 	"cr.node.sql.select.count.1": 5,


### PR DESCRIPTION
- Clarify in CONTRIBUTING.md how to start the binary
- Fix path used to view metrics on a running server
- Fix minor grammatical error in design doc

@cuongdo

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8614)

<!-- Reviewable:end -->
