### PR TITLE
storage: update client raft unit tests to remove store gossiper

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/kr/pretty"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -40,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/storage/engine"
 	"github.com/cockroachdb/cockroach/storage/storagebase"
 	"github.com/cockroachdb/cockroach/testutils"
-	"github.com/cockroachdb/cockroach/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -661,18 +661,7 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 	mtc := startMultiTestContext(t, 3)
 	defer mtc.Stop()
 
-	// Initialize the gossip network.
-	storeDescs := make([]*roachpb.StoreDescriptor, 0, len(mtc.stores))
-	for _, s := range mtc.stores {
-		desc, err := s.Descriptor()
-		if err != nil {
-			t.Fatal(err)
-		}
-		storeDescs = append(storeDescs, desc)
-	}
-	for _, g := range mtc.gossips {
-		gossiputil.NewStoreGossiper(g).GossipStores(storeDescs, t)
-	}
+	mtc.initGossipNetwork()
 
 	// Once we know our peers, trigger a scan.
 	mtc.stores[0].ForceReplicationScanAndProcess()
@@ -691,6 +680,7 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 
 // TestStoreRangeCorruptionChangeReplicas verifies that the replication queue
 // will notice corrupted replicas and replace them.
+// TODO(bram): #8664 There's some flakiness in this test when stressed.
 func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	t.Skipf("#8664: flaky")
@@ -726,21 +716,9 @@ func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 	}
 	mtc.Start(t, numReplicas+extraStores)
 	defer mtc.Stop()
+	mtc.initGossipNetwork()
 
 	store0 := mtc.stores[0]
