### PR TITLE
master -> develop

### DIFF
--- a/acceptance/event_log_test.go
+++ b/acceptance/event_log_test.go
@@ -33,6 +33,7 @@ import (
 // TestEventLog verifies that "node joined" and "node restart" events are
 // recorded whenever a node starts and contacts the cluster.
 func TestEventLog(t *testing.T) {
+	t.Skip("flaky: #8562")
 	runTestOnConfigs(t, testEventLogInner)
 }
 

--- a/cli/start.go
+++ b/cli/start.go
@@ -51,6 +51,8 @@ import (
 	"github.com/cockroachdb/cockroach/util/sdnotify"
 	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/timeutil"
+	"github.com/cockroachdb/cockroach/util/tracing"
+	opentracing "github.com/opentracing/opentracing-go"
 
 	"github.com/spf13/cobra"
 )
@@ -299,6 +301,11 @@ func runStart(_ *cobra.Command, args []string) error {
 		return rerunBackground()
 	}
 
+	tracer := tracing.NewTracer()
+	startCtx := tracing.WithTracer(context.Background(), tracer)
+	sp := tracer.StartSpan("server start")
+	startCtx = opentracing.ContextWithSpan(startCtx, sp)
+
 	if err := initInsecure(); err != nil {
 		return err
 	}
@@ -327,11 +334,12 @@ func runStart(_ *cobra.Command, args []string) error {
 	if err := os.MkdirAll(logDir, 0755); err != nil {
 		return err
 	}
+	log.Tracef(startCtx, "created log directory %s", logDir)
 
 	// We log build information to stdout (for the short summary), but also
 	// to stderr to coincide with the full logs.
 	info := build.GetInfo()
-	log.Infof(context.TODO(), info.Short())
+	log.Infof(startCtx, info.Short())
 
 	initMemProfile(f.Value.String())
 	initCPUProfile(f.Value.String())
@@ -341,6 +349,8 @@ func runStart(_ *cobra.Command, args []string) error {
 	serverCtx.User = security.NodeUser
 
 	stopper := initBacktrace(logDir)
+	log.Trace(startCtx, "initialized profiles")
+
 	if err := serverCtx.InitStores(stopper); err != nil {
 		return fmt.Errorf("failed to initialize stores: %s", err)
 	}
@@ -349,15 +359,16 @@ func runStart(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize node: %s", err)
 	}
 
-	log.Info(context.TODO(), "starting cockroach node")
+	log.Info(startCtx, "starting cockroach node")
 	s, err := server.NewServer(serverCtx, stopper)
 	if err != nil {
 		return fmt.Errorf("failed to start Cockroach server: %s", err)
 	}
 
-	if err := s.Start(); err != nil {
+	if err := s.Start(startCtx); err != nil {
 		return fmt.Errorf("cockroach server exited with error: %s", err)
 	}
+	sp.Finish()
 
 	// We don't do this in (*server.Server).Start() because we don't want it
 	// in tests.

--- a/gossip/storage_test.go
+++ b/gossip/storage_test.go
@@ -17,7 +17,6 @@
 package gossip_test
 
 import (
-	"net"
 	"reflect"
 	"sort"
 	"strings"
@@ -219,14 +218,7 @@ func TestGossipStorageCleanup(t *testing.T) {
 	network := simulation.NewNetwork(numNodes, false)
 	defer network.Stop()
 
-	// Create a definitely closed address.
-	ln, err := net.Listen("tcp", util.TestAddr.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	closedAddr := ln.Addr()
-	ln.Close()
-
+	const notReachableAddr = "localhost:0"
 	const invalidAddr = "10.0.0.1000:3333333"
 	// Set storage for each of the nodes.
 	addresses := make(unresolvedAddrSlice, len(network.Nodes))
@@ -237,7 +229,7 @@ func TestGossipStorageCleanup(t *testing.T) {
 		if err := stores[i].WriteBootstrapInfo(&gossip.BootstrapInfo{
 			Addresses: []util.UnresolvedAddr{
 				util.MakeUnresolvedAddr("tcp", network.Nodes[(i+1)%numNodes].Addr().String()), // node i+1 address
-				util.MakeUnresolvedAddr(closedAddr.Network(), closedAddr.String()),            // valid but closed address
+				util.MakeUnresolvedAddr("tcp", notReachableAddr),                              // unreachable address
 				util.MakeUnresolvedAddr("tcp", invalidAddr),                                   // invalid address
 			},
 		}); err != nil {

--- a/server/node.go
+++ b/server/node.go
@@ -224,7 +224,7 @@ func bootstrapCluster(engines []engine.Engine, txnMetrics kv.TxnMetrics) (uuid.U
 				return uuid.UUID{}, err
 			}
 		}
-		if err := s.Start(stopper); err != nil {
+		if err := s.Start(context.Background(), stopper); err != nil {
 			return uuid.UUID{}, err
 		}
 
@@ -399,9 +399,10 @@ func (n *Node) initStores(
 	}
 	for _, e := range engines {
 		s := storage.NewStore(n.ctx, e, &n.Descriptor)
+		log.Tracef(ctx, "created store for engine: %s", e)
 		// Initialize each store in turn, handling un-bootstrapped errors by
 		// adding the store to the bootstraps list.
-		if err := s.Start(stopper); err != nil {
+		if err := s.Start(ctx, stopper); err != nil {
 			if _, ok := err.(*storage.NotBootstrappedError); ok {
 				log.Infof(ctx, "store %s not bootstrapped", s)
 				bootstraps = append(bootstraps, s)
@@ -439,6 +440,7 @@ func (n *Node) initStores(
 	if err := n.validateStores(); err != nil {
 		return err
 	}
+	log.Trace(ctx, "validated stores")
 
 	// Set the stores map as the gossip persistent storage, so that
 	// gossip can bootstrap using the most recently persisted set of
@@ -450,18 +452,21 @@ func (n *Node) initStores(
 	// Connect gossip before starting bootstrap. For new nodes, connecting
 	// to the gossip network is necessary to get the cluster ID.
 	n.connectGossip()
+	log.Trace(ctx, "connected to gossip")
 
 	// If no NodeID has been assigned yet, allocate a new node ID by
 	// supplying 0 to initNodeID.
 	if n.Descriptor.NodeID == 0 {
 		n.initNodeID(0)
 		n.initialBoot = true
+		log.Tracef(ctx, "allocated node ID %d", n.Descriptor.NodeID)
 	}
 
 	// Bootstrap any uninitialized stores asynchronously.
 	if len(bootstraps) > 0 {
 		if err := stopper.RunAsyncTask(func() {
-			n.bootstrapStores(ctx, bootstraps, stopper)
+			taskCtx := context.TODO()
+			n.bootstrapStores(taskCtx, bootstraps, stopper)
 		}); err != nil {
 			return err
 		}
@@ -517,7 +522,7 @@ func (n *Node) bootstrapStores(ctx context.Context, bootstraps []*storage.Store,
 		if err := s.Bootstrap(sIdent, stopper); err != nil {
 			log.Fatal(ctx, err)
 		}
-		if err := s.Start(stopper); err != nil {
+		if err := s.Start(ctx, stopper); err != nil {
 			log.Fatal(ctx, err)
 		}
 		n.addStore(s)

--- a/server/status.go
+++ b/server/status.go
@@ -647,7 +647,7 @@ func (s *statusServer) Ranges(ctx context.Context, req *serverpb.RangesRequest) 
 	err = s.stores.VisitStores(func(store *storage.Store) error {
 		// Use IterateRangeDescriptors to read from the engine only
 		// because it's already exported.
-		err := storage.IterateRangeDescriptors(store.Engine(),
+		err := storage.IterateRangeDescriptors(ctx, store.Engine(),
 			func(desc roachpb.RangeDescriptor) (bool, error) {
 				rep, err := store.GetReplica(desc.RangeID)
 				if err != nil {

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
@@ -231,7 +233,7 @@ func (ts *TestServer) Start(params base.TestServerArgs) error {
 	// Our context must be shared with our server.
 	ts.Ctx = &ts.Server.ctx
 
-	if err := ts.Server.Start(); err != nil {
+	if err := ts.Server.Start(context.Background()); err != nil {
 		return err
 	}
 

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -163,7 +163,7 @@ func createTestStoreWithEngine(
 			t.Fatal(err)
 		}
 	}
-	if err := store.Start(stopper); err != nil {
+	if err := store.Start(context.Background(), stopper); err != nil {
 		t.Fatal(err)
 	}
 	return store
@@ -675,7 +675,7 @@ func (m *multiTestContext) addStore(idx int) {
 
 	m.gossips[idx].Start(ln.Addr())
 
-	if err := store.Start(stopper); err != nil {
+	if err := store.Start(context.Background(), stopper); err != nil {
 		m.t.Fatal(err)
 	}
 	if err := m.gossipNodeDesc(m.gossips[idx], nodeID); err != nil {
@@ -737,7 +737,7 @@ func (m *multiTestContext) restartStore(i int) {
 
 	ctx := m.makeContext(i)
 	m.stores[i] = storage.NewStore(ctx, m.engines[i], &roachpb.NodeDescriptor{NodeID: roachpb.NodeID(i + 1)})
-	if err := m.stores[i].Start(m.stoppers[i]); err != nil {
+	if err := m.stores[i].Start(context.Background(), m.stoppers[i]); err != nil {
 		m.t.Fatal(err)
 	}
 	// The sender is assumed to still exist.

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -188,7 +188,7 @@ func (tc *testContext) StartWithStoreContext(t testing.TB, ctx StoreContext) {
 				t.Fatal(err)
 			}
 		}
-		if err := tc.store.Start(tc.stopper); err != nil {
+		if err := tc.store.Start(context.Background(), tc.stopper); err != nil {
 			t.Fatal(err)
 		}
 		tc.store.WaitForInit()

--- a/storage/store.go
+++ b/storage/store.go
@@ -699,19 +699,25 @@ func (s *Store) IsStarted() bool {
 // IterateRangeDescriptors calls the provided function with each descriptor
 // from the provided Engine. The return values of this method and fn have
 // semantics similar to engine.MVCCIterate.
-func IterateRangeDescriptors(
+func IterateRangeDescriptors(ctx context.Context,
 	eng engine.Reader, fn func(desc roachpb.RangeDescriptor) (bool, error),
 ) error {
+	log.Trace(ctx, "beginning range descriptor iteration")
 	// Iterator over all range-local key-based data.
 	start := keys.RangeDescriptorKey(roachpb.RKeyMin)
 	end := keys.RangeDescriptorKey(roachpb.RKeyMax)
 
+	allCount := 0
+	matchCount := 0
+	bySuffix := make(map[string]int)
 	kvToDesc := func(kv roachpb.KeyValue) (bool, error) {
+		allCount++
 		// Only consider range metadata entries; ignore others.
 		_, suffix, _, err := keys.DecodeRangeKey(kv.Key)
 		if err != nil {
 			return false, err
 		}
+		bySuffix[string(suffix)]++
 		if !bytes.Equal(suffix, keys.LocalRangeDescriptorSuffix) {
 			return false, nil
 		}
@@ -719,11 +725,14 @@ func IterateRangeDescriptors(
 		if err := kv.Value.GetProto(&desc); err != nil {
 			return false, err
 		}
+		matchCount++
 		return fn(desc)
 	}
 
 	_, err := engine.MVCCIterate(context.Background(), eng, start, end, hlc.MaxTimestamp, false /* !consistent */, nil, /* txn */
 		false /* !reverse */, kvToDesc)
+	log.Tracef(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
+		allCount, matchCount, bySuffix)
 	return err
 }
 
@@ -738,9 +747,9 @@ func (s *Store) migrate(ctx context.Context, desc roachpb.RangeDescriptor) {
 }
 
 // Start the engine, set the GC and read the StoreIdent.
-func (s *Store) Start(stopper *stop.Stopper) error {
+func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	s.stopper = stopper
-	ctx := s.context(context.TODO())
+	ctx = s.context(ctx)
 
 	// Add a closer for the various scanner queues, needed to properly clean up
 	// the event logs.
@@ -791,6 +800,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 			return &NotBootstrappedError{}
 		}
 	}
+	log.Trace(ctx, "read store identity")
 
 	// If the nodeID is 0, it has not be assigned yet.
 	if s.nodeDesc.NodeID != 0 && s.Ident.NodeID != s.nodeDesc.NodeID {
@@ -816,39 +826,40 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 	// due to a split crashing halfway will simply be resolved on the
 	// next split attempt. They can otherwise be ignored.
 	s.mu.Lock()
-	err = IterateRangeDescriptors(s.engine, func(desc roachpb.RangeDescriptor) (bool, error) {
-		if _, ok := desc.GetReplicaDescriptor(s.StoreID()); !ok {
-			// We are no longer a member of the range, but we didn't GC
-			// the replica before shutting down. Destroy the replica now
-			// to avoid creating a new replica without a valid replica ID
-			// (which is necessary to have a non-nil raft group)
-			return false, s.destroyReplicaData(&desc)
-		}
-		if !desc.IsInitialized() {
-			return false, errors.Errorf("found uninitialized RangeDescriptor: %+v", desc)
-		}
-		s.migrate(ctx, desc)
+	err = IterateRangeDescriptors(ctx, s.engine,
+		func(desc roachpb.RangeDescriptor) (bool, error) {
+			if _, ok := desc.GetReplicaDescriptor(s.StoreID()); !ok {
+				// We are no longer a member of the range, but we didn't GC
+				// the replica before shutting down. Destroy the replica now
+				// to avoid creating a new replica without a valid replica ID
+				// (which is necessary to have a non-nil raft group)
+				return false, s.destroyReplicaData(&desc)
+			}
+			if !desc.IsInitialized() {
+				return false, errors.Errorf("found uninitialized RangeDescriptor: %+v", desc)
+			}
+			s.migrate(ctx, desc)
 
-		rng, err := NewReplica(&desc, s, 0)
-		if err != nil {
-			return false, err
-		}
-		if err = s.addReplicaInternalLocked(rng); err != nil {
-			return false, err
-		}
-		// Add this range and its stats to our counter.
-		s.metrics.ReplicaCount.Inc(1)
-		s.metrics.addMVCCStats(rng.GetMVCCStats())
-		// Note that we do not create raft groups at this time; they will be created
-		// on-demand the first time they are needed. This helps reduce the amount of
-		// election-related traffic in a cold start.
-		// Raft initialization occurs when we propose a command on this range or
-		// receive a raft message addressed to it.
-		// TODO(bdarnell): Also initialize raft groups when read leases are needed.
-		// TODO(bdarnell): Scan all ranges at startup for unapplied log entries
-		// and initialize those groups.
-		return false, nil
-	})
+			rng, err := NewReplica(&desc, s, 0)
+			if err != nil {
+				return false, err
+			}
+			if err = s.addReplicaInternalLocked(rng); err != nil {
+				return false, err
+			}
+			// Add this range and its stats to our counter.
+			s.metrics.ReplicaCount.Inc(1)
+			s.metrics.addMVCCStats(rng.GetMVCCStats())
+			// Note that we do not create raft groups at this time; they will be created
+			// on-demand the first time they are needed. This helps reduce the amount of
+			// election-related traffic in a cold start.
+			// Raft initialization occurs when we propose a command on this range or
+			// receive a raft message addressed to it.
+			// TODO(bdarnell): Also initialize raft groups when read leases are needed.
+			// TODO(bdarnell): Scan all ranges at startup for unapplied log entries
+			// and initialize those groups.
+			return false, nil
+		})
 	s.mu.Unlock()
 	if err != nil {
 		return err
@@ -860,6 +871,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 
 	doneUnfreezing := make(chan struct{})
 	if s.stopper.RunAsyncTask(func() {
+		taskCtx := context.TODO()
 		defer close(doneUnfreezing)
 		sem := make(chan struct{}, 512)
 		var wg sync.WaitGroup // wait for unfreeze goroutines
@@ -885,8 +897,8 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 					MustVersion: build.GetInfo().Tag,
 				}
 				ba.Add(&fReq)
-				if _, pErr := r.Send(ctx, ba); pErr != nil {
-					log.Errorf(ctx, "%s: could not unfreeze Range %s on startup: %s", s, r, pErr)
+				if _, pErr := r.Send(taskCtx, ba); pErr != nil {
+					log.Errorf(taskCtx, "%s: could not unfreeze Range %s on startup: %s", s, r, pErr)
 				} else {
 					// We don't use the returned RangesAffected (0 or 1) for
 					// counting. One of the other Replicas may have beaten us
@@ -902,7 +914,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 		})
 		wg.Wait()
 		if unfrozen > 0 {
-			log.Infof(ctx, "%s: reactivated %d frozen Ranges", s, unfrozen)
+			log.Infof(taskCtx, "%s: reactivated %d frozen Ranges", s, unfrozen)
 		}
 	}) != nil {
 		close(doneUnfreezing)
@@ -913,7 +925,9 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 	// loop figure it out.
 	select {
 	case <-doneUnfreezing:
+		log.Trace(ctx, "finished unfreezing")
 	case <-time.After(10 * time.Second):
+		log.Trace(ctx, "gave up waiting for unfreezing; continuing in background")
 	}
 
 	// Gossip is only ever nil while bootstrapping a cluster and
@@ -967,6 +981,7 @@ func (s *Store) Start(stopper *stop.Stopper) error {
 		if err = s.ComputeMetrics(-1); err != nil {
 			log.Infof(ctx, "%s: failed initial metrics computation: %s", s, err)
 		}
+		log.Trace(ctx, "computed initial metrics")
 	}
 
 	// Set the started flag (for unittests).

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -180,7 +180,7 @@ func createTestStoreWithContext(t testing.TB, ctx *StoreContext) (
 		&config.SystemConfig{}, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Start(stopper); err != nil {
+	if err := store.Start(context.Background(), stopper); err != nil {
 		t.Fatal(err)
 	}
 	store.WaitForInit()
@@ -200,7 +200,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	store := NewStore(ctx, eng, &roachpb.NodeDescriptor{NodeID: 1})
 
 	// Can't start as haven't bootstrapped.
-	if err := store.Start(stopper); err == nil {
+	if err := store.Start(context.Background(), stopper); err == nil {
 		t.Error("expected failure starting un-bootstrapped store")
 	}
 
@@ -231,7 +231,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 
 	// Now, attempt to initialize a store with a now-bootstrapped range.
 	store = NewStore(ctx, eng, &roachpb.NodeDescriptor{NodeID: 1})
-	if err := store.Start(stopper); err != nil {
+	if err := store.Start(context.Background(), stopper); err != nil {
 		t.Errorf("failure initializing bootstrapped store: %s", err)
 	}
 	// 1st range should be available.
@@ -269,7 +269,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	store := NewStore(ctx, eng, &roachpb.NodeDescriptor{NodeID: 1})
 
 	// Can't init as haven't bootstrapped.
-	if err := store.Start(stopper); err == nil {
+	if err := store.Start(context.Background(), stopper); err == nil {
 		t.Error("expected failure init'ing un-bootstrapped store")
 	}
 
@@ -1943,7 +1943,7 @@ func TestMaybeRemove(t *testing.T) {
 	}
 	store.scanner.AddQueues(fq)
 
-	if err := store.Start(stopper); err != nil {
+	if err := store.Start(context.Background(), stopper); err != nil {
 		t.Fatal(err)
 	}
 	store.WaitForInit()

--- a/testutils/localtestcluster/local_test_cluster.go
+++ b/testutils/localtestcluster/local_test_cluster.go
@@ -19,6 +19,8 @@ package localtestcluster
 import (
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/internal/client"
@@ -119,7 +121,7 @@ func (ltc *LocalTestCluster) Start(t util.Tester, baseCtx *base.Context, initSen
 	if err := ltc.Store.BootstrapRange(nil); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
-	if err := ltc.Store.Start(ltc.Stopper); err != nil {
+	if err := ltc.Store.Start(context.Background(), ltc.Stopper); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
 	ltc.Gossip.SetNodeID(nodeDesc.NodeID)


### PR DESCRIPTION
``` diff
commit bcd8cc247227c49a300197ec2af726001e24e430
Merge: d3baddd d8a2d32
Author: Tamir Duberstein <tamird@gmail.com>
Date:   Sun Aug 21 21:13:54 2016 -0400

    Merge branch 'master' into merge-master

diff --cc server/server.go
index 189d9c7,2d2ae5a..85a7f7d
--- a/server/server.go
+++ b/server/server.go
@@@ -521,9 -524,9 +525,10 @@@ func (s *Server) Start(ctx context.Cont
    // apply it for all web endpoints.
    s.mux.Handle(adminEndpoint, gwMux)
    s.mux.Handle(ts.URLPrefix, gwMux)
 -  s.mux.Handle(statusPrefix, s.status)
 -  s.mux.Handle(healthEndpoint, s.status)
 +  s.mux.Handle(statusPrefix, gwMux)
 +  s.mux.Handle("/health", gwMux)
 +  s.mux.Handle(statusVars, http.HandlerFunc(s.status.handleVars))
+   log.Trace(ctx, "added http endpoints")

    if err := sdnotify.Ready(); err != nil {
        log.Errorf(s.Ctx(), "failed to signal readiness using systemd protocol: %s", err)
diff --cc storage/store.go
index b12027f,def7e91..d9d029c
--- a/storage/store.go
+++ b/storage/store.go
@@@ -737,9 -747,9 +746,8 @@@ func (s *Store) migrate(ctx context.Con
  }

  // Start the engine, set the GC and read the StoreIdent.
- func (s *Store) Start(stopper *stop.Stopper) error {
+ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
    s.stopper = stopper
-   ctx := s.Ctx()
 -  ctx = s.context(ctx)

    // Add a closer for the various scanner queues, needed to properly clean up
    // the event logs.

```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8721)

<!-- Reviewable:end -->
