### PR TITLE
server,storage: plumb more contexts, set node/store log tags

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -232,6 +232,11 @@ func NewDistSender(cfg *DistSenderConfig, g *gossip.Gossip) *DistSender {
 	return ds
 }
 
+// SetNodeID sets the node ID (for logging contexts).
+func (ds *DistSender) SetNodeID(nodeID roachpb.NodeID) {
+	ds.Ctx = log.WithLogTagInt(ds.Ctx, "node", int(nodeID))
+}
+
 // RangeLookup implements the RangeDescriptorDB interface.
 // RangeLookup dispatches a RangeLookup request for the given metadata
 // key to the replicas of the given range. Note that we allow
@@ -261,7 +266,7 @@ func (ds *DistSender) RangeLookup(
 	replicas.Shuffle()
 	// TODO(tschottdorf): Ideally we would use the trace of the request which
 	// caused this lookup.
-	br, err := ds.sendRPC(context.Background(), desc.RangeID, replicas, ba)
+	br, err := ds.sendRPC(ds.Ctx, desc.RangeID, replicas, ba)
 	if err != nil {
 		return nil, nil, roachpb.NewError(err)
 	}

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -193,6 +193,11 @@ func NewTxnCoordSender(
 	return tc
 }
 
+// SetNodeID sets the node ID (for logging contexts).
+func (tc *TxnCoordSender) SetNodeID(nodeID roachpb.NodeID) {
+	tc.ctx = log.WithLogTagInt(tc.ctx, "node", int(nodeID))
+}
+
 // startStats blocks and periodically logs transaction statistics (throughput,
 // success rates, durations, ...). Note that this only captures write txns,
 // since read-only txns are stateless as far as TxnCoordSender is concerned.

--- a/server/node.go
+++ b/server/node.go
@@ -322,6 +322,8 @@ func (n *Node) initNodeID(id roachpb.NodeID) {
 	if err = n.ctx.Gossip.SetNodeDescriptor(&n.Descriptor); err != nil {
 		log.Fatalf(n.Ctx(), "couldn't gossip descriptor for node %d: %s", n.Descriptor.NodeID, err)
 	}
+	// Add log tags to context.
+	n.ctx.Ctx = log.WithLogTagInt(n.ctx.Ctx, "node", int(id))
 }
 
 // start starts the node by registering the storage instance for the

--- a/server/server.go
+++ b/server/server.go
@@ -73,30 +73,31 @@ var (
 
 // Server is the cockroach server node.
 type Server struct {
-	ctx           Context
-	mux           *http.ServeMux
-	clock         *hlc.Clock
-	rpcContext    *rpc.Context
-	grpc          *grpc.Server
-	gossip        *gossip.Gossip
-	storePool     *storage.StorePool
-	distSender    *kv.DistSender
-	db            *client.DB
-	kvDB          *kv.DBServer
-	pgServer      *pgwire.Server
-	distSQLServer *distsql.ServerImpl
-	node          *Node
-	registry      *metric.Registry
-	recorder      *status.MetricsRecorder
-	runtime       status.RuntimeStatSampler
-	admin         adminServer
-	status        *statusServer
-	tsDB          *ts.DB
-	tsServer      ts.Server
-	raftTransport *storage.RaftTransport
-	stopper       *stop.Stopper
-	sqlExecutor   *sql.Executor
-	leaseMgr      *sql.LeaseManager
+	ctx            Context
+	mux            *http.ServeMux
+	clock          *hlc.Clock
+	rpcContext     *rpc.Context
+	grpc           *grpc.Server
+	gossip         *gossip.Gossip
+	storePool      *storage.StorePool
+	txnCoordSender *kv.TxnCoordSender
+	distSender     *kv.DistSender
+	db             *client.DB
+	kvDB           *kv.DBServer
+	pgServer       *pgwire.Server
+	distSQLServer  *distsql.ServerImpl
+	node           *Node
+	registry       *metric.Registry
+	recorder       *status.MetricsRecorder
+	runtime        status.RuntimeStatSampler
+	admin          adminServer
+	status         *statusServer
+	tsDB           *ts.DB
+	tsServer       ts.Server
+	raftTransport  *storage.RaftTransport
+	stopper        *stop.Stopper
+	sqlExecutor    *sql.Executor
+	leaseMgr       *sql.LeaseManager
 }
 
 // NewServer creates a Server from a server.Context.
@@ -179,13 +180,13 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 
 	txnMetrics := kv.MakeTxnMetrics()
 	s.registry.AddMetricStruct(txnMetrics)
-	sender := kv.NewTxnCoordSender(s.Ctx(), s.distSender, s.clock, srvCtx.Linearizable,
+	s.txnCoordSender = kv.NewTxnCoordSender(s.Ctx(), s.distSender, s.clock, srvCtx.Linearizable,
 		s.stopper, txnMetrics)
-	s.db = client.NewDB(sender)
+	s.db = client.NewDB(s.txnCoordSender)
 
 	s.raftTransport = storage.NewRaftTransport(storage.GossipAddressResolver(s.gossip), s.grpc, s.rpcContext)
 
-	s.kvDB = kv.NewDBServer(s.ctx.Context, sender, s.stopper)
+	s.kvDB = kv.NewDBServer(s.ctx.Context, s.txnCoordSender, s.stopper)
 	roachpb.RegisterExternalServer(s.grpc, s.kvDB)
 
 	// Set up Lease Manager
@@ -446,6 +447,8 @@ func (s *Server) Start() error {
 
 	s.sqlExecutor.SetNodeID(s.node.Descriptor.NodeID)
 	s.distSQLServer.SetNodeID(s.node.Descriptor.NodeID)
+	s.txnCoordSender.SetNodeID(s.node.Descriptor.NodeID)
+	s.distSender.SetNodeID(s.node.Descriptor.NodeID)
 
 	// Create and start the schema change manager only after a NodeID
 	// has been assigned.

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -295,6 +295,7 @@ func (e *Executor) Ctx() context.Context {
 func (e *Executor) SetNodeID(nodeID roachpb.NodeID) {
 	e.nodeID = nodeID
 	e.cfg.LeaseManager.nodeID = uint32(nodeID)
+	e.cfg.Context = log.WithLogTagInt(e.cfg.Context, "node", int(nodeID))
 }
 
 // updateSystemConfig is called whenever the system config gossip entry is updated.

--- a/util/log/log_context_test.go
+++ b/util/log/log_context_test.go
@@ -31,36 +31,105 @@ func TestLogContext(t *testing.T) {
 
 	ctxB1 := WithLogTagStr(ctxA, "branch", "meh")
 
-	testCases := []struct{ value, expected string }{
+	testCases := []struct {
+		ctx      context.Context
+		expected string
+	}{
 		{
-			value:    makeMessage(ctx, "test", nil),
+			ctx:      ctx,
 			expected: "test",
 		},
 		{
-			value:    makeMessage(ctxA, "test", nil),
+			ctx:      ctxA,
 			expected: "[NodeID=5] test",
 		},
 		{
-			value:    makeMessage(ctxB, "test", nil),
+			ctx:      ctxB,
 			expected: "[NodeID=5,ReqID=123] test",
 		},
 		{
-			value:    makeMessage(ctxC, "test", nil),
+			ctx:      ctxC,
 			expected: "[NodeID=5,ReqID=123,aborted] test",
 		},
 		{
-			value:    makeMessage(ctxD, "test", nil),
+			ctx:      ctxD,
 			expected: "[NodeID=5,ReqID=123,aborted,slice=[1 2 3]] test",
 		},
 		{
-			value:    makeMessage(ctxB1, "test", nil),
+			ctx:      ctxB1,
 			expected: "[NodeID=5,branch=meh] test",
 		},
 	}
 
 	for i, tc := range testCases {
-		if tc.value != tc.expected {
-			t.Errorf("Test case %d failed: expected '%s', got '%s'", i, tc.expected, tc.value)
+		if value := makeMessage(tc.ctx, "test", nil); value != tc.expected {
+			t.Errorf("Test case %d failed: expected '%s', got '%s'", i, tc.expected, value)
+		}
+	}
+}
+
+func TestWithLogTagsFromCtx(t *testing.T) {
+	ctx1 := context.Background()
+	ctx1A := WithLogTagInt(ctx1, "1A", 1)
+	ctx1B := WithLogTag(ctx1A, "1B", nil)
+
+	ctx2 := context.Background()
+	ctx2A := WithLogTagInt(ctx2, "2A", 1)
+	ctx2B := WithLogTag(ctx2A, "2B", nil)
+
+	testCases := []struct {
+		ctx      context.Context
+		expected string
+	}{
+		{
+			ctx:      WithLogTagsFromCtx(ctx1, ctx2),
+			expected: "test",
+		},
+
+		{
+			ctx:      WithLogTagsFromCtx(ctx1, ctx2A),
+			expected: "[2A=1] test",
+		},
+
+		{
+			ctx:      WithLogTagsFromCtx(ctx1, ctx2B),
+			expected: "[2A=1,2B] test",
+		},
+
+		{
+			ctx:      WithLogTagsFromCtx(ctx1A, ctx2),
+			expected: "[1A=1] test",
+		},
+
+		{
+			ctx:      WithLogTagsFromCtx(ctx1A, ctx2A),
+			expected: "[1A=1,2A=1] test",
+		},
+
+		{
+			ctx:      WithLogTagsFromCtx(ctx1A, ctx2B),
+			expected: "[1A=1,2A=1,2B] test",
+		},
+
+		{
+			ctx:      WithLogTagsFromCtx(ctx1B, ctx2),
+			expected: "[1A=1,1B] test",
+		},
+
+		{
+			ctx:      WithLogTagsFromCtx(ctx1B, ctx2A),
+			expected: "[1A=1,1B,2A=1] test",
+		},
+
+		{
+			ctx:      WithLogTagsFromCtx(ctx1B, ctx2B),
+			expected: "[1A=1,1B,2A=1,2B] test",
+		},
+	}
+
+	for i, tc := range testCases {
+		if value := makeMessage(tc.ctx, "test", nil); value != tc.expected {
+			t.Errorf("Test case %d failed: expected '%s', got '%s'", i, tc.expected, value)
 		}
 	}
 }


### PR DESCRIPTION
See individual commits for descriptions.

@petermattis Do you think having `node=xx`  show up in logs is distracting in production? Or it could potentially be useful there too? (could help not having to keep track of what log file came from which node)  I could plumb a `TestingKnob` to only enable it on test clusters if we don't want it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8715)

<!-- Reviewable:end -->
