### PR TITLE
ui: Set SampleNanos field on metrics queries

### DIFF
--- a/ui/app/containers/metricsDataProvider.spec.tsx
+++ b/ui/app/containers/metricsDataProvider.spec.tsx
@@ -7,7 +7,10 @@ import * as sinon from "sinon";
 
 import * as protos from  "../js/protos";
 import { TextGraph, Axis, Metric } from "../components/graphs";
-import { MetricsDataProviderUnconnected as MetricsDataProvider } from "./metricsDataProvider";
+import {
+  MetricsDataProviderUnconnected as MetricsDataProvider,
+  QueryTimeInfo,
+} from "./metricsDataProvider";
 import { TimeSeriesQueryAggregator, TimeSeriesQueryDerivative } from "../util/protoEnums";
 import { MetricsQuery } from "../redux/metrics";
 
@@ -15,9 +18,9 @@ type TSRequestMessage = cockroach.ts.tspb.TimeSeriesQueryRequestMessage;
 
 function makeDataProvider(id: string,
                           metrics: MetricsQuery,
-                          timeSpan: Long[],
+                          timeInfo: QueryTimeInfo,
                           queryMetrics: (id: string, request: TSRequestMessage) => void) {
-  return shallow(<MetricsDataProvider id={id} metrics={metrics} timeSpan={timeSpan} queryMetrics={queryMetrics}>
+  return shallow(<MetricsDataProvider id={id} metrics={metrics} timeInfo={timeInfo} queryMetrics={queryMetrics}>
     <TextGraph>
       <Axis>
         <Metric name="test.metric.1" />
@@ -30,10 +33,11 @@ function makeDataProvider(id: string,
   </MetricsDataProvider>);
 }
 
-function makeMetricsRequest(timeSpan: Long[], sources?: string[]) {
+function makeMetricsRequest(timeInfo: QueryTimeInfo, sources?: string[]) {
   return new protos.cockroach.ts.tspb.TimeSeriesQueryRequest({
-    start_nanos: timeSpan[0],
-    end_nanos: timeSpan[1],
+    start_nanos: timeInfo.start,
+    end_nanos: timeInfo.end,
+    sample_nanos: timeInfo.sampleDuration,
     queries: [
       {
         name: "test.metric.1",
@@ -60,7 +64,7 @@ function makeMetricsRequest(timeSpan: Long[], sources?: string[]) {
   });
 }
 
-function makeMetricsQuery(id: string, timeSpan: Long[], sources?: string[]): MetricsQuery {
+function makeMetricsQuery(id: string, timeSpan: QueryTimeInfo, sources?: string[]): MetricsQuery {
   let request = makeMetricsRequest(timeSpan, sources);
   let data = new protos.cockroach.ts.tspb.TimeSeriesQueryResponse({
     results: _(request.queries).map((q) => {
@@ -81,8 +85,16 @@ function makeMetricsQuery(id: string, timeSpan: Long[], sources?: string[]): Met
 
 describe("<MetricsDataProvider>", function() {
   let spy: sinon.SinonSpy;
-  let timespan1 = [Long.fromNumber(0), Long.fromNumber(100)];
-  let timespan2 = [Long.fromNumber(100), Long.fromNumber(200)];
+  let timespan1: QueryTimeInfo = {
+    start: Long.fromNumber(0),
+    end: Long.fromNumber(100),
+    sampleDuration: Long.fromNumber(300),
+  };
+  let timespan2: QueryTimeInfo = {
+    start: Long.fromNumber(100),
+    end: Long.fromNumber(200),
+    sampleDuration: Long.fromNumber(300),
+  };
   let graphid = "testgraph";
 
   beforeEach(function() {
@@ -123,7 +135,7 @@ describe("<MetricsDataProvider>", function() {
       let provider = makeDataProvider(graphid, makeMetricsQuery(graphid, timespan1), timespan1, spy);
       assert.isTrue(spy.notCalled);
       provider.setProps({
-        timeSpan: timespan2,
+        timeInfo: timespan2,
       });
       assert.isTrue(spy.called);
       assert.isTrue(spy.calledWith(graphid, makeMetricsRequest(timespan2)));
@@ -168,7 +180,7 @@ describe("<MetricsDataProvider>", function() {
         shallow(
           <MetricsDataProvider id="id"
                                metrics={null}
-                               timeSpan={timespan1}
+                               timeInfo={timespan1}
                                queryMetrics={spy}>
             <TextGraph>
               <Axis>

--- a/ui/app/redux/timewindow.spec.ts
+++ b/ui/app/redux/timewindow.spec.ts
@@ -23,15 +23,17 @@ describe("time window reducer", function() {
     it("should create the correct action to set time window settings", function() {
       let windowSize = moment.duration(10, "s");
       let windowValid = moment.duration(10, "s");
+      let sampleSize = moment.duration(10, "s");
       const expectedSetting = {
         type: timewindow.SET_SCALE,
         payload: {
           windowSize,
           windowValid,
+          sampleSize,
         },
       };
       assert.deepEqual(
-        timewindow.setTimeScale({ windowSize, windowValid }),
+        timewindow.setTimeScale({ windowSize, windowValid, sampleSize }),
         expectedSetting);
     });
   });
@@ -47,6 +49,7 @@ describe("time window reducer", function() {
         {
           windowSize: moment.duration(10, "m"),
           windowValid: moment.duration(10, "s"),
+          sampleSize: moment.duration(10, "s"),
         }
       );
     });
@@ -71,17 +74,20 @@ describe("time window reducer", function() {
     describe("setTimeWindowSettings", () => {
       let newSize = moment.duration(1, "h");
       let newValid = moment.duration(1, "m");
+      let newSample = moment.duration(1, "m");
       it("should correctly overwrite previous value", () => {
         let expected = new timewindow.TimeWindowState();
         expected.scale = {
           windowSize: newSize,
           windowValid: newValid,
+          sampleSize: newSample,
         };
         expected.scaleChanged = true;
         assert.deepEqual(
           reducer(undefined, timewindow.setTimeScale({
             windowSize: newSize,
             windowValid: newValid,
+            sampleSize: newSample,
           })),
           expected
         );

--- a/ui/app/redux/timewindow.ts
+++ b/ui/app/redux/timewindow.ts
@@ -31,6 +31,8 @@ export interface TimeScale {
   // is invalid if now > (currentWindow.end + windowValid). Default is ten
   // seconds.
   windowValid: moment.Duration;
+  // The expected duration of individual samples for queries at this time scale.
+  sampleSize: moment.Duration;
 }
 
 export interface TimeScaleCollection {
@@ -45,22 +47,37 @@ export let availableTimeScales: TimeScaleCollection = {
   "10 min": {
     windowSize: moment.duration(10, "minutes"),
     windowValid: moment.duration(10, "seconds"),
+    sampleSize: moment.duration(10, "seconds"),
   },
   "1 hour": {
     windowSize: moment.duration(1, "hour"),
     windowValid: moment.duration(1, "minute"),
+    sampleSize: moment.duration(1, "minutes"),
   },
   "6 hours": {
     windowSize: moment.duration(6, "hours"),
     windowValid: moment.duration(5, "minutes"),
+    sampleSize: moment.duration(5, "minutes"),
   },
   "12 hours": {
     windowSize: moment.duration(12, "hours"),
     windowValid: moment.duration(10, "minutes"),
+    sampleSize: moment.duration(10, "minutes"),
   },
   "1 day": {
     windowSize: moment.duration(1, "day"),
     windowValid: moment.duration(10, "minutes"),
+    sampleSize: moment.duration(30, "minutes"),
+  },
+  "1 week": {
+    windowSize: moment.duration(7, "days"),
+    windowValid: moment.duration(10, "minutes"),
+    sampleSize: moment.duration(1, "hour"),
+  },
+  "1 month": {
+    windowSize: moment.duration(1, "month"),
+    windowValid: moment.duration(20, "minutes"),
+    sampleSize: moment.duration(2, "hours"),
   },
 };
 


### PR DESCRIPTION
Commit begins setting the SampleNanos field on metrics queries for longer time
windows. This allows queries for longer durations (1 hour +) to complete in a
reasonable time; previously, the server was returning results with a ten-second
sample duration regardless of the length of the query, which resulted in graphs
charting an excessive number of datapoints.

Commit also adds two additional time windows, "1 week" and "1 month".

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8805)

<!-- Reviewable:end -->
