### PR TITLE
sql: rekey tables during restore

### DIFF
--- a/cli/backup_experimental.go
+++ b/cli/backup_experimental.go
@@ -32,9 +32,8 @@ import (
 )
 
 type backupContext struct {
-	database  string
-	table     string
-	overwrite bool
+	database string
+	table    string
 }
 
 var backupCtx backupContext
@@ -43,7 +42,6 @@ func init() {
 	f := restoreCmd.Flags()
 	f.StringVar(&backupCtx.database, "database", "*", "database to restore (or empty for all user databases)")
 	f.StringVar(&backupCtx.table, "table", "*", "table to restore (or empty for all user tables in database(s))")
-	f.BoolVar(&backupCtx.overwrite, "overwrite", false, "true to overwrite existing tables")
 }
 
 func runBackup(cmd *cobra.Command, args []string) error {
@@ -86,16 +84,12 @@ func runRestore(cmd *cobra.Command, args []string) error {
 		DatabaseName: parser.Name(backupCtx.database),
 		TableName:    parser.Name(backupCtx.table),
 	}
-	restored, err := sql.Restore(ctx, *kvDB, base, tableName, backupCtx.overwrite)
+	restored, err := sql.Restore(ctx, *kvDB, base, tableName)
 	if err != nil {
 		return err
 	}
-	for _, desc := range restored {
-		if db := desc.GetDatabase(); db != nil {
-			fmt.Printf("Restored database %q\n", db.Name)
-			continue
-		}
-		fmt.Printf("Restored table %q\n", desc.GetTable().Name)
+	for _, table := range restored {
+		fmt.Printf("Restored table %q\n", table.Name)
 	}
 
 	fmt.Printf("Restored from %s\n", base)

--- a/sql/create.go
+++ b/sql/create.go
@@ -332,7 +332,7 @@ func (n *createTableNode) Start() error {
 		}
 	}
 
-	id, err := n.p.generateUniqueDescID()
+	id, err := generateUniqueDescID(n.p.txn)
 	if err != nil {
 		return nil
 	}

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -100,9 +100,9 @@ func (d descriptorAlreadyExistsErr) Error() string {
 	return fmt.Sprintf("%s %q already exists", d.desc.TypeName(), d.name)
 }
 
-func (p *planner) generateUniqueDescID() (sqlbase.ID, error) {
+func generateUniqueDescID(txn *client.Txn) (sqlbase.ID, error) {
 	// Increment unique descriptor counter.
-	ir, err := p.txn.Inc(keys.DescIDGenerator, 1)
+	ir, err := txn.Inc(keys.DescIDGenerator, 1)
 	if err != nil {
 		return 0, err
 	}
@@ -126,7 +126,7 @@ func (p *planner) createDescriptor(
 		return false, err
 	}
 
-	id, err := p.generateUniqueDescID()
+	id, err := generateUniqueDescID(p.txn)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Delete the existing table, if applicable.

For now, remove the ability to restore databases from backup. It's tricker than
it looks (to delete existing data and get the cli parts right) and isn't the
most interesting thing to focus on right now.

name                    time/op
RocksDBSstFileReader-8    708ns ± 1%
SstRekey-8                858ns ± 6%

name                    speed
RocksDBSstFileReader-8  155MB/s ± 1%
SstRekey-8              128MB/s ± 6%

name                    alloc/op
RocksDBSstFileReader-8     128B ± 0%
SstRekey-8                 159B ± 0%

name                    allocs/op
RocksDBSstFileReader-8     2.00 ± 0%
SstRekey-8                 2.00 ± 0%

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8783)

<!-- Reviewable:end -->
