### PR TITLE
scripts: GCE helper

### DIFF
--- a/scripts/bootstrap-debian.sh
+++ b/scripts/bootstrap-debian.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# On a (recent enough) Debian/Ubuntu system, bootstraps a source Go install
+# (with improved parallel build patches) and the cockroach repo.
+
+set -euo pipefail
+
+GOVERSION="1.7"
+
+cd "$(dirname "${0}")"
+
+sudo apt-get update -q && sudo apt-get install -q -y --no-install-recommends build-essential git gdb patch bzip2
+
+mkdir -p ~/go-bootstrap
+curl "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz" | tar -C ~/go-bootstrap -xvz --strip=1
+curl "https://storage.googleapis.com/golang/go${GOVERSION}.src.tar.gz" | tar -C ~ -xvz
+
+patch -p1 -d ../go < parallelbuilds-go1.7.patch
+
+(cd ~/go/src && GOROOT_BOOTSTRAP=~/go-bootstrap ./make.bash)
+
+echo 'export GOPATH='"${HOME}"'; export PATH="'"${HOME}"'/go/bin:${GOPATH}/bin:${PATH}"' >> ~/.bashrc_go
+echo '. .bashrc_go' >> ~/.bashrc
+
+. ~/.bashrc_go
+
+go get -d github.com/cockroachdb/cockroach

--- a/scripts/gceslave.sh
+++ b/scripts/gceslave.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project=${COCKROACH_PROJECT}
+zone=${GCESLAVE_ZONE-us-east1-b}
+name=${GCESLAVE_NAME-gceslave}
+
+cd "$(dirname "${0}")"
+
+case $1 in
+    create)
+    gcloud compute --project "cockroach-tschottdorf" \
+           instances create "${name}" \
+           --zone "${zone}" \
+           --machine-type "custom-32-65536" \
+           --network "default" \
+           --maintenance-policy "MIGRATE" \
+           --image "/debian-cloud/debian-8-jessie-v20160803" \
+           --boot-disk-size "100" \
+           --boot-disk-type "pd-ssd" \
+           --boot-disk-device-name "${name}"
+    sleep 20 # avoid SSH timeout on copy-files
+
+    gcloud compute copy-files --zone "${zone}" . "${name}:scripts"
+    gcloud compute --project "${project}" ssh "${name}" --zone "${zone}" ./scripts/bootstrap-debian.sh
+    # Install automatic shutdown after ten minutes of operation without a
+    # logged in user. To disable this, `sudo touch /.active`.
+    # This is much more intricate than it looks. A few complications which
+    # are addressed in these few commands:
+    # - Once a shutdown is close enough, ssh logins are not allowed any more;
+    #   hence we preventively remove the /etc/nologin file.
+    # - `pgrep` will never match itself, but it will match its parent process
+    #   and so we require an exact match for systemd-shutdownd's full path.
+    # - calling shutdown with a later date cancels the previous shutdown, so
+    #   once a shutdown has been scheduled, we don't want to keep scheduling
+    #   later ones or we will never actually shut down - hence the pgrep.
+    # - This is invoked via `sh -c`, and so no `bash` features must be used.
+    gcloud compute --project "${project}" ssh "${name}" --zone "${zone}" \
+      "echo '* * * * * rm -f /etc/nologin; (w -hs | (grep -q pts && /sbin/shutdown -c --no-wall) || [ -f /.active ] || pgrep -flx /lib/systemd/systemd-shutdownd || /sbin/shutdown --no-wall -h +10) >>/root/idle.log 2>&1' | sudo crontab -"
+
+    ;;
+    start)
+    gcloud compute --project "${project}" instances start "${name}" --zone "${zone}"
+    ;;
+    stop)
+    gcloud compute --project "${project}" instances stop "${name}" --zone "${zone}"
+    ;;
+    destroy)
+    gcloud compute --project "${project}" instances delete "${name}" --zone "${zone}"
+    ;;
+    ssh)
+    shift
+    gcloud compute --project "${project}" ssh "${name}" --zone "${zone}" "$@"
+    ;;
+    *)
+    echo "$0: unknown command: $1, use one of create, start, stop, destroy, or ssh"
+    exit 1
+    ;;
+esac

