### PR TITLE
log: support logging into EventLog

### DIFF
--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -58,6 +58,10 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 	}
 	file, line, _ := caller.Lookup(depth + 1)
 	msg := makeMessage(ctx, format, args)
-	Trace(ctx, msg)
+	if s >= Severity_ERROR {
+		ErrEvent(ctx, msg)
+	} else {
+		Event(ctx, msg)
+	}
 	logging.outputLogEntry(s, file, line, msg)
 }

--- a/util/log/trace.go
+++ b/util/log/trace.go
@@ -21,48 +21,127 @@ import (
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
+	"golang.org/x/net/trace"
 )
+
+// ctxEventLogKey is an empty type for the handle associated with the
+// ctxEventLog value (see context.Value).
+type ctxEventLogKey struct{}
+
+// ctxEventLog is used for contexts to keep track of an EventLog.
+type ctxEventLog struct {
+	eventLog trace.EventLog
+}
+
+// WithEventLog embeds a trace.EventLog in the context, causing future logging
+// and event calls to go to the EventLog. The current context must not have an
+// open span already.
+func WithEventLog(ctx context.Context, eventLog trace.EventLog) context.Context {
+	if opentracing.SpanFromContext(ctx) != nil {
+		panic("event log under span")
+	}
+	val := &ctxEventLog{eventLog: eventLog}
+	return context.WithValue(ctx, ctxEventLogKey{}, val)
+}
+
+func eventLogFromCtx(ctx context.Context) *ctxEventLog {
+	if val := ctx.Value(ctxEventLogKey{}); val != nil {
+		return val.(*ctxEventLog)
+	}
+	return nil
+}
 
 var noopTracer opentracing.NoopTracer
 
