### PR TITLE
build: fix upload-coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,10 @@ coverage:
 	$(GO) test -v $(GOFLAGS) -i $(PKG)
 	$(GO) test $(GOFLAGS) -cover -run "$(TESTS)" $(PKG) $(TESTFLAGS)
 
+.PHONY: upload-coverage
+upload-coverage:
+	@build/upload-coverage.sh
+
 # "make stress PKG=./storage TESTS=TestBlah" will build the given test
 # and run it in a loop (the PKG argument is required; if TESTS is not
 # given all tests in the package will be run).
@@ -211,10 +215,6 @@ $(GLOCK):
 .bootstrap: $(GITHOOKS) $(GLOCK) GLOCKFILE
 	@unset GIT_WORK_TREE; $(GLOCK) sync github.com/cockroachdb/cockroach
 	touch $@
-
-.PHONY: upload-coverage
-upload-coverage:
-	@build/upload-coverage.sh
 
 include .bootstrap
 

--- a/build/upload-coverage.sh
+++ b/build/upload-coverage.sh
@@ -58,7 +58,7 @@ for pkg in $(go list ./...); do
   # tests.
   f="${coverage_dir}/$(echo $pkg | tr / -).cover"
   touch $f
-  time ${builder} make coverage \
+  time make coverage \
     PKG="$pkg" \
     TESTFLAGS="-v -coverprofile=$f -covermode=$coverage_mode -coverpkg=$coverpkg" | \
     tee "${outdir}/coverage.log"


### PR DESCRIPTION
upload-coverage shouldn't use the builder because the whole program will
be run from the builder. Additionally, for some reason Make wasn't happy
when upload-coverage was the last target in the Makefile, so move it
next to the other coverage target.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8742)

<!-- Reviewable:end -->
