### PR TITLE
[stability] sql: add special tracing to trap #7881

### DIFF
--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -387,6 +387,7 @@ func (txn *Txn) GetDeadline() *hlc.Timestamp {
 // The txn's status is set to ABORTED in case of error. txn is
 // considered finalized and cannot be used to send any more commands.
 func (txn *Txn) Rollback() error {
+	log.VTracef(2, txn.Context, "rolling back transaction")
 	err := txn.sendEndTxnReq(false /* commit */, nil)
 	txn.finalized = true
 	return err
@@ -496,9 +497,17 @@ func (txn *Txn) Exec(
 		}
 
 		err = fn(txn, &opt)
+
+		// TODO(andrei): Until 7881 is fixed.
+		if err == nil && opt.AutoCommit && txn.Proto.Status == roachpb.ABORTED {
+			log.Errorf(txn.Context, "#7881: no err but aborted txn proto. opt: %+v, txn: %+v",
+				opt, txn)
+		}
+
 		if err == nil && opt.AutoCommit && txn.Proto.Status == roachpb.PENDING {
 			// fn succeeded, but didn't commit.
 			err = txn.Commit()
+			log.Tracef(txn.Context, "client.Txn did AutoCommit. err: %v\ntxn: %+v", err, txn.Proto)
 			if err != nil {
 				if _, retryable := err.(*roachpb.RetryableTxnError); !retryable {
 					// We can't retry, so let the caller know we tried to
@@ -525,10 +534,8 @@ func (txn *Txn) Exec(
 				r.Reset()
 			}
 		}
-		if log.V(2) {
-			log.Infof(context.TODO(), "automatically retrying transaction: %s because of error: %s",
-				txn.DebugName(), err)
-		}
+		log.VTracef(2, txn.Context, "automatically retrying transaction: %s because of error: %s",
+			txn.DebugName(), err)
 	}
 
 	return err

--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -36,10 +36,15 @@ import (
 // Txn is an in-progress distributed database transaction. A Txn is not safe for
 // concurrent use by multiple goroutines.
 type Txn struct {
-	db             DB
-	Proto          roachpb.Transaction
-	UserPriority   roachpb.UserPriority
-	Context        context.Context // must not be nil
+	db           DB
+	Proto        roachpb.Transaction
+	UserPriority roachpb.UserPriority
+	Context      context.Context // must not be nil
+	// CollectedSpans receives spans from remote hosts for "snowball" traces
+	// initiated on this host.
+	// It's also used by "EXPLAIN TRACE".
+	// Note that in SQL land there's also TxnState.CollectedSpans which
+	// should be used when we want to accumulate everything for a SQL txn.
 	CollectedSpans []basictracer.RawSpan
 	// systemConfigTrigger is set to true when modifying keys from the SystemConfig
 	// span. This sets the SystemConfigTrigger on EndTransactionRequest.

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/timeutil"
+	"github.com/cockroachdb/cockroach/util/tracing"
 )
 
 // getText fetches the HTTP response body as text in the form of a
@@ -238,8 +239,9 @@ func TestAdminAPIDatabases(t *testing.T) {
 
 	// Test databases endpoint.
 	const testdb = "test"
+	ctx := tracing.WithTracer(context.Background(), tracing.NewTracer())
 	session := sql.NewSession(
-		context.Background(), sql.SessionArgs{User: security.RootUser}, ts.sqlExecutor, nil)
+		ctx, sql.SessionArgs{User: security.RootUser}, ts.sqlExecutor, nil)
 	query := "CREATE DATABASE " + testdb
 	createRes := ts.sqlExecutor.ExecuteStatements(session, query, nil)
 	if createRes.ResultList[0].Err != nil {
@@ -363,8 +365,9 @@ func TestAdminAPITableDetails(t *testing.T) {
 	defer s.Stopper().Stop()
 	ts := s.(*TestServer)
 
+	ctx := tracing.WithTracer(context.Background(), tracing.NewTracer())
 	session := sql.NewSession(
-		context.Background(), sql.SessionArgs{User: security.RootUser}, ts.sqlExecutor, nil)
+		ctx, sql.SessionArgs{User: security.RootUser}, ts.sqlExecutor, nil)
 	setupQueries := []string{
 		"CREATE DATABASE test",
 		`
@@ -482,8 +485,9 @@ func TestAdminAPITableDetailsZone(t *testing.T) {
 	ts := s.(*TestServer)
 
 	// Create database and table.
+	ctx := tracing.WithTracer(context.Background(), tracing.NewTracer())
 	session := sql.NewSession(
-		context.Background(), sql.SessionArgs{User: security.RootUser}, ts.sqlExecutor, nil)
+		ctx, sql.SessionArgs{User: security.RootUser}, ts.sqlExecutor, nil)
 	setupQueries := []string{
 		"CREATE DATABASE test",
 		"CREATE TABLE test.tbl (val STRING)",
@@ -560,8 +564,9 @@ func TestAdminAPIUsers(t *testing.T) {
 	ts := s.(*TestServer)
 
 	// Create sample users.
+	ctx := tracing.WithTracer(context.Background(), tracing.NewTracer())
 	session := sql.NewSession(
-		context.Background(), sql.SessionArgs{User: security.RootUser}, ts.sqlExecutor, nil)
+		ctx, sql.SessionArgs{User: security.RootUser}, ts.sqlExecutor, nil)
 	query := `
 INSERT INTO system.users (username, hashedPassword)
 VALUES ('admin', 'abc'), ('bob', 'xyz')`
@@ -599,8 +604,9 @@ func TestAdminAPIEvents(t *testing.T) {
 	defer s.Stopper().Stop()
 	ts := s.(*TestServer)
 
+	ctx := tracing.WithTracer(context.Background(), tracing.NewTracer())
 	session := sql.NewSession(
-		context.Background(), sql.SessionArgs{User: security.RootUser}, ts.sqlExecutor, nil)
+		ctx, sql.SessionArgs{User: security.RootUser}, ts.sqlExecutor, nil)
 	setupQueries := []string{
 		"CREATE DATABASE api_test",
 		"CREATE TABLE api_test.tbl1 (a INT)",

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/metric"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/syncutil"
+	"github.com/cockroachdb/cockroach/util/tracing"
 	"github.com/pkg/errors"
 )
 
@@ -244,6 +245,9 @@ type ExecutorTestingKnobs struct {
 // NewExecutor creates an Executor and registers a callback on the
 // system config.
 func NewExecutor(cfg ExecutorConfig, stopper *stop.Stopper) *Executor {
+	if tracing.TracerFromCtx(cfg.Context) == nil {
+		panic("ExecutorConfig.Ctx must have a tracer in it")
+	}
 	exec := &Executor{
 		cfg:     cfg,
 		reCache: parser.NewRegexpCache(512),
@@ -282,7 +286,8 @@ func NewExecutor(cfg ExecutorConfig, stopper *stop.Stopper) *Executor {
 
 // NewDummyExecutor creates an empty Executor that is used for certain tests.
 func NewDummyExecutor() *Executor {
-	return &Executor{cfg: ExecutorConfig{Context: context.Background()}}
+	return &Executor{cfg: ExecutorConfig{
+		Context: tracing.WithTracer(context.Background(), tracing.NewTracer())}}
 }
 
 // Ctx returns the Context associated with this Executor.
@@ -349,6 +354,9 @@ func (e *Executor) Prepare(
 
 	// Prepare needs a transaction because it needs to retrieve db/table
 	// descriptors for type checking.
+	// TODO(andrei): is this OK? If we're preparing as part of a SQL txn, how do
+	// we check that they're reading descriptors consistent with the txn in which
+	// they'll be used?
 	txn := client.NewTxn(session.Ctx(), *e.cfg.DB)
 	txn.Proto.Isolation = session.DefaultIsolationLevel
 	session.planner.setTxn(txn)
@@ -482,8 +490,7 @@ func (e *Executor) execRequest(session *Session, sql string) StatementResults {
 					}()
 				}
 			}
-			txnState.reset(session.Ctx(), e, session)
-			txnState.State = Open
+			txnState.resetForNewSQLTxn(e, session)
 			txnState.autoRetry = true
 			txnState.sqlTimestamp = e.cfg.Clock.PhysicalTime()
 			if execOpt.AutoCommit {
@@ -528,7 +535,7 @@ func (e *Executor) execRequest(session *Session, sql string) StatementResults {
 		if err != nil {
 			lastResult := &results[len(results)-1]
 			if aErr, ok := err.(*client.AutoCommitError); ok {
-				// Until #7881 fixed.
+				// TODO(andrei): Until #7881 fixed.
 				if txn == nil {
 					log.Errorf(session.Ctx(), "AutoCommitError on nil txn: %+v, "+
 						"txnState %+v, execOpt %+v, stmts %+v, remaining %+v",
@@ -561,6 +568,12 @@ func (e *Executor) execRequest(session *Session, sql string) StatementResults {
 			// If execOpt.AutoCommit was set, then the txn no longer exists at this point.
 			txnState.resetStateAndTxn(NoTxn)
 		}
+
+		// If we're no longer in a transaction, finish the trace.
+		if txnState.State == NoTxn {
+			txnState.finishSQLTxn()
+		}
+
 		// If the txn is in any state but Open, exec the schema changes. They'll
 		// short-circuit themselves if the mutation that queued them has been
 		// rolled back from the table descriptor.
@@ -1050,13 +1063,11 @@ func commitSQLTransaction(
 		switch commitType {
 		case release:
 			// We'll now be waiting for a COMMIT.
-			txnState.State = CommitWait
+			txnState.resetStateAndTxn(CommitWait)
 		case commit:
 			// We're done with this txn.
-			txnState.State = NoTxn
+			txnState.resetStateAndTxn(NoTxn)
 		}
-		txnState.dumpTrace()
-		txnState.txn = nil
 	}
 	// Reset transaction to prevent running further commands on this planner.
 	p.resetTxn()

--- a/sql/session.go
+++ b/sql/session.go
@@ -48,6 +48,13 @@ import (
 var traceSQLDuration = envutil.EnvOrDefaultDuration("COCKROACH_TRACE_SQL", 0)
 var traceSQL = traceSQLDuration > 0
 
+// COCKROACH_TRACE_7881 can be used to trace all SQL transactions, in the hope
+// that we'll catch #7881 and dump the current trace for debugging.
+var traceSQLFor7881 = envutil.EnvOrDefaultBool("COCKROACH_TRACE_7881", false)
+
+// span baggage key used for marking a span
+const keyFor7881Sample = "found#7881"
+
 // Session contains the state of a SQL client connection.
 // Create instances using NewSession().
 type Session struct {
@@ -246,6 +253,16 @@ func (ts *txnState) resetForNewSQLTxn(e *Executor, s *Session) {
 		// sp is using a new tracer, so put it in the context.
 		ctx = tracing.WithTracer(
 			opentracing.ContextWithSpan(ctx, sp), sp.Tracer())
+	} else if traceSQLFor7881 {
+		sp, tr, err := tracing.NewTracerAndSpanFor7881(func(sp basictracer.RawSpan) {
+			ts.CollectedSpans = append(ts.CollectedSpans, sp)
+		})
+		if err != nil {
+			panic(fmt.Sprintf("couldn't create a tracer for debugging #7881: %s", err))
+		}
+		// Put both the new tracer and the span in the txn's context.
+		ctx = tracing.WithTracer(
+			opentracing.ContextWithSpan(ctx, sp), tr)
 	} else {
 		// Create a root span for this SQL txn.
 		tracer := tracing.TracerFromCtx(ctx)
@@ -297,13 +314,13 @@ func (ts *txnState) finishSQLTxn() {
 	if span == nil {
 		panic("No span in context? Was resetForNewSQLTxn() called previously?")
 	}
+	sampledFor7881 := (span.BaggageItem(keyFor7881Sample) != "")
 	span.Finish()
-	if traceSQL && ts.txn != nil {
-		if timeutil.Since(ts.sqlTimestamp) >= traceSQLDuration {
-			dump := tracing.FormatRawSpans(ts.txn.CollectedSpans)
-			if len(dump) > 0 {
-				log.Infof(context.Background(), "%s\n%s", ts.txn.Proto.ID, dump)
-			}
+	if (traceSQL && timeutil.Since(ts.sqlTimestamp) >= traceSQLDuration) ||
+		(traceSQLFor7881 && sampledFor7881) {
+		dump := tracing.FormatRawSpans(ts.CollectedSpans)
+		if len(dump) > 0 {
+			log.Infof(context.Background(), "SQL trace:\n%s", dump)
 		}
 	}
 }

--- a/sql/session.go
+++ b/sql/session.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/tracing"
 	basictracer "github.com/opentracing/basictracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
 )
 
 // COCKROACH_TRACE_SQL=duration can be used to log SQL transactions that take
@@ -58,6 +59,7 @@ type Session struct {
 	TxnState txnState
 
 	planner            planner
+	executor           *Executor
 	PreparedStatements PreparedStatements
 	PreparedPortals    PreparedPortals
 
@@ -66,7 +68,12 @@ type Session struct {
 	Trace                 trace.Trace
 	// context is the Session's base context. See Ctx().
 	context context.Context
-	cancel  context.CancelFunc
+	// TODO(andrei): We need to either get rid of this cancel field, or it needs
+	// to move to the TxnState and become a per-txn cancel. Right now, we're
+	// cancelling all the txns that have ever run on this session when the session
+	// is closed, as opposed to cancelling the individual transactions as soon as
+	// they COMMIT/ROLLBACK.
+	cancel context.CancelFunc
 }
 
 // SessionArgs contains arguments for creating a new Session with NewSession().
@@ -85,6 +92,7 @@ func NewSession(ctx context.Context, args SessionArgs, e *Executor, remote net.A
 		Database: args.Database,
 		User:     args.User,
 		Location: time.UTC,
+		executor: e,
 	}
 	cfg, cache := e.getSystemConfig()
 	s.planner = planner{
@@ -116,6 +124,19 @@ func (s *Session) Finish() {
 		s.Trace.Finish()
 		s.Trace = nil
 	}
+	// If we're inside a txn, roll it back.
+	if s.TxnState.State != NoTxn && s.TxnState.State != Aborted {
+		s.TxnState.updateStateAndCleanupOnErr(
+			errors.Errorf("session closing"), s.executor)
+	}
+	if s.TxnState.State != NoTxn {
+		s.TxnState.finishSQLTxn()
+	}
+	// This will stop the heartbeating of the of the txn record.
+	// TODO(andrei): This shouldn't have any effect, since, if there was a
+	// transaction, we just explicitly rolled it back above, so the heartbeat loop
+	// in the TxnCoordSender should not be waiting on this channel any more.
+	// Consider getting rid of this cancel field all-together.
 	s.cancel()
 }
 

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -68,6 +68,6 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 	msg := makeMessage(ctx, format, args)
 	// makeMessage already added the tags when forming msg, we don't want
 	// eventInternal to prepend them again.
-	eventInternal(ctx, (s >= ErrorLog), false /*withTags*/, "%s", msg)
+	eventInternal(ctx, (s >= ErrorLog), false /*withTags*/, "%s:%d %s", file, line, msg)
 	logging.outputLogEntry(s, file, line, msg)
 }

--- a/util/tracing/tracer.go
+++ b/util/tracing/tracer.go
@@ -63,6 +63,8 @@ func JoinOrNew(tr opentracing.Tracer, carrier *Span, opName string) (opentracing
 // JoinOrNewSnowball returns a Span which records directly via the specified
 // callback. If the given DelegatingCarrier is nil, a new Span is created.
 // otherwise, the created Span is a child.
+// TODO(andrei): JoinOrNewSnowball creates a new tracer, which is not kosher.
+// Also this can't use the lightstep tracer.
 func JoinOrNewSnowball(opName string, carrier *Span, callback func(sp basictracer.RawSpan)) (opentracing.Span, error) {
 	tr := basictracer.NewWithOptions(defaultOptions(callback))
 	sp, err := JoinOrNew(tr, carrier, opName)


### PR DESCRIPTION
sql: create root spans for transactions

Also:

I've decided to go medieval and invest in tracing all SQL execution in
the hope that #7881 will be triggered again.
The tracing is gated by an env var. When turned on, every SQL txn
creates a new tracer that accumulates spans in the session's txnState
(this is similar to how "SQL tracing" currently works). When we detect
7881, we mark the root span of the current one of these traces for
"sampling", which means that later, when that span (and hence the trace)
is closed, we dump the trace with all the log messages in it (note that
currently this trace only has one span, since we're not very good at
starting child spans yet).

cc @knz, @cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8681)

<!-- Reviewable:end -->
