### PR TITLE
time series: Add Downsampling Iterator

### DIFF
--- a/ts/query.go
+++ b/ts/query.go
@@ -43,21 +43,13 @@ func (rdc *calibratedData) offsetAt(idx int) int32 {
 	return rdc.Samples[idx].Offset + rdc.offsetAdjustment
 }
 
-// dataSpan is used to construct  monolithic view of a single time series over
+// dataSpan is used to construct a monolithic view of a single time series over
 // an arbitrary time span. The actual data in a span may be stored in multiple
 // instances of InternalTimeSeriesData.
 type dataSpan struct {
 	startNanos  int64
 	sampleNanos int64
 	datas       []calibratedData
-}
-
-// timestampForOffset returns an appropriate timestamp for the given offset
-// within a dataSpan. Because each offset represents a duration of time and not
-// an exact time, the returned timestamp will fall exactly in the middle of the
-// time slot represented by the offset.
-func (ds *dataSpan) timestampForOffset(offset int32) int64 {
-	return ds.startNanos + (int64(offset) * ds.sampleNanos) + (ds.sampleNanos / 2)
 }
 
 // addData adds an InternalTimeSeriesData object into this dataSpan, normalizing
@@ -99,34 +91,105 @@ func (ds *dataSpan) addData(data roachpb.InternalTimeSeriesData) error {
 	return nil
 }
 
-// downsampleFn is a function which extracts a float64 value from a time series
+// extractFn is a function which extracts a float64 value from a time series
 // sample.
-type downsampleFn func(roachpb.InternalTimeSeriesSample) float64
+type extractFn func(roachpb.InternalTimeSeriesSample) float64
 
 // dataSpanIterator is used to iterate through the samples in a dataSpan.
 // Samples are spread across multiple InternalTimeSeriesData objects; this
 // iterator thus maintains a two-level index to point to a unique sample.
 type dataSpanIterator struct {
-	*dataSpan
-	offset       int32        // The calibrated offset of the current sample within the dataSpan
-	dataIdx      int          // Index of InternalTimeSeriesData which contains current Sample
-	sampleIdx    int          // Index of current Sample within InternalTimeSeriesData
-	valid        bool         // True if this iterator points to a valid Sample
-	downsampleFn downsampleFn // Function to extract float64 values from samples
+	dataSpan
+	dataIdx   int       // Index of InternalTimeSeriesData which contains current Sample
+	sampleIdx int       // Index of current Sample within InternalTimeSeriesData
+	valid     bool      // True if this iterator points to a valid Sample
+	extractFn extractFn // Function to extract float64 values from samples
 }
 
-// value returns a float64 value by applying downsampleFn to the
+// newDataSpanIterator creates an iterator over the real data present in the
+// supplied data span. The iterator is initialized to the requested offset if a
+// real data point exists at that offset; otherwise, it is initialized to the
+// smallest offset which is greater than the requested offset.
+//
+// If the requested offset is greater than all points in the dataSpan, the
+// returned dataSpanIterator is initialized as if it had been advanced beyond
+// the last index in the dataSpan; calling retreat() on this iterator will place
+// it on the last datapoint.
+func newDataSpanIterator(ds dataSpan, offset int32, extractFn extractFn) dataSpanIterator {
+	// Use a binary search to find the data span which should contain the offset.
+	dataIdx := sort.Search(len(ds.datas), func(i int) bool {
+		data := ds.datas[i]
+		return data.offsetAt(len(data.Samples)-1) >= offset
+	})
+
+	if dataIdx == len(ds.datas) {
+		return dataSpanIterator{
+			dataSpan:  ds,
+			dataIdx:   len(ds.datas) - 1,
+			sampleIdx: len(ds.datas[len(ds.datas)-1].Samples),
+			valid:     false,
+			extractFn: extractFn,
+		}
+	}
+
+	// Use a binary search to find the sample with the smallest offset >= the
+	// target offset.
+	data := ds.datas[dataIdx]
+	sampleIdx := sort.Search(len(data.Samples), func(i int) bool {
+		return data.offsetAt(i) >= offset
+	})
+
+	return dataSpanIterator{
+		dataSpan:  ds,
+		dataIdx:   dataIdx,
+		sampleIdx: sampleIdx,
+		valid:     true,
+		extractFn: extractFn,
+	}
+}
+
+// value returns a float64 value by applying extractFn to the
 // InternalTimeSeriesSample value currently pointed to by this iterator.
