### PR TITLE
acceptance: don't report to registration cluster

### DIFF
--- a/acceptance/reference_test.go
+++ b/acceptance/reference_test.go
@@ -52,6 +52,7 @@ trap finish EXIT
 
 export PGHOST=localhost
 export PGPORT=""
+export COCKROACH_SKIP_UPDATE_CHECK=1
 
 bin=/%s/cockroach
 # TODO(bdarnell): when --background is in referenceBinPath, use it here and below.
@@ -142,6 +143,7 @@ function finish() {
 }
 trap finish EXIT
 
+export COCKROACH_SKIP_UPDATE_CHECK=1
 $bin start --alsologtostderr=INFO --background --store=/cockroach-data-reference-7429 &> out
 $bin debug kv scan
 $bin quit


### PR DESCRIPTION
The reference test was connecting to the registration cluster when
spinning up its test nodes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8911)

<!-- Reviewable:end -->
