### PR TITLE
build: Pass coverage tokens to builder.

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -134,4 +134,6 @@ docker run -i ${tty-} ${rm} \
   --env="CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX-0}" \
   --env="CIRCLE_NODE_TOTAL=${CIRCLE_NODE_TOTAL-1}" \
   --env="GOTRACEBACK=${GOTRACEBACK-all}" \
+  --env="COVERALLS_TOKEN=${COVERALLS_TOKEN-}" \
+  --env="CODECOV_TOKEN=${CODECOV_TOKEN-}" \
   "${image}:${version}" "$@"


### PR DESCRIPTION
This enables running the coverage uploader inside of the builder on CI.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8754)

<!-- Reviewable:end -->
