### PR TITLE
*: format maybe-nil error as %v

### DIFF
--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -182,7 +182,7 @@ func (r *Replica) executeCmd(
 	reply.SetHeader(header)
 
 	if log.V(2) {
-		log.Infof(ctx, "%s: executed %s command %+v: %+v, err=%s", r, args.Method(), args, reply, err)
+		log.Infof(ctx, "%s: executed %s command %+v: %+v, err=%v", r, args.Method(), args, reply, err)
 	}
 
 	// Create a roachpb.Error by initializing txn from the request/response header.


### PR DESCRIPTION
This apparently got missed by https://github.com/cockroachdb/cockroach/pull/8661. There may be a few more cases like this out there, I'm only cleaning this particular one up because it's coming up a lot on my high-verbosity rocksdb investigation cluster.

@tamird

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8848)

<!-- Reviewable:end -->
