### PR TITLE
storage: disable TestStoreRangeCorruptionChangeReplicas

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -693,6 +693,7 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 // will notice corrupted replicas and replace them.
 func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skipf("#8664: flaky")
 
 	const numReplicas = 3
 	const extraStores = 3


### PR DESCRIPTION
See #8664.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8693)

<!-- Reviewable:end -->
