### PR TITLE
storage: add test for non-preemptive snapshot

### DIFF
--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -563,6 +563,62 @@ func TestReplicateAfterTruncation(t *testing.T) {
 	})
 }
 
+// TestSnapshotAfterTruncation tests that Raft will properly send a
+// non-preemptive snapshot when a node is brought up and the log has been
+// truncated.
+func TestSnapshotAfterTruncation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	mtc := startMultiTestContext(t, 3)
+	defer mtc.Stop()
+	rng, err := mtc.stores[0].GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := roachpb.Key("a")
+	incA := int64(5)
+	incB := int64(7)
+	incAB := incA + incB
+
+	// Set up a key to replicate across the cluster. We're going to modify this
+	// key and truncate the raft logs from that command after killing one of the
+	// nodes to check that it gets the new value after it comes up.
+	incArgs := incrementArgs(key, incA)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	mtc.replicateRange(1, 1, 2)
+	mtc.waitForValues(key, []int64{incA, incA, incA})
+
+	// Now kill store 1, increment the key on the other stores and truncate
+	// their logs to make sure that when store 1 comes back up it will require a
+	// non-preemptive snapshot from Raft.
+	mtc.stopStore(1)
+
+	incArgs = incrementArgs(key, incB)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	mtc.waitForValues(key, []int64{incAB, incA, incAB})
+
+	index, err := rng.GetLastIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Truncate the log at index+1 (log entries < N are removed, so this
+	// includes the increment).
+	truncArgs := truncateLogArgs(index+1, 1)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &truncArgs); err != nil {
+		t.Fatal(err)
+	}
+	mtc.restartStore(1)
+
+	mtc.waitForValues(key, []int64{incAB, incAB, incAB})
+}
+
 // Test various mechanism for refreshing pending commands.
 func TestRefreshPendingCommands(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
This test forces a non-preemptive snapshot by bringing a node down,
sending a command to the other nodes, and truncating their logs before
bringing the first node back up. Then it ensures that the snapshot was
sent and the downed node has all data.

Resolves #8814.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8831)

<!-- Reviewable:end -->
