### PR TITLE
*: Span names should be constants

### DIFF
--- a/server/node.go
+++ b/server/node.go
@@ -778,7 +778,7 @@ func (n *Node) Batch(
 		}
 	}
 
-	opName := "node " + strconv.Itoa(int(n.Descriptor.NodeID)) // could save allocs here
+	const opName = "node.Batch"
 
 	fail := func(err error) {
 		br = &roachpb.BatchResponse{}
@@ -811,6 +811,7 @@ func (n *Node) Batch(
 		}
 		defer sp.Finish()
 		traceCtx := opentracing.ContextWithSpan(ctx, sp)
+		log.Tracef(traceCtx, "node "+strconv.Itoa(int(n.Descriptor.NodeID))) // could save allocs here.
 
 		tStart := timeutil.Now()
 		var pErr *roachpb.Error

--- a/sql/trace_test.go
+++ b/sql/trace_test.go
@@ -94,7 +94,7 @@ func TestExplainTrace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expParts := []string{"coordinator", "node 1"}
+	expParts := []string{"coordinator", "node.Batch"}
 	var parts []string
 
 	pretty := rowsToStrings(rows)

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -457,9 +457,10 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 		return nil
 	}
 
-	sp := repl.store.Tracer().StartSpan(fmt.Sprintf("%s:%d", bq.name, repl.RangeID))
+	sp := repl.store.Tracer().StartSpan(bq.name)
 	ctx := opentracing.ContextWithSpan(context.Background(), sp)
 	defer sp.Finish()
+	log.Tracef(ctx, "processing replica %s", repl)
 
 	// If the queue requires a replica to have the range lease in
 	// order to be processed, check whether this replica has range lease

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -18,7 +18,6 @@ package storage
 
 import (
 	"bytes"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -320,11 +319,11 @@ func (r *Replica) SnapshotWithContext(ctx context.Context) (raftpb.Snapshot, err
 
 	if r.store.Stopper().RunAsyncTask(func() {
 		defer close(ch)
-		sp := r.store.Tracer().StartSpan(fmt.Sprintf("snapshot async %s", r))
+		sp := r.store.Tracer().StartSpan("snapshot async")
 		ctxInner := opentracing.ContextWithSpan(context.Background(), sp)
 		defer sp.Finish()
 		snap := r.store.NewSnapshot()
-		log.Trace(ctxInner, "new engine snapshot")
+		log.Tracef(ctxInner, "new engine snapshot for replica %s", r)
 		defer snap.Close()
 		defer r.store.ReleaseRaftSnapshot()
 		// Delegate to a static function to make sure that we do not depend


### PR DESCRIPTION
The Lightstep UI assumes that there will be a finite number of distinct
span names. I'd also like to map these operation names to net/trace
"families", which have a similar UI.

Change all dynamically-constructed span names to constants and
move the variable parts into separate log.Trace messages.

@cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8741)

<!-- Reviewable:end -->
