### PR TITLE
kv/storage: plumb contexts to DistSender, Node, Store, TxnCoordSender

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -83,7 +83,11 @@ func (n noNodeAddrsAvailError) Error() string {
 // ranges. RPCs are sent to one or more of the replicas to satisfy
 // the method invocation.
 type DistSender struct {
-	opentracing.Tracer
+	// Ctx is the "base context" for DistSender, used for log messages that are
+	// not associated with a more specific request context. It also holds the
+	// Tracer that should be used.
+	Ctx context.Context
+
 	// nodeDescriptor, if set, holds the descriptor of the node the
 	// DistSender lives on. It should be accessed via getNodeDescriptor(),
 	// which tries to obtain the value from the Gossip network if the
@@ -116,6 +120,10 @@ type rpcSendFn func(SendOptions, ReplicaSlice,
 // DistSenderConfig holds configuration and auxiliary objects that can be passed
 // to NewDistSender.
 type DistSenderConfig struct {
+	// Base context for the DistSender. The context can have a Tracer set. If nil,
+	// context.Background() will be used.
+	Ctx context.Context
+
 	Clock                    *hlc.Clock
 	RangeDescriptorCacheSize int32
 	// RangeLookupMaxRanges sets how many ranges will be prefetched into the
@@ -132,7 +140,6 @@ type DistSenderConfig struct {
 	TransportFactory  TransportFactory
 	RPCContext        *rpc.Context
 	RangeDescriptorDB RangeDescriptorDB
-	Tracer            opentracing.Tracer
 	SendNextTimeout   time.Duration
 }
 
@@ -144,14 +151,27 @@ func NewDistSender(cfg *DistSenderConfig, g *gossip.Gossip) *DistSender {
 	if cfg == nil {
 		cfg = &DistSenderConfig{}
 	}
-	clock := cfg.Clock
-	if clock == nil {
-		clock = hlc.NewClock(hlc.UnixNano)
+
+	ds := &DistSender{gossip: g}
+
+	ds.Ctx = cfg.Ctx
+	if ds.Ctx == nil {
+		ds.Ctx = context.Background()
 	}
-	ds := &DistSender{
-		clock:  clock,
-		gossip: g,
+
+	if ds.Ctx.Done() != nil {
+		panic("context with cancel or deadline")
 	}
+
+	if tracing.TracerFromCtx(ds.Ctx) == nil {
+		ds.Ctx = tracing.WithTracer(ds.Ctx, tracing.NewTracer())
+	}
+
+	ds.clock = cfg.Clock
+	if ds.clock == nil {
+		ds.clock = hlc.NewClock(hlc.UnixNano)
+	}
+
 	if cfg.nodeDescriptor != nil {
 		atomic.StorePointer(&ds.nodeDescriptor, unsafe.Pointer(cfg.nodeDescriptor))
 	}
@@ -185,11 +205,6 @@ func NewDistSender(cfg *DistSenderConfig, g *gossip.Gossip) *DistSender {
 			ds.rpcRetryOptions.Closer = ds.rpcContext.Stopper.ShouldQuiesce()
 		}
 	}
-	if cfg.Tracer != nil {
-		ds.Tracer = cfg.Tracer
-	} else {
-		ds.Tracer = tracing.NewTracer()
-	}
 	if cfg.SendNextTimeout != 0 {
 		ds.sendNextTimeout = cfg.SendNextTimeout
 	} else {
@@ -199,19 +214,18 @@ func NewDistSender(cfg *DistSenderConfig, g *gossip.Gossip) *DistSender {
 	if g != nil {
 		g.RegisterCallback(gossip.KeyFirstRangeDescriptor,
 			func(_ string, value roachpb.Value) {
-				ctx := context.Background()
 				if log.V(1) {
 					var desc roachpb.RangeDescriptor
 					if err := value.GetProto(&desc); err != nil {
-						log.Errorf(ctx, "unable to parse gossipped first range descriptor: %s", err)
+						log.Errorf(ds.Ctx, "unable to parse gossipped first range descriptor: %s", err)
 					} else {
-						log.Infof(ctx,
+						log.Infof(ds.Ctx,
 							"gossipped first range descriptor: %+v", desc.Replicas)
 					}
 				}
 				err := ds.rangeCache.EvictCachedRangeDescriptor(roachpb.RKeyMin, nil, false)
 				if err != nil {
-					log.Warningf(ctx, "failed to evict first range descriptor: %s", err)
+					log.Warningf(ds.Ctx, "failed to evict first range descriptor: %s", err)
 				}
 			})
 	}
@@ -325,7 +339,7 @@ func (ds *DistSender) getNodeDescriptor() *roachpb.NodeDescriptor {
 			return nodeDesc
 		}
 	}
-	log.Infof(context.TODO(), "unable to determine this node's attributes for replica "+
+	log.Infof(ds.Ctx, "unable to determine this node's attributes for replica "+
 		"selection; node is most likely bootstrapping")
 	return nil
 }
@@ -630,7 +644,9 @@ func (ds *DistSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error, bool) {
 	isReverse := ba.IsReverse()
 
-	ctx, cleanup := tracing.EnsureContext(ctx, ds.Tracer)
+	// TODO(radu): when contexts are properly plumbed, we should be able to get
+	// the tracer from ctx, not from the DistSender.
+	ctx, cleanup := tracing.EnsureContext(ctx, tracing.TracerFromCtx(ds.Ctx))
 	defer cleanup()
 
 	// The minimal key range encompassing all requests contained within.
@@ -1013,9 +1029,9 @@ func (ds *DistSender) sendToReplicas(opts SendOptions,
 			err := call.Err
 			if err == nil {
 				if log.V(2) {
-					log.Infof(context.TODO(), "RPC reply: %+v", call.Reply)
+					log.Infof(opts.Context, "RPC reply: %+v", call.Reply)
 				} else if log.V(1) && call.Reply.Error != nil {
-					log.Infof(context.TODO(), "application error: %s", call.Reply.Error)
+					log.Infof(opts.Context, "application error: %s", call.Reply.Error)
 				}
 
 				if !ds.handlePerReplicaError(rangeID, call.Reply.Error) {
@@ -1031,7 +1047,7 @@ func (ds *DistSender) sendToReplicas(opts SendOptions,
 				// information than a RangeNotFound).
 				err = call.Reply.Error.GoError()
 			} else if log.V(1) {
-				log.Warningf(context.TODO(), "RPC error: %s", err)
+				log.Warningf(opts.Context, "RPC error: %s", err)
 			}
 
 			// Send to additional replicas if available.
@@ -1081,12 +1097,12 @@ func (ds *DistSender) updateLeaseHolderCache(
 	if log.V(1) {
 		if oldLeaseHolder, ok := ds.leaseHolderCache.Lookup(rangeID); ok {
 			if (newLeaseHolder == roachpb.ReplicaDescriptor{}) {
-				log.Infof(context.TODO(), "range %d: evicting cached lease holder %+v", rangeID, oldLeaseHolder)
+				log.Infof(ds.Ctx, "range %d: evicting cached lease holder %+v", rangeID, oldLeaseHolder)
 			} else if newLeaseHolder != oldLeaseHolder {
-				log.Infof(context.TODO(), "range %d: replacing cached lease holder %+v with %+v", rangeID, oldLeaseHolder, newLeaseHolder)
+				log.Infof(ds.Ctx, "range %d: replacing cached lease holder %+v with %+v", rangeID, oldLeaseHolder, newLeaseHolder)
 			}
 		} else {
-			log.Infof(context.TODO(), "range %d: caching new lease holder %+v", rangeID, newLeaseHolder)
+			log.Infof(ds.Ctx, "range %d: caching new lease holder %+v", rangeID, newLeaseHolder)
 		}
 	}
 	ds.leaseHolderCache.Update(rangeID, newLeaseHolder)

--- a/kv/local_test_cluster_util.go
+++ b/kv/local_test_cluster_util.go
@@ -19,6 +19,8 @@ package kv
 import (
 	"time"
 
+	"golang.org/x/net/context"
+
 	opentracing "github.com/opentracing/opentracing-go"
 
 	"github.com/cockroachdb/cockroach/base"
@@ -28,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/rpc"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/util/tracing"
 )
 
 // localTestClusterTransport augments senderTransport with an optional
@@ -81,6 +84,7 @@ func InitSenderForLocalTestCluster(
 		RangeDescriptorDB: stores.(RangeDescriptorDB), // for descriptor lookup
 	}, gossip)
 
-	return NewTxnCoordSender(distSender, clock, false /* !linearizable */, tracer,
+	ctx := tracing.WithTracer(context.Background(), tracer)
+	return NewTxnCoordSender(ctx, distSender, clock, false, /* !linearizable */
 		stopper, MakeTxnMetrics())
 }

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -81,7 +81,8 @@ func TestInvalidAddrLength(t *testing.T) {
 	// The provided replicas is nil, so its length will be always less than the
 	// specified response number
 	opts := SendOptions{Context: context.Background()}
-	ret, err := (&DistSender{}).sendToReplicas(opts, 0, nil, roachpb.BatchRequest{}, nil)
+	ds := &DistSender{Ctx: context.Background()}
+	ret, err := ds.sendToReplicas(opts, 0, nil, roachpb.BatchRequest{}, nil)
 
 	// the expected return is nil and SendError
 	if _, ok := err.(*roachpb.SendError); !ok || ret != nil {
@@ -683,5 +684,6 @@ func makeReplicas(addrs ...net.Addr) ReplicaSlice {
 
 // sendBatch sends Batch requests to specified addresses using send.
 func sendBatch(opts SendOptions, addrs []net.Addr, rpcContext *rpc.Context) (*roachpb.BatchResponse, error) {
-	return (&DistSender{}).sendToReplicas(opts, 0, makeReplicas(addrs...), roachpb.BatchRequest{}, rpcContext)
+	ds := &DistSender{Ctx: context.Background()}
+	return ds.sendToReplicas(opts, 0, makeReplicas(addrs...), roachpb.BatchRequest{}, rpcContext)
 }

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -145,6 +145,7 @@ func MakeTxnMetrics() TxnMetrics {
 // transaction. When the transaction is committed or aborted, it
 // clears accumulated write intents for the transaction.
 type TxnCoordSender struct {
+	ctx               context.Context
 	wrapped           client.Sender
 	clock             *hlc.Clock
 	heartbeatInterval time.Duration
@@ -152,7 +153,6 @@ type TxnCoordSender struct {
 	syncutil.Mutex                               // protects txns and txnStats
 	txns              map[uuid.UUID]*txnMetadata // txn key to metadata
 	linearizable      bool                       // enables linearizable behaviour
-	tracer            opentracing.Tracer
 	stopper           *stop.Stopper
 	metrics           TxnMetrics
 }
@@ -161,25 +161,30 @@ var _ client.Sender = &TxnCoordSender{}
 
 // NewTxnCoordSender creates a new TxnCoordSender for use from a KV
 // distributed DB instance.
+// ctx is the base context and is used for logs and traces when there isn't a
+// more specific context available; it must have a Tracer set.
 func NewTxnCoordSender(
+	ctx context.Context,
 	wrapped client.Sender,
 	clock *hlc.Clock,
 	linearizable bool,
-	tracer opentracing.Tracer,
 	stopper *stop.Stopper,
 	txnMetrics TxnMetrics,
 ) *TxnCoordSender {
-	if tracer == nil {
-		panic("nil tracer supplied")
+	if ctx == nil || tracing.TracerFromCtx(ctx) == nil {
+		panic("ctx with tracer must be supplied")
+	}
+	if ctx.Done() != nil {
+		panic("context with cancel or deadline")
 	}
 	tc := &TxnCoordSender{
+		ctx:               ctx,
 		wrapped:           wrapped,
 		clock:             clock,
 		heartbeatInterval: base.DefaultHeartbeatInterval,
 		clientTimeout:     defaultClientTimeout,
 		txns:              map[uuid.UUID]*txnMetadata{},
 		linearizable:      linearizable,
-		tracer:            tracer,
 		stopper:           stopper,
 		metrics:           txnMetrics,
 	}
@@ -235,7 +240,7 @@ func (tc *TxnCoordSender) startStats() {
 			rMax := restarts.Max()
 			num := durations.TotalCount()
 
-			log.Infof(context.TODO(),
+			log.Infof(tc.ctx,
 				"txn coordinator: %.2f txn/sec, %.2f/%.2f/%.2f/%.2f %%cmmt/cmmt1pc/abrt/abnd, %s/%s/%s avg/σ/max duration, %.1f/%.1f/%d avg/σ/max restarts (%d samples)",
 				totalRate, pCommitted, pCommitted1PC, pAborted, pAbandoned,
 				util.TruncateDuration(time.Duration(dMean), res),
@@ -265,8 +270,11 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 		// header for use by RPC recipients. From here on, there's always an active
 		// Trace, though its overhead is small unless it's sampled.
 		sp := opentracing.SpanFromContext(ctx)
+		// TODO(radu): once contexts are plumbed correctly, we should use the Tracer
+		// from ctx.
+		tracer := tracing.TracerFromCtx(tc.ctx)
 		if sp == nil {
-			sp = tc.tracer.StartSpan(opTxnCoordSender)
+			sp = tracer.StartSpan(opTxnCoordSender)
 			defer sp.Finish()
 			ctx = opentracing.ContextWithSpan(ctx, sp)
 		}
@@ -279,7 +287,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 		if ba.Header.Trace == nil {
 			ba.Header.Trace = &tracing.Span{}
 		}
-		if err := tc.tracer.Inject(sp.Context(), basictracer.Delegator, ba.Trace); err != nil {
+		if err := tracer.Inject(sp.Context(), basictracer.Delegator, ba.Trace); err != nil {
 			return nil, roachpb.NewError(err)
 		}
 	}
@@ -582,7 +590,7 @@ func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context, txnID uuid.UUID) {
 	var closer <-chan struct{}
 	// TODO(tschottdorf): this should join to the trace of the request
 	// which starts this goroutine.
-	sp := tc.tracer.StartSpan(opHeartbeatLoop)
+	sp := tracing.TracerFromCtx(tc.ctx).StartSpan(opHeartbeatLoop)
 	defer sp.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, sp)
 
@@ -659,11 +667,11 @@ func (tc *TxnCoordSender) tryAsyncAbort(txnID uuid.UUID) {
 		// before the goroutine.
 		if _, pErr := tc.wrapped.Send(context.Background(), ba); pErr != nil {
 			if log.V(1) {
-				log.Warningf(context.TODO(), "abort due to inactivity failed for %s: %s ", txn, pErr)
+				log.Warningf(tc.ctx, "abort due to inactivity failed for %s: %s ", txn, pErr)
 			}
 		}
 	}); err != nil {
-		log.Warning(context.TODO(), err)
+		log.Warning(tc.ctx, err)
 	}
 }
 
@@ -924,7 +932,7 @@ func (tc *TxnCoordSender) updateState(
 func (tc *TxnCoordSender) resendWithTxn(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 	// Run a one-off transaction with that single command.
 	if log.V(1) {
-		log.Infof(context.TODO(), "%s: auto-wrapping in txn and re-executing: ", ba)
+		log.Infof(tc.ctx, "%s: auto-wrapping in txn and re-executing: ", ba)
 	}
 	// TODO(bdarnell): need to be able to pass other parts of DBContext
 	// through here.

--- a/server/node.go
+++ b/server/node.go
@@ -193,7 +193,7 @@ func bootstrapCluster(engines []engine.Engine, txnMetrics kv.TxnMetrics) (uuid.U
 	ctx.Ctx = tracing.WithTracer(context.Background(), tracer)
 	// Create a KV DB with a local sender.
 	stores := storage.NewStores(ctx.Clock)
-	sender := kv.NewTxnCoordSender(stores, ctx.Clock, false, tracer, stopper, txnMetrics)
+	sender := kv.NewTxnCoordSender(ctx.Ctx, stores, ctx.Clock, false, stopper, txnMetrics)
 	ctx.DB = client.NewDB(sender)
 	ctx.Transport = storage.NewDummyRaftTransport()
 	for i, eng := range engines {

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -95,10 +95,9 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 		RPCContext:      nodeRPCContext,
 		RPCRetryOptions: &retryOpts,
 	}, g)
-	tracer := tracing.NewTracer()
-	sender := kv.NewTxnCoordSender(distSender, ctx.Clock, false, tracer, stopper,
+	ctx.Ctx = tracing.WithTracer(context.Background(), tracing.NewTracer())
+	sender := kv.NewTxnCoordSender(ctx.Ctx, distSender, ctx.Clock, false, stopper,
 		kv.MakeTxnMetrics())
-	ctx.Ctx = tracing.WithTracer(context.Background(), tracer)
 	ctx.DB = client.NewDB(sender)
 	ctx.Transport = storage.NewDummyRaftTransport()
 	node := NewNode(ctx, status.NewMetricsRecorder(ctx.Clock), metric.NewRegistry(), stopper,

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -98,9 +98,9 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	tracer := tracing.NewTracer()
 	sender := kv.NewTxnCoordSender(distSender, ctx.Clock, false, tracer, stopper,
 		kv.MakeTxnMetrics())
+	ctx.Ctx = tracing.WithTracer(context.Background(), tracer)
 	ctx.DB = client.NewDB(sender)
 	ctx.Transport = storage.NewDummyRaftTransport()
-	ctx.Tracer = tracer
 	node := NewNode(ctx, status.NewMetricsRecorder(ctx.Clock), metric.NewRegistry(), stopper,
 		kv.MakeTxnMetrics(), sql.MakeEventLogger(nil))
 	roachpb.RegisterInternalServer(grpcServer, node)

--- a/server/server.go
+++ b/server/server.go
@@ -171,11 +171,14 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 	// DistSender needs to know that it should not retry in this situation.
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = s.stopper.ShouldQuiesce()
-	s.distSender = kv.NewDistSender(&kv.DistSenderConfig{
+	distSenderCfg := kv.DistSenderConfig{
+		Ctx:             s.Ctx(),
 		Clock:           s.clock,
 		RPCContext:      s.rpcContext,
 		RPCRetryOptions: &retryOpts,
-	}, s.gossip)
+	}
+	s.distSender = kv.NewDistSender(&distSenderCfg, s.gossip)
+
 	txnMetrics := kv.MakeTxnMetrics()
 	s.registry.AddMetricStruct(txnMetrics)
 	sender := kv.NewTxnCoordSender(s.distSender, s.clock, srvCtx.Linearizable, tracer,

--- a/server/server.go
+++ b/server/server.go
@@ -230,6 +230,7 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 
 	// TODO(bdarnell): make StoreConfig configurable.
 	nCtx := storage.StoreContext{
+		Ctx:                            s.Ctx(),
 		Clock:                          s.clock,
 		DB:                             s.db,
 		Gossip:                         s.gossip,
@@ -239,8 +240,7 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 		ScanMaxIdleTime:                s.ctx.ScanMaxIdleTime,
 		ConsistencyCheckInterval:       s.ctx.ConsistencyCheckInterval,
 		ConsistencyCheckPanicOnFailure: s.ctx.ConsistencyCheckPanicOnFailure,
-		Tracer:    tracer,
-		StorePool: s.storePool,
+		StorePool:                      s.storePool,
 		SQLExecutor: sql.InternalExecutor{
 			LeaseManager: s.leaseMgr,
 		},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -230,7 +230,8 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 		RPCContext:      s.RPCContext(),
 		RPCRetryOptions: &retryOpts,
 	}, ts.Gossip())
-	tds := kv.NewTxnCoordSender(ds, s.Clock(), ts.Ctx.Linearizable, tracing.NewTracer(),
+	ctx := tracing.WithTracer(context.Background(), tracing.NewTracer())
+	tds := kv.NewTxnCoordSender(ctx, ds, s.Clock(), ts.Ctx.Linearizable,
 		ts.stopper, kv.MakeTxnMetrics())
 
 	if err := ts.node.ctx.DB.AdminSplit("m"); err != nil {
@@ -327,7 +328,8 @@ func TestMultiRangeScanWithMaxResults(t *testing.T) {
 			RPCContext:      s.RPCContext(),
 			RPCRetryOptions: &retryOpts,
 		}, ts.Gossip())
-		tds := kv.NewTxnCoordSender(ds, ts.Clock(), ts.Ctx.Linearizable, tracing.NewTracer(),
+		ctx := tracing.WithTracer(context.Background(), tracing.NewTracer())
+		tds := kv.NewTxnCoordSender(ctx, ds, ts.Clock(), ts.Ctx.Linearizable,
 			ts.stopper, kv.MakeTxnMetrics())
 
 		for _, sk := range tc.splitKeys {

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -134,7 +134,7 @@ func createTestStoreWithEngine(
 		RangeDescriptorDB: stores, // for descriptor lookup
 	}, sCtx.Gossip)
 
-	sender := kv.NewTxnCoordSender(distSender, clock, false, tracer, stopper,
+	sender := kv.NewTxnCoordSender(sCtx.Ctx, distSender, clock, false, stopper,
 		kv.MakeTxnMetrics())
 	sCtx.Clock = clock
 	sCtx.DB = client.NewDB(sender)
@@ -522,7 +522,8 @@ func (m *multiTestContext) populateDB(idx int, stopper *stop.Stopper) {
 		TransportFactory:  m.kvTransportFactory,
 		RPCRetryOptions:   &retryOpts,
 	}, m.gossips[idx])
-	sender := kv.NewTxnCoordSender(m.distSenders[idx], m.clock, false, tracing.NewTracer(),
+	ctx := tracing.WithTracer(context.Background(), tracing.NewTracer())
+	sender := kv.NewTxnCoordSender(ctx, m.distSenders[idx], m.clock, false,
 		stopper, kv.MakeTxnMetrics())
 	m.dbs[idx] = client.NewDB(sender)
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -117,7 +117,8 @@ func createTestStoreWithEngine(
 	sCtx.Gossip = gossip.New(rpcContext, server, nil, stopper, metric.NewRegistry())
 	sCtx.Gossip.SetNodeID(nodeDesc.NodeID)
 	sCtx.ScanMaxIdleTime = 1 * time.Second
-	sCtx.Tracer = tracing.NewTracer()
+	tracer := tracing.NewTracer()
+	sCtx.Ctx = tracing.WithTracer(context.Background(), tracer)
 	stores := storage.NewStores(clock)
 
 	if err := sCtx.Gossip.SetNodeDescriptor(nodeDesc); err != nil {
@@ -128,12 +129,12 @@ func createTestStoreWithEngine(
 	retryOpts.Closer = stopper.ShouldQuiesce()
 	distSender := kv.NewDistSender(&kv.DistSenderConfig{
 		Clock:             clock,
-		TransportFactory:  kv.SenderTransportFactory(sCtx.Tracer, stores),
+		TransportFactory:  kv.SenderTransportFactory(tracer, stores),
 		RPCRetryOptions:   &retryOpts,
 		RangeDescriptorDB: stores, // for descriptor lookup
 	}, sCtx.Gossip)
 
-	sender := kv.NewTxnCoordSender(distSender, clock, false, tracing.NewTracer(), stopper,
+	sender := kv.NewTxnCoordSender(distSender, clock, false, tracer, stopper,
 		kv.MakeTxnMetrics())
 	sCtx.Clock = clock
 	sCtx.DB = client.NewDB(sender)

--- a/storage/store.go
+++ b/storage/store.go
@@ -92,7 +92,7 @@ var storeReplicaRaftReadyConcurrency = 2 * runtime.NumCPU()
 // TestStoreContext has some fields initialized with values relevant in tests.
 func TestStoreContext() StoreContext {
 	return StoreContext{
-		Tracer:                         tracing.NewTracer(),
+		Ctx:                            tracing.WithTracer(context.Background(), tracing.NewTracer()),
 		RaftTickInterval:               100 * time.Millisecond,
 		RaftHeartbeatIntervalTicks:     1,
 		RaftElectionTimeoutTicks:       3,
@@ -422,7 +422,12 @@ var _ client.Sender = &Store{}
 // required to create a store.
 // All fields holding a pointer or an interface are required to create
 // a store; the rest will have sane defaults set if omitted.
+// TODO(radu): rename this to StoreConfig
 type StoreContext struct {
+	// Base context to be used for logs and traces inside the node or store; must
+	// have a Tracer set.
+	Ctx context.Context
+
 	Clock     *hlc.Clock
 	DB        *client.DB
 	Gossip    *gossip.Gossip
@@ -469,9 +474,6 @@ type StoreContext struct {
 	// AllocatorOptions configures how the store will attempt to rebalance its
 	// replicas to other stores.
 	AllocatorOptions AllocatorOptions
-
-	// Tracer is a request tracer.
-	Tracer opentracing.Tracer
 
 	// If LogRangeEvents is true, major changes to ranges will be logged into
 	// the range event log.
@@ -556,7 +558,8 @@ func (sc *StoreContext) Valid() bool {
 	return sc.Clock != nil && sc.Transport != nil &&
 		sc.RaftTickInterval != 0 && sc.RaftHeartbeatIntervalTicks > 0 &&
 		sc.RaftElectionTimeoutTicks > 0 && sc.ScanInterval > 0 &&
-		sc.ConsistencyCheckInterval > 0 && sc.Tracer != nil
+		sc.ConsistencyCheckInterval > 0 &&
+		sc.Ctx != nil && sc.Ctx.Done() == nil && tracing.TracerFromCtx(sc.Ctx) != nil
 }
 
 // setDefaults initializes unset fields in StoreConfig to values
@@ -651,6 +654,11 @@ func NewStore(ctx StoreContext, eng engine.Engine, nodeDesc *roachpb.NodeDescrip
 // String formats a store for debug output.
 func (s *Store) String() string {
 	return fmt.Sprintf("store=%d:%d", s.Ident.NodeID, s.Ident.StoreID)
+}
+
+// Ctx returns the base context for the store.
+func (s *Store) Ctx() context.Context {
+	return s.ctx.Ctx
 }
 
 // DrainLeases (when called with 'true') prevents all of the Store's
@@ -902,7 +910,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 		})
 		wg.Wait()
 		if unfrozen > 0 {
-			log.Infof(context.TODO(), "reactivated %d frozen Ranges", unfrozen)
+			log.Infof(s.Ctx(), "reactivated %d frozen Ranges", unfrozen)
 		}
 	}) != nil {
 		close(doneUnfreezing)
@@ -1344,7 +1352,7 @@ func (s *Store) Gossip() *gossip.Gossip { return s.ctx.Gossip }
 func (s *Store) Stopper() *stop.Stopper { return s.stopper }
 
 // Tracer accessor.
-func (s *Store) Tracer() opentracing.Tracer { return s.ctx.Tracer }
+func (s *Store) Tracer() opentracing.Tracer { return tracing.TracerFromCtx(s.Ctx()) }
 
 // TestingKnobs accessor.
 func (s *Store) TestingKnobs() *StoreTestingKnobs { return &s.ctx.TestingKnobs }
@@ -2351,7 +2359,7 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 		// getOrCreateReplicaLocked disallows moving the replica ID backward, so
 		// the only way we can get here is if the replica did not previously exist.
 		if log.V(1) {
-			log.Infof(context.TODO(), "refusing incoming Raft message %s for range %d from %+v to %+v",
+			log.Infof(s.Ctx(), "refusing incoming Raft message %s for range %d from %+v to %+v",
 				req.Message.Type, req.RangeID, req.FromReplica, req.ToReplica)
 		}
 		return roachpb.NewErrorf("cannot recreate replica that is not a member of its range (StoreID %s not found in range %d)",
@@ -2552,7 +2560,7 @@ func (s *Store) processRaft() {
 				pendingReplicas = pendingReplicas[:0]
 				for id, r := range s.mu.replicas {
 					if exists, err := r.tick(); err != nil {
-						log.Error(context.TODO(), err)
+						log.Error(s.Ctx(), err)
 					} else if exists {
 						pendingReplicas = append(pendingReplicas, id)
 					}
@@ -2680,7 +2688,7 @@ func (s *Store) computeReplicationStatus(now int64) (
 	// Load the system config.
 	cfg, ok := s.Gossip().GetSystemConfig()
 	if !ok {
-		log.Infof(context.TODO(), "%s: system config not yet available", s)
+		log.Infof(s.Ctx(), "%s: system config not yet available", s)
 		return
 	}
 
@@ -2691,7 +2699,7 @@ func (s *Store) computeReplicationStatus(now int64) (
 		desc := rng.Desc()
 		zoneConfig, err := cfg.GetZoneConfigForKey(desc.StartKey)
 		if err != nil {
-			log.Error(context.TODO(), err)
+			log.Error(s.Ctx(), err)
 			continue
 		}
 		raftStatus := rng.RaftStatus()
@@ -2761,7 +2769,7 @@ func (s *Store) ComputeMetrics() error {
 	if rocksdb, ok := s.engine.(*engine.RocksDB); ok {
 		sstables := rocksdb.GetSSTables()
 		readAmp := sstables.ReadAmplification()
-		log.Infof(context.TODO(), "store %d sstables (read amplification = %d):\n%s", s.StoreID(), readAmp, sstables)
+		log.Infof(s.Ctx(), "store %d sstables (read amplification = %d):\n%s", s.StoreID(), readAmp, sstables)
 		s.metrics.RdbReadAmplification.Update(int64(readAmp))
 	}
 	return nil
@@ -2800,7 +2808,7 @@ func (s *Store) FrozenStatus(collectFrozen bool) (repDescs []roachpb.ReplicaDesc
 			if _, ok := err.(*roachpb.RangeNotFoundError); ok {
 				return true
 			}
-			log.Fatalf(context.TODO(), "unexpected error: %s", err)
+			log.Fatalf(s.Ctx(), "unexpected error: %s", err)
 		}
 		r.mu.Lock()
 		if r.mu.state.Frozen == collectFrozen {

--- a/testutils/localtestcluster/local_test_cluster.go
+++ b/testutils/localtestcluster/local_test_cluster.go
@@ -19,6 +19,8 @@ package localtestcluster
 import (
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/internal/client"
@@ -106,11 +108,11 @@ func (ltc *LocalTestCluster) Start(t util.Tester, baseCtx *base.Context, initSen
 	if ltc.RangeRetryOptions != nil {
 		ctx.RangeRetryOptions = *ltc.RangeRetryOptions
 	}
+	ctx.Ctx = tracing.WithTracer(context.Background(), tracer)
 	ctx.Clock = ltc.Clock
 	ctx.DB = ltc.DB
 	ctx.Gossip = ltc.Gossip
 	ctx.Transport = transport
-	ctx.Tracer = tracer
 	ltc.Store = storage.NewStore(ctx, ltc.Eng, nodeDesc)
 	if err := ltc.Store.Bootstrap(roachpb.StoreIdent{NodeID: nodeID, StoreID: 1}, ltc.Stopper); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)


### PR DESCRIPTION
Tracers are removed, we now use the context to get the Tracer.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8625)

<!-- Reviewable:end -->
