### PR TITLE
server,storage: plumb contexts and node/store/replica log tags

### DIFF
--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -261,7 +261,8 @@ func (ds *DistSender) RangeLookup(
 	replicas.Shuffle()
 	// TODO(tschottdorf): Ideally we would use the trace of the request which
 	// caused this lookup.
-	br, err := ds.sendRPC(context.Background(), desc.RangeID, replicas, ba)
+	_ = context.TODO()
+	br, err := ds.sendRPC(ds.Ctx, desc.RangeID, replicas, ba)
 	if err != nil {
 		return nil, nil, roachpb.NewError(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -73,30 +73,33 @@ var (
 
 // Server is the cockroach server node.
 type Server struct {
-	ctx           Context
-	mux           *http.ServeMux
-	clock         *hlc.Clock
-	rpcContext    *rpc.Context
-	grpc          *grpc.Server
-	gossip        *gossip.Gossip
-	storePool     *storage.StorePool
-	distSender    *kv.DistSender
-	db            *client.DB
-	kvDB          *kv.DBServer
-	pgServer      *pgwire.Server
-	distSQLServer *distsql.ServerImpl
-	node          *Node
-	registry      *metric.Registry
-	recorder      *status.MetricsRecorder
-	runtime       status.RuntimeStatSampler
-	admin         adminServer
-	status        *statusServer
-	tsDB          *ts.DB
-	tsServer      ts.Server
-	raftTransport *storage.RaftTransport
-	stopper       *stop.Stopper
-	sqlExecutor   *sql.Executor
-	leaseMgr      *sql.LeaseManager
+	ctx            Context
+	mux            *http.ServeMux
+	clock          *hlc.Clock
+	rpcContext     *rpc.Context
+	grpc           *grpc.Server
+	gossip         *gossip.Gossip
+	storePool      *storage.StorePool
+	txnCoordSender *kv.TxnCoordSender
+	distSender     *kv.DistSender
+	db             *client.DB
+	kvDB           *kv.DBServer
+	pgServer       *pgwire.Server
+	distSQLServer  *distsql.ServerImpl
+	node           *Node
+	registry       *metric.Registry
+	recorder       *status.MetricsRecorder
+	runtime        status.RuntimeStatSampler
+	admin          adminServer
+	status         *statusServer
+	tsDB           *ts.DB
+	tsServer       ts.Server
+	raftTransport  *storage.RaftTransport
+	stopper        *stop.Stopper
+	sqlExecutor    *sql.Executor
+	leaseMgr       *sql.LeaseManager
+
+	nodeLogTagVal log.DynamicIntValue
 }
 
 // NewServer creates a Server from a server.Context.
@@ -130,11 +133,25 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	s := &Server{
-		ctx:     srvCtx,
 		mux:     http.NewServeMux(),
 		clock:   hlc.NewClock(hlc.UnixNano),
 		stopper: stopper,
 	}
+	// Add a dynamic log tag value for the node ID.
+	//
+	// We need to pass the server's Ctx as a base context for the various server
+	// components, but we won't know the node ID until we Start(). At that point
+	// it's too late to change the contexts in the components (various background
+	// processes will have already started using the contexts).
+	//
+	// The dynamic value allows us to add the log tag to the context now and
+	// update the value asynchronously. It's not significantly more expensive than
+	// a regular tag since it's just doing an (atomic) load when a log/trace
+	// message is constructed.
+	s.nodeLogTagVal.Set(log.DynamicIntValueUnknown)
+	srvCtx.Ctx = log.WithLogTag(srvCtx.Ctx, "n", &s.nodeLogTagVal)
+	s.ctx = srvCtx
+
 	s.clock.SetMaxOffset(srvCtx.MaxOffset)
 
 	s.rpcContext = rpc.NewContext(srvCtx.Context, s.clock, s.stopper)
@@ -179,13 +196,13 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 
 	txnMetrics := kv.MakeTxnMetrics()
 	s.registry.AddMetricStruct(txnMetrics)
-	sender := kv.NewTxnCoordSender(s.Ctx(), s.distSender, s.clock, srvCtx.Linearizable,
+	s.txnCoordSender = kv.NewTxnCoordSender(s.Ctx(), s.distSender, s.clock, srvCtx.Linearizable,
 		s.stopper, txnMetrics)
-	s.db = client.NewDB(sender)
+	s.db = client.NewDB(s.txnCoordSender)
 
 	s.raftTransport = storage.NewRaftTransport(storage.GossipAddressResolver(s.gossip), s.grpc, s.rpcContext)
 
-	s.kvDB = kv.NewDBServer(s.ctx.Context, sender, s.stopper)
+	s.kvDB = kv.NewDBServer(s.ctx.Context, s.txnCoordSender, s.stopper)
 	roachpb.RegisterExternalServer(s.grpc, s.kvDB)
 
 	// Set up Lease Manager
@@ -289,9 +306,16 @@ type grpcGatewayServer interface {
 	) error
 }
 
-// Start starts the server on the specified port, starts gossip and
-// initializes the node using the engines from the server's context.
+// Start starts the server on the specified port, starts gossip and initializes
+// the node using the engines from the server's context.
+//
+// The passed context can be used to trace the server startup. The context
+// should represent the general startup operation, and is different from
+// contexts used at runtime for server's background work (like `s.Ctx()`).
 func (s *Server) Start(ctx context.Context) error {
+	// Copy log tags from s.Ctx()
+	ctx = log.WithLogTagsFromCtx(ctx, s.Ctx())
+
 	tlsConfig, err := s.ctx.GetServerTLSConfig()
 	if err != nil {
 		return err
@@ -434,6 +458,10 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	log.Trace(ctx, "started node")
 
+	// Set the NodeID in the base context (which was inherited by the
+	// various components of the server).
+	s.nodeLogTagVal.Set(int64(s.node.Descriptor.NodeID))
+
 	// We can now add the node registry.
 	s.recorder.AddNode(s.registry, s.node.Descriptor, s.node.startedAt)
 
@@ -447,7 +475,6 @@ func (s *Server) Start(ctx context.Context) error {
 	s.node.startWriteSummaries(s.ctx.MetricsSampleInterval)
 
 	s.sqlExecutor.SetNodeID(s.node.Descriptor.NodeID)
-	s.distSQLServer.SetNodeID(s.node.Descriptor.NodeID)
 
 	// Create and start the schema change manager only after a NodeID
 	// has been assigned.

--- a/sql/distsql/flow.go
+++ b/sql/distsql/flow.go
@@ -84,7 +84,7 @@ func newFlow(
 	flowReg *flowRegistry,
 	simpleFlowConsumer RowReceiver,
 ) *Flow {
-	flowCtx.Context = log.WithLogTagStr(flowCtx.Context, "flow", flowCtx.id.Short())
+	flowCtx.Context = log.WithLogTagStr(flowCtx.Context, "f", flowCtx.id.Short())
 	return &Flow{
 		FlowCtx:            flowCtx,
 		flowRegistry:       flowReg,

--- a/sql/distsql/server.go
+++ b/sql/distsql/server.go
@@ -63,11 +63,6 @@ func NewServer(cfg ServerConfig) *ServerImpl {
 	return ds
 }
 
-// SetNodeID sets the NodeID for the server.
-func (ds *ServerImpl) SetNodeID(nodeID roachpb.NodeID) {
-	ds.ServerConfig.Context = log.WithLogTagInt(ds.ServerConfig.Context, "node", int(nodeID))
-}
-
 func (ds *ServerImpl) setupTxn(
 	ctx context.Context,
 	txnProto *roachpb.Transaction,

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -173,6 +174,26 @@ type replicaChecksum struct {
 	snapshot *roachpb.RaftSnapshotData
 }
 
+type atomicRangeDesc struct {
+	descPtr unsafe.Pointer
+}
+
+func (d *atomicRangeDesc) store(desc *roachpb.RangeDescriptor) {
+	atomic.StorePointer(&d.descPtr, unsafe.Pointer(desc))
+}
+
+func (d *atomicRangeDesc) load() *roachpb.RangeDescriptor {
+	return (*roachpb.RangeDescriptor)(atomic.LoadPointer(&d.descPtr))
+}
+
+// String returns the string representation of the range; since we are not
+// using a lock, the copy might be inconsistent.
+func (d *atomicRangeDesc) String() string {
+	inconsistentDesc := d.load()
+	return fmt.Sprintf("%d{%s-%s}",
+		inconsistentDesc.RangeID, inconsistentDesc.StartKey, inconsistentDesc.EndKey)
+}
+
 // A Replica is a contiguous keyspace with writes managed via an
 // instance of the Raft consensus algorithm. Many ranges may exist
 // in a store and they are unlikely to be contiguous. Ranges are
@@ -180,9 +201,14 @@ type replicaChecksum struct {
 // integrity by replacing failed replicas, splitting and merging
 // as appropriate.
 type Replica struct {
+	// ctx is a context appropriate for logging, which contains the appropriate
+	// node, store, replica log tags.
+	ctx context.Context
+
 	// TODO(tschottdorf): Duplicates r.mu.state.desc.RangeID; revisit that.
 	RangeID roachpb.RangeID // Should only be set by the constructor.
-	store   *Store
+
+	store *Store
 	// sha1 hash of the system config @ last gossip. No synchronized access;
 	// must only be accessed from maybeGossipSystemConfig (which in turn is
 	// only called from the Raft-processing goroutine).
@@ -201,7 +227,7 @@ type Replica struct {
 	// rangeDesc is a *RangeDescriptor that can be atomically read from in
 	// replica.Desc() without needing to acquire the replica.mu lock. All
 	// updates to state.Desc should be duplicated here
-	rangeDesc atomic.Value
+	rangeDesc atomicRangeDesc
 
 	mu struct {
 		// Protects all fields in the mu struct.
@@ -391,7 +417,9 @@ var _ client.Sender = &Replica{}
 // replica is initialized (i.e. desc contains more than a RangeID),
 // replicaID should be 0 and the replicaID will be discovered from the
 // descriptor.
-func NewReplica(desc *roachpb.RangeDescriptor, store *Store, replicaID roachpb.ReplicaID) (*Replica, error) {
+func NewReplica(
+	desc *roachpb.RangeDescriptor, store *Store, replicaID roachpb.ReplicaID,
+) (*Replica, error) {
 	r := &Replica{
 		RangeID:    desc.RangeID,
 		store:      store,
@@ -406,7 +434,9 @@ func NewReplica(desc *roachpb.RangeDescriptor, store *Store, replicaID roachpb.R
 	return r, nil
 }
 
-func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor, clock *hlc.Clock, replicaID roachpb.ReplicaID) error {
+func (r *Replica) newReplicaInner(
+	desc *roachpb.RangeDescriptor, clock *hlc.Clock, replicaID roachpb.ReplicaID,
+) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -416,17 +446,21 @@ func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor, clock *hlc.Cloc
 	r.mu.checksums = map[uuid.UUID]replicaChecksum{}
 
 	var err error
-	ctx := context.TODO()
+	ctx := r.store.Ctx()
 
 	if r.mu.state, err = loadState(ctx, r.store.Engine(), desc); err != nil {
 		return err
 	}
-	r.rangeDesc.Store(r.mu.state.Desc)
+	r.rangeDesc.store(r.mu.state.Desc)
 
 	r.mu.lastIndex, err = loadLastIndex(ctx, r.store.Engine(), r.RangeID)
 	if err != nil {
 		return err
 	}
+
+	// Add replica log tags - the value is rangeDesc.String().
+	ctx = log.WithLogTag(ctx, "r", &r.rangeDesc)
+	r.ctx = ctx
 
 	pErr, err := loadReplicaDestroyedError(ctx, r.store.Engine(), r.RangeID)
 	if err != nil {
@@ -459,9 +493,7 @@ func (r *Replica) newReplicaInner(desc *roachpb.RangeDescriptor, clock *hlc.Cloc
 // require a lock and its output may not be atomic with other ongoing work in
 // the replica. This is done to prevent deadlocks in logging sites.
 func (r *Replica) String() string {
-	inconsistentDesc := r.rangeDesc.Load().(*roachpb.RangeDescriptor)
-	return fmt.Sprintf("%s range=%d [%s-%s)", r.store,
-		inconsistentDesc.RangeID, inconsistentDesc.StartKey, inconsistentDesc.EndKey)
+	return fmt.Sprintf("%s %s", r.store, &r.rangeDesc)
 }
 
 // Destroy clears pending command queue by sending each pending
@@ -637,7 +669,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) *roachpb.Error {
 				if _, ok := r.mu.pendingLeaseRequest.RequestPending(); !ok &&
 					!timestamp.Less(lease.StartStasis.Add(-int64(r.store.ctx.rangeLeaseRenewalDuration), 0)) {
 					if log.V(2) {
-						log.Warningf(ctx, "%s: extending lease %s at %s", r, lease, timestamp)
+						log.Warningf(ctx, "extending lease %s at %s", lease, timestamp)
 					}
 					// We had an active lease to begin with, but we want to trigger
 					// a lease extension. We don't need to wait for that extension
@@ -680,7 +712,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) *roachpb.Error {
 			continue
 		case <-ctx.Done():
 			if log.V(2) {
-				log.Infof(ctx, "%s: lease acquisition failed: %v", r, ctx.Err())
+				log.Infof(ctx, "lease acquisition failed: %v", ctx.Err())
 			}
 		case <-r.store.Stopper().ShouldStop():
 		}
@@ -746,7 +778,7 @@ func (r *Replica) setDescWithoutProcessUpdateLocked(desc *roachpb.RangeDescripto
 
 	// NB: If we used rangeDesc for anything but informational purposes, the
 	// order here would be crucial.
-	r.rangeDesc.Store(desc)
+	r.rangeDesc.store(desc)
 	r.mu.state.Desc = desc
 }
 
@@ -827,7 +859,7 @@ func containsKeyRange(desc roachpb.RangeDescriptor, start, end roachpb.Key) bool
 func (r *Replica) getLastReplicaGCTimestamp() (hlc.Timestamp, error) {
 	key := keys.RangeLastReplicaGCTimestampKey(r.RangeID)
 	timestamp := hlc.Timestamp{}
-	_, err := engine.MVCCGetProto(context.Background(), r.store.Engine(), key, hlc.ZeroTimestamp, true, nil, &timestamp)
+	_, err := engine.MVCCGetProto(r.ctx, r.store.Engine(), key, hlc.ZeroTimestamp, true, nil, &timestamp)
 	if err != nil {
 		return hlc.ZeroTimestamp, err
 	}
@@ -836,7 +868,7 @@ func (r *Replica) getLastReplicaGCTimestamp() (hlc.Timestamp, error) {
 
 func (r *Replica) setLastReplicaGCTimestamp(timestamp hlc.Timestamp) error {
 	key := keys.RangeLastReplicaGCTimestampKey(r.RangeID)
-	return engine.MVCCPutProto(context.Background(), r.store.Engine(), nil, key, hlc.ZeroTimestamp, nil, &timestamp)
+	return engine.MVCCPutProto(r.ctx, r.store.Engine(), nil, key, hlc.ZeroTimestamp, nil, &timestamp)
 }
 
 // getLastVerificationTimestamp reads the timestamp at which the replica's
@@ -844,7 +876,7 @@ func (r *Replica) setLastReplicaGCTimestamp(timestamp hlc.Timestamp) error {
 func (r *Replica) getLastVerificationTimestamp() (hlc.Timestamp, error) {
 	key := keys.RangeLastVerificationTimestampKey(r.RangeID)
 	timestamp := hlc.Timestamp{}
-	_, err := engine.MVCCGetProto(context.Background(), r.store.Engine(), key, hlc.ZeroTimestamp, true, nil, &timestamp)
+	_, err := engine.MVCCGetProto(r.ctx, r.store.Engine(), key, hlc.ZeroTimestamp, true, nil, &timestamp)
 	if err != nil {
 		return hlc.ZeroTimestamp, err
 	}
@@ -853,7 +885,7 @@ func (r *Replica) getLastVerificationTimestamp() (hlc.Timestamp, error) {
 
 func (r *Replica) setLastVerificationTimestamp(timestamp hlc.Timestamp) error {
 	key := keys.RangeLastVerificationTimestampKey(r.RangeID)
-	return engine.MVCCPutProto(context.Background(), r.store.Engine(), nil, key, hlc.ZeroTimestamp, nil, &timestamp)
+	return engine.MVCCPutProto(r.ctx, r.store.Engine(), nil, key, hlc.ZeroTimestamp, nil, &timestamp)
 }
 
 // RaftStatus returns the current raft status of the replica. It returns nil
@@ -879,7 +911,7 @@ func (r *Replica) State() storagebase.RangeInfo {
 	ri.RaftLogSize = r.mu.raftLogSize
 	var err error
 	if ri.LastVerification, err = r.getLastVerificationTimestamp(); err != nil {
-		log.Warningf(context.TODO(), "%s: %v", r, err)
+		log.Warningf(r.ctx, "%v", err)
 	}
 	ri.NumDropped = uint64(r.mu.droppedMessages)
 
@@ -898,12 +930,12 @@ func (r *Replica) assertState(reader engine.Reader) {
 //
 // TODO(tschottdorf): Consider future removal (for example, when #7224 is resolved).
 func (r *Replica) assertStateLocked(reader engine.Reader) {
-	diskState, err := loadState(context.TODO(), reader, r.mu.state.Desc)
+	diskState, err := loadState(r.ctx, reader, r.mu.state.Desc)
 	if err != nil {
 		r.panic(err)
 	}
 	if !reflect.DeepEqual(diskState, r.mu.state) {
-		log.Fatalf(context.TODO(), "%s: on-disk and in-memory state diverged:\n%+v\n%+v", r, diskState, r.mu.state)
+		log.Fatalf(r.ctx, "on-disk and in-memory state diverged:\n%+v\n%+v", diskState, r.mu.state)
 	}
 }
 
@@ -912,7 +944,10 @@ func (r *Replica) assertStateLocked(reader engine.Reader) {
 // range's lease is confirmed. The command is then dispatched
 // either along the read-only execution path or the read-write Raft
 // command queue.
-func (r *Replica) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+// ctx should contain the log tags from the store (and up).
+func (r *Replica) Send(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error) {
 	r.assert5725(ba)
 
 	var br *roachpb.BatchResponse
@@ -920,7 +955,8 @@ func (r *Replica) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.B
 	if err := r.checkBatchRequest(ba); err != nil {
 		return nil, roachpb.NewError(err)
 	}
-
+	// Add the range log tag.
+	ctx = log.WithLogTag(ctx, "r", &r.rangeDesc)
 	ctx, cleanup := tracing.EnsureContext(ctx, r.store.Tracer())
 	defer cleanup()
 
@@ -1027,7 +1063,7 @@ func (r *Replica) beginCmds(ctx context.Context, ba *roachpb.BatchRequest) (func
 			case <-ctxDone:
 				err := ctx.Err()
 				errStr := fmt.Sprintf("%s while in command queue: %s", err, ba)
-				log.Warningf(ctx, "%s: error %v", r, errStr)
+				log.Warningf(ctx, "error %v", errStr)
 				log.Trace(ctx, errStr)
 				defer log.Trace(ctx, "removed from command queue")
 				// The command is moot, so we don't need to bother executing.
@@ -1316,8 +1352,8 @@ func (r *Replica) addReadOnlyCmd(ctx context.Context, ba roachpb.BatchRequest) (
 // a nonempty but incomplete Txn (i.e. &Transaction{})
 func (r *Replica) assert5725(ba roachpb.BatchRequest) {
 	if ba.Txn != nil && ba.Txn.ID == nil {
-		log.Fatalf(context.TODO(), "%s: nontrivial transaction with empty ID: %s\n%s",
-			r, ba.Txn, pretty.Sprint(ba))
+		log.Fatalf(r.ctx, "nontrivial transaction with empty ID: %s\n%s",
+			ba.Txn, pretty.Sprint(ba))
 	}
 }
 
@@ -1405,7 +1441,7 @@ func (r *Replica) addWriteCmd(
 					// which can be interpreted appropriately upstream.
 					pErr = roachpb.NewError(ctx.Err())
 				} else {
-					log.Warningf(ctx, "%s: unable to cancel expired Raft command %s", r, ba)
+					log.Warningf(ctx, "unable to cancel expired Raft command %s", ba)
 				}
 			}
 		}
@@ -1428,8 +1464,8 @@ func (r *Replica) prepareRaftCommandLocked(
 		r.mu.lastAssignedLeaseIndex++
 	}
 	if log.V(4) {
-		log.Infof(ctx, "%s: prepared command %x: maxLeaseIndex=%d leaseAppliedIndex=%d",
-			r, idKey, r.mu.lastAssignedLeaseIndex, r.mu.state.LeaseAppliedIndex)
+		log.Infof(ctx, "prepared command %x: maxLeaseIndex=%d leaseAppliedIndex=%d",
+			idKey, r.mu.lastAssignedLeaseIndex, r.mu.state.LeaseAppliedIndex)
 	}
 	return &pendingCmd{
 		ctx:   ctx,
@@ -1447,7 +1483,7 @@ func (r *Replica) prepareRaftCommandLocked(
 func (r *Replica) insertRaftCommandLocked(pCmd *pendingCmd) {
 	idKey := pCmd.idKey
 	if _, ok := r.mu.pendingCmds[idKey]; ok {
-		log.Fatalf(context.TODO(), "%s: pending command already exists for %s", r, idKey)
+		log.Fatalf(r.ctx, "pending command already exists for %s", idKey)
 	}
 	r.mu.pendingCmds[idKey] = pCmd
 }
@@ -1526,7 +1562,7 @@ func defaultProposeRaftCommandLocked(r *Replica, p *pendingCmd) error {
 			// EndTransactionRequest with a ChangeReplicasTrigger is special
 			// because raft needs to understand it; it cannot simply be an
 			// opaque command.
-			log.Infof(context.TODO(), "%s: proposing %s %+v for range %d: %+v", r,
+			log.Infof(r.ctx, "proposing %s %+v for range %d: %+v",
 				crt.ChangeType, crt.Replica, p.raftCmd.RangeID, crt.UpdatedReplicas)
 
 			ctx := ConfChangeContext{
@@ -1551,7 +1587,7 @@ func defaultProposeRaftCommandLocked(r *Replica, p *pendingCmd) error {
 
 	return r.withRaftGroupLocked(func(raftGroup *raft.RawNode) error {
 		if log.V(4) {
-			log.Infof(context.TODO(), "%s: proposing command %x", r, p.idKey)
+			log.Infof(r.ctx, "proposing command %x", p.idKey)
 		}
 		return raftGroup.Propose(encodeRaftCommand(string(p.idKey), data))
 	})
@@ -1560,7 +1596,7 @@ func defaultProposeRaftCommandLocked(r *Replica, p *pendingCmd) error {
 // handleRaftReady processes the Ready() messages on the replica if there are any. It takes a
 // non-nil IncomingSnapshot pointer to indicate that it is about to process a snapshot.
 func (r *Replica) handleRaftReady(inSnap *IncomingSnapshot) error {
-	ctx := context.TODO()
+	ctx := r.ctx
 	var hasReady bool
 	var rd raft.Ready
 	r.mu.Lock()
@@ -1595,7 +1631,7 @@ func (r *Replica) handleRaftReady(inSnap *IncomingSnapshot) error {
 		// indicating a newly elected leader or a conf change. Replay protection
 		// prevents any corruption, so the waste is only a performance issue.
 		if log.V(3) {
-			log.Infof(ctx, "%s: raft leader changed: %d -> %d", r, leaderID, rd.SoftState.Lead)
+			log.Infof(ctx, "raft leader changed: %d -> %d", leaderID, rd.SoftState.Lead)
 		}
 		if !r.store.TestingKnobs().DisableRefreshReasonNewLeader {
 			refreshReason = reasonNewLeader
@@ -1745,7 +1781,7 @@ func (r *Replica) handleRaftReady(inSnap *IncomingSnapshot) error {
 				return err
 			}
 		default:
-			log.Fatalf(context.TODO(), "%s: unexpected Raft entry: %v", r, e)
+			log.Fatalf(ctx, "unexpected Raft entry: %v", e)
 		}
 	}
 	if refreshReason != noReason {
@@ -1849,9 +1885,9 @@ func (r *Replica) refreshPendingCmdsLocked(reason refreshRaftReason, refreshAtDe
 		refurbished++
 	}
 	if log.V(1) && (refurbished > 0 || len(reproposals) > 0) {
-		log.Infof(context.TODO(),
-			"%s: pending commands: refurbished %d, reproposing %d (at %d.%d); %s",
-			r, refurbished, len(reproposals), r.mu.state.RaftAppliedIndex,
+		log.Infof(r.ctx,
+			"pending commands: refurbished %d, reproposing %d (at %d.%d); %s",
+			refurbished, len(reproposals), r.mu.state.RaftAppliedIndex,
 			r.mu.state.LeaseAppliedIndex, reason)
 	}
 
@@ -1884,7 +1920,6 @@ func (r *Replica) getReplicaDescriptorByIDLocked(
 }
 
 func (r *Replica) sendRaftMessage(msg raftpb.Message) {
-	ctx := context.TODO()
 	rangeID := r.RangeID
 
 	r.mu.Lock()
@@ -1894,23 +1929,23 @@ func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 	r.mu.Unlock()
 
 	if fromErr != nil {
-		log.Warningf(ctx,
-			"failed to look up sender replica %d in range %d while sending %s: %s", msg.From, rangeID, msg.Type, fromErr)
+		log.Warningf(r.ctx, "failed to look up sender replica %d in range %d while sending %s: %s",
+			msg.From, rangeID, msg.Type, fromErr)
 		return
 	}
 	if toErr != nil {
-		log.Warningf(ctx,
-			"failed to look up recipient replica %d in range %d while sending %s: %s", msg.To, rangeID, msg.Type, toErr)
+		log.Warningf(r.ctx, "failed to look up recipient replica %d in range %d while sending %s: %s",
+			msg.To, rangeID, msg.Type, toErr)
 		return
 	}
 
 	if !raft.IsEmptySnap(msg.Snapshot) {
 		msgUUID, err := uuid.FromBytes(msg.Snapshot.Data)
 		if err != nil {
-			log.Fatalf(ctx, "invalid snapshot: couldn't parse UUID from data: %s", err)
+			log.Fatalf(r.ctx, "invalid snapshot: couldn't parse UUID from data: %s", err)
 		}
 		if *msgUUID != snap.SnapUUID {
-			log.Fatalf(ctx, "programming error: snapshot message from Raft.Ready %s doesn't match outgoing snapshot UUID %s.",
+			log.Fatalf(r.ctx, "programming error: snapshot message from Raft.Ready %s doesn't match outgoing snapshot UUID %s.",
 				*msgUUID, snap.SnapUUID)
 		}
 		// Asynchronously stream the snapshot to the recipient.
@@ -1931,12 +1966,12 @@ func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 						RangeSize:  0,
 						CanDecline: false,
 					}, snap, r.store.Engine().NewBatch); err != nil {
-					log.Warningf(ctx, "range=%d: failed to send snapshot: %s", r.Desc().RangeID, err)
+					log.Warningf(r.ctx, "range=%d: failed to send snapshot: %s", r.Desc().RangeID, err)
 				}
 			})
 		}); err != nil {
 			snap.Close()
-			log.Warningf(ctx, "range=%d: failed to send snapshot: %s", r.Desc().RangeID, err)
+			log.Warningf(r.ctx, "range=%d: failed to send snapshot: %s", r.Desc().RangeID, err)
 		}
 		return
 	}
@@ -2005,12 +2040,11 @@ func (r *Replica) processRaftCommand(
 	idKey storagebase.CmdIDKey, index uint64, raftCmd roachpb.RaftCommand,
 ) *roachpb.Error {
 	if index == 0 {
-		log.Fatalf(context.TODO(), "%s: processRaftCommand requires a non-zero index", r)
+		log.Fatalf(r.ctx, "processRaftCommand requires a non-zero index")
 	}
 
 	if log.V(4) {
-		log.Infof(context.TODO(), "%s: processing command %x: maxLeaseIndex=%d",
-			r, idKey, raftCmd.MaxLeaseIndex)
+		log.Infof(r.ctx, "processing command %x: maxLeaseIndex=%d", idKey, raftCmd.MaxLeaseIndex)
 	}
 
 	r.mu.Lock()
@@ -2041,7 +2075,7 @@ func (r *Replica) processRaftCommand(
 	}
 
 	// TODO(tschottdorf): consider the Trace situation here.
-	ctx := context.Background()
+	ctx := r.ctx
 	if cmd != nil {
 		// We initiated this command, so use the caller-supplied context.
 		ctx = cmd.ctx
@@ -2059,8 +2093,8 @@ func (r *Replica) processRaftCommand(
 		forcedErr = roachpb.NewErrorf("no-op on empty Raft entry")
 	} else if isLeaseError() {
 		if log.V(1) {
-			log.Warningf(context.TODO(), "%s: command proposed from replica %+v (lease at %v): %s",
-				r, raftCmd.OriginReplica, r.mu.state.Lease.Replica, raftCmd.Cmd)
+			log.Warningf(r.ctx, "command proposed from replica %+v (lease at %v): %s",
+				raftCmd.OriginReplica, r.mu.state.Lease.Replica, raftCmd.Cmd)
 		}
 		forcedErr = roachpb.NewError(newNotLeaseHolderError(
 			r.mu.state.Lease, raftCmd.OriginReplica.StoreID, r.mu.state.Desc))
@@ -2099,8 +2133,8 @@ func (r *Replica) processRaftCommand(
 			// cycles from traces.
 			if localMaxLeaseIndex := cmd.raftCmd.MaxLeaseIndex; localMaxLeaseIndex <= raftCmd.MaxLeaseIndex {
 				if log.V(1) {
-					log.Infof(context.TODO(), "%s: refurbishing command for <= %d observed at %d",
-						r, raftCmd.MaxLeaseIndex, leaseIndex)
+					log.Infof(r.ctx, "refurbishing command for <= %d observed at %d",
+						raftCmd.MaxLeaseIndex, leaseIndex)
 				}
 
 				if pErr := r.refurbishPendingCmdLocked(cmd); pErr == nil {
@@ -2109,7 +2143,7 @@ func (r *Replica) processRaftCommand(
 					// We could try to send the error to the client instead,
 					// but to avoid even the appearance of Replica divergence,
 					// let's not.
-					log.Warningf(context.TODO(), "%s: unable to refurbish: %s", r, pErr)
+					log.Warningf(r.ctx, "unable to refurbish: %s", pErr)
 				}
 			} else {
 				// The refurbishment is already in flight, so we better get cmd back
@@ -2131,7 +2165,7 @@ func (r *Replica) processRaftCommand(
 	// replica corruption (as of now, signaled by a replicaCorruptionError).
 	// We feed its return through maybeSetCorrupt to act when that happens.
 	if log.V(1) && forcedErr != nil {
-		log.Infof(context.TODO(), "%s: applying command with forced error: %v", r, forcedErr)
+		log.Infof(r.ctx, "applying command with forced error: %v", forcedErr)
 	}
 
 	br, propResult, pErr := r.applyRaftCommand(idKey, ctx, index, leaseIndex,
@@ -2166,7 +2200,7 @@ func (r *Replica) processRaftCommand(
 		cmd.done <- roachpb.ResponseWithError{Reply: br, Err: pErr}
 		close(cmd.done)
 	} else if pErr != nil && log.V(1) {
-		log.Errorf(context.TODO(), "%s: error executing raft command: %s", r, pErr)
+		log.Errorf(r.ctx, "error executing raft command: %s", pErr)
 	}
 
 	return pErr
@@ -2224,8 +2258,8 @@ func (r *Replica) applyRaftCommand(
 
 	// TODO(tschottdorf): remove when #7224 is cleared.
 	if ba.Txn != nil && ba.Txn.Name == replicaChangeTxnName && log.V(1) {
-		log.Infof(ctx, "%s: applied part of replica change txn: %s, pErr=%v",
-			r, ba, rErr)
+		log.Infof(ctx, "applied part of replica change txn: %s, pErr=%v",
+			ba, rErr)
 	}
 
 	defer batch.Close()
@@ -2361,8 +2395,8 @@ func (r *Replica) checkIfTxnAborted(
 	if aborted {
 		// We hit the cache, so let the transaction restart.
 		if log.V(1) {
-			log.Infof(ctx, "%s: found abort cache entry for %s with priority %d",
-				r, txn.ID.Short(), entry.Priority)
+			log.Infof(ctx, "found abort cache entry for %s with priority %d",
+				txn.ID.Short(), entry.Priority)
 		}
 		newTxn := txn.Clone()
 		if entry.Priority > newTxn.Priority {
@@ -2723,15 +2757,13 @@ func (r *Replica) maybeGossipFirstRange() *roachpb.Error {
 		return nil
 	}
 
-	ctx := context.Background()
-
 	// When multiple nodes are initialized with overlapping Gossip addresses, they all
 	// will attempt to gossip their cluster ID. This is a fairly obvious misconfiguration,
 	// so we error out below.
 	if uuidBytes, err := r.store.Gossip().GetInfo(gossip.KeyClusterID); err == nil {
 		if gossipClusterID, err := uuid.FromBytes(uuidBytes); err == nil {
 			if *gossipClusterID != r.store.ClusterID() {
-				log.Fatalf(ctx, "store %d belongs to cluster %s, but attempted to join cluster %s via gossip",
+				log.Fatalf(r.ctx, "store %d belongs to cluster %s, but attempted to join cluster %s via gossip",
 					r.store.StoreID(), r.store.ClusterID(), gossipClusterID)
 			}
 		}
@@ -2740,16 +2772,16 @@ func (r *Replica) maybeGossipFirstRange() *roachpb.Error {
 	// Gossip the cluster ID from all replicas of the first range; there
 	// is no expiration on the cluster ID.
 	if log.V(1) {
-		log.Infof(ctx, "gossiping cluster id %q from store %d, range %d", r.store.ClusterID(),
+		log.Infof(r.ctx, "gossiping cluster id %q from store %d, range %d", r.store.ClusterID(),
 			r.store.StoreID(), r.RangeID)
 	}
 	if err := r.store.Gossip().AddInfo(gossip.KeyClusterID, r.store.ClusterID().GetBytes(), 0*time.Second); err != nil {
-		log.Errorf(ctx, "failed to gossip cluster ID: %s", err)
+		log.Errorf(r.ctx, "failed to gossip cluster ID: %s", err)
 	}
-	if hasLease, pErr := r.getLeaseForGossip(ctx); hasLease {
+	if hasLease, pErr := r.getLeaseForGossip(r.ctx); hasLease {
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		r.gossipFirstRangeLocked(ctx)
+		r.gossipFirstRangeLocked(r.ctx)
 	} else {
 		return pErr
 	}
@@ -2803,11 +2835,10 @@ func (r *Replica) maybeGossipSystemConfig() {
 		return
 	}
 
-	ctx := context.Background()
 	// TODO(marc): check for bad split in the middle of the SystemConfig span.
 	kvs, hash, err := r.loadSystemConfigSpan()
 	if err != nil {
-		log.Errorf(ctx, "could not load SystemConfig span: %s", err)
+		log.Errorf(r.ctx, "could not load SystemConfig span: %s", err)
 		return
 	}
 	if bytes.Equal(r.systemDBHash, hash) {
@@ -2815,13 +2846,13 @@ func (r *Replica) maybeGossipSystemConfig() {
 	}
 
 	if log.V(2) {
-		log.Infof(ctx, "gossiping system config from store %d, range %d, hash %x",
+		log.Infof(r.ctx, "gossiping system config from store %d, range %d, hash %x",
 			r.store.StoreID(), r.RangeID, hash)
 	}
 
 	cfg := &config.SystemConfig{Values: kvs}
 	if err := r.store.Gossip().AddInfoProto(gossip.KeySystemConfig, cfg, 0); err != nil {
-		log.Errorf(ctx, "failed to gossip system config: %s", err)
+		log.Errorf(r.ctx, "failed to gossip system config: %s", err)
 		return
 	}
 
@@ -2853,7 +2884,7 @@ func (r *Replica) maybeSetCorrupt(ctx context.Context, pErr *roachpb.Error) *roa
 		r.mu.Lock()
 		defer r.mu.Unlock()
 
-		log.Errorf(ctx, "%s: stalling replica due to: %s", r, cErr.ErrorMsg)
+		log.Errorf(ctx, "stalling replica due to: %s", cErr.ErrorMsg)
 		cErr.Processed = true
 		r.mu.destroyed = cErr
 		pErr = roachpb.NewError(cErr)
@@ -2879,7 +2910,7 @@ func (r *Replica) loadSystemConfigSpan() ([]roachpb.KeyValue, []byte, error) {
 	ba.Timestamp = r.store.Clock().Now()
 	ba.Add(&roachpb.ScanRequest{Span: keys.SystemConfigSpan})
 	br, trigger, pErr :=
-		r.executeBatch(context.Background(), storagebase.CmdIDKey(""), r.store.Engine(), nil, ba)
+		r.executeBatch(r.ctx, storagebase.CmdIDKey(""), r.store.Engine(), nil, ba)
 	if pErr != nil {
 		return nil, nil, pErr.GoError()
 	}

--- a/storage/replica_range_lease.go
+++ b/storage/replica_range_lease.go
@@ -20,8 +20,6 @@
 package storage
 
 import (
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util/hlc"
 	"github.com/cockroachdb/cockroach/util/protoutil"
@@ -124,7 +122,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 		ba.Timestamp = replica.store.Clock().Now()
 		ba.RangeID = replica.RangeID
 		ba.Add(leaseReq)
-		_, pErr := replica.Send(context.TODO(), ba)
+		_, pErr := replica.Send(replica.store.Ctx(), ba)
 
 		// Send result of lease to all waiter channels.
 		replica.mu.Lock()

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -361,7 +361,7 @@ func TestReplicaContains(t *testing.T) {
 	// This test really only needs a hollow shell of a Replica.
 	r := &Replica{}
 	r.mu.state.Desc = desc
-	r.rangeDesc.Store(desc)
+	r.rangeDesc.store(desc)
 
 	if statsKey := keys.RangeStatsKey(desc.RangeID); !r.ContainsKey(statsKey) {
 		t.Errorf("expected range to contain range stats key %q", statsKey)

--- a/storage/store.go
+++ b/storage/store.go
@@ -662,6 +662,14 @@ func (s *Store) Ctx() context.Context {
 	return s.ctx.Ctx
 }
 
+// logContext adds the node and store log tags to a context. Used to
+// personalize an operation context with this Store's identity.
+func (s *Store) logContext(ctx context.Context) context.Context {
+	// Copy the log tags from the base context. This allows us to opaquely set the
+	// log tags that were passed by the upper layers.
+	return log.WithLogTagsFromCtx(ctx, s.Ctx())
+}
+
 // DrainLeases (when called with 'true') prevents all of the Store's
 // Replicas from acquiring or extending range leases and waits until all of
 // them have expired. If an error is returned, the draining state is still
@@ -863,6 +871,9 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	if err != nil {
 		return err
 	}
+
+	// Set the store ID for logging.
+	s.ctx.Ctx = log.WithLogTagInt(s.ctx.Ctx, "s", int(s.StoreID()))
 
 	// Start Raft processing goroutines.
 	s.ctx.Transport.Listen(s.StoreID(), s)
@@ -1907,6 +1918,10 @@ func (s *Store) ReplicaCount() int {
 // of one of its writes), the response will have a transaction set which should
 // be used to update the client transaction.
 func (s *Store) Send(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.BatchResponse, pErr *roachpb.Error) {
+	// Attach any log tags from the store to the context (which normally
+	// comes from gRPC).
+	ctx = s.logContext(ctx)
+
 	for _, union := range ba.Requests {
 		arg := union.GetInner()
 		header := arg.Header()
@@ -2439,6 +2454,8 @@ func (s *Store) applySnapshot(
 func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) *roachpb.Error {
 	s.processRaftMu.Lock()
 	defer s.processRaftMu.Unlock()
+
+	ctx = s.logContext(ctx)
 
 	// Drop messages that come from a node that we believe was once
 	// a member of the group but has been removed.

--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -37,7 +37,6 @@ func makeMessage(ctx context.Context, format string, args []interface{}) string 
 			}
 			buf.WriteString(t.name)
 			if value := t.value(); value != nil {
-				buf.WriteString("=")
 				fmt.Fprint(&buf, value)
 			}
 		}


### PR DESCRIPTION
- Set nodeID log tag in the base server context. This context is inherited by the
  various server components. The trick is that we don't know the node ID when we
  set up the contexts, so we set a log tag with a dynamic value which gets updated
  asynchronously.
- Add log tags to request contexts in Store, using new functionality to copy
  log tags from one context to another. This pattern allows adding tags this
  particular layer doesn't have direct knowledge of (like the nodeID tag set by
  the server, or any tags potentially passed to NewServer).
- Shorten log tags (`n` for node, `s` for store) and suppress the '=' (it can
  be included explicitly in the tag name if necessary).
- Add range log tags. We reimplement the atomic rangeDesc using an atomic pointer,
  and use the new type as the value for the range log tag.

Sample messages:

```
I160822 19:43:39.073183 storage/replica.go:2121  [n1,s1,r7{/Table/51-/Max}] applying command with..
E160822 19:43:39.073284 storage/replica.go:2156  [n1,s1,r7{/Table/51-/Max}] error executing raft..
```

This is a reboot of #8715. Note that there is more work to be done to plumb contexts to a few other components in storage.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8753)

<!-- Reviewable:end -->
