### PR TITLE
log: fix tags in traces

### DIFF
--- a/util/log/structured.go
+++ b/util/log/structured.go
@@ -25,9 +25,9 @@ import (
 	"github.com/cockroachdb/cockroach/util/caller"
 )
 
-// makeMessage creates a structured log entry.
-func makeMessage(ctx context.Context, format string, args []interface{}) string {
-	var buf bytes.Buffer
+// formatTags appends the tags to a bytes.Buffer. If there are no tags,
+// returns false.
+func formatTags(buf *bytes.Buffer, ctx context.Context) bool {
 	tags := contextLogTags(ctx)
 	if len(tags) > 0 {
 		buf.WriteString("[")
@@ -37,11 +37,19 @@ func makeMessage(ctx context.Context, format string, args []interface{}) string 
 			}
 			buf.WriteString(t.name)
 			if value := t.value(); value != nil {
-				fmt.Fprint(&buf, value)
+				fmt.Fprint(buf, value)
 			}
 		}
 		buf.WriteString("] ")
+		return true
 	}
+	return false
+}
+
+// makeMessage creates a structured log entry.
+func makeMessage(ctx context.Context, format string, args []interface{}) string {
+	var buf bytes.Buffer
+	formatTags(&buf, ctx)
 	if len(format) == 0 {
 		fmt.Fprint(&buf, args...)
 	} else {
@@ -58,10 +66,8 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 	}
 	file, line, _ := caller.Lookup(depth + 1)
 	msg := makeMessage(ctx, format, args)
-	if s >= Severity_ERROR {
-		ErrEvent(ctx, msg)
-	} else {
-		Event(ctx, msg)
-	}
+	// makeMessage already added the tags when forming msg, we don't want
+	// eventInternal to prepend them again.
+	eventInternal(ctx, (s >= Severity_ERROR), false /*withTags*/, "%s", msg)
 	logging.outputLogEntry(s, file, line, msg)
 }

