### PR TITLE
build: update builder image to Go 1.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ export PATH := $(GOPATH)/bin:$(PATH)
 # Setting the SHELL variable to a value other than the default (/bin/sh)
 # is one way to do this globally.
 # http://stackoverflow.com/questions/8941110/how-i-could-add-dir-to-path-in-makefile/13468229#13468229
-SHELL := $(shell which bash)
+export SHELL := $(shell which bash)
 ifeq ($(SHELL),)
 $(error bash is required)
 endif

--- a/acceptance/cluster/localcluster.go
+++ b/acceptance/cluster/localcluster.go
@@ -54,7 +54,7 @@ import (
 
 const (
 	builderImage     = "cockroachdb/builder"
-	builderTag       = "20160816-112252"
+	builderTag       = "20160826-194528"
 	builderImageFull = builderImage + ":" + builderTag
 	networkName      = "cockroachdb_acceptance"
 )

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,10 +2,20 @@ FROM golang:1.7
 
 MAINTAINER Peter Mattis <peter@cockroachlabs.com>
 
+# nodejs is used to build and test the UI.
+# bzip2 and fontconfig are used by phantomjs-prebuilt to test the UI.
+# iptables is used in the acceptance tests' partition nemesis.
+# parallel is used to speed up `make check`.
 RUN \
  curl --silent --location https://deb.nodesource.com/setup_6.x | bash - && \
  apt-get dist-upgrade -y && \
- apt-get install --no-install-recommends --auto-remove -y bzip2 fontconfig nodejs iptables && \
+ apt-get install --no-install-recommends --auto-remove -y \
+ bzip2 \
+ fontconfig \
+ iptables \
+ nodejs \
+ parallel \
+ && \
  apt-get clean autoclean && \
  apt-get autoremove -y && \
  git clone --depth 1 https://chromium.googlesource.com/chromium/src/tools/clang && \

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -14,11 +14,20 @@
 #
 # Author: Tamir Duberstein (tamird@gmail.com)
 
-# NOTE: for some reason bash is necessary for updating the PATH to work
-# See http://stackoverflow.com/questions/8941110/how-i-could-add-dir-to-path-in-makefile
-SHELL = /bin/bash
-# Update the path to prefer binstubs over globals
-PATH := $(shell npm bin):$(PATH)
+# Prefer tools from node_modules over those elsewhere on the path.
+# This ensures that we get the versions pinned in npm-shrinkwrap.json.
+export PATH := $(shell npm bin):$(PATH)
+# HACK: Make has a fast path and a slow path for command execution,
+# but the fast path uses the PATH variable from when make was started,
+# not the one we set on the previous line. In order for the above
+# line to have any effect, we must force make to always take the slow path.
+# Setting the SHELL variable to a value other than the default (/bin/sh)
+# is one way to do this globally.
+# http://stackoverflow.com/questions/8941110/how-i-could-add-dir-to-path-in-makefile/13468229#13468229
+SHELL := $(shell which bash)
+ifeq ($(SHELL),)
+$(error bash is required)
+endif
 
 REPO_ROOT   = $(realpath ..)
 ORG_ROOT    = $(REPO_ROOT)/..

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -24,7 +24,7 @@ export PATH := $(shell npm bin):$(PATH)
 # Setting the SHELL variable to a value other than the default (/bin/sh)
 # is one way to do this globally.
 # http://stackoverflow.com/questions/8941110/how-i-could-add-dir-to-path-in-makefile/13468229#13468229
-SHELL := $(shell which bash)
+export SHELL := $(shell which bash)
 ifeq ($(SHELL),)
 $(error bash is required)
 endif


### PR DESCRIPTION
Apparently upstream's 1.7 tag still pointed to 1.7rc6 at the time of
my last update. 1.7 is 1.7rc6, but this should reduce surprise.

Also added gnu parallel while I'm here.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8859)

<!-- Reviewable:end -->
