### PR TITLE
cli: unquote the --from and --to args

### DIFF
--- a/cli/cliflags/flags.go
+++ b/cli/cliflags/flags.go
@@ -316,14 +316,17 @@ database, insecure, certs).`,
 	From = FlagInfo{
 		Name: "from",
 		Description: `
-Start key and format as [<format>:]<key>. Supported formats: raw, human, rangeID.`,
+Start key and format as [<format>:]<key>. Supported formats: raw, human,
+rangeID. The raw format supports escaped text. For example, "raw:\x01k" is the
+prefix for range local keys.`,
 	}
 
 	To = FlagInfo{
 		Name: "to",
 		Description: `
-Exclusive end key and format as [<format>:]<key>. Supported formats: raw, human, rangeID.`,
-	}
+Exclusive end key and format as [<format>:]<key>. Supported formats: raw,
+human, rangeID. The raw format supports escaped text. For example, "raw:\x01k"
+is the prefix for range local keys.`}
 
 	Values = FlagInfo{
 		Name:        "values",

--- a/cli/context.go
+++ b/cli/context.go
@@ -116,7 +116,7 @@ func (k *mvccKey) Set(value string) error {
 
 	switch typ {
 	case raw:
-		*k = mvccKey(engine.MakeMVCCMetadataKey(roachpb.Key(keyStr)))
+		*k = mvccKey(engine.MakeMVCCMetadataKey(roachpb.Key(unquoteArg(keyStr, false))))
 	case human:
 		key, err := keys.UglyPrint(keyStr)
 		if err != nil {


### PR DESCRIPTION
This make it easier to pass in system keys on the command line. For
example, `--from "raw:\x01k" --to "raw:\x01k\xff"`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8903)

<!-- Reviewable:end -->
