### PR TITLE
sql: use timestamps for consistent, retryable multi-txn backups

### DIFF
--- a/cli/backup.go
+++ b/cli/backup.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/sql"
 	"github.com/cockroachdb/cockroach/sql/parser"
+	"github.com/cockroachdb/cockroach/util/hlc"
 )
 
 type backupContext struct {
@@ -52,7 +53,7 @@ func runBackup(cmd *cobra.Command, args []string) error {
 	kvDB, stopper := makeDBClient()
 	defer stopper.Stop()
 
-	desc, err := sql.Backup(ctx, *kvDB, base)
+	desc, err := sql.Backup(ctx, *kvDB, base, hlc.NewClock(hlc.UnixNano).Now())
 	if err != nil {
 		return err
 	}

--- a/sql/backup_test.go
+++ b/sql/backup_test.go
@@ -187,7 +187,7 @@ func TestBackupRestore(t *testing.T) {
 
 		_ = setupBackupRestoreDB(t, ctx, tc, count, backupRestoreDefaultRanges)
 
-		desc, err := sql.Backup(ctx, *kvDB, dir)
+		desc, err := sql.Backup(ctx, *kvDB, dir, tc.Server(0).Clock().Now())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -319,7 +319,7 @@ func TestBackupRestoreBank(t *testing.T) {
 	for i := 0; i < backupRestoreIterations; i++ {
 		dir := filepath.Join(baseDir, strconv.Itoa(i))
 
-		_, err := sql.Backup(ctx, *kvDB, dir)
+		_, err := sql.Backup(ctx, *kvDB, dir, tc.Server(0).Clock().Now())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -385,7 +385,7 @@ func runBenchmarkClusterBackup(b *testing.B, clusterSize int, count int) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		desc, err := sql.Backup(ctx, *kvDB, dir)
+		desc, err := sql.Backup(ctx, *kvDB, dir, tc.Server(0).Clock().Now())
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -412,7 +412,7 @@ func runBenchmarkClusterRestore(b *testing.B, clusterSize int, count int) {
 	dir, cleanupFn := testingTempDir(b, 1)
 	defer cleanupFn()
 
-	desc, err := sql.Backup(ctx, *kvDB, dir)
+	desc, err := sql.Backup(ctx, *kvDB, dir, tc.Server(0).Clock().Now())
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
Using logic similar to AS OF SYSTEM TIME, allow the creation of multiple
transactions that will remain consistent because their timestamps cannot
advance. Enable retries of each operation. In the future the fetch loop
could be made to work in parallel, but would need some mechanism to
limit the number of reads at once.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8819)

<!-- Reviewable:end -->
