### PR TITLE
kv: fix deadlock in TestSlowLeaseHolderRetry

### DIFF
--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -100,7 +100,7 @@ func (l *legacyTransportAdapter) IsExhausted() bool {
 	return l.called
 }
 
-func (l *legacyTransportAdapter) SendNext(done chan BatchCall) {
+func (l *legacyTransportAdapter) SendNext(done chan<- BatchCall) {
 	l.called = true
 	br, err := l.f(l.opts, l.replicas, l.args, l.rpcContext)
 	done <- BatchCall{
@@ -1787,7 +1787,7 @@ func TestCountRanges(t *testing.T) {
 type slowLeaseHolderTransport struct {
 	created     bool
 	count       int
-	slowReqChan chan BatchCall
+	slowReqChan chan<- BatchCall
 }
 
 func (t *slowLeaseHolderTransport) factory(
@@ -1812,7 +1812,7 @@ func (t *slowLeaseHolderTransport) IsExhausted() bool {
 	return false
 }
 
-func (t *slowLeaseHolderTransport) SendNext(done chan BatchCall) {
+func (t *slowLeaseHolderTransport) SendNext(done chan<- BatchCall) {
 	if t.count == 0 {
 		// Save the first request to finish later.
 		t.slowReqChan = done

--- a/kv/local_test_cluster_util.go
+++ b/kv/local_test_cluster_util.go
@@ -38,7 +38,7 @@ type localTestClusterTransport struct {
 	latency time.Duration
 }
 
-func (l *localTestClusterTransport) SendNext(done chan BatchCall) {
+func (l *localTestClusterTransport) SendNext(done chan<- BatchCall) {
 	if l.latency > 0 {
 		time.Sleep(l.latency)
 	}

--- a/kv/transport.go
+++ b/kv/transport.go
@@ -100,7 +100,7 @@ type Transport interface {
 	// replica. May panic if the transport is exhausted. Should not
 	// block; the transport is responsible for starting other goroutines
 	// as needed.
-	SendNext(chan BatchCall)
+	SendNext(chan<- BatchCall)
 
 	// Close is called when the transport is no longer needed. It may
 	// cancel any pending RPCs without writing any response to the channel.
@@ -155,7 +155,7 @@ func (gt *grpcTransport) IsExhausted() bool {
 // SendNext invokes the specified RPC on the supplied client when the
 // client is ready. On success, the reply is sent on the channel;
 // otherwise an error is sent.
-func (gt *grpcTransport) SendNext(done chan BatchCall) {
+func (gt *grpcTransport) SendNext(done chan<- BatchCall) {
 	client := gt.orderedClients[0]
 	gt.orderedClients = gt.orderedClients[1:]
 
@@ -241,7 +241,7 @@ func (s *senderTransport) IsExhausted() bool {
 	return s.called
 }
 
-func (s *senderTransport) SendNext(done chan BatchCall) {
+func (s *senderTransport) SendNext(done chan<- BatchCall) {
 	if s.called {
 		panic("called an exhausted transport")
 	}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -386,7 +386,7 @@ func (t *multiTestContextKVTransport) IsExhausted() bool {
 	return len(t.replicas) == 0
 }
 
-func (t *multiTestContextKVTransport) SendNext(done chan kv.BatchCall) {
+func (t *multiTestContextKVTransport) SendNext(done chan<- kv.BatchCall) {
 	rep := t.replicas[0]
 	t.replicas = t.replicas[1:]
 


### PR DESCRIPTION
Previously, the transport and dist sender implicitly disagreed on the
number of replicas available, making possible the situation where the
dist sender's supplied channel was insufficiently buffered to hold all
the in-flight requests.

Concretely, this test previously constructed a dist sender with only 1
replica, with a transport which was hard coded to pretend that it had 3
replicas. A mistimed firing of the sendNextTimer could fill up the done
channel and produce a deadlock.

Found in pursuit of #8843. Closes #8843 (because I haven't been able to reproduce it at all).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8857)

<!-- Reviewable:end -->