--- a/util/log/trace.go
+++ b/util/log/trace.go
@@ -17,6 +17,7 @@
 package log
 
 import (
+	"bytes"
 	"fmt"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -53,45 +54,81 @@ func eventLogFromCtx(ctx context.Context) *ctxEventLog {
 
 var noopTracer opentracing.NoopTracer
 
+// getSpanOrEventLog returns the current Span. If there is no Span, it returns
+// the current EventLog. If neither (or the Span is NoopTracer), returns false.
+func getSpanOrEventLog(ctx context.Context) (opentracing.Span, trace.EventLog, bool) {
+	if sp := opentracing.SpanFromContext(ctx); sp != nil {
+		if sp.Tracer() == noopTracer {
+			return nil, nil, false
+		}
+		return sp, nil, true
+	}
+	if el := eventLogFromCtx(ctx); el != nil {
+		return nil, el.eventLog, true
+	}
+	return nil, nil, false
+}
+
+// eventInternal is the common code for logging an event. If no args are given,
+// the format is treated as a pre-formatted string.
+func eventInternal(ctx context.Context, isErr, withTags bool, format string, args ...interface{}) {
+	if sp, el, ok := getSpanOrEventLog(ctx); ok {
+		var buf bytes.Buffer
+		if withTags {
+			withTags = formatTags(&buf, ctx)
+		}
+
+		var msg string
+		if !withTags && len(args) == 0 {
+			// Fast path for pre-formatted messages.
+			msg = format
+		} else {
+			if len(args) == 0 {
+				buf.WriteString(format)
+			} else {
+				fmt.Fprintf(&buf, format, args...)
+			}
+			msg = buf.String()
+		}
+
+		if sp != nil {
+			sp.LogEvent(msg)
+			if isErr {
+				// TODO(radu): figure out a way to signal that this is an error. We
+				// could use LogEventWithPayload and pass an error or special sentinel
+				// as the payload. Things like NetTraceIntegrator would need to be
+				// modified to understand the difference. We could also set a special
+				// Tag or Baggage on the span. See #8827 for more discussion.
+			}
+		} else {
+			if isErr {
+				el.Errorf("%s", msg)
+			} else {
+				el.Printf("%s", msg)
+			}
+		}
+	}
+}
+
 // Event looks for an opentracing.Trace in the context and logs the given
 // message to it. If no Trace is found, it looks for an EventLog in the context
 // and logs the message to it. If neither is found, does nothing.
 func Event(ctx context.Context, msg string) {
-	sp := opentracing.SpanFromContext(ctx)
-	if sp != nil {
-		sp.LogEvent(msg)
-	} else if el := eventLogFromCtx(ctx); el != nil {
-		el.eventLog.Printf("%s", msg)
-	}
+	eventInternal(ctx, false /*isErr*/, true /*withTags*/, "%s", msg)
 }
 
 // Eventf looks for an opentracing.Trace in the context and formats and logs
 // the given message to it. If no Trace is found, it looks for an EventLog in
 // the context and logs the message to it. If neither is found, does nothing.
 func Eventf(ctx context.Context, format string, args ...interface{}) {
-	if sp := opentracing.SpanFromContext(ctx); sp != nil {
-		if sp.Tracer() != noopTracer {
-			sp.LogEvent(fmt.Sprintf(format, args...))
-		}
-	} else if el := eventLogFromCtx(ctx); el != nil {
-		el.eventLog.Printf(format, args...)
-	}
+	eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
 }
 
 // ErrEvent looks for an opentracing.Trace in the context and logs the given
 // message to it. If no Trace is found, it looks for an EventLog in the context
 // and logs the message to it (as an error). If neither is found, does nothing.
 func ErrEvent(ctx context.Context, msg string) {
-	if sp := opentracing.SpanFromContext(ctx); sp != nil {
-		// TODO(radu): figure out a way to signal that this is an error. We could
-		// use LogEventWithPayload and pass an error or special sentinel as the
-		// payload. Things like NetTraceIntegrator would need to be modified to
-		// understand the difference. We could also set a special Tag or Baggage on
-		// the span. See #8827 for more discussion.
-		sp.LogEvent(msg)
-	} else if el := eventLogFromCtx(ctx); el != nil {
-		el.eventLog.Errorf("%s", msg)
-	}
+	eventInternal(ctx, true /*isErr*/, true /*withTags*/, "%s", msg)
 }
 
 // ErrEventf looks for an opentracing.Trace in the context and formats and logs
@@ -99,14 +136,7 @@ func ErrEvent(ctx context.Context, msg string) {
 // the context and formats and logs the message to it (as an error). If neither
 // is found, does nothing.
 func ErrEventf(ctx context.Context, format string, args ...interface{}) {
-	if sp := opentracing.SpanFromContext(ctx); sp != nil {
-		if sp.Tracer() != noopTracer {
-			// TODO(radu): see TODO for ErrEvent.
-			sp.LogEvent(fmt.Sprintf(format, args...))
-		}
-	} else if el := eventLogFromCtx(ctx); el != nil {
-		el.eventLog.Printf(format, args...)
-	}
+	eventInternal(ctx, true /*isErr*/, true /*withTags*/, format, args...)
 }
 
 // VEvent either logs a message to the log files (which also outputs to the
@@ -114,9 +144,10 @@ func ErrEventf(ctx context.Context, format string, args ...interface{}) {
 // whether the specified verbosity level is active.
 func VEvent(level level, ctx context.Context, msg string) {
 	if V(level) {
-		Info(ctx, msg)
+		// Log to INFO (which also logs an event).
+		logDepth(ctx, 1, Severity_INFO, "", []interface{}{msg})
 	} else {
-		Event(ctx, msg)
+		eventInternal(ctx, false /*isErr*/, true /*withTags*/, "%s", msg)
 	}
 }
 
@@ -125,9 +156,10 @@ func VEvent(level level, ctx context.Context, msg string) {
 // whether the specified verbosity level is active.
 func VEventf(level level, ctx context.Context, format string, args ...interface{}) {
 	if V(level) {
-		Infof(ctx, format, args...)
+		// Log to INFO (which also logs an event).
+		logDepth(ctx, 1, Severity_INFO, format, args)
 	} else {
-		Eventf(ctx, format, args...)
+		eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
 	}
 }
 
@@ -143,5 +175,10 @@ func Tracef(ctx context.Context, format string, args ...interface{}) {
 
 // VTracef is a deprecated alias for VEventf.
 func VTracef(level level, ctx context.Context, format string, args ...interface{}) {
-	VEventf(level, ctx, format, args...)
+	if V(level) {
+		// Log to INFO (which also logs an event).
+		logDepth(ctx, 1, Severity_INFO, format, args)
+	} else {
+		eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
+	}
 }


### PR DESCRIPTION
The existing tracing code has a problem with log tags: when we trace through a
logging function like `Infof`, the tags show up in the events. When we trace
through an `Event` function, they do not.

Reworking the tracing code to provide a common function to log events, and
fixing this issue by always including log tags. We also fix `VEvent` functions
which were calling `Info/Infof` directly which would result in an incorrect
caller identification.

Longer term, we may want to be smarter: the tags that are part of the ancestor
context where the Span of EventLog was started should be included in the name of
the Span/EventLog (or set as span tags), and only the tags that were added to
the context later should appear in event messages. This is too complicated for
the amount of tags we currently have but we may revisit this in the future as
tag usage expands.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8850)

<!-- Reviewable:end -->
