### PR TITLE
storage: Never use fewer than 2 rocksdb threads

### DIFF
--- a/storage/engine/rocksdb/db.cc
+++ b/storage/engine/rocksdb/db.cc
@@ -1402,8 +1402,9 @@ DBStatus DBOpen(DBEngine **db, DBSlice dir, DBOptions db_opts) {
   rocksdb::Options options(rocksdb::GetOptions(db_opts.memtable_budget));
   // Increase parallelism for compactions based on the number of
   // cpus. This will use 1 high priority thread for flushes and
-  // num_cpu-1 low priority threads for compactions.
-  options.IncreaseParallelism(db_opts.num_cpu);
+  // num_cpu-1 low priority threads for compactions. Always use at
+  // least 2 threads, otherwise compactions won't happen.
+  options.IncreaseParallelism(std::max(db_opts.num_cpu, 2));
   // Enable subcompactions which will use multiple threads to speed up
   // a single compaction. The value of num_cpu/2 has not been tuned.
   options.max_subcompactions = std::max(db_opts.num_cpu / 2, 1);


### PR DESCRIPTION
If you only use one thread, then rocksdb disables background
compactions, which is no bueno.

I made sure there aren't any other bits of our configuration that
unsafely use the number of CPUs. The only other use of num_cpu (for
setting max_subcompactions) was already doing something similar.

Fixes #8784

@petermattis @tschottdorf

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8908)

<!-- Reviewable:end -->
