### PR TITLE
gossip: plumb contexts

### DIFF
--- a/gossip/client.go
+++ b/gossip/client.go
@@ -36,6 +36,7 @@ import (
 
 // client is a client-side RPC connection to a gossip peer node.
 type client struct {
+	ctx                   context.Context
 	createdAt             time.Time
 	peerID                roachpb.NodeID           // Peer node ID; 0 until first gossip response
 	addr                  net.Addr                 // Peer node network address
@@ -56,8 +57,9 @@ func extractKeys(delta map[string]*Info) string {
 }
 
 // newClient creates and returns a client struct.
-func newClient(addr net.Addr, nodeMetrics Metrics) *client {
+func newClient(ctx context.Context, addr net.Addr, nodeMetrics Metrics) *client {
 	return &client{
+		ctx:       ctx,
 		createdAt: timeutil.Now(),
 		addr:      addr,
 		remoteHighWaterStamps: map[roachpb.NodeID]int64{},
@@ -79,7 +81,7 @@ func (c *client) start(
 	breaker *circuit.Breaker,
 ) {
 	stopper.RunWorker(func() {
-		ctx, cancel := context.WithCancel(context.TODO())
+		ctx, cancel := context.WithCancel(c.ctx)
 		defer cancel()
 		defer func() {
 			disconnected <- c
@@ -172,7 +174,7 @@ func (c *client) sendGossip(g *Gossip, stream Gossip_GossipClient) error {
 		c.nodeMetrics.InfosSent.Add(infosSent)
 
 		if log.V(1) {
-			log.Infof(context.TODO(), "node %d: sending %s", g.mu.is.NodeID, extractKeys(args.Delta))
+			log.Infof(c.ctx, "node %d: sending %s", g.mu.is.NodeID, extractKeys(args.Delta))
 		}
 
 		g.mu.Unlock()
@@ -199,11 +201,11 @@ func (c *client) handleResponse(g *Gossip, reply *Response) error {
 	if reply.Delta != nil {
 		freshCount, err := g.mu.is.combine(reply.Delta, reply.NodeID)
 		if err != nil {
-			log.Warningf(context.TODO(), "node %d: failed to fully combine delta from node %d: %s", g.mu.is.NodeID, reply.NodeID, err)
+			log.Warningf(c.ctx, "node %d: failed to fully combine delta from node %d: %s", g.mu.is.NodeID, reply.NodeID, err)
 		}
 		if infoCount := len(reply.Delta); infoCount > 0 {
 			if log.V(1) {
-				log.Infof(context.TODO(), "node %d: received %s from node %d (%d fresh)", g.mu.is.NodeID, extractKeys(reply.Delta), reply.NodeID, freshCount)
+				log.Infof(c.ctx, "node %d: received %s from node %d (%d fresh)", g.mu.is.NodeID, extractKeys(reply.Delta), reply.NodeID, freshCount)
 			}
 		}
 		g.maybeTightenLocked()

--- a/gossip/client_test.go
+++ b/gossip/client_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/base"
@@ -43,7 +44,7 @@ func startGossip(nodeID roachpb.NodeID, stopper *stop.Stopper, t *testing.T, reg
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
 
 	server := rpc.NewServer(rpcContext)
-	g := New(rpcContext, server, nil, stopper, registry)
+	g := New(context.TODO(), rpcContext, server, nil, stopper, registry)
 	ln, err := netutil.ListenAndServeGRPC(stopper, server, util.TestAddr)
 	if err != nil {
 		t.Fatal(err)
@@ -103,7 +104,7 @@ func startFakeServerGossips(t *testing.T) (*Gossip, *fakeGossipServer, *stop.Sto
 	lRPCContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
 
 	lserver := rpc.NewServer(lRPCContext)
-	local := New(lRPCContext, lserver, nil, stopper, metric.NewRegistry())
+	local := New(context.TODO(), lRPCContext, lserver, nil, stopper, metric.NewRegistry())
 	lln, err := netutil.ListenAndServeGRPC(stopper, lserver, util.TestAddr)
 	if err != nil {
 		t.Fatal(err)
@@ -150,7 +151,7 @@ func TestClientGossip(t *testing.T) {
 	local := startGossip(1, stopper, t, metric.NewRegistry())
 	remote := startGossip(2, stopper, t, metric.NewRegistry())
 	disconnected := make(chan *client, 1)
-	c := newClient(remote.GetNodeAddr(), makeMetrics())
+	c := newClient(context.TODO(), remote.GetNodeAddr(), makeMetrics())
 
 	defer func() {
 		stopper.Stop()
@@ -197,7 +198,7 @@ func TestClientGossipMetrics(t *testing.T) {
 	gossipSucceedsSoon(
 		t, stopper, make(chan *client, 2),
 		map[*client]*Gossip{
-			newClient(local.GetNodeAddr(), remote.nodeMetrics): remote,
+			newClient(context.TODO(), local.GetNodeAddr(), remote.nodeMetrics): remote,
 		},
 		func() error {
 			// Infos/Bytes Sent/Received should not be zero.
@@ -247,7 +248,7 @@ func TestClientNodeID(t *testing.T) {
 
 	// Use an insecure context. We're talking to tcp socket which are not in the certs.
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
-	c := newClient(&remote.nodeAddr, makeMetrics())
+	c := newClient(context.TODO(), &remote.nodeAddr, makeMetrics())
 	disconnected := make(chan *client, 1)
 	disconnected <- c
 
@@ -410,7 +411,7 @@ func TestClientRegisterWithInitNodeID(t *testing.T) {
 			t.Fatal(err)
 		}
 		resolvers = append(resolvers, resolver)
-		gnode := New(RPCContext, server, resolvers, stopper, metric.NewRegistry())
+		gnode := New(context.TODO(), RPCContext, server, resolvers, stopper, metric.NewRegistry())
 		// node ID must be non-zero
 		gnode.SetNodeID(roachpb.NodeID(i + 1))
 		g = append(g, gnode)
@@ -486,7 +487,7 @@ func TestClientForwardUnresolved(t *testing.T) {
 	local := startGossip(nodeID, stopper, t, metric.NewRegistry())
 	addr := local.GetNodeAddr()
 
-	client := newClient(addr, makeMetrics()) // never started
+	client := newClient(context.TODO(), addr, makeMetrics()) // never started
 
 	newAddr := util.UnresolvedAddr{
 		NetworkField: "tcp",

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -42,7 +42,7 @@ func TestGossipInfoStore(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
-	g := New(rpcContext, rpc.NewServer(rpcContext), nil, stopper, metric.NewRegistry())
+	g := New(context.TODO(), rpcContext, rpc.NewServer(rpcContext), nil, stopper, metric.NewRegistry())
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	slice := []byte("b")
@@ -79,7 +79,7 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 		t.Errorf("expected 3 resolvers; got %d", len(resolvers))
 	}
 	server := rpc.NewServer(rpc.NewContext(&base.Context{Insecure: true}, nil, stopper))
-	g := New(nil, server, resolvers, stop.NewStopper(), metric.NewRegistry())
+	g := New(context.TODO(), nil, server, resolvers, stop.NewStopper(), metric.NewRegistry())
 
 	// Using specified resolvers, fetch bootstrap addresses 3 times
 	// and verify the results match expected addresses.
@@ -164,7 +164,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 	}
 
 	for _, peer := range peers {
-		c := newClient(local.GetNodeAddr(), makeMetrics())
+		c := newClient(context.TODO(), local.GetNodeAddr(), makeMetrics())
 
 		util.SucceedsSoon(t, func() error {
 			conn, err := peer.rpcContext.GRPCDial(c.addr.String(), grpc.WithBlock())
@@ -200,7 +200,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 
 		for {
 			localAddr := local.GetNodeAddr()
-			c := newClient(localAddr, makeMetrics())
+			c := newClient(context.TODO(), localAddr, makeMetrics())
 			c.start(peer, disconnectedCh, peer.rpcContext, stopper, peer.GetNodeID(), peer.rpcContext.NewBreaker())
 
 			disconnectedClient := <-disconnectedCh

--- a/gossip/infostore.go
+++ b/gossip/infostore.go
@@ -63,6 +63,7 @@ type callback struct {
 //
 // infoStores are not thread safe.
 type infoStore struct {
+	ctx     context.Context
 	stopper *stop.Stopper
 
 	Infos           infoMap                  `json:"infos,omitempty"` // Map from key to info
@@ -117,14 +118,17 @@ func (is *infoStore) String() string {
 		prepend = ", "
 		return nil
 	}); err != nil {
-		log.Errorf(context.TODO(), "failed to properly construct string representation of infoStore: %s", err)
+		log.Errorf(is.ctx, "failed to properly construct string representation of infoStore: %s", err)
 	}
 	return buf.String()
 }
 
 // newInfoStore allocates and returns a new infoStore.
-func newInfoStore(nodeID roachpb.NodeID, nodeAddr util.UnresolvedAddr, stopper *stop.Stopper) *infoStore {
+func newInfoStore(
+	ctx context.Context, nodeID roachpb.NodeID, nodeAddr util.UnresolvedAddr, stopper *stop.Stopper,
+) *infoStore {
 	return &infoStore{
+		ctx:             ctx,
 		stopper:         stopper,
 		Infos:           make(infoMap),
 		NodeID:          nodeID,
@@ -288,7 +292,7 @@ func (is *infoStore) runCallbacks(key string, content roachpb.Value, callbacks .
 			w()
 		}
 	}); err != nil {
-		log.Warning(context.TODO(), err)
+		log.Warning(is.ctx, err)
 	}
 }
 

--- a/gossip/infostore_test.go
+++ b/gossip/infostore_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/roachpb"
 	"github.com/cockroachdb/cockroach/util"
 	"github.com/cockroachdb/cockroach/util/leaktest"
@@ -42,7 +44,7 @@ func TestZeroDuration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 	info := is.newInfo(nil, 0)
 	if info.TTLStamp != math.MaxInt64 {
 		t.Errorf("expected zero duration to get max TTLStamp: %d", info.TTLStamp)
@@ -54,7 +56,7 @@ func TestNewInfo(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 	info1 := is.newInfo(nil, time.Second)
 	info2 := is.newInfo(nil, time.Second)
 	if err := is.addInfo("a", info1); err != nil {
@@ -74,7 +76,7 @@ func TestInfoStoreGetInfo(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 	i := is.newInfo(nil, time.Second)
 	i.NodeID = 1
 	if err := is.addInfo("a", i); err != nil {
@@ -99,7 +101,7 @@ func TestInfoStoreGetInfoTTL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 	i := is.newInfo(nil, time.Nanosecond)
 	if err := is.addInfo("a", i); err != nil {
 		t.Error(err)
@@ -116,7 +118,7 @@ func TestAddInfoSameKeyLessThanEqualTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 	info1 := is.newInfo(nil, time.Second)
 	if err := is.addInfo("a", info1); err != nil {
 		t.Error(err)
@@ -141,7 +143,7 @@ func TestAddInfoSameKeyGreaterTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 	info1 := is.newInfo(nil, time.Second)
 	info2 := is.newInfo(nil, time.Second)
 	if err1, err2 := is.addInfo("a", info1), is.addInfo("a", info2); err1 != nil || err2 != nil {
@@ -155,7 +157,7 @@ func TestAddInfoSameKeyDifferentHops(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 	info1 := is.newInfo(nil, time.Second)
 	info1.Hops = 1
 	info2 := is.newInfo(nil, time.Second)
@@ -188,7 +190,7 @@ func TestAddInfoSameKeyDifferentHops(t *testing.T) {
 func createTestInfoStore(t *testing.T) *infoStore {
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 
 	for i := 0; i < 10; i++ {
 		infoA := is.newInfo(nil, time.Second)
@@ -265,7 +267,7 @@ func TestInfoStoreMostDistant(t *testing.T) {
 	}
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 	// Add info from each address, with hop count equal to index+1.
 	for i := 0; i < len(nodes); i++ {
 		inf := is.newInfo(nil, time.Second)
@@ -294,7 +296,7 @@ func TestLeastUseful(t *testing.T) {
 	}
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 
 	set := makeNodeSet(3, metric.NewGauge(metric.Metadata{Name: ""}))
 	if is.leastUseful(set) != 0 {
@@ -365,7 +367,7 @@ func TestCallbacks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 	wg := &sync.WaitGroup{}
 	cb1 := callbackRecord{wg: wg}
 	cb2 := callbackRecord{wg: wg}
@@ -472,7 +474,7 @@ func TestRegisterCallback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop()
-	is := newInfoStore(1, emptyAddr, stopper)
+	is := newInfoStore(context.TODO(), 1, emptyAddr, stopper)
 	wg := &sync.WaitGroup{}
 	cb := callbackRecord{wg: wg}
 

--- a/gossip/simulation/network.go
+++ b/gossip/simulation/network.go
@@ -103,7 +103,7 @@ func (n *Network) CreateNode() (*Node, error) {
 		return nil, err
 	}
 	node := &Node{Server: server, Listener: ln, Registry: metric.NewRegistry()}
-	node.Gossip = gossip.New(n.rpcContext, server, nil, n.Stopper, node.Registry)
+	node.Gossip = gossip.New(context.TODO(), n.rpcContext, server, nil, n.Stopper, node.Registry)
 	n.Stopper.RunWorker(func() {
 		<-n.Stopper.ShouldQuiesce()
 		netutil.FatalIfUnexpected(ln.Close())

--- a/kv/dist_sender_test.go
+++ b/kv/dist_sender_test.go
@@ -598,7 +598,7 @@ func makeGossip(t *testing.T, stopper *stop.Stopper) *gossip.Gossip {
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
 	server := rpc.NewServer(rpcContext)
 
-	g := gossip.New(rpcContext, server, nil, stopper, metric.NewRegistry())
+	g := gossip.New(context.Background(), rpcContext, server, nil, stopper, metric.NewRegistry())
 	g.SetNodeID(-1)
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{
 		NodeID:  1,

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -70,7 +70,13 @@ func createTestNode(addr net.Addr, engines []engine.Engine, gossipBS net.Addr, t
 	ctx.ConsistencyCheckInterval = 10 * time.Hour
 	grpcServer := rpc.NewServer(nodeRPCContext)
 	serverCtx := makeTestContext()
-	g := gossip.New(nodeRPCContext, grpcServer, serverCtx.GossipBootstrapResolvers, stopper, metric.NewRegistry())
+	g := gossip.New(
+		context.Background(),
+		nodeRPCContext,
+		grpcServer,
+		serverCtx.GossipBootstrapResolvers,
+		stopper,
+		metric.NewRegistry())
 	ln, err := netutil.ListenAndServeGRPC(stopper, grpcServer, addr)
 	if err != nil {
 		t.Fatal(err)

--- a/server/server.go
+++ b/server/server.go
@@ -163,7 +163,8 @@ func NewServer(srvCtx Context, stopper *stop.Stopper) (*Server, error) {
 	s.grpc = rpc.NewServer(s.rpcContext)
 
 	s.registry = metric.NewRegistry()
-	s.gossip = gossip.New(s.rpcContext, s.grpc, s.ctx.GossipBootstrapResolvers, s.stopper, s.registry)
+	s.gossip = gossip.New(
+		s.Ctx(), s.rpcContext, s.grpc, s.ctx.GossipBootstrapResolvers, s.stopper, s.registry)
 	s.storePool = storage.NewStorePool(
 		s.gossip,
 		s.clock,

--- a/storage/allocator_test.go
+++ b/storage/allocator_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/config"
 	"github.com/cockroachdb/cockroach/gossip"
@@ -1153,7 +1155,7 @@ func Example_rebalancing() {
 	// randomly adding / removing stores and adding bytes.
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
 	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.New(rpcContext, server, nil, stopper, metric.NewRegistry())
+	g := gossip.New(context.Background(), rpcContext, server, nil, stopper, metric.NewRegistry())
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	sp := NewStorePool(

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -117,7 +117,7 @@ func createTestStoreWithEngine(
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, clock, stopper)
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
 	server := rpc.NewServer(rpcContext) // never started
-	sCtx.Gossip = gossip.New(rpcContext, server, nil, stopper, metric.NewRegistry())
+	sCtx.Gossip = gossip.New(context.TODO(), rpcContext, server, nil, stopper, metric.NewRegistry())
 	sCtx.Gossip.SetNodeID(nodeDesc.NodeID)
 	sCtx.ScanMaxIdleTime = 1 * time.Second
 	tracer := tracing.NewTracer()
@@ -652,7 +652,8 @@ func (m *multiTestContext) addStore(idx int) {
 		}
 		return []resolver.Resolver{r}
 	}()
-	m.gossips[idx] = gossip.New(m.rpcContext, grpcServer, resolvers, m.transportStopper, metric.NewRegistry())
+	m.gossips[idx] = gossip.New(
+		context.TODO(), m.rpcContext, grpcServer, resolvers, m.transportStopper, metric.NewRegistry())
 	m.gossips[idx].SetNodeID(roachpb.NodeID(idx + 1))
 	if m.timeUntilStoreDead == 0 {
 		m.timeUntilStoreDead = storage.TestTimeUntilStoreDeadOff

--- a/storage/raft_transport_test.go
+++ b/storage/raft_transport_test.go
@@ -103,7 +103,8 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 	}
 	rttc.nodeRPCContext = rpc.NewContext(testutils.NewNodeTestBaseContext(), nil, rttc.stopper)
 	server := rpc.NewServer(rttc.nodeRPCContext) // never started
-	rttc.gossip = gossip.New(rttc.nodeRPCContext, server, nil, rttc.stopper, metric.NewRegistry())
+	rttc.gossip = gossip.New(
+		context.TODO(), rttc.nodeRPCContext, server, nil, rttc.stopper, metric.NewRegistry())
 	rttc.gossip.SetNodeID(1)
 	return rttc
 }

--- a/storage/replica_test.go
+++ b/storage/replica_test.go
@@ -146,7 +146,8 @@ func (tc *testContext) StartWithStoreContext(t testing.TB, ctx StoreContext) {
 	if tc.gossip == nil {
 		rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, tc.stopper)
 		server := rpc.NewServer(rpcContext) // never started
-		tc.gossip = gossip.New(rpcContext, server, nil, tc.stopper, metric.NewRegistry())
+		tc.gossip = gossip.New(
+			context.Background(), rpcContext, server, nil, tc.stopper, metric.NewRegistry())
 		tc.gossip.SetNodeID(1)
 	}
 	if tc.manualClock == nil {

--- a/storage/simulation/cluster.go
+++ b/storage/simulation/cluster.go
@@ -24,6 +24,8 @@ import (
 	"sort"
 	"text/tabwriter"
 
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/base"
 	"github.com/cockroachdb/cockroach/gossip"
 	"github.com/cockroachdb/cockroach/roachpb"
@@ -77,7 +79,7 @@ func createCluster(
 	clock := hlc.NewClock(hlc.UnixNano)
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, clock, stopper)
 	server := rpc.NewServer(rpcContext)
-	g := gossip.New(rpcContext, server, nil, stopper, metric.NewRegistry())
+	g := gossip.New(context.TODO(), rpcContext, server, nil, stopper, metric.NewRegistry())
 	// NodeID is required for Gossip, so set it to -1 for the cluster Gossip
 	// instance to prevent conflicts with real NodeIDs.
 	g.SetNodeID(-1)

--- a/storage/store_pool_test.go
+++ b/storage/store_pool_test.go
@@ -64,7 +64,7 @@ func createTestStorePool(timeUntilStoreDead time.Duration) (*stop.Stopper, *goss
 	clock := hlc.NewClock(mc.UnixNano)
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, clock, stopper)
 	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.New(rpcContext, server, nil, stopper, metric.NewRegistry())
+	g := gossip.New(context.TODO(), rpcContext, server, nil, stopper, metric.NewRegistry())
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	storePool := NewStorePool(
@@ -482,7 +482,7 @@ func TestStorePoolReserve(t *testing.T) {
 	defer stopper.Stop()
 
 	// Create a fake node server to generate responses for calls to Reserve.
-	f, ctx, address, err := newFakeNodeServer(stopper)
+	f, rpcCtx, address, err := newFakeNodeServer(stopper)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -490,14 +490,14 @@ func TestStorePoolReserve(t *testing.T) {
 	// Create a fake store pool.
 	mc := hlc.NewManualClock(0)
 	clock := hlc.NewClock(mc.UnixNano)
-	server := rpc.NewServer(ctx) // never started
-	g := gossip.New(ctx, server, nil, stopper, metric.NewRegistry())
+	server := rpc.NewServer(rpcCtx) // never started
+	g := gossip.New(context.TODO(), rpcCtx, server, nil, stopper, metric.NewRegistry())
 	// Have to call g.SetNodeID before call g.AddInfo
 	g.SetNodeID(roachpb.NodeID(1))
 	storePool := NewStorePool(
 		g,
 		clock,
-		ctx,
+		rpcCtx,
 		/* reservationsEnabled */ true,
 		TestTimeUntilStoreDeadOff,
 		stopper,

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -133,7 +133,7 @@ func createTestStoreWithoutStart(t testing.TB, ctx *StoreContext) (*Store, *hlc.
 	config.TestingSetupZoneConfigHook(stopper)
 	rpcContext := rpc.NewContext(&base.Context{Insecure: true}, nil, stopper)
 	server := rpc.NewServer(rpcContext) // never started
-	ctx.Gossip = gossip.New(rpcContext, server, nil, stopper, metric.NewRegistry())
+	ctx.Gossip = gossip.New(context.TODO(), rpcContext, server, nil, stopper, metric.NewRegistry())
 	ctx.Gossip.SetNodeID(1)
 	manual := hlc.NewManualClock(0)
 	ctx.Clock = hlc.NewClock(manual.UnixNano)

--- a/testutils/localtestcluster/local_test_cluster.go
+++ b/testutils/localtestcluster/local_test_cluster.go
@@ -91,7 +91,8 @@ func (ltc *LocalTestCluster) Start(t util.Tester, baseCtx *base.Context, initSen
 	ltc.Stopper = stop.NewStopper()
 	rpcContext := rpc.NewContext(baseCtx, ltc.Clock, ltc.Stopper)
 	server := rpc.NewServer(rpcContext) // never started
-	ltc.Gossip = gossip.New(rpcContext, server, nil, ltc.Stopper, metric.NewRegistry())
+	ltc.Gossip = gossip.New(
+		context.Background(), rpcContext, server, nil, ltc.Stopper, metric.NewRegistry())
 	ltc.Eng = engine.NewInMem(roachpb.Attributes{}, 50<<20, ltc.Stopper)
 
 	ltc.Stores = storage.NewStores(ltc.Clock)


### PR DESCRIPTION
Plumbing contexts through gossip. Attaching an EventLog to the context for all
gossip logs, removing the eventLog.

Part of #7995.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8869)

<!-- Reviewable:end -->
