### PR TITLE
log: allow Finishing an EventLog concurrently with events

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -65,7 +65,6 @@ import (
 	"google.golang.org/grpc"
 
 	"golang.org/x/net/context"
-	"golang.org/x/net/trace"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
@@ -205,8 +204,7 @@ func New(
 	stopper *stop.Stopper,
 	registry *metric.Registry,
 ) *Gossip {
-	eventLog := trace.NewEventLog("gossip", "gossip")
-	ctx = log.WithEventLog(ctx, eventLog)
+	ctx = log.WithEventLog(ctx, "gossip", "gossip")
 	g := &Gossip{
 		ctx:               ctx,
 		Connected:         make(chan struct{}),
@@ -224,7 +222,7 @@ func New(
 		bootstrapAddrs:    map[util.UnresolvedAddr]struct{}{},
 	}
 	stopper.AddCloser(stop.CloserFn(func() {
-		eventLog.Finish()
+		log.FinishEventLog(ctx)
 	}))
 
 	registry.AddMetric(g.outgoing.gauge)

--- a/storage/gc_queue.go
+++ b/storage/gc_queue.go
@@ -314,7 +314,7 @@ func (gcq *gcQueue) process(
 		return err
 	}
 
-	log.Infof(gcq.mu.ctx, "completed with stats %+v", info)
+	log.Infof(gcq.ctx, "completed with stats %+v", info)
 
 	var ba roachpb.BatchRequest
 	var gcArgs roachpb.GCRequest

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -174,8 +174,8 @@ type baseQueue struct {
 		stopped     bool
 		// Some tests in this package disable queues.
 		disabled bool
-		ctx      context.Context
 	}
+	ctx context.Context
 }
 
 // makeBaseQueue returns a new instance of baseQueue with the
@@ -202,10 +202,10 @@ func makeBaseQueue(
 	bq.mu.Locker = new(syncutil.Mutex)
 	bq.mu.replicas = map[roachpb.RangeID]*replicaItem{}
 
-	bq.mu.ctx = context.TODO()
+	bq.ctx = context.TODO()
 	// Prepend [name] to logs.
-	bq.mu.ctx = log.WithLogTag(bq.mu.ctx, name, nil)
-	bq.mu.ctx = log.WithEventLog(bq.mu.ctx, "queue", name)
+	bq.ctx = log.WithLogTag(bq.ctx, name, nil)
+	bq.ctx = log.WithEventLog(bq.ctx, "queue", name)
 	return bq
 }
 
@@ -274,20 +274,20 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now hlc.Timestamp) {
 	}
 
 	if !cfgOk {
-		log.VEvent(1, bq.mu.ctx, "no system config available. skipping")
+		log.VEvent(1, bq.ctx, "no system config available. skipping")
 		return
 	}
 
 	if requiresSplit {
 		// Range needs to be split due to zone configs, but queue does
 		// not accept unsplit ranges.
-		log.VEventf(1, bq.mu.ctx, "%s: split needed; not adding", repl)
+		log.VEventf(1, bq.ctx, "%s: split needed; not adding", repl)
 		return
 	}
 
 	should, priority := bq.impl.shouldQueue(now, repl, cfg)
 	if _, err := bq.addInternal(repl, should, priority); !isExpectedQueueError(err) {
-		log.Errorf(bq.mu.ctx, "unable to add %s: %s", repl, err)
+		log.Errorf(bq.ctx, "unable to add %s: %s", repl, err)
 	}
 }
 
@@ -314,7 +314,7 @@ func (bq *baseQueue) addInternal(repl *Replica, should bool, priority float64) (
 	}
 
 	if bq.mu.disabled {
-		log.Event(bq.mu.ctx, "queue disabled")
+		log.Event(bq.ctx, "queue disabled")
 		return false, errQueueDisabled
 	}
 
