### PR TITLE
sql: append panic-causing SQL to error string

### DIFF
--- a/sql/executor.go
+++ b/sql/executor.go
@@ -387,6 +387,13 @@ func (e *Executor) ExecuteStatements(
 	session.planner.resetForBatch(e)
 	session.planner.semaCtx.Placeholders.Assign(pinfo)
 
+	defer func() {
+		if r := recover(); r != nil {
+			// On a panic, prepend the executed SQL.
+			panic(fmt.Errorf("%s: %s", stmts, r))
+		}
+	}()
+
 	// Send the Request for SQL execution and set the application-level error
 	// for each result in the reply.
 	return e.execRequest(session, stmts)


### PR DESCRIPTION
Especially useful during random testing.

See #7970

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8632)

<!-- Reviewable:end -->