-
-	// Initialize the gossip network.
-	storeDescs := make([]*roachpb.StoreDescriptor, 0, len(mtc.stores))
-	for _, s := range mtc.stores {
-		desc, err := s.Descriptor()
-		if err != nil {
-			t.Fatal(err)
-		}
-		storeDescs = append(storeDescs, desc)
-	}
-	for _, g := range mtc.gossips {
-		gossiputil.NewStoreGossiper(g).GossipStores(storeDescs, t)
-	}
 
 	for i := 0; i < extraStores; i++ {
 		util.SucceedsSoon(t, func() error {
@@ -875,6 +853,7 @@ func TestStoreRangeDownReplicate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	mtc := startMultiTestContext(t, 5)
 	defer mtc.Stop()
+	mtc.initGossipNetwork()
 	store0 := mtc.stores[0]
 
 	// Split off a range from the initial range for testing; there are
@@ -899,19 +878,6 @@ func TestStoreRangeDownReplicate(t *testing.T) {
 	replica := store0.LookupReplica(rightKeyAddr, nil)
 	desc := replica.Desc()
 	mtc.replicateRange(desc.RangeID, 3, 4)
-
-	// Initialize the gossip network.
-	storeDescs := make([]*roachpb.StoreDescriptor, 0, len(mtc.stores))
-	for _, s := range mtc.stores {
-		desc, err := s.Descriptor()
-		if err != nil {
-			t.Fatal(err)
-		}
-		storeDescs = append(storeDescs, desc)
-	}
-	for _, g := range mtc.gossips {
-		gossiputil.NewStoreGossiper(g).GossipStores(storeDescs, t)
-	}
 
 	maxTimeout := time.After(10 * time.Second)
 	succeeded := false
@@ -1643,63 +1609,90 @@ func TestStoreRangeRebalance(t *testing.T) {
 		Deterministic:  true,
 	}
 
-	// Four stores.
-	mtc.Start(t, 4)
+	mtc.Start(t, 6)
 	defer mtc.Stop()
 
-	// Replicate the first range to the first three stores.
-	store0 := mtc.stores[0]
-	replica := store0.LookupReplica(roachpb.RKeyMin, nil)
-	desc := replica.Desc()
-	mtc.replicateRange(desc.RangeID, 1, 2)
+	splitKey := roachpb.Key("split")
+	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &splitArgs); err != nil {
+		t.Fatal(err)
+	}
 
-	// Initialize the gossip network with fake capacity data.
-	storeDescs := make([]*roachpb.StoreDescriptor, 0, len(mtc.stores))
-	for _, s := range mtc.stores {
-		desc, err := s.Descriptor()
-		if err != nil {
+	// The setup for this test is to have two ranges like so:
+	// s1:r1, s2:r1r2, s3:r1, s4:r2, s5:r2, s6:-
+	// and to rebalance range 1 away from store 2 to store 6:
+	// s1:r1, s2:r2, s3:r1, s4:r2, s5:r2, s6:r1
+
+	replica1 := mtc.stores[0].LookupReplica(roachpb.RKeyMin, nil)
+	mtc.replicateRange(replica1.Desc().RangeID, 1, 2)
+
+	replica2Key := roachpb.RKey(splitKey)
+	replica2 := mtc.stores[0].LookupReplica(replica2Key, nil)
+	mtc.replicateRange(replica2.Desc().RangeID, 1, 3, 4)
+	mtc.unreplicateRange(replica2.Desc().RangeID, 0)
+
+	countReplicas := func() map[roachpb.StoreID]int {
+		counts := make(map[roachpb.StoreID]int)
+		rangeDescA := getRangeMetadata(roachpb.RKeyMin, mtc, t)
+		for _, repl := range rangeDescA.Replicas {
+			counts[repl.StoreID]++
+		}
+		rangeDescB := getRangeMetadata(replica2Key, mtc, t)
+		for _, repl := range rangeDescB.Replicas {
+			counts[repl.StoreID]++
+		}
+		return counts
+	}
+
+	// Check the initial conditions.
+	expectedStart := map[roachpb.StoreID]int{
+		roachpb.StoreID(1): 1,
+		roachpb.StoreID(2): 2,
+		roachpb.StoreID(3): 1,
+		roachpb.StoreID(4): 1,
+		roachpb.StoreID(5): 1,
+	}
+	actualStart := countReplicas()
+	if !reflect.DeepEqual(expectedStart, actualStart) {
+		t.Fatalf("replicas are not distributed as expected %s", pretty.Diff(expectedStart, actualStart))
+	}
+
+	expected := map[roachpb.StoreID]int{
+		roachpb.StoreID(1): 1,
+		roachpb.StoreID(2): 1,
+		roachpb.StoreID(3): 1,
+		roachpb.StoreID(4): 1,
+		roachpb.StoreID(5): 1,
+		roachpb.StoreID(6): 1,
+	}
+
+	mtc.initGossipNetwork()
+	util.SucceedsSoon(t, func() error {
+		// As of this writing, replicas which hold their range's lease cannot
+		// be removed; forcefully transfer the lease for range 1 to another
+		// store to allow store 2's replica to be removed.
+		if err := mtc.transferLease(replica1.RangeID, mtc.stores[0]); err != nil {
 			t.Fatal(err)
 		}
-		desc.Capacity.RangeCount = 1
-		// Make sure store[1] is chosen as removal target.
-		if desc.StoreID == mtc.stores[1].StoreID() {
-			desc.Capacity.RangeCount = 4
+
+		// It takes at least two passes to achieve the final result. In the
+		// first pass, we add the replica to store 6. In the second pass, we
+		// remove the replica from store 2. Note that it can also take some time
+		// for the snapshot to arrive.
+		mtc.stores[0].ForceReplicationScanAndProcess()
+
+		// Gossip the stores so that the store pools are up to date. Note that
+		// there might be a delay between the call below and the asynchronous
+		// update of the store pools.
+		mtc.gossipStores()
+
+		// Exit when all stores have a single replica.
+		actual := countReplicas()
+		if !reflect.DeepEqual(expected, actual) {
+			return errors.Errorf("replicas are not distributed as expected %s", pretty.Diff(expected, actual))
 		}
-		storeDescs = append(storeDescs, desc)
-	}
-	for _, g := range mtc.gossips {
-		gossiputil.NewStoreGossiper(g).GossipStores(storeDescs, t)
-	}
-
-	// This can't use SucceedsSoon as using the exponential backoff mechanic
-	// won't work well with the forced replication scans.
-	maxTimeout := time.After(5 * time.Second)
-	succeeded := false
-	for !succeeded {
-		select {
-		case <-maxTimeout:
-			t.Fatal("Failed to rebalance replica within 5 seconds")
-		case <-time.After(10 * time.Millisecond):
-			// Look up the official range descriptor, make sure fourth store is on it.
-			rangeDesc := getRangeMetadata(roachpb.RKeyMin, mtc, t)
-
-			// Test if we have already succeeded.
-			for _, repl := range rangeDesc.Replicas {
-				if repl.StoreID == mtc.stores[3].StoreID() {
-					succeeded = true
-				}
-			}
-
-			if succeeded {
-				break
-			}
-
-			// NB: The store that we ask to perform rebalancing needs to be different
-			// than the one we've configured to rebalance away from above
-			// (i.e. store[1]) because we won't rebalance away from the lease holder.
-			mtc.stores[0].ForceReplicationScanAndProcess()
-		}
-	}
+		return nil
+	})
 
 	var generated int64
 	var normalApplied int64

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -359,6 +359,57 @@ func (m *multiTestContext) Stop() {
 	}
 }
 
+// gossipStores forces each store to gossip its store descriptor and then
+// blocks until all nodes have received these updated descriptors.
+func (m *multiTestContext) gossipStores() {
+	timestamps := make(map[string]int64)
+	for i := 0; i < len(m.stores); i++ {
+		if err := m.stores[i].GossipStore(context.Background()); err != nil {
+			m.t.Fatal(err)
+		}
+		infoStatus := m.gossips[i].GetInfoStatus()
+		storeKey := gossip.MakeStoreKey(m.stores[i].Ident.StoreID)
+		timestamps[storeKey] = infoStatus.Infos[storeKey].OrigStamp
+	}
+	// Wait until all stores know about each other.
+	util.SucceedsSoon(m.t, func() error {
+		for i := 0; i < len(m.stores); i++ {
+			nodeID := m.stores[i].Ident.NodeID
+			infoStatus := m.gossips[i].GetInfoStatus()
+			for storeKey, timestamp := range timestamps {
+				info, ok := infoStatus.Infos[storeKey]
+				if !ok {
+					return errors.Errorf("node %d does not have a storeDesc for %s yet", nodeID, storeKey)
+				}
+				if info.OrigStamp < timestamp {
+					return errors.Errorf("node %d's storeDesc for %s is not up to date", nodeID, storeKey)
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// initGossipNetwork gossips all store descriptors and waits until all
+// storePools have received those descriptors.
+func (m *multiTestContext) initGossipNetwork() {
+	m.gossipStores()
+	util.SucceedsSoon(m.t, func() error {
+		for i := 0; i < len(m.stores); i++ {
+			_, alive, _ := m.storePools[i].GetStoreList(
+				roachpb.Attributes{},
+				/* deterministic */ false,
+			)
+			if alive != len(m.stores) {
+				return errors.Errorf("node %d's store pool only has %d alive stores, expected %d",
+					m.stores[i].Ident.NodeID, alive, len(m.stores))
+			}
+		}
+		return nil
+	})
+	log.Info(context.Background(), "gossip network initialized")
+}
+
 type multiTestContextKVTransport struct {
 	mtc      *multiTestContext
 	ctx      context.Context
@@ -955,6 +1006,36 @@ func (m *multiTestContext) getRaftLeader(rangeID roachpb.RangeID) *storage.Repli
 		return nil
 	})
 	return raftLeaderRepl
+}
+
+// transferLease moves the lease for the specified rangeID to the destination
+// store. The destination store must have a replica of the range on it.
+func (m *multiTestContext) transferLease(rangeID roachpb.RangeID, destStore *storage.Store) error {
+	destReplica, err := destStore.GetReplica(rangeID)
+	if err != nil {
+		return err
+	}
+	origLeasePtr, _ := destReplica.GetLease()
+	if origLeasePtr == nil {
+		return errors.Errorf("could not get lease ptr from replica %s", destReplica)
+	}
+	originalStoreID := origLeasePtr.Replica.StoreID
+
+	// Get the replica that currently holds the lease.
+	var origStore *storage.Store
+	for _, store := range m.stores {
+		if store.Ident.StoreID == originalStoreID {
+			origStore = store
+			break
+		}
+	}
+
+	origRepl, err := origStore.GetReplica(destReplica.RangeID)
+	if err != nil {
+		return err
+	}
+
+	return origRepl.AdminTransferLease(destStore.Ident.StoreID)
 }
 
 // getArgs returns a GetRequest and GetResponse pair addressed to

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -165,3 +165,8 @@ func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
 	defer r.mu.Unlock()
 	return r.mu.tsCache.lowWater
 }
+
+// GetStoreList is the same function as GetStoreList exposed for tests only.
+func (sp *StorePool) GetStoreList(required roachpb.Attributes, deterministic bool) (StoreList, int, int) {
+	return sp.getStoreList(required, deterministic)
+}

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -463,7 +463,7 @@ func (sl *StoreList) add(s roachpb.StoreDescriptor) {
 	}
 }
 
-// GetStoreList returns a storeList that contains all active stores that
+// getStoreList returns a storeList that contains all active stores that
 // contain the required attributes and their associated stats. It also returns
 // the total number of alive and throttled stores.
 // TODO(embark, spencer): consider using a reverse index map from


### PR DESCRIPTION
This change alters the replication unit tests to use the normal pathway for
stores gossiping their descriptors.

Fixes #8263

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8668)

<!-- Reviewable:end -->