--- a/scripts/parallelbuilds-go1.7.patch
+++ b/scripts/parallelbuilds-go1.7.patch
@@ -1,0 +1,128 @@
+diff --git a/src/cmd/go/build.go b/src/cmd/go/build.go
+index 5327fb9..ac92970 100644
+--- a/src/cmd/go/build.go
++++ b/src/cmd/go/build.go
+@@ -700,6 +700,8 @@ type builder struct {
+ 	exec      sync.Mutex
+ 	readySema chan bool
+ 	ready     actionQueue
++
++	tasks chan func()
+ }
+ 
+ // An action represents a single action in the action graph.
+@@ -1243,6 +1245,7 @@ func (b *builder) do(root *action) {
+ 	}
+ 
+ 	b.readySema = make(chan bool, len(all))
++	b.tasks = make(chan func(), buildP)
+ 
+ 	// Initialize per-action execution state.
+ 	for _, a := range all {
+@@ -1319,6 +1322,8 @@ func (b *builder) do(root *action) {
+ 					a := b.ready.pop()
+ 					b.exec.Unlock()
+ 					handle(a)
++				case task := <-b.tasks:
++					task()
+ 				case <-interrupted:
+ 					setExitStatus(1)
+ 					return
+@@ -3282,12 +3287,16 @@ func (b *builder) cgo(p *Package, cgoExe, obj string, pcCFLAGS, pcLDFLAGS, cgofi
+ 		staticLibs = []string{"-Wl,--start-group", "-lmingwex", "-lmingw32", "-Wl,--end-group"}
+ 	}
+ 
++	var tasks []func()
++	var results chan error
++
+ 	cflags := stringList(cgoCPPFLAGS, cgoCFLAGS)
+ 	for _, cfile := range cfiles {
++		cfile := cfile
+ 		ofile := obj + cfile[:len(cfile)-1] + "o"
+-		if err := b.gcc(p, ofile, cflags, obj+cfile); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gcc(p, ofile, cflags, obj+cfile)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		if !strings.HasSuffix(ofile, "_cgo_main.o") {
+ 			outObj = append(outObj, ofile)
+@@ -3295,31 +3304,34 @@ func (b *builder) cgo(p *Package, cgoExe, obj string, pcCFLAGS, pcLDFLAGS, cgofi
+ 	}
+ 
+ 	for _, file := range gccfiles {
++		file := file
+ 		ofile := obj + cgoRe.ReplaceAllString(file[:len(file)-1], "_") + "o"
+-		if err := b.gcc(p, ofile, cflags, file); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gcc(p, ofile, cflags, file)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		outObj = append(outObj, ofile)
+ 	}
+ 
+ 	cxxflags := stringList(cgoCPPFLAGS, cgoCXXFLAGS)
+ 	for _, file := range gxxfiles {
++		file := file
+ 		// Append .o to the file, just in case the pkg has file.c and file.cpp
+ 		ofile := obj + cgoRe.ReplaceAllString(file, "_") + ".o"
+-		if err := b.gxx(p, ofile, cxxflags, file); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gxx(p, ofile, cxxflags, file)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		outObj = append(outObj, ofile)
+ 	}
+ 
+ 	for _, file := range mfiles {
++		file := file
+ 		// Append .o to the file, just in case the pkg has file.c and file.m
+ 		ofile := obj + cgoRe.ReplaceAllString(file, "_") + ".o"
+-		if err := b.gcc(p, ofile, cflags, file); err != nil {
+-			return nil, nil, err
+-		}
++		tasks = append(tasks, func() {
++			results <- b.gcc(p, ofile, cflags, file)
++		})
+ 		linkobj = append(linkobj, ofile)
+ 		outObj = append(outObj, ofile)
+ 	}
+@@ -3335,6 +3347,33 @@ func (b *builder) cgo(p *Package, cgoExe, obj string, pcCFLAGS, pcLDFLAGS, cgofi
+ 		outObj = append(outObj, ofile)
+ 	}
+ 
++	// Give the results channel enough capacity so that sending the
++	// result is guaranteed not to block.
++	results = make(chan error, len(tasks))
++
++	// Feed the tasks into the b.tasks channel on a separate goroutine
++	// because the b.tasks channel's limited capacity might cause
++	// sending the task to block.
++	go func() {
++		for _, task := range tasks {
++			b.tasks <- task
++		}
++	}()
++
++	// Loop until we've received results from all of our tasks or an
++	// error occurs.
++	for count := 0; count < len(tasks); {
++		select {
++		case err := <-results:
++			if err != nil {
++				return nil, nil, err
++			}
++			count++
++		case task := <-b.tasks:
++			task()
++		}
++	}
++
+ 	linkobj = append(linkobj, p.SysoFiles...)
+ 	dynobj := obj + "_cgo_.o"
+ 	pie := (goarch == "arm" && goos == "linux") || goos == "android"


### PR DESCRIPTION
This helper script was originally written by @petermattis and creates a GCE
instance which is useful for stress testing or other experiments which would
otherwise exceed what one wants to do on a personal computer.

Gave this script a general do-over. In particular, it applies @petermattis'
patch which allows for parallel builds, so that from a completely fresh repo:

```
$ time make build
real 2m11.776s
```

I experimented with local scratch SSDs, but these instances can only be
destroyed, not stopped, and the SSD must be manually formatted which
complicates the script to the point where it is more trouble than it's worth.

The instance is set up to shut down ~10 minutes after the users disconnects.
If that is not desired, `sudo touch /.active`. The idea here is to be
conservative by default since these machines run at around a dollar a minute.

I encourage everyone to try this - the setup of a new machine takes only a
few minutes and never again will your laptop melt.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8871)

<!-- Reviewable:end -->
