### PR TITLE
stability: terrafarm tweaks and logging

### DIFF
--- a/acceptance/terrafarm/farmer.go
+++ b/acceptance/terrafarm/farmer.go
@@ -176,8 +176,8 @@ func (f *Farmer) Destroy(t *testing.T) error {
 	if (t.Failed() && f.KeepCluster == KeepClusterFailed) ||
 		f.KeepCluster == KeepClusterAlways {
 
-		t.Logf("not destroying; run:\n(cd %s && terraform destroy -force -state %s)",
-			baseDir, f.StateFile)
+		t.Logf("not destroying; run:\n(cd %s && terraform destroy -force -state %s && rm %s)",
+			baseDir, f.StateFile, f.StateFile)
 		return nil
 	}
 

--- a/acceptance/terraform/supervisor.conf.tpl
+++ b/acceptance/terraform/supervisor.conf.tpl
@@ -33,6 +33,8 @@ stopwaitsecs=90
 stderr_logfile=%(here)s/logs/%(program_name)s.stderr
 stdout_logfile=%(here)s/logs/%(program_name)s.stdout
 environment=${cockroach_env}
+stderr_logfile_maxbytes=500MB
+stderr_logfile_backups=10
 
 [program:block_writer]
 directory=%(here)s

--- a/acceptance/terraform/variables.tf
+++ b/acceptance/terraform/variables.tf
@@ -29,7 +29,7 @@ variable "gce_zone" {
 
 # GCE image name.
 variable "gce_image" {
-  default = "ubuntu-os-cloud/ubuntu-1510-wily-v20151021"
+  default = "ubuntu-os-cloud/ubuntu-1604-xenial-v20160815"
 }
 
 # Machine type for non-DB nodes (e.g. load generators).


### PR DESCRIPTION
Changes that were useful in debugging Raft issues on test clusters:
- acceptance/terraform: less log rotation
- kv: add logs for leaseHolderCache
- acceptance/terrafarm: enhance cluster cleanup cmd
- acceptance/terraform: upgrade Ubuntu to 16.04 LTS

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8731)

<!-- Reviewable:end -->
