### PR TITLE
docs: Copy Kubernetes config over from Kubernetes repo

### DIFF
--- a/cloud/kubernetes/README.md
+++ b/cloud/kubernetes/README.md
@@ -1,0 +1,107 @@
+# CockroachDB on Kubernetes as a PetSet
+
+This example deploys CockroachDB on [Kubernetes](https://kubernetes.io) as
+a [PetSet](http://kubernetes.io/docs/user-guide/petset/). Kubernetes is an
+open source system for managing containerized applications across multiple
+hosts, providing basic mechanisms for deployment, maintenance, and scaling
+of applications.
+
+This is a copy of the [similar example stored in the Kubernetes
+repository](https://github.com/kubernetes/kubernetes/tree/master/examples/cockroachdb).
+We keep a copy here as well for faster iteration, since merging things into
+Kubernetes can be quite slow, particularly during the code freeze before
+releases. The copy here will typically be more up-to-date.
+
+Note that if all you want to do is run a single cockroachdb instance for
+testing and don't care about data persistence, you can do so with just a single
+command instead of following this guide (which sets up a more reliable cluster):
+
+```shell
+kubectl run cockroachdb --image=cockroachdb/cockroach -- start
+```
+
+## Limitations
+
+### PetSet limitations
+
+Standard PetSet limitations apply: There is currently no possibility to use
+node-local storage (outside of single-node tests), and so there is likely
+a performance hit associated with running CockroachDB on some external storage.
+Note that CockroachDB already does replication and thus, for better performance,
+should not be deployed on a persistent volume which already replicates internally.
+High-performance use cases on a private Kubernetes cluster should consider
+a DaemonSet deployment.
+
+### Recovery after persistent storage failure
+
+A persistent storage failure (e.g. losing the hard drive) is gracefully handled
+by CockroachDB as long as enough replicas survive (two out of three by
+default). Due to the bootstrapping in this deployment, a storage failure of the
+first node is special in that the administrator must manually prepopulate the
+"new" storage medium by running an instance of CockroachDB with the `--join`
+parameter. If this is not done, the first node will bootstrap a new cluster,
+which will lead to a lot of trouble.
+
+### Dynamic provisioning
+
+The deployment is written for a use case in which dynamic provisioning is
+available. When that is not the case, the persistent volume claims need
+to be created manually. See [minikube.sh](minikube.sh) for the necessary
+steps.
+
+## Testing locally on minikube
+
+Follow the steps in [minikube.sh](minikube.sh) (or simply run that file).
+
+## Accessing the database
+
+Along with our PetSet configuration, we expose a standard Kubernetes service
+that offers a load-balanced virtual IP for clients to access the database
+with. In our example, we've called this service `cockroachdb-public`.
+
+Start up a client pod and open up an interactive, (mostly) Postgres-flavor
+SQL shell using:
+
+```console
+$ kubectl run -it cockroach-client --image=cockroachdb/cockroach --restart=Never --command -- bash
+root@cockroach-client # ./cockroach sql --host cockroachdb-public
+```
+
+You can see example SQL statements for inserting and querying data in the
+included [demo script](demo.sh), but can use almost any Postgres-style SQL
+commands. Some more basic examples can be found within
+[CockroachDB's documentation](https://www.cockroachlabs.com/docs/learn-cockroachdb-sql.html).
+
+## Simulating failures
+
+When all (or enough) nodes are up, simulate a failure like this:
+
+```shell
+kubectl exec cockroachdb-0 -- /bin/bash -c "while true; do kill 1; done"
+```
+
+You can then reconnect to the database as demonstrated above and verify
+that no data was lost. The example runs with three-fold replication, so
+it can tolerate one failure of any given node at a time. Note also that
+there is a brief period of time immediately after the creation of the
+cluster during which the three-fold replication is established, and during
+which killing a node may lead to unavailability.
+
+The [demo script](demo.sh) gives an example of killing one instance of the
+database and ensuring the other replicas have all data that was written.
+
+## Scaling up or down
+
+Simply edit the PetSet (but note that you may need to create a new persistent
+volume claim first). If you ran `minikube.sh`, there's a spare volume so you
+can immediately scale up by one. Convince yourself that the new node
+immediately serves reads and writes.
+
+## Cleaning up when you're done
+
+Because all of the resources in this example have been tagged with the label `app=cockroachdb`,
+we can clean up everything that we created in one quick command using a selector on that label:
+
+```shell
+kubectl delete petsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+```

--- a/cloud/kubernetes/cockroachdb-petset.yaml
+++ b/cloud/kubernetes/cockroachdb-petset.yaml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # This service is meant to be used by clients of the database. It exposes a ClusterIP that will
+  # automatically load balance connections to the different database pods.
+  name: cockroachdb-public
+  labels:
+    app: cockroachdb
+spec:
+  ports:
+  # The main port, served by gRPC, serves Postgres-flavor SQL, internode
+  # traffic and the cli.
+  - port: 26257
+    targetPort: 26257
+    name: grpc
+  # The secondary port serves the UI as well as health and debug endpoints.
+  - port: 8080
+    targetPort: 8080
+    name: http
+  selector:
+    app: cockroachdb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    # Make sure DNS is resolvable during initialization.
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "_status/vars"
+    prometheus.io/port: "8080"
+  # This service only exists to create DNS entries for each pet in the petset such that they can resolve
+  # each other's IP addresses. It does not create a load-balanced ClusterIP and should not be used
+  # directly by clients in most circumstances.
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+spec:
+  ports:
+  - port: 26257
+    targetPort: 26257
+    name: grpc
+  - port: 8080
+    targetPort: 8080
+    name: http
+  clusterIP: None
+  selector:
+    app: cockroachdb
+---
+apiVersion: apps/v1alpha1
+kind: PetSet
+metadata:
+  name: cockroachdb
+spec:
+  serviceName: "cockroachdb"
+  replicas: 6
+  template:
+    metadata:
+      labels:
+        app: cockroachdb
+      annotations:
+        pod.alpha.kubernetes.io/initialized: "true"
+    spec:
+      containers:
+      - name: cockroachdb
+        # Runs the master branch. Not recommended for production, but since
+        # CockroachDB is in Beta, you don't want to run it in production
+        # anyway. See
+        # https://hub.docker.com/r/cockroachdb/cockroach/tags/
+        # if you prefer to run a beta release.
+        image: cockroachdb/cockroach
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 26257
+          name: grpc
+        - containerPort: 8080
+          name: http
+        livenessProbe:
+          httpGet:
+            path: /_admin/v1/health
+            port: http
+          initialDelaySeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /_admin/v1/health
+            port: http
+          initialDelaySeconds: 10
+        volumeMounts:
+        - name: datadir
+          mountPath: /cockroach/cockroach-data
+        command:
+          - "/bin/bash"
+          - "-ecx"
+          - |
+            # The use of qualified `hostname -f` is crucial:
+            # Other nodes aren't able to look up the unqualified hostname.
+            CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)")
+            # TODO(tschottdorf): really want to use an init container to do
+            # the bootstrapping. The idea is that the container would know
+            # whether it's on the first node and could check whether there's
+            # already a data directory. If not, it would bootstrap the cluster.
+            # We will need some version of `cockroach init` back for this to
+            # work. For now, just do the same in a shell snippet.
+            # Of course this isn't without danger - if node0 loses its data,
+            # upon restarting it will simply bootstrap a new cluster and smack
+            # it into our existing cluster.
+            # There are likely ways out. For example, the init container could
+            # query the kubernetes API and see whether any other nodes are
+            # around, etc. Or, of course, the admin can pre-seed the lost
+            # volume somehow (and in that case we should provide a better way,
+            # for example a marker file).
+            if [ ! "$(hostname)" == "cockroachdb-0" ] || \
+               [ -e "/cockroach/cockroach-data/COCKROACHDB_VERSION" ]
+            then
+              CRARGS+=("--join" "cockroachdb")
+            fi
+            /cockroach/cockroach ${CRARGS[*]}
+      # No pre-stop hook is required, a SIGTERM plus some time is all that's
+      # needed for graceful shutdown of a node.
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: datadir
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: 1Gi

--- a/cloud/kubernetes/demo.sh
+++ b/cloud/kubernetes/demo.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function sql() {
+  # TODO(knz): Why does the more idiomatic read from stdin not produce any
+  # output?
+  kubectl exec "cockroachdb-${1}" -- /cockroach/cockroach sql \
+      --host "cockroachdb-${1}.cockroachdb" \
+      -e "$(cat /dev/stdin)"
+}
+
+function kill() {
+  ! kubectl exec -t "cockroachdb-${1}" -- /bin/bash -c "while true; do kill 1; done" &> /dev/null
+}
+
+# Create database on second node (idempotently for convenience).
+cat <<EOF | sql 1
+CREATE DATABASE IF NOT EXISTS foo;
+CREATE TABLE IF NOT EXISTS foo.bar (k STRING PRIMARY KEY, v STRING); 
+UPSERT INTO foo.bar VALUES ('Kuber', 'netes'), ('Cockroach', 'DB');
+EOF
+
+# Kill the node we just created the table on.
+kill 1
+
+# Read the data from all other nodes (we could also read from the one we just
+# killed, but it's awkward to wait for it to respawn).
+for i in 0 2 3 4; do
+  cat <<EOF | sql "${i}"
+SELECT CONCAT(k, v) FROM foo.bar;
+EOF
+done

--- a/cloud/kubernetes/minikube.sh
+++ b/cloud/kubernetes/minikube.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+# Clean up anything from a prior run:
+kubectl delete petsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+
+# Make persistent volumes and (correctly named) claims. We must create the
+# claims here manually even though that sounds counter-intuitive. For details
+# see https://github.com/kubernetes/contrib/pull/1295#issuecomment-230180894.
+# Note that we make an extra volume here so you can manually test scale-up.
+for i in $(seq 0 5); do
+  cat <<EOF | kubectl create -f -
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: pv${i}
+  labels:
+    type: local
+    app: cockroachdb
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/${i}"
+EOF
+
+  cat <<EOF | kubectl create -f -
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: datadir-cockroachdb-${i}
+  labels:
+    app: cockroachdb
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+EOF
+done;
+
+kubectl create -f cockroachdb-petset.yaml


### PR DESCRIPTION
Maintain it here as well so that we can iterate on it more easily and
refer to it from our docs. My improvements to the version in the
Kubernetes repo may not be merged for a couple weeks due to their code
freeze.

Slightly modified the README to make more sense in this repo, otherwise
this is unchanged.

@jseldess @tschottdorf

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8912)

<!-- Reviewable:end -->
