### PR TITLE
time series: Rename a few objects

### DIFF
--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -1539,14 +1539,14 @@ func writeRandomTimeSeriesDataToRange(
 			}
 			for k := int64(0); k <= src.Int63n(10); k++ {
 				d.Datapoints = append(d.Datapoints, tspb.TimeSeriesDatapoint{
-					TimestampNanos: src.Int63n(200) * r.KeyDuration(),
+					TimestampNanos: src.Int63n(200) * r.SlabDuration(),
 					Value:          src.Float64(),
 				})
 			}
 			data = append(data, d)
 		}
 		for _, d := range data {
-			idatas, err := d.ToInternal(r.KeyDuration(), r.SampleDuration())
+			idatas, err := d.ToInternal(r.SlabDuration(), r.SampleDuration())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1571,6 +1571,6 @@ func writeRandomTimeSeriesDataToRange(
 	}
 	// Return approximate midway point (100 is midway between random timestamps in range [0,200)).
 	midKey := append([]byte(nil), keyPrefix...)
-	midKey = encoding.EncodeVarintAscending(midKey, 100*r.KeyDuration())
+	midKey = encoding.EncodeVarintAscending(midKey, 100*r.SlabDuration())
 	return keys.MakeRowSentinelKey(midKey)
 }

--- a/ts/db.go
+++ b/ts/db.go
@@ -113,7 +113,7 @@ func (db *DB) StoreData(r Resolution, data []tspb.TimeSeriesData) error {
 	// Process data collection: data is converted to internal format, and a key
 	// is generated for each internal message.
 	for _, d := range data {
-		idatas, err := d.ToInternal(r.KeyDuration(), r.SampleDuration())
+		idatas, err := d.ToInternal(r.SlabDuration(), r.SampleDuration())
 		if err != nil {
 			return err
 		}

--- a/ts/db_test.go
+++ b/ts/db_test.go
@@ -165,7 +165,7 @@ func (tm *testModel) storeInModel(r Resolution, data tspb.TimeSeriesData) {
 	tm.seenSources[data.Source] = struct{}{}
 
 	// Process and store data in the model.
-	internalData, err := data.ToInternal(r.KeyDuration(), r.SampleDuration())
+	internalData, err := data.ToInternal(r.SlabDuration(), r.SampleDuration())
 	if err != nil {
 		tm.t.Fatalf("test could not convert time series to internal format: %s", err.Error())
 	}

--- a/ts/doc.go
+++ b/ts/doc.go
@@ -39,7 +39,7 @@ Time series data is organized on disk according to two basic, sortable propertie
 + Timestamp
 
 This is optimized for querying data for a single series over multiple
-timestamps: data for the same series with different timestamps is stored
+timestamps: data for the same series at different timestamps is stored
 contiguously.
 
 
@@ -60,14 +60,14 @@ multiple data points for a series fall in the same slot, only the most recent
 sample is kept.
 
 
-Key Space Slabbing
+Slab Storage
 
 In order to use key space efficiently, we pack data for multiple contiguous
 samples into "slab" values, with data for each slab stored in a CockroachDB key.
 This is done by again dividing time into contiguous slots, but with a longer
-duration; this is known as the "key duration". For example, CockroachDB downsamples
-its internal data at a resolution of 10 seconds, but stores it with a
-"key duration" of 1 hour, meaning that all samples that fall in the same hour
+duration; this is known as the "slab duration". For example, CockroachDB
+downsamples its internal data at a resolution of 10 seconds, but stores it with
+a "slab duration" of 1 hour, meaning that all samples that fall in the same hour
 are stored at the same key. This strategy helps reduce the number of keys
 scanned during a query.
 
@@ -104,13 +104,13 @@ year).
 
 A specific sample duration in CockroachDB is known as a Resolution. CockroachDB
 supports a fixed set of Resolutions; each Resolution has a fixed sample duration
-and a key duration. For example, the resolution "Resolution10s" has a sample
-duration of 10 seconds and a key duration of 1 hour.
+and a slab duration. For example, the resolution "Resolution10s" has a sample
+duration of 10 seconds and a slab duration of 1 hour.
 
 This feature was planned and slightly informs our key structure (resolution
 information is encoded in every time series key); however, all time series in
 CockroachDB are currently recorded at a downsample duration of 10 seconds, and a
-key duration of 1 hour.
+slab duration of 1 hour.
 
 
 Example

--- a/ts/keys.go
+++ b/ts/keys.go
@@ -64,7 +64,7 @@ import (
 // Resolution's KeyDuration.
 func MakeDataKey(name string, source string, r Resolution, timestamp int64) roachpb.Key {
 	// Normalize timestamp into a timeslot before recording.
-	timeslot := timestamp / r.KeyDuration()
+	timeslot := timestamp / r.SlabDuration()
 
 	k := append(roachpb.Key(nil), keys.TimeseriesPrefix...)
 	k = encoding.EncodeBytesAscending(k, []byte(name))
@@ -104,7 +104,7 @@ func decodeDataKeySuffix(key roachpb.Key) (string, string, Resolution, int64, er
 	if err != nil {
 		return "", "", 0, 0, err
 	}
-	timestamp := timeslot * resolution.KeyDuration()
+	timestamp := timeslot * resolution.SlabDuration()
 	// The remaining bytes are the source.
 	source := remainder
 

--- a/ts/keys_test.go
+++ b/ts/keys_test.go
@@ -73,7 +73,7 @@ func TestDataKeys(t *testing.T) {
 		// Normalize timestamp of test case; we expect MakeDataKey to
 		// automatically truncate it to an exact multiple of the Resolution's
 		// KeyDuration
-		tc.timestamp = (tc.timestamp / tc.resolution.KeyDuration()) * tc.resolution.KeyDuration()
+		tc.timestamp = (tc.timestamp / tc.resolution.SlabDuration()) * tc.resolution.SlabDuration()
 
 		d := tc
 		var err error

--- a/ts/query.go
+++ b/ts/query.go
@@ -484,41 +484,41 @@ func (ii *interpolatingIterator) value() float64 {
 	return prevAvg + (nextAvg-prevAvg)*(off-prevOff)/(nextOff-prevOff)
 }
 
-// A unionIterator jointly advances multiple interpolatingIterators, visiting
-// precisely those offsets for which at least one of the underlying
+// An aggregatingIterator jointly advances multiple interpolatingIterators,
+// visiting precisely those offsets for which at least one of the underlying
 // interpolating iterators has a real (that is, non-interpolated) value.
 //
 // All valid iterators in the set will have the same offset at all times. During
 // advancement, the next offset is chosen by finding the individual iterator
-// with the lowest value of nextReal.offset; in other words, the iteratorSet
-// will visit each possible offset in sequence, skipping offsets for which *no*
-// iterators have real data.  If even a single iterator has real data at an
-// offset, that offset will eventually be visited.
+// with the lowest value of nextReal.offset; in other words, the
+// aggregatingIterator will visit each possible offset in sequence, skipping
+// offsets for which *no* interpolatingIterators have real data.  If even a
+// single iterator has real data at an offset, that offset will eventually be
+// visited.
 //
-// In order to facilitate finding the lowest value of nextReal.offset, the set is
-// organized as a min heap using Go's heap package.
-//
-// TODO(mrtracy): Rename to aggregatingIterator
-type unionIterator []interpolatingIterator
+// In order to facilitate finding the interpolatingIterator with the lowest
+// underlying real offset, the set is organized as a min heap using Go's heap
+// package.
+type aggregatingIterator []interpolatingIterator
 
-// Len returns the length of the iteratorSet; needed by heap.Interface.
-func (is unionIterator) Len() int {
-	return len(is)
+// Len returns the length of the aggregatingIterator; needed by heap.Interface.
+func (ai aggregatingIterator) Len() int {
+	return len(ai)
 }
 
 // Swap swaps the values at the two given indices; needed by heap.Interface.
-func (is unionIterator) Swap(i, j int) {
-	is[i], is[j] = is[j], is[i]
+func (ai aggregatingIterator) Swap(i, j int) {
+	ai[i], ai[j] = ai[j], ai[i]
 }
 
 // Less determines if the iterator at the first supplied index in the
-// iteratorSet is "Less" than the iterator at the second index; need by
+// aggregatingIterator is "Less" than the iterator at the second index; need by
 // heap.Interface.
 //
-// An iterator is less than another if its nextReal iterator points to an
-// earlier offset.
-func (is unionIterator) Less(i, j int) bool {
-	thisNext, otherNext := is[i].nextReal, is[j].nextReal
+// An interpolatingIterator is considered "less" than another if its underlying
+// *real* offset points to an earlier offset.
+func (ai aggregatingIterator) Less(i, j int) bool {
+	thisNext, otherNext := ai[i].nextReal, ai[j].nextReal
 	if !(thisNext.isValid() || otherNext.isValid()) {
 		return false
 	}
@@ -531,108 +531,113 @@ func (is unionIterator) Less(i, j int) bool {
 	return thisNext.offset() < otherNext.offset()
 }
 
-// Push pushes an element into the iteratorSet heap; needed by heap.Interface
-func (is *unionIterator) Push(x interface{}) {
+// Push pushes an element into the aggregatingIterator heap; needed by
+// heap.Interface
+func (ai *aggregatingIterator) Push(x interface{}) {
 	// Push and Pop use pointer receivers because they modify the slice's length,
 	// not just its contents.
-	*is = append(*is, x.(interpolatingIterator))
+	*ai = append(*ai, x.(interpolatingIterator))
 }
 
-// Pop removes the minimum element from the iteratorSet heap; needed by
+// Pop removes the minimum element from the aggregatingIterator heap; needed by
 // heap.Interface.
-func (is *unionIterator) Pop() interface{} {
-	old := *is
+func (ai *aggregatingIterator) Pop() interface{} {
+	old := *ai
 	n := len(old)
 	x := old[n-1]
-	*is = old[0 : n-1]
+	*ai = old[0 : n-1]
 	return x
 }
 
 // isValid returns true if at least one iterator in the set is still valid. This
 // method only works if init() has already been called on the set.
-func (is unionIterator) isValid() bool {
-	return len(is) > 0 && is[0].isValid()
+func (ai aggregatingIterator) isValid() bool {
+	return len(ai) > 0 && ai[0].isValid()
 }
 
-// init initializes the iteratorSet. This method moves all iterators to the
-// first offset for which *any* iterator in the set has real data.
-func (is unionIterator) init() {
-	heap.Init(&is)
-	if !is.isValid() {
+// init initializes the aggregatingIterator. This method moves all component
+// iterators to the first offset for which *any* interpolatingIterator in the
+// set has *real* data.
+func (ai aggregatingIterator) init() {
+	heap.Init(&ai)
+	if !ai.isValid() {
 		return
 	}
-	if is[0].nextReal.offset() > 0 {
-		is.advance()
+	if ai[0].nextReal.offset() > 0 {
+		ai.advance()
 	}
 }
 
 // advance advances each iterator in the set to the next value for which *any*
 // interpolatingIterator has a real value.
-func (is unionIterator) advance() {
-	if !is.isValid() {
+func (ai aggregatingIterator) advance() {
+	if !ai.isValid() {
 		return
 	}
 
 	// All iterators in the set currently point to the same offset. Advancement
 	// begins by pre-advancing any iterators that have a real value for the
 	// current offset.
-	current := is[0].offset
-	for is[0].offset == current {
-		is[0].advanceTo(current + 1)
-		heap.Fix(&is, 0)
+	current := ai[0].offset
+	for ai[0].offset == current {
+		ai[0].advanceTo(current + 1)
+		heap.Fix(&ai, 0)
 	}
 
 	// It is possible that all iterators are now invalid.
-	if !is.isValid() {
+	if !ai.isValid() {
 		return
 	}
 
 	// The iterator in position zero now has the lowest value for
 	// nextReal.offset - advance all iterators to that offset.
-	min := is[0].nextReal.offset()
-	for i := range is {
-		is[i].advanceTo(min)
+	min := ai[0].nextReal.offset()
+	for i := range ai {
+		ai[i].advanceTo(min)
 	}
-	heap.Init(&is)
+	heap.Init(&ai)
 }
 
-// timestamp returns a timestamp for the current offset of the iterators in this
-// set. Offsets are converted into timestamps before returning them as part of a
-// query result.
-func (is unionIterator) timestamp() int64 {
-	if !is.isValid() {
+// timestamp returns a timestamp for the current offset of the
+// aggregatingIterator. Offsets should be converted into timestamps before
+// returning them as part of a query result.
+func (ai aggregatingIterator) timestamp() int64 {
+	if !ai.isValid() {
 		return 0
 	}
-	return is[0].midTimestamp()
+	return ai[0].midTimestamp()
 }
 
 // offset returns the current offset of the iterator.
-func (is unionIterator) offset() int32 {
-	if !is.isValid() {
+func (ai aggregatingIterator) offset() int32 {
+	if !ai.isValid() {
 		return 0
 	}
-	return is[0].offset
+	return ai[0].offset
 }
 
-// sum returns the sum of the current values in the iterator.
-func (is unionIterator) sum() float64 {
+// sum returns the sum of the current values of the interpolatingIterators being
+// aggregated.
+func (ai aggregatingIterator) sum() float64 {
 	var sum float64
-	for i := range is {
-		sum = sum + is[i].value()
+	for i := range ai {
+		sum = sum + ai[i].value()
 	}
 	return sum
 }
 
-// avg returns the average of the current values in the iterator.
-func (is unionIterator) avg() float64 {
-	return is.sum() / float64(len(is))
+// avg returns the average of the current values of the interpolatingIterators
+// being aggregated.
+func (ai aggregatingIterator) avg() float64 {
+	return ai.sum() / float64(len(ai))
 }
 
-// max return the maximum value of the current values in the iterator.
-func (is unionIterator) max() float64 {
-	max := is[0].value()
-	for i := range is[1:] {
-		val := is[i+1].value()
+// max return the maximum value of the current values of the
+// interpolatingIterators being aggregated.
+func (ai aggregatingIterator) max() float64 {
+	max := ai[0].value()
+	for i := range ai[1:] {
+		val := ai[i+1].value()
 		if val > max {
 			max = val
 		}
@@ -640,11 +645,12 @@ func (is unionIterator) max() float64 {
 	return max
 }
 
-// min return the minimum value of the current values in the iterator.
-func (is unionIterator) min() float64 {
-	min := is[0].value()
-	for i := range is[1:] {
-		val := is[i+1].value()
+// min return the minimum value of the current values of the
+// interpolatingIterators being aggregated.
+func (ai aggregatingIterator) min() float64 {
+	min := ai[0].value()
+	for i := range ai[1:] {
+		val := ai[i+1].value()
 		if val < min {
 			min = val
 		}
@@ -712,7 +718,7 @@ func (db *DB) Query(
 		b := &client.Batch{}
 		// Iterate over all key timestamps which may contain data for the given
 		// sources, based on the given start/end time and the resolution.
-		kd := queryResolution.KeyDuration()
+		kd := queryResolution.SlabDuration()
 		startKeyNanos := startNanos - (startNanos % kd)
 		endKeyNanos := endNanos - (endNanos % kd)
 		for currentTimestamp := startKeyNanos; currentTimestamp <= endKeyNanos; currentTimestamp += kd {
@@ -763,10 +769,10 @@ func (db *DB) Query(
 	}
 
 	// Create an interpolatingIterator for each dataSpan, adding each iterator
-	// into a unionIterator collection. This is also where we compute a list of
-	// all sources with data present in the query.
+	// into a aggregatingIterator collection. This is also where we compute a
+	// list of all sources with data present in the query.
 	sources := make([]string, 0, len(sourceSpans))
-	iters := make(unionIterator, 0, len(sourceSpans))
+	iters := make(aggregatingIterator, 0, len(sourceSpans))
 	for name, span := range sourceSpans {
 		sources = append(sources, name)
 		iters = append(iters, newInterpolatingIterator(
@@ -775,7 +781,7 @@ func (db *DB) Query(
 	}
 
 	// Choose an aggregation function to use when taking values from the
-	// unionIterator.
+	// aggregatingIterator.
 	var valueFn func() float64
 	switch query.GetSourceAggregator() {
 	case tspb.TimeSeriesQueryAggregator_SUM:
@@ -789,8 +795,9 @@ func (db *DB) Query(
 	}
 
 	// Iterate over all requested offsets, recording a value from the
-	// unionIterator at each offset encountered. If the query is requesting a
-	// derivative, a rate of change is recorded instead of the actual values.
+	// aggregatingIterator at each offset encountered. If the query is
+	// requesting a derivative, a rate of change is recorded instead of the
+	// actual values.
 	iters.init()
 	var last tspb.TimeSeriesDatapoint
 	if isDerivative {

--- a/ts/query_test.go
+++ b/ts/query_test.go
@@ -572,29 +572,29 @@ func TestAggregation(t *testing.T) {
 
 	testCases := []struct {
 		expected []float64
-		aggFunc  func(ui unionIterator) float64
+		aggFunc  func(ui aggregatingIterator) float64
 	}{
 		{
 			[]float64{4.4, 12, 17.5, 35, 40, 80, 56},
-			func(ui unionIterator) float64 {
+			func(ui aggregatingIterator) float64 {
 				return ui.sum()
 			},
 		},
 		{
 			[]float64{3.4, 7, 10, 25, 20, 40, 56},
-			func(ui unionIterator) float64 {
+			func(ui aggregatingIterator) float64 {
 				return ui.max()
 			},
 		},
 		{
 			[]float64{1, 5, 7.5, 10, 20, 40, 0},
-			func(ui unionIterator) float64 {
+			func(ui aggregatingIterator) float64 {
 				return ui.min()
 			},
 		},
 		{
 			[]float64{2.2, 6, 8.75, 17.5, 20, 40, 28},
-			func(ui unionIterator) float64 {
+			func(ui aggregatingIterator) float64 {
 				return ui.avg()
 			},
 		},
@@ -605,7 +605,7 @@ func TestAggregation(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		actual := make([]float64, 0, len(tc.expected))
-		iters := unionIterator{
+		iters := aggregatingIterator{
 			newInterpolatingIterator(dataSpan1, 0, 10, extractFn, downsampleSum),
 			newInterpolatingIterator(dataSpan2, 0, 10, extractFn, downsampleSum),
 		}
@@ -671,7 +671,7 @@ func (tm *testModel) assertQuery(
 	// Iterate over all possible sources which may have data for this query.
 	for sourceName := range sourcesToCheck {
 		// Iterate over all possible key times at which query data may be present.
-		for time := start - (start % r.KeyDuration()); time < end; time += r.KeyDuration() {
+		for time := start - (start % r.SlabDuration()); time < end; time += r.SlabDuration() {
 			// Construct a key for this source/time and retrieve it from model.
 			key := MakeDataKey(name, sourceName, r, time)
 			value, ok := tm.modelData[string(key)]
@@ -713,7 +713,7 @@ func (tm *testModel) assertQuery(
 	if err != nil {
 		tm.t.Fatal(err)
 	}
-	var iters unionIterator
+	var iters aggregatingIterator
 	for _, ds := range dataSpans {
 		iters = append(iters, newInterpolatingIterator(*ds, startOffset, sampleDuration, extractFn, downsampleFn))
 	}

--- a/ts/resolution.go
+++ b/ts/resolution.go
@@ -53,11 +53,11 @@ var sampleDurationByResolution = map[Resolution]int64{
 	resolution1ns: 1, // 1ns resolution only for tests.
 }
 
-// keyDurationByResolution is a map used to retrieve the key duration
-// corresponding to a Resolution value; the key duration determines how many
-// samples are stored at a single Cockroach key. Sample durations are expressed
-// in nanoseconds.
-var keyDurationByResolution = map[Resolution]int64{
+// slabDurationByResolution is a map used to retrieve the slab duration
+// corresponding to a Resolution value; the slab duration determines how many
+// samples are stored at a single Cockroach key/value. Slab durations are
+// expressed in nanoseconds.
+var slabDurationByResolution = map[Resolution]int64{
 	Resolution10s: int64(time.Hour),
 	resolution1ns: 10, // 1ns resolution only for tests.
 }
@@ -72,11 +72,11 @@ func (r Resolution) SampleDuration() int64 {
 	return duration
 }
 
-// KeyDuration returns the sample duration corresponding to this resolution
-// value, expressed in nanoseconds. The key duration determines how many samples
-// are stored at a single Cockroach key.
-func (r Resolution) KeyDuration() int64 {
-	duration, ok := keyDurationByResolution[r]
+// SlabDuration returns the slab duration corresponding to this resolution
+// value, expressed in nanoseconds. The slab duration determines how many
+// consecutive samples are stored in a single Cockroach key/value.
+func (r Resolution) SlabDuration() int64 {
+	duration, ok := slabDurationByResolution[r]
 	if !ok {
 		panic(fmt.Sprintf("no key duration found for resolution value %v", r))
 	}

--- a/ts/timeseries_test.go
+++ b/ts/timeseries_test.go
@@ -158,7 +158,7 @@ func TestDiscardEarlierSamples(t *testing.T) {
 		tsdp(5*time.Hour+5*time.Minute, -1.0),
 		tsdp(5*time.Hour+5*time.Minute, -2.0),
 	)
-	internal, err := ts.ToInternal(Resolution10s.KeyDuration(), Resolution10s.SampleDuration())
+	internal, err := ts.ToInternal(Resolution10s.SlabDuration(), Resolution10s.SampleDuration())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
A few quality-of-life renames in the time series package:
- unionIterator -> aggregatingIterator
- KeyDuration() -> SlabDuration()

Both of these should serve to reduce confusion going forward, as more features
are added to the time series system.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8809)

<!-- Reviewable:end -->
