### PR TITLE
master -> develop

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -81,6 +81,16 @@ echo "${username}:x:${uid_gid}::${container_home}:/bin/bash" > "${passwd_file}"
 # runs as root.
 mkdir -p "${HOME}"/.{jspm,npm} "${gopath0}"/pkg/docker_amd64{,_race} "${gopath0}/bin/docker_amd64"
 
+# Since we're mounting both /root and /root/.{jspm,npm} in our container,
+# Docker will create the .jspm and .npm on the host side under the directory
+# that we're mounting as /root, as the root user. This creates problems for CI
+# processes trying to clean up the working directory, so we create them here
+# as the invoking user to avoid root-owned paths.
+# Note: this only happens on Linux. On Docker for Mac, the directories are
+# still created, but they're owned by the invoking user already.
+# This issue is tracked in docker issue #26051.
+mkdir -p "${host_home}"/.{jspm,npm}
+
 # Run our build container with a set of volumes mounted that will
 # allow the container to store persistent build data on the host
 # computer.

--- a/storage/client_raft_test.go
+++ b/storage/client_raft_test.go
@@ -563,6 +563,62 @@ func TestReplicateAfterTruncation(t *testing.T) {
 	})
 }
 
+// TestSnapshotAfterTruncation tests that Raft will properly send a
+// non-preemptive snapshot when a node is brought up and the log has been
+// truncated.
+func TestSnapshotAfterTruncation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	mtc := startMultiTestContext(t, 3)
+	defer mtc.Stop()
+	rng, err := mtc.stores[0].GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := roachpb.Key("a")
+	incA := int64(5)
+	incB := int64(7)
+	incAB := incA + incB
+
+	// Set up a key to replicate across the cluster. We're going to modify this
+	// key and truncate the raft logs from that command after killing one of the
+	// nodes to check that it gets the new value after it comes up.
+	incArgs := incrementArgs(key, incA)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	mtc.replicateRange(1, 1, 2)
+	mtc.waitForValues(key, []int64{incA, incA, incA})
+
+	// Now kill store 1, increment the key on the other stores and truncate
+	// their logs to make sure that when store 1 comes back up it will require a
+	// non-preemptive snapshot from Raft.
+	mtc.stopStore(1)
+
+	incArgs = incrementArgs(key, incB)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &incArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	mtc.waitForValues(key, []int64{incAB, incA, incAB})
+
+	index, err := rng.GetLastIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Truncate the log at index+1 (log entries < N are removed, so this
+	// includes the increment).
+	truncArgs := truncateLogArgs(index+1, 1)
+	if _, err := client.SendWrapped(rg1(mtc.stores[0]), nil, &truncArgs); err != nil {
+		t.Fatal(err)
+	}
+	mtc.restartStore(1)
+
+	mtc.waitForValues(key, []int64{incAB, incAB, incAB})
+}
+
 // Test various mechanism for refreshing pending commands.
 func TestRefreshPendingCommands(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/storage/replica.go
+++ b/storage/replica.go
@@ -319,6 +319,12 @@ type KeyRange interface {
 
 var _ KeyRange = &Replica{}
 
+type tickInfo struct {
+	Exists             bool
+	IsRangeLeaseHolder bool
+	IsRaftLeader       bool
+}
+
 // withRaftGroupLocked calls the supplied function with the (lazily
 // initialized) Raft group. It assumes that the Replica lock is held.
 func (r *Replica) withRaftGroupLocked(f func(r *raft.RawNode) error) error {
@@ -1536,6 +1542,24 @@ func defaultProposeRaftCommandLocked(r *Replica, p *pendingCmd) error {
 	})
 }
 
+func (r *Replica) isRangeLeaseHolderLocked() bool {
+	lease := r.mu.state.Lease
+	if lease == nil {
+		return false
+	}
+	timestamp := r.store.Clock().Now()
+	if lease.Covers(timestamp) {
+		if lease.OwnedBy(r.store.Ident.StoreID) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Replica) isRaftLeaderLocked() bool {
+	return r.mu.leaderID == r.mu.replicaID
+}
+
 func (r *Replica) handleRaftReady() error {
 	ctx := context.TODO()
 	var hasReady bool
@@ -1545,6 +1569,7 @@ func (r *Replica) handleRaftReady() error {
 	lastIndex := r.mu.lastIndex // used for append below
 	raftLogSize := r.mu.raftLogSize
 	leaderID := r.mu.leaderID
+
 	err := r.withRaftGroupLocked(func(raftGroup *raft.RawNode) error {
 		if hasReady = raftGroup.HasReady(); hasReady {
 			rd = raftGroup.Ready()
@@ -1736,16 +1761,20 @@ func (r *Replica) handleRaftReady() error {
 	})
 }
 
-// tick the Raft group, returning any error and true if the raft group exists
-// and false otherwise.
-func (r *Replica) tick() (bool, error) {
+// tick the Raft group, returning any error. tick() updates the tickInfo
+// struct.
+func (r *Replica) tick(info *tickInfo) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	info.IsRaftLeader = r.isRaftLeaderLocked()
+	info.IsRangeLeaseHolder = r.isRangeLeaseHolderLocked()
 
 	// If the raft group is uninitialized, do not initialize raft groups on
 	// tick.
 	if r.mu.internalRaftGroup == nil {
-		return false, nil
+		info.Exists = false
+		return nil
 	}
 
 	r.mu.ticks++
@@ -1760,10 +1789,12 @@ func (r *Replica) tick() (bool, error) {
 		// cycles.
 		if err := r.refreshPendingCmdsLocked(
 			reasonTicks, r.store.ctx.RaftElectionTimeoutTicks); err != nil {
-			return true, err
+			info.Exists = true
+			return err
 		}
 	}
-	return true, nil
+	info.Exists = true
+	return nil
 }
 
 // pendingCmdSlice sorts by increasing MaxLeaseIndex.
@@ -1871,6 +1902,16 @@ func (r *Replica) sendRaftMessage(msg raftpb.Message) {
 			"failed to look up recipient replica %d in range %d while sending %s: %s", msg.To, rangeID, msg.Type, toErr)
 		return
 	}
+
+	r.store.ctx.Transport.mu.Lock()
+	var queuedMsgs int64
+	for _, transportQueues := range r.store.ctx.Transport.mu.queues {
+		for _, queue := range transportQueues {
+			queuedMsgs += int64(len(queue))
+		}
+	}
+	r.store.ctx.Transport.mu.Unlock()
+	r.store.metrics.RaftEnqueuedPending.Update(queuedMsgs)
 
 	if !r.store.ctx.Transport.SendAsync(&RaftMessageRequest{
 		RangeID:     rangeID,

--- a/storage/replica_command.go
+++ b/storage/replica_command.go
@@ -182,7 +182,7 @@ func (r *Replica) executeCmd(
 	reply.SetHeader(header)
 
 	if log.V(2) {
-		log.Infof(ctx, "%s: executed %s command %+v: %+v, err=%s", r, args.Method(), args, reply, err)
+		log.Infof(ctx, "%s: executed %s command %+v: %+v, err=%v", r, args.Method(), args, reply, err)
 	}
 
 	// Create a roachpb.Error by initializing txn from the request/response header.

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -6103,8 +6103,9 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		r.mu.Lock()
 		ticks := r.mu.ticks
 		r.mu.Unlock()
+		var info tickInfo
 		for ; (ticks % electionTicks) != 0; ticks++ {
-			if _, err := r.tick(); err != nil {
+			if err := r.tick(&info); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -6134,7 +6135,8 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		r.mu.Unlock()
 
 		// Tick raft.
-		if _, err := r.tick(); err != nil {
+		var info tickInfo
+		if err := r.tick(&info); err != nil {
 			t.Fatal(err)
 		}
 

--- a/storage/store.go
+++ b/storage/store.go
@@ -2202,6 +2202,9 @@ func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) 
 	}
 
 	addedPlaceholder := false
+
+	s.metrics.raftRcvdMessages[req.Message.Type].Inc(1)
+
 	switch req.Message.Type {
 	case raftpb.MsgSnap:
 		if earlyReturn := func() bool {
@@ -2540,6 +2543,7 @@ func (s *Store) processRaft() {
 			// replicas, clear all remaining placeholders.
 			s.clearAllPlaceholders()
 			s.processRaftMu.Unlock()
+
 			s.metrics.RaftWorkingDurationNanos.Inc(timeutil.Since(workingStart).Nanoseconds())
 
 			maybeWarnDuration(workingStart, s, "raft ready processing")
@@ -2568,14 +2572,33 @@ func (s *Store) processRaft() {
 				s.processRaftMu.Lock()
 				s.mu.Lock()
 				pendingReplicas = pendingReplicas[:0]
+				var raftLeaders, rangeLeaseHolders, rangeLeaseHoldersWithoutRaftLeadership int64
+
+				var info tickInfo
 				for id, r := range s.mu.replicas {
-					if exists, err := r.tick(); err != nil {
+					if err := r.tick(&info); err != nil {
 						log.Error(context.TODO(), err)
-					} else if exists {
+					} else if info.Exists {
 						pendingReplicas = append(pendingReplicas, id)
 					}
+					if info.IsRangeLeaseHolder && !info.IsRaftLeader {
+						rangeLeaseHoldersWithoutRaftLeadership++
+					}
+					if info.IsRaftLeader {
+						raftLeaders++
+					}
+					if info.IsRangeLeaseHolder {
+						rangeLeaseHolders++
+					}
 				}
+
 				s.mu.Unlock()
+
+				s.metrics.RaftLeaders.Update(raftLeaders)
+				s.metrics.RangeLeaseHolders.Update(rangeLeaseHolders)
+				s.metrics.RangeLeaseHoldersWithoutRaftLeadership.Update(rangeLeaseHoldersWithoutRaftLeadership)
+				s.metrics.RaftTicks.Inc(1)
+
 				// Enqueue all pending ranges for readiness checks. Note that we could
 				// not hold the pendingRaftGroups lock during the previous loop because
 				// of lock ordering constraints with r.tick().

--- a/ui/app/containers/nodeGraphs.tsx
+++ b/ui/app/containers/nodeGraphs.tsx
@@ -213,11 +213,47 @@ export default class extends React.Component<IInjectedProps, {}> {
 
             <StackedAreaGraph title="Raft Time" sources={sources}>
               <Axis label="Milliseconds" format={ (n) => d3.format(".1f")(NanoToMilli(n)) }>
-                <Metric name="cr.store.process-raft.waitingnanos" title="Waiting" nonNegativeRate />
-                <Metric name="cr.store.process-raft.workingnanos" title="Working" nonNegativeRate />
-                <Metric name="cr.store.process-raft.tickingnanos" title="Ticking" nonNegativeRate />
+                <Metric name="cr.store.raft.process.waitingnanos" title="Waiting" nonNegativeRate />
+                <Metric name="cr.store.raft.process.workingnanos" title="Working" nonNegativeRate />
+                <Metric name="cr.store.raft.process.tickingnanos" title="Ticking" nonNegativeRate />
               </Axis>
             </StackedAreaGraph>
+
+            <StackedAreaGraph title="Raft Messages received" sources={sources}>
+              <Axis label="Count" format={ d3.format(".1f") }>
+                <Metric name="cr.store.raft.rcvd.prop" title="MsgProp" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.app" title="MsgApp" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.appresp" title="MsgAppResp" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.vote" title="MsgVote" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.voteresp" title="MsgVoteResp" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.snap" title="MsgSnap" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.heartbeat" title="MsgHeartbeat" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.heartbeatresp" title="MsgHeartbeatResp" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.transferleader" title="MsgTransferLeader" nonNegativeRate />
+                <Metric name="cr.store.raft.rcvd.timeoutnow" title="MsgTimeoutNow" nonNegativeRate />
+              </Axis>
+            </StackedAreaGraph>
+
+            <LineGraph title="Raft Transport Queue Pending Count" sources={sources}>
+              <Axis format={ d3.format(".1f") }>
+                <Metric name="cr.store.raft.enqueued.pending" title="Outstanding message count in the Raft Transport queue" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Raft Leaders and LeaseHolders" sources={sources}>
+              <Axis format={ d3.format(".1f") }>
+                <Metric name="cr.store.raft.leaders" title="Ranges on this Store that are Raft Leaders" />
+                <Metric name="cr.store.range.leaseholders" title="Ranges on this Store that are Raft LeaseHolders" />
+                <Metric name="cr.store.range.leaseholders.without.leadership" title="Ranges on this Store that are Raft LeaseHolders but aren't Raft Leaders" />
+              </Axis>
+            </LineGraph>
+
+            <LineGraph title="Raft Ticks" sources={sources}>
+              <Axis format={ d3.format(".1f") }>
+                <Metric name="cr.store.raft.ticks" title="Raft Ticks" nonNegativeRate />
+              </Axis>
+            </LineGraph>
+
           </GraphGroup>
       </div>
     </div>;


### PR DESCRIPTION
``` diff
commit 1972833270bb7b6bf4f29dc6466963f4fd67d4e5
Merge: 93d898f b7c9d08
Author: Tobias Schottdorf <tobias.schottdorf@gmail.com>
Date:   Fri Aug 26 17:28:08 2016 -0400

    Merge remote-tracking branch 'origin/master' into develop

diff --cc storage/replica.go
index 50779b5,8d281d2..5dddc46
--- a/storage/replica.go
+++ b/storage/replica.go
@@@ -1593,10 -1542,26 +1599,28 @@@ func defaultProposeRaftCommandLocked(r 
    })
  }

+ func (r *Replica) isRangeLeaseHolderLocked() bool {
+   lease := r.mu.state.Lease
+   if lease == nil {
+       return false
+   }
+   timestamp := r.store.Clock().Now()
+   if lease.Covers(timestamp) {
+       if lease.OwnedBy(r.store.Ident.StoreID) {
+           return true
+       }
+   }
+   return false
+ }
+ 
+ func (r *Replica) isRaftLeaderLocked() bool {
+   return r.mu.leaderID == r.mu.replicaID
+ }
+ 
 -func (r *Replica) handleRaftReady() error {
 -  ctx := context.TODO()
 +// handleRaftReady processes the Ready() messages on the replica if there are any. It takes a
 +// non-nil IncomingSnapshot pointer to indicate that it is about to process a snapshot.
 +func (r *Replica) handleRaftReady(inSnap *IncomingSnapshot) error {
 +  ctx := r.ctx
    var hasReady bool
    var rd raft.Ready
    r.mu.Lock()
diff --cc storage/store.go
index 8c05fd2,39ac2f4..a5d9424
--- a/storage/store.go
+++ b/storage/store.go
@@@ -2283,184 -2246,127 +2283,186 @@@ func (s *Store) applySnapshot
    if err != nil {
        return roachpb.NewError(err)
    }
 -  r.setLastReplicaDescriptors(req)
 +  r.setLastReplicaDescriptors(rmr)
 +  snapUUID, err := uuid.FromBytes(rmr.Message.Snapshot.Data)
 +  if err != nil {
 +      return roachpb.NewError(errors.Wrap(err, "invalid snapshot: unparseable uuid"))
 +  }
 +  inSnap := IncomingSnapshot{
 +      SnapUUID:        *snapUUID,
 +      RangeDescriptor: header.RangeDescriptor,
 +      Batches:         batches,
 +      LogEntries:      logEntries,
 +  }
 +
 +  if rmr.ToReplica.ReplicaID == 0 {
 +      // Allow snapshots to be applied to replicas before they are
 +      // members of the raft group (i.e. replicas with an ID of 0). This
 +      // is the only operation that can be performed before it is part of
 +      // the raft group.
 +
 +      // Requiring that the Term is set in a message makes sure that we
 +      // get all of Raft's internal safety checks (it confuses messages
 +      // at term zero for internal messages). The sending side uses the
 +      // term from the snapshot itself, but we'll just check nonzero.
 +      if rmr.Message.Term == 0 {
 +          return roachpb.NewErrorf(
 +              "preemptive snapshot from term %d received with zero term",
 +              rmr.Message.Snapshot.Metadata.Term,
 +          )
 +      }
 +      // TODO(tschottdorf): A lot of locking of the individual Replica
 +      // going on below as well. I think that's more easily refactored
 +      // away; what really matters is that the Store doesn't do anything
 +      // else with that same Replica (or one that might conflict with us
 +      // while we still run). In effect, we'd want something like:
 +      //
 +      // 1. look up the snapshot's key range
 +      // 2. get an exclusive lock for operations on that key range from
 +      //    the store (or discard the snapshot)
 +      //    (at the time of writing, we have checked the key range in
 +      //    canApplySnapshotLocked above, but there are concerns about two
 +      //    conflicting operations passing that check simultaneously,
 +      //    see #7830)
 +      // 3. do everything below (apply the snapshot through temp Raft group)
 +      // 4. release the exclusive lock on the snapshot's key range
 +      //
 +      // There are two future outcomes: Either we begin receiving
 +      // legitimate Raft traffic for this Range (hence learning the
 +      // ReplicaID and becoming a real Replica), or the Replica GC queue
 +      // decides that the ChangeReplicas as a part of which the
 +      // preemptive snapshot was sent has likely failed and removes both
 +      // in-memory and on-disk state.
 +      r.mu.Lock()
 +      // We are paranoid about applying preemptive snapshots (which
 +      // were constructed via our code rather than raft) to the "real"
 +      // raft group. Instead, we destroy the "real" raft group if one
 +      // exists (this is rare in production, although it occurs in
 +      // tests), apply the preemptive snapshot to a temporary raft
 +      // group, then discard that one as well to be replaced by a real
 +      // raft group when we get a new replica ID.
 +      //
 +      // It might be OK instead to apply preemptive snapshots just
 +      // like normal ones (essentially switching between regular and
 +      // preemptive mode based on whether or not we have a raft group,
 +      // instead of based on the replica ID of the snapshot message).
 +      // However, this is a risk that we're not yet willing to take.
 +      r.mu.internalRaftGroup = nil
 +      r.mu.Unlock()

 -  if req.ToReplica.ReplicaID == 0 {
 -      if req.Message.Type == raftpb.MsgSnap {
 -          // Allow snapshots to be applied to replicas before they are
 -          // members of the raft group (i.e. replicas with an ID of 0). This
 -          // is the only operation that can be performed before it is part of
 -          // the raft group.
 -
 -          // Requiring that the Term is set in a message makes sure that we
 -          // get all of Raft's internal safety checks (it confuses messages
 -          // at term zero for internal messages). The sending side uses the
 -          // term from the snapshot itself, but we'll just check nonzero.
 -          if req.Message.Term == 0 {
 -              return roachpb.NewErrorf(
 -                  "preemptive snapshot from term %d received with zero term",
 -                  req.Message.Snapshot.Metadata.Term,
 -              )
 -          }
 -          // TODO(tschottdorf): A lot of locking of the individual Replica
 -          // going on below as well. I think that's more easily refactored
 -          // away; what really matters is that the Store doesn't do anything
 -          // else with that same Replica (or one that might conflict with us
 -          // while we still run). In effect, we'd want something like:
 -          //
 -          // 1. look up the snapshot's key range
 -          // 2. get an exclusive lock for operations on that key range from
 -          //    the store (or discard the snapshot)
 -          //    (at the time of writing, we have checked the key range in
 -          //    canApplySnapshotLocked above, but there are concerns about two
 -          //    conflicting operations passing that check simultaneously,
 -          //    see #7830)
 -          // 3. do everything below (apply the snapshot through temp Raft group)
 -          // 4. release the exclusive lock on the snapshot's key range
 -          //
 -          // There are two future outcomes: Either we begin receiving
 -          // legitimate Raft traffic for this Range (hence learning the
 -          // ReplicaID and becoming a real Replica), or the Replica GC queue
 -          // decides that the ChangeReplicas as a part of which the
 -          // preemptive snapshot was sent has likely failed and removes both
 -          // in-memory and on-disk state.
 -          r.mu.Lock()
 -          // We are paranoid about applying preemptive snapshots (which
 -          // were constructed via our code rather than raft) to the "real"
 -          // raft group. Instead, we destroy the "real" raft group if one
 -          // exists (this is rare in production, although it occurs in
 -          // tests), apply the preemptive snapshot to a temporary raft
 -          // group, then discard that one as well to be replaced by a real
 -          // raft group when we get a new replica ID.
 -          //
 -          // It might be OK instead to apply preemptive snapshots just
 -          // like normal ones (essentially switching between regular and
 -          // preemptive mode based on whether or not we have a raft group,
 -          // instead of based on the replica ID of the snapshot message).
 -          // However, this is a risk that we're not yet willing to take.
 -          // Additionally, without some additional plumbing work, doing so
 -          // would limit the effectiveness of RaftTransport.SendSync for
 -          // preemptive snapshots.
 -          r.mu.internalRaftGroup = nil
 -          r.mu.Unlock()
 +      appliedIndex, _, err := loadAppliedIndex(ctx, r.store.Engine(), r.RangeID)
 +      if err != nil {
 +          return roachpb.NewError(err)
 +      }
 +      raftGroup, err := raft.NewRawNode(
 +          newRaftConfig(
 +              raft.Storage(r),
 +              preemptiveSnapshotRaftGroupID,
 +              // We pass the "real" applied index here due to subtleties
 +              // arising in the case in which Raft discards the snapshot:
 +              // It would instruct us to apply entries, which would have
 +              // crashing potential for any choice of dummy value below.
 +              appliedIndex,
 +              r.store.ctx,
 +              &raftLogger{stringer: r},
 +          ), nil)
 +      if err != nil {
 +          return roachpb.NewError(err)
 +      }
 +      // We have a Raft group; feed it the message.
 +      if err := raftGroup.Step(header.RaftMessageRequest.Message); err != nil {
 +          return roachpb.NewError(errors.Wrap(err, "unable to process preemptive snapshot"))
 +      }
 +      // In the normal case, the group should ask us to apply a snapshot.
 +      // If it doesn't, our snapshot was probably stale.
 +      var ready raft.Ready
 +      if raftGroup.HasReady() {
 +          ready = raftGroup.Ready()
 +      }
 +      if raft.IsEmptySnap(ready.Snapshot) {
 +          // Raft discarded the snapshot, indicating that our local
 +          // state is already ahead of what the snapshot provides.
 +          return nil
 +      }

 -          appliedIndex, _, err := loadAppliedIndex(ctx, r.store.Engine(), r.RangeID)
 -          if err != nil {
 -              return roachpb.NewError(err)
 -          }
 -          raftGroup, err := raft.NewRawNode(
 -              newRaftConfig(
 -                  raft.Storage(r),
 -                  preemptiveSnapshotRaftGroupID,
 -                  // We pass the "real" applied index here due to subtleties
 -                  // arising in the case in which Raft discards the snapshot:
 -                  // It would instruct us to apply entries, which would have
 -                  // crashing potential for any choice of dummy value below.
 -                  appliedIndex,
 -                  r.store.ctx,
 -                  &raftLogger{stringer: r},
 -              ), nil)
 -          if err != nil {
 -              return roachpb.NewError(err)
 -          }
 -          // We have a Raft group; feed it the message.
 -          if err := raftGroup.Step(req.Message); err != nil {
 -              return roachpb.NewError(errors.Wrap(err, "unable to process preemptive snapshot"))
 -          }
 -          // In the normal case, the group should ask us to apply a snapshot.
 -          // If it doesn't, our snapshot was probably stale.
 -          var ready raft.Ready
 -          if raftGroup.HasReady() {
 -              ready = raftGroup.Ready()
 -          }
 -          if raft.IsEmptySnap(ready.Snapshot) {
 -              // Raft discarded the snapshot, indicating that our local
 -              // state is already ahead of what the snapshot provides.
 -              return nil
 -          }
 +      // Apply the snapshot, as Raft told us to.
 +      if err := r.applySnapshot(ctx, inSnap, ready.Snapshot, ready.HardState); err != nil {
 +          return roachpb.NewError(err)
 +      }

 -          // Apply the snapshot, as Raft told us to.
 -          if err := r.applySnapshot(ctx, ready.Snapshot, ready.HardState); err != nil {
 +      s.mu.Lock()
 +      defer s.mu.Unlock()
 +      if addedPlaceholder {
 +          // Clear the replica placeholder; we are about to swap it with a real replica.
 +          if err := s.removePlaceholderLocked(header.RangeDescriptor.RangeID); err != nil {
                return roachpb.NewError(err)
            }
 +      }

 -          s.mu.Lock()
 -          defer s.mu.Unlock()
 -          if addedPlaceholder {
 -              // Clear the replica placeholder; we are about to swap it with a real replica.
 -              if err := s.removePlaceholderLocked(req.RangeID); err != nil {
 -                  return roachpb.NewError(err)
 -              }
 -          }
 +      if err := s.processRangeDescriptorUpdateLocked(r); err != nil {
 +          return roachpb.NewError(err)
 +      }

 -          if err := s.processRangeDescriptorUpdateLocked(r); err != nil {
 -              return roachpb.NewError(err)
 -          }
 +      return nil

 -          return nil
 +      // At this point, the Replica has data but no ReplicaID. We hope
 +      // that it turns into a "real" Replica by means of receiving Raft
 +      // messages addressed to it with a ReplicaID, but if that doesn't
 +      // happen, at some point the Replica GC queue will have to grab it.
 +  }

 -          // At this point, the Replica has data but no ReplicaID. We hope
 -          // that it turns into a "real" Replica by means of receiving Raft
 -          // messages addressed to it with a ReplicaID, but if that doesn't
 -          // happen, at some point the Replica GC queue will have to grab it.
 +  if err := r.withRaftGroup(func(raftGroup *raft.RawNode) error {
 +      return raftGroup.Step(header.RaftMessageRequest.Message)
 +  }); err != nil {
 +      return roachpb.NewError(err)
 +  }
 +  // Force the replica to deal with this snapshot right now.
 +  if err := r.handleRaftReady(&inSnap); err != nil {
 +      return roachpb.NewError(errors.Wrap(err, "Didn't process snapshot."))
 +  }
 +  return nil
 +}
 +
 +// HandleRaftRequest dispatches a raft message to the appropriate Replica. It
 +// requires that s.processRaftMu and s.mu are not held.
 +func (s *Store) HandleRaftRequest(ctx context.Context, req *RaftMessageRequest) *roachpb.Error {
 +  s.processRaftMu.Lock()
 +  defer s.processRaftMu.Unlock()
 +
 +  ctx = s.logContext(ctx)
 +
 +  // Drop messages that come from a node that we believe was once
 +  // a member of the group but has been removed.
 +  s.mu.Lock()
 +  if r, ok := s.mu.replicas[req.RangeID]; ok {
 +      if err := checkReplicaTooOld(r, req.FromReplica.ReplicaID); err != nil {
 +          s.mu.Unlock()
 +          return err
        }
 +  }
 +
++  s.metrics.raftRcvdMessages[req.Message.Type].Inc(1)
++
 +  switch req.Message.Type {
 +  case raftpb.MsgSnap:
 +      // All snapshots should be handled by the streaming endpoint.
 +      log.Fatal(ctx, "programming error: received a snapshot via the Raft endpoint")
 +
 +  case raftpb.MsgHeartbeat:
 +      // TODO(bdarnell): handle coalesced heartbeats.
 +  }
 +
 +  // Lazily create the replica.
 +  r, err := s.getOrCreateReplicaLocked(req.RangeID, req.ToReplica.ReplicaID, req.FromReplica)
 +  // TODO(bdarnell): is it safe to release the store lock here?
 +  // It deadlocks to hold s.Mutex while calling raftGroup.Step.
 +  s.mu.Unlock()
 +  if err != nil {
 +      return roachpb.NewError(err)
 +  }
 +  r.setLastReplicaDescriptors(*req)
 +
 +  if req.ToReplica.ReplicaID == 0 {
        // We disallow non-snapshot messages to replica ID 0. Note that
        // getOrCreateReplicaLocked disallows moving the replica ID backward, so
        // the only way we can get here is if the replica did not previously exist.
@@@ -2723,7 -2537,13 +2725,8 @@@ func (s *Store) processRaft() 
                }
            }
            wg.Wait()
 -          // After a round of readys, if a placeholder hasn't been removed
 -          // by the handleRaftReady, this means that the Raft group rejected
 -          // the snapshot. Now that we have called handleRaftReady on all
 -          // replicas, clear all remaining placeholders.
 -          s.clearAllPlaceholders()
            s.processRaftMu.Unlock()
+ 
            s.metrics.RaftWorkingDurationNanos.Inc(timeutil.Since(workingStart).Nanoseconds())

            maybeWarnDuration(workingStart, s, "raft ready processing")
@@@ -2752,14 -2572,33 +2755,33 @@@
                s.processRaftMu.Lock()
                s.mu.Lock()
                pendingReplicas = pendingReplicas[:0]
+               var raftLeaders, rangeLeaseHolders, rangeLeaseHoldersWithoutRaftLeadership int64
+ 
+               var info tickInfo
                for id, r := range s.mu.replicas {
-                   if exists, err := r.tick(); err != nil {
+                   if err := r.tick(&info); err != nil {
 -                      log.Error(context.TODO(), err)
 +                      log.Error(s.Ctx(), err)
-                   } else if exists {
+                   } else if info.Exists {
                        pendingReplicas = append(pendingReplicas, id)
                    }
+                   if info.IsRangeLeaseHolder && !info.IsRaftLeader {
+                       rangeLeaseHoldersWithoutRaftLeadership++
+                   }
+                   if info.IsRaftLeader {
+                       raftLeaders++
+                   }
+                   if info.IsRangeLeaseHolder {
+                       rangeLeaseHolders++
+                   }
                }
+ 
                s.mu.Unlock()
+ 
+               s.metrics.RaftLeaders.Update(raftLeaders)
+               s.metrics.RangeLeaseHolders.Update(rangeLeaseHolders)
+               s.metrics.RangeLeaseHoldersWithoutRaftLeadership.Update(rangeLeaseHoldersWithoutRaftLeadership)
+               s.metrics.RaftTicks.Inc(1)
+ 
                // Enqueue all pending ranges for readiness checks. Note that we could
                // not hold the pendingRaftGroups lock during the previous loop because
                // of lock ordering constraints with r.tick().
diff --cc ui/embedded.go
index a0d752c,a395cc1..fc55650
Binary files differ
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8856)

<!-- Reviewable:end -->
