### PR TITLE
storage: return replica corruption on failed commit trigger

### DIFF
--- a/storage/raft_transport.go
+++ b/storage/raft_transport.go
@@ -44,7 +44,7 @@ const (
 	//
 	// TODO(peter): The normal send buffer size is larger than we would like. It
 	// is a temporary patch for the issue discussed in #8630 where
-	// Store.HandleRaftMessage can block applying a preemptive snapshot for a
+	// Store.HandleRaftRequest can block applying a preemptive snapshot for a
 	// long enough period of time that grpc flow control kicks in and messages
 	// are dropped on the sending side.
 	raftNormalSendBufferSize   = 10000

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -276,7 +276,7 @@ type Replica struct {
 		//
 		// The last seen replica descriptors are updated on receipt of every raft
 		// message via Replica.setLastReplicaDescriptors (see
-		// Store.handleRaftMessage). These last seen descriptors are used when
+		// Store.HandleRaftRequest). These last seen descriptors are used when
 		// the replica's RangeDescriptor contains missing or out of date descriptors
 		// for a replica (see Replica.sendRaftMessage).
 		//

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -609,10 +609,7 @@ func (r *Replica) EndTransaction(
 	if reply.Txn.Status == roachpb.COMMITTED {
 		var err error
 		if trigger, err = r.runCommitTrigger(ctx, batch.(engine.Batch), ms, args, reply.Txn); err != nil {
-			// TODO(tschottdorf): should an error here always amount to a
-			// ReplicaCorruptionError?
-			log.Error(ctx, errors.Wrapf(err, "%s: commit trigger", r))
-			return reply, nil, err
+			return reply, nil, NewReplicaCorruptionError(err)
 		}
 	}
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -328,7 +328,7 @@ type Store struct {
 	// There are two major entry points to this stack of locks:
 	// Store.Send (which handles incoming RPCs) and raft-related message
 	// processing (including handleRaftReady on the processRaft
-	// goroutine and handleRaftMessage on GRPC goroutines). Reads are
+	// goroutine and HandleRaftRequest on GRPC goroutines). Reads are
 	// processed solely through Store.Send; writes start out on
 	// Store.Send until they propose their raft command and then they
 	// finish on the raft goroutines.
@@ -342,7 +342,7 @@ type Store struct {
 	//
 	// * processRaftMu: Named after the processRaft goroutine; held
 	//   while any raft messages are being processed (including
-	//   handleRaftReady and handleRaftMessage) or while the set of
+	//   handleRaftReady and HandleRaftRequest) or while the set of
 	//   Replicas in the Store is being changed (which may happen
 	//   outside of raft via the replica GC queue). Multiple Replicas
 	//   may be processed at a time.
@@ -394,7 +394,7 @@ type Store struct {
 	// don't change out from under us. In particular, handleRaftReady
 	// accesses the replicaID more than once, and we rely on
 	// processRaftMu to ensure that this is not modified by a concurrent
-	// handleRaftMessage. (#4476)
+	// HandleRaftRequest. (#4476)
 
 	processRaftMu syncutil.Mutex
 	mu            struct {


### PR DESCRIPTION
The registration cluster has a range which appears healthy but has one
replica which evidently never committed a split which took place on the
range (RangeID 5179). Unfortunately there is very little evidence left about
that (the botched split happened in July, much before many relevant code
changes), but the changes in this commit elimiate a potential culprit.

cc @cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8748)

<!-- Reviewable:end -->
