### PR TITLE
storage: move range-event logs under V(1)

### DIFF
--- a/storage/log.go
+++ b/storage/log.go
@@ -78,10 +78,12 @@ func (s *Store) insertRangeLogEvent(txn *client.Txn, event rangeLogEvent) error 
 	if event.info != nil {
 		info = *event.info
 	}
-	log.Infof(txn.Context, "Range Event: %q, range: %d, info: %s",
-		event.eventType,
-		event.rangeID,
-		info)
+	if log.V(1) {
+		log.Infof(txn.Context, "Range Event: %q, range: %d, info: %s",
+			event.eventType,
+			event.rangeID,
+			info)
+	}
 
 	const insertEventTableStmt = `
 INSERT INTO system.rangelog (


### PR DESCRIPTION
We're already logging splits and adds elsewhere and these log messages
are not very readable.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8689)

<!-- Reviewable:end -->