@@ -326,13 +326,13 @@ func (bq *baseQueue) addInternal(repl *Replica, should bool, priority float64) (
 	item, ok := bq.mu.replicas[repl.RangeID]
 	if !should {
 		if ok {
-			log.Eventf(bq.mu.ctx, "%s: removing", item.value)
+			log.Eventf(bq.ctx, "%s: removing", item.value)
 			bq.remove(item)
 		}
 		return false, errReplicaNotAddable
 	} else if ok {
 		if item.priority != priority {
-			log.Eventf(bq.mu.ctx, "%s: updating priority: %0.3f -> %0.3f",
+			log.Eventf(bq.ctx, "%s: updating priority: %0.3f -> %0.3f",
 				repl, item.priority, priority)
 		}
 		// Replica has already been added; update priority.
@@ -340,7 +340,7 @@ func (bq *baseQueue) addInternal(repl *Replica, should bool, priority float64) (
 		return false, nil
 	}
 
-	log.VEventf(3, bq.mu.ctx, "%s: adding: priority=%0.3f", repl, priority)
+	log.VEventf(3, bq.ctx, "%s: adding: priority=%0.3f", repl, priority)
 	item = &replicaItem{value: repl.RangeID, priority: priority}
 	heap.Push(&bq.mu.priorityQ, item)
 	bq.mu.replicas[repl.RangeID] = item
@@ -369,7 +369,7 @@ func (bq *baseQueue) MaybeRemove(repl *Replica) {
 	}
 
 	if item, ok := bq.mu.replicas[repl.RangeID]; ok {
-		log.VEventf(3, bq.mu.ctx, "%s: removing", item.value)
+		log.VEventf(3, bq.ctx, "%s: removing", item.value)
 		bq.remove(item)
 	}
 }
@@ -384,7 +384,7 @@ func (bq *baseQueue) processLoop(clock *hlc.Clock, stopper *stop.Stopper) {
 			bq.mu.Lock()
 			bq.mu.stopped = true
 			bq.mu.Unlock()
-			log.FinishEventLog(bq.mu.ctx)
+			log.FinishEventLog(bq.ctx)
 		}()
 
 		// nextTime is initially nil; we don't start any timers until the queue
@@ -441,14 +441,14 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 	// Load the system config.
 	cfg, ok := bq.gossip.GetSystemConfig()
 	if !ok {
-		log.VEventf(1, bq.mu.ctx, "no system config available. skipping")
+		log.VEventf(1, bq.ctx, "no system config available. skipping")
 		return nil
 	}
 
 	if bq.requiresSplit(cfg, repl) {
 		// Range needs to be split due to zone configs, but queue does
 		// not accept unsplit ranges.
-		log.VEventf(3, bq.mu.ctx, "%s: split needed; skipping", repl)
+		log.VEventf(3, bq.ctx, "%s: split needed; skipping", repl)
 		return nil
 	}
 
@@ -464,7 +464,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 		// Create a "fake" get request in order to invoke redirectOnOrAcquireLease.
 		if err := repl.redirectOnOrAcquireLease(ctx); err != nil {
 			if _, harmless := err.GetDetail().(*roachpb.NotLeaseHolderError); harmless {
-				log.VEventf(3, bq.mu.ctx, "%s: not holding lease; skipping", repl)
+				log.VEventf(3, bq.ctx, "%s: not holding lease; skipping", repl)
 				return nil
 			}
 			return errors.Wrapf(err.GoError(), "%s: could not obtain lease", repl)
@@ -472,12 +472,12 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 		log.Trace(ctx, "got range lease")
 	}
 
-	log.VEventf(3, bq.mu.ctx, "%s: processing", repl)
+	log.VEventf(3, bq.ctx, "%s: processing", repl)
 	start := timeutil.Now()
 	if err := bq.impl.process(ctx, clock.Now(), repl, cfg); err != nil {
 		return err
 	}
-	log.VEventf(2, bq.mu.ctx, "%s: done: %s", repl, timeutil.Since(start))
+	log.VEventf(2, bq.ctx, "%s: done: %s", repl, timeutil.Since(start))
 	log.Trace(ctx, "done")
 	return nil
 }
@@ -491,7 +491,7 @@ func (bq *baseQueue) processReplica(repl *Replica, clock *hlc.Clock) error {
 func (bq *baseQueue) maybeAddToPurgatory(repl *Replica, err error, clock *hlc.Clock, stopper *stop.Stopper) {
 	// Check whether the failure is a purgatory error and whether the queue supports it.
 	if _, ok := err.(purgatoryError); !ok || bq.impl.purgatoryChan() == nil {
-		log.Errorf(bq.mu.ctx, "on %s: %s", repl, err)
+		log.Errorf(bq.ctx, "on %s: %s", repl, err)
 		return
 	}
 	bq.mu.Lock()
@@ -502,7 +502,7 @@ func (bq *baseQueue) maybeAddToPurgatory(repl *Replica, err error, clock *hlc.Cl
 		return
 	}
 
-	log.Errorf(bq.mu.ctx, "(purgatory) on %s: %s", repl, err)
+	log.Errorf(bq.ctx, "(purgatory) on %s: %s", repl, err)
 
 	item := &replicaItem{value: repl.RangeID}
 	bq.mu.replicas[repl.RangeID] = item
@@ -535,7 +535,7 @@ func (bq *baseQueue) maybeAddToPurgatory(repl *Replica, err error, clock *hlc.Cl
 				for _, id := range ranges {
 					repl, err := bq.store.GetReplica(id)
 					if err != nil {
-						log.Errorf(bq.mu.ctx, "range %s no longer exists on store: %s", id, err)
+						log.Errorf(bq.ctx, "range %s no longer exists on store: %s", id, err)
 						return
 					}
 					if stopper.RunTask(func() {
@@ -548,7 +548,7 @@ func (bq *baseQueue) maybeAddToPurgatory(repl *Replica, err error, clock *hlc.Cl
 				}
 				bq.mu.Lock()
 				if len(bq.mu.purgatory) == 0 {
-					log.Infof(bq.mu.ctx, "purgatory is now empty")
+					log.Infof(bq.ctx, "purgatory is now empty")
 					bq.mu.purgatory = nil
 					bq.mu.Unlock()
 					return
@@ -563,7 +563,7 @@ func (bq *baseQueue) maybeAddToPurgatory(repl *Replica, err error, clock *hlc.Cl
 				}
 				bq.mu.Unlock()
 				for errStr, count := range errMap {
-					log.Errorf(bq.mu.ctx, "%d replicas failing with %q", count, errStr)
+					log.Errorf(bq.ctx, "%d replicas failing with %q", count, errStr)
 				}
 			case <-stopper.ShouldStop():
 				return
@@ -588,7 +588,7 @@ func (bq *baseQueue) pop() *Replica {
 
 	repl, err := bq.store.GetReplica(item.value)
 	if err != nil {
-		log.Errorf(bq.mu.ctx, "range %s no longer exists on store: %s", item.value, err)
+		log.Errorf(bq.ctx, "range %s no longer exists on store: %s", item.value, err)
 		return nil
 	}
 	return repl
@@ -612,7 +612,7 @@ func (bq *baseQueue) DrainQueue(clock *hlc.Clock) {
 	repl := bq.pop()
 	for repl != nil {
 		if err := bq.processReplica(repl, clock); err != nil {
-			log.Errorf(bq.mu.ctx, "failed processing replica %s: %s", repl, err)
+			log.Errorf(bq.ctx, "failed processing replica %s: %s", repl, err)
 		}
 		repl = bq.pop()
 	}

--- a/util/log/trace_test.go
+++ b/util/log/trace_test.go
@@ -126,7 +126,7 @@ func TestEventLog(t *testing.T) {
 	Event(ctx, "should-not-show-up")
 
 	el := &testingEventLog{}
-	ctxWithEventLog := withEventLogInt(ctx, el)
+	ctxWithEventLog := withEventLogInternal(ctx, el)
 
 	Eventf(ctxWithEventLog, "test%d", 1)
 	ErrEvent(ctxWithEventLog, "testerr")
@@ -155,7 +155,7 @@ func TestEventLogAndTrace(t *testing.T) {
 	Event(ctx, "should-not-show-up")
 
 	el := &testingEventLog{}
-	ctxWithEventLog := withEventLogInt(ctx, el)
+	ctxWithEventLog := withEventLogInternal(ctx, el)
 
 	Event(ctxWithEventLog, "test1")
 	ErrEvent(ctxWithEventLog, "testerr")

--- a/util/log/trace_test.go
+++ b/util/log/trace_test.go
@@ -126,7 +126,7 @@ func TestEventLog(t *testing.T) {
 	Event(ctx, "should-not-show-up")
 
 	el := &testingEventLog{}
-	ctxWithEventLog := WithEventLog(ctx, el)
+	ctxWithEventLog := withEventLogInt(ctx, el)
 
 	Eventf(ctxWithEventLog, "test%d", 1)
 	ErrEvent(ctxWithEventLog, "testerr")
@@ -137,7 +137,10 @@ func TestEventLog(t *testing.T) {
 	// Events to parent context should still be no-ops.
 	Event(ctx, "should-not-show-up")
 
-	el.Finish()
+	FinishEventLog(ctxWithEventLog)
+
+	// Events after Finish should be ignored.
+	Errorf(ctxWithEventLog, "should-not-show-up")
 
 	expected := "[test1 testerr(err) test2 log errlog1(err) finish]"
 	if evStr := fmt.Sprint(el.ev); evStr != expected {
@@ -152,7 +155,7 @@ func TestEventLogAndTrace(t *testing.T) {
 	Event(ctx, "should-not-show-up")
 
 	el := &testingEventLog{}
-	ctxWithEventLog := WithEventLog(ctx, el)
+	ctxWithEventLog := withEventLogInt(ctx, el)
 
 	Event(ctxWithEventLog, "test1")
 	ErrEvent(ctxWithEventLog, "testerr")


### PR DESCRIPTION
(Please ignore the first commit, it's a separate PR)

The logging code now "owns" the EventLog and synchronizes access to it. We now
allow logging calls concurrent with finishing the eventlog.

Verified using

```
make stressrace PKG=./gossip TESTS=TestClientGossip TESTFLAGS='--verbosity 2'
```

Fixes #8910.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach/8913)

<!-- Reviewable:end -->
