### PR TITLE
Use a 100% unreachable address instead of a recently closed port

### DIFF
--- a/gossip/storage_test.go
+++ b/gossip/storage_test.go
@@ -17,7 +17,6 @@
 package gossip_test
 
 import (
-	"net"
 	"reflect"
 	"sort"
 	"strings"
@@ -219,14 +218,7 @@ func TestGossipStorageCleanup(t *testing.T) {
 	network := simulation.NewNetwork(numNodes, false)
 	defer network.Stop()
 
-	// Create a definitely closed address.
-	ln, err := net.Listen("tcp", util.TestAddr.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	closedAddr := ln.Addr()
-	ln.Close()
-
+	const notReachableAddr = "localhost:0"
 	const invalidAddr = "10.0.0.1000:3333333"
 	// Set storage for each of the nodes.
 	addresses := make(unresolvedAddrSlice, len(network.Nodes))
@@ -237,7 +229,7 @@ func TestGossipStorageCleanup(t *testing.T) {
 		if err := stores[i].WriteBootstrapInfo(&gossip.BootstrapInfo{
 			Addresses: []util.UnresolvedAddr{
 				util.MakeUnresolvedAddr("tcp", network.Nodes[(i+1)%numNodes].Addr().String()), // node i+1 address
-				util.MakeUnresolvedAddr(closedAddr.Network(), closedAddr.String()),            // valid but closed address
+				util.MakeUnresolvedAddr("tcp", notReachableAddr),                              // unreachable address
 				util.MakeUnresolvedAddr("tcp", invalidAddr),                                   // invalid address
 			},
 		}); err != nil {


### PR DESCRIPTION
We were previously hoping that the OS wouldn't resuscitate a recently
closed port, but this apparently isn't correct. In fact, in #8634,
a stress test of the storage cleanup gossip test was most likely
running at the same time as the gossip convergence test on the same
machine and the two tests ended up talking to each other on gossip.

The theory is that the cleanup test opened a port, closed it and
proceeded to use that address as an invalid, unreachable example.
Meanwhile, the convergence test ran and reused that closed port,
causing the two independent tests to share gossip.

Fixes #8634

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8637)

<!-- Reviewable:end -->