-// Trace looks for an opentracing.Trace in the context and logs the given
-// message to it on success.
-func Trace(ctx context.Context, msg string) {
+// Event looks for an opentracing.Trace in the context and logs the given
+// message to it. If no Trace is found, it looks for an EventLog in the context
+// and logs the message to it. If neither is found, does nothing.
+func Event(ctx context.Context, msg string) {
 	sp := opentracing.SpanFromContext(ctx)
-	if sp != nil && sp.Tracer() != noopTracer {
+	if sp != nil {
 		sp.LogEvent(msg)
+	} else if el := eventLogFromCtx(ctx); el != nil {
+		el.eventLog.Printf("%s", msg)
 	}
 }
 
-// Tracef looks for an opentracing.Trace in the context and formats and logs
-// the given message to it on success.
-func Tracef(ctx context.Context, format string, args ...interface{}) {
-	sp := opentracing.SpanFromContext(ctx)
-	if sp != nil && sp.Tracer() != noopTracer {
-		sp.LogEvent(fmt.Sprintf(format, args...))
+// Eventf looks for an opentracing.Trace in the context and formats and logs
+// the given message to it. If no Trace is found, it looks for an EventLog in
+// the context and logs the message to it. If neither is found, does nothing.
+func Eventf(ctx context.Context, format string, args ...interface{}) {
+	if sp := opentracing.SpanFromContext(ctx); sp != nil {
+		if sp.Tracer() != noopTracer {
+			sp.LogEvent(fmt.Sprintf(format, args...))
+		}
+	} else if el := eventLogFromCtx(ctx); el != nil {
+		el.eventLog.Printf(format, args...)
 	}
 }
 
-// VTrace either logs a message to the log files (which also outputs to the
-// active trace) or logs to the trace alone depending on whether the specified
-// verbosity level is active.
-func VTrace(level level, ctx context.Context, msg string) {
+// ErrEvent looks for an opentracing.Trace in the context and logs the given
+// message to it. If no Trace is found, it looks for an EventLog in the context
+// and logs the message to it (as an error). If neither is found, does nothing.
+func ErrEvent(ctx context.Context, msg string) {
+	if sp := opentracing.SpanFromContext(ctx); sp != nil {
+		// TODO(radu): figure out a way to signal that this is an error. We could
+		// use LogEventWithPayload and pass an error or special sentinel as the
+		// payload. Things like NetTraceIntegrator would need to be modified to
+		// understand the difference. We could also set a special Tag or Baggage on
+		// the span. See #8827 for more discussion.
+		sp.LogEvent(msg)
+	} else if el := eventLogFromCtx(ctx); el != nil {
+		el.eventLog.Errorf("%s", msg)
+	}
+}
+
+// ErrEventf looks for an opentracing.Trace in the context and formats and logs
+// the given message to it. If no Trace is found, it looks for an EventLog in
+// the context and formats and logs the message to it (as an error). If neither
+// is found, does nothing.
+func ErrEventf(ctx context.Context, format string, args ...interface{}) {
+	if sp := opentracing.SpanFromContext(ctx); sp != nil {
+		if sp.Tracer() != noopTracer {
+			// TODO(radu): see TODO for ErrEvent.
+			sp.LogEvent(fmt.Sprintf(format, args...))
+		}
+	} else if el := eventLogFromCtx(ctx); el != nil {
+		el.eventLog.Printf(format, args...)
+	}
+}
+
+// VEvent either logs a message to the log files (which also outputs to the
+// active trace or event log) or to the trace/event log alone, depending on
+// whether the specified verbosity level is active.
+func VEvent(level level, ctx context.Context, msg string) {
 	if V(level) {
 		Info(ctx, msg)
 	} else {
-		Trace(ctx, msg)
+		Event(ctx, msg)
 	}
 }
 
-var _ = VTrace // TODO(peter): silence unused error, remove when used
-
-// VTracef either logs a message to the log files (which also outputs to the
-// active trace) or logs to the trace alone depending on whether the specified
-// verbosity level is active.
-func VTracef(level level, ctx context.Context, format string, args ...interface{}) {
+// VEventf either logs a message to the log files (which also outputs to the
+// active trace or event log) or to the trace/event log alone, depending on
+// whether the specified verbosity level is active.
+func VEventf(level level, ctx context.Context, format string, args ...interface{}) {
 	if V(level) {
 		Infof(ctx, format, args...)
 	} else {
-		Tracef(ctx, format, args...)
+		Eventf(ctx, format, args...)
 	}
+}
+
+// Trace is a deprecated alias for Event.
+func Trace(ctx context.Context, msg string) {
+	Event(ctx, msg)
+}
+
+// Tracef is a deprecated alias for Eventf.
+func Tracef(ctx context.Context, format string, args ...interface{}) {
+	Eventf(ctx, format, args...)
+}
+
+// VTracef is a deprecated alias for VEventf.
+func VTracef(level level, ctx context.Context, format string, args ...interface{}) {
+	VEventf(level, ctx, format, args...)
 }

--- a/util/log/trace_test.go
+++ b/util/log/trace_test.go
@@ -1,0 +1,158 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Radu Berinde (radu@cockroachlabs.com)
+
+package log
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+	"golang.org/x/net/trace"
+
+	basictracer "github.com/opentracing/basictracer-go"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+type events []string
+
+// testingTracer creates a Tracer that appends the events to the given slice.
+func testingTracer(ev *events) opentracing.Tracer {
+	opts := basictracer.DefaultOptions()
+	opts.ShouldSample = func(_ uint64) bool { return true }
+	opts.NewSpanEventListener = func() func(basictracer.SpanEvent) {
+		return func(e basictracer.SpanEvent) {
+			switch t := e.(type) {
+			case basictracer.EventCreate:
+				*ev = append(*ev, "start")
+			case basictracer.EventFinish:
+				*ev = append(*ev, "finish")
+			case basictracer.EventLog:
+				*ev = append(*ev, t.Event)
+			}
+		}
+	}
+	opts.DebugAssertUseAfterFinish = true
+	// We don't care about the recorder but we need to set it to something.
+	opts.Recorder = &basictracer.InMemorySpanRecorder{}
+	return basictracer.NewWithOptions(opts)
+}
+
+func TestTrace(t *testing.T) {
+	ctx := context.Background()
+
+	// Events to context without a trace should be no-ops.
+	Event(ctx, "should-not-show-up")
+
+	var ev events
+
+	tracer := testingTracer(&ev)
+	sp := tracer.StartSpan("")
+	ctxWithSpan := opentracing.ContextWithSpan(ctx, sp)
+	Event(ctxWithSpan, "test1")
+	ErrEvent(ctxWithSpan, "testerr")
+	VEvent(logging.verbosity.get()+1, ctxWithSpan, "test2")
+
+	// Events to parent context should still be no-ops.
+	Event(ctx, "should-not-show-up")
+
+	sp.Finish()
+
+	expected := "[start test1 testerr test2 finish]"
+	if evStr := fmt.Sprint(ev); evStr != expected {
+		t.Errorf("expected events '%s', got '%s'", expected, evStr)
+	}
+}
+
+// testingEventLog is a simple implementation of trace.EventLog.
+type testingEventLog struct {
+	ev events
+}
+
+var _ trace.EventLog = &testingEventLog{}
+
+func (el *testingEventLog) Printf(format string, a ...interface{}) {
+	el.ev = append(el.ev, fmt.Sprintf(format, a...))
+}
+
+func (el *testingEventLog) Errorf(format string, a ...interface{}) {
+	el.ev = append(el.ev, fmt.Sprintf(format+"(err)", a...))
+}
+
+func (el *testingEventLog) Finish() {
+	el.ev = append(el.ev, "finish")
+}
+
+func TestEventLog(t *testing.T) {
+	ctx := context.Background()
+
+	// Events to context without a trace should be no-ops.
+	Event(ctx, "should-not-show-up")
+
+	el := &testingEventLog{}
+	ctxWithEventLog := WithEventLog(ctx, el)
+
+	Event(ctxWithEventLog, "test1")
+	ErrEvent(ctxWithEventLog, "testerr")
+	VEvent(logging.verbosity.get()+1, ctxWithEventLog, "test2")
+
+	// Events to parent context should still be no-ops.
+	Event(ctx, "should-not-show-up")
+
+	el.Finish()
+
+	expected := "[test1 testerr(err) test2 finish]"
+	if evStr := fmt.Sprint(el.ev); evStr != expected {
+		t.Errorf("expected events '%s', got '%s'", expected, evStr)
+	}
+}
+
+func TestEventLogAndTrace(t *testing.T) {
+	ctx := context.Background()
+
+	// Events to context without a trace should be no-ops.
+	Event(ctx, "should-not-show-up")
+
+	el := &testingEventLog{}
+	ctxWithEventLog := WithEventLog(ctx, el)
+
+	Event(ctxWithEventLog, "test1")
+	ErrEvent(ctxWithEventLog, "testerr")
+
+	var traceEv events
+	tracer := testingTracer(&traceEv)
+	sp := tracer.StartSpan("")
+	ctxWithBoth := opentracing.ContextWithSpan(ctxWithEventLog, sp)
+	// Events should only go to the trace.
+	Event(ctxWithBoth, "test3")
+	ErrEventf(ctxWithBoth, "%s", "test3err")
+
+	// Events to parent context should still go to the event log.
+	Event(ctxWithEventLog, "test5")
+
+	sp.Finish()
+	el.Finish()
+
+	trExpected := "[start test3 test3err finish]"
+	if evStr := fmt.Sprint(traceEv); evStr != trExpected {
+		t.Errorf("expected events '%s', got '%s'", trExpected, evStr)
+	}
+
+	elExpected := "[test1 testerr(err) test5 finish]"
+	if evStr := fmt.Sprint(el.ev); evStr != elExpected {
+		t.Errorf("expected events '%s', got '%s'", elExpected, evStr)
+	}
+}


### PR DESCRIPTION
Adding support for embedding an EventLog in a Context; the logging functions log
into the given EventLog unless there is a more recent Context that has a trace.

Renaming the tracing functions to `Event*` instead of `Trace*`. The latter
encourages people (mostly me) to refer to log events as traces, and in
opentracing vocabulary a trace is something else (it's the hierarchy of spans).
The old functions are still available for now; the call sites are not renamed to
avoid unnecessary merge conflicts while we have two branches.

The intention is to use this functioanlity to:
- replace the direct EventLog use in `queueLog` and gossip
- easily switch any existing long-running tasks to use event logs instead of
  long-lived spans.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8827)

<!-- Reviewable:end -->
