### PR TITLE
sql: remove nanoseconds

### DIFF
--- a/sql/lease.go
+++ b/sql/lease.go
@@ -135,6 +135,7 @@ func (s LeaseStore) Acquire(
 ) (*LeaseState, error) {
 	lease := &LeaseState{}
 	expiration := time.Unix(0, s.clock.Now().WallTime).Add(jitteredLeaseDuration())
+	expiration = expiration.Round(time.Microsecond)
 	if !minExpirationTime.IsZero() && expiration.Before(minExpirationTime.Time) {
 		expiration = minExpirationTime.Time
 	}

--- a/sql/parser/builtins.go
+++ b/sql/parser/builtins.go
@@ -657,58 +657,12 @@ var Builtins = map[string][]Builtin{
 				case "microsecond", "microseconds":
 					return NewDInt(DInt(fromTime.Nanosecond() / int(time.Microsecond))), nil
 
-				case "nanosecond", "nanoseconds":
-					// This is a CockroachDB extension.
-					return NewDInt(DInt(fromTime.Nanosecond())), nil
-
-				case "epoch_nanosecond", "epoch_nanoseconds":
-					// This is a CockroachDB extension.
-					return NewDInt(DInt(fromTime.UnixNano())), nil
-
 				case "epoch":
 					return NewDInt(DInt(fromTime.Unix())), nil
 
 				default:
 					return DNull, fmt.Errorf("unsupported timespan: %s", timeSpan)
 				}
-			},
-		},
-	},
-
-	// Nanosecond functions.
-	// These functions are the only ways to create and read nanoseconds in
-	// timestamps. All other functions round to microseconds.
-
-	"parse_timestamp_ns": {
-		Builtin{
-			Types:      ArgTypes{TypeString},
-			ReturnType: TypeTimestamp,
-			category:   categoryDateAndTime,
-			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
-				s := string(*args[0].(*DString))
-				return ParseDTimestamp(s, ctx.GetLocation(), time.Nanosecond)
-			},
-		},
-	},
-
-	"format_timestamp_ns": {
-		Builtin{
-			Types:      ArgTypes{TypeTimestamp},
-			ReturnType: TypeString,
-			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
-				t := args[0].(*DTimestamp)
-				return NewDString(t.Time.UTC().Format(timestampFormatNS)), nil
-			},
-		},
-	},
-
-	"current_timestamp_ns": {
-		Builtin{
-			Types:      ArgTypes{},
-			ReturnType: TypeTimestamp,
-			impure:     true,
-			fn: func(ctx *EvalContext, args DTuple) (Datum, error) {
-				return ctx.GetTxnTimestamp(time.Nanosecond), nil
 			},
 		},
 	},

