### PR TITLE
admin: Fix /database/{db}/tables/{table} endpoint for virtual schemas

### DIFF
--- a/server/admin.go
+++ b/server/admin.go
@@ -389,59 +389,62 @@ func (s *adminServer) TableDetails(
 		resp.CreateTableStatement = createStmt
 	}
 
-	// Get the number of ranges in the table. We get the key span for the table
-	// data. Then, we count the number of ranges that make up that key span.
-	{
-		var iexecutor sql.InternalExecutor
-		var tableSpan roachpb.Span
-		if err := s.server.db.Txn(context.TODO(), func(txn *client.Txn) error {
+	// Range and ZoneConfig information is not applicable to virtual schemas.
+	if !sql.IsVirtualDatabase(escDBName) {
+		// Get the number of ranges in the table. We get the key span for the table
+		// data. Then, we count the number of ranges that make up that key span.
+		{
+			var iexecutor sql.InternalExecutor
+			var tableSpan roachpb.Span
+			if err := s.server.db.Txn(context.TODO(), func(txn *client.Txn) error {
+				var err error
+				tableSpan, err = iexecutor.GetTableSpan(s.getUser(req), txn, escDBName, escTableName)
+				return err
+			}); err != nil {
+				return nil, s.serverError(err)
+			}
+			tableRSpan := roachpb.RSpan{}
 			var err error
-			tableSpan, err = iexecutor.GetTableSpan(s.getUser(req), txn, escDBName, escTableName)
-			return err
-		}); err != nil {
-			return nil, s.serverError(err)
-		}
-		tableRSpan := roachpb.RSpan{}
-		var err error
-		tableRSpan.Key, err = keys.Addr(tableSpan.Key)
-		if err != nil {
-			return nil, s.serverError(err)
-		}
-		tableRSpan.EndKey, err = keys.Addr(tableSpan.EndKey)
-		if err != nil {
-			return nil, s.serverError(err)
-		}
-		rangeCount, err := s.server.distSender.CountRanges(tableRSpan)
-		if err != nil {
-			return nil, s.serverError(err)
-		}
-		resp.RangeCount = rangeCount
-	}
-
-	// Query the zone configuration for this table.
-	{
-		path, err := s.queryDescriptorIDPath(session, []string{escDBName, escTableName})
-		if err != nil {
-			return nil, s.serverError(err)
+			tableRSpan.Key, err = keys.Addr(tableSpan.Key)
+			if err != nil {
+				return nil, s.serverError(err)
+			}
+			tableRSpan.EndKey, err = keys.Addr(tableSpan.EndKey)
+			if err != nil {
+				return nil, s.serverError(err)
+			}
+			rangeCount, err := s.server.distSender.CountRanges(tableRSpan)
+			if err != nil {
+				return nil, s.serverError(err)
+			}
+			resp.RangeCount = rangeCount
 		}
 
-		id, zone, zoneExists, err := s.queryZonePath(session, path)
-		if err != nil {
-			return nil, s.serverError(err)
-		}
+		// Query the zone configuration for this table.
+		{
+			path, err := s.queryDescriptorIDPath(session, []string{escDBName, escTableName})
+			if err != nil {
+				return nil, s.serverError(err)
+			}
 
-		if !zoneExists {
-			zone = config.DefaultZoneConfig()
-		}
-		resp.ZoneConfig = zone
+			id, zone, zoneExists, err := s.queryZonePath(session, path)
+			if err != nil {
+				return nil, s.serverError(err)
+			}
 
-		switch id {
-		case path[1]:
-			resp.ZoneConfigLevel = serverpb.ZoneConfigurationLevel_DATABASE
-		case path[2]:
-			resp.ZoneConfigLevel = serverpb.ZoneConfigurationLevel_TABLE
-		default:
-			resp.ZoneConfigLevel = serverpb.ZoneConfigurationLevel_CLUSTER
+			if !zoneExists {
+				zone = config.DefaultZoneConfig()
+			}
+			resp.ZoneConfig = zone
+
+			switch id {
+			case path[1]:
+				resp.ZoneConfigLevel = serverpb.ZoneConfigurationLevel_DATABASE
+			case path[2]:
+				resp.ZoneConfigLevel = serverpb.ZoneConfigurationLevel_TABLE
+			default:
+				resp.ZoneConfigLevel = serverpb.ZoneConfigurationLevel_CLUSTER
+			}
 		}
 	}
 

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -406,7 +406,7 @@ CREATE TABLE test.tbl (
 	for i, a := range resp.Columns {
 		e := expColumns[i]
 		if a.String() != e.String() {
-			t.Fatalf("mismatch at index %d: actual %#v != %#v", i, a, e)
+			t.Fatalf("mismatch at column %d: actual %#v != %#v", i, a, e)
 		}
 	}
 
@@ -444,6 +444,7 @@ CREATE TABLE test.tbl (
 		}
 	}
 
+	// Verify range count.
 	if a, e := resp.RangeCount, int64(1); a != e {
 		t.Fatalf("# of ranges %d != expected %d", a, e)
 	}
@@ -455,6 +456,79 @@ CREATE TABLE test.tbl (
 			createTableCol       = "CreateTable"
 		)
 
+		resSet := ts.sqlExecutor.ExecuteStatements(session, showCreateTableQuery, nil)
+		res := resSet.ResultList[0]
+		if res.Err != nil {
+			t.Fatalf("error executing '%s': %s", showCreateTableQuery, res.Err)
+		}
+
+		scanner := makeResultScanner(res.Columns)
+		var createStmt string
+		if err := scanner.Scan(res.Rows[0], createTableCol, &createStmt); err != nil {
+			t.Fatal(err)
+		}
+
+		if a, e := resp.CreateTableStatement, createStmt; a != e {
+			t.Fatalf("mismatched create table statement; expected %s, got %s", e, a)
+		}
+	}
+}
+
+func TestAdminAPITableDetailsForVirtualSchema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop()
+	ts := s.(*TestServer)
+
+	// Perform API call.
+	var resp serverpb.TableDetailsResponse
+	if err := apiGet(s, "databases/information_schema/tables/schemata", &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify columns.
+	expColumns := []serverpb.TableDetailsResponse_Column{
+		{Name: "CATALOG_NAME", Type: "STRING", Nullable: false, DefaultValue: "''"},
+		{Name: "SCHEMA_NAME", Type: "STRING", Nullable: false, DefaultValue: "''"},
+		{Name: "DEFAULT_CHARACTER_SET_NAME", Type: "STRING", Nullable: false, DefaultValue: "''"},
+		{Name: "SQL_PATH", Type: "STRING", Nullable: true},
+	}
+	testutils.SortStructs(expColumns, "Name")
+	testutils.SortStructs(resp.Columns, "Name")
+	if a, e := len(resp.Columns), len(expColumns); a != e {
+		t.Fatalf("# of result columns %d != expected %d (got: %#v)", a, e, resp.Columns)
+	}
+	for i, a := range resp.Columns {
+		e := expColumns[i]
+		if a.String() != e.String() {
+			t.Fatalf("mismatch at column %d: actual %#v != %#v", i, a, e)
+		}
+	}
+
+	// Verify grants.
+	if a, e := len(resp.Grants), 0; a != e {
+		t.Fatalf("# of grant columns %d != expected %d (got: %#v)", a, e, resp.Grants)
+	}
+
+	// Verify indexes.
+	if a, e := resp.RangeCount, int64(0); a != e {
+		t.Fatalf("# of indexes %d != expected %d", a, e)
+	}
+
+	// Verify range count.
+	if a, e := resp.RangeCount, int64(0); a != e {
+		t.Fatalf("# of ranges %d != expected %d", a, e)
+	}
+
+	// Verify Create Table Statement.
+	{
+		const (
+			showCreateTableQuery = "SHOW CREATE TABLE information_schema.schemata"
+			createTableCol       = "CreateTable"
+		)
+
+		session := sql.NewSession(
+			context.Background(), sql.SessionArgs{User: security.RootUser}, ts.sqlExecutor, nil)
 		resSet := ts.sqlExecutor.ExecuteStatements(session, showCreateTableQuery, nil)
 		res := resSet.ResultList[0]
 		if res.Err != nil {

--- a/sql/database.go
+++ b/sql/database.go
@@ -236,7 +236,7 @@ func (p *planner) getDatabaseID(name string) (sqlbase.ID, error) {
 
 // createDatabase implements the DatabaseAccessor interface.
 func (p *planner) createDatabase(desc *sqlbase.DatabaseDescriptor, ifNotExists bool) (bool, error) {
-	if isVirtualDatabase(desc.Name) {
+	if IsVirtualDatabase(desc.Name) {
 		if ifNotExists {
 			// Noop.
 			return false, nil
@@ -252,7 +252,7 @@ func (p *planner) renameDatabase(oldDesc *sqlbase.DatabaseDescriptor, newName st
 		return fmt.Errorf("the new database name %q already exists", newName)
 	}
 
-	if isVirtualDatabase(newName) {
+	if IsVirtualDatabase(newName) {
 		return onAlreadyExists()
 	}
 

--- a/sql/table.go
+++ b/sql/table.go
@@ -167,7 +167,7 @@ func (p *planner) getTableLease(tn *parser.TableName) (*sqlbase.TableDescriptor,
 	}
 
 	isSystemDB := tn.Database() == sqlbase.SystemDB.Name
-	isVirtualDB := isVirtualDatabase(tn.Database())
+	isVirtualDB := IsVirtualDatabase(tn.Database())
 	if isSystemDB || isVirtualDB || testDisableTableLeases {
 		// We don't go through the normal lease mechanism for:
 		// - system tables. The system.lease and system.descriptor table, in

--- a/sql/virtual_schema.go
+++ b/sql/virtual_schema.go
@@ -181,8 +181,8 @@ func getVirtualDatabaseDesc(name string) *sqlbase.DatabaseDescriptor {
 	return nil
 }
 
-// isVirtualDatabase checks if the provided name corresponds to a virtual database.
-func isVirtualDatabase(name string) bool {
+// IsVirtualDatabase checks if the provided name corresponds to a virtual database.
+func IsVirtualDatabase(name string) bool {
 	_, ok := getVirtualSchemaEntry(name)
 	return ok
 }


### PR DESCRIPTION
Fixes #8605.

The endpoint was attempting to get Range and ZoneConfig information for
virtual schema tables. This information is not applicable to virtual
schemas, so it makes sense that it was failing.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8789)

<!-- Reviewable:end -->
