### PR TITLE
distsql: add missing leaktest.AfterTest()

### DIFF
--- a/sql/distsql/flow_registry_test.go
+++ b/sql/distsql/flow_registry_test.go
@@ -21,10 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/uuid"
 )
 
 func TestFlowRegistry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	reg := makeFlowRegistry()
 
 	id1 := FlowID{uuid.MakeV4()}

--- a/sql/distsql/input_sync_test.go
+++ b/sql/distsql/input_sync_test.go
@@ -23,9 +23,11 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/cockroachdb/cockroach/util/leaktest"
 )
 
 func TestOrderedSync(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	v := [6]sqlbase.EncDatum{}
 	for i := range v {
 		v[i].SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))
@@ -133,6 +135,7 @@ func TestOrderedSync(t *testing.T) {
 }
 
 func TestUnorderedSync(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	mrc := &MultiplexedRowChannel{}
 	mrc.Init(5)
 	for i := 1; i <= 5; i++ {

--- a/sql/distsql/main_test.go
+++ b/sql/distsql/main_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
+//go:generate ../util/leaktest/add-leaktest.sh *_test.go
+
 func TestMain(m *testing.M) {
 	security.SetReadFileFn(securitytest.Asset)
 	randutil.SeedForTests()

--- a/sql/distsql/routers_test.go
+++ b/sql/distsql/routers_test.go
@@ -21,10 +21,12 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
 func TestHashRouter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	const numCols = 6
 	const numRows = 200
 
@@ -108,6 +110,7 @@ func TestHashRouter(t *testing.T) {
 }
 
 func TestMirrorRouter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	const numCols = 6
 	const numRows = 20
 

--- a/sql/distsql/sorter_test.go
+++ b/sql/distsql/sorter_test.go
@@ -22,11 +22,13 @@ import (
 	"github.com/cockroachdb/cockroach/sql/parser"
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/util/encoding"
+	"github.com/cockroachdb/cockroach/util/leaktest"
 
 	"golang.org/x/net/context"
 )
 
 func TestSorter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	v := [6]sqlbase.EncDatum{}
 	for i := range v {
 		v[i].SetDatum(sqlbase.ColumnType_INT, parser.NewDInt(parser.DInt(i)))

--- a/sql/distsql/stream_data_test.go
+++ b/sql/distsql/stream_data_test.go
@@ -22,12 +22,14 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/util/leaktest"
 	"github.com/cockroachdb/cockroach/util/randutil"
 )
 
 func testGetDecodedRows(
 	t *testing.T, sd *StreamDecoder, decodedRows sqlbase.EncDatumRows,
 ) sqlbase.EncDatumRows {
+	defer leaktest.AfterTest(t)()
 	for {
 		decoded, err := sd.GetRow(nil)
 		if err != nil {
@@ -82,6 +84,7 @@ func testRowStream(t *testing.T, rng *rand.Rand, rows sqlbase.EncDatumRows, trai
 // TestStreamEncodeDecode generates random streams of EncDatums and passes them
 // through a StreamEncoder and a StreamDecoder
 func TestStreamEncodeDecode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	rng, _ := randutil.NewPseudoRand()
 	for test := 0; test < 100; test++ {
 		rowLen := 1 + rng.Intn(20)
@@ -107,6 +110,7 @@ func TestStreamEncodeDecode(t *testing.T) {
 }
 
 func TestEmptyStreamEncodeDecode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	var se StreamEncoder
 	var sd StreamDecoder
 	msg := se.FormMessage(true /*final*/, nil /*error*/)


### PR DESCRIPTION
This seems to have uncovered a problem: `TestClusterFlow` is failing the cleanup.
@RaduBerinde mind taking a look?
Failure:
https://gist.github.com/andreimatei/52be302c47950fab8d7d37fe270b5cda

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8898)

<!-- Reviewable:end -->
