### PR TITLE
storage: move an overly verbose log message under V(1)

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -2154,7 +2154,7 @@ func (r *Replica) applyRaftCommand(
 	}
 
 	// TODO(tschottdorf): remove when #7224 is cleared.
-	if ba.Txn != nil && ba.Txn.Name == replicaChangeTxnName {
+	if ba.Txn != nil && ba.Txn.Name == replicaChangeTxnName && log.V(1) {
 		log.Infof(ctx, "%s: applied part of replica change txn: %s, pErr=%v",
 			r, ba, rErr)
 	}


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8687)

<!-- Reviewable:end -->
