### PR TITLE
stopper: avoid races between RunWorker and Stop

### DIFF
--- a/util/stop/stopper.go
+++ b/util/stop/stopper.go
@@ -182,7 +182,16 @@ func (s *Stopper) Recover() {
 
 // RunWorker runs the supplied function as a "worker" to be stopped
 // by the stopper. The function <f> is run in a goroutine.
+//
+// Once Stop() has been invoked, RunWorker is a no-op.
 func (s *Stopper) RunWorker(f func()) {
+	s.mu.Lock()
+	quiescing := s.mu.quiescing
+	s.mu.Unlock()
+	if quiescing {
+		return
+	}
+
 	s.stop.Add(1)
 	go func() {
 		defer s.Recover()
@@ -195,6 +204,12 @@ func (s *Stopper) RunWorker(f func()) {
 func (s *Stopper) AddCloser(c Closer) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	select {
+	case <-s.stopped:
+		c.Close()
+		return
+	default:
+	}
 	s.mu.closers = append(s.mu.closers, c)
 }
 


### PR DESCRIPTION
Many locations in our code currently use a pattern of the form

``` go
stopper.RunTask(func() {
  stopper.RunWorker(func() {
    // Stuff
  })
})
```

because RunWorker calls aren't safe once `Stop()` is invoked. However, there
seems to be no good reason for not fixing this at the source, which is done in
this commit: RunWorker calls on a draining stopper are simply a no-ops, and
Closers which are added after the stopper has processed its internal slice of
them are called immediately.

Follow-up work should remove the above pattern from the codebase.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8782)

<!-- Reviewable:end -->
