### PR TITLE
server: consolidate testing HTTP request code

### DIFF
--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -51,13 +51,12 @@ import (
 
 // getText fetches the HTTP response body as text in the form of a
 // byte slice from the specified URL.
-func getText(url string) ([]byte, error) {
-	// There are no particular permissions on admin endpoints, TestUser is fine.
-	client, err := testutils.NewTestBaseContext(TestUser).GetHTTPClient()
+func getText(ts serverutils.TestServerInterface, url string) ([]byte, error) {
+	httpClient, err := ts.GetHTTPClient()
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Get(url)
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return nil, err
 	}
@@ -68,8 +67,8 @@ func getText(url string) ([]byte, error) {
 // getJSON fetches the JSON from the specified URL and returns
 // it as unmarshaled JSON. Returns an error on any failure to fetch
 // or unmarshal response body.
-func getJSON(url string) (interface{}, error) {
-	body, err := getText(url)
+func getJSON(ts serverutils.TestServerInterface, url string) (interface{}, error) {
+	body, err := getText(ts, url)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +91,7 @@ func TestAdminDebugExpVar(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 
-	jI, err := getJSON(debugURL(s) + "vars")
+	jI, err := getJSON(s, debugURL(s)+"vars")
 	if err != nil {
 		t.Fatalf("failed to fetch JSON: %v", err)
 	}
@@ -112,7 +111,7 @@ func TestAdminDebugMetrics(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 
-	jI, err := getJSON(debugURL(s) + "metrics")
+	jI, err := getJSON(s, debugURL(s)+"metrics")
 	if err != nil {
 		t.Fatalf("failed to fetch JSON: %v", err)
 	}
@@ -132,7 +131,7 @@ func TestAdminDebugPprof(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop()
 
-	body, err := getText(debugURL(s) + "pprof/block")
+	body, err := getText(s, debugURL(s)+"pprof/block")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +155,7 @@ func TestAdminDebugTrace(t *testing.T) {
 	}
 
 	for _, c := range tc {
-		body, err := getText(debugURL(s) + c.segment)
+		body, err := getText(s, debugURL(s)+c.segment)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/util/http.go
+++ b/util/http.go
@@ -17,6 +17,7 @@
 package util
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -55,33 +56,40 @@ const (
 // GetJSON uses the supplied client to GET the URL specified by the parameters
 // and unmarshals the result into response.
 func GetJSON(httpClient http.Client, path string, response proto.Message) error {
-	resp, err := httpClient.Get(path)
+	req, err := http.NewRequest("GET", path, nil)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := ioutil.ReadAll(resp.Body)
-		return errors.Errorf("status: %s, body: %s", resp.Status, b)
-	}
-	return jsonpb.Unmarshal(resp.Body, response)
+	return doJSONRequest(httpClient, req, response)
 }
 
 // PostJSON uses the supplied client to POST request to the URL specified by
 // the parameters and unmarshals the result into response .
 func PostJSON(httpClient http.Client, path string, request, response proto.Message) error {
-	str, err := (&jsonpb.Marshaler{}).MarshalToString(request)
+	// Hack to avoid upsetting TestProtoMarshal().
+	marshalFn := (&jsonpb.Marshaler{}).Marshal
+
+	var buf bytes.Buffer
+	if err := marshalFn(&buf, request); err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", path, &buf)
 	if err != nil {
 		return err
 	}
-	resp, err := httpClient.Post(path, JSONContentType, strings.NewReader(str))
+	return doJSONRequest(httpClient, req, response)
+}
+
+func doJSONRequest(httpClient http.Client, req *http.Request, response proto.Message) error {
+	req.Header.Set(AcceptHeader, JSONContentType)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
+	if contentType := resp.Header.Get(ContentTypeHeader); !(resp.StatusCode == http.StatusOK && contentType == JSONContentType) {
 		b, err := ioutil.ReadAll(resp.Body)
-		return errors.Errorf("status: %s, body: %s, error: %s", resp.Status, b, err)
+		return errors.Errorf("status: %s, content-type: %s, body: %s, error: %s", resp.Status, contentType, b, err)
 	}
 	return jsonpb.Unmarshal(resp.Body, response)
 }


### PR DESCRIPTION
This custom retry code in the server package has been papering over
poorly understood delays for some time. This commit removes the opaque
retry code in the hope that the underlying cause is related to #8536,
and will be easier to investigate in unit tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8725)

<!-- Reviewable:end -->
