### PR TITLE
build: builder permissions bugfix

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -81,6 +81,16 @@ echo "${username}:x:${uid_gid}::${container_home}:/bin/bash" > "${passwd_file}"
 # runs as root.
 mkdir -p "${HOME}"/.{jspm,npm} "${gopath0}"/pkg/docker_amd64{,_race} "${gopath0}/bin/docker_amd64"
 
+# Since we're mounting both /root and /root/.{jspm,npm} in our container,
+# Docker will create the .jspm and .npm on the host side under the directory
+# that we're mounting as /root, as the root user. This creates problems for CI
+# processes trying to clean up the working directory, so we create them here
+# as the invoking user to avoid root-owned paths.
+# Note: this only happens on Linux. On Docker for Mac, the directories are
+# still created, but they're owned by the invoking user already.
+# This issue is tracked in docker issue #26051.
+mkdir -p "${host_home}"/.{jspm,npm}
+
 # Run our build container with a set of volumes mounted that will
 # allow the container to store persistent build data on the host
 # computer.


### PR DESCRIPTION
Due to what seems to be a bug in Docker, the builder will create
`build/builder_home/.{npm,jspm}` as root if they don't already exist, even
though we're mounting them from `$HOME/.{npm,jspm}`. Work around this
issue by creating them as the invoking user when running.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8853)

<!-- Reviewable:end -->
