### PR TITLE
Add build_timestamp metric.

### DIFF
--- a/build/ldflags.sh
+++ b/build/ldflags.sh
@@ -4,6 +4,7 @@ set -eu
 
 cd "$(dirname "${0}")/.."
 
+# The build.utcTime format must remain in sync with TimeFormat in info.go.
 echo '-X "github.com/cockroachdb/cockroach/build.tag='$(git describe --dirty --tags)'"' \
-     '-X "github.com/cockroachdb/cockroach/build.time='$(date -u '+%Y/%m/%d %H:%M:%S')'"' \
+     '-X "github.com/cockroachdb/cockroach/build.utcTime='$(date -u '+%Y/%m/%d %H:%M:%S')'"' \
      '-X "github.com/cockroachdb/cockroach/build.deps='$(build/depvers.sh)'"'

--- a/util/metric/metric.go
+++ b/util/metric/metric.go
@@ -46,6 +46,12 @@ type Iterable interface {
 // PrometheusExportable is the standard interface for an individual metric
 // that can be exported to prometheus.
 type PrometheusExportable interface {
+	// GetName is a method on Metadata
+	GetName() string
+	// GetHelp is a method on Metadata
+	GetHelp() string
+	// GetLabels is a method on Metadata
+	GetLabels() []*prometheusgo.LabelPair
 	// FillPrometheusMetric takes an initialized prometheus metric object and
 	// fills the appropriate fields for the metric type.
 	FillPrometheusMetric(promMetric *prometheusgo.MetricFamily)
@@ -55,6 +61,7 @@ type PrometheusExportable interface {
 // each metric object.
 type Metadata struct {
 	Name, Help string
+	labels     []*prometheusgo.LabelPair
 }
 
 // GetName returns the metric's name.
@@ -65,6 +72,20 @@ func (m *Metadata) GetName() string {
 // GetHelp returns the metric's help string.
 func (m *Metadata) GetHelp() string {
 	return m.Help
+}
+
+// GetLabels returns the metric's labels.
+func (m *Metadata) GetLabels() []*prometheusgo.LabelPair {
+	return m.labels
+}
+
+// AddLabel adds a label/value pair for this metric.
+func (m *Metadata) AddLabel(name, value string) {
+	m.labels = append(m.labels,
+		&prometheusgo.LabelPair{
+			Name:  proto.String(exportedLabel(name)),
+			Value: proto.String(value),
+		})
 }
 
 var _ Iterable = &Gauge{}

--- a/util/metric/metric_group.go
+++ b/util/metric/metric_group.go
@@ -67,7 +67,12 @@ func NewLatency(metadata Metadata) Histograms {
 	windows := DefaultTimeScales
 	hs := make(Histograms)
 	for _, w := range windows {
-		hs[w] = NewHistogram(Metadata{metadata.Name + sep + w.name, metadata.Help},
+		hs[w] = NewHistogram(
+			Metadata{
+				Name:   metadata.Name + sep + w.name,
+				Help:   metadata.Help,
+				labels: metadata.labels,
+			},
 			w.d, int64(time.Minute), 2)
 	}
 	return hs
@@ -99,9 +104,19 @@ func NewRates(metadata Metadata) Rates {
 	scales := DefaultTimeScales
 	es := make(map[TimeScale]*Rate)
 	for _, scale := range scales {
-		es[scale] = NewRate(Metadata{metadata.Name + sep + scale.name, metadata.Help}, scale.d)
+		es[scale] = NewRate(
+			Metadata{
+				Name:   metadata.Name + sep + scale.name,
+				Help:   metadata.Help,
+				labels: metadata.labels,
+			}, scale.d)
 	}
-	c := NewCounter(Metadata{metadata.Name + sep + "count", metadata.Help})
+	c := NewCounter(
+		Metadata{
+			Name:   metadata.Name + sep + "count",
+			Help:   metadata.Help,
+			labels: metadata.labels,
+		})
 	return Rates{Counter: c, Rates: es}
 }
 


### PR DESCRIPTION
Fixes #8673
- includes `tag` and `go_version` as labels
- add ability to specify per-metric labels
- rename `build.time` to `build.utcTime` (conflicts with `time` package)

Since metrics are numbers only, we need to stick the string information
in labels.
Both prometheus and grafana have ways of dealing with that, although not
as easily as plain numbers.

@cockroachdb/stability: this will come in handy to keep track of what's running. This will go on grafana.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8686)

<!-- Reviewable:end -->
