### PR TITLE
server: Clear the env cache after resetting environment variables

### DIFF
--- a/server/context_test.go
+++ b/server/context_test.go
@@ -117,6 +117,7 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		if err := os.Unsetenv("COCKROACH_RESERVATIONS_ENABLED"); err != nil {
 			t.Fatal(err)
 		}
+		envutil.ClearEnvCache()
 	}
 	defer resetEnvVar()
 


### PR DESCRIPTION
The cached values of these variables was causing log spam in all
subsequent tests in the package.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8653)

<!-- Reviewable:end -->
