### PR TITLE
Allow replica scanners to be disabled

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -131,7 +131,7 @@ type Context struct {
 	MetricsSampleInterval time.Duration
 
 	// ScanInterval determines a duration during which each range should be
-	// visited approximately once by the range scanner.
+	// visited approximately once by the range scanner. Set to 0 to disable.
 	// Environment Variable: COCKROACH_SCAN_INTERVAL
 	ScanInterval time.Duration
 
@@ -142,6 +142,7 @@ type Context struct {
 	ScanMaxIdleTime time.Duration
 
 	// ConsistencyCheckInterval determines the time between range consistency checks.
+	// Set to 0 to disable.
 	// Environment Variable: COCKROACH_CONSISTENCY_CHECK_INTERVAL
 	ConsistencyCheckInterval time.Duration
 

--- a/storage/scanner.go
+++ b/storage/scanner.go
@@ -17,8 +17,6 @@
 package storage
 
 import (
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"golang.org/x/net/context"
@@ -71,29 +69,37 @@ type replicaScanner struct {
 	replicas       replicaSet     // Replicas to be scanned
 	queues         []replicaQueue // Replica queues managed by this scanner
 	removed        chan *Replica  // Replicas to remove from queues
-	// Count of times and total duration through the scanning loop but locked by the completedScan
-	// mutex.
-	completedScan *sync.Cond
-	count         int64
-	total         time.Duration
-	// Some tests in this package disable scanning.
-	disabled int32 // updated atomically
+	// Count of times and total duration through the scanning loop.
+	mu struct {
+		syncutil.Mutex
+		count int64
+		total time.Duration
+		// Some tests in this package disable scanning.
+		disabled bool
+	}
+	// Used to notify processing loop if the disabled state changes.
+	setDisabledCh chan struct{}
 }
 
-// newReplicaScanner creates a new replica scanner with the provided loop intervals,
-// replica set, and replica queues.  If scanFn is not nil, after a complete
-// loop that function will be called.
+// newReplicaScanner creates a new replica scanner with the provided
+// loop intervals, replica set, and replica queues.  If scanFn is not
+// nil, after a complete loop that function will be called. If the
+// targetInterval is 0, the scanner is disabled.
 func newReplicaScanner(targetInterval, maxIdleTime time.Duration, replicas replicaSet) *replicaScanner {
-	if targetInterval <= 0 {
-		log.Fatalf(context.TODO(), "scanner interval must be greater than zero")
+	if targetInterval < 0 {
+		log.Fatalf(context.TODO(), "scanner interval must be greater than or equal to zero")
 	}
-	return &replicaScanner{
+	rs := &replicaScanner{
 		targetInterval: targetInterval,
 		maxIdleTime:    maxIdleTime,
 		replicas:       replicas,
 		removed:        make(chan *Replica, 10),
-		completedScan:  sync.NewCond(&syncutil.Mutex{}),
+		setDisabledCh:  make(chan struct{}, 1),
 	}
+	if targetInterval == 0 {
+		rs.SetDisabled(true)
+	}
+	return rs
 }
 
 // AddQueues adds a variable arg list of queues to the replica scanner.
@@ -113,26 +119,35 @@ func (rs *replicaScanner) Start(clock *hlc.Clock, stopper *stop.Stopper) {
 // Count returns the number of times the scanner has cycled through
 // all replicas.
 func (rs *replicaScanner) Count() int64 {
-	rs.completedScan.L.Lock()
-	defer rs.completedScan.L.Unlock()
-	return rs.count
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.mu.count
 }
 
 // SetDisabled turns replica scanning off or on as directed. Note that while
 // disabled, removals are still processed.
 func (rs *replicaScanner) SetDisabled(disabled bool) {
-	if disabled {
-		atomic.StoreInt32(&rs.disabled, 1)
-	} else {
-		atomic.StoreInt32(&rs.disabled, 0)
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	rs.mu.disabled = disabled
+	// The select prevents blocking on the channel.
+	select {
+	case rs.setDisabledCh <- struct{}{}:
+	default:
 	}
+}
+
+func (rs *replicaScanner) GetDisabled() bool {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.mu.disabled
 }
 
 // avgScan returns the average scan time of each scan cycle. Used in unittests.
 func (rs *replicaScanner) avgScan() time.Duration {
-	rs.completedScan.L.Lock()
-	defer rs.completedScan.L.Unlock()
-	return time.Duration(rs.total.Nanoseconds() / rs.count)
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return time.Duration(rs.mu.total.Nanoseconds() / rs.mu.count)
 }
 
 // RemoveReplica removes a replica from any replica queues the scanner may
@@ -179,9 +194,6 @@ func (rs *replicaScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stop
 			if repl == nil {
 				return false
 			}
-			if atomic.LoadInt32(&rs.disabled) == 1 {
-				return false
-			}
 
 			return nil != stopper.RunTask(func() {
 				// Try adding replica to all queues.
@@ -191,18 +203,22 @@ func (rs *replicaScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stop
 			})
 
 		case repl := <-rs.removed:
-			// Remove replica from all queues as applicable. Note that we still
-			// process removals while disabled.
-			for _, q := range rs.queues {
-				q.MaybeRemove(repl)
-			}
-			if log.V(6) {
-				log.Infof(context.TODO(), "removed replica %s", repl)
-			}
+			rs.removeReplica(repl)
 
 		case <-stopper.ShouldStop():
 			return true
 		}
+	}
+}
+
+func (rs *replicaScanner) removeReplica(repl *Replica) {
+	// Remove replica from all queues as applicable. Note that we still
+	// process removals while disabled.
+	for _, q := range rs.queues {
+		q.MaybeRemove(repl)
+	}
+	if log.V(6) {
+		log.Infof(context.TODO(), "removed replica %s", repl)
 	}
 }
 
@@ -217,6 +233,12 @@ func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 		defer rs.waitTimer.Stop()
 
 		for {
+			if rs.GetDisabled() {
+				if done := rs.waitEnabled(stopper); done {
+					return
+				}
+				continue
+			}
 			var shouldStop bool
 			count := 0
 			rs.replicas.Visit(func(repl *Replica) bool {
@@ -231,11 +253,10 @@ func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 
 			shouldStop = shouldStop || nil != stopper.RunTask(func() {
 				// Increment iteration count.
-				rs.completedScan.L.Lock()
-				rs.count++
-				rs.total += timeutil.Since(start)
-				rs.completedScan.Broadcast()
-				rs.completedScan.L.Unlock()
+				rs.mu.Lock()
+				defer rs.mu.Unlock()
+				rs.mu.count++
+				rs.mu.total += timeutil.Since(start)
 				if log.V(6) {
 					log.Infof(context.TODO(), "reset replica scan iteration")
 				}
@@ -248,4 +269,24 @@ func (rs *replicaScanner) scanLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 			}
 		}
 	})
+}
+
+// waitEnabled loops, removing replicas from the scanner's queues,
+// until scanning is enabled or the stopper signals shutdown,
+func (rs *replicaScanner) waitEnabled(stopper *stop.Stopper) bool {
+	for {
+		if !rs.GetDisabled() {
+			return false
+		}
+		select {
+		case <-rs.setDisabledCh:
+			continue
+
+		case repl := <-rs.removed:
+			rs.removeReplica(repl)
+
+		case <-stopper.ShouldStop():
+			return true
+		}
+	}
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -555,8 +555,8 @@ func (*StoreTestingKnobs) ModuleTestingKnobs() {}
 func (sc *StoreContext) Valid() bool {
 	return sc.Clock != nil && sc.Transport != nil &&
 		sc.RaftTickInterval != 0 && sc.RaftHeartbeatIntervalTicks > 0 &&
-		sc.RaftElectionTimeoutTicks > 0 && sc.ScanInterval > 0 &&
-		sc.ConsistencyCheckInterval > 0 && sc.Tracer != nil
+		sc.RaftElectionTimeoutTicks > 0 && sc.ScanInterval >= 0 &&
+		sc.ConsistencyCheckInterval >= 0 && sc.Tracer != nil
 }
 
 // setDefaults initializes unset fields in StoreConfig to values


### PR DESCRIPTION
Setting scan interval and consistency check interval to 0 disables
the scanner. This allows them to be disabled on the command line
via environment variables.

The previous code in `storage.scanner` would busy loop with an
empty scan interval, creating a mess in the CPU profiler.

Replaced condition variable with a simpler mutex (condvar wasn't
being used) and added unittests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8677)

<!-- Reviewable:end -->
