### PR TITLE
config: convert ZoneConfig to the new format

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -113,7 +113,7 @@ google.golang.org/appengine e951d3868b377b14f4e60efa3a301532ee3c1ebf
 google.golang.org/grpc b7aa4e95cbb5ec9d07c52a7541ce178ef9626316
 gopkg.in/check.v1 4f90aeace3a26ad7021961c297b22c42160c7b25
 gopkg.in/inf.v0 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
-gopkg.in/yaml.v1 9f9df34309c04878acc86042b16630b0f696e1de
+gopkg.in/yaml.v2 e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
 honnef.co/go/lint a730e73f0085f274d67b586a1d587fd6e42e6708
 honnef.co/go/simple aa6f9e72ec86009fdfc110b52e2c769d48d5a904
 honnef.co/go/staticcheck 02337b3080e043d43781e1a0d129df14848f9507

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -503,12 +503,12 @@ func Example_zone() {
 	// .default
 	// zone set system --file=./testdata/zone_attrs.yaml
 	// INSERT 1
-	// replicas:
-	// - attrs: [us-east-1a, ssd]
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
 	// gc:
 	//   ttlseconds: 86400
+	// num_replicas: 1
+	// constraints: [us-east-1a, ssd]
 	// zone ls
 	// .default
 	// system
@@ -516,28 +516,28 @@ func Example_zone() {
 	// system.nonexistent not found
 	// zone get system.lease
 	// system
-	// replicas:
-	// - attrs: [us-east-1a, ssd]
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
 	// gc:
 	//   ttlseconds: 86400
+	// num_replicas: 1
+	// constraints: [us-east-1a, ssd]
 	// zone set system --file=./testdata/zone_range_max_bytes.yaml
 	// UPDATE 1
-	// replicas:
-	// - attrs: [us-east-1a, ssd]
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
 	//   ttlseconds: 86400
+	// num_replicas: 1
+	// constraints: [us-east-1a, ssd]
 	// zone get system
 	// system
-	// replicas:
-	// - attrs: [us-east-1a, ssd]
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
 	//   ttlseconds: 86400
+	// num_replicas: 1
+	// constraints: [us-east-1a, ssd]
 	// zone rm system
 	// DELETE 1
 	// zone ls
@@ -546,20 +546,20 @@ func Example_zone() {
 	// unable to remove .default
 	// zone set .default --file=./testdata/zone_range_max_bytes.yaml
 	// UPDATE 1
-	// replicas:
-	// - attrs: []
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
 	//   ttlseconds: 86400
+	// num_replicas: 1
+	// constraints: []
 	// zone get system
 	// .default
-	// replicas:
-	// - attrs: []
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
 	//   ttlseconds: 86400
+	// num_replicas: 1
+	// constraints: []
 }
 
 func Example_sql() {

--- a/cli/testdata/zone_attrs.yaml
+++ b/cli/testdata/zone_attrs.yaml
@@ -1,2 +1,2 @@
-replicas:
-  - attrs: [us-east-1a,ssd]
+num_replicas: 1
+constraints: [us-east-1a,ssd]

--- a/cli/zone.go
+++ b/cli/zone.go
@@ -461,9 +461,8 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 	// Convert it to proto and marshal it again to put into the table. This is a
 	// bit more tedious than taking protos directly, but yaml is a more widely
 	// understood format.
-	origReplicaAttrs := zone.ReplicaAttrs
-	zone.ReplicaAttrs = nil
 	// Read zoneConfig file to conf.
+
 	var conf []byte
 	if zoneConfig == "-" {
 		conf, err = ioutil.ReadAll(os.Stdin)
@@ -475,9 +474,6 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 	}
 	if err := yaml.Unmarshal(conf, &zone); err != nil {
 		return fmt.Errorf("unable to parse zoneConfig file: %s", err)
-	}
-	if zone.ReplicaAttrs == nil {
-		zone.ReplicaAttrs = origReplicaAttrs
 	}
 
 	if err := zone.Validate(); err != nil {

--- a/cli/zone.go
+++ b/cli/zone.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/keys"

--- a/config/config.proto
+++ b/config/config.proto
@@ -35,17 +35,47 @@ message GCPolicy {
   optional int32 ttl_seconds = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "TTLSeconds"];
 }
 
-// ZoneConfig holds configuration that is needed for a range of KV pairs.
+// Constraint constrains the stores a replica can be stored on.
+message Constraint {
+  option (gogoproto.goproto_stringer) = false;
+
+  enum Type {
+    // POSITIVE will attempt to ensure all stores the replicas are on has this
+    // constraint.
+    POSITIVE = 0;
+    // REQUIRED is like POSITIVE except replication will fail if not satisfied.
+    REQUIRED = 1;
+    // PROHIBITED will prevent replicas from having this key, value.
+    PROHIBITED = 2;
+  }
+  optional Type type = 1 [(gogoproto.nullable) = false];
+  // Key is only set if this is a constraint on locality.
+  optional string key = 2 [(gogoproto.nullable) = false];
+  // Value to constrain to.
+  optional string value = 3 [(gogoproto.nullable) = false];
+}
+
+// Constraints is a collection of constraints.
+message Constraints {
+  repeated Constraint constraints = 6 [(gogoproto.nullable) = false];
+}
+
+// ZoneConfig holds configuration that is needed for a range of KV pairs. This
+// and the conversion methods must stay in sync with ZoneConfigHuman.
 message ZoneConfig {
-  // ReplicaAttrs is a slice of Attributes, each describing required attributes
-  // for each replica in the zone. The order in which the attributes are stored
-  // in ReplicaAttrs is arbitrary and may change.
-  repeated roachpb.Attributes replica_attrs = 1 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"replicas,omitempty\""];
+  // TODO(d4l3k): Remove replica_attrs after a sufficient amount of time has passed.
+  repeated roachpb.Attributes replica_attrs = 1 [deprecated = true, (gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\",omitempty\""];
   optional int64 range_min_bytes = 2 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_min_bytes\""];
   optional int64 range_max_bytes = 3 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_max_bytes\""];
   // If GC policy is not set, uses the next highest, non-null policy
   // in the zone config hierarchy, up to the default policy if necessary.
   optional GCPolicy gc = 4 [(gogoproto.nullable) = false, (gogoproto.customname) = "GC"];
+  // NumReplicas specifies the desired number of replicas
+  optional int32 num_replicas = 5 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"num_replicas\""];
+  // Constraints constrains which stores the replicas can be stored on. The
+  // order in which the constraints are stored is arbitrary and may change.
+  // https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/expressive_zone_config.md#constraint-system
+  optional Constraints constraints = 6 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"constraints,flow\""];
 }
 
 message SystemConfig {

--- a/config/migration.go
+++ b/config/migration.go
@@ -1,0 +1,46 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tristan Rice (rice@fn.lc)
+
+package config
+
+import (
+	"errors"
+
+	"github.com/cockroachdb/cockroach/roachpb"
+)
+
+// MigrateZoneConfig migrates the legacy ZoneConfig format into the new one.
+func MigrateZoneConfig(value *roachpb.Value) (ZoneConfig, error) {
+	var zone ZoneConfig
+	if err := value.GetProto(&zone); err != nil {
+		return ZoneConfig{}, err
+	}
+	if len(zone.ReplicaAttrs) > 0 {
+		if zone.NumReplicas > 0 || len(zone.Constraints.Constraints) > 0 {
+			return ZoneConfig{}, errors.New("migration to new ZoneConfig failed due to previous partial upgrade")
+		}
+		zone.NumReplicas = int32(len(zone.ReplicaAttrs))
+		if zone.NumReplicas > 0 {
+			attrs := zone.ReplicaAttrs[0].Attrs
+			zone.Constraints.Constraints = make([]Constraint, len(attrs))
+			for i, attr := range attrs {
+				zone.Constraints.Constraints[i].Value = attr
+			}
+		}
+		zone.ReplicaAttrs = nil
+	}
+	return zone, nil
+}

--- a/config/migration_test.go
+++ b/config/migration_test.go
@@ -1,0 +1,92 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Tristan Rice (rice@fn.lc)
+
+package config
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/roachpb"
+	"github.com/cockroachdb/cockroach/util/leaktest"
+	"github.com/gogo/protobuf/proto"
+)
+
+func TestMigrateZoneConfig(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		input, want proto.Message
+	}{
+		{
+			&ZoneConfig{
+				ReplicaAttrs: []roachpb.Attributes{
+					{Attrs: []string{"foo"}},
+					{},
+					{},
+				},
+			},
+			&ZoneConfig{
+				NumReplicas: 3,
+				Constraints: Constraints{
+					Constraints: []Constraint{
+						{
+							Type:  Constraint_POSITIVE,
+							Value: "foo",
+						},
+					},
+				},
+			},
+		},
+		{
+			&ZoneConfig{
+				NumReplicas: 3,
+				Constraints: Constraints{
+					Constraints: []Constraint{
+						{
+							Type:  Constraint_POSITIVE,
+							Value: "foo",
+						},
+					},
+				},
+			},
+			&ZoneConfig{
+				NumReplicas: 3,
+				Constraints: Constraints{
+					Constraints: []Constraint{
+						{
+							Type:  Constraint_POSITIVE,
+							Value: "foo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		var val roachpb.Value
+		if err := val.SetProto(tc.input); err != nil {
+			t.Fatal(err)
+		}
+		out, err := MigrateZoneConfig(&val)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !proto.Equal(tc.want, &out) {
+			t.Errorf("%d: MigrateZoneConfig(%+v) = %+v; not %+v", i, tc.input, out, tc.want)
+		}
+	}
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -376,10 +376,8 @@ func TestClientGetAndPutProto(t *testing.T) {
 	db := createTestClient(t, s.Stopper(), s.ServingAddr())
 
 	zoneConfig := config.ZoneConfig{
-		ReplicaAttrs: []roachpb.Attributes{
-			{Attrs: []string{"dc1", "mem"}},
-			{Attrs: []string{"dc2", "mem"}},
-		},
+		NumReplicas:   2,
+		Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "mem"}}},
 		RangeMinBytes: 1 << 10, // 1k
 		RangeMaxBytes: 1 << 18, // 256k
 	}

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -206,7 +206,7 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 		// Change the replication requirements so we don't get log spam about ranges
 		// not being replicated enough.
 		cfg := config.DefaultZoneConfig()
-		cfg.ReplicaAttrs = []roachpb.Attributes{{}}
+		cfg.NumReplicas = 1
 		fn := config.TestingSetDefaultZoneConfig(cfg)
 		params.Stopper.AddCloser(stop.CloserFn(fn))
 	}

--- a/sql/config.go
+++ b/sql/config.go
@@ -32,9 +32,9 @@ func init() {
 func GetZoneConfig(cfg config.SystemConfig, id uint32) (config.ZoneConfig, bool, error) {
 	// Look in the zones table.
 	if zoneVal := cfg.GetValue(sqlbase.MakeZoneKey(sqlbase.ID(id))); zoneVal != nil {
-		var zone config.ZoneConfig
 		// We're done.
-		return zone, true, zoneVal.GetProto(&zone)
+		zone, err := config.MigrateZoneConfig(zoneVal)
+		return zone, true, err
 	}
 
 	// No zone config for this ID. We need to figure out if it's a database

--- a/sql/config_test.go
+++ b/sql/config_test.go
@@ -192,13 +192,16 @@ func TestGetZoneConfig(t *testing.T) {
 	//   tb1: true
 	//   tb2: false
 	db1Cfg := config.ZoneConfig{
-		ReplicaAttrs: []roachpb.Attributes{{Attrs: []string{"db1"}}},
+		NumReplicas: 1,
+		Constraints: config.Constraints{Constraints: []config.Constraint{{Value: "db1"}}},
 	}
 	tb11Cfg := config.ZoneConfig{
-		ReplicaAttrs: []roachpb.Attributes{{Attrs: []string{"db1.tb1"}}},
+		NumReplicas: 1,
+		Constraints: config.Constraints{Constraints: []config.Constraint{{Value: "db1.tb1"}}},
 	}
 	tb21Cfg := config.ZoneConfig{
-		ReplicaAttrs: []roachpb.Attributes{{Attrs: []string{"db2.tb1"}}},
+		NumReplicas: 1,
+		Constraints: config.Constraints{Constraints: []config.Constraint{{Value: "db2.tb1"}}},
 	}
 	for objID, objZone := range map[uint32]config.ZoneConfig{
 		db1:  db1Cfg,

--- a/sql/parallel_test.go
+++ b/sql/parallel_test.go
@@ -34,7 +34,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/config"

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -20,6 +20,8 @@ package storage
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -40,24 +42,18 @@ import (
 )
 
 var simpleZoneConfig = config.ZoneConfig{
-	ReplicaAttrs: []roachpb.Attributes{
-		{Attrs: []string{"a", "ssd"}},
-	},
-}
-
-var multiDisksConfig = config.ZoneConfig{
-	ReplicaAttrs: []roachpb.Attributes{
-		{Attrs: []string{"a", "ssd"}},
-		{Attrs: []string{"a", "hdd"}},
-		{Attrs: []string{"a", "mem"}},
+	NumReplicas: 1,
+	Constraints: config.Constraints{
+		Constraints: []config.Constraint{
+			{Value: "a"},
+			{Value: "ssd"},
+		},
 	},
 }
 
 var multiDCConfig = config.ZoneConfig{
-	ReplicaAttrs: []roachpb.Attributes{
-		{Attrs: []string{"a", "ssd"}},
-		{Attrs: []string{"b", "ssd"}},
-	},
+	NumReplicas: 2,
+	Constraints: config.Constraints{Constraints: []config.Constraint{{Value: "ssd"}}},
 }
 
 var singleStore = []*roachpb.StoreDescriptor{
@@ -208,7 +204,7 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 	stopper, g, _, a, _ := createTestAllocator()
 	defer stopper.Stop()
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
-	result, err := a.AllocateTarget(simpleZoneConfig.ReplicaAttrs[0], []roachpb.ReplicaDescriptor{}, false)
+	result, err := a.AllocateTarget(simpleZoneConfig.Constraints, []roachpb.ReplicaDescriptor{}, false)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -221,7 +217,7 @@ func TestAllocatorNoAvailableDisks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, _, _, a, _ := createTestAllocator()
 	defer stopper.Stop()
-	result, err := a.AllocateTarget(simpleZoneConfig.ReplicaAttrs[0], []roachpb.ReplicaDescriptor{}, false)
+	result, err := a.AllocateTarget(simpleZoneConfig.Constraints, []roachpb.ReplicaDescriptor{}, false)
 	if result != nil {
 		t.Errorf("expected nil result: %+v", result)
 	}
@@ -230,68 +226,40 @@ func TestAllocatorNoAvailableDisks(t *testing.T) {
 	}
 }
 
-func TestAllocatorThreeDisksSameDC(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	stopper, g, _, a, _ := createTestAllocator()
-	defer stopper.Stop()
-	gossiputil.NewStoreGossiper(g).GossipStores(sameDCStores, t)
-	result1, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[0], []roachpb.ReplicaDescriptor{}, false)
-	if err != nil {
-		t.Fatalf("Unable to perform allocation: %v", err)
-	}
-	if result1.StoreID != 1 && result1.StoreID != 2 {
-		t.Errorf("Expected store 1 or 2; got %+v", result1)
-	}
-	exReplicas := []roachpb.ReplicaDescriptor{
-		{
-			NodeID:  result1.Node.NodeID,
-			StoreID: result1.StoreID,
-		},
-	}
-	result2, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[1], exReplicas, false)
-	if err != nil {
-		t.Errorf("Unable to perform allocation: %v", err)
-	}
-	if result2.StoreID != 3 && result2.StoreID != 4 {
-		t.Errorf("Expected store 3 or 4; got %+v", result2)
-	}
-	if result1.Node.NodeID == result2.Node.NodeID {
-		t.Errorf("Expected node ids to be different %+v vs %+v", result1, result2)
-	}
-	result3, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[2], []roachpb.ReplicaDescriptor{}, false)
-	if err != nil {
-		t.Errorf("Unable to perform allocation: %v", err)
-	}
-	if result3.Node.NodeID != 4 || result3.StoreID != 5 {
-		t.Errorf("Expected node 4, store 5; got %+v", result3)
-	}
-}
-
 func TestAllocatorTwoDatacenters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, a, _ := createTestAllocator()
 	defer stopper.Stop()
 	gossiputil.NewStoreGossiper(g).GossipStores(multiDCStores, t)
-	result1, err := a.AllocateTarget(multiDCConfig.ReplicaAttrs[0], []roachpb.ReplicaDescriptor{}, false)
+	result1, err := a.AllocateTarget(multiDCConfig.Constraints, []roachpb.ReplicaDescriptor{}, false)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
-	result2, err := a.AllocateTarget(multiDCConfig.ReplicaAttrs[1], []roachpb.ReplicaDescriptor{}, false)
+	result2, err := a.AllocateTarget(multiDCConfig.Constraints, []roachpb.ReplicaDescriptor{{
+		NodeID:  result1.Node.NodeID,
+		StoreID: result1.StoreID,
+	}}, false)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
-	if result1.Node.NodeID != 1 || result2.Node.NodeID != 2 {
-		t.Errorf("Expected nodes 1 & 2: %+v vs %+v", result1.Node, result2.Node)
+	ids := []int{int(result1.Node.NodeID), int(result2.Node.NodeID)}
+	sort.Ints(ids)
+	if expected := []int{1, 2}; !reflect.DeepEqual(ids, expected) {
+		t.Errorf("Expected nodes %+v: %+v vs %+v", expected, result1.Node, result2.Node)
 	}
 	// Verify that no result is forthcoming if we already have a replica.
-	_, err = a.AllocateTarget(multiDCConfig.ReplicaAttrs[1], []roachpb.ReplicaDescriptor{
+	result3, err := a.AllocateTarget(multiDCConfig.Constraints, []roachpb.ReplicaDescriptor{
+		{
+			NodeID:  result1.Node.NodeID,
+			StoreID: result1.StoreID,
+		},
 		{
 			NodeID:  result2.Node.NodeID,
 			StoreID: result2.StoreID,
 		},
 	}, false)
 	if err == nil {
-		t.Errorf("expected error on allocation without available stores")
+		t.Errorf("expected error on allocation without available stores: %+v", result3)
 	}
 }
 
@@ -300,12 +268,19 @@ func TestAllocatorExistingReplica(t *testing.T) {
 	stopper, g, _, a, _ := createTestAllocator()
 	defer stopper.Stop()
 	gossiputil.NewStoreGossiper(g).GossipStores(sameDCStores, t)
-	result, err := a.AllocateTarget(multiDisksConfig.ReplicaAttrs[1], []roachpb.ReplicaDescriptor{
-		{
-			NodeID:  2,
-			StoreID: 2,
+	result, err := a.AllocateTarget(
+		config.Constraints{
+			Constraints: []config.Constraint{
+				{Value: "a"},
+				{Value: "hdd"},
+			},
 		},
-	}, false)
+		[]roachpb.ReplicaDescriptor{
+			{
+				NodeID:  2,
+				StoreID: 2,
+			},
+		}, false)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
 	}
@@ -324,37 +299,38 @@ func TestAllocatorRelaxConstraints(t *testing.T) {
 	gossiputil.NewStoreGossiper(g).GossipStores(multiDCStores, t)
 
 	testCases := []struct {
-		required         []string // attribute strings
-		existing         []int    // existing store/node ID
-		relaxConstraints bool     // allow constraints to be relaxed?
-		expID            int      // expected store/node ID on allocate
+		required         []config.Constraint // attribute strings
+		existing         []int               // existing store/node ID
+		relaxConstraints bool                // allow constraints to be relaxed?
+		expID            int                 // expected store/node ID on allocate
 		expErr           bool
 	}{
 		// The two stores in the system have attributes:
 		//  storeID=1 {"a", "ssd"}
 		//  storeID=2 {"b", "ssd"}
-		{[]string{"a", "ssd"}, []int{}, true, 1, false},
-		{[]string{"a", "ssd"}, []int{1}, true, 2, false},
-		{[]string{"a", "ssd"}, []int{1}, false, 0, true},
-		{[]string{"a", "ssd"}, []int{1, 2}, true, 0, true},
-		{[]string{"b", "ssd"}, []int{}, true, 2, false},
-		{[]string{"b", "ssd"}, []int{1}, true, 2, false},
-		{[]string{"b", "ssd"}, []int{2}, false, 0, true},
-		{[]string{"b", "ssd"}, []int{2}, true, 1, false},
-		{[]string{"b", "ssd"}, []int{1, 2}, true, 0, true},
-		{[]string{"b", "hdd"}, []int{}, true, 2, false},
-		{[]string{"b", "hdd"}, []int{2}, true, 1, false},
-		{[]string{"b", "hdd"}, []int{2}, false, 0, true},
-		{[]string{"b", "hdd"}, []int{1, 2}, true, 0, true},
-		{[]string{"b", "ssd", "gpu"}, []int{}, true, 2, false},
-		{[]string{"b", "hdd", "gpu"}, []int{}, true, 2, false},
+		{[]config.Constraint{{Value: "a"}, {Value: "ssd"}}, []int{}, true, 1, false},
+		{[]config.Constraint{{Value: "a"}, {Value: "ssd"}}, []int{1}, true, 2, false},
+		{[]config.Constraint{{Value: "a"}, {Value: "ssd"}}, []int{1}, false, 0, true},
+		{[]config.Constraint{{Value: "a"}, {Value: "ssd"}}, []int{1, 2}, true, 0, true},
+		{[]config.Constraint{{Value: "b"}, {Value: "ssd"}}, []int{}, true, 2, false},
+		{[]config.Constraint{{Value: "b"}, {Value: "ssd"}}, []int{1}, true, 2, false},
+		{[]config.Constraint{{Value: "b"}, {Value: "ssd"}}, []int{2}, false, 0, true},
+		{[]config.Constraint{{Value: "b"}, {Value: "ssd"}}, []int{2}, true, 1, false},
+		{[]config.Constraint{{Value: "b"}, {Value: "ssd"}}, []int{1, 2}, true, 0, true},
+		{[]config.Constraint{{Value: "b"}, {Value: "hdd"}}, []int{}, true, 2, false},
+		{[]config.Constraint{{Value: "b"}, {Value: "hdd"}}, []int{2}, true, 1, false},
+		{[]config.Constraint{{Value: "b"}, {Value: "hdd"}}, []int{2}, false, 0, true},
+		{[]config.Constraint{{Value: "b"}, {Value: "hdd"}}, []int{1, 2}, true, 0, true},
+		{[]config.Constraint{{Value: "b"}, {Value: "ssd"}, {Value: "gpu"}}, []int{}, true, 2, false},
+		{[]config.Constraint{{Value: "b"}, {Value: "hdd"}, {Value: "gpu"}}, []int{}, true, 2, false},
 	}
 	for i, test := range testCases {
 		var existing []roachpb.ReplicaDescriptor
 		for _, id := range test.existing {
 			existing = append(existing, roachpb.ReplicaDescriptor{NodeID: roachpb.NodeID(id), StoreID: roachpb.StoreID(id)})
 		}
-		result, err := a.AllocateTarget(roachpb.Attributes{Attrs: test.required}, existing, test.relaxConstraints)
+		constraints := config.Constraints{Constraints: test.required}
+		result, err := a.AllocateTarget(constraints, existing, test.relaxConstraints)
 		if haveErr := (err != nil); haveErr != test.expErr {
 			t.Errorf("%d: expected error %t; got %t: %s", i, test.expErr, haveErr, err)
 		} else if err == nil && roachpb.StoreID(test.expID) != result.StoreID {
@@ -416,8 +392,7 @@ func TestAllocatorRebalance(t *testing.T) {
 
 	// Every rebalance target must be either stores 1 or 2.
 	for i := 0; i < 10; i++ {
-		result := a.RebalanceTarget(roachpb.Attributes{},
-			[]roachpb.ReplicaDescriptor{{StoreID: 3}}, 0)
+		result := a.RebalanceTarget(config.Constraints{}, []roachpb.ReplicaDescriptor{{StoreID: 3}}, 0)
 		if result == nil {
 			t.Fatal("nil result")
 		}
@@ -433,7 +408,7 @@ func TestAllocatorRebalance(t *testing.T) {
 		if !ok {
 			t.Fatalf("%d: unable to get store %d descriptor", i, store.StoreID)
 		}
-		sl, _, _ := a.storePool.getStoreList(roachpb.Attributes{}, true)
+		sl, _, _ := a.storePool.getStoreList(config.Constraints{}, true)
 		result := a.shouldRebalance(desc, sl)
 		if expResult := (i >= 2); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
@@ -476,8 +451,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 
 	// Every rebalance target must be store 4 (or nil for case of missing the only option).
 	for i := 0; i < 10; i++ {
-		result := a.RebalanceTarget(roachpb.Attributes{},
-			[]roachpb.ReplicaDescriptor{{StoreID: 1}}, 0)
+		result := a.RebalanceTarget(config.Constraints{}, []roachpb.ReplicaDescriptor{{StoreID: 1}}, 0)
 		if result != nil && result.StoreID != 4 {
 			t.Errorf("expected store 4; got %d", result.StoreID)
 		}
@@ -490,7 +464,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 		if !ok {
 			t.Fatalf("%d: unable to get store %d descriptor", i, store.StoreID)
 		}
-		sl, _, _ := a.storePool.getStoreList(roachpb.Attributes{}, true)
+		sl, _, _ := a.storePool.getStoreList(config.Constraints{}, true)
 		result := a.shouldRebalance(desc, sl)
 		if expResult := (i < 3); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
@@ -604,17 +578,8 @@ func TestAllocatorComputeAction(t *testing.T) {
 		// Needs three replicas, two are on dead stores.
 		{
 			zone: config.ZoneConfig{
-				ReplicaAttrs: []roachpb.Attributes{
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-				},
+				NumReplicas:   3,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
 			},
@@ -642,17 +607,8 @@ func TestAllocatorComputeAction(t *testing.T) {
 		// Needs three replicas, one is on a dead store.
 		{
 			zone: config.ZoneConfig{
-				ReplicaAttrs: []roachpb.Attributes{
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-				},
+				NumReplicas:   3,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
 			},
@@ -680,17 +636,8 @@ func TestAllocatorComputeAction(t *testing.T) {
 		// Needs three replicas, one is dead.
 		{
 			zone: config.ZoneConfig{
-				ReplicaAttrs: []roachpb.Attributes{
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-				},
+				NumReplicas:   3,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
 			},
@@ -718,17 +665,8 @@ func TestAllocatorComputeAction(t *testing.T) {
 		// Needs five replicas, one is on a dead store.
 		{
 			zone: config.ZoneConfig{
-				ReplicaAttrs: []roachpb.Attributes{
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-				},
+				NumReplicas:   3,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
 			},
@@ -766,17 +704,8 @@ func TestAllocatorComputeAction(t *testing.T) {
 		// Needs Three replicas, have two
 		{
 			zone: config.ZoneConfig{
-				ReplicaAttrs: []roachpb.Attributes{
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-				},
+				NumReplicas:   3,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
 			},
@@ -799,23 +728,8 @@ func TestAllocatorComputeAction(t *testing.T) {
 		// Needs Five replicas, have four.
 		{
 			zone: config.ZoneConfig{
-				ReplicaAttrs: []roachpb.Attributes{
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-				},
+				NumReplicas:   5,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
 			},
@@ -848,17 +762,8 @@ func TestAllocatorComputeAction(t *testing.T) {
 		// Need three replicas, have four.
 		{
 			zone: config.ZoneConfig{
-				ReplicaAttrs: []roachpb.Attributes{
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-				},
+				NumReplicas:   3,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
 			},
@@ -891,17 +796,8 @@ func TestAllocatorComputeAction(t *testing.T) {
 		// Need three replicas, have five.
 		{
 			zone: config.ZoneConfig{
-				ReplicaAttrs: []roachpb.Attributes{
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-				},
+				NumReplicas:   3,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
 			},
@@ -939,17 +835,8 @@ func TestAllocatorComputeAction(t *testing.T) {
 		// Three replicas have three, none of the replicas in the store pool.
 		{
 			zone: config.ZoneConfig{
-				ReplicaAttrs: []roachpb.Attributes{
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-				},
+				NumReplicas:   3,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
 			},
@@ -977,17 +864,8 @@ func TestAllocatorComputeAction(t *testing.T) {
 		// Three replicas have three.
 		{
 			zone: config.ZoneConfig{
-				ReplicaAttrs: []roachpb.Attributes{
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-					{
-						Attrs: []string{"us-east"},
-					},
-				},
+				NumReplicas:   3,
+				Constraints:   config.Constraints{Constraints: []config.Constraint{{Value: "us-east"}}},
 				RangeMinBytes: 0,
 				RangeMaxBytes: 64000,
 			},
@@ -1047,31 +925,31 @@ func TestAllocatorComputeActionNoStorePool(t *testing.T) {
 func TestAllocatorError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	attribute := roachpb.Attributes{Attrs: []string{"one"}}
-	attributes := roachpb.Attributes{Attrs: []string{"one", "two"}}
+	constraint := []config.Constraint{{Value: "one"}}
+	constraints := []config.Constraint{{Value: "one"}, {Value: "two"}}
 
 	testCases := []struct {
 		ae       allocatorError
 		expected string
 	}{
-		{allocatorError{roachpb.Attributes{}, false, 1},
+		{allocatorError{nil, false, 1},
 			"0 of 1 store with all attributes matching []; likely not enough nodes in cluster"},
-		{allocatorError{attribute, false, 1},
+		{allocatorError{constraint, false, 1},
 			"0 of 1 store with all attributes matching [one]"},
-		{allocatorError{attribute, true, 1},
+		{allocatorError{constraint, true, 1},
 			"0 of 1 store with an attribute matching [one]; likely not enough nodes in cluster"},
-		{allocatorError{attribute, false, 2},
+		{allocatorError{constraint, false, 2},
 			"0 of 2 stores with all attributes matching [one]"},
-		{allocatorError{attribute, true, 2},
+		{allocatorError{constraint, true, 2},
 			"0 of 2 stores with an attribute matching [one]; likely not enough nodes in cluster"},
-		{allocatorError{attributes, false, 1},
-			"0 of 1 store with all attributes matching [one,two]"},
-		{allocatorError{attributes, true, 1},
-			"0 of 1 store with an attribute matching [one,two]; likely not enough nodes in cluster"},
-		{allocatorError{attributes, false, 2},
-			"0 of 2 stores with all attributes matching [one,two]"},
-		{allocatorError{attributes, true, 2},
-			"0 of 2 stores with an attribute matching [one,two]; likely not enough nodes in cluster"},
+		{allocatorError{constraints, false, 1},
+			"0 of 1 store with all attributes matching [one two]"},
+		{allocatorError{constraints, true, 1},
+			"0 of 1 store with an attribute matching [one two]; likely not enough nodes in cluster"},
+		{allocatorError{constraints, false, 2},
+			"0 of 2 stores with all attributes matching [one two]"},
+		{allocatorError{constraints, true, 2},
+			"0 of 2 stores with an attribute matching [one two]; likely not enough nodes in cluster"},
 	}
 
 	for i, testCase := range testCases {
@@ -1090,7 +968,7 @@ func TestAllocatorThrottled(t *testing.T) {
 
 	// First test to make sure we would send the replica to purgatory.
 	_, err := a.AllocateTarget(
-		simpleZoneConfig.ReplicaAttrs[0],
+		simpleZoneConfig.Constraints,
 		[]roachpb.ReplicaDescriptor{},
 		false)
 	if _, ok := err.(purgatoryError); !ok {
@@ -1100,7 +978,7 @@ func TestAllocatorThrottled(t *testing.T) {
 	// Second, test the normal case in which we can allocate to the store.
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
 	result, err := a.AllocateTarget(
-		simpleZoneConfig.ReplicaAttrs[0],
+		simpleZoneConfig.Constraints,
 		[]roachpb.ReplicaDescriptor{},
 		false)
 	if err != nil {
@@ -1120,7 +998,7 @@ func TestAllocatorThrottled(t *testing.T) {
 	storeDetail.throttledUntil = timeutil.Now().Add(24 * time.Hour)
 	a.storePool.mu.Unlock()
 	_, err = a.AllocateTarget(
-		simpleZoneConfig.ReplicaAttrs[0],
+		simpleZoneConfig.Constraints,
 		[]roachpb.ReplicaDescriptor{},
 		false)
 	if _, ok := err.(purgatoryError); ok {
@@ -1202,7 +1080,7 @@ func Example_rebalancing() {
 		for j := 0; j < len(testStores); j++ {
 			ts := &testStores[j]
 			target := alloc.RebalanceTarget(
-				roachpb.Attributes{},
+				config.Constraints{},
 				[]roachpb.ReplicaDescriptor{{NodeID: ts.Node.NodeID, StoreID: ts.StoreID}},
 				-1)
 			if target != nil {

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -44,6 +44,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/gossip/resolver"
 	"github.com/cockroachdb/cockroach/internal/client"
@@ -397,7 +398,7 @@ func (m *multiTestContext) initGossipNetwork() {
 	util.SucceedsSoon(m.t, func() error {
 		for i := 0; i < len(m.stores); i++ {
 			_, alive, _ := m.storePools[i].GetStoreList(
-				roachpb.Attributes{},
+				config.Constraints{},
 				/* deterministic */ false,
 			)
 			if alive != len(m.stores) {

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -22,6 +22,7 @@
 package storage
 
 import (
+	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/internal/client"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/storage/engine/enginepb"
@@ -167,6 +168,6 @@ func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
 }
 
 // GetStoreList is the same function as GetStoreList exposed for tests only.
-func (sp *StorePool) GetStoreList(required roachpb.Attributes, deterministic bool) (StoreList, int, int) {
-	return sp.getStoreList(required, deterministic)
+func (sp *StorePool) GetStoreList(constraints config.Constraints, deterministic bool) (StoreList, int, int) {
+	return sp.getStoreList(constraints, deterministic)
 }

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -110,7 +110,7 @@ func (rq *replicateQueue) shouldQueue(
 		leaseStoreID = lease.Replica.StoreID
 	}
 	target := rq.allocator.RebalanceTarget(
-		zone.ReplicaAttrs[0], desc.Replicas, leaseStoreID)
+		zone.Constraints, desc.Replicas, leaseStoreID)
 	return target != nil, 0
 }
 
@@ -140,7 +140,7 @@ func (rq *replicateQueue) process(
 	switch action {
 	case AllocatorAdd:
 		log.Trace(ctx, "adding a new replica")
-		newStore, err := rq.allocator.AllocateTarget(zone.ReplicaAttrs[0], desc.Replicas, true)
+		newStore, err := rq.allocator.AllocateTarget(zone.Constraints, desc.Replicas, true)
 		if err != nil {
 			return err
 		}
@@ -190,7 +190,7 @@ func (rq *replicateQueue) process(
 		// We require the lease in order to process replicas, so
 		// repl.store.StoreID() corresponds to the lease-holder's store ID.
 		rebalanceStore := rq.allocator.RebalanceTarget(
-			zone.ReplicaAttrs[0], desc.Replicas, repl.store.StoreID())
+			zone.Constraints, desc.Replicas, repl.store.StoreID())
 		if rebalanceStore == nil {
 			log.VTracef(1, ctx, "%s: no suitable rebalance target", repl)
 			// No action was necessary and no rebalance target was found. Return

--- a/storage/simulation/range.go
+++ b/storage/simulation/range.go
@@ -114,7 +114,7 @@ func (r *Range) splitRange(originalRange *Range) {
 // getAllocateTarget queries the allocator for the store that would be the best
 // candidate to take on a new replica.
 func (r *Range) getAllocateTarget() (roachpb.StoreID, error) {
-	newStore, err := r.allocator.AllocateTarget(r.zone.ReplicaAttrs[0], r.desc.Replicas, true)
+	newStore, err := r.allocator.AllocateTarget(r.zone.Constraints, r.desc.Replicas, true)
 	if err != nil {
 		return 0, err
 	}
@@ -137,7 +137,7 @@ func (r *Range) getRemoveTarget() (roachpb.StoreID, error) {
 // candidate to add a replica for rebalancing. Returns true only if a target is
 // found.
 func (r *Range) getRebalanceTarget(storeID roachpb.StoreID) (roachpb.StoreID, bool) {
-	rebalanceTarget := r.allocator.RebalanceTarget(r.zone.ReplicaAttrs[0], r.desc.Replicas, storeID)
+	rebalanceTarget := r.allocator.RebalanceTarget(r.zone.Constraints, r.desc.Replicas, storeID)
 	if rebalanceTarget == nil {
 		return 0, false
 	}
@@ -153,7 +153,7 @@ func (r *Range) String() string {
 	sort.Sort(storeIDs)
 
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "Range: %3d, Factor: %d, Stores: [", r.desc.RangeID, len(r.zone.ReplicaAttrs))
+	fmt.Fprintf(&buf, "Range: %3d, Factor: %d, Stores:[", r.desc.RangeID, r.zone.NumReplicas)
 
 	first := true
 	for _, storeID := range storeIDs {

--- a/storage/store.go
+++ b/storage/store.go
@@ -2913,7 +2913,7 @@ func (s *Store) computeReplicationStatus(now int64) (
 			// TODO(bram): #4564 Compare attributes of the stores so we can
 			// track ranges that have enough replicas but still need to be
 			// migrated onto nodes with the desired attributes.
-			if len(raftStatus.Progress) >= len(zoneConfig.ReplicaAttrs) {
+			if len(raftStatus.Progress) >= int(zoneConfig.NumReplicas) {
 				replicatedRangeCount++
 			}
 

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
@@ -104,7 +105,7 @@ const (
 )
 
 // match checks the store against the attributes and returns a storeMatch.
-func (sd *storeDetail) match(now time.Time, required roachpb.Attributes) storeMatch {
+func (sd *storeDetail) match(now time.Time, constraints config.Constraints) storeMatch {
 	// The store must be alive and it must have a descriptor to be considered
 	// alive.
 	if sd.dead || sd.desc == nil {
@@ -112,8 +113,15 @@ func (sd *storeDetail) match(now time.Time, required roachpb.Attributes) storeMa
 	}
 
 	// Does the store match the attributes?
-	if !required.IsSubset(*sd.desc.CombinedAttrs()) {
-		return storeMatchAlive
+	m := map[string]struct{}{}
+	for _, s := range sd.desc.CombinedAttrs().Attrs {
+		m[s] = struct{}{}
+	}
+	for _, c := range constraints.Constraints {
+		// TODO(d4l3k): Locality constraints, number of matches.
+		if _, ok := m[c.Value]; !ok {
+			return storeMatchAlive
+		}
 	}
 
 	// The store must not have a recent declined reservation to be available.
@@ -469,7 +477,7 @@ func (sl *StoreList) add(s roachpb.StoreDescriptor) {
 // TODO(embark, spencer): consider using a reverse index map from
 // Attr->stores, for efficiency. Ensure that entries in this map still
 // have an opportunity to be garbage collected.
-func (sp *StorePool) getStoreList(required roachpb.Attributes, deterministic bool) (StoreList, int, int) {
+func (sp *StorePool) getStoreList(constraints config.Constraints, deterministic bool) (StoreList, int, int) {
 	sp.mu.RLock()
 	defer sp.mu.RUnlock()
 
@@ -488,7 +496,8 @@ func (sp *StorePool) getStoreList(required roachpb.Attributes, deterministic boo
 	var throttledStoreCount int
 	for _, storeID := range storeIDs {
 		detail := sp.mu.stores[storeID]
-		matched := detail.match(now, required)
+		// TODO(d4l3k): Sort by number of matches.
+		matched := detail.match(now, constraints)
 		switch matched {
 		case storeMatchAlive:
 			aliveStoreCount++

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/base"
+	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/rpc"
@@ -215,13 +216,13 @@ func TestStorePoolDies(t *testing.T) {
 // verifyStoreList ensures that the returned list of stores is correct.
 func verifyStoreList(
 	sp *StorePool,
-	requiredAttrs []string,
+	constraints config.Constraints,
 	expected []int,
 	expectedAliveStoreCount int,
 	expectedThrottledStoreCount int,
 ) error {
 	var actual []int
-	sl, aliveStoreCount, throttledStoreCount := sp.getStoreList(roachpb.Attributes{Attrs: requiredAttrs}, false)
+	sl, aliveStoreCount, throttledStoreCount := sp.getStoreList(constraints, false)
 	if aliveStoreCount != expectedAliveStoreCount {
 		return errors.Errorf("expected AliveStoreCount %d does not match actual %d",
 			expectedAliveStoreCount, aliveStoreCount)
@@ -249,9 +250,10 @@ func TestStorePoolGetStoreList(t *testing.T) {
 	stopper, g, _, sp := createTestStorePool(TestTimeUntilStoreDeadOff)
 	defer stopper.Stop()
 	sg := gossiputil.NewStoreGossiper(g)
+	constraints := config.Constraints{Constraints: []config.Constraint{{Value: "ssd"}, {Value: "dc"}}}
 	required := []string{"ssd", "dc"}
 	// Nothing yet.
-	if sl, _, _ := sp.getStoreList(roachpb.Attributes{Attrs: required}, false); len(sl.stores) != 0 {
+	if sl, _, _ := sp.getStoreList(constraints, false); len(sl.stores) != 0 {
 		t.Errorf("expected no stores, instead %+v", sl.stores)
 	}
 
@@ -296,7 +298,7 @@ func TestStorePoolGetStoreList(t *testing.T) {
 		&declinedStore,
 	}, t)
 
-	if err := verifyStoreList(sp, required, []int{
+	if err := verifyStoreList(sp, constraints, []int{
 		int(matchingStore.StoreID),
 		int(supersetStore.StoreID),
 		int(deadStore.StoreID),
@@ -311,7 +313,7 @@ func TestStorePoolGetStoreList(t *testing.T) {
 	sp.mu.stores[declinedStore.StoreID].throttledUntil = sp.clock.Now().GoTime().Add(time.Hour)
 	sp.mu.Unlock()
 
-	if err := verifyStoreList(sp, required, []int{
+	if err := verifyStoreList(sp, constraints, []int{
 		int(matchingStore.StoreID),
 		int(supersetStore.StoreID),
 	}, 5, 1); err != nil {
@@ -428,7 +430,7 @@ func TestStorePoolDefaultState(t *testing.T) {
 		t.Errorf("expected 0 dead replicas; got %v", dead)
 	}
 
-	sl, alive, throttled := sp.getStoreList(roachpb.Attributes{}, true)
+	sl, alive, throttled := sp.getStoreList(config.Constraints{}, true)
 	if len(sl.stores) > 0 {
 		t.Errorf("expected no live stores; got list of %v", sl)
 	}

--- a/ui/app/containers/databases/tableDetails.tsx
+++ b/ui/app/containers/databases/tableDetails.tsx
@@ -63,7 +63,7 @@ class TableMain extends React.Component<TableMainProps, {}> {
     if (tableDetails) {
       let ranges = tableDetails.range_count.toNumber();
       let createTableStatement = tableDetails.create_table_statement;
-      let replicationFactor = tableDetails.zone_config.replica_attrs.length;
+      let replicationFactor = tableDetails.zone_config.num_replicas;
       let targetRangeSize = tableDetails.zone_config.range_max_bytes.toNumber();
       let tableSize = tableStats && (tableStats.stats.live_bytes.toNumber() + tableStats.stats.key_bytes.toNumber());
 

--- a/ui/app/js/protos.js
+++ b/ui/app/js/protos.js
@@ -1612,6 +1612,74 @@ module.exports = require("protobufjs").newBuilder({})['import']({
                     ]
                 },
                 {
+                    "name": "Constraint",
+                    "options": {
+                        "(gogoproto.goproto_stringer)": false
+                    },
+                    "fields": [
+                        {
+                            "rule": "optional",
+                            "type": "Type",
+                            "name": "type",
+                            "id": 1,
+                            "options": {
+                                "(gogoproto.nullable)": false
+                            }
+                        },
+                        {
+                            "rule": "optional",
+                            "type": "string",
+                            "name": "key",
+                            "id": 2,
+                            "options": {
+                                "(gogoproto.nullable)": false
+                            }
+                        },
+                        {
+                            "rule": "optional",
+                            "type": "string",
+                            "name": "value",
+                            "id": 3,
+                            "options": {
+                                "(gogoproto.nullable)": false
+                            }
+                        }
+                    ],
+                    "enums": [
+                        {
+                            "name": "Type",
+                            "values": [
+                                {
+                                    "name": "POSITIVE",
+                                    "id": 0
+                                },
+                                {
+                                    "name": "REQUIRED",
+                                    "id": 1
+                                },
+                                {
+                                    "name": "PROHIBITED",
+                                    "id": 2
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "Constraints",
+                    "fields": [
+                        {
+                            "rule": "repeated",
+                            "type": "Constraint",
+                            "name": "constraints",
+                            "id": 6,
+                            "options": {
+                                "(gogoproto.nullable)": false
+                            }
+                        }
+                    ]
+                },
+                {
                     "name": "ZoneConfig",
                     "fields": [
                         {
@@ -1620,8 +1688,9 @@ module.exports = require("protobufjs").newBuilder({})['import']({
                             "name": "replica_attrs",
                             "id": 1,
                             "options": {
+                                "deprecated": true,
                                 "(gogoproto.nullable)": false,
-                                "(gogoproto.moretags)": "yaml:\\\"replicas,omitempty\\\""
+                                "(gogoproto.moretags)": "yaml:\\\",omitempty\\\""
                             }
                         },
                         {
@@ -1652,6 +1721,26 @@ module.exports = require("protobufjs").newBuilder({})['import']({
                             "options": {
                                 "(gogoproto.nullable)": false,
                                 "(gogoproto.customname)": "GC"
+                            }
+                        },
+                        {
+                            "rule": "optional",
+                            "type": "int32",
+                            "name": "num_replicas",
+                            "id": 5,
+                            "options": {
+                                "(gogoproto.nullable)": false,
+                                "(gogoproto.moretags)": "yaml:\\\"num_replicas\\\""
+                            }
+                        },
+                        {
+                            "rule": "optional",
+                            "type": "Constraints",
+                            "name": "constraints",
+                            "id": 6,
+                            "options": {
+                                "(gogoproto.nullable)": false,
+                                "(gogoproto.moretags)": "yaml:\\\"constraints,flow\\\""
                             }
                         }
                     ]

--- a/ui/generated/protos.d.ts
+++ b/ui/generated/protos.d.ts
@@ -2547,6 +2547,8 @@ export interface configBuilder {
 	decode(buffer: ByteBuffer) : configMessage;
 	decode64(buffer: string) : configMessage;
 	GCPolicy: config.GCPolicyBuilder;
+	Constraint: config.ConstraintBuilder;
+	Constraints: config.ConstraintsBuilder;
 	ZoneConfig: config.ZoneConfigBuilder;
 	SystemConfig: config.SystemConfigBuilder;
 	
@@ -2592,6 +2594,106 @@ export interface GCPolicyBuilder {
 
 declare module cockroach.config {
 
+	export interface Constraint {
+
+		
+
+type?: Constraint.Type;
+		
+
+getType?() : Constraint.Type;
+		setType?(type : Constraint.Type): void;
+		
+
+
+
+key?: string;
+		
+
+getKey?() : string;
+		setKey?(key : string): void;
+		
+
+
+
+value?: string;
+		
+
+getValue?() : string;
+		setValue?(value : string): void;
+		
+
+
+
+}
+
+	export interface ConstraintMessage extends Constraint {
+	toArrayBuffer(): ArrayBuffer;
+	encode(): ByteBuffer;
+	encodeJSON(): string;
+	toBase64(): string;
+	toString(): string;
+}
+
+export interface ConstraintBuilder {
+	new(data?: Constraint): ConstraintMessage;
+	decode(buffer: ArrayBuffer) : ConstraintMessage;
+	decode(buffer: ByteBuffer) : ConstraintMessage;
+	decode64(buffer: string) : ConstraintMessage;
+	Type: Constraint.Type;
+	
+}
+
+}
+
+declare module cockroach.config.Constraint {
+	export const enum Type {
+		POSITIVE = 0,
+		REQUIRED = 1,
+		PROHIBITED = 2,
+		
+}
+}
+
+
+declare module cockroach.config {
+
+	export interface Constraints {
+
+		
+
+constraints?: Constraint[];
+		
+
+getConstraints?() : Constraint[];
+		setConstraints?(constraints : Constraint[]): void;
+		
+
+
+
+}
+
+	export interface ConstraintsMessage extends Constraints {
+	toArrayBuffer(): ArrayBuffer;
+	encode(): ByteBuffer;
+	encodeJSON(): string;
+	toBase64(): string;
+	toString(): string;
+}
+
+export interface ConstraintsBuilder {
+	new(data?: Constraints): ConstraintsMessage;
+	decode(buffer: ArrayBuffer) : ConstraintsMessage;
+	decode(buffer: ByteBuffer) : ConstraintsMessage;
+	decode64(buffer: string) : ConstraintsMessage;
+	
+}
+
+}
+
+
+declare module cockroach.config {
+
 	export interface ZoneConfig {
 
 		
@@ -2628,6 +2730,24 @@ gc?: GCPolicy;
 
 getGc?() : GCPolicy;
 		setGc?(gc : GCPolicy): void;
+		
+
+
+
+num_replicas?: number;
+		
+
+getNumReplicas?() : number;
+		setNumReplicas?(numReplicas : number): void;
+		
+
+
+
+constraints?: Constraints;
+		
+
+getConstraints?() : Constraints;
+		setConstraints?(constraints : Constraints): void;
 		
 
 

--- a/ui/generated/protos.json
+++ b/ui/generated/protos.json
@@ -1611,6 +1611,74 @@
                     ]
                 },
                 {
+                    "name": "Constraint",
+                    "options": {
+                        "(gogoproto.goproto_stringer)": false
+                    },
+                    "fields": [
+                        {
+                            "rule": "optional",
+                            "type": "Type",
+                            "name": "type",
+                            "id": 1,
+                            "options": {
+                                "(gogoproto.nullable)": false
+                            }
+                        },
+                        {
+                            "rule": "optional",
+                            "type": "string",
+                            "name": "key",
+                            "id": 2,
+                            "options": {
+                                "(gogoproto.nullable)": false
+                            }
+                        },
+                        {
+                            "rule": "optional",
+                            "type": "string",
+                            "name": "value",
+                            "id": 3,
+                            "options": {
+                                "(gogoproto.nullable)": false
+                            }
+                        }
+                    ],
+                    "enums": [
+                        {
+                            "name": "Type",
+                            "values": [
+                                {
+                                    "name": "POSITIVE",
+                                    "id": 0
+                                },
+                                {
+                                    "name": "REQUIRED",
+                                    "id": 1
+                                },
+                                {
+                                    "name": "PROHIBITED",
+                                    "id": 2
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "Constraints",
+                    "fields": [
+                        {
+                            "rule": "repeated",
+                            "type": "Constraint",
+                            "name": "constraints",
+                            "id": 6,
+                            "options": {
+                                "(gogoproto.nullable)": false
+                            }
+                        }
+                    ]
+                },
+                {
                     "name": "ZoneConfig",
                     "fields": [
                         {
@@ -1619,8 +1687,9 @@
                             "name": "replica_attrs",
                             "id": 1,
                             "options": {
+                                "deprecated": true,
                                 "(gogoproto.nullable)": false,
-                                "(gogoproto.moretags)": "yaml:\\\"replicas,omitempty\\\""
+                                "(gogoproto.moretags)": "yaml:\\\",omitempty\\\""
                             }
                         },
                         {
@@ -1651,6 +1720,26 @@
                             "options": {
                                 "(gogoproto.nullable)": false,
                                 "(gogoproto.customname)": "GC"
+                            }
+                        },
+                        {
+                            "rule": "optional",
+                            "type": "int32",
+                            "name": "num_replicas",
+                            "id": 5,
+                            "options": {
+                                "(gogoproto.nullable)": false,
+                                "(gogoproto.moretags)": "yaml:\\\"num_replicas\\\""
+                            }
+                        },
+                        {
+                            "rule": "optional",
+                            "type": "Constraints",
+                            "name": "constraints",
+                            "id": 6,
+                            "options": {
+                                "(gogoproto.nullable)": false,
+                                "(gogoproto.moretags)": "yaml:\\\"constraints,flow\\\""
                             }
                         }
                     ]


### PR DESCRIPTION
Converts ZoneConfig to the new format specified in the expressive ZoneConfig
RFC.  This is intermediate work on #4868.
https://github.com/cockroachdb/cockroach/blob/develop/docs/RFCS/expressive_zone_config.md
- Allocator and StorePool use []config.Constraint instead of roachpb.Attributes
  since the new type allows for different types of constraint.
- Adds a `ZoneConfigLegacy` struct for upgrades to the new format.
- Adds a `ZoneConfigHuman` struct for easier specification on the command line.

@petermattis @bdarnell

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8627)

<!-- Reviewable:end -->
