### PR TITLE
storage: bump raft tick interval to 200ms and heartbeat ticks to 5

### DIFF
--- a/base/context.go
+++ b/base/context.go
@@ -56,7 +56,7 @@ const (
 	NetworkTimeout = 3 * time.Second
 
 	// DefaultRaftTickInterval is the default resolution of the Raft timer.
-	DefaultRaftTickInterval = 100 * time.Millisecond
+	DefaultRaftTickInterval = 200 * time.Millisecond
 )
 
 type lazyTLSConfig struct {

--- a/storage/store.go
+++ b/storage/store.go
@@ -59,7 +59,7 @@ import (
 const (
 	// rangeIDAllocCount is the number of Range IDs to allocate per allocation.
 	rangeIDAllocCount               = 10
-	defaultHeartbeatIntervalTicks   = 3
+	defaultHeartbeatIntervalTicks   = 5
 	defaultRaftElectionTimeoutTicks = 15
 	defaultAsyncSnapshotMaxAge      = time.Minute
 	// ttlStoreGossip is time-to-live for store-related info.


### PR DESCRIPTION
This will increase the heartbeat interval from 300ms to 1s and the
election timeout from ~1.5s to ~3s (the election timeout is randomized).

With the previous settings, the ~5000 ranges on the beta cluster would
generate 30k heartbeat requests and responses per second (~5k per second
per node). With the new settings they will generate 10k per
second. Still excessive, but a bit of breathing room until coalesced
heartbeats arrives.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8695)

<!-- Reviewable:end -->
