### PR TITLE
*: reformat according to STYLE.md

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,5 +1,6 @@
 cmd github.com/client9/misspell/cmd/misspell
 cmd github.com/cockroachdb/c-protobuf/cmd/protoc
+cmd github.com/cockroachdb/crlfmt
 cmd github.com/cockroachdb/cockroach/cmd/protoc-gen-gogoroach
 cmd github.com/cockroachdb/stress
 cmd github.com/cockroachdb/yacc
@@ -41,6 +42,7 @@ github.com/cockroachdb/c-rocksdb b5ca031b93fde49bfa2ba99aba423136aebf3c06
 github.com/cockroachdb/c-snappy d4e7b428fe7fc09e93573df3448567a62df8c9fa
 github.com/cockroachdb/cmux b64f5908f4945f4b11ed4a0a9d3cc1e23350866d
 github.com/cockroachdb/cockroach-go 31611c0501c812f437d4861d87d117053967c955
+github.com/cockroachdb/crlfmt 26a764d2a61998361ca51fa19e4b0d119a0892b2
 github.com/cockroachdb/pq 44a6473ebbc26e3af09fe57bbdf761475c2c9f7c
 github.com/cockroachdb/stress 029c9348806514969d1109a6ae36e521af411ca7
 github.com/cockroachdb/yacc 7c99dfd2164a5d23c3f495ffc2e0b72b6379d066