--- a/sql/parser/datum.go
+++ b/sql/parser/datum.go
@@ -775,7 +775,6 @@ const (
 	timestampRFC3339NanoWithoutZoneFormat = "2006-01-02T15:04:05"
 
 	timestampNodeFormat = timestampFormat + ".999999-07:00"
-	timestampFormatNS   = timestampFormat + ".999999999"
 )
 
 var timeFormats = []string{

--- a/sql/testdata/builtin_function
+++ b/sql/testdata/builtin_function
@@ -817,16 +817,6 @@ SELECT extract(microsecond FROM '2016-02-10 19:46:33.306157519'::timestamp)
 306158
 
 query I
-SELECT extract(nanoseconds FROM '2016-02-10 19:46:33.306157519'::timestamp)
-----
-306158000
-
-query I
-SELECT extract(nanosecond FROM '2016-02-10 19:46:33.306157519'::timestamp)
-----
-306158000
-
-query I
 SELECT extract(second FROM '2016-02-10 19:46:33.306157519'::timestamp)
 ----
 33
@@ -890,16 +880,6 @@ query I
 SELECT extract(epoch FROM '1970-01-02 00:00:01.000001'::timestamp)
 ----
 86401
-
-query I
-SELECT extract(epoch_nanosecond FROM '1970-01-02 00:00:01.000001'::timestamp)
-----
-86401000001000
-
-query I
-SELECT extract(epoch_nanoseconds FROM '1970-01-02 00:00:01.000001'::timestamp)
-----
-86401000001000
 
 query BI
 SELECT experimental_unique_bytes() < experimental_unique_bytes(), length(experimental_unique_bytes())

--- a/sql/testdata/datetime
+++ b/sql/testdata/datetime
@@ -164,7 +164,7 @@ COMMIT TRANSACTION
 # Check that the current_timestamp, now and transaction_timestamp are the same.
 # Test that the transaction_timestamp can differ from the statement_timestamp.
 # Check that the transaction_timestamp changes with each transaction.
-# We use, SELECT * FROM kv, to insert delays of more than a nanosecond.
+# We use, SELECT * FROM kv, to insert delays of more than a microsecond.
 statement ok
 BEGIN;
 INSERT INTO kv (k,v) VALUES ('b', transaction_timestamp());
@@ -370,86 +370,6 @@ query I
 SELECT extract(microsecond from '2001-04-10 12:04:59.34565423')
 ----
 345654
-
-# nanoseconds are truncated to microseconds
-query I
-SELECT extract(nanosecond from '2001-04-10 12:04:59.34565423')
-----
-345654000
-
-# verify that nanosecond uniqueness is not preserved
-statement error pq: duplicate key value
-INSERT INTO t (a) VALUES ('2001-04-10 12:04:59.000000001'), ('2001-04-10 12:04:59.000000002')
-
-# nanosecond uniqueness is preserved with parse_timestamp_ns
-statement ok
-INSERT INTO t (a) VALUES (parse_timestamp_ns('2001-04-10 12:04:59.000000001')), (parse_timestamp_ns('2001-04-10 12:04:59.000000002'))
-
-# parse_timestamp_ns retains nanoseconds
-query I
-SELECT extract(nanosecond from parse_timestamp_ns('2001-04-10 12:04:59.345654423'))
-----
-345654423
-
-# current_timestamp_ns has nanoseconds
-# Since it will produce 0 ns 1 out of 1000 executions,
-# INSERT many and verify that at least one is non-zero.
-
-statement ok
-INSERT INTO t (a) VALUES (current_timestamp_ns())
-
-statement ok
-INSERT INTO t (a) VALUES (current_timestamp_ns())
-
-statement ok
-INSERT INTO t (a) VALUES (current_timestamp_ns())
-
-statement ok
-INSERT INTO t (a) VALUES (current_timestamp_ns())
-
-statement ok
-INSERT INTO t (a) VALUES (current_timestamp_ns())
-
-query B
-SELECT max(extract(nanosecond from a) % 1000) != 0 FROM t
-----
-true
-
-query TT
-SELECT format_timestamp_ns('2001-04-10 12:04:59.345654423'), format_timestamp_ns(parse_timestamp_ns('2001-04-10 12:04:59.345654423'))
-----
-2001-04-10 12:04:59.345654 2001-04-10 12:04:59.345654423
-
-# now() should not return any nanoseconds
-query I
-SELECT extract(nanosecond from now()) % 1000
-----
-0
-
-# statement_timestamp() should not return any nanoseconds
-query I
-SELECT extract(nanosecond from statement_timestamp()) % 1000
-----
-0
-
-# clock_timestamp() should not return any nanoseconds
-query I
-SELECT extract(nanosecond from clock_timestamp()) % 1000
-----
-0
-
-# statement_timestamp() should not return any nanoseconds
-query I
-SELECT extract(nanosecond from statement_timestamp()) % 1000
-----
-0
-
-# system.lease should still have nanoseconds
-# Similar to current_timestamp_ns, make sure at least 1 is non-zero.
-query B
-SELECT max(extract(nanosecond from expiration) % 1000) != 0 from system.lease
-----
-true
 
 query error extract: unsupported timespan: nansecond
 SELECT extract(nansecond from '2001-04-10 12:04:59.34565423')


### PR DESCRIPTION
Some months ago we discovered that the nanoseconds we were sending over
pgwire in the text format were not spec compliant. We changed cockroach
to round to micros by default and added 3 functions that could create
or display those nanoseconds. Those functions carried caveats that use
of timestamps without using those functions would result in problems.
#8804 is the first of those problems that we observed. The `cockroach dump`

subcommand did not know about nanoseconds and so would mutate
nanosecond data (well, round them to nanos), equating fields with equal
microseconds, and possibly duplicating rows if they were at a page
boundary. Teaching dump about nanoseconds is possible, but quite messy.

Instead, and after some discussion in #8804, we have decided it's best
to remove nanoseconds altogether mostly because the pg wire protocol
doesn't support them, and they were creating many issues. If we decide
at some future time we want this feature, we can create a TIMESTAMPNS
type with a custom OID that marshals to a string. We will wait on user
requests for this.

Relatedly, remove the nanosecond `extract` functions because they now
won't do what users expect (since those nanoseconds would always be zero
and a user would expect non-zero). If users want those they can multiply
the microsecond versions by 1000.

There are two places in the system code where nanos are still used in
SQL. First is the lease system, which has been changed to use micros
since the timestamps appear in the system.lease table. The second is in
AS OF SYSTEM TIME queries, which will retain nanosecond support because
those are converted into hlc.Timestamps (i.e., not a DTimestamp), to
be used in transactions, and at some future time they will support the
decimal physical + logical ticks format, which preserves nanoseconds.

Fixes #8804

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8864)

<!-- Reviewable:end -->