-func (dsi *dataSpanIterator) value() float64 {
+func (dsi dataSpanIterator) value() float64 {
 	if !dsi.valid {
 		panic(fmt.Sprintf("value called on invalid dataSpanIterator: %v", dsi))
 	}
-	return dsi.downsampleFn(dsi.datas[dsi.dataIdx].Samples[dsi.sampleIdx])
+	return dsi.extractFn(dsi.datas[dsi.dataIdx].Samples[dsi.sampleIdx])
+}
+
+// return the offset of the current sample, relative to the start of the
+// dataSpan.
+func (dsi dataSpanIterator) offset() int32 {
+	if !dsi.valid {
+		panic(fmt.Sprintf("offset called on invalid dataSpanIterator: %v", dsi))
+	}
+	data := dsi.datas[dsi.dataIdx]
+	return data.offsetAt(dsi.sampleIdx)
+}
+
+// return the real timestamp represented by the current sample. The timestamp
+// is located at the beginning of the sample period.
+func (dsi dataSpanIterator) timestamp() int64 {
+	if !dsi.valid {
+		panic(fmt.Sprintf("timestamp called on invalid dataSpanIterator: %v", dsi))
+	}
+	return dsi.startNanos + (int64(dsi.offset()) * dsi.sampleNanos)
 }
 
 // advance moves the iterator to point to the next Sample.
 func (dsi *dataSpanIterator) advance() {
 	if !dsi.valid {
+		// Three possible scenarios for an invalid iterator:
+		// - iterator was never valid (no data)
+		// - iterator was advanced past the last index
+		// - iterator was retreated past the earliest index
+		// We can distinguish these based on the value of of sampleIdx. In the
+		// case where we are ahead of the earliest index, we advance sampleIdx
+		// and revalidate the index.
+		if dsi.sampleIdx < 0 {
+			dsi.valid = true
+			dsi.sampleIdx++
+		}
 		return
 	}
 	data := dsi.datas[dsi.dataIdx]
@@ -138,9 +201,180 @@ func (dsi *dataSpanIterator) advance() {
 		data = dsi.datas[dsi.dataIdx]
 		dsi.sampleIdx = 0
 	default:
+		// Iterator is at the end of available data. Increment sample index and
+		// invalidate.
+		dsi.sampleIdx++
 		dsi.valid = false
+		return
 	}
-	dsi.offset = data.offsetAt(dsi.sampleIdx)
+}
+
+// retreat moves the iterator to the previous Sample.
+func (dsi *dataSpanIterator) retreat() {
+	if !dsi.valid {
+		// Three possible scenarios for an invalid iterator:
+		// - iterator was never valid (no data)
+		// - iterator was advanced past the last index
+		// - iterator was retreated past the earliest index
+		// We can distinguish these based on the value of of sampleIdx. In the
+		// case where we are after the lastest index, we retreat sampleIdx
+		// and revalidate the index.
+		if dsi.sampleIdx > 0 {
+			dsi.valid = true
+			dsi.sampleIdx--
+		}
+		return
+	}
+	data := dsi.datas[dsi.dataIdx]
+	switch {
+	case dsi.sampleIdx > 0:
+		dsi.sampleIdx--
+	case dsi.dataIdx > 0:
+		dsi.dataIdx--
+		data = dsi.datas[dsi.dataIdx]
+		dsi.sampleIdx = len(data.Samples) - 1
+	default:
+		// Iterator is at the end of available data. Decrement sample index and
+		// invalidate.
+		dsi.sampleIdx--
+		dsi.valid = false
+		return
+	}
+}
+
+func (dsi *dataSpanIterator) isValid() bool {
+	return dsi.valid
+}
+
+// downsampleFn is a function which computes a single float64 value from a set
+// of other float64 values.
+type downsampleFn func(...float64) float64
+
+// downsamplingIterator behaves like a dataSpanIterator, but converts data to a
+// longer sample period through downsampling. Each offset of the downsampling
+// iterator covers multiple offsets of the underlying data, according to a
+// constant sampling factor. When a value is requested from this iterator, it is
+// computed from the matching underlying offsets using a downsampling function.
+//
+// In the case where sampleFactor is 1, all operations are passed directly to a
+// single underlying dataSpanIterator. Similar behavior have been accomplished
+// by creating a common interface between downsamplingIterator and
+// dataSpanIterator; however, using this technique means that no pointers are
+// necessary, and all iterator types can be used without allocations.
+type downsamplingIterator struct {
+	sampleNanos    int64
+	sampleFactor   int32
+	underlyingData dataSpan
+	start          dataSpanIterator
+	end            dataSpanIterator
+	downsampleFn   downsampleFn
+}
+
+// newDownsamplingIterator creates an iterator over given dataSpan. The iterator
+// is initialized to the requested offset if any real samples are present in the
+// underlying dataSpan which match that offset; otherwise, it is initialized to
+// the smallest offset with data which is greater than the requested offset.
+//
+// If the requested offset is greater than all points in the dataSpan, the
+// returned dataSpanIterator is initialized as if it had been advanced beyond
+// the last index in the dataSpan; calling retreat() on this iterator will place
+// it on the last datapoint.
+func newDownsamplingIterator(
+	ds dataSpan, offset int32, sampleNanos int64, extractFn extractFn, downsampleFn downsampleFn,
+) downsamplingIterator {
+	dsi := downsamplingIterator{
+		sampleNanos:    sampleNanos,
+		sampleFactor:   int32(sampleNanos / ds.sampleNanos),
+		underlyingData: ds,
+		downsampleFn:   downsampleFn,
+	}
+	if dsi.sampleFactor == 1 {
+		dsi.start = newDataSpanIterator(ds, offset, extractFn)
+		return dsi
+	}
+
+	underlyingOffset := offset * dsi.sampleFactor
+	dsi.start = newDataSpanIterator(ds, underlyingOffset, extractFn)
+	dsi.computeEnd()
+	return dsi
+}
+
+// advance moves the iterator to the next downsampling offset for which data
+// is present.
+func (dsi *downsamplingIterator) advance() {
+	if dsi.sampleFactor == 1 {
+		dsi.start.advance()
+		return
+	}
+
+	dsi.start = dsi.end
+	if dsi.start.valid {
+		dsi.computeEnd()
+	}
+}
+
+// retreat moves the iterator to the previous downsampling offset for which data
+// is present.
+func (dsi *downsamplingIterator) retreat() {
+	if dsi.sampleFactor == 1 {
+		dsi.start.retreat()
+		return
+	}
+
+	dsi.end = dsi.start
+	dsi.start.retreat()
+	if dsi.start.valid {
+		startOffset := dsi.start.offset() - (dsi.start.offset() % dsi.sampleFactor)
+		// Adjustment for negative offsets; the modulo math rounds negative
+		// numbers up to the the next offset boundary, so subtract the
+		// sampleFactor.
+		if dsi.start.offset() < 0 {
+			startOffset -= dsi.sampleFactor
+		}
+		dsi.start = newDataSpanIterator(dsi.underlyingData, startOffset, dsi.start.extractFn)
+	}
+}
+
+// isValid returns true if this iterator points to valid data.
+func (dsi *downsamplingIterator) isValid() bool {
+	return dsi.start.valid
+}
+
+// offset returns the current offset of the iterator from the start of the
+// underlying dataSpan. This offset is in terms of the sampleNanos of the
+// iterator, not of the dataSpan; they are related to dataSpan offsets by
+// sampleFactor.
+func (dsi *downsamplingIterator) offset() int32 {
+	return dsi.start.offset() / dsi.sampleFactor
+}
+
+// timestamp returns the timestamp corresponding to the current offset of the iterator.
+// The returned timestamp marks the beginning of the sample period.
+func (dsi *downsamplingIterator) timestamp() int64 {
+	return dsi.start.dataSpan.startNanos + (int64(dsi.offset()) * dsi.sampleNanos)
+}
+
+// value returns a downsampled valued, computed using downsampleFn, based on the
+// corresponding higher-resolution samples in the underlying dataSpan.
+func (dsi *downsamplingIterator) value() float64 {
+	if dsi.sampleFactor == 1 {
+		return dsi.start.value()
+	}
+
+	end := dsi.end
+	floats := make([]float64, 0, dsi.sampleFactor)
+	for iter := dsi.start; iter.valid && (!end.valid || iter.offset() != end.offset()); iter.advance() {
+		floats = append(floats, iter.value())
+	}
+	return dsi.downsampleFn(floats...)
+}
+
+func (dsi *downsamplingIterator) computeEnd() {
+	if !dsi.start.valid {
+		return
+	}
+	endOffset := (dsi.offset() + 1) * dsi.sampleFactor
+	dsi.end = newDataSpanIterator(dsi.underlyingData, endOffset, dsi.start.extractFn)
 }
 
 // interpolatingIterator is used to iterate over offsets within a dataSpan. The
@@ -150,9 +384,40 @@ func (dsi *dataSpanIterator) advance() {
 // Values for missing offsets are computed using linear interpolation from the
 // nearest real samples preceding and following the missing offset.
 type interpolatingIterator struct {
-	offset   int32            // Current offset within dataSpan
-	nextReal dataSpanIterator // Next sample with an offset >= iterator's offset
-	prevReal dataSpanIterator // Prev sample with offset < iterator's offset
+	offset   int32                // Current offset within dataSpan
+	nextReal downsamplingIterator // Next sample with an offset >= iterator's offset
+	prevReal downsamplingIterator // Prev sample with offset < iterator's offset
+}
+
+// newInterpolatingIterator returns an interpolating iterator for the given
+// dataSpan. The iterator is initialized to position startOffset, which should
+// be 0 when querying non-derivatives and -1 when querying a derivative. Values
+// returned by the iterator will be generated from samples using the supplied
+// downsampleFn.
+func newInterpolatingIterator(
+	ds dataSpan,
+	startOffset int32,
+	sampleNanos int64,
+	extractFn extractFn,
+	downsampleFn downsampleFn,
+) interpolatingIterator {
+	if len(ds.datas) == 0 {
+		return interpolatingIterator{}
+	}
+
+	nextReal := newDownsamplingIterator(ds, startOffset, sampleNanos, extractFn, downsampleFn)
+	iterator := interpolatingIterator{
+		offset:   startOffset,
+		nextReal: nextReal,
+	}
+
+	prevReal := nextReal
+	prevReal.retreat()
+	if prevReal.isValid() {
+		iterator.prevReal = prevReal
+	}
+
+	return iterator
 }
 
 // advanceTo advances the iterator to the supplied offset.
@@ -160,7 +425,7 @@ func (ii *interpolatingIterator) advanceTo(offset int32) {
 	ii.offset = offset
 	// Advance real iterators until nextReal has offset >= the interpolated
 	// offset.
-	for ii.nextReal.valid && ii.nextReal.offset < ii.offset {
+	for ii.nextReal.isValid() && ii.nextReal.offset() < ii.offset {
 		ii.prevReal = ii.nextReal
 		ii.nextReal.advance()
 	}
@@ -168,7 +433,19 @@ func (ii *interpolatingIterator) advanceTo(offset int32) {
 
 // isValid returns true if this interpolatingIterator still points to valid data.
 func (ii *interpolatingIterator) isValid() bool {
-	return ii.nextReal.valid
+	return ii.nextReal.isValid()
+}
+
+// midTimestamp returns a timestamp at the middle of the current offset's sample
+// period. The middle of the sample period has been chosen in order to minimize
+// the possible distance from the returned timestamp and the timestamp of the
+// real measurements used to compute its value.
+func (ii *interpolatingIterator) midTimestamp() int64 {
+	if !ii.isValid() {
+		panic(fmt.Sprintf("midTimestamp called on invalid interpolatingIterator: %v", ii))
+	}
+	dsi := ii.nextReal
+	return dsi.underlyingData.startNanos + (int64(ii.offset) * dsi.sampleNanos) + (dsi.sampleNanos / 2)
 }
 
 // value returns the value at the current offset of this iterator.
@@ -176,68 +453,21 @@ func (ii *interpolatingIterator) value() float64 {
 	if !ii.isValid() {
 		return 0
 	}
-	if ii.nextReal.offset == ii.offset {
+	if ii.nextReal.offset() == ii.offset {
 		return ii.nextReal.value()
 	}
 	// Cannot interpolate if previous value is invalid.
-	if !ii.prevReal.valid {
+	if !ii.prevReal.isValid() {
 		return 0
 	}
 
 	// Linear interpolation of value at the current offset.
 	off := float64(ii.offset)
 	nextAvg := ii.nextReal.value()
-	nextOff := float64(ii.nextReal.offset)
+	nextOff := float64(ii.nextReal.offset())
 	prevAvg := ii.prevReal.value()
-	prevOff := float64(ii.prevReal.offset)
+	prevOff := float64(ii.prevReal.offset())
 	return prevAvg + (nextAvg-prevAvg)*(off-prevOff)/(nextOff-prevOff)
-}
-
-// newIterator returns an interpolating iterator for the given dataSpan. The
-// iterator is initialized to position startOffset, which should be 0 when
-// querying non-derivatives and -1 when querying a derivative. Values returned
-// by the iterator will be generated from samples using the supplied
-// downsampleFn.
-func (ds *dataSpan) newIterator(startOffset int32, downsampleFn downsampleFn) interpolatingIterator {
-	if len(ds.datas) == 0 {
-		return interpolatingIterator{}
-	}
-
-	// The first data index necessarily contains the positive offset closest to
-	// 0, along with 0 itself and negative offsets. Use a binary search to
-	// find the lowest offset greater than or equal to startOffset.
-	data := ds.datas[0]
-	innerIdx := sort.Search(len(data.Samples), func(i int) bool {
-		return data.offsetAt(i) >= startOffset
-	})
-
-	iterator := interpolatingIterator{
-		offset: startOffset,
-		nextReal: dataSpanIterator{
-			dataSpan:     ds,
-			dataIdx:      0,
-			sampleIdx:    innerIdx,
-			offset:       data.offsetAt(innerIdx),
-			valid:        true,
-			downsampleFn: downsampleFn,
-		},
-	}
-
-	// If innerIdx > 0, then we can compute a "previous" iterator as well; this
-	// will let us interpolate a 0 value if it is not actually present in the
-	// data.
-	if innerIdx > 0 {
-		iterator.prevReal = dataSpanIterator{
-			dataSpan:     ds,
-			dataIdx:      0,
-			sampleIdx:    innerIdx - 1,
-			offset:       data.offsetAt(innerIdx - 1),
-			valid:        true,
-			downsampleFn: downsampleFn,
-		}
-	}
-
-	return iterator
 }
 
 // A unionIterator jointly advances multiple interpolatingIterators, visiting
@@ -253,6 +483,8 @@ func (ds *dataSpan) newIterator(startOffset int32, downsampleFn downsampleFn) in
 //
 // In order to facilitate finding the lowest value of nextReal.offset, the set is
 // organized as a min heap using Go's heap package.
+//
+// TODO(mrtracy): Rename to aggregatingIterator
 type unionIterator []interpolatingIterator
 
 // Len returns the length of the iteratorSet; needed by heap.Interface.
@@ -273,16 +505,16 @@ func (is unionIterator) Swap(i, j int) {
 // earlier offset.
 func (is unionIterator) Less(i, j int) bool {
 	thisNext, otherNext := is[i].nextReal, is[j].nextReal
-	if !(thisNext.valid || otherNext.valid) {
+	if !(thisNext.isValid() || otherNext.isValid()) {
 		return false
 	}
-	if !thisNext.valid {
+	if !thisNext.isValid() {
 		return false
 	}
-	if !otherNext.valid {
+	if !otherNext.isValid() {
 		return true
 	}
-	return thisNext.offset < otherNext.offset
+	return thisNext.offset() < otherNext.offset()
 }
 
 // Push pushes an element into the iteratorSet heap; needed by heap.Interface
@@ -315,7 +547,7 @@ func (is unionIterator) init() {
 	if !is.isValid() {
 		return
 	}
-	if is[0].nextReal.offset > 0 {
+	if is[0].nextReal.offset() > 0 {
 		is.advance()
 	}
 }
@@ -343,7 +575,7 @@ func (is unionIterator) advance() {
 
 	// The iterator in position zero now has the lowest value for
 	// nextReal.offset - advance all iterators to that offset.
-	min := is[0].nextReal.offset
+	min := is[0].nextReal.offset()
 	for i := range is {
 		is[i].advanceTo(min)
 	}
@@ -357,7 +589,7 @@ func (is unionIterator) timestamp() int64 {
 	if !is.isValid() {
 		return 0
 	}
-	return is[0].nextReal.timestampForOffset(is[0].offset)
+	return is[0].midTimestamp()
 }
 
 // offset returns the current offset of the iterator.
@@ -409,9 +641,13 @@ func (is unionIterator) min() float64 {
 // Query returns datapoints for the named time series during the supplied time
 // span.  Data is returned as a series of consecutive data points.
 //
-// Data is queried only at the Resolution supplied: if data for the named time
+// Data is queried only at the queryResolution supplied: if data for the named time
 // series is not stored at the given resolution, an empty result will be
 // returned.
+//
+// Data is returned at sampleResolution, which must have a sample period >= the
+// sample period of queryResolution. If the sampleResolution is different, the
+// queried data is downsampled.
 //
 // All data stored on the server is downsampled to some degree; the data points
 // returned represent the average value within a sample period. Each datapoint's
@@ -421,17 +657,19 @@ func (is unionIterator) min() float64 {
 // returned datapoint will represent the sum of datapoints from all sources at
 // the same time. The returned string slices contains a list of all sources for
 // the metric which were aggregated to produce the result.
-func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) ([]tspb.TimeSeriesDatapoint, []string, error) {
-	// Normalize startNanos and endNanos the nearest SampleDuration boundary.
-	startNanos -= startNanos % r.SampleDuration()
+func (db *DB) Query(
+	query tspb.Query, sampleResolution, queryResolution Resolution, startNanos, endNanos int64,
+) ([]tspb.TimeSeriesDatapoint, []string, error) {
+	// Normalize startNanos to a sampleResolution boundary.
+	startNanos -= startNanos % sampleResolution.SampleDuration()
 
 	var rows []client.KeyValue
 	if len(query.Sources) == 0 {
-		// Based on the supplied timestamps and resolution, construct start and end
-		// keys for a scan that will return every key with data relevant to the
-		// query.
-		startKey := MakeDataKey(query.Name, "" /* source */, r, startNanos)
-		endKey := MakeDataKey(query.Name, "" /* source */, r, endNanos).PrefixEnd()
+		// Based on the supplied timestamps and resolution, construct start and
+		// end keys for a scan that will return every key with data relevant to
+		// the query.
+		startKey := MakeDataKey(query.Name, "" /* source */, queryResolution, startNanos)
+		endKey := MakeDataKey(query.Name, "" /* source */, queryResolution, endNanos).PrefixEnd()
 		b := &client.Batch{}
 		b.Scan(startKey, endKey)
 
@@ -443,12 +681,12 @@ func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) 
 		b := &client.Batch{}
 		// Iterate over all key timestamps which may contain data for the given
 		// sources, based on the given start/end time and the resolution.
-		kd := r.KeyDuration()
+		kd := queryResolution.KeyDuration()
 		startKeyNanos := startNanos - (startNanos % kd)
 		endKeyNanos := endNanos - (endNanos % kd)
 		for currentTimestamp := startKeyNanos; currentTimestamp <= endKeyNanos; currentTimestamp += kd {
 			for _, source := range query.Sources {
-				key := MakeDataKey(query.Name, source, r, currentTimestamp)
+				key := MakeDataKey(query.Name, source, queryResolution, currentTimestamp)
 				b.Get(key)
 			}
 		}
@@ -472,8 +710,14 @@ func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) 
 		return nil, nil, err
 	}
 
-	// Compute a downsample function which will be used to return values from
+	// Choose an extractor function which will be used to return values from
 	// each source for each sample period.
+	extractor, err := getExtractionFunction(query.GetDownsampler())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Choose downsampler function.
 	downsampler, err := getDownsampleFunction(query.GetDownsampler())
 	if err != nil {
 		return nil, nil, err
@@ -494,7 +738,9 @@ func (db *DB) Query(query tspb.Query, r Resolution, startNanos, endNanos int64) 
 	iters := make(unionIterator, 0, len(sourceSpans))
 	for name, span := range sourceSpans {
 		sources = append(sources, name)
-		iters = append(iters, span.newIterator(startOffset, downsampler))
+		iters = append(iters, newInterpolatingIterator(
+			*span, startOffset, sampleResolution.SampleDuration(), extractor, downsampler,
+		))
 	}
 
 	// Choose an aggregation function to use when taking values from the
@@ -585,8 +831,8 @@ func makeDataSpans(rows []client.KeyValue, startNanos int64) (map[string]*dataSp
 	return sourceSpans, nil
 }
 
-// getDownsampleFunction returns
-func getDownsampleFunction(agg tspb.TimeSeriesQueryAggregator) (downsampleFn, error) {
+// getExtractionFunction returns
+func getExtractionFunction(agg tspb.TimeSeriesQueryAggregator) (extractFn, error) {
 	switch agg {
 	case tspb.TimeSeriesQueryAggregator_AVG:
 		return (roachpb.InternalTimeSeriesSample).Average, nil
@@ -596,6 +842,54 @@ func getDownsampleFunction(agg tspb.TimeSeriesQueryAggregator) (downsampleFn, er
 		return (roachpb.InternalTimeSeriesSample).Maximum, nil
 	case tspb.TimeSeriesQueryAggregator_MIN:
 		return (roachpb.InternalTimeSeriesSample).Minimum, nil
+	}
+	return nil, errors.Errorf("query specified unknown time series aggregator %s", agg.String())
+}
+
+func downsampleSum(points ...float64) float64 {
+	result := 0.0
+	for _, p := range points {
+		result += p
+	}
+	return result
+}
+
+func downsampleMax(points ...float64) float64 {
+	result := points[0]
+	for _, p := range points[1:] {
+		if p > result {
+			result = p
+		}
+	}
+	return result
+}
+
+func downsampleMin(points ...float64) float64 {
+	result := points[0]
+	for _, p := range points[1:] {
+		if p < result {
+			result = p
+		}
+	}
+	return result
+}
+
+func downsampleAvg(points ...float64) float64 {
+	result := downsampleSum(points...)
+	return result / float64(len(points))
+}
+
+// getDownsampleFunction returns
+func getDownsampleFunction(agg tspb.TimeSeriesQueryAggregator) (downsampleFn, error) {
+	switch agg {
+	case tspb.TimeSeriesQueryAggregator_AVG:
+		return downsampleAvg, nil
+	case tspb.TimeSeriesQueryAggregator_SUM:
+		return downsampleSum, nil
+	case tspb.TimeSeriesQueryAggregator_MAX:
+		return downsampleMax, nil
+	case tspb.TimeSeriesQueryAggregator_MIN:
+		return downsampleMin, nil
 	}
 	return nil, errors.Errorf("query specified unknown time series aggregator %s", agg.String())
 }

--- a/ts/server.go
+++ b/ts/server.go
@@ -69,7 +69,9 @@ func (s *Server) Query(ctx context.Context, request *tspb.TimeSeriesQueryRequest
 		Results: make([]tspb.TimeSeriesQueryResponse_Result, 0, len(request.Queries)),
 	}
 	for _, query := range request.Queries {
-		datapoints, sources, err := s.db.Query(query, Resolution10s, request.StartNanos, request.EndNanos)
+		datapoints, sources, err := s.db.Query(
+			query, Resolution10s, Resolution10s, request.StartNanos, request.EndNanos,
+		)
 		if err != nil {
 			return nil, grpc.Errorf(codes.Internal, err.Error())
 		}


### PR DESCRIPTION
Adds a "downsampling iterator" into the time series query system. This is an
additional level of iterator between the existing dataSpanIterator and
interpolatingIterator that is capable of downsampling data to a lower
resolution before interpolating.

This commit involved significant augmentation of dataSpanIterator with
additional functionality, and some refactoring of interpolatingIterator.

The downsamplingIterator is not yet being used, as all queries use the 10second
resolution which matches all stored data. However, tests have been added to
verify downsamplingIterator (as well as an additional test to verify
dataSpanIterator on a more complete level). This is being committed before
actual usage in order to reduce the size of the code review.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8682)

<!-- Reviewable:end -->
