### PR TITLE
storage, ui: add metrics for raft messages

### DIFF
--- a/storage/replica.go
+++ b/storage/replica.go
@@ -319,6 +319,12 @@ type KeyRange interface {
 
 var _ KeyRange = &Replica{}
 
+type tickInfo struct {
+	Exists             bool
+	IsRangeLeaseHolder bool
+	IsRaftLeader       bool
+}
+
 // withRaftGroupLocked calls the supplied function with the (lazily
 // initialized) Raft group. It assumes that the Replica lock is held.
 func (r *Replica) withRaftGroupLocked(f func(r *raft.RawNode) error) error {
@@ -1536,6 +1542,24 @@ func defaultProposeRaftCommandLocked(r *Replica, p *pendingCmd) error {
 	})
 }
 
+func (r *Replica) isRangeLeaseHolderLocked() bool {
+	lease := r.mu.state.Lease
+	if lease == nil {
+		return false
+	}
+	timestamp := r.store.Clock().Now()
+	if lease.Covers(timestamp) {
+		if lease.OwnedBy(r.store.Ident.StoreID) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Replica) isRaftLeaderLocked() bool {
+	return r.mu.leaderID == r.mu.replicaID
+}
+
 func (r *Replica) handleRaftReady() error {
 	ctx := context.TODO()
 	var hasReady bool
@@ -1545,6 +1569,7 @@ func (r *Replica) handleRaftReady() error {
 	lastIndex := r.mu.lastIndex // used for append below
 	raftLogSize := r.mu.raftLogSize
 	leaderID := r.mu.leaderID
+
 	err := r.withRaftGroupLocked(func(raftGroup *raft.RawNode) error {
 		if hasReady = raftGroup.HasReady(); hasReady {
 			rd = raftGroup.Ready()
@@ -1736,16 +1761,20 @@ func (r *Replica) handleRaftReady() error {
 	})
 }
 
-// tick the Raft group, returning any error and true if the raft group exists
-// and false otherwise.
-func (r *Replica) tick() (bool, error) {
+// tick the Raft group, returning any error. tick() updates the tickInfo
+// struct.
+func (r *Replica) tick(info *tickInfo) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	info.IsRaftLeader = r.isRaftLeaderLocked()
+	info.IsRangeLeaseHolder = r.isRangeLeaseHolderLocked()
 
 	// If the raft group is uninitialized, do not initialize raft groups on
 	// tick.
 	if r.mu.internalRaftGroup == nil {
-		return false, nil
+		info.Exists = false
+		return nil
 	}
 
 	r.mu.ticks++
@@ -1760,10 +1789,12 @@ func (r *Replica) tick() (bool, error) {
 		// cycles.
 		if err := r.refreshPendingCmdsLocked(
 			reasonTicks, r.store.ctx.RaftElectionTimeoutTicks); err != nil {
-			return true, err
+			info.Exists = true
+			return err
 		}
 	}
-	return true, nil
+	info.Exists = true
+	return nil
 }
 
 // pendingCmdSlice sorts by increasing MaxLeaseIndex.
@@ -1871,6 +1902,16 @@ func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 			"failed to look up recipient replica %d in range %d while sending %s: %s", msg.To, rangeID, msg.Type, toErr)
 		return
 	}
+
+	r.store.ctx.Transport.mu.Lock()
+	var queuedMsgs int64
+	for _, transportQueues := range r.store.ctx.Transport.mu.queues {
+		for _, queue := range transportQueues {
+			queuedMsgs += int64(len(queue))
+		}
+	}
+	r.store.ctx.Transport.mu.Unlock()
+	r.store.metrics.RaftEnqueuedPending.Update(queuedMsgs)
 
 	if !r.store.ctx.Transport.SendAsync(&RaftMessageRequest{
 		RangeID:     rangeID,

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -6103,8 +6103,9 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		r.mu.Lock()
 		ticks := r.mu.ticks
 		r.mu.Unlock()
+		var info tickInfo
 		for ; (ticks % electionTicks) != 0; ticks++ {
-			if _, err := r.tick(); err != nil {
+			if err := r.tick(&info); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -6134,7 +6135,8 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		r.mu.Unlock()
 
 		// Tick raft.
-		if _, err := r.tick(); err != nil {
+		var info tickInfo
+		if err := r.tick(&info); err != nil {
 			t.Fatal(err)
 		}
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -2202,6 +2202,9 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 	}
 
 	addedPlaceholder := false
+
+	s.metrics.raftRcvdMessages[req.Message.Type].Inc(1)
+
 	switch req.Message.Type {
 	case raftpb.MsgSnap:
 		if earlyReturn := func() bool {
@@ -2540,6 +2543,7 @@ func (s *Store) processRaft() {
 			// replicas, clear all remaining placeholders.
 			s.clearAllPlaceholders()
 			s.processRaftMu.Unlock()
+
 			s.metrics.RaftWorkingDurationNanos.Inc(timeutil.Since(workingStart).Nanoseconds())
 
 			maybeWarnDuration(workingStart, s, "raft ready processing")
@@ -2568,14 +2572,33 @@ func (s *Store) processRaft() {
 				s.processRaftMu.Lock()
 				s.mu.Lock()
 				pendingReplicas = pendingReplicas[:0]
+				var raftLeaders, rangeLeaseHolders, rangeLeaseHoldersWithoutRaftLeadership int64
+
+				var info tickInfo
 				for id, r := range s.mu.replicas {
-					if exists, err := r.tick(); err != nil {
+					if err := r.tick(&info); err != nil {
 						log.Error(context.TODO(), err)
-					} else if exists {
+					} else if info.Exists {
 						pendingReplicas = append(pendingReplicas, id)
 					}
+					if info.IsRangeLeaseHolder && !info.IsRaftLeader {
+						rangeLeaseHoldersWithoutRaftLeadership++
+					}
+					if info.IsRaftLeader {
+						raftLeaders++
+					}
+					if info.IsRangeLeaseHolder {
+						rangeLeaseHolders++
+					}
 				}
+
 				s.mu.Unlock()
+
+				s.metrics.RaftLeaders.Update(raftLeaders)
+				s.metrics.RangeLeaseHolders.Update(rangeLeaseHolders)
+				s.metrics.RangeLeaseHoldersWithoutRaftLeadership.Update(rangeLeaseHoldersWithoutRaftLeadership)
+				s.metrics.RaftTicks.Inc(1)
+
 				// Enqueue all pending ranges for readiness checks. Note that we could
 				// not hold the pendingRaftGroups lock during the previous loop because
 				// of lock ordering constraints with r.tick().

--- a/ui/app/containers/nodeGraphs.tsx
+++ b/ui/app/containers/nodeGraphs.tsx
@@ -213,11 +213,47 @@ export default class extends React.Component<IInjectedProps, {}> {
 
             <StackedAreaGraph title="Raft Time" sources={sources}>
               <Axis label="Milliseconds" format={ (n) => d3.format(".1f")(NanoToMilli(n)) }>
-                <Metric name="cr.store.process-raft.waitingnanos" title="Waiting" nonNegativeRate />
-                <Metric name="cr.store.process-raft.workingnanos" title="Working" nonNegativeRate />
-                <Metric name="cr.store.process-raft.tickingnanos" title="Ticking" nonNegativeRate />
+                <Metric name="cr.store.raft.process.waitingnanos" title="Waiting" nonNegativeRate />
+                <Metric name="cr.store.raft.process.workingnanos" title="Working" nonNegativeRate />
+                <Metric name="cr.store.raft.process.tickingnanos" title="Ticking" nonNegativeRate />
               </Axis>
             </StackedAreaGraph>
+
+            <StackedAreaGraph title="Raft Messages received" sources={sources}>
+              <Axis label="Count" format={ d3.format(".1f") }>
+                <Metric name="cr.store.raft.rcvd.prop" title="MsgProp" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.app" title="MsgApp" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.appresp" title="MsgAppResp" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.vote" title="MsgVote" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.voteresp" title="MsgVoteResp" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.snap" title="MsgSnap" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.heartbeat" title="MsgHeartbeat" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.heartbeatresp" title="MsgHeartbeatResp" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.transferleader" title="MsgTransferLeader" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.timeoutnow" title="MsgTimeoutNow" nonNegativeRate />
+              </Axis>
+            </StackedAreaGraph>
+
+            <LineGraph title="Raft Transport Queue Pending Count" sources={sources}>
+              <Axis format={ d3.format(".1f") }>
+                <Metric name="cr.store.raft.enqueued.pending" title="Outstanding message count in the Raft Transport queue" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Raft Leaders and LeaseHolders" sources={sources}>
+              <Axis format={ d3.format(".1f") }>
+                <Metric name="cr.store.raft.leaders" title="Ranges on this Store that are Raft Leaders" />
+                <Metric name="cr.store.range.leaseholders" title="Ranges on this Store that are Raft LeaseHolders" />
+                <Metric name="cr.store.range.leaseholders.without.leadership" title="Ranges on this Store that are Raft LeaseHolders but aren't Raft Leaders" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Raft Ticks" sources={sources}>
+              <Axis format={ d3.format(".1f") }>
+                <Metric name="cr.store.raft.ticks" title="Raft Ticks" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
           </GraphGroup>
       </div>
     </div>;


### PR DESCRIPTION
Add additional metrics for raft messages to help in debugging: total
messages sent and received, transport queue length, dropped messages,
and ticks. Expose these metrics in the Admin UI, under the Nodes -> "Advanced
Internals" section. Closes #8645. cc @mberhault.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8803)

<!-- Reviewable:end -->
