### PR TITLE
all: Remove dangling reference to make clean in the ui directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,6 @@ clean:
 	$(GO) clean $(GOFLAGS) -i github.com/cockroachdb/...
 	find . -name '*.test' -type f -exec rm -f {} \;
 	rm -f .bootstrap
-	make -C ui clean
 
 .PHONY: protobuf
 protobuf:


### PR DESCRIPTION
Verified that the ui's make clean command was intentionally removed in
https://github.com/cockroachdb/cockroach/pull/7242/files/f8957537a4938474c0f53472ea43b7e2292810d0#r75899502

@tamird

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8769)

<!-- Reviewable:end -->