--- a/acceptance/allocator_test.go
+++ b/acceptance/allocator_test.go
@@ -222,10 +222,7 @@ func (at *allocatorTest) stdDev() (float64, error) {
 
 // printStats prints the time it took for rebalancing to finish and the final
 // standard deviation of replica counts across stores.
-func (at *allocatorTest) printRebalanceStats(
-	db *gosql.DB,
-	host string,
-) error {
+func (at *allocatorTest) printRebalanceStats(db *gosql.DB, host string) error {
 	// TODO(cuongdo): Output these in a machine-friendly way and graph.
 
 	// Output time it took to rebalance.

--- a/acceptance/cluster/docker.go
+++ b/acceptance/cluster/docker.go
@@ -307,8 +307,11 @@ type resilientDockerClient struct {
 }
 
 func (cli resilientDockerClient) ContainerCreate(
-	ctx context.Context, config *container.Config, hostConfig *container.HostConfig,
-	networkingConfig *network.NetworkingConfig, containerName string,
+	ctx context.Context,
+	config *container.Config,
+	hostConfig *container.HostConfig,
+	networkingConfig *network.NetworkingConfig,
+	containerName string,
 ) (types.ContainerCreateResponse, error) {
 	response, err := cli.APIClient.ContainerCreate(ctx, config, hostConfig, networkingConfig, containerName)
 	if err != nil && strings.Contains(err.Error(), "already in use") {
@@ -352,7 +355,9 @@ func (cli resilientDockerClient) ContainerCreate(
 	return response, err
 }
 
-func (cli resilientDockerClient) ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error {
+func (cli resilientDockerClient) ContainerRemove(
+	ctx context.Context, container string, options types.ContainerRemoveOptions,
+) error {
 	err := cli.APIClient.ContainerRemove(ctx, container, options)
 
 	if os.Getenv("CIRCLECI") == "true" {
@@ -429,14 +434,18 @@ func (cli retryingDockerClient) ContainerCreate(
 	return ret, err
 }
 
-func (cli retryingDockerClient) ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error {
+func (cli retryingDockerClient) ContainerStart(
+	ctx context.Context, container string, options types.ContainerStartOptions,
+) error {
 	return retry(ctx, cli.attempts, cli.timeout, "ContainerStart", matchNone,
 		func(timeoutCtx context.Context) error {
 			return cli.resilientDockerClient.ContainerStart(timeoutCtx, container, options)
 		})
 }
 
-func (cli retryingDockerClient) ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error {
+func (cli retryingDockerClient) ContainerRemove(
+	ctx context.Context, container string, options types.ContainerRemoveOptions,
+) error {
 	return retry(ctx, cli.attempts, cli.timeout, "ContainerRemove", "No such container",
 		func(timeoutCtx context.Context) error {
 			return cli.resilientDockerClient.ContainerRemove(timeoutCtx, container, options)

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -155,7 +155,9 @@ type LocalCluster struct {
 // CreateLocal creates a new local cockroach cluster. The stopper is used to
 // gracefully shutdown the channel (e.g. when a signal arrives). The cluster
 // must be started before being used.
-func CreateLocal(cfg TestConfig, logDir string, privileged bool, stopper chan struct{}) *LocalCluster {
+func CreateLocal(
+	cfg TestConfig, logDir string, privileged bool, stopper chan struct{},
+) *LocalCluster {
 	select {
 	case <-stopper:
 		// The stopper was already closed, exit early.

--- a/acceptance/freeze_test.go
+++ b/acceptance/freeze_test.go
@@ -41,7 +41,9 @@ func TestFreezeCluster(t *testing.T) {
 	runTestOnConfigs(t, testFreezeClusterInner)
 }
 
-func postFreeze(c cluster.Cluster, freeze bool, timeout time.Duration) (serverpb.ClusterFreezeResponse, error) {
+func postFreeze(
+	c cluster.Cluster, freeze bool, timeout time.Duration,
+) (serverpb.ClusterFreezeResponse, error) {
 	httpClient := cluster.HTTPClient
 	httpClient.Timeout = timeout
 

--- a/acceptance/partition.go
+++ b/acceptance/partition.go
@@ -28,9 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/log"
 )
 
-func mustGetHosts(t *testing.T, c cluster.Cluster) (
-	[]iptables.IP, map[iptables.IP]int,
-) {
+func mustGetHosts(t *testing.T, c cluster.Cluster) ([]iptables.IP, map[iptables.IP]int) {
 	var addrs []iptables.IP
 	addrsToNode := make(map[iptables.IP]int)
 	for i := 0; i < c.NumNodes(); i++ {

--- a/acceptance/reference_test.go
+++ b/acceptance/reference_test.go
@@ -23,10 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/acceptance/cluster"
 )
 
-func runReferenceTestWithScript(
-	t *testing.T,
-	script string,
-) {
+func runReferenceTestWithScript(t *testing.T, script string) {
 	if err := testDockerOneShot(t, "reference", []string{"stat", cluster.CockroachBinaryInContainer}); err != nil {
 		t.Skipf(`TODO(dt): No binary in one-shot container, see #6086: %s`, err)
 	}
@@ -36,11 +33,7 @@ func runReferenceTestWithScript(
 	}
 }
 
-func runReadWriteReferenceTest(
-	t *testing.T,
-	referenceBinPath string,
-	backwardReferenceTest string,
-) {
+func runReadWriteReferenceTest(t *testing.T, referenceBinPath string, backwardReferenceTest string) {
 	referenceTestScript := fmt.Sprintf(`
 set -xe
 mkdir /old

--- a/acceptance/status_server_test.go
+++ b/acceptance/status_server_test.go
@@ -73,7 +73,9 @@ func get(t *testing.T, base, rel string) []byte {
 // checkNode checks all the endpoints of the status server hosted by node and
 // requests info for the node with otherNodeID. That node could be the same
 // other node, the same node or "local".
-func checkNode(t *testing.T, c cluster.Cluster, i int, nodeID, otherNodeID, expectedNodeID roachpb.NodeID) {
+func checkNode(
+	t *testing.T, c cluster.Cluster, i int, nodeID, otherNodeID, expectedNodeID roachpb.NodeID,
+) {
 	urlIDs := []string{otherNodeID.String()}
 	if nodeID == otherNodeID {
 		urlIDs = append(urlIDs, "local")

--- a/build/check-style.sh
+++ b/build/check-style.sh
@@ -171,6 +171,10 @@ TestStaticcheck() {
   staticcheck ./...
 }
 
+TestCrlfmt() {
+  crlfmt -ignore 'pb.*.go' -tab 2 .
+}
+
 # Run all the tests, wrapped in a similar output format to "go test"
 # so we can use go2xunit to generate reports in CI.
 

--- a/cli/sql_util.go
+++ b/cli/sql_util.go
@@ -229,9 +229,7 @@ func runQuery(conn *sqlConn, fn queryFunc, pretty bool) ([]string, [][]string, s
 
 // runQueryAndFormatResults takes a 'query' with optional 'parameters'.
 // It runs the sql query and writes output to 'w'.
-func runQueryAndFormatResults(
-	conn *sqlConn, w io.Writer, fn queryFunc, pretty bool,
-) error {
+func runQueryAndFormatResults(conn *sqlConn, w io.Writer, fn queryFunc, pretty bool) error {
 	for {
 		cols, allRows, result, err := runQuery(conn, fn, pretty)
 		if err != nil {
@@ -311,9 +309,7 @@ func expandTabsAndNewLines(s string) string {
 
 // printQueryOutput takes a list of column names and a list of row contents
 // writes a pretty table to 'w', or "OK" if empty.
-func printQueryOutput(
-	w io.Writer, cols []string, allRows [][]string, tag string, pretty bool,
-) {
+func printQueryOutput(w io.Writer, cols []string, allRows [][]string, tag string, pretty bool) {
 	if len(cols) == 0 {
 		// This operation did not return rows, just show the tag.
 		fmt.Fprintln(w, tag)
@@ -359,9 +355,7 @@ func isNotGraphicUnicodeOrTabOrNewline(r rune) bool {
 	return r != '\t' && r != '\n' && !unicode.IsGraphic(r)
 }
 
-func formatVal(
-	val driver.Value, showPrintableUnicode bool, showNewLinesAndTabs bool,
-) string {
+func formatVal(val driver.Value, showPrintableUnicode bool, showNewLinesAndTabs bool) string {
 	switch t := val.(type) {
 	case nil:
 		return "NULL"

--- a/cmd/gossipsim/main.go
+++ b/cmd/gossipsim/main.go
@@ -145,7 +145,9 @@ func (em edgeMap) addEdge(nodeID roachpb.NodeID, e edge) {
 // Returns the name of the output file and a boolean for whether or not
 // the network has quiesced (that is, no new edges, and all nodes are
 // connected).
-func outputDotFile(dotFN string, cycle int, network *simulation.Network, edgeSet map[string]edge) (string, bool) {
+func outputDotFile(
+	dotFN string, cycle int, network *simulation.Network, edgeSet map[string]edge,
+) (string, bool) {
 	f, err := os.Create(dotFN)
 	if err != nil {
 		log.Fatalf(context.TODO(), "unable to create temp file: %s", err)

--- a/gossip/client.go
+++ b/gossip/client.go
@@ -265,7 +265,13 @@ func (c *client) handleResponse(g *Gossip, reply *Response) error {
 // gossip loops, sending deltas of the infostore and receiving deltas
 // in turn. If an alternate is proposed on response, the client addr
 // is modified and method returns for forwarding by caller.
-func (c *client) gossip(ctx context.Context, g *Gossip, stream Gossip_GossipClient, stopper *stop.Stopper, wg *sync.WaitGroup) error {
+func (c *client) gossip(
+	ctx context.Context,
+	g *Gossip,
+	stream Gossip_GossipClient,
+	stopper *stop.Stopper,
+	wg *sync.WaitGroup,
+) error {
 	sendGossipChan := make(chan struct{}, 1)
 
 	// Register a callback for gossip updates.

--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -40,11 +40,19 @@ import (
 )
 
 // startGossip creates and starts a gossip instance.
-func startGossip(nodeID roachpb.NodeID, stopper *stop.Stopper, t *testing.T, registry *metric.Registry) *Gossip {
+func startGossip(
+	nodeID roachpb.NodeID, stopper *stop.Stopper, t *testing.T, registry *metric.Registry,
+) *Gossip {
 	return startGossipAtAddr(nodeID, util.IsolatedTestAddr, stopper, t, registry)
 }
 
-func startGossipAtAddr(nodeID roachpb.NodeID, addr net.Addr, stopper *stop.Stopper, t *testing.T, registry *metric.Registry) *Gossip {
+func startGossipAtAddr(
+	nodeID roachpb.NodeID,
+	addr net.Addr,
+	stopper *stop.Stopper,
+	t *testing.T,
+	registry *metric.Registry,
+) *Gossip {
 	rpcContext := rpc.NewContext(context.TODO(), &base.Context{Insecure: true}, nil, stopper)
 
 	server := rpc.NewServer(rpcContext)
@@ -128,7 +136,13 @@ func startFakeServerGossips(t *testing.T) (*Gossip, *fakeGossipServer, *stop.Sto
 	return local, remote, stopper
 }
 
-func gossipSucceedsSoon(t *testing.T, stopper *stop.Stopper, disconnected chan *client, gossip map[*client]*Gossip, f func() error) {
+func gossipSucceedsSoon(
+	t *testing.T,
+	stopper *stop.Stopper,
+	disconnected chan *client,
+	gossip map[*client]*Gossip,
+	f func() error,
+) {
 	// Use an insecure context since we don't need a valid cert.
 	rpcContext := rpc.NewContext(context.TODO(), &base.Context{Insecure: true}, nil, stopper)
 

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -321,7 +321,9 @@ func (is *infoStore) visitInfos(visitInfo func(string, *Info) error) error {
 // All hop distances on infos are incremented to indicate they've
 // arrived from an external source. Returns the count of "fresh"
 // infos in the provided delta.
-func (is *infoStore) combine(infos map[string]*Info, nodeID roachpb.NodeID) (freshCount int, err error) {
+func (is *infoStore) combine(
+	infos map[string]*Info, nodeID roachpb.NodeID,
+) (freshCount int, err error) {
 	for key, i := range infos {
 		infoCopy := *i
 		infoCopy.Hops++

--- a/gossip/server.go
+++ b/gossip/server.go
@@ -187,7 +187,9 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 	}
 }
 
-func (s *server) gossipReceiver(argsPtr **Request, senderFn func(*Response) error, receiverFn func() (*Request, error)) error {
+func (s *server) gossipReceiver(
+	argsPtr **Request, senderFn func(*Response) error, receiverFn func() (*Request, error),
+) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -103,7 +103,9 @@ func (ss *notifyingSender) reset(notify chan struct{}) {
 	ss.notify = notify
 }
 
-func (ss *notifyingSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+func (ss *notifyingSender) Send(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error) {
 	br, pErr := ss.wrapped.Send(ctx, ba)
 	if br != nil && br.Error != nil {
 		panic(roachpb.ErrorUnexpectedlySet(ss.wrapped, br))
@@ -122,10 +124,7 @@ func createTestClient(t *testing.T, stopper *stop.Stopper, addr string) *client.
 }
 
 func createTestClientForUser(
-	t *testing.T,
-	stopper *stop.Stopper,
-	addr, user string,
-	dbCtx client.DBContext,
+	t *testing.T, stopper *stop.Stopper, addr, user string, dbCtx client.DBContext,
 ) *client.DB {
 	rpcContext := rpc.NewContext(context.TODO(), &base.Context{
 		User:       user,
@@ -142,7 +141,9 @@ func createTestClientForUser(
 
 // createTestNotifyClient creates a new client which connects using an HTTP
 // sender to the server at addr. It contains a waitgroup to allow waiting.
-func createTestNotifyClient(t *testing.T, stopper *stop.Stopper, addr string, priority roachpb.UserPriority) (*client.DB, *notifyingSender) {
+func createTestNotifyClient(
+	t *testing.T, stopper *stop.Stopper, addr string, priority roachpb.UserPriority,
+) (*client.DB, *notifyingSender) {
 	db := createTestClient(t, stopper, addr)
 	sender := &notifyingSender{wrapped: db.GetSender()}
 	dbCtx := client.DefaultDBContext()

--- a/internal/client/db.go
+++ b/internal/client/db.go
@@ -379,7 +379,9 @@ func (db *DB) AdminSplit(ctx context.Context, splitKey interface{}) error {
 // applied the new lease, but that's about it. It's not guaranteed that the new
 // lease holder has applied it (so it might not know immediately that it is the
 // new lease holder).
-func (db *DB) AdminTransferLease(ctx context.Context, key interface{}, target roachpb.StoreID) error {
+func (db *DB) AdminTransferLease(
+	ctx context.Context, key interface{}, target roachpb.StoreID,
+) error {
 	b := &Batch{}
 	b.adminTransferLease(key, target)
 	return getOneErr(db.Run(ctx, b), b)
@@ -398,8 +400,7 @@ func (db *DB) CheckConsistency(ctx context.Context, begin, end interface{}, with
 // returning the appropriate error which is either from the first failing call,
 // or an "internal" error.
 func sendAndFill(
-	send func(roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error),
-	b *Batch,
+	send func(roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error), b *Batch,
 ) error {
 	// Errors here will be attached to the results, so we will get them from
 	// the call to fillResults in the regular case in which an individual call

--- a/internal/client/rpc_sender.go
+++ b/internal/client/rpc_sender.go
@@ -41,7 +41,9 @@ func NewSender(ctx *rpc.Context, target string) (Sender, error) {
 }
 
 // Send implements the Sender interface.
-func (s sender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+func (s sender) Send(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error) {
 	br, err := s.Batch(ctx, &ba, grpc.FailFast(false))
 	if err != nil {
 		return nil, roachpb.NewError(errors.Wrap(err, "roachpb.Batch RPC failed"))

--- a/internal/client/sender.go
+++ b/internal/client/sender.go
@@ -33,7 +33,9 @@ type Sender interface {
 type SenderFunc func(context.Context, roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)
 
 // Send calls f(ctx, c).
-func (f SenderFunc) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+func (f SenderFunc) Send(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error) {
 	return f(ctx, ba)
 }
 
@@ -65,7 +67,9 @@ func SendWrappedWith(
 // SendWrapped is identical to SendWrappedWith with a zero header.
 // TODO(tschottdorf): should move this to testutils and merge with
 // other helpers which are used, for example, in `storage`.
-func SendWrapped(sender Sender, ctx context.Context, args roachpb.Request) (roachpb.Response, *roachpb.Error) {
+func SendWrapped(
+	sender Sender, ctx context.Context, args roachpb.Request,
+) (roachpb.Response, *roachpb.Error) {
 	return SendWrappedWith(sender, ctx, roachpb.Header{}, args)
 }
 

--- a/internal/client/txn.go
+++ b/internal/client/txn.go
@@ -465,10 +465,7 @@ func (e *AutoCommitError) Error() string {
 // to clean up the transaction before returning an error. In case of
 // TransactionAbortedError, txn is reset to a fresh transaction, ready to be
 // used.
-func (txn *Txn) Exec(
-	opt TxnExecOptions,
-	fn func(txn *Txn, opt *TxnExecOptions) error,
-) (err error) {
+func (txn *Txn) Exec(opt TxnExecOptions, fn func(txn *Txn, opt *TxnExecOptions) error) (err error) {
 	// Run fn in a retry loop until we encounter a success or
 	// error condition this loop isn't capable of handling.
 	var retryOptions retry.Options

--- a/internal/client/txn_test.go
+++ b/internal/client/txn_test.go
@@ -41,7 +41,9 @@ var (
 
 // TestSender mocks out some of the txn coordinator sender's
 // functionality. It responds to PutRequests using testPutResp.
-func newTestSender(pre, post func(roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)) SenderFunc {
+func newTestSender(
+	pre, post func(roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error),
+) SenderFunc {
 	txnID := uuid.NewV4()
 
 	return func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -104,7 +104,9 @@ func MakeRangeIDReplicatedKey(rangeID roachpb.RangeID, suffix, detail roachpb.RK
 
 // DecodeRangeIDKey parses a local range ID key into range ID, infix,
 // suffix, and detail.
-func DecodeRangeIDKey(key roachpb.Key) (rangeID roachpb.RangeID, infix, suffix, detail roachpb.Key, err error) {
+func DecodeRangeIDKey(
+	key roachpb.Key,
+) (rangeID roachpb.RangeID, infix, suffix, detail roachpb.Key, err error) {
 	if !bytes.HasPrefix(key, LocalRangeIDPrefix) {
 		return 0, nil, nil, nil, errors.Errorf("key %s does not have %s prefix", key, LocalRangeIDPrefix)
 	}
@@ -212,7 +214,9 @@ func MakeRangeIDUnreplicatedPrefix(rangeID roachpb.RangeID) roachpb.Key {
 
 // MakeRangeIDUnreplicatedKey creates a range-local unreplicated key based
 // on the range's Range ID, metadata key suffix, and optional detail.
-func MakeRangeIDUnreplicatedKey(rangeID roachpb.RangeID, suffix roachpb.RKey, detail roachpb.RKey) roachpb.Key {
+func MakeRangeIDUnreplicatedKey(
+	rangeID roachpb.RangeID, suffix roachpb.RKey, detail roachpb.RKey,
+) roachpb.Key {
 	if len(suffix) != localSuffixLength {
 		panic(fmt.Sprintf("suffix len(%q) != %d", suffix, localSuffixLength))
 	}

--- a/keys/printer.go
+++ b/keys/printer.go
@@ -638,11 +638,7 @@ func MassagePrettyPrintedSpanForTest(span string, dirs []encoding.Direction) str
 //    commonPrefix{remainingStart-remainingEnd}
 // It prints at most maxChars, truncating components as needed. See
 // TestPrettyPrintRange for some examples.
-func PrettyPrintRange(
-	b *bytes.Buffer,
-	start, end roachpb.Key,
-	maxChars int,
-) {
+func PrettyPrintRange(b *bytes.Buffer, start, end roachpb.Key, maxChars int) {
 	const ellipsis = '\u2026'
 	if maxChars < 8 {
 		maxChars = 8

--- a/kv/dist_sender.go
+++ b/kv/dist_sender.go
@@ -239,10 +239,7 @@ func NewDistSender(cfg *DistSenderConfig, g *gossip.Gossip) *DistSender {
 // retry logic here; this is not an issue since the lookup performs a
 // single inconsistent read only.
 func (ds *DistSender) RangeLookup(
-	ctx context.Context,
-	key roachpb.RKey,
-	desc *roachpb.RangeDescriptor,
-	useReverseScan bool,
+	ctx context.Context, key roachpb.RKey, desc *roachpb.RangeDescriptor, useReverseScan bool,
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
 	ba := roachpb.BatchRequest{}
 	ba.ReadConsistency = roachpb.INCONSISTENT
@@ -347,10 +344,7 @@ func (ds *DistSender) getNodeDescriptor() *roachpb.NodeDescriptor {
 // The replicas are assume to have been ordered by preference, closer ones (if
 // any) at the front.
 func (ds *DistSender) sendRPC(
-	ctx context.Context,
-	rangeID roachpb.RangeID,
-	replicas ReplicaSlice,
-	ba roachpb.BatchRequest,
+	ctx context.Context, rangeID roachpb.RangeID, replicas ReplicaSlice, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error) {
 	if len(replicas) == 0 {
 		return nil, noNodeAddrsAvailError{}
@@ -489,7 +483,9 @@ func (ds *DistSender) sendSingleRange(
 // request, thus opening up a window of time during which there may be intents
 // of a transaction, but no entry. Pushing such a transaction will succeed, and
 // may lead to the transaction being aborted early.
-func (ds *DistSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+func (ds *DistSender) Send(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error) {
 	tracing.AnnotateTrace()
 
 	// In the event that timestamp isn't set and read consistency isn't
@@ -610,7 +606,9 @@ func (ds *DistSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 // correspond to client.Sender with the exception of the returned boolean,
 // which is true when indicating that the caller should retry but needs to send
 // EndTransaction in a separate request.
-func (ds *DistSender) sendChunk(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error, bool) {
+func (ds *DistSender) sendChunk(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error, bool) {
 	isReverse := ba.IsReverse()
 
 	// TODO(radu): when contexts are properly plumbed, we should be able to get
@@ -1071,8 +1069,7 @@ func (ds *DistSender) handlePerReplicaError(rangeID roachpb.RangeID, pErr *roach
 
 // updateLeaseHolderCache updates the cached lease holder for the given range.
 func (ds *DistSender) updateLeaseHolderCache(
-	rangeID roachpb.RangeID,
-	newLeaseHolder roachpb.ReplicaDescriptor,
+	rangeID roachpb.RangeID, newLeaseHolder roachpb.ReplicaDescriptor,
 ) {
 	if log.V(1) {
 		if oldLeaseHolder, ok := ds.leaseHolderCache.Lookup(rangeID); ok {

--- a/kv/dist_sender_server_test.go
+++ b/kv/dist_sender_server_test.go
@@ -104,7 +104,9 @@ func setupMultipleRanges(
 var errInfo = testutils.MakeCaller(3, 2)
 
 // checks the keys returned from a Scan/ReverseScan.
-func checkSpanResults(t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int) {
+func checkSpanResults(
+	t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int,
+) {
 	if len(expResults) != len(results) {
 		t.Fatalf("only got %d results, wanted %d", len(expResults), len(results))
 	}
@@ -135,7 +137,9 @@ func checkSpanResults(t *testing.T, spans [][]string, results []client.Result, e
 }
 
 // checks ResumeSpan returned in a ScanResponse.
-func checkResumeSpanScanResults(t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int) {
+func checkResumeSpanScanResults(
+	t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int,
+) {
 	for i, res := range results {
 		rowLen := len(res.Rows)
 		// Check ResumeSpan when request has been processed.
@@ -167,7 +171,9 @@ func checkResumeSpanScanResults(t *testing.T, spans [][]string, results []client
 }
 
 // check ResumeSpan returned in a ReverseScanResponse.
-func checkResumeSpanReverseScanResults(t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int) {
+func checkResumeSpanReverseScanResults(
+	t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int,
+) {
 	for i, res := range results {
 		// Check ResumeSpan when request has been processed.
 		rowLen := len(res.Rows)
@@ -197,13 +203,17 @@ func checkResumeSpanReverseScanResults(t *testing.T, spans [][]string, results [
 }
 
 // check an entire scan result including the ResumeSpan.
-func checkScanResults(t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int) {
+func checkScanResults(
+	t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int,
+) {
 	checkSpanResults(t, spans, results, expResults, expCount)
 	checkResumeSpanScanResults(t, spans, results, expResults, expCount)
 }
 
 // check an entire reverse scan result including the ResumeSpan.
-func checkReverseScanResults(t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int) {
+func checkReverseScanResults(
+	t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int,
+) {
 	checkSpanResults(t, spans, results, expResults, expCount)
 	checkResumeSpanReverseScanResults(t, spans, results, expResults, expCount)
 }
@@ -420,7 +430,9 @@ func TestMultiRangeBoundedBatchScanSortedOverlapping(t *testing.T) {
 }
 
 // check ResumeSpan in the DelRange results.
-func checkResumeSpanDelRangeResults(t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int) {
+func checkResumeSpanDelRangeResults(
+	t *testing.T, spans [][]string, results []client.Result, expResults [][]string, expCount int,
+) {
 	for i, res := range results {
 		// Check ResumeSpan when request has been processed.
 		rowLen := len(res.Keys)

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -376,10 +376,7 @@ func TestSendRPCOrder(t *testing.T) {
 type MockRangeDescriptorDB func(roachpb.RKey, bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error)
 
 func (mdb MockRangeDescriptorDB) RangeLookup(
-	_ context.Context,
-	key roachpb.RKey,
-	_ *roachpb.RangeDescriptor,
-	useReverseScan bool,
+	_ context.Context, key roachpb.RKey, _ *roachpb.RangeDescriptor, useReverseScan bool,
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
 	return mdb(stripMeta(key), useReverseScan)
 }

--- a/kv/range_cache_test.go
+++ b/kv/range_cache_test.go
@@ -59,7 +59,9 @@ func (a testDescriptorNode) Compare(b llrb.Comparable) int {
 	return bytes.Compare(aKey, bKey)
 }
 
-func (db *testDescriptorDB) getDescriptors(key roachpb.RKey, useReverseScan bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
+func (db *testDescriptorDB) getDescriptors(
+	key roachpb.RKey, useReverseScan bool,
+) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
 	rs := make([]roachpb.RangeDescriptor, 0, 1)
 	preRs := make([]roachpb.RangeDescriptor, 0, 2)
 	for i := 0; i < 3; i++ {
@@ -108,10 +110,7 @@ func (db *testDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, error) {
 }
 
 func (db *testDescriptorDB) RangeLookup(
-	_ context.Context,
-	key roachpb.RKey,
-	_ *roachpb.RangeDescriptor,
-	useReverseScan bool,
+	_ context.Context, key roachpb.RKey, _ *roachpb.RangeDescriptor, useReverseScan bool,
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
 	<-db.pauseChan
 	atomic.AddInt64(&db.lookupCount, 1)
@@ -205,11 +204,15 @@ func (db *testDescriptorDB) assertLookupCount(t *testing.T, from, to int64, key 
 	db.lookupCount = 0
 }
 
-func doLookup(t *testing.T, rc *rangeDescriptorCache, key string) (*roachpb.RangeDescriptor, *evictionToken) {
+func doLookup(
+	t *testing.T, rc *rangeDescriptorCache, key string,
+) (*roachpb.RangeDescriptor, *evictionToken) {
 	return doLookupWithToken(t, rc, key, nil, false, nil)
 }
 
-func doLookupConsideringIntents(t *testing.T, rc *rangeDescriptorCache, key string) (*roachpb.RangeDescriptor, *evictionToken) {
+func doLookupConsideringIntents(
+	t *testing.T, rc *rangeDescriptorCache, key string,
+) (*roachpb.RangeDescriptor, *evictionToken) {
 	return doLookupWithToken(t, rc, key, nil, false, nil)
 }
 

--- a/kv/send_test.go
+++ b/kv/send_test.go
@@ -59,7 +59,9 @@ func newTestServer(t *testing.T, ctx *rpc.Context) (*grpc.Server, net.Listener) 
 
 type Node time.Duration
 
-func (n Node) Batch(ctx context.Context, args *roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
+func (n Node) Batch(
+	ctx context.Context, args *roachpb.BatchRequest,
+) (*roachpb.BatchResponse, error) {
 	if n > 0 {
 		time.Sleep(time.Duration(n))
 	}
@@ -559,7 +561,9 @@ func makeReplicas(addrs ...net.Addr) ReplicaSlice {
 }
 
 // sendBatch sends Batch requests to specified addresses using send.
-func sendBatch(opts SendOptions, addrs []net.Addr, rpcContext *rpc.Context) (*roachpb.BatchResponse, error) {
+func sendBatch(
+	opts SendOptions, addrs []net.Addr, rpcContext *rpc.Context,
+) (*roachpb.BatchResponse, error) {
 	ds := &DistSender{Ctx: context.Background()}
 	return ds.sendToReplicas(opts, 0, makeReplicas(addrs...), roachpb.BatchRequest{}, rpcContext)
 }

--- a/kv/split_test.go
+++ b/kv/split_test.go
@@ -44,8 +44,16 @@ import (
 // transactions, each which writes up to 10 times to random keys with
 // random values. If not nil, txnChannel is written to non-blockingly
 // every time a new transaction starts.
-func startTestWriter(db *client.DB, i int64, valBytes int32, wg *sync.WaitGroup, retries *int32,
-	txnChannel chan struct{}, done <-chan struct{}, t *testing.T) {
+func startTestWriter(
+	db *client.DB,
+	i int64,
+	valBytes int32,
+	wg *sync.WaitGroup,
+	retries *int32,
+	txnChannel chan struct{},
+	done <-chan struct{},
+	t *testing.T,
+) {
 	src := rand.New(rand.NewSource(i))
 	defer func() {
 		if wg != nil {

--- a/kv/transport.go
+++ b/kv/transport.go
@@ -104,10 +104,7 @@ type Transport interface {
 // During race builds, we wrap this to hold on to and read all obtained
 // requests in a tight loop, exposing data races; see transport_race.go.
 func grpcTransportFactoryImpl(
-	opts SendOptions,
-	rpcContext *rpc.Context,
-	replicas ReplicaSlice,
-	args roachpb.BatchRequest,
+	opts SendOptions, rpcContext *rpc.Context, replicas ReplicaSlice, args roachpb.BatchRequest,
 ) (Transport, error) {
 	clients := make([]batchClient, 0, len(replicas))
 	for _, replica := range replicas {

--- a/kv/transport_race.go
+++ b/kv/transport_race.go
@@ -56,10 +56,7 @@ func jitter(avgInterval time.Duration) time.Duration {
 // intercepts all BatchRequests, reading them in a tight loop. This allows the
 // race detector to catch any mutations of a batch passed to the transport.
 func grpcTransportFactory(
-	opts SendOptions,
-	rpcContext *rpc.Context,
-	replicas ReplicaSlice,
-	args roachpb.BatchRequest,
+	opts SendOptions, rpcContext *rpc.Context, replicas ReplicaSlice, args roachpb.BatchRequest,
 ) (Transport, error) {
 	if atomic.AddInt32(&running, 1) <= 1 {
 		rpcContext.Stopper.RunWorker(func() {

--- a/kv/transport_regular.go
+++ b/kv/transport_regular.go
@@ -25,10 +25,7 @@ import (
 )
 
 func grpcTransportFactory(
-	opts SendOptions,
-	rpcContext *rpc.Context,
-	replicas ReplicaSlice,
-	args roachpb.BatchRequest,
+	opts SendOptions, rpcContext *rpc.Context, replicas ReplicaSlice, args roachpb.BatchRequest,
 ) (Transport, error) {
 	return grpcTransportFactoryImpl(opts, rpcContext, replicas, args)
 }

--- a/kv/txn_coord_sender.go
+++ b/kv/txn_coord_sender.go
@@ -265,7 +265,9 @@ func (tc *TxnCoordSender) startStats() {
 // transaction's interval tree of key ranges for eventual cleanup via resolved
 // write intents; they're tagged to an outgoing EndTransaction request, with
 // the receiving replica in charge of resolving them.
-func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+func (tc *TxnCoordSender) Send(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error) {
 	// Start new or pick up active trace. From here on, there's always an active
 	// Trace, though its overhead is small unless it's sampled.
 	sp := opentracing.SpanFromContext(ctx)
@@ -455,8 +457,7 @@ func (tc *TxnCoordSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*r
 // state that prevents it from continuing, such as the coordinator having
 // considered the client abandoned, or a heartbeat having reported an error.
 func (tc *TxnCoordSender) maybeRejectClientLocked(
-	ctx context.Context,
-	txn roachpb.Transaction,
+	ctx context.Context, txn roachpb.Transaction,
 ) *roachpb.Error {
 
 	if !txn.Writing {
@@ -569,8 +570,9 @@ func (tc *TxnCoordSender) cleanupTxnLocked(ctx context.Context, txn roachpb.Tran
 // and collects its stats. It assumes the lock is held. Returns
 // the duration, restarts, finalized txn status, and whether the
 // transaction committed on the 1PC fast path.
-func (tc *TxnCoordSender) unregisterTxnLocked(txnID uuid.UUID) (
-	duration, restarts int64, status roachpb.TransactionStatus) {
+func (tc *TxnCoordSender) unregisterTxnLocked(
+	txnID uuid.UUID,
+) (duration, restarts int64, status roachpb.TransactionStatus) {
 	txnMeta := tc.txns[txnID] // guaranteed to exist
 	if txnMeta == nil {
 		panic(fmt.Sprintf("attempt to unregister non-existent transaction: %s", txnID))
@@ -950,7 +952,9 @@ func (tc *TxnCoordSender) updateState(
 // give this error back to the client, our options are limited. We'll have to
 // run the whole thing for them, or any restart will still end up at the client
 // which will not be prepared to be handed a Txn.
-func (tc *TxnCoordSender) resendWithTxn(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+func (tc *TxnCoordSender) resendWithTxn(
+	ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error) {
 	// Run a one-off transaction with that single command.
 	if log.V(1) {
 		log.Infof(tc.ctx, "%s: auto-wrapping in txn and re-executing: ", ba)
@@ -981,7 +985,9 @@ func (tc *TxnCoordSender) resendWithTxn(ba roachpb.BatchRequest) (*roachpb.Batch
 }
 
 // updateStats updates transaction metrics after a transaction finishes.
-func (tc *TxnCoordSender) updateStats(duration, restarts int64, status roachpb.TransactionStatus, onePC bool) {
+func (tc *TxnCoordSender) updateStats(
+	duration, restarts int64, status roachpb.TransactionStatus, onePC bool,
+) {
 	tc.metrics.Durations.RecordValue(duration)
 	tc.metrics.Restarts.RecordValue(restarts)
 	switch status {

--- a/kv/txn_coord_sender_test.go
+++ b/kv/txn_coord_sender_test.go
@@ -47,7 +47,9 @@ import (
 type senderFn func(context.Context, roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)
 
 // Send implements batch.Sender.
-func (f senderFn) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+func (f senderFn) Send(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error) {
 	return f(ctx, ba)
 }
 
@@ -1108,8 +1110,12 @@ func TestTxnCoordSenderNoDuplicateIntents(t *testing.T) {
 // checkTxnMetrics verifies that the provided Sender's transaction metrics match the expected
 // values. This is done through a series of retries with increasing backoffs, to work around
 // the TxnCoordSender's asynchronous updating of metrics after a transaction ends.
-func checkTxnMetrics(t *testing.T, sender *TxnCoordSender, name string,
-	commits, commits1PC, abandons, aborts, restarts int64) {
+func checkTxnMetrics(
+	t *testing.T,
+	sender *TxnCoordSender,
+	name string,
+	commits, commits1PC, abandons, aborts, restarts int64,
+) {
 	metrics := sender.metrics
 
 	util.SucceedsSoon(t, func() error {

--- a/kv/txn_correctness_test.go
+++ b/kv/txn_correctness_test.go
@@ -346,7 +346,9 @@ var (
 // isolation types across the transactions. The inner slice describes
 // the isolation type for each transaction. The outer slice contains
 // each possible combination of such transaction isolations.
-func enumerateIsolations(numTxns int, isolations []enginepb.IsolationType) [][]enginepb.IsolationType {
+func enumerateIsolations(
+	numTxns int, isolations []enginepb.IsolationType,
+) [][]enginepb.IsolationType {
 	// Use a count from 0 to pow(# isolations, numTxns)-1 and examine
 	// n-ary digits to get all possible combinations of txn isolations.
 	n := len(isolations)
@@ -639,7 +641,9 @@ type historyVerifier struct {
 	}
 }
 
-func newHistoryVerifier(name string, txns []string, verify *verifier, t *testing.T) *historyVerifier {
+func newHistoryVerifier(
+	name string, txns []string, verify *verifier, t *testing.T,
+) *historyVerifier {
 	return &historyVerifier{
 		name:           name,
 		txns:           parseHistories(txns, t),
@@ -680,8 +684,9 @@ func (hv *historyVerifier) run(isolations []enginepb.IsolationType, db *client.D
 // history.
 //
 // This process continues recursively if there are further retries.
-func (hv *historyVerifier) runHistoryWithRetry(priorities []int32,
-	isolations []enginepb.IsolationType, cmds []*cmd, db *client.DB, t *testing.T) error {
+func (hv *historyVerifier) runHistoryWithRetry(
+	priorities []int32, isolations []enginepb.IsolationType, cmds []*cmd, db *client.DB, t *testing.T,
+) error {
 	if err := hv.runHistory(priorities, isolations, cmds, db, t); err != nil {
 		if log.V(1) {
 			log.Infof(context.Background(), "got an error running history %s: %s", historyString(cmds), err)
@@ -713,8 +718,9 @@ func (hv *historyVerifier) runHistoryWithRetry(priorities []int32,
 	return nil
 }
 
-func (hv *historyVerifier) runHistory(priorities []int32,
-	isolations []enginepb.IsolationType, cmds []*cmd, db *client.DB, t *testing.T) error {
+func (hv *historyVerifier) runHistory(
+	priorities []int32, isolations []enginepb.IsolationType, cmds []*cmd, db *client.DB, t *testing.T,
+) error {
 	hv.idx++
 	if t.Failed() {
 		return errors.New("already failed")
@@ -788,7 +794,9 @@ func (hv *historyVerifier) runHistory(priorities []int32,
 	return err
 }
 
-func (hv *historyVerifier) runCmds(cmds []*cmd, db *client.DB, t *testing.T) (string, map[string]int64, error) {
+func (hv *historyVerifier) runCmds(
+	cmds []*cmd, db *client.DB, t *testing.T,
+) (string, map[string]int64, error) {
 	var strs []string
 	env := map[string]int64{}
 	err := db.Txn(context.TODO(), func(txn *client.Txn) error {
@@ -807,8 +815,14 @@ func (hv *historyVerifier) runCmds(cmds []*cmd, db *client.DB, t *testing.T) (st
 	return strings.Join(strs, " "), env, err
 }
 
-func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
-	isolation enginepb.IsolationType, cmds []*cmd, db *client.DB, t *testing.T) error {
+func (hv *historyVerifier) runTxn(
+	txnIdx int,
+	priority int32,
+	isolation enginepb.IsolationType,
+	cmds []*cmd,
+	db *client.DB,
+	t *testing.T,
+) error {
 	var retry int
 	txnName := fmt.Sprintf("txn %d", txnIdx+1)
 	cmdIdx := -1
@@ -856,7 +870,9 @@ func (hv *historyVerifier) runTxn(txnIdx int, priority int32,
 	return err
 }
 
-func (hv *historyVerifier) runCmd(txn *client.Txn, txnIdx, retry int, c *cmd, t *testing.T) (string, error) {
+func (hv *historyVerifier) runCmd(
+	txn *client.Txn, txnIdx, retry int, c *cmd, t *testing.T,
+) (string, error) {
 	fmtStr, err := c.execute(txn, t)
 	cmdStr := fmt.Sprintf(fmtStr, txnIdx+1, retry)
 	hv.mu.Lock()
@@ -868,11 +884,7 @@ func (hv *historyVerifier) runCmd(txn *client.Txn, txnIdx, retry int, c *cmd, t 
 // checkConcurrency creates a history verifier, starts a new database
 // and runs the verifier.
 func checkConcurrency(
-	name string,
-	isolations []enginepb.IsolationType,
-	txns []string,
-	verify *verifier,
-	t *testing.T,
+	name string, isolations []enginepb.IsolationType, txns []string, verify *verifier, t *testing.T,
 ) {
 	verifier := newHistoryVerifier(name, txns, verify, t)
 	dbCtx := client.DefaultDBContext()

--- a/roachpb/batch.go
+++ b/roachpb/batch.go
@@ -191,9 +191,7 @@ func (br *BatchResponse) String() string {
 // contained in the requests are used, but when a response contains a
 // ResumeSpan the ResumeSpan is subtracted from the request span to provide a
 // more minimal span of keys affected by the request.
-func (ba *BatchRequest) IntentSpanIterate(
-	br *BatchResponse, fn func(key, endKey Key),
-) {
+func (ba *BatchRequest) IntentSpanIterate(br *BatchResponse, fn func(key, endKey Key)) {
 	for i, arg := range ba.Requests {
 		req := arg.GetInner()
 		if !IsTransactionWrite(req) {

--- a/roachpb/data.go
+++ b/roachpb/data.go
@@ -636,8 +636,14 @@ func (v Value) PrettyPrint() string {
 // randomly chosen value to yield a final priority, used to settle
 // write conflicts in a way that avoids starvation of long-running
 // transactions (see Replica.PushTxn).
-func NewTransaction(name string, baseKey Key, userPriority UserPriority,
-	isolation enginepb.IsolationType, now hlc.Timestamp, maxOffset int64) *Transaction {
+func NewTransaction(
+	name string,
+	baseKey Key,
+	userPriority UserPriority,
+	isolation enginepb.IsolationType,
+	now hlc.Timestamp,
+	maxOffset int64,
+) *Transaction {
 	// Compute priority by adjusting based on userPriority factor.
 	priority := MakePriority(userPriority)
 	// Compute timestamp and max timestamp.
@@ -799,7 +805,9 @@ func TxnIDEqual(a, b *uuid.UUID) bool {
 // incremented for an in-place restart. The timestamp of the
 // transaction on restart is set to the maximum of the transaction's
 // timestamp and the specified timestamp.
-func (t *Transaction) Restart(userPriority UserPriority, upgradePriority int32, timestamp hlc.Timestamp) {
+func (t *Transaction) Restart(
+	userPriority UserPriority, upgradePriority int32, timestamp hlc.Timestamp,
+) {
 	t.Epoch++
 	if t.Timestamp.Less(timestamp) {
 		t.Timestamp = timestamp

--- a/roachpb/errors.go
+++ b/roachpb/errors.go
@@ -467,7 +467,9 @@ func (*WriteTooOldError) canRestartTransaction() TransactionRestart {
 // NewReadWithinUncertaintyIntervalError creates a new uncertainty retry error.
 // The read and existing timestamps are purely informational and used for
 // formatting the error message.
-func NewReadWithinUncertaintyIntervalError(readTS, existingTS hlc.Timestamp) *ReadWithinUncertaintyIntervalError {
+func NewReadWithinUncertaintyIntervalError(
+	readTS, existingTS hlc.Timestamp,
+) *ReadWithinUncertaintyIntervalError {
 	return &ReadWithinUncertaintyIntervalError{
 		ReadTimestamp:     readTS,
 		ExistingTimestamp: existingTS,

--- a/rpc/context.go
+++ b/rpc/context.go
@@ -343,7 +343,9 @@ func (ctx *Context) runHeartbeat(cc *grpc.ClientConn, remoteAddr string) error {
 	}
 }
 
-func (ctx *Context) heartbeat(heartbeatClient HeartbeatClient, request PingRequest) (*PingResponse, error) {
+func (ctx *Context) heartbeat(
+	heartbeatClient HeartbeatClient, request PingRequest,
+) (*PingResponse, error) {
 	goCtx, cancel := context.WithTimeout(context.Background(), ctx.HeartbeatTimeout)
 	defer cancel()
 	// NB: We want the request to fail-fast (the default), otherwise we won't be

--- a/rpc/heartbeat.go
+++ b/rpc/heartbeat.go
@@ -91,7 +91,9 @@ type ManualHeartbeatService struct {
 }
 
 // Ping waits until the heartbeat service is ready to respond to a Heartbeat.
-func (mhs *ManualHeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingResponse, error) {
+func (mhs *ManualHeartbeatService) Ping(
+	ctx context.Context, args *PingRequest,
+) (*PingResponse, error) {
 	select {
 	case <-mhs.ready:
 	case <-mhs.stopper.ShouldStop():

--- a/security/auth.go
+++ b/security/auth.go
@@ -54,8 +54,9 @@ type RequestWithUser interface {
 // ProtoAuthHook builds an authentication hook based on the security
 // mode and client certificate.
 // The proto.Message passed to the hook must implement RequestWithUser.
-func ProtoAuthHook(insecureMode bool, tlsState *tls.ConnectionState) (
-	func(proto.Message, bool) error, error) {
+func ProtoAuthHook(
+	insecureMode bool, tlsState *tls.ConnectionState,
+) (func(proto.Message, bool) error, error) {
 	userHook, err := UserAuthHook(insecureMode, tlsState)
 	if err != nil {
 		return nil, err
@@ -77,8 +78,9 @@ func ProtoAuthHook(insecureMode bool, tlsState *tls.ConnectionState) (
 
 // UserAuthHook builds an authentication hook based on the security
 // mode and client certificate.
-func UserAuthHook(insecureMode bool, tlsState *tls.ConnectionState) (
-	func(string, bool) error, error) {
+func UserAuthHook(
+	insecureMode bool, tlsState *tls.ConnectionState,
+) (func(string, bool) error, error) {
 	var certUser string
 
 	if !insecureMode {

--- a/security/certs.go
+++ b/security/certs.go
@@ -47,8 +47,9 @@ func loadCACertAndKey(sslCA, sslCAKey string) (*x509.Certificate, crypto.Private
 // writeCertificateAndKey takes a x509 certificate and key and writes
 // them out to the individual files.
 // TODO(marc): figure out how to include the plaintext certificate in the .crt file.
-func writeCertificateAndKey(certFilePath, keyFilePath string,
-	certificate []byte, key crypto.PrivateKey) error {
+func writeCertificateAndKey(
+	certFilePath, keyFilePath string, certificate []byte, key crypto.PrivateKey,
+) error {
 	// Get PEM blocks for certificate and private key.
 	certBlock, err := certificatePEMBlock(certificate)
 	if err != nil {
@@ -112,7 +113,9 @@ func RunCreateCACert(sslCA, sslCAKey string, keySize int) error {
 // - sslCAKey: path to the CA key
 // - sslCert: path to the node certificate
 // - sslCertKey: path to the node key
-func RunCreateNodeCert(sslCA, sslCAKey, sslCert, sslCertKey string, keySize int, hosts []string) error {
+func RunCreateNodeCert(
+	sslCA, sslCAKey, sslCert, sslCertKey string, keySize int, hosts []string,
+) error {
 	if len(hosts) == 0 {
 		return errors.Errorf("no hosts specified. Need at least one")
 	}
@@ -139,7 +142,9 @@ func RunCreateNodeCert(sslCA, sslCAKey, sslCert, sslCertKey string, keySize int,
 // - sslCAKey: path to the CA key
 // - sslCert: path to the node certificate
 // - sslCertKey: path to the node key
-func RunCreateClientCert(sslCA, sslCAKey, sslCert, sslCertKey string, keySize int, username string) error {
+func RunCreateClientCert(
+	sslCA, sslCAKey, sslCert, sslCertKey string, keySize int, username string,
+) error {
 	if len(username) == 0 {
 		return errors.Errorf("no username specified.")
 	}

--- a/security/x509.go
+++ b/security/x509.go
@@ -136,8 +136,9 @@ func GenerateCA(keySize int) ([]byte, crypto.PrivateKey, error) {
 // well as the private key used to generate the certificate.
 // Takes in the CA cert and key, the size of the key to generate, and the list
 // of hosts/ip addresses this certificate applies to.
-func GenerateServerCert(caCert *x509.Certificate, caKey crypto.PrivateKey, keySize int, hosts []string) (
-	[]byte, crypto.PrivateKey, error) {
+func GenerateServerCert(
+	caCert *x509.Certificate, caKey crypto.PrivateKey, keySize int, hosts []string,
+) ([]byte, crypto.PrivateKey, error) {
 	privateKey, publicKey, err := generateKeyPair(keySize)
 	if err != nil {
 		return nil, nil, err
@@ -172,8 +173,9 @@ func GenerateServerCert(caCert *x509.Certificate, caKey crypto.PrivateKey, keySi
 // well as the private key used to generate the certificate.
 // The CA cert and private key should be passed in.
 // 'user' is the unique username stored in the Subject.CommonName field.
-func GenerateClientCert(caCert *x509.Certificate, caKey crypto.PrivateKey, keySize int, name string) (
-	[]byte, crypto.PrivateKey, error) {
+func GenerateClientCert(
+	caCert *x509.Certificate, caKey crypto.PrivateKey, keySize int, name string,
+) ([]byte, crypto.PrivateKey, error) {
 
 	privateKey, publicKey, err := generateKeyPair(keySize)
 	if err != nil {

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -50,11 +50,15 @@ import (
 	"github.com/cockroachdb/cockroach/util/tracing"
 )
 
-func getAdminJSONProto(ts serverutils.TestServerInterface, path string, response proto.Message) error {
+func getAdminJSONProto(
+	ts serverutils.TestServerInterface, path string, response proto.Message,
+) error {
 	return serverutils.GetJSONProto(ts, adminPrefix+path, response)
 }
 
-func postAdminJSONProto(ts serverutils.TestServerInterface, path string, request, response proto.Message) error {
+func postAdminJSONProto(
+	ts serverutils.TestServerInterface, path string, request, response proto.Message,
+) error {
 	return serverutils.PostJSONProto(ts, adminPrefix+path, request, response)
 }
 

--- a/server/authentication_test.go
+++ b/server/authentication_test.go
@@ -36,7 +36,9 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-func doHTTPReq(t *testing.T, client http.Client, method, url string, body proto.Message) (*http.Response, error) {
+func doHTTPReq(
+	t *testing.T, client http.Client, method, url string, body proto.Message,
+) (*http.Response, error) {
 	var b io.Reader
 	if body != nil {
 		buf, err := protoutil.Marshal(body)

--- a/server/node.go
+++ b/server/node.go
@@ -503,7 +503,9 @@ func (n *Node) validateStores() error {
 // and node IDs have been established for this node. Store IDs are
 // allocated via a sequence id generator stored at a system key per
 // node.
-func (n *Node) bootstrapStores(ctx context.Context, bootstraps []*storage.Store, stopper *stop.Stopper) {
+func (n *Node) bootstrapStores(
+	ctx context.Context, bootstraps []*storage.Store, stopper *stop.Stopper,
+) {
 	if n.ClusterID == *uuid.EmptyUUID {
 		panic("ClusterID missing during store bootstrap of auxiliary store")
 	}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -59,8 +59,9 @@ import (
 // gossip instance, KV database and a node using the specified slice
 // of engines. The server, clock and node are returned. If gossipBS is
 // not nil, the gossip bootstrap address is set to gossipBS.
-func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t *testing.T) (
-	*grpc.Server, net.Addr, *hlc.Clock, *Node, *stop.Stopper) {
+func createTestNode(
+	addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t *testing.T,
+) (*grpc.Server, net.Addr, *hlc.Clock, *Node, *stop.Stopper) {
 	ctx := storage.StoreContext{}
 
 	stopper := stop.NewStopper()
@@ -113,8 +114,9 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 }
 
 // createAndStartTestNode creates a new test node and starts it. The server and node are returned.
-func createAndStartTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t *testing.T) (
-	*grpc.Server, net.Addr, *Node, *stop.Stopper) {
+func createAndStartTestNode(
+	addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t *testing.T,
+) (*grpc.Server, net.Addr, *Node, *stop.Stopper) {
 	grpcServer, addr, _, node, stopper := createTestNode(addr, engines, gossipBS, t)
 	if err := node.start(context.Background(), addr, engines, roachpb.Attributes{}); err != nil {
 		t.Fatal(err)
@@ -325,7 +327,9 @@ func TestCorruptedClusterID(t *testing.T) {
 // the bytes and counts for Live, Key and Val are at least the expected value.
 // And that UpdatedAt has increased.
 // The latest actual stats are returned.
-func compareNodeStatus(t *testing.T, ts *TestServer, expectedNodeStatus *status.NodeStatus, testNumber int) *status.NodeStatus {
+func compareNodeStatus(
+	t *testing.T, ts *TestServer, expectedNodeStatus *status.NodeStatus, testNumber int,
+) *status.NodeStatus {
 	// ========================================
 	// Read NodeStatus from server and validate top-level fields.
 	// ========================================

--- a/server/status.go
+++ b/server/status.go
@@ -112,9 +112,7 @@ func (s *statusServer) RegisterService(g *grpc.Server) {
 // RegisterGateway starts the gateway (i.e. reverse
 // proxy) that proxies HTTP requests to the appropriate gRPC endpoints.
 func (s *statusServer) RegisterGateway(
-	ctx context.Context,
-	mux *gwruntime.ServeMux,
-	conn *grpc.ClientConn,
+	ctx context.Context, mux *gwruntime.ServeMux, conn *grpc.ClientConn,
 ) error {
 	return serverpb.RegisterStatusHandler(ctx, mux, conn)
 }
@@ -146,7 +144,9 @@ func (s *statusServer) dialNode(nodeID roachpb.NodeID) (serverpb.StatusClient, e
 }
 
 // Gossip returns gossip network status.
-func (s *statusServer) Gossip(ctx context.Context, req *serverpb.GossipRequest) (*gossip.InfoStatus, error) {
+func (s *statusServer) Gossip(
+	ctx context.Context, req *serverpb.GossipRequest,
+) (*gossip.InfoStatus, error) {
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
 		return nil, grpc.Errorf(codes.InvalidArgument, err.Error())
@@ -164,7 +164,9 @@ func (s *statusServer) Gossip(ctx context.Context, req *serverpb.GossipRequest) 
 }
 
 // Details returns node details.
-func (s *statusServer) Details(ctx context.Context, req *serverpb.DetailsRequest) (*serverpb.DetailsResponse, error) {
+func (s *statusServer) Details(
+	ctx context.Context, req *serverpb.DetailsRequest,
+) (*serverpb.DetailsResponse, error) {
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
 		return nil, grpc.Errorf(codes.InvalidArgument, err.Error())
@@ -187,7 +189,9 @@ func (s *statusServer) Details(ctx context.Context, req *serverpb.DetailsRequest
 }
 
 // LogFilesList returns a list of available log files.
-func (s *statusServer) LogFilesList(ctx context.Context, req *serverpb.LogFilesListRequest) (*serverpb.LogFilesListResponse, error) {
+func (s *statusServer) LogFilesList(
+	ctx context.Context, req *serverpb.LogFilesListRequest,
+) (*serverpb.LogFilesListResponse, error) {
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
 		return nil, grpc.Errorf(codes.InvalidArgument, err.Error())
@@ -208,7 +212,9 @@ func (s *statusServer) LogFilesList(ctx context.Context, req *serverpb.LogFilesL
 }
 
 // LogFile returns a single log file.
-func (s *statusServer) LogFile(ctx context.Context, req *serverpb.LogFileRequest) (*serverpb.LogEntriesResponse, error) {
+func (s *statusServer) LogFile(
+	ctx context.Context, req *serverpb.LogFileRequest,
+) (*serverpb.LogEntriesResponse, error) {
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
 		return nil, grpc.Errorf(codes.InvalidArgument, err.Error())
@@ -272,7 +278,9 @@ func parseInt64WithDefault(s string, defaultValue int64) (int64, error) {
 //   entries. Defaults to defaultMaxLogEntries.
 // * "level" query parameter filters the log entries to be those of the
 //   corresponding severity level or worse. Defaults to "info".
-func (s *statusServer) Logs(ctx context.Context, req *serverpb.LogsRequest) (*serverpb.LogEntriesResponse, error) {
+func (s *statusServer) Logs(
+	ctx context.Context, req *serverpb.LogsRequest,
+) (*serverpb.LogEntriesResponse, error) {
 	log.Flush()
 
 	var sev log.Severity
@@ -329,7 +337,9 @@ func (s *statusServer) Logs(ctx context.Context, req *serverpb.LogsRequest) (*se
 // that this one allows querying by NodeID.
 //
 // Stacks handles returns goroutine stack traces.
-func (s *statusServer) Stacks(ctx context.Context, req *serverpb.StacksRequest) (*serverpb.JSONResponse, error) {
+func (s *statusServer) Stacks(
+	ctx context.Context, req *serverpb.StacksRequest,
+) (*serverpb.JSONResponse, error) {
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
 		return nil, grpc.Errorf(codes.InvalidArgument, err.Error())
@@ -358,7 +368,9 @@ func (s *statusServer) Stacks(ctx context.Context, req *serverpb.StacksRequest) 
 }
 
 // Nodes returns all node statuses.
-func (s *statusServer) Nodes(ctx context.Context, req *serverpb.NodesRequest) (*serverpb.NodesResponse, error) {
+func (s *statusServer) Nodes(
+	ctx context.Context, req *serverpb.NodesRequest,
+) (*serverpb.NodesResponse, error) {
 	startKey := keys.StatusNodePrefix
 	endKey := startKey.PrefixEnd()
 
@@ -383,7 +395,9 @@ func (s *statusServer) Nodes(ctx context.Context, req *serverpb.NodesRequest) (*
 }
 
 // handleNodeStatus handles GET requests for a single node's status.
-func (s *statusServer) Node(ctx context.Context, req *serverpb.NodeRequest) (*status.NodeStatus, error) {
+func (s *statusServer) Node(
+	ctx context.Context, req *serverpb.NodeRequest,
+) (*status.NodeStatus, error) {
 	nodeID, _, err := s.parseNodeID(req.NodeId)
 	if err != nil {
 		return nil, grpc.Errorf(codes.InvalidArgument, err.Error())
@@ -407,7 +421,9 @@ func (s *statusServer) Node(ctx context.Context, req *serverpb.NodeRequest) (*st
 }
 
 // Metrics return metrics information for the server specified.
-func (s *statusServer) Metrics(ctx context.Context, req *serverpb.MetricsRequest) (*serverpb.JSONResponse, error) {
+func (s *statusServer) Metrics(
+	ctx context.Context, req *serverpb.MetricsRequest,
+) (*serverpb.JSONResponse, error) {
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
 		return nil, grpc.Errorf(codes.InvalidArgument, err.Error())
@@ -424,7 +440,9 @@ func (s *statusServer) Metrics(ctx context.Context, req *serverpb.MetricsRequest
 }
 
 // RaftDebug returns raft debug information for all known nodes.
-func (s *statusServer) RaftDebug(ctx context.Context, _ *serverpb.RaftDebugRequest) (*serverpb.RaftDebugResponse, error) {
+func (s *statusServer) RaftDebug(
+	ctx context.Context, _ *serverpb.RaftDebugRequest,
+) (*serverpb.RaftDebugResponse, error) {
 	nodes, err := s.Nodes(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -527,7 +545,9 @@ func (s *statusServer) handleVars(w http.ResponseWriter, r *http.Request) {
 }
 
 // Ranges returns range info for the server specified
-func (s *statusServer) Ranges(ctx context.Context, req *serverpb.RangesRequest) (*serverpb.RangesResponse, error) {
+func (s *statusServer) Ranges(
+	ctx context.Context, req *serverpb.RangesRequest,
+) (*serverpb.RangesResponse, error) {
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
 		return nil, grpc.Errorf(codes.InvalidArgument, err.Error())
@@ -603,9 +623,9 @@ func (s *statusServer) Ranges(ctx context.Context, req *serverpb.RangesRequest) 
 
 // SpanStats requests the total statistics stored on a node for a given key
 // span, which may include multiple ranges.
-func (s *statusServer) SpanStats(ctx context.Context, req *serverpb.SpanStatsRequest) (
-	*serverpb.SpanStatsResponse, error,
-) {
+func (s *statusServer) SpanStats(
+	ctx context.Context, req *serverpb.SpanStatsRequest,
+) (*serverpb.SpanStatsResponse, error) {
 	nodeID, local, err := s.parseNodeID(req.NodeID)
 	if err != nil {
 		return nil, grpc.Errorf(codes.InvalidArgument, err.Error())

--- a/server/status/recorder.go
+++ b/server/status/recorder.go
@@ -118,8 +118,9 @@ func NewMetricsRecorder(clock *hlc.Clock) *MetricsRecorder {
 
 // AddNode adds the Registry from an initialized node, along with its descriptor
 // and start time.
-func (mr *MetricsRecorder) AddNode(reg *metric.Registry, desc roachpb.NodeDescriptor,
-	startedAt int64) {
+func (mr *MetricsRecorder) AddNode(
+	reg *metric.Registry, desc roachpb.NodeDescriptor, startedAt int64,
+) {
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
 	mr.mu.nodeRegistry = reg

--- a/server/status_test.go
+++ b/server/status_test.go
@@ -50,7 +50,9 @@ import (
 	"github.com/cockroachdb/cockroach/util/timeutil"
 )
 
-func getStatusJSONProto(ts serverutils.TestServerInterface, path string, response proto.Message) error {
+func getStatusJSONProto(
+	ts serverutils.TestServerInterface, path string, response proto.Message,
+) error {
 	return serverutils.GetJSONProto(ts, statusPrefix+path, response)
 }
 

--- a/server/testserver.go
+++ b/server/testserver.go
@@ -431,9 +431,7 @@ type testServerFactoryImpl struct{}
 var TestServerFactory = testServerFactoryImpl{}
 
 // New is part of TestServerFactory interface.
-func (testServerFactoryImpl) New(
-	params base.TestServerArgs,
-) interface{} {
+func (testServerFactoryImpl) New(params base.TestServerArgs) interface{} {
 	ctx := makeTestContextFromParams(params)
 	return &TestServer{Ctx: &ctx}
 }

--- a/sql/analyze.go
+++ b/sql/analyze.go
@@ -98,7 +98,9 @@ func joinAndExprs(exprs parser.TypedExprs) parser.TypedExpr {
 	})
 }
 
-func joinExprs(exprs parser.TypedExprs, joinExprsFn func(left, right parser.TypedExpr) parser.TypedExpr) parser.TypedExpr {
+func joinExprs(
+	exprs parser.TypedExprs, joinExprsFn func(left, right parser.TypedExpr) parser.TypedExpr,
+) parser.TypedExpr {
 	switch len(exprs) {
 	case 0:
 		return nil
@@ -1607,10 +1609,8 @@ func makeIsNotNull(left parser.TypedExpr) parser.TypedExpr {
 // as a result.
 func (p *planner) analyzeExpr(
 	raw parser.Expr,
-	/* arguments for name resolution */
 	sources multiSourceInfo,
 	qvals qvalMap,
-	/* arguments for type checking */
 	expectedType parser.Datum,
 	requireType bool,
 	typingContext string,

--- a/sql/backfill.go
+++ b/sql/backfill.go
@@ -30,9 +30,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func makeColIDtoRowIndex(row planNode, desc *sqlbase.TableDescriptor) (
-	map[sqlbase.ColumnID]int, error,
-) {
+func makeColIDtoRowIndex(
+	row planNode, desc *sqlbase.TableDescriptor,
+) (map[sqlbase.ColumnID]int, error) {
 	columns := row.Columns()
 	colIDtoRowIndex := make(map[sqlbase.ColumnID]int, len(columns))
 	for i, column := range columns {
@@ -374,8 +374,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumnsChunk(
 }
 
 func (sc *SchemaChanger) truncateIndexes(
-	lease *sqlbase.TableDescriptor_SchemaChangeLease,
-	dropped []sqlbase.IndexDescriptor,
+	lease *sqlbase.TableDescriptor_SchemaChangeLease, dropped []sqlbase.IndexDescriptor,
 ) error {
 	for _, desc := range dropped {
 		var resume roachpb.Span
@@ -429,8 +428,7 @@ func (sc *SchemaChanger) truncateIndexes(
 const IndexBackfillChunkSize = 100
 
 func (sc *SchemaChanger) backfillIndexes(
-	lease *sqlbase.TableDescriptor_SchemaChangeLease,
-	added []sqlbase.IndexDescriptor,
+	lease *sqlbase.TableDescriptor_SchemaChangeLease, added []sqlbase.IndexDescriptor,
 ) error {
 	if len(added) == 0 {
 		return nil
@@ -460,8 +458,7 @@ func (sc *SchemaChanger) backfillIndexes(
 }
 
 func (sc *SchemaChanger) backfillIndexesChunk(
-	added []sqlbase.IndexDescriptor,
-	sp roachpb.Span,
+	added []sqlbase.IndexDescriptor, sp roachpb.Span,
 ) (roachpb.Key, bool, error) {
 	var nextKey roachpb.Key
 	done := false

--- a/sql/backup.go
+++ b/sql/backup.go
@@ -459,10 +459,7 @@ func userTablesAndDBsMatchingName(
 // Restore imports a SQL table (or tables) from a set of non-overlapping sstable
 // files.
 func Restore(
-	ctx context.Context,
-	db client.DB,
-	base string,
-	table parser.TableName,
+	ctx context.Context, db client.DB, base string, table parser.TableName,
 ) ([]sqlbase.TableDescriptor, error) {
 	// TODO(dan): It's currently impossible to restore two interleaved tables
 	// because one of them won't be to an empty range.

--- a/sql/backup_test.go
+++ b/sql/backup_test.go
@@ -120,11 +120,7 @@ func TestIntersectHalfOpen(t *testing.T) {
 // setupBackupRestoreDB creates a table and inserts `count` rows. It then splits
 // the kv ranges for the table as evenly as possible into `rangeCount` ranges.
 func setupBackupRestoreDB(
-	t testing.TB,
-	ctx context.Context,
-	tc *testcluster.TestCluster,
-	count int,
-	rangeCount int,
+	t testing.TB, ctx context.Context, tc *testcluster.TestCluster, count int, rangeCount int,
 ) []*roachpb.RangeDescriptor {
 	rng, _ := randutil.NewPseudoRand()
 
@@ -187,10 +183,7 @@ func setupBackupRestoreDB(
 }
 
 func setupReplicationAndLeases(
-	t testing.TB,
-	tc *testcluster.TestCluster,
-	ranges []*roachpb.RangeDescriptor,
-	clusterSize int,
+	t testing.TB, tc *testcluster.TestCluster, ranges []*roachpb.RangeDescriptor, clusterSize int,
 ) {
 	targets := make([]testcluster.ReplicationTarget, clusterSize-1)
 	for i := 1; i < clusterSize; i++ {

--- a/sql/bench_test.go
+++ b/sql/bench_test.go
@@ -148,10 +148,7 @@ func BenchmarkSelect1_MySQL(b *testing.B) {
 }
 
 func runBenchmarkSelectWithTargetsAndFilter(
-	b *testing.B,
-	db *gosql.DB,
-	targets, filter string,
-	args ...interface{},
+	b *testing.B, db *gosql.DB, targets, filter string, args ...interface{},
 ) {
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.select`); err != nil {
 		b.Fatal(err)
@@ -822,7 +819,9 @@ func BenchmarkScan1000Limit100_Postgres(b *testing.B) {
 }
 
 // runBenchmarkScanFilter benchmarks scanning (w/filter) from a table containing count1 * count2 rows.
-func runBenchmarkScanFilter(b *testing.B, db *gosql.DB, count1, count2 int, limit int, filter string) {
+func runBenchmarkScanFilter(
+	b *testing.B, db *gosql.DB, count1, count2 int, limit int, filter string,
+) {
 	if _, err := db.Exec(`DROP TABLE IF EXISTS bench.scan2`); err != nil {
 		b.Fatal(err)
 	}

--- a/sql/check.go
+++ b/sql/check.go
@@ -28,7 +28,9 @@ type checkHelper struct {
 	cols  []sqlbase.ColumnDescriptor
 }
 
-func (c *checkHelper) init(p *planner, tn *parser.TableName, tableDesc *sqlbase.TableDescriptor) error {
+func (c *checkHelper) init(
+	p *planner, tn *parser.TableName, tableDesc *sqlbase.TableDescriptor,
+) error {
 	if len(tableDesc.Checks) == 0 {
 		return nil
 	}
@@ -92,9 +94,7 @@ func (c *checkHelper) check(ctx *parser.EvalContext) error {
 }
 
 func (p *planner) validateCheckExpr(
-	exprStr string,
-	tableName parser.TableExpr,
-	tableDesc *sqlbase.TableDescriptor,
+	exprStr string, tableName parser.TableExpr, tableDesc *sqlbase.TableDescriptor,
 ) error {
 	expr, err := parser.ParseExprTraditional(exprStr)
 	if err != nil {

--- a/sql/create.go
+++ b/sql/create.go
@@ -879,7 +879,8 @@ func (p *planner) finalizeInterleave(
 // makeViewTableDesc returns the table descriptor for a new view.
 func makeViewTableDesc(
 	p *parser.CreateView,
-	parentID sqlbase.ID, id sqlbase.ID,
+	parentID sqlbase.ID,
+	id sqlbase.ID,
 	resultColumns []ResultColumn,
 	privileges *sqlbase.PrivilegeDescriptor,
 ) (sqlbase.TableDescriptor, error) {

--- a/sql/create_test.go
+++ b/sql/create_test.go
@@ -193,7 +193,8 @@ func createTestTable(
 // verifyTables ensures that the correct number of tables were created and that
 // they all correspond to individual table descriptor IDs in the correct range
 // of values.
-func verifyTables(t *testing.T,
+func verifyTables(
+	t *testing.T,
 	tc *testcluster.TestCluster,
 	completed chan int,
 	expectedNumOfTables int,

--- a/sql/data_source.go
+++ b/sql/data_source.go
@@ -217,9 +217,7 @@ func (p *planner) getVirtualDataSource(tn *parser.TableName) (planDataSource, bo
 // getDataSource builds a planDataSource from a single data source clause
 // (TableExpr) in a SelectClause.
 func (p *planner) getDataSource(
-	src parser.TableExpr,
-	hints *parser.IndexHints,
-	scanVisibility scanVisibility,
+	src parser.TableExpr, hints *parser.IndexHints, scanVisibility scanVisibility,
 ) (planDataSource, error) {
 	switch t := src.(type) {
 	case *parser.NormalizableTableName:
@@ -310,9 +308,7 @@ func (p *planner) getDataSource(
 // clause (either a table or a view) in a SelectClause, expanding views out
 // into subqueries.
 func (p *planner) getTableScanOrViewPlan(
-	tn *parser.TableName,
-	hints *parser.IndexHints,
-	scanVisibility scanVisibility,
+	tn *parser.TableName, hints *parser.IndexHints, scanVisibility scanVisibility,
 ) (planDataSource, error) {
 	descFunc := p.getTableLease
 	if p.asOf {
@@ -443,9 +439,7 @@ func (src *dataSourceInfo) expandStar(
 // specify a table name, all columns in the data source are
 // considered.  If no column is found, invalidColIdx is returned with
 // no error.
-func (p *planDataSource) findUnaliasedColumn(
-	c *parser.ColumnItem,
-) (colIdx int, err error) {
+func (p *planDataSource) findUnaliasedColumn(c *parser.ColumnItem) (colIdx int, err error) {
 	colName := sqlbase.NormalizeName(c.ColumnName)
 	tableName := sqlbase.NormalizeTableName(c.TableName)
 

--- a/sql/delete.go
+++ b/sql/delete.go
@@ -46,7 +46,9 @@ type deleteNode struct {
 // Privileges: DELETE and SELECT on table. We currently always use a SELECT statement.
 //   Notes: postgres requires DELETE. Also requires SELECT for "USING" and "WHERE" with tables.
 //          mysql requires DELETE. Also requires SELECT if a table is used in the "WHERE" clause.
-func (p *planner) Delete(n *parser.Delete, desiredTypes []parser.Datum, autoCommit bool) (planNode, error) {
+func (p *planner) Delete(
+	n *parser.Delete, desiredTypes []parser.Datum, autoCommit bool,
+) (planNode, error) {
 	tn, err := p.getAliasedTableName(n.Table)
 	if err != nil {
 		return nil, err

--- a/sql/descriptor.go
+++ b/sql/descriptor.go
@@ -70,7 +70,9 @@ type DescriptorAccessor interface {
 var _ DescriptorAccessor = &planner{}
 
 // checkPrivilege implements the DescriptorAccessor interface.
-func (p *planner) checkPrivilege(descriptor sqlbase.DescriptorProto, privilege privilege.Kind) error {
+func (p *planner) checkPrivilege(
+	descriptor sqlbase.DescriptorProto, privilege privilege.Kind,
+) error {
 	if descriptor.GetPrivileges().CheckPrivilege(p.session.User, privilege) {
 		return nil
 	}
@@ -186,7 +188,8 @@ func (p *planner) createDescriptorWithID(
 }
 
 // getDescriptor implements the DescriptorAccessor interface.
-func (p *planner) getDescriptor(plainKey sqlbase.DescriptorKey, descriptor sqlbase.DescriptorProto,
+func (p *planner) getDescriptor(
+	plainKey sqlbase.DescriptorKey, descriptor sqlbase.DescriptorProto,
 ) (bool, error) {
 	gr, err := p.txn.Get(plainKey.Key())
 	if err != nil {
@@ -258,8 +261,9 @@ func (p *planner) getAllDescriptors() ([]sqlbase.DescriptorProto, error) {
 }
 
 // getDescriptorsFromTargetList implements the DescriptorAccessor interface.
-func (p *planner) getDescriptorsFromTargetList(targets parser.TargetList) (
-	[]sqlbase.DescriptorProto, error) {
+func (p *planner) getDescriptorsFromTargetList(
+	targets parser.TargetList,
+) ([]sqlbase.DescriptorProto, error) {
 	if targets.Databases != nil {
 		if len(targets.Databases) == 0 {
 			return nil, errNoDatabase

--- a/sql/distsql/flow.go
+++ b/sql/distsql/flow.go
@@ -79,11 +79,7 @@ type Flow struct {
 	status flowStatus
 }
 
-func newFlow(
-	flowCtx FlowCtx,
-	flowReg *flowRegistry,
-	simpleFlowConsumer RowReceiver,
-) *Flow {
+func newFlow(flowCtx FlowCtx, flowReg *flowRegistry, simpleFlowConsumer RowReceiver) *Flow {
 	flowCtx.Context = log.WithLogTagStr(flowCtx.Context, "f", flowCtx.id.Short())
 	return &Flow{
 		FlowCtx:            flowCtx,

--- a/sql/distsql/routers.go
+++ b/sql/distsql/routers.go
@@ -27,9 +27,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func makeRouter(spec *OutputRouterSpec, streams []RowReceiver) (
-	RowReceiver, error,
-) {
+func makeRouter(spec *OutputRouterSpec, streams []RowReceiver) (RowReceiver, error) {
 	switch len(streams) {
 	case 0:
 		return nil, errors.Errorf("no streams in router")

--- a/sql/distsql/server.go
+++ b/sql/distsql/server.go
@@ -65,10 +65,7 @@ func NewServer(cfg ServerConfig) *ServerImpl {
 	return ds
 }
 
-func (ds *ServerImpl) setupTxn(
-	ctx context.Context,
-	txnProto *roachpb.Transaction,
-) *client.Txn {
+func (ds *ServerImpl) setupTxn(ctx context.Context, txnProto *roachpb.Transaction) *client.Txn {
 	txn := client.NewTxn(ctx, *ds.DB)
 	// TODO(radu): we should sanity check some of these fields
 	txn.Proto = *txnProto
@@ -126,9 +123,9 @@ func (ds *ServerImpl) RunSimpleFlow(
 }
 
 // SetupFlow is part of the DistSQLServer interface.
-func (ds *ServerImpl) SetupFlow(ctx context.Context, req *SetupFlowRequest) (
-	*SimpleResponse, error,
-) {
+func (ds *ServerImpl) SetupFlow(
+	ctx context.Context, req *SetupFlowRequest,
+) (*SimpleResponse, error) {
 	// Note: ctx will be canceled when the RPC completes, so we can't associate
 	// it with the transaction.
 

--- a/sql/distsql/sorter.go
+++ b/sql/distsql/sorter.go
@@ -39,12 +39,7 @@ type sorter struct {
 
 var _ processor = &sorter{}
 
-func newSorter(
-	flowCtx *FlowCtx,
-	spec *SorterSpec,
-	input RowSource,
-	output RowReceiver,
-) *sorter {
+func newSorter(flowCtx *FlowCtx, spec *SorterSpec, input RowSource, output RowReceiver) *sorter {
 	return &sorter{
 		input:    input,
 		output:   output,

--- a/sql/distsql/tablereader.go
+++ b/sql/distsql/tablereader.go
@@ -45,8 +45,8 @@ var _ processor = &tableReader{}
 
 // newTableReader creates a tableReader.
 func newTableReader(
-	flowCtx *FlowCtx, spec *TableReaderSpec, output RowReceiver) (*tableReader, error,
-) {
+	flowCtx *FlowCtx, spec *TableReaderSpec, output RowReceiver,
+) (*tableReader, error) {
 	tr := &tableReader{
 		output:    output,
 		hardLimit: spec.HardLimit,

--- a/sql/drop.go
+++ b/sql/drop.go
@@ -585,8 +585,7 @@ func (n *dropTableNode) ExplainPlan(v bool) (string, string, []planNode) {
 // the deleted bit set, meaning the lease manager will not hand out
 // new leases for it and existing leases are released).
 // If the table does not exist, this function returns a nil descriptor.
-func (p *planner) dropTableOrViewPrepare(name *parser.TableName,
-) (*sqlbase.TableDescriptor, error) {
+func (p *planner) dropTableOrViewPrepare(name *parser.TableName) (*sqlbase.TableDescriptor, error) {
 	tableDesc, err := p.getTableOrViewDesc(name)
 	if err != nil {
 		return nil, err

--- a/sql/event_log.go
+++ b/sql/event_log.go
@@ -82,7 +82,9 @@ func MakeEventLogger(leaseMgr *LeaseManager) EventLogger {
 
 // InsertEventRecord inserts a single event into the event log as part of the
 // provided transaction.
-func (ev EventLogger) InsertEventRecord(txn *client.Txn, eventType EventLogType, targetID, reportingID int32, info interface{}) error {
+func (ev EventLogger) InsertEventRecord(
+	txn *client.Txn, eventType EventLogType, targetID, reportingID int32, info interface{},
+) error {
 	// Record event record insertion in local log output.
 	log.Infof(txn.Context, "Event: %q, target: %d, info: %+v",
 		eventType,

--- a/sql/executor.go
+++ b/sql/executor.go
@@ -372,9 +372,7 @@ func (e *Executor) getSystemConfig() (config.SystemConfig, *databaseCache) {
 // populate the missing types. The column result types are returned (or
 // nil if there are no results).
 func (e *Executor) Prepare(
-	query string,
-	session *Session,
-	pinfo parser.PlaceholderTypes,
+	query string, session *Session, pinfo parser.PlaceholderTypes,
 ) (ResultColumns, error) {
 	if log.V(2) {
 		log.Infof(session.Ctx(), "preparing: %s", query)
@@ -950,11 +948,7 @@ func (e *Executor) execStmtInCommitWaitTxn(
 // - a Result
 // - an error, if any. In case of error, the result returned also reflects this error.
 func (e *Executor) execStmtInOpenTxn(
-	stmt parser.Statement,
-	planMaker *planner,
-	implicitTxn bool,
-	firstInTxn bool,
-	txnState *txnState,
+	stmt parser.Statement, planMaker *planner, implicitTxn bool, firstInTxn bool, txnState *txnState,
 ) (Result, error) {
 	if txnState.State != Open {
 		panic("execStmtInOpenTxn called outside of an open txn")

--- a/sql/expr_filter.go
+++ b/sql/expr_filter.go
@@ -161,7 +161,9 @@ func makeNot(expr parser.TypedExpr) parser.TypedExpr {
 //  - If weaker is false:
 //       E(x) = (RES(x) OR REM(x))
 //    This implies RES(x) => E(x), i.e. RES is "stronger"
-func splitBoolExpr(expr parser.TypedExpr, conv varConvertFunc, weaker bool) (restricted, remainder parser.TypedExpr) {
+func splitBoolExpr(
+	expr parser.TypedExpr, conv varConvertFunc, weaker bool,
+) (restricted, remainder parser.TypedExpr) {
 	// If the expression only contains "restricted" vars, the split is trivial.
 	if exprCheckVars(expr, conv) {
 		// An "empty" filter is always true in the weaker (normal) case (where the filter is

--- a/sql/fk.go
+++ b/sql/fk.go
@@ -79,7 +79,10 @@ type fkInsertHelper map[sqlbase.IndexID][]baseFKHelper
 var errSkipUnsedFK = errors.New("no columns involved in FK included in writer")
 
 func makeFKInsertHelper(
-	txn *client.Txn, table sqlbase.TableDescriptor, otherTables tableLookupsByID, colMap map[sqlbase.ColumnID]int,
+	txn *client.Txn,
+	table sqlbase.TableDescriptor,
+	otherTables tableLookupsByID,
+	colMap map[sqlbase.ColumnID]int,
 ) (fkInsertHelper, error) {
 	var fks fkInsertHelper
 	for _, idx := range table.AllNonDropIndexes() {
@@ -141,7 +144,10 @@ func (fks fkInsertHelper) checkIdx(idx sqlbase.IndexID, row parser.DTuple) error
 type fkDeleteHelper map[sqlbase.IndexID][]baseFKHelper
 
 func makeFKDeleteHelper(
-	txn *client.Txn, table sqlbase.TableDescriptor, otherTables tableLookupsByID, colMap map[sqlbase.ColumnID]int,
+	txn *client.Txn,
+	table sqlbase.TableDescriptor,
+	otherTables tableLookupsByID,
+	colMap map[sqlbase.ColumnID]int,
 ) (fkDeleteHelper, error) {
 	var fks fkDeleteHelper
 	for _, idx := range table.AllNonDropIndexes() {
@@ -205,7 +211,10 @@ type fkUpdateHelper struct {
 }
 
 func makeFKUpdateHelper(
-	txn *client.Txn, table sqlbase.TableDescriptor, otherTables tableLookupsByID, colMap map[sqlbase.ColumnID]int,
+	txn *client.Txn,
+	table sqlbase.TableDescriptor,
+	otherTables tableLookupsByID,
+	colMap map[sqlbase.ColumnID]int,
 ) (fkUpdateHelper, error) {
 	ret := fkUpdateHelper{}
 	var err error
@@ -239,7 +248,7 @@ func makeBaseFKHelper(
 	otherTables tableLookupsByID,
 	writeIdx sqlbase.IndexDescriptor,
 	ref sqlbase.ForeignKeyReference,
-	colMap map[sqlbase.ColumnID]int, // col ids (for idx being written) to row offset.
+	colMap map[sqlbase.ColumnID]int,
 ) (baseFKHelper, error) {
 	b := baseFKHelper{txn: txn, writeIdx: writeIdx, searchTable: otherTables[ref.Table].table}
 	if b.searchTable == nil {

--- a/sql/group.go
+++ b/sql/group.go
@@ -582,8 +582,7 @@ type aggregateFuncHolder struct {
 }
 
 func (n *groupNode) newAggregateFuncHolder(
-	expr, arg parser.TypedExpr,
-	create func() parser.AggregateFunc,
+	expr, arg parser.TypedExpr, create func() parser.AggregateFunc,
 ) *aggregateFuncHolder {
 	res := &aggregateFuncHolder{
 		expr:          expr,
@@ -641,7 +640,9 @@ func (a *aggregateFuncHolder) String() string { return parser.AsString(a) }
 
 func (a *aggregateFuncHolder) Walk(v parser.Visitor) parser.Expr { return a }
 
-func (a *aggregateFuncHolder) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.TypedExpr, error) {
+func (a *aggregateFuncHolder) TypeCheck(
+	_ *parser.SemaContext, desired parser.Datum,
+) (parser.TypedExpr, error) {
 	return a, nil
 }
 

--- a/sql/helpers_test.go
+++ b/sql/helpers_test.go
@@ -71,9 +71,7 @@ func (t RemovalTracker) WaitForRemoval() error {
 // LeaseRemovedNotification has to be called after a lease is removed from the
 // store. This should be hooked up as a callback to
 // LeaseStoreTestingKnobs.LeaseReleasedEvent.
-func (w *LeaseRemovalTracker) LeaseRemovedNotification(
-	lease *LeaseState, err error,
-) {
+func (w *LeaseRemovalTracker) LeaseRemovedNotification(lease *LeaseState, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if tracker, ok := w.tracking[lease]; ok {

--- a/sql/index_selection.go
+++ b/sql/index_selection.go
@@ -370,8 +370,9 @@ func (v *indexInfo) analyzeExprs(exprs []parser.TypedExprs) {
 //
 // If preferOrderMatching is true, we prefer an index that matches the desired
 // ordering completely, even if it is not a covering index.
-func (v *indexInfo) analyzeOrdering(scan *scanNode, analyzeOrdering analyzeOrderingFn,
-	preferOrderMatching bool) {
+func (v *indexInfo) analyzeOrdering(
+	scan *scanNode, analyzeOrdering analyzeOrderingFn, preferOrderMatching bool,
+) {
 	// Compute the prefix of the index for which we have exact constraints. This
 	// prefix is inconsequential for ordering because the values are identical.
 	v.exactPrefix = v.constraints.exactPrefix()
@@ -827,8 +828,7 @@ func encodeStartConstraintAscending(spans []roachpb.Span, c *parser.ComparisonEx
 	}
 }
 
-func encodeStartConstraintDescending(
-	spans []roachpb.Span, c *parser.ComparisonExpr) {
+func encodeStartConstraintDescending(spans []roachpb.Span, c *parser.ComparisonExpr) {
 	switch c.Operator {
 	case parser.Is:
 		// An IS NULL expressions allows us to constrain the start of the range
@@ -947,8 +947,8 @@ func encodeEndConstraintDescending(
 // The key is a span end key, which is exclusive, but `val` needs to
 // be inclusive. So if datum is the last end constraint, we transform it accordingly.
 func encodeInclusiveEndValue(
-	key roachpb.Key, datum parser.Datum, dir encoding.Direction,
-	isLastEndConstraint bool) roachpb.Key {
+	key roachpb.Key, datum parser.Datum, dir encoding.Direction, isLastEndConstraint bool,
+) roachpb.Key {
 	// Since the end of a span is exclusive, if the last constraint is an
 	// inclusive one, we might need to make the key exclusive by applying a
 	// PrefixEnd().  We normally avoid doing this by transforming "a = x" to
@@ -1343,7 +1343,9 @@ func (oic orIndexConstraints) exactPrefix() int {
 // constraint is "a = 1", the expression is simplified to "b > 2".
 //
 // Note that applyConstraints currently only handles simple cases.
-func applyIndexConstraints(typedExpr parser.TypedExpr, constraints orIndexConstraints) parser.TypedExpr {
+func applyIndexConstraints(
+	typedExpr parser.TypedExpr, constraints orIndexConstraints,
+) parser.TypedExpr {
 	if len(constraints) != 1 {
 		// We only support simplifying the expressions if there aren't multiple
 		// disjunctions (top-level OR branches).

--- a/sql/index_selection_test.go
+++ b/sql/index_selection_test.go
@@ -118,8 +118,9 @@ func TestMergeAndSortSpans(t *testing.T) {
 	}
 }
 
-func makeTestIndex(t *testing.T, columns []string, dirs []encoding.Direction) (
-	*sqlbase.TableDescriptor, *sqlbase.IndexDescriptor) {
+func makeTestIndex(
+	t *testing.T, columns []string, dirs []encoding.Direction,
+) (*sqlbase.TableDescriptor, *sqlbase.IndexDescriptor) {
 	desc := testTableDesc()
 	desc.Indexes = append(desc.Indexes, sqlbase.IndexDescriptor{
 		Name:        "foo",
@@ -146,7 +147,9 @@ func makeTestIndex(t *testing.T, columns []string, dirs []encoding.Direction) (
 // makeTestIndexFromStr creates a test index from a string that enumerates the
 // columns, separated by commas. Each column has an optional '-' at the end if
 // it is descending.
-func makeTestIndexFromStr(t *testing.T, columnsStr string) (*sqlbase.TableDescriptor, *sqlbase.IndexDescriptor) {
+func makeTestIndexFromStr(
+	t *testing.T, columnsStr string,
+) (*sqlbase.TableDescriptor, *sqlbase.IndexDescriptor) {
 	columns := strings.Split(columnsStr, ",")
 	dirs := make([]encoding.Direction, len(columns))
 	for i, c := range columns {
@@ -160,8 +163,9 @@ func makeTestIndexFromStr(t *testing.T, columnsStr string) (*sqlbase.TableDescri
 	return makeTestIndex(t, columns, dirs)
 }
 
-func makeConstraints(t *testing.T, sql string, desc *sqlbase.TableDescriptor,
-	index *sqlbase.IndexDescriptor) (orIndexConstraints, parser.TypedExpr) {
+func makeConstraints(
+	t *testing.T, sql string, desc *sqlbase.TableDescriptor, index *sqlbase.IndexDescriptor,
+) (orIndexConstraints, parser.TypedExpr) {
 	expr, _ := parseAndNormalizeExpr(t, sql)
 	exprs, equiv := analyzeExpr(expr)
 

--- a/sql/information_schema.go
+++ b/sql/information_schema.go
@@ -417,10 +417,7 @@ func (dbs sortedDBDescs) Less(i, j int) bool { return dbs[i].Name < dbs[j].Name 
 // forEachTableDesc retrieves all database descriptors and iterates through them in
 // lexicographical order with respect to their name. For each database, the function
 // will call fn with its descriptor.
-func forEachDatabaseDesc(
-	p *planner,
-	fn func(*sqlbase.DatabaseDescriptor) error,
-) error {
+func forEachDatabaseDesc(p *planner, fn func(*sqlbase.DatabaseDescriptor) error) error {
 	// Handle real schemas
 	dbDescs, err := p.getAllDatabaseDescs()
 	if err != nil {
@@ -448,8 +445,7 @@ func forEachDatabaseDesc(
 // to table name. For each table, the function will call fn with its respective
 // database and table descriptor.
 func forEachTableDesc(
-	p *planner,
-	fn func(*sqlbase.DatabaseDescriptor, *sqlbase.TableDescriptor) error,
+	p *planner, fn func(*sqlbase.DatabaseDescriptor, *sqlbase.TableDescriptor) error,
 ) error {
 	type dbDescTables struct {
 		desc   *sqlbase.DatabaseDescriptor
@@ -527,8 +523,7 @@ func forEachTableDesc(
 }
 
 func forEachIndexInTable(
-	table *sqlbase.TableDescriptor,
-	fn func(*sqlbase.IndexDescriptor) error,
+	table *sqlbase.TableDescriptor, fn func(*sqlbase.IndexDescriptor) error,
 ) error {
 	if table.IsPhysicalTable() {
 		if err := fn(&table.PrimaryIndex); err != nil {
@@ -544,8 +539,7 @@ func forEachIndexInTable(
 }
 
 func forEachColumnInTable(
-	table *sqlbase.TableDescriptor,
-	fn func(*sqlbase.ColumnDescriptor) error,
+	table *sqlbase.TableDescriptor, fn func(*sqlbase.ColumnDescriptor) error,
 ) error {
 	// Table descriptors already hold columns in-order.
 	for i := range table.Columns {

--- a/sql/insert.go
+++ b/sql/insert.go
@@ -344,8 +344,9 @@ func (n *insertNode) Next() (bool, error) {
 	return true, nil
 }
 
-func (p *planner) processColumns(tableDesc *sqlbase.TableDescriptor,
-	node parser.UnresolvedNames) ([]sqlbase.ColumnDescriptor, error) {
+func (p *planner) processColumns(
+	tableDesc *sqlbase.TableDescriptor, node parser.UnresolvedNames,
+) ([]sqlbase.ColumnDescriptor, error) {
 	if node == nil {
 		// VisibleColumns is used here to prevent INSERT INTO <table> VALUES (...)
 		// (as opposed to INSERT INTO <table> (...) VALUES (...)) from writing
@@ -381,8 +382,9 @@ func (p *planner) processColumns(tableDesc *sqlbase.TableDescriptor,
 	return cols, nil
 }
 
-func (p *planner) fillDefaults(defaultExprs []parser.TypedExpr,
-	cols []sqlbase.ColumnDescriptor, n *parser.Insert) (parser.SelectStatement, error) {
+func (p *planner) fillDefaults(
+	defaultExprs []parser.TypedExpr, cols []sqlbase.ColumnDescriptor, n *parser.Insert,
+) (parser.SelectStatement, error) {
 	if n.DefaultValues() {
 		row := make(parser.Exprs, 0, len(cols))
 		for i := range cols {

--- a/sql/internal.go
+++ b/sql/internal.go
@@ -47,7 +47,9 @@ func (ie InternalExecutor) ExecuteStatementInTransaction(
 }
 
 // GetTableSpan gets the key span for a SQL table, including any indices.
-func (ie InternalExecutor) GetTableSpan(user string, txn *client.Txn, dbName, tableName string) (roachpb.Span, error) {
+func (ie InternalExecutor) GetTableSpan(
+	user string, txn *client.Txn, dbName, tableName string,
+) (roachpb.Span, error) {
 	// Lookup the table ID.
 	p := makeInternalPlanner(txn, user)
 	p.leaseMgr = ie.LeaseManager

--- a/sql/join.go
+++ b/sql/join.go
@@ -47,7 +47,9 @@ type indexJoinNode struct {
 // is created separately as a member of the resulting index join node.
 // The new index scan node is also returned alongside the new index join
 // node.
-func (p *planner) makeIndexJoin(origScan *scanNode, exactPrefix int) (resultPlan *indexJoinNode, indexScan *scanNode) {
+func (p *planner) makeIndexJoin(
+	origScan *scanNode, exactPrefix int,
+) (resultPlan *indexJoinNode, indexScan *scanNode) {
 	// Reuse the input argument's scanNode and its initialized parameters
 	// at a starting point to build the new indexScan node.
 	indexScan = origScan

--- a/sql/lease_test.go
+++ b/sql/lease_test.go
@@ -106,7 +106,9 @@ func (t *leaseTest) expectLeases(descID sqlbase.ID, expected string) {
 	}
 }
 
-func (t *leaseTest) acquire(nodeID uint32, descID sqlbase.ID, version sqlbase.DescriptorVersion) (*csql.LeaseState, error) {
+func (t *leaseTest) acquire(
+	nodeID uint32, descID sqlbase.ID, version sqlbase.DescriptorVersion,
+) (*csql.LeaseState, error) {
 	var lease *csql.LeaseState
 	err := t.kvDB.Txn(context.TODO(), func(txn *client.Txn) error {
 		var err error
@@ -116,7 +118,9 @@ func (t *leaseTest) acquire(nodeID uint32, descID sqlbase.ID, version sqlbase.De
 	return lease, err
 }
 
-func (t *leaseTest) mustAcquire(nodeID uint32, descID sqlbase.ID, version sqlbase.DescriptorVersion) *csql.LeaseState {
+func (t *leaseTest) mustAcquire(
+	nodeID uint32, descID sqlbase.ID, version sqlbase.DescriptorVersion,
+) *csql.LeaseState {
 	lease, err := t.acquire(nodeID, descID, version)
 	if err != nil {
 		t.Fatal(err)
@@ -133,9 +137,7 @@ func (t *leaseTest) release(nodeID uint32, lease *csql.LeaseState) error {
 // store (i.e. it's not expired and it's not for an old descriptor version),
 // this shouldn't be set.
 func (t *leaseTest) mustRelease(
-	nodeID uint32,
-	lease *csql.LeaseState,
-	leaseRemovalTracker *csql.LeaseRemovalTracker,
+	nodeID uint32, lease *csql.LeaseState, leaseRemovalTracker *csql.LeaseRemovalTracker,
 ) {
 	var tracker csql.RemovalTracker
 	if leaseRemovalTracker != nil {
@@ -470,7 +472,9 @@ func isDeleted(tableID sqlbase.ID, cfg config.SystemConfig) bool {
 	return table.Deleted()
 }
 
-func acquire(s *server.TestServer, descID sqlbase.ID, version sqlbase.DescriptorVersion) (*csql.LeaseState, error) {
+func acquire(
+	s *server.TestServer, descID sqlbase.ID, version sqlbase.DescriptorVersion,
+) (*csql.LeaseState, error) {
 	var lease *csql.LeaseState
 	err := s.DB().Txn(context.TODO(), func(txn *client.Txn) error {
 		var err error

--- a/sql/logic_test.go
+++ b/sql/logic_test.go
@@ -779,10 +779,7 @@ func (t *logicTest) processTestFile(path string) error {
 // verifyError checks that either no error was found where none was
 // expected, or that an error was found when one was expected. Returns
 // "true" to indicate the behavior was as expected.
-func (t *logicTest) verifyError(
-	sql, pos, expectErr, expectErrCode string,
-	err error,
-) bool {
+func (t *logicTest) verifyError(sql, pos, expectErr, expectErrCode string, err error) bool {
 	if expectErr == "" && expectErrCode == "" && err != nil {
 		return t.unexpectedError(sql, pos, err)
 	}

--- a/sql/main_test.go
+++ b/sql/main_test.go
@@ -86,7 +86,8 @@ func (c *CommandFilters) runFiltersInternal(args storagebase.FilterArgs) *roachp
 // Returns a closure that the client must run for doing cleanup when the
 // filter should be deregistered.
 func (c *CommandFilters) AppendFilter(
-	filter storagebase.ReplicaCommandFilter, idempotent bool) func() {
+	filter storagebase.ReplicaCommandFilter, idempotent bool,
+) func() {
 
 	c.Lock()
 	defer c.Unlock()

--- a/sql/metric_util_test.go
+++ b/sql/metric_util_test.go
@@ -26,17 +26,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-func checkCounterEQ(
-	t *testing.T, s serverutils.TestServerInterface, meta metric.Metadata, e int64,
-) {
+func checkCounterEQ(t *testing.T, s serverutils.TestServerInterface, meta metric.Metadata, e int64) {
 	if a := s.MustGetSQLCounter(meta.Name); a != e {
 		t.Error(errors.Errorf("stat %s: actual %d != expected %d", meta.Name, a, e))
 	}
 }
 
-func checkCounterGE(
-	t *testing.T, s serverutils.TestServerInterface, meta metric.Metadata, e int64,
-) {
+func checkCounterGE(t *testing.T, s serverutils.TestServerInterface, meta metric.Metadata, e int64) {
 	if a := s.MustGetSQLCounter(meta.Name); a < e {
 		t.Error(errors.Errorf("stat %s: expected: actual %d >= %d", meta.Name, a, e))
 	}

--- a/sql/parser/eval.go
+++ b/sql/parser/eval.go
@@ -2403,7 +2403,9 @@ func anchorPattern(pattern string, caseInsensitive bool) string {
 
 // FindEqualComparisonFunction looks up an overload of the "=" operator
 // for a given pair of input operand types.
-func FindEqualComparisonFunction(leftType, rightType Datum) (func(*EvalContext, Datum, Datum) (DBool, error), bool) {
+func FindEqualComparisonFunction(
+	leftType, rightType Datum,
+) (func(*EvalContext, Datum, Datum) (DBool, error), bool) {
 	fn, found := CmpOps[EQ].lookupImpl(leftType, rightType)
 	if found {
 		return fn.fn, true

--- a/sql/parser/type_check.go
+++ b/sql/parser/type_check.go
@@ -771,7 +771,9 @@ type indexedExpr struct {
 // typeCheckSameTypedExprs type checks a list of expressions, asserting that all
 // resolved TypeExprs have the same type. An optional desired type can be provided,
 // which will hint that type which the expressions should resolve to, if possible.
-func typeCheckSameTypedExprs(ctx *SemaContext, desired Datum, exprs ...Expr) ([]TypedExpr, Datum, error) {
+func typeCheckSameTypedExprs(
+	ctx *SemaContext, desired Datum, exprs ...Expr,
+) ([]TypedExpr, Datum, error) {
 	switch len(exprs) {
 	case 0:
 		return nil, nil, nil
@@ -948,7 +950,9 @@ func typeCheckSameTypedExprs(ctx *SemaContext, desired Datum, exprs ...Expr) ([]
 // expressions are tuples, and will return a sane error if they are not. An optional
 // desired type can be provided, which will hint that type which the expressions should
 // resolve to, if possible.
-func typeCheckSameTypedTupleExprs(ctx *SemaContext, desired Datum, exprs ...Expr) ([]TypedExpr, Datum, error) {
+func typeCheckSameTypedTupleExprs(
+	ctx *SemaContext, desired Datum, exprs ...Expr,
+) ([]TypedExpr, Datum, error) {
 	// Hold the resolved type expressions of the provided exprs, in order.
 	// TODO(nvanbenschoten) Look into reducing allocations here.
 	typedExprs := make([]TypedExpr, len(exprs))

--- a/sql/pg_catalog.go
+++ b/sql/pg_catalog.go
@@ -413,8 +413,7 @@ func (h oidHasher) DBOid(db *sqlbase.DatabaseDescriptor) *parser.DInt {
 }
 
 func (h oidHasher) TableOid(
-	db *sqlbase.DatabaseDescriptor,
-	table *sqlbase.TableDescriptor,
+	db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor,
 ) *parser.DInt {
 	h.writeTypeTag(tableTypeTag)
 	h.writeDB(db)
@@ -423,9 +422,7 @@ func (h oidHasher) TableOid(
 }
 
 func (h oidHasher) IndexOid(
-	db *sqlbase.DatabaseDescriptor,
-	table *sqlbase.TableDescriptor,
-	index *sqlbase.IndexDescriptor,
+	db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor, index *sqlbase.IndexDescriptor,
 ) *parser.DInt {
 	h.writeTypeTag(indexTypeTag)
 	h.writeDB(db)
@@ -435,9 +432,7 @@ func (h oidHasher) IndexOid(
 }
 
 func (h oidHasher) ColumnOid(
-	db *sqlbase.DatabaseDescriptor,
-	table *sqlbase.TableDescriptor,
-	column *sqlbase.ColumnDescriptor,
+	db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor, column *sqlbase.ColumnDescriptor,
 ) *parser.DInt {
 	h.writeTypeTag(columnTypeTag)
 	h.writeDB(db)

--- a/sql/pgwire/v3.go
+++ b/sql/pgwire/v3.go
@@ -721,7 +721,9 @@ func (c *v3Conn) sendErrorWithCode(errCode string, errCtx sqlbase.SrcCtx, errToS
 }
 
 // sendResponse sends the results as a query response.
-func (c *v3Conn) sendResponse(results sql.ResultList, formatCodes []formatCode, sendDescription bool, limit int) error {
+func (c *v3Conn) sendResponse(
+	results sql.ResultList, formatCodes []formatCode, sendDescription bool, limit int,
+) error {
 	if len(results) == 0 {
 		return c.sendCommandComplete(nil)
 	}

--- a/sql/pgwire_test.go
+++ b/sql/pgwire_test.go
@@ -1045,8 +1045,7 @@ func TestPGCommandTags(t *testing.T) {
 // checkSQLNetworkMetrics returns the server's pgwire bytesIn/bytesOut and an
 // error if the bytesIn/bytesOut don't satisfy the given minimums and maximums.
 func checkSQLNetworkMetrics(
-	s serverutils.TestServerInterface,
-	minBytesIn, minBytesOut, maxBytesIn, maxBytesOut int64,
+	s serverutils.TestServerInterface, minBytesIn, minBytesOut, maxBytesIn, maxBytesOut int64,
 ) (int64, int64, error) {
 	if err := s.WriteSummaries(); err != nil {
 		return -1, -1, err

--- a/sql/plan.go
+++ b/sql/plan.go
@@ -227,7 +227,9 @@ func (p *planner) makePlan(stmt parser.Statement, autoCommit bool) (planNode, er
 
 // newPlan constructs a planNode from a statement. This is used
 // recursively by the various node constructors.
-func (p *planner) newPlan(stmt parser.Statement, desiredTypes []parser.Datum, autoCommit bool) (planNode, error) {
+func (p *planner) newPlan(
+	stmt parser.Statement, desiredTypes []parser.Datum, autoCommit bool,
+) (planNode, error) {
 	tracing.AnnotateTrace()
 
 	// This will set the system DB trigger for transactions containing

--- a/sql/planner.go
+++ b/sql/planner.go
@@ -274,8 +274,7 @@ func (p *planner) blockConfigUpdatesMaybe(e *Executor) func() {
 }
 
 // checkTestingVerifyMetadataInitialOrDie implements the queryRunner interface.
-func (p *planner) checkTestingVerifyMetadataInitialOrDie(
-	e *Executor, stmts parser.StatementList) {
+func (p *planner) checkTestingVerifyMetadataInitialOrDie(e *Executor, stmts parser.StatementList) {
 	if !p.execCfg.TestingKnobs.WaitForGossipUpdate {
 		return
 	}
@@ -293,8 +292,7 @@ func (p *planner) checkTestingVerifyMetadataInitialOrDie(
 }
 
 // checkTestingVerifyMetadataOrDie implements the queryRunner interface.
-func (p *planner) checkTestingVerifyMetadataOrDie(
-	e *Executor, stmts parser.StatementList) {
+func (p *planner) checkTestingVerifyMetadataOrDie(e *Executor, stmts parser.StatementList) {
 	if !p.execCfg.TestingKnobs.WaitForGossipUpdate ||
 		p.testingVerifyMetadataFn == nil {
 		return

--- a/sql/prepare.go
+++ b/sql/prepare.go
@@ -67,10 +67,7 @@ func (ps PreparedStatements) Exists(name string) bool {
 // query string, using the given PlaceholderTypes hints to assist in inferring
 // placeholder types.
 func (ps PreparedStatements) New(
-	ctx context.Context,
-	e *Executor,
-	name, query string,
-	placeholderHints parser.PlaceholderTypes,
+	ctx context.Context, e *Executor, name, query string, placeholderHints parser.PlaceholderTypes,
 ) (*PreparedStatement, error) {
 	stmt := &PreparedStatement{}
 
@@ -186,7 +183,8 @@ func (pp PreparedPortals) Exists(name string) bool {
 
 // New creates a new PreparedPortal with the provided name and corresponding
 // PreparedStatement, binding the statement using the given QueryArguments.
-func (pp PreparedPortals) New(name string, stmt *PreparedStatement, qargs parser.QueryArguments,
+func (pp PreparedPortals) New(
+	name string, stmt *PreparedStatement, qargs parser.QueryArguments,
 ) (*PreparedPortal, error) {
 	portal := &PreparedPortal{
 		Stmt:  stmt,

--- a/sql/rowwriter.go
+++ b/sql/rowwriter.go
@@ -57,11 +57,7 @@ type rowHelper struct {
 // encodeSecondaryIndexes.
 func (rh *rowHelper) encodeIndexes(
 	colIDtoRowIndex map[sqlbase.ColumnID]int, values []parser.Datum,
-) (
-	primaryIndexKey []byte,
-	secondaryIndexEntries []sqlbase.IndexEntry,
-	err error,
-) {
+) (primaryIndexKey []byte, secondaryIndexEntries []sqlbase.IndexEntry, err error) {
 	if rh.primaryIndexKeyPrefix == nil {
 		rh.primaryIndexKeyPrefix = sqlbase.MakeIndexKeyPrefix(rh.tableDesc,
 			rh.tableDesc.PrimaryIndex.ID)
@@ -83,10 +79,7 @@ func (rh *rowHelper) encodeIndexes(
 // encodeSecondaryIndexes.
 func (rh *rowHelper) encodeSecondaryIndexes(
 	colIDtoRowIndex map[sqlbase.ColumnID]int, values []parser.Datum,
-) (
-	secondaryIndexEntries []sqlbase.IndexEntry,
-	err error,
-) {
+) (secondaryIndexEntries []sqlbase.IndexEntry, err error) {
 	if len(rh.indexEntries) != len(rh.indexes) {
 		rh.indexEntries = make([]sqlbase.IndexEntry, len(rh.indexes))
 	}
@@ -520,10 +513,7 @@ func makeRowUpdater(
 //
 // The return value is only good until the next call to UpdateRow.
 func (ru *rowUpdater) updateRow(
-	ctx context.Context,
-	b *client.Batch,
-	oldValues []parser.Datum,
-	updateValues []parser.Datum,
+	ctx context.Context, b *client.Batch, oldValues []parser.Datum, updateValues []parser.Datum,
 ) ([]parser.Datum, error) {
 	if len(oldValues) != len(ru.fetchCols) {
 		return nil, errors.Errorf("got %d values but expected %d", len(oldValues), len(ru.fetchCols))

--- a/sql/rsg_test.go
+++ b/sql/rsg_test.go
@@ -179,7 +179,9 @@ func TestRandomSyntaxFuncCommon(t *testing.T) {
 }
 
 // testRandomSyntax performs all of the RSG setup and teardown for common random syntax testing operations. It takes f, a closure where the random expression should be generated and executed. It returns a boolean indicating if the statement executed successfully. This is used to verify that at least 1 success occurs (otherwise it is likely a bad test).
-func testRandomSyntax(t *testing.T, setup func(db *gosql.DB) error, f func(db *gosql.DB, r *rsg.RSG) (success bool)) {
+func testRandomSyntax(
+	t *testing.T, setup func(db *gosql.DB) error, f func(db *gosql.DB, r *rsg.RSG) (success bool),
+) {
 	if *flagRSGTime == 0 {
 		t.Skip("enable with '-rsg <duration>'")
 	}

--- a/sql/schema_changer.go
+++ b/sql/schema_changer.go
@@ -62,7 +62,8 @@ type SchemaChanger struct {
 func (sc *SchemaChanger) truncateAndDropTable(
 	ctx context.Context,
 	lease *sqlbase.TableDescriptor_SchemaChangeLease,
-	tableDesc *sqlbase.TableDescriptor) error {
+	tableDesc *sqlbase.TableDescriptor,
+) error {
 
 	l, err := sc.ExtendLease(*lease)
 	if err != nil {
@@ -197,8 +198,7 @@ func isSchemaChangeRetryError(err error) bool {
 // Execute the entire schema change in steps. startBackfillNotification is
 // called before the backfill starts; it can be nil.
 func (sc SchemaChanger) exec(
-	startBackfillNotification func() error,
-	oldNameNotInUseNotification func(),
+	startBackfillNotification func() error, oldNameNotInUseNotification func(),
 ) error {
 	// Acquire lease.
 	lease, err := sc.AcquireLease()

--- a/sql/select.go
+++ b/sql/select.go
@@ -217,7 +217,9 @@ func (s *selectNode) Close() {
 }
 
 // Select selects rows from a SELECT/UNION/VALUES, ordering and/or limiting them.
-func (p *planner) Select(n *parser.Select, desiredTypes []parser.Datum, autoCommit bool) (planNode, error) {
+func (p *planner) Select(
+	n *parser.Select, desiredTypes []parser.Datum, autoCommit bool,
+) (planNode, error) {
 	wrapped := n.Select
 	limit := n.Limit
 	orderBy := n.OrderBy

--- a/sql/select_qvalue.go
+++ b/sql/select_qvalue.go
@@ -288,7 +288,9 @@ func (s *starDatum) String() string { return parser.AsString(s) }
 func (s *starDatum) Walk(v parser.Visitor) parser.Expr { return s }
 
 // TypeCheck implements the Expr interface.
-func (s *starDatum) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.TypedExpr, error) {
+func (s *starDatum) TypeCheck(
+	_ *parser.SemaContext, desired parser.Datum,
+) (parser.TypedExpr, error) {
 	return s, nil
 }
 

--- a/sql/session.go
+++ b/sql/session.go
@@ -409,8 +409,7 @@ type schemaChangerCollection struct {
 	}
 }
 
-func (scc *schemaChangerCollection) queueSchemaChanger(
-	schemaChanger SchemaChanger) {
+func (scc *schemaChangerCollection) queueSchemaChanger(schemaChanger SchemaChanger) {
 	scc.schemaChangers = append(
 		scc.schemaChangers,
 		struct {

--- a/sql/sqlbase/errors.go
+++ b/sql/sqlbase/errors.go
@@ -178,9 +178,7 @@ func (e *ErrNonNullViolation) SrcContext() SrcCtx {
 
 // NewUniquenessConstraintViolationError creates a new
 // ErrUniquenessConstrainViolation.
-func NewUniquenessConstraintViolationError(
-	index *IndexDescriptor, vals []parser.Datum,
-) error {
+func NewUniquenessConstraintViolationError(index *IndexDescriptor, vals []parser.Datum) error {
 	return &ErrUniquenessConstraintViolation{
 		ctx:   MakeSrcCtx(1),
 		index: index,

--- a/sql/sqlbase/rowfetcher.go
+++ b/sql/sqlbase/rowfetcher.go
@@ -255,9 +255,9 @@ func (rf *RowFetcher) ReadIndexKey(k roachpb.Key) (remaining []byte, ok bool, er
 // ProcessKV processes the given key/value, setting values in the row
 // accordingly. If debugStrings is true, returns pretty printed key and value
 // information in prettyKey/prettyValue (otherwise they are empty strings).
-func (rf *RowFetcher) ProcessKV(kv client.KeyValue, debugStrings bool) (
-	prettyKey string, prettyValue string, err error,
-) {
+func (rf *RowFetcher) ProcessKV(
+	kv client.KeyValue, debugStrings bool,
+) (prettyKey string, prettyValue string, err error) {
 	if debugStrings {
 		prettyKey = fmt.Sprintf("/%s/%s%s", rf.desc.Name, rf.index.Name, prettyDatums(rf.keyVals))
 	}
@@ -491,9 +491,7 @@ func (rf *RowFetcher) NextRow() (parser.DTuple, error) {
 // NextKeyDebug processes one key at a time and returns a pretty printed key and
 // value. If we completed a row, the row is returned as well (see nextRow). If
 // there are no more keys, prettyKey is "".
-func (rf *RowFetcher) NextKeyDebug() (
-	prettyKey string, prettyValue string, row parser.DTuple, err error,
-) {
+func (rf *RowFetcher) NextKeyDebug() (prettyKey string, prettyValue string, row parser.DTuple, err error) {
 	if rf.kvEnd {
 		return "", "", nil, nil
 	}

--- a/sql/sqlbase/structured.go
+++ b/sql/sqlbase/structured.go
@@ -1244,7 +1244,9 @@ func (desc *TableDescriptor) RenameColumnNormalized(colID ColumnID, newColName s
 
 // FindActiveColumnsByNames finds all requested columns (in the requested order)
 // or returns an error.
-func (desc *TableDescriptor) FindActiveColumnsByNames(names parser.NameList) ([]ColumnDescriptor, error) {
+func (desc *TableDescriptor) FindActiveColumnsByNames(
+	names parser.NameList,
+) ([]ColumnDescriptor, error) {
 	cols := make([]ColumnDescriptor, len(names))
 	for i := range names {
 		c, err := desc.FindActiveColumnByName(names[i])
@@ -1259,7 +1261,9 @@ func (desc *TableDescriptor) FindActiveColumnsByNames(names parser.NameList) ([]
 // FindColumnByNormalizedName finds the column with the specified name. It returns
 // DescriptorStatus for the column, and an index into either the columns
 // (status == DescriptorActive) or mutations (status == DescriptorIncomplete).
-func (desc *TableDescriptor) FindColumnByNormalizedName(normName string) (DescriptorStatus, int, error) {
+func (desc *TableDescriptor) FindColumnByNormalizedName(
+	normName string,
+) (DescriptorStatus, int, error) {
 	for i, c := range desc.Columns {
 		if ReNormalizeName(c.Name) == normName {
 			return DescriptorActive, i, nil
@@ -1281,7 +1285,9 @@ func (desc *TableDescriptor) FindColumnByName(name parser.Name) (DescriptorStatu
 }
 
 // FindActiveColumnByNormalizedName finds an active column with the specified normalized name.
-func (desc *TableDescriptor) FindActiveColumnByNormalizedName(normName string) (ColumnDescriptor, error) {
+func (desc *TableDescriptor) FindActiveColumnByNormalizedName(
+	normName string,
+) (ColumnDescriptor, error) {
 	for _, c := range desc.Columns {
 		if ReNormalizeName(c.Name) == normName {
 			return c, nil
@@ -1335,7 +1341,9 @@ func (desc *TableDescriptor) FindFamilyByID(id FamilyID) (*ColumnFamilyDescripto
 // FindIndexByNormalizedName finds the index with the specified name. It returns
 // DescriptorStatus for the index, and an index into either the indexes
 // (status == DescriptorActive) or mutations (status == DescriptorIncomplete).
-func (desc *TableDescriptor) FindIndexByNormalizedName(normName string) (DescriptorStatus, int, error) {
+func (desc *TableDescriptor) FindIndexByNormalizedName(
+	normName string,
+) (DescriptorStatus, int, error) {
 	for i, idx := range desc.Indexes {
 		if ReNormalizeName(idx.Name) == normName {
 			return DescriptorActive, i, nil
@@ -1415,13 +1423,17 @@ func (desc *TableDescriptor) MakeMutationComplete(m DescriptorMutation) {
 }
 
 // AddColumnMutation adds a column mutation to desc.Mutations.
-func (desc *TableDescriptor) AddColumnMutation(c ColumnDescriptor, direction DescriptorMutation_Direction) {
+func (desc *TableDescriptor) AddColumnMutation(
+	c ColumnDescriptor, direction DescriptorMutation_Direction,
+) {
 	m := DescriptorMutation{Descriptor_: &DescriptorMutation_Column{Column: &c}, Direction: direction}
 	desc.addMutation(m)
 }
 
 // AddIndexMutation adds an index mutation to desc.Mutations.
-func (desc *TableDescriptor) AddIndexMutation(idx IndexDescriptor, direction DescriptorMutation_Direction) {
+func (desc *TableDescriptor) AddIndexMutation(
+	idx IndexDescriptor, direction DescriptorMutation_Direction,
+) {
 	m := DescriptorMutation{Descriptor_: &DescriptorMutation_Index{Index: &idx}, Direction: direction}
 	desc.addMutation(m)
 }

--- a/sql/sqlbase/table.go
+++ b/sql/sqlbase/table.go
@@ -38,7 +38,9 @@ func exprContainsVarsError(context string, Expr parser.Expr) error {
 	return fmt.Errorf("%s expression '%s' may not contain variable sub-expressions", context, Expr)
 }
 
-func incompatibleExprTypeError(context string, expectedType parser.Datum, actualType parser.Datum) error {
+func incompatibleExprTypeError(
+	context string, expectedType parser.Datum, actualType parser.Datum,
+) error {
 	return fmt.Errorf("incompatible type for %s expression: %s vs %s",
 		context, expectedType.Type(), actualType.Type())
 }
@@ -282,10 +284,7 @@ func EncodeColumns(
 // MakeKeyFromEncDatums creates a key by concatenating keyPrefix with the
 // encodings of the given EncDatum values.
 func MakeKeyFromEncDatums(
-	values EncDatumRow,
-	directions []IndexDescriptor_Direction,
-	keyPrefix []byte,
-	alloc *DatumAlloc,
+	values EncDatumRow, directions []IndexDescriptor_Direction, keyPrefix []byte, alloc *DatumAlloc,
 ) (key roachpb.Key, err error) {
 	if len(values) != len(directions) {
 		return nil, errors.Errorf("%d values, %d directions", len(values), len(directions))
@@ -445,9 +444,7 @@ func EncodeTableValue(appendTo []byte, colID ColumnID, val parser.Datum) ([]byte
 
 // MakeKeyVals returns a slice of Datums with the correct types for the given
 // columns.
-func MakeKeyVals(
-	desc *TableDescriptor, columnIDs []ColumnID,
-) ([]parser.Datum, error) {
+func MakeKeyVals(desc *TableDescriptor, columnIDs []ColumnID) ([]parser.Datum, error) {
 	vals := make([]parser.Datum, len(columnIDs))
 	for i, id := range columnIDs {
 		col, err := desc.FindActiveColumnByID(id)
@@ -484,9 +481,9 @@ func DecodeTableIDIndexID(key []byte) ([]byte, ID, IndexID, error) {
 // index id and a slice for the rest of the key.
 //
 // Don't use this function in the scan "hot path".
-func DecodeIndexKeyPrefix(a *DatumAlloc, desc *TableDescriptor, key []byte) (
-	indexID IndexID, remaining []byte, err error,
-) {
+func DecodeIndexKeyPrefix(
+	a *DatumAlloc, desc *TableDescriptor, key []byte,
+) (indexID IndexID, remaining []byte, err error) {
 	// TODO(dan): This whole operation is n^2 because of the interleaves
 	// bookkeeping. We could improve it to n with a prefix tree of components.
 
@@ -614,8 +611,9 @@ func DecodeIndexKey(
 // are returned. A slice of directions can be provided to enforce encoding
 // direction on each value in valTypes. If this slice is nil, the direction
 // used will default to encoding.Ascending.
-func DecodeKeyVals(a *DatumAlloc, valTypes, vals []parser.Datum,
-	directions []encoding.Direction, key []byte) ([]byte, error) {
+func DecodeKeyVals(
+	a *DatumAlloc, valTypes, vals []parser.Datum, directions []encoding.Direction, key []byte,
+) ([]byte, error) {
 	if directions != nil && len(directions) != len(valTypes) {
 		return nil, errors.Errorf("encoding directions doesn't parallel valTypes: %d vs %d.",
 			len(directions), len(valTypes))
@@ -639,9 +637,7 @@ func DecodeKeyVals(a *DatumAlloc, valTypes, vals []parser.Datum,
 //
 // Don't use this function in the scan "hot path".
 func ExtractIndexKey(
-	a *DatumAlloc,
-	tableDesc *TableDescriptor,
-	entry client.KeyValue,
+	a *DatumAlloc, tableDesc *TableDescriptor, entry client.KeyValue,
 ) (roachpb.Key, error) {
 	indexID, key, err := DecodeIndexKeyPrefix(a, tableDesc, entry.Key)
 	if err != nil {
@@ -1409,7 +1405,9 @@ func (desc TableDescriptor) CheckUniqueConstraints() error {
 
 // if `txn` is non-nil, provide a full summary of constraints, otherwise just
 // check that constraints have unique names.
-func (desc TableDescriptor) collectConstraintInfo(txn *client.Txn) (map[string]ConstraintDetail, error) {
+func (desc TableDescriptor) collectConstraintInfo(
+	txn *client.Txn,
+) (map[string]ConstraintDetail, error) {
 	info := make(map[string]ConstraintDetail)
 
 	// Indexes provide PK, Unique and FK constraints.

--- a/sql/subquery.go
+++ b/sql/subquery.go
@@ -261,8 +261,9 @@ type collectSubqueryPlansVisitor struct {
 
 var _ parser.Visitor = &collectSubqueryPlansVisitor{}
 
-func (v *collectSubqueryPlansVisitor) VisitPre(expr parser.Expr) (
-	recurse bool, newExpr parser.Expr) {
+func (v *collectSubqueryPlansVisitor) VisitPre(
+	expr parser.Expr,
+) (recurse bool, newExpr parser.Expr) {
 	if sq, ok := expr.(*subquery); ok {
 		if sq.plan == nil {
 			panic("cannot collect the sub-plans before they were expanded")

--- a/sql/table_join.go
+++ b/sql/table_join.go
@@ -125,7 +125,9 @@ type crossPredicate struct{}
 func (p *crossPredicate) eval(_, _ parser.DTuple) (bool, error) {
 	return true, nil
 }
-func (p *crossPredicate) prepareRow(result parser.DTuple, leftRow parser.DTuple, rightRow parser.DTuple) {
+func (p *crossPredicate) prepareRow(
+	result parser.DTuple, leftRow parser.DTuple, rightRow parser.DTuple,
+) {
 	prepareRowConcat(result, leftRow, rightRow)
 }
 func (p *crossPredicate) start() error                        { return nil }
@@ -157,7 +159,9 @@ func (p *onPredicate) eval(leftRow parser.DTuple, rightRow parser.DTuple) (bool,
 	return sqlbase.RunFilter(p.filter, &p.p.evalCtx)
 }
 
-func (p *onPredicate) prepareRow(result parser.DTuple, leftRow parser.DTuple, rightRow parser.DTuple) {
+func (p *onPredicate) prepareRow(
+	result parser.DTuple, leftRow parser.DTuple, rightRow parser.DTuple,
+) {
 	prepareRowConcat(result, leftRow, rightRow)
 }
 
@@ -267,7 +271,9 @@ func (p *usingPredicate) eval(leftRow parser.DTuple, rightRow parser.DTuple) (bo
 // clauses and CROSS JOIN: a result row contains first the values for
 // the USING columns; then the non-USING values from the left input
 // row, then the non-USING values from the right input row.
-func (p *usingPredicate) prepareRow(result parser.DTuple, leftRow parser.DTuple, rightRow parser.DTuple) {
+func (p *usingPredicate) prepareRow(
+	result parser.DTuple, leftRow parser.DTuple, rightRow parser.DTuple,
+) {
 	d := 0
 	for k, j := range p.leftUsingIndices {
 		// The result for USING columns must be computed as per COALESCE().
@@ -442,10 +448,7 @@ func commonColumns(left, right *dataSourceInfo) parser.NameList {
 // The tableInfo field from the left node is taken over (overwritten)
 // by the new node.
 func (p *planner) makeJoin(
-	astJoinType string,
-	left planDataSource,
-	right planDataSource,
-	cond parser.JoinCond,
+	astJoinType string, left planDataSource, right planDataSource, cond parser.JoinCond,
 ) (planDataSource, error) {
 	leftInfo, rightInfo := left.info, right.info
 

--- a/sql/txn_restart_test.go
+++ b/sql/txn_restart_test.go
@@ -67,9 +67,7 @@ type filterVals struct {
 	failedValues map[string]failureRecord
 }
 
-func createFilterVals(
-	restartCounts map[string]int,
-	abortCounts map[string]int) *filterVals {
+func createFilterVals(restartCounts map[string]int, abortCounts map[string]int) *filterVals {
 	return &filterVals{
 		restartCounts: restartCounts,
 		abortCounts:   abortCounts,
@@ -106,11 +104,7 @@ func checkCorrectTxn(value string, magicVals *filterVals, txn *roachpb.Transacti
 	delete(magicVals.failedValues, value)
 }
 
-func injectErrors(
-	req roachpb.Request,
-	hdr roachpb.Header,
-	magicVals *filterVals,
-) error {
+func injectErrors(req roachpb.Request, hdr roachpb.Header, magicVals *filterVals) error {
 	magicVals.Lock()
 	defer magicVals.Unlock()
 
@@ -343,9 +337,7 @@ func (ta *TxnAborter) GetExecCount(stmt string) (int, bool) {
 
 // HookupToExecutor returns a modified ExecutorTestingKnobs with the
 // StatementFilter hooked up to the TxnAborter.
-func (ta *TxnAborter) HookupToExecutor(
-	knobs sql.ExecutorTestingKnobs,
-) base.ModuleTestingKnobs {
+func (ta *TxnAborter) HookupToExecutor(knobs sql.ExecutorTestingKnobs) base.ModuleTestingKnobs {
 	if !knobs.FixTxnPriority || !knobs.DisableAutoCommit {
 		panic("TxnAborter can only be installed when " +
 			"FixTxnPriority and DisableAutoCommit are both specified")

--- a/sql/union.go
+++ b/sql/union.go
@@ -25,7 +25,9 @@ import (
 )
 
 // UnionClause constructs a planNode from a UNION/INTERSECT/EXCEPT expression.
-func (p *planner) UnionClause(n *parser.UnionClause, desiredTypes []parser.Datum, autoCommit bool) (planNode, error) {
+func (p *planner) UnionClause(
+	n *parser.UnionClause, desiredTypes []parser.Datum, autoCommit bool,
+) (planNode, error) {
 	var emitAll = false
 	var emit unionNodeEmit
 	switch n.Type {

--- a/sql/update.go
+++ b/sql/update.go
@@ -39,7 +39,9 @@ type editNodeBase struct {
 	autoCommit bool
 }
 
-func (p *planner) makeEditNode(tn *parser.TableName, autoCommit bool, priv privilege.Kind) (editNodeBase, error) {
+func (p *planner) makeEditNode(
+	tn *parser.TableName, autoCommit bool, priv privilege.Kind,
+) (editNodeBase, error) {
 	tableDesc, err := p.getTableLease(tn)
 	if err != nil {
 		return editNodeBase{}, err
@@ -71,7 +73,9 @@ type editNodeRun struct {
 	explain explainMode
 }
 
-func (r *editNodeRun) initEditNode(en *editNodeBase, rows planNode, re parser.ReturningExprs, desiredTypes []parser.Datum) error {
+func (r *editNodeRun) initEditNode(
+	en *editNodeBase, rows planNode, re parser.ReturningExprs, desiredTypes []parser.Datum,
+) error {
 	r.rows = rows
 
 	rh, err := en.p.makeReturningHelper(re, desiredTypes, en.tableDesc.Name, en.tableDesc.Columns)
@@ -129,7 +133,9 @@ type updateNode struct {
 //   Notes: postgres requires UPDATE. Requires SELECT with WHERE clause with table.
 //          mysql requires UPDATE. Also requires SELECT with WHERE clause with table.
 // TODO(guanqun): need to support CHECK in UPDATE
-func (p *planner) Update(n *parser.Update, desiredTypes []parser.Datum, autoCommit bool) (planNode, error) {
+func (p *planner) Update(
+	n *parser.Update, desiredTypes []parser.Datum, autoCommit bool,
+) (planNode, error) {
 	tracing.AnnotateTrace()
 
 	tn, err := p.getAliasedTableName(n.Table)

--- a/sql/values.go
+++ b/sql/values.go
@@ -51,7 +51,9 @@ func (p *planner) newContainerValuesNode(columns ResultColumns, capacity int) *v
 	}
 }
 
-func (p *planner) ValuesClause(n *parser.ValuesClause, desiredTypes []parser.Datum) (planNode, error) {
+func (p *planner) ValuesClause(
+	n *parser.ValuesClause, desiredTypes []parser.Datum,
+) (planNode, error) {
 	v := &valuesNode{
 		p:            p,
 		n:            n,

--- a/sql/virtual_schema.go
+++ b/sql/virtual_schema.go
@@ -210,7 +210,9 @@ func (e *Executor) IsVirtualDatabase(name string) bool {
 // pair. The function will return the table's virtual table entry if the name matches
 // a specific table. It will return an error if the name references a virtual database
 // but the table is non-existent.
-func (vs *virtualSchemaHolder) getVirtualTableEntry(tn *parser.TableName) (virtualTableEntry, error) {
+func (vs *virtualSchemaHolder) getVirtualTableEntry(
+	tn *parser.TableName,
+) (virtualTableEntry, error) {
 	if db, ok := vs.getVirtualSchemaEntry(tn.Database()); ok {
 		if t, ok := db.tables[sqlbase.NormalizeName(tn.TableName)]; ok {
 			return t, nil
@@ -222,7 +224,9 @@ func (vs *virtualSchemaHolder) getVirtualTableEntry(tn *parser.TableName) (virtu
 
 // getVirtualTableDesc checks if the provided name matches a virtual database/table
 // pair, and returns its descriptor if it does.
-func (vs *virtualSchemaHolder) getVirtualTableDesc(tn *parser.TableName) (*sqlbase.TableDescriptor, error) {
+func (vs *virtualSchemaHolder) getVirtualTableDesc(
+	tn *parser.TableName,
+) (*sqlbase.TableDescriptor, error) {
 	t, err := vs.getVirtualTableEntry(tn)
 	if err != nil {
 		return nil, err

--- a/sql/window.go
+++ b/sql/window.go
@@ -190,8 +190,7 @@ func (n *windowNode) constructWindowDefinitions(sc *parser.SelectClause, s *sele
 // modification. If the provided WindowDef does reference a named window spec, then the
 // referenced spec will be overridden with any extra clauses from the WindowDef and returned.
 func constructWindowDef(
-	def parser.WindowDef,
-	namedWindowSpecs map[string]*parser.WindowDef,
+	def parser.WindowDef, namedWindowSpecs map[string]*parser.WindowDef,
 ) (parser.WindowDef, error) {
 	modifyRef := false
 	var refName string
@@ -764,7 +763,9 @@ func (v *extractWindowFuncsVisitor) VisitPost(expr parser.Expr) parser.Expr {
 // - Window functions can wrap aggregates.
 // Invalid:    `SELECT NOW() OVER () FROM kv`
 // - NOW() is not an aggregate or a window function.
-func (v extractWindowFuncsVisitor) extract(typedExpr parser.TypedExpr) (parser.TypedExpr, int, error) {
+func (v extractWindowFuncsVisitor) extract(
+	typedExpr parser.TypedExpr,
+) (parser.TypedExpr, int, error) {
 	expr, _ := parser.WalkExpr(&v, typedExpr)
 	if v.err != nil {
 		return nil, 0, v.err
@@ -800,7 +801,9 @@ func (w *windowFuncHolder) String() string { return parser.AsString(w) }
 
 func (w *windowFuncHolder) Walk(v parser.Visitor) parser.Expr { return w }
 
-func (w *windowFuncHolder) TypeCheck(_ *parser.SemaContext, desired parser.Datum) (parser.TypedExpr, error) {
+func (w *windowFuncHolder) TypeCheck(
+	_ *parser.SemaContext, desired parser.Datum,
+) (parser.TypedExpr, error) {
 	return w, nil
 }
 

--- a/storage/abort_cache.go
+++ b/storage/abort_cache.go
@@ -91,10 +91,7 @@ func (sc *AbortCache) ClearData(e engine.Engine) error {
 // Get looks up an abort cache entry recorded for this transaction ID.
 // Returns whether an abort record was found and any error.
 func (sc *AbortCache) Get(
-	ctx context.Context,
-	e engine.Reader,
-	txnID *uuid.UUID,
-	entry *roachpb.AbortCacheEntry,
+	ctx context.Context, e engine.Reader, txnID *uuid.UUID, entry *roachpb.AbortCacheEntry,
 ) (bool, error) {
 	if txnID == nil {
 		return false, errEmptyTxnID
@@ -111,9 +108,7 @@ func (sc *AbortCache) Get(
 // entry.
 // TODO(tschottdorf): should not use a pointer to UUID.
 func (sc *AbortCache) Iterate(
-	ctx context.Context,
-	e engine.Reader,
-	f func([]byte, *uuid.UUID, roachpb.AbortCacheEntry),
+	ctx context.Context, e engine.Reader, f func([]byte, *uuid.UUID, roachpb.AbortCacheEntry),
 ) {
 	_, _ = engine.MVCCIterate(ctx, e, sc.min(), sc.max(), hlc.ZeroTimestamp,
 		true /* consistent */, nil /* txn */, false, /* !reverse */
@@ -180,9 +175,7 @@ func copySeqCache(
 // abort cache. Failures decoding individual cache entries return an error.
 // On success, returns the number of entries (key-value pairs) copied.
 func (sc *AbortCache) CopyInto(
-	e engine.ReadWriter,
-	ms *enginepb.MVCCStats,
-	destRangeID roachpb.RangeID,
+	e engine.ReadWriter, ms *enginepb.MVCCStats, destRangeID roachpb.RangeID,
 ) (int, error) {
 	return copySeqCache(e, ms, sc.rangeID, destRangeID,
 		engine.MakeMVCCMetadataKey(sc.min()), engine.MakeMVCCMetadataKey(sc.max()))
@@ -195,10 +188,7 @@ func (sc *AbortCache) CopyInto(
 // instead of interpreting values through MVCC for efficiency.
 // On success, returns the number of entries (key-value pairs) copied.
 func (sc *AbortCache) CopyFrom(
-	ctx context.Context,
-	e engine.ReadWriter,
-	ms *enginepb.MVCCStats,
-	originRangeID roachpb.RangeID,
+	ctx context.Context, e engine.ReadWriter, ms *enginepb.MVCCStats, originRangeID roachpb.RangeID,
 ) (int, error) {
 	originMin := engine.MakeMVCCMetadataKey(keys.AbortCacheKey(originRangeID, txnIDMin))
 	originMax := engine.MakeMVCCMetadataKey(keys.AbortCacheKey(originRangeID, txnIDMax))
@@ -207,10 +197,7 @@ func (sc *AbortCache) CopyFrom(
 
 // Del removes all abort cache entries for the given transaction.
 func (sc *AbortCache) Del(
-	ctx context.Context,
-	e engine.ReadWriter,
-	ms *enginepb.MVCCStats,
-	txnID *uuid.UUID,
+	ctx context.Context, e engine.ReadWriter, ms *enginepb.MVCCStats, txnID *uuid.UUID,
 ) error {
 	key := keys.AbortCacheKey(sc.rangeID, txnID)
 	return engine.MVCCDelete(ctx, e, ms, key, hlc.ZeroTimestamp, nil /* txn */)
@@ -231,9 +218,7 @@ func (sc *AbortCache) Put(
 	return engine.MVCCPutProto(ctx, e, ms, key, hlc.ZeroTimestamp, nil /* txn */, entry)
 }
 
-func decodeAbortCacheMVCCKey(
-	encKey engine.MVCCKey, dest []byte,
-) (*uuid.UUID, error) {
+func decodeAbortCacheMVCCKey(encKey engine.MVCCKey, dest []byte) (*uuid.UUID, error) {
 	if encKey.IsValue() {
 		return nil, errors.Errorf("key %s is not a raw MVCC value", encKey)
 	}

--- a/storage/abort_cache_test.go
+++ b/storage/abort_cache_test.go
@@ -58,7 +58,9 @@ func init() {
 
 // createTestAbortCache creates an in-memory engine and
 // returns a abort cache using the supplied Range ID.
-func createTestAbortCache(t *testing.T, rangeID roachpb.RangeID, stopper *stop.Stopper) (*AbortCache, engine.Engine) {
+func createTestAbortCache(
+	t *testing.T, rangeID roachpb.RangeID, stopper *stop.Stopper,
+) (*AbortCache, engine.Engine) {
 	return NewAbortCache(rangeID), engine.NewInMem(roachpb.Attributes{}, 1<<20, stopper)
 }
 

--- a/storage/allocator.go
+++ b/storage/allocator.go
@@ -147,8 +147,9 @@ func MakeAllocator(storePool *StorePool, options AllocatorOptions) Allocator {
 // range, as governed by the supplied zone configuration. It returns the
 // required action that should be taken and a replica on which the action should
 // be performed.
-func (a *Allocator) ComputeAction(zone config.ZoneConfig, desc *roachpb.RangeDescriptor) (
-	AllocatorAction, float64) {
+func (a *Allocator) ComputeAction(
+	zone config.ZoneConfig, desc *roachpb.RangeDescriptor,
+) (AllocatorAction, float64) {
 	if a.storePool == nil {
 		// Do nothing if storePool is nil for some unittests.
 		return AllocatorNoop, 0
@@ -190,9 +191,7 @@ func (a *Allocator) ComputeAction(zone config.ZoneConfig, desc *roachpb.RangeDes
 // will be relaxed as necessary, from least specific to most specific, in order
 // to allocate a target.
 func (a *Allocator) AllocateTarget(
-	constraints config.Constraints,
-	existing []roachpb.ReplicaDescriptor,
-	relaxConstraints bool,
+	constraints config.Constraints, existing []roachpb.ReplicaDescriptor, relaxConstraints bool,
 ) (*roachpb.StoreDescriptor, error) {
 	existingNodes := make(nodeIDSet, len(existing))
 	for _, repl := range existing {
@@ -235,7 +234,9 @@ func (a *Allocator) AllocateTarget(
 // the zone config associated with the provided replicas. This will allow it to
 // make correct decisions in the case of ranges with heterogeneous replica
 // requirements (i.e. multiple data centers).
-func (a Allocator) RemoveTarget(existing []roachpb.ReplicaDescriptor, leaseStoreID roachpb.StoreID) (roachpb.ReplicaDescriptor, error) {
+func (a Allocator) RemoveTarget(
+	existing []roachpb.ReplicaDescriptor, leaseStoreID roachpb.StoreID,
+) (roachpb.ReplicaDescriptor, error) {
 	if len(existing) == 0 {
 		return roachpb.ReplicaDescriptor{}, errors.Errorf("must supply at least one replica to allocator.RemoveTarget()")
 	}
@@ -282,9 +283,7 @@ func (a Allocator) RemoveTarget(existing []roachpb.ReplicaDescriptor, leaseStore
 // rebalance. This helps prevent a stampeding herd targeting an abnormally
 // under-utilized store.
 func (a Allocator) RebalanceTarget(
-	constraints config.Constraints,
-	existing []roachpb.ReplicaDescriptor,
-	leaseStoreID roachpb.StoreID,
+	constraints config.Constraints, existing []roachpb.ReplicaDescriptor, leaseStoreID roachpb.StoreID,
 ) *roachpb.StoreDescriptor {
 	if !a.options.AllowRebalance {
 		return nil
@@ -338,18 +337,14 @@ func (a Allocator) selectBad(sl StoreList) *roachpb.StoreDescriptor {
 // stores in the given store list. Any nodes in the supplied 'exclude' list
 // will be disqualified from selection. Returns the selected store, or nil if
 // no such store can be found.
-func (a Allocator) improve(
-	sl StoreList, excluded nodeIDSet,
-) *roachpb.StoreDescriptor {
+func (a Allocator) improve(sl StoreList, excluded nodeIDSet) *roachpb.StoreDescriptor {
 	rcb := rangeCountBalancer{a.randGen}
 	return rcb.improve(sl, excluded)
 }
 
 // shouldRebalance returns whether the specified store is a candidate for
 // having a replica removed from it given the candidate store list.
-func (a Allocator) shouldRebalance(
-	store roachpb.StoreDescriptor, sl StoreList,
-) bool {
+func (a Allocator) shouldRebalance(store roachpb.StoreDescriptor, sl StoreList) bool {
 	rcb := rangeCountBalancer{a.randGen}
 	return rcb.shouldRebalance(store, sl)
 }

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -176,7 +176,11 @@ func createTestAllocator() (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator
 // mockStorePool sets up a collection of a alive and dead stores in the store
 // pool for testing purposes. It also adds dead replicas to the stores and
 // ranges in deadReplicas.
-func mockStorePool(storePool *StorePool, aliveStoreIDs, deadStoreIDs []roachpb.StoreID, deadReplicas []roachpb.ReplicaIdent) {
+func mockStorePool(
+	storePool *StorePool,
+	aliveStoreIDs, deadStoreIDs []roachpb.StoreID,
+	deadReplicas []roachpb.ReplicaIdent,
+) {
 	storePool.mu.Lock()
 	defer storePool.mu.Unlock()
 

--- a/storage/balancer.go
+++ b/storage/balancer.go
@@ -33,8 +33,7 @@ const allocatorRandomCount = 10
 type nodeIDSet map[roachpb.NodeID]struct{}
 
 func formatCandidates(
-	selected *roachpb.StoreDescriptor,
-	candidates []roachpb.StoreDescriptor,
+	selected *roachpb.StoreDescriptor, candidates []roachpb.StoreDescriptor,
 ) string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("[")
@@ -76,9 +75,7 @@ func (rangeCountBalancer) selectBest(sl StoreList) *roachpb.StoreDescriptor {
 	return best
 }
 
-func (rcb rangeCountBalancer) selectGood(
-	sl StoreList, excluded nodeIDSet,
-) *roachpb.StoreDescriptor {
+func (rcb rangeCountBalancer) selectGood(sl StoreList, excluded nodeIDSet) *roachpb.StoreDescriptor {
 	// Consider a random sample of stores from the store list.
 	sl.stores = selectRandom(rcb.rand, allocatorRandomCount, sl, excluded)
 	good := rcb.selectBest(sl)
@@ -113,9 +110,7 @@ func (rangeCountBalancer) selectBad(sl StoreList) *roachpb.StoreDescriptor {
 // improve returns a candidate StoreDescriptor to rebalance a replica to. The
 // strategy is to always converge on the mean range count. If that isn't
 // possible, we don't return any candidate.
-func (rcb rangeCountBalancer) improve(
-	sl StoreList, excluded nodeIDSet,
-) *roachpb.StoreDescriptor {
+func (rcb rangeCountBalancer) improve(sl StoreList, excluded nodeIDSet) *roachpb.StoreDescriptor {
 	// Attempt to select a better candidate from the supplied list.
 	sl.stores = selectRandom(rcb.rand, allocatorRandomCount, sl, excluded)
 	candidate := rcb.selectBest(sl)
@@ -149,9 +144,7 @@ func (rcb rangeCountBalancer) improve(
 // mean range count that permits rebalances away from that store.
 var RebalanceThreshold = envutil.EnvOrDefaultFloat("COCKROACH_REBALANCE_THRESHOLD", 0.05)
 
-func (rangeCountBalancer) shouldRebalance(
-	store roachpb.StoreDescriptor, sl StoreList,
-) bool {
+func (rangeCountBalancer) shouldRebalance(store roachpb.StoreDescriptor, sl StoreList) bool {
 	// TODO(peter,bram,cuong): The FractionUsed check seems suspicious. When a
 	// node becomes fuller than maxFractionUsedThreshold we will always select it
 	// for rebalancing. This is currently utilized by tests.

--- a/storage/client_merge_test.go
+++ b/storage/client_merge_test.go
@@ -46,7 +46,9 @@ func adminMergeArgs(key roachpb.Key) roachpb.AdminMergeRequest {
 	}
 }
 
-func createSplitRanges(store *storage.Store) (*roachpb.RangeDescriptor, *roachpb.RangeDescriptor, *roachpb.Error) {
+func createSplitRanges(
+	store *storage.Store,
+) (*roachpb.RangeDescriptor, *roachpb.RangeDescriptor, *roachpb.Error) {
 	args := adminSplitArgs(roachpb.KeyMin, []byte("b"))
 	if _, err := client.SendWrapped(rg1(store), nil, &args); err != nil {
 		return nil, nil, err

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -914,7 +914,9 @@ func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 
 // getRangeMetadata retrieves the current range descriptor for the target
 // range.
-func getRangeMetadata(key roachpb.RKey, mtc *multiTestContext, t *testing.T) roachpb.RangeDescriptor {
+func getRangeMetadata(
+	key roachpb.RKey, mtc *multiTestContext, t *testing.T,
+) roachpb.RangeDescriptor {
 	// Calls to RangeLookup typically use inconsistent reads, but we
 	// want to do a consistent read here. This is important when we are
 	// considering one of the metadata ranges: we must not do an

--- a/storage/client_split_test.go
+++ b/storage/client_split_test.go
@@ -653,7 +653,9 @@ func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 
 // fillRange writes keys with the given prefix and associated values
 // until bytes bytes have been written or the given range has split.
-func fillRange(store *storage.Store, rangeID roachpb.RangeID, prefix roachpb.Key, bytes int64, t *testing.T) {
+func fillRange(
+	store *storage.Store, rangeID roachpb.RangeID, prefix roachpb.Key, bytes int64, t *testing.T,
+) {
 	src := rand.New(rand.NewSource(0))
 	for {
 		var ms enginepb.MVCCStats
@@ -889,7 +891,9 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 // Nodes 1-5 are stopped; only node 0 is running.
 //
 // See https://github.com/cockroachdb/cockroach/issues/1644.
-func runSetupSplitSnapshotRace(t *testing.T, testFn func(*multiTestContext, roachpb.Key, roachpb.Key)) {
+func runSetupSplitSnapshotRace(
+	t *testing.T, testFn func(*multiTestContext, roachpb.Key, roachpb.Key),
+) {
 	mtc := startMultiTestContext(t, 6)
 	defer mtc.Stop()
 
@@ -1515,10 +1519,7 @@ func BenchmarkStoreRangeSplit(b *testing.B) {
 }
 
 func writeRandomDataToRange(
-	t testing.TB,
-	store *storage.Store,
-	rangeID roachpb.RangeID,
-	keyPrefix []byte,
+	t testing.TB, store *storage.Store, rangeID roachpb.RangeID, keyPrefix []byte,
 ) (midpoint []byte) {
 	src := rand.New(rand.NewSource(0))
 	for i := 0; i < 100; i++ {
@@ -1540,10 +1541,7 @@ func writeRandomDataToRange(
 }
 
 func writeRandomTimeSeriesDataToRange(
-	t testing.TB,
-	store *storage.Store,
-	rangeID roachpb.RangeID,
-	keyPrefix []byte,
+	t testing.TB, store *storage.Store, rangeID roachpb.RangeID, keyPrefix []byte,
 ) (midpoint []byte) {
 	src := rand.New(rand.NewSource(0))
 	r := ts.Resolution10s

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -418,10 +418,7 @@ type multiTestContextKVTransport struct {
 }
 
 func (m *multiTestContext) kvTransportFactory(
-	_ kv.SendOptions,
-	_ *rpc.Context,
-	replicas kv.ReplicaSlice,
-	args roachpb.BatchRequest,
+	_ kv.SendOptions, _ *rpc.Context, replicas kv.ReplicaSlice, args roachpb.BatchRequest,
 ) (kv.Transport, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &multiTestContextKVTransport{
@@ -562,10 +559,7 @@ func (m *multiTestContext) FirstRange() (*roachpb.RangeDescriptor, error) {
 // RangeLookup implements the RangeDescriptorDB interface. It looks up the
 // descriptors for the given (meta) key.
 func (m *multiTestContext) RangeLookup(
-	ctx context.Context,
-	key roachpb.RKey,
-	desc *roachpb.RangeDescriptor,
-	useReverseScan bool,
+	ctx context.Context, key roachpb.RKey, desc *roachpb.RangeDescriptor, useReverseScan bool,
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
 	// DistSender's RangeLookup function will work correctly, as long as
 	// multiTestContext's FirstRange() method returns the correct descriptor for the

--- a/storage/engine/bench_test.go
+++ b/storage/engine/bench_test.go
@@ -74,7 +74,9 @@ type engineMaker func(testing.TB, string) (Engine, *stop.Stopper)
 // numbers of versions. The database is persisted between runs and stored in
 // the current directory as "mvcc_scan_<versions>_<keys>_<valueBytes>" (which
 // is also returned).
-func setupMVCCData(emk engineMaker, numVersions, numKeys, valueBytes int, b *testing.B) (Engine, string, *stop.Stopper) {
+func setupMVCCData(
+	emk engineMaker, numVersions, numKeys, valueBytes int, b *testing.B,
+) (Engine, string, *stop.Stopper) {
 	loc := fmt.Sprintf("mvcc_data_%d_%d_%d", numVersions, numKeys, valueBytes)
 
 	exists := true

--- a/storage/engine/engine_test.go
+++ b/storage/engine/engine_test.go
@@ -35,7 +35,9 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-func ensureRangeEqual(t *testing.T, sortedKeys []string, keyMap map[string][]byte, keyvals []MVCCKeyValue) {
+func ensureRangeEqual(
+	t *testing.T, sortedKeys []string, keyMap map[string][]byte, keyvals []MVCCKeyValue,
+) {
 	if len(keyvals) != len(sortedKeys) {
 		t.Errorf("length mismatch. expected %s, got %s", sortedKeys, keyvals)
 	}

--- a/storage/engine/rocksdb.go
+++ b/storage/engine/rocksdb.go
@@ -306,10 +306,7 @@ func NewRocksDB(
 }
 
 func newMemRocksDB(
-	attrs roachpb.Attributes,
-	cache RocksDBCache,
-	memtableBudget int64,
-	stopper *stop.Stopper,
+	attrs roachpb.Attributes, cache RocksDBCache, memtableBudget int64, stopper *stop.Stopper,
 ) *RocksDB {
 	return &RocksDB{
 		attrs: attrs,
@@ -467,8 +464,9 @@ func (r *RocksDB) Get(key MVCCKey) ([]byte, error) {
 }
 
 // GetProto fetches the value at the specified key and unmarshals it.
-func (r *RocksDB) GetProto(key MVCCKey, msg proto.Message) (
-	ok bool, keyBytes, valBytes int64, err error) {
+func (r *RocksDB) GetProto(
+	key MVCCKey, msg proto.Message,
+) (ok bool, keyBytes, valBytes int64, err error) {
 	return dbGetProto(r.rdb, key, msg)
 }
 
@@ -682,8 +680,9 @@ func (r *rocksDBSnapshot) Get(key MVCCKey) ([]byte, error) {
 	return dbGet(r.handle, key)
 }
 
-func (r *rocksDBSnapshot) GetProto(key MVCCKey, msg proto.Message) (
-	ok bool, keyBytes, valBytes int64, err error) {
+func (r *rocksDBSnapshot) GetProto(
+	key MVCCKey, msg proto.Message,
+) (ok bool, keyBytes, valBytes int64, err error) {
 	return dbGetProto(r.handle, key, msg)
 }
 
@@ -753,8 +752,9 @@ func (r *distinctBatch) Get(key MVCCKey) ([]byte, error) {
 	return dbGet(r.batch, key)
 }
 
-func (r *distinctBatch) GetProto(key MVCCKey, msg proto.Message) (
-	ok bool, keyBytes, valBytes int64, err error) {
+func (r *distinctBatch) GetProto(
+	key MVCCKey, msg proto.Message,
+) (ok bool, keyBytes, valBytes int64, err error) {
 	return dbGetProto(r.batch, key, msg)
 }
 
@@ -836,7 +836,9 @@ func (r *rocksDBBatchIterator) PrevKey() {
 	r.iter.PrevKey()
 }
 
-func (r *rocksDBBatchIterator) ComputeStats(start, end MVCCKey, nowNanos int64) (enginepb.MVCCStats, error) {
+func (r *rocksDBBatchIterator) ComputeStats(
+	start, end MVCCKey, nowNanos int64,
+) (enginepb.MVCCStats, error) {
 	r.batch.flushMutations()
 	return r.iter.ComputeStats(start, end, nowNanos)
 }
@@ -946,8 +948,9 @@ func (r *rocksDBBatch) Get(key MVCCKey) ([]byte, error) {
 	return dbGet(r.batch, key)
 }
 
-func (r *rocksDBBatch) GetProto(key MVCCKey, msg proto.Message) (
-	ok bool, keyBytes, valBytes int64, err error) {
+func (r *rocksDBBatch) GetProto(
+	key MVCCKey, msg proto.Message,
+) (ok bool, keyBytes, valBytes int64, err error) {
 	if r.distinctOpen {
 		panic("distinct batch open")
 	}
@@ -1227,7 +1230,9 @@ func (r *rocksDBIterator) setState(state C.DBIterState) {
 	r.value = state.value
 }
 
-func (r *rocksDBIterator) ComputeStats(start, end MVCCKey, nowNanos int64) (enginepb.MVCCStats, error) {
+func (r *rocksDBIterator) ComputeStats(
+	start, end MVCCKey, nowNanos int64,
+) (enginepb.MVCCStats, error) {
 	result := C.MVCCComputeStats(r.iter, goToCKey(start), goToCKey(end), C.int64_t(nowNanos))
 	ms := enginepb.MVCCStats{}
 	if err := statusToError(result.status); err != nil {
@@ -1401,8 +1406,9 @@ func dbGet(rdb *C.DBEngine, key MVCCKey) ([]byte, error) {
 	return cStringToGoBytes(result), nil
 }
 
-func dbGetProto(rdb *C.DBEngine, key MVCCKey,
-	msg proto.Message) (ok bool, keyBytes, valBytes int64, err error) {
+func dbGetProto(
+	rdb *C.DBEngine, key MVCCKey, msg proto.Message,
+) (ok bool, keyBytes, valBytes int64, err error) {
 	if len(key.Key) == 0 {
 		err = emptyKeyError()
 		return
@@ -1436,8 +1442,9 @@ func dbClear(rdb *C.DBEngine, key MVCCKey) error {
 	return statusToError(C.DBDelete(rdb, goToCKey(key)))
 }
 
-func dbIterate(rdb *C.DBEngine, engine Reader, start, end MVCCKey,
-	f func(MVCCKeyValue) (bool, error)) error {
+func dbIterate(
+	rdb *C.DBEngine, engine Reader, start, end MVCCKey, f func(MVCCKeyValue) (bool, error),
+) error {
 	if !start.Less(end) {
 		return nil
 	}
@@ -1502,7 +1509,9 @@ func (fr *RocksDBSstFileReader) AddFile(path string) error {
 
 // Iterate iterates over the keys between start inclusive and end
 // exclusive, invoking f() on each key/value pair.
-func (fr *RocksDBSstFileReader) Iterate(start, end MVCCKey, f func(MVCCKeyValue) (bool, error)) error {
+func (fr *RocksDBSstFileReader) Iterate(
+	start, end MVCCKey, f func(MVCCKeyValue) (bool, error),
+) error {
 	if fr.rocksDB == nil {
 		return errors.New("cannot call Iterate on a closed reader")
 	}

--- a/storage/entry_cache.go
+++ b/storage/entry_cache.go
@@ -102,8 +102,9 @@ func (rec *raftEntryCache) addEntries(rangeID roachpb.RangeID, ents []raftpb.Ent
 // start with index lo and proceed sequentially without gaps until
 // 1) all entries exclusive of hi are fetched, 2) > maxBytes of
 // entries data is fetched, or 3) a cache miss occurs.
-func (rec *raftEntryCache) getEntries(rangeID roachpb.RangeID, lo, hi, maxBytes uint64) (
-	[]raftpb.Entry, uint64 /* size in bytes */, uint64 /* next log index */) {
+func (rec *raftEntryCache) getEntries(
+	rangeID roachpb.RangeID, lo, hi, maxBytes uint64,
+) ([]raftpb.Entry, uint64, uint64) {
 	rec.Lock()
 	defer rec.Unlock()
 	var ents []raftpb.Entry

--- a/storage/entry_cache_test.go
+++ b/storage/entry_cache_test.go
@@ -41,7 +41,14 @@ func addEntries(rec *raftEntryCache, rangeID roachpb.RangeID, lo, hi uint64) []r
 	return ents
 }
 
-func verifyGet(t *testing.T, rec *raftEntryCache, rangeID roachpb.RangeID, lo, hi uint64, expEnts []raftpb.Entry, expNextIndex uint64) {
+func verifyGet(
+	t *testing.T,
+	rec *raftEntryCache,
+	rangeID roachpb.RangeID,
+	lo, hi uint64,
+	expEnts []raftpb.Entry,
+	expNextIndex uint64,
+) {
 	ents, _, nextIndex := rec.getEntries(rangeID, lo, hi, 0)
 	if !(len(expEnts) == 0 && len(ents) == 0) && !reflect.DeepEqual(expEnts, ents) {
 		t.Fatalf("expected entries %+v; got %+v", expEnts, ents)

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -120,8 +120,9 @@ type resolveFunc func([]roachpb.Intent, bool, bool) error
 // collection, and if so, at what priority. Returns true for shouldQ
 // in the event that the cumulative ages of GC'able bytes or extant
 // intents exceed thresholds.
-func (gcq *gcQueue) shouldQueue(now hlc.Timestamp, repl *Replica,
-	sysCfg config.SystemConfig) (shouldQ bool, priority float64) {
+func (gcq *gcQueue) shouldQueue(
+	now hlc.Timestamp, repl *Replica, sysCfg config.SystemConfig,
+) (shouldQ bool, priority float64) {
 	desc := repl.Desc()
 	zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
 	if err != nil {
@@ -293,10 +294,7 @@ func processAbortCache(
 // 7) push these transactions (again, recreating txn entries).
 // 8) send a GCRequest.
 func (gcq *gcQueue) process(
-	ctx context.Context,
-	now hlc.Timestamp,
-	repl *Replica,
-	sysCfg config.SystemConfig,
+	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg config.SystemConfig,
 ) error {
 	snap := repl.store.Engine().NewSnapshot()
 	desc := repl.Desc()

--- a/storage/helpers_test.go
+++ b/storage/helpers_test.go
@@ -96,7 +96,12 @@ func (s *Store) LeaseExpiration(clock *hlc.Clock) int64 {
 
 // LogReplicaChangeTest adds a fake replica change event to the log for the
 // range which contains the given key.
-func (s *Store) LogReplicaChangeTest(txn *client.Txn, changeType roachpb.ReplicaChangeType, replica roachpb.ReplicaDescriptor, desc roachpb.RangeDescriptor) error {
+func (s *Store) LogReplicaChangeTest(
+	txn *client.Txn,
+	changeType roachpb.ReplicaChangeType,
+	replica roachpb.ReplicaDescriptor,
+	desc roachpb.RangeDescriptor,
+) error {
 	return s.logChange(txn, changeType, replica, desc)
 }
 
@@ -173,7 +178,9 @@ func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
 }
 
 // GetStoreList is the same function as GetStoreList exposed for tests only.
-func (sp *StorePool) GetStoreList(constraints config.Constraints, deterministic bool) (StoreList, int, int) {
+func (sp *StorePool) GetStoreList(
+	constraints config.Constraints, deterministic bool,
+) (StoreList, int, int) {
 	return sp.getStoreList(constraints, deterministic)
 }
 

--- a/storage/intent_resolver.go
+++ b/storage/intent_resolver.go
@@ -71,9 +71,13 @@ func newIntentResolver(store *Store) *intentResolver {
 // retry behavior (if the transaction is pushed, the Resolved flag is
 // set to tell the client to retry immediately; otherwise it is false
 // to cause the client to back off).
-func (ir *intentResolver) processWriteIntentError(ctx context.Context,
-	wiPErr *roachpb.Error, args roachpb.Request, h roachpb.Header,
-	pushType roachpb.PushTxnType) *roachpb.Error {
+func (ir *intentResolver) processWriteIntentError(
+	ctx context.Context,
+	wiPErr *roachpb.Error,
+	args roachpb.Request,
+	h roachpb.Header,
+	pushType roachpb.PushTxnType,
+) *roachpb.Error {
 	wiErr, ok := wiPErr.GetDetail().(*roachpb.WriteIntentError)
 	if !ok {
 		return roachpb.NewErrorf("not a WriteIntentError: %v", wiPErr)
@@ -393,8 +397,9 @@ func (ir *intentResolver) processIntentsAsync(r *Replica, intents []intentsWithA
 // the same intents again (in the absence of #8360, we provide this
 // guarantee by resolving the intents synchronously regardless of the
 // `wait` argument).
-func (ir *intentResolver) resolveIntents(ctx context.Context,
-	intents []roachpb.Intent, wait bool, poison bool) error {
+func (ir *intentResolver) resolveIntents(
+	ctx context.Context, intents []roachpb.Intent, wait bool, poison bool,
+) error {
 	// Force synchronous operation; see above TODO.
 	wait = true
 	if len(intents) == 0 {

--- a/storage/log.go
+++ b/storage/log.go
@@ -147,8 +147,12 @@ func (s *Store) logSplit(txn *client.Txn, updatedDesc, newDesc roachpb.RangeDesc
 // to or removed from a range.
 // TODO(mrtracy): There are several different reasons that a replica change
 // could occur, and that information should be logged.
-func (s *Store) logChange(txn *client.Txn, changeType roachpb.ReplicaChangeType, replica roachpb.ReplicaDescriptor,
-	desc roachpb.RangeDescriptor) error {
+func (s *Store) logChange(
+	txn *client.Txn,
+	changeType roachpb.ReplicaChangeType,
+	replica roachpb.ReplicaDescriptor,
+	desc roachpb.RangeDescriptor,
+) error {
 	if !s.ctx.LogRangeEvents {
 		return nil
 	}

--- a/storage/migration.go
+++ b/storage/migration.go
@@ -39,7 +39,9 @@ import (
 // mean that the replica was further ahead or had voted, and so there's no
 // guarantee that this will be correct. But it will be correct in the majority
 // of cases, and some state *has* to be recovered.
-func migrate7310And6991(ctx context.Context, batch engine.ReadWriter, desc roachpb.RangeDescriptor) error {
+func migrate7310And6991(
+	ctx context.Context, batch engine.ReadWriter, desc roachpb.RangeDescriptor,
+) error {
 	state, err := loadState(ctx, batch, &desc)
 	if err != nil {
 		return errors.Wrap(err, "could not migrate TruncatedState: %s")

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -349,7 +349,9 @@ func (bq *baseQueue) requiresSplit(cfg config.SystemConfig, repl *Replica) bool 
 // addInternal adds the replica the queue with specified priority. If
 // the replica is already queued, updates the existing
 // priority. Expects the queue lock to be held by caller.
-func (bq *baseQueue) addInternal(desc *roachpb.RangeDescriptor, should bool, priority float64) (bool, error) {
+func (bq *baseQueue) addInternal(
+	desc *roachpb.RangeDescriptor, should bool, priority float64,
+) (bool, error) {
 	if bq.mu.stopped {
 		return false, errQueueStopped
 	}
@@ -546,7 +548,9 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 // purgatoryError and the queue implementation must have its own
 // mechanism for signaling re-processing of replicas held in
 // purgatory.
-func (bq *baseQueue) maybeAddToPurgatory(repl *Replica, triggeringErr error, clock *hlc.Clock, stopper *stop.Stopper) {
+func (bq *baseQueue) maybeAddToPurgatory(
+	repl *Replica, triggeringErr error, clock *hlc.Clock, stopper *stop.Stopper,
+) {
 	// Increment failures metric here to capture all error returns from
 	// process().
 	bq.failures.Inc(1)

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -46,15 +46,14 @@ type testQueueImpl struct {
 	err           error // always returns this error on process
 }
 
-func (tq *testQueueImpl) shouldQueue(now hlc.Timestamp, r *Replica, _ config.SystemConfig) (bool, float64) {
+func (tq *testQueueImpl) shouldQueue(
+	now hlc.Timestamp, r *Replica, _ config.SystemConfig,
+) (bool, float64) {
 	return tq.shouldQueueFn(now, r)
 }
 
 func (tq *testQueueImpl) process(
-	_ context.Context,
-	now hlc.Timestamp,
-	r *Replica,
-	_ config.SystemConfig,
+	_ context.Context, now hlc.Timestamp, r *Replica, _ config.SystemConfig,
 ) error {
 	atomic.AddInt32(&tq.processed, 1)
 	return tq.err
@@ -79,11 +78,7 @@ func (tq *testQueueImpl) purgatoryChan() <-chan struct{} {
 }
 
 func makeTestBaseQueue(
-	name string,
-	impl queueImpl,
-	store *Store,
-	gossip *gossip.Gossip,
-	cfg queueConfig,
+	name string, impl queueImpl, store *Store, gossip *gossip.Gossip, cfg queueConfig,
 ) *baseQueue {
 	cfg.successes = metric.NewCounter(metric.Metadata{Name: "processed"})
 	cfg.failures = metric.NewCounter(metric.Metadata{Name: "failures"})
@@ -677,10 +672,7 @@ type processTimeoutQueueImpl struct {
 }
 
 func (pq *processTimeoutQueueImpl) process(
-	ctx context.Context,
-	now hlc.Timestamp,
-	r *Replica,
-	_ config.SystemConfig,
+	ctx context.Context, now hlc.Timestamp, r *Replica, _ config.SystemConfig,
 ) error {
 	<-ctx.Done()
 	atomic.AddInt32(&pq.processed, 1)
@@ -733,10 +725,7 @@ type processTimeQueueImpl struct {
 }
 
 func (pq *processTimeQueueImpl) process(
-	_ context.Context,
-	_ hlc.Timestamp,
-	_ *Replica,
-	_ config.SystemConfig,
+	_ context.Context, _ hlc.Timestamp, _ *Replica, _ config.SystemConfig,
 ) error {
 	time.Sleep(5 * time.Millisecond)
 	return nil

--- a/storage/raft_log_queue.go
+++ b/storage/raft_log_queue.go
@@ -134,9 +134,7 @@ func getTruncatableIndexes(ctx context.Context, r *Replica) (uint64, uint64, err
 // and thus require another snapshot, likely entering a never ending loop of
 // snapshots. See #8629.
 func computeTruncatableIndex(
-	raftStatus *raft.Status,
-	raftLogSize, targetSize int64,
-	firstIndex, pendingSnapshotIndex uint64,
+	raftStatus *raft.Status, raftLogSize, targetSize int64, firstIndex, pendingSnapshotIndex uint64,
 ) uint64 {
 	truncatableIndex := raftStatus.Commit
 	if raftLogSize <= targetSize {
@@ -195,10 +193,7 @@ func (rlq *raftLogQueue) shouldQueue(
 // leader and if the total number of the range's raft log's stale entries
 // exceeds RaftLogQueueStaleThreshold.
 func (rlq *raftLogQueue) process(
-	ctx context.Context,
-	now hlc.Timestamp,
-	r *Replica,
-	_ config.SystemConfig,
+	ctx context.Context, now hlc.Timestamp, r *Replica, _ config.SystemConfig,
 ) error {
 	truncatableIndexes, oldestIndex, err := getTruncatableIndexes(rlq.ctx, r)
 	if err != nil {

--- a/storage/raft_transport.go
+++ b/storage/raft_transport.go
@@ -236,9 +236,7 @@ func NewRaftTransport(
 
 // handleRaftRequest proxies a request to the listening server interface.
 func (t *RaftTransport) handleRaftRequest(
-	ctx context.Context,
-	req *RaftMessageRequest,
-	respStream RaftMessageResponseStream,
+	ctx context.Context, req *RaftMessageRequest, respStream RaftMessageResponseStream,
 ) *roachpb.Error {
 	t.recvMu.Lock()
 	handler, ok := t.recvMu.handlers[req.ToReplica.StoreID]
@@ -395,9 +393,7 @@ func (t *RaftTransport) GetCircuitBreaker(nodeID roachpb.NodeID) *circuit.Breake
 // breaker is used to allow fast failures in SendAsync which will drop
 // incoming raft messages and report unreachable status to the raft group.
 func (t *RaftTransport) connectAndProcess(
-	nodeID roachpb.NodeID,
-	ch chan *RaftMessageRequest,
-	stats *raftTransportStats,
+	nodeID roachpb.NodeID, ch chan *RaftMessageRequest, stats *raftTransportStats,
 ) {
 	breaker := t.GetCircuitBreaker(nodeID)
 	successes := breaker.Successes()

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -636,10 +636,7 @@ func (r *Replica) EndTransaction(
 
 // isEndTransactionExceedingDeadline returns true if the transaction
 // exceeded its deadline.
-func isEndTransactionExceedingDeadline(
-	t hlc.Timestamp,
-	args roachpb.EndTransactionRequest,
-) bool {
+func isEndTransactionExceedingDeadline(t hlc.Timestamp, args roachpb.EndTransactionRequest) bool {
 	return args.Deadline != nil && args.Deadline.Less(t)
 }
 
@@ -780,8 +777,7 @@ func updateTxnWithExternalIntents(
 // TODO(tschottdorf) move to proto, make more gen-purpose - kv.truncate does
 // some similar things.
 func intersectSpan(
-	span roachpb.Span,
-	desc roachpb.RangeDescriptor,
+	span roachpb.Span, desc roachpb.RangeDescriptor,
 ) (middle *roachpb.Span, outside []roachpb.Span) {
 	start, end := desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey()
 	if len(span.EndKey) == 0 {
@@ -916,10 +912,7 @@ func (r *Replica) runCommitTrigger(
 // specifies whether descriptors are prefetched in descending or ascending
 // order.
 func (r *Replica) RangeLookup(
-	ctx context.Context,
-	batch engine.ReadWriter,
-	h roachpb.Header,
-	args roachpb.RangeLookupRequest,
+	ctx context.Context, batch engine.ReadWriter, h roachpb.Header, args roachpb.RangeLookupRequest,
 ) (roachpb.RangeLookupResponse, *PostCommitTrigger, error) {
 	log.Event(ctx, "RangeLookup")
 	var reply roachpb.RangeLookupResponse
@@ -1781,9 +1774,7 @@ func (r *Replica) applyNewLeaseLocked(
 //
 // TODO(tschottdorf): We should call this AdminCheckConsistency.
 func (r *Replica) CheckConsistency(
-	ctx context.Context,
-	args roachpb.CheckConsistencyRequest,
-	desc *roachpb.RangeDescriptor,
+	ctx context.Context, args roachpb.CheckConsistencyRequest, desc *roachpb.RangeDescriptor,
 ) (roachpb.CheckConsistencyResponse, *roachpb.Error) {
 	key := desc.StartKey.AsRawKey()
 	endKey := desc.EndKey.AsRawKey()
@@ -1914,10 +1905,7 @@ const (
 // getChecksum waits for the result of ComputeChecksum and returns it.
 // It returns false if there is no checksum being computed for the id,
 // or it has already been GCed.
-func (r *Replica) getChecksum(
-	ctx context.Context,
-	id uuid.UUID,
-) (replicaChecksum, error) {
+func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (replicaChecksum, error) {
 	now := timeutil.Now()
 	r.mu.Lock()
 	r.gcOldChecksumEntriesLocked(now)
@@ -1959,10 +1947,7 @@ func (r *Replica) getChecksum(
 // computeChecksumDone adds the computed checksum, sets a deadline for GCing the
 // checksum, and sends out a notification.
 func (r *Replica) computeChecksumDone(
-	ctx context.Context,
-	id uuid.UUID,
-	sha []byte,
-	snapshot *roachpb.RaftSnapshotData,
+	ctx context.Context, id uuid.UUID, sha []byte, snapshot *roachpb.RaftSnapshotData,
 ) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -2001,9 +1986,7 @@ func (r *Replica) ComputeChecksum(
 // sha512 computes the SHA512 hash of all the replica data at the snapshot.
 // It will dump all the k:v data into snapshot if it is provided.
 func (r *Replica) sha512(
-	desc roachpb.RangeDescriptor,
-	snap engine.Reader,
-	snapshot *roachpb.RaftSnapshotData,
+	desc roachpb.RangeDescriptor, snap engine.Reader, snapshot *roachpb.RaftSnapshotData,
 ) ([]byte, error) {
 	hasher := sha512.New()
 	// Iterate over all the data in the range.
@@ -2583,14 +2566,10 @@ func (r *Replica) AdminSplit(
 func (r *Replica) splitTrigger(
 	ctx context.Context,
 	batch engine.Batch,
-	bothDeltaMS enginepb.MVCCStats, // stats for batch so far
+	bothDeltaMS enginepb.MVCCStats,
 	split *roachpb.SplitTrigger,
 	ts hlc.Timestamp,
-) (
-	enginepb.MVCCStats,
-	*PostCommitTrigger,
-	error,
-) {
+) (enginepb.MVCCStats, *PostCommitTrigger, error) {
 	// TODO(tschottdorf): should have an incoming context from the corresponding
 	// EndTransaction, but the plumbing has not been done yet.
 	sp := r.store.Tracer().StartSpan("split")
@@ -2988,9 +2967,7 @@ func (r *Replica) mergeTrigger(
 }
 
 func (r *Replica) changeReplicasTrigger(
-	ctx context.Context,
-	batch engine.Batch,
-	change *roachpb.ChangeReplicasTrigger,
+	ctx context.Context, batch engine.Batch, change *roachpb.ChangeReplicasTrigger,
 ) *PostCommitTrigger {
 	var trigger *PostCommitTrigger
 	// If we're removing the current replica, add it to the range GC queue.
@@ -3358,9 +3335,7 @@ func replicaSetsEqual(a, b []roachpb.ReplicaDescriptor) bool {
 // and load it automatically instead of reconstructing individual
 // changes.
 func updateRangeDescriptor(
-	b *client.Batch,
-	descKey roachpb.Key,
-	oldDesc,
+	b *client.Batch, descKey roachpb.Key, oldDesc,
 	newDesc *roachpb.RangeDescriptor,
 ) error {
 	if err := newDesc.Validate(); err != nil {

--- a/storage/replica_consistency_queue.go
+++ b/storage/replica_consistency_queue.go
@@ -62,10 +62,7 @@ func (*replicaConsistencyQueue) shouldQueue(
 
 // process() is called on every range for which this node is a lease holder.
 func (q *replicaConsistencyQueue) process(
-	ctx context.Context,
-	_ hlc.Timestamp,
-	r *Replica,
-	_ config.SystemConfig,
+	ctx context.Context, _ hlc.Timestamp, r *Replica, _ config.SystemConfig,
 ) error {
 	req := roachpb.CheckConsistencyRequest{}
 	_, pErr := r.CheckConsistency(ctx, req, r.Desc())

--- a/storage/replica_data_iter.go
+++ b/storage/replica_data_iter.go
@@ -51,7 +51,9 @@ func makeReplicatedKeyRanges(d *roachpb.RangeDescriptor) []keyRange {
 	return makeReplicaKeyRanges(d, keys.MakeRangeIDReplicatedPrefix)
 }
 
-func makeReplicaKeyRanges(d *roachpb.RangeDescriptor, metaFunc func(roachpb.RangeID) roachpb.Key) []keyRange {
+func makeReplicaKeyRanges(
+	d *roachpb.RangeDescriptor, metaFunc func(roachpb.RangeID) roachpb.Key,
+) []keyRange {
 	// The first range in the keyspace starts at KeyMin, which includes the
 	// node-local space. We need the original StartKey to find the range
 	// metadata, but the actual data starts at LocalMax.

--- a/storage/replica_gc_queue.go
+++ b/storage/replica_gc_queue.go
@@ -154,10 +154,7 @@ func replicaGCShouldQueueImpl(
 // process performs a consistent lookup on the range descriptor to see if we are
 // still a member of the range.
 func (q *replicaGCQueue) process(
-	ctx context.Context,
-	now hlc.Timestamp,
-	rng *Replica,
-	_ config.SystemConfig,
+	ctx context.Context, now hlc.Timestamp, rng *Replica, _ config.SystemConfig,
 ) error {
 	// Note that the Replicas field of desc is probably out of date, so
 	// we should only use `desc` for its static fields like RangeID and

--- a/storage/replica_raftstorage.go
+++ b/storage/replica_raftstorage.go
@@ -199,11 +199,7 @@ func (r *Replica) Term(i uint64) (uint64, error) {
 }
 
 func term(
-	ctx context.Context,
-	eng engine.Reader,
-	rangeID roachpb.RangeID,
-	eCache *raftEntryCache,
-	i uint64,
+	ctx context.Context, eng engine.Reader, rangeID roachpb.RangeID, eCache *raftEntryCache, i uint64,
 ) (uint64, error) {
 	ents, err := entries(ctx, eng, rangeID, eCache, i, i+1, 0)
 	if err == raft.ErrCompacted {

--- a/storage/replica_range_lease.go
+++ b/storage/replica_range_lease.go
@@ -178,9 +178,7 @@ func (p *pendingLeaseRequest) JoinRequest() <-chan *roachpb.Error {
 // LeaderLease.
 //
 // replicaID is the ID of the parent replica.
-func (p *pendingLeaseRequest) TransferInProgress(
-	replicaID roachpb.ReplicaID,
-) (roachpb.Lease, bool) {
+func (p *pendingLeaseRequest) TransferInProgress(replicaID roachpb.ReplicaID) (roachpb.Lease, bool) {
 	if nextLease, ok := p.RequestPending(); ok {
 		// Is the lease being transferred? (as opposed to just extended)
 		if replicaID != nextLease.Replica.ReplicaID {

--- a/storage/replica_state.go
+++ b/storage/replica_state.go
@@ -34,8 +34,7 @@ import (
 // RangeDescriptor under the convention that that is the latest committed
 // version.
 func loadState(
-	ctx context.Context,
-	reader engine.Reader, desc *roachpb.RangeDescriptor,
+	ctx context.Context, reader engine.Reader, desc *roachpb.RangeDescriptor,
 ) (storagebase.ReplicaState, error) {
 	var s storagebase.ReplicaState
 	// TODO(tschottdorf): figure out whether this is always synchronous with
@@ -137,7 +136,7 @@ func setLease(
 	eng engine.ReadWriter,
 	ms *enginepb.MVCCStats,
 	rangeID roachpb.RangeID,
-	lease *roachpb.Lease, // TODO(tschottdorf): better if this is never nil
+	lease *roachpb.Lease,
 ) error {
 	if lease == nil {
 		return nil

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -248,7 +248,9 @@ func (tc *testContext) Sender() client.Sender {
 
 // SendWrappedWith is a convenience function which wraps the request in a batch
 // and sends it
-func (tc *testContext) SendWrappedWith(h roachpb.Header, args roachpb.Request) (roachpb.Response, *roachpb.Error) {
+func (tc *testContext) SendWrappedWith(
+	h roachpb.Header, args roachpb.Request,
+) (roachpb.Response, *roachpb.Error) {
 	return client.SendWrappedWith(tc.Sender(), context.Background(), h, args)
 }
 
@@ -280,8 +282,13 @@ func (tc *testContext) initConfigs(realRange bool, t testing.TB) error {
 	return nil
 }
 
-func newTransaction(name string, baseKey roachpb.Key, userPriority roachpb.UserPriority,
-	isolation enginepb.IsolationType, clock *hlc.Clock) *roachpb.Transaction {
+func newTransaction(
+	name string,
+	baseKey roachpb.Key,
+	userPriority roachpb.UserPriority,
+	isolation enginepb.IsolationType,
+	clock *hlc.Clock,
+) *roachpb.Transaction {
 	var offset int64
 	var now hlc.Timestamp
 	if clock != nil {
@@ -1074,7 +1081,9 @@ func TestReplicaGossipAllConfigs(t *testing.T) {
 	}
 }
 
-func maybeWrapWithBeginTransaction(sender client.Sender, ctx context.Context, header roachpb.Header, req roachpb.Request) (roachpb.Response, *roachpb.Error) {
+func maybeWrapWithBeginTransaction(
+	sender client.Sender, ctx context.Context, header roachpb.Header, req roachpb.Request,
+) (roachpb.Response, *roachpb.Error) {
 	if header.Txn == nil || header.Txn.Writing {
 		return client.SendWrappedWith(sender, ctx, header, req)
 	}
@@ -1265,7 +1274,9 @@ func scanArgs(start, end []byte) roachpb.ScanRequest {
 	}
 }
 
-func beginTxnArgs(key []byte, txn *roachpb.Transaction) (_ roachpb.BeginTransactionRequest, h roachpb.Header) {
+func beginTxnArgs(
+	key []byte, txn *roachpb.Transaction,
+) (_ roachpb.BeginTransactionRequest, h roachpb.Header) {
 	h.Txn = txn
 	return roachpb.BeginTransactionRequest{
 		Span: roachpb.Span{
@@ -1274,7 +1285,9 @@ func beginTxnArgs(key []byte, txn *roachpb.Transaction) (_ roachpb.BeginTransact
 	}, h
 }
 
-func endTxnArgs(txn *roachpb.Transaction, commit bool) (_ roachpb.EndTransactionRequest, h roachpb.Header) {
+func endTxnArgs(
+	txn *roachpb.Transaction, commit bool,
+) (_ roachpb.EndTransactionRequest, h roachpb.Header) {
 	h.Txn = txn
 	return roachpb.EndTransactionRequest{
 		Span: roachpb.Span{
@@ -1284,7 +1297,9 @@ func endTxnArgs(txn *roachpb.Transaction, commit bool) (_ roachpb.EndTransaction
 	}, h
 }
 
-func pushTxnArgs(pusher, pushee *roachpb.Transaction, pushType roachpb.PushTxnType) roachpb.PushTxnRequest {
+func pushTxnArgs(
+	pusher, pushee *roachpb.Transaction, pushType roachpb.PushTxnType,
+) roachpb.PushTxnRequest {
 	return roachpb.PushTxnRequest{
 		Span: roachpb.Span{
 			Key: pushee.Key,
@@ -2029,7 +2044,9 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 	}
 }
 
-func SendWrapped(sender client.Sender, ctx context.Context, header roachpb.Header, args roachpb.Request) (roachpb.Response, roachpb.BatchResponse_Header, *roachpb.Error) {
+func SendWrapped(
+	sender client.Sender, ctx context.Context, header roachpb.Header, args roachpb.Request,
+) (roachpb.Response, roachpb.BatchResponse_Header, *roachpb.Error) {
 	var ba roachpb.BatchRequest
 	ba.Add(args)
 	ba.Header = header
@@ -3300,8 +3317,9 @@ func TestEndTransactionLocalGC(t *testing.T) {
 
 // setupResolutionTest splits the range at the specified splitKey and completes
 // a transaction which creates intents at key and splitKey.
-func setupResolutionTest(t *testing.T, tc testContext, key roachpb.Key,
-	splitKey roachpb.RKey, commit bool) (*Replica, *roachpb.Transaction) {
+func setupResolutionTest(
+	t *testing.T, tc testContext, key roachpb.Key, splitKey roachpb.RKey, commit bool,
+) (*Replica, *roachpb.Transaction) {
 	// Split the range and create an intent at splitKey and key.
 	newRng := splitTestRange(tc.store, splitKey, splitKey, t)
 
@@ -4231,7 +4249,9 @@ func TestReplicaResolveIntentRange(t *testing.T) {
 	}
 }
 
-func verifyRangeStats(eng engine.Engine, rangeID roachpb.RangeID, expMS enginepb.MVCCStats, t *testing.T) {
+func verifyRangeStats(
+	eng engine.Engine, rangeID roachpb.RangeID, expMS enginepb.MVCCStats, t *testing.T,
+) {
 	var ms enginepb.MVCCStats
 	if err := engine.MVCCGetRangeStats(context.Background(), eng, rangeID, &ms); err != nil {
 		t.Fatal(err)

--- a/storage/replica_trigger.go
+++ b/storage/replica_trigger.go
@@ -180,9 +180,7 @@ func (r *Replica) gcOldChecksumEntriesLocked(now time.Time) {
 	}
 }
 
-func (r *Replica) computeChecksumTrigger(
-	ctx context.Context, args roachpb.ComputeChecksumRequest,
-) {
+func (r *Replica) computeChecksumTrigger(ctx context.Context, args roachpb.ComputeChecksumRequest) {
 	stopper := r.store.Stopper()
 	id := args.ChecksumID
 	now := timeutil.Now()
@@ -233,7 +231,7 @@ func (r *Replica) leasePostCommitTrigger(
 	ctx context.Context,
 	trigger PostCommitTrigger,
 	replicaID roachpb.ReplicaID,
-	prevLease *roachpb.Lease, // TODO(tschottdorf): could this not be nil?
+	prevLease *roachpb.Lease,
 ) {
 	iAmTheLeaseHolder := trigger.lease.Replica.ReplicaID == replicaID
 	leaseChangingHands := prevLease.Replica.StoreID != trigger.lease.Replica.StoreID
@@ -294,9 +292,7 @@ func (r *Replica) leasePostCommitTrigger(
 // The transfer might silently fail, particularly (only?) if the transferee is
 // behind on applying the log.
 func (r *Replica) maybeTransferRaftLeadership(
-	ctx context.Context,
-	replicaID roachpb.ReplicaID,
-	target roachpb.ReplicaID,
+	ctx context.Context, replicaID roachpb.ReplicaID, target roachpb.ReplicaID,
 ) {
 	err := r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
 		if raftGroup.Status().RaftState == raft.StateLeader {
@@ -320,9 +316,7 @@ func (r *Replica) maybeTransferRaftLeadership(
 }
 
 func (r *Replica) handleTrigger(
-	ctx context.Context,
-	originReplica roachpb.ReplicaDescriptor,
-	trigger PostCommitTrigger,
+	ctx context.Context, originReplica roachpb.ReplicaDescriptor, trigger PostCommitTrigger,
 ) {
 	if trigger.noConcurrentReads {
 		r.readOnlyCmdMu.Lock()

--- a/storage/replicate_queue.go
+++ b/storage/replicate_queue.go
@@ -48,8 +48,9 @@ type replicateQueue struct {
 }
 
 // newReplicateQueue returns a new instance of replicateQueue.
-func newReplicateQueue(store *Store, g *gossip.Gossip, allocator Allocator, clock *hlc.Clock,
-	options AllocatorOptions) *replicateQueue {
+func newReplicateQueue(
+	store *Store, g *gossip.Gossip, allocator Allocator, clock *hlc.Clock, options AllocatorOptions,
+) *replicateQueue {
 	rq := &replicateQueue{
 		allocator:  allocator,
 		clock:      clock,
@@ -84,9 +85,7 @@ func newReplicateQueue(store *Store, g *gossip.Gossip, allocator Allocator, cloc
 }
 
 func (rq *replicateQueue) shouldQueue(
-	now hlc.Timestamp,
-	repl *Replica,
-	sysCfg config.SystemConfig,
+	now hlc.Timestamp, repl *Replica, sysCfg config.SystemConfig,
 ) (shouldQ bool, priority float64) {
 	if !repl.store.splitQueue.Disabled() && repl.needsSplitBySize() {
 		// If the range exceeds the split threshold, let that finish first.
@@ -123,10 +122,7 @@ func (rq *replicateQueue) shouldQueue(
 }
 
 func (rq *replicateQueue) process(
-	ctx context.Context,
-	now hlc.Timestamp,
-	repl *Replica,
-	sysCfg config.SystemConfig,
+	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg config.SystemConfig,
 ) error {
 	desc := repl.Desc()
 	// Find the zone config for this range.

--- a/storage/reservation.go
+++ b/storage/reservation.go
@@ -90,10 +90,7 @@ type bookie struct {
 
 // newBookie creates a reservations system and starts its timeout queue.
 func newBookie(
-	clock *hlc.Clock,
-	stopper *stop.Stopper,
-	metrics *StoreMetrics,
-	reservationTimeout time.Duration,
+	clock *hlc.Clock, stopper *stop.Stopper, metrics *StoreMetrics, reservationTimeout time.Duration,
 ) *bookie {
 	b := &bookie{
 		clock:              clock,

--- a/storage/reservation_test.go
+++ b/storage/reservation_test.go
@@ -32,9 +32,7 @@ import (
 
 // createTestBookie creates a new bookie, stopper and manual clock for testing.
 func createTestBookie(
-	reservationTimeout time.Duration,
-	maxReservations int,
-	maxReservedBytes int64,
+	reservationTimeout time.Duration, maxReservations int, maxReservedBytes int64,
 ) (*stop.Stopper, *hlc.ManualClock, *bookie) {
 	stopper := stop.NewStopper()
 	mc := hlc.NewManualClock(0)

--- a/storage/simulation/store.go
+++ b/storage/simulation/store.go
@@ -39,7 +39,9 @@ type Store struct {
 
 // newStore returns a new store with using the passed in ID and node
 // descriptor.
-func newStore(storeID roachpb.StoreID, nodeDesc roachpb.NodeDescriptor, gossip *gossip.Gossip) *Store {
+func newStore(
+	storeID roachpb.StoreID, nodeDesc roachpb.NodeDescriptor, gossip *gossip.Gossip,
+) *Store {
 	return &Store{
 		desc: roachpb.StoreDescriptor{
 			StoreID: storeID,

--- a/storage/split_queue.go
+++ b/storage/split_queue.go
@@ -94,10 +94,7 @@ func (sq *splitQueue) shouldQueue(
 
 // process synchronously invokes admin split for each proposed split key.
 func (sq *splitQueue) process(
-	ctx context.Context,
-	now hlc.Timestamp,
-	r *Replica,
-	sysCfg config.SystemConfig,
+	ctx context.Context, now hlc.Timestamp, r *Replica, sysCfg config.SystemConfig,
 ) error {
 	// First handle case of splitting due to zone config maps.
 	desc := r.Desc()

--- a/storage/store_pool.go
+++ b/storage/store_pool.go
@@ -405,7 +405,9 @@ func (sp *StorePool) getStoreDescriptor(storeID roachpb.StoreID) (roachpb.StoreD
 
 // deadReplicas returns any replicas from the supplied slice that are
 // located on dead stores or dead replicas for the provided rangeID.
-func (sp *StorePool) deadReplicas(rangeID roachpb.RangeID, repls []roachpb.ReplicaDescriptor) []roachpb.ReplicaDescriptor {
+func (sp *StorePool) deadReplicas(
+	rangeID roachpb.RangeID, repls []roachpb.ReplicaDescriptor,
+) []roachpb.ReplicaDescriptor {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 
@@ -484,7 +486,9 @@ func (sl *StoreList) add(s roachpb.StoreDescriptor) {
 // TODO(embark, spencer): consider using a reverse index map from
 // Attr->stores, for efficiency. Ensure that entries in this map still
 // have an opportunity to be garbage collected.
-func (sp *StorePool) getStoreList(constraints config.Constraints, deterministic bool) (StoreList, int, int) {
+func (sp *StorePool) getStoreList(
+	constraints config.Constraints, deterministic bool,
+) (StoreList, int, int) {
 	sp.mu.RLock()
 	defer sp.mu.RUnlock()
 
@@ -527,10 +531,7 @@ func (sp *StorePool) getStoreList(constraints config.Constraints, deterministic 
 // TODO(bram): consider moving the nodeID to the store pool during
 // NewStorePool.
 func (sp *StorePool) reserve(
-	curIdent roachpb.StoreIdent,
-	toStoreID roachpb.StoreID,
-	rangeID roachpb.RangeID,
-	rangeSize int64,
+	curIdent roachpb.StoreIdent, toStoreID roachpb.StoreID, rangeID roachpb.RangeID, rangeSize int64,
 ) error {
 	if !sp.reservationsEnabled {
 		return nil

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -60,8 +60,8 @@ var uniqueStore = []*roachpb.StoreDescriptor{
 // createTestStorePool creates a stopper, gossip and storePool for use in
 // tests. Stopper must be stopped by the caller.
 func createTestStorePool(
-	timeUntilStoreDead time.Duration) (*stop.Stopper, *gossip.Gossip, *hlc.ManualClock, *StorePool,
-) {
+	timeUntilStoreDead time.Duration,
+) (*stop.Stopper, *gossip.Gossip, *hlc.ManualClock, *StorePool) {
 	stopper := stop.NewStopper()
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
@@ -453,7 +453,9 @@ type fakeReservationServer struct {
 
 var _ ReservationServer = fakeReservationServer{}
 
-func (f fakeReservationServer) Reserve(_ context.Context, _ *ReservationRequest) (*ReservationResponse, error) {
+func (f fakeReservationServer) Reserve(
+	_ context.Context, _ *ReservationRequest,
+) (*ReservationResponse, error) {
 	return &ReservationResponse{Reserved: f.reservationResponse}, f.reservationErr
 }
 

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -95,7 +95,9 @@ func (s *Store) testSender() client.Sender {
 // Since kv/ depends on storage/, we can't get access to a
 // TxnCoordSender from here.
 // TODO(tschottdorf): {kv->storage}.LocalSender
-func (db *testSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+func (db *testSender) Send(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error) {
 	if et, ok := ba.GetArg(roachpb.EndTransaction); ok {
 		return nil, roachpb.NewErrorf("%s method not supported", et.Method())
 	}
@@ -129,7 +131,9 @@ func (db *testSender) Send(ctx context.Context, ba roachpb.BatchRequest) (*roach
 // clock's manual unix nanos time and a stopper. The caller is
 // responsible for stopping the stopper upon completion.
 // Some fields of ctx are populated by this function.
-func createTestStoreWithoutStart(t testing.TB, ctx *StoreContext) (*Store, *hlc.ManualClock, *stop.Stopper) {
+func createTestStoreWithoutStart(
+	t testing.TB, ctx *StoreContext,
+) (*Store, *hlc.ManualClock, *stop.Stopper) {
 	stopper := stop.NewStopper()
 	// Setup fake zone config handler.
 	config.TestingSetupZoneConfigHook(stopper)
@@ -184,8 +188,9 @@ func createTestStore(t testing.TB) (*Store, *hlc.ManualClock, *stop.Stopper) {
 // engine. It returns the store, the store clock's manual unix nanos time
 // and a stopper. The caller is responsible for stopping the stopper
 // upon completion.
-func createTestStoreWithContext(t testing.TB, ctx *StoreContext) (
-	*Store, *hlc.ManualClock, *stop.Stopper) {
+func createTestStoreWithContext(
+	t testing.TB, ctx *StoreContext,
+) (*Store, *hlc.ManualClock, *stop.Stopper) {
 
 	store, manual, stopper := createTestStoreWithoutStart(t, ctx)
 	// Put an empty system config into gossip.

--- a/storage/stores.go
+++ b/storage/stores.go
@@ -138,7 +138,9 @@ func (ls *Stores) VisitStores(visitor func(s *Store) error) error {
 // store map if specified by the request; otherwise, the command is being
 // executed locally, and the replica is determined via lookup through each
 // store's LookupRange method. The latter path is taken only by unit tests.
-func (ls *Stores) Send(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+func (ls *Stores) Send(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *roachpb.Error) {
 	// If we aren't given a Replica, then a little bending over
 	// backwards here. This case applies exclusively to unittests.
 	if ba.RangeID == 0 || ba.Replica.StoreID == 0 {

--- a/storage/stores_server.go
+++ b/storage/stores_server.go
@@ -41,15 +41,11 @@ type Server struct {
 }
 
 // MakeServer returns a new instance of Server.
-func MakeServer(
-	descriptor *roachpb.NodeDescriptor, stores *Stores,
-) Server {
+func MakeServer(descriptor *roachpb.NodeDescriptor, stores *Stores) Server {
 	return Server{descriptor, stores}
 }
 
-func (is Server) execStoreCommand(
-	h StoreRequestHeader, f func(*Store) error,
-) error {
+func (is Server) execStoreCommand(h StoreRequestHeader, f func(*Store) error) error {
 	if h.NodeID != is.descriptor.NodeID {
 		return errors.Errorf("request for NodeID %d cannot be served by NodeID %d",
 			h.NodeID, is.descriptor.NodeID)

--- a/storage/timestamp_cache.go
+++ b/storage/timestamp_cache.go
@@ -182,10 +182,7 @@ func (tc *timestampCache) SetLowWater(lowWater hlc.Timestamp) {
 // whether the command adding this timestamp should update the read
 // timestamp; false to update the write timestamp cache.
 func (tc *timestampCache) add(
-	start, end roachpb.Key,
-	timestamp hlc.Timestamp,
-	txnID *uuid.UUID,
-	readTSCache bool,
+	start, end roachpb.Key, timestamp hlc.Timestamp, txnID *uuid.UUID, readTSCache bool,
 ) {
 	// This gives us a memory-efficient end key if end is empty.
 	if len(end) == 0 {
@@ -613,7 +610,9 @@ func (tc *timestampCache) GetMaxWrite(start, end roachpb.Key) (hlc.Timestamp, *u
 	return tc.getMax(start, end, false)
 }
 
-func (tc *timestampCache) getMax(start, end roachpb.Key, readTSCache bool) (hlc.Timestamp, *uuid.UUID, bool) {
+func (tc *timestampCache) getMax(
+	start, end roachpb.Key, readTSCache bool,
+) (hlc.Timestamp, *uuid.UUID, bool) {
 	if len(end) == 0 {
 		end = start.Next()
 	}

--- a/testutils/buildutil/build.go
+++ b/testutils/buildutil/build.go
@@ -66,10 +66,7 @@ func TransitiveImports(importPath string, cgo bool) (map[string]struct{}, error)
 // If GOPATH isn't set, it is an indication that the source is not available and
 // the test is skipped.
 func VerifyNoImports(
-	t testing.TB,
-	pkgPath string,
-	cgo bool,
-	forbiddenPkgs, forbiddenPrefixes []string,
+	t testing.TB, pkgPath string, cgo bool, forbiddenPkgs, forbiddenPrefixes []string,
 ) {
 	// Skip test if source is not available.
 	if build.Default.GOPATH == "" {

--- a/testutils/serverutils/test_server_shim.go
+++ b/testutils/serverutils/test_server_shim.go
@@ -114,9 +114,9 @@ func InitTestServerFactory(impl TestServerFactory) {
 
 // StartServer creates a test server and sets up a gosql DB connection.
 // The server should be stopped by calling server.Stopper().Stop().
-func StartServer(t testing.TB, params base.TestServerArgs) (
-	TestServerInterface, *gosql.DB, *client.DB,
-) {
+func StartServer(
+	t testing.TB, params base.TestServerArgs,
+) (TestServerInterface, *gosql.DB, *client.DB) {
 	server, err := StartServerRaw(params)
 	if err != nil {
 		t.Fatal(err)

--- a/testutils/sqlutils/table_gen.go
+++ b/testutils/sqlutils/table_gen.go
@@ -50,9 +50,7 @@ func genValues(w io.Writer, firstRow, lastRow int, fn GenRowFn) {
 
 // CreateTable creates a table in the "test" database with the given number of
 // rows and using the given row generation function.
-func CreateTable(
-	t *testing.T, sqlDB *gosql.DB, tableName, schema string, numRows int, fn GenRowFn,
-) {
+func CreateTable(t *testing.T, sqlDB *gosql.DB, tableName, schema string, numRows int, fn GenRowFn) {
 	r := MakeSQLRunner(t, sqlDB)
 	stmt := `CREATE DATABASE IF NOT EXISTS test;`
 	stmt += fmt.Sprintf(`CREATE TABLE test.%s (%s);`, tableName, schema)

--- a/testutils/storageutils/mocking.go
+++ b/testutils/storageutils/mocking.go
@@ -39,7 +39,8 @@ type ReplayProtectionFilterWrapper struct {
 // WrapFilterForReplayProtection wraps a filter into another one that adds Raft
 // replay protection.
 func WrapFilterForReplayProtection(
-	filter storagebase.ReplicaCommandFilter) storagebase.ReplicaCommandFilter {
+	filter storagebase.ReplicaCommandFilter,
+) storagebase.ReplicaCommandFilter {
 	wrapper := ReplayProtectionFilterWrapper{
 		processedCommands: make(map[raftCmdIDAndIndex]*roachpb.Error),
 		filter:            filter,

--- a/testutils/testcluster/testcluster.go
+++ b/testutils/testcluster/testcluster.go
@@ -293,9 +293,7 @@ func (tc *TestCluster) Target(serverIdx int) ReplicationTarget {
 }
 
 func (tc *TestCluster) changeReplicas(
-	action roachpb.ReplicaChangeType,
-	startKey roachpb.RKey,
-	targets ...ReplicationTarget,
+	action roachpb.ReplicaChangeType, startKey roachpb.RKey, targets ...ReplicationTarget,
 ) (*roachpb.RangeDescriptor, error) {
 	rangeDesc := &roachpb.RangeDescriptor{}
 
@@ -413,8 +411,7 @@ func (tc *TestCluster) TransferRangeLease(
 // different hints can yield different results. The one server that's guaranteed
 // to have applied the transfer is the previous lease holder.
 func (tc *TestCluster) FindRangeLeaseHolder(
-	rangeDesc *roachpb.RangeDescriptor,
-	hint *ReplicationTarget,
+	rangeDesc *roachpb.RangeDescriptor, hint *ReplicationTarget,
 ) (ReplicationTarget, error) {
 	if hint != nil {
 		var ok bool
@@ -466,9 +463,7 @@ func (tc *TestCluster) FindRangeLeaseHolder(
 }
 
 // findMemberStore returns the store containing a given replica.
-func (tc *TestCluster) findMemberStore(
-	storeID roachpb.StoreID,
-) (*storage.Store, error) {
+func (tc *TestCluster) findMemberStore(storeID roachpb.StoreID) (*storage.Store, error) {
 	for _, server := range tc.Servers {
 		if server.Stores().HasStore(storeID) {
 			store, err := server.Stores().GetStore(storeID)

--- a/ts/query.go
+++ b/ts/query.go
@@ -411,11 +411,7 @@ type interpolatingIterator struct {
 // returned by the iterator will be generated from samples using the supplied
 // downsampleFn.
 func newInterpolatingIterator(
-	ds dataSpan,
-	startOffset int32,
-	sampleNanos int64,
-	extractFn extractFn,
-	downsampleFn downsampleFn,
+	ds dataSpan, startOffset int32, sampleNanos int64, extractFn extractFn, downsampleFn downsampleFn,
 ) interpolatingIterator {
 	if len(ds.datas) == 0 {
 		return interpolatingIterator{}
@@ -680,7 +676,10 @@ func (ai aggregatingIterator) min() float64 {
 // the same time. The returned string slices contains a list of all sources for
 // the metric which were aggregated to produce the result.
 func (db *DB) Query(
-	ctx context.Context, query tspb.Query, queryResolution Resolution, sampleDuration, startNanos, endNanos int64,
+	ctx context.Context,
+	query tspb.Query,
+	queryResolution Resolution,
+	sampleDuration, startNanos, endNanos int64,
 ) ([]tspb.TimeSeriesDatapoint, []string, error) {
 	// Verify that sampleDuration is a multiple of
 	// queryResolution.SampleDuration().

--- a/ts/query_test.go
+++ b/ts/query_test.go
@@ -152,7 +152,9 @@ type completeDatapoint struct {
 
 // generateComplexData generates more complicated InternalTimeSeriesData, where
 // each contained point may have an explicit max and min.
-func generateComplexData(startTimestamp, sampleDuration int64, dps []completeDatapoint) roachpb.InternalTimeSeriesData {
+func generateComplexData(
+	startTimestamp, sampleDuration int64, dps []completeDatapoint,
+) roachpb.InternalTimeSeriesData {
 	result := roachpb.InternalTimeSeriesData{
 		StartTimestampNanos: startTimestamp,
 		SampleDurationNanos: sampleDuration,

--- a/ts/server.go
+++ b/ts/server.go
@@ -57,9 +57,7 @@ func (s *Server) RegisterService(g *grpc.Server) {
 // RegisterGateway starts the gateway (i.e. reverse proxy) that proxies HTTP requests
 // to the appropriate gRPC endpoints.
 func (s *Server) RegisterGateway(
-	ctx context.Context,
-	mux *gwruntime.ServeMux,
-	conn *grpc.ClientConn,
+	ctx context.Context, mux *gwruntime.ServeMux, conn *grpc.ClientConn,
 ) error {
 	return tspb.RegisterTimeSeriesHandler(ctx, mux, conn)
 }

--- a/util/decimal/decimal_test.go
+++ b/util/decimal/decimal_test.go
@@ -74,7 +74,12 @@ type decimalTwoArgsTestCase struct {
 	expected string
 }
 
-func testDecimalSingleArgFunc(t *testing.T, f func(*inf.Dec, *inf.Dec, inf.Scale) *inf.Dec, s inf.Scale, tests []decimalOneArgTestCase) {
+func testDecimalSingleArgFunc(
+	t *testing.T,
+	f func(*inf.Dec, *inf.Dec, inf.Scale) *inf.Dec,
+	s inf.Scale,
+	tests []decimalOneArgTestCase,
+) {
 	for i, tc := range tests {
 		x, exp := new(inf.Dec), new(inf.Dec)
 		x.SetString(tc.input)
@@ -102,7 +107,12 @@ func testDecimalSingleArgFunc(t *testing.T, f func(*inf.Dec, *inf.Dec, inf.Scale
 	}
 }
 
-func testDecimalDoubleArgFunc(t *testing.T, f func(*inf.Dec, *inf.Dec, *inf.Dec, inf.Scale) *inf.Dec, s inf.Scale, tests []decimalTwoArgsTestCase) {
+func testDecimalDoubleArgFunc(
+	t *testing.T,
+	f func(*inf.Dec, *inf.Dec, *inf.Dec, inf.Scale) *inf.Dec,
+	s inf.Scale,
+	tests []decimalTwoArgsTestCase,
+) {
 	for i, tc := range tests {
 		x, y, exp := new(inf.Dec), new(inf.Dec), new(inf.Dec)
 		x.SetString(tc.input1)

--- a/util/encoding/decimal.go
+++ b/util/encoding/decimal.go
@@ -396,7 +396,9 @@ func findDecimalTerminator(buf []byte) (int, error) {
 	return -1, errors.Errorf("did not find terminator %#x in buffer %#x", decimalTerminator, buf)
 }
 
-func decodeSmallNumber(negative bool, buf []byte, tmp []byte) (e int, m []byte, rest []byte, newTmp []byte, err error) {
+func decodeSmallNumber(
+	negative bool, buf []byte, tmp []byte,
+) (e int, m []byte, rest []byte, newTmp []byte, err error) {
 	var ex uint64
 	var r []byte
 	if negative {
@@ -429,7 +431,9 @@ func decodeSmallNumber(negative bool, buf []byte, tmp []byte) (e int, m []byte, 
 	return int(-ex), m, r[idx+1:], tmp, nil
 }
 
-func decodeMediumNumber(negative bool, buf []byte, tmp []byte) (e int, m []byte, rest []byte, newTmp []byte, err error) {
+func decodeMediumNumber(
+	negative bool, buf []byte, tmp []byte,
+) (e int, m []byte, rest []byte, newTmp []byte, err error) {
 	idx, err := findDecimalTerminator(buf[1:])
 	if err != nil {
 		return 0, nil, nil, nil, err
@@ -454,7 +458,9 @@ func decodeMediumNumber(negative bool, buf []byte, tmp []byte) (e int, m []byte,
 	return e, m, buf[idx+2:], tmp, nil
 }
 
-func decodeLargeNumber(negative bool, buf []byte, tmp []byte) (e int, m []byte, rest []byte, newTmp []byte, err error) {
+func decodeLargeNumber(
+	negative bool, buf []byte, tmp []byte,
+) (e int, m []byte, rest []byte, newTmp []byte, err error) {
 	var ex uint64
 	var r []byte
 	if negative {

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -32,8 +32,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func testBasicEncodeDecode32(encFunc func([]byte, uint32) []byte,
-	decFunc func([]byte) ([]byte, uint32, error), descending bool, t *testing.T) {
+func testBasicEncodeDecode32(
+	encFunc func([]byte, uint32) []byte,
+	decFunc func([]byte) ([]byte, uint32, error),
+	descending bool,
+	t *testing.T,
+) {
 	testCases := []uint32{
 		0, 1,
 		1<<8 - 1, 1 << 8,
@@ -71,8 +75,9 @@ type testCaseUint32 struct {
 	expEnc []byte
 }
 
-func testCustomEncodeUint32(testCases []testCaseUint32,
-	encFunc func([]byte, uint32) []byte, t *testing.T) {
+func testCustomEncodeUint32(
+	testCases []testCaseUint32, encFunc func([]byte, uint32) []byte, t *testing.T,
+) {
 	for _, test := range testCases {
 		enc := encFunc(nil, test.value)
 		if !bytes.Equal(enc, test.expEnc) {
@@ -218,8 +223,9 @@ type testCaseInt64 struct {
 	expEnc []byte
 }
 
-func testCustomEncodeInt64(testCases []testCaseInt64,
-	encFunc func([]byte, int64) []byte, t *testing.T) {
+func testCustomEncodeInt64(
+	testCases []testCaseInt64, encFunc func([]byte, int64) []byte, t *testing.T,
+) {
 	for _, test := range testCases {
 		enc := encFunc(nil, test.value)
 		if !bytes.Equal(enc, test.expEnc) {
@@ -233,8 +239,9 @@ type testCaseUint64 struct {
 	expEnc []byte
 }
 
-func testCustomEncodeUint64(testCases []testCaseUint64,
-	encFunc func([]byte, uint64) []byte, t *testing.T) {
+func testCustomEncodeUint64(
+	testCases []testCaseUint64, encFunc func([]byte, uint64) []byte, t *testing.T,
+) {
 	for _, test := range testCases {
 		enc := encFunc(nil, test.value)
 		if !bytes.Equal(enc, test.expEnc) {

--- a/util/log/clog.go
+++ b/util/log/clog.go
@@ -438,7 +438,9 @@ type flushSyncWriter interface {
 // 	file             The file name
 // 	line             The line number
 // 	msg              The user-supplied message
-func formatHeader(s Severity, now time.Time, gid int, file string, line int, colors *colorProfile) *buffer {
+func formatHeader(
+	s Severity, now time.Time, gid int, file string, line int, colors *colorProfile,
+) *buffer {
 	buf := logging.getBuffer()
 	if line < 0 {
 		line = 0 // not a real line number, but acceptable to someDigits

--- a/util/log/clog_test.go
+++ b/util/log/clog_test.go
@@ -63,7 +63,9 @@ func (f *flushBuffer) Sync() error {
 }
 
 // swap sets the log writers and returns the old array.
-func (l *loggingT) swap(writers [Severity_NONE]flushSyncWriter) (old [Severity_NONE]flushSyncWriter) {
+func (l *loggingT) swap(
+	writers [Severity_NONE]flushSyncWriter,
+) (old [Severity_NONE]flushSyncWriter) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	old = l.file

--- a/util/log/file.go
+++ b/util/log/file.go
@@ -324,8 +324,9 @@ func selectFiles(logFiles []FileInfo, severity Severity, endTimestamp int64) []F
 // exceeds 'maxEntries'. Log entries are further filtered by the regexp
 // 'pattern' if provided. The logs entries are returned in reverse chronological
 // order.
-func FetchEntriesFromFiles(severity Severity, startTimestamp, endTimestamp int64, maxEntries int,
-	pattern *regexp.Regexp) ([]Entry, error) {
+func FetchEntriesFromFiles(
+	severity Severity, startTimestamp, endTimestamp int64, maxEntries int, pattern *regexp.Regexp,
+) ([]Entry, error) {
 	logFiles, err := ListLogFiles()
 	if err != nil {
 		return nil, err
@@ -364,8 +365,9 @@ func FetchEntriesFromFiles(severity Severity, startTimestamp, endTimestamp int64
 // 'startTimestamp' to inform the caller that no more log files need to be
 // processed. If the number of entries returned exceeds 'maxEntries' then
 // processing of new entries is stopped immediately.
-func readAllEntriesFromFile(file FileInfo, startTimestamp, endTimestamp int64, maxEntries int,
-	pattern *regexp.Regexp) ([]Entry, bool, error) {
+func readAllEntriesFromFile(
+	file FileInfo, startTimestamp, endTimestamp int64, maxEntries int, pattern *regexp.Regexp,
+) ([]Entry, bool, error) {
 	reader, err := GetLogReader(file.Name, true /* restricted */)
 	if reader == nil || err != nil {
 		return nil, false, err

--- a/util/log/logflags/logflags.go
+++ b/util/log/logflags/logflags.go
@@ -70,8 +70,13 @@ const (
 
 // InitFlags creates logging flags which update the given variables. The passed mutex is
 // locked while the boolean variables are accessed during flag updates.
-func InitFlags(mu sync.Locker, toStderr *bool, logDir flag.Value,
-	nocolor *bool, verbosity, vmodule, traceLocation flag.Value) {
+func InitFlags(
+	mu sync.Locker,
+	toStderr *bool,
+	logDir flag.Value,
+	nocolor *bool,
+	verbosity, vmodule, traceLocation flag.Value,
+) {
 	*toStderr = true // wonky way of specifying a default
 	flag.Var(&atomicBool{Locker: mu, b: toStderr}, LogToStderrName, "log to standard error instead of files")
 	flag.BoolVar(nocolor, NoColorName, *nocolor, "disable standard error log colorization")

--- a/util/metric/metric.go
+++ b/util/metric/metric.go
@@ -148,8 +148,7 @@ type Histogram struct {
 // NewHistogram creates a new windowed HDRHistogram with the given parameters.
 // Data is kept in the active window for approximately the given duration.
 // See the documentation for hdrhistogram.WindowedHistogram for details.
-func NewHistogram(metadata Metadata, duration time.Duration,
-	maxVal int64, sigFigs int) *Histogram {
+func NewHistogram(metadata Metadata, duration time.Duration, maxVal int64, sigFigs int) *Histogram {
 	return &Histogram{
 		Metadata: metadata,
 		maxVal:   maxVal,

--- a/util/metric/prometheus_exporter.go
+++ b/util/metric/prometheus_exporter.go
@@ -46,7 +46,9 @@ func MakePrometheusExporter() PrometheusExporter {
 }
 
 // find the family for the passed-in metric, or create and return it if not found.
-func (pm *PrometheusExporter) findOrCreateFamily(prom PrometheusExportable) *prometheusgo.MetricFamily {
+func (pm *PrometheusExporter) findOrCreateFamily(
+	prom PrometheusExportable,
+) *prometheusgo.MetricFamily {
 	familyName := exportedName(prom.GetName())
 	if family, ok := pm.families[familyName]; ok {
 		return family

--- a/util/netutil/net.go
+++ b/util/netutil/net.go
@@ -38,9 +38,7 @@ import (
 // ListenAndServeGRPC creates a listener and serves the specified grpc Server
 // on it, closing the listener when signalled by the stopper.
 func ListenAndServeGRPC(
-	stopper *stop.Stopper,
-	server *grpc.Server,
-	addr net.Addr,
+	stopper *stop.Stopper, server *grpc.Server, addr net.Addr,
 ) (net.Listener, error) {
 	ln, err := net.Listen(addr.Network(), addr.String())
 	if err != nil {


### PR DESCRIPTION
This is a large automated change produced by running
`crlfmt -ignore "pb.*.go" -tab 2 -w .`

Additionally, `crlfmt` has been added to `GLOCKFILE` and will run in`make check`, failing if any reformats are created. Currently, `crlfmt` only checks for and fixes incorrectly wrapped function declarations.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8823)

<!-- Reviewable:end -->
