### PR TITLE
*: format maybe-nil errors as %v

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -55,3 +55,12 @@ Exception when omitting repeated types for consecutive arguments:
 short and related arguments (e.g. `start, end int64`) should either go on the same line
 or the type should be repeated on each line -- no argument should appear by itself
 on a line with no type (confusing and brittle when edited).
+
+### fmt Verbs
+
+Prefer the most specific verb for your use. In other words, prefer to avoid %v
+when possible. However, %v is to be used when formatting bindings which might
+be nil and which do not already handle nil formatting. Notably, nil errors
+formatted as %s will render as "%!s(<nil>)" while nil errors formatted as %v
+will render as "<nil>". Therefore, prefer %v when formatting errors which are
+not known to be non-nil.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -350,7 +350,7 @@ func TestClientRunTransaction(t *testing.T) {
 		if commit != (err == nil) {
 			t.Errorf("expected success? %t; got %s", commit, err)
 		} else if !commit && !testutils.IsError(err, "purposefully failing transaction") {
-			t.Errorf("unexpected failure with !commit: %s", err)
+			t.Errorf("unexpected failure with !commit: %v", err)
 		}
 
 		// Verify the value is now visible on commit == true, and not visible otherwise.
@@ -788,11 +788,11 @@ func TestClientPermissions(t *testing.T) {
 	for tcNum, tc := range testCases {
 		err := tc.client.Put(tc.path, value)
 		if (err == nil) != tc.allowed || (!tc.allowed && !testutils.IsError(err, matchErr)) {
-			t.Errorf("#%d: expected allowed=%t, got err=%s", tcNum, tc.allowed, err)
+			t.Errorf("#%d: expected allowed=%t, got err=%v", tcNum, tc.allowed, err)
 		}
 		_, err = tc.client.Get(tc.path)
 		if (err == nil) != tc.allowed || (!tc.allowed && !testutils.IsError(err, matchErr)) {
-			t.Errorf("#%d: expected allowed=%t, got err=%s", tcNum, tc.allowed, err)
+			t.Errorf("#%d: expected allowed=%t, got err=%v", tcNum, tc.allowed, err)
 		}
 	}
 }

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -123,7 +123,7 @@ func TestKeyAddressError(t *testing.T) {
 				t.Errorf("expected addressing key %q to throw error, but it returned address %q",
 					key, addr)
 			} else if !testutils.IsError(err, regexp) {
-				t.Errorf("expected addressing key %q to throw error matching %s, but got error %s",
+				t.Errorf("expected addressing key %q to throw error matching %s, but got error %v",
 					key, regexp, err)
 			}
 		}
@@ -228,10 +228,8 @@ func TestMetaScanBounds(t *testing.T) {
 	for i, test := range testCases {
 		resStart, resEnd, err := MetaScanBounds(test.key)
 
-		if err != nil && !testutils.IsError(err, test.expError) {
-			t.Errorf("expected error: %s ; got %s", test.expError, err)
-		} else if err == nil && test.expError != "" {
-			t.Errorf("expected error: %s", test.expError)
+		if !(test.expError == "" && err == nil || testutils.IsError(err, test.expError)) {
+			t.Errorf("expected error: %s ; got %v", test.expError, err)
 		}
 
 		if !resStart.Equal(test.expStart) || !resEnd.Equal(test.expEnd) {
@@ -299,7 +297,7 @@ func TestMetaReverseScanBounds(t *testing.T) {
 		resStart, resEnd, err := MetaReverseScanBounds(roachpb.RKey(test.key))
 
 		if err != nil && !testutils.IsError(err, test.expError) {
-			t.Errorf("expected error: %s ; got %s", test.expError, err)
+			t.Errorf("expected error: %s ; got %v", test.expError, err)
 		} else if err == nil && test.expError != "" {
 			t.Errorf("expected error: %s", test.expError)
 		}

--- a/kv/db_test.go
+++ b/kv/db_test.go
@@ -196,10 +196,8 @@ func TestKVDBInternalMethods(t *testing.T) {
 		b := &client.Batch{}
 		b.AddRawRequest(args)
 		err := db.Run(b)
-		if err == nil {
-			t.Errorf("%d: unexpected success calling %s", i, args.Method())
-		} else if !testutils.IsError(err, "contains an internal request|contains commit trigger") {
-			t.Errorf("%d: unexpected error for %s: %s", i, args.Method(), err)
+		if !testutils.IsError(err, "contains an internal request|contains commit trigger") {
+			t.Errorf("%d: unexpected error for %s: %v", i, args.Method(), err)
 		}
 	}
 }

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -377,7 +377,7 @@ func TestSendNext_AllRetryableApplicationErrors(t *testing.T) {
 	} else if _, ok := bc.Err.(*roachpb.SendError); !ok {
 		t.Fatalf("expected SendError, got err=%s", bc.Err)
 	} else if exp := "range 1 was not found"; !testutils.IsError(bc.Err, exp) {
-		t.Errorf("expected SendError to contain %q, but got %s", exp, bc.Err)
+		t.Errorf("expected SendError to contain %q, but got %v", exp, bc.Err)
 	}
 }
 

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -1241,7 +1241,7 @@ func TestTxnAbandonCount(t *testing.T) {
 
 		return nil
 	}); !testutils.IsError(err, "writing transaction timed out") {
-		t.Fatalf("unexpected error: %s", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -1277,12 +1277,10 @@ func TestTxnReadAfterAbandon(t *testing.T) {
 		checkTxnMetrics(t, sender, "abandon txn", 0, 0, 1, 0, 0)
 
 		_, err := txn.Get(key)
-		if err == nil {
-			t.Fatalf("Get succeeded on abandoned txn")
-		} else if !testutils.IsError(err, "writing transaction timed out") {
-			t.Fatalf("unexpected error from Get on abandoned txn: %s", err)
+		if !testutils.IsError(err, "writing transaction timed out") {
+			t.Fatalf("unexpected error from Get on abandoned txn: %v", err)
 		}
-		return err
+		return err // appease compiler
 	})
 
 	if err == nil {
@@ -1313,7 +1311,7 @@ func TestTxnAbortCount(t *testing.T) {
 
 		return errors.New(intentionalErrText)
 	}); !testutils.IsError(err, intentionalErrText) {
-		t.Fatalf("unexpected error: %s", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	teardownHeartbeats(sender)
 	checkTxnMetrics(t, sender, "abort txn", 0, 0, 0, 1, 0)

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -86,7 +86,7 @@ func TestTxnDBBasics(t *testing.T) {
 		if commit != (err == nil) {
 			t.Errorf("expected success? %t; got %s", commit, err)
 		} else if !commit && !testutils.IsError(err, "purposefully failing transaction") {
-			t.Errorf("unexpected failure with !commit: %s", err)
+			t.Errorf("unexpected failure with !commit: %v", err)
 		}
 
 		// Verify the value is now visible on commit == true, and not visible otherwise.

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -527,7 +527,7 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 			if err := nodeCtx.ctx.RemoteClocks.VerifyClockOffset(); testutils.IsError(err, errOffsetGreaterThanMaxOffset) {
 				t.Logf("max offset: %s - node %d with excessive clock offset of %s returned expected error: %s", maxOffset, i, nodeOffset, err)
 			} else {
-				t.Errorf("max offset: %s - node %d with excessive clock offset of %s returned unexpected error: %s", maxOffset, i, nodeOffset, err)
+				t.Errorf("max offset: %s - node %d with excessive clock offset of %s returned unexpected error: %v", maxOffset, i, nodeOffset, err)
 			}
 		} else {
 			if err := nodeCtx.ctx.RemoteClocks.VerifyClockOffset(); err != nil {

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -306,8 +306,9 @@ func TestAdminAPIDatabaseDoesNotExist(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 
-	if err := apiGet(s, "databases/I_DO_NOT_EXIST", nil); !testutils.IsError(err, "database.+does not exist") {
-		t.Fatalf("unexpected error: %s", err)
+	const errPattern = "database.+does not exist"
+	if err := apiGet(s, "databases/I_DO_NOT_EXIST", nil); !testutils.IsError(err, errPattern) {
+		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}
 }
 
@@ -320,7 +321,7 @@ func TestAdminAPIDatabaseSQLInjection(t *testing.T) {
 	const path = "databases/" + fakedb
 	const errPattern = `database \\"` + fakedb + `\\" does not exist`
 	if err := apiGet(s, path, nil); !testutils.IsError(err, errPattern) {
-		t.Fatalf("unexpected error: %s", err)
+		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}
 }
 
@@ -333,13 +334,13 @@ func TestAdminAPITableDoesNotExist(t *testing.T) {
 	const badDBPath = "databases/" + fakename + "/tables/foo"
 	const dbErrPattern = `database \\"` + fakename + `\\" does not exist`
 	if err := apiGet(s, badDBPath, nil); !testutils.IsError(err, dbErrPattern) {
-		t.Fatalf("unexpected error: %s", err)
+		t.Fatalf("unexpected error: %v\nexpected: %s", err, dbErrPattern)
 	}
 
 	const badTablePath = "databases/system/tables/" + fakename
 	const tableErrPattern = `table \\"system.` + fakename + `\\" does not exist`
 	if err := apiGet(s, badTablePath, nil); !testutils.IsError(err, tableErrPattern) {
-		t.Fatalf("unexpected error: %s", err)
+		t.Fatalf("unexpected error: %v\nexpected: %s", err, tableErrPattern)
 	}
 }
 
@@ -352,7 +353,7 @@ func TestAdminAPITableSQLInjection(t *testing.T) {
 	const path = "databases/system/tables/" + fakeTable
 	const errPattern = `table \"system.\\\"` + fakeTable + `\\\"\" does not exist`
 	if err := apiGet(s, path, nil); !testutils.IsError(err, regexp.QuoteMeta(errPattern)) {
-		t.Fatalf("unexpected error: %s\nexpected: %s", err, errPattern)
+		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}
 }
 
@@ -745,8 +746,9 @@ func TestAdminAPIUIData(t *testing.T) {
 
 	// Basic tests.
 	var badResp serverpb.GetUIDataResponse
-	if err := apiGet(s, "uidata", &badResp); !testutils.IsError(err, "400 Bad Request") {
-		t.Fatalf("unexpected error: %v", err)
+	const errPattern = "400 Bad Request"
+	if err := apiGet(s, "uidata", &badResp); !testutils.IsError(err, errPattern) {
+		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}
 
 	mustSetUIData(map[string][]byte{"k1": []byte("v1")})

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -69,7 +69,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 
 	// Database creation should fail, and nothing should have been written.
 	if _, err := sqlDB.Exec(`CREATE DATABASE test`); !testutils.IsError(err, "unexpected value") {
-		t.Fatalf("unexpected error %s", err)
+		t.Fatalf("unexpected error %v", err)
 	}
 
 	if ir, err := kvDB.Get(keys.DescIDGenerator); err != nil {

--- a/sql/drop_test.go
+++ b/sql/drop_test.go
@@ -273,7 +273,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	// Test that deleted table cannot be used. This prevents regressions where
 	// name -> descriptor ID caches might make this statement erronously work.
 	if _, err := sqlDB.Exec(`SELECT * FROM t.kv`); !testutils.IsError(err, `table "t.kv" does not exist`) {
-		t.Fatalf("different error than expected: %s", err)
+		t.Fatalf("different error than expected: %v", err)
 	}
 
 	if kvs, err := kvDB.Scan(tableStartKey, tableEndKey, 0); err != nil {
@@ -327,7 +327,7 @@ CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR);
 	// until the schema changer runs, but we shouldn't be able to ALTER it.
 	if _, err := tx.Exec(`ALTER TABLE t.kv ADD COLUMN w CHAR`); !testutils.IsError(err,
 		`table "kv" has been deleted`) {
-		t.Fatalf("different error than expected: %s", err)
+		t.Fatalf("different error than expected: %v", err)
 	}
 
 	// Can't commit after ALTER errored, so we ROLLBACK.

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -452,7 +452,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 	// already had.
 	_, err = t.acquire(1, tableDesc.ID, tableDesc.Version+1)
 	if !testutils.IsError(err, "table is being deleted") {
-		t.Fatalf("got a different error than expected: %s", err)
+		t.Fatalf("got a different error than expected: %v", err)
 	}
 }
 
@@ -578,7 +578,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 	// Now we shouldn't be able to acquire any more.
 	_, err = acquire(s.(*server.TestServer), tableDesc.ID, 0)
 	if !testutils.IsError(err, "table is being deleted") {
-		t.Fatalf("got a different error than expected: %s", err)
+		t.Fatalf("got a different error than expected: %v", err)
 	}
 }
 
@@ -645,6 +645,6 @@ func runCommandAndExpireLease(t *testing.T, clock *hlc.Clock, sqlDB *gosql.DB, s
 
 	// Commit and see the aborted txn.
 	if err := txn.Commit(); !testutils.IsError(err, "pq: restart transaction: txn aborted") {
-		t.Fatalf("%s, err = %s", sql, err)
+		t.Fatalf("%s, err = %v", sql, err)
 	}
 }

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -773,16 +773,14 @@ func (t *logicTest) processTestFile(path string) error {
 // expected, or that an error was found when one was expected. Returns
 // "true" to indicate the behavior was as expected.
 func (t *logicTest) verifyError(
-	sql string, pos string, expectErr string, expectErrCode string, err error) bool {
+	sql, pos, expectErr, expectErrCode string,
+	err error,
+) bool {
 	if expectErr == "" && expectErrCode == "" && err != nil {
 		return t.unexpectedError(sql, pos, err)
 	}
 	if expectErr != "" && !testutils.IsError(err, expectErr) {
-		if err != nil {
-			t.Errorf("%s: expected %q, but found\n%s", pos, expectErr, err)
-		} else {
-			t.Errorf("%s: expected %q, but found success", pos, expectErr)
-		}
+		t.Errorf("%s: expected %q, but found %v", pos, expectErr, err)
 		return false
 	}
 	if expectErrCode != "" {

--- a/sql/parser/expr_test.go
+++ b/sql/parser/expr_test.go
@@ -87,7 +87,7 @@ func TestNormalizeNameInExpr(t *testing.T) {
 		v, err := vBase.NormalizeVarName()
 		if tc.err != "" {
 			if !testutils.IsError(err, tc.err) {
-				t.Fatalf("%s: expected %s, but found %s", tc.in, tc.err, err)
+				t.Fatalf("%s: expected %s, but found %v", tc.in, tc.err, err)
 			}
 			continue
 		}

--- a/sql/parser/function_name_test.go
+++ b/sql/parser/function_name_test.go
@@ -50,7 +50,7 @@ func TestNormalizeFunctionName(t *testing.T) {
 		_, err = q.Normalize()
 		if tc.err != "" {
 			if !testutils.IsError(err, tc.err) {
-				t.Fatalf("%s: expected %s, but found %s", tc.in, tc.err, err)
+				t.Fatalf("%s: expected %s, but found %v", tc.in, tc.err, err)
 			}
 			continue
 		}

--- a/sql/parser/scan_test.go
+++ b/sql/parser/scan_test.go
@@ -420,7 +420,7 @@ func TestScanError(t *testing.T) {
 			t.Errorf("%s: expected ERROR, but found %d", d.sql, id)
 		}
 		if !testutils.IsError(errors.New(lval.str), d.err) {
-			t.Errorf("%s: expected %s, but found %s", d.sql, d.err, lval.str)
+			t.Errorf("%s: expected %s, but found %v", d.sql, d.err, lval.str)
 		}
 	}
 }

--- a/sql/parser/table_name_test.go
+++ b/sql/parser/table_name_test.go
@@ -53,7 +53,7 @@ func TestNormalizeTableName(t *testing.T) {
 		}
 		if tc.err != "" {
 			if !testutils.IsError(err, tc.err) {
-				t.Fatalf("%s: expected %s, but found %s", tc.in, tc.err, err)
+				t.Fatalf("%s: expected %s, but found %v", tc.in, tc.err, err)
 			}
 			continue
 		}

--- a/sql/table_test.go
+++ b/sql/table_test.go
@@ -243,7 +243,7 @@ func TestPrimaryKeyUnspecified(t *testing.T) {
 	}
 	err = desc.AllocateIDs()
 	if !testutils.IsError(err, sqlbase.ErrMissingPrimaryKey.Error()) {
-		t.Fatalf("unexpected error: %s", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -317,7 +317,7 @@ BEGIN;
 	_, err := sqlDB.Exec("INSERT INTO t.test (k, v, t) VALUES ('g', 'hooly', cluster_logical_timestamp())")
 	if !testutils.IsError(
 		err, "encountered previous write with future timestamp") {
-		t.Errorf("didn't get expected injected error. Got: %s", err)
+		t.Errorf("didn't get expected injected error. Got: %v", err)
 	}
 }
 
@@ -383,7 +383,7 @@ func runTestTxn(t *testing.T, magicVals *filterVals, expectedErr string,
 	if retriesNeeded {
 		_, err = tx.Exec("INSERT INTO t.test (k, v) VALUES (1, 'boulanger')")
 		if !testutils.IsError(err, expectedErr) {
-			t.Fatalf("expected to fail here. err: %s", err)
+			t.Fatalf("expected to fail here. err: %v", err)
 		}
 		return isRetryableErr(err)
 	}
@@ -682,12 +682,12 @@ func TestRollbackToSavepointStatement(t *testing.T) {
 	// ROLLBACK TO SAVEPOINT without a transaction
 	_, err := sqlDB.Exec("ROLLBACK TO SAVEPOINT cockroach_restart")
 	if !testutils.IsError(err, "the transaction is not in a retriable state") {
-		t.Fatal("expected to fail here. err: ", err)
+		t.Fatalf("expected to fail here. err: %v", err)
 	}
 	// ROLLBACK TO SAVEPOINT with a wrong name
 	_, err = sqlDB.Exec("ROLLBACK TO SAVEPOINT foo")
 	if !testutils.IsError(err, "SAVEPOINT not supported except for COCKROACH_RESTART") {
-		t.Fatal("expected to fail here. err: ", err)
+		t.Fatalf("expected to fail here. err: %v", err)
 	}
 
 	// ROLLBACK TO SAVEPOINT in a non-retriable transaction
@@ -699,12 +699,12 @@ func TestRollbackToSavepointStatement(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err = tx.Exec("BOGUS SQL STATEMENT"); err == nil {
-		t.Fatalf("expected to fail here. err: %s", err)
+		t.Fatalf("expected to fail here. err: %v", err)
 	}
 	_, err = tx.Exec("ROLLBACK TO SAVEPOINT cockroach_restart")
 	if !testutils.IsError(err,
 		"SAVEPOINT COCKROACH_RESTART has not been used or a non-retriable error was encountered") {
-		t.Fatal("expected to fail here. err: ", err)
+		t.Fatalf("expected to fail here. err: %v", err)
 	}
 }
 
@@ -737,7 +737,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 	}
 	_, err = tx.Exec("INSERT INTO t.test (k, v) VALUES (0, 'test');")
 	if !testutils.IsError(err, "duplicate key value") {
-		t.Errorf("expected duplicate key error. Got: %s", err)
+		t.Errorf("expected duplicate key error. Got: %v", err)
 	}
 	if _, err := tx.Exec("ROLLBACK TO SAVEPOINT cockroach_restart"); !testutils.IsError(
 		err, "current transaction is aborted, commands ignored until end of "+
@@ -829,7 +829,7 @@ CREATE TABLE t.test (k TEXT PRIMARY KEY, v TEXT);
 INSERT INTO t.test (k, v) VALUES ('test_key', 'test_val');
 SELECT * from t.test WHERE k = 'test_key';
 `); !testutils.IsError(err, "pq: testError") {
-		t.Errorf("unexpected error %s", err)
+		t.Errorf("unexpected error %v", err)
 	}
 	if !hitError {
 		t.Errorf("expected to hit error, but it didn't happen")
@@ -859,7 +859,7 @@ func TestNonRetryableErrorFromCommit(t *testing.T) {
 	defer cleanupFilter()
 
 	if _, err := sqlDB.Exec("CREATE DATABASE t;"); !testutils.IsError(err, "pq: testError") {
-		t.Errorf("unexpected error %s", err)
+		t.Errorf("unexpected error %v", err)
 	}
 	if !hitError {
 		t.Errorf("expected to hit error, but it didn't happen")

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -2337,6 +2337,6 @@ func TestFailedPreemptiveSnapshot(t *testing.T) {
 	if err := rep.ChangeReplicas(context.Background(), roachpb.ADD_REPLICA,
 		roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3},
 		rep.Desc()); !testutils.IsError(err, expErr) {
-		t.Fatalf("expected %s; got %s", expErr, err)
+		t.Fatalf("expected %s; got %v", expErr, err)
 	}
 }

--- a/storage/client_replica_gc_test.go
+++ b/storage/client_replica_gc_test.go
@@ -79,7 +79,7 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 	// Make sure the range is removed from the store.
 	util.SucceedsSoon(t, func() error {
 		if _, err := mtc.stores[1].GetReplica(rangeID); !testutils.IsError(err, "range .* was not found") {
-			return errors.Errorf("expected range removal")
+			return errors.Errorf("expected range removal: %v", err) // NB: errors.Wrapf(nil, ...) returns nil.
 		}
 		return nil
 	})
@@ -118,7 +118,7 @@ func TestReplicaGCQueueDropReplicaGCOnScan(t *testing.T) {
 		store := mtc.stores[1]
 		store.ForceReplicaGCScanAndProcess()
 		if _, err := store.GetReplica(rangeID); !testutils.IsError(err, "range .* was not found") {
-			return errors.Errorf("expected range removal: %s", err)
+			return errors.Errorf("expected range removal: %v", err) // NB: errors.Wrapf(nil, ...) returns nil.
 		}
 		return nil
 	})

--- a/storage/engine/mvcc_test.go
+++ b/storage/engine/mvcc_test.go
@@ -799,7 +799,7 @@ func TestMVCCInlineWithTxn(t *testing.T) {
 
 	// Verify inline put with txn is an error.
 	if err = MVCCPut(context.Background(), engine, nil, testKey2, hlc.ZeroTimestamp, value2, txn2); !testutils.IsError(err, "writes not allowed within transactions") {
-		t.Errorf("unexpected success")
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 
@@ -3571,7 +3571,7 @@ func TestMVCCComputeStatsError(t *testing.T) {
 		mvccKey(roachpb.KeyMax), 100)
 	iter.Close()
 	if e := "unable to decode MVCCMetadata"; !testutils.IsError(err, e) {
-		t.Fatalf("expected %s", e)
+		t.Fatalf("expected %s, got %v", e, err)
 	}
 }
 

--- a/storage/engine/rocksdb_test.go
+++ b/storage/engine/rocksdb_test.go
@@ -212,7 +212,7 @@ func TestRocksDBOpenWithVersions(t *testing.T) {
 			continue
 		}
 		if !testutils.IsError(err, testCase.expectedErr) {
-			t.Errorf("%d: expected error '%s', actual '%s'", i, testCase.expectedErr, err)
+			t.Errorf("%d: expected error '%s', actual '%v'", i, testCase.expectedErr, err)
 		}
 	}
 }

--- a/storage/engine/version_test.go
+++ b/storage/engine/version_test.go
@@ -68,6 +68,6 @@ func TestVersions(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := getVersion(dir); !testutils.IsError(err, "is not formatted correctly") {
-		t.Errorf("expected error contains '%s', got '%s'", "is not formatted correctly", err)
+		t.Errorf("expected error contains '%s', got '%v'", "is not formatted correctly", err)
 	}
 }

--- a/storage/replica_state_test.go
+++ b/storage/replica_state_test.go
@@ -76,9 +76,8 @@ func TestSynthesizeHardState(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := synthesizeHardState(context.Background(), batch, testState, oldHS); ((err == nil) != (test.Err == "")) ||
-				(err != nil && !testutils.IsError(err, test.Err)) {
-				t.Fatalf("%d: %v (expected '%s')", i, err, test.Err)
+			if err := synthesizeHardState(context.Background(), batch, testState, oldHS); !(test.Err == "" && err == nil || testutils.IsError(err, test.Err)) {
+				t.Fatalf("%d: expected %s got %v", i, test.Err, err)
 			} else if err != nil {
 				// No further checking if we expected an error and got it.
 				return

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -553,16 +553,8 @@ func TestStorePoolReserve(t *testing.T) {
 			roachpb.RangeID(2),
 			100000,
 		)
-		if len(testCase.expErr) == 0 {
-			if err != nil {
-				t.Errorf("%d: expected no error, got %s", i, err)
-			}
-			continue
-		}
-		if err == nil {
-			t.Errorf("%d: expected an error:%s, got none", i, testCase.expErr)
-		} else if !testutils.IsError(err, testCase.expErr) {
-			t.Errorf("%d: expected error:%s, actual:%s", i, testCase.expErr, err)
+		if !(testCase.expErr == "" && err == nil || testutils.IsError(err, testCase.expErr)) {
+			t.Errorf("%d: expected error:%s, actual:%v", i, testCase.expErr, err)
 		}
 	}
 }

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -389,7 +389,7 @@ func TestStoreRemoveReplicaOldDescriptor(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := store.RemoveReplica(rep, *origDesc, true); !testutils.IsError(err, "replica ID has changed") {
-		t.Fatalf("expected error 'replica ID has changed' but got %s", err)
+		t.Fatalf("expected error 'replica ID has changed' but got %v", err)
 	}
 
 	// Now try a fresh descriptor and succeed.
@@ -413,16 +413,14 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 
 	// Verify that removal of a replica marks it as destroyed so that future raft
 	// commands on the Replica will silently be dropped.
-	err = rng1.withRaftGroup(func(r *raft.RawNode) error {
+	if err := rng1.withRaftGroup(func(r *raft.RawNode) error {
 		return errors.Errorf("unexpectedly created a raft group")
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	_, _, err = rng1.proposeRaftCommand(context.Background(), roachpb.BatchRequest{})
-	expected := "replica .* was garbage collected"
-	if !testutils.IsError(err, expected) {
+	const expected = "replica .* was garbage collected"
+	if _, _, err := rng1.proposeRaftCommand(context.Background(), roachpb.BatchRequest{}); !testutils.IsError(err, expected) {
 		t.Fatalf("expected error %s, but got %v", expected, err)
 	}
 }
@@ -2212,7 +2210,7 @@ func TestStoreRangePlaceholders(t *testing.T) {
 		t.Fatalf("could not re-add placeholder after removal, got %s", err)
 	}
 	if err := s.addPlaceholderLocked(placeholder1); !testutils.IsError(err, ".*overlaps with existing KeyRange") {
-		t.Fatalf("should not be able to add ReplicaPlaceholder for the same key twice, got: %s", err)
+		t.Fatalf("should not be able to add ReplicaPlaceholder for the same key twice, got: %v", err)
 	}
 
 	// Test cannot double delete a placeholder.
@@ -2220,7 +2218,7 @@ func TestStoreRangePlaceholders(t *testing.T) {
 		t.Fatalf("could not remove placeholder that was present, got %s", err)
 	}
 	if err := s.removePlaceholderLocked(placeholder1.rangeDesc.RangeID); !testutils.IsError(err, "cannot remove placeholder for RangeID \\d+; Placeholder doesn't exist") {
-		t.Fatalf("could not remove placeholder that was present, got %s", err)
+		t.Fatalf("could not remove placeholder that was present, got %v", err)
 	}
 
 	// This placeholder overlaps with an existing replica.
@@ -2234,11 +2232,11 @@ func TestStoreRangePlaceholders(t *testing.T) {
 
 	// Test that placeholder cannot clobber existing replica.
 	if err := s.addPlaceholderLocked(placeholder1); !testutils.IsError(err, ".*overlaps with existing KeyRange") {
-		t.Fatalf("should not be able to add ReplicaPlaceholder when Replica already exists, got: %s", err)
+		t.Fatalf("should not be able to add ReplicaPlaceholder when Replica already exists, got: %v", err)
 	}
 
 	// Test that Placeholder deletion doesn't delete replicas.
 	if err := s.removePlaceholderLocked(repID); !testutils.IsError(err, "cannot remove placeholder for RangeID \\d+; Placeholder doesn't exist") {
-		t.Fatalf("should not be able to process removeReplicaPlaceholder for a RangeID where a Replica exists, got: %s", err)
+		t.Fatalf("should not be able to process removeReplicaPlaceholder for a RangeID where a Replica exists, got: %v", err)
 	}
 }


### PR DESCRIPTION
This produces "<nil>" rather than "%!s(<nil>)".

PRing to master because this is a test-only change and affects workflow (so I'd like it to be on both branches).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8661)

<!-- Reviewable:end -->
