### PR TITLE
ui: Convert Database pages to use SortedTable

### DIFF
--- a/ui/app/containers/databases/databaseDetails.tsx
+++ b/ui/app/containers/databases/databaseDetails.tsx
@@ -11,7 +11,8 @@ import { Bytes } from "../../util/format";
 import { AdminUIState } from "../../redux/state";
 import { setUISetting } from "../../redux/ui";
 import { refreshDatabaseDetails, refreshTableDetails, refreshTableStats, generateTableID, KeyedCachedDataReducerState } from "../../redux/apiReducers";
-import { SortableTable, SortableColumn, SortSetting } from "../../components/sortabletable";
+import { SortSetting } from "../../components/sortabletable";
+import { SortedTable } from "../../components/sortedtable";
 import Visualization from "../../components/visualization";
 
 type DatabaseDetailsResponseMessage = cockroach.server.serverpb.DatabaseDetailsResponseMessage;
@@ -20,8 +21,9 @@ type TableStatsResponseMessage = cockroach.server.serverpb.TableStatsResponseMes
 
 // Constants used to store per-page sort settings in the redux UI store.
 const UI_DATABASE_TABLES_SORT_SETTING_KEY = "databaseDetails/sort_setting/tables";
-const UI_DATABASE_GRANTS_SORT_SETTING_KEY = "databaseDetails/sort_setting/grants";
 
