### PR TITLE
storage: deflake TestScannerDisabled + fix race in timer.Reset

### DIFF
--- a/storage/scanner.go
+++ b/storage/scanner.go
@@ -180,16 +180,20 @@ func (rs *replicaScanner) paceInterval(start, now time.Time) time.Duration {
 // if repl is not nil. The method returns true when the scanner needs
 // to be stopped. The method also removes a replica from queues when it
 // is signaled via the removed channel.
-func (rs *replicaScanner) waitAndProcess(start time.Time, clock *hlc.Clock, stopper *stop.Stopper,
-	repl *Replica) bool {
+func (rs *replicaScanner) waitAndProcess(
+	start time.Time, clock *hlc.Clock, stopper *stop.Stopper, repl *Replica,
+) bool {
 	waitInterval := rs.paceInterval(start, timeutil.Now())
 	rs.waitTimer.Reset(waitInterval)
 	if log.V(6) {
-		log.Infof(context.TODO(), "Wait time interval set to %s", waitInterval)
+		log.Infof(context.TODO(), "wait timer interval set to %s", waitInterval)
 	}
 	for {
 		select {
 		case <-rs.waitTimer.C:
+			if log.V(6) {
+				log.Infof(context.TODO(), "wait timer fired")
+			}
 			rs.waitTimer.Read = true
 			if repl == nil {
 				return false

--- a/util/timeutil/timer.go
+++ b/util/timeutil/timer.go
@@ -61,9 +61,10 @@ func (t *Timer) Reset(d time.Duration) {
 		t.Timer = time.NewTimer(d)
 		return
 	}
-	if !t.Timer.Reset(d) && !t.Read {
+	if !t.Timer.Stop() && !t.Read {
 		<-t.C
 	}
+	t.Timer.Reset(d)
 	t.Read = false
 }
 


### PR DESCRIPTION
See commits for descriptions.
CC @cockroachdb/stability

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8766)

<!-- Reviewable:end -->
