### PR TITLE
storage: replace queueLog with EventLog in context

### DIFF
--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -314,7 +314,7 @@ func (gcq *gcQueue) process(
 		return err
 	}
 
-	gcq.eventLog.VInfof(true, "completed with stats %+v", info)
+	log.Infof(gcq.mu.ctx, "completed with stats %+v", info)
 
 	var ba roachpb.BatchRequest
 	var gcArgs roachpb.GCRequest


### PR DESCRIPTION
Replacing the queueLog with new infrastructure that allows us to embed an
EventLog in the context and use regular logs and events.

@tamird @tschottdorf @andreimatei

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8846)

<!-- Reviewable:end -->