+// TableInfo is a structure which contains basic information about a Table, as
+// computed from multiple backend queries.
 class TableInfo {
   constructor(
     public name: string,
@@ -31,104 +33,30 @@ class TableInfo {
   ) { };
 }
 
-/******************************
- *      TABLE COLUMN DEFINITION
- */
+// Specialization of generic SortedTable component:
+//   https://github.com/Microsoft/TypeScript/issues/3960
+//
+// The variable name must start with a capital letter or TSX will not recognize
+// it as a component.
+// tslint:disable-next-line:variable-name
+const DatabaseTableListSortedTable = SortedTable as new () => SortedTable<TableInfo>;
 
 /**
- * TablesTableColumn provides an enumeration value for each column in the tables table.
- */
-enum TablesTableColumn {
-  Name = 1,
-  NumColumns = 2,
-  NumIndices = 3,
-  LastModified = 4,
-  LastModifiedBy = 5,
-}
-
-/**
- * TablesColumnDescriptor is used to describe metadata about an individual column
- * in the Tables table.
- */
-interface TablesColumnDescriptor {
-  // Enumeration key to distinguish this column from others.
-  key: TablesTableColumn;
-  // Title string that should appear in the header column.
-  title: string;
-  // Function which generates the contents of an individual cell in this table.
-  cell: (tableInfo: TableInfo, id: string) => React.ReactNode;
-  // Function which returns a value that can be used to sort a collection of
-  // tables. This will be used to sort the table according to the data in
-  // this column.
-  sort?: (tableInfo: TableInfo) => any;
-  // className to be applied to the td elements
-  className?: string;
-}
-
-/**
- * tablesColumnDescriptors describes all columns that appear in the tables table.
- * Columns are displayed in the same order they do in this collection, from left
- * to right.
- */
-let tablesColumnDescriptors: TablesColumnDescriptor[] = [
-  {
-    key: TablesTableColumn.Name,
-    title: "Table Name",
-    cell: (tableInfo, id) => {
-      return <Link to={`databases/database/${id}/table/${tableInfo.name}`}>{tableInfo.name}</Link>;
-    } ,
-    sort: (tableInfo) => tableInfo.name,
-    className: "expand-link", // don't pad the td element to allow the link to expand
-  },
-  {
-    key: TablesTableColumn.NumColumns,
-    title: "# of Columns",
-    cell: (tableInfo, id) => tableInfo.numColumns,
-    sort: (tableInfo) => tableInfo.numColumns,
-  },
-  {
-    key: TablesTableColumn.NumIndices,
-    title: "# of Indices",
-    cell: (tableInfo, id) => tableInfo.numIndices,
-    sort: (tableInfo) => tableInfo.numIndices,
-  },
-  {
-    key: TablesTableColumn.LastModified,
-    title: "Last Modified",
-    cell: (tableInfo, id) => "", // TODO (maxlang): Pending #8246
-    sort: _.identity,
-  },
-  {
-    key: TablesTableColumn.LastModifiedBy,
-    title: "Last Modified By",
-    cell: (tableInfo, id) => "", // TODO (maxlang): Pending #8246
-    sort: _.identity,
-  },
-];
-
-/******************************
- *   DATABASE MAIN COMPONENT
- */
-
-/**
- * DatabaseMainData are the data properties which should be passed to the DatabaseMain
+ * DatabaseDetailsData are the data properties which should be passed to the DatabaseDetails
  * container.
  */
-
-interface DatabaseMainData {
-  // Current sort setting for the grant table. Incoming rows will already be sorted
-  // according to this setting.
+interface DatabaseDetailsData {
+  // Current sort setting for the table list.
   tablesSortSetting: SortSetting;
-  // A list of grants, which are possibly sorted according to
-  // sortSetting.
-  sortedTables: TableInfo[];
+  // A list of TableInfo for the tables in the selected database.
+  tableInfos: TableInfo[];
 }
 
 /**
- * DatabaseMainActions are the action dispatchers which should be passed to the
- * DatabaseMain container.
+ * DatabaseDetailsActions are the action dispatchers which should be passed to the
+ * DatabaseDetails container.
  */
-interface DatabaseMainActions {
+interface DatabaseDetailsActions {
   // Call if the user indicates they wish to change the sort of the table data.
   setUISetting: typeof setUISetting;
   refreshDatabaseDetails: typeof refreshDatabaseDetails;
@@ -137,46 +65,24 @@ interface DatabaseMainActions {
 }
 
 /**
- * DatabaseMainProps is the type of the props object that must be passed to
- * DatabaseMain component.
+ * DatabaseDetailsProps is the type of the props object that must be passed to
+ * DatabaseDetails component.
  */
-type DatabaseMainProps = DatabaseMainData & DatabaseMainActions & IInjectedProps;
+type DatabaseDetailsProps = DatabaseDetailsData & DatabaseDetailsActions & IInjectedProps;
 
 /**
- * DatabaseMain renders the main content of the database details page, which is primarily a
- * data table of all tables and grants.
+ * DatabaseDetails renders the main content of the database details page.
  */
-class DatabaseMain extends React.Component<DatabaseMainProps, {}> {
-  /**
-   * tableColumns is a selector which computes the input Columns to the table table,
-   * based on the tableColumnDescriptors and the current sorted table data
-   */
-  tableColumns = createSelector(
-    (props: DatabaseMainProps) => props.sortedTables,
-    (tables: TableInfo[]) => {
-      return _.map(tablesColumnDescriptors, (cd): SortableColumn => {
-        return {
-          title: cd.title,
-          cell: (index) => cd.cell(tables[index], this.props.params[databaseNameAttr]),
-          sortKey: cd.sort ? cd.key : undefined,
-          className: cd.className,
-        };
-      });
-    });
-
+class DatabaseDetails extends React.Component<DatabaseDetailsProps, {}> {
   // Callback when the user elects to change the table table sort setting.
   changeTableSortSetting(setting: SortSetting) {
     this.props.setUISetting(UI_DATABASE_TABLES_SORT_SETTING_KEY, setting);
   }
 
-  // Callback when the user elects to change the grant table sort setting.
-  changeGrantSortSetting(setting: SortSetting) {
-    this.props.setUISetting(UI_DATABASE_GRANTS_SORT_SETTING_KEY, setting);
-  }
   // loadTableDetails loads data for each table with no info in the store.
   loadTableDetails(props = this.props) {
-    if (props.sortedTables.length) {
-      _.each(props.sortedTables, (tblInfo) => {
+    if (props.tableInfos.length) {
+      _.each(props.tableInfos, (tblInfo) => {
         if (_.isUndefined(tblInfo.numColumns)) {
           props.refreshTableDetails(new protos.cockroach.server.serverpb.TableDetailsRequest({
             database: props.params[databaseNameAttr],
@@ -199,16 +105,17 @@ class DatabaseMain extends React.Component<DatabaseMainProps, {}> {
     this.loadTableDetails();
   }
 
-  componentWillReceiveProps(props: DatabaseMainProps) {
+  componentWillReceiveProps(props: DatabaseDetailsProps) {
     this.loadTableDetails(props);
   }
 
   render() {
-    let { sortedTables, tablesSortSetting } = this.props;
+    let { tableInfos, tablesSortSetting } = this.props;
+    let dbID = this.props.params[databaseNameAttr];
 
-    let numTables = this.props.sortedTables.length;
+    let numTables = this.props.tableInfos.length;
 
-    if (sortedTables) {
+    if (tableInfos) {
       return <div className="sql-table">
                 <div className="table-stats small half">
           <Visualization
@@ -221,7 +128,7 @@ class DatabaseMain extends React.Component<DatabaseMainProps, {}> {
           <Visualization title="Database Size" tooltip="Not yet implemented.">
             <div className="visualization">
               <div style={{ zoom: "40%" }} className="number">
-                { Bytes(_.reduce(sortedTables, (memo, t) => memo + t.size, 0)) }
+                { Bytes(_.reduce(tableInfos, (memo, t) => memo + t.size, 0)) }
               </div>
             </div>
           </Visualization>
@@ -236,10 +143,40 @@ class DatabaseMain extends React.Component<DatabaseMainProps, {}> {
             </div>
           </Visualization>
         </div>
-          <SortableTable count={sortedTables.length}
+          <DatabaseTableListSortedTable
+            data={tableInfos}
             sortSetting={tablesSortSetting}
             onChangeSortSetting={(setting) => this.changeTableSortSetting(setting) }
-            columns={ this.tableColumns(this.props) }/>
+            columns={[
+            {
+              title: "Table Name",
+              cell: (tableInfo) => {
+                return <Link to={`databases/database/${dbID}/table/${tableInfo.name}`}>{tableInfo.name}</Link>;
+              },
+              sort: (tableInfo) => tableInfo.name,
+              className: "expand-link", // don't pad the td element to allow the link to expand
+            },
+            {
+              title: "# of Columns",
+              cell: (tableInfo) => tableInfo.numColumns,
+              sort: (tableInfo) => tableInfo.numColumns,
+            },
+            {
+              title: "# of Indices",
+              cell: (tableInfo) => tableInfo.numIndices,
+              sort: (tableInfo) => tableInfo.numIndices,
+            },
+            {
+              title: "Last Modified",
+              cell: (tableInfo) => "", // TODO (maxlang): Pending #8246
+              sort: _.identity,
+            },
+            {
+              title: "Last Modified By",
+              cell: (tableInfo) => "", // TODO (maxlang): Pending #8246
+              sort: _.identity,
+            },
+            ]}/>
         </div>;
     }
     return <div>No results.</div>;
@@ -260,11 +197,8 @@ function databaseDetails(state: AdminUIState, props: IInjectedProps): DatabaseDe
 let tables = (state: AdminUIState, props: IInjectedProps): string[] => databaseDetails(state, props) ? databaseDetails(state, props).table_names : [];
 let tablesSortSetting = (state: AdminUIState): SortSetting => state.ui[UI_DATABASE_TABLES_SORT_SETTING_KEY] || {};
 
-// Selectors which sorts statuses according to current sort setting.
-let tablesSortFunctionLookup = _(tablesColumnDescriptors).keyBy("key").mapValues<(s: TableInfo) => any>("sort").value();
-
 // Selector which generates the table rows as a TableInfo[].
-let tableInfo = createSelector(
+let tableInfos = createSelector(
   (dummy: {}, props: IInjectedProps) => props.params[databaseNameAttr],
   tables,
   (state: AdminUIState) => state.cachedData.tableDetails,
@@ -285,24 +219,11 @@ let tableInfo = createSelector(
     }
 );
 
-// Selector which generates the sorted table rows as a TableInfo[].
-let sortedTables = createSelector(
-  tableInfo,
-  tablesSortSetting,
-  (t: TableInfo[], sort: SortSetting) => {
-    let sortFn = tablesSortFunctionLookup[sort.sortKey];
-    if (sort && sortFn) {
-      return _.orderBy(t, sortFn, sort.ascending ? "asc" : "desc");
-    } else {
-      return t;
-    }
-  });
-
-// Connect the DatabaseMain class with our redux store.
-let databaseMainConnected = connect(
+// Connect the DatabaseDetails class with our redux store.
+let databaseDetailsConnected = connect(
   (state: AdminUIState, ownProps: IInjectedProps) => {
     return {
-      sortedTables: sortedTables(state, ownProps),
+      tableInfos: tableInfos(state, ownProps),
       tablesSortSetting: tablesSortSetting(state),
     };
   },
@@ -312,6 +233,6 @@ let databaseMainConnected = connect(
     refreshTableDetails,
     refreshTableStats,
   }
-)(DatabaseMain);
+)(DatabaseDetails);
 
-export default databaseMainConnected;
+export default databaseDetailsConnected;

--- a/ui/app/containers/databases/databaseGrants.tsx
+++ b/ui/app/containers/databases/databaseGrants.tsx
@@ -1,8 +1,6 @@
-import _ from "lodash";
 import * as React from "react";
 import { IInjectedProps } from "react-router";
 import { connect } from "react-redux";
-import { createSelector } from "reselect";
 
 import * as protos from "../../js/protos";
 import { databaseNameAttr, tableNameAttr } from "../../util/constants";
@@ -11,7 +9,8 @@ import { AdminUIState } from "../../redux/state";
 import { setUISetting } from "../../redux/ui";
 import { refreshDatabaseDetails, refreshTableDetails, generateTableID, CachedDataReducerState } from "../../redux/apiReducers";
 
-import { SortableTable, SortableColumn, SortSetting } from "../../components/sortabletable";
+import { SortSetting } from "../../components/sortabletable";
+import { SortedTable } from "../../components/sortedtable";
 
 type DatabaseDetailsResponseMessage = cockroach.server.serverpb.DatabaseDetailsResponseMessage;
 type TableDetailsResponseMessage = cockroach.server.serverpb.TableDetailsResponseMessage;
@@ -20,78 +19,30 @@ type Grant = cockroach.server.serverpb.DatabaseDetailsResponse.Grant | cockroach
 // Constants used to store per-page sort settings in the redux UI store.
 const UI_DATABASE_GRANTS_SORT_SETTING_KEY = "databaseDetails/sort_setting/grants";
 
-/******************************
- *      GRANT COLUMN DEFINITION
- */
+// Specialization of generic SortedTable component:
+//   https://github.com/Microsoft/TypeScript/issues/3960
+//
+// The variable name must start with a capital letter or TSX will not recognize
+// it as a component.
+// tslint:disable-next-line:variable-name
+const DatabaseGrantsSortedTable = SortedTable as new () => SortedTable<Grant>;
 
 /**
- * GrantsTableColumn provides an enumeration value for each column in the grants table.
- */
-enum GrantsTableColumn {
-  User = 1,
-  Grants,
-}
-
-/**
- * GrantsColumnDescriptor is used to describe metadata about an individual column
- * in the Grants table.
- */
-interface GrantsColumnDescriptor {
-  // Enumeration key to distinguish this column from others.
-  key: GrantsTableColumn;
-  // Title string that should appear in the header column.
-  title: string;
-  // Function which generates the contents of an individual cell in this table.
-  cell: (g: Grant) => React.ReactNode;
-  // Function which returns a value that can be used to sort a collection of
-  // Grants. This will be used to sort the table according to the data in
-  // this column.
-  sort?: (s: Grant) => string;
-}
-
-/**
- * grantsColumnDescriptors describes all columns that appear in the grants table.
- * Columns are displayed in the same order they do in this collection, from left
- * to right.
- */
-let grantsColumnDescriptors: GrantsColumnDescriptor[] = [
-  {
-    key: GrantsTableColumn.User,
-    title: "User",
-    cell: (grants) => grants.user,
-    sort: (grants) => grants.user,
-  },
-  {
-    key: GrantsTableColumn.Grants,
-    title: "Grants",
-    cell: (grants) => grants.privileges.join(", "),
-    sort: (grants) => grants.privileges.join(", "),
-  },
-];
-
-/******************************
- *   DATABASE MAIN COMPONENT
- */
-
-/**
- * DatabaseMainData are the data properties which should be passed to the DatabaseMain
+ * DatabaseGrantsData are the data properties which should be passed to the DatabaseGrants
  * container.
  */
-
-interface DatabaseMainData {
-  // Current sort setting for the grant table. Incoming rows will already be sorted
-  // according to this setting.
+interface DatabaseGrantsData {
+  // Current sort setting for the grant table.
   grantsSortSetting: SortSetting;
-  // A list of grants, which are possibly sorted according to
-  // sortSetting.
+  // A list of grants for the selected database.
   sortedGrants: Grant[];
 }
 
 /**
- * DatabaseMainActions are the action dispatchers which should be passed to the
- * DatabaseMain container.
+ * DatabaseGrantsActions are the action dispatchers which should be passed to the
+ * DatabaseGrants container.
  */
-interface DatabaseMainActions {
+interface DatabaseGrantsActions {
   // Call if the user indicates they wish to change the sort of the table data.
   setUISetting: typeof setUISetting;
   refreshDatabaseDetails: typeof refreshDatabaseDetails;
@@ -99,32 +50,15 @@ interface DatabaseMainActions {
 }
 
 /**
- * DatabaseMainProps is the type of the props object that must be passed to
- * DatabaseMain component.
+ * DatabaseGrantsProps is the type of the props object that must be passed to
+ * DatabaseGrants component.
  */
-type DatabaseMainProps = DatabaseMainData & DatabaseMainActions & IInjectedProps;
+type DatabaseGrantsProps = DatabaseGrantsData & DatabaseGrantsActions & IInjectedProps;
 
 /**
- * DatabaseMain renders the main content of the database details page, which is primarily a
- * data table of all tables and grants.
+ * DatabaseGrants renders the grants tabof the database details page.
  */
-class DatabaseMain extends React.Component<DatabaseMainProps, {}> {
-  /**
-   * grantColumns is a selector which computes the input Columns to the grants table,
-   * based on the tableColumnDescriptors and the current sorted table data
-   */
-  grantColumns = createSelector(
-    (props: DatabaseMainProps) => props.sortedGrants,
-    (grants: Grant[]) => {
-      return _.map(grantsColumnDescriptors, (cd): SortableColumn => {
-        return {
-          title: cd.title,
-          cell: (index) => cd.cell(grants[index]),
-          sortKey: cd.sort ? cd.key : undefined,
-        };
-      });
-    });
-
+class DatabaseGrants extends React.Component<DatabaseGrantsProps, {}> {
   // Callback when the user elects to change the grant table sort setting.
   changeGrantSortSetting(setting: SortSetting) {
     this.props.setUISetting(UI_DATABASE_GRANTS_SORT_SETTING_KEY, setting);
@@ -144,19 +78,27 @@ class DatabaseMain extends React.Component<DatabaseMainProps, {}> {
 
     if (sortedGrants) {
       return <div className="sql-table">
-          <SortableTable count={sortedGrants.length}
-            sortSetting={grantsSortSetting}
-            onChangeSortSetting={(setting) => this.changeGrantSortSetting(setting) }
-            columns={this.grantColumns(this.props) }/>
-        </div>;
+        <DatabaseGrantsSortedTable
+          data={sortedGrants}
+          sortSetting={grantsSortSetting}
+          onChangeSortSetting={(setting) => this.changeGrantSortSetting(setting) }
+          columns={[
+            {
+              title: "User",
+              cell: (grants) => grants.user,
+              sort: (grants) => grants.user,
+            },
+            {
+              title: "Grants",
+              cell: (grants) => grants.privileges.join(", "),
+              sort: (grants) => grants.privileges.join(", "),
+            },
+          ]}/>
+      </div>;
     }
     return <div>No results.</div>;
   }
 }
-
-/******************************
- *         SELECTORS
- */
 
 // Base selectors to extract data from redux state.
 function grants(state: AdminUIState, props: IInjectedProps): Grant[] {
@@ -170,27 +112,11 @@ function grants(state: AdminUIState, props: IInjectedProps): Grant[] {
 }
 let grantsSortSetting = (state: AdminUIState): SortSetting => state.ui[UI_DATABASE_GRANTS_SORT_SETTING_KEY] || {};
 
-// Selectors which sorts statuses according to current sort setting.
-let grantsSortFunctionLookup = _(grantsColumnDescriptors).keyBy("key").mapValues<(s: Grant) => any>("sort").value();
-
-// Sorted grants
-let sortedGrants = createSelector(
-  grants,
-  grantsSortSetting,
-  (g, sort) => {
-    let sortFn = grantsSortFunctionLookup[sort.sortKey];
-    if (sort && sortFn) {
-      return _.orderBy(g, sortFn, sort.ascending ? "asc" : "desc");
-    } else {
-      return g;
-    }
-  });
-
-// Connect the DatabaseMain class with our redux store.
-let databaseMainConnected = connect(
+// Connect the DatabaseGrants class with our redux store.
+let databaseGrantsConnected = connect(
   (state: AdminUIState, ownProps: IInjectedProps) => {
     return {
-      sortedGrants: sortedGrants(state, ownProps),
+      sortedGrants: grants(state, ownProps),
       grantsSortSetting: grantsSortSetting(state),
     };
   },
@@ -199,6 +125,6 @@ let databaseMainConnected = connect(
     refreshDatabaseDetails,
     refreshTableDetails,
   }
-)(DatabaseMain);
+)(DatabaseGrants);
 
-export default databaseMainConnected;
+export default databaseGrantsConnected;

--- a/ui/app/containers/databases/databaseList.tsx
+++ b/ui/app/containers/databases/databaseList.tsx
@@ -7,161 +7,74 @@ import { createSelector } from "reselect";
 import * as protos from "../../js/protos";
 import { AdminUIState } from "../../redux/state";
 import { setUISetting } from "../../redux/ui";
-import { refreshDatabases, refreshDatabaseDetails, refreshTableDetails, refreshEvents, KeyedCachedDataReducerState } from "../../redux/apiReducers";
-import { SortableTable, SortableColumn, SortSetting } from "../../components/sortabletable";
+import { refreshDatabases, refreshDatabaseDetails, KeyedCachedDataReducerState } from "../../redux/apiReducers";
+import { SortSetting } from "../../components/sortabletable";
+import { SortedTable } from "../../components/sortedtable";
 
 type DatabaseDetailsResponseMessage = cockroach.server.serverpb.DatabaseDetailsResponseMessage;
 
 // Constant used to store sort settings in the redux UI store.
 const UI_DATABASES_SORT_SETTING_KEY = "databaseList/sort_setting";
 
+// DatabaseInfo is a structure that aggregates information from multiple backend
+// queries regarding the same database.
 class DatabaseInfo {
   constructor(public name: string, public numTables: number) { };
 }
 
-/******************************
- *      COLUMN DEFINITION
- */
+// Specialization of generic SortedTable component:
+//   https://github.com/Microsoft/TypeScript/issues/3960
+//
+// The variable name must start with a capital letter or TSX will not recognize
+// it as a component.
+// tslint:disable-next-line:variable-name
+const DatabasesSortedTable = SortedTable as new () => SortedTable<DatabaseInfo>;
 
 /**
- * DatabasesTableColumn provides an enumeration value for each column in the databases table.
- */
-enum DatabasesTableColumn {
-  Name = 1,
-  NumTables = 2,
-  LastModified = 3,
-  EventsLink = 4,
-  ReplicationFactor = 5,
-  TargetRangeSize = 6,
-}
-
-/**
- * DatabasesColumnDescriptor is used to describe metadata about an individual column
- * in the Databases table.
- */
-interface DatabasesColumnDescriptor {
-  // Enumeration key to distinguish this column from others.
-  key: DatabasesTableColumn;
-  // Title string that should appear in the header column.
-  title: string;
-  // Function which generates the contents of an individual cell in this table.
-  cell: (s: DatabaseInfo) => React.ReactNode;
-  // Function which returns a value that can be used to sort a collection of
-  // databases. This will be used to sort the table according to the data in
-  // this column.
-  sort?: (s: DatabaseInfo) => any;
-  // className to be applied to the td elements
-  className?: string;
-}
-
-/**
- * columnDescriptors describes all columns that appear in the databases table.
- * Columns are displayed in the same order they do in this collection, from left
- * to right.
- */
-let columnDescriptors: DatabasesColumnDescriptor[] = [
-  {
-    key: DatabasesTableColumn.Name,
-    title: "Database Name",
-    cell: (dbInfo) => <Link to={`databases/database/${dbInfo.name}`}>{dbInfo.name}</Link>,
-    sort: (dbInfo) => dbInfo.name,
-    className: "expand-link", // don't pad the td element to allow the link to expand
-  },
-  {
-    key: DatabasesTableColumn.NumTables,
-    title: "# Of Tables",
-    cell: (dbInfo) => dbInfo.numTables,
-    sort: (dbInfo) => dbInfo.numTables,
-  },
-  {
-    key: DatabasesTableColumn.LastModified,
-    title: "Last Modified",
-    cell: (dbInfo) => "", // TODO (maxlang): Pending #8246
-  },
-  {
-    key: DatabasesTableColumn.EventsLink,
-    title: "Events",
-    cell: (dbInfo) => "", // TODO (maxlang): Pending #8246
-  },
-  {
-    key: DatabasesTableColumn.ReplicationFactor,
-    title: "Replication Factor",
-    cell: (dbInfo) => "", // TODO (maxlang): Pending #8248
-  },
-  {
-    key: DatabasesTableColumn.TargetRangeSize,
-    title: "Target Range Size",
-    cell: (dbInfo) => "", // TODO (maxlang): Pending #8248
-  },
-];
-
-/******************************
- *   DATABASES MAIN COMPONENT
- */
-
-/**
- * DatabasesMainData are the data properties which should be passed to the DatabasesMain
+ * DatabaseListData are the data properties which should be passed to the DatabaseList
  * container.
  */
-
-interface DatabasesMainData {
+interface DatabaseListData {
   // Current sort setting for the table. Incoming rows will already be sorted
   // according to this setting.
   sortSetting: SortSetting;
   // A list of databases, which are possibly sorted according to
   // sortSetting.
-  sortedDatabases: DatabaseInfo[];
+  databaseInfos: DatabaseInfo[];
 }
 
 /**
- * DatabasesMainActions are the action dispatchers which should be passed to the
- * DatabasesMain container.
+ * DatabaseListActions are the action dispatchers which should be passed to the
+ * DatabaseList container.
  */
-interface DatabasesMainActions {
+interface DatabaseListActions {
   // Call if the user indicates they wish to change the sort of the table data.
   setUISetting: typeof setUISetting;
-
   refreshDatabases: typeof refreshDatabases;
   refreshDatabaseDetails: typeof refreshDatabaseDetails;
 }
 
 /**
- * DatabasesMainProps is the type of the props object that must be passed to
- * DatabasesMain component.
+ * DatabaseListProps is the type of the props object that must be passed to
+ * DatabaseList component.
  */
-type DatabasesMainProps = DatabasesMainData & DatabasesMainActions & IInjectedProps;
+type DatabaseListProps = DatabaseListData & DatabaseListActions & IInjectedProps;
 
 /**
- * DatabasesMain renders the main content of the databases page, which is primarily a
+ * DatabaseList renders the main content of the databases page, which is primarily a
  * data table of all databases.
  */
-class DatabasesMain extends React.Component<DatabasesMainProps, {}> {
-  /**
-   * columns is a selector which computes the input Columns to our data table,
-   * based our columnDescriptors and the current sorted data
-   */
-  columns = createSelector(
-    (props: DatabasesMainProps) => props.sortedDatabases,
-    (databases: DatabaseInfo[]) => {
-      return _.map(columnDescriptors, (cd): SortableColumn => {
-        return {
-          title: cd.title,
-          cell: (index) => cd.cell(databases[index]),
-          sortKey: cd.sort ? cd.key : undefined,
-          className: cd.className,
-        };
-      });
-    });
-
+class DatabaseList extends React.Component<DatabaseListProps, {}> {
   // Callback when the user elects to change the sort setting.
   changeSortSetting(setting: SortSetting) {
     this.props.setUISetting(UI_DATABASES_SORT_SETTING_KEY, setting);
   }
 
-  // loadDatabaseDetails loads data for each database with no info in the store.
+  // loadDatabaseDetails loads detailed data for each database with no info in 
+  // the store.
   loadDatabaseDetails(props = this.props) {
-    if (props.sortedDatabases.length) {
-      _.each(props.sortedDatabases, (dbInfo) => {
+    if (props.databaseInfos.length) {
+      _.each(props.databaseInfos, (dbInfo) => {
         if (_.isUndefined(dbInfo.numTables)) {
           props.refreshDatabaseDetails(new protos.cockroach.server.serverpb.DatabaseDetailsRequest({
             database: dbInfo.name,
@@ -176,62 +89,73 @@ class DatabasesMain extends React.Component<DatabasesMainProps, {}> {
     this.loadDatabaseDetails();
   }
 
-  componentWillReceiveProps(props: DatabasesMainProps) {
+  componentWillReceiveProps(props: DatabaseListProps) {
     this.loadDatabaseDetails(props);
   }
 
   render() {
-    let { sortedDatabases: databases, sortSetting } = this.props;
+    let { databaseInfos, sortSetting } = this.props;
 
-    if (databases) {
+    if (databaseInfos) {
       return <div className="sql-table">
-        <SortableTable count={databases.length}
+        <DatabasesSortedTable
+          data={databaseInfos}
           sortSetting={sortSetting}
           onChangeSortSetting={(setting) => this.changeSortSetting(setting)}
-          columns={this.columns(this.props) } />
+          columns={[
+            {
+              title: "Database Name",
+              cell: (dbInfo) => <Link to={`databases/database/${dbInfo.name}`}>{dbInfo.name}</Link>,
+              sort: (dbInfo) => dbInfo.name,
+              className: "expand-link", // don't pad the td element to allow the link to expand
+            },
+            {
+              title: "# Of Tables",
+              cell: (dbInfo) => dbInfo.numTables,
+              sort: (dbInfo) => dbInfo.numTables,
+            },
+            {
+              title: "Last Modified",
+              cell: (dbInfo) => "", // TODO (maxlang): Pending #8246
+            },
+            {
+              title: "Events",
+              cell: (dbInfo) => "", // TODO (maxlang): Pending #8246
+            },
+            {
+              title: "Replication Factor",
+              cell: (dbInfo) => "", // TODO (maxlang): Pending #8248
+            },
+            {
+              title: "Target Range Size",
+              cell: (dbInfo) => "", // TODO (maxlang): Pending #8248
+            },
+          ]} />
       </div>;
     }
     return <div>No results.</div>;
   }
 }
 
-/******************************
- *         SELECTORS
- */
-
 // Base selectors to extract data from redux state.
 let databases = (state: AdminUIState): string[] => state.cachedData.databases.data  && state.cachedData.databases.data.databases;
-let sortSetting = (state: AdminUIState): SortSetting => state.ui[UI_DATABASES_SORT_SETTING_KEY] || {};
 let databaseDetails = (state: AdminUIState) => state.cachedData.databaseDetails;
-
-// Selector which sorts statuses according to current sort setting.
-let sortFunctionLookup = _(columnDescriptors).keyBy("key").mapValues<(s: DatabaseInfo) => any>("sort").value();
+let sortSetting = (state: AdminUIState): SortSetting => state.ui[UI_DATABASES_SORT_SETTING_KEY] || {};
 
 // Selector which generates the table rows as a DatabaseInfo[].
-let databaseInfo = createSelector(
+let databaseInfos = createSelector(
   databases,
   databaseDetails,
-  (dbs: string[], details: KeyedCachedDataReducerState<DatabaseDetailsResponseMessage>): DatabaseInfo[] => _.map(dbs, (db) => new DatabaseInfo(db, details[db] && details[db].data && details[db].data.table_names.length))
+  (dbs: string[], details: KeyedCachedDataReducerState<DatabaseDetailsResponseMessage>): DatabaseInfo[] => {
+    return _.map(dbs, (db) => new DatabaseInfo(db, details[db] && details[db].data && details[db].data.table_names.length));
+  }
 );
 
-// Selector which generates the sorted table rows as a DatabaseInfo[].
-let sortedDatabases = createSelector(
-  databaseInfo,
-  sortSetting,
-  (dbInfo: DatabaseInfo[], sort: SortSetting) => {
-    let sortFn = sortFunctionLookup[sort.sortKey];
-    if (sort && sortFn) {
-      return _.orderBy(dbInfo, sortFn, sort.ascending ? "asc" : "desc");
-    } else {
-      return dbInfo;
-    }
-  });
-
-// Connect the DatabasesMain class with our redux store.
-let databasesMainConnected = connect(
+// Connect the DatabaseList class with our redux store.
+let databaseListConnected = connect(
   (state: AdminUIState) => {
     return {
-      sortedDatabases: sortedDatabases(state),
+      databaseInfos: databaseInfos(state),
       sortSetting: sortSetting(state),
     };
   },
@@ -239,9 +163,7 @@ let databasesMainConnected = connect(
     setUISetting,
     refreshDatabases,
     refreshDatabaseDetails,
-    refreshTableDetails,
-    refreshEvents,
   }
-)(DatabasesMain);
+)(DatabaseList);
 
-export default databasesMainConnected;
+export default databaseListConnected;


### PR DESCRIPTION
Modifies existing Database details pages to use SortedTable component (instead
of using the simpler SortableTable). This decreases the amount of boilerplate on
these pages significantly.

Commit also cleans up some of the copy/paste artifacts that were present in
these components (apparently a legacy of being split into three parts from a
single component earlier).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8801)

<!-- Reviewable:end -->
