### PR TITLE
gossip/simulation: pass stopper into NewNetwork

### DIFF
--- a/cmd/gossipsim/main.go
+++ b/cmd/gossipsim/main.go
@@ -76,6 +76,7 @@ import (
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/cockroachdb/cockroach/util/randutil"
+	"github.com/cockroachdb/cockroach/util/stop"
 )
 
 const (
@@ -303,7 +304,10 @@ func main() {
 
 	edgeSet := make(map[string]edge)
 
-	n := simulation.NewNetwork(nodeCount, true)
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+
+	n := simulation.NewNetwork(stopper, nodeCount, true)
 	n.SimulateNetwork(
 		func(cycle int, network *simulation.Network) bool {
 			// Output dot graph.
@@ -311,8 +315,8 @@ func main() {
 			_, quiescent := outputDotFile(dotFN, cycle, network, edgeSet)
 			// Run until network has quiesced.
 			return !quiescent
-		})
-	n.Stop()
+		},
+	)
 
 	// Output instructions for viewing graphs.
 	fmt.Printf("To view simulation graph output run (you must install graphviz):\n\nfor f in %s/*.dot ; do circo $f -Tpng -o $f.png ; echo $f.png ; done\n", dirName)

--- a/gossip/convergence_test.go
+++ b/gossip/convergence_test.go
@@ -24,19 +24,8 @@ import (
 	"github.com/cockroachdb/cockroach/gossip/simulation"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/log"
+	"github.com/cockroachdb/cockroach/util/stop"
 )
-
-// verifyConvergence verifies that info from each node is visible from
-// every node in the network within numCycles cycles of the gossip protocol.
-func verifyConvergence(numNodes, maxCycles int, _ *testing.T) {
-	network := simulation.NewNetwork(numNodes, true)
-
-	if connectedCycle := network.RunUntilFullyConnected(); connectedCycle > maxCycles {
-		log.Warningf(context.TODO(), "expected a fully-connected network within %d cycles; took %d",
-			maxCycles, connectedCycle)
-	}
-	network.Stop()
-}
 
 // TestConvergence verifies a 10 node gossip network converges within
 // a fixed number of simulation cycles. It's really difficult to
@@ -48,5 +37,14 @@ func verifyConvergence(numNodes, maxCycles int, _ *testing.T) {
 // actual production gossip code than seems worthwhile for a unittest.
 func TestConvergence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	verifyConvergence(10, 100, t)
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+
+	network := simulation.NewNetwork(stopper, 10, true)
+
+	const maxCycles = 100
+	if connectedCycle := network.RunUntilFullyConnected(); connectedCycle > maxCycles {
+		log.Warningf(context.TODO(), "expected a fully-connected network within %d cycles; took %d",
+			maxCycles, connectedCycle)
+	}
 }

--- a/gossip/storage_test.go
+++ b/gossip/storage_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/protoutil"
+	"github.com/cockroachdb/cockroach/util/stop"
 	"github.com/cockroachdb/cockroach/util/syncutil"
 )
 
@@ -97,9 +98,10 @@ func (s unresolvedAddrSlice) Swap(i, j int) {
 // using the bootstrap hosts in a gossip.Storage object.
 func TestGossipStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
 
-	network := simulation.NewNetwork(3, true)
-	defer network.Stop()
+	network := simulation.NewNetwork(stopper, 3, true)
 
 	// Set storage for each of the nodes.
 	addresses := make(unresolvedAddrSlice, len(network.Nodes))
@@ -213,10 +215,11 @@ func TestGossipStorage(t *testing.T) {
 // from the bootstrap info after gossip has successfully connected.
 func TestGossipStorageCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
 
 	const numNodes = 3
-	network := simulation.NewNetwork(numNodes, false)
-	defer network.Stop()
+	network := simulation.NewNetwork(stopper, numNodes, false)
 
 	const notReachableAddr = "localhost:0"
 	const invalidAddr = "10.0.0.1000:3333333"

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -113,7 +113,8 @@ func (*legacyTransportAdapter) Close() {
 }
 
 func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
-	n := simulation.NewNetwork(1, true)
+	stopper := stop.NewStopper()
+	n := simulation.NewNetwork(stopper, 1, true)
 	n.Start()
 	g := n.Nodes[0].Gossip
 	// TODO(spencer): remove the use of gossip/simulation here.
@@ -133,7 +134,7 @@ func makeTestGossip(t *testing.T) (*gossip.Gossip, func()) {
 	}, time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	return g, n.Stop
+	return g, stopper.Stop
 }
 
 // TestMoveLocalReplicaToFront verifies that optimizeReplicaOrder correctly
@@ -895,7 +896,10 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 
 func TestGetFirstRangeDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	n := simulation.NewNetwork(3, true)
+	stopper := stop.NewStopper()
+	defer stopper.Stop()
+
+	n := simulation.NewNetwork(stopper, 3, true)
 	for _, node := range n.Nodes {
 		// TODO(spencer): remove the use of gossip/simulation here.
 		node.Gossip.EnableSimulationCycler(false)
@@ -932,7 +936,6 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 		}
 		return false
 	})
-	n.Stop()
 }
 
 // TestSendRPCRetry verifies that sendRPC failed on first address but succeed on


### PR DESCRIPTION
Updates #8500.

This doesn't fix that issue, but makes it more obvious that all the listeners are indeed being cleaned up properly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8841)

<!-- Reviewable:end -->
