### PR TITLE
ui: tweak redux-dev-tools fix

### DIFF
--- a/ui/app/redux/state.ts
+++ b/ui/app/redux/state.ts
@@ -43,24 +43,34 @@ export const store = createStore<AdminUIState>(
       /**
        * HACK HACK HACK
        * The state object insn't currently serializeable, which redux dev tools
-       * expects, because there's a circular reference which is causing
-       * JSON.stringify to fail. The specific path with the circular reference
-       * appears to be state.cachedData.nodes.data.metrics.field
+       * expects, because there's a an issue with the path
+       * state.cachedData.nodes.data[...].metrics.field. Redux-dev-tools should
+       * be using jsan, which should be able to handle circular references, but
+       * something about the generated ProtoBufMap type is breaking it. It will
+       * take some time to construct an example that appropriately demonstrates
+       * why ProtoBufMap breaks jsan which will be necessary to file issues for
+       * those libraries.
        *
-       * Fix inspired by this suggestion for avoiding large blobs in redux dev
-       * tools: https://github.com/zalmoxisus/redux-devtools-extension/issues/159#issuecomment-231034408
-       * TODO (maxlang): file issues upstream
+       * TODO (maxlang): Create an example demonstrating ProtoBufMap breaking
+       * jsan and file issues upstream.
        *
-       * NOTE: this only affects environments with react dev tools installed
+       * Current fix inspired by this suggestion for avoiding large blobs in
+       * redux dev tools:
+       * https://github.com/zalmoxisus/redux-devtools-extension/issues/159#issuecomment-231034408
+       *
+       * NOTE: This only affects environments with redux dev tools installed and
+       * opened.
        */
-      actionsFilter: (action: PayloadAction<any>): PayloadAction<any> => (/nodes/).test(action.type) ? {type: action.type, payload: "<<NODE_DATA>>"} : action,
+      actionsFilter: (action: PayloadAction<any>): PayloadAction<any> => (/nodes/).test(action.type) ? {type: action.type, payload: []} : action,
       statesFilter: (state: AdminUIState): AdminUIState => {
+        let clone = _.clone(state);
+        // Filter out circular reference in nodes.data[...].metrics.field.
         if (state.cachedData.nodes.data) {
-          let clone = _.clone(state);
-          clone.cachedData.nodes.data = <any>"<<NODE_DATA>>";
-          return clone;
+          clone.cachedData = _.clone(clone.cachedData);
+          clone.cachedData.nodes = _.clone(clone.cachedData.nodes);
+          clone.cachedData.nodes.data = [];
         }
-        return state;
+        return clone;
       },
     }) : _.identity
   ) as StoreEnhancer<AdminUIState>


### PR DESCRIPTION
When using the redux-dev-tools chrome extension, the UI would
break because of an improper use of _.clone. We need to clone
all the way down the path to the object we're overwriting to
avoid modifying the actual state.

cc @tamird

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8740)

<!-- Reviewable:end -->
