### PR TITLE
sql: preliminary mechanism to track and limit SQL memory usage.

### DIFF
--- a/server/admin.go
+++ b/server/admin.go
@@ -165,16 +165,20 @@ func (s *adminServer) Databases(
 ) (*serverpb.DatabasesResponse, error) {
 	args := sql.SessionArgs{User: s.getUser(req)}
 	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
+	defer session.Finish()
+
 	r := s.server.sqlExecutor.ExecuteStatements(session, "SHOW DATABASES;", nil)
+	defer r.Close()
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, s.serverError(err)
 	}
 
 	var resp serverpb.DatabasesResponse
-	for _, row := range r.ResultList[0].Rows {
-		dbname, ok := row.Values[0].(*parser.DString)
+	for i, nRows := 0, r.ResultList[0].Rows.Len(); i < nRows; i++ {
+		row := r.ResultList[0].Rows.At(i)
+		dbname, ok := row[0].(*parser.DString)
 		if !ok {
-			return nil, s.serverErrorf("type assertion failed on db name: %T", row.Values[0])
+			return nil, s.serverErrorf("type assertion failed on db name: %T", row[0])
 		}
 		resp.Databases = append(resp.Databases, string(*dbname))
 	}
@@ -189,6 +193,7 @@ func (s *adminServer) DatabaseDetails(
 ) (*serverpb.DatabaseDetailsResponse, error) {
 	args := sql.SessionArgs{User: s.getUser(req)}
 	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
+	defer session.Finish()
 
 	// Placeholders don't work with SHOW statements, so we need to manually
 	// escape the database name.
@@ -197,6 +202,7 @@ func (s *adminServer) DatabaseDetails(
 	escDBName := parser.Name(req.Database).String()
 	query := fmt.Sprintf("SHOW GRANTS ON DATABASE %s; SHOW TABLES FROM %s;", escDBName, escDBName)
 	r := s.server.sqlExecutor.ExecuteStatements(session, query, nil)
+	defer r.Close()
 	if err := s.firstNotFoundError(r.ResultList); err != nil {
 		return nil, grpc.Errorf(codes.NotFound, "%s", err)
 	}
@@ -213,7 +219,8 @@ func (s *adminServer) DatabaseDetails(
 		)
 
 		scanner := makeResultScanner(r.ResultList[0].Columns)
-		for _, row := range r.ResultList[0].Rows {
+		for i, nRows := 0, r.ResultList[0].Rows.Len(); i < nRows; i++ {
+			row := r.ResultList[0].Rows.At(i)
 			// Marshal grant, splitting comma-separated privileges into a proper slice.
 			var grant serverpb.DatabaseDetailsResponse_Grant
 			var privileges string
@@ -235,7 +242,8 @@ func (s *adminServer) DatabaseDetails(
 		if a, e := len(r.ResultList[1].Columns), 1; a != e {
 			return nil, s.serverErrorf("show tables columns mismatch: %d != expected %d", a, e)
 		}
-		for _, row := range r.ResultList[1].Rows {
+		for i, nRows := 0, r.ResultList[1].Rows.Len(); i < nRows; i++ {
+			row := r.ResultList[1].Rows.At(i)
 			var tableName string
 			if err := scanner.Scan(row, tableCol, &tableName); err != nil {
 				return nil, err
@@ -280,6 +288,7 @@ func (s *adminServer) TableDetails(
 ) (*serverpb.TableDetailsResponse, error) {
 	args := sql.SessionArgs{User: s.getUser(req)}
 	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
+	defer session.Finish()
 
 	// TODO(cdo): Use real placeholders for the table and database names when we've extended our SQL
 	// grammar to allow that.
@@ -289,6 +298,7 @@ func (s *adminServer) TableDetails(
 	query := fmt.Sprintf("SHOW COLUMNS FROM %s; SHOW INDEX FROM %s; SHOW GRANTS ON TABLE %s; SHOW CREATE TABLE %s;",
 		escQualTable, escQualTable, escQualTable, escQualTable)
 	r := s.server.sqlExecutor.ExecuteStatements(session, query, nil)
+	defer r.Close()
 	if err := s.firstNotFoundError(r.ResultList); err != nil {
 		return nil, grpc.Errorf(codes.NotFound, "%s", err)
 	}
@@ -312,7 +322,8 @@ func (s *adminServer) TableDetails(
 			defaultCol = "Default"
 		)
 		scanner := makeResultScanner(r.ResultList[0].Columns)
-		for _, row := range r.ResultList[0].Rows {
+		for i, nRows := 0, r.ResultList[0].Rows.Len(); i < nRows; i++ {
+			row := r.ResultList[0].Rows.At(i)
 			var col serverpb.TableDetailsResponse_Column
 			if err := scanner.Scan(row, fieldCol, &col.Name); err != nil {
 				return nil, err
@@ -347,7 +358,8 @@ func (s *adminServer) TableDetails(
 			storingCol   = "Storing"
 		)
 		scanner := makeResultScanner(r.ResultList[1].Columns)
-		for _, row := range r.ResultList[1].Rows {
+		for i, nRows := 0, r.ResultList[1].Rows.Len(); i < nRows; i++ {
+			row := r.ResultList[1].Rows.At(i)
 			// Marshal grant, splitting comma-separated privileges into a proper slice.
 			var index serverpb.TableDetailsResponse_Index
 			if err := scanner.Scan(row, nameCol, &index.Name); err != nil {
@@ -379,7 +391,8 @@ func (s *adminServer) TableDetails(
 			privilegesCol = "Privileges"
 		)
 		scanner := makeResultScanner(r.ResultList[2].Columns)
-		for _, row := range r.ResultList[2].Rows {
+		for i, nRows := 0, r.ResultList[2].Rows.Len(); i < nRows; i++ {
+			row := r.ResultList[2].Rows.At(i)
 			// Marshal grant, splitting comma-separated privileges into a proper slice.
 			var grant serverpb.TableDetailsResponse_Grant
 			var privileges string
@@ -398,13 +411,13 @@ func (s *adminServer) TableDetails(
 	{
 		const createTableCol = "CreateTable"
 		showResult := r.ResultList[3]
-		if len(showResult.Rows) != 1 {
+		if showResult.Rows.Len() != 1 {
 			return nil, s.serverErrorf("CreateTable response not available.")
 		}
 
 		scanner := makeResultScanner(showResult.Columns)
 		var createStmt string
-		if err := scanner.Scan(showResult.Rows[0], createTableCol, &createStmt); err != nil {
+		if err := scanner.Scan(showResult.Rows.At(0), createTableCol, &createStmt); err != nil {
 			return nil, err
 		}
 
@@ -594,15 +607,19 @@ func (s *adminServer) TableStats(ctx context.Context, req *serverpb.TableStatsRe
 func (s *adminServer) Users(ctx context.Context, req *serverpb.UsersRequest) (*serverpb.UsersResponse, error) {
 	args := sql.SessionArgs{User: s.getUser(req)}
 	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
+	defer session.Finish()
+
 	query := "SELECT username FROM system.users"
 	r := s.server.sqlExecutor.ExecuteStatements(session, query, nil)
+	defer r.Close()
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, s.serverError(err)
 	}
 
 	var resp serverpb.UsersResponse
-	for _, row := range r.ResultList[0].Rows {
-		resp.Users = append(resp.Users, serverpb.UsersResponse_User{Username: string(*row.Values[0].(*parser.DString))})
+	for i, nRows := 0, r.ResultList[0].Rows.Len(); i < nRows; i++ {
+		row := r.ResultList[0].Rows.At(i)
+		resp.Users = append(resp.Users, serverpb.UsersResponse_User{Username: string(*row[0].(*parser.DString))})
 	}
 	return &resp, nil
 }
@@ -615,6 +632,7 @@ func (s *adminServer) Users(ctx context.Context, req *serverpb.UsersRequest) (*s
 func (s *adminServer) Events(ctx context.Context, req *serverpb.EventsRequest) (*serverpb.EventsResponse, error) {
 	args := sql.SessionArgs{User: s.getUser(req)}
 	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
+	defer session.Finish()
 
 	// Execute the query.
 	q := makeSQLQuery()
@@ -633,6 +651,7 @@ func (s *adminServer) Events(ctx context.Context, req *serverpb.EventsRequest) (
 		return nil, s.serverErrors(q.Errors())
 	}
 	r := s.server.sqlExecutor.ExecuteStatements(session, q.String(), q.QueryArguments())
+	defer r.Close()
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, s.serverError(err)
 	}
@@ -640,7 +659,8 @@ func (s *adminServer) Events(ctx context.Context, req *serverpb.EventsRequest) (
 	// Marshal response.
 	var resp serverpb.EventsResponse
 	scanner := makeResultScanner(r.ResultList[0].Columns)
-	for _, row := range r.ResultList[0].Rows {
+	for i, nRows := 0, r.ResultList[0].Rows.Len(); i < nRows; i++ {
+		row := r.ResultList[0].Rows.At(i)
 		var event serverpb.EventsResponse_Event
 		var ts time.Time
 		if err := scanner.ScanIndex(row, 0, &ts); err != nil {
@@ -689,24 +709,26 @@ func (s *adminServer) getUIData(session *sql.Session, user string, keys []string
 		return nil, s.serverErrorf("error constructing query: %v", err)
 	}
 	r := s.server.sqlExecutor.ExecuteStatements(session, query.String(), query.QueryArguments())
+	defer r.Close()
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return nil, s.serverError(err)
 	}
 
 	// Marshal results.
 	resp := serverpb.GetUIDataResponse{KeyValues: make(map[string]serverpb.GetUIDataResponse_Value)}
-	for _, row := range r.ResultList[0].Rows {
-		dKey, ok := row.Values[0].(*parser.DString)
+	for i, nRows := 0, r.ResultList[0].Rows.Len(); i < nRows; i++ {
+		row := r.ResultList[0].Rows.At(i)
+		dKey, ok := row[0].(*parser.DString)
 		if !ok {
-			return nil, s.serverErrorf("unexpected type for UI key: %T", row.Values[0])
+			return nil, s.serverErrorf("unexpected type for UI key: %T", row[0])
 		}
-		dValue, ok := row.Values[1].(*parser.DBytes)
+		dValue, ok := row[1].(*parser.DBytes)
 		if !ok {
-			return nil, s.serverErrorf("unexpected type for UI value: %T", row.Values[1])
+			return nil, s.serverErrorf("unexpected type for UI value: %T", row[1])
 		}
-		dLastUpdated, ok := row.Values[2].(*parser.DTimestamp)
+		dLastUpdated, ok := row[2].(*parser.DTimestamp)
 		if !ok {
-			return nil, s.serverErrorf("unexpected type for UI lastUpdated: %T", row.Values[2])
+			return nil, s.serverErrorf("unexpected type for UI lastUpdated: %T", row[2])
 		}
 
 		resp.KeyValues[string(*dKey)] = serverpb.GetUIDataResponse_Value{
@@ -726,11 +748,13 @@ func (s *adminServer) SetUIData(ctx context.Context, req *serverpb.SetUIDataRequ
 
 	args := sql.SessionArgs{User: s.getUser(req)}
 	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
+	defer session.Finish()
 
 	for key, val := range req.KeyValues {
 		// Do an upsert of the key. We update each key in a separate transaction to
 		// avoid long-running transactions and possible deadlocks.
 		br := s.server.sqlExecutor.ExecuteStatements(session, "BEGIN;", nil)
+		defer br.Close()
 		if err := s.checkQueryResults(br.ResultList, 1); err != nil {
 			return nil, s.serverError(err)
 		}
@@ -749,6 +773,7 @@ func (s *adminServer) SetUIData(ctx context.Context, req *serverpb.SetUIDataRequ
 			qargs.SetValue(`1`, parser.NewDString(string(val)))
 			qargs.SetValue(`2`, parser.NewDString(key))
 			r := s.server.sqlExecutor.ExecuteStatements(session, query, qargs)
+			defer r.Close()
 			if err := s.checkQueryResults(r.ResultList, 2); err != nil {
 				return nil, s.serverError(err)
 			}
@@ -761,6 +786,7 @@ func (s *adminServer) SetUIData(ctx context.Context, req *serverpb.SetUIDataRequ
 			qargs.SetValue(`1`, parser.NewDString(key))
 			qargs.SetValue(`2`, parser.NewDBytes(parser.DBytes(val)))
 			r := s.server.sqlExecutor.ExecuteStatements(session, query, qargs)
+			defer r.Close()
 			if err := s.checkQueryResults(r.ResultList, 2); err != nil {
 				return nil, s.serverError(err)
 			}
@@ -782,6 +808,7 @@ func (s *adminServer) SetUIData(ctx context.Context, req *serverpb.SetUIDataRequ
 func (s *adminServer) GetUIData(ctx context.Context, req *serverpb.GetUIDataRequest) (*serverpb.GetUIDataResponse, error) {
 	args := sql.SessionArgs{User: s.getUser(req)}
 	session := sql.NewSession(ctx, args, s.server.sqlExecutor, nil)
+	defer session.Finish()
 
 	if len(req.Keys) == 0 {
 		return nil, grpc.Errorf(codes.InvalidArgument, "keys cannot be empty")
@@ -1152,17 +1179,17 @@ func makeResultScanner(cols []sql.ResultColumn) resultScanner {
 
 // IsNull returns whether the specified column of the given row contains
 // a SQL NULL value.
-func (rs resultScanner) IsNull(row sql.ResultRow, col string) (bool, error) {
+func (rs resultScanner) IsNull(row parser.DTuple, col string) (bool, error) {
 	idx, ok := rs.colNameToIdx[col]
 	if !ok {
 		return false, errors.Errorf("result is missing column %s", col)
 	}
-	return row.Values[idx] == parser.DNull, nil
+	return row[idx] == parser.DNull, nil
 }
 
 // ScanIndex scans the given column index of the given row into dst.
-func (rs resultScanner) ScanIndex(row sql.ResultRow, index int, dst interface{}) error {
-	src := row.Values[index]
+func (rs resultScanner) ScanIndex(row parser.DTuple, index int, dst interface{}) error {
+	src := row[index]
 
 	switch d := dst.(type) {
 	case *string:
@@ -1224,7 +1251,7 @@ func (rs resultScanner) ScanIndex(row sql.ResultRow, index int, dst interface{})
 }
 
 // Scan scans the column with the given name from the given row into dst.
-func (rs resultScanner) Scan(row sql.ResultRow, colName string, dst interface{}) error {
+func (rs resultScanner) Scan(row parser.DTuple, colName string, dst interface{}) error {
 	idx, ok := rs.colNameToIdx[colName]
 	if !ok {
 		return errors.Errorf("result is missing column %s", colName)
@@ -1251,18 +1278,19 @@ func (s *adminServer) queryZone(
 	params := parser.NewPlaceholderInfo()
 	params.SetValue(`1`, parser.NewDInt(parser.DInt(id)))
 	r := s.server.sqlExecutor.ExecuteStatements(session, query, params)
+	defer r.Close()
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return config.ZoneConfig{}, false, err
 	}
 
 	result := r.ResultList[0]
-	if len(result.Rows) == 0 {
+	if result.Rows.Len() == 0 {
 		return config.ZoneConfig{}, false, nil
 	}
 
 	var zoneBytes []byte
 	scanner := resultScanner{}
-	err := scanner.ScanIndex(result.Rows[0], 0, &zoneBytes)
+	err := scanner.ScanIndex(result.Rows.At(0), 0, &zoneBytes)
 	if err != nil {
 		return config.ZoneConfig{}, false, err
 	}
@@ -1299,18 +1327,19 @@ func (s *adminServer) queryNamespaceID(
 	params.SetValue(`1`, parser.NewDInt(parser.DInt(parentID)))
 	params.SetValue(`2`, parser.NewDString(name))
 	r := s.server.sqlExecutor.ExecuteStatements(session, query, params)
+	defer r.Close()
 	if err := s.checkQueryResults(r.ResultList, 1); err != nil {
 		return 0, err
 	}
 
 	result := r.ResultList[0]
-	if len(result.Rows) == 0 {
+	if result.Rows.Len() == 0 {
 		return 0, errors.Errorf("namespace %s with ParentID %d not found", name, parentID)
 	}
 
 	var id int64
 	scanner := resultScanner{}
-	err := scanner.ScanIndex(result.Rows[0], 0, &id)
+	err := scanner.ScanIndex(result.Rows.At(0), 0, &id)
 	if err != nil {
 		return 0, err
 	}

--- a/sql/alter_table.go
+++ b/sql/alter_table.go
@@ -361,7 +361,8 @@ func (n *alterTableNode) Start() error {
 }
 
 func (n *alterTableNode) Next() (bool, error)                 { return false, nil }
-func (n *alterTableNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
+func (n *alterTableNode) Close()                              {}
+func (n *alterTableNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
 func (n *alterTableNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *alterTableNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *alterTableNode) DebugValues() debugValues            { return debugValues{} }

--- a/sql/copy.go
+++ b/sql/copy.go
@@ -20,7 +20,9 @@ import (
 	"bytes"
 	"fmt"
 	"time"
+	"unsafe"
 
+	"github.com/cockroachdb/cockroach/sql/mon"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/privilege"
 )
@@ -42,12 +44,13 @@ type copyNode struct {
 	p             *planner
 	table         parser.TableExpr
 	columns       parser.UnresolvedNames
-	resultColumns []ResultColumn
+	resultColumns ResultColumns
 	buf           bytes.Buffer
 	rows          []*parser.Tuple
+	rowsMemAcc    mon.MemoryAccount
 }
 
-func (n *copyNode) Columns() []ResultColumn           { return n.resultColumns }
+func (n *copyNode) Columns() ResultColumns            { return n.resultColumns }
 func (*copyNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (*copyNode) Values() parser.DTuple               { return nil }
 func (*copyNode) ExplainTypes(_ func(string, string)) {}
@@ -55,6 +58,10 @@ func (*copyNode) SetLimitHint(_ int64, _ bool)        {}
 func (*copyNode) MarkDebug(_ explainMode)             {}
 func (*copyNode) expandPlan() error                   { return nil }
 func (*copyNode) Next() (bool, error)                 { return false, nil }
+
+func (n *copyNode) Close() {
+	n.rowsMemAcc.Close(n.p.session.Ctx())
+}
 
 func (*copyNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	return "copy", "-", nil
@@ -89,15 +96,16 @@ func (p *planner) CopyFrom(n *parser.CopyFrom, autoCommit bool) (planNode, error
 	if err != nil {
 		return nil, err
 	}
-	cn.resultColumns = make([]ResultColumn, len(cols))
+	cn.resultColumns = make(ResultColumns, len(cols))
 	for i, c := range cols {
 		cn.resultColumns[i] = ResultColumn{Typ: c.Type.ToDatumType()}
 	}
 	cn.p = p
+	cn.rowsMemAcc = p.session.mon.OpenAccount(p.session.Ctx())
 	return cn, nil
 }
 
-// Start
+// Start implements the planNode interface.
 func (n *copyNode) Start() error {
 	// Should never happen because the executor prevents non-COPY messages during
 	// a COPY.
@@ -235,9 +243,20 @@ func (n *copyNode) addRow(line []byte) error {
 		if err != nil {
 			return err
 		}
+
+		sz, _ := d.Size()
+		if err := n.rowsMemAcc.Grow(n.p.session.Ctx(), int64(sz)); err != nil {
+			return err
+		}
+
 		exprs[i] = d
 	}
-	n.rows = append(n.rows, &parser.Tuple{Exprs: exprs})
+	tuple := &parser.Tuple{Exprs: exprs}
+	if err := n.rowsMemAcc.Grow(n.p.session.Ctx(), int64(unsafe.Sizeof(*tuple))); err != nil {
+		return err
+	}
+
+	n.rows = append(n.rows, tuple)
 	return nil
 }
 
@@ -351,6 +370,7 @@ func (p *planner) CopyData(n CopyDataBlock, autoCommit bool) (planNode, error) {
 	vc := &parser.ValuesClause{Tuples: cf.rows}
 	// Reuse the same backing array once the Insert is complete.
 	cf.rows = cf.rows[:0]
+	cf.rowsMemAcc.Clear(p.session.Ctx())
 
 	in := parser.Insert{
 		Table:   cf.table,

--- a/sql/create.go
+++ b/sql/create.go
@@ -98,7 +98,8 @@ func (n *createDatabaseNode) Start() error {
 }
 
 func (n *createDatabaseNode) Next() (bool, error)                 { return false, nil }
-func (n *createDatabaseNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
+func (n *createDatabaseNode) Close()                              {}
+func (n *createDatabaseNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
 func (n *createDatabaseNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *createDatabaseNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *createDatabaseNode) DebugValues() debugValues            { return debugValues{} }
@@ -216,7 +217,8 @@ func (n *createIndexNode) Start() error {
 }
 
 func (n *createIndexNode) Next() (bool, error)                 { return false, nil }
-func (n *createIndexNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
+func (n *createIndexNode) Close()                              {}
+func (n *createIndexNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
 func (n *createIndexNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *createIndexNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *createIndexNode) DebugValues() debugValues            { return debugValues{} }
@@ -265,6 +267,10 @@ func (p *planner) CreateTable(n *parser.CreateTable) (planNode, error) {
 
 	var selectPlan planNode
 	if n.As() {
+		// The selectPlan is needed to determine the set of columns to use
+		// to populate the new table descriptor in Start() below. We
+		// instantiate the selectPlan as early as here so that EXPLAIN has
+		// something useful to show about CREATE TABLE .. AS ...
 		selectPlan, err = p.getSelectPlan(n)
 		if err != nil {
 			return nil, err
@@ -280,14 +286,14 @@ func removeParens(sel parser.SelectStatement) (parser.SelectStatement, error) {
 	case *parser.ParenSelect:
 		return removeParens(ps.Select.Select)
 	default:
-		return nil, errors.Errorf("Invalid Select type.")
+		return nil, errors.Errorf("invalid select type %T", sel)
 	}
 }
 
 func (p *planner) getSelectPlan(n *parser.CreateTable) (planNode, error) {
 	selNoParens, err := removeParens(n.AsSource.Select)
 	if err != nil {
-		return nil, errors.Errorf("Invalid Select type.")
+		return nil, err
 	}
 	s, err := p.SelectClause(selNoParens.(*parser.SelectClause), n.AsSource.OrderBy, n.AsSource.Limit, []parser.Datum{}, 0)
 	if err != nil {
@@ -481,6 +487,17 @@ func (n *createTableNode) Start() error {
 		if err != nil {
 			return err
 		}
+
+		// TODO(knz): Ideally we would want to plug the selectPlan which
+		// was already computed as a data source into the insertNode. Now
+		// unfortunately this is not so easy: when this point is reached,
+		// selectPlan.expandPlan() has already been called, and
+		// insertPlan.expandPlan() below would cause a 2nd invocation and
+		// cause a panic. So instead we close this selectPlan and let the
+		// insertNode create it anew from the AsSource syntax node.
+		n.selectPlan.Close()
+		n.selectPlan = nil
+
 		desiredTypesFromSelect := make([]parser.Datum, len(resultColumns))
 		for i, col := range resultColumns {
 			desiredTypesFromSelect[i] = col.Typ
@@ -491,12 +508,10 @@ func (n *createTableNode) Start() error {
 			return err
 		}
 		n.insertPlan = insertPlan
-		err = insertPlan.expandPlan()
-		if err != nil {
+		if err := insertPlan.expandPlan(); err != nil {
 			return err
 		}
-		err = insertPlan.Start()
-		if err != nil {
+		if err = insertPlan.Start(); err != nil {
 			return err
 		}
 		// This loop is done here instead of in the Next method
@@ -511,11 +526,14 @@ func (n *createTableNode) Start() error {
 	return nil
 }
 
-func (n *createTableNode) Next() (bool, error) {
-	return false, nil
+func (n *createTableNode) Close() {
+	if n.insertPlan != nil {
+		n.insertPlan.Close()
+	}
 }
 
-func (n *createTableNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
+func (n *createTableNode) Next() (bool, error)                 { return false, nil }
+func (n *createTableNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
 func (n *createTableNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *createTableNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *createTableNode) DebugValues() debugValues            { return debugValues{} }

--- a/sql/data_source.go
+++ b/sql/data_source.go
@@ -112,7 +112,7 @@ import (
 type dataSourceInfo struct {
 	// sourceColumns match the plan.Columns() 1-to-1. However the column
 	// names might be different if the statement renames them using AS.
-	sourceColumns []ResultColumn
+	sourceColumns ResultColumns
 
 	// sourceAliases indicates to which table alias column ranges
 	// belong.
@@ -153,7 +153,7 @@ func fillColumnRange(firstIdx, lastIdx int) columnRange {
 
 // newSourceInfoForSingleTable creates a simple dataSourceInfo
 // which maps the same tableAlias to all columns.
-func newSourceInfoForSingleTable(tn parser.TableName, columns []ResultColumn) *dataSourceInfo {
+func newSourceInfoForSingleTable(tn parser.TableName, columns ResultColumns) *dataSourceInfo {
 	norm := sqlbase.NormalizeTableName(tn)
 	return &dataSourceInfo{
 		sourceColumns: columns,
@@ -294,7 +294,7 @@ func (p *planner) getDataSource(
 
 		if len(colAlias) > 0 {
 			// Make a copy of the slice since we are about to modify the contents.
-			src.info.sourceColumns = append([]ResultColumn(nil), src.info.sourceColumns...)
+			src.info.sourceColumns = append(ResultColumns(nil), src.info.sourceColumns...)
 
 			// The column aliases can only refer to explicit columns.
 			for colIdx, aliasIdx := 0, 0; aliasIdx < len(colAlias); colIdx++ {
@@ -328,7 +328,7 @@ func (p *planner) getDataSource(
 // expressions that correspond to the expansion of a star.
 func (src *dataSourceInfo) expandStar(
 	v parser.VarName, qvals qvalMap,
-) (columns []ResultColumn, exprs []parser.TypedExpr, err error) {
+) (columns ResultColumns, exprs []parser.TypedExpr, err error) {
 	if len(src.sourceColumns) == 0 {
 		return nil, nil, fmt.Errorf("cannot use %q without a FROM clause", v)
 	}
@@ -598,7 +598,7 @@ func concatDataSourceInfos(left *dataSourceInfo, right *dataSourceInfo) (*dataSo
 		aliases[k] = v
 	}
 
-	columns := make([]ResultColumn, 0, len(left.sourceColumns)+len(right.sourceColumns))
+	columns := make(ResultColumns, 0, len(left.sourceColumns)+len(right.sourceColumns))
 	columns = append(columns, left.sourceColumns...)
 	columns = append(columns, right.sourceColumns...)
 

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -133,6 +133,10 @@ func (d *deleteNode) Start() error {
 	return d.run.tw.init(d.p.txn)
 }
 
+func (d *deleteNode) Close() {
+	d.run.rows.Close()
+}
+
 func (d *deleteNode) FastPathResults() (int, bool) {
 	if d.run.fastPath {
 		return d.rh.rowCount, true
@@ -213,7 +217,7 @@ func (d *deleteNode) fastDelete(scan *scanNode) error {
 	return nil
 }
 
-func (d *deleteNode) Columns() []ResultColumn {
+func (d *deleteNode) Columns() ResultColumns {
 	return d.rh.columns
 }
 

--- a/sql/distinct.go
+++ b/sql/distinct.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/sql/mon"
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 )
@@ -28,25 +29,34 @@ import (
 // distinctNode de-duplicates rows returned by a wrapped planNode.
 type distinctNode struct {
 	plan planNode
+	p    *planner
 	top  *selectTopNode
 	// All the columns that are part of the Sort. Set to nil if no-sort, or
 	// sort used an expression that was not part of the requested column set.
 	columnsInOrder []bool
 	// Encoding of the columnsInOrder columns for the previous row.
-	prefixSeen []byte
+	prefixSeen   []byte
+	prefixMemAcc mon.MemoryAccount
+
 	// Encoding of the non-columnInOrder columns for rows sharing the same
 	// prefixSeen value.
-	suffixSeen map[string]struct{}
-	explain    explainMode
-	debugVals  debugValues
+	suffixSeen   map[string]struct{}
+	suffixMemAcc mon.MemoryAccount
+
+	explain   explainMode
+	debugVals debugValues
 }
 
 // distinct constructs a distinctNode.
-func (*planner) Distinct(n *parser.SelectClause) *distinctNode {
+func (p *planner) Distinct(n *parser.SelectClause) *distinctNode {
 	if !n.Distinct {
 		return nil
 	}
-	return &distinctNode{}
+	d := &distinctNode{p: p}
+	ctx := p.session.Ctx()
+	d.prefixMemAcc = p.session.mon.OpenAccount(ctx)
+	d.suffixMemAcc = p.session.mon.OpenAccount(ctx)
+	return d
 }
 
 // wrap connects the distinctNode to its source planNode.
@@ -103,7 +113,7 @@ func (n *distinctNode) setTop(top *selectTopNode) {
 	}
 }
 
-func (n *distinctNode) Columns() []ResultColumn {
+func (n *distinctNode) Columns() ResultColumns {
 	if n.plan != nil {
 		return n.plan.Columns()
 	}
@@ -129,6 +139,15 @@ func (n *distinctNode) DebugValues() debugValues {
 	return n.debugVals
 }
 
+func (n *distinctNode) addSuffixSeen(sKey string) error {
+	sz := int64(len(sKey))
+	if err := n.suffixMemAcc.Grow(n.p.session.Ctx(), sz); err != nil {
+		return err
+	}
+	n.suffixSeen[sKey] = struct{}{}
+	return nil
+}
+
 func (n *distinctNode) Next() (bool, error) {
 	for {
 		next, err := n.plan.Next()
@@ -152,11 +171,18 @@ func (n *distinctNode) Next() (bool, error) {
 			// The prefix of the row which is ordered differs from the last row;
 			// reset our seen set.
 			if len(n.suffixSeen) > 0 {
+				n.suffixMemAcc.Clear(n.p.session.Ctx())
 				n.suffixSeen = make(map[string]struct{})
+			}
+			if err := n.prefixMemAcc.ResizeItem(n.p.session.Ctx(),
+				int64(len(n.prefixSeen)), int64(len(prefix))); err != nil {
+				return false, err
 			}
 			n.prefixSeen = prefix
 			if suffix != nil {
-				n.suffixSeen[string(suffix)] = struct{}{}
+				if err := n.addSuffixSeen(string(suffix)); err != nil {
+					return false, err
+				}
 			}
 			return true, nil
 		}
@@ -166,7 +192,9 @@ func (n *distinctNode) Next() (bool, error) {
 		if suffix != nil {
 			sKey := string(suffix)
 			if _, ok := n.suffixSeen[sKey]; !ok {
-				n.suffixSeen[sKey] = struct{}{}
+				if err := n.addSuffixSeen(sKey); err != nil {
+					return false, err
+				}
 				return true, nil
 			}
 		}
@@ -222,4 +250,13 @@ func (n *distinctNode) ExplainTypes(_ func(string, string)) {}
 func (n *distinctNode) SetLimitHint(numRows int64, soft bool) {
 	// Any limit becomes a "soft" limit underneath.
 	n.plan.SetLimitHint(numRows, true)
+}
+
+func (n *distinctNode) Close() {
+	n.plan.Close()
+	n.prefixSeen = nil
+	n.suffixSeen = nil
+	ctx := n.p.session.Ctx()
+	n.prefixMemAcc.Close(ctx)
+	n.suffixMemAcc.Close(ctx)
 }

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -149,7 +149,8 @@ func (n *dropDatabaseNode) Start() error {
 }
 
 func (n *dropDatabaseNode) Next() (bool, error)                 { return false, nil }
-func (n *dropDatabaseNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
+func (n *dropDatabaseNode) Close()                              {}
+func (n *dropDatabaseNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
 func (n *dropDatabaseNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *dropDatabaseNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *dropDatabaseNode) DebugValues() debugValues            { return debugValues{} }
@@ -294,7 +295,8 @@ func (n *dropIndexNode) Start() error {
 }
 
 func (n *dropIndexNode) Next() (bool, error)                 { return false, nil }
-func (n *dropIndexNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
+func (n *dropIndexNode) Close()                              {}
+func (n *dropIndexNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
 func (n *dropIndexNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *dropIndexNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *dropIndexNode) DebugValues() debugValues            { return debugValues{} }
@@ -459,7 +461,8 @@ func (n *dropTableNode) Start() error {
 }
 
 func (n *dropTableNode) Next() (bool, error)                 { return false, nil }
-func (n *dropTableNode) Columns() []ResultColumn             { return make([]ResultColumn, 0) }
+func (n *dropTableNode) Close()                              {}
+func (n *dropTableNode) Columns() ResultColumns              { return make(ResultColumns, 0) }
 func (n *dropTableNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (n *dropTableNode) Values() parser.DTuple               { return parser.DTuple{} }
 func (n *dropTableNode) ExplainTypes(_ func(string, string)) {}

--- a/sql/empty.go
+++ b/sql/empty.go
@@ -27,7 +27,7 @@ type emptyNode struct {
 	results bool
 }
 
-func (*emptyNode) Columns() []ResultColumn             { return nil }
+func (*emptyNode) Columns() ResultColumns              { return nil }
 func (*emptyNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (*emptyNode) Values() parser.DTuple               { return nil }
 func (*emptyNode) ExplainTypes(_ func(string, string)) {}
@@ -35,6 +35,7 @@ func (*emptyNode) Start() error                        { return nil }
 func (*emptyNode) SetLimitHint(_ int64, _ bool)        {}
 func (*emptyNode) MarkDebug(_ explainMode)             {}
 func (*emptyNode) expandPlan() error                   { return nil }
+func (*emptyNode) Close()                              {}
 
 func (*emptyNode) ExplainPlan(_ bool) (name, description string, children []planNode) {
 	return "empty", "-", nil

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -98,6 +98,13 @@ type StatementResults struct {
 	Empty bool
 }
 
+// Close ensures that the resources claimed by the results are released.
+func (s *StatementResults) Close() {
+	for _, r := range s.ResultList {
+		r.Close()
+	}
+}
+
 // Result corresponds to the execution of a single SQL statement.
 type Result struct {
 	Err error
@@ -111,11 +118,20 @@ type Result struct {
 	// the names and types of the columns returned in the result set in the order
 	// specified in the SQL statement. The number of columns will equal the number
 	// of values in each Row.
-	Columns []ResultColumn
+	Columns ResultColumns
 	// Rows will be populated if the statement type is "Rows". It will contain
 	// the result set of the result.
 	// TODO(nvanbenschoten): Can this be streamed from the planNode?
-	Rows []ResultRow
+	Rows *RowContainer
+}
+
+// Close ensures that the resources claimed by the result are released.
+func (r *Result) Close() {
+	// The Rows pointer may be nil if the statement returned no rows or
+	// if an error occurred.
+	if r.Rows != nil {
+		r.Rows.Close()
+	}
 }
 
 // ResultColumn contains the name and type of a SQL "cell".
@@ -127,10 +143,9 @@ type ResultColumn struct {
 	hidden bool
 }
 
-// ResultRow is a collection of values representing a row in a result.
-type ResultRow struct {
-	Values []parser.Datum
-}
+// ResultColumns is the type used throughout the sql module to
+// describe the column types of a table.
+type ResultColumns []ResultColumn
 
 // An Executor executes SQL statements.
 // Executor is thread-safe.
@@ -343,7 +358,7 @@ func (e *Executor) Prepare(
 	query string,
 	session *Session,
 	pinfo parser.PlaceholderTypes,
-) ([]ResultColumn, error) {
+) (ResultColumns, error) {
 	if log.V(2) {
 		log.Infof(session.Ctx(), "preparing: %s", query)
 	} else if traceSQL {
@@ -388,6 +403,7 @@ func (e *Executor) Prepare(
 	if plan == nil {
 		return nil, nil
 	}
+	defer plan.Close()
 	cols := plan.Columns()
 	for _, c := range cols {
 		if err := checkResultDatum(c.Typ); err != nil {
@@ -428,6 +444,7 @@ func (e *Executor) CopyDone(session *Session) StatementResults {
 
 // CopyEnd ends the COPY mode. Any buffered data is discarded.
 func (session *Session) CopyEnd() {
+	session.planner.copyFrom.Close()
 	session.planner.copyFrom = nil
 }
 
@@ -1017,6 +1034,10 @@ func (e *Executor) execStmtInOpenTxn(
 	autoCommit := implicitTxn && !e.cfg.TestingKnobs.DisableAutoCommit
 	result, err := e.execStmt(stmt, planMaker, autoCommit)
 	if err != nil {
+		if result.Rows != nil {
+			result.Rows.Close()
+			result.Rows = nil
+		}
 		if traceSQL {
 			log.ErrEventf(txnState.txn.Context, "ERROR: %v", err)
 		}
@@ -1030,7 +1051,7 @@ func (e *Executor) execStmtInOpenTxn(
 	case parser.RowsAffected:
 		tResult.count = result.RowsAffected
 	case parser.Rows:
-		tResult.count = len(result.Rows)
+		tResult.count = result.Rows.Len()
 	}
 	if traceSQL {
 		log.Eventf(txnState.txn.Context, "%s done", tResult)
@@ -1127,6 +1148,8 @@ func (e *Executor) execStmt(
 		return result, err
 	}
 
+	defer plan.Close()
+
 	if testDistSQL != 0 {
 		if err := hackPlanToUseDistSQL(plan, testDistSQL == 1); err != nil {
 			return result, err
@@ -1155,9 +1178,10 @@ func (e *Executor) execStmt(
 				return result, err
 			}
 		}
+		result.Rows = planMaker.NewRowContainer(result.Columns, 0)
 
 		// valuesAlloc is used to allocate the backing storage for the
-		// ResultRow.Values slices in chunks.
+		// result row slices in chunks.
 		var valuesAlloc []parser.Datum
 		const maxChunkSize = 64 // Arbitrary, could use tuning.
 		chunkSize := 4          // Arbitrary as well.
@@ -1169,21 +1193,23 @@ func (e *Executor) execStmt(
 
 			n := len(values)
 			if len(valuesAlloc) < n {
-				valuesAlloc = make([]parser.Datum, len(result.Columns)*chunkSize)
+				valuesAlloc = make(parser.DTuple, len(result.Columns)*chunkSize)
 				if chunkSize < maxChunkSize {
 					chunkSize *= 2
 				}
 			}
-			row := ResultRow{Values: valuesAlloc[:0:n]}
+			row := valuesAlloc[:0:n]
 			valuesAlloc = valuesAlloc[n:]
 
 			for _, val := range values {
 				if err := checkResultDatum(val); err != nil {
 					return result, err
 				}
-				row.Values = append(row.Values, val)
+				row = append(row, val)
 			}
-			result.Rows = append(result.Rows, row)
+			if err := result.Rows.AddRow(row); err != nil {
+				return result, err
+			}
 		}
 		if err != nil {
 			return result, err
@@ -1308,8 +1334,8 @@ func checkResultDatum(datum parser.Datum) error {
 }
 
 // makeResultColumns converts sqlbase.ColumnDescriptors to ResultColumns.
-func makeResultColumns(colDescs []sqlbase.ColumnDescriptor) []ResultColumn {
-	cols := make([]ResultColumn, 0, len(colDescs))
+func makeResultColumns(colDescs []sqlbase.ColumnDescriptor) ResultColumns {
+	cols := make(ResultColumns, 0, len(colDescs))
 	for _, colDesc := range colDescs {
 		// Convert the sqlbase.ColumnDescriptor to ResultColumn.
 		typ := colDesc.Type.ToDatumType()

--- a/sql/explain.go
+++ b/sql/explain.go
@@ -102,29 +102,39 @@ func (p *planner) Explain(n *parser.Explain, autoCommit bool) (planNode, error) 
 		return &explainDebugNode{plan}, nil
 
 	case explainTypes:
+		columns := ResultColumns{
+			{Name: "Level", Typ: parser.TypeInt},
+			{Name: "Type", Typ: parser.TypeString},
+			{Name: "Element", Typ: parser.TypeString},
+			{Name: "Description", Typ: parser.TypeString},
+		}
 		node := &explainTypesNode{
 			plan:     plan,
 			expanded: expanded,
-			results: &valuesNode{
-				columns: []ResultColumn{
-					{Name: "Level", Typ: parser.TypeInt},
-					{Name: "Type", Typ: parser.TypeString},
-					{Name: "Element", Typ: parser.TypeString},
-					{Name: "Description", Typ: parser.TypeString},
-				},
-			},
+			results:  p.newContainerValuesNode(columns, 0),
 		}
 		return node, nil
 
 	case explainPlan:
+		columns := ResultColumns{
+			{Name: "Level", Typ: parser.TypeInt},
+			{Name: "Type", Typ: parser.TypeString},
+			{Name: "Description", Typ: parser.TypeString},
+		}
+		if verbose {
+			columns = append(columns, ResultColumn{Name: "Columns", Typ: parser.TypeString})
+			columns = append(columns, ResultColumn{Name: "Ordering", Typ: parser.TypeString})
+		}
+
 		node := &explainPlanNode{
 			verbose: verbose,
 			plan:    plan,
+			results: p.newContainerValuesNode(columns, 0),
 		}
 		return node, nil
 
 	case explainTrace:
-		return makeTraceNode(plan, p.txn), nil
+		return p.makeTraceNode(plan, p.txn), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported EXPLAIN mode: %d", mode)
@@ -139,7 +149,7 @@ type explainTypesNode struct {
 
 func (e *explainTypesNode) ExplainTypes(fn func(string, string)) {}
 func (e *explainTypesNode) Next() (bool, error)                  { return e.results.Next() }
-func (e *explainTypesNode) Columns() []ResultColumn              { return e.results.Columns() }
+func (e *explainTypesNode) Columns() ResultColumns               { return e.results.Columns() }
 func (e *explainTypesNode) Ordering() orderingInfo               { return e.results.Ordering() }
 func (e *explainTypesNode) Values() parser.DTuple                { return e.results.Values() }
 func (e *explainTypesNode) DebugValues() debugValues             { return e.results.DebugValues() }
@@ -164,11 +174,15 @@ func (e *explainTypesNode) expandPlan() error {
 }
 
 func (e *explainTypesNode) Start() error {
-	populateTypes(e.results, e.plan, 0)
-	return nil
+	return populateTypes(e.results, e.plan, 0)
 }
 
-func formatColumns(cols []ResultColumn, printTypes bool) string {
+func (e *explainTypesNode) Close() {
+	e.plan.Close()
+	e.results.Close()
+}
+
+func formatColumns(cols ResultColumns, printTypes bool) string {
 	var buf bytes.Buffer
 	buf.WriteByte('(')
 	for i, rCol := range cols {
@@ -188,7 +202,7 @@ func formatColumns(cols []ResultColumn, printTypes bool) string {
 	return buf.String()
 }
 
-func populateTypes(v *valuesNode, plan planNode, level int) {
+func populateTypes(v *valuesNode, plan planNode, level int) error {
 	name, _, children := plan.ExplainPlan(true)
 
 	// Format the result column types.
@@ -198,24 +212,39 @@ func populateTypes(v *valuesNode, plan planNode, level int) {
 		parser.NewDString("result"),
 		parser.NewDString(formatColumns(plan.Columns(), true)),
 	}
-	v.rows = append(v.rows, row)
+	if err := v.rows.AddRow(row); err != nil {
+		return err
+	}
 
 	// Format the node's typing details.
+	var err error
 	regType := func(elt string, desc string) {
+		if err != nil {
+			return
+		}
+
 		row := parser.DTuple{
 			parser.NewDInt(parser.DInt(level)),
 			parser.NewDString(name),
 			parser.NewDString(elt),
 			parser.NewDString(desc),
 		}
-		v.rows = append(v.rows, row)
+		err = v.rows.AddRow(row)
 	}
 	plan.ExplainTypes(regType)
 
+	if err != nil {
+		return err
+	}
+
 	// Recurse into sub-nodes.
 	for _, child := range children {
-		populateTypes(v, child, level+1)
+		if err := populateTypes(v, child, level+1); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
 type explainPlanNode struct {
@@ -226,24 +255,13 @@ type explainPlanNode struct {
 
 func (e *explainPlanNode) ExplainTypes(fn func(string, string)) {}
 func (e *explainPlanNode) Next() (bool, error)                  { return e.results.Next() }
-func (e *explainPlanNode) Columns() []ResultColumn              { return e.results.Columns() }
+func (e *explainPlanNode) Columns() ResultColumns               { return e.results.Columns() }
 func (e *explainPlanNode) Ordering() orderingInfo               { return e.results.Ordering() }
 func (e *explainPlanNode) Values() parser.DTuple                { return e.results.Values() }
 func (e *explainPlanNode) DebugValues() debugValues             { return debugValues{} }
 func (e *explainPlanNode) SetLimitHint(n int64, s bool)         { e.results.SetLimitHint(n, s) }
 func (e *explainPlanNode) MarkDebug(mode explainMode)           {}
 func (e *explainPlanNode) expandPlan() error {
-	columns := []ResultColumn{
-		{Name: "Level", Typ: parser.TypeInt},
-		{Name: "Type", Typ: parser.TypeString},
-		{Name: "Description", Typ: parser.TypeString},
-	}
-	if e.verbose {
-		columns = append(columns, ResultColumn{Name: "Columns", Typ: parser.TypeString})
-		columns = append(columns, ResultColumn{Name: "Ordering", Typ: parser.TypeString})
-	}
-	e.results = &valuesNode{columns: columns}
-
 	if err := e.plan.expandPlan(); err != nil {
 		return err
 	}
@@ -259,11 +277,15 @@ func (e *explainPlanNode) ExplainPlan(v bool) (string, string, []planNode) {
 }
 
 func (e *explainPlanNode) Start() error {
-	populateExplain(e.verbose, e.results, e.plan, 0)
-	return nil
+	return populateExplain(e.verbose, e.results, e.plan, 0)
 }
 
-func populateExplain(verbose bool, v *valuesNode, plan planNode, level int) {
+func (e *explainPlanNode) Close() {
+	e.plan.Close()
+	e.results.Close()
+}
+
+func populateExplain(verbose bool, v *valuesNode, plan planNode, level int) error {
 	name, description, children := plan.ExplainPlan(verbose)
 
 	row := parser.DTuple{
@@ -275,11 +297,16 @@ func populateExplain(verbose bool, v *valuesNode, plan planNode, level int) {
 		row = append(row, parser.NewDString(formatColumns(plan.Columns(), false)))
 		row = append(row, parser.NewDString(plan.Ordering().AsString(plan.Columns())))
 	}
-	v.rows = append(v.rows, row)
+	if err := v.rows.AddRow(row); err != nil {
+		return err
+	}
 
 	for _, child := range children {
-		populateExplain(verbose, v, child, level+1)
+		if err := populateExplain(verbose, v, child, level+1); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 type debugValueType int
@@ -359,15 +386,15 @@ type explainDebugNode struct {
 }
 
 // Columns for explainDebug mode.
-var debugColumns = []ResultColumn{
+var debugColumns = ResultColumns{
 	{Name: "RowIdx", Typ: parser.TypeInt},
 	{Name: "Key", Typ: parser.TypeString},
 	{Name: "Value", Typ: parser.TypeString},
 	{Name: "Disposition", Typ: parser.TypeString},
 }
 
-func (*explainDebugNode) Columns() []ResultColumn { return debugColumns }
-func (*explainDebugNode) Ordering() orderingInfo  { return orderingInfo{} }
+func (*explainDebugNode) Columns() ResultColumns { return debugColumns }
+func (*explainDebugNode) Ordering() orderingInfo { return orderingInfo{} }
 
 func (n *explainDebugNode) expandPlan() error {
 	if err := n.plan.expandPlan(); err != nil {
@@ -379,6 +406,7 @@ func (n *explainDebugNode) expandPlan() error {
 
 func (n *explainDebugNode) Start() error        { return n.plan.Start() }
 func (n *explainDebugNode) Next() (bool, error) { return n.plan.Next() }
+func (n *explainDebugNode) Close()              { n.plan.Close() }
 
 func (n *explainDebugNode) ExplainPlan(v bool) (name, description string, children []planNode) {
 	return n.plan.ExplainPlan(v)

--- a/sql/group_test.go
+++ b/sql/group_test.go
@@ -46,9 +46,10 @@ func TestDesiredAggregateOrder(t *testing.T) {
 		{`(COUNT(a), MIN(a))`, nil},
 		{`(MIN(a+1))`, nil},
 	}
+	p := makePlanner()
 	for _, d := range testData {
 		expr, _ := parseAndNormalizeExpr(t, d.expr)
-		group := &groupNode{}
+		group := &groupNode{planner: p}
 		_, err := extractAggregatesVisitor{n: group}.extract(expr)
 		if err != nil {
 			t.Fatal(err)

--- a/sql/join.go
+++ b/sql/join.go
@@ -118,7 +118,7 @@ func (p *planner) makeIndexJoin(origScan *scanNode, exactPrefix int) (resultPlan
 	}, indexScan
 }
 
-func (n *indexJoinNode) Columns() []ResultColumn {
+func (n *indexJoinNode) Columns() ResultColumns {
 	return n.table.Columns()
 }
 
@@ -243,4 +243,9 @@ func (n *indexJoinNode) ExplainTypes(_ func(string, string)) {}
 
 func (n *indexJoinNode) SetLimitHint(numRows int64, soft bool) {
 	n.index.SetLimitHint(numRows, soft)
+}
+
+func (n *indexJoinNode) Close() {
+	n.index.Close()
+	n.table.Close()
 }

--- a/sql/limit.go
+++ b/sql/limit.go
@@ -200,7 +200,7 @@ func (n *limitNode) setTop(top *selectTopNode) {
 	}
 }
 
-func (n *limitNode) Columns() []ResultColumn {
+func (n *limitNode) Columns() ResultColumns {
 	if n.plan != nil {
 		return n.plan.Columns()
 	}
@@ -279,6 +279,10 @@ func (n *limitNode) ExplainPlan(_ bool) (string, string, []planNode) {
 		subplans = n.p.collectSubqueryPlans(n.offsetExpr, subplans)
 	}
 	return "limit", buf.String(), subplans
+}
+
+func (n *limitNode) Close() {
+	n.plan.Close()
 }
 
 // getLimit computes the actual number of rows to request from the

--- a/sql/mon/account.go
+++ b/sql/mon/account.go
@@ -1,0 +1,97 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package mon
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+)
+
+// MemoryAccount tracks the cumulated allocations for one client of
+// MemoryUsageMonitor. This allows a client to release all the memory
+// at once when it completes its work.
+type MemoryAccount struct {
+	mon          *MemoryUsageMonitor
+	curAllocated int64
+}
+
+// OpenAccount creates a new empty account.
+func (mm *MemoryUsageMonitor) OpenAccount(_ context.Context) MemoryAccount {
+	// TODO(knz): conditionally track accounts in the memory monitor
+	// (#9122).
+	return MemoryAccount{mon: mm, curAllocated: 0}
+}
+
+// OpenAndInitAccount creates a new account and pre-allocates some
+// initial amount of memory.
+func (mm *MemoryUsageMonitor) OpenAndInitAccount(
+	ctx context.Context, acc *MemoryAccount, initialAllocation int64,
+) error {
+	*acc = mm.OpenAccount(ctx)
+	return acc.Grow(ctx, initialAllocation)
+}
+
+// Grow requests a new allocation in an account.
+func (acc *MemoryAccount) Grow(
+	ctx context.Context, extraSize int64,
+) error {
+	if err := acc.mon.reserveMemory(ctx, extraSize); err != nil {
+		return err
+	}
+	acc.curAllocated += extraSize
+	return nil
+}
+
+// Close releases all the cumulated allocations of an account at once.
+func (acc *MemoryAccount) Close(ctx context.Context) {
+	acc.mon.releaseMemory(ctx, acc.curAllocated)
+}
+
+// Clear releases all the cumulated allocations of an account at once
+// and primes it for reuse.
+func (acc *MemoryAccount) Clear(ctx context.Context) {
+	acc.mon.releaseMemory(ctx, acc.curAllocated)
+	acc.curAllocated = 0
+}
+
+// ResizeItem requests a size change for an object already registered
+// in an account. The reservation is not modified if the new allocation is
+// refused, so that the caller can keep using the original item
+// without an accounting error. This is better than calling Clear
+// then Grow because if the Clear succeeds and the Grow fails
+// the original item becomes invisible from the perspective of the
+// monitor.
+func (acc *MemoryAccount) ResizeItem(
+	ctx context.Context, oldSize, newSize int64,
+) error {
+	delta := newSize - oldSize
+	mm := acc.mon
+	switch {
+	case delta > 0:
+		if err := mm.reserveMemory(ctx, delta); err != nil {
+			return err
+		}
+	case delta < 0:
+		if acc.curAllocated < -delta {
+			panic(fmt.Sprintf("no memory in account to release, current %d, free %d", acc.curAllocated, delta))
+		}
+		mm.releaseMemory(ctx, -delta)
+	}
+	acc.curAllocated += delta
+	return nil
+}

--- a/sql/mon/mem_usage.go
+++ b/sql/mon/mem_usage.go
@@ -1,0 +1,136 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package mon
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/cockroachdb/cockroach/util"
+	"github.com/cockroachdb/cockroach/util/envutil"
+	"github.com/cockroachdb/cockroach/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+// noteworthyMemoryUsageBytes is the minimum size tracked by a monitor
+// before the monitor starts explicitly logging overall usage growth in the log.
+var noteworthyMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_MEMORY_USAGE", 10000)
+
+// MemoryUsageMonitor defines an object that can track and limit
+// memory usage by other CockroachDB components.
+//
+// This is currently used by the SQL session, see sql/session_mem_usage.go.
+//
+// The monitor must be set up via StartMonitor/StopMonitor just before
+// and after a processing context.
+// The various counters express sizes in bytes.
+type MemoryUsageMonitor struct {
+	// curAllocated tracks the current amount of memory allocated for
+	// in-memory row storage.
+	curAllocated int64
+
+	// totalAllocated tracks the cumulated amount of memory allocated.
+	totalAllocated int64
+
+	// maxAllocated tracks the high water mark of allocations.
+	maxAllocated int64
+
+	// maxAllocatedBudget sets the allowable upper limit for allocations.
+	// Set to MaxInt64 to indicate no limit.
+	maxAllocatedBudget int64
+}
+
+// reserveMemory declares the intent to allocate a given number of
+// bytes to this monitor. An error is returned if the intent is
+// denied.
+func (mm *MemoryUsageMonitor) reserveMemory(ctx context.Context, x int64) error {
+	// TODO(knz): This is here that a policy will restrict how large a
+	// query can become.
+	if mm.curAllocated > mm.maxAllocatedBudget-x {
+		err := errors.Errorf("memory budget exceeded: %d requested, %s already allocated",
+			x, humanizeutil.IBytes(mm.curAllocated))
+		if log.V(2) {
+			log.Errorf(ctx, "%s - %s", err, util.GetSmallTrace(2))
+		}
+		return err
+	}
+	mm.curAllocated += x
+	mm.totalAllocated += x
+	if mm.maxAllocated < mm.curAllocated {
+		mm.maxAllocated = mm.curAllocated
+	}
+
+	// Report "large" queries to the log for further investigation.
+	if mm.curAllocated > noteworthyMemoryUsageBytes {
+		// We only report changes in binary magnitude of the size.  This
+		// is to limit the amount of log messages when a size blowup is
+		// caused by many small allocations.
+		if util.RoundUpPowerOfTwo(mm.curAllocated) != util.RoundUpPowerOfTwo(mm.curAllocated-x) {
+			log.Infof(ctx, "memory usage increases to %s (+%d)",
+				humanizeutil.IBytes(mm.curAllocated), x)
+		}
+	}
+
+	if log.V(2) {
+		log.Infof(ctx, "now at %d bytes (+%d) - %s", mm.curAllocated, x, util.GetSmallTrace(2))
+	}
+	return nil
+}
+
+// releaseMemory releases memory previously successfully registered
+// via reserveMemory().
+func (mm *MemoryUsageMonitor) releaseMemory(ctx context.Context, x int64) {
+	if mm.curAllocated < x {
+		panic(fmt.Sprintf("no memory to release, current %d, free %d", mm.curAllocated, x))
+	}
+	mm.curAllocated -= x
+
+	if log.V(2) {
+		log.Infof(ctx, "now at %d bytes (-%d) - %s", mm.curAllocated, x, util.GetSmallTrace(2))
+	}
+}
+
+// StartMonitor begins a monitoring region.
+func (mm *MemoryUsageMonitor) StartMonitor() {
+	if mm.curAllocated != 0 {
+		panic(fmt.Sprintf("monitor started with %d bytes left over", mm.curAllocated))
+	}
+	mm.curAllocated = 0
+	mm.maxAllocated = 0
+	mm.totalAllocated = 0
+	// TODO(knz): this is where we will use a policy to set a maximum.
+	mm.maxAllocatedBudget = math.MaxInt64
+}
+
+// StopMonitor completes a monitoring region.
+func (mm *MemoryUsageMonitor) StopMonitor(ctx context.Context) {
+	if log.V(1) {
+		log.InfofDepth(ctx, 1, "memory usage max %s total %s",
+			humanizeutil.IBytes(mm.maxAllocated),
+			humanizeutil.IBytes(mm.totalAllocated))
+	}
+
+	if mm.curAllocated != 0 {
+		panic(fmt.Sprintf("unexpected leftover memory: %d bytes", mm.curAllocated))
+	}
+
+	// Disable the budget for further allocations, so that further SQL
+	// uses outside of monitor control get errors.
+	mm.maxAllocatedBudget = 0
+}

--- a/sql/mon/mem_usage_test.go
+++ b/sql/mon/mem_usage_test.go
@@ -1,0 +1,116 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package mon
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/util/leaktest"
+	"golang.org/x/net/context"
+)
+
+func TestMemoryUsageMonitor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	m := MemoryUsageMonitor{}
+	ctx := context.Background()
+
+	if err := m.reserveMemory(ctx, 10); err == nil {
+		t.Fatal("monitor failed to reject non-monitored request")
+	}
+
+	m.StartMonitor()
+	m.maxAllocatedBudget = 100
+
+	if err := m.reserveMemory(ctx, 10); err != nil {
+		t.Fatalf("monitor refused small allocation: %v", err)
+	}
+	if err := m.reserveMemory(ctx, 91); err == nil {
+		t.Fatalf("monitor accepted excessive allocation: %v", err)
+	}
+	if err := m.reserveMemory(ctx, 90); err != nil {
+		t.Fatalf("monitor refused top allocation: %v", err)
+	}
+	if m.curAllocated != 100 {
+		t.Fatalf("incorrect current allocation: got %d, expected %d", m.curAllocated, 100)
+	}
+
+	m.releaseMemory(ctx, 90) // Should succeed without panic.
+	if m.curAllocated != 10 {
+		t.Fatalf("incorrect current allocation: got %d, expected %d", m.curAllocated, 10)
+	}
+	if m.maxAllocated != 100 {
+		t.Fatalf("incorrect max allocation: got %d, expected %d", m.maxAllocated, 100)
+	}
+
+	m.releaseMemory(ctx, 10) // Should succeed without panic.
+	if m.curAllocated != 0 {
+		t.Fatalf("incorrect current allocation: got %d, expected %d", m.curAllocated, 0)
+	}
+}
+
+func TestMemoryAccount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	m := MemoryUsageMonitor{}
+	ctx := context.Background()
+
+	var a1, a2 MemoryAccount
+
+	m.StartMonitor()
+	a1 = m.OpenAccount(ctx)
+	a2 = m.OpenAccount(ctx)
+
+	m.maxAllocatedBudget = 100
+
+	if err := a1.Grow(ctx, 10); err != nil {
+		t.Fatalf("monitor refused allocation: %v", err)
+	}
+
+	if err := a2.Grow(ctx, 30); err != nil {
+		t.Fatalf("monitor refused allocation: %v", err)
+	}
+
+	if err := a1.Grow(ctx, 61); err == nil {
+		t.Fatalf("monitor accepted excessive allocation")
+	}
+
+	if err := a2.Grow(ctx, 61); err == nil {
+		t.Fatalf("monitor accepted excessive allocation")
+	}
+
+	a1.Clear(ctx)
+
+	if err := a2.Grow(ctx, 61); err != nil {
+		t.Fatalf("monitor refused allocation: %v", err)
+	}
+
+	if err := a2.ResizeItem(ctx, 50, 60); err == nil {
+		t.Fatalf("monitor accepted excessive allocation")
+	}
+
+	if err := a1.ResizeItem(ctx, 0, 5); err != nil {
+		t.Fatalf("monitor refused allocation: %v", err)
+	}
+
+	a1.Close(ctx)
+	a2.Close(ctx)
+
+	if m.curAllocated != 0 {
+		t.Fatal("closing spans leaves bytes in monitor")
+	}
+}

--- a/sql/mon/mem_usage_test.go
+++ b/sql/mon/mem_usage_test.go
@@ -72,43 +72,43 @@ func TestMemoryAccount(t *testing.T) {
 	var a1, a2 MemoryAccount
 
 	m.StartMonitor()
-	a1 = m.OpenAccount(ctx)
-	a2 = m.OpenAccount(ctx)
+	m.OpenAccount(ctx, &a1)
+	m.OpenAccount(ctx, &a2)
 
 	m.maxAllocatedBudget = 100
 
-	if err := a1.Grow(ctx, 10); err != nil {
+	if err := m.GrowAccount(ctx, &a1, 10); err != nil {
 		t.Fatalf("monitor refused allocation: %v", err)
 	}
 
-	if err := a2.Grow(ctx, 30); err != nil {
+	if err := m.GrowAccount(ctx, &a2, 30); err != nil {
 		t.Fatalf("monitor refused allocation: %v", err)
 	}
 
-	if err := a1.Grow(ctx, 61); err == nil {
+	if err := m.GrowAccount(ctx, &a1, 61); err == nil {
 		t.Fatalf("monitor accepted excessive allocation")
 	}
 
-	if err := a2.Grow(ctx, 61); err == nil {
+	if err := m.GrowAccount(ctx, &a2, 61); err == nil {
 		t.Fatalf("monitor accepted excessive allocation")
 	}
 
-	a1.Clear(ctx)
+	m.ClearAccount(ctx, &a1)
 
-	if err := a2.Grow(ctx, 61); err != nil {
+	if err := m.GrowAccount(ctx, &a2, 61); err != nil {
 		t.Fatalf("monitor refused allocation: %v", err)
 	}
 
-	if err := a2.ResizeItem(ctx, 50, 60); err == nil {
+	if err := m.ResizeItem(ctx, &a2, 50, 60); err == nil {
 		t.Fatalf("monitor accepted excessive allocation")
 	}
 
-	if err := a1.ResizeItem(ctx, 0, 5); err != nil {
+	if err := m.ResizeItem(ctx, &a1, 0, 5); err != nil {
 		t.Fatalf("monitor refused allocation: %v", err)
 	}
 
-	a1.Close(ctx)
-	a2.Close(ctx)
+	m.CloseAccount(ctx, &a1)
+	m.CloseAccount(ctx, &a2)
 
 	if m.curAllocated != 0 {
 		t.Fatal("closing spans leaves bytes in monitor")

--- a/sql/ordering.go
+++ b/sql/ordering.go
@@ -57,7 +57,7 @@ type orderingInfo struct {
 
 // Format pretty-prints the orderingInfo to a stream.
 // If columns is not nil, column names are printed instead of column indexes.
-func (ord orderingInfo) Format(buf *bytes.Buffer, columns []ResultColumn) {
+func (ord orderingInfo) Format(buf *bytes.Buffer, columns ResultColumns) {
 	sep := ""
 
 	// Print the exact match columns. We sort them to ensure
@@ -104,7 +104,7 @@ func (ord orderingInfo) Format(buf *bytes.Buffer, columns []ResultColumn) {
 }
 
 // AsString pretty-prints the orderingInfo to a string.
-func (ord orderingInfo) AsString(columns []ResultColumn) string {
+func (ord orderingInfo) AsString(columns ResultColumns) string {
 	var buf bytes.Buffer
 	ord.Format(&buf, columns)
 	return buf.String()

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -20,10 +20,12 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"math/big"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"unsafe"
 
 	"gopkg.in/inf.v0"
 
@@ -82,6 +84,11 @@ type Datum interface {
 	// IsMin returns true if the datum is equal to the minimum value the datum
 	// type can hold.
 	IsMin() bool
+
+	// Size returns a lower bound on the Datum's size, in bytes.  The
+	// second return value indicates whether the size is dependent on
+	// the particular value.
+	Size() (uintptr, bool)
 }
 
 // DBool is the boolean Datum.
@@ -199,6 +206,11 @@ func (d *DBool) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(strconv.FormatBool(bool(*d)))
 }
 
+// Size implements the Datum interface.
+func (d *DBool) Size() (uintptr, bool) {
+	return unsafe.Sizeof(*d), false
+}
+
 // DInt is the int Datum.
 type DInt int64
 
@@ -289,6 +301,11 @@ func (d *DInt) IsMin() bool {
 // Format implements the NodeFormatter interface.
 func (d *DInt) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(strconv.FormatInt(int64(*d), 10))
+}
+
+// Size implements the Datum interface.
+func (d *DInt) Size() (uintptr, bool) {
+	return unsafe.Sizeof(*d), false
 }
 
 // DFloat is the float Datum.
@@ -392,6 +409,11 @@ func (d *DFloat) Format(buf *bytes.Buffer, f FmtFlags) {
 	}
 }
 
+// Size implements the Datum interface.
+func (d *DFloat) Size() (uintptr, bool) {
+	return unsafe.Sizeof(*d), false
+}
+
 // DDecimal is the decimal Datum.
 type DDecimal struct {
 	inf.Dec
@@ -475,6 +497,12 @@ func (d *DDecimal) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(d.Dec.String())
 }
 
+// Size implements the Datum interface.
+func (d *DDecimal) Size() (uintptr, bool) {
+	intVal := d.Dec.UnscaledBig()
+	return unsafe.Sizeof(*d) + unsafe.Sizeof(*intVal) + uintptr(cap(intVal.Bits()))*unsafe.Sizeof(big.Word(0)), true
+}
+
 // DString is the string Datum.
 type DString string
 
@@ -555,6 +583,11 @@ func (d *DString) Format(buf *bytes.Buffer, f FmtFlags) {
 	encodeSQLString(buf, string(*d))
 }
 
+// Size implements the Datum interface.
+func (d *DString) Size() (uintptr, bool) {
+	return unsafe.Sizeof(*d) + uintptr(len(*d)), true
+}
+
 // DBytes is the bytes Datum. The underlying type is a string because we want
 // the immutability, but this may contain arbitrary bytes.
 type DBytes string
@@ -633,6 +666,11 @@ func (d *DBytes) IsMin() bool {
 // Format implements the NodeFormatter interface.
 func (d *DBytes) Format(buf *bytes.Buffer, f FmtFlags) {
 	encodeSQLBytes(buf, string(*d))
+}
+
+// Size implements the Datum interface.
+func (d *DBytes) Size() (uintptr, bool) {
+	return unsafe.Sizeof(*d) + uintptr(len(*d)), true
 }
 
 // DDate is the date Datum represented as the number of days after
@@ -754,6 +792,11 @@ func (d *DDate) IsMin() bool {
 // Format implements the NodeFormatter interface.
 func (d *DDate) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(time.Unix(int64(*d)*secondsInDay, 0).UTC().Format(dateFormat))
+}
+
+// Size implements the Datum interface.
+func (d *DDate) Size() (uintptr, bool) {
+	return unsafe.Sizeof(*d), false
 }
 
 // DTimestamp is the timestamp Datum.
@@ -878,6 +921,11 @@ func (d *DTimestamp) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(d.UTC().Format(timestampNodeFormat))
 }
 
+// Size implements the Datum interface.
+func (d *DTimestamp) Size() (uintptr, bool) {
+	return unsafe.Sizeof(*d), false
+}
+
 // DTimestampTZ is the timestamp Datum that is rendered with session offset.
 type DTimestampTZ struct {
 	time.Time
@@ -970,6 +1018,11 @@ func (d *DTimestampTZ) IsMin() bool {
 // Format implements the NodeFormatter interface.
 func (d *DTimestampTZ) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(d.UTC().Format(timestampNodeFormat))
+}
+
+// Size implements the Datum interface.
+func (d *DTimestampTZ) Size() (uintptr, bool) {
+	return unsafe.Sizeof(*d), false
 }
 
 // DInterval is the interval Datum.
@@ -1113,6 +1166,11 @@ func (d *DInterval) Format(buf *bytes.Buffer, f FmtFlags) {
 	} else {
 		buf.WriteString((time.Duration(d.Duration.Nanos) * time.Nanosecond).String())
 	}
+}
+
+// Size implements the Datum interface.
+func (d *DInterval) Size() (uintptr, bool) {
+	return unsafe.Sizeof(*d), false
 }
 
 // DTuple is the tuple Datum.
@@ -1280,6 +1338,16 @@ func (d *DTuple) makeUnique() {
 	*d = (*d)[:n]
 }
 
+// Size implements the Datum interface.
+func (d *DTuple) Size() (uintptr, bool) {
+	sz := unsafe.Sizeof(*d)
+	for _, e := range *d {
+		dsz, _ := e.Size()
+		sz += dsz
+	}
+	return sz, true
+}
+
 // SortedDifference finds the elements of d which are not in other,
 // assuming that d and other are already sorted.
 func (d *DTuple) SortedDifference(other *DTuple) *DTuple {
@@ -1362,6 +1430,11 @@ func (dNull) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("NULL")
 }
 
+// Size implements the Datum interface.
+func (d dNull) Size() (uintptr, bool) {
+	return unsafe.Sizeof(d), false
+}
+
 var _ VariableExpr = &DPlaceholder{}
 
 // DPlaceholder is the named placeholder Datum.
@@ -1436,6 +1509,11 @@ func (*DPlaceholder) IsMin() bool {
 func (d *DPlaceholder) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteByte('$')
 	buf.WriteString(d.name)
+}
+
+// Size implements the Datum interface.
+func (d *DPlaceholder) Size() (uintptr, bool) {
+	return unsafe.Sizeof(*d) + uintptr(len(d.name)), true
 }
 
 // Temporary workaround for #3633, allowing comparisons between

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -605,7 +605,10 @@ func (c *v3Conn) handleBind(buf *readBuffer) error {
 		return c.sendInternalError(fmt.Sprintf("expected 0, 1, or %d for number of format codes, got %d", numColumns, numColumnFormatCodes))
 	}
 	// Create the new PreparedPortal in the connection's Session.
-	portal := c.session.PreparedPortals.New(portalName, stmt, qargs)
+	portal, err := c.session.PreparedPortals.New(portalName, stmt, qargs)
+	if err != nil {
+		return err
+	}
 	// Attach pgwire-specific metadata to the PreparedPortal.
 	portal.ProtocolMeta = preparedPortalMeta{outFormats: columnFormatCodes}
 	c.writeBuf.initMsg(serverMsgBindComplete)
@@ -646,6 +649,7 @@ func (c *v3Conn) executeStatements(
 ) error {
 	tracing.AnnotateTrace()
 	results := c.executor.ExecuteStatements(c.session, stmts, pinfo)
+	defer results.Close()
 
 	tracing.AnnotateTrace()
 	if results.Empty {
@@ -716,6 +720,7 @@ func (c *v3Conn) sendErrorWithCode(errCode string, errCtx sqlbase.SrcCtx, errToS
 	return c.wr.Flush()
 }
 
+// sendResponse sends the results as a query response.
 func (c *v3Conn) sendResponse(results sql.ResultList, formatCodes []formatCode, sendDescription bool, limit int) error {
 	if len(results) == 0 {
 		return c.sendCommandComplete(nil)
@@ -727,8 +732,8 @@ func (c *v3Conn) sendResponse(results sql.ResultList, formatCodes []formatCode, 
 			}
 			break
 		}
-		if limit != 0 && len(result.Rows) > limit {
-			if err := c.sendInternalError(fmt.Sprintf("execute row count limits not supported: %d of %d", limit, len(result.Rows))); err != nil {
+		if limit != 0 && result.Rows != nil && result.Rows.Len() > limit {
+			if err := c.sendInternalError(fmt.Sprintf("execute row count limits not supported: %d of %d", limit, result.Rows.Len())); err != nil {
 				return err
 			}
 			break
@@ -759,10 +764,12 @@ func (c *v3Conn) sendResponse(results sql.ResultList, formatCodes []formatCode, 
 			}
 
 			// Send DataRows.
-			for _, row := range result.Rows {
+			nRows := result.Rows.Len()
+			for rowIdx := 0; rowIdx < nRows; rowIdx++ {
+				row := result.Rows.At(rowIdx)
 				c.writeBuf.initMsg(serverMsgDataRow)
-				c.writeBuf.putInt16(int16(len(row.Values)))
-				for i, col := range row.Values {
+				c.writeBuf.putInt16(int16(len(row)))
+				for i, col := range row {
 					fmtCode := formatText
 					if formatCodes != nil {
 						fmtCode = formatCodes[i]
@@ -783,7 +790,7 @@ func (c *v3Conn) sendResponse(results sql.ResultList, formatCodes []formatCode, 
 
 			// Send CommandComplete.
 			tag = append(tag, ' ')
-			tag = strconv.AppendUint(tag, uint64(len(result.Rows)), 10)
+			tag = strconv.AppendUint(tag, uint64(result.Rows.Len()), 10)
 			if err := c.sendCommandComplete(tag); err != nil {
 				return err
 			}

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -122,7 +122,7 @@ type planNode interface {
 	// Stable after expandPlan() (or makePlan).
 	// Available after newPlan(), but may change on intermediate plan
 	// nodes during expandPlan() due to index selection.
-	Columns() []ResultColumn
+	Columns() ResultColumns
 
 	// The indexes of the columns the output is ordered by.
 	//
@@ -171,6 +171,9 @@ type planNode interface {
 	// Available after Next() and MarkDebug(explainDebug), see
 	// explain.go.
 	DebugValues() debugValues
+
+	// Close terminates the planNode execution and releases its resources.
+	Close()
 }
 
 // planNodeFastPath is implemented by nodes that can perform all their
@@ -206,6 +209,7 @@ var _ planNode = &dropTableNode{}
 var _ planNode = &dropIndexNode{}
 var _ planNode = &alterTableNode{}
 var _ planNode = &joinNode{}
+var _ planNode = &distSQLNode{}
 
 // makePlan implements the Planner interface.
 func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, error) {

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -220,10 +220,13 @@ func (p *planner) query(sql string, args ...interface{}) (planNode, error) {
 
 // queryRow implements the queryRunner interface.
 func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, error) {
+	p.session.mon.StartMonitor()
+	defer p.session.mon.StopMonitor(p.ctx())
 	plan, err := p.query(sql, args...)
 	if err != nil {
 		return nil, err
 	}
+	defer plan.Close()
 	if err := plan.Start(); err != nil {
 		return nil, err
 	}
@@ -243,10 +246,13 @@ func (p *planner) queryRow(sql string, args ...interface{}) (parser.DTuple, erro
 
 // exec implements the queryRunner interface.
 func (p *planner) exec(sql string, args ...interface{}) (int, error) {
+	p.session.mon.StartMonitor()
+	defer p.session.mon.StopMonitor(p.ctx())
 	plan, err := p.query(sql, args...)
 	if err != nil {
 		return 0, err
 	}
+	defer plan.Close()
 	if err := plan.Start(); err != nil {
 		return 0, err
 	}

--- a/sql/prepare.go
+++ b/sql/prepare.go
@@ -17,8 +17,11 @@
 package sql
 
 import (
+	"unsafe"
+
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/sql/mon"
 	"github.com/cockroachdb/cockroach/sql/parser"
 )
 
@@ -27,10 +30,12 @@ import (
 type PreparedStatement struct {
 	Query       string
 	SQLTypes    parser.PlaceholderTypes
-	Columns     []ResultColumn
+	Columns     ResultColumns
 	portalNames map[string]struct{}
 
 	ProtocolMeta interface{} // a field for protocol implementations to hang metadata off of.
+
+	memAcc mon.MemoryAccount
 }
 
 // PreparedStatements is a mapping of PreparedStatement names to their
@@ -68,17 +73,31 @@ func (ps PreparedStatements) New(
 	name, query string,
 	placeholderHints parser.PlaceholderTypes,
 ) (*PreparedStatement, error) {
+	stmt := &PreparedStatement{}
+
+	// For now we are just counting the size of the query string and
+	// statement name. When we start storing the prepared query plan
+	// during prepare, this should be tallied up to the monitor as well.
+	sz := int64(uintptr(len(query)+len(name)) + unsafe.Sizeof(*stmt))
+	if err := ps.session.mon.OpenAndInitAccount(ps.session.Ctx(), &stmt.memAcc, sz); err != nil {
+		return nil, err
+	}
+
 	// Prepare the query. This completes the typing of placeholders.
 	cols, err := e.Prepare(query, ps.session, placeholderHints)
 	if err != nil {
+		stmt.memAcc.Close(ps.session.Ctx())
 		return nil, err
 	}
-	stmt := &PreparedStatement{
-		Query:       query,
-		SQLTypes:    placeholderHints,
-		Columns:     cols,
-		portalNames: make(map[string]struct{}),
+	stmt.Query = query
+	stmt.SQLTypes = placeholderHints
+	stmt.Columns = cols
+	stmt.portalNames = make(map[string]struct{})
+
+	if prevStmt, ok := ps.Get(name); ok {
+		prevStmt.memAcc.Close(ps.session.Ctx())
 	}
+
 	ps.stmts[name] = stmt
 	return stmt, nil
 }
@@ -87,18 +106,45 @@ func (ps PreparedStatements) New(
 // The method returns whether a statement with that name was found and removed.
 func (ps PreparedStatements) Delete(name string) bool {
 	if stmt, ok := ps.Get(name); ok {
-		for portalName := range stmt.portalNames {
-			delete(ps.session.PreparedPortals.portals, portalName)
+		if ps.session.PreparedPortals.portals != nil {
+			for portalName := range stmt.portalNames {
+				if portal, ok := ps.session.PreparedPortals.Get(name); ok {
+					delete(ps.session.PreparedPortals.portals, portalName)
+					portal.memAcc.Close(ps.session.Ctx())
+				}
+			}
 		}
+		stmt.memAcc.Close(ps.session.Ctx())
 		delete(ps.stmts, name)
 		return true
 	}
 	return false
 }
 
+// closeAll de-registers all statements and portals from the monitor.
+func (ps PreparedStatements) closeAll(s *Session) {
+	for _, stmt := range ps.stmts {
+		stmt.memAcc.Close(s.Ctx())
+	}
+	for _, portal := range s.PreparedPortals.portals {
+		portal.memAcc.Close(s.Ctx())
+	}
+}
+
+// ClearStatementsAndPortals de-registers all statements and
+// portals. Afterwards none can be added any more.
+func (s *Session) ClearStatementsAndPortals() {
+	s.PreparedStatements.closeAll(s)
+	s.PreparedStatements.stmts = nil
+	s.PreparedPortals.portals = nil
+}
+
 // DeleteAll removes all PreparedStatements from the PreparedStatements. This will in turn
 // remove all PreparedPortals from the session's PreparedPortals.
+// This is used by the "delete" message in the pgwire protocol; after DeleteAll
+// statements and portals can be added again.
 func (ps PreparedStatements) DeleteAll() {
+	ps.closeAll(ps.session)
 	ps.stmts = make(map[string]*PreparedStatement)
 	ps.session.PreparedPortals.portals = make(map[string]*PreparedPortal)
 }
@@ -109,6 +155,8 @@ type PreparedPortal struct {
 	Qargs parser.QueryArguments
 
 	ProtocolMeta interface{} // a field for protocol implementations to hang metadata off of.
+
+	memAcc mon.MemoryAccount
 }
 
 // PreparedPortals is a mapping of PreparedPortal names to their corresponding
@@ -140,14 +188,24 @@ func (pp PreparedPortals) Exists(name string) bool {
 // New creates a new PreparedPortal with the provided name and corresponding
 // PreparedStatement, binding the statement using the given QueryArguments.
 func (pp PreparedPortals) New(name string, stmt *PreparedStatement, qargs parser.QueryArguments,
-) *PreparedPortal {
-	stmt.portalNames[name] = struct{}{}
+) (*PreparedPortal, error) {
 	portal := &PreparedPortal{
 		Stmt:  stmt,
 		Qargs: qargs,
 	}
+	sz := int64(uintptr(len(name)) + unsafe.Sizeof(*portal))
+	if err := pp.session.mon.OpenAndInitAccount(pp.session.Ctx(), &portal.memAcc, sz); err != nil {
+		return nil, err
+	}
+
+	stmt.portalNames[name] = struct{}{}
+
+	if prevPortal, ok := pp.Get(name); ok {
+		prevPortal.memAcc.Close(pp.session.Ctx())
+	}
+
 	pp.portals[name] = portal
-	return portal
+	return portal, nil
 }
 
 // Delete removes the PreparedPortal with the provided name from the PreparedPortals.
@@ -155,6 +213,7 @@ func (pp PreparedPortals) New(name string, stmt *PreparedStatement, qargs parser
 func (pp PreparedPortals) Delete(name string) bool {
 	if portal, ok := pp.Get(name); ok {
 		delete(portal.Stmt.portalNames, name)
+		portal.memAcc.Close(pp.session.Ctx())
 		delete(pp.portals, name)
 		return true
 	}

--- a/sql/returning.go
+++ b/sql/returning.go
@@ -26,7 +26,7 @@ import (
 type returningHelper struct {
 	p *planner
 	// Expected columns.
-	columns []ResultColumn
+	columns ResultColumns
 	// Processed copies of expressions from ReturningExprs.
 	exprs    []parser.TypedExpr
 	qvals    qvalMap
@@ -53,7 +53,7 @@ func (p *planner) makeReturningHelper(
 		}
 	}
 
-	rh.columns = make([]ResultColumn, 0, len(r))
+	rh.columns = make(ResultColumns, 0, len(r))
 	aliasTableName := parser.TableName{TableName: parser.Name(alias)}
 	rh.source = newSourceInfoForSingleTable(aliasTableName, makeResultColumns(tablecols))
 	rh.qvals = make(qvalMap)

--- a/sql/row_container.go
+++ b/sql/row_container.go
@@ -1,0 +1,167 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package sql
+
+import (
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/sql/mon"
+	"github.com/cockroachdb/cockroach/sql/parser"
+)
+
+// RowContainer is a container for rows of DTuples which tracks the
+// approximate amount of memory allocated for row data.
+// Rows must be added using AddRow(); once the work is done
+// the Close() method must be called to release the allocated memory.
+//
+// TODO(knz): this does not currently track the amount of memory used
+// for the outer array of DTuple references.
+type RowContainer struct {
+	p    *planner
+	rows []parser.DTuple
+
+	// fixedColsSize is the sum of widths of fixed-width columns in a
+	// single row.
+	fixedColsSize int64
+	// varSizedColumns indicates for which columns the datum size
+	// is variable.
+	varSizedColumns []int
+
+	// memAcc tracks the current memory consumption of this
+	// RowContainer.
+	memAcc mon.MemoryAccount
+}
+
+// NewRowContainer allocates a new row container.
+//
+// The rowCapacity argument indicates how many rows are to be
+// expected; it is used to pre-allocate the outer array of row
+// references, in the fashion of Go's capacity argument to the make()
+// function.
+//
+// Note that we could, but do not (yet), report the size of the row
+// container itself to the monitor in this constructor. This is
+// because the various planNodes are not (yet) equipped to call
+// Close() upon encountering errors in their constructor (all nodes
+// initializing a RowContainer there) and SetLimitHint() (for sortNode
+// which initializes a RowContainer there). This would be rather
+// error-prone to implement consistently and hellishly difficult to
+// test properly.  The trade-off is that very large table schemas or
+// column selections could cause unchecked and potentially dangerous
+// memory growth.
+func (p *planner) NewRowContainer(h ResultColumns, rowCapacity int) *RowContainer {
+	nCols := len(h)
+
+	res := &RowContainer{
+		p:               p,
+		rows:            make([]parser.DTuple, 0, rowCapacity),
+		varSizedColumns: make([]int, 0, nCols),
+	}
+
+	res.memAcc = p.session.mon.OpenAccount(p.session.Ctx())
+
+	for i := 0; i < nCols; i++ {
+		sz, variable := h[i].Typ.Size()
+		if variable {
+			res.varSizedColumns = append(res.varSizedColumns, i)
+		} else {
+			res.fixedColsSize += int64(sz)
+		}
+	}
+	res.fixedColsSize += int64(unsafe.Sizeof(parser.Datum(nil)) * uintptr(nCols))
+
+	return res
+}
+
+// Close releases the memory associated with the RowContainer.
+func (c *RowContainer) Close() {
+	c.rows = nil
+	c.varSizedColumns = nil
+	c.memAcc.Close(c.p.session.Ctx())
+}
+
+// rowSize computes the size of a single row.
+func (c *RowContainer) rowSize(row parser.DTuple) int64 {
+	rsz := c.fixedColsSize
+	for _, i := range c.varSizedColumns {
+		sz, _ := row[i].Size()
+		rsz += int64(sz)
+	}
+	return rsz
+}
+
+// AddRow attempts to insert a new row in the RowContainer.
+// Returns an error if the allocation was denied by the MemoryUsageMonitor.
+func (c *RowContainer) AddRow(row parser.DTuple) error {
+	if err := c.memAcc.Grow(c.p.session.Ctx(), c.rowSize(row)); err != nil {
+		return err
+	}
+	c.rows = append(c.rows, row)
+	return nil
+}
+
+// Len reports the number of rows currently held in this RowContainer.
+func (c *RowContainer) Len() int {
+	return len(c.rows)
+}
+
+// At accesses a row at a specific index.
+func (c *RowContainer) At(i int) parser.DTuple {
+	return c.rows[i]
+}
+
+// Swap exchanges two rows. Used for sorting.
+func (c *RowContainer) Swap(i, j int) {
+	c.rows[i], c.rows[j] = c.rows[j], c.rows[i]
+}
+
+// PseudoPop retrieves a pointer to the last row, and decreases the
+// visible size of the RowContainer.  This is used for heap sorting in
+// sql.sortNode.  A pointer is returned to avoid an allocation when
+// passing the DTuple as an interface{} to heap.Push().
+// Note that the pointer is only valid until the next call to AddRow.
+// We use this for heap sorting in sort.go.
+func (c *RowContainer) PseudoPop() *parser.DTuple {
+	idx := len(c.rows) - 1
+	x := &(c.rows)[idx]
+	c.rows = c.rows[:idx]
+	return x
+}
+
+// ResetLen cancels the effects of PseudoPop(), that is, it restores
+// the visible size of the RowContainer to its actual size.
+func (c *RowContainer) ResetLen(l int) {
+	c.rows = c.rows[:l]
+}
+
+// Replace substitutes one row for another. This does query the
+// MemoryUsageMonitor to determine whether the new row fits the
+// allowance.
+func (c *RowContainer) Replace(i int, newRow parser.DTuple) error {
+	newSz := c.rowSize(newRow)
+	oldSz := int64(0)
+	if c.rows[i] != nil {
+		oldSz = c.rowSize(c.rows[i])
+	}
+	if newSz != oldSz {
+		if err := c.memAcc.ResizeItem(c.p.session.Ctx(), oldSz, newSz); err != nil {
+			return err
+		}
+	}
+	c.rows[i] = newRow
+	return nil
+}

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -43,7 +43,7 @@ type scanNode struct {
 	// The table columns, possibly including ones currently in schema changes.
 	cols []sqlbase.ColumnDescriptor
 	// There is a 1-1 correspondence between cols and resultColumns.
-	resultColumns []ResultColumn
+	resultColumns ResultColumns
 	// Contains values for the current row. There is a 1-1 correspondence
 	// between resultColumns and values in row.
 	row parser.DTuple
@@ -80,7 +80,7 @@ func (p *planner) Scan() *scanNode {
 	return &scanNode{p: p}
 }
 
-func (n *scanNode) Columns() []ResultColumn {
+func (n *scanNode) Columns() ResultColumns {
 	return n.resultColumns
 }
 
@@ -138,6 +138,8 @@ func (n *scanNode) Start() error {
 
 	return n.p.startSubqueryPlans(n.filter)
 }
+
+func (n *scanNode) Close() {}
 
 // initScan sets up the rowFetcher and starts a scan.
 func (n *scanNode) initScan() error {

--- a/sql/select.go
+++ b/sql/select.go
@@ -59,7 +59,7 @@ type selectNode struct {
 	// groupNode copies/extends the render array defined by initTargets()
 	// will add extra selectNode renders for the aggregation sources.
 	render  []parser.TypedExpr
-	columns []ResultColumn
+	columns ResultColumns
 
 	// The number of initial columns - before adding any internal render
 	// targets for grouping, filtering or ordering. The original columns
@@ -88,10 +88,7 @@ type selectNode struct {
 	row parser.DTuple
 }
 
-func (s *selectNode) Columns() []ResultColumn {
-	if s.explain == explainDebug {
-		return debugColumns
-	}
+func (s *selectNode) Columns() ResultColumns {
 	return s.columns
 }
 
@@ -213,6 +210,10 @@ func (s *selectNode) ExplainPlan(v bool) (name, description string, children []p
 
 func (s *selectNode) SetLimitHint(numRows int64, soft bool) {
 	s.source.plan.SetLimitHint(numRows, soft || s.filter != nil)
+}
+
+func (s *selectNode) Close() {
+	s.source.plan.Close()
 }
 
 // Select selects rows from a SELECT/UNION/VALUES, ordering and/or limiting them.
@@ -502,7 +503,7 @@ func (s *selectNode) initWhere(where *parser.Where) error {
 // returned for each column.
 func checkRenderStar(
 	target parser.SelectExpr, src *dataSourceInfo, qvals qvalMap,
-) (isStar bool, columns []ResultColumn, exprs []parser.TypedExpr, err error) {
+) (isStar bool, columns ResultColumns, exprs []parser.TypedExpr, err error) {
 	v, ok := target.Expr.(parser.VarName)
 	if !ok {
 		return false, nil, nil, nil

--- a/sql/select_top.go
+++ b/sql/select_top.go
@@ -152,7 +152,7 @@ func (n *selectTopNode) ExplainPlan(v bool) (name, description string, subplans 
 	return "select", "", subplans
 }
 
-func (n *selectTopNode) Columns() []ResultColumn {
+func (n *selectTopNode) Columns() ResultColumns {
 	// sort, window, group and source may have different ideas about the
 	// result columns. Ask them in turn.
 	// (We cannot ask n.plan because it may not be connected yet.)
@@ -180,3 +180,8 @@ func (n *selectTopNode) Start() error               { return n.plan.Start() }
 func (n *selectTopNode) Next() (bool, error)        { return n.plan.Next() }
 func (n *selectTopNode) Values() parser.DTuple      { return n.plan.Values() }
 func (n *selectTopNode) DebugValues() debugValues   { return n.plan.DebugValues() }
+func (n *selectTopNode) Close() {
+	if n.plan != nil {
+		n.plan.Close()
+	}
+}

--- a/sql/session_mem_usage.go
+++ b/sql/session_mem_usage.go
@@ -24,7 +24,9 @@ import (
 
 // OpenAccount interfaces between Session and mon.MemoryUsageMonitor.
 func (s *Session) OpenAccount() WrappableMemoryAccount {
-	return WrappableMemoryAccount{acc: s.mon.OpenAccount(s.Ctx())}
+	res := WrappableMemoryAccount{}
+	s.mon.OpenAccount(s.Ctx(), &res.acc)
+	return res
 }
 
 // WrappableMemoryAccount encapsulates a MemoryAccount to
@@ -59,20 +61,20 @@ func (w WrappedMemoryAccount) OpenAndInit(initialAllocation int64) error {
 
 // Grow interfaces between Session and mon.MemoryUsageMonitor.
 func (w WrappedMemoryAccount) Grow(extraSize int64) error {
-	return w.acc.Grow(w.ctx, extraSize)
+	return w.mon.GrowAccount(w.ctx, w.acc, extraSize)
 }
 
 // Close interfaces between Session and mon.MemoryUsageMonitor.
 func (w WrappedMemoryAccount) Close() {
-	w.acc.Close(w.ctx)
+	w.mon.CloseAccount(w.ctx, w.acc)
 }
 
 // Clear interfaces between Session and mon.MemoryUsageMonitor.
 func (w WrappedMemoryAccount) Clear() {
-	w.acc.Clear(w.ctx)
+	w.mon.ClearAccount(w.ctx, w.acc)
 }
 
 // ResizeItem interfaces between Session and mon.MemoryUsageMonitor.
 func (w WrappedMemoryAccount) ResizeItem(oldSize, newSize int64) error {
-	return w.acc.ResizeItem(w.ctx, oldSize, newSize)
+	return w.mon.ResizeItem(w.ctx, w.acc, oldSize, newSize)
 }

--- a/sql/session_mem_usage.go
+++ b/sql/session_mem_usage.go
@@ -1,0 +1,78 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package sql
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/sql/mon"
+)
+
+// OpenAccount interfaces between Session and mon.MemoryUsageMonitor.
+func (s *Session) OpenAccount() WrappableMemoryAccount {
+	return WrappableMemoryAccount{acc: s.mon.OpenAccount(s.Ctx())}
+}
+
+// WrappableMemoryAccount encapsulates a MemoryAccount to
+// give it the W() method below.
+type WrappableMemoryAccount struct {
+	acc mon.MemoryAccount
+}
+
+// W captures the current monitor pointer and session logging context
+// so they can be provided transparently to the other Account APIs
+// below.
+func (w *WrappableMemoryAccount) W(s *Session) WrappedMemoryAccount {
+	return WrappedMemoryAccount{
+		acc: &w.acc,
+		mon: &s.mon,
+		ctx: s.Ctx(),
+	}
+}
+
+// WrappedMemoryAccount is the transient structure that carries
+// the extra argument to the MemoryAccount APIs.
+type WrappedMemoryAccount struct {
+	acc *mon.MemoryAccount
+	mon *mon.MemoryUsageMonitor
+	ctx context.Context
+}
+
+// OpenAndInit interfaces between Session and mon.MemoryUsageMonitor.
+func (w WrappedMemoryAccount) OpenAndInit(initialAllocation int64) error {
+	return w.mon.OpenAndInitAccount(w.ctx, w.acc, initialAllocation)
+}
+
+// Grow interfaces between Session and mon.MemoryUsageMonitor.
+func (w WrappedMemoryAccount) Grow(extraSize int64) error {
+	return w.acc.Grow(w.ctx, extraSize)
+}
+
+// Close interfaces between Session and mon.MemoryUsageMonitor.
+func (w WrappedMemoryAccount) Close() {
+	w.acc.Close(w.ctx)
+}
+
+// Clear interfaces between Session and mon.MemoryUsageMonitor.
+func (w WrappedMemoryAccount) Clear() {
+	w.acc.Clear(w.ctx)
+}
+
+// ResizeItem interfaces between Session and mon.MemoryUsageMonitor.
+func (w WrappedMemoryAccount) ResizeItem(oldSize, newSize int64) error {
+	return w.acc.ResizeItem(w.ctx, oldSize, newSize)
+}

--- a/sql/show.go
+++ b/sql/show.go
@@ -32,24 +32,31 @@ import (
 func (p *planner) Show(n *parser.Show) (planNode, error) {
 	name := strings.ToUpper(n.Name)
 
-	v := &valuesNode{columns: []ResultColumn{{Name: name, Typ: parser.TypeString}}}
+	v := p.newContainerValuesNode(ResultColumns{{Name: name, Typ: parser.TypeString}}, 0)
 
+	var newRow parser.DTuple
 	switch name {
 	case `DATABASE`:
-		v.rows = append(v.rows, []parser.Datum{parser.NewDString(p.session.Database)})
+		newRow = parser.DTuple{parser.NewDString(p.session.Database)}
 	case `TIME ZONE`:
-		v.rows = append(v.rows, []parser.Datum{parser.NewDString(p.session.Location.String())})
+		newRow = parser.DTuple{parser.NewDString(p.session.Location.String())}
 	case `SYNTAX`:
-		v.rows = append(v.rows, []parser.Datum{parser.NewDString(parser.Syntax(p.session.Syntax).String())})
+		newRow = parser.DTuple{parser.NewDString(parser.Syntax(p.session.Syntax).String())}
 	case `DEFAULT_TRANSACTION_ISOLATION`:
 		level := p.session.DefaultIsolationLevel.String()
-		v.rows = append(v.rows, []parser.Datum{parser.NewDString(level)})
+		newRow = parser.DTuple{parser.NewDString(level)}
 	case `TRANSACTION ISOLATION LEVEL`:
-		v.rows = append(v.rows, []parser.Datum{parser.NewDString(p.txn.Proto.Isolation.String())})
+		newRow = parser.DTuple{parser.NewDString(p.txn.Proto.Isolation.String())}
 	case `TRANSACTION PRIORITY`:
-		v.rows = append(v.rows, []parser.Datum{parser.NewDString(p.txn.UserPriority.String())})
+		newRow = parser.DTuple{parser.NewDString(p.txn.UserPriority.String())}
 	default:
 		return nil, fmt.Errorf("unknown variable: %q", name)
+	}
+	if newRow != nil {
+		if err := v.rows.AddRow(newRow); err != nil {
+			v.rows.Close()
+			return nil, err
+		}
 	}
 
 	return v, nil
@@ -73,26 +80,29 @@ func (p *planner) ShowColumns(n *parser.ShowColumns) (planNode, error) {
 		return nil, err
 	}
 
-	v := &valuesNode{
-		columns: []ResultColumn{
-			{Name: "Field", Typ: parser.TypeString},
-			{Name: "Type", Typ: parser.TypeString},
-			{Name: "Null", Typ: parser.TypeBool},
-			{Name: "Default", Typ: parser.TypeString},
-		},
+	columns := ResultColumns{
+		{Name: "Field", Typ: parser.TypeString},
+		{Name: "Type", Typ: parser.TypeString},
+		{Name: "Null", Typ: parser.TypeBool},
+		{Name: "Default", Typ: parser.TypeString},
 	}
+	v := p.newContainerValuesNode(columns, 0)
 
 	for i, col := range desc.Columns {
 		defaultExpr := parser.DNull
 		if e := desc.Columns[i].DefaultExpr; e != nil {
 			defaultExpr = parser.NewDString(*e)
 		}
-		v.rows = append(v.rows, []parser.Datum{
+		newRow := parser.DTuple{
 			parser.NewDString(desc.Columns[i].Name),
 			parser.NewDString(col.Type.SQLString()),
 			parser.MakeDBool(parser.DBool(desc.Columns[i].Nullable)),
 			defaultExpr,
-		})
+		}
+		if err := v.rows.AddRow(newRow); err != nil {
+			v.rows.Close()
+			return nil, err
+		}
 	}
 	return v, nil
 }
@@ -134,12 +144,11 @@ func (p *planner) ShowCreateTable(n *parser.ShowCreateTable) (planNode, error) {
 		return nil, err
 	}
 
-	v := &valuesNode{
-		columns: []ResultColumn{
-			{Name: "Table", Typ: parser.TypeString},
-			{Name: "CreateTable", Typ: parser.TypeString},
-		},
+	columns := ResultColumns{
+		{Name: "Table", Typ: parser.TypeString},
+		{Name: "CreateTable", Typ: parser.TypeString},
 	}
+	v := p.newContainerValuesNode(columns, 0)
 
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "CREATE TABLE %s (", quoteNames(n.Table.String()))
@@ -174,6 +183,7 @@ func (p *planner) ShowCreateTable(n *parser.ShowCreateTable) (planNode, error) {
 		}
 		interleave, err := p.showCreateInterleave(&idx)
 		if err != nil {
+			v.rows.Close()
 			return nil, err
 		}
 		fmt.Fprintf(&buf, ",\n\t%sINDEX %s (%s)%s%s",
@@ -206,16 +216,21 @@ func (p *planner) ShowCreateTable(n *parser.ShowCreateTable) (planNode, error) {
 	}
 
 	buf.WriteString("\n)")
+
 	interleave, err := p.showCreateInterleave(&desc.PrimaryIndex)
 	if err != nil {
+		v.rows.Close()
 		return nil, err
 	}
 	buf.WriteString(interleave)
 
-	v.rows = append(v.rows, []parser.Datum{
+	if err := v.rows.AddRow(parser.DTuple{
 		parser.NewDString(n.Table.String()),
 		parser.NewDString(buf.String()),
-	})
+	}); err != nil {
+		v.rows.Close()
+		return nil, err
+	}
 	return v, nil
 }
 
@@ -244,17 +259,24 @@ func (p *planner) ShowDatabases(n *parser.ShowDatabases) (planNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	v := &valuesNode{columns: []ResultColumn{{Name: "Database", Typ: parser.TypeString}}}
+	v := p.newContainerValuesNode(ResultColumns{{Name: "Database", Typ: parser.TypeString}}, 0)
 	for db := range virtualSchemaMap {
-		v.rows = append(v.rows, []parser.Datum{parser.NewDString(db)})
+		if err := v.rows.AddRow(parser.DTuple{parser.NewDString(db)}); err != nil {
+			v.rows.Close()
+			return nil, err
+		}
 	}
 	for _, row := range sr {
 		_, name, err := encoding.DecodeUnsafeStringAscending(
 			bytes.TrimPrefix(row.Key, prefix), nil)
 		if err != nil {
+			v.rows.Close()
 			return nil, err
 		}
-		v.rows = append(v.rows, []parser.Datum{parser.NewDString(name)})
+		if err := v.rows.AddRow(parser.DTuple{parser.NewDString(name)}); err != nil {
+			v.rows.Close()
+			return nil, err
+		}
 	}
 	return v, nil
 }
@@ -278,13 +300,12 @@ func (p *planner) ShowGrants(n *parser.ShowGrants) (planNode, error) {
 		objectType = "Table"
 	}
 
-	v := &valuesNode{
-		columns: []ResultColumn{
-			{Name: objectType, Typ: parser.TypeString},
-			{Name: "User", Typ: parser.TypeString},
-			{Name: "Privileges", Typ: parser.TypeString},
-		},
+	columns := ResultColumns{
+		{Name: objectType, Typ: parser.TypeString},
+		{Name: "User", Typ: parser.TypeString},
+		{Name: "Privileges", Typ: parser.TypeString},
 	}
+	v := p.newContainerValuesNode(columns, 0)
 	var wantedUsers map[string]struct{}
 	if len(n.Grantees) != 0 {
 		wantedUsers = make(map[string]struct{})
@@ -301,11 +322,15 @@ func (p *planner) ShowGrants(n *parser.ShowGrants) (planNode, error) {
 					continue
 				}
 			}
-			v.rows = append(v.rows, []parser.Datum{
+			newRow := parser.DTuple{
 				parser.NewDString(descriptor.GetName()),
 				parser.NewDString(userPriv.User),
 				parser.NewDString(userPriv.PrivilegeString()),
-			})
+			}
+			if err := v.rows.AddRow(newRow); err != nil {
+				v.rows.Close()
+				return nil, err
+			}
 		}
 	}
 	return v, nil
@@ -329,21 +354,20 @@ func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, error) {
 		return nil, err
 	}
 
-	v := &valuesNode{
-		columns: []ResultColumn{
-			{Name: "Table", Typ: parser.TypeString},
-			{Name: "Name", Typ: parser.TypeString},
-			{Name: "Unique", Typ: parser.TypeBool},
-			{Name: "Seq", Typ: parser.TypeInt},
-			{Name: "Column", Typ: parser.TypeString},
-			{Name: "Direction", Typ: parser.TypeString},
-			{Name: "Storing", Typ: parser.TypeBool},
-		},
+	columns := ResultColumns{
+		{Name: "Table", Typ: parser.TypeString},
+		{Name: "Name", Typ: parser.TypeString},
+		{Name: "Unique", Typ: parser.TypeBool},
+		{Name: "Seq", Typ: parser.TypeInt},
+		{Name: "Column", Typ: parser.TypeString},
+		{Name: "Direction", Typ: parser.TypeString},
+		{Name: "Storing", Typ: parser.TypeBool},
 	}
+	v := p.newContainerValuesNode(columns, 0)
 
 	appendRow := func(index sqlbase.IndexDescriptor, colName string, sequence int,
-		direction string, isStored bool) {
-		v.rows = append(v.rows, []parser.Datum{
+		direction string, isStored bool) error {
+		newRow := parser.DTuple{
 			parser.NewDString(tn.Table()),
 			parser.NewDString(index.Name),
 			parser.MakeDBool(parser.DBool(index.Unique)),
@@ -351,17 +375,24 @@ func (p *planner) ShowIndex(n *parser.ShowIndex) (planNode, error) {
 			parser.NewDString(colName),
 			parser.NewDString(direction),
 			parser.MakeDBool(parser.DBool(isStored)),
-		})
+		}
+		return v.rows.AddRow(newRow)
 	}
 
 	for _, index := range append([]sqlbase.IndexDescriptor{desc.PrimaryIndex}, desc.Indexes...) {
 		sequence := 1
 		for i, col := range index.ColumnNames {
-			appendRow(index, col, sequence, index.ColumnDirections[i].String(), false)
+			if err := appendRow(index, col, sequence, index.ColumnDirections[i].String(), false); err != nil {
+				v.rows.Close()
+				return nil, err
+			}
 			sequence++
 		}
 		for _, col := range index.StoreColumnNames {
-			appendRow(index, col, sequence, "N/A", true)
+			if err := appendRow(index, col, sequence, "N/A", true); err != nil {
+				v.rows.Close()
+				return nil, err
+			}
 			sequence++
 		}
 	}
@@ -386,15 +417,14 @@ func (p *planner) ShowConstraints(n *parser.ShowConstraints) (planNode, error) {
 		return nil, err
 	}
 
-	v := &valuesNode{
-		columns: []ResultColumn{
-			{Name: "Table", Typ: parser.TypeString},
-			{Name: "Name", Typ: parser.TypeString},
-			{Name: "Type", Typ: parser.TypeString},
-			{Name: "Column(s)", Typ: parser.TypeString},
-			{Name: "Details", Typ: parser.TypeString},
-		},
+	columns := ResultColumns{
+		{Name: "Table", Typ: parser.TypeString},
+		{Name: "Name", Typ: parser.TypeString},
+		{Name: "Type", Typ: parser.TypeString},
+		{Name: "Column(s)", Typ: parser.TypeString},
+		{Name: "Details", Typ: parser.TypeString},
 	}
+	v := p.newContainerValuesNode(columns, 0)
 
 	info, err := desc.GetConstraintInfo(p.txn)
 	if err != nil {
@@ -413,18 +443,23 @@ func (p *planner) ShowConstraints(n *parser.ShowConstraints) (planNode, error) {
 		if c.Unvalidated {
 			kind += " (UNVALIDATED)"
 		}
-		v.rows = append(v.rows, []parser.Datum{
+		newRow := []parser.Datum{
 			parser.NewDString(tn.Table()),
 			parser.NewDString(name),
 			parser.NewDString(kind),
 			columnsDatum,
 			detailsDatum,
-		})
+		}
+		if err := v.rows.AddRow(newRow); err != nil {
+			v.Close()
+			return nil, err
+		}
 	}
 
 	// Sort the results by constraint name.
 	sort := &sortNode{
 		ctx: p.ctx(),
+		p:   p,
 		ordering: sqlbase.ColumnOrdering{
 			{ColIdx: 0, Direction: encoding.Ascending},
 			{ColIdx: 1, Direction: encoding.Ascending},
@@ -461,9 +496,12 @@ func (p *planner) ShowTables(n *parser.ShowTables) (planNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	v := &valuesNode{columns: []ResultColumn{{Name: "Table", Typ: parser.TypeString}}}
+	v := p.newContainerValuesNode(ResultColumns{{Name: "Table", Typ: parser.TypeString}}, len(tableNames))
 	for _, name := range tableNames {
-		v.rows = append(v.rows, []parser.Datum{parser.NewDString(name.Table())})
+		if err := v.rows.AddRow(parser.DTuple{parser.NewDString(name.Table())}); err != nil {
+			v.rows.Close()
+			return nil, err
+		}
 	}
 
 	return v, nil

--- a/sql/split.go
+++ b/sql/split.go
@@ -168,8 +168,8 @@ func (n *splitNode) Values() parser.DTuple {
 	}
 }
 
-func (*splitNode) Columns() []ResultColumn {
-	return []ResultColumn{
+func (*splitNode) Columns() ResultColumns {
+	return ResultColumns{
 		{
 			Name: "key",
 			Typ:  parser.TypeBytes,
@@ -181,6 +181,7 @@ func (*splitNode) Columns() []ResultColumn {
 	}
 }
 
+func (*splitNode) Close()                              {}
 func (*splitNode) Ordering() orderingInfo              { return orderingInfo{} }
 func (*splitNode) ExplainTypes(_ func(string, string)) {}
 func (*splitNode) SetLimitHint(_ int64, _ bool)        {}

--- a/sql/testdata/explain
+++ b/sql/testdata/explain
@@ -68,8 +68,8 @@ Level  Type                  Description    Columns                             
 0      select                               ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition) +9,+"Span Pos"
 1      sort                  +9,+"Span Pos" ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition) +9,+"Span Pos"
 2      explain               trace          ("Cumulative Time", Duration, "Span Pos", Operation, Event, RowIdx, Key, Value, Disposition)
-3      select                               (RowIdx, Key, Value, Disposition)
-4      render/filter(debug)  from ()        (RowIdx, Key, Value, Disposition)
+3      select                               ("1")
+4      render/filter(debug)  from ()        ("1")
 5      empty                 -              ()
 
 # Ensure that all relevant statement types can be explained

--- a/sql/union.go
+++ b/sql/union.go
@@ -136,8 +136,8 @@ type unionNode struct {
 	debugVals   debugValues
 }
 
-func (n *unionNode) Columns() []ResultColumn { return n.left.Columns() }
-func (n *unionNode) Ordering() orderingInfo  { return orderingInfo{} }
+func (n *unionNode) Columns() ResultColumns { return n.left.Columns() }
+func (n *unionNode) Ordering() orderingInfo { return orderingInfo{} }
 
 func (n *unionNode) Values() parser.DTuple {
 	switch {
@@ -208,6 +208,7 @@ func (n *unionNode) readRight() (bool, error) {
 	}
 
 	n.rightDone = true
+	n.right.Close()
 	return n.readLeft()
 }
 
@@ -242,6 +243,7 @@ func (n *unionNode) readLeft() (bool, error) {
 		return false, err
 	}
 	n.leftDone = true
+	n.left.Close()
 	return false, nil
 }
 
@@ -267,6 +269,15 @@ func (n *unionNode) Next() (bool, error) {
 		return n.readLeft()
 	default:
 		return false, nil
+	}
+}
+
+func (n *unionNode) Close() {
+	switch {
+	case !n.rightDone:
+		n.right.Close()
+	case !n.leftDone:
+		n.left.Close()
 	}
 }
 

--- a/sql/update.go
+++ b/sql/update.go
@@ -284,6 +284,10 @@ func (u *updateNode) Start() error {
 	return u.run.tw.init(u.p.txn)
 }
 
+func (u *updateNode) Close() {
+	u.run.rows.Close()
+}
+
 func (u *updateNode) Next() (bool, error) {
 	next, err := u.run.rows.Next()
 	if !next {
@@ -381,7 +385,7 @@ func fillDefault(
 	return expr
 }
 
-func (u *updateNode) Columns() []ResultColumn {
+func (u *updateNode) Columns() ResultColumns {
 	return u.rh.columns
 }
 

--- a/sql/values.go
+++ b/sql/values.go
@@ -31,16 +31,24 @@ import (
 type valuesNode struct {
 	n        *parser.ValuesClause
 	p        *planner
-	columns  []ResultColumn
+	columns  ResultColumns
 	ordering sqlbase.ColumnOrdering
 	tuples   [][]parser.TypedExpr
-	rows     []parser.DTuple
+	rows     *RowContainer
 
 	desiredTypes []parser.Datum // This can be removed when we only type check once.
 
 	nextRow       int           // The index of the next row.
 	invertSorting bool          // Inverts the sorting predicate.
 	tmpValues     parser.DTuple // Used to store temporary values.
+	err           error         // Used to propagate errors during heap operations.
+}
+
+func (p *planner) newContainerValuesNode(columns ResultColumns, capacity int) *valuesNode {
+	return &valuesNode{
+		columns: columns,
+		rows:    p.NewRowContainer(columns, capacity),
+	}
 }
 
 func (p *planner) ValuesClause(n *parser.ValuesClause, desiredTypes []parser.Datum) (planNode, error) {
@@ -58,7 +66,7 @@ func (p *planner) ValuesClause(n *parser.ValuesClause, desiredTypes []parser.Dat
 	v.tuples = make([][]parser.TypedExpr, 0, len(n.Tuples))
 	tupleBuf := make([]parser.TypedExpr, len(n.Tuples)*numCols)
 
-	v.columns = make([]ResultColumn, 0, numCols)
+	v.columns = make(ResultColumns, 0, numCols)
 
 	for num, tuple := range n.Tuples {
 		if a, e := len(tuple.Exprs), numCols; a != e {
@@ -128,8 +136,9 @@ func (n *valuesNode) Start() error {
 	// others that create a valuesNode internally for storing results
 	// from other planNodes), so its expressions need evaluting.
 	// This may run subqueries.
+	n.rows = n.p.NewRowContainer(n.columns, len(n.n.Tuples))
+
 	numCols := len(n.columns)
-	n.rows = make([]parser.DTuple, 0, len(n.n.Tuples))
 	rowBuf := make([]parser.Datum, len(n.n.Tuples)*numCols)
 	for _, tupleRow := range n.tuples {
 		// Chop off prefix of rowBuf and limit its capacity.
@@ -147,13 +156,15 @@ func (n *valuesNode) Start() error {
 				return err
 			}
 		}
-		n.rows = append(n.rows, row)
+		if err := n.rows.AddRow(row); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (n *valuesNode) Columns() []ResultColumn {
+func (n *valuesNode) Columns() ResultColumns {
 	return n.columns
 }
 
@@ -162,37 +173,45 @@ func (n *valuesNode) Ordering() orderingInfo {
 }
 
 func (n *valuesNode) Values() parser.DTuple {
-	return n.rows[n.nextRow-1]
+	return n.rows.At(n.nextRow - 1)
 }
 
 func (*valuesNode) MarkDebug(_ explainMode) {}
 
 func (n *valuesNode) DebugValues() debugValues {
+	val := n.rows.At(n.nextRow - 1)
 	return debugValues{
 		rowIdx: n.nextRow - 1,
 		key:    fmt.Sprintf("%d", n.nextRow-1),
-		value:  n.rows[n.nextRow-1].String(),
+		value:  val.String(),
 		output: debugValueRow,
 	}
 }
 
 func (n *valuesNode) Next() (bool, error) {
-	if n.nextRow >= len(n.rows) {
+	if n.nextRow >= n.rows.Len() {
 		return false, nil
 	}
 	n.nextRow++
 	return true, nil
 }
 
+func (n *valuesNode) Close() {
+	if n.rows != nil {
+		n.rows.Close()
+		n.rows = nil
+	}
+}
+
 func (n *valuesNode) Len() int {
-	return len(n.rows)
+	return n.rows.Len()
 }
 
 func (n *valuesNode) Less(i, j int) bool {
 	// TODO(pmattis): An alternative to this type of field-based comparison would
 	// be to construct a sort-key per row using encodeTableKey(). Using a
 	// sort-key approach would likely fit better with a disk-based sort.
-	ra, rb := n.rows[i], n.rows[j]
+	ra, rb := n.rows.At(i), n.rows.At(j)
 	return n.invertSorting != n.ValuesLess(ra, rb)
 }
 
@@ -222,31 +241,28 @@ func (n *valuesNode) ValuesLess(ra, rb parser.DTuple) bool {
 }
 
 func (n *valuesNode) Swap(i, j int) {
-	n.rows[i], n.rows[j] = n.rows[j], n.rows[i]
+	n.rows.Swap(i, j)
 }
 
 var _ heap.Interface = (*valuesNode)(nil)
 
 // Push implements the heap.Interface interface.
 func (n *valuesNode) Push(x interface{}) {
-	n.rows = append(n.rows, n.tmpValues)
+	n.err = n.rows.AddRow(n.tmpValues)
 }
 
 // PushValues pushes the given DTuple value into the heap representation
 // of the valuesNode.
-func (n *valuesNode) PushValues(values parser.DTuple) {
+func (n *valuesNode) PushValues(values parser.DTuple) error {
 	// Avoid passing slice through interface{} to avoid allocation.
 	n.tmpValues = values
 	heap.Push(n, nil)
+	return n.err
 }
 
 // Pop implements the heap.Interface interface.
 func (n *valuesNode) Pop() interface{} {
-	idx := len(n.rows) - 1
-	// Returning a pointer to avoid an allocation when storing the slice in an interface{}.
-	x := &(n.rows)[idx]
-	n.rows = n.rows[:idx]
-	return x
+	return n.rows.PseudoPop()
 }
 
 // PopValues pops the top DTuple value off the heap representation

--- a/sql/values_test.go
+++ b/sql/values_test.go
@@ -30,12 +30,15 @@ import (
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/timeutil"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 func TestValues(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	p := makePlanner()
+	p.session.mon.StartMonitor()
+	defer p.session.mon.StopMonitor(context.Background())
 
 	vInt := int64(5)
 	vNum := 3.14159
@@ -119,6 +122,7 @@ func TestValues(t *testing.T) {
 			t.Errorf("%d: error_expected=%t, but got error %v", i, tc.ok, err)
 		}
 		if plan != nil {
+			defer plan.Close()
 			if err := plan.expandPlan(); err != nil {
 				t.Errorf("%d: unexpected error in expandPlan: %v", i, err)
 				continue

--- a/sql/virtual_schema.go
+++ b/sql/virtual_schema.go
@@ -44,7 +44,7 @@ type virtualSchema struct {
 // virtualSchemaTable represents a table within a virtualSchema.
 type virtualSchemaTable struct {
 	schema   string
-	populate func(p *planner, addRow func(...parser.Datum)) error
+	populate func(p *planner, addRow func(...parser.Datum) error) error
 }
 
 // virtualSchemas holds a slice of statically registered virtualSchema objects.
@@ -93,21 +93,23 @@ type virtualTableEntry struct {
 // getValuesNode returns a new valuesNode for the virtual table using the
 // provided planner.
 func (e virtualTableEntry) getValuesNode(p *planner) (*valuesNode, error) {
-	v := &valuesNode{}
+	var columns ResultColumns
 	for _, col := range e.desc.Columns {
-		v.columns = append(v.columns, ResultColumn{
+		columns = append(columns, ResultColumn{
 			Name: col.Name,
 			Typ:  col.Type.ToDatumType(),
 		})
 	}
+	v := p.newContainerValuesNode(columns, 0)
 
-	err := e.tableDef.populate(p, func(datum ...parser.Datum) {
+	err := e.tableDef.populate(p, func(datum ...parser.Datum) error {
 		if r, c := len(datum), len(v.columns); r != c {
 			panic(fmt.Sprintf("datum row count and column count differ: %d vs %d", r, c))
 		}
-		v.rows = append(v.rows, datum)
+		return v.rows.AddRow(datum)
 	})
 	if err != nil {
+		v.Close()
 		return nil, err
 	}
 	return v, nil

--- a/util/roundup2.go
+++ b/util/roundup2.go
@@ -1,0 +1,30 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package util
+
+// RoundUpPowerOfTwo returns the first power of 2 greater or equal to the number.
+// Source: http://graphics.stanford.edu/%7Eseander/bithacks.html#RoundUpPowerOf2
+func RoundUpPowerOfTwo(x int64) int64 {
+	x--
+	x |= x >> 1
+	x |= x >> 2
+	x |= x >> 4
+	x |= x >> 8
+	x |= x >> 16
+	x |= x >> 32
+	return x + 1
+}

--- a/util/smalltrace.go
+++ b/util/smalltrace.go
@@ -1,0 +1,47 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package util
+
+import (
+	"runtime"
+	"strings"
+)
+
+// GetTopCallers populates an array with the names of the topmost 5
+// caller functions in the stack after skipping a given number of
+// frames. We use this to provide context to allocations in the logs
+// with high verbosity.
+func GetTopCallers(callers []string, skip int) {
+	var pc [5]uintptr
+	nCallers := runtime.Callers(skip+1, pc[:])
+	for i := 0; i < nCallers; i++ {
+		name := runtime.FuncForPC(pc[i]).Name()
+		const crl = "github.com/cockroachdb/cockroach/"
+		if strings.HasPrefix(name, crl) {
+			name = name[len(crl):]
+		}
+		callers[i] = name
+	}
+}
+
+// GetSmallTrace produces a ":"-separated single line containing the
+// topmost 5 callers from a given skip level.
+func GetSmallTrace(skip int) string {
+	var callers [5]string
+	GetTopCallers(callers[0:], skip+2)
+	return strings.Join(callers[0:], ":")
+}

--- a/util/smalltrace_test.go
+++ b/util/smalltrace_test.go
@@ -1,0 +1,37 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Raphael 'kena' Poss (knz@cockroachlabs.com)
+
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func testSmallTrace2(t *testing.T) {
+	s := GetSmallTrace(2)
+	if !strings.Contains(s, "TestGenerateSmallTrace") {
+		t.Fatalf("trace not generated properly: %q", s)
+	}
+}
+
+func testSmallTrace(t *testing.T) {
+	testSmallTrace2(t)
+}
+
+func TestGenerateSmallTrace(t *testing.T) {
+	testSmallTrace(t)
+}


### PR DESCRIPTION
This patch instruments SQL execution to track memory allocations whose
amounts depend on user input and current database contents (as opposed
to allocations dependent on other parameters e.g. statement size).

This tracks and limits allocations in `valueNode`, buckets in
`groupNode`, sorted data in `sortNode`, temp results in `joinNode`,
seen prefixes in `distinctNode` and the Result array in Executor.

A moderate amount of intelligence is implemented so as to avoid
computing sizes for every column of every row in a valueNode - the
combined size of all fixed-size columns is precomputed and counted at
once for every row.

The maximum amount of memory allocated by SQL values is limited in
this patch to 1GB. An error is reported to the client if this limit is
exceeded. Additionally, queries that allocate more than 10KB worth of
data will see their usage printed in the log files automatically.

This patch does not track the memory allocated for write intents in
the KV transaction object.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8691)

<!-- Reviewable:end -->
